### PR TITLE
feat(timeline): add signet evolution timeline recap view

### DIFF
--- a/packages/cli/dashboard/src/lib/api.ts
+++ b/packages/cli/dashboard/src/lib/api.ts
@@ -49,7 +49,6 @@ export interface MemoryTimelineBucket {
 	typeBreakdown: TimelineMetric[];
 	sourceBreakdown: TimelineMetric[];
 	topTags: TimelineMetric[];
-	summary: string;
 }
 
 export interface MemoryTimelineResponse {
@@ -295,7 +294,10 @@ function buildTimelineFallback(memories: readonly Memory[]): MemoryTimelineRespo
 
 		let tags: string[] = [];
 		if (Array.isArray(memory.tags)) {
-			tags = memory.tags;
+			tags = memory.tags
+				.filter((tag): tag is string => typeof tag === "string")
+				.map((tag) => tag.trim())
+				.filter((tag) => tag.length > 0);
 		} else if (typeof memory.tags === "string") {
 			const trimmed = memory.tags.trim();
 			if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
@@ -362,14 +364,14 @@ function buildTimelineFallback(memories: readonly Memory[]): MemoryTimelineRespo
 			recovered: 0,
 			avgImportance:
 				bucket.importanceCount > 0
-					? Number((bucket.importanceSum / bucket.importanceCount).toFixed(3))
+					? Number(
+							Math.min(1, Math.max(0, bucket.importanceSum / bucket.importanceCount)).toFixed(3),
+						)
 					: 0,
 			pinned: bucket.pinned,
 			typeBreakdown: toMetrics(bucket.typeMap),
 			sourceBreakdown: toMetrics(bucket.sourceMap),
 			topTags: toMetrics(bucket.tagMap),
-			summary:
-				`${bucket.memoriesAdded} added. Fallback timeline from memory index only.`,
 		})),
 	};
 }

--- a/packages/cli/dashboard/src/lib/api.ts
+++ b/packages/cli/dashboard/src/lib/api.ts
@@ -28,6 +28,42 @@ export interface MemoryStats {
 	critical: number;
 }
 
+export interface TimelineMetric {
+	key: string;
+	count: number;
+}
+
+export interface MemoryTimelineBucket {
+	eraIndex: number;
+	rangeKey: "today" | "last_week" | "one_month";
+	label: string;
+	start: string;
+	end: string;
+	memoriesAdded: number;
+	trackedEvents: number;
+	evolved: number;
+	strengthened: number;
+	recovered: number;
+	avgImportance: number;
+	pinned: number;
+	typeBreakdown: TimelineMetric[];
+	sourceBreakdown: TimelineMetric[];
+	topTags: TimelineMetric[];
+	summary: string;
+}
+
+export interface MemoryTimelineResponse {
+	generatedAt: string;
+	generatedFor: string;
+	rangePreset: "today-last_week-one_month";
+	totalMemories: number;
+	totalHistoryEvents: number;
+	invalidMemoryTimestamps: number;
+	invalidHistoryTimestamps: number;
+	buckets: MemoryTimelineBucket[];
+	error?: string;
+}
+
 export interface ConfigFile {
 	name: string;
 	content: string;
@@ -195,6 +231,168 @@ export async function getMemories(limit = 100, offset = 0): Promise<{ memories: 
 		return {
 			memories: [],
 			stats: { total: 0, withEmbeddings: 0, critical: 0 },
+		};
+	}
+}
+
+function buildTimelineFallback(memories: readonly Memory[]): MemoryTimelineResponse {
+	const now = new Date();
+	const nowStart = Date.UTC(
+		now.getUTCFullYear(),
+		now.getUTCMonth(),
+		now.getUTCDate(),
+	);
+
+	const ranges = [
+		{ eraIndex: 0 as const, rangeKey: "today" as const, label: "Today" as const, startDaysAgo: 0, endDaysAgo: 0 },
+		{
+			eraIndex: 1 as const,
+			rangeKey: "last_week" as const,
+			label: "Last week" as const,
+			startDaysAgo: 0,
+			endDaysAgo: 6,
+		},
+		{
+			eraIndex: 2 as const,
+			rangeKey: "one_month" as const,
+			label: "One month" as const,
+			startDaysAgo: 0,
+			endDaysAgo: 29,
+		},
+	];
+
+	const buckets = ranges.map((range) => {
+		const start =
+			range.startDaysAgo === 0
+				? nowStart
+				: nowStart - range.endDaysAgo * 24 * 60 * 60 * 1000;
+		const end =
+			range.startDaysAgo === 0
+				? nowStart + 24 * 60 * 60 * 1000 - 1
+				: nowStart - (range.startDaysAgo - 1) * 24 * 60 * 60 * 1000 - 1;
+		return {
+			range,
+			start,
+			end,
+			memoriesAdded: 0,
+			importanceSum: 0,
+			importanceCount: 0,
+			pinned: 0,
+			typeMap: new Map<string, number>(),
+			sourceMap: new Map<string, number>(),
+			tagMap: new Map<string, number>(),
+		};
+	});
+
+	for (const memory of memories) {
+		const ts = Date.parse(memory.created_at);
+		if (!Number.isFinite(ts)) continue;
+		const matchingBuckets = buckets.filter(
+			(entry) => ts >= entry.start && ts <= entry.end,
+		);
+		if (matchingBuckets.length === 0) continue;
+
+		for (const bucket of matchingBuckets) {
+			bucket.memoriesAdded += 1;
+			if (memory.pinned) bucket.pinned += 1;
+			if (
+				typeof memory.importance === "number" &&
+				Number.isFinite(memory.importance)
+			) {
+				bucket.importanceSum += memory.importance;
+				bucket.importanceCount += 1;
+			}
+
+			const typeKey = memory.type?.trim() || "unknown";
+			bucket.typeMap.set(typeKey, (bucket.typeMap.get(typeKey) ?? 0) + 1);
+
+			const whoKey = memory.who?.trim() || "unknown";
+			bucket.sourceMap.set(whoKey, (bucket.sourceMap.get(whoKey) ?? 0) + 1);
+		}
+
+		let tags: string[] = [];
+		if (Array.isArray(memory.tags)) {
+			tags = memory.tags;
+		} else if (typeof memory.tags === "string") {
+			const trimmed = memory.tags.trim();
+			if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+				try {
+					const parsed = JSON.parse(trimmed);
+					if (Array.isArray(parsed)) {
+						tags = parsed
+							.filter((tag) => typeof tag === "string")
+							.map((tag) => tag.trim())
+							.filter((tag) => tag.length > 0);
+					}
+				} catch {
+					tags = [];
+				}
+			} else {
+				tags = trimmed
+					.split(",")
+					.map((tag) => tag.trim())
+					.filter((tag) => tag.length > 0);
+			}
+		}
+		for (const bucket of matchingBuckets) {
+			for (const tag of tags) {
+				bucket.tagMap.set(tag, (bucket.tagMap.get(tag) ?? 0) + 1);
+			}
+		}
+	}
+
+	const toMetrics = (map: Map<string, number>): TimelineMetric[] =>
+		[...map.entries()]
+			.sort((a, b) => {
+				if (b[1] !== a[1]) return b[1] - a[1];
+				return a[0].localeCompare(b[0]);
+			})
+			.slice(0, 5)
+			.map(([key, count]) => ({ key, count }));
+
+	return {
+		generatedAt: new Date().toISOString(),
+		generatedFor: new Date(nowStart).toISOString(),
+		rangePreset: "today-last_week-one_month",
+		totalMemories: memories.length,
+		totalHistoryEvents: 0,
+		invalidMemoryTimestamps: 0,
+		invalidHistoryTimestamps: 0,
+		buckets: buckets.map((bucket) => ({
+			eraIndex: bucket.range.eraIndex,
+			rangeKey: bucket.range.rangeKey,
+			label: bucket.range.label,
+			start: new Date(bucket.start).toISOString(),
+			end: new Date(bucket.end).toISOString(),
+			memoriesAdded: bucket.memoriesAdded,
+			trackedEvents: 0,
+			evolved: 0,
+			strengthened: 0,
+			recovered: 0,
+			avgImportance:
+				bucket.importanceCount > 0
+					? Number((bucket.importanceSum / bucket.importanceCount).toFixed(3))
+					: 0,
+			pinned: bucket.pinned,
+			typeBreakdown: toMetrics(bucket.typeMap),
+			sourceBreakdown: toMetrics(bucket.sourceMap),
+			topTags: toMetrics(bucket.tagMap),
+			summary:
+				`${bucket.memoriesAdded} added. Fallback timeline from memory index only.`,
+		})),
+	};
+}
+
+export async function getMemoryTimeline(): Promise<MemoryTimelineResponse> {
+	try {
+		const response = await fetch(`${API_BASE}/api/memory/timeline`);
+		if (!response.ok) throw new Error("Failed to fetch memory timeline");
+		return await response.json();
+	} catch {
+		const fallback = await getMemories(5000, 0);
+		return {
+			...buildTimelineFallback(fallback.memories),
+			error: "Timeline API unavailable. Showing memory-index fallback.",
 		};
 	}
 }

--- a/packages/cli/dashboard/src/lib/api.ts
+++ b/packages/cli/dashboard/src/lib/api.ts
@@ -308,6 +308,12 @@ function buildTimelineFallback(memories: readonly Memory[]): MemoryTimelineRespo
 							.filter((tag) => typeof tag === "string")
 							.map((tag) => tag.trim())
 							.filter((tag) => tag.length > 0);
