### PR TITLE
fix(tasks): improve task edit UX and detail running state

### DIFF
--- a/packages/cli/dashboard/src/lib/components/tabs/TasksTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/TasksTab.svelte
@@ -137,7 +137,10 @@ onMount(() => {
 	onclose={closeDetail}
 	ontrigger={doTrigger}
 	ondelete={doDelete}
-	onedit={(id) => openForm(id)}
+	onedit={(id) => {
+		closeDetail();
+		openForm(id);
+	}}
 />
 
 <style>

--- a/packages/cli/dashboard/src/lib/components/tasks/TaskDetail.svelte
+++ b/packages/cli/dashboard/src/lib/components/tasks/TaskDetail.svelte
@@ -29,6 +29,7 @@ function formatDate(iso: string | null): string {
 }
 
 let confirmingDelete = $state(false);
+let taskIsRunning = $derived(runs.some((run) => run.status === "running"));
 
 function handleDelete() {
 	if (!task) return;
@@ -120,15 +121,26 @@ function handleDelete() {
 
 				<!-- Actions -->
 				<div class="flex gap-2">
-					<Button
-						variant="outline"
-						size="sm"
-						class="h-7 gap-1.5 text-[11px]"
-						onclick={() => task && ontrigger(task.id)}
-					>
-						<Play class="size-3" />
-						Run Now
-					</Button>
+					{#if taskIsRunning}
+						<Button
+							variant="outline"
+							size="sm"
+							class="h-7 gap-1.5 text-[11px]"
+							disabled
+						>
+							Running...
+						</Button>
+					{:else}
+						<Button
+							variant="outline"
+							size="sm"
+							class="h-7 gap-1.5 text-[11px]"
+							onclick={() => task && ontrigger(task.id)}
+						>
+							<Play class="size-3" />
+							Run Now
+						</Button>
+					{/if}
 					<Button
 						variant="outline"
 						size="sm"
@@ -165,13 +177,11 @@ function handleDelete() {
 						</span>
 					{:else}
 						<ScrollArea.Root class="max-h-[400px]">
-							<ScrollArea.Viewport class="w-full">
-								<div class="flex flex-col gap-2">
-									{#each runs as run (run.id)}
-										<RunLog {run} />
-									{/each}
-								</div>
-							</ScrollArea.Viewport>
+							<div class="flex flex-col gap-2 w-full">
+								{#each runs as run (run.id)}
+									<RunLog {run} />
+								{/each}
+							</div>
 							<ScrollArea.Scrollbar orientation="vertical" />
 						</ScrollArea.Root>
 					{/if}

--- a/packages/cli/dashboard/src/lib/components/tasks/TaskForm.svelte
+++ b/packages/cli/dashboard/src/lib/components/tasks/TaskForm.svelte
@@ -81,13 +81,16 @@ async function handleSubmit() {
 	submitting = true;
 
 	if (editingId) {
-		await doUpdate(editingId, {
+		const success = await doUpdate(editingId, {
 			name: name.trim(),
 			prompt: prompt.trim(),
 			cronExpression: cronExpression.trim(),
 			harness,
 			workingDirectory: workingDirectory.trim() || null,
 		});
+		if (success) {
+			onclose();
+		}
 	} else {
 		await doCreate({
 			name: name.trim(),


### PR DESCRIPTION
## Summary
- Fix task editing flow from the detail sheet by closing detail before opening edit form.
- Close the edit form after a successful update so changes feel applied immediately.
- Show a disabled `Running...` action in task detail while a run is in progress, and keep card-level run controls unchanged.
- Remove unsupported `ScrollArea.Viewport` usage in task detail run history to match the local scroll-area exports.

## How It Was Done
- Updated `TasksTab` edit handler to call `closeDetail()` then `openForm(id)`.
- Updated `TaskForm` submit path to check `doUpdate(...)` success and call `onclose()` on success.
- Added derived `taskIsRunning` in `TaskDetail` from current runs and conditionally render `Run Now` vs disabled `Running...` button.
- Simplified run history scroll area markup in `TaskDetail` by removing `ScrollArea.Viewport` wrapper.

## Validation
- Built dashboard locally with `bun run build` in `packages/cli/dashboard`.
- Confirmed no merge conflicts by rebasing branch on `origin/main`.
