### PR TITLE
feat(cli): require explicit providers for non-interactive setup

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -92,12 +92,17 @@ If the daemon is not running, you'll be prompted to start it.
 `signet setup`
 ---
 
-Interactive first-time setup wizard. Creates the `~/.agents/` directory
-and all necessary files.
+Interactive first-time setup wizard (with optional non-interactive mode).
+Creates the `~/.agents/` directory and all necessary files.
 
 ```bash
 signet setup
 signet setup --path /custom/path
+signet setup --non-interactive \
+  --name "My Agent" \
+  --harness claude-code \
+  --embedding-provider ollama \
+  --extraction-provider claude-code
 ```
 
 Options:
@@ -105,6 +110,26 @@ Options:
 | Option | Description |
 |--------|-------------|
 | `-p, --path <path>` | Custom base path (default: `~/.agents`) |
+| `--non-interactive` | Run setup without prompts |
+| `--name <name>` | Agent name in non-interactive mode |
+| `--description <description>` | Agent description in non-interactive mode |
+| `--harness <harness>` | Repeatable/comma-separated harness list (`claude-code`, `opencode`, `openclaw`) |
+| `--embedding-provider <provider>` | Non-interactive embedding provider (`ollama`, `openai`, `none`) — required in non-interactive setup |
+| `--embedding-model <model>` | Non-interactive embedding model |
+| `--extraction-provider <provider>` | Non-interactive extraction provider (`claude-code`, `ollama`, `none`) — required in non-interactive setup |
+| `--extraction-model <model>` | Non-interactive extraction model |
+| `--search-balance <alpha>` | Non-interactive search alpha (`0-1`) |
+| `--openclaw-runtime-path <mode>` | Non-interactive OpenClaw mode (`plugin`, `legacy`) |
+| `--configure-openclaw-workspace` | Patch discovered OpenClaw configs to `~/.agents` |
+| `--open-dashboard` | Open dashboard after non-interactive setup |
+| `--skip-git` | Skip git initialization/commits in non-interactive mode |
+
+Non-interactive behavior:
+
+- setup method: create new identity (no GitHub import)
+- embedding provider must be explicitly provided via `--embedding-provider`
+- extraction provider must be explicitly provided via `--extraction-provider`
+- git: enabled unless `--skip-git` is passed
 
 Wizard steps:
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -40,6 +40,19 @@ the full setup. You don't need to read anything else first. Signet records
 your primary package manager during setup and reuses it for skill installs
 and update commands.
 
+For agent-driven onboarding, use non-interactive mode:
+
+```bash
+signet setup --non-interactive \
+  --name "My Agent" \
+  --harness claude-code \
+  --embedding-provider ollama \
+  --extraction-provider claude-code
+```
+
+In non-interactive mode, agents should ask the user to choose both
+providers first, then pass those choices explicitly.
+
 ---
 
 Setup Wizard

--- a/packages/cli/templates/skills/signet/SKILL.md
+++ b/packages/cli/templates/skills/signet/SKILL.md
@@ -85,10 +85,32 @@ Install skills:
 npx skills install <skill-name>
 ```
 
+## Setup Modes
+
+When helping a user bootstrap Signet, both setup modes are valid:
+
+```bash
+# Interactive setup
+signet
+
+# Non-interactive setup (agent-driven)
+signet setup --non-interactive \
+  --name "My Agent" \
+  --harness claude-code \
+  --embedding-provider <ollama|openai|none> \
+  --extraction-provider <claude-code|ollama|none>
+```
+
+Use `--non-interactive` when the agent needs to complete setup without
+waiting for terminal prompts. Ask the user for provider choices first,
+then pass both provider flags explicitly.
+
 ## Commands Reference
 
 ```bash
 signet                  # Interactive menu
+signet setup            # Setup wizard
+signet setup --non-interactive --name "Agent" --harness claude-code --embedding-provider ollama --extraction-provider claude-code
 signet status           # Show status
 signet dashboard        # Open web UI
 signet secret put NAME  # Store a secret

--- a/packages/signetai/templates/skills/onboarding/SKILL.md
+++ b/packages/signetai/templates/skills/onboarding/SKILL.md
@@ -19,6 +19,24 @@ Walk the user through an interactive interview to personalize their Signet works
 - User says "I want to redo my agent setup"
 - User says "clean up my memory" or "optimize my workspace"
 
+## Setup Preflight (Agent-Driven)
+
+If Signet is not initialized yet (`~/.agents/agent.yaml` missing),
+bootstrap setup first and then continue onboarding:
+
+```bash
+signet setup --non-interactive \
+  --name "My Agent" \
+  --description "Personal AI assistant" \
+  --harness claude-code \
+  --embedding-provider <ollama|openai|none> \
+  --extraction-provider <claude-code|ollama|none>
+```
+
+Use interactive `signet` when the user wants to answer prompts manually.
+Use `--non-interactive` when the agent should complete setup directly.
+Before running it, explicitly ask the user for both provider choices.
+
 ## Interview Philosophy
 
 Don't interrogate. Make it conversational. One or two questions at a time, then respond naturally before continuing. Sprinkle in personality. Adapt based on their energy level. 

