### PR TITLE
fix(openclaw): harden workspace validation + connector health dashboard

### DIFF
--- a/packages/cli/dashboard/src/lib/api.ts
+++ b/packages/cli/dashboard/src/lib/api.ts
@@ -36,8 +36,21 @@ export interface ConfigFile {
 
 export interface Harness {
 	name: string;
+	id: string;
 	path: string;
 	exists: boolean;
+	lastSeen: string | null;
+}
+
+export interface DocumentConnector {
+	id: string;
+	provider: string;
+	display_name: string | null;
+	status: string;
+	last_sync_at: string | null;
+	last_error: string | null;
+	created_at: string;
+	updated_at: string;
 }
 
 export interface Identity {
@@ -537,6 +550,17 @@ export async function getHarnesses(): Promise<Harness[]> {
 		if (!response.ok) throw new Error("Failed to fetch harnesses");
 		const data = await response.json();
 		return data.harnesses || [];
+	} catch {
+		return [];
+	}
+}
+
+export async function getConnectors(): Promise<DocumentConnector[]> {
+	try {
+		const response = await fetch(`${API_BASE}/api/connectors`);
+		if (!response.ok) return [];
+		const data = await response.json();
+		return data.connectors ?? [];
 	} catch {
 		return [];
 	}

--- a/packages/cli/dashboard/src/lib/components/app-sidebar.svelte
+++ b/packages/cli/dashboard/src/lib/components/app-sidebar.svelte
@@ -11,6 +11,7 @@
 	import Zap from "@lucide/svelte/icons/zap";
 	import CalendarClock from "@lucide/svelte/icons/calendar-clock";
 	import Activity from "@lucide/svelte/icons/activity";
+	import Plug from "@lucide/svelte/icons/plug";
 	import Sun from "@lucide/svelte/icons/sun";
 	import Moon from "@lucide/svelte/icons/moon";
 	import Github from "@lucide/svelte/icons/github";
@@ -43,6 +44,7 @@
 		{ id: "secrets", label: "Secrets", icon: KeyRound },
 		{ id: "skills", label: "Skills", icon: Zap },
 		{ id: "tasks", label: "Tasks", icon: CalendarClock },
+		{ id: "connectors", label: "Connectors", icon: Plug },
 	];
 </script>
 

--- a/packages/cli/dashboard/src/lib/components/layout/page-headers.ts
+++ b/packages/cli/dashboard/src/lib/components/layout/page-headers.ts
@@ -40,4 +40,8 @@ export const PAGE_HEADERS = {
 		title: "Tasks",
 		eyebrow: "Scheduled agent prompts",
 	},
+	connectors: {
+		title: "Connectors",
+		eyebrow: "Harness and data source health",
+	},
 } as const satisfies Record<string, PageHeaderDefinition>;

