### PR TITLE
chore(specs): add spec dependency index and validation guard

### DIFF
--- a/docs/KNOWLEDGE-ARCHITECTURE.md
+++ b/docs/KNOWLEDGE-ARCHITECTURE.md
@@ -229,9 +229,10 @@ Small. Dense. Connected. Correct.
 
 ---
 
-*This document describes the architectural concepts. For the schema
-specification, see the planned migration spec. For the extraction pipeline
-implementation, see [Memory Pipeline](./PIPELINE.md).*
+*This document describes the architectural concepts. For the implementation
+contract, see [Knowledge Architecture Schema and Traversal Spec](./specs/planning/knowledge-architecture-schema.md).
+For predictive ranking integration, see [Signet Predictive Memory Scorer](./specs/planning/predictive-memory-scorer.md).
+For extraction pipeline behavior, see [Memory Pipeline](./PIPELINE.md).*
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -380,6 +380,7 @@ Documentation
 - [API Reference](./docs/API.md)
 - [Self-Hosting](./docs/SELF-HOSTING.md)
 - [Architecture](./docs/ARCHITECTURE.md)
+- [Specs Index](./docs/specs/INDEX.md)
 
 Development
 ===

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -86,7 +86,7 @@ Legend:
    locked before GA.
 
 Validation command:
-- `bun run spec:deps`
+- `bun scripts/spec-deps-check.ts`
 - Script: `scripts/spec-deps-check.ts`
 - Checks: unknown IDs, hard-dependency cycles, missing spec paths,
   and `INDEX.md` <-> `dependencies.yaml` drift (ID/status/path).
@@ -95,7 +95,7 @@ Validation command:
 
 ## Suggested Next Spec Ops
 
-1. Wire `bun run spec:deps` into CI as a required docs gate.
+1. Wire `bun scripts/spec-deps-check.ts` into CI as a required docs gate.
 2. Add per-spec `Spec Metadata` blocks (ID, status, depends_on) to make each
    spec self-describing.
 3. Add a dashboard/API view later, reading `dependencies.yaml`, so dependency

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -1,0 +1,102 @@
+---
+title: "Spec Index and Dependency Graph"
+---
+
+# Spec Index and Dependency Graph
+
+This is the planning control plane for specs. If we are deciding what ships
+next, this file is the first stop.
+
+Source of truth for dependency metadata:
+- `docs/specs/dependencies.yaml`
+
+---
+
+## Core Cognition Graph
+
+```mermaid
+flowchart TD
+  MP[Memory Pipeline v2]
+  SCP[Session Continuity Protocol]
+  PM[Procedural Memory Plan]
+  KA[Knowledge Architecture Schema]
+  PMS[Predictive Memory Scorer]
+
+  MP --> SCP
+  MP --> PM
+  MP --> KA
+  SCP --> KA
+  PM --> KA
+  KA --> PMS
+  SCP --> PMS
+  MP --> PMS
+```
+
+Interpretation:
+- `Memory Pipeline v2` is the substrate.
+- `Knowledge Architecture Schema` is the structural retrieval layer.
+- `Predictive Memory Scorer` ranks on top of that structure.
+
+---
+
+## Critical Path (Knowledge + Predictor)
+
+1. Memory Pipeline contracts and durability (`memory-pipeline-plan`)
+2. Structural schema + assignment + traversal (`knowledge-architecture-schema`)
+3. Continuity signal quality (`session-continuity-protocol`)
+4. Predictor ranking and comparison (`predictive-memory-scorer`)
+
+---
+
+## Spec Registry
+
+Legend:
+- `planning`: design in progress
+- `approved`: accepted design, pending or partial implementation
+- `complete`: delivered baseline or merged strategy
+- `reference`: directional or notebook artifact, not an implementation contract
+
+| ID | Status | Path | Hard Depends On | Blocks |
+|---|---|---|---|---|
+| `memory-pipeline-v2` | complete | `docs/specs/complete/memory-pipeline-plan.md` | - | `session-continuity-protocol`, `procedural-memory-plan`, `knowledge-architecture-schema`, `predictive-memory-scorer` |
+| `session-continuity-protocol` | approved | `docs/specs/approved/session-continuity-protocol.md` | `memory-pipeline-v2` | `knowledge-architecture-schema`, `predictive-memory-scorer` |
+| `procedural-memory-plan` | approved | `docs/specs/approved/procedural-memory-plan.md` | `memory-pipeline-v2` | `knowledge-architecture-schema` |
+| `knowledge-architecture-schema` | planning | `docs/specs/planning/knowledge-architecture-schema.md` | `memory-pipeline-v2`, `session-continuity-protocol`, `procedural-memory-plan` | `predictive-memory-scorer` |
+| `predictive-memory-scorer` | planning | `docs/specs/planning/predictive-memory-scorer.md` | `memory-pipeline-v2`, `knowledge-architecture-schema`, `session-continuity-protocol` | - |
+| `daemon-refactor` | approved | `docs/specs/approved/daemon-refactor.md` | - | `daemon-refactor-plan` |
+| `daemon-refactor-plan` | planning | `docs/specs/planning/daemon-refactor-plan.md` | `daemon-refactor` | - |
+| `daemon-rust-rewrite` | planning | `docs/specs/planning/daemon-rust-rewrite.md` | `memory-pipeline-v2` | - |
+| `multi-agent-support` | approved | `docs/specs/approved/multi-agent-support.md` | `memory-pipeline-v2` | - |
+| `signet-roadmap-spec` | planning | `docs/specs/planning/signet-roadmap-spec.md` | - | - |
+| `openclaw-integration-strategy` | complete | `docs/specs/complete/openclaw-integration-strategy.md` | - | `openclaw-importance-scoring-pr` |
+| `openclaw-importance-scoring-pr` | complete | `docs/specs/complete/openclaw-importance-scoring-pr.md` | `openclaw-integration-strategy` | - |
+| `notebook-dump-2026-02-25` | reference | `docs/specs/planning/notebook-dump-2026-02-25.md` | - | - |
+
+---
+
+## Dependency Tracking Rules
+
+1. Every new spec gets a stable ID and entry in `dependencies.yaml`.
+2. If a spec introduces a new hard dependency, update both:
+   - `docs/specs/dependencies.yaml`
+   - this file's registry and graph if the dependency is on the critical path.
+3. Hard dependency means: implementation work should not merge ahead of the
+   dependency unless explicitly marked partial/spike.
+4. Soft dependency means: work can run in parallel, but interfaces must be
+   locked before GA.
+
+Validation command:
+- `bun run spec:deps`
+- Script: `scripts/spec-deps-check.ts`
+- Checks: unknown IDs, hard-dependency cycles, missing spec paths,
+  and `INDEX.md` <-> `dependencies.yaml` drift (ID/status/path).
+
+---
+
+## Suggested Next Spec Ops
+
+1. Wire `bun run spec:deps` into CI as a required docs gate.
+2. Add per-spec `Spec Metadata` blocks (ID, status, depends_on) to make each
+   spec self-describing.
+3. Add a dashboard/API view later, reading `dependencies.yaml`, so dependency
+   drift is visible without opening docs.

