### PR TITLE
fix: add missing agent_id scoping to knowledge-graph queries

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/adapters/openclaw": {
       "name": "@signetai/signet-memory-openclaw",
-      "version": "0.35.4",
+      "version": "0.36.2",
       "dependencies": {
         "@sinclair/typebox": "0.34.47",
       },
@@ -22,7 +22,7 @@
     },
     "packages/cli": {
       "name": "@signet/cli",
-      "version": "0.35.4",
+      "version": "0.36.2",
       "bin": "./dist/cli.js",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
@@ -44,7 +44,7 @@
     },
     "packages/connector-base": {
       "name": "@signet/connector-base",
-      "version": "0.35.4",
+      "version": "0.36.2",
       "dependencies": {
         "@signet/core": "workspace:*",
       },
@@ -58,7 +58,7 @@
     },
     "packages/connector-claude-code": {
       "name": "@signet/connector-claude-code",
-      "version": "0.35.4",
+      "version": "0.36.2",
       "dependencies": {
         "@signet/connector-base": "workspace:*",
         "@signet/core": "workspace:*",
@@ -70,7 +70,7 @@
     },
     "packages/connector-openclaw": {
       "name": "@signet/connector-openclaw",
-      "version": "0.35.4",
+      "version": "0.36.2",
       "dependencies": {
         "@signet/connector-base": "workspace:*",
       },
@@ -81,7 +81,7 @@
     },
     "packages/connector-opencode": {
       "name": "@signet/connector-opencode",
-      "version": "0.35.4",
+      "version": "0.36.2",
       "dependencies": {
         "@signet/connector-base": "workspace:*",
         "@signet/core": "workspace:*",
@@ -93,7 +93,7 @@
     },
     "packages/core": {
       "name": "@signet/core",
-      "version": "0.35.4",
+      "version": "0.36.2",
       "dependencies": {
         "sqlite-vec": "^0.1.7-alpha.2",
         "yaml": "^2.6.0",
@@ -113,7 +113,7 @@
     },
     "packages/daemon": {
       "name": "@signet/daemon",
-      "version": "0.35.4",
+      "version": "0.36.2",
       "bin": {
         "signet-daemon": "./dist/daemon.js",
         "signet-mcp": "./dist/mcp-stdio.js",
@@ -131,6 +131,7 @@
         "onnxruntime-node": "1.21.0",
         "sharp": "^0.34.1",
         "umap-js": "^1.4.0",
+        "yaml": "^2.8.2",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -139,7 +140,7 @@
     },
     "packages/extension": {
       "name": "@signet/extension",
-      "version": "0.35.4",
+      "version": "0.36.2",
       "devDependencies": {
         "@types/chrome": "^0.0.287",
         "typescript": "^5.7.0",
@@ -147,14 +148,14 @@
     },
     "packages/opencode-plugin": {
       "name": "@signet/opencode-plugin",
-      "version": "0.35.4",
+      "version": "0.36.2",
       "peerDependencies": {
         "@opencode-ai/plugin": ">=0.1.0",
       },
     },
     "packages/sdk": {
       "name": "@signet/sdk",
-      "version": "0.35.4",
+      "version": "0.36.2",
       "devDependencies": {
         "@types/react": "^19.0.0",
         "react": "^19.0.0",
@@ -170,7 +171,7 @@
     },
     "packages/signetai": {
       "name": "signetai",
-      "version": "0.35.4",
+      "version": "0.36.2",
       "bin": {
         "signet": "bin/signet.js",
         "signet-mcp": "dist/mcp-stdio.js",
@@ -200,7 +201,7 @@
     },
     "packages/tray": {
       "name": "@signet/tray",
-      "version": "0.35.4",
+      "version": "0.36.2",
       "dependencies": {
         "@signet/sdk": "workspace:*",
         "@tauri-apps/api": "^2.5.0",

--- a/docs/IDEAL-SIGNET.md
+++ b/docs/IDEAL-SIGNET.md
@@ -1,3 +1,10 @@
+---
+title: "Ideal Signet"
+description: "End-to-end engineering specification for the ideal Signet system."
+order: 51
+section: "Project"
+---
+
 # Signet (Ideal): Monolithic Engineering Spec
 
 This document is a single, end-to-end specification for the *ideal* Signet

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -64,8 +64,17 @@ Tables affected: `memories`, `entities`, `entity_aspects`,
 `entity_attributes`, `entity_dependencies`, `skill_meta`, `task_meta`,
 `session_checkpoints`, `session_memories`, `predictor_comparisons`.
 
+Note: `entities` (migration 002) predates this invariant and does not
+yet have `agent_id`. Migration 019 (KA-1) backfills it. `skill_meta`
+(migration 018) already has `agent_id`.
+
 Scoping rule: queries filter by `agent_id` unless explicitly requesting
 cross-agent results (e.g., shared skill lookup with allowlist).
+
+The `agent_id` column is infrastructure for database-level tenant
+isolation, not a knowledge architecture concern. It exists on every
+table for the same reason: so multiple agents sharing the same SQLite
+file don't step on each other's data.
 
 Skills are scoped to `agent_id` in the graph. The filesystem pool
 (`~/.agents/skills/`) is shared, but graph nodes (entity + skill_meta +

--- a/docs/specs/SPRINT-BRIEF-KA1.md
+++ b/docs/specs/SPRINT-BRIEF-KA1.md
@@ -1,0 +1,345 @@
+---
+title: "Sprint Brief: Knowledge Architecture KA-1"
+---
+
+# Sprint Brief: Knowledge Architecture KA-1
+
+Schema + Types + Read/Write Helpers
+
+---
+
+## What You're Building
+
+The knowledge graph gets its structural backbone. Entities gain aspects,
+attributes, constraints, dependencies, and task lifecycle — the data
+model described in `docs/KNOWLEDGE-ARCHITECTURE.md`. This sprint is
+schema and types only. Structural assignment (KA-2) and traversal
+retrieval (KA-3) come later.
+
+## Required Reading
+
+1. `docs/specs/INDEX.md` — **read the Cross-Cutting Invariants section
+   first.** These override anything in the individual spec.
+2. `docs/specs/approved/knowledge-architecture-schema.md` — sections
+   5 (data model) and 6 (extraction contracts, for context only)
+3. `docs/KNOWLEDGE-ARCHITECTURE.md` — conceptual north star
+
+## Cross-Cutting Rules (from INDEX)
+
+- **`agent_id` on every new table.** All four new tables must have an
+  `agent_id TEXT NOT NULL DEFAULT 'default'` column with an index.
+  This is infrastructure for tenant isolation, not a KA concern.
+- **`entities` needs `agent_id` backfill.** The `entities` table
+  (migration 002) predates the multi-agent invariant. This migration
+  adds the column.
+- **Entity type taxonomy is canonical.** Valid types: `person`,
+  `project`, `system`, `tool`, `concept`, `skill`, `task`, `unknown`.
+- **Constraints always surface.** `entity_attributes` rows with
+  `kind = 'constraint'` are never suppressed by scoring. Design the
+  schema to make this query cheap.
+
+## Deliverables
+
+### 1. Migration: `019-knowledge-structure.ts`
+
+New migration file in `packages/core/src/migrations/`. Register it in
+`migrations/index.ts` as version 19.
+
+#### 1a. Backfill `agent_id` on `entities`
+
+```sql
+-- ALTER TABLE won't fail if column already exists (use addColumnIfMissing pattern)
+ALTER TABLE entities ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'default';
+CREATE INDEX IF NOT EXISTS idx_entities_agent ON entities(agent_id);
+```
+
+Use the same `PRAGMA table_info` + column check pattern as migration
+017 to make this idempotent.
+
+#### 1b. `entity_aspects`
+
+```sql
+CREATE TABLE IF NOT EXISTS entity_aspects (
+  id            TEXT PRIMARY KEY,
+  entity_id     TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+  agent_id      TEXT NOT NULL DEFAULT 'default',
+  name          TEXT NOT NULL,
+  canonical_name TEXT NOT NULL,
+  weight        REAL NOT NULL DEFAULT 0.5,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(entity_id, canonical_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_aspects_entity ON entity_aspects(entity_id);
+CREATE INDEX IF NOT EXISTS idx_entity_aspects_agent ON entity_aspects(agent_id);
+CREATE INDEX IF NOT EXISTS idx_entity_aspects_weight ON entity_aspects(weight DESC);
+```
+
+#### 1c. `entity_attributes`
+
+```sql
+CREATE TABLE IF NOT EXISTS entity_attributes (
+  id                TEXT PRIMARY KEY,
+  aspect_id         TEXT NOT NULL REFERENCES entity_aspects(id) ON DELETE CASCADE,
+  agent_id          TEXT NOT NULL DEFAULT 'default',
+  memory_id         TEXT REFERENCES memories(id) ON DELETE SET NULL,
+  kind              TEXT NOT NULL,
+  content           TEXT NOT NULL,
+  normalized_content TEXT NOT NULL,
+  confidence        REAL NOT NULL DEFAULT 0.0,
+  importance        REAL NOT NULL DEFAULT 0.5,
+  status            TEXT NOT NULL DEFAULT 'active',
+  superseded_by     TEXT,
+  created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_attributes_aspect ON entity_attributes(aspect_id);
+CREATE INDEX IF NOT EXISTS idx_entity_attributes_agent ON entity_attributes(agent_id);
+CREATE INDEX IF NOT EXISTS idx_entity_attributes_kind ON entity_attributes(kind);
+CREATE INDEX IF NOT EXISTS idx_entity_attributes_status ON entity_attributes(status);
+```
+
+`kind` values: `'attribute'` or `'constraint'`. Constraints are
+first-class rows, not inferred.
+
+`status` values: `'active'`, `'superseded'`, `'deleted'`.
+
+#### 1d. `entity_dependencies`
+
+```sql
+CREATE TABLE IF NOT EXISTS entity_dependencies (
+  id                TEXT PRIMARY KEY,
+  source_entity_id  TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+  target_entity_id  TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+  agent_id          TEXT NOT NULL DEFAULT 'default',
+  aspect_id         TEXT REFERENCES entity_aspects(id) ON DELETE SET NULL,
+  dependency_type   TEXT NOT NULL,
+  strength          REAL NOT NULL DEFAULT 0.5,
+  created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_dependencies_source ON entity_dependencies(source_entity_id);
+CREATE INDEX IF NOT EXISTS idx_entity_dependencies_target ON entity_dependencies(target_entity_id);
+CREATE INDEX IF NOT EXISTS idx_entity_dependencies_agent ON entity_dependencies(agent_id);
+```
+
+`dependency_type` values: `'uses'`, `'requires'`, `'owned_by'`,
+`'blocks'`, `'informs'`.
+
+#### 1e. `task_meta`
+
+```sql
+CREATE TABLE IF NOT EXISTS task_meta (
+  entity_id       TEXT PRIMARY KEY REFERENCES entities(id) ON DELETE CASCADE,
+  agent_id        TEXT NOT NULL DEFAULT 'default',
+  status          TEXT NOT NULL,
+  expires_at      TEXT,
+  retention_until TEXT,
+  completed_at    TEXT,
+  updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_task_meta_agent ON task_meta(agent_id);
+CREATE INDEX IF NOT EXISTS idx_task_meta_status ON task_meta(status);
+CREATE INDEX IF NOT EXISTS idx_task_meta_retention ON task_meta(retention_until);
+```
+
+`status` values: `'open'`, `'in_progress'`, `'blocked'`, `'done'`,
+`'cancelled'`.
+
+### 2. Core types
+
+Add to `packages/core/src/types.ts`:
+
+```typescript
+// -- Knowledge Architecture types --
+
+export const ENTITY_TYPES = [
+  'person', 'project', 'system', 'tool',
+  'concept', 'skill', 'task', 'unknown',
+] as const;
+export type EntityType = (typeof ENTITY_TYPES)[number];
+
+export const ATTRIBUTE_KINDS = ['attribute', 'constraint'] as const;
+export type AttributeKind = (typeof ATTRIBUTE_KINDS)[number];
+
+export const ATTRIBUTE_STATUSES = ['active', 'superseded', 'deleted'] as const;
+export type AttributeStatus = (typeof ATTRIBUTE_STATUSES)[number];
+
+export const DEPENDENCY_TYPES = [
+  'uses', 'requires', 'owned_by', 'blocks', 'informs',
+] as const;
+export type DependencyType = (typeof DEPENDENCY_TYPES)[number];
+
+export const TASK_STATUSES = [
+  'open', 'in_progress', 'blocked', 'done', 'cancelled',
+] as const;
+export type TaskStatus = (typeof TASK_STATUSES)[number];
+
+export interface EntityAspect {
+  readonly id: string;
+  readonly entityId: string;
+  readonly agentId: string;
+  readonly name: string;
+  readonly canonicalName: string;
+  readonly weight: number;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface EntityAttribute {
+  readonly id: string;
+  readonly aspectId: string;
+  readonly agentId: string;
+  readonly memoryId: string | null;
+  readonly kind: AttributeKind;
+  readonly content: string;
+  readonly normalizedContent: string;
+  readonly confidence: number;
+  readonly importance: number;
+  readonly status: AttributeStatus;
+  readonly supersededBy: string | null;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface EntityDependency {
+  readonly id: string;
+  readonly sourceEntityId: string;
+  readonly targetEntityId: string;
+  readonly agentId: string;
+  readonly aspectId: string | null;
+  readonly dependencyType: DependencyType;
+  readonly strength: number;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface TaskMeta {
+  readonly entityId: string;
+  readonly agentId: string;
+  readonly status: TaskStatus;
+  readonly expiresAt: string | null;
+  readonly retentionUntil: string | null;
+  readonly completedAt: string | null;
+  readonly updatedAt: string;
+}
+```
+
+Also update the existing `Entity` interface to include `agentId`:
+
+```typescript
+export interface Entity {
+  id: string;
+  name: string;
+  canonicalName?: string;
+  entityType: string;
+  agentId: string;          // <-- add
+  description?: string;
+  mentions?: number;
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+### 3. Read/write helpers
+
+New module: `packages/daemon/src/knowledge-graph.ts`
+
+Provide CRUD operations using the `DbAccessor` pattern (same as
+`skill-graph.ts`). All write operations go through `withWriteTx`,
+all reads through `withReadDb`.
+
+Required functions:
+
+```typescript
+// -- Aspects --
+upsertAspect(accessor, params): EntityAspect
+getAspectsForEntity(accessor, entityId, agentId): EntityAspect[]
+deleteAspect(accessor, aspectId): void
+
+// -- Attributes --
+createAttribute(accessor, params): EntityAttribute
+getAttributesForAspect(accessor, aspectId, agentId): EntityAttribute[]
+getConstraintsForEntity(accessor, entityId, agentId): EntityAttribute[]
+supersedeAttribute(accessor, id, supersededById): void
+deleteAttribute(accessor, id): void
+
+// -- Dependencies --
+upsertDependency(accessor, params): EntityDependency
+getDependenciesFrom(accessor, entityId, agentId): EntityDependency[]
+getDependenciesTo(accessor, entityId, agentId): EntityDependency[]
+deleteDependency(accessor, id): void
+
+// -- Task meta --
+upsertTaskMeta(accessor, params): TaskMeta
+getTaskMeta(accessor, entityId): TaskMeta | null
+updateTaskStatus(accessor, entityId, status): void
+
+// -- Structural density --
+getStructuralDensity(accessor, entityId, agentId): {
+  aspectCount: number;
+  attributeCount: number;
+  constraintCount: number;
+  dependencyCount: number;
+}
+```
+
+Key implementation notes:
+
+- `upsertAspect` matches on `(entity_id, canonical_name)` unique
+  constraint. Use INSERT OR REPLACE or ON CONFLICT.
+- `getConstraintsForEntity` must join through `entity_aspects` to get
+  all `kind = 'constraint'` attributes for an entity. This is the
+  query that enforces the "constraints always surface" invariant.
+- `upsertDependency` is idempotent on
+  `(source_entity_id, target_entity_id, dependency_type)`.
+- All functions take `agentId` param and filter by it.
+- Generate IDs with the existing pattern from `skill-graph.ts` (check
+  how entity IDs and `crypto.randomUUID()` are used there).
+
+### 4. Update Entity interface consumers
+
+After adding `agentId` to the `Entity` interface, update any code that
+creates entity rows to include `agent_id = 'default'`. Key locations:
+
+- `packages/daemon/src/pipeline/graph-transactions.ts` — `txPersistEntities`
+- `packages/daemon/src/pipeline/skill-graph.ts` — `installSkillNode`
+- Any other direct INSERT into `entities`
+
+Search for: `INSERT INTO entities` and `INSERT OR REPLACE INTO entities`
+
+## Key Files
+
+- `packages/core/src/migrations/` — new migration goes here
+- `packages/core/src/migrations/index.ts` — register migration
+- `packages/core/src/types.ts` — add types and update Entity
+- `packages/daemon/src/knowledge-graph.ts` — new module
+- `packages/daemon/src/db-accessor.ts` — DbAccessor interface (reference)
+- `packages/daemon/src/pipeline/skill-graph.ts` — pattern reference
+- `packages/daemon/src/pipeline/graph-transactions.ts` — update for agent_id
+
+## What NOT to Build (KA-2+)
+
+- Structural assignment stage in the pipeline (KA-2)
+- Traversal query builder or session-start wiring (KA-3)
+- Predictor structural features (KA-4)
+- Checkpoint structural snapshots (KA-5)
+- Backfill worker for legacy memories (KA-2)
+- Dashboard visualization (KA-5)
+- API endpoints for aspects/attributes (KA-3)
+
+## Verification
+
+1. `bun run build` — no type errors
+2. `bun test` — existing tests pass (616+)
+3. `bun run typecheck` — clean
+4. Daemon startup creates all four new tables + entities.agent_id
+5. Verify indexes exist: `PRAGMA index_list(entity_aspects)` etc.
+6. Existing entity creation still works (agent_id defaults to 'default')
+7. `getConstraintsForEntity` returns correct rows in a simple test
+8. `getStructuralDensity` returns zeroes for an entity with no aspects
+9. Verify `agent_id = 'default'` on all rows created by existing code

--- a/docs/specs/approved/knowledge-architecture-schema.md
+++ b/docs/specs/approved/knowledge-architecture-schema.md
@@ -4,13 +4,13 @@ title: "Knowledge Architecture Schema and Traversal Spec"
 
 # Knowledge Architecture Schema and Traversal Spec
 
-Status: Planning (v0)
+Status: Approved (v1)
 
 Audience: Core + Daemon maintainers
 
 Spec metadata:
 - ID: `knowledge-architecture-schema`
-- Status: `planning`
+- Status: `approved`
 - Hard depends on: `memory-pipeline-v2`, `session-continuity-protocol`,
   `procedural-memory-plan`
 - Blocks: `predictive-memory-scorer`
@@ -113,12 +113,28 @@ Extend `entities.entity_type` usage to the canonical set:
 - `task`
 - `unknown` (fallback)
 
-### 5.2 New table: `entity_aspects`
+### 5.2 Backfill: `agent_id` on `entities`
+
+The `entities` table (migration 002) predates the multi-agent scoping
+invariant. Add `agent_id` with a default and index:
+
+```sql
+ALTER TABLE entities ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'default';
+CREATE INDEX idx_entities_agent ON entities(agent_id);
+```
+
+All new KA tables include `agent_id` for database-level tenant isolation.
+This is not a KA concern — it is the multi-agent invariant applied
+uniformly. Queries filter by `agent_id` unless explicitly requesting
+cross-agent results.
+
+### 5.3 New table: `entity_aspects`
 
 ```sql
 CREATE TABLE entity_aspects (
   id TEXT PRIMARY KEY,
   entity_id TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+  agent_id TEXT NOT NULL DEFAULT 'default',
   name TEXT NOT NULL,
   canonical_name TEXT NOT NULL,
   weight REAL NOT NULL DEFAULT 0.5,
@@ -128,17 +144,19 @@ CREATE TABLE entity_aspects (
 );
 
 CREATE INDEX idx_entity_aspects_entity ON entity_aspects(entity_id);
+CREATE INDEX idx_entity_aspects_agent ON entity_aspects(agent_id);
 CREATE INDEX idx_entity_aspects_weight ON entity_aspects(weight DESC);
 ```
 
 `weight` is structural centrality + learned utility. It is not pure frequency.
 
-### 5.3 New table: `entity_attributes`
+### 5.4 New table: `entity_attributes`
 
 ```sql
 CREATE TABLE entity_attributes (
   id TEXT PRIMARY KEY,
   aspect_id TEXT NOT NULL REFERENCES entity_aspects(id) ON DELETE CASCADE,
+  agent_id TEXT NOT NULL DEFAULT 'default',
   memory_id TEXT REFERENCES memories(id) ON DELETE SET NULL,
   kind TEXT NOT NULL,                 -- 'attribute' | 'constraint'
   content TEXT NOT NULL,
@@ -152,19 +170,21 @@ CREATE TABLE entity_attributes (
 );
 
 CREATE INDEX idx_entity_attributes_aspect ON entity_attributes(aspect_id);
+CREATE INDEX idx_entity_attributes_agent ON entity_attributes(agent_id);
 CREATE INDEX idx_entity_attributes_kind ON entity_attributes(kind);
 CREATE INDEX idx_entity_attributes_status ON entity_attributes(status);
 ```
 
 Constraints are first-class rows (`kind='constraint'`), not inferred tags.
 
-### 5.4 New table: `entity_dependencies`
+### 5.5 New table: `entity_dependencies`
 
 ```sql
 CREATE TABLE entity_dependencies (
   id TEXT PRIMARY KEY,
   source_entity_id TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
   target_entity_id TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+  agent_id TEXT NOT NULL DEFAULT 'default',
   aspect_id TEXT REFERENCES entity_aspects(id) ON DELETE SET NULL,
   dependency_type TEXT NOT NULL,      -- 'uses' | 'requires' | 'owned_by' | 'blocks' | 'informs'
   strength REAL NOT NULL DEFAULT 0.5,
@@ -174,15 +194,17 @@ CREATE TABLE entity_dependencies (
 
 CREATE INDEX idx_entity_dependencies_source ON entity_dependencies(source_entity_id);
 CREATE INDEX idx_entity_dependencies_target ON entity_dependencies(target_entity_id);
+CREATE INDEX idx_entity_dependencies_agent ON entity_dependencies(agent_id);
 ```
 
 These are explicit traversal edges. They are not similarity artifacts.
 
-### 5.5 New table: `task_meta`
+### 5.6 New table: `task_meta`
 
 ```sql
 CREATE TABLE task_meta (
   entity_id TEXT PRIMARY KEY REFERENCES entities(id) ON DELETE CASCADE,
+  agent_id TEXT NOT NULL DEFAULT 'default',
   status TEXT NOT NULL,                -- 'open' | 'in_progress' | 'blocked' | 'done' | 'cancelled'
   expires_at TEXT,
   retention_until TEXT,
@@ -190,6 +212,7 @@ CREATE TABLE task_meta (
   updated_at TEXT NOT NULL
 );
 
+CREATE INDEX idx_task_meta_agent ON task_meta(agent_id);
 CREATE INDEX idx_task_meta_status ON task_meta(status);
 CREATE INDEX idx_task_meta_retention ON task_meta(retention_until);
 ```
@@ -317,8 +340,10 @@ This keeps one graph with type-specific lifecycle rules.
 
 ### KA-1 Schema and types
 
-1. Add migration `017-knowledge-structure.ts` (`entity_aspects`,
-   `entity_attributes`, `entity_dependencies`, `task_meta`)
+1. Add migration `019-knowledge-structure.ts`:
+   - Backfill `agent_id` on `entities` table
+   - Create `entity_aspects`, `entity_attributes`, `entity_dependencies`,
+     `task_meta` — all with `agent_id` column
 2. Add core types and read/write helpers
 
 ### KA-2 Structural assignment in pipeline

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,7 @@ export type {
 	PipelineTelemetryConfig,
 	PipelineEmbeddingTrackerConfig,
 	PipelineContinuityConfig,
+	PipelineProceduralConfig,
 	ExtractedFact,
 	ExtractedEntity,
 	ExtractionResult,

--- a/packages/core/src/migrations/018-skill-meta.ts
+++ b/packages/core/src/migrations/018-skill-meta.ts
@@ -1,0 +1,48 @@
+/**
+ * Migration 018: Skill Meta
+ *
+ * Creates the skill_meta table for procedural memory P1.
+ * Skills become first-class nodes in the knowledge graph,
+ * with per-agent scoping, usage tracking, and decay.
+ */
+
+import type { MigrationDb } from "./index";
+
+export function up(db: MigrationDb): void {
+	// Check if table already exists (idempotent)
+	const existing = db
+		.prepare(
+			"SELECT name FROM sqlite_master WHERE type='table' AND name='skill_meta'",
+		)
+		.get();
+
+	if (existing) return;
+
+	db.exec(`
+		CREATE TABLE skill_meta (
+			entity_id     TEXT PRIMARY KEY REFERENCES entities(id),
+			agent_id      TEXT NOT NULL DEFAULT 'default',
+			version       TEXT,
+			author        TEXT,
+			license       TEXT,
+			source        TEXT NOT NULL,
+			role          TEXT NOT NULL DEFAULT 'utility',
+			triggers      TEXT,
+			tags          TEXT,
+			permissions   TEXT,
+			enriched      INTEGER DEFAULT 0,
+			installed_at  TEXT NOT NULL,
+			last_used_at  TEXT,
+			use_count     INTEGER DEFAULT 0,
+			importance    REAL DEFAULT 0.7,
+			decay_rate    REAL DEFAULT 0.99,
+			fs_path       TEXT NOT NULL,
+			uninstalled_at TEXT,
+			created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+			updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
+		);
+
+		CREATE INDEX idx_skill_meta_agent ON skill_meta(agent_id);
+		CREATE INDEX idx_skill_meta_source ON skill_meta(source);
+	`);
+}

--- a/packages/core/src/migrations/index.ts
+++ b/packages/core/src/migrations/index.ts
@@ -23,6 +23,7 @@ import { up as telemetry } from "./014-telemetry";
 import { up as sessionMemories } from "./015-session-memories";
 import { up as sessionCheckpoints } from "./016-session-checkpoints";
 import { up as taskSkills } from "./017-task-skills";
+import { up as skillMeta } from "./018-skill-meta";
 
 // -- Public interface consumed by Database.init() --
 
@@ -107,6 +108,11 @@ export const MIGRATIONS: readonly Migration[] = [
 		version: 17,
 		name: "task-skills",
 		up: taskSkills,
+	},
+	{
+		version: 18,
+		name: "skill-meta",
+		up: skillMeta,
 	},
 ];
 

--- a/packages/core/src/migrations/migrations.test.ts
+++ b/packages/core/src/migrations/migrations.test.ts
@@ -33,7 +33,7 @@ describe("migration framework", () => {
 				"SELECT version, applied_at FROM schema_migrations ORDER BY version",
 			)
 			.all() as Array<{ version: number; applied_at: string }>;
-		expect(migrations.length).toBe(17);
+		expect(migrations.length).toBe(18);
 		expect(migrations[0].version).toBe(1);
 		expect(migrations[1].version).toBe(2);
 		expect(migrations[2].version).toBe(3);
@@ -51,6 +51,7 @@ describe("migration framework", () => {
 		expect(migrations[14].version).toBe(15);
 		expect(migrations[15].version).toBe(16);
 		expect(migrations[16].version).toBe(17);
+		expect(migrations[17].version).toBe(18);
 	});
 
 	test("re-running migrations is idempotent", () => {
@@ -160,7 +161,7 @@ describe("migration framework", () => {
 		const audits = db
 			.query("SELECT version, applied_at FROM schema_migrations_audit")
 			.all() as Array<{ version: number; applied_at: string }>;
-		expect(audits.length).toBe(17);
+		expect(audits.length).toBe(18);
 		for (const audit of audits) {
 			expect(audit.applied_at).toBeTruthy();
 		}
@@ -362,7 +363,7 @@ describe("migration framework", () => {
 		const migrations = db
 			.query("SELECT version FROM schema_migrations ORDER BY version")
 			.all() as Array<{ version: number }>;
-		expect(migrations.length).toBe(17);
+		expect(migrations.length).toBe(18);
 	});
 
 	test("version 1 stamped by old inline migrate upgrades cleanly", () => {
@@ -405,7 +406,7 @@ describe("migration framework", () => {
 		const migrations = db
 			.query("SELECT version FROM schema_migrations ORDER BY version")
 			.all() as Array<{ version: number }>;
-		expect(migrations.length).toBe(17);
+		expect(migrations.length).toBe(18);
 	});
 
 	test("DB with existing v1 schema only gets v2 migration", () => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -224,12 +224,23 @@ export interface PipelineV2Config {
 	readonly telemetry: PipelineTelemetryConfig;
 	readonly continuity: PipelineContinuityConfig;
 	readonly embeddingTracker: PipelineEmbeddingTrackerConfig;
+	readonly procedural: PipelineProceduralConfig;
 }
 
 export interface PipelineEmbeddingTrackerConfig {
 	readonly enabled: boolean;
 	readonly pollMs: number;
 	readonly batchSize: number;
+}
+
+export interface PipelineProceduralConfig {
+	readonly enabled: boolean;
+	readonly decayRate: number;
+	readonly minImportance: number;
+	readonly importanceOnInstall: number;
+	readonly enrichOnInstall: boolean;
+	readonly enrichMinDescription: number;
+	readonly reconcileIntervalMs: number;
 }
 
 // -- Status/union constants --

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -32,16 +32,17 @@
   "dependencies": {
     "@1password/sdk": "^0.3.0",
     "@hono/node-server": "^1.14.0",
+    "@huggingface/transformers": "^3.4.0",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@signet/core": "workspace:*",
     "chokidar": "^4.0.0",
     "cron-parser": "^5.5.0",
     "hono": "^4.8.0",
     "libsodium-wrappers": "^0.8.2",
-    "@huggingface/transformers": "^3.4.0",
     "onnxruntime-node": "1.21.0",
     "sharp": "^0.34.1",
     "umap-js": "^1.4.0",
+    "yaml": "^2.8.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -68,7 +68,7 @@ import { createProviderTracker, getDiagnostics } from "./diagnostics";
 import { buildEmbeddingHealth } from "./embedding-health";
 import { type EmbeddingTrackerHandle, startEmbeddingTracker } from "./embedding-tracker";
 import { getAllFeatureFlags, initFeatureFlags } from "./feature-flags";
-import { closeLlmProvider, initLlmProvider } from "./llm";
+import { closeLlmProvider, getLlmProvider, initLlmProvider } from "./llm";
 import { type LogEntry, logger } from "./logger";
 import { type EmbeddingConfig, loadMemoryConfig } from "./memory-config";
 import { type RecallParams, hybridRecall } from "./memory-search";
@@ -164,6 +164,7 @@ const repairLimiter = createRateLimiter();
 // Telemetry — assigned in main(), read by cleanup()
 let telemetryRef: TelemetryCollector | undefined;
 let embeddingTrackerHandle: EmbeddingTrackerHandle | null = null;
+let skillReconcilerHandle: ReconcilerHandle | null = null;
 let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
 let checkpointPruneTimer: ReturnType<typeof setInterval> | undefined;
 
@@ -3952,8 +3953,10 @@ app.get("/api/connectors/:id/health", (c) => {
 });
 
 // Skills routes (extracted to routes/skills.ts)
-import { mountSkillsRoutes } from "./routes/skills.js";
+import { mountSkillsRoutes, setFetchEmbedding } from "./routes/skills.js";
+import { startReconciler, type ReconcilerHandle } from "./pipeline/skill-reconciler.js";
 mountSkillsRoutes(app);
+setFetchEmbedding(fetchEmbedding);
 
 // Marketplace routes (MCP servers catalog + routing)
 import { mountMarketplaceRoutes } from "./routes/marketplace.js";
@@ -7120,6 +7123,12 @@ async function cleanup() {
 		telemetryRef = undefined;
 	}
 
+	// Stop skill reconciler
+	if (skillReconcilerHandle) {
+		skillReconcilerHandle.stop();
+		skillReconcilerHandle = null;
+	}
+
 	// Stop embedding tracker before pipeline/DB teardown
 	if (embeddingTrackerHandle) {
 		try {
@@ -7357,6 +7366,20 @@ async function main() {
 			fetchEmbedding,
 			checkEmbeddingProvider,
 		);
+	}
+
+	// Start skill reconciler if procedural memory is enabled
+	if (memoryCfg.pipelineV2.procedural.enabled) {
+		skillReconcilerHandle = startReconciler({
+			accessor: getDbAccessor(),
+			pipelineConfig: memoryCfg.pipelineV2,
+			embeddingConfig: memoryCfg.embedding,
+			fetchEmbedding,
+			getProvider: () => {
+				try { return getLlmProvider(); } catch { return null; }
+			},
+			agentsDir: AGENTS_DIR,
+		});
 	}
 
 	// Initialize checkpoint flush queue for continuity protocol

--- a/packages/daemon/src/knowledge-graph.ts
+++ b/packages/daemon/src/knowledge-graph.ts
@@ -1,0 +1,604 @@
+/**
+ * Knowledge graph CRUD operations for KA-1.
+ *
+ * Provides read/write helpers for entity aspects, attributes,
+ * dependencies, task metadata, and structural density queries.
+ * All writes go through withWriteTx, all reads through withReadDb.
+ *
+ * Follows the DbAccessor pattern established in skill-graph.ts.
+ */
+
+import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
+import type {
+	EntityAspect,
+	EntityAttribute,
+	EntityDependency,
+	TaskMeta,
+	AttributeKind,
+	AttributeStatus,
+	DependencyType,
+	TaskStatus,
+} from "@signet/core";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toCanonicalName(raw: string): string {
+	return raw.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function now(): string {
+	return new Date().toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Row mappers
+// ---------------------------------------------------------------------------
+
+function rowToAspect(r: Record<string, unknown>): EntityAspect {
+	return {
+		id: r.id as string,
+		entityId: r.entity_id as string,
+		agentId: r.agent_id as string,
+		name: r.name as string,
+		canonicalName: r.canonical_name as string,
+		weight: r.weight as number,
+		createdAt: r.created_at as string,
+		updatedAt: r.updated_at as string,
+	};
+}
+
+function rowToAttribute(r: Record<string, unknown>): EntityAttribute {
+	return {
+		id: r.id as string,
+		aspectId: r.aspect_id as string,
+		agentId: r.agent_id as string,
+		memoryId: (r.memory_id as string) ?? null,
+		kind: r.kind as AttributeKind,
+		content: r.content as string,
+		normalizedContent: r.normalized_content as string,
+		confidence: r.confidence as number,
+		importance: r.importance as number,
+		status: r.status as AttributeStatus,
+		supersededBy: (r.superseded_by as string) ?? null,
+		createdAt: r.created_at as string,
+		updatedAt: r.updated_at as string,
+	};
+}
+
+function rowToDependency(r: Record<string, unknown>): EntityDependency {
+	return {
+		id: r.id as string,
+		sourceEntityId: r.source_entity_id as string,
+		targetEntityId: r.target_entity_id as string,
+		agentId: r.agent_id as string,
+		aspectId: (r.aspect_id as string) ?? null,
+		dependencyType: r.dependency_type as DependencyType,
+		strength: r.strength as number,
+		createdAt: r.created_at as string,
+		updatedAt: r.updated_at as string,
+	};
+}
+
+function rowToTaskMeta(r: Record<string, unknown>): TaskMeta {
+	return {
+		entityId: r.entity_id as string,
+		agentId: r.agent_id as string,
+		status: r.status as TaskStatus,
+		expiresAt: (r.expires_at as string) ?? null,
+		retentionUntil: (r.retention_until as string) ?? null,
+		completedAt: (r.completed_at as string) ?? null,
+		updatedAt: r.updated_at as string,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Aspects
+// ---------------------------------------------------------------------------
+
+export interface UpsertAspectParams {
+	readonly entityId: string;
+	readonly agentId: string;
+	readonly name: string;
+	readonly weight?: number;
+}
+
+export function upsertAspect(
+	accessor: DbAccessor,
+	params: UpsertAspectParams,
+): EntityAspect {
+	const canonical = toCanonicalName(params.name);
+	const ts = now();
+
+	return accessor.withWriteTx((db) => {
+		const existing = db
+			.prepare(
+				`SELECT * FROM entity_aspects
+				 WHERE entity_id = ? AND canonical_name = ? AND agent_id = ?`,
+			)
+			.get(params.entityId, canonical, params.agentId) as Record<string, unknown> | undefined;
+
+		if (existing) {
+			db.prepare(
+				`UPDATE entity_aspects
+				 SET name = ?, weight = ?, updated_at = ?
+				 WHERE id = ?`,
+			).run(
+				params.name,
+				params.weight ?? (existing.weight as number),
+				ts,
+				existing.id as string,
+			);
+			return rowToAspect({
+				...existing,
+				name: params.name,
+				weight: params.weight ?? (existing.weight as number),
+				updated_at: ts,
+			});
+		}
+
+		const id = crypto.randomUUID();
+		db.prepare(
+			`INSERT INTO entity_aspects
+			 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			id,
+			params.entityId,
+			params.agentId,
+			params.name,
+			canonical,
+			params.weight ?? 0.5,
+			ts,
+			ts,
+		);
+
+		return {
+			id,
+			entityId: params.entityId,
+			agentId: params.agentId,
+			name: params.name,
+			canonicalName: canonical,
+			weight: params.weight ?? 0.5,
+			createdAt: ts,
+			updatedAt: ts,
+		};
+	});
+}
+
+export function getAspectsForEntity(
+	accessor: DbAccessor,
+	entityId: string,
+	agentId: string,
+): readonly EntityAspect[] {
+	return accessor.withReadDb((db) => {
+		const rows = db
+			.prepare(
+				`SELECT * FROM entity_aspects
+				 WHERE entity_id = ? AND agent_id = ?
+				 ORDER BY weight DESC`,
+			)
+			.all(entityId, agentId) as Array<Record<string, unknown>>;
+		return rows.map(rowToAspect);
+	});
+}
+
+export function deleteAspect(accessor: DbAccessor, aspectId: string): void {
+	accessor.withWriteTx((db) => {
+		db.prepare("DELETE FROM entity_aspects WHERE id = ?").run(aspectId);
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Attributes
+// ---------------------------------------------------------------------------
+
+export interface CreateAttributeParams {
+	readonly aspectId: string;
+	readonly agentId: string;
+	readonly memoryId?: string;
+	readonly kind: AttributeKind;
+	readonly content: string;
+	readonly confidence?: number;
+	readonly importance?: number;
+}
+
+export function createAttribute(
+	accessor: DbAccessor,
+	params: CreateAttributeParams,
+): EntityAttribute {
+	const id = crypto.randomUUID();
+	const ts = now();
+	const normalized = params.content.trim().toLowerCase().replace(/\s+/g, " ");
+
+	accessor.withWriteTx((db) => {
+		db.prepare(
+			`INSERT INTO entity_attributes
+			 (id, aspect_id, agent_id, memory_id, kind, content,
+			  normalized_content, confidence, importance, status,
+			  created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?)`,
+		).run(
+			id,
+			params.aspectId,
+			params.agentId,
+			params.memoryId ?? null,
+			params.kind,
+			params.content,
+			normalized,
+			params.confidence ?? 0.0,
+			params.importance ?? 0.5,
+			ts,
+			ts,
+		);
+	});
+
+	return {
+		id,
+		aspectId: params.aspectId,
+		agentId: params.agentId,
+		memoryId: params.memoryId ?? null,
+		kind: params.kind,
+		content: params.content,
+		normalizedContent: normalized,
+		confidence: params.confidence ?? 0.0,
+		importance: params.importance ?? 0.5,
+		status: "active",
+		supersededBy: null,
+		createdAt: ts,
+		updatedAt: ts,
+	};
+}
+
+export function getAttributesForAspect(
+	accessor: DbAccessor,
+	aspectId: string,
+	agentId: string,
+): readonly EntityAttribute[] {
+	return accessor.withReadDb((db) => {
+		const rows = db
+			.prepare(
+				`SELECT * FROM entity_attributes
+				 WHERE aspect_id = ? AND agent_id = ? AND status = 'active'
+				 ORDER BY importance DESC`,
+			)
+			.all(aspectId, agentId) as Array<Record<string, unknown>>;
+		return rows.map(rowToAttribute);
+	});
+}
+
+/**
+ * Get all constraints for an entity across all its aspects.
+ * Joins through entity_aspects to collect kind='constraint' rows.
+ * This is the query that enforces the "constraints always surface" invariant.
+ */
+export function getConstraintsForEntity(
+	accessor: DbAccessor,
+	entityId: string,
+	agentId: string,
+): readonly EntityAttribute[] {
+	return accessor.withReadDb((db) => {
+		const rows = db
+			.prepare(
+				`SELECT ea.* FROM entity_attributes ea
+				 JOIN entity_aspects asp ON asp.id = ea.aspect_id
+				 WHERE asp.entity_id = ? AND ea.agent_id = ?
+				   AND ea.kind = 'constraint'
+				   AND ea.status = 'active'
+				 ORDER BY ea.importance DESC`,
+			)
+			.all(entityId, agentId) as Array<Record<string, unknown>>;
+		return rows.map(rowToAttribute);
+	});
+}
+
+export function supersedeAttribute(
+	accessor: DbAccessor,
+	id: string,
+	supersededById: string,
+): void {
+	const ts = now();
+	accessor.withWriteTx((db) => {
+		db.prepare(
+			`UPDATE entity_attributes
+			 SET status = 'superseded', superseded_by = ?, updated_at = ?
+			 WHERE id = ?`,
+		).run(supersededById, ts, id);
+	});
+}
+
+export function deleteAttribute(accessor: DbAccessor, id: string): void {
+	const ts = now();
+	accessor.withWriteTx((db) => {
+		db.prepare(
+			`UPDATE entity_attributes
+			 SET status = 'deleted', updated_at = ?
+			 WHERE id = ?`,
+		).run(ts, id);
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Dependencies
+// ---------------------------------------------------------------------------
+
+export interface UpsertDependencyParams {
+	readonly sourceEntityId: string;
+	readonly targetEntityId: string;
+	readonly agentId: string;
+	readonly aspectId?: string;
+	readonly dependencyType: DependencyType;
+	readonly strength?: number;
+}
+
+export function upsertDependency(
+	accessor: DbAccessor,
+	params: UpsertDependencyParams,
+): EntityDependency {
+	const ts = now();
+
+	return accessor.withWriteTx((db) => {
+		const existing = db
+			.prepare(
+				`SELECT * FROM entity_dependencies
+				 WHERE source_entity_id = ? AND target_entity_id = ?
+				   AND dependency_type = ? AND agent_id = ?`,
+			)
+			.get(
+				params.sourceEntityId,
+				params.targetEntityId,
+				params.dependencyType,
+				params.agentId,
+			) as Record<string, unknown> | undefined;
+
+		if (existing) {
+			db.prepare(
+				`UPDATE entity_dependencies
+				 SET strength = ?, aspect_id = ?, updated_at = ?
+				 WHERE id = ?`,
+			).run(
+				params.strength ?? (existing.strength as number),
+				params.aspectId ?? (existing.aspect_id as string | null),
+				ts,
+				existing.id as string,
+			);
+			return rowToDependency({
+				...existing,
+				strength: params.strength ?? (existing.strength as number),
+				aspect_id: params.aspectId ?? (existing.aspect_id as string | null),
+				updated_at: ts,
+			});
+		}
+
+		const id = crypto.randomUUID();
+		db.prepare(
+			`INSERT INTO entity_dependencies
+			 (id, source_entity_id, target_entity_id, agent_id,
+			  aspect_id, dependency_type, strength, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			id,
+			params.sourceEntityId,
+			params.targetEntityId,
+			params.agentId,
+			params.aspectId ?? null,
+			params.dependencyType,
+			params.strength ?? 0.5,
+			ts,
+			ts,
+		);
+
+		return {
+			id,
+			sourceEntityId: params.sourceEntityId,
+			targetEntityId: params.targetEntityId,
+			agentId: params.agentId,
+			aspectId: params.aspectId ?? null,
+			dependencyType: params.dependencyType,
+			strength: params.strength ?? 0.5,
+			createdAt: ts,
+			updatedAt: ts,
+		};
+	});
+}
+
+export function getDependenciesFrom(
+	accessor: DbAccessor,
+	entityId: string,
+	agentId: string,
+): readonly EntityDependency[] {
+	return accessor.withReadDb((db) => {
+		const rows = db
+			.prepare(
+				`SELECT * FROM entity_dependencies
+				 WHERE source_entity_id = ? AND agent_id = ?`,
+			)
+			.all(entityId, agentId) as Array<Record<string, unknown>>;
+		return rows.map(rowToDependency);
+	});
+}
+
+export function getDependenciesTo(
+	accessor: DbAccessor,
+	entityId: string,
+	agentId: string,
+): readonly EntityDependency[] {
+	return accessor.withReadDb((db) => {
+		const rows = db
+			.prepare(
+				`SELECT * FROM entity_dependencies
+				 WHERE target_entity_id = ? AND agent_id = ?`,
+			)
+			.all(entityId, agentId) as Array<Record<string, unknown>>;
+		return rows.map(rowToDependency);
+	});
+}
+
+export function deleteDependency(accessor: DbAccessor, id: string): void {
+	accessor.withWriteTx((db) => {
+		db.prepare("DELETE FROM entity_dependencies WHERE id = ?").run(id);
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Task meta
+// ---------------------------------------------------------------------------
+
+export interface UpsertTaskMetaParams {
+	readonly entityId: string;
+	readonly agentId: string;
+	readonly status: TaskStatus;
+	readonly expiresAt?: string;
+	readonly retentionUntil?: string;
+}
+
+export function upsertTaskMeta(
+	accessor: DbAccessor,
+	params: UpsertTaskMetaParams,
+): TaskMeta {
+	const ts = now();
+
+	return accessor.withWriteTx((db) => {
+		const existing = db
+			.prepare("SELECT * FROM task_meta WHERE entity_id = ? AND agent_id = ?")
+			.get(params.entityId, params.agentId) as Record<string, unknown> | undefined;
+
+		if (existing) {
+			db.prepare(
+				`UPDATE task_meta
+				 SET status = ?, expires_at = ?, retention_until = ?,
+				     completed_at = ?, updated_at = ?
+				 WHERE entity_id = ? AND agent_id = ?`,
+			).run(
+				params.status,
+				params.expiresAt ?? null,
+				params.retentionUntil ?? null,
+				params.status === "done" || params.status === "cancelled" ? ts : null,
+				ts,
+				params.entityId,
+				params.agentId,
+			);
+		} else {
+			db.prepare(
+				`INSERT INTO task_meta
+				 (entity_id, agent_id, status, expires_at, retention_until,
+				  completed_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			).run(
+				params.entityId,
+				params.agentId,
+				params.status,
+				params.expiresAt ?? null,
+				params.retentionUntil ?? null,
+				params.status === "done" || params.status === "cancelled" ? ts : null,
+				ts,
+			);
+		}
+
+		return {
+			entityId: params.entityId,
+			agentId: params.agentId,
+			status: params.status,
+			expiresAt: params.expiresAt ?? null,
+			retentionUntil: params.retentionUntil ?? null,
+			completedAt:
+				params.status === "done" || params.status === "cancelled" ? ts : null,
+			updatedAt: ts,
+		};
+	});
+}
+
+export function getTaskMeta(
+	accessor: DbAccessor,
+	entityId: string,
+	agentId: string,
+): TaskMeta | null {
+	return accessor.withReadDb((db) => {
+		const row = db
+			.prepare("SELECT * FROM task_meta WHERE entity_id = ? AND agent_id = ?")
+			.get(entityId, agentId) as Record<string, unknown> | undefined;
+		return row ? rowToTaskMeta(row) : null;
+	});
+}
+
+export function updateTaskStatus(
+	accessor: DbAccessor,
+	entityId: string,
+	agentId: string,
+	status: TaskStatus,
+): void {
+	const ts = now();
+	accessor.withWriteTx((db) => {
+		db.prepare(
+			`UPDATE task_meta
+			 SET status = ?, completed_at = ?, updated_at = ?
+			 WHERE entity_id = ? AND agent_id = ?`,
+		).run(
+			status,
+			status === "done" || status === "cancelled" ? ts : null,
+			ts,
+			entityId,
+			agentId,
+		);
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Structural density
+// ---------------------------------------------------------------------------
+
+export interface StructuralDensity {
+	readonly aspectCount: number;
+	readonly attributeCount: number;
+	readonly constraintCount: number;
+	readonly dependencyCount: number;
+}
+
+export function getStructuralDensity(
+	accessor: DbAccessor,
+	entityId: string,
+	agentId: string,
+): StructuralDensity {
+	return accessor.withReadDb((db) => {
+		const aspects = db
+			.prepare(
+				`SELECT COUNT(*) as n FROM entity_aspects
+				 WHERE entity_id = ? AND agent_id = ?`,
+			)
+			.get(entityId, agentId) as { n: number };
+
+		const attributes = db
+			.prepare(
+				`SELECT COUNT(*) as n FROM entity_attributes ea
+				 JOIN entity_aspects asp ON asp.id = ea.aspect_id
+				 WHERE asp.entity_id = ? AND ea.agent_id = ?
+				   AND ea.kind = 'attribute' AND ea.status = 'active'`,
+			)
+			.get(entityId, agentId) as { n: number };
+
+		const constraints = db
+			.prepare(
+				`SELECT COUNT(*) as n FROM entity_attributes ea
+				 JOIN entity_aspects asp ON asp.id = ea.aspect_id
+				 WHERE asp.entity_id = ? AND ea.agent_id = ?
+				   AND ea.kind = 'constraint' AND ea.status = 'active'`,
+			)
+			.get(entityId, agentId) as { n: number };
+
+		const dependencies = db
+			.prepare(
+				`SELECT COUNT(*) as n FROM entity_dependencies
+				 WHERE (source_entity_id = ? OR target_entity_id = ?)
+				   AND agent_id = ?`,
+			)
+			.get(entityId, entityId, agentId) as { n: number };
+
+		return {
+			aspectCount: aspects.n,
+			attributeCount: attributes.n,
+			constraintCount: constraints.n,
+			dependencyCount: dependencies.n,
+		};
+	});
+}

--- a/packages/daemon/src/memory-config.ts
+++ b/packages/daemon/src/memory-config.ts
@@ -104,6 +104,15 @@ export const DEFAULT_PIPELINE_V2: PipelineV2Config = {
 		pollMs: 5000,
 		batchSize: 8,
 	},
+	procedural: {
+		enabled: true,
+		decayRate: 0.99,
+		minImportance: 0.3,
+		importanceOnInstall: 0.7,
+		enrichOnInstall: true,
+		enrichMinDescription: 30,
+		reconcileIntervalMs: 60000,
+	},
 };
 
 export interface ResolvedMemoryConfig {
@@ -151,6 +160,7 @@ export function loadPipelineConfig(
 	const telemetryRaw = raw.telemetry as Record<string, unknown> | undefined;
 	const continuityRaw = raw.continuity as Record<string, unknown> | undefined;
 	const embeddingTrackerRaw = raw.embeddingTracker as Record<string, unknown> | undefined;
+	const proceduralRaw = raw.procedural as Record<string, unknown> | undefined;
 
 	// Helper: resolve nested-first, flat-fallback
 	const d = DEFAULT_PIPELINE_V2;
@@ -468,6 +478,39 @@ export function loadPipelineConfig(
 				1,
 				20,
 				d.embeddingTracker.batchSize,
+			),
+		},
+
+		procedural: {
+			enabled: resolveBool(
+				proceduralRaw?.enabled, undefined, d.procedural.enabled,
+			),
+			decayRate: clampFraction(
+				proceduralRaw?.decayRate,
+				d.procedural.decayRate,
+			),
+			minImportance: clampFraction(
+				proceduralRaw?.minImportance,
+				d.procedural.minImportance,
+			),
+			importanceOnInstall: clampFraction(
+				proceduralRaw?.importanceOnInstall,
+				d.procedural.importanceOnInstall,
+			),
+			enrichOnInstall: resolveBool(
+				proceduralRaw?.enrichOnInstall, undefined, d.procedural.enrichOnInstall,
+			),
+			enrichMinDescription: clampPositive(
+				proceduralRaw?.enrichMinDescription,
+				10,
+				500,
+				d.procedural.enrichMinDescription,
+			),
+			reconcileIntervalMs: clampPositive(
+				proceduralRaw?.reconcileIntervalMs,
+				10000,
+				600000,
+				d.procedural.reconcileIntervalMs,
 			),
 		},
 	};

--- a/packages/daemon/src/pipeline/skill-enrichment.ts
+++ b/packages/daemon/src/pipeline/skill-enrichment.ts
@@ -1,0 +1,132 @@
+/**
+ * Skill frontmatter enrichment via LLM.
+ *
+ * When a skill is installed with thin frontmatter (short description,
+ * no triggers), this module generates richer metadata so the skill
+ * can be discovered through memory retrieval.
+ *
+ * Lives alongside the other extraction/decision prompts in pipeline/.
+ */
+
+import type { LlmProvider } from "./provider";
+import { logger } from "../logger";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SkillEnrichmentInput {
+	readonly name: string;
+	readonly description: string;
+	readonly body: string;
+}
+
+export interface SkillEnrichmentResult {
+	readonly description: string;
+	readonly triggers: readonly string[];
+	readonly tags: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Prompt
+// ---------------------------------------------------------------------------
+
+function buildEnrichmentPrompt(input: SkillEnrichmentInput): string {
+	const bodyPreview = input.body.length > 3000
+		? `${input.body.slice(0, 3000)}\n[truncated]`
+		: input.body;
+
+	return `You are analyzing an AI agent skill to generate discovery metadata.
+
+Skill name: ${input.name}
+Current description: ${input.description || "(none)"}
+
+Skill content:
+${bodyPreview}
+
+Generate:
+1. "description": A rich 1-2 sentence description explaining what this skill does and when to use it. Focus on mechanism and use-case.
+2. "triggers": A list of 3-8 short phrases a user might say when they need this skill. These are discovery keywords, not commands. Examples: "help me write tests", "optimize database queries", "create a new component".
+3. "tags": A list of 2-5 domain tags for grouping. Use lowercase, single words or hyphenated compounds. Examples: "testing", "database", "ui", "code-review", "deployment".
+
+Return ONLY a JSON object with these three keys. No other text.
+{"description": "...", "triggers": ["...", "..."], "tags": ["...", "..."]}`;
+}
+
+// ---------------------------------------------------------------------------
+// JSON parsing
+// ---------------------------------------------------------------------------
+
+const THINK_RE = /<think>[\s\S]*?<\/think>\s*/g;
+const FENCE_RE = /```(?:json)?\s*([\s\S]*?)```/;
+
+function parseEnrichmentOutput(raw: string): SkillEnrichmentResult | null {
+	const stripped = raw.replace(THINK_RE, "").trim();
+	const fenceMatch = stripped.match(FENCE_RE);
+	const jsonStr = fenceMatch ? fenceMatch[1].trim() : stripped;
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(jsonStr);
+	} catch {
+		return null;
+	}
+
+	if (typeof parsed !== "object" || parsed === null) return null;
+	const obj = parsed as Record<string, unknown>;
+
+	const description = typeof obj.description === "string"
+		? obj.description.trim()
+		: "";
+
+	const triggers = Array.isArray(obj.triggers)
+		? obj.triggers.filter((t): t is string => typeof t === "string" && t.trim().length > 0)
+		: [];
+
+	const tags = Array.isArray(obj.tags)
+		? obj.tags.filter((t): t is string => typeof t === "string" && t.trim().length > 0)
+		: [];
+
+	if (!description && triggers.length === 0) return null;
+
+	return { description, triggers, tags };
+}
+
+// ---------------------------------------------------------------------------
+// Main enrichment function
+// ---------------------------------------------------------------------------
+
+export async function enrichSkillFrontmatter(
+	input: SkillEnrichmentInput,
+	provider: LlmProvider,
+): Promise<SkillEnrichmentResult | null> {
+	const prompt = buildEnrichmentPrompt(input);
+
+	try {
+		const raw = await provider.generate(prompt, { maxTokens: 512 });
+		const result = parseEnrichmentOutput(raw);
+
+		if (!result) {
+			logger.warn("pipeline", "Failed to parse skill enrichment output", {
+				skill: input.name,
+				preview: raw.slice(0, 200),
+			});
+			return null;
+		}
+
+		logger.debug("pipeline", "Skill enrichment complete", {
+			skill: input.name,
+			triggerCount: result.triggers.length,
+			tagCount: result.tags.length,
+		});
+
+		return result;
+	} catch (e) {
+		const msg = e instanceof Error ? e.message : String(e);
+		logger.warn("pipeline", "Skill enrichment LLM call failed", {
+			skill: input.name,
+			error: msg,
+		});
+		return null;
+	}
+}

--- a/packages/daemon/src/pipeline/skill-frontmatter.ts
+++ b/packages/daemon/src/pipeline/skill-frontmatter.ts
@@ -1,0 +1,110 @@
+/**
+ * YAML round-trip frontmatter read/write for SKILL.md files.
+ *
+ * Uses the `yaml` package's Document API to preserve comments,
+ * formatting, and existing fields when rewriting enrichment data
+ * back into SKILL.md frontmatter.
+ */
+
+import { parseDocument, stringify } from "yaml";
+import type { SkillFrontmatter } from "./skill-graph";
+
+// ---------------------------------------------------------------------------
+// Parse
+// ---------------------------------------------------------------------------
+
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/;
+
+export interface ParsedSkillFile {
+	readonly frontmatter: SkillFrontmatter;
+	readonly body: string;
+	readonly rawFrontmatter: string;
+}
+
+export function parseSkillFile(content: string): ParsedSkillFile | null {
+	const match = content.match(FRONTMATTER_RE);
+	if (!match) return null;
+
+	const rawFm = match[1];
+	const body = match[2];
+
+	const doc = parseDocument(rawFm);
+	const data = doc.toJSON() as Record<string, unknown> | null;
+	if (!data) return null;
+
+	const getString = (key: string): string =>
+		typeof data[key] === "string" ? (data[key] as string) : "";
+
+	const getStringArray = (key: string): string[] => {
+		const val = data[key];
+		if (Array.isArray(val)) return val.filter((v): v is string => typeof v === "string");
+		if (typeof val === "string") {
+			return val.split(",").map((s) => s.trim()).filter(Boolean);
+		}
+		return [];
+	};
+
+	return {
+		frontmatter: {
+			name: getString("name") || getString("title") || "",
+			description: getString("description"),
+			version: getString("version") || undefined,
+			author: getString("author") || undefined,
+			license: getString("license") || undefined,
+			triggers: getStringArray("triggers").length > 0
+				? getStringArray("triggers")
+				: undefined,
+			tags: getStringArray("tags").length > 0
+				? getStringArray("tags")
+				: undefined,
+			permissions: getStringArray("permissions").length > 0
+				? getStringArray("permissions")
+				: undefined,
+			role: getString("role") || undefined,
+		},
+		body,
+		rawFrontmatter: rawFm,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Rewrite (round-trip preserving)
+// ---------------------------------------------------------------------------
+
+export interface FrontmatterPatch {
+	readonly description?: string;
+	readonly triggers?: readonly string[];
+	readonly tags?: readonly string[];
+}
+
+/**
+ * Apply enrichment data to a SKILL.md file's frontmatter using
+ * YAML round-trip parsing. Preserves existing fields and comments.
+ *
+ * Returns the full rewritten file content, or null if parsing fails.
+ */
+export function patchSkillFrontmatter(
+	fileContent: string,
+	patch: FrontmatterPatch,
+): string | null {
+	const match = fileContent.match(FRONTMATTER_RE);
+	if (!match) return null;
+
+	const rawFm = match[1];
+	const body = match[2];
+
+	const doc = parseDocument(rawFm);
+
+	if (patch.description) {
+		doc.set("description", patch.description);
+	}
+	if (patch.triggers && patch.triggers.length > 0) {
+		doc.set("triggers", [...patch.triggers]);
+	}
+	if (patch.tags && patch.tags.length > 0) {
+		doc.set("tags", [...patch.tags]);
+	}
+
+	const newFm = doc.toString().trimEnd();
+	return `---\n${newFm}\n---\n${body}`;
+}

--- a/packages/daemon/src/pipeline/skill-graph.ts
+++ b/packages/daemon/src/pipeline/skill-graph.ts
@@ -1,0 +1,339 @@
+/**
+ * Skill graph operations for procedural memory P1.
+ *
+ * Handles creating and removing skill nodes in the knowledge graph
+ * when skills are installed or uninstalled. Each skill gets:
+ * - An entity row (entity_type = 'skill')
+ * - A skill_meta row with installation metadata
+ * - An embedding from enriched frontmatter
+ * - Entity extraction from the SKILL.md body
+ */
+
+import type { DbAccessor, WriteDb } from "../db-accessor";
+import type { EmbeddingConfig, PipelineV2Config } from "../memory-config";
+import type { LlmProvider } from "./provider";
+import { enrichSkillFrontmatter } from "./skill-enrichment";
+import { extractFactsAndEntities } from "./extraction";
+import { txPersistEntities } from "./graph-transactions";
+import { vectorToBlob, syncVecInsert, syncVecDeleteByEmbeddingIds } from "../db-helpers";
+import { logger } from "../logger";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SkillFrontmatter {
+	readonly name: string;
+	readonly description: string;
+	readonly version?: string;
+	readonly author?: string;
+	readonly license?: string;
+	readonly triggers?: readonly string[];
+	readonly tags?: readonly string[];
+	readonly permissions?: readonly string[];
+	readonly role?: string;
+}
+
+export interface SkillInstallInput {
+	readonly frontmatter: SkillFrontmatter;
+	readonly body: string;
+	readonly source: string;
+	readonly fsPath: string;
+	readonly agentId?: string;
+}
+
+export interface SkillInstallResult {
+	readonly entityId: string;
+	readonly enriched: boolean;
+	readonly embeddingCreated: boolean;
+	readonly entitiesExtracted: number;
+}
+
+export interface SkillUninstallInput {
+	readonly skillName: string;
+	readonly agentId?: string;
+}
+
+export interface SkillUninstallResult {
+	readonly removed: boolean;
+	readonly entityId: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function skillEntityId(agentId: string, name: string): string {
+	return `skill:${agentId}:${name}`;
+}
+
+function buildEmbeddingText(fm: SkillFrontmatter): string {
+	const parts = [fm.name];
+	if (fm.description) parts.push(fm.description);
+	if (fm.triggers && fm.triggers.length > 0) {
+		parts.push(fm.triggers.join(", "));
+	}
+	return parts.join(" — ");
+}
+
+function contentHash(text: string): string {
+	const h = new Bun.CryptoHasher("sha256");
+	h.update(text);
+	return h.digest("hex").slice(0, 16);
+}
+
+// ---------------------------------------------------------------------------
+// Install: create entity + skill_meta + embedding + extraction
+// ---------------------------------------------------------------------------
+
+export async function installSkillNode(
+	input: SkillInstallInput,
+	accessor: DbAccessor,
+	config: PipelineV2Config,
+	embeddingCfg: EmbeddingConfig,
+	fetchEmbedding: (text: string, cfg: EmbeddingConfig) => Promise<number[] | null>,
+	provider: LlmProvider | null,
+): Promise<SkillInstallResult> {
+	const agentId = input.agentId ?? "default";
+	const entityId = skillEntityId(agentId, input.frontmatter.name);
+	const now = new Date().toISOString();
+	const procCfg = config.procedural;
+
+	let fm = input.frontmatter;
+	let enriched = false;
+
+	// Step 1: Enrich if needed
+	const needsEnrichment =
+		fm.description.length < procCfg.enrichMinDescription ||
+		!fm.triggers || fm.triggers.length === 0;
+
+	if (procCfg.enrichOnInstall && needsEnrichment && provider === null) {
+		logger.warn("pipeline", "Skill enrichment skipped — LLM provider not available", {
+			skill: fm.name,
+			descriptionLength: fm.description.length,
+			hasTriggers: Boolean(fm.triggers && fm.triggers.length > 0),
+		});
+	}
+
+	if (procCfg.enrichOnInstall && needsEnrichment && provider !== null) {
+		const enrichResult = await enrichSkillFrontmatter(
+			{ name: fm.name, description: fm.description, body: input.body },
+			provider,
+		);
+		if (enrichResult) {
+			fm = {
+				...fm,
+				description: enrichResult.description || fm.description,
+				triggers: enrichResult.triggers.length > 0
+					? enrichResult.triggers
+					: fm.triggers,
+				tags: enrichResult.tags.length > 0
+					? enrichResult.tags
+					: fm.tags,
+			};
+			enriched = true;
+		}
+	}
+
+	// Step 2: Create entity + skill_meta in a write transaction
+	accessor.withWriteTx((db) => {
+		// Check if entity already exists (idempotent)
+		const existing = db.prepare(
+			"SELECT id FROM entities WHERE id = ?",
+		).get(entityId) as { id: string } | undefined;
+
+		if (existing) {
+			// Update existing entity
+			db.prepare(
+				`UPDATE entities SET description = ?, updated_at = ? WHERE id = ?`,
+			).run(fm.description, now, entityId);
+
+			// Update skill_meta
+			db.prepare(
+				`UPDATE skill_meta SET
+					version = ?, author = ?, license = ?, source = ?,
+					role = ?, triggers = ?, tags = ?, permissions = ?,
+					enriched = ?, fs_path = ?, uninstalled_at = NULL,
+					updated_at = ?
+				 WHERE entity_id = ?`,
+			).run(
+				fm.version ?? null,
+				fm.author ?? null,
+				fm.license ?? null,
+				input.source,
+				fm.role ?? "utility",
+				fm.triggers ? JSON.stringify(fm.triggers) : null,
+				fm.tags ? JSON.stringify(fm.tags) : null,
+				fm.permissions ? JSON.stringify(fm.permissions) : null,
+				enriched ? 1 : 0,
+				input.fsPath,
+				now,
+				entityId,
+			);
+		} else {
+			// Insert new entity
+			db.prepare(
+				`INSERT INTO entities
+				 (id, name, canonical_name, entity_type, description, mentions, created_at, updated_at)
+				 VALUES (?, ?, ?, 'skill', ?, 0, ?, ?)`,
+			).run(entityId, fm.name, fm.name.toLowerCase(), fm.description, now, now);
+
+			// Insert skill_meta
+			db.prepare(
+				`INSERT INTO skill_meta
+				 (entity_id, agent_id, version, author, license, source,
+				  role, triggers, tags, permissions, enriched,
+				  installed_at, importance, decay_rate, fs_path)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			).run(
+				entityId,
+				agentId,
+				fm.version ?? null,
+				fm.author ?? null,
+				fm.license ?? null,
+				input.source,
+				fm.role ?? "utility",
+				fm.triggers ? JSON.stringify(fm.triggers) : null,
+				fm.tags ? JSON.stringify(fm.tags) : null,
+				fm.permissions ? JSON.stringify(fm.permissions) : null,
+				enriched ? 1 : 0,
+				now,
+				procCfg.importanceOnInstall,
+				procCfg.decayRate,
+				input.fsPath,
+			);
+		}
+	});
+
+	// Step 3: Generate embedding from enriched frontmatter
+	let embeddingCreated = false;
+	const embeddingText = buildEmbeddingText(fm);
+	const embVec = await fetchEmbedding(embeddingText, embeddingCfg);
+
+	if (embVec && embVec.length > 0) {
+		const embId = crypto.randomUUID();
+		const hash = contentHash(embeddingText);
+		const blob = vectorToBlob(embVec);
+
+		accessor.withWriteTx((db) => {
+			// Remove any old skill embeddings
+			const oldEmbs = db.prepare(
+				`SELECT id FROM embeddings WHERE source_type = 'skill' AND source_id = ?`,
+			).all(entityId) as Array<{ id: string }>;
+
+			if (oldEmbs.length > 0) {
+				syncVecDeleteByEmbeddingIds(db, oldEmbs.map((e) => e.id));
+				db.prepare(
+					`DELETE FROM embeddings WHERE source_type = 'skill' AND source_id = ?`,
+				).run(entityId);
+			}
+
+			// Insert new embedding
+			db.prepare(
+				`INSERT INTO embeddings
+				 (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at)
+				 VALUES (?, ?, ?, ?, 'skill', ?, ?, ?)
+				 ON CONFLICT(content_hash) DO UPDATE SET
+				   vector = excluded.vector,
+				   dimensions = excluded.dimensions,
+				   source_id = excluded.source_id,
+				   chunk_text = excluded.chunk_text`,
+			).run(embId, hash, blob, embVec.length, entityId, embeddingText, now);
+
+			syncVecInsert(db, embId, embVec);
+		});
+
+		embeddingCreated = true;
+	}
+
+	// Step 4: Extract entities from SKILL.md body for graph relations
+	let entitiesExtracted = 0;
+	if (config.graph.enabled && provider !== null && input.body.trim().length >= 20) {
+		try {
+			const extraction = await extractFactsAndEntities(input.body, provider);
+			if (extraction.entities.length > 0) {
+				accessor.withWriteTx((db) => {
+					const result = txPersistEntities(db, {
+						entities: extraction.entities,
+						sourceMemoryId: entityId,
+						extractedAt: now,
+					});
+					entitiesExtracted = result.entitiesInserted + result.entitiesUpdated;
+				});
+			}
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : String(e);
+			logger.warn("pipeline", "Skill body extraction failed", {
+				skill: fm.name,
+				error: msg,
+			});
+		}
+	}
+
+	logger.info("pipeline", "Skill node installed", {
+		skill: fm.name,
+		entityId,
+		enriched,
+		embeddingCreated,
+		entitiesExtracted,
+	});
+
+	return { entityId, enriched, embeddingCreated, entitiesExtracted };
+}
+
+// ---------------------------------------------------------------------------
+// Uninstall: remove entity + skill_meta + embeddings + relations
+// ---------------------------------------------------------------------------
+
+export function uninstallSkillNode(
+	input: SkillUninstallInput,
+	accessor: DbAccessor,
+): SkillUninstallResult {
+	const agentId = input.agentId ?? "default";
+	const entityId = skillEntityId(agentId, input.skillName);
+
+	const exists = accessor.withReadDb((db) =>
+		db.prepare("SELECT id FROM entities WHERE id = ?")
+			.get(entityId) as { id: string } | undefined,
+	);
+
+	if (!exists) {
+		return { removed: false, entityId: null };
+	}
+
+	accessor.withWriteTx((db) => {
+		// 1. Remove skill relation edges
+		db.prepare(
+			`DELETE FROM relations
+			 WHERE source_entity_id = ? OR target_entity_id = ?`,
+		).run(entityId, entityId);
+
+		// 2. Remove skill mention links
+		db.prepare(
+			`DELETE FROM memory_entity_mentions WHERE entity_id = ?`,
+		).run(entityId);
+
+		// 3. Remove embeddings + vec sync
+		const embRows = db.prepare(
+			`SELECT id FROM embeddings WHERE source_type = 'skill' AND source_id = ?`,
+		).all(entityId) as Array<{ id: string }>;
+
+		if (embRows.length > 0) {
+			syncVecDeleteByEmbeddingIds(db, embRows.map((e) => e.id));
+			db.prepare(
+				`DELETE FROM embeddings WHERE source_type = 'skill' AND source_id = ?`,
+			).run(entityId);
+		}
+
+		// 4. Hard-delete skill_meta + entity in same transaction
+		db.prepare("DELETE FROM skill_meta WHERE entity_id = ?").run(entityId);
+		db.prepare("DELETE FROM entities WHERE id = ?").run(entityId);
+	});
+
+	logger.info("pipeline", "Skill node uninstalled", {
+		skill: input.skillName,
+		entityId,
+	});
+
+	return { removed: true, entityId };
+}

--- a/packages/daemon/src/pipeline/skill-reconciler.ts
+++ b/packages/daemon/src/pipeline/skill-reconciler.ts
@@ -1,0 +1,337 @@
+/**
+ * Skill filesystem reconciler for procedural memory P1.
+ *
+ * Ensures the knowledge graph stays in sync with the skills directory:
+ * - Startup backfill: creates graph nodes for installed skills missing from DB
+ * - Periodic reconciler: same scan on configurable interval
+ * - File watcher: low-latency reconciliation via chokidar
+ * - Orphan cleanup: removes graph nodes when SKILL.md files are deleted
+ *
+ * Idempotent — matched by canonical name + frontmatter content hash.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, basename, dirname } from "node:path";
+import { watch } from "chokidar";
+import type { DbAccessor } from "../db-accessor.js";
+import type { EmbeddingConfig, PipelineV2Config } from "../memory-config.js";
+import type { LlmProvider } from "./provider.js";
+import { parseSkillFile } from "./skill-frontmatter.js";
+import { installSkillNode, uninstallSkillNode } from "./skill-graph.js";
+import { logger } from "../logger.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ReconcilerDeps {
+	readonly accessor: DbAccessor;
+	readonly pipelineConfig: PipelineV2Config;
+	readonly embeddingConfig: EmbeddingConfig;
+	readonly fetchEmbedding: (text: string, cfg: EmbeddingConfig) => Promise<number[] | null>;
+	readonly getProvider: () => LlmProvider | null;
+	readonly agentsDir: string;
+}
+
+export interface ReconcilerHandle {
+	stop(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function skillsDir(agentsDir: string): string {
+	return join(agentsDir, "skills");
+}
+
+// ---------------------------------------------------------------------------
+// Reconciliation logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Single reconciliation pass:
+ * 1. Scan filesystem for installed skills
+ * 2. For each skill with SKILL.md:
+ *    - If entity missing → install
+ *    - If entity exists but frontmatter changed → re-install
+ * 3. For each skill_meta row with no matching file → uninstall
+ */
+export async function reconcileOnce(deps: ReconcilerDeps): Promise<{
+	installed: number;
+	updated: number;
+	removed: number;
+}> {
+	const dir = skillsDir(deps.agentsDir);
+	let installed = 0;
+	let updated = 0;
+	let removed = 0;
+
+	if (!existsSync(dir)) {
+		return { installed, updated, removed };
+	}
+
+	// 1. Scan filesystem
+	const diskSkills = new Map<string, string>(); // name → SKILL.md path
+	const entries = readdirSync(dir, { withFileTypes: true });
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+		const skillMdPath = join(dir, entry.name, "SKILL.md");
+		if (existsSync(skillMdPath)) {
+			diskSkills.set(entry.name, skillMdPath);
+		}
+	}
+
+	// 2. Check each disk skill against the graph
+	for (const [name, mdPath] of diskSkills) {
+		try {
+			const content = readFileSync(mdPath, "utf-8");
+			const parsed = parseSkillFile(content);
+			if (!parsed) continue;
+
+			const entityId = `skill:default:${name}`;
+			const fingerprint = buildFrontmatterFingerprint(
+				parsed.frontmatter.name,
+				parsed.frontmatter.description,
+				parsed.frontmatter.triggers,
+			);
+
+			// Check if entity already exists
+			const existing = deps.accessor.withReadDb((db) =>
+				db.prepare("SELECT id FROM entities WHERE id = ?")
+					.get(entityId) as { id: string } | undefined,
+			);
+
+			if (!existing) {
+				// Missing from graph — install
+				await installSkillNode(
+					{
+						frontmatter: parsed.frontmatter,
+						body: parsed.body,
+						source: "reconciler",
+						fsPath: mdPath,
+					},
+					deps.accessor,
+					deps.pipelineConfig,
+					deps.embeddingConfig,
+					deps.fetchEmbedding,
+					deps.getProvider(),
+				);
+				installed++;
+				logger.info("reconciler", "Backfilled skill node", { skill: name });
+			} else {
+				// Entity exists — check if frontmatter changed
+				const storedEmb = deps.accessor.withReadDb((db) =>
+					db.prepare(
+						"SELECT chunk_text FROM embeddings WHERE source_type = 'skill' AND source_id = ?",
+					).get(entityId) as { chunk_text: string } | undefined,
+				);
+
+				// Compare fingerprints: if the embedding text would be different,
+				// the skill has been updated on disk
+				const currentEmbText = [
+					parsed.frontmatter.name,
+					parsed.frontmatter.description,
+					...(parsed.frontmatter.triggers && parsed.frontmatter.triggers.length > 0
+						? [parsed.frontmatter.triggers.join(", ")]
+						: []),
+				].join(" — ");
+
+				if (storedEmb && storedEmb.chunk_text !== currentEmbText) {
+					await installSkillNode(
+						{
+							frontmatter: parsed.frontmatter,
+							body: parsed.body,
+							source: "reconciler",
+							fsPath: mdPath,
+						},
+						deps.accessor,
+						deps.pipelineConfig,
+						deps.embeddingConfig,
+						deps.fetchEmbedding,
+						deps.getProvider(),
+					);
+					updated++;
+					logger.info("reconciler", "Updated changed skill node", { skill: name });
+				}
+			}
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : String(e);
+			logger.warn("reconciler", "Failed to reconcile skill", {
+				skill: name,
+				error: msg,
+			});
+		}
+	}
+
+	// 3. Check for orphaned graph nodes (file removed from disk)
+	const graphSkills = deps.accessor.withReadDb((db) =>
+		db.prepare(
+			"SELECT entity_id, fs_path FROM skill_meta WHERE agent_id = 'default' AND uninstalled_at IS NULL",
+		).all() as Array<{ entity_id: string; fs_path: string }>,
+	);
+
+	for (const row of graphSkills) {
+		if (!existsSync(row.fs_path)) {
+			// Extract skill name from entity_id: "skill:default:{name}"
+			const parts = row.entity_id.split(":");
+			const skillName = parts.slice(2).join(":");
+			if (skillName) {
+				uninstallSkillNode({ skillName }, deps.accessor);
+				removed++;
+				logger.info("reconciler", "Removed orphaned skill node", {
+					skill: skillName,
+					entityId: row.entity_id,
+				});
+			}
+		}
+	}
+
+	if (installed > 0 || updated > 0 || removed > 0) {
+		logger.info("reconciler", "Reconciliation complete", {
+			installed,
+			updated,
+			removed,
+		});
+	}
+
+	return { installed, updated, removed };
+}
+
+// ---------------------------------------------------------------------------
+// Reconciler lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Start the skill reconciler:
+ * 1. Run an immediate backfill pass
+ * 2. Set up periodic reconciliation on interval
+ * 3. Watch the skills directory for file changes
+ */
+export function startReconciler(deps: ReconcilerDeps): ReconcilerHandle {
+	const intervalMs = deps.pipelineConfig.procedural.reconcileIntervalMs;
+	const dir = skillsDir(deps.agentsDir);
+
+	// Immediate backfill (async, doesn't block startup)
+	reconcileOnce(deps).catch((e) => {
+		logger.error("reconciler", "Startup backfill failed", e instanceof Error ? e : undefined, {
+			error: String(e),
+		});
+	});
+
+	// Periodic reconciliation
+	const timer = setInterval(() => {
+		reconcileOnce(deps).catch((e) => {
+			logger.error("reconciler", "Periodic reconciliation failed", e instanceof Error ? e : undefined, {
+				error: String(e),
+			});
+		});
+	}, intervalMs);
+
+	// File watcher for low-latency reconciliation
+	let watcher: ReturnType<typeof watch> | null = null;
+
+	if (existsSync(dir)) {
+		watcher = watch(join(dir, "*", "SKILL.md"), {
+			ignoreInitial: true,
+			awaitWriteFinish: { stabilityThreshold: 500 },
+		});
+
+		watcher.on("add", (filePath) => {
+			const skillName = basename(dirname(filePath));
+			logger.info("reconciler", "SKILL.md added", { skill: skillName });
+			reconcileSkill(skillName, filePath, deps);
+		});
+
+		watcher.on("change", (filePath) => {
+			const skillName = basename(dirname(filePath));
+			logger.info("reconciler", "SKILL.md changed", { skill: skillName });
+			reconcileSkill(skillName, filePath, deps);
+		});
+
+		watcher.on("unlink", (filePath) => {
+			const skillName = basename(dirname(filePath));
+			logger.info("reconciler", "SKILL.md removed", { skill: skillName });
+			uninstallSkillNode({ skillName }, deps.accessor);
+		});
+	}
+
+	logger.info("reconciler", "Skill reconciler started", {
+		intervalMs,
+		skillsDir: dir,
+		watcherActive: watcher !== null,
+	});
+
+	return {
+		stop() {
+			clearInterval(timer);
+			if (watcher) {
+				watcher.close();
+				watcher = null;
+			}
+			logger.info("reconciler", "Skill reconciler stopped");
+		},
+	};
+}
+
+/**
+ * Reconcile a single skill by name (triggered by file watcher).
+ */
+async function reconcileSkill(
+	skillName: string,
+	mdPath: string,
+	deps: ReconcilerDeps,
+): Promise<void> {
+	try {
+		if (!existsSync(mdPath)) {
+			uninstallSkillNode({ skillName }, deps.accessor);
+			return;
+		}
+
+		const content = readFileSync(mdPath, "utf-8");
+		const parsed = parseSkillFile(content);
+		if (!parsed) return;
+
+		// Skip if frontmatter hasn't changed (avoid redundant embedding work)
+		const entityId = `skill:default:${skillName}`;
+		const currentEmbText = [
+			parsed.frontmatter.name,
+			parsed.frontmatter.description,
+			...(parsed.frontmatter.triggers && parsed.frontmatter.triggers.length > 0
+				? [parsed.frontmatter.triggers.join(", ")]
+				: []),
+		].join(" — ");
+
+		const storedEmb = deps.accessor.withReadDb((db) =>
+			db.prepare(
+				"SELECT chunk_text FROM embeddings WHERE source_type = 'skill' AND source_id = ?",
+			).get(entityId) as { chunk_text: string } | undefined,
+		);
+
+		if (storedEmb && storedEmb.chunk_text === currentEmbText) {
+			logger.debug("reconciler", "Skill unchanged, skipping", { skill: skillName });
+			return;
+		}
+
+		await installSkillNode(
+			{
+				frontmatter: parsed.frontmatter,
+				body: parsed.body,
+				source: "reconciler",
+				fsPath: mdPath,
+			},
+			deps.accessor,
+			deps.pipelineConfig,
+			deps.embeddingConfig,
+			deps.fetchEmbedding,
+			deps.getProvider(),
+		);
+
+		logger.debug("reconciler", "Skill reconciled via watcher", { skill: skillName });
+	} catch (e) {
+		logger.warn("reconciler", "Watcher reconciliation failed", {
+			skill: skillName,
+			error: e instanceof Error ? e.message : String(e),
+		});
+	}
+}

--- a/packages/daemon/src/routes/skills.ts
+++ b/packages/daemon/src/routes/skills.ts
@@ -2,16 +2,22 @@
  * Skills API routes — extracted from daemon.ts
  *
  * Handles skill listing, browsing, searching, installing, and uninstalling.
- * All filesystem-based, no database dependencies.
+ * Integrates with the procedural memory graph for skill discovery.
  */
 
 import { spawn } from "node:child_process";
-import { existsSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { getSkillsRunnerCommand, resolvePrimaryPackageManager } from "@signet/core";
 import type { Hono } from "hono";
 import { logger } from "../logger.js";
+import { parseSkillFile, patchSkillFrontmatter } from "../pipeline/skill-frontmatter.js";
+import { installSkillNode, uninstallSkillNode } from "../pipeline/skill-graph.js";
+import { getDbAccessor, type DbAccessor } from "../db-accessor.js";
+import { loadMemoryConfig, type EmbeddingConfig, type PipelineV2Config } from "../memory-config.js";
+import { getLlmProvider } from "../llm.js";
+import type { LlmProvider } from "../pipeline/provider.js";
 
 function getAgentsDir(): string {
 	return process.env.SIGNET_PATH || join(homedir(), ".agents");
@@ -272,6 +278,162 @@ async function fetchClawhubCatalog(): Promise<ClawhubItem[]> {
 // Route mount
 // ---------------------------------------------------------------------------
 
+// Lazy dependency accessors — singletons are initialised at daemon startup
+// before any route handler runs. These callsites are safe.
+let fetchEmbeddingFn: ((text: string, cfg: EmbeddingConfig) => Promise<number[] | null>) | null = null;
+
+export function setFetchEmbedding(fn: (text: string, cfg: EmbeddingConfig) => Promise<number[] | null>): void {
+	fetchEmbeddingFn = fn;
+}
+
+function getAccessorSafe(): DbAccessor | null {
+	try { return getDbAccessor(); } catch { return null; }
+}
+
+function getProviderSafe(): LlmProvider | null {
+	try { return getLlmProvider(); } catch { return null; }
+}
+
+// Per-skill lock to prevent concurrent enrichment writes to SKILL.md
+const skillLocks = new Map<string, Promise<void>>();
+
+function withSkillLock(skillName: string, fn: () => Promise<void>): Promise<void> {
+	const prev = skillLocks.get(skillName) ?? Promise.resolve();
+	const next = prev.then(fn, fn).finally(() => {
+		if (skillLocks.get(skillName) === next) {
+			skillLocks.delete(skillName);
+		}
+	});
+	skillLocks.set(skillName, next);
+	return next;
+}
+
+/**
+ * After a successful skill install, create the graph node.
+ * Runs async — does not block the install response.
+ * Serialized per skill name to prevent concurrent SKILL.md writes.
+ */
+async function onSkillInstalled(skillName: string): Promise<void> {
+	return withSkillLock(skillName, () => onSkillInstalledInner(skillName));
+}
+
+async function onSkillInstalledInner(skillName: string): Promise<void> {
+	const accessor = getAccessorSafe();
+	if (!accessor) return;
+
+	const skillMdPath = join(getSkillsDir(), skillName, "SKILL.md");
+	if (!existsSync(skillMdPath)) return;
+
+	try {
+		const content = readFileSync(skillMdPath, "utf-8");
+		const parsed = parseSkillFile(content);
+		if (!parsed) {
+			logger.warn("skills", "Failed to parse SKILL.md frontmatter for graph", { skill: skillName });
+			return;
+		}
+
+		const memoryCfg = loadMemoryConfig(getAgentsDir());
+		if (!memoryCfg.pipelineV2.procedural.enabled) return;
+		if (!fetchEmbeddingFn) return;
+
+		const result = await installSkillNode(
+			{
+				frontmatter: parsed.frontmatter,
+				body: parsed.body,
+				source: "installed",
+				fsPath: skillMdPath,
+			},
+			accessor,
+			memoryCfg.pipelineV2,
+			memoryCfg.embedding,
+			fetchEmbeddingFn,
+			getProviderSafe(),
+		);
+
+		// Write enrichment back to SKILL.md if enriched
+		if (result.enriched) {
+			const freshContent = readFileSync(skillMdPath, "utf-8");
+			const freshParsed = parseSkillFile(freshContent);
+			if (freshParsed) {
+				// Get the enriched frontmatter from the installed node
+				const enrichedFm = accessor.withReadDb((db) =>
+					db.prepare(
+						"SELECT triggers, tags FROM skill_meta WHERE entity_id = ?",
+					).get(result.entityId) as { triggers: string | null; tags: string | null } | undefined,
+				);
+
+				if (enrichedFm) {
+					// Build a properly typed patch from DB values
+					let patchDescription: string | undefined;
+					let patchTriggers: readonly string[] | undefined;
+					let patchTags: readonly string[] | undefined;
+
+					const entity = accessor.withReadDb((db) =>
+						db.prepare("SELECT description FROM entities WHERE id = ?")
+							.get(result.entityId) as { description: string | null } | undefined,
+					);
+					if (entity?.description) patchDescription = entity.description;
+					if (enrichedFm.triggers) {
+						try {
+							const parsed: unknown = JSON.parse(enrichedFm.triggers);
+							if (Array.isArray(parsed)) patchTriggers = parsed.filter((v): v is string => typeof v === "string");
+						} catch { /* skip */ }
+					}
+					if (enrichedFm.tags) {
+						try {
+							const parsed: unknown = JSON.parse(enrichedFm.tags);
+							if (Array.isArray(parsed)) patchTags = parsed.filter((v): v is string => typeof v === "string");
+						} catch { /* skip */ }
+					}
+
+					const patched = patchSkillFrontmatter(freshContent, {
+						description: patchDescription,
+						triggers: patchTriggers,
+						tags: patchTags,
+					});
+					if (patched) {
+						writeFileSync(skillMdPath, patched, "utf-8");
+						logger.info("skills", "Wrote enrichment back to SKILL.md", { skill: skillName });
+					}
+				}
+			}
+		}
+
+		logger.info("skills", "Graph node created for skill", {
+			skill: skillName,
+			entityId: result.entityId,
+			enriched: result.enriched,
+			embeddingCreated: result.embeddingCreated,
+		});
+	} catch (e) {
+		logger.error("skills", "Failed to create graph node for skill", e as Error, {
+			skill: skillName,
+		});
+	}
+}
+
+/**
+ * Before a skill is uninstalled from the filesystem, remove its graph node.
+ */
+function onSkillUninstalling(skillName: string): void {
+	const accessor = getAccessorSafe();
+	if (!accessor) return;
+
+	try {
+		const result = uninstallSkillNode({ skillName }, accessor);
+		if (result.removed) {
+			logger.info("skills", "Graph node removed for skill", {
+				skill: skillName,
+				entityId: result.entityId,
+			});
+		}
+	} catch (e) {
+		logger.error("skills", "Failed to remove graph node for skill", e as Error, {
+			skill: skillName,
+		});
+	}
+}
+
 export function mountSkillsRoutes(app: Hono): void {
 	// GET /api/skills - list installed skills
 	app.get("/api/skills", (c) => {
@@ -525,6 +687,10 @@ export function mountSkillsRoutes(app: Hono): void {
 			proc.on("close", (code) => {
 				if (code === 0) {
 					logger.info("skills", "Skill installed", { name });
+					// Fire-and-forget graph node creation
+					onSkillInstalled(name).catch((e) => {
+						logger.error("skills", "Post-install graph hook failed", e as Error);
+					});
 					resolve(c.json({ success: true, name, output: stdout }));
 				} else {
 					const errMsg = stderr || stdout || `Install exited with code ${code}`;
@@ -554,6 +720,8 @@ export function mountSkillsRoutes(app: Hono): void {
 		}
 
 		try {
+			// Remove graph node before filesystem cleanup
+			onSkillUninstalling(name);
 			rmSync(skillDir, { recursive: true, force: true });
 			logger.info("skills", "Skill removed", { name });
 			return c.json({ success: true, name, message: `Removed ${name}` });

--- a/web/public/contentIndex.json
+++ b/web/public/contentIndex.json
@@ -193,6 +193,13 @@
     ],
     "collection": "docs"
   },
+  "docs/ideal-signet": {
+    "title": "Ideal Signet",
+    "url": "/docs/ideal-signet/",
+    "tags": [],
+    "links": [],
+    "collection": "docs"
+  },
   "docs/knowledge-architecture": {
     "title": "Knowledge Architecture",
     "url": "/docs/knowledge-architecture/",


### PR DESCRIPTION
## Summary

- Fixed 5 queries in `knowledge-graph.ts` that omitted `agent_id` from WHERE clauses, breaking multi-agent data isolation
- `upsertAspect`, `upsertDependency`, and `upsertTaskMeta` SELECT/UPDATE queries now filter by `agent_id`
- `getTaskMeta` and `updateTaskStatus` now require an `agentId` parameter and scope queries accordingly

## Test plan

- [x] `bun run typecheck` passes (no type errors from signature changes)
- [x] `bun test` passes (616 tests, 0 failures)
- [ ] Manual verification: confirm multi-agent upsert operations don't cross-contaminate data