### PR TITLE
feat: dashboard UI polish — readout panel design language

### DIFF
--- a/packages/cli/dashboard/src/app.css
+++ b/packages/cli/dashboard/src/app.css
@@ -154,7 +154,7 @@
 	--sig-border-strong: rgba(0, 0, 0, 0.18);
 	--sig-text: #1a1a1e;
 	--sig-text-bright: #0a0a0c;
-	--sig-text-muted: #6e6e72;
+	--sig-text-muted: #525252;
 	--sig-accent: #c83a18;
 	--sig-accent-hover: #a83010;
 	--sig-danger: #9a3030;

--- a/packages/cli/dashboard/src/app.css
+++ b/packages/cli/dashboard/src/app.css
@@ -30,13 +30,13 @@
 	--ring: #5a5a66;
 
 	/* shadcn sidebar tokens */
-	--sidebar: #08080c;
+	--sidebar: #0a0a0e;
 	--sidebar-foreground: #d4d4d8;
 	--sidebar-primary: #f0f0f2;
 	--sidebar-primary-foreground: #060608;
 	--sidebar-accent: rgba(255, 255, 255, 0.06);
 	--sidebar-accent-foreground: #d4d4d8;
-	--sidebar-border: rgba(255, 255, 255, 0.05);
+	--sidebar-border: rgba(255, 255, 255, 0.10);
 	--sidebar-ring: #5a5a66;
 
 	/* Signet extended tokens */
@@ -51,6 +51,7 @@
 	--sig-accent: #8a8a96;
 	--sig-accent-hover: #c0c0c8;
 	--sig-danger: #8a4a48;
+	--sig-warning: #d4a017;
 	--sig-success: #4a7a5e;
 	--sig-dither: #f0f0f2;
 	--sig-grain-opacity: 0.05;
@@ -115,74 +116,76 @@
 	--dur: 0.2s;
 }
 
-/* === Light theme === */
+/* === Light theme — cool concrete + burnt orange (Aeris Systems) === */
 [data-theme="light"] {
-	--background: #e4dfd8;
-	--foreground: #2a2a2e;
-	--card: #dbd5cd;
-	--card-foreground: #2a2a2e;
-	--popover: #dbd5cd;
-	--popover-foreground: #2a2a2e;
+	--background: #e6e6e6;
+	--foreground: #1a1a1e;
+	--card: #dddddd;
+	--card-foreground: #1a1a1e;
+	--popover: #dddddd;
+	--popover-foreground: #1a1a1e;
 	--primary: #0a0a0c;
-	--primary-foreground: #e4dfd8;
-	--secondary: #d1cbc2;
-	--secondary-foreground: #2a2a2e;
-	--muted: #d1cbc2;
-	--muted-foreground: #7a756e;
-	--accent: #d1cbc2;
-	--accent-foreground: #2a2a2e;
-	--destructive: #8a4a48;
+	--primary-foreground: #e6e6e6;
+	--secondary: #d4d4d4;
+	--secondary-foreground: #1a1a1e;
+	--muted: #d4d4d4;
+	--muted-foreground: #6e6e72;
+	--accent: #d4d4d4;
+	--accent-foreground: #1a1a1e;
+	--destructive: #9a3030;
 	--destructive-foreground: #f0f0f2;
-	--border: rgba(0, 0, 0, 0.06);
+	--border: rgba(0, 0, 0, 0.08);
 	--input: rgba(0, 0, 0, 0.12);
-	--ring: #7a756e;
+	--ring: #6e6e72;
 
-	--sidebar: #d6d0c8;
-	--sidebar-foreground: #2a2a2e;
+	--sidebar: #dddddd;
+	--sidebar-foreground: #1a1a1e;
 	--sidebar-primary: #0a0a0c;
-	--sidebar-primary-foreground: #e4dfd8;
-	--sidebar-accent: rgba(0, 0, 0, 0.08);
-	--sidebar-accent-foreground: #2a2a2e;
-	--sidebar-border: rgba(0, 0, 0, 0.06);
-	--sidebar-ring: #7a756e;
+	--sidebar-primary-foreground: #e6e6e6;
+	--sidebar-accent: rgba(0, 0, 0, 0.06);
+	--sidebar-accent-foreground: #1a1a1e;
+	--sidebar-border: rgba(0, 0, 0, 0.10);
+	--sidebar-ring: #6e6e72;
 
-	--sig-bg: #e4dfd8;
-	--sig-surface: #dbd5cd;
-	--sig-surface-raised: #d1cbc2;
-	--sig-border: rgba(0, 0, 0, 0.1);
+	--sig-bg: #e6e6e6;
+	--sig-surface: #dddddd;
+	--sig-surface-raised: #d4d4d4;
+	--sig-border: rgba(0, 0, 0, 0.10);
 	--sig-border-strong: rgba(0, 0, 0, 0.18);
-	--sig-text: #2a2a2e;
+	--sig-text: #1a1a1e;
 	--sig-text-bright: #0a0a0c;
-	--sig-text-muted: #7a756e;
-	--sig-accent: #6a6660;
-	--sig-accent-hover: #3a3832;
-	--sig-danger: #8a4a48;
-	--sig-success: #4a7a5e;
+	--sig-text-muted: #6e6e72;
+	--sig-accent: #c83a18;
+	--sig-accent-hover: #a83010;
+	--sig-danger: #9a3030;
+	--sig-warning: #b87a00;
+	--sig-success: #2e7a4e;
 	--sig-dither: #0a0a0c;
-	--sig-grain-opacity: 0.06;
+	--sig-grain-opacity: 0.04;
 
-	/* Pinterest accent system — deeper/saturated for light backgrounds */
-	--sig-highlight: #6b8f00;
-	--sig-highlight-muted: rgba(107, 143, 0, 0.10);
-	--sig-highlight-dim: rgba(107, 143, 0, 0.05);
-	--sig-highlight-text: #4a6600;
+	/* Accent system — burnt orange for light (Aeris Systems inspired) */
+	--sig-highlight: #e8461e;
+	--sig-highlight-muted: rgba(232, 70, 30, 0.10);
+	--sig-highlight-dim: rgba(232, 70, 30, 0.06);
+	--sig-highlight-text: #c83a18;
 	--sig-electric: #2563eb;
 	--sig-electric-muted: rgba(37, 99, 235, 0.10);
 	--sig-electric-dim: rgba(37, 99, 235, 0.05);
 	--sig-blueprint: rgba(37, 99, 235, 0.03);
-	--sig-grid-line: rgba(0, 0, 0, 0.03);
-	--sig-glow-highlight: 0 0 16px rgba(107, 143, 0, 0.12);
-	--sig-glow-electric: 0 0 16px rgba(37, 99, 235, 0.12);
-	--sig-scanline-opacity: 0.01;
+	--sig-grid-line: rgba(0, 0, 0, 0.04);
+	/* No glow in light mode — clean flat look */
+	--sig-glow-highlight: none;
+	--sig-glow-electric: none;
+	--sig-scanline-opacity: 0.008;
 
 	--sig-icon-fg: #111827;
-	--sig-icon-border: rgba(0, 0, 0, 0.22);
-	--sig-icon-bg-1: #8fa8c8;
-	--sig-icon-bg-2: #b0a0c4;
-	--sig-icon-bg-3: #8abfa8;
-	--sig-icon-bg-4: #c4a870;
-	--sig-icon-bg-5: #c49090;
-	--sig-icon-bg-6: #8ab4c4;
+	--sig-icon-border: rgba(0, 0, 0, 0.18);
+	--sig-icon-bg-1: #8898b0;
+	--sig-icon-bg-2: #a090b0;
+	--sig-icon-bg-3: #80a898;
+	--sig-icon-bg-4: #b0a070;
+	--sig-icon-bg-5: #b08888;
+	--sig-icon-bg-6: #80a8b0;
 
 	/* Log category colors (light theme) */
 	--sig-log-category-watcher: #2563eb;
@@ -190,8 +193,8 @@
 	--sig-log-category-pipeline: #059669;
 	--sig-log-category-system: #6b7280;
 	--sig-log-category-embedding-tracker: #db2777;
-	--sig-log-category-document-worker: #ea580c;
-	--sig-log-category-maintenance: #6b8f00;
+	--sig-log-category-document-worker: #e8461e;
+	--sig-log-category-maintenance: #c83a18;
 	--sig-log-category-git: #0d9488;
 	--sig-log-category-scheduler: #9333ea;
 	--sig-log-category-retention: #dc2626;
@@ -304,6 +307,21 @@ body::after {
 ::selection {
 	background: var(--sig-highlight-muted);
 	color: var(--sig-text-bright);
+}
+
+/* Floating sidebar card */
+[data-variant="floating"] [data-sidebar="sidebar"] {
+	background: var(--sidebar);
+	border-color: var(--sig-border-strong);
+	box-shadow:
+		0 1px 3px rgba(0, 0, 0, 0.3),
+		0 0 0 1px rgba(255, 255, 255, 0.02) inset;
+}
+[data-theme="light"] [data-variant="floating"] [data-sidebar="sidebar"] {
+	border-color: var(--sig-border-strong);
+	box-shadow:
+		0 1px 3px rgba(0, 0, 0, 0.08),
+		0 0 0 1px rgba(255, 255, 255, 0.5) inset;
 }
 
 /* Subtle scrollbars */

--- a/packages/cli/dashboard/src/app.html
+++ b/packages/cli/dashboard/src/app.html
@@ -18,7 +18,6 @@
 			})();
 		</script>
 		%sveltekit.head%
-		<script src="https://mcp.figma.com/mcp/html-to-design/capture.js" async></script>
 	</head>
 	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>

--- a/packages/cli/dashboard/src/app.html
+++ b/packages/cli/dashboard/src/app.html
@@ -18,6 +18,7 @@
 			})();
 		</script>
 		%sveltekit.head%
+		<script src="https://mcp.figma.com/mcp/html-to-design/capture.js" async></script>
 	</head>
 	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>

--- a/packages/cli/dashboard/src/lib/components/UpgradeBanner.svelte
+++ b/packages/cli/dashboard/src/lib/components/UpgradeBanner.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { browser } from "$app/environment";
 	import type { DaemonStatus } from "$lib/api";
-	import Sparkles from "@lucide/svelte/icons/sparkles";
 	import X from "@lucide/svelte/icons/x";
 
 	const STORAGE_KEY_PREFIX = "signet-upgrade-banner-dismissed-";
