### PR TITLE
Marketplace overhaul: unified app detail sheets and scoped reviews

### DIFF
--- a/docs/specs/planning/marketplace-reviews-cloudflare-staging.md
+++ b/docs/specs/planning/marketplace-reviews-cloudflare-staging.md
@@ -1,0 +1,119 @@
+# Marketplace Reviews Cloudflare Staging Plan
+
+## Context
+
+The Marketplace UI overhaul introduces `Signet Reviews` scaffolding for Skills and MCP servers.
+We are intentionally not completing the production review backend in this PR.
+This document defines how reviews are staged now and how we complete Cloudflare-backed persistence next.
+
+## Current Stage (in this branch)
+
+- UI scaffolding exists in Marketplace right rail (`Signet Reviews` and `Sync`).
+- API surface exists in daemon for reviews CRUD + sync config.
+- Temporary local persistence is file-based and only intended for staging and UX validation.
+- Display-name authorship is used for PR1 (no signed identity yet).
+
+## Target Cloudflare Architecture (next stage)
+
+- Runtime: Cloudflare Worker service dedicated to Marketplace Reviews API.
+- Database: Cloudflare D1 (`signet_marketplace_reviews`) for review records and sync metadata.
+- Optional cache: Cloudflare KV for hot aggregates and rate-limit counters.
+- Daemon role: sync client and local UX adapter, not source of truth.
+
+## D1 Schema (proposed)
+
+```sql
+CREATE TABLE IF NOT EXISTS reviews (
+  id TEXT PRIMARY KEY,
+  target_type TEXT NOT NULL CHECK (target_type IN ('skill', 'mcp')),
+  target_id TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  rating INTEGER NOT NULL CHECK (rating BETWEEN 1 AND 5),
+  title TEXT NOT NULL,
+  body TEXT NOT NULL,
+  source TEXT NOT NULL DEFAULT 'signet',
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  deleted_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_reviews_target
+  ON reviews(target_type, target_id, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS review_sync_events (
+  id TEXT PRIMARY KEY,
+  direction TEXT NOT NULL CHECK (direction IN ('push', 'pull')),
+  status TEXT NOT NULL CHECK (status IN ('ok', 'error')),
+  error TEXT,
+  created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS review_aggregates (
+  target_type TEXT NOT NULL,
+  target_id TEXT NOT NULL,
+  review_count INTEGER NOT NULL DEFAULT 0,
+  avg_rating REAL NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (target_type, target_id)
+);
+```
+
+## API Contract (Cloudflare Worker)
+
+- `GET /reviews?type=&id=&limit=&offset=`
+- `POST /reviews`
+- `PATCH /reviews/:id`
+- `DELETE /reviews/:id`
+- `GET /reviews/summary?type=&id=`
+
+Daemon sync endpoint target (for PR1-compatible shape):
+
+- `POST /ingest/signet-reviews`
+  - accepts batched review payload currently sent by daemon
+  - returns `{ success: true, accepted: number }`
+
+## Rollout Stages
+
+1. **PR1 (current):** UI + daemon review scaffold + temporary local persistence.
+2. **Stage 2:** Deploy Worker + D1 schema + ingest endpoint (no UI contract changes).
+3. **Stage 3:** Switch daemon sync default to Cloudflare endpoint; local mode remains fallback.
+4. **Stage 4:** Add moderation and trust/rate controls (display-name abuse hardening).
+
+## Migration Notes
+
+- Keep daemon response shapes stable so UI does not change.
+- Add backend metadata in config response later:
+  - `backend: "local-file" | "cloudflare-d1"`
+  - `mode: "staging" | "production"`
+- Backfill path from local file records to D1 should run once per workstation if needed.
+
+## Security and Abuse Controls (Stage 2+)
+
+- Worker-level rate limiting by IP and target_id.
+- Payload validation and title/body length limits.
+- Soft delete only; preserve audit trail in `review_sync_events`.
+- Optional signed daemon token header for ingest endpoint.
+
+## QA Checklist Before Cloudflare Cutover
+
+- CRUD parity between local mode and Cloudflare mode.
+- Summary math parity (`count`, `avg_rating`) across endpoints.
+- Sync retries and duplicate idempotency behavior verified.
+- Error paths in UI remain non-blocking and actionable.
+
+## PR Review Summary Block (for Nicholai)
+
+Use this in the PR description under a dedicated section:
+
+```md
+### Reviews Staging (Cloudflare Plan)
+
+This PR intentionally ships **Signet Reviews scaffolding only** (UI + daemon contracts + staged local persistence) and does **not** finalize production review infrastructure.
+
+- Current stage: review UX and API contracts are in place for Skills and MCP servers.
+- Temporary backend: local file persistence for development/staging validation.
+- Next stage: migrate source-of-truth storage to **Cloudflare Worker + D1** with unchanged UI contracts.
+- Follow-up scope: Worker endpoints, D1 schema, daemon sync cutover, and moderation/rate-limit hardening.
+
+This keeps PR1 focused on Marketplace UX while preserving a low-risk path to Cloudflare-backed reviews.
+```

--- a/packages/cli/dashboard/src/app.css
+++ b/packages/cli/dashboard/src/app.css
@@ -54,6 +54,14 @@
 	--sig-success: #4a7a5e;
 	--sig-dither: #f0f0f2;
 	--sig-grain-opacity: 0.04;
+	--sig-icon-fg: #f8fafc;
+	--sig-icon-border: rgba(255, 255, 255, 0.26);
+	--sig-icon-bg-1: #2563eb;
+	--sig-icon-bg-2: #7c3aed;
+	--sig-icon-bg-3: #059669;
+	--sig-icon-bg-4: #d97706;
+	--sig-icon-bg-5: #dc2626;
+	--sig-icon-bg-6: #0891b2;
 
 	/* Typography & spacing */
 	--font-display: "Diamond Grotesk", "Chakra Petch", sans-serif;
@@ -121,6 +129,14 @@
 	--sig-success: #4a7a5e;
 	--sig-dither: #0a0a0c;
 	--sig-grain-opacity: 0.06;
+	--sig-icon-fg: #111827;
+	--sig-icon-border: rgba(0, 0, 0, 0.22);
+	--sig-icon-bg-1: #93c5fd;
+	--sig-icon-bg-2: #c4b5fd;
+	--sig-icon-bg-3: #86efac;
+	--sig-icon-bg-4: #fcd34d;
+	--sig-icon-bg-5: #fca5a5;
+	--sig-icon-bg-6: #67e8f9;
 }
 
 /* === Tailwind v4 theme registration === */