--- a/packages/cli/dashboard/src/lib/components/tabs/ConnectorsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/ConnectorsTab.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { Badge } from "$lib/components/ui/badge/index.js";
+	import {
+		getHarnesses,
+		getConnectors,
+		type Harness,
+		type DocumentConnector,
+	} from "$lib/api";
+
+	let harnesses = $state<Harness[]>([]);
+	let connectors = $state<DocumentConnector[]>([]);
+	let loading = $state(true);
+
+	function relativeTime(iso: string | null): string {
+		if (!iso) return "never";
+		const ts = new Date(iso).getTime();
+		if (Number.isNaN(ts)) return "unknown";
+		const diff = Date.now() - ts;
+		const minutes = Math.floor(diff / 60_000);
+		if (minutes < 1) return "just now";
+		if (minutes < 60) return `${minutes}m ago`;
+		const hours = Math.floor(minutes / 60);
+		if (hours < 24) return `${hours}h ago`;
+		return `${Math.floor(hours / 24)}d ago`;
+	}
+
+	function statusVariant(
+		status: string,
+	): "default" | "secondary" | "destructive" | "outline" {
+		if (status === "error") return "destructive";
+		if (status === "syncing") return "default";
+		return "secondary";
+	}
+
+	async function load() {
+		const [h, c] = await Promise.all([getHarnesses(), getConnectors()]);
+		harnesses = h;
+		connectors = c;
+		loading = false;
+	}
+
+	onMount(() => {
+		load();
+		const timer = setInterval(load, 30_000);
+		return () => clearInterval(timer);
+	});
+</script>
+
+<div class="flex flex-1 flex-col gap-6 p-4 overflow-y-auto">
+	{#if loading}
+		<div
+			class="flex flex-1 items-center justify-center text-[12px]
+				text-[var(--sig-text-muted)] font-[family-name:var(--font-mono)]"
+		>
+			Loading connectors...
+		</div>
+	{:else}
+		<!-- Platform Harnesses -->
+		<section>
+			<h3
+				class="text-[11px] uppercase tracking-[0.1em] text-[var(--sig-text-muted)]
+					font-[family-name:var(--font-mono)] mb-3"
+			>
+				Platform Harnesses
+			</h3>
+			<div class="grid gap-2">
+				{#each harnesses as h (h.id)}
+					<div
+						class="flex items-center gap-3 px-3 py-2.5
+							border border-[var(--sig-border)]
+							bg-[var(--sig-surface-raised)]"
+					>
+						<span
+							class="inline-block h-2 w-2 shrink-0"
+							class:bg-[var(--sig-success)]={h.exists}
+							class:border={!h.exists}
+							class:border-[var(--sig-text-muted)]={!h.exists}
+						></span>
+						<div class="flex flex-col gap-0.5 min-w-0 flex-1">
+							<span
+								class="text-[12px] font-medium text-[var(--sig-text-bright)]
+									font-[family-name:var(--font-display)] tracking-[0.04em]"
+							>
+								{h.name}
+							</span>
+							<span
+								class="text-[10px] text-[var(--sig-text-muted)]
+									font-[family-name:var(--font-mono)] truncate"
+							>
+								{h.path}
+							</span>
+						</div>
+						<div class="flex flex-col items-end gap-0.5 shrink-0">
+							<span
+								class="text-[10px] font-[family-name:var(--font-mono)]"
+								class:text-[var(--sig-text-bright)]={h.exists}
+								class:text-[var(--sig-text-muted)]={!h.exists}
+							>
+								{h.exists ? "installed" : "not found"}
+							</span>
+							<span
+								class="text-[10px] text-[var(--sig-text-muted)]
+									font-[family-name:var(--font-mono)]"
+							>
+								{#if h.lastSeen}
+									seen {relativeTime(h.lastSeen)}
+								{:else}
+									no activity
+								{/if}
+							</span>
+						</div>
+					</div>
+				{/each}
+			</div>
+		</section>
+
+		<!-- Document Connectors -->
+		<section>
+			<h3
+				class="text-[11px] uppercase tracking-[0.1em] text-[var(--sig-text-muted)]
+					font-[family-name:var(--font-mono)] mb-3"
+			>
+				Document Connectors
+			</h3>
+			{#if connectors.length === 0}
+				<div
+					class="flex items-center justify-center py-8
+						text-[12px] text-[var(--sig-text-muted)]
+						font-[family-name:var(--font-mono)]
+						border border-dashed border-[var(--sig-border)]"
+				>
+					No document connectors configured
+				</div>
+			{:else}
+				<div class="grid gap-2">
+					{#each connectors as conn (conn.id)}
+						<div
+							class="flex items-center gap-3 px-3 py-2.5
+								border border-[var(--sig-border)]
+								bg-[var(--sig-surface-raised)]"
+						>
+							<Badge variant={statusVariant(conn.status)}>
+								{conn.status}
+							</Badge>
+							<div class="flex flex-col gap-0.5 min-w-0 flex-1">
+								<span
+									class="text-[12px] font-medium text-[var(--sig-text-bright)]
+										font-[family-name:var(--font-display)] tracking-[0.04em]"
+								>
+									{conn.display_name ?? conn.id}
+								</span>
+								<span
+									class="text-[10px] text-[var(--sig-text-muted)]
+										font-[family-name:var(--font-mono)]"
+								>
+									{conn.provider}
+								</span>
+							</div>
+							<div class="flex flex-col items-end gap-0.5 shrink-0">
+								<span
+									class="text-[10px] text-[var(--sig-text-muted)]
+										font-[family-name:var(--font-mono)]"
+								>
+									{#if conn.last_sync_at}
+										synced {relativeTime(conn.last_sync_at)}
+									{:else}
+										never synced
+									{/if}
+								</span>
+								{#if conn.last_error}
+									<span
+										class="text-[10px] text-[var(--sig-danger)]
+											font-[family-name:var(--font-mono)] truncate max-w-[200px]"
+										title={conn.last_error}
+									>
+										{conn.last_error}
+									</span>
+								{/if}
+							</div>
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</section>
+	{/if}
+</div>

--- a/packages/cli/dashboard/src/lib/stores/navigation.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/navigation.svelte.ts
@@ -13,7 +13,8 @@ export type TabId =
 	| "logs"
 	| "secrets"
 	| "skills"
-	| "tasks";
+	| "tasks"
+	| "connectors";
 
 export const nav = $state({
 	activeTab: "config" as TabId,

--- a/packages/cli/dashboard/src/routes/+page.svelte
+++ b/packages/cli/dashboard/src/routes/+page.svelte
@@ -280,6 +280,14 @@ onMount(() => {
 						Failed to load tab: {error instanceof Error ? error.message : "unknown error"}
 					</div>
 				{/await}
+			{:else if activeTab === "connectors"}
+				{#await import("$lib/components/tabs/ConnectorsTab.svelte") then module}
+					<module.default />
+				{:catch error}
+					<div class="flex flex-1 items-center justify-center text-[12px] text-[var(--sig-danger)] font-[family-name:var(--font-mono)]">
+						Failed to load tab: {error instanceof Error ? error.message : "unknown error"}
+					</div>
+				{/await}
 			{/if}
 		</div>
 
@@ -329,6 +337,9 @@ onMount(() => {
 			{:else if activeTab === "tasks"}
 				<span>{ts.tasks.length} scheduled tasks</span>
 				<span>cron scheduler</span>
+			{:else if activeTab === "connectors"}
+				<span>platform harnesses + data sources</span>
+				<span>connector health</span>
 			{/if}
 		</div>
 	</main>


### PR DESCRIPTION
## Summary

- **Root cause fix**: connector-openclaw's `install()` wrote an incorrect workspace path (`/home/test-user/.agents`) into `openclaw.json` when `HOME` was wrong at install time — every Discord message then crashed with `EACCES: permission denied, mkdir '/home/test-user'`
- **Workspace validation hardening**: new `checkWorkspaceOwnership()` warns when the resolved path doesn't exist or is outside the current user's home directory (with trailing-separator-safe comparison to avoid `/home/alice-admin` falsely matching `/home/alice`)
- **Plugin health reporting**: startup health ping + 60s periodic heartbeat in the openclaw adapter, with state-transition logging (reachable/unreachable). Instance-scoped to prevent interval leaks on multi-register
- **Dashboard Connectors tab**: new tab showing platform harness health (installed status, lastSeen timestamps) and document connector status (sync state, errors) with 30s polling

## Files changed

| File | Change |
|------|--------|
| `packages/connector-openclaw/src/index.ts` | `checkWorkspaceOwnership()` + wiring |
| `packages/adapters/openclaw/src/index.ts` | Health ping + periodic heartbeat |
| `packages/daemon/src/daemon.ts` | `harnessLastSeen` map + expanded `/api/harnesses` |
| `packages/cli/dashboard/src/lib/api.ts` | Updated `Harness` type + `getConnectors()` |
| `packages/cli/dashboard/src/lib/stores/navigation.svelte.ts` | `"connectors"` TabId |
| `packages/cli/dashboard/src/lib/components/layout/page-headers.ts` | Header entry |
| `packages/cli/dashboard/src/lib/components/app-sidebar.svelte` | Nav item |
| `packages/cli/dashboard/src/routes/+page.svelte` | Tab routing + footer |
| `packages/cli/dashboard/src/lib/components/tabs/ConnectorsTab.svelte` | New component |

## Test plan

- [x] `bun run build` passes
- [x] `bun test` — 537 pass, 0 fail
- [x] Daemon serves expanded `/api/harnesses` with `id` + `lastSeen` fields
- [x] Dashboard Connectors tab loads and renders harness cards
- [x] OpenClaw gateway restarts cleanly with no EACCES errors
- [ ] Verify `lastSeen` populates after a hook call from openclaw/claude-code
- [ ] Verify document connectors section renders when connectors are configured