### PR TITLE
docs: add OpenClaw migration guidance and self-healing checks

### DIFF
--- a/packages/signetai/templates/skills/onboarding/SKILL.md
+++ b/packages/signetai/templates/skills/onboarding/SKILL.md
@@ -639,6 +639,39 @@ curl -s http://localhost:3850/api/hooks/synthesis/config
 If the daemon isn't running, suggest `signet restart`. If synthesis
 hasn't run recently, suggest triggering it manually.
 
+### OpenClaw Integration Check
+
+If the user has OpenClaw (or Clawdbot/Moltbot) installed, check
+that Signet is the sole memory provider. Both systems running
+simultaneously causes token burn and duplicate context.
+
+```bash
+# Find OpenClaw configs
+find ~/.openclaw ~/.clawdbot ~/.moltbot ~/.config/openclaw \
+  -name "*.json" -o -name "*.json5" 2>/dev/null
+```
+
+For each config found, verify:
+
+1. **`memorySearch.enabled` is `false`** — If true or missing,
+   OpenClaw's native memory is still active alongside Signet.
+2. **`signet-memory-openclaw` plugin is registered** — Check
+   `plugins.entries["signet-memory-openclaw"].enabled` is `true`.
+3. **No dual runtime paths** — Either the plugin path OR legacy
+   hooks should be active, not both.
+
+If any check fails, fix with:
+```bash
+signet setup --harness openclaw
+```
+
+Report the OpenClaw integration status in the audit summary:
+```
+openclaw integration: [healthy/dual-system detected/not installed]
+memorySearch disabled: [yes/no/n/a]
+runtime path: [plugin/legacy/n/a]
+```
+
 ### Report
 
 After the audit, provide a summary:

--- a/packages/signetai/templates/skills/onboarding/SKILL.md
+++ b/packages/signetai/templates/skills/onboarding/SKILL.md
@@ -647,7 +647,10 @@ simultaneously causes token burn and duplicate context.
 
 ```bash
 # Find OpenClaw configs
-find ~/.openclaw ~/.clawdbot ~/.moltbot ~/.config/openclaw \
+# Find OpenClaw configs
+find ~/.openclaw ~/.clawdbot ~/.moltbot \
+  ~/.config/openclaw ~/.config/clawdbot ~/.config/moltbot \
+  ~/.local/state/openclaw ~/.local/state/clawdbot ~/.local/state/moltbot \
   -name "*.json" -o -name "*.json5" 2>/dev/null
 ```
 

--- a/packages/signetai/templates/skills/signet/SKILL.md
+++ b/packages/signetai/templates/skills/signet/SKILL.md
@@ -237,6 +237,113 @@ Use `--non-interactive` when the agent needs to complete setup without
 waiting for terminal prompts. Ask the user for provider choices first,
 then pass both provider flags explicitly.
 
