### PR TITLE
fix[URGENT](daemon): use Homebrew SQLite on macOS for extension loading

### DIFF
--- a/packages/daemon/src/db-accessor.ts
+++ b/packages/daemon/src/db-accessor.ts
@@ -8,6 +8,31 @@
 
 import { Database, type Statement } from "bun:sqlite";
 import { copyFileSync, existsSync, mkdirSync, readdirSync, statSync, unlinkSync } from "node:fs";
+
+// ---------------------------------------------------------------------------
+// macOS SQLite extension loading fix
+// ---------------------------------------------------------------------------
+// Apple's system SQLite is compiled with SQLITE_OMIT_LOAD_EXTENSION for
+// security reasons. Bun's bun:sqlite uses the system SQLite by default,
+// which prevents loading sqlite-vec and silently degrades to keyword-only
+// search. Use Homebrew's SQLite if available (supports extension loading).
+// ---------------------------------------------------------------------------
+
+const HOMEBREW_SQLITE_PATHS = [
+	"/opt/homebrew/opt/sqlite/lib/libsqlite3.dylib", // Apple Silicon
+	"/usr/local/opt/sqlite/lib/libsqlite3.dylib", // Intel
+];
+
+for (const sqlitePath of HOMEBREW_SQLITE_PATHS) {
+	if (existsSync(sqlitePath)) {
+		try {
+			Database.setCustomSQLite(sqlitePath);
+		} catch {
+			// SQLite already loaded (e.g., in test environment) — skip
+		}
+		break;
+	}
+}
 import { basename, dirname, join } from "node:path";
 import {
 	runMigrations,


### PR DESCRIPTION
## Summary

Fixes silent vector search degradation on macOS caused by Apple's system SQLite lacking extension loading support.

## Problem

- Apple compiles system SQLite with `SQLITE_OMIT_LOAD_EXTENSION` for security
- Bun's `bun:sqlite` uses the system SQLite by default
- This prevents loading `sqlite-vec`, causing vector search to silently fail
- All macOS users see keyword-only results with no semantic/hybrid search

**Symptoms:**
- "vec embeddings table not found" error on startup
- All `signet recall` results show `source: "keyword"` only
- No vector or hybrid search results despite embeddings existing

## Solution

Auto-detect Homebrew's SQLite installation at daemon startup and use it via `Database.setCustomSQLite()`:

```typescript
const HOMEBREW_SQLITE_PATHS = [
  "/opt/homebrew/opt/sqlite/lib/libsqlite3.dylib", // Apple Silicon
  "/usr/local/opt/sqlite/lib/libsqlite3.dylib",    // Intel
];

for (const sqlitePath of HOMEBREW_SQLITE_PATHS) {
  if (existsSync(sqlitePath)) {
    try {
      Database.setCustomSQLite(sqlitePath);
    } catch {
      // SQLite already loaded (e.g., in test environment) — skip
    }
    break;
  }
}
```

Homebrew's SQLite is compiled with extension loading enabled, allowing sqlite-vec to work correctly.

## Testing

- [x] `bun install` ✓
- [x] `bun run build` ✓
- [x] `bun test` — 579/579 pass ✓
- [x] `bun run typecheck` ✓
- [x] Manual verification: `signet recall` now returns `source: "vector"` and `source: "hybrid"` results

## Notes

- If Homebrew SQLite isn't installed, behavior is unchanged (falls back to system SQLite with keyword-only search)
- The try-catch handles test environments where multiple test files may import the module
- This is a runtime fix; no changes needed for users who already have Homebrew SQLite installed
- Health is now 100%, and shows no vec embedding table errors.