+					} else {
+						// JSON parsed but not an array — fall through to CSV
+						tags = trimmed
+							.split(",")
+							.map((tag) => tag.trim())
+							.filter((tag) => tag.length > 0);
 					}
 				} catch {
 					// Fall through to CSV parsing on JSON parse error

--- a/packages/cli/dashboard/src/lib/api.ts
+++ b/packages/cli/dashboard/src/lib/api.ts
@@ -236,6 +236,7 @@ export async function getMemories(limit = 100, offset = 0): Promise<{ memories: 
 }
 
 function buildTimelineFallback(memories: readonly Memory[]): MemoryTimelineResponse {
+	const MS_PER_DAY = 24 * 60 * 60 * 1000;
 	const now = new Date();
 	const nowStart = Date.UTC(
 		now.getUTCFullYear(),
@@ -244,32 +245,14 @@ function buildTimelineFallback(memories: readonly Memory[]): MemoryTimelineRespo
 	);
 
 	const ranges = [
-		{ eraIndex: 0 as const, rangeKey: "today" as const, label: "Today" as const, startDaysAgo: 0, endDaysAgo: 0 },
-		{
-			eraIndex: 1 as const,
-			rangeKey: "last_week" as const,
-			label: "Last week" as const,
-			startDaysAgo: 0,
-			endDaysAgo: 6,
-		},
-		{
-			eraIndex: 2 as const,
-			rangeKey: "one_month" as const,
-			label: "One month" as const,
-			startDaysAgo: 0,
-			endDaysAgo: 29,
-		},
+		{ eraIndex: 0 as const, rangeKey: "today" as const, label: "Today" as const, lookbackDays: 1 },
+		{ eraIndex: 1 as const, rangeKey: "last_week" as const, label: "Last week" as const, lookbackDays: 7 },
+		{ eraIndex: 2 as const, rangeKey: "one_month" as const, label: "One month" as const, lookbackDays: 30 },
 	];
 
 	const buckets = ranges.map((range) => {
-		const start =
-			range.startDaysAgo === 0
-				? nowStart
-				: nowStart - range.endDaysAgo * 24 * 60 * 60 * 1000;
-		const end =
-			range.startDaysAgo === 0
-				? nowStart + 24 * 60 * 60 * 1000 - 1
-				: nowStart - (range.startDaysAgo - 1) * 24 * 60 * 60 * 1000 - 1;
+		const start = nowStart - (range.lookbackDays - 1) * MS_PER_DAY;
+		const end = nowStart + MS_PER_DAY - 1;
 		return {
 			range,
 			start,
@@ -325,7 +308,11 @@ function buildTimelineFallback(memories: readonly Memory[]): MemoryTimelineRespo
 							.filter((tag) => tag.length > 0);
 					}
 				} catch {
-					tags = [];
+					// Fall through to CSV parsing on JSON parse error
+					tags = trimmed
+						.split(",")
+						.map((tag) => tag.trim())
+						.filter((tag) => tag.length > 0);
 				}
 			} else {
 				tags = trimmed
@@ -350,11 +337,15 @@ function buildTimelineFallback(memories: readonly Memory[]): MemoryTimelineRespo
 			.slice(0, 5)
 			.map(([key, count]) => ({ key, count }));
 
+	// Use the widest bucket (30-day) count to match daemon semantics
+	const widestBucket = buckets[buckets.length - 1];
+	const totalInWindow = widestBucket?.memoriesAdded ?? 0;
+
 	return {
 		generatedAt: new Date().toISOString(),
 		generatedFor: new Date(nowStart).toISOString(),
 		rangePreset: "today-last_week-one_month",
-		totalMemories: memories.length,
+		totalMemories: totalInWindow,
 		totalHistoryEvents: 0,
 		invalidMemoryTimestamps: 0,
 		invalidHistoryTimestamps: 0,
@@ -383,15 +374,34 @@ function buildTimelineFallback(memories: readonly Memory[]): MemoryTimelineRespo
 	};
 }
 
-export async function getMemoryTimeline(): Promise<MemoryTimelineResponse> {
+export async function getMemoryTimeline(options?: {
+	readonly fallbackMemories?: readonly Memory[] | Promise<readonly Memory[]>;
+}): Promise<MemoryTimelineResponse> {
 	try {
-		const response = await fetch(`${API_BASE}/api/memory/timeline`);
+		const controller = new AbortController();
+		const timeoutId = setTimeout(() => controller.abort(), 10_000);
+		let response: Response;
+		try {
+			response = await fetch(`${API_BASE}/api/memory/timeline`, {
+				signal: controller.signal,
+			});
+		} finally {
+			clearTimeout(timeoutId);
+		}
 		if (!response.ok) throw new Error("Failed to fetch memory timeline");
 		return await response.json();
 	} catch {
-		const fallback = await getMemories(5000, 0);
+		let fallbackMemories: readonly Memory[];
+		try {
+			fallbackMemories = options?.fallbackMemories
+				? await options.fallbackMemories
+				: (await getMemories(5000, 0)).memories;
+		} catch {
+			// If fallback also fails, return an empty timeline
+			fallbackMemories = [];
+		}
 		return {
-			...buildTimelineFallback(fallback.memories),
+			...buildTimelineFallback(fallbackMemories),
 			error: "Timeline API unavailable. Showing memory-index fallback.",
 		};
 	}

--- a/packages/cli/dashboard/src/lib/components/layout/page-headers.ts
+++ b/packages/cli/dashboard/src/lib/components/layout/page-headers.ts
@@ -16,6 +16,10 @@ export const PAGE_HEADERS = {
 		title: "Memory",
 		eyebrow: "Persistent memory index",
 	},
+	timeline: {
+		title: "Memory",
+		eyebrow: "Era evolution timeline",
+	},
 	embeddings: {
 		title: "Memory",
 		eyebrow: "Semantic projection workspace",

--- a/packages/cli/dashboard/src/lib/components/tabs/TimelineTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/TimelineTab.svelte
@@ -218,17 +218,62 @@ function buildBucketTopMemories(
 	bucketsInput: readonly MemoryTimelineBucket[],
 	memories: readonly Memory[],
 ): Record<string, Memory[]> {
+	const parsedRangeBounds = new Map<
+		MemoryTimelineBucket["rangeKey"],
+		{ startMs: number; endMs: number }
+	>();
+	for (const bucket of bucketsInput) {
+		const startMs = Date.parse(bucket.start);
+		const endMs = Date.parse(bucket.end);
+		if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) continue;
+		parsedRangeBounds.set(bucket.rangeKey, { startMs, endMs });
+	}
+
+	const todayRange = parsedRangeBounds.get("today") ?? null;
+	const lastWeekRange = parsedRangeBounds.get("last_week") ?? null;
+
+	function getSelectionWindow(
+		bucket: MemoryTimelineBucket,
+	): { startMs: number; endMs: number } {
+		const parsed = parsedRangeBounds.get(bucket.rangeKey);
+		const fallbackStartMs = Date.parse(bucket.start);
+		const fallbackEndMs = Date.parse(bucket.end);
+		const fallback = {
+			startMs: Number.isFinite(fallbackStartMs) ? fallbackStartMs : Number.NEGATIVE_INFINITY,
+			endMs: Number.isFinite(fallbackEndMs) ? fallbackEndMs : Number.POSITIVE_INFINITY,
+		};
+		if (!parsed) return fallback;
+
+		let startMs = parsed.startMs;
+		let endMs = parsed.endMs;
+		if (bucket.rangeKey === "last_week" && todayRange) {
+			endMs = Math.min(endMs, todayRange.startMs - 1);
+		} else if (bucket.rangeKey === "one_month") {
+			if (lastWeekRange) {
+				endMs = Math.min(endMs, lastWeekRange.startMs - 1);
+			} else if (todayRange) {
+				endMs = Math.min(endMs, todayRange.startMs - 1);
+			}
+		}
+
+		if (endMs < startMs) return fallback;
+		return { startMs, endMs };
+	}
+
 	const bucketEntries: Array<{
 		bucket: MemoryTimelineBucket;
 		startMs: number;
 		endMs: number;
 		candidates: Array<{ memory: Memory; score: number; createdAt: number }>;
-	}> = bucketsInput.map((bucket) => ({
-		bucket,
-		startMs: Date.parse(bucket.start),
-		endMs: Date.parse(bucket.end),
-		candidates: [],
-	}));
+	}> = bucketsInput.map((bucket) => {
+		const window = getSelectionWindow(bucket);
+		return {
+			bucket,
+			startMs: window.startMs,
+			endMs: window.endMs,
+			candidates: [],
+		};
+	});
 
 	for (const memory of memories) {
 		const createdAt = Date.parse(memory.created_at);
@@ -357,13 +402,13 @@ function formatMemoryMoment(
 		return date.toLocaleTimeString("en-US", {
 			hour: "numeric",
 			minute: "2-digit",
-			timeZone: "UTC",
 		});
 	}
-	return date.toLocaleDateString("en-US", {
+	return date.toLocaleString("en-US", {
 		month: "short",
 		day: "numeric",
-		timeZone: "UTC",
+		hour: "numeric",
+		minute: "2-digit",
 	});
 }
 

--- a/packages/cli/dashboard/src/lib/components/tabs/TimelineTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/TimelineTab.svelte
@@ -401,6 +401,19 @@ function getRangeChipLabel(bucket: MemoryTimelineBucket): string {
 }
 
 function handleKeydown(event: KeyboardEvent): void {
+	const target = event.target;
+	if (target instanceof HTMLElement) {
+		const tag = target.tagName;
+		if (
+			tag === "INPUT" ||
+			tag === "TEXTAREA" ||
+			tag === "SELECT" ||
+			target.isContentEditable
+		) {
+			return;
+		}
+	}
+
 	if (event.key === "ArrowRight") {
 		event.preventDefault();
 		moveOlder(event.shiftKey ? 3 : 1);
@@ -494,7 +507,7 @@ onMount(() => {
 							<p class="sig-heading timeline-era-title">
 								{activeBucket.label}: <span class="timeline-era-title-range">{formatDateRange(activeBucket.start, activeBucket.end)}</span>
 							</p>
-							<div class="timeline-era-controls" role="tablist" aria-orientation="horizontal">
+							<div class="timeline-era-controls flex items-center gap-1">
 								<Button
 									variant="outline"
 									size="sm"
@@ -506,20 +519,22 @@ onMount(() => {
 									<ChevronLeft class="size-3.5" />
 								</Button>
 
-								{#each buckets as bucket, index (bucket.eraIndex)}
-									<button
-										class={`${railButtonBase} ${index === activeIndex
-											? 'border-[var(--sig-accent)] bg-[color-mix(in_srgb,var(--sig-surface-raised)_76%,transparent)] text-[var(--sig-text-bright)]'
-											: 'border-[var(--sig-border-strong)] text-[var(--sig-text-muted)] hover:text-[var(--sig-text-bright)]'}`}
-										onclick={() => {
-											activeIndex = index;
-										}}
-										role="tab"
-										aria-selected={index === activeIndex}
-									>
-										{getRangeChipLabel(bucket)}
-									</button>
-								{/each}
+								<div role="tablist" aria-orientation="horizontal" class="flex items-center gap-1">
+									{#each buckets as bucket, index (bucket.eraIndex)}
+										<button
+											class={`${railButtonBase} ${index === activeIndex
+												? 'border-[var(--sig-accent)] bg-[color-mix(in_srgb,var(--sig-surface-raised)_76%,transparent)] text-[var(--sig-text-bright)]'
+												: 'border-[var(--sig-border-strong)] text-[var(--sig-text-muted)] hover:text-[var(--sig-text-bright)]'}`}
+											onclick={() => {
+												activeIndex = index;
+											}}
+											role="tab"
+											aria-selected={index === activeIndex}
+										>
+											{getRangeChipLabel(bucket)}
+										</button>
+									{/each}
+								</div>
 
 								<Button
 									variant="outline"

--- a/packages/cli/dashboard/src/lib/components/tabs/TimelineTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/TimelineTab.svelte
@@ -402,6 +402,7 @@ function formatMemoryMoment(
 		return date.toLocaleTimeString("en-US", {
 			hour: "numeric",
 			minute: "2-digit",
+			timeZone: "UTC",
 		});
 	}
 	return date.toLocaleString("en-US", {
@@ -409,6 +410,7 @@ function formatMemoryMoment(
 		day: "numeric",
 		hour: "numeric",
 		minute: "2-digit",
+		timeZone: "UTC",
 	});
 }
 

--- a/packages/cli/dashboard/src/lib/components/tabs/TimelineTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/TimelineTab.svelte
@@ -1,0 +1,979 @@
+<script lang="ts">
+import {
+	getMarketplaceMcpServers,
+	getMemories,
+	getMemoryTimeline,
+	getSkills,
+	type MarketplaceMcpServer,
+	type Memory,
+	type MemoryTimelineBucket,
+	type Skill,
+} from "$lib/api";
+import { Button } from "$lib/components/ui/button/index.js";
+import ChevronLeft from "@lucide/svelte/icons/chevron-left";
+import ChevronRight from "@lucide/svelte/icons/chevron-right";
+import RotateCcw from "@lucide/svelte/icons/rotate-ccw";
+import { onMount } from "svelte";
+
+interface Props {
+	ontimelinegeneratedforchange?: (generatedFor: string) => void;
+}
+
+const { ontimelinegeneratedforchange }: Props = $props();
+
+const railButtonBase =
+	"h-8 px-3 rounded-lg border text-[10px] uppercase tracking-[0.08em] font-[family-name:var(--font-mono)] transition-colors";
+
+const memoryCardIconColors = [
+	"var(--sig-icon-bg-1)",
+	"var(--sig-icon-bg-2)",
+	"var(--sig-icon-bg-3)",
+	"var(--sig-icon-bg-4)",
+	"var(--sig-icon-bg-5)",
+	"var(--sig-icon-bg-6)",
+] as const;
+
+let loading = $state(false);
+let error = $state<string | null>(null);
+let buckets = $state<MemoryTimelineBucket[]>([]);
+let activeIndex = $state(0);
+let bucketSkillUsage = $state<Record<string, number>>({});
+let bucketMcpUsage = $state<Record<string, number>>({});
+let bucketTopMemories = $state<Record<string, Memory[]>>({});
+let rootEl = $state<HTMLDivElement | null>(null);
+
+const activeBucket = $derived(buckets[activeIndex] ?? null);
+const activeSkillsUsed = $derived(
+	activeBucket ? (bucketSkillUsage[activeBucket.rangeKey] ?? 0) : 0,
+);
+
+function inferMcpUsageFromBucket(bucket: MemoryTimelineBucket): number {
+	const sourceSignals = bucket.sourceBreakdown.filter(
+		(metric: { key: string }) =>
+		/\bmcp\b|openclaw-memory|tool server|modelcontextprotocol/i.test(
+			metric.key,
+		),
+	).length;
+	const tagSignals = bucket.topTags.filter(
+		(metric: { key: string }) =>
+		/\bmcp\b|tool-server|model-context-protocol/i.test(metric.key),
+	).length;
+	return sourceSignals + tagSignals;
+}
+
+const activeMcpServersUsed = $derived(
+	activeBucket
+		? Math.max(
+				bucketMcpUsage[activeBucket.rangeKey] ?? 0,
+				inferMcpUsageFromBucket(activeBucket),
+			)
+		: 0,
+);
+
+const activeTopMemories = $derived(
+	activeBucket ? (bucketTopMemories[activeBucket.rangeKey] ?? []) : [],
+);
+
+function escapeRegex(raw: string): string {
+	return raw.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function parseTags(tags: Memory["tags"]): string[] {
+	if (Array.isArray(tags)) {
+		return tags
+			.filter((tag) => typeof tag === "string")
+			.map((tag) => tag.trim())
+			.filter((tag) => tag.length > 0);
+	}
+	if (typeof tags === "string") {
+		const trimmed = tags.trim();
+		if (!trimmed) return [];
+		if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+			try {
+				const parsed = JSON.parse(trimmed);
+				if (Array.isArray(parsed)) {
+					return parsed
+						.filter((tag) => typeof tag === "string")
+						.map((tag) => tag.trim())
+						.filter((tag) => tag.length > 0);
+				}
+			} catch {
+				return [];
+			}
+		}
+		return trimmed
+			.split(",")
+			.map((tag) => tag.trim())
+			.filter((tag) => tag.length > 0);
+	}
+	return [];
+}
+
+function buildBucketUsageMaps(
+	bucketsInput: readonly MemoryTimelineBucket[],
+	memories: readonly Memory[],
+	skills: readonly Skill[],
+	mcpServers: readonly MarketplaceMcpServer[],
+): {
+	skillUsage: Record<string, number>;
+	mcpUsage: Record<string, number>;
+} {
+	const skillMatchers = skills
+		.map((skill) => skill.name.trim().toLowerCase())
+		.filter((name) => name.length > 0)
+		.map((name) => ({
+			name,
+			pattern: new RegExp(`\\b${escapeRegex(name)}\\b`, "i"),
+		}));
+
+	const mcpMatchers = mcpServers
+		.flatMap((server) => [server.name, server.id])
+		.map((value) => value.trim().toLowerCase())
+		.filter((value) => value.length > 0)
+		.map((value) => ({
+			value,
+			pattern: new RegExp(`\\b${escapeRegex(value)}\\b`, "i"),
+		}));
+
+	const storage = bucketsInput.map((bucket) => ({
+		bucket,
+		skillSet: new Set<string>(),
+		mcpSet: new Set<string>(),
+		mcpMentionIds: new Set<string>(),
+		startMs: Date.parse(bucket.start),
+		endMs: Date.parse(bucket.end),
+	}));
+
+	for (const memory of memories) {
+		const createdAt = Date.parse(memory.created_at);
+		if (!Number.isFinite(createdAt)) continue;
+
+		const tags = parseTags(memory.tags).join(" ");
+		const memoryText = [memory.content, memory.who, memory.type, tags]
+			.filter((value): value is string => typeof value === "string")
+			.join(" ")
+			.toLowerCase();
+
+		for (const entry of storage) {
+			if (createdAt < entry.startMs || createdAt > entry.endMs) continue;
+
+			for (const matcher of skillMatchers) {
+				if (matcher.pattern.test(memoryText)) {
+					entry.skillSet.add(matcher.name);
+				}
+			}
+
+			let matchedMcp = false;
+			for (const matcher of mcpMatchers) {
+				if (matcher.pattern.test(memoryText)) {
+					entry.mcpSet.add(matcher.value);
+					matchedMcp = true;
+				}
+			}
+
+			if (!matchedMcp && /\bmcp\b|model context protocol|tool server/i.test(memoryText)) {
+				entry.mcpMentionIds.add(memory.id);
+			}
+		}
+	}
+
+	const skillUsage: Record<string, number> = {};
+	const mcpUsage: Record<string, number> = {};
+	for (const entry of storage) {
+		skillUsage[entry.bucket.rangeKey] = entry.skillSet.size;
+		mcpUsage[entry.bucket.rangeKey] =
+			entry.mcpSet.size > 0 ? entry.mcpSet.size : entry.mcpMentionIds.size;
+	}
+
+	return { skillUsage, mcpUsage };
+}
+
+function normalizeImportance(value: number | undefined): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+	if (value <= 0) return 0;
+	if (value >= 1) return 1;
+	return value;
+}
+
+function buildBucketTopMemories(
+	bucketsInput: readonly MemoryTimelineBucket[],
+	memories: readonly Memory[],
+): Record<string, Memory[]> {
+	const bucketEntries: Array<{
+		bucket: MemoryTimelineBucket;
+		startMs: number;
+		endMs: number;
+		candidates: Array<{ memory: Memory; score: number; createdAt: number }>;
+	}> = bucketsInput.map((bucket) => ({
+		bucket,
+		startMs: Date.parse(bucket.start),
+		endMs: Date.parse(bucket.end),
+		candidates: [],
+	}));
+
+	for (const memory of memories) {
+		const createdAt = Date.parse(memory.created_at);
+		if (!Number.isFinite(createdAt)) continue;
+
+		for (const entry of bucketEntries) {
+			if (createdAt < entry.startMs || createdAt > entry.endMs) continue;
+
+			const rangeSpan = Math.max(1, entry.endMs - entry.startMs);
+			const recency = Math.max(
+				0,
+				Math.min(1, (createdAt - entry.startMs) / rangeSpan),
+			);
+			const score =
+				normalizeImportance(memory.importance) * 100 +
+				(memory.pinned ? 24 : 0) +
+				recency * 8;
+
+			entry.candidates.push({ memory, score, createdAt });
+		}
+	}
+
+	const result: Record<string, Memory[]> = {};
+	for (const entry of bucketEntries) {
+		entry.candidates.sort((left, right) => {
+			if (right.score !== left.score) return right.score - left.score;
+			const leftImportance = normalizeImportance(left.memory.importance);
+			const rightImportance = normalizeImportance(right.memory.importance);
+			if (rightImportance !== leftImportance) {
+				return rightImportance - leftImportance;
+			}
+			if (right.createdAt !== left.createdAt) {
+				return right.createdAt - left.createdAt;
+			}
+			return left.memory.id.localeCompare(right.memory.id);
+		});
+
+		result[entry.bucket.rangeKey] = entry.candidates
+			.slice(0, 3)
+			.map((candidate) => candidate.memory);
+	}
+
+	return result;
+}
+
+function moveOlder(step = 1): void {
+	if (buckets.length === 0) return;
+	activeIndex = Math.min(buckets.length - 1, activeIndex + step);
+}
+
+function moveNewer(step = 1): void {
+	if (buckets.length === 0) return;
+	activeIndex = Math.max(0, activeIndex - step);
+}
+
+function emitGeneratedFor(value: string): void {
+	if (!ontimelinegeneratedforchange) return;
+	ontimelinegeneratedforchange(value);
+}
+
+async function loadTimeline(): Promise<void> {
+	loading = true;
+	error = null;
+	try {
+		const [response, skills, mcp, memoryResult] = await Promise.all([
+			getMemoryTimeline(),
+			getSkills(),
+			getMarketplaceMcpServers(),
+			getMemories(5000, 0),
+		]);
+		buckets = response.buckets;
+		emitGeneratedFor(response.generatedFor);
+		const usage = buildBucketUsageMaps(
+			response.buckets,
+			memoryResult.memories,
+			skills,
+			mcp.servers,
+		);
+		bucketSkillUsage = usage.skillUsage;
+		bucketMcpUsage = usage.mcpUsage;
+		bucketTopMemories = buildBucketTopMemories(
+			response.buckets,
+			memoryResult.memories,
+		);
+		activeIndex = 0;
+		if (response.error) {
+			error = response.error;
+		}
+	} catch {
+		error = "Failed to load timeline.";
+		buckets = [];
+		emitGeneratedFor("");
+		bucketSkillUsage = {};
+		bucketMcpUsage = {};
+		bucketTopMemories = {};
+	}
+	loading = false;
+}
+
+function formatDateRange(startIso: string, endIso: string): string {
+	const start = new Date(startIso);
+	const end = new Date(endIso);
+	return `${start.toLocaleDateString("en-US", {
+		month: "short",
+		day: "numeric",
+	})} - ${end.toLocaleDateString("en-US", {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+	})}`;
+}
+
+function formatMemoryMoment(
+	value: string,
+	rangeKey: MemoryTimelineBucket["rangeKey"],
+): string {
+	const parsed = Date.parse(value);
+	if (!Number.isFinite(parsed)) return "Unknown";
+	const date = new Date(parsed);
+	if (rangeKey === "today") {
+		return date.toLocaleTimeString("en-US", {
+			hour: "numeric",
+			minute: "2-digit",
+		});
+	}
+	return date.toLocaleDateString("en-US", {
+		month: "short",
+		day: "numeric",
+	});
+}
+
+function formatMemoryImportance(value: number | undefined): string {
+	return `${Math.round(normalizeImportance(value) * 100)}%`;
+}
+
+function formatCountUnit(value: number, singular: string, plural: string): string {
+	return value === 1 ? singular : plural;
+}
+
+function getMemoryMonogram(value: string): string {
+	const parts = value
+		.split(/[-_.\s]+/)
+		.map((part) => part.trim())
+		.filter((part) => part.length > 0);
+	if (parts.length >= 2) {
+		return `${parts[0]?.[0] ?? ""}${parts[1]?.[0] ?? ""}`.toUpperCase();
+	}
+	return value.slice(0, 2).toUpperCase() || "M";
+}
+
+function getMemoryMonogramBg(seed: string): string {
+	let hash = 0;
+	for (const char of seed) {
+		hash = (hash * 31 + char.charCodeAt(0)) & 0xffff;
+	}
+	return memoryCardIconColors[Math.abs(hash) % memoryCardIconColors.length] ?? memoryCardIconColors[0];
+}
+
+function getRangeChipLabel(bucket: MemoryTimelineBucket): string {
+	if (bucket.rangeKey === "last_week") return "Week";
+	if (bucket.rangeKey === "one_month") return "Month";
+	return "Today";
+}
+
+function handleKeydown(event: KeyboardEvent): void {
+	if (event.key === "ArrowRight") {
+		event.preventDefault();
+		moveOlder(event.shiftKey ? 3 : 1);
+		return;
+	}
+	if (event.key === "ArrowLeft") {
+		event.preventDefault();
+		moveNewer(event.shiftKey ? 3 : 1);
+		return;
+	}
+	if (event.key === "PageDown") {
+		event.preventDefault();
+		moveOlder(3);
+		return;
+	}
+	if (event.key === "PageUp") {
+		event.preventDefault();
+		moveNewer(3);
+	}
+}
+
+onMount(() => {
+	loadTimeline();
+	return () => {
+		emitGeneratedFor("");
+	};
+});
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<div
+	bind:this={rootEl}
+	class="timeline-shell flex flex-1 min-h-0 flex-col gap-3 bg-[var(--sig-bg)] p-3"
+	role="region"
+	aria-label="Memory timeline. Use left and right arrows to move through eras."
+>
+	{#if loading}
+		<div class="flex flex-1 items-center justify-center sig-label">Loading timeline...</div>
+	{:else if buckets.length === 0}
+		<div class="flex flex-1 items-center justify-center sig-label text-[var(--sig-text-muted)]">
+			No timeline data yet.
+		</div>
+	{:else if activeBucket}
+		<div class="timeline-stack flex flex-1 min-h-0 flex-col gap-3">
+			<section
+				class="timeline-hero rounded-xl border border-[var(--sig-border)] p-3"
+			>
+				<div class="timeline-hero-grid">
+					<div class="min-w-0">
+						<h2 class="timeline-hero-title">
+							Signet Evolution Timeline
+						</h2>
+						<p class="timeline-hero-subtitle">
+							Track added, evolved, and pinned memories across recap eras.
+						</p>
+					</div>
+					<div class="timeline-hero-metrics">
+						<div class="timeline-hero-metric">
+							<span class="timeline-hero-metric-label">Agent skills used</span>
+							<strong class="timeline-hero-metric-display">
+								{activeSkillsUsed} {formatCountUnit(activeSkillsUsed, "skill", "skills")}
+							</strong>
+						</div>
+						<div class="timeline-hero-metric">
+							<span class="timeline-hero-metric-label">MCP servers used</span>
+							<strong class="timeline-hero-metric-display">
+								{activeMcpServersUsed} {formatCountUnit(activeMcpServersUsed, "server", "servers")}
+							</strong>
+						</div>
+						<div class="timeline-hero-metric">
+							<span class="timeline-hero-metric-label">Average importance</span>
+							<strong class="timeline-hero-metric-display">
+								{Math.round(activeBucket.avgImportance * 100)}% avg
+							</strong>
+						</div>
+						<div class="timeline-hero-metric">
+							<span class="timeline-hero-metric-label">Pinned</span>
+							<strong class="timeline-hero-metric-display">
+								{activeBucket.pinned} {formatCountUnit(activeBucket.pinned, "card", "cards")}
+							</strong>
+						</div>
+					</div>
+				</div>
+			</section>
+
+			<div class="timeline-content-split min-h-0 gap-3">
+				<section class="timeline-detail-panel flex min-h-0 flex-col gap-3 overflow-auto rounded-xl border border-[var(--sig-border)] bg-[var(--sig-surface)] p-3">
+					<div class="timeline-era-head">
+						<div class="timeline-era-title-row">
+							<p class="sig-heading timeline-era-title">
+								{activeBucket.label}: <span class="timeline-era-title-range">{formatDateRange(activeBucket.start, activeBucket.end)}</span>
+							</p>
+							<div class="timeline-era-controls" role="tablist" aria-orientation="horizontal">
+								<Button
+									variant="outline"
+									size="sm"
+									class="h-8 px-2"
+									onclick={() => moveNewer()}
+									disabled={activeIndex <= 0}
+									title="Move to newer era"
+								>
+									<ChevronLeft class="size-3.5" />
+								</Button>
+
+								{#each buckets as bucket, index (bucket.eraIndex)}
+									<button
+										class={`${railButtonBase} ${index === activeIndex
+											? 'border-[var(--sig-accent)] bg-[color-mix(in_srgb,var(--sig-surface-raised)_76%,transparent)] text-[var(--sig-text-bright)]'
+											: 'border-[var(--sig-border-strong)] text-[var(--sig-text-muted)] hover:text-[var(--sig-text-bright)]'}`}
+										onclick={() => {
+											activeIndex = index;
+										}}
+										role="tab"
+										aria-selected={index === activeIndex}
+									>
+										{getRangeChipLabel(bucket)}
+									</button>
+								{/each}
+
+								<Button
+									variant="outline"
+									size="sm"
+									class="h-8 px-2"
+									onclick={() => moveOlder()}
+									disabled={activeIndex >= buckets.length - 1}
+									title="Move to older era"
+								>
+									<ChevronRight class="size-3.5" />
+								</Button>
+
+								<Button
+									variant="ghost"
+									size="sm"
+									class="h-8 px-2 sig-label"
+									onclick={() => {
+										activeIndex = 0;
+									}}
+									title="Jump to today"
+								>
+									<RotateCcw class="size-3.5" />
+								</Button>
+							</div>
+						</div>
+					</div>
+
+					<div class="timeline-summary-grid">
+						<div class="flex min-h-[56px] items-center justify-center rounded-lg border border-[var(--sig-border-strong)] bg-[var(--sig-surface-raised)] p-2">
+							<p class="timeline-summary-line">
+								<span class="sig-heading leading-none">{activeBucket.memoriesAdded}</span>
+								<span class="timeline-summary-copy">- Added</span>
+							</p>
+						</div>
+						<div class="flex min-h-[56px] items-center justify-center rounded-lg border border-[var(--sig-border-strong)] bg-[var(--sig-surface-raised)] p-2">
+							<p class="timeline-summary-line">
+								<span class="sig-heading leading-none">{activeBucket.trackedEvents}</span>
+								<span class="timeline-summary-copy">- Tracked events captured</span>
+							</p>
+						</div>
+						<div class="flex min-h-[56px] items-center justify-center rounded-lg border border-[var(--sig-border-strong)] bg-[var(--sig-surface-raised)] p-2">
+							<p class="timeline-summary-line">
+								<span class="sig-heading leading-none">{activeBucket.evolved}</span>
+								<span class="timeline-summary-copy">- Evolved</span>
+							</p>
+						</div>
+						<div class="flex min-h-[56px] items-center justify-center rounded-lg border border-[var(--sig-border-strong)] bg-[var(--sig-surface-raised)] p-2">
+							<p class="timeline-summary-line">
+								<span class="sig-heading leading-none">{activeBucket.strengthened}</span>
+								<span class="timeline-summary-copy">- Strengthened</span>
+							</p>
+						</div>
+					</div>
+
+					<div class="timeline-mix-grid">
+						<div class="timeline-mix-card timeline-mix-card--type rounded-lg p-2">
+							<p class="sig-label mb-1">Type mix</p>
+							{#if activeBucket.typeBreakdown.length === 0}
+								<p class="sig-label text-[var(--sig-text-muted)]">No type signals</p>
+							{:else}
+								{#each activeBucket.typeBreakdown as metric}
+									<div class="flex items-center justify-between text-[11px]">
+										<span>{metric.key}</span>
+										<span class="text-[var(--sig-text-muted)]">{metric.count}</span>
+									</div>
+								{/each}
+							{/if}
+						</div>
+
+						<div class="timeline-mix-card timeline-mix-card--source rounded-lg p-2">
+							<p class="sig-label mb-1">Source mix</p>
+							{#if activeBucket.sourceBreakdown.length === 0}
+								<p class="sig-label text-[var(--sig-text-muted)]">No source signals</p>
+							{:else}
+								{#each activeBucket.sourceBreakdown as metric}
+									<div class="flex items-center justify-between text-[11px]">
+										<span>{metric.key}</span>
+										<span class="text-[var(--sig-text-muted)]">{metric.count}</span>
+									</div>
+								{/each}
+							{/if}
+						</div>
+
+						<div class="timeline-mix-card timeline-mix-card--tags rounded-lg p-2">
+							<p class="sig-label mb-1">Top tags</p>
+							{#if activeBucket.topTags.length === 0}
+								<p class="sig-label text-[var(--sig-text-muted)]">No tags this era</p>
+							{:else}
+								{#each activeBucket.topTags as metric}
+									<div class="flex items-center justify-between text-[11px]">
+										<span>{metric.key}</span>
+										<span class="text-[var(--sig-text-muted)]">{metric.count}</span>
+									</div>
+								{/each}
+							{/if}
+						</div>
+					</div>
+				</section>
+
+				<section class="timeline-top-panel rounded-xl border border-[var(--sig-border)] bg-[var(--sig-surface)] p-3">
+					<div class="flex items-center justify-between gap-2">
+						<p class="sig-label">Top Three Memories</p>
+						<p class="text-[11px] text-[var(--sig-text-muted)]">{activeBucket.label}</p>
+					</div>
+					{#if activeTopMemories.length === 0}
+						<p class="mt-2 sig-label text-[var(--sig-text-muted)]">
+							No memories saved in this era yet.
+						</p>
+					{:else}
+						<div class="timeline-top-card-grid mt-2">
+							{#each activeTopMemories as memory (memory.id)}
+								<article class="timeline-top-card rounded-lg border border-[var(--sig-border-strong)] bg-[var(--sig-surface-raised)] p-2">
+									<div class="timeline-top-card-head">
+										<div class="timeline-top-card-icon" style={`background: ${getMemoryMonogramBg(memory.id)};`}>
+											{getMemoryMonogram(memory.who || memory.type || "memory")}
+										</div>
+										<div class="timeline-top-card-title-wrap">
+											<p class="timeline-top-card-title">{memory.who || "Unknown source"}</p>
+											<p class="timeline-top-card-subtitle">{memory.type?.trim() || "memory"}</p>
+										</div>
+									</div>
+									<p class="timeline-top-card-content mt-1 text-[11px] leading-relaxed text-[var(--sig-text)] line-clamp-4">
+										{memory.content}
+									</p>
+									<div class="timeline-top-card-meta mt-auto flex items-center justify-between gap-2 pt-2 text-[11px] text-[var(--sig-text-muted)]">
+										<p class="timeline-top-card-badge">imp {formatMemoryImportance(memory.importance)}</p>
+										<p>{formatMemoryMoment(memory.created_at, activeBucket.rangeKey)}</p>
+									</div>
+								</article>
+							{/each}
+						</div>
+					{/if}
+				</section>
+			</div>
+		</div>
+	{/if}
+
+	{#if error}
+		<p class="sig-label text-[var(--sig-danger)]">{error}</p>
+	{/if}
+</div>
+
+<style>
+	.timeline-hero {
+		border-radius: 1rem;
+		background:
+			radial-gradient(circle at 85% -20%, color-mix(in srgb, var(--sig-accent) 16%, transparent), transparent 45%),
+			linear-gradient(140deg, color-mix(in srgb, var(--sig-surface-raised) 88%, black) 0%, var(--sig-surface) 68%);
+		padding: 1.05rem 1.15rem;
+	}
+
+	.timeline-hero-grid {
+		display: grid;
+		gap: 0.6rem;
+		grid-template-columns: minmax(0, 1fr);
+	}
+
+	.timeline-hero-title {
+		margin: 0;
+		font-family: var(--font-display);
+		font-size: clamp(1.05rem, 1.65vw, 1.35rem);
+		line-height: 1.2;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--sig-text-bright);
+	}
+
+	.timeline-hero-subtitle {
+		margin: 0.22rem 0 0;
+		font-family: var(--font-mono);
+		font-size: 0.66rem;
+		line-height: 1.45;
+		letter-spacing: 0.04em;
+		color: var(--sig-text-muted);
+	}
+
+	.timeline-hero-metrics {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 0.45rem;
+	}
+
+	.timeline-hero-metric {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		justify-content: flex-start;
+		gap: 0.2rem;
+		padding: 0.45rem 0.55rem;
+		border: 1px solid var(--sig-border-strong);
+		border-radius: 0.4rem;
+		background: color-mix(in srgb, var(--sig-surface-raised) 55%, transparent);
+	}
+
+	.timeline-hero-metric-label {
+		font-family: var(--font-mono);
+		font-size: 0.57rem;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--sig-text-muted);
+	}
+
+	.timeline-hero-metric-display {
+		font-family: var(--font-display);
+		font-size: 0.76rem;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--sig-text-bright);
+	}
+
+	.timeline-summary-panel {
+		background:
+			linear-gradient(135deg, color-mix(in srgb, var(--sig-surface-raised) 92%, transparent), var(--sig-surface-raised));
+		border-color: var(--sig-border-strong);
+		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+	}
+
+	.timeline-mix-grid {
+		display: grid;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		gap: 0.5rem;
+	}
+
+	.timeline-mix-card {
+		border: 1px solid var(--sig-border);
+		background: color-mix(in srgb, var(--sig-surface-raised) 58%, transparent);
+	}
+
+	.timeline-mix-card--type {
+		border-color: color-mix(in srgb, var(--sig-log-category-watcher) 58%, var(--sig-border-strong));
+	}
+
+	.timeline-mix-card--source {
+		border-color: color-mix(in srgb, var(--sig-log-category-daemon) 58%, var(--sig-border-strong));
+	}
+
+	.timeline-mix-card--tags {
+		border-color: color-mix(in srgb, var(--sig-log-category-pipeline) 58%, var(--sig-border-strong));
+	}
+
+	.timeline-summary-grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 0.5rem;
+	}
+
+	.timeline-summary-line {
+		display: flex;
+		width: 100%;
+		align-items: center;
+		justify-content: center;
+		gap: 0.3rem;
+		text-align: center;
+		font-size: 0.69rem;
+		line-height: 1.2;
+	}
+
+	.timeline-summary-copy {
+		color: var(--sig-text-muted);
+	}
+
+	.timeline-content-split {
+		display: grid;
+		grid-template-columns: minmax(0, 1.45fr) minmax(18rem, 1fr);
+		align-items: stretch;
+	}
+
+	.timeline-top-panel {
+		display: flex;
+		min-height: 0;
+		flex-direction: column;
+	}
+
+	.timeline-content-split .timeline-top-card-grid {
+		grid-template-columns: minmax(0, 1fr);
+	}
+
+	.timeline-top-card-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+		gap: 0.5rem;
+	}
+
+	.timeline-top-card {
+		display: flex;
+		min-height: 8.2rem;
+		flex-direction: column;
+		gap: 0.45rem;
+		background:
+			radial-gradient(circle at 12% -24%, color-mix(in srgb, var(--sig-accent) 8%, transparent), transparent 52%),
+			linear-gradient(220deg, color-mix(in srgb, var(--sig-surface-raised) 92%, black) 0%, var(--sig-surface-raised) 72%);
+		transition: border-color 0.15s;
+	}
+
+	.timeline-top-card:hover {
+		border-color: var(--sig-accent);
+	}
+
+	.timeline-top-card-head {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.timeline-top-card-icon {
+		display: flex;
+		height: 1.65rem;
+		width: 1.65rem;
+		align-items: center;
+		justify-content: center;
+		border-radius: 0.35rem;
+		font-family: var(--font-display);
+		font-size: 0.62rem;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--sig-icon-fg);
+		border: 1px solid var(--sig-icon-border);
+		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.22);
+	}
+
+	.timeline-top-card-title-wrap {
+		min-width: 0;
+	}
+
+	.timeline-top-card-title {
+		margin: 0;
+		font-family: var(--font-display);
+		font-size: 0.68rem;
+		letter-spacing: 0.05em;
+		text-transform: uppercase;
+		color: var(--sig-text-bright);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.timeline-top-card-subtitle {
+		margin: 0;
+		font-family: var(--font-mono);
+		font-size: 0.6rem;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--sig-text-muted);
+	}
+
+	.timeline-top-card-content {
+		margin: 0;
+	}
+
+	.timeline-top-card-meta {
+		font-family: var(--font-mono);
+	}
+
+	.timeline-top-card-badge {
+		margin: 0;
+		padding: 0.08rem 0.3rem;
+		border: 1px solid var(--sig-border-strong);
+		border-radius: 0.32rem;
+		font-size: 0.6rem;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--sig-text-muted);
+		background: color-mix(in srgb, var(--sig-surface-raised) 62%, transparent);
+	}
+
+	@media (max-width: 900px) and (orientation: portrait) {
+		.timeline-hero {
+			border-radius: 1rem;
+			padding: 0.95rem;
+		}
+
+		.timeline-content-split {
+			grid-template-columns: minmax(0, 1fr);
+		}
+
+		.timeline-summary-grid {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+			gap: 0.45rem;
+		}
+
+		.timeline-summary-line {
+			gap: 0.22rem;
+			font-size: 0.64rem;
+		}
+
+		.timeline-summary-copy {
+			letter-spacing: 0.01em;
+		}
+
+		.timeline-content-split .timeline-top-card-grid {
+			grid-template-columns: minmax(0, 1fr);
+		}
+
+		.timeline-hero-metrics {
+			display: grid;
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+			gap: 0.4rem;
+		}
+
+		.timeline-hero-metric {
+			padding: 0.42rem 0.48rem;
+			gap: 0.16rem;
+		}
+
+		.timeline-hero-metric-label {
+			font-size: 0.53rem;
+		}
+
+		.timeline-hero-metric-display {
+			font-size: 0.68rem;
+		}
+
+		.timeline-shell {
+			overflow-y: auto;
+		}
+
+		.timeline-stack {
+			min-height: auto;
+		}
+
+		.timeline-detail-panel {
+			overflow: visible;
+			min-height: auto;
+		}
+
+		.timeline-top-card-grid {
+			grid-template-columns: minmax(0, 1fr);
+		}
+
+		.timeline-top-card {
+			min-height: 0;
+		}
+	}
+
+	.timeline-era-head {
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+	}
+
+	.timeline-era-title-row {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) auto;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
+	.timeline-era-title {
+		justify-self: start;
+	}
+
+	.timeline-era-title-range {
+		font-size: 0.8rem;
+		font-weight: 500;
+		color: var(--sig-text-muted);
+		white-space: nowrap;
+	}
+
+	.timeline-era-controls {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: flex-end;
+		justify-self: end;
+		gap: 0.45rem;
+	}
+
+	@media (min-width: 1024px) {
+		.timeline-hero-grid {
+			grid-template-columns: minmax(0, 1fr) minmax(24rem, 0.95fr);
+			align-items: start;
+			gap: 0.95rem;
+		}
+
+		.timeline-hero-metric {
+			min-height: 3rem;
+		}
+
+		.timeline-era-controls {
+			flex-wrap: nowrap;
+		}
+	}
+</style>

--- a/packages/cli/dashboard/src/lib/components/tabs/TimelineTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/TimelineTab.svelte
@@ -474,7 +474,7 @@ onMount(() => {
 						<div class="timeline-hero-metric">
 							<span class="timeline-hero-metric-label">Average importance</span>
 							<strong class="timeline-hero-metric-display">
-								{Math.round(activeBucket.avgImportance * 100)}% avg
+								{Math.round(normalizeImportance(activeBucket.avgImportance) * 100)}% avg
 							</strong>
 						</div>
 						<div class="timeline-hero-metric">

--- a/packages/cli/dashboard/src/lib/components/tabs/TimelineTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/TimelineTab.svelte
@@ -48,17 +48,22 @@ const activeSkillsUsed = $derived(
 );
 
 function inferMcpUsageFromBucket(bucket: MemoryTimelineBucket): number {
-	const sourceSignals = bucket.sourceBreakdown.filter(
-		(metric: { key: string }) =>
-		/\bmcp\b|openclaw-memory|tool server|modelcontextprotocol/i.test(
-			metric.key,
-		),
+	// Use source breakdown only; tags are a weaker signal and can double-count with sources
+	const sourceSignals = bucket.sourceBreakdown.filter((metric: { key: string }) =>
+		hasMcpSignal(metric.key),
 	).length;
-	const tagSignals = bucket.topTags.filter(
-		(metric: { key: string }) =>
-		/\bmcp\b|tool-server|model-context-protocol/i.test(metric.key),
-	).length;
-	return sourceSignals + tagSignals;
+	return sourceSignals;
+}
+
+function hasMcpSignal(raw: string): boolean {
+	const key = raw.trim().toLowerCase();
+	if (!key) return false;
+	if (/\bmcp\b/.test(key)) return true;
+	if (/\btool[-\s]?servers?\b/.test(key)) return true;
+	if (key.includes("model context protocol")) return true;
+	if (key.includes("model-context-protocol")) return true;
+	if (key.includes("modelcontextprotocol")) return true;
+	return false;
 }
 
 const activeMcpServersUsed = $derived(
@@ -98,7 +103,7 @@ function parseTags(tags: Memory["tags"]): string[] {
 						.filter((tag) => tag.length > 0);
 				}
 			} catch {
-				return [];
+				// Fall through to CSV parsing on JSON error
 			}
 		}
 		return trimmed
@@ -126,20 +131,26 @@ function buildBucketUsageMaps(
 			pattern: new RegExp(`\\b${escapeRegex(name)}\\b`, "i"),
 		}));
 
-	const mcpMatchers = mcpServers
-		.flatMap((server) => [server.name, server.id])
-		.map((value) => value.trim().toLowerCase())
-		.filter((value) => value.length > 0)
-		.map((value) => ({
-			value,
-			pattern: new RegExp(`\\b${escapeRegex(value)}\\b`, "i"),
-		}));
+	// Key by serverId so a server matching on both name and id counts as 1
+	const mcpMatchers = mcpServers.flatMap((server) => {
+		const entries: Array<{ serverId: string; pattern: RegExp }> = [];
+		for (const raw of [server.name, server.id]) {
+			const value = raw.trim().toLowerCase();
+			if (value.length > 0) {
+				entries.push({
+					serverId: server.id,
+					pattern: new RegExp(`\\b${escapeRegex(value)}\\b`, "i"),
+				});
+			}
+		}
+		return entries;
+	});
 
 	const storage = bucketsInput.map((bucket) => ({
 		bucket,
 		skillSet: new Set<string>(),
 		mcpSet: new Set<string>(),
-		mcpMentionIds: new Set<string>(),
+		hasMcpSignal: false,
 		startMs: Date.parse(bucket.start),
 		endMs: Date.parse(bucket.end),
 	}));
@@ -150,6 +161,12 @@ function buildBucketUsageMaps(
 
 		const tags = parseTags(memory.tags).join(" ");
 		const memoryText = [memory.content, memory.who, memory.type, tags]
+			.filter((value): value is string => typeof value === "string")
+			.join(" ")
+			.toLowerCase();
+		// For MCP signal detection fallback, exclude content to avoid false positives
+		// from memories that merely mention "MCP" conversationally
+		const signalText = [memory.who, memory.type, tags]
 			.filter((value): value is string => typeof value === "string")
 			.join(" ")
 			.toLowerCase();
@@ -166,13 +183,14 @@ function buildBucketUsageMaps(
 			let matchedMcp = false;
 			for (const matcher of mcpMatchers) {
 				if (matcher.pattern.test(memoryText)) {
-					entry.mcpSet.add(matcher.value);
+					entry.mcpSet.add(matcher.serverId);
 					matchedMcp = true;
 				}
 			}
 
-			if (!matchedMcp && /\bmcp\b|model context protocol|tool server/i.test(memoryText)) {
-				entry.mcpMentionIds.add(memory.id);
+			// If no named server matched, check for MCP signal in metadata only
+			if (!matchedMcp && hasMcpSignal(signalText)) {
+				entry.hasMcpSignal = true;
 			}
 		}
 	}
@@ -181,8 +199,9 @@ function buildBucketUsageMaps(
 	const mcpUsage: Record<string, number> = {};
 	for (const entry of storage) {
 		skillUsage[entry.bucket.rangeKey] = entry.skillSet.size;
+		// If we matched named servers, use that count; otherwise cap at 1 if signal detected
 		mcpUsage[entry.bucket.rangeKey] =
-			entry.mcpSet.size > 0 ? entry.mcpSet.size : entry.mcpMentionIds.size;
+			entry.mcpSet.size > 0 ? entry.mcpSet.size : (entry.hasMcpSignal ? 1 : 0);
 	}
 
 	return { skillUsage, mcpUsage };
@@ -274,11 +293,15 @@ async function loadTimeline(): Promise<void> {
 	loading = true;
 	error = null;
 	try {
+		// Share the memory fetch promise with getMemoryTimeline for its fallback path
+		const memoryResultPromise = getMemories(5000, 0);
 		const [response, skills, mcp, memoryResult] = await Promise.all([
-			getMemoryTimeline(),
+			getMemoryTimeline({
+				fallbackMemories: memoryResultPromise.then((r) => r.memories),
+			}),
 			getSkills(),
 			getMarketplaceMcpServers(),
-			getMemories(5000, 0),
+			memoryResultPromise,
 		]);
 		buckets = response.buckets;
 		emitGeneratedFor(response.generatedFor);
@@ -305,21 +328,22 @@ async function loadTimeline(): Promise<void> {
 		bucketSkillUsage = {};
 		bucketMcpUsage = {};
 		bucketTopMemories = {};
+	} finally {
+		loading = false;
 	}
-	loading = false;
 }
 
 function formatDateRange(startIso: string, endIso: string): string {
-	const start = new Date(startIso);
-	const end = new Date(endIso);
-	return `${start.toLocaleDateString("en-US", {
+	// Format in UTC to avoid timezone offset issues where UTC midnight
+	// appears as the previous local day in negative-UTC-offset timezones
+	const opts: Intl.DateTimeFormatOptions = {
 		month: "short",
 		day: "numeric",
-	})} - ${end.toLocaleDateString("en-US", {
-		month: "short",
-		day: "numeric",
-		year: "numeric",
-	})}`;
+		timeZone: "UTC",
+	};
+	const start = new Date(startIso).toLocaleDateString("en-US", opts);
+	const end = new Date(endIso).toLocaleDateString("en-US", { ...opts, year: "numeric" });
+	return `${start} - ${end}`;
 }
 
 function formatMemoryMoment(
@@ -333,11 +357,13 @@ function formatMemoryMoment(
 		return date.toLocaleTimeString("en-US", {
 			hour: "numeric",
 			minute: "2-digit",
+			timeZone: "UTC",
 		});
 	}
 	return date.toLocaleDateString("en-US", {
 		month: "short",
 		day: "numeric",
+		timeZone: "UTC",
 	});
 }
 

--- a/packages/cli/dashboard/src/lib/stores/navigation.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/navigation.svelte.ts
@@ -11,6 +11,7 @@ export type TabId =
 	| "config"
 	| "settings"
 	| "memory"
+	| "timeline"
 	| "embeddings"
 	| "pipeline"
 	| "logs"
@@ -23,6 +24,7 @@ const VALID_TABS: ReadonlySet<string> = new Set<TabId>([
 	"config",
 	"settings",
 	"memory",
+	"timeline",
 	"embeddings",
 	"pipeline",
 	"logs",
@@ -44,7 +46,11 @@ export const nav = $state({
 
 /* ── Tab groups (display-layer only) ── */
 
-const MEMORY_TABS: ReadonlySet<TabId> = new Set(["memory", "embeddings"]);
+const MEMORY_TABS: ReadonlySet<TabId> = new Set([
+	"memory",
+	"timeline",
+	"embeddings",
+]);
 const ENGINE_TABS: ReadonlySet<TabId> = new Set([
 	"settings",
 	"pipeline",

--- a/packages/cli/dashboard/src/routes/+page.svelte
+++ b/packages/cli/dashboard/src/routes/+page.svelte
@@ -119,6 +119,7 @@ function formatTimelineGeneratedFor(value: string): string {
 		year: "numeric",
 		hour: "numeric",
 		minute: "2-digit",
+		timeZone: "UTC",
 	});
 }
 

--- a/packages/cli/dashboard/src/routes/+page.svelte
+++ b/packages/cli/dashboard/src/routes/+page.svelte
@@ -38,6 +38,7 @@ const tabInactive = `${tabBtn} bg-transparent text-[var(--sig-text-muted)] hover
 const { data } = $props();
 let daemonStatus = $state<DaemonStatus | null>(null);
 let embeddingsPrefetchPromise: Promise<unknown[]> | null = null;
+let timelineGeneratedFor = $state("");
 
 // --- Theme ---
 let theme = $state<"dark" | "light">("dark");
@@ -102,6 +103,23 @@ function prefetchEmbeddingsTab(): void {
 		import("$lib/components/tabs/EmbeddingsTab.svelte"),
 		import("3d-force-graph"),
 	]);
+}
+
+function handleTimelineGeneratedForChange(value: string): void {
+	timelineGeneratedFor = value;
+}
+
+function formatTimelineGeneratedFor(value: string): string {
+	if (!value) return "";
+	const parsed = Date.parse(value);
+	if (!Number.isFinite(parsed)) return "";
+	return new Date(parsed).toLocaleString("en-US", {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+		hour: "numeric",
+		minute: "2-digit",
+	});
 }
 
 // --- Cleanup ---
@@ -177,6 +195,10 @@ onMount(() => {
 							onclick={() => setTab("memory")}
 						>Index</button>
 						<button
+							class={activeTab === 'timeline' ? tabActive : tabInactive}
+							onclick={() => setTab("timeline")}
+						>Timeline</button>
+						<button
 							class={activeTab === 'embeddings' ? tabActive : tabInactive}
 							onclick={() => setTab("embeddings")}
 						>Constellation</button>
@@ -224,6 +246,10 @@ onMount(() => {
 							Reset
 						</Button>
 					{/if}
+				{:else if activeTab === "timeline"}
+					<span class="sig-label">
+						Era timeline
+					</span>
 				{:else if activeTab === "pipeline"}
 					<span class="sig-label">
 						Memory loop
@@ -339,6 +365,14 @@ onMount(() => {
 				{:catch error}
 					{@render skeletonError(error)}
 				{/await}
+			{:else if activeTab === "timeline"}
+				{#await import("$lib/components/tabs/TimelineTab.svelte")}
+					{@render skeletonCards()}
+				{:then module}
+					<module.default ontimelinegeneratedforchange={handleTimelineGeneratedForChange} />
+				{:catch error}
+					{@render skeletonError(error)}
+				{/await}
 			{:else if activeTab === "embeddings"}
 				{#await import("$lib/components/tabs/EmbeddingsTab.svelte")}
 					<div class="flex flex-1 items-center justify-center">
@@ -426,6 +460,15 @@ onMount(() => {
 						similarity mode
 					{:else}
 						hybrid search index
+					{/if}
+				</span>
+			{:else if activeTab === "timeline"}
+				<span>timeline eras</span>
+				<span>
+					{#if timelineGeneratedFor}
+						As of {formatTimelineGeneratedFor(timelineGeneratedFor)}
+					{:else}
+						memory evolution view
 					{/if}
 				</span>
 			{:else if activeTab === "pipeline"}

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -980,6 +980,9 @@ app.use("/memory/search", async (c, next) => {
 app.use("/memory/similar", async (c, next) => {
 	return requirePermission("recall", authConfig)(c, next);
 });
+app.use("/api/memory/timeline", async (c, next) => {
+	return requirePermission("recall", authConfig)(c, next);
+});
 
 // Modify — with rate limiting
 app.use("/api/memory/modify", async (c, next) => {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -71,6 +71,7 @@ import { getAllFeatureFlags, initFeatureFlags } from "./feature-flags";
 import { closeLlmProvider, initLlmProvider } from "./llm";
 import { type LogEntry, logger } from "./logger";
 import { type EmbeddingConfig, loadMemoryConfig } from "./memory-config";
+import { buildMemoryTimeline } from "./memory-timeline";
 import { type RecallParams, hybridRecall } from "./memory-search";
 import { ONEPASSWORD_SERVICE_ACCOUNT_SECRET, importOnePasswordSecrets, listOnePasswordVaults } from "./onepassword.js";
 import {
@@ -1275,6 +1276,29 @@ app.get("/api/memories", (c) => {
 			stats: { total: 0, withEmbeddings: 0, critical: 0 },
 			error: "Failed to load memories",
 		});
+	}
+});
+
+app.get("/api/memory/timeline", (c) => {
+	try {
+		const timeline = getDbAccessor().withReadDb((db) => buildMemoryTimeline(db));
+		return c.json(timeline);
+	} catch (e) {
+		logger.error("memory", "Error building memory timeline", e as Error);
+		return c.json(
+			{
+				error: "Failed to build memory timeline",
+				generatedAt: new Date().toISOString(),
+				generatedFor: new Date().toISOString(),
+				rangePreset: "today-last_week-one_month",
+				totalMemories: 0,
+				totalHistoryEvents: 0,
+				invalidMemoryTimestamps: 0,
+				invalidHistoryTimestamps: 0,
+				buckets: [],
+			},
+			500,
+		);
 	}
 });
 

--- a/packages/daemon/src/memory-timeline.test.ts
+++ b/packages/daemon/src/memory-timeline.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { runMigrations } from "@signet/core";
+import type { ReadDb } from "./db-accessor";
+import { buildMemoryTimeline } from "./memory-timeline";
+
+function makeDb(): Database {
+	const db = new Database(":memory:");
+	runMigrations(db as any);
+	return db;
+}
+
+function insertMemory(
+	db: Database,
+	args: {
+		id: string;
+		createdAt: string;
+		type?: string;
+		who?: string;
+		tags?: string | null;
+		importance?: number;
+		pinned?: number;
+		deleted?: number;
+	},
+): void {
+	db.prepare(
+		`INSERT INTO memories
+		 (id, content, type, who, tags, importance, pinned, source_type, is_deleted, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, 'test', ?, ?, ?)`,
+	).run(
+		args.id,
+		`content-${args.id}`,
+		args.type ?? "fact",
+		args.who ?? "agent",
+		args.tags ?? null,
+		args.importance ?? 0.5,
+		args.pinned ?? 0,
+		args.deleted ?? 0,
+		args.createdAt,
+		args.createdAt,
+	);
+}
+
+function insertHistory(
+	db: Database,
+	args: {
+		id: string;
+		memoryId: string;
+		event: string;
+		createdAt: string;
+		reason?: string;
+	},
+): void {
+	db.prepare(
+		`INSERT INTO memory_history
+		 (id, memory_id, event, old_content, new_content, changed_by, reason, metadata, created_at)
+		 VALUES (?, ?, ?, NULL, NULL, 'tester', ?, NULL, ?)`,
+	).run(args.id, args.memoryId, args.event, args.reason ?? null, args.createdAt);
+}
+
+describe("buildMemoryTimeline", () => {
+	test("builds fixed buckets for today, last week, and one month", () => {
+		const db = makeDb();
+		try {
+			insertMemory(db, {
+				id: "mem-today",
+				createdAt: "2026-03-04T09:00:00.000Z",
+				type: "fact",
+				who: "claude",
+				tags: "alpha,beta",
+				importance: 0.9,
+				pinned: 1,
+			});
+			insertMemory(db, {
+				id: "mem-last-week",
+				createdAt: "2026-03-01T12:00:00.000Z",
+				type: "decision",
+				who: "opencode",
+				tags: '["beta","gamma"]',
+				importance: 0.7,
+			});
+			insertMemory(db, {
+				id: "mem-one-month",
+				createdAt: "2026-02-10T12:00:00.000Z",
+				type: "preference",
+				who: "opencode",
+				importance: 0.6,
+			});
+			insertMemory(db, {
+				id: "mem-too-old",
+				createdAt: "2025-12-20T12:00:00.000Z",
+				type: "fact",
+			});
+
+			insertHistory(db, {
+				id: "hist-1",
+				memoryId: "mem-last-week",
+				event: "updated",
+				createdAt: "2026-03-01T13:00:00.000Z",
+				reason: "reinforced with follow-up",
+			});
+			insertHistory(db, {
+				id: "hist-2",
+				memoryId: "mem-one-month",
+				event: "recovered",
+				createdAt: "2026-02-10T13:00:00.000Z",
+			});
+
+			const timeline = buildMemoryTimeline(db as unknown as ReadDb, {
+				now: new Date("2026-03-04T16:00:00.000Z"),
+			});
+
+			expect(timeline.buckets).toHaveLength(3);
+			expect(timeline.rangePreset).toBe("today-last_week-one_month");
+
+			const today = timeline.buckets[0];
+			expect(today.label).toBe("Today");
+			expect(today.memoriesAdded).toBe(1);
+			expect(today.pinned).toBe(1);
+
+			const lastWeek = timeline.buckets[1];
+			expect(lastWeek.label).toBe("Last week");
+			expect(lastWeek.memoriesAdded).toBe(2);
+			expect(lastWeek.evolved).toBe(1);
+			expect(lastWeek.strengthened).toBe(1);
+
+			const oneMonth = timeline.buckets[2];
+			expect(oneMonth.label).toBe("One month");
+			expect(oneMonth.memoriesAdded).toBe(3);
+			expect(oneMonth.evolved).toBe(2);
+			expect(oneMonth.recovered).toBe(1);
+		} finally {
+			db.close();
+		}
+	});
+
+	test("handles invalid timestamps safely", () => {
+		const db = makeDb();
+		try {
+			insertMemory(db, {
+				id: "mem-valid",
+				createdAt: "2026-03-04T09:00:00.000Z",
+			});
+
+			db.prepare(
+				`INSERT INTO memories
+				 (id, content, type, source_type, is_deleted, created_at, updated_at)
+				 VALUES ('mem-invalid', 'oops', 'fact', 'test', 0, 'not-a-date', 'not-a-date')`,
+			).run();
+
+			insertHistory(db, {
+				id: "hist-invalid",
+				memoryId: "mem-valid",
+				event: "updated",
+				createdAt: "nope-date",
+			});
+
+			const timeline = buildMemoryTimeline(db as unknown as ReadDb, {
+				now: new Date("2026-03-04T16:00:00.000Z"),
+			});
+
+			expect(timeline.invalidMemoryTimestamps).toBe(1);
+			expect(timeline.invalidHistoryTimestamps).toBe(1);
+			expect(timeline.buckets[0]?.memoriesAdded).toBe(1);
+		} finally {
+			db.close();
+		}
+	});
+
+	test("ignores soft-deleted memories and their history", () => {
+		const db = makeDb();
+		try {
+			insertMemory(db, {
+				id: "mem-live",
+				createdAt: "2026-03-04T09:00:00.000Z",
+			});
+			insertMemory(db, {
+				id: "mem-deleted",
+				createdAt: "2026-03-04T09:00:00.000Z",
+				deleted: 1,
+			});
+
+			insertHistory(db, {
+				id: "hist-live",
+				memoryId: "mem-live",
+				event: "updated",
+				createdAt: "2026-03-04T10:00:00.000Z",
+			});
+			insertHistory(db, {
+				id: "hist-deleted",
+				memoryId: "mem-deleted",
+				event: "updated",
+				createdAt: "2026-03-04T10:00:00.000Z",
+			});
+
+			const timeline = buildMemoryTimeline(db as unknown as ReadDb, {
+				now: new Date("2026-03-04T16:00:00.000Z"),
+			});
+
+			expect(timeline.totalMemories).toBe(1);
+			expect(timeline.totalHistoryEvents).toBe(1);
+			expect(timeline.buckets[0]?.memoriesAdded).toBe(1);
+			expect(timeline.buckets[0]?.trackedEvents).toBe(1);
+		} finally {
+			db.close();
+		}
+	});
+});

--- a/packages/daemon/src/memory-timeline.ts
+++ b/packages/daemon/src/memory-timeline.ts
@@ -73,7 +73,6 @@ export interface MemoryTimelineBucket {
 	readonly typeBreakdown: readonly TimelineMetric[];
 	readonly sourceBreakdown: readonly TimelineMetric[];
 	readonly topTags: readonly TimelineMetric[];
-	readonly summary: string;
 }
 
 export interface MemoryTimelineResponse {
@@ -213,16 +212,6 @@ function sortMetrics(map: Map<string, number>, limit = 5): TimelineMetric[] {
 		.map(([key, count]) => ({ key, count }));
 }
 
-function bucketSummary(bucket: MutableBucket): string {
-	const added = `${bucket.memoriesAdded} added`;
-	const evolved = `${bucket.evolved} evolved`;
-	const strengthened = `${bucket.strengthened} strengthened`;
-	if (bucket.trackedEvents === 0) {
-		return `${added}. Quiet window with no tracked memory mutations.`;
-	}
-	return `${added}, ${evolved}, ${strengthened}. ${bucket.trackedEvents} tracked events captured.`;
-}
-
 export function buildMemoryTimeline(
 	db: ReadDb,
 	options?: {
@@ -341,7 +330,6 @@ export function buildMemoryTimeline(
 			typeBreakdown: sortMetrics(bucket.typeBreakdown),
 			sourceBreakdown: sortMetrics(bucket.sourceBreakdown),
 			topTags: sortMetrics(bucket.topTags),
-			summary: bucketSummary(bucket),
 		});
 	}
 

--- a/packages/daemon/src/memory-timeline.ts
+++ b/packages/daemon/src/memory-timeline.ts
@@ -341,8 +341,9 @@ export function buildMemoryTimeline(
 		// memoryRows.length includes rows with corrupt timestamps that fail parseTimestamp
 		// and are excluded from all buckets — subtract them for an accurate count.
 		totalMemories: memoryRows.length - invalidMemoryTimestamps,
-		// Count of history events within the 30-day window for non-deleted memories
-		totalHistoryEvents: historyRows.length,
+		// Same rationale as totalMemories: subtract corrupt-timestamp rows that are
+		// counted by historyRows.length but skipped via continue in the loop above.
+		totalHistoryEvents: historyRows.length - invalidHistoryTimestamps,
 		invalidMemoryTimestamps,
 		invalidHistoryTimestamps,
 		buckets: responseBuckets,

--- a/packages/daemon/src/memory-timeline.ts
+++ b/packages/daemon/src/memory-timeline.ts
@@ -337,8 +337,10 @@ export function buildMemoryTimeline(
 		generatedAt: new Date().toISOString(),
 		generatedFor: new Date(nowStartMs).toISOString(),
 		rangePreset: "today-last_week-one_month",
-		// Count of non-deleted memories within the 30-day query window, not the full DB total
-		totalMemories: memoryRows.length,
+		// Count of non-deleted memories within the 30-day query window with valid timestamps.
+		// memoryRows.length includes rows with corrupt timestamps that fail parseTimestamp
+		// and are excluded from all buckets — subtract them for an accurate count.
+		totalMemories: memoryRows.length - invalidMemoryTimestamps,
 		// Count of history events within the 30-day window for non-deleted memories
 		totalHistoryEvents: historyRows.length,
 		invalidMemoryTimestamps,

--- a/packages/daemon/src/memory-timeline.ts
+++ b/packages/daemon/src/memory-timeline.ts
@@ -1,0 +1,359 @@
+import type { ReadDb } from "./db-accessor";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const EVOLVED_EVENTS = new Set(["updated", "merged", "recovered"]);
+const STRENGTHENED_REASON_PATTERN =
+	/(reinfor|strength|consolidat|stabiliz|promot|confidence|refin)/i;
+
+interface MemoryRow {
+	readonly id: string;
+	readonly created_at: string;
+	readonly type: string | null;
+	readonly who: string | null;
+	readonly tags: string | null;
+	readonly importance: number | null;
+	readonly pinned: number | null;
+}
+
+interface HistoryRow {
+	readonly memory_id: string;
+	readonly event: string;
+	readonly reason: string | null;
+	readonly created_at: string;
+}
+
+interface RangeSpec {
+	readonly eraIndex: number;
+	readonly key: "today" | "last_week" | "one_month";
+	readonly label: "Today" | "Last week" | "One month";
+	readonly startDaysAgo: number;
+	readonly endDaysAgo: number;
+}
+
+const RANGE_SPECS: readonly RangeSpec[] = [
+	{
+		eraIndex: 0,
+		key: "today",
+		label: "Today",
+		startDaysAgo: 0,
+		endDaysAgo: 0,
+	},
+	{
+		eraIndex: 1,
+		key: "last_week",
+		label: "Last week",
+		startDaysAgo: 0,
+		endDaysAgo: 6,
+	},
+	{
+		eraIndex: 2,
+		key: "one_month",
+		label: "One month",
+		startDaysAgo: 0,
+		endDaysAgo: 29,
+	},
+] as const;
+
+export interface TimelineMetric {
+	readonly key: string;
+	readonly count: number;
+}
+
+export interface MemoryTimelineBucket {
+	readonly eraIndex: number;
+	readonly rangeKey: "today" | "last_week" | "one_month";
+	readonly label: "Today" | "Last week" | "One month";
+	readonly start: string;
+	readonly end: string;
+	readonly memoriesAdded: number;
+	readonly trackedEvents: number;
+	readonly evolved: number;
+	readonly strengthened: number;
+	readonly recovered: number;
+	readonly avgImportance: number;
+	readonly pinned: number;
+	readonly typeBreakdown: readonly TimelineMetric[];
+	readonly sourceBreakdown: readonly TimelineMetric[];
+	readonly topTags: readonly TimelineMetric[];
+	readonly summary: string;
+}
+
+export interface MemoryTimelineResponse {
+	readonly generatedAt: string;
+	readonly generatedFor: string;
+	readonly rangePreset: "today-last_week-one_month";
+	readonly totalMemories: number;
+	readonly totalHistoryEvents: number;
+	readonly invalidMemoryTimestamps: number;
+	readonly invalidHistoryTimestamps: number;
+	readonly buckets: readonly MemoryTimelineBucket[];
+}
+
+interface MutableBucket {
+	readonly spec: RangeSpec;
+	readonly startMs: number;
+	readonly endMs: number;
+	totalImportance: number;
+	importanceSamples: number;
+	memoriesAdded: number;
+	trackedEvents: number;
+	evolved: number;
+	strengthened: number;
+	recovered: number;
+	pinned: number;
+	readonly typeBreakdown: Map<string, number>;
+	readonly sourceBreakdown: Map<string, number>;
+	readonly topTags: Map<string, number>;
+}
+
+function startOfUtcDay(ms: number): number {
+	const d = new Date(ms);
+	return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+}
+
+function parseTimestamp(raw: string): number | null {
+	const parsed = Date.parse(raw);
+	if (!Number.isFinite(parsed)) return null;
+	return parsed;
+}
+
+function rangeBounds(spec: RangeSpec, nowStartMs: number): {
+	startMs: number;
+	endMs: number;
+} {
+	if (spec.startDaysAgo === 0 && spec.endDaysAgo === 0) {
+		return {
+			startMs: nowStartMs,
+			endMs: nowStartMs + MS_PER_DAY - 1,
+		};
+	}
+
+	const startMs = nowStartMs - spec.endDaysAgo * MS_PER_DAY;
+	const endMs = nowStartMs - (spec.startDaysAgo - 1) * MS_PER_DAY - 1;
+	return { startMs, endMs };
+}
+
+function createBuckets(nowStartMs: number): Map<RangeSpec["eraIndex"], MutableBucket> {
+	const buckets = new Map<RangeSpec["eraIndex"], MutableBucket>();
+	for (const spec of RANGE_SPECS) {
+		const { startMs, endMs } = rangeBounds(spec, nowStartMs);
+		buckets.set(spec.eraIndex, {
+			spec,
+			startMs,
+			endMs,
+			totalImportance: 0,
+			importanceSamples: 0,
+			memoriesAdded: 0,
+			trackedEvents: 0,
+			evolved: 0,
+			strengthened: 0,
+			recovered: 0,
+			pinned: 0,
+			typeBreakdown: new Map<string, number>(),
+			sourceBreakdown: new Map<string, number>(),
+			topTags: new Map<string, number>(),
+		});
+	}
+	return buckets;
+}
+
+function forEachMatchingBucket(
+	timestampMs: number,
+	buckets: Map<RangeSpec["eraIndex"], MutableBucket>,
+	cb: (bucket: MutableBucket) => void,
+): boolean {
+	let matched = false;
+	for (const spec of RANGE_SPECS) {
+		const bucket = buckets.get(spec.eraIndex);
+		if (!bucket) continue;
+		if (timestampMs >= bucket.startMs && timestampMs <= bucket.endMs) {
+			matched = true;
+			cb(bucket);
+		}
+	}
+	return matched;
+}
+
+function incMap(target: Map<string, number>, key: string): void {
+	target.set(key, (target.get(key) ?? 0) + 1);
+}
+
+function normalizeMetricKey(
+	raw: string | null | undefined,
+	fallback: string,
+): string {
+	const trimmed = raw?.trim();
+	if (!trimmed) return fallback;
+	return trimmed;
+}
+
+function parseTags(raw: string | null): string[] {
+	if (!raw) return [];
+	const trimmed = raw.trim();
+	if (!trimmed) return [];
+
+	if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+		try {
+			const parsed = JSON.parse(trimmed);
+			if (Array.isArray(parsed)) {
+				return parsed
+					.filter((tag) => typeof tag === "string")
+					.map((tag) => tag.trim())
+					.filter((tag) => tag.length > 0);
+			}
+		} catch {
+			// fall through to csv parsing
+		}
+	}
+
+	return trimmed
+		.split(",")
+		.map((tag) => tag.trim())
+		.filter((tag) => tag.length > 0);
+}
+
+function sortMetrics(map: Map<string, number>, limit = 5): TimelineMetric[] {
+	return [...map.entries()]
+		.sort((a, b) => {
+			if (b[1] !== a[1]) return b[1] - a[1];
+			return a[0].localeCompare(b[0]);
+		})
+		.slice(0, limit)
+		.map(([key, count]) => ({ key, count }));
+}
+
+function bucketSummary(bucket: MutableBucket): string {
+	const added = `${bucket.memoriesAdded} added`;
+	const evolved = `${bucket.evolved} evolved`;
+	const strengthened = `${bucket.strengthened} strengthened`;
+	if (bucket.trackedEvents === 0) {
+		return `${added}. Quiet window with no tracked memory mutations.`;
+	}
+	return `${added}, ${evolved}, ${strengthened}. ${bucket.trackedEvents} tracked events captured.`;
+}
+
+export function buildMemoryTimeline(
+	db: ReadDb,
+	options?: {
+		readonly now?: Date;
+	},
+): MemoryTimelineResponse {
+	const now = options?.now ?? new Date();
+	const nowStartMs = startOfUtcDay(now.getTime());
+	const buckets = createBuckets(nowStartMs);
+
+	const memoryRows = db
+		.prepare(
+			`SELECT id, created_at, type, who, tags, importance, pinned
+			 FROM memories
+			 WHERE is_deleted = 0
+			 ORDER BY created_at DESC`,
+		)
+		.all() as MemoryRow[];
+
+	const historyRows = db
+		.prepare(
+			`SELECT h.memory_id, h.event, h.reason, h.created_at
+			 FROM memory_history h
+			 INNER JOIN memories m ON m.id = h.memory_id
+			 WHERE m.is_deleted = 0
+			 ORDER BY h.created_at DESC`,
+		)
+		.all() as HistoryRow[];
+
+	let invalidMemoryTimestamps = 0;
+	let invalidHistoryTimestamps = 0;
+
+	for (const row of memoryRows) {
+		const ts = parseTimestamp(row.created_at);
+		if (ts === null) {
+			invalidMemoryTimestamps += 1;
+			continue;
+		}
+
+		forEachMatchingBucket(ts, buckets, (bucket) => {
+			bucket.memoriesAdded += 1;
+			if (row.pinned === 1) bucket.pinned += 1;
+
+			if (
+				typeof row.importance === "number" &&
+				Number.isFinite(row.importance)
+			) {
+				bucket.totalImportance += row.importance;
+				bucket.importanceSamples += 1;
+			}
+
+			incMap(bucket.typeBreakdown, normalizeMetricKey(row.type, "unknown"));
+			incMap(bucket.sourceBreakdown, normalizeMetricKey(row.who, "unknown"));
+
+			const tags = parseTags(row.tags);
+			for (const tag of tags) {
+				incMap(bucket.topTags, tag);
+			}
+		});
+	}
+
+	for (const row of historyRows) {
+		const ts = parseTimestamp(row.created_at);
+		if (ts === null) {
+			invalidHistoryTimestamps += 1;
+			continue;
+		}
+
+		forEachMatchingBucket(ts, buckets, (bucket) => {
+			bucket.trackedEvents += 1;
+			if (EVOLVED_EVENTS.has(row.event)) {
+				bucket.evolved += 1;
+			}
+			if (row.event === "recovered") {
+				bucket.recovered += 1;
+			}
+			if (row.event === "updated" || row.event === "merged") {
+				bucket.strengthened += 1;
+			} else if (row.reason && STRENGTHENED_REASON_PATTERN.test(row.reason)) {
+				bucket.strengthened += 1;
+			}
+		});
+	}
+
+	const responseBuckets: MemoryTimelineBucket[] = [];
+	for (const spec of RANGE_SPECS) {
+		const bucket = buckets.get(spec.eraIndex);
+		if (!bucket) continue;
+		const avgImportance =
+			bucket.importanceSamples > 0
+				? Number((bucket.totalImportance / bucket.importanceSamples).toFixed(3))
+				: 0;
+
+		responseBuckets.push({
+			eraIndex: spec.eraIndex,
+			rangeKey: spec.key,
+			label: spec.label,
+			start: new Date(bucket.startMs).toISOString(),
+			end: new Date(bucket.endMs).toISOString(),
+			memoriesAdded: bucket.memoriesAdded,
+			trackedEvents: bucket.trackedEvents,
+			evolved: bucket.evolved,
+			strengthened: bucket.strengthened,
+			recovered: bucket.recovered,
+			avgImportance,
+			pinned: bucket.pinned,
+			typeBreakdown: sortMetrics(bucket.typeBreakdown),
+			sourceBreakdown: sortMetrics(bucket.sourceBreakdown),
+			topTags: sortMetrics(bucket.topTags),
+			summary: bucketSummary(bucket),
+		});
+	}
+
+	return {
+		generatedAt: new Date().toISOString(),
+		generatedFor: new Date(nowStartMs).toISOString(),
+		rangePreset: "today-last_week-one_month",
+		totalMemories: memoryRows.length,
+		totalHistoryEvents: historyRows.length,
+		invalidMemoryTimestamps,
+		invalidHistoryTimestamps,
+		buckets: responseBuckets,
+	};
+}

--- a/packages/daemon/src/memory-timeline.ts
+++ b/packages/daemon/src/memory-timeline.ts
@@ -27,8 +27,8 @@ interface RangeSpec {
 	readonly eraIndex: number;
 	readonly key: "today" | "last_week" | "one_month";
 	readonly label: "Today" | "Last week" | "One month";
-	readonly startDaysAgo: number;
-	readonly endDaysAgo: number;
+	/** Number of days the range spans, starting from "today" and going back */
+	readonly lookbackDays: number;
 }
 
 const RANGE_SPECS: readonly RangeSpec[] = [
@@ -36,22 +36,19 @@ const RANGE_SPECS: readonly RangeSpec[] = [
 		eraIndex: 0,
 		key: "today",
 		label: "Today",
-		startDaysAgo: 0,
-		endDaysAgo: 0,
+		lookbackDays: 1,
 	},
 	{
 		eraIndex: 1,
 		key: "last_week",
 		label: "Last week",
-		startDaysAgo: 0,
-		endDaysAgo: 6,
+		lookbackDays: 7,
 	},
 	{
 		eraIndex: 2,
 		key: "one_month",
 		label: "One month",
-		startDaysAgo: 0,
-		endDaysAgo: 29,
+		lookbackDays: 30,
 	},
 ] as const;
 
@@ -122,15 +119,8 @@ function rangeBounds(spec: RangeSpec, nowStartMs: number): {
 	startMs: number;
 	endMs: number;
 } {
-	if (spec.startDaysAgo === 0 && spec.endDaysAgo === 0) {
-		return {
-			startMs: nowStartMs,
-			endMs: nowStartMs + MS_PER_DAY - 1,
-		};
-	}
-
-	const startMs = nowStartMs - spec.endDaysAgo * MS_PER_DAY;
-	const endMs = nowStartMs - (spec.startDaysAgo - 1) * MS_PER_DAY - 1;
+	const startMs = nowStartMs - (spec.lookbackDays - 1) * MS_PER_DAY;
+	const endMs = nowStartMs + MS_PER_DAY - 1;
 	return { startMs, endMs };
 }
 
@@ -243,14 +233,19 @@ export function buildMemoryTimeline(
 	const nowStartMs = startOfUtcDay(now.getTime());
 	const buckets = createBuckets(nowStartMs);
 
+	// Widest bucket is 30 days — filter SQL to avoid full table scan
+	const cutoffMs = nowStartMs - 29 * MS_PER_DAY;
+	const cutoffIso = new Date(cutoffMs).toISOString();
+
 	const memoryRows = db
 		.prepare(
 			`SELECT id, created_at, type, who, tags, importance, pinned
 			 FROM memories
 			 WHERE is_deleted = 0
+			   AND created_at >= ?
 			 ORDER BY created_at DESC`,
 		)
-		.all() as MemoryRow[];
+		.all(cutoffIso) as MemoryRow[];
 
 	const historyRows = db
 		.prepare(
@@ -258,9 +253,10 @@ export function buildMemoryTimeline(
 			 FROM memory_history h
 			 INNER JOIN memories m ON m.id = h.memory_id
 			 WHERE m.is_deleted = 0
+			   AND h.created_at >= ?
 			 ORDER BY h.created_at DESC`,
 		)
-		.all() as HistoryRow[];
+		.all(cutoffIso) as HistoryRow[];
 
 	let invalidMemoryTimestamps = 0;
 	let invalidHistoryTimestamps = 0;
@@ -305,14 +301,16 @@ export function buildMemoryTimeline(
 			bucket.trackedEvents += 1;
 			if (EVOLVED_EVENTS.has(row.event)) {
 				bucket.evolved += 1;
+				// Only count strengthened for events that also count as evolved
+				// (updated/merged imply strength; recovered with strengthening reason also counts)
+				if (row.event === "updated" || row.event === "merged") {
+					bucket.strengthened += 1;
+				} else if (row.reason && STRENGTHENED_REASON_PATTERN.test(row.reason)) {
+					bucket.strengthened += 1;
+				}
 			}
 			if (row.event === "recovered") {
 				bucket.recovered += 1;
-			}
-			if (row.event === "updated" || row.event === "merged") {
-				bucket.strengthened += 1;
-			} else if (row.reason && STRENGTHENED_REASON_PATTERN.test(row.reason)) {
-				bucket.strengthened += 1;
 			}
 		});
 	}
@@ -350,7 +348,9 @@ export function buildMemoryTimeline(
 		generatedAt: new Date().toISOString(),
 		generatedFor: new Date(nowStartMs).toISOString(),
 		rangePreset: "today-last_week-one_month",
+		// Count of non-deleted memories within the 30-day query window, not the full DB total
 		totalMemories: memoryRows.length,
+		// Count of history events within the 30-day window for non-deleted memories
 		totalHistoryEvents: historyRows.length,
 		invalidMemoryTimestamps,
 		invalidHistoryTimestamps,

--- a/packages/daemon/src/memory-timeline.ts
+++ b/packages/daemon/src/memory-timeline.ts
@@ -319,10 +319,11 @@ export function buildMemoryTimeline(
 	for (const spec of RANGE_SPECS) {
 		const bucket = buckets.get(spec.eraIndex);
 		if (!bucket) continue;
-		const avgImportance =
+		const rawAvg =
 			bucket.importanceSamples > 0
-				? Number((bucket.totalImportance / bucket.importanceSamples).toFixed(3))
+				? bucket.totalImportance / bucket.importanceSamples
 				: 0;
+		const avgImportance = Number(Math.min(1, Math.max(0, rawAvg)).toFixed(3));
 
 		responseBuckets.push({
 			eraIndex: spec.eraIndex,


### PR DESCRIPTION
## What

Adds a new Timeline tab to the dashboard showing a recap view of Signet's memory evolution over time periods (today, 7 days, 30 days).

## Why

Users need visibility into how their agent's memory has grown and evolved - what types of memories were captured, which skills and MCP servers were mentioned, and what the most important memories are per time bucket. This gives a birds-eye view of the agent's learning journey.

## How

- New `/api/memory/timeline` daemon endpoint that aggregates memories into time buckets with statistics (counts by type, source, tags, evolution events)
- `memory-timeline.ts` module builds bucketed stats with SQL date-range filtering for performance
- `TimelineTab.svelte` renders era navigation, hero metrics, summary panels, and top memories grid
- Client-side fallback builds timeline from raw memories when daemon endpoint unavailable
- Shared memory fetch promise between main load and fallback path to avoid duplicate requests

## Changes from original PR #139

The original PR was corrupted when Greptile review suggestions were accepted via GitHub web UI - the suggestions were code review comments that got applied literally as code, destroying working functions. This PR cherry-picks the original feature commit and applies all legitimate fixes properly:

- Add `requirePermission('recall')` guard for timeline endpoint
- Simplify `RangeSpec` to use single `lookbackDays` field instead of confusing `startDaysAgo`/`endDaysAgo`
- Add 30-day SQL date-range WHERE clause to avoid full table scans
- Fix `strengthened` counter to only increment within `EVOLVED_EVENTS` check
- Add clarifying comments for `totalMemories`/`totalHistoryEvents` fields
- Fix `buildTimelineFallback` ranges to use `lookbackDays`
- Fix `totalMemories` in fallback to use widest bucket (30-day) count
- Fix `parseTags` JSON-error path to fall through to CSV parsing
- Add AbortController with 10s timeout to `getMemoryTimeline` fetch
- Wrap fallback await in nested try/catch
- Allow `getMemoryTimeline` to accept caller-provided fallback memories
- Remove stale `openclaw-memory` MCP signal check
- Fix `inferMcpUsageFromBucket` to use only sourceSignals (avoid double-counting)
- Fix MCP server counting - key `mcpSet` by serverId instead of matched value
- Fix MCP signal detection - exclude `memory.content`, use `signalText` with only who/type/tags
- Fix `mcpMentionIds` fallback - change to boolean `hasMcpSignal` flag, cap at 1
- Move `loading = false` to `finally` block in `loadTimeline`
- Update `loadTimeline` to share memory fetch promise with `getMemoryTimeline`
- Fix `formatDateRange` timezone - use UTC formatting
- Fix `formatMemoryMoment` timezone - use UTC formatting
- Fix `formatTimelineGeneratedFor` timezone - use UTC formatting

## Testing

- `bun run check` ✅
- `bun run build` ✅
- `bun test packages/daemon/src/memory-timeline.test.ts` ✅ (3 tests pass)

Closes #139