### PR TITLE
feat: custom window decorations and UI scaling

### DIFF
--- a/packages/cli/dashboard/bun.lock
+++ b/packages/cli/dashboard/bun.lock
@@ -14,6 +14,7 @@
         "@codemirror/search": "^6.5.0",
         "@codemirror/state": "^6.5.4",
         "@codemirror/view": "^6.39.15",
+        "@tauri-apps/api": "^2",
         "better-sqlite3": "^12.6.2",
         "clsx": "^2.1.1",
         "d3-force": "^3.0.0",
@@ -258,6 +259,8 @@
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.2.0", "", { "os": "win32", "cpu": "x64" }, "sha512-CrFadmFoc+z76EV6LPG1jx6XceDsaCG3lFhyLNo/bV9ByPrE+FnBPckXQVP4XRkN76h3Fjt/a+5Er/oA/nCBvQ=="],
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.0", "", { "dependencies": { "@tailwindcss/node": "4.2.0", "@tailwindcss/oxide": "4.2.0", "tailwindcss": "4.2.0" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7" } }, "sha512-da9mFCaHpoOgtQiWtDGIikTrSpUFBtIZCG3jy/u2BGV+l/X1/pbxzmIUxNt6JWm19N3WtGi4KlJdSH/Si83WOA=="],
+
+    "@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
 
     "@tweenjs/tween.js": ["@tweenjs/tween.js@25.0.0", "", {}, "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A=="],
 

--- a/packages/cli/dashboard/package.json
+++ b/packages/cli/dashboard/package.json
@@ -21,6 +21,7 @@
     "@codemirror/search": "^6.5.0",
     "@codemirror/state": "^6.5.4",
     "@codemirror/view": "^6.39.15",
+    "@tauri-apps/api": "^2",
     "better-sqlite3": "^12.6.2",
     "clsx": "^2.1.1",
     "d3-force": "^3.0.0",

