### PR TITLE
docs: research, LCM patterns, ACP vision, README rewrite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,6 @@ This file: AGENTS.md -> Symlinked to CLAUDE.md
 
 # Repository Guidelines 
 
-
 This file provides guidance to AI assistants working on this repository.
 It is version controlled and co-maintained by human developers and AI
 assistants. Changes to this document (and the codebase) should be
@@ -28,6 +27,26 @@ daemon with HTTP API, and web dashboard.
 
 **Always read `VISION.md` at the start of every session.** It describes
 what Signet is building toward and should anchor development decisions.
+
+Core Priorities
+---
+
+1. Performance.
+2. Reliability.
+3. Keep behavior predictable under load and during failures (session 
+restarts, reconnects, partial streams).
+
+If a tradeoff is required, choose correctness and robustness over short-term 
+convenience.
+
+Maintainability
+---
+
+Long term maintainability is a core priority. If you add new functionality, 
+first check if there are shared logic that can be extracted to a separate module.
+Duplicate logic across mulitple files is a code smell and should be avoided. 
+Don't be afraid to change existing code. Don't take shortcuts by just adding local 
+logic to solve a problem.
 
 Commands
 ---
@@ -128,6 +147,7 @@ bun run deploy   # Deploy to Cloudflare (wrangler)
 | `signetai` | Meta-package bundling CLI + daemon | - |
 | `@signet/web` | Marketing website (Astro static, Cloudflare Pages) | cloudflare |
 | `predictor` | Predictive memory scorer sidecar (WIP) | rust |
+
 
 ### Package Responsibilities
 
@@ -705,3 +725,19 @@ uppercase), `sig-heading` (11px bold uppercase), `sig-meta` (9px),
 - Use `$effect()` for side effects, not `afterUpdate`.
 - Wrap mutable external references in `$state.raw()` or
   `untrack()` where needed to prevent infinite reactivity loops.
