### PR TITLE
Redesign dashboard with Codex‑inspired data‑lab visual system

### DIFF
--- a/packages/cli/dashboard/src/app.css
+++ b/packages/cli/dashboard/src/app.css
@@ -1,38 +1,36 @@
 @import "tailwindcss";
 
-/* === Minimalist Theme: Seal & Ink ===
- * 
- * Intent: Developer tool for managing AI agent memory.
- * Feel: Precision instrument. Content-first. Every pixel earns its place.
- * Depth: Borders-only. Hairline separation, no shadows.
- * Surfaces: Unified canvas. Elevation through border hierarchy only.
- * Signature: The seal - circular indicators, ring accents, authentication marks.
+/* === Codex x Data-Lab Theme ===
+ * High-contrast editorial UI with deep data-viz accents.
+ * Dark command-center baseline + electric signal highlights.
  */
 
 :root {
-	/* Primitives - reduced palette, clearer intent */
-	--bg-canvas: #0a0a0b;
-	--bg-surface: #0f0f10;
-	--bg-elevated: #131314;
+	/* Primitives */
+	--bg-canvas: #060709;
+	--bg-surface: #0c0f14;
+	--bg-elevated: #11151d;
 
-	--text-primary: #e8e8e6;
-	--text-secondary: #8a8a88;
-	--text-tertiary: #5a5a58;
-	--text-muted: #40403e;
+	--text-primary: #ebeff7;
+	--text-secondary: #a9b3c7;
+	--text-tertiary: #6d7790;
+	--text-muted: #495167;
 
-	--accent-seal: #5eada4;
-	--accent-seal-dim: rgba(94, 173, 164, 0.08);
-	--accent-seal-ring: rgba(94, 173, 164, 0.15);
+	--accent-seal: #8aa8ff;
+	--accent-seal-dim: rgba(138, 168, 255, 0.1);
+	--accent-seal-ring: rgba(138, 168, 255, 0.2);
+	--accent-pop: #3d4dff;
+	--accent-lime: #d4ff00;
 
 	--success: #4ade80;
 	--warning: #fbbf24;
 	--error: #f87171;
 
-	/* Borders - hairline system */
-	--border-subtle: rgba(255, 255, 255, 0.04);
-	--border-standard: rgba(255, 255, 255, 0.08);
-	--border-emphasis: rgba(255, 255, 255, 0.12);
-	--border-accent: rgba(94, 173, 164, 0.25);
+	/* Borders */
+	--border-subtle: rgba(187, 206, 255, 0.07);
+	--border-standard: rgba(187, 206, 255, 0.14);
+	--border-emphasis: rgba(187, 206, 255, 0.22);
+	--border-accent: rgba(138, 168, 255, 0.36);
 
 	/* Spacing - 4px base */
 	--space-1: 4px;
@@ -52,31 +50,39 @@
 	--font-sans: "Inter", system-ui, -apple-system, sans-serif;
 	--font-mono: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
 
+	/* Legacy aliases used in component styles */
+	--border: var(--border-standard);
+	--bg-secondary: var(--bg-elevated);
+	--bg-tertiary: color-mix(in srgb, var(--bg-elevated) 75%, white 25%);
+	--mono: var(--font-mono);
+
 	color-scheme: dark;
 }
 
 [data-theme="light"] {
-	--bg-canvas: #fafaf9;
+	--bg-canvas: #f4f6fb;
 	--bg-surface: #ffffff;
-	--bg-elevated: #f5f5f4;
+	--bg-elevated: #eaf0ff;
 
-	--text-primary: #1c1917;
-	--text-secondary: #78716c;
-	--text-tertiary: #a8a29e;
-	--text-muted: #d6d3d1;
+	--text-primary: #111827;
+	--text-secondary: #4b5563;
+	--text-tertiary: #6b7280;
+	--text-muted: #c5ccda;
 
-	--accent-seal: #3d8a82;
-	--accent-seal-dim: rgba(61, 138, 130, 0.06);
-	--accent-seal-ring: rgba(61, 138, 130, 0.12);
+	--accent-seal: #3b5bfd;
+	--accent-seal-dim: rgba(59, 91, 253, 0.08);
+	--accent-seal-ring: rgba(59, 91, 253, 0.16);
+	--accent-pop: #253fff;
+	--accent-lime: #98a400;
 
 	--success: #16a34a;
 	--warning: #d97706;
 	--error: #dc2626;
 
-	--border-subtle: rgba(0, 0, 0, 0.04);
-	--border-standard: rgba(0, 0, 0, 0.08);
-	--border-emphasis: rgba(0, 0, 0, 0.12);
-	--border-accent: rgba(61, 138, 130, 0.2);
+	--border-subtle: rgba(37, 62, 130, 0.08);
+	--border-standard: rgba(37, 62, 130, 0.16);
+	--border-emphasis: rgba(37, 62, 130, 0.24);
+	--border-accent: rgba(59, 91, 253, 0.26);
 
 	color-scheme: light;
 }
