### PR TITLE
feat(dashboard): add skills compare mode and trust guidance

### DIFF
--- a/packages/cli/dashboard/src/lib/api.ts
+++ b/packages/cli/dashboard/src/lib/api.ts
@@ -589,6 +589,10 @@ export interface Skill {
 	builtin?: boolean;
 	user_invocable?: boolean;
 	arg_hint?: string;
+	author?: string;
+	maintainer?: string;
+	verified?: boolean;
+	permissions?: string[];
 }
 
 export interface SkillSearchResult {
@@ -603,6 +607,9 @@ export interface SkillSearchResult {
 	downloads?: number;
 	versions?: number;
 	author?: string;
+	maintainer?: string;
+	verified?: boolean;
+	permissions?: string[];
 }
 
 export interface SkillDetail extends Skill {

--- a/packages/cli/dashboard/src/lib/components/skills/SkillCard.svelte
+++ b/packages/cli/dashboard/src/lib/components/skills/SkillCard.svelte
@@ -8,11 +8,13 @@ type Props = {
 	mode: "installed" | "browse";
 	featured?: boolean;
 	selected?: boolean;
+	compareSelected?: boolean;
 	installing?: boolean;
 	uninstalling?: boolean;
 	onclick?: () => void;
 	oninstall?: () => void;
 	onuninstall?: () => void;
+	oncomparetoggle?: () => void;
 };
 
 let {
@@ -20,11 +22,13 @@ let {
 	mode,
 	featured = false,
 	selected = false,
+	compareSelected = false,
 	installing = false,
 	uninstalling = false,
 	onclick,
 	oninstall,
 	onuninstall,
+	oncomparetoggle,
 }: Props = $props();
 
 function isSearchResult(
@@ -90,6 +94,28 @@ let isInstalled = $derived(
 				<div class="card-header">
 					<span class="card-name" class:card-name-featured={featured}>{item.name}</span>
 					<div class="badge-row">
+						{#if mode === "browse" && isSearchResult(item)}
+							<span
+								class="compare-toggle"
+								role="checkbox"
+								aria-checked={compareSelected}
+								tabindex="0"
+								onclick={(e) => {
+									e.stopPropagation();
+									oncomparetoggle?.();
+								}}
+								onkeydown={(e) => {
+									if (e.key === "Enter" || e.key === " ") {
+										e.preventDefault();
+										e.stopPropagation();
+										oncomparetoggle?.();
+									}
+								}}
+							>
+								<span class="compare-dot" class:active={compareSelected}></span>
+								<span>Compare</span>
+							</span>
+						{/if}
 						{#if isSearchResult(item) && item.provider}
 							<span
 								class="provider-badge"
@@ -376,5 +402,30 @@ let isInstalled = $derived(
 
 	.card-action {
 		margin-top: auto;
+	}
+
+	.compare-toggle {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		font-family: var(--font-mono);
+		font-size: 9px;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--sig-text-muted);
+		cursor: pointer;
+		outline: none;
+	}
+
+	.compare-dot {
+		display: inline-block;
+		width: 8px;
+		height: 8px;
+		border: 1px solid var(--sig-border-strong);
+	}
+
+	.compare-dot.active {
+		background: var(--sig-accent);
+		border-color: var(--sig-accent);
 	}
 </style>

--- a/packages/cli/dashboard/src/lib/components/skills/SkillsComparePanel.svelte
+++ b/packages/cli/dashboard/src/lib/components/skills/SkillsComparePanel.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+import type { SkillSearchResult } from "$lib/api";
+import { computePermissionFootprint } from "$lib/skills/risk-profile";
+
+type Props = {
+	items: SkillSearchResult[];
+	onRemove: (key: string) => void;
+	onClear: () => void;
+};
+
+let { items, onRemove, onClear }: Props = $props();
+
+function itemKey(item: SkillSearchResult): string {
+	return item.fullName;
+}
+
+function formatCount(value: number | undefined): string {
+	if (value === undefined) return "-";
+	if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+	if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+	return String(value);
+}
+
+function maintainerLabel(item: SkillSearchResult): string {
+	if (item.maintainer) return item.maintainer;
+	if (item.author) return item.author;
+	return item.fullName.split("@")[0] || "unknown";
+}
+
+function verifiedLabel(item: SkillSearchResult): string {
+	if (item.verified === true) return "Verified";
+	if (item.verified === false) return "Unverified";
+	return "Unknown";
+}
+</script>
+
+<div class="compare-wrap">
+	<div class="compare-head">
+		<p class="compare-title">Compare Skills ({items.length}/3)</p>
+		<button type="button" class="clear-btn" onclick={onClear}>Clear</button>
+	</div>
+	<div class="compare-table-wrap">
+		<table class="compare-table">
+			<thead>
+				<tr>
+					<th>Skill</th>
+					<th>Maintainer</th>
+					<th>Stars/Downloads</th>
+					<th>Verified</th>
+					<th>Permissions</th>
+					<th></th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each items as item (itemKey(item))}
+					<tr>
+						<td>{item.name}</td>
+						<td>{maintainerLabel(item)}</td>
+						<td>{formatCount(item.stars)} / {formatCount(item.downloads ?? item.installsRaw)}</td>
+						<td>{verifiedLabel(item)}</td>
+						<td>{computePermissionFootprint(item.permissions)}</td>
+						<td>
+							<button type="button" class="row-remove" onclick={() => onRemove(itemKey(item))}>
+								Remove
+							</button>
+						</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</div>
+</div>
+
+<style>
+	.compare-wrap {
+		padding: 10px var(--space-md);
+		border-bottom: 1px solid var(--sig-border);
+		background: var(--sig-surface-raised);
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.compare-head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+	}
+
+	.compare-title {
+		margin: 0;
+		font-family: var(--font-display);
+		font-size: 11px;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: var(--sig-text-bright);
+	}
+
+	.clear-btn,
+	.row-remove {
+		font-family: var(--font-mono);
+		font-size: 9px;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		padding: 3px 6px;
+		border: 1px solid var(--sig-border-strong);
+		background: transparent;
+		color: var(--sig-text-muted);
+		cursor: pointer;
+	}
+
+	.clear-btn:hover,
+	.row-remove:hover {
+		color: var(--sig-text-bright);
+		border-color: var(--sig-accent);
+	}
+
+	.compare-table-wrap {
+		overflow-x: auto;
+	}
+
+	.compare-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-family: var(--font-mono);
+		font-size: 10px;
+		color: var(--sig-text);
+	}
+
+	.compare-table th,
+	.compare-table td {
+		text-align: left;
+		padding: 5px 6px;
+		border-bottom: 1px solid var(--sig-border);
+		white-space: nowrap;
+	}
+
+	.compare-table th {
+		font-size: 9px;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--sig-text-muted);
+	}
+</style>

--- a/packages/cli/dashboard/src/lib/components/skills/SkillsEmptyState.svelte
+++ b/packages/cli/dashboard/src/lib/components/skills/SkillsEmptyState.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+type EmptyStateKind = "installed" | "browse" | "search";
+
+type Action = {
+	label: string;
+	onClick: () => void;
+	variant?: "primary" | "secondary";
+};
+
+type Props = {
+	kind: EmptyStateKind;
+	actions: Action[];
+};
+
+let { kind, actions }: Props = $props();
+
+const contentByKind: Record<
+	EmptyStateKind,
+	{ title: string; description: string }
+> = {
+	installed: {
+		title: "No installed skills yet",
+		description: "Browse the catalog and install your first skill.",
+	},
+	browse: {
+		title: "No skills match this browse view",
+		description: "Try clearing filters or reload the catalog.",
+	},
+	search: {
+		title: "No search matches",
+		description: "Try a broader keyword or browse popular skills.",
+	},
+};
+</script>
+
+<div class="empty-state">
+	<p class="empty-title">{contentByKind[kind].title}</p>
+	<p class="empty-desc">{contentByKind[kind].description}</p>
+	<div class="empty-actions">
+		{#each actions as action}
+			<button
+				type="button"
+				class="empty-btn"
+				class:primary={action.variant === "primary"}
+				onclick={action.onClick}
+			>
+				{action.label}
+			</button>
+		{/each}
+	</div>
+</div>
+
+<style>
+	.empty-state {
+		padding: var(--space-xl) var(--space-lg);
+		margin: var(--space-md) auto;
+		max-width: 520px;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		text-align: center;
+		gap: 8px;
+		border: 1px dashed var(--sig-border-strong);
+		background: var(--sig-surface-raised);
+	}
+
+	.empty-title {
+		margin: 0;
+		font-family: var(--font-display);
+		font-size: 13px;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--sig-text-bright);
+	}
+
+	.empty-desc {
+		margin: 0;
+		font-family: var(--font-mono);
+		font-size: 11px;
+		line-height: 1.5;
+		color: var(--sig-text-muted);
+	}
+
+	.empty-actions {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		gap: 8px;
+		margin-top: 6px;
+	}
+
+	.empty-btn {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		padding: 5px 10px;
+		border: 1px solid var(--sig-border-strong);
+		background: transparent;
+		color: var(--sig-text-muted);
+		cursor: pointer;
+	}
+
+	.empty-btn:hover {
+		border-color: var(--sig-accent);
+		color: var(--sig-text-bright);
+	}
+
+	.empty-btn.primary {
+		border-color: var(--sig-accent);
+		background: var(--sig-accent);
+		color: var(--sig-bg);
+	}
+</style>

--- a/packages/cli/dashboard/src/lib/skills/risk-profile.ts
+++ b/packages/cli/dashboard/src/lib/skills/risk-profile.ts
@@ -1,0 +1,94 @@
+import type { Skill, SkillSearchResult } from "$lib/api";
+
+export type PermissionFootprint = "low" | "medium" | "high" | "unknown";
+
+export type SkillLike = Partial<Skill & SkillSearchResult>;
+
+export interface TrustProfile {
+	compatibilityScore: number;
+	securityConfidence: number;
+	permissionFootprint: PermissionFootprint;
+	verified: "yes" | "no" | "unknown";
+	maintainer: string;
+	compatibilityReason: string;
+	securityReason: string;
+}
+
+const HIGH_RISK_PERMS = ["secrets", "network", "exec", "shell", "system"];
+const MEDIUM_RISK_PERMS = ["write", "filesystem", "fs", "process", "clipboard"];
+
+function clamp(value: number): number {
+	if (value < 0) return 0;
+	if (value > 100) return 100;
+	return Math.round(value);
+}
+
+export function computePermissionFootprint(
+	permissions: readonly string[] | undefined,
+): PermissionFootprint {
+	if (!permissions || permissions.length === 0) return "unknown";
+	const lowered = permissions.map((p) => p.toLowerCase());
+	const hasHigh = lowered.some((p) => HIGH_RISK_PERMS.some((k) => p.includes(k)));
+	if (hasHigh) return "high";
+	const hasMedium = lowered.some((p) => MEDIUM_RISK_PERMS.some((k) => p.includes(k)));
+	if (hasMedium) return "medium";
+	return "low";
+}
+
+export function computeTrustProfile(
+	skill: SkillLike,
+	installedNames: readonly string[],
+): TrustProfile {
+	const permissions = skill.permissions;
+	const footprint = computePermissionFootprint(permissions);
+	const installed = !!skill.name && installedNames.includes(skill.name);
+
+	const maintainer =
+		skill.maintainer ||
+		skill.author ||
+		(skill.fullName ? skill.fullName.split("@")[0] : "unknown");
+
+	let compatibility = 40;
+	if (skill.provider) compatibility += 15;
+	if (skill.name) compatibility += 10;
+	if (installed) compatibility += 20;
+	if (skill.user_invocable) compatibility += 10;
+	if (skill.builtin) compatibility += 15;
+
+	let security = 50;
+	if (skill.verified === true) security += 25;
+	if (skill.verified === false) security -= 15;
+	if (maintainer !== "unknown") security += 10;
+	if ((skill.stars ?? 0) >= 100) security += 8;
+	if ((skill.downloads ?? 0) >= 1000 || (skill.installsRaw ?? 0) >= 1000) security += 8;
+
+	if (footprint === "high") security -= 20;
+	if (footprint === "medium") security -= 8;
+	if (footprint === "unknown") security -= 5;
+
+	const verified: "yes" | "no" | "unknown" =
+		skill.verified === true ? "yes" : skill.verified === false ? "no" : "unknown";
+
+	const compatibilityReason = installed
+		? "Already installed in this workspace."
+		: skill.provider
+			? `Published on ${skill.provider}.`
+			: "Provider metadata is missing.";
+
+	const securityReason =
+		verified === "yes"
+			? "Verified metadata present."
+			: footprint === "unknown"
+				? "Permissions metadata unavailable."
+				: `Permissions footprint is ${footprint}.`;
+
+	return {
+		compatibilityScore: clamp(compatibility),
+		securityConfidence: clamp(security),
+		permissionFootprint: footprint,
+		verified,
+		maintainer,
+		compatibilityReason,
+		securityReason,
+	};
+}

--- a/packages/cli/dashboard/src/lib/stores/skills.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/skills.svelte.ts
@@ -41,6 +41,9 @@ export const sk = $state({
 	sortBy: "installs" as SortBy,
 	providerFilter: "all" as ProviderFilter,
 
+	// Compare mode
+	compareSelected: [] as string[],
+
 	// Detail panel
 	selectedName: null as string | null,
 	detailOpen: false,
@@ -89,6 +92,25 @@ export function getFilteredCatalog(): SkillSearchResult[] {
 export function getFilteredResults(): SkillSearchResult[] {
 	const filtered = filterByProvider(sk.results, sk.providerFilter);
 	return sortItems(filtered, sk.sortBy);
+}
+
+export function resetFilters(): void {
+	sk.sortBy = "installs";
+	sk.providerFilter = "all";
+}
+
+export function clearCompare(): void {
+	sk.compareSelected = [];
+}
+
+export function toggleCompare(skillKey: string): void {
+	const has = sk.compareSelected.includes(skillKey);
+	if (has) {
+		sk.compareSelected = sk.compareSelected.filter((k) => k !== skillKey);
+		return;
+	}
+	if (sk.compareSelected.length >= 3) return;
+	sk.compareSelected = [...sk.compareSelected, skillKey];
 }
 
 export async function fetchInstalled(): Promise<void> {

--- a/packages/daemon/src/routes/skills.test.ts
+++ b/packages/daemon/src/routes/skills.test.ts
@@ -65,6 +65,18 @@ author: 'single-quoted'
 		expect(meta.description).toBe("quoted description");
 		expect(meta.author).toBe("single-quoted");
 	});
+
+	it("parses optional verified and permissions metadata", () => {
+		const content = `---
+description: metadata skill
+verified: true
+permissions: [network, filesystem]
+---`;
+
+		const meta = parseSkillFrontmatter(content);
+		expect(meta.verified).toBe(true);
+		expect(meta.permissions).toEqual(["network", "filesystem"]);
+	});
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed
- Added tab-specific empty states in Skills with actionable recovery actions for Installed, Browse, and Search contexts.
- Added compare mode for up to 3 selected skills, including maintainer, stars/downloads, verified status, and permissions footprint.
- Added a pre-install trust/risk profile card in skill details with compatibility and security confidence scoring.
- Extended skills API metadata surface with optional `maintainer`, `verified`, and `permissions` fields and parser/test coverage for frontmatter metadata.

## How it was implemented
- Created new dashboard components:
  - `SkillsEmptyState.svelte` for guided empty states
  - `SkillsComparePanel.svelte` for side-by-side comparisons
  - `risk-profile.ts` utility for deterministic trust scoring and permissions footprint classification
- Extended skills store state with compare-selection behavior and filter reset helpers.
- Wired compare selection into skill cards and Skills tab rendering flow.
- Updated daemon skills route parsing/mapping to expose metadata consistently across installed/browse/search payloads.
- Added daemon route tests to validate parsing of `verified` and `permissions` frontmatter.

## Why this was done
- Users lacked clear guidance when Skills tabs were empty and had no direct next action.
- Evaluating multiple skills before install required manual context switching.
- Install decisions needed clearer trust and compatibility signal without heuristic guessing when metadata is unavailable.

## Validation
- `bun run build` (workspace)
- `bun run typecheck` (workspace)
- `bun test` (workspace)
- `bun test packages/daemon/src/routes/skills.test.ts`
- Checked recent GitHub workflows:
  - Version Consistency (CI) recent runs are passing
  - Release (CD) recent runs are passing