### PR TITLE
fix(logs): refresh dashboard logs UX and stabilize stream behavior

### DIFF
--- a/packages/cli/dashboard/src/app.css
+++ b/packages/cli/dashboard/src/app.css
@@ -63,6 +63,18 @@
 	--sig-icon-bg-5: #dc2626;
 	--sig-icon-bg-6: #0891b2;
 
+	/* Log category colors (dark theme) */
+	--sig-log-category-watcher: #60a5fa;
+	--sig-log-category-daemon: #a78bfa;
+	--sig-log-category-pipeline: #34d399;
+	--sig-log-category-system: #9ca3af;
+	--sig-log-category-embedding-tracker: #f472b6;
+	--sig-log-category-document-worker: #fb923c;
+	--sig-log-category-maintenance: #facc15;
+	--sig-log-category-git: #2dd4bf;
+	--sig-log-category-scheduler: #c084fc;
+	--sig-log-category-retention: #f87171;
+
 	/* Typography & spacing */
 	--font-display: "Diamond Grotesk", "Chakra Petch", sans-serif;
 	--font-mono: "Geist Mono", "IBM Plex Mono", monospace;
@@ -137,6 +149,18 @@
 	--sig-icon-bg-4: #fcd34d;
 	--sig-icon-bg-5: #fca5a5;
 	--sig-icon-bg-6: #67e8f9;
+
+	/* Log category colors (light theme) */
+	--sig-log-category-watcher: #2563eb;
+	--sig-log-category-daemon: #7c3aed;
+	--sig-log-category-pipeline: #059669;
+	--sig-log-category-system: #6b7280;
+	--sig-log-category-embedding-tracker: #db2777;
+	--sig-log-category-document-worker: #ea580c;
+	--sig-log-category-maintenance: #ca8a04;
+	--sig-log-category-git: #0d9488;
+	--sig-log-category-scheduler: #9333ea;
+	--sig-log-category-retention: #dc2626;
 }
 
 /* === Tailwind v4 theme registration === */

--- a/packages/cli/dashboard/src/lib/components/tabs/LogsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/LogsTab.svelte
@@ -40,6 +40,7 @@ let logLevelFilter = $state<string>("");
 let logCategoryFilter = $state<string>("");
 let logAutoScroll = $state(false);
 let logAutoScrollPausedByScroll = $state(false);
+let initialLoadDone = $state(false);
 let logViewport = $state<HTMLElement | null>(null);
 let selectedLogKey = $state<string | null>(null);
 let copied = $state(false);