--- a/packages/cli/dashboard/src/app.css
+++ b/packages/cli/dashboard/src/app.css
@@ -1,349 +1,357 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+/* Slightly thinner icon strokes for a lighter feel */
+svg.lucide {
+    stroke-width: 2;
+}
+
 /* Dark is default; light activates via data-theme="light" */
 @custom-variant dark (&:is(:root:not([data-theme="light"]) *));
 
 /* === Dark theme (default) === */
 :root {
-	--radius: 0.5rem;
+    --radius: 0.5rem;
 
-	/* shadcn semantic tokens */
-	--background: #060608;
-	--foreground: #d4d4d8;
-	--card: #0a0a0e;
-	--card-foreground: #d4d4d8;
-	--popover: #0a0a0e;
-	--popover-foreground: #d4d4d8;
-	--primary: #f0f0f2;
-	--primary-foreground: #060608;
-	--secondary: #111115;
-	--secondary-foreground: #d4d4d8;
-	--muted: #111115;
-	--muted-foreground: #5a5a66;
-	--accent: #111115;
-	--accent-foreground: #d4d4d8;
-	--destructive: #8a4a48;
-	--destructive-foreground: #f0f0f2;
-	--border: rgba(255, 255, 255, 0.05);
-	--input: rgba(255, 255, 255, 0.10);
-	--ring: #5a5a66;
+    /* shadcn semantic tokens */
+    --background: #060608;
+    --foreground: #d4d4d8;
+    --card: #0a0a0e;
+    --card-foreground: #d4d4d8;
+    --popover: #0a0a0e;
+    --popover-foreground: #d4d4d8;
+    --primary: #f0f0f2;
+    --primary-foreground: #060608;
+    --secondary: #111115;
+    --secondary-foreground: #d4d4d8;
+    --muted: #111115;
+    --muted-foreground: #5a5a66;
+    --accent: #111115;
+    --accent-foreground: #d4d4d8;
+    --destructive: #8a4a48;
+    --destructive-foreground: #f0f0f2;
+    --border: rgba(255, 255, 255, 0.05);
+    --input: rgba(255, 255, 255, 0.10);
+    --ring: #5a5a66;
 
-	/* shadcn sidebar tokens */
-	--sidebar: #0a0a0e;
-	--sidebar-foreground: #d4d4d8;
-	--sidebar-primary: #f0f0f2;
-	--sidebar-primary-foreground: #060608;
-	--sidebar-accent: rgba(255, 255, 255, 0.06);
-	--sidebar-accent-foreground: #d4d4d8;
-	--sidebar-border: rgba(255, 255, 255, 0.10);
-	--sidebar-ring: #5a5a66;
+    /* shadcn sidebar tokens */
+    --sidebar: #0a0a0e;
+    --sidebar-foreground: #d4d4d8;
+    --sidebar-primary: #f0f0f2;
+    --sidebar-primary-foreground: #060608;
+    --sidebar-accent: rgba(255, 255, 255, 0.06);
+    --sidebar-accent-foreground: #d4d4d8;
+    --sidebar-border: rgba(255, 255, 255, 0.10);
+    --sidebar-ring: #5a5a66;
 
-	/* Signet extended tokens */
-	--sig-bg: #060608;
-	--sig-surface: #0a0a0e;
-	--sig-surface-raised: #111115;
-	--sig-border: rgba(255, 255, 255, 0.1);
-	--sig-border-strong: rgba(255, 255, 255, 0.15);
-	--sig-text: #c8c8d0;
-	--sig-text-bright: #f0f0f2;
-	--sig-text-muted: #5a5a66;
-	--sig-accent: #8a8a96;
-	--sig-accent-hover: #c0c0c8;
-	--sig-danger: #8a4a48;
-	--sig-warning: #d4a017;
-	--sig-success: #4a7a5e;
-	--sig-dither: #f0f0f2;
-	--sig-grain-opacity: 0.05;
+    /* Signet extended tokens */
+    --sig-bg: #060608;
+    --sig-surface: #0a0a0e;
+    --sig-surface-raised: #111115;
+    --sig-border: rgba(255, 255, 255, 0.1);
+    --sig-border-strong: rgba(255, 255, 255, 0.15);
+    --sig-text: #c8c8d0;
+    --sig-text-bright: #f0f0f2;
+    --sig-text-muted: #5a5a66;
+    --sig-accent: #8a8a96;
+    --sig-accent-hover: #c0c0c8;
+    --sig-danger: #8a4a48;
+    --sig-warning: #d4a017;
+    --sig-success: #4a7a5e;
+    --sig-dither: #f0f0f2;
+    --sig-grain-opacity: 0.05;
 
-	/* Pinterest-inspired accent system — neon yellow-green (Aphex Twin / data grids) */
-	--sig-highlight: #c8ff00;
-	--sig-highlight-muted: rgba(200, 255, 0, 0.12);
-	--sig-highlight-dim: rgba(200, 255, 0, 0.06);
-	--sig-highlight-text: #d4ff2a;
-	/* Electric blue — data visualization / constellation patterns */
-	--sig-electric: #3b82f6;
-	--sig-electric-muted: rgba(59, 130, 246, 0.12);
-	--sig-electric-dim: rgba(59, 130, 246, 0.06);
-	/* Blueprint / schematic overlay */
-	--sig-blueprint: rgba(59, 130, 246, 0.04);
-	--sig-grid-line: rgba(255, 255, 255, 0.025);
-	/* Glow effects */
-	--sig-glow-highlight: 0 0 20px rgba(200, 255, 0, 0.15);
-	--sig-glow-electric: 0 0 20px rgba(59, 130, 246, 0.15);
-	/* Scanline opacity */
-	--sig-scanline-opacity: 0.015;
+    /* Pinterest-inspired accent system — neon yellow-green (Aphex Twin / data grids) */
+    --sig-highlight: #c8ff00;
+    --sig-highlight-muted: rgba(200, 255, 0, 0.12);
+    --sig-highlight-dim: rgba(200, 255, 0, 0.06);
+    --sig-highlight-text: #d4ff2a;
+    /* Electric blue — data visualization / constellation patterns */
+    --sig-electric: #3b82f6;
+    --sig-electric-muted: rgba(59, 130, 246, 0.12);
+    --sig-electric-dim: rgba(59, 130, 246, 0.06);
+    /* Blueprint / schematic overlay */
+    --sig-blueprint: rgba(59, 130, 246, 0.04);
+    --sig-grid-line: rgba(255, 255, 255, 0.025);
+    /* Glow effects */
+    --sig-glow-highlight: 0 0 20px rgba(200, 255, 0, 0.15);
+    --sig-glow-electric: 0 0 20px rgba(59, 130, 246, 0.15);
+    /* Scanline opacity */
+    --sig-scanline-opacity: 0.015;
 
-	--sig-icon-fg: #f8fafc;
-	--sig-icon-border: rgba(255, 255, 255, 0.22);
-	--sig-icon-bg-1: #3b5998;
-	--sig-icon-bg-2: #6b4c8a;
-	--sig-icon-bg-3: #4a7c6f;
-	--sig-icon-bg-4: #8a6d3b;
-	--sig-icon-bg-5: #7c4a4a;
-	--sig-icon-bg-6: #4a6e7c;
+    --sig-icon-fg: #f8fafc;
+    --sig-icon-border: rgba(255, 255, 255, 0.22);
+    --sig-icon-bg-1: #3b5998;
+    --sig-icon-bg-2: #6b4c8a;
+    --sig-icon-bg-3: #4a7c6f;
+    --sig-icon-bg-4: #8a6d3b;
+    --sig-icon-bg-5: #7c4a4a;
+    --sig-icon-bg-6: #4a6e7c;
 
-	/* Log category colors (dark theme) */
-	--sig-log-category-watcher: #60a5fa;
-	--sig-log-category-daemon: #a78bfa;
-	--sig-log-category-pipeline: #34d399;
-	--sig-log-category-system: #9ca3af;
-	--sig-log-category-embedding-tracker: #f472b6;
-	--sig-log-category-document-worker: #fb923c;
-	--sig-log-category-maintenance: #c8ff00;
-	--sig-log-category-git: #2dd4bf;
-	--sig-log-category-scheduler: #c084fc;
-	--sig-log-category-retention: #f87171;
+    /* Log category colors (dark theme) */
+    --sig-log-category-watcher: #60a5fa;
+    --sig-log-category-daemon: #a78bfa;
+    --sig-log-category-pipeline: #34d399;
+    --sig-log-category-system: #9ca3af;
+    --sig-log-category-embedding-tracker: #f472b6;
+    --sig-log-category-document-worker: #fb923c;
+    --sig-log-category-maintenance: #c8ff00;
+    --sig-log-category-git: #2dd4bf;
+    --sig-log-category-scheduler: #c084fc;
+    --sig-log-category-retention: #f87171;
 
-	/* Typography & spacing */
-	--font-display: "Diamond Grotesk", "Chakra Petch", sans-serif;
-	--font-mono: "Geist Mono", "IBM Plex Mono", monospace;
-	--font-sans: var(--font-display);
+    /* Typography & spacing */
+    --font-display: "Diamond Grotesk", "Chakra Petch", sans-serif;
+    --font-mono: "Geist Mono", "IBM Plex Mono", monospace;
+    --font-sans: var(--font-display);
 
-	--space-xs: 4px;
-	--space-sm: 8px;
-	--space-md: 16px;
-	--space-lg: 24px;
-	--space-xl: 48px;
-	--space-2xl: 80px;
+    --space-xs: 4px;
+    --space-sm: 8px;
+    --space-md: 16px;
+    --space-lg: 24px;
+    --space-xl: 48px;
+    --space-2xl: 80px;
 
-	--font-size-xs: 10px;
-	--font-size-sm: 11px;
-	--font-size-base: 13px;
-	--font-size-lg: 15px;
+    --font-size-xs: 10px;
+    --font-size-sm: 11px;
+    --font-size-base: 13px;
+    --font-size-lg: 15px;
 
-	--ease: cubic-bezier(0.16, 1, 0.3, 1);
-	--dur: 0.2s;
+    --ease: cubic-bezier(0.16, 1, 0.3, 1);
+    --dur: 0.2s;
 }
 
 /* === Light theme — cool concrete + burnt orange (Aeris Systems) === */
 [data-theme="light"] {
-	--background: #e6e6e6;
-	--foreground: #1a1a1e;
-	--card: #dddddd;
-	--card-foreground: #1a1a1e;
-	--popover: #dddddd;
-	--popover-foreground: #1a1a1e;
-	--primary: #0a0a0c;
-	--primary-foreground: #e6e6e6;
-	--secondary: #d4d4d4;
-	--secondary-foreground: #1a1a1e;
-	--muted: #d4d4d4;
-	--muted-foreground: #6e6e72;
-	--accent: #d4d4d4;
-	--accent-foreground: #1a1a1e;
-	--destructive: #9a3030;
-	--destructive-foreground: #f0f0f2;
-	--border: rgba(0, 0, 0, 0.08);
-	--input: rgba(0, 0, 0, 0.12);
-	--ring: #6e6e72;
+    --background: #e6e6e6;
+    --foreground: #1a1a1e;
+    --card: #dddddd;
+    --card-foreground: #1a1a1e;
+    --popover: #dddddd;
+    --popover-foreground: #1a1a1e;
+    --primary: #0a0a0c;
+    --primary-foreground: #e6e6e6;
+    --secondary: #d4d4d4;
+    --secondary-foreground: #1a1a1e;
+    --muted: #d4d4d4;
+    --muted-foreground: #6e6e72;
+    --accent: #d4d4d4;
+    --accent-foreground: #1a1a1e;
+    --destructive: #9a3030;
+    --destructive-foreground: #f0f0f2;
+    --border: rgba(0, 0, 0, 0.08);
+    --input: rgba(0, 0, 0, 0.12);
+    --ring: #6e6e72;
 
-	--sidebar: #dddddd;
-	--sidebar-foreground: #1a1a1e;
-	--sidebar-primary: #0a0a0c;
-	--sidebar-primary-foreground: #e6e6e6;
-	--sidebar-accent: rgba(0, 0, 0, 0.06);
-	--sidebar-accent-foreground: #1a1a1e;
-	--sidebar-border: rgba(0, 0, 0, 0.10);
-	--sidebar-ring: #6e6e72;
+    --sidebar: #dddddd;
+    --sidebar-foreground: #1a1a1e;
+    --sidebar-primary: #0a0a0c;
+    --sidebar-primary-foreground: #e6e6e6;
+    --sidebar-accent: rgba(0, 0, 0, 0.06);
+    --sidebar-accent-foreground: #1a1a1e;
+    --sidebar-border: rgba(0, 0, 0, 0.10);
+    --sidebar-ring: #6e6e72;
 
-	--sig-bg: #e6e6e6;
-	--sig-surface: #dddddd;
-	--sig-surface-raised: #d4d4d4;
-	--sig-border: rgba(0, 0, 0, 0.10);
-	--sig-border-strong: rgba(0, 0, 0, 0.18);
-	--sig-text: #1a1a1e;
-	--sig-text-bright: #0a0a0c;
-	--sig-text-muted: #525252;
-	--sig-accent: #c83a18;
-	--sig-accent-hover: #a83010;
-	--sig-danger: #9a3030;
-	--sig-warning: #b87a00;
-	--sig-success: #2e7a4e;
-	--sig-dither: #0a0a0c;
-	--sig-grain-opacity: 0.04;
+    --sig-bg: #e6e6e6;
+    --sig-surface: #dddddd;
+    --sig-surface-raised: #d4d4d4;
+    --sig-border: rgba(0, 0, 0, 0.10);
+    --sig-border-strong: rgba(0, 0, 0, 0.18);
+    --sig-text: #1a1a1e;
+    --sig-text-bright: #0a0a0c;
+    --sig-text-muted: #525252;
+    --sig-accent: #c83a18;
+    --sig-accent-hover: #a83010;
+    --sig-danger: #9a3030;
+    --sig-warning: #b87a00;
+    --sig-success: #2e7a4e;
+    --sig-dither: #0a0a0c;
+    --sig-grain-opacity: 0.04;
 
-	/* Accent system — burnt orange for light (Aeris Systems inspired) */
-	--sig-highlight: #e8461e;
-	--sig-highlight-muted: rgba(232, 70, 30, 0.10);
-	--sig-highlight-dim: rgba(232, 70, 30, 0.06);
-	--sig-highlight-text: #c83a18;
-	--sig-electric: #2563eb;
-	--sig-electric-muted: rgba(37, 99, 235, 0.10);
-	--sig-electric-dim: rgba(37, 99, 235, 0.05);
-	--sig-blueprint: rgba(37, 99, 235, 0.03);
-	--sig-grid-line: rgba(0, 0, 0, 0.04);
-	/* No glow in light mode — clean flat look */
-	--sig-glow-highlight: none;
-	--sig-glow-electric: none;
-	--sig-scanline-opacity: 0.008;
+    /* Accent system — burnt orange for light (Aeris Systems inspired) */
+    --sig-highlight: #e8461e;
+    --sig-highlight-muted: rgba(232, 70, 30, 0.10);
+    --sig-highlight-dim: rgba(232, 70, 30, 0.06);
+    --sig-highlight-text: #c83a18;
+    --sig-electric: #2563eb;
+    --sig-electric-muted: rgba(37, 99, 235, 0.10);
+    --sig-electric-dim: rgba(37, 99, 235, 0.05);
+    --sig-blueprint: rgba(37, 99, 235, 0.03);
+    --sig-grid-line: rgba(0, 0, 0, 0.04);
+    /* No glow in light mode — clean flat look */
+    --sig-glow-highlight: none;
+    --sig-glow-electric: none;
+    --sig-scanline-opacity: 0.008;
 
-	--sig-icon-fg: #111827;
-	--sig-icon-border: rgba(0, 0, 0, 0.18);
-	--sig-icon-bg-1: #8898b0;
-	--sig-icon-bg-2: #a090b0;
-	--sig-icon-bg-3: #80a898;
-	--sig-icon-bg-4: #b0a070;
-	--sig-icon-bg-5: #b08888;
-	--sig-icon-bg-6: #80a8b0;
+    --sig-icon-fg: #111827;
+    --sig-icon-border: rgba(0, 0, 0, 0.18);
+    --sig-icon-bg-1: #8898b0;
+    --sig-icon-bg-2: #a090b0;
+    --sig-icon-bg-3: #80a898;
+    --sig-icon-bg-4: #b0a070;
+    --sig-icon-bg-5: #b08888;
+    --sig-icon-bg-6: #80a8b0;
 
-	/* Log category colors (light theme) */
-	--sig-log-category-watcher: #2563eb;
-	--sig-log-category-daemon: #7c3aed;
-	--sig-log-category-pipeline: #059669;
-	--sig-log-category-system: #6b7280;
-	--sig-log-category-embedding-tracker: #db2777;
-	--sig-log-category-document-worker: #e8461e;
-	--sig-log-category-maintenance: #c83a18;
-	--sig-log-category-git: #0d9488;
-	--sig-log-category-scheduler: #9333ea;
-	--sig-log-category-retention: #dc2626;
+    /* Log category colors (light theme) */
+    --sig-log-category-watcher: #2563eb;
+    --sig-log-category-daemon: #7c3aed;
+    --sig-log-category-pipeline: #059669;
+    --sig-log-category-system: #6b7280;
+    --sig-log-category-embedding-tracker: #db2777;
+    --sig-log-category-document-worker: #e8461e;
+    --sig-log-category-maintenance: #c83a18;
+    --sig-log-category-git: #0d9488;
+    --sig-log-category-scheduler: #9333ea;
+    --sig-log-category-retention: #dc2626;
 }
 
 /* === Tailwind v4 theme registration === */
 @theme inline {
-	--radius-sm: calc(var(--radius) - 4px);
-	--radius-md: calc(var(--radius) - 2px);
-	--radius-lg: var(--radius);
-	--radius-xl: calc(var(--radius) + 4px);
+    --radius-sm: calc(var(--radius) - 4px);
+    --radius-md: calc(var(--radius) - 2px);
+    --radius-lg: var(--radius);
+    --radius-xl: calc(var(--radius) + 4px);
 
-	--color-background: var(--background);
-	--color-foreground: var(--foreground);
-	--color-card: var(--card);
-	--color-card-foreground: var(--card-foreground);
-	--color-popover: var(--popover);
-	--color-popover-foreground: var(--popover-foreground);
-	--color-primary: var(--primary);
-	--color-primary-foreground: var(--primary-foreground);
-	--color-secondary: var(--secondary);
-	--color-secondary-foreground: var(--secondary-foreground);
-	--color-muted: var(--muted);
-	--color-muted-foreground: var(--muted-foreground);
-	--color-accent: var(--accent);
-	--color-accent-foreground: var(--accent-foreground);
-	--color-destructive: var(--destructive);
-	--color-destructive-foreground: var(--destructive-foreground);
-	--color-border: var(--border);
-	--color-input: var(--input);
-	--color-ring: var(--ring);
+    --color-background: var(--background);
+    --color-foreground: var(--foreground);
+    --color-card: var(--card);
+    --color-card-foreground: var(--card-foreground);
+    --color-popover: var(--popover);
+    --color-popover-foreground: var(--popover-foreground);
+    --color-primary: var(--primary);
+    --color-primary-foreground: var(--primary-foreground);
+    --color-secondary: var(--secondary);
+    --color-secondary-foreground: var(--secondary-foreground);
+    --color-muted: var(--muted);
+    --color-muted-foreground: var(--muted-foreground);
+    --color-accent: var(--accent);
+    --color-accent-foreground: var(--accent-foreground);
+    --color-destructive: var(--destructive);
+    --color-destructive-foreground: var(--destructive-foreground);
+    --color-border: var(--border);
+    --color-input: var(--input);
+    --color-ring: var(--ring);
 
-	--color-sidebar: var(--sidebar);
-	--color-sidebar-foreground: var(--sidebar-foreground);
-	--color-sidebar-primary: var(--sidebar-primary);
-	--color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-	--color-sidebar-accent: var(--sidebar-accent);
-	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-	--color-sidebar-border: var(--sidebar-border);
-	--color-sidebar-ring: var(--sidebar-ring);
+    --color-sidebar: var(--sidebar);
+    --color-sidebar-foreground: var(--sidebar-foreground);
+    --color-sidebar-primary: var(--sidebar-primary);
+    --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+    --color-sidebar-accent: var(--sidebar-accent);
+    --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+    --color-sidebar-border: var(--sidebar-border);
+    --color-sidebar-ring: var(--sidebar-ring);
 }
 
 /* === Base layer === */
 @layer base {
-	*,
-	::after,
-	::before,
-	::backdrop,
-	::file-selector-button {
-		border-color: var(--color-border, currentcolor);
-	}
 
-	* {
-		@apply border-border outline-ring/50;
-	}
+    *,
+    ::after,
+    ::before,
+    ::backdrop,
+    ::file-selector-button {
+        border-color: var(--color-border, currentcolor);
+    }
 
-	body {
-		@apply bg-background text-foreground;
-	}
+    * {
+        @apply border-border outline-ring/50;
+    }
+
+    body {
+        @apply bg-background text-foreground;
+    }
 }
 
 /* === Global styles === */
 html {
-	background: var(--sig-bg);
-	color: var(--sig-text);
-	font-family: var(--font-mono);
-	font-size: 13px;
-	line-height: 1.55;
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-	transition: background 0.4s var(--ease), color 0.4s var(--ease);
+    background: var(--sig-bg);
+    color: var(--sig-text);
+    font-family: var(--font-mono);
+    font-size: 13px;
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    transition: background 0.4s var(--ease), color 0.4s var(--ease);
 }
 
 body {
-	margin: 0;
-	min-height: 100vh;
+    margin: 0;
+    min-height: 100vh;
 }
 
 /* Grain overlay — enhanced with denser noise */
 body::before {
-	content: "";
-	position: fixed;
-	inset: 0;
-	z-index: 9999;
-	pointer-events: none;
-	opacity: var(--sig-grain-opacity);
-	background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 512 512' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.5' numOctaves='6' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
-	background-repeat: repeat;
-	background-size: 200px;
+    content: "";
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    pointer-events: none;
+    opacity: var(--sig-grain-opacity);
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 512 512' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.5' numOctaves='6' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    background-repeat: repeat;
+    background-size: 200px;
 }
 
 /* Scanline overlay — retro CRT effect from Pinterest tech aesthetic */
 body::after {
-	content: "";
-	position: fixed;
-	inset: 0;
-	z-index: 9998;
-	pointer-events: none;
-	opacity: var(--sig-scanline-opacity);
-	background-image: repeating-linear-gradient(
-		0deg,
-		transparent,
-		transparent 2px,
-		rgba(0, 0, 0, 0.3) 2px,
-		rgba(0, 0, 0, 0.3) 4px
-	);
-	background-size: 100% 4px;
+    content: "";
+    position: fixed;
+    inset: 0;
+    z-index: 9998;
+    pointer-events: none;
+    opacity: var(--sig-scanline-opacity);
+    background-image: repeating-linear-gradient(0deg,
+            transparent,
+            transparent 2px,
+            rgba(0, 0, 0, 0.3) 2px,
+            rgba(0, 0, 0, 0.3) 4px);
+    background-size: 100% 4px;
 }
 
 ::selection {
-	background: var(--sig-highlight-muted);
-	color: var(--sig-text-bright);
+    background: var(--sig-highlight-muted);
+    color: var(--sig-text-bright);
 }
 
 /* Floating sidebar card */
 [data-variant="floating"] [data-sidebar="sidebar"] {
-	background: var(--sidebar);
-	border-color: var(--sig-border-strong);
-	box-shadow:
-		0 1px 3px rgba(0, 0, 0, 0.3),
-		0 0 0 1px rgba(255, 255, 255, 0.02) inset;
+    background: var(--sidebar);
+    border-color: var(--sig-border-strong);
+    box-shadow:
+        0 1px 3px rgba(0, 0, 0, 0.3),
+        0 0 0 1px rgba(255, 255, 255, 0.02) inset;
 }
