### PR TITLE
fix(daemon): harden VPS runtime config and pipeline behavior

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -15,7 +15,8 @@ port are configurable via environment variables (see [[configuration]]).
 ```
 Base URL: http://localhost:3850
 SIGNET_PORT  — override port (default: 3850)
-SIGNET_HOST  — override bind host (default: localhost)
+SIGNET_HOST  — daemon host for local calls (default: 127.0.0.1)
+SIGNET_BIND  — bind host override (default: SIGNET_HOST)
 ```
 
 Authentication

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -755,7 +755,9 @@ Environment Variables
 |----------|-------------|---------|
 | `SIGNET_PORT` | Daemon HTTP port | `3850` |
 | `SIGNET_PATH` | Base agents directory | `~/.agents` |
-| `SIGNET_HOST` | Daemon bind address | `localhost` |
+| `SIGNET_HOST` | Daemon host for local calls and default bind address | `127.0.0.1` |
+| `SIGNET_BIND` | Explicit daemon bind address override | `SIGNET_HOST` |
+| `SIGNET_LOG_FILE` | Explicit daemon log file path | unset |
 | `SIGNET_BYPASS` | Skip all hook processing (exit immediately) | unset |
 
 ---

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -758,6 +758,7 @@ Environment Variables
 | `SIGNET_HOST` | Daemon host for local calls and default bind address | `127.0.0.1` |
 | `SIGNET_BIND` | Explicit daemon bind address override | `SIGNET_HOST` |
 | `SIGNET_LOG_FILE` | Explicit daemon log file path | unset |
+| `SIGNET_LOG_DIR` | Daemon log directory override | `~/.agents/.daemon/logs` |
 | `SIGNET_BYPASS` | Skip all hook processing (exit immediately) | unset |
 
 ---

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -577,7 +577,10 @@ editing the config file is impractical.
 |----------|---------|-------------|
 | `SIGNET_PATH` | `~/.agents` | Base agents directory |
 | `SIGNET_PORT` | `3850` | Daemon HTTP port |
-| `SIGNET_HOST` | `localhost` | Daemon bind address |
+| `SIGNET_HOST` | `127.0.0.1` | Daemon host for local calls and default bind address |
+| `SIGNET_BIND` | `SIGNET_HOST` | Explicit bind address override (`0.0.0.0`, etc.) |
+| `SIGNET_LOG_FILE` | — | Optional explicit daemon log file path |
+| `SIGNET_LOG_DIR` | `~/.agents/.daemon/logs` | Optional daemon log directory override |
 | `OPENAI_API_KEY` | — | OpenAI key when embedding provider is `openai` |
 
 `SIGNET_PATH` changes where Signet reads and writes all agent data,

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -61,8 +61,11 @@ Configuration
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `SIGNET_PORT` | `3850` | HTTP server port |
-| `SIGNET_HOST` | `localhost` | Bind address |
+| `SIGNET_HOST` | `127.0.0.1` | Daemon host for local calls and default bind address |
+| `SIGNET_BIND` | `SIGNET_HOST` | Explicit bind address override (for example `0.0.0.0`) |
 | `SIGNET_PATH` | `~/.agents` | Base agents directory |
+| `SIGNET_LOG_FILE` | — | Optional explicit log file path |
+| `SIGNET_LOG_DIR` | `~/.agents/.daemon/logs` | Optional log directory override |
 
 ### Files
 

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -69,6 +69,11 @@ Configuration
 
 ### Files
 
+When log path overrides are set:
+- `SIGNET_LOG_FILE` takes highest precedence and points to the exact file.
+- Else `SIGNET_LOG_DIR` overrides the default log directory.
+- Else the default `~/.agents/.daemon/logs/` paths below apply.
+
 | File | Description |
 |------|-------------|
 | `~/.agents/.daemon/pid` | Process ID file |
@@ -338,7 +343,10 @@ Logging
 -------
 
 Logs are written to the console and to a daily file at
-`~/.agents/.daemon/logs/daemon-YYYY-MM-DD.log`.
+`~/.agents/.daemon/logs/daemon-YYYY-MM-DD.log` by default. When
+`SIGNET_LOG_FILE` is set, logs are written to that exact file.
+When `SIGNET_LOG_DIR` is set (and `SIGNET_LOG_FILE` is unset), daily
+logs are written under `$SIGNET_LOG_DIR/`.
 
 ```
 [2025-02-17T18:00:00.000Z] [INFO] Message here
@@ -368,7 +376,7 @@ signet start
 
 Read the error log:
 ```bash
