### PR TITLE
feat: daemon-driven MEMORY.md synthesis on schedule

### DIFF
--- a/packages/daemon/src/logger.ts
+++ b/packages/daemon/src/logger.ts
@@ -32,6 +32,7 @@ export type LogCategory =
 	| "pipeline" // Extraction/decision pipeline
 	| "embedding-tracker" // Incremental embedding refresh tracker
 	| "summary-worker" // Session summary worker
+	| "synthesis" // MEMORY.md synthesis worker
 	| "session-memories" // Session memory tracking
 	| "system" // System events
 	| "update"; // Auto-update cycle

--- a/packages/daemon/src/pipeline/index.ts
+++ b/packages/daemon/src/pipeline/index.ts
@@ -2,32 +2,20 @@
  * Pipeline barrel — startPipeline/stopPipeline orchestration.
  */
 
-import type { DbAccessor } from "../db-accessor";
-import type { EmbeddingConfig, PipelineV2Config } from "../memory-config";
-import { getLlmProvider } from "../llm";
-import { startWorker, type WorkerHandle } from "./worker";
-import {
-	startRetentionWorker,
-	DEFAULT_RETENTION,
-	type RetentionHandle,
-} from "./retention-worker";
-import {
-	startMaintenanceWorker,
-	type MaintenanceHandle,
-} from "./maintenance-worker";
-import {
-	startDocumentWorker,
-	type DocumentWorkerHandle,
-} from "./document-worker";
-import {
-	startSummaryWorker,
-	type SummaryWorkerHandle,
-} from "./summary-worker";
-import type { DecisionConfig } from "./decision";
-import type { ProviderTracker } from "../diagnostics";
 import type { AnalyticsCollector } from "../analytics";
-import type { TelemetryCollector } from "../telemetry";
+import type { DbAccessor } from "../db-accessor";
+import type { ProviderTracker } from "../diagnostics";
+import { getLlmProvider } from "../llm";
 import { logger } from "../logger";
+import type { EmbeddingConfig, PipelineV2Config } from "../memory-config";
+import type { TelemetryCollector } from "../telemetry";
+import type { DecisionConfig } from "./decision";
+import { type DocumentWorkerHandle, startDocumentWorker } from "./document-worker";
+import { type MaintenanceHandle, startMaintenanceWorker } from "./maintenance-worker";
+import { DEFAULT_RETENTION, type RetentionHandle, startRetentionWorker } from "./retention-worker";
+import { type SummaryWorkerHandle, startSummaryWorker } from "./summary-worker";
+import { type SynthesisWorkerHandle, startSynthesisWorker } from "./synthesis-worker";
+import { type WorkerHandle, startWorker } from "./worker";
 
 export { enqueueExtractionJob } from "./worker";
 export { enqueueDocumentIngestJob } from "./document-worker";
@@ -43,6 +31,8 @@ export type { RetentionHandle, RetentionConfig } from "./retention-worker";
 export type { MaintenanceHandle } from "./maintenance-worker";
 export { startSummaryWorker, enqueueSummaryJob } from "./summary-worker";
 export type { SummaryWorkerHandle } from "./summary-worker";
+export { startSynthesisWorker } from "./synthesis-worker";
+export type { SynthesisWorkerHandle } from "./synthesis-worker";
 
 // ---------------------------------------------------------------------------
 // Singleton state
@@ -53,6 +43,7 @@ let retentionHandle: RetentionHandle | null = null;
 let maintenanceHandle: MaintenanceHandle | null = null;
 let documentWorkerHandle: DocumentWorkerHandle | null = null;
 let summaryWorkerHandle: SummaryWorkerHandle | null = null;
+let synthesisWorkerHandle: SynthesisWorkerHandle | null = null;
 
 /** Snapshot of running state for each worker — used by /api/pipeline/status */
 export function getPipelineWorkerStatus(): Record<string, { running: boolean }> {
@@ -62,6 +53,7 @@ export function getPipelineWorkerStatus(): Record<string, { running: boolean }> 
 		document: { running: documentWorkerHandle !== null },
 		retention: { running: retentionHandle !== null },
 		maintenance: { running: maintenanceHandle !== null },
+		synthesis: { running: synthesisWorkerHandle !== null },
 	};
 }
 