@@ -101,7 +107,10 @@
 }
 
 html {
-	background: var(--bg-canvas);
+	background:
+		radial-gradient(circle at 15% -10%, rgba(61, 77, 255, 0.25), transparent 45%),
+		radial-gradient(circle at 85% 120%, rgba(212, 255, 0, 0.15), transparent 40%),
+		var(--bg-canvas);
 	color: var(--text-primary);
 	font-family: var(--font-sans);
 	font-size: 13px;
@@ -113,6 +122,10 @@ html {
 body {
 	margin: 0;
 	min-height: 100vh;
+	background-image:
+		linear-gradient(rgba(137, 167, 255, 0.06) 1px, transparent 1px),
+		linear-gradient(90deg, rgba(137, 167, 255, 0.04) 1px, transparent 1px);
+	background-size: 40px 40px, 40px 40px;
 }
 
 ::selection {

--- a/packages/cli/dashboard/src/routes/+page.svelte
+++ b/packages/cli/dashboard/src/routes/+page.svelte
@@ -1089,7 +1089,12 @@ function formatDate(dateStr: string): string {
         <circle cx="7" cy="7" r="6" stroke="currentColor" stroke-width="1.2"/>
         <circle cx="7" cy="7" r="2" fill="currentColor"/>
       </svg>
-      <span class="brand-name">signet</span>
+      <span class="brand-name">signet // codex lab</span>
+    </div>
+
+    <div class="header-signals" aria-hidden="true">
+      <span class="signal-chip">NODEMAP</span>
+      <span class="signal-chip signal-chip-pop">ASCII FLOW</span>
     </div>
     
     <button class="btn-icon" onclick={toggleTheme} aria-label="Toggle theme">
@@ -1313,6 +1318,7 @@ function formatDate(dateStr: string): string {
                 <p>Loading...</p>
               </div>
             {/if}
+            <div class="graph-ascii" aria-hidden="true">:: ○ ○ 01 10 11 // latent topology</div>
             <div class="graph-corners" aria-hidden="true">
               <span class="corner corner-tl"></span>
               <span class="corner corner-tr"></span>
@@ -1541,7 +1547,7 @@ function formatDate(dateStr: string): string {
           </span>
         {:else if activeTab === 'embeddings'}
           <span>{nodes.length} nodes · {edges.length} edges</span>
-          <span class="statusbar-right">UMAP · {graphMode.toUpperCase()}</span>
+          <span class="statusbar-right">UMAP · {graphMode.toUpperCase()} · SIGNAL</span>
         {:else if activeTab === 'logs'}
           <span>{logs.length} entries</span>
           <span class="statusbar-right">
@@ -1694,7 +1700,7 @@ function formatDate(dateStr: string): string {
     display: flex;
     flex-direction: column;
     height: 100vh;
-    background: var(--bg-canvas);
+    background: linear-gradient(180deg, rgba(61, 77, 255, 0.08), transparent 120px), var(--bg-canvas);
     color: var(--text-primary);
     overflow: hidden;
   }
@@ -1712,9 +1718,10 @@ function formatDate(dateStr: string): string {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    height: 44px;
+    height: 48px;
     padding: 0 var(--space-4);
-    border-bottom: 1px solid var(--border-standard);
+    border-bottom: 1px solid var(--border-emphasis);
+    backdrop-filter: blur(6px);
     flex-shrink: 0;
   }
 
@@ -1729,9 +1736,36 @@ function formatDate(dateStr: string): string {
   }
 
   .brand-name {
-    font-size: 13px;
-    font-weight: 500;
-    letter-spacing: -0.01em;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-primary);
+  }
+
+  .header-signals {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-left: auto;
+    margin-right: 8px;
+  }
+
+  .signal-chip {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    letter-spacing: 0.08em;
+    border: 1px solid var(--border-standard);
+    color: var(--text-secondary);
+    padding: 2px 6px;
+    border-radius: 999px;
+    background: rgba(138, 168, 255, 0.08);
+  }
+
+  .signal-chip-pop {
+    color: var(--bg-canvas);
+    background: var(--accent-lime);
+    border-color: transparent;
   }
 
   .btn-icon {
@@ -1762,12 +1796,12 @@ function formatDate(dateStr: string): string {
   }
 
   .sidebar-left {
-    width: 200px;
+    width: 220px;
     border-right: 1px solid var(--border-standard);
   }
 
   .sidebar-right {
-    width: 280px;
+    width: 300px;
     border-left: 1px solid var(--border-standard);
   }
 
@@ -1917,9 +1951,10 @@ function formatDate(dateStr: string): string {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    height: 40px;
+    height: 44px;
     padding: 0 var(--space-3);
-    border-bottom: 1px solid var(--border-standard);
+    border-bottom: 1px solid var(--border-emphasis);
+    backdrop-filter: blur(6px);
     flex-shrink: 0;
   }
 
@@ -1946,7 +1981,8 @@ function formatDate(dateStr: string): string {
 
   .tab-active {
     color: var(--text-primary);
-    background: var(--bg-elevated);
+    background: linear-gradient(135deg, rgba(138, 168, 255, 0.15), rgba(61, 77, 255, 0.12));
+    border: 1px solid var(--border-accent);
   }
 
   .tab-info {
@@ -2042,6 +2078,19 @@ function formatDate(dateStr: string): string {
     background: #050505;
   }
 
+  .graph-ascii {
+    position: absolute;
+    left: 14px;
+    top: 10px;
+    z-index: 6;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: rgba(212, 255, 0, 0.78);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    pointer-events: none;
+  }
+
   .graph-corners {
     position: absolute;
     inset: 0;
@@ -2123,6 +2172,7 @@ function formatDate(dateStr: string): string {
   
   .statusbar {
     display: flex;
+    background: rgba(8, 11, 18, 0.7);
     align-items: center;
     justify-content: space-between;
     height: 26px;
@@ -2171,8 +2221,8 @@ function formatDate(dateStr: string): string {
     font-size: 12px;
     font-family: var(--font-mono);
     color: var(--text-primary);
-    background: var(--bg-elevated);
-    border: 1px solid var(--border-subtle);
+    background: linear-gradient(135deg, rgba(138, 168, 255, 0.15), rgba(61, 77, 255, 0.12));
+    border: 1px solid var(--border-accent);
     border-radius: var(--radius-md);
     outline: none;
   }
@@ -2547,9 +2597,9 @@ function formatDate(dateStr: string): string {
   .secrets-input {
     flex: 1;
     padding: 8px 12px;
-    border: 1px solid var(--border);
+    border: 1px solid var(--border-standard);
     border-radius: 6px;
-    background: var(--bg-secondary);
+    background: var(--bg-elevated);
     color: var(--text-primary);
     font-size: 13px;
   }
@@ -2578,21 +2628,21 @@ function formatDate(dateStr: string): string {
     align-items: center;
     gap: 12px;
     padding: 12px 16px;
-    background: var(--bg-secondary);
+    background: var(--bg-elevated);
     border-radius: 8px;
-    border: 1px solid var(--border);
+    border: 1px solid var(--border-standard);
   }
 
   .secret-name {
     flex: 1;
-    font-family: var(--mono);
+    font-family: var(--font-mono);
     font-size: 13px;
     color: var(--text-primary);
   }
 
   .secret-value {
     color: var(--text-tertiary);
-    font-family: var(--mono);
+    font-family: var(--font-mono);
     font-size: 12px;
   }
 
@@ -2636,9 +2686,9 @@ function formatDate(dateStr: string): string {
   .skills-search-input {
     flex: 1;
     padding: 8px 12px;
-    border: 1px solid var(--border);
+    border: 1px solid var(--border-standard);
     border-radius: 6px;
-    background: var(--bg-secondary);
+    background: var(--bg-elevated);
     color: var(--text-primary);
     font-size: 13px;
   }
@@ -2681,9 +2731,9 @@ function formatDate(dateStr: string): string {
 
   .skill-item {
     padding: 12px 16px;
-    background: var(--bg-secondary);
+    background: var(--bg-elevated);
     border-radius: 8px;
-    border: 1px solid var(--border);
+    border: 1px solid var(--border-standard);
     display: flex;
     flex-direction: column;
     gap: 6px;
@@ -2700,7 +2750,7 @@ function formatDate(dateStr: string): string {
   }
 
   .skill-name {
-    font-family: var(--mono);
+    font-family: var(--font-mono);
     font-size: 13px;
     font-weight: 500;
     color: var(--text-primary);
@@ -2724,9 +2774,9 @@ function formatDate(dateStr: string): string {
   }
 
   .skill-badge.invocable {
-    background: var(--bg-tertiary);
+    background: color-mix(in srgb, var(--bg-elevated) 80%, white 20%);
     color: var(--text-secondary);
-    font-family: var(--mono);
+    font-family: var(--font-mono);
     text-transform: none;
   }
 


### PR DESCRIPTION
### Motivation
- Refresh the dashboard UI to a Codex (2026) × data‑lab aesthetic — high‑contrast command center with electric accents and an ASCII/data‑viz feel — while preserving all existing features and behaviors.

### Description
- Updated global theme tokens and backgrounds in `packages/cli/dashboard/src/app.css` to a darker command‑center palette with electric blue/lime accents, subtle radial highlights and a faint grid texture. 
- Introduced a few legacy CSS aliases (`--border`, `--bg-secondary`, `--mono`) and tightened border/accent semantics to improve visual consistency across panels. 
- Adjusted header and navigation in `packages/cli/dashboard/src/routes/+page.svelte` to include an updated brand label and non‑functional “signal chips”, increased header/tab dimensions, stronger active tab styling and subtle blur to the top bar. 
- Added a small ASCII telemetry overlay to the embeddings canvas and aligned search/secrets/skills control styles to the new tokens; no application logic, data fetching, or feature flows were changed. 

### Testing
- Ran `bun run lint` which failed because the `biome` binary is not available in this environment (automated lint not executed). 
- Ran `cd packages/cli/dashboard && bun run check` which failed because `svelte-kit` is not installed (dependencies not available). 
- Attempted `cd packages/cli/dashboard && bun install` which failed due to upstream registry `403` responses preventing dependency installation. 
- Attempted a Playwright screenshot of a running dev server at `http://127.0.0.1:5173` which returned `ERR_EMPTY_RESPONSE` because no dashboard server was running in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996dff9951c8332b373cabd399c07a4)