### PR TITLE
fix: replace node:child_process with Bun.spawn for reliable subprocess I/O

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -149,7 +149,7 @@ export interface PipelineEscalationConfig {
 }
 
 export interface PipelineExtractionConfig {
-	readonly provider: "ollama" | "claude-code" | "opencode" | "codex";
+	readonly provider: "ollama" | "claude-code" | "opencode" | "codex" | "anthropic";
 	readonly model: string;
 	readonly timeout: number;
 	readonly minConfidence: number;
@@ -293,7 +293,7 @@ export interface PipelineEmbeddingTrackerConfig {
 
 export interface PipelineSynthesisConfig {
 	readonly enabled: boolean;
-	readonly provider: "ollama" | "claude-code" | "opencode";
+	readonly provider: "ollama" | "claude-code" | "opencode" | "anthropic";
 	readonly model: string;
 	readonly timeout: number;
 	readonly maxTokens: number;

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -9131,31 +9131,38 @@ async function main() {
 		}
 	}
 
+	// When falling back to ollama, reset model so ollama uses its own default
+	// instead of inheriting an anthropic-specific alias like "haiku".
+	let effectiveExtractionModel: string | undefined = memoryCfg.pipelineV2.extraction.model;
+	if (effectiveExtractionProvider === "ollama" && memoryCfg.pipelineV2.extraction.provider !== "ollama") {
+		effectiveExtractionModel = undefined;
+	}
+
 	// Create LLM provider once, register as daemon-wide singleton
 	const llmProvider =
 		effectiveExtractionProvider === "anthropic"
 			? createAnthropicProvider({
-					model: memoryCfg.pipelineV2.extraction.model || "haiku",
+					model: effectiveExtractionModel || "haiku",
 					apiKey: anthropicApiKey ?? "",
 					defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 				})
 			: effectiveExtractionProvider === "opencode"
 				? createOpenCodeProvider({
-						model: memoryCfg.pipelineV2.extraction.model || "anthropic/claude-haiku-4-5-20251001",
+						model: effectiveExtractionModel || "anthropic/claude-haiku-4-5-20251001",
 						defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 					})
 				: effectiveExtractionProvider === "claude-code"
 					? createClaudeCodeProvider({
-							model: memoryCfg.pipelineV2.extraction.model || "haiku",
+							model: effectiveExtractionModel || "haiku",
 							defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 						})
 					: effectiveExtractionProvider === "codex"
 						? createCodexProvider({
-								model: memoryCfg.pipelineV2.extraction.model || "gpt-5.3-codex",
+								model: effectiveExtractionModel || "gpt-5.3-codex",
 								defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 							})
 						: createOllamaProvider({
-								model: memoryCfg.pipelineV2.extraction.model || "qwen3:4b",
+								model: effectiveExtractionModel || "qwen3:4b",
 								defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 							});
 	initLlmProvider(llmProvider);
@@ -9194,25 +9201,31 @@ async function main() {
 		}
 		logger.info("config", "Synthesis provider", { provider: effectiveSynthesisProvider });
 
+		// When falling back to ollama, reset model so ollama uses its own default
+		let effectiveSynthesisModel: string | undefined = memoryCfg.pipelineV2.synthesis.model;
+		if (effectiveSynthesisProvider === "ollama" && memoryCfg.pipelineV2.synthesis.provider !== "ollama") {
+			effectiveSynthesisModel = undefined;
+		}
+
 		const synthesisProvider =
 			effectiveSynthesisProvider === "anthropic"
 				? createAnthropicProvider({
-						model: memoryCfg.pipelineV2.synthesis.model || "haiku",
+						model: effectiveSynthesisModel || "haiku",
 						apiKey: anthropicApiKey ?? "",
 						defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
 					})
 				: effectiveSynthesisProvider === "opencode"
 					? createOpenCodeProvider({
-							model: memoryCfg.pipelineV2.synthesis.model || "anthropic/claude-haiku-4-5-20251001",
+							model: effectiveSynthesisModel || "anthropic/claude-haiku-4-5-20251001",
 							defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
 						})
 					: effectiveSynthesisProvider === "claude-code"
 						? createClaudeCodeProvider({
-								model: memoryCfg.pipelineV2.synthesis.model || "haiku",
+								model: effectiveSynthesisModel || "haiku",
 								defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
 							})
 						: createOllamaProvider({
-								model: memoryCfg.pipelineV2.synthesis.model || "qwen3:4b",
+								model: effectiveSynthesisModel || "qwen3:4b",
 								defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
 							});
 		initSynthesisProvider(synthesisProvider);

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -9143,10 +9143,10 @@ async function main() {
 
 	// Create LLM provider once, register as daemon-wide singleton
 	const llmProvider =
-		effectiveExtractionProvider === "anthropic"
+		effectiveExtractionProvider === "anthropic" && anthropicApiKey
 			? createAnthropicProvider({
 					model: effectiveExtractionModel || "haiku",
-					apiKey: anthropicApiKey ?? "",
+					apiKey: anthropicApiKey,
 					defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 				})
 			: effectiveExtractionProvider === "opencode"
@@ -9211,10 +9211,10 @@ async function main() {
 		}
 
 		const synthesisProvider =
-			effectiveSynthesisProvider === "anthropic"
+			effectiveSynthesisProvider === "anthropic" && anthropicApiKey
 				? createAnthropicProvider({
 						model: effectiveSynthesisModel || "haiku",
-						apiKey: anthropicApiKey ?? "",
+						apiKey: anthropicApiKey,
 						defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
 					})
 				: effectiveSynthesisProvider === "opencode"

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -9114,7 +9114,10 @@ async function main() {
 
 	// Resolve Anthropic API key once — shared by extraction and synthesis
 	let anthropicApiKey: string | undefined;
-	if (effectiveExtractionProvider === "anthropic" || memoryCfg.pipelineV2.synthesis.provider === "anthropic") {
+	const needsAnthropicForSynthesis =
+		memoryCfg.pipelineV2.synthesis.enabled &&
+		memoryCfg.pipelineV2.synthesis.provider === "anthropic";
+	if (effectiveExtractionProvider === "anthropic" || needsAnthropicForSynthesis) {
 		anthropicApiKey = process.env.ANTHROPIC_API_KEY;
 		if (!anthropicApiKey) {
 			try {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -140,6 +140,7 @@ import {
 import { getFeedbackTelemetry } from "./pipeline/aspect-feedback";
 import { type PredictorClient, createPredictorClient, resolvePredictorCheckpointPath } from "./predictor-client";
 import {
+	createAnthropicProvider,
 	createClaudeCodeProvider,
 	createCodexProvider,
 	createOllamaProvider,
@@ -9111,27 +9112,49 @@ async function main() {
 	}
 	logger.info("config", "Extraction provider", { provider: effectiveExtractionProvider });
 
+	// Resolve Anthropic API key once — shared by extraction and synthesis
+	let anthropicApiKey: string | undefined;
+	if (effectiveExtractionProvider === "anthropic" || memoryCfg.pipelineV2.synthesis.provider === "anthropic") {
+		anthropicApiKey = process.env.ANTHROPIC_API_KEY;
+		if (!anthropicApiKey) {
+			try {
+				anthropicApiKey = await getSecret("ANTHROPIC_API_KEY") ?? undefined;
+			} catch {
+				logger.warn("config", "Failed to resolve ANTHROPIC_API_KEY from secrets store");
+			}
+		}
+		if (!anthropicApiKey) {
+			logger.error("config", "ANTHROPIC_API_KEY not found — anthropic provider will fail. Set via env or `signet secrets set ANTHROPIC_API_KEY`");
+		}
+	}
+
 	// Create LLM provider once, register as daemon-wide singleton
 	const llmProvider =
-		effectiveExtractionProvider === "opencode"
-			? createOpenCodeProvider({
-					model: memoryCfg.pipelineV2.extraction.model || "anthropic/claude-haiku-4-5-20251001",
+		effectiveExtractionProvider === "anthropic"
+			? createAnthropicProvider({
+					model: memoryCfg.pipelineV2.extraction.model || "haiku",
+					apiKey: anthropicApiKey ?? "",
 					defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 				})
-			: effectiveExtractionProvider === "claude-code"
-				? createClaudeCodeProvider({
-						model: memoryCfg.pipelineV2.extraction.model || "haiku",
+			: effectiveExtractionProvider === "opencode"
+				? createOpenCodeProvider({
+						model: memoryCfg.pipelineV2.extraction.model || "anthropic/claude-haiku-4-5-20251001",
 						defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 					})
-				: effectiveExtractionProvider === "codex"
-					? createCodexProvider({
-							model: memoryCfg.pipelineV2.extraction.model || "gpt-5.3-codex",
+				: effectiveExtractionProvider === "claude-code"
+					? createClaudeCodeProvider({
+							model: memoryCfg.pipelineV2.extraction.model || "haiku",
 							defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 						})
-					: createOllamaProvider({
-							model: memoryCfg.pipelineV2.extraction.model || "qwen3:4b",
-							defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
-						});
+					: effectiveExtractionProvider === "codex"
+						? createCodexProvider({
+								model: memoryCfg.pipelineV2.extraction.model || "gpt-5.3-codex",
+								defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
+							})
+						: createOllamaProvider({
+								model: memoryCfg.pipelineV2.extraction.model || "qwen3:4b",
+								defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
+							});
 	initLlmProvider(llmProvider);
 
 	// Create synthesis provider — separate from extraction because synthesis
@@ -9164,20 +9187,26 @@ async function main() {
 		logger.info("config", "Synthesis provider", { provider: effectiveSynthesisProvider });
 
 		const synthesisProvider =
-			effectiveSynthesisProvider === "opencode"
-				? createOpenCodeProvider({
-						model: memoryCfg.pipelineV2.synthesis.model || "anthropic/claude-haiku-4-5-20251001",
+			effectiveSynthesisProvider === "anthropic"
+				? createAnthropicProvider({
+						model: memoryCfg.pipelineV2.synthesis.model || "haiku",
+						apiKey: anthropicApiKey ?? "",
 						defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
 					})
-				: effectiveSynthesisProvider === "claude-code"
-					? createClaudeCodeProvider({
-							model: memoryCfg.pipelineV2.synthesis.model || "haiku",
+				: effectiveSynthesisProvider === "opencode"
+					? createOpenCodeProvider({
+							model: memoryCfg.pipelineV2.synthesis.model || "anthropic/claude-haiku-4-5-20251001",
 							defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
 						})
-					: createOllamaProvider({
-							model: memoryCfg.pipelineV2.synthesis.model || "qwen3:4b",
-							defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
-						});
+					: effectiveSynthesisProvider === "claude-code"
+						? createClaudeCodeProvider({
+								model: memoryCfg.pipelineV2.synthesis.model || "haiku",
+								defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
+							})
+						: createOllamaProvider({
+								model: memoryCfg.pipelineV2.synthesis.model || "qwen3:4b",
+								defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
+							});
 		initSynthesisProvider(synthesisProvider);
 	} else {
 		logger.info("config", "Synthesis disabled");

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -9124,7 +9124,10 @@ async function main() {
 			}
 		}
 		if (!anthropicApiKey) {
-			logger.error("config", "ANTHROPIC_API_KEY not found — anthropic provider will fail. Set via env or `signet secrets set ANTHROPIC_API_KEY`");
+			logger.error("config", "ANTHROPIC_API_KEY not found — falling back to ollama. Set via env or `signet secrets set ANTHROPIC_API_KEY`");
+			if (effectiveExtractionProvider === "anthropic") {
+				effectiveExtractionProvider = "ollama";
+			}
 		}
 	}
 
@@ -9165,6 +9168,11 @@ async function main() {
 			const serverReady = await ensureOpenCodeServer(4096);
 			if (!serverReady) {
 				logger.warn("config", "OpenCode server not available for synthesis, falling back to ollama");
+				effectiveSynthesisProvider = "ollama";
+			}
+		} else if (effectiveSynthesisProvider === "anthropic") {
+			if (!anthropicApiKey) {
+				logger.warn("config", "ANTHROPIC_API_KEY not found for synthesis, falling back to ollama");
 				effectiveSynthesisProvider = "ollama";
 			}
 		} else if (effectiveSynthesisProvider === "claude-code") {

--- a/packages/daemon/src/memory-config.ts
+++ b/packages/daemon/src/memory-config.ts
@@ -250,9 +250,9 @@ export function loadPipelineConfig(
 	const flatProvider = raw.extractionProvider;
 	const flatModel = raw.extractionModel;
 
-	type ProviderKind = "ollama" | "claude-code" | "opencode" | "codex";
+	type ProviderKind = "ollama" | "claude-code" | "opencode" | "codex" | "anthropic";
 	const VALID_PROVIDERS: ReadonlySet<string> = new Set<ProviderKind>([
-		"codex", "opencode", "claude-code", "ollama",
+		"codex", "opencode", "claude-code", "ollama", "anthropic",
 	]);
 
 	function isValidProvider(v: unknown): v is ProviderKind {

--- a/packages/daemon/src/memory-config.ts
+++ b/packages/daemon/src/memory-config.ts
@@ -641,7 +641,7 @@ export function loadPipelineConfig(
 			enabled: resolveBool(synthesisRaw?.enabled, undefined, d.synthesis.enabled),
 			provider: (() => {
 				const p = synthesisRaw?.provider;
-				if (p === "ollama" || p === "claude-code" || p === "opencode") return p;
+				if (p === "ollama" || p === "claude-code" || p === "opencode" || p === "anthropic") return p;
 				return d.synthesis.provider;
 			})(),
 			model:

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -128,9 +128,12 @@ function spawnHidden(cmd: string[], options?: { env?: Record<string, string | un
 		stderr: proc.stderr,
 		exited: proc.exited,
 		kill(signal?: string) {
-			// Default to SIGTERM (15) when no signal is specified
-			const sigNum = signal === "SIGKILL" ? 9 : 15;
-			proc.kill(sigNum);
+			const sigMap: Record<string, number> = { SIGTERM: 15, SIGKILL: 9 };
+			const sigNum = signal ? sigMap[signal] : 15;
+			if (signal && sigNum === undefined) {
+				logger.warn("pipeline", `Unknown signal "${signal}", defaulting to SIGTERM`);
+			}
+			proc.kill(sigNum ?? 15);
 		},
 	};
 }
@@ -564,7 +567,8 @@ export function createAnthropicProvider(
 
 			// Pre-check deadline before waiting on semaphore
 			if (deadline - Date.now() <= 0) {
-				throw lastError ?? new Error(`Anthropic timeout after ${timeoutMs}ms (deadline exceeded before attempt ${attempt})`);
+				const reason = lastError ? `last error: ${lastError.message}` : "no successful attempt";
+				throw new Error(`Anthropic timeout after ${timeoutMs}ms (deadline exceeded before attempt ${attempt}; ${reason})`);
 			}
 
 			// Acquire semaphore only for the actual API call, release
@@ -574,7 +578,8 @@ export function createAnthropicProvider(
 				// contention delay is accounted for in the abort timer.
 				const remainingMs = deadline - Date.now();
 				if (remainingMs <= 0) {
-					throw lastError ?? new Error(`Anthropic timeout after ${timeoutMs}ms (deadline exceeded waiting for semaphore)`);
+					const reason = lastError ? `last error: ${lastError.message}` : "no successful attempt";
+					throw new Error(`Anthropic timeout after ${timeoutMs}ms (deadline exceeded waiting for semaphore; ${reason})`);
 				}
 				const controller = new AbortController();
 				const timer = setTimeout(() => controller.abort(), remainingMs);

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -547,14 +547,20 @@ export function createAnthropicProvider(
 				});
 			}
 
-			const remainingMs = deadline - Date.now();
-			if (remainingMs <= 0) {
+			// Pre-check deadline before waiting on semaphore
+			if (deadline - Date.now() <= 0) {
 				throw lastError ?? new Error(`Anthropic timeout after ${timeoutMs}ms (deadline exceeded before attempt ${attempt})`);
 			}
 
 			// Acquire semaphore only for the actual API call, release
 			// immediately after so backoff sleep doesn't hold a slot.
 			const result = await withSemaphore(async () => {
+				// Recompute remaining time AFTER semaphore acquisition so
+				// contention delay is accounted for in the abort timer.
+				const remainingMs = deadline - Date.now();
+				if (remainingMs <= 0) {
+					throw lastError ?? new Error(`Anthropic timeout after ${timeoutMs}ms (deadline exceeded waiting for semaphore)`);
+				}
 				const controller = new AbortController();
 				const timer = setTimeout(() => controller.abort(), remainingMs);
 

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -647,7 +647,7 @@ export function createAnthropicProvider(
 
 					const text = textParts.join("\n").trim();
 					if (text.length === 0) {
-						throw new Error(
+						throw new NonRetryableError(
 							`Anthropic returned empty response (stop_reason: ${data.stop_reason ?? "unknown"})`,
 						);
 					}

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -517,9 +517,9 @@ class NonRetryableError extends Error {
 }
 
 function isRetryableStatus(status: number): boolean {
-	// 429 = rate limited, 500 = internal error, 502/503 = transient,
+	// 429 = rate limited, 500 = internal error, 502/503/504 = transient gateway,
 	// 529 = overloaded. Don't retry 501 (not implemented) or other 5xx.
-	return status === 429 || status === 500 || status === 502 || status === 503 || status === 529;
+	return status === 429 || status === 500 || status === 502 || status === 503 || status === 504 || status === 529;
 }
 
 export function createAnthropicProvider(

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -466,8 +466,8 @@ const ANTHROPIC_API_VERSION = "2023-06-01";
 function resolveAnthropicModel(model: string): string {
 	const aliases: Record<string, string> = {
 		haiku: "claude-haiku-4-5-20251001",
-		sonnet: "claude-sonnet-4-6-20250514",
-		opus: "claude-opus-4-6-20250514",
+		sonnet: "claude-sonnet-4-6",
+		opus: "claude-opus-4-6",
 	};
 	return aliases[model] ?? model;
 }
@@ -631,7 +631,8 @@ export function createAnthropicProvider(
 				// Don't retry non-retryable errors
 				if (e instanceof Error && (
 					e.message.includes("auth failed") ||
-					e.message.includes("timeout after")
+					e.message.includes("timeout after") ||
+					e.message.includes("empty response")
 				)) {
 					throw e;
 				}
@@ -696,8 +697,12 @@ export function createAnthropicProvider(
 					}),
 					signal: AbortSignal.timeout(5000),
 				});
-				// 200 = works, 401 = bad key but API is reachable
-				return res.ok || res.status === 401;
+				// 200 = works; 401 = bad key means provider is NOT usable
+				if (res.status === 401) {
+					logger.warn("pipeline", "Anthropic API key is invalid (401)");
+					return false;
+				}
+				return res.ok;
 			} catch {
 				logger.debug("pipeline", "Anthropic API not reachable");
 				return false;

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -112,6 +112,7 @@ function spawnHidden(cmd: string[], options?: { env?: Record<string, string | un
 		}
 	}
 	const proc = Bun.spawn(cmd, {
+		stdin: "ignore",
 		stdout: "pipe",
 		stderr: "pipe",
 		env: options?.env ? sanitizedEnv : undefined,
@@ -128,7 +129,7 @@ function spawnHidden(cmd: string[], options?: { env?: Record<string, string | un
 		stderr: proc.stderr,
 		exited: proc.exited,
 		kill(signal?: string) {
-			const sigMap: Record<string, number> = { SIGTERM: 15, SIGKILL: 9 };
+			const sigMap: Record<string, number | undefined> = { SIGTERM: 15, SIGKILL: 9 };
 			const sigNum = signal ? sigMap[signal] : 15;
 			if (signal && sigNum === undefined) {
 				logger.warn("pipeline", `Unknown signal "${signal}", defaulting to SIGTERM`);
@@ -538,7 +539,7 @@ export function createAnthropicProvider(
 		opts?: { timeoutMs?: number; maxTokens?: number },
 	): Promise<{ text: string; usage: AnthropicUsage | null }> {
 		const timeoutMs = opts?.timeoutMs ?? cfg.defaultTimeoutMs;
-		const maxTokens = opts?.maxTokens ?? 4096;
+		const maxTokens = opts?.maxTokens || 4096;
 		const url = `${cfg.baseUrl}/v1/messages`;
 		const body = JSON.stringify({
 			model: resolvedModel,

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -519,7 +519,6 @@ export function createAnthropicProvider(
 		prompt: string,
 		opts?: { timeoutMs?: number; maxTokens?: number },
 	): Promise<{ text: string; usage: AnthropicUsage | null }> {
-		return withSemaphore(async () => {
 		const timeoutMs = opts?.timeoutMs ?? cfg.defaultTimeoutMs;
 		const maxTokens = opts?.maxTokens ?? 4096;
 		const url = `${cfg.baseUrl}/v1/messages`;
@@ -536,7 +535,8 @@ export function createAnthropicProvider(
 
 		for (let attempt = 0; attempt <= cfg.maxRetries; attempt++) {
 			if (attempt > 0) {
-				// Exponential backoff: 1s, 2s, 4s...
+				// Exponential backoff happens OUTSIDE the semaphore so idle
+				// sleep doesn't block other providers from using the slot.
 				const backoffMs = Math.min(1000 * (2 ** (attempt - 1)), 8000);
 				await new Promise((r) => setTimeout(r, backoffMs));
 
@@ -552,110 +552,117 @@ export function createAnthropicProvider(
 				throw lastError ?? new Error(`Anthropic timeout after ${timeoutMs}ms (deadline exceeded before attempt ${attempt})`);
 			}
 
-			const controller = new AbortController();
-			const timer = setTimeout(() => controller.abort(), remainingMs);
+			// Acquire semaphore only for the actual API call, release
+			// immediately after so backoff sleep doesn't hold a slot.
+			const result = await withSemaphore(async () => {
+				const controller = new AbortController();
+				const timer = setTimeout(() => controller.abort(), remainingMs);
 
-			try {
-				const res = await fetch(url, {
-					method: "POST",
-					headers: {
-						"Content-Type": "application/json",
-						"x-api-key": cfg.apiKey,
-						"anthropic-version": ANTHROPIC_API_VERSION,
-					},
-					body,
-					signal: controller.signal,
-				});
+				try {
+					const res = await fetch(url, {
+						method: "POST",
+						headers: {
+							"Content-Type": "application/json",
+							"x-api-key": cfg.apiKey,
+							"anthropic-version": ANTHROPIC_API_VERSION,
+						},
+						body,
+						signal: controller.signal,
+					});
 
-				if (!res.ok) {
-					const rawBody = await res.text().catch(() => "");
-					let errorDetail = rawBody.slice(0, 300);
+					if (!res.ok) {
+						const rawBody = await res.text().catch(() => "");
+						let errorDetail = rawBody.slice(0, 300);
 
-					// Parse structured error if available
-					try {
-						const parsed = JSON.parse(rawBody) as AnthropicErrorBody;
-						if (parsed.error?.message) {
-							errorDetail = `${parsed.error.type ?? "error"}: ${parsed.error.message}`;
+						// Parse structured error if available
+						try {
+							const parsed = JSON.parse(rawBody) as AnthropicErrorBody;
+							if (parsed.error?.message) {
+								errorDetail = `${parsed.error.type ?? "error"}: ${parsed.error.message}`;
+							}
+						} catch {
+							// Use raw body
 						}
-					} catch {
-						// Use raw body
-					}
 
-					if (res.status === 401) {
+						if (res.status === 401) {
+							throw new Error(
+								`Anthropic auth failed (401): ${errorDetail}. Check your ANTHROPIC_API_KEY.`,
+							);
+						}
+
+						if (isRetryableStatus(res.status) && attempt < cfg.maxRetries) {
+							lastError = new Error(
+								`Anthropic HTTP ${res.status}: ${errorDetail}`,
+							);
+							logger.warn("pipeline", "Anthropic API retryable error", {
+								status: res.status,
+								attempt,
+								detail: errorDetail.slice(0, 100),
+							});
+							return { retry: true } as const;
+						}
+
 						throw new Error(
-							`Anthropic auth failed (401): ${errorDetail}. Check your ANTHROPIC_API_KEY.`,
-						);
-					}
-
-					if (isRetryableStatus(res.status) && attempt < cfg.maxRetries) {
-						lastError = new Error(
 							`Anthropic HTTP ${res.status}: ${errorDetail}`,
 						);
-						logger.warn("pipeline", "Anthropic API retryable error", {
-							status: res.status,
-							attempt,
-							detail: errorDetail.slice(0, 100),
-						});
-						continue;
 					}
 
-					throw new Error(
-						`Anthropic HTTP ${res.status}: ${errorDetail}`,
-					);
-				}
+					const data = (await res.json()) as AnthropicResponse;
 
-				const data = (await res.json()) as AnthropicResponse;
-
-				// Extract text from content blocks
-				const textParts: string[] = [];
-				if (Array.isArray(data.content)) {
-					for (const block of data.content) {
-						if (block.type === "text" && typeof block.text === "string") {
-							textParts.push(block.text);
+					// Extract text from content blocks
+					const textParts: string[] = [];
+					if (Array.isArray(data.content)) {
+						for (const block of data.content) {
+							if (block.type === "text" && typeof block.text === "string") {
+								textParts.push(block.text);
+							}
 						}
 					}
+
+					const text = textParts.join("\n").trim();
+					if (text.length === 0) {
+						throw new Error(
+							`Anthropic returned empty response (stop_reason: ${data.stop_reason ?? "unknown"})`,
+						);
+					}
+
+					return { retry: false, text, usage: data.usage ?? null } as const;
+				} catch (e) {
+					if (e instanceof DOMException && e.name === "AbortError") {
+						throw new Error(`Anthropic timeout after ${timeoutMs}ms`);
+					}
+
+					// Don't retry non-retryable errors
+					if (e instanceof Error && (
+						e.message.includes("auth failed") ||
+						e.message.includes("timeout after") ||
+						e.message.includes("empty response")
+					)) {
+						throw e;
+					}
+
+					lastError = e instanceof Error ? e : new Error(String(e));
+
+					if (attempt < cfg.maxRetries) {
+						logger.warn("pipeline", "Anthropic API network error", {
+							attempt,
+							error: lastError.message.slice(0, 100),
+						});
+						return { retry: true } as const;
+					}
+
+					throw lastError;
+				} finally {
+					clearTimeout(timer);
 				}
+			});
 
-				const text = textParts.join("\n").trim();
-				if (text.length === 0) {
-					throw new Error(
-						`Anthropic returned empty response (stop_reason: ${data.stop_reason ?? "unknown"})`,
-					);
-				}
-
-				return { text, usage: data.usage ?? null };
-			} catch (e) {
-				if (e instanceof DOMException && e.name === "AbortError") {
-					throw new Error(`Anthropic timeout after ${timeoutMs}ms`);
-				}
-
-				// Don't retry non-retryable errors
-				if (e instanceof Error && (
-					e.message.includes("auth failed") ||
-					e.message.includes("timeout after") ||
-					e.message.includes("empty response")
-				)) {
-					throw e;
-				}
-
-				lastError = e instanceof Error ? e : new Error(String(e));
-
-				if (attempt < cfg.maxRetries) {
-					logger.warn("pipeline", "Anthropic API network error", {
-						attempt,
-						error: lastError.message.slice(0, 100),
-					});
-					continue;
-				}
-
-				throw lastError;
-			} finally {
-				clearTimeout(timer);
+			if (!result.retry) {
+				return { text: result.text, usage: result.usage };
 			}
 		}
 
 		throw lastError ?? new Error("Anthropic call failed after retries");
-		});
 	}
 
 	return {

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -88,11 +88,11 @@ async function withSemaphore<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 // ---------------------------------------------------------------------------
-// Windows-safe spawn helper
+// Subprocess spawn helper
 // ---------------------------------------------------------------------------
-// Bun.spawn does not support windowsHide, so CLI subprocesses flash a
-// console window on Windows. This helper wraps Node's child_process.spawn
-// (which does support windowsHide) with a Bun.spawn-compatible interface.
+// Wraps Bun.spawn with a simplified interface for CLI subprocess calls.
+// Note: Bun.spawn does not support windowsHide, so CLI subprocesses may
+// flash a console window on Windows.
 
 interface SpawnResult {
 	readonly stdout: ReadableStream<Uint8Array>;
@@ -105,15 +105,27 @@ function spawnHidden(cmd: string[], options?: { env?: Record<string, string | un
 	// Use Bun.spawn directly — it natively returns ReadableStreams and
 	// handles subprocess I/O correctly. The previous node:child_process
 	// wrapper had stream-closing issues that caused hangs.
+	const sanitizedEnv: Record<string, string> = {};
+	if (options?.env) {
+		for (const [k, v] of Object.entries(options.env)) {
+			if (v !== undefined) sanitizedEnv[k] = v;
+		}
+	}
 	const proc = Bun.spawn(cmd, {
 		stdout: "pipe",
 		stderr: "pipe",
-		env: options?.env as Record<string, string>,
+		env: options?.env ? sanitizedEnv : undefined,
 	});
 
+	// Bun.spawn with stdout:"pipe" guarantees ReadableStream, but the
+	// type is nullable in the general case. Guard at runtime.
+	if (!proc.stdout || !proc.stderr) {
+		throw new Error("spawnHidden: stdout/stderr unexpectedly null despite pipe mode");
+	}
+
 	return {
-		stdout: proc.stdout as ReadableStream<Uint8Array>,
-		stderr: proc.stderr as ReadableStream<Uint8Array>,
+		stdout: proc.stdout,
+		stderr: proc.stderr,
 		exited: proc.exited,
 		kill(signal?: string) {
 			const sigNum = signal === "SIGKILL" ? 9 : signal === "SIGTERM" ? 15 : undefined;
@@ -359,6 +371,11 @@ export function createClaudeCodeProvider(
 				return result;
 			})();
 
+			// Guard against unhandled rejection if resultPromise rejects
+			// after the timeout wins the race (e.g. subprocess exit error
+			// after SIGKILL). The no-op catch prevents crashing the process.
+			resultPromise.catch(() => {});
+
 			return Promise.race([resultPromise, timeoutPromise]);
 		});
 	}
@@ -512,6 +529,9 @@ export function createAnthropicProvider(
 		});
 
 		let lastError: Error | null = null;
+		// Use a single absolute deadline so retries cannot exceed the
+		// configured timeout.
+		const deadline = Date.now() + timeoutMs;
 
 		for (let attempt = 0; attempt <= cfg.maxRetries; attempt++) {
 			if (attempt > 0) {
@@ -526,8 +546,13 @@ export function createAnthropicProvider(
 				});
 			}
 
+			const remainingMs = deadline - Date.now();
+			if (remainingMs <= 0) {
+				throw lastError ?? new Error(`Anthropic timeout after ${timeoutMs}ms (deadline exceeded before attempt ${attempt})`);
+			}
+
 			const controller = new AbortController();
-			const timer = setTimeout(() => controller.abort(), timeoutMs);
+			const timer = setTimeout(() => controller.abort(), remainingMs);
 
 			try {
 				const res = await fetch(url, {

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -342,7 +342,7 @@ export function createClaudeCodeProvider(
 				let killTimer: ReturnType<typeof setTimeout> | null = null;
 				const timer = setTimeout(() => {
 					// SIGTERM first, SIGKILL after grace period
-					proc.kill("SIGTERM");
+					try { proc.kill("SIGTERM"); } catch { /* already exited */ }
 					killTimer = setTimeout(() => {
 						try { proc.kill("SIGKILL"); } catch { /* already dead */ }
 					}, SIGKILL_GRACE_MS);
@@ -856,7 +856,7 @@ export function createCodexProvider(
 			const timeoutPromise = new Promise<never>((_resolve, reject) => {
 				let killTimer: ReturnType<typeof setTimeout> | null = null;
 				const timer = setTimeout(() => {
-					proc.kill("SIGTERM");
+					try { proc.kill("SIGTERM"); } catch { /* already exited */ }
 					killTimer = setTimeout(() => {
 						try { proc.kill("SIGKILL"); } catch { /* already dead */ }
 					}, SIGKILL_GRACE_MS);

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -339,16 +339,19 @@ export function createClaudeCodeProvider(
 			const SIGKILL_GRACE_MS = 2000;
 
 			const timeoutPromise = new Promise<never>((_resolve, reject) => {
+				let killTimer: ReturnType<typeof setTimeout> | null = null;
 				const timer = setTimeout(() => {
 					// SIGTERM first, SIGKILL after grace period
 					proc.kill("SIGTERM");
-					setTimeout(() => {
+					killTimer = setTimeout(() => {
 						try { proc.kill("SIGKILL"); } catch { /* already dead */ }
 					}, SIGKILL_GRACE_MS);
 					reject(new Error(`claude-code timeout after ${timeoutMs}ms`));
 				}, timeoutMs);
-				// Allow the timer to be GC'd if the process finishes first
-				proc.exited.then(() => clearTimeout(timer)).catch(() => clearTimeout(timer));
+				// Clear both timers if the process exits on its own
+				proc.exited
+					.then(() => { clearTimeout(timer); if (killTimer) clearTimeout(killTimer); })
+					.catch(() => { clearTimeout(timer); if (killTimer) clearTimeout(killTimer); });
 			});
 
 			const resultPromise = (async (): Promise<string> => {
@@ -851,14 +854,17 @@ export function createCodexProvider(
 			const SIGKILL_GRACE_MS = 2000;
 
 			const timeoutPromise = new Promise<never>((_resolve, reject) => {
+				let killTimer: ReturnType<typeof setTimeout> | null = null;
 				const timer = setTimeout(() => {
 					proc.kill("SIGTERM");
-					setTimeout(() => {
+					killTimer = setTimeout(() => {
 						try { proc.kill("SIGKILL"); } catch { /* already dead */ }
 					}, SIGKILL_GRACE_MS);
 					reject(new Error(`codex timeout after ${timeoutMs}ms`));
 				}, timeoutMs);
-				proc.exited.then(() => clearTimeout(timer)).catch(() => clearTimeout(timer));
+				proc.exited
+					.then(() => { clearTimeout(timer); if (killTimer) clearTimeout(killTimer); })
+					.catch(() => { clearTimeout(timer); if (killTimer) clearTimeout(killTimer); });
 			});
 
 			const resultPromise = (async (): Promise<LlmGenerateResult> => {

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -519,6 +519,7 @@ export function createAnthropicProvider(
 		prompt: string,
 		opts?: { timeoutMs?: number; maxTokens?: number },
 	): Promise<{ text: string; usage: AnthropicUsage | null }> {
+		return withSemaphore(async () => {
 		const timeoutMs = opts?.timeoutMs ?? cfg.defaultTimeoutMs;
 		const maxTokens = opts?.maxTokens ?? 4096;
 		const url = `${cfg.baseUrl}/v1/messages`;
@@ -654,6 +655,7 @@ export function createAnthropicProvider(
 		}
 
 		throw lastError ?? new Error("Anthropic call failed after retries");
+		});
 	}
 
 	return {
@@ -683,19 +685,12 @@ export function createAnthropicProvider(
 
 		async available(): Promise<boolean> {
 			try {
-				const res = await fetch(`${cfg.baseUrl}/v1/messages`, {
-					method: "POST",
+				const res = await fetch(`${cfg.baseUrl}/v1/models`, {
 					headers: {
-						"Content-Type": "application/json",
 						"x-api-key": cfg.apiKey,
 						"anthropic-version": ANTHROPIC_API_VERSION,
 					},
-					body: JSON.stringify({
-						model: resolvedModel,
-						max_tokens: 1,
-						messages: [{ role: "user", content: "ping" }],
-					}),
-					signal: AbortSignal.timeout(5000),
+					signal: AbortSignal.timeout(10_000),
 				});
 				// 200 = works; 401 = bad key means provider is NOT usable
 				if (res.status === 401) {

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -501,7 +501,9 @@ interface AnthropicResponse {
 }
 
 function isRetryableStatus(status: number): boolean {
-	return status === 429 || status === 529 || status >= 500;
+	// 429 = rate limited, 500 = internal error, 502/503 = transient,
+	// 529 = overloaded. Don't retry 501 (not implemented) or other 5xx.
+	return status === 429 || status === 500 || status === 502 || status === 503 || status === 529;
 }
 
 export function createAnthropicProvider(

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -632,11 +632,14 @@ export function createAnthropicProvider(
 						throw new Error(`Anthropic timeout after ${timeoutMs}ms`);
 					}
 
-					// Don't retry non-retryable errors
+					// Don't retry non-retryable errors — auth failures,
+					// timeouts, empty responses, and 4xx client errors
+					// (bad model, invalid request) won't succeed on retry.
 					if (e instanceof Error && (
 						e.message.includes("auth failed") ||
 						e.message.includes("timeout after") ||
-						e.message.includes("empty response")
+						e.message.includes("empty response") ||
+						e.message.includes("Anthropic HTTP 4")
 					)) {
 						throw e;
 					}

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -839,29 +839,41 @@ export function createCodexProvider(
 				},
 			});
 
-			let timedOut = false;
-			const timer = setTimeout(() => {
-				timedOut = true;
-				proc.kill();
-			}, timeoutMs);
+			// Race the subprocess against a timeout. On timeout we kill the
+			// process and reject immediately instead of waiting for streams
+			// to drain — a hanging subprocess may never close its stdio.
+			const SIGKILL_GRACE_MS = 2000;
 
-			try {
+			const timeoutPromise = new Promise<never>((_resolve, reject) => {
+				const timer = setTimeout(() => {
+					proc.kill("SIGTERM");
+					setTimeout(() => {
+						try { proc.kill("SIGKILL"); } catch { /* already dead */ }
+					}, SIGKILL_GRACE_MS);
+					reject(new Error(`codex timeout after ${timeoutMs}ms`));
+				}, timeoutMs);
+				proc.exited.then(() => clearTimeout(timer)).catch(() => clearTimeout(timer));
+			});
+
+			const resultPromise = (async (): Promise<LlmGenerateResult> => {
 				const [stdout, stderr, exitCode] = await Promise.all([
 					new Response(proc.stdout).text().catch(() => ""),
 					new Response(proc.stderr).text().catch(() => ""),
 					proc.exited.catch(() => -1),
 				]);
-				if (timedOut) {
-					throw new Error(`codex timeout after ${timeoutMs}ms`);
-				}
+
 				if (exitCode !== 0) {
 					const detail = stderr.trim() || stdout.trim();
 					throw new Error(`codex exit ${exitCode}: ${detail.slice(0, 500)}`);
 				}
 				return parseCodexJsonl(stdout);
-			} finally {
-				clearTimeout(timer);
-			}
+			})();
+
+			// Guard against unhandled rejection if resultPromise rejects
+			// after the timeout wins the race.
+			resultPromise.catch(() => {});
+
+			return Promise.race([resultPromise, timeoutPromise]);
 		});
 	}
 

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -500,6 +500,15 @@ interface AnthropicResponse {
 	readonly stop_reason?: string;
 }
 
+/** Sentinel error type for failures that should never be retried
+ *  (auth errors, timeouts, empty responses, non-transient HTTP 4xx). */
+class NonRetryableError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "NonRetryableError";
+	}
+}
+
 function isRetryableStatus(status: number): boolean {
 	// 429 = rate limited, 500 = internal error, 502/503 = transient,
 	// 529 = overloaded. Don't retry 501 (not implemented) or other 5xx.
@@ -594,7 +603,7 @@ export function createAnthropicProvider(
 						}
 
 						if (res.status === 401) {
-							throw new Error(
+							throw new NonRetryableError(
 								`Anthropic auth failed (401): ${errorDetail}. Check your ANTHROPIC_API_KEY.`,
 							);
 						}
@@ -611,7 +620,7 @@ export function createAnthropicProvider(
 							return { retry: true } as const;
 						}
 
-						throw new Error(
+						throw new NonRetryableError(
 							`Anthropic HTTP ${res.status}: ${errorDetail}`,
 						);
 					}
@@ -638,18 +647,12 @@ export function createAnthropicProvider(
 					return { retry: false, text, usage: data.usage ?? null } as const;
 				} catch (e) {
 					if (e instanceof DOMException && e.name === "AbortError") {
-						throw new Error(`Anthropic timeout after ${timeoutMs}ms`);
+						throw new NonRetryableError(`Anthropic timeout after ${timeoutMs}ms`);
 					}
 
-					// Don't retry non-retryable errors — auth failures,
-					// timeouts, empty responses, and 4xx client errors
-					// (bad model, invalid request) won't succeed on retry.
-					if (e instanceof Error && (
-						e.message.includes("auth failed") ||
-						e.message.includes("timeout after") ||
-						e.message.includes("empty response") ||
-						e.message.includes("Anthropic HTTP 4")
-					)) {
+					// Non-retryable errors use the typed sentinel —
+					// no substring matching needed.
+					if (e instanceof NonRetryableError) {
 						throw e;
 					}
 

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -1,6 +1,6 @@
 /**
  * LLM provider implementations: Ollama (HTTP), Claude Code (CLI subprocess),
- * and OpenCode (headless HTTP server).
+ * Anthropic (direct HTTP API), and OpenCode (headless HTTP server).
  *
  * The LlmProvider interface itself lives in @signet/core so that the
  * ingestion pipeline and other consumers can accept any provider.
@@ -9,7 +9,7 @@
 import type { LlmProvider, LlmGenerateResult } from "@signet/core";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
-import { spawn as nodeSpawn } from "node:child_process";
+// node:child_process removed — using Bun.spawn directly for reliable I/O
 import { logger } from "../logger";
 
 // ---------------------------------------------------------------------------
@@ -102,38 +102,23 @@ interface SpawnResult {
 }
 
 function spawnHidden(cmd: string[], options?: { env?: Record<string, string | undefined> }): SpawnResult {
-	const proc = nodeSpawn(cmd[0], cmd.slice(1), {
-		stdio: "pipe",
-		windowsHide: true,
-		env: options?.env as NodeJS.ProcessEnv,
-	});
-
-	const stdout = new ReadableStream<Uint8Array>({
-		start(controller) {
-			proc.stdout?.on("data", (chunk: Buffer) => controller.enqueue(new Uint8Array(chunk)));
-			proc.stdout?.on("end", () => { try { controller.close(); } catch {} });
-			proc.stdout?.on("error", (err) => { try { controller.error(err); } catch {} });
-		},
-	});
-
-	const stderr = new ReadableStream<Uint8Array>({
-		start(controller) {
-			proc.stderr?.on("data", (chunk: Buffer) => controller.enqueue(new Uint8Array(chunk)));
-			proc.stderr?.on("end", () => { try { controller.close(); } catch {} });
-			proc.stderr?.on("error", (err) => { try { controller.error(err); } catch {} });
-		},
-	});
-
-	const exited = new Promise<number>((resolve) => {
-		proc.on("close", (code) => resolve(code ?? 1));
-		proc.on("error", () => resolve(1));
+	// Use Bun.spawn directly — it natively returns ReadableStreams and
+	// handles subprocess I/O correctly. The previous node:child_process
+	// wrapper had stream-closing issues that caused hangs.
+	const proc = Bun.spawn(cmd, {
+		stdout: "pipe",
+		stderr: "pipe",
+		env: options?.env as Record<string, string>,
 	});
 
 	return {
-		stdout,
-		stderr,
-		exited,
-		kill(signal?: string) { proc.kill(signal as NodeJS.Signals); },
+		stdout: proc.stdout as ReadableStream<Uint8Array>,
+		stderr: proc.stderr as ReadableStream<Uint8Array>,
+		exited: proc.exited,
+		kill(signal?: string) {
+			const sigNum = signal === "SIGKILL" ? 9 : signal === "SIGTERM" ? 15 : undefined;
+			proc.kill(sigNum);
+		},
 	};
 }
 
@@ -314,31 +299,51 @@ export function createClaudeCodeProvider(
 				"--output-format", outputFormat,
 			];
 
-			// Unset CLAUDECODE to avoid nested-session detection when the
-			// daemon itself is launched from within a Claude Code session.
+			// Strip ALL Claude Code env vars to prevent nested-session
+			// detection when the daemon is launched from a CC session.
 			// Also inject SIGNET_NO_HOOKS to prevent recursive hook loops.
-			const { CLAUDECODE: _, SIGNET_NO_HOOKS: __, ...cleanEnv } = process.env;
+			const cleanEnv: Record<string, string> = {};
+			for (const [k, v] of Object.entries(process.env)) {
+				if (v === undefined) continue;
+				if (k === "CLAUDECODE" || k.startsWith("CLAUDE_CODE_") || k === "SIGNET_NO_HOOKS") continue;
+				cleanEnv[k] = v;
+			}
+
+			logger.debug("pipeline", "Spawning claude-code subprocess", {
+				model: cfg.model,
+				outputFormat,
+				promptLen: prompt.length,
+				timeoutMs,
+			});
 
 			const proc = spawnHidden(["claude", ...args], {
 				env: { ...cleanEnv, NO_COLOR: "1", SIGNET_NO_HOOKS: "1" },
 			});
 
-			let timedOut = false;
-			const timer = setTimeout(() => {
-				timedOut = true;
-				proc.kill();
-			}, timeoutMs);
+			// Race the subprocess against a timeout. On timeout we kill the
+			// process and reject immediately instead of waiting for streams
+			// to drain — a hanging subprocess may never close its stdio.
+			const SIGKILL_GRACE_MS = 2000;
 
-			try {
+			const timeoutPromise = new Promise<never>((_resolve, reject) => {
+				const timer = setTimeout(() => {
+					// SIGTERM first, SIGKILL after grace period
+					proc.kill("SIGTERM");
+					setTimeout(() => {
+						try { proc.kill("SIGKILL"); } catch { /* already dead */ }
+					}, SIGKILL_GRACE_MS);
+					reject(new Error(`claude-code timeout after ${timeoutMs}ms`));
+				}, timeoutMs);
+				// Allow the timer to be GC'd if the process finishes first
+				proc.exited.then(() => clearTimeout(timer)).catch(() => clearTimeout(timer));
+			});
+
+			const resultPromise = (async (): Promise<string> => {
 				const [stdout, stderr, exitCode] = await Promise.all([
 					new Response(proc.stdout).text().catch(() => ""),
 					new Response(proc.stderr).text().catch(() => ""),
 					proc.exited.catch(() => -1),
 				]);
-
-				if (timedOut) {
-					throw new Error(`claude-code timeout after ${timeoutMs}ms`);
-				}
 
 				if (exitCode !== 0) {
 					throw new Error(
@@ -352,9 +357,9 @@ export function createClaudeCodeProvider(
 				}
 
 				return result;
-			} finally {
-				clearTimeout(timer);
-			}
+			})();
+
+			return Promise.race([resultPromise, timeoutPromise]);
 		});
 	}
 
@@ -409,6 +414,267 @@ export function createClaudeCodeProvider(
 				return exitCode === 0;
 			} catch {
 				logger.debug("pipeline", "Claude Code CLI not available");
+				return false;
+			}
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic via direct HTTP API
+// ---------------------------------------------------------------------------
+// Bypasses the Claude Code CLI subprocess entirely by calling the
+// Anthropic Messages API over HTTP. Eliminates subprocess hanging,
+// auth-prompt deadlocks, and concurrency starvation.
+
+export interface AnthropicProviderConfig {
+	readonly model: string;
+	readonly apiKey: string;
+	readonly baseUrl: string;
+	readonly defaultTimeoutMs: number;
+	readonly maxRetries: number;
+}
+
+const DEFAULT_ANTHROPIC_CONFIG: AnthropicProviderConfig = {
+	model: "claude-haiku-4-5-20251001",
+	apiKey: "",
+	baseUrl: "https://api.anthropic.com",
+	defaultTimeoutMs: 60000,
+	maxRetries: 2,
+};
+
+const ANTHROPIC_API_VERSION = "2023-06-01";
+
+/** Map short model aliases to full Anthropic model IDs. */
+function resolveAnthropicModel(model: string): string {
+	const aliases: Record<string, string> = {
+		haiku: "claude-haiku-4-5-20251001",
+		sonnet: "claude-sonnet-4-6-20250514",
+		opus: "claude-opus-4-6-20250514",
+	};
+	return aliases[model] ?? model;
+}
+
+interface AnthropicUsage {
+	readonly input_tokens?: number;
+	readonly output_tokens?: number;
+	readonly cache_creation_input_tokens?: number;
+	readonly cache_read_input_tokens?: number;
+}
+
+interface AnthropicContentBlock {
+	readonly type: string;
+	readonly text?: string;
+}
+
+interface AnthropicErrorBody {
+	readonly type?: string;
+	readonly error?: {
+		readonly type?: string;
+		readonly message?: string;
+	};
+}
+
+interface AnthropicResponse {
+	readonly id?: string;
+	readonly content?: readonly AnthropicContentBlock[];
+	readonly usage?: AnthropicUsage;
+	readonly stop_reason?: string;
+}
+
+function isRetryableStatus(status: number): boolean {
+	return status === 429 || status === 529 || status >= 500;
+}
+
+export function createAnthropicProvider(
+	config?: Partial<AnthropicProviderConfig>,
+): LlmProvider {
+	const cfg = { ...DEFAULT_ANTHROPIC_CONFIG, ...config };
+	const resolvedModel = resolveAnthropicModel(cfg.model);
+
+	if (!cfg.apiKey) {
+		throw new Error(
+			"Anthropic provider requires an API key. Set ANTHROPIC_API_KEY env var or configure it in Signet secrets.",
+		);
+	}
+
+	async function callAnthropic(
+		prompt: string,
+		opts?: { timeoutMs?: number; maxTokens?: number },
+	): Promise<{ text: string; usage: AnthropicUsage | null }> {
+		const timeoutMs = opts?.timeoutMs ?? cfg.defaultTimeoutMs;
+		const maxTokens = opts?.maxTokens ?? 4096;
+		const url = `${cfg.baseUrl}/v1/messages`;
+		const body = JSON.stringify({
+			model: resolvedModel,
+			max_tokens: maxTokens,
+			messages: [{ role: "user", content: prompt }],
+		});
+
+		let lastError: Error | null = null;
+
+		for (let attempt = 0; attempt <= cfg.maxRetries; attempt++) {
+			if (attempt > 0) {
+				// Exponential backoff: 1s, 2s, 4s...
+				const backoffMs = Math.min(1000 * (2 ** (attempt - 1)), 8000);
+				await new Promise((r) => setTimeout(r, backoffMs));
+
+				logger.debug("pipeline", "Anthropic API retry", {
+					attempt,
+					maxRetries: cfg.maxRetries,
+					backoffMs,
+				});
+			}
+
+			const controller = new AbortController();
+			const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+			try {
+				const res = await fetch(url, {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						"x-api-key": cfg.apiKey,
+						"anthropic-version": ANTHROPIC_API_VERSION,
+					},
+					body,
+					signal: controller.signal,
+				});
+
+				if (!res.ok) {
+					const rawBody = await res.text().catch(() => "");
+					let errorDetail = rawBody.slice(0, 300);
+
+					// Parse structured error if available
+					try {
+						const parsed = JSON.parse(rawBody) as AnthropicErrorBody;
+						if (parsed.error?.message) {
+							errorDetail = `${parsed.error.type ?? "error"}: ${parsed.error.message}`;
+						}
+					} catch {
+						// Use raw body
+					}
+
+					if (res.status === 401) {
+						throw new Error(
+							`Anthropic auth failed (401): ${errorDetail}. Check your ANTHROPIC_API_KEY.`,
+						);
+					}
+
+					if (isRetryableStatus(res.status) && attempt < cfg.maxRetries) {
+						lastError = new Error(
+							`Anthropic HTTP ${res.status}: ${errorDetail}`,
+						);
+						logger.warn("pipeline", "Anthropic API retryable error", {
+							status: res.status,
+							attempt,
+							detail: errorDetail.slice(0, 100),
+						});
+						continue;
+					}
+
+					throw new Error(
+						`Anthropic HTTP ${res.status}: ${errorDetail}`,
+					);
+				}
+
+				const data = (await res.json()) as AnthropicResponse;
+
+				// Extract text from content blocks
+				const textParts: string[] = [];
+				if (Array.isArray(data.content)) {
+					for (const block of data.content) {
+						if (block.type === "text" && typeof block.text === "string") {
+							textParts.push(block.text);
+						}
+					}
+				}
+
+				const text = textParts.join("\n").trim();
+				if (text.length === 0) {
+					throw new Error(
+						`Anthropic returned empty response (stop_reason: ${data.stop_reason ?? "unknown"})`,
+					);
+				}
+
+				return { text, usage: data.usage ?? null };
+			} catch (e) {
+				if (e instanceof DOMException && e.name === "AbortError") {
+					throw new Error(`Anthropic timeout after ${timeoutMs}ms`);
+				}
+
+				// Don't retry non-retryable errors
+				if (e instanceof Error && (
+					e.message.includes("auth failed") ||
+					e.message.includes("timeout after")
+				)) {
+					throw e;
+				}
+
+				lastError = e instanceof Error ? e : new Error(String(e));
+
+				if (attempt < cfg.maxRetries) {
+					logger.warn("pipeline", "Anthropic API network error", {
+						attempt,
+						error: lastError.message.slice(0, 100),
+					});
+					continue;
+				}
+
+				throw lastError;
+			} finally {
+				clearTimeout(timer);
+			}
+		}
+
+		throw lastError ?? new Error("Anthropic call failed after retries");
+	}
+
+	return {
+		name: `anthropic:${resolvedModel}`,
+
+		async generate(prompt, opts): Promise<string> {
+			const { text } = await callAnthropic(prompt, opts);
+			return text;
+		},
+
+		async generateWithUsage(prompt, opts): Promise<LlmGenerateResult> {
+			const { text, usage } = await callAnthropic(prompt, opts);
+			return {
+				text,
+				usage: usage
+					? {
+							inputTokens: usage.input_tokens ?? null,
+							outputTokens: usage.output_tokens ?? null,
+							cacheReadTokens: usage.cache_read_input_tokens ?? null,
+							cacheCreationTokens: usage.cache_creation_input_tokens ?? null,
+							totalCost: null,
+							totalDurationMs: null,
+						}
+					: null,
+			};
+		},
+
+		async available(): Promise<boolean> {
+			try {
+				const res = await fetch(`${cfg.baseUrl}/v1/messages`, {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						"x-api-key": cfg.apiKey,
+						"anthropic-version": ANTHROPIC_API_VERSION,
+					},
+					body: JSON.stringify({
+						model: resolvedModel,
+						max_tokens: 1,
+						messages: [{ role: "user", content: "ping" }],
+					}),
+					signal: AbortSignal.timeout(5000),
+				});
+				// 200 = works, 401 = bad key but API is reachable
+				return res.ok || res.status === 401;
+			} catch {
+				logger.debug("pipeline", "Anthropic API not reachable");
 				return false;
 			}
 		},

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -474,8 +474,8 @@ const ANTHROPIC_API_VERSION = "2023-06-01";
 function resolveAnthropicModel(model: string): string {
 	const aliases: Record<string, string> = {
 		haiku: "claude-haiku-4-5-20251001",
-		sonnet: "claude-sonnet-4-6",
-		opus: "claude-opus-4-6",
+		sonnet: "claude-sonnet-4-5-20250514",
+		opus: "claude-opus-4-5-20250514",
 	};
 	return aliases[model] ?? model;
 }

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -128,7 +128,8 @@ function spawnHidden(cmd: string[], options?: { env?: Record<string, string | un
 		stderr: proc.stderr,
 		exited: proc.exited,
 		kill(signal?: string) {
-			const sigNum = signal === "SIGKILL" ? 9 : signal === "SIGTERM" ? 15 : undefined;
+			// Default to SIGTERM (15) when no signal is specified
+			const sigNum = signal === "SIGKILL" ? 9 : 15;
 			proc.kill(sigNum);
 		},
 	};

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -809,7 +809,7 @@ async function resolveProvider(cfg: ReturnType<typeof loadMemoryConfig>): Promis
 			}
 			if (!apiKey) {
 				logger.error("summary-worker", "ANTHROPIC_API_KEY not found for summary worker — falling back to ollama. Set via env or `signet secrets set ANTHROPIC_API_KEY`");
-				return createOllamaProvider({ model: model || "qwen3:4b", defaultTimeoutMs: timeout });
+				return createOllamaProvider({ model: "qwen3:4b", defaultTimeoutMs: timeout });
 			}
 			return createAnthropicProvider({ model: model || "haiku", apiKey, defaultTimeoutMs: timeout });
 		}

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -888,9 +888,9 @@ export function startSummaryWorker(
 				project: job.project,
 			});
 
-			// Cache provider across jobs — re-resolve on config change, key
-			// rotation, or TTL expiry. Include a fingerprint of the current
-			// API key so rotations take effect immediately.
+			// Cache provider across jobs — re-resolve on config change, env
+			// key rotation, or TTL expiry. Env-var key changes invalidate
+			// immediately; secrets-store-only rotations rely on the 5-min TTL.
 			const envKey = process.env.ANTHROPIC_API_KEY ?? "";
 			const keyFingerprint = envKey.length > 8 ? envKey.slice(-8) : envKey;
 			const providerKey = `${cfg.pipelineV2.synthesis.provider}:${cfg.pipelineV2.synthesis.model}:${cfg.pipelineV2.synthesis.timeout}:${keyFingerprint}`;

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -828,6 +828,11 @@ export function startSummaryWorker(
 	let timer: ReturnType<typeof setTimeout> | null = null;
 	let stopped = false;
 
+	// Cache the LLM provider to avoid per-job getSecret calls.
+	// Re-resolve only when the synthesis config changes.
+	let cachedProvider: LlmProvider | null = null;
+	let cachedProviderKey = "";
+
 	async function tick(): Promise<void> {
 		if (stopped) return;
 
@@ -880,8 +885,13 @@ export function startSummaryWorker(
 				project: job.project,
 			});
 
-			const provider = await resolveProvider(cfg);
-			await processJob(accessor, provider, job, cfg);
+			// Cache provider across jobs — only re-resolve when config changes
+			const providerKey = `${cfg.pipelineV2.synthesis.provider}:${cfg.pipelineV2.synthesis.model}:${cfg.pipelineV2.synthesis.timeout}`;
+			if (!cachedProvider || providerKey !== cachedProviderKey) {
+				cachedProvider = await resolveProvider(cfg);
+				cachedProviderKey = providerKey;
+			}
+			await processJob(accessor, cachedProvider, job, cfg);
 
 			// Mark complete
 			accessor.withWriteTx((db) => {

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -829,9 +829,12 @@ export function startSummaryWorker(
 	let stopped = false;
 
 	// Cache the LLM provider to avoid per-job getSecret calls.
-	// Re-resolve only when the synthesis config changes.
+	// Re-resolve when config changes or after a TTL expires (so a
+	// newly added API key gets picked up without a restart).
 	let cachedProvider: LlmProvider | null = null;
 	let cachedProviderKey = "";
+	let cachedProviderAt = 0;
+	const PROVIDER_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 	async function tick(): Promise<void> {
 		if (stopped) return;
@@ -885,11 +888,13 @@ export function startSummaryWorker(
 				project: job.project,
 			});
 
-			// Cache provider across jobs — only re-resolve when config changes
+			// Cache provider across jobs — re-resolve on config change or TTL expiry
 			const providerKey = `${cfg.pipelineV2.synthesis.provider}:${cfg.pipelineV2.synthesis.model}:${cfg.pipelineV2.synthesis.timeout}`;
-			if (!cachedProvider || providerKey !== cachedProviderKey) {
+			const cacheExpired = Date.now() - cachedProviderAt > PROVIDER_CACHE_TTL_MS;
+			if (!cachedProvider || providerKey !== cachedProviderKey || cacheExpired) {
 				cachedProvider = await resolveProvider(cfg);
 				cachedProviderKey = providerKey;
+				cachedProviderAt = Date.now();
 			}
 			await processJob(accessor, cachedProvider, job, cfg);
 

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -21,6 +21,7 @@ import { createAnthropicProvider, createOllamaProvider, createClaudeCodeProvider
 import { isDuplicate, inferType } from "../hooks";
 import { loadMemoryConfig } from "../memory-config";
 import { logger } from "../logger";
+import { getSecret } from "../secrets";
 import {
 	assessSignificance,
 	type SignificanceConfig,
@@ -792,13 +793,24 @@ function writeSummaryToDAG(
 
 /** Resolve from synthesis config — distinct from extraction so users can
  *  decouple the summary provider/model/timeout from the extraction pipeline. */
-function resolveProvider(cfg: ReturnType<typeof loadMemoryConfig>): LlmProvider {
+async function resolveProvider(cfg: ReturnType<typeof loadMemoryConfig>): Promise<LlmProvider> {
 	const p = cfg.pipelineV2.synthesis.provider;
 	const model = cfg.pipelineV2.synthesis.model;
 	const timeout = cfg.pipelineV2.synthesis.timeout;
 	switch (p) {
 		case "anthropic": {
-			const apiKey = process.env.ANTHROPIC_API_KEY ?? "";
+			let apiKey = process.env.ANTHROPIC_API_KEY;
+			if (!apiKey) {
+				try {
+					apiKey = await getSecret("ANTHROPIC_API_KEY") ?? undefined;
+				} catch {
+					// secrets store unavailable
+				}
+			}
+			if (!apiKey) {
+				logger.error("summary-worker", "ANTHROPIC_API_KEY not found for summary worker — falling back to ollama. Set via env or `signet secrets set ANTHROPIC_API_KEY`");
+				return createOllamaProvider({ model: model || "qwen3:4b", defaultTimeoutMs: timeout });
+			}
 			return createAnthropicProvider({ model: model || "haiku", apiKey, defaultTimeoutMs: timeout });
 		}
 		case "claude-code":
@@ -868,7 +880,7 @@ export function startSummaryWorker(
 				project: job.project,
 			});
 
-			const provider = resolveProvider(cfg);
+			const provider = await resolveProvider(cfg);
 			await processJob(accessor, provider, job, cfg);
 
 			// Mark complete

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -892,7 +892,7 @@ export function startSummaryWorker(
 			// key rotation, or TTL expiry. Env-var key changes invalidate
 			// immediately; secrets-store-only rotations rely on the 5-min TTL.
 			const envKey = process.env.ANTHROPIC_API_KEY ?? "";
-			const keyFingerprint = envKey ? `len${envKey.length}` : "";
+			const keyFingerprint = envKey ? new Bun.CryptoHasher("sha256").update(envKey).digest("hex").slice(0, 8) : "";
 			const providerKey = `${cfg.pipelineV2.synthesis.provider}:${cfg.pipelineV2.synthesis.model}:${cfg.pipelineV2.synthesis.timeout}:${keyFingerprint}`;
 			const cacheExpired = Date.now() - cachedProviderAt > PROVIDER_CACHE_TTL_MS;
 			if (!cachedProvider || providerKey !== cachedProviderKey || cacheExpired) {

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -888,8 +888,12 @@ export function startSummaryWorker(
 				project: job.project,
 			});
 
-			// Cache provider across jobs — re-resolve on config change or TTL expiry
-			const providerKey = `${cfg.pipelineV2.synthesis.provider}:${cfg.pipelineV2.synthesis.model}:${cfg.pipelineV2.synthesis.timeout}`;
+			// Cache provider across jobs — re-resolve on config change, key
+			// rotation, or TTL expiry. Include a fingerprint of the current
+			// API key so rotations take effect immediately.
+			const envKey = process.env.ANTHROPIC_API_KEY ?? "";
+			const keyFingerprint = envKey.length > 8 ? envKey.slice(-8) : envKey;
+			const providerKey = `${cfg.pipelineV2.synthesis.provider}:${cfg.pipelineV2.synthesis.model}:${cfg.pipelineV2.synthesis.timeout}:${keyFingerprint}`;
 			const cacheExpired = Date.now() - cachedProviderAt > PROVIDER_CACHE_TTL_MS;
 			if (!cachedProvider || providerKey !== cachedProviderKey || cacheExpired) {
 				cachedProvider = await resolveProvider(cfg);

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -892,7 +892,7 @@ export function startSummaryWorker(
 			// key rotation, or TTL expiry. Env-var key changes invalidate
 			// immediately; secrets-store-only rotations rely on the 5-min TTL.
 			const envKey = process.env.ANTHROPIC_API_KEY ?? "";
-			const keyFingerprint = envKey.length > 8 ? envKey.slice(-8) : envKey;
+			const keyFingerprint = envKey ? `len${envKey.length}` : "";
 			const providerKey = `${cfg.pipelineV2.synthesis.provider}:${cfg.pipelineV2.synthesis.model}:${cfg.pipelineV2.synthesis.timeout}:${keyFingerprint}`;
 			const cacheExpired = Date.now() - cachedProviderAt > PROVIDER_CACHE_TTL_MS;
 			if (!cachedProvider || providerKey !== cachedProviderKey || cacheExpired) {

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -16,7 +16,7 @@ import { join } from "node:path";
 import type { Database } from "bun:sqlite";
 import type { DbAccessor } from "../db-accessor";
 import type { LlmProvider } from "@signet/core";
-import { createOllamaProvider, createClaudeCodeProvider, createOpenCodeProvider } from "./provider";
+import { createAnthropicProvider, createOllamaProvider, createClaudeCodeProvider, createOpenCodeProvider } from "./provider";
 
 import { isDuplicate, inferType } from "../hooks";
 import { loadMemoryConfig } from "../memory-config";
@@ -797,6 +797,10 @@ function resolveProvider(cfg: ReturnType<typeof loadMemoryConfig>): LlmProvider 
 	const model = cfg.pipelineV2.synthesis.model;
 	const timeout = cfg.pipelineV2.synthesis.timeout;
 	switch (p) {
+		case "anthropic": {
+			const apiKey = process.env.ANTHROPIC_API_KEY ?? "";
+			return createAnthropicProvider({ model: model || "haiku", apiKey, defaultTimeoutMs: timeout });
+		}
 		case "claude-code":
 			return createClaudeCodeProvider({ model: model || "haiku", defaultTimeoutMs: timeout });
 		case "opencode":


### PR DESCRIPTION
## What
Replaced the `spawnHidden()` subprocess helper in the LLM provider pipeline with `Bun.spawn`, and hardened the timeout/kill logic for CLI subprocess providers (claude-code, codex).

## How
- **Swapped `node:child_process.spawn` → `Bun.spawn`**: The old implementation manually wrapped Node.js streams in Web API `ReadableStream` objects. Bun's `node:child_process` compat layer has a bug where the stream `end` event doesn't reliably fire, so `new Response(proc.stdout).text()` hangs forever waiting for stream close — even after the subprocess has exited and flushed its output. `Bun.spawn` natively returns proper `ReadableStream` objects that close correctly on process exit.
- **Added `Promise.race` timeout pattern**: Previously, the timeout fired `proc.kill()` but then still waited on `Promise.all([stdout, stderr, exited])`. If the streams never closed (the exact bug above), the semaphore slot was consumed forever. Now the timeout rejects immediately via `Promise.race`, freeing the slot. Added SIGTERM → SIGKILL escalation (2s grace) for processes that don't respond to SIGTERM.
- **Broadened env var stripping**: Was only unsetting `CLAUDECODE`. Now strips all `CLAUDE_CODE_*` prefixed vars (like `CLAUDE_CODE_ENTRYPOINT`) to prevent nested-session detection when the daemon spawns `claude -p` from within a Claude Code session context.
- **Added `anthropic` direct HTTP API provider**: Additive option — calls the Anthropic Messages API directly with retry logic, exponential backoff, and structured error classification. No existing provider behavior changed. Wired into daemon.ts, summary-worker.ts, and memory-config.ts.

## Why
After Claude Code CLI updated from v2.1.71 to v2.1.72 (between March 8–9), all extraction and synthesis subprocess calls began hanging. The 90s timeout would fire but the old code path couldn't break free of the hung `Promise.all`, consuming all 4 semaphore slots and cascading into total pipeline starvation — 128+ jobs backed up, zero extractions completing. The Bun.spawn fix immediately resolved it: extraction jobs started completing within seconds with full fact/entity/relation extraction.

## Test plan
- [x] Dev daemon with fix: extraction jobs completing successfully (3 facts, 3 entities, 3 relations extracted)
- [x] Build passes (`bun run build`)
- [x] Typecheck passes (no new errors)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Anthropic added as a supported provider for extraction, synthesis, and summarization with unified API key resolution and automatic fallback when the key is missing.
  * Configuration schemas updated to accept "anthropic" as a valid provider option.

* **Improvements**
  * Per-request timeouts, retries/backoff, improved error reporting and response validation, global concurrency throttling, and more robust subprocess handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->