### PR TITLE
feat(dashboard): consolidate nav to 6 grouped items

### DIFF
--- a/packages/cli/dashboard/src/app.css
+++ b/packages/cli/dashboard/src/app.css
@@ -6,7 +6,7 @@
 
 /* === Dark theme (default) === */
 :root {
-	--radius: 0px;
+	--radius: 0.5rem;
 
 	/* shadcn semantic tokens */
 	--background: #08080a;
@@ -56,8 +56,8 @@
 	--sig-grain-opacity: 0.04;
 
 	/* Typography & spacing */
-	--font-display: "Chakra Petch", sans-serif;
-	--font-mono: "IBM Plex Mono", monospace;
+	--font-display: "Diamond Grotesk", "Chakra Petch", sans-serif;
+	--font-mono: "Geist Mono", "IBM Plex Mono", monospace;
 	--font-sans: var(--font-display);
 
 	--space-xs: 4px;
@@ -395,6 +395,59 @@ h3 {
 	text-transform: uppercase;
 	font-size: 10px;
 	letter-spacing: 0.04em;
+}
+
+/* === Component utilities === */
+
+/* Small monospace label (11px, muted) */
+.sig-label {
+	font-family: var(--font-mono);
+	font-size: 11px;
+	color: var(--sig-text-muted);
+}
+
+/* Tiny uppercase monospace (eyebrows, metadata, counters) */
+.sig-eyebrow {
+	font-family: var(--font-mono);
+	font-size: 10px;
+	text-transform: uppercase;
+	letter-spacing: 0.06em;
+	color: var(--sig-text-muted);
+}
+
+/* Display heading used in section headers */
+.sig-heading {
+	font-family: var(--font-display);
+	font-size: 11px;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.1em;
+	color: var(--sig-text-bright);
+}
+
+/* Tiny monospace for badge-like metadata (9px) */
+.sig-meta {
+	font-family: var(--font-mono);
+	font-size: 9px;
+	color: var(--sig-text-muted);
+	white-space: nowrap;
+}
+
+/* Standard badge styling used across memory cards, pipeline, etc. */
+.sig-badge {
+	font-family: var(--font-mono);
+	font-size: 9px;
+	border-radius: 0.5rem;
+	padding: 1px 5px;
+}
+
+/* Feed/log tiny text (8-9px monospace) */
+.sig-micro {
+	font-family: var(--font-mono);
+	font-size: 8px;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: var(--sig-text-muted);
 }
 
 /* Reduced motion */

--- a/packages/cli/dashboard/src/app.html
+++ b/packages/cli/dashboard/src/app.html
@@ -5,7 +5,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="preconnect" href="https://fonts.googleapis.com">
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-		<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+		<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
 		<script>
 			// Set theme before first paint to prevent flash
 			(function() {

--- a/packages/cli/dashboard/src/lib/components/app-sidebar.svelte
+++ b/packages/cli/dashboard/src/lib/components/app-sidebar.svelte
@@ -1,20 +1,23 @@
 <script lang="ts">
 import type { DaemonStatus, Harness, Identity } from "$lib/api";
 import * as Sidebar from "$lib/components/ui/sidebar/index.js";
-import { type TabId, nav, setTab } from "$lib/stores/navigation.svelte";
-import Activity from "@lucide/svelte/icons/activity";
-import CalendarClock from "@lucide/svelte/icons/calendar-clock";
-import Database from "@lucide/svelte/icons/database";
-import FileText from "@lucide/svelte/icons/file-text";
+import {
+	type TabId,
+	isEngineGroup,
+	isMemoryGroup,
+	nav,
+	navigateToGroup,
+	setTab,
+} from "$lib/stores/navigation.svelte";
+import Brain from "@lucide/svelte/icons/brain";
+import Cog from "@lucide/svelte/icons/cog";
 import Github from "@lucide/svelte/icons/github";
-import KeyRound from "@lucide/svelte/icons/key-round";
+import ListChecks from "@lucide/svelte/icons/list-checks";
 import Moon from "@lucide/svelte/icons/moon";
-import Network from "@lucide/svelte/icons/network";
-import Plug from "@lucide/svelte/icons/plug";
-import ScrollText from "@lucide/svelte/icons/scroll-text";
-import SlidersHorizontal from "@lucide/svelte/icons/sliders-horizontal";
+import Pencil from "@lucide/svelte/icons/pencil";
+import ShieldCheck from "@lucide/svelte/icons/shield-check";
+import Store from "@lucide/svelte/icons/store";
 import Sun from "@lucide/svelte/icons/sun";
-import Zap from "@lucide/svelte/icons/zap";
 
 interface Props {
 	identity: Identity;
@@ -36,23 +39,37 @@ const {
 	onprefetchembeddings,
 }: Props = $props();
 
-function maybePrefetchEmbeddings(id: TabId): void {
-	if (id !== "embeddings") return;
+function maybePrefetchEmbeddings(id: string): void {
+	if (id !== "memory") return;
 	onprefetchembeddings?.();
 }
 
-const navItems: { id: TabId; label: string; icon: typeof FileText }[] = [
-	{ id: "config", label: "Config", icon: FileText },
-	{ id: "settings", label: "Settings", icon: SlidersHorizontal },
-	{ id: "memory", label: "Memory", icon: Database },
-	{ id: "embeddings", label: "Constellation", icon: Network },
-	{ id: "pipeline", label: "Pipeline", icon: Activity },
-	{ id: "logs", label: "Logs", icon: ScrollText },
-	{ id: "secrets", label: "Secrets", icon: KeyRound },
-	{ id: "skills", label: "Marketplace", icon: Zap },
-	{ id: "tasks", label: "Tasks", icon: CalendarClock },
-	{ id: "connectors", label: "Connectors", icon: Plug },
+type NavItem =
+	| { id: TabId; label: string; icon: typeof Pencil; group?: undefined }
+	| { id: string; label: string; icon: typeof Pencil; group: "memory" | "engine" };
+
+const navItems: NavItem[] = [
+	{ id: "config", label: "Config", icon: Pencil },
+	{ id: "memory-group", label: "Memory", icon: Brain, group: "memory" },
+	{ id: "secrets", label: "Secrets", icon: ShieldCheck },
+	{ id: "skills", label: "Marketplace", icon: Store },
+	{ id: "tasks", label: "Tasks", icon: ListChecks },
+	{ id: "engine-group", label: "Engine", icon: Cog, group: "engine" },
 ];
+
+function isActive(item: NavItem): boolean {
+	if (item.group === "memory") return isMemoryGroup(nav.activeTab);
+	if (item.group === "engine") return isEngineGroup(nav.activeTab);
+	return nav.activeTab === item.id;
+}
+
+function handleClick(item: NavItem): void {
+	if (item.group) {
+		navigateToGroup(item.group);
+	} else {
+		setTab(item.id as TabId);
+	}
+}
 </script>
 
 <Sidebar.Root variant="sidebar" collapsible="icon">
@@ -101,8 +118,8 @@ const navItems: { id: TabId; label: string; icon: typeof FileText }[] = [
 					{#each navItems as item (item.id)}
 						<Sidebar.MenuItem>
 							<Sidebar.MenuButton
-								isActive={nav.activeTab === item.id}
-								onclick={() => setTab(item.id)}
+								isActive={isActive(item)}
+								onclick={() => handleClick(item)}
 								onmouseenter={() => maybePrefetchEmbeddings(item.id)}
 								onfocus={() => maybePrefetchEmbeddings(item.id)}
 								tooltipContent={item.label}

--- a/packages/cli/dashboard/src/lib/components/command/GlobalCommandPalette.svelte
+++ b/packages/cli/dashboard/src/lib/components/command/GlobalCommandPalette.svelte
@@ -87,7 +87,7 @@ function handleGlobalKeydown(e: KeyboardEvent) {
 <CommandPrimitive.Root bind:open>
 	<CommandPrimitive.Portal>
 		<CommandPrimitive.Overlay class="fixed inset-0 z-50 bg-black/60" />
-		<CommandPrimitive.Content class="fixed left-1/2 top-[20%] z-50 w-full max-w-[480px] -translate-x-1/2 rounded-none border border-[var(--sig-border-strong)] bg-[var(--sig-surface-raised)] shadow-xl">
+		<CommandPrimitive.Content class="fixed left-1/2 top-[20%] z-50 w-full max-w-[480px] -translate-x-1/2 rounded-lg border border-[var(--sig-border-strong)] bg-[var(--sig-surface-raised)] shadow-xl">
 			<div class="flex items-center border-b border-[var(--sig-border)] px-3">
 				<Search class="size-4 shrink-0 text-[var(--sig-text-muted)]" />
 				<input

--- a/packages/cli/dashboard/src/lib/components/config/MarkdownViewer.svelte
+++ b/packages/cli/dashboard/src/lib/components/config/MarkdownViewer.svelte
@@ -103,7 +103,7 @@ let rendered = $derived.by(() => {
 				<Button
 					variant="outline"
 					size="sm"
-					class="h-auto rounded-none gap-1 font-[family-name:var(--font-mono)] text-[10px]
+					class="h-auto rounded-lg gap-1 font-[family-name:var(--font-mono)] text-[10px]
 						font-medium uppercase tracking-[0.1em] px-2 py-[3px]
 						text-[var(--sig-text-muted)] border-[var(--sig-border)]
 						hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
@@ -116,7 +116,7 @@ let rendered = $derived.by(() => {
 				<Button
 					variant="outline"
 					size="sm"
-					class="h-auto rounded-none gap-1 font-[family-name:var(--font-mono)] text-[10px]
+					class="h-auto rounded-lg gap-1 font-[family-name:var(--font-mono)] text-[10px]
 						font-medium uppercase tracking-[0.1em] px-2 py-[3px]
 						border-[var(--sig-accent)] text-[var(--sig-text-bright)]
 						hover:bg-[var(--sig-text-bright)] hover:text-[var(--sig-bg)]
@@ -130,7 +130,7 @@ let rendered = $derived.by(() => {
 			<Button
 				variant="outline"
 				size="sm"
-				class="h-auto rounded-none gap-1 font-[family-name:var(--font-mono)] text-[10px]
+				class="h-auto rounded-lg gap-1 font-[family-name:var(--font-mono)] text-[10px]
 					font-medium uppercase tracking-[0.1em] px-2 py-[3px]
 					text-[var(--sig-text)] border-[var(--sig-border-strong)]
 					hover:text-[var(--sig-text-bright)] hover:border-[var(--sig-text-muted)]"

--- a/packages/cli/dashboard/src/lib/components/layout/page-headers.ts
+++ b/packages/cli/dashboard/src/lib/components/layout/page-headers.ts
@@ -9,7 +9,7 @@ export const PAGE_HEADERS = {
 		eyebrow: "Identity markdown workspace",
 	},
 	settings: {
-		title: "Settings",
+		title: "Engine",
 		eyebrow: "Runtime and harness controls",
 	},
 	memory: {
@@ -17,15 +17,15 @@ export const PAGE_HEADERS = {
 		eyebrow: "Persistent memory index",
 	},
 	embeddings: {
-		title: "Constellation",
+		title: "Memory",
 		eyebrow: "Semantic projection workspace",
 	},
 	pipeline: {
-		title: "Pipeline",
+		title: "Engine",
 		eyebrow: "Live memory loop telemetry",
 	},
 	logs: {
-		title: "Logs",
+		title: "Engine",
 		eyebrow: "Daemon event stream",
 	},
 	secrets: {
@@ -41,7 +41,7 @@ export const PAGE_HEADERS = {
 		eyebrow: "Scheduled agent prompts",
 	},
 	connectors: {
-		title: "Connectors",
+		title: "Engine",
 		eyebrow: "Harness and data source health",
 	},
 } as const satisfies Record<string, PageHeaderDefinition>;

--- a/packages/cli/dashboard/src/lib/components/marketplace/McpInstallSheet.svelte
+++ b/packages/cli/dashboard/src/lib/components/marketplace/McpInstallSheet.svelte
@@ -683,13 +683,13 @@ async function installWithConfig(): Promise<void> {
 	:global(.field-select) {
 		height: 32px;
 		padding: 0 8px;
-		border-radius: 0;
+		border-radius: 0.5rem;
 	}
 
 	:global(.field-select-content) {
 		background: var(--sig-surface-raised);
 		border: 1px solid var(--sig-border-strong);
-		border-radius: 0;
+		border-radius: 0.5rem;
 	}
 
 	:global(.field-select-item) {

--- a/packages/cli/dashboard/src/lib/components/marketplace/McpServersTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/marketplace/McpServersTab.svelte
@@ -307,13 +307,13 @@ function closeInstallSheet(): void {
 		background: var(--sig-surface-raised);
 		border: 1px solid var(--sig-border-strong);
 		color: var(--sig-text-bright);
-		border-radius: 0;
+		border-radius: 0.5rem;
 	}
 
 	:global(.select-content) {
 		background: var(--sig-surface-raised);
 		border: 1px solid var(--sig-border-strong);
-		border-radius: 0;
+		border-radius: 0.5rem;
 	}
 
 	:global(.select-item) {

--- a/packages/cli/dashboard/src/lib/components/skills/SkillCard.svelte
+++ b/packages/cli/dashboard/src/lib/components/skills/SkillCard.svelte
@@ -172,7 +172,7 @@ let isInstalled = $derived(
 					<span class="stat">/{item.name}</span>
 				{/if}
 				{#if item.builtin}
-					<Badge variant="outline" class="rounded-none font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] border-[var(--sig-accent)] text-[var(--sig-accent)]">Built-in</Badge>
+					<Badge variant="outline" class="rounded-lg font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] border-[var(--sig-accent)] text-[var(--sig-accent)]">Built-in</Badge>
 				{/if}
 			{/if}
 		</div>
@@ -184,7 +184,7 @@ let isInstalled = $derived(
 					<Button
 						variant="outline"
 						size="sm"
-						class="w-full h-auto rounded-none font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] px-2 py-1 border-[var(--sig-danger)] text-[var(--sig-danger)] hover:bg-[var(--sig-danger)] hover:text-[var(--sig-text-bright)]"
+						class="w-full h-auto rounded-lg font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] px-2 py-1 border-[var(--sig-danger)] text-[var(--sig-danger)] hover:bg-[var(--sig-danger)] hover:text-[var(--sig-text-bright)]"
 						onclick={(e: MouseEvent) => { e.stopPropagation(); onuninstall?.(); }}
 						disabled={uninstalling}
 					>
@@ -194,7 +194,7 @@ let isInstalled = $derived(
 					<Button
 						variant="outline"
 						size="sm"
-						class="w-full h-auto rounded-none font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] px-2 py-1 bg-[var(--sig-accent)] border-[var(--sig-accent)] text-[var(--sig-bg)] hover:bg-[var(--sig-accent-hover,var(--sig-accent))] hover:border-[var(--sig-accent)]"
+						class="w-full h-auto rounded-lg font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] px-2 py-1 bg-[var(--sig-accent)] border-[var(--sig-accent)] text-[var(--sig-bg)] hover:bg-[var(--sig-accent-hover,var(--sig-accent))] hover:border-[var(--sig-accent)]"
 						onclick={(e: MouseEvent) => { e.stopPropagation(); oninstall?.(); }}
 						disabled={installing}
 					>

--- a/packages/cli/dashboard/src/lib/components/skills/SkillDetail.svelte
+++ b/packages/cli/dashboard/src/lib/components/skills/SkillDetail.svelte
@@ -90,15 +90,15 @@ let trustProfile = $derived.by(() => {
 							{/if}
 							{#if sk.detailMeta}
 								{#if sk.detailMeta.user_invocable}
-									<Badge variant="outline" class="rounded-none font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] border-[var(--sig-accent)] text-[var(--sig-accent)]">
+									<Badge variant="outline" class="rounded-lg font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] border-[var(--sig-accent)] text-[var(--sig-accent)]">
 										/{sk.detailMeta.name}
 									</Badge>
 								{/if}
 								{#if sk.detailMeta.builtin}
-									<Badge variant="outline" class="rounded-none font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] border-[var(--sig-accent)] text-[var(--sig-accent)]">Built-in</Badge>
+									<Badge variant="outline" class="rounded-lg font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] border-[var(--sig-accent)] text-[var(--sig-accent)]">Built-in</Badge>
 								{/if}
 								{#if sk.detailMeta.arg_hint}
-									<Badge variant="outline" class="rounded-none font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] border-[var(--sig-border-strong)] text-[var(--sig-text-muted)]">
+									<Badge variant="outline" class="rounded-lg font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] border-[var(--sig-border-strong)] text-[var(--sig-text-muted)]">
 										{sk.detailMeta.arg_hint}
 									</Badge>
 								{/if}
@@ -109,12 +109,12 @@ let trustProfile = $derived.by(() => {
 					<!-- Action button -->
 					<div class="shrink-0">
 						{#if sk.detailMeta?.builtin}
-							<Badge variant="outline" class="rounded-none font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] border-[var(--sig-border-strong)] text-[var(--sig-text-muted)]">System</Badge>
+							<Badge variant="outline" class="rounded-lg font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] border-[var(--sig-border-strong)] text-[var(--sig-text-muted)]">System</Badge>
 						{:else if isInstalled}
 							<Button
 								variant="outline"
 								size="sm"
-								class="rounded-none font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] border-[var(--sig-danger)] text-[var(--sig-danger)] hover:bg-[var(--sig-danger)] hover:text-[var(--sig-text-bright)]"
+								class="rounded-lg font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] border-[var(--sig-danger)] text-[var(--sig-danger)] hover:bg-[var(--sig-danger)] hover:text-[var(--sig-text-bright)]"
 								onclick={() => sk.detailMeta && doUninstall(sk.detailMeta.name)}
 								disabled={sk.uninstalling === sk.detailMeta?.name}
 							>
@@ -124,7 +124,7 @@ let trustProfile = $derived.by(() => {
 							<Button
 								variant="outline"
 								size="sm"
-								class="rounded-none font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] border-[var(--sig-text-bright)] text-[var(--sig-text-bright)] hover:bg-[var(--sig-text-bright)] hover:text-[var(--sig-bg)]"
+								class="rounded-lg font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] border-[var(--sig-text-bright)] text-[var(--sig-text-bright)] hover:bg-[var(--sig-text-bright)] hover:text-[var(--sig-bg)]"
 								onclick={() => sk.selectedName && doInstall(sk.selectedName)}
 								disabled={sk.installing === sk.selectedName}
 							>

--- a/packages/cli/dashboard/src/lib/components/skills/SkillsTable.svelte
+++ b/packages/cli/dashboard/src/lib/components/skills/SkillsTable.svelte
@@ -72,12 +72,12 @@ function isSkill(item: Skill | SkillSearchResult): item is Skill {
 				{#if mode === "search" && isSearchResult(item)}
 					<span class="skill-count">{item.installs}</span>
 					{#if item.installed}
-						<Badge variant="outline" class="rounded-none font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] border-[var(--sig-success)] text-[var(--sig-success)]">Installed</Badge>
+						<Badge variant="outline" class="rounded-lg font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] border-[var(--sig-success)] text-[var(--sig-success)]">Installed</Badge>
 					{:else}
 						<Button
 							variant="outline"
 							size="sm"
-							class="h-auto rounded-none font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] px-2 py-0.5 border-[var(--sig-text-bright)] text-[var(--sig-text-bright)] hover:bg-[var(--sig-text-bright)] hover:text-[var(--sig-bg)]"
+							class="h-auto rounded-lg font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] px-2 py-0.5 border-[var(--sig-text-bright)] text-[var(--sig-text-bright)] hover:bg-[var(--sig-text-bright)] hover:text-[var(--sig-bg)]"
 							onclick={(e: MouseEvent) => { e.stopPropagation(); oninstall?.(item.name); }}
 							disabled={installing === item.name}
 						>
@@ -86,16 +86,16 @@ function isSkill(item: Skill | SkillSearchResult): item is Skill {
 					{/if}
 				{:else if mode === "installed" && isSkill(item)}
 					{#if item.builtin}
-						<Badge variant="outline" class="rounded-none font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] border-[var(--sig-accent)] text-[var(--sig-accent)]">Built-in</Badge>
+						<Badge variant="outline" class="rounded-lg font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] border-[var(--sig-accent)] text-[var(--sig-accent)]">Built-in</Badge>
 					{/if}
 					{#if item.user_invocable}
-						<Badge variant="outline" class="rounded-none font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] border-[var(--sig-border-strong)] text-[var(--sig-text-muted)]">/{item.name}</Badge>
+						<Badge variant="outline" class="rounded-lg font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] border-[var(--sig-border-strong)] text-[var(--sig-text-muted)]">/{item.name}</Badge>
 					{/if}
 					{#if !item.builtin}
 						<Button
 							variant="outline"
 							size="sm"
-							class="h-auto rounded-none font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] px-2 py-0.5 border-[var(--sig-danger)] text-[var(--sig-danger)] hover:bg-[var(--sig-danger)] hover:text-[var(--sig-text-bright)]"
+							class="h-auto rounded-lg font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] px-2 py-0.5 border-[var(--sig-danger)] text-[var(--sig-danger)] hover:bg-[var(--sig-danger)] hover:text-[var(--sig-text-bright)]"
 							onclick={(e: MouseEvent) => { e.stopPropagation(); onuninstall?.(item.name); }}
 							disabled={uninstalling === item.name}
 						>

--- a/packages/cli/dashboard/src/lib/components/tabs/ConfigTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/ConfigTab.svelte
@@ -476,7 +476,7 @@
 		padding: 0;
 		background: var(--sig-surface-raised);
 		border: 1px solid var(--sig-border-strong);
-		border-radius: 0;
+		border-radius: 0.5rem;
 	}
 
 	.jump-filter {

--- a/packages/cli/dashboard/src/lib/components/tabs/ConnectorsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/ConnectorsTab.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from "svelte";
 	import { Badge } from "$lib/components/ui/badge/index.js";
+	import { Button } from "$lib/components/ui/button/index.js";
 	import * as Popover from "$lib/components/ui/popover/index.js";
 	import {
 		getHarnesses,
@@ -99,19 +100,13 @@
 
 <div class="flex flex-1 flex-col gap-6 p-4 overflow-y-auto">
 	{#if loading}
-		<div
-			class="flex flex-1 items-center justify-center text-[12px]
-				text-[var(--sig-text-muted)] font-[family-name:var(--font-mono)]"
-		>
+		<div class="flex flex-1 items-center justify-center sig-label">
 			Loading connectors...
 		</div>
 	{:else}
 		<!-- Platform Harnesses -->
 		<section>
-			<h3
-				class="text-[11px] uppercase tracking-[0.1em] text-[var(--sig-text-muted)]
-					font-[family-name:var(--font-mono)] mb-3"
-			>
+			<h3 class="sig-label uppercase tracking-[0.1em] mb-3">
 				Platform Harnesses
 			</h3>
 			<div class="grid gap-2">
@@ -128,31 +123,23 @@
 							class:border-[var(--sig-text-muted)]={!h.exists}
 						></span>
 						<div class="flex flex-col gap-0.5 min-w-0 flex-1">
-							<span
-								class="text-[12px] font-medium text-[var(--sig-text-bright)]
-									font-[family-name:var(--font-display)] tracking-[0.04em]"
-							>
+							<span class="text-[12px] font-medium text-[var(--sig-text-bright)]
+								font-[family-name:var(--font-display)] tracking-[0.04em]">
 								{h.name}
 							</span>
-							<span
-								class="text-[10px] text-[var(--sig-text-muted)]
-									font-[family-name:var(--font-mono)] truncate"
-							>
+							<span class="sig-eyebrow truncate">
 								{h.path}
 							</span>
 						</div>
 						<div class="flex flex-col items-end gap-0.5 shrink-0">
 							<span
-								class="text-[10px] font-[family-name:var(--font-mono)]"
+								class="sig-eyebrow"
 								class:text-[var(--sig-text-bright)]={h.exists}
 								class:text-[var(--sig-text-muted)]={!h.exists}
 							>
 								{h.exists ? "installed" : "not found"}
 							</span>
-							<span
-								class="text-[10px] text-[var(--sig-text-muted)]
-									font-[family-name:var(--font-mono)]"
-							>
+							<span class="sig-eyebrow">
 								{#if h.lastSeen}
 									seen {relativeTime(h.lastSeen)}
 								{:else}
@@ -167,19 +154,12 @@
 
 		<!-- Document Connectors -->
 		<section>
-			<h3
-				class="text-[11px] uppercase tracking-[0.1em] text-[var(--sig-text-muted)]
-					font-[family-name:var(--font-mono)] mb-3"
-			>
+			<h3 class="sig-label uppercase tracking-[0.1em] mb-3">
 				Document Connectors
 			</h3>
 			{#if connectors.length === 0}
-				<div
-					class="flex items-center justify-center py-8
-						text-[12px] text-[var(--sig-text-muted)]
-						font-[family-name:var(--font-mono)]
-						border border-dashed border-[var(--sig-border)]"
-				>
+				<div class="flex items-center justify-center py-8
+					sig-label border border-dashed border-[var(--sig-border)]">
 					No document connectors configured
 				</div>
 			{:else}
@@ -194,25 +174,17 @@
 								{conn.status}
 							</Badge>
 							<div class="flex flex-col gap-0.5 min-w-0 flex-1">
-								<span
-									class="text-[12px] font-medium text-[var(--sig-text-bright)]
-										font-[family-name:var(--font-display)] tracking-[0.04em]"
-								>
+								<span class="text-[12px] font-medium text-[var(--sig-text-bright)]
+									font-[family-name:var(--font-display)] tracking-[0.04em]">
 									{conn.display_name ?? conn.id}
 								</span>
-								<span
-									class="text-[10px] text-[var(--sig-text-muted)]
-										font-[family-name:var(--font-mono)]"
-								>
+								<span class="sig-eyebrow">
 									{conn.provider}
 								</span>
 							</div>
 							<div class="flex flex-col items-end gap-0.5 shrink-0">
 								<div class="flex items-center gap-2">
-									<span
-										class="text-[10px] text-[var(--sig-text-muted)]
-											font-[family-name:var(--font-mono)]"
-									>
+									<span class="sig-eyebrow">
 										{#if conn.status === "syncing" || syncingId === conn.id}
 											syncing...
 										{:else if conn.last_sync_at}
@@ -224,57 +196,52 @@
 									<Popover.Root open={syncMenuOpen === conn.id} onOpenChange={(open) => { syncMenuOpen = open ? conn.id : null; }}>
 										<Popover.Trigger>
 											{#snippet child({ props })}
-												<button
+												<Button
 													{...props}
-													type="button"
+													variant="outline"
+													size="sm"
 													disabled={conn.status === "syncing" || syncingId === conn.id}
-													class="px-2 py-0.5 text-[9px] uppercase tracking-[0.08em]
-														font-[family-name:var(--font-mono)] border
-														border-[var(--sig-border)] text-[var(--sig-text-muted)]
+													class="sig-meta uppercase tracking-[0.08em] px-2 py-0.5 h-auto
 														hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]
 														disabled:opacity-50 disabled:cursor-not-allowed"
 												>
 													Sync ▾
-												</button>
+												</Button>
 											{/snippet}
 										</Popover.Trigger>
 										<Popover.Content
 											align="end"
 											side="bottom"
 											class="w-[140px] p-1 bg-[var(--sig-surface-raised)]
-												border-[var(--sig-border-strong)] rounded-none"
+												border-[var(--sig-border-strong)] rounded-lg"
 										>
 											<div class="flex flex-col gap-1">
-												<button
-													type="button"
-													class="w-full text-left px-2 py-1 text-[10px]
-														uppercase tracking-[0.08em]
-														font-[family-name:var(--font-mono)] border
-														border-[var(--sig-border)] text-[var(--sig-text-muted)]
+												<Button
+													variant="outline"
+													size="sm"
+													class="w-full justify-start sig-eyebrow tracking-[0.08em] px-2 py-1 h-auto
 														hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
 													onclick={() => triggerSync(conn)}
 												>
 													Sync
-												</button>
-												<button
-													type="button"
-													class="w-full text-left px-2 py-1 text-[10px]
-														uppercase tracking-[0.08em]
-														font-[family-name:var(--font-mono)] border
-														border-[var(--sig-border)] text-[var(--sig-danger)]
+												</Button>
+												<Button
+													variant="outline"
+													size="sm"
+													class="w-full justify-start sig-eyebrow tracking-[0.08em] px-2 py-1 h-auto
+														text-[var(--sig-danger)]
 														hover:text-[var(--sig-text-bright)] hover:border-[var(--sig-danger)]"
 													onclick={() => triggerFullSync(conn)}
 												>
 													Full Resync
-												</button>
+												</Button>
 											</div>
 										</Popover.Content>
 									</Popover.Root>
 								</div>
 								{#if conn.last_error}
 									<span
-										class="text-[10px] text-[var(--sig-danger)]
-											font-[family-name:var(--font-mono)] truncate max-w-[200px]"
+										class="sig-eyebrow text-[var(--sig-danger)] truncate max-w-[200px]"
 										title={conn.last_error}
 									>
 										{conn.last_error}

--- a/packages/cli/dashboard/src/lib/components/tabs/LogsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/LogsTab.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { onMount } from "svelte";
 import * as Select from "$lib/components/ui/select/index.js";
+import { Button } from "$lib/components/ui/button/index.js";
 import { Checkbox } from "$lib/components/ui/checkbox/index.js";
 import { ScrollArea } from "$lib/components/ui/scroll-area/index.js";
 import { ActionLabels } from "$lib/ui/action-labels";
@@ -334,10 +335,10 @@ $effect(() => {
 <div class="flex flex-col flex-1 min-h-0">
 	<div class="flex items-center gap-[var(--space-sm)] px-[var(--space-md)] py-[var(--space-sm)] border-b border-[var(--sig-border)] shrink-0">
 		<Select.Root type="single" value={logLevelFilter} onValueChange={(v) => { logLevelFilter = v ?? ""; fetchLogs(); }}>
-			<Select.Trigger class="font-[family-name:var(--font-mono)] text-[length:var(--font-size-sm)] bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] text-[var(--sig-text-bright)] rounded-none h-auto py-1 px-2 min-w-[100px]">
+			<Select.Trigger class="font-[family-name:var(--font-mono)] text-[length:var(--font-size-sm)] bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] text-[var(--sig-text-bright)] rounded-lg h-auto py-1 px-2 min-w-[100px]">
 				{logLevelFilter || "All levels"}
 			</Select.Trigger>
-			<Select.Content class="bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] rounded-none">
+			<Select.Content class="bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] rounded-lg">
 				<Select.Item value="" label="All levels" />
 				{#each logLevels as level}
 					<Select.Item value={level} label={level} />
@@ -345,49 +346,53 @@ $effect(() => {
 			</Select.Content>
 		</Select.Root>
 		<Select.Root type="single" value={logCategoryFilter} onValueChange={(v) => { logCategoryFilter = v ?? ""; fetchLogs(); }}>
-			<Select.Trigger class="font-[family-name:var(--font-mono)] text-[length:var(--font-size-sm)] bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] text-[var(--sig-text-bright)] rounded-none h-auto py-1 px-2 min-w-[100px]">
+			<Select.Trigger class="font-[family-name:var(--font-mono)] text-[length:var(--font-size-sm)] bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] text-[var(--sig-text-bright)] rounded-lg h-auto py-1 px-2 min-w-[100px]">
 				{logCategoryFilter || "All categories"}
 			</Select.Trigger>
-			<Select.Content class="bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] rounded-none">
+			<Select.Content class="bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] rounded-lg">
 				<Select.Item value="" label="All categories" />
 				{#each logCategories as cat}
 					<Select.Item value={cat} label={cat} />
 				{/each}
 			</Select.Content>
 		</Select.Root>
-		<label class="flex items-center gap-1.5 text-[length:var(--font-size-sm)] text-[var(--sig-text)] cursor-pointer">
-			<Checkbox checked={logAutoScroll} onCheckedChange={(value: unknown) => { logAutoScroll = value === true; }} class="rounded-none" />
+		<label class="flex items-center gap-1.5 sig-label text-[var(--sig-text)] cursor-pointer">
+			<Checkbox checked={logAutoScroll} onCheckedChange={(value: unknown) => { logAutoScroll = value === true; }} class="rounded-lg" />
 			Auto-scroll
 		</label>
 		<span
-			class="text-[10px] font-[family-name:var(--font-mono)]"
+			class="sig-eyebrow"
 			class:text-[#4ade80]={logAutoScroll && logFollow}
 			class:text-[var(--sig-text-muted)]={!logAutoScroll || !logFollow}
 		>
 			{logAutoScroll && logFollow ? "following" : "paused"}
 		</span>
-		<button
-			class="text-[11px] px-2 py-1 border border-[var(--sig-border)] text-[var(--sig-text)] hover:border-[var(--sig-border-strong)] hover:text-[var(--sig-text-bright)]"
+		<Button
+			variant="outline"
+			size="sm"
+			class="sig-label px-2 py-1 h-auto hover:border-[var(--sig-border-strong)] hover:text-[var(--sig-text-bright)]"
 			onclick={fetchLogs}
 			title="Reload logs"
 		>
 			{ActionLabels.Refresh}
-		</button>
-		<button
-			class={`flex items-center justify-center w-7 h-7 bg-transparent border border-transparent cursor-pointer hover:text-[var(--sig-text)] hover:border-[var(--sig-border)] ${logsStreaming ? 'text-[var(--sig-success)]' : 'text-[var(--sig-text-muted)]'}`}
+		</Button>
+		<Button
+			variant="ghost"
+			size="sm"
+			class={`flex items-center justify-center w-7 h-7 p-0 hover:text-[var(--sig-text)] hover:border-[var(--sig-border)] ${logsStreaming ? 'text-[var(--sig-success)]' : 'text-[var(--sig-text-muted)]'}`}
 			onclick={toggleLogStream}
 			title={logsStreaming ? 'Stop stream' : logsReconnecting ? 'Cancel reconnect' : 'Start stream'}
 		>
 			{#if logsStreaming}
-				<span class="text-[var(--sig-success)] text-[length:var(--font-size-sm)] font-medium [animation:pulse_2s_infinite]">● Live</span>
+				<span class="text-[var(--sig-success)] sig-label font-medium [animation:pulse_2s_infinite]">● Live</span>
 			{:else if logsReconnecting}
-				<span class="text-[var(--sig-text-muted)] text-[length:var(--font-size-sm)] [animation:pulse_2s_infinite]">↺</span>
+				<span class="text-[var(--sig-text-muted)] sig-label [animation:pulse_2s_infinite]">↺</span>
 			{:else}
 				▶
 			{/if}
-		</button>
+		</Button>
 		{#if streamError}
-			<span class="text-[10px] text-[var(--sig-text-muted)] font-[family-name:var(--font-mono)] truncate max-w-[220px]">
+			<span class="sig-eyebrow truncate max-w-[220px]">
 				{streamError}
 			</span>
 		{/if}
@@ -433,12 +438,13 @@ $effect(() => {
 		<div class="min-h-0 overflow-auto p-[var(--space-md)] font-[family-name:var(--font-mono)] text-[length:var(--font-size-sm)]">
 			{#if selectedLog}
 				<div class="flex items-center justify-between gap-2 mb-[var(--space-sm)]">
-					<div class="text-[var(--sig-text-muted)] text-[length:var(--font-size-xs)] uppercase tracking-[0.08em]">Log details</div>
-					<button
-						type="button"
-						class="text-[10px] px-2 py-1 border border-[var(--sig-border)] text-[var(--sig-text)] hover:border-[var(--sig-border-strong)] hover:text-[var(--sig-text-bright)]"
+					<div class="sig-eyebrow tracking-[0.08em]">Log details</div>
+					<Button
+						variant="outline"
+						size="sm"
+						class="sig-eyebrow px-2 py-1 h-auto hover:border-[var(--sig-border-strong)] hover:text-[var(--sig-text-bright)]"
 						onclick={copySelectedLog}
-					>{copied ? "Copied" : ActionLabels.CopyJson}</button>
+					>{copied ? "Copied" : ActionLabels.CopyJson}</Button>
 				</div>
 				<div class="grid grid-cols-[80px_1fr] gap-y-1 gap-x-2 mb-[var(--space-sm)]">
 					<div class="text-[var(--sig-text-muted)]">Time</div>

--- a/packages/cli/dashboard/src/lib/components/tabs/MarketplaceTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/MarketplaceTab.svelte
@@ -236,7 +236,7 @@ function applySpotlight(item: SpotlightItem): void {
 		background: var(--sig-surface-raised);
 		border: 1px solid var(--sig-border-strong);
 		outline: none;
-		border-radius: 0;
+		border-radius: 0.5rem;
 	}
 
 	:global(.market-select) {
@@ -248,7 +248,7 @@ function applySpotlight(item: SpotlightItem): void {
 		background: var(--sig-surface-raised);
 		border: 1px solid var(--sig-border-strong);
 		outline: none;
-		border-radius: 0;
+		border-radius: 0.5rem;
 	}
 
 	.market-search:focus,
@@ -259,7 +259,7 @@ function applySpotlight(item: SpotlightItem): void {
 	:global(.market-select-content) {
 		background: var(--sig-surface-raised);
 		border: 1px solid var(--sig-border-strong);
-		border-radius: 0;
+		border-radius: 0.5rem;
 	}
 
 	:global(.market-select-item) {

--- a/packages/cli/dashboard/src/lib/components/tabs/MemoryTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/MemoryTab.svelte
@@ -12,6 +12,8 @@ import {
 } from "$lib/stores/memory.svelte";
 import MemoryForm from "$lib/components/memory/MemoryForm.svelte";
 import { Badge } from "$lib/components/ui/badge/index.js";
+import { Button } from "$lib/components/ui/button/index.js";
+import { Input } from "$lib/components/ui/input/index.js";
 import { ActionLabels } from "$lib/ui/action-labels";
 import * as Select from "$lib/components/ui/select/index.js";
 import * as Popover from "$lib/components/ui/popover/index.js";
@@ -96,13 +98,14 @@ function formatDate(dateStr: string): string {
 	}
 }
 
-const pillBase = "text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.08em] px-2 py-0.5 border cursor-pointer transition-colors duration-150";
+const pillBase = "sig-eyebrow tracking-[0.08em] px-2 py-0.5 border cursor-pointer transition-colors duration-150";
 const pillActive = `${pillBase} text-[var(--sig-accent)] border-[var(--sig-accent)] bg-[rgba(138,138,150,0.1)]`;
 const pillInactive = `${pillBase} text-[var(--sig-text-muted)] border-[var(--sig-border-strong)] bg-transparent hover:text-[var(--sig-text)]`;
 
-const inputClass = "text-[11px] font-[family-name:var(--font-mono)] text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)] border border-[var(--sig-border-strong)] rounded-none px-2 py-1 outline-none placeholder:text-[var(--sig-text-muted)]";
-const dateTriggerClass = `${inputClass} w-[130px] inline-flex items-center justify-between gap-2 cursor-pointer`;
-const dateClearClass = "text-[9px] px-1.5 py-1 border border-[var(--sig-border-strong)] rounded-none text-[var(--sig-text-muted)] bg-[var(--sig-surface-raised)] hover:text-[var(--sig-text-bright)]";
+const dateTriggerClass = "sig-label text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)] border border-[var(--sig-border-strong)] rounded-lg px-2 py-1 w-[130px] inline-flex items-center justify-between gap-2 cursor-pointer";
+
+const badgeBase = "sig-badge border-[var(--sig-border-strong)] text-[var(--sig-text)]";
+const badgeAccent = "sig-badge border-[var(--sig-accent)] text-[var(--sig-accent)]";
 
 let sincePickerOpen = $state(false);
 
@@ -145,38 +148,37 @@ function formatIsoDate(value: string): string {
 		border border-[var(--sig-border-strong)]
 		bg-[var(--sig-surface-raised)]">
 		{#if mem.debouncing || mem.searching}
-			<span class="text-[var(--sig-accent)] text-[11px] animate-pulse">◐</span>
+			<span class="text-[var(--sig-accent)] sig-label animate-pulse">◐</span>
 		{:else}
-			<span class="text-[var(--sig-accent)] text-[11px]">◇</span>
+			<span class="text-[var(--sig-accent)] sig-label">◇</span>
 		{/if}
-		<input
+		<Input
 			type="text"
-			class="flex-1 text-[12px] font-[family-name:var(--font-mono)]
-				text-[var(--sig-text-bright)] bg-transparent
-				border-none outline-none
-				placeholder:text-[var(--sig-text-muted)]"
+			class="flex-1 text-[12px] text-[var(--sig-text-bright)] bg-transparent
+				border-none shadow-none outline-none focus-visible:ring-0
+				placeholder:text-[var(--sig-text-muted)] h-auto py-0 px-0"
 			bind:value={mem.query}
 			oninput={queueMemorySearch}
 			onkeydown={(e) => e.key === 'Enter' && doSearch()}
 			placeholder="Search across memories..."
 		/>
 		{#if mem.searched || hasActiveFilters() || mem.similarSourceId}
-			<button
-				class="text-[10px] text-[var(--sig-accent)]
-					bg-transparent border-none cursor-pointer
-					hover:underline whitespace-nowrap"
+			<Button
+				variant="ghost"
+				size="sm"
+				class="sig-eyebrow text-[var(--sig-accent)] hover:underline whitespace-nowrap h-auto py-0 px-1"
 				onclick={clearAll}
-			>{ActionLabels.Clear}</button>
+			>{ActionLabels.Clear}</Button>
 		{/if}
 	</label>
 
 	<!-- Filter row -->
 	<div class="flex flex-wrap items-center gap-2">
 		<Select.Root type="single" value={mem.filterWho} onValueChange={(v) => { mem.filterWho = v ?? ""; }}>
-			<Select.Trigger class="font-[family-name:var(--font-mono)] text-[11px] bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] text-[var(--sig-text-bright)] rounded-none h-auto py-1 px-2 min-w-[120px] max-w-[180px]">
+			<Select.Trigger class="font-[family-name:var(--font-mono)] text-[11px] bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] text-[var(--sig-text-bright)] rounded-lg h-auto py-1 px-2 min-w-[120px] max-w-[180px]">
 				{mem.filterWho || "Any source"}
 			</Select.Trigger>
-			<Select.Content class="bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] rounded-none">
+			<Select.Content class="bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] rounded-lg">
 				<Select.Item value="" label="Any source" />
 				{#each mem.whoOptions as w}
 					<Select.Item value={w} label={w} />
@@ -184,15 +186,17 @@ function formatIsoDate(value: string): string {
 			</Select.Content>
 		</Select.Root>
 
-		<input
-			class="{inputClass} min-w-[120px] flex-1 max-w-[200px]"
+		<Input
+			class="sig-label min-w-[120px] flex-1 max-w-[200px] text-[var(--sig-text-bright)]
+				bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] rounded-lg h-auto py-1 px-2"
 			placeholder="Tags"
 			bind:value={mem.filterTags}
 		/>
 
-		<input
+		<Input
 			type="number"
-			class="{inputClass} w-[70px]"
+			class="sig-label w-[70px] text-[var(--sig-text-bright)]
+				bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] rounded-lg h-auto py-1 px-2"
 			min="0" max="1" step="0.1"
 			bind:value={mem.filterImportanceMin}
 			placeholder="imp"
@@ -208,7 +212,7 @@ function formatIsoDate(value: string): string {
 				{/snippet}
 			</Popover.Trigger>
 			<Popover.Content
-				class="w-auto overflow-hidden p-0 bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] rounded-none"
+				class="w-auto overflow-hidden p-0 bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] rounded-lg"
 				align="start"
 			>
 				<Calendar
@@ -219,14 +223,19 @@ function formatIsoDate(value: string): string {
 						mem.filterSince = toIsoDate(v);
 						sincePickerOpen = false;
 					}}
-					class="bg-[var(--sig-surface-raised)] text-[var(--sig-text)] rounded-none border-0 p-2"
+					class="bg-[var(--sig-surface-raised)] text-[var(--sig-text)] rounded-lg border-0 p-2"
 				/>
 			</Popover.Content>
 		</Popover.Root>
 		{#if mem.filterSince}
-			<button class={dateClearClass} onclick={() => { mem.filterSince = ""; }}>
+			<Button
+				variant="outline"
+				size="sm"
+				class="sig-meta px-1.5 py-1 rounded-lg h-auto border-[var(--sig-border-strong)] bg-[var(--sig-surface-raised)] hover:text-[var(--sig-text-bright)]"
+				onclick={() => { mem.filterSince = ""; }}
+			>
 				{ActionLabels.Clear}
-			</button>
+			</Button>
 		{/if}
 
 		<button
@@ -244,7 +253,7 @@ function formatIsoDate(value: string): string {
 	</div>
 
 	<!-- Count bar -->
-	<div class="flex items-center text-[10px] font-[family-name:var(--font-mono)] text-[var(--sig-text-muted)]">
+	<div class="flex items-center sig-eyebrow">
 		{#if mem.similarSourceId}
 			Showing {displayCount} similar {displayCount === 1 ? 'memory' : 'memories'}
 		{:else if mem.searched || hasActiveFilters()}
@@ -259,22 +268,21 @@ function formatIsoDate(value: string): string {
 		<div class="flex items-center justify-between gap-3
 			px-3 py-1.5 border border-dashed
 			border-[var(--sig-border-strong)]
-			text-[11px] font-[family-name:var(--font-mono)]
-			text-[var(--sig-text)] bg-[var(--sig-surface)]">
+			sig-label text-[var(--sig-text)] bg-[var(--sig-surface)]">
 			<span class="truncate">
 				Similar to: {(mem.similarSource.content ?? '').slice(0, 100)}
 				{(mem.similarSource.content ?? '').length > 100 ? '...' : ''}
 			</span>
-			<button
-				class="text-[11px] text-[var(--sig-accent)]
-					bg-transparent border-none cursor-pointer
-					hover:underline shrink-0"
+			<Button
+				variant="ghost"
+				size="sm"
+				class="sig-label text-[var(--sig-accent)] hover:underline shrink-0 h-auto py-0 px-1"
 				onclick={() => {
 					mem.similarSourceId = null;
 					mem.similarSource = null;
 					mem.similarResults = [];
 				}}
-			>Back</button>
+			>Back</Button>
 		</div>
 	{/if}
 
@@ -339,17 +347,15 @@ function formatIsoDate(value: string): string {
 
 					<header class="flex justify-between items-start gap-1.5">
 						<div class="flex items-center flex-wrap gap-1">
-							<Badge variant="outline" class="rounded-none font-[family-name:var(--font-mono)] text-[9px] py-px px-[5px] border-[var(--sig-accent)] text-[var(--sig-accent)]">{memory.who || 'unknown'}</Badge>
+							<Badge variant="outline" class={badgeAccent}>{memory.who || 'unknown'}</Badge>
 							{#if memory.type}
-								<Badge variant="outline" class="rounded-none font-[family-name:var(--font-mono)] text-[9px] py-px px-[5px] border-[var(--sig-border-strong)] text-[var(--sig-text)]">{memory.type}</Badge>
+								<Badge variant="outline" class={badgeBase}>{memory.type}</Badge>
 							{/if}
 							{#if memory.pinned}
-								<Badge variant="outline" class="rounded-none font-[family-name:var(--font-mono)] text-[9px] py-px px-[5px] border-[var(--sig-border-strong)] text-[var(--sig-text-bright)] bg-[rgba(255,255,255,0.06)]">pinned</Badge>
+								<Badge variant="outline" class="{badgeBase} text-[var(--sig-text-bright)] bg-[rgba(255,255,255,0.06)]">pinned</Badge>
 							{/if}
 						</div>
-						<span class="font-[family-name:var(--font-mono)]
-							text-[9px] text-[var(--sig-text-muted)]
-							whitespace-nowrap shrink-0">
+						<span class="sig-meta shrink-0">
 							{formatDate(memory.created_at)}
 						</span>
 					</header>
@@ -363,48 +369,58 @@ function formatIsoDate(value: string): string {
 					{#if tags.length > 0}
 						<div class="flex flex-wrap gap-1">
 							{#each tags.slice(0, 5) as tag}
-								<Badge variant="outline" class="rounded-none font-[family-name:var(--font-mono)] text-[9px] py-px px-[5px] border-[var(--sig-border-strong)] text-[var(--sig-text)]">#{tag}</Badge>
+								<Badge variant="outline" class={badgeBase}>#{tag}</Badge>
 							{/each}
 						</div>
 					{/if}
 
 					<footer class="flex items-center gap-1.5 mt-auto pt-1">
-						<Badge variant="outline" class="rounded-none font-[family-name:var(--font-mono)] text-[9px] py-px px-[5px] border-[var(--sig-border-strong)] text-[var(--sig-text)]">imp {Math.round((memory.importance ?? 0) * 100)}%</Badge>
+						<Badge variant="outline" class={badgeBase}>imp {Math.round((memory.importance ?? 0) * 100)}%</Badge>
 
 						{#if scoreLabel}
-							<Badge variant="outline" class="rounded-none font-[family-name:var(--font-mono)] text-[9px] py-px px-[5px] border-[var(--sig-border-strong)] text-[var(--sig-accent)]">{scoreLabel}</Badge>
+							<Badge variant="outline" class="{badgeBase} text-[var(--sig-accent)]">{scoreLabel}</Badge>
 						{/if}
 
 					{#if memory.id}
-						<button
-							class="rounded-none font-[family-name:var(--font-mono)] text-[9px] py-px px-[5px] border border-[var(--sig-border-strong)] text-[var(--sig-text-muted)] cursor-pointer hover:text-[var(--sig-accent)] transition-colors duration-100 bg-transparent"
+						<Button
+							variant="outline"
+							size="sm"
+							class="sig-badge py-px px-[5px] h-auto border-[var(--sig-border-strong)] text-[var(--sig-text-muted)] hover:text-[var(--sig-accent)]"
 							onclick={() => openEditForm(memory.id, "edit")}
 							title="Edit memory"
-						>edit</button>
+						>edit</Button>
 						{#if deleteConfirmId === memory.id}
 							<!-- Inline delete confirmation -->
-							<button
-								class="rounded-none font-[family-name:var(--font-mono)] text-[9px] py-px px-[5px] border border-red-500 text-red-400 cursor-pointer hover:bg-red-500 hover:text-white transition-colors duration-100 bg-transparent"
+							<Button
+								variant="outline"
+								size="sm"
+								class="sig-badge py-px px-[5px] h-auto border-red-500 text-red-400 hover:bg-red-500 hover:text-white"
 								onclick={() => { openEditForm(memory.id, "delete"); deleteConfirmId = null; }}
 								title="Confirm delete"
-							>confirm</button>
-							<button
-								class="rounded-none font-[family-name:var(--font-mono)] text-[9px] py-px px-[5px] border border-[var(--sig-border-strong)] text-[var(--sig-text-muted)] cursor-pointer hover:text-[var(--sig-text-bright)] transition-colors duration-100 bg-transparent"
+							>confirm</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								class="sig-badge py-px px-[5px] h-auto border-[var(--sig-border-strong)] text-[var(--sig-text-muted)] hover:text-[var(--sig-text-bright)]"
 								onclick={() => deleteConfirmId = null}
 								title="Cancel delete"
-							>cancel</button>
+							>cancel</Button>
 						{:else}
-							<button
-								class="rounded-none font-[family-name:var(--font-mono)] text-[9px] py-px px-[5px] border border-[var(--sig-border-strong)] text-[var(--sig-text-muted)] cursor-pointer hover:text-red-400 transition-colors duration-100 bg-transparent"
+							<Button
+								variant="outline"
+								size="sm"
+								class="sig-badge py-px px-[5px] h-auto border-[var(--sig-border-strong)] text-[var(--sig-text-muted)] hover:text-red-400"
 								onclick={() => deleteConfirmId = memory.id}
 								title="Delete memory"
-							>delete</button>
+							>delete</Button>
 						{/if}
-						<button
-							class="ml-auto rounded-none font-[family-name:var(--font-mono)] text-[9px] py-px px-[5px] border border-[var(--sig-border-strong)] text-[var(--sig-text-muted)] cursor-pointer hover:text-[var(--sig-accent)] transition-colors duration-100 bg-transparent"
+						<Button
+							variant="outline"
+							size="sm"
+							class="ml-auto sig-badge py-px px-[5px] h-auto border-[var(--sig-border-strong)] text-[var(--sig-text-muted)] hover:text-[var(--sig-accent)]"
 							onclick={() => findSimilar(memory.id, memory)}
 							title="Find similar"
-						>similar</button>
+						>similar</Button>
 					{/if}
 					</footer>
 				</article>

--- a/packages/cli/dashboard/src/lib/components/tabs/PipelineTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/PipelineTab.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from "svelte";
 	import { Badge } from "$lib/components/ui/badge/index.js";
+	import { Button } from "$lib/components/ui/button/index.js";
 	import * as Switch from "$lib/components/ui/switch/index.js";
 	import * as Popover from "$lib/components/ui/popover/index.js";
 	import PipelineGraph from "$lib/components/pipeline/PipelineGraph.svelte";
@@ -340,7 +341,7 @@
 					class:bg-[#f87171]={!pipeline.connected}
 					class:animate-pulse={pipeline.connected}
 				></span>
-				<span class="text-[10px] text-[var(--sig-text-muted)] font-[family-name:var(--font-mono)]">
+				<span class="sig-eyebrow">
 					{pipeline.connected ? "LIVE" : "DISCONNECTED"}
 				</span>
 			</div>
@@ -348,14 +349,14 @@
 			<!-- Pipeline mode -->
 			<Badge
 				variant="outline"
-				class="text-[9px] px-1.5 py-0 font-[family-name:var(--font-mono)] {modeClass}"
+				class="sig-badge px-1.5 py-0 {modeClass}"
 			>
 				{pipeline.mode}
 			</Badge>
 
 			<!-- Active nodes count -->
 			{#if activeCount > 0}
-				<span class="text-[10px] text-[#4ade80] font-[family-name:var(--font-mono)]">
+				<span class="sig-eyebrow text-[#4ade80]">
 					{activeCount} active
 				</span>
 			{/if}
@@ -363,7 +364,7 @@
 
 		<div class="flex items-center gap-3">
 			{#if pipeline.lastPoll}
-				<span class="text-[9px] text-[var(--sig-text-muted)] font-[family-name:var(--font-mono)]">
+				<span class="sig-meta">
 					polled {formatTime(pipeline.lastPoll)}
 				</span>
 			{/if}
@@ -384,15 +385,15 @@
 			<!-- Feed header -->
 			<div class="px-3 py-2 border-b border-[var(--sig-border)] space-y-2">
 				<div class="flex items-center justify-between gap-2">
-					<span class="text-[10px] uppercase tracking-[0.1em] text-[var(--sig-text-muted)] font-[family-name:var(--font-display)]">
+					<span class="sig-heading text-[10px]">
 						Live Feed
 					</span>
 					<div class="flex items-center gap-2">
-						<span class="text-[9px] text-[var(--sig-text-muted)] font-[family-name:var(--font-mono)]">
+						<span class="sig-meta">
 							{pipeline.feed.length} events
 						</span>
 						<span
-							class="text-[9px] font-[family-name:var(--font-mono)]"
+							class="sig-meta"
 							class:text-[#4ade80]={autoScroll && feedFollow}
 							class:text-[var(--sig-text-muted)]={!autoScroll || !feedFollow}
 						>
@@ -401,7 +402,7 @@
 					</div>
 				</div>
 				<div class="flex items-center justify-between gap-2 min-w-0">
-					<label class="inline-flex items-center gap-1.5 text-[10px] text-[var(--sig-text)] font-[family-name:var(--font-mono)] cursor-pointer min-w-0">
+					<label class="inline-flex items-center gap-1.5 sig-eyebrow text-[var(--sig-text)] cursor-pointer min-w-0">
 						<Switch.Root
 							checked={autoScroll}
 							onCheckedChange={(value: boolean) => handleAutoScrollChange(value)}
@@ -410,54 +411,59 @@
 						<span>Auto-scroll</span>
 					</label>
 					<div class="hidden lg:flex items-center gap-1.5 shrink-0">
-						<button
-							type="button"
-							class="px-2 py-[3px] text-[9px] uppercase tracking-[0.08em] font-[family-name:var(--font-mono)] border border-[var(--sig-border)] text-[var(--sig-text-muted)] hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
+						<Button
+							variant="outline"
+							size="sm"
+							class="sig-meta uppercase tracking-[0.08em] px-2 py-[3px] h-auto hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
 							onclick={(event: MouseEvent) => handleFeedJumpClick(event)}
 						>
 							{feedPositionLabel}
-						</button>
-						<button
-							type="button"
-							class="px-2 py-[3px] text-[9px] uppercase tracking-[0.08em] font-[family-name:var(--font-mono)] border border-[var(--sig-border)] text-[var(--sig-text-muted)] hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
+						</Button>
+						<Button
+							variant="outline"
+							size="sm"
+							class="sig-meta uppercase tracking-[0.08em] px-2 py-[3px] h-auto hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
 							onclick={(event: MouseEvent) => handleFeedWidthToggle(event)}
 						>
 							{feedDensityLabel}
-						</button>
+						</Button>
 					</div>
 					<div class="lg:hidden shrink-0">
 						<Popover.Root bind:open={mobileFeedActionsOpen}>
 							<Popover.Trigger>
 								{#snippet child({ props })}
-									<button
+									<Button
 										{...props}
-										type="button"
-										class="px-2 py-[3px] text-[9px] uppercase tracking-[0.08em] font-[family-name:var(--font-mono)] border border-[var(--sig-border)] text-[var(--sig-text-muted)] hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
+										variant="outline"
+										size="sm"
+										class="sig-meta uppercase tracking-[0.08em] px-2 py-[3px] h-auto hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
 									>
 										Feed actions
-									</button>
+									</Button>
 								{/snippet}
 							</Popover.Trigger>
 							<Popover.Content
 								align="end"
 								side="bottom"
-								class="w-[170px] p-1 bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] rounded-none"
+								class="w-[170px] p-1 bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] rounded-lg"
 							>
 								<div class="flex flex-col gap-1">
-									<button
-										type="button"
-										class="w-full text-left px-2 py-1 text-[10px] uppercase tracking-[0.08em] font-[family-name:var(--font-mono)] border border-[var(--sig-border)] text-[var(--sig-text-muted)] hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
+									<Button
+										variant="outline"
+										size="sm"
+										class="w-full justify-start sig-eyebrow tracking-[0.08em] px-2 py-1 h-auto hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
 										onclick={(event: MouseEvent) => handleFeedJumpClick(event)}
 									>
 										{feedPositionLabel}
-									</button>
-									<button
-										type="button"
-										class="w-full text-left px-2 py-1 text-[10px] uppercase tracking-[0.08em] font-[family-name:var(--font-mono)] border border-[var(--sig-border)] text-[var(--sig-text-muted)] hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
+									</Button>
+									<Button
+										variant="outline"
+										size="sm"
+										class="w-full justify-start sig-eyebrow tracking-[0.08em] px-2 py-1 h-auto hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
 										onclick={(event: MouseEvent) => handleFeedWidthToggle(event)}
 									>
 										{feedDensityLabel}
-									</button>
+									</Button>
 								</div>
 							</Popover.Content>
 						</Popover.Root>
@@ -482,7 +488,7 @@
 					<div class="feed-entry px-2 py-1.5 rounded hover:bg-[var(--sig-surface-raised)] transition-colors">
 						<div class="flex items-center gap-1.5">
 							<!-- Time -->
-							<span class="text-[9px] text-[var(--sig-text-muted)] font-[family-name:var(--font-mono)] shrink-0 w-[48px]">
+							<span class="sig-meta shrink-0 w-[48px]">
 								{formatTime(entry.timestamp)}
 							</span>
 							<!-- Level dot -->
@@ -492,7 +498,7 @@
 							></span>
 							<!-- Category -->
 							<span
-								class="text-[9px] font-[family-name:var(--font-mono)] shrink-0"
+								class="sig-meta shrink-0"
 								style="color: {catColor}"
 							>
 								{entry.category}
@@ -500,58 +506,58 @@
 						</div>
 						<!-- Message -->
 						{#if feedExpanded}
-							<div class="mt-1 pl-[56px] inline-flex items-center gap-2 text-[8px] uppercase tracking-[0.06em] font-[family-name:var(--font-mono)]">
-								<span class="px-1 py-[1px] border border-[var(--sig-border)] text-[var(--sig-text-muted)]">
+							<div class="mt-1 pl-[56px] inline-flex items-center gap-2 sig-micro">
+								<span class="px-1 py-[1px] border border-[var(--sig-border)]">
 									{processSummary}
 								</span>
-								<span class="text-[var(--sig-text-muted)]">{formatRelativeTime(entry.timestamp)}</span>
+								<span>{formatRelativeTime(entry.timestamp)}</span>
 							</div>
-							<div class="text-[10px] text-[var(--sig-text)] font-[family-name:var(--font-mono)] mt-0.5 pl-[56px] whitespace-pre-wrap break-words">
+							<div class="sig-eyebrow text-[var(--sig-text)] mt-0.5 pl-[56px] whitespace-pre-wrap break-words normal-case tracking-normal">
 								{entry.message}
 							</div>
-							<div class="mt-1 pl-[56px] grid grid-cols-1 md:grid-cols-2 gap-x-3 gap-y-1 text-[8px] font-[family-name:var(--font-mono)]">
+							<div class="mt-1 pl-[56px] grid grid-cols-1 md:grid-cols-2 gap-x-3 gap-y-1 sig-micro">
 								{#each metaRows as row}
 									<div class="flex items-start justify-between gap-2 border-b border-[var(--sig-border)]/30 pb-[1px]">
-										<span class="text-[var(--sig-text-muted)] uppercase tracking-[0.05em]">{row.label}</span>
-										<span class="text-[var(--sig-text)] break-all text-right">{row.value}</span>
+										<span class="text-[var(--sig-text-muted)]">{row.label}</span>
+										<span class="text-[var(--sig-text)] break-all text-right normal-case">{row.value}</span>
 									</div>
 								{/each}
 							</div>
 							{#if dataKeySummary}
-								<div class="mt-1 pl-[56px] text-[8px] text-[var(--sig-text-muted)] font-[family-name:var(--font-mono)] uppercase tracking-[0.05em]">
+								<div class="mt-1 pl-[56px] sig-micro">
 									Data keys: {dataKeySummary}
 								</div>
 							{/if}
 							{#if entry.error}
-								<div class="mt-1 pl-[56px] text-[9px] text-[#f87171] font-[family-name:var(--font-mono)] whitespace-pre-wrap break-words">
+								<div class="mt-1 pl-[56px] sig-meta text-[#f87171] whitespace-pre-wrap break-words">
 									{entry.error.name}: {entry.error.message}
 								</div>
 							{/if}
 							{#if rawPayload}
 								<details class="mt-1 pl-[56px]">
-									<summary class="cursor-pointer text-[8px] text-[var(--sig-text-muted)] uppercase tracking-[0.05em] font-[family-name:var(--font-mono)]">
+									<summary class="cursor-pointer sig-micro">
 										Raw payload
 									</summary>
-									<pre class="mt-1 p-2 border border-[var(--sig-border)] bg-[var(--sig-surface)] text-[8px] text-[var(--sig-text)] whitespace-pre-wrap break-words font-[family-name:var(--font-mono)]">{rawPayload}</pre>
+									<pre class="mt-1 p-2 border border-[var(--sig-border)] bg-[var(--sig-surface)] sig-micro text-[var(--sig-text)] whitespace-pre-wrap break-words normal-case">{rawPayload}</pre>
 								</details>
 							{/if}
 						{:else}
 							{#if canExpand}
 								<details class="mt-0.5 pl-[56px] group">
-									<summary class="list-none cursor-pointer text-[10px] text-[var(--sig-text)] font-[family-name:var(--font-mono)] line-clamp-2 break-words [&::-webkit-details-marker]:hidden">
+									<summary class="list-none cursor-pointer sig-eyebrow text-[var(--sig-text)] normal-case tracking-normal line-clamp-2 break-words [&::-webkit-details-marker]:hidden">
 										{entry.message}
 									</summary>
-									<div class="mt-1 text-[10px] text-[var(--sig-text)] font-[family-name:var(--font-mono)] whitespace-pre-wrap break-words">
+									<div class="mt-1 sig-eyebrow text-[var(--sig-text)] normal-case tracking-normal whitespace-pre-wrap break-words">
 										{entry.message}
 									</div>
 								</details>
 							{:else}
-								<div class="text-[10px] text-[var(--sig-text)] font-[family-name:var(--font-mono)] mt-0.5 pl-[56px] whitespace-pre-wrap break-words">
+								<div class="sig-eyebrow text-[var(--sig-text)] normal-case tracking-normal mt-0.5 pl-[56px] whitespace-pre-wrap break-words">
 									{entry.message}
 								</div>
 							{/if}
 							{#if entry.duration}
-								<span class="text-[8px] text-[var(--sig-text-muted)] font-[family-name:var(--font-mono)] pl-[56px]">
+								<span class="sig-micro pl-[56px]">
 									{entry.duration}ms
 								</span>
 							{/if}
@@ -559,7 +565,7 @@
 					</div>
 				{/each}
 				{#if pipeline.feed.length === 0}
-					<div class="flex items-center justify-center h-full text-[11px] text-[var(--sig-text-muted)] italic">
+					<div class="flex items-center justify-center h-full sig-label italic">
 						Waiting for events...
 					</div>
 				{/if}

--- a/packages/cli/dashboard/src/lib/components/tabs/SecretsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/SecretsTab.svelte
@@ -176,7 +176,7 @@ onMount(() => {
 			<div class="flex shrink-0 gap-[var(--space-sm)]">
 				<Input
 					type="text"
-					class="flex-1 rounded-none border-[var(--sig-border-strong)]
+					class="flex-1 rounded-lg border-[var(--sig-border-strong)]
 						bg-[var(--sig-surface-raised)] font-[family-name:var(--font-mono)]
 						text-[13px] text-[var(--sig-text-bright)]
 						focus:border-[var(--sig-accent)]"
@@ -185,7 +185,7 @@ onMount(() => {
 				/>
 				<Input
 					type="password"
-					class="flex-1 rounded-none border-[var(--sig-border-strong)]
+					class="flex-1 rounded-lg border-[var(--sig-border-strong)]
 						bg-[var(--sig-surface-raised)] font-[family-name:var(--font-mono)]
 						text-[13px] text-[var(--sig-text-bright)]
 						focus:border-[var(--sig-accent)]"
@@ -193,7 +193,7 @@ onMount(() => {
 					placeholder="Secret value"
 				/>
 				<Button
-					class="rounded-none bg-[var(--sig-text-bright)] text-[var(--sig-bg)]
+					class="rounded-lg bg-[var(--sig-text-bright)] text-[var(--sig-bg)]
 						hover:bg-[var(--sig-text)] text-[11px] font-medium"
 					size="sm"
 					onclick={addSecret}
@@ -216,7 +216,7 @@ onMount(() => {
 					{#each secrets as name}
 						<div
 							class="flex items-center gap-3 border border-[var(--sig-border-strong)]
-								bg-[var(--sig-surface-raised)] px-[var(--space-md)] py-3"
+								bg-[var(--sig-surface-raised)] px-[var(--space-md)] py-3 rounded-lg"
 						>
 							<span class="flex-1 font-[family-name:var(--font-mono)] text-[13px] text-[var(--sig-text-bright)]"
 								>{name}</span
@@ -227,7 +227,7 @@ onMount(() => {
 							<Button
 								variant="outline"
 								size="sm"
-								class="rounded-none border-[var(--sig-danger)] text-[var(--sig-danger)]
+								class="rounded-lg border-[var(--sig-danger)] text-[var(--sig-danger)]
 									text-[11px] hover:bg-[var(--sig-danger)] hover:text-[var(--sig-text-bright)]"
 								onclick={() => removeSecret(name)}
 								disabled={secretDeleting === name}
@@ -244,16 +244,16 @@ onMount(() => {
 			<div
 				class="flex min-h-0 flex-1 flex-col gap-[var(--space-sm)] overflow-hidden
 					border border-[var(--sig-border-strong)] bg-[var(--sig-surface-raised)]
-					p-[var(--space-md)]"
+					p-[var(--space-md)] rounded-lg"
 			>
 				<div class="flex items-center justify-between gap-3">
-					<div class="font-[family-name:var(--font-mono)] text-[12px] uppercase tracking-[0.08em] text-[var(--sig-text-muted)]">
+					<div class="sig-label uppercase tracking-[0.08em]">
 						1Password
 					</div>
 					<Button
 						variant="outline"
 						size="sm"
-						class="rounded-none text-[11px]"
+						class="rounded-lg text-[11px]"
 						onclick={refreshOnePasswordStatus}
 						disabled={onePasswordLoading}
 					>
@@ -284,7 +284,7 @@ onMount(() => {
 				<div class="flex gap-[var(--space-sm)]">
 					<Input
 						type="password"
-						class="rounded-none border-[var(--sig-border-strong)]
+						class="rounded-lg border-[var(--sig-border-strong)]
 							bg-[var(--sig-surface)] font-[family-name:var(--font-mono)]
 							text-[13px] text-[var(--sig-text-bright)]"
 						bind:value={onePasswordToken}
@@ -294,7 +294,7 @@ onMount(() => {
 					/>
 					<Button
 						size="sm"
-						class="rounded-none bg-[var(--sig-text-bright)] text-[var(--sig-bg)] text-[11px] hover:bg-[var(--sig-text)]"
+						class="rounded-lg bg-[var(--sig-text-bright)] text-[var(--sig-bg)] text-[11px] hover:bg-[var(--sig-text)]"
 						onclick={connectOnePasswordAccount}
 						disabled={onePasswordConnecting || !onePasswordToken.trim()}
 					>
@@ -313,7 +313,7 @@ onMount(() => {
 					<Input
 						id="op-prefix"
 						type="text"
-						class="h-8 rounded-none border-[var(--sig-border-strong)]
+						class="h-8 rounded-lg border-[var(--sig-border-strong)]
 							bg-[var(--sig-surface)] font-[family-name:var(--font-mono)]
 							text-[12px] text-[var(--sig-text-bright)]"
 						bind:value={onePasswordImportOptions.prefix}
@@ -331,7 +331,7 @@ onMount(() => {
 					</label>
 				</div>
 
-				<div class="min-h-0 flex-1 overflow-y-auto border border-[var(--sig-border)] p-2">
+				<div class="min-h-0 flex-1 overflow-y-auto border border-[var(--sig-border)] p-2 rounded-lg">
 					{#if !onePasswordStatus.connected}
 						<div class="px-2 py-3 text-[12px] text-[var(--sig-text-muted)]">
 							Connect first, then choose vaults to import. Leave all unchecked to import from every vault.
@@ -361,7 +361,7 @@ onMount(() => {
 				<div class="flex flex-wrap gap-[var(--space-sm)]">
 					<Button
 						size="sm"
-						class="rounded-none bg-[var(--sig-text-bright)] text-[var(--sig-bg)] text-[11px] hover:bg-[var(--sig-text)]"
+						class="rounded-lg bg-[var(--sig-text-bright)] text-[var(--sig-bg)] text-[11px] hover:bg-[var(--sig-text)]"
 						onclick={importFromOnePassword}
 						disabled={onePasswordImporting || !onePasswordStatus.connected}
 					>
@@ -370,7 +370,7 @@ onMount(() => {
 					<Button
 						variant="outline"
 						size="sm"
-						class="rounded-none border-[var(--sig-danger)] text-[var(--sig-danger)]
+						class="rounded-lg border-[var(--sig-danger)] text-[var(--sig-danger)]
 							text-[11px] hover:bg-[var(--sig-danger)] hover:text-[var(--sig-text-bright)]"
 						onclick={disconnectOnePasswordAccount}
 						disabled={onePasswordDisconnecting || !onePasswordStatus.configured}

--- a/packages/cli/dashboard/src/lib/components/tabs/SettingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/SettingsTab.svelte
@@ -492,7 +492,7 @@
 		padding: 0;
 		background: var(--sig-surface-raised);
 		border: 1px solid var(--sig-border-strong);
-		border-radius: 0;
+		border-radius: 0.5rem;
 	}
 
 	.jump-filter {

--- a/packages/cli/dashboard/src/lib/components/tabs/SkillsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/SkillsTab.svelte
@@ -330,7 +330,7 @@ onMount(() => {
 		min-height: 28px;
 		outline: none;
 		cursor: pointer;
-		border-radius: 0;
+		border-radius: 0.5rem;
 	}
 	:global(.sort-select:focus) {
 		border-color: var(--sig-accent);
@@ -339,7 +339,7 @@ onMount(() => {
 	:global(.sort-select-content) {
 		background: var(--sig-surface-raised);
 		border: 1px solid var(--sig-border-strong);
-		border-radius: 0;
+		border-radius: 0.5rem;
 	}
 
 	:global(.sort-select-item) {

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/AuthSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/AuthSection.svelte
@@ -6,10 +6,10 @@ import * as Select from "$lib/components/ui/select/index.js";
 import { st } from "$lib/stores/settings.svelte";
 
 const selectTriggerClass =
-	"font-[family-name:var(--font-mono)] text-[11px] text-[var(--sig-text)] bg-[var(--sig-bg)] border-[var(--sig-border-strong)] rounded-none w-full h-auto min-h-[30px] px-2 py-[5px] box-border focus-visible:border-[var(--sig-accent)]";
+	"font-[family-name:var(--font-mono)] text-[11px] text-[var(--sig-text)] bg-[var(--sig-bg)] border-[var(--sig-border-strong)] rounded-lg w-full h-auto min-h-[30px] px-2 py-[5px] box-border focus-visible:border-[var(--sig-accent)]";
 const selectContentClass =
-	"font-[family-name:var(--font-mono)] text-[11px] bg-[var(--sig-bg)] text-[var(--sig-text)] border-[var(--sig-border-strong)] rounded-none";
-const selectItemClass = "font-[family-name:var(--font-mono)] text-[11px] rounded-none";
+	"font-[family-name:var(--font-mono)] text-[11px] bg-[var(--sig-bg)] text-[var(--sig-text)] border-[var(--sig-border-strong)] rounded-lg";
+const selectItemClass = "font-[family-name:var(--font-mono)] text-[11px] rounded-lg";
 
 function setSelect(path: string[]) {
 	return (v: string | undefined) => {

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/EmbeddingsSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/EmbeddingsSection.svelte
@@ -6,10 +6,10 @@
 	import { st } from "$lib/stores/settings.svelte";
 
 	const selectTriggerClass =
-		"font-[family-name:var(--font-mono)] text-[11px] text-[var(--sig-text)] bg-[var(--sig-bg)] border-[var(--sig-border-strong)] rounded-none w-full h-auto min-h-[30px] px-2 py-[5px] box-border focus-visible:border-[var(--sig-accent)]";
+		"font-[family-name:var(--font-mono)] text-[11px] text-[var(--sig-text)] bg-[var(--sig-bg)] border-[var(--sig-border-strong)] rounded-lg w-full h-auto min-h-[30px] px-2 py-[5px] box-border focus-visible:border-[var(--sig-accent)]";
 	const selectContentClass =
-		"font-[family-name:var(--font-mono)] text-[11px] bg-[var(--sig-bg)] text-[var(--sig-text)] border-[var(--sig-border-strong)] rounded-none";
-	const selectItemClass = "font-[family-name:var(--font-mono)] text-[11px] rounded-none";
+		"font-[family-name:var(--font-mono)] text-[11px] bg-[var(--sig-bg)] text-[var(--sig-text)] border-[var(--sig-border-strong)] rounded-lg";
+	const selectItemClass = "font-[family-name:var(--font-mono)] text-[11px] rounded-lg";
 
 	function handleProviderChange(v: string | undefined) {
 		st.sSetStr([...st.embPath(), "provider"], v ?? "");

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
@@ -15,10 +15,10 @@ import {
 } from "$lib/stores/settings.svelte";
 
 const selectTriggerClass =
-	"font-[family-name:var(--font-mono)] text-[11px] text-[var(--sig-text)] bg-[var(--sig-bg)] border-[var(--sig-border-strong)] rounded-none w-full h-auto min-h-[30px] px-2 py-[5px] box-border focus-visible:border-[var(--sig-accent)]";
+	"font-[family-name:var(--font-mono)] text-[11px] text-[var(--sig-text)] bg-[var(--sig-bg)] border-[var(--sig-border-strong)] rounded-lg w-full h-auto min-h-[30px] px-2 py-[5px] box-border focus-visible:border-[var(--sig-accent)]";
 const selectContentClass =
-	"font-[family-name:var(--font-mono)] text-[11px] bg-[var(--sig-bg)] text-[var(--sig-text)] border-[var(--sig-border-strong)] rounded-none";
-const selectItemClass = "font-[family-name:var(--font-mono)] text-[11px] rounded-none";
+	"font-[family-name:var(--font-mono)] text-[11px] bg-[var(--sig-bg)] text-[var(--sig-text)] border-[var(--sig-border-strong)] rounded-lg";
+const selectItemClass = "font-[family-name:var(--font-mono)] text-[11px] rounded-lg";
 
 function setNum(path: string[]) {
 	return (e: Event) => {

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/TrustSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/TrustSection.svelte
@@ -6,10 +6,10 @@ import * as Select from "$lib/components/ui/select/index.js";
 import { st } from "$lib/stores/settings.svelte";
 
 const selectTriggerClass =
-	"font-[family-name:var(--font-mono)] text-[11px] text-[var(--sig-text)] bg-[var(--sig-bg)] border-[var(--sig-border-strong)] rounded-none w-full h-auto min-h-[30px] px-2 py-[5px] box-border focus-visible:border-[var(--sig-accent)]";
+	"font-[family-name:var(--font-mono)] text-[11px] text-[var(--sig-text)] bg-[var(--sig-bg)] border-[var(--sig-border-strong)] rounded-lg w-full h-auto min-h-[30px] px-2 py-[5px] box-border focus-visible:border-[var(--sig-accent)]";
 const selectContentClass =
-	"font-[family-name:var(--font-mono)] text-[11px] bg-[var(--sig-bg)] text-[var(--sig-text)] border-[var(--sig-border-strong)] rounded-none";
-const selectItemClass = "font-[family-name:var(--font-mono)] text-[11px] rounded-none";
+	"font-[family-name:var(--font-mono)] text-[11px] bg-[var(--sig-bg)] text-[var(--sig-text)] border-[var(--sig-border-strong)] rounded-lg";
+const selectItemClass = "font-[family-name:var(--font-mono)] text-[11px] rounded-lg";
 
 function setSelect(path: string[]) {
 	return (v: string | undefined) => {

--- a/packages/cli/dashboard/src/lib/components/ui/spinner/index.ts
+++ b/packages/cli/dashboard/src/lib/components/ui/spinner/index.ts
@@ -1,0 +1,1 @@
+export { default as Spinner } from "./spinner.svelte";

--- a/packages/cli/dashboard/src/lib/components/ui/spinner/spinner.svelte
+++ b/packages/cli/dashboard/src/lib/components/ui/spinner/spinner.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import Loader2Icon from "@lucide/svelte/icons/loader-2";
+	import type { ComponentProps } from "svelte";
+
+	let { class: className, ...restProps }: ComponentProps<typeof Loader2Icon> = $props();
+</script>
+
+<Loader2Icon
+	role="status"
+	aria-label="Loading"
+	class={cn("size-4 animate-spin", className)}
+	{...restProps}
+/>

--- a/packages/cli/dashboard/src/lib/stores/navigation.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/navigation.svelte.ts
@@ -42,14 +42,44 @@ export const nav = $state({
 	activeTab: "config" as TabId,
 });
 
+/* ── Tab groups (display-layer only) ── */
+
+const MEMORY_TABS: ReadonlySet<TabId> = new Set(["memory", "embeddings"]);
+const ENGINE_TABS: ReadonlySet<TabId> = new Set([
+	"settings",
+	"pipeline",
+	"connectors",
+	"logs",
+]);
+
+export type NavGroup = "memory" | "engine";
+
+const lastMemoryTab = $state({ value: "memory" as TabId });
+const lastEngineTab = $state({ value: "settings" as TabId });
+
+export function isMemoryGroup(tab: TabId): boolean {
+	return MEMORY_TABS.has(tab);
+}
+export function isEngineGroup(tab: TabId): boolean {
+	return ENGINE_TABS.has(tab);
+}
+
 export function setTab(tab: TabId): boolean {
 	if (tab === nav.activeTab) return true;
 	if (!confirmDiscardChanges(`switch to ${tab}`)) return false;
 	nav.activeTab = tab;
+	if (MEMORY_TABS.has(tab)) lastMemoryTab.value = tab;
+	if (ENGINE_TABS.has(tab)) lastEngineTab.value = tab;
 	if (typeof window !== "undefined") {
 		history.replaceState(null, "", `#${tab}`);
 	}
 	return true;
+}
+
+export function navigateToGroup(group: NavGroup): boolean {
+	const tab =
+		group === "memory" ? lastMemoryTab.value : lastEngineTab.value;
+	return setTab(tab);
 }
 
 /**

--- a/packages/cli/dashboard/src/routes/+page.svelte
+++ b/packages/cli/dashboard/src/routes/+page.svelte
@@ -17,14 +17,25 @@ import {
 	mem,
 	queueMemorySearch,
 } from "$lib/stores/memory.svelte";
-import { initNavFromHash, nav, setTab } from "$lib/stores/navigation.svelte";
+import {
+	initNavFromHash,
+	isEngineGroup,
+	isMemoryGroup,
+	nav,
+	setTab,
+} from "$lib/stores/navigation.svelte";
 import { sk } from "$lib/stores/skills.svelte";
 import { openForm, ts } from "$lib/stores/tasks.svelte";
 import { hasUnsavedChanges } from "$lib/stores/unsaved-changes.svelte";
+import { Skeleton } from "$lib/components/ui/skeleton/index.js";
 import Plus from "@lucide/svelte/icons/plus";
 import { onMount } from "svelte";
 
 const activeTab = $derived(nav.activeTab);
+
+const tabBtn = "px-2.5 py-0.5 sig-label uppercase tracking-[0.06em] rounded-md transition-colors duration-150 border-none cursor-pointer";
+const tabActive = `${tabBtn} bg-[var(--sig-accent)] text-[var(--sig-bg)]`;
+const tabInactive = `${tabBtn} bg-transparent text-[var(--sig-text-muted)] hover:bg-[var(--sig-surface-raised)] hover:text-[var(--sig-text-bright)]`;
 
 const { data } = $props();
 let daemonStatus = $state<DaemonStatus | null>(null);
@@ -149,53 +160,82 @@ onMount(() => {
 		>
 			<div class="flex items-center gap-2">
 				<Sidebar.Trigger class="-ml-1" />
-				<span
-					class="text-[11px] font-bold uppercase tracking-[0.1em]
-						text-[var(--sig-text-bright)]
-						font-[family-name:var(--font-display)]"
-				>
+				<span class="sig-heading">
 					{PAGE_HEADERS[activeTab].title}
 				</span>
-				<span class="text-[10px] text-[var(--sig-text-muted)]">&middot;</span>
-				<span
-					class="text-[10px] uppercase tracking-[0.1em]
-						text-[var(--sig-text-muted)]
-						font-[family-name:var(--font-mono)]"
-				>
-					{PAGE_HEADERS[activeTab].eyebrow}
-				</span>
+				{#if !isMemoryGroup(activeTab) && !isEngineGroup(activeTab)}
+					<span class="sig-eyebrow tracking-[0.1em]">&middot;</span>
+					<span class="sig-eyebrow tracking-[0.1em]">
+						{PAGE_HEADERS[activeTab].eyebrow}
+					</span>
+				{/if}
+
+				{#if isMemoryGroup(activeTab)}
+					<span class="ml-1 w-px h-4 bg-[var(--sig-border)]"></span>
+					<div class="flex items-center gap-px
+						border border-[var(--sig-border)] rounded-lg p-px">
+						<button
+							class={activeTab === 'memory' ? tabActive : tabInactive}
+							onclick={() => setTab("memory")}
+						>Index</button>
+						<button
+							class={activeTab === 'embeddings' ? tabActive : tabInactive}
+							onclick={() => setTab("embeddings")}
+						>Constellation</button>
+					</div>
+				{:else if isEngineGroup(activeTab)}
+					<span class="ml-1 w-px h-4 bg-[var(--sig-border)]"></span>
+					<div class="flex items-center gap-px
+						border border-[var(--sig-border)] rounded-lg p-px">
+						<button
+							class={activeTab === 'settings' ? tabActive : tabInactive}
+							onclick={() => setTab("settings")}
+						>Settings</button>
+						<button
+							class={activeTab === 'pipeline' ? tabActive : tabInactive}
+							onclick={() => setTab("pipeline")}
+						>Pipeline</button>
+						<button
+							class={activeTab === 'connectors' ? tabActive : tabInactive}
+							onclick={() => setTab("connectors")}
+						>Connectors</button>
+						<button
+							class={activeTab === 'logs' ? tabActive : tabInactive}
+							onclick={() => setTab("logs")}
+						>Logs</button>
+					</div>
+				{/if}
 			</div>
 			<div class="flex items-center gap-3">
 				{#if activeTab === "memory"}
-					<span class="text-[11px] text-[var(--sig-text-muted)]">
+					<span class="sig-label">
 						{displayMemories.length} documents
 					</span>
 					{#if mem.searching}
-						<span class="text-[11px] text-[var(--sig-text-muted)]">
+						<span class="sig-label">
 							searching...
 						</span>
 					{/if}
 					{#if mem.searched || hasActiveFilters() || mem.similarSourceId}
-						<button
-							class="text-[11px] text-[var(--sig-accent)]
-								bg-transparent border-none cursor-pointer
-								hover:underline p-0"
+						<Button
+							variant="ghost"
+							size="sm"
+							class="sig-label text-[var(--sig-accent)] hover:underline p-0 h-auto"
 							onclick={clearAll}
 						>
 							Reset
-						</button>
+						</Button>
 					{/if}
 				{:else if activeTab === "pipeline"}
-					<span class="text-[11px] text-[var(--sig-text-muted)]">
+					<span class="sig-label">
 						Memory loop
 					</span>
 				{:else if activeTab === "embeddings"}
-					<span class="text-[11px] text-[var(--sig-text-muted)]">
+					<span class="sig-label">
 						Constellation
 					</span>
 				{:else if activeTab === "skills"}
-					<span class="text-[10px] text-[var(--sig-text-muted)]
-						font-[family-name:var(--font-mono)]">
+					<span class="sig-eyebrow">
 						{#if sk.catalogTotal || mcpMarket.catalogTotal}
 							{(sk.catalogTotal + mcpMarket.catalogTotal).toLocaleString()} listed
 							<span class="text-[var(--sig-border-strong)]">&middot;</span>
@@ -219,89 +259,153 @@ onMount(() => {
 		<ExtensionBanner />
 
 		<div class="flex flex-1 flex-col min-h-0 relative">
+			{#snippet skeletonError(error: unknown)}
+				<div class="flex flex-1 items-center justify-center sig-label text-[var(--sig-danger)]">
+					Failed to load tab: {error instanceof Error ? error.message : "unknown error"}
+				</div>
+			{/snippet}
+
+			{#snippet skeletonEditor()}
+				<div class="flex flex-1 min-h-0">
+					<div class="w-48 border-r border-[var(--sig-border)] p-3 space-y-2">
+						<Skeleton class="h-4 w-full" />
+						<Skeleton class="h-4 w-3/4" />
+						<Skeleton class="h-4 w-5/6" />
+						<Skeleton class="h-4 w-2/3" />
+					</div>
+					<div class="flex-1 p-4 space-y-2">
+						{#each Array(12) as _}
+							<Skeleton class="h-3.5 w-full" />
+						{/each}
+						<Skeleton class="h-3.5 w-2/3" />
+					</div>
+				</div>
+			{/snippet}
+
+			{#snippet skeletonCards()}
+				<div class="p-4 space-y-3">
+					<Skeleton class="h-9 w-full" />
+					<div class="flex gap-2">
+						<Skeleton class="h-7 w-24" />
+						<Skeleton class="h-7 w-20" />
+						<Skeleton class="h-7 w-16" />
+					</div>
+					<div class="grid grid-cols-3 gap-3">
+						{#each Array(6) as _}
+							<Skeleton class="h-36 w-full" />
+						{/each}
+					</div>
+				</div>
+			{/snippet}
+
+			{#snippet skeletonList()}
+				<div class="p-4 space-y-2">
+					<div class="flex gap-2 mb-3">
+						<Skeleton class="h-8 w-28" />
+						<Skeleton class="h-8 w-28" />
+					</div>
+					{#each Array(8) as _}
+						<Skeleton class="h-8 w-full" />
+					{/each}
+				</div>
+			{/snippet}
+
+			{#snippet skeletonForm()}
+				<div class="p-4 space-y-4 max-w-2xl">
+					{#each Array(5) as _}
+						<div class="space-y-1.5">
+							<Skeleton class="h-3 w-24" />
+							<Skeleton class="h-9 w-full" />
+						</div>
+					{/each}
+				</div>
+			{/snippet}
+
 			{#if activeTab === "config"}
-				{#await import("$lib/components/tabs/ConfigTab.svelte") then module}
+				{#await import("$lib/components/tabs/ConfigTab.svelte")}
+					{@render skeletonEditor()}
+				{:then module}
 					<module.default
 						configFiles={data.configFiles}
 						{selectedFile}
 						onselectfile={selectFile}
 					/>
 				{:catch error}
-					<div class="flex flex-1 items-center justify-center text-[12px] text-[var(--sig-danger)] font-[family-name:var(--font-mono)]">
-						Failed to load tab: {error instanceof Error ? error.message : "unknown error"}
-					</div>
+					{@render skeletonError(error)}
 				{/await}
 			{:else if activeTab === "settings"}
-				{#await import("$lib/components/tabs/SettingsTab.svelte") then module}
+				{#await import("$lib/components/tabs/SettingsTab.svelte")}
+					{@render skeletonForm()}
+				{:then module}
 					<module.default configFiles={data.configFiles} />
 				{:catch error}
-					<div class="flex flex-1 items-center justify-center text-[12px] text-[var(--sig-danger)] font-[family-name:var(--font-mono)]">
-						Failed to load tab: {error instanceof Error ? error.message : "unknown error"}
-					</div>
+					{@render skeletonError(error)}
 				{/await}
 			{:else if activeTab === "memory"}
-				{#await import("$lib/components/tabs/MemoryTab.svelte") then module}
+				{#await import("$lib/components/tabs/MemoryTab.svelte")}
+					{@render skeletonCards()}
+				{:then module}
 					<module.default memories={memoryDocs} />
 				{:catch error}
-					<div class="flex flex-1 items-center justify-center text-[12px] text-[var(--sig-danger)] font-[family-name:var(--font-mono)]">
-						Failed to load tab: {error instanceof Error ? error.message : "unknown error"}
-					</div>
+					{@render skeletonError(error)}
 				{/await}
 			{:else if activeTab === "embeddings"}
-				{#await import("$lib/components/tabs/EmbeddingsTab.svelte") then module}
+				{#await import("$lib/components/tabs/EmbeddingsTab.svelte")}
+					<div class="flex flex-1 items-center justify-center">
+						<Skeleton class="h-64 w-64 rounded-full" />
+					</div>
+				{:then module}
 					<module.default onopenglobalsimilar={openGlobalSimilar} />
 				{:catch error}
-					<div class="flex flex-1 items-center justify-center text-[12px] text-[var(--sig-danger)] font-[family-name:var(--font-mono)]">
-						Failed to load tab: {error instanceof Error ? error.message : "unknown error"}
-					</div>
+					{@render skeletonError(error)}
 				{/await}
 			{:else if activeTab === "pipeline"}
-				{#await import("$lib/components/tabs/PipelineTab.svelte") then module}
+				{#await import("$lib/components/tabs/PipelineTab.svelte")}
+					{@render skeletonList()}
+				{:then module}
 					<module.default />
 				{:catch error}
-					<div class="flex flex-1 items-center justify-center text-[12px] text-[var(--sig-danger)] font-[family-name:var(--font-mono)]">
-						Failed to load tab: {error instanceof Error ? error.message : "unknown error"}
-					</div>
+					{@render skeletonError(error)}
 				{/await}
 			{:else if activeTab === "logs"}
-				{#await import("$lib/components/tabs/LogsTab.svelte") then module}
+				{#await import("$lib/components/tabs/LogsTab.svelte")}
+					{@render skeletonList()}
+				{:then module}
 					<module.default />
 				{:catch error}
-					<div class="flex flex-1 items-center justify-center text-[12px] text-[var(--sig-danger)] font-[family-name:var(--font-mono)]">
-						Failed to load tab: {error instanceof Error ? error.message : "unknown error"}
-					</div>
+					{@render skeletonError(error)}
 				{/await}
 			{:else if activeTab === "secrets"}
-				{#await import("$lib/components/tabs/SecretsTab.svelte") then module}
+				{#await import("$lib/components/tabs/SecretsTab.svelte")}
+					{@render skeletonList()}
+				{:then module}
 					<module.default />
 				{:catch error}
-					<div class="flex flex-1 items-center justify-center text-[12px] text-[var(--sig-danger)] font-[family-name:var(--font-mono)]">
-						Failed to load tab: {error instanceof Error ? error.message : "unknown error"}
-					</div>
+					{@render skeletonError(error)}
 				{/await}
 			{:else if activeTab === "skills"}
-				{#await import("$lib/components/tabs/MarketplaceTab.svelte") then module}
+				{#await import("$lib/components/tabs/MarketplaceTab.svelte")}
+					{@render skeletonCards()}
+				{:then module}
 					<module.default />
 				{:catch error}
-					<div class="flex flex-1 items-center justify-center text-[12px] text-[var(--sig-danger)] font-[family-name:var(--font-mono)]">
-						Failed to load tab: {error instanceof Error ? error.message : "unknown error"}
-					</div>
+					{@render skeletonError(error)}
 				{/await}
 			{:else if activeTab === "tasks"}
-				{#await import("$lib/components/tabs/TasksTab.svelte") then module}
+				{#await import("$lib/components/tabs/TasksTab.svelte")}
+					{@render skeletonList()}
+				{:then module}
 					<module.default />
 				{:catch error}
-					<div class="flex flex-1 items-center justify-center text-[12px] text-[var(--sig-danger)] font-[family-name:var(--font-mono)]">
-						Failed to load tab: {error instanceof Error ? error.message : "unknown error"}
-					</div>
+					{@render skeletonError(error)}
 				{/await}
 			{:else if activeTab === "connectors"}
-				{#await import("$lib/components/tabs/ConnectorsTab.svelte") then module}
+				{#await import("$lib/components/tabs/ConnectorsTab.svelte")}
+					{@render skeletonList()}
+				{:then module}
 					<module.default />
 				{:catch error}
-					<div class="flex flex-1 items-center justify-center text-[12px] text-[var(--sig-danger)] font-[family-name:var(--font-mono)]">
-						Failed to load tab: {error instanceof Error ? error.message : "unknown error"}
-					</div>
+					{@render skeletonError(error)}
 				{/await}
 			{/if}
 		</div>
@@ -310,8 +414,7 @@ onMount(() => {
 			class="flex items-center justify-between h-[26px] px-4
 				border-t border-[var(--sig-border)]
 				bg-[var(--sig-surface)]
-				text-[10px] text-[var(--sig-text-muted)]
-				font-[family-name:var(--font-mono)] shrink-0"
+				sig-eyebrow shrink-0"
 		>
 			{#if activeTab === "config"}
 				<span>{selectedFile}</span>


### PR DESCRIPTION
## Summary

- Refactored dashboard sidebar from 10 flat nav items to 6 grouped items
- **Memory** group: Index + Constellation with sub-tab pill bar
- **Engine** group: Settings + Pipeline + Connectors + Logs with sub-tab pill bar
- All existing deep links (`#pipeline`, `#embeddings`, `#logs`, etc.) still work
- Icon refresh across all nav items (Pencil, Brain, ShieldCheck, Store, ListChecks, Cog)
- Font swap: Geist Mono replaces IBM Plex Mono, Diamond Grotesk added as display with Chakra Petch fallback
- Global 8px border-radius via `--radius` CSS variable across all components
- Skeleton loading states for every lazy-loaded tab (no more blank flash)
- Extracted repeated inline styles into utility classes (`sig-label`, `sig-eyebrow`, `sig-heading`, `sig-meta`, `sig-badge`, `sig-micro`)
- Replaced raw `<button>` and `<input>` elements with shadcn-svelte `Button` and `Input` across tab components

## Test plan

- [ ] Sidebar shows 6 items with correct icons
- [ ] Clicking Memory shows index view, sub-tab bar toggles to Constellation
- [ ] Clicking Engine shows settings, sub-tab bar toggles between Settings/Pipeline/Connectors/Logs
- [ ] Direct URL navigation works: `#pipeline`, `#embeddings`, `#logs`, `#connectors`
- [ ] Sidebar highlights correctly for grouped items
- [ ] Collapsed sidebar (icon-only mode) still works
- [ ] Skeleton loading appears briefly on first tab switch
- [ ] Border radius consistent across all components (8px)
- [ ] Fonts render correctly (Geist Mono for body, Diamond Grotesk/Chakra Petch for display)