--- a/docs/specs/dependencies.yaml
+++ b/docs/specs/dependencies.yaml
@@ -1,0 +1,116 @@
+version: 1
+updated_at: "2026-03-03"
+
+specs:
+  - id: memory-pipeline-v2
+    status: complete
+    path: docs/specs/complete/memory-pipeline-plan.md
+    hard_depends_on: []
+    soft_depends_on: []
+    blocks:
+      - session-continuity-protocol
+      - procedural-memory-plan
+      - knowledge-architecture-schema
+      - predictive-memory-scorer
+
+  - id: session-continuity-protocol
+    status: approved
+    path: docs/specs/approved/session-continuity-protocol.md
+    hard_depends_on:
+      - memory-pipeline-v2
+    soft_depends_on: []
+    blocks:
+      - knowledge-architecture-schema
+      - predictive-memory-scorer
+
+  - id: procedural-memory-plan
+    status: approved
+    path: docs/specs/approved/procedural-memory-plan.md
+    hard_depends_on:
+      - memory-pipeline-v2
+    soft_depends_on: []
+    blocks:
+      - knowledge-architecture-schema
+
+  - id: knowledge-architecture-schema
+    status: planning
+    path: docs/specs/planning/knowledge-architecture-schema.md
+    hard_depends_on:
+      - memory-pipeline-v2
+      - session-continuity-protocol
+      - procedural-memory-plan
+    soft_depends_on: []
+    blocks:
+      - predictive-memory-scorer
+
+  - id: predictive-memory-scorer
+    status: planning
+    path: docs/specs/planning/predictive-memory-scorer.md
+    hard_depends_on:
+      - memory-pipeline-v2
+      - knowledge-architecture-schema
+      - session-continuity-protocol
+    soft_depends_on: []
+    blocks: []
+
+  - id: daemon-refactor
+    status: approved
+    path: docs/specs/approved/daemon-refactor.md
+    hard_depends_on: []
+    soft_depends_on: []
+    blocks:
+      - daemon-refactor-plan
+
+  - id: daemon-refactor-plan
+    status: planning
+    path: docs/specs/planning/daemon-refactor-plan.md
+    hard_depends_on:
+      - daemon-refactor
+    soft_depends_on: []
+    blocks: []
+
+  - id: daemon-rust-rewrite
+    status: planning
+    path: docs/specs/planning/daemon-rust-rewrite.md
+    hard_depends_on:
+      - memory-pipeline-v2
+    soft_depends_on: []
+    blocks: []
+
+  - id: multi-agent-support
+    status: approved
+    path: docs/specs/approved/multi-agent-support.md
+    hard_depends_on:
+      - memory-pipeline-v2
+    soft_depends_on: []
+    blocks: []
+
+  - id: signet-roadmap-spec
+    status: planning
+    path: docs/specs/planning/signet-roadmap-spec.md
+    hard_depends_on: []
+    soft_depends_on: []
+    blocks: []
+
+  - id: openclaw-integration-strategy
+    status: complete
+    path: docs/specs/complete/openclaw-integration-strategy.md
+    hard_depends_on: []
+    soft_depends_on: []
+    blocks:
+      - openclaw-importance-scoring-pr
+
+  - id: openclaw-importance-scoring-pr
+    status: complete
+    path: docs/specs/complete/openclaw-importance-scoring-pr.md
+    hard_depends_on:
+      - openclaw-integration-strategy
+    soft_depends_on: []
+    blocks: []
+
+  - id: notebook-dump-2026-02-25
+    status: reference
+    path: docs/specs/planning/notebook-dump-2026-02-25.md
+    hard_depends_on: []
+    soft_depends_on: []
+    blocks: []

