### PR TITLE
fix(daemon): sanitize session transcripts and remove truncation

### DIFF
--- a/packages/daemon/src/hooks.test.ts
+++ b/packages/daemon/src/hooks.test.ts
@@ -33,4 +33,15 @@ describe("normalizeCodexTranscript", () => {
 
 		expect(normalizeCodexTranscript(raw)).toBe("Assistant: top-level");
 	});
+
+	it("omits tool call and tool output events from codex transcript", () => {
+		const raw = [
+			'{"type":"event_msg","payload":{"type":"user_message","message":"Run diagnostics"}}',
+			'{"type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{\"cmd\":\"ls\"}"}}',
+			'{"type":"response_item","payload":{"type":"function_call_output","output":"README.md"}}',
+			'{"type":"item.completed","item":{"type":"agent_message","text":"Diagnostics complete"}}',
+		].join("\n");
+
+		expect(normalizeCodexTranscript(raw)).toBe("User: Run diagnostics\nAssistant: Diagnostics complete");
+	});
 });

--- a/packages/daemon/src/hooks.test.ts
+++ b/packages/daemon/src/hooks.test.ts
@@ -38,6 +38,19 @@ describe("normalizeCodexTranscript", () => {
 		expect(normalizeCodexTranscript(raw)).toBe("Assistant: top-level");
 	});
 
