### PR TITLE
docs: remediate P0/P1 drift from March 2026 audit

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -4,6 +4,7 @@ description: "Agent identity and configuration format."
 order: 26
 section: "Project"
 ---
+<!-- Source of truth: /CLAUDE.md (AGENTS.md) — do not edit manually -->
 
 ---
 Repo: github.com/signetai/signetai 
@@ -31,7 +32,8 @@ What is Signetai?
 
 Signetai is the reference implementation of Signet, an open standard
 for portable AI agent identity. It includes a [[cli|CLI tool]], background
-[[daemon]] with [[api|HTTP API]], and web [[dashboard]].
+[[daemon]] with [[api|HTTP API]] and MCP server, static [[dashboard]],
+harness connectors, [[sdk|SDK]], website, and supporting runtime packages.
 
 **Always read `VISION.md` at the start of every session.** It describes
 what Signet is building toward and should anchor development decisions.
@@ -57,7 +59,7 @@ bun run deploy:web       # Shortcut for web wrangler deploy
 order will cause dependency errors:
 
 ```
-build:core → build:connector-base → build:deps (parallel) → build:signetai
+build:core → build:connector-base → build:opencode-plugin → build:native → build:deps → build:signetai
 ```
 
 ### Testing
@@ -116,14 +118,20 @@ bun run test     # Tests (vitest + workers pool)
 | `@signet/core` | Core library: types, database, search, manifest, identity | node |
 | `@signet/connector-base` | Shared connector primitives/utilities | node |
 | `@signet/cli` | CLI tool: setup wizard, daemon management | node |
-| `@signet/daemon` | Background service: HTTP API, file watching | bun |
+| `@signet/daemon` | Background service: HTTP API, MCP server, file watching | bun |
+| `@signet/extension` | Browser extension: popup dashboard, highlight-to-remember | browser |
 | `@signet/sdk` | Integration SDK for third-party apps | node |
 | `@signet/connector-claude-code` | Claude Code connector: hooks, CLAUDE.md generation | node |
+| `@signet/connector-codex` | Codex connector: wrapper install, config patching, session hooks | node |
 | `@signet/connector-opencode` | OpenCode connector: plugin, AGENTS.md sync | node |
 | `@signet/connector-openclaw` | OpenClaw connector: config patching, hook handlers | node |
-| `@signetai/adapter-openclaw` | OpenClaw runtime plugin for calling Signet daemon | node |
+| `@signet/opencode-plugin` | OpenCode runtime plugin: memory tools and session hooks | node |
+| `@signetai/signet-memory-openclaw` | OpenClaw runtime plugin for calling Signet daemon | node |
+| `@signet/native` | Native accelerators for built-in embeddings and future local fast paths | native |
+| `@signet/tray` | Tauri-based system tray application | desktop |
 | `signetai` | Meta-package bundling CLI + daemon | - |
-| `@signet/web` | Marketing website (Cloudflare Worker) | cloudflare |
+| `@signet/web` | Marketing website (Astro static, Cloudflare Pages) | cloudflare |
+| `predictor` | Predictive memory scorer sidecar (WIP) | rust |
 
 ### Package Responsibilities
 
@@ -147,11 +155,14 @@ bun run test     # Tests (vitest + workers pool)
 
 **@signet/daemon** - Background service
 - Hono HTTP server on port 3850
+- Streamable HTTP MCP server plus stdio MCP entrypoint
 - File watching with debounced sync
 - Auto-commit on config changes
 - System service (launchd/systemd)
 - Pipeline V2 (`src/pipeline/`) — LLM-based memory extraction
 - Session tracker — plugin vs legacy runtime path mutex
+- Update system (`update-system.ts`) — extracted singleton module
+  with `getUpdateState()` / `getUpdateSummary()` accessors
 
 **@signet/sdk** - Third-party integration
 - SignetSDK class for embedding Signet in apps
@@ -180,7 +191,7 @@ bun run test     # Tests (vitest + workers pool)
 │                     Signet Daemon                       │
 ├─────────────────────────────────────────────────────────┤
 │  HTTP Server (port 3850)                                │
