### PR TITLE
fix(dashboard): center PageBanner title on pages without side slots

### DIFF
--- a/packages/cli/dashboard/src/lib/components/embeddings/EmbeddingCanvas2D.svelte
+++ b/packages/cli/dashboard/src/lib/components/embeddings/EmbeddingCanvas2D.svelte
@@ -65,7 +65,7 @@ let canvas = $state<HTMLCanvasElement | null>(null);
 // Camera state (internal)
 let camX = 0;
 let camY = 0;
-let camZoom = 1;
+let camZoom = 0.15;
 
 // Interaction state
 let isPanning = false;
@@ -123,7 +123,7 @@ const MAX_EDGES_FAR = 5000;
 export function resetCamera(): void {
 	camX = 0;
 	camY = 0;
-	camZoom = 1;
+	camZoom = 0.15;
 	userAdjustedCamera = false;
 }
 
@@ -153,10 +153,15 @@ export function startSimulation(
 			forceCollide().radius((entry: any) => entry.radius + 2),
 		)
 		.alphaDecay(0.03)
-		.on("tick", requestRedraw)
+		.on("tick", () => {
+			if (!userAdjustedCamera) fitCameraToBounds();
+			requestRedraw();
+		})
 		.on("end", () => {
 			if (!userAdjustedCamera) fitCameraToBounds();
 		});
+	// Fit immediately — nodes already have UMAP positions before simulation ticks
+	if (!userAdjustedCamera) fitCameraToBounds();
 }
 
 export function startKnowledgeGraphSimulation(
@@ -200,10 +205,14 @@ export function startKnowledgeGraphSimulation(
 			forceCollide().radius((entry: any) => entry.radius + 2),
 		)
 		.alphaDecay(0.03)
-		.on("tick", requestRedraw)
+		.on("tick", () => {
+			if (!userAdjustedCamera) fitCameraToBounds();
+			requestRedraw();
+		})
 		.on("end", () => {
 			if (!userAdjustedCamera) fitCameraToBounds();
 		});
+	if (!userAdjustedCamera) fitCameraToBounds();
 }
 
 export function updatePhysics(nextPhysics: GraphPhysicsConfig): void {
@@ -272,7 +281,7 @@ function fitCameraToBounds(): void {
 	if (nodes.length === 0) {
 		camX = 0;
 		camY = 0;
-		camZoom = 1;
+		camZoom = 0.15;
 		return;
 	}
 
@@ -285,7 +294,7 @@ function fitCameraToBounds(): void {
 
 	camX = (bounds.minX + bounds.maxX) / 2;
 	camY = (bounds.minY + bounds.maxY) / 2;
-	camZoom = Math.max(0.08, Math.min(1, fitZoom));
+	camZoom = Math.max(0.08, fitZoom);
 }
 
 function screenToWorld(sx: number, sy: number): [number, number] {

--- a/packages/cli/dashboard/src/lib/components/embeddings/EmbeddingCanvas2D.svelte
+++ b/packages/cli/dashboard/src/lib/components/embeddings/EmbeddingCanvas2D.svelte
@@ -87,6 +87,18 @@ let needsRedraw = true;
 let lastHoveredId: string | null = null;
 let userAdjustedCamera = false;
 
+// Throttled camera fit — avoids O(n) computeWorldBounds on every tick
+let lastFitTime = 0;
+const FIT_THROTTLE_MS = 100;
+
+function throttledFitCamera(): void {
+	const now = performance.now();
+	if (now - lastFitTime > FIT_THROTTLE_MS) {
+		fitCameraToBounds();
+		lastFitTime = now;
+	}
+}
+
 // Minimap state
 const MINIMAP_WIDTH = 160;
 const MINIMAP_HEIGHT = 120;
@@ -154,7 +166,7 @@ export function startSimulation(
 		)
 		.alphaDecay(0.03)
 		.on("tick", () => {
-			if (!userAdjustedCamera) fitCameraToBounds();
+			if (!userAdjustedCamera) throttledFitCamera();
 			requestRedraw();
 		})
 		.on("end", () => {
@@ -206,7 +218,7 @@ export function startKnowledgeGraphSimulation(
 		)
 		.alphaDecay(0.03)
 		.on("tick", () => {
-			if (!userAdjustedCamera) fitCameraToBounds();
+			if (!userAdjustedCamera) throttledFitCamera();
 			requestRedraw();
 		})
 		.on("end", () => {

--- a/packages/cli/dashboard/src/lib/components/layout/PageBanner.svelte
+++ b/packages/cli/dashboard/src/lib/components/layout/PageBanner.svelte
@@ -12,19 +12,19 @@
 
 <div class="banner">
 	<div class="banner-content">
-		{#if children}
-			<div class="banner-left">
+		<div class="banner-left">
+			{#if children}
 				{@render children()}
-			</div>
-		{/if}
+			{/if}
+		</div>
 		<div class="banner-text">
 			<h2 class="banner-title">{title}</h2>
 		</div>
-		{#if right}
-			<div class="banner-right">
+		<div class="banner-right">
+			{#if right}
 				{@render right()}
-			</div>
-		{/if}
+			{/if}
+		</div>
 	</div>
 	<!-- Coordinate markers -->
 	<span class="banner-coord banner-coord--tl" aria-hidden="true">0,0</span>


### PR DESCRIPTION
The 3-column grid layout requires all three cells to be present for the title to land in the center column. Pages like Home, Secrets, and Changelog that pass no children/right snippets were missing the side grid cells, causing the title to fall into column 1 instead.

Always render the left/right wrapper divs so the grid structure is preserved regardless of slot content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified banner layout so left/right wrapper elements always render; their content displays only when provided.

* **Bug Fixes / UX**
  * Embedding canvas: lowered initial/reset zoom for a wider default view, added throttled camera-fitting to reduce work, ensure camera fits immediately when simulations start/end, and relaxed upper zoom limit while enforcing a tighter minimum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->