### PR TITLE
fix: dashboard config persistence, version display, auto-update, and docs

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -16,13 +16,13 @@ Installation
 ---
 
 ```bash
-# Via npm/npx
-npx signet setup
+# bun (recommended)
+bun add -g signetai
 
-# Via bun
-bunx signet setup
+# npm
+npm install -g signetai
 
-# Via installer script
+# or installer script
 curl -sL https://signetai.sh/install | bash
 ```
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -25,13 +25,13 @@ Install
 ---
 
 ```bash
-# Via npm/npx
-npx signet setup
+# bun (recommended)
+bun add -g signetai
 
-# Via bun
-bunx signet setup
+# npm
+npm install -g signetai
 
-# Via one-line installer
+# or one-line installer
 curl -sL https://signetai.sh/install | bash
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -207,15 +207,14 @@ Install
 ---
 
 ```bash
-# one-line installer
-curl -sL https://signetai.sh/install | bash
+# bun (recommended)
+bun add -g signetai
 
-# or global install
+# npm
 npm install -g signetai
-# bun add -g signetai
 
-# or run without installing
-npx signetai setup
+# or one-line installer
+curl -sL https://signetai.sh/install | bash
 ```
 
 Setup

--- a/docs/TRAY.md
+++ b/docs/TRAY.md
@@ -74,7 +74,7 @@ A `DaemonManager` platform trait abstracts start/stop/is_running.
 
 Start order: check for `~/.config/systemd/user/signet.service` — if
 present, use `systemctl --user start signet`. Otherwise: locate bun
-binary → locate `signet-daemon` → fall back to `bunx signetai daemon start`.
+binary → locate `signet-daemon` → fall back to the globally installed `signet daemon start`.
 
 Stop: send SIGTERM, poll at 100ms intervals up to 3 seconds, then clean
 up the PID file.

--- a/packages/cli/dashboard/src/lib/components/app-sidebar.svelte
+++ b/packages/cli/dashboard/src/lib/components/app-sidebar.svelte
@@ -187,13 +187,20 @@ const navItems: { id: TabId; label: string; icon: typeof FileText }[] = [
 				<Sidebar.MenuItem>
 					<span
 						class="px-2 py-1 text-[10px] tracking-[0.06em]
-							text-[var(--sig-text-muted)]
 							font-[family-name:var(--font-mono)]
 							overflow-hidden whitespace-nowrap
 							transition-opacity duration-200 ease-out
-							group-data-[collapsible=icon]:opacity-0"
+							group-data-[collapsible=icon]:opacity-0
+							{daemonStatus.update?.pendingRestart
+								? 'text-[var(--sig-warning)]'
+								: 'text-[var(--sig-text-muted)]'}"
 					>
-						v{daemonStatus.version}
+						{#if daemonStatus.update?.pendingRestart}
+							v{daemonStatus.version} → v{daemonStatus.update.pendingRestart}
+							<span class="block text-[9px] opacity-70">restart needed</span>
+						{:else}
+							v{daemonStatus.version}
+						{/if}
 					</span>
 				</Sidebar.MenuItem>
 			{/if}

--- a/packages/cli/dashboard/src/lib/components/tabs/ConfigTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/ConfigTab.svelte
@@ -36,6 +36,7 @@
 	};
 
 	let editorContent = $state("");
+	let prevSelectedFile = $state("");
 	let saving = $state(false);
 	let lastSavedAt = $state<string | null>(null);
 	let saveFeedback = $state("");
@@ -73,9 +74,12 @@
 		}
 	});
 
-	// Load content when file changes
+	// Load content only when switching to a different file
 	$effect(() => {
-		editorContent = activeFile?.content ?? "";
+		if (selectedFile !== prevSelectedFile) {
+			prevSelectedFile = selectedFile;
+			editorContent = activeFile?.content ?? "";
+		}
 	});
 
 	// Track dirty state globally

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -7174,7 +7174,35 @@ async function main() {
 
 	// Start git sync timer (if enabled and has token)
 	startGitSyncTimer();
-	initUpdateSystem(CURRENT_VERSION, AGENTS_DIR);
+	initUpdateSystem(CURRENT_VERSION, AGENTS_DIR, () => {
+		// Self-restart: spawn a replacement daemon process before exiting.
+		// This mirrors the spawn pattern used by `signet daemon start` in the CLI.
+		const daemonScript = process.argv[1] ?? "";
+		if (!daemonScript) {
+			logger.warn("daemon", "Cannot self-restart: process.argv[1] is empty, falling back to clean exit");
+			setTimeout(() => { process.exit(0); }, 500);
+			return;
+		}
+
+		logger.info("daemon", "Spawning replacement daemon process", {
+			execPath: process.execPath,
+			script: daemonScript,
+		});
+
+		const replacement = spawn(process.execPath, [daemonScript], {
+			detached: true,
+			stdio: "ignore",
+			env: {
+				...process.env,
+				SIGNET_PORT: String(PORT),
+				SIGNET_PATH: AGENTS_DIR,
+			},
+		});
+		replacement.unref();
+
+		logger.info("daemon", "Replacement daemon spawned, exiting current process");
+		setTimeout(() => { process.exit(0); }, 500);
+	});
 	initFeatureFlags(AGENTS_DIR);
 	startUpdateTimer();
 

--- a/packages/daemon/src/logger.ts
+++ b/packages/daemon/src/logger.ts
@@ -33,7 +33,8 @@ export type LogCategory =
 	| "embedding-tracker" // Incremental embedding refresh tracker
 	| "summary-worker" // Session summary worker
 	| "session-memories" // Session memory tracking
-	| "system"; // System events
+	| "system" // System events
+	| "update"; // Auto-update cycle
 
 export interface LogEntry {
 	timestamp: string;

--- a/packages/daemon/src/update-system.ts
+++ b/packages/daemon/src/update-system.ts
@@ -99,6 +99,7 @@ let updateConfig: UpdateConfig = {
 	checkInterval: DEFAULT_UPDATE_INTERVAL_SECONDS,
 	channel: "latest" as const,
 };
+let restartCallback: (() => void) | null = null;
 
 // ---------------------------------------------------------------------------
 // Init / accessors
@@ -107,10 +108,12 @@ let updateConfig: UpdateConfig = {
 export function initUpdateSystem(
 	version: string,
 	dir: string,
+	onRestartNeeded?: () => void,
 ): void {
 	currentVersion = version;
 	agentsDir = dir;
 	updateConfig = loadUpdateConfig();
+	restartCallback = onRestartNeeded ?? null;
 	initialized = true;
 }
 
@@ -180,7 +183,10 @@ export function getUpdateSummary(): string | null {
 	if (pendingRestartVersion) {
 		return (
 			`Signet v${pendingRestartVersion} is installed but needs ` +
-			"a daemon restart. Run `signet daemon restart`."
+			"a daemon restart. Run:\n" +
+			"  signet daemon restart\n" +
+			"  signet sync\n\n" +
+			"These are the ONLY supported post-update commands."
 		);
 	}
 
@@ -197,19 +203,43 @@ export function getUpdateSummary(): string | null {
 		const notes = lastUpdateCheck.releaseNotes
 			? `\n\nWhat's new:\n${lastUpdateCheck.releaseNotes}`
 			: "";
