### PR TITLE
Add built-in /memory-debug skill for Signet memory troubleshooting

### DIFF
--- a/docs/MEMORY-SKILLS.md
+++ b/docs/MEMORY-SKILLS.md
@@ -7,7 +7,7 @@
 
 ---
 
-Signet ships with two core skills for memory management: `remember` and `recall`. These integrate directly with the Signet daemon.
+Signet ships with three core skills for memory management: `remember`, `recall`, and `memory-debug`. These integrate directly with the Signet daemon.
 
 ## Overview
 
@@ -15,6 +15,7 @@ Signet ships with two core skills for memory management: `remember` and `recall`
 |-------|-------------|-----------------|---------|
 | remember | `signet remember <content>` | `/remember <content>` | Save to persistent memory |
 | recall | `signet recall <query>` | `/recall <query>` | Search persistent memory |
+| memory-debug | diagnostic checks | `/memory-debug [symptom]` | Diagnose memory failures and quality issues |
 
 These are the primary interface between agents and the memory system.
 

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -56,7 +56,7 @@ signet skill create my-tool
 
 ## Built-in Skills
 
-Signet ships with two built-in skills that integrate directly with the memory system:
+Signet ships with three built-in skills that integrate directly with the memory system:
 
 ### `/remember`
 
@@ -96,6 +96,23 @@ signet recall "signet architecture" --type decision -l 5
 ```
 
 See [MEMORY.md](./MEMORY.md) for full details.
+
+### `/memory-debug`
+
+Diagnose memory issues end-to-end (daemon health, remember/write path, recall/read path, embedding health, and API checks).
+
+```bash
+# In harness
+/memory-debug
+/memory-debug recall is empty
+
+# Core checks it should run
+signet status
+signet remember "memory-debug smoke test" -t debug,smoke
+signet recall "memory-debug smoke test" --json
+```
+
+Use this when memory results are missing, low quality, or inconsistent across sessions.
 
 ---
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1410,7 +1410,7 @@ async function setupWizard(options: { path?: string }) {
 			copyDirRecursive(utilScriptsSource, join(basePath, "scripts"));
 		}
 
-		// Install built-in skills (remember, recall)
+		// Install built-in skills (remember, recall, memory-debug)
 		spinner.text = "Installing built-in skills...";
 		const skillsSource = join(templatesDir, "skills");
 		if (existsSync(skillsSource)) {

--- a/packages/signetai/templates/skills/memory-debug/SKILL.md
+++ b/packages/signetai/templates/skills/memory-debug/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: memory-debug
+description: Diagnose and fix Signet memory issues (daemon health, embeddings, search quality, and data integrity).
+user_invocable: true
+arg_hint: "[symptom or query]"
+builtin: true
+---
+
+# /memory-debug
+
+Debug the Signet memory system when recall quality is poor, memories are missing, or remember/recall commands fail.
+
+Use this skill when the user asks things like:
+- "memory is broken"
+- "recall isn't finding anything"
+- "remember didn't save"
+- "why are results low quality?"
+
+## syntax
+
+```bash
+/memory-debug
+/memory-debug recall is empty
+/memory-debug embeddings failing
+```
+
+## workflow
+
+Run these checks in order and stop when you find the root cause.
+
+### 1) verify daemon + config
+
+```bash
+signet status
+curl -s http://localhost:3850/health
+```
+
+If daemon is down, run:
+
+```bash
+signet start
+signet restart
+```
+
+Then verify key files exist:
+- `~/.agents/agent.yaml`
+- `~/.agents/memory/memories.db`
+- `~/.agents/memory/scripts/`
+
+### 2) verify write path (`remember`)
+
+```bash
+signet remember "memory-debug smoke test" -t debug,smoke -w claude-code
+```
+
+Expected: success response with `embedded: true` or a clear fallback message.
+
+If save fails, capture exact CLI error and recommend the fix (daemon restart, permissions, missing config, etc.).
+
+### 3) verify read path (`recall`)
+
+```bash
+signet recall "memory-debug smoke test" -l 5 --json
+```
+
+If no results:
+- retry with simpler keyword query
+- check `search.min_score` and `search.alpha` in `~/.agents/agent.yaml`
+- confirm the memory was actually written in step 2
+
+### 4) check embedding health
+
+If memories save but semantic recall is weak:
+
+```bash
+signet recall "memory-debug smoke test" --json
+```
+
+Inspect whether scores are keyword-heavy and whether embedding appears unavailable.
+
+Then verify embedding provider configuration in `~/.agents/agent.yaml`:
+- `embedding.provider`
+- `embedding.model`
+- `embedding.dimensions`
+
+Common fixes:
+- provider offline (Ollama/OpenAI unreachable)
+- wrong model name
+- dimensions mismatch after model change
+
+### 5) advanced diagnostics
+
+Use direct API checks for deeper issues:
+
+```bash
+curl -s "http://localhost:3850/api/memory/search?q=debug&limit=5"
+curl -s http://localhost:3850/api/status
+```
+
+If needed, inspect/migrate scripts:
+
+```bash
+python ~/.agents/memory/scripts/migrate.py
+python ~/.agents/memory/scripts/regenerate_memory.py
+```
+
+## response format
+
+When reporting back, include:
+1. what failed
+2. exact command + error
+3. likely root cause
+4. concrete fix steps
+5. verification command to confirm fix
+
+Prefer minimal, reproducible checks over broad speculation.


### PR DESCRIPTION
### Motivation

- Provide agents with a built-in, user-invocable skill to systematically diagnose Signet memory failures, poor recall quality, and embedding/provider issues.
- Make the troubleshooting workflow available by default in the project templates so new installs get an actionable guide for memory problems.

### Description

- Add `packages/signetai/templates/skills/memory-debug/SKILL.md`, a builtin `user_invocable: true` skill that outlines step-by-step checks (daemon health, write-path `remember`, read-path `recall`, embedding health, API checks, and migration scripts) and example commands to reproduce and verify issues.
- Update `docs/SKILLS.md` to list `/memory-debug` among built-in skills and provide example invocations.
- Update `docs/MEMORY-SKILLS.md` to include `memory-debug` in the memory skills overview table and narrative.
- Update the CLI setup messaging in `packages/cli/src/cli.ts` to reflect installation of the three built-in skills (`remember`, `recall`, `memory-debug`).

### Testing

- Ran `git diff --check` which returned no whitespace or diff-check errors and indicated the repository changes are well-formed.
- Ran `git status --short` to verify working tree cleanliness after changes which reported expected modified/added files.
- Attempted to run `bunx biome check` (lint) against the changed files but the run failed due to external package registry access (`GET https://registry.npmjs.org/biome - 403`), so linting could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996e4bfd3948332a04f8f34a8951507)