### PR TITLE
Ui-Overhaul(Dashboard/Settings): polish settings page with single-section view

### DIFF
--- a/packages/cli/dashboard/src/lib/components/config/FormField.svelte
+++ b/packages/cli/dashboard/src/lib/components/config/FormField.svelte
@@ -1,28 +1,92 @@
 <script lang="ts">
-import type { Snippet } from "svelte";
-import { Label } from "$lib/components/ui/label/index.js";
+	import type { Snippet } from "svelte";
+	import { Label } from "$lib/components/ui/label/index.js";
 
-interface Props {
-	label: string;
-	description?: string;
-	children: Snippet;
-}
+	interface Props {
+		label: string;
+		description?: string;
+		children: Snippet;
+		layout?: "vertical" | "horizontal";
+	}
 
-let { label, description, children }: Props = $props();
+	let { label, description, children, layout = "horizontal" }: Props = $props();
 </script>
 
-<div class="flex flex-col gap-1">
-	<Label class="font-[family-name:var(--font-mono)] text-[11px] font-medium
-		text-[var(--sig-text-bright)] uppercase tracking-[0.06em]">
-		{label}
-		{#if description}
-			<span class="block text-[10px] font-normal text-[var(--sig-text-muted)]
-				normal-case tracking-[0.02em] mt-px">
-				{description}
-			</span>
-		{/if}
-	</Label>
-	<div class="flex flex-col">
-		{@render children()}
+{#if layout === "vertical"}
+	<div class="flex flex-col gap-1">
+		<Label class="font-[family-name:var(--font-mono)] text-[11px] font-medium
+			text-[var(--sig-text-bright)] uppercase tracking-[0.06em]">
+			{label}
+			{#if description}
+				<span class="block text-[10px] font-normal text-[var(--sig-text-muted)]
+					normal-case tracking-[0.02em] mt-px">
+					{description}
+				</span>
+			{/if}
+		</Label>
+		<div class="flex flex-col">
+			{@render children()}
+		</div>
 	</div>
-</div>
+{:else}
+	<div class="form-field-horizontal">
+		<div class="field-label">
+			<span class="font-[family-name:var(--font-mono)] text-[11px] font-medium
+				text-[var(--sig-text-bright)] uppercase tracking-[0.06em]">
+				{label}
+			</span>
+			{#if description}
+				<span class="field-desc">
+					{description}
+				</span>
+			{/if}
+		</div>
+		<div class="field-input">
+			{@render children()}
+		</div>
+	</div>
+{/if}
+
+<style>
+	.form-field-horizontal {
+		display: grid;
+		grid-template-columns: minmax(140px, 1fr) minmax(0, 2fr);
+		gap: var(--space-sm) var(--space-md);
+		align-items: start;
+	}
+
+	.field-label {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		padding-top: 6px;
+	}
+
+	.field-desc {
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+		font-family: var(--font-mono);
+		font-size: 10px;
+		font-weight: normal;
+		color: var(--sig-text-muted);
+		text-transform: none;
+		letter-spacing: 0.02em;
+		line-height: 1.4;
+	}
+
+	.field-input {
+		min-width: 0;
+	}
+
+	@media (max-width: 640px) {
+		.form-field-horizontal {
+			grid-template-columns: 1fr;
+		}
+
+		.field-label {
+			padding-top: 0;
+		}
+	}
+</style>

--- a/packages/cli/dashboard/src/lib/components/config/FormSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/config/FormSection.svelte
@@ -1,41 +1,45 @@
 <script lang="ts">
-import * as Collapsible from "$lib/components/ui/collapsible/index.js";
-import ChevronDown from "@lucide/svelte/icons/chevron-down";
-import type { Snippet } from "svelte";
+	import type { Snippet } from "svelte";
 
-interface Props {
-	title: string;
-	description?: string;
-	children: Snippet;
-	defaultOpen?: boolean;
-	dirty?: boolean;
-}
+	interface Props {
+		description?: string;
+		children: Snippet;
+	}
 
-const { title, description, children, defaultOpen = true, dirty = false }: Props = $props();
-let open = $state(defaultOpen);
+	const { description, children }: Props = $props();
 </script>
 
-<Collapsible.Root bind:open class="border-b border-[var(--sig-border)]">
-	<Collapsible.Trigger
-		class="flex w-full items-center justify-between px-[var(--space-md)] py-3
-			bg-transparent border-none cursor-pointer
-			text-[var(--sig-text-bright)] font-[family-name:var(--font-display)]
-			text-[11px] font-semibold uppercase tracking-[0.1em]
-			hover:bg-[var(--sig-surface-raised)]"
-	>
-		<span>{title}{#if dirty}<span class="text-[var(--sig-accent)] ml-1">•</span>{/if}</span>
-		<ChevronDown
-			class="text-[var(--sig-text-muted)] transition-transform duration-200
-				{open ? 'rotate-180' : ''}"
-			size={14}
-		/>
-	</Collapsible.Trigger>
-	<Collapsible.Content>
-		<div class="flex flex-col gap-3.5 px-[var(--space-md)] pt-1 pb-[var(--space-md)]">
-			{#if description}
-				<p class="font-[family-name:var(--font-mono)] text-[11px] leading-relaxed text-[var(--sig-text-muted)] m-0">{description}</p>
-			{/if}
-			{@render children()}
-		</div>
-	</Collapsible.Content>
-</Collapsible.Root>
+<div class="form-section">
+	{#if description}
+		<p class="section-description">{description}</p>
+	{/if}
+	<div class="fields-container">
+		{@render children()}
+	</div>
+</div>
+
+<style>
+	.form-section {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-lg);
+		padding: var(--space-lg);
+		min-height: 100%;
+	}
+
+	.section-description {
+		font-family: var(--font-mono);
+		font-size: 11px;
+		line-height: 1.6;
+		color: var(--sig-text-muted);
+		margin: 0;
+		padding-bottom: var(--space-md);
+		border-bottom: 1px solid var(--sig-border);
+	}
+
+	.fields-container {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-lg);
+	}
+</style>

--- a/packages/cli/dashboard/src/lib/components/tabs/SettingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/SettingsTab.svelte
@@ -1,57 +1,200 @@
 <script lang="ts">
-import type { ConfigFile } from "$lib/api";
-import { st } from "$lib/stores/settings.svelte";
-import { setSettingsDirty } from "$lib/stores/unsaved-changes.svelte";
-import { untrack } from "svelte";
-import AgentSection from "./settings/AgentSection.svelte";
-import AuthSection from "./settings/AuthSection.svelte";
-import EmbeddingsSection from "./settings/EmbeddingsSection.svelte";
-import MemorySection from "./settings/MemorySection.svelte";
-import PathsSection from "./settings/PathsSection.svelte";
-import PipelineSection from "./settings/PipelineSection.svelte";
-import SearchSection from "./settings/SearchSection.svelte";
-import TrustSection from "./settings/TrustSection.svelte";
+	import type { ConfigFile } from "$lib/api";
+	import { st } from "$lib/stores/settings.svelte";
+	import { setSettingsDirty } from "$lib/stores/unsaved-changes.svelte";
+	import { untrack } from "svelte";
+	import * as Popover from "$lib/components/ui/popover/index.js";
+	import * as Select from "$lib/components/ui/select/index.js";
+	import AgentSection from "./settings/AgentSection.svelte";
+	import AuthSection from "./settings/AuthSection.svelte";
+	import EmbeddingsSection from "./settings/EmbeddingsSection.svelte";
+	import HarnessesSection from "./settings/HarnessesSection.svelte";
+	import MemorySection from "./settings/MemorySection.svelte";
+	import PathsSection from "./settings/PathsSection.svelte";
+	import PipelineSection from "./settings/PipelineSection.svelte";
+	import SearchSection from "./settings/SearchSection.svelte";
+	import TrustSection from "./settings/TrustSection.svelte";
 
-interface Props {
-	configFiles: ConfigFile[];
-}
-
-const { configFiles }: Props = $props();
-
-// Track configFiles so the effect re-runs when the prop changes,
-// but untrack the init call — it mutates $state which would
-// otherwise trigger an infinite reactive loop.
-$effect(() => {
-	const files = configFiles;
-	untrack(() => st.init(files));
-});
-
-async function saveSettings() {
-	await st.save();
-}
-
-function handleGlobalKey(e: KeyboardEvent) {
-	if (e.key === "s" && (e.metaKey || e.ctrlKey)) {
-		e.preventDefault();
-		if (st.isDirty && !st.saving) saveSettings();
+	interface Props {
+		configFiles: ConfigFile[];
 	}
-}
 
-function formatSavedAt(raw: string | null): string {
-	if (!raw) return "";
-	try {
-		return `Last saved ${new Date(raw).toLocaleTimeString()}`;
-	} catch {
-		return "";
+	const { configFiles }: Props = $props();
+
+	interface SectionDef {
+		id: string;
+		title: string;
+		paths: string[][];
+		source: "agent" | "config";
 	}
-}
 
-$effect(() => {
-	setSettingsDirty(st.isDirty);
-	return () => {
-		setSettingsDirty(false);
-	};
-});
+	const sectionDefs: SectionDef[] = [
+		{
+			id: "agent",
+			title: "Agent",
+			source: "agent",
+			paths: [["agent", "name"], ["agent", "description"]],
+		},
+		{
+			id: "harnesses",
+			title: "Harnesses",
+			source: "agent",
+			paths: [["harnesses"]],
+		},
+		{
+			id: "embeddings",
+			title: "Embeddings",
+			source: "config",
+			paths: [["embedding"], ["memory", "embeddings"], ["embeddings"]],
+		},
+		{
+			id: "search",
+			title: "Search",
+			source: "config",
+			paths: [["memory", "search"]],
+		},
+		{
+			id: "memory",
+			title: "Memory",
+			source: "config",
+			paths: [["memory", "session_budget"], ["memory", "current_md_budget"], ["memory", "decay_rate"]],
+		},
+		{
+			id: "paths",
+			title: "Paths",
+			source: "agent",
+			paths: [["paths"]],
+		},
+		{
+			id: "pipeline",
+			title: "Pipeline",
+			source: "agent",
+			paths: [["memory", "pipelineV2"]],
+		},
+		{
+			id: "trust",
+			title: "Trust",
+			source: "agent",
+			paths: [["trust"]],
+		},
+		{
+			id: "auth",
+			title: "Auth",
+			source: "config",
+			paths: [["auth"]],
+		},
+	];
+
+	let activeSection = $state("agent");
+	let jumpMenuOpen = $state(false);
+	let jumpFilter = $state("");
+	let discardDialogOpen = $state(false);
+	let jumpInputRef = $state<HTMLInputElement | null>(null);
+
+	$effect(() => {
+		const files = configFiles;
+		untrack(() => st.init(files));
+	});
+
+	async function saveSettings() {
+		await st.save();
+	}
+
+	let sections = $derived(
+		sectionDefs.map((def) => ({
+			id: def.id,
+			title: def.title,
+			dirty: st.isAnyPathDirty(def.source, def.paths),
+		}))
+	);
+
+	let filteredSections = $derived(
+		jumpFilter
+			? sections.filter((s) => s.title.toLowerCase().includes(jumpFilter.toLowerCase()))
+			: sections
+	);
+
+	let dirtySections = $derived(sections.filter((s) => s.dirty));
+	let dirtyCount = $derived(dirtySections.length);
+	let currentSection = $derived(sections.find((s) => s.id === activeSection));
+	let currentSectionIndex = $derived(sections.findIndex((s) => s.id === activeSection) + 1);
+
+	function handleGlobalKey(e: KeyboardEvent) {
+		const target = e.target as HTMLElement;
+		const isInputFocused = target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable;
+
+		if (e.key === "s" && (e.metaKey || e.ctrlKey)) {
+			e.preventDefault();
+			if (st.isDirty && !st.saving) saveSettings();
+			return;
+		}
+
+		if (e.key === "j" && (e.metaKey || e.ctrlKey)) {
+			e.preventDefault();
+			jumpMenuOpen = true;
+			setTimeout(() => jumpInputRef?.focus(), 0);
+			return;
+		}
+
+		if (jumpMenuOpen) {
+			if (e.key === "Escape") {
+				e.preventDefault();
+				jumpMenuOpen = false;
+				jumpFilter = "";
+			}
+			if (!isInputFocused && /^[1-8]$/.test(e.key)) {
+				e.preventDefault();
+				const idx = parseInt(e.key, 10) - 1;
+				if (sections[idx]) {
+					switchSection(sections[idx].id);
+				}
+			}
+		}
+
+		if (!isInputFocused && !jumpMenuOpen) {
+			if (e.key === "ArrowLeft") {
+				e.preventDefault();
+				const prevIdx = currentSectionIndex <= 1 ? sections.length - 1 : currentSectionIndex - 2;
+				switchSection(sections[prevIdx].id);
+			}
+			if (e.key === "ArrowRight") {
+				e.preventDefault();
+				const nextIdx = currentSectionIndex >= sections.length ? 0 : currentSectionIndex;
+				switchSection(sections[nextIdx].id);
+			}
+		}
+	}
+
+	function switchSection(sectionId: string): void {
+		jumpMenuOpen = false;
+		jumpFilter = "";
+		activeSection = sectionId;
+	}
+
+	function handleDiscard(): void {
+		discardDialogOpen = true;
+	}
+
+	function confirmDiscard(): void {
+		st.reset();
+		discardDialogOpen = false;
+	}
+
+	function formatSavedAt(raw: string | null): string {
+		if (!raw) return "";
+		try {
+			return `Last saved ${new Date(raw).toLocaleTimeString()}`;
+		} catch {
+			return "";
+		}
+	}
+
+	$effect(() => {
+		setSettingsDirty(st.isDirty);
+		return () => {
+			setSettingsDirty(false);
+		};
+	});
 </script>
 
 <svelte:window onkeydown={handleGlobalKey} />
@@ -60,33 +203,160 @@ $effect(() => {
 	{#if !st.hasFiles}
 		<div class="empty-state">No YAML config files found</div>
 	{:else}
-		<div class="form-body">
-			<AgentSection />
-			<EmbeddingsSection />
-			<SearchSection />
-			<MemorySection />
-			<PathsSection />
-			<PipelineSection />
-			<TrustSection />
-			<AuthSection />
+		<!-- Section header with navigation -->
+		<header class="section-header">
+			<div class="header-left">
+				<button
+					type="button"
+					class="nav-btn"
+					onclick={() => {
+						const prevIdx = currentSectionIndex <= 1 ? sections.length - 1 : currentSectionIndex - 2;
+						switchSection(sections[prevIdx].id);
+					}}
+					title="Previous section (←)"
+				>
+					←
+				</button>
+
+				<Popover.Root bind:open={jumpMenuOpen}>
+					<Popover.Trigger>
+						{#snippet child({ props })}
+							<button {...props} type="button" class="section-selector">
+								<span class="section-title">{currentSection?.title || "Select section"}</span>
+								{#if currentSection?.dirty}
+									<span class="section-dirty" title="Unsaved changes">•</span>
+								{/if}
+								<span class="section-position">{currentSectionIndex}/{sections.length}</span>
+								<span class="dropdown-arrow">▾</span>
+							</button>
+						{/snippet}
+					</Popover.Trigger>
+					<Popover.Content align="start" side="bottom" class="jump-menu">
+						<div class="jump-filter">
+							<input
+								bind:this={jumpInputRef}
+								type="text"
+								placeholder="Filter sections..."
+								bind:value={jumpFilter}
+							/>
+						</div>
+						<div class="jump-list">
+							{#each filteredSections as section, i (section.id)}
+								<button
+									type="button"
+									class="jump-item"
+									class:active={section.id === activeSection}
+									class:dirty={section.dirty}
+									onclick={() => switchSection(section.id)}
+								>
+									<span class="jump-num">{i + 1}</span>
+									<span class="jump-title">{section.title}</span>
+									{#if section.dirty}
+										<span class="jump-dirty" title="Unsaved changes">•</span>
+									{/if}
+								</button>
+							{/each}
+							{#if filteredSections.length === 0}
+								<div class="jump-empty">No sections found</div>
+							{/if}
+						</div>
+						<div class="jump-footer">
+							<span>1-8 jump</span>
+							<span>←/→ nav</span>
+							<span>Esc close</span>
+						</div>
+					</Popover.Content>
+				</Popover.Root>
+
+				<button
+					type="button"
+					class="nav-btn"
+					onclick={() => {
+						const nextIdx = currentSectionIndex >= sections.length ? 0 : currentSectionIndex;
+                        switchSection(sections[nextIdx].id);
+                    }}
+					title="Next section (→)"
+				>
+					→
+				</button>
+			</div>
+
+			<div class="header-right">
+				{#if dirtyCount > 0}
+					<span class="dirty-badge">{dirtyCount} unsaved</span>
+				{/if}
+			</div>
+		</header>
+
+		<!-- Active section content -->
+		<div class="section-content">
+			{#if activeSection === "agent"}
+				<AgentSection />
+			{:else if activeSection === "harnesses"}
+				<HarnessesSection />
+			{:else if activeSection === "embeddings"}
+				<EmbeddingsSection />
+			{:else if activeSection === "search"}
+				<SearchSection />
+			{:else if activeSection === "memory"}
+				<MemorySection />
+			{:else if activeSection === "paths"}
+				<PathsSection />
+			{:else if activeSection === "pipeline"}
+				<PipelineSection />
+			{:else if activeSection === "trust"}
+				<TrustSection />
+			{:else if activeSection === "auth"}
+				<AuthSection />
+			{/if}
 		</div>
 
-		<div class="save-bar">
+		<!-- Save bar -->
+		<footer class="save-bar">
 			<div class="save-meta">
 				<span class="save-state" class:dirty={st.isDirty}>
-					{st.isDirty ? "Unsaved changes" : "All changes saved"}
+					{st.isDirty ? "Unsaved changes" : "All saved"}
 				</span>
 				{#if st.lastSavedAt}
 					<span>{formatSavedAt(st.lastSavedAt)}</span>
 				{/if}
-				{#if st.lastSaveFeedback}
-					<span>{st.lastSaveFeedback}</span>
-				{/if}
 			</div>
-			<button class="save-btn" onclick={saveSettings} disabled={st.saving || !st.isDirty} title="Save (⌘S / Ctrl+S)">
+			{#if st.isDirty}
+				<button type="button" class="discard-btn" onclick={handleDiscard} disabled={st.saving}>
+					Discard
+				</button>
+			{/if}
+			<button
+				type="button"
+				class="save-btn"
+				onclick={saveSettings}
+				disabled={st.saving || !st.isDirty}
+				title="Save (Ctrl+S)"
+			>
 				{st.saving ? "Saving…" : "Save"}
 			</button>
-		</div>
+		</footer>
+
+		<!-- Discard confirmation dialog -->
+		{#if discardDialogOpen}
+			<div class="dialog-overlay" onclick={() => discardDialogOpen = false}>
+				<div class="dialog" onclick={(e) => e.stopPropagation()}>
+					<div class="dialog-title">Discard changes?</div>
+					<div class="dialog-body">
+						This will revert all unsaved changes in {dirtyCount} section{dirtyCount !== 1 ? "s" : ""}.
+						This cannot be undone.
+					</div>
+					<div class="dialog-actions">
+						<button type="button" class="dialog-btn cancel" onclick={() => discardDialogOpen = false}>
+							Cancel
+						</button>
+						<button type="button" class="dialog-btn danger" onclick={confirmDiscard}>
+							Discard
+						</button>
+					</div>
+				</div>
+			</div>
+		{/if}
 	{/if}
 </div>
 
@@ -108,19 +378,233 @@ $effect(() => {
 		color: var(--sig-text-muted);
 	}
 
-	.form-body {
-		flex: 1;
-		overflow-y: auto;
-		padding-bottom: 56px;
-	}
-
-	/* Save bar */
-	.save-bar {
-		position: sticky;
-		bottom: 0;
+	.section-header {
 		display: flex;
 		align-items: center;
-		gap: var(--space-md);
+		justify-content: space-between;
+		padding: var(--space-sm) var(--space-md);
+		background: var(--sig-surface);
+		border-bottom: 1px solid var(--sig-border);
+		flex-shrink: 0;
+	}
+
+	.header-left {
+		display: flex;
+		align-items: center;
+		gap: var(--space-sm);
+	}
+
+	.header-right {
+		display: flex;
+		align-items: center;
+		gap: var(--space-sm);
+	}
+
+	.nav-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 28px;
+		height: 28px;
+		font-family: var(--font-mono);
+		font-size: 14px;
+		color: var(--sig-text-muted);
+		background: var(--sig-surface-raised);
+		border: 1px solid var(--sig-border);
+		cursor: pointer;
+		transition: all 0.15s ease;
+	}
+
+	.nav-btn:hover:not(:disabled) {
+		color: var(--sig-text);
+		border-color: var(--sig-border-strong);
+	}
+
+	.nav-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.section-selector {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+		width: 160px;
+		padding: 6px 12px;
+		font-family: var(--font-display);
+		font-size: 13px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--sig-text-bright);
+		background: var(--sig-surface-raised);
+		border: 1px solid var(--sig-border-strong);
+		cursor: pointer;
+		transition: all 0.15s ease;
+	}
+
+	.section-selector:hover {
+		border-color: var(--sig-accent);
+	}
+
+	.section-title {
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.section-dirty {
+		color: var(--sig-accent);
+		font-size: 16px;
+		flex-shrink: 0;
+	}
+
+	.section-position {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		font-weight: normal;
+		color: var(--sig-text-muted);
+		text-transform: none;
+		flex-shrink: 0;
+	}
+
+	.dropdown-arrow {
+		font-size: 10px;
+		color: var(--sig-text-muted);
+		flex-shrink: 0;
+	}
+
+	.dirty-badge {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--sig-warning, #d4a017);
+		padding: 3px 8px;
+		background: color-mix(in srgb, var(--sig-warning, #d4a017) 15%, transparent);
+		border: 1px solid var(--sig-warning, #d4a017);
+	}
+
+	:global(.jump-menu) {
+		width: 240px;
+		padding: 0;
+		background: var(--sig-surface-raised);
+		border: 1px solid var(--sig-border-strong);
+		border-radius: 0;
+	}
+
+	.jump-filter {
+		padding: 8px;
+		border-bottom: 1px solid var(--sig-border);
+	}
+
+	.jump-filter input {
+		width: 100%;
+		font-family: var(--font-mono);
+		font-size: 11px;
+		color: var(--sig-text-bright);
+		background: var(--sig-bg);
+		border: 1px solid var(--sig-border);
+		padding: 6px 8px;
+		outline: none;
+	}
+
+	.jump-filter input:focus {
+		border-color: var(--sig-accent);
+	}
+
+	.jump-list {
+		max-height: 280px;
+		overflow-y: auto;
+	}
+
+	.jump-item {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		width: 100%;
+		padding: 8px 10px;
+		font-family: var(--font-mono);
+		font-size: 11px;
+		color: var(--sig-text);
+		background: transparent;
+		border: none;
+		cursor: pointer;
+		text-align: left;
+		transition: background 0.1s ease;
+	}
+
+	.jump-item:hover {
+		background: var(--sig-surface);
+	}
+
+	.jump-item.active {
+		background: var(--sig-surface);
+		color: var(--sig-text-bright);
+	}
+
+	.jump-item.dirty .jump-title {
+		font-weight: 600;
+	}
+
+	.jump-num {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 18px;
+		height: 18px;
+		font-size: 9px;
+		color: var(--sig-text-muted);
+		background: var(--sig-bg);
+		border: 1px solid var(--sig-border);
+	}
+
+	.jump-item.active .jump-num {
+		background: var(--sig-accent);
+		color: var(--sig-bg);
+		border-color: var(--sig-accent);
+	}
+
+	.jump-title {
+		flex: 1;
+	}
+
+	.jump-dirty {
+		color: var(--sig-accent);
+		font-size: 14px;
+	}
+
+	.jump-empty {
+		padding: 16px;
+		font-family: var(--font-mono);
+		font-size: 11px;
+		color: var(--sig-text-muted);
+		text-align: center;
+	}
+
+	.jump-footer {
+		display: flex;
+		justify-content: space-between;
+		padding: 6px 10px;
+		font-family: var(--font-mono);
+		font-size: 9px;
+		color: var(--sig-text-muted);
+		border-top: 1px solid var(--sig-border);
+	}
+
+	.section-content {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+	}
+
+	.save-bar {
+		display: flex;
+		align-items: center;
+		gap: var(--space-sm);
 		justify-content: flex-end;
 		padding: var(--space-sm) var(--space-md);
 		background: var(--sig-surface);
@@ -146,6 +630,24 @@ $effect(() => {
 		color: var(--sig-warning, #d4a017);
 	}
 
+	.discard-btn {
+		font-family: var(--font-mono);
+		font-size: 11px;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: var(--sig-text-muted);
+		background: transparent;
+		border: 1px solid var(--sig-border);
+		padding: 6px 16px;
+		cursor: pointer;
+		transition: all 0.15s ease;
+	}
+
+	.discard-btn:hover {
+		color: var(--sig-text);
+		border-color: var(--sig-border-strong);
+	}
+
 	.save-btn {
 		font-family: var(--font-mono);
 		font-size: 11px;
@@ -154,12 +656,102 @@ $effect(() => {
 		color: var(--sig-bg);
 		background: var(--sig-text-bright);
 		border: none;
-		border-radius: 0;
 		padding: 6px 20px;
 		cursor: pointer;
-		transition: opacity var(--dur) var(--ease);
+		transition: opacity 0.15s ease;
 	}
 
-	.save-btn:disabled { opacity: 0.5; cursor: not-allowed; }
-	.save-btn:not(:disabled):hover { opacity: 0.85; }
+	.save-btn:disabled,
+	.discard-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.save-btn:not(:disabled):hover {
+		opacity: 0.85;
+	}
+
+	.dialog-overlay {
+		position: fixed;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: rgba(0, 0, 0, 0.6);
+		z-index: 100;
+	}
+
+	.dialog {
+		width: 360px;
+		max-width: 90vw;
+		background: var(--sig-surface-raised);
+		border: 1px solid var(--sig-border-strong);
+	}
+
+	.dialog-title {
+		padding: 12px 16px;
+		font-family: var(--font-display);
+		font-size: 12px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--sig-text-bright);
+		border-bottom: 1px solid var(--sig-border);
+	}
+
+	.dialog-body {
+		padding: 16px;
+		font-family: var(--font-mono);
+		font-size: 11px;
+		line-height: 1.6;
+		color: var(--sig-text);
+	}
+
+	.dialog-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 8px;
+		padding: 12px 16px;
+		border-top: 1px solid var(--sig-border);
+	}
+
+	.dialog-btn {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		padding: 6px 14px;
+		cursor: pointer;
+		transition: all 0.15s ease;
+	}
+
+	.dialog-btn.cancel {
+		color: var(--sig-text);
+		background: transparent;
+		border: 1px solid var(--sig-border);
+	}
+
+	.dialog-btn.cancel:hover {
+		border-color: var(--sig-border-strong);
+	}
+
+	.dialog-btn.danger {
+		color: var(--sig-bg);
+		background: var(--sig-danger);
+		border: 1px solid var(--sig-danger);
+	}
+
+	.dialog-btn.danger:hover {
+		opacity: 0.85;
+	}
+
+	@media (max-width: 640px) {
+		.header-right {
+			display: none;
+		}
+
+		.section-selector {
+			padding: 6px 10px;
+		}
+	}
 </style>

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/AgentSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/AgentSection.svelte
@@ -1,16 +1,9 @@
 <script lang="ts">
 import FormField from "$lib/components/config/FormField.svelte";
 import FormSection from "$lib/components/config/FormSection.svelte";
-import { Checkbox } from "$lib/components/ui/checkbox/index.js";
 import { Input } from "$lib/components/ui/input/index.js";
 import { Textarea } from "$lib/components/ui/textarea/index.js";
-import { KNOWN_HARNESSES, st } from "$lib/stores/settings.svelte";
-
-const AGENT_PATHS: string[][] = [
-	["agent", "name"],
-	["agent", "description"],
-	["harnesses"],
-];
+import { st } from "$lib/stores/settings.svelte";
 
 function formatDate(raw: unknown): string {
 	if (!raw) return "";
@@ -21,30 +14,15 @@ function formatDate(raw: unknown): string {
 	}
 }
 
-let customHarnessInput = $state("");
-
-function handleAddCustom() {
-	st.addCustomHarness(customHarnessInput);
-	customHarnessInput = "";
-}
-
 function setStr(path: string[]) {
 	return (e: Event) => {
 		st.aSetStr(path, (e.currentTarget as HTMLInputElement | HTMLTextAreaElement).value);
 	};
 }
-
-function toggleHarness(h: string) {
-	return (v: boolean | string | undefined) => {
-		st.toggleHarness(h, !!v);
-	};
-}
-
-let isDirty = $derived(st.isAnyPathDirty("agent", AGENT_PATHS));
 </script>
 
 {#if st.agentFile}
-	<FormSection title="Agent" description="Core identity metadata. Created by signet setup, synced to all harnesses on change." dirty={isDirty}>
+	<FormSection description="Core identity metadata. Created by signet setup, synced to all harnesses on change.">
 		<FormField label="Name" description="Display name shown in harness configs and session context.">
 			<Input value={st.aStr(["agent", "name"])} oninput={setStr(["agent", "name"])} />
 		</FormField>
@@ -56,31 +34,6 @@ let isDirty = $derived(st.isAnyPathDirty("agent", AGENT_PATHS));
 		</FormField>
 		<FormField label="Updated" description="ISO 8601 last update timestamp. Read-only.">
 			<Input class="text-[var(--sig-text-muted)] cursor-default" readonly value={formatDate(st.get(st.agent, "agent", "updated"))} />
-		</FormField>
-	</FormSection>
-
-	<FormSection title="Harnesses" defaultOpen={false} description="AI platforms to integrate with. The daemon syncs identity files and installs hooks for each active harness." dirty={isDirty}>
-		<FormField label="Active harnesses" description="Supported: claude-code, openclaw, opencode. Cursor, windsurf, chatgpt, and gemini are planned.">
-			<div class="flex flex-col gap-1.5">
-				{#each KNOWN_HARNESSES as h (h)}
-					<label class="flex items-center gap-2 font-[family-name:var(--font-mono)] text-[11px] text-[var(--sig-text)] cursor-pointer">
-						<Checkbox checked={st.harnessArray().includes(h)} onCheckedChange={toggleHarness(h)} />
-						<span>{h}</span>
-					</label>
-				{/each}
-				{#each st.harnessArray().filter((h) => !KNOWN_HARNESSES.includes(h)) as h (h)}
-					<label class="flex items-center gap-2 font-[family-name:var(--font-mono)] text-[11px] text-[var(--sig-text)] cursor-pointer">
-						<Checkbox checked={true} onCheckedChange={() => st.removeCustomHarness(h)} />
-						<span>{h} <em class="not-italic text-[9px] text-[var(--sig-text-muted)] border border-[var(--sig-border-strong)] px-1 align-middle ml-1">custom</em></span>
-					</label>
-				{/each}
-			</div>
-		</FormField>
-		<FormField label="Add custom harness" description="Add a custom harness name for third-party integrations.">
-			<div class="flex gap-1.5">
-				<Input placeholder="harness-name" bind:value={customHarnessInput} onkeydown={(e) => { if (e.key === "Enter") handleAddCustom(); }} />
-				<button class="font-[family-name:var(--font-mono)] text-[10px] tracking-[0.04em] text-[var(--sig-text)] bg-[var(--sig-surface-raised)] border border-[var(--sig-border-strong)] rounded-none px-3 py-1 cursor-pointer whitespace-nowrap transition-colors hover:bg-[var(--sig-border-strong)]" onclick={handleAddCustom}>Add</button>
-			</div>
 		</FormField>
 	</FormSection>
 {/if}

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/AuthSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/AuthSection.svelte
@@ -11,12 +11,6 @@ const selectContentClass =
 	"font-[family-name:var(--font-mono)] text-[11px] bg-[var(--sig-bg)] text-[var(--sig-text)] border-[var(--sig-border-strong)] rounded-none";
 const selectItemClass = "font-[family-name:var(--font-mono)] text-[11px] rounded-none";
 
-const AUTH_PATHS: string[][] = [
-	["auth", "method"],
-	["auth", "mode"],
-	["auth", "chainId"],
-];
-
 function setSelect(path: string[]) {
 	return (v: string | undefined) => {
 		st.aSetStr(path, v ?? "");
@@ -28,12 +22,10 @@ function setNum(path: string[]) {
 		st.aSetNum(path, (e.currentTarget as HTMLInputElement).value);
 	};
 }
-
-let isDirty = $derived(st.isAnyPathDirty("agent", AUTH_PATHS));
 </script>
 
 {#if st.agentFile}
-	<FormSection title="Auth" defaultOpen={false} description="Authentication for the daemon API. Optional — disabled in local mode. Uses HMAC-SHA256 signed tokens." dirty={isDirty}>
+	<FormSection description="Authentication for the daemon API. Optional — disabled in local mode. Uses HMAC-SHA256 signed tokens.">
 		<FormField label="Method" description="Signing method for auth tokens. erc8128 uses wallet signatures, gpg/did use alternative signing.">
 			<Select.Root
 				type="single"

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/EmbeddingsSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/EmbeddingsSection.svelte
@@ -1,49 +1,12 @@
 <script lang="ts">
-import FormField from "$lib/components/config/FormField.svelte";
-import FormSection from "$lib/components/config/FormSection.svelte";
-import { Input } from "$lib/components/ui/input/index.js";
-import * as Select from "$lib/components/ui/select/index.js";
-import { st } from "$lib/stores/settings.svelte";
-
-const selectTriggerClass =
-	"font-[family-name:var(--font-mono)] text-[11px] text-[var(--sig-text)] bg-[var(--sig-bg)] border-[var(--sig-border-strong)] rounded-none w-full h-auto min-h-[30px] px-2 py-[5px] box-border focus-visible:border-[var(--sig-accent)]";
-const selectContentClass =
-	"font-[family-name:var(--font-mono)] text-[11px] bg-[var(--sig-bg)] text-[var(--sig-text)] border-[var(--sig-border-strong)] rounded-none";
-const selectItemClass = "font-[family-name:var(--font-mono)] text-[11px] rounded-none";
-
-function handleProviderChange(v: string | undefined) {
-	st.sSetStr([...st.embPath(), "provider"], v ?? "");
-}
-
-let embeddingPaths = $derived([
-	[...st.embPath(), "provider"],
-	[...st.embPath(), "model"],
-	[...st.embPath(), "dimensions"],
-	[...st.embPath(), "base_url"],
-	[...st.embPath(), "api_key"],
-]);
-
-let isDirty = $derived(st.isAnyPathDirty(st.settingsIsSameAsAgent ? "agent" : "config", embeddingPaths));
+	import FormField from "$lib/components/config/FormField.svelte";
+	import FormSection from "$lib/components/config/FormSection.svelte";
+	import { Input } from "$lib/components/ui/input/index.js";
+	import { st } from "$lib/stores/settings.svelte";
 </script>
 
 {#if st.settingsFileName}
-	<FormSection title="Embeddings" defaultOpen={false} description="Vector embedding configuration for semantic memory search. Embeddings power the vector half of hybrid recall." dirty={isDirty}>
-		<FormField label="Provider" description="Embedding backend. Ollama runs locally, OpenAI requires an API key.">
-			<Select.Root
-				type="single"
-				value={st.sStr([...st.embPath(), "provider"])}
-				onValueChange={handleProviderChange}
-			>
-				<Select.Trigger class={selectTriggerClass}>
-					{st.sStr([...st.embPath(), "provider"]) || "— select —"}
-				</Select.Trigger>
-				<Select.Content class={selectContentClass}>
-					<Select.Item class={selectItemClass} value="" label="— select —" />
-					<Select.Item class={selectItemClass} value="ollama" label="ollama" />
-					<Select.Item class={selectItemClass} value="openai" label="openai" />
-				</Select.Content>
-			</Select.Root>
-		</FormField>
+	<FormSection description="Vector embedding configuration for semantic memory search. Embeddings power the vector half of hybrid recall.">
 		<FormField label="Model" description="Ollama: nomic-embed-text (768d), all-minilm (384d), mxbai-embed-large (1024d). OpenAI: text-embedding-3-small (1536d), text-embedding-3-large (3072d).">
 			<Input value={st.sStr([...st.embPath(), "model"])} oninput={(e) => st.sSetStr([...st.embPath(), "model"], e.currentTarget.value)} />
 		</FormField>

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/HarnessesSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/HarnessesSection.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+	import FormField from "$lib/components/config/FormField.svelte";
+	import FormSection from "$lib/components/config/FormSection.svelte";
+	import { Checkbox } from "$lib/components/ui/checkbox/index.js";
+	import { Input } from "$lib/components/ui/input/index.js";
+	import { st, KNOWN_HARNESSES } from "$lib/stores/settings.svelte";
+
+	let customHarnessInput = $state("");
+
+	function handleAddCustom(): void {
+		st.addCustomHarness(customHarnessInput);
+		customHarnessInput = "";
+	}
+</script>
+
+{#if st.agentFile}
+	<FormSection description="AI platforms to integrate with. The daemon syncs identity files and installs hooks for each active harness.">
+		<FormField label="Active harnesses" description="Supported: claude-code, openclaw, opencode. Cursor, windsurf, chatgpt, and gemini are planned.">
+			<div class="harness-grid">
+				{#each KNOWN_HARNESSES as h (h)}
+					<label class="harness-item">
+						<Checkbox checked={st.harnessArray().includes(h)} onCheckedChange={(v: boolean | string) => st.toggleHarness(h, !!v)} />
+						<span class="harness-name">{h}</span>
+					</label>
+				{/each}
+				{#each st.harnessArray().filter((h) => !KNOWN_HARNESSES.includes(h)) as h (h)}
+					<label class="harness-item">
+						<Checkbox checked={true} onCheckedChange={() => st.removeCustomHarness(h)} />
+						<span class="harness-name">{h}</span>
+						<span class="harness-badge">custom</span>
+					</label>
+				{/each}
+			</div>
+		</FormField>
+		<FormField label="Add custom harness" description="Add a custom harness name for third-party integrations." layout="vertical">
+			<div class="add-harness">
+				<Input placeholder="harness-name" bind:value={customHarnessInput} onkeydown={(e) => { if (e.key === "Enter") handleAddCustom(); }} />
+				<button type="button" class="add-btn" onclick={handleAddCustom}>Add</button>
+			</div>
+		</FormField>
+	</FormSection>
+{/if}
+
+<style>
+	.harness-grid {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-sm);
+	}
+
+	.harness-item {
+		display: flex;
+		align-items: center;
+		gap: var(--space-sm);
+		font-family: var(--font-mono);
+		font-size: 11px;
+		color: var(--sig-text);
+		cursor: pointer;
+	}
+
+	.harness-name {
+		flex: 1;
+	}
+
+	.harness-badge {
+		font-style: normal;
+		font-size: 9px;
+		color: var(--sig-text-muted);
+		border: 1px solid var(--sig-border-strong);
+		padding: 0 var(--space-xs);
+	}
+
+	.add-harness {
+		display: flex;
+		gap: var(--space-sm);
+	}
+
+	.add-btn {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--sig-text);
+		background: var(--sig-surface-raised);
+		border: 1px solid var(--sig-border-strong);
+		padding: 0 var(--space-md);
+		cursor: pointer;
+		white-space: nowrap;
+		transition: background 0.15s ease;
+	}
+
+	.add-btn:hover {
+		background: var(--sig-border-strong);
+	}
+</style>

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/MemorySection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/MemorySection.svelte
@@ -3,18 +3,10 @@ import FormField from "$lib/components/config/FormField.svelte";
 import FormSection from "$lib/components/config/FormSection.svelte";
 import { Input } from "$lib/components/ui/input/index.js";
 import { st } from "$lib/stores/settings.svelte";
-
-const MEMORY_PATHS: string[][] = [
-	["memory", "session_budget"],
-	["memory", "current_md_budget"],
-	["memory", "decay_rate"],
-];
-
-let isDirty = $derived(st.isAnyPathDirty(st.settingsIsSameAsAgent ? "agent" : "config", MEMORY_PATHS));
 </script>
 
 {#if st.settingsFileName}
-	<FormSection title="Memory" defaultOpen={false} description="Memory system settings. Controls how much context is injected into sessions and how memories age over time." dirty={isDirty}>
+	<FormSection description="Memory system settings. Controls how much context is injected into sessions and how memories age over time.">
 		<FormField label="Session budget" description="Character limit for context injected at session start via hooks. Default: 2000.">
 			<Input type="number" value={st.sNum(["memory", "session_budget"])} oninput={(e) => st.sSetNum(["memory", "session_budget"], e.currentTarget.value)} />
 		</FormField>

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/PathsSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/PathsSection.svelte
@@ -4,22 +4,15 @@ import FormSection from "$lib/components/config/FormSection.svelte";
 import { Input } from "$lib/components/ui/input/index.js";
 import { st } from "$lib/stores/settings.svelte";
 
-const PATHS_PATHS: string[][] = [
-	["paths", "database"],
-	["paths", "current_md"],
-];
-
 function setStr(path: string[]) {
 	return (e: Event) => {
 		st.sSetStr(path, (e.currentTarget as HTMLInputElement).value);
 	};
 }
-
-let isDirty = $derived(st.isAnyPathDirty(st.settingsIsSameAsAgent ? "agent" : "config", PATHS_PATHS));
 </script>
 
 {#if st.settingsFileName}
-	<FormSection title="Paths" defaultOpen={false} description="File paths for memory storage. All paths are relative to ~/.agents/ (or $SIGNET_PATH)." dirty={isDirty}>
+	<FormSection description="File paths for memory storage. All paths are relative to ~/.agents/ (or $SIGNET_PATH).">
 		<FormField label="Database" description="SQLite database file for structured memory storage.">
 			<Input value={st.sStr(["paths", "database"])} oninput={setStr(["paths", "database"])} />
 		</FormField>

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
@@ -43,24 +43,10 @@ function setSelect(path: string[]) {
 		st.aSetStr(path, v ?? "");
 	};
 }
-
-let pipelinePaths = $derived([
-	...PIPELINE_CORE_BOOLS.map((b) => ["memory", "pipelineV2", b.key] as string[]),
-	...PIPELINE_FEATURE_BOOLS.map((b) => ["memory", "pipelineV2", b.key] as string[]),
-	...PIPELINE_RERANKER_BOOLS.map((b) => ["memory", "pipelineV2", b.key] as string[]),
-	...PIPELINE_EXTRACTION_NUMS.map((n) => ["memory", "pipelineV2", n.key] as string[]),
-	...PIPELINE_SEARCH_NUMS.map((n) => ["memory", "pipelineV2", n.key] as string[]),
-	...PIPELINE_WORKER_NUMS.map((n) => ["memory", "pipelineV2", n.key] as string[]),
-	["memory", "pipelineV2", "extractionProvider"],
-	["memory", "pipelineV2", "extractionModel"],
-	["memory", "pipelineV2", "maintenanceMode"],
-]);
-
-let isDirty = $derived(st.isAnyPathDirty("agent", pipelinePaths));
 </script>
 
 {#if st.agentFile}
-	<FormSection title="Pipeline" defaultOpen={false} description="V2 memory pipeline. Runs LLM-based fact extraction on incoming memories, then decides whether to write, update, or skip. Lives under memory.pipelineV2 in agent.yaml." dirty={isDirty}>
+	<FormSection description="V2 memory pipeline. Runs LLM-based fact extraction on incoming memories, then decides whether to write, update, or skip. Lives under memory.pipelineV2 in agent.yaml.">
 		<div class="font-[family-name:var(--font-mono)] text-[9px] tracking-[0.08em] uppercase text-[var(--sig-text-muted)] pt-3 pb-1 border-b border-[var(--sig-border)] mb-1">
 			Core
 		</div>

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/SearchSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/SearchSection.svelte
@@ -5,15 +5,6 @@ import { Input } from "$lib/components/ui/input/index.js";
 import { Switch } from "$lib/components/ui/switch/index.js";
 import { st } from "$lib/stores/settings.svelte";
 
-const SEARCH_PATHS: string[][] = [
-	["search", "alpha"],
-	["search", "top_k"],
-	["search", "min_score"],
-	["search", "rehearsal_enabled"],
-	["search", "rehearsal_weight"],
-	["search", "rehearsal_half_life_days"],
-];
-
 function setNum(path: string[]) {
 	return (e: Event) => {
 		st.sSetNum(path, (e.currentTarget as HTMLInputElement).value);
@@ -25,12 +16,10 @@ function setBool(path: string[]) {
 		st.sSetBool(path, !!v);
 	};
 }
-
-let isDirty = $derived(st.isAnyPathDirty(st.settingsIsSameAsAgent ? "agent" : "config", SEARCH_PATHS));
 </script>
 
 {#if st.settingsFileName}
-	<FormSection title="Search" defaultOpen={false} description="Hybrid search tuning. Controls the blend between semantic (vector) and keyword (BM25) retrieval." dirty={isDirty}>
+	<FormSection description="Hybrid search tuning. Controls the blend between semantic (vector) and keyword (BM25) retrieval.">
 		<FormField label="Alpha" description="Vector weight (0–1). At 0.9 results are heavily semantic; at 0.3 they skew toward keyword matching. Default 0.7 works well generally.">
 			<Input type="number" min="0" max="1" step="0.1" value={st.sNum(["search", "alpha"])} oninput={setNum(["search", "alpha"])} />
 		</FormField>

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/TrustSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/TrustSection.svelte
@@ -11,11 +11,6 @@ const selectContentClass =
 	"font-[family-name:var(--font-mono)] text-[11px] bg-[var(--sig-bg)] text-[var(--sig-text)] border-[var(--sig-border-strong)] rounded-none";
 const selectItemClass = "font-[family-name:var(--font-mono)] text-[11px] rounded-none";
 
-const TRUST_PATHS: string[][] = [
-	["trust", "verification"],
-	["trust", "registry"],
-];
-
 function setSelect(path: string[]) {
 	return (v: string | undefined) => {
 		st.aSetStr(path, v ?? "");
@@ -27,12 +22,10 @@ function setStr(path: string[]) {
 		st.aSetStr(path, (e.currentTarget as HTMLInputElement).value);
 	};
 }
-
-let isDirty = $derived(st.isAnyPathDirty("agent", TRUST_PATHS));
 </script>
 
 {#if st.agentFile}
-	<FormSection title="Trust" defaultOpen={false} description="Identity verification method. Controls how the agent proves its identity to peers and registries." dirty={isDirty}>
+	<FormSection description="Identity verification method. Controls how the agent proves its identity to peers and registries.">
 		<FormField label="Verification" description="none = local only. erc8128 = wallet-based (recommended). gpg/did = alternative signing. registry = contract-based lookup.">
 			<Select.Root
 				type="single"

--- a/packages/cli/dashboard/src/lib/stores/settings.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/settings.svelte.ts
@@ -283,6 +283,20 @@ class SettingsStore {
 		return paths.some((p) => this.isPathDirty(obj, p));
 	}
 
+	reset(): void {
+		try {
+			this.agent = JSON.parse(this.agentSnapshot);
+		} catch {
+			this.agent = {};
+		}
+		try {
+			this.config = JSON.parse(this.configSnapshot);
+		} catch {
+			this.config = {};
+		}
+		this.lastSaveFeedback = "Changes discarded";
+	}
+
 	async save(): Promise<void> {
 		if (!this.isDirty) {
 			this.lastSaveFeedback = "No changes to save";


### PR DESCRIPTION
## Summary
- Restructures settings page to show one section at a time via dropdown selector
- Separates Harnesses into its own section (was nested in Agent)
- Simplifies FormSection component (removed collapsible behavior)
- Adds consistent navigation with wrapping (1↔9)

## Changes
- **SettingsTab**: Single-section view with jump menu (Ctrl+J), keyboard nav (←/→, 1-9)
- **FormSection**: Removed `title`, `defaultOpen`, `dirty` props - sections always expanded
- **FormField**: Added `layout="horizontal"` (default) and `layout="vertical"` options
- **HarnessesSection**: New file for harness configuration
- **settings store**: Added `reset()` and `isAnyPathDirty()` methods
- Section selector fixed at 160px width for consistency
- Nav buttons wrap around at boundaries

## Test plan
- [x] `bun test` passes (588 tests)
- [x] Dashboard builds successfully
- [x] All 9 sections display correctly
- [x] Keyboard navigation works
- [x] Wrapping navigation (9→1, 1→9)