### PR TITLE
fix: auto-detect git sync branch instead of hardcoding "main"

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -7767,6 +7767,7 @@ function detectGitBranch(remote: string): string {
 			cwd: AGENTS_DIR,
 			encoding: "utf-8",
 			stdio: ["pipe", "pipe", "pipe"],
+			timeout: 3000,
 		}).trim();
 		// ref looks like "refs/remotes/origin/main" — extract the branch name
 		const prefix = `refs/remotes/${remote}/`;
@@ -7782,6 +7783,7 @@ function detectGitBranch(remote: string): string {
 			cwd: AGENTS_DIR,
 			encoding: "utf-8",
 			stdio: ["pipe", "pipe", "pipe"],
+			timeout: 3000,
 		}).trim();
 		if (branch && branch !== "HEAD") {
 			return branch;


### PR DESCRIPTION
## Summary

- The `loadGitConfig()` function in the daemon hardcoded `branch: "main"` as the default for git sync. This silently fails for any user whose backup repo uses `master`, `trunk`, or any other default branch name. The only symptom is a warning logged every 5 minutes: `"Fetch failed: fatal: couldn't find remote ref main"`.
- Added a `detectGitBranch()` helper that auto-detects the correct branch:
  1. First tries `git symbolic-ref refs/remotes/{remote}/HEAD` (remote's default branch)
  2. Falls back to `git rev-parse --abbrev-ref HEAD` (current local branch)
  3. Falls back to `"main"` only if both git commands fail (no repo, no remote, etc.)
- Branch detection only runs when no explicit `branch` is set in `agent.yaml`, so existing user configs are unaffected.

## Details

All git subprocess calls use `cwd: AGENTS_DIR` per the repo's convention for git sync operations. The detection runs at daemon startup (when `loadGitConfig()` is called), not on every sync cycle.

## Test plan

- [ ] Verify build passes (`bun run build`)
- [ ] Test with a repo where remote default is `main` — should detect `main`
- [ ] Test with a repo where remote default is `master` — should detect `master`
- [ ] Test with explicit `branch: trunk` in `agent.yaml` — should use `trunk` (skip detection)
- [ ] Test with no git repo in `~/.agents/` — should fall back to `"main"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic Git branch detection for repository syncing — the agent now auto-populates a sensible default branch when none is configured, improving startup behavior and reducing manual setup for fetch/merge/push operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->