### PR TITLE
feat(mcp): live refresh marketplace proxy tools

### DIFF
--- a/packages/adapters/openclaw/src/index.ts
+++ b/packages/adapters/openclaw/src/index.ts
@@ -192,6 +192,31 @@ interface MarketplaceToolCatalog {
 	}>;
 }
 
+function sanitizeToolSegment(value: string): string {
+	const normalized = value
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "_")
+		.replace(/^_+|_+$/g, "");
+	return normalized.length > 0 ? normalized : "tool";
+}
+
+function buildProxyToolName(used: Set<string>, serverId: string, toolName: string): string {
+	const base = `signet_${sanitizeToolSegment(serverId)}_${sanitizeToolSegment(toolName)}`;
+	if (!used.has(base)) {
+		used.add(base);
+		return base;
+	}
+
+	let suffix = 2;
+	while (used.has(`${base}_${suffix}`)) {
+		suffix += 1;
+	}
+	const uniqueName = `${base}_${suffix}`;
+	used.add(uniqueName);
+	return uniqueName;
+}
+
 // ============================================================================
 // Shared fetch helper
 // ============================================================================
@@ -596,6 +621,77 @@ function textResult(text: string, details?: Record<string, unknown>): OpenClawTo
 	};
 }
 
+async function registerMarketplaceProxyTools(
+	api: OpenClawPluginApi,
+	options: { daemonUrl?: string },
+	knownNames: Set<string>,
+): Promise<{ registeredNow: number; total: number }> {
+	const catalog = await marketplaceToolList({ ...options, refresh: true });
+	if (!catalog || catalog.tools.length === 0) {
+		return { registeredNow: 0, total: knownNames.size };
+	}
+
+	const usedNames = new Set<string>([
+		"memory_search",
+		"memory_store",
+		"memory_get",
+		"memory_list",
+		"memory_modify",
+		"memory_forget",
+		"mcp_server_list",
+		"mcp_server_call",
+	]);
+	for (const name of knownNames) {
+		usedNames.add(name);
+	}
+
+	let registeredNow = 0;
+	for (const tool of [...catalog.tools].sort((a, b) =>
+		`${a.serverId}:${a.toolName}`.localeCompare(`${b.serverId}:${b.toolName}`),
+	)) {
+		const proxyName = buildProxyToolName(usedNames, tool.serverId, tool.toolName);
+		if (knownNames.has(proxyName)) {
+			continue;
+		}
+
+		api.registerTool(
+			{
+				name: proxyName,
+				label: `Signet ${tool.serverName} • ${tool.toolName}`,
+				description:
+					tool.description && tool.description.trim().length > 0
+						? tool.description
+						: `Proxy tool ${tool.toolName} from MCP server ${tool.serverName}`,
+				parameters: Type.Object({}, { additionalProperties: true }),
+				async execute(_toolCallId, params) {
+					const args = typeof params === "object" && params !== null ? (params as Record<string, unknown>) : {};
+
+					try {
+						const result = await marketplaceToolCall(tool.serverId, tool.toolName, args, options);
+						if (!result?.success) {
+							return textResult(`Tool server call failed: ${result?.error ?? "unknown error"}`, {
+								error: result?.error ?? "unknown",
+							});
+						}
+
+						const text = typeof result.result === "string" ? result.result : JSON.stringify(result.result, null, 2);
+						return textResult(text, { result: result.result });
+					} catch (err) {
+						return textResult(`Tool server call failed: ${String(err)}`, {
+							error: String(err),
+						});
+					}
+				},
+			},
+			{ name: proxyName },
+		);
+		knownNames.add(proxyName);
+		registeredNow += 1;
+	}
+
+	return { registeredNow, total: knownNames.size };
+}
+
 // ============================================================================
 // Plugin definition (OpenClaw register(api) pattern)
 // ============================================================================
