### PR TITLE
fix(embedding): resolve native embedding regression and restore ollama support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/adapters/openclaw": {
       "name": "@signetai/signet-memory-openclaw",
-      "version": "0.31.0",
+      "version": "0.35.2",
       "dependencies": {
         "@sinclair/typebox": "0.34.47",
       },
@@ -22,7 +22,7 @@
     },
     "packages/cli": {
       "name": "@signet/cli",
-      "version": "0.31.0",
+      "version": "0.35.2",
       "bin": "./dist/cli.js",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
@@ -44,7 +44,7 @@
     },
     "packages/connector-base": {
       "name": "@signet/connector-base",
-      "version": "0.31.0",
+      "version": "0.35.2",
       "dependencies": {
         "@signet/core": "workspace:*",
       },
@@ -58,7 +58,7 @@
     },
     "packages/connector-claude-code": {
       "name": "@signet/connector-claude-code",
-      "version": "0.31.0",
+      "version": "0.35.2",
       "dependencies": {
         "@signet/connector-base": "workspace:*",
         "@signet/core": "workspace:*",
@@ -70,7 +70,7 @@
     },
     "packages/connector-openclaw": {
       "name": "@signet/connector-openclaw",
-      "version": "0.31.0",
+      "version": "0.35.2",
       "dependencies": {
         "@signet/connector-base": "workspace:*",
       },
@@ -81,7 +81,7 @@
     },
     "packages/connector-opencode": {
       "name": "@signet/connector-opencode",
-      "version": "0.31.0",
+      "version": "0.35.2",
       "dependencies": {
         "@signet/connector-base": "workspace:*",
         "@signet/core": "workspace:*",
@@ -93,7 +93,7 @@
     },
     "packages/core": {
       "name": "@signet/core",
-      "version": "0.31.0",
+      "version": "0.35.2",
       "dependencies": {
         "sqlite-vec": "^0.1.7-alpha.2",
         "yaml": "^2.6.0",
@@ -113,7 +113,7 @@
     },
     "packages/daemon": {
       "name": "@signet/daemon",
-      "version": "0.31.0",
+      "version": "0.35.2",
       "bin": {
         "signet-daemon": "./dist/daemon.js",
         "signet-mcp": "./dist/mcp-stdio.js",
@@ -128,6 +128,8 @@
         "cron-parser": "^5.5.0",
         "hono": "^4.8.0",
         "libsodium-wrappers": "^0.8.2",
+        "onnxruntime-node": "1.21.0",
+        "sharp": "^0.34.1",
         "umap-js": "^1.4.0",
         "zod": "^4.3.6",
       },
@@ -137,7 +139,7 @@
     },
     "packages/extension": {
       "name": "@signet/extension",
-      "version": "0.31.0",
+      "version": "0.35.2",
       "devDependencies": {
         "@types/chrome": "^0.0.287",
         "typescript": "^5.7.0",
@@ -145,14 +147,14 @@
     },
     "packages/opencode-plugin": {
       "name": "@signet/opencode-plugin",
-      "version": "0.31.0",
+      "version": "0.35.2",
       "peerDependencies": {
         "@opencode-ai/plugin": ">=0.1.0",
       },
     },
     "packages/sdk": {
       "name": "@signet/sdk",
-      "version": "0.31.0",
+      "version": "0.35.2",
       "devDependencies": {
         "@types/react": "^19.0.0",
         "react": "^19.0.0",
@@ -168,19 +170,21 @@
     },
     "packages/signetai": {
       "name": "signetai",
-      "version": "0.31.0",
+      "version": "0.35.2",
       "bin": {
         "signet": "bin/signet.js",
         "signet-mcp": "dist/mcp-stdio.js",
       },
       "dependencies": {
         "@hono/node-server": "^1.14.0",
+        "@huggingface/transformers": "^3.4.0",
         "@inquirer/prompts": "^7.0.0",
         "chalk": "^5.3.0",
         "chokidar": "^4.0.0",
         "commander": "^12.0.0",
         "hono": "^4.8.0",
         "libsodium-wrappers": "^0.8.2",
+        "onnxruntime-node": "1.21.0",
         "open": "^10.0.0",
         "ora": "^8.0.0",
         "sqlite-vec": "^0.1.7-alpha.2",
@@ -190,12 +194,13 @@
         "@types/libsodium-wrappers": "^0.8.2",
       },
       "optionalDependencies": {
+        "@1password/sdk": "^0.3.0",
         "better-sqlite3": "^12.0.0",
       },
     },
     "packages/tray": {
       "name": "@signet/tray",
-      "version": "0.31.0",
+      "version": "0.35.2",
       "dependencies": {
         "@signet/sdk": "workspace:*",
         "@tauri-apps/api": "^2.5.0",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -39,6 +39,7 @@
     "hono": "^4.8.0",
     "libsodium-wrappers": "^0.8.2",
     "@huggingface/transformers": "^3.4.0",
+    "onnxruntime-node": "1.21.0",
     "sharp": "^0.34.1",
     "umap-js": "^1.4.0",
     "zod": "^4.3.6"

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -230,26 +230,53 @@ interface EmbeddingStatus {
 // Cached native embed function — avoids dynamic import on every call
 let cachedNativeEmbed: ((text: string) => Promise<number[]>) | null = null;
 
+async function fetchOllamaEmbedding(text: string, baseUrl: string, model: string): Promise<number[] | null> {
+	const res = await fetch(`${baseUrl.replace(/\/$/, "")}/api/embeddings`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ model, prompt: text }),
+		signal: AbortSignal.timeout(30000),
+	});
+	if (!res.ok) return null;
+	const data = (await res.json()) as { embedding: number[] };
+	return data.embedding ?? null;
+}
+
+// Track whether we've already fallen back to ollama for native failures
+let nativeFallbackToOllama = false;
+
 async function fetchEmbedding(text: string, cfg: EmbeddingConfig): Promise<number[] | null> {
 	if (cfg.provider === "none") return null;
 	try {
 		if (cfg.provider === "native") {
-			if (!cachedNativeEmbed) {
-				const mod = await import("./native-embedding");
-				cachedNativeEmbed = mod.nativeEmbed;
+			// If we've already determined native is broken, go straight to ollama
+			if (nativeFallbackToOllama) {
+				return await fetchOllamaEmbedding(text, "http://localhost:11434", "nomic-embed-text");
 			}
-			return await cachedNativeEmbed(text);
+			try {
+				if (!cachedNativeEmbed) {
+					const mod = await import("./native-embedding");
+					cachedNativeEmbed = mod.nativeEmbed;
+				}
+				return await cachedNativeEmbed(text);
+			} catch (nativeErr) {
+				// Native failed — try ollama as fallback
+				logger.warn("embedding", `Native embedding failed, attempting ollama fallback: ${nativeErr instanceof Error ? nativeErr.message : String(nativeErr)}`);
+				try {
+					const result = await fetchOllamaEmbedding(text, "http://localhost:11434", "nomic-embed-text");
+					if (result !== null) {
+						nativeFallbackToOllama = true;
+						logger.info("embedding", "Ollama fallback succeeded — will use ollama for remaining embeddings this session");
+						return result;
+					}
+				} catch {
+					// ollama also not available
+				}
+				return null;
+			}
 		}
 		if (cfg.provider === "ollama") {
-			const res = await fetch(`${cfg.base_url.replace(/\/$/, "")}/api/embeddings`, {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ model: cfg.model, prompt: text }),
-				signal: AbortSignal.timeout(30000),
-			});
-			if (!res.ok) return null;
-			const data = (await res.json()) as { embedding: number[] };
-			return data.embedding ?? null;
+			return await fetchOllamaEmbedding(text, cfg.base_url, cfg.model);
 		} else {
 			// OpenAI-compatible
 			const apiKey = cfg.api_key ?? process.env.OPENAI_API_KEY ?? "";
@@ -641,10 +668,36 @@ async function checkEmbeddingProvider(cfg: EmbeddingConfig): Promise<EmbeddingSt
 			// Reuse the cached module from fetchEmbedding path
 			const mod = await import("./native-embedding");
 			const nativeStatus = await mod.checkNativeProvider();
-			status.available = nativeStatus.available;
-			status.dimensions = nativeStatus.dimensions;
-			if (!nativeStatus.available) {
-				status.error = nativeStatus.error ?? "Native embedding provider not ready";
+			if (nativeStatus.available) {
+				status.available = true;
+				status.dimensions = nativeStatus.dimensions;
+			} else {
+				// Native unavailable — check if ollama is available as fallback
+				logger.warn("embedding", `Native provider unavailable: ${nativeStatus.error ?? "unknown"}`);
+				try {
+					const ollamaRes = await fetch("http://localhost:11434/api/tags", {
+						method: "GET",
+						signal: AbortSignal.timeout(3000),
+					});
+					if (ollamaRes.ok) {
+						const ollamaData = (await ollamaRes.json()) as { models?: { name: string }[] };
+						const models = ollamaData.models ?? [];
+						const hasNomic = models.some((m) => m.name.startsWith("nomic-embed-text"));
+						if (hasNomic) {
+							status.available = true;
+							status.dimensions = 768;
+							status.error = "Native unavailable — using ollama fallback";
+							nativeFallbackToOllama = true;
+							logger.info("embedding", "Ollama fallback available — will use ollama for embeddings");
+						} else {
+							status.error = `Native: ${nativeStatus.error ?? "not ready"}. Ollama available but nomic-embed-text not found.`;
+						}
+					} else {
+						status.error = `Native: ${nativeStatus.error ?? "not ready"}. Ollama not available.`;
+					}
+				} catch {
+					status.error = `Native: ${nativeStatus.error ?? "not ready"}. Ollama not reachable.`;
+				}
 			}
 		} else if (cfg.provider === "ollama") {
 			// Check Ollama API availability

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -269,8 +269,9 @@ async function fetchEmbedding(text: string, cfg: EmbeddingConfig): Promise<numbe
 						logger.info("embedding", "Ollama fallback succeeded — will use ollama for remaining embeddings this session");
 						return result;
 					}
+					logger.warn("embedding", "Ollama fallback also failed");
 				} catch {
-					// ollama also not available
+					logger.warn("embedding", "Ollama fallback not reachable");
 				}
 				return null;
 			}

--- a/packages/daemon/src/memory-config.test.ts
+++ b/packages/daemon/src/memory-config.test.ts
@@ -93,25 +93,25 @@ describe("loadMemoryConfig", () => {
 		expect(cfg.embedding.dimensions).toBe(768);
 	});
 
-	it("auto-migrates ollama+nomic-embed-text to native provider", () => {
+	it("respects ollama+nomic-embed-text config without overriding", () => {
 		const agentsDir = makeTempAgentsDir();
 		writeFileSync(
 			join(agentsDir, "agent.yaml"),
 			"embedding:\n  provider: ollama\n  model: nomic-embed-text\n  dimensions: 768\n",
 		);
 		const cfg = loadMemoryConfig(agentsDir);
-		expect(cfg.embedding.provider).toBe("native");
-		expect(cfg.embedding.model).toBe("nomic-embed-text-v1.5");
+		expect(cfg.embedding.provider).toBe("ollama");
+		expect(cfg.embedding.model).toBe("nomic-embed-text");
 	});
 
-	it("auto-migrates ollama+nomic-embed-text:latest to native", () => {
+	it("respects ollama+nomic-embed-text:latest config without overriding", () => {
 		const agentsDir = makeTempAgentsDir();
 		writeFileSync(
 			join(agentsDir, "agent.yaml"),
 			"embedding:\n  provider: ollama\n  model: nomic-embed-text:latest\n  dimensions: 768\n",
 		);
 		const cfg = loadMemoryConfig(agentsDir);
-		expect(cfg.embedding.provider).toBe("native");
+		expect(cfg.embedding.provider).toBe("ollama");
 	});
 
 	it("does NOT migrate ollama+bge-large (non-nomic model)", () => {

--- a/packages/daemon/src/memory-config.ts
+++ b/packages/daemon/src/memory-config.ts
@@ -544,19 +544,6 @@ export function loadMemoryConfig(agentsDir: string): ResolvedMemoryConfig {
 				defaults.search.rehearsal_half_life_days = Math.max(1, srch.rehearsal_half_life_days);
 			}
 
-			// Auto-migrate ollama+nomic users to native provider
-			if (
-				defaults.embedding.provider === "ollama" &&
-				(defaults.embedding.model === "nomic-embed-text" ||
-					defaults.embedding.model === "nomic-embed-text-v1.5" ||
-					defaults.embedding.model.startsWith("nomic-embed-text:"))
-			) {
-				defaults.embedding.provider = "native";
-				defaults.embedding.model = "nomic-embed-text-v1.5";
-				defaults.embedding.base_url = "";
-				console.info("[signet] Using native embedding provider (runtime override for ollama+nomic config)");
-			}
-
 			defaults.pipelineV2 = loadPipelineConfig(yaml);
 			defaults.auth = parseAuthConfig(yaml.auth, agentsDir);
 


### PR DESCRIPTION
## Summary

- **Add missing `onnxruntime-node` dependency** to daemon's package.json — the build externalized it but never declared it, causing "Unable to get model file path or buffer" on all platforms
- **Remove silent ollama-to-native auto-migration** — users who explicitly configure `provider: ollama` now get ollama instead of being force-switched to the broken native path
- **Add native→ollama fallback** — when native embedding init fails, the daemon checks for local ollama as a fallback so embeddings don't go completely dark

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds
- [x] memory-config tests updated and passing (26/26)
- [x] native-embedding tests passing (8/8)
- [ ] Manual: start daemon with `provider: native` — verify no "model file path" error
- [ ] Manual: set `provider: ollama` in agent.yaml — verify ollama is used (not overridden)
- [ ] Manual: stop ollama, set `provider: native` with broken ONNX — verify fallback logs