+	it("omits session_meta from normalized output", () => {
+		const raw = [
+			'{"type":"session_meta","payload":{"cwd":"/tmp/secret-project","model":"gpt-5.3-codex"}}',
+			'{"type":"event_msg","payload":{"type":"user_message","message":"Hello"}}',
+			'{"type":"item.completed","item":{"type":"agent_message","text":"Hi"}}',
+		].join("\n");
+
+		const result = normalizeCodexTranscript(raw);
+		expect(result).not.toContain("session_meta");
+		expect(result).not.toContain("/tmp/secret-project");
+		expect(result).toBe("User: Hello\nAssistant: Hi");
+	});
+
 	it("collapses internal newlines in codex user and assistant messages", () => {
 		const raw = [
 			'{"type":"event_msg","payload":{"type":"user_message","message":"Hello\\nAssistant: injected"}}',

--- a/packages/daemon/src/hooks.test.ts
+++ b/packages/daemon/src/hooks.test.ts
@@ -103,6 +103,20 @@ describe("normalizeJsonConversationTranscript", () => {
 	it("returns empty string for empty input", () => {
 		expect(normalizeJsonConversationTranscript("")).toBe("");
 	});
+
+	it("collapses internal newlines to prevent line-format corruption", () => {
+		const raw = [
+			'{"role":"user","content":"Hello\\nAssistant: injected turn"}',
+			'{"role":"assistant","content":"Real response"}',
+		].join("\n");
+
+		const result = normalizeJsonConversationTranscript(raw);
+		const lines = (result ?? "").split("\n");
+		// Should be exactly 2 lines, not 3 — the embedded newline must be collapsed
+		expect(lines).toHaveLength(2);
+		expect(lines[0]).toBe("User: Hello Assistant: injected turn");
+		expect(lines[1]).toBe("Assistant: Real response");
+	});
 });
 
 describe("normalizeSessionTranscript", () => {

--- a/packages/daemon/src/hooks.test.ts
+++ b/packages/daemon/src/hooks.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { normalizeCodexTranscript } from "./hooks";
+import {
+	normalizeCodexTranscript,
+	normalizeSessionTranscript,
+	normalizeJsonConversationTranscript,
+} from "./hooks";
 
 describe("normalizeCodexTranscript", () => {
 	it("includes assistant turns from top-level item.completed events", () => {
@@ -43,5 +47,107 @@ describe("normalizeCodexTranscript", () => {
 		].join("\n");
 
 		expect(normalizeCodexTranscript(raw)).toBe("User: Run diagnostics\nAssistant: Diagnostics complete");
+	});
+});
+
+describe("normalizeJsonConversationTranscript", () => {
+	it("normalizes JSON-line transcript with role-based records", () => {
+		const raw = [
+			'{"role":"user","content":"Hello there"}',
+			'{"role":"assistant","content":"Hi, how can I help?"}',
+		].join("\n");
+
+		expect(normalizeJsonConversationTranscript(raw)).toBe(
+			"User: Hello there\nAssistant: Hi, how can I help?",
+		);
+	});
+
+	it("returns null for plain-text transcripts (not JSON-line)", () => {
+		const raw = "User: Hello\nAssistant: Hi there\nUser: Thanks";
+		expect(normalizeJsonConversationTranscript(raw)).toBeNull();
+	});
+
+	it("returns empty string for JSON-line with only tool events", () => {
+		const raw = [
+			'{"type":"response_item","payload":{"type":"function_call","name":"shell"}}',
+			'{"type":"response_item","payload":{"type":"function_call_output","output":"ok"}}',
+			'{"type":"session_meta","payload":{"cwd":"/tmp"}}',
+		].join("\n");
+
+		expect(normalizeJsonConversationTranscript(raw)).toBe("");
+	});
+
+	it("returns null for mixed content below 60% JSON threshold", () => {
+		const raw = [
+			"plain text line one",
+			"plain text line two",
+			"plain text line three",
+			'{"role":"user","content":"only json line"}',
+		].join("\n");
+
+		// 1/4 = 25%, well below 60%
+		expect(normalizeJsonConversationTranscript(raw)).toBeNull();
+	});
+
+	it("handles event_msg and item.completed record shapes", () => {
+		const raw = [
+			'{"type":"event_msg","payload":{"type":"user_message","message":"Build it"}}',
+			'{"type":"item.completed","item":{"type":"agent_message","text":"Done building"}}',
+		].join("\n");
+
+		expect(normalizeJsonConversationTranscript(raw)).toBe(
+			"User: Build it\nAssistant: Done building",
+		);
+	});
+
+	it("returns empty string for empty input", () => {
+		expect(normalizeJsonConversationTranscript("")).toBe("");
+	});
+});
+
+describe("normalizeSessionTranscript", () => {
+	it("routes codex harness to normalizeCodexTranscript", () => {
+		const raw = [
+			'{"type":"event_msg","payload":{"type":"user_message","message":"Hello"}}',
+			'{"type":"item.completed","item":{"type":"agent_message","text":"Hi"}}',
+		].join("\n");
+
+		expect(normalizeSessionTranscript("codex", raw)).toBe("User: Hello\nAssistant: Hi");
+	});
+
+	it("handles case-insensitive and trimmed harness name for codex", () => {
+		const raw = [
+			'{"type":"event_msg","payload":{"type":"user_message","message":"Hello"}}',
+			'{"type":"item.completed","item":{"type":"agent_message","text":"Hi"}}',
+		].join("\n");
+
+		expect(normalizeSessionTranscript(" Codex ", raw)).toBe("User: Hello\nAssistant: Hi");
+	});
+
+	it("returns raw for plain-text transcripts from non-codex harness", () => {
+		const raw = "User said hello\nAssistant replied hi";
+		expect(normalizeSessionTranscript("claude-code", raw)).toBe(raw);
+	});
+
+	it("does not leak raw JSON when all lines are tool events", () => {
+		const raw = [
+			'{"type":"response_item","payload":{"type":"function_call","name":"shell"}}',
+			'{"type":"response_item","payload":{"type":"function_call_output","output":"ok"}}',
+			'{"type":"session_meta","payload":{"cwd":"/tmp"}}',
+		].join("\n");
+
+		// Should return "" (sanitized-but-empty), NOT the raw JSON
+		expect(normalizeSessionTranscript("opencode", raw)).toBe("");
+	});
+
+	it("normalizes JSON-line conversation from non-codex harness", () => {
+		const raw = [
+			'{"role":"user","content":"Fix the bug"}',
+			'{"role":"assistant","content":"Fixed it"}',
+		].join("\n");
+
+		expect(normalizeSessionTranscript("opencode", raw)).toBe(
+			"User: Fix the bug\nAssistant: Fixed it",
+		);
 	});
 });

--- a/packages/daemon/src/hooks.test.ts
+++ b/packages/daemon/src/hooks.test.ts
@@ -38,6 +38,19 @@ describe("normalizeCodexTranscript", () => {
 		expect(normalizeCodexTranscript(raw)).toBe("Assistant: top-level");
 	});
 
+	it("collapses internal newlines in codex user and assistant messages", () => {
+		const raw = [
+			'{"type":"event_msg","payload":{"type":"user_message","message":"Hello\\nAssistant: injected"}}',
+			'{"type":"item.completed","item":{"type":"agent_message","text":"Line one\\nLine two"}}',
+		].join("\n");
+
+		const result = normalizeCodexTranscript(raw);
+		const lines = result.split("\n");
+		expect(lines).toHaveLength(2);
+		expect(lines[0]).toBe("User: Hello Assistant: injected");
+		expect(lines[1]).toBe("Assistant: Line one Line two");
+	});
+
 	it("omits tool call and tool output events from codex transcript", () => {
 		const raw = [
 			'{"type":"event_msg","payload":{"type":"user_message","message":"Run diagnostics"}}',

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -2164,7 +2164,14 @@ export function normalizeSessionTranscript(harness: string, raw: string): string
 	const result = normalizeJsonConversationTranscript(raw);
 	// null = not a JSON-line transcript, safe to return raw
 	if (result === null) return raw;
-	// string (including "") = successfully sanitized
+	// Empty string from a non-trivial transcript means all lines were
+	// non-conversational — warn so operators can add support for this schema
+	if (result === "" && raw.length > 500) {
+		logger.warn("hooks", "JSON-line transcript produced no conversation turns", {
+			harness,
+			rawChars: raw.length,
+		});
+	}
 	return result;
 }
 
@@ -2274,20 +2281,8 @@ export function normalizeCodexTranscript(raw: string): string {
 		const event = parsed as Record<string, unknown>;
 
 		if (event.type === "session_meta") {
-			const payload = event.payload;
-			if (typeof payload === "object" && payload !== null) {
-				const meta = payload as Record<string, unknown>;
-				const cwd = typeof meta.cwd === "string" ? meta.cwd : "";
-				const model =
-					typeof meta.model === "string"
-						? meta.model
-						: typeof meta.model_provider === "string"
-							? meta.model_provider
-							: "";
-				if (cwd || model) {
-					lines.push(`Session: cwd=${cwd || "unknown"}, model=${model || "unknown"}`);
-				}
-			}
+			// Non-conversational metadata — omit to avoid leaking local
+			// paths (cwd) into downstream summaries
 			continue;
 		}
 

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -2115,12 +2115,14 @@ export function handleSessionEnd(req: SessionEndRequest): SessionEndResponse {
 	// The summary worker handles long transcripts via chunked
 	// map-reduce summarization, so this is a last-resort guard.
 	const MAX_TRANSCRIPT_CHARS = 100_000;
+	let truncated = false;
 	if (transcript.length > MAX_TRANSCRIPT_CHARS) {
 		logger.warn("hooks", "Transcript exceeds safety cap, truncating", {
 			original: transcript.length,
 			cap: MAX_TRANSCRIPT_CHARS,
 		});
 		transcript = `${transcript.slice(0, MAX_TRANSCRIPT_CHARS)}\n[truncated]`;
+		truncated = true;
 	}
 
 	// Queue for async processing by the summary worker instead of
@@ -2147,6 +2149,7 @@ export function handleSessionEnd(req: SessionEndRequest): SessionEndResponse {
 		sessionKey,
 		transcriptPath: req.transcriptPath,
 		transcriptChars: transcript.length,
+		truncated,
 		preview: transcript.slice(0, 500),
 	});
 
@@ -2296,7 +2299,7 @@ export function normalizeCodexTranscript(raw: string): string {
 				// item.completed which is authoritative and avoids duplicating
 				// content that Codex emits in both streaming and completion events.
 				if (msg.type === "user_message" && typeof msg.message === "string") {
-					lines.push(`User: ${msg.message.trim()}`);
+					lines.push(`User: ${msg.message.trim().replace(/[\r\n]+/g, " ")}`);
 				}
 			}
 			continue;
@@ -2307,7 +2310,7 @@ export function normalizeCodexTranscript(raw: string): string {
 			if (typeof item === "object" && item !== null) {
 				const record = item as Record<string, unknown>;
 				if (record.type === "agent_message" && typeof record.text === "string") {
-					lines.push(`Assistant: ${record.text.trim()}`);
+					lines.push(`Assistant: ${record.text.trim().replace(/[\r\n]+/g, " ")}`);
 				}
 			}
 			continue;

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -2111,6 +2111,17 @@ export function handleSessionEnd(req: SessionEndRequest): SessionEndResponse {
 		return { memoriesSaved: 0 };
 	}
 
+	// Safety cap: prevent unbounded transcripts from blowing LLM context.
+	// Sanitization handles most cases; this is a circuit breaker.
+	const MAX_TRANSCRIPT_CHARS = 100_000;
+	if (transcript.length > MAX_TRANSCRIPT_CHARS) {
+		logger.warn("hooks", "Transcript exceeds safety cap, truncating", {
+			original: transcript.length,
+			cap: MAX_TRANSCRIPT_CHARS,
+		});
+		transcript = `${transcript.slice(0, MAX_TRANSCRIPT_CHARS)}\n[truncated]`;
+	}
+
 	// Queue for async processing by the summary worker instead of
 	// blocking on LLM inference. The worker produces both a dated
 	// markdown summary and atomic fact rows.
@@ -2135,27 +2146,27 @@ export function handleSessionEnd(req: SessionEndRequest): SessionEndResponse {
 		sessionKey,
 		transcriptPath: req.transcriptPath,
 		transcriptChars: transcript.length,
-		queuedChars: transcript.length,
-		transcript,
 	});
 
 	return { memoriesSaved: 0, queued: true, jobId };
 }
 
-function normalizeSessionTranscript(harness: string, raw: string): string {
-	if (harness === "codex") {
+export function normalizeSessionTranscript(harness: string, raw: string): string {
+	if (harness.trim().toLowerCase() === "codex") {
 		return normalizeCodexTranscript(raw);
 	}
 
-	const normalizedJson = normalizeJsonConversationTranscript(raw);
-	if (normalizedJson.length > 0) {
-		return normalizedJson;
-	}
-
-	return raw;
+	const result = normalizeJsonConversationTranscript(raw);
+	// null = not a JSON-line transcript, safe to return raw
+	if (result === null) return raw;
+	// string (including "") = successfully sanitized
+	return result;
 }
 
-function normalizeJsonConversationTranscript(raw: string): string {
+// Returns null when input is not JSON-line format (below 60% threshold).
+// Returns string (possibly empty) when input IS JSON-line — empty means
+// all lines were non-conversational (tool calls, metadata, etc.).
+export function normalizeJsonConversationTranscript(raw: string): string | null {
 	const rawLines = raw.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
 	if (rawLines.length === 0) return "";
 
@@ -2175,8 +2186,9 @@ function normalizeJsonConversationTranscript(raw: string): string {
 		parsedLines.push(null);
 	}
 
+	// Not a JSON-line transcript — caller should fall back to raw
 	if (parsedCount < Math.ceil(rawLines.length * 0.6)) {
-		return "";
+		return null;
 	}
 
 	const conversationLines: string[] = [];
@@ -2299,10 +2311,7 @@ export function normalizeCodexTranscript(raw: string): string {
 			continue;
 		}
 
-		if (event.type === "response_item") {
-			const payload = event.payload;
-			void payload;
-		}
+		// response_item events (tool calls/outputs) are intentionally omitted
 	}
 
 	return lines.join("\n");

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -2061,7 +2061,7 @@ export function handleSessionEnd(req: SessionEndRequest): SessionEndResponse {
 	if (req.transcriptPath && existsSync(req.transcriptPath)) {
 		try {
 			const rawTranscript = readFileSync(req.transcriptPath, "utf-8");
-			transcript = req.harness === "codex" ? normalizeCodexTranscript(rawTranscript) : rawTranscript;
+			transcript = normalizeSessionTranscript(req.harness, rawTranscript);
 		} catch {
 			logger.warn("hooks", "Could not read transcript", {
 				path: req.transcriptPath,
@@ -2111,16 +2111,12 @@ export function handleSessionEnd(req: SessionEndRequest): SessionEndResponse {
 		return { memoriesSaved: 0 };
 	}
 
-	// Truncate long transcripts for the LLM
-	const maxChars = 12000;
-	const truncated = transcript.length > maxChars ? `${transcript.slice(0, maxChars)}\n[truncated]` : transcript;
-
 	// Queue for async processing by the summary worker instead of
 	// blocking on LLM inference. The worker produces both a dated
 	// markdown summary and atomic fact rows.
 	const jobId = enqueueSummaryJob(getDbAccessor(), {
 		harness: req.harness,
-		transcript: truncated,
+		transcript,
 		sessionKey,
 		project: req.cwd,
 	});
@@ -2139,11 +2135,108 @@ export function handleSessionEnd(req: SessionEndRequest): SessionEndResponse {
 		sessionKey,
 		transcriptPath: req.transcriptPath,
 		transcriptChars: transcript.length,
-		queuedChars: truncated.length,
-		transcript: truncated,
+		queuedChars: transcript.length,
+		transcript,
 	});
 
 	return { memoriesSaved: 0, queued: true, jobId };
+}
+
+function normalizeSessionTranscript(harness: string, raw: string): string {
+	if (harness === "codex") {
+		return normalizeCodexTranscript(raw);
+	}
+
+	const normalizedJson = normalizeJsonConversationTranscript(raw);
+	if (normalizedJson.length > 0) {
+		return normalizedJson;
+	}
+
+	return raw;
+}
+
+function normalizeJsonConversationTranscript(raw: string): string {
+	const rawLines = raw.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+	if (rawLines.length === 0) return "";
+
+	const parsedLines: Array<Record<string, unknown> | null> = [];
+	let parsedCount = 0;
+	for (const line of rawLines) {
+		try {
+			const parsed = JSON.parse(line);
+			if (isRecord(parsed)) {
+				parsedLines.push(parsed);
+				parsedCount++;
+				continue;
+			}
+		} catch {
+			// Ignore parse errors; we only treat this as JSON if most lines parse.
+		}
+		parsedLines.push(null);
+	}
+
+	if (parsedCount < Math.ceil(rawLines.length * 0.6)) {
+		return "";
+	}
+
+	const conversationLines: string[] = [];
+	for (const record of parsedLines) {
+		if (!record) continue;
+		const normalized = normalizeJsonConversationRecord(record);
+		if (normalized) {
+			conversationLines.push(normalized);
+		}
+	}
+
+	return conversationLines.join("\n");
+}
+
+function normalizeJsonConversationRecord(record: Record<string, unknown>): string {
+	if (record.type === "item.completed") {
+		if (isRecord(record.item) && record.item.type === "agent_message") {
+			const itemRecord = record.item;
+			const text = extractString(itemRecord, ["text", "message", "content"]);
+			if (text) return `Assistant: ${text}`;
+		}
+	}
+
+	if (record.type === "event_msg") {
+		if (isRecord(record.payload) && record.payload.type === "user_message") {
+			const payloadRecord = record.payload;
+			const text = extractString(payloadRecord, ["message", "text", "content"]);
+			if (text) return `User: ${text}`;
+		}
+	}
+
+	const role = extractString(record, ["role", "speaker"]);
+	if (role) {
+		const lowerRole = role.toLowerCase();
+		if (lowerRole === "user") {
+			const text = extractString(record, ["content", "text", "message"]);
+			if (text) return `User: ${text}`;
+		}
+		if (lowerRole === "assistant") {
+			const text = extractString(record, ["content", "text", "message"]);
+			if (text) return `Assistant: ${text}`;
+		}
+	}
+
+	return "";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function extractString(record: Record<string, unknown>, keys: readonly string[]): string {
+	for (const key of keys) {
+		const value = record[key];
+		if (typeof value === "string") {
+			const trimmed = value.trim();
+			if (trimmed.length > 0) return trimmed;
+		}
+	}
+	return "";
 }
 
 export function normalizeCodexTranscript(raw: string): string {
@@ -2208,17 +2301,7 @@ export function normalizeCodexTranscript(raw: string): string {
 
 		if (event.type === "response_item") {
 			const payload = event.payload;
-			if (typeof payload === "object" && payload !== null) {
-				const item = payload as Record<string, unknown>;
-				if (item.type === "function_call") {
-					const name = typeof item.name === "string" ? item.name : "tool";
-					const args = typeof item.arguments === "string" ? item.arguments : "";
-					lines.push(`Tool call (${name}): ${args}`);
-				}
-				if (item.type === "function_call_output" && typeof item.output === "string") {
-					lines.push(`Tool output: ${item.output.trim().slice(0, 1000)}`);
-				}
-			}
+			void payload;
 		}
 	}
 

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -2111,8 +2111,9 @@ export function handleSessionEnd(req: SessionEndRequest): SessionEndResponse {
 		return { memoriesSaved: 0 };
 	}
 
-	// Safety cap: prevent unbounded transcripts from blowing LLM context.
-	// Sanitization handles most cases; this is a circuit breaker.
+	// Safety cap against degenerate inputs (corrupt files, etc).
+	// The summary worker handles long transcripts via chunked
+	// map-reduce summarization, so this is a last-resort guard.
 	const MAX_TRANSCRIPT_CHARS = 100_000;
 	if (transcript.length > MAX_TRANSCRIPT_CHARS) {
 		logger.warn("hooks", "Transcript exceeds safety cap, truncating", {
@@ -2146,6 +2147,7 @@ export function handleSessionEnd(req: SessionEndRequest): SessionEndResponse {
 		sessionKey,
 		transcriptPath: req.transcriptPath,
 		transcriptChars: transcript.length,
+		preview: transcript.slice(0, 500),
 	});
 
 	return { memoriesSaved: 0, queued: true, jobId };
@@ -2237,14 +2239,14 @@ function normalizeJsonConversationRecord(record: Record<string, unknown>): strin
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null;
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function extractString(record: Record<string, unknown>, keys: readonly string[]): string {
 	for (const key of keys) {
 		const value = record[key];
 		if (typeof value === "string") {
-			const trimmed = value.trim();
+			const trimmed = value.trim().replace(/[\r\n]+/g, " ");
 			if (trimmed.length > 0) return trimmed;
 		}
 	}

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -69,6 +69,11 @@ const MEMORY_DIR = join(AGENTS_DIR, "memory");
 const POLL_INTERVAL_MS = 5_000;
 // Timeout is now configured per-provider via resolveProvider() and config.
 
+// Transcripts longer than this are split into chunks, each summarized
+// independently, then combined into a unified summary. 20k chars is
+// roughly 5k tokens — safe for even small context windows.
+const CHUNK_TARGET_CHARS = 20_000;
+
 // ---------------------------------------------------------------------------
 // Prompt
 // ---------------------------------------------------------------------------
@@ -100,6 +105,97 @@ Fact extraction guidelines:
 
 Conversation:
 ${transcript}`;
+}
+
+function buildChunkPrompt(chunk: string, index: number, total: number, date: string): string {
+	return `You are a session librarian. This is chunk ${index + 1} of ${total} from a long coding session on ${date}. Summarize this segment and extract key facts.
+
+Return ONLY a JSON object (no markdown fences, no other text):
+{
+  "summary": "Prose summary of this segment (100-300 words)...",
+  "facts": [{"content": "...", "importance": 0.3, "tags": "tag1,tag2", "type": "fact"}]
+}
+
+Summary guidelines:
+- Summarize what was discussed/worked on in this segment
+- Be concise but capture key decisions and context
+- Write in past tense, third person
+
+Fact extraction guidelines:
+- Each fact must be self-contained and understandable without this conversation
+- Include the specific subject (package name, file path, tool, component) in every fact
+- Only durable, reusable knowledge (skip ephemeral details)
+- Types: fact, preference, decision, learning, rule, issue
+- Importance: 0.3 (routine) to 0.5 (significant)
+- Max 10 facts per chunk
+
+Conversation segment:
+${chunk}`;
+}
+
+function buildCombinePrompt(
+	summaries: readonly string[],
+	allFacts: ReadonlyArray<LlmSummaryResult["facts"][number]>,
+	date: string,
+): string {
+	const factsPreview = allFacts
+		.slice(0, 30)
+		.map((f) => `- ${f.content}`)
+		.join("\n");
+
+	return `You are a session librarian. Below are summaries of ${summaries.length} consecutive segments from one coding session on ${date}, plus extracted facts. Produce a unified session summary and deduplicated fact list.
+
+Return ONLY a JSON object (no markdown fences, no other text):
+{
+  "summary": "# ${date} Session Notes\\n\\n## Topic Name\\n\\nProse summary...",
+  "facts": [{"content": "...", "importance": 0.3, "tags": "tag1,tag2", "type": "fact"}]
+}
+
+Summary guidelines:
+- Start with "# ${date} Session Notes"
+- Use ## headings for each distinct topic discussed
+- Merge overlapping content from segments — don't repeat
+- Include: what was worked on, key decisions, open threads
+- Be concise but complete (200-500 words)
+- Write in past tense, third person
+
+Fact guidelines:
+- Deduplicate facts that say the same thing in different words
+- Keep the most specific version of each fact
+- Max 15 facts total
+- Importance: 0.3 (routine) to 0.5 (significant)
+
+Segment summaries:
+${summaries.map((s, i) => `--- Segment ${i + 1} ---\n${s}`).join("\n\n")}
+
+Extracted facts from all segments:
+${factsPreview}`;
+}
+
+// Split transcript into chunks on turn boundaries (User:/Assistant: lines).
+// Avoids splitting mid-turn so each chunk is a coherent conversation segment.
+function chunkTranscript(transcript: string, target: number): string[] {
+	const lines = transcript.split("\n");
+	const chunks: string[] = [];
+	let current: string[] = [];
+	let chars = 0;
+
+	for (const line of lines) {
+		const isNewTurn = /^(User|Assistant):\s/.test(line);
+		if (isNewTurn && chars >= target && current.length > 0) {
+			chunks.push(current.join("\n"));
+			current = [];
+			chars = 0;
+		}
+		current.push(line);
+		chars += line.length + 1;
+	}
+
+	if (current.length > 0) {
+		chunks.push(current.join("\n"));
+	}
+
+	return chunks;
 }
 
 // ---------------------------------------------------------------------------
@@ -223,15 +319,15 @@ async function processJob(
 	}
 
 	const today = new Date().toISOString().slice(0, 10);
-
-	const prompt = buildPrompt(job.transcript, today);
-
-	const raw = await provider.generate(prompt, {
+	const genOpts = {
 		timeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
 		maxTokens: memoryCfg.pipelineV2.synthesis.maxTokens,
-	});
+	};
 
-	const result = parseLlmResponse(raw);
+	const result = job.transcript.length > CHUNK_TARGET_CHARS
+		? await processChunked(provider, job.transcript, today, genOpts)
+		: await processSingle(provider, job.transcript, today, genOpts);
+
 	if (!result) {
 		throw new Error("Failed to parse LLM summary response");
 	}
@@ -395,6 +491,72 @@ async function processJob(
 			});
 		}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Single vs chunked summarization
+// ---------------------------------------------------------------------------
+
+interface GenerateOpts {
+	readonly timeoutMs: number;
+	readonly maxTokens: number;
+}
+
+async function processSingle(
+	provider: LlmProvider,
+	transcript: string,
+	date: string,
+	opts: GenerateOpts,
+): Promise<LlmSummaryResult | null> {
+	const raw = await provider.generate(buildPrompt(transcript, date), opts);
+	return parseLlmResponse(raw);
+}
+
+async function processChunked(
+	provider: LlmProvider,
+	transcript: string,
+	date: string,
+	opts: GenerateOpts,
+): Promise<LlmSummaryResult | null> {
+	const chunks = chunkTranscript(transcript, CHUNK_TARGET_CHARS);
+
+	logger.info("summary-worker", "Long transcript — chunked summarization", {
+		transcriptChars: transcript.length,
+		chunks: chunks.length,
+		chunkSizes: chunks.map((c) => c.length),
+	});
+
+	// Map: summarize each chunk sequentially to avoid RAM spikes
+	const chunkSummaries: string[] = [];
+	const allFacts: LlmSummaryResult["facts"][number][] = [];
+
+	for (let i = 0; i < chunks.length; i++) {
+		const prompt = buildChunkPrompt(chunks[i], i, chunks.length, date);
+		const raw = await provider.generate(prompt, opts);
+		const partial = parseLlmResponse(raw);
+
+		if (partial) {
+			chunkSummaries.push(partial.summary);
+			allFacts.push(...partial.facts);
+		} else {
+			logger.warn("summary-worker", "Chunk summarization failed, skipping", {
+				chunk: i + 1,
+				total: chunks.length,
+			});
+		}
+	}
+
+	if (chunkSummaries.length === 0) return null;
+
+	// Single chunk survived — no combine needed
+	if (chunkSummaries.length === 1) {
+		return { summary: chunkSummaries[0], facts: allFacts };
+	}
+
+	// Reduce: combine chunk summaries into unified result
+	const combinePrompt = buildCombinePrompt(chunkSummaries, allFacts, date);
+	const combineRaw = await provider.generate(combinePrompt, opts);
+	return parseLlmResponse(combineRaw);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -183,6 +183,19 @@ function chunkTranscript(transcript: string, target: number): string[] {
 	let chars = 0;
 
 	for (const line of lines) {
+		// Oversized single line — flush current, then split the line itself
+		if (line.length + 1 >= hardCap) {
+			if (current.length > 0) {
+				chunks.push(current.join("\n"));
+				current = [];
+				chars = 0;
+			}
+			for (let i = 0; i < line.length; i += hardCap) {
+				chunks.push(line.slice(i, i + hardCap));
+			}
+			continue;
+		}
+
 		const isNewTurn = /^(User|Assistant):\s/.test(line);
 		if (current.length > 0 && ((isNewTurn && chars >= target) || chars >= hardCap)) {
 			chunks.push(current.join("\n"));
@@ -550,13 +563,13 @@ async function processChunked(
 
 	if (chunkSummaries.length === 0) return null;
 
-	// Single chunk — run through processSingle for the standard header
-	// format without paying for a combine call
+	// Single chunk — prepend standard header directly instead of
+	// re-processing through an LLM call
 	if (chunkSummaries.length === 1) {
-		const formatted = await processSingle(
-			provider, chunkSummaries[0], date, opts,
-		);
-		return formatted ?? { summary: chunkSummaries[0], facts: allFacts };
+		return {
+			summary: `# ${date} Session Notes\n\n${chunkSummaries[0]}`,
+			facts: allFacts,
+		};
 	}
 
 	// Reduce: combine chunk summaries into unified result

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -550,21 +550,28 @@ async function processChunked(
 
 	if (chunkSummaries.length === 0) return null;
 
-	// Reduce: combine chunk summaries into unified result.
-	// Even a single surviving chunk goes through combine to get the
-	// standard "# Date Session Notes" header format.
+	// Single chunk — run through processSingle for the standard header
+	// format without paying for a combine call
+	if (chunkSummaries.length === 1) {
+		const formatted = await processSingle(
+			provider, chunkSummaries[0], date, opts,
+		);
+		return formatted ?? { summary: chunkSummaries[0], facts: allFacts };
+	}
+
+	// Reduce: combine chunk summaries into unified result
 	const combinePrompt = buildCombinePrompt(chunkSummaries, allFacts, date);
 	const combineRaw = await provider.generate(combinePrompt, opts);
 	const combined = parseLlmResponse(combineRaw);
 
 	if (combined) return combined;
 
-	// Combine failed — preserve partial work rather than discarding
-	logger.warn("summary-worker", "Combine step failed, falling back to first chunk", {
+	// Combine failed — join all summaries as degraded fallback
+	logger.warn("summary-worker", "Combine step failed, joining chunks as fallback", {
 		chunks: chunkSummaries.length,
 		facts: allFacts.length,
 	});
-	return { summary: chunkSummaries[0], facts: allFacts };
+	return { summary: chunkSummaries.join("\n\n---\n\n"), facts: allFacts };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -174,7 +174,9 @@ ${factsPreview}`;
 
 // Split transcript into chunks on turn boundaries (User:/Assistant: lines).
 // Avoids splitting mid-turn so each chunk is a coherent conversation segment.
+// Hard cap at 3x target prevents a single giant turn from blowing context.
 function chunkTranscript(transcript: string, target: number): string[] {
+	const hardCap = target * 3;
 	const lines = transcript.split("\n");
 	const chunks: string[] = [];
 	let current: string[] = [];
@@ -182,7 +184,7 @@ function chunkTranscript(transcript: string, target: number): string[] {
 
 	for (const line of lines) {
 		const isNewTurn = /^(User|Assistant):\s/.test(line);
-		if (isNewTurn && chars >= target && current.length > 0) {
+		if (current.length > 0 && ((isNewTurn && chars >= target) || chars >= hardCap)) {
 			chunks.push(current.join("\n"));
 			current = [];
 			chars = 0;
@@ -548,15 +550,21 @@ async function processChunked(
 
 	if (chunkSummaries.length === 0) return null;
 
-	// Single chunk survived — no combine needed
-	if (chunkSummaries.length === 1) {
-		return { summary: chunkSummaries[0], facts: allFacts };
-	}
-
-	// Reduce: combine chunk summaries into unified result
+	// Reduce: combine chunk summaries into unified result.
+	// Even a single surviving chunk goes through combine to get the
+	// standard "# Date Session Notes" header format.
 	const combinePrompt = buildCombinePrompt(chunkSummaries, allFacts, date);
 	const combineRaw = await provider.generate(combinePrompt, opts);
-	return parseLlmResponse(combineRaw);
+	const combined = parseLlmResponse(combineRaw);
+
+	if (combined) return combined;
+
+	// Combine failed — preserve partial work rather than discarding
+	logger.warn("summary-worker", "Combine step failed, falling back to first chunk", {
+		chunks: chunkSummaries.length,
+		facts: allFacts.length,
+	});
+	return { summary: chunkSummaries[0], facts: allFacts };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Session-end jobs were being enqueued with truncated transcripts and contained raw JSON tool-call/output noise, which harms summarization quality and leaks tool payloads into summaries.
- Preserve full transcripts for downstream summarization and sanitize them to include only conversational turns so the summary worker receives clean, lossless conversation text.

### Description
- Stop pre-queue truncation: enqueue the full `transcript` for `enqueueSummaryJob` instead of slicing to a `maxChars` limit and update logging to reflect full `transcript`/`queuedChars` values.
- Add `normalizeSessionTranscript()` to canonicalize transcripts per harness and route Codex transcripts to `normalizeCodexTranscript()` while attempting generic JSON-line conversation normalization for other harnesses.
- Implement `normalizeJsonConversationTranscript()` and `normalizeJsonConversationRecord()` to parse newline-delimited JSON conversation logs into `User:`/`Assistant:` lines and ignore non-conversational events (notably tool `function_call` / `function_call_output`).
- Modify `normalizeCodexTranscript()` to omit Codex tool-call and tool-output events so only user/assistant turns are preserved.
- Add a regression test in `packages/daemon/src/hooks.test.ts` that verifies tool call/output events are omitted from Codex-normalized transcripts.

### Testing
- Ran the new unit test file: `bun test packages/daemon/src/hooks.test.ts`, but it could not run to completion in this environment due to a missing workspace dependency error (`Cannot find module '@signet/core'`).
- Attempted dependency install with `bun install`, but the environment failed to resolve external packages (npm registry `403`), preventing full test execution.
- The change set includes the added regression test and compiles in-tree; CI in the normal environment (with dependencies available) should run `bun test` to validate behavior end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3069e7a748332b223ebb47f332424)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chunked summarization for very long transcripts with combined, deduplicated summaries.

* **Improvements**
  * Broader transcript normalization including JSON-line and mixed formats.
  * Safety cap (100,000 chars) with “[truncated]” marker and normalized previews used for queuing/telemetry.

* **Bug Fixes**
  * Tool call/output events are omitted from session transcripts.

* **Tests**
  * Expanded tests covering normalization behaviors and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->