-cat ~/.agents/.daemon/logs/daemon.err.log
+cat "${SIGNET_LOG_FILE:-$HOME/.agents/.daemon/logs/daemon.err.log}"
 ```
 
 ### Daemon keeps crashing

--- a/docs/SELF-HOSTING.md
+++ b/docs/SELF-HOSTING.md
@@ -26,9 +26,11 @@ runs inside that one process.
 
 Environment variables control the network address:
 
-- `SIGNET_HOST` — interface to bind (default: `localhost`)
+- `SIGNET_HOST` — daemon host for local calls and default bind address (default: `127.0.0.1`)
+- `SIGNET_BIND` — explicit bind address override (default: `SIGNET_HOST`)
 - `SIGNET_PORT` — port to listen on (default: `3850`)
 - `SIGNET_PATH` — override the data directory (default: `~/.agents/`)
+- `SIGNET_LOG_FILE` — optional explicit daemon log file path
 
 Bun is a hard requirement. The daemon uses `bun:sqlite` directly and will
 refuse to start under Node.

--- a/packages/adapters/openclaw/package.json
+++ b/packages/adapters/openclaw/package.json
@@ -18,12 +18,12 @@
   ],
   "openclaw": {
     "extensions": [
-      "./dist/index.js"
+      "dist/index.js"
     ]
   },
   "clawdbot": {
     "extensions": [
-      "./dist/index.js"
+      "dist/index.js"
     ]
   },
   "scripts": {

--- a/packages/cli/templates/agent.yaml.template
+++ b/packages/cli/templates/agent.yaml.template
@@ -114,7 +114,7 @@ memory:
       # "claude-code" (Claude CLI), "codex" (Codex CLI), "opencode" (OpenCode), or "ollama" (local)
       provider: claude-code
       model: haiku
-      # ollama endpoint override (only used when provider resolves to ollama)
+      # endpoint/base_url override (used by ollama and OpenCode ollama fallback)
       # endpoint: http://localhost:11434
       # timeout: 45000
       # minConfidence: 0.7

--- a/packages/cli/templates/agent.yaml.template
+++ b/packages/cli/templates/agent.yaml.template
@@ -99,7 +99,8 @@ memory:
 
   # Pipeline V2 — automatic memory extraction from conversations
   pipelineV2:
-    # Master switch (true = extract memories from conversations)
+    # Master switch (true = run pipeline workers)
+    # When false, shadowMode is ignored and the pipeline is fully disabled.
     enabled: true
 
     # Shadow mode: extract but don't write to DB (dry-run for testing)
@@ -113,6 +114,8 @@ memory:
       # "claude-code" (Claude CLI), "codex" (Codex CLI), "opencode" (OpenCode), or "ollama" (local)
       provider: claude-code
       model: haiku
+      # ollama endpoint override (only used when provider resolves to ollama)
+      # endpoint: http://localhost:11434
       # timeout: 45000
       # minConfidence: 0.7
 

--- a/packages/cli/templates/agent.yaml.template
+++ b/packages/cli/templates/agent.yaml.template
@@ -114,8 +114,9 @@ memory:
       # "claude-code" (Claude CLI), "codex" (Codex CLI), "opencode" (OpenCode), or "ollama" (local)
       provider: claude-code
       model: haiku
-      # endpoint/base_url override (used by ollama and OpenCode ollama fallback)
-      # endpoint: http://localhost:11434
+      # endpoint/base_url override (ollama base URL, or OpenCode server URL when provider=opencode)
+      # endpoint: http://127.0.0.1:11434  # ollama
+      # endpoint: http://127.0.0.1:4096   # opencode
       # timeout: 45000
       # minConfidence: 0.7
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -151,6 +151,7 @@ export interface PipelineEscalationConfig {
 export interface PipelineExtractionConfig {
 	readonly provider: "ollama" | "claude-code" | "opencode" | "codex" | "anthropic";
 	readonly model: string;
+	readonly endpoint?: string;
 	readonly timeout: number;
 	readonly minConfidence: number;
 	readonly escalation?: PipelineEscalationConfig;
@@ -295,6 +296,7 @@ export interface PipelineSynthesisConfig {
 	readonly enabled: boolean;
 	readonly provider: "ollama" | "claude-code" | "opencode" | "anthropic";
 	readonly model: string;
+	readonly endpoint?: string;
 	readonly timeout: number;
 	readonly maxTokens: number;
 	readonly idleGapMinutes: number;

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -938,7 +938,7 @@ async function checkEmbeddingProvider(cfg: EmbeddingConfig): Promise<EmbeddingSt
 				// Native unavailable — check if ollama is available as fallback
 				logger.warn("embedding", `Native provider unavailable: ${nativeStatus.error ?? "unknown"}`);
 				try {
-					const ollamaRes = await fetch("http://localhost:11434/api/tags", {
+					const ollamaRes = await fetch("http://127.0.0.1:11434/api/tags", {
 						method: "GET",
 						signal: AbortSignal.timeout(3000),
 					});

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -230,8 +230,82 @@ const MEMORY_DB = join(AGENTS_DIR, "memory", "memories.db");
 const SCRIPTS_DIR = join(AGENTS_DIR, "scripts");
 
 // Config
-const PORT = Number.parseInt(process.env.SIGNET_PORT || "3850", 10);
-const HOST = process.env.SIGNET_HOST || "localhost";
+function readEnvTrimmed(key: string): string | undefined {
+	const raw = process.env[key];
+	if (typeof raw !== "string") return undefined;
+	const trimmed = raw.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeBaseUrl(url: string | undefined): string | undefined {
+	if (!url) return undefined;
+	return url.endsWith("/") ? url.slice(0, -1) : url;
+}
+
+function normalizeLoopbackHost(host: string): string {
+	return host === "localhost" ? "127.0.0.1" : host;
+}
+
+function normalizeRuntimeBaseUrl(url: string | undefined, fallback: string): string {
+	const base = normalizeBaseUrl(url) ?? fallback;
+	try {
+		const parsed = new URL(base);
+		if (parsed.hostname === "localhost" || parsed.hostname === "::1") {
+			parsed.hostname = "127.0.0.1";
+		}
+		return normalizeBaseUrl(parsed.toString()) ?? fallback;
+	} catch {
+		return base;
+	}
+}
+
+function isManagedOpenCodeLocalEndpoint(baseUrl: string): boolean {
+	try {
+		const parsed = new URL(baseUrl);
+		const isLoopbackHost =
+			parsed.hostname === "127.0.0.1" ||
+			parsed.hostname === "localhost" ||
+			parsed.hostname === "::1";
+		if (!isLoopbackHost) return false;
+		if (parsed.protocol !== "http:") return false;
+		const port = parsed.port.length > 0 ? Number.parseInt(parsed.port, 10) : 80;
+		return port === 4096;
+	} catch {
+		return false;
+	}
+}
+
+const PORT = Number.parseInt(readEnvTrimmed("SIGNET_PORT") ?? "3850", 10);
+const HOST = normalizeLoopbackHost(readEnvTrimmed("SIGNET_HOST") ?? "127.0.0.1");
+const BIND_HOST = normalizeLoopbackHost(readEnvTrimmed("SIGNET_BIND") ?? HOST);
+
+type RuntimeProviderName = "ollama" | "claude-code" | "opencode" | "codex";
+
+interface ProviderRuntimeResolution {
+	extraction: {
+		configured: string | null;
+		resolved: RuntimeProviderName;
+		effective: RuntimeProviderName;
+	};
+	synthesis: {
+		configured: string | null;
+		resolved: "ollama" | "claude-code" | "opencode" | "anthropic" | null;
+		effective: "ollama" | "claude-code" | "opencode" | "anthropic" | null;
+	};
+}
+
+const providerRuntimeResolution: ProviderRuntimeResolution = {
+	extraction: {
+		configured: null,
+		resolved: "claude-code",
+		effective: "claude-code",
+	},
+	synthesis: {
+		configured: null,
+		resolved: null,
+		effective: null,
+	},
+};
 
 // Autonomous maintenance singletons
 const providerTracker = createProviderTracker();
@@ -544,6 +618,43 @@ function parseIsoDateQuery(raw: string | undefined): string | undefined {
 	const date = new Date(value);
 	if (Number.isNaN(date.getTime())) return undefined;
 	return date.toISOString();
+}
+
+function getConfiguredProviderHints(agentsDir: string): {
+	readonly extraction: string | null;
+	readonly synthesis: string | null;
+} {
+	const paths = [
+		join(agentsDir, "agent.yaml"),
+		join(agentsDir, "AGENT.yaml"),
+		join(agentsDir, "config.yaml"),
+	];
+
+	for (const path of paths) {
+		if (!existsSync(path)) continue;
+		try {
+			const yaml = parseSimpleYaml(readFileSync(path, "utf-8"));
+			const mem = yaml.memory as Record<string, unknown> | undefined;
+			const pipeline = mem?.pipelineV2 as Record<string, unknown> | undefined;
+			const extractionObj = pipeline?.extraction as Record<string, unknown> | undefined;
+			const synthesisObj = pipeline?.synthesis as Record<string, unknown> | undefined;
+			const extraction =
+				typeof pipeline?.extractionProvider === "string"
+					? pipeline.extractionProvider
+					: typeof extractionObj?.provider === "string"
+						? extractionObj.provider
+						: null;
+			const synthesis =
+				typeof synthesisObj?.provider === "string"
+					? synthesisObj.provider
+					: null;
+			return { extraction, synthesis };
+		} catch {
+			continue;
+		}
+	}
+
+	return { extraction: null, synthesis: null };
 }
 
 interface LegacyEmbeddingsResponse {
@@ -6257,6 +6368,12 @@ app.get("/api/tasks/:id/runs", (c) => {
 
 app.get("/api/status", (c) => {
 	const config = loadMemoryConfig(AGENTS_DIR);
+	const configuredLogFile = readEnvTrimmed("SIGNET_LOG_FILE");
+	const configuredLogDir = readEnvTrimmed("SIGNET_LOG_DIR") ?? LOG_DIR;
+	const datedLogFile = join(
+		configuredLogDir,
+		`signet-${new Date().toISOString().slice(0, 10)}.log`,
+	);
 
 	let health: { score: number; status: string } | undefined;
 	try {
@@ -6293,9 +6410,15 @@ app.get("/api/status", (c) => {
 		startedAt: new Date(Date.now() - process.uptime() * 1000).toISOString(),
 		port: PORT,
 		host: HOST,
+		bindHost: BIND_HOST,
 		agentsDir: AGENTS_DIR,
 		memoryDb: existsSync(MEMORY_DB),
 		pipelineV2: config.pipelineV2,
+		providerResolution: providerRuntimeResolution,
+		logging: {
+			logDir: configuredLogFile ? dirname(configuredLogFile) : configuredLogDir,
+			logFile: configuredLogFile ?? datedLogFile,
+		},
 		activeSessions: activeSessionCount(),
 		bypassedSessions: getBypassedSessionKeys().size,
 		agentCreatedAt,
@@ -9015,7 +9138,7 @@ process.on("uncaughtException", (err) => {
 async function main() {
 	logger.info("daemon", "Signet Daemon starting");
 	logger.info("daemon", "Agents directory", { path: AGENTS_DIR });
-	logger.info("daemon", "Port configured", { port: PORT });
+	logger.info("daemon", "Network configured", { port: PORT, host: HOST, bindHost: BIND_HOST });
 
 	// Ensure daemon directory exists
 	mkdirSync(DAEMON_DIR, { recursive: true });
@@ -9064,14 +9187,73 @@ async function main() {
 	if (rl.batchForget) authBatchForgetLimiter = new AuthRateLimiter(rl.batchForget.windowMs, rl.batchForget.max);
 	if (rl.admin) authAdminLimiter = new AuthRateLimiter(rl.admin.windowMs, rl.admin.max);
 
+	const providerHints = getConfiguredProviderHints(AGENTS_DIR);
+	const validExtractionProviders = new Set([
+		"ollama",
+		"claude-code",
+		"opencode",
+		"codex",
+		"anthropic",
+	]);
+	const validSynthesisProviders = new Set([
+		"ollama",
+		"claude-code",
+		"opencode",
+		"anthropic",
+	]);
+
+	providerRuntimeResolution.extraction = {
+		configured: providerHints.extraction,
+		resolved: memoryCfg.pipelineV2.extraction.provider,
+		effective: memoryCfg.pipelineV2.extraction.provider,
+	};
+	providerRuntimeResolution.synthesis = {
+		configured: providerHints.synthesis,
+		resolved: memoryCfg.pipelineV2.synthesis.enabled ? memoryCfg.pipelineV2.synthesis.provider : null,
+		effective: memoryCfg.pipelineV2.synthesis.enabled ? memoryCfg.pipelineV2.synthesis.provider : null,
+	};
+	if (providerHints.extraction && !validExtractionProviders.has(providerHints.extraction)) {
+		logger.warn("config", "Unsupported extraction provider configured, using resolved fallback", {
+			configured: providerHints.extraction,
+			resolved: memoryCfg.pipelineV2.extraction.provider,
+		});
+	}
+	if (
+		providerHints.synthesis &&
+		memoryCfg.pipelineV2.synthesis.enabled &&
+		!validSynthesisProviders.has(providerHints.synthesis)
+	) {
+		logger.warn("config", "Unsupported synthesis provider configured, using resolved fallback", {
+			configured: providerHints.synthesis,
+			resolved: memoryCfg.pipelineV2.synthesis.provider,
+		});
+	}
+
 	// Auto-detect extraction provider: verify the configured provider is
 	// available, falling back to ollama with a warning if not.
 	let effectiveExtractionProvider = memoryCfg.pipelineV2.extraction.provider;
+	const extractionOllamaBaseUrl = normalizeRuntimeBaseUrl(
+		memoryCfg.pipelineV2.extraction.endpoint,
+		"http://127.0.0.1:11434",
+	);
+	const extractionOpenCodeBaseUrl = normalizeRuntimeBaseUrl(
+		memoryCfg.pipelineV2.extraction.endpoint,
+		"http://127.0.0.1:4096",
+	);
+	const extractionOpenCodeShouldManage = isManagedOpenCodeLocalEndpoint(
+		extractionOpenCodeBaseUrl,
+	);
 	if (effectiveExtractionProvider === "opencode") {
-		const serverReady = await ensureOpenCodeServer(4096);
-		if (!serverReady) {
-			logger.warn("config", "OpenCode server not available, falling back to ollama for extraction");
-			effectiveExtractionProvider = "ollama";
+		if (extractionOpenCodeShouldManage) {
+			const serverReady = await ensureOpenCodeServer(4096);
+			if (!serverReady) {
+				logger.warn("config", "OpenCode server not available, falling back to ollama for extraction");
+				effectiveExtractionProvider = "ollama";
+			}
+		} else {
+			logger.info("config", "Using external OpenCode endpoint for extraction", {
+				baseUrl: extractionOpenCodeBaseUrl,
+			});
 		}
 	} else if (effectiveExtractionProvider === "claude-code") {
 		try {
@@ -9110,7 +9292,29 @@ async function main() {
 			effectiveExtractionProvider = "ollama";
 		}
 	}
-	logger.info("config", "Extraction provider", { provider: effectiveExtractionProvider });
+	providerRuntimeResolution.extraction = {
+		configured: providerHints.extraction,
+		resolved: memoryCfg.pipelineV2.extraction.provider,
+		effective: effectiveExtractionProvider,
+	};
+	if (providerHints.extraction && providerHints.extraction !== effectiveExtractionProvider) {
+		logger.warn("config", "Extraction provider resolved differently than configured", {
+			configured: providerHints.extraction,
+			resolved: memoryCfg.pipelineV2.extraction.provider,
+			effective: effectiveExtractionProvider,
+		});
+	}
+	logger.info("config", "Extraction provider", {
+		configured: providerHints.extraction,
+		resolved: memoryCfg.pipelineV2.extraction.provider,
+		effective: effectiveExtractionProvider,
+		endpoint:
+			effectiveExtractionProvider === "ollama"
+				? extractionOllamaBaseUrl
+				: effectiveExtractionProvider === "opencode"
+					? extractionOpenCodeBaseUrl
+					: undefined,
+	});
 
 	// Resolve Anthropic API key once — shared by extraction and synthesis
 	let anthropicApiKey: string | undefined;
@@ -9152,6 +9356,8 @@ async function main() {
 			: effectiveExtractionProvider === "opencode"
 				? createOpenCodeProvider({
 						model: effectiveExtractionModel || "anthropic/claude-haiku-4-5-20251001",
+						baseUrl: extractionOpenCodeBaseUrl,
+						ollamaFallbackBaseUrl: "http://127.0.0.1:11434",
 						defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 					})
 				: effectiveExtractionProvider === "claude-code"
@@ -9166,6 +9372,7 @@ async function main() {
 							})
 						: createOllamaProvider({
 								model: effectiveExtractionModel || "qwen3:4b",
+								baseUrl: extractionOllamaBaseUrl,
 								defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 							});
 	initLlmProvider(llmProvider);
@@ -9174,11 +9381,28 @@ async function main() {
 	// needs a smarter model that can reason across long context
 	if (memoryCfg.pipelineV2.synthesis.enabled) {
 		let effectiveSynthesisProvider = memoryCfg.pipelineV2.synthesis.provider;
+		const synthesisOllamaBaseUrl = normalizeRuntimeBaseUrl(
+			memoryCfg.pipelineV2.synthesis.endpoint,
+			"http://127.0.0.1:11434",
+		);
+		const synthesisOpenCodeBaseUrl = normalizeRuntimeBaseUrl(
+			memoryCfg.pipelineV2.synthesis.endpoint,
+			"http://127.0.0.1:4096",
+		);
+		const synthesisOpenCodeShouldManage = isManagedOpenCodeLocalEndpoint(
+			synthesisOpenCodeBaseUrl,
+		);
 		if (effectiveSynthesisProvider === "opencode") {
-			const serverReady = await ensureOpenCodeServer(4096);
-			if (!serverReady) {
-				logger.warn("config", "OpenCode server not available for synthesis, falling back to ollama");
-				effectiveSynthesisProvider = "ollama";
+			if (synthesisOpenCodeShouldManage) {
+				const serverReady = await ensureOpenCodeServer(4096);
+				if (!serverReady) {
+					logger.warn("config", "OpenCode server not available for synthesis, falling back to ollama");
+					effectiveSynthesisProvider = "ollama";
+				}
+			} else {
+				logger.info("config", "Using external OpenCode endpoint for synthesis", {
+					baseUrl: synthesisOpenCodeBaseUrl,
+				});
 			}
 		} else if (effectiveSynthesisProvider === "anthropic") {
 			if (!anthropicApiKey) {
@@ -9202,7 +9426,29 @@ async function main() {
 				effectiveSynthesisProvider = "ollama";
 			}
 		}
-		logger.info("config", "Synthesis provider", { provider: effectiveSynthesisProvider });
+		providerRuntimeResolution.synthesis = {
+			configured: providerHints.synthesis,
+			resolved: memoryCfg.pipelineV2.synthesis.provider,
+			effective: effectiveSynthesisProvider,
+		};
+		if (providerHints.synthesis && providerHints.synthesis !== effectiveSynthesisProvider) {
+			logger.warn("config", "Synthesis provider resolved differently than configured", {
+				configured: providerHints.synthesis,
+				resolved: memoryCfg.pipelineV2.synthesis.provider,
+				effective: effectiveSynthesisProvider,
+			});
+		}
+		logger.info("config", "Synthesis provider", {
+			configured: providerHints.synthesis,
+			resolved: memoryCfg.pipelineV2.synthesis.provider,
+			effective: effectiveSynthesisProvider,
+			endpoint:
+				effectiveSynthesisProvider === "ollama"
+					? synthesisOllamaBaseUrl
+					: effectiveSynthesisProvider === "opencode"
+						? synthesisOpenCodeBaseUrl
+						: undefined,
+		});
 
 		// When falling back to ollama, reset model so ollama uses its own default
 		let effectiveSynthesisModel: string | undefined = memoryCfg.pipelineV2.synthesis.model;
@@ -9220,6 +9466,8 @@ async function main() {
 				: effectiveSynthesisProvider === "opencode"
 					? createOpenCodeProvider({
 							model: effectiveSynthesisModel || "anthropic/claude-haiku-4-5-20251001",
+							baseUrl: synthesisOpenCodeBaseUrl,
+							ollamaFallbackBaseUrl: "http://127.0.0.1:11434",
 							defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
 						})
 					: effectiveSynthesisProvider === "claude-code"
@@ -9229,10 +9477,16 @@ async function main() {
 							})
 						: createOllamaProvider({
 								model: effectiveSynthesisModel || "qwen3:4b",
+								baseUrl: synthesisOllamaBaseUrl,
 								defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
 							});
 		initSynthesisProvider(synthesisProvider);
 	} else {
+		providerRuntimeResolution.synthesis = {
+			configured: providerHints.synthesis,
+			resolved: null,
+			effective: null,
+		};
 		logger.info("config", "Synthesis disabled");
 	}
 
@@ -9284,8 +9538,9 @@ async function main() {
 		);
 	}
 
-	// Start extraction pipeline if enabled
-	if (memoryCfg.pipelineV2.enabled || memoryCfg.pipelineV2.shadowMode) {
+	// Start extraction pipeline only when explicitly enabled.
+	// shadowMode controls behavior inside the enabled pipeline.
+	if (memoryCfg.pipelineV2.enabled) {
 		startPipeline(
 			getDbAccessor(),
 			memoryCfg.pipelineV2,
@@ -9421,6 +9676,8 @@ async function main() {
 			env: {
 				...process.env,
 				SIGNET_PORT: String(PORT),
+				SIGNET_HOST: HOST,
+				SIGNET_BIND: BIND_HOST,
 				SIGNET_PATH: AGENTS_DIR,
 			},
 		});
@@ -9439,7 +9696,7 @@ async function main() {
 		{
 			fetch: app.fetch,
 			port: PORT,
-			hostname: HOST,
+			hostname: BIND_HOST,
 		},
 		(info) => {
 			logger.info("daemon", "Server listening", {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -280,13 +280,27 @@ function isManagedOpenCodeLocalEndpoint(baseUrl: string): boolean {
 	}
 }
 
+function redactUrlForLogs(url: string | undefined): string | undefined {
+	if (!url) return undefined;
+	try {
+		const parsed = new URL(url);
+		parsed.username = "";
+		parsed.password = "";
+		parsed.search = "";
+		parsed.hash = "";
+		return normalizeBaseUrl(parsed.toString()) ?? url;
+	} catch {
+		return url;
+	}
+}
+
 const PORT = parsePort(readEnvTrimmed("SIGNET_PORT"), 3850);
 const HOST = normalizeLoopbackHost(readEnvTrimmed("SIGNET_HOST") ?? "127.0.0.1");
 const BIND_HOST = normalizeLoopbackHost(readEnvTrimmed("SIGNET_BIND") ?? HOST);
 const INTERNAL_SELF_HOST =
 	BIND_HOST === "0.0.0.0" || BIND_HOST === "::" ? "127.0.0.1" : BIND_HOST;
 
-type RuntimeProviderName = "ollama" | "claude-code" | "opencode" | "codex";
+type RuntimeProviderName = "ollama" | "claude-code" | "opencode" | "codex" | "anthropic";
 
 interface ProviderRuntimeResolution {
 	extraction: {
@@ -9253,6 +9267,10 @@ async function main() {
 		memoryCfg.pipelineV2.extraction.endpoint,
 		"http://127.0.0.1:11434",
 	);
+	const extractionOllamaFallbackBaseUrl =
+		memoryCfg.pipelineV2.extraction.provider === "opencode"
+			? "http://127.0.0.1:11434"
+			: extractionOllamaBaseUrl;
 	const extractionOpenCodeBaseUrl = normalizeRuntimeBaseUrl(
 		memoryCfg.pipelineV2.extraction.endpoint,
 		"http://127.0.0.1:4096",
@@ -9269,7 +9287,7 @@ async function main() {
 			}
 		} else {
 			logger.info("config", "Using external OpenCode endpoint for extraction", {
-				baseUrl: extractionOpenCodeBaseUrl,
+				baseUrl: redactUrlForLogs(extractionOpenCodeBaseUrl),
 			});
 		}
 	} else if (effectiveExtractionProvider === "claude-code") {
@@ -9309,30 +9327,6 @@ async function main() {
 			effectiveExtractionProvider = "ollama";
 		}
 	}
-	providerRuntimeResolution.extraction = {
-		configured: providerHints.extraction,
-		resolved: memoryCfg.pipelineV2.extraction.provider,
-		effective: effectiveExtractionProvider,
-	};
-	if (providerHints.extraction && providerHints.extraction !== effectiveExtractionProvider) {
-		logger.warn("config", "Extraction provider resolved differently than configured", {
-			configured: providerHints.extraction,
-			resolved: memoryCfg.pipelineV2.extraction.provider,
-			effective: effectiveExtractionProvider,
-		});
-	}
-	logger.info("config", "Extraction provider", {
-		configured: providerHints.extraction,
-		resolved: memoryCfg.pipelineV2.extraction.provider,
-		effective: effectiveExtractionProvider,
-		endpoint:
-			effectiveExtractionProvider === "ollama"
-				? extractionOllamaBaseUrl
-				: effectiveExtractionProvider === "opencode"
-					? extractionOpenCodeBaseUrl
-					: undefined,
-	});
-
 	// Resolve Anthropic API key once — shared by extraction and synthesis
 	let anthropicApiKey: string | undefined;
 	const needsAnthropicForSynthesis =
@@ -9361,6 +9355,30 @@ async function main() {
 	if (effectiveExtractionProvider === "ollama" && memoryCfg.pipelineV2.extraction.provider !== "ollama") {
 		effectiveExtractionModel = undefined;
 	}
+	providerRuntimeResolution.extraction = {
+		configured: providerHints.extraction,
+		resolved: memoryCfg.pipelineV2.extraction.provider,
+		effective: effectiveExtractionProvider,
+	};
+	if (providerHints.extraction && providerHints.extraction !== effectiveExtractionProvider) {
+		logger.warn("config", "Extraction provider resolved differently than configured", {
+			configured: providerHints.extraction,
+			resolved: memoryCfg.pipelineV2.extraction.provider,
+			effective: effectiveExtractionProvider,
+		});
+	}
+	logger.info("config", "Extraction provider", {
+		configured: providerHints.extraction,
+		resolved: memoryCfg.pipelineV2.extraction.provider,
+		effective: effectiveExtractionProvider,
+		endpoint: redactUrlForLogs(
+			effectiveExtractionProvider === "ollama"
+				? extractionOllamaFallbackBaseUrl
+				: effectiveExtractionProvider === "opencode"
+					? extractionOpenCodeBaseUrl
+					: undefined,
+		),
+	});
 
 	// Create LLM provider once, register as daemon-wide singleton
 	const llmProvider =
@@ -9389,7 +9407,7 @@ async function main() {
 							})
 						: createOllamaProvider({
 								model: effectiveExtractionModel || "qwen3:4b",
-								baseUrl: extractionOllamaBaseUrl,
+								baseUrl: extractionOllamaFallbackBaseUrl,
 								defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 							});
 	initLlmProvider(llmProvider);
@@ -9402,6 +9420,10 @@ async function main() {
 			memoryCfg.pipelineV2.synthesis.endpoint,
 			"http://127.0.0.1:11434",
 		);
+		const synthesisOllamaFallbackBaseUrl =
+			memoryCfg.pipelineV2.synthesis.provider === "opencode"
+				? "http://127.0.0.1:11434"
+				: synthesisOllamaBaseUrl;
 		const synthesisOpenCodeBaseUrl = normalizeRuntimeBaseUrl(
 			memoryCfg.pipelineV2.synthesis.endpoint,
 			"http://127.0.0.1:4096",
@@ -9418,7 +9440,7 @@ async function main() {
 				}
 			} else {
 				logger.info("config", "Using external OpenCode endpoint for synthesis", {
-					baseUrl: synthesisOpenCodeBaseUrl,
+					baseUrl: redactUrlForLogs(synthesisOpenCodeBaseUrl),
 				});
 			}
 		} else if (effectiveSynthesisProvider === "anthropic") {
@@ -9459,12 +9481,13 @@ async function main() {
 			configured: providerHints.synthesis,
 			resolved: memoryCfg.pipelineV2.synthesis.provider,
 			effective: effectiveSynthesisProvider,
-			endpoint:
+			endpoint: redactUrlForLogs(
 				effectiveSynthesisProvider === "ollama"
-					? synthesisOllamaBaseUrl
+					? synthesisOllamaFallbackBaseUrl
 					: effectiveSynthesisProvider === "opencode"
 						? synthesisOpenCodeBaseUrl
 						: undefined,
+			),
 		});
 
 		// When falling back to ollama, reset model so ollama uses its own default
@@ -9492,11 +9515,11 @@ async function main() {
 								model: effectiveSynthesisModel || "haiku",
 								defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
 							})
-						: createOllamaProvider({
-								model: effectiveSynthesisModel || "qwen3:4b",
-								baseUrl: synthesisOllamaBaseUrl,
-								defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
-							});
+					: createOllamaProvider({
+							model: effectiveSynthesisModel || "qwen3:4b",
+							baseUrl: synthesisOllamaFallbackBaseUrl,
+							defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
+						});
 		initSynthesisProvider(synthesisProvider);
 	} else {
 		providerRuntimeResolution.synthesis = {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -243,7 +243,12 @@ function normalizeBaseUrl(url: string | undefined): string | undefined {
 }
 
 function normalizeLoopbackHost(host: string): string {
-	return host === "localhost" ? "127.0.0.1" : host;
+	return host === "localhost" || host === "::1" ? "127.0.0.1" : host;
+}
+
+function parsePort(raw: string | undefined, fallback: number): number {
+	const parsed = Number.parseInt(raw ?? "", 10);
+	return Number.isInteger(parsed) && parsed >= 1 && parsed <= 65_535 ? parsed : fallback;
 }
 
 function normalizeRuntimeBaseUrl(url: string | undefined, fallback: string): string {
@@ -275,7 +280,7 @@ function isManagedOpenCodeLocalEndpoint(baseUrl: string): boolean {
 	}
 }
 
-const PORT = Number.parseInt(readEnvTrimmed("SIGNET_PORT") ?? "3850", 10);
+const PORT = parsePort(readEnvTrimmed("SIGNET_PORT"), 3850);
 const HOST = normalizeLoopbackHost(readEnvTrimmed("SIGNET_HOST") ?? "127.0.0.1");
 const BIND_HOST = normalizeLoopbackHost(readEnvTrimmed("SIGNET_BIND") ?? HOST);
 const INTERNAL_SELF_HOST =

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -278,6 +278,8 @@ function isManagedOpenCodeLocalEndpoint(baseUrl: string): boolean {
 const PORT = Number.parseInt(readEnvTrimmed("SIGNET_PORT") ?? "3850", 10);
 const HOST = normalizeLoopbackHost(readEnvTrimmed("SIGNET_HOST") ?? "127.0.0.1");
 const BIND_HOST = normalizeLoopbackHost(readEnvTrimmed("SIGNET_BIND") ?? HOST);
+const INTERNAL_SELF_HOST =
+	BIND_HOST === "0.0.0.0" || BIND_HOST === "::" ? "127.0.0.1" : BIND_HOST;
 
 type RuntimeProviderName = "ollama" | "claude-code" | "opencode" | "codex";
 
@@ -629,32 +631,42 @@ function getConfiguredProviderHints(agentsDir: string): {
 		join(agentsDir, "AGENT.yaml"),
 		join(agentsDir, "config.yaml"),
 	];
+	let extraction: string | null = null;
+	let synthesis: string | null = null;
 
 	for (const path of paths) {
 		if (!existsSync(path)) continue;
 		try {
-			const yaml = parseSimpleYaml(readFileSync(path, "utf-8"));
-			const mem = yaml.memory as Record<string, unknown> | undefined;
-			const pipeline = mem?.pipelineV2 as Record<string, unknown> | undefined;
-			const extractionObj = pipeline?.extraction as Record<string, unknown> | undefined;
-			const synthesisObj = pipeline?.synthesis as Record<string, unknown> | undefined;
-			const extraction =
+			const yaml = toRecord(parseSimpleYaml(readFileSync(path, "utf-8")));
+			const mem = toRecord(yaml?.memory);
+			const pipeline = toRecord(mem?.pipelineV2);
+			const extractionObj = toRecord(pipeline?.extraction);
+			const synthesisObj = toRecord(pipeline?.synthesis);
+			const extractionInFile =
 				typeof pipeline?.extractionProvider === "string"
 					? pipeline.extractionProvider
 					: typeof extractionObj?.provider === "string"
 						? extractionObj.provider
 						: null;
-			const synthesis =
+			const synthesisInFile =
 				typeof synthesisObj?.provider === "string"
 					? synthesisObj.provider
 					: null;
-			return { extraction, synthesis };
+			if (extraction === null && extractionInFile !== null) {
+				extraction = extractionInFile;
+			}
+			if (synthesis === null && synthesisInFile !== null) {
+				synthesis = synthesisInFile;
+			}
+			if (extraction !== null && synthesis !== null) {
+				break;
+			}
 		} catch {
 			continue;
 		}
 	}
 
-	return { extraction: null, synthesis: null };
+	return { extraction, synthesis };
 }
 
 interface LegacyEmbeddingsResponse {
@@ -2249,7 +2261,7 @@ app.post("/api/memory/remember", async (c) => {
 		const importance = body.importance ?? parsedPrefixes.importance;
 		const pinned = (body.pinned ?? parsedPrefixes.pinned) ? 1 : 0;
 		const tags = body.tags ?? parsedPrefixes.tags;
-		const pipelineEnqueueEnabled = pipelineCfg.enabled || pipelineCfg.shadowMode;
+		const pipelineEnqueueEnabled = pipelineCfg.enabled;
 
 		const groupId = crypto.randomUUID();
 		const now = new Date().toISOString();
@@ -2420,7 +2432,7 @@ app.post("/api/memory/remember", async (c) => {
 	const normalizedContentForInsert =
 		normalizedContent.normalizedContent.length > 0 ? normalizedContent.normalizedContent : normalizedContent.hashBasis;
 	const contentHash = normalizedContent.contentHash;
-	const pipelineEnqueueEnabled = pipelineCfg.enabled || pipelineCfg.shadowMode;
+	const pipelineEnqueueEnabled = pipelineCfg.enabled;
 
 	type DedupeRow = {
 		id: string;
@@ -2606,7 +2618,7 @@ app.post("/api/memory/remember", async (c) => {
 app.post("/api/memory/save", async (c) => {
 	// Re-use the same handler by forwarding to the internal fetch
 	const body = await c.req.json().catch(() => ({}));
-	return fetch(`http://${HOST}:${PORT}/api/memory/remember`, {
+	return fetch(`http://${INTERNAL_SELF_HOST}:${PORT}/api/memory/remember`, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify(body),
@@ -2616,7 +2628,7 @@ app.post("/api/memory/save", async (c) => {
 // Alias for Claude Code skill compatibility
 app.post("/api/hook/remember", async (c) => {
 	const body = await c.req.json().catch(() => ({}));
-	return fetch(`http://${HOST}:${PORT}/api/memory/remember`, {
+	return fetch(`http://${INTERNAL_SELF_HOST}:${PORT}/api/memory/remember`, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify(body),
@@ -8673,7 +8685,7 @@ async function syncClaudeMemoryFile(filePath: string): Promise<number> {
 			syncedClaudeMemories.add(chunkKey);
 
 			try {
-				const response = await fetch(`http://${HOST}:${PORT}/api/memory/remember`, {
+				const response = await fetch(`http://${INTERNAL_SELF_HOST}:${PORT}/api/memory/remember`, {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({
@@ -8931,7 +8943,7 @@ async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 		const chunk = chunks[i];
 		const chunkKey = `openclaw:${filename}:${createHash("sha256").update(chunk.text).digest("hex").slice(0, 16)}`;
 		try {
-			const response = await fetch(`http://${HOST}:${PORT}/api/memory/remember`, {
+			const response = await fetch(`http://${INTERNAL_SELF_HOST}:${PORT}/api/memory/remember`, {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({

--- a/packages/daemon/src/diagnostics.test.ts
+++ b/packages/daemon/src/diagnostics.test.ts
@@ -80,6 +80,7 @@ function insertJob(
 	memId: string,
 	status: string,
 	createdAt = now,
+	updatedAt = now,
 ): void {
 	raw
 		.prepare(
@@ -88,7 +89,7 @@ function insertJob(
 				 created_at, updated_at)
 			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 		)
-		.run(id, memId, "extract", status, 0, 3, createdAt, now);
+		.run(id, memId, "extract", status, 0, 3, createdAt, updatedAt);
 }
 
 function insertHistory(
@@ -146,6 +147,19 @@ describe("getQueueHealth", () => {
 		const result = getQueueHealth(asReadDb(db));
 		expect(result.deadRate).toBeGreaterThan(0.01);
 		expect(result.score).toBeLessThan(1);
+	});
+
+	test("old dead jobs outside the recent window do not degrade queue health", () => {
+		const oldTs = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+		for (let i = 0; i < 20; i++) {
+			const memId = `mem-old-dead-${i}`;
+			insertMemory(db, memId);
+			insertJob(db, `job-old-dead-${i}`, memId, "dead", oldTs, oldTs);
+		}
+
+		const result = getQueueHealth(asReadDb(db));
+		expect(result.deadRate).toBe(0);
+		expect(result.status).toBe("healthy");
 	});
 });
 

--- a/packages/daemon/src/diagnostics.ts
+++ b/packages/daemon/src/diagnostics.ts
@@ -193,6 +193,8 @@ function clamp(n: number): number {
 	return Math.max(0, Math.min(1, n));
 }
 
+const QUEUE_RECENT_WINDOW_MS = 60 * 60 * 1000;
+
 // ---------------------------------------------------------------------------
 // Domain health functions
 // ---------------------------------------------------------------------------
@@ -211,7 +213,7 @@ export function getQueueHealth(db: ReadDb): QueueHealth {
 		? Math.max(0, (Date.now() - new Date(oldestAt).getTime()) / 1000)
 		: 0;
 
-	const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+	const windowStart = new Date(Date.now() - QUEUE_RECENT_WINDOW_MS).toISOString();
 	const deadRow = db
 		.prepare(
 			`SELECT
@@ -220,7 +222,7 @@ export function getQueueHealth(db: ReadDb): QueueHealth {
 			 FROM memory_jobs
 			 WHERE updated_at >= ?`,
 		)
-		.get(oneDayAgo) as { dead: number; total: number } | undefined;
+		.get(windowStart) as { dead: number; total: number } | undefined;
 
 	const dead = deadRow?.dead ?? 0;
 	const completedAndDead = deadRow?.total ?? 0;

--- a/packages/daemon/src/logger.ts
+++ b/packages/daemon/src/logger.ts
@@ -21,7 +21,7 @@ import {
 	unlinkSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 
 // Types
 export type LogLevel = "debug" | "info" | "warn" | "error";
@@ -66,6 +66,7 @@ export interface LogEntry {
 
 export interface LoggerConfig {
 	logDir: string;
+	logFilePath?: string;
 	level: LogLevel;
 	maxFileSize: number; // bytes
 	maxFiles: number; // number of rotated files to keep
@@ -83,6 +84,7 @@ const LOG_LEVELS: Record<LogLevel, number> = {
 // Default configuration
 const DEFAULT_CONFIG: LoggerConfig = {
 	logDir: join(homedir(), ".agents", ".daemon", "logs"),
+	logFilePath: undefined,
 	level: "info",
 	maxFileSize: 10 * 1024 * 1024, // 10MB
 	maxFiles: 5,
@@ -108,8 +110,11 @@ class Logger extends EventEmitter {
 
 	private ensureLogDir() {
 		try {
-			if (!existsSync(this.config.logDir)) {
-				mkdirSync(this.config.logDir, { recursive: true });
+			const dir = this.config.logFilePath
+				? dirname(this.config.logFilePath)
+				: this.config.logDir;
+			if (!existsSync(dir)) {
+				mkdirSync(dir, { recursive: true });
 			}
 		} catch (e) {
 			this.fileOutputEnabled = false;
@@ -118,6 +123,9 @@ class Logger extends EventEmitter {
 	}
 
 	private getLogFileName(): string {
+		if (this.config.logFilePath) {
+			return this.config.logFilePath;
+		}
 		const date = new Date().toISOString().split("T")[0];
 		return join(this.config.logDir, `signet-${date}.log`);
 	}
@@ -156,9 +164,19 @@ class Logger extends EventEmitter {
 	}
 
 	private listLogFilesNewestFirst(): Array<{ name: string; path: string }> {
-		if (!this.fileOutputEnabled || !existsSync(this.config.logDir)) {
+		if (!this.fileOutputEnabled) {
 			return [];
 		}
+		if (this.config.logFilePath) {
+			if (!existsSync(this.config.logFilePath)) return [];
+			return [
+				{
+					name: basename(this.config.logFilePath),
+					path: this.config.logFilePath,
+				},
+			];
+		}
+		if (!existsSync(this.config.logDir)) return [];
 		return readdirSync(this.config.logDir)
 			.filter((f) => this.parseLogFileName(f) !== null)
 			.map((f) => ({
@@ -254,6 +272,7 @@ class Logger extends EventEmitter {
 
 	private checkRotation() {
 		if (!this.fileOutputEnabled) return;
+		if (this.config.logFilePath) return;
 		try {
 			if (!existsSync(this.currentLogFile)) return;
 
@@ -485,6 +504,15 @@ class Logger extends EventEmitter {
 }
 
 // Singleton instance
-export const logger = new Logger();
+const envLogFile = process.env.SIGNET_LOG_FILE?.trim();
+const envLogDir = process.env.SIGNET_LOG_DIR?.trim();
+const loggerConfig: Partial<LoggerConfig> = {
+	...(envLogFile
+		? { logFilePath: envLogFile, logDir: dirname(envLogFile) }
+		: envLogDir
+			? { logDir: envLogDir }
+			: {}),
+};
+export const logger = new Logger(loggerConfig);
 
 export default logger;

--- a/packages/daemon/src/mcp-stdio.ts
+++ b/packages/daemon/src/mcp-stdio.ts
@@ -13,7 +13,7 @@ import { createMcpServer, refreshMarketplaceProxyTools } from "./mcp/tools.js";
 
 const DAEMON_URL =
 	process.env.SIGNET_DAEMON_URL ??
-	`http://${process.env.SIGNET_HOST ?? "localhost"}:${process.env.SIGNET_PORT ?? "3850"}`;
+	`http://${process.env.SIGNET_HOST ?? "127.0.0.1"}:${process.env.SIGNET_PORT ?? "3850"}`;
 
 const server = await createMcpServer({
 	daemonUrl: DAEMON_URL,

--- a/packages/daemon/src/memory-config.test.ts
+++ b/packages/daemon/src/memory-config.test.ts
@@ -126,6 +126,17 @@ describe("loadMemoryConfig", () => {
 		expect(cfg.embedding.base_url).toBe("http://192.168.1.100:11434");
 	});
 
+	it("accepts embedding.endpoint as an alias for embedding.base_url", () => {
+		const agentsDir = makeTempAgentsDir();
+		writeFileSync(
+			join(agentsDir, "agent.yaml"),
+			"embedding:\n  provider: ollama\n  model: nomic-embed-text\n  endpoint: http://172.17.0.1:11434\n",
+		);
+		const cfg = loadMemoryConfig(agentsDir);
+		expect(cfg.embedding.provider).toBe("ollama");
+		expect(cfg.embedding.base_url).toBe("http://172.17.0.1:11434");
+	});
+
 	it("defaults ollama base_url when explicitly empty", () => {
 		const agentsDir = makeTempAgentsDir();
 		writeFileSync(
@@ -266,6 +277,36 @@ describe("loadPipelineConfig", () => {
 		// Flat keys win as a pair — dashboard writes flat, so they must take priority
 		expect(result.extraction.provider).toBe("ollama");
 		expect(result.extraction.model).toBe("qwen3:4b");
+	});
+
+	it("parses extraction endpoint aliases", () => {
+		const result = loadPipelineConfig({
+			memory: {
+				pipelineV2: {
+					extraction: {
+						provider: "ollama",
+						model: "qwen3:1.7b",
+						endpoint: "http://172.17.0.1:11434",
+					},
+				},
+			},
+		});
+		expect(result.extraction.endpoint).toBe("http://172.17.0.1:11434");
+	});
+
+	it("parses synthesis base_url as endpoint alias", () => {
+		const result = loadPipelineConfig({
+			memory: {
+				pipelineV2: {
+					synthesis: {
+						provider: "ollama",
+						model: "qwen3:4b",
+						base_url: "http://172.17.0.1:11434",
+					},
+				},
+			},
+		});
+		expect(result.synthesis.endpoint).toBe("http://172.17.0.1:11434");
 	});
 
 	it("flat provider without flat model uses provider default", () => {

--- a/packages/daemon/src/memory-config.ts
+++ b/packages/daemon/src/memory-config.ts
@@ -36,6 +36,7 @@ export const DEFAULT_PIPELINE_V2: PipelineV2Config = {
 	extraction: {
 		provider: "claude-code",
 		model: "haiku",
+		endpoint: undefined,
 		timeout: 90000,
 		minConfidence: 0.7,
 		escalation: {
@@ -123,6 +124,7 @@ export const DEFAULT_PIPELINE_V2: PipelineV2Config = {
 		enabled: true,
 		provider: "claude-code",
 		model: "haiku",
+		endpoint: undefined,
 		timeout: 120000,
 		maxTokens: 8000,
 		idleGapMinutes: 15,
@@ -198,6 +200,12 @@ function clampPositive(
 function clampFraction(raw: unknown, fallback: number): number {
 	if (typeof raw !== "number" || !Number.isFinite(raw)) return fallback;
 	return Math.max(0, Math.min(1, raw));
+}
+
+function parseOptionalUrl(raw: unknown): string | undefined {
+	if (typeof raw !== "string") return undefined;
+	const trimmed = raw.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
 }
 
 /**
@@ -299,6 +307,11 @@ export function loadPipelineConfig(
 					: flatModelOnly
 						? flatModel
 						: d.extraction.model,
+			endpoint:
+				parseOptionalUrl(extractionRaw?.endpoint) ??
+				parseOptionalUrl(extractionRaw?.base_url) ??
+				parseOptionalUrl(raw.extractionEndpoint) ??
+				parseOptionalUrl(raw.extractionBaseUrl),
 			timeout: clampPositive(
 				extractionRaw?.timeout ?? raw.extractionTimeout,
 				5000,
@@ -648,6 +661,9 @@ export function loadPipelineConfig(
 				typeof synthesisRaw?.model === "string"
 					? synthesisRaw.model
 					: d.synthesis.model,
+			endpoint:
+				parseOptionalUrl(synthesisRaw?.endpoint) ??
+				parseOptionalUrl(synthesisRaw?.base_url),
 			timeout: clampPositive(
 				synthesisRaw?.timeout,
 				5000,
@@ -897,7 +913,9 @@ export function loadMemoryConfig(agentsDir: string): ResolvedMemoryConfig {
 					String(emb.dimensions ?? "768"),
 					10,
 				);
-				const explicitBaseUrl = emb.base_url as string | undefined;
+				const explicitBaseUrl =
+					(typeof emb.base_url === "string" ? emb.base_url : undefined) ??
+					(typeof emb.endpoint === "string" ? emb.endpoint : undefined);
 				if (defaults.embedding.provider === "ollama") {
 					defaults.embedding.base_url =
 						typeof explicitBaseUrl === "string" && explicitBaseUrl.trim().length > 0

--- a/packages/daemon/src/pipeline/decision.test.ts
+++ b/packages/daemon/src/pipeline/decision.test.ts
@@ -193,6 +193,40 @@ describe("runShadowDecisions", () => {
 		expect(result.warnings).toHaveLength(0);
 	});
 
+	it("passes timeout options through to decision provider calls", async () => {
+		insertMemory(db, "mem-timeout", MATCHING_MEMORY_CONTENT);
+
+		let seenTimeout: number | undefined;
+		const provider: LlmProvider = {
+			name: "mock-timeout",
+			async generate(_prompt, opts) {
+				seenTimeout = opts?.timeoutMs;
+				return JSON.stringify({
+					action: "none",
+					confidence: 0.8,
+					reason: "already covered",
+				});
+			},
+			async available() {
+				return true;
+			},
+		};
+
+		const timeoutCfg: DecisionConfig = {
+			...cfg,
+			timeoutMs: 54321,
+		};
+		const result = await runShadowDecisions(
+			[MATCHING_FACT],
+			accessor,
+			provider,
+			timeoutCfg,
+		);
+
+		expect(result.proposals).toHaveLength(1);
+		expect(seenTimeout).toBe(54321);
+	});
+
 	it("rejects an invalid action with a warning", async () => {
 		insertMemory(db, "mem-002", MATCHING_MEMORY_CONTENT);
 

--- a/packages/daemon/src/pipeline/decision.ts
+++ b/packages/daemon/src/pipeline/decision.ts
@@ -32,6 +32,7 @@ interface CandidateMemory {
 export interface DecisionConfig {
 	readonly embedding: EmbeddingConfig;
 	readonly search: MemorySearchConfig;
+	readonly timeoutMs?: number;
 	readonly fetchEmbedding: (
 		text: string,
 		cfg: EmbeddingConfig,
@@ -309,7 +310,9 @@ export async function runShadowDecisions(
 		const prompt = buildDecisionPrompt(fact, candidates);
 
 		try {
-			const output = await provider.generate(prompt);
+			const output = await provider.generate(prompt, {
+				timeoutMs: cfg.timeoutMs,
+			});
 			const proposal = parseDecision(output, candidateIds, warnings);
 			if (proposal) {
 				const targetContent =

--- a/packages/daemon/src/pipeline/extraction-escalation.ts
+++ b/packages/daemon/src/pipeline/extraction-escalation.ts
@@ -107,11 +107,12 @@ async function runLevel2Extraction(
 	content: string,
 	provider: LlmProvider,
 	maxEntities: number,
+	timeoutMs?: number,
 ): Promise<ExtractionResult> {
 	const prompt = buildLevel2Prompt(content, maxEntities);
 	let rawOutput: string;
 	try {
-		rawOutput = await provider.generate(prompt);
+		rawOutput = await provider.generate(prompt, { timeoutMs });
 	} catch (e) {
 		const msg = e instanceof Error ? e.message : String(e);
 		logger.warn("pipeline", "Level 2 extraction LLM call failed", {
@@ -230,6 +231,7 @@ export async function escalate(
 	accessor: DbAccessor,
 	agentId: string,
 	thresholds: PipelineEscalationConfig,
+	opts?: { timeoutMs?: number },
 ): Promise<EscalatedExtraction> {
 	const originalEntityCount = extraction.entities.length;
 	const originalFactCount = extraction.facts.length;
@@ -247,7 +249,12 @@ export async function escalate(
 		threshold: thresholds.maxNewEntitiesPerChunk,
 	});
 
-	const level2 = await runLevel2Extraction(content, provider, thresholds.level2MaxEntities);
+	const level2 = await runLevel2Extraction(
+		content,
+		provider,
+		thresholds.level2MaxEntities,
+		opts?.timeoutMs,
+	);
 	const level2Needed = checkEscalationNeeded(level2, thresholds);
 	if (level2Needed === 1) {
 		return { result: level2, level: 2, originalEntityCount, originalFactCount };

--- a/packages/daemon/src/pipeline/extraction.test.ts
+++ b/packages/daemon/src/pipeline/extraction.test.ts
@@ -47,6 +47,28 @@ const VALID_RESPONSE = JSON.stringify({
 // ---------------------------------------------------------------------------
 
 describe("extractFactsAndEntities", () => {
+	it("passes timeout options through to the provider", async () => {
+		let seenTimeout: number | undefined;
+		const provider: LlmProvider = {
+			name: "timeout-probe",
+			async generate(_prompt, opts) {
+				seenTimeout = opts?.timeoutMs;
+				return VALID_RESPONSE;
+			},
+			async available() {
+				return true;
+			},
+		};
+
+		await extractFactsAndEntities(
+			"User prefers dark mode and uses vim keybindings",
+			provider,
+			{ timeoutMs: 12345 },
+		);
+
+		expect(seenTimeout).toBe(12345);
+	});
+
 	it("parses valid JSON response correctly", async () => {
 		const provider = mockProvider([VALID_RESPONSE]);
 		const result = await extractFactsAndEntities(

--- a/packages/daemon/src/pipeline/extraction.ts
+++ b/packages/daemon/src/pipeline/extraction.ts
@@ -318,7 +318,11 @@ export function parseRawExtractionOutput(rawOutput: string): ExtractionResult {
 // Main extraction function
 // ---------------------------------------------------------------------------
 
-export async function extractFactsAndEntities(input: string, provider: LlmProvider): Promise<ExtractionResult> {
+export async function extractFactsAndEntities(
+	input: string,
+	provider: LlmProvider,
+	opts?: { timeoutMs?: number },
+): Promise<ExtractionResult> {
 	const trimmed = input.trim().replace(/\s+/g, " ");
 	if (trimmed.length < 20) {
 		return {
@@ -334,7 +338,9 @@ export async function extractFactsAndEntities(input: string, provider: LlmProvid
 
 	let rawOutput: string;
 	try {
-		rawOutput = await provider.generate(prompt);
+		rawOutput = await provider.generate(prompt, {
+			timeoutMs: opts?.timeoutMs,
+		});
 	} catch (e) {
 		const msg = e instanceof Error ? e.message : String(e);
 		logger.warn("pipeline", "Extraction LLM call failed", { error: msg });

--- a/packages/daemon/src/pipeline/index.ts
+++ b/packages/daemon/src/pipeline/index.ts
@@ -86,12 +86,17 @@ export function startPipeline(
 		logger.warn("pipeline", "Pipeline already running, skipping start");
 		return;
 	}
+	if (!pipelineCfg.enabled) {
+		logger.info("pipeline", "Pipeline disabled; worker start skipped");
+		return;
+	}
 
 	const provider = getLlmProvider();
 
 	const decisionCfg: DecisionConfig = {
 		embedding: embeddingCfg,
 		search: searchCfg,
+		timeoutMs: pipelineCfg.extraction.timeout,
 		fetchEmbedding,
 	};
 

--- a/packages/daemon/src/pipeline/provider.test.ts
+++ b/packages/daemon/src/pipeline/provider.test.ts
@@ -505,4 +505,52 @@ describe("createOpenCodeProvider", () => {
 		expect(result).toBe('{"facts":[],"entities":[]}');
 		expect(getCalls).toBeGreaterThan(0);
 	});
+
+	it("uses configured ollama fallback base URL for OpenCode fallback", async () => {
+		const seenUrls: string[] = [];
+		mockFetch(async (url, init) => {
+			seenUrls.push(url);
+			if (url.includes("/session") && !url.includes("/message")) {
+				return Response.json({
+					id: "ses_fallback",
+					slug: "test",
+					projectID: "p",
+					directory: "/tmp",
+					title: "test",
+					version: "1",
+				});
+			}
+			if (url.includes("/session/ses_fallback/message")) {
+				if (init?.method === "POST") {
+					return new Response("", {
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					});
+				}
+				return Response.json([
+					{
+						info: { role: "user" },
+						parts: [{ type: "text", text: "still pending" }],
+					},
+				]);
+			}
+			if (url === "http://172.17.0.1:11434/api/tags") {
+				return Response.json({ models: [] });
+			}
+			if (url === "http://172.17.0.1:11434/api/generate") {
+				return Response.json({ response: '{"facts":[],"entities":[]}' });
+			}
+			return new Response("unexpected url", { status: 500 });
+		});
+
+		const provider = createOpenCodeProvider({
+			baseUrl: "http://localhost:9999",
+			enableOllamaFallback: true,
+			ollamaFallbackBaseUrl: "http://172.17.0.1:11434",
+		});
+		const result = await provider.generate("test", { timeoutMs: 250 });
+		expect(result).toBe('{"facts":[],"entities":[]}');
+		expect(seenUrls).toContain("http://172.17.0.1:11434/api/tags");
+		expect(seenUrls).toContain("http://172.17.0.1:11434/api/generate");
+	});
 });

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -173,6 +173,10 @@ const DEFAULT_OLLAMA_CONFIG: OllamaProviderConfig = {
 	defaultTimeoutMs: 90000,
 };
 
+function trimTrailingSlash(url: string): string {
+	return url.endsWith("/") ? url.slice(0, -1) : url;
+}
+
 interface OllamaGenerateResponse {
 	readonly response?: string;
 	readonly eval_count?: number;
@@ -184,7 +188,8 @@ interface OllamaGenerateResponse {
 export function createOllamaProvider(
 	config?: Partial<OllamaProviderConfig>,
 ): LlmProvider {
-	const cfg = { ...DEFAULT_OLLAMA_CONFIG, ...config };
+	const merged = { ...DEFAULT_OLLAMA_CONFIG, ...config };
+	const cfg = { ...merged, baseUrl: trimTrailingSlash(merged.baseUrl) };
 
 	async function callOllama(
 		prompt: string,
@@ -936,6 +941,7 @@ export interface OpenCodeProviderConfig {
 	readonly defaultTimeoutMs: number;
 	readonly enableOllamaFallback: boolean;
 	readonly ollamaFallbackModel: string;
+	readonly ollamaFallbackBaseUrl: string;
 }
 
 const DEFAULT_OPENCODE_CONFIG: OpenCodeProviderConfig = {
@@ -944,6 +950,7 @@ const DEFAULT_OPENCODE_CONFIG: OpenCodeProviderConfig = {
 	defaultTimeoutMs: 60000,
 	enableOllamaFallback: true,
 	ollamaFallbackModel: "qwen3:4b",
+	ollamaFallbackBaseUrl: "http://localhost:11434",
 };
 
 /**
@@ -1202,7 +1209,12 @@ function extractOpenCodeText(data: OpenCodeMessageResponse): string {
 export function createOpenCodeProvider(
 	config?: Partial<OpenCodeProviderConfig>,
 ): LlmProvider {
-	const cfg = { ...DEFAULT_OPENCODE_CONFIG, ...config };
+	const merged = { ...DEFAULT_OPENCODE_CONFIG, ...config };
+	const cfg = {
+		...merged,
+		baseUrl: trimTrailingSlash(merged.baseUrl),
+		ollamaFallbackBaseUrl: trimTrailingSlash(merged.ollamaFallbackBaseUrl),
+	};
 
 	// Parse "provider/model" format (e.g. "anthropic/claude-haiku-4-5-20251001")
 	const slashIdx = cfg.model.indexOf("/");
@@ -1216,6 +1228,7 @@ export function createOpenCodeProvider(
 		if (ollamaFallbackProvider) return ollamaFallbackProvider;
 		ollamaFallbackProvider = createOllamaProvider({
 			model: cfg.ollamaFallbackModel,
+			baseUrl: cfg.ollamaFallbackBaseUrl,
 			defaultTimeoutMs: cfg.defaultTimeoutMs,
 		});
 		return ollamaFallbackProvider;
@@ -1248,7 +1261,7 @@ export function createOpenCodeProvider(
 			let inputTokens: number | null = null;
 			let outputTokens: number | null = null;
 			try {
-				const res = await fetch("http://localhost:11434/api/generate", {
+				const res = await fetch(`${cfg.ollamaFallbackBaseUrl}/api/generate`, {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -169,7 +169,7 @@ export interface OllamaProviderConfig {
 
 const DEFAULT_OLLAMA_CONFIG: OllamaProviderConfig = {
 	model: "qwen3:4b",
-	baseUrl: "http://localhost:11434",
+	baseUrl: "http://127.0.0.1:11434",
 	defaultTimeoutMs: 90000,
 };
 
@@ -945,12 +945,12 @@ export interface OpenCodeProviderConfig {
 }
 
 const DEFAULT_OPENCODE_CONFIG: OpenCodeProviderConfig = {
-	baseUrl: "http://localhost:4096",
+	baseUrl: "http://127.0.0.1:4096",
 	model: "anthropic/claude-haiku-4-5-20251001",
 	defaultTimeoutMs: 60000,
 	enableOllamaFallback: true,
 	ollamaFallbackModel: "qwen3:4b",
-	ollamaFallbackBaseUrl: "http://localhost:11434",
+	ollamaFallbackBaseUrl: "http://127.0.0.1:11434",
 };
 
 /**
@@ -990,7 +990,7 @@ let openCodeChild: {
  * configured port. Tracks the child for explicit cleanup.
  */
 export async function ensureOpenCodeServer(port: number): Promise<boolean> {
-	const healthUrl = `http://localhost:${port}/global/health`;
+	const healthUrl = `http://127.0.0.1:${port}/global/health`;
 
 	// Already managed by us?
 	if (openCodeChild?.port === port) {

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -797,6 +797,7 @@ async function resolveProvider(cfg: ReturnType<typeof loadMemoryConfig>): Promis
 	const p = cfg.pipelineV2.synthesis.provider;
 	const model = cfg.pipelineV2.synthesis.model;
 	const timeout = cfg.pipelineV2.synthesis.timeout;
+	const endpoint = cfg.pipelineV2.synthesis.endpoint;
 	switch (p) {
 		case "anthropic": {
 			let apiKey = process.env.ANTHROPIC_API_KEY;
@@ -816,9 +817,18 @@ async function resolveProvider(cfg: ReturnType<typeof loadMemoryConfig>): Promis
 		case "claude-code":
 			return createClaudeCodeProvider({ model: model || "haiku", defaultTimeoutMs: timeout });
 		case "opencode":
-			return createOpenCodeProvider({ model: model || "anthropic/claude-haiku-4-5-20251001", defaultTimeoutMs: timeout });
+			return createOpenCodeProvider({
+				model: model || "anthropic/claude-haiku-4-5-20251001",
+				baseUrl: endpoint ?? "http://127.0.0.1:4096",
+				ollamaFallbackBaseUrl: "http://127.0.0.1:11434",
+				defaultTimeoutMs: timeout,
+			});
 		default:
-			return createOllamaProvider({ model: model || "qwen3:4b", defaultTimeoutMs: timeout });
+			return createOllamaProvider({
+				model: model || "qwen3:4b",
+				baseUrl: endpoint,
+				defaultTimeoutMs: timeout,
+			});
 	}
 }
 
@@ -841,7 +851,7 @@ export function startSummaryWorker(
 
 		// Re-check config each tick — respect runtime config changes
 		const cfg = loadMemoryConfig(AGENTS_DIR);
-		if (!cfg.pipelineV2.enabled && !cfg.pipelineV2.shadowMode) {
+		if (!cfg.pipelineV2.enabled) {
 			scheduleTick(POLL_INTERVAL_MS);
 			return;
 		}

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -249,8 +249,7 @@ async function processJob(
 		summaryChars: result.summary.length,
 	});
 
-	let saved = 0;
-	saved = insertSummaryFacts(accessor, job, result.facts);
+	const saved = insertSummaryFacts(accessor, job, result.facts);
 
 	logger.info("summary-worker", "Inserted session facts", {
 		total: result.facts.length,

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -250,24 +250,16 @@ async function processJob(
 	});
 
 	let saved = 0;
-	if (memoryCfg.pipelineV2.shadowMode) {
-		logger.info("summary-worker", "Shadow mode enabled — skipping summary fact writes", {
-			total: result.facts.length,
-			sessionKey: job.session_key,
-			project: job.project,
-		});
-	} else {
-		saved = insertSummaryFacts(accessor, job, result.facts);
+	saved = insertSummaryFacts(accessor, job, result.facts);
 
-		logger.info("summary-worker", "Inserted session facts", {
-			total: result.facts.length,
-			saved,
-			deduplicated: result.facts.length - saved,
-			factsPreview: result.facts
-				.slice(0, 10)
-				.map((fact) => fact.content),
-		});
-	}
+	logger.info("summary-worker", "Inserted session facts", {
+		total: result.facts.length,
+		saved,
+		deduplicated: result.facts.length - saved,
+		factsPreview: result.facts
+			.slice(0, 10)
+			.map((fact) => fact.content),
+	});
 
 	// Agent ID is hardcoded because summary_jobs and session_scores tables
 	// lack an agent_id column (pre-existing schema limitation). In a

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -249,16 +249,25 @@ async function processJob(
 		summaryChars: result.summary.length,
 	});
 
-	const saved = insertSummaryFacts(accessor, job, result.facts);
+	let saved = 0;
+	if (memoryCfg.pipelineV2.shadowMode) {
+		logger.info("summary-worker", "Shadow mode enabled — skipping summary fact writes", {
+			total: result.facts.length,
+			sessionKey: job.session_key,
+			project: job.project,
+		});
+	} else {
+		saved = insertSummaryFacts(accessor, job, result.facts);
 
-	logger.info("summary-worker", "Inserted session facts", {
-		total: result.facts.length,
-		saved,
-		deduplicated: result.facts.length - saved,
-		factsPreview: result.facts
-			.slice(0, 10)
-			.map((fact) => fact.content),
-	});
+		logger.info("summary-worker", "Inserted session facts", {
+			total: result.facts.length,
+			saved,
+			deduplicated: result.facts.length - saved,
+			factsPreview: result.facts
+				.slice(0, 10)
+				.map((fact) => fact.content),
+		});
+	}
 
 	// Agent ID is hardcoded because summary_jobs and session_scores tables
 	// lack an agent_id column (pre-existing schema limitation). In a
@@ -826,7 +835,7 @@ async function resolveProvider(cfg: ReturnType<typeof loadMemoryConfig>): Promis
 		default:
 			return createOllamaProvider({
 				model: model || "qwen3:4b",
-				baseUrl: endpoint,
+				...(endpoint ? { baseUrl: endpoint } : {}),
 				defaultTimeoutMs: timeout,
 			});
 	}
@@ -851,7 +860,7 @@ export function startSummaryWorker(
 
 		// Re-check config each tick — respect runtime config changes
 		const cfg = loadMemoryConfig(AGENTS_DIR);
-		if (!cfg.pipelineV2.enabled) {
+		if (!cfg.pipelineV2.enabled || cfg.pipelineV2.shadowMode) {
 			scheduleTick(POLL_INTERVAL_MS);
 			return;
 		}

--- a/packages/daemon/src/pipeline/synthesis-worker.ts
+++ b/packages/daemon/src/pipeline/synthesis-worker.ts
@@ -78,6 +78,18 @@ function writeLastSynthesisTime(timestamp: number): void {
  * Get the timestamp of the most recent session end from checkpoints.
  * Falls back to the latest completed summary job when no checkpoint exists.
  */
+function parseLastEndTimestamp(row: unknown): number {
+	if (typeof row !== "object" || row === null || !("last_end" in row)) {
+		return 0;
+	}
+	const value = row.last_end;
+	if (typeof value !== "string" || value.length === 0) {
+		return 0;
+	}
+	const ts = Date.parse(value);
+	return Number.isNaN(ts) ? 0 : ts;
+}
+
 function isExpectedSessionActivityLookupError(error: unknown, table: string): boolean {
 	if (!(error instanceof Error)) return false;
 	const message = error.message.toLowerCase();
@@ -95,10 +107,11 @@ function getLastSessionEndTime(): number {
 				SELECT MAX(created_at) as last_end
 				FROM session_checkpoints
 				WHERE trigger = 'session_end'
-			`).get() as { last_end: string | null } | undefined;
+			`).get();
 		});
-		if (checkpointRow?.last_end) {
-			return new Date(checkpointRow.last_end).getTime();
+		const checkpointTs = parseLastEndTimestamp(checkpointRow);
+		if (checkpointTs > 0) {
+			return checkpointTs;
 		}
 	} catch (error) {
 		if (!isExpectedSessionActivityLookupError(error, "session_checkpoints")) {
@@ -119,10 +132,9 @@ function getLastSessionEndTime(): number {
 					FROM summary_jobs
 					WHERE status = 'completed'
 				`)
-				.get() as { last_end: string | null } | undefined;
+				.get();
 		});
-		if (!summaryRow?.last_end) return 0;
-		return new Date(summaryRow.last_end).getTime();
+		return parseLastEndTimestamp(summaryRow);
 	} catch (error) {
 		if (!isExpectedSessionActivityLookupError(error, "summary_jobs")) {
 			logger.error(

--- a/packages/daemon/src/pipeline/synthesis-worker.ts
+++ b/packages/daemon/src/pipeline/synthesis-worker.ts
@@ -76,20 +76,62 @@ function writeLastSynthesisTime(timestamp: number): void {
 
 /**
  * Get the timestamp of the most recent session end from checkpoints.
- * Returns 0 if no session-end checkpoints exist.
+ * Falls back to the latest completed summary job when no checkpoint exists.
  */
+function isExpectedSessionActivityLookupError(error: unknown, table: string): boolean {
+	if (!(error instanceof Error)) return false;
+	const message = error.message.toLowerCase();
+	return (
+		message.includes(`no such table: ${table}`) ||
+		message.includes("dbaccessor not initialised") ||
+		message.includes("dbaccessor is closed")
+	);
+}
+
 function getLastSessionEndTime(): number {
 	try {
-		const row = getDbAccessor().withReadDb((db) => {
+		const checkpointRow = getDbAccessor().withReadDb((db) => {
 			return db.prepare(`
 				SELECT MAX(created_at) as last_end
 				FROM session_checkpoints
 				WHERE trigger = 'session_end'
 			`).get() as { last_end: string | null } | undefined;
 		});
-		if (!row?.last_end) return 0;
-		return new Date(row.last_end).getTime();
-	} catch {
+		if (checkpointRow?.last_end) {
+			return new Date(checkpointRow.last_end).getTime();
+		}
+	} catch (error) {
+		if (!isExpectedSessionActivityLookupError(error, "session_checkpoints")) {
+			logger.error(
+				"synthesis",
+				"Failed to query session_checkpoints for synthesis scheduling",
+				error instanceof Error ? error : new Error(String(error)),
+			);
+			throw error;
+		}
+	}
+
+	try {
+		const summaryRow = getDbAccessor().withReadDb((db) => {
+			return db
+				.prepare(`
+					SELECT MAX(completed_at) as last_end
+					FROM summary_jobs
+					WHERE status = 'completed'
+				`)
+				.get() as { last_end: string | null } | undefined;
+		});
+		if (!summaryRow?.last_end) return 0;
+		return new Date(summaryRow.last_end).getTime();
+	} catch (error) {
+		if (!isExpectedSessionActivityLookupError(error, "summary_jobs")) {
+			logger.error(
+				"synthesis",
+				"Failed to query summary_jobs for synthesis scheduling",
+				error instanceof Error ? error : new Error(String(error)),
+			);
+			throw error;
+		}
 		return 0;
 	}
 }

--- a/packages/daemon/src/pipeline/worker.ts
+++ b/packages/daemon/src/pipeline/worker.ts
@@ -1026,7 +1026,11 @@ export function startWorker(
 
 		// Run extraction
 		const extractionStart = Date.now();
-		const rawExtraction = await extractFactsAndEntities(row.content, instrumentedProvider);
+		const rawExtraction = await extractFactsAndEntities(
+			row.content,
+			instrumentedProvider,
+			{ timeoutMs: pipelineCfg.extraction.timeout },
+		);
 		const extractionMs = Date.now() - extractionStart;
 
 		// Escalation: check output volume and re-run or filter if noisy
@@ -1043,6 +1047,7 @@ export function startWorker(
 			accessor,
 			"default",
 			escalationThresholds,
+			{ timeoutMs: pipelineCfg.extraction.timeout },
 		);
 
 		const extraction = escalated.result;


### PR DESCRIPTION
## Summary

This PR addresses the production issues reported for Signet v0.47.2 in containerized/VPS deployments.

Primary goals were:
- make daemon/network behavior predictable in Docker and Bun environments
- ensure pipeline providers honor configured endpoints/timeouts
- reduce silent/opaque fallback behavior
- improve operability (logging, health recovery, synthesis trigger robustness)

## Issue-to-fix mapping

1. **Daemon ignores `SIGNET_HOST` for bind address**
- Daemon bind host resolution now respects env config and no longer hardcodes loopback behavior.
- Added explicit `SIGNET_BIND` support and surfaced bind host in status output.

2. **Extraction/synthesis ignore endpoint config**
- Added endpoint parsing for extraction/synthesis config (`endpoint` + `base_url` aliases).
- Wired extraction and synthesis Ollama providers to use configured endpoint.
- Wired OpenCode Ollama fallback base URL to configured endpoint.

3. **`localhost` resolves to IPv6 `::1` under Bun**
- Default host changed to `127.0.0.1`.
- `localhost` is normalized for bind/connect defaults to avoid daemon/CLI mismatch.

4. **Extraction timeout effectively hardcoded to 90s**
- Extraction timeout is now propagated from pipeline config into extraction/escalation/decision provider calls.
- Added tests to verify timeout pass-through behavior.

5. **Provider resolution is opaque (hint vs selector)**
- Added provider resolution visibility and warnings when configured providers are unsupported or fall back.
- Status output now includes configured/resolved/effective provider context.

6. **Pipeline still runs with `enabled: false` when `shadowMode: true`**
- `enabled` is now authoritative for pipeline startup/summary execution.
- Updated template docs to make this explicit.

7. **OpenClaw adapter blocked by `./dist/index.js` path validation**
- Updated adapter extension entries from `./dist/index.js` to `dist/index.js`.

8. **Health score doesn’t recover after transient errors**
- Queue dead-rate scoring switched to a recent time window (1h) instead of long-lived accumulation.

9. **`MEMORY.md` synthesis doesn’t write output**
- Synthesis idle trigger now has a fallback path using latest completed summary job when session-end checkpoint is missing.

10. **No persistent log file controls by default**
- Added `SIGNET_LOG_FILE` and `SIGNET_LOG_DIR` support for explicit/persistent daemon log destinations.
- Exposed logging path details in status output.

## Tests

Added/updated coverage for:
- memory config endpoint alias parsing
- extraction timeout pass-through
- decision timeout pass-through
- OpenCode fallback endpoint usage
- diagnostics dead-rate window behavior

Focused test run passed for all touched suites except a known pre-existing timeout in one existing `provider.test.ts` case unrelated to this change.

## Notes

- This PR intentionally excludes unrelated local workspace changes.
- Documentation updated across API/CLI/configuration/daemon/self-hosting pages for new/default env behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New environment variables for bind and logging overrides; explicit provider endpoint support; per-operation timeouts for extraction and decisions; daemon/provider defaults moved to 127.0.0.1.

* **Bug Fixes**
  * Queue health now uses a 1-hour window for fresher metrics; startup/status now exposes bind host and logging configuration.

* **Documentation**
  * Docs and self-hosting guides updated with new env vars and endpoint guidance.

* **Tests**
  * Added coverage for endpoint aliasing, fallback behavior, and timeout propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->