--- a/docs/specs/planning/knowledge-architecture-schema.md
+++ b/docs/specs/planning/knowledge-architecture-schema.md
@@ -1,0 +1,378 @@
+---
+title: "Knowledge Architecture Schema and Traversal Spec"
+---
+
+# Knowledge Architecture Schema and Traversal Spec
+
+Status: Planning (v0)
+
+Audience: Core + Daemon maintainers
+
+Spec metadata:
+- ID: `knowledge-architecture-schema`
+- Status: `planning`
+- Hard depends on: `memory-pipeline-v2`, `session-continuity-protocol`,
+  `procedural-memory-plan`
+- Blocks: `predictive-memory-scorer`
+- Registry: `docs/specs/INDEX.md`
+
+Related docs:
+- `docs/KNOWLEDGE-ARCHITECTURE.md` (conceptual model)
+- `docs/specs/planning/predictive-memory-scorer.md` (learned ranking)
+- `docs/specs/complete/memory-pipeline-plan.md` (pipeline contracts)
+- `docs/specs/approved/procedural-memory-plan.md` (skills as procedural memory)
+- `docs/specs/approved/session-continuity-protocol.md` (checkpoint and recovery)
+
+---
+
+## 1) Purpose
+
+`KNOWLEDGE-ARCHITECTURE.md` defines the conceptual model (entity -> aspect
+-> attribute/constraint, plus dependency traversal). This spec turns that
+model into an implementation contract with:
+
+1. additive schema changes
+2. extraction and backfill contracts
+3. traversal-first retrieval contracts
+4. integration points with predictive scoring and continuity checkpoints
+
+This is the structural floor that predictive ranking should run on.
+
+Local dependency graph:
+
+```mermaid
+flowchart LR
+  MP[memory-pipeline-v2] --> KA[knowledge-architecture-schema]
+  SCP[session-continuity-protocol] --> KA
+  PM[procedural-memory-plan] --> KA
+  KA --> PMS[predictive-memory-scorer]
+```
+
+---
+
+## 2) Scope and Non-Goals
+
+### In scope
+
+1. Entity/aspect/attribute/constraint/task representation in SQLite
+2. Dependency edges as explicit graph structure
+3. Session-start traversal contracts for context injection
+4. Cross-spec contracts with scorer, procedural memory, and continuity
+
+### Out of scope (this revision)
+
+1. Multi-hop planning/reasoning beyond one-hop dependency traversal
+2. Automatic task execution
+3. Autonomous destructive mutations without existing policy gates
+
+---
+
+## 3) Baseline (Current State)
+
+Current graph-relevant state already in repo:
+
+1. `entities`, `relations`, and `memory_entity_mentions` exist
+2. `session_memories` exists and stores candidate/injection telemetry
+3. `session_checkpoints` exists and stores continuity digests
+4. Predictor crate and training pipeline exist through Phase 2
+
+Current gap:
+
+The system has entity mentions and relation edges, but no first-class
+representation for aspects, constraints, or task lifecycle. Retrieval is still
+primarily search/scoring-first, not traversal-first.
+
+---
+
+## 4) Cross-Spec Contract Map
+
+| Spec | Produces | Consumes from this spec |
+|---|---|---|
+| `memory-pipeline-plan.md` | extraction + mutation pipeline | structural assignment contract, schema ownership, backfill behavior |
+| `predictive-memory-scorer.md` | ranking model + training loop | traversal candidate pool, structural features (entity/aspect/constraint) |
+| `procedural-memory-plan.md` | skill nodes + procedural decay | shared entity/aspect model (`entity_type='skill'`) |
+| `session-continuity-protocol.md` | checkpoint + recovery | focal entity/aspect snapshot for recovery injection and training context |
+
+Normative rule: predictive ranking is an enhancer. Traversal-defined structure
+is the primary retrieval floor.
+
+---
+
+## 5) Data Model (Additive)
+
+### 5.1 Entity type taxonomy
+
+Extend `entities.entity_type` usage to the canonical set:
+
+- `person`
+- `project`
+- `system`
+- `tool`
+- `concept`
+- `skill`
+- `task`
+- `unknown` (fallback)
+
+### 5.2 New table: `entity_aspects`
+
+```sql
+CREATE TABLE entity_aspects (
+  id TEXT PRIMARY KEY,
+  entity_id TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  canonical_name TEXT NOT NULL,
+  weight REAL NOT NULL DEFAULT 0.5,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE(entity_id, canonical_name)
+);
+
+CREATE INDEX idx_entity_aspects_entity ON entity_aspects(entity_id);
+CREATE INDEX idx_entity_aspects_weight ON entity_aspects(weight DESC);
+```
+
+`weight` is structural centrality + learned utility. It is not pure frequency.
+
+### 5.3 New table: `entity_attributes`
+
+```sql
+CREATE TABLE entity_attributes (
+  id TEXT PRIMARY KEY,
+  aspect_id TEXT NOT NULL REFERENCES entity_aspects(id) ON DELETE CASCADE,
+  memory_id TEXT REFERENCES memories(id) ON DELETE SET NULL,
+  kind TEXT NOT NULL,                 -- 'attribute' | 'constraint'
+  content TEXT NOT NULL,
+  normalized_content TEXT NOT NULL,
+  confidence REAL NOT NULL DEFAULT 0.0,
+  importance REAL NOT NULL DEFAULT 0.5,
+  status TEXT NOT NULL DEFAULT 'active',  -- 'active' | 'superseded' | 'deleted'
+  superseded_by TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_entity_attributes_aspect ON entity_attributes(aspect_id);
+CREATE INDEX idx_entity_attributes_kind ON entity_attributes(kind);
+CREATE INDEX idx_entity_attributes_status ON entity_attributes(status);
+```
+
+Constraints are first-class rows (`kind='constraint'`), not inferred tags.
+
+### 5.4 New table: `entity_dependencies`
+
+```sql
+CREATE TABLE entity_dependencies (
+  id TEXT PRIMARY KEY,
+  source_entity_id TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+  target_entity_id TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+  aspect_id TEXT REFERENCES entity_aspects(id) ON DELETE SET NULL,
+  dependency_type TEXT NOT NULL,      -- 'uses' | 'requires' | 'owned_by' | 'blocks' | 'informs'
+  strength REAL NOT NULL DEFAULT 0.5,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_entity_dependencies_source ON entity_dependencies(source_entity_id);
+CREATE INDEX idx_entity_dependencies_target ON entity_dependencies(target_entity_id);
+```
+
+These are explicit traversal edges. They are not similarity artifacts.
+
+### 5.5 New table: `task_meta`
+
+```sql
+CREATE TABLE task_meta (
+  entity_id TEXT PRIMARY KEY REFERENCES entities(id) ON DELETE CASCADE,
+  status TEXT NOT NULL,                -- 'open' | 'in_progress' | 'blocked' | 'done' | 'cancelled'
+  expires_at TEXT,
+  retention_until TEXT,
+  completed_at TEXT,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_task_meta_status ON task_meta(status);
+CREATE INDEX idx_task_meta_retention ON task_meta(retention_until);
+```
+
+Tasks share entity structure but use separate lifecycle rules.
+
+---
+
+## 6) Extraction and Backfill Contracts
+
+### 6.1 New structural assignment stage
+
+After fact extraction and decision, pipeline runs structural assignment per
+fact memory:
+
+1. resolve primary entity (existing or new)
+2. resolve/create aspect under that entity
+3. classify fact as `attribute` or `constraint`
+4. optionally emit dependency edges
+5. for task-like facts, assign/maintain `entity_type='task'` and `task_meta`
+
+### 6.2 Assignment invariants
+
+1. Every active atomic fact memory should map to exactly one primary
+   `entity_attributes` row.
+2. Constraints always map to `kind='constraint'`.
+3. Dependency edges are additive and idempotent.
+4. `superseded` attributes remain auditable; they do not vanish.
+
+### 6.3 Backfill behavior
+
+Maintenance worker backfills unassigned legacy memories incrementally:
+
+1. scan unassigned memories in batches
+2. assign entity/aspect/attribute with confidence
+3. skip low-confidence rows and record telemetry
+4. never block foreground hooks
+
+---
+
+## 7) Retrieval Contract (Traversal First)
+
+### 7.1 Session-start context assembly
+
+Order of operations:
+
+1. Resolve focal entities from session signals (project path, checkpoint,
+   session key lineage, prompt hints)
+2. Pull all active constraints for focal entities and one-hop dependencies
+3. Pull top aspects by `weight` for each focal entity
+4. Pull active attributes under those aspects
+5. Materialize candidate memory IDs via `entity_attributes.memory_id`
+
+This produces a structurally coherent candidate pool before heuristic or model
+ranking runs.
+
+### 7.2 Candidate pool fusion with predictor pre-filter
+
+Predictor pre-filter contract changes from:
+
+`effective top-50 U embedding top-50`
+
+to:
+
+`traversal pool U effective top-50 U embedding top-50`
+
+Then dedupe and cap (configurable, default 100).
+
+### 7.3 Hard retrieval invariant
+
+Constraints are always surfaced when their entity is in scope, independent of
+score rank.
+
+---
+
+## 8) Predictive Scorer Integration
+
+`predictive-memory-scorer.md` consumes this spec in three places:
+
+1. **Candidate quality**: scorer receives structurally coherent candidates
+2. **Feature enrichment**: add structural features per candidate
+   - entity slot hash
+   - aspect slot hash
+   - `is_constraint`
+3. **Evaluation slices**: report win/loss by focal entity/project, not only
+   global EMA
+
+The predictor still earns influence via comparisons. This spec improves its
+input quality and interpretability.
+
+---
+
+## 9) Procedural Memory Integration
+
+`procedural-memory-plan.md` remains authoritative for skill lifecycle.
+
+Alignment rules:
+
+1. Skills remain `entity_type='skill'`
+2. Skill metadata (`skill_meta`) remains source-of-truth for runtime skill
+   behavior
+3. Skill knowledge can also map into `entity_aspects` / `entity_attributes`
+   for unified traversal and scoring
+
+This keeps one graph with type-specific lifecycle rules.
+
+---
+
+## 10) Continuity Protocol Integration
+
+`session-continuity-protocol.md` integration points:
+
+1. checkpoint digests add optional structural snapshot fields:
+   - focal entities
+   - active aspects
+   - surfaced constraints
+2. recovery injection should prioritize these structural snapshots over raw
+   narrative when budget is tight
+3. predictor label quality improves when session-end evaluation knows which
+   constraints and aspects were in play
+
+---
+
+## 11) Migration and Phase Plan
+
+### KA-1 Schema and types
+
+1. Add migration `017-knowledge-structure.ts` (`entity_aspects`,
+   `entity_attributes`, `entity_dependencies`, `task_meta`)
+2. Add core types and read/write helpers
+
+### KA-2 Structural assignment in pipeline
+
+1. Add assignment stage in summary/extraction path
+2. Persist mappings for newly extracted atomic facts
+3. Add telemetry for assignment confidence and coverage
+
+### KA-3 Traversal retrieval path
+
+1. Add traversal query builder in daemon
+2. Wire session-start and recall flows to include traversal candidates
+3. Enforce constraint surfacing invariant
+
+### KA-4 Predictor coupling
+
+1. Extend predictor request payload with structural features
+2. Update comparison/audit APIs with structural slices
+
+### KA-5 Continuity + dashboard
+
+1. Store structural checkpoint slices
+2. Surface entity/aspect/constraint context in dashboard timeline and
+   predictor inspector
+
+---
+
+## 12) Acceptance Criteria
+
+1. >=90% of active atomic fact memories have structural assignment
+   (entity + aspect + attribute/constraint)
+2. Session-start context includes constraint rows for in-scope entities with
+   zero omissions in test fixtures
+3. Traversal candidate pool remains bounded and deterministic
+4. Predictor comparison reports include structural slices (entity/project)
+5. Recovery injections include structural snapshot fields when available
+
+---
+
+## 13) Open Questions
+
+1. Should aspects be free-form with canonicalization, or backed by a small
+   taxonomy per entity type?
+2. Should task retention default to fixed duration or confidence-driven decay?
+3. Do we need a dedicated `constraints` table later for policy-level joins,
+   or is `entity_attributes(kind='constraint')` sufficient?
+
+---
+
+## 14) Immediate Next Steps
+
+1. Approve this spec as the implementation contract for structural retrieval.
+2. Update predictive scorer Phase 3 tasks to include traversal pool fusion.
+3. Draft migration `017-knowledge-structure.ts` with exact indexes and
+   idempotency behavior.
+4. Add a small offline benchmark set comparing traversal-first candidate
+   generation vs current heuristic pre-filter.