+## OpenClaw Coexistence & Self-Healing
+
+Signet replaces OpenClaw's memory layer — it does NOT replace OpenClaw
+itself. After installation, OpenClaw continues to handle the harness
+(tool routing, session management, MCP servers, extensions) while
+Signet handles identity, memory, and personality.
+
+### How It Should Work
+
+The OpenClaw connector patches `openclaw.json` to:
+1. Register `signet-memory-openclaw` as the memory plugin
+2. Set `agents.defaults.memorySearch.enabled: false` (disables
+   OpenClaw's built-in memory)
+3. Set `agents.defaults.workspace` to `~/.agents/`
+
+When this is working correctly, only Signet injects memory context.
+OpenClaw's native memory system is fully disabled.
+
+### Detecting the Dual-System Problem
+
+If the user reports high token burn, duplicate memories, or bloated
+context after installing Signet, both memory systems may be active.
+Run these checks:
+
+```bash
+# Find all OpenClaw config files
+find ~/.openclaw ~/.clawdbot ~/.moltbot ~/.config/openclaw \
+  ~/.config/clawdbot ~/.config/moltbot ~/.local/state/openclaw \
+  -name "*.json" -o -name "*.json5" 2>/dev/null
+
+# For each config found, check these fields:
+cat <config_path>
+```
+
+**Check 1: Is OpenClaw's native memory disabled?**
+Look for `agents.defaults.memorySearch.enabled`. It MUST be `false`.
+If it's `true` or missing, OpenClaw is still running its own memory
+search alongside Signet.
+
+**Check 2: Is the Signet plugin registered?**
+Look for `plugins.entries["signet-memory-openclaw"]`. It should exist
+with `enabled: true`. If missing, the connector patch didn't land.
+
+**Check 3: Which runtime path is active?**
+- **Plugin path** (preferred): `plugins.slots.memory` is set to
+  `"signet-memory-openclaw"`. Automatic memory on every prompt.
+- **Legacy path**: `hooks.internal.entries["signet-memory"]` is
+  enabled. Manual — requires `/remember` and `/recall` commands.
+- **Both active**: This shouldn't happen (the daemon enforces a mutex),
+  but if both are configured, the plugin path takes priority. Clean
+  up by disabling the legacy hook entry.
+
+### Fixing the Problem
+
+**Option 1: Re-run setup** (preferred)
+```bash
+signet setup --harness openclaw
+```
+This re-discovers configs and re-patches them. Safe to run multiple
+times — the connector is idempotent.
+
+**Option 2: Manual patch** (if setup can't find the config)
+
+Find the config file and ensure it contains:
+```json
+{
+  "plugins": {
+    "slots": { "memory": "signet-memory-openclaw" },
+    "entries": {
+      "signet-memory-openclaw": {
+        "enabled": true,
+        "config": { "daemonUrl": "http://localhost:3850" }
+      }
+    }
+  },
+  "agents": {
+    "defaults": {
+      "memorySearch": { "enabled": false }
+    }
+  }
+}
+```
+
+**Option 3: Verify the fix**
+```bash
+# Restart the daemon to pick up changes
+signet daemon restart
+
+# Check daemon health
+curl -s http://localhost:3850/health
+
+# Check that Signet is the active memory provider
+signet status
+```
+
+After fixing, run a test conversation and verify that token usage
+has decreased and memory context isn't duplicated.
+
+### Why This Breaks
+
+OpenClaw ships frequent updates (the upstream has 40k+ commits in
+recent months). Any upstream change to how plugins are loaded, how
+`memorySearch` is respected, or where config files are stored can
+break the connector's patch. The connector works on tested versions,
+but it cannot guarantee compatibility with every future OpenClaw
+release. When in doubt, check the config manually.
+
 ## Commands Reference
 
 ```bash

--- a/packages/signetai/templates/skills/signet/SKILL.md
+++ b/packages/signetai/templates/skills/signet/SKILL.md
@@ -263,8 +263,10 @@ Run these checks:
 
 ```bash
 # Find all OpenClaw config files
-find ~/.openclaw ~/.clawdbot ~/.moltbot ~/.config/openclaw \
-  ~/.config/clawdbot ~/.config/moltbot ~/.local/state/openclaw \
+find ~/.openclaw ~/.clawdbot ~/.moltbot \
+  ~/.config/openclaw ~/.config/clawdbot ~/.config/moltbot \
+  ~/.local/state/openclaw ~/.local/state/clawdbot ~/.local/state/moltbot \
+  -name "*.json" -o -name "*.json5" 2>/dev/null
   -name "*.json" -o -name "*.json5" 2>/dev/null
 
 # For each config found, check these fields:

--- a/web/public/skill.md
+++ b/web/public/skill.md
@@ -463,6 +463,99 @@ automatically.
 - If migration fails or you want to start fresh, you can re-run
   `signet setup` and choose "Start fresh" instead.
 
+### OpenClaw-Specific Migration
+
+OpenClaw (also known as Clawdbot and Moltbot — same platform, different
+names) has its own built-in memory system. When Signet installs the
+OpenClaw connector, it **must** disable OpenClaw's native memory to
+prevent both systems running simultaneously. If both are active, you
+get duplicate context injection and increased token burn — the opposite
+of what Signet is supposed to fix.
+
+**What `signet setup` does automatically:**
+
+1. Discovers OpenClaw config files. The connector searches these
+   locations in order:
+   - `$OPENCLAW_CONFIG_PATH` (if set, colon-separated)
+   - `$OPENCLAW_HOME/openclaw.json`
+   - `~/.openclaw/openclaw.json`
+   - `~/.clawdbot/clawdbot.json` (old name)
+   - `~/.moltbot/moltbot.json` (oldest name)
+   - `$XDG_CONFIG_HOME/openclaw/openclaw.json`
+   - `$XDG_STATE_HOME/openclaw/openclaw.json`
+   - (same pattern for clawdbot/moltbot under XDG paths)
+
+2. Patches the config to register Signet's memory plugin:
+   ```json
+   {
+     "plugins": {
+       "slots": { "memory": "signet-memory-openclaw" },
+       "entries": {
+         "signet-memory-openclaw": {
+           "enabled": true,
+           "config": { "daemonUrl": "http://localhost:3850" }
+         }
+       }
+     },
+     "agents": {
+       "defaults": {
+         "workspace": "/home/user/.agents",
+         "memorySearch": { "enabled": false }
+       }
+     }
+   }
+   ```
+
+3. Sets `memorySearch.enabled: false` — this is the critical line
+   that disables OpenClaw's built-in memory search.
+
+4. Sets the workspace to `~/.agents/` so OpenClaw reads identity
+   files directly (no generated output file needed).
+
+**Two runtime paths:**
+
+- **Plugin path** (preferred): `signet-memory-openclaw` runs as a
+  native OpenClaw plugin. Automatic memory injection on every prompt,
+  automatic extraction on session end. Full tool suite registered.
+- **Legacy path**: Hook-based. Uses `/remember`, `/recall`, `/context`
+  slash commands. Manual — the user has to explicitly invoke commands.
+
+The plugin path is preferred because it's fully automatic. The legacy
+path exists for backward compatibility with older OpenClaw versions
+that don't support the plugin API.
+
+**If migration didn't work (both systems still active):**
+
+OpenClaw ships frequent updates. If the connector's config patch
+didn't land correctly (schema change, different config location, etc.),
+both memory systems may be running simultaneously. Signs of this:
+
+- Token burn didn't decrease after installing Signet
+- Duplicate memory entries appearing
+- Context feels bloated with redundant information
+
+To diagnose and fix:
+
+```bash
+# 1. Find your OpenClaw config
+find ~/.openclaw ~/.clawdbot ~/.moltbot ~/.config/openclaw \
+  -name "*.json" -o -name "*.json5" 2>/dev/null
+
+# 2. Check if memorySearch is disabled (should be false)
+cat <config_path> | grep -A1 memorySearch
+
+# 3. Check if the plugin is registered
+cat <config_path> | grep -A3 signet-memory-openclaw
+
+# 4. If either check fails, re-run setup
+signet setup --harness openclaw
+```
+
+If `signet setup` can't find the config, you may need to manually
+patch `openclaw.json` with the JSON shown above. The critical fields
+are `plugins.entries["signet-memory-openclaw"].enabled: true` and
+`agents.defaults.memorySearch.enabled: false`.
+
 ---
 
 ## Platform-Specific Details

--- a/web/public/skill.md
+++ b/web/public/skill.md
@@ -535,9 +535,11 @@ both memory systems may be running simultaneously. Signs of this:
 - Context feels bloated with redundant information
 
 To diagnose and fix:
-
-```bash
 # 1. Find your OpenClaw config
+find ~/.openclaw ~/.clawdbot ~/.moltbot \
+  ~/.config/openclaw ~/.config/clawdbot ~/.config/moltbot \
+  ~/.local/state/openclaw ~/.local/state/clawdbot ~/.local/state/moltbot \
+  -name "*.json" -o -name "*.json5" 2>/dev/null
 find ~/.openclaw ~/.clawdbot ~/.moltbot ~/.config/openclaw \
   -name "*.json" -o -name "*.json5" 2>/dev/null
 


### PR DESCRIPTION
## Summary

- Expands the install guide (`web/public/skill.md`) with OpenClaw-specific migration details: actual config file locations, what the connector patches, plugin vs legacy runtime paths, and a diagnostic flow for when both memory systems end up active simultaneously
- Adds a self-healing migration section to the `/signet` skill (`packages/signetai/templates/skills/signet/SKILL.md`) so agents can detect and fix the dual-system problem autonomously
- Adds OpenClaw integration checks to the `/onboarding` workspace audit (`packages/signetai/templates/skills/onboarding/SKILL.md`)

## Why

PR #112 proposed a dedicated `/openclaw-migration` skill. The concept was good (credit to Mike from the OpenClaw community for the systematic migration flow idea), but the implementation assumed wrong file paths, misused CLI flags, and wasn't grounded in the actual connector code. Instead of a separate skill, this PR integrates accurate migration guidance into the existing docs and templates that already ship with Signet.

The core problem: when Signet installs alongside OpenClaw, the connector must disable OpenClaw's native `memorySearch`. If this patch doesn't land (due to OpenClaw version changes, config location differences, etc.), both memory systems run simultaneously — causing token burn and duplicate context. Agents need to be able to detect and fix this on their own.

## Test plan

- [ ] Verify `web/public/skill.md` renders correctly and OpenClaw config paths match `packages/connector-openclaw/src/index.ts`
- [ ] Verify `/signet` skill self-healing section references correct JSON structure from connector
- [ ] Verify `/onboarding` audit checks are actionable and produce clear output
- [ ] `bun run build` passes (docs-only change, no code impact)

Closes #112 (superseded by this PR)