### PR TITLE
fix: openclaw plugin discovery — symlink + load.paths fallback

### DIFF
--- a/packages/adapters/openclaw/src/index.ts
+++ b/packages/adapters/openclaw/src/index.ts
@@ -1351,11 +1351,12 @@ const signetPlugin = {
 				sessionKey,
 			});
 			if (!result) {
-				if (!daemonReachable) {
-					api.logger.warn(
-						"signet-memory: user-prompt-submit returned no result — daemon may be unreachable",
-					);
-				}
+				// daemonFetch already logs ECONNREFUSED; this gives a higher-level
+				// signal at the injection layer, fires immediately rather than waiting
+				// for the health-check interval.
+				api.logger.warn(
+					"signet-memory: user-prompt-submit returned no result — daemon may be unreachable",
+				);
 				return undefined;
 			}
 			recentPromptTurns.set(promptTurnKey, Date.now());

--- a/packages/adapters/openclaw/src/index.ts
+++ b/packages/adapters/openclaw/src/index.ts
@@ -319,7 +319,19 @@ async function daemonFetch<T>(
 
 		return (await res.json()) as T;
 	} catch (e) {
-		console.warn(`[signet] ${method} ${path} error:`, e);
+		const cause: unknown = e instanceof TypeError ? e.cause : undefined;
+		const isConnRefused =
+			typeof cause === "object" &&
+			cause !== null &&
+			"code" in cause &&
+			cause.code === "ECONNREFUSED";
+		if (isConnRefused) {
+			console.warn(
+				`[signet] daemon unreachable at ${daemonUrl} — is the Signet daemon running? (${method} ${path})`,
+			);
+		} else {
+			console.warn(`[signet] ${method} ${path} error:`, e);
+		}
 		return null;
 	}
 }
@@ -1339,6 +1351,11 @@ const signetPlugin = {
 				sessionKey,
 			});
 			if (!result) {
+				if (!daemonReachable) {
+					api.logger.warn(
+						"signet-memory: user-prompt-submit returned no result — daemon may be unreachable",
+					);
+				}
 				return undefined;
 			}
 			recentPromptTurns.set(promptTurnKey, Date.now());

--- a/packages/adapters/openclaw/src/index.ts
+++ b/packages/adapters/openclaw/src/index.ts
@@ -1351,12 +1351,7 @@ const signetPlugin = {
 				sessionKey,
 			});
 			if (!result) {
-				// daemonFetch already logs ECONNREFUSED; this gives a higher-level
-				// signal at the injection layer, fires immediately rather than waiting
-				// for the health-check interval.
-				api.logger.warn(
-					"signet-memory: user-prompt-submit returned no result — daemon may be unreachable",
-				);
+				// daemonFetch already logged the specific error (ECONNREFUSED or HTTP status).
 				return undefined;
 			}
 			recentPromptTurns.set(promptTurnKey, Date.now());

