### PR TITLE
fix(daemon): ignore SQLite journal files in file watcher

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/adapters/openclaw": {
       "name": "@signetai/signet-memory-openclaw",
-      "version": "0.29.0",
+      "version": "0.31.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.47",
       },
@@ -22,7 +22,7 @@
     },
     "packages/cli": {
       "name": "@signet/cli",
-      "version": "0.29.0",
+      "version": "0.31.0",
       "bin": "./dist/cli.js",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
@@ -44,7 +44,7 @@
     },
     "packages/connector-base": {
       "name": "@signet/connector-base",
-      "version": "0.29.0",
+      "version": "0.31.0",
       "dependencies": {
         "@signet/core": "workspace:*",
       },
@@ -58,7 +58,7 @@
     },
     "packages/connector-claude-code": {
       "name": "@signet/connector-claude-code",
-      "version": "0.29.0",
+      "version": "0.31.0",
       "dependencies": {
         "@signet/connector-base": "workspace:*",
         "@signet/core": "workspace:*",
@@ -70,7 +70,7 @@
     },
     "packages/connector-openclaw": {
       "name": "@signet/connector-openclaw",
-      "version": "0.29.0",
+      "version": "0.31.0",
       "dependencies": {
         "@signet/connector-base": "workspace:*",
       },
@@ -81,7 +81,7 @@
     },
     "packages/connector-opencode": {
       "name": "@signet/connector-opencode",
-      "version": "0.29.0",
+      "version": "0.31.0",
       "dependencies": {
         "@signet/connector-base": "workspace:*",
         "@signet/core": "workspace:*",
@@ -93,7 +93,7 @@
     },
     "packages/core": {
       "name": "@signet/core",
-      "version": "0.29.0",
+      "version": "0.31.0",
       "dependencies": {
         "sqlite-vec": "^0.1.7-alpha.2",
         "yaml": "^2.6.0",
@@ -113,7 +113,7 @@
     },
     "packages/daemon": {
       "name": "@signet/daemon",
-      "version": "0.29.0",
+      "version": "0.31.0",
       "bin": {
         "signet-daemon": "./dist/daemon.js",
         "signet-mcp": "./dist/mcp-stdio.js",
@@ -136,7 +136,7 @@
     },
     "packages/extension": {
       "name": "@signet/extension",
-      "version": "0.29.0",
+      "version": "0.31.0",
       "devDependencies": {
         "@types/chrome": "^0.0.287",
         "typescript": "^5.7.0",
@@ -144,14 +144,14 @@
     },
     "packages/opencode-plugin": {
       "name": "@signet/opencode-plugin",
-      "version": "0.29.0",
+      "version": "0.31.0",
       "peerDependencies": {
         "@opencode-ai/plugin": ">=0.1.0",
       },
     },
     "packages/sdk": {
       "name": "@signet/sdk",
-      "version": "0.29.0",
+      "version": "0.31.0",
       "devDependencies": {
         "@types/react": "^19.0.0",
         "react": "^19.0.0",
@@ -167,7 +167,7 @@
     },
     "packages/signetai": {
       "name": "signetai",
-      "version": "0.29.0",
+      "version": "0.31.0",
       "bin": {
         "signet": "bin/signet.js",
         "signet-mcp": "dist/mcp-stdio.js",
@@ -194,7 +194,7 @@
     },
     "packages/tray": {
       "name": "@signet/tray",
-      "version": "0.29.0",
+      "version": "0.31.0",
       "dependencies": {
         "@signet/sdk": "workspace:*",
         "@tauri-apps/api": "^2.5.0",

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6420,6 +6420,7 @@ function startFileWatcher() {
 		{
 			persistent: true,
 			ignoreInitial: true,
+			ignored: [/\.db-wal$/, /\.db-shm$/, /\.db-journal$/],
 		},
 	);
 


### PR DESCRIPTION
## Summary

- The chokidar file watcher was monitoring the entire `~/.agents/memory/` directory without an `ignored` option, causing it to fire on every SQLite WAL/SHM change (~every 2 seconds)
- This triggered `scheduleAutoCommit` constantly, producing thousands of noise commits containing only `memories.db-wal` changes
- Added `ignored` regex patterns for `.db-wal`, `.db-shm`, and `.db-journal` files to the chokidar config

## Test plan

- [x] Rebuild daemon and restart
- [x] Verified no new WAL-only commits after 15+ seconds (previously every ~5s)
- [x] Confirmed `git status` in `~/.agents/` stays clean
- [ ] CI passes