### PR TITLE
fix(dashboard): restore feed follow behavior on latest main && bug fixes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/adapters/openclaw": {
       "name": "@signetai/signet-memory-openclaw",
-      "version": "0.12.3",
+      "version": "0.14.3",
       "dependencies": {
         "@sinclair/typebox": "0.34.47",
       },
@@ -22,7 +22,7 @@
     },
     "packages/cli": {
       "name": "@signet/cli",
-      "version": "0.12.3",
+      "version": "0.14.3",
       "bin": "./dist/cli.js",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
@@ -44,7 +44,7 @@
     },
     "packages/connector-base": {
       "name": "@signet/connector-base",
-      "version": "0.12.3",
+      "version": "0.14.3",
       "dependencies": {
         "@signet/core": "workspace:*",
       },
@@ -58,7 +58,7 @@
     },
     "packages/connector-claude-code": {
       "name": "@signet/connector-claude-code",
-      "version": "0.12.3",
+      "version": "0.14.3",
       "dependencies": {
         "@signet/connector-base": "workspace:*",
         "@signet/core": "workspace:*",
@@ -70,7 +70,7 @@
     },
     "packages/connector-openclaw": {
       "name": "@signet/connector-openclaw",
-      "version": "0.12.3",
+      "version": "0.14.3",
       "dependencies": {
         "@signet/connector-base": "workspace:*",
       },
@@ -81,7 +81,7 @@
     },
     "packages/connector-opencode": {
       "name": "@signet/connector-opencode",
-      "version": "0.12.3",
+      "version": "0.14.3",
       "dependencies": {
         "@signet/connector-base": "workspace:*",
         "@signet/core": "workspace:*",
@@ -93,7 +93,7 @@
     },
     "packages/core": {
       "name": "@signet/core",
-      "version": "0.12.3",
+      "version": "0.14.3",
       "dependencies": {
         "sqlite-vec": "^0.1.7-alpha.2",
         "yaml": "^2.6.0",
@@ -113,7 +113,7 @@
     },
     "packages/daemon": {
       "name": "@signet/daemon",
-      "version": "0.12.3",
+      "version": "0.14.3",
       "bin": {
         "signet-daemon": "./dist/daemon.js",
         "signet-mcp": "./dist/mcp-stdio.js",
@@ -133,30 +133,16 @@
         "@types/libsodium-wrappers": "^0.8.2",
       },
     },
-    "packages/harness": {
-      "name": "signet-harness",
-      "version": "0.12.3",
-      "bin": {
-        "signet-harness": "./dist/cli.js",
-      },
-      "dependencies": {
-        "@mariozechner/pi-agent-core": "^0.55.3",
-        "@mariozechner/pi-ai": "^0.55.3",
-        "@mariozechner/pi-coding-agent": "^0.55.3",
-        "@mariozechner/pi-tui": "^0.55.3",
-        "@signet/core": "workspace:*",
-      },
-    },
     "packages/opencode-plugin": {
       "name": "@signet/opencode-plugin",
-      "version": "0.12.3",
+      "version": "0.14.3",
       "peerDependencies": {
         "@opencode-ai/plugin": ">=0.1.0",
       },
     },
     "packages/sdk": {
       "name": "@signet/sdk",
-      "version": "0.12.3",
+      "version": "0.14.3",
       "devDependencies": {
         "@types/react": "^19.0.0",
         "react": "^19.0.0",
@@ -172,7 +158,7 @@
     },
     "packages/signetai": {
       "name": "signetai",
-      "version": "0.12.3",
+      "version": "0.14.3",
       "bin": {
         "signet": "bin/signet.js",
         "signet-mcp": "dist/mcp-stdio.js",
@@ -199,7 +185,7 @@
     },
     "packages/tray": {
       "name": "@signet/tray",
-      "version": "0.12.3",
+      "version": "0.14.3",
       "dependencies": {
         "@signet/sdk": "workspace:*",
         "@tauri-apps/api": "^2.5.0",
@@ -657,13 +643,13 @@
 
     "@mariozechner/jiti": ["@mariozechner/jiti@2.6.5", "", { "dependencies": { "std-env": "^3.10.0", "yoctocolors": "^2.1.2" }, "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw=="],
 
-    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.55.3", "", { "dependencies": { "@mariozechner/pi-ai": "^0.55.3" } }, "sha512-rqbfpQ9BrP6BDiW+Ps3A8Z/p9+Md/pAfc/ECq8JP6cwnZL/jQgU355KWZKtF8zM9az1p0Q9hIWi9cQygVo6Auw=="],
+    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.54.1", "", { "dependencies": { "@mariozechner/pi-ai": "^0.54.1" } }, "sha512-AC0SqEbR62PckWOyP0CmhYtfcC+Q6e1DGghwEcKpomTtmNfHTy7iTVy64mmtB2CFiN8j4rJFCqh2xJHgucUvkA=="],
 
-    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.55.3", "", { "dependencies": { "@anthropic-ai/sdk": "^0.73.0", "@aws-sdk/client-bedrock-runtime": "^3.983.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.10.0", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.10.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-f9jWoDzJR9Wy/H8JPMbjoM4WvVUeFZ65QdYA9UHIfoOopDfwWE8F8JHQOj5mmmILMacXuzsqA3J7MYqNWZRvvQ=="],
+    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.54.1", "", { "dependencies": { "@anthropic-ai/sdk": "^0.73.0", "@aws-sdk/client-bedrock-runtime": "^3.983.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.10.0", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.10.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-tiVvoNQV+3dpWgRQ1U/3bwJoDVSYwL17BE/kc00nXmaSLAPwNZoxLagtQ+HBr/rGzkq5viOgQf2dk+ud+/4UCg=="],
 
-    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.55.3", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.55.3", "@mariozechner/pi-ai": "^0.55.3", "@mariozechner/pi-tui": "^0.55.3", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-5SFbB7/BIp/Crjre7UNjUeNfpoU1KSW/i6LXa+ikJTBqI5LukWq2avE5l0v0M8Pg/dt1go2XCLrNFlQJiQDSPQ=="],
+    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.54.1", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.54.1", "@mariozechner/pi-ai": "^0.54.1", "@mariozechner/pi-tui": "^0.54.1", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.1.1", "proper-lockfile": "^4.1.2", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-pPFrdaKZ16oIcdhZVcfWPhCDFx8PWHaACjQS9aFFcMOhLBduyKAGyf8bQtfysekl+gIbBSGDT2rgCxsOwK2bQw=="],
 
-    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.55.3", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "koffi": "^2.9.0", "marked": "^15.0.12", "mime-types": "^3.0.1" } }, "sha512-Gh4wkYgiSPCJJaB/4wEWSL7Ga8bxSq1Crp1RPRT4vKybE/DG0W/MQr5VJDvktarxtJrD16ixScwE4dzdox/PIA=="],
+    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.54.1", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "koffi": "^2.9.0", "marked": "^15.0.12", "mime-types": "^3.0.1" } }, "sha512-FY8QcLlr9T276oZAwMSSPo1drg+J9Y7B+A0S9g8Jh6IFJxymKZZq29/Vit6XDziJfZIgJDraC6lpobtxgTEoFQ=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
@@ -1283,8 +1269,6 @@
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
-    "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
-
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
@@ -1390,8 +1374,6 @@
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
-
-    "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
@@ -1657,8 +1639,6 @@
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
-    "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
-
     "fast-content-type-parse": ["fast-content-type-parse@3.0.0", "", {}, "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
@@ -1666,8 +1646,6 @@
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fast-xml-parser": ["fast-xml-parser@5.3.6", "", { "dependencies": { "strnum": "^2.1.2" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA=="],
-
-    "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -1732,8 +1710,6 @@
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
-
-    "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
 
     "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
 
@@ -2131,7 +2107,7 @@
 
     "miniflare": ["miniflare@4.20260219.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.18.2", "workerd": "1.20260219.0", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-EIb5wXbWUnnC60XU2aiFOPNd4fgTXzECkwRSOXZ1vdcY9WZaEE9rVf+h+Apw+WkOHRkp3Dr9/ZhQ5y1R+9iZ4Q=="],
 
-    "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
+    "minimatch": ["minimatch@10.2.2", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
@@ -2284,8 +2260,6 @@
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pdfjs-dist": ["pdfjs-dist@5.4.624", "", { "optionalDependencies": { "@napi-rs/canvas": "^0.1.88", "node-readable-to-web-readable-stream": "^0.4.2" } }, "sha512-sm6TxKTtWv1Oh6n3C6J6a8odejb5uO4A4zo/2dgkHuC0iu8ZMAXOezEODkVaoVp8nX1Xzr+0WxFJJmUr45hQzg=="],
-
-    "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
     "piccolore": ["piccolore@0.1.3", "", {}, "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw=="],
 
@@ -2471,9 +2445,7 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
-    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
-
-    "signet-harness": ["signet-harness@workspace:packages/harness"],
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "signetai": ["signetai@workspace:packages/signetai"],
 
@@ -2739,8 +2711,6 @@
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
-    "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
-
     "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 
     "yocto-spinner": ["yocto-spinner@0.2.3", "", { "dependencies": { "yoctocolors": "^2.1.1" } }, "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ=="],
@@ -2782,8 +2752,6 @@
     "@discordjs/node-pre-gyp/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "@discordjs/node-pre-gyp/tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
-
-    "@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
@@ -2867,8 +2835,6 @@
 
     "@types/ws/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
-    "@types/yauzl/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
-
     "@whiskeysockets/baileys/p-queue": ["p-queue@9.1.0", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^7.0.0" } }, "sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw=="],
 
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -2903,11 +2869,11 @@
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
-    "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
-
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "gauge/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "gauge/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -2916,8 +2882,6 @@
     "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "gaxios/rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ=="],
-
-    "glob/minimatch": ["minimatch@10.2.2", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw=="],
 
     "hast-util-from-html/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
@@ -2959,14 +2923,6 @@
 
     "node-llama-cpp/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
-    "openclaw/@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.54.1", "", { "dependencies": { "@mariozechner/pi-ai": "^0.54.1" } }, "sha512-AC0SqEbR62PckWOyP0CmhYtfcC+Q6e1DGghwEcKpomTtmNfHTy7iTVy64mmtB2CFiN8j4rJFCqh2xJHgucUvkA=="],
-
-    "openclaw/@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.54.1", "", { "dependencies": { "@anthropic-ai/sdk": "^0.73.0", "@aws-sdk/client-bedrock-runtime": "^3.983.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.10.0", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.10.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-tiVvoNQV+3dpWgRQ1U/3bwJoDVSYwL17BE/kc00nXmaSLAPwNZoxLagtQ+HBr/rGzkq5viOgQf2dk+ud+/4UCg=="],
-
-    "openclaw/@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.54.1", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.54.1", "@mariozechner/pi-ai": "^0.54.1", "@mariozechner/pi-tui": "^0.54.1", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.1.1", "proper-lockfile": "^4.1.2", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-pPFrdaKZ16oIcdhZVcfWPhCDFx8PWHaACjQS9aFFcMOhLBduyKAGyf8bQtfysekl+gIbBSGDT2rgCxsOwK2bQw=="],
-
-    "openclaw/@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.54.1", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "koffi": "^2.9.0", "marked": "^15.0.12", "mime-types": "^3.0.1" } }, "sha512-FY8QcLlr9T276oZAwMSSPo1drg+J9Y7B+A0S9g8Jh6IFJxymKZZq29/Vit6XDziJfZIgJDraC6lpobtxgTEoFQ=="],
-
     "openclaw/@sinclair/typebox": ["@sinclair/typebox@0.34.48", "", {}, "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA=="],
 
     "openclaw/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
@@ -2981,6 +2937,8 @@
 
     "proper-lockfile/retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
+    "proper-lockfile/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
     "protobufjs/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
     "proxy-addr/ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
@@ -2990,8 +2948,6 @@
     "radix-ui/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
-
-    "restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
@@ -3095,8 +3051,6 @@
 
     "@types/ws/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
-    "@types/yauzl/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
     "@whiskeysockets/baileys/p-queue/p-timeout": ["p-timeout@7.0.1", "", {}, "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg=="],
 
     "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -3174,8 +3128,6 @@
     "node-llama-cpp/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "node-llama-cpp/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "openclaw/@mariozechner/pi-coding-agent/minimatch": ["minimatch@10.2.2", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw=="],
 
     "openclaw/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
@@ -3274,6 +3226,8 @@
     "ansi-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "cmake-js/npmlog/are-we-there-yet/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "cmake-js/npmlog/gauge/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "cmake-js/npmlog/gauge/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 

--- a/packages/cli/dashboard/src/lib/components/app-sidebar.svelte
+++ b/packages/cli/dashboard/src/lib/components/app-sidebar.svelte
@@ -89,7 +89,7 @@ const navItems: { id: TabId; label: string; icon: typeof FileText }[] = [
 							<Sidebar.MenuButton
 								isActive={nav.activeTab === item.id}
 								onclick={() => setTab(item.id)}
-								tooltip={item.label}
+								tooltipContent={item.label}
 							>
 								<item.icon class="size-4" />
 								<span class="text-xs uppercase tracking-[0.06em]
@@ -132,10 +132,10 @@ const navItems: { id: TabId; label: string; icon: typeof FileText }[] = [
 			</Sidebar.MenuItem>
 
 			<Sidebar.MenuItem>
-				<Sidebar.MenuButton
-					onclick={onthemetoggle}
-					tooltip={theme === "dark" ? "Light mode" : "Dark mode"}
-				>
+			<Sidebar.MenuButton
+				onclick={onthemetoggle}
+				tooltipContent={theme === "dark" ? "Light mode" : "Dark mode"}
+			>
 					{#if theme === "dark"}
 						<Sun class="size-4" />
 					{:else}
@@ -152,10 +152,10 @@ const navItems: { id: TabId; label: string; icon: typeof FileText }[] = [
 			</Sidebar.MenuItem>
 
 			<Sidebar.MenuItem>
-				<Sidebar.MenuButton
-					onclick={() => window.open("https://github.com/Signet-AI/signetai", "_blank")}
-					tooltip="GitHub"
-				>
+			<Sidebar.MenuButton
+				onclick={() => window.open("https://github.com/Signet-AI/signetai", "_blank")}
+				tooltipContent="GitHub"
+			>
 					<Github class="size-4" />
 					<span class="text-xs font-[family-name:var(--font-mono)]
 						overflow-hidden whitespace-nowrap

--- a/packages/cli/dashboard/src/lib/components/app-sidebar.svelte
+++ b/packages/cli/dashboard/src/lib/components/app-sidebar.svelte
@@ -23,9 +23,23 @@ interface Props {
 	daemonStatus: DaemonStatus | null;
 	theme: "dark" | "light";
 	onthemetoggle: () => void;
+	onprefetchembeddings?: () => void;
 }
 
-const { identity, harnesses, memCount, daemonStatus, theme, onthemetoggle }: Props = $props();
+const {
+	identity,
+	harnesses,
+	memCount,
+	daemonStatus,
+	theme,
+	onthemetoggle,
+	onprefetchembeddings,
+}: Props = $props();
+
+function maybePrefetchEmbeddings(id: TabId): void {
+	if (id !== "embeddings") return;
+	onprefetchembeddings?.();
+}
 
 const navItems: { id: TabId; label: string; icon: typeof FileText }[] = [
 	{ id: "config", label: "Config", icon: FileText },
@@ -89,6 +103,8 @@ const navItems: { id: TabId; label: string; icon: typeof FileText }[] = [
 							<Sidebar.MenuButton
 								isActive={nav.activeTab === item.id}
 								onclick={() => setTab(item.id)}
+								onmouseenter={() => maybePrefetchEmbeddings(item.id)}
+								onfocus={() => maybePrefetchEmbeddings(item.id)}
 								tooltipContent={item.label}
 							>
 								<item.icon class="size-4" />

--- a/packages/cli/dashboard/src/lib/components/embeddings/EmbeddingCanvas2D.svelte
+++ b/packages/cli/dashboard/src/lib/components/embeddings/EmbeddingCanvas2D.svelte
@@ -81,6 +81,7 @@ let resizeListenerAttached = false;
 let lastFrameTime = 0;
 let needsRedraw = true;
 let lastHoveredId: string | null = null;
+let userAdjustedCamera = false;
 
 // Minimap state
 const MINIMAP_WIDTH = 160;
@@ -119,6 +120,7 @@ export function resetCamera(): void {
 	camX = 0;
 	camY = 0;
 	camZoom = 1;
+	userAdjustedCamera = false;
 }
 
 export function focusNode(id: string): void {
@@ -127,6 +129,7 @@ export function focusNode(id: string): void {
 	camX = node.x;
 	camY = node.y;
 	camZoom = Math.max(camZoom, 1.6);
+	userAdjustedCamera = true;
 }
 
 export function startSimulation(
@@ -161,6 +164,7 @@ export function stopSimulation(): void {
 }
 
 export function startRendering(): void {
+	userAdjustedCamera = false;
 	resizeCanvas();
 	if (!resizeListenerAttached) {
 		window.addEventListener("resize", resizeCanvas);
@@ -203,7 +207,31 @@ function resizeCanvas(): void {
 	if (!rect || rect.width === 0) return;
 	canvas.width = rect.width;
 	canvas.height = rect.height;
+	if (!userAdjustedCamera) {
+		fitCameraToBounds();
+	}
 	requestRedraw();
+}
+
+function fitCameraToBounds(): void {
+	if (!canvas) return;
+	if (nodes.length === 0) {
+		camX = 0;
+		camY = 0;
+		camZoom = 1;
+		return;
+	}
+
+	const bounds = computeWorldBounds();
+	const worldWidth = Math.max(bounds.maxX - bounds.minX, 1);
+	const worldHeight = Math.max(bounds.maxY - bounds.minY, 1);
+	const viewWidth = Math.max(canvas.width, 1);
+	const viewHeight = Math.max(canvas.height, 1);
+	const fitZoom = Math.min(viewWidth / worldWidth, viewHeight / worldHeight) * 0.92;
+
+	camX = (bounds.minX + bounds.maxX) / 2;
+	camY = (bounds.minY + bounds.maxY) / 2;
+	camZoom = Math.max(0.08, Math.min(1, fitZoom));
 }
 
 function screenToWorld(sx: number, sy: number): [number, number] {
@@ -548,6 +576,7 @@ function setupInteractions(): void {
 			}
 			if (!didDrag) {
 				didDrag = true;
+				userAdjustedCamera = true;
 				dragNode.fx = dragNode.x;
 				dragNode.fy = dragNode.y;
 				(simulation as any)?.alphaTarget(0.3).restart();
@@ -559,6 +588,7 @@ function setupInteractions(): void {
 			return;
 		}
 		if (isPanning) {
+			userAdjustedCamera = true;
 			camX = panCamStartX - (event.clientX - panStartX) / camZoom;
 			camY = panCamStartY - (event.clientY - panStartY) / camZoom;
 			requestRedraw();
@@ -606,6 +636,7 @@ function setupInteractions(): void {
 
 	const onWheel = (event: WheelEvent) => {
 		event.preventDefault();
+		userAdjustedCamera = true;
 		const factor = event.deltaY > 0 ? 0.9 : 1.1;
 		const newZoom = Math.max(0.1, Math.min(5, camZoom * factor));
 		const rect = target.getBoundingClientRect();

--- a/packages/cli/dashboard/src/lib/components/embeddings/EmbeddingCanvas3D.svelte
+++ b/packages/cli/dashboard/src/lib/components/embeddings/EmbeddingCanvas3D.svelte
@@ -50,6 +50,9 @@ let {
 
 let container = $state<HTMLDivElement | null>(null);
 let graph3d: any = null;
+let graphResizeObserver: ResizeObserver | null = null;
+let controlsCleanup: (() => void) | null = null;
+let userAdjustedCamera = false;
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -63,6 +66,7 @@ export function focusNode(id: string): void {
 		(entry: any) => String(entry.id) === id,
 	);
 	if (!node) return;
+	userAdjustedCamera = true;
 	const distance = 120;
 	const len =
 		Math.hypot(node.x ?? 0, node.y ?? 0, node.z ?? 0) || 1;
@@ -76,6 +80,48 @@ export function focusNode(id: string): void {
 		node,
 		900,
 	);
+}
+
+function sizeGraphToContainer(): void {
+	if (!graph3d || !container) return;
+	const rect = container.getBoundingClientRect();
+	const width = Math.max(1, Math.round(rect.width || container.offsetWidth));
+	const height = Math.max(1, Math.round(rect.height || container.offsetHeight));
+	graph3d.width(width);
+	graph3d.height(height);
+}
+
+function fitGraphCamera(durationMs = 0): void {
+	if (!graph3d) return;
+	const graphData = graph3d.graphData?.();
+	if (!graphData?.nodes?.length) return;
+	graph3d.zoomToFit?.(durationMs, 44);
+}
+
+function setupInteractionTracking(): void {
+	if (!graph3d) return;
+	const controls = graph3d.controls?.();
+	if (!controls?.addEventListener || !controls?.removeEventListener) return;
+	const onStart = () => {
+		userAdjustedCamera = true;
+	};
+	controls.addEventListener("start", onStart);
+	controlsCleanup = () => {
+		controls.removeEventListener("start", onStart);
+	};
+}
+
+function setupResizeHandling(): void {
+	if (!container || !graph3d) return;
+	graphResizeObserver?.disconnect();
+	graphResizeObserver = new ResizeObserver(() => {
+		sizeGraphToContainer();
+		if (!userAdjustedCamera) {
+			fitGraphCamera(0);
+		}
+		graph3d.refresh?.();
+	});
+	graphResizeObserver.observe(container);
 }
 
 export function refreshAppearance(): void {
@@ -121,6 +167,7 @@ export function refreshAppearance(): void {
 export async function init(): Promise<void> {
 	if (!container) return;
 	destroy();
+	userAdjustedCamera = false;
 
 	const { default: ForceGraph3D } = await import("3d-force-graph");
 
@@ -200,9 +247,23 @@ export async function init(): Promise<void> {
 				node ? (embeddingById.get(String(node.id)) ?? null) : null,
 			);
 		});
+
+	sizeGraphToContainer();
+	setupInteractionTracking();
+	setupResizeHandling();
+
+	requestAnimationFrame(() => {
+		if (!userAdjustedCamera) {
+			fitGraphCamera(0);
+		}
+	});
 }
 
 export function destroy(): void {
+	graphResizeObserver?.disconnect();
+	graphResizeObserver = null;
+	controlsCleanup?.();
+	controlsCleanup = null;
 	if (graph3d) {
 		graph3d._destructor?.();
 		graph3d = null;

--- a/packages/cli/dashboard/src/lib/components/skills/SkillGrid.svelte
+++ b/packages/cli/dashboard/src/lib/components/skills/SkillGrid.svelte
@@ -105,7 +105,7 @@ let showFeatured = $derived(mode === "browse" && featuredItems.length > 0);
 
 		<!-- Main grid -->
 		<div class="grid">
-			{#each items as item (`${'fullName' in item ? item.fullName : item.name}`)}
+			{#each items as item (item.name)}
 				<SkillCard
 					{item}
 					{mode}

--- a/packages/cli/dashboard/src/lib/components/tabs/LogsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/LogsTab.svelte
@@ -35,6 +35,8 @@ let logAutoScroll = $state(true);
 let logViewport = $state<HTMLElement | null>(null);
 let selectedLogKey = $state<string | null>(null);
 let copied = $state(false);
+let logFollow = $state(true);
+const BOTTOM_THRESHOLD_PX = 24;
 
 const logCategories = [
 	"daemon", "api", "memory", "sync", "git",
@@ -95,6 +97,11 @@ function scrollToBottom(behavior: ScrollBehavior = "smooth"): void {
 	});
 }
 
+function isNearBottom(viewport: HTMLElement | null): boolean {
+	if (!viewport) return true;
+	return viewport.scrollTop + viewport.clientHeight >= viewport.scrollHeight - BOTTOM_THRESHOLD_PX;
+}
+
 async function fetchLogs() {
 	logsLoading = true;
 	logsError = "";
@@ -106,7 +113,10 @@ async function fetchLogs() {
 		const data = await res.json();
 		logs = data.logs || [];
 		selectLatestLog();
-		setTimeout(() => scrollToBottom("auto"), 0);
+		setTimeout(() => {
+			scrollToBottom("auto");
+			logFollow = true;
+		}, 0);
 	} catch {
 		logsError = "Failed to fetch logs";
 	} finally {
@@ -141,10 +151,17 @@ function startLogStream() {
 			}
 			if (logLevelFilter && entry.level !== logLevelFilter) return;
 			if (logCategoryFilter && entry.category !== logCategoryFilter) return;
+			const wasNearBottom = isNearBottom(logViewport);
+			const shouldAutoFollow = logAutoScroll && (logFollow || wasNearBottom);
 			const wasViewingLatest = isViewingLatest();
 			logs = [...logs.slice(-499), entry];
 			if (wasViewingLatest) selectLatestLog();
-			if (logAutoScroll && wasViewingLatest) setTimeout(() => scrollToBottom(), 0);
+			if (shouldAutoFollow) {
+				setTimeout(() => {
+					scrollToBottom("auto");
+					logFollow = true;
+				}, 0);
+			}
 		} catch {
 			// ignore parse errors
 		}
@@ -296,6 +313,22 @@ onMount(() => {
 		if (logEventSource) logEventSource.close();
 	};
 });
+
+$effect(() => {
+	const viewport = logViewport;
+	if (!viewport) return;
+
+	const onScroll = () => {
+		logFollow = isNearBottom(viewport);
+	};
+
+	viewport.addEventListener("scroll", onScroll, { passive: true });
+	onScroll();
+
+	return () => {
+		viewport.removeEventListener("scroll", onScroll);
+	};
+});
 </script>
 
 <div class="flex flex-col flex-1 min-h-0">
@@ -326,6 +359,13 @@ onMount(() => {
 			<Checkbox checked={logAutoScroll} onCheckedChange={(value: unknown) => { logAutoScroll = value === true; }} class="rounded-none" />
 			Auto-scroll
 		</label>
+		<span
+			class="text-[10px] font-[family-name:var(--font-mono)]"
+			class:text-[#4ade80]={logAutoScroll && logFollow}
+			class:text-[var(--sig-text-muted)]={!logAutoScroll || !logFollow}
+		>
+			{logAutoScroll && logFollow ? "following" : "paused"}
+		</span>
 		<button
 			class="text-[11px] px-2 py-1 border border-[var(--sig-border)] text-[var(--sig-text)] hover:border-[var(--sig-border-strong)] hover:text-[var(--sig-text-bright)]"
 			onclick={fetchLogs}

--- a/packages/cli/dashboard/src/lib/components/tabs/PipelineTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/PipelineTab.svelte
@@ -27,6 +27,7 @@
 	let mobileFeedActionsOpen = $state(false);
 	const AUTO_SCROLL_THRESHOLD_PX = 24;
 	let feedAtLatest = $state(true);
+	let feedFollow = $state(true);
 	let feedWidthClass = $derived(feedExpanded ? "lg:w-[420px]" : "lg:w-[320px]");
 	let feedPositionLabel = $derived(feedAtLatest ? "Latest" : "Oldest");
 	let feedDensityLabel = $derived(feedExpanded ? "Expanded" : "Compact");
@@ -46,12 +47,13 @@
 
 	function updateFeedPositionFlags(): void {
 		if (!feedViewport) return;
+		feedFollow = isFeedNearBottom();
 		const overflow =
 			feedViewport.scrollHeight - feedViewport.clientHeight >
 			AUTO_SCROLL_THRESHOLD_PX;
 		if (!overflow) return;
 
-		if (isFeedNearBottom()) {
+		if (feedFollow) {
 			feedAtLatest = true;
 			return;
 		}
@@ -66,10 +68,12 @@
 
 		if (feedAtLatest) {
 			autoScroll = false;
+			feedFollow = false;
 			feedAtLatest = false;
 			feedViewport.scrollTo({ top: 0, behavior: "smooth" });
 		} else {
 			autoScroll = true;
+			feedFollow = true;
 			feedAtLatest = true;
 			scrollFeedToBottom("auto");
 		}
@@ -85,6 +89,7 @@
 		workspaceLayout.pipeline.autoScroll = checked;
 		syncLayoutToStorage();
 		if (checked) {
+			feedFollow = true;
 			feedAtLatest = true;
 			requestAnimationFrame(() => {
 				scrollFeedToBottom("auto");
@@ -116,9 +121,11 @@
 		const _ = pipeline.feed.length;
 		updateFeedPositionFlags();
 		if (autoScroll && feedViewport) {
-			if (!isFeedNearBottom()) return;
+			if (!feedFollow) return;
 			requestAnimationFrame(() => {
-				scrollFeedToBottom("smooth");
+				scrollFeedToBottom("auto");
+				feedFollow = true;
+				feedAtLatest = true;
 				updateFeedPositionFlags();
 			});
 		}
@@ -380,9 +387,18 @@
 					<span class="text-[10px] uppercase tracking-[0.1em] text-[var(--sig-text-muted)] font-[family-name:var(--font-display)]">
 						Live Feed
 					</span>
-					<span class="text-[9px] text-[var(--sig-text-muted)] font-[family-name:var(--font-mono)]">
-						{pipeline.feed.length} events
-					</span>
+					<div class="flex items-center gap-2">
+						<span class="text-[9px] text-[var(--sig-text-muted)] font-[family-name:var(--font-mono)]">
+							{pipeline.feed.length} events
+						</span>
+						<span
+							class="text-[9px] font-[family-name:var(--font-mono)]"
+							class:text-[#4ade80]={autoScroll && feedFollow}
+							class:text-[var(--sig-text-muted)]={!autoScroll || !feedFollow}
+						>
+							{autoScroll && feedFollow ? "following" : "paused"}
+						</span>
+					</div>
 				</div>
 				<div class="flex items-center justify-between gap-2 min-w-0">
 					<label class="inline-flex items-center gap-1.5 text-[10px] text-[var(--sig-text)] font-[family-name:var(--font-mono)] cursor-pointer min-w-0">
@@ -397,14 +413,14 @@
 						<button
 							type="button"
 							class="px-2 py-[3px] text-[9px] uppercase tracking-[0.08em] font-[family-name:var(--font-mono)] border border-[var(--sig-border)] text-[var(--sig-text-muted)] hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
-							onclick={(event) => handleFeedJumpClick(event)}
+							onclick={(event: MouseEvent) => handleFeedJumpClick(event)}
 						>
 							{feedPositionLabel}
 						</button>
 						<button
 							type="button"
 							class="px-2 py-[3px] text-[9px] uppercase tracking-[0.08em] font-[family-name:var(--font-mono)] border border-[var(--sig-border)] text-[var(--sig-text-muted)] hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
-							onclick={(event) => handleFeedWidthToggle(event)}
+							onclick={(event: MouseEvent) => handleFeedWidthToggle(event)}
 						>
 							{feedDensityLabel}
 						</button>
@@ -431,14 +447,14 @@
 									<button
 										type="button"
 										class="w-full text-left px-2 py-1 text-[10px] uppercase tracking-[0.08em] font-[family-name:var(--font-mono)] border border-[var(--sig-border)] text-[var(--sig-text-muted)] hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
-										onclick={(event) => handleFeedJumpClick(event)}
+										onclick={(event: MouseEvent) => handleFeedJumpClick(event)}
 									>
 										{feedPositionLabel}
 									</button>
 									<button
 										type="button"
 										class="w-full text-left px-2 py-1 text-[10px] uppercase tracking-[0.08em] font-[family-name:var(--font-mono)] border border-[var(--sig-border)] text-[var(--sig-text-muted)] hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
-										onclick={(event) => handleFeedWidthToggle(event)}
+										onclick={(event: MouseEvent) => handleFeedWidthToggle(event)}
 									>
 										{feedDensityLabel}
 									</button>

--- a/packages/cli/dashboard/src/lib/components/tasks/TaskCard.svelte
+++ b/packages/cli/dashboard/src/lib/components/tasks/TaskCard.svelte
@@ -90,16 +90,16 @@ let lastRunLabel = $derived(formatRelativeTime(task.last_run_at));
 			<div class="flex items-center justify-between pt-1">
 				<!-- svelte-ignore a11y_click_events_have_key_events -->
 				<!-- svelte-ignore a11y_no_static_element_interactions -->
-				<div onclick={(e) => e.stopPropagation()}>
+				<div onclick={(e: MouseEvent) => e.stopPropagation()}>
 					<Switch
 						checked={!!task.enabled}
-						onCheckedChange={(v) => ontoggle(v)}
+						onCheckedChange={(v: unknown) => ontoggle(v === true)}
 						class="scale-75 origin-left"
 					/>
 				</div>
 				<!-- svelte-ignore a11y_click_events_have_key_events -->
 				<!-- svelte-ignore a11y_no_static_element_interactions -->
-				<div onclick={(e) => e.stopPropagation()}>
+				<div onclick={(e: MouseEvent) => e.stopPropagation()}>
 					<Button
 						variant="ghost"
 						size="sm"

--- a/packages/cli/dashboard/src/lib/components/ui/calendar/calendar-caption.svelte
+++ b/packages/cli/dashboard/src/lib/components/ui/calendar/calendar-caption.svelte
@@ -45,9 +45,9 @@
 		{months}
 		{monthFormat}
 		value={month.month}
-		onchange={(e) => {
+		onchange={(e: Event) => {
 			if (!placeholder) return;
-			const v = Number.parseInt(e.currentTarget.value);
+			const v = Number.parseInt((e.currentTarget as HTMLSelectElement).value);
 			const newPlaceholder = placeholder.set({ month: v });
 			placeholder = newPlaceholder.subtract({ months: monthIndex });
 		}}

--- a/packages/cli/dashboard/src/lib/utils.ts
+++ b/packages/cli/dashboard/src/lib/utils.ts
@@ -8,3 +8,9 @@ export function cn(...inputs: ClassValue[]): string {
 export type WithElementRef<T, El extends HTMLElement = HTMLElement> = T & {
 	ref?: El | null;
 };
+
+export type WithoutChildren<T> = T extends object ? Omit<T, "children"> : T;
+export type WithoutChild<T> = T extends object ? Omit<T, "child"> : T;
+export type WithoutChildrenOrChild<T> = T extends object
+	? Omit<T, "children" | "child">
+	: T;

--- a/packages/cli/dashboard/src/routes/+page.svelte
+++ b/packages/cli/dashboard/src/routes/+page.svelte
@@ -27,6 +27,7 @@ const activeTab = $derived(nav.activeTab);
 
 const { data } = $props();
 let daemonStatus = $state<DaemonStatus | null>(null);
+let embeddingsPrefetchPromise: Promise<unknown[]> | null = null;
 
 // --- Theme ---
 let theme = $state<"dark" | "light">("dark");
@@ -83,6 +84,16 @@ function openGlobalSimilar(memory: Memory) {
 	queueMemorySearch();
 }
 
+function prefetchEmbeddingsTab(): void {
+	if (!browser) return;
+	if (embeddingsPrefetchPromise) return;
+
+	embeddingsPrefetchPromise = Promise.all([
+		import("$lib/components/tabs/EmbeddingsTab.svelte"),
+		import("3d-force-graph"),
+	]);
+}
+
 // --- Cleanup ---
 $effect(() => {
 	return () => {
@@ -123,6 +134,7 @@ onMount(() => {
 		{daemonStatus}
 		{theme}
 		onthemetoggle={toggleTheme}
+		onprefetchembeddings={prefetchEmbeddingsTab}
 	/>
 	<main class="flex flex-1 flex-col min-w-0 min-h-0 overflow-hidden
 		m-2 ml-0 rounded-lg border border-[var(--sig-border)] md:border-l-0

--- a/packages/cli/dashboard/vite.config.ts
+++ b/packages/cli/dashboard/vite.config.ts
@@ -4,4 +4,55 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
 	plugins: [tailwindcss(), sveltekit()],
+	build: {
+		chunkSizeWarningLimit: 1200,
+		rollupOptions: {
+			output: {
+				manualChunks(id) {
+					if (!id.includes("node_modules")) return;
+
+					if (
+						id.includes("/three-forcegraph/") ||
+						id.includes("/three-spritetext/")
+					) {
+						return "vendor-forcegraph3d";
+					}
+
+					if (id.includes("/3d-force-graph/") || id.includes("/three-render-objects/")) {
+						return "vendor-3d-force";
+					}
+
+					if (id.includes("/three/")) {
+						return "vendor-three";
+					}
+
+					if (id.includes("/d3-force/")) {
+						return "vendor-embeddings-2d";
+					}
+
+					if (
+						id.includes("/@codemirror/view/") ||
+						id.includes("/@codemirror/state/") ||
+						id.includes("/@codemirror/commands/") ||
+						id.includes("/@codemirror/search/") ||
+						id.includes("/@codemirror/lang-") ||
+						id.includes("/@codemirror/autocomplete/") ||
+						id.includes("/@codemirror/language/") ||
+						id.includes("/@lezer/") ||
+						id.includes("/codemirror/")
+					) {
+						return "vendor-codemirror";
+					}
+
+					if (id.includes("/bits-ui/") || id.includes("/svelte-sonner/")) {
+						return "vendor-ui";
+					}
+
+					if (id.includes("/yaml/") || id.includes("/marked/")) {
+						return "vendor-utils";
+					}
+				},
+			},
+		},
+	},
 });

--- a/packages/daemon/src/memory-config.test.ts
+++ b/packages/daemon/src/memory-config.test.ts
@@ -25,7 +25,7 @@ function makeTempAgentsDir(): string {
 }
 
 describe("loadMemoryConfig", () => {
-	it("prefers agent.yaml embedding settings over legacy files", () => {
+	it("prefers agent.yaml embedding settings over config.yaml fallback", () => {
 		const agentsDir = makeTempAgentsDir();
 		writeFileSync(
 			join(agentsDir, "agent.yaml"),


### PR DESCRIPTION
## What
- Restores feed follow behavior on latest `main` for Logs and Pipeline so auto-scroll only follows when the user is already at live tail.
- Adds explicit live-feed state indicators (`following` / `paused`) in both feed tabs.
- Improves Embeddings tab responsiveness by prefetching heavy assets from sidebar hover/focus and tuning dashboard chunking.
- Fixes constellation framing in vertical/narrow viewports so both 2D and 3D open zoomed out to show the full constellation.
- Hardens daemon checkpoint persistence for missing `session_checkpoints` table paths.
- Syncs `bun.lock` to match current workspace dependency resolution.

## How
- **Feed follow logic:** switched Logs/Pipeline follow behavior to viewport-near-bottom detection with scroll listeners, rather than selection-driven assumptions.
- **Feed UX:** surfaced follow state with clear `following`/`paused` labels tied to scroll position.
- **Embeddings prefetch/perf:** triggers tab prefetch on sidebar hover/focus and updates Vite manual chunk settings/chunk warning thresholds.
- **2D constellation fit:** computes world bounds and applies an initial fit-to-bounds camera on render/resize; auto-fit disables after user pan/zoom/drag.
- **3D constellation fit:** applies `zoomToFit` after init and on resize (via observer), then stops auto-fit once user controls interaction begins.
- **Checkpoint resilience:** adds schema guards/fallback creation for session checkpoint read/write/prune paths.

## Why
- Feed panes were unexpectedly snapping or not following correctly, making live monitoring unreliable.
- Users need immediate visual confirmation of whether a feed is actively following or paused.
- Embeddings view had noticeable first-open cost that benefits from early warming.
- On portrait/vertical browser layouts, constellation appeared too zoomed in and hid global structure; the default should preserve full-context visibility like desktop.
- Checkpoint code needed to tolerate stale/missing table states so tests and runtime remain stable.
- Lockfile needed alignment to avoid inconsistent dependency graphs across local/CI installs.

## Files changed
- `packages/cli/dashboard/src/lib/components/tabs/LogsTab.svelte`
- `packages/cli/dashboard/src/lib/components/tabs/PipelineTab.svelte`
- `packages/cli/dashboard/src/lib/components/app-sidebar.svelte`
- `packages/cli/dashboard/src/routes/+page.svelte`
- `packages/cli/dashboard/vite.config.ts`
- `packages/cli/dashboard/src/lib/components/embeddings/EmbeddingCanvas2D.svelte`
- `packages/cli/dashboard/src/lib/components/embeddings/EmbeddingCanvas3D.svelte`
- `packages/daemon/src/session-checkpoints.ts`
- `bun.lock`

## Validation
- `bun test` ✅
- `bun run typecheck` ✅
- `bun run check` (`packages/cli/dashboard`) ✅ (warnings only)
- `bun run build` (`packages/cli/dashboard`) ✅
- `bun run build` (workspace) ✅