### PR TITLE
fix(embeddings): wire repair actions and vec resync

### DIFF
--- a/packages/cli/dashboard/src/lib/api.ts
+++ b/packages/cli/dashboard/src/lib/api.ts
@@ -524,32 +524,84 @@ export async function getEmbeddingHealth(): Promise<EmbeddingHealthReport | null
 	}
 }
 
-export async function repairCleanOrphans(): Promise<{ success: boolean; affected: number; message: string } | null> {
+export interface RepairActionResult {
+	success: boolean;
+	affected: number;
+	message: string;
+	action?: string;
+	status: number;
+}
+
+async function runRepairAction(path: string, payload: Record<string, unknown>): Promise<RepairActionResult> {
 	try {
-		const response = await fetch(`${API_BASE}/api/repair/clean-orphans`, {
+		const response = await fetch(`${API_BASE}${path}`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ reason: "dashboard: embedding health", actor: "dashboard" }),
+			body: JSON.stringify(payload),
 		});
-		if (!response.ok) return null;
-		return await response.json();
-	} catch {
-		return null;
+		const body = (await response.json().catch(() => null)) as {
+			success?: unknown;
+			affected?: unknown;
+			message?: unknown;
+			error?: unknown;
+			action?: unknown;
+		} | null;
+
+		const affected = typeof body?.affected === "number" ? body.affected : 0;
+		const action = typeof body?.action === "string" ? body.action : undefined;
+		const responseMessage =
+			typeof body?.message === "string"
+				? body.message
+				: typeof body?.error === "string"
+					? body.error
+					: `HTTP ${response.status}`;
+
+		if (response.ok) {
+			const success = typeof body?.success === "boolean" ? body.success : true;
+			return {
+				success,
+				affected,
+				message: responseMessage,
+				action,
+				status: response.status,
+			};
+		}
+
+		return {
+			success: false,
+			affected,
+			message: responseMessage,
+			action,
+			status: response.status,
+		};
+	} catch (error) {
+		return {
+			success: false,
+			affected: 0,
+			message: error instanceof Error ? error.message : String(error),
+			status: 0,
+		};
 	}
 }
 
