### PR TITLE
fix(connectors): add harness and connector re-sync actions

### DIFF
--- a/packages/cli/dashboard/src/lib/api.ts
+++ b/packages/cli/dashboard/src/lib/api.ts
@@ -657,6 +657,16 @@ export interface SyncResult {
 	message?: string;
 }
 
+export interface BulkConnectorSyncResult {
+	status: string;
+	total: number;
+	started: number;
+	alreadySyncing: number;
+	unsupported: number;
+	failed: number;
+	error?: string;
+}
+
 export async function syncConnector(id: string): Promise<SyncResult> {
 	try {
 		const response = await fetch(`${API_BASE}/api/connectors/${encodeURIComponent(id)}/sync`, { method: "POST" });
@@ -674,6 +684,56 @@ export async function syncConnectorFull(id: string): Promise<SyncResult> {
 		return await response.json();
 	} catch (e) {
 		return { status: "error", error: e instanceof Error ? e.message : String(e) };
+	}
+}
+
+export async function resyncConnectors(): Promise<BulkConnectorSyncResult> {
+	try {
+		const response = await fetch(`${API_BASE}/api/connectors/resync`, { method: "POST" });
+		const body = (await response.json().catch(() => null)) as
+			| {
+					status?: unknown;
+					total?: unknown;
+					started?: unknown;
+					alreadySyncing?: unknown;
+					unsupported?: unknown;
+					failed?: unknown;
+					error?: unknown;
+			  }
+			| null;
+
+		const status = typeof body?.status === "string" ? body.status : response.ok ? "ok" : "error";
+		const total = typeof body?.total === "number" ? body.total : 0;
+		const started = typeof body?.started === "number" ? body.started : 0;
+		const alreadySyncing = typeof body?.alreadySyncing === "number" ? body.alreadySyncing : 0;
+		const unsupported = typeof body?.unsupported === "number" ? body.unsupported : 0;
+		const failed = typeof body?.failed === "number" ? body.failed : 0;
+		const error =
+			typeof body?.error === "string"
+				? body.error
+				: response.ok
+					? undefined
+					: `HTTP ${response.status}`;
+
+		return {
+			status,
+			total,
+			started,
+			alreadySyncing,
+			unsupported,
+			failed,
+			error,
+		};
+	} catch (e) {
+		return {
+			status: "error",
+			total: 0,
+			started: 0,
+			alreadySyncing: 0,
+			unsupported: 0,
+			failed: 0,
+			error: e instanceof Error ? e.message : String(e),
+		};
 	}
 }
 

--- a/packages/cli/dashboard/src/lib/components/tabs/ConnectorsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/ConnectorsTab.svelte
@@ -6,6 +6,8 @@
 	import {
 		getHarnesses,
 		getConnectors,
+		regenerateHarnesses,
+		resyncConnectors,
 		syncConnector,
 		syncConnectorFull,
 		type Harness,
@@ -18,6 +20,8 @@
 	let loading = $state(true);
 	let syncingId = $state<string | null>(null);
 	let syncMenuOpen = $state<string | null>(null);
+	let harnessResyncing = $state(false);
+	let connectorsResyncing = $state(false);
 
 	function relativeTime(iso: string | null): string {
 		if (!iso) return "never";
@@ -41,10 +45,80 @@
 	}
 
 	async function load() {
-		const [h, c] = await Promise.all([getHarnesses(), getConnectors()]);
-		harnesses = h;
-		connectors = c;
-		loading = false;
+		try {
+			const [h, c] = await Promise.all([getHarnesses(), getConnectors()]);
+			harnesses = h;
+			connectors = c;
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function triggerHarnessResync(): Promise<void> {
+		harnessResyncing = true;
+		try {
+			const result = await regenerateHarnesses();
+			if (!result.success) {
+				toast(`Harness re-sync failed: ${result.error ?? "unknown error"}`, "error");
+				return;
+			}
+			toast(result.message ?? "Harness re-sync completed", "success");
+			await load();
+		} catch (e) {
+			toast(
+				`Harness re-sync failed: ${e instanceof Error ? e.message : String(e)}`,
+				"error",
+			);
+		} finally {
+			harnessResyncing = false;
+		}
+	}
+
+	function buildConnectorResyncMessage(result: {
+		started: number;
+		alreadySyncing: number;
+		unsupported: number;
+		failed: number;
+		total: number;
+	}): string {
+		const parts: string[] = [];
+		parts.push(`Started ${result.started}`);
+		if (result.alreadySyncing > 0) parts.push(`${result.alreadySyncing} already syncing`);
+		if (result.unsupported > 0) parts.push(`${result.unsupported} unsupported`);
+		if (result.failed > 0) parts.push(`${result.failed} failed`);
+		parts.push(`of ${result.total}`);
+		return `Connector re-sync summary: ${parts.join(", ")}`;
+	}
+
+	async function triggerConnectorsResync(): Promise<void> {
+		if (connectors.length === 0) {
+			toast("No document connectors configured", "error");
+			return;
+		}
+
+		connectorsResyncing = true;
+		try {
+			const result = await resyncConnectors();
+			if (result.status === "error") {
+				toast(`Connector re-sync failed: ${result.error ?? "unknown error"}`, "error");
+				return;
+			}
+
+			const message = buildConnectorResyncMessage(result);
+			if (result.failed > 0) {
+				toast(message, "error");
+			} else {
+				toast(message, "success");
+			}
+			await load();
+		} catch (e) {
+			toast(
+				`Connector re-sync failed: ${e instanceof Error ? e.message : String(e)}`,
+				"error",
+			);
+		} finally {
+			connectorsResyncing = false;
+		}
 	}
 
 	async function triggerSync(conn: DocumentConnector): Promise<void> {
@@ -106,9 +180,20 @@
 	{:else}
 		<!-- Platform Harnesses -->
 		<section>
-			<h3 class="sig-label uppercase tracking-[0.1em] mb-3">
-				Platform Harnesses
-			</h3>
+			<div class="flex items-center justify-between mb-3 gap-3">
+				<h3 class="sig-label uppercase tracking-[0.1em]">
+					Platform Harnesses
+				</h3>
+				<Button
+					variant="outline"
+					size="sm"
+					disabled={harnessResyncing}
+					class="sig-meta uppercase tracking-[0.08em] h-auto px-2 py-1"
+					onclick={triggerHarnessResync}
+				>
+					{harnessResyncing ? "Re-syncing..." : "Re-sync Harnesses"}
+				</Button>
+			</div>
 			<div class="grid gap-2">
 				{#each harnesses as h (h.id)}
 					<div
@@ -154,9 +239,20 @@
 
 		<!-- Document Connectors -->
 		<section>
-			<h3 class="sig-label uppercase tracking-[0.1em] mb-3">
-				Document Connectors
-			</h3>
+			<div class="flex items-center justify-between mb-3 gap-3">
+				<h3 class="sig-label uppercase tracking-[0.1em]">
+					Document Connectors
+				</h3>
+				<Button
+					variant="outline"
+					size="sm"
+					disabled={connectorsResyncing || connectors.length === 0}
+					class="sig-meta uppercase tracking-[0.08em] h-auto px-2 py-1"
+					onclick={triggerConnectorsResync}
+				>
+					{connectorsResyncing ? "Re-syncing..." : "Re-sync Connectors"}
+				</Button>
+			</div>
 			{#if connectors.length === 0}
 				<div class="flex items-center justify-center py-8
 					sig-label border border-dashed border-[var(--sig-border)]">

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3624,6 +3624,99 @@ app.delete("/api/documents/:id", async (c) => {
 // Connectors API
 // ============================================================================
 
+type ConnectorSyncStartOutcome =
+	| { status: "syncing" }
+	| { status: "already-syncing" }
+	| { status: "unsupported"; provider: string }
+	| { status: "error"; error: string };
+
+function startConnectorSync(
+	connectorId: string,
+	mode: "incremental" | "full",
+): ConnectorSyncStartOutcome {
+	const accessor = getDbAccessor();
+	const connectorRow = getConnector(accessor, connectorId);
+	if (!connectorRow) {
+		return { status: "error", error: "Connector not found" };
+	}
+
+	if (connectorRow.status === "syncing") {
+		return { status: "already-syncing" };
+	}
+
+	let config: {
+		id: string;
+		provider: "filesystem" | "github-docs" | "gdrive";
+		displayName: string;
+		settings: Record<string, unknown>;
+		enabled: boolean;
+	};
+	try {
+		config = JSON.parse(connectorRow.config_json) as {
+			id: string;
+			provider: "filesystem" | "github-docs" | "gdrive";
+			displayName: string;
+			settings: Record<string, unknown>;
+			enabled: boolean;
+		};
+	} catch {
+		return { status: "error", error: "Connector config is invalid JSON" };
+	}
+
+	if (config.provider !== "filesystem") {
+		return { status: "unsupported", provider: config.provider };
+	}
+
+	updateConnectorStatus(accessor, connectorId, "syncing");
+	const connector = createFilesystemConnector(config, accessor);
+
+	let incrementalCursor:
+		| {
+				lastSyncAt: string;
+				checkpoint?: string;
+				version?: number;
+		  }
+		| null = null;
+	if (mode === "incremental") {
+		if (!connectorRow.cursor_json) {
+			incrementalCursor = { lastSyncAt: new Date(0).toISOString() };
+		} else {
+			try {
+				incrementalCursor = JSON.parse(connectorRow.cursor_json) as {
+					lastSyncAt: string;
+					checkpoint?: string;
+					version?: number;
+				};
+			} catch {
+				incrementalCursor = { lastSyncAt: new Date(0).toISOString() };
+			}
+		}
+	}
+
+	const syncPromise =
+		mode === "full"
+			? connector.syncFull()
+			: connector.syncIncremental(incrementalCursor ?? { lastSyncAt: new Date(0).toISOString() });
+
+	syncPromise
+		.then((result) => {
+			updateCursor(accessor, connectorId, result.cursor);
+			updateConnectorStatus(accessor, connectorId, "idle");
+			logger.info("connectors", mode === "full" ? "Full sync completed" : "Sync completed", {
+				connectorId,
+				added: result.documentsAdded,
+				updated: result.documentsUpdated,
+			});
+		})
+		.catch((err) => {
+			const msg = err instanceof Error ? err.message : String(err);
+			updateConnectorStatus(accessor, connectorId, "error", msg);
+			logger.error("connectors", mode === "full" ? "Full sync failed" : "Sync failed", new Error(msg));
+		});
+
+	return { status: "syncing" };
+}
+
 // GET /api/connectors — list all connectors
 app.get("/api/connectors", (c) => {
 	try {
@@ -3689,58 +3782,56 @@ app.get("/api/connectors/:id", (c) => {
 // POST /api/connectors/:id/sync — trigger incremental sync
 app.post("/api/connectors/:id/sync", async (c) => {
 	const id = c.req.param("id");
-	const accessor = getDbAccessor();
-
-	const connectorRow = getConnector(accessor, id);
-	if (!connectorRow) return c.json({ error: "Connector not found" }, 404);
-
-	if (connectorRow.status === "syncing") {
+	const outcome = startConnectorSync(id, "incremental");
+	if (outcome.status === "error") return c.json({ error: outcome.error }, 404);
+	if (outcome.status === "already-syncing") {
 		return c.json({ status: "syncing", message: "Already syncing" });
 	}
-
-	const config = JSON.parse(connectorRow.config_json) as {
-		id: string;
-		provider: "filesystem" | "github-docs" | "gdrive";
-		displayName: string;
-		settings: Record<string, unknown>;
-		enabled: boolean;
-	};
-
-	// Only filesystem is supported for now
-	if (config.provider !== "filesystem") {
-		return c.json({ error: `Provider ${config.provider} not yet supported` }, 501);
+	if (outcome.status === "unsupported") {
+		return c.json({ error: `Provider ${outcome.provider} not yet supported` }, 501);
 	}
-
-	updateConnectorStatus(accessor, id, "syncing");
-
-	// Fire and forget — caller polls GET /api/connectors/:id for status
-	const connector = createFilesystemConnector(config, accessor);
-	const cursor = connectorRow.cursor_json
-		? (JSON.parse(connectorRow.cursor_json) as {
-				lastSyncAt: string;
-				checkpoint?: string;
-				version?: number;
-			})
-		: { lastSyncAt: new Date(0).toISOString() };
-
-	connector
-		.syncIncremental(cursor)
-		.then((result) => {
-			updateCursor(accessor, id, result.cursor);
-			updateConnectorStatus(accessor, id, "idle");
-			logger.info("connectors", "Sync completed", {
-				connectorId: id,
-				added: result.documentsAdded,
-				updated: result.documentsUpdated,
-			});
-		})
-		.catch((err) => {
-			const msg = err instanceof Error ? err.message : String(err);
-			updateConnectorStatus(accessor, id, "error", msg);
-			logger.error("connectors", "Sync failed", new Error(msg));
-		});
-
 	return c.json({ status: "syncing" });
+});
+
+// POST /api/connectors/resync — trigger incremental sync for all connectors
+app.post("/api/connectors/resync", async (c) => {
+	try {
+		const accessor = getDbAccessor();
+		const connectors = listConnectors(accessor);
+
+		let started = 0;
+		let alreadySyncing = 0;
+		let unsupported = 0;
+		let failed = 0;
+
+		for (const conn of connectors) {
+			const outcome = startConnectorSync(conn.id, "incremental");
+			if (outcome.status === "syncing") started++;
+			if (outcome.status === "already-syncing") alreadySyncing++;
+			if (outcome.status === "unsupported") unsupported++;
+			if (outcome.status === "error") failed++;
+		}
+
+		return c.json({
+			status: "ok",
+			total: connectors.length,
+			started,
+			alreadySyncing,
+			unsupported,
+			failed,
+		});
+	} catch (e) {
+		logger.error("connectors", "Failed to trigger bulk resync", e as Error);
+		return c.json({
+			status: "error",
+			error: "Failed to trigger connector re-sync",
+			total: 0,
+			started: 0,
+			alreadySyncing: 0,
+			unsupported: 0,
+			failed: 0,
+		}, 500);
+	}
 });
 
 // POST /api/connectors/:id/sync/full — trigger full resync
@@ -3751,41 +3842,14 @@ app.post("/api/connectors/:id/sync/full", async (c) => {
 		return c.json({ error: "Full resync requires ?confirm=true" }, 400);
 	}
 
-	const accessor = getDbAccessor();
-	const connectorRow = getConnector(accessor, id);
-	if (!connectorRow) return c.json({ error: "Connector not found" }, 404);
-
-	const config = JSON.parse(connectorRow.config_json) as {
-		id: string;
-		provider: "filesystem" | "github-docs" | "gdrive";
-		displayName: string;
-		settings: Record<string, unknown>;
-		enabled: boolean;
-	};
-
-	if (config.provider !== "filesystem") {
-		return c.json({ error: `Provider ${config.provider} not yet supported` }, 501);
+	const outcome = startConnectorSync(id, "full");
+	if (outcome.status === "error") return c.json({ error: outcome.error }, 404);
+	if (outcome.status === "already-syncing") {
+		return c.json({ status: "syncing", message: "Already syncing" });
 	}
-
-	updateConnectorStatus(accessor, id, "syncing");
-
-	const connector = createFilesystemConnector(config, accessor);
-
-	connector
-		.syncFull()
-		.then((result) => {
-			updateCursor(accessor, id, result.cursor);
-			updateConnectorStatus(accessor, id, "idle");
-			logger.info("connectors", "Full sync completed", {
-				connectorId: id,
-				added: result.documentsAdded,
-			});
-		})
-		.catch((err) => {
-			const msg = err instanceof Error ? err.message : String(err);
-			updateConnectorStatus(accessor, id, "error", msg);
-			logger.error("connectors", "Full sync failed", new Error(msg));
-		});
+	if (outcome.status === "unsupported") {
+		return c.json({ error: `Provider ${outcome.provider} not yet supported` }, 501);
+	}
 
 	return c.json({ status: "syncing" });
 });

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -29,6 +29,9 @@ import {
 	parseSimpleYaml,
 	stripSignetBlock,
 	vectorSearch,
+	CONNECTOR_PROVIDERS,
+	type ConnectorConfig,
+	type SyncCursor,
 } from "@signet/core";
 import { watch } from "chokidar";
 import { type Context, Hono } from "hono";
@@ -3644,24 +3647,25 @@ function startConnectorSync(
 		return { status: "already-syncing" };
 	}
 
-	let config: {
-		id: string;
-		provider: "filesystem" | "github-docs" | "gdrive";
-		displayName: string;
-		settings: Record<string, unknown>;
-		enabled: boolean;
-	};
+	let parsed: unknown;
 	try {
-		config = JSON.parse(connectorRow.config_json) as {
-			id: string;
-			provider: "filesystem" | "github-docs" | "gdrive";
-			displayName: string;
-			settings: Record<string, unknown>;
-			enabled: boolean;
-		};
+		parsed = JSON.parse(connectorRow.config_json);
 	} catch {
 		return { status: "error", error: "Connector config is invalid JSON" };
 	}
+	if (
+		typeof parsed !== "object" ||
+		parsed === null ||
+		!("provider" in parsed) ||
+		typeof (parsed as Record<string, unknown>).provider !== "string" ||
+		!(CONNECTOR_PROVIDERS as readonly string[]).includes(
+			(parsed as Record<string, unknown>).provider as string,
+		)
+	) {
+		return { status: "error", error: "Invalid connector config" };
+	}
+	// provider validated above — safe to treat as ConnectorConfig
+	const config = parsed as ConnectorConfig;
 
 	if (config.provider !== "filesystem") {
 		return { status: "unsupported", provider: config.provider };
@@ -3670,23 +3674,23 @@ function startConnectorSync(
 	updateConnectorStatus(accessor, connectorId, "syncing");
 	const connector = createFilesystemConnector(config, accessor);
 
-	let incrementalCursor:
-		| {
-				lastSyncAt: string;
-				checkpoint?: string;
-				version?: number;
-		  }
-		| null = null;
+	let incrementalCursor: SyncCursor | null = null;
 	if (mode === "incremental") {
 		if (!connectorRow.cursor_json) {
 			incrementalCursor = { lastSyncAt: new Date(0).toISOString() };
 		} else {
 			try {
-				incrementalCursor = JSON.parse(connectorRow.cursor_json) as {
-					lastSyncAt: string;
-					checkpoint?: string;
-					version?: number;
-				};
+				const cursorParsed: unknown = JSON.parse(connectorRow.cursor_json);
+				if (
+					typeof cursorParsed === "object" &&
+					cursorParsed !== null &&
+					"lastSyncAt" in cursorParsed &&
+					typeof (cursorParsed as Record<string, unknown>).lastSyncAt === "string"
+				) {
+					incrementalCursor = cursorParsed as SyncCursor;
+				} else {
+					incrementalCursor = { lastSyncAt: new Date(0).toISOString() };
+				}
 			} catch {
 				incrementalCursor = { lastSyncAt: new Date(0).toISOString() };
 			}
@@ -3821,7 +3825,7 @@ app.post("/api/connectors/resync", async (c) => {
 			failed,
 		});
 	} catch (e) {
-		logger.error("connectors", "Failed to trigger bulk resync", e as Error);
+		logger.error("connectors", "Failed to trigger bulk resync", e instanceof Error ? e : new Error(String(e)));
 		return c.json({
 			status: "error",
 			error: "Failed to trigger connector re-sync",


### PR DESCRIPTION
## What
- Add two top-right actions on the dashboard Connectors tab: **Re-sync Harnesses** and **Re-sync Connectors**.
- Keep the existing per-connector Sync/Full Resync controls, while adding a bulk incremental re-sync workflow for all connectors.
- Surface clear success/error summaries in toasts for both harness and connector re-sync operations.

## How
- Added a new daemon endpoint: `POST /api/connectors/resync` to trigger incremental sync across all registered connectors.
- Refactored connector sync kickoff into shared daemon logic (`startConnectorSync`) used by:
  - `POST /api/connectors/:id/sync`
  - `POST /api/connectors/:id/sync/full`
  - `POST /api/connectors/resync`
- Added dashboard API client support via `resyncConnectors()` and `BulkConnectorSyncResult`.
- Updated `ConnectorsTab.svelte` to:
  - render header-right action buttons for both sections
  - call `regenerateHarnesses()` for harness re-sync
  - call `resyncConnectors()` for connector bulk re-sync
  - handle loading/disable states, no-connectors state, partial outcomes, and error paths

## Why
- Users need a one-click way to re-sync harness configs and connector ingestion state without triggering each connector individually.
- Bulk orchestration on the daemon side keeps behavior consistent with per-connector sync semantics and centralizes edge-case handling.
- Summary feedback improves operator clarity when some connectors are already syncing, unsupported, or fail to start.

## Changes
- `packages/daemon/src/daemon.ts`
  - Added shared connector sync starter
  - Added `POST /api/connectors/resync`
  - Reused shared logic in existing single-connector sync endpoints
- `packages/cli/dashboard/src/lib/api.ts`
  - Added `BulkConnectorSyncResult`
  - Added `resyncConnectors()` API helper
- `packages/cli/dashboard/src/lib/components/tabs/ConnectorsTab.svelte`
  - Added section-level re-sync buttons
  - Added async state management + summary toast messaging

## Verification
- `bun run build` (workspace)
- `bun test` (614 passing)
- `bun run typecheck`
- `cd packages/daemon && bun run build`
- `cd packages/cli/dashboard && bun run build`

Note: `svelte-check` currently reports pre-existing dashboard typing/a11y issues outside this PR scope.