--- a/docs/specs/planning/predictive-memory-scorer.md
+++ b/docs/specs/planning/predictive-memory-scorer.md
@@ -4,6 +4,13 @@ title: "Signet Predictive Memory Scorer"
 
 # Signet Predictive Memory Scorer
 
+Spec metadata:
+- ID: `predictive-memory-scorer`
+- Status: `planning`
+- Hard depends on: `memory-pipeline-v2`, `knowledge-architecture-schema`,
+  `session-continuity-protocol`
+- Registry: `docs/specs/INDEX.md`
+
 ## The North Star
 
 Signet isn't just a memory database with search. It's a prediction
@@ -38,6 +45,28 @@ back into future scoring. Meanwhile, recent research (ACAN, Memory-R1) shows
 that learned memory retrieval dramatically outperforms heuristic approaches -
 but nobody is training a per-user model that progressively improves on their
 personal memory corpus. That's what we're building.
+
+## Knowledge Architecture Coupling
+
+This spec now depends on
+`docs/specs/planning/knowledge-architecture-schema.md`.
+
+The predictor is still a ranking layer, but the candidate floor is no longer
+"flat facts only." Structural retrieval (entity -> aspect ->
+attribute/constraint + dependencies) defines the first-pass candidate pool,
+then the predictor ranks within that coherent set.
+
+Integration contracts:
+
+1. Candidate pre-filter includes traversal candidates from structural graph
+   walking in addition to effective score and embedding similarity.
+2. Predictor feature payload includes structural signals (`entity_slot`,
+   `aspect_slot`, `is_constraint`) so the model can learn aspect-level
+   relevance patterns.
+3. Comparison reporting includes structural slices (per-project and
+   per-entity), not only global EMA.
+4. Constraints remain non-negotiable surfaced context. The predictor may rank
+   them, but cannot suppress required constraints.
 
 ## Research Foundation
 

