### PR TITLE
fix(daemon): remove hardcoded qwen3:4b fallback model

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -146,6 +146,7 @@ import {
 	createOllamaProvider,
 	createOpenCodeProvider,
 	ensureOpenCodeServer,
+	resolveDefaultOllamaFallbackMaxContextTokens,
 	stopOpenCodeServer,
 } from "./pipeline/provider";
 import { type RerankCandidate, noopReranker, rerank } from "./pipeline/reranker";
@@ -9275,6 +9276,8 @@ async function main() {
 		memoryCfg.pipelineV2.extraction.endpoint,
 		"http://127.0.0.1:4096",
 	);
+	const ollamaFallbackMaxContextTokens =
+		resolveDefaultOllamaFallbackMaxContextTokens();
 	const extractionOpenCodeShouldManage = isManagedOpenCodeLocalEndpoint(
 		extractionOpenCodeBaseUrl,
 	);
@@ -9355,6 +9358,9 @@ async function main() {
 	if (effectiveExtractionProvider === "ollama" && memoryCfg.pipelineV2.extraction.provider !== "ollama") {
 		effectiveExtractionModel = undefined;
 	}
+	const usingExtractionOllamaFallback =
+		effectiveExtractionProvider === "ollama" &&
+		memoryCfg.pipelineV2.extraction.provider !== "ollama";
 	providerRuntimeResolution.extraction = {
 		configured: providerHints.extraction,
 		resolved: memoryCfg.pipelineV2.extraction.provider,
@@ -9392,7 +9398,9 @@ async function main() {
 				? createOpenCodeProvider({
 						model: effectiveExtractionModel || "anthropic/claude-haiku-4-5-20251001",
 						baseUrl: extractionOpenCodeBaseUrl,
-						ollamaFallbackBaseUrl: "http://127.0.0.1:11434",
+						ollamaFallbackBaseUrl: extractionOllamaFallbackBaseUrl,
+						ollamaFallbackMaxContextTokens:
+							ollamaFallbackMaxContextTokens,
 						defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 					})
 				: effectiveExtractionProvider === "claude-code"
@@ -9406,9 +9414,17 @@ async function main() {
 								defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 							})
 						: createOllamaProvider({
-								model: effectiveExtractionModel || "qwen3:4b",
+								...(effectiveExtractionModel
+									? { model: effectiveExtractionModel }
+									: {}),
 								baseUrl: extractionOllamaFallbackBaseUrl,
 								defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
+								...(usingExtractionOllamaFallback
+									? {
+										maxContextTokens:
+											ollamaFallbackMaxContextTokens,
+									}
+									: {}),
 							});
 	initLlmProvider(llmProvider);
 
@@ -9495,6 +9511,9 @@ async function main() {
 		if (effectiveSynthesisProvider === "ollama" && memoryCfg.pipelineV2.synthesis.provider !== "ollama") {
 			effectiveSynthesisModel = undefined;
 		}
+		const usingSynthesisOllamaFallback =
+			effectiveSynthesisProvider === "ollama" &&
+			memoryCfg.pipelineV2.synthesis.provider !== "ollama";
 
 		const synthesisProvider =
 			effectiveSynthesisProvider === "anthropic" && anthropicApiKey
@@ -9507,7 +9526,9 @@ async function main() {
 					? createOpenCodeProvider({
 							model: effectiveSynthesisModel || "anthropic/claude-haiku-4-5-20251001",
 							baseUrl: synthesisOpenCodeBaseUrl,
-							ollamaFallbackBaseUrl: "http://127.0.0.1:11434",
+							ollamaFallbackBaseUrl: synthesisOllamaFallbackBaseUrl,
+							ollamaFallbackMaxContextTokens:
+								ollamaFallbackMaxContextTokens,
 							defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
 						})
 					: effectiveSynthesisProvider === "claude-code"
@@ -9516,9 +9537,17 @@ async function main() {
 								defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
 							})
 					: createOllamaProvider({
-							model: effectiveSynthesisModel || "qwen3:4b",
+							...(effectiveSynthesisModel
+								? { model: effectiveSynthesisModel }
+								: {}),
 							baseUrl: synthesisOllamaFallbackBaseUrl,
 							defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
+							...(usingSynthesisOllamaFallback
+								? {
+									maxContextTokens:
+										ollamaFallbackMaxContextTokens,
+								}
+								: {}),
 						});
 		initSynthesisProvider(synthesisProvider);
 	} else {

--- a/packages/daemon/src/pipeline/provider.test.ts
+++ b/packages/daemon/src/pipeline/provider.test.ts
@@ -50,21 +50,37 @@ function streamFromString(value: string): ReadableStream<Uint8Array> {
 describe("createOllamaProvider", () => {
 	afterEach(() => restoreFetch());
 
+	function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
+		if (typeof value !== "object" || value === null) return false;
+		const then = Reflect.get(value, "then");
+		return typeof then === "function";
+	}
+
 	function withEnvOverride<T>(
 		key: "SIGNET_OLLAMA_FALLBACK_MODEL" | "SIGNET_OLLAMA_FALLBACK_MAX_CTX",
 		value: string,
-		fn: () => T,
-	): T {
+		fn: () => T | Promise<T>,
+	): T | Promise<T> {
 		const prev = process.env[key];
 		process.env[key] = value;
-		try {
-			return fn();
-		} finally {
+		const restore = (): void => {
 			if (prev === undefined) {
 				delete process.env[key];
-			} else {
-				process.env[key] = prev;
+				return;
 			}
+			process.env[key] = prev;
+		};
+
+		try {
+			const result = fn();
+			if (isPromiseLike<T>(result)) {
+				return Promise.resolve(result).finally(restore);
+			}
+			restore();
+			return result;
+		} catch (error) {
+			restore();
+			throw error;
 		}
 	}
 
@@ -98,6 +114,16 @@ describe("createOllamaProvider", () => {
 			const provider = createOllamaProvider();
 			expect(provider.name).toBe("ollama:llama3.1:8b");
 		});
+	});
+
+	it("withEnvOverride keeps env set for async callbacks", async () => {
+		const key = "SIGNET_OLLAMA_FALLBACK_MODEL";
+		const prev = process.env[key];
+		await withEnvOverride(key, "async-test-model", async () => {
+			await Promise.resolve();
+			expect(process.env[key]).toBe("async-test-model");
+		});
+		expect(process.env[key]).toBe(prev);
 	});
 
 	it("generate() returns trimmed response on success", async () => {

--- a/packages/daemon/src/pipeline/provider.test.ts
+++ b/packages/daemon/src/pipeline/provider.test.ts
@@ -43,6 +43,37 @@ function streamFromString(value: string): ReadableStream<Uint8Array> {
 	});
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseJsonObjectBody(body: BodyInit | null | undefined): Record<string, unknown> {
+	if (typeof body !== "string") {
+		throw new Error("Expected JSON body to be a string");
+	}
+	const parsed: unknown = JSON.parse(body);
+	if (!isRecord(parsed)) {
+		throw new Error("Expected JSON body to parse as an object");
+	}
+	return parsed;
+}
+
+function getObjectField(
+	record: Record<string, unknown>,
+	key: string,
+): Record<string, unknown> | undefined {
+	const value = record[key];
+	return isRecord(value) ? value : undefined;
+}
+
+function getNumberField(
+	record: Record<string, unknown>,
+	key: string,
+): number | undefined {
+	const value = record[key];
+	return typeof value === "number" ? value : undefined;
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -103,6 +134,14 @@ describe("createOllamaProvider", () => {
 
 	it("returns default max context when SIGNET_OLLAMA_FALLBACK_MAX_CTX is invalid", () => {
 		withEnvOverride("SIGNET_OLLAMA_FALLBACK_MAX_CTX", "abc", () => {
+			expect(resolveDefaultOllamaFallbackMaxContextTokens()).toBe(
+				DEFAULT_OLLAMA_FALLBACK_MAX_CONTEXT_TOKENS,
+			);
+		});
+	});
+
+	it("returns default max context when SIGNET_OLLAMA_FALLBACK_MAX_CTX has trailing text", () => {
+		withEnvOverride("SIGNET_OLLAMA_FALLBACK_MAX_CTX", "8192foo", () => {
 			expect(resolveDefaultOllamaFallbackMaxContextTokens()).toBe(
 				DEFAULT_OLLAMA_FALLBACK_MAX_CONTEXT_TOKENS,
 			);
@@ -179,19 +218,20 @@ describe("createOllamaProvider", () => {
 	it("generate() sends maxTokens as num_predict", async () => {
 		let capturedBody: Record<string, unknown> = {};
 		mockFetch(async (_url, init) => {
-			capturedBody = JSON.parse(init?.body as string);
+			capturedBody = parseJsonObjectBody(init?.body);
 			return Response.json({ response: "ok" });
 		});
 
 		const provider = createOllamaProvider({ model: "test-model" });
 		await provider.generate("test", { maxTokens: 100 });
-		expect((capturedBody.options as Record<string, unknown>)?.num_predict).toBe(100);
+		const options = getObjectField(capturedBody, "options");
+		expect(options ? getNumberField(options, "num_predict") : undefined).toBe(100);
 	});
 
 	it("generate() sends maxContextTokens as num_ctx", async () => {
 		let capturedBody: Record<string, unknown> = {};
 		mockFetch(async (_url, init) => {
-			capturedBody = JSON.parse(init?.body as string);
+			capturedBody = parseJsonObjectBody(init?.body);
 			return Response.json({ response: "ok" });
 		});
 
@@ -200,7 +240,23 @@ describe("createOllamaProvider", () => {
 			maxContextTokens: 4096,
 		});
 		await provider.generate("test");
-		expect((capturedBody.options as Record<string, unknown>)?.num_ctx).toBe(4096);
+		const options = getObjectField(capturedBody, "options");
+		expect(options ? getNumberField(options, "num_ctx") : undefined).toBe(4096);
+	});
+
+	it("generate() omits num_ctx when maxContextTokens is non-finite", async () => {
+		let capturedBody: Record<string, unknown> = {};
+		mockFetch(async (_url, init) => {
+			capturedBody = parseJsonObjectBody(init?.body);
+			return Response.json({ response: "ok" });
+		});
+
+		const provider = createOllamaProvider({
+			model: "test-model",
+			maxContextTokens: Number.NaN,
+		});
+		await provider.generate("test");
+		expect(getObjectField(capturedBody, "options")).toBeUndefined();
 	});
 
 	it("available() returns true when /api/tags responds 200", async () => {
@@ -627,7 +683,7 @@ describe("createOpenCodeProvider", () => {
 				return Response.json({ models: [] });
 			}
 			if (url === "http://172.17.0.1:11434/api/generate") {
-				fallbackBody = JSON.parse(init?.body as string) as Record<string, unknown>;
+				fallbackBody = parseJsonObjectBody(init?.body);
 				return Response.json({ response: '{"facts":[],"entities":[]}' });
 			}
 			return new Response("unexpected url", { status: 500 });
@@ -643,8 +699,11 @@ describe("createOpenCodeProvider", () => {
 		expect(result).toBe('{"facts":[],"entities":[]}');
 		expect(seenUrls).toContain("http://172.17.0.1:11434/api/tags");
 		expect(seenUrls).toContain("http://172.17.0.1:11434/api/generate");
+		const fallbackOptions = fallbackBody
+			? getObjectField(fallbackBody, "options")
+			: undefined;
 		expect(
-			((fallbackBody?.options as Record<string, unknown> | undefined)?.num_ctx),
+			fallbackOptions ? getNumberField(fallbackOptions, "num_ctx") : undefined,
 		).toBe(2048);
 	});
 });

--- a/packages/daemon/src/pipeline/provider.test.ts
+++ b/packages/daemon/src/pipeline/provider.test.ts
@@ -5,7 +5,15 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
-import { createOllamaProvider, createClaudeCodeProvider, createCodexProvider, createOpenCodeProvider } from "./provider";
+import {
+	DEFAULT_OLLAMA_FALLBACK_MAX_CONTEXT_TOKENS,
+	createOllamaProvider,
+	createClaudeCodeProvider,
+	createCodexProvider,
+	createOpenCodeProvider,
+	resolveDefaultOllamaFallbackMaxContextTokens,
+	resolveDefaultOllamaFallbackModel,
+} from "./provider";
 
 // ---------------------------------------------------------------------------
 // Fetch mock helpers
@@ -42,6 +50,24 @@ function streamFromString(value: string): ReadableStream<Uint8Array> {
 describe("createOllamaProvider", () => {
 	afterEach(() => restoreFetch());
 
+	function withEnvOverride<T>(
+		key: "SIGNET_OLLAMA_FALLBACK_MODEL" | "SIGNET_OLLAMA_FALLBACK_MAX_CTX",
+		value: string,
+		fn: () => T,
+	): T {
+		const prev = process.env[key];
+		process.env[key] = value;
+		try {
+			return fn();
+		} finally {
+			if (prev === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = prev;
+			}
+		}
+	}
+
 	it("returns a provider with the correct name", () => {
 		const provider = createOllamaProvider({ model: "llama3" });
 		expect(provider.name).toBe("ollama:llama3");
@@ -51,6 +77,27 @@ describe("createOllamaProvider", () => {
 		const provider = createOllamaProvider();
 		expect(provider.name).toContain("ollama:");
 		expect(provider.name.length).toBeGreaterThan("ollama:".length);
+	});
+
+	it("resolves fallback model from SIGNET_OLLAMA_FALLBACK_MODEL", () => {
+		withEnvOverride("SIGNET_OLLAMA_FALLBACK_MODEL", "mistral:7b", () => {
+			expect(resolveDefaultOllamaFallbackModel()).toBe("mistral:7b");
+		});
+	});
+
+	it("returns default max context when SIGNET_OLLAMA_FALLBACK_MAX_CTX is invalid", () => {
+		withEnvOverride("SIGNET_OLLAMA_FALLBACK_MAX_CTX", "abc", () => {
+			expect(resolveDefaultOllamaFallbackMaxContextTokens()).toBe(
+				DEFAULT_OLLAMA_FALLBACK_MAX_CONTEXT_TOKENS,
+			);
+		});
+	});
+
+	it("uses SIGNET_OLLAMA_FALLBACK_MODEL when model is not explicitly configured", () => {
+		withEnvOverride("SIGNET_OLLAMA_FALLBACK_MODEL", "llama3.1:8b", () => {
+			const provider = createOllamaProvider();
+			expect(provider.name).toBe("ollama:llama3.1:8b");
+		});
 	});
 
 	it("generate() returns trimmed response on success", async () => {

--- a/packages/daemon/src/pipeline/provider.test.ts
+++ b/packages/daemon/src/pipeline/provider.test.ts
@@ -115,6 +115,21 @@ describe("createOllamaProvider", () => {
 		expect((capturedBody.options as Record<string, unknown>)?.num_predict).toBe(100);
 	});
 
+	it("generate() sends maxContextTokens as num_ctx", async () => {
+		let capturedBody: Record<string, unknown> = {};
+		mockFetch(async (_url, init) => {
+			capturedBody = JSON.parse(init?.body as string);
+			return Response.json({ response: "ok" });
+		});
+
+		const provider = createOllamaProvider({
+			model: "test-model",
+			maxContextTokens: 4096,
+		});
+		await provider.generate("test");
+		expect((capturedBody.options as Record<string, unknown>)?.num_ctx).toBe(4096);
+	});
+
 	it("available() returns true when /api/tags responds 200", async () => {
 		mockFetch(() => Response.json({ models: [] }));
 
@@ -508,6 +523,7 @@ describe("createOpenCodeProvider", () => {
 
 	it("uses configured ollama fallback base URL for OpenCode fallback", async () => {
 		const seenUrls: string[] = [];
+		let fallbackBody: Record<string, unknown> | null = null;
 		mockFetch(async (url, init) => {
 			seenUrls.push(url);
 			if (url.includes("/session") && !url.includes("/message")) {
@@ -538,6 +554,7 @@ describe("createOpenCodeProvider", () => {
 				return Response.json({ models: [] });
 			}
 			if (url === "http://172.17.0.1:11434/api/generate") {
+				fallbackBody = JSON.parse(init?.body as string) as Record<string, unknown>;
 				return Response.json({ response: '{"facts":[],"entities":[]}' });
 			}
 			return new Response("unexpected url", { status: 500 });
@@ -547,10 +564,14 @@ describe("createOpenCodeProvider", () => {
 			baseUrl: "http://localhost:9999",
 			enableOllamaFallback: true,
 			ollamaFallbackBaseUrl: "http://172.17.0.1:11434",
+			ollamaFallbackMaxContextTokens: 2048,
 		});
 		const result = await provider.generate("test", { timeoutMs: 250 });
 		expect(result).toBe('{"facts":[],"entities":[]}');
 		expect(seenUrls).toContain("http://172.17.0.1:11434/api/tags");
 		expect(seenUrls).toContain("http://172.17.0.1:11434/api/generate");
+		expect(
+			((fallbackBody?.options as Record<string, unknown> | undefined)?.num_ctx),
+		).toBe(2048);
 	});
 });

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -1262,7 +1262,7 @@ export function createOpenCodeProvider(
 	const ollamaFallbackMaxContextTokens =
 		typeof merged.ollamaFallbackMaxContextTokens === "number"
 			? merged.ollamaFallbackMaxContextTokens
-			: resolveDefaultOllamaFallbackMaxContextTokens();
+			: resolveDefaultOllamaFallbackMaxContextTokens(); // Eagerly resolved even when fallback is disabled; tryOllamaFallback gates on enableOllamaFallback.
 	const cfg = {
 		...merged,
 		baseUrl: trimTrailingSlash(merged.baseUrl),

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -178,9 +178,18 @@ const DEFAULT_OLLAMA_CONFIG = {
 
 function parseOptionalPositiveInt(raw: string | undefined): number | undefined {
 	if (typeof raw !== "string") return undefined;
-	const parsed = Number.parseInt(raw, 10);
-	if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
-	return parsed;
+	const trimmed = raw.trim();
+	if (!/^[1-9]\d*$/.test(trimmed)) return undefined;
+	return normalizePositiveInt(Number(trimmed));
+}
+
+function normalizePositiveInt(value: number | undefined): number | undefined {
+	if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+		return undefined;
+	}
+	const normalized = Math.floor(value);
+	if (normalized <= 0 || !Number.isSafeInteger(normalized)) return undefined;
+	return normalized;
 }
 
 export function resolveDefaultOllamaFallbackModel(): string {
@@ -223,7 +232,7 @@ export function createOllamaProvider(
 		baseUrl: trimTrailingSlash(config?.baseUrl ?? DEFAULT_OLLAMA_CONFIG.baseUrl),
 		defaultTimeoutMs:
 			config?.defaultTimeoutMs ?? DEFAULT_OLLAMA_CONFIG.defaultTimeoutMs,
-		maxContextTokens: config?.maxContextTokens,
+		maxContextTokens: normalizePositiveInt(config?.maxContextTokens),
 		model,
 	};
 
@@ -239,7 +248,7 @@ export function createOllamaProvider(
 		try {
 			const options: Record<string, number> = {};
 			if (opts?.maxTokens) options.num_predict = opts.maxTokens;
-			if (typeof cfg.maxContextTokens === "number") {
+			if (cfg.maxContextTokens !== undefined) {
 				options.num_ctx = cfg.maxContextTokens;
 			}
 			const res = await fetch(`${cfg.baseUrl}/api/generate`, {
@@ -1260,9 +1269,8 @@ export function createOpenCodeProvider(
 			? rawFallbackModel.trim()
 			: resolveDefaultOllamaFallbackModel();
 	const ollamaFallbackMaxContextTokens =
-		typeof merged.ollamaFallbackMaxContextTokens === "number"
-			? merged.ollamaFallbackMaxContextTokens
-			: resolveDefaultOllamaFallbackMaxContextTokens(); // Eagerly resolved even when fallback is disabled; tryOllamaFallback gates on enableOllamaFallback.
+		normalizePositiveInt(merged.ollamaFallbackMaxContextTokens) ??
+		resolveDefaultOllamaFallbackMaxContextTokens(); // Eagerly resolved even when fallback is disabled; tryOllamaFallback gates on enableOllamaFallback.
 	const cfg = {
 		...merged,
 		baseUrl: trimTrailingSlash(merged.baseUrl),
@@ -1320,7 +1328,7 @@ export function createOpenCodeProvider(
 				const options: Record<string, number> = {
 					num_predict: fallbackOpts.maxTokens,
 				};
-				if (typeof cfg.ollamaFallbackMaxContextTokens === "number") {
+				if (cfg.ollamaFallbackMaxContextTokens !== undefined) {
 					options.num_ctx = cfg.ollamaFallbackMaxContextTokens;
 				}
 				const res = await fetch(`${cfg.ollamaFallbackBaseUrl}/api/generate`, {

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -162,16 +162,42 @@ export async function generateWithTracking(
 // ---------------------------------------------------------------------------
 
 export interface OllamaProviderConfig {
-	readonly model: string;
+	readonly model?: string;
 	readonly baseUrl: string;
 	readonly defaultTimeoutMs: number;
+	readonly maxContextTokens?: number;
 }
 
-const DEFAULT_OLLAMA_CONFIG: OllamaProviderConfig = {
-	model: "qwen3:4b",
+export const DEFAULT_OLLAMA_FALLBACK_MODEL = "llama3.2:3b";
+export const DEFAULT_OLLAMA_FALLBACK_MAX_CONTEXT_TOKENS = 8192;
+
+const DEFAULT_OLLAMA_CONFIG = {
 	baseUrl: "http://127.0.0.1:11434",
 	defaultTimeoutMs: 90000,
 };
+
+function parseOptionalPositiveInt(raw: string | undefined): number | undefined {
+	if (typeof raw !== "string") return undefined;
+	const parsed = Number.parseInt(raw, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+	return parsed;
+}
+
+export function resolveDefaultOllamaFallbackModel(): string {
+	const raw = process.env.SIGNET_OLLAMA_FALLBACK_MODEL;
+	if (typeof raw === "string") {
+		const trimmed = raw.trim();
+		if (trimmed.length > 0) return trimmed;
+	}
+	return DEFAULT_OLLAMA_FALLBACK_MODEL;
+}
+
+export function resolveDefaultOllamaFallbackMaxContextTokens(): number {
+	return (
+		parseOptionalPositiveInt(process.env.SIGNET_OLLAMA_FALLBACK_MAX_CTX)
+		?? DEFAULT_OLLAMA_FALLBACK_MAX_CONTEXT_TOKENS
+	);
+}
 
 function trimTrailingSlash(url: string): string {
 	return url.endsWith("/") ? url.slice(0, -1) : url;
@@ -188,8 +214,18 @@ interface OllamaGenerateResponse {
 export function createOllamaProvider(
 	config?: Partial<OllamaProviderConfig>,
 ): LlmProvider {
-	const merged = { ...DEFAULT_OLLAMA_CONFIG, ...config };
-	const cfg = { ...merged, baseUrl: trimTrailingSlash(merged.baseUrl) };
+	const rawModel = config?.model;
+	const model =
+		typeof rawModel === "string" && rawModel.trim().length > 0
+			? rawModel.trim()
+			: resolveDefaultOllamaFallbackModel();
+	const cfg = {
+		baseUrl: trimTrailingSlash(config?.baseUrl ?? DEFAULT_OLLAMA_CONFIG.baseUrl),
+		defaultTimeoutMs:
+			config?.defaultTimeoutMs ?? DEFAULT_OLLAMA_CONFIG.defaultTimeoutMs,
+		maxContextTokens: config?.maxContextTokens,
+		model,
+	};
 
 	async function callOllama(
 		prompt: string,
@@ -201,6 +237,11 @@ export function createOllamaProvider(
 		const timer = setTimeout(() => controller.abort(), timeoutMs);
 
 		try {
+			const options: Record<string, number> = {};
+			if (opts?.maxTokens) options.num_predict = opts.maxTokens;
+			if (typeof cfg.maxContextTokens === "number") {
+				options.num_ctx = cfg.maxContextTokens;
+			}
 			const res = await fetch(`${cfg.baseUrl}/api/generate`, {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
@@ -208,7 +249,7 @@ export function createOllamaProvider(
 					model: cfg.model,
 					prompt,
 					stream: false,
-					...(opts?.maxTokens ? { options: { num_predict: opts.maxTokens } } : {}),
+					...(Object.keys(options).length > 0 ? { options } : {}),
 				}),
 				signal: controller.signal,
 			});
@@ -940,8 +981,9 @@ export interface OpenCodeProviderConfig {
 	readonly model: string;
 	readonly defaultTimeoutMs: number;
 	readonly enableOllamaFallback: boolean;
-	readonly ollamaFallbackModel: string;
+	readonly ollamaFallbackModel?: string;
 	readonly ollamaFallbackBaseUrl: string;
+	readonly ollamaFallbackMaxContextTokens?: number;
 }
 
 const DEFAULT_OPENCODE_CONFIG: OpenCodeProviderConfig = {
@@ -949,8 +991,9 @@ const DEFAULT_OPENCODE_CONFIG: OpenCodeProviderConfig = {
 	model: "anthropic/claude-haiku-4-5-20251001",
 	defaultTimeoutMs: 60000,
 	enableOllamaFallback: true,
-	ollamaFallbackModel: "qwen3:4b",
+	ollamaFallbackModel: undefined,
 	ollamaFallbackBaseUrl: "http://127.0.0.1:11434",
+	ollamaFallbackMaxContextTokens: undefined,
 };
 
 /**
@@ -1210,10 +1253,22 @@ export function createOpenCodeProvider(
 	config?: Partial<OpenCodeProviderConfig>,
 ): LlmProvider {
 	const merged = { ...DEFAULT_OPENCODE_CONFIG, ...config };
+	const rawFallbackModel = merged.ollamaFallbackModel;
+	const ollamaFallbackModel =
+		typeof rawFallbackModel === "string" &&
+			rawFallbackModel.trim().length > 0
+			? rawFallbackModel.trim()
+			: resolveDefaultOllamaFallbackModel();
+	const ollamaFallbackMaxContextTokens =
+		typeof merged.ollamaFallbackMaxContextTokens === "number"
+			? merged.ollamaFallbackMaxContextTokens
+			: resolveDefaultOllamaFallbackMaxContextTokens();
 	const cfg = {
 		...merged,
 		baseUrl: trimTrailingSlash(merged.baseUrl),
 		ollamaFallbackBaseUrl: trimTrailingSlash(merged.ollamaFallbackBaseUrl),
+		ollamaFallbackModel,
+		ollamaFallbackMaxContextTokens,
 	};
 
 	// Parse "provider/model" format (e.g. "anthropic/claude-haiku-4-5-20251001")
@@ -1230,6 +1285,7 @@ export function createOpenCodeProvider(
 			model: cfg.ollamaFallbackModel,
 			baseUrl: cfg.ollamaFallbackBaseUrl,
 			defaultTimeoutMs: cfg.defaultTimeoutMs,
+			maxContextTokens: cfg.ollamaFallbackMaxContextTokens,
 		});
 		return ollamaFallbackProvider;
 	}
@@ -1261,6 +1317,12 @@ export function createOpenCodeProvider(
 			let inputTokens: number | null = null;
 			let outputTokens: number | null = null;
 			try {
+				const options: Record<string, number> = {
+					num_predict: fallbackOpts.maxTokens,
+				};
+				if (typeof cfg.ollamaFallbackMaxContextTokens === "number") {
+					options.num_ctx = cfg.ollamaFallbackMaxContextTokens;
+				}
 				const res = await fetch(`${cfg.ollamaFallbackBaseUrl}/api/generate`, {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
@@ -1270,7 +1332,7 @@ export function createOpenCodeProvider(
 						stream: false,
 						format: "json",
 						think: false,
-						options: { num_predict: fallbackOpts.maxTokens },
+						options,
 					}),
 					signal: controller.signal,
 				});

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -836,6 +836,8 @@ async function resolveProvider(cfg: ReturnType<typeof loadMemoryConfig>): Promis
 				defaultTimeoutMs: timeout,
 			});
 		default:
+			// Intentionally omit maxContextTokens here. When Ollama is explicitly
+			// configured (not fallback), users control context via model config.
 			return createOllamaProvider({
 				...(typeof model === "string" && model.trim().length > 0
 					? { model }

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -16,7 +16,13 @@ import { join } from "node:path";
 import type { Database } from "bun:sqlite";
 import type { DbAccessor } from "../db-accessor";
 import type { LlmProvider } from "@signet/core";
-import { createAnthropicProvider, createOllamaProvider, createClaudeCodeProvider, createOpenCodeProvider } from "./provider";
+import {
+	createAnthropicProvider,
+	createOllamaProvider,
+	createClaudeCodeProvider,
+	createOpenCodeProvider,
+	resolveDefaultOllamaFallbackMaxContextTokens,
+} from "./provider";
 
 import { isDuplicate, inferType } from "../hooks";
 import { loadMemoryConfig } from "../memory-config";
@@ -798,6 +804,8 @@ async function resolveProvider(cfg: ReturnType<typeof loadMemoryConfig>): Promis
 	const model = cfg.pipelineV2.synthesis.model;
 	const timeout = cfg.pipelineV2.synthesis.timeout;
 	const endpoint = cfg.pipelineV2.synthesis.endpoint;
+	const ollamaFallbackMaxContextTokens =
+		resolveDefaultOllamaFallbackMaxContextTokens();
 	switch (p) {
 		case "anthropic": {
 			let apiKey = process.env.ANTHROPIC_API_KEY;
@@ -810,7 +818,10 @@ async function resolveProvider(cfg: ReturnType<typeof loadMemoryConfig>): Promis
 			}
 			if (!apiKey) {
 				logger.error("summary-worker", "ANTHROPIC_API_KEY not found for summary worker — falling back to ollama. Set via env or `signet secrets set ANTHROPIC_API_KEY`");
-				return createOllamaProvider({ model: "qwen3:4b", defaultTimeoutMs: timeout });
+				return createOllamaProvider({
+					defaultTimeoutMs: timeout,
+					maxContextTokens: ollamaFallbackMaxContextTokens,
+				});
 			}
 			return createAnthropicProvider({ model: model || "haiku", apiKey, defaultTimeoutMs: timeout });
 		}
@@ -821,11 +832,14 @@ async function resolveProvider(cfg: ReturnType<typeof loadMemoryConfig>): Promis
 				model: model || "anthropic/claude-haiku-4-5-20251001",
 				baseUrl: endpoint ?? "http://127.0.0.1:4096",
 				ollamaFallbackBaseUrl: "http://127.0.0.1:11434",
+				ollamaFallbackMaxContextTokens,
 				defaultTimeoutMs: timeout,
 			});
 		default:
 			return createOllamaProvider({
-				model: model || "qwen3:4b",
+				...(typeof model === "string" && model.trim().length > 0
+					? { model }
+					: {}),
 				...(endpoint ? { baseUrl: endpoint } : {}),
 				defaultTimeoutMs: timeout,
 			});


### PR DESCRIPTION
## Summary
Fixes #191.

This removes hardcoded `qwen3:4b` fallback usage in daemon runtime paths that can silently trigger very high RAM usage when provider fallback activates.

### What changed
- Removed hardcoded `qwen3:4b` defaults from daemon extraction/synthesis fallback wiring
- Added configurable Ollama fallback defaults in provider layer:
  - `SIGNET_OLLAMA_FALLBACK_MODEL` (default: `llama3.2:3b`)
  - `SIGNET_OLLAMA_FALLBACK_MAX_CTX` (default: `8192`)
- Added `maxContextTokens` support to Ollama provider, sent as `options.num_ctx`
- Propagated fallback context cap into OpenCode -> Ollama fallback path
- Updated summary worker fallback to avoid hardcoded `qwen3:4b`
- Added tests covering `num_ctx` propagation for direct and OpenCode fallback Ollama calls

## Validation
- `bun test packages/daemon/src/pipeline/provider.test.ts`
- `bun run build:core && bun run --filter @signet/daemon build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Ollama fallback now respects configurable default context-token limits and environment-driven model selection; those limits are honored for extraction and synthesis fallbacks.
  * Provider selection is more robust with clearer fallback behavior and additional warnings when external endpoints or CLI tools are unavailable.
* **Tests**
  * Added tests to verify fallback model selection and that context-token limits are correctly applied and sent with Ollama fallback requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->