### PR TITLE
fix(codex): address post-merge Greptile follow-ups

### DIFF
--- a/packages/daemon/src/embedding-fetch.test.ts
+++ b/packages/daemon/src/embedding-fetch.test.ts
@@ -15,6 +15,10 @@ describe("requiresOpenAiApiKey", () => {
 	it("does not require a key for custom OpenAI-compatible endpoints", () => {
 		expect(requiresOpenAiApiKey("http://localhost:1234/v1")).toBe(false);
 	});
+
+	it("does not treat proxy paths containing api.openai.com as official", () => {
+		expect(requiresOpenAiApiKey("http://proxy.example.com/api.openai.com/v1")).toBe(false);
+	});
 });
 
 describe("fetchEmbedding", () => {

--- a/packages/daemon/src/embedding-fetch.test.ts
+++ b/packages/daemon/src/embedding-fetch.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import {
+	fetchEmbedding,
+	requiresOpenAiApiKey,
+	setNativeFallbackToOllama,
+} from "./embedding-fetch";
+
+const originalFetch = globalThis.fetch;
+
+describe("requiresOpenAiApiKey", () => {
+	it("requires a key for official OpenAI endpoints", () => {
+		expect(requiresOpenAiApiKey("https://api.openai.com/v1")).toBe(true);
+	});
+
+	it("does not require a key for custom OpenAI-compatible endpoints", () => {
+		expect(requiresOpenAiApiKey("http://localhost:1234/v1")).toBe(false);
+	});
+});
+
+describe("fetchEmbedding", () => {
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		setNativeFallbackToOllama(false);
+		delete process.env.OPENAI_API_KEY;
+	});
+
+	it("allows keyless requests for custom OpenAI-compatible endpoints", async () => {
+		let capturedHeaders: HeadersInit | undefined;
+		globalThis.fetch = mock((_url: string | URL | Request, init?: RequestInit) => {
+			capturedHeaders = init?.headers;
+			return Promise.resolve(
+				Response.json({ data: [{ embedding: [0.1, 0.2, 0.3] }] }),
+			);
+		}) as typeof fetch;
+
+		const result = await fetchEmbedding("hello", {
+			provider: "openai",
+			model: "text-embedding-3-small",
+			dimensions: 3,
+			base_url: "http://localhost:1234/v1",
+		});
+
+		expect(result).toEqual([0.1, 0.2, 0.3]);
+		expect(capturedHeaders).toEqual({
+			"Content-Type": "application/json",
+		});
+	});
+});

--- a/packages/daemon/src/embedding-fetch.ts
+++ b/packages/daemon/src/embedding-fetch.ts
@@ -33,6 +33,10 @@ export function resolveEmbeddingBaseUrl(cfg: EmbeddingConfig): string {
 	return cfg.base_url;
 }
 
