### PR TITLE
fix(dashboard): improve expanded pipeline log visibility

### DIFF
--- a/packages/cli/dashboard/src/lib/components/tabs/PipelineTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/PipelineTab.svelte
@@ -179,6 +179,138 @@
 		harness: "#4dabf7",
 		llm: "#fcc419",
 	};
+
+	const PRIORITY_DATA_KEYS = [
+		"jobId",
+		"memoryId",
+		"sessionKey",
+		"project",
+		"attempt",
+		"maxRetries",
+		"mode",
+		"provider",
+		"model",
+		"facts",
+		"entities",
+		"proposals",
+		"added",
+		"updated",
+		"deleted",
+		"deduped",
+		"skippedLowConfidence",
+		"blockedDestructive",
+		"runId",
+		"taskId",
+		"path",
+		"port",
+		"pid",
+		"error",
+	] as const;
+
+	function formatRelativeTime(ts: string): string {
+		const deltaMs = Date.now() - new Date(ts).getTime();
+		if (!Number.isFinite(deltaMs) || deltaMs < 0) return "just now";
+		const sec = Math.floor(deltaMs / 1000);
+		if (sec < 60) return `${sec}s ago`;
+		const min = Math.floor(sec / 60);
+		if (min < 60) return `${min}m ago`;
+		const hr = Math.floor(min / 60);
+		if (hr < 24) return `${hr}h ago`;
+		const day = Math.floor(hr / 24);
+		return `${day}d ago`;
+	}
+
+	function keyLabel(key: string): string {
+		return key
+			.replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+			.replace(/[_-]+/g, " ")
+			.replace(/^./, (s) => s.toUpperCase());
+	}
+
+	function formatValue(value: unknown): string {
+		if (value === null) return "null";
+		if (value === undefined) return "undefined";
+		if (typeof value === "string") return value;
+		if (typeof value === "number" || typeof value === "boolean") {
+			return String(value);
+		}
+		if (Array.isArray(value)) return `[${value.length} items]`;
+		if (typeof value === "object") return "{object}";
+		return String(value);
+	}
+
+	function summarizeProcess(entry: {
+		readonly category: string;
+		readonly message: string;
+		readonly data?: Record<string, unknown>;
+	}): string {
+		const msg = entry.message.toLowerCase();
+		const stage = entry.category.replace(/-/g, " ");
+
+		if (msg.includes("job failed")) {
+			const attempt = entry.data?.attempt;
+			return typeof attempt === "number"
+				? `${stage} failed (attempt ${attempt})`
+				: `${stage} failed`;
+		}
+		if (msg.includes("completed")) return `${stage} completed`;
+		if (msg.includes("started") || msg.includes("starting")) {
+			return `${stage} started`;
+		}
+		if (msg.includes("enqueued")) return `${stage} queued`;
+		if (msg.includes("failed")) return `${stage} warning`;
+		if (msg.includes("file changed")) return "watcher detected file change";
+		return `${stage} event`;
+	}
+
+	function getEntryMetaRows(entry: {
+		readonly level: string;
+		readonly category: string;
+		readonly duration?: number;
+		readonly data?: Record<string, unknown>;
+	}): Array<{ label: string; value: string }> {
+		const rows: Array<{ label: string; value: string }> = [
+			{ label: "Level", value: entry.level },
+			{ label: "Category", value: entry.category },
+		];
+
+		if (entry.duration !== undefined) {
+			rows.push({ label: "Duration", value: `${entry.duration} ms` });
+		}
+
+		const data = entry.data;
+		if (!data) return rows;
+
+		const used = new Set<string>();
+		for (const key of PRIORITY_DATA_KEYS) {
+			if (key in data) {
+				rows.push({ label: keyLabel(key), value: formatValue(data[key]) });
+				used.add(key);
+			}
+		}
+
+		for (const key of Object.keys(data).sort()) {
+			if (used.has(key)) continue;
+			rows.push({ label: keyLabel(key), value: formatValue(data[key]) });
+		}
+
+		return rows;
+	}
+
+	function getEntryRawPayload(entry: {
+		readonly data?: Record<string, unknown>;
+		readonly error?: { name: string; message: string };
+	}): string {
+		const payload: Record<string, unknown> = {};
+		if (entry.data) payload.data = entry.data;
+		if (entry.error) payload.error = entry.error;
+		if (Object.keys(payload).length === 0) return "";
+		const raw = JSON.stringify(payload, null, 2);
+		if (!raw) return "";
+		const MAX_CHARS = 3200;
+		if (raw.length <= MAX_CHARS) return raw;
+		return `${raw.slice(0, MAX_CHARS)}\n...truncated`;
+	}
 </script>
 
 <div class="flex flex-col h-full overflow-hidden">
