### PR TITLE
fix(cli): display agent.yaml instead of config.yaml in signet status

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1978,7 +1978,7 @@ async function showStatus(options: { path?: string }) {
 	// Files
 	const checks = [
 		{ name: "AGENTS.md", exists: existing.agentsMd },
-		{ name: "config.yaml", exists: existing.configYaml },
+		{ name: "agent.yaml", exists: existing.agentYaml },
 		{ name: "memories.db", exists: existing.memoryDb },
 	];
 


### PR DESCRIPTION
### Motivation
- The status UI displayed a failing check for `config.yaml` on clean installs even though `signet setup` writes `agent.yaml`, causing a misleading `✗ config.yaml` in the output.

### Description
- Updated the files checklist in `packages/cli/src/cli.ts` to show `agent.yaml` by replacing the `config.yaml` entry with `{ name: "agent.yaml", exists: existing.agentYaml }`, while leaving setup detection fields intact for backward compatibility.

### Testing
- Ran `bun run --filter @signet/cli test`, which completed successfully (the package has no matching test files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996dc0e1adc8332aeb411f8e775af42)