### PR TITLE
fix(daemon): harden SIGNET-ARCHITECTURE.md persistence

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6659,6 +6659,15 @@ function startFileWatcher() {
 		}
 	});
 
+	watcher.on("unlink", (path) => {
+		logger.info("watcher", "File removed", { path });
+		// Recreate the architecture doc immediately if deleted at runtime
+		if (path.endsWith("SIGNET-ARCHITECTURE.md")) {
+			ensureArchitectureDoc();
+		}
+		scheduleAutoCommit(path);
+	});
+
 	watcher.on("add", (path) => {
 		logger.info("watcher", "File added", { path });
 		scheduleAutoCommit(path);

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6584,7 +6584,11 @@ ${fileList}
 		}
 	}
 
-	// Write SIGNET-ARCHITECTURE.md if missing or outdated
+	ensureArchitectureDoc();
+}
+
+/** Write SIGNET-ARCHITECTURE.md if missing or outdated. */
+function ensureArchitectureDoc(): void {
 	const archPath = join(AGENTS_DIR, "SIGNET-ARCHITECTURE.md");
 	try {
 		const archContent = buildArchitectureDoc();
@@ -6624,6 +6628,7 @@ function startFileWatcher() {
 			join(AGENTS_DIR, "MEMORY.md"),
 			join(AGENTS_DIR, "IDENTITY.md"),
 			join(AGENTS_DIR, "USER.md"),
+			join(AGENTS_DIR, "SIGNET-ARCHITECTURE.md"),
 			join(AGENTS_DIR, "memory"), // Watch entire memory directory for new/changed .md files
 		],
 		{
@@ -7225,6 +7230,10 @@ async function main() {
 	// Start file watcher
 	startFileWatcher();
 	logger.info("watcher", "File watcher started");
+
+	// Ensure SIGNET-ARCHITECTURE.md exists on startup (file watcher uses
+	// ignoreInitial:true so it won't recreate missing files on its own)
+	ensureArchitectureDoc();
 
 	// Load config and log resolved embedding settings for diagnostics
 	const memoryCfg = loadMemoryConfig(AGENTS_DIR);


### PR DESCRIPTION
## Summary

- Extracts inline SIGNET-ARCHITECTURE.md write logic into a reusable `ensureArchitectureDoc()` helper
- Calls it on daemon startup so the file is recreated if missing (previously only written on identity file changes)
- Adds the file to the chokidar watcher so edits/deletions trigger `scheduleAutoCommit()`
- Does NOT add to `SYNC_TRIGGER_FILES` to avoid harness sync loops

## Context

A user reported the file missing after `git filter-repo` wiped their `.git` directory. Signet didn't cause it, but two resilience gaps meant the file wouldn't self-heal: the watcher uses `ignoreInitial: true` (so no recreation on startup), and the file wasn't watched for auto-commit.

## Test plan

- [ ] `bun run build` — clean build
- [ ] `bun run typecheck` — no type errors
- [ ] Delete `~/.agents/SIGNET-ARCHITECTURE.md`, restart daemon, verify file is recreated immediately
- [ ] Edit the file content, verify auto-commit fires within 5s