### PR TITLE
fix(hooks): sanitize user-prompt recall query context

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1481,12 +1481,14 @@ for in-context injection.
 {
   "harness": "claude-code",
   "userPrompt": "How do I set up dark mode?",
+  "lastAssistantMessage": "Earlier we discussed using CSS variables for theme tokens.",
   "sessionKey": "session-uuid",
   "runtimePath": "plugin"
 }
 ```
 
 `harness` and `userPrompt` are required.
+`lastAssistantMessage` is optional and improves recall matching.
 
 ### POST /api/hooks/session-end
 

--- a/packages/adapters/openclaw/src/index.ts
+++ b/packages/adapters/openclaw/src/index.ts
@@ -84,6 +84,84 @@ export interface UserPromptSubmitResult {
 	engine?: string;
 }
 
+function firstNonEmptyString(...values: readonly unknown[]): string | undefined {
+	for (const value of values) {
+		if (typeof value === "string" && value.trim().length > 0) {
+			return value;
+		}
+	}
+	return undefined;
+}
+
+function isAssistantMessage(message: Record<string, unknown>): boolean {
+	const role =
+		typeof message.role === "string" ? message.role.toLowerCase() : "";
+	const sender =
+		typeof message.sender === "string" ? message.sender.toLowerCase() : "";
+
+	return (
+		role === "assistant" ||
+		role === "agent" ||
+		role === "model" ||
+		sender === "assistant" ||
+		sender === "agent"
+	);
+}
+
+function getMessageText(message: Record<string, unknown>): string | undefined {
+	const direct = firstNonEmptyString(
+		message.content,
+		message.text,
+		message.message,
+	);
+	if (direct) return direct;
+
+	if (!Array.isArray(message.content)) return undefined;
+
+	const textParts: string[] = [];
+	for (const chunk of message.content) {
+		if (typeof chunk !== "object" || chunk === null) continue;
+		const part = chunk as Record<string, unknown>;
+		if (part.type !== "text") continue;
+		if (typeof part.text === "string" && part.text.trim().length > 0) {
+			textParts.push(part.text);
+		}
+	}
+
+	if (textParts.length === 0) return undefined;
+	return textParts.join("\n");
+}
+
+function extractLastAssistantMessage(
+	event: Record<string, unknown>,
+): string | undefined {
+	const explicit = firstNonEmptyString(
+		event.lastAssistantMessage,
+		event.last_assistant_message,
+		event.assistantMessage,
+		event.assistant_message,
+		event.previousAssistantMessage,
+		event.previous_assistant_message,
+	);
+	if (explicit) return explicit;
+
+	const messages = event.messages;
+	if (!Array.isArray(messages)) return undefined;
+
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const raw = messages[i];
+		if (typeof raw !== "object" || raw === null) continue;
+
+		const message = raw as Record<string, unknown>;
+		if (!isAssistantMessage(message)) continue;
+
+		const text = getMessageText(message);
+		if (text) return text;
+	}
+
+	return undefined;
+}
+
 export interface SessionEndResult {
 	memoriesSaved: number;
 }
@@ -210,6 +288,7 @@ export async function onUserPromptSubmit(
 	options: {
 		daemonUrl?: string;
 		userPrompt: string;
+		lastAssistantMessage?: string;
 		sessionKey?: string;
 		project?: string;
 	},
@@ -222,6 +301,7 @@ export async function onUserPromptSubmit(
 			body: {
 				harness,
 				userPrompt: options.userPrompt,
+				lastAssistantMessage: options.lastAssistantMessage,
 				sessionKey: options.sessionKey,
 				project: options.project,
 				runtimePath: RUNTIME_PATH,
@@ -908,9 +988,11 @@ const signetPlugin = {
 				const rawPrompt = event.prompt as string | undefined;
 				const prompt = rawPrompt ? extractUserMessage(rawPrompt) : undefined;
 				if (prompt && prompt.length > 3) {
+					const lastAssistantMessage = extractLastAssistantMessage(event);
 					const result = await onUserPromptSubmit("openclaw", {
 						...opts,
 						userPrompt: prompt,
+						lastAssistantMessage,
 						sessionKey,
 					});
 					if (result?.inject) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4805,6 +4805,7 @@ hookCmd
 		let userPrompt = "";
 		let sessionKey = "";
 		let stdinProject = "";
+		let lastAssistantMessage = "";
 		try {
 			const chunks: Buffer[] = [];
 			for await (const chunk of process.stdin) {
@@ -4812,10 +4813,62 @@ hookCmd
 			}
 			const input = Buffer.concat(chunks).toString("utf-8").trim();
 			if (input) {
-				const parsed = JSON.parse(input);
-				userPrompt = parsed.prompt || parsed.user_prompt || parsed.userPrompt || "";
-				sessionKey = parsed.session_id || parsed.sessionId || "";
-				stdinProject = parsed.cwd || "";
+				const parsed = JSON.parse(input) as Record<string, unknown>;
+
+				const pickString = (...values: unknown[]): string => {
+					for (const value of values) {
+						if (typeof value === "string" && value.trim().length > 0) {
+							return value;
+						}
+					}
+					return "";
+				};
+
+				userPrompt = pickString(parsed.prompt, parsed.user_prompt, parsed.userPrompt);
+				sessionKey = pickString(parsed.session_id, parsed.sessionId);
+				stdinProject = pickString(parsed.cwd);
+
+				lastAssistantMessage = pickString(
+					parsed.last_assistant_message,
+					parsed.lastAssistantMessage,
+					parsed.assistant_message,
+					parsed.assistantMessage,
+					parsed.previous_assistant_message,
+					parsed.previousAssistantMessage,
+				);
+
+				if (!lastAssistantMessage && Array.isArray(parsed.messages)) {
+					for (let i = parsed.messages.length - 1; i >= 0; i--) {
+						const msg = parsed.messages[i];
+						if (typeof msg !== "object" || msg === null) continue;
+
+						const record = msg as Record<string, unknown>;
+						const role =
+							typeof record.role === "string" ? record.role.toLowerCase() : "";
+						const sender =
+							typeof record.sender === "string"
+								? record.sender.toLowerCase()
+								: "";
+						const isAssistant =
+							role === "assistant" ||
+							role === "agent" ||
+							role === "model" ||
+							sender === "assistant" ||
+							sender === "agent";
+
+						if (!isAssistant) continue;
+
+						const content = pickString(
+							record.content,
+							record.text,
+							record.message,
+						);
+						if (content) {
+							lastAssistantMessage = content;
+							break;
+						}
+					}
+				}
 			}
 		} catch {
 			// No stdin or invalid JSON
@@ -4833,6 +4886,7 @@ hookCmd
 				project: options.project || stdinProject,
 				userPrompt,
 				sessionKey,
+				lastAssistantMessage: lastAssistantMessage || undefined,
 			}),
 		});
 

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -135,6 +135,7 @@ export interface UserPromptSubmitRequest {
 	harness: string;
 	project?: string;
 	userPrompt: string;
+	lastAssistantMessage?: string;
 	sessionKey?: string;
 	runtimePath?: "plugin" | "legacy";
 }
@@ -1062,17 +1063,104 @@ ${guidelines}
 // User Prompt Submit
 // ============================================================================
 
+const UNTRUSTED_METADATA_HEADER =
+	/conversation info \(untrusted metadata\)\s*:/i;
+
+function findJsonObjectEnd(text: string, startIndex: number): number {
+	let depth = 0;
+	let inString = false;
+	let escaped = false;
+
+	for (let i = startIndex; i < text.length; i++) {
+		const ch = text[i];
+
+		if (inString) {
+			if (escaped) {
+				escaped = false;
+				continue;
+			}
+			if (ch === "\\") {
+				escaped = true;
+				continue;
+			}
+			if (ch === '"') {
+				inString = false;
+			}
+			continue;
+		}
+
+		if (ch === '"') {
+			inString = true;
+			continue;
+		}
+
+		if (ch === "{") {
+			depth++;
+			continue;
+		}
+
+		if (ch === "}") {
+			depth--;
+			if (depth === 0) return i;
+		}
+	}
+
+	return -1;
+}
+
+function stripUntrustedMetadata(text: string): string {
+	let remaining = text;
+
+	while (true) {
+		const match = UNTRUSTED_METADATA_HEADER.exec(remaining);
+		if (!match || match.index === undefined) break;
+
+		const blockStart = match.index;
+		let blockEnd = blockStart + match[0].length;
+
+		while (blockEnd < remaining.length && /\s/.test(remaining[blockEnd])) {
+			blockEnd++;
+		}
+
+		if (remaining[blockEnd] === "{") {
+			const jsonEnd = findJsonObjectEnd(remaining, blockEnd);
+			if (jsonEnd > blockEnd) {
+				blockEnd = jsonEnd + 1;
+			}
+		}
+
+		const before = remaining.slice(0, blockStart).trimEnd();
+		const after = remaining.slice(blockEnd).trimStart();
+		remaining = [before, after].filter((part) => part.length > 0).join("\n\n");
+	}
+
+	return remaining.trim();
+}
+
+function extractRecallWords(
+	userPrompt: string,
+	lastAssistantMessage?: string,
+): string[] {
+	const cleanedUserPrompt = stripUntrustedMetadata(userPrompt);
+	const cleanedAssistant = lastAssistantMessage
+		? stripUntrustedMetadata(lastAssistantMessage)
+		: "";
+
+	return [cleanedUserPrompt, cleanedAssistant]
+		.filter((part) => part.length > 0)
+		.join(" ")
+		.toLowerCase()
+		.split(/\W+/)
+		.filter((word) => word.length >= 3)
+		.slice(0, 12);
+}
+
 export function handleUserPromptSubmit(
 	req: UserPromptSubmitRequest,
 ): UserPromptSubmitResponse {
 	const start = Date.now();
 
-	// Extract meaningful words from prompt
-	const words = req.userPrompt
-		.toLowerCase()
-		.split(/\W+/)
-		.filter((w) => w.length >= 3)
-		.slice(0, 10);
+	const words = extractRecallWords(req.userPrompt, req.lastAssistantMessage);
 
 	// Always record the prompt for continuity tracking, even if no FTS query
 	const snippet = req.userPrompt.slice(0, 200).trim();


### PR DESCRIPTION
## Summary
- Strip `Conversation info (untrusted metadata)` blocks from `userPrompt` before building per-prompt recall query terms.
- Include optional `lastAssistantMessage` in recall query term extraction so FTS can use the last assistant turn plus user message.
- Wire the optional assistant context through the CLI hook payload parser and OpenClaw adapter lifecycle hook, and document the API field.
- Add daemon hook regression tests for metadata stripping and assistant-message query inclusion.

## Validation
- bun test packages/daemon/test/hooks.test.ts
- (cd packages/daemon && bun run build)
- (cd packages/cli && bun run build:cli)
- (cd packages/adapters/openclaw && bun run build)