### PR TITLE
feat(dashboard): add section-level dirty indicators in settings

### DIFF
--- a/packages/cli/dashboard/src/lib/components/config/FormSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/config/FormSection.svelte
@@ -8,9 +8,10 @@ interface Props {
 	description?: string;
 	children: Snippet;
 	defaultOpen?: boolean;
+	dirty?: boolean;
 }
 
-const { title, description, children, defaultOpen = true }: Props = $props();
+const { title, description, children, defaultOpen = true, dirty = false }: Props = $props();
 let open = $state(defaultOpen);
 </script>
 
@@ -22,7 +23,7 @@ let open = $state(defaultOpen);
 			text-[11px] font-semibold uppercase tracking-[0.1em]
 			hover:bg-[var(--sig-surface-raised)]"
 	>
-		<span>{title}</span>
+		<span>{title}{#if dirty}<span class="text-[var(--sig-accent)] ml-1">•</span>{/if}</span>
 		<ChevronDown
 			class="text-[var(--sig-text-muted)] transition-transform duration-200
 				{open ? 'rotate-180' : ''}"

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/AgentSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/AgentSection.svelte
@@ -6,6 +6,12 @@ import { Input } from "$lib/components/ui/input/index.js";
 import { Textarea } from "$lib/components/ui/textarea/index.js";
 import { KNOWN_HARNESSES, st } from "$lib/stores/settings.svelte";
 
+const AGENT_PATHS: string[][] = [
+	["agent", "name"],
+	["agent", "description"],
+	["harnesses"],
+];
+
 function formatDate(raw: unknown): string {
 	if (!raw) return "";
 	try {
@@ -33,10 +39,12 @@ function toggleHarness(h: string) {
 		st.toggleHarness(h, !!v);
 	};
 }
+
+let isDirty = $derived(st.isAnyPathDirty("agent", AGENT_PATHS));
 </script>
 
 {#if st.agentFile}
-	<FormSection title="Agent" description="Core identity metadata. Created by signet setup, synced to all harnesses on change.">
+	<FormSection title="Agent" description="Core identity metadata. Created by signet setup, synced to all harnesses on change." dirty={isDirty}>
 		<FormField label="Name" description="Display name shown in harness configs and session context.">
 			<Input value={st.aStr(["agent", "name"])} oninput={setStr(["agent", "name"])} />
 		</FormField>
@@ -51,7 +59,7 @@ function toggleHarness(h: string) {
 		</FormField>
 	</FormSection>
 
-	<FormSection title="Harnesses" defaultOpen={false} description="AI platforms to integrate with. The daemon syncs identity files and installs hooks for each active harness.">
+	<FormSection title="Harnesses" defaultOpen={false} description="AI platforms to integrate with. The daemon syncs identity files and installs hooks for each active harness." dirty={isDirty}>
 		<FormField label="Active harnesses" description="Supported: claude-code, openclaw, opencode. Cursor, windsurf, chatgpt, and gemini are planned.">
 			<div class="flex flex-col gap-1.5">
 				{#each KNOWN_HARNESSES as h (h)}

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/AuthSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/AuthSection.svelte
@@ -11,6 +11,12 @@ const selectContentClass =
 	"font-[family-name:var(--font-mono)] text-[11px] bg-[var(--sig-bg)] text-[var(--sig-text)] border-[var(--sig-border-strong)] rounded-none";
 const selectItemClass = "font-[family-name:var(--font-mono)] text-[11px] rounded-none";
 
+const AUTH_PATHS: string[][] = [
+	["auth", "method"],
+	["auth", "mode"],
+	["auth", "chainId"],
+];
+
 function setSelect(path: string[]) {
 	return (v: string | undefined) => {
 		st.aSetStr(path, v ?? "");
@@ -22,10 +28,12 @@ function setNum(path: string[]) {
 		st.aSetNum(path, (e.currentTarget as HTMLInputElement).value);
 	};
 }
+
+let isDirty = $derived(st.isAnyPathDirty("agent", AUTH_PATHS));
 </script>
 
 {#if st.agentFile}
-	<FormSection title="Auth" defaultOpen={false} description="Authentication for the daemon API. Optional — disabled in local mode. Uses HMAC-SHA256 signed tokens.">
+	<FormSection title="Auth" defaultOpen={false} description="Authentication for the daemon API. Optional — disabled in local mode. Uses HMAC-SHA256 signed tokens." dirty={isDirty}>
 		<FormField label="Method" description="Signing method for auth tokens. erc8128 uses wallet signatures, gpg/did use alternative signing.">
 			<Select.Root
 				type="single"

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/EmbeddingsSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/EmbeddingsSection.svelte
@@ -14,10 +14,20 @@ const selectItemClass = "font-[family-name:var(--font-mono)] text-[11px] rounded
 function handleProviderChange(v: string | undefined) {
 	st.sSetStr([...st.embPath(), "provider"], v ?? "");
 }
+
+let embeddingPaths = $derived([
+	[...st.embPath(), "provider"],
+	[...st.embPath(), "model"],
+	[...st.embPath(), "dimensions"],
+	[...st.embPath(), "base_url"],
+	[...st.embPath(), "api_key"],
+]);
+
+let isDirty = $derived(st.isAnyPathDirty(st.settingsIsSameAsAgent ? "agent" : "config", embeddingPaths));
 </script>
 
 {#if st.settingsFileName}
-	<FormSection title="Embeddings" defaultOpen={false} description="Vector embedding configuration for semantic memory search. Embeddings power the vector half of hybrid recall.">
+	<FormSection title="Embeddings" defaultOpen={false} description="Vector embedding configuration for semantic memory search. Embeddings power the vector half of hybrid recall." dirty={isDirty}>
 		<FormField label="Provider" description="Embedding backend. Ollama runs locally, OpenAI requires an API key.">
 			<Select.Root
 				type="single"

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/MemorySection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/MemorySection.svelte
@@ -3,10 +3,18 @@ import FormField from "$lib/components/config/FormField.svelte";
 import FormSection from "$lib/components/config/FormSection.svelte";
 import { Input } from "$lib/components/ui/input/index.js";
 import { st } from "$lib/stores/settings.svelte";
+
+const MEMORY_PATHS: string[][] = [
+	["memory", "session_budget"],
+	["memory", "current_md_budget"],
+	["memory", "decay_rate"],
+];
+
+let isDirty = $derived(st.isAnyPathDirty(st.settingsIsSameAsAgent ? "agent" : "config", MEMORY_PATHS));
 </script>
 
 {#if st.settingsFileName}
-	<FormSection title="Memory" defaultOpen={false} description="Memory system settings. Controls how much context is injected into sessions and how memories age over time.">
+	<FormSection title="Memory" defaultOpen={false} description="Memory system settings. Controls how much context is injected into sessions and how memories age over time." dirty={isDirty}>
 		<FormField label="Session budget" description="Character limit for context injected at session start via hooks. Default: 2000.">
 			<Input type="number" value={st.sNum(["memory", "session_budget"])} oninput={(e) => st.sSetNum(["memory", "session_budget"], e.currentTarget.value)} />
 		</FormField>

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/PathsSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/PathsSection.svelte
@@ -4,15 +4,22 @@ import FormSection from "$lib/components/config/FormSection.svelte";
 import { Input } from "$lib/components/ui/input/index.js";
 import { st } from "$lib/stores/settings.svelte";
 
+const PATHS_PATHS: string[][] = [
+	["paths", "database"],
+	["paths", "current_md"],
+];
+
 function setStr(path: string[]) {
 	return (e: Event) => {
 		st.sSetStr(path, (e.currentTarget as HTMLInputElement).value);
 	};
 }
+
+let isDirty = $derived(st.isAnyPathDirty(st.settingsIsSameAsAgent ? "agent" : "config", PATHS_PATHS));
 </script>
 
 {#if st.settingsFileName}
-	<FormSection title="Paths" defaultOpen={false} description="File paths for memory storage. All paths are relative to ~/.agents/ (or $SIGNET_PATH).">
+	<FormSection title="Paths" defaultOpen={false} description="File paths for memory storage. All paths are relative to ~/.agents/ (or $SIGNET_PATH)." dirty={isDirty}>
 		<FormField label="Database" description="SQLite database file for structured memory storage.">
 			<Input value={st.sStr(["paths", "database"])} oninput={setStr(["paths", "database"])} />
 		</FormField>

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
@@ -43,10 +43,24 @@ function setSelect(path: string[]) {
 		st.aSetStr(path, v ?? "");
 	};
 }
+
+let pipelinePaths = $derived([
+	...PIPELINE_CORE_BOOLS.map((b) => ["memory", "pipelineV2", b.key] as string[]),
+	...PIPELINE_FEATURE_BOOLS.map((b) => ["memory", "pipelineV2", b.key] as string[]),
+	...PIPELINE_RERANKER_BOOLS.map((b) => ["memory", "pipelineV2", b.key] as string[]),
+	...PIPELINE_EXTRACTION_NUMS.map((n) => ["memory", "pipelineV2", n.key] as string[]),
+	...PIPELINE_SEARCH_NUMS.map((n) => ["memory", "pipelineV2", n.key] as string[]),
+	...PIPELINE_WORKER_NUMS.map((n) => ["memory", "pipelineV2", n.key] as string[]),
+	["memory", "pipelineV2", "extractionProvider"],
+	["memory", "pipelineV2", "extractionModel"],
+	["memory", "pipelineV2", "maintenanceMode"],
+]);
+
+let isDirty = $derived(st.isAnyPathDirty("agent", pipelinePaths));
 </script>
 
 {#if st.agentFile}
-	<FormSection title="Pipeline" defaultOpen={false} description="V2 memory pipeline. Runs LLM-based fact extraction on incoming memories, then decides whether to write, update, or skip. Lives under memory.pipelineV2 in agent.yaml.">
+	<FormSection title="Pipeline" defaultOpen={false} description="V2 memory pipeline. Runs LLM-based fact extraction on incoming memories, then decides whether to write, update, or skip. Lives under memory.pipelineV2 in agent.yaml." dirty={isDirty}>
 		<div class="font-[family-name:var(--font-mono)] text-[9px] tracking-[0.08em] uppercase text-[var(--sig-text-muted)] pt-3 pb-1 border-b border-[var(--sig-border)] mb-1">
 			Core
 		</div>

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/SearchSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/SearchSection.svelte
@@ -5,6 +5,15 @@ import { Input } from "$lib/components/ui/input/index.js";
 import { Switch } from "$lib/components/ui/switch/index.js";
 import { st } from "$lib/stores/settings.svelte";
 
+const SEARCH_PATHS: string[][] = [
+	["search", "alpha"],
+	["search", "top_k"],
+	["search", "min_score"],
+	["search", "rehearsal_enabled"],
+	["search", "rehearsal_weight"],
+	["search", "rehearsal_half_life_days"],
+];
+
 function setNum(path: string[]) {
 	return (e: Event) => {
 		st.sSetNum(path, (e.currentTarget as HTMLInputElement).value);
@@ -16,10 +25,12 @@ function setBool(path: string[]) {
 		st.sSetBool(path, !!v);
 	};
 }
+
+let isDirty = $derived(st.isAnyPathDirty(st.settingsIsSameAsAgent ? "agent" : "config", SEARCH_PATHS));
 </script>
 
 {#if st.settingsFileName}
-	<FormSection title="Search" defaultOpen={false} description="Hybrid search tuning. Controls the blend between semantic (vector) and keyword (BM25) retrieval.">
+	<FormSection title="Search" defaultOpen={false} description="Hybrid search tuning. Controls the blend between semantic (vector) and keyword (BM25) retrieval." dirty={isDirty}>
 		<FormField label="Alpha" description="Vector weight (0–1). At 0.9 results are heavily semantic; at 0.3 they skew toward keyword matching. Default 0.7 works well generally.">
 			<Input type="number" min="0" max="1" step="0.1" value={st.sNum(["search", "alpha"])} oninput={setNum(["search", "alpha"])} />
 		</FormField>

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/TrustSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/TrustSection.svelte
@@ -11,6 +11,11 @@ const selectContentClass =
 	"font-[family-name:var(--font-mono)] text-[11px] bg-[var(--sig-bg)] text-[var(--sig-text)] border-[var(--sig-border-strong)] rounded-none";
 const selectItemClass = "font-[family-name:var(--font-mono)] text-[11px] rounded-none";
 
+const TRUST_PATHS: string[][] = [
+	["trust", "verification"],
+	["trust", "registry"],
+];
+
 function setSelect(path: string[]) {
 	return (v: string | undefined) => {
 		st.aSetStr(path, v ?? "");
@@ -22,10 +27,12 @@ function setStr(path: string[]) {
 		st.aSetStr(path, (e.currentTarget as HTMLInputElement).value);
 	};
 }
+
+let isDirty = $derived(st.isAnyPathDirty("agent", TRUST_PATHS));
 </script>
 
 {#if st.agentFile}
-	<FormSection title="Trust" defaultOpen={false} description="Identity verification method. Controls how the agent proves its identity to peers and registries.">
+	<FormSection title="Trust" defaultOpen={false} description="Identity verification method. Controls how the agent proves its identity to peers and registries." dirty={isDirty}>
 		<FormField label="Verification" description="none = local only. erc8128 = wallet-based (recommended). gpg/did = alternative signing. registry = contract-based lookup.">
 			<Select.Root
 				type="single"

--- a/packages/cli/dashboard/src/lib/stores/settings.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/settings.svelte.ts
@@ -268,6 +268,21 @@ class SettingsStore {
 		);
 	}
 
+	isPathDirty(obj: "agent" | "config", path: string[]): boolean {
+		const current = obj === "agent" ? this.agent : this.config;
+		const snapshot = obj === "agent"
+			? JSON.parse(this.agentSnapshot)
+			: JSON.parse(this.configSnapshot);
+
+		const currentVal = JSON.stringify(this.get(current, ...path));
+		const snapshotVal = JSON.stringify(this.get(snapshot, ...path));
+		return currentVal !== snapshotVal;
+	}
+
+	isAnyPathDirty(obj: "agent" | "config", paths: string[][]): boolean {
+		return paths.some((p) => this.isPathDirty(obj, p));
+	}
+
 	async save(): Promise<void> {
 		if (!this.isDirty) {
 			this.lastSaveFeedback = "No changes to save";


### PR DESCRIPTION
## Summary
- Adds visual indicators (`•`) to section headers when they contain unsaved changes
- Helps users quickly locate modified fields in large settings forms

## Changes
- **settings.svelte.ts**: Add `isPathDirty()` and `isAnyPathDirty()` helper methods for comparing current state vs snapshot
- **FormSection.svelte**: Add optional `dirty` prop, render accent-colored dot indicator
- **All 8 section components**: Define field path arrays, compute dirty state via `$derived`, pass to FormSection

## Test plan
1. Open Settings tab in dashboard
2. Modify a field in any section (e.g., change Agent name)
3. Verify `•` appears next to that section's title
4. Modify fields in multiple sections
5. Verify each dirty section shows the indicator
6. Save settings - verify indicators clear
7. Collapse/expand sections - verify indicators persist