--- a/packages/adapters/openclaw/src/index.ts
+++ b/packages/adapters/openclaw/src/index.ts
@@ -319,7 +319,9 @@ async function daemonFetch<T>(
 
 		return (await res.json()) as T;
 	} catch (e) {
-		const cause: unknown = e instanceof TypeError ? e.cause : undefined;
+		// Native fetch wraps OS errors as TypeError.cause, but polyfill/proxy
+		// layers may rethrow the OS error directly — check both forms.
+		const cause: unknown = e instanceof TypeError ? e.cause : e;
 		const isConnRefused =
 			typeof cause === "object" &&
 			cause !== null &&

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -554,17 +554,9 @@ async function configureHarnessHooks(
 				runtimePath,
 			});
 			if (runtimePath === "plugin") {
-				await ensureOpenClawPluginPackage(basePath);
-				// Resolve the now-installed global path and re-patch config
-				// with plugins.load.paths as a discovery fallback.
-				const packageManager = resolvePrimaryPackageManager({
-					agentsDir: basePath,
-					env: process.env,
-				});
-				const globalPkgPath = resolveGlobalPackagePath(
-					packageManager.family,
-					OPENCLAW_PLUGIN_PACKAGE,
-				);
+				// ensureOpenClawPluginPackage returns the resolved global path — reuse
+				// it to patch load.paths without spawning a second subprocess.
+				const globalPkgPath = await ensureOpenClawPluginPackage(basePath);
 				if (globalPkgPath) {
 					await connector.install(basePath, {
 						configureWorkspace: false,
@@ -660,20 +652,24 @@ function writeOpenClawPluginSyncVersion(basePath: string, version: string): void
 async function ensureOpenClawPluginPackage(
 	basePath: string,
 	options: { force?: boolean; silent?: boolean } = {},
-): Promise<boolean> {
+): Promise<string | undefined> {
 	const connector = new OpenClawConnector();
 	if (connector.getConfiguredRuntimePath() !== "plugin") {
-		return false;
-	}
-
-	if (!options.force && readOpenClawPluginSyncVersion(basePath) === VERSION) {
-		return true;
+		return undefined;
 	}
 
 	const packageManager = resolvePrimaryPackageManager({
 		agentsDir: basePath,
 		env: process.env,
 	});
+
+	if (!options.force && readOpenClawPluginSyncVersion(basePath) === VERSION) {
+		// Cached — skip re-install but still resolve and return path for caller
+		const cachedPath = resolveGlobalPackagePath(packageManager.family, OPENCLAW_PLUGIN_PACKAGE);
+		if (cachedPath) ensureOpenClawExtensionSymlink(cachedPath, options.silent);
+		return cachedPath;
+	}
+
 	const installCommand = getGlobalInstallCommand(
 		packageManager.family,
 		`${OPENCLAW_PLUGIN_PACKAGE}@${VERSION}`,
@@ -694,7 +690,7 @@ async function ensureOpenClawPluginPackage(
 				),
 			);
 		}
-		return false;
+		return undefined;
 	}
 
 	writeOpenClawPluginSyncVersion(basePath, VERSION);
@@ -704,11 +700,10 @@ async function ensureOpenClawPluginPackage(
 		);
 	}
 
-	// Symlink global package into OpenClaw's extensions directory so
-	// plugin discovery finds it without needing plugins.load.paths.
-	ensureOpenClawExtensionSymlink(packageManager.family, options.silent);
-
-	return true;
+	// Resolve once and reuse for both symlink creation and load.paths patch.
+	const globalPath = resolveGlobalPackagePath(packageManager.family, OPENCLAW_PLUGIN_PACKAGE);
+	if (globalPath) ensureOpenClawExtensionSymlink(globalPath, options.silent);
+	return globalPath;
 }
 
 /**
@@ -717,18 +712,9 @@ async function ensureOpenClawPluginPackage(
  * updates if stale, creates if missing.
  */
 function ensureOpenClawExtensionSymlink(
-	family: import("@signet/core").PackageManagerFamily,
+	globalPath: string,
 	silent?: boolean,
 ): void {
-	const globalPath = resolveGlobalPackagePath(family, OPENCLAW_PLUGIN_PACKAGE);
-	if (!globalPath) {
-		if (!silent) {
-			console.log(
-				chalk.yellow("  Warning: could not resolve global package path for symlink"),
-			);
-		}
-		return;
-	}
 
 	// Discover the active OpenClaw state directory. Check env overrides first,
 	// then probe for existing legacy dirs (~/.clawdbot, ~/.moldbot, ~/.moltbot).

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -563,7 +563,23 @@ async function configureHarnessHooks(
 					// that OpenClaw scans for "signet-memory-openclaw" subdirectory.
 					// patchLoadPaths already calls console.warn internally for each
 					// skipped config (same pattern as sibling private methods).
-					connector.patchLoadPaths(dirname(globalPkgPath));
+					const { patched: lPathPatched, warnings: lPathWarnings } =
+						connector.patchLoadPaths(dirname(globalPkgPath));
+					if (lPathPatched.length > 0) {
+						console.log(
+							chalk.green(
+								`  ✓ OpenClaw config updated with plugins.load.paths (${lPathPatched.length} file(s))`,
+							),
+						);
+					} else if (lPathWarnings.length === 0) {
+						// No configs found yet — expected on first run before OpenClaw
+						// has been launched and created its config file.
+						console.log(
+							chalk.dim(
+								"  (no OpenClaw configs found to patch with load.paths; run 'signet setup' again after first OpenClaw launch)",
+							),
+						);
+					}
 				}
 			}
 			break;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -12,8 +12,10 @@ import {
 	mkdirSync,
 	readFileSync,
 	readdirSync,
+	readlinkSync,
 	rmSync,
 	statSync,
+	symlinkSync,
 	writeFileSync,
 } from "fs";
 import { homedir, platform } from "os";
@@ -37,6 +39,7 @@ import {
 	ensureUnifiedSchema,
 	formatYaml,
 	getGlobalInstallCommand,
+	resolveGlobalPackagePath,
 	getMissingIdentityFiles,
 	getSkillsRunnerCommand,
 	hasValidIdentity,
@@ -544,12 +547,32 @@ async function configureHarnessHooks(
 				options?.openclawRuntimePath ??
 				connector.getConfiguredRuntimePath() ??
 				"plugin";
+			// Install connector first — writes config with runtimePath so
+			// ensureOpenClawPluginPackage's getConfiguredRuntimePath() check passes.
 			await connector.install(basePath, {
 				configureWorkspace: options?.configureOpenClawWorkspace ?? false,
 				runtimePath,
 			});
 			if (runtimePath === "plugin") {
 				await ensureOpenClawPluginPackage(basePath);
+				// Resolve the now-installed global path and re-patch config
+				// with plugins.load.paths as a discovery fallback.
+				const packageManager = resolvePrimaryPackageManager({
+					agentsDir: basePath,
+					env: process.env,
+				});
+				const globalPkgPath = resolveGlobalPackagePath(
+					packageManager.family,
+					OPENCLAW_PLUGIN_PACKAGE,
+				);
+				if (globalPkgPath) {
+					await connector.install(basePath, {
+						configureWorkspace: false,
+						configureHooks: false,
+						runtimePath,
+						globalPackagePath: globalPkgPath,
+					});
+				}
 			}
 			break;
 		}
@@ -681,7 +704,103 @@ async function ensureOpenClawPluginPackage(
 		);
 	}
 
+	// Symlink global package into OpenClaw's extensions directory so
+	// plugin discovery finds it without needing plugins.load.paths.
+	ensureOpenClawExtensionSymlink(packageManager.family, options.silent);
+
 	return true;
+}
+
+/**
+ * Create a symlink from OpenClaw's extensions directory to the globally
+ * installed plugin package. Idempotent — skips if already correct,
+ * updates if stale, creates if missing.
+ */
+function ensureOpenClawExtensionSymlink(
+	family: import("@signet/core").PackageManagerFamily,
+	silent?: boolean,
+): void {
+	const globalPath = resolveGlobalPackagePath(family, OPENCLAW_PLUGIN_PACKAGE);
+	if (!globalPath) {
+		if (!silent) {
+			console.log(
+				chalk.yellow("  Warning: could not resolve global package path for symlink"),
+			);
+		}
+		return;
+	}
+
+	// Discover the active OpenClaw state directory. Check env overrides first,
+	// then probe for existing legacy dirs (~/.clawdbot, ~/.moldbot, ~/.moltbot).
+	const stateDirCandidates: string[] = [];
+	if (process.env.OPENCLAW_STATE_DIR) {
+		stateDirCandidates.push(resolvePath(process.env.OPENCLAW_STATE_DIR));
+	}
+	if (process.env.CLAWDBOT_STATE_DIR) {
+		stateDirCandidates.push(resolvePath(process.env.CLAWDBOT_STATE_DIR));
+	}
+	const home = homedir();
+	for (const name of [".openclaw", ".clawdbot", ".moldbot", ".moltbot"]) {
+		const candidate = join(home, name);
+		if (existsSync(candidate)) {
+			stateDirCandidates.push(candidate);
+		}
+	}
+	// Default to ~/.openclaw if nothing else exists
+	if (stateDirCandidates.length === 0) {
+		stateDirCandidates.push(join(home, ".openclaw"));
+	}
+
+	// Create symlink in every discovered state dir
+	for (const stateDir of [...new Set(stateDirCandidates)]) {
+		createExtensionSymlink(stateDir, globalPath, silent);
+	}
+}
+
+function createExtensionSymlink(
+	stateDir: string,
+	globalPath: string,
+	silent?: boolean,
+): void {
+	const extensionsDir = join(stateDir, "extensions");
+	const symlinkPath = join(extensionsDir, "signet-memory-openclaw");
+
+	mkdirSync(extensionsDir, { recursive: true });
+
+	// Check existing symlink — lstatSync doesn't follow symlinks, so it
+	// catches both valid and broken symlinks. existsSync follows symlinks
+	// and misses broken ones.
+	try {
+		const stat = lstatSync(symlinkPath);
+		if (stat.isSymbolicLink()) {
+			const currentTarget = readlinkSync(symlinkPath);
+			if (currentTarget === globalPath) {
+				return; // Already correct
+			}
+			// Stale symlink — remove and recreate
+			rmSync(symlinkPath, { force: true });
+		} else {
+			// Exists but not a symlink — remove
+			rmSync(symlinkPath, { force: true, recursive: true });
+		}
+	} catch {
+		// Path doesn't exist — will create below
+	}
+
+	try {
+		symlinkSync(globalPath, symlinkPath, "dir");
+		if (!silent) {
+			console.log(
+				chalk.green("  ✓ OpenClaw extension symlink created"),
+			);
+		}
+	} catch (err) {
+		if (!silent) {
+			console.log(
+				chalk.yellow(`  Warning: could not create extension symlink: ${err}`),
+			);
+		}
+	}
 }
 
 /**

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -664,7 +664,15 @@ async function ensureOpenClawPluginPackage(
 	if (!options.force && readOpenClawPluginSyncVersion(basePath) === VERSION) {
 		// Cached — skip re-install but still resolve and return path for caller
 		const cachedPath = resolveGlobalPackagePath(packageManager.family, OPENCLAW_PLUGIN_PACKAGE);
-		if (cachedPath) ensureOpenClawExtensionSymlink(cachedPath, options.silent);
+		if (cachedPath) {
+			ensureOpenClawExtensionSymlink(cachedPath, options.silent);
+		} else if (!options.silent) {
+			console.log(
+				chalk.yellow(
+					`  Warning: could not resolve global path for ${OPENCLAW_PLUGIN_PACKAGE}; plugin discovery may be incomplete. Run 'signet setup' again if needed.`,
+				),
+			);
+		}
 		return cachedPath;
 	}
 
@@ -700,7 +708,15 @@ async function ensureOpenClawPluginPackage(
 
 	// Resolve once and reuse for both symlink creation and load.paths patch.
 	const globalPath = resolveGlobalPackagePath(packageManager.family, OPENCLAW_PLUGIN_PACKAGE);
-	if (globalPath) ensureOpenClawExtensionSymlink(globalPath, options.silent);
+	if (globalPath) {
+		ensureOpenClawExtensionSymlink(globalPath, options.silent);
+	} else if (!options.silent) {
+		console.log(
+			chalk.yellow(
+				`  Warning: could not resolve global path for ${OPENCLAW_PLUGIN_PACKAGE} after install; plugin discovery may be incomplete. Run 'signet setup' again if needed.`,
+			),
+		);
+	}
 	return globalPath;
 }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -554,16 +554,14 @@ async function configureHarnessHooks(
 				runtimePath,
 			});
 			if (runtimePath === "plugin") {
-				// ensureOpenClawPluginPackage returns the resolved global path — reuse
-				// it to patch load.paths without spawning a second subprocess.
+				// ensureOpenClawPluginPackage installs the package, creates the symlink,
+				// and returns the resolved global path so we can patch load.paths in one
+				// targeted call without re-running the full connector install.
 				const globalPkgPath = await ensureOpenClawPluginPackage(basePath);
 				if (globalPkgPath) {
-					await connector.install(basePath, {
-						configureWorkspace: false,
-						configureHooks: false,
-						runtimePath,
-						globalPackagePath: globalPkgPath,
-					});
+					// dirname gives the parent search directory (e.g. …/@signetai/)
+					// that OpenClaw scans for "signet-memory-openclaw" subdirectory.
+					connector.patchLoadPaths(dirname(globalPkgPath));
 				}
 			}
 			break;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -561,7 +561,10 @@ async function configureHarnessHooks(
 				if (globalPkgPath) {
 					// dirname gives the parent search directory (e.g. …/@signetai/)
 					// that OpenClaw scans for "signet-memory-openclaw" subdirectory.
-					connector.patchLoadPaths(dirname(globalPkgPath));
+					const { warnings: loadPathWarnings } = connector.patchLoadPaths(dirname(globalPkgPath));
+					for (const w of loadPathWarnings) {
+						console.warn(w);
+					}
 				}
 			}
 			break;
@@ -776,7 +779,18 @@ function createExtensionSymlink(
 	const extensionsDir = join(stateDir, "extensions");
 	const symlinkPath = join(extensionsDir, "signet-memory-openclaw");
 
-	mkdirSync(extensionsDir, { recursive: true });
+	try {
+		mkdirSync(extensionsDir, { recursive: true });
+	} catch (err) {
+		if (!silent) {
+			console.log(
+				chalk.yellow(
+					`  Warning: could not prepare OpenClaw extensions dir at ${extensionsDir}: ${err}`,
+				),
+			);
+		}
+		return;
+	}
 
 	// Check existing symlink — lstatSync doesn't follow symlinks, so it
 	// catches both valid and broken symlinks. existsSync follows symlinks

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -561,10 +561,9 @@ async function configureHarnessHooks(
 				if (globalPkgPath) {
 					// dirname gives the parent search directory (e.g. …/@signetai/)
 					// that OpenClaw scans for "signet-memory-openclaw" subdirectory.
-					const { warnings: loadPathWarnings } = connector.patchLoadPaths(dirname(globalPkgPath));
-					for (const w of loadPathWarnings) {
-						console.warn(w);
-					}
+					// patchLoadPaths already calls console.warn internally for each
+					// skipped config (same pattern as sibling private methods).
+					connector.patchLoadPaths(dirname(globalPkgPath));
 				}
 			}
 			break;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -662,18 +662,22 @@ async function ensureOpenClawPluginPackage(
 	});
 
 	if (!options.force && readOpenClawPluginSyncVersion(basePath) === VERSION) {
-		// Cached — skip re-install but still resolve and return path for caller
+		// Cached — skip re-install but still resolve and return path for caller.
+		// If the path can't be resolved (package was pruned after the stamp was
+		// written), fall through to re-install rather than returning undefined.
 		const cachedPath = resolveGlobalPackagePath(packageManager.family, OPENCLAW_PLUGIN_PACKAGE);
 		if (cachedPath) {
 			ensureOpenClawExtensionSymlink(cachedPath, options.silent);
-		} else if (!options.silent) {
+			return cachedPath;
+		}
+		if (!options.silent) {
 			console.log(
 				chalk.yellow(
-					`  Warning: could not resolve global path for ${OPENCLAW_PLUGIN_PACKAGE}; plugin discovery may be incomplete. Run 'signet setup' again if needed.`,
+					`  Warning: cached ${OPENCLAW_PLUGIN_PACKAGE} not found on disk; retrying install.`,
 				),
 			);
 		}
-		return cachedPath;
+		// Fall through to re-install below.
 	}
 
 	const installCommand = getGlobalInstallCommand(
@@ -794,15 +798,18 @@ function createExtensionSymlink(
 				return;
 			}
 		} else {
-			// Exists but not a symlink — remove
-			try {
-				rmSync(symlinkPath, { force: true, recursive: true });
-			} catch (rmErr) {
-				if (!silent) {
-					console.log(chalk.yellow(`  Warning: could not remove existing path at ${symlinkPath}: ${rmErr}`));
-				}
-				return;
+			// Exists but is not a symlink (real file or directory). Removing it
+			// before symlinkSync could permanently destroy a working manual
+			// installation if symlink creation then fails. Leave it in place and
+			// warn — the user can remove it manually to enable the managed symlink.
+			if (!silent) {
+				console.log(
+					chalk.yellow(
+						`  Warning: existing non-symlink at ${symlinkPath}; leaving it in place. Remove it manually to enable the Signet-managed symlink.`,
+					),
+				);
 			}
+			return;
 		}
 	} catch {
 		// Path doesn't exist — will create below

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -785,10 +785,24 @@ function createExtensionSymlink(
 				return; // Already correct
 			}
 			// Stale symlink — remove and recreate
-			rmSync(symlinkPath, { force: true });
+			try {
+				rmSync(symlinkPath, { force: true });
+			} catch (rmErr) {
+				if (!silent) {
+					console.log(chalk.yellow(`  Warning: could not remove stale symlink at ${symlinkPath}: ${rmErr}`));
+				}
+				return;
+			}
 		} else {
 			// Exists but not a symlink — remove
-			rmSync(symlinkPath, { force: true, recursive: true });
+			try {
+				rmSync(symlinkPath, { force: true, recursive: true });
+			} catch (rmErr) {
+				if (!silent) {
+					console.log(chalk.yellow(`  Warning: could not remove existing path at ${symlinkPath}: ${rmErr}`));
+				}
+				return;
+			}
 		}
 	} catch {
 		// Path doesn't exist — will create below

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -730,14 +730,21 @@ function ensureOpenClawExtensionSymlink(
 	silent?: boolean,
 ): void {
 
-	// Discover the active OpenClaw state directory. Check env overrides first,
-	// then probe for existing legacy dirs (~/.clawdbot, ~/.moldbot, ~/.moltbot).
+	// Discover the active OpenClaw state directory. Check env overrides first
+	// (expanding ~ just like the connector does), then probe for existing legacy
+	// dirs (~/.clawdbot, ~/.moldbot, ~/.moltbot).
 	const stateDirCandidates: string[] = [];
+	// normalizeAgentPath expands ~ and resolves to an absolute path.
 	if (process.env.OPENCLAW_STATE_DIR) {
-		stateDirCandidates.push(resolvePath(process.env.OPENCLAW_STATE_DIR));
+		stateDirCandidates.push(normalizeAgentPath(process.env.OPENCLAW_STATE_DIR));
 	}
 	if (process.env.CLAWDBOT_STATE_DIR) {
-		stateDirCandidates.push(resolvePath(process.env.CLAWDBOT_STATE_DIR));
+		stateDirCandidates.push(normalizeAgentPath(process.env.CLAWDBOT_STATE_DIR));
+	}
+	// OPENCLAW_STATE_HOME is the root of the state directory (openclaw.json lives
+	// directly inside it), so extensions/ belongs there too.
+	if (process.env.OPENCLAW_STATE_HOME) {
+		stateDirCandidates.push(normalizeAgentPath(process.env.OPENCLAW_STATE_HOME));
 	}
 	const home = homedir();
 	for (const name of [".openclaw", ".clawdbot", ".moldbot", ".moltbot"]) {

--- a/packages/connector-openclaw/src/index.ts
+++ b/packages/connector-openclaw/src/index.ts
@@ -23,7 +23,7 @@
 
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { delimiter, join, resolve } from "node:path";
+import { delimiter, dirname, join, resolve } from "node:path";
 import { BaseConnector, type InstallResult, type UninstallResult } from "@signet/connector-base";
 import { parse as parseJson5 } from "json5";
 
@@ -737,11 +737,17 @@ export class OpenClawConnector extends BaseConnector {
 				// Add global package path to plugins.load.paths as a fallback
 				// for environments where the symlink can't be created (Docker, perms).
 				if (globalPackagePath) {
+					// Use the parent directory as the load path. OpenClaw scans each
+					// entry in load.paths for a subdirectory named after the plugin
+					// ("signet-memory-openclaw"). The package lives at:
+					//   …/@signetai/signet-memory-openclaw
+					// so dirname gives …/@signetai/, which contains "signet-memory-openclaw".
+					const searchPath = dirname(globalPackagePath);
 					const pluginsObj = (config.plugins ?? {}) as JsonObject;
 					const loadObj = (pluginsObj.load ?? {}) as JsonObject;
 					const existingPaths = Array.isArray(loadObj.paths) ? (loadObj.paths as string[]) : [];
-					if (!existingPaths.includes(globalPackagePath)) {
-						loadObj.paths = [...existingPaths, globalPackagePath];
+					if (!existingPaths.includes(searchPath)) {
+						loadObj.paths = [...existingPaths, searchPath];
 						pluginsObj.load = loadObj;
 						config.plugins = pluginsObj;
 					}

--- a/packages/connector-openclaw/src/index.ts
+++ b/packages/connector-openclaw/src/index.ts
@@ -804,6 +804,18 @@ export class OpenClawConnector extends BaseConnector {
 				const config = parseJsonOrJson5(raw);
 				const indent = this.detectIndent(raw);
 
+				// Legacy configs store plugins as an array of strings. The
+				// install() call migrates these to object form before patchLoadPaths
+				// is called in the normal CLI flow, but guard explicitly so a direct
+				// SDK caller against an unmigrated config doesn't silently produce a
+				// no-op (JSON.stringify drops non-index array properties).
+				if (Array.isArray(config.plugins)) {
+					const warning = `[signet/openclaw] Skipped load.paths patch for ${configPath}: plugins is in legacy array format; run install() first`;
+					warnings.push(warning);
+					console.warn(warning);
+					continue;
+				}
+
 				const pluginsObj = (config.plugins ?? {}) as JsonObject;
 				const loadObj = (pluginsObj.load ?? {}) as JsonObject;
 				const rawPaths = loadObj.paths;

--- a/packages/connector-openclaw/src/index.ts
+++ b/packages/connector-openclaw/src/index.ts
@@ -261,6 +261,12 @@ export class OpenClawConnector extends BaseConnector {
 	 * - Patches OpenClaw hook entries by default
 	 * - Patches OpenClaw workspace only when explicitly requested
 	 * - Installs hook handler files under `<basePath>/hooks/agent-memory/`
+	 *
+	 * **`runtimePath` default changed in 0.53:** The default is now `"plugin"`
+	 * (automatic per-prompt memory injection via the OpenClaw plugin system)
+	 * instead of the old `"legacy"` (manual `/remember`/`/recall` commands
+	 * only). SDK callers that relied on the legacy path must now pass
+	 * `{ runtimePath: "legacy" }` explicitly.
 	 */
 	async install(basePath: string, options: OpenClawInstallOptions = {}): Promise<InstallResult> {
 		const expandedBasePath = this.expandPath(basePath);

--- a/packages/connector-openclaw/src/index.ts
+++ b/packages/connector-openclaw/src/index.ts
@@ -824,6 +824,15 @@ export class OpenClawConnector extends BaseConnector {
 					console.warn(warning);
 					continue;
 				}
+				if (rawLoad !== undefined && !isJsonObject(rawLoad)) {
+					// Scalar values (false, "disabled", 0, etc.) likely represent an
+					// intentional opt-out — overwriting them silently could change
+					// deliberate user config.
+					const warning = `[signet/openclaw] Skipped load.paths patch for ${configPath}: plugins.load has unexpected type (${typeof rawLoad}); cannot safely merge`;
+					warnings.push(warning);
+					console.warn(warning);
+					continue;
+				}
 				const loadObj = isJsonObject(rawLoad) ? rawLoad : {};
 				const rawPaths = loadObj.paths;
 				// filter (not every) so valid string entries are preserved even

--- a/packages/connector-openclaw/src/index.ts
+++ b/packages/connector-openclaw/src/index.ts
@@ -23,7 +23,7 @@
 
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { delimiter, dirname, join, resolve } from "node:path";
+import { delimiter, join, resolve } from "node:path";
 import { BaseConnector, type InstallResult, type UninstallResult } from "@signet/connector-base";
 import { parse as parseJson5 } from "json5";
 
@@ -67,9 +67,6 @@ export interface OpenClawInstallOptions {
 	configureWorkspace?: boolean;
 	configureHooks?: boolean;
 	runtimePath?: "plugin" | "legacy";
-	/** Resolved filesystem path to the globally-installed plugin package.
-	 *  When provided, added to plugins.load.paths as a discovery fallback. */
-	globalPackagePath?: string;
 }
 
 /**
@@ -325,7 +322,7 @@ export class OpenClawConnector extends BaseConnector {
 
 		if (Object.keys(patch).length > 0) {
 			if (runtimePath === "plugin") {
-				const pluginResult = this.patchAllConfigsWithPlugin(patch, options.globalPackagePath);
+				const pluginResult = this.patchAllConfigsWithPlugin(patch);
 				configsPatched.push(...pluginResult.patched);
 				warnings.push(...pluginResult.warnings);
 			} else {
@@ -672,7 +669,6 @@ export class OpenClawConnector extends BaseConnector {
 	 */
 	private patchAllConfigsWithPlugin(
 		patch: JsonObject,
-		globalPackagePath?: string,
 	): {
 		patched: string[];
 		warnings: string[];
@@ -734,25 +730,6 @@ export class OpenClawConnector extends BaseConnector {
 					config.signet = undefined;
 				}
 
-				// Add global package path to plugins.load.paths as a fallback
-				// for environments where the symlink can't be created (Docker, perms).
-				if (globalPackagePath) {
-					// Use the parent directory as the load path. OpenClaw scans each
-					// entry in load.paths for a subdirectory named after the plugin
-					// ("signet-memory-openclaw"). The package lives at:
-					//   …/@signetai/signet-memory-openclaw
-					// so dirname gives …/@signetai/, which contains "signet-memory-openclaw".
-					const searchPath = dirname(globalPackagePath);
-					const pluginsObj = (config.plugins ?? {}) as JsonObject;
-					const loadObj = (pluginsObj.load ?? {}) as JsonObject;
-					const existingPaths = Array.isArray(loadObj.paths) ? (loadObj.paths as string[]) : [];
-					if (!existingPaths.includes(searchPath)) {
-						loadObj.paths = [...existingPaths, searchPath];
-						pluginsObj.load = loadObj;
-						config.plugins = pluginsObj;
-					}
-				}
-
 				deepMerge(config, patch);
 				writeFileSync(configPath, JSON.stringify(config, null, indent));
 				patched.push(configPath);
@@ -801,6 +778,51 @@ export class OpenClawConnector extends BaseConnector {
 		const indent = this.detectIndent(raw);
 		deepMerge(config, patch);
 		writeFileSync(configPath, JSON.stringify(config, null, indent));
+	}
+
+	/**
+	 * Narrow config-only update: add `searchPath` to `plugins.load.paths` in
+	 * all discovered configs without re-running the full install flow.
+	 *
+	 * `searchPath` should be the **parent** directory of the plugin package
+	 * (e.g. `…/@signetai/`) so OpenClaw can find `signet-memory-openclaw`
+	 * as a subdirectory.
+	 */
+	patchLoadPaths(searchPath: string): { patched: string[]; warnings: string[] } {
+		const patched: string[] = [];
+		const warnings: string[] = [];
+
+		for (const configPath of this.getDiscoveredConfigPaths()) {
+			try {
+				const raw = readFileSync(configPath, "utf-8");
+				const config = parseJsonOrJson5(raw);
+				const indent = this.detectIndent(raw);
+
+				const pluginsObj = (config.plugins ?? {}) as JsonObject;
+				const loadObj = (pluginsObj.load ?? {}) as JsonObject;
+				const rawPaths = loadObj.paths;
+				const existingPaths =
+					Array.isArray(rawPaths) &&
+					rawPaths.every((entry): entry is string => typeof entry === "string")
+						? rawPaths
+						: [];
+
+				if (!existingPaths.includes(searchPath)) {
+					loadObj.paths = [...existingPaths, searchPath];
+					pluginsObj.load = loadObj;
+					config.plugins = pluginsObj;
+					writeFileSync(configPath, JSON.stringify(config, null, indent));
+					patched.push(configPath);
+				}
+			} catch (e) {
+				const message = e instanceof Error ? e.message : String(e);
+				const warning = `[signet/openclaw] Skipped load.paths patch for ${configPath}: ${message}`;
+				warnings.push(warning);
+				console.warn(warning);
+			}
+		}
+
+		return { patched, warnings };
 	}
 
 	/**

--- a/packages/connector-openclaw/src/index.ts
+++ b/packages/connector-openclaw/src/index.ts
@@ -48,6 +48,9 @@ interface OpenClawConfigShape {
 			memory?: string;
 		};
 		entries?: Record<string, { enabled?: boolean; config?: Record<string, unknown> }>;
+		load?: {
+			paths?: string[];
+		};
 	};
 	agents?: {
 		defaults?: {
@@ -64,6 +67,9 @@ export interface OpenClawInstallOptions {
 	configureWorkspace?: boolean;
 	configureHooks?: boolean;
 	runtimePath?: "plugin" | "legacy";
+	/** Resolved filesystem path to the globally-installed plugin package.
+	 *  When provided, added to plugins.load.paths as a discovery fallback. */
+	globalPackagePath?: string;
 }
 
 /**
@@ -267,7 +273,7 @@ export class OpenClawConnector extends BaseConnector {
 
 		const configureHooks = options.configureHooks ?? true;
 		const configureWorkspace = options.configureWorkspace ?? true;
-		const runtimePath = options.runtimePath ?? "legacy";
+		const runtimePath = options.runtimePath ?? "plugin";
 
 		const patch: JsonObject = {};
 		if (configureWorkspace) {
@@ -319,7 +325,7 @@ export class OpenClawConnector extends BaseConnector {
 
 		if (Object.keys(patch).length > 0) {
 			if (runtimePath === "plugin") {
-				const pluginResult = this.patchAllConfigsWithPlugin(patch);
+				const pluginResult = this.patchAllConfigsWithPlugin(patch, options.globalPackagePath);
 				configsPatched.push(...pluginResult.patched);
 				warnings.push(...pluginResult.warnings);
 			} else {
@@ -664,7 +670,10 @@ export class OpenClawConnector extends BaseConnector {
 	 * - Top-level `signet: { daemonUrl }` key
 	 * - Old plugin name "signet-memory" -> "signet-memory-openclaw"
 	 */
-	private patchAllConfigsWithPlugin(patch: JsonObject): {
+	private patchAllConfigsWithPlugin(
+		patch: JsonObject,
+		globalPackagePath?: string,
+	): {
 		patched: string[];
 		warnings: string[];
 	} {
@@ -723,6 +732,19 @@ export class OpenClawConnector extends BaseConnector {
 					pluginsObj.entries = entriesObj;
 					config.plugins = pluginsObj;
 					config.signet = undefined;
+				}
+
+				// Add global package path to plugins.load.paths as a fallback
+				// for environments where the symlink can't be created (Docker, perms).
+				if (globalPackagePath) {
+					const pluginsObj = (config.plugins ?? {}) as JsonObject;
+					const loadObj = (pluginsObj.load ?? {}) as JsonObject;
+					const existingPaths = Array.isArray(loadObj.paths) ? (loadObj.paths as string[]) : [];
+					if (!existingPaths.includes(globalPackagePath)) {
+						loadObj.paths = [...existingPaths, globalPackagePath];
+						pluginsObj.load = loadObj;
+						config.plugins = pluginsObj;
+					}
 				}
 
 				deepMerge(config, patch);

--- a/packages/connector-openclaw/src/index.ts
+++ b/packages/connector-openclaw/src/index.ts
@@ -826,11 +826,11 @@ export class OpenClawConnector extends BaseConnector {
 				}
 				const loadObj = isJsonObject(rawLoad) ? rawLoad : {};
 				const rawPaths = loadObj.paths;
-				const existingPaths =
-					Array.isArray(rawPaths) &&
-					rawPaths.every((entry): entry is string => typeof entry === "string")
-						? rawPaths
-						: [];
+				// filter (not every) so valid string entries are preserved even
+				// if the array contains a stray non-string element.
+				const existingPaths = Array.isArray(rawPaths)
+					? rawPaths.filter((entry): entry is string => typeof entry === "string")
+					: [];
 
 				if (!existingPaths.includes(searchPath)) {
 					loadObj.paths = [...existingPaths, searchPath];

--- a/packages/connector-openclaw/src/index.ts
+++ b/packages/connector-openclaw/src/index.ts
@@ -816,8 +816,15 @@ export class OpenClawConnector extends BaseConnector {
 					continue;
 				}
 
-				const pluginsObj = (config.plugins ?? {}) as JsonObject;
-				const loadObj = (pluginsObj.load ?? {}) as JsonObject;
+				const pluginsObj = isJsonObject(config.plugins) ? config.plugins : {};
+				const rawLoad = pluginsObj.load;
+				if (Array.isArray(rawLoad)) {
+					const warning = `[signet/openclaw] Skipped load.paths patch for ${configPath}: plugins.load is array-shaped; run install() first`;
+					warnings.push(warning);
+					console.warn(warning);
+					continue;
+				}
+				const loadObj = isJsonObject(rawLoad) ? rawLoad : {};
 				const rawPaths = loadObj.paths;
 				const existingPaths =
 					Array.isArray(rawPaths) &&

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -202,6 +202,7 @@ export {
 	resolvePrimaryPackageManager,
 	getSkillsRunnerCommand,
 	getGlobalInstallCommand,
+	resolveGlobalPackagePath,
 	type PackageManagerFamily,
 	type PackageManagerResolution,
 	type PackageManagerCommand,

--- a/packages/core/src/package-manager.ts
+++ b/packages/core/src/package-manager.ts
@@ -306,18 +306,40 @@ export function resolveGlobalPackagePath(
 				return undefined;
 			}
 			case "yarn": {
-				const result = spawnSync("yarn", ["global", "dir"], {
+				// `yarn global dir` is Yarn Classic (v1) only. Yarn Berry (v2+)
+				// removed all `yarn global` subcommands. Detect version first.
+				const versionResult = spawnSync("yarn", ["--version"], {
 					encoding: "utf-8",
-					timeout: 10_000,
+					timeout: 5_000,
 					windowsHide: true,
 				});
-				if (result.status === 0 && result.stdout.trim()) {
-					const candidate = join(
-						result.stdout.trim(),
+				const isClassic =
+					versionResult.status === 0 &&
+					/^1\./.test(versionResult.stdout.trim());
+
+				if (isClassic) {
+					const result = spawnSync("yarn", ["global", "dir"], {
+						encoding: "utf-8",
+						timeout: 10_000,
+						windowsHide: true,
+					});
+					if (result.status === 0 && result.stdout.trim()) {
+						const candidate = join(
+							result.stdout.trim(),
+							"node_modules",
+							packageName,
+						);
+						if (existsSync(candidate)) return candidate;
+					}
+				} else {
+					// Berry defaults to ~/.yarn/berry/global; respects YARN_GLOBAL_FOLDER
+					const berryGlobal = join(
+						process.env.YARN_GLOBAL_FOLDER ??
+							join(homedir(), ".yarn", "berry", "global"),
 						"node_modules",
 						packageName,
 					);
-					if (existsSync(candidate)) return candidate;
+					if (existsSync(berryGlobal)) return berryGlobal;
 				}
 				return undefined;
 			}

--- a/packages/core/src/package-manager.ts
+++ b/packages/core/src/package-manager.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { parseSimpleYaml } from "./yaml";
 
@@ -256,6 +257,73 @@ export function getSkillsRunnerCommand(
 				command: "npm",
 				args: ["exec", "--yes", "--", "skills", ...skillsArgs],
 			};
+	}
+}
+
+/**
+ * Resolve the filesystem path where a globally-installed package lives.
+ * Returns undefined if the path cannot be determined or does not exist.
+ */
+export function resolveGlobalPackagePath(
+	family: PackageManagerFamily,
+	packageName: string,
+): string | undefined {
+	try {
+		switch (family) {
+			case "bun": {
+				const bunGlobal = join(
+					process.env.BUN_INSTALL ?? join(homedir(), ".bun"),
+					"install",
+					"global",
+					"node_modules",
+					packageName,
+				);
+				if (existsSync(bunGlobal)) return bunGlobal;
+				return undefined;
+			}
+			case "npm": {
+				const result = spawnSync("npm", ["root", "-g"], {
+					encoding: "utf-8",
+					timeout: 10_000,
+					windowsHide: true,
+				});
+				if (result.status === 0 && result.stdout.trim()) {
+					const candidate = join(result.stdout.trim(), packageName);
+					if (existsSync(candidate)) return candidate;
+				}
+				return undefined;
+			}
+			case "pnpm": {
+				const result = spawnSync("pnpm", ["root", "-g"], {
+					encoding: "utf-8",
+					timeout: 10_000,
+					windowsHide: true,
+				});
+				if (result.status === 0 && result.stdout.trim()) {
+					const candidate = join(result.stdout.trim(), packageName);
+					if (existsSync(candidate)) return candidate;
+				}
+				return undefined;
+			}
+			case "yarn": {
+				const result = spawnSync("yarn", ["global", "dir"], {
+					encoding: "utf-8",
+					timeout: 10_000,
+					windowsHide: true,
+				});
+				if (result.status === 0 && result.stdout.trim()) {
+					const candidate = join(
+						result.stdout.trim(),
+						"node_modules",
+						packageName,
+					);
+					if (existsSync(candidate)) return candidate;
+				}
+				return undefined;
+			}
+		}
+	} catch {
+		return undefined;
 	}
 }
 

--- a/packages/core/src/package-manager.ts
+++ b/packages/core/src/package-manager.ts
@@ -332,7 +332,13 @@ export function resolveGlobalPackagePath(
 						if (existsSync(candidate)) return candidate;
 					}
 				} else {
-					// Berry defaults to ~/.yarn/berry/global; respects YARN_GLOBAL_FOLDER
+					// Yarn Berry (v2+) removed `yarn global add` entirely, so no
+					// global package tree is created under the default linker (PnP).
+					// This path only resolves for Berry users who explicitly set
+					// `nodeLinker: node-modules` in their .yarnrc.yml — PnP installs
+					// will not have a node_modules directory here. Checked as a
+					// best-effort fallback; callers should warn when this returns
+					// undefined, since Berry users may need an alternative install path.
 					const berryGlobal = join(
 						process.env.YARN_GLOBAL_FOLDER ??
 							join(homedir(), ".yarn", "berry", "global"),


### PR DESCRIPTION
## Summary

- Fixes user-prompt-submit hook never firing for OpenClaw (affects all channels including Telegram)
- Root cause: `signet-memory-openclaw` installed globally but never discovered by OpenClaw's plugin search paths
- Adds `resolveGlobalPackagePath()` helper (bun/npm/pnpm/yarn), symlinks plugin into OpenClaw extensions dir(s), and adds `plugins.load.paths` config fallback for Docker/permissions
- Defaults connector runtimePath to `"plugin"` (aligns with existing CLI default)
- Improves `daemonFetch` error visibility — ECONNREFUSED now logs actionable message instead of silent null

## Test plan

- [x] `bun run build` — all packages compile
- [x] `bun run typecheck` — no type errors in modified packages
- [x] `bun test packages/core/src/package-manager.test.ts packages/adapters/openclaw/src/index.test.ts` — 13/13 pass
- [ ] Manual: `signet setup` with openclaw harness → verify `~/.openclaw/extensions/signet-memory-openclaw` symlink exists
- [ ] Manual: verify OpenClaw config has `plugins.load.paths` with global package path
- [ ] Manual: start daemon + OpenClaw, send Telegram message → check daemon logs for `user-prompt-submit` activity
- [ ] Manual: stop daemon, send message → verify "daemon unreachable" warning in OpenClaw logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better detection and clearer warnings when the background daemon is unreachable; related submit flows now note logged errors.

* **New Features**
  * Detect and use globally installed plugins; CLI refreshes and exposes global plugin paths.
  * Automatic per-state symlink creation so global plugins are available across state directories.
  * Connector can patch plugin load paths in discovered configs.
  * Default runtime mode changed from "legacy" to "plugin".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->