--- a/docs/specs/planning/signet-roadmap-spec.md
+++ b/docs/specs/planning/signet-roadmap-spec.md
@@ -7,6 +7,7 @@ title: "Signet Roadmap & Technical Spec"
 **Date:** 2026-02-25
 **Status:** Living document
 **Source:** Notebook review, install observations, user feedback
+**Spec Registry:** `docs/specs/INDEX.md`
 
 This is the honest state of things. What's broken, what's missing, what
 we're building toward. Each section covers the why, then the what, then
@@ -330,9 +331,11 @@ No detailed spec here yet -- this is ongoing directional work.
 
 ## 3.3 Predictive Memory Scorer
 
-Already designed in `docs/wip/predictive-memory-scorer.md`. ~1.11M
-parameter model for memory importance scoring. Replaces heuristic
-scoring with learned predictions.
+Already designed in `docs/specs/planning/predictive-memory-scorer.md`
+and now paired with
+`docs/specs/planning/knowledge-architecture-schema.md`. ~1.11M
+parameter model for memory importance scoring, running on top of
+structural traversal candidates instead of a flat fact pool.
 
 Needs implementation. This is a medium-priority project that improves
 memory quality over time.

--- a/package.json
+++ b/package.json
@@ -1,39 +1,42 @@
 {
-	"name": "signet",
-	"version": "0.31.3",
-	"private": true,
-	"description": "Portable AI agent identity",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/signetai/signetai.git"
-	},
-	"author": "Signet AI",
-	"license": "Apache-2.0",
-	"workspaces": ["packages/*", "packages/adapters/*", "web"],
-	"scripts": {
-		"build": "bun run build:core && bun run build:connector-base && bun run build:opencode-plugin && bun run build:deps && bun run build:signetai",
-		"build:core": "cd packages/core && bun run build",
-		"build:connector-base": "cd packages/connector-base && bun run build",
-		"build:opencode-plugin": "cd packages/opencode-plugin && bun run build",
-		"build:deps": "bun run --filter '@signet/connector-*' --filter '@signet/adapter-*' --filter '@signet/daemon' --filter '@signet/sdk' --filter '@signet/cli' build",
-		"build:signetai": "cd packages/signetai && bun run build",
-		"build:publish": "bun run build:dashboard && bun run build:signetai",
-		"build:dashboard": "cd packages/cli/dashboard && bun install && bun run build",
-		"dev": "bun run --filter '*' dev",
-		"test": "bun run --filter '*' test",
-		"lint": "biome check .",
-		"format": "biome format --write .",
-		"typecheck": "bun run --filter '*' typecheck",
-		"version:sync": "bun scripts/version-sync.ts",
-		"publish:signetai": "cd packages/signetai && npm publish --access public",
-		"dev:web": "cd web && bun run dev",
-		"deploy:web": "cd web && bun run deploy",
-		"changelog": "bun scripts/changelog.ts",
-		"spec:deps": "bun scripts/spec-deps-check.ts"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "^1.9.0",
-		"bun-types": "^1.3.9",
-		"typescript": "^5.7.0"
-	}
+  "name": "signet",
+  "version": "0.31.3",
+  "private": true,
+  "description": "Portable AI agent identity",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/signetai/signetai.git"
+  },
+  "author": "Signet AI",
+  "license": "Apache-2.0",
+  "workspaces": [
+    "packages/*",
+    "packages/adapters/*",
+    "web"
+  ],
+  "scripts": {
+    "build": "bun run build:core && bun run build:connector-base && bun run build:opencode-plugin && bun run build:deps && bun run build:signetai",
+    "build:core": "cd packages/core && bun run build",
+    "build:connector-base": "cd packages/connector-base && bun run build",
+    "build:opencode-plugin": "cd packages/opencode-plugin && bun run build",
+    "build:deps": "bun run --filter '@signet/connector-*' --filter '@signet/adapter-*' --filter '@signet/daemon' --filter '@signet/sdk' --filter '@signet/cli' build",
+    "build:signetai": "cd packages/signetai && bun run build",
+    "build:publish": "bun run build:dashboard && bun run build:signetai",
+    "build:dashboard": "cd packages/cli/dashboard && bun install && bun run build",
+    "dev": "bun run --filter '*' dev",
+    "test": "bun run --filter '*' test",
+    "lint": "biome check .",
+    "format": "biome format --write .",
+    "typecheck": "bun run --filter '*' typecheck",
+    "version:sync": "bun scripts/version-sync.ts",
+    "publish:signetai": "cd packages/signetai && npm publish --access public",
+    "dev:web": "cd web && bun run dev",
+    "deploy:web": "cd web && bun run deploy",
+    "changelog": "bun scripts/changelog.ts"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.0",
+    "bun-types": "^1.3.9",
+    "typescript": "^5.7.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,42 +1,39 @@
 {
-  "name": "signet",
-  "version": "0.31.3",
-  "private": true,
-  "description": "Portable AI agent identity",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/signetai/signetai.git"
-  },
-  "author": "Signet AI",
-  "license": "Apache-2.0",
-  "workspaces": [
-    "packages/*",
-    "packages/adapters/*",
-    "web"
-  ],
-  "scripts": {
-    "build": "bun run build:core && bun run build:connector-base && bun run build:opencode-plugin && bun run build:deps && bun run build:signetai",
-    "build:core": "cd packages/core && bun run build",
-    "build:connector-base": "cd packages/connector-base && bun run build",
-    "build:opencode-plugin": "cd packages/opencode-plugin && bun run build",
-    "build:deps": "bun run --filter '@signet/connector-*' --filter '@signet/adapter-*' --filter '@signet/daemon' --filter '@signet/sdk' --filter '@signet/cli' build",
-    "build:signetai": "cd packages/signetai && bun run build",
-    "build:publish": "bun run build:dashboard && bun run build:signetai",
-    "build:dashboard": "cd packages/cli/dashboard && bun install && bun run build",
-    "dev": "bun run --filter '*' dev",
-    "test": "bun run --filter '*' test",
-    "lint": "biome check .",
-    "format": "biome format --write .",
-    "typecheck": "bun run --filter '*' typecheck",
-    "version:sync": "bun scripts/version-sync.ts",
-    "publish:signetai": "cd packages/signetai && npm publish --access public",
-    "dev:web": "cd web && bun run dev",
-    "deploy:web": "cd web && bun run deploy",
-    "changelog": "bun scripts/changelog.ts"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "^1.9.0",
-    "bun-types": "^1.3.9",
-    "typescript": "^5.7.0"
-  }
+	"name": "signet",
+	"version": "0.31.3",
+	"private": true,
+	"description": "Portable AI agent identity",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/signetai/signetai.git"
+	},
+	"author": "Signet AI",
+	"license": "Apache-2.0",
+	"workspaces": ["packages/*", "packages/adapters/*", "web"],
+	"scripts": {
+		"build": "bun run build:core && bun run build:connector-base && bun run build:opencode-plugin && bun run build:deps && bun run build:signetai",
+		"build:core": "cd packages/core && bun run build",
+		"build:connector-base": "cd packages/connector-base && bun run build",
+		"build:opencode-plugin": "cd packages/opencode-plugin && bun run build",
+		"build:deps": "bun run --filter '@signet/connector-*' --filter '@signet/adapter-*' --filter '@signet/daemon' --filter '@signet/sdk' --filter '@signet/cli' build",
+		"build:signetai": "cd packages/signetai && bun run build",
+		"build:publish": "bun run build:dashboard && bun run build:signetai",
+		"build:dashboard": "cd packages/cli/dashboard && bun install && bun run build",
+		"dev": "bun run --filter '*' dev",
+		"test": "bun run --filter '*' test",
+		"lint": "biome check .",
+		"format": "biome format --write .",
+		"typecheck": "bun run --filter '*' typecheck",
+		"version:sync": "bun scripts/version-sync.ts",
+		"publish:signetai": "cd packages/signetai && npm publish --access public",
+		"dev:web": "cd web && bun run dev",
+		"deploy:web": "cd web && bun run deploy",
+		"changelog": "bun scripts/changelog.ts",
+		"spec:deps": "bun scripts/spec-deps-check.ts"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^1.9.0",
+		"bun-types": "^1.3.9",
+		"typescript": "^5.7.0"
+	}
 }

