### PR TITLE
fix(pipeline): harden OpenCode extraction recovery

### DIFF
--- a/packages/cli/dashboard/vite.config.ts
+++ b/packages/cli/dashboard/vite.config.ts
@@ -4,4 +4,12 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
 	plugins: [tailwindcss(), sveltekit()],
+	server: {
+		proxy: {
+			"/api": "http://127.0.0.1:3850",
+			"/health": "http://127.0.0.1:3850",
+			"/memory": "http://127.0.0.1:3850",
+			"/mcp": "http://127.0.0.1:3850",
+		},
+	},
 });


### PR DESCRIPTION
## Summary
- Stabilize extraction when OpenCode returns malformed/empty payloads by hardening provider response parsing and retry behavior.
- Add robust extraction JSON parsing so fallback model output with prose wrappers, fenced blocks, trailing commas, or string-encoded JSON can still be parsed.
- Wire dashboard dev server (`5174`) API proxy to daemon endpoints so logs/status/pipeline views work during local development.

## What changed
- `packages/daemon/src/pipeline/provider.ts`
  - Added strict payload guards for OpenCode responses.
  - Added retry with session reset for malformed payloads.
  - Added polling support for assistant message retrieval when POST payload is incomplete.
  - Added controlled fallback path to Ollama when OpenCode stays malformed.
- `packages/daemon/src/pipeline/extraction.ts`
  - Added tolerant JSON extraction/parsing pipeline for wrapped or slightly malformed model output.
- `packages/cli/dashboard/vite.config.ts`
  - Added local dev proxy for `/api`, `/health`, `/memory`, and `/mcp` to daemon on `127.0.0.1:3850`.
- Added/updated tests:
  - `packages/daemon/src/pipeline/provider.test.ts`
  - `packages/daemon/src/pipeline/extraction.test.ts`

## Why
OpenCode occasionally returns payloads that don't match expected shape (`data.parts` null/missing), which previously caused extraction call failures and job retries/dead jobs. This change keeps extraction resilient, preserves pipeline continuity, and makes local dashboard visibility reliable on port `5174`.

## Validation
- `bun run build` ✅
- `bun run typecheck` ✅
- `bun test` ✅ (534 passing)
- CI/CD workflow health check via GitHub CLI ✅
  - `gh workflow list`
  - `gh run list --limit 5` (latest runs successful)

## Notes
- `bun run lint` currently reports pre-existing repository formatting drift in multiple `package.json` files outside this PR scope.
- `bun.lock` remains locally modified but is intentionally excluded from this PR.