### PR TITLE
fix(dashboard): remove sidebar and pipeline divider lines

### DIFF
--- a/packages/cli/dashboard/src/lib/components/tabs/PipelineTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/PipelineTab.svelte
@@ -364,7 +364,7 @@
 
 		<!-- Live feed panel -->
 		<div
-			class={`w-full shrink-0 border-t lg:border-t-0 lg:border-l border-[var(--sig-border)] flex flex-col bg-[var(--sig-bg)] min-h-[220px] max-h-[40vh] lg:max-h-none ${feedWidthClass}`}
+			class={`w-full shrink-0 border-t lg:border-t-0 border-[var(--sig-border)] flex flex-col bg-[var(--sig-bg)] min-h-[220px] max-h-[40vh] lg:max-h-none ${feedWidthClass}`}
 		>
 			<!-- Feed header -->
 			<div class="px-3 py-2 border-b border-[var(--sig-border)] space-y-2">

--- a/packages/cli/dashboard/src/lib/components/ui/sheet/sheet-content.svelte
+++ b/packages/cli/dashboard/src/lib/components/ui/sheet/sheet-content.svelte
@@ -6,7 +6,7 @@
 			side: {
 				top: "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
 				bottom: "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
-				left: "data-[state=closed]:slide-out-to-start data-[state=open]:slide-in-from-start inset-y-0 start-0 h-full w-3/4 border-e sm:max-w-sm",
+				left: "data-[state=closed]:slide-out-to-start data-[state=open]:slide-in-from-start inset-y-0 start-0 h-full w-3/4 sm:max-w-sm",
 				right: "data-[state=closed]:slide-out-to-end data-[state=open]:slide-in-from-end inset-y-0 end-0 h-full w-3/4 border-s sm:max-w-sm",
 			},
 		},

--- a/packages/cli/dashboard/src/lib/components/ui/sidebar/sidebar.svelte
+++ b/packages/cli/dashboard/src/lib/components/ui/sidebar/sidebar.svelte
@@ -87,7 +87,7 @@
 				// Adjust the padding for floating and inset variants.
 				variant === "floating" || variant === "inset"
 					? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
-					: "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-e group-data-[side=right]:border-s",
+					: "group-data-[collapsible=icon]:w-(--sidebar-width-icon)",
 				className
 			)}
 			{...restProps}

--- a/packages/cli/dashboard/src/routes/+page.svelte
+++ b/packages/cli/dashboard/src/routes/+page.svelte
@@ -114,7 +114,7 @@
 		onthemetoggle={toggleTheme}
 	/>
 	<main class="flex flex-1 flex-col min-w-0 min-h-0 overflow-hidden
-		m-2 ml-0 rounded-lg border border-[var(--sig-border)]
+		m-2 ml-0 rounded-lg border border-[var(--sig-border)] md:border-l-0
 		bg-[var(--sig-surface)]">
 		<header
 			class="flex h-10 shrink-0 items-center justify-between


### PR DESCRIPTION
## Summary
- Remove the bright white divider line on the right edge of the left sidebar menu on both desktop and mobile.
- Remove the vertical divider line between the Pipeline graph and live feed panel.

## Changes
- Desktop sidebar: removed edge border (`border-e`/`border-s`) from `sidebar.svelte`.
- Mobile sidebar drawer: removed left-edge border from `sheet-content.svelte`.
- Main app shell: added `md:border-l-0` to eliminate the residual left-border seam on desktop.
- Pipeline tab: removed `lg:border-l` from the live feed panel.

## Why
The white divider lines created visual noise and broke the clean aesthetic of the dashboard. The left sidebar should flow seamlessly into the main content area, and the Pipeline feed panel should not have a distracting vertical separator.

Also, **nicholai really wanted this change** — he was so bothered by those lines that he might have contracted a terminal illness if they weren't removed. This PR saves lives.

## Validation
- `bun run typecheck`
- `bun run --filter @signet/cli build:dashboard`