+
 [data-theme="light"] [data-variant="floating"] [data-sidebar="sidebar"] {
-	border-color: var(--sig-border-strong);
-	box-shadow:
-		0 1px 3px rgba(0, 0, 0, 0.08),
-		0 0 0 1px rgba(255, 255, 255, 0.5) inset;
+    border-color: var(--sig-border-strong);
+    box-shadow:
+        0 1px 3px rgba(0, 0, 0, 0.08),
+        0 0 0 1px rgba(255, 255, 255, 0.5) inset;
 }
 
 /* Subtle scrollbars */
 ::-webkit-scrollbar {
-	width: 3px;
-	height: 3px;
+    width: 3px;
+    height: 3px;
 }
+
 ::-webkit-scrollbar-track {
-	background: transparent;
+    background: transparent;
 }
+
 ::-webkit-scrollbar-thumb {
-	background: var(--sig-border-strong);
-	border-radius: 0;
+    background: var(--sig-border-strong);
+    border-radius: 0;
 }
+
 ::-webkit-scrollbar-thumb:hover {
-	background: var(--sig-text-muted);
+    background: var(--sig-text-muted);
 }
 
 /* Focus ring */
 :focus-visible {
-	outline: 1px solid var(--sig-text-muted);
-	outline-offset: 1px;
+    outline: 1px solid var(--sig-text-muted);
+    outline-offset: 1px;
 }
 
 /* Element transitions */
@@ -352,375 +360,389 @@ a,
 input,
 select,
 textarea {
-	transition: background-color var(--dur) var(--ease), border-color var(--dur)
-		var(--ease), color var(--dur) var(--ease);
+    transition: background-color var(--dur) var(--ease), border-color var(--dur) var(--ease), color var(--dur) var(--ease);
 }
 
 /* Typography */
 h1,
 h2,
 h3 {
-	font-family: var(--font-display);
-	font-weight: 600;
-	line-height: 1.1;
-	color: var(--sig-text-bright);
-	text-transform: uppercase;
+    font-family: var(--font-display);
+    font-weight: 600;
+    line-height: 1.1;
+    color: var(--sig-text-bright);
+    text-transform: uppercase;
 }
 
 h1 {
-	font-size: 1.5rem;
-	letter-spacing: 0.06em;
+    font-size: 1.5rem;
+    letter-spacing: 0.06em;
 }
+
 h2 {
-	font-size: 1rem;
-	letter-spacing: 0.05em;
+    font-size: 1rem;
+    letter-spacing: 0.05em;
 }
+
 h3 {
-	font-size: 0.875rem;
-	letter-spacing: 0.04em;
+    font-size: 0.875rem;
+    letter-spacing: 0.04em;
 }
 
 /* Prose styles for rendered markdown */
 .prose {
-	font-family: var(--font-mono);
-	font-size: 13px;
-	line-height: 1.7;
-	color: var(--sig-text);
+    font-family: var(--font-mono);
+    font-size: 13px;
+    line-height: 1.7;
+    color: var(--sig-text);
 }
 
 .prose h1,
 .prose h2,
 .prose h3 {
-	font-family: var(--font-display);
-	font-weight: 600;
-	color: var(--sig-text-bright);
-	text-transform: uppercase;
-	margin: 1.5em 0 0.5em;
-	line-height: 1.2;
+    font-family: var(--font-display);
+    font-weight: 600;
+    color: var(--sig-text-bright);
+    text-transform: uppercase;
+    margin: 1.5em 0 0.5em;
+    line-height: 1.2;
 }
 
 .prose h1 {
-	font-size: 1.25rem;
-	letter-spacing: 0.06em;
-	border-bottom: 1px solid var(--sig-border);
-	padding-bottom: 0.4em;
+    font-size: 1.25rem;
+    letter-spacing: 0.06em;
+    border-bottom: 1px solid var(--sig-border);
+    padding-bottom: 0.4em;
 }
 
 .prose h2 {
-	font-size: 1rem;
-	letter-spacing: 0.05em;
+    font-size: 1rem;
+    letter-spacing: 0.05em;
 }
 
 .prose h3 {
-	font-size: 0.875rem;
-	letter-spacing: 0.04em;
+    font-size: 0.875rem;
+    letter-spacing: 0.04em;
 }
 
 .prose p {
-	margin: 0.75em 0;
+    margin: 0.75em 0;
 }
 
 .prose ul,
 .prose ol {
-	margin: 0.5em 0;
-	padding-left: 1.5em;
+    margin: 0.5em 0;
+    padding-left: 1.5em;
 }
 
 .prose li {
-	margin: 0.25em 0;
+    margin: 0.25em 0;
 }
 
 .prose code {
-	font-family: var(--font-mono);
-	font-size: 0.9em;
-	background: var(--sig-surface-raised);
-	padding: 1px 5px;
-	border: 1px solid var(--sig-border);
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--sig-surface-raised);
+    padding: 1px 5px;
+    border: 1px solid var(--sig-border);
 }
 
 .prose pre {
-	background: var(--sig-bg);
-	border: 1px solid var(--sig-border);
-	padding: var(--space-sm) var(--space-md);
-	overflow-x: auto;
-	margin: 0.75em 0;
+    background: var(--sig-bg);
+    border: 1px solid var(--sig-border);
+    padding: var(--space-sm) var(--space-md);
+    overflow-x: auto;
+    margin: 0.75em 0;
 }
 
 .prose pre code {
-	background: none;
-	border: none;
-	padding: 0;
+    background: none;
+    border: none;
+    padding: 0;
 }
 
 .prose a {
-	color: var(--sig-accent);
-	text-decoration: underline;
-	text-underline-offset: 2px;
+    color: var(--sig-accent);
+    text-decoration: underline;
+    text-underline-offset: 2px;
 }
 
 .prose a:hover {
-	color: var(--sig-accent-hover);
+    color: var(--sig-accent-hover);
 }
 
 .prose strong {
-	color: var(--sig-text-bright);
-	font-weight: 600;
+    color: var(--sig-text-bright);
+    font-weight: 600;
 }
 
 .prose em {
-	font-style: italic;
+    font-style: italic;
 }
 
 .prose blockquote {
-	border-left: 2px solid var(--sig-border-strong);
-	margin: 0.75em 0;
-	padding: 0.25em 0 0.25em var(--space-md);
-	color: var(--sig-text-muted);
+    border-left: 2px solid var(--sig-border-strong);
+    margin: 0.75em 0;
+    padding: 0.25em 0 0.25em var(--space-md);
+    color: var(--sig-text-muted);
 }
 
 .prose hr {
-	border: none;
-	border-top: 1px solid var(--sig-border);
-	margin: 1.5em 0;
+    border: none;
+    border-top: 1px solid var(--sig-border);
+    margin: 1.5em 0;
 }
 
 .prose table {
-	width: 100%;
-	border-collapse: collapse;
-	margin: 0.75em 0;
-	font-size: 12px;
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0.75em 0;
+    font-size: 12px;
 }
 
 .prose th,
 .prose td {
-	border: 1px solid var(--sig-border);
-	padding: 4px 8px;
-	text-align: left;
+    border: 1px solid var(--sig-border);
+    padding: 4px 8px;
+    text-align: left;
 }
 
 .prose th {
-	background: var(--sig-surface-raised);
-	color: var(--sig-text-bright);
-	font-weight: 600;
-	text-transform: uppercase;
-	font-size: 10px;
-	letter-spacing: 0.04em;
+    background: var(--sig-surface-raised);
+    color: var(--sig-text-bright);
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 10px;
+    letter-spacing: 0.04em;
 }
 
 /* === Component utilities === */
 
 /* Small monospace label (11px, muted) */
 .sig-label {
-	font-family: var(--font-mono);
-	font-size: 11px;
-	color: var(--sig-text-muted);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--sig-text-muted);
 }
 
 /* Tiny uppercase monospace (eyebrows, metadata, counters) */
 .sig-eyebrow {
-	font-family: var(--font-mono);
-	font-size: 10px;
-	text-transform: uppercase;
-	letter-spacing: 0.06em;
-	color: var(--sig-text-muted);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--sig-text-muted);
 }
 
 /* Display heading used in section headers */
 .sig-heading {
-	font-family: var(--font-display);
-	font-size: 11px;
-	font-weight: 700;
-	text-transform: uppercase;
-	letter-spacing: 0.1em;
-	color: var(--sig-text-bright);
+    font-family: var(--font-display);
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--sig-text-bright);
 }
 
 /* Tiny monospace for badge-like metadata (9px) */
 .sig-meta {
-	font-family: var(--font-mono);
-	font-size: 9px;
-	color: var(--sig-text-muted);
-	white-space: nowrap;
+    font-family: var(--font-mono);
+    font-size: 9px;
+    color: var(--sig-text-muted);
+    white-space: nowrap;
 }
 
 /* Standard badge styling used across memory cards, pipeline, etc. */
 .sig-badge {
-	font-family: var(--font-mono);
-	font-size: 9px;
-	border-radius: 0.5rem;
-	padding: 1px 5px;
+    font-family: var(--font-mono);
+    font-size: 9px;
+    border-radius: 0.5rem;
+    padding: 1px 5px;
 }
 
 /* Feed/log tiny text (8-9px monospace) */
 .sig-micro {
-	font-family: var(--font-mono);
-	font-size: 8px;
-	text-transform: uppercase;
-	letter-spacing: 0.05em;
-	color: var(--sig-text-muted);
+    font-family: var(--font-mono);
+    font-size: 8px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--sig-text-muted);
 }
 
 /* === Pinterest-inspired design utilities === */
 
 /* Neon highlight text — Aphex Twin / data grid accent */
 .sig-highlight-text {
-	color: var(--sig-highlight-text);
+    color: var(--sig-highlight-text);
 }
 
 /* Highlighted badge with neon glow */
 .sig-highlight-badge {
-	font-family: var(--font-mono);
-	font-size: 9px;
-	border-radius: 0.5rem;
-	padding: 1px 6px;
-	background: var(--sig-highlight-muted);
-	color: var(--sig-highlight-text);
-	border: 1px solid var(--sig-highlight-dim);
+    font-family: var(--font-mono);
+    font-size: 9px;
+    border-radius: 0.5rem;
+    padding: 1px 6px;
+    background: var(--sig-highlight-muted);
+    color: var(--sig-highlight-text);
+    border: 1px solid var(--sig-highlight-dim);
 }
 
 /* Electric blue badge — data viz accent */
 .sig-electric-badge {
-	font-family: var(--font-mono);
-	font-size: 9px;
-	border-radius: 0.5rem;
-	padding: 1px 6px;
-	background: var(--sig-electric-muted);
-	color: var(--sig-electric);
-	border: 1px solid var(--sig-electric-dim);
+    font-family: var(--font-mono);
+    font-size: 9px;
+    border-radius: 0.5rem;
+    padding: 1px 6px;
+    background: var(--sig-electric-muted);
+    color: var(--sig-electric);
+    border: 1px solid var(--sig-electric-dim);
 }
 
 /* Dense data display — technical readout style (retro tech / forma 04) */
 .sig-data {
-	font-family: var(--font-mono);
-	font-size: 10px;
-	letter-spacing: 0.08em;
-	line-height: 1.8;
-	color: var(--sig-text);
-	font-variant-numeric: tabular-nums;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    line-height: 1.8;
+    color: var(--sig-text);
+    font-variant-numeric: tabular-nums;
 }
 
 /* Subtle glow container — neon accent glow */
 .sig-glow {
-	box-shadow: var(--sig-glow-highlight);
+    box-shadow: var(--sig-glow-highlight);
 }
 
 /* Electric glow variant */
 .sig-glow-blue {
-	box-shadow: var(--sig-glow-electric);
+    box-shadow: var(--sig-glow-electric);
 }
 
 /* Constellation dot — for node graph / data viz points */
 .sig-node {
-	width: 4px;
-	height: 4px;
-	border-radius: 50%;
-	background: var(--sig-highlight);
-	box-shadow: 0 0 6px var(--sig-highlight);
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background: var(--sig-highlight);
+    box-shadow: 0 0 6px var(--sig-highlight);
 }
 
 /* Crosshair marker — technical / schematic reference point */
 .sig-crosshair {
-	position: relative;
+    position: relative;
 }
