### PR TITLE
fix(mcp): flatten agent_message_send schema, clarify agent_peers description

### DIFF
--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -730,7 +730,9 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		"agent_peers",
 		{
 			title: "List Peer Sessions",
-			description: "List currently active Signet peer agent sessions.",
+			description:
+				"List currently active Signet peer agent sessions. " +
+				"Pass include_self: true to include sessions from the same agent (same agentId).",
 			inputSchema: z.object({
 				agent_id: z.string().optional().describe("Current agent id (default: default)"),
 				session_key: z.string().optional().describe("Current session key (excluded from peers)"),
@@ -768,34 +770,19 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 			description:
 				"Send a structured message to another Signet agent session. " +
 				"Supports local daemon delivery or ACP relay for cross-provider communication.",
-			inputSchema: z.union([
-				z.object({
-					from_agent_id: z.string().optional().describe("Sender agent id"),
-					from_session_key: z.string().optional().describe("Sender session key"),
-					to_agent_id: z.string().optional().describe("Target agent id"),
-					to_session_key: z.string().optional().describe("Target session key"),
-					broadcast: z.boolean().optional().describe("Broadcast to all active sessions"),
-					type: z.enum(["assist_request", "decision_update", "info", "question"]).optional().describe("Message type"),
-					content: z.string().describe("Message content"),
-					via: z.literal("local").optional().describe("Delivery path (default: local)"),
-					acp_base_url: z.string().optional().describe("ACP server base URL"),
-					acp_target_agent_name: z.string().optional().describe("ACP target agent name"),
-					acp_timeout_ms: z.number().optional().describe("ACP request timeout"),
-				}),
-				z.object({
-					from_agent_id: z.string().optional().describe("Sender agent id"),
-					from_session_key: z.string().optional().describe("Sender session key"),
-					to_agent_id: z.string().optional().describe("Target agent id"),
-					to_session_key: z.string().optional().describe("Target session key"),
-					broadcast: z.boolean().optional().describe("Broadcast to all active sessions"),
-					type: z.enum(["assist_request", "decision_update", "info", "question"]).optional().describe("Message type"),
-					content: z.string().describe("Message content"),
-					via: z.literal("acp").describe("Delivery path"),
-					acp_base_url: z.string().min(1).describe("ACP server base URL"),
-					acp_target_agent_name: z.string().min(1).describe("ACP target agent name"),
-					acp_timeout_ms: z.number().optional().describe("ACP request timeout"),
-				}),
-			]),
+			inputSchema: z.object({
+				from_agent_id: z.string().optional().describe("Sender agent id"),
+				from_session_key: z.string().optional().describe("Sender session key"),
+				to_agent_id: z.string().optional().describe("Target agent id"),
+				to_session_key: z.string().optional().describe("Target session key"),
+				broadcast: z.boolean().optional().describe("Broadcast to all active sessions"),
+				type: z.enum(["assist_request", "decision_update", "info", "question"]).optional().describe("Message type"),
+				content: z.string().describe("Message content"),
+				via: z.enum(["local", "acp"]).optional().describe("Delivery path (default: local)"),
+				acp_base_url: z.string().optional().describe("ACP server base URL (required when via='acp')"),
+				acp_target_agent_name: z.string().optional().describe("ACP target agent name (required when via='acp')"),
+				acp_timeout_ms: z.number().optional().describe("ACP request timeout"),
+			}),
 			annotations: { readOnlyHint: false },
 		},
 		async ({


### PR DESCRIPTION
## Summary

- `agent_message_send` — replaced `z.union([...])` with a flat `z.object({...})`. The MCP SDK serializes `z.union()` as `{"type":"object","properties":{}}` (empty), making parameter names invisible to callers. Now all fields are discoverable with their snake_case names. ACP field validation (`acp_base_url` required when `via='acp'`) stays in the handler at runtime.
- `agent_peers` — updated description to explicitly mention that `include_self: true` is required to see peer sessions from the same agent.

## Motivation

Dogfooding two Mr. Claude instances talking to each other surfaced three issues:
1. Tool schema was empty — callers had to guess param names and guessed wrong (camelCase vs snake_case)
2. Direct sends with `to_session_key` failed because callers couldn't see the field name at all
3. `agent_peers` silently excluded self-sessions with no documentation explaining why

## Test plan

- [ ] Call `agent_message_send` — schema should show all parameters with snake_case names and `required: ["content"]`
- [ ] Send a direct message with `to_session_key: "<key>"` — should succeed without falling back to broadcast
- [ ] Call `agent_peers` without `include_self` — description now clearly explains the default behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced agent_peers tool description to clarify include_self parameter functionality.

* **Refactor**
  * Streamlined agent_message_send tool with a unified input schema that consolidates local and remote delivery options into a single interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->