### PR TITLE
fix(dashboard): upgrade save-state UX in config and settings

### DIFF
--- a/packages/cli/dashboard/src/lib/components/config/MarkdownViewer.svelte
+++ b/packages/cli/dashboard/src/lib/components/config/MarkdownViewer.svelte
@@ -11,9 +11,25 @@ interface Props {
 	charBudget?: number;
 	onchange?: (value: string) => void;
 	onsave?: () => void;
+	dirty?: boolean;
+	saving?: boolean;
+	saveDisabled?: boolean;
+	lastSavedText?: string;
+	saveFeedback?: string;
 }
 
-let { content, filename, charBudget, onchange, onsave }: Props = $props();
+let {
+	content,
+	filename,
+	charBudget,
+	onchange,
+	onsave,
+	dirty = false,
+	saving = false,
+	saveDisabled = false,
+	lastSavedText,
+	saveFeedback,
+}: Props = $props();
 
 const BOXED_SECTION_TITLES = new Set([
 	"behavioral guidelines",
@@ -96,6 +112,15 @@ let rendered = $derived.by(() => {
 			</span>
 		{/if}
 		<div class="md-viewer-actions">
+			{#if lastSavedText}
+				<span class="md-viewer-save-meta">{lastSavedText}</span>
+			{/if}
+			{#if saveFeedback}
+				<span class="md-viewer-save-meta">{saveFeedback}</span>
+			{/if}
+			<span class="md-viewer-save-state" class:dirty={dirty}>
+				{dirty ? "Unsaved changes" : "All changes saved"}
+			</span>
 			{#if editing && onsave}
 				<Button
 					variant="outline"
@@ -105,9 +130,10 @@ let rendered = $derived.by(() => {
 						border-[var(--sig-accent)] text-[var(--sig-text-bright)]
 						hover:bg-[var(--sig-text-bright)] hover:text-[var(--sig-bg)]
 						hover:border-[var(--sig-text-bright)]"
+					disabled={saveDisabled}
 					onclick={onsave}
 				>
-					SAVE
+					{saving ? "SAVING..." : "SAVE"}
 				</Button>
 			{/if}
 			<Button
@@ -197,6 +223,25 @@ let rendered = $derived.by(() => {
 		display: flex;
 		align-items: center;
 		gap: 6px;
+	}
+
+	.md-viewer-save-meta {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		color: var(--sig-text-muted);
+		letter-spacing: 0.02em;
+	}
+
+	.md-viewer-save-state {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--sig-text-muted);
+	}
+
+	.md-viewer-save-state.dirty {
+		color: var(--sig-warning, #d4a017);
 	}
 
 	.md-viewer-prose {

--- a/packages/cli/dashboard/src/lib/stores/navigation.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/navigation.svelte.ts
@@ -2,6 +2,8 @@
  * Shared navigation state for the dashboard.
  */
 
+import { confirmDiscardChanges } from "$lib/stores/unsaved-changes.svelte";
+
 export type TabId =
 	| "config"
 	| "settings"
@@ -17,7 +19,9 @@ export const nav = $state({
 	activeTab: "config" as TabId,
 });
 
-export function setTab(tab: TabId): void {
+export function setTab(tab: TabId): boolean {
+	if (tab === nav.activeTab) return true;
+	if (!confirmDiscardChanges(`switch to ${tab}`)) return false;
 	nav.activeTab = tab;
+	return true;
 }
-

--- a/packages/cli/dashboard/src/lib/stores/unsaved-changes.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/unsaved-changes.svelte.ts
@@ -1,0 +1,33 @@
+export const unsaved = $state({
+	configDirty: false,
+	settingsDirty: false,
+});
+
+export function setConfigDirty(value: boolean): void {
+	unsaved.configDirty = value;
+}
+
+export function setSettingsDirty(value: boolean): void {
+	unsaved.settingsDirty = value;
+}
+
+export function hasUnsavedChanges(): boolean {
+	return unsaved.configDirty || unsaved.settingsDirty;
+}
+
+function changedAreas(): string {
+	const areas: string[] = [];
+	if (unsaved.configDirty) areas.push("Config");
+	if (unsaved.settingsDirty) areas.push("Settings");
+	return areas.join(" and ");
+}
+
+export function confirmDiscardChanges(action: string): boolean {
+	if (!hasUnsavedChanges()) return true;
+	if (typeof window === "undefined") return true;
+
+	const areaLabel = changedAreas();
+	return window.confirm(
+		`You have unsaved changes in ${areaLabel}. Leave anyway to ${action}?`,
+	);
+}

--- a/packages/cli/dashboard/src/routes/+page.svelte
+++ b/packages/cli/dashboard/src/routes/+page.svelte
@@ -2,15 +2,16 @@
 	import { onMount } from "svelte";
 	import { browser } from "$app/environment";
 	import { getStatus, type DaemonStatus, type Memory } from "$lib/api";
-	import {
-		mem,
+import {
+	mem,
 		hasActiveFilters,
 		clearAll,
 		clearSearchTimer,
 		queueMemorySearch,
 		loadWhoOptions,
-	} from "$lib/stores/memory.svelte";
-	import { nav } from "$lib/stores/navigation.svelte";
+} from "$lib/stores/memory.svelte";
+import { nav } from "$lib/stores/navigation.svelte";
+import { hasUnsavedChanges } from "$lib/stores/unsaved-changes.svelte";
 	import { sk } from "$lib/stores/skills.svelte";
 	import { ts, openForm } from "$lib/stores/tasks.svelte";
 	import { PAGE_HEADERS } from "$lib/components/layout/page-headers";
@@ -92,12 +93,24 @@
 	});
 
 	// --- Init ---
-	onMount(() => {
-		getStatus().then((s) => {
-			daemonStatus = s;
-		});
-		loadWhoOptions();
+onMount(() => {
+	getStatus().then((s) => {
+		daemonStatus = s;
 	});
+	loadWhoOptions();
+
+	const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+		if (!hasUnsavedChanges()) return;
+		event.preventDefault();
+		event.returnValue = "";
+	};
+
+	window.addEventListener("beforeunload", handleBeforeUnload);
+
+	return () => {
+		window.removeEventListener("beforeunload", handleBeforeUnload);
+	};
+});
 </script>
 
 <svelte:head>


### PR DESCRIPTION
## Summary
- Upgrade save-state UX across Config and Settings to prevent accidental data loss and make save status clearer.
- Add dirty-state tracking, navigation guards, and unload warnings for unsaved edits.
- Improve save feedback with per-file result details and last-saved metadata, while hiding "Not saved yet" until editing actually starts.

## What Changed
- Added shared unsaved-change state and guard helpers:
  - `packages/cli/dashboard/src/lib/stores/unsaved-changes.svelte.ts`
- Added guarded tab navigation for dirty states:
  - `packages/cli/dashboard/src/lib/stores/navigation.svelte.ts`
- Config tab save-state improvements:
  - dirty detection per file baseline
  - save disabled when unchanged or saving
  - file-switch discard confirmation
  - last-saved + specific save feedback in toolbar
  - `packages/cli/dashboard/src/lib/components/tabs/ConfigTab.svelte`
  - `packages/cli/dashboard/src/lib/components/config/MarkdownViewer.svelte`
- Settings save-state improvements:
  - snapshot-based dirty tracking
  - save disabled when unchanged
  - granular save outcomes (success/partial/failure)
  - last-saved + status metadata in save bar
  - `packages/cli/dashboard/src/lib/stores/settings.svelte.ts`
  - `packages/cli/dashboard/src/lib/components/tabs/SettingsTab.svelte`
- Added beforeunload warning for unsaved changes:
  - `packages/cli/dashboard/src/routes/+page.svelte`
- Added richer config-save API return for detailed errors:
  - `packages/cli/dashboard/src/lib/api.ts`

## How
- Introduced centralized unsaved flags for Config and Settings, then consumed them in navigation + beforeunload guards.
- Established in-memory save baselines/snapshots and compared current editor/store state against them to compute dirty status.
- Switched save actions to detailed result handling (`ok/status/error`) to provide actionable user feedback.
- Kept UI styling token-based and consistent with existing dashboard design language.

## Why
- Users need clear confidence signals while editing config/settings data.
- Preventing accidental tab/file/window navigation with unsaved edits reduces data-loss risk.
- Specific save outcomes and timestamps increase trust and reduce ambiguity after edits.

## Validation
- `bun run build` ✅
- `bun run typecheck` ✅
- `bun test` ✅ (530 pass, 0 fail)
- CI/CD visibility check:
  - `gh run list --limit 8` (recent runs successful)