+
 .sig-crosshair::before,
 .sig-crosshair::after {
-	content: "";
-	position: absolute;
-	background: var(--sig-grid-line);
+    content: "";
+    position: absolute;
+    background: var(--sig-grid-line);
 }
+
 .sig-crosshair::before {
-	width: 1px;
-	height: 100%;
-	left: 50%;
+    width: 1px;
+    height: 100%;
+    left: 50%;
 }
+
 .sig-crosshair::after {
-	width: 100%;
-	height: 1px;
-	top: 50%;
+    width: 100%;
+    height: 1px;
+    top: 50%;
 }
 
 /* Retro tech section divider — PlayStation/Sony inspired */
 .sig-divider {
-	border: none;
-	height: 1px;
-	background: linear-gradient(
-		90deg,
-		transparent 0%,
-		var(--sig-border-strong) 20%,
-		var(--sig-highlight-dim) 50%,
-		var(--sig-border-strong) 80%,
-		transparent 100%
-	);
+    border: none;
+    height: 1px;
+    background: linear-gradient(90deg,
+            transparent 0%,
+            var(--sig-border-strong) 20%,
+            var(--sig-highlight-dim) 50%,
+            var(--sig-border-strong) 80%,
+            transparent 100%);
 }
 
 /* Data readout number — large monospace numeric display */
 .sig-readout {
-	font-family: var(--font-mono);
-	font-size: 28px;
-	font-weight: 700;
-	letter-spacing: -0.02em;
-	line-height: 1;
-	color: var(--sig-text-bright);
-	font-variant-numeric: tabular-nums;
+    font-family: var(--font-mono);
+    font-size: 28px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    line-height: 1;
+    color: var(--sig-text-bright);
+    font-variant-numeric: tabular-nums;
 }
 
 /* Keep Lucide icon stroke weight consistent across zoom levels.
    WebKit page zoom scales via transforms; non-scaling-stroke
    prevents strokes from thickening at higher zoom. */
 svg.lucide [stroke] {
-	vector-effect: non-scaling-stroke;
+    vector-effect: non-scaling-stroke;
 }
 
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
-	*,
-	*::before,
-	*::after {
-		animation-duration: 0.01ms !important;
-		animation-iteration-count: 1 !important;
-		transition-duration: 0.01ms !important;
-	}
+
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
 }
 
 @keyframes pulse {
-	0%,
-	100% {
-		opacity: 1;
-	}
-	50% {
-		opacity: 0.5;
-	}
+
+    0%,
+    100% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.5;
+    }
 }
 
 /* Neon flicker — subtle CRT-style flicker for accent elements */
 @keyframes sig-flicker {
-	0%, 97%, 100% {
-		opacity: 1;
-	}
-	98% {
-		opacity: 0.85;
-	}
-	99% {
-		opacity: 0.95;
-	}
+
+    0%,
+    97%,
+    100% {
+        opacity: 1;
+    }
+
+    98% {
+        opacity: 0.85;
+    }
+
+    99% {
+        opacity: 0.95;
+    }
 }
 
 /* Slow glow pulse — for constellation nodes and status indicators */
 @keyframes sig-glow-pulse {
-	0%, 100% {
-		box-shadow: 0 0 4px var(--sig-highlight);
-	}
-	50% {
-		box-shadow: 0 0 12px var(--sig-highlight), 0 0 24px var(--sig-highlight-dim);
-	}
+
+    0%,
+    100% {
+        box-shadow: 0 0 4px var(--sig-highlight);
+    }
+
+    50% {
+        box-shadow: 0 0 12px var(--sig-highlight), 0 0 24px var(--sig-highlight-dim);
+    }
 }
 
 /* Blueprint grid scroll — subtle parallax for schematic backgrounds */
 @keyframes sig-grid-drift {
-	0% {
-		background-position: -1px -1px;
-	}
-	100% {
-		background-position: 23px 23px;
-	}
+    0% {
+        background-position: -1px -1px;
+    }
+
+    100% {
+        background-position: 23px 23px;
+    }
 }

--- a/packages/cli/dashboard/src/lib/components/layout/WindowTitlebar.svelte
+++ b/packages/cli/dashboard/src/lib/components/layout/WindowTitlebar.svelte
@@ -26,22 +26,33 @@
 		return windowApi;
 	}
 
-	// Poll maximized state and scale factor
+	// Track maximized state and scale factor via resize event (no polling).
+	// onResized fires synchronously on maximize/restore/resize, so the
+	// button icon updates immediately instead of lagging up to 500ms.
 	$effect(() => {
 		if (!isTauri) return;
+		let unlisten: (() => void) | null = null;
 		let cancelled = false;
-		const check = async () => {
+
+		async function init() {
 			const api = await ensureApi();
 			if (!api || cancelled) return;
 			const win = api.getCurrentWindow();
+			// Initial state
 			maximized = await win.isMaximized();
 			scaleFactor = await win.scaleFactor();
-		};
-		check();
-		const interval = setInterval(check, 500);
+			// Subscribe to resize events
+			unlisten = await win.onResized(async () => {
+				if (cancelled) return;
+				maximized = await win.isMaximized();
+				scaleFactor = await win.scaleFactor();
+			});
+		}
+
+		init();
 		return () => {
 			cancelled = true;
-			clearInterval(interval);
+			unlisten?.();
 		};
 	});
 

--- a/packages/cli/dashboard/src/lib/components/layout/WindowTitlebar.svelte
+++ b/packages/cli/dashboard/src/lib/components/layout/WindowTitlebar.svelte
@@ -13,7 +13,6 @@
 
 	let maximized = $state(false);
 	let hovered = $state(false);
-	let scaleFactor = $state(1);
 
 	// Tauri window API — lazy loaded to avoid errors in browser
 	let windowApi: typeof import("@tauri-apps/api/window") | null = null;
@@ -26,9 +25,10 @@
 		return windowApi;
 	}
 
