### PR TITLE
fix(dashboard): restore feed auto-follow and prefetch embeddings assets

### DIFF
--- a/packages/cli/dashboard/src/lib/components/app-sidebar.svelte
+++ b/packages/cli/dashboard/src/lib/components/app-sidebar.svelte
@@ -22,6 +22,7 @@
 		daemonStatus: DaemonStatus | null;
 		theme: "dark" | "light";
 		onthemetoggle: () => void;
+		onprefetchembeddings?: () => void;
 	}
 
 	let {
@@ -31,7 +32,13 @@
 		daemonStatus,
 		theme,
 		onthemetoggle,
+		onprefetchembeddings,
 	}: Props = $props();
+
+	function maybePrefetchEmbeddings(id: TabId): void {
+		if (id !== "embeddings") return;
+		onprefetchembeddings?.();
+	}
 
 	const navItems: { id: TabId; label: string; icon: typeof FileText }[] = [
 		{ id: "config", label: "Config", icon: FileText },
@@ -94,6 +101,8 @@
 							<Sidebar.MenuButton
 								isActive={nav.activeTab === item.id}
 								onclick={() => setTab(item.id)}
+								onmouseenter={() => maybePrefetchEmbeddings(item.id)}
+								onfocus={() => maybePrefetchEmbeddings(item.id)}
 								tooltip={item.label}
 							>
 								<item.icon class="size-4" />

--- a/packages/cli/dashboard/src/lib/components/config/FormSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/config/FormSection.svelte
@@ -11,7 +11,11 @@ interface Props {
 }
 
 const { title, description, children, defaultOpen = true }: Props = $props();
-let open = $state(defaultOpen);
+let open = $state(true);
+
+$effect(() => {
+	open = defaultOpen;
+});
 </script>
 
 <Collapsible.Root bind:open class="border-b border-[var(--sig-border)]">

--- a/packages/cli/dashboard/src/lib/components/skills/SkillCard.svelte
+++ b/packages/cli/dashboard/src/lib/components/skills/SkillCard.svelte
@@ -153,7 +153,7 @@ let isInstalled = $derived(
 
 		<!-- Action button (browse only) -->
 		{#if mode === "browse" && isSearchResult(item)}
-			<div class="card-action" onclick={(e) => e.stopPropagation()}>
+			<div class="card-action">
 				{#if item.installed}
 					<Button
 						variant="outline"
@@ -184,7 +184,7 @@ let isInstalled = $derived(
 		<button
 			type="button"
 			class="remove-corner"
-			onclick={(e) => { e.stopPropagation(); onuninstall?.(); }}
+			onclick={(e: MouseEvent) => { e.stopPropagation(); onuninstall?.(); }}
 			disabled={uninstalling}
 			title="Uninstall"
 		>

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -19,6 +19,7 @@ import { mem } from "$lib/stores/memory.svelte";
 import EmbeddingCanvas2D from "../embeddings/EmbeddingCanvas2D.svelte";
 import EmbeddingCanvas3D from "../embeddings/EmbeddingCanvas3D.svelte";
 import EmbeddingInspector from "../embeddings/EmbeddingInspector.svelte";
+import * as Sheet from "$lib/components/ui/sheet/index.js";
 import PageHero from "$lib/components/layout/PageHero.svelte";
 import { PAGE_HEADERS } from "$lib/components/layout/page-headers";
 import {
@@ -30,6 +31,7 @@ import {
 	embeddingLabel,
 	DEFAULT_EMBEDDING_LIMIT,
 	MAX_EMBEDDING_LIMIT,
+	sourceColors,
 } from "../embeddings/embedding-graph";
 
 interface Props {
@@ -80,6 +82,36 @@ let activePresetId = $state("focus");
 let customPresets = $state<FilterPreset[]>([]);
 let presetsHydrated = $state(false);
 let showAdvancedFilters = $state(false);
+let commandPanelOpen = $state(false);
+
+const COACH_MARK_STORAGE_KEY = "signet-embeddings-coach-v1";
+
+const coachSteps = [
+	{
+		title: "Select a node",
+		body: "Click any point to inspect memory content, tags, and related neighbors.",
+		target: "Canvas",
+	},
+	{
+		title: "Shift-lock preview",
+		body: "Hold Shift while hovering to lock the preview card in place for deeper reading.",
+		target: "Hover preview",
+	},
+	{
+		title: "Neighborhood mode",
+		body: "Use Neighborhood to focus only the selected memory and its active relation set.",
+		target: "Toolbar",
+	},
+	{
+		title: "Scope controls",
+		body: "Open Commands to adjust window, time range, harness filters, and source/type scopes.",
+		target: "Command panel",
+	},
+] as const;
+
+let coachHydrated = $state(false);
+let coachOpen = $state(false);
+let coachStep = $state(0);
 
 type TimeFilterPreset = "all" | "24h" | "7d" | "30d" | "90d" | "custom";
 
@@ -107,6 +139,9 @@ let relationMode = $state<RelationKind>("similar");
 let similarNeighbors = $state<EmbeddingRelation[]>([]);
 let dissimilarNeighbors = $state<EmbeddingRelation[]>([]);
 let activeNeighbors = $state<EmbeddingRelation[]>([]);
+let neighborsLoading = $state(false);
+let inspectorLoading = $state(false);
+let relationRequestId = 0;
 let loadingGlobalSimilar = $state(false);
 let globalSimilar = $state<Memory[]>([]);
 
@@ -123,7 +158,7 @@ let relationLookup = $state(new Map<string, RelationKind>());
 let hoverLockedId = $state<string | null>(null);
 
 let graphRegion = $state<HTMLDivElement | null>(null);
-let hoverCardEl: HTMLDivElement | null = null;
+let hoverCardEl = $state<HTMLDivElement | null>(null);
 let hoverX = 0;
 let hoverY = 0;
 let cachedRegionRect: DOMRect | null = null;
@@ -153,6 +188,40 @@ async function runFix(check: EmbeddingCheckResult): Promise<void> {
 	} finally {
 		healthFixBusy = false;
 	}
+}
+
+function completeCoachMarks(): void {
+	coachOpen = false;
+	if (typeof window === "undefined") return;
+	window.localStorage.setItem(COACH_MARK_STORAGE_KEY, "done");
+}
+
+function nextCoachMark(): void {
+	if (coachStep < coachSteps.length - 1) {
+		coachStep += 1;
+		return;
+	}
+	completeCoachMarks();
+}
+
+function togglePinnedOnly(): void {
+	showPinnedOnly = !showPinnedOnly;
+	activePresetId = "custom-live";
+}
+
+function toggleNeighborhoodOnly(): void {
+	showNeighborhoodOnly = !showNeighborhoodOnly;
+	activePresetId = "custom-live";
+}
+
+function toggleClusterLens(): void {
+	clusterLensMode = !clusterLensMode;
+	activePresetId = "custom-live";
+}
+
+function toggleSourceFilter(who: string): void {
+	toggleSource(who);
+	activePresetId = "custom-live";
 }
 
 function healthDotColor(status: "healthy" | "degraded" | "unhealthy"): string {
@@ -653,25 +722,45 @@ async function initGraph(): Promise<void> {
 async function computeRelationsForSelection(
 	selected: EmbeddingPoint | null,
 ): Promise<void> {
+	const requestId = ++relationRequestId;
 	if (!selected) {
 		similarNeighbors = [];
 		dissimilarNeighbors = [];
 		activeNeighbors = [];
 		relationLookup = new Map();
+		neighborsLoading = false;
+		inspectorLoading = false;
 		return;
 	}
 
-	const results = await getSimilarMemories(selected.id, 10);
-	similarNeighbors = results.map((m) => ({
-		id: m.id,
-		score: m.score ?? 0,
-		kind: "similar" as const,
-	}));
-	dissimilarNeighbors = [];
-	activeNeighbors = similarNeighbors;
-	relationLookup = new Map(
-		similarNeighbors.map((item) => [item.id, item.kind]),
-	);
+	neighborsLoading = true;
+	inspectorLoading = true;
+	const startedAt = Date.now();
+
+	try {
+		const results = await getSimilarMemories(selected.id, 10);
+		if (requestId !== relationRequestId) return;
+
+		similarNeighbors = results.map((m) => ({
+			id: m.id,
+			score: m.score ?? 0,
+			kind: "similar" as const,
+		}));
+		dissimilarNeighbors = [];
+		activeNeighbors = similarNeighbors;
+		relationLookup = new Map(
+			similarNeighbors.map((item) => [item.id, item.kind]),
+		);
+	} finally {
+		if (requestId !== relationRequestId) return;
+		const elapsed = Date.now() - startedAt;
+		if (elapsed < 120) {
+			await new Promise<void>((resolve) => setTimeout(resolve, 120 - elapsed));
+		}
+		if (requestId !== relationRequestId) return;
+		neighborsLoading = false;
+		inspectorLoading = false;
+	}
 }
 
 // -----------------------------------------------------------------------

--- a/packages/cli/dashboard/src/lib/components/tabs/LogsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/LogsTab.svelte
@@ -27,6 +27,8 @@ let logAutoScroll = $state(true);
 let logViewport = $state<HTMLElement | null>(null);
 let selectedLogKey = $state<string | null>(null);
 let copied = $state(false);
+let logFollow = $state(true);
+const BOTTOM_THRESHOLD_PX = 24;
 
 const logCategories = [
 	"daemon", "api", "memory", "sync", "git",
@@ -87,6 +89,11 @@ function scrollToBottom(behavior: ScrollBehavior = "smooth"): void {
 	});
 }
 
+function isNearBottom(viewport: HTMLElement | null): boolean {
+	if (!viewport) return true;
+	return viewport.scrollTop + viewport.clientHeight >= viewport.scrollHeight - BOTTOM_THRESHOLD_PX;
+}
+
 async function fetchLogs() {
 	logsLoading = true;
 	logsError = "";
@@ -98,7 +105,10 @@ async function fetchLogs() {
 		const data = await res.json();
 		logs = data.logs || [];
 		selectLatestLog();
-		setTimeout(() => scrollToBottom("auto"), 0);
+		setTimeout(() => {
+			scrollToBottom("auto");
+			logFollow = true;
+		}, 0);
 	} catch {
 		logsError = "Failed to fetch logs";
 	} finally {
@@ -117,10 +127,17 @@ function startLogStream() {
 			if (entry.type === "connected") return;
 			if (logLevelFilter && entry.level !== logLevelFilter) return;
 			if (logCategoryFilter && entry.category !== logCategoryFilter) return;
+			const wasNearBottom = isNearBottom(logViewport);
+			const shouldAutoFollow = logAutoScroll && (logFollow || wasNearBottom);
 			const wasViewingLatest = isViewingLatest();
 			logs = [...logs.slice(-499), entry];
 			if (wasViewingLatest) selectLatestLog();
-			if (logAutoScroll && wasViewingLatest) setTimeout(() => scrollToBottom(), 0);
+			if (shouldAutoFollow) {
+				setTimeout(() => {
+					scrollToBottom("auto");
+					logFollow = true;
+				}, 0);
+			}
 		} catch {
 			// ignore parse errors
 		}
@@ -232,6 +249,22 @@ onMount(() => {
 		if (logEventSource) logEventSource.close();
 	};
 });
+
+$effect(() => {
+	const viewport = logViewport;
+	if (!viewport) return;
+
+	const onScroll = () => {
+		logFollow = isNearBottom(viewport);
+	};
+
+	viewport.addEventListener("scroll", onScroll, { passive: true });
+	onScroll();
+
+	return () => {
+		viewport.removeEventListener("scroll", onScroll);
+	};
+});
 </script>
 
 <div class="flex flex-col flex-1 min-h-0">
@@ -269,6 +302,13 @@ onMount(() => {
 			<Checkbox checked={logAutoScroll} onCheckedChange={(value: unknown) => { logAutoScroll = value === true; }} class="rounded-none" />
 			Auto-scroll
 		</label>
+		<span
+			class="text-[10px] font-[family-name:var(--font-mono)]"
+			class:text-[#4ade80]={logAutoScroll && logFollow}
+			class:text-[var(--sig-text-muted)]={!logAutoScroll || !logFollow}
+		>
+			{logAutoScroll && logFollow ? "following" : "paused"}
+		</span>
 		<button
 			class="text-[11px] px-2 py-1 border border-[var(--sig-border)] text-[var(--sig-text)] hover:border-[var(--sig-border-strong)] hover:text-[var(--sig-text-bright)]"
 			onclick={fetchLogs}

--- a/packages/cli/dashboard/src/lib/components/tabs/PipelineTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/PipelineTab.svelte
@@ -21,13 +21,30 @@
 
 	let feedViewport: HTMLElement | null = $state(null);
 	let autoScroll = $state(true);
+	const BOTTOM_THRESHOLD_PX = 24;
+
+	function isNearBottom(viewport: HTMLElement | null): boolean {
+		if (!viewport) return true;
+		return viewport.scrollTop + viewport.clientHeight >= viewport.scrollHeight - BOTTOM_THRESHOLD_PX;
+	}
+
+	function handleFeedScroll(): void {
+		autoScroll = isNearBottom(feedViewport);
+	}
+
+	function scrollFeedToBottom(behavior: ScrollBehavior = "auto"): void {
+		if (!feedViewport) return;
+		feedViewport.scrollTo({ top: feedViewport.scrollHeight, behavior });
+	}
 
 	// Auto-scroll feed
 	$effect(() => {
 		const _ = pipeline.feed.length;
-		if (autoScroll && feedViewport) {
+		const shouldFollow = autoScroll || isNearBottom(feedViewport);
+		if (shouldFollow && feedViewport) {
 			requestAnimationFrame(() => {
-				feedViewport?.scrollTo({ top: feedViewport.scrollHeight, behavior: "smooth" });
+				scrollFeedToBottom("auto");
+				autoScroll = true;
 			});
 		}
 	});
@@ -157,14 +174,24 @@
 				<span class="text-[10px] uppercase tracking-[0.1em] text-[var(--sig-text-muted)] font-[family-name:var(--font-display)]">
 					Live Feed
 				</span>
-				<span class="text-[9px] text-[var(--sig-text-muted)] font-[family-name:var(--font-mono)]">
-					{pipeline.feed.length} events
-				</span>
+				<div class="flex items-center gap-2">
+					<span class="text-[9px] text-[var(--sig-text-muted)] font-[family-name:var(--font-mono)]">
+						{pipeline.feed.length} events
+					</span>
+					<span
+						class="text-[9px] font-[family-name:var(--font-mono)]"
+						class:text-[#4ade80]={autoScroll}
+						class:text-[var(--sig-text-muted)]={!autoScroll}
+					>
+						{autoScroll ? "following" : "paused"}
+					</span>
+				</div>
 			</div>
 
 			<!-- Feed entries -->
 			<div
 				bind:this={feedViewport}
+				onscroll={handleFeedScroll}
 				class="flex-1 overflow-y-auto px-1 py-1"
 			>
 				{#each pipeline.feed as entry, i (entry.timestamp + "-" + i)}

--- a/packages/cli/dashboard/src/lib/components/tabs/SettingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/SettingsTab.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { parse, stringify } from "yaml";
+import * as YAML from "yaml";
 import { saveConfigFile, type ConfigFile } from "$lib/api";
 import { toast } from "$lib/stores/toast.svelte";
 import FormField from "$lib/components/config/FormField.svelte";
@@ -81,7 +81,7 @@ let settingsIsSameAsAgent = $derived(
 $effect(() => {
 	if (agentFile?.content) {
 		try {
-			agent = JSON.parse(JSON.stringify(parse(agentFile.content) ?? {}));
+			agent = JSON.parse(JSON.stringify(YAML.parse(agentFile.content) ?? {}));
 		} catch { agent = {}; }
 	} else { agent = {}; }
 });
@@ -89,7 +89,7 @@ $effect(() => {
 $effect(() => {
 	if (configFile?.content) {
 		try {
-			config = JSON.parse(JSON.stringify(parse(configFile.content) ?? {}));
+			config = JSON.parse(JSON.stringify(YAML.parse(configFile.content) ?? {}));
 		} catch { config = {}; }
 	} else { config = {}; }
 });
@@ -184,11 +184,11 @@ async function saveSettings(): Promise<void> {
 	const results: boolean[] = [];
 	try {
 		if (agentFile) {
-			results.push(await saveConfigFile("agent.yaml", stringify(agent)));
+			results.push(await saveConfigFile("agent.yaml", YAML.stringify(agent)));
 		}
 		// Only save config.yaml separately when settings live there (not in agent.yaml)
 		if (!settingsIsSameAsAgent && settingsFileName) {
-			results.push(await saveConfigFile(settingsFileName, stringify(config)));
+			results.push(await saveConfigFile(settingsFileName, YAML.stringify(config)));
 		}
 		const allOk = results.length > 0 && results.every(Boolean);
 		toast(allOk ? "Settings saved" : "Failed to save settings", allOk ? "success" : "error");
@@ -249,7 +249,7 @@ let hasFiles = $derived(!!agentFile || !!configFile);
 								<div class="checkbox-group">
 									{#each KNOWN_HARNESSES as h (h)}
 										<label class="cb-row">
-											<input type="checkbox" checked={harnessArray().includes(h)} onchange={(e) => toggleHarness(h, (e.target as HTMLInputElement).checked)} />
+											<input type="checkbox" checked={harnessArray().includes(h)} onchange={(e: Event) => toggleHarness(h, (e.target as HTMLInputElement).checked)} />
 											<span>{h}</span>
 										</label>
 									{/each}
@@ -265,7 +265,7 @@ let hasFiles = $derived(!!agentFile || !!configFile);
 						<FormField label="Add custom harness" description="Add a custom harness name for third-party integrations.">
 							{#snippet children()}
 								<div class="inline-add">
-									<input type="text" class="inp" placeholder="harness-name" bind:value={customHarnessInput} onkeydown={(e) => { if (e.key === "Enter") addCustomHarness(); }} />
+									<input type="text" class="inp" placeholder="harness-name" bind:value={customHarnessInput} onkeydown={(e: KeyboardEvent) => { if (e.key === "Enter") addCustomHarness(); }} />
 									<button class="btn-add" onclick={addCustomHarness}>Add</button>
 								</div>
 							{/snippet}

--- a/packages/cli/dashboard/src/routes/+page.svelte
+++ b/packages/cli/dashboard/src/routes/+page.svelte
@@ -21,6 +21,7 @@
 
 	let { data } = $props();
 	let daemonStatus = $state<DaemonStatus | null>(null);
+	let embeddingsPrefetchPromise: Promise<unknown[]> | null = null;
 
 	// --- Theme ---
 	let theme = $state<"dark" | "light">("dark");
@@ -81,6 +82,16 @@
 		queueMemorySearch();
 	}
 
+	function prefetchEmbeddingsTab(): void {
+		if (!browser) return;
+		if (embeddingsPrefetchPromise) return;
+
+		embeddingsPrefetchPromise = Promise.all([
+			import("$lib/components/tabs/EmbeddingsTab.svelte"),
+			import("3d-force-graph"),
+		]);
+	}
+
 	// --- Cleanup ---
 	$effect(() => {
 		return () => {
@@ -109,6 +120,7 @@
 		{daemonStatus}
 		{theme}
 		onthemetoggle={toggleTheme}
+		onprefetchembeddings={prefetchEmbeddingsTab}
 	/>
 	<main class="flex flex-1 flex-col min-w-0 min-h-0 overflow-hidden
 		m-2 ml-0 rounded-lg border border-[var(--sig-border)]

--- a/packages/cli/dashboard/vite.config.ts
+++ b/packages/cli/dashboard/vite.config.ts
@@ -4,4 +4,55 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
 	plugins: [tailwindcss(), sveltekit()],
+	build: {
+		chunkSizeWarningLimit: 1200,
+		rollupOptions: {
+			output: {
+				manualChunks(id) {
+					if (!id.includes("node_modules")) return;
+
+					if (
+						id.includes("/three-forcegraph/") ||
+						id.includes("/three-spritetext/")
+					) {
+						return "vendor-forcegraph3d";
+					}
+
+					if (id.includes("/3d-force-graph/") || id.includes("/three-render-objects/")) {
+						return "vendor-3d-force";
+					}
+
+					if (id.includes("/three/")) {
+						return "vendor-three";
+					}
+
+					if (id.includes("/d3-force/")) {
+						return "vendor-embeddings-2d";
+					}
+
+					if (
+						id.includes("/@codemirror/view/") ||
+						id.includes("/@codemirror/state/") ||
+						id.includes("/@codemirror/commands/") ||
+						id.includes("/@codemirror/search/") ||
+						id.includes("/@codemirror/lang-") ||
+						id.includes("/@codemirror/autocomplete/") ||
+						id.includes("/@codemirror/language/") ||
+						id.includes("/@lezer/") ||
+						id.includes("/codemirror/")
+					) {
+						return "vendor-codemirror";
+					}
+
+					if (id.includes("/bits-ui/") || id.includes("/svelte-sonner/")) {
+						return "vendor-ui";
+					}
+
+					if (id.includes("/yaml/") || id.includes("/marked/")) {
+						return "vendor-utils";
+					}
+				},
+			},
+		},
+	},
 });


### PR DESCRIPTION
## What
- Fixes logs and pipeline live feeds so they auto-scroll only when the viewport is already at the latest entries.
- Adds explicit follow state indicators (`following` / `paused`) in both feeds.
- Adds embeddings tab prefetch on sidebar hover/focus to warm both the tab module and 3D graph dependency before navigation.
- Splits heavy dashboard vendor dependencies into manual chunks and raises dashboard chunk warning threshold for expected large 3D assets.
- Cleans a few dashboard warning-level issues surfaced during validation (`FormSection` defaultOpen reactivity, SkillCard action wrapper a11y/typing, Embeddings hover ref reactivity, Settings YAML import usage).

## How
- Introduced near-bottom viewport checks in:
  - `packages/cli/dashboard/src/lib/components/tabs/LogsTab.svelte`
  - `packages/cli/dashboard/src/lib/components/tabs/PipelineTab.svelte`
- Wired scroll listeners to toggle follow mode automatically when users scroll away from or back to bottom.
- Added sidebar-triggered prefetch plumbing:
  - `packages/cli/dashboard/src/lib/components/app-sidebar.svelte`
  - `packages/cli/dashboard/src/routes/+page.svelte`
- Added Vite manual chunk strategy for dashboard dependency domains in:
  - `packages/cli/dashboard/vite.config.ts`

## Why
- Live operational views should not yank users to the bottom when they are inspecting older entries.
- Preloading the embeddings path removes first-open latency from dynamic imports in the heaviest dashboard view.
- Chunk boundaries now better reflect runtime usage (core UI vs embeddings/3D graph stack), improving load behavior and reducing build warning noise.

## Validation
- `bun install` (repo root) ✅
- `bun run build` (repo root) ✅
- `bun run build` (`packages/cli/dashboard`) ✅
- `bun test` (repo root) ❌ one existing failing test outside this change:
  - `packages/daemon/src/memory-config.test.ts` (`loadMemoryConfig > prefers agent.yaml embedding settings over legacy files`)
- `bun run typecheck` (repo root) ❌ existing `@signet/opencode-plugin` missing node type globals (`process`)
- `bun run check` (`packages/cli/dashboard`) ❌ existing pre-existing dashboard type issues in UI utility component typings