### PR TITLE
feat(mcp): add scoped search-driven tool exposure

### DIFF
--- a/packages/adapters/openclaw/src/index.ts
+++ b/packages/adapters/openclaw/src/index.ts
@@ -192,6 +192,20 @@ interface MarketplaceToolCatalog {
 	}>;
 }
 
+interface MarketplaceContextOptions {
+	readonly daemonUrl?: string;
+	readonly harness?: string;
+	readonly workspace?: string;
+	readonly channel?: string;
+}
+
+interface MarketplaceExposurePolicy {
+	readonly mode: "compact" | "hybrid" | "expanded";
+	readonly maxExpandedTools: number;
+	readonly maxSearchResults: number;
+	readonly updatedAt: string;
+}
+
 function sanitizeToolSegment(value: string): string {
 	const normalized = value
 		.trim()
@@ -532,13 +546,16 @@ export async function memoryForget(
 }
 
 export async function marketplaceToolList(
-	options: {
-		daemonUrl?: string;
-		refresh?: boolean;
-	} = {},
+	options: MarketplaceContextOptions & { refresh?: boolean } = {},
 ): Promise<MarketplaceToolCatalog | null> {
 	const daemonUrl = options.daemonUrl || DEFAULT_DAEMON_URL;
-	const path = options.refresh ? "/api/marketplace/mcp/tools?refresh=1" : "/api/marketplace/mcp/tools";
+	const params = new URLSearchParams();
+	if (options.refresh) params.set("refresh", "1");
+	if (options.harness) params.set("harness", options.harness);
+	if (options.workspace) params.set("workspace", options.workspace);
+	if (options.channel) params.set("channel", options.channel);
+	const query = params.toString();
+	const path = `/api/marketplace/mcp/tools${query.length > 0 ? `?${query}` : ""}`;
 	return daemonFetch<MarketplaceToolCatalog>(daemonUrl, path, {
 		timeout: READ_TIMEOUT,
 	});
@@ -548,12 +565,16 @@ export async function marketplaceToolCall(
 	serverId: string,
 	toolName: string,
 	args: Record<string, unknown>,
-	options: {
-		daemonUrl?: string;
-	} = {},
+	options: MarketplaceContextOptions = {},
 ): Promise<{ success: boolean; result?: unknown; error?: string } | null> {
 	const daemonUrl = options.daemonUrl || DEFAULT_DAEMON_URL;
-	return daemonFetch<{ success: boolean; result?: unknown; error?: string }>(daemonUrl, "/api/marketplace/mcp/call", {
+	const params = new URLSearchParams();
+	if (options.harness) params.set("harness", options.harness);
+	if (options.workspace) params.set("workspace", options.workspace);
+	if (options.channel) params.set("channel", options.channel);
+	const query = params.toString();
+	const path = `/api/marketplace/mcp/call${query.length > 0 ? `?${query}` : ""}`;
+	return daemonFetch<{ success: boolean; result?: unknown; error?: string }>(daemonUrl, path, {
 		method: "POST",
 		body: {
 			serverId,
@@ -562,6 +583,19 @@ export async function marketplaceToolCall(
 		},
 		timeout: WRITE_TIMEOUT,
 	});
+}
+
+async function getMarketplaceExposurePolicy(
+	options: MarketplaceContextOptions = {},
+): Promise<MarketplaceExposurePolicy | null> {
+	const daemonUrl = options.daemonUrl || DEFAULT_DAEMON_URL;
+	const result = await daemonFetch<{ policy?: MarketplaceExposurePolicy }>(daemonUrl, "/api/marketplace/mcp/policy", {
+		timeout: READ_TIMEOUT,
+	});
+	if (!result?.policy) {
+		return null;
+	}
+	return result.policy;
 }
 
 // ============================================================================
@@ -623,13 +657,29 @@ function textResult(text: string, details?: Record<string, unknown>): OpenClawTo
 
 async function registerMarketplaceProxyTools(
 	api: OpenClawPluginApi,
-	options: { daemonUrl?: string },
+	options: MarketplaceContextOptions,
 	knownNames: Set<string>,
 ): Promise<{ registeredNow: number; total: number }> {
-	const catalog = await marketplaceToolList({ ...options, refresh: true });
+	const [catalog, policy] = await Promise.all([
+		marketplaceToolList({ ...options, refresh: true }),
+		getMarketplaceExposurePolicy(options),
+	]);
 	if (!catalog || catalog.tools.length === 0) {
 		return { registeredNow: 0, total: knownNames.size };
 	}
+
+	const mode = policy?.mode ?? "hybrid";
+	const maxExpandedTools =
+		typeof policy?.maxExpandedTools === "number" && Number.isFinite(policy.maxExpandedTools)
+			? Math.max(0, Math.min(100, Math.round(policy.maxExpandedTools)))
+			: 12;
+
+	const sortedTools = [...catalog.tools].sort((a, b) =>
+		`${a.serverId}:${a.toolName}`.localeCompare(`${b.serverId}:${b.toolName}`),
+	);
+
+	const candidates =
+		mode === "expanded" ? sortedTools : mode === "hybrid" ? sortedTools.slice(0, maxExpandedTools) : [];
 
 	const usedNames = new Set<string>([
 		"memory_search",
@@ -646,9 +696,7 @@ async function registerMarketplaceProxyTools(
 	}
 
 	let registeredNow = 0;
-	for (const tool of [...catalog.tools].sort((a, b) =>
-		`${a.serverId}:${a.toolName}`.localeCompare(`${b.serverId}:${b.toolName}`),
-	)) {
+	for (const tool of candidates) {
 		const proxyName = buildProxyToolName(usedNames, tool.serverId, tool.toolName);
 		if (knownNames.has(proxyName)) {
 			continue;
@@ -706,7 +754,12 @@ const signetPlugin = {
 	register(api: OpenClawPluginApi): void {
 		const cfg = signetConfigSchema.parse(api.pluginConfig);
 		const daemonUrl = cfg.daemonUrl || DEFAULT_DAEMON_URL;
-		const opts = { daemonUrl };
+		const opts = {
+			daemonUrl,
+			harness: "openclaw",
+			workspace: process.env.SIGNET_WORKSPACE ?? process.cwd(),
+			channel: process.env.SIGNET_CHANNEL,
+		};
 
 		// Instance-scoped health state (safe for multi-register)
 		let daemonReachable = true;

--- a/packages/daemon/src/mcp-stdio.ts
+++ b/packages/daemon/src/mcp-stdio.ts
@@ -18,6 +18,11 @@ const DAEMON_URL =
 const server = await createMcpServer({
 	daemonUrl: DAEMON_URL,
 	version: "0.1.0",
+	context: {
+		harness: process.env.SIGNET_HARNESS,
+		workspace: process.env.SIGNET_WORKSPACE ?? process.cwd(),
+		channel: process.env.SIGNET_CHANNEL,
+	},
 });
 
 const transport = new StdioServerTransport();

--- a/packages/daemon/src/mcp/route.ts
+++ b/packages/daemon/src/mcp/route.ts
@@ -20,7 +20,17 @@ export function mountMcpRoute(app: Hono): void {
 			enableJsonResponse: true,
 		});
 
-		const server = await createMcpServer();
+		const harness = c.req.query("harness") ?? c.req.header("x-signet-harness") ?? undefined;
+		const workspace = c.req.query("workspace") ?? c.req.header("x-signet-workspace") ?? undefined;
+		const channel = c.req.query("channel") ?? c.req.header("x-signet-channel") ?? undefined;
+
+		const server = await createMcpServer({
+			context: {
+				harness,
+				workspace,
+				channel,
+			},
+		});
 		await server.connect(transport);
 
 		try {

--- a/packages/daemon/src/mcp/tools.test.ts
+++ b/packages/daemon/src/mcp/tools.test.ts
@@ -94,10 +94,17 @@ describe("createMcpServer", () => {
 		expect(names).toContain("memory_modify");
 		expect(names).toContain("memory_forget");
 		expect(names).toContain("mcp_server_list");
+		expect(names).toContain("mcp_server_search");
 		expect(names).toContain("mcp_server_call");
+		expect(names).toContain("mcp_server_enable");
+		expect(names).toContain("mcp_server_disable");
+		expect(names).toContain("mcp_server_scope_get");
+		expect(names).toContain("mcp_server_scope_set");
+		expect(names).toContain("mcp_server_policy_get");
+		expect(names).toContain("mcp_server_policy_set");
 		expect(names).toContain("secret_list");
 		expect(names).toContain("secret_exec");
-		expect(names.length).toBe(10);
+		expect(names.length).toBe(17);
 	});
 
 	describe("memory_search", () => {
@@ -253,6 +260,56 @@ describe("createMcpServer", () => {
 			expect(body.serverId).toBe("playwright");
 			expect(body.toolName).toBe("navigate");
 			expect(body.args.url).toBe("https://example.com");
+		});
+	});
+
+	describe("mcp management tools", () => {
+		it("mcp_server_search calls search endpoint", async () => {
+			const cap: { url?: string } = {};
+			mockFetch(200, { query: "sum", count: 1, results: [] }, cap);
+
+			await callTool(server, "mcp_server_search", {
+				query: "sum",
+				limit: 3,
+				refresh: true,
+				promote: false,
+			});
+
+			expect(cap.url).toContain("/api/marketplace/mcp/search?");
+			expect(cap.url).toContain("q=sum");
+			expect(cap.url).toContain("limit=3");
+			expect(cap.url).toContain("refresh=1");
+		});
+
+		it("mcp_server_enable patches enabled=true", async () => {
+			const cap: { method?: string; body?: string; url?: string } = {};
+			mockFetch(200, { success: true }, cap);
+
+			await callTool(server, "mcp_server_enable", {
+				server_id: "dogfood-everything",
+			});
+
+			expect(cap.method).toBe("PATCH");
+			expect(cap.url).toContain("/api/marketplace/mcp/dogfood-everything");
+			const body = JSON.parse(cap.body ?? "{}");
+			expect(body.enabled).toBe(true);
+		});
+
+		it("mcp_server_policy_set maps policy fields", async () => {
+			const cap: { method?: string; body?: string } = {};
+			mockFetch(200, { success: true, policy: { mode: "compact" } }, cap);
+
+			await callTool(server, "mcp_server_policy_set", {
+				mode: "compact",
+				max_expanded_tools: 5,
+				max_search_results: 4,
+			});
+
+			expect(cap.method).toBe("PATCH");
+			const body = JSON.parse(cap.body ?? "{}");
+			expect(body.mode).toBe("compact");
+			expect(body.maxExpandedTools).toBe(5);
+			expect(body.maxSearchResults).toBe(4);
 		});
 	});
 

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -20,6 +20,12 @@ interface McpServerOptions {
 	readonly version?: string;
 	/** Register installed marketplace MCP tools as first-class MCP tools */
 	readonly enableMarketplaceProxyTools?: boolean;
+	/** Optional scope context used for marketplace filtering */
+	readonly context?: {
+		readonly harness?: string;
+		readonly workspace?: string;
+		readonly channel?: string;
+	};
 }
 
 interface MarketplaceRoutedTool {
@@ -38,11 +44,52 @@ interface MarketplaceToolsResponse {
 	readonly count: number;
 }
 
+interface MarketplaceServerRecord {
+	readonly id: string;
+	readonly name: string;
+	readonly enabled: boolean;
+	readonly source: string;
+	readonly scope: {
+		readonly harnesses: readonly string[];
+		readonly workspaces: readonly string[];
+		readonly channels: readonly string[];
+	};
+}
+
+interface MarketplaceServersResponse {
+	readonly servers: ReadonlyArray<MarketplaceServerRecord>;
+	readonly count: number;
+}
+
+interface MarketplaceSearchResponse {
+	readonly query: string;
+	readonly count: number;
+	readonly results: ReadonlyArray<MarketplaceRoutedTool>;
+}
+
+interface MarketplacePolicy {
+	readonly mode: "compact" | "hybrid" | "expanded";
+	readonly maxExpandedTools: number;
+	readonly maxSearchResults: number;
+	readonly updatedAt: string;
+}
+
+interface MarketplacePolicyResponse {
+	readonly policy: MarketplacePolicy;
+}
+
 interface MarketplaceProxyState {
 	baseUrl: string;
 	enabled: boolean;
 	names: Set<string>;
 	signature: string;
+	context: {
+		readonly harness?: string;
+		readonly workspace?: string;
+		readonly channel?: string;
+	};
+	policy: MarketplacePolicy;
+	contextKey: string;
 }
 
 interface DaemonResponse<T> {
@@ -69,9 +116,19 @@ const BASE_TOOL_NAMES = new Set<string>([
 	"secret_exec",
 	"mcp_server_list",
 	"mcp_server_call",
+	"mcp_server_search",
+	"mcp_server_enable",
+	"mcp_server_disable",
+	"mcp_server_scope_get",
+	"mcp_server_scope_set",
+	"mcp_server_policy_get",
+	"mcp_server_policy_set",
 ]);
 
 const marketplaceProxyState = new WeakMap<McpServer, MarketplaceProxyState>();
+const hotToolIdsByContext = new Map<string, Set<string>>();
+const hotToolTouchedAt = new Map<string, number>();
+const HOT_CONTEXT_TTL_MS = 30 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // Internal HTTP helper
@@ -177,6 +234,128 @@ function buildToolsSignature(tools: ReadonlyArray<MarketplaceRoutedTool>): strin
 		.join("|");
 }
 
+function normalizeContextValue(value: string | undefined): string | undefined {
+	if (!value) return undefined;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeContext(context: McpServerOptions["context"]): {
+	harness?: string;
+	workspace?: string;
+	channel?: string;
+} {
+	return {
+		harness: normalizeContextValue(context?.harness),
+		workspace: normalizeContextValue(context?.workspace),
+		channel: normalizeContextValue(context?.channel),
+	};
+}
+
+function buildContextKey(context: { harness?: string; workspace?: string; channel?: string }): string {
+	return `${context.harness ?? "*"}|${context.workspace ?? "*"}|${context.channel ?? "*"}`;
+}
+
+function appendMarketplaceContext(
+	path: string,
+	context: { harness?: string; workspace?: string; channel?: string },
+): string {
+	const params = new URLSearchParams();
+	if (context.harness) params.set("harness", context.harness);
+	if (context.workspace) params.set("workspace", context.workspace);
+	if (context.channel) params.set("channel", context.channel);
+
+	if (params.size === 0) {
+		return path;
+	}
+	const separator = path.includes("?") ? "&" : "?";
+	return `${path}${separator}${params.toString()}`;
+}
+
+function cleanupHotContextCache(): void {
+	const now = Date.now();
+	for (const [key, touchedAt] of hotToolTouchedAt.entries()) {
+		if (now - touchedAt <= HOT_CONTEXT_TTL_MS) continue;
+		hotToolTouchedAt.delete(key);
+		hotToolIdsByContext.delete(key);
+	}
+}
+
+function getHotToolSet(contextKey: string): Set<string> {
+	cleanupHotContextCache();
+	const existing = hotToolIdsByContext.get(contextKey);
+	if (existing) {
+		hotToolTouchedAt.set(contextKey, Date.now());
+		return existing;
+	}
+	const created = new Set<string>();
+	hotToolIdsByContext.set(contextKey, created);
+	hotToolTouchedAt.set(contextKey, Date.now());
+	return created;
+}
+
+function trimHotToolSet(hotSet: Set<string>, max = 500): void {
+	if (hotSet.size <= max) return;
+	for (const value of hotSet) {
+		hotSet.delete(value);
+		if (hotSet.size <= max) break;
+	}
+}
+
+function selectToolsByPolicy(
+	tools: readonly MarketplaceRoutedTool[],
+	state: MarketplaceProxyState,
+): MarketplaceRoutedTool[] {
+	if (state.policy.mode === "expanded") {
+		return [...tools];
+	}
+
+	const hot = getHotToolSet(state.contextKey);
+	const ordered = [...tools].sort((a, b) => `${a.serverId}:${a.toolName}`.localeCompare(`${b.serverId}:${b.toolName}`));
+	const hotFirst = ordered.filter((tool) => hot.has(tool.id));
+
+	if (state.policy.mode === "compact") {
+		return hotFirst.slice(0, state.policy.maxSearchResults);
+	}
+
+	const max = Math.max(0, state.policy.maxExpandedTools);
+	if (max === 0) {
+		return [];
+	}
+
+	const selected: MarketplaceRoutedTool[] = [];
+	const seen = new Set<string>();
+	for (const tool of hotFirst) {
+		if (seen.has(tool.id)) continue;
+		selected.push(tool);
+		seen.add(tool.id);
+		if (selected.length >= max) {
+			return selected;
+		}
+	}
+
+	for (const tool of ordered) {
+		if (seen.has(tool.id)) continue;
+		selected.push(tool);
+		seen.add(tool.id);
+		if (selected.length >= max) {
+			break;
+		}
+	}
+
+	return selected;
+}
+
+async function fetchMarketplacePolicy(baseUrl: string): Promise<MarketplacePolicy | null> {
+	const result = await daemonFetch<MarketplacePolicyResponse>(baseUrl, "/api/marketplace/mcp/policy", {
+		timeout: 3_000,
+	});
+	if (!result.ok) {
+		return null;
+	}
+	return result.data.policy;
+}
+
 export async function refreshMarketplaceProxyTools(
 	server: McpServer,
 	options?: {
@@ -190,18 +369,24 @@ export async function refreshMarketplaceProxyTools(
 
 	const notify = options?.notify ?? true;
 	const registeredTools = getRegisteredToolsMap(server);
+	const policy = await fetchMarketplacePolicy(state.baseUrl);
+	if (policy) {
+		state.policy = policy;
+	}
 
-	const routed = await daemonFetch<MarketplaceToolsResponse>(state.baseUrl, "/api/marketplace/mcp/tools?refresh=1", {
-		timeout: 3_000,
-	});
+	const routed = await daemonFetch<MarketplaceToolsResponse>(
+		state.baseUrl,
+		appendMarketplaceContext("/api/marketplace/mcp/tools?refresh=1", state.context),
+		{
+			timeout: 3_000,
+		},
+	);
 
 	if (!routed.ok) {
 		return { changed: false, count: state.names.size, error: routed.error };
 	}
 
-	const tools = [...routed.data.tools].sort((a, b) =>
-		`${a.serverId}:${a.toolName}`.localeCompare(`${b.serverId}:${b.toolName}`),
-	);
+	const tools = selectToolsByPolicy(routed.data.tools, state);
 	const signature = buildToolsSignature(tools);
 	if (signature === state.signature) {
 		return { changed: false, count: tools.length };
@@ -249,7 +434,7 @@ export async function refreshMarketplaceProxyTools(
 					success: boolean;
 					result?: unknown;
 					error?: string;
-				}>(state.baseUrl, "/api/marketplace/mcp/call", {
+				}>(state.baseUrl, appendMarketplaceContext("/api/marketplace/mcp/call", state.context), {
 					method: "POST",
 					body: {
 						serverId: tool.serverId,
@@ -283,7 +468,7 @@ export async function refreshMarketplaceProxyTools(
 		}
 	}
 
-	return { changed: true, count: tools.length };
+	return { changed: true, count: routed.data.tools.length };
 }
 
 // ---------------------------------------------------------------------------
@@ -294,6 +479,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 	const baseUrl = opts?.daemonUrl ?? "http://localhost:3850";
 	const version = opts?.version ?? "0.1.0";
 	const enableMarketplaceProxyTools = opts?.enableMarketplaceProxyTools ?? true;
+	const context = normalizeContext(opts?.context);
+	const contextKey = buildContextKey(context);
 
 	const server = new McpServer({
 		name: "signet",
@@ -305,6 +492,14 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		enabled: enableMarketplaceProxyTools,
 		names: new Set<string>(),
 		signature: "",
+		context,
+		contextKey,
+		policy: {
+			mode: "hybrid",
+			maxExpandedTools: 12,
+			maxSearchResults: 8,
+			updatedAt: new Date(0).toISOString(),
+		},
 	});
 
 	// ------------------------------------------------------------------
@@ -559,6 +754,13 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 	// ------------------------------------------------------------------
 	// mcp_server_list — list routed marketplace MCP tools
 	// ------------------------------------------------------------------
+	const proxyState = marketplaceProxyState.get(server);
+	if (!proxyState) {
+		throw new Error("marketplace proxy state not initialized");
+	}
+
+	const contextPath = (path: string): string => appendMarketplaceContext(path, proxyState.context);
+
 	server.registerTool(
 		"mcp_server_list",
 		{
@@ -578,12 +780,252 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 				count: number;
 				tools: unknown[];
 				servers: unknown[];
-			}>(baseUrl, path);
+				policy?: MarketplacePolicy;
+			}>(baseUrl, contextPath(path));
 
 			if (!result.ok) {
 				return errorResult(`Tool server list failed: ${result.error}`);
 			}
 
+			return textResult(result.data);
+		},
+	);
+
+	server.registerTool(
+		"mcp_server_search",
+		{
+			title: "Search Tool Servers",
+			description:
+				"Search routed MCP tools with lightweight matching and optionally promote matches into first-class tools.",
+			inputSchema: z.object({
+				query: z.string().min(2).describe("Search query text"),
+				limit: z.number().optional().describe("Max results to return"),
+				refresh: z.boolean().optional().describe("Refresh tool catalog before searching"),
+				promote: z
+					.boolean()
+					.optional()
+					.describe("Promote matches into expanded tool list (default true)")
+					.default(true),
+			}),
+		},
+		async ({ query, limit, refresh, promote }) => {
+			const searchPath = new URLSearchParams();
+			searchPath.set("q", query);
+			if (typeof limit === "number" && Number.isFinite(limit)) {
+				searchPath.set("limit", String(Math.max(1, Math.min(50, Math.round(limit)))));
+			}
+			if (refresh) {
+				searchPath.set("refresh", "1");
+			}
+
+			const result = await daemonFetch<MarketplaceSearchResponse>(
+				baseUrl,
+				contextPath(`/api/marketplace/mcp/search?${searchPath.toString()}`),
+			);
+
+			if (!result.ok) {
+				return errorResult(`Tool server search failed: ${result.error}`);
+			}
+
+			const shouldPromote = promote !== false;
+			if (shouldPromote && enableMarketplaceProxyTools) {
+				const hotSet = getHotToolSet(proxyState.contextKey);
+				for (const tool of result.data.results) {
+					hotSet.add(tool.id);
+				}
+				trimHotToolSet(hotSet);
+				hotToolTouchedAt.set(proxyState.contextKey, Date.now());
+				await refreshMarketplaceProxyTools(server, { notify: true });
+			}
+
+			return textResult({
+				query: result.data.query,
+				count: result.data.count,
+				results: result.data.results,
+				promoted: shouldPromote,
+				mode: proxyState.policy.mode,
+				maxExpandedTools: proxyState.policy.maxExpandedTools,
+			});
+		},
+	);
+
+	server.registerTool(
+		"mcp_server_enable",
+		{
+			title: "Enable Tool Server",
+			description: "Enable an installed MCP server for the current scope context.",
+			inputSchema: z.object({
+				server_id: z.string().describe("Installed Tool Server id"),
+			}),
+			annotations: { readOnlyHint: false },
+		},
+		async ({ server_id }) => {
+			const result = await daemonFetch<{ success: boolean; server?: unknown; error?: string }>(
+				baseUrl,
+				contextPath(`/api/marketplace/mcp/${encodeURIComponent(server_id)}`),
+				{
+					method: "PATCH",
+					body: { enabled: true },
+				},
+			);
+
+			if (!result.ok) {
+				return errorResult(`Enable failed: ${result.error}`);
+			}
+			if (enableMarketplaceProxyTools) {
+				await refreshMarketplaceProxyTools(server, { notify: true });
+			}
+			return textResult(result.data);
+		},
+	);
+
+	server.registerTool(
+		"mcp_server_disable",
+		{
+			title: "Disable Tool Server",
+			description: "Disable an installed MCP server for the current scope context.",
+			inputSchema: z.object({
+				server_id: z.string().describe("Installed Tool Server id"),
+			}),
+			annotations: { readOnlyHint: false },
+		},
+		async ({ server_id }) => {
+			const result = await daemonFetch<{ success: boolean; server?: unknown; error?: string }>(
+				baseUrl,
+				contextPath(`/api/marketplace/mcp/${encodeURIComponent(server_id)}`),
+				{
+					method: "PATCH",
+					body: { enabled: false },
+				},
+			);
+
+			if (!result.ok) {
+				return errorResult(`Disable failed: ${result.error}`);
+			}
+			if (enableMarketplaceProxyTools) {
+				await refreshMarketplaceProxyTools(server, { notify: true });
+			}
+			return textResult(result.data);
+		},
+	);
+
+	server.registerTool(
+		"mcp_server_scope_get",
+		{
+			title: "Get Tool Server Scope",
+			description: "Inspect scope rules for one server or all installed servers.",
+			inputSchema: z.object({
+				server_id: z.string().optional().describe("Optional server id"),
+			}),
+		},
+		async ({ server_id }) => {
+			if (server_id) {
+				const result = await daemonFetch<{ server: MarketplaceServerRecord }>(
+					baseUrl,
+					contextPath(`/api/marketplace/mcp/${encodeURIComponent(server_id)}`),
+				);
+				if (!result.ok) {
+					return errorResult(`Scope get failed: ${result.error}`);
+				}
+				return textResult(result.data);
+			}
+
+			const result = await daemonFetch<MarketplaceServersResponse>(
+				baseUrl,
+				contextPath("/api/marketplace/mcp?scoped=0"),
+			);
+			if (!result.ok) {
+				return errorResult(`Scope list failed: ${result.error}`);
+			}
+			return textResult(result.data);
+		},
+	);
+
+	server.registerTool(
+		"mcp_server_scope_set",
+		{
+			title: "Set Tool Server Scope",
+			description: "Set harness/workspace/channel scope for an installed MCP server.",
+			inputSchema: z.object({
+				server_id: z.string().describe("Installed Tool Server id"),
+				harnesses: z.array(z.string()).optional().describe("Allowed harness names"),
+				workspaces: z.array(z.string()).optional().describe("Allowed workspace paths"),
+				channels: z.array(z.string()).optional().describe("Allowed channel ids"),
+			}),
+			annotations: { readOnlyHint: false },
+		},
+		async ({ server_id, harnesses, workspaces, channels }) => {
+			const result = await daemonFetch<{ success: boolean; server?: unknown; error?: string }>(
+				baseUrl,
+				contextPath(`/api/marketplace/mcp/${encodeURIComponent(server_id)}`),
+				{
+					method: "PATCH",
+					body: {
+						scope: {
+							harnesses: harnesses ?? [],
+							workspaces: workspaces ?? [],
+							channels: channels ?? [],
+						},
+					},
+				},
+			);
+			if (!result.ok) {
+				return errorResult(`Scope set failed: ${result.error}`);
+			}
+			if (enableMarketplaceProxyTools) {
+				await refreshMarketplaceProxyTools(server, { notify: true });
+			}
+			return textResult(result.data);
+		},
+	);
+
+	server.registerTool(
+		"mcp_server_policy_get",
+		{
+			title: "Get MCP Exposure Policy",
+			description: "Get compact/hybrid/expanded exposure policy for dynamic tool expansion.",
+			inputSchema: z.object({}),
+		},
+		async () => {
+			const result = await daemonFetch<MarketplacePolicyResponse>(baseUrl, "/api/marketplace/mcp/policy");
+			if (!result.ok) {
+				return errorResult(`Policy get failed: ${result.error}`);
+			}
+			return textResult(result.data);
+		},
+	);
+
+	server.registerTool(
+		"mcp_server_policy_set",
+		{
+			title: "Set MCP Exposure Policy",
+			description: "Update compact/hybrid/expanded policy and expansion limits.",
+			inputSchema: z.object({
+				mode: z.enum(["compact", "hybrid", "expanded"]).optional(),
+				max_expanded_tools: z.number().optional(),
+				max_search_results: z.number().optional(),
+			}),
+			annotations: { readOnlyHint: false },
+		},
+		async ({ mode, max_expanded_tools, max_search_results }) => {
+			const result = await daemonFetch<{ success: boolean; policy?: MarketplacePolicy; error?: string }>(
+				baseUrl,
+				"/api/marketplace/mcp/policy",
+				{
+					method: "PATCH",
+					body: {
+						mode,
+						maxExpandedTools: max_expanded_tools,
+						maxSearchResults: max_search_results,
+					},
+				},
+			);
+			if (!result.ok) {
+				return errorResult(`Policy set failed: ${result.error}`);
+			}
+			if (enableMarketplaceProxyTools) {
+				await refreshMarketplaceProxyTools(server, { notify: true });
+			}
 			return textResult(result.data);
 		},
 	);
@@ -610,7 +1052,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 				success: boolean;
 				result?: unknown;
 				error?: string;
-			}>(baseUrl, "/api/marketplace/mcp/call", {
+			}>(baseUrl, contextPath("/api/marketplace/mcp/call"), {
 				method: "POST",
 				body: {
 					serverId: server_id,

--- a/packages/daemon/src/routes/marketplace.ts
+++ b/packages/daemon/src/routes/marketplace.ts
@@ -21,6 +21,26 @@ const TOOLS_TTL_MS = 30 * 1000;
 
 export type MarketplaceMcpTransport = "stdio" | "http";
 export type MarketplaceMcpCatalogSource = "mcpservers.org" | "modelcontextprotocol/servers";
+export type MarketplaceMcpExposureMode = "compact" | "hybrid" | "expanded";
+
+export interface MarketplaceMcpScope {
+	readonly harnesses: readonly string[];
+	readonly workspaces: readonly string[];
+	readonly channels: readonly string[];
+}
+
+export interface MarketplaceMcpExposurePolicy {
+	readonly mode: MarketplaceMcpExposureMode;
+	readonly maxExpandedTools: number;
+	readonly maxSearchResults: number;
+	readonly updatedAt: string;
+}
+
+export interface MarketplaceMcpScopeContext {
+	readonly harness?: string;
+	readonly workspace?: string;
+	readonly channel?: string;
+}
 
 export interface MarketplaceMcpConfigStdio {
 	readonly transport: "stdio";
@@ -50,6 +70,7 @@ export interface InstalledMarketplaceMcpServer {
 	readonly homepage?: string;
 	readonly official: boolean;
 	readonly enabled: boolean;
+	readonly scope: MarketplaceMcpScope;
 	readonly config: MarketplaceMcpConfig;
 	readonly installedAt: string;
 	readonly updatedAt: string;
@@ -106,13 +127,19 @@ interface DetailConfig {
 
 const DEFAULT_TIMEOUT_MS = 20_000;
 const SECRET_REF_PREFIX = "secret://";
+const DEFAULT_EXPOSURE_POLICY: MarketplaceMcpExposurePolicy = {
+	mode: "hybrid",
+	maxExpandedTools: 12,
+	maxSearchResults: 8,
+	updatedAt: new Date(0).toISOString(),
+};
 
 const catalogCache = new Map<number, { fetchedAt: number; page: ParsedCatalogPage }>();
 let referenceCatalogCache: {
 	readonly fetchedAt: number;
 	readonly entries: readonly MarketplaceMcpCatalogEntry[];
 } | null = null;
-let toolsCache: MarketplaceToolsCache | null = null;
+const toolsCache = new Map<string, MarketplaceToolsCache>();
 
 function getAgentsDir(): string {
 	return process.env.SIGNET_PATH || join(homedir(), ".agents");
@@ -124,6 +151,10 @@ function getMarketplaceDir(): string {
 
 function getInstalledMcpPath(): string {
 	return join(getMarketplaceDir(), "mcp-servers.json");
+}
+
+function getExposurePolicyPath(): string {
+	return join(getMarketplaceDir(), "mcp-policy.json");
 }
 
 function ensureMarketplaceDir(): void {
@@ -149,6 +180,173 @@ function toStringRecord(value: unknown): Record<string, string> {
 function toStringArray(value: unknown): string[] {
 	if (!Array.isArray(value)) return [];
 	return value.filter((v): v is string => typeof v === "string");
+}
+
+function normalizeScopeValues(values: unknown): string[] {
+	const seen = new Set<string>();
+	const normalized: string[] = [];
+	for (const value of toStringArray(values)) {
+		const item = value.trim();
+		if (item.length === 0) continue;
+		const key = item.toLowerCase();
+		if (seen.has(key)) continue;
+		seen.add(key);
+		normalized.push(item);
+	}
+	return normalized;
+}
+
+function normalizeScope(value: unknown): MarketplaceMcpScope {
+	if (!isRecord(value)) {
+		return {
+			harnesses: [],
+			workspaces: [],
+			channels: [],
+		};
+	}
+
+	return {
+		harnesses: normalizeScopeValues(value.harnesses),
+		workspaces: normalizeScopeValues(value.workspaces),
+		channels: normalizeScopeValues(value.channels),
+	};
+}
+
+function normalizeScopeContextValue(value: string | undefined): string | undefined {
+	if (!value) return undefined;
+	const trimmed = value.trim();
+	if (trimmed.length === 0) return undefined;
+	return trimmed;
+}
+
+function extractScopeContext(input: {
+	harness?: string;
+	workspace?: string;
+	channel?: string;
+}): MarketplaceMcpScopeContext {
+	return {
+		harness: normalizeScopeContextValue(input.harness),
+		workspace: normalizeScopeContextValue(input.workspace),
+		channel: normalizeScopeContextValue(input.channel),
+	};
+}
+
+function normalizeWorkspaceScopeEntry(value: string): string {
+	const trimmed = value.trim();
+	return trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
+}
+
+function dimensionMatches(
+	allowed: readonly string[],
+	current: string | undefined,
+	kind: "default" | "workspace",
+): boolean {
+	if (allowed.length === 0) return true;
+	if (!current) return false;
+
+	const currentLower = current.toLowerCase();
+	for (const rawEntry of allowed) {
+		const entry = rawEntry.toLowerCase();
+		if (kind === "workspace") {
+			const normalized = normalizeWorkspaceScopeEntry(entry);
+			const wildcard = normalized.endsWith("*") ? normalizeWorkspaceScopeEntry(normalized.slice(0, -1)) : null;
+			if (wildcard && (currentLower === wildcard || currentLower.startsWith(`${wildcard}/`))) {
+				return true;
+			}
+			if (currentLower === normalized || currentLower.startsWith(`${normalized}/`)) {
+				return true;
+			}
+			continue;
+		}
+
+		if (currentLower === entry) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+function scopeMatches(scope: MarketplaceMcpScope, context: MarketplaceMcpScopeContext): boolean {
+	return (
+		dimensionMatches(scope.harnesses, context.harness, "default") &&
+		dimensionMatches(scope.channels, context.channel, "default") &&
+		dimensionMatches(scope.workspaces, context.workspace, "workspace")
+	);
+}
+
+function parseExposureMode(value: unknown): MarketplaceMcpExposureMode | null {
+	if (value === "compact" || value === "hybrid" || value === "expanded") {
+		return value;
+	}
+	return null;
+}
+
+function parsePositiveInt(value: unknown, fallback: number, min: number, max: number): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		return fallback;
+	}
+	return Math.max(min, Math.min(max, Math.round(value)));
+}
+
+function parseExposurePolicy(value: unknown): MarketplaceMcpExposurePolicy | null {
+	if (!isRecord(value)) return null;
+	const mode = parseExposureMode(value.mode);
+	if (!mode) return null;
+
+	const maxExpandedTools = parsePositiveInt(value.maxExpandedTools, DEFAULT_EXPOSURE_POLICY.maxExpandedTools, 0, 100);
+	const maxSearchResults = parsePositiveInt(value.maxSearchResults, DEFAULT_EXPOSURE_POLICY.maxSearchResults, 1, 50);
+	const updatedAt = typeof value.updatedAt === "string" ? value.updatedAt : new Date().toISOString();
+
+	return {
+		mode,
+		maxExpandedTools,
+		maxSearchResults,
+		updatedAt,
+	};
+}
+
+function readExposurePolicy(): MarketplaceMcpExposurePolicy {
+	const path = getExposurePolicyPath();
+	if (!existsSync(path)) {
+		return DEFAULT_EXPOSURE_POLICY;
+	}
+
+	try {
+		const raw = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+		return parseExposurePolicy(raw) ?? DEFAULT_EXPOSURE_POLICY;
+	} catch {
+		return DEFAULT_EXPOSURE_POLICY;
+	}
+}
+
+function writeExposurePolicy(policy: MarketplaceMcpExposurePolicy): void {
+	ensureMarketplaceDir();
+	writeFileSync(getExposurePolicyPath(), JSON.stringify(policy, null, 2));
+}
+
+function extractContextFromRequest(c: {
+	req: {
+		query: (key: string) => string | undefined;
+		header: (key: string) => string | undefined;
+	};
+}): MarketplaceMcpScopeContext {
+	return extractScopeContext({
+		harness: c.req.query("harness") ?? c.req.header("x-signet-harness") ?? undefined,
+		workspace: c.req.query("workspace") ?? c.req.header("x-signet-workspace") ?? undefined,
+		channel: c.req.query("channel") ?? c.req.header("x-signet-channel") ?? undefined,
+	});
+}
+
+function filterServersByScope(
+	servers: readonly InstalledMarketplaceMcpServer[],
+	context: MarketplaceMcpScopeContext,
+): InstalledMarketplaceMcpServer[] {
+	return servers.filter((server) => scopeMatches(server.scope, context));
+}
+
+function hasScopeContext(context: MarketplaceMcpScopeContext): boolean {
+	return Boolean(context.harness || context.workspace || context.channel);
 }
 
 function parseSecretReference(value: string): string | null {
@@ -537,6 +735,7 @@ function parseInstalledServer(value: unknown): InstalledMarketplaceMcpServer | n
 		homepage: typeof value.homepage === "string" ? value.homepage : undefined,
 		official: value.official,
 		enabled: value.enabled,
+		scope: normalizeScope(value.scope),
 		config,
 		installedAt: value.installedAt,
 		updatedAt: value.updatedAt,
@@ -652,7 +851,13 @@ function sanitizeToolName(name: string): string {
 async function loadMarketplaceTools(
 	installed: readonly InstalledMarketplaceMcpServer[],
 ): Promise<MarketplaceToolsCache> {
-	const cached = toolsCache;
+	const cacheKey = installed
+		.filter((server) => server.enabled)
+		.map((server) => `${server.id}:${server.updatedAt}`)
+		.sort()
+		.join("|");
+
+	const cached = toolsCache.get(cacheKey);
 	const now = Date.now();
 	if (cached && now - cached.fetchedAt < TOOLS_TTL_MS) {
 		return cached;
@@ -724,18 +929,97 @@ async function loadMarketplaceTools(
 		serverHealth: toolBuckets.map((b) => b.health),
 	};
 
-	toolsCache = nextCache;
+	toolsCache.set(cacheKey, nextCache);
 	return nextCache;
 }
 
 function invalidateMarketplaceToolsCache(): void {
-	toolsCache = null;
+	toolsCache.clear();
+}
+
+function tokenizeQuery(value: string): string[] {
+	return value
+		.toLowerCase()
+		.split(/\s+/g)
+		.map((token) => token.trim())
+		.filter((token) => token.length > 1);
+}
+
+function rankMarketplaceTools(tools: readonly MarketplaceMcpTool[], query: string): MarketplaceMcpTool[] {
+	const tokens = tokenizeQuery(query);
+	if (tokens.length === 0) {
+		return [...tools];
+	}
+
+	const scored = tools
+		.map((tool) => {
+			const haystack = `${tool.serverId} ${tool.serverName} ${tool.toolName} ${tool.description}`.toLowerCase();
+			let score = 0;
+			for (const token of tokens) {
+				if (tool.toolName.toLowerCase() === token) score += 6;
+				if (tool.toolName.toLowerCase().includes(token)) score += 4;
+				if (tool.serverName.toLowerCase().includes(token)) score += 3;
+				if (tool.description.toLowerCase().includes(token)) score += 2;
+				if (haystack.includes(token)) score += 1;
+			}
+			return { tool, score };
+		})
+		.filter((entry) => entry.score > 0)
+		.sort((a, b) => {
+			if (b.score !== a.score) return b.score - a.score;
+			return `${a.tool.serverId}:${a.tool.toolName}`.localeCompare(`${b.tool.serverId}:${b.tool.toolName}`);
+		});
+
+	return scored.map((entry) => entry.tool);
 }
 
 export function mountMarketplaceRoutes(app: Hono): void {
 	app.get("/api/marketplace/mcp", (c) => {
 		const servers = readInstalledServers();
-		return c.json({ servers, count: servers.length });
+		const context = extractContextFromRequest(c);
+		const scopedQuery = c.req.query("scoped");
+		const scoped = scopedQuery === "1" ? true : scopedQuery === "0" ? false : hasScopeContext(context);
+		const visible = scoped ? filterServersByScope(servers, context) : servers;
+		return c.json({
+			servers: visible,
+			count: visible.length,
+			scoped,
+			context,
+		});
+	});
+
+	app.get("/api/marketplace/mcp/policy", (c) => {
+		const policy = readExposurePolicy();
+		return c.json({ policy });
+	});
+
+	app.patch("/api/marketplace/mcp/policy", async (c) => {
+		let body: {
+			mode?: MarketplaceMcpExposureMode;
+			maxExpandedTools?: number;
+			maxSearchResults?: number;
+		} = {};
+		try {
+			body = await c.req.json();
+		} catch {
+			return c.json({ error: "Invalid JSON body" }, 400);
+		}
+
+		const current = readExposurePolicy();
+		const mode = body.mode ?? current.mode;
+		if (!parseExposureMode(mode)) {
+			return c.json({ error: "mode must be compact, hybrid, or expanded" }, 400);
+		}
+
+		const next: MarketplaceMcpExposurePolicy = {
+			mode,
+			maxExpandedTools: parsePositiveInt(body.maxExpandedTools, current.maxExpandedTools, 0, 100),
+			maxSearchResults: parsePositiveInt(body.maxSearchResults, current.maxSearchResults, 1, 50),
+			updatedAt: new Date().toISOString(),
+		};
+
+		writeExposurePolicy(next);
+		return c.json({ success: true, policy: next });
 	});
 
 	app.get("/api/marketplace/mcp/browse", async (c) => {
@@ -849,6 +1133,7 @@ export function mountMarketplaceRoutes(app: Hono): void {
 			category: "Other",
 			official: false,
 			enabled: true,
+			scope: normalizeScope(undefined),
 			config,
 			installedAt: new Date().toISOString(),
 			updatedAt: new Date().toISOString(),
@@ -883,6 +1168,7 @@ export function mountMarketplaceRoutes(app: Hono): void {
 			source?: MarketplaceMcpCatalogSource;
 			alias?: string;
 			config?: unknown;
+			scope?: unknown;
 		} = {};
 		try {
 			body = await c.req.json();
@@ -902,6 +1188,7 @@ export function mountMarketplaceRoutes(app: Hono): void {
 
 		let normalized = normalizeMcpConfig(body.config);
 		let detail: DetailConfig | undefined;
+		const scope = normalizeScope(body.scope);
 
 		if (!normalized) {
 			try {
@@ -932,6 +1219,7 @@ export function mountMarketplaceRoutes(app: Hono): void {
 			const updated: InstalledMarketplaceMcpServer = {
 				...existing,
 				enabled: true,
+				scope: body.scope === undefined ? existing.scope : scope,
 				config: normalized,
 				updatedAt: now,
 			};
@@ -959,6 +1247,7 @@ export function mountMarketplaceRoutes(app: Hono): void {
 			homepage,
 			official: selection.source === "modelcontextprotocol/servers",
 			enabled: true,
+			scope,
 			config: normalized,
 			installedAt: now,
 			updatedAt: now,
@@ -970,7 +1259,7 @@ export function mountMarketplaceRoutes(app: Hono): void {
 	});
 
 	app.post("/api/marketplace/mcp/register", async (c) => {
-		let body: { name?: string; description?: string; category?: string; config?: unknown } = {};
+		let body: { name?: string; description?: string; category?: string; config?: unknown; scope?: unknown } = {};
 		try {
 			body = await c.req.json();
 		} catch {
@@ -998,6 +1287,7 @@ export function mountMarketplaceRoutes(app: Hono): void {
 			category: body.category?.trim() || inferCategory(body.name),
 			official: false,
 			enabled: true,
+			scope: normalizeScope(body.scope),
 			config: normalized,
 			installedAt: now,
 			updatedAt: now,
@@ -1008,9 +1298,25 @@ export function mountMarketplaceRoutes(app: Hono): void {
 		return c.json({ success: true, server });
 	});
 
+	app.get("/api/marketplace/mcp/:id", (c) => {
+		const id = c.req.param("id");
+		const installed = readInstalledServers();
+		const server = installed.find((item) => item.id === id);
+		if (!server) {
+			return c.json({ error: "Server not found" }, 404);
+		}
+
+		const context = extractContextFromRequest(c);
+		if (hasScopeContext(context) && !scopeMatches(server.scope, context)) {
+			return c.json({ error: "Server is out of scope for current context" }, 403);
+		}
+
+		return c.json({ server, context });
+	});
+
 	app.patch("/api/marketplace/mcp/:id", async (c) => {
 		const id = c.req.param("id");
-		let body: { enabled?: boolean; config?: unknown; name?: string; description?: string } = {};
+		let body: { enabled?: boolean; config?: unknown; name?: string; description?: string; scope?: unknown } = {};
 		try {
 			body = await c.req.json();
 		} catch {
@@ -1029,6 +1335,7 @@ export function mountMarketplaceRoutes(app: Hono): void {
 		const updated: InstalledMarketplaceMcpServer = {
 			...existing,
 			enabled: typeof body.enabled === "boolean" ? body.enabled : existing.enabled,
+			scope: body.scope === undefined ? existing.scope : normalizeScope(body.scope),
 			config: normalized ?? existing.config,
 			name: typeof body.name === "string" && body.name.trim().length > 0 ? body.name.trim() : existing.name,
 			description:
@@ -1056,21 +1363,57 @@ export function mountMarketplaceRoutes(app: Hono): void {
 
 	app.get("/api/marketplace/mcp/tools", async (c) => {
 		const installed = readInstalledServers();
+		const context = extractContextFromRequest(c);
+		const scopedInstalled = filterServersByScope(installed, context);
 		const refresh = c.req.query("refresh") === "1";
 		if (refresh) {
 			invalidateMarketplaceToolsCache();
 		}
 
 		try {
-			const cached = await loadMarketplaceTools(installed);
+			const cached = await loadMarketplaceTools(scopedInstalled);
 			return c.json({
 				tools: cached.tools,
 				servers: cached.serverHealth,
 				count: cached.tools.length,
+				context,
+				policy: readExposurePolicy(),
 			});
 		} catch (error) {
 			logger.error("skills", "Failed to load marketplace MCP tools", error as Error);
-			return c.json({ tools: [], servers: [], count: 0, error: "Failed to load tools" }, 500);
+			return c.json({ tools: [], servers: [], count: 0, error: "Failed to load tools", context }, 500);
+		}
+	});
+
+	app.get("/api/marketplace/mcp/search", async (c) => {
+		const query = (c.req.query("q") ?? "").trim();
+		const refresh = c.req.query("refresh") === "1";
+		const policy = readExposurePolicy();
+		const rawLimit = Number(c.req.query("limit") ?? String(policy.maxSearchResults));
+		const limit = parsePositiveInt(rawLimit, policy.maxSearchResults, 1, 50);
+
+		if (query.length < 2) {
+			return c.json({ query, count: 0, results: [], error: "query must be at least 2 characters" }, 400);
+		}
+
+		const context = extractContextFromRequest(c);
+		const installed = filterServersByScope(readInstalledServers(), context);
+		if (refresh) {
+			invalidateMarketplaceToolsCache();
+		}
+
+		try {
+			const cached = await loadMarketplaceTools(installed);
+			const ranked = rankMarketplaceTools(cached.tools, query).slice(0, limit);
+			return c.json({
+				query,
+				count: ranked.length,
+				results: ranked,
+				context,
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return c.json({ query, count: 0, results: [], error: message, context }, 500);
 		}
 	});
 
@@ -1086,10 +1429,11 @@ export function mountMarketplaceRoutes(app: Hono): void {
 			return c.json({ error: "serverId and toolName are required" }, 400);
 		}
 
+		const context = extractContextFromRequest(c);
 		const installed = readInstalledServers();
-		const server = installed.find((s) => s.id === body.serverId && s.enabled);
+		const server = installed.find((s) => s.id === body.serverId && s.enabled && scopeMatches(s.scope, context));
 		if (!server) {
-			return c.json({ error: "Server not found or disabled" }, 404);
+			return c.json({ error: "Server not found, disabled, or out of scope" }, 404);
 		}
 
 		try {


### PR DESCRIPTION
## Summary
- add scope-aware marketplace MCP server visibility and invocation rules (harness/workspace/channel) with policy-backed exposure modes (`compact`, `hybrid`, `expanded`)
- introduce marketplace policy and search endpoints plus MCP management tools (`mcp_server_search`, enable/disable, scope get/set, policy get/set) so agents can discover and control MCP servers without leaving MCP
- make dynamic proxy registration policy-driven and context-aware, with search-based promotion to keep tool lists lean while still allowing rapid expansion
- propagate scope context through daemon MCP HTTP/stdio entrypoints and OpenClaw adapter marketplace requests for consistent filtering behavior
- expand daemon MCP tests to cover new management tools and policy payload mapping

## Testing
- `bunx @biomejs/biome check packages/daemon/src/routes/marketplace.ts packages/daemon/src/mcp/tools.ts packages/daemon/src/mcp/tools.test.ts packages/daemon/src/mcp/route.ts packages/daemon/src/mcp-stdio.ts packages/adapters/openclaw/src/index.ts`
- `bun test src/mcp/tools.test.ts src/routes/marketplace.test.ts` (in `packages/daemon`)
- `bun run build` (in `packages/daemon`)
- `bun run build` (in `packages/adapters/openclaw`)
- isolated daemon smoke validation for scope/policy tools (`mcp_server_policy_*`, `mcp_server_scope_*`, enable/disable)