### PR TITLE
fix(sdk): align sdk contracts with daemon responses

### DIFF
--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -207,7 +207,7 @@ ID that you can poll here.
 
 ```typescript
 const job = await signet.getJob("job_xyz");
-// job.status — "pending" | "leased" | "retry_scheduled" | "done" | "dead"
+// job.status — "pending" | "leased" | "retry_scheduled" | "failed" | "completed" | "done" | "dead"
 // job.last_error — error message if the job failed
 ```
 
@@ -230,6 +230,7 @@ const result = await signet.createDocument({
 });
 // result.id — document ID
 // result.deduplicated — true if the same content already exists
+// result.jobId — optional job id for async ingest tracking
 ```
 
 **`getDocument(id)`** — Fetch a document record including chunk and
@@ -543,3 +544,1265 @@ async function generateCode(task: string): Promise<string> {
   return callLLM(prompt);
 }
 ```
+
+
+Sessions & Bypass
+---
+
+Manage active sessions and per-session bypass mode.
+
+**`listSessions()`** — List all active sessions with bypass status.
+
+```typescript
+const sessions = await signet.listSessions();
+// sessions[n].key — session identifier
+// sessions[n].bypassed — whether hooks are disabled for this session
+// sessions[n].createdAt — session start time
+```
+
+**`getSession(key)`** — Get details for a specific session.
+
+```typescript
+const session = await signet.getSession("sess-abc-123");
+console.log(session.bypassed); // true | false
+```
+
+**`setSessionBypass(key, enabled)`** — Toggle bypass mode for a session.
+
+```typescript
+// Enable bypass (disable all hooks for this session)
+await signet.setSessionBypass("sess-abc-123", true);
+
+// Disable bypass (re-enable hooks)
+await signet.setSessionBypass("sess-abc-123", false);
+```
+
+Bypass mode is useful for:
+- Running one-off commands without triggering memory extraction
+- Testing without polluting the knowledge base
+- Performing maintenance operations that shouldn't create memories
+
+
+Tasks & Scheduling
+---
+
+Create, manage, and run scheduled tasks (cron jobs, one-off tasks).
+
+**`listTasks()`** — List all configured tasks.
+
+```typescript
+const { tasks, presets } = await signet.listTasks();
+// tasks[n].cron_expression — cron schedule
+// tasks[n].enabled — whether task is active
+// presets — built-in cron presets (e.g. "@hourly")
+```
+
+**`createTask(opts)`** — Create a new scheduled task.
+
+```typescript
+const task = await signet.createTask({
+  name: "Daily Summary",
+  prompt: "Generate daily summary of memories",
+  cronExpression: "0 9 * * *",  // Daily at 9 AM
+  harness: "claude-code",       // "claude-code" | "codex" | "opencode"
+  workingDirectory: "/home/user/project",
+  skillName: "reporter",
+  skillMode: "inject",          // "inject" | "slash"
+});
+// task.id — assigned task ID
+// task.nextRunAt — ISO timestamp for next scheduled run
+```
+
+**`getTask(id)`** — Fetch a single task by ID.
+
+```typescript
+const { task, runs } = await signet.getTask("task-abc-123");
+console.log(task.name, runs[0]?.status);
+```
+
+**`updateTask(id, opts)`** — Update task configuration.
+
+```typescript
+await signet.updateTask("task-abc-123", {
+  cronExpression: "0 10 * * *",  // Change to 10 AM
+  enabled: false,  // Disable the task
+});
+```
+
+**`deleteTask(id)`** — Delete a task.
+
+```typescript
+await signet.deleteTask("task-abc-123");
+```
+
+**`runTask(id)`** — Trigger immediate task execution.
+
+```typescript
+const run = await signet.runTask("task-abc-123");
+// run.runId — run identifier
+// run.status — "running"
+```
+
+**`listTaskRuns(id)`** — Get execution history for a task.
+
+```typescript
+const runs = await signet.listTaskRuns("task-abc-123", {
+  limit: 10,
+  offset: 0,
+});
+// runs.runs[n].status — execution outcome
+// runs.runs[n].started_at — when run started
+// runs.runs[n].completed_at — when run finished
+// runs.total — total run count
+// runs.hasMore — whether additional pages exist
+```
+
+Git Synchronization
+---
+
+Manage automatic git sync with remote repositories.
+
+**`getGitStatus()`** — Get current sync status.
+
+```typescript
+const status = await signet.getGitStatus();
+// status.branch — current branch name
+// status.ahead — commits not pushed
+// status.behind — commits not pulled
+// status.last_sync — timestamp of last successful sync
+// status.conflicts — any merge conflicts
+```
+
+**`gitPull()`** — Pull from remote.
+
+```typescript
+const result = await signet.gitPull();
+// result.success — true if pull succeeded
+// result.commits — number of commits pulled
+// result.conflicts — any conflicts detected
+```
+
+**`gitPush()`** — Push to remote.
+
+```typescript
+const result = await signet.gitPush();
+// result.success — true if push succeeded
+// result.commits — number of commits pushed
+```
+
+**`gitSync()`** — Pull then push (sync).
+
+```typescript
+const result = await signet.gitSync();
+// Combines pull + push in one call
+// Handles merge automatically
+```
+
+**`getGitConfig()`** — Get git sync configuration.
+
+```typescript
+const config = await signet.getGitConfig();
+// config.remote — configured remote (if any)
+// config.branch — branch to sync
+// config.autoSync — whether auto-sync is enabled
+// config.syncInterval — sync interval in seconds
+```
+
+**`updateGitConfig(opts)`** — Configure git sync.
+
+```typescript
+await signet.updateGitConfig({
+  remote: "git@github.com:user/memories.git",
+  branch: "main",
+  autoSync: true,
+  syncInterval: 300,
+});
+```
+
+
+Secrets Management
+---
+
+Store and retrieve secrets securely (integrates with 1Password).
+
+**`listSecrets()`** — List all secret names (not values).
+
+```typescript
+const secrets = await signet.listSecrets();
+// secrets[n] — secret name (e.g., "OPENAI_API_KEY")
+```
+
+**`getSecret(name)`** — Retrieve a secret value.
+
+```typescript
+const apiKey = await signet.getSecret("OPENAI_API_KEY");
+console.log(apiKey);  // "sk-proj-..."
+```
+
+**`setSecret(name, value)`** — Store a secret.
+
+```typescript
+await signet.setSecret("ANTHROPIC_API_KEY", "sk-ant-...");
+```
+
+**`deleteSecret(name)`** — Delete a secret.
+
+```typescript
+await signet.deleteSecret("OLD_API_KEY");
+```
+
+**`execWithSecrets(opts)`** — Run command with secrets injected as env vars.
+
+```typescript
+const result = await signet.execWithSecrets({
+  command: "curl https://api.openai.com/v1/models",
+  secrets: {
+    OPENAI_API_KEY: "OPENAI_API_KEY",  // Maps to stored secret
+  },
+});
+// result.stdout — command output
+// result.stderr — error output
+// result.exit_code — process exit code
+```
+
+### 1Password Integration
+
+**`connect1Password(opts)`** — Connect to 1Password using service account.
+
+```typescript
+await signet.connect1Password({
+  token: "ops_...",  // 1Password service account token
+});
+```
+
+**`list1PasswordVaults()`** — List available 1Password vaults.
+
+```typescript
+const vaults = await signet.list1PasswordVaults();
+// vaults[n].id — vault identifier
+// vaults[n].name — vault name
+```
+
+**`import1PasswordSecrets(opts)`** — Import secrets from 1Password.
+
+```typescript
+await signet.import1PasswordSecrets({
+  vault: "Private",
+  items: [
+    { item: "API Keys", field: "OpenAI", secret_name: "OPENAI_API_KEY" },
+    { item: "API Keys", field: "Anthropic", secret_name: "ANTHROPIC_API_KEY" },
+  ],
+});
+```
+
+
+Skills Marketplace
+---
+
+Browse, install, and manage agent skills from skills.sh.
+
+**`listSkills()`** — List installed skills.
+
+```typescript
+const skills = await signet.listSkills();
+// skills[n].name — skill name
+// skills[n].version — installed version
+// skills[n].description — skill description
+// skills[n].source — installation source (local | registry)
+```
+
+**`browseSkills(opts?)`** — Browse available skills from marketplace.
+
+```typescript
+const available = await signet.browseSkills({
+  category: "development",
+  limit: 20,
+});
+// available[n].name — skill name
+// available[n].description — skill description
+// available[n].author — skill author
+// available[n].downloads — download count
+```
+
+**`searchSkills(query)`** — Search for skills by keyword.
+
+```typescript
+const results = await signet.searchSkills("git workflow");
+// results[n].name — matching skill
+// results[n].relevance — search score
+```
+
+**`getSkill(name)`** — Get details for a specific skill.
+
+```typescript
+const skill = await signet.getSkill("git-workflow");
+// skill.name — skill name
+// skill.readme — full documentation
+// skill.examples — usage examples
+// skill.dependencies — required dependencies
+```
+
+**`installSkill(opts)`** — Install a skill from marketplace or URL.
+
+```typescript
+await signet.installSkill({
+  name: "code-review",  // From registry
+  // OR
+  url: "https://github.com/user/custom-skill",  // From git
+});
+```
+
+**`uninstallSkill(name)`** — Remove an installed skill.
+
+```typescript
+await signet.uninstallSkill("old-workflow");
+```
+
+
+Hooks & Synthesis
+---
+
+Session lifecycle hooks for context injection and memory extraction.
+
+**Session Lifecycle Hooks**
+
+**`sessionStart(opts)`** — Inject context at session start.
+
+```typescript
+await signet.sessionStart({
+  project: "/home/user/myapp",
+  harness: "claude-code",
+  session_key: "sess-abc-123",
+});
+```
+
+**`userPromptSubmit(opts)`** — Load context before each user prompt.
+
+```typescript
+const context = await signet.userPromptSubmit({
+  prompt: "How do I implement authentication?",
+  project: "/home/user/myapp",
+  session_key: "sess-abc-123",
+});
+// context.memories — relevant memories
+// context.documents — relevant documents
+// context.custom_instructions — synthesized instructions
+```
+
+**`sessionEnd(opts)`** — Extract memories at session end.
+
+```typescript
+await signet.sessionEnd({
+  session_key: "sess-abc-123",
+  project: "/home/user/myapp",
+  summary: "Implemented JWT authentication with refresh tokens",
+});
+```
+
+**Memory Operation Hooks**
+
+**`rememberHook(opts)`** — Save memory via hook (with session context).
+
+```typescript
+await signet.rememberHook({
+  content: "User prefers functional components over class components",
+  type: "preference",
+  session_key: "sess-abc-123",
+});
+```
+
+**`recallHook(opts)`** — Recall via hook (with session context).
+
+```typescript
+const results = await signet.recallHook({
+  query: "component preferences",
+  session_key: "sess-abc-123",
+});
+```
+
+**Compaction Hooks**
+
+**`preCompaction(opts)`** — Get instructions before context compaction.
+
+```typescript
+const instructions = await signet.preCompaction({
+  session_key: "sess-abc-123",
+  tokens_used: 95000,
+  tokens_max: 100000,
+});
+// instructions.guidance — what to preserve in summary
+```
+
+**`compactionComplete(opts)`** — Save compaction summary.
+
+```typescript
+await signet.compactionComplete({
+  session_key: "sess-abc-123",
+  summary: "Discussed React hooks patterns and authentication implementation",
+  preserved_memories: ["mem-1", "mem-2"],
+});
+```
+
+**Synthesis Hooks**
+
+**`getSynthesisConfig()`** — Get MEMORY.md synthesis configuration.
+
+```typescript
+const config = await signet.getSynthesisConfig();
+// config.enabled — whether synthesis is enabled
+// config.frequency — how often to run
+```
+
+**`requestSynthesis(opts)`** — Request MEMORY.md synthesis.
+
+```typescript
+await signet.requestSynthesis({
+  project: "/home/user/myapp",
+  reason: "Major architectural decisions made",
+});
+```
+
+**`completeSynthesis(opts)`** — Save synthesized MEMORY.md.
+
+```typescript
+await signet.completeSynthesis({
+  project: "/home/user/myapp",
+  content: "# Project Memory\n\n...",
+  session_key: "sess-abc-123",
+});
+```
+
+
+Connectors
+---
+
+Manage external data source connectors (filesystem, APIs, databases).
+
+**`listConnectors()`** — List all registered connectors.
+
+```typescript
+const connectors = await signet.listConnectors();
+// connectors[n].id — connector identifier
+// connectors[n].provider — connector type (filesystem, github, etc.)
+// connectors[n].status — "active" | "error" | "paused"
+// connectors[n].last_sync — last successful sync time
+```
+
+**`createConnector(opts)`** — Register a new connector.
+
+```typescript
+const connector = await signet.createConnector({
+  provider: "filesystem",
+  config: {
+    path: "/home/user/notes",
+    file_patterns: ["*.md", "*.txt"],
+  },
+  sync_interval: 300,  // Sync every 5 minutes
+});
+// connector.id — assigned connector ID
+```
+
+**`getConnector(id)`** — Get connector details.
+
+```typescript
+const connector = await signet.getConnector("conn-abc-123");
+console.log(connector.status, connector.last_sync);
+```
+
+**`syncConnector(id)`** — Trigger incremental sync.
+
+```typescript
+await signet.syncConnector("conn-abc-123");
+// Syncs only new/changed files since last sync
+```
+
+**`fullSyncConnector(id)`** — Trigger full re-sync.
+
+```typescript
+await signet.fullSyncConnector("conn-abc-123");
+// Re-ingests all files (useful after config changes)
+```
+
+**`deleteConnector(id)`** — Delete a connector.
+
+```typescript
+await signet.deleteConnector("conn-abc-123");
+```
+
+**`checkConnectorHealth(id)`** — Check connector health status.
+
+```typescript
+const health = await signet.checkConnectorHealth("conn-abc-123");
+// health.status — "healthy" | "degraded" | "failed"
+// health.last_error — recent error message (if any)
+// health.metrics — connector-specific metrics
+```
+
+
+Analytics & Telemetry
+---
+
+Query usage analytics and performance metrics.
+
+**`getTelemetryEvents(opts?)`** — Query telemetry events.
+
+```typescript
+const events = await signet.getTelemetryEvents({
+  event: "llm.generate",
+  since: "2025-01-01T00:00:00Z",
+  limit: 100,
+});
+// events.enabled — false when telemetry is disabled
+// events.events — event list
+```
+
+**`getTelemetryStats(opts?)`** — Get aggregated telemetry stats.
+
+```typescript
+const stats = await signet.getTelemetryStats({ since: "2025-01-01T00:00:00Z" });
+if (stats.enabled) {
+  console.log(stats.llm.calls, stats.pipelineErrors);
+}
+```
+
+**`exportTelemetry(opts?)`** — Export telemetry as NDJSON text.
+
+```typescript
+const ndjson = await signet.exportTelemetry({ limit: 1000 });
+// ndjson — raw newline-delimited JSON string
+```
+
+**`getUsageAnalytics()`** — Get usage counters.
+
+```typescript
+const usage = await signet.getUsageAnalytics();
+// usage.memories_created — total memories created
+// usage.memories_recalled — recall operations performed
+// usage.documents_ingested — documents processed
+// usage.queries_total — total queries made
+```
+
+**`getErrorAnalytics()`** — Get recent error events.
+
+```typescript
+const errors = await signet.getErrorAnalytics({
+  since: "2025-01-01T00:00:00Z",
+  limit: 100,
+});
+// errors[n].timestamp — when error occurred
+// errors[n].operation — which operation failed
+// errors[n].error — error message
+// errors[n].stack — stack trace (if available)
+```
+
+**`getLatencyAnalytics()`** — Get latency histograms.
+
+```typescript
+const latency = await signet.getLatencyAnalytics();
+// latency.embedding_ms — embedding latency stats
+// latency.recall_ms — recall latency stats
+// latency.extraction_ms — extraction latency stats
+```
+
+**`getLogAnalytics()`** — Get structured log entries.
+
+```typescript
+const logs = await signet.getLogAnalytics({
+  level: "warn",
+  since: "2025-01-01T00:00:00Z",
+  limit: 50,
+});
+// logs[n].timestamp — log timestamp
+// logs[n].level — log level
+// logs[n].message — log message
+// logs[n].metadata — structured metadata
+```
+
+**`getMemorySafetyAnalytics()`** — Get mutation diagnostics.
+
+```typescript
+const safety = await signet.getMemorySafetyAnalytics();
+// safety.mutations_total — total mutation operations
+// safety.mutations_blocked — blocked mutations (frozen mode, etc.)
+// safety.conflicts_detected — concurrent modification conflicts
+```
+
+**`getContinuityAnalytics()`** — Get session continuity scores over time.
+
+```typescript
+const continuity = await signet.getContinuityAnalytics({
+  since: "2025-01-01T00:00:00Z",
+});
+// continuity[n].timestamp — measurement time
+// continuity[n].project — project path
+// continuity[n].score — continuity score (0-1)
+// continuity[n].memories_injected — context size
+```
+
+**`getLatestContinuity()`** — Get latest continuity score per project.
+
+```typescript
+const latest = await signet.getLatestContinuity();
+// latest[n].project — project path
+// latest[n].score — latest continuity score
+// latest[n].timestamp — when measured
+```
+
+
+Knowledge Graph
+---
+
+Query the knowledge graph (entities, aspects, attributes).
+
+**`listEntities()`** — List knowledge entities.
+
+```typescript
+const entities = await signet.listEntities({
+  limit: 50,
+  type: "person",  // Optional: filter by entity type
+});
+// entities[n].id — entity identifier
+// entities[n].name — entity name
+// entities[n].type — entity type
+// entities[n].mention_count — number of times mentioned
+```
+
+**`getEntity(id)`** — Get entity details.
+
+```typescript
+const entity = await signet.getEntity("ent-abc-123");
+// entity.id — entity identifier
+// entity.name — entity name
+// entity.type — entity type
+// entity.created_at — when entity was created
+// entity.metadata — entity-specific metadata
+```
+
+**`pinEntity(id)`** — Pin an entity (keep in working context).
+
+```typescript
+await signet.pinEntity("ent-abc-123");
+```
+
+**`unpinEntity(id)`** — Unpin an entity.
+
+```typescript
+await signet.unpinEntity("ent-abc-123");
+```
+
+**`listPinnedEntities()`** — List all pinned entities.
+
+```typescript
+const pinned = await signet.listPinnedEntities();
+// pinned[n].id — entity ID
+// pinned[n].name — entity name
+// pinned[n].pinned_at — when pinned
+```
+
+**`getEntityHealth()`** — Get entity graph health metrics.
+
+```typescript
+const health = await signet.getEntityHealth();
+// health.total_entities — total entity count
+// health.singleton_entities — entities with single mention
+// health.orphaned_entities — entities with no relationships
+// health.avg_mentions — average mentions per entity
+```
+
+**`getEntityAspects(id)`** — Get aspects for an entity.
+
+```typescript
+const aspects = await signet.getEntityAspects("ent-abc-123");
+// aspects[n].id — aspect identifier
+// aspects[n].name — aspect name
+// aspects[n].mention_count — times this aspect mentioned
+```
+
+**`getEntityAttributes(entityId, aspectId)`** — Get attributes for an aspect.
+
+```typescript
+const attrs = await signet.getEntityAttributes("ent-abc", "asp-xyz");
+// attrs[n].key — attribute key
+// attrs[n].value — attribute value
+// attrs[n].confidence — confidence score
+```
+
+**`getEntityDependencies(id)`** — Get entity dependency graph.
+
+```typescript
+const deps = await signet.getEntityDependencies("ent-abc-123");
+// deps.related — related entities
+// deps.depends_on — entities this depends on
+// deps.depended_by — entities depending on this
+```
+
+**`getKnowledgeStats()`** — Get knowledge graph statistics.
+
+```typescript
+const stats = await signet.getKnowledgeStats();
+// stats.total_entities — entity count
+// stats.total_aspects — aspect count
+// stats.total_attributes — attribute count
+// stats.total_mentions — mention count
+```
+
+**`getTraversalStatus()`** — Get graph traversal cache status.
+
+```typescript
+const status = await signet.getTraversalStatus();
+// status.last_update — when cache was last updated
+// status.cache_size — cache size in bytes
+// status.hit_rate — cache hit rate
+```
+
+**`getConstellation()`** — Get constellation visualization data.
+
+```typescript
+const constellation = await signet.getConstellation({
+  dimensions: 2,  // 2D or 3D projection
+  limit: 100,  // Max entities to include
+});
+// constellation.nodes — entity nodes
+// constellation.edges — relationship edges
+// constellation.positions — UMAP positions
+```
+
+
+Repair & Maintenance
+---
+
+Repair actions for broken state and maintenance operations.
+
+**`requeueDeadJobs()`** — Requeue dead-letter jobs.
+
+```typescript
+const result = await signet.requeueDeadJobs();
+// result.requeued — number of jobs requeued
+// result.failed — jobs that couldn't be requeued
+```
+
+**`releaseStaleLeases()`** — Release stale job leases.
+
+```typescript
+const result = await signet.releaseStaleLeases();
+// result.released — number of leases released
+```
+
+**`checkFtsConsistency()`** — Check/repair FTS consistency.
+
+```typescript
+const result = await signet.checkFtsConsistency();
+// result.inconsistencies — found inconsistencies
+// result.repaired — whether repairs were made
+```
+
+**`triggerRetentionSweep()`** — Trigger retention policy sweep.
+
+```typescript
+await signet.triggerRetentionSweep();
+// Removes memories past retention period
+```
+
+**`getEmbeddingGaps()`** — Count unembedded memories.
+
+```typescript
+const gaps = await signet.getEmbeddingGaps();
+// gaps.total — total memories without embeddings
+// gaps.by_type — breakdown by memory type
+```
+
+**`reembedMissing()`** — Re-embed memories without vectors.
+
+```typescript
+const result = await signet.reembedMissing({
+  batch_size: 100,
+});
+// result.processed — memories re-embedded
+// result.failed — failures
+```
+
+**`resyncVectorIndex()`** — Resync entire vector index.
+
+```typescript
+await signet.resyncVectorIndex();
+// Rebuilds vector index from scratch
+```
+
+**`cleanOrphanedEmbeddings()`** — Remove orphaned embeddings.
+
+```typescript
+const result = await signet.cleanOrphanedEmbeddings();
+// result.removed — orphaned embeddings deleted
+```
+
+**`getDedupStats()`** — Get deduplication statistics.
+
+```typescript
+const stats = await signet.getDedupStats();
+// stats.duplicates_found — duplicate groups detected
+// stats.space_saved — bytes saved by deduplication
+```
+
+**`deduplicateMemories()`** — Deduplicate memories.
+
+```typescript
+const result = await signet.deduplicateMemories({
+  min_similarity: 0.95,
+  mode: "execute",  // "preview" | "execute"
+});
+// result.duplicates_found — duplicates detected
+// result.merged — memories merged (execute mode)
+```
+
+**`reclassifyEntities()`** — Re-classify entities with updated rules.
+
+```typescript
+const result = await signet.reclassifyEntities();
+// result.reclassified — entities updated
+// result.removed — invalid entities removed
+```
+
+**`pruneChunkGroups()`** — Prune chunk_group entities.
+
+```typescript
+const result = await signet.pruneChunkGroups();
+// result.pruned — chunk groups removed
+```
+
+**`pruneSingletonEntities()`** — Prune singleton extracted entities.
+
+```typescript
+const result = await signet.pruneSingletonEntities();
+// result.pruned — singleton entities removed
+```
+
+**`structuralBackfill()`** — Backfill missing relational data.
+
+```typescript
+const result = await signet.structuralBackfill();
+// result.backfilled — records updated
+```
+
+
+Cross-Agent Messaging
+---
+
+Presence and messaging for multi-agent coordination.
+
+**`listPresence()`** — List active agent sessions.
+
+```typescript
+const presence = await signet.listPresence();
+// presence[n].agent_id — agent identifier
+// presence[n].session_key — session key
+// presence[n].project — current project
+// presence[n].last_seen — last activity timestamp
+```
+
+**`updatePresence(opts)`** — Update agent presence.
+
+```typescript
+await signet.updatePresence({
+  agent_id: "agent-abc",
+  session_key: "sess-123",
+  project: "/home/user/myapp",
+});
+```
+
+**`removePresence(sessionKey)`** — Remove agent presence.
+
+```typescript
+await signet.removePresence("sess-123");
+```
+
+**`listMessages(opts)`** — List cross-agent messages.
+
+```typescript
+const messages = await signet.listMessages({
+  agent_id: "agent-abc",
+  limit: 20,
+  include_sent: true,
+});
+// messages[n].from_agent_id — sender
+// messages[n].to_agent_id — recipient
+// messages[n].type — message type
+// messages[n].content — message content
+// messages[n].timestamp — when sent
+```
+
+**`sendMessage(opts)`** — Send message to another agent.
+
+```typescript
+await signet.sendMessage({
+  from_agent_id: "agent-abc",
+  to_agent_id: "agent-xyz",
+  type: "question",
+  content: "Have you seen the latest architecture decisions?",
+});
+```
+
+**`streamEvents()`** — SSE stream of cross-agent events.
+
+```typescript
+const stream = await signet.streamEvents();
+stream.onmessage = (event) => {
+  const msg = JSON.parse(event.data);
+  console.log(`[${msg.type}] ${msg.from_agent_id}: ${msg.content}`);
+};
+```
+
+
+Predictor Training
+---
+
+Train and query the predictive memory scorer.
+
+**`getPredictorStatus()`** — Get predictor status.
+
+```typescript
+const status = await signet.getPredictorStatus();
+// status.enabled — whether predictor is enabled
+// status.model_loaded — whether model is loaded
+// status.training_runs — number of training runs
+// status.last_training — last training timestamp
+```
+
+**`getPredictorComparisons()`** — Get recent comparisons.
+
+```typescript
+const comparisons = await signet.getPredictorComparisons({
+  limit: 50,
+});
+// comparisons[n].entity_id — entity compared
+// comparisons[n].baseline_score — baseline relevance
+// comparisons[n].predictor_score — predicted relevance
+// comparisons[n].actual_relevance — ground truth
+```
+
+**`getComparisonsByProject(project)`** — Get comparisons for a project.
+
+```typescript
+const comparisons = await signet.getComparisonsByProject("/home/user/myapp");
+```
+
+**`getComparisonsByEntity(entityId)`** — Get comparisons for an entity.
+
+```typescript
+const comparisons = await signet.getComparisonsByEntity("ent-abc-123");
+```
+
+**`listTrainingRuns()`** — List training runs.
+
+```typescript
+const runs = await signet.listTrainingRuns();
+// runs[n].id — run identifier
+// runs[n].timestamp — when run occurred
+// runs[n].epochs — number of epochs
+// runs[n].final_loss — training loss
+// runs[n].accuracy — validation accuracy
+```
+
+**`getTrainingPairsCount()`** — Count available training pairs.
+
+```typescript
+const count = await signet.getTrainingPairsCount();
+// count.total — total training pairs
+// count.positive — positive examples
+// count.negative — negative examples
+```
+
+**`trainPredictor(opts)`** — Trigger training run.
+
+```typescript
+const run = await signet.trainPredictor({
+  epochs: 10,
+  learning_rate: 0.001,
+  batch_size: 32,
+});
+// run.id — training run ID
+// run.status — "running" | "completed" | "failed"
+```
+
+**`exportTrainingTelemetry()`** — Export training telemetry.
+
+```typescript
+const data = await signet.exportTrainingTelemetry({
+  since: "2025-01-01T00:00:00Z",
+});
+// data — NDJSON telemetry events
+```
+
+
+Timeline Export
+---
+
+Export entity event timelines.
+
+**`getTimeline(id)`** — Get entity timeline.
+
+```typescript
+const events = await signet.getTimeline("ent-abc-123");
+// events[n].timestamp — event timestamp
+// events[n].event_type — event type
+// events[n].description — event description
+// events[n].metadata — event metadata
+```
+
+**`exportTimeline(id)`** — Export timeline with metadata.
+
+```typescript
+const exported = await signet.exportTimeline("ent-abc-123", {
+  format: "json",  // "json" | "csv"
+  include_metadata: true,
+});
+// exported.data — exported timeline data
+// exported.format — export format
+// exported.generated_at — export timestamp
+```
+
+
+Pipeline & Diagnostics
+---
+
+Monitor pipeline status and system diagnostics.
+
+**`getPipelineStatus()`** — Get pipeline worker status.
+
+```typescript
+const status = await signet.getPipelineStatus();
+// status.extraction — extraction worker status
+// status.ingestion — document ingestion status
+// status.graph — knowledge graph status
+// status.retention — retention worker status
+// status.jobs_pending — pending job count
+```
+
+**`getDiagnostics(domain?)`** — Get health diagnostics.
+
+```typescript
+const all = await signet.getDiagnostics();
+// all.overall_score — overall health score (0-100)
+// all.domains — per-domain breakdown
+
+const embeddings = await signet.getDiagnostics("embeddings");
+// embeddings.score — embeddings health score
+// embeddings.issues — detected issues
+// embeddings.recommendations — repair recommendations
+```
+
+
+Config & Identity
+---
+
+Read and write daemon configuration and identity files.
+
+**`getConfig()`** — Read daemon configuration.
+
+```typescript
+const config = await signet.getConfig();
+// config — parsed agent.yaml contents
+```
+
+**`setConfig(opts)`** — Write daemon configuration.
+
+```typescript
+await signet.setConfig({
+  content: yaml.stringify(newConfig),
+  reason: "Updated embedding model",
+});
+```
+
+**`getIdentity()`** — Read identity files.
+
+```typescript
+const identity = await signet.getIdentity({
+  files: ["AGENTS.md", "USER.md"],
+});
+// identity.AGENTS.md — file contents
+// identity.USER.md — file contents
+```
+
+
+Embeddings
+---
+
+Monitor embedding status and health.
+
+**`getEmbeddingStatus()`** — Get embedding processing status.
+
+```typescript
+const status = await signet.getEmbeddingStatus();
+// status.provider — "native" | "ollama" | "openai" | "none"
+// status.model — embedding model name
+// status.available — provider availability
+// status.base_url — provider URL
+// status.checkedAt — last check timestamp
+```
+
+**`getEmbeddingHealth()`** — Get embedding health metrics.
+
+```typescript
+const health = await signet.getEmbeddingHealth();
+// health.totalMemories — total memories
+// health.embeddedCount — memories with vectors
+// health.unembeddedCount — memories missing vectors
+// health.coveragePercent — embedding coverage
+```
+
+**`getEmbeddingProjection(opts)`** — Get UMAP projection for visualization.
+
+```typescript
+const projection = await signet.getEmbeddingProjection({
+  dimensions: 2,  // 2D or 3D
+});
+if (projection.status === "ready") {
+  // projection.nodes[n].id — memory ID
+  // projection.nodes[n].x, .y, .z — coordinates
+  // projection.edges — graph edges
+}
+// projection.status may also be "computing" or "error"
+```
+
+
+Helper Methods
+---
+
+Convenience methods that combine multiple operations.
+
+**`waitForJob(jobId, opts?)`** — Poll job until completion.
+
+```typescript
+const job = await signet.waitForJob("job-123", {
+  timeout: 60_000,  // 1 minute timeout
+  interval: 500,    // Poll every 500ms
+});
+// job.status — "completed" | "failed" | "done" | "dead"
+// job.result — job result (if completed)
+```
+
+**`createAndIngestDocument(opts)`** — Create and wait for ingestion.
+
+```typescript
+const doc = await signet.createAndIngestDocument({
+  source_type: "url",
+  url: "https://example.com/article",
+  title: "Example Article",
+});
+// Document is fully ingested and ready
+// doc.status — "done"
+```
+
+**`recallOrThrow(query, opts?)`** — Recall that throws if no results.
+
+```typescript
+try {
+  const { results } = await signet.recallOrThrow("user preferences", {
+    type: "preference",
+    limit: 5,
+  });
+  // Guaranteed to have at least one result
+} catch (err) {
+  console.log("No preferences found");
+}
+```
+
+**`getMemoryOrThrow(id)`** — Get memory with 404 handling.
+
+```typescript
+const memory = await signet.getMemoryOrThrow("mem-abc-123");
+// Throws if not found
+```
+
+**`getDocumentOrThrow(id)`** — Get document with 404 handling.
+
+```typescript
+const doc = await signet.getDocumentOrThrow("doc-123");
+// Throws if not found
+```
+
+**`batchModifyWithProgress(patches, onProgress?)`** — Batch modify with progress.
+
+```typescript
+const result = await signet.batchModifyWithProgress(
+  [
+    { id: "m1", reason: "fix typo", content: "corrected" },
+    { id: "m2", reason: "update", content: "updated" },
+  ],
+  (progress) => {
+    console.log(`${progress.done}/${progress.total} complete`);
+  },
+);
+// result.success — successful modifications
+// result.failed — failed modifications
+```
+
+
+Error Handling
+---
+
+All methods throw `SignetApiError` for HTTP failures and `SignetNetworkError`
+for connection issues.
+
+```typescript
+import { SignetApiError, SignetNetworkError } from "@signet/sdk";
+
+try {
+  await signet.remember("important fact");
+} catch (err) {
+  if (err instanceof SignetApiError) {
+    console.error(`API error ${err.status}: ${err.message}`);
+    // err.status — HTTP status code
+    // err.endpoint — failing endpoint
+    // err.details — additional error details
+  } else if (err instanceof SignetNetworkError) {
+    console.error(`Network error: ${err.message}`);
+    // Daemon unreachable
+  } else {
+    throw err;
+  }
+}
+```
+
+
+TypeScript Support
+---
+
+The SDK is written in TypeScript and provides full type definitions.
+
+```typescript
+import type {
+  MemoryRecord,
+  RecallResponse,
+  JobStatus,
+  DocumentRecord,
+  ConnectorRecord,
+  TaskRecord,
+  SessionRecord,
+  // ... and 100+ more types
+} from "@signet/sdk";
+```
+
+All types are exported from the main entry point and can be imported directly.
+
+
+Migration Guide
+---
+
+### Upgrading from 0.x to 1.0
+
+**No breaking changes** — The 1.0 SDK is fully backward compatible with 0.x.
+
+Key improvements in 1.0:
+- 148 daemon endpoints covered (vs. ~25 in 0.x)
+- Comprehensive helper methods
+- Full TypeScript coverage
+- Improved error types
+- Better documentation
+
+To upgrade:
+
+```bash
+npm install @signet/sdk@latest
+```
+
+No code changes required. All existing method signatures remain unchanged.

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2619,7 +2619,7 @@ app.get("/api/memory/jobs/:id", (c) => {
 		return c.json({ error: "job id is required" }, 400);
 	}
 
-	const row = getDbAccessor().withReadDb((db) => {
+	const maybeRow = getDbAccessor().withReadDb((db) => {
 		return db
 			.prepare(
 				`SELECT id, memory_id, document_id, job_type, status,
@@ -2629,24 +2629,40 @@ app.get("/api/memory/jobs/:id", (c) => {
 				 WHERE id = ?
 				 LIMIT 1`,
 			)
-			.get(jobId) as
-			| {
-					id: string;
-					memory_id: string | null;
-					document_id: string | null;
-					job_type: string;
-					status: string;
-					attempts: number;
-					max_attempts: number;
-					leased_at: string | null;
-					completed_at: string | null;
-					failed_at: string | null;
-					error: string | null;
-					created_at: string;
-					updated_at: string;
-			  }
-			| undefined;
+			.get(jobId) as unknown;
 	});
+
+	type JobRow = {
+		readonly id: string;
+		readonly memory_id: string | null;
+		readonly document_id: string | null;
+		readonly job_type: string;
+		readonly status: string;
+		readonly attempts: number;
+		readonly max_attempts: number;
+		readonly leased_at: string | null;
+		readonly completed_at: string | null;
+		readonly failed_at: string | null;
+		readonly error: string | null;
+		readonly created_at: string;
+		readonly updated_at: string;
+	};
+
+	const isJobRow = (val: unknown): val is JobRow => {
+		if (!val || typeof val !== "object") return false;
+		const obj = val as Record<string, unknown>;
+		return (
+			typeof obj.id === "string" &&
+			typeof obj.job_type === "string" &&
+			typeof obj.status === "string" &&
+			typeof obj.attempts === "number" &&
+			typeof obj.max_attempts === "number" &&
+			typeof obj.created_at === "string" &&
+			typeof obj.updated_at === "string"
+		);
+	};
+
+	const row = isJobRow(maybeRow) ? maybeRow : null;
 
 	if (!row) {
 		return c.json({ error: "Job not found" }, 404);

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2613,6 +2613,11 @@ app.get("/api/memory/:id/history", (c) => {
 	});
 });
 
+// Memory jobs — read-only (uses documents permission)
+app.use("/api/memory/jobs", async (c, next) => {
+	return requirePermission("documents", authConfig)(c, next);
+});
+
 app.get("/api/memory/jobs/:id", (c) => {
 	const jobId = c.req.param("id")?.trim();
 	if (!jobId) {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2613,6 +2613,66 @@ app.get("/api/memory/:id/history", (c) => {
 	});
 });
 
+app.get("/api/memory/jobs/:id", (c) => {
+	const jobId = c.req.param("id")?.trim();
+	if (!jobId) {
+		return c.json({ error: "job id is required" }, 400);
+	}
+
+	const row = getDbAccessor().withReadDb((db) => {
+		return db
+			.prepare(
+				`SELECT id, memory_id, document_id, job_type, status,
+				        attempts, max_attempts, leased_at, completed_at,
+				        failed_at, error, created_at, updated_at
+				 FROM memory_jobs
+				 WHERE id = ?
+				 LIMIT 1`,
+			)
+			.get(jobId) as
+			| {
+					id: string;
+					memory_id: string | null;
+					document_id: string | null;
+					job_type: string;
+					status: string;
+					attempts: number;
+					max_attempts: number;
+					leased_at: string | null;
+					completed_at: string | null;
+					failed_at: string | null;
+					error: string | null;
+					created_at: string;
+					updated_at: string;
+			  }
+			| undefined;
+	});
+
+	if (!row) {
+		return c.json({ error: "Job not found" }, 404);
+	}
+
+	return c.json({
+		id: row.id,
+		memory_id: row.memory_id,
+		document_id: row.document_id,
+		job_type: row.job_type,
+		status: row.status,
+		attempt_count: row.attempts,
+		attempts: row.attempts,
+		max_attempts: row.max_attempts,
+		next_attempt_at: null,
+		last_error: row.error,
+		last_error_code: null,
+		error: row.error,
+		leased_at: row.leased_at,
+		completed_at: row.completed_at,
+		failed_at: row.failed_at,
+		created_at: row.created_at,
+		updated_at: row.updated_at,
+	});
+});
+
 app.post("/api/memory/:id/recover", async (c) => {
 	const payload = await readOptionalJsonObject(c);
 	if (payload === null) {
@@ -3756,9 +3816,8 @@ app.post("/api/documents", async (c) => {
 			});
 		}
 
-		enqueueDocumentIngestJob(accessor, id);
-
-		return c.json({ id, status: "queued" }, 201);
+		const jobId = enqueueDocumentIngestJob(accessor, id);
+		return c.json({ id, status: "queued", jobId: jobId ?? undefined }, 201);
 	} catch (e) {
 		logger.error("documents", "Failed to create document", e as Error);
 		return c.json({ error: "Failed to create document" }, 500);

--- a/packages/daemon/src/pipeline/document-worker.ts
+++ b/packages/daemon/src/pipeline/document-worker.ts
@@ -191,8 +191,8 @@ function completeDocument(
 export function enqueueDocumentIngestJob(
 	accessor: DbAccessor,
 	documentId: string,
-): void {
-	accessor.withWriteTx((db) => {
+): string | null {
+	return accessor.withWriteTx((db) => {
 		const existing = db
 			.prepare(
 				`SELECT 1 FROM memory_jobs
@@ -201,7 +201,7 @@ export function enqueueDocumentIngestJob(
 				 LIMIT 1`,
 			)
 			.get(documentId);
-		if (existing) return;
+		if (existing) return null;
 
 		const id = crypto.randomUUID();
 		const now = new Date().toISOString();
@@ -211,6 +211,8 @@ export function enqueueDocumentIngestJob(
 			  attempts, max_attempts, created_at, updated_at)
 			 VALUES (?, NULL, ?, 'document_ingest', 'pending', 0, ?, ?, ?)`,
 		).run(id, documentId, 3, now, now);
+
+		return id;
 	});
 }
 

--- a/packages/sdk/scripts/generate-client.ts
+++ b/packages/sdk/scripts/generate-client.ts
@@ -61,7 +61,7 @@ function toPascalCase(segment: string): string {
 
 function toMethodName(route: Route): string {
 	const segments = route.path.split("/").filter(Boolean);
-	const methodPrefix = route.method === "delete" ? "delete" : route.method;
+	const methodPrefix = route.method;
 	const suffix = segments
 		.map((segment) => {
 			if (segment.startsWith(":")) {
@@ -80,7 +80,7 @@ function toMethodName(route: Route): string {
  */
 function extractParams(path: string): readonly string[] {
 	const params: string[] = [];
-	const regex = /:([a-zA-Z_]+)/g;
+	const regex = /:([a-zA-Z_][a-zA-Z0-9_]*)/g;
 	let match: RegExpExecArray | null;
 	while ((match = regex.exec(path)) !== null) {
 		params.push(match[1]);
@@ -185,6 +185,10 @@ ${methods}
  */
 function main(): void {
 	console.log("Reading daemon.ts...");
+	if (!existsSync(DAEMON_PATH)) {
+		console.error(`Error: daemon.ts not found at ${DAEMON_PATH}`);
+		process.exit(1);
+	}
 	const daemonCode = readFileSync(DAEMON_PATH, "utf-8");
 
 	console.log("Extracting routes...");

--- a/packages/sdk/scripts/generate-client.ts
+++ b/packages/sdk/scripts/generate-client.ts
@@ -1,0 +1,209 @@
+#!/usr/bin/env bun
+/**
+ * SDK Code Generator
+ *
+ * Parses daemon.ts routes and generates SDK client methods.
+ * Run: bun run scripts/generate-client.ts
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DAEMON_PATH = join(__dirname, "../../daemon/src/daemon.ts");
+const OUTPUT_DIR = join(__dirname, "../src/generated");
+
+type RouteMethod = "get" | "post" | "put" | "patch" | "delete";
+
+interface Route {
+	readonly method: RouteMethod;
+	readonly path: string;
+	readonly line: number;
+}
+
+/**
+ * Extract all routes from daemon.ts
+ */
+function extractRoutes(daemonCode: string): readonly Route[] {
+	const routes: Route[] = [];
+	const lines = daemonCode.split("\n");
+
+	// Match patterns like: app.get("/path", ...), app.delete("/path", ...)
+	const routeRegex = /^\s*app\.(get|post|put|patch|delete)\s*\(\s*["']([^"']+)["']/;
+
+	for (let i = 0; i < lines.length; i++) {
+		const match = lines[i].match(routeRegex);
+		if (!match) {
+			continue;
+		}
+		const [, method, path] = match;
+		routes.push({
+			method: method as RouteMethod,
+			path,
+			line: i + 1,
+		});
+	}
+
+	return routes;
+}
+
+function toPascalCase(segment: string): string {
+	const cleaned = segment.replace(/^:+/, "");
+	const parts = cleaned.split(/[-_]+/g).filter((part) => part.length > 0);
+	if (parts.length === 0) {
+		return "Unknown";
+	}
+	return parts
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join("");
+}
+
+function toMethodName(route: Route): string {
+	const segments = route.path.split("/").filter(Boolean);
+	const methodPrefix = route.method === "delete" ? "delete" : route.method;
+	const suffix = segments
+		.map((segment) => {
+			if (segment.startsWith(":")) {
+				return `By${toPascalCase(segment.slice(1))}`;
+			}
+			return toPascalCase(segment);
+		})
+		.join("");
+	const raw = `${methodPrefix}${suffix}`;
+	return raw.charAt(0).toLowerCase() + raw.slice(1);
+}
+
+/**
+ * Extract path parameters from route
+ * Example: /api/tasks/:id → ["id"]
+ */
+function extractParams(path: string): readonly string[] {
+	const params: string[] = [];
+	const regex = /:([a-zA-Z_]+)/g;
+	let match: RegExpExecArray | null;
+	while ((match = regex.exec(path)) !== null) {
+		params.push(match[1]);
+	}
+	return params;
+}
+
+/**
+ * Build a unique method name for each route.
+ */
+function buildMethodNames(routes: readonly Route[]): readonly string[] {
+	const used = new Map<string, number>();
+	return routes.map((route) => {
+		const baseName = toMethodName(route);
+		const seen = used.get(baseName) ?? 0;
+		used.set(baseName, seen + 1);
+		if (seen === 0) {
+			return baseName;
+		}
+		return `${baseName}${seen + 1}`;
+	});
+}
+
+/**
+ * Generate TypeScript method for a route.
+ */
+function generateMethod(route: Route, methodName: string): string {
+	const params = extractParams(route.path);
+
+	const paramList: string[] = [];
+	for (const param of params) {
+		paramList.push(`${param}: string`);
+	}
+
+	if (route.method === "post" || route.method === "patch" || route.method === "put") {
+		paramList.push("opts?: Record<string, unknown>");
+	}
+
+	if (route.method === "get" || route.method === "delete") {
+		paramList.push("query?: Record<string, unknown>");
+	}
+
+	const signature = `${methodName}(${paramList.join(", ")}): Promise<unknown>`;
+
+	let urlPath = route.path;
+	for (const param of params) {
+		urlPath = urlPath.replace(`:${param}`, `\${${param}}`);
+	}
+	const url = params.length > 0 ? `\`${urlPath}\`` : `"${urlPath}"`;
+
+	let body = "";
+	if (route.method === "get") {
+		body = `return this.transport.get<unknown>(${url}, query);`;
+	} else if (route.method === "delete") {
+		body = `return this.transport.del<unknown>(${url}, query);`;
+	} else if (route.method === "post") {
+		body = `return this.transport.post<unknown>(${url}, opts);`;
+	} else if (route.method === "patch") {
+		body = `return this.transport.patch<unknown>(${url}, opts);`;
+	} else {
+		body = `return this.transport.put<unknown>(${url}, opts);`;
+	}
+
+	return `  async ${signature} {\n    ${body}\n  }`;
+}
+
+/**
+ * Generate the full client file.
+ */
+function generateClient(routes: readonly Route[]): string {
+	const methodNames = buildMethodNames(routes);
+	const methods = routes
+		.map((route, index) => generateMethod(route, methodNames[index]))
+		.join("\n\n");
+
+	return `/**
+ * AUTO-GENERATED FILE — DO NOT EDIT
+ * Generated from daemon.ts routes by scripts/generate-client.ts
+ *
+ * This file provides broad coverage of daemon endpoints.
+ * Manual helpers live in ../helpers.ts
+ */
+
+export class GeneratedClient {
+  constructor(
+    private readonly transport: {
+      readonly get: <T>(path: string, query?: Record<string, unknown>) => Promise<T>;
+      readonly post: <T>(path: string, body?: unknown) => Promise<T>;
+      readonly put: <T>(path: string, body?: unknown) => Promise<T>;
+      readonly patch: <T>(path: string, body?: unknown) => Promise<T>;
+      readonly del: <T>(path: string, query?: Record<string, unknown>) => Promise<T>;
+    },
+  ) {}
+
+${methods}
+}
+`;
+}
+
+/**
+ * Main
+ */
+function main(): void {
+	console.log("Reading daemon.ts...");
+	const daemonCode = readFileSync(DAEMON_PATH, "utf-8");
+
+	console.log("Extracting routes...");
+	const routes = extractRoutes(daemonCode);
+	console.log(`Found ${routes.length} routes`);
+
+	console.log("Generating client...");
+	const clientCode = generateClient(routes);
+
+	if (!existsSync(OUTPUT_DIR)) {
+		mkdirSync(OUTPUT_DIR, { recursive: true });
+	}
+
+	const outputPath = join(OUTPUT_DIR, "client.ts");
+	console.log(`Writing to ${outputPath}...`);
+	writeFileSync(outputPath, clientCode, "utf-8");
+
+	console.log("✓ Generated SDK client methods for all daemon routes");
+	console.log(`  Total methods: ${routes.length}`);
+}
+
+main();

--- a/packages/sdk/scripts/generate-client.ts
+++ b/packages/sdk/scripts/generate-client.ts
@@ -210,4 +210,6 @@ function main(): void {
 	console.log(`  Total methods: ${routes.length}`);
 }
 
-main();
+if (import.meta.main) {
+	main();
+}

--- a/packages/sdk/src/__tests__/embeddings.test.ts
+++ b/packages/sdk/src/__tests__/embeddings.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { SignetClient } from "../index.js";
+import type { Server } from "bun";
+
+interface RecordedRequest {
+  readonly method: string;
+  readonly path: string;
+  readonly query: Record<string, string>;
+  readonly body: unknown;
+}
+
+let servers: Server[] = [];
+let recorded: RecordedRequest[] = [];
+
+function mockDaemon(
+  responseOverride?: (req: RecordedRequest) => unknown,
+): { server: Server; client: SignetClient } {
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const query: Record<string, string> = {};
+      for (const [k, v] of url.searchParams) {
+        query[k] = v;
+      }
+
+      let body: unknown = null;
+      const ct = req.headers.get("content-type");
+      if (ct?.includes("application/json")) {
+        body = await req.json();
+      }
+
+      const entry: RecordedRequest = {
+        method: req.method,
+        path: url.pathname,
+        query,
+        body,
+      };
+      recorded.push(entry);
+
+      const responseBody = responseOverride
+        ? responseOverride(entry)
+        : { ok: true };
+      return Response.json(responseBody);
+    },
+  });
+
+  servers.push(server);
+  const client = new SignetClient({
+    daemonUrl: `http://localhost:${server.port}`,
+    retries: 0,
+  });
+
+  return { server, client };
+}
+
+function lastRequest(): RecordedRequest {
+  const req = recorded[recorded.length - 1];
+  if (!req) throw new Error("No requests recorded");
+  return req;
+}
+
+afterEach(() => {
+  for (const s of servers) {
+    s.stop(true);
+  }
+  servers = [];
+  recorded = [];
+});
+
+describe("Embeddings API", () => {
+  test("getEmbeddingStatus() sends GET /api/embeddings/status", async () => {
+    const { client } = mockDaemon();
+    await client.getEmbeddingStatus();
+
+    const req = lastRequest();
+    expect(req.method).toBe("GET");
+    expect(req.path).toBe("/api/embeddings/status");
+  });
+
+  test("getEmbeddingHealth() sends GET /api/embeddings/health", async () => {
+    const { client } = mockDaemon();
+    await client.getEmbeddingHealth();
+
+    const req = lastRequest();
+    expect(req.method).toBe("GET");
+    expect(req.path).toBe("/api/embeddings/health");
+  });
+
+  test("getEmbeddingProjection() sends GET /api/embeddings/projection with dimensions", async () => {
+    const { client } = mockDaemon((req) => {
+      if (req.path === "/api/embeddings/projection") {
+        return {
+          status: "ready",
+          dimensions: 2,
+          count: 1,
+          total: 1,
+          limit: 1,
+          offset: 0,
+          hasMore: false,
+          nodes: [{ id: "m1", x: 0, y: 0 }],
+          edges: [],
+        };
+      }
+      return { ok: true };
+    });
+    const projection = await client.getEmbeddingProjection({ dimensions: 2 });
+
+    const req = lastRequest();
+    expect(req.method).toBe("GET");
+    expect(req.path).toBe("/api/embeddings/projection");
+    expect(req.query.dimensions).toBe("2");
+    expect(projection.status).toBe("ready");
+  });
+});

--- a/packages/sdk/src/__tests__/helpers.test.ts
+++ b/packages/sdk/src/__tests__/helpers.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { SignetClient } from "../index.js";
+import type { Server } from "bun";
+
+interface RecordedRequest {
+  readonly method: string;
+  readonly path: string;
+  readonly query: Record<string, string>;
+  readonly body: unknown;
+}
+
+let servers: Server[] = [];
+let recorded: RecordedRequest[] = [];
+
+function mockDaemon(
+  responseOverride?: (req: RecordedRequest) => Response | unknown,
+): { server: Server; client: SignetClient } {
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const query: Record<string, string> = {};
+      for (const [k, v] of url.searchParams) {
+        query[k] = v;
+      }
+
+      let body: unknown = null;
+      const ct = req.headers.get("content-type");
+      if (ct?.includes("application/json")) {
+        body = await req.json();
+      }
+
+      const entry: RecordedRequest = {
+        method: req.method,
+        path: url.pathname,
+        query,
+        body,
+      };
+      recorded.push(entry);
+
+      const responseBody = responseOverride
+        ? responseOverride(entry)
+        : { ok: true };
+      if (responseBody instanceof Response) {
+        return responseBody;
+      }
+      return Response.json(responseBody);
+    },
+  });
+
+  servers.push(server);
+  const client = new SignetClient({
+    daemonUrl: `http://localhost:${server.port}`,
+    retries: 0,
+  });
+
+  return { server, client };
+}
+
+function lastRequest(): RecordedRequest {
+  const req = recorded[recorded.length - 1];
+  if (!req) throw new Error("No requests recorded");
+  return req;
+}
+
+afterEach(() => {
+  for (const s of servers) {
+    s.stop(true);
+  }
+  servers = [];
+  recorded = [];
+});
+
+describe("SignetClientHelpers", () => {
+  test("waitForJob() polls until job completes", async () => {
+    let callCount = 0;
+    const { client } = mockDaemon((req) => {
+      if (req.path.includes("/jobs/")) {
+        callCount++;
+        return {
+          id: "job-123",
+          status: callCount < 3 ? "pending" : "done",
+          progress: callCount * 33,
+        };
+      }
+      return { ok: true };
+    });
+
+    const result = await client.waitForJob("job-123", {
+      interval: 10,
+      timeout: 1000,
+    });
+
+    expect(result.status).toBe("done");
+    expect(callCount).toBeGreaterThanOrEqual(3);
+  });
+
+  test("waitForJob() throws on timeout", async () => {
+    const { client } = mockDaemon(() => ({
+      id: "job-123",
+      status: "pending",
+      progress: 0,
+    }));
+
+    await expect(
+      client.waitForJob("job-123", { interval: 10, timeout: 50 }),
+    ).rejects.toThrow("did not complete within 50ms");
+  });
+
+  test("createAndIngestDocument() creates and waits for ingestion", async () => {
+    let readCount = 0;
+    const { client } = mockDaemon((req) => {
+      if (req.path === "/api/documents" && req.method === "POST") {
+        return { id: "doc-123", status: "queued" };
+      }
+      if (req.path === "/api/documents/doc-123") {
+        readCount++;
+        return {
+          id: "doc-123",
+          status: readCount < 3 ? "embedding" : "done",
+          title: "Test Doc",
+          created_at: new Date().toISOString(),
+        };
+      }
+      return { ok: true };
+    });
+
+    const doc = await client.createAndIngestDocument({
+      source_type: "url",
+      url: "https://example.com",
+    });
+
+    expect(doc.id).toBe("doc-123");
+    expect(doc.status).toBe("done");
+    expect(readCount).toBeGreaterThanOrEqual(3);
+  });
+
+  test("recallOrThrow() returns results when found", async () => {
+    const { client } = mockDaemon(() => ({
+      results: [
+        {
+          id: "mem-1",
+          content: "user prefers dark mode",
+          score: 0.95,
+        },
+      ],
+      total: 1,
+    }));
+
+    const result = await client.recallOrThrow("dark mode");
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].content).toBe("user prefers dark mode");
+  });
+
+  test("recallOrThrow() throws when no results", async () => {
+    const { client } = mockDaemon(() => ({
+      results: [],
+      total: 0,
+    }));
+
+    await expect(client.recallOrThrow("nonexistent")).rejects.toThrow(
+      'No memories found for query: "nonexistent"',
+    );
+  });
+
+  test("getMemoryOrThrow() returns memory when found", async () => {
+    const { client } = mockDaemon(() => ({
+      id: "mem-abc",
+      content: "test memory",
+      created_at: new Date().toISOString(),
+      type: "fact",
+    }));
+
+    const memory = await client.getMemoryOrThrow("mem-abc");
+    expect(memory.id).toBe("mem-abc");
+    expect(memory.content).toBe("test memory");
+  });
+
+  test("getMemoryOrThrow() maps API 404 to friendly message", async () => {
+    const { client } = mockDaemon((req) => {
+      if (req.path === "/api/memory/mem-missing") {
+        return Response.json({ error: "not found" }, { status: 404 });
+      }
+      return { ok: true };
+    });
+
+    await expect(client.getMemoryOrThrow("mem-missing")).rejects.toThrow(
+      "Memory not found: mem-missing",
+    );
+  });
+
+  test("getDocumentOrThrow() returns document when found", async () => {
+    const { client } = mockDaemon(() => ({
+      id: "doc-123",
+      status: "ready",
+      title: "Test Document",
+      created_at: new Date().toISOString(),
+    }));
+
+    const doc = await client.getDocumentOrThrow("doc-123");
+    expect(doc.id).toBe("doc-123");
+    expect(doc.title).toBe("Test Document");
+  });
+
+  test("getDocumentOrThrow() maps API 404 to friendly message", async () => {
+    const { client } = mockDaemon((req) => {
+      if (req.path === "/api/documents/doc-missing") {
+        return Response.json({ error: "missing document" }, { status: 404 });
+      }
+      return { ok: true };
+    });
+
+    await expect(client.getDocumentOrThrow("doc-missing")).rejects.toThrow(
+      "Document not found: doc-missing",
+    );
+  });
+
+  test("batchModifyWithProgress() calls progress callback", async () => {
+    const progressCalls: Array<{ done: number; total: number }> = [];
+
+    const { client } = mockDaemon(() => ({
+      success: 2,
+      failed: 0,
+      results: [
+        { id: "m1", success: true },
+        { id: "m2", success: true },
+      ],
+    }));
+
+    const result = await client.batchModifyWithProgress(
+      [
+        { id: "m1", reason: "fix", content: "updated 1" },
+        { id: "m2", reason: "fix", content: "updated 2" },
+      ],
+      (progress) => {
+        progressCalls.push(progress);
+      },
+    );
+
+    expect(result.success).toBe(2);
+    expect(progressCalls).toHaveLength(2);
+    expect(progressCalls[0]).toEqual({ done: 0, total: 2 });
+    expect(progressCalls[1]).toEqual({ done: 2, total: 2 });
+  });
+});

--- a/packages/sdk/src/__tests__/tasks.test.ts
+++ b/packages/sdk/src/__tests__/tasks.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { SignetClient } from "../index.js";
+import type { Server } from "bun";
+
+interface RecordedRequest {
+  readonly method: string;
+  readonly path: string;
+  readonly query: Record<string, string>;
+  readonly body: unknown;
+}
+
+let servers: Server[] = [];
+let recorded: RecordedRequest[] = [];
+
+function mockDaemon(
+  responseOverride?: (req: RecordedRequest) => unknown,
+): { server: Server; client: SignetClient } {
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const query: Record<string, string> = {};
+      for (const [k, v] of url.searchParams) {
+        query[k] = v;
+      }
+
+      let body: unknown = null;
+      const ct = req.headers.get("content-type");
+      if (ct?.includes("application/json")) {
+        body = await req.json();
+      }
+
+      const entry: RecordedRequest = {
+        method: req.method,
+        path: url.pathname,
+        query,
+        body,
+      };
+      recorded.push(entry);
+
+      const responseBody = responseOverride
+        ? responseOverride(entry)
+        : { ok: true };
+      return Response.json(responseBody);
+    },
+  });
+
+  servers.push(server);
+  const client = new SignetClient({
+    daemonUrl: `http://localhost:${server.port}`,
+    retries: 0,
+  });
+
+  return { server, client };
+}
+
+function lastRequest(): RecordedRequest {
+  const req = recorded[recorded.length - 1];
+  if (!req) throw new Error("No requests recorded");
+  return req;
+}
+
+afterEach(() => {
+  for (const s of servers) {
+    s.stop(true);
+  }
+  servers = [];
+  recorded = [];
+});
+
+describe("Tasks/Scheduler API", () => {
+  test("listTasks() sends GET /api/tasks", async () => {
+    const { client } = mockDaemon();
+    await client.listTasks();
+
+    const req = lastRequest();
+    expect(req.method).toBe("GET");
+    expect(req.path).toBe("/api/tasks");
+  });
+
+  test("createTask() sends POST /api/tasks with payload", async () => {
+    const { client } = mockDaemon();
+    await client.createTask({
+      name: "Daily Report",
+      prompt: "Generate daily report",
+      cronExpression: "0 9 * * *",
+      harness: "claude-code",
+      workingDirectory: "/home/user/project",
+      skillName: "report-gen",
+      skillMode: "inject",
+    });
+
+    const req = lastRequest();
+    expect(req.method).toBe("POST");
+    expect(req.path).toBe("/api/tasks");
+    expect(req.body).toEqual({
+      name: "Daily Report",
+      prompt: "Generate daily report",
+      cronExpression: "0 9 * * *",
+      harness: "claude-code",
+      workingDirectory: "/home/user/project",
+      skillName: "report-gen",
+      skillMode: "inject",
+    });
+  });
+
+  test("getTask() sends GET /api/tasks/:id", async () => {
+    const { client } = mockDaemon();
+    await client.getTask("task-abc-123");
+
+    const req = lastRequest();
+    expect(req.method).toBe("GET");
+    expect(req.path).toBe("/api/tasks/task-abc-123");
+  });
+
+  test("updateTask() sends PATCH /api/tasks/:id with patch", async () => {
+    const { client } = mockDaemon();
+    await client.updateTask("task-xyz-789", {
+      enabled: false,
+      prompt: "Updated prompt",
+    });
+
+    const req = lastRequest();
+    expect(req.method).toBe("PATCH");
+    expect(req.path).toBe("/api/tasks/task-xyz-789");
+    expect(req.body).toEqual({
+      enabled: false,
+      prompt: "Updated prompt",
+    });
+  });
+
+  test("deleteTask() sends DELETE /api/tasks/:id", async () => {
+    const { client } = mockDaemon();
+    await client.deleteTask("task-del-456");
+
+    const req = lastRequest();
+    expect(req.method).toBe("DELETE");
+    expect(req.path).toBe("/api/tasks/task-del-456");
+  });
+
+  test("runTask() sends POST /api/tasks/:id/run", async () => {
+    const { client } = mockDaemon((req) => {
+      if (req.path === "/api/tasks/task-run-123/run") {
+        return { runId: "run-abc", status: "running" };
+      }
+      return { ok: true };
+    });
+    const result = await client.runTask("task-run-123");
+
+    const req = lastRequest();
+    expect(req.method).toBe("POST");
+    expect(req.path).toBe("/api/tasks/task-run-123/run");
+    expect(req.body).toEqual({});
+    expect(result).toEqual({ runId: "run-abc", status: "running" });
+  });
+
+  test("listTaskRuns() sends GET /api/tasks/:id/runs with query params", async () => {
+    const { client } = mockDaemon((req) => {
+      if (req.path === "/api/tasks/task-runs-123/runs") {
+        return {
+          runs: [{ id: "run-1", task_id: "task-runs-123", status: "running" }],
+          total: 1,
+          hasMore: false,
+        };
+      }
+      return { ok: true };
+    });
+    const response = await client.listTaskRuns("task-runs-123", { limit: 20, offset: 5 });
+
+    const req = lastRequest();
+    expect(req.method).toBe("GET");
+    expect(req.path).toBe("/api/tasks/task-runs-123/runs");
+    expect(req.query.limit).toBe("20");
+    expect(req.query.offset).toBe("5");
+    expect(response.total).toBe(1);
+    expect(response.hasMore).toBe(false);
+    expect(response.runs).toHaveLength(1);
+  });
+});