@@ -615,6 +711,8 @@ const signetPlugin = {
 		// Instance-scoped health state (safe for multi-register)
 		let daemonReachable = true;
 		let healthTimer: ReturnType<typeof setInterval> | null = null;
+		let marketplaceProxyTimer: ReturnType<typeof setInterval> | null = null;
+		const marketplaceProxyNames = new Set<string>();
 
 		api.logger.info(`signet-memory: registered (daemon: ${daemonUrl})`);
 
@@ -990,6 +1088,24 @@ const signetPlugin = {
 			{ name: "mcp_server_call" },
 		);
 
+		const refreshMarketplaceProxyTools = (): Promise<void> =>
+			registerMarketplaceProxyTools(api, opts, marketplaceProxyNames)
+				.then((result) => {
+					if (result.registeredNow > 0) {
+						api.logger.info(
+							`signet-memory: registered ${result.registeredNow} marketplace proxy tools (${result.total} total)`,
+						);
+					}
+				})
+				.catch((error) => {
+					api.logger.warn(`signet-memory: failed to register marketplace proxy tools: ${String(error)}`);
+				});
+
+		void refreshMarketplaceProxyTools();
+		marketplaceProxyTimer = setInterval(() => {
+			void refreshMarketplaceProxyTools();
+		}, 15_000);
+
 		// ==================================================================
 		// Lifecycle hooks
 		// ==================================================================
@@ -1059,6 +1175,10 @@ const signetPlugin = {
 				if (healthTimer) {
 					clearInterval(healthTimer);
 					healthTimer = null;
+				}
+				if (marketplaceProxyTimer) {
+					clearInterval(marketplaceProxyTimer);
+					marketplaceProxyTimer = null;
 				}
 			},
 		});

--- a/packages/daemon/src/mcp-stdio.ts
+++ b/packages/daemon/src/mcp-stdio.ts
@@ -9,15 +9,30 @@
  */
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { createMcpServer } from "./mcp/tools.js";
+import { createMcpServer, refreshMarketplaceProxyTools } from "./mcp/tools.js";
 
-const DAEMON_URL = process.env.SIGNET_DAEMON_URL
-	?? `http://${process.env.SIGNET_HOST ?? "localhost"}:${process.env.SIGNET_PORT ?? "3850"}`;
+const DAEMON_URL =
+	process.env.SIGNET_DAEMON_URL ??
+	`http://${process.env.SIGNET_HOST ?? "localhost"}:${process.env.SIGNET_PORT ?? "3850"}`;
 
-const server = createMcpServer({
+const server = await createMcpServer({
 	daemonUrl: DAEMON_URL,
 	version: "0.1.0",
 });
 
 const transport = new StdioServerTransport();
 await server.connect(transport);
+
+const refreshMsRaw = Number(process.env.SIGNET_MCP_PROXY_REFRESH_MS ?? "15000");
+const refreshMs = Number.isFinite(refreshMsRaw) && refreshMsRaw >= 1000 ? refreshMsRaw : 15000;
+
+const refreshTimer = setInterval(() => {
+	void refreshMarketplaceProxyTools(server, { notify: true });
+}, refreshMs);
+
+const shutdown = () => {
+	clearInterval(refreshTimer);
+};
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);

--- a/packages/daemon/src/mcp/route.ts
+++ b/packages/daemon/src/mcp/route.ts
@@ -6,8 +6,8 @@
  * each request gets a fresh server + transport instance.
  */
 
-import type { Hono } from "hono";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import type { Hono } from "hono";
 import { createMcpServer } from "./tools.js";
 
 export function mountMcpRoute(app: Hono): void {
@@ -20,7 +20,7 @@ export function mountMcpRoute(app: Hono): void {
 			enableJsonResponse: true,
 		});
 
-		const server = createMcpServer();
+		const server = await createMcpServer();
 		await server.connect(transport);
 
 		try {

--- a/packages/daemon/src/mcp/tools.test.ts
+++ b/packages/daemon/src/mcp/tools.test.ts
@@ -6,7 +6,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { createMcpServer } from "./tools.js";
+import { createMcpServer, refreshMarketplaceProxyTools } from "./tools.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -17,17 +17,22 @@ interface RegisteredTool {
 	enabled: boolean;
 }
 
-type InternalMcpServer = McpServer & {
-	_registeredTools: Record<string, RegisteredTool>;
-};
+function getRegisteredTools(server: McpServer): Record<string, RegisteredTool> {
+	const internal = server as unknown as {
+		readonly _registeredTools?: Record<string, RegisteredTool>;
+	};
+	if (!internal._registeredTools) {
+		throw new Error("MCP server internals unavailable in test");
+	}
+	return internal._registeredTools;
+}
 
 async function callTool(
 	server: McpServer,
 	name: string,
 	args: Record<string, unknown>,
 ): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
-	const internal = server as unknown as InternalMcpServer;
-	const tool = internal._registeredTools[name];
+	const tool = getRegisteredTools(server)[name];
 	if (!tool) {
 		throw new Error(`Tool ${name} not found`);
 	}
@@ -38,8 +43,7 @@ async function callTool(
 }
 
 function getToolNames(server: McpServer): string[] {
-	const internal = server as unknown as InternalMcpServer;
-	return Object.keys(internal._registeredTools);
+	return Object.keys(getRegisteredTools(server));
 }
 
 function mockFetch(status: number, body: unknown, capture?: { url?: string; method?: string; body?: string }): void {
@@ -53,7 +57,7 @@ function mockFetch(status: number, body: unknown, capture?: { url?: string; meth
 			status,
 			headers: { "Content-Type": "application/json" },
 		});
-	}) as typeof fetch;
+	}) as unknown as typeof fetch;
 }
 
 // ---------------------------------------------------------------------------