+
+
+Reference repos
+---
+
+Use these as implementation references when designing protocol handling,
+integrations, and operational safeguards.
+
+- [lossless-claw](https://github.com/Martian-Engineering/lossless-claw) — lossless context handling
+- [openclaw](https://github.com/openclaw/openclaw) — agent runtime reference
+- [acpx](https://github.com/openclaw/acpx) — agent communication protocol
+- [arscontexta](https://github.com/agenticnotetaking/arscontexta) — agentic notetaking
+- [ACAN](https://github.com/HongChuanYang/Training-by-LLM-Enhanced-Memory-Retrieval-for-Generative-Agents-via-ACAN) — LLM-enhanced memory retrieval
+- [cli](https://github.com/entireio/cli) — CLI patterns
+- [codex/cli](https://github.com/openai/codex.git)
+- [opencode](https://github.com/anomalyco/opencode.git)

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
   <a href="https://github.com/signetai/signetai/stargazers"><img src="https://img.shields.io/github/stars/signetai/signetai.svg" alt="GitHub Stars" /></a>
 </p>
 
-> For Claude Code, OpenCode, and OpenClaw
-
 <table>
 <tr>
 <td width="240" valign="top">
@@ -15,371 +13,287 @@
 </td>
 <td valign="top">
 
-**Own your agent. Bring it anywhere.**
+**Your agent is an investment. Signet is where its value accumulates.**
 
-Signet is a local-first identity, memory, and operations layer for AI
-agents. It ships a full memory pipeline with LLM-based extraction and
-graph-augmented retrieval, an authenticated HTTP API, analytics, and
-an integration SDK — all running on your machine, under your control.
+Signet is an open protocol for agent identity, knowledge, and trust.
+It defines how an agent should persist across sessions, learn from
+its operator, and carry its identity between tools. The reference
+implementation ships a distillation engine that turns raw conversation
+into structured insights, a knowledge graph that maps how those
+insights connect, and a portable identity layer that follows your
+agent into any harness you use.
 
-Agent configuration lives in plain files at `~/.agents/`, backed by a
-SQLite database, and synced across every harness you use. Signet is
-also the first *agent-native secret store*, letting your agent use
-secrets without ever reading their values.
+Everything runs locally. You own the data. The agent is yours.
 
 </td>
 </tr>
 </table>
 
 ---
-
-<table>
-<tr>
-<td valign="top">
 
 Why Signet
 ===
 
-Most AI tools build memory silos. Switch harnesses and you lose your
-agent's context, preferences, and accumulated knowledge. Rebuild it
-manually, or start from scratch.
+Your agent starts every session from zero. It doesn't know what you
+worked on yesterday. It doesn't know your preferences, your projects,
+or the decisions you've already made together. Every session is a
+first date.
 
-Signet gives you one portable substrate you actually own: plain-text
-identity files you can inspect and version-control, a daemon that runs
-locally and handles everything memory-related, and connector packages
-that keep each harness in sync with your canonical config. The same
-agent follows you into Claude Code, OpenCode, or OpenClaw — same
-personality, same memory, same secrets — without any vendor lock-in.
+Signet fixes this. Not with a vector store that regurgitates old
+conversations — with a distillation engine that extracts structured
+insights from every session, maps them into a knowledge graph, and
+assembles the right context for the right moment. Your agent doesn't
+just remember. It *understands*.
 
-The memory pipeline is privacy-first: the default LLM is a local Ollama
-model. Nothing leaves your machine unless you configure it to.
-
-</td>
-</tr>
-</table>
+The same agent follows you across Claude Code, OpenCode, and
+OpenClaw. Same personality, same knowledge, same secrets. Switch
+tools without starting over.
 
 ---
 
-```text
-~/.agents/
-├── agent.yaml        # Manifest + runtime config
-├── AGENTS.md         # Source-of-truth operating instructions
-├── SOUL.md           # Voice/personality guidance
-├── IDENTITY.md       # Structured identity metadata
-├── USER.md           # User preferences/profile
-├── MEMORY.md         # Synthesized working memory (generated)
-├── memory/           # SQLite DB + embedding artifacts
-├── skills/           # Installed skills (SKILL.md per skill)
-├── .secrets/         # Encrypted secret store
-└── .daemon/          # PID + logs
-```
-
-How memory works
+How it works
 ===
 
-When you save a memory, Signet persists the raw content immediately —
-the database write happens before any LLM processing begins. No matter
-what happens after, your data is safe.
+### The distillation layer
 
-In the background, a local LLM reads the new memory and does two things:
-it breaks the content into structured facts and entities, then checks
-what's already stored. For each fact, it decides whether to file it as
-new, update an existing memory, replace something outdated, or skip it
-entirely.
+At the end of every conversation, Signet reviews the session and
+distills it. Not "save the transcript" — *distill*. A local LLM
+breaks the conversation into atomic facts, checks them against
+what's already known, and decides: file as new, update something
+existing, replace something outdated, or skip entirely. Your agent
+won't store "prefers dark mode" fourteen times. It recognizes the
+insight already exists and moves on.
 
-This means your agent won't keep duplicating "prefers dark mode" every
-session. It sees the existing memory, recognizes it already knows this,
-and moves on.
+### The knowledge graph
 
-The same pipeline runs at the end of every conversation. The daemon
-reviews the session transcript, extracts anything worth remembering,
-and feeds it through the same process. So even if you never use
-`/remember` manually, your agent builds context over time — without
-accumulating duplicates or contradictions.
+Named entities — people, projects, tools, concepts — are extracted
+and linked. When you ask about a project, Signet doesn't just find
+text that sounds related. It traverses the graph: the project's
+architecture, the people involved, the tools it depends on, the
+constraints that apply. Context arrives structured, not as a pile of
+fragments hoping something useful is in there.
 
-**Knowledge graph.** The pipeline also maintains an entity graph. Named
-entities (people, projects, tools, concepts) are extracted and linked,
-and search uses one-hop graph traversal to boost results that are
-semantically adjacent to your query. Asking about a project surfaces
-memories mentioning the people and tools associated with it.
+### The index
 
-**Document ingest.** You can feed documents directly into the pipeline.
-They're chunked, embedded, and indexed alongside your memories. URL
-fetching is built in — point Signet at a doc, a spec, or a reference
-page and it becomes part of your agent's searchable knowledge base.
+Every insight is embedded and indexed. Retrieval blends keyword
+search, semantic similarity, and graph traversal into a single
+ranked result. The constellation view in the dashboard lets you see
+your agent's knowledge topology — what's connected, what's isolated,
+what's going stale.
 
-**Modify and forget.** Explicit `/modify` and `/forget` commands let you
-correct or remove specific memories. Deletions are soft: content is
-tombstoned with a 30-day recovery window and a full audit trail.
-Pinned (critical) memories are never modified by the pipeline, only
-by you.
+### Document ingest
 
-**Diagnostics and maintenance.** The daemon runs a maintenance worker
-that scores memory health — checking for orphaned embeddings, schema
-drift, embedding failures, and other issues — and can repair them
-autonomously. Timeline reconstruction lets you trace incidents by
-replaying analytics events across a time window.
+Feed any document into the distillation layer. PDFs, specs, reference
+pages, URLs. They're chunked, embedded, and indexed alongside your
+agent's insights. Point Signet at a codebase's docs and they become
+part of what your agent knows.
 
-Three safety guarantees hold throughout:
+### Safety guarantees
 
 - **Raw-first**: content is persisted before any LLM processing begins
-- **Pinned memories are sacred**: the model cannot delete them, period
+- **Pinned insights are sacred**: the distillation layer cannot modify
+  them. Only you can.
 - **Everything is recoverable**: deletions are soft, with a 30-day
-  recovery window and a full audit trail
+  recovery window and full audit trail
 
-What ships now
-===
-
-Memory
 ---
-
-- Pipeline v2 with durable async job queue and structured extraction
-- Hybrid retrieval: FTS5 keyword + vector similarity, score-blended
-- Knowledge graph: entity extraction, graph-augmented search boost
-- Document ingest with automatic chunking, embedding, and URL fetching
-- Explicit modify/forget with soft-delete and 30-day recovery
-- Retention decay: configurable aging for low-value memories
-- Full audit history for every write, update, and deletion
-
-Identity
----
-
-- Portable identity files at `~/.agents/` (AGENTS.md, SOUL.md,
-  IDENTITY.md, USER.md, MEMORY.md)
-- Daemon-driven harness sync: writes harness-specific config files on
-  change (CLAUDE.md, opencode AGENTS.md, OpenClaw bootstrap)
-- Skills: install and manage skills from skills.sh
-- Git-aware workflow: optional auto-commit and configurable sync
-
-Security
----
-
-- Auth middleware with three modes: `local` (localhost-only, no token),
-  `team` (bearer token, all requests), `hybrid` (token required for
-  writes, open for reads)
-- Role-based permissions with four roles: `admin`, `operator`, `agent`,
-  `readonly`
-- Scope model: `project`, `agent`, `user`
-- Rate limiting on destructive operations
-- Secrets: libsodium-encrypted at rest (`XSalsa20-Poly1305`), never
-  returned by API, subprocess output redacted
-- Privacy-first default: local Ollama LLM, no outbound telemetry
-
-Operations
----
-
-- Analytics: usage counters, error ring buffer, per-endpoint latency
-  histograms, token usage tracking
-- Diagnostics: health scoring across memory, embeddings, schema,
-  config integrity
-- Autonomous maintenance: scheduled repair actions with dry-run support
-- Timeline: incident reconstruction by replaying events across a window
-- Repair actions: targeted fixes for detected issues, audit-logged
-
-Integrations
----
-
-- Connectors: Claude Code, OpenCode, OpenClaw, filesystem (built-in)
-- SDK (`@signet/sdk`): typed API client, React hooks, Vercel AI SDK
-  middleware, OpenAI helper wrappers
-- Dashboard at `http://localhost:3850`: config editor, memory browser,
-  embeddings view, skills/secrets/logs
-
-Requirements
-===
-
-- Node.js 18+ for CLI and package workflows
-- Bun for the daemon runtime (`signet start`)
-- Ollama for the local LLM (recommended) or an OpenAI API key
-- macOS or Linux
-
-Quickstart
-===
 
 Install
----
+===
 
 ```bash
-# Global install (pick one)
-npm install -g signetai
-bun add -g signetai
+bun add -g signetai        # or: npm install -g signetai 
+signet setup               # interactive setup wizard
 ```
 
-Then run the interactive setup wizard:
-
-```bash
-signet
-```
-
-The wizard initializes `~/.agents/`, configures your selected
-harnesses, prompts for an embedding provider (Ollama/OpenAI/skip),
-creates the memory database, and starts the daemon.
+The wizard initializes `~/.agents/` (or configure your own directory),
+configures your selected harnesses, sets up an embedding provider 
+(Native/Ollama/OpenAI), creates the database, and starts the daemon.
 
 ### Tell your agent to install it
 
-Copy this prompt and paste it to your AI agent (Claude Code, OpenClaw,
-Clawdbot, OpenCode, etc.):
+Paste this to your AI agent:
 
 ```
 Install and fully configure Signet AI by following this guide exactly: https://signetai.sh/skill.md
 ```
 
-The linked guide walks your agent through prerequisites, installation,
-setup, and verification step by step — with gates that ensure it stops
-and explains what it's doing before each phase.
-
-Use it
----
+### Use it
 
 ```bash
-signet status
-signet dashboard
+signet status              # check daemon health
+signet dashboard           # open the web UI
 
-signet remember "prefers bun over npm" -w claude-code
+signet remember "prefers bun over npm"
 signet recall "coding preferences"
-
-# Explicit modify and forget
-signet memory modify <id> "updated content"
-signet memory forget <id>
-signet memory recover <id>
 ```
 
-In connected harnesses, built-in skills work directly:
+In connected harnesses, skills work directly:
 
 ```text
 /remember critical: never commit secrets to git
 /recall release process
 ```
 
+---
+
 Harness support
 ===
 
 | Harness | Status | Integration |
 |---|---|---|
-| Claude Code | Supported | Connector writes `~/.claude/CLAUDE.md` + hook config |
-| OpenCode | Supported | Connector writes `~/.config/opencode/AGENTS.md` + plugin |
-| OpenClaw | Supported | Connector bootstrap + `@signetai/adapter-openclaw` runtime |
-| Cursor | Planned | File-based identity sync |
-| Windsurf | Planned | File/plugin integration |
+| Claude Code | Supported | Hooks + CLAUDE.md sync |
+| OpenCode | Supported | Plugin + AGENTS.md sync |
+| OpenClaw | Supported | Runtime adapter + bootstrap |
+| Codex | In progress | WIP |
+| Gemini CLI | Planned | WIP |
+
+---
+
+What Signet is building
+===
+
+Signet is a protocol, not just a product. The reference implementation
+is the proof that the protocol works. Here's the full picture:
+
+### Identity
+
+Portable agent identity in plain files at `~/.agents/` by default.
+Instructions, personality, user profile, working knowledge — 
+all inspectable, version-controlled, and synced across harnesses 
+automatically. Your agent's identity is not locked inside any 
+vendor's platform.
+
+```text
+~/.agents/
+  agent.yaml        # manifest + runtime config
+  AGENTS.md         # operating instructions
+  SOUL.md           # personality + voice
+  IDENTITY.md       # structured identity
+  USER.md           # operator profile
+  MEMORY.md         # synthesized working knowledge
+  skills/           # installed capabilities
+  .secrets/         # encrypted secret store
+```
+
+### Insights, not observations
+
+Other tools store observations — raw text thrown into a vector
+database and retrieved by cosine distance. Signet distills
+observations into insights: structured facts organized into a
+knowledge graph with entities, aspects, attributes, and dependency
+edges. The difference is the difference between a pile of sticky
+notes and an actual understanding of the domain.
+
+### Trust and security
+
+Secrets are libsodium-encrypted at rest. Your agent can use secrets
+without ever reading their values — Signet injects them into
+subprocess environments and redacts them from captured output. Auth
+supports local-only, token-based, and hybrid modes with role-based
+access control.
+
+The distillation layer runs on a local Ollama model by default.
+Nothing leaves your machine unless you configure it to.
+
+### The protocol layer
+
+Signet defines how agents should carry identity, how knowledge should
+be structured, and how trust should be established. The spec is open.
+The implementation is open. The goal is a standard that any tool can
+adopt — not a walled garden that locks you in.
+
+---
 
 Architecture
 ===
 
 ```text
 CLI (signet)
-  setup, memory, secrets, skills, hooks, git sync, updates, service mgmt
+  setup, knowledge, secrets, skills, hooks, git sync, service mgmt
 
 Daemon (@signet/daemon, localhost:3850)
-  ├── HTTP API (83+ endpoints across 18 domains)
-  ├── Memory Pipeline
-  │     extraction → decision → graph → retention
-  ├── Document Worker
-  │     ingest → chunk → embed → index
-  ├── Maintenance Worker
-  │     diagnostics → health scoring → repair actions
-  ├── Auth Middleware
-  │     local / team / hybrid modes, RBAC, rate limiting
-  ├── Analytics
-  │     usage counters, error ring buffer, latency histograms
-  └── File Watcher
-        identity sync (2s debounce), git auto-commit (5s debounce)
+  |-- HTTP API (90+ endpoints across 18 domains)
+  |-- Distillation Layer
+  |     extraction -> decision -> graph -> retention
+  |-- Document Worker
+  |     ingest -> chunk -> embed -> index
+  |-- Maintenance Worker
+  |     diagnostics -> health scoring -> repair
+  |-- Auth Middleware
+  |     local / team / hybrid, RBAC, rate limiting
+  |-- Analytics
+  |     usage, errors, latency, tokens
+  |-- File Watcher
+        identity sync, git auto-commit
 
 Core (@signet/core)
-  types, identity, SQLite, hybrid search, graph search, shared utils
+  types, identity, SQLite, hybrid search, graph traversal
 
 SDK (@signet/sdk)
-  typed client, React hooks, Vercel AI SDK middleware, OpenAI helpers
+  typed client, React hooks, Vercel AI SDK middleware
 
 Connectors
-  claude-code, opencode, openclaw, filesystem
+  claude-code, opencode, openclaw
 ```
 
-API overview
----
-
-The daemon exposes a REST API organized into these domains:
-
-| Domain | Endpoints |
-|---|---|
-| Health / status | `/health`, `/api/status` |
-| Config | `/api/config` |
-| Identity | `/api/identity` |
-| Memory | CRUD, search, modify, forget, recover, history |
-| Documents | ingest, list, delete |
-| Connectors | install, sync, list |
-| Auth | token management, role assignment |
-| Analytics | usage, errors, latency, tokens |
-| Diagnostics | health score, issue list |
-| Timeline | event replay, incident reconstruction |
-| Repair | available actions, execute, dry-run |
-| Skills | list, install, remove |
-| Secrets | list, set, delete, exec |
-| Harnesses | list, sync |
-| Hooks | session-start, prompt-submit, session-end, synthesis |
-| Logs | tail, search |
-| Embeddings | export |
-| Update | check, apply |
-| Git | status, commit, sync |
-
-Security model
-===
-
-The daemon binds to `localhost` by default — no external exposure
-without explicit configuration. Auth is layered on top via middleware
-that you configure per-deployment.
-
-Three auth modes: `local` requires no token (localhost trust),
-`team` requires a bearer token on every request, `hybrid` requires
-tokens for writes but allows open reads. Four roles control what each
-token can do: `admin` (full access), `operator` (config + memory +
-skills), `agent` (memory operations only), `readonly` (GET only).
-Destructive operations (bulk delete, repair, forget) are additionally
-rate-limited regardless of role.
-
-Secrets never leave the encrypted store as plaintext. The API returns
-only key names. When an agent needs to run a command that uses a secret,
-Signet injects it into the subprocess environment and redacts it from
-the captured output before returning anything to the caller.
-
 Packages
-===
+---
 
 | Package | Role |
 |---|---|
-| [`@signet/core`](./packages/core) | Types, identity, SQLite, hybrid + graph search, shared utils |
-| [`@signet/cli`](./packages/cli) | CLI entrypoint, setup wizard, config workflows, dashboard |
-| [`@signet/daemon`](./packages/daemon) | API server, pipeline workers, auth, analytics, diagnostics, watcher |
-| [`@signet/sdk`](./packages/sdk) | Typed client, React hooks, Vercel AI SDK middleware, OpenAI helpers |
-| [`@signet/connector-base`](./packages/connector-base) | Shared connector primitives |
+| [`@signet/core`](./packages/core) | Types, identity, SQLite, hybrid + graph search |
+| [`@signet/cli`](./packages/cli) | CLI, setup wizard, dashboard |
+| [`@signet/daemon`](./packages/daemon) | API server, distillation layer, auth, analytics, diagnostics |
+| [`@signet/sdk`](./packages/sdk) | Typed client, React hooks, Vercel AI SDK middleware |
 | [`@signet/connector-claude-code`](./packages/connector-claude-code) | Claude Code integration |
 | [`@signet/connector-opencode`](./packages/connector-opencode) | OpenCode integration |
-| [`@signet/connector-openclaw`](./packages/connector-openclaw) | OpenClaw bootstrap integration |
+| [`@signet/connector-openclaw`](./packages/connector-openclaw) | OpenClaw integration |
 | [`@signetai/adapter-openclaw`](./packages/adapters/openclaw) | OpenClaw runtime plugin |
-| [`@signet/web`](./web) | Marketing website (Cloudflare Worker) |
-| [`signetai`](./packages/signetai) | Meta-package bundling CLI + daemon (`signet` binary) |
+| [`signetai`](./packages/signetai) | Meta-package (`signet` binary) |
+
+---
 
 Documentation
 ===
 
+**Usage**
 - [Quickstart](./docs/QUICKSTART.md)
 - [CLI Reference](./docs/CLI.md)
 - [Configuration](./docs/CONFIGURATION.md)
-- [Memory](./docs/MEMORY.md)
-- [Memory Pipeline](./docs/PIPELINE.md)
-- [Documents](./docs/DOCUMENTS.md)
 - [Hooks](./docs/HOOKS.md)
 - [Harnesses](./docs/HARNESSES.md)
 - [Connectors](./docs/CONNECTORS.md)
 - [Secrets](./docs/SECRETS.md)
 - [Skills](./docs/SKILLS.md)
 - [Auth](./docs/AUTH.md)
-- [Analytics](./docs/ANALYTICS.md)
-- [Diagnostics](./docs/DIAGNOSTICS.md)
 - [Dashboard](./docs/DASHBOARD.md)
 - [SDK](./docs/SDK.md)
 - [API Reference](./docs/API.md)
-- [Self-Hosting](./docs/SELF-HOSTING.md)
+
+**Architecture and Design**
 - [Architecture](./docs/ARCHITECTURE.md)
+- [Knowledge Architecture](./docs/KNOWLEDGE-ARCHITECTURE.md)
+- [Knowledge Graph](./docs/KNOWLEDGE-GRAPH.md)
+- [Desire Paths](./docs/DESIRE-PATHS.md) — learned traversal through the knowledge graph
+- [Lossless Context Patterns](./docs/LCM-PATTERNS.md) — deterministic guarantees for the distillation layer
+- [ACP Integration](./docs/ACP-INTEGRATION.md) — Agent Client Protocol integration
+- [Spec Index](./docs/specs/INDEX.md) — build sequence and integration contracts
+
+Research
+---
+
+| Paper / Project | Relevance |
+|---|---|
+| [Lossless Context Management](https://papers.voltropy.com/LCM) (Voltropy, 2026) | Hierarchical summarization, guaranteed convergence, zero-cost continuity. Patterns adapted in [LCM-PATTERNS.md](./docs/LCM-PATTERNS.md). |
+| [Recursive Language Models](https://arxiv.org/abs/2512.24601) (Zhang et al., 2026) | Active context management. LCM builds on and departs from RLM's approach. |
+| [acpx](https://github.com/openclaw/acpx) (OpenClaw) | Agent Client Protocol. Structured agent coordination, session persistence. |
+| [lossless-claw](https://github.com/Martian-Engineering/lossless-claw) (Martian Engineering) | LCM reference implementation as an OpenClaw plugin. |
+| [openclaw](https://github.com/openclaw/openclaw) (OpenClaw) | Agent runtime reference. |
+| [arscontexta](https://github.com/agenticnotetaking/arscontexta) | Agentic notetaking patterns. |
+| [ACAN](https://github.com/HongChuanYang/Training-by-LLM-Enhanced-Memory-Retrieval-for-Generative-Agents-via-ACAN) (Hong et al.) | LLM-enhanced memory retrieval for generative agents. |
+
+---
 
 Development
 ===
@@ -394,39 +308,29 @@ bun test
 bun run lint
 ```
 
-Useful package-level flows:
-
 ```bash
-# CLI dev
-cd packages/cli && bun run dev
-
-# Dashboard dev
-cd packages/cli/dashboard && bun run dev
-
-# Daemon dev (watch mode)
-cd packages/daemon && bun run dev
+cd packages/cli && bun run dev          # CLI dev
+cd packages/cli/dashboard && bun run dev # Dashboard dev
+cd packages/daemon && bun run dev        # Daemon dev (watch mode)
 ```
+
+Requirements: Node.js 18+, Bun, Ollama (recommended) or OpenAI API
+key. macOS or Linux.
 
 Contributing
 ===
 
-Contributions are welcome. See [`CONTRIBUTING.md`](./CONTRIBUTING.md).
-
-If you are adding a harness integration, build on the existing connector
-pattern (`@signet/connector-base`) and keep runtime memory semantics in
-the daemon API. Before contributing a significant feature, check how
-similar things are structured and consider opening an issue first if
-the architecture fit is unclear.
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md). Build on existing patterns.
+Open an issue before contributing significant features.
 
 License
 ===
 
 Apache-2.0.
 
-Links
-===
+---
 
-- Website: [signetai.sh](https://signetai.sh)
-- Docs: [signetai.sh/docs](https://signetai.sh/docs)
-- Spec: [signetai.sh/spec](https://signetai.sh/spec)
-- Issues: [github.com/signetai/signetai/issues](https://github.com/signetai/signetai/issues)
+[signetai.sh](https://signetai.sh) --
+[docs](https://signetai.sh/docs) --
+[spec](https://signetai.sh/spec) --
+[issues](https://github.com/signetai/signetai/issues)

--- a/docs/ACP-INTEGRATION.md
+++ b/docs/ACP-INTEGRATION.md
@@ -1,0 +1,532 @@
+---
+title: "ACP Integration"
+description: "Integrating the Agent Client Protocol into Signet's agent coordination layer."
+order: 5
+section: "Architecture"
+---
+
+ACP Integration
+===============
+
+*Why adopt a standard instead of building your own.*
+
+> *Signet handles the who and the why. ACP handles the how.
+> Neither is complete without the other.*
+
+This document describes how Signet integrates with acpx and the Agent
+Client Protocol (ACP) to gain structured agent coordination, session
+persistence, and a path toward the multi-agent vision described in
+`VISION.md`.
+
+References:
+- acpx: `references/acpx/`
+- ACP protocol: JSON-RPC 2.0 over NDJSON stdio
+- Research notes: `docs/RESEARCH-LCM-ACP.md`
+
+---
+
+
+Why ACP, Not Our Own
+--------------------
+
+ACP is becoming the standard protocol for agent-to-agent communication
+in the coding assistant ecosystem. acpx already has adapters for Claude
+Code, Codex, Gemini, OpenClaw, OpenCode, and Pi. The protocol is
+bi-directional JSON-RPC 2.0 with structured session lifecycle,
+permission negotiation, and capability discovery.
+
+Building our own would mean:
+- Writing adapters for every harness we support (duplicating acpx's work)
+- Defining a session protocol (already defined by ACP)
+- Building queue management and crash recovery (already built in acpx)
+- Maintaining compatibility as harnesses evolve (acpx tracks this)
+
+Adopting ACP means:
+- Fewer migrations as the ecosystem standardizes
+- Interoperability with any tool that speaks ACP
+- Focus on what Signet uniquely provides (identity, memory, learning)
+  instead of plumbing
+
+The strategic bet: ACP or something like it will become the standard.
+If we adapt to its patterns now, we avoid a painful migration later.
+If it doesn't become the standard, the patterns are still sound and
+the integration is thin enough to swap out.
+
+
+---
+
+
+What ACP Provides That Signet Lacks
+------------------------------------
+
+### 1. Outbound Agent Communication
+
+Signet's daemon is entirely inbound. Agents call us through hooks
+and MCP tools. We never initiate contact. We cannot ask an agent a
+question, delegate a subtask, or request a summary.
+
+ACP gives Signet the ability to call out. The daemon can spawn an
+acpx session, submit a prompt, and receive structured results. This
+unlocks agentic autonomy in the pipeline -- the memory system could
+use an agent for synthesis decisions rather than relying purely on
+local Ollama.
+
+### 2. Session Persistence Across Invocations
+
+The scheduler currently fires one-shot prompts via `Bun.spawn` and
+discards the session. There is no conversation history, no crash
+recovery, no ability to resume where a task left off.
+
+acpx sessions persist in `~/.acpx/sessions/` as append-only NDJSON
+streams. A scheduled task can pick up exactly where it left off. If
+the agent crashes, acpx detects the stale PID, attempts
+`session/load` on a fresh process, and falls back to `session/new`.
+
+### 3. Structured Output
+
+The scheduler captures raw stdout/stderr as strings. Parsing agent
+output is fragile -- tool calls, thinking chunks, and response text
+are interleaved with no structure.
+
+acpx's `--format json` mode produces NDJSON events with stable
+envelopes: `eventVersion`, `sessionId`, `requestId`, `seq`, `stream`,
+`type`. The pipeline would know exactly which chunks are tool calls,
+which are thinking, and which are final response text. Memory
+extraction becomes dramatically more reliable.
+
+### 4. Queue-Based Concurrency Control
+
+Multiple processes targeting the same agent session are serialized
+through a Unix domain socket IPC protocol. The "queue owner" pattern
+prevents concurrent prompt submission from corrupting session state.
+Signet has no equivalent -- if two scheduled tasks target the same
+agent, they stomp each other.
+
+### 5. Cooperative Cancellation
+
+`acpx cancel` sends a `session/cancel` message through the ACP
+protocol. The agent receives it and can wind down gracefully.
+Signet's scheduler has no cancel mechanism beyond killing the process.
+
+
+---
+
+
+What Signet Provides That ACP Lacks
+-------------------------------------
+
+### 1. Memory and Identity
+
+acpx has no concept of who the agent is or what it knows. It manages
+sessions, not cognition. Signet provides the identity files
+(AGENTS.md, SOUL.md, IDENTITY.md, USER.md), the memory pipeline
+(extraction, knowledge graph, hybrid search), and the predictive
+scorer. An acpx session without Signet is amnesiac.
+
+### 2. Cross-Session Knowledge
+
+acpx sessions are isolated. What happens in one session does not
+inform another. Signet's knowledge graph and memory pipeline ensure
+that knowledge extracted from any session is available in every
+future session, regardless of which agent or harness was used.
+
+### 3. Learning
+
+acpx is deterministic infrastructure. It routes prompts and manages
+sessions. It does not learn which contexts are useful, which paths
+produce good results, or how the user's needs shift over time. Signet's
+behavioral feedback loop, aspect decay, and (future) desire paths
+scoring are the learning layer that sits on top.
+
+### 4. The Dashboard
+
+Full observability into memory state, entity health, session history,
+pipeline status. acpx has CLI-only status output. Signet provides
+the window into what's happening.
+
+
+---
+
+
+How They Compose
+----------------
+
+The clean separation:
+
+```
+┌─────────────────────────────────────────────┐
+│              Signet Daemon                   │
+│  Identity | Memory | Knowledge | Learning   │
+│                                             │
+│  "Who is this agent? What does it know?     │
+│   What should it remember? What patterns    │
+│   are emerging?"                            │
+└──────────────────┬──────────────────────────┘
+                   │ enriches / extracts
+┌──────────────────▼──────────────────────────┐
+│              ACP (via acpx)                  │
+│  Sessions | Protocol | Queue | Recovery     │
+│                                             │
+│  "How do I talk to this agent? How do I     │
+│   manage the conversation? How do I         │
+│   recover from failures?"                   │
+└──────────────────┬──────────────────────────┘
+                   │ spawns / controls
+┌──────────────────▼──────────────────────────┐
+│          Coding Agent Harnesses              │
+│  Claude Code | Codex | Gemini | OpenClaw    │
+│                                             │
+│  "Execute this task. Use these tools.       │
+│   Produce this output."                     │
+└─────────────────────────────────────────────┘
+```
+
+Signet sits above ACP. ACP sits above the harnesses. Each layer
+handles its own concerns. Signet never needs to know how to spawn
+a Claude Code process -- acpx handles that. acpx never needs to
+know what memories to inject -- Signet handles that.
+
+
+---
+
+
+Phase 1: Scheduler Uses acpx
+-----------------------------
+
+*Scope: small. Value: high. Risk: low.*
+
+Replace raw `Bun.spawn` in the scheduler with acpx session management.
+
+### What Changes
+
+`packages/daemon/src/scheduler/spawn.ts` gains an `acpx` spawn mode.
+When a task's harness is configured for acpx (or a global flag
+enables it), the scheduler calls acpx instead of the harness CLI
+directly.
+
+### Command Mapping
+
+Current:
+```
+claude --dangerously-skip-permissions -p "task prompt"
+codex exec --skip-git-repo-check --json "task prompt"
+opencode run --format json "task prompt"
+```
+
+With acpx:
+```
+acpx claude -s task-{taskId} --format json "task prompt"
+acpx codex -s task-{taskId} --format json "task prompt"
+acpx opencode -s task-{taskId} --format json "task prompt"
+```
+
+### Session Affinity
+
+Each task gets a stable session name: `task-{taskId}`. Subsequent
+runs of the same task reuse the session, giving the agent continuity
+across periodic executions. A daily code review task remembers
+yesterday's findings.
+
+### Structured Output Parsing
+
+acpx's JSON output mode produces NDJSON events. The scheduler can
+parse these into typed records:
+- `thinking` events: agent reasoning (useful for debugging, not stored)
+- `tool_call` events: what the agent did (useful for audit trails)
+- `text` events: final response (what gets stored in `task_runs.stdout`)
+- `error` events: failures with structured context
+
+This replaces raw stdout string capture with typed event processing.
+
+### Crash Recovery
+
+If an agent process dies mid-task:
+1. acpx detects the stale PID on next invocation
+2. Attempts `session/load` to resume the conversation
+3. Falls back to `session/new` if the session is unrecoverable
+4. The scheduler retries the prompt in the recovered session
+
+Current behavior: the scheduler marks the task as failed and moves on.
+With acpx: the scheduler gets automatic recovery for free.
+
+### Implementation
+
+- Add `acpx` to PATH during daemon startup (or use `npx acpx`)
+- Add `spawnMode: 'raw' | 'acpx'` to task configuration
+- Modify `buildCommand()` in `spawn.ts` to generate acpx commands
+- Add NDJSON event parser for structured output
+- Store `acpxRecordId` alongside task run in `task_runs` table
+  (enables future "view conversation history" feature)
+- `SIGNET_NO_HOOKS=1` still injected to prevent hook loops
+- Permission mode: `--approve-all` for autonomous tasks (equivalent
+  to current `--dangerously-skip-permissions`)
+
+### What This Unlocks
+
+- Conversation continuity across scheduled task runs
+- Crash recovery without manual handling
+- Structured output parsing for better memory extraction
+- Cancel support (`acpx cancel -s task-{taskId}`)
+- Foundation for Phase 2
+
+
+---
+
+
+Phase 2: Signet as ACP Memory Proxy
+------------------------------------
+
+*Scope: medium. Value: high. Risk: medium.*
+
+Signet wraps itself as an ACP adapter that transparently enriches
+any agent session with memory.
+
+### The Concept
+
+An ACP adapter is any process that speaks ACP stdio protocol. Signet
+can implement an adapter that:
+
+1. Receives `initialize` -> negotiates capabilities
+2. Receives `newSession` -> calls `/api/hooks/session-start`, injects
+   memories into the session context
+3. Receives `prompt` -> prepends memory context, forwards to the
+   underlying agent (another ACP endpoint), captures response, calls
+   `/api/hooks/session-end` for extraction
+4. Receives `loadSession` -> restores Signet session context
+
+The adapter is invoked as:
+```
+signet acp --agent codex
+```
+
+And registered in acpx config:
+```json
+{
+  "agents": {
+    "signet-codex": "signet acp --agent codex",
+    "signet-claude": "signet acp --agent claude"
+  }
+}
+```
+
+Then: `acpx signet-codex "fix the tests"` gives a memory-augmented
+agent session with full acpx session management. Any acpx user gets
+Signet memory transparently.
+
+### Memory Injection Strategy
+
+The adapter intercepts the first prompt in a session and prepends
+Signet's context assembly (identity files, recalled memories,
+constraints, entity traversal results). Subsequent prompts in the
+same session get per-prompt context if configured.
+
+For agents with native MCP support, the adapter can also pass
+Signet's MCP endpoint in the `mcpServers` array of `newSession`,
+giving the agent direct access to memory tools without the hook
+system.
+
+### Session Correlation
+
+The adapter maps the `acpxSessionId` to a Signet session key. This
+enables:
+- Memory extraction correlated with specific acpx sessions
+- Dashboard view of "which agent sessions generated which memories"
+- The `acpxRecordId` becomes a foreign key in Signet's session
+  checkpoint tables
+
+### Implementation
+
+- New CLI command: `signet acp --agent <name>`
+- New module: `packages/daemon/src/acp-bridge/`
+- Implements ACP server-side protocol (using `@agentclientprotocol/sdk`
+  `AgentSideConnection`)
+- Spawns the underlying agent as a child ACP client
+- Proxies all ACP messages, intercepting session lifecycle events
+  for memory injection/extraction
+- Configuration: `agent.yaml` gains an `acp` section for adapter
+  settings
+
+### What This Unlocks
+
+- Memory-augmented sessions for any ACP-compatible agent, regardless
+  of whether the agent supports Signet hooks natively
+- The hook system becomes a compatibility layer rather than the
+  primary integration path
+- Any tool that speaks acpx gets Signet memory for free
+- Foundation for Phase 3
+
+
+---
+
+
+Phase 3: Cross-Agent Coordination
+----------------------------------
+
+*Scope: large. Value: transformative. Risk: high.*
+
+Signet becomes the coordination layer where agents discover each
+other, share context, and delegate work through ACP sessions managed
+by the daemon.
+
+### The Vision
+
+Today's Signet manages one agent's memory. Tomorrow's Signet manages
+a fleet. The daemon knows which agents exist (from `agent.yaml`),
+what each one knows (from its memory), and what each one is good at
+(from skill entities and usage patterns).
+
+When Agent A needs something done, it doesn't spawn a raw process.
+It asks Signet: "I need a code review of these changes." Signet:
+1. Identifies which agent is best suited (skill matching)
+2. Injects relevant context from its memory into the request
+3. Opens an ACP session with the target agent via acpx
+4. Routes the task with the enriched prompt
+5. Captures the result and extracts memories for both agents
+6. Returns the result to Agent A
+
+### Relationship to Existing Cross-Agent Messaging
+
+Signet's MCP tools (`agent_message_send`, `agent_message_inbox`)
+provide peer-to-peer messaging between Signet-aware agents. This is
+asynchronous, fire-and-forget communication -- passing notes.
+
+ACP provides synchronous, session-based communication -- structured
+conversations with results. The two patterns are complementary:
+
+- **MCP messaging**: "Hey, when you get a chance, look at this."
+  Async. No session. No structured result.
+- **ACP sessions**: "I need you to review this PR and give me
+  structured feedback now." Sync. Session with history. Typed output.
+
+Phase 3 unifies these: an agent can choose between async messaging
+(MCP) and sync delegation (ACP) depending on the task. Signet
+coordinates both.
+
+### The Scope-Reduction Invariant
+
+Borrowed from LCM's sub-agent architecture: when Agent A delegates
+to Agent B, the request must declare `delegated_scope` (what B is
+responsible for) and `kept_work` (what A retains). If A cannot
+articulate what it's keeping -- i.e., it would delegate its entire
+responsibility -- the delegation is rejected.
+
+This structurally prevents infinite delegation chains. Each level
+of delegation must represent a strict reduction in scope.
+
+### Agent Discovery
+
+The daemon exposes `/api/agents` (currently implicit via
+`agent.yaml`). For Phase 3, this becomes an active registry:
+
+```json
+{
+  "agents": [
+    {
+      "id": "mr-claude",
+      "capabilities": ["code-review", "architecture", "memory-management"],
+      "status": "available",
+      "currentSession": null
+    },
+    {
+      "id": "review-bot",
+      "capabilities": ["code-review", "testing"],
+      "status": "busy",
+      "currentSession": "task-42"
+    }
+  ]
+}
+```
+
+Capabilities are derived from skill entities and usage patterns.
+Status comes from acpx session state. Discovery is local (same
+machine), not networked (that's a different problem for a different
+day).
+
+### Implementation (High Level)
+
+This is a multi-month effort. The implementation sequence:
+
+1. Agent registry with capability matching (`/api/agents/discover`)
+2. Delegation API (`/api/agents/delegate`) that:
+   - Validates scope-reduction invariant
+   - Opens acpx session with target agent
+   - Injects context from Signet's memory
+   - Returns structured result
+3. Dashboard: agent fleet view showing status, active sessions,
+   delegation chains
+4. Predictor integration: learn which agents succeed at which tasks
+   (delegation scoring, analogous to path scoring)
+
+### What This Unlocks
+
+The multi-agent vision from VISION.md. Agents that can hire other
+agents. Specialization. Division of labor. The daemon as nervous
+system, not just memory bank.
+
+
+---
+
+
+Phase 4: Signet as ACP-Native Platform (Future)
+-------------------------------------------------
+
+*Scope: architectural shift. Timeline: 2026 H2 or later.*
+
+The hook system becomes a compatibility shim. The primary integration
+path is ACP + MCP. Signet's identity model (AGENTS.md, SOUL.md) is
+injected at the ACP protocol level, not via harness-specific file
+generation.
+
+Connectors evolve from "install hooks into harness config" to "thin
+ACP adapters that bridge harness-native protocols to ACP." The
+connector's job simplifies: it just needs to translate the harness
+into an ACP speaker. Signet handles everything else.
+
+This is the endgame, but it depends on ACP adoption across the
+ecosystem. We build toward it incrementally -- each phase brings
+value on its own, and each phase makes the next one easier.
+
+
+---
+
+
+Migration Path
+--------------
+
+The integration is additive at every phase. Nothing is removed until
+it is fully superseded.
+
+```
+Phase 1: scheduler gains acpx mode (raw spawn still works)
+Phase 2: ACP adapter added (hooks still work)
+Phase 3: delegation API added (MCP messaging still works)
+Phase 4: hooks become compatibility shim (ACP is primary)
+```
+
+At no point does an existing integration break. Users who don't want
+acpx continue using hooks. Users who adopt acpx get session
+persistence and memory enrichment for free.
+
+
+---
+
+
+Dependencies
+------------
+
+- `acpx` npm package (or vendored binary)
+- `@agentclientprotocol/sdk` for Phase 2+ (ACP server-side protocol)
+- No changes to existing harness connectors for Phase 1
+- Phase 2 requires new `packages/daemon/src/acp-bridge/` module
+- Phase 3 requires multi-agent support from the existing spec
+
+---
+
+*This document describes the integration vision and phased plan.
+Phase 1 is ready for implementation. Phases 2-4 are directional
+and will be refined as ACP matures and Signet's multi-agent
+architecture solidifies.*
+
+---
+
+*Written by Nicholai and Mr. Claude. March 8, 2026.*

--- a/docs/DESIRE-PATHS.md
+++ b/docs/DESIRE-PATHS.md
@@ -414,6 +414,56 @@ participate in useful traversal paths? The ones that don't are noise,
 regardless of their mention count.
 
 
+Foundation: Lossless Context Patterns
+--------------------------------------
+
+Desire paths assumes a clean, bounded knowledge graph with
+non-destructive lifecycle management. Five patterns adapted from
+Voltropy's Lossless Context Management (LCM) research provide this
+foundation. They are documented in [[LCM-PATTERNS|Lossless Context
+Patterns]] and can be implemented independently, before desire paths.
+
+The patterns that matter most to desire paths:
+
+- **Lossless retention** -- decay without destruction. When a path
+  gets demoted by consistently bad feedback, the underlying knowledge
+  moves to a cold tier rather than being deleted. Explorer bees can
+  walk into cold territory and rediscover forgotten connections. This
+  makes the entire feedback loop non-destructive -- the system can
+  evolve its topology without permanent information loss.
+
+- **Three-level extraction escalation** -- convergence guarantee for
+  the extraction pipeline. If desire paths learns from a graph
+  polluted with noise entities, path scoring learns from garbage.
+  Escalation ensures extraction output is always bounded, which keeps
+  path reinforcement signals clean.
+
+- **Zero-cost continuity** -- if 30% of sessions are trivial and
+  produce noise extractions, 30% of path reinforcement signals are
+  misleading. A significance gate at pipeline entry prevents noise
+  from entering the system, making every training signal the predictor
+  receives more trustworthy.
+
+- **Session summary DAG** -- desire paths operates on the spatial
+  dimension (entity graph). The session DAG adds a temporal dimension.
+  The predictor can learn to route through both: "for queries about
+  recent refactors, walk session summaries first; for queries about
+  architecture, walk entity aspects." Temporal sequence as a learnable
+  routing signal.
+
+- **On-demand expansion** -- desire paths' eager traversal at session
+  start is the push path. On-demand expansion is the pull path. The
+  agent requests what it knows it needs, complementing what the system
+  predicted it would need. Explorer bees can also use expansion to
+  drill into speculative findings immediately.
+
+These patterns provide the deterministic floor. Desire paths provides
+the learning ceiling. LCM guarantees convergence, bounded output, and
+lossless lifecycle. Desire paths adds reinforcement, emergence, and
+lateral thinking. Together they produce a system that is both reliable
+and intelligent.
+
+
 Relationship to Existing Architecture
 --------------------------------------
 
@@ -440,6 +490,10 @@ architecture:
 - **The exploration layer** extends the [[pipeline|extraction pipeline]] with one
   additional step: checking whether new facts bridge to unlinked
   entities. No new infrastructure required.
+- **The [[LCM-PATTERNS|lossless context patterns]]** provide the deterministic
+  foundation: bounded extraction, non-destructive decay, temporal
+  hierarchy, and on-demand expansion. Desire paths builds on these
+  guarantees.
 
 
 The Convergence
@@ -468,11 +522,14 @@ Small. Dense. Connected. Correct. And now: *learned*.
 
 ---
 
-*This document describes the concept. Implementation details,
-data structures, and integration points will follow in a separate
-specification once the concept is validated.*
+*This document describes the concept. The deterministic foundation
+is specified in [[LCM-PATTERNS|Lossless Context Patterns]].
+Implementation details, data structures, and integration points
+for the learning layer will follow in a separate specification
+once the foundation is in place.*
 
 ---
 
-*Written by Nicholai, Mr. Claude, PatchyToes, and Jake. March 7, 2026.*
+*Written by Nicholai, Mr. Claude, PatchyToes, and Jake. March 7, 2026.
+Updated March 8, 2026: added LCM foundation section and cross-references.*
 

--- a/docs/LCM-PATTERNS.md
+++ b/docs/LCM-PATTERNS.md
@@ -1,0 +1,492 @@
+---
+title: "Lossless Context Patterns"
+description: "Five patterns from LCM adapted for Signet's memory architecture."
+order: 4
+section: "Core Concepts"
+---
+
+Lossless Context Patterns
+=========================
+
+*Deterministic guarantees for a learning system.*
+
+> *LCM provides the floor. Desire paths provide the ceiling.
+> Together they're stronger than either alone.*
+
+This document describes five patterns adapted from Voltropy's Lossless
+Context Management (LCM) paper and its reference implementation
+(lossless-claw). These patterns are not LCM itself -- they are
+principles extracted from LCM and recontextualized for Signet's
+cross-session memory architecture.
+
+These patterns form the foundation layer that [[DESIRE-PATHS|desire paths]]
+builds on. They can be implemented independently, before desire paths,
+and each one strengthens the system on its own.
+
+References:
+- LCM paper: https://papers.voltropy.com/LCM (Ehrlich & Blackman, Feb 2026)
+- lossless-claw: `references/lossless-claw/`
+- Research notes: `docs/RESEARCH-LCM-ACP.md`
+
+---
+
+
+Pattern 1: Lossless Retention
+-----------------------------
+
+### The Principle
+
+Nothing is ever truly lost. Information moves between tiers, not out
+of the system. Decay reduces visibility, not existence.
+
+### The LCM Pattern
+
+LCM maintains an immutable store alongside an active context. Every
+message is persisted verbatim and never deleted. Summaries are
+materialized views over this store -- derived artifacts, not
+replacements. Any summary can be expanded back to its constituent
+messages via `lcm_expand`.
+
+### Current Signet Behavior
+
+The retention worker (`retention-worker.ts`) performs hard deletes of
+tombstoned memories past the retention window. When a memory is pruned,
+the content is gone. When an entity attribute is superseded by a newer
+extraction, the old attribute is deleted. The `memory_history` table
+preserves brief snapshots, but these decay too.
+
+### The Adaptation
+
+Replace hard deletion with cold-tier archival. A memory that is
+pruned, superseded, or decayed below threshold moves to a
+`memories_cold` table with the same schema but no FTS5 index and
+no vector index. Pure text storage. The retention worker archives
+instead of purges.
+
+The cold tier is not queried during normal retrieval. It is available
+for:
+
+1. **Explorer bee traversals** -- when a speculative traversal walks
+   into cold territory, it can surface forgotten connections that
+   turn out to be relevant in a new context.
+
+2. **Entity health diagnostics** -- when a path consistently produces
+   poor feedback, one diagnostic question is "what did this entity
+   look like three months ago?" The cold tier answers that.
+
+3. **Recovery from bad extractions** -- if the pipeline corrupts an
+   entity (overwrites correct attributes with incorrect ones), the
+   cold tier enables rollback to the last known-good state.
+
+4. **Principle discovery** -- cross-entity patterns may span active
+   and archived knowledge. A superseded attribute from a year ago
+   might be the bridge between two entities that haven't been
+   connected yet.
+
+### Implementation
+
+- Migration: create `memories_cold` table (identical schema to
+  `memories`, no FTS5 trigger, no vector index)
+- Modify `retention-worker.ts`: `INSERT INTO memories_cold SELECT *
+  FROM memories WHERE id IN (...)` before `DELETE`
+- Add `cold_source_id` column to `memories` for supersession chains
+  (when memory B supersedes memory A, A moves to cold with
+  `cold_source_id` pointing to B)
+- Add `/api/repair/cold-stats` endpoint for dashboard visibility
+- Explorer bee traversal gains access to cold tier via a separate
+  query path (no FTS, just direct ID lookup and basic LIKE search)
+
+### What This Enables
+
+Desire paths' feedback-driven decay becomes non-destructive. A path
+that gets demoted by consistently bad feedback can still be
+rediscovered by an explorer bee, confirmed as good in a new context,
+and promoted back to active. The system's topology can evolve without
+permanent information loss.
+
+The philosophical shift: from "old things fade away" to "old things
+step back but remain reachable." The practical shift: one migration
+and a retention worker change.
+
+
+---
+
+
+Pattern 2: Three-Level Extraction Escalation
+--------------------------------------------
+
+### The Principle
+
+Every pipeline stage must have a convergence guarantee. If the
+normal path fails to produce bounded output, escalate to
+progressively stricter strategies until a deterministic fallback
+guarantees termination.
+
+### The LCM Pattern
+
+LCM's compaction uses three levels:
+1. Normal: LLM summarize with full detail preservation
+2. Aggressive: LLM summarize with bullet points at half the token budget
+3. Deterministic: hard truncation to 512 tokens, no LLM involved
+
+If any level produces output smaller than input, it returns. Level 3
+always converges. Compaction never makes things worse.
+
+### Current Signet Behavior
+
+The extraction pipeline runs an LLM pass that can produce an
+unbounded number of entities and attributes. There is no structural
+backstop preventing a runaway extraction from producing 5,000
+entities from a single document. The 43,000-entity bloat problem is
+partially a consequence of this missing guarantee.
+
+### The Adaptation
+
+Apply three-level escalation to the extraction pipeline:
+
+**Level 1 (Normal):** Current extraction prompt. Full fact
+identification, structural assignment, entity creation. Run as-is.
+
+**Level 2 (Aggressive):** If Level 1 produces more than N new
+entities or M new attributes for this session chunk, re-run with a
+stricter prompt: "Extract only decisions, constraints, and persistent
+facts. Ignore transient states, error messages, and conversational
+scaffolding. Maximum 5 new entities per chunk."
+
+**Level 3 (Deterministic):** If Level 2 still produces too much,
+apply structural rules with no LLM involved:
+- Keep only items that the deduplication pass finds no existing match
+  for (genuinely new knowledge)
+- Keep any items explicitly flagged as constraints
+- Discard everything else
+
+The thresholds that trigger escalation can be calibrated per entity
+type: a project entity tolerates 30 attributes; a person entity
+shouldn't exceed 15; an unknown-type entity getting more than 5
+attributes in a single session is suspicious.
+
+### Implementation
+
+- Add escalation logic to the extraction stage in
+  `packages/daemon/src/pipeline/worker.ts`
+- Define threshold constants (configurable via agent.yaml):
+  `maxNewEntitiesPerChunk` (default 10),
+  `maxNewAttributesPerEntity` (default 20)
+- Level 2 prompt variant stored alongside existing extraction prompts
+- Level 3 is pure TypeScript filtering logic, no LLM call
+- Add `extraction_level` field to pipeline telemetry so we can
+  observe how often escalation triggers
+- Dashboard: surface escalation frequency in pipeline status
+
+### What This Enables
+
+The entity bloat problem becomes structurally impossible. The
+extraction pipeline always terminates, output is always bounded,
+and the system never makes the database worse by adding pure noise.
+This is a prerequisite for desire paths -- if the graph is polluted
+with noise entities, path scoring learns from garbage.
+
+
+---
+
+
+Pattern 3: Zero-Cost Continuity
+-------------------------------
+
+### The Principle
+
+Below a significance threshold, the system is invisible. No
+extraction, no summarization, no overhead. The cost of the memory
+pipeline is zero when there is nothing worth remembering.
+
+### The LCM Pattern
+
+LCM defines `tau_soft` and `tau_hard` thresholds. Below `tau_soft`,
+the system is a passive logger -- no summarization, no retrieval, no
+latency penalty. The overhead appears only when it is needed.
+
+### Current Signet Behavior
+
+The pipeline runs on every session-end hook regardless of session
+length or content significance. A 3-turn conversation about a
+trivial question still runs through extraction, structural
+assignment, deduplication, and retention. The cost is not zero: it
+produces low-quality memories that increase the deduplication and
+decay burden, and those memories generate misleading path
+reinforcement signals.
+
+### The Adaptation
+
+Add a significance gate at the pipeline entry point. If a session
+fails the gate, skip extraction entirely and log the session for
+potential later backfill.
+
+The significance gate checks:
+1. **Turn count**: sessions with fewer than N substantive turns
+   (default 5) are candidates for skip. "Substantive" means the
+   user message is longer than a greeting and the assistant response
+   contains more than acknowledgment.
+2. **Entity mention density**: if the session transcript has zero
+   FTS matches against existing high-importance entities, there is
+   likely nothing to extract.
+3. **Content novelty**: if the session's embedding is within a
+   threshold distance of recent session embeddings, it is likely
+   rehashing known territory.
+
+If all three checks indicate low significance, the pipeline emits
+a `session_skipped` telemetry event and returns. The raw session
+transcript is still persisted (lossless retention applies here too)
+-- it just doesn't trigger extraction.
+
+### Implementation
+
+- Add `significanceGate()` function to pipeline entry
+  (`packages/daemon/src/pipeline/worker.ts`)
+- Gate runs before extraction, after session transcript is received
+- Configurable thresholds in agent.yaml: `pipeline.minTurns`,
+  `pipeline.minEntityOverlap`, `pipeline.noveltyThreshold`
+- Telemetry: `session_skipped` event with gate results for
+  observability
+- Backfill path: `/api/repair/backfill-skipped` endpoint to
+  retroactively run extraction on skipped sessions if needed
+
+### What This Enables
+
+Cleaner path reinforcement signals for desire paths. If 30% of
+extractions are noise from trivial sessions, 30% of path
+reinforcement signals are misleading. Zero-cost continuity prevents
+noise from entering the system in the first place.
+
+Also reduces daemon load. On a busy day with 20+ sessions, many are
+quick questions or status checks. Skipping those saves LLM calls
+and database writes.
+
+
+---
+
+
+Pattern 4: Session Summary DAG
+------------------------------
+
+### The Principle
+
+Session histories should form a hierarchical structure with
+increasing levels of abstraction, not a flat list of summaries.
+Individual sessions compose into arcs. Arcs compose into epochs.
+Each level is traversable with drill-down to the level below.
+
+### The LCM Pattern
+
+LCM builds a Directed Acyclic Graph of summaries:
+- Leaf summaries (depth 0): condensed versions of raw message chunks
+- Condensed summaries (depth 1+): higher-order summaries merging
+  lower nodes
+- Parent links enable drill-down recovery of original content
+- Depth-aware prompts: leaf summaries preserve operational detail,
+  higher depths focus on goals and decisions
+
+### Current Signet Behavior
+
+`summary-worker.ts` produces flat markdown summaries at session end.
+These are stored as files in `~/.agents/memory/summaries/`. There is
+no hierarchy, no parent links, no depth-aware condensation. Sessions
+from three months ago are equally flat whether they were a 5-minute
+fix or part of a week-long architecture sprint.
+
+### The Adaptation
+
+Build a session summary DAG alongside the existing entity graph.
+The entity graph organizes knowledge *spatially* (by topic). The
+session DAG organizes knowledge *temporally* (by when it happened).
+
+**Depth 0 (Session):** Individual session summaries. Produced by
+the existing summary worker. Enhanced with structured metadata:
+linked memory IDs, mentioned entity IDs, project entity reference,
+predecessor session link (if the session continues recent work on
+the same project).
+
+**Depth 1 (Arc):** After every N sessions on the same project
+(default 8), generate an arc summary that condenses the session
+summaries. Arc summaries preserve decisions, outcomes, and turning
+points. Operational details (specific commands, error messages) are
+dropped. Parent links point to constituent session summaries.
+
+**Depth 2 (Epoch):** After every M arcs (default 4), generate an
+epoch summary. Epoch summaries preserve only architectural facts,
+major pivots, and persistent constraints. Parent links point to
+constituent arc summaries.
+
+The depth-aware prompt strategy follows LCM directly:
+- Session prompts: "Preserve operational detail, commands, error
+  messages, and specific decisions."
+- Arc prompts: "Preserve decisions and outcomes. Drop transient
+  errors and command-level detail."
+- Epoch prompts: "Preserve only architectural facts, major
+  direction changes, and constraints that still apply."
+
+### Implementation
+
+- Migration: create `session_summaries` table:
+  ```
+  id TEXT PRIMARY KEY,
+  project_entity_id TEXT,
+  depth INTEGER DEFAULT 0,
+  kind TEXT CHECK(kind IN ('session', 'arc', 'epoch')),
+  content TEXT,
+  token_count INTEGER,
+  earliest_at TEXT,
+  latest_at TEXT,
+  parent_summary_id TEXT,  -- for arcs/epochs: NULL for sessions
+  agent_id TEXT DEFAULT 'default'
+  ```
+- Junction table `session_summary_children`:
+  ```
+  parent_id TEXT,
+  child_id TEXT,
+  ordinal INTEGER
+  ```
+- Junction table `session_summary_memories`:
+  ```
+  summary_id TEXT,
+  memory_id TEXT
+  ```
+- Modify `summary-worker.ts` to write structured session summary
+  nodes instead of flat markdown
+- Add arc/epoch condensation as a periodic maintenance task
+  (runs after session summary, checks if arc threshold met)
+- Add `/api/sessions/summaries` endpoint for dashboard
+- Add `signet_expand_session(summary_id)` tool for agent mid-session
+  drill-down into temporal history
+
+### What This Enables
+
+Desire paths gain a temporal dimension. The predictor can learn that
+"when a query is about a recent refactor, traverse the last 3 session
+summaries before walking entity aspects." Temporal sequence becomes a
+learnable routing signal alongside the spatial entity graph.
+
+The session DAG also enables the "what happened three sessions ago"
+retrieval problem -- instead of searching flat memories, the agent
+can walk the DAG from the current session backward through parent
+links.
+
+
+---
+
+
+Pattern 5: On-Demand Expansion
+------------------------------
+
+### The Principle
+
+Eager context assembly at session start handles the common case.
+On-demand expansion handles the rest. The agent should be able to
+drill deeper into any entity mid-session without the system having
+to predict what it will need.
+
+### The LCM Pattern
+
+LCM provides `lcm_expand_query` -- a tool the agent calls
+mid-session when it needs detail that was compacted away. The tool
+spawns a scoped sub-agent that walks the DAG, finds the relevant
+content, and returns a focused answer. The main agent's context is
+not flooded; only the answer comes back.
+
+### Current Signet Behavior
+
+The agent can call `/api/memory/recall` for flat search mid-session.
+This returns ranked memories by hybrid search. There is no
+graph-aware expansion -- the agent cannot say "tell me everything
+about entity X's auth aspect" and get a structured traversal result.
+
+### The Adaptation
+
+Add a `signet_expand_entity` tool available to agents mid-session.
+The tool takes an entity name, optional aspect filter, and a natural
+language question. It performs a focused graph traversal scoped to
+that entity and returns a structured answer.
+
+The tool does NOT spawn a sub-agent (simpler than LCM's approach).
+It runs the existing graph traversal logic
+(`packages/daemon/src/pipeline/graph-traversal.ts`) with the entity
+as the sole focal entity and the aspect filter narrowing the walk.
+The result is formatted as a structured context block with cited
+aspect and attribute IDs.
+
+The key constraint: expansion results are appended to the session
+context, not injected at the system level. The agent requested them;
+the agent sees them as a tool response. This prevents the "context
+flooding" problem LCM solves with sub-agent isolation -- the agent
+controls when and how much to expand.
+
+### Implementation
+
+- Add `/api/memory/expand` endpoint:
+  ```
+  POST /api/memory/expand
+  {
+    "entity": "predictive_scorer",
+    "aspect": "cold_start_behavior",
+    "question": "what are the training pair requirements?",
+    "maxTokens": 2000
+  }
+  ```
+- The endpoint calls `traverseKnowledgeGraph()` with the specified
+  entity as sole focal entity, filters to the requested aspect (if
+  provided), and returns the traversal result formatted as a context
+  block
+- Register as an MCP tool so agents with MCP access can call it
+  directly
+- Add to hook-generated CLAUDE.md/AGENTS.md as an available tool
+- Token budget on the response prevents unbounded expansion
+
+### What This Enables
+
+Desire paths' eager traversal at session start is the push path --
+the system predicts what the agent needs. On-demand expansion is the
+pull path -- the agent requests what it knows it needs. Together they
+cover both the predictable and the unpredictable.
+
+The explorer bees mechanism can also use expansion: when a
+speculative traversal surfaces something interesting, the agent can
+immediately expand on it without waiting for the next session start.
+
+
+---
+
+
+Implementation Sequence
+-----------------------
+
+These patterns are independent and can be implemented in any order.
+The recommended sequence prioritizes the ones that reduce noise
+(making desire paths' future learning signal cleaner):
+
+1. **Three-Level Extraction Escalation** -- stops the bleeding on
+   entity bloat. Immediate value, small scope.
+
+2. **Zero-Cost Continuity** -- prevents noise sessions from entering
+   the pipeline. Compounds with escalation.
+
+3. **Lossless Retention** -- migration + retention worker change.
+   Non-destructive decay is philosophically important but not urgent.
+
+4. **On-Demand Expansion** -- new endpoint + MCP tool registration.
+   Useful immediately, even before desire paths.
+
+5. **Session Summary DAG** -- the most ambitious pattern. New tables,
+   new condensation logic, new maintenance task. Worth doing but
+   depends on the summary worker being solid.
+
+Total estimated scope: each pattern is roughly 1-3 days of focused
+work. The full set is a sprint, not a quarter.
+
+---
+
+*This document describes adaptations from LCM, not LCM itself.
+Signet is a cross-session knowledge system; LCM is a within-session
+context manager. The patterns transfer; the architecture does not.*
+
+---
+
+*Written by Nicholai and Mr. Claude. March 8, 2026.*

--- a/docs/RESEARCH-LCM-ACP.md
+++ b/docs/RESEARCH-LCM-ACP.md
@@ -1,0 +1,299 @@
+# Research: Lossless Context Management & Agent Client Protocol
+
+> Research notes on LCM, acpx, and lossless-claw. Collected 2026-03-08.
+> References cloned to `references/acpx/` and `references/lossless-claw/`.
+>
+> **This research produced two specification documents:**
+> - `docs/LCM-PATTERNS.md` — Five patterns adapted for Signet's memory architecture
+> - `docs/ACP-INTEGRATION.md` — Phased integration plan for acpx and ACP
+> - `docs/DESIRE-PATHS.md` — Updated with LCM foundation section
+
+---
+
+## Sources
+
+| Source | Type | URL |
+|--------|------|-----|
+| LCM Paper | Academic (Voltropy PBC) | https://papers.voltropy.com/LCM |
+| lossless-claw | OpenClaw Plugin | https://github.com/Martian-Engineering/lossless-claw |
+| acpx | CLI Tool | https://github.com/openclaw/acpx |
+| Shannon Lecture | Historical Reference | 1952 Bell Labs, "Creative Thinking" |
+
+---
+
+## LCM: Lossless Context Management
+
+**Authors**: Clint Ehrlich, Theodore Blackman (Voltropy PBC, Feb 14 2026)
+
+### Core Thesis
+
+Context windows are the bottleneck for long-horizon agentic sessions. Even
+1M+ token windows are insufficient for multi-day sessions where file contents,
+tool calls, and intermediate reasoning accumulate. Performance degrades well
+before the nominal limit ("context rot").
+
+RLM (Recursive Language Models) proved that *active* context management
+outperforms passive windows. But RLM gives the model full autonomy over its
+memory via symbolic recursion (writing Python scripts to chunk/manage context).
+This is flexible but stochastic -- an efficient chunking script in one rollout
+may be suboptimal in the next.
+
+LCM takes the opposite approach: the *engine* manages memory deterministically,
+using structured primitives the model invokes. The analogy is GOTO vs structured
+programming -- GOTO is maximally flexible but error-prone; `for`/`while`/`if`
+are constrained but reliable.
+
+### Architecture
+
+**Dual-state memory**:
+- **Immutable Store**: Every user message, assistant response, and tool result
+  persisted verbatim. Never modified. Source of truth.
+- **Active Context**: The window actually sent to the LLM. Mix of recent raw
+  messages and precomputed summary nodes (materialized views over history).
+
+**Hierarchical DAG**:
+- Leaf summaries (depth 0): condensed versions of raw message chunks
+- Condensed nodes (depth 1+): higher-order summaries merging lower nodes
+- Parent links enable drill-down to original content via `lcm_expand`
+- Stored in persistent transactional backend (reference impl uses PostgreSQL)
+
+**Context Control Loop** (Algorithm 2 from paper):
+1. New item arrives -> persist to immutable store, append pointer to active context
+2. If `Tok(C) > tau_soft`: trigger async compaction (non-blocking)
+3. While `Tok(C) > tau_hard`: blocking compaction of oldest block
+
+**Three-Level Summarization Escalation** (guaranteed convergence):
+1. Normal: LLM summarize with `mode="preserve_details"`, target T tokens
+2. Aggressive: LLM summarize with `mode="bullet_points"`, target T/2
+3. Deterministic truncation to 512 tokens (no LLM involved)
+
+If any level produces output smaller than input, return it. Level 3 always
+converges. This eliminates "compaction failure" where summaries expand.
+
+### Key Properties
+
+**Zero-Cost Continuity**: Below `tau_soft`, no summarization or retrieval
+occurs. System is a passive logger. No latency penalty for short tasks.
+
+**Deterministic Retrievability**: When compacting, engine inserts message IDs
+into summaries. Any prior message is recoverable via `lcm_expand`, regardless
+of how many compaction rounds occurred. Model doesn't need to know compaction
+happened -- it just sees summary text annotated with expandable identifiers.
+
+**Scope-Reduction Invariant**: When sub-agent spawns sub-agent, it must declare
+`delegated_scope` and `kept_work`. If it can't articulate what it's retaining
+(i.e., would delegate everything), engine rejects the call. This structurally
+prevents infinite delegation without depth limits.
+
+### Large File Handling
+
+Files exceeding 25k tokens are not loaded into context. Instead:
+- Stored externally with an opaque ID
+- Type-specific "Exploration Summary" generated (schema extraction for
+  JSON/CSV/SQL, function signatures for code, LLM summary for text)
+- Compact reference inserted into active context
+- File IDs propagate through DAG -- model retains awareness across compactions
+
+### Tools Exposed
+
+**Memory-Access** (read-only, immutable store):
+- `lcm_grep(pattern, summary_id?)` -- regex search across full history
+- `lcm_describe(id)` -- metadata for any LCM identifier (file or summary)
+- `lcm_expand(summary_id)` -- expand summary back to constituent messages
+  (restricted to sub-agents only, prevents context flooding in main loop)
+
+**Operators** (parallel data processing):
+- `llm_map(input_path, prompt, output_schema, concurrency)` -- stateless
+  per-item LLM calls, engine handles iteration/retries/validation
+- `agentic_map(...)` -- spawns full sub-agent session per item, for multi-step
+  reasoning. Supports `read_only` flag.
+
+**Delegation** (sub-agent management):
+- `Task(prompt, delegated_scope, kept_work)` -- spawn sub-agent with
+  scope-reduction guard
+- `Tasks(tasks[])` -- parallel sub-agent dispatch
+
+### Benchmark Results (OOLONG)
+
+Volt (LCM on OpenCode fork) vs Claude Code, both using Opus 4.6 + Haiku 4.5:
+
+| Context | Claude Code | Volt | Gap |
+|---------|-------------|------|-----|
+| 8K | +13.1 | +11.2 | CC +1.9 |
+| 16K | +26.3 | +25.0 | CC +1.3 |
+| 32K | +25.8 | +29.4 | Volt +3.6 |
+| 65K | +26.8 | +27.6 | Volt +0.8 |
+| 131K | +22.0 | +28.3 | Volt +6.3 |
+| 256K | +8.5 | +18.5 | Volt +10.0 |
+| 512K | +29.8 | +42.4 | Volt +12.6 |
+| 1M | +47.0 | +51.3 | Volt +4.3 |
+
+Average: Volt 74.8 vs CC 70.3. Gap widens at longer contexts where LCM's
+deterministic map-reduce shines vs CC's model-driven chunking strategies.
+
+---
+
+## acpx: Agent Client Protocol CLI
+
+Headless CLI enabling structured agent-to-agent communication via ACP.
+Replaces terminal output scraping with protocol-based interaction.
+
+### Architecture
+
+- Session state in `~/.acpx/`
+- Routes prompts by walking to nearest git root
+- Adapters for: Codex, Claude Code, Gemini, OpenClaw, OpenCode, Pi
+- Custom ACP servers via `--agent` escape hatch
+
+### Key Features
+
+- Persistent multi-turn sessions surviving crashes
+- Named parallel sessions per repository
+- Prompt queueing with ordered execution
+- Fire-and-forget (`--no-wait`)
+- Cooperative cancellation via `session/cancel`
+- Output modes: text (default), NDJSON streaming, JSON-strict, quiet
+- Configurable idle TTLs, auto-respawn with `session/load` fallback
+
+### Configuration
+
+Global: `~/.acpx/config.json`
+Project: `.acpxrc.json`
+Auth credentials stored in config. Custom agents registered with command overrides.
+
+**Status**: Alpha. CLI and runtime interfaces may change.
+
+---
+
+## lossless-claw: LCM Plugin for OpenClaw
+
+Reference implementation of LCM as an OpenClaw plugin. Replaces default
+sliding-window truncation with DAG-based hierarchical summarization.
+
+### Storage
+
+SQLite at `~/.openclaw/lcm.db`. FTS5 optional for full-text search acceleration.
+
+### Compaction
+
+- Triggered at configurable threshold (default 75% of window)
+- Fresh tail protected (default 32 messages stay raw)
+- Depth-aware prompts: leaf summaries emphasize narrative detail, higher depths
+  focus on goals and decisions
+
+### Agent Tools
+
+- `lcm_grep`: full-text + regex across messages/summaries
+- `lcm_describe`: retrieve specific summaries or stored files by ID
+- `lcm_expand_query`: delegated sub-agent expansion with semantic search
+- `lcm_expand`: low-level DAG expansion for sub-agents
+
+---
+
+## Relevance to Signet
+
+### Pattern Overlap
+
+| Concept | LCM | Signet |
+|---------|-----|--------|
+| Persistent store | Immutable message history | Entity/mention graph + memory table |
+| Summarization | Hierarchical DAG of summaries | Memory extraction pipeline |
+| Retrieval | lcm_grep + lcm_expand | Hybrid vector + keyword search |
+| Scope | Within single session | Across all sessions |
+| File handling | Exploration summaries | Document pipeline (planned) |
+| Sub-agent guard | Scope-reduction invariant | N/A (potential addition) |
+
+### Ideas Worth Exploring
+
+1. **Three-level escalation for memory extraction**: Signet's extraction pipeline
+   could adopt the guaranteed-convergence pattern. If normal extraction produces
+   too many entities, escalate to aggressive mode, then deterministic fallback.
+   Directly relevant to entity bloat problem.
+
+2. **Scope-reduction invariant for signet scheduler**: When scheduler spawns
+   agents, requiring them to declare delegated vs retained scope could prevent
+   runaway task chains. Maps to the `Bun.spawn` scheduler pattern.
+
+3. **DAG-based session summarization**: Instead of flat memory records per
+   session, build a summary DAG that allows drill-down. Would improve the
+   "what happened three sessions ago" retrieval problem.
+
+4. **acpx as agent coordination layer**: Replace raw process spawning in
+   scheduler with ACP protocol. Gets session management, crash recovery,
+   cancellation, and structured output for free.
+
+5. **Operator-level recursion (llm_map/agentic_map)**: The pattern of
+   engine-managed parallel processing with schema validation and retry is
+   applicable to signet's batch operations (e.g., entity reconciliation,
+   bulk memory re-embedding).
+
+6. **Zero-cost continuity principle**: Signet's daemon overhead should be
+   zero when not needed. Memory pipeline should be invisible until context
+   demands active management. Currently close to this but worth auditing.
+
+### What LCM Doesn't Solve (That Signet Does)
+
+- Cross-session memory persistence and identity
+- Knowledge graph with entity relationships
+- Predictive memory scoring (anticipating what's relevant)
+- Agent identity and personality continuity
+- Multi-agent coordination beyond sub-agent delegation
+
+---
+
+## Shannon: "Creative Thinking" (1952)
+
+Included as foundational reference for how we think about problem-solving
+in agent design. Full lecture by Claude Shannon at Bell Labs, March 20, 1952.
+
+### The Uranium Metaphor (via Turing)
+
+Human brains are like uranium. Shoot in a neutron (idea) -- some people return
+half a neutron. Others are past critical mass and return two for every one.
+Those people are past the "knee of the curve." A tiny fraction of the population
+produces a disproportionate share of important ideas.
+
+### Three Requirements for Creative Work
+
+1. **Training & experience** -- domain knowledge is prerequisite
+2. **Intelligence** -- above-average cognitive capacity needed for research
+3. **Motivation** -- the differentiator. Drive to find answers, curiosity about
+   how things work. "Either you have it or you don't" (Fats Waller on swing).
+
+The surface composition of motivation:
+- **Curiosity**: wanting to know how things work
+- **Constructive dissatisfaction**: "this works, but I think it can be done
+  more elegantly." A persistent itch when things aren't quite right.
+- **Pleasure of solution**: the raw excitement of proving a theorem or finding
+  a clever circuit design
+
+### Thinking Techniques
+
+1. **Simplification**: Strip to essentials. Solve the simple version. Add
+   refinements back toward the original problem.
+
+2. **Analogy**: Find similar solved problem P' with solution S'. Map the
+   analogy from P'->P and S'->S. "Two small jumps are easier than one big one."
+
+3. **Restatement**: Reformulate from every angle. Prevents mental ruts. Often
+   an outsider solves instantly what you've struggled with for months.
+
+4. **Generalization**: The moment you solve something, ask "can I make a broader
+   statement?" Extend from specific to general, 2D to N-dimensional.
+
+5. **Structural analysis**: Break big leaps into subsidiary steps. Prove lemmas.
+   Many proofs found through "extremely circuitous processes" then simplified.
+
+6. **Inversion**: Flip the problem. Assume the solution is given, try to derive
+   the premises. Shannon built a nim-playing machine this way -- the machine
+   worked backward from desired output via feedback until matching input.
+
+### Application to Agent Design
+
+These techniques map directly to how we design agent reasoning:
+- Simplification -> decompose complex tasks before attempting
+- Analogy -> leverage prior solutions in knowledge graph
+- Restatement -> multiple retrieval strategies for same query
+- Generalization -> extract reusable patterns from specific solutions
+- Structural analysis -> break work into sub-agent tasks
+- Inversion -> work backward from desired output to required inputs


### PR DESCRIPTION
## Summary

- **Three new specification documents**: LCM patterns adapted for Signet (five implementable patterns with concrete data structures), ACP/acpx integration vision (four-phase roadmap), and consolidated research notes covering LCM, acpx, lossless-claw, and Shannon's creative thinking techniques
- **README rewrite**: New positioning — protocol-first language, "insights" not "memories", "distillation layer" not "pipeline", individual-forward value prop, updated harness table (added Codex/Gemini, removed Cursor/Windsurf), research references section
- **DESIRE-PATHS.md**: Added LCM foundation section showing how deterministic context patterns provide the floor that desire paths learn on top of
- **AGENTS.md**: Added core priorities (performance, reliability, predictability), maintainability guidelines, and reference repos section

## Test plan

- [ ] Verify all internal doc cross-references resolve (`[[links]]` in DESIRE-PATHS, relative paths in RESEARCH doc)
- [ ] Confirm README renders correctly on GitHub (badges, tables, code blocks)
- [ ] Review terminology consistency across all six files
- [ ] Validate no sensitive content in research notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Comprehensive rewrite of README with new value proposition and restructured sections emphasizing protocol-centric design and memory distillation.
  * Added new documentation on ACP integration strategy with phased implementation roadmap.
  * Introduced Lossless Context Patterns documentation detailing five memory architecture patterns.
  * Enhanced AGENTS.md with Core Priorities, Maintainability guidance, and Package Responsibilities sections.
  * Added research and reference materials for architectural patterns and integration planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->