### PR TITLE
fix(tasks): stream live run output and fix opencode scheduled execution

### DIFF
--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -74,7 +74,7 @@ Custom expressions are validated before saving.
 ### Process Commands
 
 - **Claude Code**: `claude --dangerously-skip-permissions -p "<prompt>"`
-- **OpenCode**: `opencode -m "<prompt>"`
+- **OpenCode**: `opencode run --format json "<prompt>"`
 
 ## Managing Tasks
 

--- a/packages/cli/dashboard/src/lib/components/tabs/TasksTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/TasksTab.svelte
@@ -134,6 +134,7 @@ onMount(() => {
 	task={ts.detailTask}
 	runs={ts.detailRuns}
 	loading={ts.detailLoading}
+	liveConnected={ts.detailStreamConnected}
 	onclose={closeDetail}
 	ontrigger={doTrigger}
 	ondelete={doDelete}

--- a/packages/cli/dashboard/src/lib/components/tasks/TaskDetail.svelte
+++ b/packages/cli/dashboard/src/lib/components/tasks/TaskDetail.svelte
@@ -14,13 +14,24 @@ interface Props {
 	task: ScheduledTask | null;
 	runs: TaskRun[];
 	loading: boolean;
+	liveConnected: boolean;
 	onclose: () => void;
 	ontrigger: (id: string) => void;
 	ondelete: (id: string) => void;
 	onedit: (id: string) => void;
 }
 
-let { open, task, runs, loading, onclose, ontrigger, ondelete, onedit }: Props =
+let {
+	open,
+	task,
+	runs,
+	loading,
+	liveConnected,
+	onclose,
+	ontrigger,
+	ondelete,
+	onedit,
+}: Props =
 	$props();
 
 function formatDate(iso: string | null): string {
@@ -151,13 +162,23 @@ function handleDelete() {
 
 				<!-- Run history -->
 				<div class="flex flex-col gap-2 min-h-0">
-					<span
-						class="text-[10px] font-bold uppercase tracking-[0.1em]
+					<div class="flex items-center gap-2">
+						<span
+							class="text-[10px] font-bold uppercase tracking-[0.1em]
 							text-[var(--sig-text-muted)]
 							font-[family-name:var(--font-display)]"
-					>
-						Run History ({runs.length})
-					</span>
+						>
+							Run History ({runs.length})
+						</span>
+						{#if liveConnected}
+							<span
+								class="text-[9px] text-[var(--sig-success)]
+									font-[family-name:var(--font-mono)]"
+							>
+								Live
+							</span>
+						{/if}
+					</div>
 
 					{#if runs.length === 0}
 						<span class="text-[11px] text-[var(--sig-text-muted)]">
@@ -165,13 +186,11 @@ function handleDelete() {
 						</span>
 					{:else}
 						<ScrollArea.Root class="max-h-[400px]">
-							<ScrollArea.Viewport class="w-full">
-								<div class="flex flex-col gap-2">
-									{#each runs as run (run.id)}
-										<RunLog {run} />
-									{/each}
-								</div>
-							</ScrollArea.Viewport>
+							<div class="flex flex-col gap-2 w-full">
+								{#each runs as run (run.id)}
+									<RunLog {run} />
+								{/each}
+							</div>
 							<ScrollArea.Scrollbar orientation="vertical" />
 						</ScrollArea.Root>
 					{/if}

--- a/packages/daemon/src/scheduler/task-stream.ts
+++ b/packages/daemon/src/scheduler/task-stream.ts
@@ -1,0 +1,160 @@
+export type TaskStreamEvent =
+	| {
+			readonly type: "connected";
+			readonly taskId: string;
+			readonly timestamp: string;
+	  }
+	| {
+			readonly type: "run-started";
+			readonly taskId: string;
+			readonly runId: string;
+			readonly startedAt: string;
+			readonly timestamp: string;
+	  }
+	| {
+			readonly type: "run-output";
+			readonly taskId: string;
+			readonly runId: string;
+			readonly stream: "stdout" | "stderr";
+			readonly chunk: string;
+			readonly timestamp: string;
+	  }
+	| {
+			readonly type: "run-completed";
+			readonly taskId: string;
+			readonly runId: string;
+			readonly status: "completed" | "failed";
+			readonly completedAt: string;
+			readonly exitCode: number | null;
+			readonly error: string | null;
+			readonly timestamp: string;
+	  };
+
+type TaskStreamListener = (event: TaskStreamEvent) => void;
+
+interface RunningTaskStreamState {
+	readonly runId: string;
+	readonly startedAt: string;
+	readonly stdoutChunks: string[];
+	readonly stderrChunks: string[];
+	stdoutChars: number;
+	stderrChars: number;
+}
+
+export interface TaskStreamReplaySnapshot {
+	readonly runId: string;
+	readonly startedAt: string;
+	readonly stdoutChunks: ReadonlyArray<string>;
+	readonly stderrChunks: ReadonlyArray<string>;
+}
+
+const listenersByTaskId = new Map<string, Set<TaskStreamListener>>();
+const runningByTaskId = new Map<string, RunningTaskStreamState>();
+
+const MAX_BUFFER_CHARS_PER_STREAM = 200_000;
+
+function appendChunk(
+	chunks: string[],
+	currentChars: number,
+	chunk: string,
+): number {
+	if (chunk.length === 0) return currentChars;
+
+	chunks.push(chunk);
+	let nextChars = currentChars + chunk.length;
+
+	while (nextChars > MAX_BUFFER_CHARS_PER_STREAM && chunks.length > 0) {
+		const first = chunks[0];
+		if (!first) break;
+
+		if (nextChars - first.length >= MAX_BUFFER_CHARS_PER_STREAM) {
+			chunks.shift();
+			nextChars -= first.length;
+			continue;
+		}
+
+		const overflow = nextChars - MAX_BUFFER_CHARS_PER_STREAM;
+		chunks[0] = first.slice(overflow);
+		nextChars -= overflow;
+		break;
+	}
+
+	return nextChars;
+}
+
+export function subscribeTaskStream(
+	taskId: string,
+	listener: TaskStreamListener,
+): () => void {
+	const existing = listenersByTaskId.get(taskId);
+	if (existing) {
+		existing.add(listener);
+	} else {
+		listenersByTaskId.set(taskId, new Set([listener]));
+	}
+
+	return () => {
+		const listeners = listenersByTaskId.get(taskId);
+		if (!listeners) return;
+		listeners.delete(listener);
+		if (listeners.size === 0) {
+			listenersByTaskId.delete(taskId);
+		}
+	};
+}
+
+export function getTaskStreamSnapshot(
+	taskId: string,
+): TaskStreamReplaySnapshot | null {
+	const running = runningByTaskId.get(taskId);
+	if (!running) return null;
+
+	return {
+		runId: running.runId,
+		startedAt: running.startedAt,
+		stdoutChunks: [...running.stdoutChunks],
+		stderrChunks: [...running.stderrChunks],
+	};
+}
+
+export function emitTaskStream(event: TaskStreamEvent): void {
+	if (event.type === "run-started") {
+		runningByTaskId.set(event.taskId, {
+			runId: event.runId,
+			startedAt: event.startedAt,
+			stdoutChunks: [],
+			stderrChunks: [],
+			stdoutChars: 0,
+			stderrChars: 0,
+		});
+	} else if (event.type === "run-output") {
+		const running = runningByTaskId.get(event.taskId);
+		if (running && running.runId === event.runId) {
+			if (event.stream === "stdout") {
+				running.stdoutChars = appendChunk(
+					running.stdoutChunks,
+					running.stdoutChars,
+					event.chunk,
+				);
+			} else {
+				running.stderrChars = appendChunk(
+					running.stderrChunks,
+					running.stderrChars,
+					event.chunk,
+				);
+			}
+		}
+	} else if (event.type === "run-completed") {
+		const running = runningByTaskId.get(event.taskId);
+		if (running && running.runId === event.runId) {
+			runningByTaskId.delete(event.taskId);
+		}
+	}
+
+	const listeners = listenersByTaskId.get(event.taskId);
+	if (!listeners || listeners.size === 0) return;
+
+	for (const listener of listeners) {
+		listener(event);
+	}
+}


### PR DESCRIPTION
## Summary
- add a task SSE endpoint (`/api/tasks/:id/stream`) and task-scoped event bus so run start/output/completion events are emitted for both scheduled and manual runs
- add replay buffering for active runs so opening the task detail late still shows in-progress output instead of an empty running card
- fix OpenCode scheduler invocation to use non-interactive execution (`opencode run --format json "<prompt>"`) and normalize streamed JSON/ANSI output into readable live logs in the dashboard

## How It Works
- backend now streams incremental stdout/stderr chunks from `spawnTask` hooks instead of waiting for process exit
- daemon publishes run lifecycle events and keeps a bounded in-memory buffer per active run for late subscribers
- dashboard subscribes to task SSE, maintains a resilient connection with reconnects, upserts live run rows without reopening the detail panel, and parses OpenCode JSON events (`text`, `tool_use`) for readable output

## Safety / Scope
- changes are limited to scheduled-task streaming and display paths in daemon + dashboard; no auth, memory, secrets, connector, or infra paths were modified
- lockfile was intentionally excluded from this PR to avoid unrelated dependency churn for the team

## Validation
- `cd packages/daemon && bun run build`
- `cd packages/cli/dashboard && bun run build`
- manually verified `/api/tasks/:id/stream` returns `connected`, `run-started`, and `run-output` events, including replay after late subscription