@@ -36,41 +35,86 @@
 </script>
 
 {#if visible}
-	<div
-		class="flex items-center justify-between gap-3 px-4 py-2
-			border-b border-[var(--sig-border)]
-			bg-[var(--sig-surface-raised)]"
-	>
-		<div class="flex items-center gap-3 min-w-0">
-			<span
-				class="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-[0.08em]
-					text-[var(--sig-accent)]
-					font-[family-name:var(--font-display)]
-					shrink-0"
-			>
-				<Sparkles class="size-3" />
-				v{version}
-			</span>
-			<span
-				class="text-[12px] text-[var(--sig-text)]
-					font-[family-name:var(--font-mono)]
-					truncate"
-			>
-				Knowledge graph, session continuity, constellation entity overlay
-			</span>
-		</div>
-		<div class="flex items-center gap-2 shrink-0">
-			<button
-				onclick={dismiss}
-				class="flex items-center justify-center size-6
-					text-[var(--sig-text-muted)]
-					hover:text-[var(--sig-text-bright)]
-					bg-transparent border-none cursor-pointer
-					transition-colors duration-200"
-				aria-label="Dismiss upgrade banner"
-			>
-				<X class="size-3.5" />
-			</button>
-		</div>
+	<div class="banner">
+		<span class="banner-accent" aria-hidden="true"></span>
+		<span class="banner-version">v{version}</span>
+		<span class="banner-separator" aria-hidden="true"></span>
+		<span class="banner-text">
+			Knowledge graph, session continuity, constellation entity overlay
+		</span>
+		<button
+			onclick={dismiss}
+			class="banner-dismiss"
+			aria-label="Dismiss upgrade banner"
+		>
+			<X class="size-3" />
+		</button>
 	</div>
 {/if}
+
+<style>
+	.banner {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		height: 24px;
+		padding: 0 12px;
+		background: var(--sig-bg);
+		border-bottom: 1px solid var(--sig-border);
+		font-family: var(--font-mono);
+		font-size: 9px;
+		letter-spacing: 0.06em;
+		flex-shrink: 0;
+	}
+
+	.banner-accent {
+		width: 3px;
+		height: 10px;
+		background: var(--sig-highlight);
+		border-radius: 1px;
+		flex-shrink: 0;
+	}
+
+	.banner-version {
+		color: var(--sig-highlight);
+		font-weight: 700;
+		text-transform: uppercase;
+		flex-shrink: 0;
+	}
+
+	.banner-separator {
+		width: 1px;
+		height: 8px;
+		background: var(--sig-border-strong);
+		flex-shrink: 0;
+	}
+
+	.banner-text {
+		color: var(--sig-text-muted);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		min-width: 0;
+	}
+
+	.banner-dismiss {
+		margin-left: auto;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 18px;
+		height: 18px;
+		flex-shrink: 0;
+		color: var(--sig-text-muted);
+		background: none;
+		border: none;
+		border-radius: 2px;
+		cursor: pointer;
+		transition: color var(--dur) var(--ease), background var(--dur) var(--ease);
+	}
+
+	.banner-dismiss:hover {
+		color: var(--sig-text-bright);
+		background: var(--sig-surface-raised);
+	}
+</style>

--- a/packages/cli/dashboard/src/lib/components/app-sidebar.svelte
+++ b/packages/cli/dashboard/src/lib/components/app-sidebar.svelte
@@ -147,7 +147,7 @@ function activateItem(item: NavItem): void {
 }
 </script>
 
-<Sidebar.Root variant="sidebar" collapsible="icon">
+<Sidebar.Root variant="floating" collapsible="icon">
 	<Sidebar.Header>
 		<Sidebar.Menu>
 			<Sidebar.MenuItem>
@@ -163,7 +163,6 @@ function activateItem(item: NavItem): void {
 									before:bg-[var(--sig-highlight)]
 									after:absolute after:w-full after:h-px after:top-1/2
 									after:bg-[var(--sig-highlight)]"
-								style="filter: drop-shadow(0 0 3px var(--sig-highlight-dim));"
 								aria-hidden="true"
 							></span>
 							<div class="flex flex-col gap-0.5 leading-none overflow-hidden
@@ -241,7 +240,7 @@ function activateItem(item: NavItem): void {
 						class:bg-[var(--sig-highlight)]={!!daemonStatus}
 						class:border={!daemonStatus}
 						class:border-[var(--sig-text-muted)]={!daemonStatus}
-						style={daemonStatus ? "box-shadow: 0 0 6px var(--sig-highlight);" : ""}
+						style={daemonStatus ? "box-shadow: var(--sig-glow-highlight);" : ""}
 					></span>
 					<span
 						class="text-[10px] tracking-[0.1em] uppercase
@@ -340,123 +339,30 @@ function activateItem(item: NavItem): void {
 
 <style>
 	/*
-	 * "Blend into page" effect: the active sidebar item extends to the
-	 * right edge and visually merges with the main content area, using
-	 * rounded cutout corners above and below to form a tab shape.
+	 * Floating card sidebar: active item uses a contained highlight
+	 * with left accent border, no bleed-through to content area.
 	 */
 
 	.nav-blend-item {
 		position: relative;
-		margin-right: -8px; /* extend to the sidebar's right edge */
 		border-radius: 6px;
 		transition: background 0.2s ease, border-color 0.2s ease;
 	}
 
 	.nav-blend-item--active {
-		background: var(--sig-surface);
-		border-radius: 6px 0 0 6px;
+		background: var(--sig-surface-raised);
+		border-radius: 6px;
 		border-left: 2px solid var(--sig-highlight);
-		border-top: 1px solid var(--sig-border-strong);
-		border-bottom: 1px solid var(--sig-border-strong);
 	}
 
-	/* Rounded cutout above the active item */
-	.nav-blend-item--active::before {
-		content: "";
-		position: absolute;
-		right: 0;
-		bottom: 100%;
-		width: 10px;
-		height: 10px;
-		background: transparent;
-		border-bottom-right-radius: 8px;
-		box-shadow: 3px 3px 0 0 var(--sig-surface);
-		pointer-events: none;
-	}
-
-	/* Rounded cutout below the active item */
-	.nav-blend-item--active::after {
-		content: "";
-		position: absolute;
-		right: 0;
-		top: 100%;
-		width: 10px;
-		height: 10px;
-		background: transparent;
-		border-top-right-radius: 8px;
-		box-shadow: 3px -3px 0 0 var(--sig-surface);
-		pointer-events: none;
-	}
-
-	/* Override the active button styling to match the blend */
+	/* Override the active button styling */
 	:global(.nav-blend-item--active [data-sidebar="menu-button"]) {
 		background: transparent !important;
 		color: var(--sig-text-bright) !important;
 	}
 
-	/* When collapsed, disable the blend effect */
-	:global([data-collapsible="icon"][data-state="collapsed"]) .nav-blend-item {
-		margin-right: 0;
-	}
-	:global([data-collapsible="icon"][data-state="collapsed"]) .nav-blend-item--active {
-		background: transparent;
-		border-radius: 6px;
-		border-left: none;
-	}
-	:global([data-collapsible="icon"][data-state="collapsed"]) .nav-blend-item--active::before,
-	:global([data-collapsible="icon"][data-state="collapsed"]) .nav-blend-item--active::after {
-		display: none;
-	}
-
-	/* Carbon fiber texture on sidebar footer */
+	/* Sidebar footer separator */
 	:global(.sidebar-carbon-footer) {
-		position: relative;
-		border-top: none;
-	}
-	:global(.sidebar-carbon-footer)::before {
-		content: "";
-		position: absolute;
-		inset: 0;
-		pointer-events: none;
-		border-radius: inherit;
-		background:
-			repeating-conic-gradient(
-				rgba(255, 255, 255, 0.02) 0% 25%,
-				transparent 0% 50%
-			) 0 0 / 10px 10px,
-			repeating-conic-gradient(
-				transparent 0% 25%,
-				rgba(0, 0, 0, 0.03) 0% 50%
-			) 5px 5px / 10px 10px,
-			repeating-conic-gradient(
-				var(--sig-surface) 0% 25%,
-				color-mix(in srgb, var(--sig-surface) 96%, black) 0% 50%
-			) 0 0 / 10px 10px;
-		-webkit-mask-image: linear-gradient(to bottom, transparent, black 12px), linear-gradient(to right, black 50%, transparent 100%);
-		-webkit-mask-composite: source-in;
-		mask-image: linear-gradient(to bottom, transparent, black 12px), linear-gradient(to right, black 50%, transparent 100%);
-		mask-composite: intersect;
-		z-index: 0;
-	}
-	:global(.sidebar-carbon-footer > *) {
-		position: relative;
-		z-index: 1;
-	}
-
-	/* Light theme — darken the weave instead */
-	:global([data-theme="light"] .sidebar-carbon-footer)::before {
-		background:
-			repeating-conic-gradient(
-				rgba(0, 0, 0, 0.02) 0% 25%,
-				transparent 0% 50%
-			) 0 0 / 10px 10px,
-			repeating-conic-gradient(
-				transparent 0% 25%,
-				rgba(0, 0, 0, 0.03) 0% 50%
-			) 5px 5px / 10px 10px,
-			repeating-conic-gradient(
-				var(--sig-surface) 0% 25%,
-				color-mix(in srgb, var(--sig-surface) 96%, black) 0% 50%
-			) 0 0 / 10px 10px;
+		border-top: 1px solid var(--sig-border);
 	}
 </style>

--- a/packages/cli/dashboard/src/lib/components/home/AgentHeader.svelte
+++ b/packages/cli/dashboard/src/lib/components/home/AgentHeader.svelte
@@ -70,7 +70,7 @@
 	}
 
 	const projectName = $derived(
-		latestProject?.project?.replace(/^\/.*\//, "").replace(/\/$/, "") ?? "--",
+		latestProject?.project?.replace(/\/$/, "").split("/").pop() ?? "--",
 	);
 
 	const recency = $derived(
@@ -119,7 +119,7 @@
 	function scoreColor(score: number | null): string {
 		if (score === null) return "var(--sig-text-muted)";
 		if (score >= 0.8) return "var(--sig-success)";
-		if (score >= 0.5) return "var(--sig-warning, #d4a017)";
+		if (score >= 0.5) return "var(--sig-warning)";
 		return "var(--sig-danger)";
 	}
 

--- a/packages/cli/dashboard/src/lib/components/home/AgentHeader.svelte
+++ b/packages/cli/dashboard/src/lib/components/home/AgentHeader.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
-	import type { Identity, DaemonStatus, ContinuityEntry } from "$lib/api";
-	import Database from "@lucide/svelte/icons/database";
-	import Cable from "@lucide/svelte/icons/cable";
-	import Cpu from "@lucide/svelte/icons/cpu";
+	import type {
+		Identity,
+		DaemonStatus,
+		ContinuityEntry,
+		DiagnosticsReport,
+		PipelineStatus,
+		MemoryStats,
+	} from "$lib/api";
 
 	interface Props {
 		identity: Identity;
@@ -11,15 +15,21 @@
 		connectorCount: number;
 		continuity: ContinuityEntry[];
 		memoryCount: number;
+		diagnostics?: DiagnosticsReport | null;
+		pipelineStatus?: PipelineStatus | null;
+		memoryStats?: MemoryStats | null;
 	}
 
 	const {
 		identity,
-		greeting,
+		greeting: _greeting,
 		daemonStatus,
 		connectorCount,
 		continuity,
 		memoryCount,
+		diagnostics = null,
+		pipelineStatus = null,
+		memoryStats = null,
 	}: Props = $props();
 
 	const ageDays = $derived.by(() => {
@@ -31,13 +41,14 @@
 	});
 
 	const ageLabel = $derived.by(() => {
-		if (ageDays === null) return null;
-		if (ageDays === 0) return "today";
-		if (ageDays === 1) return "1 day";
-		return `${ageDays} days`;
+		if (ageDays === null) return "--";
+		if (ageDays === 0) return "TODAY";
+		if (ageDays === 1) return "1 DAY";
+		return `${ageDays} DAYS`;
 	});
 
 	const activeSessions = $derived(daemonStatus?.activeSessions ?? 0);
+	const version = $derived(daemonStatus?.version ?? "--");
 
 	const latestProject = $derived.by(() => {
 		if (continuity.length === 0) return null;
@@ -52,157 +63,329 @@
 	function formatRecency(dateStr: string): string {
 		const diff = Date.now() - new Date(dateStr).getTime();
 		const mins = Math.floor(diff / 60_000);
-		if (mins < 1) return "just now";
-		if (mins < 60) return `${mins}m ago`;
+		if (mins < 1) return "JUST NOW";
+		if (mins < 60) return `${mins}M AGO`;
 		const hours = Math.floor(mins / 60);
-		if (hours < 24) return `${hours}h ago`;
+		if (hours < 24) return `${hours}H AGO`;
 		const days = Math.floor(hours / 24);
-		return `${days}d ago`;
+		return `${days}D AGO`;
 	}
+
+	const projectName = $derived(
+		latestProject?.project?.replace(/^\/.*\//, "").replace(/\/$/, "") ?? "--",
+	);
+
+	const recency = $derived(
+		latestProject ? formatRecency(latestProject.created_at) : "--",
+	);
+
+	/* use name from identity; daemon /api/identity sometimes returns empty
+	   strings even when agent.yaml has a name configured — fall back gracefully */
+	const agentName = $derived(
+		(identity.name && identity.name.trim()) || "SIGNET AGENT",
+	);
+
+	/* health metrics from diagnostics */
+	const healthScore = $derived(diagnostics?.composite?.score ?? null);
+	const healthStatus = $derived(diagnostics?.composite?.status ?? "UNKNOWN");
+
+	const embeddingPct = $derived.by(() => {
+		if (diagnostics?.index?.embeddingCoverage !== undefined) {
+			return Math.round(diagnostics.index.embeddingCoverage * 100);
+		}
+		if (!memoryStats || memoryStats.total === 0) return null;
+		return Math.round((memoryStats.withEmbeddings / memoryStats.total) * 100);
+	});
+
+	const pipelineMode = $derived.by(() => {
+		if (!pipelineStatus) return "UNKNOWN";
+		const mode = (pipelineStatus as Record<string, unknown>).mode;
+		if (typeof mode === "string") return mode.toUpperCase();
+		return "ACTIVE";
+	});
+
+	const warningCount = $derived.by(() => {
+		if (!diagnostics) return 0;
+		let count = 0;
+		const domains = ["queue", "storage", "index", "provider", "connector", "predictor"] as const;
+		for (const d of domains) {
+			const domain = diagnostics[d];
+			if (domain && typeof domain === "object" && "status" in domain) {
+				const status = (domain as { status: string }).status;
+				if (status === "degraded" || status === "unhealthy") count++;
+			}
+		}
+		return count;
+	});
+
+	function scoreColor(score: number | null): string {
+		if (score === null) return "var(--sig-text-muted)";
+		if (score >= 0.8) return "var(--sig-success)";
+		if (score >= 0.5) return "var(--sig-warning, #d4a017)";
+		return "var(--sig-danger)";
+	}
+
+	type Row = { idx: string; label: string; value: string; color?: string };
+
+	const leftRows: Row[] = $derived([
+		{ idx: "01", label: "UPTIME", value: ageLabel },
+		{ idx: "02", label: "PROJECT", value: projectName },
+		{ idx: "03", label: "LAST SEEN", value: recency },
+		{ idx: "04", label: "CONNECTORS", value: String(connectorCount) },
+		{ idx: "05", label: "SESSIONS", value: String(activeSessions) },
+	]);
+
+	const rightRows: Row[] = $derived([
+		{
+			idx: "06",
+			label: "HEALTH",
+			value: healthScore !== null ? `${healthScore.toFixed(2)} ${healthStatus.toUpperCase()}` : "--",
+			color: scoreColor(healthScore),
+		},
+		{
+			idx: "07",
+			label: "EMBEDDED",
+			value: embeddingPct !== null ? `${embeddingPct}%` : "--",
+		},
+		{
+			idx: "08",
+			label: "PIPELINE",
+			value: pipelineMode,
+		},
+		{
+			idx: "09",
+			label: "WARNINGS",
+			value: String(warningCount),
+			color: warningCount > 0 ? "var(--sig-danger)" : undefined,
+		},
+	]);
 </script>
 
-<div class="agent-header">
-	<div class="header-left">
-		<span class="greeting">{greeting}</span>
-		<div class="name-row">
-			<h1 class="agent-name">{identity.name ?? "Agent"}</h1>
-			{#if ageLabel}
-				<span class="sig-meta age-label">{ageLabel}</span>
-			{/if}
-			{#if latestProject}
-				<span class="sig-meta project-label">
-					{latestProject.project}
-					<span class="recency">{formatRecency(latestProject.created_at)}</span>
-				</span>
-			{/if}
-		</div>
-	</div>
+<div class="readout">
+	<!-- Scanline texture layer -->
+	<div class="readout-texture" aria-hidden="true"></div>
 
-	<div class="header-right">
-		<div class="chip">
-			<Database class="chip-icon" />
-			<span class="chip-value">{memoryCount.toLocaleString()}</span>
-			<span class="chip-label">memories</span>
+	<div class="readout-content">
+		<!-- Eyebrow -->
+		<div class="readout-eyebrow">
+			<span class="eyebrow-left">SIGNET AGENT READOUT</span>
+			<span class="eyebrow-right">v{version}</span>
 		</div>
-		<div class="chip">
-			<Cable class="chip-icon" />
-			<span class="chip-value">{connectorCount}</span>
-			<span class="chip-label">connectors</span>
+
+		<!-- Hero: agent name + memory count -->
+		<div class="readout-hero">
+			<h1 class="agent-name">{agentName}</h1>
+			<div class="hero-stat">
+				<span class="hero-number">{memoryCount.toLocaleString()}</span>
+				<span class="hero-unit">MEMORIES<br/>STORED</span>
+			</div>
 		</div>
-		<div class="chip">
-			<Cpu class="chip-icon" />
-			<span class="chip-value">{activeSessions}</span>
-			<span class="chip-label">active</span>
+
+		<!-- Divider -->
+		<div class="readout-divider" aria-hidden="true"></div>
+
+		<!-- Two-column data grid -->
+		<div class="readout-grid">
+			<div class="readout-col">
+				{#each leftRows as row}
+					<div class="data-row">
+						<span class="data-idx">{row.idx}</span>
+						<span class="data-label">{row.label}</span>
+						<span class="data-fill"></span>
+						<span
+							class="data-value"
+							style={row.color ? `color: ${row.color}` : ""}
+						>{row.value}</span>
+					</div>
+				{/each}
+			</div>
+			<div class="readout-col">
+				{#each rightRows as row}
+					<div class="data-row">
+						<span class="data-idx">{row.idx}</span>
+						<span class="data-label">{row.label}</span>
+						<span class="data-fill"></span>
+						<span
+							class="data-value"
+							style={row.color ? `color: ${row.color}` : ""}
+						>{row.value}</span>
+					</div>
+				{/each}
+			</div>
 		</div>
 	</div>
 </div>
 
 <style>
-	.agent-header {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: var(--space-md);
-		padding: var(--space-sm) var(--space-md);
-		background:
-			repeating-conic-gradient(
-				rgba(255, 255, 255, 0.02) 0% 25%,
-				transparent 0% 50%
-			) 0 0 / 10px 10px,
-			repeating-conic-gradient(
-				transparent 0% 25%,
-				rgba(0, 0, 0, 0.03) 0% 50%
-			) 5px 5px / 10px 10px,
-			repeating-conic-gradient(
-				var(--sig-surface) 0% 25%,
-				color-mix(in srgb, var(--sig-surface) 96%, black) 0% 50%
-			) 0 0 / 10px 10px;
-		border: 1px solid var(--sig-border);
+	.readout {
+		position: relative;
+		overflow: hidden;
+		border: 1px solid var(--sig-border-strong);
 		border-radius: var(--radius);
+		background: var(--sig-bg);
 	}
 
-	.header-left {
+	.readout-texture {
+		position: absolute;
+		inset: 0;
+		pointer-events: none;
+		background:
+			repeating-linear-gradient(
+				0deg,
+				transparent 0px,
+				transparent 3px,
+				var(--sig-grid-line) 3px,
+				var(--sig-grid-line) 4px
+			);
+		z-index: 1;
+	}
+
+	.readout-content {
+		position: relative;
+		z-index: 2;
+		padding: var(--space-md) var(--space-lg);
+	}
+
+	/* --- Eyebrow --- */
+	.readout-eyebrow {
 		display: flex;
-		flex-direction: column;
-		gap: 2px;
-		min-width: 0;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: var(--space-md);
 	}
 
-	.greeting {
+	.eyebrow-left {
 		font-family: var(--font-mono);
-		font-size: var(--font-size-xs);
+		font-size: 8px;
+		letter-spacing: 0.14em;
 		color: var(--sig-text-muted);
-		text-transform: lowercase;
 	}
 
-	.name-row {
+	.eyebrow-right {
+		font-family: var(--font-mono);
+		font-size: 8px;
+		letter-spacing: 0.1em;
+		color: var(--sig-accent);
+	}
+
+	/* --- Hero --- */
+	.readout-hero {
 		display: flex;
-		align-items: baseline;
-		gap: var(--space-sm);
-		flex-wrap: wrap;
+		align-items: flex-end;
+		justify-content: space-between;
+		gap: var(--space-lg);
+		margin-bottom: var(--space-md);
 	}
 
 	.agent-name {
 		font-family: var(--font-display);
-		font-size: 18px;
+		font-size: 42px;
 		font-weight: 700;
 		text-transform: uppercase;
 		letter-spacing: 0.08em;
 		color: var(--sig-highlight);
 		margin: 0;
-		line-height: 1.1;
+		line-height: 0.9;
 	}
 
-	.age-label {
-		color: var(--sig-text-muted);
+	/* Neon glow only in dark mode */
+	:global(:root:not([data-theme="light"])) .agent-name {
+		text-shadow:
+			0 0 30px var(--sig-highlight-dim),
+			0 0 60px var(--sig-highlight-dim);
 	}
 
-	.project-label {
-		color: var(--sig-accent);
-	}
-
-	.recency {
-		color: var(--sig-text-muted);
-		margin-left: 4px;
-	}
-
-	.header-right {
+	.hero-stat {
 		display: flex;
-		align-items: center;
-		gap: var(--space-xs);
+		align-items: flex-end;
+		gap: var(--space-sm);
 		flex-shrink: 0;
 	}
 
-	.chip {
-		display: flex;
-		align-items: center;
-		gap: 4px;
-		padding: 3px 8px;
-		background: var(--sig-surface-raised);
-		border: 1px solid var(--sig-border);
-		border-radius: 1rem;
-		white-space: nowrap;
+	.hero-number {
+		font-family: var(--font-mono);
+		font-size: 36px;
+		font-weight: 700;
+		line-height: 0.9;
+		color: var(--sig-text-bright);
+		font-variant-numeric: tabular-nums;
+		letter-spacing: -0.02em;
 	}
 
-	:global(.chip-icon) {
-		width: 11px;
-		height: 11px;
+	.hero-unit {
+		font-family: var(--font-mono);
+		font-size: 8px;
+		line-height: 1.4;
+		letter-spacing: 0.1em;
 		color: var(--sig-text-muted);
-		flex-shrink: 0;
+		padding-bottom: 4px;
 	}
 
-	.chip-value {
+	/* --- Divider --- */
+	.readout-divider {
+		height: 1px;
+		background: linear-gradient(
+			90deg,
+			var(--sig-highlight) 0%,
+			var(--sig-highlight-dim) 30%,
+			var(--sig-border) 60%,
+			transparent 100%
+		);
+		margin-bottom: var(--space-sm);
+	}
+
+	/* --- Data grid --- */
+	.readout-grid {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 0 var(--space-xl);
+	}
+
+	.readout-col {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+	}
+
+	.data-row {
+		display: flex;
+		align-items: baseline;
 		font-family: var(--font-mono);
 		font-size: 10px;
-		font-weight: 600;
-		color: var(--sig-highlight);
+		line-height: 2;
+		letter-spacing: 0.04em;
 	}
 
-	.chip-label {
-		font-family: var(--font-mono);
+	.data-idx {
+		width: 20px;
+		flex-shrink: 0;
+		color: var(--sig-highlight);
+		opacity: 0.4;
 		font-size: 9px;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.data-label {
 		color: var(--sig-text-muted);
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
+		white-space: nowrap;
+		flex-shrink: 0;
+	}
+
+	.data-fill {
+		flex: 1;
+		min-width: 16px;
+		border-bottom: 1px dotted var(--sig-border-strong);
+		margin: 0 8px;
+		position: relative;
+		top: -3px;
+	}
+
+	.data-value {
+		color: var(--sig-text-bright);
+		font-weight: 600;
+		white-space: nowrap;
+		flex-shrink: 0;
+		font-variant-numeric: tabular-nums;
+		text-align: right;
 	}
 </style>

--- a/packages/cli/dashboard/src/lib/components/home/AgentHeader.svelte
+++ b/packages/cli/dashboard/src/lib/components/home/AgentHeader.svelte
@@ -10,7 +10,6 @@
 
 	interface Props {
 		identity: Identity;
-		greeting: string;
 		daemonStatus: DaemonStatus | null;
 		connectorCount: number;
 		continuity: ContinuityEntry[];
@@ -22,7 +21,6 @@
 
 	const {
 		identity,
-		greeting: _greeting,
 		daemonStatus,
 		connectorCount,
 		continuity,

--- a/packages/cli/dashboard/src/lib/components/home/PinnedEntityCluster.svelte
+++ b/packages/cli/dashboard/src/lib/components/home/PinnedEntityCluster.svelte
@@ -208,7 +208,7 @@
 		padding: var(--space-md);
 	}
 
-	:global(.empty-icon) {
+	:global(.panel .empty-icon) {
 		width: 16px;
 		height: 16px;
 		color: var(--sig-border-strong);

--- a/packages/cli/dashboard/src/lib/components/home/PinnedEntityCluster.svelte
+++ b/packages/cli/dashboard/src/lib/components/home/PinnedEntityCluster.svelte
@@ -1,10 +1,4 @@
 <script lang="ts">
-	import {
-		Card,
-		CardContent,
-		CardHeader,
-		CardTitle,
-	} from "$lib/components/ui/card/index.js";
 	import { setTab } from "$lib/stores/navigation.svelte";
 	import Network from "@lucide/svelte/icons/network";
 	import { onMount } from "svelte";
@@ -30,7 +24,7 @@
 				entities = data.entities ?? data.items ?? [];
 			}
 		} catch {
-			// endpoint may not exist yet — show empty state
+			// endpoint may not exist yet
 		}
 		loaded = true;
 	}
@@ -40,76 +34,183 @@
 	});
 </script>
 
-<Card
-	class="flex flex-1 flex-col overflow-hidden rounded-none
-		border-[var(--sig-border)] py-0
-		shadow-none"
-	style="background: var(--sig-surface);"
->
-	<CardHeader class="px-3 py-2.5">
-		<div class="flex items-center gap-2">
-			<Network class="size-3.5 text-[var(--sig-text-muted)]" />
-			<CardTitle
-				class="font-display text-[11px] font-bold uppercase tracking-[0.1em]
-					text-[var(--sig-text-bright)]"
-			>
-				Spotlight
-			</CardTitle>
-		</div>
-	</CardHeader>
+<div class="panel">
+	<div class="panel-header">
+		<span class="panel-title">SPOTLIGHT</span>
+		<span class="panel-count">{entities.length} PINNED</span>
+	</div>
 
-	<CardContent class="flex flex-1 flex-col px-3 pb-3 pt-0">
+	<div class="panel-body">
 		{#if !loaded}
-			<div class="flex-1"></div>
+			<div class="empty-state">LOADING</div>
 		{:else if entities.length === 0}
-			<!-- Empty state -->
-			<div class="flex flex-1 flex-col items-center justify-center gap-2 py-4">
-				<div
-					class="flex items-center justify-center rounded-md size-10"
-					style="background: var(--sig-surface-raised); border: 1px solid var(--sig-border)"
-				>
-					<Network class="size-5 text-[var(--sig-text-muted)]" />
-				</div>
-				<p
-					class="max-w-[180px] text-center font-[family-name:var(--font-mono)]
-						text-[10px] leading-4 text-[var(--sig-text-muted)]"
-				>
-					Pin an entity in Knowledge to set it as your spotlight
-				</p>
+			<div class="empty-state">
+				<Network class="empty-icon" />
+				<span>PIN AN ENTITY IN KNOWLEDGE<br/>TO SET YOUR SPOTLIGHT</span>
 			</div>
 		{:else}
-			<!-- Pinned entity list -->
-			<div class="flex flex-1 flex-col gap-1.5">
+			<div class="entity-list">
 				{#each entities as entity, idx (entity.id ?? `entity-${idx}`)}
-					<div
-						class="flex items-center gap-2 rounded-sm px-2 py-1.5"
-						style="background: var(--sig-surface-raised); border: 1px solid var(--sig-border)"
-					>
-						<div
-							class="size-2 shrink-0 rounded-full"
-							style="background: var(--sig-accent)"
-						></div>
+					<div class="entity-row">
+						<span class="entity-idx">{String(idx + 1).padStart(2, "0")}</span>
 						<span
-							class="min-w-0 truncate font-[family-name:var(--font-mono)]
-								text-[11px] text-[var(--sig-text)]"
-						>
-							{entity.name}
-						</span>
+							class="entity-dot"
+							style="background: var(--sig-highlight)"
+						></span>
+						<span class="entity-name">{entity.name}</span>
 						{#if entity.mentionCount !== undefined}
-							<span class="sig-micro ml-auto shrink-0 text-[var(--sig-text-muted)]">
-								{entity.mentionCount}
-							</span>
+							<span class="entity-count">{entity.mentionCount}</span>
 						{/if}
 					</div>
 				{/each}
 			</div>
 		{/if}
+	</div>
 
-		<button
-			class="mt-2 sig-meta text-[var(--sig-accent)] transition-opacity hover:opacity-80"
-			onclick={() => setTab("knowledge")}
-		>
-			View in Knowledge &rarr;
+	<div class="panel-footer">
+		<button class="panel-link" onclick={() => setTab("knowledge")}>
+			VIEW IN KNOWLEDGE
 		</button>
-	</CardContent>
-</Card>
+	</div>
+</div>
+
+<style>
+	.panel {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		background: var(--sig-surface);
+		border: 1px solid var(--sig-border);
+		border-radius: var(--radius);
+		overflow: hidden;
+	}
+
+	.panel-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--space-sm) var(--space-md);
+		border-bottom: 1px solid var(--sig-border);
+		flex-shrink: 0;
+	}
+
+	.panel-title {
+		font-family: var(--font-display);
+		font-size: 11px;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--sig-text-bright);
+	}
+
+	.panel-count {
+		font-family: var(--font-mono);
+		font-size: 8px;
+		letter-spacing: 0.1em;
+		color: var(--sig-text-muted);
+	}
+
+	.panel-body {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+		padding: var(--space-sm) 0;
+	}
+
+	.panel-footer {
+		padding: var(--space-sm) var(--space-md);
+		border-top: 1px solid var(--sig-border);
+		flex-shrink: 0;
+	}
+
+	.panel-link {
+		font-family: var(--font-mono);
+		font-size: 9px;
+		letter-spacing: 0.08em;
+		color: var(--sig-accent);
+		background: none;
+		border: none;
+		padding: 0;
+		cursor: pointer;
+		transition: color var(--dur) var(--ease);
+	}
+
+	.panel-link:hover {
+		color: var(--sig-highlight-text);
+	}
+
+	/* Entity list */
+	.entity-list {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.entity-row {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		padding: 3px var(--space-md);
+		font-family: var(--font-mono);
+		font-size: 10px;
+		transition: background var(--dur) var(--ease);
+	}
+
+	.entity-row:hover {
+		background: var(--sig-surface-raised);
+	}
+
+	.entity-idx {
+		width: 16px;
+		flex-shrink: 0;
+		color: var(--sig-highlight);
+		opacity: 0.4;
+		font-size: 9px;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.entity-dot {
+		width: 4px;
+		height: 4px;
+		border-radius: 50%;
+		flex-shrink: 0;
+	}
+
+	.entity-name {
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		color: var(--sig-text);
+	}
+
+	.entity-count {
+		flex-shrink: 0;
+		font-size: 9px;
+		color: var(--sig-text-muted);
+		font-variant-numeric: tabular-nums;
+	}
+
+	/* Empty state */
+	.empty-state {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: var(--space-sm);
+		height: 100%;
+		font-family: var(--font-mono);
+		font-size: 9px;
+		letter-spacing: 0.08em;
+		color: var(--sig-text-muted);
+		text-align: center;
+		line-height: 1.6;
+		padding: var(--space-md);
+	}
+
+	:global(.empty-icon) {
+		width: 16px;
+		height: 16px;
+		color: var(--sig-border-strong);
+	}
+</style>

--- a/packages/cli/dashboard/src/lib/components/home/PredictorSplitBar.svelte
+++ b/packages/cli/dashboard/src/lib/components/home/PredictorSplitBar.svelte
@@ -53,7 +53,7 @@
 
 	function statusColor(status: string): string {
 		if (status === "healthy") return "var(--sig-success)";
-		if (status === "degraded" || status === "cold_start") return "var(--sig-warning, #d4a017)";
+		if (status === "degraded" || status === "cold_start") return "var(--sig-warning)";
 		if (status === "unhealthy") return "var(--sig-danger)";
 		return "var(--sig-text-muted)";
 	}
@@ -80,6 +80,8 @@
 	$effect(() => {
 		if (daemonStatus) {
 			fetchData();
+		} else {
+			loaded = true;
 		}
 	});
 </script>

--- a/packages/cli/dashboard/src/lib/components/home/PredictorSplitBar.svelte
+++ b/packages/cli/dashboard/src/lib/components/home/PredictorSplitBar.svelte
@@ -1,14 +1,6 @@
 <script lang="ts">
-	import {
-		Card,
-		CardContent,
-		CardHeader,
-		CardTitle,
-	} from "$lib/components/ui/card/index.js";
-	import { Badge } from "$lib/components/ui/badge/index.js";
 	import { setTab } from "$lib/stores/navigation.svelte";
 	import type { DaemonStatus } from "$lib/api";
-	import Gauge from "@lucide/svelte/icons/gauge";
 
 	const isDev = import.meta.env.DEV;
 	const API_BASE = isDev ? "http://localhost:3850" : "";
@@ -24,28 +16,11 @@
 		trainingSessions: number;
 	}
 
-	interface DiagnosticsPredictor {
-		score: number;
-		status: string;
-	}
-
-	interface DiagnosticsIndex {
-		embeddingCoverage: number;
-	}
-
-	interface DiagnosticsStorage {
-		totalMemories: number;
-	}
-
-	interface DiagnosticsComposite {
-		score: number;
-	}
-
 	interface DiagnosticsData {
-		predictor?: DiagnosticsPredictor;
-		index?: DiagnosticsIndex;
-		storage?: DiagnosticsStorage;
-		composite?: DiagnosticsComposite;
+		predictor?: { score: number; status: string };
+		index?: { embeddingCoverage: number };
+		storage?: { totalMemories: number };
+		composite?: { score: number };
 	}
 
 	interface Props {
@@ -76,19 +51,12 @@
 		diagnostics?.composite?.score ?? 0,
 	);
 
-	const healthBadgeVariant = $derived.by(() => {
-		switch (healthStatus) {
-			case "healthy":
-				return "default" as const;
-			case "degraded":
-			case "cold_start":
-				return "secondary" as const;
-			case "unhealthy":
-				return "destructive" as const;
-			default:
-				return "outline" as const;
-		}
-	});
+	function statusColor(status: string): string {
+		if (status === "healthy") return "var(--sig-success)";
+		if (status === "degraded" || status === "cold_start") return "var(--sig-warning, #d4a017)";
+		if (status === "unhealthy") return "var(--sig-danger)";
+		return "var(--sig-text-muted)";
+	}
 
 	async function fetchData(): Promise<void> {
 		try {
@@ -116,83 +84,250 @@
 	});
 </script>
 
-<Card
-	class="flex flex-col overflow-hidden rounded-none
-		border-[var(--sig-border)] py-0
-		shadow-none"
-	style="background: var(--sig-surface);"
->
-	<CardHeader class="px-3 py-2.5">
-		<div class="flex items-center gap-2">
-			<Gauge class="size-3.5 text-[var(--sig-text-muted)]" />
-			<CardTitle
-				class="font-display text-[11px] font-bold uppercase tracking-[0.1em]
-					text-[var(--sig-text-bright)]"
-			>
-				Memory Scoring
-			</CardTitle>
-		</div>
-	</CardHeader>
+<div class="panel">
+	<div class="panel-header">
+		<span class="panel-title">MEMORY SCORING</span>
+		{#if loaded}
+			<span
+				class="status-indicator"
+				style="color: {statusColor(healthStatus)}"
+			>{healthStatus.toUpperCase()}</span>
+		{/if}
+	</div>
 
-	<CardContent class="px-3 pb-3 pt-0">
+	<div class="panel-body">
 		{#if !loaded}
-			<div class="h-12"></div>
+			<div class="empty-state">LOADING</div>
 		{:else if predictorAvailable}
-			<!-- Split bar: baseline vs predictor -->
-			<div class="space-y-1.5">
-				<div class="flex gap-px h-2 w-full overflow-hidden rounded-sm">
-					<div
-						class="transition-all duration-300"
-						style="width: {alpha * 100}%; background: var(--sig-text-muted)"
-					></div>
-					<div
-						class="transition-all duration-300"
-						style="width: {(1 - alpha) * 100}%; background: var(--sig-accent)"
-					></div>
-				</div>
-				<div class="flex justify-between">
-					<span class="sig-micro text-[var(--sig-text-muted)]">baseline</span>
-					<span class="sig-micro text-[var(--sig-accent)]">predictor</span>
+			<!-- Predictor active: split bar + stats -->
+			<div class="scoring-data">
+				<div class="split-bar-container">
+					<div class="split-bar">
+						<div
+							class="split-segment baseline"
+							style="width: {alpha * 100}%"
+						></div>
+						<div
+							class="split-segment predictor"
+							style="width: {(1 - alpha) * 100}%"
+						></div>
+					</div>
+					<div class="split-labels">
+						<span class="split-label">BASELINE {Math.round(alpha * 100)}%</span>
+						<span class="split-label accent">PREDICTOR {Math.round((1 - alpha) * 100)}%</span>
+					</div>
 				</div>
 
-				<div class="flex items-center gap-2 pt-1">
-					<span class="sig-meta text-[var(--sig-text-muted)]">
-						success {Math.round(successRate * 100)}%
-					</span>
-					<Badge variant={healthBadgeVariant} class="text-[8px] px-1.5 py-0">
-						{healthStatus}
-					</Badge>
+				<div class="stat-rows">
+					<div class="stat-row">
+						<span class="stat-label">SUCCESS RATE</span>
+						<span class="stat-fill"></span>
+						<span class="stat-value">{Math.round(successRate * 100)}%</span>
+					</div>
+					<div class="stat-row">
+						<span class="stat-label">MODEL VERSION</span>
+						<span class="stat-fill"></span>
+						<span class="stat-value">v{health?.modelVersion ?? "--"}</span>
+					</div>
+					<div class="stat-row">
+						<span class="stat-label">TRAINING SESSIONS</span>
+						<span class="stat-fill"></span>
+						<span class="stat-value">{health?.trainingSessions ?? "--"}</span>
+					</div>
 				</div>
 			</div>
 		{:else}
-			<!-- Baseline-only stats -->
-			<div class="space-y-2">
-				<div class="flex justify-between items-center">
-					<span class="sig-meta text-[var(--sig-text-muted)]">embedding coverage</span>
-					<span class="sig-meta text-[var(--sig-text)]">
-						{Math.round(embeddingCoverage * 100)}%
-					</span>
+			<!-- Baseline only -->
+			<div class="stat-rows">
+				<div class="stat-row">
+					<span class="stat-label">EMBEDDING COVERAGE</span>
+					<span class="stat-fill"></span>
+					<span class="stat-value">{Math.round(embeddingCoverage * 100)}%</span>
 				</div>
-				<div class="flex justify-between items-center">
-					<span class="sig-meta text-[var(--sig-text-muted)]">total memories</span>
-					<span class="sig-meta text-[var(--sig-text)]">
-						{totalMemories.toLocaleString()}
-					</span>
+				<div class="stat-row">
+					<span class="stat-label">TOTAL MEMORIES</span>
+					<span class="stat-fill"></span>
+					<span class="stat-value">{totalMemories.toLocaleString()}</span>
 				</div>
-				<div class="flex justify-between items-center">
-					<span class="sig-meta text-[var(--sig-text-muted)]">health score</span>
-					<span class="sig-meta text-[var(--sig-text)]">
-						{Math.round(compositeScore * 100)}%
-					</span>
+				<div class="stat-row">
+					<span class="stat-label">HEALTH SCORE</span>
+					<span class="stat-fill"></span>
+					<span class="stat-value">{Math.round(compositeScore * 100)}%</span>
 				</div>
 			</div>
 		{/if}
+	</div>
 
-		<button
-			class="mt-2 sig-meta text-[var(--sig-accent)] transition-opacity hover:opacity-80"
-			onclick={() => setTab("predictor")}
-		>
-			View predictor &rarr;
+	<div class="panel-footer">
+		<button class="panel-link" onclick={() => setTab("predictor")}>
+			VIEW PREDICTOR
 		</button>
-	</CardContent>
-</Card>
+	</div>
+</div>
+
+<style>
+	.panel {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		background: var(--sig-surface);
+		border: 1px solid var(--sig-border);
+		border-radius: var(--radius);
+		overflow: hidden;
+	}
+
+	.panel-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--space-sm) var(--space-md);
+		border-bottom: 1px solid var(--sig-border);
+		flex-shrink: 0;
+	}
+
+	.panel-title {
+		font-family: var(--font-display);
+		font-size: 11px;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--sig-text-bright);
+	}
+
+	.status-indicator {
+		font-family: var(--font-mono);
+		font-size: 8px;
+		letter-spacing: 0.1em;
+		font-weight: 600;
+	}
+
+	.panel-body {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+		padding: var(--space-sm) var(--space-md);
+	}
+
+	.panel-footer {
+		padding: var(--space-sm) var(--space-md);
+		border-top: 1px solid var(--sig-border);
+		flex-shrink: 0;
+	}
+
+	.panel-link {
+		font-family: var(--font-mono);
+		font-size: 9px;
+		letter-spacing: 0.08em;
+		color: var(--sig-accent);
+		background: none;
+		border: none;
+		padding: 0;
+		cursor: pointer;
+		transition: color var(--dur) var(--ease);
+	}
+
+	.panel-link:hover {
+		color: var(--sig-highlight-text);
+	}
+
+	/* Split bar */
+	.scoring-data {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-sm);
+	}
+
+	.split-bar-container {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	.split-bar {
+		display: flex;
+		gap: 1px;
+		height: 6px;
+		width: 100%;
+		overflow: hidden;
+		border-radius: 1px;
+	}
+
+	.split-segment {
+		transition: width 0.3s var(--ease);
+	}
+
+	.split-segment.baseline {
+		background: var(--sig-text-muted);
+	}
+
+	.split-segment.predictor {
+		background: var(--sig-highlight);
+	}
+
+	.split-labels {
+		display: flex;
+		justify-content: space-between;
+	}
+
+	.split-label {
+		font-family: var(--font-mono);
+		font-size: 8px;
+		letter-spacing: 0.08em;
+		color: var(--sig-text-muted);
+	}
+
+	.split-label.accent {
+		color: var(--sig-highlight-text);
+	}
+
+	/* Stat rows — matching readout language */
+	.stat-rows {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+	}
+
+	.stat-row {
+		display: flex;
+		align-items: baseline;
+		font-family: var(--font-mono);
+		font-size: 10px;
+		line-height: 2;
+		letter-spacing: 0.04em;
+	}
+
+	.stat-label {
+		color: var(--sig-text-muted);
+		white-space: nowrap;
+		flex-shrink: 0;
+	}
+
+	.stat-fill {
+		flex: 1;
+		min-width: 12px;
+		border-bottom: 1px dotted var(--sig-border-strong);
+		margin: 0 6px;
+		position: relative;
+		top: -3px;
+	}
+
+	.stat-value {
+		color: var(--sig-text-bright);
+		font-weight: 600;
+		white-space: nowrap;
+		flex-shrink: 0;
+		font-variant-numeric: tabular-nums;
+	}
+
+	/* Empty state */
+	.empty-state {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 100%;
+		font-family: var(--font-mono);
+		font-size: 9px;
+		letter-spacing: 0.1em;
+		color: var(--sig-text-muted);
+	}
+</style>

--- a/packages/cli/dashboard/src/lib/components/home/SuggestedInsights.svelte
+++ b/packages/cli/dashboard/src/lib/components/home/SuggestedInsights.svelte
@@ -14,7 +14,7 @@
 	const { memories }: Props = $props();
 
 	let actedIds = $state<Set<string>>(new Set());
-	let refreshKey = $state(0);
+	let displayOffset = $state(0);
 
 	function scoreMemory(m: Memory): number {
 		const now = Date.now();
@@ -42,9 +42,8 @@
 			.filter(Boolean);
 	}
 
-	const scoredPool = $derived.by(() => {
-		void refreshKey;
-		return memories
+	const scoredPool = $derived(
+		memories
 			.filter((m) => {
 				if (actedIds.has(m.id)) return false;
 				if (m.pinned) return false;
@@ -53,16 +52,20 @@
 				return true;
 			})
 			.map((m) => ({ memory: m, score: scoreMemory(m) }))
-			.sort((a, b) => b.score - a.score);
-	});
-
-	const displayCards = $derived(
-		scoredPool.slice(0, 3).map((s) => s.memory),
+			.sort((a, b) => b.score - a.score),
 	);
+
+	const displayCards = $derived.by(() => {
+		if (scoredPool.length === 0) return [];
+		const start = displayOffset % scoredPool.length;
+		return Array.from({ length: Math.min(3, scoredPool.length) }, (_, i) =>
+			scoredPool[(start + i) % scoredPool.length].memory,
+		);
+	});
 
 	function importanceColor(imp: number): string {
 		if (imp >= 0.8) return "var(--sig-danger)";
-		if (imp >= 0.5) return "var(--sig-warning, #d4a017)";
+		if (imp >= 0.5) return "var(--sig-warning)";
 		return "var(--sig-success)";
 	}
 
@@ -122,7 +125,7 @@
 	}
 
 	function handleRefresh(): void {
-		refreshKey += 1;
+		displayOffset = (displayOffset + 3) % Math.max(1, scoredPool.length);
 	}
 </script>
 

--- a/packages/cli/dashboard/src/lib/components/home/SuggestedInsights.svelte
+++ b/packages/cli/dashboard/src/lib/components/home/SuggestedInsights.svelte
@@ -303,7 +303,7 @@
 		border-color: var(--sig-border-strong);
 	}
 
-	:global(.refresh-icon) {
+	:global(.insights-panel .refresh-icon) {
 		width: 10px;
 		height: 10px;
 	}

--- a/packages/cli/dashboard/src/lib/components/home/SuggestedInsights.svelte
+++ b/packages/cli/dashboard/src/lib/components/home/SuggestedInsights.svelte
@@ -303,6 +303,11 @@
 		border-color: var(--sig-border-strong);
 	}
 
+	.refresh-btn:focus-visible {
+		outline: 2px solid var(--sig-highlight);
+		outline-offset: 1px;
+	}
+
 	:global(.insights-panel .refresh-icon) {
 		width: 10px;
 		height: 10px;
@@ -438,6 +443,11 @@
 	.action-btn.edit:hover {
 		color: var(--sig-accent-hover);
 		border-color: var(--sig-accent);
+	}
+
+	.action-btn:focus-visible {
+		outline: 2px solid var(--sig-highlight);
+		outline-offset: 1px;
 	}
 
 	/* --- Empty state --- */

--- a/packages/cli/dashboard/src/lib/components/home/SuggestedInsights.svelte
+++ b/packages/cli/dashboard/src/lib/components/home/SuggestedInsights.svelte
@@ -2,13 +2,9 @@
 	import type { Memory } from "$lib/api";
 	import { setMemoryPinned, updateMemory } from "$lib/api";
 	import { toast } from "$lib/stores/toast.svelte";
-	import * as Card from "$lib/components/ui/card/index.js";
 	import * as Popover from "$lib/components/ui/popover/index.js";
 	import { Button } from "$lib/components/ui/button/index.js";
 	import { Textarea } from "$lib/components/ui/textarea/index.js";
-	import Check from "@lucide/svelte/icons/check";
-	import X from "@lucide/svelte/icons/x";
-	import Pencil from "@lucide/svelte/icons/pencil";
 	import RefreshCw from "@lucide/svelte/icons/refresh-cw";
 
 	interface Props {
@@ -70,6 +66,13 @@
 		return "var(--sig-success)";
 	}
 
+	function formatDate(dateStr: string): string {
+		const d = new Date(dateStr);
+		const month = d.toLocaleDateString("en-US", { month: "short" }).toUpperCase();
+		const day = String(d.getDate()).padStart(2, "0");
+		return `${month} ${day}`;
+	}
+
 	async function acceptMemory(m: Memory): Promise<void> {
 		const result = await setMemoryPinned(m.id, true);
 		if (result.success) {
@@ -123,234 +126,330 @@
 	}
 </script>
 
-<Card.Root class="flex flex-col h-full overflow-hidden">
-	<Card.Header class="flex-row items-center justify-between py-2 px-3 shrink-0">
-		<Card.Title>
-			<span class="sig-heading">Suggested Insights</span>
-		</Card.Title>
-		<Button
-			variant="ghost"
-			size="sm"
-			class="h-6 w-6 p-0"
-			onclick={handleRefresh}
-		>
-			<RefreshCw class="size-3.5" />
-		</Button>
-	</Card.Header>
-	<Card.Content class="flex-1 min-h-0 overflow-hidden px-3 pb-3">
-		{#if displayCards.length === 0}
-			<div class="flex items-center justify-center h-full">
-				<span class="sig-label">No insights to curate</span>
-			</div>
-		{:else}
-			<div class="insight-grid">
-				{#each displayCards as m (m.id)}
-					<div class="insight-card">
-						<div class="insight-header">
+<div class="insights-panel">
+	<div class="insights-header">
+		<span class="insights-title">SUGGESTED INSIGHTS</span>
+		<div class="insights-header-right">
+			<span class="insights-count">{displayCards.length} OF {scoredPool.length}</span>
+			<button class="refresh-btn" onclick={handleRefresh} title="Refresh suggestions">
+				<RefreshCw class="refresh-icon" />
+				<span>REFRESH</span>
+			</button>
+		</div>
+	</div>
+
+	{#if displayCards.length === 0}
+		<div class="empty-state">
+			<span>NO INSIGHTS TO CURATE</span>
+		</div>
+	{:else}
+		<div class="insights-list">
+			{#each displayCards as m, i (m.id)}
+				<div class="insight-entry">
+					<!-- Index + date row -->
+					<div class="entry-top">
+						<div class="entry-top-left">
+							<span class="entry-idx">{String(i + 1).padStart(2, "0")}</span>
 							<span
-								class="importance-dot"
+								class="entry-dot"
 								style="background: {importanceColor(m.importance ?? 0.5)}"
 								title="importance: {(m.importance ?? 0.5).toFixed(2)}"
 							></span>
-							<span class="sig-micro">
-								{new Date(m.created_at).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
-							</span>
+							<span class="entry-date">{formatDate(m.created_at)}</span>
 						</div>
-
-						<p class="insight-content">{m.content}</p>
-
 						{#if parseTags(m.tags).length > 0}
-							<div class="insight-tags">
+							<div class="entry-tags">
 								{#each parseTags(m.tags).slice(0, 3) as tag}
-									<span class="sig-badge tag-badge">{tag}</span>
+									<span class="entry-tag">{tag}</span>
 								{/each}
 							</div>
 						{/if}
-
-						<div class="insight-actions">
-							<Button
-								variant="ghost"
-								size="sm"
-								class="action-btn accept"
-								onclick={() => acceptMemory(m)}
-								title="Pin memory"
-							>
-								<Check class="size-3" />
-							</Button>
-							<Button
-								variant="ghost"
-								size="sm"
-								class="action-btn reject"
-								onclick={() => rejectMemory(m)}
-								title="Dismiss"
-							>
-								<X class="size-3" />
-							</Button>
-							<Popover.Root>
-								<Popover.Trigger>
-									{#snippet child({ props })}
-										<button
-											{...props}
-											class="action-btn-raw"
-											onclick={() => initEdit(m)}
-											title="Correct"
-										>
-											<Pencil class="size-3" />
-										</button>
-									{/snippet}
-								</Popover.Trigger>
-								<Popover.Content
-									class="w-72 !bg-[var(--sig-surface-raised)] !border-[var(--sig-border-strong)]"
-									side="bottom"
-									align="start"
-								>
-									<div class="edit-popover">
-										<span class="sig-eyebrow">Correct memory</span>
-										<Textarea
-											class="mt-2 min-h-[60px] text-[11px] font-[family-name:var(--font-mono)]
-												bg-[var(--sig-bg)] border-[var(--sig-border)]
-												text-[var(--sig-text)]"
-											value={editContent[m.id] ?? m.content}
-											oninput={(e) => {
-												const target = e.currentTarget;
-												if (target instanceof HTMLTextAreaElement) {
-													editContent[m.id] = target.value;
-												}
-											}}
-										/>
-										<div class="flex justify-end gap-1 mt-1">
-											<Popover.Close>
-												{#snippet child({ props })}
-													<button
-														{...props}
-														class="text-[10px] px-2 py-1 text-[var(--sig-text-muted)] hover:text-[var(--sig-text)]"
-													>Cancel</button>
-												{/snippet}
-											</Popover.Close>
-											<Button
-												variant="default"
-												size="sm"
-												class="text-[10px] h-6"
-												onclick={() => saveCorrection(m)}
-											>
-												Save
-											</Button>
-										</div>
-									</div>
-								</Popover.Content>
-							</Popover.Root>
-						</div>
 					</div>
-				{/each}
-			</div>
-		{/if}
-	</Card.Content>
-</Card.Root>
+
+					<!-- Content -->
+					<p class="entry-content">{m.content}</p>
+
+					<!-- Actions -->
+					<div class="entry-actions">
+						<button
+							class="action-btn accept"
+							onclick={() => acceptMemory(m)}
+						>PIN</button>
+						<button
+							class="action-btn reject"
+							onclick={() => rejectMemory(m)}
+						>DISMISS</button>
+						<Popover.Root>
+							<Popover.Trigger>
+								{#snippet child({ props })}
+									<button
+										{...props}
+										class="action-btn edit"
+										onclick={() => initEdit(m)}
+									>EDIT</button>
+								{/snippet}
+							</Popover.Trigger>
+							<Popover.Content
+								class="w-72 !bg-[var(--sig-surface-raised)] !border-[var(--sig-border-strong)]"
+								side="bottom"
+								align="start"
+							>
+								<div class="edit-popover">
+									<span class="sig-eyebrow">Correct memory</span>
+									<Textarea
+										class="mt-2 min-h-[60px] text-[11px] font-[family-name:var(--font-mono)]
+											bg-[var(--sig-bg)] border-[var(--sig-border)]
+											text-[var(--sig-text)]"
+										value={editContent[m.id] ?? m.content}
+										oninput={(e) => {
+											const target = e.currentTarget;
+											if (target instanceof HTMLTextAreaElement) {
+												editContent[m.id] = target.value;
+											}
+										}}
+									/>
+									<div class="flex justify-end gap-1 mt-1">
+										<Popover.Close>
+											{#snippet child({ props })}
+												<button
+													{...props}
+													class="text-[10px] px-2 py-1 text-[var(--sig-text-muted)] hover:text-[var(--sig-text)]"
+												>Cancel</button>
+											{/snippet}
+										</Popover.Close>
+										<Button
+											variant="default"
+											size="sm"
+											class="text-[10px] h-6"
+											onclick={() => saveCorrection(m)}
+										>
+											Save
+										</Button>
+									</div>
+								</div>
+							</Popover.Content>
+						</Popover.Root>
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>
 
 <style>
-	.insight-grid {
-		display: grid;
-		grid-template-columns: repeat(3, 1fr);
-		gap: var(--space-sm);
-		height: 100%;
-	}
-
-	.insight-card {
-		padding: var(--space-sm);
-		background: var(--sig-surface-raised);
-		border: 1px solid var(--sig-border);
-		border-radius: var(--radius);
+	.insights-panel {
 		display: flex;
 		flex-direction: column;
-		gap: 4px;
-		min-height: 0;
+		height: 100%;
+		background: var(--sig-surface);
+		border: 1px solid var(--sig-border);
+		border-radius: var(--radius);
 		overflow: hidden;
 	}
 
-	.insight-header {
+	/* --- Header --- */
+	.insights-header {
 		display: flex;
 		align-items: center;
-		gap: var(--space-xs);
+		justify-content: space-between;
+		padding: var(--space-sm) var(--space-md);
+		border-bottom: 1px solid var(--sig-border);
 		flex-shrink: 0;
 	}
 
-	.importance-dot {
+	.insights-title {
+		font-family: var(--font-display);
+		font-size: 11px;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--sig-text-bright);
+	}
+
+	.insights-header-right {
+		display: flex;
+		align-items: center;
+		gap: var(--space-sm);
+	}
+
+	.insights-count {
+		font-family: var(--font-mono);
+		font-size: 8px;
+		letter-spacing: 0.1em;
+		color: var(--sig-text-muted);
+	}
+
+	.refresh-btn {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		padding: 3px 8px;
+		background: transparent;
+		border: 1px solid var(--sig-border);
+		border-radius: var(--radius);
+		color: var(--sig-text-muted);
+		font-family: var(--font-mono);
+		font-size: 8px;
+		letter-spacing: 0.08em;
+		cursor: pointer;
+		transition: color var(--dur) var(--ease), border-color var(--dur) var(--ease);
+	}
+
+	.refresh-btn:hover {
+		color: var(--sig-text-bright);
+		border-color: var(--sig-border-strong);
+	}
+
+	:global(.refresh-icon) {
+		width: 10px;
+		height: 10px;
+	}
+
+	/* --- List --- */
+	.insights-list {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.insight-entry {
+		padding: var(--space-sm) var(--space-md);
+		border-bottom: 1px solid var(--sig-border);
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		transition: background var(--dur) var(--ease);
+	}
+
+	.insight-entry:last-child {
+		border-bottom: none;
+	}
+
+	.insight-entry:hover {
+		background: var(--sig-surface-raised);
+	}
+
+	/* --- Entry top row --- */
+	.entry-top {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--space-sm);
+	}
+
+	.entry-top-left {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.entry-idx {
+		font-family: var(--font-mono);
+		font-size: 9px;
+		color: var(--sig-highlight);
+		opacity: 0.4;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.entry-dot {
 		width: 5px;
 		height: 5px;
 		border-radius: 50%;
 		flex-shrink: 0;
 	}
 
-	.insight-content {
+	.entry-date {
 		font-family: var(--font-mono);
-		font-size: var(--font-size-xs);
-		line-height: 1.5;
-		color: var(--sig-text);
-		margin: 0;
-		flex: 1;
-		overflow: hidden;
-		display: -webkit-box;
-		-webkit-line-clamp: 5;
-		line-clamp: 5;
-		-webkit-box-orient: vertical;
-	}
-
-	.insight-tags {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 2px;
-		flex-shrink: 0;
-	}
-
-	.tag-badge {
-		font-size: 8px;
-		padding: 1px 4px;
-		background: var(--sig-bg);
-		border: 1px solid var(--sig-border);
+		font-size: 9px;
+		letter-spacing: 0.06em;
 		color: var(--sig-text-muted);
 	}
 
-	.insight-actions {
+	.entry-tags {
 		display: flex;
-		gap: 2px;
-		margin-top: auto;
+		gap: 4px;
 		flex-shrink: 0;
 	}
 
-	:global(.action-btn) {
-		height: 22px !important;
-		width: 22px !important;
-		padding: 0 !important;
+	.entry-tag {
+		font-family: var(--font-mono);
+		font-size: 8px;
+		padding: 1px 6px;
+		background: var(--sig-bg);
+		border: 1px solid var(--sig-border);
+		border-radius: 2px;
+		color: var(--sig-accent);
+		letter-spacing: 0.04em;
 	}
 
-	.action-btn-raw {
+	/* --- Content --- */
+	.entry-content {
+		font-family: var(--font-mono);
+		font-size: 11px;
+		line-height: 1.6;
+		color: var(--sig-text);
+		margin: 0;
+		display: -webkit-box;
+		-webkit-line-clamp: 3;
+		line-clamp: 3;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+
+	/* --- Actions --- */
+	.entry-actions {
+		display: flex;
+		gap: 4px;
+	}
+
+	.action-btn {
+		font-family: var(--font-mono);
+		font-size: 8px;
+		letter-spacing: 0.08em;
+		padding: 2px 8px;
+		background: transparent;
+		border: 1px solid var(--sig-border);
+		border-radius: 2px;
+		color: var(--sig-text-muted);
+		cursor: pointer;
+		transition: color var(--dur) var(--ease), border-color var(--dur) var(--ease), background var(--dur) var(--ease);
+	}
+
+	.action-btn:hover {
+		color: var(--sig-text-bright);
+		border-color: var(--sig-border-strong);
+	}
+
+	.action-btn.accept:hover {
+		color: var(--sig-success);
+		border-color: var(--sig-success);
+	}
+
+	.action-btn.reject:hover {
+		color: var(--sig-danger);
+		border-color: var(--sig-danger);
+	}
+
+	.action-btn.edit:hover {
+		color: var(--sig-accent-hover);
+		border-color: var(--sig-accent);
+	}
+
+	/* --- Empty state --- */
+	.empty-state {
+		flex: 1;
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		height: 22px;
-		width: 22px;
-		padding: 0;
-		border: none;
-		background: transparent;
+		font-family: var(--font-mono);
+		font-size: 9px;
+		letter-spacing: 0.1em;
 		color: var(--sig-text-muted);
-		cursor: pointer;
-		border-radius: var(--radius);
-		transition: color var(--dur) var(--ease), background var(--dur) var(--ease);
 	}
 
-	.action-btn-raw:hover {
-		color: var(--sig-accent);
-		background: var(--sig-surface-raised);
-	}
-
-	:global(.action-btn.accept:hover) {
-		color: var(--sig-success) !important;
-	}
-
-	:global(.action-btn.reject:hover) {
-		color: var(--sig-danger) !important;
-	}
-
+	/* --- Edit popover --- */
 	.edit-popover {
 		display: flex;
 		flex-direction: column;

--- a/packages/cli/dashboard/src/lib/components/layout/PageFooter.svelte
+++ b/packages/cli/dashboard/src/lib/components/layout/PageFooter.svelte
@@ -35,47 +35,88 @@ function formatTimelineGeneratedFor(value: string): string {
 }
 
 const staticFooter = $derived(PAGE_FOOTERS[activeTab]);
+
+interface FooterSlot {
+	left: string;
+	right: string;
+}
+
+const content = $derived.by((): FooterSlot | null => {
+	if (activeTab === "skills") return null;
+	if (activeTab === "settings") return {
+		left: "SETTINGS",
+		right: "CTRL+S SAVE",
+	};
+	if (activeTab === "memory") return {
+		left: memoryFooterLabel.toUpperCase(),
+		right: memorySearching
+			? "SEARCHING"
+			: memorySimilarActive
+				? "SIMILARITY"
+				: "HYBRID INDEX",
+	};
+	if (activeTab === "timeline") return {
+		left: "TIMELINE",
+		right: timelineGeneratedFor
+			? formatTimelineGeneratedFor(timelineGeneratedFor).toUpperCase()
+			: "EVOLUTION VIEW",
+	};
+	if (activeTab === "tasks") return {
+		left: `${taskCount} TASKS`,
+		right: "SCHEDULER",
+	};
+	if (staticFooter) return {
+		left: staticFooter.left.toUpperCase(),
+		right: staticFooter.right.toUpperCase(),
+	};
+	return null;
+});
 </script>
 
-{#if activeTab !== "skills"}
-<div
-	class="flex items-center justify-between h-[26px] px-4
-		bg-[var(--sig-bg)]
-		sig-eyebrow shrink-0"
->
-	{#if activeTab === "settings"}
-		<span>Settings</span>
-		<span class="flex items-center gap-2">
-			<kbd class="px-1 py-px text-[10px] text-[var(--sig-text-muted)]
-				bg-[var(--sig-surface-raised)]"
-			>Ctrl+S</kbd> save
-		</span>
-	{:else if activeTab === "memory"}
-		<span>{memoryFooterLabel}</span>
-		<span>
-			{#if memorySearching}
-				semantic search in progress
-			{:else if memorySimilarActive}
-				similarity mode
-			{:else}
-				hybrid search index
-			{/if}
-		</span>
-	{:else if activeTab === "timeline"}
-		<span>timeline eras</span>
-		<span>
-			{#if timelineGeneratedFor}
-				As of {formatTimelineGeneratedFor(timelineGeneratedFor)}
-			{:else}
-				memory evolution view
-			{/if}
-		</span>
-	{:else if activeTab === "tasks"}
-		<span>{taskCount} scheduled tasks</span>
-		<span>cron scheduler</span>
-	{:else if staticFooter}
-		<span>{staticFooter.left}</span>
-		<span>{staticFooter.right}</span>
-	{/if}
+{#if content}
+<div class="footer">
+	<span class="footer-pip" aria-hidden="true"></span>
+	<span class="footer-text">{content.left}</span>
+	<span class="footer-fill"></span>
+	<span class="footer-text">{content.right}</span>
 </div>
 {/if}
+
+<style>
+	.footer {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		height: 22px;
+		padding: 0 12px;
+		background: var(--sig-bg);
+		border-top: 1px solid var(--sig-border);
+		flex-shrink: 0;
+		font-family: var(--font-mono);
+		font-size: 8px;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	.footer-pip {
+		width: 4px;
+		height: 4px;
+		border-radius: 50%;
+		background: var(--sig-highlight);
+		opacity: 0.5;
+		flex-shrink: 0;
+	}
+
+	.footer-text {
+		color: var(--sig-text-muted);
+		white-space: nowrap;
+		flex-shrink: 0;
+	}
+
+	.footer-fill {
+		flex: 1;
+		min-width: 8px;
+		height: 1px;
+		background: var(--sig-border);
+	}
+</style>

--- a/packages/cli/dashboard/src/lib/components/layout/TabContentLoader.svelte
+++ b/packages/cli/dashboard/src/lib/components/layout/TabContentLoader.svelte
@@ -9,6 +9,7 @@ import type {
 	MemoryStats,
 } from "$lib/api";
 import { Skeleton } from "$lib/components/ui/skeleton/index.js";
+import { fade } from "svelte/transition";
 
 interface Props {
 	activeTab: TabId;
@@ -80,6 +81,8 @@ const {
 	</div>
 {/snippet}
 
+{#key activeTab}
+<div class="tab-transition" in:fade={{ duration: 80 }}>
 {#if activeTab === "home"}
 	{#await import("$lib/components/tabs/HomeTab.svelte")}
 		{@render skeletonCards()}
@@ -201,3 +204,14 @@ const {
 		{@render skeletonError(error)}
 	{/await}
 {/if}
+</div>
+{/key}
+
+<style>
+	.tab-transition {
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+		min-height: 0;
+	}
+</style>

--- a/packages/cli/dashboard/src/lib/components/skills/SkillCard.svelte
+++ b/packages/cli/dashboard/src/lib/components/skills/SkillCard.svelte
@@ -254,9 +254,9 @@ let isInstalled = $derived(
 	}
 
 	.card:focus-visible {
-		outline: none;
+		outline: 2px solid var(--sig-highlight);
+		outline-offset: 1px;
 		border-color: var(--sig-highlight);
-		border-left: 2px solid var(--sig-highlight);
 	}
 
 	.action-row {

--- a/packages/cli/dashboard/src/lib/components/skills/SkillCard.svelte
+++ b/packages/cli/dashboard/src/lib/components/skills/SkillCard.svelte
@@ -236,30 +236,27 @@ let isInstalled = $derived(
 	.card {
 		display: flex;
 		flex-direction: column;
-		gap: 8px;
+		gap: 6px;
 		padding: var(--space-sm);
-		background:
-			radial-gradient(circle at 15% 120%, color-mix(in srgb, var(--sig-accent) 8%, transparent), transparent 45%),
-			linear-gradient(to right, color-mix(in srgb, var(--sig-surface-raised) 94%, black) 0%, var(--sig-surface) 65%);
+		background: var(--sig-surface);
 		border: 1px solid var(--sig-border);
+		border-radius: var(--radius);
 		cursor: pointer;
-		transition: border-color 0.15s, background 0.15s;
+		transition: border-color var(--dur) var(--ease), background var(--dur) var(--ease);
 		text-align: left;
-		min-height: 140px;
+		min-height: 0;
 		width: 100%;
 	}
 
 	.card:hover {
-		border-color: var(--sig-highlight);
-		background:
-			radial-gradient(circle at 15% 120%, color-mix(in srgb, var(--sig-accent) 11%, transparent), transparent 45%),
-			linear-gradient(to right, color-mix(in srgb, var(--sig-surface-raised) 91%, black) 0%, var(--sig-surface) 65%);
+		border-color: var(--sig-border-strong);
+		background: var(--sig-surface-raised);
 	}
 
 	.card:focus-visible {
-		outline: 2px solid var(--sig-highlight);
-		outline-offset: 1px;
+		outline: none;
 		border-color: var(--sig-highlight);
+		border-left: 2px solid var(--sig-highlight);
 	}
 
 	.action-row {
@@ -269,12 +266,11 @@ let isInstalled = $derived(
 	}
 	.card-wrap.selected > .card {
 		border-color: var(--sig-highlight);
-		background:
-			radial-gradient(circle at 15% 120%, color-mix(in srgb, var(--sig-accent) 14%, transparent), transparent 45%),
-			linear-gradient(to right, color-mix(in srgb, var(--sig-surface-raised) 88%, black) 0%, var(--sig-surface) 65%);
+		border-left: 2px solid var(--sig-highlight);
+		background: var(--sig-surface-raised);
 	}
 	.card-wrap.featured > .card {
-		min-height: 160px;
+		min-height: 0;
 	}
 
 	.remove-corner {
@@ -313,15 +309,15 @@ let isInstalled = $derived(
 
 	.monogram {
 		flex-shrink: 0;
-		width: 28px;
-		height: 28px;
+		width: 24px;
+		height: 24px;
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		border-radius: 0.45rem;
+		border-radius: 3px;
 		border: 1px solid var(--sig-icon-border);
 		font-family: var(--font-mono);
-		font-size: 10px;
+		font-size: 9px;
 		font-weight: 700;
 		color: var(--sig-icon-fg);
 		letter-spacing: 0.06em;
@@ -329,9 +325,9 @@ let isInstalled = $derived(
 		user-select: none;
 	}
 	.monogram.monogram-featured {
-		width: 34px;
-		height: 34px;
-		font-size: 11px;
+		width: 24px;
+		height: 24px;
+		font-size: 9px;
 	}
 
 	.card-header-content {
@@ -355,10 +351,10 @@ let isInstalled = $derived(
 	}
 
 	.card-name {
-		font-family: var(--font-display);
-		font-size: 12px;
+		font-family: var(--font-mono);
+		font-size: 11px;
 		font-weight: 600;
-		color: var(--sig-highlight);
+		color: var(--sig-text-bright);
 		text-transform: uppercase;
 		letter-spacing: 0.04em;
 		overflow: hidden;
@@ -368,7 +364,7 @@ let isInstalled = $derived(
 		min-width: 0;
 	}
 	.card-name.card-name-featured {
-		font-size: 13px;
+		font-size: 11px;
 	}
 
 	.provider-badge {
@@ -388,14 +384,14 @@ let isInstalled = $derived(
 
 	.card-desc {
 		font-family: var(--font-mono);
-		font-size: 10px;
+		font-size: 9px;
 		color: var(--sig-text-muted);
 		line-height: 1.5;
 		margin: 0;
 		flex: 1;
-		line-clamp: 3;
+		line-clamp: 2;
 		display: -webkit-box;
-		-webkit-line-clamp: 3;
+		-webkit-line-clamp: 2;
 		-webkit-box-orient: vertical;
 		overflow: hidden;
 	}
@@ -403,7 +399,7 @@ let isInstalled = $derived(
 	.card-stats {
 		display: flex;
 		align-items: center;
-		gap: 10px;
+		gap: 8px;
 		flex-wrap: wrap;
 	}
 
@@ -412,7 +408,7 @@ let isInstalled = $derived(
 		align-items: center;
 		gap: 3px;
 		font-family: var(--font-mono);
-		font-size: 10px;
+		font-size: 9px;
 		color: var(--sig-text-muted);
 		font-variant-numeric: tabular-nums;
 	}

--- a/packages/cli/dashboard/src/lib/components/skills/SkillGrid.svelte
+++ b/packages/cli/dashboard/src/lib/components/skills/SkillGrid.svelte
@@ -128,25 +128,11 @@ let remainingCount = $derived(items.length - visibleCount);
 		flex: 1;
 		min-height: 0;
 		overflow-y: auto;
-		padding: var(--space-md);
+		padding: var(--space-sm);
 		display: flex;
 		flex-direction: column;
 		gap: var(--space-sm);
-		border: 1px solid var(--sig-border-strong);
-		border-radius: 8px;
-		background:
-			repeating-conic-gradient(
-				rgba(255, 255, 255, 0.02) 0% 25%,
-				transparent 0% 50%
-			) 0 0 / 10px 10px,
-			repeating-conic-gradient(
-				transparent 0% 25%,
-				rgba(0, 0, 0, 0.03) 0% 50%
-			) 5px 5px / 10px 10px,
-			repeating-conic-gradient(
-				var(--sig-surface) 0% 25%,
-				color-mix(in srgb, var(--sig-surface) 96%, black) 0% 50%
-			) 0 0 / 10px 10px;
+		background: transparent;
 	}
 
 	.grid {

--- a/packages/cli/dashboard/src/lib/components/tabs/HomeTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/HomeTab.svelte
@@ -12,7 +12,6 @@
 	} from "$lib/api";
 	import {
 		getDiagnostics,
-		getHomeGreeting,
 		getContinuityLatest,
 		getPipelineStatus,
 		getConnectors,
@@ -35,7 +34,6 @@
 		$props();
 
 	let diagnostics = $state<DiagnosticsReport | null>(null);
-	let greeting = $state<string>("welcome back");
 	let continuity = $state<ContinuityEntry[]>([]);
 	let pipelineStatus = $state<PipelineStatus | null>(null);
 	let connectors = $state<DocumentConnector[]>([]);
@@ -44,7 +42,6 @@
 	onMount(async () => {
 		const results = await Promise.allSettled([
 			getDiagnostics(),
-			getHomeGreeting(),
 			getContinuityLatest(),
 			getPipelineStatus(),
 			getConnectors(),
@@ -52,14 +49,12 @@
 
 		if (results[0].status === "fulfilled" && results[0].value)
 			diagnostics = results[0].value;
-		if (results[1].status === "fulfilled" && results[1].value)
-			greeting = results[1].value.greeting;
+		if (results[1].status === "fulfilled")
+			continuity = results[1].value;
 		if (results[2].status === "fulfilled")
-			continuity = results[2].value;
+			pipelineStatus = results[2].value;
 		if (results[3].status === "fulfilled")
-			pipelineStatus = results[3].value;
-		if (results[4].status === "fulfilled")
-			connectors = results[4].value;
+			connectors = results[3].value;
 		loaded = true;
 	});
 </script>
@@ -69,7 +64,6 @@
 	<div class="area-banner">
 		<AgentHeader
 			{identity}
-			{greeting}
 			{daemonStatus}
 			connectorCount={connectors.length}
 			{continuity}

--- a/packages/cli/dashboard/src/lib/components/tabs/HomeTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/HomeTab.svelte
@@ -16,16 +16,12 @@
 		getContinuityLatest,
 		getPipelineStatus,
 		getConnectors,
-		fetchChangelog,
 	} from "$lib/api";
 	import AgentHeader from "$lib/components/home/AgentHeader.svelte";
 	import SuggestedInsights from "$lib/components/home/SuggestedInsights.svelte";
 	import PredictorSplitBar from "$lib/components/home/PredictorSplitBar.svelte";
 	import PinnedEntityCluster from "$lib/components/home/PinnedEntityCluster.svelte";
-	import SystemInfoCard from "$lib/components/home/SystemInfoCard.svelte";
-	import MiniChangelog from "$lib/components/home/MiniChangelog.svelte";
 	import { onMount } from "svelte";
-	import PageBanner from "$lib/components/layout/PageBanner.svelte";
 
 	interface Props {
 		identity: Identity;
@@ -43,7 +39,6 @@
 	let continuity = $state<ContinuityEntry[]>([]);
 	let pipelineStatus = $state<PipelineStatus | null>(null);
 	let connectors = $state<DocumentConnector[]>([]);
-	let changelogHtml = $state<string | null>(null);
 	let loaded = $state(false);
 
 	onMount(async () => {
@@ -53,7 +48,6 @@
 			getContinuityLatest(),
 			getPipelineStatus(),
 			getConnectors(),
-			fetchChangelog(),
 		]);
 
 		if (results[0].status === "fulfilled" && results[0].value)
@@ -66,14 +60,11 @@
 			pipelineStatus = results[3].value;
 		if (results[4].status === "fulfilled")
 			connectors = results[4].value;
-		if (results[5].status === "fulfilled" && results[5].value)
-			changelogHtml = results[5].value.html;
 		loaded = true;
 	});
 </script>
 
 <div class="flex flex-col flex-1 min-h-0 overflow-hidden">
-<PageBanner title="Home" />
 <div class="home-grid">
 	<div class="area-banner">
 		<AgentHeader
@@ -83,24 +74,17 @@
 			connectorCount={connectors.length}
 			{continuity}
 			memoryCount={memoryStats?.total ?? 0}
-		/>
-	</div>
-	<div class="area-insights">
-		<SuggestedInsights {memories} />
-	</div>
-	<div class="area-right-top">
-		<PinnedEntityCluster />
-		<PredictorSplitBar {daemonStatus} />
-	</div>
-	<div class="area-health">
-		<SystemInfoCard
 			{diagnostics}
 			{pipelineStatus}
 			{memoryStats}
 		/>
 	</div>
-	<div class="area-changelog">
-		<MiniChangelog html={changelogHtml} />
+	<div class="area-insights">
+		<SuggestedInsights {memories} />
+	</div>
+	<div class="area-sidebar">
+		<PinnedEntityCluster />
+		<PredictorSplitBar {daemonStatus} />
 	</div>
 </div>
 </div>
@@ -109,11 +93,10 @@
 	.home-grid {
 		display: grid;
 		grid-template-columns: 1.6fr 1fr;
-		grid-template-rows: auto 1fr 1fr;
+		grid-template-rows: auto 1fr;
 		grid-template-areas:
-			"banner     banner"
-			"insights   righttop"
-			"health     changelog";
+			"banner  banner"
+			"insights sidebar";
 		gap: var(--space-sm);
 		flex: 1;
 		min-height: 0;
@@ -131,26 +114,18 @@
 		overflow: hidden;
 	}
 
-	.area-right-top {
-		grid-area: righttop;
+	.area-sidebar {
+		grid-area: sidebar;
 		display: flex;
+		flex-direction: column;
 		gap: var(--space-sm);
 		min-height: 0;
 		overflow: hidden;
 	}
 
-	.area-right-top > :global(*) {
+	.area-sidebar > :global(*) {
 		flex: 1;
 		min-width: 0;
-	}
-
-	.area-health {
-		grid-area: health;
-	}
-
-	.area-changelog {
-		grid-area: changelog;
 		min-height: 0;
-		overflow: hidden;
 	}
 </style>

--- a/packages/cli/dashboard/src/lib/components/tabs/MarketplaceTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/MarketplaceTab.svelte
@@ -664,57 +664,45 @@ $effect(() => {
 <svelte:window onkeydown={handleGlobalKey} />
 
 <div class="store-shell">
-	<section class="hero">
-		<div class="hero-main">
-			<h2>
-				{section === "skills"
-					? "Discover skill packs that level up your agent workflow"
-					: "Browse MCP servers and route production tools with confidence"}
-			</h2>
-			<p>
-				{section === "skills"
-					? "Install trusted skills, compare options, and rate what actually delivers results."
-					: "Connect tool servers, monitor routed tools, and leave Signet Reviews for your stack."}
-			</p>
-			<div class="hero-actions">
-				<Button
-					variant="outline"
-					size="sm"
-					class={`hero-switch ${section === "skills" ? "hero-switch-active" : ""}`}
-					onclick={() => handleSectionChange("skills")}
-					onkeydown={(e) => {
-						if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
-							e.stopPropagation();
-							handleGlobalKey(e);
-							e.preventDefault();
-						}
-					}}
-				>
-					Agent Skills
-				</Button>
-				<Button
-					variant="outline"
-					size="sm"
-					class={`hero-switch ${section === "mcp" ? "hero-switch-active" : ""}`}
-					onclick={() => handleSectionChange("mcp")}
-					onkeydown={(e) => {
-						if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
-							e.stopPropagation();
-							handleGlobalKey(e);
-							e.preventDefault();
-						}
-					}}
-				>
-					MCP Servers
-				</Button>
-			</div>
+	<!-- Header -->
+	<div class="tab-header">
+		<div class="tab-header-left">
+			<span class="tab-header-title">MARKETPLACE</span>
+			<span class="tab-header-count">{activeInstalledCount} INSTALLED</span>
+			<span class="tab-header-sep" aria-hidden="true"></span>
+			<span class="tab-header-count">{sectionCatalogCount.toLocaleString()} CATALOG</span>
 		</div>
-		<div class="hero-aside">
-			<div class="hero-metric"><span>Active section</span><strong>{activeSectionLabel} · {activeInstalledCount} installed</strong></div>
-			<div class="hero-metric"><span>Catalog size</span><strong>{sectionCatalogCount.toLocaleString()}</strong></div>
-			<div class="hero-metric"><span>Signet Reviews</span><strong>{reviewsMarket.summary.count} reviews</strong></div>
+		<div class="tab-header-right">
+			<button
+				class="section-switch"
+				class:section-switch--active={section === "skills"}
+				onclick={() => handleSectionChange("skills")}
+				onkeydown={(e) => {
+					if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
+						e.stopPropagation();
+						handleGlobalKey(e);
+						e.preventDefault();
+					}
+				}}
+			>
+				SKILLS
+			</button>
+			<button
+				class="section-switch"
+				class:section-switch--active={section === "mcp"}
+				onclick={() => handleSectionChange("mcp")}
+				onkeydown={(e) => {
+					if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
+						e.stopPropagation();
+						handleGlobalKey(e);
+						e.preventDefault();
+					}
+				}}
+			>
+				MCP SERVERS
+			</button>
 		</div>
-	</section>
+	</div>
 
 	<div class="store-grid">
 		<main class="store-main">
@@ -999,86 +987,103 @@ $effect(() => {
 		height: 100%;
 		display: flex;
 		flex-direction: column;
-		gap: 10px;
 		overflow: hidden;
-		padding: 10px;
 	}
 
-	.hero,
 	.store-main,
 	:global(.rail-panel) {
 		border: none;
 		background: var(--sig-surface);
 	}
 
-	.hero {
-		display: grid;
-		grid-template-columns: minmax(0, 1fr) 260px;
-		gap: 10px;
-		padding: 14px;
-		background:
-			radial-gradient(circle at 85% -20%, color-mix(in srgb, var(--sig-accent) 16%, transparent), transparent 45%),
-			linear-gradient(140deg, color-mix(in srgb, var(--sig-surface-raised) 88%, black) 0%, var(--sig-surface) 65%);
+	/* Header — matches Tasks/Secrets */
+	.tab-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--space-sm) var(--space-md);
+		border-bottom: 1px solid var(--sig-border);
+		flex-shrink: 0;
 	}
 
-	.hero-main h2 {
-		margin: 8px 0 4px;
-		font-size: clamp(19px, 2vw, 27px);
-		line-height: 1.15;
+	.tab-header-left {
+		display: flex;
+		align-items: center;
+		gap: var(--space-sm);
 	}
 
-	.hero-main p {
-		margin: 0;
-		font-family: var(--font-mono);
+	.tab-header-title {
+		font-family: var(--font-display);
 		font-size: 11px;
-		line-height: 1.55;
-		color: var(--sig-text);
-	}
-
-	.hero-aside {
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
-	}
-
-	.hero-metric {
-		display: flex;
-		flex-direction: column;
-		gap: 3px;
-		padding: 8px;
-		background: var(--sig-surface-raised);
-		border: 1px solid var(--sig-border);
-		border-radius: 0.45rem;
-	}
-
-	.hero-metric span {
-		font-family: var(--font-mono);
-		font-size: 9px;
+		font-weight: 700;
 		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--sig-text-bright);
+	}
+
+	.tab-header-count {
+		font-family: var(--font-mono);
+		font-size: 8px;
 		letter-spacing: 0.1em;
 		color: var(--sig-text-muted);
 	}
 
-	.hero-metric strong {
-		font-family: var(--font-display);
-		font-size: 11px;
-		letter-spacing: 0.04em;
-		text-transform: uppercase;
-		color: var(--sig-text-bright);
+	.tab-header-sep {
+		width: 1px;
+		height: 10px;
+		background: var(--sig-border);
+	}
+
+	.tab-header-right {
+		display: flex;
+		align-items: center;
+		gap: 2px;
+	}
+
+	.section-switch {
+		padding: 3px 10px;
+		background: transparent;
+		border: 1px solid var(--sig-border);
+		color: var(--sig-text-muted);
+		font-family: var(--font-mono);
+		font-size: 9px;
+		letter-spacing: 0.06em;
+		cursor: pointer;
+		transition: color var(--dur) var(--ease), border-color var(--dur) var(--ease), background var(--dur) var(--ease);
+	}
+
+	.section-switch:first-child {
+		border-radius: var(--radius) 0 0 var(--radius);
+		border-right: none;
+	}
+
+	.section-switch:last-child {
+		border-radius: 0 var(--radius) var(--radius) 0;
+	}
+
+	.section-switch:hover {
+		color: var(--sig-highlight);
+		border-color: var(--sig-highlight);
+	}
+
+	.section-switch--active {
+		color: var(--sig-highlight);
+		border-color: var(--sig-highlight);
+		background: color-mix(in srgb, var(--sig-highlight), var(--sig-bg) 92%);
 	}
 
 	.module-search,
 	.input,
 	:global(.section-select) {
-		height: 34px;
+		height: 28px;
 		padding: 0 10px;
 		font-family: var(--font-mono);
-		font-size: 11px;
+		font-size: 10px;
 		color: var(--sig-text-bright);
-		background: var(--sig-surface-raised);
-		border: 1px solid var(--sig-border-strong);
+		background: var(--sig-surface);
+		border: 1px solid var(--sig-border);
 		outline: none;
-		border-radius: 0.5rem;
+		border-radius: var(--radius);
 		transition: border-color 0.15s;
 	}
 
@@ -1110,7 +1115,8 @@ $effect(() => {
 		min-height: 0;
 		display: grid;
 		grid-template-columns: minmax(0, 1fr) 250px;
-		gap: 10px;
+		gap: var(--space-sm);
+		padding: var(--space-sm);
 	}
 
 	.store-main {
@@ -1125,15 +1131,16 @@ $effect(() => {
 		grid-template-columns: minmax(260px, 1fr) auto;
 		align-items: center;
 		gap: 8px;
-		padding: 0 8px;
-		margin-bottom: 8px;
+		padding: var(--space-sm) var(--space-sm) 0;
+		margin-bottom: var(--space-sm);
 	}
 
 	.module-search {
-		height: 30px;
+		height: 28px;
 		min-width: 0;
 		width: 100%;
 		padding-right: 72px;
+		font-size: 10px;
 	}
 
 	.module-search-wrap {
@@ -1165,9 +1172,9 @@ $effect(() => {
 	}
 
 	:global(.view-tab) {
-		height: 30px;
+		height: 28px;
 		font-family: var(--font-mono);
-		font-size: 10px;
+		font-size: 9px;
 		text-transform: uppercase;
 		letter-spacing: 0.06em;
 		transition: border-color 0.15s;
@@ -1189,35 +1196,6 @@ $effect(() => {
 		background: color-mix(in srgb, var(--sig-highlight), var(--sig-bg) 90%);
 	}
 
-	.hero-actions {
-		display: flex;
-		gap: 8px;
-		margin-top: 12px;
-	}
-
-	:global(.hero-switch) {
-		height: 30px;
-		font-size: 10px;
-		text-transform: uppercase;
-		letter-spacing: 0.08em;
-		transition: border-color 0.15s, background-color 0.15s;
-	}
-
-	:global(.hero-switch:hover) {
-		border-color: var(--sig-highlight);
-		color: var(--sig-highlight);
-	}
-
-	:global(.hero-switch:focus-visible) {
-		outline: 2px solid var(--sig-highlight);
-		outline-offset: 1px;
-	}
-
-	:global(.hero-switch.hero-switch-active) {
-		border-color: var(--sig-highlight);
-		color: var(--sig-highlight);
-		background: color-mix(in srgb, var(--sig-highlight), var(--sig-bg) 90%);
-	}
 
 	.module-body {
 		flex: 1;
@@ -1237,13 +1215,13 @@ $effect(() => {
 	}
 
 	:global(.rail-panel) {
-		padding: 8px;
+		padding: var(--space-sm);
 		display: flex;
 		flex-direction: column;
 		gap: 8px;
-		background: color-mix(in srgb, var(--sig-highlight), var(--sig-bg) 96%);
+		background: var(--sig-surface);
 		border: 1px solid var(--sig-border);
-		border-radius: 0.5rem;
+		border-radius: var(--radius);
 	}
 
 	:global(.rail-trigger) {
@@ -1255,16 +1233,17 @@ $effect(() => {
 		background: transparent;
 		border: none;
 		font-family: var(--font-display);
-		font-size: 11px;
+		font-size: 10px;
+		font-weight: 700;
 		text-transform: uppercase;
-		letter-spacing: 0.05em;
-		color: var(--sig-highlight);
+		letter-spacing: 0.1em;
+		color: var(--sig-text-muted);
 		cursor: pointer;
 		transition: color 0.15s;
 	}
 
 	:global(.rail-trigger:hover) {
-		color: var(--sig-highlight-text);
+		color: var(--sig-text-bright);
 	}
 
 	:global(.rail-trigger:focus-visible) {
@@ -1280,16 +1259,16 @@ $effect(() => {
 	}
 
 	:global(.rail-select) {
-		height: 32px;
+		height: 28px;
 		width: 100%;
-		padding: 0 10px;
+		padding: 0 8px;
 		font-family: var(--font-mono);
-		font-size: 10px;
+		font-size: 9px;
 		text-transform: uppercase;
 		letter-spacing: 0.06em;
-		background: var(--sig-surface-raised);
-		border: 1px solid var(--sig-border-strong);
-		border-radius: 0.5rem;
+		background: var(--sig-bg);
+		border: 1px solid var(--sig-border);
+		border-radius: var(--radius);
 		transition: border-color 0.15s, outline-color 0.15s;
 	}
 
@@ -1312,8 +1291,8 @@ $effect(() => {
 	:global(.rail-btn) {
 		justify-content: flex-start;
 		font-family: var(--font-mono);
-		font-size: 10px;
-		height: 30px;
+		font-size: 9px;
+		height: 28px;
 		transition: border-color 0.15s, outline-color 0.15s;
 	}
 
@@ -1402,8 +1381,9 @@ $effect(() => {
 	}
 
 	@media (max-width: 980px) {
-		.hero {
-			grid-template-columns: 1fr;
+		.tab-header {
+			flex-wrap: wrap;
+			gap: var(--space-sm);
 		}
 
 		.module-head {

--- a/packages/cli/dashboard/src/lib/components/tabs/SecretsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/SecretsTab.svelte
@@ -444,7 +444,7 @@ let onePasswordStatusColor = $derived(
 	onePasswordStatus.connected
 		? "var(--sig-success)"
 		: onePasswordStatus.configured
-			? "var(--sig-warning, #d4a017)"
+			? "var(--sig-warning)"
 			: "var(--sig-text-muted)",
 );
 
@@ -531,6 +531,7 @@ onMount(() => {
 								class="secret-delete"
 								onclick={() => removeSecret(name)}
 								disabled={secretDeleting === name}
+								aria-label={`Delete secret ${name}`}
 							>
 								{#if secretDeleting === name}
 									<span class="secret-delete-text">...</span>
@@ -546,34 +547,38 @@ onMount(() => {
 
 		<!-- 1Password integration panel -->
 		<div class="panel" role="group" aria-label="1Password integration">
-			<!-- svelte-ignore a11y_no_static_element_interactions -->
-			<div
-				class="panel-header panel-header--toggle"
-				onclick={() => { onePasswordExpanded = !onePasswordExpanded; }}
-				onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onePasswordExpanded = !onePasswordExpanded; } }}
-				tabindex="0"
-				role="button"
-			>
-				{#if onePasswordExpanded}
-					<ChevronDown class="panel-chevron" />
-				{:else}
-					<ChevronRight class="panel-chevron" />
-				{/if}
-				<span class="panel-label">1Password</span>
-				<span class="panel-status" style="color: {onePasswordStatusColor}">
-					{onePasswordStatusLabel}
-				</span>
+			<div class="panel-header-row">
+				<button
+					class="panel-header panel-header--toggle"
+					onclick={() => {
+						onePasswordExpanded = !onePasswordExpanded;
+						if (!onePasswordExpanded) focusedOnePasswordInput = -1;
+					}}
+					aria-expanded={onePasswordExpanded}
+					aria-controls="op-panel"
+				>
+					{#if onePasswordExpanded}
+						<ChevronDown class="panel-chevron" />
+					{:else}
+						<ChevronRight class="panel-chevron" />
+					{/if}
+					<span class="panel-label">1Password</span>
+					<span class="panel-status" style="color: {onePasswordStatusColor}">
+						{onePasswordStatusLabel}
+					</span>
+				</button>
 				<button
 					class="panel-action"
-					onclick={(e) => { e.stopPropagation(); refreshOnePasswordStatus(); }}
+					onclick={() => refreshOnePasswordStatus()}
 					disabled={onePasswordLoading}
+					aria-label="Refresh 1Password status"
 				>
-					<RefreshCw class="size-3" style={onePasswordLoading ? "animation: spin 1s linear infinite" : ""} />
+					<RefreshCw class={`size-3${onePasswordLoading ? " op-spin" : ""}`} />
 				</button>
 			</div>
 
 			{#if onePasswordExpanded}
-				<div class="onepassword-panel" onkeydown={handleOnePasswordPanelKeydown}>
+				<div id="op-panel" class="onepassword-panel" onkeydown={handleOnePasswordPanelKeydown}>
 					<!-- Status message -->
 					{#if onePasswordStatus.connected}
 						<div class="op-status op-status--ok">
@@ -853,13 +858,32 @@ onMount(() => {
 		flex-shrink: 0;
 	}
 
+	.panel-header-row {
+		display: flex;
+		align-items: center;
+	}
+
 	.panel-header--toggle {
+		flex: 1;
 		cursor: pointer;
+		background: none;
+		border: none;
+		text-align: left;
 		transition: background var(--dur) var(--ease);
 	}
 
 	.panel-header--toggle:hover {
 		background: var(--sig-surface-raised);
+	}
+
+	:global(.op-spin) {
+		animation: spin 1s linear infinite;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		:global(.op-spin) {
+			animation: none;
+		}
 	}
 
 	.panel-pip {

--- a/packages/cli/dashboard/src/lib/components/tabs/SecretsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/SecretsTab.svelte
@@ -792,7 +792,7 @@ onMount(() => {
 		height: 28px !important;
 	}
 
-	:global(.add-input:focus) {
+	:global(.secrets-add-input:focus) {
 		border-color: var(--sig-highlight) !important;
 	}
 
@@ -1096,7 +1096,8 @@ onMount(() => {
 		height: 28px !important;
 	}
 
-	:global(.op-input:focus) {
+	:global(.secrets-op-input:focus),
+	:global(.secrets-op-input-sm:focus) {
 		border-color: var(--sig-highlight) !important;
 	}
 

--- a/packages/cli/dashboard/src/lib/components/tabs/SecretsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/SecretsTab.svelte
@@ -11,15 +11,21 @@ import {
 	listOnePasswordVaults,
 	putSecret,
 } from "$lib/api";
-import { Button } from "$lib/components/ui/button/index.js";
 import { Input } from "$lib/components/ui/input/index.js";
+import { Checkbox } from "$lib/components/ui/checkbox/index.js";
 import { toast } from "$lib/stores/toast.svelte";
 import { returnToSidebar } from "$lib/stores/focus.svelte";
 import { nav } from "$lib/stores/navigation.svelte";
-import { Checkbox } from "$lib/components/ui/checkbox/index.js";
-import { ActionLabels } from "$lib/ui/action-labels";
 import { onMount } from "svelte";
-import PageBanner from "$lib/components/layout/PageBanner.svelte";
+import Plus from "@lucide/svelte/icons/plus";
+import Trash2 from "@lucide/svelte/icons/trash-2";
+import KeyRound from "@lucide/svelte/icons/key-round";
+import ChevronDown from "@lucide/svelte/icons/chevron-down";
+import ChevronRight from "@lucide/svelte/icons/chevron-right";
+import RefreshCw from "@lucide/svelte/icons/refresh-cw";
+import Link from "@lucide/svelte/icons/link";
+import Unlink from "@lucide/svelte/icons/unlink";
+import Import from "@lucide/svelte/icons/import";
 
 let secrets = $state<string[]>([]);
 let secretsLoading = $state(false);
@@ -27,6 +33,7 @@ let newSecretName = $state("");
 let newSecretValue = $state("");
 let secretAdding = $state(false);
 let secretDeleting = $state<string | null>(null);
+let addFormOpen = $state(false);
 
 let onePasswordLoading = $state(false);
 let onePasswordStatus = $state<OnePasswordStatus>({
@@ -44,9 +51,11 @@ let onePasswordConnecting = $state(false);
 let onePasswordDisconnecting = $state(false);
 let onePasswordImporting = $state(false);
 let selectedVaultIds = $state<string[]>([]);
-let focusedSecretIndex = $state(-1); // -1 means no secret focused
-let focusArea = $state<'list' | '1password'>('list'); // Track which area has focus
-let focusedOnePasswordInput = $state(-1); // -1 means panel itself, 0+ = input index
+let onePasswordExpanded = $state(false);
+
+let focusedSecretIndex = $state(-1);
+let focusArea = $state<"list" | "1password">("list");
+let focusedOnePasswordInput = $state(-1);
 
 async function fetchSecrets() {
 	secretsLoading = true;
@@ -68,7 +77,8 @@ async function refreshOnePasswordStatus(): Promise<void> {
 		onePasswordStatus = await getOnePasswordStatus();
 		if (onePasswordStatus.connected) {
 			const fetchedVaults = await listOnePasswordVaults();
-			onePasswordVaults = fetchedVaults.length > 0 ? fetchedVaults : onePasswordStatus.vaults;
+			onePasswordVaults =
+				fetchedVaults.length > 0 ? fetchedVaults : onePasswordStatus.vaults;
 		} else {
 			onePasswordVaults = [];
 			selectedVaultIds = [];
@@ -89,6 +99,7 @@ async function addSecret() {
 		toast(`Secret ${newSecretName.trim()} added`, "success");
 		newSecretName = "";
 		newSecretValue = "";
+		addFormOpen = false;
 		await fetchSecrets();
 	} else {
 		toast("Failed to add secret", "error");
@@ -165,15 +176,15 @@ async function importFromOnePassword(): Promise<void> {
 	const importedCount = result.importedCount ?? 0;
 	const skippedCount = result.skippedCount ?? 0;
 	const errorCount = result.errorCount ?? 0;
-	toast(`Imported ${importedCount} secrets (skipped ${skippedCount}, errors ${errorCount})`, "success");
+	toast(
+		`Imported ${importedCount} secrets (skipped ${skippedCount}, errors ${errorCount})`,
+		"success",
+	);
 }
 
 // Keyboard navigation
 function handleGlobalKey(e: KeyboardEvent) {
-	// Only handle events when Secrets tab is active
 	if (nav.activeTab !== "secrets") return;
-
-	// Skip events already handled by local handlers
 	if (e.defaultPrevented) return;
 
 	const target = e.target as HTMLElement;
@@ -182,30 +193,57 @@ function handleGlobalKey(e: KeyboardEvent) {
 		target.tagName === "TEXTAREA" ||
 		target.isContentEditable;
 
+	// Escape: close add form or 1password panel first
+	if (e.key === "Escape") {
+		if (addFormOpen) {
+			e.preventDefault();
+			addFormOpen = false;
+			return;
+		}
+		if (focusArea === "1password") {
+			e.preventDefault();
+			if (document.activeElement instanceof HTMLElement) {
+				document.activeElement.blur();
+			}
+			focusArea = "list";
+			focusedSecretIndex = -1;
+			focusedOnePasswordInput = -1;
+			return;
+		}
+		e.preventDefault();
+		returnToSidebar();
+		return;
+	}
+
 	if (isInputFocused) return;
 
-	// Right Arrow to focus first secret or 1Password panel (only when at page level)
+	// N: open add form
+	if ((e.key === "n" || e.key === "N") && !addFormOpen) {
+		e.preventDefault();
+		addFormOpen = true;
+		return;
+	}
+
+	// Right Arrow to focus first secret
 	if (e.key === "ArrowRight" && focusArea === "list" && focusedSecretIndex === -1) {
 		e.preventDefault();
 		if (secrets.length > 0) {
 			focusedSecretIndex = 0;
 			focusSecretItem(0);
 		} else {
-			// No secrets — jump to 1Password panel
 			focusArea = "1password";
 			focusedOnePasswordInput = 0;
 			focusOnePasswordInputField(0);
 		}
 	}
 
-	// Arrow Up/Down to navigate secrets when in list area
+	// Arrow Up/Down to navigate secrets
 	if (e.key === "ArrowUp" && focusArea === "list" && focusedSecretIndex >= 0) {
 		e.preventDefault();
 		if (focusedSecretIndex > 0) {
 			focusedSecretIndex--;
 			focusSecretItem(focusedSecretIndex);
 		} else {
-			// At first secret — return to sidebar
 			focusedSecretIndex = -1;
 			returnToSidebar();
 		}
@@ -217,8 +255,7 @@ function handleGlobalKey(e: KeyboardEvent) {
 			focusedSecretIndex++;
 			focusSecretItem(focusedSecretIndex);
 		} else if (focusedSecretIndex === secrets.length - 1) {
-			// At last secret, blur then move to 1Password panel
-			const items = document.querySelectorAll('.secret-item');
+			const items = document.querySelectorAll(".secret-item");
 			if (items[focusedSecretIndex] instanceof HTMLElement) {
 				(items[focusedSecretIndex] as HTMLElement).blur();
 			}
@@ -229,15 +266,12 @@ function handleGlobalKey(e: KeyboardEvent) {
 		}
 	}
 
-	// Arrow Up from 1Password panel - return to last secret or exit panel
 	if (e.key === "ArrowUp" && focusArea === "1password") {
 		e.preventDefault();
 		if (focusedOnePasswordInput > 0) {
-			// Navigate to previous input in 1Password panel
 			focusedOnePasswordInput--;
 			focusOnePasswordInputField(focusedOnePasswordInput);
 		} else if (focusedOnePasswordInput === 0 && secrets.length > 0) {
-			// At first input, blur then return to last secret
 			if (document.activeElement instanceof HTMLElement) {
 				document.activeElement.blur();
 			}
@@ -246,7 +280,6 @@ function handleGlobalKey(e: KeyboardEvent) {
 			focusedOnePasswordInput = -1;
 			focusSecretItem(focusedSecretIndex);
 		} else if (focusedOnePasswordInput === 0 && secrets.length === 0) {
-			// No secrets — exit panel and return to sidebar
 			if (document.activeElement instanceof HTMLElement) {
 				document.activeElement.blur();
 			}
@@ -256,7 +289,6 @@ function handleGlobalKey(e: KeyboardEvent) {
 		}
 	}
 
-	// Arrow Down in 1Password panel (when panel itself or inputs focused)
 	if (e.key === "ArrowDown" && focusArea === "1password") {
 		e.preventDefault();
 		const targets = getOnePasswordFocusTargets();
@@ -267,19 +299,6 @@ function handleGlobalKey(e: KeyboardEvent) {
 		}
 	}
 
-	// Escape from 1Password panel returns to secrets list (not sidebar)
-	if (e.key === "Escape" && focusArea === "1password") {
-		e.preventDefault();
-		// Blur current element first
-		if (document.activeElement instanceof HTMLElement) {
-			document.activeElement.blur();
-		}
-		focusArea = "list";
-		focusedSecretIndex = -1;
-		focusedOnePasswordInput = -1;
-	}
-
-	// Left Arrow returns to sidebar (only when at page level in list area)
 	if (e.key === "ArrowLeft" && focusArea === "list" && focusedSecretIndex === -1) {
 		e.preventDefault();
 		returnToSidebar();
@@ -287,22 +306,21 @@ function handleGlobalKey(e: KeyboardEvent) {
 }
 
 function focusSecretItem(index: number): void {
-	const items = document.querySelectorAll('.secret-item');
+	const items = document.querySelectorAll(".secret-item");
 	if (items[index] instanceof HTMLElement) {
 		(items[index] as HTMLElement).focus();
 	}
 }
 
 function getOnePasswordFocusTargets(): HTMLElement[] {
-	const panel = document.querySelector('.onepassword-panel');
+	const panel = document.querySelector(".onepassword-panel");
 	if (!panel) return [];
-	// Get all focusable elements sorted by data-focus-index, filtering out disabled ones
-	const all = panel.querySelectorAll('[data-focus-index]');
+	const all = panel.querySelectorAll("[data-focus-index]");
 	return (Array.from(all) as HTMLElement[])
 		.filter((el) => !(el as HTMLButtonElement).disabled)
 		.sort((a, b) => {
-			const ai = parseInt(a.getAttribute('data-focus-index') ?? '0', 10);
-			const bi = parseInt(b.getAttribute('data-focus-index') ?? '0', 10);
+			const ai = parseInt(a.getAttribute("data-focus-index") ?? "0", 10);
+			const bi = parseInt(b.getAttribute("data-focus-index") ?? "0", 10);
 			return ai - bi;
 		});
 }
@@ -315,14 +333,12 @@ function focusOnePasswordInputField(index: number): void {
 }
 
 function handleOnePasswordPanelKeydown(e: KeyboardEvent): void {
-	// Arrow Up navigates within 1Password or returns to secrets
 	if (e.key === "ArrowUp") {
 		e.preventDefault();
 		if (focusedOnePasswordInput > 0) {
 			focusedOnePasswordInput--;
 			focusOnePasswordInputField(focusedOnePasswordInput);
 		} else if (focusedOnePasswordInput === 0 && secrets.length > 0) {
-			// At any input/button, blur then return to last secret
 			if (document.activeElement instanceof HTMLElement) {
 				document.activeElement.blur();
 			}
@@ -331,7 +347,6 @@ function handleOnePasswordPanelKeydown(e: KeyboardEvent): void {
 			focusedOnePasswordInput = -1;
 			focusSecretItem(focusedSecretIndex);
 		} else if (focusedOnePasswordInput === 0 && secrets.length === 0) {
-			// No secrets — exit panel and return to sidebar
 			if (document.activeElement instanceof HTMLElement) {
 				document.activeElement.blur();
 			}
@@ -340,7 +355,6 @@ function handleOnePasswordPanelKeydown(e: KeyboardEvent): void {
 			returnToSidebar();
 		}
 	}
-	// Arrow Down navigates within 1Password inputs
 	if (e.key === "ArrowDown") {
 		e.preventDefault();
 		const targets = getOnePasswordFocusTargets();
@@ -350,10 +364,8 @@ function handleOnePasswordPanelKeydown(e: KeyboardEvent): void {
 			focusOnePasswordInputField(focusedOnePasswordInput);
 		}
 	}
-	// Escape returns to secrets list (not sidebar)
 	if (e.key === "Escape") {
 		e.preventDefault();
-		// Blur current element first
 		if (document.activeElement instanceof HTMLElement) {
 			document.activeElement.blur();
 		}
@@ -361,7 +373,6 @@ function handleOnePasswordPanelKeydown(e: KeyboardEvent): void {
 		focusedSecretIndex = -1;
 		focusedOnePasswordInput = -1;
 	}
-	// Tab navigation within 1Password (let browser handle naturally but track state)
 	if (e.key === "Tab") {
 		const targets = getOnePasswordFocusTargets();
 		const maxIdx = Math.max(0, targets.length - 1);
@@ -370,7 +381,6 @@ function handleOnePasswordPanelKeydown(e: KeyboardEvent): void {
 		} else if (!e.shiftKey && focusedOnePasswordInput < maxIdx) {
 			focusedOnePasswordInput++;
 		}
-		// Don't prevent default - let browser handle tab navigation
 	}
 }
 
@@ -392,7 +402,6 @@ function handleSecretItemKeydown(e: KeyboardEvent, index: number): void {
 			focusedSecretIndex = index + 1;
 			focusSecretItem(focusedSecretIndex);
 		} else {
-			// Move to 1Password panel - blur current then focus first input
 			(e.target as HTMLElement).blur();
 			focusArea = "1password";
 			focusedSecretIndex = -1;
@@ -406,7 +415,6 @@ function handleSecretItemKeydown(e: KeyboardEvent, index: number): void {
 			focusedSecretIndex = index - 1;
 			focusSecretItem(focusedSecretIndex);
 		} else if (index === 0) {
-			// At first secret — return to sidebar
 			focusedSecretIndex = -1;
 			if (e.target instanceof HTMLElement) {
 				e.target.blur();
@@ -424,6 +432,22 @@ function handleSecretItemKeydown(e: KeyboardEvent, index: number): void {
 	}
 }
 
+let onePasswordStatusLabel = $derived(
+	onePasswordStatus.connected
+		? "CONNECTED"
+		: onePasswordStatus.configured
+			? "UNREACHABLE"
+			: "NOT CONFIGURED",
+);
+
+let onePasswordStatusColor = $derived(
+	onePasswordStatus.connected
+		? "var(--sig-success)"
+		: onePasswordStatus.configured
+			? "var(--sig-warning, #d4a017)"
+			: "var(--sig-text-muted)",
+);
+
 onMount(() => {
 	fetchSecrets();
 	refreshOnePasswordStatus();
@@ -432,276 +456,805 @@ onMount(() => {
 
 <svelte:window onkeydown={handleGlobalKey} />
 
-<div class="flex flex-col flex-1 min-h-0 overflow-hidden">
-	<PageBanner title="Secrets" />
-	<div
-		class="grid flex-1 gap-[var(--space-md)] overflow-hidden p-[var(--space-md)]
-			xl:grid-cols-[1.2fr_0.8fr]"
-	>
-		<div class="flex min-h-0 flex-col gap-[var(--space-sm)] overflow-hidden">
-			<div class="flex shrink-0 gap-[var(--space-sm)]">
+<div class="secrets-page">
+	<!-- Header -->
+	<div class="tab-header">
+		<div class="tab-header-left">
+			<span class="tab-header-title">SECRETS</span>
+			<span class="tab-header-count">{secrets.length} STORED</span>
+		</div>
+		<button class="new-secret-btn" onclick={() => { addFormOpen = !addFormOpen; }}>
+			<Plus class="size-3" />
+			<span>ADD SECRET</span>
+		</button>
+	</div>
+
+	<!-- Add form (collapsible) -->
+	{#if addFormOpen}
+		<div class="add-form">
+			<div class="add-form-row">
 				<Input
 					type="text"
-					class="flex-1 rounded-lg border-[var(--sig-border-strong)]
-						bg-[var(--sig-surface-raised)] font-[family-name:var(--font-mono)]
-						text-[13px] text-[var(--sig-text-bright)]
-						focus:border-[var(--sig-accent)]"
+					class="add-input"
 					bind:value={newSecretName}
-					placeholder="Secret name (e.g. OPENAI_API_KEY)"
+					placeholder="SECRET_NAME"
 				/>
 				<Input
 					type="password"
-					class="flex-1 rounded-lg border-[var(--sig-border-strong)]
-						bg-[var(--sig-surface-raised)] font-[family-name:var(--font-mono)]
-						text-[13px] text-[var(--sig-text-bright)]
-						focus:border-[var(--sig-accent)]"
+					class="add-input"
 					bind:value={newSecretValue}
-					placeholder="Secret value"
+					placeholder="value"
 				/>
-				<Button
-					class="rounded-lg bg-[var(--sig-text-bright)] text-[var(--sig-bg)]
-						hover:bg-[var(--sig-text)] text-[11px] font-medium"
-					size="sm"
+				<button
+					class="add-submit"
 					onclick={addSecret}
 					disabled={secretAdding || !newSecretName.trim() || !newSecretValue.trim()}
 				>
-					{secretAdding ? "Adding..." : ActionLabels.Add}
-				</Button>
+					{secretAdding ? "ADDING..." : "ADD"}
+				</button>
 			</div>
+		</div>
+	{/if}
 
-			<div class="flex flex-1 flex-col gap-[var(--space-sm)] overflow-y-auto">
+	<!-- Main content -->
+	<div class="secrets-content">
+		<!-- Secrets list panel -->
+		<div class="panel">
+			<div class="panel-header">
+				<span class="panel-pip" style="background: var(--sig-highlight)"></span>
+				<span class="panel-label">Stored Secrets</span>
+				<span class="panel-count">{secrets.length}</span>
+			</div>
+			<div class="panel-body">
 				{#if secretsLoading}
-					<div class="p-8 text-center text-[var(--sig-text-muted)]">
-						Loading secrets...
-					</div>
+					<div class="panel-empty">LOADING</div>
 				{:else if secrets.length === 0}
-					<div class="p-8 text-center text-[var(--sig-text-muted)]">
-						No secrets stored. Add one above.
+					<div class="panel-empty">
+						<span>NO SECRETS STORED</span>
+						<span class="panel-empty-hint">PRESS N TO ADD ONE</span>
 					</div>
 				{:else}
 					{#each secrets as name, index}
+						<!-- svelte-ignore a11y_no_static_element_interactions -->
 						<div
+							class="secret-item"
+							class:secret-item--focused={focusArea === "list" && focusedSecretIndex === index}
+							tabindex="0"
 							role="listitem"
-							tabindex={0}
-							class="secret-item flex items-center gap-3 border border-[var(--sig-border-strong)]
-								bg-[var(--sig-surface-raised)] px-[var(--space-md)] py-3 rounded-lg
-								hover:bg-[var(--sig-surface)] hover:border-[var(--sig-accent)]
-								focus-visible:outline focus-visible:outline-2
-								focus-visible:outline-[var(--sig-accent)]
-								focus-visible:outline-offset-2
-								transition-colors cursor-pointer"
 							onkeydown={(e) => handleSecretItemKeydown(e, index)}
 							onfocus={() => handleSecretItemFocus(index)}
 						>
-							<span class="flex-1 font-[family-name:var(--font-mono)] text-[13px] text-[var(--sig-text-bright)]"
-								>{name}</span
-							>
-							<span class="font-[family-name:var(--font-mono)] text-[12px] text-[var(--sig-text-muted)]"
-								>••••••••</span
-							>
-							<Button
-								variant="outline"
-								size="sm"
-								class="rounded-lg border-[var(--sig-danger)] text-[var(--sig-danger)]
-									text-[11px] hover:bg-[var(--sig-danger)] hover:text-[var(--sig-text-bright)]"
+							<KeyRound class="secret-icon" />
+							<span class="secret-name">{name}</span>
+							<span class="secret-mask">········</span>
+							<button
+								class="secret-delete"
 								onclick={() => removeSecret(name)}
 								disabled={secretDeleting === name}
 							>
-								{secretDeleting === name ? "..." : ActionLabels.Delete}
-							</Button>
+								{#if secretDeleting === name}
+									<span class="secret-delete-text">...</span>
+								{:else}
+									<Trash2 class="size-3" />
+								{/if}
+							</button>
 						</div>
 					{/each}
 				{/if}
 			</div>
 		</div>
 
-		<div class="flex min-h-0 flex-col gap-[var(--space-sm)] overflow-hidden">
+		<!-- 1Password integration panel -->
+		<div class="panel" role="group" aria-label="1Password integration">
+			<!-- svelte-ignore a11y_no_static_element_interactions -->
 			<div
-				role="group"
-				aria-label="1Password settings"
-				class="onepassword-panel flex min-h-0 flex-1 flex-col gap-[var(--space-sm)] overflow-hidden
-					border border-[var(--sig-border-strong)] bg-[var(--sig-surface-raised)]
-					p-[var(--space-md)] rounded-lg
-					hover:bg-[var(--sig-surface)] hover:border-[var(--sig-accent)]
-					transition-colors"
-				onkeydown={handleOnePasswordPanelKeydown}
+				class="panel-header panel-header--toggle"
+				onclick={() => { onePasswordExpanded = !onePasswordExpanded; }}
+				onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onePasswordExpanded = !onePasswordExpanded; } }}
+				tabindex="0"
+				role="button"
 			>
-				<div class="flex items-center justify-between gap-3">
-					<div class="sig-label uppercase tracking-[0.08em]">
-						1Password
-					</div>
-					<Button
-						variant="outline"
-						size="sm"
-						class="rounded-lg text-[11px]
-							hover:bg-[var(--sig-surface)]
-							focus-visible:outline focus-visible:outline-2
-							focus-visible:outline-[var(--sig-accent)]
-							focus-visible:outline-offset-2"
-						onclick={refreshOnePasswordStatus}
-						disabled={onePasswordLoading}
-					>
-						{onePasswordLoading ? "Refreshing..." : "Refresh"}
-					</Button>
-				</div>
-
-				{#if onePasswordStatus.connected}
-					<div class="text-[12px] text-emerald-400">
-						Connected.
-						{#if typeof onePasswordStatus.vaultCount === "number"}
-							{onePasswordStatus.vaultCount} vaults available.
-						{/if}
-					</div>
-				{:else if onePasswordStatus.configured}
-					<div class="text-[12px] text-amber-400">
-						Token saved, but 1Password is not reachable.
-						{#if onePasswordStatus.error}
-							{onePasswordStatus.error}
-						{/if}
-					</div>
+				{#if onePasswordExpanded}
+					<ChevronDown class="panel-chevron" />
 				{:else}
-					<div class="text-[12px] text-[var(--sig-text-muted)]">
-						Connect a 1Password service account to import secrets.
-					</div>
+					<ChevronRight class="panel-chevron" />
 				{/if}
+				<span class="panel-label">1Password</span>
+				<span class="panel-status" style="color: {onePasswordStatusColor}">
+					{onePasswordStatusLabel}
+				</span>
+				<button
+					class="panel-action"
+					onclick={(e) => { e.stopPropagation(); refreshOnePasswordStatus(); }}
+					disabled={onePasswordLoading}
+				>
+					<RefreshCw class="size-3" style={onePasswordLoading ? "animation: spin 1s linear infinite" : ""} />
+				</button>
+			</div>
 
-				<div class="flex gap-[var(--space-sm)]">
-					<Input
-						type="password"
-						data-focus-index="0"
-						class="rounded-lg border-[var(--sig-border-strong)]
-							bg-[var(--sig-surface)] font-[family-name:var(--font-mono)]
-							text-[13px] text-[var(--sig-text-bright)]
-							hover:border-[var(--sig-accent)]
-							focus-visible:outline focus-visible:outline-2
-							focus-visible:outline-[var(--sig-accent)]
-							focus-visible:outline-offset-2"
-						bind:value={onePasswordToken}
-						placeholder={onePasswordStatus.connected
-							? "Replace service account token"
-							: "1Password service account token"}
-						onfocus={() => handleOnePasswordInputFocus(0)}
-					/>
-					<Button
-						size="sm"
-						data-focus-index="2"
-
-						class="rounded-lg bg-[var(--sig-text-bright)] text-[var(--sig-bg)] text-[11px]
-							hover:bg-[var(--sig-text)]
-							focus-visible:outline focus-visible:outline-2
-							focus-visible:outline-[var(--sig-accent)]
-							focus-visible:outline-offset-2"
-						onclick={connectOnePasswordAccount}
-						disabled={onePasswordConnecting || !onePasswordToken.trim()}
-						onfocus={() => handleOnePasswordInputFocus(2)}
-					>
-						{onePasswordConnecting
-							? "Connecting..."
-							: onePasswordStatus.connected
-								? "Update Token"
-								: "Connect"}
-					</Button>
-				</div>
-
-				<div class="grid grid-cols-[auto_1fr] items-center gap-x-3 gap-y-2">
-					<label for="op-prefix" class="text-[12px] text-[var(--sig-text-muted)]"
-						>Prefix</label
-					>
-					<Input
-						id="op-prefix"
-						type="text"
-						data-focus-index="1"
-
-						class="h-8 rounded-lg border-[var(--sig-border-strong)]
-							bg-[var(--sig-surface)] font-[family-name:var(--font-mono)]
-							text-[12px] text-[var(--sig-text-bright)]
-							hover:border-[var(--sig-accent)]
-							focus-visible:outline focus-visible:outline-2
-							focus-visible:outline-[var(--sig-accent)]
-							focus-visible:outline-offset-2"
-						bind:value={onePasswordImportOptions.prefix}
-						placeholder="OP"
-						onfocus={() => handleOnePasswordInputFocus(1)}
-					/>
-					<label class="text-[12px] text-[var(--sig-text-muted)]"
-						for="op-overwrite">Overwrite</label
-					>
-					<label id="op-overwrite" class="flex items-center gap-2 text-[12px] text-[var(--sig-text-muted)] cursor-pointer">
-						<Checkbox
-							bind:checked={onePasswordImportOptions.overwrite}
-							class="border-[var(--sig-border-strong)] data-[state=checked]:bg-[var(--sig-accent)] data-[state=checked]:border-[var(--sig-accent)]"
-						/>
-						Overwrite existing secret names
-					</label>
-				</div>
-
-				<div class="min-h-0 flex-1 overflow-y-auto border border-[var(--sig-border)] p-2 rounded-lg">
-					{#if !onePasswordStatus.connected}
-						<div class="px-2 py-3 text-[12px] text-[var(--sig-text-muted)]">
-							Connect first, then choose vaults to import. Leave all unchecked to import from every vault.
+			{#if onePasswordExpanded}
+				<div class="onepassword-panel" onkeydown={handleOnePasswordPanelKeydown}>
+					<!-- Status message -->
+					{#if onePasswordStatus.connected}
+						<div class="op-status op-status--ok">
+							Connected{#if typeof onePasswordStatus.vaultCount === "number"} · {onePasswordStatus.vaultCount} vaults{/if}
 						</div>
-					{:else if onePasswordVaults.length === 0}
-						<div class="px-2 py-3 text-[12px] text-[var(--sig-text-muted)]">
-							No accessible vaults found.
+					{:else if onePasswordStatus.configured}
+						<div class="op-status op-status--warn">
+							Token saved but unreachable{#if onePasswordStatus.error} · {onePasswordStatus.error}{/if}
 						</div>
 					{:else}
-						{#each onePasswordVaults as vault}
-							<label
-								class="flex cursor-pointer items-center gap-2 px-2 py-1 text-[12px]
-									text-[var(--sig-text)] hover:bg-[var(--sig-surface)]
-									focus-within:bg-[var(--sig-surface)] rounded transition-colors"
-							>
-								<Checkbox
-									checked={selectedVaultIds.includes(vault.id)}
-									onCheckedChange={() => toggleVaultSelection(vault.id)}
-									class="border-[var(--sig-border-strong)] data-[state=checked]:bg-[var(--sig-accent)] data-[state=checked]:border-[var(--sig-accent)]"
-								/>
-								<span class="font-[family-name:var(--font-mono)]">{vault.name}</span>
-								<span class="text-[var(--sig-text-dim)]">({vault.id})</span>
-							</label>
-						{/each}
+						<div class="op-status">
+							Connect a 1Password service account to import secrets
+						</div>
 					{/if}
+
+					<!-- Token input -->
+					<div class="op-row">
+						<Input
+							type="password"
+							data-focus-index="0"
+							class="op-input"
+							bind:value={onePasswordToken}
+							placeholder={onePasswordStatus.connected
+								? "Replace service account token"
+								: "Service account token"}
+							onfocus={() => handleOnePasswordInputFocus(0)}
+						/>
+						<button
+							class="op-btn"
+							data-focus-index="2"
+							onclick={connectOnePasswordAccount}
+							disabled={onePasswordConnecting || !onePasswordToken.trim()}
+							onfocus={() => handleOnePasswordInputFocus(2)}
+						>
+							<Link class="size-3" />
+							<span>{onePasswordConnecting ? "..." : onePasswordStatus.connected ? "UPDATE" : "CONNECT"}</span>
+						</button>
+					</div>
+
+					<!-- Options row -->
+					<div class="op-options">
+						<div class="op-option">
+							<span class="op-option-label">PREFIX</span>
+							<Input
+								type="text"
+								data-focus-index="1"
+								class="op-input-sm"
+								bind:value={onePasswordImportOptions.prefix}
+								placeholder="OP"
+								onfocus={() => handleOnePasswordInputFocus(1)}
+							/>
+						</div>
+						<label class="op-option op-option--check" for="op-overwrite">
+							<Checkbox
+								id="op-overwrite"
+								bind:checked={onePasswordImportOptions.overwrite}
+								class="op-checkbox"
+							/>
+							<span class="op-option-label">OVERWRITE</span>
+						</label>
+					</div>
+
+					<!-- Vault selector -->
+					{#if onePasswordStatus.connected && onePasswordVaults.length > 0}
+						<div class="op-vaults">
+							<span class="op-vaults-label">VAULTS</span>
+							<div class="op-vault-list">
+								{#each onePasswordVaults as vault}
+									<label class="op-vault">
+										<Checkbox
+											checked={selectedVaultIds.includes(vault.id)}
+											onCheckedChange={() => toggleVaultSelection(vault.id)}
+											class="op-checkbox"
+										/>
+										<span class="op-vault-name">{vault.name}</span>
+									</label>
+								{/each}
+							</div>
+						</div>
+					{:else if onePasswordStatus.connected}
+						<div class="op-vaults-empty">NO ACCESSIBLE VAULTS</div>
+					{/if}
+
+					<!-- Actions -->
+					<div class="op-actions">
+						<button
+							class="op-btn"
+							data-focus-index="3"
+							onclick={importFromOnePassword}
+							disabled={onePasswordImporting || !onePasswordStatus.connected}
+							onfocus={() => handleOnePasswordInputFocus(3)}
+						>
+							<Import class="size-3" />
+							<span>{onePasswordImporting ? "IMPORTING..." : "IMPORT"}</span>
+						</button>
+						<button
+							class="op-btn op-btn--danger"
+							data-focus-index="4"
+							onclick={disconnectOnePasswordAccount}
+							disabled={onePasswordDisconnecting || !onePasswordStatus.configured}
+							onfocus={() => handleOnePasswordInputFocus(4)}
+						>
+							<Unlink class="size-3" />
+							<span>{onePasswordDisconnecting ? "..." : "DISCONNECT"}</span>
+						</button>
+					</div>
+
+					<!-- Tip -->
+					<div class="op-tip">
+						TIP: MAP DIRECT REFS AS <code>op://vault/item/field</code>
+					</div>
 				</div>
-
-				<div class="flex flex-wrap gap-[var(--space-sm)]">
-					<Button
-						size="sm"
-						data-focus-index="3"
-
-						class="rounded-lg bg-[var(--sig-text-bright)] text-[var(--sig-bg)] text-[11px]
-							hover:bg-[var(--sig-text)]
-							focus-visible:outline focus-visible:outline-2
-							focus-visible:outline-[var(--sig-accent)]
-							focus-visible:outline-offset-2"
-						onclick={importFromOnePassword}
-						disabled={onePasswordImporting || !onePasswordStatus.connected}
-						onfocus={() => handleOnePasswordInputFocus(3)}
-					>
-						{onePasswordImporting ? "Importing..." : "Import Into Signet"}
-					</Button>
-					<Button
-						variant="outline"
-						size="sm"
-						data-focus-index="4"
-
-						class="rounded-lg border-[var(--sig-danger)] text-[var(--sig-danger)]
-							text-[11px] hover:bg-[var(--sig-danger)] hover:text-[var(--sig-text-bright)]
-							focus-visible:outline focus-visible:outline-2
-							focus-visible:outline-[var(--sig-accent)]
-							focus-visible:outline-offset-2"
-						onclick={disconnectOnePasswordAccount}
-						disabled={onePasswordDisconnecting || !onePasswordStatus.configured}
-						onfocus={() => handleOnePasswordInputFocus(4)}
-					>
-						{onePasswordDisconnecting ? "Disconnecting..." : "Disconnect"}
-					</Button>
-				</div>
-
-				<div class="text-[11px] text-[var(--sig-text-dim)]">
-					Tip: you can also map direct refs in command execution as
-					<span class="font-[family-name:var(--font-mono)]">op://vault/item/field</span>.
-				</div>
-			</div>
+			{/if}
 		</div>
 	</div>
+
+	<!-- Shortcut bar -->
+	<div class="shortcut-bar">
+		{#if !addFormOpen}
+			<span class="shortcut"><kbd>N</kbd> ADD</span>
+		{:else}
+			<span class="shortcut"><kbd>ESC</kbd> CANCEL</span>
+		{/if}
+	</div>
 </div>
+
+<style>
+	.secrets-page {
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	/* Header — matches Tasks */
+	.tab-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--space-sm) var(--space-md);
+		border-bottom: 1px solid var(--sig-border);
+		flex-shrink: 0;
+	}
+
+	.tab-header-left {
+		display: flex;
+		align-items: center;
+		gap: var(--space-sm);
+	}
+
+	.tab-header-title {
+		font-family: var(--font-display);
+		font-size: 11px;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--sig-text-bright);
+	}
+
+	.tab-header-count {
+		font-family: var(--font-mono);
+		font-size: 8px;
+		letter-spacing: 0.1em;
+		color: var(--sig-text-muted);
+	}
+
+	.new-secret-btn {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		padding: 3px 10px;
+		background: transparent;
+		border: 1px solid var(--sig-border-strong);
+		border-radius: var(--radius);
+		color: var(--sig-text-muted);
+		font-family: var(--font-mono);
+		font-size: 9px;
+		letter-spacing: 0.06em;
+		cursor: pointer;
+		transition: color var(--dur) var(--ease), border-color var(--dur) var(--ease);
+	}
+
+	.new-secret-btn:hover {
+		color: var(--sig-highlight);
+		border-color: var(--sig-highlight);
+	}
+
+	/* Add form */
+	.add-form {
+		padding: var(--space-sm) var(--space-md);
+		border-bottom: 1px solid var(--sig-border);
+		flex-shrink: 0;
+	}
+
+	.add-form-row {
+		display: flex;
+		gap: var(--space-sm);
+		align-items: center;
+	}
+
+	:global(.add-input) {
+		flex: 1;
+		font-family: var(--font-mono) !important;
+		font-size: 11px !important;
+		background: var(--sig-surface) !important;
+		border-color: var(--sig-border) !important;
+		color: var(--sig-text-bright) !important;
+		height: 28px !important;
+	}
+
+	:global(.add-input:focus) {
+		border-color: var(--sig-highlight) !important;
+	}
+
+	.add-submit {
+		padding: 4px 12px;
+		height: 28px;
+		background: transparent;
+		border: 1px solid var(--sig-border-strong);
+		border-radius: var(--radius);
+		color: var(--sig-text-muted);
+		font-family: var(--font-mono);
+		font-size: 9px;
+		letter-spacing: 0.06em;
+		cursor: pointer;
+		transition: color var(--dur) var(--ease), border-color var(--dur) var(--ease);
+		white-space: nowrap;
+	}
+
+	.add-submit:hover:not(:disabled) {
+		color: var(--sig-highlight);
+		border-color: var(--sig-highlight);
+	}
+
+	.add-submit:disabled {
+		opacity: 0.3;
+		cursor: not-allowed;
+	}
+
+	/* Content area */
+	.secrets-content {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-sm);
+		padding: var(--space-sm);
+		flex: 1;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	/* Panel — matches TaskBoard columns */
+	.panel {
+		display: flex;
+		flex-direction: column;
+		min-height: 0;
+		border: 1px solid var(--sig-border);
+		border-radius: var(--radius);
+		overflow: hidden;
+		background: var(--sig-surface);
+	}
+
+	.panel:first-child {
+		flex: 1;
+	}
+
+	.panel:last-child {
+		flex-shrink: 0;
+	}
+
+	.panel-header {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		padding: var(--space-sm) var(--space-md);
+		border-bottom: 1px solid var(--sig-border);
+		flex-shrink: 0;
+	}
+
+	.panel-header--toggle {
+		cursor: pointer;
+		transition: background var(--dur) var(--ease);
+	}
+
+	.panel-header--toggle:hover {
+		background: var(--sig-surface-raised);
+	}
+
+	.panel-pip {
+		display: inline-block;
+		width: 4px;
+		height: 4px;
+		flex-shrink: 0;
+		border-radius: 50%;
+	}
+
+	:global(.panel-chevron) {
+		width: 12px;
+		height: 12px;
+		flex-shrink: 0;
+		color: var(--sig-text-muted);
+	}
+
+	.panel-label {
+		font-family: var(--font-display);
+		font-size: 10px;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--sig-text-muted);
+	}
+
+	.panel-count {
+		font-family: var(--font-mono);
+		font-size: 9px;
+		color: var(--sig-text-muted);
+		margin-left: auto;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.panel-status {
+		font-family: var(--font-mono);
+		font-size: 8px;
+		letter-spacing: 0.08em;
+		margin-left: auto;
+	}
+
+	.panel-action {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 22px;
+		height: 22px;
+		background: none;
+		border: none;
+		color: var(--sig-text-muted);
+		cursor: pointer;
+		border-radius: 2px;
+		transition: color var(--dur) var(--ease);
+		flex-shrink: 0;
+	}
+
+	.panel-action:hover {
+		color: var(--sig-highlight);
+	}
+
+	.panel-body {
+		display: flex;
+		flex-direction: column;
+		overflow-y: auto;
+		min-height: 0;
+		flex: 1;
+	}
+
+	.panel-empty {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 4px;
+		padding: var(--space-lg) var(--space-md);
+		font-family: var(--font-mono);
+		font-size: 9px;
+		letter-spacing: 0.08em;
+		color: var(--sig-text-muted);
+		opacity: 0.4;
+	}
+
+	.panel-empty-hint {
+		font-size: 8px;
+		opacity: 0.7;
+	}
+
+	/* Secret items — flat list like TaskCard */
+	.secret-item {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: var(--space-sm) var(--space-md);
+		background: transparent;
+		border-bottom: 1px solid var(--sig-border);
+		cursor: pointer;
+		outline: none;
+		transition: background var(--dur) var(--ease);
+	}
+
+	.secret-item:last-child {
+		border-bottom: none;
+	}
+
+	.secret-item:hover {
+		background: var(--sig-surface-raised);
+	}
+
+	.secret-item:focus-visible,
+	.secret-item--focused {
+		background: var(--sig-surface-raised);
+		border-left: 2px solid var(--sig-highlight);
+	}
+
+	:global(.secret-icon) {
+		width: 12px;
+		height: 12px;
+		color: var(--sig-highlight);
+		opacity: 0.4;
+		flex-shrink: 0;
+	}
+
+	.secret-name {
+		font-family: var(--font-mono);
+		font-size: 11px;
+		font-weight: 600;
+		color: var(--sig-text-bright);
+		flex: 1;
+		min-width: 0;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.secret-mask {
+		font-family: var(--font-mono);
+		font-size: 9px;
+		color: var(--sig-text-muted);
+		letter-spacing: 0.1em;
+		flex-shrink: 0;
+	}
+
+	.secret-delete {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 22px;
+		height: 22px;
+		background: none;
+		border: none;
+		color: var(--sig-text-muted);
+		cursor: pointer;
+		border-radius: 2px;
+		transition: color var(--dur) var(--ease), background var(--dur) var(--ease);
+		flex-shrink: 0;
+	}
+
+	.secret-delete:hover:not(:disabled) {
+		color: var(--sig-danger);
+		background: var(--sig-surface-raised);
+	}
+
+	.secret-delete:disabled {
+		opacity: 0.3;
+	}
+
+	.secret-delete-text {
+		font-family: var(--font-mono);
+		font-size: 9px;
+	}
+
+	/* 1Password panel content */
+	.onepassword-panel {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-sm);
+		padding: var(--space-sm) var(--space-md) var(--space-md);
+	}
+
+	.op-status {
+		font-family: var(--font-mono);
+		font-size: 9px;
+		letter-spacing: 0.04em;
+		color: var(--sig-text-muted);
+	}
+
+	.op-status--ok {
+		color: var(--sig-success);
+	}
+
+	.op-status--warn {
+		color: var(--sig-warning, #d4a017);
+	}
+
+	.op-row {
+		display: flex;
+		gap: var(--space-sm);
+		align-items: center;
+	}
+
+	:global(.op-input) {
+		flex: 1;
+		font-family: var(--font-mono) !important;
+		font-size: 11px !important;
+		background: var(--sig-bg) !important;
+		border-color: var(--sig-border) !important;
+		color: var(--sig-text-bright) !important;
+		height: 28px !important;
+	}
+
+	:global(.op-input:focus) {
+		border-color: var(--sig-highlight) !important;
+	}
+
+	.op-btn {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		padding: 4px 10px;
+		height: 28px;
+		background: transparent;
+		border: 1px solid var(--sig-border-strong);
+		border-radius: var(--radius);
+		color: var(--sig-text-muted);
+		font-family: var(--font-mono);
+		font-size: 8px;
+		letter-spacing: 0.06em;
+		cursor: pointer;
+		transition: color var(--dur) var(--ease), border-color var(--dur) var(--ease);
+		white-space: nowrap;
+		flex-shrink: 0;
+	}
+
+	.op-btn:hover:not(:disabled) {
+		color: var(--sig-highlight);
+		border-color: var(--sig-highlight);
+	}
+
+	.op-btn:disabled {
+		opacity: 0.3;
+		cursor: not-allowed;
+	}
+
+	.op-btn--danger:hover:not(:disabled) {
+		color: var(--sig-danger);
+		border-color: var(--sig-danger);
+	}
+
+	/* Options row */
+	.op-options {
+		display: flex;
+		align-items: center;
+		gap: var(--space-md);
+	}
+
+	.op-option {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.op-option--check {
+		cursor: pointer;
+	}
+
+	.op-option-label {
+		font-family: var(--font-mono);
+		font-size: 8px;
+		letter-spacing: 0.08em;
+		color: var(--sig-text-muted);
+	}
+
+	:global(.op-input-sm) {
+		width: 60px !important;
+		font-family: var(--font-mono) !important;
+		font-size: 10px !important;
+		background: var(--sig-bg) !important;
+		border-color: var(--sig-border) !important;
+		color: var(--sig-text-bright) !important;
+		height: 24px !important;
+	}
+
+	:global(.op-checkbox) {
+		width: 14px !important;
+		height: 14px !important;
+		border-color: var(--sig-border-strong) !important;
+	}
+
+	/* Vault selector */
+	.op-vaults {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	.op-vaults-label {
+		font-family: var(--font-mono);
+		font-size: 8px;
+		letter-spacing: 0.08em;
+		color: var(--sig-text-muted);
+	}
+
+	.op-vault-list {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		padding: 4px;
+		border: 1px solid var(--sig-border);
+		border-radius: var(--radius);
+		max-height: 120px;
+		overflow-y: auto;
+	}
+
+	.op-vault {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		padding: 2px 4px;
+		border-radius: 2px;
+		cursor: pointer;
+		transition: background var(--dur) var(--ease);
+	}
+
+	.op-vault:hover {
+		background: var(--sig-surface-raised);
+	}
+
+	.op-vault-name {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		color: var(--sig-text);
+	}
+
+	.op-vaults-empty {
+		font-family: var(--font-mono);
+		font-size: 8px;
+		letter-spacing: 0.08em;
+		color: var(--sig-text-muted);
+		opacity: 0.4;
+		padding: 4px 0;
+	}
+
+	/* Actions row */
+	.op-actions {
+		display: flex;
+		gap: var(--space-sm);
+	}
+
+	/* Tip */
+	.op-tip {
+		font-family: var(--font-mono);
+		font-size: 8px;
+		letter-spacing: 0.06em;
+		color: var(--sig-text-muted);
+		opacity: 0.5;
+	}
+
+	.op-tip code {
+		color: var(--sig-text);
+		opacity: 1;
+	}
+
+	/* Shortcut bar — matches Tasks */
+	.shortcut-bar {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		height: 22px;
+		padding: 0 12px;
+		border-top: 1px solid var(--sig-border);
+		flex-shrink: 0;
+		font-family: var(--font-mono);
+		font-size: 8px;
+		letter-spacing: 0.06em;
+		color: var(--sig-text-muted);
+	}
+
+	.shortcut {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+	}
+
+	.shortcut kbd {
+		font-family: var(--font-mono);
+		font-size: 8px;
+		padding: 0 3px;
+		background: var(--sig-surface-raised);
+		border: 1px solid var(--sig-border);
+		border-radius: 2px;
+		color: var(--sig-text-muted);
+	}
+
+	@keyframes spin {
+		from { transform: rotate(0deg); }
+		to { transform: rotate(360deg); }
+	}
+</style>

--- a/packages/cli/dashboard/src/lib/components/tabs/SecretsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/SecretsTab.svelte
@@ -475,13 +475,13 @@ onMount(() => {
 			<div class="add-form-row">
 				<Input
 					type="text"
-					class="add-input"
+					class="secrets-add-input"
 					bind:value={newSecretName}
 					placeholder="SECRET_NAME"
 				/>
 				<Input
 					type="password"
-					class="add-input"
+					class="secrets-add-input"
 					bind:value={newSecretValue}
 					placeholder="value"
 				/>
@@ -524,7 +524,7 @@ onMount(() => {
 							onkeydown={(e) => handleSecretItemKeydown(e, index)}
 							onfocus={() => handleSecretItemFocus(index)}
 						>
-							<KeyRound class="secret-icon" />
+							<KeyRound class="secrets-secret-icon" />
 							<span class="secret-name">{name}</span>
 							<span class="secret-mask">········</span>
 							<button
@@ -552,15 +552,17 @@ onMount(() => {
 					class="panel-header panel-header--toggle"
 					onclick={() => {
 						onePasswordExpanded = !onePasswordExpanded;
-						if (!onePasswordExpanded) focusedOnePasswordInput = -1;
+						if (!onePasswordExpanded) {
+							focusedOnePasswordInput = -1;
+							focusArea = "list";
+						}
 					}}
 					aria-expanded={onePasswordExpanded}
-					aria-controls="op-panel"
 				>
 					{#if onePasswordExpanded}
-						<ChevronDown class="panel-chevron" />
+						<ChevronDown class="secrets-panel-chevron" />
 					{:else}
-						<ChevronRight class="panel-chevron" />
+						<ChevronRight class="secrets-panel-chevron" />
 					{/if}
 					<span class="panel-label">1Password</span>
 					<span class="panel-status" style="color: {onePasswordStatusColor}">
@@ -578,7 +580,7 @@ onMount(() => {
 			</div>
 
 			{#if onePasswordExpanded}
-				<div id="op-panel" class="onepassword-panel" onkeydown={handleOnePasswordPanelKeydown}>
+				<div class="onepassword-panel" onkeydown={handleOnePasswordPanelKeydown}>
 					<!-- Status message -->
 					{#if onePasswordStatus.connected}
 						<div class="op-status op-status--ok">
@@ -599,7 +601,7 @@ onMount(() => {
 						<Input
 							type="password"
 							data-focus-index="0"
-							class="op-input"
+							class="secrets-op-input"
 							bind:value={onePasswordToken}
 							placeholder={onePasswordStatus.connected
 								? "Replace service account token"
@@ -625,7 +627,7 @@ onMount(() => {
 							<Input
 								type="text"
 								data-focus-index="1"
-								class="op-input-sm"
+								class="secrets-op-input-sm"
 								bind:value={onePasswordImportOptions.prefix}
 								placeholder="OP"
 								onfocus={() => handleOnePasswordInputFocus(1)}
@@ -635,7 +637,7 @@ onMount(() => {
 							<Checkbox
 								id="op-overwrite"
 								bind:checked={onePasswordImportOptions.overwrite}
-								class="op-checkbox"
+								class="secrets-op-checkbox"
 							/>
 							<span class="op-option-label">OVERWRITE</span>
 						</label>
@@ -651,7 +653,7 @@ onMount(() => {
 										<Checkbox
 											checked={selectedVaultIds.includes(vault.id)}
 											onCheckedChange={() => toggleVaultSelection(vault.id)}
-											class="op-checkbox"
+											class="secrets-op-checkbox"
 										/>
 										<span class="op-vault-name">{vault.name}</span>
 									</label>
@@ -780,7 +782,7 @@ onMount(() => {
 		align-items: center;
 	}
 
-	:global(.add-input) {
+	:global(.secrets-add-input) {
 		flex: 1;
 		font-family: var(--font-mono) !important;
 		font-size: 11px !important;
@@ -894,7 +896,7 @@ onMount(() => {
 		border-radius: 50%;
 	}
 
-	:global(.panel-chevron) {
+	:global(.secrets-panel-chevron) {
 		width: 12px;
 		height: 12px;
 		flex-shrink: 0;
@@ -998,7 +1000,7 @@ onMount(() => {
 		border-left: 2px solid var(--sig-highlight);
 	}
 
-	:global(.secret-icon) {
+	:global(.secrets-secret-icon) {
 		width: 12px;
 		height: 12px;
 		color: var(--sig-highlight);
@@ -1084,7 +1086,7 @@ onMount(() => {
 		align-items: center;
 	}
 
-	:global(.op-input) {
+	:global(.secrets-op-input) {
 		flex: 1;
 		font-family: var(--font-mono) !important;
 		font-size: 11px !important;
@@ -1156,7 +1158,7 @@ onMount(() => {
 		color: var(--sig-text-muted);
 	}
 
-	:global(.op-input-sm) {
+	:global(.secrets-op-input-sm) {
 		width: 60px !important;
 		font-family: var(--font-mono) !important;
 		font-size: 10px !important;
@@ -1166,7 +1168,7 @@ onMount(() => {
 		height: 24px !important;
 	}
 
-	:global(.op-checkbox) {
+	:global(.secrets-op-checkbox) {
 		width: 14px !important;
 		height: 14px !important;
 		border-color: var(--sig-border-strong) !important;

--- a/packages/cli/dashboard/src/lib/components/tabs/TasksTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/TasksTab.svelte
@@ -16,8 +16,6 @@ import { nav } from "$lib/stores/navigation.svelte";
 import TaskBoard from "$lib/components/tasks/TaskBoard.svelte";
 import TaskForm from "$lib/components/tasks/TaskForm.svelte";
 import TaskDetail from "$lib/components/tasks/TaskDetail.svelte";
-import PageBanner from "$lib/components/layout/PageBanner.svelte";
-import { Button } from "$lib/components/ui/button/index.js";
 import Plus from "@lucide/svelte/icons/plus";
 
 // Track position as [columnIndex, taskIndex]
@@ -103,10 +101,8 @@ function handleGlobalKey(e: KeyboardEvent) {
 		if (e.key === "ArrowLeft" && isBoardFocused) {
 			e.preventDefault();
 			if (selectedColumn === 0) {
-				// At first column, return to sidebar
 				returnToSidebar();
 			} else if (selectedColumn > 0) {
-				// Move to previous column (skip empty columns)
 				let newCol = selectedColumn - 1;
 				while (newCol > 0 && getColumnTasks(columnKeys[newCol]).length === 0) {
 					newCol--;
@@ -117,7 +113,6 @@ function handleGlobalKey(e: KeyboardEvent) {
 					selectedTaskInColumn = Math.min(selectedTaskInColumn, prevColTasks.length - 1);
 					focusTaskCard(selectedColumn, selectedTaskInColumn);
 				} else {
-					// No non-empty column found to the left, return to sidebar
 					returnToSidebar();
 				}
 			}
@@ -126,12 +121,10 @@ function handleGlobalKey(e: KeyboardEvent) {
 
 		if (e.key === "ArrowRight") {
 			e.preventDefault();
-			// If coming from sidebar (no task focused yet), select first task
 			const currentFocus = document.activeElement;
 			const isTaskFocused = currentFocus?.classList.contains('task-card');
 
 			if (!isTaskFocused && ts.tasks.length > 0) {
-				// First arrow right from sidebar - focus first task
 				selectedColumn = findFirstColumnWithTasks();
 				const colTasks = getColumnTasks(columnKeys[selectedColumn]);
 				if (colTasks.length > 0) {
@@ -139,7 +132,6 @@ function handleGlobalKey(e: KeyboardEvent) {
 					focusTaskCard(selectedColumn, selectedTaskInColumn);
 				}
 			} else if (selectedColumn < columnKeys.length - 1) {
-				// Move to next column (skip empty columns)
 				let newCol = selectedColumn + 1;
 				while (newCol < columnKeys.length - 1 && getColumnTasks(columnKeys[newCol]).length === 0) {
 					newCol++;
@@ -194,14 +186,12 @@ function handleGlobalKey(e: KeyboardEvent) {
 
 	// R/D require a selected task (detail panel must be open)
 	if (ts.detailOpen && ts.selectedId) {
-		// R: Trigger/Run task
 		if (e.key === "r" || e.key === "R") {
 			e.preventDefault();
 			doTrigger(ts.selectedId);
 			return;
 		}
 
-		// D: Delete task
 		if (e.key === "d" || e.key === "D") {
 			e.preventDefault();
 			doDelete(ts.selectedId);
@@ -211,7 +201,6 @@ function handleGlobalKey(e: KeyboardEvent) {
 }
 
 function focusTaskCard(columnIndex: number, taskIndex: number): void {
-	// Find the column container and get only the cards within that column
 	const columns = document.querySelectorAll('[data-column-idx]');
 	const column = columns[columnIndex];
 	if (!column) return;
@@ -233,24 +222,25 @@ onMount(() => {
 		if (refreshTimer) clearInterval(refreshTimer);
 	};
 });
+
+const taskCount = $derived(ts.tasks.length);
 </script>
 
 <svelte:window onkeydown={handleGlobalKey} />
 
 <div class="flex flex-col flex-1 min-h-0 overflow-hidden">
-	<PageBanner title="Tasks">
-		{#snippet right()}
-			<Button
-				variant="outline"
-				size="sm"
-				class="h-7 gap-1.5 text-[11px] bg-[var(--sig-bg)] border-[var(--sig-border)]"
-				onclick={() => openForm()}
-			>
-				<Plus class="size-3.5" />
-				New Task
-			</Button>
-		{/snippet}
-	</PageBanner>
+	<!-- Inline header -->
+	<div class="tab-header">
+		<div class="tab-header-left">
+			<span class="tab-header-title">SCHEDULER</span>
+			<span class="tab-header-count">{taskCount} TASKS</span>
+		</div>
+		<button class="new-task-btn" onclick={() => openForm()}>
+			<Plus class="size-3" />
+			<span>NEW TASK</span>
+		</button>
+	</div>
+
 	<!-- Board -->
 	<div class="flex flex-col flex-1 min-h-0 overflow-auto">
 		<TaskBoard
@@ -268,21 +258,17 @@ onMount(() => {
 		/>
 	</div>
 
-	<!-- Keyboard shortcuts -->
-	<div
-		class="shrink-0 px-4 py-2 border-t border-[var(--sig-border)]
-			flex items-center gap-4 text-[10px] text-[var(--sig-text-muted)]
-			font-[family-name:var(--font-mono)]"
-	>
+	<!-- Keyboard hints -->
+	<div class="shortcut-bar">
 		{#if !ts.formOpen}
-			<span><kbd class="px-1 py-px bg-[var(--sig-surface-raised)] border border-[var(--sig-border)]">N</kbd> New</span>
+			<span class="shortcut"><kbd>N</kbd> NEW</span>
 		{/if}
 		{#if ts.detailOpen}
-			<span><kbd class="px-1 py-px bg-[var(--sig-surface-raised)] border border-[var(--sig-border)]">R</kbd> Run</span>
-			<span><kbd class="px-1 py-px bg-[var(--sig-surface-raised)] border border-[var(--sig-border)]">D</kbd> Delete</span>
-			<span><kbd class="px-1 py-px bg-[var(--sig-surface-raised)] border border-[var(--sig-border)]">Esc</kbd> Close</span>
+			<span class="shortcut"><kbd>R</kbd> RUN</span>
+			<span class="shortcut"><kbd>D</kbd> DELETE</span>
+			<span class="shortcut"><kbd>ESC</kbd> CLOSE</span>
 		{:else if ts.formOpen}
-			<span><kbd class="px-1 py-px bg-[var(--sig-surface-raised)] border border-[var(--sig-border)]">Esc</kbd> Cancel</span>
+			<span class="shortcut"><kbd>ESC</kbd> CANCEL</span>
 		{/if}
 	</div>
 </div>
@@ -310,3 +296,87 @@ onMount(() => {
 		openForm(id);
 	}}
 />
+
+<style>
+	.tab-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--space-sm) var(--space-md);
+		border-bottom: 1px solid var(--sig-border);
+		flex-shrink: 0;
+	}
+
+	.tab-header-left {
+		display: flex;
+		align-items: center;
+		gap: var(--space-sm);
+	}
+
+	.tab-header-title {
+		font-family: var(--font-display);
+		font-size: 11px;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--sig-text-bright);
+	}
+
+	.tab-header-count {
+		font-family: var(--font-mono);
+		font-size: 8px;
+		letter-spacing: 0.1em;
+		color: var(--sig-text-muted);
+	}
+
+	.new-task-btn {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		padding: 3px 10px;
+		background: transparent;
+		border: 1px solid var(--sig-border-strong);
+		border-radius: var(--radius);
+		color: var(--sig-text-muted);
+		font-family: var(--font-mono);
+		font-size: 9px;
+		letter-spacing: 0.06em;
+		cursor: pointer;
+		transition: color var(--dur) var(--ease), border-color var(--dur) var(--ease);
+	}
+
+	.new-task-btn:hover {
+		color: var(--sig-highlight);
+		border-color: var(--sig-highlight);
+	}
+
+	.shortcut-bar {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		height: 22px;
+		padding: 0 12px;
+		border-top: 1px solid var(--sig-border);
+		flex-shrink: 0;
+		font-family: var(--font-mono);
+		font-size: 8px;
+		letter-spacing: 0.06em;
+		color: var(--sig-text-muted);
+	}
+
+	.shortcut {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+	}
+
+	.shortcut kbd {
+		font-family: var(--font-mono);
+		font-size: 8px;
+		padding: 0 3px;
+		background: var(--sig-surface-raised);
+		border: 1px solid var(--sig-border);
+		border-radius: 2px;
+		color: var(--sig-text-muted);
+	}
+</style>

--- a/packages/cli/dashboard/src/lib/components/tasks/TaskBoard.svelte
+++ b/packages/cli/dashboard/src/lib/components/tasks/TaskBoard.svelte
@@ -24,7 +24,6 @@ let running = $derived(
 	),
 );
 
-// For completed/failed, show recent tasks that had runs with that status
 let completed = $derived(
 	tasks.filter(
 		(t) =>
@@ -42,10 +41,10 @@ let failed = $derived(
 let disabled = $derived(tasks.filter((t) => !t.enabled));
 
 const columns = [
-	{ key: "scheduled", label: "Scheduled", color: "var(--sig-accent)" },
-	{ key: "running", label: "Running", color: "var(--sig-warning, #f59e0b)" },
+	{ key: "scheduled", label: "Scheduled", color: "var(--sig-highlight)" },
+	{ key: "running", label: "Running", color: "var(--sig-warning)" },
 	{ key: "completed", label: "Completed", color: "var(--sig-success)" },
-	{ key: "failed", label: "Failed", color: "var(--sig-error, #ef4444)" },
+	{ key: "failed", label: "Failed", color: "var(--sig-danger)" },
 ] as const;
 
 function getColumnTasks(key: string): ScheduledTask[] {
@@ -65,36 +64,26 @@ function getColumnTasks(key: string): ScheduledTask[] {
 </script>
 
 {#if loading && tasks.length === 0}
-	<div
-		class="flex items-center justify-center h-full
-			text-[var(--sig-text-muted)] text-[12px]"
-	>
-		Loading tasks...
-	</div>
+	<div class="empty-state">LOADING</div>
 {:else if tasks.length === 0}
-	<div
-		class="flex flex-col items-center justify-center h-full gap-2
-			text-[var(--sig-text-muted)]"
-	>
-		<span class="text-[13px]">No scheduled tasks yet</span>
-		<span class="text-[11px]">
-			Create one to start automating agent workflows
-		</span>
+	<div class="empty-state">
+		<span>NO SCHEDULED TASKS</span>
+		<span class="empty-hint">PRESS N TO CREATE ONE</span>
 	</div>
 {:else}
 	<div class="board-grid">
 		{#each columns as col, colIndex (col.key)}
 			{@const colTasks = getColumnTasks(col.key)}
-			<div class="column-window" data-column-idx={colIndex}>
+			<div class="column" data-column-idx={colIndex}>
 				<div class="column-header">
 					<span
-						class="column-dot"
+						class="column-pip"
 						style="background: {col.color}"
 					></span>
 					<span class="column-label">{col.label}</span>
 					<span class="column-count">{colTasks.length}</span>
 				</div>
-				<div class="column-cards">
+				<div class="column-body">
 					{#each colTasks as task, taskIndex (task.id)}
 						<TaskCard
 							{task}
@@ -106,7 +95,7 @@ function getColumnTasks(key: string): ScheduledTask[] {
 						/>
 					{/each}
 					{#if colTasks.length === 0}
-						<div class="column-empty">No tasks</div>
+						<div class="column-empty">NO TASKS</div>
 					{/if}
 				</div>
 			</div>
@@ -115,9 +104,9 @@ function getColumnTasks(key: string): ScheduledTask[] {
 
 	{#if disabled.length > 0}
 		<div class="disabled-section">
-			<div class="column-window">
+			<div class="column">
 				<div class="column-header">
-					<span class="column-dot" style="background: var(--sig-text-muted)"></span>
+					<span class="column-pip" style="background: var(--sig-text-muted)"></span>
 					<span class="column-label">Disabled</span>
 					<span class="column-count">{disabled.length}</span>
 				</div>
@@ -143,31 +132,19 @@ function getColumnTasks(key: string): ScheduledTask[] {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
 		gap: var(--space-sm);
-		padding: var(--space-md);
+		padding: var(--space-sm);
 		min-height: 0;
 		flex: 1;
 	}
 
-	.column-window {
+	.column {
 		display: flex;
 		flex-direction: column;
 		min-height: 0;
-		border: 1px solid var(--sig-border-strong);
-		border-radius: 8px;
+		border: 1px solid var(--sig-border);
+		border-radius: var(--radius);
 		overflow: hidden;
-		background:
-			repeating-conic-gradient(
-				color-mix(in srgb, var(--sig-text) 1%, transparent) 0% 25%,
-				transparent 0% 50%
-			) 0 0 / 10px 10px,
-			repeating-conic-gradient(
-				transparent 0% 25%,
-				color-mix(in srgb, var(--sig-text) 1.5%, transparent) 0% 50%
-			) 5px 5px / 10px 10px,
-			repeating-conic-gradient(
-				var(--sig-surface) 0% 25%,
-				color-mix(in srgb, var(--sig-surface) 98%, var(--sig-bg)) 0% 50%
-			) 0 0 / 10px 10px;
+		background: var(--sig-surface);
 	}
 
 	.column-header {
@@ -179,10 +156,10 @@ function getColumnTasks(key: string): ScheduledTask[] {
 		flex-shrink: 0;
 	}
 
-	.column-dot {
+	.column-pip {
 		display: inline-block;
-		width: 6px;
-		height: 6px;
+		width: 4px;
+		height: 4px;
 		flex-shrink: 0;
 		border-radius: 50%;
 	}
@@ -198,16 +175,16 @@ function getColumnTasks(key: string): ScheduledTask[] {
 
 	.column-count {
 		font-family: var(--font-mono);
-		font-size: 10px;
+		font-size: 9px;
 		color: var(--sig-text-muted);
 		margin-left: auto;
+		font-variant-numeric: tabular-nums;
 	}
 
-	.column-cards {
+	.column-body {
 		display: flex;
 		flex-direction: column;
-		gap: var(--space-sm);
-		padding: var(--space-sm);
+		gap: 1px;
 		overflow-y: auto;
 		min-height: 0;
 		flex: 1;
@@ -219,19 +196,38 @@ function getColumnTasks(key: string): ScheduledTask[] {
 		justify-content: center;
 		padding: var(--space-lg) var(--space-md);
 		font-family: var(--font-mono);
-		font-size: 10px;
+		font-size: 9px;
+		letter-spacing: 0.08em;
 		color: var(--sig-text-muted);
-		opacity: 0.5;
+		opacity: 0.4;
 	}
 
 	.disabled-section {
-		padding: 0 var(--space-md) var(--space-md);
+		padding: 0 var(--space-sm) var(--space-sm);
 	}
 
 	.disabled-cards {
 		display: grid;
 		grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-		gap: var(--space-sm);
-		padding: var(--space-sm);
+		gap: 1px;
+		padding: 0;
+	}
+
+	.empty-state {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 4px;
+		height: 100%;
+		font-family: var(--font-mono);
+		font-size: 10px;
+		letter-spacing: 0.1em;
+		color: var(--sig-text-muted);
+	}
+
+	.empty-hint {
+		font-size: 8px;
+		opacity: 0.5;
 	}
 </style>

--- a/packages/cli/dashboard/src/lib/components/tasks/TaskCard.svelte
+++ b/packages/cli/dashboard/src/lib/components/tasks/TaskCard.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
 import type { ScheduledTask } from "$lib/api";
-import * as Card from "$lib/components/ui/card/index.js";
-import { Badge } from "$lib/components/ui/badge/index.js";
 import { Switch } from "$lib/components/ui/switch/index.js";
-import { Button } from "$lib/components/ui/button/index.js";
 import Play from "@lucide/svelte/icons/play";
 
 interface Props {
@@ -18,7 +15,7 @@ interface Props {
 let { task, columnKey, isSelected = false, onclick, ontrigger, ontoggle }: Props = $props();
 
 function formatRelativeTime(iso: string | null): string {
-	if (!iso) return "—";
+	if (!iso) return "--";
 	const diff = new Date(iso).getTime() - Date.now();
 	const absDiff = Math.abs(diff);
 	if (absDiff < 60_000) return diff > 0 ? "< 1m" : "just now";
@@ -42,131 +39,167 @@ let nextRunLabel = $derived(formatRelativeTime(task.next_run_at));
 let lastRunLabel = $derived(formatRelativeTime(task.last_run_at));
 </script>
 
-<button
-	class="w-full text-left cursor-pointer bg-transparent border-none p-0 task-card"
-	class:selected={isSelected}
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+	class="task-card"
+	class:task-card--selected={isSelected}
+	class:task-card--disabled={!task.enabled}
 	onclick={onclick}
+	onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onclick(); } }}
 	tabindex="0"
+	role="button"
 	data-task-id={task.id}
 	data-column={columnKey}
 >
-	<Card.Root
-		class="border-[var(--sig-border)]
-			transition-all duration-150
-			{!task.enabled ? 'opacity-50' : ''}"
-		style="background: radial-gradient(circle at 15% 120%, color-mix(in srgb, var(--sig-accent) 2%, transparent), transparent 40%), linear-gradient(to right, color-mix(in srgb, var(--sig-surface-raised) 99%, black) 0%, var(--sig-surface) 65%);"
-	>
-		<Card.Content class="p-3 space-y-2">
-			<div class="flex items-start justify-between gap-2">
-				<span
-					class="text-[12px] font-medium text-[var(--sig-text-bright)]
-						leading-tight line-clamp-2"
-				>
-					{task.name}
-				</span>
-				<Badge
-					variant="outline"
-					class="text-[9px] shrink-0 px-1.5 py-0
-						border-[var(--sig-border)]
-						text-[var(--sig-text-muted)]"
-				>
-					{harnessLabel}
-				</Badge>
-			</div>
+	<div class="task-top">
+		<span class="task-name">{task.name}</span>
+		<span class="task-harness">{harnessLabel}</span>
+	</div>
 
-			<div
-				class="text-[10px] text-[var(--sig-text-muted)]
-					font-[family-name:var(--font-mono)]
-					flex items-center gap-3"
-			>
-				<span>{task.cron_expression}</span>
-				{#if columnKey === "scheduled"}
-					<span>next: {nextRunLabel}</span>
-				{:else if columnKey === "running"}
-					<span class="text-[var(--sig-warning, #f59e0b)]">running...</span>
-				{:else if columnKey === "completed"}
-					<span>exit 0 · {lastRunLabel}</span>
-				{:else if columnKey === "failed"}
-					<span class="text-[var(--sig-error, #ef4444)]">
-						exit {task.last_run_exit_code ?? "?"} · {lastRunLabel}
-					</span>
-				{/if}
-			</div>
+	<div class="task-meta">
+		<span>{task.cron_expression}</span>
+		{#if columnKey === "scheduled"}
+			<span>next: {nextRunLabel}</span>
+		{:else if columnKey === "running"}
+			<span class="task-status-running">running</span>
+		{:else if columnKey === "completed"}
+			<span>exit 0 · {lastRunLabel}</span>
+		{:else if columnKey === "failed"}
+			<span class="task-status-failed">
+				exit {task.last_run_exit_code ?? "?"} · {lastRunLabel}
+			</span>
+		{/if}
+	</div>
 
-			<div class="flex items-center justify-between pt-1">
-				<!-- svelte-ignore a11y_click_events_have_key_events -->
-				<!-- svelte-ignore a11y_no_static_element_interactions -->
-				<div onclick={(e: MouseEvent) => e.stopPropagation()}>
-					<Switch
-						checked={!!task.enabled}
-						onCheckedChange={(v: unknown) => ontoggle(v === true)}
-						class="scale-75 origin-left"
-					/>
-				</div>
-				<!-- svelte-ignore a11y_click_events_have_key_events -->
-				<!-- svelte-ignore a11y_no_static_element_interactions -->
-				<div onclick={(e: MouseEvent) => e.stopPropagation()}>
-					<Button
-						variant="ghost"
-						size="sm"
-						class="h-6 w-6 p-0"
-						onclick={ontrigger}
-					>
-						<Play class="size-3" />
-					</Button>
-				</div>
-			</div>
-		</Card.Content>
-	</Card.Root>
-</button>
+	<div class="task-actions">
+		<!-- svelte-ignore a11y_click_events_have_key_events -->
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<div onclick={(e: MouseEvent) => e.stopPropagation()}>
+			<Switch
+				checked={!!task.enabled}
+				onCheckedChange={(v: unknown) => ontoggle(v === true)}
+				class="scale-75 origin-left"
+			/>
+		</div>
+		<!-- svelte-ignore a11y_click_events_have_key_events -->
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<button
+			class="trigger-btn"
+			onclick={(e: MouseEvent) => { e.stopPropagation(); ontrigger(); }}
+		>
+			<Play class="size-3" />
+		</button>
+	</div>
+</div>
 
 <style>
 	.task-card {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		padding: var(--space-sm) var(--space-md);
+		background: transparent;
+		border: none;
+		border-bottom: 1px solid var(--sig-border);
+		text-align: left;
+		cursor: pointer;
 		outline: none;
+		transition: background var(--dur) var(--ease);
+		width: 100%;
 	}
 
-	/* Hover state - prominent mouse indication with lift effect */
-	.task-card:hover :global(.card-root) {
-		border-color: var(--sig-border-strong);
-		background: color-mix(in srgb, var(--sig-surface-raised) 95%, var(--sig-accent) 5%);
-		transform: translateY(-1px);
-		box-shadow: 0 4px 12px -2px rgba(0, 0, 0, 0.3);
+	.task-card:last-child {
+		border-bottom: none;
 	}
 
-	/* Keyboard focus-visible state - clear, distinct visual indication */
-	.task-card:focus-visible :global(.card-root) {
-		border-color: var(--sig-accent);
-		box-shadow:
-			0 0 0 2px var(--sig-accent),
-			0 0 0 4px color-mix(in srgb, var(--sig-accent) 30%, transparent);
-		background: color-mix(in srgb, var(--sig-surface-raised) 92%, var(--sig-accent) 8%);
+	.task-card:hover {
+		background: var(--sig-surface-raised);
 	}
 
-	/* Focus state (non-visible) - same as hover for consistency */
-	.task-card:focus:not(:focus-visible) :global(.card-root) {
-		border-color: var(--sig-border-strong);
+	.task-card--selected {
+		background: var(--sig-surface-raised);
+		border-left: 2px solid var(--sig-highlight);
 	}
 
-	/* Selected state (clicked/active) - strong accent indication */
-	.task-card.selected :global(.card-root) {
-		border-color: var(--sig-accent);
-		box-shadow: 0 0 0 2px var(--sig-accent);
-		background: color-mix(in srgb, var(--sig-surface-raised) 90%, var(--sig-accent) 10%);
+	.task-card:focus-visible {
+		background: var(--sig-surface-raised);
+		border-left: 2px solid var(--sig-highlight);
 	}
 
-	/* Combine hover + focus-visible - focus takes precedence */
-	.task-card:focus-visible:hover :global(.card-root) {
-		border-color: var(--sig-accent);
-		box-shadow:
-			0 0 0 2px var(--sig-accent),
-			0 0 0 4px color-mix(in srgb, var(--sig-accent) 30%, transparent);
-		transform: none;
+	.task-card--disabled {
+		opacity: 0.4;
 	}
 
-	/* Selected + hover - keep selected styling */
-	.task-card.selected:hover :global(.card-root) {
-		border-color: var(--sig-accent);
-		box-shadow: 0 0 0 2px var(--sig-accent);
-		transform: none;
+	.task-top {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 8px;
+	}
+
+	.task-name {
+		font-family: var(--font-mono);
+		font-size: 11px;
+		font-weight: 600;
+		color: var(--sig-text-bright);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		min-width: 0;
+	}
+
+	.task-harness {
+		font-family: var(--font-mono);
+		font-size: 8px;
+		letter-spacing: 0.06em;
+		color: var(--sig-text-muted);
+		padding: 1px 5px;
+		border: 1px solid var(--sig-border);
+		border-radius: 2px;
+		flex-shrink: 0;
+	}
+
+	.task-meta {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		font-family: var(--font-mono);
+		font-size: 9px;
+		letter-spacing: 0.04em;
+		color: var(--sig-text-muted);
+	}
+
+	.task-status-running {
+		color: var(--sig-warning);
+	}
+
+	.task-status-failed {
+		color: var(--sig-danger);
+	}
+
+	.task-actions {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding-top: 2px;
+	}
+
+	.trigger-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 22px;
+		height: 22px;
+		background: none;
+		border: none;
+		color: var(--sig-text-muted);
+		cursor: pointer;
+		border-radius: 2px;
+		transition: color var(--dur) var(--ease), background var(--dur) var(--ease);
+	}
+
+	.trigger-btn:hover {
+		color: var(--sig-highlight);
+		background: var(--sig-surface-raised);
 	}
 </style>

--- a/packages/cli/dashboard/src/routes/+page.svelte
+++ b/packages/cli/dashboard/src/routes/+page.svelte
@@ -210,8 +210,7 @@ $effect(() => {
 		onprefetchembeddings={prefetchEmbeddingsTab}
 	/>
 	<main data-page-content="true" class="flex flex-1 flex-col min-w-0 min-h-0 overflow-hidden
-		mr-2 rounded-br-lg border border-[var(--sig-border-strong)] border-l-0 border-t-0 border-b-0
-		bg-[var(--sig-surface)]">
+		bg-[var(--sig-bg)]">
 
 		<UpgradeBanner {daemonStatus} />
 		<ExtensionBanner />


### PR DESCRIPTION
## Summary

- Comprehensive UI restyle across dashboard tabs applying a consistent "readout panel" design language: slim inline headers, flat panel surfaces, border-bottom separators, monospace readout typography, outline buttons with highlight hover
- **Tasks tab**: TaskBoard columns and TaskCard flat items with inline header
- **Secrets tab**: Full rewrite — collapsible add form, flat secret items, 1Password panel with chevron toggle, keyboard shortcut bar
- **Marketplace tab**: Slim header replacing hero section, SkillCard flat surfaces with 24px monograms, SkillGrid transparent background (no checkerboard)
- **Home tab**: AgentHeader, PredictorSplitBar, SuggestedInsights, PinnedEntityCluster all tightened to match
- **Cross-cutting**: 80ms fade transition on tab switch, new design tokens/utility classes in app.css, sidebar and footer visual refinements, UpgradeBanner restyle

## Test plan

- [ ] Hard refresh dashboard, verify all tabs render without errors
- [ ] Tasks tab: create/edit tasks, verify board columns and card styling
- [ ] Secrets tab: add/remove secrets, toggle 1Password panel, test keyboard shortcuts (N, Escape)
- [ ] Marketplace tab: switch between Skills/MCP Servers, install/uninstall, verify card hover states
- [ ] Home tab: verify all cards display correctly with data and in empty states
- [ ] Tab transitions: click between tabs rapidly, verify smooth 80ms fade
- [ ] Light theme: toggle `data-theme="light"` and verify token contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Floating sidebar card; compact upgrade banner; expanded Agent header with diagnostics, memory, pipeline, and warning readouts
  * Secrets panel: keyboard shortcuts, 1Password integration, vault import, and streamlined add/import flows
  * Tab content now fades when switching

* **Style**
  * Light/dark theme rework with warmer accent palette, explicit no-glow in light mode, updated icon/log colors, refined panels and compact skill/task visuals

* **Refactor**
  * Multiple card-based UIs rebuilt as lightweight panels for consistency and performance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->