-export async function repairReEmbed(): Promise<{ success: boolean; affected: number; message: string } | null> {
-	try {
-		const response = await fetch(`${API_BASE}/api/repair/re-embed`, {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ reason: "dashboard: embedding health", actor: "dashboard" }),
-		});
-		if (!response.ok) return null;
-		return await response.json();
-	} catch {
-		return null;
-	}
+const DASHBOARD_REPAIR_PAYLOAD = {
+	reason: "dashboard: embedding health",
+	actor: "dashboard",
+};
+
+export async function repairCleanOrphans(): Promise<RepairActionResult> {
+	return runRepairAction("/api/repair/clean-orphans", DASHBOARD_REPAIR_PAYLOAD);
+}
+
+export async function repairReEmbed(batchSize = 250): Promise<RepairActionResult> {
+	return runRepairAction("/api/repair/re-embed", {
+		...DASHBOARD_REPAIR_PAYLOAD,
+		batchSize,
+	});
+}
+
+export async function repairResyncVectorIndex(): Promise<RepairActionResult> {
+	return runRepairAction("/api/repair/resync-vec", DASHBOARD_REPAIR_PAYLOAD);
 }
 
 export async function getHarnesses(): Promise<Harness[]> {
@@ -582,10 +634,7 @@ export interface SyncResult {
 
 export async function syncConnector(id: string): Promise<SyncResult> {
 	try {
-		const response = await fetch(
-			`${API_BASE}/api/connectors/${encodeURIComponent(id)}/sync`,
-			{ method: "POST" },
-		);
+		const response = await fetch(`${API_BASE}/api/connectors/${encodeURIComponent(id)}/sync`, { method: "POST" });
 		return await response.json();
 	} catch (e) {
 		return { status: "error", error: e instanceof Error ? e.message : String(e) };
@@ -594,10 +643,9 @@ export async function syncConnector(id: string): Promise<SyncResult> {
 
 export async function syncConnectorFull(id: string): Promise<SyncResult> {
 	try {
-		const response = await fetch(
-			`${API_BASE}/api/connectors/${encodeURIComponent(id)}/sync/full?confirm=true`,
-			{ method: "POST" },
-		);
+		const response = await fetch(`${API_BASE}/api/connectors/${encodeURIComponent(id)}/sync/full?confirm=true`, {
+			method: "POST",
+		});
 		return await response.json();
 	} catch (e) {
 		return { status: "error", error: e instanceof Error ? e.message : String(e) };

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -6,16 +6,19 @@ import {
 	type Memory,
 	type ProjectionNode,
 	type ProjectionQueryOptions,
+	type RepairActionResult,
 	getDistinctWho,
 	getEmbeddingHealth,
 	getProjection,
 	getSimilarMemories,
 	repairCleanOrphans,
 	repairReEmbed,
+	repairResyncVectorIndex,
 	setMemoryPinned,
 } from "$lib/api";
 import * as Collapsible from "$lib/components/ui/collapsible/index.js";
 import { mem } from "$lib/stores/memory.svelte";
+import { toast } from "$lib/stores/toast.svelte";
 import { syncLayoutToStorage, workspaceLayout } from "$lib/stores/workspace-layout.svelte";
 import { ActionLabels } from "$lib/ui/action-labels";
 import ChevronDown from "@lucide/svelte/icons/chevron-down";
@@ -189,10 +192,27 @@ async function runFix(check: EmbeddingCheckResult): Promise<void> {
 	if (healthFixBusy) return;
 	healthFixBusy = true;
 	try {
+		let result: RepairActionResult;
 		if (check.name === "orphaned-embeddings") {
-			await repairCleanOrphans();
+			result = await repairCleanOrphans();
+		} else if (check.name === "vec-table-sync") {
+			result = await repairResyncVectorIndex();
 		} else if (check.name === "coverage" || check.name === "null-vectors") {
-			await repairReEmbed();
+			result = await repairReEmbed();
+		} else {
+			toast(`Repair action not wired for ${check.name}`, "warning");
+			return;
+		}
+
+		if (!result.success) {
+			toast(`Repair failed: ${result.message}`, "error", 5000);
+			return;
+		}
+
+		if (result.affected > 0) {
+			toast(result.message, "success", 4500);
+		} else {
+			toast(result.message, "info", 4500);
 		}
 		await fetchHealth();
 	} finally {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -99,6 +99,7 @@ import {
 	reembedMissingMemories,
 	releaseStaleLeases,
 	requeueDeadJobs,
+	resyncVectorIndex,
 	triggerRetentionSweep,
 } from "./repair-actions";
 import { CRON_PRESETS, computeNextRun, isHarnessAvailable, startSchedulerWorker, validateCron } from "./scheduler";
@@ -5133,6 +5134,13 @@ app.post("/api/repair/re-embed", async (c) => {
 		dryRun,
 	);
 
+	return c.json(result, result.success ? 200 : 429);
+});
+
+app.post("/api/repair/resync-vec", (c) => {
+	const cfg = loadMemoryConfig(AGENTS_DIR);
+	const ctx = resolveRepairContext(c);
+	const result = resyncVectorIndex(getDbAccessor(), cfg.pipelineV2, ctx, repairLimiter);
 	return c.json(result, result.success ? 200 : 429);
 });
 

--- a/packages/daemon/src/repair-actions.test.ts
+++ b/packages/daemon/src/repair-actions.test.ts
@@ -5,17 +5,18 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { runMigrations } from "@signet/core";
-import type { DbAccessor, WriteDb, ReadDb } from "./db-accessor";
+import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
 import type { PipelineV2Config } from "./memory-config";
 import {
-	createRateLimiter,
-	checkRepairGate,
-	requeueDeadJobs,
-	releaseStaleLeases,
 	checkFtsConsistency,
-	triggerRetentionSweep,
-	getDedupStats,
+	checkRepairGate,
+	createRateLimiter,
 	deduplicateMemories,
+	getDedupStats,
+	releaseStaleLeases,
+	requeueDeadJobs,
+	resyncVectorIndex,
+	triggerRetentionSweep,
 } from "./repair-actions";
 
 // ---------------------------------------------------------------------------
@@ -48,6 +49,7 @@ const TEST_CFG: PipelineV2Config = {
 	enabled: true,
 	shadowMode: false,
 	mutationsFrozen: false,
+	semanticContradictionEnabled: false,
 	extraction: {
 		provider: "ollama",
 		model: "test",
@@ -98,6 +100,14 @@ const TEST_CFG: PipelineV2Config = {
 		chunkTargetChars: 300,
 		recallTruncateChars: 500,
 	},
+	telemetryEnabled: false,
+	telemetry: {
+		posthogHost: "",
+		posthogApiKey: "",
+		flushIntervalMs: 60000,
+		flushBatchSize: 50,
+		retentionDays: 90,
+	},
 };
 
 const CTX_OPERATOR = {
@@ -120,18 +130,50 @@ function insertMemory(db: Database, id: string): void {
 	).run(id, `content for ${id}`, "fact", now, now, "test");
 }
 
-function insertJob(
-	db: Database,
-	id: string,
-	memId: string,
-	status: string,
-	leasedAt?: string,
-): void {
+function insertJob(db: Database, id: string, memId: string, status: string, leasedAt?: string): void {
 	const now = new Date().toISOString();
 	db.prepare(
 		`INSERT INTO memory_jobs (id, memory_id, job_type, status, leased_at, created_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
 	).run(id, memId, "extract", status, leasedAt ?? null, now, now);
+}
+
+function ensureVecTable(db: Database): void {
+	try {
+		db.exec("DROP TABLE IF EXISTS vec_embeddings");
+	} catch {
+		// ignore drop failures in tests
+	}
+	db.exec("CREATE TABLE vec_embeddings (id TEXT PRIMARY KEY, embedding BLOB)");
+}
+
+function vectorBlob(values: readonly number[]): Buffer {
+	const f32 = new Float32Array(values);
+	return Buffer.from(f32.buffer.slice(0));
+}
+
+function insertEmbedding(
+	db: Database,
+	params: {
+		id: string;
+		contentHash: string;
+		sourceId: string;
+		vector: readonly number[];
+	},
+): void {
+	const now = new Date().toISOString();
+	db.prepare(
+		`INSERT INTO embeddings (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at)
+		 VALUES (?, ?, ?, ?, 'memory', ?, ?, ?)`,
+	).run(
+		params.id,
+		params.contentHash,
+		vectorBlob(params.vector),
+		params.vector.length,
+		params.sourceId,
+		`chunk for ${params.sourceId}`,
+		now,
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -267,9 +309,9 @@ describe("requeueDeadJobs", () => {
 		expect(result.success).toBe(true);
 		expect(result.affected).toBe(2);
 
-		const statuses = db
-			.prepare("SELECT status FROM memory_jobs WHERE memory_id = 'mem-1'")
-			.all() as Array<{ status: string }>;
+		const statuses = db.prepare("SELECT status FROM memory_jobs WHERE memory_id = 'mem-1'").all() as Array<{
+			status: string;
+		}>;
 		expect(statuses.every((r) => r.status === "pending")).toBe(true);
 	});
 
@@ -280,20 +322,12 @@ describe("requeueDeadJobs", () => {
 		}
 
 		const limiter = createRateLimiter();
-		const result = requeueDeadJobs(
-			accessor,
-			TEST_CFG,
-			CTX_OPERATOR,
-			limiter,
-			3,
-		);
+		const result = requeueDeadJobs(accessor, TEST_CFG, CTX_OPERATOR, limiter, 3);
 
 		expect(result.success).toBe(true);
 		expect(result.affected).toBe(3);
 
-		const remaining = db
-			.prepare("SELECT COUNT(*) as n FROM memory_jobs WHERE status = 'dead'")
-			.get() as { n: number };
+		const remaining = db.prepare("SELECT COUNT(*) as n FROM memory_jobs WHERE status = 'dead'").get() as { n: number };
 		expect(remaining.n).toBe(2);
 	});
 });
@@ -334,14 +368,10 @@ describe("releaseStaleLeases", () => {
 		expect(result.success).toBe(true);
 		expect(result.affected).toBe(1);
 
-		const stale = db
-			.prepare("SELECT status FROM memory_jobs WHERE id = 'job-stale'")
-			.get() as { status: string };
+		const stale = db.prepare("SELECT status FROM memory_jobs WHERE id = 'job-stale'").get() as { status: string };
 		expect(stale.status).toBe("pending");
 
-		const fresh = db
-			.prepare("SELECT status FROM memory_jobs WHERE id = 'job-fresh'")
-			.get() as { status: string };
+		const fresh = db.prepare("SELECT status FROM memory_jobs WHERE id = 'job-fresh'").get() as { status: string };
 		expect(fresh.status).toBe("leased");
 	});
 });
@@ -367,13 +397,7 @@ describe("checkFtsConsistency", () => {
 	it("reports consistent FTS when counts match", () => {
 		insertMemory(db, "mem-fts-ok");
 		const limiter = createRateLimiter();
-		const result = checkFtsConsistency(
-			accessor,
-			TEST_CFG,
-			CTX_OPERATOR,
-			limiter,
-			false,
-		);
+		const result = checkFtsConsistency(accessor, TEST_CFG, CTX_OPERATOR, limiter, false);
 
 		expect(result.success).toBe(true);
 		// counts match (FTS5 external content reads from memories)
@@ -385,13 +409,7 @@ describe("checkFtsConsistency", () => {
 		insertMemory(db, "mem-fts-rebuild");
 		const limiter = createRateLimiter();
 		// repair=true triggers rebuild even when consistent; should not throw
-		const result = checkFtsConsistency(
-			accessor,
-			TEST_CFG,
-			CTX_OPERATOR,
-			limiter,
-			true,
-		);
+		const result = checkFtsConsistency(accessor, TEST_CFG, CTX_OPERATOR, limiter, true);
 		// Rebuild only runs on mismatch; consistent case is a no-op
 		expect(result.success).toBe(true);
 	});
@@ -527,12 +545,7 @@ describe("deduplicateMemories", () => {
 		).run("mid-importance", "duplicate content", now, now);
 
 		const limiter = createRateLimiter();
-		const result = await deduplicateMemories(
-			accessor,
-			TEST_CFG,
-			CTX_OPERATOR,
-			limiter,
-		);
+		const result = await deduplicateMemories(accessor, TEST_CFG, CTX_OPERATOR, limiter);
 
 		expect(result.success).toBe(true);
 		expect(result.affected).toBe(2); // 2 losers soft-deleted
@@ -566,9 +579,7 @@ describe("deduplicateMemories", () => {
 		const limiter = createRateLimiter();
 		await deduplicateMemories(accessor, TEST_CFG, CTX_OPERATOR, limiter);
 
-		const row = db
-			.prepare("SELECT tags FROM memories WHERE id = 'keeper-tags'")
-			.get() as { tags: string };
+		const row = db.prepare("SELECT tags FROM memories WHERE id = 'keeper-tags'").get() as { tags: string };
 		const tags = row.tags.split(",");
 		expect(tags).toContain("alpha");
 		expect(tags).toContain("beta");
@@ -588,12 +599,7 @@ describe("deduplicateMemories", () => {
 		).run("unpinned-mem", "content", now, now);
 
 		const limiter = createRateLimiter();
-		const result = await deduplicateMemories(
-			accessor,
-			TEST_CFG,
-			CTX_OPERATOR,
-			limiter,
-		);
+		const result = await deduplicateMemories(accessor, TEST_CFG, CTX_OPERATOR, limiter);
 
 		// Pinned memories are excluded from the initial query, so the
 		// cluster only contains unpinned-mem (1 row) -- not enough to deduplicate
@@ -639,13 +645,7 @@ describe("deduplicateMemories", () => {
 		).run("dry-2", "content", now, now);
 
 		const limiter = createRateLimiter();
-		const result = await deduplicateMemories(
-			accessor,
-			TEST_CFG,
-			CTX_OPERATOR,
-			limiter,
-			{ dryRun: true },
-		);
+		const result = await deduplicateMemories(accessor, TEST_CFG, CTX_OPERATOR, limiter, { dryRun: true });
 
 		expect(result.success).toBe(true);
 		expect(result.affected).toBe(0);
@@ -653,9 +653,7 @@ describe("deduplicateMemories", () => {
 		expect(result.message).toMatch(/dry run/);
 
 		// Nothing should be deleted
-		const active = db
-			.prepare("SELECT COUNT(*) AS n FROM memories WHERE is_deleted = 0")
-			.get() as { n: number };
+		const active = db.prepare("SELECT COUNT(*) AS n FROM memories WHERE is_deleted = 0").get() as { n: number };
 		expect(active.n).toBe(2);
 	});
 
@@ -691,12 +689,7 @@ describe("deduplicateMemories", () => {
 			autonomous: { ...TEST_CFG.autonomous, frozen: true },
 		};
 		const limiter = createRateLimiter();
-		const result = await deduplicateMemories(
-			accessor,
-			frozenCfg,
-			CTX_OPERATOR,
-			limiter,
-		);
+		const result = await deduplicateMemories(accessor, frozenCfg, CTX_OPERATOR, limiter);
 		expect(result.success).toBe(false);
 	});
 
@@ -718,20 +711,13 @@ describe("deduplicateMemories", () => {
 		}
 
 		const limiter = createRateLimiter();
-		const result = await deduplicateMemories(
-			accessor,
-			TEST_CFG,
-			CTX_OPERATOR,
-			limiter,
-		);
+		const result = await deduplicateMemories(accessor, TEST_CFG, CTX_OPERATOR, limiter);
 
 		expect(result.success).toBe(true);
 		expect(result.clusters).toBe(2);
 		expect(result.affected).toBe(3); // 2 from cluster A + 1 from cluster B
 
-		const active = db
-			.prepare("SELECT COUNT(*) AS n FROM memories WHERE is_deleted = 0")
-			.get() as { n: number };
+		const active = db.prepare("SELECT COUNT(*) AS n FROM memories WHERE is_deleted = 0").get() as { n: number };
 		expect(active.n).toBe(2); // 1 keeper per cluster
 	});
 });
@@ -750,14 +736,74 @@ describe("triggerRetentionSweep", () => {
 		};
 
 		const limiter = createRateLimiter();
-		const result = triggerRetentionSweep(
-			TEST_CFG,
-			CTX_OPERATOR,
-			limiter,
-			handle,
-		);
+		const result = triggerRetentionSweep(TEST_CFG, CTX_OPERATOR, limiter, handle);
 
 		expect(result.success).toBe(true);
 		expect(swept).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// resyncVectorIndex
+// ---------------------------------------------------------------------------
+
+describe("resyncVectorIndex", () => {
+	let db: Database;
+	let accessor: DbAccessor;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+		ensureVecTable(db);
+		accessor = asAccessor(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("inserts missing vec rows and removes orphan vec rows", () => {
+		insertMemory(db, "mem-v-1");
+		insertMemory(db, "mem-v-2");
+
+		insertEmbedding(db, {
+			id: "emb-v-1",
+			contentHash: "hash-v-1",
+			sourceId: "mem-v-1",
+			vector: [0.1, 0.2, 0.3],
+		});
+		insertEmbedding(db, {
+			id: "emb-v-2",
+			contentHash: "hash-v-2",
+			sourceId: "mem-v-2",
+			vector: [0.4, 0.5, 0.6],
+		});
+
+		db.prepare("INSERT INTO vec_embeddings (id, embedding) VALUES (?, ?)").run(
+			"emb-v-1",
+			new Float32Array([0.1, 0.2, 0.3]),
+		);
+		db.prepare("INSERT INTO vec_embeddings (id, embedding) VALUES (?, ?)").run(
+			"emb-orphan",
+			new Float32Array([9, 9, 9]),
+		);
+
+		const limiter = createRateLimiter();
+		const result = resyncVectorIndex(accessor, TEST_CFG, CTX_OPERATOR, limiter);
+
+		expect(result.success).toBe(true);
+		expect(result.affected).toBe(2);
+
+		const ids = db.prepare("SELECT id FROM vec_embeddings ORDER BY id").all() as Array<{ id: string }>;
+		expect(ids.map((row) => row.id)).toEqual(["emb-v-1", "emb-v-2"]);
+	});
+
+	it("returns a clear error when vec table is missing", () => {
+		db.exec("DROP TABLE vec_embeddings");
+		const limiter = createRateLimiter();
+		const result = resyncVectorIndex(accessor, TEST_CFG, CTX_OPERATOR, limiter);
+
+		expect(result.success).toBe(false);
+		expect(result.message).toMatch(/vec_embeddings table not found/);
 	});
 });

--- a/packages/daemon/src/repair-actions.ts
+++ b/packages/daemon/src/repair-actions.ts
@@ -7,11 +7,17 @@
  */
 
 import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
-import type { EmbeddingConfig } from "./memory-config";
-import { countChanges, vectorToBlob, syncVecInsert, syncVecDeleteBySourceExceptHash, syncVecDeleteByEmbeddingIds } from "./db-helpers";
-import { insertHistoryEvent } from "./transactions";
+import {
+	countChanges,
+	syncVecDeleteByEmbeddingIds,
+	syncVecDeleteBySourceExceptHash,
+	syncVecInsert,
+	vectorToBlob,
+} from "./db-helpers";
 import { logger } from "./logger";
+import type { EmbeddingConfig } from "./memory-config";
 import type { PipelineV2Config } from "./memory-config";
+import { insertHistoryEvent } from "./transactions";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -47,11 +53,7 @@ interface RateLimiterEntry {
 }
 
 export interface RateLimiter {
-	check(
-		action: string,
-		cooldownMs: number,
-		hourlyBudget: number,
-	): RepairGateCheck;
+	check(action: string, cooldownMs: number, hourlyBudget: number): RepairGateCheck;
 	record(action: string): void;
 }
 
@@ -59,11 +61,7 @@ export function createRateLimiter(): RateLimiter {
 	const state = new Map<string, RateLimiterEntry>();
 
 	return {
-		check(
-			action: string,
-			cooldownMs: number,
-			hourlyBudget: number,
-		): RepairGateCheck {
+		check(action: string, cooldownMs: number, hourlyBudget: number): RepairGateCheck {
 			const now = Date.now();
 			const entry = state.get(action);
 
@@ -78,8 +76,7 @@ export function createRateLimiter(): RateLimiter {
 			}
 
 			// Reset hourly counter if the window has passed
-			const effectiveCount =
-				now >= entry.hourResetAt ? 0 : entry.hourlyCount;
+			const effectiveCount = now >= entry.hourResetAt ? 0 : entry.hourlyCount;
 			if (effectiveCount >= hourlyBudget) {
 				return {
 					allowed: false,
@@ -146,13 +143,7 @@ export function checkRepairGate(
 // Audit helper
 // ---------------------------------------------------------------------------
 
-function writeRepairAudit(
-	db: WriteDb,
-	action: string,
-	ctx: RepairContext,
-	affected: number,
-	message: string,
-): void {
+function writeRepairAudit(db: WriteDb, action: string, ctx: RepairContext, affected: number, message: string): void {
 	insertHistoryEvent(db, {
 		memoryId: "system",
 		event: "none",
@@ -186,14 +177,7 @@ export function requeueDeadJobs(
 	maxBatch: number = DEFAULT_REQUEUE_BATCH,
 ): RepairResult {
 	const action = "requeueDeadJobs";
-	const gate = checkRepairGate(
-		cfg,
-		ctx,
-		limiter,
-		action,
-		cfg.repair.requeueCooldownMs,
-		cfg.repair.requeueHourlyBudget,
-	);
+	const gate = checkRepairGate(cfg, ctx, limiter, action, cfg.repair.requeueCooldownMs, cfg.repair.requeueHourlyBudget);
 
 	if (!gate.allowed) {
 		return {
@@ -205,9 +189,9 @@ export function requeueDeadJobs(
 	}
 
 	const affected = accessor.withWriteTx((db) => {
-		const dead = db
-			.prepare("SELECT id FROM memory_jobs WHERE status = 'dead' LIMIT ?")
-			.all(maxBatch) as Array<{ id: string }>;
+		const dead = db.prepare("SELECT id FROM memory_jobs WHERE status = 'dead' LIMIT ?").all(maxBatch) as Array<{
+			id: string;
+		}>;
 
 		if (dead.length === 0) return 0;
 
@@ -253,14 +237,7 @@ export function releaseStaleLeases(
 	limiter: RateLimiter,
 ): RepairResult {
 	const action = "releaseStaleLeases";
-	const gate = checkRepairGate(
-		cfg,
-		ctx,
-		limiter,
-		action,
-		cfg.repair.requeueCooldownMs,
-		cfg.repair.requeueHourlyBudget,
-	);
+	const gate = checkRepairGate(cfg, ctx, limiter, action, cfg.repair.requeueCooldownMs, cfg.repair.requeueHourlyBudget);
 
 	if (!gate.allowed) {
 		return {
@@ -314,17 +291,10 @@ export function checkFtsConsistency(
 	cfg: PipelineV2Config,
 	ctx: RepairContext,
 	limiter: RateLimiter,
-	repair: boolean = false,
+	repair = false,
 ): RepairResult {
 	const action = "checkFtsConsistency";
-	const gate = checkRepairGate(
-		cfg,
-		ctx,
-		limiter,
-		action,
-		cfg.repair.reembedCooldownMs,
-		FTS_HOURLY_BUDGET,
-	);
+	const gate = checkRepairGate(cfg, ctx, limiter, action, cfg.repair.reembedCooldownMs, FTS_HOURLY_BUDGET);
 
 	if (!gate.allowed) {
 		return {
@@ -336,17 +306,13 @@ export function checkFtsConsistency(
 	}
 
 	const { memCount, ftsCount, ftsMissing } = accessor.withReadDb((db) => {
-		const memRow = db
-			.prepare("SELECT COUNT(*) as n FROM memories WHERE is_deleted = 0")
-			.get() as { n: number };
+		const memRow = db.prepare("SELECT COUNT(*) as n FROM memories WHERE is_deleted = 0").get() as { n: number };
 
 		// Guard against missing FTS table (can happen on upgrades)
 		let ftsN = 0;
 		let missing = false;
 		try {
-			const ftsRow = db
-				.prepare("SELECT COUNT(*) as n FROM memories_fts")
-				.get() as { n: number };
+			const ftsRow = db.prepare("SELECT COUNT(*) as n FROM memories_fts").get() as { n: number };
 			ftsN = ftsRow.n;
 		} catch {
 			missing = true;
@@ -376,19 +342,12 @@ export function checkFtsConsistency(
 	// FTS5 external content tables include tombstones, so ftsCount >=
 	// memCount is normal. Only flag when the gap exceeds 10%, matching
 	// the threshold in diagnostics.ts getIndexHealth().
-	const mismatch =
-		memCount > 0 && ftsCount > memCount * 1.1;
+	const mismatch = memCount > 0 && ftsCount > memCount * 1.1;
 
 	if (mismatch && repair) {
 		accessor.withWriteTx((db) => {
 			db.prepare("INSERT INTO memories_fts(memories_fts) VALUES('rebuild')").run();
-			writeRepairAudit(
-				db,
-				action,
-				ctx,
-				1,
-				`FTS rebuilt: ${memCount} active vs ${ftsCount} FTS rows`,
-			);
+			writeRepairAudit(db, action, ctx, 1, `FTS rebuilt: ${memCount} active vs ${ftsCount} FTS rows`);
 		});
 	}
 
@@ -424,14 +383,7 @@ export function triggerRetentionSweep(
 	retentionHandle: { sweep(): unknown },
 ): RepairResult {
 	const action = "triggerRetentionSweep";
-	const gate = checkRepairGate(
-		cfg,
-		ctx,
-		limiter,
-		action,
-		cfg.repair.requeueCooldownMs,
-		cfg.repair.requeueHourlyBudget,
-	);
+	const gate = checkRepairGate(cfg, ctx, limiter, action, cfg.repair.requeueCooldownMs, cfg.repair.requeueHourlyBudget);
 
 	if (!gate.allowed) {
 		return {
@@ -468,13 +420,9 @@ export interface EmbeddingGapStats {
 	readonly coverage: string;
 }
 
-export function getEmbeddingGapStats(
-	accessor: DbAccessor,
-): EmbeddingGapStats {
+export function getEmbeddingGapStats(accessor: DbAccessor): EmbeddingGapStats {
 	return accessor.withReadDb((db) => {
-		const totalRow = db
-			.prepare("SELECT COUNT(*) as n FROM memories WHERE is_deleted = 0")
-			.get() as { n: number };
+		const totalRow = db.prepare("SELECT COUNT(*) as n FROM memories WHERE is_deleted = 0").get() as { n: number };
 		const unembeddedRow = db
 			.prepare(
 				`SELECT COUNT(*) as n FROM memories m
@@ -519,23 +467,13 @@ export async function reembedMissingMemories(
 	cfg: PipelineV2Config,
 	ctx: RepairContext,
 	limiter: RateLimiter,
-	embeddingFn: (
-		content: string,
-		cfg: EmbeddingConfig,
-	) => Promise<number[] | null>,
+	embeddingFn: (content: string, cfg: EmbeddingConfig) => Promise<number[] | null>,
 	embeddingCfg: EmbeddingConfig,
 	batchSize: number = DEFAULT_REEMBED_BATCH,
-	dryRun: boolean = false,
+	dryRun = false,
 ): Promise<RepairResult> {
 	const action = "reembedMissingMemories";
-	const gate = checkRepairGate(
-		cfg,
-		ctx,
-		limiter,
-		action,
-		cfg.repair.reembedCooldownMs,
-		cfg.repair.reembedHourlyBudget,
-	);
+	const gate = checkRepairGate(cfg, ctx, limiter, action, cfg.repair.reembedCooldownMs, cfg.repair.reembedHourlyBudget);
 
 	if (!gate.allowed) {
 		return {
@@ -617,12 +555,7 @@ export async function reembedMissingMemories(
 		for (const { memory, vector } of results) {
 			const embId = crypto.randomUUID();
 			const blob = vectorToBlob(vector);
-			syncVecDeleteBySourceExceptHash(
-				db,
-				"memory",
-				memory.id,
-				memory.content_hash,
-			);
+			syncVecDeleteBySourceExceptHash(db, "memory", memory.id, memory.content_hash);
 			db.prepare(
 				`DELETE FROM embeddings
 				 WHERE source_type = 'memory' AND source_id = ?
@@ -642,15 +575,7 @@ export async function reembedMissingMemories(
 					   chunk_text = excluded.chunk_text,
 					   created_at = excluded.created_at`,
 				)
-				.run(
-					embId,
-					memory.content_hash,
-					blob,
-					vector.length,
-					memory.id,
-					memory.content,
-					now,
-				);
+				.run(embId, memory.content_hash, blob, vector.length, memory.id, memory.content, now);
 			if (countChanges(result) > 0) {
 				syncVecInsert(db, embId, vector);
 				count++;
@@ -693,14 +618,7 @@ export function cleanOrphanedEmbeddings(
 	limiter: RateLimiter,
 ): RepairResult {
 	const action = "cleanOrphanedEmbeddings";
-	const gate = checkRepairGate(
-		cfg,
-		ctx,
-		limiter,
-		action,
-		cfg.repair.requeueCooldownMs,
-		cfg.repair.requeueHourlyBudget,
-	);
+	const gate = checkRepairGate(cfg, ctx, limiter, action, cfg.repair.requeueCooldownMs, cfg.repair.requeueHourlyBudget);
 
 	if (!gate.allowed) {
 		return {
@@ -727,9 +645,7 @@ export function cleanOrphanedEmbeddings(
 		syncVecDeleteByEmbeddingIds(db, ids);
 
 		const placeholders = ids.map(() => "?").join(", ");
-		const result = db
-			.prepare(`DELETE FROM embeddings WHERE id IN (${placeholders})`)
-			.run(...ids);
+		const result = db.prepare(`DELETE FROM embeddings WHERE id IN (${placeholders})`).run(...ids);
 
 		const count = countChanges(result);
 		const msg = `cleaned ${count} orphaned embedding(s)`;
@@ -749,6 +665,154 @@ export function cleanOrphanedEmbeddings(
 		success: true,
 		affected,
 		message: `cleaned ${affected} orphaned embedding(s)`,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Resync vec index
+// ---------------------------------------------------------------------------
+
+interface VecResyncStats {
+	readonly vecAvailable: boolean;
+	readonly inserted: number;
+	readonly deleted: number;
+	readonly skipped: number;
+}
+
+function blobToFloat32Vector(raw: unknown): Float32Array | null {
+	if (raw instanceof Float32Array) return raw;
+	if (raw instanceof ArrayBuffer) {
+		if (raw.byteLength % 4 !== 0) return null;
+		return new Float32Array(raw.slice(0));
+	}
+	if (ArrayBuffer.isView(raw)) {
+		const buffer = raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength);
+		if (buffer.byteLength % 4 !== 0) return null;
+		return new Float32Array(buffer);
+	}
+	return null;
+}
+
+/**
+ * Reconcile vec_embeddings with embeddings by deleting orphan vec rows
+ * and inserting rows missing from the vec index.
+ */
+export function resyncVectorIndex(
+	accessor: DbAccessor,
+	cfg: PipelineV2Config,
+	ctx: RepairContext,
+	limiter: RateLimiter,
+): RepairResult {
+	const action = "resyncVectorIndex";
+	const gate = checkRepairGate(cfg, ctx, limiter, action, cfg.repair.reembedCooldownMs, cfg.repair.reembedHourlyBudget);
+
+	if (!gate.allowed) {
+		return {
+			action,
+			success: false,
+			affected: 0,
+			message: gate.reason ?? "denied by policy gate",
+		};
+	}
+
+	const stats: VecResyncStats = accessor.withWriteTx((db): VecResyncStats => {
+		try {
+			db.prepare("SELECT 1 FROM vec_embeddings LIMIT 1").get();
+		} catch {
+			return {
+				vecAvailable: false,
+				inserted: 0,
+				deleted: 0,
+				skipped: 0,
+			};
+		}
+
+		const orphanRows = db
+			.prepare(
+				`SELECT v.id
+				 FROM vec_embeddings v
+				 LEFT JOIN embeddings e ON e.id = v.id
+				 WHERE e.id IS NULL`,
+			)
+			.all() as Array<{ id: string }>;
+
+		let deleted = 0;
+		if (orphanRows.length > 0) {
+			const remove = db.prepare("DELETE FROM vec_embeddings WHERE id = ?");
+			for (const row of orphanRows) {
+				const result = remove.run(row.id);
+				if (countChanges(result) > 0) deleted++;
+			}
+		}
+
+		const missingRows = db
+			.prepare(
+				`SELECT e.id, e.vector
+				 FROM embeddings e
+				 LEFT JOIN vec_embeddings v ON v.id = e.id
+				 WHERE v.id IS NULL`,
+			)
+			.all() as Array<{ id: string; vector: unknown }>;
+
+		let inserted = 0;
+		let skipped = 0;
+		const insert = db.prepare("INSERT OR REPLACE INTO vec_embeddings (id, embedding) VALUES (?, ?)");
+
+		for (const row of missingRows) {
+			const vector = blobToFloat32Vector(row.vector);
+			if (!vector) {
+				skipped++;
+				continue;
+			}
+			const result = insert.run(row.id, vector);
+			if (countChanges(result) > 0) inserted++;
+		}
+
+		const affected = inserted + deleted;
+		const msg =
+			skipped > 0
+				? `resynced vec index (+${inserted}/-${deleted}, skipped ${skipped} malformed vector(s))`
+				: `resynced vec index (+${inserted}/-${deleted})`;
+		writeRepairAudit(db, action, ctx, affected, msg);
+
+		return {
+			vecAvailable: true,
+			inserted,
+			deleted,
+			skipped,
+		};
+	});
+
+	if (!stats.vecAvailable) {
+		return {
+			action,
+			success: false,
+			affected: 0,
+			message: "vec_embeddings table not found; restart daemon to initialize vector index",
+		};
+	}
+
+	limiter.record(action);
+	const affected = stats.inserted + stats.deleted;
+	const message =
+		stats.skipped > 0
+			? `resynced vec index (+${stats.inserted}/-${stats.deleted}, skipped ${stats.skipped} malformed vector(s))`
+			: `resynced vec index (+${stats.inserted}/-${stats.deleted})`;
+
+	logger.info("pipeline", "repair: resynced vec index", {
+		affected,
+		inserted: stats.inserted,
+		deleted: stats.deleted,
+		skipped: stats.skipped,
+		actor: ctx.actor,
+		reason: ctx.reason,
+	});
+
+	return {
+		action,
+		success: true,
+		affected,
+		message,
 	};
 }
 
@@ -778,9 +842,7 @@ export function getDedupStats(accessor: DbAccessor): DedupStats {
 			)
 			.get() as { clusters: number; excess_total: number } | undefined;
 
-		const totalRow = db
-			.prepare("SELECT COUNT(*) AS n FROM memories WHERE is_deleted = 0")
-			.get() as { n: number };
+		const totalRow = db.prepare("SELECT COUNT(*) AS n FROM memories WHERE is_deleted = 0").get() as { n: number };
 
 		return {
 			exactClusters: row?.clusters ?? 0,
@@ -824,8 +886,18 @@ function scoreDedupCandidate(c: DedupCandidate): number {
 }
 
 function mergeTags(existing: string | null, incoming: string | null): string | null {
-	const a = existing ? existing.split(",").map((t) => t.trim()).filter(Boolean) : [];
-	const b = incoming ? incoming.split(",").map((t) => t.trim()).filter(Boolean) : [];
+	const a = existing
+		? existing
+				.split(",")
+				.map((t) => t.trim())
+				.filter(Boolean)
+		: [];
+	const b = incoming
+		? incoming
+				.split(",")
+				.map((t) => t.trim())
+				.filter(Boolean)
+		: [];
 	const merged = [...new Set([...a, ...b])];
 	return merged.length > 0 ? merged.join(",") : null;
 }
@@ -844,7 +916,7 @@ function processCluster(
 
 	// Score and pick keeper
 	let bestIdx = 0;
-	let bestScore = -Infinity;
+	let bestScore = Number.NEGATIVE_INFINITY;
 	for (let i = 0; i < candidates.length; i++) {
 		const score = scoreDedupCandidate(candidates[i]);
 		if (score > bestScore) {
@@ -864,8 +936,7 @@ function processCluster(
 	}
 
 	if (mergedTags !== keeper.tags) {
-		db.prepare("UPDATE memories SET tags = ?, updated_at = ? WHERE id = ?")
-			.run(mergedTags, now, keeper.id);
+		db.prepare("UPDATE memories SET tags = ?, updated_at = ? WHERE id = ?").run(mergedTags, now, keeper.id);
 	}
 
 	// Audit keeper
@@ -887,9 +958,11 @@ function processCluster(
 
 	// Soft-delete losers
 	for (const loser of losers) {
-		db.prepare(
-			"UPDATE memories SET is_deleted = 1, deleted_at = ?, updated_at = ? WHERE id = ?",
-		).run(now, now, loser.id);
+		db.prepare("UPDATE memories SET is_deleted = 1, deleted_at = ?, updated_at = ? WHERE id = ?").run(
+			now,
+			now,
+			loser.id,
+		);
 
 		insertHistoryEvent(db, {
 			memoryId: loser.id,
@@ -921,14 +994,7 @@ export async function deduplicateMemories(
 	},
 ): Promise<DedupResult> {
 	const action = "deduplicateMemories";
-	const gate = checkRepairGate(
-		cfg,
-		ctx,
-		limiter,
-		action,
-		cfg.repair.dedupCooldownMs,
-		cfg.repair.dedupHourlyBudget,
-	);
+	const gate = checkRepairGate(cfg, ctx, limiter, action, cfg.repair.dedupCooldownMs, cfg.repair.dedupHourlyBudget);
 
 	if (!gate.allowed) {
 		return {
@@ -941,8 +1007,7 @@ export async function deduplicateMemories(
 	}
 
 	const batchSize = options?.batchSize ?? cfg.repair.dedupBatchSize;
-	const semanticThreshold =
-		options?.semanticThreshold ?? cfg.repair.dedupSemanticThreshold;
+	const semanticThreshold = options?.semanticThreshold ?? cfg.repair.dedupSemanticThreshold;
 	const dryRun = options?.dryRun ?? false;
 	const semanticEnabled = options?.semanticEnabled ?? false;
 
@@ -966,11 +1031,7 @@ export async function deduplicateMemories(
 		const totalExcess = hashClusters.reduce((sum, c) => sum + c.cnt - 1, 0);
 		let semanticClusterCount = 0;
 		if (semanticEnabled) {
-			const semanticClusters = await findSemanticDuplicates(
-				accessor,
-				semanticThreshold,
-				batchSize,
-			);
+			const semanticClusters = await findSemanticDuplicates(accessor, semanticThreshold, batchSize);
 			semanticClusterCount = semanticClusters.length;
 		}
 		limiter.record(action);
@@ -1016,11 +1077,7 @@ export async function deduplicateMemories(
 
 	// Phase 2: Semantic clusters (only if exact phase didn't fill batch)
 	if (semanticEnabled && totalClusters < batchSize) {
-		const semanticClusters = await findSemanticDuplicates(
-			accessor,
-			semanticThreshold,
-			batchSize - totalClusters,
-		);
+		const semanticClusters = await findSemanticDuplicates(accessor, semanticThreshold, batchSize - totalClusters);
 
 		for (const cluster of semanticClusters) {
 			const removed = accessor.withWriteTx((db) => {
@@ -1102,9 +1159,9 @@ async function findSemanticDuplicates(
 
 		const neighbors = accessor.withReadDb((db) => {
 			// Get the vector for this candidate's embedding
-			const vecRow = db
-				.prepare("SELECT embedding FROM vec_embeddings WHERE id = ?")
-				.get(candidate.embedding_id) as { embedding: ArrayBuffer } | undefined;
+			const vecRow = db.prepare("SELECT embedding FROM vec_embeddings WHERE id = ?").get(candidate.embedding_id) as
+				| { embedding: ArrayBuffer }
+				| undefined;
 
 			if (!vecRow) return [];
 


### PR DESCRIPTION
## Summary
- fix the embeddings health panel repair actions so they actually execute backend repairs instead of failing silently
- add a new daemon repair action and endpoint (`POST /api/repair/resync-vec`) to resync `vec_embeddings` with `embeddings` by backfilling missing rows and removing orphans
- improve dashboard repair UX by surfacing success/failure feedback and wiring the `vec-table-sync` check to the new resync endpoint

## Validation
- `bun test packages/daemon/src/repair-actions.test.ts`
- `bun run build` (in `packages/daemon`)
- `bun run check` (in `packages/cli/dashboard`)
- `bun run build` (in `packages/cli/dashboard`)
