### PR TITLE
fix(daemon): replace self-fetch in search endpoint, add vec0 error logging

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2980,8 +2980,12 @@ app.post("/api/memory/recall", async (c) => {
 });
 
 // Alias: GET /api/memory/search?q=... (spec-compatible)
+// Calls hybridRecall directly instead of self-fetching to avoid potential
+// issues with loopback fetch in single-threaded runtimes.
 app.get("/api/memory/search", async (c) => {
-	const q = c.req.query("q") ?? "";
+	const q = (c.req.query("q") ?? "").trim();
+	if (!q) return c.json({ error: "query is required" }, 400);
+
 	const limit = Number.parseInt(c.req.query("limit") ?? "10", 10);
 	const type = c.req.query("type");
 	const tags = c.req.query("tags");
@@ -2990,20 +2994,27 @@ app.get("/api/memory/search", async (c) => {
 	const importanceMin = c.req.query("importance_min");
 	const since = c.req.query("since");
 
-	return fetch(`http://${HOST}:${PORT}/api/memory/recall`, {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({
-			query: q,
-			limit,
-			type,
-			tags,
-			who,
-			pinned: pinned === "1" || pinned === "true",
-			importance_min: importanceMin ? Number.parseFloat(importanceMin) : undefined,
-			since,
-		}),
-	});
+	const cfg = loadMemoryConfig(AGENTS_DIR);
+	try {
+		const result = await hybridRecall(
+			{
+				query: q,
+				limit,
+				type,
+				tags,
+				who,
+				pinned: pinned === "1" || pinned === "true",
+				importance_min: importanceMin ? Number.parseFloat(importanceMin) : undefined,
+				since,
+			},
+			cfg,
+			fetchEmbedding,
+		);
+		return c.json(result);
+	} catch (e) {
+		logger.error("memory", "Search (recall alias) failed", e as Error);
+		return c.json({ error: "Recall failed", results: [] }, 500);
+	}
 });
 
 // ============================================================================

--- a/packages/daemon/src/db-accessor.ts
+++ b/packages/daemon/src/db-accessor.ts
@@ -27,8 +27,13 @@ for (const sqlitePath of HOMEBREW_SQLITE_PATHS) {
 	if (existsSync(sqlitePath)) {
 		try {
 			Database.setCustomSQLite(sqlitePath);
-		} catch {
-			// SQLite already loaded (e.g., in test environment) — skip
+		} catch (e) {
+			// SQLite already loaded (e.g., in test environment) — skip.
+			// Log so users can diagnose extension-loading failures.
+			console.warn(
+				`[db-accessor] setCustomSQLite(${sqlitePath}) skipped:`,
+				(e as Error).message ?? e,
+			);
 		}
 		break;
 	}
@@ -96,8 +101,11 @@ function loadVecExtension(db: Database): void {
 	if (vecExtPath) {
 		try {
 			db.loadExtension(vecExtPath);
-		} catch {
-			// Extension may already be loaded or unavailable
+		} catch (e) {
+			console.warn(
+				"[db-accessor] loadExtension failed:",
+				(e as Error).message ?? e,
+			);
 		}
 	}
 }


### PR DESCRIPTION
## Problem

Two issues causing degraded search on macOS with Bun:

### 1. `GET /api/memory/search` returns 500

The search endpoint self-fetches `POST /api/memory/recall` via loopback HTTP (`fetch(\`http://${HOST}:${PORT}/api/memory/recall\`)`). In some Bun environments this internal fetch fails, returning 500 to the caller even though the recall endpoint works fine when called directly.

### 2. Silent `catch {}` blocks hide extension-loading failures

Both `setCustomSQLite()` and `loadExtension()` swallow all errors silently. When vec0 fails to load, the daemon starts up looking healthy but silently degrades to keyword-only search. Users have no way to diagnose why vector search isn't working without reading source code.

## Fix

1. **Replace self-fetch with direct function call** — the search handler now calls `hybridRecall()` directly (same function the recall POST handler uses), eliminating the loopback HTTP dependency. Also adds empty-query validation consistent with the POST endpoint.

2. **Add `console.warn` logging** to both `setCustomSQLite()` and `loadExtension()` catch blocks so failures appear in daemon logs.

## Testing

- Verified `hybridRecall`, `loadMemoryConfig`, and `fetchEmbedding` are all in scope at the call site
- The search endpoint now has identical behavior to the recall endpoint (same function, same error handling pattern)
- Tested on macOS ARM64 with Bun 1.3.9 + Signet v0.38.0