+
 		if (updateConfig.autoInstall) {
+			const autoInfo = lastAutoUpdateAt
+				? ` Last auto-update: ${lastAutoUpdateAt.toISOString()}.`
+				: "";
 			return (
 				`Signet v${latest} is available (current: v${currentVersion}). ` +
 				"Auto-update will install it on the next check cycle." +
+				autoInfo +
 				notes
 			);
 		}
+
+		const packageManager = resolvePrimaryPackageManager({
+			agentsDir,
+			env: process.env,
+		});
+		const installCmd = getGlobalInstallCommand(
+			packageManager.family,
+			NPM_PACKAGE,
+		);
+		const fullInstallCmd = `${installCmd.command} ${installCmd.args.join(" ")}`;
+
 		return (
-			`Signet v${latest} is available (current: v${currentVersion}). ` +
-			"Run `signet update install` to update, or " +
-			"`signet update enable` for automatic updates." +
+			`Signet v${latest} is available (current: v${currentVersion}).\n\n` +
+			"To update Signet:\n" +
+			`  ${fullInstallCmd}\n` +
+			"  signet daemon restart\n" +
+			"  signet sync\n\n" +
+			"These are the ONLY supported update commands. " +
+			"Do not use npx, bunx, or signet update install." +
 			notes
 		);
+	}
+
+	if (lastAutoUpdateAt && updateConfig.autoInstall) {
+		return `Signet is up to date (v${currentVersion}). Last auto-update: ${lastAutoUpdateAt.toISOString()}.`;
 	}
 
 	return null;
