### PR TITLE
fix(dashboard): make settings collapsible sections clickable

### DIFF
--- a/packages/cli/dashboard/src/lib/components/tabs/SettingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/SettingsTab.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { ConfigFile } from "$lib/api";
 import { st } from "$lib/stores/settings.svelte";
+import { untrack } from "svelte";
 import AgentSection from "./settings/AgentSection.svelte";
 import AuthSection from "./settings/AuthSection.svelte";
 import EmbeddingsSection from "./settings/EmbeddingsSection.svelte";
@@ -16,8 +17,12 @@ interface Props {
 
 const { configFiles }: Props = $props();
 
+// Track configFiles so the effect re-runs when the prop changes,
+// but untrack the init call — it mutates $state which would
+// otherwise trigger an infinite reactive loop.
 $effect(() => {
-	st.init(configFiles);
+	const files = configFiles;
+	untrack(() => st.init(files));
 });
 
 async function saveSettings() {


### PR DESCRIPTION
## Summary

- Fixed infinite reactive loop in Settings tab that prevented collapsible section headers from toggling
- The `$effect` in `SettingsTab.svelte` called `st.init(configFiles)` which mutates `$state` properties tracked by Svelte, causing `effect_update_depth_exceeded` errors
- Wrapped the `st.init()` call in `untrack()` to break the cycle while preserving reactivity to `configFiles` prop changes

## Test plan

- [ ] Open dashboard Settings tab — no console errors
- [ ] Click each collapsible section header (Agent, Harnesses, Embeddings, Search, Memory, Paths, Pipeline, Trust, Auth) — verify toggle open/close
- [ ] Verify form controls inside expanded sections still work (inputs, selects, switches)
- [ ] Save settings — verify save still works