### PR TITLE
fix(ui): Consistent-Header-UI-Fix across dashboard tabs

### DIFF
--- a/packages/cli/dashboard/src/lib/components/layout/PageHero.svelte
+++ b/packages/cli/dashboard/src/lib/components/layout/PageHero.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+import type { Snippet } from "svelte";
+
+interface Props {
+	title: string;
+	wordmarkLines: ReadonlyArray<string>;
+	wordmarkMaxWidth?: string;
+	eyebrow: string;
+	description: string;
+	meta?: Snippet;
+	actions?: Snippet;
+}
+
+let {
+	title,
+	wordmarkLines,
+	wordmarkMaxWidth = "260px",
+	eyebrow,
+	description,
+	meta,
+	actions,
+}: Props = $props();
+
+const BLOCK_FONT: Record<
+	string,
+	readonly [string, string, string, string, string]
+> = {
+	A: [" █ ", "█ █", "███", "█ █", "█ █"],
+	B: ["██ ", "█ █", "██ ", "█ █", "██ "],
+	C: [" ██", "█  ", "█  ", "█  ", " ██"],
+	D: ["██ ", "█ █", "█ █", "█ █", "██ "],
+	E: ["███", "█  ", "██ ", "█  ", "███"],
+	F: ["███", "█  ", "██ ", "█  ", "█  "],
+	G: [" ██", "█  ", "█ █", "█ █", " ██"],
+	H: ["█ █", "█ █", "███", "█ █", "█ █"],
+	I: ["███", " █ ", " █ ", " █ ", "███"],
+	J: ["███", "  █", "  █", "█ █", " █ "],
+	K: ["█ █", "█ █", "██ ", "█ █", "█ █"],
+	L: ["█  ", "█  ", "█  ", "█  ", "███"],
+	M: ["█ █", "███", "███", "█ █", "█ █"],
+	N: ["█ █", "███", "███", "███", "█ █"],
+	O: [" █ ", "█ █", "█ █", "█ █", " █ "],
+	P: ["██ ", "█ █", "██ ", "█  ", "█  "],
+	Q: [" █ ", "█ █", "█ █", "███", "  █"],
+	R: ["██ ", "█ █", "██ ", "█ █", "█ █"],
+	S: [" ██", "█  ", " █ ", "  █", "██ "],
+	T: ["███", " █ ", " █ ", " █ ", " █ "],
+	U: ["█ █", "█ █", "█ █", "█ █", "███"],
+	V: ["█ █", "█ █", "█ █", "█ █", " █ "],
+	W: ["█ █", "█ █", "███", "███", "█ █"],
+	X: ["█ █", "█ █", " █ ", "█ █", "█ █"],
+	Y: ["█ █", "█ █", " █ ", " █ ", " █ "],
+	Z: ["███", "  █", " █ ", "█  ", "███"],
+	"-": ["   ", "   ", "███", "   ", "   "],
+	" ": ["   ", "   ", "   ", "   ", "   "],
+	"?": ["██ ", "  █", " █ ", "   ", " █ "],
+};
+
+function renderAsciiLine(input: string): string {
+	const rows = ["", "", "", "", ""];
+	for (const char of input) {
+		const glyph = BLOCK_FONT[char] ?? BLOCK_FONT["?"];
+		for (let i = 0; i < rows.length; i += 1) {
+			rows[i] += `${glyph[i]} `;
+		}
+	}
+	return rows.map((row) => row.trimEnd()).join("\n");
+}
+
+function renderWordmark(lines: ReadonlyArray<string>): string {
+	return lines
+		.map((line) => renderAsciiLine(line.toUpperCase()))
+		.join("\n\n");
+}
+
+let asciiWordmark = $derived(renderWordmark(wordmarkLines));
+</script>
+
+<div
+	class="shrink-0 px-[var(--space-md)] pt-[var(--space-md)]
+		pb-[var(--space-sm)] border-b border-[var(--sig-border)]"
+>
+	<div class="flex items-start gap-6 min-h-[112px]">
+		<div class="flex flex-col gap-1 shrink-0">
+			<h1 class="absolute hidden">{title}</h1>
+			<div
+				class="relative overflow-hidden"
+				style={`max-width: ${wordmarkMaxWidth};`}
+			>
+				<pre
+					class="hero-ascii m-0 text-[var(--sig-text-muted)]
+						select-none whitespace-pre"
+					aria-hidden="true"
+				>{asciiWordmark}</pre>
+				<pre
+					class="hero-ascii absolute left-px top-px m-0
+						text-[var(--sig-text-bright)] select-none whitespace-pre"
+					aria-label={title}
+				>{asciiWordmark}</pre>
+			</div>
+			<span
+				class="font-[family-name:var(--font-mono)] text-[10px]
+					font-medium text-[var(--sig-text)] uppercase
+					tracking-[0.12em]"
+			>
+				{eyebrow}
+			</span>
+			{#if meta}
+				{@render meta()}
+			{/if}
+		</div>
+
+		<div class="flex-1 flex flex-col gap-2 pt-[2px] min-w-0">
+			<p
+				class="text-[12px] text-[var(--sig-text)] leading-[1.5] m-0
+					max-w-[460px]"
+			>
+				{description}
+			</p>
+			{#if actions}
+				<div class="flex gap-2 flex-wrap">
+					{@render actions()}
+				</div>
+			{/if}
+		</div>
+	</div>
+</div>
+
+<style>
+	.hero-ascii {
+		font-size: 8px;
+		line-height: 1.15;
+		font-family: var(--font-mono);
+		letter-spacing: -0.04em;
+	}
+</style>

--- a/packages/cli/dashboard/src/lib/components/layout/page-headers.ts
+++ b/packages/cli/dashboard/src/lib/components/layout/page-headers.ts
@@ -1,0 +1,74 @@
+export interface PageHeaderDefinition {
+	readonly title: string;
+	readonly wordmarkLines: readonly string[];
+	readonly wordmarkMaxWidth?: string;
+	readonly eyebrow: string;
+	readonly description: string;
+}
+
+export const PAGE_HEADERS = {
+	config: {
+		title: "Config",
+		wordmarkLines: ["CONFIG"],
+		eyebrow: "Identity markdown workspace",
+		description:
+			"Edit AGENTS.md, MEMORY.md, USER.md, and related identity files that define agent behavior.",
+	},
+	settings: {
+		title: "Settings",
+		wordmarkLines: ["SETTINGS"],
+		eyebrow: "Runtime and harness controls",
+		description:
+			"Tune pipeline behavior, harness integration, and runtime configuration with safe defaults.",
+	},
+	memory: {
+		title: "Memory",
+		wordmarkLines: ["MEMORY"],
+		eyebrow: "Persistent memory index",
+		description:
+			"Search, filter, and inspect long-term memories with hybrid semantic and keyword retrieval.",
+	},
+	embeddings: {
+		title: "Constellation",
+		wordmarkLines: ["CONSTELLATION"],
+		wordmarkMaxWidth: "420px",
+		eyebrow: "Semantic projection workspace",
+		description:
+			"Explore memory embeddings, neighborhoods, and projection slices to understand memory structure.",
+	},
+	pipeline: {
+		title: "Pipeline",
+		wordmarkLines: ["PIPELINE"],
+		eyebrow: "Live memory loop telemetry",
+		description:
+			"Monitor extraction, decisions, maintenance, and feed events across the full memory pipeline.",
+	},
+	logs: {
+		title: "Logs",
+		wordmarkLines: ["LOGS"],
+		eyebrow: "Daemon event stream",
+		description:
+			"Filter and inspect structured daemon logs with live streaming and detailed payload views.",
+	},
+	secrets: {
+		title: "Secrets",
+		wordmarkLines: ["SECRETS"],
+		eyebrow: "Secure secret vault",
+		description:
+			"Store and manage secret names safely for runtime injection without exposing raw values.",
+	},
+	skills: {
+		title: "Skills",
+		wordmarkLines: ["SKILLS"],
+		eyebrow: "Open agent skill ecosystem",
+		description:
+			"Discover, install, and manage reusable agent skills from curated registries.",
+	},
+	tasks: {
+		title: "Tasks",
+		wordmarkLines: ["TASKS"],
+		eyebrow: "Scheduled agent prompts",
+		description:
+			"Schedule recurring prompts to run automatically via Claude Code or OpenCode.",
+	},
+} as const satisfies Record<string, PageHeaderDefinition>;

--- a/packages/cli/dashboard/src/lib/components/tabs/ConfigTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/ConfigTab.svelte
@@ -3,6 +3,8 @@ import { saveConfigFile, type ConfigFile } from "$lib/api";
 import { toast } from "$lib/stores/toast.svelte";
 import MarkdownViewer from "$lib/components/config/MarkdownViewer.svelte";
 import * as Tabs from "$lib/components/ui/tabs/index.js";
+import PageHero from "$lib/components/layout/PageHero.svelte";
+import { PAGE_HEADERS } from "$lib/components/layout/page-headers";
 
 interface Props {
 	configFiles: ConfigFile[];
@@ -57,6 +59,13 @@ async function saveFile() {
 </script>
 
 <div class="config-tab">
+	<PageHero
+		title={PAGE_HEADERS.config.title}
+		wordmarkLines={PAGE_HEADERS.config.wordmarkLines}
+		eyebrow={PAGE_HEADERS.config.eyebrow}
+		description={PAGE_HEADERS.config.description}
+	/>
+
 	<Tabs.Root value={selectedFile} onValueChange={(v) => onselectfile(v)}>
 		<Tabs.List class="bg-transparent h-auto gap-0 rounded-none border-b border-[var(--sig-border)] px-[var(--space-md)] w-full justify-start">
 			{#each mdFiles as file (file.name)}

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -19,6 +19,8 @@ import { mem } from "$lib/stores/memory.svelte";
 import EmbeddingCanvas2D from "../embeddings/EmbeddingCanvas2D.svelte";
 import EmbeddingCanvas3D from "../embeddings/EmbeddingCanvas3D.svelte";
 import EmbeddingInspector from "../embeddings/EmbeddingInspector.svelte";
+import PageHero from "$lib/components/layout/PageHero.svelte";
+import { PAGE_HEADERS } from "$lib/components/layout/page-headers";
 import {
 	type RelationKind,
 	type EmbeddingRelation,
@@ -1156,8 +1158,17 @@ $effect(() => {
 });
 </script>
 
-<div class="flex flex-1 min-h-0 bg-[#050505] max-lg:flex-col">
-	<div
+<div class="flex h-full flex-col overflow-hidden">
+	<PageHero
+		title={PAGE_HEADERS.embeddings.title}
+		wordmarkLines={PAGE_HEADERS.embeddings.wordmarkLines}
+		wordmarkMaxWidth={PAGE_HEADERS.embeddings.wordmarkMaxWidth}
+		eyebrow={PAGE_HEADERS.embeddings.eyebrow}
+		description={PAGE_HEADERS.embeddings.description}
+	/>
+
+	<div class="flex flex-1 min-h-0 bg-[#050505] max-lg:flex-col">
+		<div
 		bind:this={graphRegion}
 		class="flex-1 relative overflow-hidden bg-[#050505]"
 		role="presentation"
@@ -1165,7 +1176,7 @@ $effect(() => {
 		onmouseleave={() => {
 			if (!hoverLockedId) graphHovered = null;
 		}}
-	>
+		>
 		<div class="absolute top-2 left-3 right-3 z-[8] flex items-center gap-2 pointer-events-none">
 			<input
 				type="text"
@@ -1591,9 +1602,9 @@ $effect(() => {
 				onhovernode={updateGraphHover}
 			/>
 		</div>
-	</div>
+		</div>
 
-	<EmbeddingInspector
+		<EmbeddingInspector
 		{graphSelected}
 		{embeddings}
 		{embeddingById}
@@ -1612,5 +1623,6 @@ $effect(() => {
 		onsetrelationmode={(mode) => (relationMode = mode)}
 		onfocusembedding={() => graphSelected && focusEmbedding(graphSelected.id)}
 		onpintoggle={togglePinForSelected}
-	/>
+		/>
+	</div>
 </div>

--- a/packages/cli/dashboard/src/lib/components/tabs/LogsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/LogsTab.svelte
@@ -3,6 +3,8 @@ import { onMount } from "svelte";
 import * as Select from "$lib/components/ui/select/index.js";
 import { Checkbox } from "$lib/components/ui/checkbox/index.js";
 import { ScrollArea } from "$lib/components/ui/scroll-area/index.js";
+import PageHero from "$lib/components/layout/PageHero.svelte";
+import { PAGE_HEADERS } from "$lib/components/layout/page-headers";
 
 interface LogEntry {
 	timestamp: string;
@@ -233,6 +235,13 @@ onMount(() => {
 </script>
 
 <div class="flex flex-col flex-1 min-h-0">
+	<PageHero
+		title={PAGE_HEADERS.logs.title}
+		wordmarkLines={PAGE_HEADERS.logs.wordmarkLines}
+		eyebrow={PAGE_HEADERS.logs.eyebrow}
+		description={PAGE_HEADERS.logs.description}
+	/>
+
 	<div class="flex items-center gap-[var(--space-sm)] px-[var(--space-md)] py-[var(--space-sm)] border-b border-[var(--sig-border)] shrink-0">
 		<Select.Root type="single" value={logLevelFilter} onValueChange={(v) => { logLevelFilter = v ?? ""; fetchLogs(); }}>
 			<Select.Trigger class="font-[family-name:var(--font-mono)] text-[length:var(--font-size-sm)] bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] text-[var(--sig-text-bright)] rounded-none h-auto py-1 px-2 min-w-[100px]">

--- a/packages/cli/dashboard/src/lib/components/tabs/MemoryTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/MemoryTab.svelte
@@ -12,6 +12,8 @@ import { Badge } from "$lib/components/ui/badge/index.js";
 import * as Select from "$lib/components/ui/select/index.js";
 import * as Popover from "$lib/components/ui/popover/index.js";
 import { Calendar } from "$lib/components/ui/calendar/index.js";
+import PageHero from "$lib/components/layout/PageHero.svelte";
+import { PAGE_HEADERS } from "$lib/components/layout/page-headers";
 import CalendarIcon from "@lucide/svelte/icons/calendar";
 import { getLocalTimeZone, CalendarDate, type DateValue } from "@internationalized/date";
 
@@ -120,7 +122,15 @@ function formatIsoDate(value: string): string {
 }
 </script>
 
-<section class="flex flex-col flex-1 min-h-0 gap-2.5 p-3 bg-[var(--sig-bg)]">
+<div class="flex flex-col flex-1 min-h-0 overflow-hidden">
+	<PageHero
+		title={PAGE_HEADERS.memory.title}
+		wordmarkLines={PAGE_HEADERS.memory.wordmarkLines}
+		eyebrow={PAGE_HEADERS.memory.eyebrow}
+		description={PAGE_HEADERS.memory.description}
+	/>
+
+	<section class="flex flex-col flex-1 min-h-0 gap-2.5 p-3 bg-[var(--sig-bg)]">
 	<!-- Search bar -->
 	<label class="flex items-center gap-2 px-3 py-1.5
 		border border-[var(--sig-border-strong)]
@@ -192,7 +202,7 @@ function formatIsoDate(value: string): string {
 					type="single"
 					captionLayout="dropdown"
 					value={toCalendarDate(mem.filterSince)}
-					onValueChange={(v) => {
+					onValueChange={(v: DateValue | undefined) => {
 						mem.filterSince = toIsoDate(v);
 						sincePickerOpen = false;
 					}}
@@ -326,7 +336,8 @@ function formatIsoDate(value: string): string {
 			{/each}
 		{/if}
 	</div>
-</section>
+	</section>
+</div>
 
 <style>
 	.doc-card::before,

--- a/packages/cli/dashboard/src/lib/components/tabs/PipelineTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/PipelineTab.svelte
@@ -12,6 +12,8 @@
 		selectNode,
 	} from "$lib/components/pipeline/pipeline-store.svelte";
 	import { PIPELINE_NODES, type LogEntry } from "$lib/components/pipeline/pipeline-types";
+	import PageHero from "$lib/components/layout/PageHero.svelte";
+	import { PAGE_HEADERS } from "$lib/components/layout/page-headers";
 
 	function handleSelectNode(id: string) {
 		selectNode(pipeline.selectedNodeId === id ? null : id);
@@ -93,6 +95,13 @@
 </script>
 
 <div class="flex flex-col h-full overflow-hidden">
+	<PageHero
+		title={PAGE_HEADERS.pipeline.title}
+		wordmarkLines={PAGE_HEADERS.pipeline.wordmarkLines}
+		eyebrow={PAGE_HEADERS.pipeline.eyebrow}
+		description={PAGE_HEADERS.pipeline.description}
+	/>
+
 	<!-- Toolbar -->
 	<div class="flex items-center justify-between px-4 py-2 border-b border-[var(--sig-border)] shrink-0">
 		<div class="flex items-center gap-3">

--- a/packages/cli/dashboard/src/lib/components/tabs/SecretsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/SecretsTab.svelte
@@ -4,6 +4,8 @@ import { getSecrets, putSecret, deleteSecret } from "$lib/api";
 import { toast } from "$lib/stores/toast.svelte";
 import { Button } from "$lib/components/ui/button/index.js";
 import { Input } from "$lib/components/ui/input/index.js";
+import PageHero from "$lib/components/layout/PageHero.svelte";
+import { PAGE_HEADERS } from "$lib/components/layout/page-headers";
 
 let secrets = $state<string[]>([]);
 let secretsLoading = $state(false);
@@ -50,8 +52,16 @@ onMount(() => {
 });
 </script>
 
-<div class="flex h-full flex-col gap-[var(--space-md)] overflow-hidden p-[var(--space-md)]">
-	<div class="flex shrink-0 gap-[var(--space-sm)]">
+<div class="flex h-full flex-col overflow-hidden">
+	<PageHero
+		title={PAGE_HEADERS.secrets.title}
+		wordmarkLines={PAGE_HEADERS.secrets.wordmarkLines}
+		eyebrow={PAGE_HEADERS.secrets.eyebrow}
+		description={PAGE_HEADERS.secrets.description}
+	/>
+
+	<div class="flex flex-1 flex-col gap-[var(--space-md)] overflow-hidden p-[var(--space-md)]">
+		<div class="flex shrink-0 gap-[var(--space-sm)]">
 		<Input
 			type="text"
 			class="flex-1 rounded-none border-[var(--sig-border-strong)]
@@ -79,30 +89,31 @@ onMount(() => {
 		>
 			{secretAdding ? 'Adding...' : 'Add'}
 		</Button>
-	</div>
+		</div>
 
-	<div class="flex flex-1 flex-col gap-[var(--space-sm)] overflow-y-auto">
-		{#if secretsLoading}
-			<div class="p-8 text-center text-[var(--sig-text-muted)]">Loading secrets...</div>
-		{:else if secrets.length === 0}
-			<div class="p-8 text-center text-[var(--sig-text-muted)]">No secrets stored. Add one above.</div>
-		{:else}
-			{#each secrets as name}
-				<div class="flex items-center gap-3 border border-[var(--sig-border-strong)] bg-[var(--sig-surface-raised)] px-[var(--space-md)] py-3">
-					<span class="flex-1 font-[family-name:var(--font-mono)] text-[13px] text-[var(--sig-text-bright)]">{name}</span>
-					<span class="font-[family-name:var(--font-mono)] text-[12px] text-[var(--sig-text-muted)]">••••••••</span>
-					<Button
-						variant="outline"
-						size="sm"
-						class="rounded-none border-[var(--sig-danger)] text-[var(--sig-danger)]
-							text-[11px] hover:bg-[var(--sig-danger)] hover:text-[var(--sig-text-bright)]"
-						onclick={() => removeSecret(name)}
-						disabled={secretDeleting === name}
-					>
-						{secretDeleting === name ? '...' : 'Delete'}
-					</Button>
-				</div>
-			{/each}
-		{/if}
+		<div class="flex flex-1 flex-col gap-[var(--space-sm)] overflow-y-auto">
+			{#if secretsLoading}
+				<div class="p-8 text-center text-[var(--sig-text-muted)]">Loading secrets...</div>
+			{:else if secrets.length === 0}
+				<div class="p-8 text-center text-[var(--sig-text-muted)]">No secrets stored. Add one above.</div>
+			{:else}
+				{#each secrets as name}
+					<div class="flex items-center gap-3 border border-[var(--sig-border-strong)] bg-[var(--sig-surface-raised)] px-[var(--space-md)] py-3">
+						<span class="flex-1 font-[family-name:var(--font-mono)] text-[13px] text-[var(--sig-text-bright)]">{name}</span>
+						<span class="font-[family-name:var(--font-mono)] text-[12px] text-[var(--sig-text-muted)]">••••••••</span>
+						<Button
+							variant="outline"
+							size="sm"
+							class="rounded-none border-[var(--sig-danger)] text-[var(--sig-danger)]
+								text-[11px] hover:bg-[var(--sig-danger)] hover:text-[var(--sig-text-bright)]"
+							onclick={() => removeSecret(name)}
+							disabled={secretDeleting === name}
+						>
+							{secretDeleting === name ? '...' : 'Delete'}
+						</Button>
+					</div>
+				{/each}
+			{/if}
+		</div>
 	</div>
 </div>

--- a/packages/cli/dashboard/src/lib/components/tabs/SettingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/SettingsTab.svelte
@@ -5,6 +5,8 @@ import { toast } from "$lib/stores/toast.svelte";
 import FormField from "$lib/components/config/FormField.svelte";
 import FormSection from "$lib/components/config/FormSection.svelte";
 import * as Select from "$lib/components/ui/select/index.js";
+import PageHero from "$lib/components/layout/PageHero.svelte";
+import { PAGE_HEADERS } from "$lib/components/layout/page-headers";
 
 interface Props {
 	configFiles: ConfigFile[];
@@ -201,6 +203,13 @@ let hasFiles = $derived(!!agentFile || !!configFile);
 </script>
 
 <div class="settings-tab">
+	<PageHero
+		title={PAGE_HEADERS.settings.title}
+		wordmarkLines={PAGE_HEADERS.settings.wordmarkLines}
+		eyebrow={PAGE_HEADERS.settings.eyebrow}
+		description={PAGE_HEADERS.settings.description}
+	/>
+
 	{#if !hasFiles}
 		<div class="empty-state">No YAML config files found</div>
 	{:else}

--- a/packages/cli/dashboard/src/lib/components/tabs/SkillsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/SkillsTab.svelte
@@ -18,6 +18,8 @@ import {
 import SkillGrid from "$lib/components/skills/SkillGrid.svelte";
 import SkillDetail from "$lib/components/skills/SkillDetail.svelte";
 import * as Tabs from "$lib/components/ui/tabs/index.js";
+import PageHero from "$lib/components/layout/PageHero.svelte";
+import { PAGE_HEADERS } from "$lib/components/layout/page-headers";
 
 let searchInput = $state<HTMLInputElement | null>(null);
 
@@ -84,123 +86,93 @@ onMount(() => {
 <svelte:window onkeydown={handleGlobalKey} />
 
 <div class="h-full flex flex-col overflow-hidden">
-	<!-- Hero header -->
-	<div
-		class="shrink-0 px-[var(--space-md)] pt-[var(--space-md)]
-			pb-[var(--space-sm)]
-			border-b border-[var(--sig-border)]"
+	<PageHero
+		title={PAGE_HEADERS.skills.title}
+		wordmarkLines={PAGE_HEADERS.skills.wordmarkLines}
+		eyebrow={PAGE_HEADERS.skills.eyebrow}
+		description={PAGE_HEADERS.skills.description}
 	>
-		<div class="flex items-start gap-6">
-			<div class="flex flex-col gap-1 shrink-0">
-				<h1 class="absolute hidden">Skills</h1>
-				<div class="relative max-w-[260px] overflow-hidden">
-					<pre
-						class="skills-ascii m-0 text-[var(--sig-text-muted)]
-							select-none whitespace-pre"
-						aria-hidden="true"
-					>███████╗██╗  ██╗██╗██╗     ██╗     ███████╗
-██╔════╝██║ ██╔╝██║██║     ██║     ██╔════╝
-███████╗█████╔╝ ██║██║     ██║     ███████╗
-╚════██║██╔═██╗ ██║██║     ██║     ╚════██║
-███████║██║  ██╗██║███████╗███████╗███████║
-╚══════╝╚═╝  ╚═╝╚═╝╚══════╝╚══════╝╚══════╝</pre>
-					<pre
-						class="skills-ascii absolute top-0 left-0 m-0
-							text-[var(--sig-text-bright)] select-none whitespace-pre"
-						aria-label="SKILLS"
-					>███████ ██   ██ ██ ██      ██      ███████
-██      ██  ██  ██ ██      ██      ██
-███████ █████   ██ ██      ██      ███████
-     ██ ██  ██  ██ ██      ██           ██
-███████ ██   ██ ██ ███████ ███████ ███████
-{' '}</pre>
-				</div>
-				<span
-					class="font-[family-name:var(--font-mono)] text-[10px]
-						font-medium text-[var(--sig-text)]
-						uppercase tracking-[0.12em]"
-				>
-					The open agent skills ecosystem
-				</span>
-				<span class="stats-bar">
-					{#if sk.catalogTotal}
-						{sk.catalogTotal.toLocaleString()} available
-						<span class="stats-sep">·</span>
-					{/if}
-					{sk.installed.length} installed
-				</span>
-			</div>
+		{#snippet meta()}
+			<span class="stats-bar">
+				{#if sk.catalogTotal}
+					{sk.catalogTotal.toLocaleString()} available
+					<span class="stats-sep">·</span>
+				{/if}
+				{sk.installed.length} installed
+			</span>
+		{/snippet}
+	</PageHero>
 
-			<!-- Search bar -->
-			<div class="flex-1 flex flex-col gap-2 pt-[2px] min-w-0">
-				<div class="relative">
-					<input
-						bind:this={searchInput}
-						type="text"
-						class="w-full px-3 py-[6px]
-							border border-[var(--sig-border-strong)]
-							bg-[var(--sig-surface-raised)]
-							text-[var(--sig-text-bright)] text-[11px]
-							font-[family-name:var(--font-mono)]
-							outline-none focus:border-[var(--sig-accent)]
-							pr-8"
-						value={sk.query}
-						oninput={(e) => setQuery(e.currentTarget.value)}
-						placeholder="Search skills..."
+	<div
+		class="shrink-0 px-[var(--space-md)] py-[var(--space-sm)]
+			border-b border-[var(--sig-border)] flex flex-col gap-2"
+	>
+		<div class="relative">
+			<input
+				bind:this={searchInput}
+				type="text"
+				class="w-full px-3 py-[6px]
+					border border-[var(--sig-border-strong)]
+					bg-[var(--sig-surface-raised)]
+					text-[var(--sig-text-bright)] text-[11px]
+					font-[family-name:var(--font-mono)]
+					outline-none focus:border-[var(--sig-accent)]
+					pr-8"
+				value={sk.query}
+				oninput={(e) => setQuery(e.currentTarget.value)}
+				placeholder="Search skills..."
+			/>
+			<kbd
+				class="absolute right-2 top-1/2 -translate-y-1/2
+					px-[5px] py-px text-[9px]
+					text-[var(--sig-text-muted)]
+					bg-[var(--sig-bg)]
+					border border-[var(--sig-border)]
+					pointer-events-none"
+			>/</kbd>
+		</div>
+		<div class="flex items-center gap-3 flex-wrap">
+			<a
+				href="https://skills.sh"
+				target="_blank"
+				rel="noopener"
+				class="font-[family-name:var(--font-mono)] text-[10px]
+					text-[var(--sig-text-muted)]
+					hover:text-[var(--sig-accent)] no-underline"
+			>
+				skills.sh
+			</a>
+			<span class="text-[var(--sig-border-strong)]">|</span>
+			<a
+				href="https://clawhub.ai"
+				target="_blank"
+				rel="noopener"
+				class="font-[family-name:var(--font-mono)] text-[10px]
+					text-[var(--sig-text-muted)]
+					hover:text-[var(--sig-accent)] no-underline"
+			>
+				clawhub.ai
+			</a>
+			<span class="text-[var(--sig-border-strong)]">|</span>
+			<a
+				href="https://socket.dev/blog/socket-brings-supply-chain-security-to-skills"
+				target="_blank"
+				rel="noopener"
+				class="inline-flex items-center gap-[5px]
+					font-[family-name:var(--font-mono)] text-[10px]
+					text-[var(--sig-success)] no-underline
+					hover:underline"
+			>
+				<svg width="10" height="10" viewBox="0 0 16 16" fill="none"
+					class="shrink-0"
+				>
+					<path
+						d="M8 0L10 5.5L16 6L11.5 10L13 16L8 12.5L3 16L4.5 10L0 6L6 5.5L8 0Z"
+						fill="currentColor"
 					/>
-					<kbd
-						class="absolute right-2 top-1/2 -translate-y-1/2
-							px-[5px] py-px text-[9px]
-							text-[var(--sig-text-muted)]
-							bg-[var(--sig-bg)]
-							border border-[var(--sig-border)]
-							pointer-events-none"
-					>/</kbd>
-				</div>
-				<div class="flex items-center gap-3 flex-wrap">
-					<a
-						href="https://skills.sh"
-						target="_blank"
-						rel="noopener"
-						class="font-[family-name:var(--font-mono)] text-[10px]
-							text-[var(--sig-text-muted)]
-							hover:text-[var(--sig-accent)] no-underline"
-					>
-						skills.sh
-					</a>
-					<span class="text-[var(--sig-border-strong)]">|</span>
-					<a
-						href="https://clawhub.ai"
-						target="_blank"
-						rel="noopener"
-						class="font-[family-name:var(--font-mono)] text-[10px]
-							text-[var(--sig-text-muted)]
-							hover:text-[var(--sig-accent)] no-underline"
-					>
-						clawhub.ai
-					</a>
-					<span class="text-[var(--sig-border-strong)]">|</span>
-					<a
-						href="https://socket.dev/blog/socket-brings-supply-chain-security-to-skills"
-						target="_blank"
-						rel="noopener"
-						class="inline-flex items-center gap-[5px]
-							font-[family-name:var(--font-mono)] text-[10px]
-							text-[var(--sig-success)] no-underline
-							hover:underline"
-					>
-						<svg width="10" height="10" viewBox="0 0 16 16" fill="none"
-							class="shrink-0"
-						>
-							<path
-								d="M8 0L10 5.5L16 6L11.5 10L13 16L8 12.5L3 16L4.5 10L0 6L6 5.5L8 0Z"
-								fill="currentColor"
-							/>
-						</svg>
-						Verified by Socket.dev
-					</a>
-				</div>
-			</div>
+				</svg>
+				Verified by Socket.dev
+			</a>
 		</div>
 	</div>
 
@@ -292,13 +264,6 @@ onMount(() => {
 
 	.stats-sep {
 		color: var(--sig-border-strong);
-	}
-
-	.skills-ascii {
-		font-family: var(--font-mono);
-		font-size: 10px;
-		letter-spacing: -1px;
-		line-height: 125%;
 	}
 
 	.sort-select {

--- a/packages/cli/dashboard/src/lib/components/tabs/TasksTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/TasksTab.svelte
@@ -15,6 +15,8 @@ import TaskBoard from "$lib/components/tasks/TaskBoard.svelte";
 import TaskForm from "$lib/components/tasks/TaskForm.svelte";
 import TaskDetail from "$lib/components/tasks/TaskDetail.svelte";
 import { Button } from "$lib/components/ui/button/index.js";
+import PageHero from "$lib/components/layout/PageHero.svelte";
+import { PAGE_HEADERS } from "$lib/components/layout/page-headers";
 import Plus from "@lucide/svelte/icons/plus";
 
 function handleGlobalKey(e: KeyboardEvent) {
@@ -47,66 +49,24 @@ onMount(() => {
 <svelte:window onkeydown={handleGlobalKey} />
 
 <div class="h-full flex flex-col overflow-hidden">
-	<!-- Hero header -->
-	<div
-		class="shrink-0 px-[var(--space-md)] pt-[var(--space-md)]
-			pb-[var(--space-sm)] flex items-start gap-6
-			border-b border-[var(--sig-border)]"
+	<PageHero
+		title={PAGE_HEADERS.tasks.title}
+		wordmarkLines={PAGE_HEADERS.tasks.wordmarkLines}
+		eyebrow={PAGE_HEADERS.tasks.eyebrow}
+		description={PAGE_HEADERS.tasks.description}
 	>
-		<div class="flex flex-col gap-1 shrink-0">
-			<h1 class="absolute hidden">Tasks</h1>
-			<div class="relative max-w-[260px] overflow-hidden">
-				<pre
-					class="tasks-ascii m-0 text-[var(--sig-text-muted)]
-						select-none whitespace-pre"
-					aria-hidden="true"
-				>████████╗ █████╗ ███████╗██╗  ██╗███████╗
-╚══██╔══╝██╔══██╗██╔════╝██║ ██╔╝██╔════╝
-   ██║   ███████║███████╗█████╔╝ ███████╗
-   ██║   ██╔══██║╚════██║██╔═██╗ ╚════██║
-   ██║   ██║  ██║███████║██║  ██╗███████║
-   ╚═╝   ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚══════╝</pre>
-				<pre
-					class="tasks-ascii absolute top-0 left-0 m-0
-						text-[var(--sig-text-bright)] select-none whitespace-pre"
-					aria-label="TASKS"
-				>████████  █████  ███████ ██   ██ ███████
-   ██    ██   ██ ██      ██  ██  ██
-   ██    ███████ ███████ █████   ███████
-   ██    ██   ██      ██ ██  ██       ██
-   ██    ██   ██ ███████ ██   ██ ███████
-{' '}</pre>
-			</div>
-			<span
-				class="font-[family-name:var(--font-mono)] text-[10px]
-					font-medium text-[var(--sig-text)]
-					uppercase tracking-[0.12em]"
+		{#snippet actions()}
+			<Button
+				variant="outline"
+				size="sm"
+				class="h-7 gap-1.5 text-[11px]"
+				onclick={() => openForm()}
 			>
-				Scheduled agent prompts
-			</span>
-		</div>
-		<div class="flex flex-col gap-2 pt-[2px]">
-			<p
-				class="text-[12px] text-[var(--sig-text)] leading-[1.5] m-0
-					max-w-[460px]"
-			>
-				Schedule recurring prompts to run automatically via Claude Code or
-				OpenCode. The daemon evaluates cron expressions and spawns CLI
-				processes on schedule.
-			</p>
-			<div class="flex gap-2">
-				<Button
-					variant="outline"
-					size="sm"
-					class="h-7 gap-1.5 text-[11px]"
-					onclick={() => openForm()}
-				>
-					<Plus class="size-3.5" />
-					New Task
-				</Button>
-			</div>
-		</div>
-	</div>
+				<Plus class="size-3.5" />
+				New Task
+			</Button>
+		{/snippet}
+	</PageHero>
 
 	<!-- Board -->
 	<div class="flex-1 min-h-0 overflow-auto">
@@ -143,12 +103,3 @@ onMount(() => {
 		openForm(id);
 	}}
 />
-
-<style>
-	.tasks-ascii {
-		font-size: 8px;
-		line-height: 1.15;
-		font-family: var(--font-mono);
-		letter-spacing: -0.04em;
-	}
-</style>


### PR DESCRIPTION
## Summary
- Standardized dashboard page headers with a shared hero component so each tab now has the same visual size and spacing.
- Added unique page-specific header content (title, ASCII wordmark, eyebrow text, description) for every main tab.
- Updated the Constellation header to render left-to-right as a single word (`CONSTELLATION`) instead of stacking vertically.

## How It Was Fixed
- Added a reusable hero component at `packages/cli/dashboard/src/lib/components/layout/PageHero.svelte`.
  - Centralizes header structure, typography, spacing, and action/meta slots.
  - Uses generated ASCII wordmarks for consistent presentation.
- Added page header definitions at `packages/cli/dashboard/src/lib/components/layout/page-headers.ts`.
  - Each tab now has unique copy while sharing a consistent layout system.
- Migrated tab pages to the shared hero:
  - `ConfigTab.svelte`
  - `SettingsTab.svelte`
  - `MemoryTab.svelte`
  - `EmbeddingsTab.svelte`
  - `PipelineTab.svelte`
  - `LogsTab.svelte`
  - `SecretsTab.svelte`
  - `SkillsTab.svelte`
  - `TasksTab.svelte`
- Skills-specific normalization:
  - Moved search and provider links out of the hero into a dedicated row below, so header size now matches the Tasks reference design.
- Constellation-specific correction:
  - Switched embeddings wordmark to a single line and added a per-page `wordmarkMaxWidth` override so it fits horizontally above description text.

## Validation
- Built dashboard successfully:
  - `bun run build` in `packages/cli/dashboard`
- Verified no backend/database/scheduler changes were introduced; this PR is UI-only.
