### PR TITLE
fix(daemon): bump extraction timeout default from 45s to 90s

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -7280,16 +7280,16 @@ async function main() {
 		effectiveExtractionProvider === "opencode"
 			? createOpenCodeProvider({
 					model: memoryCfg.pipelineV2.extraction.model || "anthropic/claude-haiku-4-5-20251001",
-					defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout || 60000,
+					defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 				})
 			: effectiveExtractionProvider === "claude-code"
 				? createClaudeCodeProvider({
 						model: memoryCfg.pipelineV2.extraction.model || "haiku",
-						defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout || 60000,
+						defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 					})
 				: createOllamaProvider({
 						model: memoryCfg.pipelineV2.extraction.model || "qwen3:4b",
-						defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout || 90000,
+						defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 					});
 	initLlmProvider(llmProvider);
 

--- a/packages/daemon/src/memory-config.ts
+++ b/packages/daemon/src/memory-config.ts
@@ -36,7 +36,7 @@ export const DEFAULT_PIPELINE_V2: PipelineV2Config = {
 	extraction: {
 		provider: "claude-code",
 		model: "haiku",
-		timeout: 45000,
+		timeout: 90000,
 		minConfidence: 0.7,
 	},
 	worker: {

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -42,7 +42,7 @@ export interface OllamaProviderConfig {
 const DEFAULT_OLLAMA_CONFIG: OllamaProviderConfig = {
 	model: "qwen3:4b",
 	baseUrl: "http://localhost:11434",
-	defaultTimeoutMs: 45000,
+	defaultTimeoutMs: 90000,
 };
 
 interface OllamaGenerateResponse {


### PR DESCRIPTION
## Summary

- Bumps default extraction timeout from 45s to 90s — users running local Ollama models on slower hardware were hitting timeouts
- Removes dead `|| 60000` / `|| 90000` fallbacks in daemon.ts that were never reached (config always provides a value)
- Timeout remains user-configurable via `extraction.timeout` in agent.yaml (clamped to 5s–300s)

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — no regressions
- [ ] Start daemon, trigger extraction, confirm 90s timeout in provider config log