+export function requiresOpenAiApiKey(baseUrl: string): boolean {
+	return /(^https?:\/\/)?api\.openai\.com(\/|$)/i.test(baseUrl.trim());
+}
+
 export async function resolveEmbeddingApiKey(
 	rawApiKey: string | undefined,
 ): Promise<string> {
@@ -102,13 +106,19 @@ export async function fetchEmbedding(
 		}
 
 		const apiKey = await resolveEmbeddingApiKey(cfg.api_key);
-		if (!apiKey) return null;
 		const baseUrl = resolveEmbeddingBaseUrl(cfg);
+		if (!apiKey && requiresOpenAiApiKey(baseUrl)) {
+			logger.warn(
+				"embedding",
+				"No API key configured for OpenAI embeddings, skipping request to api.openai.com",
+			);
+			return null;
+		}
 		const res = await fetch(`${baseUrl.replace(/\/$/, "")}/embeddings`, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
-				Authorization: `Bearer ${apiKey}`,
+				...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
 			},
 			body: JSON.stringify({ model: cfg.model, input: text }),
 			signal: AbortSignal.timeout(30000),

--- a/packages/daemon/src/embedding-fetch.ts
+++ b/packages/daemon/src/embedding-fetch.ts
@@ -34,7 +34,15 @@ export function resolveEmbeddingBaseUrl(cfg: EmbeddingConfig): string {
 }
 
 export function requiresOpenAiApiKey(baseUrl: string): boolean {
-	return /(^https?:\/\/)?api\.openai\.com(\/|$)/i.test(baseUrl.trim());
+	try {
+		const parsed = new URL(baseUrl.trim());
+		return (
+			(parsed.protocol === "https:" || parsed.protocol === "http:") &&
+			parsed.hostname === "api.openai.com"
+		);
+	} catch {
+		return false;
+	}
 }
 
 export async function resolveEmbeddingApiKey(

--- a/packages/daemon/src/hooks.test.ts
+++ b/packages/daemon/src/hooks.test.ts
@@ -24,4 +24,13 @@ describe("normalizeCodexTranscript", () => {
 		expect(assistantLines).toHaveLength(1);
 		expect(assistantLines[0]).toBe("Assistant: Hi there");
 	});
+
+	it("ignores nested item.completed payloads inside response_item events", () => {
+		const raw = [
+			'{"type":"response_item","payload":{"type":"item.completed","item":{"type":"agent_message","text":"nested"}}}',
+			'{"type":"item.completed","item":{"type":"agent_message","text":"top-level"}}',
+		].join("\n");
+
+		expect(normalizeCodexTranscript(raw)).toBe("Assistant: top-level");
+	});
 });

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -1605,15 +1605,6 @@ export function normalizeCodexTranscript(raw: string): string {
 				if (item.type === "function_call_output" && typeof item.output === "string") {
 					lines.push(`Tool output: ${item.output.trim().slice(0, 1000)}`);
 				}
-				if (item.type === "item.completed") {
-					const completed = item.item;
-					if (typeof completed === "object" && completed !== null) {
-						const done = completed as Record<string, unknown>;
-						if (done.type === "agent_message" && typeof done.text === "string") {
-							lines.push(`Assistant: ${done.text.trim()}`);
-						}
-					}
-				}
 			}
 		}
 	}

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -434,9 +434,6 @@ export function createCodexProvider(
 			}
 			return parseCodexJsonl(stdout);
 		} catch (e) {
-			if (timedOut) {
-				throw new Error(`codex timeout after ${timeoutMs}ms`);
-			}
 			throw e;
 		} finally {
 			clearTimeout(timer);

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -433,8 +433,6 @@ export function createCodexProvider(
 				throw new Error(`codex exit ${exitCode}: ${stderr.slice(0, 300)}`);
 			}
 			return parseCodexJsonl(stdout);
-		} catch (e) {
-			throw e;
 		} finally {
 			clearTimeout(timer);
 		}

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -422,9 +422,9 @@ export function createCodexProvider(
 
 		try {
 			const [stdout, stderr, exitCode] = await Promise.all([
-				new Response(proc.stdout).text(),
-				new Response(proc.stderr).text(),
-				proc.exited,
+				new Response(proc.stdout).text().catch(() => ""),
+				new Response(proc.stderr).text().catch(() => ""),
+				proc.exited.catch(() => -1),
 			]);
 			if (timedOut) {
 				throw new Error(`codex timeout after ${timeoutMs}ms`);

--- a/packages/daemon/src/scheduler/spawn.test.ts
+++ b/packages/daemon/src/scheduler/spawn.test.ts
@@ -1,0 +1,49 @@
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "bun:test";
+import { spawnTask } from "./spawn";
+
+describe("spawnTask", () => {
+	const originalPath = process.env.PATH;
+	const originalWhich = Bun.which;
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		process.env.PATH = originalPath;
+		Bun.which = originalWhich;
+		for (const dir of tempDirs.splice(0)) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("passes the configured model to codex scheduled tasks", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "signet-spawn-test-"));
+		tempDirs.push(dir);
+
+		const outPath = join(dir, "args.txt");
+		const binPath = join(dir, "codex");
+		writeFileSync(
+			binPath,
+			`#!/bin/sh
+printf '%s\n' "$@" > ${JSON.stringify(outPath)}
+printf 'ok'
+`,
+		);
+		chmodSync(binPath, 0o755);
+		process.env.PATH = `${dir}:${originalPath ?? ""}`;
+		Bun.which = ((bin: string) => (bin === "codex" ? binPath : originalWhich(bin))) as typeof Bun.which;
+
+		const result = await spawnTask("codex", "summarize this", dir, 5000, undefined, "gpt-5.3-codex");
+
+		expect(result.exitCode).toBe(0);
+		expect(readFileSync(outPath, "utf8").trim().split("\n")).toEqual([
+			"exec",
+			"--skip-git-repo-check",
+			"--json",
+			"--model",
+			"gpt-5.3-codex",
+			"summarize this",
+		]);
+	});
+});

