### PR TITLE
fix(dashboard): improve pipeline live feed usability

### DIFF
--- a/packages/cli/dashboard/src/lib/components/pipeline/PipelineGraph.svelte
+++ b/packages/cli/dashboard/src/lib/components/pipeline/PipelineGraph.svelte
@@ -17,6 +17,17 @@
 
 	const groups = Object.entries(GROUP_BOXES) as Array<[NodeGroup, typeof GROUP_BOXES[NodeGroup]]>;
 
+	const MIN_ZOOM = 0.7;
+	const MAX_ZOOM = 2.4;
+	const ZOOM_STEP = 0.12;
+
+	let zoom = $state(1);
+	let panX = $state(0);
+	let panY = $state(0);
+	let isPanning = $state(false);
+	let panStartX = $state(0);
+	let panStartY = $state(0);
+
 	// Track which nodes had recent activity (within last 5s)
 	function isNodeActive(id: string): boolean {
 		const node = pipeline.nodes[id];
@@ -24,13 +35,87 @@
 		const age = Date.now() - new Date(node.lastActivity).getTime();
 		return age < 5000;
 	}
+
+	function clampZoom(value: number): number {
+		return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, value));
+	}
+
+	function resetViewport(): void {
+		zoom = 1;
+		panX = 0;
+		panY = 0;
+	}
+
+	function handleWheel(event: WheelEvent): void {
+		event.preventDefault();
+
+		const svg = event.currentTarget;
+		if (!(svg instanceof SVGSVGElement)) return;
+
+		const rect = svg.getBoundingClientRect();
+		const pointerX = event.clientX - rect.left;
+		const pointerY = event.clientY - rect.top;
+
+		const direction = event.deltaY < 0 ? 1 : -1;
+		const nextZoom = clampZoom(zoom + direction * ZOOM_STEP);
+		if (nextZoom === zoom) return;
+
+		const graphX = (pointerX - panX) / zoom;
+		const graphY = (pointerY - panY) / zoom;
+
+		zoom = nextZoom;
+		panX = pointerX - graphX * nextZoom;
+		panY = pointerY - graphY * nextZoom;
+	}
+
+	function handlePointerDown(event: PointerEvent): void {
+		if (event.button !== 0) return;
+		if (event.target !== event.currentTarget) return;
+
+		const svg = event.currentTarget;
+		if (svg instanceof SVGSVGElement) {
+			svg.setPointerCapture(event.pointerId);
+		}
+
+		isPanning = true;
+		panStartX = event.clientX;
+		panStartY = event.clientY;
+	}
+
+	function handlePointerMove(event: PointerEvent): void {
+		if (!isPanning) return;
+		const dx = event.clientX - panStartX;
+		const dy = event.clientY - panStartY;
+		panStartX = event.clientX;
+		panStartY = event.clientY;
+		panX += dx;
+		panY += dy;
+	}
+
+	function handlePointerEnd(event: PointerEvent): void {
+		if (!isPanning) return;
+		const svg = event.currentTarget;
+		if (svg instanceof SVGSVGElement) {
+			svg.releasePointerCapture(event.pointerId);
+		}
+		isPanning = false;
+	}
 </script>
 
 <svg
 	viewBox="0 0 1160 650"
 	preserveAspectRatio="xMidYMid meet"
-	class="w-full h-full"
+	class="w-full h-full select-none"
 	xmlns="http://www.w3.org/2000/svg"
+	role="application"
+	aria-label="Pipeline graph. Use mouse wheel to zoom, drag background to pan, double-click to reset."
+	onwheel={handleWheel}
+	onpointerdown={handlePointerDown}
+	onpointermove={handlePointerMove}
+	onpointerup={handlePointerEnd}
+	onpointercancel={handlePointerEnd}
+	onpointerleave={handlePointerEnd}
+	ondblclick={resetViewport}
 >
 	<defs>
 		<!-- Glow filter for active elements -->
@@ -56,49 +141,51 @@
 		</marker>
 	</defs>
 
