### PR TITLE
fix(adapter): add clawdbot compatibility to openclaw adapter

### DIFF
--- a/packages/adapters/openclaw/clawdbot.plugin.json
+++ b/packages/adapters/openclaw/clawdbot.plugin.json
@@ -1,0 +1,23 @@
+{
+  "id": "signet-memory-openclaw",
+  "kind": "memory",
+  "uiHints": {
+    "daemonUrl": {
+      "label": "Daemon URL",
+      "placeholder": "http://localhost:3850",
+      "help": "URL of the Signet daemon. Default: http://localhost:3850"
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "daemonUrl": {
+        "type": "string",
+        "description": "URL of the Signet daemon",
+        "default": "http://localhost:3850"
+      }
+    },
+    "required": []
+  }
+}

--- a/packages/adapters/openclaw/package.json
+++ b/packages/adapters/openclaw/package.json
@@ -13,9 +13,15 @@
   },
   "files": [
     "dist",
-    "openclaw.plugin.json"
+    "openclaw.plugin.json",
+    "clawdbot.plugin.json"
   ],
   "openclaw": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "clawdbot": {
     "extensions": [
       "./dist/index.js"
     ]
@@ -36,6 +42,7 @@
   "keywords": [
     "signet",
     "openclaw",
+    "clawdbot",
     "adapter",
     "ai-memory",
     "agent-identity"


### PR DESCRIPTION
## Summary

The `@signetai/signet-memory-openclaw` adapter now works with both **openclaw** (current naming) and **clawdbot** (pre-rename version). This enables users still on clawdbot to use the Signet memory plugin.

### Changes

- Add `clawdbot.extensions` field to package.json for plugin discovery (clawdbot looks for this instead of `openclaw.extensions`)
- Add `clawdbot.plugin.json` manifest file (clawdbot looks for `clawdbot.plugin.json` instead of `openclaw.plugin.json`)
- Include `clawdbot.plugin.json` in npm publish `files` array
- Add "clawdbot" to package keywords for discoverability

### Background

When testing the adapter with clawdbot 2026.1.24-3, two issues were found:

1. **Plugin not discovered**: clawdbot's plugin discovery code (`dist/plugins/discovery.js`) looks for `clawdbot.extensions` in package.json, not `openclaw.extensions`
2. **Manifest not found**: clawdbot's manifest loader (`dist/plugins/manifest.js`) looks for `clawdbot.plugin.json`, not `openclaw.plugin.json`

The `connector-openclaw` package already has clawdbot support (config path discovery, env vars), but the runtime adapter was missing the corresponding compatibility.

### Backwards Compatibility

This is a **fully backwards-compatible, additive change**:
- Existing `openclaw.extensions` and `openclaw.plugin.json` remain unchanged
- New `clawdbot.extensions` and `clawdbot.plugin.json` are additive
- No behavioral changes to existing code

## Test plan

- [x] Verified `npm pack --dry-run` includes both `openclaw.plugin.json` and `clawdbot.plugin.json`
- [x] Verified clawdbot discovers and loads the plugin after installing from local build
- [x] Verified `clawdbot status` shows `Memory │ enabled (plugin signet-memory-openclaw)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)