### PR TITLE
Add macOS defaults reset action in settings

### DIFF
--- a/packages/cli/dashboard/src/lib/components/tabs/SettingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/SettingsTab.svelte
@@ -30,6 +30,10 @@ async function saveSettings() {
 	await st.save();
 }
 
+function resetToDefaults() {
+	st.resetToMacDefaults();
+}
+
 function formatSavedAt(raw: string | null): string {
 	if (!raw) return "";
 	try {
@@ -74,9 +78,14 @@ $effect(() => {
 					<span>{st.lastSaveFeedback}</span>
 				{/if}
 			</div>
-			<button class="save-btn" onclick={saveSettings} disabled={st.saving || !st.isDirty}>
-				{st.saving ? "Saving…" : "Save"}
-			</button>
+			<div class="save-actions">
+				<button class="reset-btn" onclick={resetToDefaults} disabled={st.saving}>
+					Reset to Defaults
+				</button>
+				<button class="save-btn" onclick={saveSettings} disabled={st.saving || !st.isDirty}>
+					{st.saving ? "Saving…" : "Save"}
+				</button>
+			</div>
 		</div>
 	{/if}
 </div>
@@ -137,18 +146,38 @@ $effect(() => {
 		color: var(--sig-warning, #d4a017);
 	}
 
+	.save-actions {
+		display: flex;
+		align-items: center;
+		gap: var(--space-xs);
+	}
+
+	.reset-btn,
 	.save-btn {
 		font-family: var(--font-mono);
 		font-size: 11px;
 		letter-spacing: 0.06em;
 		text-transform: uppercase;
-		color: var(--sig-bg);
-		background: var(--sig-text-bright);
-		border: none;
 		border-radius: 0;
 		padding: 6px 20px;
 		cursor: pointer;
-		transition: opacity var(--dur) var(--ease);
+		transition: opacity var(--dur) var(--ease), background var(--dur) var(--ease), color var(--dur) var(--ease), border-color var(--dur) var(--ease);
+	}
+
+	.reset-btn {
+		color: var(--sig-text);
+		background: var(--sig-surface-raised);
+		border: 1px solid var(--sig-border-strong);
+	}
+
+	.reset-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+	.reset-btn:not(:disabled):hover { background: var(--sig-border); }
+
+	.save-btn {
+		color: var(--sig-bg);
+		background: var(--sig-text-bright);
+		border: 1px solid var(--sig-text-bright);
+		border-radius: 0;
 	}
 
 	.save-btn:disabled { opacity: 0.5; cursor: not-allowed; }

--- a/packages/cli/dashboard/src/lib/stores/settings.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/settings.svelte.ts
@@ -114,6 +114,28 @@ export type YamlObject = { [key: string]: YamlValue };
 
 export const SETTINGS_PRIORITY = ["agent.yaml", "AGENT.yaml", "config.yaml"] as const;
 
+const MACOS_DEFAULT_HARNESSES = ["opencode"] as const;
+
+const MACOS_DEFAULT_EMBEDDINGS = {
+	provider: "ollama",
+	model: "nomic-embed-text",
+	dimensions: 768,
+} as const;
+
+const MACOS_DEFAULT_SEARCH = {
+	rehearsal_enabled: true,
+} as const;
+
+const MACOS_DEFAULT_PIPELINE = {
+	enabled: true,
+	extractionProvider: "ollama",
+	extractionModel: "qwen3:4b",
+	maintenanceMode: "execute",
+	graphEnabled: true,
+	autonomousEnabled: true,
+	rerankerEnabled: true,
+} as const;
+
 class SettingsStore {
 	agent = $state<YamlObject>({});
 	config = $state<YamlObject>({});
@@ -266,6 +288,28 @@ class SettingsStore {
 			["harnesses"],
 			this.harnessArray().filter((x) => x !== name),
 		);
+	}
+
+	resetToMacDefaults(): void {
+		this.set(this.agent, ["harnesses"], [...MACOS_DEFAULT_HARNESSES]);
+
+		const embeddingsPath = this.embPath();
+		this.set(this.sObj(), [...embeddingsPath, "provider"], MACOS_DEFAULT_EMBEDDINGS.provider);
+		this.set(this.sObj(), [...embeddingsPath, "model"], MACOS_DEFAULT_EMBEDDINGS.model);
+		this.set(this.sObj(), [...embeddingsPath, "dimensions"], MACOS_DEFAULT_EMBEDDINGS.dimensions);
+
+		this.set(this.sObj(), ["search", "rehearsal_enabled"], MACOS_DEFAULT_SEARCH.rehearsal_enabled);
+
+		this.set(this.agent, ["memory", "pipelineV2", "enabled"], MACOS_DEFAULT_PIPELINE.enabled);
+		this.set(this.agent, ["memory", "pipelineV2", "extractionProvider"], MACOS_DEFAULT_PIPELINE.extractionProvider);
+		this.set(this.agent, ["memory", "pipelineV2", "extractionModel"], MACOS_DEFAULT_PIPELINE.extractionModel);
+		this.set(this.agent, ["memory", "pipelineV2", "maintenanceMode"], MACOS_DEFAULT_PIPELINE.maintenanceMode);
+		this.set(this.agent, ["memory", "pipelineV2", "graphEnabled"], MACOS_DEFAULT_PIPELINE.graphEnabled);
+		this.set(this.agent, ["memory", "pipelineV2", "autonomousEnabled"], MACOS_DEFAULT_PIPELINE.autonomousEnabled);
+		this.set(this.agent, ["memory", "pipelineV2", "rerankerEnabled"], MACOS_DEFAULT_PIPELINE.rerankerEnabled);
+
+		this.lastSaveFeedback = "Applied macOS defaults (not saved yet)";
+		toast(this.lastSaveFeedback, "success");
 	}
 
 	async save(): Promise<void> {


### PR DESCRIPTION
## Summary
- add a `Reset to Defaults` action in the Settings footer, positioned left of Save
- implement a store-level `resetToMacDefaults()` helper that applies the requested macOS defaults for harnesses, embeddings, search rehearsal, and pipeline toggles
- show immediate feedback after reset while keeping changes unsaved until the user clicks Save

## Testing
- attempted `bun run check` in `packages/cli/dashboard` (fails in this environment because `svelte-kit` is not installed)