@@ -180,7 +181,10 @@ async function fetchLogs() {
 		const data = await res.json();
 		logs = data.logs || [];
 		selectLatestLog();
-		if (logAutoScroll) {
+		if (!initialLoadDone) {
+			initialLoadDone = true;
+			void tick().then(() => scrollToBottom("auto"));
+		} else if (logAutoScroll) {
 			scrollToBottomNextFrame("auto");
 		}
 	} catch {
@@ -215,6 +219,10 @@ function startLogStream() {
 				logsStreaming = true;
 				streamError = "";
 				return;
+			}
+			if (logsConnecting) {
+				logsConnecting = false;
+				logsStreaming = true;
 			}
 			const entryLevelValue =
 				typeof entry.level === "string"

--- a/packages/cli/dashboard/src/lib/components/tabs/LogsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/LogsTab.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-import { onMount } from "svelte";
-import * as Select from "$lib/components/ui/select/index.js";
 import { Button } from "$lib/components/ui/button/index.js";
 import { Checkbox } from "$lib/components/ui/checkbox/index.js";
 import { ScrollArea } from "$lib/components/ui/scroll-area/index.js";
+import * as Select from "$lib/components/ui/select/index.js";
 import { ActionLabels } from "$lib/ui/action-labels";
-
+import { onMount, tick } from "svelte";
 
 interface LogEntry {
 	timestamp: string;
@@ -19,32 +18,55 @@ interface LogEntry {
 
 const RECONNECT_BASE_MS = 2000;
 const RECONNECT_MAX_MS = 30000;
-const RECONNECT_MAX_ATTEMPTS = 5;
+const LOG_LEVEL_ORDER: Record<LogEntry["level"], number> = {
+	debug: 0,
+	info: 1,
+	warn: 2,
+	error: 3,
+};
 
 let logs = $state<LogEntry[]>([]);
 let logsLoading = $state(false);
 let logsError = $state("");
 let logsStreaming = $state(false);
 let logsReconnecting = $state(false);
+let logsConnecting = $state(false);
 let streamError = $state("");
 let logEventSource: EventSource | null = null;
 let reconnectAttempt = 0;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let logLevelFilter = $state<string>("");
 let logCategoryFilter = $state<string>("");
-let logAutoScroll = $state(true);
+let logAutoScroll = $state(false);
 let logViewport = $state<HTMLElement | null>(null);
 let selectedLogKey = $state<string | null>(null);
 let copied = $state(false);
-let logFollow = $state(true);
+let autoScrollSnapFrame: number | null = null;
 const BOTTOM_THRESHOLD_PX = 24;
 
 const logCategories = [
-	"daemon", "api", "memory", "sync", "git",
-	"watcher", "embedding", "harness", "system",
-	"hooks", "pipeline", "skills", "secrets", "auth",
-	"session-tracker", "summary-worker", "document-worker", "maintenance",
-	"retention", "llm",
+	"daemon",
+	"api",
+	"memory",
+	"sync",
+	"git",
+	"watcher",
+	"embedding",
+	"embedding-tracker",
+	"harness",
+	"system",
+	"hooks",
+	"pipeline",
+	"skills",
+	"secrets",
+	"auth",
+	"session-tracker",
+	"summary-worker",
+	"document-worker",
+	"maintenance",
+	"scheduler",
+	"retention",
+	"llm",
 ];
 const logLevels = ["debug", "info", "warn", "error"];
 
@@ -56,9 +78,39 @@ function getLogLevelClass(level: LogEntry["level"]): string {
 			return "log-level--warn";
 		case "debug":
 			return "log-level--debug";
-		case "info":
 		default:
 			return "log-level--info";
+	}
+}
+
+function getLogCategoryClass(category: string): string {
+	switch (category.toLowerCase()) {
+		case "watcher":
+			return "log-category--watcher";
+		case "daemon":
+			return "log-category--daemon";
+		case "pipeline":
+			return "log-category--pipeline";
+		case "system":
+			return "log-category--system";
+		// Backwards compatibility for historical typo in old log emitters.
+		case "embeding-tracker":
+		case "embedding-tracker":
+			return "log-category--embedding-tracker";
+		case "document-worker":
+			return "log-category--document-worker";
+		case "maintenance":
+			return "log-category--maintenance";
+		case "git":
+			return "log-category--git";
+		// Backwards compatibility for historical typo in old log emitters.
+		case "schedular":
+		case "scheduler":
+			return "log-category--scheduler";
+		case "retention":
+			return "log-category--retention";
+		default:
+			return "log-category--default";
 	}
 }
 
@@ -98,6 +150,18 @@ function scrollToBottom(behavior: ScrollBehavior = "smooth"): void {
 	});
 }
 
+function scrollToBottomNextFrame(behavior: ScrollBehavior = "auto"): void {
+	if (autoScrollSnapFrame !== null) return;
+	void tick().then(() => {
+		if (autoScrollSnapFrame !== null) return;
+		autoScrollSnapFrame = requestAnimationFrame(() => {
+			autoScrollSnapFrame = null;
+			if (!logAutoScroll) return;
+			scrollToBottom(behavior);
+		});
+	});
+}
+
 function isNearBottom(viewport: HTMLElement | null): boolean {
 	if (!viewport) return true;
 	return viewport.scrollTop + viewport.clientHeight >= viewport.scrollHeight - BOTTOM_THRESHOLD_PX;
@@ -114,10 +178,9 @@ async function fetchLogs() {
 		const data = await res.json();
 		logs = data.logs || [];
 		selectLatestLog();
-		setTimeout(() => {
-			scrollToBottom("auto");
-			logFollow = true;
-		}, 0);
+		if (logAutoScroll) {
+			scrollToBottomNextFrame("auto");
+		}
 	} catch {
 		logsError = "Failed to fetch logs";
 	} finally {
@@ -126,42 +189,38 @@ async function fetchLogs() {
 }
 
 function startLogStream() {
-	// Cancel any pending reconnect before opening a fresh connection
 	if (reconnectTimer !== null) {
 		clearTimeout(reconnectTimer);
 		reconnectTimer = null;
 	}
-	// NOTE: do NOT reset reconnectAttempt here — this function is called
-	// recursively by the retry timer and must preserve the counter so that
-	// exponential backoff progresses and the give-up limit is respected.
-	// Reset only happens in manualStartLogStream() (user-initiated start).
-
 	if (logEventSource) logEventSource.close();
-	logsStreaming = true;
+	logsConnecting = true;
 	logEventSource = new EventSource("/api/logs/stream");
 
 	logEventSource.onmessage = (event) => {
 		try {
 			const entry = JSON.parse(event.data);
 			if (entry.type === "connected") {
-				// Server confirmed healthy — clear any leftover retry state
 				reconnectAttempt = 0;
 				logsReconnecting = false;
+				logsConnecting = false;
+				logsStreaming = true;
 				streamError = "";
 				return;
 			}
-			if (logLevelFilter && entry.level !== logLevelFilter) return;
+			const entryLevelValue =
+				typeof entry.level === "string"
+					? LOG_LEVEL_ORDER[entry.level as LogEntry["level"]]
+					: undefined;
+			const filterLevelValue =
+				LOG_LEVEL_ORDER[logLevelFilter as LogEntry["level"]];
+			if (logLevelFilter && (entryLevelValue ?? -1) < (filterLevelValue ?? -1)) return;
 			if (logCategoryFilter && entry.category !== logCategoryFilter) return;
-			const wasNearBottom = isNearBottom(logViewport);
-			const shouldAutoFollow = logAutoScroll && (logFollow || wasNearBottom);
 			const wasViewingLatest = isViewingLatest();
 			logs = [...logs.slice(-499), entry];
 			if (wasViewingLatest) selectLatestLog();
-			if (shouldAutoFollow) {
-				setTimeout(() => {
-					scrollToBottom("auto");
-					logFollow = true;
-				}, 0);
+			if (logAutoScroll) {
+				scrollToBottomNextFrame("auto");
 			}
 		} catch {
 			// ignore parse errors
@@ -170,59 +229,22 @@ function startLogStream() {
 
 	logEventSource.onerror = () => {
 		logsStreaming = false;
+		logsConnecting = false;
 		logEventSource?.close();
 		logEventSource = null;
 
-		// Guard: onerror can fire repeatedly — don't stack timers
 		if (reconnectTimer !== null) return;
 
-		if (reconnectAttempt < RECONNECT_MAX_ATTEMPTS) {
-			const delay = Math.min(
-				RECONNECT_BASE_MS * 2 ** reconnectAttempt,
-				RECONNECT_MAX_MS,
-			);
-			reconnectAttempt++;
-			logsReconnecting = true;
-			streamError = `Stream lost — reconnecting in ${delay / 1000}s (${reconnectAttempt}/${RECONNECT_MAX_ATTEMPTS})`;
+		const delay = Math.min(RECONNECT_BASE_MS * 2 ** Math.min(reconnectAttempt, 10), RECONNECT_MAX_MS);
+		reconnectAttempt++;
+		logsReconnecting = true;
+		streamError = `Stream lost — reconnecting in ${delay / 1000}s`;
 
-			reconnectTimer = setTimeout(() => {
-				reconnectTimer = null;
-				startLogStream();
-			}, delay);
-		} else {
-			// Give up — let the user reconnect manually
-			logsReconnecting = false;
-			streamError = "Stream disconnected. Click ▶ to reconnect.";
-			reconnectAttempt = 0;
-		}
+		reconnectTimer = setTimeout(() => {
+			reconnectTimer = null;
+			startLogStream();
+		}, delay);
 	};
-}
-
-// User-initiated start: reset retry state before opening the stream
-function manualStartLogStream() {
-	reconnectAttempt = 0;
-	logsReconnecting = false;
-	streamError = "";
-	startLogStream();
-}
-
-function stopLogStream() {
-	logsStreaming = false;
-	logsReconnecting = false;
-	streamError = "";
-	reconnectAttempt = 0;
-	if (reconnectTimer !== null) {
-		clearTimeout(reconnectTimer);
-		reconnectTimer = null;
-	}
-	logEventSource?.close();
-	logEventSource = null;
-}
-
-function toggleLogStream() {
-	// Treat reconnecting state as "active" — clicking cancels and stops cleanly
-	if (logsStreaming || logsReconnecting) stopLogStream();
-	else manualStartLogStream();
 }
 
 function formatLogTime(timestamp: string): string {
@@ -261,7 +283,6 @@ function getReadableLogSections(log: LogEntry): LogSection[] {
 
 	const sections: LogSection[] = [];
 
-	// New full-content fields first, fall back to old *Preview keys
 	const inject = readString(data.inject) ?? readString(data.injectPreview);
 	if (inject) sections.push({ label: "Inject", content: inject });
 
@@ -289,7 +310,10 @@ function getReadableLogSections(log: LogEntry): LogSection[] {
 function getReadableLogSnippet(log: LogEntry): string {
 	const sections = getReadableLogSections(log);
 	if (sections.length === 0) return "";
-	const detail = sections.map((s) => s.content).join("\n\n").trim();
+	const detail = sections
+		.map((s) => s.content)
+		.join("\n\n")
+		.trim();
 	if (detail.length <= 220) return detail;
 	return `${detail.slice(0, 220)}...`;
 }
@@ -309,7 +333,9 @@ async function copySelectedLog(): Promise<void> {
 
 onMount(() => {
 	fetchLogs();
+	startLogStream();
 	return () => {
+		if (autoScrollSnapFrame !== null) cancelAnimationFrame(autoScrollSnapFrame);
 		if (reconnectTimer !== null) clearTimeout(reconnectTimer);
 		if (logEventSource) logEventSource.close();
 	};
@@ -320,7 +346,14 @@ $effect(() => {
 	if (!viewport) return;
 
 	const onScroll = () => {
-		logFollow = isNearBottom(viewport);
+		const nearBottom = isNearBottom(viewport);
+		if (logAutoScroll && !nearBottom) {
+			logAutoScroll = false;
+			return;
+		}
+		if (!logAutoScroll && nearBottom) {
+			logAutoScroll = true;
+		}
 	};
 
 	viewport.addEventListener("scroll", onScroll, { passive: true });
@@ -332,127 +365,117 @@ $effect(() => {
 });
 </script>
 
-<div class="flex flex-col flex-1 min-h-0">
-	<div class="flex items-center gap-[var(--space-sm)] px-[var(--space-md)] py-[var(--space-sm)] border-b border-[var(--sig-border)] shrink-0">
-		<Select.Root type="single" value={logLevelFilter} onValueChange={(v) => { logLevelFilter = v ?? ""; fetchLogs(); }}>
-			<Select.Trigger class="font-[family-name:var(--font-mono)] text-[length:var(--font-size-sm)] bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] text-[var(--sig-text-bright)] rounded-lg h-auto py-1 px-2 min-w-[100px]">
-				{logLevelFilter || "All levels"}
-			</Select.Trigger>
-			<Select.Content class="bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] rounded-lg">
-				<Select.Item value="" label="All levels" />
-				{#each logLevels as level}
-					<Select.Item value={level} label={level} />
-				{/each}
-			</Select.Content>
-		</Select.Root>
-		<Select.Root type="single" value={logCategoryFilter} onValueChange={(v) => { logCategoryFilter = v ?? ""; fetchLogs(); }}>
-			<Select.Trigger class="font-[family-name:var(--font-mono)] text-[length:var(--font-size-sm)] bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] text-[var(--sig-text-bright)] rounded-lg h-auto py-1 px-2 min-w-[100px]">
-				{logCategoryFilter || "All categories"}
-			</Select.Trigger>
-			<Select.Content class="bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] rounded-lg">
-				<Select.Item value="" label="All categories" />
-				{#each logCategories as cat}
-					<Select.Item value={cat} label={cat} />
-				{/each}
-			</Select.Content>
-		</Select.Root>
-		<label class="flex items-center gap-1.5 sig-label text-[var(--sig-text)] cursor-pointer">
-			<Checkbox checked={logAutoScroll} onCheckedChange={(value: unknown) => { logAutoScroll = value === true; }} class="rounded-lg" />
-			Auto-scroll
-		</label>
-		<span
-			class="sig-eyebrow"
-			class:text-[#4ade80]={logAutoScroll && logFollow}
-			class:text-[var(--sig-text-muted)]={!logAutoScroll || !logFollow}
-		>
-			{logAutoScroll && logFollow ? "following" : "paused"}
-		</span>
-		<Button
-			variant="outline"
-			size="sm"
-			class="sig-label px-2 py-1 h-auto hover:border-[var(--sig-border-strong)] hover:text-[var(--sig-text-bright)]"
-			onclick={fetchLogs}
-			title="Reload logs"
-		>
-			{ActionLabels.Refresh}
-		</Button>
-		<Button
-			variant="ghost"
-			size="sm"
-			class={`flex items-center justify-center w-7 h-7 p-0 hover:text-[var(--sig-text)] hover:border-[var(--sig-border)] ${logsStreaming ? 'text-[var(--sig-success)]' : 'text-[var(--sig-text-muted)]'}`}
-			onclick={toggleLogStream}
-			title={logsStreaming ? 'Stop stream' : logsReconnecting ? 'Cancel reconnect' : 'Start stream'}
-		>
-			{#if logsStreaming}
-				<span class="text-[var(--sig-success)] sig-label font-medium [animation:pulse_2s_infinite]">● Live</span>
-			{:else if logsReconnecting}
-				<span class="text-[var(--sig-text-muted)] sig-label [animation:pulse_2s_infinite]">↺</span>
-			{:else}
-				▶
-			{/if}
-		</Button>
-		{#if streamError}
-			<span class="sig-eyebrow truncate max-w-[220px]">
-				{streamError}
-			</span>
-		{/if}
-	</div>
-
-	<div class="flex-1 min-h-0 grid grid-cols-1 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
-		<ScrollArea class="min-h-0 border-r border-[var(--sig-border)]" viewportRef={logViewport}>
-			<div class="font-[family-name:var(--font-mono)] text-[length:var(--font-size-sm)] leading-relaxed">
-				{#if logsLoading}
-					<div class="py-[var(--space-xl)] text-center text-[var(--sig-text-muted)] font-[family-name:var(--font-display)] text-[length:var(--font-size-base)]">Loading logs...</div>
-				{:else if logsError}
-					<div class="py-[var(--space-xl)] text-center text-[var(--sig-danger)] font-[family-name:var(--font-display)] text-[length:var(--font-size-base)]">{logsError}</div>
-				{:else if logs.length === 0}
-					<div class="py-[var(--space-xl)] text-center text-[var(--sig-text-muted)] font-[family-name:var(--font-display)] text-[length:var(--font-size-base)]">No logs found</div>
-				{:else}
-					{#each logs as log, i}
-						<button
-							type="button"
-							class={`log-row ${getLogLevelClass(log.level)} w-full text-left px-[var(--space-md)] py-1.5 border-b border-[var(--sig-border)] hover:bg-[var(--sig-surface-raised)] cursor-pointer ${
-								selectedLogKey === buildLogKey(log, i) ? "bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)]" : ""
-							}`}
-							onclick={() => {
-								selectedLogKey = buildLogKey(log, i);
-							}}
-						>
-							<div class="flex flex-wrap items-baseline gap-[var(--space-xs)]">
-								<span class="text-[var(--sig-text-muted)] shrink-0">{formatLogTime(log.timestamp)}</span>
-								<span class={`font-semibold shrink-0 min-w-[40px] ${getLogLevelClass(log.level)}`}>{log.level.toUpperCase()}</span>
-								<span class="text-[var(--sig-text)] shrink-0">[{log.category}]</span>
-								<span class="text-[var(--sig-text-bright)] break-all">{log.message}</span>
-								{#if log.duration !== undefined}
-									<span class="text-[var(--sig-text-muted)]">({log.duration}ms)</span>
-								{/if}
-							</div>
-							{#if getReadableLogSnippet(log)}
-								<div class="mt-1 text-[11px] text-[var(--sig-text-muted)] whitespace-pre-wrap break-words">{getReadableLogSnippet(log)}</div>
-							{/if}
-						</button>
-					{/each}
-				{/if}
-			</div>
-		</ScrollArea>
-		<div class="min-h-0 overflow-auto p-[var(--space-md)] font-[family-name:var(--font-mono)] text-[length:var(--font-size-sm)]">
-			{#if selectedLog}
-				<div class="flex items-center justify-between gap-2 mb-[var(--space-sm)]">
-					<div class="sig-eyebrow tracking-[0.08em]">Log details</div>
+<div class="flex flex-col flex-1 min-h-0 p-[var(--space-sm)] lg:p-[var(--space-md)]">
+	<div class="flex-1 min-h-0 grid grid-cols-1 gap-[var(--space-md)] lg:grid-cols-[minmax(0,1.55fr)_minmax(0,1fr)]">
+		<section class="min-h-0 flex flex-col rounded-lg border border-[var(--sig-border-strong)] bg-[var(--sig-surface-raised)] overflow-hidden">
+			<div class="flex flex-wrap items-center gap-[var(--space-sm)] px-[var(--space-md)] py-[var(--space-sm)] border-b border-[var(--sig-border)] shrink-0">
+				<Select.Root type="single" value={logLevelFilter} onValueChange={(v) => { logLevelFilter = v ?? ""; fetchLogs(); }}>
+					<Select.Trigger class="font-[family-name:var(--font-mono)] text-[length:var(--font-size-sm)] bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] text-[var(--sig-text-bright)] rounded-lg h-auto py-1 px-2 min-w-[100px]">
+						{logLevelFilter || "All levels"}
+					</Select.Trigger>
+					<Select.Content class="bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] rounded-lg">
+						<Select.Item value="" label="All levels" />
+						{#each logLevels as level}
+							<Select.Item value={level} label={level} />
+						{/each}
+					</Select.Content>
+				</Select.Root>
+				<Select.Root type="single" value={logCategoryFilter} onValueChange={(v) => { logCategoryFilter = v ?? ""; fetchLogs(); }}>
+					<Select.Trigger class="font-[family-name:var(--font-mono)] text-[length:var(--font-size-sm)] bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] text-[var(--sig-text-bright)] rounded-lg h-auto py-1 px-2 min-w-[100px]">
+						{logCategoryFilter || "All categories"}
+					</Select.Trigger>
+					<Select.Content class="bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] rounded-lg">
+						<Select.Item value="" label="All categories" />
+						{#each logCategories as cat}
+							<Select.Item value={cat} label={cat} />
+						{/each}
+					</Select.Content>
+				</Select.Root>
+				<label class="flex items-center gap-1.5 sig-label text-[var(--sig-text)] cursor-pointer">
+					<Checkbox checked={logAutoScroll} onCheckedChange={(value: unknown) => {
+						logAutoScroll = value === true;
+						if (logAutoScroll) {
+							scrollToBottomNextFrame("auto");
+						}
+					}} class="rounded-lg" />
+					Auto-scroll
+				</label>
+				<div class="ml-auto flex items-center gap-[var(--space-sm)] min-w-0">
+					{#if streamError}
+						<span class="sig-eyebrow truncate max-w-[220px]">
+							{streamError}
+						</span>
+					{/if}
+					<span class={`sig-label font-medium ${logsStreaming ? "text-[var(--sig-success)] [animation:pulse_2s_infinite]" : logsReconnecting || logsConnecting ? "text-[var(--sig-accent)] [animation:pulse_2s_infinite]" : "text-[var(--sig-danger)]"}`}>
+						{#if logsStreaming}
+							● Live
+						{:else if logsReconnecting}
+							↺ Reconnecting
+						{:else if logsConnecting}
+							◌ Connecting
+						{:else}
+							● Offline
+						{/if}
+					</span>
 					<Button
 						variant="outline"
 						size="sm"
-						class="sig-eyebrow px-2 py-1 h-auto hover:border-[var(--sig-border-strong)] hover:text-[var(--sig-text-bright)]"
-						onclick={copySelectedLog}
-					>{copied ? "Copied" : ActionLabels.CopyJson}</Button>
+						class="sig-label px-2 py-1 h-auto hover:border-[var(--sig-border-strong)] hover:text-[var(--sig-text-bright)]"
+						onclick={fetchLogs}
+						title="Reload logs"
+					>
+						{ActionLabels.Refresh}
+					</Button>
 				</div>
+			</div>
+
+			<ScrollArea class="min-h-0 flex-1" bind:viewportRef={logViewport}>
+				<div class="font-[family-name:var(--font-mono)] text-[length:var(--font-size-sm)] leading-relaxed">
+					{#if logsLoading}
+						<div class="py-[var(--space-xl)] text-center text-[var(--sig-text-muted)] font-[family-name:var(--font-display)] text-[length:var(--font-size-base)]">Loading logs...</div>
+					{:else if logsError}
+						<div class="py-[var(--space-xl)] text-center text-[var(--sig-danger)] font-[family-name:var(--font-display)] text-[length:var(--font-size-base)]">{logsError}</div>
+					{:else if logs.length === 0}
+						<div class="py-[var(--space-xl)] text-center text-[var(--sig-text-muted)] font-[family-name:var(--font-display)] text-[length:var(--font-size-base)]">No logs found</div>
+					{:else}
+						{#each logs as log, i}
+							<button
+								type="button"
+								class={`log-row ${getLogLevelClass(log.level)} w-full text-left px-[var(--space-md)] py-1.5 border-b border-[var(--sig-border)] hover:bg-[var(--sig-surface)] cursor-pointer ${
+									selectedLogKey === buildLogKey(log, i) ? "bg-[var(--sig-surface)] border-[var(--sig-border-strong)]" : ""
+								}`}
+								onclick={() => {
+									selectedLogKey = buildLogKey(log, i);
+								}}
+							>
+								<div class="flex flex-wrap items-baseline gap-[var(--space-xs)]">
+									<span class="text-[var(--sig-text-muted)] shrink-0">{formatLogTime(log.timestamp)}</span>
+									<span class={`font-semibold shrink-0 min-w-[40px] ${getLogLevelClass(log.level)}`}>{log.level.toUpperCase()}</span>
+									<span class={`log-category ${getLogCategoryClass(log.category)} shrink-0`}>[{log.category}]</span>
+									<span class="text-[var(--sig-text-bright)] break-all">{log.message}</span>
+									{#if log.duration !== undefined}
+										<span class="text-[var(--sig-text-muted)]">({log.duration}ms)</span>
+									{/if}
+								</div>
+								{#if getReadableLogSnippet(log)}
+									<div class="mt-1 text-[11px] text-[var(--sig-text-muted)] whitespace-pre-wrap break-words">{getReadableLogSnippet(log)}</div>
+								{/if}
+							</button>
+						{/each}
+					{/if}
+				</div>
+			</ScrollArea>
+		</section>
+
+		<section class="log-details-window min-h-0 overflow-auto rounded-lg border border-[var(--sig-border-strong)] p-[var(--space-md)] font-[family-name:var(--font-mono)] text-[length:var(--font-size-sm)]">
+			{#if selectedLog}
 				<div class="grid grid-cols-[80px_1fr] gap-y-1 gap-x-2 mb-[var(--space-sm)]">
 					<div class="text-[var(--sig-text-muted)]">Time</div>
 					<div class="text-[var(--sig-text-bright)] break-all">{formatLogDate(selectedLog.timestamp)}</div>
 					<div class="text-[var(--sig-text-muted)]">Level</div>
 					<div class={`uppercase ${getLogLevelClass(selectedLog.level)}`}>{selectedLog.level}</div>
 					<div class="text-[var(--sig-text-muted)]">Category</div>
-					<div class="text-[var(--sig-text-bright)]">{selectedLog.category}</div>
+					<div class={`log-category ${getLogCategoryClass(selectedLog.category)}`}>{selectedLog.category}</div>
 					<div class="text-[var(--sig-text-muted)]">Message</div>
 					<div class="text-[var(--sig-text-bright)] break-all">{selectedLog.message}</div>
 					{#if selectedLog.duration !== undefined}
@@ -466,7 +489,7 @@ $effect(() => {
 						<div class="text-[var(--sig-text-muted)] text-[length:var(--font-size-xs)] uppercase tracking-[0.08em] mb-1">Readable output</div>
 						{#each logSections as section}
 							{#if section.content.length > 500}
-								<details class="mb-1 border border-[var(--sig-border)] bg-[var(--sig-surface)]">
+								<details class="mb-1 border border-[var(--sig-border)] bg-[var(--sig-surface)] rounded-lg">
 									<summary class="cursor-pointer px-2 py-1 text-[10px] text-[var(--sig-text-muted)] hover:text-[var(--sig-text)] select-none">
 										<span class="font-semibold text-[var(--sig-text)]">{section.label}</span>
 										<span class="ml-1 opacity-60">({section.content.length.toLocaleString()} chars)</span>
@@ -477,17 +500,28 @@ $effect(() => {
 							{:else}
 								<div class="mb-1">
 									<div class="text-[10px] text-[var(--sig-text-muted)] font-semibold mb-0.5">{section.label}</div>
-									<pre class="m-0 p-2 text-[10px] leading-relaxed whitespace-pre-wrap break-words border border-[var(--sig-border)] bg-[var(--sig-surface)] text-[var(--sig-text)]">{section.content}</pre>
+									<pre class="m-0 p-2 text-[10px] leading-relaxed whitespace-pre-wrap break-words border border-[var(--sig-border)] rounded-lg bg-[var(--sig-surface)] text-[var(--sig-text)]">{section.content}</pre>
 								</div>
 							{/if}
 						{/each}
 					</div>
 				{/if}
-				<pre class="m-0 p-2 text-[10px] leading-relaxed whitespace-pre-wrap break-all border border-[var(--sig-border)] bg-[var(--sig-surface-raised)] text-[var(--sig-text-muted)]">{formatJson(selectedLog)}</pre>
+				<div class="rounded-lg border border-[var(--sig-border)] bg-[var(--sig-surface)] overflow-hidden">
+					<div class="flex items-center justify-between gap-2 px-2 py-1 border-b border-[var(--sig-border)]">
+						<div class="sig-eyebrow tracking-[0.08em]">Log details</div>
+						<Button
+							variant="outline"
+							size="sm"
+							class="sig-eyebrow px-2 py-1 h-auto hover:border-[var(--sig-border-strong)] hover:text-[var(--sig-text-bright)]"
+							onclick={copySelectedLog}
+						>{copied ? "Copied" : ActionLabels.CopyJson}</Button>
+					</div>
+					<pre class="m-0 p-2 text-[10px] leading-relaxed whitespace-pre-wrap break-all text-[var(--sig-text-muted)]">{formatJson(selectedLog)}</pre>
+				</div>
 			{:else}
 				<div class="text-[var(--sig-text-muted)]">Select a log entry to inspect details.</div>
 			{/if}
-		</div>
+		</section>
 	</div>
 </div>
 
@@ -496,6 +530,20 @@ $effect(() => {
 	position: relative;
 	border-left: 2px solid transparent;
 	border-left-color: var(--log-level-color, transparent);
+}
+
+.log-details-window {
+	background:
+		radial-gradient(
+			circle at 86% -18%,
+			color-mix(in srgb, var(--sig-accent) 16%, transparent),
+			transparent 46%
+		),
+		linear-gradient(
+			145deg,
+			color-mix(in srgb, var(--sig-surface-raised) 90%, var(--sig-bg)) 0%,
+			var(--sig-surface-raised) 72%
+		);
 }
 
 .log-row::before {
@@ -542,5 +590,53 @@ $effect(() => {
 
 .log-level--error {
 	color: var(--sig-danger);
+}
+
+.log-category {
+	font-weight: 600;
+}
+
+.log-category--watcher {
+	color: var(--sig-log-category-watcher);
+}
+
+.log-category--daemon {
+	color: var(--sig-log-category-daemon);
+}
+
+.log-category--pipeline {
+	color: var(--sig-log-category-pipeline);
+}
+
+.log-category--system {
+	color: var(--sig-log-category-system);
+}
+
+.log-category--embedding-tracker {
+	color: var(--sig-log-category-embedding-tracker);
+}
+
+.log-category--document-worker {
+	color: var(--sig-log-category-document-worker);
+}
+
+.log-category--maintenance {
+	color: var(--sig-log-category-maintenance);
+}
+
+.log-category--git {
+	color: var(--sig-log-category-git);
+}
+
+.log-category--scheduler {
+	color: var(--sig-log-category-scheduler);
+}
+
+.log-category--retention {
+	color: var(--sig-log-category-retention);
+}
+
+.log-category--default {
+	color: var(--sig-text);
 }
 </style>

--- a/packages/cli/dashboard/src/lib/components/tabs/LogsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/LogsTab.svelte
@@ -33,11 +33,13 @@ let logsReconnecting = $state(false);
 let logsConnecting = $state(false);
 let streamError = $state("");
 let logEventSource: EventSource | null = null;
+let streamEnabled = $state(true);
 let reconnectAttempt = 0;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let logLevelFilter = $state<string>("");
 let logCategoryFilter = $state<string>("");
 let logAutoScroll = $state(false);
+let logAutoScrollPausedByScroll = $state(false);
 let logViewport = $state<HTMLElement | null>(null);
 let selectedLogKey = $state<string | null>(null);
 let copied = $state(false);
@@ -189,12 +191,18 @@ async function fetchLogs() {
 }
 
 function startLogStream() {
+	if (!streamEnabled) return;
+
 	if (reconnectTimer !== null) {
 		clearTimeout(reconnectTimer);
 		reconnectTimer = null;
 	}
 	if (logEventSource) logEventSource.close();
 	logsConnecting = true;
+	if (reconnectAttempt === 0) {
+		logsReconnecting = false;
+		streamError = "";
+	}
 	logEventSource = new EventSource("/api/logs/stream");
 
 	logEventSource.onmessage = (event) => {
@@ -228,6 +236,8 @@ function startLogStream() {
 	};
 
 	logEventSource.onerror = () => {
+		if (!streamEnabled) return;
+
 		logsStreaming = false;
 		logsConnecting = false;
 		logEventSource?.close();
@@ -236,7 +246,7 @@ function startLogStream() {
 		if (reconnectTimer !== null) return;
 
 		const delay = Math.min(RECONNECT_BASE_MS * 2 ** Math.min(reconnectAttempt, 10), RECONNECT_MAX_MS);
-		reconnectAttempt++;
+		reconnectAttempt = Math.min(reconnectAttempt + 1, 10);
 		logsReconnecting = true;
 		streamError = `Stream lost — reconnecting in ${delay / 1000}s`;
 
@@ -245,6 +255,42 @@ function startLogStream() {
 			startLogStream();
 		}, delay);
 	};
+}
+
+function stopLogStream(): void {
+	streamEnabled = false;
+	logsStreaming = false;
+	logsConnecting = false;
+	logsReconnecting = false;
+	streamError = "";
+	reconnectAttempt = 0;
+
+	if (reconnectTimer !== null) {
+		clearTimeout(reconnectTimer);
+		reconnectTimer = null;
+	}
+
+	if (logEventSource) {
+		logEventSource.close();
+		logEventSource = null;
+	}
+}
+
+function manualStartLogStream(): void {
+	streamEnabled = true;
+	reconnectAttempt = 0;
+	logsReconnecting = false;
+	streamError = "";
+	startLogStream();
+}
+
+function toggleLogStream(): void {
+	if (streamEnabled) {
+		stopLogStream();
+		return;
+	}
+
+	manualStartLogStream();
 }
 
 function formatLogTime(timestamp: string): string {
@@ -333,8 +379,9 @@ async function copySelectedLog(): Promise<void> {
 
 onMount(() => {
 	fetchLogs();
-	startLogStream();
+	manualStartLogStream();
 	return () => {
+		streamEnabled = false;
 		if (autoScrollSnapFrame !== null) cancelAnimationFrame(autoScrollSnapFrame);
 		if (reconnectTimer !== null) clearTimeout(reconnectTimer);
 		if (logEventSource) logEventSource.close();
@@ -349,10 +396,12 @@ $effect(() => {
 		const nearBottom = isNearBottom(viewport);
 		if (logAutoScroll && !nearBottom) {
 			logAutoScroll = false;
+			logAutoScrollPausedByScroll = true;
 			return;
 		}
-		if (!logAutoScroll && nearBottom) {
+		if (!logAutoScroll && logAutoScrollPausedByScroll && nearBottom) {
 			logAutoScroll = true;
+			logAutoScrollPausedByScroll = false;
 		}
 	};
 
@@ -394,6 +443,7 @@ $effect(() => {
 				<label class="flex items-center gap-1.5 sig-label text-[var(--sig-text)] cursor-pointer">
 					<Checkbox checked={logAutoScroll} onCheckedChange={(value: unknown) => {
 						logAutoScroll = value === true;
+						logAutoScrollPausedByScroll = false;
 						if (logAutoScroll) {
 							scrollToBottomNextFrame("auto");
 						}
@@ -417,6 +467,15 @@ $effect(() => {
 							● Offline
 						{/if}
 					</span>
+					<Button
+						variant="outline"
+						size="sm"
+						class="sig-label px-2 py-1 h-auto hover:border-[var(--sig-border-strong)] hover:text-[var(--sig-text-bright)]"
+						onclick={toggleLogStream}
+						title={streamEnabled ? "Disconnect stream" : "Reconnect stream"}
+					>
+						{streamEnabled ? "Disconnect" : "Reconnect"}
+					</Button>
 					<Button
 						variant="outline"
 						size="sm"

--- a/packages/cli/dashboard/src/routes/+page.svelte
+++ b/packages/cli/dashboard/src/routes/+page.svelte
@@ -31,7 +31,7 @@ import { onMount } from "svelte";
 
 const activeTab = $derived(nav.activeTab);
 
-const tabBtn = "px-2.5 py-0.5 sig-label uppercase tracking-[0.06em] rounded-md transition-colors duration-150 border-none cursor-pointer";
+const tabBtn = "px-3 py-1 text-[11px] font-medium uppercase tracking-[0.06em] rounded-md transition-colors duration-150 border-none cursor-pointer";
 const tabActive = `${tabBtn} bg-[var(--sig-accent)] text-[var(--sig-bg)]`;
 const tabInactive = `${tabBtn} bg-transparent text-[var(--sig-text-muted)] hover:bg-[var(--sig-surface-raised)] hover:text-[var(--sig-text-bright)]`;
 
@@ -153,7 +153,7 @@ onMount(() => {
 		m-2 ml-0 rounded-lg border border-[var(--sig-border)] md:border-l-0
 		bg-[var(--sig-surface)]">
 		<header
-			class="flex h-10 shrink-0 items-center justify-between
+			class="flex h-12 shrink-0 items-center justify-between
 				border-b border-[var(--sig-border)] px-4"
 		>
 			<div class="flex items-center gap-2">

--- a/packages/daemon/src/logger.ts
+++ b/packages/daemon/src/logger.ts
@@ -81,6 +81,7 @@ class Logger extends EventEmitter {
 	private currentLogFile: string;
 	private buffer: LogEntry[] = [];
 	private flushTimer: ReturnType<typeof setInterval> | null = null;
+	private static readonly LOG_FILE_PATTERN = /^signet-(\d{4}-\d{2}-\d{2})(?:-(.+))?\.log$/;
 
 	constructor(config: Partial<LoggerConfig> = {}) {
 		super();
@@ -103,6 +104,45 @@ class Logger extends EventEmitter {
 
 	private shouldLog(level: LogLevel): boolean {
 		return LOG_LEVELS[level] >= LOG_LEVELS[this.config.level];
+	}
+
+	private parseLogFileName(fileName: string): { date: string; archiveSuffix: string | null } | null {
+		const match = Logger.LOG_FILE_PATTERN.exec(fileName);
+		if (!match) return null;
+		return {
+			date: match[1],
+			archiveSuffix: match[2] ?? null,
+		};
+	}
+
+	private compareLogFilesNewestFirst(aName: string, bName: string): number {
+		const aMeta = this.parseLogFileName(aName);
+		const bMeta = this.parseLogFileName(bName);
+
+		if (!aMeta && !bMeta) return bName.localeCompare(aName);
+		if (!aMeta) return 1;
+		if (!bMeta) return -1;
+
+		const byDate = bMeta.date.localeCompare(aMeta.date);
+		if (byDate !== 0) return byDate;
+
+		const aIsArchive = aMeta.archiveSuffix !== null;
+		const bIsArchive = bMeta.archiveSuffix !== null;
+		if (aIsArchive !== bIsArchive) return aIsArchive ? 1 : -1;
+
+		if (!aIsArchive) return bName.localeCompare(aName);
+
+		return (bMeta.archiveSuffix ?? "").localeCompare(aMeta.archiveSuffix ?? "");
+	}
+
+	private listLogFilesNewestFirst(): Array<{ name: string; path: string }> {
+		return readdirSync(this.config.logDir)
+			.filter((f) => this.parseLogFileName(f) !== null)
+			.map((f) => ({
+				name: f,
+				path: join(this.config.logDir, f),
+			}))
+			.sort((a, b) => this.compareLogFilesNewestFirst(a.name, b.name));
 	}
 
 	private formatConsole(entry: LogEntry): string {
@@ -214,13 +254,7 @@ class Logger extends EventEmitter {
 
 	private cleanOldLogs() {
 		try {
-			const files = readdirSync(this.config.logDir)
-				.filter((f) => f.startsWith("signet-") && f.endsWith(".log"))
-				.map((f) => ({
-					name: f,
-					path: join(this.config.logDir, f),
-				}))
-				.sort((a, b) => b.name.localeCompare(a.name));
+			const files = this.listLogFilesNewestFirst();
 
 			// Keep only maxFiles
 			for (let i = this.config.maxFiles; i < files.length; i++) {
@@ -369,14 +403,8 @@ class Logger extends EventEmitter {
 		const results: LogEntry[] = [];
 
 		try {
-			// Get all log files sorted by date in filename (newest first)
-			const logFiles = readdirSync(this.config.logDir)
-				.filter((f) => f.startsWith("signet-") && f.endsWith(".log"))
-				.map((f) => ({
-					name: f,
-					path: join(this.config.logDir, f),
-				}))
-				.sort((a, b) => b.name.localeCompare(a.name));
+			// Get all log files sorted by canonical log date (newest first)
+			const logFiles = this.listLogFilesNewestFirst();
 
 			// Read files until we have enough entries
 			for (const file of logFiles) {
@@ -390,8 +418,6 @@ class Logger extends EventEmitter {
 					const recentLines = lines.slice(-(limit * 2));
 
 					for (const line of recentLines) {
-						if (results.length >= limit * 2) break;
-
 						try {
 							const entry = JSON.parse(line) as LogEntry;
 

--- a/packages/daemon/src/logger.ts
+++ b/packages/daemon/src/logger.ts
@@ -219,9 +219,8 @@ class Logger extends EventEmitter {
 				.map((f) => ({
 					name: f,
 					path: join(this.config.logDir, f),
-					mtime: statSync(join(this.config.logDir, f)).mtime.getTime(),
 				}))
-				.sort((a, b) => b.mtime - a.mtime);
+				.sort((a, b) => b.name.localeCompare(a.name));
 
 			// Keep only maxFiles
 			for (let i = this.config.maxFiles; i < files.length; i++) {
@@ -357,7 +356,7 @@ class Logger extends EventEmitter {
 		},
 	};
 
-	// Get recent logs
+	// Get recent logs (reads across all log files, not just current day)
 	getRecent(
 		options: {
 			limit?: number;
@@ -370,27 +369,49 @@ class Logger extends EventEmitter {
 		const results: LogEntry[] = [];
 
 		try {
-			// Read from current log file
-			if (existsSync(this.currentLogFile)) {
-				const content = readFileSync(this.currentLogFile, "utf-8");
-				const lines = content.trim().split("\n").filter(Boolean);
+			// Get all log files sorted by date in filename (newest first)
+			const logFiles = readdirSync(this.config.logDir)
+				.filter((f) => f.startsWith("signet-") && f.endsWith(".log"))
+				.map((f) => ({
+					name: f,
+					path: join(this.config.logDir, f),
+				}))
+				.sort((a, b) => b.name.localeCompare(a.name));
 
-				for (const line of lines.slice(-limit * 2)) {
-					// Read extra for filtering
-					try {
-						const entry = JSON.parse(line) as LogEntry;
+			// Read files until we have enough entries
+			for (const file of logFiles) {
+				if (results.length >= limit * 2) break; // Read extra for filtering
 
-						// Apply filters
-						if (level && LOG_LEVELS[entry.level] < LOG_LEVELS[level]) continue;
-						if (category && entry.category !== category) continue;
-						if (since && new Date(entry.timestamp) < since) continue;
+				try {
+					const content = readFileSync(file.path, "utf-8");
+					const lines = content.trim().split("\n").filter(Boolean);
+					// Assumption: entries in each file are append-only in timestamp order.
+					// Cross-file timestamp interleaving is not supported by this tail read.
+					const recentLines = lines.slice(-(limit * 2));
 
-						results.push(entry);
-					} catch {
-						// Skip non-JSON lines
+					for (const line of recentLines) {
+						if (results.length >= limit * 2) break;
+
+						try {
+							const entry = JSON.parse(line) as LogEntry;
+
+							// Apply filters
+							if (level && LOG_LEVELS[entry.level] < LOG_LEVELS[level]) continue;
+							if (category && entry.category !== category) continue;
+							if (since && new Date(entry.timestamp) < since) continue;
+
+							results.push(entry);
+						} catch {
+							// Skip non-JSON lines
+						}
 					}
+				} catch {
+					// Skip files that can't be read
 				}
 			}
+
+			// Sort all results by timestamp (newest last for chronological order)
+			results.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
 		} catch {
 			// Return empty on read error
 		}


### PR DESCRIPTION
## Summary
- Refreshes the Logs tab with a two-pane feed/details layout and category color coding.
- Hardens stream behavior with clearer connection states, capped exponential reconnect backoff, and consistent level filtering semantics.
- Improves daemon log retrieval to scan multiple log files with deterministic filename ordering.

## Key Improvements
- Reworked `LogsTab` UX for faster scanning and richer details.
- Fixed auto-scroll timing/race issues and reduced redundant frame scheduling under bursts.
- Added explicit connecting/reconnecting/live state handling for clearer status reporting.
- Updated daemon `getRecent()` and cleanup ordering to use stable filename sort (`signet-YYYY-MM-DD.log`).

## Validation
- `bun run typecheck`
- `packages/cli/dashboard`: `bun run build`
- `packages/daemon`: `bun run build`