--- a/packages/sdk/src/__tests__/telemetry.test.ts
+++ b/packages/sdk/src/__tests__/telemetry.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { SignetClient } from "../index.js";
+import type { Server } from "bun";
+
+interface RecordedRequest {
+  readonly method: string;
+  readonly path: string;
+  readonly query: Record<string, string>;
+  readonly body: unknown;
+}
+
+let servers: Server[] = [];
+let recorded: RecordedRequest[] = [];
+
+function mockDaemon(
+  responseOverride?: (req: RecordedRequest) => Response | unknown,
+): { server: Server; client: SignetClient } {
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const query: Record<string, string> = {};
+      for (const [k, v] of url.searchParams) {
+        query[k] = v;
+      }
+
+      let body: unknown = null;
+      const ct = req.headers.get("content-type");
+      if (ct?.includes("application/json")) {
+        body = await req.json();
+      }
+
+      const entry: RecordedRequest = {
+        method: req.method,
+        path: url.pathname,
+        query,
+        body,
+      };
+      recorded.push(entry);
+
+      const responseBody = responseOverride
+        ? responseOverride(entry)
+        : { ok: true };
+      if (responseBody instanceof Response) {
+        return responseBody;
+      }
+      return Response.json(responseBody);
+    },
+  });
+
+  servers.push(server);
+  const client = new SignetClient({
+    daemonUrl: `http://localhost:${server.port}`,
+    retries: 0,
+  });
+
+  return { server, client };
+}
+
+function lastRequest(): RecordedRequest {
+  const req = recorded[recorded.length - 1];
+  if (!req) throw new Error("No requests recorded");
+  return req;
+}
+
+afterEach(() => {
+  for (const s of servers) {
+    s.stop(true);
+  }
+  servers = [];
+  recorded = [];
+});
+
+describe("Telemetry API", () => {
+  test("getTelemetryEvents() sends GET /api/telemetry/events with query params", async () => {
+    const { client } = mockDaemon();
+    await client.getTelemetryEvents({
+      event: "llm.generate",
+      since: "2024-01-01",
+      limit: 50,
+    });
+
+    const req = lastRequest();
+    expect(req.method).toBe("GET");
+    expect(req.path).toBe("/api/telemetry/events");
+    expect(req.query.event).toBe("llm.generate");
+    expect(req.query.since).toBe("2024-01-01");
+    expect(req.query.limit).toBe("50");
+  });
+
+  test("getTelemetryStats() sends GET /api/telemetry/stats", async () => {
+    const { client } = mockDaemon();
+    await client.getTelemetryStats({ since: "2024-01-01" });
+
+    const req = lastRequest();
+    expect(req.method).toBe("GET");
+    expect(req.path).toBe("/api/telemetry/stats");
+    expect(req.query.since).toBe("2024-01-01");
+  });
+
+  test("exportTelemetry() sends GET /api/telemetry/export", async () => {
+    const { client } = mockDaemon((req) => {
+      if (req.path === "/api/telemetry/export") {
+        return new Response('{"id":"1","event":"test"}\n{"id":"2","event":"test"}', {
+          headers: { "content-type": "application/x-ndjson" },
+        });
+      }
+      return { ok: true };
+    });
+    const result = await client.exportTelemetry({ limit: 100 });
+
+    const req = lastRequest();
+    expect(req.method).toBe("GET");
+    expect(req.path).toBe("/api/telemetry/export");
+    expect(req.query.limit).toBe("100");
+    expect(typeof result).toBe("string");
+    expect(result).toContain('{"id":"1","event":"test"}');
+  });
+});

