### PR TITLE
fix: resolve UNIQUE constraint crash in skill reconciler

### DIFF
--- a/packages/core/src/migrations/027-backfill-canonical-names.ts
+++ b/packages/core/src/migrations/027-backfill-canonical-names.ts
@@ -11,7 +11,14 @@
 import type { MigrationDb } from "./index";
 
 export function up(db: MigrationDb): void {
-	db.exec(
-		"UPDATE entities SET canonical_name = LOWER(TRIM(name)) WHERE canonical_name IS NULL",
-	);
+	// Match toCanonicalName(): trim, lowercase, collapse internal whitespace.
+	// SQLite lacks regex replace, so iteratively collapse double-spaces
+	// (covers the realistic cases; triple+ spaces converge after a few passes).
+	db.exec(`
+		UPDATE entities
+		SET canonical_name = REPLACE(REPLACE(REPLACE(
+			LOWER(TRIM(name)),
+			'  ', ' '), '  ', ' '), '  ', ' ')
+		WHERE canonical_name IS NULL
+	`);
 }

--- a/packages/core/src/migrations/027-backfill-canonical-names.ts
+++ b/packages/core/src/migrations/027-backfill-canonical-names.ts
@@ -1,0 +1,17 @@
+/**
+ * Migration 027: Backfill NULL canonical_name on entities
+ *
+ * Migration 005 added the canonical_name column but never backfilled
+ * existing rows, leaving them NULL. This causes the upsertEntity
+ * lookup (which queries by canonical_name) to miss existing entities,
+ * leading to UNIQUE constraint violations on the name column during
+ * skill reconciliation and extraction.
+ */
+
+import type { MigrationDb } from "./index";
+
+export function up(db: MigrationDb): void {
+	db.exec(
+		"UPDATE entities SET canonical_name = LOWER(TRIM(name)) WHERE canonical_name IS NULL",
+	);
+}

--- a/packages/core/src/migrations/index.ts
+++ b/packages/core/src/migrations/index.ts
@@ -32,6 +32,7 @@ import { up as predictorColumns } from "./023-predictor-columns";
 import { up as predictorComparisonColumns } from "./024-predictor-comparison-columns";
 import { up as agentFeedback } from "./025-agent-feedback";
 import { up as predictorTrainingPairs } from "./026-predictor-training-pairs";
+import { up as backfillCanonicalNames } from "./027-backfill-canonical-names";
 
 // -- Public interface consumed by Database.init() --
 
@@ -161,6 +162,11 @@ export const MIGRATIONS: readonly Migration[] = [
 		version: 26,
 		name: "predictor-training-pairs",
 		up: predictorTrainingPairs,
+	},
+	{
+		version: 27,
+		name: "backfill-canonical-names",
+		up: backfillCanonicalNames,
 	},
 ];
 

--- a/packages/core/src/migrations/migrations.test.ts
+++ b/packages/core/src/migrations/migrations.test.ts
@@ -32,7 +32,7 @@ describe("migration framework", () => {
 			version: number;
 			applied_at: string;
 		}>;
-		expect(migrations.length).toBe(26);
+		expect(migrations.length).toBe(27);
 		expect(migrations[0].version).toBe(1);
 		expect(migrations[1].version).toBe(2);
 		expect(migrations[2].version).toBe(3);
@@ -172,7 +172,7 @@ describe("migration framework", () => {
 			version: number;
 			applied_at: string;
 		}>;
-		expect(audits.length).toBe(26);
+		expect(audits.length).toBe(27);
 		for (const audit of audits) {
 			expect(audit.applied_at).toBeTruthy();
 		}
@@ -392,7 +392,7 @@ describe("migration framework", () => {
 		const migrations = db.query("SELECT version FROM schema_migrations ORDER BY version").all() as Array<{
 			version: number;
 		}>;
-		expect(migrations.length).toBe(26);
+		expect(migrations.length).toBe(27);
 	});
 
 	test("version 1 stamped by old inline migrate upgrades cleanly", () => {
@@ -433,7 +433,7 @@ describe("migration framework", () => {
 		const migrations = db.query("SELECT version FROM schema_migrations ORDER BY version").all() as Array<{
 			version: number;
 		}>;
-		expect(migrations.length).toBe(26);
+		expect(migrations.length).toBe(27);
 	});
 
 	test("DB with existing v1 schema only gets v2 migration", () => {

--- a/packages/daemon/src/pipeline/graph-transactions.ts
+++ b/packages/daemon/src/pipeline/graph-transactions.ts
@@ -71,13 +71,15 @@ function upsertEntity(
 	// Skip trivially short names like "50", "0", "cli", "npm"
 	if (canonical.length < 4) return null;
 
+	// Look up by canonical_name first, then fall back to name (handles
+	// rows where canonical_name was never backfilled and is still NULL).
 	const existing = db
 		.prepare(
 			`SELECT id, mentions, entity_type FROM entities
-			 WHERE canonical_name = ? AND agent_id = ?
+			 WHERE (canonical_name = ? AND agent_id = ?) OR name = ?
 			 LIMIT 1`,
 		)
-		.get(canonical, agentId) as
+		.get(canonical, agentId, rawName) as
 		| { id: string; mentions: number; entity_type: string }
 		| undefined;
 
@@ -105,13 +107,14 @@ function upsertEntity(
 		).run(id, rawName, canonical, entityType, agentId, now, now);
 		return { id, inserted: true };
 	} catch (e) {
-		// name UNIQUE constraint collision — fall back to existing row
+		// name UNIQUE constraint collision — fall back to existing row.
+		// Don't scope by agent_id here: the UNIQUE is on name alone.
 		const msg = e instanceof Error ? e.message : String(e);
 		if (!msg.includes("UNIQUE constraint")) throw e;
 
 		const fallback = db
-			.prepare("SELECT id FROM entities WHERE name = ? AND agent_id = ? LIMIT 1")
-			.get(rawName, agentId) as { id: string } | undefined;
+			.prepare("SELECT id FROM entities WHERE name = ? LIMIT 1")
+			.get(rawName) as { id: string } | undefined;
 
 		if (fallback) {
 			db.prepare(


### PR DESCRIPTION
## Summary
- **Root cause**: `upsertEntity` in `graph-transactions.ts` missed entities with NULL `canonical_name` (never backfilled since migration 005) and scoped the UNIQUE collision fallback by `agent_id` despite the constraint being global on `name` alone — causing the reconciler to re-throw and crash daemon startup
- Initial lookup now also matches by `name` directly to handle NULL `canonical_name` rows
- UNIQUE collision fallback no longer scopes by `agent_id` since the constraint is on `name` alone
- Migration 027 backfills all NULL `canonical_name` values with `LOWER(TRIM(name))`

## Test plan
- [x] Migration tests pass (15/15, updated count assertions for migration 027)
- [x] Pre-existing graph-transactions test failures confirmed unrelated (5 pass, 3 fail — same before and after)
- [ ] Verify daemon starts cleanly in watch mode without UNIQUE constraint errors
- [ ] Confirm skill reconciliation completes on a DB with existing NULL canonical_name entities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added database migration to normalize and backfill canonical names for all entities, standardizing spacing and whitespace formatting in existing data.

* **Improvements**
  * Enhanced entity lookup logic to prioritize canonical names alongside agent identifiers when available, improving consistency and accuracy in entity identification and matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->