--- a/packages/daemon/src/scheduler/spawn.ts
+++ b/packages/daemon/src/scheduler/spawn.ts
@@ -56,8 +56,9 @@ export async function spawnTask(
 	workingDirectory: string | null,
 	timeoutMs: number = DEFAULT_TIMEOUT_MS,
 	hooks?: SpawnHooks,
+	model?: string,
 ): Promise<SpawnResult> {
-	const [bin, args] = buildCommand(harness, prompt);
+	const [bin, args] = buildCommand(harness, prompt, model);
 	const resolvedBin = Bun.which(bin);
 
 	if (resolvedBin === null) {

--- a/packages/daemon/src/scheduler/worker-execute.test.ts
+++ b/packages/daemon/src/scheduler/worker-execute.test.ts
@@ -1,0 +1,103 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { runMigrations } from "@signet/core";
+
+mock.module("../memory-config", () => ({
+	loadMemoryConfig: () => {
+		throw new Error("config read failed");
+	},
+}));
+
+mock.module("./spawn", () => ({
+	spawnTask: mock(async () => ({
+		exitCode: 0,
+		stdout: "",
+		stderr: "",
+		error: null,
+		timedOut: false,
+	})),
+}));
+
+mock.module("./task-stream", () => ({
+	emitTaskStream() {},
+}));
+
+mock.module("./skill-resolver", () => ({
+	resolveSkillPrompt: (prompt: string) => prompt,
+}));
+
+mock.module("./cron", () => ({
+	computeNextRun: () => "2026-03-06T16:00:00.000Z",
+}));
+
+mock.module("../logger", () => ({
+	logger: {
+		info() {},
+		warn() {},
+		error() {},
+	},
+}));
+
+const { executeTask } = await import("./worker");
+
+describe("executeTask", () => {
+	let db: Database;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("marks the run failed when task model resolution throws", async () => {
+		const now = "2026-03-06T15:55:00.000Z";
+		db.prepare(
+			`INSERT INTO scheduled_tasks
+			 (id, name, prompt, cron_expression, harness, working_directory,
+			  enabled, last_run_at, next_run_at, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			"task-1",
+			"task-task-1",
+			"test prompt",
+			"*/15 * * * *",
+			"codex",
+			null,
+			1,
+			null,
+			now,
+			now,
+			now,
+		);
+
+		const accessor = {
+			withReadDb<T>(fn: (rdb: unknown) => T): T {
+				return fn(db);
+			},
+			withWriteTx<T>(fn: (wdb: unknown) => T): T {
+				return fn(db);
+			},
+		};
+
+		await executeTask(accessor as never, {
+			id: "task-1",
+			name: "task-task-1",
+			prompt: "test prompt",
+			cron_expression: "*/15 * * * *",
+			harness: "codex",
+			working_directory: null,
+			skill_name: null,
+			skill_mode: null,
+		});
+
+		const run = db.prepare(
+			`SELECT status, error FROM task_runs WHERE task_id = ? ORDER BY started_at DESC LIMIT 1`,
+		).get("task-1") as { status: string; error: string | null } | undefined;
+
+		expect(run?.status).toBe("failed");
+		expect(run?.error).toContain("config read failed");
+	});
+});

--- a/packages/daemon/src/scheduler/worker-execute.test.ts
+++ b/packages/daemon/src/scheduler/worker-execute.test.ts
@@ -1,6 +1,7 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { runMigrations } from "@signet/core";
+import type { DbAccessor } from "../db-accessor";
 
 mock.module("../memory-config", () => ({
 	loadMemoryConfig: () => {
@@ -40,12 +41,17 @@ mock.module("../logger", () => ({
 
 const { executeTask } = await import("./worker");
 
+function isTaskRunRow(value: unknown): value is { status: string; error: string | null } {
+	if (typeof value !== "object" || value === null) return false;
+	return "status" in value && "error" in value;
+}
+
 describe("executeTask", () => {
 	let db: Database;
 
 	beforeEach(() => {
 		db = new Database(":memory:");
-		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+		runMigrations(db);
 	});
 
 	afterEach(() => {
@@ -73,16 +79,17 @@ describe("executeTask", () => {
 			now,
 		);
 
-		const accessor = {
+		const accessor: DbAccessor = {
 			withReadDb<T>(fn: (rdb: unknown) => T): T {
 				return fn(db);
 			},
 			withWriteTx<T>(fn: (wdb: unknown) => T): T {
 				return fn(db);
 			},
+			close() {},
 		};
 
-		await executeTask(accessor as never, {
+		await executeTask(accessor, {
 			id: "task-1",
 			name: "task-task-1",
 			prompt: "test prompt",
@@ -95,8 +102,12 @@ describe("executeTask", () => {
 
 		const run = db.prepare(
 			`SELECT status, error FROM task_runs WHERE task_id = ? ORDER BY started_at DESC LIMIT 1`,
-		).get("task-1") as { status: string; error: string | null } | undefined;
+		).get("task-1");
 
+		expect(isTaskRunRow(run)).toBe(true);
+		if (!isTaskRunRow(run)) {
+			throw new Error("expected task run row");
+		}
 		expect(run?.status).toBe("failed");
 		expect(run?.error).toContain("config read failed");
 	});

--- a/packages/daemon/src/scheduler/worker.test.ts
+++ b/packages/daemon/src/scheduler/worker.test.ts
@@ -5,7 +5,7 @@ import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { runMigrations } from "@signet/core";
 import type { ReadDb } from "../db-accessor";
-import { resolveTaskModel, selectDueTasks } from "./worker";
+import { clearTaskModelCache, resolveTaskModel, selectDueTasks } from "./worker";
 
 interface TaskInsert {
 	readonly id: string;
@@ -52,6 +52,7 @@ describe("scheduler due task selection", () => {
 
 	afterEach(() => {
 		db.close();
+		clearTaskModelCache();
 	});
 
 	it("selects tasks that are overdue when next_run_at is ISO timestamp", () => {
@@ -91,6 +92,10 @@ describe("scheduler due task selection", () => {
 });
 
 describe("resolveTaskModel", () => {
+	afterEach(() => {
+		clearTaskModelCache();
+	});
+
 	it("returns the configured codex extraction model for codex tasks", () => {
 		const agentsDir = mkdtempSync(join(tmpdir(), "signet-agents-"));
 		try {
@@ -107,6 +112,42 @@ describe("resolveTaskModel", () => {
 
 			expect(resolveTaskModel("codex", agentsDir)).toBe("gpt-5.3-codex");
 			expect(resolveTaskModel("opencode", agentsDir)).toBeUndefined();
+		} finally {
+			rmSync(agentsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("caches the resolved model for repeated codex task lookups", () => {
+		const agentsDir = mkdtempSync(join(tmpdir(), "signet-agents-"));
+		try {
+			const configPath = join(agentsDir, "agent.yaml");
+			writeFileSync(
+				configPath,
+				[
+					"memory:",
+					"  pipelineV2:",
+					"    extraction:",
+					"      provider: codex",
+					"      model: gpt-5.3-codex",
+				].join("\n"),
+			);
+
+			expect(resolveTaskModel("codex", agentsDir)).toBe("gpt-5.3-codex");
+
+			writeFileSync(
+				configPath,
+				[
+					"memory:",
+					"  pipelineV2:",
+					"    extraction:",
+					"      provider: codex",
+					"      model: gpt-5.4-codex",
+				].join("\n"),
+			);
+
+			expect(resolveTaskModel("codex", agentsDir)).toBe("gpt-5.3-codex");
+			clearTaskModelCache();
+			expect(resolveTaskModel("codex", agentsDir)).toBe("gpt-5.4-codex");
 		} finally {
 			rmSync(agentsDir, { recursive: true, force: true });
 		}

--- a/packages/daemon/src/scheduler/worker.test.ts
+++ b/packages/daemon/src/scheduler/worker.test.ts
@@ -1,8 +1,11 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { runMigrations } from "@signet/core";
 import type { ReadDb } from "../db-accessor";
-import { selectDueTasks } from "./worker";
+import { resolveTaskModel, selectDueTasks } from "./worker";
 
 interface TaskInsert {
 	readonly id: string;
@@ -84,5 +87,28 @@ describe("scheduler due task selection", () => {
 
 		const rows = selectDueTasks(db as unknown as ReadDb, nowIso, 2);
 		expect(rows.map((row) => row.id)).toEqual(["earliest", "middle"]);
+	});
+});
+
+describe("resolveTaskModel", () => {
+	it("returns the configured codex extraction model for codex tasks", () => {
+		const agentsDir = mkdtempSync(join(tmpdir(), "signet-agents-"));
+		try {
+			writeFileSync(
+				join(agentsDir, "agent.yaml"),
+				[
+					"memory:",
+					"  pipelineV2:",
+					"    extraction:",
+					"      provider: codex",
+					"      model: gpt-5.3-codex",
+				].join("\n"),
+			);
+
+			expect(resolveTaskModel("codex", agentsDir)).toBe("gpt-5.3-codex");
+			expect(resolveTaskModel("opencode", agentsDir)).toBeUndefined();
+		} finally {
+			rmSync(agentsDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/packages/daemon/src/scheduler/worker.ts
+++ b/packages/daemon/src/scheduler/worker.ts
@@ -5,7 +5,10 @@
  * Polls every 15 seconds (cron granularity is minutes).
  */
 
+import { homedir } from "node:os";
+import { join } from "node:path";
 import type { DbAccessor, ReadDb } from "../db-accessor";
+import { loadMemoryConfig } from "../memory-config";
 import type { WorkerHandle } from "../pipeline/worker";
 import { computeNextRun } from "./cron";
 import { resolveSkillPrompt } from "./skill-resolver";
@@ -15,6 +18,7 @@ import { logger } from "../logger";
 
 const POLL_INTERVAL_MS = 15_000;
 const MAX_CONCURRENT = 3;
+const AGENTS_DIR = process.env.SIGNET_PATH || join(homedir(), ".agents");
 
 export interface DueTaskRow {
 	readonly id: string;
@@ -51,6 +55,18 @@ export function selectDueTasks(
 			 LIMIT ?`,
 		)
 		.all(nowIso, limit) as ReadonlyArray<DueTaskRow>;
+}
+
+export function resolveTaskModel(
+	harness: DueTaskRow["harness"],
+	agentsDir: string = AGENTS_DIR,
+): string | undefined {
+	if (harness !== "codex") return undefined;
+
+	const cfg = loadMemoryConfig(agentsDir);
+	return cfg.pipelineV2.extraction.provider === "codex"
+		? cfg.pipelineV2.extraction.model
+		: undefined;
 }
 
 /** Start the scheduler worker. Returns a handle to stop it. */
@@ -180,6 +196,7 @@ async function executeTask(
 		task.skill_name,
 		task.skill_mode,
 	);
+	const model = resolveTaskModel(task.harness);
 
 	// Spawn the process
 	let result: SpawnResult;
@@ -211,6 +228,7 @@ async function executeTask(
 					});
 				},
 			},
+			model,
 		);
 	} catch (err) {
 		result = {

--- a/packages/daemon/src/scheduler/worker.ts
+++ b/packages/daemon/src/scheduler/worker.ts
@@ -5,6 +5,7 @@
  * Polls every 15 seconds (cron granularity is minutes).
  */
 
+import type { TaskHarness } from "@signet/core";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { DbAccessor, ReadDb } from "../db-accessor";
@@ -27,6 +28,10 @@ interface TaskModelCacheEntry {
 }
 
 const taskModelCache = new Map<string, TaskModelCacheEntry>();
+
+function isTaskHarness(value: string): value is TaskHarness {
+	return value === "claude-code" || value === "opencode" || value === "codex";
+}
 
 export interface DueTaskRow {
 	readonly id: string;
@@ -223,9 +228,12 @@ export async function executeTask(
 	// Spawn the process
 	let result: SpawnResult;
 	try {
+		if (!isTaskHarness(task.harness)) {
+			throw new Error(`Unsupported harness: ${task.harness}`);
+		}
 		const model = resolveTaskModel(task.harness);
 		result = await spawnTask(
-			task.harness as "claude-code" | "opencode" | "codex",
+			task.harness,
 			effectivePrompt,
 			task.working_directory,
 			undefined,

--- a/packages/daemon/src/scheduler/worker.ts
+++ b/packages/daemon/src/scheduler/worker.ts
@@ -19,6 +19,14 @@ import { logger } from "../logger";
 const POLL_INTERVAL_MS = 15_000;
 const MAX_CONCURRENT = 3;
 const AGENTS_DIR = process.env.SIGNET_PATH || join(homedir(), ".agents");
+const TASK_MODEL_CACHE_TTL_MS = 5_000;
+
+interface TaskModelCacheEntry {
+	readonly model: string | undefined;
+	readonly expiresAt: number;
+}
+
+const taskModelCache = new Map<string, TaskModelCacheEntry>();
 
 export interface DueTaskRow {
 	readonly id: string;
@@ -63,10 +71,25 @@ export function resolveTaskModel(
 ): string | undefined {
 	if (harness !== "codex") return undefined;
 
+	const now = Date.now();
+	const cached = taskModelCache.get(agentsDir);
+	if (cached && cached.expiresAt > now) {
+		return cached.model;
+	}
+
 	const cfg = loadMemoryConfig(agentsDir);
-	return cfg.pipelineV2.extraction.provider === "codex"
+	const model = cfg.pipelineV2.extraction.provider === "codex"
 		? cfg.pipelineV2.extraction.model
 		: undefined;
+	taskModelCache.set(agentsDir, {
+		model,
+		expiresAt: now + TASK_MODEL_CACHE_TTL_MS,
+	});
+	return model;
+}
+
+export function clearTaskModelCache(): void {
+	taskModelCache.clear();
 }
 
 /** Start the scheduler worker. Returns a handle to stop it. */

--- a/packages/daemon/src/scheduler/worker.ts
+++ b/packages/daemon/src/scheduler/worker.ts
@@ -167,7 +167,7 @@ export function startSchedulerWorker(db: DbAccessor): WorkerHandle {
 }
 
 /** Lease and execute a single task. */
-async function executeTask(
+export async function executeTask(
 	db: DbAccessor,
 	task: DueTaskRow,
 ): Promise<void> {
@@ -219,11 +219,11 @@ async function executeTask(
 		task.skill_name,
 		task.skill_mode,
 	);
-	const model = resolveTaskModel(task.harness);
 
 	// Spawn the process
 	let result: SpawnResult;
 	try {
+		const model = resolveTaskModel(task.harness);
 		result = await spawnTask(
 			task.harness as "claude-code" | "opencode" | "codex",
 			effectivePrompt,


### PR DESCRIPTION
## Summary

Follow-up for merged PR #145 with only the remaining Greptile fixes that were still present on `main` after merge.

### What changed

- remove the dead nested `response_item -> item.completed` assistant branch from `normalizeCodexTranscript()` and lock it with a regression test
- thread the configured Codex extraction model through scheduled task execution so Codex task runs can append `--model`
- harden the Codex provider timeout path so killed streams still surface a consistent timeout error
- allow keyless requests for custom OpenAI-compatible embedding endpoints while still warning and skipping official `api.openai.com` requests without an API key

### Why

PR #145 was merged before the remaining Greptile follow-up items were fully fixed. This PR isolates those fixes from the already-merged feature work.

### Verification

- `bun test packages/daemon/src/scheduler/worker.test.ts packages/daemon/src/scheduler/spawn.test.ts packages/daemon/src/embedding-fetch.test.ts packages/daemon/src/hooks.test.ts packages/daemon/src/pipeline/provider.test.ts`

### Cleanup

- deleted the old merged branch: `add-codex-harnessing-embedding-fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyless support for OpenAI‑compatible endpoints; API keys used only when required.
  * Per-task model resolution and caching; resolved model is forwarded to task runs.

* **Bug Fixes**
  * More robust process output and exit-code handling; simplified timeout behavior.
  * Removed duplicate assistant messages from transcripts.

* **Tests**
  * Added tests for embedding fetch (keyless flow), scheduler spawn/worker behavior, task execution error path, and transcript normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->