-	<!-- Group background boxes -->
-	{#each groups as [groupId, box]}
-		<g>
-			<rect
-				x={box.x}
-				y={box.y}
-				width={box.w}
-				height={box.h}
-				rx="8"
-				ry="8"
-				fill={box.color}
-				fill-opacity="0.06"
-				stroke={box.color}
-				stroke-opacity="0.25"
-				stroke-width="1"
-				stroke-dasharray="4 3"
+	<g transform={`translate(${panX} ${panY}) scale(${zoom})`}>
+		<!-- Group background boxes -->
+		{#each groups as [groupId, box]}
+			<g>
+				<rect
+					x={box.x}
+					y={box.y}
+					width={box.w}
+					height={box.h}
+					rx="8"
+					ry="8"
+					fill={box.color}
+					fill-opacity="0.06"
+					stroke={box.color}
+					stroke-opacity="0.25"
+					stroke-width="1"
+					stroke-dasharray="4 3"
+				/>
+				<text
+					x={box.x + 8}
+					y={box.y + 14}
+					fill={box.color}
+					font-size="9"
+					font-family="var(--font-mono)"
+					opacity="0.6"
+					letter-spacing="0.08em"
+				>
+					{box.label.toUpperCase()}
+				</text>
+			</g>
+		{/each}
+
+		<!-- Edges (behind nodes) -->
+		{#each PIPELINE_EDGES as edge (edge.from + "-" + edge.to)}
+			<PipelineEdge {edge} active={isNodeActive(edge.from)} />
+		{/each}
+
+		<!-- Nodes -->
+		{#each PIPELINE_NODES as def (def.id)}
+			<PipelineNode
+				{def}
+				nodeState={pipeline.nodes[def.id]}
+				selected={pipeline.selectedNodeId === def.id}
+				{onselectnode}
 			/>
-			<text
-				x={box.x + 8}
-				y={box.y + 14}
-				fill={box.color}
-				font-size="9"
-				font-family="var(--font-mono)"
-				opacity="0.6"
-				letter-spacing="0.08em"
-			>
-				{box.label.toUpperCase()}
-			</text>
-		</g>
-	{/each}
-
-	<!-- Edges (behind nodes) -->
-	{#each PIPELINE_EDGES as edge (edge.from + "-" + edge.to)}
-		<PipelineEdge {edge} active={isNodeActive(edge.from)} />
-	{/each}
-
-	<!-- Nodes -->
-	{#each PIPELINE_NODES as def (def.id)}
-		<PipelineNode
-			{def}
-			nodeState={pipeline.nodes[def.id]}
-			selected={pipeline.selectedNodeId === def.id}
-			{onselectnode}
-		/>
-	{/each}
+		{/each}
+	</g>
 </svg>

--- a/packages/cli/dashboard/src/lib/components/tabs/PipelineTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/PipelineTab.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { onMount } from "svelte";
 	import { Badge } from "$lib/components/ui/badge/index.js";
+	import * as Switch from "$lib/components/ui/switch/index.js";
+	import * as Popover from "$lib/components/ui/popover/index.js";
 	import PipelineGraph from "$lib/components/pipeline/PipelineGraph.svelte";
 	import PipelineDetailSheet from "$lib/components/pipeline/PipelineDetailSheet.svelte";
 	import {
@@ -11,7 +13,7 @@
 		stopPolling,
 		selectNode,
 	} from "$lib/components/pipeline/pipeline-store.svelte";
-	import { PIPELINE_NODES, type LogEntry } from "$lib/components/pipeline/pipeline-types";
+	import { PIPELINE_NODES } from "$lib/components/pipeline/pipeline-types";
 
 
 	function handleSelectNode(id: string) {
@@ -20,13 +22,99 @@
 
 	let feedViewport: HTMLElement | null = $state(null);
 	let autoScroll = $state(true);
+	let feedExpanded = $state(false);
+	let mobileFeedActionsOpen = $state(false);
+	const AUTO_SCROLL_THRESHOLD_PX = 24;
+	let feedAtLatest = $state(true);
+	let feedWidthClass = $derived(feedExpanded ? "lg:w-[420px]" : "lg:w-[320px]");
+	let feedPositionLabel = $derived(feedAtLatest ? "Latest" : "Oldest");
+	let feedDensityLabel = $derived(feedExpanded ? "Expanded" : "Compact");
+
+	function scrollFeedToBottom(behavior: ScrollBehavior = "smooth"): void {
+		if (!feedViewport) return;
+		feedViewport.scrollTo({ top: feedViewport.scrollHeight, behavior });
+	}
+
+	function isFeedNearBottom(): boolean {
+		if (!feedViewport) return true;
+		const distance =
+			feedViewport.scrollHeight - feedViewport.scrollTop -
+			feedViewport.clientHeight;
+		return distance <= AUTO_SCROLL_THRESHOLD_PX;
+	}
+
+	function updateFeedPositionFlags(): void {
+		if (!feedViewport) return;
+		const overflow =
+			feedViewport.scrollHeight - feedViewport.clientHeight >
+			AUTO_SCROLL_THRESHOLD_PX;
+		if (!overflow) return;
+
+		if (isFeedNearBottom()) {
+			feedAtLatest = true;
+			return;
+		}
+
+		if (feedViewport.scrollTop <= AUTO_SCROLL_THRESHOLD_PX) {
+			feedAtLatest = false;
+		}
+	}
+
+	function handleFeedJumpClick(event?: Event): void {
+		if (!feedViewport) return;
+
+		if (feedAtLatest) {
+			autoScroll = false;
+			feedAtLatest = false;
+			feedViewport.scrollTo({ top: 0, behavior: "smooth" });
+		} else {
+			autoScroll = true;
+			feedAtLatest = true;
+			scrollFeedToBottom("auto");
+		}
+
+		if (event?.currentTarget instanceof HTMLElement) {
+			event.currentTarget.blur();
+		}
+		mobileFeedActionsOpen = false;
+	}
+
+	function handleAutoScrollChange(checked: boolean): void {
+		autoScroll = checked;
+		if (checked) {
+			feedAtLatest = true;
+			requestAnimationFrame(() => {
+				scrollFeedToBottom("auto");
+				updateFeedPositionFlags();
+			});
+		}
+	}
+
+	function handleFeedWidthToggle(event?: Event): void {
+		feedExpanded = !feedExpanded;
+		if (event?.currentTarget instanceof HTMLElement) {
+			event.currentTarget.blur();
+		}
+		mobileFeedActionsOpen = false;
+	}
+
+	function getEntryDataKeySummary(data?: Record<string, unknown>): string {
+		if (!data) return "";
+		const keys = Object.keys(data);
+		if (keys.length === 0) return "";
+		const shown = keys.slice(0, 4).join(", ");
+		return keys.length > 4 ? `${shown} +${keys.length - 4}` : shown;
+	}
 
 	// Auto-scroll feed
 	$effect(() => {
 		const _ = pipeline.feed.length;
+		updateFeedPositionFlags();
 		if (autoScroll && feedViewport) {
+			if (!isFeedNearBottom()) return;
 			requestAnimationFrame(() => {
-				feedViewport?.scrollTo({ top: feedViewport.scrollHeight, behavior: "smooth" });
+				scrollFeedToBottom("smooth");
+				updateFeedPositionFlags();
 			});
 		}
 	});
@@ -136,32 +224,102 @@
 	</div>
 
 	<!-- Main content: graph + feed -->
-	<div class="flex flex-1 min-h-0">
+	<div class="flex flex-1 min-h-0 flex-col lg:flex-row">
 		<!-- Graph area -->
-		<div class="flex-1 min-w-0 p-4 overflow-auto">
+		<div class="flex-1 min-w-0 min-h-[46vh] lg:min-h-0 p-4 overflow-auto">
 			<PipelineGraph onselectnode={handleSelectNode} />
 		</div>
 
 		<!-- Live feed panel -->
-		<div class="w-[280px] shrink-0 border-l border-[var(--sig-border)] flex flex-col bg-[var(--sig-bg)]">
+		<div
+			class={`w-full shrink-0 border-t lg:border-t-0 lg:border-l border-[var(--sig-border)] flex flex-col bg-[var(--sig-bg)] min-h-[220px] max-h-[40vh] lg:max-h-none ${feedWidthClass}`}
+		>
 			<!-- Feed header -->
-			<div class="flex items-center justify-between px-3 py-2 border-b border-[var(--sig-border)]">
-				<span class="text-[10px] uppercase tracking-[0.1em] text-[var(--sig-text-muted)] font-[family-name:var(--font-display)]">
-					Live Feed
-				</span>
-				<span class="text-[9px] text-[var(--sig-text-muted)] font-[family-name:var(--font-mono)]">
-					{pipeline.feed.length} events
-				</span>
+			<div class="px-3 py-2 border-b border-[var(--sig-border)] space-y-2">
+				<div class="flex items-center justify-between gap-2">
+					<span class="text-[10px] uppercase tracking-[0.1em] text-[var(--sig-text-muted)] font-[family-name:var(--font-display)]">
+						Live Feed
+					</span>
+					<span class="text-[9px] text-[var(--sig-text-muted)] font-[family-name:var(--font-mono)]">
+						{pipeline.feed.length} events
+					</span>
+				</div>
+				<div class="flex items-center justify-between gap-2 min-w-0">
+					<label class="inline-flex items-center gap-1.5 text-[10px] text-[var(--sig-text)] font-[family-name:var(--font-mono)] cursor-pointer min-w-0">
+						<Switch.Root
+							checked={autoScroll}
+							onCheckedChange={(value: boolean) => handleAutoScrollChange(value)}
+							class="scale-90"
+						/>
+						<span>Auto-scroll</span>
+					</label>
+					<div class="hidden lg:flex items-center gap-1.5 shrink-0">
+						<button
+							type="button"
+							class="px-2 py-[3px] text-[9px] uppercase tracking-[0.08em] font-[family-name:var(--font-mono)] border border-[var(--sig-border)] text-[var(--sig-text-muted)] hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
+							onclick={(event) => handleFeedJumpClick(event)}
+						>
+							{feedPositionLabel}
+						</button>
+						<button
+							type="button"
+							class="px-2 py-[3px] text-[9px] uppercase tracking-[0.08em] font-[family-name:var(--font-mono)] border border-[var(--sig-border)] text-[var(--sig-text-muted)] hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
+							onclick={(event) => handleFeedWidthToggle(event)}
+						>
+							{feedDensityLabel}
+						</button>
+					</div>
+					<div class="lg:hidden shrink-0">
+						<Popover.Root bind:open={mobileFeedActionsOpen}>
+							<Popover.Trigger>
+								{#snippet child({ props })}
+									<button
+										{...props}
+										type="button"
+										class="px-2 py-[3px] text-[9px] uppercase tracking-[0.08em] font-[family-name:var(--font-mono)] border border-[var(--sig-border)] text-[var(--sig-text-muted)] hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
+									>
+										Feed actions
+									</button>
+								{/snippet}
+							</Popover.Trigger>
+							<Popover.Content
+								align="end"
+								side="bottom"
+								class="w-[170px] p-1 bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] rounded-none"
+							>
+								<div class="flex flex-col gap-1">
+									<button
+										type="button"
+										class="w-full text-left px-2 py-1 text-[10px] uppercase tracking-[0.08em] font-[family-name:var(--font-mono)] border border-[var(--sig-border)] text-[var(--sig-text-muted)] hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
+										onclick={(event) => handleFeedJumpClick(event)}
+									>
+										{feedPositionLabel}
+									</button>
+									<button
+										type="button"
+										class="w-full text-left px-2 py-1 text-[10px] uppercase tracking-[0.08em] font-[family-name:var(--font-mono)] border border-[var(--sig-border)] text-[var(--sig-text-muted)] hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
+										onclick={(event) => handleFeedWidthToggle(event)}
+									>
+										{feedDensityLabel}
+									</button>
+								</div>
+							</Popover.Content>
+						</Popover.Root>
+					</div>
+				</div>
 			</div>
 
 			<!-- Feed entries -->
 			<div
 				bind:this={feedViewport}
+				onscroll={updateFeedPositionFlags}
 				class="flex-1 overflow-y-auto px-1 py-1"
 			>
 				{#each pipeline.feed as entry, i (entry.timestamp + "-" + i)}
 					{@const catColor = CATEGORY_COLORS[entry.category] ?? "var(--sig-text-muted)"}
 					{@const levelColor = LEVEL_COLORS[entry.level] ?? "#6b6b76"}
+					{@const canExpand = entry.message.length > 72}
+					{@const dataKeySummary = getEntryDataKeySummary(entry.data)}
 					<div class="feed-entry px-2 py-1.5 rounded hover:bg-[var(--sig-surface-raised)] transition-colors">
 						<div class="flex items-center gap-1.5">
 							<!-- Time -->
@@ -182,13 +340,45 @@
 							</span>
 						</div>
 						<!-- Message -->
-						<div class="text-[10px] text-[var(--sig-text)] font-[family-name:var(--font-mono)] mt-0.5 pl-[56px] truncate">
-							{entry.message}
-						</div>
-						{#if entry.duration}
-							<span class="text-[8px] text-[var(--sig-text-muted)] font-[family-name:var(--font-mono)] pl-[56px]">
-								{entry.duration}ms
-							</span>
+						{#if feedExpanded}
+							<div class="text-[10px] text-[var(--sig-text)] font-[family-name:var(--font-mono)] mt-0.5 pl-[56px] whitespace-pre-wrap break-words">
+								{entry.message}
+							</div>
+							<div class="mt-1 pl-[56px] flex flex-wrap gap-x-2 gap-y-1 text-[8px] text-[var(--sig-text-muted)] font-[family-name:var(--font-mono)] uppercase tracking-[0.05em]">
+								<span>level {entry.level}</span>
+								<span>category {entry.category}</span>
+								{#if entry.duration}
+									<span>duration {entry.duration}ms</span>
+								{/if}
+								{#if dataKeySummary}
+									<span>data {dataKeySummary}</span>
+								{/if}
+							</div>
+							{#if entry.error}
+								<div class="mt-1 pl-[56px] text-[9px] text-[#f87171] font-[family-name:var(--font-mono)] whitespace-pre-wrap break-words">
+									{entry.error.name}: {entry.error.message}
+								</div>
+							{/if}
+						{:else}
+							{#if canExpand}
+								<details class="mt-0.5 pl-[56px] group">
+									<summary class="list-none cursor-pointer text-[10px] text-[var(--sig-text)] font-[family-name:var(--font-mono)] line-clamp-2 break-words [&::-webkit-details-marker]:hidden">
+										{entry.message}
+									</summary>
+									<div class="mt-1 text-[10px] text-[var(--sig-text)] font-[family-name:var(--font-mono)] whitespace-pre-wrap break-words">
+										{entry.message}
+									</div>
+								</details>
+							{:else}
+								<div class="text-[10px] text-[var(--sig-text)] font-[family-name:var(--font-mono)] mt-0.5 pl-[56px] whitespace-pre-wrap break-words">
+									{entry.message}
+								</div>
+							{/if}
+							{#if entry.duration}
+								<span class="text-[8px] text-[var(--sig-text-muted)] font-[family-name:var(--font-mono)] pl-[56px]">
+									{entry.duration}ms
+								</span>
+							{/if}
 						{/if}
 					</div>
 				{/each}


### PR DESCRIPTION
## Summary
- Fix the Pipeline tab layout so graph/feed stack cleanly on mobile and stay side-by-side on desktop.
- Improve Live Feed readability with compact vs expanded modes and richer event metadata in expanded view.
- Restore Pipeline graph interactions (wheel zoom, drag pan, double-click reset) and improve feed control behavior.

## How
- Updated `PipelineTab.svelte` to add responsive container behavior (`flex-col` on mobile, `lg:flex-row` on desktop), bounded feed heights, and mobile feed actions via popover.
- Added explicit feed position state and refined auto-scroll + jump logic so `Latest`/`Oldest` reflects current state and switches correctly on first click.
- Added expanded feed rendering details (level/category/duration/data keys/error) while keeping compact mode concise.
- Updated `PipelineGraph.svelte` with zoom/pan/reset viewport handlers and wrapped graph elements in transformed group for interaction-driven viewport updates.

## Why
- The previous mobile layout made Pipeline hard to use by squeezing graph and feed together.
- Live feed controls were showing next actions rather than current state and could require extra clicks, which felt broken.
- Graph interaction parity (zoom/pan) is essential for navigating dense pipeline topology quickly.

## Validation
- `bun run typecheck`
- `bun run --filter @signet/cli build:dashboard`