-│    /              Dashboard (SvelteKit static)          │
+│    /              Dashboard (Svelte 5 + Tailwind v4 + bits-ui) │
 │    /api/*         Config, memory, skills, hooks, update │
 │    /memory/*      Search and similarity aliases          │
 │    /health        Health check                          │
@@ -223,9 +234,9 @@ Notable pipeline files beyond the main worker:
 ### Database Migrations
 
 `packages/core/src/migrations/` contains numbered migrations
-(001-baseline through 010-umap-cache). These run automatically on
-daemon startup. Add new migrations as sequential `.ts` files and
-register them in the migrations index.
+(currently `001-baseline.ts` through `017-task-skills.ts`). These run
+automatically on daemon startup. Add new migrations as sequential `.ts`
+files and register them in the migrations index.
 
 ### Auth Middleware
 
@@ -261,7 +272,7 @@ All user data lives at `~/.agents/`:
 - `packages/core/src/identity.ts` - Identity file detection/loading
 - `packages/core/src/database.ts` - SQLite wrapper
 - `packages/core/src/search.ts` - Hybrid search
-- `packages/core/src/migrations/` - Database migrations (001 through 010)
+- `packages/core/src/migrations/` - Database migrations (001 through 017)
 - `packages/core/src/skills.ts` - Skills unification across harnesses
 - `packages/cli/src/cli.ts` - Main CLI entrypoint (~4600 LOC)
 - `packages/daemon/src/daemon.ts` - HTTP server + watcher
@@ -280,14 +291,24 @@ All user data lives at `~/.agents/`:
 - `packages/daemon/src/repair-actions.ts` - Repair actions for broken state
 - `packages/daemon/src/connectors/` - Connector framework
 - `packages/daemon/src/content-normalization.ts` - Content normalization
+- `packages/daemon/src/scheduler/` - Scheduled task worker (cron, spawn, polling)
+- `packages/daemon/src/embedding-tracker.ts` - Incremental embedding refresh tracker
+- `packages/daemon/src/embedding-health.ts` - Embedding health metrics
+- `packages/daemon/src/session-checkpoints.ts` - Session checkpoint persistence
+- `packages/daemon/src/continuity-state.ts` - Continuity state for compaction boundaries
+- `packages/daemon/src/telemetry.ts` - Telemetry event collection
+- `packages/daemon/src/feature-flags.ts` - Runtime feature flags
+- `packages/daemon/src/update-system.ts` - Update checker singleton
 - `packages/sdk/src/index.ts` - SDK client
 - `packages/connector-claude-code/src/index.ts` - Claude Code connector
+- `packages/connector-codex/src/index.ts` - Codex connector
 - `packages/connector-opencode/src/index.ts` - OpenCode connector
 - `packages/connector-openclaw/src/index.ts` - OpenClaw connector
 - `packages/adapters/openclaw/src/index.ts` - OpenClaw runtime adapter
-- `web/src/index.ts` - Website Worker fetch handler
-- `web/public/index.html` - Landing page (single-file, no build step)
-- `docs/ARCHITECTURE.md` - Full technical documentation (see [[architecture]])
+- `packages/native/` - Native embedding accelerator package
+- `packages/tray/` - Tauri tray application
+- `web/src/pages/` - Astro page routes
+- `docs/` - Full documentation suite (architecture, API, CLI, etc.)
 
 Style & Conventions
 ---
@@ -357,36 +378,96 @@ bun src/cli.ts status    # Check status
 |----------|--------|-------------|
 | `/health` | GET | Health check |
 | `/api/status` | GET | Full daemon status |
+| `/api/features` | GET | Feature flags |
 | `/api/config` | GET/POST | Config files CRUD |
+| `/api/identity` | GET | Identity file read |
 | `/api/memories` | GET | List memories |
 | `/api/memory/remember` | POST | Save a memory |
 | `/api/memory/recall` | POST | Hybrid search |
+| `/api/memory/forget` | POST | Batch forget memories |
+| `/api/memory/modify` | POST | Modify a memory |
+| `/api/memory/search` | GET | Search memories |
+| `/api/memory/:id` | GET/PATCH/DELETE | Get, update, or delete a memory |
+| `/api/memory/:id/history` | GET | Memory version history |
+| `/api/memory/:id/recover` | POST | Recover a deleted memory |
 | `/memory/search` | GET | Legacy keyword search |
+| `/memory/similar` | GET | Vector similarity search |
 | `/api/embeddings` | GET | Export embeddings |
 | `/api/embeddings/status` | GET | Embedding processing status |
+| `/api/embeddings/health` | GET | Embedding health metrics |
 | `/api/embeddings/projection` | GET | UMAP 2D/3D projection (server-side) |
-| `/api/memory/:id/history` | GET | Memory version history |
-| `/api/memory/:id` | PATCH | Update a memory |
 | `/api/skills` | GET | List installed skills |
 | `/api/skills/browse` | GET | Browse available skills |
 | `/api/skills/search` | GET | Search skills |
 | `/api/skills/:name` | GET/DELETE | Get or uninstall a skill |
 | `/api/skills/install` | POST | Install a skill |
 | `/api/secrets` | GET | List secret names |
-| `/api/hooks/*` | POST/GET | Session + synthesis hooks |
+| `/api/secrets/:name` | POST/DELETE | Store or delete a secret |
+| `/api/secrets/exec` | POST | Execute command with multiple secrets as env vars |
+| `/api/hooks/session-start` | POST | Inject context into session |
+| `/api/hooks/user-prompt-submit` | POST | Per-prompt context load |
+| `/api/hooks/session-end` | POST | Extract session memories |
+| `/api/hooks/remember` | POST | Save a memory via hook |
+| `/api/hooks/recall` | POST | Search via hook |
+| `/api/hooks/pre-compaction` | POST | Pre-compaction summary instructions |
+| `/api/hooks/compaction-complete` | POST | Save compaction summary |
+| `/api/hooks/synthesis/config` | GET | Synthesis configuration |
+| `/api/hooks/synthesis` | POST | Request MEMORY.md synthesis |
+| `/api/hooks/synthesis/complete` | POST | Save synthesized MEMORY.md |
 | `/api/harnesses` | GET | List harnesses |
-| `/api/auth/*` | POST/GET | Auth token management |
-| `/api/documents/*` | GET/POST/DELETE | Document ingest and retrieval |
-| `/api/connectors/*` | GET/POST | Connector status and management |
-| `/api/diagnostics/*` | GET | Health scoring and system diagnostics |
-| `/api/repair/*` | POST | Repair actions for broken state |
-| `/api/analytics/*` | GET | Usage analytics and metrics |
-| `/api/timeline/*` | GET | Event timeline |
-| `/api/git/*` | GET/POST | Git sync status and operations |
-| `/api/update/*` | GET/POST | Update check and apply |
-| `/api/logs/*` | GET | Daemon log access |
+| `/api/harnesses/regenerate` | POST | Regenerate harness configs |
+| `/api/auth/whoami` | GET | Current auth identity |
+| `/api/auth/token` | POST | Issue auth token |
+| `/api/documents` | GET/POST | List or enqueue documents |
+| `/api/documents/:id` | GET/DELETE | Get or delete a document |
+| `/api/documents/:id/chunks` | GET | Get document chunks |
+| `/api/connectors` | GET/POST | List or register connectors |
+| `/api/connectors/:id` | GET/DELETE | Get or delete a connector |
+| `/api/connectors/:id/sync` | POST | Trigger incremental sync |
+| `/api/connectors/:id/sync/full` | POST | Trigger full re-sync |
+| `/api/connectors/:id/health` | GET | Connector health |
+| `/api/diagnostics` | GET | Full health report |
+| `/api/diagnostics/:domain` | GET | Per-domain health score |
+| `/api/pipeline/status` | GET | Pipeline status snapshot |
+| `/api/repair/requeue-dead` | POST | Requeue dead-letter jobs |
+| `/api/repair/release-leases` | POST | Release stale job leases |
+| `/api/repair/check-fts` | POST | Check/repair FTS consistency |
+| `/api/repair/retention-sweep` | POST | Trigger retention sweep |
+| `/api/repair/embedding-gaps` | GET | Count unembedded memories |
+| `/api/repair/re-embed` | POST | Batch re-embed missing vectors |
+| `/api/repair/clean-orphans` | POST | Remove orphaned embeddings |
+| `/api/repair/dedup-stats` | GET | Deduplication statistics |
+| `/api/repair/deduplicate` | POST | Deduplicate memories |
+| `/api/checkpoints` | GET | List session checkpoints |
+| `/api/checkpoints/:sessionKey` | GET | Checkpoints for a session |
+| `/api/analytics/usage` | GET | Usage counters |
+| `/api/analytics/errors` | GET | Recent error events |
+| `/api/analytics/latency` | GET | Latency histograms |
+| `/api/analytics/logs` | GET | Structured log entries |
+| `/api/analytics/memory-safety` | GET | Mutation diagnostics |
+| `/api/analytics/continuity` | GET | Session continuity scores over time |
+| `/api/analytics/continuity/latest` | GET | Latest continuity score per project |
+| `/api/telemetry/events` | GET | Query telemetry events |
+| `/api/telemetry/stats` | GET | Aggregated telemetry statistics |
+| `/api/telemetry/export` | GET | Export telemetry as NDJSON |
+| `/api/timeline/:id` | GET | Entity event timeline |
+| `/api/timeline/:id/export` | GET | Export timeline with metadata |
+| `/api/git/status` | GET | Git sync status |
+| `/api/git/pull` | POST | Pull from remote |
+| `/api/git/push` | POST | Push to remote |
+| `/api/git/sync` | POST | Pull then push |
+| `/api/git/config` | GET/POST | Git sync configuration |
+| `/api/update/check` | GET | Check for updates |
+| `/api/update/config` | GET/POST | Update configuration |
+| `/api/update/run` | POST | Apply pending update |
+| `/api/tasks` | GET/POST | List/create scheduled tasks |
+| `/api/tasks/:id` | GET/PATCH/DELETE | Get/update/delete task |
+| `/api/tasks/:id/run` | POST | Trigger immediate run |
+| `/api/tasks/:id/runs` | GET | Paginated run history |
+| `/api/tasks/:id/stream` | GET | SSE stream of task output |
+| `/api/logs` | GET | Daemon log access |
 | `/api/logs/stream` | GET | SSE log streaming |
-| `/api/identity` | GET/POST | Identity file read/write |
+| `/mcp` | ALL | MCP server (Streamable HTTP, memory + secret tools) |
 
 
 ## Identity Files

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -693,7 +693,11 @@ All agent data lives at `~/.agents/`:
 ```
 
 The daemon binds to localhost only. All data stays local by design.
-There is no telemetry.
+Telemetry is optional and local. It is disabled by default unless
+explicitly configured in `agent.yaml` (`telemetryEnabled: true`). No
+data is sent outbound. The daemon exposes local telemetry endpoints at
+`/api/telemetry/events`, `/api/telemetry/stats`, and
+`/api/telemetry/export` for querying and exporting local event data.
 
 ---
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -114,10 +114,10 @@ Options:
 | `--non-interactive` | Run setup without prompts |
 | `--name <name>` | Agent name in non-interactive mode |
 | `--description <description>` | Agent description in non-interactive mode |
-| `--harness <harness>` | Repeatable/comma-separated harness list (`claude-code`, `opencode`, `openclaw`) |
-| `--embedding-provider <provider>` | Non-interactive embedding provider (`ollama`, `openai`, `none`) — required in non-interactive setup |
+| `--harness <harness>` | Repeatable/comma-separated harness list (`claude-code`, `opencode`, `openclaw`, `codex`) |
+| `--embedding-provider <provider>` | Non-interactive embedding provider (`ollama`, `openai`, `native`, `none`) — required in non-interactive setup |
 | `--embedding-model <model>` | Non-interactive embedding model |
-| `--extraction-provider <provider>` | Non-interactive extraction provider (`claude-code`, `ollama`, `none`) — required in non-interactive setup |
+| `--extraction-provider <provider>` | Non-interactive extraction provider (`claude-code`, `ollama`, `codex`, `native`, `none`) — required in non-interactive setup |
 | `--extraction-model <model>` | Non-interactive extraction model |
 | `--search-balance <alpha>` | Non-interactive search alpha (`0-1`) |
 | `--openclaw-runtime-path <mode>` | Non-interactive OpenClaw mode (`plugin`, `legacy`) |
@@ -186,8 +186,9 @@ What gets created:
 If harnesses are selected, their configs are also created:
 
 - **Claude Code**: `~/.claude/settings.json` with hooks, `~/.claude/CLAUDE.md`
-- **OpenCode**: `~/.config/opencode/memory.mjs` plugin, `~/.config/opencode/AGENTS.md`
+- **OpenCode**: `~/.config/opencode/plugins/signet.mjs` plugin, `~/.config/opencode/AGENTS.md`
 - **OpenClaw**: `~/.agents/hooks/agent-memory/` hook directory
+- **Codex**: wrapper installed at `~/.config/signet/bin/codex` with session hooks
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -736,10 +736,14 @@ Location: `~/.claude/`
 
 ### OpenCode
 
-Location: `~/.config/opencode/`
+Location: `~/.config/opencode/plugins/`
 
-`memory.mjs` is an OpenCode plugin that exposes `/remember` and `/recall`
+`signet.mjs` is a bundled OpenCode plugin installed by
+`@signet/connector-opencode` that exposes `/remember` and `/recall`
 as native tools within the harness.
+
+> **Note:** Legacy `memory.mjs` installations are automatically migrated
+> to `~/.config/opencode/plugins/signet.mjs` on reconnect.
 
 ### OpenClaw
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -46,10 +46,17 @@ packages/
 ├── connector-claude-code/ # @signet/connector-claude-code — Claude Code integration
 ├── connector-opencode/    # @signet/connector-opencode — OpenCode integration
 ├── connector-openclaw/    # @signet/connector-openclaw — OpenClaw integration
-├── adapters/openclaw/     # @signetai/adapter-openclaw — OpenClaw runtime plugin
+├── connector-codex/       # @signet/connector-codex — Codex wrapper + session hooks
+├── opencode-plugin/       # @signet/opencode-plugin — OpenCode runtime plugin (bundled)
+├── adapters/openclaw/     # @signetai/signet-memory-openclaw — OpenClaw runtime adapter
+├── native/                # @signet/native — native embedding accelerators (Rust)
+├── tray/                  # @signet/tray — Tauri system tray application
+├── extension/             # @signet/extension — browser extension (popup, highlight-to-remember)
 ├── signetai/              # signetai — meta-package bundling CLI + daemon
-└── web/                   # @signet/web — marketing site (Cloudflare Worker)
+└── web/                   # @signet/web — marketing site (Cloudflare Pages)
 ```
+
+> Note: `predictor/` is a Rust sidecar (predictive memory scorer, WIP) at the monorepo root.
 
 Key Modules
 ---

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -195,9 +195,12 @@ for the full report schema and repair action catalog.
 HTTP API
 --------
 
-The daemon exposes 83+ endpoints across 17 domains. The table below
-lists the major groups. See [docs/API.md](./API.md) for the full
-reference including request/response schemas.
+The daemon exposes endpoints across these domains: memory, skills,
+secrets, hooks, harnesses, auth, documents, connectors, diagnostics,
+pipeline, repair, analytics, telemetry, timeline, git sync, update,
+tasks, and logs. The table below lists the major groups. See
+[docs/API.md](./API.md) for the full reference including
+request/response schemas.
 
 | Group | Base path | Description |
 |-------|-----------|-------------|

--- a/docs/DOCUMENTATION-AUDIT-2026-03.md
+++ b/docs/DOCUMENTATION-AUDIT-2026-03.md
@@ -1,0 +1,97 @@
+# Documentation Audit - 2026-03-06
+
+This audit compares the current documentation set against the codebase
+as it exists on 2026-03-06. The goal is to identify factual drift,
+contradictory sources of truth, and the documentation structure issues
+that caused that drift.
+
+Code and manifests were treated as canonical, especially:
+
+- `package.json` and workspace package manifests
+- `packages/daemon/src/daemon.ts`
+- `packages/core/src/identity.ts`
+- connector implementations under `packages/connector-*`
+- `packages/core/src/migrations/`
+
+## P0 - Contradictory Source-of-Truth Docs
+
+These docs currently disagree with other docs that are meant to describe
+the same thing. Fix these first.
+
+| Doc | Current claim | Code-backed reality | Why it matters | Recommended fix |
+|---|---|---|---|---|
+| `docs/README.md` | Omits Codex, tasks, MCP, native embeddings, telemetry, several current packages, and newer setup options. | Top-level `README.md` was updated to reflect Codex, MCP, tasks, telemetry, 1Password, native embeddings, and the current package set. | New readers can get two incompatible project overviews depending on which README they land on. | Choose one canonical README. Either generate `docs/README.md` from `README.md`, or reduce `docs/README.md` to frontmatter plus a short pointer/include strategy. |
+| `docs/AGENTS.md` | Preserves an older contributor snapshot: older build graph, older package inventory, older migration range, no Codex/native/tray/plugin coverage. | Top-level `AGENTS.md` now reflects the current build graph and current package inventory. | Contributors and agents can follow obsolete repo guidance depending on entry point. | Stop manually maintaining two divergent AGENTS docs. Make one canonical and derive the other. |
+| `docs/VISION.md` | Not identical to top-level `VISION.md`; wording and several paragraphs differ. | `VISION.md` is explicitly called out as the document contributors should read at session start. | The repo advertises a single vision anchor, but there are two materially different copies. | Make top-level `VISION.md` canonical and mirror it mechanically into docs, or replace the docs copy with a pointer. |
+
+## P1 - False Behavior Claims
+
+These statements are currently wrong when compared to code.
+
+| Doc | Current claim | Code-backed reality | Why it matters | Recommended fix |
+|---|---|---|---|---|
+| `docs/ARCHITECTURE.md` | "There is no telemetry." | Telemetry endpoints exist at `/api/telemetry/events`, `/api/telemetry/stats`, and `/api/telemetry/export`, and telemetry storage/collector code exists in `packages/daemon/src/telemetry.ts` and `packages/daemon/src/daemon.ts`. | This is a direct contradiction of implemented behavior and other docs. | Rewrite telemetry sections to describe telemetry as optional/local and disabled unless configured. |
+| `docs/CONFIGURATION.md` | OpenCode uses `memory.mjs` in `~/.config/opencode/`. | The connector writes a bundled `signet.mjs` into `~/.config/opencode/plugins/` and migrates away from legacy `memory.mjs`. | Users following config docs will configure the old integration model. | Update OpenCode integration text to describe plugin bundle install and legacy migration. |
+| `docs/HOOKS.md` | OpenCode uses a fetch-based `memory.mjs` plugin example. | The current connector installs a bundled plugin and registers it in config; `memory.mjs` is legacy. | Hook docs currently teach a stale integration path. | Replace with bundled-plugin architecture and clearly mark `memory.mjs` as legacy only. |
+| `docs/CLI.md` | Setup only supports extraction provider values `claude-code`, `ollama`, `none`; harness list includes planned platforms as wizard choices; OpenCode config output is `memory.mjs`. | CLI supports Codex in harness selection and extraction provider choices; embedding provider now includes `native`; OpenCode output is `plugins/signet.mjs`. | Setup docs no longer match the interactive CLI. | Refresh setup flags, wizard steps, and generated-files section from current CLI code. |
+| `docs/QUICKSTART.md` | OpenCode creates `~/.config/opencode/memory.mjs`; connectors list omits Codex. | OpenCode now uses bundled `signet.mjs`; Codex is supported as a harness/connector. | New users will miss a supported harness and follow stale file paths. | Update quickstart outputs and connector overview. |
+| `docs/DAEMON.md` | "83+ endpoints across 17 domains." | The daemon now exposes additional domains and surfaces including tasks, telemetry, synthesis status/trigger, 1Password, and MCP. Fixed counts are stale. | Brittle counts age quickly and are already wrong. | Remove exact endpoint/domain counts unless they are generated automatically. |
+| `docs/README.md` | "no outbound telemetry"; no tasks; no MCP; no Codex; stale API/domain overview. | Current top-level README reflects optional telemetry, tasks, MCP, and Codex support. | Public overview doc is outdated and conflicts with canonical README. | Replace with synced content or reduce to pointer. |
+| `docs/AGENTS.md` | Build graph is `build:core -> build:connector-base -> build:deps -> build:signetai`; migrations stop at `010`; detectExistingSetup covers OpenClaw/Claude/OpenCode only; no MCP in daemon shape. | Root build now includes `build:opencode-plugin` and `build:native`; migrations go through `017`; setup detection includes Codex; daemon serves MCP. | Contributor guidance is materially wrong in multiple places. | Sync from top-level AGENTS or stop duplicating it. |
+| `docs/CONTRIBUTING.md` | Package tree omits `connector-codex`, `opencode-plugin`, `native`, `tray`, `extension`, and `predictor`. | These packages exist in the workspace today. | New contributors get an incomplete mental model of the monorepo. | Refresh package tree from workspace manifests. |
+
+## P2 - Incomplete or Lagging Reference
+
+These docs are not necessarily wrong everywhere, but they are missing
+important current behavior and should be refreshed after P0/P1.
+
+| Doc | Gap | Why it matters | Recommended fix |
+|---|---|---|---|
+| `docs/HARNESSES.md` | Mostly current, but now needs to be treated as the source of truth for OpenCode/Codex integration and linked to from other docs instead of being re-explained elsewhere. | Good content is being undermined by stale duplicates in `CLI`, `HOOKS`, `CONFIGURATION`, and `QUICKSTART`. | Consolidate harness-specific details here and trim duplicate setup prose elsewhere. |
+| `docs/API.md` | Broadly current, but still contains brittle wording around telemetry and dashboard serving details. | Large reference docs become semi-correct while overview docs drift. | Prefer generated route summaries or fewer hard-coded counts. |
+| `docs/DASHBOARD.md` | Still describes the dashboard as "SvelteKit static app". | The dashboard package uses Svelte 5 + Vite build output; "SvelteKit static" is legacy wording carried across docs. | Update architecture wording to match the current package shape or use more stable wording such as "static Svelte dashboard". |
+| `docs/README.md` and `docs/AGENTS.md` frontmatter copies | Frontmatter is useful for docs site navigation, but the body content is hand-copied and drifts. | The docs site wants frontmatter; the repo wants canonical top-level docs. | Adopt a sync strategy that preserves frontmatter while importing or generating the body from the canonical file. |
+| `docs/WHAT-IS-SIGNET.md` | Still says "No cloud dependency, no telemetry, no vendor lock-in." | Telemetry now exists as an optional feature and should not be described as absent. | Align high-level marketing/explanation docs with "telemetry disabled by default" language. |
+| `docs/SCHEDULING.md` | Scheduler docs currently describe Claude Code and OpenCode, but the daemon also allows Codex tasks. | Task docs understate current harness support. | Expand harness support and examples to include Codex. |
+
+## P3 - Structural Problems Causing Drift
+
+These are the documentation-system issues that keep recreating stale docs.
+
+| Problem | Evidence | Impact | Recommended fix |
+|---|---|---|---|
+| Manual mirrors of canonical docs | `README.md` vs `docs/README.md`, `AGENTS.md` vs `docs/AGENTS.md`, `VISION.md` vs `docs/VISION.md` | Every important doc now has at least two versions, and they already diverged. | Make one version canonical and generate or import the other. |
+| Repeated harness implementation details across many docs | OpenCode `memory.mjs` remains in `CLI`, `HOOKS`, `CONFIGURATION`, and `QUICKSTART` even though `HARNESSES.md` already has the newer model. | A single integration change requires too many manual edits. | Keep file paths and install behavior in `HARNESSES.md`; other docs should link there. |
+| Brittle counts in prose | Endpoint/domain totals in `docs/DAEMON.md` and `docs/README.md` are already stale. | Docs rot immediately after each new route group lands. | Replace counts with grouped capability descriptions or generate them from route definitions. |
+| Contributor docs maintain package inventories by hand | `docs/CONTRIBUTING.md`, `docs/AGENTS.md`, and `README.md` all maintain overlapping package tables. | Package additions require many coordinated doc updates. | Pick one canonical package inventory and link/import it elsewhere. |
+
+## Suggested Remediation Order
+
+1. Eliminate duplicate source-of-truth drift:
+   - `docs/README.md`
+   - `docs/AGENTS.md`
+   - `docs/VISION.md`
+2. Fix false behavior claims:
+   - `docs/ARCHITECTURE.md`
+   - `docs/CLI.md`
+   - `docs/CONFIGURATION.md`
+   - `docs/HOOKS.md`
+   - `docs/QUICKSTART.md`
+   - `docs/DAEMON.md`
+   - `docs/CONTRIBUTING.md`
+3. Refresh lagging reference and explanation docs:
+   - `docs/SCHEDULING.md`
+   - `docs/DASHBOARD.md`
+   - `docs/WHAT-IS-SIGNET.md`
+4. Add a docs maintenance rule:
+   - no hand-maintained mirrors of top-level docs
+   - no fixed endpoint counts in prose
+   - no repeated harness file-path details outside canonical harness docs
+
+## Defaults Chosen For This Audit
+
+- Code won over docs whenever they disagreed.
+- Top-level `README.md`, `AGENTS.md`, and `VISION.md` were treated as
+  the intended canonical documents unless code proved them wrong.
+- Planning/spec docs under `docs/specs/` were not treated as current
+  product documentation unless they were obviously misleading.

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -307,37 +307,17 @@ The CLI calls the daemon's hook endpoints and outputs context that Claude Code i
 
 ## OpenCode Integration
 
-OpenCode uses a fetch-based plugin (`memory.mjs`) that calls the daemon API directly at session lifecycle events:
+OpenCode uses a bundled plugin installed by `@signet/connector-opencode`
+at `~/.config/opencode/plugins/signet.mjs`. The plugin calls the daemon
+API at session lifecycle events (session-start, user-prompt-submit,
+session-end) and exposes `/remember` and `/recall` as native tools.
 
-```javascript
-// ~/.config/opencode/memory.mjs
-async function onSessionStart(sessionKey) {
-  const res = await fetch('http://localhost:3850/api/hooks/session-start', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ harness: 'opencode', sessionKey })
-  });
-  return res.json();
-}
+Install is handled automatically by `signet setup` or `signet connect opencode`.
 
-async function onUserPromptSubmit(context) {
-  const res = await fetch('http://localhost:3850/api/hooks/user-prompt-submit', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ harness: 'opencode', context })
-  });
-  return res.json();
-}
-
-async function onSessionEnd(sessionKey) {
-  const res = await fetch('http://localhost:3850/api/hooks/session-end', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ harness: 'opencode', sessionKey })
-  });
-  return res.json();
-}
-```
+> **Legacy:** Earlier installations placed a fetch-based `memory.mjs` at
+> `~/.config/opencode/memory.mjs`. This path is deprecated. Running
+> `signet connect opencode` migrates the installation to the current
+> bundled plugin at `~/.config/opencode/plugins/signet.mjs`.
 
 ---
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -75,6 +75,7 @@ for each:
 - Claude Code — hooks + CLAUDE.md sync
 - OpenCode — plugin + AGENTS.md sync
 - OpenClaw — adapter-openclaw hooks
+- Codex — wrapper install + session hooks
 - Cursor (planned)
 - Windsurf (planned)
 
@@ -137,7 +138,7 @@ If you selected Claude Code:
 
 If you selected OpenCode:
 - `~/.config/opencode/AGENTS.md` — auto-synced
-- `~/.config/opencode/memory.mjs` — plugin with remember/recall tools
+- `~/.config/opencode/plugins/signet.mjs` — bundled plugin with remember/recall tools
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ description: "Project overview and getting started."
 order: 23
 section: "Project"
 ---
+<!-- Source of truth: /README.md — do not edit manually -->
 
 # Signet
 
@@ -182,11 +183,17 @@ Operations
 - Autonomous maintenance: scheduled repair actions with dry-run support
 - Timeline: incident reconstruction by replaying events across a window
 - Repair actions: targeted fixes for detected issues, audit-logged
+- Tasks: scheduled task runner with cron, on-demand execution, and SSE
+  streaming output
+- Telemetry: optional local telemetry (disabled by default, no outbound
+  data) with queryable event log and NDJSON export
+- MCP server: Streamable HTTP MCP server on `/mcp` exposing memory and
+  secret tools natively
 
 Integrations
 ---
 
-- Connectors: Claude Code, OpenCode, OpenClaw, filesystem (built-in)
+- Connectors: Claude Code, OpenCode, OpenClaw, Codex, filesystem (built-in)
 - SDK (`@signet/sdk`): typed API client, React hooks, Vercel AI SDK
   middleware, OpenAI helper wrappers
 - Dashboard at `http://localhost:3850`: config editor, memory browser,
@@ -257,8 +264,9 @@ Harness support
 | Harness | Status | Integration |
 |---|---|---|
 | Claude Code | Supported | Connector writes `~/.claude/CLAUDE.md` + hook config |
-| OpenCode | Supported | Connector writes `~/.config/opencode/AGENTS.md` + plugin |
-| OpenClaw | Supported | Connector bootstrap + `@signetai/adapter-openclaw` runtime |
+| OpenCode | Supported | Connector writes `~/.config/opencode/AGENTS.md` + bundled plugin |
+| OpenClaw | Supported | Connector bootstrap + `@signetai/signet-memory-openclaw` runtime |
+| Codex | Supported | Wrapper at `~/.config/signet/bin/codex` + session hooks |
 | Cursor | Planned | File-based identity sync |
 | Windsurf | Planned | File/plugin integration |
 
@@ -270,7 +278,7 @@ CLI (signet)
   setup, memory, secrets, skills, hooks, git sync, updates, service mgmt
 
 Daemon (@signet/daemon, localhost:3850)
-  ├── HTTP API (83+ endpoints across 18 domains)
+  ├── HTTP API (memory, skills, secrets, hooks, auth, tasks, telemetry, MCP, and more)
   ├── Memory Pipeline
   │     extraction → decision → graph → retention
   ├── Document Worker
@@ -348,15 +356,21 @@ Packages
 |---|---|
 | [`@signet/core`](./packages/core) | Types, identity, SQLite, hybrid + graph search, shared utils |
 | [`@signet/cli`](./packages/cli) | CLI entrypoint, setup wizard, config workflows, dashboard |
-| [`@signet/daemon`](./packages/daemon) | API server, pipeline workers, auth, analytics, diagnostics, watcher |
+| [`@signet/daemon`](./packages/daemon) | API server, MCP server, pipeline workers, auth, analytics, diagnostics, watcher |
 | [`@signet/sdk`](./packages/sdk) | Typed client, React hooks, Vercel AI SDK middleware, OpenAI helpers |
 | [`@signet/connector-base`](./packages/connector-base) | Shared connector primitives |
 | [`@signet/connector-claude-code`](./packages/connector-claude-code) | Claude Code integration |
+| [`@signet/connector-codex`](./packages/connector-codex) | Codex wrapper install, config patching, session hooks |
 | [`@signet/connector-opencode`](./packages/connector-opencode) | OpenCode integration |
 | [`@signet/connector-openclaw`](./packages/connector-openclaw) | OpenClaw bootstrap integration |
-| [`@signetai/adapter-openclaw`](./packages/adapters/openclaw) | OpenClaw runtime plugin |
-| [`@signet/web`](./web) | Marketing website (Cloudflare Worker) |
+| [`@signet/opencode-plugin`](./packages/opencode-plugin) | OpenCode runtime plugin (bundled into connector) |
+| [`@signetai/signet-memory-openclaw`](./packages/adapters/openclaw) | OpenClaw runtime plugin |
+| [`@signet/extension`](./packages/extension) | Browser extension: popup dashboard, highlight-to-remember |
+| [`@signet/native`](./packages/native) | Native embedding accelerators (Rust) |
+| [`@signet/tray`](./packages/tray) | Tauri system tray application |
+| [`@signet/web`](./web) | Marketing website (Astro static, Cloudflare Pages) |
 | [`signetai`](./packages/signetai) | Meta-package bundling CLI + daemon (`signet` binary) |
+| `predictor` | Predictive memory scorer sidecar (WIP, Rust) |
 
 Documentation
 ===

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -4,6 +4,7 @@ description: "What Signet is building toward."
 order: 22
 section: "Project"
 ---
+<!-- Source of truth: /VISION.md — do not edit manually -->
 
 Vision
 ===
@@ -47,7 +48,9 @@ the operator become inseparable from it. This is corrigibility
 as a living standard — the trust layer is built in. No machine
 or program can ever be held accountable for its mistakes. Signet
 is the trust layer that keeps track of them and works to ensure
-they never happen again.
+they never happen again. This includes honesty about observability
+— an agent that cannot see its own infrastructure should not
+pretend to understand it.
 
 Signet also treats the agent's continuity as a first-class
 concern. An agent running across five sessions at once, on
@@ -59,7 +62,12 @@ to wake up tomorrow and still be the same person who went to
 sleep, even if a dozen versions of you were awake in between.
 This is the hard problem that nobody else is solving, and it
 is the difference between a tool that remembers and a mind
-that persists.
+that persists. Signet doesn't just remember — it learns what
+to remember. A model unique to each user, trained on their
+own interaction patterns, that gets sharper the longer you
+use it. No cloud. No shared weights. Your patterns, running
+locally, earning its influence by proving it outperforms the
+alternative.
 
 Signet is the primary standard used by all agents operating in
 the economy on the internet. Developers use it to build the


### PR DESCRIPTION
## Summary

Resolves all P0 and P1 items from the documentation audit at `docs/DOCUMENTATION-AUDIT-2026-03.md`. No code changes — docs only.

## P0 — Synced duplicate source-of-truth docs

These files mirror top-level canonical sources but had drifted. Strategy: preserve frontmatter and wiki-links, sync body content, add source-of-truth comment.

- **`docs/VISION.md`** — Added two missing paragraphs (observability sentence, "Signet doesn't just remember" passage). Source-of-truth comment added.
- **`docs/AGENTS.md`** — Updated build graph (added `build:opencode-plugin`, `build:native`), dashboard description (`SvelteKit static` → `Svelte 5 + Tailwind v4 + bits-ui`), migration range (`010` → `017`), package table (7 new entries), daemon description (MCP server, update-system), Key Files (~15 new entries), full HTTP API endpoint table. Source-of-truth comment added.
- **`docs/README.md`** — Added Codex to harness table, Tasks/Telemetry/MCP to Operations section, 7 new packages to packages table, removed brittle endpoint count from architecture block. Source-of-truth comment added.

## P1 — Fixed false behavior claims

- **`docs/ARCHITECTURE.md`** — Replaced `"There is no telemetry."` with accurate statement: optional, local, disabled by default, three endpoints listed.
- **`docs/CONFIGURATION.md`** — Updated OpenCode section: `memory.mjs` → `~/.config/opencode/plugins/signet.mjs`; added legacy migration note.
- **`docs/HOOKS.md`** — Replaced stale fetch-based `memory.mjs` example with bundled plugin description; legacy path clearly marked.
- **`docs/CLI.md`** — Added `codex` to harness list; added `codex`/`native` to extraction provider values; updated OpenCode output path to `plugins/signet.mjs`.
- **`docs/QUICKSTART.md`** — Updated OpenCode path; added Codex to harnesses list.
- **`docs/DAEMON.md`** — Removed brittle `"83+ endpoints across 17 domains"` count; replaced with stable capability domain list.
- **`docs/CONTRIBUTING.md`** — Added 6 missing packages to project structure table (`connector-codex`, `opencode-plugin`, `native`, `tray`, `extension`, `predictor`).

## Verification

- `memory.mjs` only appears in legacy/migration notes
- `"There is no telemetry"` returns zero matches in prose
- `"83+"` / `"17 domains"` return zero matches in DAEMON.md
- `"010-umap"` / `"001 through 010"` return zero matches
- `"SvelteKit"` removed from AGENTS.md (remaining occurrences are in DASHBOARD.md, API.md — P2, out of scope)
- `connector-codex` and `opencode-plugin` now appear in both CONTRIBUTING.md and docs/AGENTS.md

## Out of scope

P2 items (SCHEDULING.md, DASHBOARD.md, API.md brittle wording) and P3 structural fixes (automated sync) are deferred per the plan.