### PR TITLE
feat(dashboard{Memory/Skills}): show total/filtered memory count above grid/Improve loading times

### DIFF
--- a/packages/cli/dashboard/src/lib/components/tabs/MemoryTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/MemoryTab.svelte
@@ -31,6 +31,9 @@ let display = $derived(
 			: memories,
 );
 
+let totalCount = $derived(memories.length);
+let displayCount = $derived(display.length);
+
 function parseMemoryTags(raw: Memory["tags"]): string[] {
 	if (!raw) return [];
 	if (Array.isArray(raw)) {
@@ -221,6 +224,17 @@ function formatIsoDate(value: string): string {
 				onclick={() => mem.filterType = mem.filterType === t ? '' : t}
 			>{t}</button>
 		{/each}
+	</div>
+
+	<!-- Count bar -->
+	<div class="flex items-center text-[10px] font-[family-name:var(--font-mono)] text-[var(--sig-text-muted)]">
+		{#if mem.similarSourceId}
+			Showing {displayCount} similar {displayCount === 1 ? 'memory' : 'memories'}
+		{:else if mem.searched || hasActiveFilters()}
+			Showing {displayCount} of {totalCount} {totalCount === 1 ? 'memory' : 'memories'}
+		{:else}
+			{totalCount} {totalCount === 1 ? 'memory' : 'memories'}
+		{/if}
 	</div>
 
 	<!-- Similarity mode banner -->


### PR DESCRIPTION
## What

Two improvements to the Skills page shipped on this branch.

---

### 1. Total / filtered count above the memory grid

Adds a reactive count bar above the memory grid that tells users exactly how many memories they're looking at.

### 2. Skills catalog localStorage cache (instant repeat loads)

Caches the browse catalog in localStorage so the grid renders with no loading state on repeat visits.

---

## Changes

### Count bar (`MemoryTab.svelte`)
Two `$derived` vars off the already-reactive `display` and `memories` props — no store or API changes:

```ts
let totalCount = $derived(memories.length);
let displayCount = $derived(display.length);
```

Count bar inserted between the filter row and the similarity banner.

| Mode | Label |
|---|---|
| No filters | `87 memories` |
| Search / filter active | `Showing 12 of 87 memories` |
| Similarity mode | `Showing 5 similar memories` |

Singular/plural handled (`1 memory` vs `2 memories`).

### Catalog cache (`skills.svelte.ts`)

`fetchCatalog()` now has three paths:

| Scenario | Before | After |
|---|---|---|
| First ever load | Spinner → fetch (slow) | Spinner → fetch → save cache |
| Repeat load, cache < 5min | Spinner → fetch (slow) | **Instant from cache, no fetch** |
| Repeat load, cache > 5min | Spinner → fetch (slow) | **Instant from cache** + silent background refresh |
| Same session re-visit | Already guarded by `catalogLoaded` | Unchanged |

Cache key: `signet:skills:catalog:v1`. TTL: 5 minutes. Background refresh runs silently after serving stale cache — no flicker, no loading state.

---

## Why

- The memory grid rendered results with no feedback on count — users had no way to gauge search quality or dataset size at a glance.
- The browse catalog fetches from external registries (skills.sh, clawhub.ai) on every page load — the main first-load bottleneck. After the first cold load, every subsequent visit is instant.

---

## Files changed

| File | Change |
|---|---|
| `packages/cli/dashboard/src/lib/components/tabs/MemoryTab.svelte` | +14 lines — count bar |
| `packages/cli/dashboard/src/lib/stores/skills.svelte.ts` | +66 lines — catalog cache |

## Checks

- `bun run build` ✓
- `bun test` — 579/579 pass ✓
- `bun run typecheck` ✓
- `svelte-check` (MemoryTab.svelte) — no new errors ✓