### PR TITLE
Refine constellation newness palette and source gating

### DIFF
--- a/packages/cli/dashboard/src/lib/components/embeddings/EmbeddingCanvas2D.svelte
+++ b/packages/cli/dashboard/src/lib/components/embeddings/EmbeddingCanvas2D.svelte
@@ -5,10 +5,12 @@ import {
 	type GraphEdge,
 	type GraphNode,
 	type GraphPhysicsConfig,
+	type NodeColorMode,
 	type RelationKind,
 	clampGraphPhysics,
 	edgeStrokeStyle,
 	embeddingLabel,
+	isNewSinceLastSeen,
 	nodeFillStyle,
 } from "./embedding-graph";
 
@@ -23,6 +25,10 @@ interface Props {
 	lensIds: Set<string>;
 	clusterLensMode: boolean;
 	graphPhysics: GraphPhysicsConfig;
+	colorMode: NodeColorMode;
+	nowMs: number;
+	showNewSinceLastSeen: boolean;
+	lastSeenMs: number | null;
 	onselectnode: (embedding: EmbeddingPoint | null) => void;
 	onhovernode: (embedding: EmbeddingPoint | null) => void;
 }
@@ -39,6 +45,10 @@ let {
 	lensIds,
 	clusterLensMode,
 	graphPhysics,
+	colorMode,
+	nowMs,
+	showNewSinceLastSeen,
+	lastSeenMs,
 	onselectnode,
 	onhovernode,
 }: Props = $props();
@@ -436,8 +446,18 @@ function draw(ctx: CanvasRenderingContext2D, now: number): void {
 			pinnedIds,
 			lensIds,
 			clusterLensMode,
+			colorMode,
+			nowMs,
 		);
 		ctx.fill();
