### PR TITLE
fix(pipeline): handle null OpenCode response in extractOpenCodeText

### DIFF
--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -446,10 +446,11 @@ interface OpenCodeMessageResponse {
  * Response shape: `{ info: AssistantMessage, parts: Part[] }`
  * Text lives in parts where `type === "text"`.
  */
-function extractOpenCodeText(data: OpenCodeMessageResponse): string {
+function extractOpenCodeText(data: OpenCodeMessageResponse | null | undefined): string {
+	if (!data?.parts) return "";
 	const textParts: string[] = [];
 	for (const part of data.parts) {
-		if (part.type === "text" && typeof part.text === "string") {
+		if (part?.type === "text" && typeof part.text === "string") {
 			textParts.push(part.text);
 		}
 	}


### PR DESCRIPTION
## Summary
- Fix null pointer crash in `extractOpenCodeText()` when OpenCode returns an unexpected response shape.

## What
- Added null/undefined guard to `data` parameter.
- Added null check for `data.parts` before iterating.
- Added optional chaining for `part.type` access.

## Why
Pipeline jobs were failing with error:
```
LLM extraction failed: null is not an object (evaluating 'data.parts')
```

Root cause: When OpenCode returns `null`, an empty object, or a malformed response (missing `parts`), the function attempts to iterate over `data.parts` directly, causing a crash that surfaces as extraction failure.

## How
Changed function signature from:
```typescript
function extractOpenCodeText(data: OpenCodeMessageResponse): string
```

To:
```typescript
function extractOpenCodeText(data: OpenCodeMessageResponse | null | undefined): string {
  if (!data?.parts) return "";
  // ... rest of function with optional chaining
}
```

Now gracefully returns empty string instead of crashing when response is malformed.

## Validation
- `bun run typecheck` ✅
- `bun run --filter @signet/daemon build` ✅

## Impact
- Extraction jobs will no longer crash on malformed OpenCode responses.
- Empty/malformed responses will be logged as warnings but won't kill the extraction pipeline.