### PR TITLE
fix: tune macOS Ollama extraction defaults for reliability

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -246,7 +246,7 @@ memory:
     shadowMode: true        # extract without writing — safe first step
     extraction:
       provider: ollama
-      model: qwen3:4b
+      model: qwen2.5:7b-instruct
 ```
 
 
@@ -283,6 +283,27 @@ When using `ollama`, the model must be available locally. When using
 `claude-code`, the Claude Code CLI must be on PATH. Lower `minConfidence`
 to capture more facts at the cost of noise; raise it to write only
 high-confidence facts.
+
+On Apple Silicon macOS (`darwin` + `arm64`), Signet applies a
+stability-focused local Ollama default profile when pipeline settings are
+not explicitly set in `agent.yaml`:
+
+| Field | Apple Silicon default |
+|-------|------------------------|
+| `extraction.provider` | `"ollama"` |
+| `extraction.model` | `"qwen2.5:7b-instruct"` |
+| `extraction.timeout` | `180000` |
+| `extraction.minConfidence` | `0.6` |
+| `worker.pollMs` | `1000` |
+| `worker.leaseTimeoutMs` | `420000` |
+| `graph.enabled` | `false` |
+| `reranker.topN` | `25` |
+| `reranker.timeoutMs` | `2500` |
+| `autonomous.maintenanceIntervalMs` | `600000` |
+
+The setup wizard also uses this profile by default for Ollama extraction
+on Apple Silicon, while other platforms keep the standard cross-platform
+defaults unless overridden.
 
 
 ### Worker (`worker`)

--- a/packages/cli/dashboard/src/lib/components/pipeline/pipeline-types.ts
+++ b/packages/cli/dashboard/src/lib/components/pipeline/pipeline-types.ts
@@ -258,7 +258,7 @@ export const PIPELINE_NODES: readonly PipelineNodeDef[] = [
 		logCategories: ["llm"],
 		diagnosticDomain: "provider",
 		icon: "brain",
-		description: "Ollama qwen3:4b (or configured provider)",
+		description: "Ollama qwen2.5:7b-instruct (or configured provider)",
 	},
 ] as const;
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2233,16 +2233,21 @@ async function setupWizard(options: SetupWizardOptions) {
 			})) as string;
 		}
 	} else if (extractionProvider === "ollama") {
+		const useMacOllamaProfile = platform() === "darwin" && process.arch === "arm64";
 		if (nonInteractive) {
 			extractionModel =
 				normalizeStringValue(options.extractionModel) ||
 				normalizeStringValue(existingMemory.pipelineV2?.extractionModel) ||
-				"glm-4.7-flash";
+				(useMacOllamaProfile ? "qwen2.5:7b-instruct" : "glm-4.7-flash");
 		} else {
 			console.log();
 			extractionModel = (await select({
 				message: "Which Ollama model for extraction?",
 				choices: [
+					{
+						value: "qwen2.5:7b-instruct",
+						name: `qwen2.5:7b-instruct (${useMacOllamaProfile ? "recommended for Apple Silicon" : "balanced quality and speed"})`,
+					},
 					{
 						value: "glm-4.7-flash",
 						name: "glm-4.7-flash (good quality, recommended)",
@@ -2453,20 +2458,49 @@ ${agentName} is a helpful assistant.
 		}
 
 		if (extractionProvider !== "none") {
-			(config.memory as Record<string, unknown>).pipelineV2 = {
+			const useMacOllamaProfile =
+				extractionProvider === "ollama" &&
+				platform() === "darwin" &&
+				process.arch === "arm64";
+			const pipelineV2Config: Record<string, unknown> = {
 				enabled: true,
 				extraction: {
 					provider: extractionProvider,
 					model: extractionModel,
+					...(useMacOllamaProfile
+						? { timeout: 180000, minConfidence: 0.6 }
+						: {}),
 				},
-				graph: { enabled: true },
-				reranker: { enabled: true },
+				graph: {
+					enabled: !useMacOllamaProfile,
+					...(useMacOllamaProfile ? { boostWeight: 0.15 } : {}),
+				},
+				reranker: {
+					enabled: true,
+					...(useMacOllamaProfile ? { topN: 25, timeoutMs: 2500 } : {}),
+				},
+				...(useMacOllamaProfile
+					? {
+						worker: {
+							pollMs: 1000,
+							maxRetries: 3,
+							leaseTimeoutMs: 420000,
+						},
+					}
+					: {}),
 				autonomous: {
 					enabled: true,
 					allowUpdateDelete: true,
+					...(useMacOllamaProfile ? { maintenanceIntervalMs: 10 * 60 * 1000 } : {}),
 					maintenanceMode: "execute",
 				},
+				...(useMacOllamaProfile
+					? {
+						semanticContradictionEnabled: false,
+					}
+					: {}),
 			};
+			(config.memory as Record<string, unknown>).pipelineV2 = pipelineV2Config;
 		}
 
 		writeFileSync(join(basePath, "agent.yaml"), formatYaml(config));

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2189,6 +2189,11 @@ async function setupWizard(options: SetupWizardOptions) {
 		})) as ExtractionProviderChoice;
 	}
 
+	const useMacOllamaProfile =
+		extractionProvider === "ollama" &&
+		platform() === "darwin" &&
+		process.arch === "arm64";
+
 	let extractionModel = "haiku";
 	if (extractionProvider === "claude-code") {
 		if (nonInteractive) {
@@ -2233,7 +2238,6 @@ async function setupWizard(options: SetupWizardOptions) {
 			})) as string;
 		}
 	} else if (extractionProvider === "ollama") {
-		const useMacOllamaProfile = platform() === "darwin" && process.arch === "arm64";
 		if (nonInteractive) {
 			extractionModel =
 				normalizeStringValue(options.extractionModel) ||
@@ -2458,10 +2462,6 @@ ${agentName} is a helpful assistant.
 		}
 
 		if (extractionProvider !== "none") {
-			const useMacOllamaProfile =
-				extractionProvider === "ollama" &&
-				platform() === "darwin" &&
-				process.arch === "arm64";
 			const pipelineV2Config: Record<string, unknown> = {
 				enabled: true,
 				extraction: {
@@ -2473,7 +2473,6 @@ ${agentName} is a helpful assistant.
 				},
 				graph: {
 					enabled: !useMacOllamaProfile,
-					...(useMacOllamaProfile ? { boostWeight: 0.15 } : {}),
 				},
 				reranker: {
 					enabled: true,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2493,11 +2493,6 @@ ${agentName} is a helpful assistant.
 					...(useMacOllamaProfile ? { maintenanceIntervalMs: 10 * 60 * 1000 } : {}),
 					maintenanceMode: "execute",
 				},
-				...(useMacOllamaProfile
-					? {
-						semanticContradictionEnabled: false,
-					}
-					: {}),
 			};
 			(config.memory as Record<string, unknown>).pipelineV2 = pipelineV2Config;
 		}

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -7287,10 +7287,10 @@ async function main() {
 						model: memoryCfg.pipelineV2.extraction.model || "haiku",
 						defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 					})
-				: createOllamaProvider({
-						model: memoryCfg.pipelineV2.extraction.model || "qwen3:4b",
-						defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
-					});
+			: createOllamaProvider({
+					model: memoryCfg.pipelineV2.extraction.model || "qwen2.5:7b-instruct",
+					defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
+				});
 	initLlmProvider(llmProvider);
 
 	// Telemetry collector (opt-in, anonymous)

--- a/packages/daemon/src/memory-config.test.ts
+++ b/packages/daemon/src/memory-config.test.ts
@@ -153,7 +153,7 @@ describe("loadMemoryConfig", () => {
 
 		expect(DEFAULT_PIPELINE_V2.extraction.provider).toBe("claude-code");
 		expect(DEFAULT_PIPELINE_V2.extraction.model).toBe("haiku");
-		expect(DEFAULT_PIPELINE_V2.extraction.timeout).toBe(45000);
+		expect(DEFAULT_PIPELINE_V2.extraction.timeout).toBe(90000);
 		expect(DEFAULT_PIPELINE_V2.worker.leaseTimeoutMs).toBe(300000);
 	});
 

--- a/packages/daemon/src/memory-config.test.ts
+++ b/packages/daemon/src/memory-config.test.ts
@@ -141,6 +141,14 @@ describe("loadMemoryConfig", () => {
 		expect(cfg.pipelineV2).toEqual(DEFAULT_PIPELINE_V2);
 	});
 
+	it("applies Apple Silicon Ollama defaults on macOS", () => {
+		if (process.platform !== "darwin" || process.arch !== "arm64") return;
+		expect(DEFAULT_PIPELINE_V2.extraction.provider).toBe("ollama");
+		expect(DEFAULT_PIPELINE_V2.extraction.model).toBe("qwen2.5:7b-instruct");
+		expect(DEFAULT_PIPELINE_V2.extraction.timeout).toBe(180000);
+		expect(DEFAULT_PIPELINE_V2.worker.leaseTimeoutMs).toBe(420000);
+	});
+
 	it("loads pipelineV2 flags from agent.yaml (flat keys, backward compat)", () => {
 		const agentsDir = makeTempAgentsDir();
 		writeFileSync(

--- a/packages/daemon/src/memory-config.test.ts
+++ b/packages/daemon/src/memory-config.test.ts
@@ -142,11 +142,19 @@ describe("loadMemoryConfig", () => {
 	});
 
 	it("applies Apple Silicon Ollama defaults on macOS", () => {
-		if (process.platform !== "darwin" || process.arch !== "arm64") return;
-		expect(DEFAULT_PIPELINE_V2.extraction.provider).toBe("ollama");
-		expect(DEFAULT_PIPELINE_V2.extraction.model).toBe("qwen2.5:7b-instruct");
-		expect(DEFAULT_PIPELINE_V2.extraction.timeout).toBe(180000);
-		expect(DEFAULT_PIPELINE_V2.worker.leaseTimeoutMs).toBe(420000);
+		const isAppleSiliconMac = process.platform === "darwin" && process.arch === "arm64";
+		if (isAppleSiliconMac) {
+			expect(DEFAULT_PIPELINE_V2.extraction.provider).toBe("ollama");
+			expect(DEFAULT_PIPELINE_V2.extraction.model).toBe("qwen2.5:7b-instruct");
+			expect(DEFAULT_PIPELINE_V2.extraction.timeout).toBe(180000);
+			expect(DEFAULT_PIPELINE_V2.worker.leaseTimeoutMs).toBe(420000);
+			return;
+		}
+
+		expect(DEFAULT_PIPELINE_V2.extraction.provider).toBe("claude-code");
+		expect(DEFAULT_PIPELINE_V2.extraction.model).toBe("haiku");
+		expect(DEFAULT_PIPELINE_V2.extraction.timeout).toBe(45000);
+		expect(DEFAULT_PIPELINE_V2.worker.leaseTimeoutMs).toBe(300000);
 	});
 
 	it("loads pipelineV2 flags from agent.yaml (flat keys, backward compat)", () => {

--- a/packages/daemon/src/memory-config.test.ts
+++ b/packages/daemon/src/memory-config.test.ts
@@ -147,14 +147,26 @@ describe("loadMemoryConfig", () => {
 			expect(DEFAULT_PIPELINE_V2.extraction.provider).toBe("ollama");
 			expect(DEFAULT_PIPELINE_V2.extraction.model).toBe("qwen2.5:7b-instruct");
 			expect(DEFAULT_PIPELINE_V2.extraction.timeout).toBe(180000);
+			expect(DEFAULT_PIPELINE_V2.extraction.minConfidence).toBe(0.6);
+			expect(DEFAULT_PIPELINE_V2.worker.pollMs).toBe(1000);
 			expect(DEFAULT_PIPELINE_V2.worker.leaseTimeoutMs).toBe(420000);
+			expect(DEFAULT_PIPELINE_V2.graph.enabled).toBe(false);
+			expect(DEFAULT_PIPELINE_V2.reranker.topN).toBe(25);
+			expect(DEFAULT_PIPELINE_V2.reranker.timeoutMs).toBe(2500);
+			expect(DEFAULT_PIPELINE_V2.autonomous.maintenanceIntervalMs).toBe(600000);
 			return;
 		}
 
 		expect(DEFAULT_PIPELINE_V2.extraction.provider).toBe("claude-code");
 		expect(DEFAULT_PIPELINE_V2.extraction.model).toBe("haiku");
 		expect(DEFAULT_PIPELINE_V2.extraction.timeout).toBe(90000);
+		expect(DEFAULT_PIPELINE_V2.extraction.minConfidence).toBe(0.7);
+		expect(DEFAULT_PIPELINE_V2.worker.pollMs).toBe(2000);
 		expect(DEFAULT_PIPELINE_V2.worker.leaseTimeoutMs).toBe(300000);
+		expect(DEFAULT_PIPELINE_V2.graph.enabled).toBe(true);
+		expect(DEFAULT_PIPELINE_V2.reranker.topN).toBe(20);
+		expect(DEFAULT_PIPELINE_V2.reranker.timeoutMs).toBe(2000);
+		expect(DEFAULT_PIPELINE_V2.autonomous.maintenanceIntervalMs).toBe(1800000);
 	});
 
 	it("loads pipelineV2 flags from agent.yaml (flat keys, backward compat)", () => {
@@ -468,6 +480,26 @@ describe("loadPipelineConfig", () => {
 		expect(result.autonomous.allowUpdateDelete).toBe(true);
 		expect(result.autonomous.maintenanceIntervalMs).toBe(60000);
 		expect(result.autonomous.maintenanceMode).toBe("execute");
+	});
+
+	it("uses base extraction defaults for non-ollama providers on Apple Silicon", () => {
+		const result = loadPipelineConfig({
+			memory: {
+				pipelineV2: {
+					extraction: {
+						provider: "claude-code",
+						model: "haiku",
+					},
+				},
+			},
+		});
+
+		expect(result.extraction.provider).toBe("claude-code");
+		expect(result.extraction.model).toBe("haiku");
+		expect(result.extraction.timeout).toBe(90000);
+		expect(result.extraction.minConfidence).toBe(0.7);
+		expect(result.worker.pollMs).toBe(2000);
+		expect(result.worker.leaseTimeoutMs).toBe(300000);
 	});
 
 	it("nested keys take precedence over flat keys", () => {

--- a/packages/daemon/src/memory-config.ts
+++ b/packages/daemon/src/memory-config.ts
@@ -28,7 +28,9 @@ export interface MemorySearchConfig {
 export { PIPELINE_FLAGS };
 export type { PipelineFlag, PipelineV2Config };
 
-export const DEFAULT_PIPELINE_V2: PipelineV2Config = {
+const MAC_OLLAMA_PROFILE = process.platform === "darwin" && process.arch === "arm64";
+
+const BASE_PIPELINE_V2_DEFAULTS: PipelineV2Config = {
 	enabled: true,
 	shadowMode: false,
 	mutationsFrozen: false,
@@ -105,6 +107,36 @@ export const DEFAULT_PIPELINE_V2: PipelineV2Config = {
 		batchSize: 8,
 	},
 };
+
+export const DEFAULT_PIPELINE_V2: PipelineV2Config = MAC_OLLAMA_PROFILE
+	? {
+			...BASE_PIPELINE_V2_DEFAULTS,
+			extraction: {
+				provider: "ollama",
+				model: "qwen2.5:7b-instruct",
+				timeout: 180000,
+				minConfidence: 0.6,
+			},
+			worker: {
+				...BASE_PIPELINE_V2_DEFAULTS.worker,
+				pollMs: 1000,
+				leaseTimeoutMs: 420000,
+			},
+			graph: {
+				...BASE_PIPELINE_V2_DEFAULTS.graph,
+				enabled: false,
+			},
+			reranker: {
+				...BASE_PIPELINE_V2_DEFAULTS.reranker,
+				topN: 25,
+				timeoutMs: 2500,
+			},
+			autonomous: {
+				...BASE_PIPELINE_V2_DEFAULTS.autonomous,
+				maintenanceIntervalMs: 10 * 60 * 1000,
+			},
+		}
+	: BASE_PIPELINE_V2_DEFAULTS;
 
 export interface ResolvedMemoryConfig {
 	embedding: EmbeddingConfig;

--- a/packages/daemon/src/memory-config.ts
+++ b/packages/daemon/src/memory-config.ts
@@ -185,7 +185,7 @@ export function loadPipelineConfig(
 	const embeddingTrackerRaw = raw.embeddingTracker as Record<string, unknown> | undefined;
 
 	// Helper: resolve nested-first, flat-fallback
-	const d = DEFAULT_PIPELINE_V2;
+	const baseDefaults = BASE_PIPELINE_V2_DEFAULTS;
 
 	function resolveBool(nested: unknown, flat: unknown, fallback: boolean): boolean {
 		if (typeof nested === "boolean") return nested;
@@ -209,7 +209,12 @@ export function loadPipelineConfig(
 						  nestedProvider === undefined &&
 						  flatProvider === undefined
 						? "ollama"
-						: d.extraction.provider;
+						: DEFAULT_PIPELINE_V2.extraction.provider;
+
+	const d =
+		MAC_OLLAMA_PROFILE && resolvedProvider === "ollama"
+			? DEFAULT_PIPELINE_V2
+			: BASE_PIPELINE_V2_DEFAULTS;
 
 	return {
 		enabled: typeof raw.enabled === "boolean" ? raw.enabled : d.enabled,

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -40,9 +40,9 @@ export interface OllamaProviderConfig {
 }
 
 const DEFAULT_OLLAMA_CONFIG: OllamaProviderConfig = {
-	model: "qwen3:4b",
+	model: "qwen2.5:7b-instruct",
 	baseUrl: "http://localhost:11434",
-	defaultTimeoutMs: 90000,
+	defaultTimeoutMs: 180000,
 };
 
 interface OllamaGenerateResponse {
@@ -307,7 +307,7 @@ const DEFAULT_OPENCODE_CONFIG: OpenCodeProviderConfig = {
 	model: "anthropic/claude-haiku-4-5-20251001",
 	defaultTimeoutMs: 60000,
 	enableOllamaFallback: true,
-	ollamaFallbackModel: "qwen3:4b",
+	ollamaFallbackModel: "qwen2.5:7b-instruct",
 };
 
 /**

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -42,7 +42,7 @@ export interface OllamaProviderConfig {
 const DEFAULT_OLLAMA_CONFIG: OllamaProviderConfig = {
 	model: "qwen2.5:7b-instruct",
 	baseUrl: "http://localhost:11434",
-	defaultTimeoutMs: 180000,
+	defaultTimeoutMs: 90000,
 };
 
 interface OllamaGenerateResponse {


### PR DESCRIPTION
## Summary
- add Apple Silicon-specific pipeline defaults that use Ollama `qwen2.5:7b-instruct` with longer extraction timeout and stability-oriented worker/reranker settings
- update setup wizard defaults for Ollama on Apple Silicon so newly generated `agent.yaml` files include the same tuned extraction profile
- align daemon/provider fallback model labels in runtime and dashboard copy to the new Ollama default model

## Validation
- bun test packages/daemon/src/memory-config.test.ts
- bun test packages/daemon/src/pipeline/provider.test.ts
- bun test packages/daemon/src/pipeline/worker.test.ts