-	// Track maximized state and scale factor via resize event (no polling).
-	// onResized fires synchronously on maximize/restore/resize, so the
-	// button icon updates immediately instead of lagging up to 500ms.
+	// Track maximized state via resize event (no polling).
+	// onResized fires synchronously on maximize/restore/resize.
+	// Guard: if teardown happens while init() is still awaiting, check
+	// `cancelled` after onResized resolves and immediately unlisten.
 	$effect(() => {
 		if (!isTauri) return;
 		let unlisten: (() => void) | null = null;
@@ -38,15 +38,17 @@
 			const api = await ensureApi();
 			if (!api || cancelled) return;
 			const win = api.getCurrentWindow();
-			// Initial state
 			maximized = await win.isMaximized();
-			scaleFactor = await win.scaleFactor();
-			// Subscribe to resize events
-			unlisten = await win.onResized(async () => {
+			const stop = await win.onResized(async () => {
 				if (cancelled) return;
 				maximized = await win.isMaximized();
-				scaleFactor = await win.scaleFactor();
 			});
+			// If teardown ran while we were awaiting onResized, unlisten immediately
+			if (cancelled) {
+				stop();
+				return;
+			}
+			unlisten = stop;
 		}
 
 		init();
@@ -112,6 +114,12 @@
 				: EyeOff,
 	);
 </script>
+
+{#if isTauri && !titlebar.visible}
+	<!-- "none" mode: invisible drag strip so the window stays movable.
+	     Without this, `decorations: false` + no titlebar = permanently stuck. -->
+	<div class="titlebar__drag-strip" data-tauri-drag-region></div>
+{/if}
 
 {#if isTauri && titlebar.visible}
 	<!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -222,6 +230,28 @@
 {/if}
 
 <style>
+	/* ── Platform color tokens (intentionally platform-specific, not theme tokens) ──
+	   macOS traffic lights use the exact system colors for authentic look.
+	   Windows close hover uses the system red. These are not interchangeable
+	   with --sig-danger or --sig-success which carry semantic UI meaning. */
+	:root {
+		--tb-mac-close: #ff5f57;
+		--tb-mac-minimize: #febc2e;
+		--tb-mac-maximize: #28c840;
+		--tb-win-close-bg: #c42b1c;
+		--tb-win-close-fg: #fff;
+	}
+
+	/* ── Drag strip for "none" mode — keeps window movable when titlebar is hidden ── */
+	.titlebar__drag-strip {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		height: 8px;
+		z-index: 9999;
+	}
+
 	/* ── Shared titlebar ── */
 	.titlebar {
 		display: flex;
@@ -317,21 +347,21 @@
 	}
 
 	.traffic-light--close {
-		background: #ff5f57;
+		background: var(--tb-mac-close);
 	}
 	.traffic-light--close:hover {
 		filter: brightness(1.1);
 	}
 
 	.traffic-light--minimize {
-		background: #febc2e;
+		background: var(--tb-mac-minimize);
 	}
 	.traffic-light--minimize:hover {
 		filter: brightness(1.1);
 	}
 
 	.traffic-light--maximize {
-		background: #28c840;
+		background: var(--tb-mac-maximize);
 	}
 	.traffic-light--maximize:hover {
 		filter: brightness(1.1);
@@ -382,7 +412,7 @@
 	}
 
 	.win-btn--close:hover {
-		background: #c42b1c;
-		color: #fff;
+		background: var(--tb-win-close-bg);
+		color: var(--tb-win-close-fg);
 	}
 </style>

--- a/packages/cli/dashboard/src/lib/components/layout/WindowTitlebar.svelte
+++ b/packages/cli/dashboard/src/lib/components/layout/WindowTitlebar.svelte
@@ -118,6 +118,7 @@
 					class="traffic-light traffic-light--close"
 					onclick={close}
 					title="Close"
+					aria-label="Close"
 				>
 					<span class="traffic-light__icon">
 						<X size={8} strokeWidth={2.5} />
@@ -127,6 +128,7 @@
 					class="traffic-light traffic-light--minimize"
 					onclick={minimize}
 					title="Minimize"
+					aria-label="Minimize"
 				>
 					<span class="traffic-light__icon">
 						<Minus size={8} strokeWidth={2.5} />
@@ -136,6 +138,7 @@
 					class="traffic-light traffic-light--maximize"
 					onclick={toggleMaximize}
 					title={maximized ? "Restore" : "Maximize"}
+					aria-label={maximized ? "Restore" : "Maximize"}
 				>
 					<span class="traffic-light__icon">
 						{#if maximized}
@@ -154,6 +157,7 @@
 					class="titlebar__mode-btn"
 					onclick={cycleMode}
 					title="Window style: {modeLabel[titlebar.mode]}"
+					aria-label="Toggle window style"
 				>
 					<ModeIcon size={12} />
 				</button>
@@ -165,6 +169,7 @@
 					class="titlebar__mode-btn"
 					onclick={cycleMode}
 					title="Window style: {modeLabel[titlebar.mode]}"
+					aria-label="Toggle window style"
 				>
 					<ModeIcon size={12} />
 				</button>
@@ -176,6 +181,7 @@
 					class="win-btn win-btn--minimize"
 					onclick={minimize}
 					title="Minimize"
+					aria-label="Minimize"
 				>
 					<Minus size={14} strokeWidth={1.5} />
 				</button>
@@ -183,6 +189,7 @@
 					class="win-btn win-btn--maximize"
 					onclick={toggleMaximize}
 					title={maximized ? "Restore" : "Maximize"}
+					aria-label={maximized ? "Restore" : "Maximize"}
 				>
 					{#if maximized}
 						<Copy size={12} strokeWidth={1.5} />
@@ -194,6 +201,7 @@
 					class="win-btn win-btn--close"
 					onclick={close}
 					title="Close"
+					aria-label="Close"
 				>
 					<X size={14} strokeWidth={1.5} />
 				</button>
@@ -238,7 +246,7 @@
 		color: var(--sig-text-muted);
 		border-radius: 4px;
 		cursor: pointer;
-		transition: background 0.15s, color 0.15s;
+		transition: background var(--dur) var(--ease), color var(--dur) var(--ease);
 	}
 
 	.titlebar__mode-btn:hover {
@@ -280,7 +288,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		transition: filter 0.15s;
+		transition: filter var(--dur) var(--ease);
 		position: relative;
 	}
 
@@ -290,7 +298,7 @@
 		justify-content: center;
 		opacity: 0;
 		color: rgba(0, 0, 0, 0.6);
-		transition: opacity 0.15s;
+		transition: opacity var(--dur) var(--ease);
 	}
 
 	.titlebar:hover .traffic-light__icon {
@@ -354,7 +362,7 @@
 		background: transparent;
 		color: var(--sig-text-muted);
 		cursor: pointer;
-		transition: background 0.1s, color 0.1s;
+		transition: background var(--dur) var(--ease), color var(--dur) var(--ease);
 	}
 
 	.win-btn:hover {

--- a/packages/cli/dashboard/src/lib/components/layout/WindowTitlebar.svelte
+++ b/packages/cli/dashboard/src/lib/components/layout/WindowTitlebar.svelte
@@ -1,0 +1,369 @@
+<script lang="ts">
+	import { titlebar, type DecorationMode } from "$lib/stores/titlebar.svelte";
+	import Minus from "@lucide/svelte/icons/minus";
+	import Square from "@lucide/svelte/icons/square";
+	import X from "@lucide/svelte/icons/x";
+	import Copy from "@lucide/svelte/icons/copy";
+	import Monitor from "@lucide/svelte/icons/monitor";
+	import AppWindowMac from "@lucide/svelte/icons/app-window-mac";
+	import EyeOff from "@lucide/svelte/icons/eye-off";
+
+	const isTauri =
+		typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+
+	let maximized = $state(false);
+	let hovered = $state(false);
+	let scaleFactor = $state(1);
+
+	// Tauri window API — lazy loaded to avoid errors in browser
+	let windowApi: typeof import("@tauri-apps/api/window") | null = null;
+
+	async function ensureApi() {
+		if (!isTauri) return null;
+		if (!windowApi) {
+			windowApi = await import("@tauri-apps/api/window");
+		}
+		return windowApi;
+	}
+
+	// Poll maximized state and scale factor
+	$effect(() => {
+		if (!isTauri) return;
+		let cancelled = false;
+		const check = async () => {
+			const api = await ensureApi();
+			if (!api || cancelled) return;
+			const win = api.getCurrentWindow();
+			maximized = await win.isMaximized();
+			scaleFactor = await win.scaleFactor();
+		};
+		check();
+		const interval = setInterval(check, 500);
+		return () => {
+			cancelled = true;
+			clearInterval(interval);
+		};
+	});
+
+	// Native dimensions in logical pixels, scaled to match OS chrome.
+	// macOS: 28px titlebar, 12px traffic lights, 8px gap
+	// Windows: 32px titlebar, 46x32px caption buttons
+	// We scale relative to 1x baseline so higher DPI displays get
+	// correctly proportioned chrome.
+	const MACOS_HEIGHT = 28;
+	const MACOS_DOT = 12;
+	const MACOS_GAP = 8;
+	const WIN_HEIGHT = 32;
+	const WIN_BTN_W = 46;
+
+	const barHeight = $derived(
+		titlebar.mode === "macos" ? MACOS_HEIGHT : WIN_HEIGHT,
+	);
+	const dotSize = $derived(MACOS_DOT);
+	const dotGap = $derived(MACOS_GAP);
+	const winBtnWidth = $derived(WIN_BTN_W);
+
+	async function minimize() {
+		const api = await ensureApi();
+		if (!api) return;
+		await api.getCurrentWindow().minimize();
+	}
+
+	async function toggleMaximize() {
+		const api = await ensureApi();
+		if (!api) return;
+		await api.getCurrentWindow().toggleMaximize();
+	}
+
+	async function close() {
+		const api = await ensureApi();
+		if (!api) return;
+		await api.getCurrentWindow().close();
+	}
+
+	function cycleMode() {
+		const modes: DecorationMode[] = ["macos", "windows", "none"];
+		const idx = modes.indexOf(titlebar.mode);
+		titlebar.mode = modes[(idx + 1) % modes.length];
+	}
+
+	const modeLabel: Record<DecorationMode, string> = {
+		macos: "macOS",
+		windows: "Windows",
+		none: "None",
+	};
+
+	const ModeIcon = $derived(
+		titlebar.mode === "macos"
+			? AppWindowMac
+			: titlebar.mode === "windows"
+				? Monitor
+				: EyeOff,
+	);
+</script>
+
+{#if isTauri && titlebar.visible}
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div
+		class="titlebar titlebar--{titlebar.mode}"
+		data-tauri-drag-region
+		style="--tb-h: {barHeight}px; --tb-dot: {dotSize}px; --tb-dot-gap: {dotGap}px; --tb-win-btn: {winBtnWidth}px;"
+		onmouseenter={() => (hovered = true)}
+		onmouseleave={() => (hovered = false)}
+	>
+		{#if titlebar.mode === "macos"}
+			<!-- macOS: traffic lights left, title center -->
+			<div class="titlebar__controls titlebar__controls--macos">
+				<button
+					class="traffic-light traffic-light--close"
+					onclick={close}
+					title="Close"
+				>
+					<span class="traffic-light__icon">
+						<X size={8} strokeWidth={2.5} />
+					</span>
+				</button>
+				<button
+					class="traffic-light traffic-light--minimize"
+					onclick={minimize}
+					title="Minimize"
+				>
+					<span class="traffic-light__icon">
+						<Minus size={8} strokeWidth={2.5} />
+					</span>
+				</button>
+				<button
+					class="traffic-light traffic-light--maximize"
+					onclick={toggleMaximize}
+					title={maximized ? "Restore" : "Maximize"}
+				>
+					<span class="traffic-light__icon">
+						{#if maximized}
+							<Copy size={7} strokeWidth={2.5} />
+						{:else}
+							<Square size={7} strokeWidth={2.5} />
+						{/if}
+					</span>
+				</button>
+			</div>
+
+			<span class="titlebar__title" data-tauri-drag-region>SIGNET</span>
+
+			<div class="titlebar__spacer">
+				<button
+					class="titlebar__mode-btn"
+					onclick={cycleMode}
+					title="Window style: {modeLabel[titlebar.mode]}"
+				>
+					<ModeIcon size={12} />
+				</button>
+			</div>
+		{:else}
+			<!-- Windows: title left, controls right -->
+			<div class="titlebar__left">
+				<button
+					class="titlebar__mode-btn"
+					onclick={cycleMode}
+					title="Window style: {modeLabel[titlebar.mode]}"
+				>
+					<ModeIcon size={12} />
+				</button>
+				<span class="titlebar__title" data-tauri-drag-region>SIGNET</span>
+			</div>
+
+			<div class="titlebar__controls titlebar__controls--windows">
+				<button
+					class="win-btn win-btn--minimize"
+					onclick={minimize}
+					title="Minimize"
+				>
+					<Minus size={14} strokeWidth={1.5} />
+				</button>
+				<button
+					class="win-btn win-btn--maximize"
+					onclick={toggleMaximize}
+					title={maximized ? "Restore" : "Maximize"}
+				>
+					{#if maximized}
+						<Copy size={12} strokeWidth={1.5} />
+					{:else}
+						<Square size={12} strokeWidth={1.5} />
+					{/if}
+				</button>
+				<button
+					class="win-btn win-btn--close"
+					onclick={close}
+					title="Close"
+				>
+					<X size={14} strokeWidth={1.5} />
+				</button>
+			</div>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	/* ── Shared titlebar ── */
+	.titlebar {
+		display: flex;
+		align-items: center;
+		height: var(--tb-h);
+		width: 100%;
+		background: var(--sig-surface);
+		border-bottom: 1px solid var(--sig-border);
+		user-select: none;
+		-webkit-user-select: none;
+		flex-shrink: 0;
+		z-index: 9999;
+		font-family: var(--font-mono);
+	}
+
+	.titlebar__title {
+		font-size: 11px;
+		font-weight: 700;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--sig-text-muted);
+		pointer-events: none;
+	}
+
+	.titlebar__mode-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 24px;
+		height: 24px;
+		border: none;
+		background: transparent;
+		color: var(--sig-text-muted);
+		border-radius: 4px;
+		cursor: pointer;
+		transition: background 0.15s, color 0.15s;
+	}
+
+	.titlebar__mode-btn:hover {
+		background: var(--sig-surface-raised);
+		color: var(--sig-text-bright);
+	}
+
+	/* ── macOS traffic lights ── */
+	.titlebar--macos {
+		justify-content: space-between;
+		padding: 0 12px;
+	}
+
+	.titlebar--macos .titlebar__title {
+		position: absolute;
+		left: 50%;
+		transform: translateX(-50%);
+	}
+
+	.titlebar__spacer {
+		display: flex;
+		align-items: center;
+		width: 80px;
+		justify-content: flex-end;
+	}
+
+	.titlebar__controls--macos {
+		display: flex;
+		align-items: center;
+		gap: var(--tb-dot-gap);
+	}
+
+	.traffic-light {
+		width: var(--tb-dot);
+		height: var(--tb-dot);
+		border-radius: 50%;
+		border: none;
+		cursor: pointer;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		transition: filter 0.15s;
+		position: relative;
+	}
+
+	.traffic-light__icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		opacity: 0;
+		color: rgba(0, 0, 0, 0.6);
+		transition: opacity 0.15s;
+	}
+
+	.titlebar:hover .traffic-light__icon {
+		opacity: 1;
+	}
+
+	.traffic-light--close {
+		background: #ff5f57;
+	}
+	.traffic-light--close:hover {
+		filter: brightness(1.1);
+	}
+
+	.traffic-light--minimize {
+		background: #febc2e;
+	}
+	.traffic-light--minimize:hover {
+		filter: brightness(1.1);
+	}
+
+	.traffic-light--maximize {
+		background: #28c840;
+	}
+	.traffic-light--maximize:hover {
+		filter: brightness(1.1);
+	}
+
+	/* Unfocused state — all grey */
+	.titlebar--macos:not(:hover) .traffic-light--close,
+	.titlebar--macos:not(:hover) .traffic-light--minimize,
+	.titlebar--macos:not(:hover) .traffic-light--maximize {
+		background: var(--sig-text-muted);
+		opacity: 0.4;
+	}
+
+	/* ── Windows controls ── */
+	.titlebar--windows {
+		justify-content: space-between;
+		padding: 0 0 0 8px;
+	}
+
+	.titlebar__left {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.titlebar__controls--windows {
+		display: flex;
+		align-items: stretch;
+		height: 100%;
+	}
+
+	.win-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: var(--tb-win-btn);
+		height: 100%;
+		border: none;
+		background: transparent;
+		color: var(--sig-text-muted);
+		cursor: pointer;
+		transition: background 0.1s, color 0.1s;
+	}
+
+	.win-btn:hover {
+		background: var(--sig-surface-raised);
+		color: var(--sig-text-bright);
+	}
+
+	.win-btn--close:hover {
+		background: #c42b1c;
+		color: #fff;
+	}
+</style>

--- a/packages/cli/dashboard/src/lib/components/tabs/SettingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/SettingsTab.svelte
@@ -10,6 +10,7 @@
 	import PipelineSection from "./settings/PipelineSection.svelte";
 	import SearchSection from "./settings/SearchSection.svelte";
 	import TrustSection from "./settings/TrustSection.svelte";
+	import AppearanceSection from "./settings/AppearanceSection.svelte";
 	import IdentityPanel from "$lib/components/config/IdentityPanel.svelte";
 	import PageBanner from "$lib/components/layout/PageBanner.svelte";
 	import TabGroupBar from "$lib/components/layout/TabGroupBar.svelte";
@@ -72,6 +73,12 @@
 			title: "Auth",
 			source: "config",
 			paths: [["auth"]],
+		},
+		{
+			id: "appearance",
+			title: "Appearance",
+			source: "config",
+			paths: [],
 		},
 	];
 
@@ -189,6 +196,8 @@
 					<TrustSection />
 				{:else if activeSection === "auth"}
 					<AuthSection />
+				{:else if activeSection === "appearance"}
+					<AppearanceSection />
 				{/if}
 			</div>
 

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/AppearanceSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/AppearanceSection.svelte
@@ -51,14 +51,14 @@
 
 	<FormField label="UI scale" description="Adjust text and spacing size. Icons remain crisp at all levels. Ctrl+/- or Ctrl+0 to reset.">
 		<div class="scale-control">
-			<button class="scale-btn" onclick={() => uiScale.zoomOut()} title="Zoom out (Ctrl+-)">
+			<button class="scale-btn" onclick={() => uiScale.zoomOut()} title="Zoom out (Ctrl+-)" aria-label="Zoom out">
 				<ZoomOut size={14} />
 			</button>
 			<span class="scale-value">{uiScale.percent}</span>
-			<button class="scale-btn" onclick={() => uiScale.zoomIn()} title="Zoom in (Ctrl+=)">
+			<button class="scale-btn" onclick={() => uiScale.zoomIn()} title="Zoom in (Ctrl+=)" aria-label="Zoom in">
 				<ZoomIn size={14} />
 			</button>
-			<button class="scale-btn scale-btn--reset" onclick={() => uiScale.reset()} title="Reset (Ctrl+0)">
+			<button class="scale-btn scale-btn--reset" onclick={() => uiScale.reset()} title="Reset (Ctrl+0)" aria-label="Reset zoom">
 				<RotateCcw size={12} />
 			</button>
 		</div>

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/AppearanceSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/AppearanceSection.svelte
@@ -1,0 +1,183 @@
+<script lang="ts">
+	import FormField from "$lib/components/config/FormField.svelte";
+	import FormSection from "$lib/components/config/FormSection.svelte";
+	import { titlebar, type DecorationMode } from "$lib/stores/titlebar.svelte";
+	import { uiScale } from "$lib/stores/ui-scale.svelte";
+	import AppWindowMac from "@lucide/svelte/icons/app-window-mac";
+	import Monitor from "@lucide/svelte/icons/monitor";
+	import EyeOff from "@lucide/svelte/icons/eye-off";
+	import ZoomIn from "@lucide/svelte/icons/zoom-in";
+	import ZoomOut from "@lucide/svelte/icons/zoom-out";
+	import RotateCcw from "@lucide/svelte/icons/rotate-ccw";
+
+	const isTauri =
+		typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+
+	const modes: { id: DecorationMode; label: string; icon: typeof Monitor; desc: string }[] = [
+		{ id: "macos", label: "macOS", icon: AppWindowMac, desc: "Traffic light buttons, centered title" },
+		{ id: "windows", label: "Windows", icon: Monitor, desc: "Minimize / maximize / close on right" },
+		{ id: "none", label: "None", icon: EyeOff, desc: "No window titlebar" },
+	];
+</script>
+
+<FormSection description="Local display preferences. These settings are stored in your browser and not synced.">
+	{#if isTauri}
+		<FormField label="Window decorations" description="Controls how the window titlebar and controls are rendered.">
+			<div class="mode-grid">
+				{#each modes as mode (mode.id)}
+					<button
+						class="mode-card"
+						class:mode-card--active={titlebar.mode === mode.id}
+						onclick={() => (titlebar.mode = mode.id)}
+					>
+						<div class="mode-icon">
+							<mode.icon size={18} />
+						</div>
+						<div class="mode-info">
+							<span class="mode-label">{mode.label}</span>
+							<span class="mode-desc">{mode.desc}</span>
+						</div>
+					</button>
+				{/each}
+			</div>
+		</FormField>
+	{:else}
+		<FormField label="Window decorations" description="Only available in the desktop app.">
+			<span class="not-available">Run Signet as a desktop app to configure window decorations.</span>
+		</FormField>
+	{/if}
+
+	<FormField label="UI scale" description="Adjust text and spacing size. Icons remain crisp at all levels. Ctrl+/- or Ctrl+0 to reset.">
+		<div class="scale-control">
+			<button class="scale-btn" onclick={() => uiScale.zoomOut()} title="Zoom out (Ctrl+-)">
+				<ZoomOut size={14} />
+			</button>
+			<span class="scale-value">{uiScale.percent}</span>
+			<button class="scale-btn" onclick={() => uiScale.zoomIn()} title="Zoom in (Ctrl+=)">
+				<ZoomIn size={14} />
+			</button>
+			<button class="scale-btn scale-btn--reset" onclick={() => uiScale.reset()} title="Reset (Ctrl+0)">
+				<RotateCcw size={12} />
+			</button>
+		</div>
+	</FormField>
+</FormSection>
+
+<style>
+	.mode-grid {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+
+	.mode-card {
+		display: flex;
+		align-items: center;
+		gap: var(--space-sm);
+		padding: 10px 12px;
+		background: var(--sig-bg);
+		border: 1px solid var(--sig-border);
+		border-radius: 6px;
+		cursor: pointer;
+		transition: border-color 0.15s, background 0.15s;
+		text-align: left;
+	}
+
+	.mode-card:hover {
+		border-color: var(--sig-border-strong);
+		background: var(--sig-surface);
+	}
+
+	.mode-card--active {
+		border-color: var(--sig-highlight);
+		background: color-mix(in srgb, var(--sig-highlight), var(--sig-bg) 94%);
+	}
+
+	.mode-card--active:hover {
+		border-color: var(--sig-highlight);
+	}
+
+	.mode-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		flex-shrink: 0;
+		color: var(--sig-text-muted);
+		border-radius: 4px;
+	}
+
+	.mode-card--active .mode-icon {
+		color: var(--sig-highlight);
+	}
+
+	.mode-info {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.mode-label {
+		font-family: var(--font-mono);
+		font-size: 11px;
+		font-weight: 600;
+		color: var(--sig-text-bright);
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+	}
+
+	.mode-desc {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		color: var(--sig-text-muted);
+	}
+
+	.not-available {
+		font-family: var(--font-mono);
+		font-size: 11px;
+		color: var(--sig-text-muted);
+	}
+
+	.scale-control {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+	}
+
+	.scale-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		border: 1px solid var(--sig-border);
+		background: var(--sig-bg);
+		color: var(--sig-text-muted);
+		border-radius: 4px;
+		cursor: pointer;
+		transition: border-color 0.15s, color 0.15s, background 0.15s;
+	}
+
+	.scale-btn:hover {
+		border-color: var(--sig-border-strong);
+		color: var(--sig-text-bright);
+		background: var(--sig-surface);
+	}
+
+	.scale-btn--reset {
+		margin-left: 4px;
+		width: 28px;
+		height: 28px;
+	}
+
+	.scale-value {
+		min-width: 48px;
+		text-align: center;
+		font-family: var(--font-mono);
+		font-size: 12px;
+		font-weight: 600;
+		color: var(--sig-text-bright);
+		letter-spacing: 0.04em;
+	}
+</style>

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/AppearanceSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/AppearanceSection.svelte
@@ -26,8 +26,10 @@
 			<div class="mode-grid">
 				{#each modes as mode (mode.id)}
 					<button
+						type="button"
 						class="mode-card"
 						class:mode-card--active={titlebar.mode === mode.id}
+						aria-pressed={titlebar.mode === mode.id}
 						onclick={() => (titlebar.mode = mode.id)}
 					>
 						<div class="mode-icon">

--- a/packages/cli/dashboard/src/lib/components/ui/sidebar/context.svelte.ts
+++ b/packages/cli/dashboard/src/lib/components/ui/sidebar/context.svelte.ts
@@ -30,7 +30,13 @@ class SidebarState {
 
 	constructor(props: SidebarStateProps) {
 		this.setOpen = props.setOpen;
-		this.#isMobile = new IsMobile();
+		// In the Tauri desktop shell, the app has a minimum window width of 800px
+		// and a min zoom level of 50%, so at 200% DPI the logical width can be as
+		// low as ~400px. Use 200px to prevent the sidebar collapsing to a sheet in
+		// the desktop app. On the web (browser), use the standard 768px breakpoint.
+		const isTauri =
+			typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+		this.#isMobile = new IsMobile(isTauri ? 200 : undefined);
 		this.props = props;
 	}
 

--- a/packages/cli/dashboard/src/lib/components/ui/sidebar/sidebar.svelte
+++ b/packages/cli/dashboard/src/lib/components/ui/sidebar/sidebar.svelte
@@ -58,7 +58,7 @@
 {:else}
 	<div
 		bind:this={ref}
-		class="text-sidebar-foreground group peer hidden min-[200px]:block"
+		class="text-sidebar-foreground group peer hidden md:block"
 		data-state={sidebar.state}
 		data-collapsible={sidebar.state === "collapsed" ? collapsible : ""}
 		data-variant={variant}
@@ -80,7 +80,7 @@
 		<div
 			data-slot="sidebar-container"
 			class={cn(
-				"fixed inset-y-0 z-10 hidden w-(--sidebar-width) transition-[left,right,width] duration-200 ease-out min-[200px]:flex",
+				"fixed inset-y-0 z-10 hidden w-(--sidebar-width) transition-[left,right,width] duration-200 ease-out md:flex",
 				"top-[var(--titlebar-h,0px)] h-[calc(100svh-var(--titlebar-h,0px))]",
 				side === "left"
 					? "start-0 group-data-[collapsible=offcanvas]:start-[calc(var(--sidebar-width)*-1)]"

--- a/packages/cli/dashboard/src/lib/components/ui/sidebar/sidebar.svelte
+++ b/packages/cli/dashboard/src/lib/components/ui/sidebar/sidebar.svelte
@@ -58,7 +58,7 @@
 {:else}
 	<div
 		bind:this={ref}
-		class="text-sidebar-foreground group peer hidden md:block"
+		class="text-sidebar-foreground group peer hidden min-[200px]:block"
 		data-state={sidebar.state}
 		data-collapsible={sidebar.state === "collapsed" ? collapsible : ""}
 		data-variant={variant}
@@ -80,7 +80,8 @@
 		<div
 			data-slot="sidebar-container"
 			class={cn(
-				"fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-out md:flex",
+				"fixed inset-y-0 z-10 hidden w-(--sidebar-width) transition-[left,right,width] duration-200 ease-out min-[200px]:flex",
+				"top-[var(--titlebar-h,0px)] h-[calc(100svh-var(--titlebar-h,0px))]",
 				side === "left"
 					? "start-0 group-data-[collapsible=offcanvas]:start-[calc(var(--sidebar-width)*-1)]"
 					: "end-0 group-data-[collapsible=offcanvas]:end-[calc(var(--sidebar-width)*-1)]",

--- a/packages/cli/dashboard/src/lib/hooks/is-mobile.svelte.ts
+++ b/packages/cli/dashboard/src/lib/hooks/is-mobile.svelte.ts
@@ -1,6 +1,9 @@
 import { MediaQuery } from "svelte/reactivity";
 
-const DEFAULT_MOBILE_BREAKPOINT = 768;
+// Desktop app — only collapse to mobile sheet at extremely narrow widths.
+// The default shadcn 768px is for responsive websites; a native app with
+// min-width 800px at 200% DPI yields ~400px logical, so we go well below that.
+const DEFAULT_MOBILE_BREAKPOINT = 200;
 
 export class IsMobile extends MediaQuery {
 	constructor(breakpoint: number = DEFAULT_MOBILE_BREAKPOINT) {

--- a/packages/cli/dashboard/src/lib/hooks/is-mobile.svelte.ts
+++ b/packages/cli/dashboard/src/lib/hooks/is-mobile.svelte.ts
@@ -1,9 +1,6 @@
 import { MediaQuery } from "svelte/reactivity";
 
-// Desktop app — only collapse to mobile sheet at extremely narrow widths.
-// The default shadcn 768px is for responsive websites; a native app with
-// min-width 800px at 200% DPI yields ~400px logical, so we go well below that.
-const DEFAULT_MOBILE_BREAKPOINT = 200;
+const DEFAULT_MOBILE_BREAKPOINT = 768;
 
 export class IsMobile extends MediaQuery {
 	constructor(breakpoint: number = DEFAULT_MOBILE_BREAKPOINT) {

--- a/packages/cli/dashboard/src/lib/stores/titlebar.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/titlebar.svelte.ts
@@ -1,0 +1,54 @@
+/**
+ * Titlebar decoration mode store.
+ *
+ * Modes:
+ *   "macos"   — traffic-light buttons on the left, centered title
+ *   "windows" — minimize/maximize/close on the right, left-aligned title
+ *   "none"    — no titlebar, pure content (chromeless)
+ *
+ * Auto-detects OS on first load, persists override in localStorage.
+ */
+
+export type DecorationMode = "macos" | "windows" | "none";
+
+const STORAGE_KEY = "signet-decoration-mode";
+
+function detectOS(): DecorationMode {
+	if (typeof navigator === "undefined") return "none";
+	const ua = navigator.userAgent.toLowerCase();
+	if (ua.includes("mac")) return "macos";
+	if (ua.includes("win")) return "windows";
+	// Linux — default to windows-style (more familiar with close on right)
+	return "windows";
+}
+
+function loadMode(): DecorationMode {
+	if (typeof localStorage === "undefined") return detectOS();
+	const stored = localStorage.getItem(STORAGE_KEY);
+	if (stored === "macos" || stored === "windows" || stored === "none") {
+		return stored;
+	}
+	return detectOS();
+}
+
+let mode = $state<DecorationMode>(loadMode());
+
+export const titlebar = {
+	get mode() {
+		return mode;
+	},
+	set mode(v: DecorationMode) {
+		mode = v;
+		if (typeof localStorage !== "undefined") {
+			localStorage.setItem(STORAGE_KEY, v);
+		}
+	},
+	get visible() {
+		return mode !== "none";
+	},
+	/** Height in logical pixels — matches native OS chrome */
+	get height() {
+		if (mode === "none") return 0;
+		return mode === "macos" ? 28 : 32;
+	},
+};

--- a/packages/cli/dashboard/src/lib/stores/titlebar.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/titlebar.svelte.ts
@@ -6,12 +6,18 @@
  *   "windows" — minimize/maximize/close on the right, left-aligned title
  *   "none"    — no titlebar, pure content (chromeless)
  *
- * Auto-detects OS on first load, persists override in localStorage.
+ * Only active inside the Tauri desktop shell. In a normal browser session
+ * this store always resolves to "none" so the web dashboard never renders
+ * a phantom titlebar offset.
  */
 
 export type DecorationMode = "macos" | "windows" | "none";
 
 const STORAGE_KEY = "signet-decoration-mode";
+
+function isTauriShell(): boolean {
+	return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
 
 function detectOS(): DecorationMode {
 	if (typeof navigator === "undefined") return "none";
@@ -23,6 +29,7 @@ function detectOS(): DecorationMode {
 }
 
 function loadMode(): DecorationMode {
+	if (!isTauriShell()) return "none";
 	if (typeof localStorage === "undefined") return detectOS();
 	const stored = localStorage.getItem(STORAGE_KEY);
 	if (stored === "macos" || stored === "windows" || stored === "none") {

--- a/packages/cli/dashboard/src/lib/stores/ui-scale.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/ui-scale.svelte.ts
@@ -57,20 +57,26 @@ export const uiScale = {
 		if (index < STEPS.length - 1) {
 			index++;
 			applyScale();
-			localStorage.setItem(STORAGE_KEY, String(index));
+			if (typeof localStorage !== "undefined") {
+				localStorage.setItem(STORAGE_KEY, String(index));
+			}
 		}
 	},
 	zoomOut(): void {
 		if (index > 0) {
 			index--;
 			applyScale();
-			localStorage.setItem(STORAGE_KEY, String(index));
+			if (typeof localStorage !== "undefined") {
+				localStorage.setItem(STORAGE_KEY, String(index));
+			}
 		}
 	},
 	reset(): void {
 		index = DEFAULT_INDEX;
 		applyScale();
-		localStorage.setItem(STORAGE_KEY, String(index));
+		if (typeof localStorage !== "undefined") {
+			localStorage.setItem(STORAGE_KEY, String(index));
+		}
 	},
 	/** Call from a wheel handler to zoom with Ctrl+scroll */
 	handleZoomWheel(e: WheelEvent): boolean {

--- a/packages/cli/dashboard/src/lib/stores/ui-scale.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/ui-scale.svelte.ts
@@ -18,7 +18,7 @@ function loadIndex(): number {
 	const stored = localStorage.getItem(STORAGE_KEY);
 	if (stored !== null) {
 		const n = Number(stored);
-		if (Number.isFinite(n) && n >= 0 && n < STEPS.length) return n;
+		if (Number.isInteger(n) && n >= 0 && n < STEPS.length) return n;
 	}
 	return DEFAULT_INDEX;
 }

--- a/packages/cli/dashboard/src/lib/stores/ui-scale.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/ui-scale.svelte.ts
@@ -1,0 +1,106 @@
+/**
+ * UI scale store — replaces browser zoom with controlled CSS zoom.
+ *
+ * Uses the CSS `zoom` property on the root element, which scales
+ * everything uniformly (text, spacing, borders) while keeping SVG
+ * stroke rendering consistent — unlike browser-level zoom which
+ * causes stroke-width distortion in WebKit.
+ *
+ * Persisted in localStorage.
+ */
+
+const STORAGE_KEY = "signet-ui-scale";
+const STEPS = [0.5, 0.6, 0.7, 0.8, 0.85, 0.9, 0.95, 1.0, 1.1, 1.2, 1.3, 1.5, 1.75, 2.0, 2.5, 3.0] as const;
+const DEFAULT_INDEX = 7; // 1.0
+
+function loadIndex(): number {
+	if (typeof localStorage === "undefined") return DEFAULT_INDEX;
+	const stored = localStorage.getItem(STORAGE_KEY);
+	if (stored !== null) {
+		const n = Number(stored);
+		if (Number.isFinite(n) && n >= 0 && n < STEPS.length) return n;
+	}
+	return DEFAULT_INDEX;
+}
+
+let index = $state(loadIndex());
+
+function applyScale(): void {
+	if (typeof document === "undefined") return;
+	const scale = STEPS[index];
+	// CSS zoom scales everything uniformly — text, spacing, SVGs —
+	// without the WebKit stroke-width rendering bugs that come from
+	// the browser's native zoom implementation.
+	document.documentElement.style.zoom = String(scale);
+	document.documentElement.style.setProperty("--ui-scale", String(scale));
+}
+
+// Apply on load
+if (typeof document !== "undefined") {
+	applyScale();
+}
+
+export const uiScale = {
+	get value(): number {
+		return STEPS[index];
+	},
+	get index(): number {
+		return index;
+	},
+	get steps(): readonly number[] {
+		return STEPS;
+	},
+	get percent(): string {
+		return `${Math.round(STEPS[index] * 100)}%`;
+	},
+	zoomIn(): void {
+		if (index < STEPS.length - 1) {
+			index++;
+			applyScale();
+			localStorage.setItem(STORAGE_KEY, String(index));
+		}
+	},
+	zoomOut(): void {
+		if (index > 0) {
+			index--;
+			applyScale();
+			localStorage.setItem(STORAGE_KEY, String(index));
+		}
+	},
+	reset(): void {
+		index = DEFAULT_INDEX;
+		applyScale();
+		localStorage.setItem(STORAGE_KEY, String(index));
+	},
+	/** Call from a wheel handler to zoom with Ctrl+scroll */
+	handleZoomWheel(e: WheelEvent): boolean {
+		if (!(e.ctrlKey || e.metaKey)) return false;
+		e.preventDefault();
+		if (e.deltaY < 0) {
+			uiScale.zoomIn();
+		} else if (e.deltaY > 0) {
+			uiScale.zoomOut();
+		}
+		return true;
+	},
+	/** Call from a keydown handler to intercept Ctrl+/Ctrl-/Ctrl+0 */
+	handleZoomKey(e: KeyboardEvent): boolean {
+		if (!(e.ctrlKey || e.metaKey)) return false;
+		if (e.key === "=" || e.key === "+") {
+			e.preventDefault();
+			uiScale.zoomIn();
+			return true;
+		}
+		if (e.key === "-") {
+			e.preventDefault();
+			uiScale.zoomOut();
+			return true;
+		}
+		if (e.key === "0") {
+			e.preventDefault();
+			uiScale.reset();
+			return true;
+		}
+		return false;
+	},
+};

--- a/packages/cli/dashboard/src/lib/stores/ui-scale.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/ui-scale.svelte.ts
@@ -18,11 +18,13 @@ function loadIndex(): number {
 	const stored = localStorage.getItem(STORAGE_KEY);
 	if (stored !== null) {
 		const v = parseFloat(stored);
-		if (!isNaN(v)) {
+		// Guard: values above the max step are old index-based storage (e.g. "7" for
+		// index 7). Passing them to nearest-match would silently set max zoom (3.0×).
+		if (!isNaN(v) && v <= STEPS[STEPS.length - 1]) {
 			// Exact match first
 			const exact = (STEPS as readonly number[]).indexOf(v);
 			if (exact !== -1) return exact;
-			// Nearest match — handles old index-based values and future STEPS changes
+			// Nearest match — gracefully handles future STEPS reshuffling
 			return STEPS.reduce(
 				(best, s, i) => (Math.abs(s - v) < Math.abs(STEPS[best] - v) ? i : best),
 				DEFAULT_INDEX,

--- a/packages/cli/dashboard/src/lib/stores/ui-scale.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/ui-scale.svelte.ts
@@ -17,8 +17,17 @@ function loadIndex(): number {
 	if (typeof localStorage === "undefined") return DEFAULT_INDEX;
 	const stored = localStorage.getItem(STORAGE_KEY);
 	if (stored !== null) {
-		const n = Number(stored);
-		if (Number.isInteger(n) && n >= 0 && n < STEPS.length) return n;
+		const v = parseFloat(stored);
+		if (!isNaN(v)) {
+			// Exact match first
+			const exact = (STEPS as readonly number[]).indexOf(v);
+			if (exact !== -1) return exact;
+			// Nearest match — handles old index-based values and future STEPS changes
+			return STEPS.reduce(
+				(best, s, i) => (Math.abs(s - v) < Math.abs(STEPS[best] - v) ? i : best),
+				DEFAULT_INDEX,
+			);
+		}
 	}
 	return DEFAULT_INDEX;
 }
@@ -58,7 +67,7 @@ export const uiScale = {
 			index++;
 			applyScale();
 			if (typeof localStorage !== "undefined") {
-				localStorage.setItem(STORAGE_KEY, String(index));
+				localStorage.setItem(STORAGE_KEY, String(STEPS[index]));
 			}
 		}
 	},
@@ -67,7 +76,7 @@ export const uiScale = {
 			index--;
 			applyScale();
 			if (typeof localStorage !== "undefined") {
-				localStorage.setItem(STORAGE_KEY, String(index));
+				localStorage.setItem(STORAGE_KEY, String(STEPS[index]));
 			}
 		}
 	},
@@ -75,7 +84,7 @@ export const uiScale = {
 		index = DEFAULT_INDEX;
 		applyScale();
 		if (typeof localStorage !== "undefined") {
-			localStorage.setItem(STORAGE_KEY, String(index));
+			localStorage.setItem(STORAGE_KEY, String(STEPS[index]));
 		}
 	},
 	/** Call from a wheel handler to zoom with Ctrl+scroll */

--- a/packages/cli/dashboard/src/routes/+page.svelte
+++ b/packages/cli/dashboard/src/routes/+page.svelte
@@ -40,6 +40,9 @@ import {
 	MEMORY_TABS,
 } from "$lib/stores/tab-group-focus.svelte";
 import { focus } from "$lib/stores/focus.svelte";
+import WindowTitlebar from "$lib/components/layout/WindowTitlebar.svelte";
+import { titlebar } from "$lib/stores/titlebar.svelte";
+import { uiScale } from "$lib/stores/ui-scale.svelte";
 import { onMount } from "svelte";
 
 const activeTab = $derived(nav.activeTab);
@@ -156,10 +159,15 @@ onMount(() => {
 	};
 	window.addEventListener("beforeunload", handleBeforeUnload);
 
+	// Ctrl+scroll wheel zoom — needs {passive: false} to allow preventDefault
+	const handleWheel = (e: WheelEvent) => uiScale.handleZoomWheel(e);
+	window.addEventListener("wheel", handleWheel, { passive: false });
+
 	return () => {
 		cleanupNav();
 		cleanupTabGroups();
 		window.removeEventListener("beforeunload", handleBeforeUnload);
+		window.removeEventListener("wheel", handleWheel);
 	};
 });
 
@@ -197,9 +205,12 @@ $effect(() => {
 	<title>Signet</title>
 </svelte:head>
 
-<svelte:window onkeydown={handleGlobalKey} onfocusin={handleFocusIn} onclick={handlePageClick} />
+<svelte:window onkeydown={(e) => { if (!uiScale.handleZoomKey(e)) handleGlobalKey(e); }} onfocusin={handleFocusIn} onclick={handlePageClick} />
 
-<Sidebar.Provider>
+<div class="flex flex-col h-screen overflow-hidden" style="--titlebar-h: {titlebar.visible ? titlebar.height : 0}px;">
+<WindowTitlebar />
+
+<Sidebar.Provider class="!h-full flex-1 min-h-0">
 	<AppSidebar
 		identity={data.identity}
 		harnesses={data.harnesses}
@@ -239,6 +250,7 @@ $effect(() => {
 		/>
 	</main>
 </Sidebar.Provider>
+</div>
 
 <GlobalCommandPalette />
 

--- a/packages/cli/dashboard/src/routes/+page.svelte
+++ b/packages/cli/dashboard/src/routes/+page.svelte
@@ -159,15 +159,20 @@ onMount(() => {
 	};
 	window.addEventListener("beforeunload", handleBeforeUnload);
 
-	// Ctrl+scroll wheel zoom — needs {passive: false} to allow preventDefault
+	// Ctrl+scroll wheel zoom — only in Tauri (web build preserves native browser zoom)
+	const isTauri = "__TAURI_INTERNALS__" in window;
 	const handleWheel = (e: WheelEvent) => uiScale.handleZoomWheel(e);
-	window.addEventListener("wheel", handleWheel, { passive: false });
+	if (isTauri) {
+		window.addEventListener("wheel", handleWheel, { passive: false });
+	}
 
 	return () => {
 		cleanupNav();
 		cleanupTabGroups();
 		window.removeEventListener("beforeunload", handleBeforeUnload);
-		window.removeEventListener("wheel", handleWheel);
+		if (isTauri) {
+			window.removeEventListener("wheel", handleWheel);
+		}
 	};
 });
 
@@ -205,7 +210,15 @@ $effect(() => {
 	<title>Signet</title>
 </svelte:head>
 
-<svelte:window onkeydown={(e) => { if (!uiScale.handleZoomKey(e)) handleGlobalKey(e); }} onfocusin={handleFocusIn} onclick={handlePageClick} />
+<svelte:window
+	onkeydown={(e) => {
+		const isTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+		if (isTauri && uiScale.handleZoomKey(e)) return;
+		handleGlobalKey(e);
+	}}
+	onfocusin={handleFocusIn}
+	onclick={handlePageClick}
+/>
 
 <div class="flex flex-col h-screen overflow-hidden" style="--titlebar-h: {titlebar.visible ? titlebar.height : 0}px;">
 <WindowTitlebar />

--- a/packages/cli/dashboard/src/routes/+page.svelte
+++ b/packages/cli/dashboard/src/routes/+page.svelte
@@ -159,9 +159,16 @@ onMount(() => {
 	};
 	window.addEventListener("beforeunload", handleBeforeUnload);
 
-	// Ctrl+scroll wheel zoom — only in Tauri (web build preserves native browser zoom)
+	// Ctrl+scroll wheel zoom — only in Tauri (web build preserves native browser zoom).
+	// Modifier check is inlined so non-ctrl scrolls exit immediately, minimising the
+	// cost of the { passive: false } constraint on ordinary scrolling.
 	const isTauri = "__TAURI_INTERNALS__" in window;
-	const handleWheel = (e: WheelEvent) => uiScale.handleZoomWheel(e);
+	const handleWheel = (e: WheelEvent) => {
+		if (!(e.ctrlKey || e.metaKey)) return;
+		e.preventDefault();
+		if (e.deltaY < 0) uiScale.zoomIn();
+		else if (e.deltaY > 0) uiScale.zoomOut();
+	};
 	if (isTauri) {
 		window.addEventListener("wheel", handleWheel, { passive: false });
 	}

--- a/packages/tray/src-tauri/capabilities/default.json
+++ b/packages/tray/src-tauri/capabilities/default.json
@@ -13,6 +13,11 @@
     "core:window:allow-show",
     "core:window:allow-hide",
     "core:window:allow-create",
-    "core:webview:allow-set-webview-zoom"
+    "core:window:allow-minimize",
+    "core:window:allow-toggle-maximize",
+    "core:window:allow-is-maximized",
+    "core:window:allow-start-dragging",
+    "core:webview:allow-set-webview-zoom",
+    "core:webview:allow-set-webview-size"
   ]
 }

--- a/packages/tray/src-tauri/src/commands.rs
+++ b/packages/tray/src-tauri/src/commands.rs
@@ -134,7 +134,7 @@ pub(crate) fn open_dashboard_inner(app: &AppHandle) -> Result<(), String> {
         .min_inner_size(800.0, 600.0)
         .center()
         .decorations(false)
-        .zoom_hotkeys_enabled(true)
+        .zoom_hotkeys_enabled(false)
         .build()
         .map_err(|e| e.to_string())?;
     }

--- a/packages/tray/src-tauri/tauri.conf.json
+++ b/packages/tray/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
         "visible": false,
         "decorations": false,
         "center": true,
-        "zoomHotkeysEnabled": true
+        "zoomHotkeysEnabled": false
       }
     ],
     "security": {


### PR DESCRIPTION
## Summary

- Custom-drawn window titlebar with 3 modes: macOS (traffic lights), Windows (caption buttons), and None (chromeless)
- Auto-detects OS, persists user preference in localStorage
- Replaces browser zoom with CSS zoom-based UI scaling (50%–300%) to fix WebKit SVG stroke-width rendering bugs
- Appearance section in Settings with decoration mode picker and zoom controls (Ctrl+/-/0 and scroll wheel)
- Sidebar collapse breakpoint lowered from 768px to 200px to prevent early disappearance at high DPI

## Test plan

- [ ] Launch Tauri app, verify titlebar renders in Windows style on Linux
- [ ] Click mode switcher icon to cycle through macOS / Windows / None
- [ ] Verify window drag works on the titlebar
- [ ] Verify minimize / maximize / close buttons work
- [ ] Go to Settings > Appearance, change decoration mode via cards
- [ ] Test Ctrl+/Ctrl-/Ctrl+0 zoom controls
- [ ] Test Ctrl+scroll wheel zoom
- [ ] Verify SVG icon stroke weight stays consistent across zoom levels
- [ ] Verify sidebar stays visible at high zoom
- [ ] Verify settings persist across app restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native, cross-platform draggable window titlebar (macOS/Windows/None)
  * Appearance settings panel to choose window decoration mode
  * UI scale controls: zoom in, zoom out, reset, with wheel and keyboard handling

* **Style**
  * Lightweight icon stroke tweak for sharper icon rendering

* **Chores**
  * Desktop shell integration and breakpoint adjustments for desktop builds
  * Sidebar layout updated to account for custom titlebar
  * Desktop permissions expanded and main-window zoom hotkeys disabled
<!-- end of auto-generated comment: release notes by coderabbit.ai -->