### PR TITLE
feat: add secret get and secret exec CLI subcommands

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3976,23 +3976,28 @@ secretCmd
 	});
 
 secretCmd
-	.command("exec <command>")
+	.command("exec <command...>")
 	.description("Run a command with secrets injected as environment variables")
 	.option("-s, --secret <name>", "Secret to inject (repeatable)", appendCliString, [] as string[])
-	.action(async (command: string, opts: { secret: string[] }) => {
+	.action(async (commandParts: string[], opts: { secret: string[] }) => {
 		if (!(await ensureDaemonForSecrets())) return;
 
 		if (opts.secret.length === 0) {
 			console.error(chalk.red("  At least one --secret is required."));
 			console.log(chalk.dim("\n  Example:"));
-			console.log(`    signet secret exec --secret OPENAI_API_KEY "curl -H 'Authorization: Bearer $OPENAI_API_KEY' ..."\n`);
+			console.log(`    signet secret exec --secret OPENAI_API_KEY curl https://api.openai.com/v1/models\n`);
 			process.exit(1);
 		}
 
+		// Map each name to itself — env var name and secret name are the same.
+		// The daemon API accepts Record<envVarName, secretName> for future
+		// "ENV=SECRET" remapping support.
 		const secrets: Record<string, string> = {};
 		for (const name of opts.secret) {
 			secrets[name] = name;
 		}
+
+		const command = commandParts.join(" ");
 
 		try {
 			const { ok, data } = await secretApiCall("POST", "/api/secrets/exec", {
@@ -4005,10 +4010,11 @@ secretCmd
 				process.exit(1);
 			}
 
-			const result = data as { stdout: string; stderr: string; code: number };
+			const result = data as { stdout: string; stderr: string; code: number | null };
 			if (result.stdout) process.stdout.write(result.stdout);
 			if (result.stderr) process.stderr.write(result.stderr);
-			process.exit(result.code);
+			// code is null when the process was killed by a signal — treat as failure
+			process.exit(result.code ?? 1);
 		} catch (e) {
 			console.error(chalk.red(`  Error: ${(e as Error).message}`));
 			process.exit(1);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3977,14 +3977,20 @@ secretCmd
 
 secretCmd
 	.command("exec <command...>")
-	.description("Run a command with secrets injected as environment variables")
+	.description(
+		"Run a command with secrets injected as environment variables\n" +
+			"  NOTE: --secret flags must appear before the command token.\n" +
+			"  Secrets are available via process.env / os.environ in the subprocess;\n" +
+			"  shell-level $VAR expansion is intentionally disabled for security.",
+	)
 	.passThroughOptions()
-	.option("-s, --secret <name>", "Secret to inject (repeatable)", appendCliString, [] as string[])
+	.option("-s, --secret <name>", "Secret to inject (repeatable, must precede command)", appendCliString, [] as string[])
 	.action(async (commandParts: string[], opts: { secret: string[] }) => {
 		if (!(await ensureDaemonForSecrets())) return;
 
 		if (opts.secret.length === 0) {
 			console.error(chalk.red("  At least one --secret is required."));
+			console.log(chalk.dim("  NOTE: --secret flags must come before the command token."));
 			console.log(chalk.dim("\n  Example:"));
 			console.log(`    signet secret exec --secret OPENAI_API_KEY curl https://api.openai.com/v1/models\n`);
 			process.exit(1);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3998,7 +3998,12 @@ secretCmd
 			secrets[name] = name;
 		}
 
-		const command = commandParts.join(" ");
+		// Shell-escape each part so arguments with embedded spaces or special
+		// characters survive the daemon's `sh -c` invocation intact.
+		// e.g. ["python", "-c", "import os; print(1)"] → "python -c 'import os; print(1)'"
+		const command = commandParts
+			.map((arg) => `'${arg.replace(/'/g, "'\\''")}'`)
+			.join(" ");
 
 		try {
 			// TODO: stream output once the daemon exposes a SSE endpoint for
@@ -4012,17 +4017,20 @@ secretCmd
 
 			if (!ok) {
 				console.error(chalk.red(`  Error: ${(data as { error: string }).error}`));
-				process.exit(1);
+				process.exitCode = 1;
+				return;
 			}
 
 			const result = data as { stdout: string; stderr: string; code: number | null };
 			if (result.stdout) process.stdout.write(result.stdout);
 			if (result.stderr) process.stderr.write(result.stderr);
-			// code is null when the process was killed by a signal — treat as failure
-			process.exit(result.code ?? 1);
+			// Use exitCode + return so Node flushes stdout/stderr buffers before
+			// the process actually exits. process.exit() can truncate buffered output.
+			// code is null when the child was killed by a signal — treat as failure.
+			process.exitCode = result.code ?? 1;
 		} catch (e) {
 			console.error(chalk.red(`  Error: ${(e as Error).message}`));
-			process.exit(1);
+			process.exitCode = 1;
 		}
 	});
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4059,7 +4059,13 @@ secretCmd
 			// code is null when the child was killed by a signal — treat as failure.
 			process.exitCode = result.code ?? 1;
 		} catch (e) {
-			console.error(chalk.red(`  Error: ${(e as Error).message}`));
+			if (e instanceof Error && e.name === "TimeoutError") {
+				console.error(chalk.red("  Error: command timed out after 60 seconds."));
+				console.error(chalk.dim("  The subprocess may still be running on the daemon."));
+				console.error(chalk.dim("  Streaming support is planned — see TODO in source."));
+			} else {
+				console.error(chalk.red(`  Error: ${(e as Error).message}`));
+			}
 			process.exitCode = 1;
 		}
 	});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3954,9 +3954,9 @@ secretCmd
 			const exists = secrets.includes(name);
 
 			if (!exists) {
-				console.log(chalk.red(`\n  Secret "${chalk.bold(name)}" not found.\n`));
-				console.log(chalk.dim("  Store it with:"));
-				console.log(`    signet secret put ${name}\n`);
+				console.error(chalk.red(`\n  Secret "${chalk.bold(name)}" not found.\n`));
+				console.error(chalk.dim("  Store it with:"));
+				console.error(`    signet secret put ${name}\n`);
 				process.exit(1);
 			}
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3978,6 +3978,7 @@ secretCmd
 secretCmd
 	.command("exec <command...>")
 	.description("Run a command with secrets injected as environment variables")
+	.passThroughOptions()
 	.option("-s, --secret <name>", "Secret to inject (repeatable)", appendCliString, [] as string[])
 	.action(async (commandParts: string[], opts: { secret: string[] }) => {
 		if (!(await ensureDaemonForSecrets())) return;
@@ -4000,6 +4001,10 @@ secretCmd
 		const command = commandParts.join(" ");
 
 		try {
+			// TODO: stream output once the daemon exposes a SSE endpoint for
+			// exec (e.g. POST /api/secrets/exec/stream). Currently the daemon
+			// buffers all output before responding, so long-running commands
+			// produce no output until they complete or the 60 s timeout fires.
 			const { ok, data } = await secretApiCall("POST", "/api/secrets/exec", {
 				command,
 				secrets,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3999,14 +3999,21 @@ secretCmd
 		}
 
 		// Double-quote each part so arguments with embedded spaces survive
-		// the daemon's `sh -c` invocation. Double quotes (not single quotes)
-		// are used deliberately: they allow $VAR expansion in the daemon's
-		// shell, which is what makes `signet secret exec -s KEY echo $KEY` work.
-		// Backslash, double-quote, and backtick are escaped to prevent
-		// unintended interpretation; dollar signs are left unescaped.
+		// the daemon's `sh -c` invocation. Backslash, double-quote, backtick,
+		// and dollar sign are all escaped. Escaping $ blocks both $VAR expansion
+		// and $(...) command substitution — the latter is a shell injection risk
+		// for a secrets tool and cannot be left open. Secrets are already
+		// injected directly into the subprocess environment; programs access
+		// them via process.env / os.environ, not via in-string shell expansion.
 		// e.g. ["python", "-c", "import os; print(1)"] → "python" "-c" "import os; print(1)"
 		const command = commandParts
-			.map((arg) => `"${arg.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/`/g, "\\`")}"`)
+			.map((arg) =>
+				`"${arg
+					.replace(/\\/g, "\\\\")
+					.replace(/"/g, '\\"')
+					.replace(/`/g, "\\`")
+					.replace(/\$/g, "\\$")}"`,
+			)
 			.join(" ");
 
 		try {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3998,11 +3998,15 @@ secretCmd
 			secrets[name] = name;
 		}
 
-		// Shell-escape each part so arguments with embedded spaces or special
-		// characters survive the daemon's `sh -c` invocation intact.
-		// e.g. ["python", "-c", "import os; print(1)"] → "python -c 'import os; print(1)'"
+		// Double-quote each part so arguments with embedded spaces survive
+		// the daemon's `sh -c` invocation. Double quotes (not single quotes)
+		// are used deliberately: they allow $VAR expansion in the daemon's
+		// shell, which is what makes `signet secret exec -s KEY echo $KEY` work.
+		// Backslash, double-quote, and backtick are escaped to prevent
+		// unintended interpretation; dollar signs are left unescaped.
+		// e.g. ["python", "-c", "import os; print(1)"] → "python" "-c" "import os; print(1)"
 		const command = commandParts
-			.map((arg) => `'${arg.replace(/'/g, "'\\''")}'`)
+			.map((arg) => `"${arg.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/`/g, "\\`")}"`)
 			.join(" ");
 
 		try {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3939,6 +3939,79 @@ secretCmd
 	});
 
 secretCmd
+	.command("get <name>")
+	.description("Explain how to use a secret (values are never exposed)")
+	.action(async (name: string) => {
+		if (!(await ensureDaemonForSecrets())) return;
+
+		try {
+			const { data } = await secretApiCall("GET", "/api/secrets");
+			const secrets = (data as { secrets: string[] }).secrets ?? [];
+			const exists = secrets.includes(name);
+
+			if (!exists) {
+				console.log(chalk.red(`\n  Secret "${chalk.bold(name)}" not found.\n`));
+				console.log(chalk.dim("  Store it with:"));
+				console.log(`    signet secret put ${name}\n`);
+				process.exit(1);
+			}
+
+			console.log(
+				chalk.yellow(`\n  Secret "${chalk.bold(name)}" exists, but values are never exposed directly.`)
+			);
+			console.log(chalk.dim("\n  Signet secrets are injected at runtime, not read from disk."));
+			console.log(chalk.dim("  Use one of the following:\n"));
+			console.log(chalk.dim("  In a command (injected as env var):"));
+			console.log(`    signet secret exec --secret ${name} "your-command-here"\n`);
+			console.log(chalk.dim("  In agent.yaml (resolved by the daemon):"));
+			console.log(`    api_key: $secret:${name}\n`);
+		} catch (e) {
+			console.error(chalk.red(`  Error: ${(e as Error).message}`));
+			process.exit(1);
+		}
+	});
+
+secretCmd
+	.command("exec <command>")
+	.description("Run a command with secrets injected as environment variables")
+	.option("-s, --secret <name>", "Secret to inject (repeatable)", appendCliString, [] as string[])
+	.action(async (command: string, opts: { secret: string[] }) => {
+		if (!(await ensureDaemonForSecrets())) return;
+
+		if (opts.secret.length === 0) {
+			console.error(chalk.red("  At least one --secret is required."));
+			console.log(chalk.dim("\n  Example:"));
+			console.log(`    signet secret exec --secret OPENAI_API_KEY "curl -H 'Authorization: Bearer $OPENAI_API_KEY' ..."\n`);
+			process.exit(1);
+		}
+
+		const secrets: Record<string, string> = {};
+		for (const name of opts.secret) {
+			secrets[name] = name;
+		}
+
+		try {
+			const { ok, data } = await secretApiCall("POST", "/api/secrets/exec", {
+				command,
+				secrets,
+			});
+
+			if (!ok) {
+				console.error(chalk.red(`  Error: ${(data as { error: string }).error}`));
+				process.exit(1);
+			}
+
+			const result = data as { stdout: string; stderr: string; code: number };
+			if (result.stdout) process.stdout.write(result.stdout);
+			if (result.stderr) process.stderr.write(result.stderr);
+			process.exit(result.code);
+		} catch (e) {
+			console.error(chalk.red(`  Error: ${(e as Error).message}`));
+			process.exit(1);
+		}
+	});
+
+secretCmd
 	.command("has <name>")
 	.description("Check if a secret exists (exits 0 if found, 1 if not)")
 	.action(async (name: string) => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3828,12 +3828,12 @@ program
 
 const DAEMON_URL = `http://localhost:${DEFAULT_PORT}`;
 
-async function secretApiCall(method: string, path: string, body?: unknown): Promise<{ ok: boolean; data: unknown }> {
+async function secretApiCall(method: string, path: string, body?: unknown, timeoutMs = 5_000): Promise<{ ok: boolean; data: unknown }> {
 	const res = await fetch(`${DAEMON_URL}${path}`, {
 		method,
 		headers: body ? { "Content-Type": "application/json" } : {},
 		body: body ? JSON.stringify(body) : undefined,
-		signal: AbortSignal.timeout(5000),
+		signal: AbortSignal.timeout(timeoutMs),
 	});
 	const data = await res.json();
 	return { ok: res.ok, data };
@@ -3945,7 +3945,11 @@ secretCmd
 		if (!(await ensureDaemonForSecrets())) return;
 
 		try {
-			const { data } = await secretApiCall("GET", "/api/secrets");
+			const { ok, data } = await secretApiCall("GET", "/api/secrets");
+			if (!ok) {
+				console.error(chalk.red(`  Error: ${(data as { error: string }).error}`));
+				process.exit(1);
+			}
 			const secrets = (data as { secrets: string[] }).secrets ?? [];
 			const exists = secrets.includes(name);
 
@@ -3994,7 +3998,7 @@ secretCmd
 			const { ok, data } = await secretApiCall("POST", "/api/secrets/exec", {
 				command,
 				secrets,
-			});
+			}, 60_000);
 
 			if (!ok) {
 				console.error(chalk.red(`  Error: ${(data as { error: string }).error}`));

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3996,6 +3996,19 @@ secretCmd
 			process.exit(1);
 		}
 
+		// Validate that each name is a legal POSIX env var identifier.
+		// Secret names that contain hyphens or start with a digit are valid
+		// Signet identifiers but cannot be injected as env vars.
+		const VALID_ENV_VAR = /^[A-Za-z_][A-Za-z0-9_]*$/;
+		for (const name of opts.secret) {
+			if (!VALID_ENV_VAR.test(name)) {
+				console.error(chalk.red(`  Invalid secret name for env injection: "${name}"`));
+				console.log(chalk.dim("  Names must be valid env var identifiers: letters, digits, underscore; no leading digit or hyphens."));
+				process.exitCode = 1;
+				return;
+			}
+		}
+
 		// Map each name to itself — env var name and secret name are the same.
 		// The daemon API accepts Record<envVarName, secretName> for future
 		// "ENV=SECRET" remapping support.


### PR DESCRIPTION
## Summary
- Adds `signet secret get <name>` — tells the user the secret exists but explains why values are never exposed, then points them to `secret exec` or `$secret:NAME` config syntax
- Adds `signet secret exec <command> --secret NAME` — CLI wrapper around the existing daemon `/api/secrets/exec` endpoint so users can inject secrets into commands without going through MCP

## Notes
- `--secret` flags must appear **before** the command token (required by `.passThroughOptions()`)
- Shell-level $VAR expansion is intentionally disabled in injected commands for security ($(...) command substitution blocked). Secrets are available to subprocesses via process.env / os.environ — use SDKs or libraries that read env vars directly.
- Streaming output requires a daemon-side SSE endpoint — left as a TODO for a follow-up daemon PR

## Test plan
- [ ] `signet secret get NONEXISTENT` shows "not found" with `put` guidance
- [ ] `signet secret get EXISTING_KEY` shows the yellow explanation + usage examples
- [ ] `signet secret exec --secret OPENAI_API_KEY curl https://api.openai.com/v1/models` runs curl with key in subprocess env
- [ ] `signet secret exec "echo hi"` (no --secret) shows error with ordering note
- [ ] `signet secret exec --secret KEY curl -X POST url` works (sub-command flags not eaten by Commander)
- [ ] `signet secret exec "my-cmd" --secret KEY` shows missing-secret error with ordering hint