### PR TITLE
fix: resolve vec_embeddings desync causing constellation crash

### DIFF
--- a/packages/daemon/src/db-accessor.ts
+++ b/packages/daemon/src/db-accessor.ts
@@ -350,6 +350,29 @@ function backfillVecEmbeddings(db: Database): void {
 			`[db-accessor] Backfilled ${migrated}/${rows.length} missing embeddings into vec_embeddings`,
 		);
 	}
+
+	// Clean orphaned vec_embeddings rows (phantom IDs from prior sync bugs)
+	try {
+		const orphanRow = db
+			.prepare(
+				`SELECT COUNT(*) AS n FROM vec_embeddings v
+				 LEFT JOIN embeddings e ON e.id = v.id
+				 WHERE e.id IS NULL`,
+			)
+			.get() as { n: number } | undefined;
+		const orphanCount = orphanRow?.n ?? 0;
+		if (orphanCount > 0) {
+			db.prepare(
+				"DELETE FROM vec_embeddings WHERE id NOT IN (SELECT id FROM embeddings)",
+			).run();
+			// eslint-disable-next-line no-console
+			console.log(
+				`[db-accessor] Cleaned ${orphanCount} orphaned vec_embeddings rows`,
+			);
+		}
+	} catch {
+		// vec_embeddings may not exist — non-fatal
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/embedding-health.ts
+++ b/packages/daemon/src/embedding-health.ts
@@ -212,7 +212,7 @@ function checkModelDrift(db: ReadDb): EmbeddingCheckResult {
 function checkNullVectors(db: ReadDb): EmbeddingCheckResult {
 	const row = db
 		.prepare(
-			"SELECT COUNT(*) AS n FROM embeddings WHERE vector IS NULL OR length(vector) = 0",
+			"SELECT COUNT(*) AS n FROM embeddings e LEFT JOIN vec_embeddings v ON v.id = e.id WHERE v.id IS NULL",
 		)
 		.get() as { n: number } | undefined;
 	const count = row?.n ?? 0;

--- a/packages/daemon/src/pipeline/document-worker.ts
+++ b/packages/daemon/src/pipeline/document-worker.ts
@@ -385,7 +385,13 @@ async function processDocument(
 						chunkText,
 						now,
 					);
-					syncVecInsert(db, embId, vector);
+					// Resolve actual embedding ID (may differ from embId on conflict)
+					const actualEmbRow = db
+						.prepare("SELECT id FROM embeddings WHERE content_hash = ?")
+						.get(normalized.contentHash) as { id: string } | undefined;
+					if (actualEmbRow) {
+						syncVecInsert(db, actualEmbRow.id, vector);
+					}
 				}
 			}
 

--- a/packages/daemon/src/pipeline/worker.ts
+++ b/packages/daemon/src/pipeline/worker.ts
@@ -416,11 +416,14 @@ function insertMemoryEmbedding(
 		content,
 		now,
 	);
-	if (countChanges(result) > 0) {
-		syncVecInsert(db, embId, vector);
-		return true;
+	// Resolve actual embedding ID (may differ from embId on conflict)
+	const actualRow = db
+		.prepare("SELECT id FROM embeddings WHERE content_hash = ?")
+		.get(contentHash) as { id: string } | undefined;
+	if (actualRow) {
+		syncVecInsert(db, actualRow.id, vector);
 	}
-	return false;
+	return actualRow !== undefined;
 }
 
 function applyPhaseCWrites(

--- a/packages/daemon/src/repair-actions.ts
+++ b/packages/daemon/src/repair-actions.ts
@@ -552,12 +552,12 @@ async function reembedMissingMemoriesBatch(
 					   created_at = excluded.created_at`,
 				)
 				.run(embId, contentHash, blob, vector.length, memory.id, memory.content, now);
-			if (countChanges(result) > 0) {
-				const actualRow = db.prepare("SELECT id FROM embeddings WHERE content_hash = ?").get(contentHash) as
-					| { id: string }
-					| undefined;
-				const actualEmbeddingId = actualRow?.id ?? embId;
-				syncVecInsert(db, actualEmbeddingId, vector);
+			// Resolve actual embedding ID (may differ from embId on conflict)
+			const actualRow = db
+				.prepare("SELECT id FROM embeddings WHERE content_hash = ?")
+				.get(contentHash) as { id: string } | undefined;
+			if (actualRow) {
+				syncVecInsert(db, actualRow.id, vector);
 				count++;
 			}
 		}

--- a/packages/daemon/src/umap-projection.ts
+++ b/packages/daemon/src/umap-projection.ts
@@ -281,6 +281,7 @@ const EMBEDDINGS_FROM_SQL = `
 	FROM embeddings e
 	INNER JOIN memories m ON m.id = e.source_id
 	WHERE e.source_type = 'memory'
+	  AND e.vector IS NOT NULL AND length(e.vector) > 0
 `;
 
 function normalizeFilterValues(values: readonly string[] | undefined): string[] {


### PR DESCRIPTION
## Summary

- Fixes the root cause behind PR #111 — the constellation tab crashing with "Computing layout..." and `/api/embeddings/health` returning 500
- The `embeddings.vector` column exists and was never dropped. The real issue is `vec_embeddings` falling out of sync due to bugs in three embedding write paths

## Root Cause

Three write paths had bugs causing `vec_embeddings` to silently desync:

- **pipeline/worker.ts**: `countChanges()` guard skipped `syncVecInsert()` on `ON CONFLICT` upserts, and passed a phantom UUID instead of the actual persisted ID
- **repair-actions.ts**: same `countChanges()` guard issue
- **document-worker.ts**: always called `syncVecInsert()` (good) but with a fresh UUID that didn't match the persisted row on conflict

## Fix

- All three paths now resolve the actual embedding ID via `content_hash` after the upsert, matching the correct pattern already used in `embedding-tracker.ts`
- Adds startup healing to clean orphaned `vec_embeddings` rows (phantom IDs from the bug)
- Hardens the projection query with a null-vector guard as defense in depth
- Improves `checkNullVectors` health check to use LEFT JOIN against `vec_embeddings` (credit to @ddasgupta4 from #111)

## Test plan

- [x] `bun run build` passes
- [x] `bun run typecheck` passes
- [x] `bun test packages/daemon/src/pipeline/worker.test.ts` — 24 pass, 0 fail
- [x] `bun test packages/daemon/src/repair-actions.test.ts` — 30 pass, 0 fail
- [ ] Manual: restart daemon, verify constellation tab loads
- [ ] Manual: verify `/api/embeddings/health` returns 200
- [ ] Manual: create a memory, verify both `embeddings` and `vec_embeddings` have matching rows

Supersedes #111.