@@ -64,10 +68,11 @@ describe("createMcpServer", () => {
 	let server: McpServer;
 	const originalFetch = globalThis.fetch;
 
-	beforeEach(() => {
-		server = createMcpServer({
+	beforeEach(async () => {
+		server = await createMcpServer({
 			daemonUrl: "http://localhost:3850",
 			version: "0.0.1-test",
+			enableMarketplaceProxyTools: false,
 		});
 	});
 
@@ -248,6 +253,174 @@ describe("createMcpServer", () => {
 			expect(body.serverId).toBe("playwright");
 			expect(body.toolName).toBe("navigate");
 			expect(body.args.url).toBe("https://example.com");
+		});
+	});
+
+	describe("marketplace proxy tools", () => {
+		it("registers dynamic proxy tools for installed MCP tools", async () => {
+			globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+				const url = typeof input === "string" ? input : input.toString();
+
+				if (url.endsWith("/api/marketplace/mcp/tools?refresh=1")) {
+					return new Response(
+						JSON.stringify({
+							count: 1,
+							servers: [
+								{
+									serverId: "dogfood-everything",
+									serverName: "dogfood-everything",
+									ok: true,
+									toolCount: 1,
+								},
+							],
+							tools: [
+								{
+									id: "dogfood-everything:echo",
+									serverId: "dogfood-everything",
+									serverName: "dogfood-everything",
+									toolName: "echo",
+									description: "Echo input text",
+									readOnly: false,
+									inputSchema: {},
+								},
+							],
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				if (url.endsWith("/api/marketplace/mcp/call")) {
+					const rawBody = typeof init?.body === "string" ? init.body : "{}";
+					const body = JSON.parse(rawBody) as Record<string, unknown>;
+					return new Response(
+						JSON.stringify({
+							success: true,
+							result: {
+								serverId: body.serverId,
+								toolName: body.toolName,
+								args: body.args,
+							},
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				return new Response(JSON.stringify({ error: "unexpected" }), {
+					status: 404,
+					headers: { "Content-Type": "application/json" },
+				});
+			}) as unknown as typeof fetch;
+
+			const dynamicServer = await createMcpServer({
+				daemonUrl: "http://localhost:3850",
+				version: "0.0.1-test",
+				enableMarketplaceProxyTools: true,
+			});
+
+			const names = getToolNames(dynamicServer);
+			expect(names).toContain("signet_dogfood_everything_echo");
+
+			const result = await callTool(dynamicServer, "signet_dogfood_everything_echo", {
+				message: "hello",
+			});
+			expect(result.isError).toBeUndefined();
+			expect(result.content[0]?.text).toContain("dogfood-everything");
+			expect(result.content[0]?.text).toContain("echo");
+		});
+
+		it("refreshes proxy tools and reports changes", async () => {
+			let stage: "initial" | "updated" = "initial";
+
+			globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+				const url = typeof input === "string" ? input : input.toString();
+
+				if (url.endsWith("/api/marketplace/mcp/tools?refresh=1")) {
+					const tools =
+						stage === "initial"
+							? [
+									{
+										id: "dogfood-everything:echo",
+										serverId: "dogfood-everything",
+										serverName: "dogfood-everything",
+										toolName: "echo",
+										description: "Echo input text",
+										readOnly: false,
+										inputSchema: {},
+									},
+								]
+							: [
+									{
+										id: "dogfood-everything:echo",
+										serverId: "dogfood-everything",
+										serverName: "dogfood-everything",
+										toolName: "echo",
+										description: "Echo input text",
+										readOnly: false,
+										inputSchema: {},
+									},
+									{
+										id: "dogfood-everything:get-sum",
+										serverId: "dogfood-everything",
+										serverName: "dogfood-everything",
+										toolName: "get-sum",
+										description: "Calculate a sum",
+										readOnly: false,
+										inputSchema: {},
+									},
+								];
+
+					return new Response(
+						JSON.stringify({
+							count: tools.length,
+							servers: [
+								{
+									serverId: "dogfood-everything",
+									serverName: "dogfood-everything",
+									ok: true,
+									toolCount: tools.length,
+								},
+							],
+							tools,
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				if (url.endsWith("/api/marketplace/mcp/call")) {
+					const rawBody = typeof init?.body === "string" ? init.body : "{}";
+					const body = JSON.parse(rawBody) as Record<string, unknown>;
+					return new Response(
+						JSON.stringify({
+							success: true,
+							result: {
+								serverId: body.serverId,
+								toolName: body.toolName,
+								args: body.args,
+							},
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				return new Response(JSON.stringify({ error: "unexpected" }), {
+					status: 404,
+					headers: { "Content-Type": "application/json" },
+				});
+			}) as unknown as typeof fetch;
+
+			const dynamicServer = await createMcpServer({
+				daemonUrl: "http://localhost:3850",
+				version: "0.0.1-test",
+				enableMarketplaceProxyTools: true,
+			});
+
+			expect(getToolNames(dynamicServer)).toContain("signet_dogfood_everything_echo");
+			expect(getToolNames(dynamicServer)).not.toContain("signet_dogfood_everything_get_sum");
+
+			stage = "updated";
+			const refresh = await refreshMarketplaceProxyTools(dynamicServer, { notify: false });
+			expect(refresh.changed).toBe(true);
+			expect(getToolNames(dynamicServer)).toContain("signet_dogfood_everything_get_sum");
 		});
 	});
 });

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -18,6 +18,31 @@ interface McpServerOptions {
 	readonly daemonUrl?: string;
 	/** Server version string */
 	readonly version?: string;
+	/** Register installed marketplace MCP tools as first-class MCP tools */
+	readonly enableMarketplaceProxyTools?: boolean;
+}
+
+interface MarketplaceRoutedTool {
+	readonly id: string;
+	readonly serverId: string;
+	readonly serverName: string;
+	readonly toolName: string;
+	readonly description: string;
+	readonly readOnly: boolean;
+	readonly inputSchema: unknown;
+}
+
+interface MarketplaceToolsResponse {
+	readonly tools: ReadonlyArray<MarketplaceRoutedTool>;
+	readonly servers: ReadonlyArray<unknown>;
+	readonly count: number;
+}
+
+interface MarketplaceProxyState {
+	baseUrl: string;
+	enabled: boolean;
+	names: Set<string>;
+	signature: string;
 }
 
 interface DaemonResponse<T> {
@@ -32,6 +57,21 @@ interface DaemonError {
 }
 
 type FetchResult<T> = DaemonResponse<T> | DaemonError;
+
+const BASE_TOOL_NAMES = new Set<string>([
+	"memory_search",
+	"memory_store",
+	"memory_get",
+	"memory_list",
+	"memory_modify",
+	"memory_forget",
+	"secret_list",
+	"secret_exec",
+	"mcp_server_list",
+	"mcp_server_call",
+]);
+
+const marketplaceProxyState = new WeakMap<McpServer, MarketplaceProxyState>();
 
 // ---------------------------------------------------------------------------
 // Internal HTTP helper
@@ -77,7 +117,7 @@ async function daemonFetch<T>(
 	}
 }
 
-function textResult(value: unknown): { content: ReadonlyArray<{ readonly type: "text"; readonly text: string }> } {
+function textResult(value: unknown): { content: Array<{ type: "text"; text: string }> } {
 	return {
 		content: [
 			{
@@ -89,7 +129,7 @@ function textResult(value: unknown): { content: ReadonlyArray<{ readonly type: "
 }
 
 function errorResult(msg: string): {
-	content: ReadonlyArray<{ readonly type: "text"; readonly text: string }>;
+	content: Array<{ type: "text"; text: string }>;
 	isError: true;
 } {
 	return {
@@ -98,17 +138,173 @@ function errorResult(msg: string): {
 	};
 }
 
+function sanitizeToolSegment(value: string): string {
+	const normalized = value
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "_")
+		.replace(/^_+|_+$/g, "");
+	return normalized.length > 0 ? normalized : "tool";
+}
+
+function buildProxyToolName(used: Set<string>, serverId: string, toolName: string): string {
+	const base = `signet_${sanitizeToolSegment(serverId)}_${sanitizeToolSegment(toolName)}`;
+	if (!used.has(base)) {
+		used.add(base);
+		return base;
+	}
+
+	let suffix = 2;
+	while (used.has(`${base}_${suffix}`)) {
+		suffix += 1;
+	}
+	const uniqueName = `${base}_${suffix}`;
+	used.add(uniqueName);
+	return uniqueName;
+}
+
+function getRegisteredToolsMap(server: McpServer): Record<string, unknown> | null {
+	const internal = server as unknown as {
+		_registeredTools?: Record<string, unknown>;
+	};
+	return internal._registeredTools ?? null;
+}
+
+function buildToolsSignature(tools: ReadonlyArray<MarketplaceRoutedTool>): string {
+	return tools
+		.map((tool) => `${tool.serverId}:${tool.toolName}:${tool.readOnly ? "ro" : "rw"}`)
+		.sort()
+		.join("|");
+}
+
+export async function refreshMarketplaceProxyTools(
+	server: McpServer,
+	options?: {
+		readonly notify?: boolean;
+	},
+): Promise<{ changed: boolean; count: number; error?: string }> {
+	const state = marketplaceProxyState.get(server);
+	if (!state || !state.enabled) {
+		return { changed: false, count: 0 };
+	}
+
+	const notify = options?.notify ?? true;
+	const registeredTools = getRegisteredToolsMap(server);
+
+	const routed = await daemonFetch<MarketplaceToolsResponse>(state.baseUrl, "/api/marketplace/mcp/tools?refresh=1", {
+		timeout: 3_000,
+	});
+
+	if (!routed.ok) {
+		return { changed: false, count: state.names.size, error: routed.error };
+	}
+
+	const tools = [...routed.data.tools].sort((a, b) =>
+		`${a.serverId}:${a.toolName}`.localeCompare(`${b.serverId}:${b.toolName}`),
+	);
+	const signature = buildToolsSignature(tools);
+	if (signature === state.signature) {
+		return { changed: false, count: tools.length };
+	}
+
+	if (registeredTools) {
+		for (const name of state.names) {
+			delete registeredTools[name];
+		}
+	}
+
+	const usedNames = new Set<string>(BASE_TOOL_NAMES);
+	if (registeredTools) {
+		for (const name of Object.keys(registeredTools)) {
+			usedNames.add(name);
+		}
+	}
+
+	const nextNames = new Set<string>();
+
+	for (const tool of tools) {
+		if (!tool.serverId || !tool.toolName) {
+			continue;
+		}
+
+		const proxyName = buildProxyToolName(usedNames, tool.serverId, tool.toolName);
+		const title = `Signet • ${tool.serverName} • ${tool.toolName}`;
+		const description =
+			tool.description && tool.description.trim().length > 0
+				? tool.description
+				: `Proxy tool ${tool.toolName} from MCP server ${tool.serverName}`;
+
+		nextNames.add(proxyName);
+
+		server.registerTool(
+			proxyName,
+			{
+				title,
+				description,
+				inputSchema: z.object({}).passthrough(),
+				annotations: { readOnlyHint: tool.readOnly },
+			},
+			async (args) => {
+				const callResult = await daemonFetch<{
+					success: boolean;
+					result?: unknown;
+					error?: string;
+				}>(state.baseUrl, "/api/marketplace/mcp/call", {
+					method: "POST",
+					body: {
+						serverId: tool.serverId,
+						toolName: tool.toolName,
+						args,
+					},
+					timeout: 60_000,
+				});
+
+				if (!callResult.ok) {
+					return errorResult(`Tool server call failed: ${callResult.error}`);
+				}
+
+				if (!callResult.data.success) {
+					return errorResult(`Tool server call failed: ${callResult.data.error ?? "unknown error"}`);
+				}
+
+				return textResult(callResult.data.result ?? { success: true });
+			},
+		);
+	}
+
+	state.names = nextNames;
+	state.signature = signature;
+
+	if (notify) {
+		try {
+			server.sendToolListChanged();
+		} catch {
+			// ignore notification errors for transports that do not support it yet
+		}
+	}
+
+	return { changed: true, count: tools.length };
+}
+
 // ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
 
-export function createMcpServer(opts?: McpServerOptions): McpServer {
+export async function createMcpServer(opts?: McpServerOptions): Promise<McpServer> {
 	const baseUrl = opts?.daemonUrl ?? "http://localhost:3850";
 	const version = opts?.version ?? "0.1.0";
+	const enableMarketplaceProxyTools = opts?.enableMarketplaceProxyTools ?? true;
 
 	const server = new McpServer({
 		name: "signet",
 		version,
+	});
+
+	marketplaceProxyState.set(server, {
+		baseUrl,
+		enabled: enableMarketplaceProxyTools,
+		names: new Set<string>(),
+		signature: "",
 	});
 
 	// ------------------------------------------------------------------
@@ -373,6 +569,10 @@ export function createMcpServer(opts?: McpServerOptions): McpServer {
 			}),
 		},
 		async ({ refresh }) => {
+			if (refresh && enableMarketplaceProxyTools) {
+				await refreshMarketplaceProxyTools(server, { notify: true });
+			}
+
 			const path = refresh ? "/api/marketplace/mcp/tools?refresh=1" : "/api/marketplace/mcp/tools";
 			const result = await daemonFetch<{
 				count: number;
@@ -431,6 +631,10 @@ export function createMcpServer(opts?: McpServerOptions): McpServer {
 			return textResult(result.data.result ?? { success: true });
 		},
 	);
+
+	if (enableMarketplaceProxyTools) {
+		await refreshMarketplaceProxyTools(server, { notify: false });
+	}
 
 	return server;
 }


### PR DESCRIPTION
## Summary
- expose installed Marketplace MCP tools as first-class Signet MCP tools (`signet_<server>_<tool>`) and add runtime refresh support without requiring daemon/session restart
- add `refreshMarketplaceProxyTools()` in the daemon MCP server, wire it into `mcp_server_list(refresh=true)`, and send MCP tool-list-changed notifications when proxy tools change
- update MCP entrypoints (`/mcp` route and stdio server) to support async MCP server creation and periodic proxy refresh for stdio sessions
- update OpenClaw adapter to register dynamic marketplace proxy tools on an interval so newly enabled server tools appear as plugin tools during long-running sessions
- add tests covering dynamic proxy registration and refresh behavior

## Testing
- `bun test src/mcp/tools.test.ts src/routes/marketplace.test.ts` (in `packages/daemon`)
- `bun run build` (in `packages/daemon`)
- `bun run build` (in `packages/adapters/openclaw`)
- runtime smoke script against local daemon: enable server -> refresh removes/adds dynamic proxy tools as expected