--- a/scripts/spec-deps-check.ts
+++ b/scripts/spec-deps-check.ts
@@ -1,0 +1,334 @@
+#!/usr/bin/env bun
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface SpecRecord {
+	id: string;
+	status: string;
+	path: string;
+	hardDependsOn: string[];
+	softDependsOn: string[];
+	blocks: string[];
+}
+
+interface ParsedDeps {
+	version: number;
+	updatedAt: string;
+	specs: SpecRecord[];
+}
+
+interface IndexRow {
+	id: string;
+	status: string;
+	path: string;
+}
+
+const ROOT = process.cwd();
+const DEPS_PATH = resolve(ROOT, "docs/specs/dependencies.yaml");
+const INDEX_PATH = resolve(ROOT, "docs/specs/INDEX.md");
+
+function stripQuotes(value: string): string {
+	const trimmed = value.trim();
+	if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+		return trimmed.slice(1, -1);
+	}
+	return trimmed;
+}
+
+function parseDepsYaml(yaml: string): ParsedDeps {
+	const lines = yaml.split(/\r?\n/);
+	let version = 0;
+	let updatedAt = "";
+	const specs: SpecRecord[] = [];
+
+	let inSpecs = false;
+	let current: SpecRecord | null = null;
+	let currentArrayKey: "hardDependsOn" | "softDependsOn" | "blocks" | null = null;
+
+	for (const rawLine of lines) {
+		if (!rawLine.trim() || rawLine.trim().startsWith("#")) {
+			continue;
+		}
+
+		if (/^specs:\s*$/.test(rawLine)) {
+			inSpecs = true;
+			currentArrayKey = null;
+			continue;
+		}
+
+		if (!inSpecs) {
+			const topMatch = rawLine.match(/^([a-z_]+):\s*(.+?)\s*$/);
+			if (!topMatch) continue;
+			const [, key, valueRaw] = topMatch;
+			const value = stripQuotes(valueRaw);
+			if (key === "version") {
+				const parsed = Number.parseInt(value, 10);
+				if (Number.isNaN(parsed)) {
+					throw new Error(`Invalid version in dependencies file: ${value}`);
+				}
+				version = parsed;
+			} else if (key === "updated_at") {
+				updatedAt = value;
+			}
+			continue;
+		}
+
+		const specStart = rawLine.match(/^\s{2}-\s+id:\s*(.+?)\s*$/);
+		if (specStart) {
+			if (current !== null) {
+				specs.push(current);
+			}
+			current = {
+				id: stripQuotes(specStart[1]),
+				status: "",
+				path: "",
+				hardDependsOn: [],
+				softDependsOn: [],
+				blocks: [],
+			};
+			currentArrayKey = null;
+			continue;
+		}
+
+		if (current === null) {
+			continue;
+		}
+
+		if (/^\s{4}hard_depends_on:\s*\[\s*\]\s*$/.test(rawLine)) {
+			current.hardDependsOn = [];
+			currentArrayKey = null;
+			continue;
+		}
+		if (/^\s{4}soft_depends_on:\s*\[\s*\]\s*$/.test(rawLine)) {
+			current.softDependsOn = [];
+			currentArrayKey = null;
+			continue;
+		}
+		if (/^\s{4}blocks:\s*\[\s*\]\s*$/.test(rawLine)) {
+			current.blocks = [];
+			currentArrayKey = null;
+			continue;
+		}
+
+		if (/^\s{4}hard_depends_on:\s*$/.test(rawLine)) {
+			currentArrayKey = "hardDependsOn";
+			continue;
+		}
+		if (/^\s{4}soft_depends_on:\s*$/.test(rawLine)) {
+			currentArrayKey = "softDependsOn";
+			continue;
+		}
+		if (/^\s{4}blocks:\s*$/.test(rawLine)) {
+			currentArrayKey = "blocks";
+			continue;
+		}
+
+		const arrayItem = rawLine.match(/^\s{6}-\s+(.+?)\s*$/);
+		if (arrayItem && currentArrayKey !== null) {
+			current[currentArrayKey].push(stripQuotes(arrayItem[1]));
+			continue;
+		}
+
+		const scalar = rawLine.match(/^\s{4}([a-z_]+):\s*(.+?)\s*$/);
+		if (scalar) {
+			const [, key, valueRaw] = scalar;
+			const value = stripQuotes(valueRaw);
+			if (key === "status") current.status = value;
+			if (key === "path") current.path = value;
+			currentArrayKey = null;
+		}
+	}
+
+	if (current !== null) {
+		specs.push(current);
+	}
+
+	return { version, updatedAt, specs };
+}
+
+function parseIndexRows(markdown: string): IndexRow[] {
+	const lines = markdown.split(/\r?\n/);
+	const rows: IndexRow[] = [];
+
+	let inRegistry = false;
+
+	for (const rawLine of lines) {
+		const line = rawLine.trim();
+
+		if (line === "## Spec Registry") {
+			inRegistry = true;
+			continue;
+		}
+
+		if (!inRegistry) continue;
+
+		if (line.startsWith("## ") && line !== "## Spec Registry") {
+			break;
+		}
+
+		if (!line.startsWith("|")) continue;
+		if (line.includes("---")) continue;
+
+		const cells = line
+			.split("|")
+			.map((cell) => cell.trim())
+			.filter((cell) => cell.length > 0);
+		if (cells.length < 3) continue;
+		if (cells[0] === "ID") continue;
+
+		const id = stripQuotes(cells[0]).replace(/`/g, "");
+		const status = stripQuotes(cells[1]).replace(/`/g, "");
+		const path = stripQuotes(cells[2]).replace(/`/g, "");
+
+		rows.push({ id, status, path });
+	}
+
+	return rows;
+}
+
+function detectHardDepCycles(specs: SpecRecord[]): string[][] {
+	const byId = new Map(specs.map((spec) => [spec.id, spec]));
+	const color = new Map<string, 0 | 1 | 2>();
+	const stack: string[] = [];
+	const cycles: string[][] = [];
+
+	for (const spec of specs) {
+		color.set(spec.id, 0);
+	}
+
+	function dfs(id: string): void {
+		color.set(id, 1);
+		stack.push(id);
+
+		const spec = byId.get(id);
+		if (spec !== undefined) {
+			for (const dep of spec.hardDependsOn) {
+				if (!byId.has(dep)) continue;
+				const depColor = color.get(dep) ?? 0;
+				if (depColor === 0) {
+					dfs(dep);
+				} else if (depColor === 1) {
+					const cycleStart = stack.indexOf(dep);
+					if (cycleStart >= 0) {
+						cycles.push(stack.slice(cycleStart).concat(dep));
+					}
+				}
+			}
+		}
+
+		stack.pop();
+		color.set(id, 2);
+	}
+
+	for (const spec of specs) {
+		if ((color.get(spec.id) ?? 0) === 0) {
+			dfs(spec.id);
+		}
+	}
+
+	return cycles;
+}
+
+function main(): void {
+	const failures: string[] = [];
+
+	if (!existsSync(DEPS_PATH)) {
+		throw new Error(`Missing dependency file: ${DEPS_PATH}`);
+	}
+	if (!existsSync(INDEX_PATH)) {
+		throw new Error(`Missing spec index file: ${INDEX_PATH}`);
+	}
+
+	const deps = parseDepsYaml(readFileSync(DEPS_PATH, "utf8"));
+	const indexRows = parseIndexRows(readFileSync(INDEX_PATH, "utf8"));
+
+	if (deps.version <= 0) {
+		failures.push("dependencies.yaml must declare a positive version");
+	}
+	if (deps.updatedAt.length === 0) {
+		failures.push("dependencies.yaml must declare updated_at");
+	}
+
+	const allowedStatuses = new Set(["planning", "approved", "complete", "reference"]);
+
+	const ids = new Set<string>();
+	for (const spec of deps.specs) {
+		if (!spec.id) {
+			failures.push("spec entry with empty id");
+			continue;
+		}
+		if (ids.has(spec.id)) {
+			failures.push(`duplicate spec id in dependencies.yaml: ${spec.id}`);
+		}
+		ids.add(spec.id);
+
+		if (!allowedStatuses.has(spec.status)) {
+			failures.push(`invalid status for ${spec.id}: ${spec.status} (allowed: planning|approved|complete|reference)`);
+		}
+
+		if (!spec.path) {
+			failures.push(`missing path for ${spec.id}`);
+		} else if (!existsSync(resolve(ROOT, spec.path))) {
+			failures.push(`path does not exist for ${spec.id}: ${spec.path}`);
+		}
+	}
+
+	for (const spec of deps.specs) {
+		for (const dep of spec.hardDependsOn) {
+			if (!ids.has(dep)) {
+				failures.push(`${spec.id} hard_depends_on unknown spec id: ${dep}`);
+			}
+		}
+
+		for (const dep of spec.softDependsOn) {
+			if (!ids.has(dep)) {
+				failures.push(`${spec.id} soft_depends_on unknown spec id: ${dep}`);
+			}
+		}
+
+		for (const dep of spec.blocks) {
+			if (!ids.has(dep)) {
+				failures.push(`${spec.id} blocks unknown spec id: ${dep}`);
+			}
+		}
+	}
+
+	const cycles = detectHardDepCycles(deps.specs);
+	for (const cycle of cycles) {
+		failures.push(`hard dependency cycle detected: ${cycle.join(" -> ")}`);
+	}
+
+	const indexMap = new Map(indexRows.map((row) => [row.id, row]));
+	for (const spec of deps.specs) {
+		const row = indexMap.get(spec.id);
+		if (row === undefined) {
+			failures.push(`spec missing from INDEX.md registry: ${spec.id}`);
+			continue;
+		}
+		if (row.status !== spec.status) {
+			failures.push(`status drift for ${spec.id}: dependencies.yaml=${spec.status}, INDEX.md=${row.status}`);
+		}
+		if (row.path !== spec.path) {
+			failures.push(`path drift for ${spec.id}: dependencies.yaml=${spec.path}, INDEX.md=${row.path}`);
+		}
+	}
+
+	for (const row of indexRows) {
+		if (!ids.has(row.id)) {
+			failures.push(`INDEX.md registry has unknown spec id: ${row.id}`);
+		}
+	}
+
+	if (failures.length > 0) {
+		console.error("Spec dependency check failed:\n");
+		for (const failure of failures) {
+			console.error(`- ${failure}`);
+		}
+		process.exit(1);
+	}
+
+	console.log(`Spec dependency check passed (${deps.specs.length} specs, ${indexRows.length} indexed).`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a centralized spec registry and dependency graph at `docs/specs/INDEX.md`, including critical path and tracking rules
- add `docs/specs/dependencies.yaml` as the machine-readable source of truth for spec IDs, statuses, dependencies, and blocked work
- add `scripts/spec-deps-check.ts` plus `bun run spec:deps` to validate unknown dependency IDs, hard-dependency cycles, missing spec paths, and drift between the index table and YAML metadata
- align knowledge architecture and predictor planning docs with explicit metadata and dependency coupling, and wire docs navigation links from `docs/KNOWLEDGE-ARCHITECTURE.md`, `docs/specs/planning/signet-roadmap-spec.md`, and `docs/README.md`

## Validation
- `bun run spec:deps`