### PR TITLE
fix(dashboard): persist active tab in URL hash

### DIFF
--- a/packages/cli/dashboard/src/lib/components/command/GlobalCommandPalette.svelte
+++ b/packages/cli/dashboard/src/lib/components/command/GlobalCommandPalette.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { type TabId, nav } from "$lib/stores/navigation.svelte";
+import { type TabId, setTab } from "$lib/stores/navigation.svelte";
 import { ActionLabels } from "$lib/ui/action-labels";
 import Search from "@lucide/svelte/icons/search";
 import { Dialog as CommandPrimitive } from "bits-ui";
@@ -46,7 +46,7 @@ $effect(() => {
 });
 
 function setTabAndClose(tab: TabId) {
-	nav.activeTab = tab;
+	setTab(tab);
 	open = false;
 	query = "";
 	selectedIndex = 0;

--- a/packages/cli/dashboard/src/lib/stores/navigation.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/navigation.svelte.ts
@@ -1,5 +1,8 @@
 /**
  * Shared navigation state for the dashboard.
+ *
+ * Active tab is synced to location.hash for refresh persistence
+ * and browser back/forward support.
  */
 
 import { confirmDiscardChanges } from "$lib/stores/unsaved-changes.svelte";
@@ -16,6 +19,25 @@ export type TabId =
 	| "tasks"
 	| "connectors";
 
+const VALID_TABS: ReadonlySet<string> = new Set<TabId>([
+	"config",
+	"settings",
+	"memory",
+	"embeddings",
+	"pipeline",
+	"logs",
+	"secrets",
+	"skills",
+	"tasks",
+	"connectors",
+]);
+
+function readTabFromHash(): TabId | null {
+	if (typeof window === "undefined") return null;
+	const hash = window.location.hash.slice(1);
+	return VALID_TABS.has(hash) ? (hash as TabId) : null;
+}
+
 export const nav = $state({
 	activeTab: "config" as TabId,
 });
@@ -24,5 +46,30 @@ export function setTab(tab: TabId): boolean {
 	if (tab === nav.activeTab) return true;
 	if (!confirmDiscardChanges(`switch to ${tab}`)) return false;
 	nav.activeTab = tab;
+	if (typeof window !== "undefined") {
+		history.replaceState(null, "", `#${tab}`);
+	}
 	return true;
+}
+
+/**
+ * Read initial tab from URL hash and listen for hashchange events.
+ * Call from onMount in the root page component.
+ * Returns a cleanup function to remove the event listener.
+ */
+export function initNavFromHash(): () => void {
+	const initial = readTabFromHash();
+	if (initial) {
+		nav.activeTab = initial;
+	} else if (typeof window !== "undefined") {
+		// No hash present — set it to the default tab
+		history.replaceState(null, "", `#${nav.activeTab}`);
+	}
+
+	const onHashChange = () => {
+		const tab = readTabFromHash();
+		if (tab && tab !== nav.activeTab) nav.activeTab = tab;
+	};
+	window.addEventListener("hashchange", onHashChange);
+	return () => window.removeEventListener("hashchange", onHashChange);
 }

--- a/packages/cli/dashboard/src/routes/+page.svelte
+++ b/packages/cli/dashboard/src/routes/+page.svelte
@@ -17,7 +17,7 @@ import {
 	mem,
 	queueMemorySearch,
 } from "$lib/stores/memory.svelte";
-import { nav } from "$lib/stores/navigation.svelte";
+import { initNavFromHash, nav, setTab } from "$lib/stores/navigation.svelte";
 import { sk } from "$lib/stores/skills.svelte";
 import { openForm, ts } from "$lib/stores/tasks.svelte";
 import { hasUnsavedChanges } from "$lib/stores/unsaved-changes.svelte";
@@ -55,7 +55,7 @@ $effect(() => {
 
 function selectFile(name: string) {
 	selectedFile = name;
-	nav.activeTab = "config";
+	setTab("config");
 }
 
 // --- Memory display ---
@@ -81,7 +81,7 @@ $effect(() => {
 // --- Embeddings bridge ---
 function openGlobalSimilar(memory: Memory) {
 	mem.query = memory.content;
-	nav.activeTab = "memory";
+	setTab("memory");
 	queueMemorySearch();
 }
 
@@ -104,6 +104,8 @@ $effect(() => {
 
 // --- Init ---
 onMount(() => {
+	const cleanupNav = initNavFromHash();
+
 	getStatus().then((s) => {
 		daemonStatus = s;
 	});
@@ -118,6 +120,7 @@ onMount(() => {
 	window.addEventListener("beforeunload", handleBeforeUnload);
 
 	return () => {
+		cleanupNav();
 		window.removeEventListener("beforeunload", handleBeforeUnload);
 	};
 });


### PR DESCRIPTION
## Summary

- Syncs the dashboard's active tab to `location.hash` so refreshing the page remembers where you were
- Enables direct linking (e.g. `localhost:3850/#memory`) and browser back/forward for hash changes
- Routes all tab changes through `setTab()` for consistent hash sync (fixes direct `nav.activeTab` assignments in page component and command palette)

## Changes

- **`navigation.svelte.ts`** — `setTab()` pushes hash via `replaceState`; new `initNavFromHash()` reads hash on load + listens for `hashchange`
- **`+page.svelte`** — calls `initNavFromHash()` in `onMount`; direct assignments replaced with `setTab()`
- **`GlobalCommandPalette.svelte`** — uses `setTab()` instead of direct assignment

## Test plan

- [ ] Open dashboard, switch to Memory tab, refresh — should stay on Memory
- [ ] Navigate to `localhost:3850/#tasks` directly — should open Tasks tab
- [ ] Navigate to `localhost:3850/#garbage` — should fall back to config
- [ ] Unsaved changes warning still fires when switching tabs
- [ ] Command palette tab switching updates the hash