### PR TITLE
feat(dashboard): add keyboard shortcuts for tasks tab

### DIFF
--- a/packages/cli/dashboard/src/lib/components/tabs/TasksTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/TasksTab.svelte
@@ -17,6 +17,13 @@ import TaskDetail from "$lib/components/tasks/TaskDetail.svelte";
 
 
 function handleGlobalKey(e: KeyboardEvent) {
+	const target = e.target as HTMLElement;
+	const isInput =
+		target.tagName === "INPUT" ||
+		target.tagName === "TEXTAREA" ||
+		target.isContentEditable;
+
+	// Escape: Close modals
 	if (e.key === "Escape") {
 		if (ts.formOpen) {
 			e.preventDefault();
@@ -26,6 +33,33 @@ function handleGlobalKey(e: KeyboardEvent) {
 		if (ts.detailOpen) {
 			e.preventDefault();
 			closeDetail();
+			return;
+		}
+	}
+
+	// Don't process other shortcuts when typing in inputs or form is open
+	if (isInput || ts.formOpen) return;
+
+	// N: Create new task
+	if (e.key === "n" || e.key === "N") {
+		e.preventDefault();
+		openForm();
+		return;
+	}
+
+	// R/D require a selected task (detail panel must be open)
+	if (ts.detailOpen && ts.selectedId) {
+		// R: Trigger/Run task
+		if (e.key === "r" || e.key === "R") {
+			e.preventDefault();
+			doTrigger(ts.selectedId);
+			return;
+		}
+
+		// D: Delete task
+		if (e.key === "d" || e.key === "D") {
+			e.preventDefault();
+			doDelete(ts.selectedId);
 			return;
 		}
 	}
@@ -55,6 +89,22 @@ onMount(() => {
 			ontrigger={doTrigger}
 			ontoggle={(id, enabled) => doUpdate(id, { enabled })}
 		/>
+	</div>
+
+	<!-- Keyboard shortcuts -->
+	<div
+		class="shrink-0 px-4 py-2 border-t border-[var(--sig-border)]
+			flex items-center gap-4 text-[10px] text-[var(--sig-text-muted)]
+			font-[family-name:var(--font-mono)]"
+	>
+		<span><kbd class="px-1 py-px bg-[var(--sig-surface-raised)] border border-[var(--sig-border)]">N</kbd> New</span>
+		{#if ts.detailOpen}
+			<span><kbd class="px-1 py-px bg-[var(--sig-surface-raised)] border border-[var(--sig-border)]">R</kbd> Run</span>
+			<span><kbd class="px-1 py-px bg-[var(--sig-surface-raised)] border border-[var(--sig-border)]">D</kbd> Delete</span>
+			<span><kbd class="px-1 py-px bg-[var(--sig-surface-raised)] border border-[var(--sig-border)]">Esc</kbd> Close</span>
+		{:else if ts.formOpen}
+			<span><kbd class="px-1 py-px bg-[var(--sig-surface-raised)] border border-[var(--sig-border)]">Esc</kbd> Cancel</span>
+		{/if}
 	</div>
 </div>
 

--- a/packages/cli/dashboard/src/lib/components/tabs/TasksTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/TasksTab.svelte
@@ -97,7 +97,9 @@ onMount(() => {
 			flex items-center gap-4 text-[10px] text-[var(--sig-text-muted)]
 			font-[family-name:var(--font-mono)]"
 	>
-		<span><kbd class="px-1 py-px bg-[var(--sig-surface-raised)] border border-[var(--sig-border)]">N</kbd> New</span>
+		{#if !ts.formOpen}
+			<span><kbd class="px-1 py-px bg-[var(--sig-surface-raised)] border border-[var(--sig-border)]">N</kbd> New</span>
+		{/if}
 		{#if ts.detailOpen}
 			<span><kbd class="px-1 py-px bg-[var(--sig-surface-raised)] border border-[var(--sig-border)]">R</kbd> Run</span>
 			<span><kbd class="px-1 py-px bg-[var(--sig-surface-raised)] border border-[var(--sig-border)]">D</kbd> Delete</span>


### PR DESCRIPTION
## Summary
- Add keyboard shortcuts for common task actions
- N = new task, R = run, D = delete, Esc = close
- Contextual footer shows available shortcuts

## Changes
- Extend `handleGlobalKey` to handle N/R/D keys
- Add footer bar with `<kbd>` hints that update based on context
- Shortcuts only fire when not typing in inputs or forms

## Shortcuts

| Key | Action | Context |
|-----|--------|---------|
| `N` | New task | Always (when not in input/form) |
| `R` | Trigger task | When detail panel is open |
| `D` | Delete task | When detail panel is open |
| `Esc` | Close | Form or detail panel |

## Test plan
1. Open Tasks tab
2. Press `N` - form should open
3. Press `Esc` - form should close
4. Click a task to open detail
5. Press `R` - task should trigger
6. Press `D` - task should delete
7. Press `Esc` - detail should close
8. Verify footer shows context-aware hints
9. Verify shortcuts don't fire when typing in inputs