+
+		if (showNewSinceLastSeen && isNewSinceLastSeen(node.data.createdAt, lastSeenMs)) {
+			ctx.beginPath();
+			ctx.arc(node.x, node.y, node.radius + 2.2, 0, Math.PI * 2);
+			ctx.strokeStyle = "rgba(246, 194, 107, 0.85)";
+			ctx.lineWidth = 1.1 / camZoom;
+			ctx.stroke();
+		}
 
 		if (pinnedIds.has(node.data.id)) {
 			const side = (node.radius + 2.5) * 2;

--- a/packages/cli/dashboard/src/lib/components/embeddings/EmbeddingCanvas2D.svelte
+++ b/packages/cli/dashboard/src/lib/components/embeddings/EmbeddingCanvas2D.svelte
@@ -29,6 +29,7 @@ interface Props {
 	nowMs: number;
 	showNewSinceLastSeen: boolean;
 	lastSeenMs: number | null;
+	sourceFocusSources: Set<string> | null;
 	onselectnode: (embedding: EmbeddingPoint | null) => void;
 	onhovernode: (embedding: EmbeddingPoint | null) => void;
 }
@@ -49,6 +50,7 @@ let {
 	nowMs,
 	showNewSinceLastSeen,
 	lastSeenMs,
+	sourceFocusSources,
 	onselectnode,
 	onhovernode,
 }: Props = $props();
@@ -448,6 +450,7 @@ function draw(ctx: CanvasRenderingContext2D, now: number): void {
 			clusterLensMode,
 			colorMode,
 			nowMs,
+			sourceFocusSources,
 		);
 		ctx.fill();
 

--- a/packages/cli/dashboard/src/lib/components/embeddings/EmbeddingCanvas3D.svelte
+++ b/packages/cli/dashboard/src/lib/components/embeddings/EmbeddingCanvas3D.svelte
@@ -7,6 +7,7 @@ import {
 	edgeColor3D,
 	embeddingLabel,
 	GRAPH_K,
+	type NodeColorMode,
 } from "./embedding-graph";
 
 interface Props {
@@ -18,6 +19,10 @@ interface Props {
 	pinnedIds: Set<string>;
 	lensIds: Set<string>;
 	clusterLensMode: boolean;
+	colorMode: NodeColorMode;
+	nowMs: number;
+	showNewSinceLastSeen: boolean;
+	lastSeenMs: number | null;
 	onselectnode: (embedding: EmbeddingPoint | null) => void;
 	onhovernode: (embedding: EmbeddingPoint | null) => void;
 	embeddingById: Map<string, EmbeddingPoint>;
@@ -32,6 +37,10 @@ let {
 	pinnedIds,
 	lensIds,
 	clusterLensMode,
+	colorMode,
+	nowMs,
+	showNewSinceLastSeen,
+	lastSeenMs,
 	onselectnode,
 	onhovernode,
 	embeddingById,
@@ -73,12 +82,17 @@ export function refreshAppearance(): void {
 		nodeColor3D(
 			String(node.id),
 			String(node.who ?? "unknown"),
+			embeddingById.get(String(node.id))?.createdAt,
 			graphSelected?.id ?? null,
 			embeddingFilterIds,
 			relationLookup,
 			pinnedIds,
 			lensIds,
 			clusterLensMode,
+			colorMode,
+			nowMs,
+			showNewSinceLastSeen,
+			lastSeenMs,
 		),
 	);
 	graph3d.linkColor((link: any) => {
@@ -138,12 +152,17 @@ export async function init(): Promise<void> {
 			nodeColor3D(
 				String(node.id),
 				String(node.who ?? "unknown"),
+				embeddingById.get(String(node.id))?.createdAt,
 				graphSelected?.id ?? null,
 				embeddingFilterIds,
 				relationLookup,
 				pinnedIds,
 				lensIds,
 				clusterLensMode,
+				colorMode,
+				nowMs,
+				showNewSinceLastSeen,
+				lastSeenMs,
 			),
 		)
 		.nodeVal(

--- a/packages/cli/dashboard/src/lib/components/embeddings/EmbeddingCanvas3D.svelte
+++ b/packages/cli/dashboard/src/lib/components/embeddings/EmbeddingCanvas3D.svelte
@@ -23,6 +23,7 @@ interface Props {
 	nowMs: number;
 	showNewSinceLastSeen: boolean;
 	lastSeenMs: number | null;
+	sourceFocusSources: Set<string> | null;
 	onselectnode: (embedding: EmbeddingPoint | null) => void;
 	onhovernode: (embedding: EmbeddingPoint | null) => void;
 	embeddingById: Map<string, EmbeddingPoint>;
@@ -41,6 +42,7 @@ let {
 	nowMs,
 	showNewSinceLastSeen,
 	lastSeenMs,
+	sourceFocusSources,
 	onselectnode,
 	onhovernode,
 	embeddingById,
@@ -93,6 +95,7 @@ export function refreshAppearance(): void {
 			nowMs,
 			showNewSinceLastSeen,
 			lastSeenMs,
+			sourceFocusSources,
 		),
 	);
 	graph3d.linkColor((link: any) => {
@@ -163,6 +166,7 @@ export async function init(): Promise<void> {
 				nowMs,
 				showNewSinceLastSeen,
 				lastSeenMs,
+				sourceFocusSources,
 			),
 		)
 		.nodeVal(

--- a/packages/cli/dashboard/src/lib/components/embeddings/embedding-graph.ts
+++ b/packages/cli/dashboard/src/lib/components/embeddings/embedding-graph.ts
@@ -45,11 +45,18 @@ export const sourceColors: Record<string, string> = {
 	unknown: "#737373",
 };
 
+const NEWNESS_HOUR_MS = 60 * 60 * 1000;
+const NEWNESS_DAY_MS = 24 * NEWNESS_HOUR_MS;
+const NEWNESS_WEEK_MS = 7 * NEWNESS_DAY_MS;
+const NEWNESS_MONTH_MS = 30 * NEWNESS_DAY_MS;
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
 export type RelationKind = "similar" | "dissimilar";
+
+export type NodeColorMode = "source" | "newness";
 
 export interface EmbeddingRelation {
 	id: string;
@@ -131,6 +138,46 @@ export function hexToRgb(hex: string): [number, number, number] {
 export function sourceColorRgba(who: string | undefined, alpha: number): string {
 	const [r, g, b] = hexToRgb(sourceColors[who ?? "unknown"] ?? sourceColors["unknown"]);
 	return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function parseCreatedAtMs(createdAt: string | undefined): number | null {
+	if (!createdAt) return null;
+	const parsed = new Date(createdAt).getTime();
+	if (Number.isNaN(parsed)) return null;
+	return parsed;
+}
+
+export function newnessIntensity(createdAt: string | undefined, nowMs: number): number {
+	const createdMs = parseCreatedAtMs(createdAt);
+	if (createdMs === null) return 0.35;
+	const ageMs = Math.max(0, nowMs - createdMs);
+	if (ageMs <= NEWNESS_HOUR_MS) return 1;
+	if (ageMs <= NEWNESS_DAY_MS) {
+		const t = (ageMs - NEWNESS_HOUR_MS) / (NEWNESS_DAY_MS - NEWNESS_HOUR_MS);
+		return 0.85 - t * 0.25;
+	}
+	if (ageMs <= NEWNESS_WEEK_MS) {
+		const t = (ageMs - NEWNESS_DAY_MS) / (NEWNESS_WEEK_MS - NEWNESS_DAY_MS);
+		return 0.6 - t * 0.35;
+	}
+	if (ageMs <= NEWNESS_MONTH_MS) {
+		const t = (ageMs - NEWNESS_WEEK_MS) / (NEWNESS_MONTH_MS - NEWNESS_WEEK_MS);
+		return 0.25 - t * 0.13;
+	}
+	return 0.12;
+}
+
+export function newnessFillStyle(intensity: number, alpha: number): string {
+	const normalized = Math.min(1, Math.max(0.08, intensity));
+	const lightness = Math.round(26 + normalized * 56);
+	return `hsla(38, 70%, ${lightness}%, ${alpha})`;
+}
+
+export function isNewSinceLastSeen(createdAt: string | undefined, lastSeenMs: number | null): boolean {
+	if (lastSeenMs === null) return false;
+	const createdMs = parseCreatedAtMs(createdAt);
+	if (createdMs === null) return false;
+	return createdMs > lastSeenMs;
 }
 
 // ---------------------------------------------------------------------------
@@ -353,6 +400,8 @@ export function nodeFillStyle(
 	pinnedIds: Set<string>,
 	lensIds: Set<string>,
 	lensActive: boolean,
+	colorMode: NodeColorMode,
+	nowMs: number,
 ): string {
 	const id = node.data.id;
 	const relation = relations.get(id) ?? null;
@@ -366,6 +415,10 @@ export function nodeFillStyle(
 	if (relation === "dissimilar") return dimmed ? "rgba(255, 146, 146, 0.35)" : "rgba(255, 146, 146, 0.9)";
 	if (isPinned) return dimmed ? "rgba(220, 220, 220, 0.42)" : "rgba(235, 235, 235, 0.95)";
 	if (dimmed) return "rgba(120, 120, 120, 0.2)";
+	if (colorMode === "newness") {
+		const intensity = newnessIntensity(node.data.createdAt, nowMs);
+		return newnessFillStyle(intensity, 0.9);
+	}
 	return sourceColorRgba(node.data.who, 0.85);
 }
 
@@ -395,12 +448,17 @@ export function edgeStrokeStyle(
 export function nodeColor3D(
 	id: string,
 	who: string,
+	createdAt: string | undefined,
 	selectedId: string | null,
 	filterIds: Set<string> | null,
 	relations: Map<string, RelationKind>,
 	pinnedIds: Set<string>,
 	lensIds: Set<string>,
 	lensActive: boolean,
+	colorMode: NodeColorMode,
+	nowMs: number,
+	showNewSinceLastSeen: boolean,
+	lastSeenMs: number | null,
 ): string {
 	if (selectedId === id) return "#ffffff";
 	if (lensActive && !lensIds.has(id)) return "#3b3b3b";
@@ -410,6 +468,8 @@ export function nodeColor3D(
 	if (pinnedIds.has(id)) return "#e5e7eb";
 	const dimmed = filterIds !== null && !filterIds.has(id);
 	if (dimmed) return "#5b5b5b";
+	if (showNewSinceLastSeen && isNewSinceLastSeen(createdAt, lastSeenMs)) return "#f6c26b";
+	if (colorMode === "newness") return newnessFillStyle(newnessIntensity(createdAt, nowMs), 1);
 	return sourceColors[who] ?? sourceColors["unknown"];
 }
 

--- a/packages/cli/dashboard/src/lib/components/embeddings/embedding-graph.ts
+++ b/packages/cli/dashboard/src/lib/components/embeddings/embedding-graph.ts
@@ -167,11 +167,15 @@ function newnessBucketFromIntensity(intensity: number): NewnessBucket {
 	return "older";
 }
 
+export function newnessBucket(createdAt: string | undefined, nowMs: number): NewnessBucket {
+	return newnessBucketFromIntensity(newnessIntensity(createdAt, nowMs));
+}
+
 export function newnessFillStyle(intensity: number, alpha: number): string {
 	const bucket = newnessBucketFromIntensity(intensity);
-	if (bucket === "minutes") return `rgba(255, 246, 150, ${alpha})`;
-	if (bucket === "hours") return `rgba(255, 198, 96, ${alpha})`;
-	if (bucket === "week") return `rgba(244, 146, 78, ${alpha})`;
+	if (bucket === "minutes") return `rgba(255, 255, 255, ${alpha})`;
+	if (bucket === "hours") return `rgba(168, 34, 98, ${alpha})`;
+	if (bucket === "week") return `rgba(76, 34, 122, ${alpha})`;
 	return `rgba(118, 111, 102, ${alpha})`;
 }
 
@@ -418,6 +422,7 @@ export function nodeFillStyle(
 	if (isPinned) return dimmed ? "rgba(220, 220, 220, 0.42)" : "rgba(235, 235, 235, 0.95)";
 	if (dimmed) return "rgba(120, 120, 120, 0.2)";
 	if (colorMode === "newness") {
+		if (newnessBucket(node.data.createdAt, nowMs) === "older") return sourceColorRgba(node.data.who, 0.85);
 		const intensity = newnessIntensity(node.data.createdAt, nowMs);
 		return newnessFillStyle(intensity, 0.9);
 	}
@@ -471,7 +476,10 @@ export function nodeColor3D(
 	const dimmed = filterIds !== null && !filterIds.has(id);
 	if (dimmed) return "#5b5b5b";
 	if (showNewSinceLastSeen && isNewSinceLastSeen(createdAt, lastSeenMs)) return "#f6c26b";
-	if (colorMode === "newness") return newnessFillStyle(newnessIntensity(createdAt, nowMs), 1);
+	if (colorMode === "newness") {
+		if (newnessBucket(createdAt, nowMs) === "older") return sourceColors[who] ?? sourceColors["unknown"];
+		return newnessFillStyle(newnessIntensity(createdAt, nowMs), 1);
+	}
 	return sourceColors[who] ?? sourceColors["unknown"];
 }
 

--- a/packages/cli/dashboard/src/lib/components/embeddings/embedding-graph.ts
+++ b/packages/cli/dashboard/src/lib/components/embeddings/embedding-graph.ts
@@ -48,7 +48,10 @@ export const sourceColors: Record<string, string> = {
 const NEWNESS_HOUR_MS = 60 * 60 * 1000;
 const NEWNESS_DAY_MS = 24 * NEWNESS_HOUR_MS;
 const NEWNESS_WEEK_MS = 7 * NEWNESS_DAY_MS;
-const NEWNESS_MONTH_MS = 30 * NEWNESS_DAY_MS;
+const NEWNESS_MINUTES_MS = 15 * 60 * 1000;
+const NEWNESS_HOURS_MS = 6 * NEWNESS_HOUR_MS;
+
+type NewnessBucket = "minutes" | "hours" | "week" | "older";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -149,28 +152,27 @@ function parseCreatedAtMs(createdAt: string | undefined): number | null {
 
 export function newnessIntensity(createdAt: string | undefined, nowMs: number): number {
 	const createdMs = parseCreatedAtMs(createdAt);
-	if (createdMs === null) return 0.35;
+	if (createdMs === null) return 0.22;
 	const ageMs = Math.max(0, nowMs - createdMs);
-	if (ageMs <= NEWNESS_HOUR_MS) return 1;
-	if (ageMs <= NEWNESS_DAY_MS) {
-		const t = (ageMs - NEWNESS_HOUR_MS) / (NEWNESS_DAY_MS - NEWNESS_HOUR_MS);
-		return 0.85 - t * 0.25;
-	}
-	if (ageMs <= NEWNESS_WEEK_MS) {
-		const t = (ageMs - NEWNESS_DAY_MS) / (NEWNESS_WEEK_MS - NEWNESS_DAY_MS);
-		return 0.6 - t * 0.35;
-	}
-	if (ageMs <= NEWNESS_MONTH_MS) {
-		const t = (ageMs - NEWNESS_WEEK_MS) / (NEWNESS_MONTH_MS - NEWNESS_WEEK_MS);
-		return 0.25 - t * 0.13;
-	}
-	return 0.12;
+	if (ageMs <= NEWNESS_MINUTES_MS) return 1;
+	if (ageMs <= NEWNESS_HOURS_MS) return 0.76;
+	if (ageMs <= NEWNESS_WEEK_MS) return 0.52;
+	return 0.22;
+}
+
+function newnessBucketFromIntensity(intensity: number): NewnessBucket {
+	if (intensity >= 0.95) return "minutes";
+	if (intensity >= 0.7) return "hours";
+	if (intensity >= 0.45) return "week";
+	return "older";
 }
 
 export function newnessFillStyle(intensity: number, alpha: number): string {
-	const normalized = Math.min(1, Math.max(0.08, intensity));
-	const lightness = Math.round(26 + normalized * 56);
-	return `hsla(38, 70%, ${lightness}%, ${alpha})`;
+	const bucket = newnessBucketFromIntensity(intensity);
+	if (bucket === "minutes") return `rgba(255, 246, 150, ${alpha})`;
+	if (bucket === "hours") return `rgba(255, 198, 96, ${alpha})`;
+	if (bucket === "week") return `rgba(244, 146, 78, ${alpha})`;
+	return `rgba(118, 111, 102, ${alpha})`;
 }
 
 export function isNewSinceLastSeen(createdAt: string | undefined, lastSeenMs: number | null): boolean {

--- a/packages/cli/dashboard/src/lib/components/embeddings/embedding-graph.ts
+++ b/packages/cli/dashboard/src/lib/components/embeddings/embedding-graph.ts
@@ -173,7 +173,7 @@ export function newnessBucket(createdAt: string | undefined, nowMs: number): New
 
 export function newnessFillStyle(intensity: number, alpha: number): string {
 	const bucket = newnessBucketFromIntensity(intensity);
-	if (bucket === "minutes") return `rgba(255, 255, 255, ${alpha})`;
+	if (bucket === "minutes") return `rgba(255, 176, 74, ${alpha})`;
 	if (bucket === "hours") return `rgba(168, 34, 98, ${alpha})`;
 	if (bucket === "week") return `rgba(76, 34, 122, ${alpha})`;
 	return `rgba(118, 111, 102, ${alpha})`;
@@ -408,6 +408,7 @@ export function nodeFillStyle(
 	lensActive: boolean,
 	colorMode: NodeColorMode,
 	nowMs: number,
+	sourceFocusSources: Set<string> | null,
 ): string {
 	const id = node.data.id;
 	const relation = relations.get(id) ?? null;
@@ -422,7 +423,12 @@ export function nodeFillStyle(
 	if (isPinned) return dimmed ? "rgba(220, 220, 220, 0.42)" : "rgba(235, 235, 235, 0.95)";
 	if (dimmed) return "rgba(120, 120, 120, 0.2)";
 	if (colorMode === "newness") {
-		if (newnessBucket(node.data.createdAt, nowMs) === "older") return sourceColorRgba(node.data.who, 0.85);
+		if (newnessBucket(node.data.createdAt, nowMs) === "older") {
+			const source = node.data.who ?? "unknown";
+			if (sourceFocusSources !== null && sourceFocusSources.has(source)) {
+				return sourceColorRgba(source, 0.85);
+			}
+		}
 		const intensity = newnessIntensity(node.data.createdAt, nowMs);
 		return newnessFillStyle(intensity, 0.9);
 	}
@@ -466,6 +472,7 @@ export function nodeColor3D(
 	nowMs: number,
 	showNewSinceLastSeen: boolean,
 	lastSeenMs: number | null,
+	sourceFocusSources: Set<string> | null,
 ): string {
 	if (selectedId === id) return "#ffffff";
 	if (lensActive && !lensIds.has(id)) return "#3b3b3b";
@@ -477,7 +484,11 @@ export function nodeColor3D(
 	if (dimmed) return "#5b5b5b";
 	if (showNewSinceLastSeen && isNewSinceLastSeen(createdAt, lastSeenMs)) return "#f6c26b";
 	if (colorMode === "newness") {
-		if (newnessBucket(createdAt, nowMs) === "older") return sourceColors[who] ?? sourceColors["unknown"];
+		if (newnessBucket(createdAt, nowMs) === "older") {
+			if (sourceFocusSources !== null && sourceFocusSources.has(who)) {
+				return sourceColors[who] ?? sourceColors["unknown"];
+			}
+		}
 		return newnessFillStyle(newnessIntensity(createdAt, nowMs), 1);
 	}
 	return sourceColors[who] ?? sourceColors["unknown"];

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -33,9 +33,12 @@ import {
 	type GraphNode,
 	type GraphPhysicsConfig,
 	MAX_EMBEDDING_LIMIT,
+	type NodeColorMode,
 	type RelationKind,
 	clampGraphPhysics,
 	embeddingLabel,
+	newnessFillStyle,
+	newnessIntensity,
 	sourceColorRgba,
 } from "../embeddings/embedding-graph";
 
@@ -95,6 +98,10 @@ let sourcesMenuOpen = $state(true);
 const LEGEND_PRIORITY_SOURCES = ["daemon", "user", "opencode"] as const;
 const LEGEND_PRIORITY_SOURCE_SET = new Set<string>(LEGEND_PRIORITY_SOURCES);
 
+const NODE_COLOR_MODE_STORAGE_KEY = "signet-constellation-color-mode";
+const NEW_SINCE_STORAGE_KEY = "signet-constellation-new-since";
+const LAST_SEEN_STORAGE_KEY = "signet-constellation-last-seen";
+
 type TimeFilterPreset = "all" | "24h" | "7d" | "30d" | "90d" | "custom";
 
 let projectionRangeMin = $state(0);
@@ -124,6 +131,13 @@ let dissimilarNeighbors = $state<EmbeddingRelation[]>([]);
 let activeNeighbors = $state<EmbeddingRelation[]>([]);
 let loadingGlobalSimilar = $state(false);
 let globalSimilar = $state<Memory[]>([]);
+
+let nodeColorMode = $state<NodeColorMode>("newness");
+let showNewSinceLastSeen = $state(false);
+let lastSeenMs = $state<number | null>(null);
+let lastSeenWriteMs = $state<number | null>(null);
+let viewSettingsHydrated = $state(false);
+let newnessNowMs = $state(Date.now());
 
 let nodes = $state<GraphNode[]>([]);
 let edges = $state<GraphEdge[]>([]);
@@ -245,6 +259,11 @@ function formatShortDate(dateLike: string | undefined): string {
 		hour: "2-digit",
 		minute: "2-digit",
 	});
+}
+
+function newnessLegendColor(ageMs: number, alpha: number): string {
+	const createdAt = new Date(newnessNowMs - ageMs).toISOString();
+	return newnessFillStyle(newnessIntensity(createdAt, newnessNowMs), alpha);
 }
 
 function normalizeProjectionWindow(): { offset: number; limit: number } {
@@ -1054,6 +1073,42 @@ $effect(() => {
 });
 
 $effect(() => {
+	if (typeof window === "undefined" || viewSettingsHydrated) return;
+	try {
+		const rawMode = window.localStorage.getItem(NODE_COLOR_MODE_STORAGE_KEY);
+		if (rawMode === "source" || rawMode === "newness") nodeColorMode = rawMode;
+		const rawNewSince = window.localStorage.getItem(NEW_SINCE_STORAGE_KEY);
+		if (rawNewSince === "true" || rawNewSince === "false") {
+			showNewSinceLastSeen = rawNewSince === "true";
+		}
+		const rawLastSeen = window.localStorage.getItem(LAST_SEEN_STORAGE_KEY);
+		if (rawLastSeen) {
+			const parsed = Number.parseInt(rawLastSeen, 10);
+			if (!Number.isNaN(parsed)) lastSeenMs = parsed;
+		}
+	} finally {
+		viewSettingsHydrated = true;
+	}
+});
+
+$effect(() => {
+	if (typeof window === "undefined" || !viewSettingsHydrated) return;
+	window.localStorage.setItem(NODE_COLOR_MODE_STORAGE_KEY, nodeColorMode);
+	window.localStorage.setItem(NEW_SINCE_STORAGE_KEY, String(showNewSinceLastSeen));
+	if (lastSeenWriteMs !== null) {
+		window.localStorage.setItem(LAST_SEEN_STORAGE_KEY, String(lastSeenWriteMs));
+	}
+});
+
+$effect(() => {
+	if (typeof window === "undefined") return;
+	const timer = window.setInterval(() => {
+		newnessNowMs = Date.now();
+	}, 60000);
+	return () => window.clearInterval(timer);
+});
+
+$effect(() => {
 	const ids = new Set<string>();
 	if (clusterLensMode) {
 		const seed = graphSelected ?? previewHovered;
@@ -1072,6 +1127,21 @@ $effect(() => {
 	clusterLensMode;
 	lensIds;
 	scheduleRefresh3d();
+});
+
+$effect(() => {
+	nodeColorMode;
+	showNewSinceLastSeen;
+	newnessNowMs;
+	lastSeenMs;
+	if (graphMode === "2d") canvas2d?.requestRedraw();
+	scheduleRefresh3d();
+});
+
+$effect(() => {
+	if (!graphInitialized || typeof window === "undefined") return;
+	if (lastSeenWriteMs !== null) return;
+	lastSeenWriteMs = Date.now();
 });
 
 $effect(() => {
@@ -1329,34 +1399,55 @@ $effect(() => {
 			</div>
 		{/if}
 
-		<div class="absolute left-3 bottom-3 z-[8] pointer-events-none space-y-2 max-w-[320px]">
-			<div class="pointer-events-auto border border-[rgba(255,255,255,0.2)] bg-[rgba(5,5,5,0.72)] px-2 py-1.5">
-				<div class="text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.06em] text-[var(--sig-text-muted)] mb-1">Legend</div>
-				<div class="text-[10px] text-[var(--sig-text-muted)] leading-[1.35] mb-1">
-					<span class="text-[var(--sig-text)]">Color</span> = source
-				</div>
-				<div class="flex flex-wrap gap-1 mb-1.5">
-					{#each legendSourceCounts as source}
-						<span class="h-5 inline-flex items-center gap-1 px-1.5 py-0 font-[family-name:var(--font-mono)] text-[10px] border border-[rgba(255,255,255,0.14)] {selectedSources.size === 0 || selectedSources.has(source.who) ? 'bg-[rgba(255,255,255,0.08)] text-[var(--sig-text-bright)]' : 'bg-transparent text-[var(--sig-text-muted)]'}">
-							<span class="inline-block w-[6px] h-[6px] rounded-full" style={`background:${sourceColorRgba(source.who, 1)}`}></span>
-							{source.who} {source.count}
-						</span>
-					{/each}
-				</div>
-				<div class="text-[10px] text-[var(--sig-text-muted)] leading-[1.35] mb-1">
-					<span class="text-[var(--sig-text)]">Radius</span> = importance
-				</div>
-				<div class="flex items-center gap-2 text-[10px] text-[var(--sig-text-muted)] mb-1.5">
-					<span class="inline-block w-[6px] h-[6px] rounded-full border border-[rgba(255,255,255,0.24)]"></span>
-					<span class="inline-block w-[9px] h-[9px] rounded-full border border-[rgba(255,255,255,0.28)]"></span>
-					<span class="inline-block w-[12px] h-[12px] rounded-full border border-[rgba(255,255,255,0.32)]"></span>
-					<span>low to high</span>
-				</div>
-				<div class="text-[10px] text-[var(--sig-text-muted)] leading-[1.35]">
-					<span class="text-[var(--sig-text)]">Relation highlight</span> = selected node neighborhood emphasis
+			<div class="absolute left-3 bottom-3 z-[8] pointer-events-none space-y-2 max-w-[320px]">
+				<div class="pointer-events-auto border border-[rgba(255,255,255,0.2)] bg-[rgba(5,5,5,0.72)] px-2 py-1.5">
+					<div class="text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.06em] text-[var(--sig-text-muted)] mb-1">Legend</div>
+					<div class="text-[10px] text-[var(--sig-text-muted)] leading-[1.35] mb-1">
+						<span class="text-[var(--sig-text)]">Color</span> = {nodeColorMode === "newness" ? "newness" : "source"}
+					</div>
+					{#if nodeColorMode === "newness"}
+						<div class="flex items-center gap-2 text-[10px] text-[var(--sig-text-muted)] mb-1.5">
+							<span class="inline-block w-[7px] h-[7px] rounded-full" style={`background:${newnessLegendColor(30 * 60 * 1000, 0.95)}`}></span>
+							<span class="inline-block w-[7px] h-[7px] rounded-full" style={`background:${newnessLegendColor(12 * 60 * 60 * 1000, 0.85)}`}></span>
+							<span class="inline-block w-[7px] h-[7px] rounded-full" style={`background:${newnessLegendColor(7 * 24 * 60 * 60 * 1000, 0.75)}`}></span>
+							<span>last hour → week+</span>
+						</div>
+						<div class="flex flex-wrap gap-1 mb-1.5">
+							{#each legendSourceCounts as source}
+								<span class="h-5 inline-flex items-center gap-1 px-1.5 py-0 font-[family-name:var(--font-mono)] text-[10px] border border-[rgba(255,255,255,0.14)] {selectedSources.size === 0 || selectedSources.has(source.who) ? 'bg-[rgba(255,255,255,0.08)] text-[var(--sig-text-bright)]' : 'bg-transparent text-[var(--sig-text-muted)]'}">
+									{source.who} {source.count}
+								</span>
+							{/each}
+						</div>
+					{:else}
+						<div class="flex flex-wrap gap-1 mb-1.5">
+							{#each legendSourceCounts as source}
+								<span class="h-5 inline-flex items-center gap-1 px-1.5 py-0 font-[family-name:var(--font-mono)] text-[10px] border border-[rgba(255,255,255,0.14)] {selectedSources.size === 0 || selectedSources.has(source.who) ? 'bg-[rgba(255,255,255,0.08)] text-[var(--sig-text-bright)]' : 'bg-transparent text-[var(--sig-text-muted)]'}">
+									<span class="inline-block w-[6px] h-[6px] rounded-full" style={`background:${sourceColorRgba(source.who, 1)}`}></span>
+									{source.who} {source.count}
+								</span>
+							{/each}
+						</div>
+					{/if}
+					<div class="text-[10px] text-[var(--sig-text-muted)] leading-[1.35] mb-1">
+						<span class="text-[var(--sig-text)]">Radius</span> = importance
+					</div>
+					<div class="flex items-center gap-2 text-[10px] text-[var(--sig-text-muted)] mb-1.5">
+						<span class="inline-block w-[6px] h-[6px] rounded-full border border-[rgba(255,255,255,0.24)]"></span>
+						<span class="inline-block w-[9px] h-[9px] rounded-full border border-[rgba(255,255,255,0.28)]"></span>
+						<span class="inline-block w-[12px] h-[12px] rounded-full border border-[rgba(255,255,255,0.32)]"></span>
+						<span>low to high</span>
+					</div>
+					{#if showNewSinceLastSeen}
+						<div class="text-[10px] text-[var(--sig-text-muted)] leading-[1.35] mb-1">
+							<span class="text-[var(--sig-text)]">Outline</span> = new since last seen
+						</div>
+					{/if}
+					<div class="text-[10px] text-[var(--sig-text-muted)] leading-[1.35]">
+						<span class="text-[var(--sig-text)]">Relation highlight</span> = selected node neighborhood emphasis
+					</div>
 				</div>
 			</div>
-		</div>
 
 		{#if graphStatus}
 			<div class="absolute inset-0 flex items-center justify-center bg-[var(--sig-bg)] z-10">
@@ -1449,7 +1540,11 @@ $effect(() => {
 					{pinnedIds}
 					{lensIds}
 					clusterLensMode={clusterLensMode && lensIds.size > 0}
-					onselectnode={(e) => {
+					colorMode={nodeColorMode}
+					nowMs={newnessNowMs}
+					showNewSinceLastSeen={showNewSinceLastSeen}
+					lastSeenMs={lastSeenMs}
+					onselectnode={(e: EmbeddingPoint | null) => {
 						if (e) selectEmbeddingById(e.id);
 						else graphSelected = null;
 					}}
@@ -1479,7 +1574,11 @@ $effect(() => {
 					{lensIds}
 					clusterLensMode={clusterLensMode && lensIds.size > 0}
 					{embeddingById}
-					onselectnode={(e) => {
+					colorMode={nodeColorMode}
+					nowMs={newnessNowMs}
+					showNewSinceLastSeen={showNewSinceLastSeen}
+					lastSeenMs={lastSeenMs}
+					onselectnode={(e: EmbeddingPoint | null) => {
 						if (e) selectEmbeddingById(e.id);
 						else graphSelected = null;
 					}}
@@ -1520,6 +1619,14 @@ $effect(() => {
 								<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {showNeighborhoodOnly ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={toggleNeighborhoodOnly}>Neighborhood</button>
 								<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {clusterLensMode ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={toggleClusterLens}>Lens</button>
 								<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] text-[var(--sig-text-muted)] hover:text-[var(--sig-text-bright)]" onclick={resetProjectionFilters}>{ActionLabels.Reset}</button>
+							</div>
+							<div class="border border-[var(--sig-border)] px-2 py-2 space-y-1.5">
+								<div class="font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] text-[var(--sig-text-muted)]">Color Mode</div>
+								<div class="flex flex-wrap gap-1">
+									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {nodeColorMode === 'newness' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (nodeColorMode = "newness")}>Newness</button>
+									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {nodeColorMode === 'source' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (nodeColorMode = "source")}>Source</button>
+									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {showNewSinceLastSeen ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (showNewSinceLastSeen = !showNewSinceLastSeen)}>New since last seen</button>
+								</div>
 							</div>
 							<div class="border border-[var(--sig-border)] px-2 py-2 space-y-1.5">
 								<div class="font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] text-[var(--sig-text-muted)]">Graph Physics</div>

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -1410,7 +1410,7 @@ $effect(() => {
 							<span class="inline-flex items-center gap-1"><span class="inline-block w-[8px] h-[8px] rounded-full" style={`background:${newnessLegendColor(5 * 60 * 1000, 0.95)}`}></span>last few minutes</span>
 							<span class="inline-flex items-center gap-1"><span class="inline-block w-[8px] h-[8px] rounded-full" style={`background:${newnessLegendColor(3 * 60 * 60 * 1000, 0.9)}`}></span>last few hours</span>
 							<span class="inline-flex items-center gap-1"><span class="inline-block w-[8px] h-[8px] rounded-full" style={`background:${newnessLegendColor(3 * 24 * 60 * 60 * 1000, 0.85)}`}></span>last week</span>
-							<span class="inline-flex items-center gap-1"><span class="inline-block w-[8px] h-[8px] rounded-full border border-[rgba(255,255,255,0.28)]" style={`background:${sourceColorRgba('unknown', 0.95)}`}></span>older (source)</span>
+							<span class="inline-flex items-center gap-1"><span class="inline-block w-[8px] h-[8px] rounded-full" style={`background:${newnessLegendColor(30 * 24 * 60 * 60 * 1000, 0.85)}`}></span>older</span>
 						</div>
 						<div class="flex flex-wrap gap-1 mb-1.5">
 							{#each legendSourceCounts as source}
@@ -1544,6 +1544,7 @@ $effect(() => {
 					nowMs={newnessNowMs}
 					showNewSinceLastSeen={showNewSinceLastSeen}
 					lastSeenMs={lastSeenMs}
+					sourceFocusSources={selectedSources.size > 0 ? selectedSources : null}
 					onselectnode={(e: EmbeddingPoint | null) => {
 						if (e) selectEmbeddingById(e.id);
 						else graphSelected = null;
@@ -1578,6 +1579,7 @@ $effect(() => {
 					nowMs={newnessNowMs}
 					showNewSinceLastSeen={showNewSinceLastSeen}
 					lastSeenMs={lastSeenMs}
+					sourceFocusSources={selectedSources.size > 0 ? selectedSources : null}
 					onselectnode={(e: EmbeddingPoint | null) => {
 						if (e) selectEmbeddingById(e.id);
 						else graphSelected = null;

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -1410,7 +1410,7 @@ $effect(() => {
 							<span class="inline-flex items-center gap-1"><span class="inline-block w-[8px] h-[8px] rounded-full" style={`background:${newnessLegendColor(5 * 60 * 1000, 0.95)}`}></span>last few minutes</span>
 							<span class="inline-flex items-center gap-1"><span class="inline-block w-[8px] h-[8px] rounded-full" style={`background:${newnessLegendColor(3 * 60 * 60 * 1000, 0.9)}`}></span>last few hours</span>
 							<span class="inline-flex items-center gap-1"><span class="inline-block w-[8px] h-[8px] rounded-full" style={`background:${newnessLegendColor(3 * 24 * 60 * 60 * 1000, 0.85)}`}></span>last week</span>
-							<span class="inline-flex items-center gap-1"><span class="inline-block w-[8px] h-[8px] rounded-full" style={`background:${newnessLegendColor(30 * 24 * 60 * 60 * 1000, 0.8)}`}></span>older</span>
+							<span class="inline-flex items-center gap-1"><span class="inline-block w-[8px] h-[8px] rounded-full border border-[rgba(255,255,255,0.28)]" style={`background:${sourceColorRgba('unknown', 0.95)}`}></span>older (source)</span>
 						</div>
 						<div class="flex flex-wrap gap-1 mb-1.5">
 							{#each legendSourceCounts as source}

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -1406,11 +1406,11 @@ $effect(() => {
 						<span class="text-[var(--sig-text)]">Color</span> = {nodeColorMode === "newness" ? "newness" : "source"}
 					</div>
 					{#if nodeColorMode === "newness"}
-						<div class="flex items-center gap-2 text-[10px] text-[var(--sig-text-muted)] mb-1.5">
-							<span class="inline-block w-[7px] h-[7px] rounded-full" style={`background:${newnessLegendColor(30 * 60 * 1000, 0.95)}`}></span>
-							<span class="inline-block w-[7px] h-[7px] rounded-full" style={`background:${newnessLegendColor(12 * 60 * 60 * 1000, 0.85)}`}></span>
-							<span class="inline-block w-[7px] h-[7px] rounded-full" style={`background:${newnessLegendColor(7 * 24 * 60 * 60 * 1000, 0.75)}`}></span>
-							<span>last hour → week+</span>
+						<div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-[var(--sig-text-muted)] mb-1.5">
+							<span class="inline-flex items-center gap-1"><span class="inline-block w-[8px] h-[8px] rounded-full" style={`background:${newnessLegendColor(5 * 60 * 1000, 0.95)}`}></span>last few minutes</span>
+							<span class="inline-flex items-center gap-1"><span class="inline-block w-[8px] h-[8px] rounded-full" style={`background:${newnessLegendColor(3 * 60 * 60 * 1000, 0.9)}`}></span>last few hours</span>
+							<span class="inline-flex items-center gap-1"><span class="inline-block w-[8px] h-[8px] rounded-full" style={`background:${newnessLegendColor(3 * 24 * 60 * 60 * 1000, 0.85)}`}></span>last week</span>
+							<span class="inline-flex items-center gap-1"><span class="inline-block w-[8px] h-[8px] rounded-full" style={`background:${newnessLegendColor(30 * 24 * 60 * 60 * 1000, 0.8)}`}></span>older</span>
 						</div>
 						<div class="flex flex-wrap gap-1 mb-1.5">
 							{#each legendSourceCounts as source}


### PR DESCRIPTION
## Summary
- tighten newness mode colors to explicit buckets: yellow/orange (last few minutes), dark pink (last few hours), dark purple (last week), and neutral older
- prevent source colors (like daemon/opencode green/blue) from showing in newness mode unless that source is explicitly selected in the legend filters
- thread source-focus state through 2D/3D renderers so both views behave consistently, and update legend copy/swatches to match

## Validation
- `cd packages/cli/dashboard && bun run build`