### PR TITLE
fix(connectors): rebuild connectors tab with tested harness-state parsing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/adapters/openclaw": {
       "name": "@signetai/signet-memory-openclaw",
-      "version": "0.35.4",
+      "version": "0.38.4",
       "dependencies": {
         "@sinclair/typebox": "0.34.47",
       },
@@ -22,7 +22,7 @@
     },
     "packages/cli": {
       "name": "@signet/cli",
-      "version": "0.35.4",
+      "version": "0.38.4",
       "bin": "./dist/cli.js",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
@@ -44,7 +44,7 @@
     },
     "packages/connector-base": {
       "name": "@signet/connector-base",
-      "version": "0.35.4",
+      "version": "0.38.4",
       "dependencies": {
         "@signet/core": "workspace:*",
       },
@@ -58,7 +58,7 @@
     },
     "packages/connector-claude-code": {
       "name": "@signet/connector-claude-code",
-      "version": "0.35.4",
+      "version": "0.38.4",
       "dependencies": {
         "@signet/connector-base": "workspace:*",
         "@signet/core": "workspace:*",
@@ -70,7 +70,7 @@
     },
     "packages/connector-openclaw": {
       "name": "@signet/connector-openclaw",
-      "version": "0.35.4",
+      "version": "0.38.4",
       "dependencies": {
         "@signet/connector-base": "workspace:*",
       },
@@ -81,7 +81,7 @@
     },
     "packages/connector-opencode": {
       "name": "@signet/connector-opencode",
-      "version": "0.35.4",
+      "version": "0.38.4",
       "dependencies": {
         "@signet/connector-base": "workspace:*",
         "@signet/core": "workspace:*",
@@ -93,7 +93,7 @@
     },
     "packages/core": {
       "name": "@signet/core",
-      "version": "0.35.4",
+      "version": "0.38.4",
       "dependencies": {
         "sqlite-vec": "^0.1.7-alpha.2",
         "yaml": "^2.6.0",
@@ -113,7 +113,7 @@
     },
     "packages/daemon": {
       "name": "@signet/daemon",
-      "version": "0.35.4",
+      "version": "0.38.4",
       "bin": {
         "signet-daemon": "./dist/daemon.js",
         "signet-mcp": "./dist/mcp-stdio.js",
@@ -131,6 +131,7 @@
         "onnxruntime-node": "1.21.0",
         "sharp": "^0.34.1",
         "umap-js": "^1.4.0",
+        "yaml": "^2.8.2",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -139,7 +140,7 @@
     },
     "packages/extension": {
       "name": "@signet/extension",
-      "version": "0.35.4",
+      "version": "0.38.4",
       "devDependencies": {
         "@types/chrome": "^0.0.287",
         "typescript": "^5.7.0",
@@ -147,14 +148,14 @@
     },
     "packages/opencode-plugin": {
       "name": "@signet/opencode-plugin",
-      "version": "0.35.4",
+      "version": "0.38.4",
       "peerDependencies": {
         "@opencode-ai/plugin": ">=0.1.0",
       },
     },
     "packages/sdk": {
       "name": "@signet/sdk",
-      "version": "0.35.4",
+      "version": "0.38.4",
       "devDependencies": {
         "@types/react": "^19.0.0",
         "react": "^19.0.0",
@@ -170,7 +171,7 @@
     },
     "packages/signetai": {
       "name": "signetai",
-      "version": "0.35.4",
+      "version": "0.38.4",
       "bin": {
         "signet": "bin/signet.js",
         "signet-mcp": "dist/mcp-stdio.js",
@@ -200,7 +201,7 @@
     },
     "packages/tray": {
       "name": "@signet/tray",
-      "version": "0.35.4",
+      "version": "0.38.4",
       "dependencies": {
         "@signet/sdk": "workspace:*",
         "@tauri-apps/api": "^2.5.0",

--- a/packages/cli/dashboard/src/lib/api.ts
+++ b/packages/cli/dashboard/src/lib/api.ts
@@ -6,7 +6,7 @@
 // In production, the dashboard is served by the daemon, so use relative URLs
 // In development, point to the daemon on port 3850
 const isDev = import.meta.env.DEV;
-const API_BASE = isDev ? "http://localhost:3850" : "";
+export const API_BASE = isDev ? "http://localhost:3850" : "";
 
 export interface Memory {
 	id: string;
@@ -39,6 +39,7 @@ export interface Harness {
 	id: string;
 	path: string;
 	exists: boolean;
+	enabled?: boolean;
 	lastSeen: string | null;
 }
 

--- a/packages/cli/dashboard/src/lib/components/tabs/ConnectorsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/ConnectorsTab.svelte
@@ -1,235 +1,308 @@
 <script lang="ts">
-	import { onMount } from "svelte";
-	import { Badge } from "$lib/components/ui/badge/index.js";
-	import { Button } from "$lib/components/ui/button/index.js";
-	import * as Popover from "$lib/components/ui/popover/index.js";
-	import {
-		getHarnesses,
-		getConnectors,
-		regenerateHarnesses,
-		resyncConnectors,
-		syncConnector,
-		syncConnectorFull,
-		type Harness,
-		type DocumentConnector,
-	} from "$lib/api";
-	import { toast } from "$lib/stores/toast.svelte";
+import { onMount } from "svelte";
+import { Badge } from "$lib/components/ui/badge/index.js";
+import { Button } from "$lib/components/ui/button/index.js";
+import * as Popover from "$lib/components/ui/popover/index.js";
+import * as Tooltip from "$lib/components/ui/tooltip/index.js";
+import {
+	getHarnesses,
+	getConnectors,
+	getConfigFiles,
+	API_BASE,
+	regenerateHarnesses,
+	resyncConnectors,
+	syncConnector,
+	syncConnectorFull,
+	type Harness,
+	type DocumentConnector,
+} from "$lib/api";
+import { toast } from "$lib/stores/toast.svelte";
+import { parse } from "yaml";
 
-	let harnesses = $state<Harness[]>([]);
-	let connectors = $state<DocumentConnector[]>([]);
-	let loading = $state(true);
-	let syncingId = $state<string | null>(null);
-	let syncMenuOpen = $state<string | null>(null);
-	let harnessResyncing = $state(false);
-	let connectorsResyncing = $state(false);
+interface ConnectorHealth {
+	documentCount: number;
+}
 
-	function relativeTime(iso: string | null): string {
-		if (!iso) return "never";
-		const ts = new Date(iso).getTime();
-		if (Number.isNaN(ts)) return "unknown";
-		const diff = Date.now() - ts;
-		const minutes = Math.floor(diff / 60_000);
-		if (minutes < 1) return "just now";
-		if (minutes < 60) return `${minutes}m ago`;
-		const hours = Math.floor(minutes / 60);
-		if (hours < 24) return `${hours}h ago`;
-		return `${Math.floor(hours / 24)}d ago`;
-	}
+let harnesses = $state<Harness[]>([]);
+let connectors = $state<DocumentConnector[]>([]);
+let connectorHealthMap = $state<Map<string, ConnectorHealth>>(new Map());
+let enabledHarnessIds = $state<Set<string> | null>(null);
+let loading = $state(true);
+let didInitialLoadErrorToast = $state(false);
+let syncingId = $state<string | null>(null);
+let syncMenuOpen = $state<string | null>(null);
+let harnessResyncing = $state(false);
+let connectorsResyncing = $state(false);
 
-	function statusVariant(
-		status: string,
-	): "default" | "secondary" | "destructive" | "outline" {
-		if (status === "error") return "destructive";
-		if (status === "syncing") return "default";
-		return "secondary";
-	}
+type HarnessEnabledState = "enabled" | "disabled" | "unknown";
 
-	async function load() {
-		try {
-			const [h, c] = await Promise.all([getHarnesses(), getConnectors()]);
-			harnesses = h;
-			connectors = c;
-		} finally {
-			loading = false;
+function resolveHarnessState(harness: Harness): HarnessEnabledState {
+	if (harness.enabled === true) return "enabled";
+	if (harness.enabled === false) return "disabled";
+	if (!enabledHarnessIds) return "unknown";
+	return enabledHarnessIds.has(harness.id) ? "enabled" : "disabled";
+}
+
+function relativeTime(iso: string | null): string {
+	if (!iso) return "never";
+	const ts = new Date(iso).getTime();
+	if (Number.isNaN(ts)) return "unknown";
+	const diff = Date.now() - ts;
+	const minutes = Math.floor(diff / 60_000);
+	if (minutes < 1) return "just now";
+	if (minutes < 60) return `${minutes}m ago`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `${hours}h ago`;
+	return `${Math.floor(hours / 24)}d ago`;
+}
+
+function statusVariant(status: string): "default" | "secondary" | "destructive" | "outline" {
+	if (status === "error") return "destructive";
+	if (status === "syncing") return "default";
+	return "secondary";
+}
+
+async function load() {
+	let loadedConnectors: DocumentConnector[] = [];
+	let loadedPrimary = false;
+	try {
+		const [h, c] = await Promise.all([getHarnesses(), getConnectors()]);
+		harnesses = h;
+		connectors = c;
+		loadedConnectors = c;
+		loadedPrimary = true;
+
+		if (h.some((harness) => harness.enabled === undefined)) {
+			const configFiles = await getConfigFiles();
+			enabledHarnessIds = readEnabledHarnesses(configFiles);
+		} else {
+			enabledHarnessIds = null;
+		}
+	} catch {
+		// Keep previously rendered data if this refresh fails
+		if (loading && !didInitialLoadErrorToast) {
+			toast("Failed to load connectors. Check daemon status and retry.", "error");
+			didInitialLoadErrorToast = true;
+		}
+	} finally {
+		loading = false;
+		if (loadedPrimary) {
+			void fetchConnectorHealth(loadedConnectors);
 		}
 	}
+}
 
-	async function triggerHarnessResync(): Promise<void> {
-		harnessResyncing = true;
+function readEnabledHarnesses(
+	files: Array<{ name: string; content: string }>,
+): Set<string> | null {
+	const file =
+		files.find((f) => f.name === "agent.yaml") ??
+		files.find((f) => f.name === "AGENT.yaml");
+	if (!file) return null;
+
+	try {
+		const data = parse(file.content) as { harnesses?: unknown };
+		if (!Array.isArray(data.harnesses)) return null;
+		const ids = data.harnesses
+			.filter((item): item is string => typeof item === "string")
+			.map((item) => item.trim())
+			.filter((item) => item.length > 0);
+		return new Set(ids);
+	} catch {
+		return null;
+	}
+}
+
+async function fetchConnectorHealth(conns: DocumentConnector[]): Promise<void> {
+	const healthPromises = conns.map(async (conn) => {
 		try {
-			const result = await regenerateHarnesses();
-			if (!result.success) {
-				toast(`Harness re-sync failed: ${result.error ?? "unknown error"}`, "error");
-				return;
+			const res = await fetch(`${API_BASE}/api/connectors/${encodeURIComponent(conn.id)}/health`);
+			if (res.ok) {
+				const data = await res.json() as ConnectorHealth;
+				return { id: conn.id, health: data };
 			}
-			toast(result.message ?? "Harness re-sync completed", "success");
-			await load();
-		} catch (e) {
-			toast(
-				`Harness re-sync failed: ${e instanceof Error ? e.message : String(e)}`,
-				"error",
-			);
-		} finally {
-			harnessResyncing = false;
+		} catch {
+			// Ignore health fetch errors
+		}
+		return null;
+	});
+
+	const results = await Promise.all(healthPromises);
+	const previousMap = connectorHealthMap;
+	const newMap = new Map<string, ConnectorHealth>();
+	for (let index = 0; index < results.length; index++) {
+		const result = results[index];
+		if (result) {
+			newMap.set(result.id, result.health);
+			continue;
+		}
+		const previous = previousMap.get(conns[index].id);
+		if (previous) {
+			newMap.set(conns[index].id, previous);
 		}
 	}
+	connectorHealthMap = newMap;
+}
 
-	function buildConnectorResyncMessage(result: {
-		started: number;
-		alreadySyncing: number;
-		unsupported: number;
-		failed: number;
-		total: number;
-	}): string {
-		const parts: string[] = [];
-		parts.push(`Started ${result.started}`);
-		if (result.alreadySyncing > 0) parts.push(`${result.alreadySyncing} already syncing`);
-		if (result.unsupported > 0) parts.push(`${result.unsupported} unsupported`);
-		if (result.failed > 0) parts.push(`${result.failed} failed`);
-		parts.push(`of ${result.total}`);
-		return `Connector re-sync summary: ${parts.join(", ")}`;
+async function triggerHarnessResync(): Promise<void> {
+	harnessResyncing = true;
+	try {
+		const result = await regenerateHarnesses();
+		if (!result.success) {
+			toast(`Harness re-sync failed: ${result.error ?? "unknown error"}`, "error");
+			return;
+		}
+		toast(result.message ?? "Harness re-sync completed", "success");
+		await load();
+	} catch (e) {
+		toast(`Harness re-sync failed: ${e instanceof Error ? e.message : String(e)}`, "error");
+	} finally {
+		harnessResyncing = false;
+	}
+}
+
+function buildConnectorResyncMessage(result: {
+	started: number;
+	alreadySyncing: number;
+	unsupported: number;
+	failed: number;
+	total: number;
+}): string {
+	const parts: string[] = [];
+	parts.push(`Started ${result.started}`);
+	if (result.alreadySyncing > 0) parts.push(`${result.alreadySyncing} already syncing`);
+	if (result.unsupported > 0) parts.push(`${result.unsupported} unsupported`);
+	if (result.failed > 0) parts.push(`${result.failed} failed`);
+	parts.push(`of ${result.total}`);
+	return `Connector re-sync summary: ${parts.join(", ")}`;
+}
+
+async function triggerConnectorsResync(): Promise<void> {
+	if (connectors.length === 0) {
+		toast("No document connectors configured", "error");
+		return;
 	}
 
-	async function triggerConnectorsResync(): Promise<void> {
-		if (connectors.length === 0) {
-			toast("No document connectors configured", "error");
+	connectorsResyncing = true;
+	try {
+		const result = await resyncConnectors();
+		if (result.status === "error") {
+			toast(`Connector re-sync failed: ${result.error ?? "unknown error"}`, "error");
 			return;
 		}
 
-		connectorsResyncing = true;
-		try {
-			const result = await resyncConnectors();
-			if (result.status === "error") {
-				toast(`Connector re-sync failed: ${result.error ?? "unknown error"}`, "error");
-				return;
-			}
+		const message = buildConnectorResyncMessage(result);
+		if (result.failed > 0) {
+			toast(message, "error");
+		} else {
+			toast(message, "success");
+		}
+		await load();
+	} catch (e) {
+		toast(`Connector re-sync failed: ${e instanceof Error ? e.message : String(e)}`, "error");
+	} finally {
+		connectorsResyncing = false;
+	}
+}
 
-			const message = buildConnectorResyncMessage(result);
-			if (result.failed > 0) {
-				toast(message, "error");
-			} else {
-				toast(message, "success");
-			}
+async function triggerSync(conn: DocumentConnector): Promise<void> {
+	const name = conn.display_name ?? conn.id;
+	syncMenuOpen = null;
+	syncingId = conn.id;
+	try {
+		const result = await syncConnector(conn.id);
+		if (result.error) {
+			toast(`Sync failed: ${result.error}`, "error");
+		} else {
+			toast(`Sync started for ${name}`, "success");
 			await load();
-		} catch (e) {
-			toast(
-				`Connector re-sync failed: ${e instanceof Error ? e.message : String(e)}`,
-				"error",
-			);
-		} finally {
-			connectorsResyncing = false;
 		}
+	} catch (e) {
+		toast(`Sync failed: ${e instanceof Error ? e.message : String(e)}`, "error");
+	} finally {
+		syncingId = null;
 	}
+}
 
-	async function triggerSync(conn: DocumentConnector): Promise<void> {
-		const name = conn.display_name ?? conn.id;
-		syncMenuOpen = null;
-		syncingId = conn.id;
-		try {
-			const result = await syncConnector(conn.id);
-			if (result.error) {
-				toast(`Sync failed: ${result.error}`, "error");
-			} else {
-				toast(`Sync started for ${name}`, "success");
-				await load();
-			}
-		} catch (e) {
-			toast(`Sync failed: ${e instanceof Error ? e.message : String(e)}`, "error");
-		} finally {
-			syncingId = null;
+async function triggerFullSync(conn: DocumentConnector): Promise<void> {
+	const name = conn.display_name ?? conn.id;
+	syncMenuOpen = null;
+
+	const confirmed = window.confirm(
+		`Full resync will clear all documents from "${name}" and reindex everything. This may take a while.\n\nContinue?`,
+	);
+	if (!confirmed) return;
+
+	syncingId = conn.id;
+	try {
+		const result = await syncConnectorFull(conn.id);
+		if (result.error) {
+			toast(`Full resync failed: ${result.error}`, "error");
+		} else {
+			toast(`Full resync started for ${name}`, "success");
+			await load();
 		}
+	} catch (e) {
+		toast(`Full resync failed: ${e instanceof Error ? e.message : String(e)}`, "error");
+	} finally {
+		syncingId = null;
 	}
+}
 
-	async function triggerFullSync(conn: DocumentConnector): Promise<void> {
-		const name = conn.display_name ?? conn.id;
-		syncMenuOpen = null;
-
-		const confirmed = window.confirm(
-			`Full resync will clear all documents from "${name}" and reindex everything. This may take a while.\n\nContinue?`,
-		);
-		if (!confirmed) return;
-
-		syncingId = conn.id;
-		try {
-			const result = await syncConnectorFull(conn.id);
-			if (result.error) {
-				toast(`Full resync failed: ${result.error}`, "error");
-			} else {
-				toast(`Full resync started for ${name}`, "success");
-				await load();
-			}
-		} catch (e) {
-			toast(`Full resync failed: ${e instanceof Error ? e.message : String(e)}`, "error");
-		} finally {
-			syncingId = null;
-		}
-	}
-
-	onMount(() => {
-		load();
-		const timer = setInterval(load, 30_000);
-		return () => clearInterval(timer);
-	});
+onMount(() => {
+	load();
+	const timer = setInterval(load, 30_000);
+	return () => clearInterval(timer);
+});
 </script>
 
-<div class="flex flex-1 flex-col gap-6 p-4 overflow-y-auto">
+<div class="flex flex-col flex-1 min-h-0 p-[var(--space-sm)] lg:p-[var(--space-md)] gap-[var(--space-md)] overflow-y-auto">
 	{#if loading}
 		<div class="flex flex-1 items-center justify-center sig-label">
 			Loading connectors...
 		</div>
 	{:else}
 		<!-- Platform Harnesses -->
-		<section>
-			<div class="flex items-center justify-between mb-3 gap-3">
-				<h3 class="sig-label uppercase tracking-[0.1em]">
+		<section class="rounded-lg border border-[var(--sig-border-strong)] bg-[var(--sig-surface-raised)] overflow-hidden">
+			<div class="harness-header flex items-center justify-between px-[var(--space-md)] py-[var(--space-sm)] border-b border-[var(--sig-border)]">
+				<h3 class="sig-heading tracking-[0.08em]">
 					Platform Harnesses
 				</h3>
 				<Button
 					variant="outline"
 					size="sm"
 					disabled={harnessResyncing}
-					class="sig-meta uppercase tracking-[0.08em] h-auto px-2 py-1"
+					class="sig-label px-2 py-1 h-auto hover:border-[var(--sig-border-strong)] hover:text-[var(--sig-text-bright)]"
 					onclick={triggerHarnessResync}
 				>
-					{harnessResyncing ? "Re-syncing..." : "Re-sync Harnesses"}
+					{harnessResyncing ? "Re-syncing..." : "Re-sync"}
 				</Button>
 			</div>
-			<div class="grid gap-2">
+			<div class="grid gap-[var(--space-sm)] p-[var(--space-md)] sm:grid-cols-2 lg:grid-cols-3">
 				{#each harnesses as h (h.id)}
-					<div
-						class="flex items-center gap-3 px-3 py-2.5
-							border border-[var(--sig-border)]
-							bg-[var(--sig-surface-raised)]"
-					>
-						<span
-							class="inline-block h-2 w-2 shrink-0"
-							class:bg-[var(--sig-success)]={h.exists}
-							class:border={!h.exists}
-							class:border-[var(--sig-text-muted)]={!h.exists}
-						></span>
-						<div class="flex flex-col gap-0.5 min-w-0 flex-1">
-							<span class="text-[12px] font-medium text-[var(--sig-text-bright)]
-								font-[family-name:var(--font-display)] tracking-[0.04em]">
-								{h.name}
-							</span>
-							<span class="sig-eyebrow truncate">
-								{h.path}
-							</span>
-						</div>
-						<div class="flex flex-col items-end gap-0.5 shrink-0">
+					{@const harnessState = resolveHarnessState(h)}
+					<div class="harness-card flex flex-col gap-[var(--space-sm)] p-[var(--space-md)] rounded-lg border border-[var(--sig-border)] bg-[var(--sig-surface)] transition-colors hover:border-[var(--sig-border-strong)]">
+						<span class="text-[13px] font-semibold text-[var(--sig-text-bright)] font-[family-name:var(--font-display)] tracking-[0.04em]">
+							{h.name}
+						</span>
+						<Tooltip.Provider>
+							<Tooltip.Root>
+								<Tooltip.Trigger class="text-left">
+									<span class="sig-eyebrow truncate block max-w-[220px]">
+										{h.path}
+									</span>
+								</Tooltip.Trigger>
+								<Tooltip.Content class="max-w-[400px] break-all">
+									{h.path}
+								</Tooltip.Content>
+							</Tooltip.Root>
+						</Tooltip.Provider>
+						<div class="flex items-center justify-between gap-3 sig-eyebrow">
+							<span>{h.exists ? "Config found" : "Config not found"}</span>
 							<span
-								class="sig-eyebrow"
-								class:text-[var(--sig-text-bright)]={h.exists}
-								class:text-[var(--sig-text-muted)]={!h.exists}
+								class={`harness-state ${harnessState === "enabled" ? "harness-state--enabled" : harnessState === "disabled" ? "harness-state--disabled" : "harness-state--unknown"}`}
 							>
-								{h.exists ? "installed" : "not found"}
-							</span>
-							<span class="sig-eyebrow">
-								{#if h.lastSeen}
-									seen {relativeTime(h.lastSeen)}
-								{:else}
-									no activity
-								{/if}
+								{harnessState === "enabled" ? "Enabled" : harnessState === "disabled" ? "Disabled" : "Unknown"}
 							</span>
 						</div>
 					</div>
@@ -238,111 +311,117 @@
 		</section>
 
 		<!-- Document Connectors -->
-		<section>
-			<div class="flex items-center justify-between mb-3 gap-3">
-				<h3 class="sig-label uppercase tracking-[0.1em]">
+		<section class="rounded-lg border border-[var(--sig-border-strong)] bg-[var(--sig-surface-raised)] overflow-hidden">
+			<div class="connector-header flex items-center justify-between px-[var(--space-md)] py-[var(--space-sm)] border-b border-[var(--sig-border)]">
+				<h3 class="sig-heading tracking-[0.08em]">
 					Document Connectors
 				</h3>
 				<Button
 					variant="outline"
 					size="sm"
 					disabled={connectorsResyncing || connectors.length === 0}
-					class="sig-meta uppercase tracking-[0.08em] h-auto px-2 py-1"
+					class="sig-label px-2 py-1 h-auto hover:border-[var(--sig-border-strong)] hover:text-[var(--sig-text-bright)]"
 					onclick={triggerConnectorsResync}
 				>
-					{connectorsResyncing ? "Re-syncing..." : "Re-sync Connectors"}
+					{connectorsResyncing ? "Re-syncing..." : "Re-sync"}
 				</Button>
 			</div>
 			{#if connectors.length === 0}
-				<div class="flex items-center justify-center py-8
-					sig-label border border-dashed border-[var(--sig-border)]">
+				<div class="flex items-center justify-center py-[var(--space-xl)] sig-label text-[var(--sig-text-muted)]">
 					No document connectors configured
 				</div>
 			{:else}
-				<div class="grid gap-2">
+				<div class="grid gap-[var(--space-sm)] p-[var(--space-md)] sm:grid-cols-2 lg:grid-cols-3">
 					{#each connectors as conn (conn.id)}
-						<div
-							class="flex items-center gap-3 px-3 py-2.5
-								border border-[var(--sig-border)]
-								bg-[var(--sig-surface-raised)]"
-						>
-							<Badge variant={statusVariant(conn.status)}>
-								{conn.status}
-							</Badge>
-							<div class="flex flex-col gap-0.5 min-w-0 flex-1">
-								<span class="text-[12px] font-medium text-[var(--sig-text-bright)]
-									font-[family-name:var(--font-display)] tracking-[0.04em]">
-									{conn.display_name ?? conn.id}
-								</span>
-								<span class="sig-eyebrow">
-									{conn.provider}
-								</span>
-							</div>
-							<div class="flex flex-col items-end gap-0.5 shrink-0">
-								<div class="flex items-center gap-2">
-									<span class="sig-eyebrow">
-										{#if conn.status === "syncing" || syncingId === conn.id}
-											syncing...
-										{:else if conn.last_sync_at}
-											synced {relativeTime(conn.last_sync_at)}
-										{:else}
-											never synced
-										{/if}
+						{@const health = connectorHealthMap.get(conn.id)}
+						<div class="connector-card flex flex-col gap-[var(--space-sm)] p-[var(--space-md)] rounded-lg border border-[var(--sig-border)] bg-[var(--sig-surface)] transition-colors hover:border-[var(--sig-border-strong)]">
+							<div class="flex items-start justify-between gap-2">
+								<div class="flex flex-col gap-1 min-w-0 flex-1">
+									<span class="text-[13px] font-semibold text-[var(--sig-text-bright)] font-[family-name:var(--font-display)] tracking-[0.04em]">
+										{conn.display_name ?? conn.id}
 									</span>
-									<Popover.Root open={syncMenuOpen === conn.id} onOpenChange={(open) => { syncMenuOpen = open ? conn.id : null; }}>
-										<Popover.Trigger>
-											{#snippet child({ props })}
-												<Button
-													{...props}
-													variant="outline"
-													size="sm"
-													disabled={conn.status === "syncing" || syncingId === conn.id}
-													class="sig-meta uppercase tracking-[0.08em] px-2 py-0.5 h-auto
-														hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]
-														disabled:opacity-50 disabled:cursor-not-allowed"
-												>
-													Sync ▾
-												</Button>
-											{/snippet}
-										</Popover.Trigger>
-										<Popover.Content
-											align="end"
-											side="bottom"
-											class="w-[140px] p-1 bg-[var(--sig-surface-raised)]
-												border-[var(--sig-border-strong)] rounded-lg"
-										>
-											<div class="flex flex-col gap-1">
-												<Button
-													variant="outline"
-													size="sm"
-													class="w-full justify-start sig-eyebrow tracking-[0.08em] px-2 py-1 h-auto
-														hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
-													onclick={() => triggerSync(conn)}
-												>
-													Sync
-												</Button>
-												<Button
-													variant="outline"
-													size="sm"
-													class="w-full justify-start sig-eyebrow tracking-[0.08em] px-2 py-1 h-auto
-														text-[var(--sig-danger)]
-														hover:text-[var(--sig-text-bright)] hover:border-[var(--sig-danger)]"
-													onclick={() => triggerFullSync(conn)}
-												>
-													Full Resync
-												</Button>
-											</div>
-										</Popover.Content>
-									</Popover.Root>
+									<span class="sig-eyebrow">
+										{conn.provider}
+									</span>
 								</div>
-								{#if conn.last_error}
-									<span
-										class="sig-eyebrow text-[var(--sig-danger)] truncate max-w-[200px]"
-										title={conn.last_error}
-									>
-										{conn.last_error}
+								<Badge variant={statusVariant(conn.status)} class="shrink-0">
+									{conn.status}
+								</Badge>
+							</div>
+
+							<div class="flex items-center gap-3 sig-eyebrow">
+								{#if health?.documentCount !== undefined}
+									<span class="flex items-center gap-1">
+										<span class="text-[var(--sig-text-bright)] font-medium">{health.documentCount.toLocaleString()}</span>
+										docs
 									</span>
 								{/if}
+								<span>
+									{#if conn.status === "syncing" || syncingId === conn.id}
+										Syncing...
+									{:else if conn.last_sync_at}
+										Synced {relativeTime(conn.last_sync_at)}
+									{:else}
+										Never synced
+									{/if}
+								</span>
+							</div>
+
+							{#if conn.last_error}
+								<Tooltip.Provider>
+									<Tooltip.Root>
+										<Tooltip.Trigger class="text-left">
+											<span class="sig-eyebrow text-[var(--sig-danger)] truncate block">
+												Error: {conn.last_error.slice(0, 50)}{conn.last_error.length > 50 ? "..." : ""}
+											</span>
+										</Tooltip.Trigger>
+										<Tooltip.Content class="max-w-[400px] break-all text-[var(--sig-danger)]">
+											{conn.last_error}
+										</Tooltip.Content>
+									</Tooltip.Root>
+								</Tooltip.Provider>
+							{/if}
+
+							<div class="flex items-center gap-2 mt-auto pt-[var(--space-xs)] border-t border-[var(--sig-border)]">
+								<Popover.Root open={syncMenuOpen === conn.id} onOpenChange={(open) => { syncMenuOpen = open ? conn.id : null; }}>
+									<Popover.Trigger class="flex-1">
+										{#snippet child({ props })}
+											<Button
+												{...props}
+												variant="outline"
+												size="sm"
+												disabled={conn.status === "syncing" || syncingId === conn.id}
+												class="w-full sig-eyebrow px-2 py-1 h-auto hover:border-[var(--sig-border-strong)] hover:text-[var(--sig-text-bright)] disabled:opacity-50"
+											>
+												Sync ▾
+											</Button>
+										{/snippet}
+									</Popover.Trigger>
+									<Popover.Content
+										align="start"
+										side="top"
+										class="w-[160px] p-1 bg-[var(--sig-surface-raised)] border-[var(--sig-border-strong)] rounded-lg"
+									>
+										<div class="flex flex-col gap-1">
+											<Button
+												variant="ghost"
+												size="sm"
+												class="w-full justify-start sig-eyebrow px-2 py-1.5 h-auto hover:bg-[var(--sig-surface)]"
+												onclick={() => triggerSync(conn)}
+											>
+												Incremental Sync
+											</Button>
+											<Button
+												variant="ghost"
+												size="sm"
+												class="w-full justify-start sig-eyebrow px-2 py-1.5 h-auto text-[var(--sig-danger)] hover:bg-[color-mix(in_srgb,var(--sig-danger)_10%,transparent)]"
+												onclick={() => triggerFullSync(conn)}
+											>
+												Full Resync
+											</Button>
+										</div>
+									</Popover.Content>
+								</Popover.Root>
 							</div>
 						</div>
 					{/each}
@@ -351,3 +430,63 @@
 		</section>
 	{/if}
 </div>
+
+<style>
+.harness-header {
+	background:
+		radial-gradient(
+			circle at 0% 0%,
+			color-mix(in srgb, var(--sig-success) 8%, transparent),
+			transparent 50%
+		),
+		var(--sig-surface-raised);
+}
+
+.connector-header {
+	background:
+		radial-gradient(
+			circle at 100% 0%,
+			color-mix(in srgb, var(--sig-accent) 12%, transparent),
+			transparent 50%
+		),
+		var(--sig-surface-raised);
+}
+
+.harness-card,
+.connector-card {
+	background:
+		linear-gradient(
+			145deg,
+			color-mix(in srgb, var(--sig-surface) 95%, var(--sig-bg)) 0%,
+			var(--sig-surface) 100%
+		);
+}
+
+.harness-state {
+	padding: 2px 8px;
+	border-radius: 6px;
+	font-size: 10px;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.06em;
+	border: 1px solid transparent;
+}
+
+.harness-state--enabled {
+	color: var(--sig-success);
+	border-color: color-mix(in srgb, var(--sig-success) 45%, transparent);
+	background: color-mix(in srgb, var(--sig-success) 12%, transparent);
+}
+
+.harness-state--disabled {
+	color: var(--sig-danger);
+	border-color: color-mix(in srgb, var(--sig-danger) 45%, transparent);
+	background: color-mix(in srgb, var(--sig-danger) 12%, transparent);
+}
+
+.harness-state--unknown {
+	color: var(--sig-text-muted);
+	border-color: var(--sig-border);
+	background: color-mix(in srgb, var(--sig-text-muted) 10%, transparent);
+}
+</style>

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -42,6 +42,7 @@
     "onnxruntime-node": "1.21.0",
     "sharp": "^0.34.1",
     "umap-js": "^1.4.0",
+    "yaml": "^2.8.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -70,6 +70,7 @@ import { type EmbeddingTrackerHandle, startEmbeddingTracker } from "./embedding-
 import { getAllFeatureFlags, initFeatureFlags } from "./feature-flags";
 import { closeLlmProvider, initLlmProvider } from "./llm";
 import { type LogEntry, logger } from "./logger";
+import { readEnabledHarnessesFromConfigFiles } from "./harness-config";
 import { type EmbeddingConfig, loadMemoryConfig } from "./memory-config";
 import { type RecallParams, hybridRecall } from "./memory-search";
 import { ONEPASSWORD_SERVICE_ACCOUNT_SECRET, importOnePasswordSecrets, listOnePasswordVaults } from "./onepassword.js";
@@ -3989,11 +3990,14 @@ app.get("/api/harnesses", async (c) => {
 		{ name: "OpenClaw", id: "openclaw", path: join(AGENTS_DIR, "AGENTS.md") },
 	];
 
+	const enabledHarnesses = readEnabledHarnessesFromConfigFiles(AGENTS_DIR);
+
 	const harnesses = configs.map((config) => ({
 		name: config.name,
 		id: config.id,
 		path: config.path,
 		exists: existsSync(config.path),
+		enabled: enabledHarnesses ? enabledHarnesses.has(config.id) : undefined,
 		lastSeen: harnessLastSeen.get(config.id) ?? null,
 	}));
 

--- a/packages/daemon/src/harness-config.test.ts
+++ b/packages/daemon/src/harness-config.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readEnabledHarnessesFromConfigFiles, readHarnessesFromConfigContent } from "./harness-config";
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+	while (tmpDirs.length > 0) {
+		const dir = tmpDirs.pop();
+		if (!dir) continue;
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+function makeTempAgentsDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), "signet-harness-config-"));
+	tmpDirs.push(dir);
+	return dir;
+}
+
+describe("readHarnessesFromConfigContent", () => {
+	it("parses root-level block sequence lists", () => {
+		const content = "harnesses:\n- claude-code\n- opencode\n";
+		expect(readHarnessesFromConfigContent(content)).toEqual(["claude-code", "opencode"]);
+	});
+
+	it("parses inline lists with trailing comments", () => {
+		const content = "harnesses: [claude-code, opencode] # preferred harnesses\n";
+		expect(readHarnessesFromConfigContent(content)).toEqual(["claude-code", "opencode"]);
+	});
+
+	it("parses multi-line flow lists with base-indent closing bracket", () => {
+		const content = "harnesses: [\n  claude-code,\n  opencode\n]\n";
+		expect(readHarnessesFromConfigContent(content)).toEqual(["claude-code", "opencode"]);
+	});
+
+	it("handles embedded closing bracket characters in quoted values", () => {
+		const content = "harnesses: ['foo[bar]', opencode]\n";
+		expect(readHarnessesFromConfigContent(content)).toEqual(["foo[bar]", "opencode"]);
+	});
+
+	it("ignores empty list items while keeping valid harnesses", () => {
+		const content = "harnesses:\n  - claude-code\n  -\n  - opencode\n";
+		expect(readHarnessesFromConfigContent(content)).toEqual(["claude-code", "opencode"]);
+	});
+
+	it("returns null when harnesses key is missing", () => {
+		const content = "name: boogy\n";
+		expect(readHarnessesFromConfigContent(content)).toBeNull();
+	});
+});
+
+describe("readEnabledHarnessesFromConfigFiles", () => {
+	it("returns null when no harness config file exists", () => {
+		const agentsDir = makeTempAgentsDir();
+		expect(readEnabledHarnessesFromConfigFiles(agentsDir)).toBeNull();
+	});
+
+	it("reads harnesses from agent.yaml", () => {
+		const agentsDir = makeTempAgentsDir();
+		writeFileSync(
+			join(agentsDir, "agent.yaml"),
+			"harnesses:\n  - claude-code\n  - opencode\n",
+		);
+
+		const enabled = readEnabledHarnessesFromConfigFiles(agentsDir);
+		expect(enabled).not.toBeNull();
+		expect(enabled?.has("claude-code")).toBe(true);
+		expect(enabled?.has("opencode")).toBe(true);
+		expect(enabled?.has("openclaw")).toBe(false);
+	});
+
+	it("falls back to AGENT.yaml when agent.yaml is missing", () => {
+		const agentsDir = makeTempAgentsDir();
+		writeFileSync(join(agentsDir, "AGENT.yaml"), "harnesses: [openclaw]\n");
+
+		const enabled = readEnabledHarnessesFromConfigFiles(agentsDir);
+		expect(enabled).not.toBeNull();
+		expect(enabled?.has("openclaw")).toBe(true);
+	});
+
+	it("returns empty set when config explicitly disables all harnesses", () => {
+		const agentsDir = makeTempAgentsDir();
+		writeFileSync(join(agentsDir, "agent.yaml"), "harnesses: []\n");
+
+		const enabled = readEnabledHarnessesFromConfigFiles(agentsDir);
+		expect(enabled).not.toBeNull();
+		expect(enabled?.size).toBe(0);
+	});
+});

--- a/packages/daemon/src/harness-config.ts
+++ b/packages/daemon/src/harness-config.ts
@@ -1,0 +1,47 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseSimpleYaml } from "@signet/core";
+import { parse as parseYaml } from "yaml";
+
+function parseHarnessList(value: unknown): string[] | null {
+	if (!Array.isArray(value)) return null;
+	return value
+		.filter((item): item is string => typeof item === "string")
+		.map((item) => item.trim())
+		.filter((item) => item.length > 0);
+}
+
+export function readHarnessesFromConfigContent(content: string): string[] | null {
+	try {
+		const parsed = parseYaml(content) as { harnesses?: unknown };
+		return parseHarnessList(parsed.harnesses);
+	} catch {
+		// Fall through to compatibility parser when strict YAML parsing fails
+	}
+
+	try {
+		const parsed = parseSimpleYaml(content) as { harnesses?: unknown };
+		return parseHarnessList(parsed.harnesses);
+	} catch {
+		return null;
+	}
+}
+
+export function readEnabledHarnessesFromConfigFiles(agentsDir: string): Set<string> | null {
+	const harnessConfigPaths = [join(agentsDir, "agent.yaml"), join(agentsDir, "AGENT.yaml")];
+
+	for (const filePath of harnessConfigPaths) {
+		if (!existsSync(filePath)) continue;
+		try {
+			const fileContent = readFileSync(filePath, "utf-8");
+			const harnesses = readHarnessesFromConfigContent(fileContent);
+			if (!harnesses) continue;
+
+			return new Set(harnesses);
+		} catch {
+			// Ignore read errors and try the next config path
+		}
+	}
+
+	return null;
+}


### PR DESCRIPTION
## What
- Rebuilds the Engine Connectors tab overhaul on a fresh branch/PR.
- Keeps the refreshed card-based Connectors UI and explicit harness state badges.
- Fixes daemon harness enabled-state detection to avoid silent all-disabled regressions.
- Adds explicit daemon tests for YAML edge cases that previously caused review churn.

## How
- **Dashboard (`ConnectorsTab.svelte`)**
  - Uses `${API_BASE}` and URL-encoded connector IDs for health fetches.
  - Loads fallback config only when daemon omits `h.enabled`.
  - Uses a tri-state harness resolution (`enabled` / `disabled` / `unknown`) so missing config is never misreported as disabled.
  - Preserves existing connector health values across partial health-fetch failures.
  - Avoids unhandled refresh failures and surfaces a one-time initial load error toast.

- **Dashboard API typing (`api.ts`)**
  - Exports `API_BASE` for direct tab-level fetches.
  - Marks `Harness.enabled` optional for old-daemon compatibility.

- **Daemon (`daemon.ts` + new `harness-config.ts`)**
  - Moves harness config parsing into a dedicated module.
  - Parses with `yaml` first and falls back to `parseSimpleYaml` only when strict parse throws.
  - Returns `enabled: undefined` when no harness config is present, allowing dashboard fallback instead of forcing false.

- **Tests (`harness-config.test.ts`)**
  - Adds explicit tests for edge cases:
    - root-level block sequences
    - inline lists with trailing comments
    - multi-line flow lists with base-indent close bracket
    - values containing `]`
    - empty list items
    - missing config file behavior
    - explicit empty harness list behavior

## Why
- The previous PR accumulated repeated parser edge-case fixes and review noise.
- This PR intentionally resets to a cleaner implementation path and adds tests to prevent regressions.
- The goal is correctness first: no silent all-disabled states, no misleading fallback badges, and stable connector health rendering during refresh failures.

## Validation
- `bun test packages/daemon/src/harness-config.test.ts`
- `bun run check` in `packages/cli/dashboard` (0 errors, 0 warnings)
- `bun run build` in `packages/cli/dashboard`
- `bun run build` in `packages/daemon`

## Replaces
- Replaces #131 (closed per request)