--- a/packages/sdk/src/__tests__/transport.test.ts
+++ b/packages/sdk/src/__tests__/transport.test.ts
@@ -41,6 +41,20 @@ describe("SignetTransport", () => {
     expect(result).toEqual(payload);
   });
 
+  test("successful GET returns text for non-JSON content types", async () => {
+    const server = mockServer(() =>
+      new Response('{"id":"1"}\n{"id":"2"}', {
+        headers: { "content-type": "application/x-ndjson" },
+      }),
+    );
+
+    const transport = new SignetTransport({
+      baseUrl: `http://localhost:${server.port}`,
+    });
+    const result = await transport.get<string>("/export");
+    expect(result).toContain('{"id":"1"}');
+  });
+
   test("successful POST sends body and returns parsed JSON", async () => {
     let receivedBody: unknown;
     let receivedContentType: string | null = null;

--- a/packages/sdk/src/client-p2.ts
+++ b/packages/sdk/src/client-p2.ts
@@ -1,0 +1,856 @@
+/**
+ * P2 domain methods for SignetClient.
+ * This file will be merged into index.ts
+ */
+
+import type { SignetTransport } from "./transport.js";
+import type {
+  // Hooks
+  SessionStartResponse,
+  UserPromptSubmitResponse,
+  SessionEndResponse,
+  PreCompactionResponse,
+  CompactionCompleteResponse,
+  SynthesisConfigResponse,
+  SynthesisRequestResponse,
+  SynthesisCompleteResponse,
+
+  // Connectors
+  ConnectorListResponse,
+  ConnectorRecord,
+  ConnectorCreateResponse,
+  ConnectorSyncResponse,
+  ConnectorResyncResponse,
+  ConnectorDeleteResponse,
+  ConnectorHealthResponse,
+
+  // Analytics
+  UsageCountersResponse,
+  ErrorsResponse,
+  LatencyResponse,
+  LogsResponse,
+  MemorySafetyResponse,
+  ContinuityResponse,
+  ContinuityLatestResponse,
+
+  // Knowledge Graph
+  KnowledgeEntityListResponse,
+  KnowledgeEntityDetail,
+  PinEntityResponse,
+  UnpinEntityResponse,
+  EntityAspectsResponse,
+  AspectAttributesResponse,
+  EntityDependenciesResponse,
+  KnowledgeStatsResponse,
+  TraversalStatusResponse,
+  ConstellationResponse,
+
+  // Repair
+  RepairActionResponse,
+  EmbeddingGapsResponse,
+  DedupStatsResponse,
+  DeduplicateResponse,
+
+  // Cross-Agent
+  AgentPresenceListResponse,
+  AgentPresenceUpdateResponse,
+  AgentMessageListResponse,
+  AgentMessageSendResponse,
+
+  // Predictor
+  PredictorStatusResponse,
+  ComparisonsByProjectResponse,
+  ComparisonsByEntityResponse,
+  ComparisonsListResponse,
+  TrainingRunsResponse,
+  TrainingPairsCountResponse,
+  TrainPredictorResponse,
+} from "./types-p2.js";
+
+// ============================================================================
+// Hooks API (10 methods)
+// ============================================================================
+
+export class SignetClientP2 {
+  constructor(private readonly transport: SignetTransport) {}
+
+  // --- Hooks ---
+
+  /**
+   * @example
+   * const result = await client.sessionStart({
+   *   sessionKey: 'sess-123',
+   *   project: 'my-project'
+   * });
+   */
+  async sessionStart(opts: {
+    readonly sessionKey: string;
+    readonly project?: string;
+    readonly harness?: string;
+    readonly runtimePath?: string;
+  }): Promise<SessionStartResponse> {
+    return this.transport.post<SessionStartResponse>("/api/hooks/session-start", opts);
+  }
+
+  /**
+   * @example
+   * const result = await client.userPromptSubmit({
+   *   sessionKey: 'sess-123',
+   *   prompt: 'Help me with...'
+   * });
+   */
+  async userPromptSubmit(opts: {
+    readonly sessionKey: string;
+    readonly prompt: string;
+    readonly project?: string;
+  }): Promise<UserPromptSubmitResponse> {
+    return this.transport.post<UserPromptSubmitResponse>("/api/hooks/user-prompt-submit", opts);
+  }
+
+  /**
+   * @example
+   * const result = await client.sessionEnd({
+   *   sessionKey: 'sess-123',
+   *   summary: 'Completed task X'
+   * });
+   */
+  async sessionEnd(opts: {
+    readonly sessionKey: string;
+    readonly summary?: string;
+    readonly project?: string;
+  }): Promise<SessionEndResponse> {
+    return this.transport.post<SessionEndResponse>("/api/hooks/session-end", opts);
+  }
+
+  /**
+   * @example
+   * const result = await client.hookRemember({
+   *   content: 'User prefers dark mode',
+   *   type: 'preference'
+   * });
+   */
+  async hookRemember(opts: {
+    readonly content: string;
+    readonly type?: string;
+    readonly importance?: number;
+    readonly tags?: string;
+    readonly who?: string;
+    readonly sessionKey?: string;
+    readonly runtimePath?: string;
+  }): Promise<{ readonly id: string }> {
+    return this.transport.post<{ readonly id: string }>("/api/hooks/remember", opts);
+  }
+
+  /**
+   * @example
+   * const result = await client.hookRecall({
+   *   query: 'dark mode preferences'
+   * });
+   */
+  async hookRecall(opts: {
+    readonly query: string;
+    readonly limit?: number;
+    readonly type?: string;
+    readonly tags?: string;
+  }): Promise<{ readonly results: readonly unknown[] }> {
+    return this.transport.post<{ readonly results: readonly unknown[] }>("/api/hooks/recall", opts);
+  }
+
+  /**
+   * @example
+   * const result = await client.preCompaction({
+   *   sessionKey: 'sess-123',
+   *   context: 'Current conversation about...'
+   * });
+   */
+  async preCompaction(opts: {
+    readonly sessionKey: string;
+    readonly context: string;
+    readonly project?: string;
+  }): Promise<PreCompactionResponse> {
+    return this.transport.post<PreCompactionResponse>("/api/hooks/pre-compaction", opts);
+  }
+
+  /**
+   * @example
+   * const result = await client.compactionComplete({
+   *   sessionKey: 'sess-123',
+   *   summary: 'Discussed X, Y, Z'
+   * });
+   */
+  async compactionComplete(opts: {
+    readonly sessionKey: string;
+    readonly summary: string;
+    readonly project?: string;
+  }): Promise<CompactionCompleteResponse> {
+    return this.transport.post<CompactionCompleteResponse>("/api/hooks/compaction-complete", opts);
+  }
+
+  /**
+   * @example
+   * const config = await client.getSynthesisConfig();
+   */
+  async getSynthesisConfig(): Promise<SynthesisConfigResponse> {
+    return this.transport.get<SynthesisConfigResponse>("/api/hooks/synthesis/config");
+  }
+
+  /**
+   * @example
+   * const result = await client.requestSynthesis({
+   *   project: 'my-project'
+   * });
+   */
+  async requestSynthesis(opts?: {
+    readonly project?: string;
+    readonly force?: boolean;
+  }): Promise<SynthesisRequestResponse> {
+    return this.transport.post<SynthesisRequestResponse>("/api/hooks/synthesis", opts ?? {});
+  }
+
+  /**
+   * @example
+   * const result = await client.synthesisComplete({
+   *   content: '# MEMORY.md\n...'
+   * });
+   */
+  async synthesisComplete(opts: {
+    readonly content: string;
+    readonly project?: string;
+  }): Promise<SynthesisCompleteResponse> {
+    return this.transport.post<SynthesisCompleteResponse>("/api/hooks/synthesis/complete", opts);
+  }
+
+  // --- Connectors ---
+
+  /**
+   * @example
+   * const { connectors } = await client.listConnectors();
+   */
+  async listConnectors(): Promise<ConnectorListResponse> {
+    return this.transport.get<ConnectorListResponse>("/api/connectors");
+  }
+
+  /**
+   * @example
+   * const { id } = await client.createConnector({
+   *   provider: 'filesystem',
+   *   displayName: 'My Docs',
+   *   settings: { rootPath: '/path/to/docs' }
+   * });
+   */
+  async createConnector(opts: {
+    readonly provider: "filesystem" | "github-docs" | "gdrive";
+    readonly displayName?: string;
+    readonly settings?: Record<string, unknown>;
+  }): Promise<ConnectorCreateResponse> {
+    return this.transport.post<ConnectorCreateResponse>("/api/connectors", opts);
+  }
+
+  /**
+   * @example
+   * const connector = await client.getConnector('conn-123');
+   */
+  async getConnector(id: string): Promise<ConnectorRecord> {
+    return this.transport.get<ConnectorRecord>(`/api/connectors/${id}`);
+  }
+
+  /**
+   * @example
+   * const result = await client.syncConnector('conn-123');
+   */
+  async syncConnector(id: string): Promise<ConnectorSyncResponse> {
+    return this.transport.post<ConnectorSyncResponse>(`/api/connectors/${id}/sync`, {});
+  }
+
+  /**
+   * @example
+   * const result = await client.resyncAllConnectors();
+   */
+  async resyncAllConnectors(): Promise<ConnectorResyncResponse> {
+    return this.transport.post<ConnectorResyncResponse>("/api/connectors/resync", {});
+  }
+
+  /**
+   * @example
+   * const result = await client.fullSyncConnector('conn-123');
+   */
+  async fullSyncConnector(id: string): Promise<ConnectorSyncResponse> {
+    return this.transport.post<ConnectorSyncResponse>(
+      `/api/connectors/${id}/sync/full?confirm=true`,
+      {},
+    );
+  }
+
+  /**
+   * @example
+   * const { deleted } = await client.deleteConnector('conn-123', { cascade: true });
+   */
+  async deleteConnector(
+    id: string,
+    opts?: { readonly cascade?: boolean },
+  ): Promise<ConnectorDeleteResponse> {
+    const cascade = opts?.cascade ? "?cascade=true" : "";
+    return this.transport.del<ConnectorDeleteResponse>(
+      `/api/connectors/${id}${cascade}`,
+      {},
+    );
+  }
+
+  /**
+   * @example
+   * const health = await client.getConnectorHealth('conn-123');
+   */
+  async getConnectorHealth(id: string): Promise<ConnectorHealthResponse> {
+    return this.transport.get<ConnectorHealthResponse>(`/api/connectors/${id}/health`);
+  }
+
+  // --- Analytics ---
+
+  /**
+   * @example
+   * const usage = await client.getUsageCounters();
+   */
+  async getUsageCounters(): Promise<UsageCountersResponse> {
+    return this.transport.get<UsageCountersResponse>("/api/analytics/usage");
+  }
+
+  /**
+   * @example
+   * const { errors, summary } = await client.getErrors({ stage: 'mutation', limit: 50 });
+   */
+  async getErrors(opts?: {
+    readonly stage?: string;
+    readonly since?: string;
+    readonly limit?: number;
+  }): Promise<ErrorsResponse> {
+    return this.transport.get<ErrorsResponse>("/api/analytics/errors", opts);
+  }
+
+  /**
+   * @example
+   * const latency = await client.getLatency();
+   */
+  async getLatency(): Promise<LatencyResponse> {
+    return this.transport.get<LatencyResponse>("/api/analytics/latency");
+  }
+
+  /**
+   * @example
+   * const { logs, count } = await client.getAnalyticsLogs({ level: 'error', limit: 100 });
+   */
+  async getAnalyticsLogs(opts?: {
+    readonly limit?: number;
+    readonly level?: "debug" | "info" | "warn" | "error";
+    readonly category?: string;
+    readonly since?: string;
+  }): Promise<LogsResponse> {
+    return this.transport.get<LogsResponse>("/api/analytics/logs", opts);
+  }
+
+  /**
+   * @example
+   * const safety = await client.getMemorySafety();
+   */
+  async getMemorySafety(): Promise<MemorySafetyResponse> {
+    return this.transport.get<MemorySafetyResponse>("/api/analytics/memory-safety");
+  }
+
+  /**
+   * @example
+   * const { scores, summary } = await client.getContinuity({ project: 'my-project', limit: 50 });
+   */
+  async getContinuity(opts?: {
+    readonly project?: string;
+    readonly limit?: number;
+  }): Promise<ContinuityResponse> {
+    return this.transport.get<ContinuityResponse>("/api/analytics/continuity", opts);
+  }
+
+  /**
+   * @example
+   * const { scores } = await client.getLatestContinuity();
+   */
+  async getLatestContinuity(): Promise<ContinuityLatestResponse> {
+    return this.transport.get<ContinuityLatestResponse>(
+      "/api/analytics/continuity/latest",
+    );
+  }
+
+  // --- Knowledge Graph ---
+
+  /**
+   * @example
+   * const { items } = await client.listKnowledgeEntities({ type: 'person', limit: 50 });
+   */
+  async listKnowledgeEntities(opts?: {
+    readonly agentId?: string;
+    readonly type?: string;
+    readonly query?: string;
+    readonly limit?: number;
+    readonly offset?: number;
+  }): Promise<KnowledgeEntityListResponse> {
+    return this.transport.get<KnowledgeEntityListResponse>(
+      "/api/knowledge/entities",
+      opts,
+    );
+  }
+
+  /**
+   * @example
+   * const { pinned, pinnedAt } = await client.pinEntity('entity-123');
+   */
+  async pinEntity(
+    id: string,
+    opts?: { readonly agentId?: string },
+  ): Promise<PinEntityResponse> {
+    return this.transport.post<PinEntityResponse>(
+      `/api/knowledge/entities/${id}/pin`,
+      {},
+      opts ? { query: opts } : undefined,
+    );
+  }
+
+  /**
+   * @example
+   * const { pinned } = await client.unpinEntity('entity-123');
+   */
+  async unpinEntity(
+    id: string,
+    opts?: { readonly agentId?: string },
+  ): Promise<UnpinEntityResponse> {
+    const query = opts?.agentId ? `?agent_id=${opts.agentId}` : "";
+    return this.transport.del<UnpinEntityResponse>(
+      `/api/knowledge/entities/${id}/pin${query}`,
+      {},
+    );
+  }
+
+  /**
+   * @example
+   * const entities = await client.getPinnedEntities();
+   */
+  async getPinnedEntities(opts?: {
+    readonly agentId?: string;
+  }): Promise<KnowledgeEntityListResponse> {
+    return this.transport.get<KnowledgeEntityListResponse>(
+      "/api/knowledge/entities/pinned",
+      opts,
+    );
+  }
+
+  /**
+   * @example
+   * const health = await client.getEntityHealth({ minComparisons: 3 });
+   */
+  async getEntityHealth(opts?: {
+    readonly agentId?: string;
+    readonly since?: string;
+    readonly minComparisons?: number;
+  }): Promise<{ readonly entities: readonly unknown[] }> {
+    return this.transport.get<{ readonly entities: readonly unknown[] }>(
+      "/api/knowledge/entities/health",
+      opts,
+    );
+  }
+
+  /**
+   * @example
+   * const entity = await client.getKnowledgeEntity('entity-123');
+   */
+  async getKnowledgeEntity(
+    id: string,
+    opts?: { readonly agentId?: string },
+  ): Promise<KnowledgeEntityDetail> {
+    return this.transport.get<KnowledgeEntityDetail>(
+      `/api/knowledge/entities/${id}`,
+      opts,
+    );
+  }
+
+  /**
+   * @example
+   * const { items } = await client.getEntityAspects('entity-123');
+   */
+  async getEntityAspects(
+    entityId: string,
+    opts?: { readonly agentId?: string },
+  ): Promise<EntityAspectsResponse> {
+    return this.transport.get<EntityAspectsResponse>(
+      `/api/knowledge/entities/${entityId}/aspects`,
+      opts,
+    );
+  }
+
+  /**
+   * @example
+   * const { items } = await client.getAspectAttributes('entity-123', 'aspect-456', { kind: 'attribute' });
+   */
+  async getAspectAttributes(
+    entityId: string,
+    aspectId: string,
+    opts?: {
+      readonly agentId?: string;
+      readonly kind?: "attribute" | "constraint";
+      readonly status?: "active" | "superseded" | "deleted";
+      readonly limit?: number;
+      readonly offset?: number;
+    },
+  ): Promise<AspectAttributesResponse> {
+    return this.transport.get<AspectAttributesResponse>(
+      `/api/knowledge/entities/${entityId}/aspects/${aspectId}/attributes`,
+      opts,
+    );
+  }
+
+  /**
+   * @example
+   * const { dependencies } = await client.getEntityDependencies('entity-123');
+   */
+  async getEntityDependencies(
+    entityId: string,
+    opts?: { readonly agentId?: string },
+  ): Promise<EntityDependenciesResponse> {
+    return this.transport.get<EntityDependenciesResponse>(
+      `/api/knowledge/entities/${entityId}/dependencies`,
+      opts,
+    );
+  }
+
+  /**
+   * @example
+   * const stats = await client.getKnowledgeStats();
+   */
+  async getKnowledgeStats(): Promise<KnowledgeStatsResponse> {
+    return this.transport.get<KnowledgeStatsResponse>("/api/knowledge/stats");
+  }
+
+  /**
+   * @example
+   * const status = await client.getTraversalStatus();
+   */
+  async getTraversalStatus(): Promise<TraversalStatusResponse> {
+    return this.transport.get<TraversalStatusResponse>(
+      "/api/knowledge/traversal/status",
+    );
+  }
+
+  /**
+   * @example
+   * const constellation = await client.getConstellation();
+   */
+  async getConstellation(): Promise<ConstellationResponse> {
+    return this.transport.get<ConstellationResponse>(
+      "/api/knowledge/constellation",
+    );
+  }
+
+  // --- Repair ---
+
+  /**
+   * @example
+   * const result = await client.requeueDeadJobs();
+   */
+  async requeueDeadJobs(): Promise<RepairActionResponse> {
+    return this.transport.post<RepairActionResponse>("/api/repair/requeue-dead", {});
+  }
+
+  /**
+   * @example
+   * const result = await client.releaseStaleLeases();
+   */
+  async releaseStaleLeases(): Promise<RepairActionResponse> {
+    return this.transport.post<RepairActionResponse>("/api/repair/release-leases", {});
+  }
+
+  /**
+   * @example
+   * const result = await client.checkFts({ repair: true });
+   */
+  async checkFts(opts?: { readonly repair?: boolean }): Promise<RepairActionResponse> {
+    return this.transport.post<RepairActionResponse>("/api/repair/check-fts", opts ?? {});
+  }
+
+  /**
+   * @example
+   * const result = await client.triggerRetentionSweep();
+   */
+  async triggerRetentionSweep(): Promise<RepairActionResponse> {
+    return this.transport.post<RepairActionResponse>("/api/repair/retention-sweep", {});
+  }
+
+  /**
+   * @example
+   * const gaps = await client.getEmbeddingGaps();
+   */
+  async getEmbeddingGaps(): Promise<EmbeddingGapsResponse> {
+    return this.transport.get<EmbeddingGapsResponse>("/api/repair/embedding-gaps");
+  }
+
+  /**
+   * @example
+   * const result = await client.reembedMissing({ limit: 100 });
+   */
+  async reembedMissing(opts?: {
+    readonly limit?: number;
+  }): Promise<RepairActionResponse> {
+    return this.transport.post<RepairActionResponse>("/api/repair/re-embed", opts ?? {});
+  }
+
+  /**
+   * @example
+   * const result = await client.resyncVectorIndex();
+   */
+  async resyncVectorIndex(): Promise<RepairActionResponse> {
+    return this.transport.post<RepairActionResponse>("/api/repair/resync-vec", {});
+  }
+
+  /**
+   * @example
+   * const result = await client.cleanOrphanedEmbeddings();
+   */
+  async cleanOrphanedEmbeddings(): Promise<RepairActionResponse> {
+    return this.transport.post<RepairActionResponse>("/api/repair/clean-orphans", {});
+  }
+
+  /**
+   * @example
+   * const stats = await client.getDedupStats();
+   */
+  async getDedupStats(): Promise<DedupStatsResponse> {
+    return this.transport.get<DedupStatsResponse>("/api/repair/dedup-stats");
+  }
+
+  /**
+   * @example
+   * const result = await client.deduplicateMemories({ dryRun: false });
+   */
+  async deduplicateMemories(opts?: {
+    readonly dryRun?: boolean;
+  }): Promise<DeduplicateResponse> {
+    return this.transport.post<DeduplicateResponse>(
+      "/api/repair/deduplicate",
+      opts ?? {},
+    );
+  }
+
+  /**
+   * @example
+   * const result = await client.reclassifyEntities();
+   */
+  async reclassifyEntities(): Promise<RepairActionResponse> {
+    return this.transport.post<RepairActionResponse>(
+      "/api/repair/reclassify-entities",
+      {},
+    );
+  }
+
+  /**
+   * @example
+   * const result = await client.pruneChunkGroups();
+   */
+  async pruneChunkGroups(): Promise<RepairActionResponse> {
+    return this.transport.post<RepairActionResponse>(
+      "/api/repair/prune-chunk-groups",
+      {},
+    );
+  }
+
+  /**
+   * @example
+   * const result = await client.pruneSingletonEntities({ minMentions: 2 });
+   */
+  async pruneSingletonEntities(opts?: {
+    readonly minMentions?: number;
+  }): Promise<RepairActionResponse> {
+    return this.transport.post<RepairActionResponse>(
+      "/api/repair/prune-singleton-entities",
+      opts ?? {},
+    );
+  }
+
+  /**
+   * @example
+   * const result = await client.structuralBackfill();
+   */
+  async structuralBackfill(): Promise<RepairActionResponse> {
+    return this.transport.post<RepairActionResponse>(
+      "/api/repair/structural-backfill",
+      {},
+    );
+  }
+
+  // --- Cross-Agent ---
+
+  /**
+   * @example
+   * const { sessions, count } = await client.listAgentPresence({ project: 'my-project' });
+   */
+  async listAgentPresence(opts?: {
+    readonly agentId?: string;
+    readonly sessionKey?: string;
+    readonly project?: string;
+    readonly includeSelf?: boolean;
+    readonly limit?: number;
+  }): Promise<AgentPresenceListResponse> {
+    return this.transport.get<AgentPresenceListResponse>(
+      "/api/cross-agent/presence",
+      opts,
+    );
+  }
+
+  /**
+   * @example
+   * const result = await client.updateAgentPresence({
+   *   harness: 'claude-code',
+   *   runtimePath: 'plugin',
+   *   project: 'my-project'
+   * });
+   */
+  async updateAgentPresence(opts: {
+    readonly harness: string;
+    readonly runtimePath?: "plugin" | "legacy";
+    readonly agentId?: string;
+    readonly sessionKey?: string;
+    readonly project?: string;
+  }): Promise<AgentPresenceUpdateResponse> {
+    return this.transport.post<AgentPresenceUpdateResponse>(
+      "/api/cross-agent/presence",
+      opts,
+    );
+  }
+
+  /**
+   * @example
+   * await client.removeAgentPresence('sess-123');
+   */
+  async removeAgentPresence(sessionKey: string): Promise<{ readonly removed: boolean }> {
+    return this.transport.del<{ readonly removed: boolean }>(
+      `/api/cross-agent/presence/${sessionKey}`,
+      {},
+    );
+  }
+
+  /**
+   * @example
+   * const { messages, count } = await client.listAgentMessages({ limit: 50 });
+   */
+  async listAgentMessages(opts?: {
+    readonly agentId?: string;
+    readonly sessionKey?: string;
+    readonly since?: string;
+    readonly limit?: number;
+    readonly includeSent?: boolean;
+    readonly includeBroadcast?: boolean;
+  }): Promise<AgentMessageListResponse> {
+    return this.transport.get<AgentMessageListResponse>(
+      "/api/cross-agent/messages",
+      opts,
+    );
+  }
+
+  /**
+   * @example
+   * const { id } = await client.sendAgentMessage({
+   *   toAgentId: 'agent-456',
+   *   type: 'assist_request',
+   *   content: 'Need help with...'
+   * });
+   */
+  async sendAgentMessage(opts: {
+    readonly toAgentId?: string;
+    readonly toSessionKey?: string;
+    readonly type: "assist_request" | "decision_update" | "info" | "question";
+    readonly content: string;
+    readonly broadcast?: boolean;
+    readonly via?: "local" | "acp";
+  }): Promise<AgentMessageSendResponse> {
+    return this.transport.post<AgentMessageSendResponse>(
+      "/api/cross-agent/messages",
+      opts,
+    );
+  }
+
+  // --- Predictor ---
+
+  /**
+   * @example
+   * const status = await client.getPredictorStatus();
+   */
+  async getPredictorStatus(): Promise<PredictorStatusResponse> {
+    return this.transport.get<PredictorStatusResponse>("/api/predictor/status");
+  }
+
+  /**
+   * @example
+   * const { comparisons, count } = await client.getComparisonsByProject('my-project');
+   */
+  async getComparisonsByProject(project: string): Promise<ComparisonsByProjectResponse> {
+    return this.transport.get<ComparisonsByProjectResponse>(
+      "/api/predictor/comparisons/by-project",
+      { project },
+    );
+  }
+
+  /**
+   * @example
+   * const { comparisons, count } = await client.getComparisonsByEntity('entity-123');
+   */
+  async getComparisonsByEntity(entityId: string): Promise<ComparisonsByEntityResponse> {
+    return this.transport.get<ComparisonsByEntityResponse>(
+      "/api/predictor/comparisons/by-entity",
+      { entity_id: entityId },
+    );
+  }
+
+  /**
+   * @example
+   * const { comparisons, total } = await client.listComparisons({ limit: 50, offset: 0 });
+   */
+  async listComparisons(opts?: {
+    readonly limit?: number;
+    readonly offset?: number;
+    readonly agentId?: string;
+  }): Promise<ComparisonsListResponse> {
+    return this.transport.get<ComparisonsListResponse>(
+      "/api/predictor/comparisons",
+      opts,
+    );
+  }
+
+  /**
+   * @example
+   * const { runs, count } = await client.listTrainingRuns();
+   */
+  async listTrainingRuns(opts?: {
+    readonly agentId?: string;
+    readonly limit?: number;
+  }): Promise<TrainingRunsResponse> {
+    return this.transport.get<TrainingRunsResponse>(
+      "/api/predictor/training",
+      opts,
+    );
+  }
+
+  /**
+   * @example
+   * const { count } = await client.getTrainingPairsCount();
+   */
+  async getTrainingPairsCount(): Promise<TrainingPairsCountResponse> {
+    return this.transport.get<TrainingPairsCountResponse>(
+      "/api/predictor/training-pairs-count",
+    );
+  }
+
+  /**
+   * @example
+   * const result = await client.trainPredictor({ force: false });
+   */
+  async trainPredictor(opts?: {
+    readonly force?: boolean;
+  }): Promise<TrainPredictorResponse> {
+    return this.transport.post<TrainPredictorResponse>(
+      "/api/predictor/train",
+      opts ?? {},
+    );
+  }
+}

--- a/packages/sdk/src/generated/client.ts
+++ b/packages/sdk/src/generated/client.ts
@@ -1,0 +1,611 @@
+/**
+ * AUTO-GENERATED FILE — DO NOT EDIT
+ * Generated from daemon.ts routes by scripts/generate-client.ts
+ *
+ * This file provides broad coverage of daemon endpoints.
+ * Manual helpers live in ../helpers.ts
+ */
+
+export class GeneratedClient {
+  constructor(
+    private readonly transport: {
+      readonly get: <T>(path: string, query?: Record<string, unknown>) => Promise<T>;
+      readonly post: <T>(path: string, body?: unknown) => Promise<T>;
+      readonly put: <T>(path: string, body?: unknown) => Promise<T>;
+      readonly patch: <T>(path: string, body?: unknown) => Promise<T>;
+      readonly del: <T>(path: string, query?: Record<string, unknown>) => Promise<T>;
+    },
+  ) {}
+
+  async getHealth(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/health", query);
+  }
+
+  async getApiFeatures(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/features", query);
+  }
+
+  async getApiAuthWhoami(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/auth/whoami", query);
+  }
+
+  async postApiAuthToken(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/auth/token", opts);
+  }
+
+  async getApiLogs(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/logs", query);
+  }
+
+  async getApiLogsStream(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/logs/stream", query);
+  }
+
+  async getApiConfig(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/config", query);
+  }
+
+  async postApiConfig(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/config", opts);
+  }
+
+  async getApiIdentity(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/identity", query);
+  }
+
+  async getApiMemories(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/memories", query);
+  }
+
+  async getApiMemoryTimeline(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/memory/timeline", query);
+  }
+
+  async getMemorySearch(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/memory/search", query);
+  }
+
+  async postApiMemoryRemember(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/memory/remember", opts);
+  }
+
+  async postApiMemorySave(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/memory/save", opts);
+  }
+
+  async postApiHookRemember(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/hook/remember", opts);
+  }
+
+  async getApiMemoryById(id: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>(`/api/memory/${id}`, query);
+  }
+
+  async getApiMemoryByIdHistory(id: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>(`/api/memory/${id}/history`, query);
+  }
+
+  async postApiMemoryByIdRecover(id: string, opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>(`/api/memory/${id}/recover`, opts);
+  }
+
+  async patchApiMemoryById(id: string, opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.patch<unknown>(`/api/memory/${id}`, opts);
+  }
+
+  async deleteApiMemoryById(id: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.del<unknown>(`/api/memory/${id}`, query);
+  }
+
+  async postApiMemoryFeedback(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/memory/feedback", opts);
+  }
+
+  async postApiMemoryForget(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/memory/forget", opts);
+  }
+
+  async postApiMemoryModify(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/memory/modify", opts);
+  }
+
+  async postApiMemoryRecall(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/memory/recall", opts);
+  }
+
+  async getApiMemorySearch(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/memory/search", query);
+  }
+
+  async getMemorySimilar(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/memory/similar", query);
+  }
+
+  async getApiEmbeddings(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/embeddings", query);
+  }
+
+  async getApiEmbeddingsStatus(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/embeddings/status", query);
+  }
+
+  async getApiEmbeddingsHealth(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/embeddings/health", query);
+  }
+
+  async getApiEmbeddingsProjection(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/embeddings/projection", query);
+  }
+
+  async postApiDocuments(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/documents", opts);
+  }
+
+  async getApiDocuments(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/documents", query);
+  }
+
+  async getApiDocumentsById(id: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>(`/api/documents/${id}`, query);
+  }
+
+  async getApiDocumentsByIdChunks(id: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>(`/api/documents/${id}/chunks`, query);
+  }
+
+  async deleteApiDocumentsById(id: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.del<unknown>(`/api/documents/${id}`, query);
+  }
+
+  async getApiConnectors(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/connectors", query);
+  }
+
+  async postApiConnectors(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/connectors", opts);
+  }
+
+  async getApiConnectorsById(id: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>(`/api/connectors/${id}`, query);
+  }
+
+  async postApiConnectorsByIdSync(id: string, opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>(`/api/connectors/${id}/sync`, opts);
+  }
+
+  async postApiConnectorsResync(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/connectors/resync", opts);
+  }
+
+  async postApiConnectorsByIdSyncFull(id: string, opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>(`/api/connectors/${id}/sync/full`, opts);
+  }
+
+  async deleteApiConnectorsById(id: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.del<unknown>(`/api/connectors/${id}`, query);
+  }
+
+  async getApiConnectorsByIdHealth(id: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>(`/api/connectors/${id}/health`, query);
+  }
+
+  async getApiHarnesses(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/harnesses", query);
+  }
+
+  async postApiHarnessesRegenerate(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/harnesses/regenerate", opts);
+  }
+
+  async getApiSecrets(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/secrets", query);
+  }
+
+  async getApiSecrets1passwordStatus(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/secrets/1password/status", query);
+  }
+
+  async postApiSecrets1passwordConnect(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/secrets/1password/connect", opts);
+  }
+
+  async deleteApiSecrets1passwordConnect(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.del<unknown>("/api/secrets/1password/connect", query);
+  }
+
+  async getApiSecrets1passwordVaults(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/secrets/1password/vaults", query);
+  }
+
+  async postApiSecrets1passwordImport(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/secrets/1password/import", opts);
+  }
+
+  async postApiSecretsExec(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/secrets/exec", opts);
+  }
+
+  async postApiSecretsByNameExec(name: string, opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>(`/api/secrets/${name}/exec`, opts);
+  }
+
+  async postApiSecretsByName(name: string, opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>(`/api/secrets/${name}`, opts);
+  }
+
+  async deleteApiSecretsByName(name: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.del<unknown>(`/api/secrets/${name}`, query);
+  }
+
+  async postApiHooksSessionStart(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/hooks/session-start", opts);
+  }
+
+  async postApiHooksUserPromptSubmit(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/hooks/user-prompt-submit", opts);
+  }
+
+  async postApiHooksSessionEnd(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/hooks/session-end", opts);
+  }
+
+  async postApiHooksRemember(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/hooks/remember", opts);
+  }
+
+  async postApiHooksRecall(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/hooks/recall", opts);
+  }
+
+  async postApiHooksPreCompaction(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/hooks/pre-compaction", opts);
+  }
+
+  async postApiHooksCompactionComplete(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/hooks/compaction-complete", opts);
+  }
+
+  async getApiCrossAgentPresence(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/cross-agent/presence", query);
+  }
+
+  async postApiCrossAgentPresence(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/cross-agent/presence", opts);
+  }
+
+  async deleteApiCrossAgentPresenceBySessionKey(sessionKey: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.del<unknown>(`/api/cross-agent/presence/${sessionKey}`, query);
+  }
+
+  async getApiCrossAgentMessages(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/cross-agent/messages", query);
+  }
+
+  async postApiCrossAgentMessages(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/cross-agent/messages", opts);
+  }
+
+  async getApiCrossAgentStream(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/cross-agent/stream", query);
+  }
+
+  async getApiHooksSynthesisConfig(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/hooks/synthesis/config", query);
+  }
+
+  async postApiHooksSynthesis(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/hooks/synthesis", opts);
+  }
+
+  async postApiHooksSynthesisComplete(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/hooks/synthesis/complete", opts);
+  }
+
+  async postApiSynthesisTrigger(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/synthesis/trigger", opts);
+  }
+
+  async getApiSynthesisStatus(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/synthesis/status", query);
+  }
+
+  async getApiSessions(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/sessions", query);
+  }
+
+  async getApiSessionsByKey(key: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>(`/api/sessions/${key}`, query);
+  }
+
+  async postApiSessionsByKeyBypass(key: string, opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>(`/api/sessions/${key}/bypass`, opts);
+  }
+
+  async getApiGitStatus(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/git/status", query);
+  }
+
+  async postApiGitPull(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/git/pull", opts);
+  }
+
+  async postApiGitPush(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/git/push", opts);
+  }
+
+  async postApiGitSync(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/git/sync", opts);
+  }
+
+  async getApiGitConfig(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/git/config", query);
+  }
+
+  async postApiGitConfig(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/git/config", opts);
+  }
+
+  async getApiUpdateCheck(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/update/check", query);
+  }
+
+  async getApiUpdateConfig(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/update/config", query);
+  }
+
+  async postApiUpdateConfig(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/update/config", opts);
+  }
+
+  async postApiUpdateRun(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/update/run", opts);
+  }
+
+  async getApiTasksByIdStream(id: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>(`/api/tasks/${id}/stream`, query);
+  }
+
+  async getApiTasks(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/tasks", query);
+  }
+
+  async postApiTasks(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/tasks", opts);
+  }
+
+  async getApiTasksById(id: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>(`/api/tasks/${id}`, query);
+  }
+
+  async patchApiTasksById(id: string, opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.patch<unknown>(`/api/tasks/${id}`, opts);
+  }
+
+  async deleteApiTasksById(id: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.del<unknown>(`/api/tasks/${id}`, query);
+  }
+
+  async postApiTasksByIdRun(id: string, opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>(`/api/tasks/${id}/run`, opts);
+  }
+
+  async getApiTasksByIdRuns(id: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>(`/api/tasks/${id}/runs`, query);
+  }
+
+  async getApiStatus(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/status", query);
+  }
+
+  async getApiHomeGreeting(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/home/greeting", query);
+  }
+
+  async getApiDiagnostics(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/diagnostics", query);
+  }
+
+  async getApiDiagnosticsByDomain(domain: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>(`/api/diagnostics/${domain}`, query);
+  }
+
+  async getApiPipelineStatus(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/pipeline/status", query);
+  }
+
+  async getApiPredictorStatus(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/predictor/status", query);
+  }
+
+  async postApiRepairRequeueDead(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/repair/requeue-dead", opts);
+  }
+
+  async postApiRepairReleaseLeases(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/repair/release-leases", opts);
+  }
+
+  async postApiRepairCheckFts(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/repair/check-fts", opts);
+  }
+
+  async postApiRepairRetentionSweep(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/repair/retention-sweep", opts);
+  }
+
+  async getApiRepairEmbeddingGaps(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/repair/embedding-gaps", query);
+  }
+
+  async postApiRepairReEmbed(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/repair/re-embed", opts);
+  }
+
+  async postApiRepairResyncVec(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/repair/resync-vec", opts);
+  }
+
+  async postApiRepairCleanOrphans(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/repair/clean-orphans", opts);
+  }
+
+  async getApiRepairDedupStats(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/repair/dedup-stats", query);
+  }
+
+  async postApiRepairDeduplicate(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/repair/deduplicate", opts);
+  }
+
+  async postApiRepairReclassifyEntities(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/repair/reclassify-entities", opts);
+  }
+
+  async postApiRepairPruneChunkGroups(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/repair/prune-chunk-groups", opts);
+  }
+
+  async postApiRepairPruneSingletonEntities(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/repair/prune-singleton-entities", opts);
+  }
+
+  async postApiRepairStructuralBackfill(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/repair/structural-backfill", opts);
+  }
+
+  async getApiCheckpoints(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/checkpoints", query);
+  }
+
+  async getApiCheckpointsBySessionKey(sessionKey: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>(`/api/checkpoints/${sessionKey}`, query);
+  }
+
+  async getApiKnowledgeEntities(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/knowledge/entities", query);
+  }
+
+  async postApiKnowledgeEntitiesByIdPin(id: string, opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>(`/api/knowledge/entities/${id}/pin`, opts);
+  }
+
+  async deleteApiKnowledgeEntitiesByIdPin(id: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.del<unknown>(`/api/knowledge/entities/${id}/pin`, query);
+  }
+
+  async getApiKnowledgeEntitiesPinned(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/knowledge/entities/pinned", query);
+  }
+
+  async getApiKnowledgeEntitiesHealth(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/knowledge/entities/health", query);
+  }
+
+  async getApiKnowledgeEntitiesById(id: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>(`/api/knowledge/entities/${id}`, query);
+  }
+
+  async getApiKnowledgeEntitiesByIdAspects(id: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>(`/api/knowledge/entities/${id}/aspects`, query);
+  }
+
+  async getApiKnowledgeEntitiesByIdAspectsByAspectIdAttributes(id: string, aspectId: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>(`/api/knowledge/entities/${id}/aspects/${aspectId}/attributes`, query);
+  }
+
+  async getApiKnowledgeEntitiesByIdDependencies(id: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>(`/api/knowledge/entities/${id}/dependencies`, query);
+  }
+
+  async getApiKnowledgeStats(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/knowledge/stats", query);
+  }
+
+  async getApiKnowledgeTraversalStatus(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/knowledge/traversal/status", query);
+  }
+
+  async getApiKnowledgeConstellation(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/knowledge/constellation", query);
+  }
+
+  async getApiAnalyticsUsage(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/analytics/usage", query);
+  }
+
+  async getApiAnalyticsErrors(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/analytics/errors", query);
+  }
+
+  async getApiAnalyticsLatency(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/analytics/latency", query);
+  }
+
+  async getApiAnalyticsLogs(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/analytics/logs", query);
+  }
+
+  async getApiAnalyticsMemorySafety(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/analytics/memory-safety", query);
+  }
+
+  async getApiAnalyticsContinuity(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/analytics/continuity", query);
+  }
+
+  async getApiAnalyticsContinuityLatest(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/analytics/continuity/latest", query);
+  }
+
+  async getApiPredictorComparisonsByProject(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/predictor/comparisons/by-project", query);
+  }
+
+  async getApiPredictorComparisonsByEntity(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/predictor/comparisons/by-entity", query);
+  }
+
+  async getApiPredictorComparisons(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/predictor/comparisons", query);
+  }
+
+  async getApiPredictorTraining(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/predictor/training", query);
+  }
+
+  async getApiPredictorTrainingPairsCount(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/predictor/training-pairs-count", query);
+  }
+
+  async postApiPredictorTrain(opts?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.post<unknown>("/api/predictor/train", opts);
+  }
+
+  async getApiTelemetryEvents(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/telemetry/events", query);
+  }
+
+  async getApiTelemetryStats(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/telemetry/stats", query);
+  }
+
+  async getApiTelemetryExport(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/telemetry/export", query);
+  }
+
+  async getApiTelemetryTrainingExport(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/api/telemetry/training-export", query);
+  }
+
+  async getApiTimelineById(id: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>(`/api/timeline/${id}`, query);
+  }
+
+  async getApiTimelineByIdExport(id: string, query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>(`/api/timeline/${id}/export`, query);
+  }
+
+  async get(query?: Record<string, unknown>): Promise<unknown> {
+    return this.transport.get<unknown>("/", query);
+  }
+}

--- a/packages/sdk/src/helpers.ts
+++ b/packages/sdk/src/helpers.ts
@@ -1,0 +1,272 @@
+/**
+ * Manual helper methods for SignetClient
+ *
+ * These provide conveniences beyond the auto-generated API coverage:
+ * - Polling utilities
+ * - Composite operations
+ * - Progress callbacks
+ * - Error shortcuts
+ */
+
+import type { SignetTransport } from "./transport.js";
+import type { JobStatus, MemoryRecord, DocumentRecord, RecallResponse } from "./types.js";
+import { SignetApiError } from "./errors.js";
+
+export interface WaitForJobOptions {
+	/** Maximum time to wait in milliseconds (default: 30_000) */
+	readonly timeout?: number;
+	/** Polling interval in milliseconds (default: 500) */
+	readonly interval?: number;
+}
+
+export interface BatchModifyProgress {
+	/** Number of patches completed */
+	readonly done: number;
+	/** Total patches to process */
+	readonly total: number;
+}
+
+export class SignetClientHelpers {
+	protected readonly transport: SignetTransport;
+
+	constructor(transport: SignetTransport) {
+		this.transport = transport;
+	}
+
+	/**
+	 * Poll a job until it completes, fails, or times out.
+	 *
+	 * @example
+		 * ```typescript
+		 * const job = await client.createDocument({ source_type: "url", url: "https://..." });
+		 * const result = await client.waitForJob(job.jobId, { timeout: 60_000 });
+		 * console.log(result.status); // "completed" | "failed" | "done" | "dead"
+		 * ```
+		 */
+	async waitForJob(jobId: string, opts?: WaitForJobOptions): Promise<JobStatus> {
+		const timeout = opts?.timeout ?? 30_000;
+		const interval = opts?.interval ?? 500;
+		const startTime = Date.now();
+
+		while (Date.now() - startTime < timeout) {
+			const job = await this.transport.get<JobStatus>(`/api/memory/jobs/${jobId}`);
+
+			if (isTerminalJobStatus(job.status)) {
+				return job;
+			}
+
+			await new Promise((resolve) => setTimeout(resolve, interval));
+		}
+
+		throw new Error(`Job ${jobId} did not complete within ${timeout}ms`);
+	}
+
+	/**
+	 * Poll a document until ingestion reaches a terminal state.
+	 */
+	async waitForDocument(
+		documentId: string,
+		opts?: WaitForJobOptions,
+	): Promise<DocumentRecord> {
+		const timeout = opts?.timeout ?? 30_000;
+		const interval = opts?.interval ?? 500;
+		const startTime = Date.now();
+
+		while (Date.now() - startTime < timeout) {
+			const doc = await this.transport.get<DocumentRecord>(
+				`/api/documents/${documentId}`,
+			);
+			if (isTerminalDocumentStatus(doc.status)) {
+				return doc;
+			}
+			await new Promise((resolve) => setTimeout(resolve, interval));
+		}
+
+		throw new Error(`Document ${documentId} did not complete within ${timeout}ms`);
+	}
+
+	/**
+	 * Create a document and wait for ingestion to complete.
+	 *
+	 * @example
+	 * ```typescript
+	 * const doc = await client.createAndIngestDocument({
+	 *   source_type: "url",
+	 *   url: "https://example.com/article",
+	 *   title: "Example Article"
+	 * });
+	 * console.log(doc.status); // "done"
+	 * ```
+	 */
+	async createAndIngestDocument(opts: {
+		readonly source_type: "text" | "url" | "file";
+		readonly content?: string;
+		readonly url?: string;
+		readonly title?: string;
+		readonly content_type?: string;
+		readonly connector_id?: string;
+		readonly metadata?: Record<string, unknown>;
+	}): Promise<DocumentRecord> {
+		const result = await this.transport.post<{ id: string; jobId?: string }>(
+			"/api/documents",
+			opts,
+		);
+
+		// If the daemon returns a job id (legacy/optional), wait for it first.
+		if (result.jobId) {
+			await this.waitForJob(result.jobId);
+		}
+
+		// Poll document status until ingest reaches a terminal state.
+		return this.waitForDocument(result.id);
+	}
+
+	/**
+	 * Recall memories and throw if no results found.
+	 *
+	 * @example
+	 * ```typescript
+	 * // Throws if no preferences found
+	 * const memories = await client.recallOrThrow("user preferences", {
+	 *   type: "preference",
+	 *   limit: 5
+	 * });
+	 * ```
+	 */
+	async recallOrThrow(
+		query: string,
+		opts?: {
+			readonly limit?: number;
+			readonly type?: string;
+			readonly tags?: string;
+			readonly who?: string;
+			readonly pinned?: boolean;
+			readonly importance_min?: number;
+			readonly since?: string;
+			readonly minScore?: number;
+		},
+	): Promise<RecallResponse> {
+		const result = await this.transport.post<RecallResponse>("/api/memory/recall", {
+			query,
+			...opts,
+		});
+
+		if (!result.results || result.results.length === 0) {
+			throw new Error(`No memories found for query: "${query}"`);
+		}
+
+		return result;
+	}
+
+	/**
+	 * Get a memory by ID and throw if not found.
+	 *
+	 * @example
+	 * ```typescript
+	 * const memory = await client.getMemoryOrThrow("mem-abc-123");
+	 * ```
+	 */
+	async getMemoryOrThrow(id: string): Promise<MemoryRecord> {
+		try {
+			return await this.transport.get<MemoryRecord>(`/api/memory/${id}`);
+		} catch (error) {
+			if (error instanceof SignetApiError && error.status === 404) {
+				throw new Error(`Memory not found: ${id}`);
+			}
+			throw error;
+		}
+	}
+
+	/**
+	 * Get a document by ID and throw if not found.
+	 *
+	 * @example
+	 * ```typescript
+	 * const doc = await client.getDocumentOrThrow("doc-456");
+	 * ```
+	 */
+	async getDocumentOrThrow(id: string): Promise<DocumentRecord> {
+		try {
+			return await this.transport.get<DocumentRecord>(`/api/documents/${id}`);
+		} catch (error) {
+			if (error instanceof SignetApiError && error.status === 404) {
+				throw new Error(`Document not found: ${id}`);
+			}
+			throw error;
+		}
+	}
+
+	/**
+	 * Batch modify memories with progress callback.
+	 *
+	 * @example
+	 * ```typescript
+	 * await client.batchModifyWithProgress(
+	 *   [
+	 *     { id: "m1", reason: "fix", content: "updated" },
+	 *     { id: "m2", reason: "fix", content: "updated" },
+	 *   ],
+	 *   (done, total) => console.log(`${done}/${total} complete`)
+	 * );
+	 * ```
+	 */
+	async batchModifyWithProgress(
+		patches: readonly {
+			readonly id: string;
+			readonly content?: string;
+			readonly type?: string;
+			readonly importance?: number;
+			readonly tags?: string;
+			readonly pinned?: boolean;
+			readonly project?: string;
+			readonly reason: string;
+			readonly ifVersion?: number;
+		}[],
+		onProgress?: (progress: BatchModifyProgress) => void,
+		opts?: {
+			readonly reason?: string;
+			readonly changed_by?: string;
+		},
+	): Promise<{ success: number; failed: number; results: unknown[] }> {
+		// Notify start
+		onProgress?.({ done: 0, total: patches.length });
+
+		// Send batch request
+		const mapped = patches.map(({ ifVersion, ...rest }) => ({
+			...rest,
+			if_version: ifVersion,
+		}));
+
+		const response = await this.transport.post<{
+			success: number;
+			failed: number;
+			results: unknown[];
+		}>("/api/memory/modify", {
+			patches: mapped,
+			...opts,
+		});
+
+		// Notify completion
+		onProgress?.({ done: patches.length, total: patches.length });
+
+		return response;
+	}
+}
+
+function isTerminalJobStatus(status: JobStatus["status"]): boolean {
+	return (
+		status === "completed" ||
+		status === "failed" ||
+		status === "done" ||
+		status === "dead"
+	);
+}
+
+function isTerminalDocumentStatus(status: string): boolean {
+	return (
+		status === "done" ||
+		status === "failed" ||
+		status === "deleted" ||
+		status === "ready"
+	);
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -4,26 +4,70 @@
  */
 
 import { SignetTransport } from "./transport.js";
+import { SignetClientHelpers } from "./helpers.js";
+import { SignetClientP2 } from "./client-p2.js";
 import type {
   BatchModifyItemResult,
   BatchModifyResponse,
+  CheckpointListResponse,
+  ConfigListResponse,
+  ConfigWriteResponse,
   DeleteResult,
   DocumentChunksResponse,
   DocumentCreateResult,
   DocumentDeleteResult,
   DocumentListResponse,
   DocumentRecord,
+  EmbeddingHealthResponse,
+  EmbeddingProjectionResponse,
+  EmbeddingStatusResponse,
+  FeaturesResponse,
   ForgetResponse,
+  GitConfig,
+  GitPullResult,
+  GitPushResult,
+  GitStatus,
+  GitSyncResult,
+  GreetingResponse,
+  HarnessListResponse,
+  HarnessRegenerateResponse,
   HealthResponse,
   HistoryResponse,
+  IdentityResponse,
   JobStatus,
   MemoryListResponse,
   MemoryRecord,
   ModifyResult,
+  OnePasswordConnectResult,
+  OnePasswordImportResult,
+  OnePasswordStatus,
+  PipelineStatusResponse,
   RecallResponse,
   RecoverResult,
   RememberResult,
+  SecretExecResult,
+  SecretListResponse,
+  SessionInfo,
+  SessionListResponse,
+  SkillBrowseResponse,
+  SkillDeleteResult,
+  SkillGetResponse,
+  SkillInstallResult,
+  SkillListResponse,
+  SkillSearchResponse,
   StatusResponse,
+  TaskCreatePayload,
+  TaskCreateResult,
+  TaskGetResponse,
+  TaskListResponse,
+  TaskRecord,
+  TaskRun,
+  TaskRunListResponse,
+  TaskUpdatePayload,
+  TelemetryEventsResponse,
+  TelemetryStatsResponse,
+  TimelineExportResponse,
+  TimelineResponse,
 } from "./types.js";
 
 export interface SignetClientConfig {
@@ -35,9 +79,7 @@ export interface SignetClientConfig {
   readonly token?: string;
 }
 
-export class SignetClient {
-  private readonly transport: SignetTransport;
-
+export class SignetClient extends SignetClientHelpers {
   constructor(config?: SignetClientConfig) {
     const headers: Record<string, string> = {};
     if (config?.token) {
@@ -50,12 +92,14 @@ export class SignetClient {
       headers["x-signet-actor-type"] = config.actorType;
     }
 
-    this.transport = new SignetTransport({
+    const transport = new SignetTransport({
       baseUrl: config?.daemonUrl ?? "http://localhost:3850",
       timeoutMs: config?.timeoutMs ?? 10_000,
       retries: config?.retries ?? 2,
       headers: Object.keys(headers).length > 0 ? headers : undefined,
     });
+
+    super(transport);
   }
 
   // --- Memory lifecycle ---
@@ -310,7 +354,791 @@ export class SignetClient {
       "/api/auth/whoami",
     );
   }
+
+  // --- Timeline ---
+
+  /**
+   * Get timeline events for an entity.
+   *
+   * @example
+   * ```typescript
+   * const timeline = await client.getTimeline("mem-abc-123");
+   * console.log(timeline.events[0].event);
+   * ```
+   */
+  async getTimeline(entityId: string): Promise<TimelineResponse> {
+    return this.transport.get<TimelineResponse>(`/api/timeline/${entityId}`);
+  }
+
+  /**
+   * Export timeline with metadata.
+   *
+   * @example
+   * ```typescript
+   * const export = await client.exportTimeline("mem-abc-123");
+   * console.log(export.meta.version);
+   * ```
+   */
+  async exportTimeline(entityId: string): Promise<TimelineExportResponse> {
+    return this.transport.get<TimelineExportResponse>(
+      `/api/timeline/${entityId}/export`,
+    );
+  }
+
+  // --- Pipeline ---
+
+  /**
+   * Get pipeline status snapshot.
+   *
+   * @example
+   * ```typescript
+   * const status = await client.getPipelineStatus();
+   * console.log(status.mode); // "shadow" | "controlled-write" | "frozen" | "disabled"
+   * ```
+   */
+  async getPipelineStatus(): Promise<PipelineStatusResponse> {
+    return this.transport.get<PipelineStatusResponse>("/api/pipeline/status");
+  }
+
+  // --- Telemetry ---
+
+  /**
+   * Query telemetry events.
+   *
+   * @example
+   * ```typescript
+   * const events = await client.getTelemetryEvents({
+   *   event: "llm.generate",
+   *   limit: 50
+   * });
+   * console.log(events.enabled, events.events.length);
+   * ```
+   */
+  async getTelemetryEvents(opts?: {
+    readonly event?: string;
+    readonly since?: string;
+    readonly until?: string;
+    readonly limit?: number;
+  }): Promise<TelemetryEventsResponse> {
+    return this.transport.get<TelemetryEventsResponse>("/api/telemetry/events", {
+      event: opts?.event,
+      since: opts?.since,
+      until: opts?.until,
+      limit: opts?.limit,
+    });
+  }
+
+  /**
+   * Get aggregated telemetry statistics.
+   *
+   * @example
+   * ```typescript
+   * const stats = await client.getTelemetryStats({ since: "2024-01-01" });
+   * if (stats.enabled) {
+   *   console.log(stats.llm.calls, stats.llm.totalCost);
+   * }
+   * ```
+   */
+  async getTelemetryStats(opts?: {
+    readonly since?: string;
+  }): Promise<TelemetryStatsResponse> {
+    return this.transport.get<TelemetryStatsResponse>("/api/telemetry/stats", {
+      since: opts?.since,
+    });
+  }
+
+  /**
+   * Export telemetry events as NDJSON text.
+   *
+   * @example
+   * ```typescript
+   * const ndjson = await client.exportTelemetry({ limit: 1000 });
+   * const events = ndjson.split("\n").map(JSON.parse);
+   * ```
+   */
+  async exportTelemetry(opts?: {
+    readonly since?: string;
+    readonly limit?: number;
+  }): Promise<string> {
+    return this.transport.get<string>("/api/telemetry/export", {
+      since: opts?.since,
+      limit: opts?.limit,
+    });
+  }
+
+  // --- Config / Identity ---
+
+  /**
+   * List all config files.
+   *
+   * @example
+   * ```typescript
+   * const config = await client.listConfig();
+   * const agentsMd = config.files.find(f => f.name === "AGENTS.md");
+   * console.log(agentsMd?.content);
+   * ```
+   */
+  async listConfig(): Promise<ConfigListResponse> {
+    return this.transport.get<ConfigListResponse>("/api/config");
+  }
+
+  /**
+   * Write a config file.
+   *
+   * @example
+   * ```typescript
+   * await client.writeConfig("USER.md", "# User\n\n- Location: Seattle");
+   * ```
+   */
+  async writeConfig(file: string, content: string): Promise<ConfigWriteResponse> {
+    return this.transport.post<ConfigWriteResponse>("/api/config", {
+      file,
+      content,
+    });
+  }
+
+  /**
+   * Get parsed identity from IDENTITY.md.
+   *
+   * @example
+   * ```typescript
+   * const identity = await client.getIdentity();
+   * console.log(identity.name, identity.creature);
+   * ```
+   */
+  async getIdentity(): Promise<IdentityResponse> {
+    return this.transport.get<IdentityResponse>("/api/identity");
+  }
+
+  // --- Embeddings ---
+
+  /**
+   * Get embedding status.
+   *
+   * @example
+   * ```typescript
+   * const status = await client.getEmbeddingStatus();
+   * console.log(status.provider, status.model, status.available);
+   * ```
+   */
+  async getEmbeddingStatus(): Promise<EmbeddingStatusResponse> {
+    return this.transport.get<EmbeddingStatusResponse>(
+      "/api/embeddings/status",
+    );
+  }
+
+  /**
+   * Get embedding health metrics.
+   *
+   * @example
+   * ```typescript
+   * const health = await client.getEmbeddingHealth();
+   * console.log(`${health.coveragePercent}% embedded`);
+   * ```
+   */
+  async getEmbeddingHealth(): Promise<EmbeddingHealthResponse> {
+    return this.transport.get<EmbeddingHealthResponse>(
+      "/api/embeddings/health",
+    );
+  }
+
+  /**
+   * Get UMAP projection of embeddings (2D or 3D).
+   *
+   * @example
+   * ```typescript
+   * const projection = await client.getEmbeddingProjection({ dimensions: 2 });
+   * if (projection.status === "ready") {
+   *   console.log(projection.nodes[0]?.x, projection.nodes[0]?.y);
+   * }
+   * ```
+   */
+  async getEmbeddingProjection(opts?: {
+    readonly dimensions?: 2 | 3;
+  }): Promise<EmbeddingProjectionResponse> {
+    return this.transport.get<EmbeddingProjectionResponse>(
+      "/api/embeddings/projection",
+      { dimensions: opts?.dimensions },
+    );
+  }
+
+  // --- Harnesses ---
+
+  /**
+   * List all harnesses.
+   *
+   * @example
+   * ```typescript
+   * const harnesses = await client.listHarnesses();
+   * console.log(harnesses.harnesses.filter(h => h.exists));
+   * ```
+   */
+  async listHarnesses(): Promise<HarnessListResponse> {
+    return this.transport.get<HarnessListResponse>("/api/harnesses");
+  }
+
+  /**
+   * Regenerate harness configs.
+   *
+   * @example
+   * ```typescript
+   * const result = await client.regenerateHarnesses();
+   * if (result.success) {
+   *   console.log("Harnesses regenerated");
+   * }
+   * ```
+   */
+  async regenerateHarnesses(): Promise<HarnessRegenerateResponse> {
+    return this.transport.post<HarnessRegenerateResponse>(
+      "/api/harnesses/regenerate",
+      {},
+    );
+  }
+
+  // --- Checkpoints ---
+
+  /**
+   * List checkpoints by project.
+   *
+   * @example
+   * ```typescript
+   * const checkpoints = await client.listCheckpoints({
+   *   project: "/home/user/myproject",
+   *   limit: 10
+   * });
+   * console.log(checkpoints.count);
+   * ```
+   */
+  async listCheckpoints(opts: {
+    readonly project: string;
+    readonly limit?: number;
+  }): Promise<CheckpointListResponse> {
+    return this.transport.get<CheckpointListResponse>("/api/checkpoints", {
+      project: opts.project,
+      limit: opts.limit,
+    });
+  }
+
+  /**
+   * List checkpoints by session.
+   *
+   * @example
+   * ```typescript
+   * const checkpoints = await client.listSessionCheckpoints("sess-abc-123");
+   * console.log(checkpoints.checkpoints[0].checkpointType);
+   * ```
+   */
+  async listSessionCheckpoints(
+    sessionKey: string,
+  ): Promise<CheckpointListResponse> {
+    return this.transport.get<CheckpointListResponse>(
+      `/api/checkpoints/${sessionKey}`,
+    );
+  }
+
+  // --- Misc ---
+
+  /**
+   * Get feature flags.
+   *
+   * @example
+   * ```typescript
+   * const features = await client.getFeatures();
+   * console.log(features.graphEnabled);
+   * ```
+   */
+  async getFeatures(): Promise<FeaturesResponse> {
+    return this.transport.get<FeaturesResponse>("/api/features");
+  }
+
+  /**
+   * Get home greeting.
+   *
+   * @example
+   * ```typescript
+   * const greeting = await client.getGreeting();
+   * console.log(greeting.greeting);
+   * ```
+   */
+  async getGreeting(): Promise<GreetingResponse> {
+    return this.transport.get<GreetingResponse>("/api/home/greeting");
+  }
+
+  // --- Sessions ---
+
+  /**
+   * List all active sessions.
+   *
+   * @example
+   * ```typescript
+   * const { sessions } = await client.listSessions();
+   * console.log(sessions.filter(s => s.bypassed));
+   * ```
+   */
+  async listSessions(): Promise<SessionListResponse> {
+    return this.transport.get<SessionListResponse>("/api/sessions");
+  }
+
+  /**
+   * Get a single session by key.
+   *
+   * @example
+   * ```typescript
+   * const session = await client.getSession("sess-abc-123");
+   * console.log(session.runtimePath, session.bypassed);
+   * ```
+   */
+  async getSession(key: string): Promise<SessionInfo> {
+    return this.transport.get<SessionInfo>(`/api/sessions/${key}`);
+  }
+
+  /**
+   * Toggle bypass for a session.
+   *
+   * @example
+   * ```typescript
+   * await client.setSessionBypass("sess-abc-123", true);
+   * const session = await client.getSession("sess-abc-123");
+   * console.log(session.bypassed); // true
+   * ```
+   */
+  async setSessionBypass(key: string, enabled: boolean): Promise<{ key: string; bypassed: boolean }> {
+    return this.transport.post<{ key: string; bypassed: boolean }>(
+      `/api/sessions/${key}/bypass`,
+      { enabled },
+    );
+  }
+
+  // --- Git Sync ---
+
+  /**
+   * Get git status.
+   *
+   * @example
+   * ```typescript
+   * const status = await client.getGitStatus();
+   * console.log(status.isRepo, status.branch, status.hasCredentials);
+   * ```
+   */
+  async getGitStatus(): Promise<GitStatus> {
+    return this.transport.get<GitStatus>("/api/git/status");
+  }
+
+  /**
+   * Pull changes from remote.
+   *
+   * @example
+   * ```typescript
+   * const result = await client.gitPull();
+   * console.log(result.success, result.changes);
+   * ```
+   */
+  async gitPull(): Promise<GitPullResult> {
+    return this.transport.post<GitPullResult>("/api/git/pull", {});
+  }
+
+  /**
+   * Push changes to remote.
+   *
+   * @example
+   * ```typescript
+   * const result = await client.gitPush();
+   * console.log(result.success, result.changes);
+   * ```
+   */
+  async gitPush(): Promise<GitPushResult> {
+    return this.transport.post<GitPushResult>("/api/git/push", {});
+  }
+
+  /**
+   * Full sync (pull + push).
+   *
+   * @example
+   * ```typescript
+   * const result = await client.gitSync();
+   * console.log(result.pulled, result.pushed);
+   * ```
+   */
+  async gitSync(): Promise<GitSyncResult> {
+    return this.transport.post<GitSyncResult>("/api/git/sync", {});
+  }
+
+  /**
+   * Get git configuration.
+   *
+   * @example
+   * ```typescript
+   * const config = await client.getGitConfig();
+   * console.log(config.autoSync, config.branch, config.remote);
+   * ```
+   */
+  async getGitConfig(): Promise<GitConfig> {
+    return this.transport.get<GitConfig>("/api/git/config");
+  }
+
+  /**
+   * Update git configuration.
+   *
+   * @example
+   * ```typescript
+   * await client.updateGitConfig({
+   *   autoSync: true,
+   *   syncInterval: 300
+   * });
+   * ```
+   */
+  async updateGitConfig(patch: Partial<GitConfig>): Promise<{ success: boolean; config: GitConfig }> {
+    return this.transport.post<{ success: boolean; config: GitConfig }>(
+      "/api/git/config",
+      patch,
+    );
+  }
+
+  // --- Tasks/Scheduler ---
+
+  /**
+   * List all scheduled tasks.
+   *
+   * @example
+   * ```typescript
+   * const { tasks, presets } = await client.listTasks();
+   * console.log(tasks.filter(t => t.enabled));
+   * console.log(presets["@hourly"]); // "0 * * * *"
+   * ```
+   */
+  async listTasks(): Promise<TaskListResponse> {
+    return this.transport.get<TaskListResponse>("/api/tasks");
+  }
+
+  /**
+   * Create a new scheduled task.
+   *
+   * @example
+   * ```typescript
+   * const result = await client.createTask({
+   *   name: "Daily Report",
+   *   prompt: "Generate daily report",
+   *   cronExpression: "0 9 * * *",
+   *   harness: "claude-code"
+   * });
+   * console.log(result.id, result.nextRunAt);
+   * ```
+   */
+  async createTask(payload: TaskCreatePayload): Promise<TaskCreateResult> {
+    return this.transport.post<TaskCreateResult>("/api/tasks", payload);
+  }
+
+  /**
+   * Get a single task with recent runs.
+   *
+   * @example
+   * ```typescript
+   * const { task, runs } = await client.getTask("task-abc-123");
+   * console.log(task.name, runs[0]?.status);
+   * ```
+   */
+  async getTask(id: string): Promise<TaskGetResponse> {
+    return this.transport.get<TaskGetResponse>(`/api/tasks/${id}`);
+  }
+
+  /**
+   * Update a task.
+   *
+   * @example
+   * ```typescript
+   * await client.updateTask("task-abc-123", {
+   *   enabled: false,
+   *   prompt: "Updated prompt"
+   * });
+   * ```
+   */
+  async updateTask(id: string, patch: TaskUpdatePayload): Promise<{ success: boolean }> {
+    return this.transport.patch<{ success: boolean }>(`/api/tasks/${id}`, patch);
+  }
+
+  /**
+   * Delete a task.
+   *
+   * @example
+   * ```typescript
+   * await client.deleteTask("task-abc-123");
+   * ```
+   */
+  async deleteTask(id: string): Promise<{ success: boolean }> {
+    return this.transport.del<{ success: boolean }>(`/api/tasks/${id}`);
+  }
+
+  /**
+   * Trigger an immediate task run.
+   *
+   * @example
+   * ```typescript
+   * const result = await client.runTask("task-abc-123");
+   * console.log(result.runId, result.status);
+   * ```
+   */
+  async runTask(id: string): Promise<{ runId: string; status: "running" }> {
+    return this.transport.post<{ runId: string; status: "running" }>(
+      `/api/tasks/${id}/run`,
+      {},
+    );
+  }
+
+  /**
+   * Get paginated run history for a task.
+   *
+   * @example
+   * ```typescript
+   * const runs = await client.listTaskRuns("task-abc-123", { limit: 20, offset: 0 });
+   * console.log(runs.runs.length, runs.total, runs.hasMore);
+   * ```
+   */
+  async listTaskRuns(id: string, opts?: {
+    readonly limit?: number;
+    readonly offset?: number;
+  }): Promise<TaskRunListResponse> {
+    return this.transport.get<TaskRunListResponse>(`/api/tasks/${id}/runs`, {
+      limit: opts?.limit,
+      offset: opts?.offset,
+    });
+  }
+
+  // --- Secrets ---
+
+  /**
+   * List secret names (never values).
+   *
+   * @example
+   * ```typescript
+   * const { secrets } = await client.listSecrets();
+   * console.log(secrets); // ["GITHUB_TOKEN", "OPENAI_API_KEY"]
+   * ```
+   */
+  async listSecrets(): Promise<SecretListResponse> {
+    return this.transport.get<SecretListResponse>("/api/secrets");
+  }
+
+  /**
+   * Store a secret.
+   *
+   * @example
+   * ```typescript
+   * await client.storeSecret("MY_API_KEY", "sk-abc123");
+   * ```
+   */
+  async storeSecret(name: string, value: string): Promise<{ success: boolean; name: string }> {
+    return this.transport.post<{ success: boolean; name: string }>(
+      `/api/secrets/${name}`,
+      { value },
+    );
+  }
+
+  /**
+   * Delete a secret.
+   *
+   * @example
+   * ```typescript
+   * await client.deleteSecret("MY_API_KEY");
+   * ```
+   */
+  async deleteSecret(name: string): Promise<{ success: boolean; name: string }> {
+    return this.transport.del<{ success: boolean; name: string }>(
+      `/api/secrets/${name}`,
+    );
+  }
+
+  /**
+   * Execute a command with secrets injected as env vars.
+   *
+   * @example
+   * ```typescript
+   * const result = await client.execWithSecrets("echo $GREETING", {
+   *   GREETING: "MY_SECRET"
+   * });
+   * console.log(result.stdout, result.code);
+   * ```
+   */
+  async execWithSecrets(
+    command: string,
+    secrets: Record<string, string>,
+  ): Promise<SecretExecResult> {
+    return this.transport.post<SecretExecResult>("/api/secrets/exec", {
+      command,
+      secrets,
+    });
+  }
+
+  /**
+   * Get 1Password connection status.
+   *
+   * @example
+   * ```typescript
+   * const status = await client.getOnePasswordStatus();
+   * console.log(status.configured, status.connected, status.vaultCount);
+   * ```
+   */
+  async getOnePasswordStatus(): Promise<OnePasswordStatus> {
+    return this.transport.get<OnePasswordStatus>("/api/secrets/1password/status");
+  }
+
+  /**
+   * Connect 1Password service account.
+   *
+   * @example
+   * ```typescript
+   * const result = await client.connectOnePassword("ops_token_abc123");
+   * console.log(result.vaultCount);
+   * ```
+   */
+  async connectOnePassword(token: string): Promise<OnePasswordConnectResult> {
+    return this.transport.post<OnePasswordConnectResult>(
+      "/api/secrets/1password/connect",
+      { token },
+    );
+  }
+
+  /**
+   * Disconnect 1Password service account.
+   *
+   * @example
+   * ```typescript
+   * await client.disconnectOnePassword();
+   * ```
+   */
+  async disconnectOnePassword(): Promise<{ success: boolean; disconnected: boolean; existed: boolean }> {
+    return this.transport.del<{ success: boolean; disconnected: boolean; existed: boolean }>(
+      "/api/secrets/1password/connect",
+    );
+  }
+
+  /**
+   * List 1Password vaults.
+   *
+   * @example
+   * ```typescript
+   * const { vaults } = await client.listOnePasswordVaults();
+   * console.log(vaults.map(v => v.name));
+   * ```
+   */
+  async listOnePasswordVaults(): Promise<{ vaults: readonly { readonly id: string; readonly name: string }[]; count: number }> {
+    return this.transport.get<{ vaults: readonly { readonly id: string; readonly name: string }[]; count: number }>(
+      "/api/secrets/1password/vaults",
+    );
+  }
+
+  /**
+   * Import secrets from 1Password.
+   *
+   * @example
+   * ```typescript
+   * const result = await client.importOnePasswordSecrets({
+   *   vaults: ["Private", "Work"],
+   *   prefix: "OP",
+   *   overwrite: false
+   * });
+   * console.log(result.importedCount);
+   * ```
+   */
+  async importOnePasswordSecrets(opts: {
+    readonly token?: string;
+    readonly vaults?: readonly string[];
+    readonly prefix?: string;
+    readonly overwrite?: boolean;
+  }): Promise<OnePasswordImportResult> {
+    return this.transport.post<OnePasswordImportResult>(
+      "/api/secrets/1password/import",
+      opts,
+    );
+  }
+
+  // --- Skills ---
+
+  /**
+   * List installed skills.
+   *
+   * @example
+   * ```typescript
+   * const { skills } = await client.listSkills();
+   * console.log(skills.map(s => s.name));
+   * ```
+   */
+  async listSkills(): Promise<SkillListResponse> {
+    return this.transport.get<SkillListResponse>("/api/skills");
+  }
+
+  /**
+   * Browse available skills.
+   *
+   * @example
+   * ```typescript
+   * const { results, total } = await client.browseSkills();
+   * console.log(results.filter(r => r.installed));
+   * ```
+   */
+  async browseSkills(): Promise<SkillBrowseResponse> {
+    return this.transport.get<SkillBrowseResponse>("/api/skills/browse");
+  }
+
+  /**
+   * Search skills by query.
+   *
+   * @example
+   * ```typescript
+   * const { results } = await client.searchSkills("git");
+   * console.log(results[0].name, results[0].description);
+   * ```
+   */
+  async searchSkills(query: string): Promise<SkillSearchResponse> {
+    return this.transport.get<SkillSearchResponse>("/api/skills/search", { q: query });
+  }
+
+  /**
+   * Get skill details.
+   *
+   * @example
+   * ```typescript
+   * const skill = await client.getSkill("signet-design");
+   * console.log(skill.description, skill.content);
+   * ```
+   */
+  async getSkill(name: string, source?: string): Promise<SkillGetResponse> {
+    return this.transport.get<SkillGetResponse>(`/api/skills/${name}`, {
+      source,
+    });
+  }
+
+  /**
+   * Install a skill.
+   *
+   * @example
+   * ```typescript
+   * const result = await client.installSkill("signet-design");
+   * console.log(result.success);
+   * ```
+   */
+  async installSkill(name: string, source?: string): Promise<SkillInstallResult> {
+    return this.transport.post<SkillInstallResult>("/api/skills/install", {
+      name,
+      source,
+    });
+  }
+
+  /**
+   * Uninstall a skill.
+   *
+   * @example
+   * ```typescript
+   * const result = await client.uninstallSkill("signet-design");
+   * console.log(result.message);
+   * ```
+   */
+  async uninstallSkill(name: string): Promise<SkillDeleteResult> {
+    return this.transport.del<SkillDeleteResult>(`/api/skills/${name}`);
+  }
 }
+
+export interface SignetClient extends SignetClientP2 {}
+Object.assign(SignetClient.prototype, SignetClientP2.prototype);
 
 /** @deprecated Use SignetClient instead */
 export const SignetSDK = SignetClient;
@@ -329,25 +1157,70 @@ export {
 export type {
   BatchModifyItemResult,
   BatchModifyResponse,
+  CheckpointListResponse,
+  ConfigListResponse,
+  ConfigWriteResponse,
   DeleteResult,
   DocumentChunksResponse,
   DocumentCreateResult,
   DocumentDeleteResult,
   DocumentListResponse,
   DocumentRecord,
+  EmbeddingHealthResponse,
+  EmbeddingProjectionResponse,
+  EmbeddingStatusResponse,
+  FeaturesResponse,
   ForgetExecuteResponse,
   ForgetPreviewResponse,
   ForgetResponse,
+  GitConfig,
+  GitPullResult,
+  GitPushResult,
+  GitStatus,
+  GitSyncResult,
+  GreetingResponse,
+  HarnessListResponse,
+  HarnessRegenerateResponse,
   HealthResponse,
   HistoryEvent,
   HistoryResponse,
+  IdentityResponse,
   JobStatus,
   MemoryListResponse,
   MemoryRecord,
   ModifyResult,
+  OnePasswordConnectResult,
+  OnePasswordImportResult,
+  OnePasswordStatus,
+  PipelineStatusResponse,
   RecallResponse,
   RecallResult,
   RecoverResult,
   RememberResult,
+  SecretExecResult,
+  SecretListResponse,
+  SessionInfo,
+  SessionListResponse,
+  SkillBrowseResponse,
+  SkillBrowseResult,
+  SkillDeleteResult,
+  SkillGetResponse,
+  SkillInstallResult,
+  SkillListResponse,
+  SkillMeta,
+  SkillSearchResponse,
   StatusResponse,
+  TaskCreatePayload,
+  TaskCreateResult,
+  TaskGetResponse,
+  TaskListResponse,
+  TaskRecord,
+  TaskRun,
+  TaskRunListResponse,
+  TaskUpdatePayload,
+  TelemetryEventsResponse,
+  TelemetryStatsResponse,
+  TimelineExportResponse,
+  TimelineResponse,
+  InstalledSkill,
 } from "./types.js";

--- a/packages/sdk/src/transport.ts
+++ b/packages/sdk/src/transport.ts
@@ -69,16 +69,11 @@ export class SignetTransport {
         });
 
         if (!response.ok) {
-          let body: unknown;
-          try {
-            body = await response.json();
-          } catch {
-            body = await response.text().catch(() => null);
-          }
+          const body = await parseResponseBody(response);
           throw new SignetApiError(response.status, body);
         }
 
-        return (await response.json()) as T;
+        return await parseResponseBody<T>(response);
       } catch (error) {
         if (error instanceof SignetApiError) {
           // API errors are not retryable
@@ -144,4 +139,35 @@ export class SignetTransport {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isJsonContentType(contentType: string | null): boolean {
+  if (!contentType) return false;
+  const normalized = contentType.toLowerCase();
+  return (
+    normalized.includes("application/json")
+    || normalized.includes("+json")
+  );
+}
+
+async function parseResponseBody<T = unknown>(response: Response): Promise<T> {
+  if (response.status === 204 || response.status === 205) {
+    return undefined as T;
+  }
+
+  const text = await response.text();
+  if (text.length === 0) {
+    return undefined as T;
+  }
+
+  if (isJsonContentType(response.headers.get("content-type"))) {
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      // Some endpoints mislabel text as JSON; return raw to avoid masking payloads.
+      return text as T;
+    }
+  }
+
+  return text as T;
 }

--- a/packages/sdk/src/types-p2.ts
+++ b/packages/sdk/src/types-p2.ts
@@ -183,11 +183,11 @@ export interface ContinuityResponse {
 }
 
 export interface ContinuityLatestResponse {
-  readonly scores: Array<{
+  readonly scores: readonly {
     readonly project: string;
     readonly score: number;
     readonly created_at: string;
-  }>;
+  }[];
 }
 
 // ============================================================================

--- a/packages/sdk/src/types-p2.ts
+++ b/packages/sdk/src/types-p2.ts
@@ -1,0 +1,453 @@
+// P2 domain types for the Signet daemon HTTP API.
+// These types cover Hooks, Connectors, Analytics, Knowledge Graph, Repair, Cross-Agent, and Predictor domains.
+
+// ============================================================================
+// Hooks types
+// ============================================================================
+
+export interface SessionStartResponse {
+  readonly context: string;
+  readonly sessionId: string;
+}
+
+export interface UserPromptSubmitResponse {
+  readonly context: string;
+}
+
+export interface SessionEndResponse {
+  readonly message: string;
+}
+
+export interface PreCompactionResponse {
+  readonly instructions: string;
+}
+
+export interface CompactionCompleteResponse {
+  readonly message: string;
+}
+
+export interface SynthesisConfigResponse {
+  readonly enabled: boolean;
+  readonly model?: string;
+  readonly interval?: string;
+  readonly lastRun?: string;
+}
+
+export interface SynthesisRequestResponse {
+  readonly message: string;
+  readonly triggered: boolean;
+}
+
+export interface SynthesisCompleteResponse {
+  readonly message: string;
+}
+
+// ============================================================================
+// Connectors types
+// ============================================================================
+
+export interface ConnectorRecord {
+  readonly id: string;
+  readonly provider: string;
+  readonly displayName: string;
+  readonly enabled: boolean;
+  readonly configJson: string;
+  readonly cursorJson: string | null;
+  readonly status: string;
+  readonly lastSync: string | null;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface ConnectorListResponse {
+  readonly connectors: readonly ConnectorRecord[];
+  readonly count: number;
+}
+
+export interface ConnectorCreateResponse {
+  readonly id: string;
+}
+
+export interface ConnectorSyncResponse {
+  readonly status: string;
+  readonly message?: string;
+}
+
+export interface ConnectorResyncResponse {
+  readonly status: string;
+  readonly total: number;
+  readonly started: number;
+  readonly alreadySyncing: number;
+  readonly unsupported: number;
+  readonly failed: number;
+}
+
+export interface ConnectorDeleteResponse {
+  readonly deleted: boolean;
+}
+
+export interface ConnectorHealthResponse {
+  readonly id: string;
+  readonly status: string;
+  readonly lastSync?: string;
+  readonly documentsCount?: number;
+  readonly memoriesCount?: number;
+  readonly error?: string;
+}
+
+// ============================================================================
+// Analytics types
+// ============================================================================
+
+export interface UsageCountersResponse {
+  readonly requests: Record<string, number>;
+  readonly errors: Record<string, number>;
+  readonly period: {
+    readonly start: string;
+    readonly end: string;
+  };
+}
+
+export interface ErrorEvent {
+  readonly timestamp: string;
+  readonly stage: string;
+  readonly operation: string;
+  readonly error: string;
+  readonly code?: string;
+  readonly actor?: string;
+}
+
+export interface ErrorsResponse {
+  readonly errors: readonly ErrorEvent[];
+  readonly summary: Record<string, number>;
+}
+
+export interface LatencyHistogram {
+  readonly p50: number;
+  readonly p95: number;
+  readonly p99: number;
+  readonly count: number;
+}
+
+export interface LatencyResponse {
+  readonly remember: LatencyHistogram;
+  readonly recall: LatencyHistogram;
+  readonly mutate: LatencyHistogram;
+  readonly predictor_score?: LatencyHistogram;
+  readonly predictor_train?: LatencyHistogram;
+}
+
+export interface LogEntry {
+  readonly timestamp: string;
+  readonly level: string;
+  readonly category: string;
+  readonly message: string;
+  readonly meta?: Record<string, unknown>;
+}
+
+export interface LogsResponse {
+  readonly logs: readonly LogEntry[];
+  readonly count: number;
+}
+
+export interface MemorySafetyResponse {
+  readonly mutation: {
+    readonly healthScore: number;
+    readonly status: string;
+  };
+  readonly recentErrors: readonly ErrorEvent[];
+  readonly errorSummary: Record<string, number>;
+}
+
+export interface ContinuityScore {
+  readonly id: string;
+  readonly session_key: string;
+  readonly project: string | null;
+  readonly harness: string | null;
+  readonly score: number;
+  readonly memories_recalled: number;
+  readonly memories_used: number;
+  readonly novel_context_count: number;
+  readonly reasoning: string | null;
+  readonly created_at: string;
+}
+
+export interface ContinuityResponse {
+  readonly scores: readonly ContinuityScore[];
+  readonly summary: {
+    readonly count: number;
+    readonly average: number;
+    readonly trend: number;
+    readonly latest: number | null;
+  };
+}
+
+export interface ContinuityLatestResponse {
+  readonly scores: Array<{
+    readonly project: string;
+    readonly score: number;
+    readonly created_at: string;
+  }>;
+}
+
+// ============================================================================
+// Knowledge Graph types
+// ============================================================================
+
+export interface KnowledgeEntity {
+  readonly id: string;
+  readonly agentId: string;
+  readonly type: string;
+  readonly name: string;
+  readonly canonical: string;
+  readonly description: string | null;
+  readonly pinnedAt: string | null;
+  readonly mentionCount: number;
+  readonly aspectCount: number;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface KnowledgeEntityDetail {
+  readonly entity: KnowledgeEntity;
+  readonly aspects: readonly {
+    readonly id: string;
+    readonly label: string;
+    readonly mentionCount: number;
+  }[];
+}
+
+export interface KnowledgeEntityListResponse {
+  readonly items: readonly KnowledgeEntity[];
+  readonly limit: number;
+  readonly offset: number;
+}
+
+export interface PinEntityResponse {
+  readonly pinned: boolean;
+  readonly pinnedAt: string;
+}
+
+export interface UnpinEntityResponse {
+  readonly pinned: boolean;
+}
+
+export interface EntityAspect {
+  readonly id: string;
+  readonly label: string;
+  readonly mentionCount: number;
+}
+
+export interface EntityAspectsResponse {
+  readonly items: readonly EntityAspect[];
+}
+
+export interface AspectAttribute {
+  readonly id: string;
+  readonly kind: string;
+  readonly valueText: string;
+  readonly status: string;
+  readonly createdAt: string;
+}
+
+export interface AspectAttributesResponse {
+  readonly items: readonly AspectAttribute[];
+  readonly limit: number;
+  readonly offset: number;
+}
+
+export interface EntityDependency {
+  readonly entityId: string;
+  readonly entityName: string;
+  readonly entityType: string;
+  readonly aspectLabel: string;
+  readonly relationType: string;
+}
+
+export interface EntityDependenciesResponse {
+  readonly entityId: string;
+  readonly dependencies: readonly EntityDependency[];
+}
+
+export interface KnowledgeStatsResponse {
+  readonly entities: number;
+  readonly aspects: number;
+  readonly attributes: number;
+  readonly mentions: number;
+  readonly pinnedEntities: number;
+}
+
+export interface TraversalStatusResponse {
+  readonly valid: boolean;
+  readonly computedAt: string | null;
+  readonly entityCount: number;
+  readonly relationCount: number;
+}
+
+export interface ConstellationNode {
+  readonly id: string;
+  readonly type: string;
+  readonly name: string;
+  readonly x: number;
+  readonly y: number;
+  readonly z?: number;
+  readonly size: number;
+  readonly mentionCount: number;
+}
+
+export interface ConstellationEdge {
+  readonly source: string;
+  readonly target: string;
+  readonly weight: number;
+  readonly relationType: string;
+}
+
+export interface ConstellationResponse {
+  readonly nodes: readonly ConstellationNode[];
+  readonly edges: readonly ConstellationEdge[];
+}
+
+// ============================================================================
+// Repair types
+// ============================================================================
+
+export interface RepairActionResponse {
+  readonly action: string;
+  readonly success: boolean;
+  readonly affected: number;
+  readonly message?: string;
+}
+
+export interface EmbeddingGapsResponse {
+  readonly total: number;
+  readonly unembedded: number;
+  readonly oldestUnembedded: string | null;
+}
+
+export interface DedupStatsResponse {
+  readonly total: number;
+  readonly duplicates: number;
+  readonly candidates: number;
+}
+
+export interface DeduplicateResponse extends RepairActionResponse {
+  readonly duplicatesRemoved: number;
+}
+
+// ============================================================================
+// Cross-Agent types
+// ============================================================================
+
+export interface AgentPresence {
+  readonly agentId: string;
+  readonly sessionKey: string;
+  readonly project: string | null;
+  readonly harness: string;
+  readonly runtimePath: string | null;
+  readonly lastSeen: string;
+  readonly createdAt: string;
+}
+
+export interface AgentPresenceListResponse {
+  readonly sessions: readonly AgentPresence[];
+  readonly count: number;
+}
+
+export interface AgentPresenceUpdateResponse {
+  readonly agentId: string;
+  readonly sessionKey: string;
+  readonly created: boolean;
+}
+
+export interface AgentMessage {
+  readonly id: string;
+  readonly fromAgentId: string;
+  readonly fromSessionKey: string | null;
+  readonly toAgentId: string;
+  readonly toSessionKey: string | null;
+  readonly type: string;
+  readonly content: string;
+  readonly broadcast: boolean;
+  readonly createdAt: string;
+}
+
+export interface AgentMessageListResponse {
+  readonly messages: readonly AgentMessage[];
+  readonly count: number;
+}
+
+export interface AgentMessageSendResponse {
+  readonly id: string;
+  readonly created: boolean;
+}
+
+// ============================================================================
+// Predictor types
+// ============================================================================
+
+export interface PredictorStatusResponse {
+  readonly enabled: boolean;
+  readonly alive: boolean;
+  readonly crashCount: number;
+  readonly crashDisabled: boolean;
+  readonly status: {
+    readonly modelVersion: number;
+    readonly trainingSessions: number;
+    readonly lastTrainedAt: string | null;
+    readonly coldStartExited: boolean;
+    readonly successRate: number;
+  } | null;
+}
+
+export interface PredictorComparison {
+  readonly id: string;
+  readonly memoryId: string;
+  readonly agentId: string;
+  readonly predictedScore: number;
+  readonly actualScore: number | null;
+  readonly feedbackType: string | null;
+  readonly createdAt: string;
+}
+
+export interface ComparisonsByProjectResponse {
+  readonly project: string;
+  readonly comparisons: readonly PredictorComparison[];
+  readonly count: number;
+}
+
+export interface ComparisonsByEntityResponse {
+  readonly entityId: string;
+  readonly comparisons: readonly PredictorComparison[];
+  readonly count: number;
+}
+
+export interface ComparisonsListResponse {
+  readonly comparisons: readonly PredictorComparison[];
+  readonly total: number;
+  readonly limit: number;
+  readonly offset: number;
+}
+
+export interface TrainingRun {
+  readonly id: string;
+  readonly agentId: string;
+  readonly modelVersion: number;
+  readonly samplesUsed: number;
+  readonly accuracyBefore: number | null;
+  readonly accuracyAfter: number | null;
+  readonly trainedAt: string;
+}
+
+export interface TrainingRunsResponse {
+  readonly runs: readonly TrainingRun[];
+  readonly count: number;
+}
+
+export interface TrainingPairsCountResponse {
+  readonly count: number;
+}
+
+export interface TrainPredictorResponse {
+  readonly message: string;
+  readonly triggered: boolean;
+}

--- a/packages/sdk/src/types-p2.ts
+++ b/packages/sdk/src/types-p2.ts
@@ -182,12 +182,14 @@ export interface ContinuityResponse {
   };
 }
 
+export interface ContinuityLatestScore {
+  readonly project: string;
+  readonly score: number;
+  readonly created_at: string;
+}
+
 export interface ContinuityLatestResponse {
-  readonly scores: readonly {
-    readonly project: string;
-    readonly score: number;
-    readonly created_at: string;
-  }[];
+  readonly scores: readonly ContinuityLatestScore[];
 }
 
 // ============================================================================
@@ -210,11 +212,7 @@ export interface KnowledgeEntity {
 
 export interface KnowledgeEntityDetail {
   readonly entity: KnowledgeEntity;
-  readonly aspects: readonly {
-    readonly id: string;
-    readonly label: string;
-    readonly mentionCount: number;
-  }[];
+  readonly aspects: readonly EntityAspect[];
 }
 
 export interface KnowledgeEntityListResponse {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -209,32 +209,54 @@ export interface DocumentDeleteResult {
 
 // Job types
 
-export interface JobStatus {
+type JobStatusBase = {
   readonly id: string;
   readonly memory_id: string | null;
-  readonly document_id?: string | null;
+  readonly document_id: string | null;
   readonly job_type: string;
-  readonly status:
-    | "pending"
-    | "leased"
-    | "retry_scheduled"
-    | "failed"
-    | "completed"
-    | "done"
-    | "dead";
-  readonly attempt_count?: number;
-  readonly attempts?: number;
   readonly max_attempts: number;
   readonly next_attempt_at: string | null;
-  readonly last_error?: string | null;
-  readonly last_error_code?: string | null;
-  readonly error?: string | null;
   readonly created_at: string;
   readonly updated_at: string;
-  readonly leased_at?: string | null;
-  readonly completed_at?: string | null;
-  readonly failed_at?: string | null;
-}
+};
+
+export type JobStatus =
+  | (JobStatusBase & {
+      readonly status: "pending";
+    })
+  | (JobStatusBase & {
+      readonly status: "leased";
+      readonly attempts: number;
+      readonly leased_at: string;
+    })
+  | (JobStatusBase & {
+      readonly status: "retry_scheduled";
+      readonly attempts: number;
+      readonly next_attempt_at: string;
+    })
+  | (JobStatusBase & {
+      readonly status: "failed";
+      readonly attempts: number;
+      readonly failed_at: string;
+      readonly error: string;
+      readonly last_error_code?: string;
+    })
+  | (JobStatusBase & {
+      readonly status: "completed";
+      readonly attempts: number;
+      readonly completed_at: string;
+    })
+  | (JobStatusBase & {
+      readonly status: "done";
+      readonly attempts: number;
+      readonly completed_at: string;
+    })
+  | (JobStatusBase & {
+      readonly status: "dead";
+      readonly attempts: number;
+      readonly failed_at: string;
+      readonly error: string;
+    });
 
 // Health / status types
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -180,6 +180,7 @@ export interface DocumentCreateResult {
   readonly id: string;
   readonly status: string;
   readonly deduplicated?: boolean;
+  readonly jobId?: string;
 }
 
 export interface DocumentListResponse {
@@ -210,16 +211,29 @@ export interface DocumentDeleteResult {
 
 export interface JobStatus {
   readonly id: string;
-  readonly memory_id: string;
+  readonly memory_id: string | null;
+  readonly document_id?: string | null;
   readonly job_type: string;
-  readonly status: "pending" | "leased" | "retry_scheduled" | "done" | "dead";
-  readonly attempt_count: number;
+  readonly status:
+    | "pending"
+    | "leased"
+    | "retry_scheduled"
+    | "failed"
+    | "completed"
+    | "done"
+    | "dead";
+  readonly attempt_count?: number;
+  readonly attempts?: number;
   readonly max_attempts: number;
   readonly next_attempt_at: string | null;
-  readonly last_error: string | null;
-  readonly last_error_code: string | null;
+  readonly last_error?: string | null;
+  readonly last_error_code?: string | null;
+  readonly error?: string | null;
   readonly created_at: string;
   readonly updated_at: string;
+  readonly leased_at?: string | null;
+  readonly completed_at?: string | null;
+  readonly failed_at?: string | null;
 }
 
 // Health / status types
@@ -261,3 +275,538 @@ export interface StatusResponse {
     readonly status: string;
   };
 }
+
+// Timeline types
+
+export interface TimelineEvent {
+  readonly id: string;
+  readonly entityType: string;
+  readonly entityId: string;
+  readonly event: string;
+  readonly timestamp: string;
+  readonly metadata?: Record<string, unknown>;
+}
+
+export interface TimelineResponse {
+  readonly events: readonly TimelineEvent[];
+}
+
+export interface TimelineExportResponse {
+  readonly meta: {
+    readonly version: string;
+    readonly exportedAt: string;
+    readonly entityId: string;
+  };
+  readonly timeline: TimelineResponse;
+}
+
+// Pipeline types
+
+export interface PipelineStatusResponse {
+  readonly workers: Record<string, unknown>;
+  readonly queues: {
+    readonly memory: Record<string, number>;
+    readonly summary: Record<string, number>;
+  };
+  readonly diagnostics: Record<string, unknown>;
+  readonly latency: Record<string, unknown>;
+  readonly errorSummary: Record<string, unknown>;
+  readonly mode: "disabled" | "frozen" | "shadow" | "controlled-write";
+  readonly feedback: Record<string, unknown>;
+  readonly traversal: {
+    readonly enabled: boolean;
+    readonly lastRun: string | null;
+  };
+  readonly predictor: {
+    readonly running: boolean;
+    readonly modelReady: boolean;
+    readonly coldStartExited: boolean;
+    readonly successRate: number;
+    readonly alpha: number;
+  };
+}
+
+// Telemetry types
+
+export interface TelemetryEvent {
+  readonly id: string;
+  readonly event: string;
+  readonly timestamp: string;
+  readonly properties: Record<string, unknown>;
+}
+
+export interface TelemetryEventsResponse {
+  readonly events: readonly TelemetryEvent[];
+  readonly enabled: boolean;
+}
+
+export interface TelemetryStatsDisabledResponse {
+  readonly enabled: false;
+}
+
+export interface TelemetryStatsEnabledResponse {
+  readonly enabled: true;
+  readonly totalEvents: number;
+  readonly llm: {
+    readonly calls: number;
+    readonly errors: number;
+    readonly totalInputTokens: number;
+    readonly totalOutputTokens: number;
+    readonly totalCost: number;
+    readonly p50: number;
+    readonly p95: number;
+  };
+  readonly pipelineErrors: number;
+}
+
+export type TelemetryStatsResponse =
+  | TelemetryStatsDisabledResponse
+  | TelemetryStatsEnabledResponse;
+
+// Config types
+
+export interface ConfigFile {
+  readonly name: string;
+  readonly content: string;
+  readonly size: number;
+}
+
+export interface ConfigListResponse {
+  readonly files: readonly ConfigFile[];
+  readonly error?: string;
+}
+
+export interface ConfigWriteResponse {
+  readonly success: boolean;
+  readonly error?: string;
+}
+
+// Identity types
+
+export interface IdentityResponse {
+  readonly name: string;
+  readonly creature: string;
+  readonly vibe: string;
+}
+
+// Embeddings types
+
+export interface EmbeddingStatusResponse {
+  readonly provider: "native" | "ollama" | "openai" | "none";
+  readonly model: string;
+  readonly available: boolean;
+  readonly dimensions?: number;
+  readonly base_url: string;
+  readonly error?: string;
+  readonly checkedAt: string;
+}
+
+export interface EmbeddingHealthResponse {
+  readonly healthy: boolean;
+  readonly totalMemories: number;
+  readonly embeddedCount: number;
+  readonly unembeddedCount: number;
+  readonly coveragePercent: number;
+}
+
+export interface EmbeddingProjectionNode {
+  readonly id: string;
+  readonly x: number;
+  readonly y: number;
+  readonly z?: number;
+  readonly [key: string]: unknown;
+}
+
+export interface EmbeddingProjectionEdge {
+  readonly source: string;
+  readonly target: string;
+  readonly [key: string]: unknown;
+}
+
+export interface EmbeddingProjectionReadyResponse {
+  readonly status: "ready";
+  readonly dimensions: 2 | 3;
+  readonly count: number;
+  readonly total: number;
+  readonly limit: number;
+  readonly offset: number;
+  readonly hasMore: boolean;
+  readonly nodes: readonly EmbeddingProjectionNode[];
+  readonly edges: readonly EmbeddingProjectionEdge[];
+  readonly cachedAt?: string;
+}
+
+export interface EmbeddingProjectionComputingResponse {
+  readonly status: "computing";
+  readonly dimensions: 2 | 3;
+}
+
+export interface EmbeddingProjectionErrorResponse {
+  readonly status: "error";
+  readonly message: string;
+}
+
+export type EmbeddingProjectionResponse =
+  | EmbeddingProjectionReadyResponse
+  | EmbeddingProjectionComputingResponse
+  | EmbeddingProjectionErrorResponse;
+
+// Harness types
+
+export interface Harness {
+  readonly name: string;
+  readonly id: string;
+  readonly path: string;
+  readonly exists: boolean;
+  readonly lastSeen: string | null;
+}
+
+export interface HarnessListResponse {
+  readonly harnesses: readonly Harness[];
+}
+
+export interface HarnessRegenerateResponse {
+  readonly success: boolean;
+  readonly message?: string;
+  readonly output?: string;
+  readonly error?: string;
+}
+
+// Checkpoint types
+
+export interface Checkpoint {
+  readonly id: string;
+  readonly sessionKey: string;
+  readonly project: string;
+  readonly checkpointType: string;
+  readonly createdAt: string;
+  readonly data: Record<string, unknown>;
+}
+
+export interface CheckpointListResponse {
+  readonly checkpoints: readonly Checkpoint[];
+  readonly count: number;
+}
+
+// Features types
+
+export interface FeaturesResponse {
+  readonly [key: string]: boolean | string | number;
+}
+
+// Greeting types
+
+export interface GreetingResponse {
+  readonly greeting: string;
+  readonly cachedAt: string;
+}
+
+// Session types
+
+export interface SessionInfo {
+  readonly key: string;
+  readonly runtimePath: "plugin" | "legacy";
+  readonly claimedAt: string;
+  readonly bypassed: boolean;
+}
+
+export interface SessionListResponse {
+  readonly sessions: readonly SessionInfo[];
+  readonly count: number;
+}
+
+// Git sync types
+
+export interface GitStatus {
+  readonly isRepo: boolean;
+  readonly branch?: string;
+  readonly remote?: string;
+  readonly hasCredentials: boolean;
+  readonly authMethod?: string;
+  readonly autoSync: boolean;
+  readonly lastSync?: string;
+  readonly uncommittedChanges?: number;
+  readonly unpushedCommits?: number;
+  readonly unpulledCommits?: number;
+}
+
+export interface GitPullResult {
+  readonly success: boolean;
+  readonly message: string;
+  readonly changes?: number;
+}
+
+export interface GitPushResult {
+  readonly success: boolean;
+  readonly message: string;
+  readonly changes?: number;
+}
+
+export interface GitSyncResult {
+  readonly success: boolean;
+  readonly message: string;
+  readonly pulled?: number;
+  readonly pushed?: number;
+}
+
+export interface GitConfig {
+  readonly autoSync: boolean;
+  readonly syncInterval: number;
+  readonly remote: string;
+  readonly branch: string;
+}
+
+// Task/scheduler types
+
+export interface TaskRecord {
+  readonly id: string;
+  readonly name: string;
+  readonly prompt: string;
+  readonly cron_expression: string;
+  readonly harness: string;
+  readonly working_directory: string | null;
+  readonly enabled: boolean;
+  readonly next_run_at: string | null;
+  readonly skill_name: string | null;
+  readonly skill_mode: string | null;
+  readonly last_run_at: string | null;
+  readonly created_at: string;
+  readonly updated_at: string;
+  readonly last_run_status?: string;
+  readonly last_run_exit_code?: number | null;
+}
+
+export interface TaskRun {
+  readonly id: string;
+  readonly task_id: string;
+  readonly status: string;
+  readonly exit_code: number | null;
+  readonly started_at: string;
+  readonly completed_at: string | null;
+  readonly error: string | null;
+}
+
+export interface TaskCreateResult {
+  readonly id: string;
+  readonly nextRunAt: string;
+}
+
+export interface TaskListResponse {
+  readonly tasks: readonly TaskRecord[];
+  readonly presets: Record<string, string>;
+}
+
+export interface TaskGetResponse {
+  readonly task: TaskRecord;
+  readonly runs: readonly TaskRun[];
+}
+
+export interface TaskRunListResponse {
+  readonly runs: readonly TaskRun[];
+  readonly total: number;
+  readonly hasMore: boolean;
+}
+
+export interface TaskUpdatePayload {
+  readonly name?: string;
+  readonly prompt?: string;
+  readonly cronExpression?: string;
+  readonly harness?: string;
+  readonly workingDirectory?: string;
+  readonly enabled?: boolean;
+  readonly skillName?: string;
+  readonly skillMode?: string;
+}
+
+export interface TaskCreatePayload {
+  readonly name: string;
+  readonly prompt: string;
+  readonly cronExpression: string;
+  readonly harness: string;
+  readonly workingDirectory?: string;
+  readonly skillName?: string;
+  readonly skillMode?: string;
+}
+
+// Secret types
+
+export interface SecretListResponse {
+  readonly secrets: readonly string[];
+}
+
+export interface SecretExecResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly code: number;
+}
+
+export interface OnePasswordStatus {
+  readonly configured: boolean;
+  readonly connected: boolean;
+  readonly vaultCount?: number;
+  readonly vaults: readonly { readonly id: string; readonly name: string }[];
+  readonly error?: string;
+}
+
+export interface OnePasswordConnectResult {
+  readonly success: boolean;
+  readonly connected: boolean;
+  readonly vaultCount: number;
+  readonly vaults: readonly { readonly id: string; readonly name: string }[];
+}
+
+export interface OnePasswordImportResult {
+  readonly success: boolean;
+  readonly vaultsScanned: number;
+  readonly itemsScanned: number;
+  readonly importedCount: number;
+  readonly errorCount: number;
+}
+
+// Skill types
+
+export interface SkillMeta {
+  readonly description: string;
+  readonly version?: string;
+  readonly author?: string;
+  readonly maintainer?: string;
+  readonly license?: string;
+  readonly user_invocable?: boolean;
+  readonly arg_hint?: string;
+  readonly verified?: boolean;
+  readonly permissions?: readonly string[];
+}
+
+export interface InstalledSkill {
+  readonly name: string;
+  readonly path: string;
+  readonly meta: SkillMeta;
+}
+
+export interface SkillListResponse {
+  readonly skills: readonly InstalledSkill[];
+  readonly count: number;
+}
+
+export interface SkillBrowseResult {
+  readonly name: string;
+  readonly fullName: string;
+  readonly installs: string;
+  readonly installsRaw: number;
+  readonly popularityScore: number;
+  readonly description: string;
+  readonly installed: boolean;
+  readonly provider: "skills.sh" | "clawhub";
+  readonly category: string;
+  readonly downloads?: number;
+  readonly maintainer?: string;
+  readonly stars?: number;
+  readonly versions?: number;
+  readonly author?: string;
+}
+
+export interface SkillBrowseResponse {
+  readonly results: readonly SkillBrowseResult[];
+  readonly total: number;
+}
+
+export interface SkillSearchResponse {
+  readonly results: readonly SkillBrowseResult[];
+}
+
+export interface SkillGetResponse extends SkillMeta {
+  readonly name: string;
+  readonly path?: string;
+  readonly content: string;
+}
+
+export interface SkillInstallResult {
+  readonly success: boolean;
+  readonly name: string;
+  readonly output?: string;
+  readonly error?: string;
+}
+
+export interface SkillDeleteResult {
+  readonly success: boolean;
+  readonly name: string;
+  readonly message: string;
+}
+
+// Re-export P2 domain types
+export type {
+  // Hooks
+  SessionStartResponse,
+  UserPromptSubmitResponse,
+  SessionEndResponse,
+  PreCompactionResponse,
+  CompactionCompleteResponse,
+  SynthesisConfigResponse,
+  SynthesisRequestResponse,
+  SynthesisCompleteResponse,
+
+  // Connectors
+  ConnectorRecord,
+  ConnectorListResponse,
+  ConnectorCreateResponse,
+  ConnectorSyncResponse,
+  ConnectorResyncResponse,
+  ConnectorDeleteResponse,
+  ConnectorHealthResponse,
+
+  // Analytics
+  UsageCountersResponse,
+  ErrorEvent,
+  ErrorsResponse,
+  LatencyHistogram,
+  LatencyResponse,
+  LogEntry,
+  LogsResponse,
+  MemorySafetyResponse,
+  ContinuityScore,
+  ContinuityResponse,
+  ContinuityLatestResponse,
+
+  // Knowledge Graph
+  KnowledgeEntity,
+  KnowledgeEntityDetail,
+  KnowledgeEntityListResponse,
+  PinEntityResponse,
+  UnpinEntityResponse,
+  EntityAspect,
+  EntityAspectsResponse,
+  AspectAttribute,
+  AspectAttributesResponse,
+  EntityDependency,
+  EntityDependenciesResponse,
+  KnowledgeStatsResponse,
+  TraversalStatusResponse,
+  ConstellationNode,
+  ConstellationEdge,
+  ConstellationResponse,
+
+  // Repair
+  RepairActionResponse,
+  EmbeddingGapsResponse,
+  DedupStatsResponse,
+  DeduplicateResponse,
+
+  // Cross-Agent
+  AgentPresence,
+  AgentPresenceListResponse,
+  AgentPresenceUpdateResponse,
+  AgentMessage,
+  AgentMessageListResponse,
+  AgentMessageSendResponse,
+
+  // Predictor
+  PredictorStatusResponse,
+  PredictorComparison,
+  ComparisonsByProjectResponse,
+  ComparisonsByEntityResponse,
+  ComparisonsListResponse,
+  TrainingRun,
+  TrainingRunsResponse,
+  TrainingPairsCountResponse,
+  TrainPredictorResponse,
+} from "./types-p2.js";


### PR DESCRIPTION
## Summary
- make SDK transport response parsing content-type aware so non-JSON responses (including NDJSON telemetry export) are handled correctly
- align SDK task, telemetry, embedding projection, document ingest, and job status contracts with current daemon responses
- add `SignetClientP2` mixin wiring in `index.ts` and extend SDK helper ergonomics (`waitForDocument`, terminal status handling, better 404 mapping)
- add daemon compatibility surface for SDK polling (`GET /api/memory/jobs/:id`) and return optional `jobId` from `POST /api/documents`
- repair and regenerate the SDK generated client by updating the generator to support `delete` routes and safe/deduplicated method naming
- update `docs/SDK.md` to match real SDK/daemon behavior and examples
- add/adjust focused SDK tests for transport, telemetry, tasks, embeddings, and helpers

## Validation
- `bun run --cwd packages/sdk build`
- `bun run --cwd packages/daemon build`
- `bun test packages/sdk/src/__tests__/openai.test.ts`
- `bun test packages/sdk/src/__tests__/transport.test.ts packages/sdk/src/__tests__/telemetry.test.ts packages/sdk/src/__tests__/tasks.test.ts packages/sdk/src/__tests__/embeddings.test.ts packages/sdk/src/__tests__/helpers.test.ts packages/sdk/src/__tests__/openai.test.ts`

Note: the multi-file SDK test run above fails in this sandbox because `Bun.serve({ port: 0 })` returns `EADDRINUSE`; this is an environment limitation, not an SDK runtime/build failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SDK: major public API expansion (new client surfaces, helpers, session/task/telemetry/embeddings/skills/secrets/checkpoints endpoints)
  * API: document creation may return an async jobId; new memory job lookup endpoint

* **Documentation**
  * Large “Sessions & Bypass” and expanded “Jobs” docs; documentCreate now notes optional jobId and new job statuses (failed, completed)

* **Tests**
  * Added comprehensive tests for embeddings, tasks, telemetry, helpers, and transport behavior

* **Chores**
  * Added client generation script and centralized response parsing for improved non-JSON handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->