### PR TITLE
feat(dashboard): add Cmd/Ctrl+S keyboard shortcut to save settings

### DIFF
--- a/packages/cli/dashboard/src/lib/components/tabs/SettingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/SettingsTab.svelte
@@ -30,6 +30,13 @@ async function saveSettings() {
 	await st.save();
 }
 
+function handleGlobalKey(e: KeyboardEvent) {
+	if (e.key === "s" && (e.metaKey || e.ctrlKey)) {
+		e.preventDefault();
+		if (st.isDirty && !st.saving) saveSettings();
+	}
+}
+
 function formatSavedAt(raw: string | null): string {
 	if (!raw) return "";
 	try {
@@ -46,6 +53,8 @@ $effect(() => {
 	};
 });
 </script>
+
+<svelte:window onkeydown={handleGlobalKey} />
 
 <div class="settings-tab">
 	{#if !st.hasFiles}
@@ -74,7 +83,7 @@ $effect(() => {
 					<span>{st.lastSaveFeedback}</span>
 				{/if}
 			</div>
-			<button class="save-btn" onclick={saveSettings} disabled={st.saving || !st.isDirty}>
+			<button class="save-btn" onclick={saveSettings} disabled={st.saving || !st.isDirty} title="Save (⌘S / Ctrl+S)">
 				{st.saving ? "Saving…" : "Save"}
 			</button>
 		</div>


### PR DESCRIPTION
## What

Adds a `Cmd+S` (Mac) / `Ctrl+S` (Win/Linux) keyboard shortcut to trigger save on the Settings page.

## How

Follows the existing `<svelte:window onkeydown={...}>` pattern used by `SkillsTab` and `TasksTab`.

```ts
function handleGlobalKey(e: KeyboardEvent) {
  if (e.key === \"s\" && (e.metaKey || e.ctrlKey)) {
    e.preventDefault();
    if (st.isDirty && !st.saving) saveSettings();
  }
}
```

Guards:
- `e.preventDefault()` — stops the browser's native Save Dialog
- `st.isDirty` — no-op if there's nothing to save
- `!st.saving` — no-op if a save is already in flight

Also adds `title=\"Save (⌘S / Ctrl+S)\"` to the Save button so the shortcut is discoverable on hover.

## Why

The Save button was mouse-only. Developers editing a multi-field settings form expect `Cmd/Ctrl+S` to work — it's a universal convention in editors and dashboards.

## Lockfile sync follow-up

- Updated only `bun.lock` to sync workspace dependency resolution with the current repo state.
- Aligned workspace package version entries in the lock snapshot and removed stale lock records.
- Adjusted transitive pins so install/test environments resolve consistently.
- No runtime/source logic changes in this follow-up commit.

## Files changed

- `packages/cli/dashboard/src/lib/components/tabs/SettingsTab.svelte`
- `bun.lock`

## Checks

- `bun run build` ✓
- `bun test` — 579/579 pass ✓
- `bun run typecheck` ✓