### PR TITLE
fix(config): mac defaults for ollama extraction only

### DIFF
--- a/packages/daemon/src/memory-config.test.ts
+++ b/packages/daemon/src/memory-config.test.ts
@@ -141,6 +141,22 @@ describe("loadMemoryConfig", () => {
 		expect(cfg.pipelineV2).toEqual(DEFAULT_PIPELINE_V2);
 	});
 
+	it("uses mac-specific ollama defaults only for extraction and lease timeout", () => {
+		const isAppleSiliconMac = process.platform === "darwin" && process.arch === "arm64";
+		if (isAppleSiliconMac) {
+			expect(DEFAULT_PIPELINE_V2.extraction.provider).toBe("ollama");
+			expect(DEFAULT_PIPELINE_V2.extraction.model).toBe("qwen2.5:7b-instruct");
+			expect(DEFAULT_PIPELINE_V2.extraction.timeout).toBe(300000);
+			expect(DEFAULT_PIPELINE_V2.worker.leaseTimeoutMs).toBe(420000);
+			return;
+		}
+
+		expect(DEFAULT_PIPELINE_V2.extraction.provider).toBe("claude-code");
+		expect(DEFAULT_PIPELINE_V2.extraction.model).toBe("haiku");
+		expect(DEFAULT_PIPELINE_V2.extraction.timeout).toBe(90000);
+		expect(DEFAULT_PIPELINE_V2.worker.leaseTimeoutMs).toBe(300000);
+	});
+
 	it("loads pipelineV2 flags from agent.yaml (flat keys, backward compat)", () => {
 		const agentsDir = makeTempAgentsDir();
 		writeFileSync(

--- a/packages/daemon/src/memory-config.ts
+++ b/packages/daemon/src/memory-config.ts
@@ -28,7 +28,9 @@ export interface MemorySearchConfig {
 export { PIPELINE_FLAGS };
 export type { PipelineFlag, PipelineV2Config };
 
-export const DEFAULT_PIPELINE_V2: PipelineV2Config = {
+const MAC_OLLAMA_DEFAULTS = process.platform === "darwin" && process.arch === "arm64";
+
+const BASE_PIPELINE_V2_DEFAULTS: PipelineV2Config = {
 	enabled: true,
 	shadowMode: false,
 	mutationsFrozen: false,
@@ -105,6 +107,22 @@ export const DEFAULT_PIPELINE_V2: PipelineV2Config = {
 		batchSize: 8,
 	},
 };
+
+export const DEFAULT_PIPELINE_V2: PipelineV2Config = MAC_OLLAMA_DEFAULTS
+	? {
+			...BASE_PIPELINE_V2_DEFAULTS,
+			extraction: {
+				...BASE_PIPELINE_V2_DEFAULTS.extraction,
+				provider: "ollama",
+				model: "qwen2.5:7b-instruct",
+				timeout: 300000,
+			},
+			worker: {
+				...BASE_PIPELINE_V2_DEFAULTS.worker,
+				leaseTimeoutMs: 420000,
+			},
+		}
+	: BASE_PIPELINE_V2_DEFAULTS;
 
 export interface ResolvedMemoryConfig {
 	embedding: EmbeddingConfig;


### PR DESCRIPTION
## Summary
- add a minimal Apple Silicon macOS default profile for pipeline v2
- scope changes to four defaults only: extraction provider/model/timeout and worker lease timeout
- keep all other pipeline defaults unchanged

## macOS defaults (darwin + arm64)
- `extraction.provider`: `ollama`
- `extraction.model`: `qwen2.5:7b-instruct`
- `extraction.timeout`: `300000`
- `worker.leaseTimeoutMs`: `420000`

## Validation
- bun test packages/daemon/src/memory-config.test.ts