@@ -320,6 +452,9 @@
 					{@const levelColor = LEVEL_COLORS[entry.level] ?? "#6b6b76"}
 					{@const canExpand = entry.message.length > 72}
 					{@const dataKeySummary = getEntryDataKeySummary(entry.data)}
+					{@const processSummary = summarizeProcess(entry)}
+					{@const metaRows = getEntryMetaRows(entry)}
+					{@const rawPayload = getEntryRawPayload(entry)}
 					<div class="feed-entry px-2 py-1.5 rounded hover:bg-[var(--sig-surface-raised)] transition-colors">
 						<div class="flex items-center gap-1.5">
 							<!-- Time -->
@@ -341,23 +476,40 @@
 						</div>
 						<!-- Message -->
 						{#if feedExpanded}
+							<div class="mt-1 pl-[56px] inline-flex items-center gap-2 text-[8px] uppercase tracking-[0.06em] font-[family-name:var(--font-mono)]">
+								<span class="px-1 py-[1px] border border-[var(--sig-border)] text-[var(--sig-text-muted)]">
+									{processSummary}
+								</span>
+								<span class="text-[var(--sig-text-muted)]">{formatRelativeTime(entry.timestamp)}</span>
+							</div>
 							<div class="text-[10px] text-[var(--sig-text)] font-[family-name:var(--font-mono)] mt-0.5 pl-[56px] whitespace-pre-wrap break-words">
 								{entry.message}
 							</div>
-							<div class="mt-1 pl-[56px] flex flex-wrap gap-x-2 gap-y-1 text-[8px] text-[var(--sig-text-muted)] font-[family-name:var(--font-mono)] uppercase tracking-[0.05em]">
-								<span>level {entry.level}</span>
-								<span>category {entry.category}</span>
-								{#if entry.duration}
-									<span>duration {entry.duration}ms</span>
-								{/if}
-								{#if dataKeySummary}
-									<span>data {dataKeySummary}</span>
-								{/if}
+							<div class="mt-1 pl-[56px] grid grid-cols-1 md:grid-cols-2 gap-x-3 gap-y-1 text-[8px] font-[family-name:var(--font-mono)]">
+								{#each metaRows as row}
+									<div class="flex items-start justify-between gap-2 border-b border-[var(--sig-border)]/30 pb-[1px]">
+										<span class="text-[var(--sig-text-muted)] uppercase tracking-[0.05em]">{row.label}</span>
+										<span class="text-[var(--sig-text)] break-all text-right">{row.value}</span>
+									</div>
+								{/each}
 							</div>
+							{#if dataKeySummary}
+								<div class="mt-1 pl-[56px] text-[8px] text-[var(--sig-text-muted)] font-[family-name:var(--font-mono)] uppercase tracking-[0.05em]">
+									Data keys: {dataKeySummary}
+								</div>
+							{/if}
 							{#if entry.error}
 								<div class="mt-1 pl-[56px] text-[9px] text-[#f87171] font-[family-name:var(--font-mono)] whitespace-pre-wrap break-words">
 									{entry.error.name}: {entry.error.message}
 								</div>
+							{/if}
+							{#if rawPayload}
+								<details class="mt-1 pl-[56px]">
+									<summary class="cursor-pointer text-[8px] text-[var(--sig-text-muted)] uppercase tracking-[0.05em] font-[family-name:var(--font-mono)]">
+										Raw payload
+									</summary>
+									<pre class="mt-1 p-2 border border-[var(--sig-border)] bg-[var(--sig-surface)] text-[8px] text-[var(--sig-text)] whitespace-pre-wrap break-words font-[family-name:var(--font-mono)]">{rawPayload}</pre>
+								</details>
 							{/if}
 						{:else}
 							{#if canExpand}


### PR DESCRIPTION
## What
- Upgrades Pipeline tab expanded feed entries to show clearer process context per timestamp.
- Adds structured metadata rows for expanded logs (prioritized operational keys first, then remaining payload keys).
- Adds a collapsible `Raw payload` inspector with safe truncation for large JSON payloads.

## Why
- Expanded logs previously showed only limited context, making it hard to understand what the pipeline was actually doing at each event.
- During incident/debug workflows, the team needs direct visibility into job IDs, attempts, mode/provider/model, write stats, and error payloads without leaving the feed.
- Rich context in-place reduces context switching and speeds up diagnosis.

## How
- Updated `packages/cli/dashboard/src/lib/components/tabs/PipelineTab.svelte` with helper formatters for:
  - relative time (`Xs/m/h/d ago`),
  - process summaries inferred from category/message,
  - metadata label/value normalization and deterministic key ordering,
  - raw payload serialization + truncation guard.
- Expanded-mode UI now renders:
  - process badge + relative time,
  - full log message,
  - key/value metadata grid,
  - optional data-key summary,
  - error block,
  - optional raw JSON payload details section.
- Compact mode behavior is preserved.

## Validation
- `bun run typecheck`
- `bun run build`