### PR TITLE
fix(daemon): replace `as Error` casts with proper narrowing

### DIFF
--- a/packages/daemon/src/db-accessor.ts
+++ b/packages/daemon/src/db-accessor.ts
@@ -32,7 +32,7 @@ for (const sqlitePath of HOMEBREW_SQLITE_PATHS) {
 			// Log so users can diagnose extension-loading failures.
 			console.warn(
 				`[db-accessor] setCustomSQLite(${sqlitePath}) skipped:`,
-				(e as Error).message ?? e,
+				e instanceof Error ? e.message : String(e),
 			);
 		}
 		break;
@@ -104,7 +104,7 @@ function loadVecExtension(db: Database): void {
 		} catch (e) {
 			console.warn(
 				"[db-accessor] loadExtension failed:",
-				(e as Error).message ?? e,
+				e instanceof Error ? e.message : String(e),
 			);
 		}
 	}


### PR DESCRIPTION
## Summary

- Follow-up to #119 — replaces two `(e as Error).message ?? e` patterns in `db-accessor.ts` with `e instanceof Error ? e.message : String(e)`
- Aligns the new vec0 logging catch blocks with the project's TypeScript discipline (no `as` assertions)

## Test plan

- [ ] `bun run typecheck` passes
- [ ] Daemon starts normally on macOS and Linux