### PR TITLE
fix(install): harden agent setup instructions and add guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Copy this prompt and paste it to your AI agent (Claude Code, OpenClaw,
 Clawdbot, OpenCode, etc.):
 
 ```
-Install Signet AI, the open agent memory and identity system: https://signetai.sh/skill.md
+Install and fully configure Signet AI by following this guide exactly: https://signetai.sh/skill.md
 ```
 
 The linked guide walks your agent through prerequisites, installation,

--- a/scripts/check-install-guide.ts
+++ b/scripts/check-install-guide.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env bun
+
+import { readFileSync } from "node:fs";
+
+interface Rule {
+	kind: "require" | "forbid";
+	pattern: RegExp;
+	description: string;
+}
+
+function load(path: string): string {
+	return readFileSync(path, "utf8");
+}
+
+function runRules(path: string, content: string, rules: Rule[]): string[] {
+	const failures: string[] = [];
+
+	for (const rule of rules) {
+		const matched = rule.pattern.test(content);
+		if (rule.kind === "require" && !matched) {
+			failures.push(`[${path}] Missing: ${rule.description}`);
+		}
+		if (rule.kind === "forbid" && matched) {
+			failures.push(`[${path}] Forbidden content found: ${rule.description}`);
+		}
+	}
+
+	return failures;
+}
+
+function main(): void {
+	const skillPath = "web/public/skill.md";
+	const readmePath = "README.md";
+	const heroPath = "web/src/components/landing/Hero.astro";
+	const ctaPath = "web/src/components/landing/Cta.astro";
+
+	const expectedPrompt =
+		"Install and fully configure Signet AI by following this guide exactly: https://signetai.sh/skill.md";
+
+	const skill = load(skillPath);
+	const readme = load(readmePath);
+	const hero = load(heroPath);
+	const cta = load(ctaPath);
+
+	const failures: string[] = [];
+
+	failures.push(
+		...runRules(skillPath, skill, [
+			{
+				kind: "require",
+				pattern: /## Install Objective \(Must Complete\)/,
+				description: "Install objective section",
+			},
+			{
+				kind: "require",
+				pattern: /`signet --version` succeeds/,
+				description: "Completion check for signet --version",
+			},
+			{
+				kind: "require",
+				pattern: /`signet status` shows the daemon is running/,
+				description: "Completion check for daemon running",
+			},
+			{
+				kind: "require",
+				pattern: /"status":"healthy"/,
+				description: "Health response requirement (status healthy)",
+			},
+			{
+				kind: "require",
+				pattern: /There is intentionally no `signet secret get` command/,
+				description: "Explicit secret-get deprecation note",
+			},
+			{
+				kind: "forbid",
+				pattern: /^\s*signet secret get\b/m,
+				description: "Deprecated command: signet secret get",
+			},
+			{
+				kind: "forbid",
+				pattern: /# Should return OK/,
+				description: "Outdated health expectation comment",
+			},
+		]),
+	);
+
+	const promptRule: Rule = {
+		kind: "require",
+		pattern: new RegExp(expectedPrompt.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+		description: `Expected install prompt: ${expectedPrompt}`,
+	};
+
+	failures.push(...runRules(readmePath, readme, [promptRule]));
+	failures.push(...runRules(heroPath, hero, [promptRule]));
+	failures.push(...runRules(ctaPath, cta, [promptRule]));
+
+	if (failures.length > 0) {
+		console.error("Install guide guard failed:\n");
+		for (const failure of failures) {
+			console.error(`- ${failure}`);
+		}
+		process.exit(1);
+	}
+
+	console.log("Install guide guard passed.");
+}
+
+main();

--- a/web/src/components/landing/Cta.astro
+++ b/web/src/components/landing/Cta.astro
@@ -25,7 +25,7 @@
         </div>
         <div class="install-panel" id="cta-install-agent">
           <div class="install-box install-box--agent">
-            <code class="install-cmd">Install Signet AI, the open agent memory and identity system: https://signetai.sh/skill.md</code>
+            <code class="install-cmd">Install and fully configure Signet AI by following this guide exactly: https://signetai.sh/skill.md</code>
             <button class="copy-btn push-right" aria-label="Copy agent prompt">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
             </button>

--- a/web/src/components/landing/Hero.astro
+++ b/web/src/components/landing/Hero.astro
@@ -39,7 +39,7 @@
           </div>
           <div class="install-panel" id="install-agent">
             <div class="install-box install-box--agent">
-              <code class="install-cmd">Install Signet AI, the open agent memory and identity system: https://signetai.sh/skill.md</code>
+              <code class="install-cmd">Install and fully configure Signet AI by following this guide exactly: https://signetai.sh/skill.md</code>
               <button class="copy-btn push-right" aria-label="Copy agent prompt">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
               </button>


### PR DESCRIPTION
## Summary
- strengthen the agent-facing install guide so agents complete end-to-end setup (install, setup wizard, daemon running, health verification, and user handoff)
- update install prompt copy in README and landing sections to explicitly ask agents to fully configure Signet, not just install it
- add a docs guard script at `scripts/check-install-guide.ts` that fails if deprecated guidance reappears (for example `signet secret get`) or canonical install prompt text drifts

## Validation
- `bun scripts/check-install-guide.ts`
- `cd web && bun run build`