--- a/packages/cli/dashboard/src/lib/api.ts
+++ b/packages/cli/dashboard/src/lib/api.ts
@@ -69,6 +69,17 @@ export interface DaemonStatus {
 	host: string;
 	agentsDir: string;
 	memoryDb: boolean;
+	update?: {
+		currentVersion: string;
+		latestVersion: string | null;
+		updateAvailable: boolean;
+		pendingRestart: string | null;
+		autoInstall: boolean;
+		checkInterval: number;
+		lastCheckAt: string | null;
+		lastError: string | null;
+		timerActive: boolean;
+	};
 }
 
 export interface EmbeddingPoint {
@@ -1218,6 +1229,141 @@ export async function testMarketplaceMcpConfig(input: {
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(input),
 		});
+		return await response.json();
+	} catch (e) {
+		return { success: false, error: String(e) };
+	}
+}
+
+export type MarketplaceReviewTargetType = "skill" | "mcp";
+
+export interface MarketplaceReview {
+	id: string;
+	targetType: MarketplaceReviewTargetType;
+	targetId: string;
+	displayName: string;
+	rating: number;
+	title: string;
+	body: string;
+	source: "local" | "synced";
+	createdAt: string;
+	updatedAt: string;
+	syncedAt: string | null;
+}
+
+export interface MarketplaceReviewConfig {
+	enabled: boolean;
+	endpointUrl: string;
+	lastSyncAt: string | null;
+	lastSyncError: string | null;
+	pending: number;
+}
+
+export async function getMarketplaceReviews(params: {
+	targetType?: MarketplaceReviewTargetType;
+	targetId?: string;
+	limit?: number;
+	offset?: number;
+}): Promise<{
+	reviews: MarketplaceReview[];
+	total: number;
+	limit: number;
+	offset: number;
+	summary: { count: number; avgRating: number };
+}> {
+	try {
+		const search = new URLSearchParams();
+		if (params.targetType) search.set("type", params.targetType);
+		if (params.targetId) search.set("id", params.targetId);
+		if (typeof params.limit === "number") search.set("limit", String(params.limit));
+		if (typeof params.offset === "number") search.set("offset", String(params.offset));
+		const query = search.toString();
+		const response = await fetch(`${API_BASE}/api/marketplace/reviews${query ? `?${query}` : ""}`);
+		if (!response.ok) throw new Error("Failed to fetch marketplace reviews");
+		return await response.json();
+	} catch {
+		return {
+			reviews: [],
+			total: 0,
+			limit: params.limit ?? 20,
+			offset: params.offset ?? 0,
+			summary: { count: 0, avgRating: 0 },
+		};
+	}
+}
+
+export async function createMarketplaceReview(input: {
+	targetType: MarketplaceReviewTargetType;
+	targetId: string;
+	displayName: string;
+	rating: number;
+	title: string;
+	body: string;
+}): Promise<{ success: boolean; review?: MarketplaceReview; error?: string }> {
+	try {
+		const response = await fetch(`${API_BASE}/api/marketplace/reviews`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(input),
+		});
+		return await response.json();
+	} catch (e) {
+		return { success: false, error: String(e) };
+	}
+}
+
+export async function deleteMarketplaceReview(id: string): Promise<{ success: boolean; id?: string; error?: string }> {
+	try {
+		const response = await fetch(`${API_BASE}/api/marketplace/reviews/${encodeURIComponent(id)}`, {
+			method: "DELETE",
+		});
+		return await response.json();
+	} catch (e) {
+		return { success: false, error: String(e) };
+	}
+}
+
+export async function getMarketplaceReviewConfig(): Promise<MarketplaceReviewConfig> {
+	try {
+		const response = await fetch(`${API_BASE}/api/marketplace/reviews/config`);
+		if (!response.ok) throw new Error("Failed to fetch review config");
+		return await response.json();
+	} catch {
+		return {
+			enabled: false,
+			endpointUrl: "",
+			lastSyncAt: null,
+			lastSyncError: null,
+			pending: 0,
+		};
+	}
+}
+
+export async function updateMarketplaceReviewConfig(input: {
+	enabled?: boolean;
+	endpointUrl?: string;
+}): Promise<{ success: boolean; config?: MarketplaceReviewConfig; error?: string }> {
+	try {
+		const response = await fetch(`${API_BASE}/api/marketplace/reviews/config`, {
+			method: "PATCH",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(input),
+		});
+		return await response.json();
+	} catch (e) {
+		return { success: false, error: String(e) };
+	}
+}
+
+export async function syncMarketplaceReviews(): Promise<{
+	success: boolean;
+	error?: string;
+	sent?: number;
+	synced?: number;
+	message?: string;
+}> {
+	try {
+		const response = await fetch(`${API_BASE}/api/marketplace/reviews/sync`, { method: "POST" });
 		return await response.json();
 	} catch (e) {
 		return { success: false, error: String(e) };

--- a/packages/cli/dashboard/src/lib/components/config/FormField.svelte
+++ b/packages/cli/dashboard/src/lib/components/config/FormField.svelte
@@ -63,6 +63,7 @@
 	}
 
 	.field-desc {
+		line-clamp: 2;
 		display: -webkit-box;
 		-webkit-line-clamp: 2;
 		-webkit-box-orient: vertical;

--- a/packages/cli/dashboard/src/lib/components/embeddings/EmbeddingCanvas2D.svelte
+++ b/packages/cli/dashboard/src/lib/components/embeddings/EmbeddingCanvas2D.svelte
@@ -707,7 +707,6 @@ $effect(() => {
 			width={MINIMAP_WIDTH}
 			height={MINIMAP_HEIGHT}
 			class="minimap"
-			role="img"
 			aria-label="Graph navigation minimap"
 			onmousedown={handleMinimapMouseDown}
 			onmousemove={handleMinimapMouseMove}

--- a/packages/cli/dashboard/src/lib/components/marketplace/McpDetailSheet.svelte
+++ b/packages/cli/dashboard/src/lib/components/marketplace/McpDetailSheet.svelte
@@ -1,0 +1,595 @@
+<script lang="ts">
+import type { MarketplaceMcpCatalogEntry, MarketplaceReview } from "$lib/api";
+import { createMarketplaceReview, getMarketplaceReviews } from "$lib/api";
+import { Button } from "$lib/components/ui/button/index.js";
+import * as Collapsible from "$lib/components/ui/collapsible/index.js";
+import { Input } from "$lib/components/ui/input/index.js";
+import * as Select from "$lib/components/ui/select/index.js";
+import * as Sheet from "$lib/components/ui/sheet/index.js";
+import { Textarea } from "$lib/components/ui/textarea/index.js";
+import { toast } from "$lib/stores/toast.svelte";
+import ChevronDown from "@lucide/svelte/icons/chevron-down";
+
+interface McpDetailItem {
+	targetId: string;
+	name: string;
+	description: string;
+	category: string;
+	sourceLabel: string;
+	official: boolean;
+	popularityRank: number | null;
+	sourceUrl: string;
+	catalogEntry: MarketplaceMcpCatalogEntry | null;
+	serverId: string | null;
+}
+
+interface Props {
+	open: boolean;
+	item: McpDetailItem | null;
+	isInstalled: boolean;
+	canReview: boolean;
+	installBusy?: boolean;
+	removeBusy?: boolean;
+	onclose: () => void;
+	oninstall?: (entry: MarketplaceMcpCatalogEntry) => void;
+	onuninstall?: (serverId: string) => void;
+}
+
+const REVIEW_DISPLAY_NAME_KEY = "signet:marketplace:reviews:display-name";
+
+type RatingValue = 1 | 2 | 3 | 4 | 5;
+type ReviewFilter = "top" | "good" | "bad" | "all";
+
+const {
+	open,
+	item,
+	isInstalled,
+	canReview,
+	installBusy = false,
+	removeBusy = false,
+	onclose,
+	oninstall,
+	onuninstall,
+}: Props = $props();
+
+let reviewFilter = $state<ReviewFilter>("top");
+let reviewLoading = $state(false);
+let reviewItems = $state<MarketplaceReview[]>([]);
+let reviewsOpen = $state(true);
+
+let displayName = $state(loadDisplayName());
+let rating = $state<RatingValue>(5);
+let title = $state("");
+let body = $state("");
+let submitting = $state(false);
+
+const activeRatingLabel = $derived(`${rating}/5`);
+
+const visibleReviews = $derived.by(() => {
+	const items = [...reviewItems];
+	if (reviewFilter === "top") {
+		return items.sort((a, b) =>
+			b.rating === a.rating
+				? b.updatedAt.localeCompare(a.updatedAt)
+				: b.rating - a.rating,
+		);
+	}
+	if (reviewFilter === "good") {
+		return items
+			.filter((r) => r.rating >= 4)
+			.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+	}
+	if (reviewFilter === "bad") {
+		return items
+			.filter((r) => r.rating <= 2)
+			.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+	}
+	return items.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+});
+
+$effect(() => {
+	if (!open || !item?.targetId) {
+		reviewItems = [];
+		return;
+	}
+	reviewFilter = "top";
+	void loadReviews(item.targetId);
+});
+
+function loadDisplayName(): string {
+	try {
+		return localStorage.getItem(REVIEW_DISPLAY_NAME_KEY) ?? "";
+	} catch {
+		return "";
+	}
+}
+
+function saveDisplayName(value: string): void {
+	try {
+		localStorage.setItem(REVIEW_DISPLAY_NAME_KEY, value);
+	} catch {
+		// ignore storage failures
+	}
+}
+
+function parseRating(value: string): RatingValue {
+	if (value === "1") return 1;
+	if (value === "2") return 2;
+	if (value === "3") return 3;
+	if (value === "4") return 4;
+	return 5;
+}
+
+async function loadReviews(targetId: string): Promise<void> {
+	reviewLoading = true;
+	try {
+		const data = await getMarketplaceReviews({
+			targetType: "mcp",
+			targetId,
+			limit: 100,
+		});
+		reviewItems = data.reviews;
+	} finally {
+		reviewLoading = false;
+	}
+}
+
+async function submitReview(): Promise<void> {
+	if (!item?.targetId) {
+		return;
+	}
+
+	if (!canReview) {
+		toast("Install or use this app before leaving a review.", "error");
+		return;
+	}
+
+	const nextDisplayName = displayName.trim();
+	const nextTitle = title.trim();
+	const nextBody = body.trim();
+
+	if (!nextDisplayName || !nextTitle || !nextBody) {
+		toast("Display name, title, and review are required", "error");
+		return;
+	}
+
+	submitting = true;
+	try {
+		const result = await createMarketplaceReview({
+			targetType: "mcp",
+			targetId: item.targetId,
+			displayName: nextDisplayName,
+			rating,
+			title: nextTitle,
+			body: nextBody,
+		});
+
+		if (!result.success) {
+			toast(result.error ?? "Failed to submit review", "error");
+			return;
+		}
+
+		saveDisplayName(nextDisplayName);
+		title = "";
+		body = "";
+		toast("Review posted", "success");
+		await loadReviews(item.targetId);
+	} finally {
+		submitting = false;
+	}
+}
+</script>
+
+<Sheet.Root {open} onOpenChange={(v) => { if (!v) onclose(); }}>
+	<Sheet.Content
+		side="right"
+		showClose={false}
+		class="!w-[520px] !max-w-[90vw] !bg-[var(--sig-surface)]
+			!border-l !border-l-[var(--sig-border)] !p-0 flex flex-col"
+	>
+		<div class="detail-header">
+			<div class="detail-title-wrap">
+				<h2 class="detail-title">{item?.name ?? "Tool Server"}</h2>
+				{#if item}
+					<div class="detail-badges">
+						<span class="detail-badge">{item.sourceLabel}</span>
+						<span class="detail-badge">{item.category}</span>
+						{#if item.official}
+							<span class="detail-badge detail-badge-official">official</span>
+						{/if}
+						{#if item.popularityRank !== null}
+							<span class="detail-rank">#{item.popularityRank}</span>
+						{/if}
+					</div>
+				{/if}
+			</div>
+
+			{#if item}
+				<div class="detail-action">
+					{#if item.serverId}
+						<Button
+							variant="outline"
+							size="sm"
+							class="rounded-lg font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] border-[var(--sig-danger)] text-[var(--sig-danger)] hover:bg-[var(--sig-danger)] hover:text-[var(--sig-text-bright)]"
+							onclick={() => item.serverId && onuninstall?.(item.serverId)}
+							disabled={removeBusy}
+						>
+							{removeBusy ? "..." : "Remove"}
+						</Button>
+					{:else if item.catalogEntry}
+						<Button
+							variant="outline"
+							size="sm"
+							class="rounded-lg font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] border-[var(--sig-text-bright)] text-[var(--sig-text-bright)] hover:bg-[var(--sig-text-bright)] hover:text-[var(--sig-bg)]"
+							onclick={() => item.catalogEntry && oninstall?.(item.catalogEntry)}
+							disabled={installBusy}
+						>
+							{installBusy ? "..." : "Install"}
+						</Button>
+					{/if}
+				</div>
+			{/if}
+		</div>
+
+		<div class="detail-body">
+			{#if item}
+				<p class="detail-description">{item.description || "No description available."}</p>
+				{#if item.sourceUrl}
+					<a class="detail-link" href={item.sourceUrl} target="_blank" rel="noopener">View source</a>
+				{/if}
+
+				<Collapsible.Root bind:open={reviewsOpen} class="reviews-section">
+					<Collapsible.Trigger class="reviews-trigger">
+						<span>Signet Reviews</span>
+						<ChevronDown class={`size-3 text-[var(--sig-text-muted)] transition-transform ${reviewsOpen ? "rotate-180" : ""}`} />
+					</Collapsible.Trigger>
+					<Collapsible.Content>
+						<div class="reviews-content">
+							<div class="review-form">
+						<Input
+							class="review-input"
+							placeholder="Display name"
+							value={displayName}
+							oninput={(e) => {
+								displayName = e.currentTarget.value;
+							}}
+						/>
+
+						<div class="review-row">
+							<Select.Root
+								type="single"
+								value={String(rating)}
+								onValueChange={(v) => {
+									rating = parseRating(v ?? "5");
+								}}
+							>
+								<Select.Trigger class="review-rating">{activeRatingLabel}</Select.Trigger>
+								<Select.Content class="review-rating-content">
+									<Select.Item value="5" label="5/5" class="review-rating-item" />
+									<Select.Item value="4" label="4/5" class="review-rating-item" />
+									<Select.Item value="3" label="3/5" class="review-rating-item" />
+									<Select.Item value="2" label="2/5" class="review-rating-item" />
+									<Select.Item value="1" label="1/5" class="review-rating-item" />
+								</Select.Content>
+							</Select.Root>
+							<Input
+								class="review-input"
+								placeholder="Review title"
+								value={title}
+								oninput={(e) => {
+									title = e.currentTarget.value;
+								}}
+							/>
+						</div>
+
+						<Textarea
+							class="review-textarea"
+							rows={3}
+							placeholder="What worked? What should improve?"
+							value={body}
+							oninput={(e) => {
+								body = e.currentTarget.value;
+							}}
+						/>
+							<div class="review-actions">
+								<span class="review-gate">Install or use this app before leaving a review.</span>
+								<Button
+								variant="outline"
+								size="sm"
+								class="review-submit"
+								onclick={() => void submitReview()}
+								disabled={submitting || !canReview}
+							>
+								{submitting ? "Posting..." : "Post review"}
+							</Button>
+							</div>
+							</div>
+
+							<div class="reviews-filters">
+								<button class="review-filter" class:active={reviewFilter === "top"} onclick={() => (reviewFilter = "top")}>Top comments</button>
+								<button class="review-filter" class:active={reviewFilter === "good"} onclick={() => (reviewFilter = "good")}>Good</button>
+								<button class="review-filter" class:active={reviewFilter === "bad"} onclick={() => (reviewFilter = "bad")}>Bad</button>
+								<button class="review-filter" class:active={reviewFilter === "all"} onclick={() => (reviewFilter = "all")}>All</button>
+							</div>
+
+							{#if reviewLoading}
+								<p class="review-muted">Loading reviews...</p>
+							{:else if visibleReviews.length === 0}
+								<p class="review-muted">No reviews yet for this app.</p>
+							{:else}
+								<div class="review-list">
+									{#each visibleReviews as review (review.id)}
+										<article class="review-item">
+											<div class="review-title">{review.title}</div>
+											<div class="review-meta">{review.displayName} · {review.rating}/5</div>
+											<p class="review-body">{review.body}</p>
+										</article>
+									{/each}
+								</div>
+							{/if}
+						</div>
+					</Collapsible.Content>
+				</Collapsible.Root>
+			{:else}
+				<p class="review-muted">Select a server to view details.</p>
+			{/if}
+		</div>
+	</Sheet.Content>
+</Sheet.Root>
+
+<style>
+	.detail-header {
+		display: flex;
+		justify-content: space-between;
+		gap: 10px;
+		padding: 14px 16px;
+		border-bottom: 1px solid var(--sig-border);
+	}
+
+	.detail-title-wrap {
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+
+	.detail-title {
+		margin: 0;
+		font-family: var(--font-display);
+		font-size: 14px;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: var(--sig-text-bright);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.detail-badges {
+		display: flex;
+		gap: 6px;
+		flex-wrap: wrap;
+	}
+
+	.detail-badge,
+	.detail-rank {
+		font-family: var(--font-mono);
+		font-size: 9px;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--sig-text-muted);
+	}
+
+	.detail-badge {
+		border: 1px solid var(--sig-border-strong);
+		padding: 2px 6px;
+	}
+
+	.detail-badge-official {
+		border-color: color-mix(in srgb, var(--sig-success) 70%, var(--sig-border-strong));
+		color: var(--sig-success);
+	}
+
+	.detail-action {
+		flex-shrink: 0;
+	}
+
+	.detail-body {
+		flex: 1;
+		overflow-y: auto;
+		padding: 14px 16px;
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+	}
+
+	.detail-description,
+	.review-muted,
+	.review-meta,
+	.review-body {
+		margin: 0;
+		font-family: var(--font-mono);
+		font-size: 10px;
+		line-height: 1.45;
+		color: var(--sig-text-muted);
+	}
+
+	.detail-link {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		color: var(--sig-accent);
+		text-decoration: none;
+	}
+
+	.detail-link:hover {
+		text-decoration: underline;
+	}
+
+	:global(.reviews-section) {
+		margin-top: 6px;
+		padding-top: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		border: 1px solid var(--sig-border);
+		background: var(--sig-surface-raised);
+		border-radius: 0.5rem;
+	}
+
+	:global(.reviews-trigger) {
+		width: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+		padding: 8px 10px;
+		background: transparent;
+		border: 0;
+		cursor: pointer;
+	}
+
+	:global(.reviews-trigger span) {
+		font-family: var(--font-display);
+		font-size: 11px;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--sig-text-bright);
+	}
+
+	.reviews-content {
+		padding: 0 10px 10px;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.reviews-filters {
+		display: flex;
+		gap: 6px;
+		flex-wrap: wrap;
+	}
+
+	.review-filter {
+		border: 1px solid var(--sig-border);
+		background: var(--sig-surface-raised);
+		color: var(--sig-text-muted);
+		font-family: var(--font-mono);
+		font-size: 9px;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		padding: 3px 7px;
+		cursor: pointer;
+	}
+
+	.review-filter.active {
+		color: var(--sig-text-bright);
+		border-color: var(--sig-accent);
+	}
+
+	.review-form {
+		display: flex;
+		flex-direction: column;
+		gap: 7px;
+		padding: 8px;
+		background: var(--sig-surface-raised);
+		border: 1px solid var(--sig-border);
+		border-radius: 0.45rem;
+	}
+
+	:global(.review-input),
+	:global(.review-textarea) {
+		font-family: var(--font-mono);
+		font-size: 10px;
+	}
+
+	.review-row {
+		display: grid;
+		grid-template-columns: 92px minmax(0, 1fr);
+		gap: 6px;
+	}
+
+	:global(.review-rating) {
+		height: 32px;
+		padding: 0 8px;
+		font-family: var(--font-mono);
+		font-size: 10px;
+		background: var(--sig-surface);
+		border: 1px solid var(--sig-border-strong);
+		border-radius: 0.45rem;
+	}
+
+	:global(.review-rating-content) {
+		background: var(--sig-surface-raised);
+		border: 1px solid var(--sig-border-strong);
+		border-radius: 0.5rem;
+	}
+
+	:global(.review-rating-item) {
+		font-family: var(--font-mono);
+		font-size: 10px;
+	}
+
+	.review-actions {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+	}
+
+	.review-gate {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		line-height: 1.4;
+		color: var(--sig-text-muted);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		min-width: 0;
+	}
+
+	:global(.review-submit) {
+		height: 30px;
+		font-family: var(--font-mono);
+		font-size: 10px;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+	}
+
+	.review-list {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.review-item {
+		padding: 8px;
+		background: var(--sig-surface-raised);
+		border-radius: 0.45rem;
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	.review-title {
+		font-family: var(--font-display);
+		font-size: 11px;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--sig-text-bright);
+	}
+
+	@media (max-width: 640px) {
+		.review-row {
+			grid-template-columns: 1fr;
+		}
+
+		.review-actions {
+			align-items: flex-start;
+			flex-direction: column;
+		}
+
+		.review-gate {
+			white-space: normal;
+		}
+	}
+</style>

--- a/packages/cli/dashboard/src/lib/components/marketplace/McpServersTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/marketplace/McpServersTab.svelte
@@ -1,53 +1,98 @@
 <script lang="ts">
-import type { MarketplaceMcpCatalogEntry } from "$lib/api";
+import {
+	type MarketplaceMcpCatalogEntry,
+	type MarketplaceMcpServer,
+} from "$lib/api";
+import McpDetailSheet from "$lib/components/marketplace/McpDetailSheet.svelte";
 import McpInstallSheet from "$lib/components/marketplace/McpInstallSheet.svelte";
 import { Button } from "$lib/components/ui/button/index.js";
 import * as Select from "$lib/components/ui/select/index.js";
-import { Switch } from "$lib/components/ui/switch/index.js";
+import * as Tabs from "$lib/components/ui/tabs/index.js";
 import {
 	type McpCatalogSort,
 	type McpCatalogSourceFilter,
 	fetchMarketplaceMcpCatalog,
 	fetchMarketplaceMcpInstalled,
 	getFilteredMarketplaceMcpCatalog,
-	getMarketplaceMcpCategoryOptions,
 	getMarketplaceMcpSourceOptions,
 	mcpMarket,
 	refreshMarketplaceMcpTools,
 	removeMarketplaceMcpServer,
-	toggleMarketplaceMcpServer,
 } from "$lib/stores/marketplace-mcp.svelte";
 import { onMount } from "svelte";
 
 interface Props {
 	embedded?: boolean;
+	showViewTabs?: boolean;
+	currentView?: "browse" | "installed";
+	onviewchange?: (view: "browse" | "installed") => void;
+	onreviewrequest?: (payload: {
+		targetType: "mcp";
+		targetId: string;
+		targetLabel: string;
+	}) => void | Promise<void>;
 }
 
-const { embedded = false }: Props = $props();
+const {
+	embedded = false,
+	showViewTabs = true,
+	currentView = "browse",
+	onviewchange,
+}: Props = $props();
+
+interface McpDetailItem {
+	targetId: string;
+	name: string;
+	description: string;
+	category: string;
+	sourceLabel: string;
+	official: boolean;
+	popularityRank: number | null;
+	sourceUrl: string;
+	catalogEntry: MarketplaceMcpCatalogEntry | null;
+	serverId: string | null;
+}
 
 const filteredCatalog = $derived(getFilteredMarketplaceMcpCatalog());
-const categories = $derived(getMarketplaceMcpCategoryOptions());
 const sourceOptions = $derived(getMarketplaceMcpSourceOptions());
 const installedCatalogIds = $derived(
 	new Set(mcpMarket.installed.flatMap((s) => (s.catalogId ? [`${s.source}:${s.catalogId}`] : []))),
 );
-const healthByServer = $derived(new Map(mcpMarket.serverHealth.map((h) => [h.serverId, h])));
+const installedServerByCatalogId = $derived(
+	new Map<string, string>(
+		mcpMarket.installed.flatMap((s) =>
+			s.catalogId ? [[`${s.source}:${s.catalogId}`, s.id] as [string, string]] : [],
+		),
+	),
+);
+const catalogById = $derived(
+	new Map<string, MarketplaceMcpCatalogEntry>(
+		mcpMarket.catalog.map((entry) => [entry.id, entry]),
+	),
+);
 let installSheetOpen = $state(false);
 let selectedCatalogEntry = $state<MarketplaceMcpCatalogEntry | null>(null);
-const activeCategoryLabel = $derived(mcpMarket.category === "all" ? "All categories" : mcpMarket.category);
+let detailOpen = $state(false);
+let detailItem = $state<McpDetailItem | null>(null);
+let view = $state<"browse" | "installed">("browse");
 const activeSourceLabel = $derived(mcpMarket.source === "all" ? "All sources" : formatSourceLabel(mcpMarket.source));
 const activeSortLabel = $derived.by(() => {
 	if (mcpMarket.sortBy === "name") return "Name";
 	if (mcpMarket.sortBy === "official") return "Official";
 	return "Popularity";
 });
-const installedPanelHint = $derived(
-	mcpMarket.loadingInstalled
-		? "Loading installed tool servers..."
-		: mcpMarket.installedError
-			? `Failed to load installed servers: ${mcpMarket.installedError}`
-			: "No Tool Servers installed yet.",
+const displayMode = $derived<"installed" | "browse">(
+	view === "installed" && !mcpMarket.query.trim() ? "installed" : "browse",
 );
+
+const MONOGRAM_COLORS = [
+	"var(--sig-icon-bg-1)",
+	"var(--sig-icon-bg-2)",
+	"var(--sig-icon-bg-3)",
+	"var(--sig-icon-bg-4)",
+	"var(--sig-icon-bg-5)",
+	"var(--sig-icon-bg-6)",
+] as const;
 
 onMount(() => {
 	fetchMarketplaceMcpInstalled();
@@ -79,9 +124,28 @@ function parseSource(value: string): McpCatalogSourceFilter {
 	return "all";
 }
 
-function parseCategory(value: string): string {
-	if (value === "all") return "all";
-	return categories.includes(value) ? value : "all";
+$effect(() => {
+	view = currentView;
+});
+
+function parseView(value: string): "browse" | "installed" {
+	return value === "installed" ? "installed" : "browse";
+}
+
+function getMonogram(name: string): string {
+	const parts = name.split(/[-_.\s]+/).filter(Boolean);
+	if (parts.length >= 2) {
+		return `${parts[0]?.[0] ?? ""}${parts[1]?.[0] ?? ""}`.toUpperCase();
+	}
+	return name.slice(0, 2).toUpperCase();
+}
+
+function getMonogramBg(name: string): string {
+	let hash = 0;
+	for (const ch of name) {
+		hash = (hash * 31 + ch.charCodeAt(0)) & 0xffff;
+	}
+	return MONOGRAM_COLORS[Math.abs(hash) % MONOGRAM_COLORS.length] ?? MONOGRAM_COLORS[0];
 }
 
 function openInstallSheet(entry: MarketplaceMcpCatalogEntry): void {
@@ -93,12 +157,83 @@ function closeInstallSheet(): void {
 	installSheetOpen = false;
 	selectedCatalogEntry = null;
 }
+
+function mcpReviewTargetIdForInstalled(server: MarketplaceMcpServer): string {
+	if (server.catalogId) {
+		return `${server.source}:${server.catalogId}`;
+	}
+	const normalized = server.name.trim().toLowerCase().replace(/\s+/g, "-");
+	return `${server.source}:${normalized}`;
+}
+
+function openCatalogDetail(entry: MarketplaceMcpCatalogEntry): void {
+	detailItem = {
+		targetId: entry.id,
+		name: entry.name,
+		description: entry.description,
+		category: entry.category,
+		sourceLabel: formatSourceLabel(entry.source),
+		official: entry.official,
+		popularityRank: entry.popularityRank,
+		sourceUrl: entry.sourceUrl,
+		catalogEntry: entry,
+		serverId: installedServerByCatalogId.get(entry.id) ?? null,
+	};
+	detailOpen = true;
+}
+
+function openInstalledDetail(server: MarketplaceMcpServer): void {
+	const catalogKey = server.catalogId ? `${server.source}:${server.catalogId}` : null;
+	const catalogEntry = catalogKey ? (catalogById.get(catalogKey) ?? null) : null;
+	detailItem = {
+		targetId: catalogKey ?? mcpReviewTargetIdForInstalled(server),
+		name: server.name,
+		description: server.description || catalogEntry?.description || server.id,
+		category: server.category || catalogEntry?.category || "general",
+		sourceLabel: formatSourceLabel(server.source),
+		official: server.official || catalogEntry?.official || false,
+		popularityRank: catalogEntry?.popularityRank ?? null,
+		sourceUrl: catalogEntry?.sourceUrl || server.homepage || "",
+		catalogEntry,
+		serverId: server.id,
+	};
+	detailOpen = true;
+}
+
+function closeDetailSheet(): void {
+	detailOpen = false;
+}
+
+function onCatalogCardKeydown(event: KeyboardEvent, entry: MarketplaceMcpCatalogEntry): void {
+	if (event.key !== "Enter" && event.key !== " ") return;
+	event.preventDefault();
+	openCatalogDetail(entry);
+}
+
+function onInstalledCardKeydown(event: KeyboardEvent, server: MarketplaceMcpServer): void {
+	if (event.key !== "Enter" && event.key !== " ") return;
+	event.preventDefault();
+	openInstalledDetail(server);
+}
+
+function openInstallFromDetail(entry: MarketplaceMcpCatalogEntry): void {
+	detailOpen = false;
+	openInstallSheet(entry);
+}
+
+async function removeFromDetail(serverId: string): Promise<void> {
+	await removeMarketplaceMcpServer(serverId);
+	if (!detailItem || detailItem.serverId !== serverId) return;
+	detailItem = { ...detailItem, serverId: null };
+}
+
 </script>
 
 <div class="h-full flex flex-col overflow-hidden">
 	<div
-		class="shrink-0 px-[var(--space-md)] py-[var(--space-sm)]
-			border-b border-[var(--sig-border)] flex items-center gap-2 flex-wrap"
+		class={`shrink-0 px-[var(--space-md)] py-[var(--space-sm)] flex items-center gap-2 flex-wrap ${
+			embedded ? "" : "border-b border-[var(--sig-border)]"
+		}`}
 	>
 		{#if !embedded}
 			<input
@@ -112,167 +247,187 @@ function closeInstallSheet(): void {
 			/>
 		{/if}
 
-		<Select.Root type="single" value={mcpMarket.category} onValueChange={(v) => { mcpMarket.category = parseCategory(v ?? "all"); }}>
-			<Select.Trigger class="select-trigger">{activeCategoryLabel}</Select.Trigger>
-			<Select.Content class="select-content">
-				{#each categories as category}
-					<Select.Item value={category} label={category} class="select-item" />
-				{/each}
-			</Select.Content>
-		</Select.Root>
-
-		<Select.Root type="single" value={mcpMarket.source} onValueChange={(v) => { mcpMarket.source = parseSource(v ?? "all"); }}>
-			<Select.Trigger class="select-trigger">{activeSourceLabel}</Select.Trigger>
-			<Select.Content class="select-content">
-				{#each sourceOptions as source}
-					<Select.Item
-						value={source}
-						label={source === "all" ? "All sources" : formatSourceLabel(source)}
-						class="select-item"
-					/>
-				{/each}
-			</Select.Content>
-		</Select.Root>
-
-		<Select.Root type="single" value={mcpMarket.sortBy} onValueChange={(v) => { mcpMarket.sortBy = parseSort(v ?? "popularity"); }}>
-			<Select.Trigger class="select-trigger">{activeSortLabel}</Select.Trigger>
-			<Select.Content class="select-content">
-				<Select.Item value="popularity" label="Popularity" class="select-item" />
-				<Select.Item value="official" label="Official" class="select-item" />
-				<Select.Item value="name" label="Name" class="select-item" />
-			</Select.Content>
-		</Select.Root>
-
-		<Button
-			variant="outline"
-			size="sm"
-			class="h-7 text-[10px] font-[family-name:var(--font-mono)]"
-			onclick={() => refreshMarketplaceMcpTools(true)}
-			disabled={mcpMarket.toolsLoading}
+		{#if showViewTabs}
+		<Tabs.Root
+			value={view}
+			onValueChange={(v) => {
+				view = parseView(v ?? "browse");
+				onviewchange?.(view);
+			}}
 		>
-			{mcpMarket.toolsLoading ? "Refreshing..." : "Refresh routed tools"}
-		</Button>
+			<Tabs.List class="bg-transparent h-auto gap-0 rounded-none border-none">
+				<Tabs.Trigger
+					value="browse"
+					class="font-[family-name:var(--font-mono)] text-[11px] text-[var(--sig-text-muted)] data-[state=active]:text-[var(--sig-text-bright)] data-[state=active]:border-b-[var(--sig-text-bright)] border-b-2 border-b-transparent rounded-none bg-transparent px-[var(--space-md)] py-[var(--space-xs)] hover:text-[var(--sig-text)] data-[state=active]:shadow-none"
+				>
+					Browse{mcpMarket.catalogTotal ? ` (${mcpMarket.catalogTotal.toLocaleString()})` : ""}
+				</Tabs.Trigger>
+				<Tabs.Trigger
+					value="installed"
+					class="font-[family-name:var(--font-mono)] text-[11px] text-[var(--sig-text-muted)] data-[state=active]:text-[var(--sig-text-bright)] data-[state=active]:border-b-[var(--sig-text-bright)] border-b-2 border-b-transparent rounded-none bg-transparent px-[var(--space-md)] py-[var(--space-xs)] hover:text-[var(--sig-text)] data-[state=active]:shadow-none"
+				>
+					Installed ({mcpMarket.installed.length})
+				</Tabs.Trigger>
+			</Tabs.List>
+		</Tabs.Root>
+		{/if}
+
+		{#if !embedded}
+		<div class="ml-auto flex items-center gap-2">
+			<Select.Root type="single" value={mcpMarket.sortBy} onValueChange={(v) => { mcpMarket.sortBy = parseSort(v ?? "popularity"); }}>
+				<Select.Trigger class="select-trigger">{activeSortLabel}</Select.Trigger>
+				<Select.Content class="select-content">
+					<Select.Item value="popularity" label="Popularity" class="select-item" />
+					<Select.Item value="official" label="Official" class="select-item" />
+					<Select.Item value="name" label="Name" class="select-item" />
+				</Select.Content>
+			</Select.Root>
+
+			<Select.Root type="single" value={mcpMarket.source} onValueChange={(v) => { mcpMarket.source = parseSource(v ?? "all"); }}>
+				<Select.Trigger class="select-trigger">{activeSourceLabel}</Select.Trigger>
+				<Select.Content class="select-content">
+					{#each sourceOptions as source}
+						<Select.Item
+							value={source}
+							label={source === "all" ? "All sources" : formatSourceLabel(source)}
+							class="select-item"
+						/>
+					{/each}
+				</Select.Content>
+			</Select.Root>
+		</div>
+		{/if}
 	</div>
 
-	<div class="flex-1 overflow-y-auto p-[var(--space-sm)] flex flex-col gap-[var(--space-sm)]">
-		<section class="panel">
-			<div class="panel-head">
-				<span>Installed Tool Servers ({mcpMarket.installed.length})</span>
-				<span>{mcpMarket.tools.length} routed tools</span>
-			</div>
-			{#if mcpMarket.toolsError}
-				<div class="panel-alert">Tool routing refresh failed: {mcpMarket.toolsError}</div>
-			{/if}
+	<div class="flex-1 overflow-y-auto px-[var(--space-sm)] pb-[var(--space-sm)] pt-0 flex flex-col gap-[var(--space-sm)]">
+		{#if displayMode === "installed"}
 			{#if mcpMarket.installed.length === 0}
 				<div class="panel-empty">
-					{installedPanelHint}
-					{#if !mcpMarket.loadingInstalled && !mcpMarket.installedError}
-						<span class="panel-empty-hint">Install one from the catalog below to route tools.</span>
-					{/if}
+					{mcpMarket.loadingInstalled
+						? "Loading installed tool servers..."
+						: mcpMarket.installedError
+							? `Failed to load installed servers: ${mcpMarket.installedError}`
+							: "No Tool Servers installed yet."}
 				</div>
 			{:else}
-				<div class="installed-list">
+				<div class="catalog-grid">
 					{#each mcpMarket.installed as server (server.id)}
-						<div class="installed-row">
-							<div class="installed-main">
-								<div class="installed-name">{server.name}</div>
-								<div class="installed-meta">
-									<span>{server.id}</span>
-									<span>&middot;</span>
-									<span>{server.config.transport}</span>
-									<span>&middot;</span>
-									<span>{healthByServer.get(server.id)?.toolCount ?? 0} tools</span>
-									{#if healthByServer.get(server.id)?.ok === false}
-										<span class="text-[var(--sig-danger)]">offline</span>
-									{/if}
+						<div
+							class="catalog-card"
+							role="button"
+							tabindex="0"
+							onclick={() => openInstalledDetail(server)}
+							onkeydown={(event) => onInstalledCardKeydown(event, server)}
+						>
+							<div class="catalog-top">
+								<div class="mcp-icon" style={`background: ${getMonogramBg(server.name)};`}>
+									{getMonogram(server.name)}
 								</div>
+								<div class="catalog-name">{server.name}</div>
 							</div>
-							<div class="installed-actions">
-								<Switch
-									checked={server.enabled}
-									onCheckedChange={(v: boolean) =>
-										toggleMarketplaceMcpServer(server.id, v)}
-									disabled={mcpMarket.togglingId === server.id}
-									class="scale-75 origin-right"
-								/>
+							<div class="catalog-desc">{server.description || server.id}</div>
+							<div class="catalog-meta">
+								<span class="mcp-badge">installed</span>
+								<span class="mcp-badge">{server.config.transport}</span>
+							</div>
+							<div class="catalog-actions">
 								<Button
 									variant="outline"
 									size="sm"
-									class="h-6 text-[9px]"
-									onclick={() => removeMarketplaceMcpServer(server.id)}
+									class="flex-1 h-auto rounded-lg font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] px-2 py-1 border-[var(--sig-danger)] text-[var(--sig-danger)] hover:bg-[var(--sig-danger)] hover:text-[var(--sig-text-bright)]"
+									onclick={(event: MouseEvent) => {
+										event.stopPropagation();
+										void removeMarketplaceMcpServer(server.id);
+									}}
 									disabled={mcpMarket.removingId === server.id}
 								>
-									{mcpMarket.removingId === server.id ? "..." : "Remove"}
+									{mcpMarket.removingId === server.id ? "..." : "REMOVE"}
 								</Button>
 							</div>
 						</div>
 					{/each}
 				</div>
 			{/if}
-		</section>
-
-		<section class="panel">
-			<div class="panel-head">
-				<span>Discover Tool Servers (MCP)</span>
-				<span>{filteredCatalog.length} shown{#if mcpMarket.catalogTotal > 0} / {mcpMarket.catalogTotal} total{/if}</span>
+		{:else if mcpMarket.catalogError}
+			<div class="panel-alert">Failed to load catalog: {mcpMarket.catalogError}</div>
+		{:else if mcpMarket.catalogLoading}
+			<div class="panel-empty">Loading catalog...</div>
+		{:else if filteredCatalog.length === 0}
+			<div class="panel-empty">
+				No matching Tool Servers.
+				<button
+					type="button"
+					class="panel-reset"
+					onclick={() => {
+						mcpMarket.query = "";
+						mcpMarket.category = "all";
+						mcpMarket.source = "all";
+					}}
+				>
+					Clear filters
+				</button>
 			</div>
-			{#if mcpMarket.catalogError}
-				<div class="panel-alert">Failed to load catalog: {mcpMarket.catalogError}</div>
-			{/if}
-			{#if mcpMarket.catalogLoading}
-				<div class="panel-empty">Loading catalog...</div>
-			{:else if filteredCatalog.length === 0}
-				<div class="panel-empty">
-					No matching Tool Servers.
-					<button
-						type="button"
-						class="panel-reset"
-						onclick={() => {
-							mcpMarket.query = "";
-							mcpMarket.category = "all";
-							mcpMarket.source = "all";
-						}}
+		{:else}
+			<div class="catalog-grid">
+				{#each filteredCatalog as entry (entry.id)}
+					<div
+						class="catalog-card"
+						role="button"
+						tabindex="0"
+						onclick={() => openCatalogDetail(entry)}
+						onkeydown={(event) => onCatalogCardKeydown(event, entry)}
 					>
-						Clear filters
-					</button>
-				</div>
-			{:else}
-				<div class="catalog-grid">
-					{#each filteredCatalog as entry (entry.id)}
-						<div class="catalog-card">
+						<div class="catalog-top">
+							<div class="mcp-icon" style={`background: ${getMonogramBg(entry.name)};`}>
+								{getMonogram(entry.name)}
+							</div>
 							<div class="catalog-name">{entry.name}</div>
-							<div class="catalog-desc">{entry.description}</div>
-							<div class="catalog-meta">
-								<span>{formatSourceLabel(entry.source)}</span>
-								<span>{entry.category}</span>
-								{#if entry.official}
-									<span class="text-[var(--sig-success)]">official</span>
-								{/if}
-								<span>#{entry.popularityRank}</span>
-							</div>
-							<div class="catalog-actions">
-								<a href={entry.sourceUrl} target="_blank" rel="noopener" class="catalog-link">View</a>
-								{#if installedCatalogIds.has(entry.id)}
-									<Button variant="outline" size="sm" class="h-6 text-[9px]" disabled>
-										Installed
-									</Button>
-								{:else}
-									<Button
-										variant="outline"
-										size="sm"
-										class="h-6 text-[9px]"
-										onclick={() => openInstallSheet(entry)}
-										disabled={mcpMarket.installingId === entry.id}
-									>
-										{mcpMarket.installingId === entry.id ? "..." : "Install"}
-									</Button>
-								{/if}
-							</div>
 						</div>
-					{/each}
-				</div>
-			{/if}
-		</section>
+						<div class="catalog-desc">{entry.description}</div>
+						<div class="catalog-meta">
+							<span class="mcp-badge">{formatSourceLabel(entry.source)}</span>
+							<span class="mcp-badge">{entry.category}</span>
+							{#if entry.official}
+								<span class="mcp-badge mcp-official">official</span>
+							{/if}
+							<span class="mcp-rank">#{entry.popularityRank}</span>
+						</div>
+						<div class="catalog-actions">
+							{#if installedCatalogIds.has(entry.id)}
+								<Button
+									variant="outline"
+									size="sm"
+									class="flex-1 h-auto rounded-lg font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] px-2 py-1 border-[var(--sig-danger)] text-[var(--sig-danger)] hover:bg-[var(--sig-danger)] hover:text-[var(--sig-text-bright)]"
+									onclick={(event: MouseEvent) => {
+										event.stopPropagation();
+										const serverId = installedServerByCatalogId.get(entry.id);
+										if (serverId) {
+											void removeMarketplaceMcpServer(serverId);
+										}
+									}}
+									disabled={!installedServerByCatalogId.get(entry.id)}
+								>
+									REMOVE
+								</Button>
+							{:else}
+								<Button
+									variant="outline"
+									size="sm"
+									class="flex-1 h-auto rounded-lg font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] px-2 py-1 border-[var(--sig-border-strong)] text-[var(--sig-text-bright)]"
+										onclick={(event: MouseEvent) => {
+											event.stopPropagation();
+											openInstallSheet(entry);
+										}}
+										disabled={mcpMarket.installingId === entry.id}
+								>
+									{mcpMarket.installingId === entry.id ? "..." : "INSTALL"}
+								</Button>
+							{/if}
+						</div>
+					</div>
+				{/each}
+			</div>
+		{/if}
 	</div>
 </div>
 
@@ -280,6 +435,20 @@ function closeInstallSheet(): void {
 	open={installSheetOpen}
 	entry={selectedCatalogEntry}
 	onclose={closeInstallSheet}
+/>
+
+<McpDetailSheet
+	open={detailOpen}
+	item={detailItem}
+	isInstalled={detailItem ? detailItem.serverId !== null : false}
+	canReview={detailItem ? detailItem.serverId !== null : false}
+	installBusy={detailItem?.catalogEntry ? mcpMarket.installingId === detailItem.catalogEntry.id : false}
+	removeBusy={detailItem?.serverId ? mcpMarket.removingId === detailItem.serverId : false}
+	onclose={closeDetailSheet}
+	oninstall={openInstallFromDetail}
+	onuninstall={(serverId) => {
+		void removeFromDetail(serverId);
+	}}
 />
 
 <style>
@@ -384,16 +553,20 @@ function closeInstallSheet(): void {
 
 	.installed-row {
 		display: flex;
-		justify-content: space-between;
+		align-items: flex-start;
 		gap: 10px;
 		padding: 9px 10px;
 		border-bottom: 1px solid var(--sig-border);
+		background:
+			radial-gradient(circle at 12% -24%, color-mix(in srgb, var(--sig-accent) 8%, transparent), transparent 52%),
+			linear-gradient(220deg, color-mix(in srgb, var(--sig-surface-raised) 92%, black) 0%, var(--sig-surface) 72%);
 	}
 	.installed-row:last-child {
 		border-bottom: none;
 	}
 
 	.installed-main {
+		flex: 1;
 		min-width: 0;
 	}
 
@@ -424,7 +597,7 @@ function closeInstallSheet(): void {
 		display: grid;
 		grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
 		gap: 8px;
-		padding: 8px;
+		padding: 0;
 	}
 
 	.catalog-card {
@@ -433,7 +606,29 @@ function closeInstallSheet(): void {
 		gap: 8px;
 		padding: 9px;
 		border: 1px solid var(--sig-border);
-		background: var(--sig-surface);
+		background:
+			radial-gradient(circle at 12% -24%, color-mix(in srgb, var(--sig-accent) 8%, transparent), transparent 52%),
+			linear-gradient(220deg, color-mix(in srgb, var(--sig-surface-raised) 92%, black) 0%, var(--sig-surface-raised) 72%);
+		cursor: pointer;
+		transition: border-color 0.15s;
+		min-height: 140px;
+		width: 100%;
+		text-align: left;
+	}
+
+	.catalog-card:hover {
+		border-color: var(--sig-accent);
+	}
+
+	.catalog-card:focus-visible {
+		outline: none;
+		border-color: var(--sig-accent);
+	}
+
+	.catalog-top {
+		display: flex;
+		align-items: center;
+		gap: 8px;
 	}
 
 	.catalog-name {
@@ -442,6 +637,22 @@ function closeInstallSheet(): void {
 		color: var(--sig-text-bright);
 		text-transform: uppercase;
 		letter-spacing: 0.04em;
+	}
+
+	.mcp-icon {
+		width: 28px;
+		height: 28px;
+		border-radius: 0.45rem;
+		border: 1px solid var(--sig-icon-border);
+		display: grid;
+		place-items: center;
+		font-family: var(--font-mono);
+		font-size: 10px;
+		font-weight: 700;
+		letter-spacing: 0.06em;
+		color: var(--sig-icon-fg);
+		text-transform: uppercase;
+		flex-shrink: 0;
 	}
 
 	.catalog-desc {
@@ -467,10 +678,26 @@ function closeInstallSheet(): void {
 		color: var(--sig-text-muted);
 	}
 
+	.mcp-badge {
+		border: 1px solid var(--sig-border-strong);
+		padding: 1px 6px;
+		line-height: 1.3;
+	}
+
+	.mcp-official {
+		border-color: color-mix(in srgb, var(--sig-success) 70%, var(--sig-border-strong));
+		color: var(--sig-success);
+	}
+
+	.mcp-rank {
+		color: var(--sig-text-muted);
+	}
+
 	.catalog-actions {
 		display: flex;
-		justify-content: space-between;
+		justify-content: flex-start;
 		align-items: center;
+		gap: 6px;
 		margin-top: auto;
 	}
 
@@ -483,4 +710,5 @@ function closeInstallSheet(): void {
 	.catalog-link:hover {
 		text-decoration: underline;
 	}
+
 </style>

--- a/packages/cli/dashboard/src/lib/components/marketplace/McpServersTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/marketplace/McpServersTab.svelte
@@ -660,6 +660,7 @@ async function removeFromDetail(serverId: string): Promise<void> {
 		font-size: 10px;
 		line-height: 1.45;
 		color: var(--sig-text-muted);
+		line-clamp: 4;
 		display: -webkit-box;
 		-webkit-line-clamp: 4;
 		-webkit-box-orient: vertical;

--- a/packages/cli/dashboard/src/lib/components/skills/SkillCard.svelte
+++ b/packages/cli/dashboard/src/lib/components/skills/SkillCard.svelte
@@ -49,13 +49,18 @@ function formatStat(n: number | undefined): string {
 }
 
 const MONOGRAM_COLORS = [
-	"#1e3448", "#341e48", "#48321e", "#1e4832", "#481e1e", "#1e2448"
+	"var(--sig-icon-bg-1)",
+	"var(--sig-icon-bg-2)",
+	"var(--sig-icon-bg-3)",
+	"var(--sig-icon-bg-4)",
+	"var(--sig-icon-bg-5)",
+	"var(--sig-icon-bg-6)",
 ];
 
 function getMonogramBg(name: string): string {
 	let hash = 0;
 	for (const ch of name) hash = (hash * 31 + ch.charCodeAt(0)) & 0xffff;
-	return MONOGRAM_COLORS[hash % MONOGRAM_COLORS.length];
+	return MONOGRAM_COLORS[Math.abs(hash) % MONOGRAM_COLORS.length] ?? MONOGRAM_COLORS[0];
 }
 
 function getMonogram(name: string): string {
@@ -124,9 +129,6 @@ let isInstalled = $derived(
 								{item.provider}
 							</span>
 						{/if}
-						{#if isInstalled && mode === "browse"}
-							<span class="installed-badge">INSTALLED</span>
-						{/if}
 					</div>
 				</div>
 			</div>
@@ -179,12 +181,13 @@ let isInstalled = $derived(
 
 		<!-- Action button (browse only) -->
 		{#if mode === "browse" && isSearchResult(item)}
-			<div class="card-action" onclick={(e) => e.stopPropagation()}>
+			<div class="card-action">
+				<div class="action-row">
 				{#if item.installed}
 					<Button
 						variant="outline"
 						size="sm"
-						class="w-full h-auto rounded-lg font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] px-2 py-1 border-[var(--sig-danger)] text-[var(--sig-danger)] hover:bg-[var(--sig-danger)] hover:text-[var(--sig-text-bright)]"
+						class="flex-1 h-auto rounded-lg font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] px-2 py-1 border-[var(--sig-danger)] text-[var(--sig-danger)] hover:bg-[var(--sig-danger)] hover:text-[var(--sig-text-bright)]"
 						onclick={(e: MouseEvent) => { e.stopPropagation(); onuninstall?.(); }}
 						disabled={uninstalling}
 					>
@@ -194,13 +197,14 @@ let isInstalled = $derived(
 					<Button
 						variant="outline"
 						size="sm"
-						class="w-full h-auto rounded-lg font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] px-2 py-1 bg-[var(--sig-accent)] border-[var(--sig-accent)] text-[var(--sig-bg)] hover:bg-[var(--sig-accent-hover,var(--sig-accent))] hover:border-[var(--sig-accent)]"
+						class="flex-1 h-auto rounded-lg font-[family-name:var(--font-mono)] text-[9px] uppercase tracking-[0.08em] px-2 py-1 border-[var(--sig-border-strong)] text-[var(--sig-text-bright)]"
 						onclick={(e: MouseEvent) => { e.stopPropagation(); oninstall?.(); }}
 						disabled={installing}
 					>
 						{installing ? "..." : "INSTALL"}
 					</Button>
 				{/if}
+				</div>
 			</div>
 		{/if}
 	</button>
@@ -234,7 +238,9 @@ let isInstalled = $derived(
 		flex-direction: column;
 		gap: 8px;
 		padding: var(--space-sm);
-		background: var(--sig-surface-raised);
+		background:
+			radial-gradient(circle at 12% -24%, color-mix(in srgb, var(--sig-accent) 8%, transparent), transparent 52%),
+			linear-gradient(220deg, color-mix(in srgb, var(--sig-surface-raised) 92%, black) 0%, var(--sig-surface-raised) 72%);
 		border: 1px solid var(--sig-border);
 		cursor: pointer;
 		transition: border-color 0.15s;
@@ -245,9 +251,17 @@ let isInstalled = $derived(
 	.card:hover {
 		border-color: var(--sig-accent);
 	}
+
+	.action-row {
+		display: flex;
+		gap: 6px;
+		width: 100%;
+	}
 	.card-wrap.selected > .card {
 		border-color: var(--sig-accent);
-		background: var(--sig-surface);
+		background:
+			radial-gradient(circle at 12% -24%, color-mix(in srgb, var(--sig-accent) 10%, transparent), transparent 54%),
+			linear-gradient(220deg, color-mix(in srgb, var(--sig-surface) 90%, black) 0%, var(--sig-surface) 74%);
 	}
 	.card-wrap.featured > .card {
 		min-height: 160px;
@@ -289,22 +303,25 @@ let isInstalled = $derived(
 
 	.monogram {
 		flex-shrink: 0;
-		width: 32px;
-		height: 32px;
+		width: 28px;
+		height: 28px;
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		font-family: var(--font-display);
-		font-size: 11px;
+		border-radius: 0.45rem;
+		border: 1px solid var(--sig-icon-border);
+		font-family: var(--font-mono);
+		font-size: 10px;
 		font-weight: 700;
-		color: var(--sig-text-bright);
-		letter-spacing: 0.04em;
+		color: var(--sig-icon-fg);
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
 		user-select: none;
 	}
 	.monogram.monogram-featured {
-		width: 40px;
-		height: 40px;
-		font-size: 13px;
+		width: 34px;
+		height: 34px;
+		font-size: 11px;
 	}
 
 	.card-header-content {
@@ -357,17 +374,6 @@ let isInstalled = $derived(
 	.provider-badge.clawhub {
 		border-color: var(--sig-accent);
 		color: var(--sig-accent);
-	}
-
-	.installed-badge {
-		flex-shrink: 0;
-		font-family: var(--font-mono);
-		font-size: 9px;
-		padding: 1px 5px;
-		border: 1px solid var(--sig-success);
-		color: var(--sig-success);
-		text-transform: uppercase;
-		letter-spacing: 0.06em;
 	}
 
 	.card-desc {

--- a/packages/cli/dashboard/src/lib/components/skills/SkillCard.svelte
+++ b/packages/cli/dashboard/src/lib/components/skills/SkillCard.svelte
@@ -383,6 +383,7 @@ let isInstalled = $derived(
 		line-height: 1.5;
 		margin: 0;
 		flex: 1;
+		line-clamp: 3;
 		display: -webkit-box;
 		-webkit-line-clamp: 3;
 		-webkit-box-orient: vertical;

--- a/packages/cli/dashboard/src/lib/components/skills/SkillDetail.svelte
+++ b/packages/cli/dashboard/src/lib/components/skills/SkillDetail.svelte
@@ -1,11 +1,25 @@
 <script lang="ts">
 import { marked } from "marked";
+import {
+	createMarketplaceReview,
+	getMarketplaceReviews,
+	type MarketplaceReview,
+} from "$lib/api";
 import * as Sheet from "$lib/components/ui/sheet/index.js";
+import * as Collapsible from "$lib/components/ui/collapsible/index.js";
 import { Badge } from "$lib/components/ui/badge/index.js";
 import { Button } from "$lib/components/ui/button/index.js";
+import { Input } from "$lib/components/ui/input/index.js";
+import * as Select from "$lib/components/ui/select/index.js";
+import { Textarea } from "$lib/components/ui/textarea/index.js";
+import ChevronDown from "@lucide/svelte/icons/chevron-down";
 import { sk, doInstall, doUninstall, closeDetail } from "$lib/stores/skills.svelte";
 import { toast } from "$lib/stores/toast.svelte";
 import { computeTrustProfile } from "$lib/skills/risk-profile";
+
+const REVIEW_DISPLAY_NAME_KEY = "signet:marketplace:reviews:display-name";
+
+type RatingValue = 1 | 2 | 3 | 4 | 5;
 
 let open = $derived(sk.detailOpen);
 
@@ -59,11 +73,128 @@ let trustProfile = $derived.by(() => {
 	const item = { ...(source ?? {}), ...(meta ?? {}) };
 	return computeTrustProfile(item, sk.installed.map((s) => s.name));
 });
+
+let reviewFilter = $state<"top" | "good" | "bad" | "all">("top");
+let reviewLoading = $state(false);
+let reviewItems = $state<MarketplaceReview[]>([]);
+let reviewsOpen = $state(true);
+let additionalOpen = $state(false);
+let displayName = $state(loadDisplayName());
+let rating = $state<RatingValue>(5);
+let reviewTitle = $state("");
+let reviewBody = $state("");
+let reviewSubmitting = $state(false);
+
+const activeRatingLabel = $derived(`${rating}/5`);
+
+const reviewTargetId = $derived(sk.selectedName ?? "");
+
+const visibleReviews = $derived.by(() => {
+	const items = [...reviewItems];
+	if (reviewFilter === "top") {
+		return items.sort((a, b) => (b.rating === a.rating ? b.updatedAt.localeCompare(a.updatedAt) : b.rating - a.rating));
+	}
+	if (reviewFilter === "good") {
+		return items.filter((r) => r.rating >= 4).sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+	}
+	if (reviewFilter === "bad") {
+		return items.filter((r) => r.rating <= 2).sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+	}
+	return items.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+});
+
+async function loadReviewsForDetail(): Promise<void> {
+	if (!reviewTargetId) {
+		reviewItems = [];
+		return;
+	}
+	reviewLoading = true;
+	try {
+		const data = await getMarketplaceReviews({
+			targetType: "skill",
+			targetId: reviewTargetId,
+			limit: 100,
+		});
+		reviewItems = data.reviews;
+	} finally {
+		reviewLoading = false;
+	}
+}
+
+$effect(() => {
+	reviewTargetId;
+	void loadReviewsForDetail();
+});
+
+function parseRating(value: string): RatingValue {
+	if (value === "1") return 1;
+	if (value === "2") return 2;
+	if (value === "3") return 3;
+	if (value === "4") return 4;
+	return 5;
+}
+
+function loadDisplayName(): string {
+	try {
+		return localStorage.getItem(REVIEW_DISPLAY_NAME_KEY) ?? "";
+	} catch {
+		return "";
+	}
+}
+
+function saveDisplayName(value: string): void {
+	try {
+		localStorage.setItem(REVIEW_DISPLAY_NAME_KEY, value);
+	} catch {
+		// localStorage may be unavailable
+	}
+}
+
+async function submitReviewForDetail(): Promise<void> {
+	if (!reviewTargetId) return;
+	if (!isInstalled) {
+		toast("Install or use this skill before leaving a review.", "error");
+		return;
+	}
+
+	const nextDisplayName = displayName.trim();
+	const nextTitle = reviewTitle.trim();
+	const nextBody = reviewBody.trim();
+	if (!nextDisplayName || !nextTitle || !nextBody) {
+		toast("Display name, title, and review are required", "error");
+		return;
+	}
+
+	reviewSubmitting = true;
+	try {
+		const result = await createMarketplaceReview({
+			targetType: "skill",
+			targetId: reviewTargetId,
+			displayName: nextDisplayName,
+			rating,
+			title: nextTitle,
+			body: nextBody,
+		});
+		if (!result.success) {
+			toast(result.error ?? "Failed to submit review", "error");
+			return;
+		}
+
+		saveDisplayName(nextDisplayName);
+		reviewTitle = "";
+		reviewBody = "";
+		toast("Review posted", "success");
+		await loadReviewsForDetail();
+	} finally {
+		reviewSubmitting = false;
+	}
+}
 </script>
 
 <Sheet.Root bind:open onOpenChange={handleOpenChange}>
 	<Sheet.Content
 		side="right"
+		showClose={false}
 		class="!w-[520px] !max-w-[90vw] !bg-[var(--sig-surface)]
 			!border-l !border-l-[var(--sig-border)] !p-0 flex flex-col"
 	>
@@ -75,7 +206,7 @@ let trustProfile = $derived.by(() => {
 			</div>
 		{:else}
 			<!-- Header -->
-			<div class="px-5 pt-5 pb-4 border-b border-[var(--sig-border)]">
+			<div class="px-5 pt-5 pb-4">
 				<div class="flex items-start justify-between gap-4">
 					<div class="flex flex-col gap-1 min-w-0">
 						<h2 class="detail-title">{sk.selectedName}</h2>
@@ -229,23 +360,125 @@ let trustProfile = $derived.by(() => {
 
 			<!-- Body -->
 			<div class="flex-1 overflow-y-auto px-5 py-4">
-				{#if renderedContent}
-					<div class="skill-markdown">
-						{@html renderedContent}
-					</div>
-				{:else if sk.detailMeta?.description}
-					<p class="text-[12px] text-[var(--sig-text)] leading-[1.6]">
-						{sk.detailMeta.description}
-					</p>
-				{:else if sk.detailSource?.description}
-					<p class="text-[12px] text-[var(--sig-text)] leading-[1.6]">
-						{sk.detailSource.description}
-					</p>
-				{:else}
-					<p class="text-[12px] text-[var(--sig-text-muted)]">
-						No documentation available.
-					</p>
-				{/if}
+				<Collapsible.Root bind:open={reviewsOpen} class="reviews-section">
+					<Collapsible.Trigger class="reviews-trigger">
+						<span>Signet Reviews</span>
+						<ChevronDown class={`size-3 text-[var(--sig-text-muted)] transition-transform ${reviewsOpen ? "rotate-180" : ""}`} />
+					</Collapsible.Trigger>
+					<Collapsible.Content>
+						<div class="reviews-content">
+							<div class="review-form">
+						<Input
+							class="review-input"
+							placeholder="Display name"
+							value={displayName}
+							oninput={(e) => {
+								displayName = e.currentTarget.value;
+							}}
+						/>
+
+						<div class="review-row">
+							<Select.Root
+								type="single"
+								value={String(rating)}
+								onValueChange={(v) => {
+									rating = parseRating(v ?? "5");
+								}}
+							>
+								<Select.Trigger class="review-rating">{activeRatingLabel}</Select.Trigger>
+								<Select.Content class="review-rating-content">
+									<Select.Item value="5" label="5/5" class="review-rating-item" />
+									<Select.Item value="4" label="4/5" class="review-rating-item" />
+									<Select.Item value="3" label="3/5" class="review-rating-item" />
+									<Select.Item value="2" label="2/5" class="review-rating-item" />
+									<Select.Item value="1" label="1/5" class="review-rating-item" />
+								</Select.Content>
+							</Select.Root>
+							<Input
+								class="review-input"
+								placeholder="Review title"
+								value={reviewTitle}
+								oninput={(e) => {
+									reviewTitle = e.currentTarget.value;
+								}}
+							/>
+						</div>
+
+						<Textarea
+							class="review-textarea"
+							rows={3}
+							placeholder="What worked? What should improve?"
+							value={reviewBody}
+							oninput={(e) => {
+								reviewBody = e.currentTarget.value;
+							}}
+						/>
+							<div class="review-actions">
+								<span class="review-gate">Install or use this app before leaving a review.</span>
+								<Button
+								variant="outline"
+								size="sm"
+								class="review-submit"
+								onclick={() => void submitReviewForDetail()}
+								disabled={reviewSubmitting || !isInstalled}
+							>
+								{reviewSubmitting ? "Posting..." : "Post review"}
+							</Button>
+							</div>
+							</div>
+
+							<div class="reviews-filters">
+								<button class="review-filter" class:active={reviewFilter === "top"} onclick={() => (reviewFilter = "top")}>Top comments</button>
+								<button class="review-filter" class:active={reviewFilter === "good"} onclick={() => (reviewFilter = "good")}>Good</button>
+								<button class="review-filter" class:active={reviewFilter === "bad"} onclick={() => (reviewFilter = "bad")}>Bad</button>
+								<button class="review-filter" class:active={reviewFilter === "all"} onclick={() => (reviewFilter = "all")}>All</button>
+							</div>
+							{#if reviewLoading}
+								<p class="review-muted">Loading reviews...</p>
+							{:else if visibleReviews.length === 0}
+								<p class="review-muted">No reviews yet for this skill.</p>
+							{:else}
+								<div class="review-list">
+									{#each visibleReviews as review (review.id)}
+										<article class="review-item">
+											<div class="review-title">{review.title}</div>
+											<div class="review-meta">{review.displayName} · {review.rating}/5</div>
+											<p class="review-body">{review.body}</p>
+										</article>
+									{/each}
+								</div>
+							{/if}
+						</div>
+					</Collapsible.Content>
+				</Collapsible.Root>
+
+				<Collapsible.Root bind:open={additionalOpen} class="additional-section">
+					<Collapsible.Trigger class="additional-trigger">
+						<span>Additional provided descriptions</span>
+						<ChevronDown class={`size-3 text-[var(--sig-text-muted)] transition-transform ${additionalOpen ? "rotate-180" : ""}`} />
+					</Collapsible.Trigger>
+					<Collapsible.Content>
+						<div class="additional-content">
+							{#if renderedContent}
+								<div class="skill-markdown">
+									{@html renderedContent}
+								</div>
+							{:else if sk.detailMeta?.description}
+								<p class="additional-copy">
+									{sk.detailMeta.description}
+								</p>
+							{:else if sk.detailSource?.description}
+								<p class="additional-copy">
+									{sk.detailSource.description}
+								</p>
+							{:else}
+								<p class="additional-copy additional-copy-muted">
+									No additional documentation available.
+								</p>
+							{/if}
+						</div>
+					</Collapsible.Content>
+				</Collapsible.Root>
 			</div>
 		{/if}
 	</Sheet.Content>
@@ -384,10 +617,214 @@ let trustProfile = $derived.by(() => {
 		color: var(--sig-text-muted);
 	}
 
+	:global(.reviews-section) {
+		margin-top: 14px;
+		padding-top: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		border: 1px solid var(--sig-border);
+		background: var(--sig-surface-raised);
+		border-radius: 0.5rem;
+	}
+
+	:global(.reviews-trigger) {
+		width: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+		padding: 8px 10px;
+		background: transparent;
+		border: 0;
+		cursor: pointer;
+	}
+
+	:global(.reviews-trigger span) {
+		font-family: var(--font-display);
+		font-size: 11px;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--sig-text-bright);
+	}
+
+	.reviews-content {
+		padding: 0 10px 10px;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.reviews-filters {
+		display: flex;
+		gap: 6px;
+		flex-wrap: wrap;
+	}
+
+	.review-filter {
+		border: 1px solid var(--sig-border);
+		background: var(--sig-surface-raised);
+		color: var(--sig-text-muted);
+		font-family: var(--font-mono);
+		font-size: 9px;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		padding: 3px 7px;
+		cursor: pointer;
+	}
+
+	.review-filter.active {
+		color: var(--sig-text-bright);
+		border-color: var(--sig-accent);
+	}
+
+	.review-muted,
+	.review-meta,
+	.review-body {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		color: var(--sig-text-muted);
+	}
+
+	.review-list {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.review-form {
+		display: flex;
+		flex-direction: column;
+		gap: 7px;
+		padding: 8px;
+		background: var(--sig-surface-raised);
+		border: 1px solid var(--sig-border);
+		border-radius: 0.45rem;
+	}
+
+	:global(.review-input),
+	:global(.review-textarea) {
+		font-family: var(--font-mono);
+		font-size: 10px;
+	}
+
+	.review-row {
+		display: grid;
+		grid-template-columns: 92px minmax(0, 1fr);
+		gap: 6px;
+	}
+
+	:global(.review-rating) {
+		height: 32px;
+		padding: 0 8px;
+		font-family: var(--font-mono);
+		font-size: 10px;
+		background: var(--sig-surface);
+		border: 1px solid var(--sig-border-strong);
+		border-radius: 0.45rem;
+	}
+
+	:global(.review-rating-content) {
+		background: var(--sig-surface-raised);
+		border: 1px solid var(--sig-border-strong);
+		border-radius: 0.5rem;
+	}
+
+	:global(.review-rating-item) {
+		font-family: var(--font-mono);
+		font-size: 10px;
+	}
+
+	.review-actions {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+	}
+
+	.review-gate {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		line-height: 1.4;
+		color: var(--sig-text-muted);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		min-width: 0;
+	}
+
+	:global(.review-submit) {
+		height: 30px;
+		font-family: var(--font-mono);
+		font-size: 10px;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+	}
+
+	.review-item {
+		padding: 8px;
+		background: var(--sig-surface-raised);
+		border-radius: 0.45rem;
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	.review-title {
+		font-family: var(--font-display);
+		font-size: 11px;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--sig-text-bright);
+	}
+
+	:global(.additional-section) {
+		margin-top: 10px;
+		border: 1px solid var(--sig-border);
+		background: var(--sig-surface-raised);
+		border-radius: 0.5rem;
+	}
+
+	:global(.additional-trigger) {
+		width: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		background: transparent;
+		border: none;
+		padding: 8px 10px;
+		font-family: var(--font-display);
+		font-size: 11px;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--sig-text-bright);
+		cursor: pointer;
+	}
+
+	.additional-content {
+		padding: 0 10px 10px;
+		max-height: 52vh;
+		overflow-y: auto;
+	}
+
+	.additional-copy {
+		margin: 0;
+		font-size: 12px;
+		line-height: 1.65;
+		color: var(--sig-text);
+		white-space: pre-wrap;
+		overflow-wrap: anywhere;
+	}
+
+	.additional-copy-muted {
+		color: var(--sig-text-muted);
+	}
+
 	:global(.skill-markdown) {
 		font-size: 12px;
 		line-height: 1.7;
 		color: var(--sig-text);
+		overflow-wrap: anywhere;
 	}
 	:global(.skill-markdown h1),
 	:global(.skill-markdown h2),
@@ -438,5 +875,20 @@ let trustProfile = $derived.by(() => {
 	}
 	:global(.skill-markdown a:hover) {
 		text-decoration: underline;
+	}
+
+	@media (max-width: 640px) {
+		.review-row {
+			grid-template-columns: 1fr;
+		}
+
+		.review-actions {
+			align-items: flex-start;
+			flex-direction: column;
+		}
+
+		.review-gate {
+			white-space: normal;
+		}
 	}
 </style>

--- a/packages/cli/dashboard/src/lib/components/skills/SkillGrid.svelte
+++ b/packages/cli/dashboard/src/lib/components/skills/SkillGrid.svelte
@@ -18,6 +18,11 @@ type Props = {
 	onemptyaction?: (action: "primary" | "secondary") => void;
 	compareSelectedKeys?: string[];
 	oncomparetoggle?: (key: string) => void;
+	onreviewrequest?: (payload: {
+		targetType: "skill";
+		targetId: string;
+		targetLabel: string;
+	}) => void | Promise<void>;
 };
 
 let {
@@ -33,6 +38,7 @@ let {
 	onemptyaction,
 	compareSelectedKeys = [],
 	oncomparetoggle,
+	onreviewrequest,
 }: Props = $props();
 
 function isSearchResult(i: Skill | SkillSearchResult): i is SkillSearchResult {
@@ -65,16 +71,6 @@ let emptyActions = $derived.by(() => {
 	return [];
 });
 
-// Featured items: top 6 with installsRaw > 0, only in browse mode
-let featuredItems = $derived.by(() => {
-	if (mode !== "browse" || items.length === 0) return [];
-	return items
-		.filter((i): i is SkillSearchResult => isSearchResult(i) && (i.installsRaw ?? 0) > 0)
-		.slice(0, 6);
-});
-
-let showFeatured = $derived(mode === "browse" && featuredItems.length > 0);
-
 // Progressive rendering: show N items initially, expand on demand
 const PAGE_SIZE = 60;
 let visibleCount = $state(PAGE_SIZE);
@@ -91,31 +87,6 @@ let remainingCount = $derived(items.length - visibleCount);
 
 <div class="grid-container">
 	{#if items.length > 0}
-		<!-- Trending featured row -->
-		{#if showFeatured}
-			<div class="section-label">TRENDING</div>
-			<div class="featured-row">
-				{#each featuredItems as item (`${item.fullName}-featured`)}
-					<div class="featured-card-wrapper">
-						<SkillCard
-							{item}
-							{mode}
-							featured={true}
-							selected={selectedName === item.name}
-							installing={installing === item.name}
-							uninstalling={uninstalling === item.name}
-							compareSelected={compareSelectedKeys.includes(skillKey(item))}
-							onclick={() => onitemclick?.(item.name)}
-							oninstall={() => oninstall?.(item.name)}
-							onuninstall={() => onuninstall?.(item.name)}
-							oncomparetoggle={() => oncomparetoggle?.(skillKey(item))}
-						/>
-					</div>
-				{/each}
-			</div>
-			<div class="section-label">ALL SKILLS</div>
-		{/if}
-
 		<!-- Main grid -->
 		<div class="grid">
 			{#each visibleItems as item (skillKey(item))}
@@ -161,29 +132,6 @@ let remainingCount = $derived(items.length - visibleCount);
 		display: flex;
 		flex-direction: column;
 		gap: var(--space-sm);
-	}
-
-	.section-label {
-		font-family: var(--font-mono);
-		font-size: 9px;
-		text-transform: uppercase;
-		letter-spacing: 0.1em;
-		color: var(--sig-text-muted);
-		padding: 2px 0;
-	}
-
-	.featured-row {
-		display: flex;
-		flex-direction: row;
-		overflow-x: auto;
-		gap: var(--space-sm);
-		padding-bottom: 4px;
-	}
-
-	.featured-card-wrapper {
-		min-width: 260px;
-		max-width: 280px;
-		flex-shrink: 0;
 	}
 
 	.grid {

--- a/packages/cli/dashboard/src/lib/components/skills/SkillsTable.svelte
+++ b/packages/cli/dashboard/src/lib/components/skills/SkillsTable.svelte
@@ -65,10 +65,7 @@ function isSkill(item: Skill | SkillSearchResult): item is Skill {
 			</div>
 
 			<!-- Right side: badges / counts / actions -->
-			<div
-				class="flex items-center gap-[6px] shrink-0"
-				onclick={(e) => e.stopPropagation()}
-			>
+			<div class="flex items-center gap-[6px] shrink-0">
 				{#if mode === "search" && isSearchResult(item)}
 					<span class="skill-count">{item.installs}</span>
 					{#if item.installed}

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -1765,8 +1765,7 @@ $effect(() => {
 		</div>
 		<div style:display={graphMode === "3d" ? "contents" : "none"}>
 			{#if Canvas3D && !canvas3dLoading}
-				<svelte:component
-					this={Canvas3D}
+				<Canvas3D
 					bind:this={canvas3d}
 					{embeddings}
 					projected3d={projected3dCoords}
@@ -1786,7 +1785,7 @@ $effect(() => {
 						if (e) selectEmbeddingById(e.id);
 						else graphSelected = null;
 					}}
-					onhovernode={updateGraphHover}
+						onhovernode={updateGraphHover}
 				/>
 			{:else if canvas3dLoading}
 				<div class="absolute inset-0 flex items-center justify-center bg-[#050505]">

--- a/packages/cli/dashboard/src/lib/components/tabs/MarketplaceTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/MarketplaceTab.svelte
@@ -1,42 +1,116 @@
 <script lang="ts">
 import McpServersTab from "$lib/components/marketplace/McpServersTab.svelte";
 import SkillsTab from "$lib/components/tabs/SkillsTab.svelte";
+import { Button } from "$lib/components/ui/button/index.js";
+import * as Collapsible from "$lib/components/ui/collapsible/index.js";
 import * as Select from "$lib/components/ui/select/index.js";
-import * as Tabs from "$lib/components/ui/tabs/index.js";
-import { getFilteredMarketplaceMcpCatalog, mcpMarket } from "$lib/stores/marketplace-mcp.svelte";
-import { getFilteredCatalog, setQuery, sk } from "$lib/stores/skills.svelte";
+import ChevronDown from "@lucide/svelte/icons/chevron-down";
+import {
+	fetchTargetReviews,
+	loadMarketplaceReviewConfig,
+	reviewsMarket,
+	removeMarketplaceReview,
+	saveMarketplaceReviewConfig,
+	setReviewTarget,
+	submitMarketplaceReview,
+	syncMarketplaceReviewsNow,
+} from "$lib/stores/marketplace-reviews.svelte";
+import { toast } from "$lib/stores/toast.svelte";
+import {
+	fetchMarketplaceMcpCatalog,
+	fetchMarketplaceMcpInstalled,
+	refreshMarketplaceMcpTools,
+	getMarketplaceMcpCategoryOptions,
+	mcpMarket,
+} from "$lib/stores/marketplace-mcp.svelte";
+import {
+	fetchCatalog,
+	fetchInstalled,
+	getCategoryOptions,
+	setQuery,
+	sk,
+} from "$lib/stores/skills.svelte";
+import { onMount } from "svelte";
 
 let section = $state<"skills" | "mcp">("skills");
+let sortOpen = $state(true);
+let reviewSyncOpen = $state(false);
+let refreshingSkills = $state(false);
+let refreshingMcp = $state(false);
+let refreshingTools = $state(false);
+const MOBILE_RAIL_QUERY = "(max-width: 1120px)";
 
 type SpotlightItem = {
 	readonly title: string;
 	readonly subtitle: string;
+	readonly targetType: "skill" | "mcp";
+	readonly targetId: string;
 };
 
 const activeQuery = $derived(section === "skills" ? sk.query : mcpMarket.query);
-const activeSectionLabel = $derived(section === "skills" ? "Agent Skills" : "Tool Servers");
-
+const activeSectionLabel = $derived(section === "skills" ? "Agent Skills" : "MCP Tool Servers");
 const sectionCatalogCount = $derived(section === "skills" ? sk.catalogTotal : mcpMarket.catalogTotal);
+const activeInstalledCount = $derived(section === "skills" ? sk.installed.length : mcpMarket.installed.length);
 
-const spotlight = $derived.by((): SpotlightItem[] => {
+const skillsFirst = $derived(
+	sk.catalog[0]
+		? {
+			title: sk.catalog[0].name,
+			targetType: "skill" as const,
+			targetId: sk.catalog[0].name,
+		}
+		: null,
+);
+
+const mcpFirst = $derived(
+	mcpMarket.catalog[0]
+		? {
+			title: mcpMarket.catalog[0].name,
+			targetType: "mcp" as const,
+			targetId: mcpMarket.catalog[0].id,
+		}
+		: null,
+);
+
+const firstReviewTarget = $derived(section === "skills" ? skillsFirst : mcpFirst);
+
+const categoryOptions = $derived.by(() => {
 	if (section === "skills") {
-		return getFilteredCatalog()
-			.slice(0, 8)
-			.map((item) => ({
-				title: item.name,
-				subtitle: item.provider ?? "skills.sh",
-			}));
+		return getCategoryOptions();
 	}
-
-	return getFilteredMarketplaceMcpCatalog()
-		.slice(0, 8)
-		.map((item) => ({
-			title: item.name,
-			subtitle: item.source === "modelcontextprotocol/servers" ? "MCP GitHub" : "MCP Registry",
-		}));
+	return getMarketplaceMcpCategoryOptions();
 });
 
-const totalInstalled = $derived(sk.installed.length + mcpMarket.installed.length);
+const activeCategory = $derived.by(() => {
+	if (section === "skills") return sk.categoryFilter;
+	return mcpMarket.category;
+});
+
+const activeCategoryLabel = $derived(activeCategory === "all" ? "All categories" : activeCategory);
+const activeView = $derived(section === "skills" ? sk.view : mcpMarket.view);
+const activeSortLabel = $derived.by(() => {
+	if (section === "skills") {
+		if (sk.sortBy === "installs") return "Downloads";
+		if (sk.sortBy === "stars") return "Stars";
+		if (sk.sortBy === "name") return "Name";
+		if (sk.sortBy === "newest") return "Newest";
+		return "Popularity";
+	}
+	if (mcpMarket.sortBy === "official") return "Official";
+	if (mcpMarket.sortBy === "name") return "Name";
+	return "Popularity";
+});
+
+const activeSecondarySortLabel = $derived.by(() => {
+	if (section === "skills") {
+		if (sk.providerFilter === "skills.sh") return "skills.sh";
+		if (sk.providerFilter === "clawhub") return "ClawHub";
+		return "All providers";
+	}
+	if (mcpMarket.source === "mcpservers.org") return "MCP Registry";
+	if (mcpMarket.source === "modelcontextprotocol/servers") return "MCP GitHub";
+	return "All sources";
+});
 
 function handleSectionChange(value: string): void {
 	section = value === "mcp" ? "mcp" : "skills";
@@ -50,118 +124,361 @@ function updateActiveQuery(value: string): void {
 	mcpMarket.query = value;
 }
 
-function applySpotlight(item: SpotlightItem): void {
-	updateActiveQuery(item.title);
+function applyCategory(category: string): void {
+	const safe = categoryOptions.includes(category) ? category : "all";
+	if (section === "skills") {
+		sk.categoryFilter = safe;
+		return;
+	}
+	mcpMarket.category = safe;
 }
+
+function applySort(value: string): void {
+	if (section === "skills") {
+		if (value === "installs" || value === "stars" || value === "name" || value === "newest") {
+			sk.sortBy = value;
+			return;
+		}
+		sk.sortBy = "popularity";
+		return;
+	}
+	if (value === "name" || value === "official") {
+		mcpMarket.sortBy = value;
+		return;
+	}
+	mcpMarket.sortBy = "popularity";
+}
+
+function applySecondarySort(value: string): void {
+	if (section === "skills") {
+		if (value === "skills.sh" || value === "clawhub") {
+			sk.providerFilter = value;
+			return;
+		}
+		sk.providerFilter = "all";
+		return;
+	}
+	if (value === "mcpservers.org" || value === "modelcontextprotocol/servers") {
+		mcpMarket.source = value;
+		return;
+	}
+	mcpMarket.source = "all";
+}
+
+function clearSectionFilters(): void {
+	if (section === "skills") {
+		setQuery("");
+		sk.categoryFilter = "all";
+		sk.providerFilter = "all";
+		return;
+	}
+	mcpMarket.query = "";
+	mcpMarket.category = "all";
+	mcpMarket.source = "all";
+}
+
+function setActiveView(value: "browse" | "installed"): void {
+	if (section === "skills") {
+		sk.view = value;
+		return;
+	}
+	mcpMarket.view = value;
+}
+
+function hasUsedTarget(targetType: "skill" | "mcp", targetId: string): boolean {
+	if (targetType === "skill") {
+		return sk.installed.some((s) => s.name === targetId);
+	}
+	return mcpMarket.installed.some((s) => (s.catalogId ? `${s.source}:${s.catalogId}` === targetId : false));
+}
+
+async function handleReviewRequest(payload: {
+	targetType: "skill" | "mcp";
+	targetId: string;
+	targetLabel: string;
+}): Promise<void> {
+	const canReview = hasUsedTarget(payload.targetType, payload.targetId);
+	await setReviewTarget(payload.targetType, payload.targetId, payload.targetLabel, {
+		canReview,
+		reason: "Install or use this app before leaving a review.",
+	});
+	if (!canReview) {
+		toast("Install or use this app before leaving a review.", "error");
+	}
+}
+
+async function refreshSkills(): Promise<void> {
+	refreshingSkills = true;
+	try {
+		sk.catalogLoaded = false;
+		await Promise.all([fetchInstalled(), fetchCatalog()]);
+	} finally {
+		refreshingSkills = false;
+	}
+}
+
+async function refreshMcpServers(): Promise<void> {
+	refreshingMcp = true;
+	try {
+		mcpMarket.catalogLoaded = false;
+		await Promise.all([fetchMarketplaceMcpInstalled(), fetchMarketplaceMcpCatalog(5)]);
+	} finally {
+		refreshingMcp = false;
+	}
+}
+
+async function refreshRoutedToolsNow(): Promise<void> {
+	refreshingTools = true;
+	try {
+		await refreshMarketplaceMcpTools(true);
+	} finally {
+		refreshingTools = false;
+	}
+}
+
+onMount(() => {
+	const media = window.matchMedia(MOBILE_RAIL_QUERY);
+	const applyRailLayoutState = (): void => {
+		if (media.matches) {
+			sortOpen = false;
+			reviewSyncOpen = false;
+			return;
+		}
+		sortOpen = true;
+		reviewSyncOpen = false;
+	};
+
+	applyRailLayoutState();
+	media.addEventListener("change", applyRailLayoutState);
+
+	void fetchInstalled();
+	void fetchCatalog();
+	void fetchMarketplaceMcpInstalled();
+	void fetchMarketplaceMcpCatalog(5);
+	void refreshMarketplaceMcpTools();
+	void loadMarketplaceReviewConfig();
+
+	return () => {
+		media.removeEventListener("change", applyRailLayoutState);
+	};
+});
+
+$effect(() => {
+	if (!firstReviewTarget) return;
+	if (reviewsMarket.targetId && reviewsMarket.targetType) return;
+	void setReviewTarget(firstReviewTarget.targetType, firstReviewTarget.targetId, firstReviewTarget.title, {
+		canReview: hasUsedTarget(firstReviewTarget.targetType, firstReviewTarget.targetId),
+		reason: "Install or use this app before leaving a review.",
+	});
+});
+
+$effect(() => {
+	if (!reviewsMarket.targetType || !reviewsMarket.targetId) return;
+	void fetchTargetReviews();
+});
 </script>
 
-<div class="market-shell">
-	<div class="market-utility">
-		<div class="utility-left">
-			<span class="utility-kicker">Signet Marketplace</span>
-			<span class="utility-copy">Curated capabilities for agents that ship work.</span>
-		</div>
-		<div class="utility-stats">
-			<span>{sk.catalogTotal.toLocaleString()} skills</span>
-			<span>{mcpMarket.catalogTotal.toLocaleString()} tool servers</span>
-			<span>{totalInstalled} installed</span>
-		</div>
-	</div>
-
-	<div class="market-search-row">
-		<input
-			type="text"
-			class="market-search"
-			placeholder={section === "skills" ? "Search curated skills..." : "Search curated MCP servers..."}
-			value={activeQuery}
-			oninput={(e) => {
-				updateActiveQuery(e.currentTarget.value);
-			}}
-		/>
-		<Select.Root type="single" value={section} onValueChange={(v) => { section = v === "mcp" ? "mcp" : "skills"; }}>
-			<Select.Trigger class="market-select">{activeSectionLabel}</Select.Trigger>
-			<Select.Content class="market-select-content">
-				<Select.Item value="skills" label="Agent Skills" class="market-select-item" />
-				<Select.Item value="mcp" label="Tool Servers" class="market-select-item" />
-			</Select.Content>
-		</Select.Root>
-	</div>
-
-	<div class="hero-panel">
+<div class="store-shell">
+	<section class="hero">
 		<div class="hero-main">
-			<p class="hero-label">Storefront</p>
 			<h2>
 				{section === "skills"
-					? "Premium Skill Packs for serious operators"
-					: "Production MCP Servers for live toolchains"}
+					? "Discover skill packs that level up your agent workflow"
+					: "Browse MCP servers and route production tools with confidence"}
 			</h2>
 			<p>
 				{section === "skills"
-					? "Discover trusted automations, compare options, and install in one click."
-					: "Connect best-in-class tool servers, test configs, and route tools with confidence."}
+					? "Install trusted skills, compare options, and rate what actually delivers results."
+					: "Connect tool servers, monitor routed tools, and leave Signet Reviews for your stack."}
 			</p>
 			<div class="hero-actions">
-				<button type="button" class="hero-action" onclick={() => (section = "skills")}>Explore Skills</button>
-				<button type="button" class="hero-action ghost" onclick={() => (section = "mcp")}>Explore Tool Servers</button>
-			</div>
-		</div>
-		<div class="hero-side">
-			<div class="hero-metric">
-				<span class="metric-label">Current aisle</span>
-				<span class="metric-value">{section === "skills" ? "Agent Skills" : "Tool Servers"}</span>
-			</div>
-			<div class="hero-metric">
-				<span class="metric-label">Results</span>
-				<span class="metric-value">{sectionCatalogCount.toLocaleString()}</span>
-			</div>
-			<div class="hero-metric">
-				<span class="metric-label">Curation</span>
-				<span class="metric-value">Verified sources only</span>
-			</div>
-		</div>
-	</div>
-
-	{#if spotlight.length > 0}
-		<div class="spotlight-row">
-			{#each spotlight as item (item.title)}
-				<button
-					type="button"
-					class="spotlight-card"
-					onclick={() => applySpotlight(item)}
+				<Button
+					variant="outline"
+					size="sm"
+					class={`hero-switch ${section === "skills" ? "hero-switch-active" : ""}`}
+					onclick={() => handleSectionChange("skills")}
 				>
-					<span class="spotlight-title">{item.title}</span>
-					<span class="spotlight-subtitle">{item.subtitle}</span>
-				</button>
-			{/each}
-		</div>
-	{/if}
-
-	<div class="content-shell">
-		<Tabs.Root value={section} onValueChange={handleSectionChange}>
-			<div class="section-bar">
-				<Tabs.List class="bg-transparent h-auto gap-0 rounded-none border-none">
-					<Tabs.Trigger value="skills" class="section-trigger">
-						Agent Skills
-					</Tabs.Trigger>
-					<Tabs.Trigger value="mcp" class="section-trigger">
-						Tool Servers (MCP)
-					</Tabs.Trigger>
-				</Tabs.List>
+					Agent Skills
+				</Button>
+				<Button
+					variant="outline"
+					size="sm"
+					class={`hero-switch ${section === "mcp" ? "hero-switch-active" : ""}`}
+					onclick={() => handleSectionChange("mcp")}
+				>
+					MCP Servers
+				</Button>
 			</div>
-		</Tabs.Root>
-
-		<div class="content-body">
-			{#if section === "skills"}
-				<SkillsTab embedded={true} />
-			{:else}
-				<McpServersTab embedded={true} />
-			{/if}
 		</div>
+		<div class="hero-aside">
+			<div class="hero-metric"><span>Active section</span><strong>{activeSectionLabel} · {activeInstalledCount} installed</strong></div>
+			<div class="hero-metric"><span>Catalog size</span><strong>{sectionCatalogCount.toLocaleString()}</strong></div>
+			<div class="hero-metric"><span>Signet Reviews</span><strong>{reviewsMarket.summary.count} reviews</strong></div>
+		</div>
+	</section>
+
+	<div class="store-grid">
+		<main class="store-main">
+			<div class="module-head">
+				<div class="module-search-wrap">
+					<div class="module-search-inner">
+						<input
+							type="text"
+							class="module-search"
+							placeholder={section === "skills" ? "Search skills..." : "Search MCP servers..."}
+							value={activeQuery}
+							oninput={(e) => updateActiveQuery(e.currentTarget.value)}
+						/>
+						<Button variant="outline" size="sm" class="search-clear" onclick={clearSectionFilters}>Clear</Button>
+					</div>
+				</div>
+				<div class="module-view-tabs">
+					<Button
+						variant="outline"
+						size="sm"
+						class={`view-tab ${activeView === "browse" ? "view-tab-active" : ""}`}
+						onclick={() => setActiveView("browse")}
+					>
+						Browse
+					</Button>
+					<Button
+						variant="outline"
+						size="sm"
+						class={`view-tab ${activeView === "installed" ? "view-tab-active" : ""}`}
+						onclick={() => setActiveView("installed")}
+					>
+						Installed
+					</Button>
+				</div>
+			</div>
+
+			<div class="module-body">
+				{#if section === "skills"}
+					<SkillsTab embedded={true} showViewTabs={false} onreviewrequest={handleReviewRequest} />
+				{:else}
+					<McpServersTab
+						embedded={true}
+						showViewTabs={false}
+						currentView={activeView}
+						onviewchange={(v) => setActiveView(v)}
+						onreviewrequest={handleReviewRequest}
+					/>
+				{/if}
+			</div>
+		</main>
+
+		<aside class="store-rail">
+			<Collapsible.Root bind:open={sortOpen} class="rail-panel">
+				<Collapsible.Trigger class="rail-trigger">
+					<span>Sort</span>
+					<ChevronDown class={`size-3 text-[var(--sig-text-muted)] transition-transform ${sortOpen ? "rotate-180" : ""}`} />
+				</Collapsible.Trigger>
+				<Collapsible.Content>
+					<div class="rail-content">
+						<Select.Root
+							type="single"
+							value={section === "skills" ? sk.sortBy : mcpMarket.sortBy}
+							onValueChange={(v) => applySort(v ?? "popularity")}
+						>
+							<Select.Trigger class="rail-select">{activeSortLabel}</Select.Trigger>
+							<Select.Content class="section-select-content">
+								{#if section === "skills"}
+									<Select.Item value="popularity" label="Popularity" class="section-select-item" />
+									<Select.Item value="installs" label="Downloads" class="section-select-item" />
+									<Select.Item value="stars" label="Stars" class="section-select-item" />
+									<Select.Item value="name" label="Name" class="section-select-item" />
+									<Select.Item value="newest" label="Newest" class="section-select-item" />
+								{:else}
+									<Select.Item value="popularity" label="Popularity" class="section-select-item" />
+									<Select.Item value="official" label="Official" class="section-select-item" />
+									<Select.Item value="name" label="Name" class="section-select-item" />
+								{/if}
+							</Select.Content>
+						</Select.Root>
+
+						<Select.Root
+							type="single"
+							value={section === "skills" ? sk.providerFilter : mcpMarket.source}
+							onValueChange={(v) => applySecondarySort(v ?? "all")}
+						>
+							<Select.Trigger class="rail-select">{activeSecondarySortLabel}</Select.Trigger>
+							<Select.Content class="section-select-content">
+								{#if section === "skills"}
+									<Select.Item value="all" label="All providers" class="section-select-item" />
+									<Select.Item value="skills.sh" label="skills.sh" class="section-select-item" />
+									<Select.Item value="clawhub" label="ClawHub" class="section-select-item" />
+								{:else}
+									<Select.Item value="all" label="All sources" class="section-select-item" />
+									<Select.Item value="mcpservers.org" label="MCP Registry" class="section-select-item" />
+									<Select.Item value="modelcontextprotocol/servers" label="MCP GitHub" class="section-select-item" />
+								{/if}
+							</Select.Content>
+						</Select.Root>
+
+						<Select.Root type="single" value={activeCategory} onValueChange={(v) => applyCategory(v ?? "all")}>
+							<Select.Trigger class="rail-select">{activeCategoryLabel}</Select.Trigger>
+							<Select.Content class="section-select-content">
+								{#each categoryOptions as category (category)}
+									<Select.Item value={category} label={category} class="section-select-item" />
+								{/each}
+							</Select.Content>
+						</Select.Root>
+					</div>
+				</Collapsible.Content>
+			</Collapsible.Root>
+
+			<Collapsible.Root bind:open={reviewSyncOpen} class="rail-panel">
+				<Collapsible.Trigger class="rail-trigger">
+					<span>Sync</span>
+					<ChevronDown class={`size-3 text-[var(--sig-text-muted)] transition-transform ${reviewSyncOpen ? "rotate-180" : ""}`} />
+				</Collapsible.Trigger>
+				<Collapsible.Content>
+					<div class="rail-content">
+						<div class="rail-refresh">
+							<Button variant="outline" size="sm" class="rail-btn" disabled={refreshingSkills} onclick={refreshSkills}>
+								{refreshingSkills ? "Refreshing Skills..." : "Refresh Skills"}
+							</Button>
+							<Button variant="outline" size="sm" class="rail-btn" disabled={refreshingMcp} onclick={refreshMcpServers}>
+								{refreshingMcp ? "Refreshing MCP Servers..." : "Refresh MCP Servers"}
+							</Button>
+							<Button variant="outline" size="sm" class="rail-btn" disabled={refreshingTools} onclick={refreshRoutedToolsNow}>
+								{refreshingTools ? "Refreshing Routed Tools..." : "Refresh Routed Tools"}
+							</Button>
+						</div>
+
+				<label class="toggle-row">
+					<input type="checkbox" bind:checked={reviewsMarket.configEnabled} />
+					<span>Enable endpoint sync</span>
+				</label>
+				<input
+					type="url"
+					class="input"
+					placeholder="https://example.com/signet-reviews"
+					bind:value={reviewsMarket.configEndpointUrl}
+				/>
+				<div class="sync-actions">
+					<Button variant="outline" size="sm" disabled={reviewsMarket.configSaving} onclick={saveMarketplaceReviewConfig}>
+						{reviewsMarket.configSaving ? "Saving..." : "Save Sync Config"}
+					</Button>
+					<Button variant="outline" size="sm" disabled={reviewsMarket.syncing} onclick={syncMarketplaceReviewsNow}>
+						{reviewsMarket.syncing ? "Syncing..." : `Sync Now (${reviewsMarket.pendingSync})`}
+					</Button>
+				</div>
+				{#if reviewsMarket.lastSyncAt}
+					<div class="muted">Last sync: {new Date(reviewsMarket.lastSyncAt).toLocaleString()}</div>
+				{/if}
+				{#if reviewsMarket.lastSyncError}
+					<div class="error">{reviewsMarket.lastSyncError}</div>
+				{/if}
+					</div>
+				</Collapsible.Content>
+			</Collapsible.Root>
+		</aside>
 	</div>
 </div>
 
 <style>
-	.market-shell {
+	.store-shell {
 		height: 100%;
 		display: flex;
 		flex-direction: column;
@@ -170,140 +487,163 @@ function applySpotlight(item: SpotlightItem): void {
 		padding: 10px;
 	}
 
-	.market-utility {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		gap: 10px;
-		padding: 8px 10px;
-		border: 1px solid var(--sig-border);
+	.hero,
+	.store-main,
+	:global(.rail-panel) {
+		border: none;
 		background: var(--sig-surface);
 	}
 
-	.utility-left {
-		display: flex;
-		align-items: baseline;
-		gap: 10px;
-		min-width: 0;
-	}
-
-	.utility-kicker {
-		font-family: var(--font-display);
-		font-size: 12px;
-		text-transform: uppercase;
-		letter-spacing: 0.06em;
-		color: var(--sig-text-bright);
-	}
-
-	.utility-copy {
-		font-family: var(--font-mono);
-		font-size: 10px;
-		color: var(--sig-text-muted);
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-
-	.utility-stats {
-		display: flex;
-		gap: 8px;
-		flex-wrap: wrap;
-		justify-content: flex-end;
-	}
-
-	.utility-stats span {
-		font-family: var(--font-mono);
-		font-size: 9px;
-		text-transform: uppercase;
-		letter-spacing: 0.08em;
-		padding: 3px 6px;
-		border: 1px solid var(--sig-border-strong);
-		color: var(--sig-text-muted);
-	}
-
-	.market-search-row {
-		display: grid;
-		grid-template-columns: 1fr 190px;
-		gap: 8px;
-	}
-
-	.market-search {
-		height: 34px;
-		padding: 0 10px;
-		font-family: var(--font-mono);
-		font-size: 11px;
-		color: var(--sig-text-bright);
-		background: var(--sig-surface-raised);
-		border: 1px solid var(--sig-border-strong);
-		outline: none;
-		border-radius: 0.5rem;
-	}
-
-	:global(.market-select) {
-		height: 34px;
-		padding: 0 10px;
-		font-family: var(--font-mono);
-		font-size: 11px;
-		color: var(--sig-text-bright);
-		background: var(--sig-surface-raised);
-		border: 1px solid var(--sig-border-strong);
-		outline: none;
-		border-radius: 0.5rem;
-	}
-
-	.market-search:focus,
-	:global(.market-select:focus) {
-		border-color: var(--sig-accent);
-	}
-
-	:global(.market-select-content) {
-		background: var(--sig-surface-raised);
-		border: 1px solid var(--sig-border-strong);
-		border-radius: 0.5rem;
-	}
-
-	:global(.market-select-item) {
-		font-family: var(--font-mono);
-		font-size: 10px;
-	}
-
-	.hero-panel {
+	.hero {
 		display: grid;
 		grid-template-columns: minmax(0, 1fr) 260px;
 		gap: 10px;
 		padding: 14px;
-		border: 1px solid var(--sig-border);
 		background:
-			radial-gradient(circle at 85% -20%, color-mix(in srgb, var(--sig-accent) 18%, transparent), transparent 45%),
-			linear-gradient(140deg, color-mix(in srgb, var(--sig-surface-raised) 85%, black) 0%, var(--sig-surface) 65%);
-	}
-
-	.hero-label {
-		margin: 0;
-		font-family: var(--font-mono);
-		font-size: 10px;
-		text-transform: uppercase;
-		letter-spacing: 0.12em;
-		color: var(--sig-text-muted);
+			radial-gradient(circle at 85% -20%, color-mix(in srgb, var(--sig-accent) 16%, transparent), transparent 45%),
+			linear-gradient(140deg, color-mix(in srgb, var(--sig-surface-raised) 88%, black) 0%, var(--sig-surface) 65%);
 	}
 
 	.hero-main h2 {
 		margin: 8px 0 4px;
-		font-family: var(--font-display);
-		font-size: clamp(20px, 2vw, 28px);
-		text-transform: uppercase;
-		letter-spacing: 0.03em;
-		color: var(--sig-text-bright);
+		font-size: clamp(19px, 2vw, 27px);
 		line-height: 1.15;
 	}
 
 	.hero-main p {
 		margin: 0;
-		max-width: 70ch;
 		font-family: var(--font-mono);
 		font-size: 11px;
 		line-height: 1.55;
 		color: var(--sig-text);
+	}
+
+	.hero-aside {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.hero-metric {
+		display: flex;
+		flex-direction: column;
+		gap: 3px;
+		padding: 8px;
+		background: color-mix(in srgb, var(--sig-surface-raised) 55%, transparent);
+		border-radius: 0.45rem;
+	}
+
+	.hero-metric span {
+		font-family: var(--font-mono);
+		font-size: 9px;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--sig-text-muted);
+	}
+
+	.hero-metric strong {
+		font-family: var(--font-display);
+		font-size: 11px;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--sig-text-bright);
+	}
+
+	.module-search,
+	.input,
+	:global(.section-select) {
+		height: 34px;
+		padding: 0 10px;
+		font-family: var(--font-mono);
+		font-size: 11px;
+		color: var(--sig-text-bright);
+		background: var(--sig-surface-raised);
+		border: 1px solid var(--sig-border-strong);
+		outline: none;
+		border-radius: 0.5rem;
+	}
+
+	:global(.section-select-content) {
+		background: var(--sig-surface-raised);
+		border: 1px solid var(--sig-border-strong);
+		border-radius: 0.5rem;
+	}
+
+	:global(.section-select-item) {
+		font-family: var(--font-mono);
+		font-size: 10px;
+	}
+
+	.store-grid {
+		flex: 1;
+		min-height: 0;
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) 250px;
+		gap: 10px;
+	}
+
+	.store-main {
+		display: flex;
+		flex-direction: column;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	.module-head {
+		display: grid;
+		grid-template-columns: minmax(260px, 1fr) auto;
+		align-items: center;
+		gap: 8px;
+		padding: 0 8px;
+		margin-bottom: 8px;
+	}
+
+	.module-search {
+		height: 30px;
+		min-width: 0;
+		width: 100%;
+		padding-right: 72px;
+	}
+
+	.module-search-wrap {
+		display: block;
+	}
+
+	.module-search-inner {
+		position: relative;
+		display: flex;
+		align-items: center;
+	}
+
+	:global(.search-clear) {
+		position: absolute;
+		right: 4px;
+		height: 22px;
+		min-height: 22px;
+		padding: 0 8px;
+		font-family: var(--font-mono);
+		font-size: 9px;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+	}
+
+	.module-view-tabs {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	:global(.view-tab) {
+		height: 30px;
+		font-family: var(--font-mono);
+		font-size: 10px;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+	}
+
+	:global(.view-tab.view-tab-active) {
+		border-color: var(--sig-accent);
+		color: var(--sig-text-bright);
 	}
 
 	.hero-actions {
@@ -312,147 +652,156 @@ function applySpotlight(item: SpotlightItem): void {
 		margin-top: 12px;
 	}
 
-	.hero-action {
+	:global(.hero-switch) {
 		height: 30px;
+		font-size: 10px;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+	}
+
+	:global(.hero-switch.hero-switch-active) {
+		border-color: var(--sig-accent);
+		color: var(--sig-text-bright);
+		background: color-mix(in srgb, var(--sig-surface-raised) 84%, transparent);
+	}
+
+	.module-body {
+		flex: 1;
+		min-height: 0;
+	}
+
+	.store-rail {
+		min-height: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+		overflow-y: auto;
+		padding-top: 2px;
+		justify-self: center;
+		width: 100%;
+		max-width: 250px;
+	}
+
+	:global(.rail-panel) {
+		padding: 8px;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		background: color-mix(in srgb, var(--sig-surface-raised) 35%, transparent);
+		border-radius: 0.5rem;
+	}
+
+	:global(.rail-trigger) {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		width: 100%;
+		padding: 2px 0;
+		background: transparent;
+		border: none;
+		font-family: var(--font-display);
+		font-size: 11px;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--sig-text-bright);
+		cursor: pointer;
+	}
+
+	:global(.rail-content) {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		padding-top: 6px;
+	}
+
+	:global(.rail-select) {
+		height: 32px;
+		width: 100%;
 		padding: 0 10px;
 		font-family: var(--font-mono);
 		font-size: 10px;
 		text-transform: uppercase;
-		letter-spacing: 0.08em;
-		border: 1px solid var(--sig-accent);
-		background: var(--sig-accent);
-		color: var(--sig-bg);
-		cursor: pointer;
-	}
-
-	.hero-action.ghost {
-		border-color: var(--sig-border-strong);
-		background: transparent;
-		color: var(--sig-text-bright);
-	}
-
-	.hero-side {
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
-	}
-
-	.hero-metric {
-		padding: 8px;
-		border: 1px solid var(--sig-border);
-		background: color-mix(in srgb, var(--sig-surface-raised) 80%, transparent);
-		display: flex;
-		flex-direction: column;
-		gap: 3px;
-	}
-
-	.metric-label {
-		font-family: var(--font-mono);
-		font-size: 9px;
-		text-transform: uppercase;
-		letter-spacing: 0.1em;
-		color: var(--sig-text-muted);
-	}
-
-	.metric-value {
-		font-family: var(--font-display);
-		font-size: 11px;
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
-		color: var(--sig-text-bright);
-	}
-
-	.spotlight-row {
-		display: flex;
-		gap: 8px;
-		overflow-x: auto;
-		padding-bottom: 2px;
-	}
-
-	.spotlight-card {
-		min-width: 170px;
-		padding: 8px;
-		border: 1px solid var(--sig-border);
+		letter-spacing: 0.06em;
 		background: var(--sig-surface-raised);
+		border: 1px solid var(--sig-border-strong);
+		border-radius: 0.5rem;
+	}
+
+	.rail-refresh {
 		display: flex;
 		flex-direction: column;
-		gap: 3px;
-		text-align: left;
-		cursor: pointer;
+		gap: 6px;
+		padding-top: 4px;
 	}
 
-	.spotlight-card:hover {
-		border-color: var(--sig-accent);
-	}
-
-	.spotlight-title {
-		font-family: var(--font-display);
-		font-size: 11px;
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
-		color: var(--sig-text-bright);
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
-	}
-
-	.spotlight-subtitle {
-		font-family: var(--font-mono);
-		font-size: 9px;
-		text-transform: uppercase;
-		letter-spacing: 0.08em;
-		color: var(--sig-text-muted);
-	}
-
-	.content-shell {
-		flex: 1;
-		min-height: 0;
-		overflow: hidden;
-		display: flex;
-		flex-direction: column;
-		border: 1px solid var(--sig-border);
-		background: var(--sig-surface);
-	}
-
-	.section-bar {
-		border-bottom: 1px solid var(--sig-border);
-		padding: 0 6px;
-	}
-
-	.content-body {
-		flex: 1;
-		min-height: 0;
-	}
-
-	:global(.section-trigger) {
+	:global(.rail-btn) {
+		justify-content: flex-start;
 		font-family: var(--font-mono);
 		font-size: 10px;
-		text-transform: uppercase;
-		letter-spacing: 0.09em;
-		color: var(--sig-text-muted);
-		background: transparent;
-		border-radius: 0;
-		border-bottom: 2px solid transparent;
-		padding: 8px 12px;
+		height: 30px;
 	}
 
-	:global(.section-trigger[data-state="active"]) {
-		color: var(--sig-text-bright);
-		border-bottom-color: var(--sig-accent);
-		box-shadow: none;
+	.muted {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		color: var(--sig-text-muted);
+	}
+
+	.toggle-row span,
+	.error {
+		font-family: var(--font-mono);
+		font-size: 10px;
+	}
+
+	.toggle-row span {
+		color: var(--sig-text-muted);
+	}
+
+	.toggle-row {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.sync-actions {
+		display: flex;
+		gap: 6px;
+		flex-wrap: wrap;
+	}
+
+	.error {
+		color: var(--sig-danger);
+	}
+
+	@media (max-width: 1120px) {
+		.store-grid {
+			grid-template-columns: 1fr;
+		}
+
+		.store-rail {
+			display: grid;
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+			gap: 8px;
+			max-width: none;
+			max-height: none;
+		}
+
+		:global(.rail-panel) {
+			min-height: 0;
+		}
 	}
 
 	@media (max-width: 980px) {
-		.market-search-row {
+		.hero {
 			grid-template-columns: 1fr;
 		}
 
-		.hero-panel {
+		.module-head {
 			grid-template-columns: 1fr;
 		}
 
-		.utility-copy {
-			display: none;
+		.module-search-wrap {
+			display: block;
 		}
 	}
 </style>

--- a/packages/cli/dashboard/src/lib/components/tabs/MemoryTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/MemoryTab.svelte
@@ -301,7 +301,6 @@ function formatIsoDate(value: string): string {
 				{@const tags = parseMemoryTags(memory.tags)}
 				{@const scoreLabel = memoryScoreLabel(memory)}
 
-			<!-- svelte-ignore a11y_no_noninteractive_tabindex a11y_no_noninteractive_element_interactions -->
 			<article
 				class="doc-card relative flex flex-col
 				gap-1.5 p-3 border border-[var(--sig-border-strong)]
@@ -309,41 +308,7 @@ function formatIsoDate(value: string): string {
 				bg-[var(--sig-surface)] overflow-hidden
 				transition-colors duration-150
 				hover:border-[var(--sig-text-muted)]"
-				tabindex="0"
-				aria-label="Memory from {memory.who || 'unknown'}: {memory.content.slice(0, 80)}{memory.content.length > 80 ? '...' : ''}"
-				onkeydown={(e) => {
-					if (!memory.id) return;
-					// Enter or Space: Edit memory (or confirm delete if pending)
-					if (e.key === 'Enter' || e.key === ' ') {
-						e.preventDefault();
-						if (deleteConfirmId === memory.id) {
-							openEditForm(memory.id, "delete");
-							deleteConfirmId = null;
-						} else {
-							openEditForm(memory.id, "edit");
-						}
-					}
-					// Escape: Cancel pending delete confirmation
-					if (e.key === 'Escape' && deleteConfirmId === memory.id) {
-						e.preventDefault();
-						deleteConfirmId = null;
-					}
-					// Delete or Backspace: Show delete confirmation (or confirm if already pending)
-					if (e.key === 'Delete' || e.key === 'Backspace') {
-						e.preventDefault();
-						if (deleteConfirmId === memory.id) {
-							openEditForm(memory.id, "delete");
-							deleteConfirmId = null;
-						} else {
-							deleteConfirmId = memory.id;
-						}
-					}
-					// 's' key: Find similar
-					if (e.key === 's' && !e.metaKey && !e.ctrlKey) {
-						e.preventDefault();
-						findSimilar(memory.id, memory);
-					}
-				}}>
+			>
 
 					<header class="flex justify-between items-start gap-1.5">
 						<div class="flex items-center flex-wrap gap-1">

--- a/packages/cli/dashboard/src/lib/components/tabs/SettingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/SettingsTab.svelte
@@ -338,9 +338,24 @@
 
 		<!-- Discard confirmation dialog -->
 		{#if discardDialogOpen}
-			<div class="dialog-overlay" onclick={() => discardDialogOpen = false}>
-				<div class="dialog" onclick={(e) => e.stopPropagation()}>
-					<div class="dialog-title">Discard changes?</div>
+			<div
+				class="dialog-overlay"
+				role="button"
+				tabindex="0"
+				aria-label="Close discard dialog"
+				onclick={(e) => {
+					if (e.currentTarget !== e.target) return;
+					discardDialogOpen = false;
+				}}
+				onkeydown={(e) => {
+					if (e.key === "Escape" || e.key === "Enter" || e.key === " ") {
+						e.preventDefault();
+						discardDialogOpen = false;
+					}
+				}}
+			>
+				<div class="dialog" role="dialog" aria-modal="true" aria-labelledby="discard-dialog-title">
+					<div class="dialog-title" id="discard-dialog-title">Discard changes?</div>
 					<div class="dialog-body">
 						This will revert all unsaved changes in {dirtyCount} section{dirtyCount !== 1 ? "s" : ""}.
 						This cannot be undone.

--- a/packages/cli/dashboard/src/lib/components/tabs/SkillsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/SkillsTab.svelte
@@ -26,9 +26,15 @@ import { onMount } from "svelte";
 
 interface Props {
 	embedded?: boolean;
+	showViewTabs?: boolean;
+	onreviewrequest?: (payload: {
+		targetType: "skill";
+		targetId: string;
+		targetLabel: string;
+	}) => void | Promise<void>;
 }
 
-const { embedded = false }: Props = $props();
+const { embedded = false, showViewTabs = true, onreviewrequest }: Props = $props();
 
 const searchInputId = "skills-search-input";
 
@@ -55,9 +61,19 @@ function parseSort(value: string): SkillsSort {
 	return "popularity";
 }
 
+function parseProvider(value: string): ProviderFilter {
+	if (value === "skills.sh" || value === "clawhub") return value;
+	return "all";
+}
+
 const activeSortLabel = $derived.by(() => {
 	const match = sortOptions.find((option) => option.value === sk.sortBy);
 	return match?.label ?? "Popularity";
+});
+
+const activeProviderLabel = $derived.by(() => {
+	const match = providerOptions.find((option) => option.value === sk.providerFilter);
+	return match?.label ?? "All";
 });
 
 function switchView(v: SkillsView) {
@@ -232,6 +248,7 @@ onMount(() => {
 	{/if}
 
 	<!-- Tabs bar + controls -->
+	{#if showViewTabs}
 	<Tabs.Root value={sk.view} onValueChange={(v) => switchView(v as SkillsView)}>
 		<div class="flex items-center shrink-0 border-b border-[var(--sig-border)] gap-2">
 			<Tabs.List class="bg-transparent h-auto gap-0 rounded-none border-none">
@@ -250,6 +267,7 @@ onMount(() => {
 			</Tabs.List>
 
 			<!-- Sort + filter controls -->
+			{#if !embedded}
 			<div class="flex items-center gap-2 ml-auto pr-[var(--space-md)]">
 				<!-- Sort dropdown -->
 				<div class="flex items-center gap-1">
@@ -264,22 +282,22 @@ onMount(() => {
 					</Select.Root>
 				</div>
 
-				<!-- Provider filter chips -->
-				<div class="flex items-center gap-0">
-					{#each providerOptions as opt}
-						<button
-							type="button"
-							class="filter-chip"
-							class:active={sk.providerFilter === opt.value}
-							onclick={() => { sk.providerFilter = opt.value; }}
-						>
-							{opt.label}
-						</button>
-					{/each}
+				<div class="flex items-center gap-1">
+					<span class="text-[9px] font-[family-name:var(--font-mono)] text-[var(--sig-text-muted)] uppercase tracking-wider">Provider</span>
+					<Select.Root type="single" value={sk.providerFilter} onValueChange={(v) => { sk.providerFilter = parseProvider(v ?? "all"); }}>
+						<Select.Trigger class="provider-select">{activeProviderLabel}</Select.Trigger>
+						<Select.Content class="sort-select-content">
+							{#each providerOptions as opt}
+								<Select.Item value={opt.value} label={opt.label} class="sort-select-item" />
+							{/each}
+						</Select.Content>
+					</Select.Root>
 				</div>
 			</div>
+			{/if}
 		</div>
 	</Tabs.Root>
+	{/if}
 
 	<!-- Content -->
 	{#if compareItems.length > 0}
@@ -311,6 +329,7 @@ onMount(() => {
 			onemptyaction={handleEmptyAction}
 			compareSelectedKeys={sk.compareSelected}
 			oncomparetoggle={toggleCompare}
+			onreviewrequest={onreviewrequest}
 		/>
 	{/if}
 </div>
@@ -347,31 +366,20 @@ onMount(() => {
 		font-size: 10px;
 	}
 
-	.filter-chip {
+	:global(.provider-select) {
 		font-family: var(--font-mono);
-		font-size: 9px;
-		text-transform: uppercase;
-		letter-spacing: 0.06em;
-		color: var(--sig-text-muted);
-		background: transparent;
-		border: 1px solid var(--sig-border);
-		padding: 2px 8px;
-		cursor: pointer;
-		transition: all 0.1s;
-	}
-	.filter-chip:not(:first-child) {
-		border-left: none;
-	}
-	.filter-chip:hover {
-		color: var(--sig-text);
-		background: var(--sig-surface-raised);
-	}
-	.filter-chip.active {
+		font-size: 10px;
 		color: var(--sig-text-bright);
 		background: var(--sig-surface-raised);
-		border-color: var(--sig-accent);
+		border: 1px solid var(--sig-border-strong);
+		padding: 2px 8px;
+		height: auto;
+		min-height: 28px;
+		outline: none;
+		cursor: pointer;
+		border-radius: 0.5rem;
 	}
-	.filter-chip.active + .filter-chip {
-		border-left-color: var(--sig-accent);
+	:global(.provider-select:focus) {
+		border-color: var(--sig-accent);
 	}
 </style>

--- a/packages/cli/dashboard/src/lib/components/ui/sheet/sheet-content.svelte
+++ b/packages/cli/dashboard/src/lib/components/ui/sheet/sheet-content.svelte
@@ -31,12 +31,14 @@
 		ref = $bindable(null),
 		class: className,
 		side = "right",
+		showClose = true,
 		portalProps,
 		children,
 		...restProps
 	}: WithoutChildrenOrChild<SheetPrimitive.ContentProps> & {
 		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof SheetPortal>>;
 		side?: Side;
+		showClose?: boolean;
 		children: Snippet;
 	} = $props();
 </script>
@@ -50,11 +52,13 @@
 		{...restProps}
 	>
 		{@render children?.()}
-		<SheetPrimitive.Close
-			class="ring-offset-background focus-visible:ring-ring absolute end-4 top-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none"
-		>
-			<XIcon class="size-4" />
-			<span class="sr-only">Close</span>
-		</SheetPrimitive.Close>
+		{#if showClose}
+			<SheetPrimitive.Close
+				class="ring-offset-background focus-visible:ring-ring absolute end-4 top-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none"
+			>
+				<XIcon class="size-4" />
+				<span class="sr-only">Close</span>
+			</SheetPrimitive.Close>
+		{/if}
 	</SheetPrimitive.Content>
 </SheetPortal>

--- a/packages/cli/dashboard/src/lib/stores/marketplace-mcp.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/marketplace-mcp.svelte.ts
@@ -15,6 +15,7 @@ import { toast } from "$lib/stores/toast.svelte";
 
 export type McpCatalogSort = "popularity" | "name" | "official";
 export type McpCatalogSourceFilter = "all" | "mcpservers.org" | "modelcontextprotocol/servers";
+export type McpMarketView = "browse" | "installed";
 
 export const mcpMarket = $state({
 	installed: [] as MarketplaceMcpServer[],
@@ -26,6 +27,7 @@ export const mcpMarket = $state({
 	catalogLoading: false,
 
 	query: "",
+	view: "browse" as McpMarketView,
 	category: "all",
 	source: "all" as McpCatalogSourceFilter,
 	sortBy: "popularity" as McpCatalogSort,

--- a/packages/cli/dashboard/src/lib/stores/marketplace-reviews.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/marketplace-reviews.svelte.ts
@@ -1,0 +1,212 @@
+import {
+	createMarketplaceReview,
+	deleteMarketplaceReview,
+	getMarketplaceReviewConfig,
+	getMarketplaceReviews,
+	syncMarketplaceReviews,
+	updateMarketplaceReviewConfig,
+	type MarketplaceReview,
+	type MarketplaceReviewTargetType,
+} from "$lib/api";
+import { toast } from "$lib/stores/toast.svelte";
+
+const DISPLAY_NAME_KEY = "signet:marketplace:reviews:display-name";
+
+function loadDisplayName(): string {
+	try {
+		return localStorage.getItem(DISPLAY_NAME_KEY) ?? "";
+	} catch {
+		return "";
+	}
+}
+
+function saveDisplayName(value: string): void {
+	try {
+		localStorage.setItem(DISPLAY_NAME_KEY, value);
+	} catch {
+		// localStorage may be unavailable
+	}
+}
+
+export const reviewsMarket = $state({
+	targetType: null as MarketplaceReviewTargetType | null,
+	targetId: null as string | null,
+	targetLabel: "",
+	canReview: false,
+	reviewEligibilityReason: "Install or use this app before leaving a review.",
+
+	loading: false,
+	items: [] as MarketplaceReview[],
+	total: 0,
+	summary: { count: 0, avgRating: 0 },
+
+	displayName: loadDisplayName(),
+	rating: 5,
+	title: "",
+	body: "",
+	submitting: false,
+
+	configLoading: false,
+	configSaving: false,
+	syncing: false,
+	configEnabled: false,
+	configEndpointUrl: "",
+	lastSyncAt: null as string | null,
+	lastSyncError: null as string | null,
+	pendingSync: 0,
+});
+
+export async function setReviewTarget(
+	targetType: MarketplaceReviewTargetType,
+	targetId: string,
+	targetLabel: string,
+	options?: {
+		canReview?: boolean;
+		reason?: string;
+	},
+): Promise<void> {
+	const same =
+		reviewsMarket.targetType === targetType &&
+		reviewsMarket.targetId === targetId &&
+		reviewsMarket.targetLabel === targetLabel;
+	if (same) return;
+
+	reviewsMarket.targetType = targetType;
+	reviewsMarket.targetId = targetId;
+	reviewsMarket.targetLabel = targetLabel;
+	reviewsMarket.canReview = options?.canReview ?? false;
+	reviewsMarket.reviewEligibilityReason =
+		options?.reason ?? "Install or use this app before leaving a review.";
+	await fetchTargetReviews();
+}
+
+export async function fetchTargetReviews(): Promise<void> {
+	if (!reviewsMarket.targetType || !reviewsMarket.targetId) {
+		reviewsMarket.items = [];
+		reviewsMarket.total = 0;
+		reviewsMarket.summary = { count: 0, avgRating: 0 };
+		return;
+	}
+
+	reviewsMarket.loading = true;
+	try {
+		const data = await getMarketplaceReviews({
+			targetType: reviewsMarket.targetType,
+			targetId: reviewsMarket.targetId,
+			limit: 50,
+		});
+		reviewsMarket.items = data.reviews;
+		reviewsMarket.total = data.total;
+		reviewsMarket.summary = data.summary;
+	} finally {
+		reviewsMarket.loading = false;
+	}
+}
+
+export async function submitMarketplaceReview(): Promise<void> {
+	if (!reviewsMarket.targetType || !reviewsMarket.targetId) {
+		toast("Select an item before writing a review", "error");
+		return;
+	}
+
+	if (!reviewsMarket.canReview) {
+		toast(reviewsMarket.reviewEligibilityReason, "error");
+		return;
+	}
+
+	const displayName = reviewsMarket.displayName.trim();
+	const title = reviewsMarket.title.trim();
+	const body = reviewsMarket.body.trim();
+	if (!displayName || !title || !body) {
+		toast("Display name, title, and review are required", "error");
+		return;
+	}
+
+	reviewsMarket.submitting = true;
+	try {
+		const result = await createMarketplaceReview({
+			targetType: reviewsMarket.targetType,
+			targetId: reviewsMarket.targetId,
+			displayName,
+			rating: reviewsMarket.rating,
+			title,
+			body,
+		});
+		if (!result.success) {
+			toast(result.error ?? "Failed to submit review", "error");
+			return;
+		}
+
+		saveDisplayName(displayName);
+		reviewsMarket.title = "";
+		reviewsMarket.body = "";
+		toast("Review posted", "success");
+		await Promise.all([fetchTargetReviews(), loadMarketplaceReviewConfig()]);
+	} finally {
+		reviewsMarket.submitting = false;
+	}
+}
+
+export async function removeMarketplaceReview(id: string): Promise<void> {
+	const result = await deleteMarketplaceReview(id);
+	if (!result.success) {
+		toast(result.error ?? "Failed to delete review", "error");
+		return;
+	}
+	toast("Review deleted", "success");
+	await Promise.all([fetchTargetReviews(), loadMarketplaceReviewConfig()]);
+}
+
+export async function loadMarketplaceReviewConfig(): Promise<void> {
+	reviewsMarket.configLoading = true;
+	try {
+		const config = await getMarketplaceReviewConfig();
+		reviewsMarket.configEnabled = config.enabled;
+		reviewsMarket.configEndpointUrl = config.endpointUrl;
+		reviewsMarket.lastSyncAt = config.lastSyncAt;
+		reviewsMarket.lastSyncError = config.lastSyncError;
+		reviewsMarket.pendingSync = config.pending;
+	} finally {
+		reviewsMarket.configLoading = false;
+	}
+}
+
+export async function saveMarketplaceReviewConfig(): Promise<void> {
+	reviewsMarket.configSaving = true;
+	try {
+		const result = await updateMarketplaceReviewConfig({
+			enabled: reviewsMarket.configEnabled,
+			endpointUrl: reviewsMarket.configEndpointUrl,
+		});
+		if (!result.success || !result.config) {
+			toast(result.error ?? "Failed to save review sync config", "error");
+			return;
+		}
+		reviewsMarket.configEnabled = result.config.enabled;
+		reviewsMarket.configEndpointUrl = result.config.endpointUrl;
+		toast("Review sync config saved", "success");
+	} finally {
+		reviewsMarket.configSaving = false;
+	}
+}
+
+export async function syncMarketplaceReviewsNow(): Promise<void> {
+	reviewsMarket.syncing = true;
+	try {
+		const result = await syncMarketplaceReviews();
+		if (!result.success) {
+			toast(result.error ?? "Review sync failed", "error");
+			await loadMarketplaceReviewConfig();
+			return;
+		}
+
+		if (result.message) {
+			toast(result.message, "success");
+		} else {
+			toast(`Synced ${result.synced ?? 0} reviews`, "success");
+		}
+		await loadMarketplaceReviewConfig();
+	} finally {
+		reviewsMarket.syncing = false;
+	}
+}

--- a/packages/cli/dashboard/src/routes/+page.svelte
+++ b/packages/cli/dashboard/src/routes/+page.svelte
@@ -8,7 +8,6 @@ import { PAGE_HEADERS } from "$lib/components/layout/page-headers";
 import { Button } from "$lib/components/ui/button/index.js";
 import * as Sidebar from "$lib/components/ui/sidebar/index.js";
 import { Toaster } from "$lib/components/ui/sonner/index.js";
-import { mcpMarket } from "$lib/stores/marketplace-mcp.svelte";
 import {
 	clearAll,
 	clearSearchTimer,
@@ -24,7 +23,6 @@ import {
 	nav,
 	setTab,
 } from "$lib/stores/navigation.svelte";
-import { sk } from "$lib/stores/skills.svelte";
 import { openForm, ts } from "$lib/stores/tasks.svelte";
 import { hasUnsavedChanges } from "$lib/stores/unsaved-changes.svelte";
 import { Skeleton } from "$lib/components/ui/skeleton/index.js";
@@ -234,14 +232,6 @@ onMount(() => {
 					<span class="sig-label">
 						Constellation
 					</span>
-				{:else if activeTab === "skills"}
-					<span class="sig-eyebrow">
-						{#if sk.catalogTotal || mcpMarket.catalogTotal}
-							{(sk.catalogTotal + mcpMarket.catalogTotal).toLocaleString()} listed
-							<span class="text-[var(--sig-border-strong)]">&middot;</span>
-						{/if}
-						{sk.installed.length} skills &middot; {mcpMarket.installed.length} tool servers
-					</span>
 				{:else if activeTab === "tasks"}
 					<Button
 						variant="outline"
@@ -410,6 +400,7 @@ onMount(() => {
 			{/if}
 		</div>
 
+		{#if activeTab !== "skills"}
 		<div
 			class="flex items-center justify-between h-[26px] px-4
 				border-t border-[var(--sig-border)]
@@ -449,9 +440,6 @@ onMount(() => {
 			{:else if activeTab === "secrets"}
 				<span>Secrets</span>
 				<span>libsodium</span>
-			{:else if activeTab === "skills"}
-				<span>{sk.installed.length} skills · {mcpMarket.installed.length} tool servers</span>
-				<span>{mcpMarket.tools.length} routed tools</span>
 			{:else if activeTab === "tasks"}
 				<span>{ts.tasks.length} scheduled tasks</span>
 				<span>cron scheduler</span>
@@ -460,6 +448,7 @@ onMount(() => {
 				<span>connector health</span>
 			{/if}
 		</div>
+		{/if}
 	</main>
 </Sidebar.Provider>
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3891,6 +3891,10 @@ mountSkillsRoutes(app);
 import { mountMarketplaceRoutes } from "./routes/marketplace.js";
 mountMarketplaceRoutes(app);
 
+// Marketplace review routes (Signet Reviews scaffold)
+import { mountMarketplaceReviewsRoutes } from "./routes/marketplace-reviews.js";
+mountMarketplaceReviewsRoutes(app);
+
 // ============================================================================
 // Harnesses API
 // ============================================================================

--- a/packages/daemon/src/routes/marketplace-reviews.test.ts
+++ b/packages/daemon/src/routes/marketplace-reviews.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Hono } from "hono";
+import { mountMarketplaceReviewsRoutes } from "./marketplace-reviews.js";
+
+describe("marketplace reviews routes", () => {
+	const tmpAgentsDir = join(tmpdir(), `signet-marketplace-reviews-route-test-${process.pid}`);
+	let origSignetPath: string | undefined;
+	let app: Hono;
+
+	beforeEach(() => {
+		origSignetPath = process.env.SIGNET_PATH;
+		process.env.SIGNET_PATH = tmpAgentsDir;
+		mkdirSync(tmpAgentsDir, { recursive: true });
+
+		app = new Hono();
+		mountMarketplaceReviewsRoutes(app);
+	});
+
+	afterEach(() => {
+		process.env.SIGNET_PATH = origSignetPath;
+		if (existsSync(tmpAgentsDir)) {
+			rmSync(tmpAgentsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("creates and lists reviews for a target", async () => {
+		const createRes = await app.request("/api/marketplace/reviews", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				targetType: "skill",
+				targetId: "skills.sh/foo",
+				displayName: "avery",
+				rating: 5,
+				title: "Great",
+				body: "Does the job",
+			}),
+		});
+
+		expect(createRes.status).toBe(200);
+		const createBody = (await createRes.json()) as { success: boolean };
+		expect(createBody.success).toBe(true);
+
+		const listRes = await app.request("/api/marketplace/reviews?type=skill&id=skills.sh%2Ffoo");
+		expect(listRes.status).toBe(200);
+		const listBody = (await listRes.json()) as {
+			reviews: Array<{ targetType: string; targetId: string; rating: number }>;
+			total: number;
+			summary: { count: number; avgRating: number };
+		};
+
+		expect(listBody.total).toBe(1);
+		expect(listBody.reviews[0]?.targetType).toBe("skill");
+		expect(listBody.reviews[0]?.targetId).toBe("skills.sh/foo");
+		expect(listBody.summary.count).toBe(1);
+		expect(listBody.summary.avgRating).toBe(5);
+	});
+
+	it("updates review sync config", async () => {
+		const patchRes = await app.request("/api/marketplace/reviews/config", {
+			method: "PATCH",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ enabled: true, endpointUrl: "https://example.com/reviews" }),
+		});
+
+		expect(patchRes.status).toBe(200);
+		const patchBody = (await patchRes.json()) as {
+			success: boolean;
+			config: { enabled: boolean; endpointUrl: string };
+		};
+		expect(patchBody.success).toBe(true);
+		expect(patchBody.config.enabled).toBe(true);
+		expect(patchBody.config.endpointUrl).toBe("https://example.com/reviews");
+	});
+});

--- a/packages/daemon/src/routes/marketplace-reviews.ts
+++ b/packages/daemon/src/routes/marketplace-reviews.ts
@@ -1,0 +1,377 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { Hono } from "hono";
+
+type ReviewTargetType = "skill" | "mcp";
+
+interface MarketplaceReview {
+	readonly id: string;
+	readonly targetType: ReviewTargetType;
+	readonly targetId: string;
+	readonly displayName: string;
+	readonly rating: number;
+	readonly title: string;
+	readonly body: string;
+	readonly source: "local" | "synced";
+	readonly createdAt: string;
+	readonly updatedAt: string;
+	readonly syncedAt: string | null;
+}
+
+interface ReviewsSyncConfig {
+	readonly enabled: boolean;
+	readonly endpointUrl: string;
+	readonly lastSyncAt: string | null;
+	readonly lastSyncError: string | null;
+}
+
+const DEFAULT_CONFIG: ReviewsSyncConfig = {
+	enabled: false,
+	endpointUrl: "",
+	lastSyncAt: null,
+	lastSyncError: null,
+};
+
+function getAgentsDir(): string {
+	return process.env.SIGNET_PATH || join(homedir(), ".agents");
+}
+
+function getMarketplaceDir(): string {
+	return join(getAgentsDir(), "marketplace");
+}
+
+function getReviewsPath(): string {
+	return join(getMarketplaceDir(), "reviews.json");
+}
+
+function getReviewsConfigPath(): string {
+	return join(getMarketplaceDir(), "reviews-config.json");
+}
+
+function ensureMarketplaceDir(): void {
+	const dir = getMarketplaceDir();
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true });
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseTargetType(value: unknown): ReviewTargetType | null {
+	if (value === "skill" || value === "mcp") {
+		return value;
+	}
+	return null;
+}
+
+function parseText(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	if (trimmed.length === 0) return null;
+	return trimmed;
+}
+
+function parseRating(value: unknown): number | null {
+	if (typeof value !== "number" || !Number.isFinite(value)) return null;
+	const rounded = Math.round(value);
+	if (rounded < 1 || rounded > 5) return null;
+	return rounded;
+}
+
+function normalizeReview(value: unknown): MarketplaceReview | null {
+	if (!isRecord(value)) return null;
+	const targetType = parseTargetType(value.targetType);
+	const targetId = parseText(value.targetId);
+	const displayName = parseText(value.displayName);
+	const rating = parseRating(value.rating);
+	const title = parseText(value.title);
+	const body = parseText(value.body);
+	const id = parseText(value.id);
+	const createdAt = parseText(value.createdAt);
+	const updatedAt = parseText(value.updatedAt);
+	const source = value.source === "synced" ? "synced" : "local";
+	const syncedAt = typeof value.syncedAt === "string" ? value.syncedAt : null;
+
+	if (!targetType || !targetId || !displayName || !rating || !title || !body || !id || !createdAt || !updatedAt) {
+		return null;
+	}
+
+	return {
+		id,
+		targetType,
+		targetId,
+		displayName,
+		rating,
+		title,
+		body,
+		source,
+		createdAt,
+		updatedAt,
+		syncedAt,
+	};
+}
+
+function readReviews(): MarketplaceReview[] {
+	const path = getReviewsPath();
+	if (!existsSync(path)) return [];
+	try {
+		const raw = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+		if (!Array.isArray(raw)) return [];
+		return raw.map(normalizeReview).filter((item): item is MarketplaceReview => item !== null);
+	} catch {
+		return [];
+	}
+}
+
+function writeReviews(reviews: readonly MarketplaceReview[]): void {
+	ensureMarketplaceDir();
+	writeFileSync(getReviewsPath(), JSON.stringify(reviews, null, 2), "utf-8");
+}
+
+function readConfig(): ReviewsSyncConfig {
+	const path = getReviewsConfigPath();
+	if (!existsSync(path)) return DEFAULT_CONFIG;
+	try {
+		const raw = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+		if (!isRecord(raw)) return DEFAULT_CONFIG;
+		return {
+			enabled: raw.enabled === true,
+			endpointUrl: typeof raw.endpointUrl === "string" ? raw.endpointUrl : "",
+			lastSyncAt: typeof raw.lastSyncAt === "string" ? raw.lastSyncAt : null,
+			lastSyncError: typeof raw.lastSyncError === "string" ? raw.lastSyncError : null,
+		};
+	} catch {
+		return DEFAULT_CONFIG;
+	}
+}
+
+function writeConfig(config: ReviewsSyncConfig): void {
+	ensureMarketplaceDir();
+	writeFileSync(getReviewsConfigPath(), JSON.stringify(config, null, 2), "utf-8");
+}
+
+function parseLimit(raw: string | undefined): number {
+	if (!raw) return 20;
+	const value = Number(raw);
+	if (!Number.isFinite(value)) return 20;
+	return Math.max(1, Math.min(100, Math.round(value)));
+}
+
+function parseOffset(raw: string | undefined): number {
+	if (!raw) return 0;
+	const value = Number(raw);
+	if (!Number.isFinite(value)) return 0;
+	return Math.max(0, Math.round(value));
+}
+
+function summarize(reviews: readonly MarketplaceReview[]): { count: number; avgRating: number } {
+	if (reviews.length === 0) return { count: 0, avgRating: 0 };
+	const total = reviews.reduce((sum, item) => sum + item.rating, 0);
+	return {
+		count: reviews.length,
+		avgRating: Number((total / reviews.length).toFixed(2)),
+	};
+}
+
+export function mountMarketplaceReviewsRoutes(app: Hono): void {
+	app.get("/api/marketplace/reviews", (c) => {
+		const targetType = parseTargetType(c.req.query("type"));
+		const targetId = parseText(c.req.query("id"));
+		const limit = parseLimit(c.req.query("limit"));
+		const offset = parseOffset(c.req.query("offset"));
+
+		const allReviews = readReviews().sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+		const filtered = allReviews.filter((item) => {
+			if (targetType && item.targetType !== targetType) return false;
+			if (targetId && item.targetId !== targetId) return false;
+			return true;
+		});
+
+		const page = filtered.slice(offset, offset + limit);
+		return c.json({
+			reviews: page,
+			total: filtered.length,
+			limit,
+			offset,
+			summary: summarize(filtered),
+		});
+	});
+
+	app.post("/api/marketplace/reviews", async (c) => {
+		let body: {
+			targetType?: unknown;
+			targetId?: unknown;
+			displayName?: unknown;
+			rating?: unknown;
+			title?: unknown;
+			body?: unknown;
+		} = {};
+
+		try {
+			body = await c.req.json();
+		} catch {
+			return c.json({ error: "Invalid JSON body" }, 400);
+		}
+
+		const targetType = parseTargetType(body.targetType);
+		const targetId = parseText(body.targetId);
+		const displayName = parseText(body.displayName);
+		const rating = parseRating(body.rating);
+		const title = parseText(body.title);
+		const reviewBody = parseText(body.body);
+
+		if (!targetType || !targetId || !displayName || !rating || !title || !reviewBody) {
+			return c.json({ error: "targetType, targetId, displayName, rating, title, and body are required" }, 400);
+		}
+
+		const now = new Date().toISOString();
+		const review: MarketplaceReview = {
+			id: randomUUID(),
+			targetType,
+			targetId,
+			displayName,
+			rating,
+			title,
+			body: reviewBody,
+			source: "local",
+			createdAt: now,
+			updatedAt: now,
+			syncedAt: null,
+		};
+
+		const reviews = readReviews();
+		writeReviews([review, ...reviews]);
+		return c.json({ success: true, review });
+	});
+
+	app.patch("/api/marketplace/reviews/config", async (c) => {
+		let body: { enabled?: unknown; endpointUrl?: unknown } = {};
+		try {
+			body = await c.req.json();
+		} catch {
+			return c.json({ error: "Invalid JSON body" }, 400);
+		}
+
+		const current = readConfig();
+		const next: ReviewsSyncConfig = {
+			enabled: typeof body.enabled === "boolean" ? body.enabled : current.enabled,
+			endpointUrl: body.endpointUrl === undefined ? current.endpointUrl : typeof body.endpointUrl === "string" ? body.endpointUrl.trim() : current.endpointUrl,
+			lastSyncAt: current.lastSyncAt,
+			lastSyncError: current.lastSyncError,
+		};
+
+		writeConfig(next);
+		return c.json({ success: true, config: next });
+	});
+
+	app.patch("/api/marketplace/reviews/:id", async (c) => {
+		const id = c.req.param("id");
+		let body: {
+			displayName?: unknown;
+			rating?: unknown;
+			title?: unknown;
+			body?: unknown;
+		} = {};
+
+		try {
+			body = await c.req.json();
+		} catch {
+			return c.json({ error: "Invalid JSON body" }, 400);
+		}
+
+		const reviews = readReviews();
+		const existing = reviews.find((item) => item.id === id);
+		if (!existing) {
+			return c.json({ error: "Review not found" }, 404);
+		}
+
+		const displayName = body.displayName === undefined ? existing.displayName : parseText(body.displayName);
+		const rating = body.rating === undefined ? existing.rating : parseRating(body.rating);
+		const title = body.title === undefined ? existing.title : parseText(body.title);
+		const reviewBody = body.body === undefined ? existing.body : parseText(body.body);
+
+		if (!displayName || !rating || !title || !reviewBody) {
+			return c.json({ error: "displayName, rating, title, and body must be valid when provided" }, 400);
+		}
+
+		const updated: MarketplaceReview = {
+			...existing,
+			displayName,
+			rating,
+			title,
+			body: reviewBody,
+			updatedAt: new Date().toISOString(),
+			syncedAt: null,
+		};
+
+		writeReviews(reviews.map((item) => (item.id === id ? updated : item)));
+		return c.json({ success: true, review: updated });
+	});
+
+	app.delete("/api/marketplace/reviews/:id", (c) => {
+		const id = c.req.param("id");
+		const reviews = readReviews();
+		if (!reviews.some((item) => item.id === id)) {
+			return c.json({ error: "Review not found" }, 404);
+		}
+
+		writeReviews(reviews.filter((item) => item.id !== id));
+		return c.json({ success: true, id });
+	});
+
+	app.get("/api/marketplace/reviews/config", (c) => {
+		const config = readConfig();
+		const pending = readReviews().filter((item) => item.syncedAt === null || item.updatedAt > item.syncedAt).length;
+		return c.json({ ...config, pending });
+	});
+
+	app.post("/api/marketplace/reviews/sync", async (c) => {
+		const config = readConfig();
+		if (!config.enabled || config.endpointUrl.length === 0) {
+			return c.json({ success: false, error: "Review sync endpoint is not configured" }, 400);
+		}
+
+		const reviews = readReviews();
+		const pending = reviews.filter((item) => item.syncedAt === null || item.updatedAt > item.syncedAt);
+		if (pending.length === 0) {
+			return c.json({ success: true, sent: 0, synced: 0, message: "No pending reviews" });
+		}
+
+		try {
+			const response = await fetch(config.endpointUrl, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					source: "signet-marketplace",
+					type: "reviews-sync",
+					sentAt: new Date().toISOString(),
+					reviews: pending,
+				}),
+			});
+
+			if (!response.ok) {
+				const errorText = `Sync endpoint returned HTTP ${response.status}`;
+				writeConfig({ ...config, lastSyncError: errorText });
+				return c.json({ success: false, error: errorText }, 502);
+			}
+
+			const syncedAt = new Date().toISOString();
+			const pendingIds = new Set(pending.map((item) => item.id));
+			const nextReviews = reviews.map((item) =>
+				pendingIds.has(item.id) ? { ...item, syncedAt, source: "synced" as const } : item,
+			);
+			writeReviews(nextReviews);
+
+			writeConfig({ ...config, lastSyncAt: syncedAt, lastSyncError: null });
+			return c.json({ success: true, sent: pending.length, synced: pending.length, syncedAt });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			writeConfig({ ...config, lastSyncError: message });
+			return c.json({ success: false, error: message }, 502);
+		}
+	});
+}


### PR DESCRIPTION
## Summary

Scrub a dub dub. Avery was hard at work here. Here's what he did:

- Unifies Marketplace app-detail behavior across Agent Skills and MCP Servers by opening full side detail sheets from card clicks, with matching install/remove actions and in-sheet Signet Reviews.
- Adds scoped review plumbing end-to-end (dashboard store + daemon routes + tests) so reviews are tied to each specific app/target ID, including stable IDs for installed MCP servers without catalog IDs.
- Refines Marketplace UX polish requested in review: remove card-level REVIEW buttons, hide detail-sheet close `x`, improve icon theme contrast for dark/light modes, and make mobile rail controls collapse by default with `Sort | Sync` side-by-side.
- Documents staged Cloudflare review-sync architecture and handoff notes for Nicholai in `docs/specs/planning/marketplace-reviews-cloudflare-staging.md`.

## Testing
- `cd packages/cli/dashboard && bun run check` (passes with warnings only)
- `cd packages/cli/dashboard && bun run build` (passes; warnings only)
- `bun test packages/daemon/src/routes/marketplace-reviews.test.ts` (2 passed)
- `bun run typecheck` (workspace typecheck command succeeds)
- `bun run lint` currently reports repository-wide Biome formatting/lint diagnostics not specific to this branch's functional changes

## Notes
- This branch was rebased onto latest `origin/main` before PR creation.
- Remaining warnings seen in dashboard checks are existing a11y/style warnings in unrelated areas and do not block build output.