### PR TITLE
fix(dashboard): make constellation color mode session-scoped

### DIFF
--- a/packages/cli/dashboard/src/lib/components/embeddings/EmbeddingCanvas2D.svelte
+++ b/packages/cli/dashboard/src/lib/components/embeddings/EmbeddingCanvas2D.svelte
@@ -482,7 +482,7 @@ function draw(ctx: CanvasRenderingContext2D, now: number): void {
 		);
 		ctx.fill();
 
-		if (showNewSinceLastSeen && isNewSinceLastSeen(node.data.createdAt, lastSeenMs)) {
+		if (colorMode !== "none" && showNewSinceLastSeen && isNewSinceLastSeen(node.data.createdAt, lastSeenMs)) {
 			ctx.beginPath();
 			ctx.arc(node.x, node.y, node.radius + 2.2, 0, Math.PI * 2);
 			ctx.strokeStyle = "rgba(246, 194, 107, 0.85)";

--- a/packages/cli/dashboard/src/lib/components/embeddings/embedding-graph.ts
+++ b/packages/cli/dashboard/src/lib/components/embeddings/embedding-graph.ts
@@ -421,11 +421,11 @@ export function nodeFillStyle(
 	if (selectedId === id) return "rgba(255, 255, 255, 0.95)";
 	if (outsideLens) return dimmed ? "rgba(80, 80, 80, 0.08)" : "rgba(95, 95, 95, 0.15)";
 	if (relation === "similar") {
-		if (colorMode === "none") return dimmed ? "rgba(164, 164, 164, 0.28)" : "rgba(206, 206, 206, 0.82)";
+		if (colorMode === "none") return dimmed ? "rgba(160, 170, 185, 0.3)" : "rgba(198, 210, 228, 0.84)";
 		return dimmed ? "rgba(129, 180, 255, 0.35)" : "rgba(129, 180, 255, 0.9)";
 	}
 	if (relation === "dissimilar") {
-		if (colorMode === "none") return dimmed ? "rgba(122, 122, 122, 0.24)" : "rgba(178, 178, 178, 0.7)";
+		if (colorMode === "none") return dimmed ? "rgba(165, 150, 150, 0.28)" : "rgba(208, 190, 190, 0.8)";
 		return dimmed ? "rgba(255, 146, 146, 0.35)" : "rgba(255, 146, 146, 0.9)";
 	}
 	if (isPinned) return dimmed ? "rgba(220, 220, 220, 0.42)" : "rgba(235, 235, 235, 0.95)";
@@ -487,8 +487,8 @@ export function nodeColor3D(
 	if (selectedId === id) return "#ffffff";
 	if (lensActive && !lensIds.has(id)) return "#3b3b3b";
 	const relation = relations.get(id) ?? null;
-	if (relation === "similar") return noColorMode ? "#c6c6c6" : "#81b4ff";
-	if (relation === "dissimilar") return noColorMode ? "#8f8f8f" : "#ff9292";
+	if (relation === "similar") return noColorMode ? "#c6d2e4" : "#81b4ff";
+	if (relation === "dissimilar") return noColorMode ? "#cfbcbc" : "#ff9292";
 	if (pinnedIds.has(id)) return "#e5e7eb";
 	const dimmed = filterIds !== null && !filterIds.has(id);
 	if (dimmed) return "#5b5b5b";

--- a/packages/cli/dashboard/src/lib/components/embeddings/embedding-graph.ts
+++ b/packages/cli/dashboard/src/lib/components/embeddings/embedding-graph.ts
@@ -39,8 +39,10 @@ export const sourceColors: Record<string, string> = {
 	clawdbot: "#a78bfa",
 	daemon: "#22c55e",
 	"signet-daemon": "#22c55e",
-	openclaw: "#4ade80",
+	openclaw: "#facc15",
+	"openclaw-memory": "#facc15",
 	opencode: "#60a5fa",
+	user: "#ef4444",
 	manual: "#f472b6",
 	unknown: "#737373",
 };

--- a/packages/cli/dashboard/src/lib/components/embeddings/embedding-graph.ts
+++ b/packages/cli/dashboard/src/lib/components/embeddings/embedding-graph.ts
@@ -59,7 +59,7 @@ type NewnessBucket = "minutes" | "hours" | "week" | "older";
 
 export type RelationKind = "similar" | "dissimilar";
 
-export type NodeColorMode = "source" | "newness";
+export type NodeColorMode = "source" | "newness" | "none";
 
 export interface EmbeddingRelation {
 	id: string;
@@ -418,10 +418,17 @@ export function nodeFillStyle(
 
 	if (selectedId === id) return "rgba(255, 255, 255, 0.95)";
 	if (outsideLens) return dimmed ? "rgba(80, 80, 80, 0.08)" : "rgba(95, 95, 95, 0.15)";
-	if (relation === "similar") return dimmed ? "rgba(129, 180, 255, 0.35)" : "rgba(129, 180, 255, 0.9)";
-	if (relation === "dissimilar") return dimmed ? "rgba(255, 146, 146, 0.35)" : "rgba(255, 146, 146, 0.9)";
+	if (relation === "similar") {
+		if (colorMode === "none") return dimmed ? "rgba(164, 164, 164, 0.28)" : "rgba(206, 206, 206, 0.82)";
+		return dimmed ? "rgba(129, 180, 255, 0.35)" : "rgba(129, 180, 255, 0.9)";
+	}
+	if (relation === "dissimilar") {
+		if (colorMode === "none") return dimmed ? "rgba(122, 122, 122, 0.24)" : "rgba(178, 178, 178, 0.7)";
+		return dimmed ? "rgba(255, 146, 146, 0.35)" : "rgba(255, 146, 146, 0.9)";
+	}
 	if (isPinned) return dimmed ? "rgba(220, 220, 220, 0.42)" : "rgba(235, 235, 235, 0.95)";
 	if (dimmed) return "rgba(120, 120, 120, 0.2)";
+	if (colorMode === "none") return "rgba(168, 168, 168, 0.82)";
 	if (colorMode === "newness") {
 		if (newnessBucket(node.data.createdAt, nowMs) === "older") {
 			const source = node.data.who ?? "unknown";
@@ -474,15 +481,17 @@ export function nodeColor3D(
 	lastSeenMs: number | null,
 	sourceFocusSources: Set<string> | null,
 ): string {
+	const noColorMode = colorMode === "none";
 	if (selectedId === id) return "#ffffff";
 	if (lensActive && !lensIds.has(id)) return "#3b3b3b";
 	const relation = relations.get(id) ?? null;
-	if (relation === "similar") return "#81b4ff";
-	if (relation === "dissimilar") return "#ff9292";
+	if (relation === "similar") return noColorMode ? "#c6c6c6" : "#81b4ff";
+	if (relation === "dissimilar") return noColorMode ? "#8f8f8f" : "#ff9292";
 	if (pinnedIds.has(id)) return "#e5e7eb";
 	const dimmed = filterIds !== null && !filterIds.has(id);
 	if (dimmed) return "#5b5b5b";
-	if (showNewSinceLastSeen && isNewSinceLastSeen(createdAt, lastSeenMs)) return "#f6c26b";
+	if (!noColorMode && showNewSinceLastSeen && isNewSinceLastSeen(createdAt, lastSeenMs)) return "#f6c26b";
+	if (noColorMode) return "#a8a8a8";
 	if (colorMode === "newness") {
 		if (newnessBucket(createdAt, nowMs) === "older") {
 			if (sourceFocusSources !== null && sourceFocusSources.has(who)) {

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -1871,7 +1871,7 @@ $effect(() => {
 							<div class="border border-[var(--sig-border)] px-2 py-2 space-y-1.5">
 								<div class="font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] text-[var(--sig-text-muted)]">Overlays</div>
 								<div class="flex flex-wrap gap-1">
-									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {showNewSinceLastSeen ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'} {nodeColorMode === 'none' ? 'opacity-60 cursor-not-allowed' : ''}" onclick={() => (showNewSinceLastSeen = !showNewSinceLastSeen)} disabled={nodeColorMode === "none"}>New since last seen</button>
+									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {showNewSinceLastSeen && nodeColorMode !== 'none' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'} {nodeColorMode === 'none' ? 'opacity-60 cursor-not-allowed' : ''}" onclick={() => (showNewSinceLastSeen = !showNewSinceLastSeen)} disabled={nodeColorMode === "none"}>New since last seen</button>
 								</div>
 							</div>
 							<div class="border border-[var(--sig-border)] px-2 py-2 space-y-1.5">

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -1844,15 +1844,8 @@ $effect(() => {
 								<div class="font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] text-[var(--sig-text-muted)]">Color Mode</div>
 								<div class="flex flex-wrap gap-1">
 									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {nodeColorMode === 'newness' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (nodeColorMode = "newness")}>Newness</button>
+									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {nodeColorMode === 'source' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (nodeColorMode = "source")}>Source</button>
 									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {nodeColorMode === 'none' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (nodeColorMode = "none")}>None</button>
-								</div>
-								<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {nodeColorMode === 'none' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (nodeColorMode = "none")}>None</button>
-							</div>
-						</div>
-						<div class="border border-[var(--sig-border)] px-2 py-2 space-y-1.5">
-							<div class="font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] text-[var(--sig-text-muted)]">Overlays</div>
-							<div class="flex flex-wrap gap-1">
-								<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {showNewSinceLastSeen && nodeColorMode !== 'none' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (showNewSinceLastSeen = !showNewSinceLastSeen)}>New since last seen</button>
 								</div>
 							</div>
 							<div class="border border-[var(--sig-border)] px-2 py-2 space-y-1.5">

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -1293,7 +1293,7 @@ $effect(() => {
 		// Ignore sessionStorage write failures and keep in-memory state.
 	}
 	try {
-		if (showNewSinceLastSeen) {
+		if (showNewSinceLastSeen && nodeColorMode !== "none") {
 			window.sessionStorage.setItem(NEW_SINCE_SESSION_STORAGE_KEY, "true");
 		} else {
 			window.sessionStorage.removeItem(NEW_SINCE_SESSION_STORAGE_KEY);

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -1280,11 +1280,15 @@ $effect(() => {
 		} else {
 			window.sessionStorage.setItem(NODE_COLOR_MODE_SESSION_STORAGE_KEY, nodeColorMode);
 		}
+	} catch {
+		// Ignore sessionStorage write failures and keep in-memory state.
+	}
+	try {
 		if (lastSeenWriteMs !== null) {
 			window.localStorage.setItem(LAST_SEEN_STORAGE_KEY, String(lastSeenWriteMs));
 		}
 	} catch {
-		// Ignore storage write failures and keep in-memory state.
+		// Ignore localStorage write failures and keep in-memory state.
 	}
 });
 

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -1848,7 +1848,7 @@ $effect(() => {
 						<div class="border border-[var(--sig-border)] px-2 py-2 space-y-1.5">
 							<div class="font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] text-[var(--sig-text-muted)]">Overlays</div>
 							<div class="flex flex-wrap gap-1">
-								<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {showNewSinceLastSeen ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (showNewSinceLastSeen = !showNewSinceLastSeen)}>New since last seen</button>
+								<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {showNewSinceLastSeen && nodeColorMode !== 'none' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (showNewSinceLastSeen = !showNewSinceLastSeen)}>New since last seen</button>
 								</div>
 							</div>
 							<div class="border border-[var(--sig-border)] px-2 py-2 space-y-1.5">

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -1260,13 +1260,16 @@ $effect(() => {
 			const parsed = Number.parseInt(rawLastSeen, 10);
 			if (!Number.isNaN(parsed)) lastSeenMs = parsed;
 		}
+	} catch {
+		// Ignore storage read failures and keep in-memory defaults.
+	}
+	try {
 		window.localStorage.removeItem(LEGACY_NODE_COLOR_MODE_STORAGE_KEY);
 		window.localStorage.removeItem(LEGACY_NEW_SINCE_STORAGE_KEY);
 	} catch {
-		// Ignore storage read failures and keep in-memory defaults.
-	} finally {
-		viewSettingsHydrated = true;
+		// Ignore storage cleanup failures.
 	}
+	viewSettingsHydrated = true;
 });
 
 $effect(() => {
@@ -1851,7 +1854,7 @@ $effect(() => {
 							<div class="border border-[var(--sig-border)] px-2 py-2 space-y-1.5">
 								<div class="font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] text-[var(--sig-text-muted)]">Overlays</div>
 								<div class="flex flex-wrap gap-1">
-									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {showNewSinceLastSeen && nodeColorMode !== 'none' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (showNewSinceLastSeen = !showNewSinceLastSeen)}>New since last seen</button>
+									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {showNewSinceLastSeen ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'} {nodeColorMode === 'none' ? 'opacity-60 cursor-not-allowed' : ''}" onclick={() => (showNewSinceLastSeen = !showNewSinceLastSeen)} disabled={nodeColorMode === "none"}>New since last seen</button>
 								</div>
 							</div>
 							<div class="border border-[var(--sig-border)] px-2 py-2 space-y-1.5">

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -1841,7 +1841,13 @@ $effect(() => {
 								<div class="flex flex-wrap gap-1">
 									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {nodeColorMode === 'newness' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (nodeColorMode = "newness")}>Newness</button>
 									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {nodeColorMode === 'source' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (nodeColorMode = "source")}>Source</button>
-									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {nodeColorMode === 'none' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (nodeColorMode = "none")}>None</button>
+								<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {nodeColorMode === 'none' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (nodeColorMode = "none")}>None</button>
+							</div>
+						</div>
+						<div class="border border-[var(--sig-border)] px-2 py-2 space-y-1.5">
+							<div class="font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] text-[var(--sig-text-muted)]">Overlays</div>
+							<div class="flex flex-wrap gap-1">
+								<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {showNewSinceLastSeen ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (showNewSinceLastSeen = !showNewSinceLastSeen)}>New since last seen</button>
 								</div>
 							</div>
 							<div class="border border-[var(--sig-border)] px-2 py-2 space-y-1.5">

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -1865,7 +1865,15 @@ $effect(() => {
 								<div class="flex flex-wrap gap-1">
 									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {nodeColorMode === 'newness' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (nodeColorMode = "newness")}>Newness</button>
 									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {nodeColorMode === 'source' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (nodeColorMode = "source")}>Source</button>
-									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {nodeColorMode === 'none' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (nodeColorMode = "none")}>None</button>
+									<button
+										class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {nodeColorMode === 'none' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}"
+										onclick={() => {
+											nodeColorMode = "none";
+											showNewSinceLastSeen = false;
+										}}
+									>
+										None
+									</button>
 								</div>
 							</div>
 							<div class="border border-[var(--sig-border)] px-2 py-2 space-y-1.5">

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -103,6 +103,8 @@ const LEGEND_PRIORITY_SOURCES = ["daemon", "user", "opencode"] as const;
 const LEGEND_PRIORITY_SOURCE_SET = new Set<string>(LEGEND_PRIORITY_SOURCES);
 
 const NODE_COLOR_MODE_SESSION_STORAGE_KEY = "signet-constellation-color-mode-session";
+const LEGACY_NODE_COLOR_MODE_STORAGE_KEY = "signet-constellation-color-mode";
+const LEGACY_NEW_SINCE_STORAGE_KEY = "signet-constellation-new-since";
 const LAST_SEEN_STORAGE_KEY = "signet-constellation-last-seen";
 
 type TimeFilterPreset = "all" | "24h" | "7d" | "30d" | "90d" | "custom";
@@ -1258,6 +1260,8 @@ $effect(() => {
 			const parsed = Number.parseInt(rawLastSeen, 10);
 			if (!Number.isNaN(parsed)) lastSeenMs = parsed;
 		}
+		window.localStorage.removeItem(LEGACY_NODE_COLOR_MODE_STORAGE_KEY);
+		window.localStorage.removeItem(LEGACY_NEW_SINCE_STORAGE_KEY);
 	} catch {
 		// Ignore storage read failures and keep in-memory defaults.
 	} finally {
@@ -1849,6 +1853,12 @@ $effect(() => {
 							<div class="font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] text-[var(--sig-text-muted)]">Overlays</div>
 							<div class="flex flex-wrap gap-1">
 								<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {showNewSinceLastSeen && nodeColorMode !== 'none' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (showNewSinceLastSeen = !showNewSinceLastSeen)}>New since last seen</button>
+								</div>
+							</div>
+							<div class="border border-[var(--sig-border)] px-2 py-2 space-y-1.5">
+								<div class="font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] text-[var(--sig-text-muted)]">Overlays</div>
+								<div class="flex flex-wrap gap-1">
+									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {showNewSinceLastSeen && nodeColorMode !== 'none' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (showNewSinceLastSeen = !showNewSinceLastSeen)}>New since last seen</button>
 								</div>
 							</div>
 							<div class="border border-[var(--sig-border)] px-2 py-2 space-y-1.5">

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -1257,8 +1257,8 @@ $effect(() => {
 		const rawMode = window.sessionStorage.getItem(NODE_COLOR_MODE_SESSION_STORAGE_KEY);
 		if (rawMode === "source" || rawMode === "newness" || rawMode === "none") nodeColorMode = rawMode;
 		const rawNewSince = window.sessionStorage.getItem(NEW_SINCE_SESSION_STORAGE_KEY);
-		if (rawNewSince === "true" || rawNewSince === "false") {
-			showNewSinceLastSeen = rawNewSince === "true";
+		if (rawNewSince === "true") {
+			showNewSinceLastSeen = true;
 		}
 		const rawLastSeen = window.localStorage.getItem(LAST_SEEN_STORAGE_KEY);
 		if (rawLastSeen) {

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -1660,13 +1660,8 @@ $effect(() => {
 							{/each}
 						</div>
 					{:else}
-						<div class="flex flex-wrap gap-1 mb-1.5">
-							{#each legendSourceCounts as source}
-								<span class="h-5 inline-flex items-center gap-1 px-1.5 py-0 font-[family-name:var(--font-mono)] text-[10px] border border-[rgba(255,255,255,0.14)] {selectedSources.size === 0 || selectedSources.has(source.who) ? 'bg-[rgba(255,255,255,0.08)] text-[var(--sig-text-bright)]' : 'bg-transparent text-[var(--sig-text-muted)]'}">
-									<span class="inline-block w-[6px] h-[6px] rounded-full bg-[rgba(210,210,210,0.85)]"></span>
-									{source.who} {source.count}
-								</span>
-							{/each}
+						<div class="text-[10px] text-[var(--sig-text-muted)] leading-[1.35] mb-1.5">
+							No source colors in none mode.
 						</div>
 					{/if}
 					<div class="text-[10px] text-[var(--sig-text-muted)] leading-[1.35] mb-1">

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -1260,13 +1260,17 @@ $effect(() => {
 		if (rawNewSince === "true") {
 			showNewSinceLastSeen = true;
 		}
+	} catch {
+		// Ignore sessionStorage read failures and keep in-memory defaults.
+	}
+	try {
 		const rawLastSeen = window.localStorage.getItem(LAST_SEEN_STORAGE_KEY);
 		if (rawLastSeen) {
 			const parsed = Number.parseInt(rawLastSeen, 10);
 			if (!Number.isNaN(parsed)) lastSeenMs = parsed;
 		}
 	} catch {
-		// Ignore storage read failures and keep in-memory defaults.
+		// Ignore localStorage read failures and keep in-memory defaults.
 	}
 	try {
 		window.localStorage.removeItem(LEGACY_NODE_COLOR_MODE_STORAGE_KEY);

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -103,6 +103,7 @@ const LEGEND_PRIORITY_SOURCES = ["daemon", "user", "opencode"] as const;
 const LEGEND_PRIORITY_SOURCE_SET = new Set<string>(LEGEND_PRIORITY_SOURCES);
 
 const NODE_COLOR_MODE_SESSION_STORAGE_KEY = "signet-constellation-color-mode-session";
+const NEW_SINCE_SESSION_STORAGE_KEY = "signet-constellation-new-since-session";
 const LEGACY_NODE_COLOR_MODE_STORAGE_KEY = "signet-constellation-color-mode";
 const LEGACY_NEW_SINCE_STORAGE_KEY = "signet-constellation-new-since";
 const LAST_SEEN_STORAGE_KEY = "signet-constellation-last-seen";
@@ -1255,6 +1256,10 @@ $effect(() => {
 	try {
 		const rawMode = window.sessionStorage.getItem(NODE_COLOR_MODE_SESSION_STORAGE_KEY);
 		if (rawMode === "source" || rawMode === "newness" || rawMode === "none") nodeColorMode = rawMode;
+		const rawNewSince = window.sessionStorage.getItem(NEW_SINCE_SESSION_STORAGE_KEY);
+		if (rawNewSince === "true" || rawNewSince === "false") {
+			showNewSinceLastSeen = rawNewSince === "true";
+		}
 		const rawLastSeen = window.localStorage.getItem(LAST_SEEN_STORAGE_KEY);
 		if (rawLastSeen) {
 			const parsed = Number.parseInt(rawLastSeen, 10);
@@ -1279,6 +1284,15 @@ $effect(() => {
 			window.sessionStorage.removeItem(NODE_COLOR_MODE_SESSION_STORAGE_KEY);
 		} else {
 			window.sessionStorage.setItem(NODE_COLOR_MODE_SESSION_STORAGE_KEY, nodeColorMode);
+		}
+	} catch {
+		// Ignore sessionStorage write failures and keep in-memory state.
+	}
+	try {
+		if (showNewSinceLastSeen) {
+			window.sessionStorage.setItem(NEW_SINCE_SESSION_STORAGE_KEY, "true");
+		} else {
+			window.sessionStorage.removeItem(NEW_SINCE_SESSION_STORAGE_KEY);
 		}
 	} catch {
 		// Ignore sessionStorage write failures and keep in-memory state.

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -102,8 +102,7 @@ let sourcesMenuOpen = $state(true);
 const LEGEND_PRIORITY_SOURCES = ["daemon", "user", "opencode"] as const;
 const LEGEND_PRIORITY_SOURCE_SET = new Set<string>(LEGEND_PRIORITY_SOURCES);
 
-const NODE_COLOR_MODE_STORAGE_KEY = "signet-constellation-color-mode";
-const NEW_SINCE_STORAGE_KEY = "signet-constellation-new-since";
+const NODE_COLOR_MODE_SESSION_STORAGE_KEY = "signet-constellation-color-mode-session";
 const LAST_SEEN_STORAGE_KEY = "signet-constellation-last-seen";
 
 type TimeFilterPreset = "all" | "24h" | "7d" | "30d" | "90d" | "custom";
@@ -136,7 +135,7 @@ let activeNeighbors = $state<EmbeddingRelation[]>([]);
 let loadingGlobalSimilar = $state(false);
 let globalSimilar = $state<Memory[]>([]);
 
-let nodeColorMode = $state<NodeColorMode>("newness");
+let nodeColorMode = $state<NodeColorMode>("source");
 let showNewSinceLastSeen = $state(false);
 let lastSeenMs = $state<number | null>(null);
 let lastSeenWriteMs = $state<number | null>(null);
@@ -1252,17 +1251,15 @@ $effect(() => {
 $effect(() => {
 	if (typeof window === "undefined" || viewSettingsHydrated) return;
 	try {
-		const rawMode = window.localStorage.getItem(NODE_COLOR_MODE_STORAGE_KEY);
-		if (rawMode === "source" || rawMode === "newness") nodeColorMode = rawMode;
-		const rawNewSince = window.localStorage.getItem(NEW_SINCE_STORAGE_KEY);
-		if (rawNewSince === "true" || rawNewSince === "false") {
-			showNewSinceLastSeen = rawNewSince === "true";
-		}
+		const rawMode = window.sessionStorage.getItem(NODE_COLOR_MODE_SESSION_STORAGE_KEY);
+		if (rawMode === "source" || rawMode === "newness" || rawMode === "none") nodeColorMode = rawMode;
 		const rawLastSeen = window.localStorage.getItem(LAST_SEEN_STORAGE_KEY);
 		if (rawLastSeen) {
 			const parsed = Number.parseInt(rawLastSeen, 10);
 			if (!Number.isNaN(parsed)) lastSeenMs = parsed;
 		}
+	} catch {
+		// Ignore storage read failures and keep in-memory defaults.
 	} finally {
 		viewSettingsHydrated = true;
 	}
@@ -1270,10 +1267,17 @@ $effect(() => {
 
 $effect(() => {
 	if (typeof window === "undefined" || !viewSettingsHydrated) return;
-	window.localStorage.setItem(NODE_COLOR_MODE_STORAGE_KEY, nodeColorMode);
-	window.localStorage.setItem(NEW_SINCE_STORAGE_KEY, String(showNewSinceLastSeen));
-	if (lastSeenWriteMs !== null) {
-		window.localStorage.setItem(LAST_SEEN_STORAGE_KEY, String(lastSeenWriteMs));
+	try {
+		if (nodeColorMode === "source") {
+			window.sessionStorage.removeItem(NODE_COLOR_MODE_SESSION_STORAGE_KEY);
+		} else {
+			window.sessionStorage.setItem(NODE_COLOR_MODE_SESSION_STORAGE_KEY, nodeColorMode);
+		}
+		if (lastSeenWriteMs !== null) {
+			window.localStorage.setItem(LAST_SEEN_STORAGE_KEY, String(lastSeenWriteMs));
+		}
+	} catch {
+		// Ignore storage write failures and keep in-memory state.
 	}
 });
 
@@ -1605,7 +1609,7 @@ $effect(() => {
 				<div class="pointer-events-auto border border-[rgba(255,255,255,0.2)] bg-[rgba(5,5,5,0.72)] px-2 py-1.5">
 					<div class="text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.06em] text-[var(--sig-text-muted)] mb-1">Legend</div>
 					<div class="text-[10px] text-[var(--sig-text-muted)] leading-[1.35] mb-1">
-						<span class="text-[var(--sig-text)]">Color</span> = {nodeColorMode === "newness" ? "newness" : "source"}
+						<span class="text-[var(--sig-text)]">Color</span> = {nodeColorMode}
 					</div>
 					{#if nodeColorMode === "newness"}
 						<div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-[var(--sig-text-muted)] mb-1.5">
@@ -1621,11 +1625,20 @@ $effect(() => {
 								</span>
 							{/each}
 						</div>
-					{:else}
+					{:else if nodeColorMode === "source"}
 						<div class="flex flex-wrap gap-1 mb-1.5">
 							{#each legendSourceCounts as source}
 								<span class="h-5 inline-flex items-center gap-1 px-1.5 py-0 font-[family-name:var(--font-mono)] text-[10px] border border-[rgba(255,255,255,0.14)] {selectedSources.size === 0 || selectedSources.has(source.who) ? 'bg-[rgba(255,255,255,0.08)] text-[var(--sig-text-bright)]' : 'bg-transparent text-[var(--sig-text-muted)]'}">
 									<span class="inline-block w-[6px] h-[6px] rounded-full" style={`background:${sourceColorRgba(source.who, 1)}`}></span>
+									{source.who} {source.count}
+								</span>
+							{/each}
+						</div>
+					{:else}
+						<div class="flex flex-wrap gap-1 mb-1.5">
+							{#each legendSourceCounts as source}
+								<span class="h-5 inline-flex items-center gap-1 px-1.5 py-0 font-[family-name:var(--font-mono)] text-[10px] border border-[rgba(255,255,255,0.14)] {selectedSources.size === 0 || selectedSources.has(source.who) ? 'bg-[rgba(255,255,255,0.08)] text-[var(--sig-text-bright)]' : 'bg-transparent text-[var(--sig-text-muted)]'}">
+									<span class="inline-block w-[6px] h-[6px] rounded-full bg-[rgba(210,210,210,0.85)]"></span>
 									{source.who} {source.count}
 								</span>
 							{/each}
@@ -1640,7 +1653,7 @@ $effect(() => {
 						<span class="inline-block w-[12px] h-[12px] rounded-full border border-[rgba(255,255,255,0.32)]"></span>
 						<span>low to high</span>
 					</div>
-					{#if showNewSinceLastSeen}
+					{#if showNewSinceLastSeen && nodeColorMode !== "none"}
 						<div class="text-[10px] text-[var(--sig-text-muted)] leading-[1.35] mb-1">
 							<span class="text-[var(--sig-text)]">Outline</span> = new since last seen
 						</div>
@@ -1828,7 +1841,7 @@ $effect(() => {
 								<div class="flex flex-wrap gap-1">
 									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {nodeColorMode === 'newness' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (nodeColorMode = "newness")}>Newness</button>
 									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {nodeColorMode === 'source' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (nodeColorMode = "source")}>Source</button>
-									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {showNewSinceLastSeen ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (showNewSinceLastSeen = !showNewSinceLastSeen)}>New since last seen</button>
+									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {nodeColorMode === 'none' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (nodeColorMode = "none")}>None</button>
 								</div>
 							</div>
 							<div class="border border-[var(--sig-border)] px-2 py-2 space-y-1.5">

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -1634,7 +1634,7 @@ $effect(() => {
 				<div class="pointer-events-auto border border-[rgba(255,255,255,0.2)] bg-[rgba(5,5,5,0.72)] px-2 py-1.5">
 					<div class="text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.06em] text-[var(--sig-text-muted)] mb-1">Legend</div>
 					<div class="text-[10px] text-[var(--sig-text-muted)] leading-[1.35] mb-1">
-						<span class="text-[var(--sig-text)]">Color</span> = {nodeColorMode}
+						<span class="text-[var(--sig-text)]">Color</span> = {nodeColorMode === "none" ? "off" : nodeColorMode === "newness" ? "by recency" : "by source"}
 					</div>
 					{#if nodeColorMode === "newness"}
 						<div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-[var(--sig-text-muted)] mb-1.5">

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -1840,7 +1840,8 @@ $effect(() => {
 								<div class="font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.08em] text-[var(--sig-text-muted)]">Color Mode</div>
 								<div class="flex flex-wrap gap-1">
 									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {nodeColorMode === 'newness' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (nodeColorMode = "newness")}>Newness</button>
-									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {nodeColorMode === 'source' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (nodeColorMode = "source")}>Source</button>
+									<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {nodeColorMode === 'none' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (nodeColorMode = "none")}>None</button>
+								</div>
 								<button class="px-2 py-[2px] font-[family-name:var(--font-mono)] text-[10px] uppercase border border-[var(--sig-border-strong)] {nodeColorMode === 'none' ? 'text-[var(--sig-text-bright)] bg-[var(--sig-surface-raised)]' : 'text-[var(--sig-text-muted)] bg-transparent'}" onclick={() => (nodeColorMode = "none")}>None</button>
 							</div>
 						</div>

--- a/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/EmbeddingsTab.svelte
@@ -1661,7 +1661,7 @@ $effect(() => {
 						</div>
 					{:else}
 						<div class="text-[10px] text-[var(--sig-text-muted)] leading-[1.35] mb-1.5">
-							No source colors in none mode.
+							No color applied - all nodes are shown in gray.
 						</div>
 					{/if}
 					<div class="text-[10px] text-[var(--sig-text-muted)] leading-[1.35] mb-1">


### PR DESCRIPTION
## Summary
- add explicit constellation color modes (`Newness`, `Source`, `None`) and default to `Source` to avoid auto-enabling expensive heatmap rendering on large memory sets
- make color mode session-scoped via `sessionStorage` instead of persisted settings/localStorage so the choice only lasts for the active browser session
- add a neutral no-color rendering path for both 2D and 3D graphs, including relation highlights, and suppress `new since last seen` outline in `None` mode
- update source-mode palette to improve source distinguishability: `openclaw`/`openclaw-memory` now use yellow and `user` now uses red

## How
- update `EmbeddingsTab.svelte` to read/write `signet-constellation-color-mode-session` in `sessionStorage` with safe storage fallbacks (`try/catch`)
- remove durable persistence of color mode and `new since` preference from localStorage for this control path
- extend `NodeColorMode` in `embedding-graph.ts` to include `none`, and branch fill/color logic to return grayscale colors for normal nodes and relation-highlighted nodes
- gate 2D outline rendering in `EmbeddingCanvas2D.svelte` so it does not draw when color mode is `none`
- refresh `sourceColors` mappings in `embedding-graph.ts` for `openclaw`, `openclaw-memory`, and `user`

## Why
With very large memory sets, heatmap/newness coloring can increase load/render cost and cause edge-case delays. This keeps the graph safe by default, gives users explicit control when they want heatmap semantics, and avoids sticky cross-session surprises.

The source-palette update keeps key producers visually distinct in source mode and aligns OpenClaw-ingested rows (`openclaw-memory`) with the OpenClaw color family.

## Validation
- `bun run check` (dashboard)
- `bun run build` (dashboard)