### PR TITLE
fix(daemon): prevent MCP marketplace static routes from being shadowed

### DIFF
--- a/packages/daemon/src/routes/marketplace.test.ts
+++ b/packages/daemon/src/routes/marketplace.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "bun:test";
-import { extractStandardMcpConfig, parseReferenceServersMarkdown } from "./marketplace.js";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Hono } from "hono";
+import { extractStandardMcpConfig, mountMarketplaceRoutes, parseReferenceServersMarkdown } from "./marketplace.js";
 
 describe("parseReferenceServersMarkdown", () => {
 	it("parses official reference server section", () => {
@@ -74,5 +78,61 @@ describe("extractStandardMcpConfig", () => {
 			expect(detail.config.command).toBe("uvx");
 			expect(detail.config.args[0]).toBe("mcp-server-time");
 		}
+	});
+});
+
+describe("marketplace routes", () => {
+	const tmpAgentsDir = join(tmpdir(), `signet-marketplace-route-test-${process.pid}`);
+	let origSignetPath: string | undefined;
+	let app: Hono;
+
+	beforeEach(() => {
+		origSignetPath = process.env.SIGNET_PATH;
+		process.env.SIGNET_PATH = tmpAgentsDir;
+		mkdirSync(tmpAgentsDir, { recursive: true });
+
+		app = new Hono();
+		mountMarketplaceRoutes(app);
+	});
+
+	afterEach(() => {
+		process.env.SIGNET_PATH = origSignetPath;
+		if (existsSync(tmpAgentsDir)) {
+			rmSync(tmpAgentsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("GET /api/marketplace/mcp/tools resolves to tools handler", async () => {
+		const res = await app.request("/api/marketplace/mcp/tools");
+		expect(res.status).toBe(200);
+
+		const body = (await res.json()) as {
+			count: number;
+			tools: unknown[];
+			servers: unknown[];
+			error?: string;
+		};
+
+		expect(body.error).toBeUndefined();
+		expect(body.count).toBe(0);
+		expect(body.tools).toEqual([]);
+		expect(body.servers).toEqual([]);
+	});
+
+	it("GET /api/marketplace/mcp/search resolves to search handler", async () => {
+		const res = await app.request("/api/marketplace/mcp/search?q=time");
+		expect(res.status).toBe(200);
+
+		const body = (await res.json()) as {
+			query: string;
+			count: number;
+			results: unknown[];
+			error?: string;
+		};
+
+		expect(body.error).toBeUndefined();
+		expect(body.query).toBe("time");
+		expect(body.count).toBe(0);
+		expect(body.results).toEqual([]);
 	});
 });

--- a/packages/daemon/src/routes/marketplace.ts
+++ b/packages/daemon/src/routes/marketplace.ts
@@ -1298,69 +1298,6 @@ export function mountMarketplaceRoutes(app: Hono): void {
 		return c.json({ success: true, server });
 	});
 
-	app.get("/api/marketplace/mcp/:id", (c) => {
-		const id = c.req.param("id");
-		const installed = readInstalledServers();
-		const server = installed.find((item) => item.id === id);
-		if (!server) {
-			return c.json({ error: "Server not found" }, 404);
-		}
-
-		const context = extractContextFromRequest(c);
-		if (hasScopeContext(context) && !scopeMatches(server.scope, context)) {
-			return c.json({ error: "Server is out of scope for current context" }, 403);
-		}
-
-		return c.json({ server, context });
-	});
-
-	app.patch("/api/marketplace/mcp/:id", async (c) => {
-		const id = c.req.param("id");
-		let body: { enabled?: boolean; config?: unknown; name?: string; description?: string; scope?: unknown } = {};
-		try {
-			body = await c.req.json();
-		} catch {
-			return c.json({ error: "Invalid JSON body" }, 400);
-		}
-
-		const installed = readInstalledServers();
-		const existing = installed.find((s) => s.id === id);
-		if (!existing) return c.json({ error: "Server not found" }, 404);
-
-		const normalized = body.config ? normalizeMcpConfig(body.config) : null;
-		if (body.config && !normalized) {
-			return c.json({ error: "Invalid config" }, 400);
-		}
-
-		const updated: InstalledMarketplaceMcpServer = {
-			...existing,
-			enabled: typeof body.enabled === "boolean" ? body.enabled : existing.enabled,
-			scope: body.scope === undefined ? existing.scope : normalizeScope(body.scope),
-			config: normalized ?? existing.config,
-			name: typeof body.name === "string" && body.name.trim().length > 0 ? body.name.trim() : existing.name,
-			description:
-				typeof body.description === "string" && body.description.trim().length > 0
-					? body.description.trim()
-					: existing.description,
-			updatedAt: new Date().toISOString(),
-		};
-
-		writeInstalledServers(installed.map((s) => (s.id === id ? updated : s)));
-		invalidateMarketplaceToolsCache();
-		return c.json({ success: true, server: updated });
-	});
-
-	app.delete("/api/marketplace/mcp/:id", (c) => {
-		const id = c.req.param("id");
-		const installed = readInstalledServers();
-		if (!installed.some((s) => s.id === id)) {
-			return c.json({ error: "Server not found" }, 404);
-		}
-		writeInstalledServers(installed.filter((s) => s.id !== id));
-		invalidateMarketplaceToolsCache();
-		return c.json({ success: true, id });
-	});
-
 	app.get("/api/marketplace/mcp/tools", async (c) => {
 		const installed = readInstalledServers();
 		const context = extractContextFromRequest(c);
@@ -1446,5 +1383,68 @@ export function mountMarketplaceRoutes(app: Hono): void {
 			const msg = error instanceof Error ? error.message : String(error);
 			return c.json({ success: false, error: msg }, 500);
 		}
+	});
+
+	app.get("/api/marketplace/mcp/:id", (c) => {
+		const id = c.req.param("id");
+		const installed = readInstalledServers();
+		const server = installed.find((item) => item.id === id);
+		if (!server) {
+			return c.json({ error: "Server not found" }, 404);
+		}
+
+		const context = extractContextFromRequest(c);
+		if (hasScopeContext(context) && !scopeMatches(server.scope, context)) {
+			return c.json({ error: "Server is out of scope for current context" }, 403);
+		}
+
+		return c.json({ server, context });
+	});
+
+	app.patch("/api/marketplace/mcp/:id", async (c) => {
+		const id = c.req.param("id");
+		let body: { enabled?: boolean; config?: unknown; name?: string; description?: string; scope?: unknown } = {};
+		try {
+			body = await c.req.json();
+		} catch {
+			return c.json({ error: "Invalid JSON body" }, 400);
+		}
+
+		const installed = readInstalledServers();
+		const existing = installed.find((s) => s.id === id);
+		if (!existing) return c.json({ error: "Server not found" }, 404);
+
+		const normalized = body.config ? normalizeMcpConfig(body.config) : null;
+		if (body.config && !normalized) {
+			return c.json({ error: "Invalid config" }, 400);
+		}
+
+		const updated: InstalledMarketplaceMcpServer = {
+			...existing,
+			enabled: typeof body.enabled === "boolean" ? body.enabled : existing.enabled,
+			scope: body.scope === undefined ? existing.scope : normalizeScope(body.scope),
+			config: normalized ?? existing.config,
+			name: typeof body.name === "string" && body.name.trim().length > 0 ? body.name.trim() : existing.name,
+			description:
+				typeof body.description === "string" && body.description.trim().length > 0
+					? body.description.trim()
+					: existing.description,
+			updatedAt: new Date().toISOString(),
+		};
+
+		writeInstalledServers(installed.map((s) => (s.id === id ? updated : s)));
+		invalidateMarketplaceToolsCache();
+		return c.json({ success: true, server: updated });
+	});
+
+	app.delete("/api/marketplace/mcp/:id", (c) => {
+		const id = c.req.param("id");
+		const installed = readInstalledServers();
+		if (!installed.some((s) => s.id === id)) {
+			return c.json({ error: "Server not found" }, 404);
+		}
+		writeInstalledServers(installed.filter((s) => s.id !== id));
+		invalidateMarketplaceToolsCache();
+		return c.json({ success: true, id });
 	});
 }


### PR DESCRIPTION
## Summary
- Fix route matching order in marketplace MCP routes so `/api/marketplace/mcp/tools` and `/api/marketplace/mcp/search` are handled by their static handlers instead of being captured by `/:id`.
- Keep existing `/:id` behavior intact by moving those handlers below static routes.
- Add route-level regression tests that mount the Hono app and assert both static endpoints resolve correctly.

## Validation
- bun test packages/daemon/src/routes/marketplace.test.ts packages/daemon/src/mcp/tools.test.ts
- bunx biome check packages/daemon/src/routes/marketplace.ts packages/daemon/src/routes/marketplace.test.ts