@@ -73,10 +65,7 @@ export function startPipeline(
 	accessor: DbAccessor,
 	pipelineCfg: PipelineV2Config,
 	embeddingCfg: EmbeddingConfig,
-	fetchEmbedding: (
-		text: string,
-		cfg: EmbeddingConfig,
-	) => Promise<number[] | null>,
+	fetchEmbedding: (text: string, cfg: EmbeddingConfig) => Promise<number[] | null>,
 	searchCfg: { alpha: number; top_k: number; min_score: number },
 	providerTracker?: ProviderTracker,
 	analytics?: AnalyticsCollector,
@@ -105,12 +94,7 @@ export function startPipeline(
 
 	// Maintenance worker (F3) — runs alongside retention
 	if (!maintenanceHandle && providerTracker) {
-		maintenanceHandle = startMaintenanceWorker(
-			accessor,
-			pipelineCfg,
-			providerTracker,
-			retentionHandle,
-		);
+		maintenanceHandle = startMaintenanceWorker(accessor, pipelineCfg, providerTracker, retentionHandle);
 	}
 
 	// Document ingest worker runs alongside the extraction pipeline
@@ -128,17 +112,22 @@ export function startPipeline(
 		summaryWorkerHandle = startSummaryWorker(accessor);
 	}
 
+	// Synthesis worker — periodic MEMORY.md regeneration
+	if (!synthesisWorkerHandle) {
+		synthesisWorkerHandle = startSynthesisWorker();
+	}
+
 	logger.info("pipeline", "Pipeline started", {
 		mode:
-			pipelineCfg.enabled &&
-			!pipelineCfg.shadowMode &&
-			!pipelineCfg.mutationsFrozen
-				? "controlled-write"
-				: "shadow",
+			pipelineCfg.enabled && !pipelineCfg.shadowMode && !pipelineCfg.mutationsFrozen ? "controlled-write" : "shadow",
 	});
 }
 
 export async function stopPipeline(): Promise<void> {
+	if (synthesisWorkerHandle) {
+		synthesisWorkerHandle.stop();
+		synthesisWorkerHandle = null;
+	}
 	if (summaryWorkerHandle) {
 		summaryWorkerHandle.stop();
 		summaryWorkerHandle = null;

--- a/packages/daemon/src/pipeline/synthesis-worker.ts
+++ b/packages/daemon/src/pipeline/synthesis-worker.ts
@@ -1,0 +1,223 @@
+/**
+ * Synthesis worker: periodic MEMORY.md regeneration.
+ *
+ * Reads the synthesis schedule from agent.yaml, calls the daemon's own
+ * LLM provider to summarize recent memories, and writes the result to
+ * MEMORY.md via the existing synthesis-complete logic.
+ *
+ * This closes the loop that previously required an external harness
+ * (OpenClaw, Claude Code) to drive the two-step synthesis hook.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { type MemorySynthesisConfig, getSynthesisConfig, handleSynthesisRequest } from "../hooks";
+import { getLlmProvider } from "../llm";
+import { logger } from "../logger";
+import { generateWithTracking } from "./provider";
+
+const AGENTS_DIR = join(homedir(), ".agents");
+
+// ---------------------------------------------------------------------------
+// Schedule helpers
+// ---------------------------------------------------------------------------
+
+const SCHEDULE_INTERVALS: Record<string, number> = {
+	daily: 24 * 60 * 60 * 1000,
+	weekly: 7 * 24 * 60 * 60 * 1000,
+};
+
+/** Check interval — how often we check if synthesis is due (5 min). */
+const CHECK_INTERVAL_MS = 5 * 60 * 1000;
+
+/** Minimum time between syntheses to avoid rapid re-runs (1 hour). */
+const MIN_INTERVAL_MS = 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Timestamp persistence
+// ---------------------------------------------------------------------------
+
+function getLastSynthesisPath(): string {
+	return join(AGENTS_DIR, ".daemon", "last-synthesis.json");
+}
+
+function readLastSynthesisTime(): number {
+	try {
+		const path = getLastSynthesisPath();
+		if (!existsSync(path)) return 0;
+		const data = JSON.parse(readFileSync(path, "utf-8"));
+		return typeof data.lastRunAt === "number" ? data.lastRunAt : 0;
+	} catch {
+		return 0;
+	}
+}
+
+function writeLastSynthesisTime(timestamp: number): void {
+	try {
+		const path = getLastSynthesisPath();
+		mkdirSync(join(AGENTS_DIR, ".daemon"), { recursive: true });
+		writeFileSync(path, JSON.stringify({ lastRunAt: timestamp }));
+	} catch (e) {
+		logger.warn("synthesis", "Failed to persist synthesis timestamp", {
+			error: (e as Error).message,
+		});
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Core synthesis execution
+// ---------------------------------------------------------------------------
+
+async function runSynthesis(config: MemorySynthesisConfig): Promise<boolean> {
+	logger.info("synthesis", "Starting scheduled synthesis", {
+		model: config.model,
+		schedule: config.schedule,
+	});
+
+	try {
+		// Step 1: Get the synthesis prompt with memories
+		const synthesisData = handleSynthesisRequest({ trigger: "scheduled" });
+
+		if (synthesisData.memories.length === 0) {
+			logger.info("synthesis", "No memories to synthesize, skipping");
+			return true;
+		}
+
+		// Step 2: Call LLM to generate the summary
+		const provider = getLlmProvider();
+		const result = await generateWithTracking(provider, synthesisData.prompt, {
+			maxTokens: config.max_tokens ?? 4000,
+			timeoutMs: 120_000,
+		});
+
+		if (!result.text || result.text.trim().length === 0) {
+			logger.warn("synthesis", "LLM returned empty synthesis");
+			return false;
+		}
+
+		// Step 3: Write MEMORY.md (same logic as synthesis-complete endpoint)
+		const memoryMdPath = join(AGENTS_DIR, "MEMORY.md");
+
+		// Backup existing
+		if (existsSync(memoryMdPath)) {
+			const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+			const backupPath = join(AGENTS_DIR, "memory", `MEMORY.backup-${timestamp}.md`);
+			mkdirSync(join(AGENTS_DIR, "memory"), { recursive: true });
+			writeFileSync(backupPath, readFileSync(memoryMdPath, "utf-8"));
+		}
+
+		// Write new MEMORY.md
+		const header = `<!-- generated ${new Date().toISOString().slice(0, 16).replace("T", " ")} -->\n\n`;
+		writeFileSync(memoryMdPath, header + result.text);
+
+		logger.info("synthesis", "MEMORY.md synthesized", {
+			memories: synthesisData.memories.length,
+			outputLength: result.text.length,
+			...(result.usage
+				? {
+						inputTokens: result.usage.inputTokens,
+						outputTokens: result.usage.outputTokens,
+					}
+				: {}),
+		});
+
+		return true;
+	} catch (e) {
+		logger.error("synthesis", "Synthesis failed", e as Error);
+		return false;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Worker handle
+// ---------------------------------------------------------------------------
+
+export interface SynthesisWorkerHandle {
+	stop(): void;
+	readonly running: boolean;
+	/** Trigger an immediate synthesis (e.g. from API). */
+	triggerNow(): Promise<boolean>;
+}
+
+export function startSynthesisWorker(): SynthesisWorkerHandle {
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	let stopped = false;
+
+	async function tick(): Promise<void> {
+		if (stopped) return;
+
+		try {
+			const config = getSynthesisConfig();
+
+			// "on-demand" means never auto-run
+			if (config.schedule === "on-demand") {
+				scheduleTick(CHECK_INTERVAL_MS);
+				return;
+			}
+
+			const interval = SCHEDULE_INTERVALS[config.schedule] ?? SCHEDULE_INTERVALS.daily;
+			const lastRun = readLastSynthesisTime();
+			const elapsed = Date.now() - lastRun;
+
+			if (elapsed < interval) {
+				// Not due yet
+				scheduleTick(CHECK_INTERVAL_MS);
+				return;
+			}
+
+			const success = await runSynthesis(config);
+			if (success) {
+				writeLastSynthesisTime(Date.now());
+			}
+		} catch (e) {
+			logger.error("synthesis", "Unhandled tick error", e as Error);
+		}
+
+		scheduleTick(CHECK_INTERVAL_MS);
+	}
+
+	function scheduleTick(delay: number): void {
+		if (stopped) return;
+		timer = setTimeout(() => {
+			tick().catch((err) => {
+				logger.error("synthesis", "Unhandled tick error", err as Error);
+			});
+		}, delay);
+	}
+
+	// Initial delay: 60s after daemon start to let other workers settle
+	scheduleTick(60_000);
+
+	logger.info("synthesis", "Synthesis worker started");
+
+	return {
+		stop() {
+			stopped = true;
+			if (timer) clearTimeout(timer);
+			logger.info("synthesis", "Synthesis worker stopped");
+		},
+		get running() {
+			return !stopped;
+		},
+		async triggerNow(): Promise<boolean> {
+			const config = getSynthesisConfig();
+			const lastRun = readLastSynthesisTime();
+			const elapsed = Date.now() - lastRun;
+
+			if (elapsed < MIN_INTERVAL_MS) {
+				logger.info("synthesis", "Skipping manual trigger — too recent", {
+					elapsedMs: elapsed,
+					minIntervalMs: MIN_INTERVAL_MS,
+				});
+				return false;
+			}
+
+			const success = await runSynthesis(config);
+			if (success) {
+				writeLastSynthesisTime(Date.now());
+			}
+			return success;
+		},
+	};
+}


### PR DESCRIPTION
## Summary

- The synthesis hooks (`POST /api/hooks/synthesis` + `/synthesis/complete`) require an external harness to drive the two-step LLM call. Nothing triggers this automatically, so `MEMORY.md` stays empty even when `schedule: "daily"` is configured in `agent.yaml`.
- Adds a **synthesis worker** to the daemon pipeline that closes the loop internally — using the daemon's own LLM provider to generate the summary and write `MEMORY.md` on schedule.
- Follows the same patterns as `summary-worker.ts` (timer-based polling, graceful start/stop, singleton lifecycle in `index.ts`).

## What it does

1. Reads `memory.synthesis.schedule` from `agent.yaml` (`daily` / `weekly` / `on-demand`)
2. Checks every 5 minutes if synthesis is due (based on persisted last-run timestamp in `~/.agents/.daemon/last-synthesis.json`)
3. Calls `handleSynthesisRequest()` to build the prompt with top 100 memories
4. Runs the prompt through `generateWithTracking()` using the daemon's LLM provider
5. Writes `MEMORY.md` with backup (same logic as the `synthesis-complete` endpoint)
6. Exposes `triggerNow()` on the worker handle for manual/API-driven synthesis
7. 1-hour minimum interval between runs as a safety net

## Files changed

- **New:** `packages/daemon/src/pipeline/synthesis-worker.ts` — the synthesis worker
- **Modified:** `packages/daemon/src/pipeline/index.ts` — wired into pipeline start/stop lifecycle
- **Modified:** `packages/daemon/src/logger.ts` — added `"synthesis"` log category

## Test plan

- [ ] `bun run build` passes
- [ ] `bun run typecheck` passes
- [ ] Start daemon with `schedule: "daily"` in `agent.yaml` — verify synthesis runs after 60s startup delay
- [ ] Verify `MEMORY.md` is written with `<!-- generated -->` header
- [ ] Verify backup created in `~/.agents/memory/MEMORY.backup-*.md`
- [ ] Set `schedule: "on-demand"` — verify synthesis does not auto-run
- [ ] Check `GET /api/pipeline/status` includes `synthesis: { running: true }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)