@@ -513,6 +543,10 @@ export async function runUpdate(
 			});
 
 			proc.on("close", (code) => {
+				logger.info("update", "Update command exited", {
+					exitCode: code ?? -1,
+					command: `${installCommand.command} ${installCommand.args.join(" ")}`,
+				});
 				if (code === 0) {
 					pendingRestartVersion = targetVersion ?? "unknown";
 					lastUpdateCheck = null;
@@ -558,30 +592,46 @@ async function runAutoUpdateCycle(): Promise<void> {
 	}
 
 	if (updateCheckInProgress || updateInstallInProgress) {
+		logger.info("update", "Auto-update cycle skipped — check or install already in progress");
 		return;
 	}
 
 	updateCheckInProgress = true;
+	logger.info("update", "Auto-update cycle started");
 
 	try {
 		const checkResult = await checkForUpdates();
+
 		if (checkResult.checkError) {
 			lastAutoUpdateError = categorizeUpdateError(checkResult.checkError);
+			logger.warn("update", "Auto-update check returned error", {
+				error: checkResult.checkError,
+			});
 			return;
 		}
 
+		logger.info("update", "Update check complete", {
+			current: currentVersion,
+			latest: checkResult.latestVersion ?? "unknown",
+			updateAvailable: checkResult.updateAvailable,
+		});
+
 		if (!checkResult.updateAvailable || !checkResult.latestVersion) {
+			logger.info("update", "No update available — skipping install");
 			return;
 		}
 
 		if (isMajorUpgrade(currentVersion, checkResult.latestVersion)) {
-			logger.warn("system", "Major upgrade available — manual install required");
+			logger.warn("update", "Major upgrade available — skipping auto-install (manual install required)", {
+				current: currentVersion,
+				latest: checkResult.latestVersion,
+			});
 			lastAutoUpdateError = "Major version upgrade requires manual install";
 			return;
 		}
 
 		logger.info(
-			"system",
+			"update",
 			`Auto-installing update v${checkResult.latestVersion}`,
 		);
 		const installResult = await runUpdate(checkResult.latestVersion);
@@ -590,27 +640,33 @@ async function runAutoUpdateCycle(): Promise<void> {
 			lastAutoUpdateAt = new Date();
 			lastAutoUpdateError = null;
 			logger.info(
-				"system",
-				`Auto-update installed v${checkResult.latestVersion}. Restarting daemon.`,
+				"update",
+				`Auto-update installed v${checkResult.latestVersion}. Triggering daemon restart.`,
 			);
 
-			// Clean exit — systemd/launchd Restart=always will respawn us.
-			// For non-service runs, the CLI's `signet daemon start` can
-			// detect the clean exit and re-launch if desired.
 			stopUpdateTimer();
-			setTimeout(() => {
-				process.exit(0);
-			}, 500);
+
+			if (restartCallback) {
+				logger.info("update", "Invoking restart callback to spawn replacement daemon");
+				restartCallback();
+			} else {
+				// Fallback: clean exit — systemd/launchd Restart=always will respawn.
+				// Without a restart callback, the daemon simply exits.
+				logger.warn("update", "No restart callback registered — exiting and relying on service manager to restart");
+				setTimeout(() => {
+					process.exit(0);
+				}, 500);
+			}
 			return;
 		}
 
 		lastAutoUpdateError = categorizeUpdateError(installResult.message);
-		logger.warn("system", "Auto-update failed", {
+		logger.warn("update", "Auto-update install failed", {
 			error: installResult.message,
 		});
 	} catch (e) {
 		lastAutoUpdateError = categorizeUpdateError((e as Error).message);
-		logger.warn("system", "Auto-update cycle failed", {
+		logger.warn("update", "Auto-update cycle failed", {
 			error: lastAutoUpdateError,
 		});
 	} finally {
@@ -638,8 +694,8 @@ export function startUpdateTimer(): void {
 	}
 
 	logger.info(
-		"system",
-		`Auto-update enabled: every ${updateConfig.checkInterval}s`,
+		"update",
+		`Update timer started: checking every ${updateConfig.checkInterval}s, autoInstall=${updateConfig.autoInstall}, channel=${updateConfig.channel}`,
 	);
 
 	void runAutoUpdateCycle();

--- a/packages/signetai/README.md
+++ b/packages/signetai/README.md
@@ -7,14 +7,11 @@ Signet gives your AI agents persistent memory and identity that follows them acr
 ## Install
 
 ```bash
-# npm
-npm install -g signetai
-
 # bun (recommended)
 bun add -g signetai
 
-# or run directly
-npx signetai
+# npm
+npm install -g signetai
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary

- **Config editor persistence**: Fixed unguarded Svelte 5 `$effect` in ConfigTab that reset editor content on every reactive tick, silently discarding user edits after save
- **Version display**: Sidebar footer now shows pending restart version (`v0.31.0 → v0.32.0 restart needed`) when an update is installed but daemon hasn't restarted
- **Auto-update self-restart**: Daemon now spawns a replacement process before exiting after auto-install, instead of relying on systemd/launchd `Restart=always` (which doesn't work for detached bun processes)
- **Update logging**: Added comprehensive `"update"` log category covering every branch of the auto-update cycle
- **Agent update instructions**: `getUpdateSummary()` now detects the user's package manager and tells agents the exact global install command, explicitly warning against `npx`/`bunx`/`signet update install`
- **Docs cleanup**: Removed all incorrect `npx signet`/`bunx signet` install commands from QUICKSTART.md, CLI.md, README.md, signetai README, and TRAY.md

## Test plan

- [ ] `bun run build` passes (verified locally)
- [ ] `bun run typecheck` passes for all packages except pre-existing extension chrome types issue
- [ ] Dashboard: edit a config file, save, switch files, switch back — edits persist
- [ ] Dashboard: sidebar shows pending version after `POST /api/update/run`
- [ ] `grep -r "npx signet" docs/ packages/signetai/` returns zero results
- [ ] Review `getUpdateSummary()` output for correct install command detection
- [ ] Review daemon restart callback spawns replacement process correctly