### PR TITLE
fix(dashboard): prevent task form from resetting on auto-refresh

### DIFF
--- a/packages/cli/dashboard/src/lib/components/tasks/TaskForm.svelte
+++ b/packages/cli/dashboard/src/lib/components/tasks/TaskForm.svelte
@@ -45,7 +45,8 @@ function presetLabel(expr: string): string {
 }
 
 // Track the last initialized task to prevent re-initialization on auto-refresh
-let lastInitializedId = $state<string | null>(null);
+// Use undefined as sentinel to distinguish from null (new task)
+let lastInitializedId = $state<string | null | undefined>(undefined);
 
 // Initialize form state only when opening or switching tasks
 $effect(() => {
@@ -74,7 +75,7 @@ $effect(() => {
 	
 	// Reset tracking when form closes
 	if (!open) {
-		lastInitializedId = null;
+		lastInitializedId = undefined;
 	}
 });
 

--- a/packages/cli/dashboard/src/lib/components/tasks/TaskForm.svelte
+++ b/packages/cli/dashboard/src/lib/components/tasks/TaskForm.svelte
@@ -52,7 +52,7 @@ $effect(() => {
 	// Only initialize when:
 	// 1. Form just opened (open is true)
 	// 2. editingId changed (different task being edited)
-	if (open && editingId !== lastInitializedId) {
+	if (open && (lastInitializedId === undefined || editingId !== lastInitializedId)) {
 		if (editing) {
 			name = editing.name;
 			prompt = editing.prompt;

--- a/packages/cli/dashboard/src/lib/components/tasks/TaskForm.svelte
+++ b/packages/cli/dashboard/src/lib/components/tasks/TaskForm.svelte
@@ -44,9 +44,15 @@ function presetLabel(expr: string): string {
 	return match ? match.label : expr;
 }
 
-// Reset form when opening
+// Track the last initialized task to prevent re-initialization on auto-refresh
+let lastInitializedId = $state<string | null>(null);
+
+// Initialize form state only when opening or switching tasks
 $effect(() => {
-	if (open) {
+	// Only initialize when:
+	// 1. Form just opened (open is true)
+	// 2. editingId changed (different task being edited)
+	if (open && editingId !== lastInitializedId) {
 		if (editing) {
 			name = editing.name;
 			prompt = editing.prompt;
@@ -63,6 +69,12 @@ $effect(() => {
 			workingDirectory = "";
 			cronMode = "preset";
 		}
+		lastInitializedId = editingId;
+	}
+	
+	// Reset tracking when form closes
+	if (!open) {
+		lastInitializedId = null;
 	}
 });
 


### PR DESCRIPTION
## Summary

Fixes task editing bug where text and schedule changes disappeared after 7-15 seconds during editing. Also fixes the "New Task" button that was initially broken in the first iteration.

## What Changed

Modified `TaskForm.svelte` reactive effect to prevent form state from resetting when the task list auto-refreshes:

- Added `lastInitializedId` tracking state with `undefined` as sentinel value
- Modified `$effect` to only initialize form state when:
  1. Form opens (`open === true`)
  2. **AND** `editingId` changes (different task or first open)
- Reset tracking to `undefined` when form closes
- Uses three distinct states:
  - `undefined`: form not yet initialized
  - `null`: new task (no editingId)
  - `string`: editing existing task

## Why This Was Needed

**Root Cause:**
- `TasksTab.svelte` auto-refreshes every 15 seconds (`fetchTasks()` on line 39)
- This updates the `ts.tasks` array with fresh data from the API
- The `editing` derived value re-computes with a new object reference (even though the task data is identical)
- The reactive `$effect` saw `editing` change and reset all form fields to the task's saved values
- **User edits vanished** after the next auto-refresh cycle (7-15 seconds depending on when editing started)

**Timeline:**
1. User opens edit form at `t=0`
2. User types changes at `t=3`
3. Auto-refresh fires at `t=15` → `fetchTasks()` runs
4. `ts.tasks` updates → `editing` re-derives → `$effect` fires
5. Form fields reset to original values → **user's edits disappear**

## How It Works

The fix decouples form initialization from the reactive `editing` object by tracking the `editingId` instead:

**Before:**
```typescript
$effect(() => {
  if (open) {
    // Runs whenever 'editing' object reference changes
    // (every 15 seconds due to auto-refresh)
    name = editing.name;
    prompt = editing.prompt;
    // ...
  }
});
```

**After:**
```typescript
// Use undefined as sentinel to distinguish from null (new task)
let lastInitializedId = $state<string | null | undefined>(undefined);

$effect(() => {
  // Only initialize when editingId changes, not when editing object changes
  if (open && editingId !== lastInitializedId) {
    if (editing) {
      name = editing.name;
      prompt = editing.prompt;
      // ...
    } else {
      // New task defaults
      name = "";
      prompt = "";
      // ...
    }
    lastInitializedId = editingId;
  }
  
  // Reset to undefined (not null) when form closes
  if (!open) {
    lastInitializedId = undefined;
  }
});
```

**State Transitions:**
- **New Task:** `editingId = null`, `lastInitializedId = undefined` → `null !== undefined` → ✅ initializes
- **Edit Task:** `editingId = "task-123"`, `lastInitializedId = undefined` → ✅ initializes
- **Auto-refresh:** `editingId = "task-123"`, `lastInitializedId = "task-123"` → ❌ skips re-init (correct!)
- **Close form:** Reset to `undefined` for next open

Form state now persists through auto-refresh cycles because `editingId` remains stable when the user is editing the same task.

## Testing

- ✅ TypeScript typecheck passed
- ✅ Build completed successfully
- ✅ New Task button works (opens blank form)
- ✅ Edit Task loads correctly
- ✅ Edit persistence verified (text remains after 20+ seconds)
- ✅ Schedule changes persist through refresh

## Files Changed

- `packages/cli/dashboard/src/lib/components/tasks/TaskForm.svelte` (17 insertions, 4 deletions)