--- a/packages/signetai/templates/skills/signet/SKILL.md
+++ b/packages/signetai/templates/skills/signet/SKILL.md
@@ -217,10 +217,32 @@ Install skills:
 npx skills install <skill-name>
 ```
 
+## Setup Modes
+
+When helping a user bootstrap Signet, both setup modes are valid:
+
+```bash
+# Interactive setup
+signet
+
+# Non-interactive setup (agent-driven)
+signet setup --non-interactive \
+  --name "My Agent" \
+  --harness claude-code \
+  --embedding-provider <ollama|openai|none> \
+  --extraction-provider <claude-code|ollama|none>
+```
+
+Use `--non-interactive` when the agent needs to complete setup without
+waiting for terminal prompts. Ask the user for provider choices first,
+then pass both provider flags explicitly.
+
 ## Commands Reference
 
 ```bash
 signet                  # Interactive menu
+signet setup            # Setup wizard
+signet setup --non-interactive --name "Agent" --harness claude-code --embedding-provider ollama --extraction-provider claude-code
 signet status           # Show status
 signet dashboard        # Open web UI
 signet secret put NAME  # Store a secret

--- a/web/public/skill.md
+++ b/web/public/skill.md
@@ -279,7 +279,7 @@ These are the ONLY two supported install methods. Do not use:
 ### Step 3: Run the setup wizard
 
 > GATE: Tell your user:
-> "Signet is installed. Now I need to run the interactive setup wizard.
+> "Signet is installed. Now I need to run the setup wizard.
 > This will ask you to choose:
 > - A name and description for your agent (me)
 > - Which platforms to connect (Claude Code, OpenClaw, OpenCode)
@@ -288,18 +288,38 @@ These are the ONLY two supported install methods. Do not use:
 > - Whether to enable git sync for your agent config
 >
 > The wizard will configure hooks, connectors, and skills automatically.
-> Some prompts are interactive — I may need you to answer them directly
-> in the terminal. Ready?"
+> I can run this interactively (you answer prompts) or non-interactively
+> (I pass flags myself). Ready?"
 >
 > WAIT for the user to confirm before running the wizard.
 > 
 
+Interactive mode:
 ```bash
 signet
 ```
 
 Run `signet` with no arguments. It automatically detects a fresh
 install and launches the interactive setup wizard.
+
+Non-interactive mode (for agent-driven setup):
+```bash
+signet setup --non-interactive \
+  --name "Your Agent Name" \
+  --description "Personal AI assistant" \
+  --harness claude-code \
+  --embedding-provider <ollama|openai|none> \
+  --extraction-provider <claude-code|ollama|none>
+```
+
+For non-interactive mode:
+- Ask the user to choose both providers before running the command
+- Do not default providers silently
+- Use `--harness` multiple times or as comma-separated values
+- Add `--embedding-provider ollama` and `--embedding-model nomic-embed-text`
+  if Ollama is available
+- Add `--openclaw-runtime-path plugin` for OpenClaw
+- Add `--skip-git` if the user does not want git initialized
 
 The wizard will ask:
 1. **Agent name and description** — the identity for your agent
@@ -459,9 +479,10 @@ make during installation. Do not repeat them.
 | Running `npx signet init` | Not a thing. Install globally first, then run `signet`. |
 | Manually writing to `~/.agents/memory/` | The daemon manages memory files. Do not write there directly. |
 | Calling `signet recall` before every response | Context injection is automatic. Only use recall for explicit searches. |
+| Defaulting embedding/extraction providers without asking | In non-interactive setup, ask the user which providers they want and pass both flags explicitly. |
 | Building a custom HTTP integration | Use the setup wizard's connector selection. It handles everything. |
 | Treating Clawdbot/Moltbot as separate from OpenClaw | They are the same platform. One connector handles all three. |
-| Skipping the interactive setup wizard | The wizard configures connectors, hooks, skills, and identity. Do not try to set these up manually. |
+| Skipping setup or manually writing files | Setup configures connectors, hooks, skills, and identity. Use interactive or `--non-interactive`, but do not hand-roll files. |
 | Manually editing `~/.claude/settings.json` hooks | The Claude Code connector manages these. Run setup to install them. |
 | Cloning the git repository to install | Signet is installed via npm/bun as a global package, not by cloning. |
 
@@ -527,6 +548,7 @@ bun add -g signetai          # or: npm install -g signetai
 # Setup
 signet                       # First run launches setup wizard
 signet setup                 # Explicit setup command
+signet setup --non-interactive --name "Agent" --harness claude-code --embedding-provider ollama --extraction-provider claude-code
 
 # Daemon
 signet start                 # Start daemon


### PR DESCRIPTION
## Summary
- add `signet setup --non-interactive` support for agent-driven bootstrap flows
- require explicit `--embedding-provider` and `--extraction-provider` in non-interactive mode (fail fast with clear guidance)
- apply provider requirements to both fresh setup and existing-identity migration paths
- document interactive vs non-interactive setup flows in agent-facing docs and template skills

## Why
Agents should ask users for embedding and extraction provider choices instead of silently defaulting. This keeps setup explicit and avoids half-configured installs.

## Validation
- `bun run --filter @signet/cli build:cli`
- verified runtime errors when required provider flags are omitted
