### PR TITLE
feat: dynamic model registry + extraction strength

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/adapters/openclaw": {
       "name": "@signetai/signet-memory-openclaw",
-      "version": "0.47.2",
+      "version": "0.56.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.47",
       },
@@ -22,7 +22,7 @@
     },
     "packages/cli": {
       "name": "@signet/cli",
-      "version": "0.47.2",
+      "version": "0.56.0",
       "bin": "./dist/cli.js",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
@@ -45,7 +45,7 @@
     },
     "packages/connector-base": {
       "name": "@signet/connector-base",
-      "version": "0.47.2",
+      "version": "0.56.0",
       "dependencies": {
         "@signet/core": "workspace:*",
       },
@@ -59,7 +59,7 @@
     },
     "packages/connector-claude-code": {
       "name": "@signet/connector-claude-code",
-      "version": "0.47.2",
+      "version": "0.56.0",
       "dependencies": {
         "@signet/connector-base": "workspace:*",
         "@signet/core": "workspace:*",
@@ -71,7 +71,7 @@
     },
     "packages/connector-codex": {
       "name": "@signet/connector-codex",
-      "version": "0.47.2",
+      "version": "0.56.0",
       "dependencies": {
         "@signet/connector-base": "workspace:*",
         "@signet/core": "workspace:*",
@@ -83,7 +83,7 @@
     },
     "packages/connector-openclaw": {
       "name": "@signet/connector-openclaw",
-      "version": "0.47.2",
+      "version": "0.56.0",
       "dependencies": {
         "@signet/connector-base": "workspace:*",
         "json5": "^2.2.3",
@@ -95,7 +95,7 @@
     },
     "packages/connector-opencode": {
       "name": "@signet/connector-opencode",
-      "version": "0.47.2",
+      "version": "0.56.0",
       "dependencies": {
         "@signet/connector-base": "workspace:*",
         "@signet/core": "workspace:*",
@@ -107,7 +107,7 @@
     },
     "packages/core": {
       "name": "@signet/core",
-      "version": "0.47.2",
+      "version": "0.56.0",
       "dependencies": {
         "sqlite-vec": "^0.1.7-alpha.2",
         "yaml": "^2.6.0",
@@ -128,7 +128,7 @@
     },
     "packages/daemon": {
       "name": "@signet/daemon",
-      "version": "0.47.2",
+      "version": "0.56.0",
       "bin": {
         "signet-daemon": "./dist/daemon.js",
         "signet-mcp": "./dist/mcp-stdio.js",
@@ -158,7 +158,7 @@
     },
     "packages/extension": {
       "name": "@signet/extension",
-      "version": "0.47.2",
+      "version": "0.56.0",
       "devDependencies": {
         "@types/chrome": "^0.0.287",
         "typescript": "^5.7.0",
@@ -166,21 +166,21 @@
     },
     "packages/native": {
       "name": "@signet/native",
-      "version": "0.47.2",
+      "version": "0.56.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.5.1",
       },
     },
     "packages/opencode-plugin": {
       "name": "@signet/opencode-plugin",
-      "version": "0.47.2",
+      "version": "0.56.0",
       "peerDependencies": {
         "@opencode-ai/plugin": ">=0.1.0",
       },
     },
     "packages/sdk": {
       "name": "@signet/sdk",
-      "version": "0.47.2",
+      "version": "0.56.0",
       "devDependencies": {
         "@types/react": "^19.0.0",
         "react": "^19.0.0",
@@ -196,7 +196,7 @@
     },
     "packages/signetai": {
       "name": "signetai",
-      "version": "0.47.2",
+      "version": "0.56.0",
       "bin": {
         "signet": "bin/signet.js",
         "signet-mcp": "dist/mcp-stdio.js",
@@ -226,7 +226,7 @@
     },
     "packages/tray": {
       "name": "@signet/tray",
-      "version": "0.47.2",
+      "version": "0.56.0",
       "dependencies": {
         "@signet/sdk": "workspace:*",
         "@tauri-apps/api": "^2.5.0",

--- a/packages/cli/dashboard/package.json
+++ b/packages/cli/dashboard/package.json
@@ -32,6 +32,7 @@
     "yaml": "^2.8.2"
   },
   "devDependencies": {
+    "@signet/core": "workspace:*",
     "@internationalized/date": "^3.10.0",
     "@lucide/svelte": "^0.561.0",
     "@sveltejs/adapter-static": "^3.0.0",

--- a/packages/cli/dashboard/src/lib/api.ts
+++ b/packages/cli/dashboard/src/lib/api.ts
@@ -2467,3 +2467,37 @@ export async function getContinuityLatest(): Promise<ContinuityEntry[]> {
 		return [];
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Model Registry
+// ---------------------------------------------------------------------------
+
+export interface ModelRegistryEntry {
+	id: string;
+	provider: string;
+	label: string;
+	tier: "high" | "mid" | "low";
+	deprecated: boolean;
+}
+
+export async function getModelsByProvider(): Promise<Record<string, ModelRegistryEntry[]>> {
+	try {
+		const res = await fetch(`${API_BASE}/api/pipeline/models/by-provider`);
+		if (!res.ok) return {};
+		return (await res.json()) as Record<string, ModelRegistryEntry[]>;
+	} catch {
+		return {};
+	}
+}
+
+export async function refreshModelRegistry(): Promise<Record<string, ModelRegistryEntry[]>> {
+	try {
+		const res = await fetch(`${API_BASE}/api/pipeline/models/refresh`, { method: "POST" });
+		if (!res.ok) return {};
+		const body = (await res.json()) as { models: Record<string, ModelRegistryEntry[]> };
+		return body.models ?? {};
+	} catch {
+		return {};
+	}
+}
+

--- a/packages/cli/dashboard/src/lib/api.ts
+++ b/packages/cli/dashboard/src/lib/api.ts
@@ -4,6 +4,7 @@
  */
 
 import { marked } from "marked";
+import type { ModelRegistryEntry } from "@signet/core";
 
 // When served by the daemon, use relative URLs.
 // When served by Tauri (frontendDist) or Vite dev server, use absolute URL.
@@ -2472,13 +2473,7 @@ export async function getContinuityLatest(): Promise<ContinuityEntry[]> {
 // Model Registry
 // ---------------------------------------------------------------------------
 
-export interface ModelRegistryEntry {
-	id: string;
-	provider: string;
-	label: string;
-	tier: "high" | "mid" | "low";
-	deprecated: boolean;
-}
+export type { ModelRegistryEntry };
 
 export async function getModelsByProvider(): Promise<Record<string, ModelRegistryEntry[]>> {
 	try {

--- a/packages/cli/dashboard/src/lib/api.ts
+++ b/packages/cli/dashboard/src/lib/api.ts
@@ -2485,14 +2485,4 @@ export async function getModelsByProvider(): Promise<Record<string, ModelRegistr
 	}
 }
 
-export async function refreshModelRegistry(): Promise<Record<string, ModelRegistryEntry[]>> {
-	try {
-		const res = await fetch(`${API_BASE}/api/pipeline/models/refresh`, { method: "POST" });
-		if (!res.ok) return {};
-		const body = (await res.json()) as { models: Record<string, ModelRegistryEntry[]> };
-		return body.models ?? {};
-	} catch {
-		return {};
-	}
-}
 

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
@@ -263,9 +263,7 @@ const ADVANCED_FEATURE_KEYS = ["autonomousFrozen"] as const;
 						<Select.Item class={selectItemClass} value="high" label="high" />
 					</Select.Content>
 				</Select.Root>
-				{#if st.aStr(["memory", "pipelineV2", "extractionStrength"])}
-					<span class="text-[9px] text-[var(--sig-text-muted)] tracking-wider uppercase">{strengthMaxTokensLabel()} max tokens</span>
-				{/if}
+				<span class="text-[9px] text-[var(--sig-text-muted)] tracking-wider uppercase">{strengthMaxTokensLabel()} max tokens</span>
 				{#if (st.aStr(["memory", "pipelineV2", "extractionStrength"]) || "low") === "high"}
 					<span class="text-[9px] text-[var(--sig-danger)] tracking-wider uppercase">running extraction at high is usually unnecessary and will increase API costs significantly</span>
 				{/if}

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
@@ -15,6 +15,10 @@ import {
 	PIPELINE_WORKER_NUMS,
 	st,
 } from "$lib/stores/settings.svelte";
+import {
+	getModelsByProvider,
+	type ModelRegistryEntry,
+} from "$lib/api";
 
 const selectTriggerClass =
 	"font-[family-name:var(--font-mono)] text-[11px] text-[var(--sig-text)] bg-[var(--sig-bg)] border-[var(--sig-border-strong)] rounded-lg w-full h-auto min-h-[30px] px-2 py-[5px] box-border focus-visible:border-[var(--sig-accent)]";
@@ -27,43 +31,79 @@ const EXTRACTION_PROVIDER_OPTIONS = [
 	{ value: "claude-code", label: "claude-code" },
 	{ value: "codex", label: "codex" },
 	{ value: "opencode", label: "opencode" },
+	{ value: "anthropic", label: "anthropic" },
 ] as const;
 
-const EXTRACTION_MODEL_PRESETS = {
+// Hardcoded fallback presets — used when the registry API is unavailable
+const FALLBACK_MODEL_PRESETS: Record<string, Array<{ value: string; label: string }>> = {
 	"ollama": [
 		{ value: "glm-4.7-flash", label: "glm-4.7-flash" },
 		{ value: "qwen3:4b", label: "qwen3:4b" },
 		{ value: "llama3", label: "llama3" },
 	],
 	"claude-code": [
-		{ value: "haiku", label: "haiku" },
-		{ value: "sonnet", label: "sonnet" },
+		{ value: "claude-opus-4-6", label: "Claude Opus 4.6" },
+		{ value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+		{ value: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
+		{ value: "claude-3-5-haiku-20241022", label: "Claude 3.5 Haiku" },
 	],
 	"codex": [
-		{ value: "gpt-5.3-codex", label: "gpt-5.3-codex" },
-		{ value: "gpt-5-codex", label: "gpt-5-codex" },
-		{ value: "gpt-5-codex-mini", label: "gpt-5-codex-mini" },
+		{ value: "gpt-5.4", label: "GPT 5.4" },
+		{ value: "gpt-5.3-codex", label: "GPT 5.3 Codex" },
+		{ value: "gpt-5.3-codex-spark", label: "GPT 5.3 Codex Spark" },
+		{ value: "gpt-5-codex", label: "GPT 5 Codex" },
+		{ value: "codex-mini-latest", label: "Codex Mini" },
 	],
 	"opencode": [
-		{ value: "anthropic/claude-haiku-4-5-20251001", label: "anthropic/claude-haiku-4-5-20251001" },
-		{ value: "anthropic/claude-sonnet-4-5-20250514", label: "anthropic/claude-sonnet-4-5-20250514" },
-		{ value: "google/gemini-2.5-flash", label: "google/gemini-2.5-flash" },
+		{ value: "anthropic/claude-opus-4-6", label: "Claude Opus 4.6" },
+		{ value: "anthropic/claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+		{ value: "anthropic/claude-haiku-4-5-20251001", label: "Claude Haiku 4.5" },
+		{ value: "google/gemini-2.5-flash", label: "Gemini 2.5 Flash" },
 	],
-} as const;
+	"anthropic": [
+		{ value: "claude-opus-4-6", label: "Claude Opus 4.6" },
+		{ value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+		{ value: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5" },
+		{ value: "claude-3-5-haiku-20241022", label: "Claude 3.5 Haiku" },
+	],
+};
 
-type ExtractionProvider = keyof typeof EXTRACTION_MODEL_PRESETS;
+// Dynamic model registry — fetched from daemon API
+let dynamicModels = $state<Record<string, ModelRegistryEntry[]>>({});
+let registryLoaded = $state(false);
 
-function extractionProvider(): ExtractionProvider | "" {
-	const provider = st.aStr(["memory", "pipelineV2", "extractionProvider"]);
-	return provider in EXTRACTION_MODEL_PRESETS ? (provider as ExtractionProvider) : "";
+$effect(() => {
+	getModelsByProvider().then((models) => {
+		if (models && Object.keys(models).length > 0) {
+			dynamicModels = models;
+			registryLoaded = true;
+		}
+	});
+});
+
+function getModelPresets(provider: string): Array<{ value: string; label: string }> {
+	if (registryLoaded && dynamicModels[provider]) {
+		return dynamicModels[provider].map((m) => ({
+			value: m.id,
+			label: m.label,
+		}));
+	}
+	return FALLBACK_MODEL_PRESETS[provider] ?? [];
+}
+
+function extractionProvider(): string {
+	return st.aStr(["memory", "pipelineV2", "extractionProvider"]);
 }
 
 function extractionModelPresets() {
 	const provider = extractionProvider();
-	return provider ? EXTRACTION_MODEL_PRESETS[provider] : [];
+	return provider ? getModelPresets(provider) : [];
 }
 
+let customModelActive = $state(false);
+
 function extractionModelSelectValue(): string {
+	if (customModelActive) return "__custom__";
 	const model = st.aStr(["memory", "pipelineV2", "extractionModel"]);
 	if (!model) return "";
 	return extractionModelPresets().some((preset) => preset.value === model)
@@ -72,13 +112,18 @@ function extractionModelSelectValue(): string {
 }
 
 function isKnownPreset(model: string): boolean {
-	return Object.values(EXTRACTION_MODEL_PRESETS).some((presets) =>
-		presets.some((preset) => preset.value === model),
-	);
+	for (const presets of Object.values(dynamicModels)) {
+		if (presets.some((p) => p.id === model)) return true;
+	}
+	for (const presets of Object.values(FALLBACK_MODEL_PRESETS)) {
+		if (presets.some((p) => p.value === model)) return true;
+	}
+	return false;
 }
 
-function defaultModelForProvider(provider: ExtractionProvider): string {
-	return EXTRACTION_MODEL_PRESETS[provider][0]?.value ?? "";
+function defaultModelForProvider(provider: string): string {
+	const presets = getModelPresets(provider);
+	return presets[0]?.value ?? "";
 }
 
 function setNum(path: string[]) {
@@ -106,8 +151,9 @@ function setSelect(path: string[]) {
 }
 
 function setExtractionProvider(v: string | undefined): void {
-	const nextProvider = (v ?? "") as ExtractionProvider | "";
+	const nextProvider = v ?? "";
 	const currentModel = st.aStr(["memory", "pipelineV2", "extractionModel"]);
+	customModelActive = false;
 	st.aSetStr(["memory", "pipelineV2", "extractionProvider"], nextProvider);
 	if (!nextProvider) return;
 	if (!currentModel || isKnownPreset(currentModel)) {
@@ -116,8 +162,30 @@ function setExtractionProvider(v: string | undefined): void {
 }
 
 function setExtractionModelPreset(v: string | undefined): void {
-	if (!v || v === "__custom__") return;
+	if (!v) {
+		customModelActive = false;
+		return;
+	}
+	if (v === "__custom__") {
+		customModelActive = true;
+		return;
+	}
+	customModelActive = false;
 	st.aSetStr(["memory", "pipelineV2", "extractionModel"], v);
+}
+
+function extractionModelLabel(): string {
+	const model = st.aStr(["memory", "pipelineV2", "extractionModel"]);
+	if (!model) return "";
+	const preset = extractionModelPresets().find((p) => p.value === model);
+	return preset ? preset.label : model;
+}
+
+const STRENGTH_MAX_TOKENS: Record<string, number> = { low: 1024, medium: 2048, high: 4096 };
+
+function strengthMaxTokensLabel(): number {
+	const s = st.aStr(["memory", "pipelineV2", "extractionStrength"]) || "low";
+	return STRENGTH_MAX_TOKENS[s] ?? 1024;
 }
 
 const TOP_LEVEL_FEATURE_KEYS = ["allowUpdateDelete", "graphEnabled", "autonomousEnabled", "semanticContradictionEnabled"] as const;
@@ -126,23 +194,21 @@ const ADVANCED_FEATURE_KEYS = ["autonomousFrozen"] as const;
 
 {#if st.agentFile}
 	<FormSection description="V2 memory pipeline. Runs LLM-based fact extraction on incoming memories, then decides whether to write, update, or skip. Lives under memory.pipelineV2 in agent.yaml.">
-		<!-- enabled toggle -->
 		<FormField label={PIPELINE_CORE_BOOLS[0].key} description={PIPELINE_CORE_BOOLS[0].desc}>
 			<Switch checked={st.aBool(["memory", "pipelineV2", PIPELINE_CORE_BOOLS[0].key])} onCheckedChange={setBool(["memory", "pipelineV2", PIPELINE_CORE_BOOLS[0].key])} />
 		</FormField>
 
-		<!-- Extraction provider -->
-		<FormField label="Extraction provider" description="LLM backend for fact extraction. Ollama runs locally; claude-code uses Claude Code CLI; codex uses the local Codex CLI; opencode uses the OpenCode server.">
+		<FormField label="Extraction provider" description="LLM backend for fact extraction. Ollama runs locally; claude-code uses Claude Code CLI; codex uses the local Codex CLI; opencode uses the OpenCode server; anthropic uses direct API.">
 			<Select.Root
 				type="single"
 				value={st.aStr(["memory", "pipelineV2", "extractionProvider"])}
 				onValueChange={setExtractionProvider}
 			>
 				<Select.Trigger class={selectTriggerClass}>
-					{st.aStr(["memory", "pipelineV2", "extractionProvider"]) || "\u2014 select \u2014"}
+					{st.aStr(["memory", "pipelineV2", "extractionProvider"]) || "None selected"}
 				</Select.Trigger>
 				<Select.Content class={selectContentClass}>
-					<Select.Item class={selectItemClass} value="" label="\u2014 select \u2014" />
+					<Select.Item class={selectItemClass} value="" label="None selected" />
 					{#each EXTRACTION_PROVIDER_OPTIONS as option (option.value)}
 						<Select.Item class={selectItemClass} value={option.value} label={option.label} />
 					{/each}
@@ -150,8 +216,7 @@ const ADVANCED_FEATURE_KEYS = ["autonomousFrozen"] as const;
 			</Select.Root>
 		</FormField>
 
-		<!-- Extraction model -->
-		<FormField label="Extraction model" description="Choose a provider default or switch to custom for any supported model string. Existing custom values are preserved.">
+		<FormField label="Extraction model" description={registryLoaded ? "Models auto-discovered from provider. Switch to custom for any supported model string." : "Choose a provider default or switch to custom. Models will auto-update when the registry connects."}>
 			<div class="flex flex-col gap-2">
 				<Select.Root
 					type="single"
@@ -161,10 +226,10 @@ const ADVANCED_FEATURE_KEYS = ["autonomousFrozen"] as const;
 					<Select.Trigger class={selectTriggerClass}>
 						{extractionModelSelectValue() === "__custom__"
 							? `custom: ${st.aStr(["memory", "pipelineV2", "extractionModel"])}`
-							: st.aStr(["memory", "pipelineV2", "extractionModel"]) || "\u2014 select \u2014"}
+							: extractionModelLabel() || "None selected"}
 					</Select.Trigger>
 					<Select.Content class={selectContentClass}>
-						<Select.Item class={selectItemClass} value="" label="\u2014 select \u2014" />
+						<Select.Item class={selectItemClass} value="" label="None selected" />
 						{#each extractionModelPresets() as preset (preset.value)}
 							<Select.Item class={selectItemClass} value={preset.value} label={preset.label} />
 						{/each}
@@ -174,24 +239,57 @@ const ADVANCED_FEATURE_KEYS = ["autonomousFrozen"] as const;
 				{#if extractionModelSelectValue() === "__custom__" || extractionModelPresets().length === 0}
 					<Input value={st.aStr(["memory", "pipelineV2", "extractionModel"])} oninput={setStr(["memory", "pipelineV2", "extractionModel"])} placeholder="custom model id" />
 				{/if}
+				{#if registryLoaded}
+					<span class="text-[9px] text-[var(--sig-text-muted)] tracking-wider uppercase">auto-discovered from registry</span>
+				{/if}
 			</div>
 		</FormField>
 
-		<!-- Top-level feature toggles -->
+		<FormField label="Extraction strength" description="Controls how aggressively the pipeline extracts facts from incoming memories.">
+			<div class="flex flex-col gap-2">
+				<Select.Root
+					type="single"
+					value={st.aStr(["memory", "pipelineV2", "extractionStrength"])}
+					onValueChange={setSelect(["memory", "pipelineV2", "extractionStrength"])}
+				>
+					<Select.Trigger class={selectTriggerClass}>
+						{st.aStr(["memory", "pipelineV2", "extractionStrength"]) || "None selected"}
+					</Select.Trigger>
+					<Select.Content class={selectContentClass}>
+						<Select.Item class={selectItemClass} value="" label="None selected" />
+						<Select.Item class={selectItemClass} value="low" label="low" />
+						<Select.Item class={selectItemClass} value="medium" label="medium" />
+						<Select.Item class={selectItemClass} value="high" label="high" />
+					</Select.Content>
+				</Select.Root>
+				{#if st.aStr(["memory", "pipelineV2", "extractionStrength"])}
+					<span class="text-[9px] text-[var(--sig-text-muted)] tracking-wider uppercase">{strengthMaxTokensLabel()} max tokens</span>
+				{/if}
+				{#if (st.aStr(["memory", "pipelineV2", "extractionStrength"]) || "low") === "high"}
+					<span class="text-[9px] text-[var(--sig-danger)] tracking-wider uppercase">running extraction at high is usually unnecessary and will increase API costs significantly</span>
+				{/if}
+			</div>
+		</FormField>
+
 		{#each PIPELINE_FEATURE_BOOLS.filter(b => TOP_LEVEL_FEATURE_KEYS.includes(b.key as typeof TOP_LEVEL_FEATURE_KEYS[number])) as { key, desc } (key)}
 			<FormField label={key} description={desc}>
 				<Switch checked={st.aBool(["memory", "pipelineV2", key])} onCheckedChange={setBool(["memory", "pipelineV2", key])} />
 			</FormField>
 		{/each}
 
-		<!-- Reranker -->
 		{#each PIPELINE_RERANKER_BOOLS as { key, desc } (key)}
 			<FormField label={key} description={desc}>
 				<Switch checked={st.aBool(["memory", "pipelineV2", key])} onCheckedChange={setBool(["memory", "pipelineV2", key])} />
 			</FormField>
 		{/each}
 
-		<!-- Predictor subsection -->
+		<div class="font-[family-name:var(--font-mono)] text-[9px] tracking-[0.08em] uppercase text-[var(--sig-text-muted)] pt-3 pb-1 border-b border-[var(--sig-border)] mb-1">
+			Model Registry
+		</div>
+		<FormField label="modelRegistryEnabled" description="Auto-discover available models from each provider. New models appear without code changes.">
+			<Switch checked={st.aBool(["memory", "pipelineV2", "modelRegistry", "enabled"])} onCheckedChange={setBool(["memory", "pipelineV2", "modelRegistry", "enabled"])} />
+		</FormField>
+
 		<div class="font-[family-name:var(--font-mono)] text-[9px] tracking-[0.08em] uppercase text-[var(--sig-text-muted)] pt-3 pb-1 border-b border-[var(--sig-border)] mb-1">
 			Predictor
 		</div>
@@ -205,7 +303,6 @@ const ADVANCED_FEATURE_KEYS = ["autonomousFrozen"] as const;
 			<Switch checked={st.aBool(["memory", "pipelineV2", "predictorPipeline", "trainingTelemetry"])} onCheckedChange={setBool(["memory", "pipelineV2", "predictorPipeline", "trainingTelemetry"])} />
 		</FormField>
 
-		<!-- Advanced collapsible -->
 		<AdvancedSection>
 			<FormField label={PIPELINE_CORE_BOOLS[1].key} description={PIPELINE_CORE_BOOLS[1].desc}>
 				<Switch checked={st.aBool(["memory", "pipelineV2", PIPELINE_CORE_BOOLS[1].key])} onCheckedChange={setBool(["memory", "pipelineV2", PIPELINE_CORE_BOOLS[1].key])} />
@@ -226,10 +323,10 @@ const ADVANCED_FEATURE_KEYS = ["autonomousFrozen"] as const;
 					onValueChange={setSelect(["memory", "pipelineV2", "maintenanceMode"])}
 				>
 					<Select.Trigger class={selectTriggerClass}>
-						{st.aStr(["memory", "pipelineV2", "maintenanceMode"]) || "\u2014 select \u2014"}
+						{st.aStr(["memory", "pipelineV2", "maintenanceMode"]) || "None selected"}
 					</Select.Trigger>
 					<Select.Content class={selectContentClass}>
-						<Select.Item class={selectItemClass} value="" label="\u2014 select \u2014" />
+						<Select.Item class={selectItemClass} value="" label="None selected" />
 						<Select.Item class={selectItemClass} value="observe" label="observe" />
 						<Select.Item class={selectItemClass} value="execute" label="execute" />
 					</Select.Content>

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
@@ -157,7 +157,10 @@ function setExtractionProvider(v: string | undefined): void {
 	const currentModel = st.aStr(["memory", "pipelineV2", "extractionModel"]);
 	customModelActive = false;
 	st.aSetStr(["memory", "pipelineV2", "extractionProvider"], nextProvider);
-	if (!nextProvider) return;
+	if (!nextProvider) {
+		st.aSetStr(["memory", "pipelineV2", "extractionModel"], "");
+		return;
+	}
 	if (!currentModel || isKnownPreset(currentModel)) {
 		st.aSetStr(["memory", "pipelineV2", "extractionModel"], defaultModelForProvider(nextProvider));
 	}

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
@@ -76,7 +76,9 @@ $effect(() => {
 	// Re-fetch when registry toggle changes
 	const _enabled = st.aBool(["memory", "pipelineV2", "modelRegistry", "enabled"]);
 	void _enabled;
+	let cancelled = false;
 	getModelsByProvider().then((models) => {
+		if (cancelled) return;
 		if (models && Object.keys(models).length > 0) {
 			dynamicModels = models;
 			registryLoaded = true;
@@ -84,6 +86,7 @@ $effect(() => {
 	}).catch(() => {
 		// Registry unavailable — fall back to static presets
 	});
+	return () => { cancelled = true; };
 });
 
 function getModelPresets(provider: string): Array<{ value: string; label: string }> {

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
@@ -164,6 +164,7 @@ function setExtractionProvider(v: string | undefined): void {
 function setExtractionModelPreset(v: string | undefined): void {
 	if (!v) {
 		customModelActive = false;
+		st.aSetStr(["memory", "pipelineV2", "extractionModel"], "");
 		return;
 	}
 	if (v === "__custom__") {

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
@@ -73,6 +73,9 @@ let dynamicModels = $state<Record<string, ModelRegistryEntry[]>>({});
 let registryLoaded = $state(false);
 
 $effect(() => {
+	// Re-fetch when registry toggle changes
+	const _enabled = st.aBool(["memory", "pipelineV2", "modelRegistry", "enabled"]);
+	void _enabled;
 	getModelsByProvider().then((models) => {
 		if (models && Object.keys(models).length > 0) {
 			dynamicModels = models;
@@ -268,7 +271,11 @@ const ADVANCED_FEATURE_KEYS = ["autonomousFrozen"] as const;
 						<Select.Item class={selectItemClass} value="high" label="high" />
 					</Select.Content>
 				</Select.Root>
+				{#if st.aStr(["memory", "pipelineV2", "extractionStrength"])}
 				<span class="text-[9px] text-[var(--sig-text-muted)] tracking-wider uppercase">{strengthMaxTokensLabel()} max tokens</span>
+			{:else}
+				<span class="text-[9px] text-[var(--sig-text-muted)] tracking-wider uppercase">default: 1024 max tokens</span>
+			{/if}
 				{#if (st.aStr(["memory", "pipelineV2", "extractionStrength"]) || "low") === "high"}
 					<span class="text-[9px] text-[var(--sig-danger)] tracking-wider uppercase">running extraction at high is usually unnecessary and will increase API costs significantly</span>
 				{/if}

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
@@ -78,6 +78,8 @@ $effect(() => {
 			dynamicModels = models;
 			registryLoaded = true;
 		}
+	}).catch(() => {
+		// Registry unavailable — fall back to static presets
 	});
 });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,6 +72,8 @@ export type {
 	TaskMeta,
 	PipelineStructuralConfig,
 	PipelineSignificanceConfig,
+	PipelineModelRegistryConfig,
+	ModelRegistryEntry,
 } from "./types";
 export { parseManifest, generateManifest } from "./manifest";
 export { parseSoul, generateSoul } from "./soul";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -151,6 +151,7 @@ export interface PipelineEscalationConfig {
 export interface PipelineExtractionConfig {
 	readonly provider: "ollama" | "claude-code" | "opencode" | "codex" | "anthropic";
 	readonly model: string;
+	readonly strength: "low" | "medium" | "high";
 	readonly endpoint?: string;
 	readonly timeout: number;
 	readonly minConfidence: number;
@@ -265,6 +266,20 @@ export interface PipelineV2Config {
 	readonly significance?: PipelineSignificanceConfig;
 	readonly predictor?: PredictorConfig;
 	readonly predictorPipeline: PipelinePredictorConfig;
+	readonly modelRegistry: PipelineModelRegistryConfig;
+}
+
+export interface ModelRegistryEntry {
+	readonly id: string;
+	readonly provider: string;
+	readonly label: string;
+	readonly tier: "high" | "mid" | "low";
+	readonly deprecated: boolean;
+}
+
+export interface PipelineModelRegistryConfig {
+	readonly enabled: boolean;
+	readonly refreshIntervalMs: number;
 }
 
 export interface PipelinePredictorConfig {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -9468,10 +9468,21 @@ async function main() {
 
 	// Initialize model registry for dynamic model discovery
 	if (memoryCfg.pipelineV2.modelRegistry.enabled) {
+		let registryAnthropicApiKey = anthropicApiKey;
+		if (!registryAnthropicApiKey) {
+			registryAnthropicApiKey = process.env.ANTHROPIC_API_KEY;
+			if (!registryAnthropicApiKey) {
+				try {
+					registryAnthropicApiKey = (await getSecret("ANTHROPIC_API_KEY")) ?? undefined;
+				} catch {
+					// ignore: registry can still run without Anthropic discovery
+				}
+			}
+		}
 		initModelRegistry(
 			memoryCfg.pipelineV2.modelRegistry,
 			effectiveExtractionProvider === "ollama" ? extractionOllamaBaseUrl : undefined,
-			anthropicApiKey,
+			registryAnthropicApiKey,
 		);
 	}
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -148,6 +148,14 @@ import {
 	ensureOpenCodeServer,
 	stopOpenCodeServer,
 } from "./pipeline/provider";
+import {
+	initModelRegistry,
+	getAvailableModels,
+	getModelsByProvider,
+	getRegistryStatus,
+	refreshRegistry,
+	stopModelRegistry,
+} from "./pipeline/model-registry";
 import { type RerankCandidate, noopReranker, rerank } from "./pipeline/reranker";
 import { createEmbeddingReranker } from "./pipeline/reranker-embedding";
 import {
@@ -6613,6 +6621,41 @@ app.get("/api/pipeline/status", (c) => {
 	});
 });
 
+// ---------------------------------------------------------------------------
+// Model Registry endpoints
+// ---------------------------------------------------------------------------
+
+app.get("/api/pipeline/models", (c) => {
+	const provider = c.req.query("provider");
+	const includeDeprecated = c.req.query("deprecated") === "true";
+	return c.json({
+		models: getAvailableModels(provider ?? undefined, includeDeprecated),
+		registry: getRegistryStatus(),
+	});
+});
+
+app.get("/api/pipeline/models/by-provider", (c) => {
+	return c.json(getModelsByProvider());
+});
+
+app.post("/api/pipeline/models/refresh", async (c) => {
+	const cfg = loadMemoryConfig(AGENTS_DIR);
+	let anthropicKey: string | undefined = process.env.ANTHROPIC_API_KEY;
+	if (!anthropicKey) {
+		try {
+			anthropicKey = await getSecret("ANTHROPIC_API_KEY") ?? undefined;
+		} catch { /* ignore */ }
+	}
+	await refreshRegistry(
+		cfg.pipelineV2.extraction.provider === "ollama" ? "http://localhost:11434" : undefined,
+		anthropicKey,
+	);
+	return c.json({
+		models: getModelsByProvider(),
+		registry: getRegistryStatus(),
+	});
+});
+
 app.get("/api/predictor/status", async (c) => {
 	const cfg = loadMemoryConfig(AGENTS_DIR);
 	const predictorCfg = cfg.pipelineV2.predictor;
@@ -9126,6 +9169,7 @@ async function cleanup() {
 	closeLlmProvider();
 	closeSynthesisProvider();
 	stopOpenCodeServer();
+	stopModelRegistry();
 
 	// Stop git sync timer
 	stopGitSyncTimer();
@@ -9181,6 +9225,7 @@ async function main() {
 
 	// Migrations may have created traversal tables — clear the cache
 	invalidateTraversalCache();
+
 
 	// Write PID file
 	writeFileSync(PID_FILE, process.pid.toString());
@@ -9411,6 +9456,15 @@ async function main() {
 								defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 							});
 	initLlmProvider(llmProvider);
+
+	// Initialize model registry for dynamic model discovery
+	if (memoryCfg.pipelineV2.modelRegistry.enabled) {
+		initModelRegistry(
+			memoryCfg.pipelineV2.modelRegistry,
+			effectiveExtractionProvider === "ollama" ? "http://localhost:11434" : undefined,
+			anthropicApiKey,
+		);
+	}
 
 	// Create synthesis provider — separate from extraction because synthesis
 	// needs a smarter model that can reason across long context

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6647,7 +6647,19 @@ app.get("/api/pipeline/models/by-provider", (c) => {
 	return c.json(getModelsByProvider());
 });
 
+let lastRefreshRequestAt = 0;
+const REFRESH_COOLDOWN_MS = 60_000;
+
 app.post("/api/pipeline/models/refresh", async (c) => {
+	const now = Date.now();
+	if (now - lastRefreshRequestAt < REFRESH_COOLDOWN_MS) {
+		return c.json({
+			models: getModelsByProvider(),
+			registry: getRegistryStatus(),
+			throttled: true,
+		}, 429);
+	}
+	lastRefreshRequestAt = now;
 	const cfg = loadMemoryConfig(AGENTS_DIR);
 	let anthropicKey: string | undefined = process.env.ANTHROPIC_API_KEY;
 	if (!anthropicKey) {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -272,6 +272,15 @@ function normalizeRuntimeBaseUrl(url: string | undefined, fallback: string): str
 	}
 }
 
+/**
+ * Resolve the Ollama base URL for the model registry, returning undefined
+ * when the current provider is not Ollama.
+ */
+function resolveRegistryOllamaBaseUrl(provider: string, endpoint: string | undefined): string | undefined {
+	if (provider !== "ollama") return undefined;
+	return normalizeRuntimeBaseUrl(endpoint, "http://127.0.0.1:11434");
+}
+
 function isManagedOpenCodeLocalEndpoint(baseUrl: string): boolean {
 	try {
 		const parsed = new URL(baseUrl);
@@ -6647,7 +6656,7 @@ app.post("/api/pipeline/models/refresh", async (c) => {
 		} catch { /* ignore */ }
 	}
 	await refreshRegistry(
-		cfg.pipelineV2.extraction.provider === "ollama" ? "http://localhost:11434" : undefined,
+		resolveRegistryOllamaBaseUrl(cfg.pipelineV2.extraction.provider, cfg.pipelineV2.extraction.endpoint),
 		anthropicKey,
 	);
 	return c.json({
@@ -9461,7 +9470,7 @@ async function main() {
 	if (memoryCfg.pipelineV2.modelRegistry.enabled) {
 		initModelRegistry(
 			memoryCfg.pipelineV2.modelRegistry,
-			effectiveExtractionProvider === "ollama" ? "http://localhost:11434" : undefined,
+			effectiveExtractionProvider === "ollama" ? extractionOllamaBaseUrl : undefined,
 			anthropicApiKey,
 		);
 	}

--- a/packages/daemon/src/memory-config.ts
+++ b/packages/daemon/src/memory-config.ts
@@ -208,6 +208,10 @@ function clampFraction(raw: unknown, fallback: number): number {
 	return Math.max(0, Math.min(1, raw));
 }
 
+function isExtractionStrength(v: unknown): v is "low" | "medium" | "high" {
+	return typeof v === "string" && ["low", "medium", "high"].includes(v);
+}
+
 function parseOptionalUrl(raw: unknown): string | undefined {
 	if (typeof raw !== "string") return undefined;
 	const trimmed = raw.trim();
@@ -320,9 +324,10 @@ export function loadPipelineConfig(
 					: flatModelOnly
 						? flatModel
 						: d.extraction.model,
-			strength: (["low", "medium", "high"].includes(extractionRaw?.strength ?? raw.extractionStrength)
-				? (extractionRaw?.strength ?? raw.extractionStrength)
-				: d.extraction.strength) as "low" | "medium" | "high",
+			strength: (() => {
+				const candidate = extractionRaw?.strength ?? raw.extractionStrength;
+				return isExtractionStrength(candidate) ? candidate : d.extraction.strength;
+			})(),
 			endpoint:
 				parseOptionalUrl(extractionRaw?.endpoint) ??
 				parseOptionalUrl(extractionRaw?.base_url) ??

--- a/packages/daemon/src/memory-config.ts
+++ b/packages/daemon/src/memory-config.ts
@@ -325,7 +325,8 @@ export function loadPipelineConfig(
 						? flatModel
 						: d.extraction.model,
 			strength: (() => {
-				const candidate = extractionRaw?.strength ?? raw.extractionStrength;
+				// Flat keys win when set (dashboard writes these); nested is fallback
+				const candidate = raw.extractionStrength ?? extractionRaw?.strength;
 				return isExtractionStrength(candidate) ? candidate : d.extraction.strength;
 			})(),
 			endpoint:

--- a/packages/daemon/src/memory-config.ts
+++ b/packages/daemon/src/memory-config.ts
@@ -37,6 +37,7 @@ export const DEFAULT_PIPELINE_V2: PipelineV2Config = {
 	extraction: {
 		provider: "claude-code",
 		model: "haiku",
+		strength: "low",
 		endpoint: undefined,
 		timeout: 90000,
 		minConfidence: 0.7,
@@ -176,6 +177,10 @@ export const DEFAULT_PIPELINE_V2: PipelineV2Config = {
 		agentFeedback: true,
 		trainingTelemetry: true,
 	},
+	modelRegistry: {
+		enabled: true,
+		refreshIntervalMs: 3600_000,
+	},
 };
 
 export const DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434";
@@ -242,6 +247,7 @@ export function loadPipelineConfig(
 	const significanceRaw = raw.significance as Record<string, unknown> | undefined;
 	const predictorRaw = raw.predictor as Record<string, unknown> | undefined;
 	const predictorPipelineRaw = raw.predictorPipeline as Record<string, unknown> | undefined;
+	const modelRegistryRaw = raw.modelRegistry as Record<string, unknown> | undefined;
 
 	// Helper: resolve with flat-fallback (non-extraction fields still nested-first)
 	const d = DEFAULT_PIPELINE_V2;
@@ -314,6 +320,9 @@ export function loadPipelineConfig(
 					: flatModelOnly
 						? flatModel
 						: d.extraction.model,
+			strength: (["low", "medium", "high"].includes(extractionRaw?.strength ?? raw.extractionStrength)
+				? (extractionRaw?.strength ?? raw.extractionStrength)
+				: d.extraction.strength) as "low" | "medium" | "high",
 			endpoint:
 				parseOptionalUrl(extractionRaw?.endpoint) ??
 				parseOptionalUrl(extractionRaw?.base_url) ??
@@ -866,6 +875,18 @@ export function loadPipelineConfig(
 			),
 			trainingTelemetry: resolveBool(
 				predictorPipelineRaw?.trainingTelemetry, undefined, d.predictorPipeline.trainingTelemetry,
+			),
+		},
+
+		modelRegistry: {
+			enabled: resolveBool(
+				modelRegistryRaw?.enabled, undefined, d.modelRegistry.enabled,
+			),
+			refreshIntervalMs: clampPositive(
+				modelRegistryRaw?.refreshIntervalMs,
+				60000,
+				86400000,
+				d.modelRegistry.refreshIntervalMs,
 			),
 		},
 	};

--- a/packages/daemon/src/pipeline/extraction-escalation.ts
+++ b/packages/daemon/src/pipeline/extraction-escalation.ts
@@ -231,7 +231,7 @@ export async function escalate(
 	accessor: DbAccessor,
 	agentId: string,
 	thresholds: PipelineEscalationConfig,
-	opts?: { timeoutMs?: number },
+	opts?: { timeoutMs?: number; maxTokens?: number },
 ): Promise<EscalatedExtraction> {
 	const originalEntityCount = extraction.entities.length;
 	const originalFactCount = extraction.facts.length;

--- a/packages/daemon/src/pipeline/extraction-escalation.ts
+++ b/packages/daemon/src/pipeline/extraction-escalation.ts
@@ -107,12 +107,12 @@ async function runLevel2Extraction(
 	content: string,
 	provider: LlmProvider,
 	maxEntities: number,
-	timeoutMs?: number,
+	opts?: { timeoutMs?: number; maxTokens?: number },
 ): Promise<ExtractionResult> {
 	const prompt = buildLevel2Prompt(content, maxEntities);
 	let rawOutput: string;
 	try {
-		rawOutput = await provider.generate(prompt, { timeoutMs });
+		rawOutput = await provider.generate(prompt, { timeoutMs: opts?.timeoutMs, maxTokens: opts?.maxTokens });
 	} catch (e) {
 		const msg = e instanceof Error ? e.message : String(e);
 		logger.warn("pipeline", "Level 2 extraction LLM call failed", {
@@ -253,7 +253,7 @@ export async function escalate(
 		content,
 		provider,
 		thresholds.level2MaxEntities,
-		opts?.timeoutMs,
+		opts,
 	);
 	const level2Needed = checkEscalationNeeded(level2, thresholds);
 	if (level2Needed === 1) {

--- a/packages/daemon/src/pipeline/extraction.ts
+++ b/packages/daemon/src/pipeline/extraction.ts
@@ -321,7 +321,7 @@ export function parseRawExtractionOutput(rawOutput: string): ExtractionResult {
 export async function extractFactsAndEntities(
 	input: string,
 	provider: LlmProvider,
-	opts?: { timeoutMs?: number },
+	opts?: { timeoutMs?: number; maxTokens?: number },
 ): Promise<ExtractionResult> {
 	const trimmed = input.trim().replace(/\s+/g, " ");
 	if (trimmed.length < 20) {
@@ -340,6 +340,7 @@ export async function extractFactsAndEntities(
 	try {
 		rawOutput = await provider.generate(prompt, {
 			timeoutMs: opts?.timeoutMs,
+			maxTokens: opts?.maxTokens,
 		});
 	} catch (e) {
 		const msg = e instanceof Error ? e.message : String(e);

--- a/packages/daemon/src/pipeline/model-registry.ts
+++ b/packages/daemon/src/pipeline/model-registry.ts
@@ -309,12 +309,12 @@ async function _refreshRegistryInner(ollamaBaseUrl?: string, anthropicApiKey?: s
 	if (!state || state.epoch !== startEpoch) return;
 
 	if (ollamaModels.length > 0) {
-		// Merge discovered with known, dedup by id
+		// Merge discovered with known, dedup by id, then mark deprecations
 		const known = KNOWN_MODELS.ollama ?? [];
 		const merged = new Map<string, ModelRegistryEntry>();
 		for (const m of known) merged.set(m.id, m);
 		for (const m of ollamaModels) merged.set(m.id, m);
-		state.models.set("ollama", [...merged.values()]);
+		state.models.set("ollama", markDeprecatedVersions([...merged.values()]));
 	}
 
 	if (anthropicModels.length > 0) {

--- a/packages/daemon/src/pipeline/model-registry.ts
+++ b/packages/daemon/src/pipeline/model-registry.ts
@@ -143,10 +143,12 @@ interface RegistryState {
 	models: Map<string, ModelRegistryEntry[]>;
 	lastRefreshAt: number;
 	refreshTimer: ReturnType<typeof setInterval> | null;
+	epoch: number;
 }
 
 let state: RegistryState | null = null;
 let refreshInFlight: Promise<void> | null = null;
+let registryEpoch = 0;
 
 // ---------------------------------------------------------------------------
 // Discovery functions
@@ -237,10 +239,12 @@ export function initModelRegistry(
 		clearInterval(state.refreshTimer);
 	}
 
+	registryEpoch++;
 	state = {
 		models: new Map(),
 		lastRefreshAt: 0,
 		refreshTimer: null,
+		epoch: registryEpoch,
 	};
 
 	// Seed with known models
@@ -291,6 +295,7 @@ export async function refreshRegistry(ollamaBaseUrl?: string, anthropicApiKey?: 
 
 async function _refreshRegistryInner(ollamaBaseUrl?: string, anthropicApiKey?: string): Promise<void> {
 	if (!state) return;
+	const startEpoch = state.epoch;
 
 	logger.debug("model-registry", "Refreshing model registry");
 
@@ -300,7 +305,8 @@ async function _refreshRegistryInner(ollamaBaseUrl?: string, anthropicApiKey?: s
 		discoverAnthropicModels(anthropicApiKey),
 	]);
 
-	if (!state) return; // registry may have been stopped during discovery
+	// Bail if registry was stopped or re-initialized during discovery
+	if (!state || state.epoch !== startEpoch) return;
 
 	if (ollamaModels.length > 0) {
 		// Merge discovered with known, dedup by id
@@ -332,8 +338,9 @@ async function _refreshRegistryInner(ollamaBaseUrl?: string, anthropicApiKey?: s
  */
 export function getAvailableModels(provider?: string, includeDeprecated = false): ModelRegistryEntry[] {
 	if (!state) {
-		// Return known models if registry not initialized
-		const all = provider ? (KNOWN_MODELS[provider] ?? []) : Object.values(KNOWN_MODELS).flat();
+		// Return known models with deprecation marks if registry not initialized
+		const raw = provider ? (KNOWN_MODELS[provider] ?? []) : Object.values(KNOWN_MODELS).flat();
+		const all = markDeprecatedVersions(raw);
 		return includeDeprecated ? all : all.filter((m) => !m.deprecated);
 	}
 
@@ -353,7 +360,7 @@ export function getModelsByProvider(): Record<string, ModelRegistryEntry[]> {
 	const result: Record<string, ModelRegistryEntry[]> = {};
 	if (!state) {
 		for (const [provider, models] of Object.entries(KNOWN_MODELS)) {
-			result[provider] = models.filter((m) => !m.deprecated);
+			result[provider] = markDeprecatedVersions(models).filter((m) => !m.deprecated);
 		}
 		return result;
 	}

--- a/packages/daemon/src/pipeline/model-registry.ts
+++ b/packages/daemon/src/pipeline/model-registry.ts
@@ -105,10 +105,10 @@ function cleanModelLabel(raw: string): string {
 }
 
 /**
- * Given a list of models, mark older versions of the same family as
- * deprecated. Mutates entries in place.
+ * Given a list of models, return a new array with older versions of the
+ * same family marked as deprecated. Does not mutate the input.
  */
-function markDeprecatedVersions(entries: ModelRegistryEntry[]): void {
+function markDeprecatedVersions(entries: readonly ModelRegistryEntry[]): ModelRegistryEntry[] {
 	const familyBest = new Map<string, { version: number; id: string }>();
 
 	for (const entry of entries) {
@@ -122,16 +122,17 @@ function markDeprecatedVersions(entries: ModelRegistryEntry[]): void {
 		}
 	}
 
-	for (const entry of entries) {
+	return entries.map((entry) => {
 		const family = parseModelFamily(entry.id);
 		const version = parseModelVersion(entry.id);
-		if (version === null) continue;
+		if (version === null) return { ...entry };
 
 		const best = familyBest.get(family);
 		if (best && best.id !== entry.id && version < best.version) {
-			(entry as { deprecated: boolean }).deprecated = true;
+			return { ...entry, deprecated: true };
 		}
-	}
+		return { ...entry };
+	});
 }
 
 // ---------------------------------------------------------------------------
@@ -195,7 +196,7 @@ async function discoverAnthropicModels(apiKey: string | undefined): Promise<Mode
 		const data = (await res.json()) as { data?: Array<{ id: string; display_name?: string }> };
 		if (!Array.isArray(data.data)) return KNOWN_MODELS.anthropic ?? [];
 
-		const entries: ModelRegistryEntry[] = data.data
+		let entries: ModelRegistryEntry[] = data.data
 			.filter((m) => m.id.startsWith("claude-"))
 			.map((m) => {
 				const tier: "high" | "mid" | "low" = m.id.includes("opus") ? "high" : m.id.includes("sonnet") ? "mid" : "low";
@@ -208,7 +209,7 @@ async function discoverAnthropicModels(apiKey: string | undefined): Promise<Mode
 				};
 			});
 
-		markDeprecatedVersions(entries);
+		entries = markDeprecatedVersions(entries);
 		return entries.length > 0 ? entries : (KNOWN_MODELS.anthropic ?? []);
 	} catch {
 		logger.debug("model-registry", "Anthropic model discovery failed, using known list");

--- a/packages/daemon/src/pipeline/model-registry.ts
+++ b/packages/daemon/src/pipeline/model-registry.ts
@@ -299,9 +299,9 @@ async function _refreshRegistryInner(ollamaBaseUrl?: string, anthropicApiKey?: s
 
 	logger.debug("model-registry", "Refreshing model registry");
 
-	// Discover Ollama models in parallel with Anthropic
+	// Discover models in parallel — only probe providers that are configured
 	const [ollamaModels, anthropicModels] = await Promise.all([
-		discoverOllamaModels(ollamaBaseUrl ?? "http://localhost:11434"),
+		ollamaBaseUrl ? discoverOllamaModels(ollamaBaseUrl) : Promise.resolve([]),
 		discoverAnthropicModels(anthropicApiKey),
 	]);
 

--- a/packages/daemon/src/pipeline/model-registry.ts
+++ b/packages/daemon/src/pipeline/model-registry.ts
@@ -243,12 +243,17 @@ export function initModelRegistry(
 	}
 
 	// Run initial discovery
-	refreshRegistry(ollamaBaseUrl, anthropicApiKey).catch(() => {});
+	refreshRegistry(ollamaBaseUrl, anthropicApiKey).catch((err) => {
+		logger.warn("model-registry", "Initial registry refresh failed", { error: String(err) });
+	});
 
 	// Schedule periodic refresh
 	if (config.refreshIntervalMs > 0) {
 		state.refreshTimer = setInterval(
-			() => refreshRegistry(ollamaBaseUrl, anthropicApiKey).catch(() => {}),
+			() =>
+				refreshRegistry(ollamaBaseUrl, anthropicApiKey).catch((err) => {
+					logger.warn("model-registry", "Periodic registry refresh failed", { error: String(err) });
+				}),
 			config.refreshIntervalMs,
 		);
 	}
@@ -270,6 +275,8 @@ export async function refreshRegistry(ollamaBaseUrl?: string, anthropicApiKey?: 
 		discoverAnthropicModels(anthropicApiKey),
 	]);
 
+	if (!state) return; // registry may have been stopped during discovery
+
 	if (ollamaModels.length > 0) {
 		// Merge discovered with known, dedup by id
 		const known = KNOWN_MODELS.ollama ?? [];
@@ -281,39 +288,9 @@ export async function refreshRegistry(ollamaBaseUrl?: string, anthropicApiKey?: 
 
 	if (anthropicModels.length > 0) {
 		state.models.set("anthropic", anthropicModels);
-
-		// Also update claude-code aliases based on discovered models
-		const ccModels: ModelRegistryEntry[] = [];
-		const latestOpus = anthropicModels.find((m) => m.id.includes("opus") && !m.deprecated);
-		const latestSonnet = anthropicModels.find((m) => m.id.includes("sonnet") && !m.deprecated);
-		const latestHaiku = anthropicModels.find((m) => m.id.includes("haiku") && !m.deprecated);
-		if (latestOpus)
-			ccModels.push({
-				id: latestOpus.id,
-				provider: "claude-code",
-				label: latestOpus.label,
-				tier: "high",
-				deprecated: false,
-			});
-		if (latestSonnet)
-			ccModels.push({
-				id: latestSonnet.id,
-				provider: "claude-code",
-				label: latestSonnet.label,
-				tier: "mid",
-				deprecated: false,
-			});
-		if (latestHaiku)
-			ccModels.push({
-				id: latestHaiku.id,
-				provider: "claude-code",
-				label: latestHaiku.label,
-				tier: "low",
-				deprecated: false,
-			});
-		if (ccModels.length > 0) {
-			state.models.set("claude-code", ccModels);
-		}
+		// Do NOT overwrite "claude-code" — its IDs must match what the
+		// Claude Code CLI accepts (shorthand aliases, not dated Anthropic IDs).
+		// The seeded KNOWN_MODELS["claude-code"] entries use the correct shorthands.
 	}
 
 	state.lastRefreshAt = Date.now();

--- a/packages/daemon/src/pipeline/model-registry.ts
+++ b/packages/daemon/src/pipeline/model-registry.ts
@@ -146,6 +146,7 @@ interface RegistryState {
 }
 
 let state: RegistryState | null = null;
+let refreshInFlight: Promise<void> | null = null;
 
 // ---------------------------------------------------------------------------
 // Discovery functions
@@ -177,7 +178,7 @@ async function discoverOllamaModels(baseUrl: string): Promise<ModelRegistryEntry
 }
 
 async function discoverAnthropicModels(apiKey: string | undefined): Promise<ModelRegistryEntry[]> {
-	if (!apiKey) return KNOWN_MODELS.anthropic ?? [];
+	if (!apiKey) return markDeprecatedVersions(KNOWN_MODELS.anthropic ?? []);
 
 	try {
 		const res = await fetch("https://api.anthropic.com/v1/models", {
@@ -190,11 +191,11 @@ async function discoverAnthropicModels(apiKey: string | undefined): Promise<Mode
 
 		if (!res.ok) {
 			// API might not support /v1/models — fall back to known list
-			return KNOWN_MODELS.anthropic ?? [];
+			return markDeprecatedVersions(KNOWN_MODELS.anthropic ?? []);
 		}
 
 		const data = (await res.json()) as { data?: Array<{ id: string; display_name?: string }> };
-		if (!Array.isArray(data.data)) return KNOWN_MODELS.anthropic ?? [];
+		if (!Array.isArray(data.data)) return markDeprecatedVersions(KNOWN_MODELS.anthropic ?? []);
 
 		let entries: ModelRegistryEntry[] = data.data
 			.filter((m) => m.id.startsWith("claude-"))
@@ -210,10 +211,10 @@ async function discoverAnthropicModels(apiKey: string | undefined): Promise<Mode
 			});
 
 		entries = markDeprecatedVersions(entries);
-		return entries.length > 0 ? entries : (KNOWN_MODELS.anthropic ?? []);
+		return entries.length > 0 ? entries : markDeprecatedVersions(KNOWN_MODELS.anthropic ?? []);
 	} catch {
 		logger.debug("model-registry", "Anthropic model discovery failed, using known list");
-		return KNOWN_MODELS.anthropic ?? [];
+		return markDeprecatedVersions(KNOWN_MODELS.anthropic ?? []);
 	}
 }
 
@@ -229,6 +230,11 @@ export function initModelRegistry(
 	if (!config.enabled) {
 		logger.info("model-registry", "Model registry disabled");
 		return;
+	}
+
+	// Clean up any previous instance to avoid leaking timers
+	if (state?.refreshTimer) {
+		clearInterval(state.refreshTimer);
 	}
 
 	state = {
@@ -265,6 +271,25 @@ export function initModelRegistry(
 }
 
 export async function refreshRegistry(ollamaBaseUrl?: string, anthropicApiKey?: string): Promise<void> {
+	if (!state) return;
+
+	// Serialize refreshes to prevent stale out-of-order writes
+	if (refreshInFlight) {
+		await refreshInFlight;
+	}
+
+	const doRefresh = async (): Promise<void> => {
+		await _refreshRegistryInner(ollamaBaseUrl, anthropicApiKey);
+	};
+	refreshInFlight = doRefresh();
+	try {
+		await refreshInFlight;
+	} finally {
+		refreshInFlight = null;
+	}
+}
+
+async function _refreshRegistryInner(ollamaBaseUrl?: string, anthropicApiKey?: string): Promise<void> {
 	if (!state) return;
 
 	logger.debug("model-registry", "Refreshing model registry");
@@ -314,7 +339,7 @@ export function getAvailableModels(provider?: string, includeDeprecated = false)
 
 	if (provider) {
 		const models = state.models.get(provider) ?? [];
-		return includeDeprecated ? models : models.filter((m) => !m.deprecated);
+		return includeDeprecated ? [...models] : models.filter((m) => !m.deprecated);
 	}
 
 	const all = [...state.models.values()].flat();

--- a/packages/daemon/src/pipeline/model-registry.ts
+++ b/packages/daemon/src/pipeline/model-registry.ts
@@ -247,9 +247,9 @@ export function initModelRegistry(
 		epoch: registryEpoch,
 	};
 
-	// Seed with known models
+	// Seed with known models, applying deprecation marks
 	for (const [provider, models] of Object.entries(KNOWN_MODELS)) {
-		state.models.set(provider, [...models]);
+		state.models.set(provider, markDeprecatedVersions(models));
 	}
 
 	// Run initial discovery

--- a/packages/daemon/src/pipeline/model-registry.ts
+++ b/packages/daemon/src/pipeline/model-registry.ts
@@ -1,0 +1,391 @@
+/**
+ * Dynamic Model Registry
+ *
+ * Auto-discovers available models from each LLM provider and maintains
+ * a live registry. Replaces hardcoded model lists in the dashboard and
+ * config — when Anthropic ships claude-opus-4-7 or OpenAI ships
+ * gpt-6-codex, it appears automatically without code changes.
+ *
+ * Discovery strategies per provider:
+ * - Ollama: GET /api/tags (lists locally pulled models)
+ * - Anthropic: known model catalog with version probing
+ * - Claude Code: `claude --version` + known model aliases
+ * - Codex: `codex --version` + known model catalog
+ * - OpenCode: routes through configured model list
+ */
+
+import type { ModelRegistryEntry, PipelineModelRegistryConfig } from "@signet/core";
+import { logger } from "../logger";
+
+// ---------------------------------------------------------------------------
+// Known model catalogs (seed data, updated by discovery)
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical model catalogs per provider. Discovery enriches these at
+ * runtime, and deprecated entries get flagged automatically when a
+ * newer version of the same family is found.
+ */
+const KNOWN_MODELS: Record<string, ModelRegistryEntry[]> = {
+	"claude-code": [
+		{ id: "claude-opus-4-6", provider: "claude-code", label: "Claude Opus 4.6", tier: "high", deprecated: false },
+		{ id: "claude-sonnet-4-6", provider: "claude-code", label: "Claude Sonnet 4.6", tier: "mid", deprecated: false },
+		{ id: "claude-haiku-4-5", provider: "claude-code", label: "Claude Haiku 4.5", tier: "low", deprecated: false },
+		{ id: "claude-3-5-haiku-20241022", provider: "claude-code", label: "Claude 3.5 Haiku", tier: "low", deprecated: false },
+	],
+	anthropic: [
+		{ id: "claude-opus-4-6", provider: "anthropic", label: "Claude Opus 4.6", tier: "high", deprecated: false },
+		{ id: "claude-sonnet-4-6", provider: "anthropic", label: "Claude Sonnet 4.6", tier: "mid", deprecated: false },
+		{ id: "claude-haiku-4-5-20251001", provider: "anthropic", label: "Claude Haiku 4.5", tier: "low", deprecated: false },
+		{ id: "claude-3-5-haiku-20241022", provider: "anthropic", label: "Claude 3.5 Haiku", tier: "low", deprecated: false },
+	],
+	codex: [
+		{ id: "gpt-5.4", provider: "codex", label: "GPT 5.4", tier: "high", deprecated: false },
+		{ id: "gpt-5.3-codex", provider: "codex", label: "GPT 5.3 Codex", tier: "high", deprecated: false },
+		{ id: "gpt-5.3-codex-spark", provider: "codex", label: "GPT 5.3 Codex Spark", tier: "high", deprecated: false },
+		{ id: "gpt-5-codex", provider: "codex", label: "GPT 5 Codex", tier: "mid", deprecated: false },
+		{ id: "codex-mini-latest", provider: "codex", label: "Codex Mini", tier: "low", deprecated: false },
+	],
+	opencode: [
+		{ id: "anthropic/claude-opus-4-6", provider: "opencode", label: "Claude Opus 4.6", tier: "high", deprecated: false },
+		{ id: "anthropic/claude-sonnet-4-6", provider: "opencode", label: "Claude Sonnet 4.6", tier: "mid", deprecated: false },
+		{ id: "anthropic/claude-haiku-4-5-20251001", provider: "opencode", label: "Claude Haiku 4.5", tier: "low", deprecated: false },
+		{ id: "google/gemini-2.5-flash", provider: "opencode", label: "Gemini 2.5 Flash", tier: "low", deprecated: false },
+	],
+	ollama: [
+		{ id: "qwen3:4b", provider: "ollama", label: "Qwen3 4B", tier: "low", deprecated: false },
+		{ id: "glm-4.7-flash", provider: "ollama", label: "GLM 4.7 Flash", tier: "low", deprecated: false },
+		{ id: "llama3", provider: "ollama", label: "Llama 3", tier: "low", deprecated: false },
+	],
+};
+
+// ---------------------------------------------------------------------------
+// Version parsing for auto-deprecation
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a version number from a model ID for comparison.
+ * Examples: "claude-opus-4-6" → 4.6, "gpt-5.3-codex" → 5.3
+ */
+function parseModelVersion(modelId: string): number | null {
+	// Match patterns like 4.6, 4-6, 5.3
+	const match = modelId.match(/(\d+)[.\-](\d+)/);
+	if (!match) return null;
+	return Number.parseFloat(`${match[1]}.${match[2]}`);
+}
+
+/**
+ * Extract the model family from an ID.
+ * Examples: "claude-opus-4-6" → "claude-opus", "gpt-5.3-codex" → "gpt-codex"
+ */
+function parseModelFamily(modelId: string): string {
+	return modelId
+		.replace(/[-_]?\d+([.\-]\d+)?/g, "")
+		.replace(/--+/g, "-")
+		.replace(/^-|-$/g, "");
+}
+
+/**
+ * Clean a model label by stripping date suffixes (e.g. "20251001") and
+ * normalising "Claude X N.N" format so users see e.g. "Claude Opus 4.6"
+ * instead of "Claude claude-opus-4-6-20251001".
+ */
+function cleanModelLabel(raw: string): string {
+	// Strip trailing date stamps like "-20251001" or " 20250514"
+	let label = raw.replace(/[-\s]\d{8}$/, "");
+	// If the label is still a raw model ID, humanise it
+	if (/^claude-/.test(label)) {
+		label = label
+			.replace(/^claude-/, "Claude ")
+			.replace(/-(\d+)-(\d+)/, " $1.$2")
+			.replace(/-/g, " ")
+			.replace(/\b\w/g, (c) => c.toUpperCase());
+	}
+	return label;
+}
+
+/**
+ * Given a list of models, mark older versions of the same family as
+ * deprecated. Mutates entries in place.
+ */
+function markDeprecatedVersions(entries: ModelRegistryEntry[]): void {
+	const familyBest = new Map<string, { version: number; id: string }>();
+
+	for (const entry of entries) {
+		const family = parseModelFamily(entry.id);
+		const version = parseModelVersion(entry.id);
+		if (version === null) continue;
+
+		const best = familyBest.get(family);
+		if (!best || version > best.version) {
+			familyBest.set(family, { version, id: entry.id });
+		}
+	}
+
+	for (const entry of entries) {
+		const family = parseModelFamily(entry.id);
+		const version = parseModelVersion(entry.id);
+		if (version === null) continue;
+
+		const best = familyBest.get(family);
+		if (best && best.id !== entry.id && version < best.version) {
+			(entry as { deprecated: boolean }).deprecated = true;
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Registry state
+// ---------------------------------------------------------------------------
+
+interface RegistryState {
+	models: Map<string, ModelRegistryEntry[]>;
+	lastRefreshAt: number;
+	refreshTimer: ReturnType<typeof setInterval> | null;
+}
+
+let state: RegistryState | null = null;
+
+// ---------------------------------------------------------------------------
+// Discovery functions
+// ---------------------------------------------------------------------------
+
+async function discoverOllamaModels(baseUrl: string): Promise<ModelRegistryEntry[]> {
+	try {
+		const res = await fetch(`${baseUrl}/api/tags`, {
+			signal: AbortSignal.timeout(5000),
+		});
+		if (!res.ok) return [];
+
+		const data = (await res.json()) as {
+			models?: Array<{ name: string; details?: { family?: string; parameter_size?: string } }>;
+		};
+		if (!Array.isArray(data.models)) return [];
+
+		return data.models.map((m) => ({
+			id: m.name,
+			provider: "ollama",
+			label: `${m.name}${m.details?.parameter_size ? ` (${m.details.parameter_size})` : ""}`,
+			tier: "low" as const,
+			deprecated: false,
+		}));
+	} catch {
+		logger.debug("model-registry", "Ollama discovery failed (expected if not running)");
+		return [];
+	}
+}
+
+async function discoverAnthropicModels(apiKey: string | undefined): Promise<ModelRegistryEntry[]> {
+	if (!apiKey) return KNOWN_MODELS.anthropic ?? [];
+
+	try {
+		const res = await fetch("https://api.anthropic.com/v1/models", {
+			headers: {
+				"x-api-key": apiKey,
+				"anthropic-version": "2023-06-01",
+			},
+			signal: AbortSignal.timeout(10000),
+		});
+
+		if (!res.ok) {
+			// API might not support /v1/models — fall back to known list
+			return KNOWN_MODELS.anthropic ?? [];
+		}
+
+		const data = (await res.json()) as { data?: Array<{ id: string; display_name?: string }> };
+		if (!Array.isArray(data.data)) return KNOWN_MODELS.anthropic ?? [];
+
+		const entries: ModelRegistryEntry[] = data.data
+			.filter((m) => m.id.startsWith("claude-"))
+			.map((m) => {
+				const tier: "high" | "mid" | "low" = m.id.includes("opus") ? "high" : m.id.includes("sonnet") ? "mid" : "low";
+				return {
+					id: m.id,
+					provider: "anthropic",
+					label: cleanModelLabel(m.display_name ?? m.id),
+					tier,
+					deprecated: false,
+				};
+			});
+
+		markDeprecatedVersions(entries);
+		return entries.length > 0 ? entries : (KNOWN_MODELS.anthropic ?? []);
+	} catch {
+		logger.debug("model-registry", "Anthropic model discovery failed, using known list");
+		return KNOWN_MODELS.anthropic ?? [];
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function initModelRegistry(
+	config: PipelineModelRegistryConfig,
+	ollamaBaseUrl?: string,
+	anthropicApiKey?: string,
+): void {
+	if (!config.enabled) {
+		logger.info("model-registry", "Model registry disabled");
+		return;
+	}
+
+	state = {
+		models: new Map(),
+		lastRefreshAt: 0,
+		refreshTimer: null,
+	};
+
+	// Seed with known models
+	for (const [provider, models] of Object.entries(KNOWN_MODELS)) {
+		state.models.set(provider, [...models]);
+	}
+
+	// Run initial discovery
+	refreshRegistry(ollamaBaseUrl, anthropicApiKey).catch(() => {});
+
+	// Schedule periodic refresh
+	if (config.refreshIntervalMs > 0) {
+		state.refreshTimer = setInterval(
+			() => refreshRegistry(ollamaBaseUrl, anthropicApiKey).catch(() => {}),
+			config.refreshIntervalMs,
+		);
+	}
+
+	logger.info("model-registry", "Model registry initialized", {
+		refreshIntervalMs: config.refreshIntervalMs,
+		providers: Object.keys(KNOWN_MODELS).length,
+	});
+}
+
+export async function refreshRegistry(ollamaBaseUrl?: string, anthropicApiKey?: string): Promise<void> {
+	if (!state) return;
+
+	logger.debug("model-registry", "Refreshing model registry");
+
+	// Discover Ollama models in parallel with Anthropic
+	const [ollamaModels, anthropicModels] = await Promise.all([
+		discoverOllamaModels(ollamaBaseUrl ?? "http://localhost:11434"),
+		discoverAnthropicModels(anthropicApiKey),
+	]);
+
+	if (ollamaModels.length > 0) {
+		// Merge discovered with known, dedup by id
+		const known = KNOWN_MODELS.ollama ?? [];
+		const merged = new Map<string, ModelRegistryEntry>();
+		for (const m of known) merged.set(m.id, m);
+		for (const m of ollamaModels) merged.set(m.id, m);
+		state.models.set("ollama", [...merged.values()]);
+	}
+
+	if (anthropicModels.length > 0) {
+		state.models.set("anthropic", anthropicModels);
+
+		// Also update claude-code aliases based on discovered models
+		const ccModels: ModelRegistryEntry[] = [];
+		const latestOpus = anthropicModels.find((m) => m.id.includes("opus") && !m.deprecated);
+		const latestSonnet = anthropicModels.find((m) => m.id.includes("sonnet") && !m.deprecated);
+		const latestHaiku = anthropicModels.find((m) => m.id.includes("haiku") && !m.deprecated);
+		if (latestOpus)
+			ccModels.push({
+				id: latestOpus.id,
+				provider: "claude-code",
+				label: latestOpus.label,
+				tier: "high",
+				deprecated: false,
+			});
+		if (latestSonnet)
+			ccModels.push({
+				id: latestSonnet.id,
+				provider: "claude-code",
+				label: latestSonnet.label,
+				tier: "mid",
+				deprecated: false,
+			});
+		if (latestHaiku)
+			ccModels.push({
+				id: latestHaiku.id,
+				provider: "claude-code",
+				label: latestHaiku.label,
+				tier: "low",
+				deprecated: false,
+			});
+		if (ccModels.length > 0) {
+			state.models.set("claude-code", ccModels);
+		}
+	}
+
+	state.lastRefreshAt = Date.now();
+	const totalModels = [...state.models.values()].reduce((sum, arr) => sum + arr.length, 0);
+	logger.info("model-registry", "Registry refreshed", {
+		totalModels,
+		providers: state.models.size,
+	});
+}
+
+/**
+ * Get all available models, optionally filtered by provider.
+ * Excludes deprecated models unless includeDeprecated is true.
+ */
+export function getAvailableModels(provider?: string, includeDeprecated = false): ModelRegistryEntry[] {
+	if (!state) {
+		// Return known models if registry not initialized
+		const all = provider ? (KNOWN_MODELS[provider] ?? []) : Object.values(KNOWN_MODELS).flat();
+		return includeDeprecated ? all : all.filter((m) => !m.deprecated);
+	}
+
+	if (provider) {
+		const models = state.models.get(provider) ?? [];
+		return includeDeprecated ? models : models.filter((m) => !m.deprecated);
+	}
+
+	const all = [...state.models.values()].flat();
+	return includeDeprecated ? all : all.filter((m) => !m.deprecated);
+}
+
+/**
+ * Get models grouped by provider, for the dashboard dropdown.
+ */
+export function getModelsByProvider(): Record<string, ModelRegistryEntry[]> {
+	const result: Record<string, ModelRegistryEntry[]> = {};
+	if (!state) {
+		for (const [provider, models] of Object.entries(KNOWN_MODELS)) {
+			result[provider] = models.filter((m) => !m.deprecated);
+		}
+		return result;
+	}
+
+	for (const [provider, models] of state.models.entries()) {
+		result[provider] = models.filter((m) => !m.deprecated);
+	}
+	return result;
+}
+
+export function getRegistryStatus(): {
+	initialized: boolean;
+	lastRefreshAt: number;
+	modelCounts: Record<string, number>;
+} {
+	if (!state) {
+		return { initialized: false, lastRefreshAt: 0, modelCounts: {} };
+	}
+
+	const modelCounts: Record<string, number> = {};
+	for (const [provider, models] of state.models.entries()) {
+		modelCounts[provider] = models.length;
+	}
+
+	return {
+		initialized: true,
+		lastRefreshAt: state.lastRefreshAt,
+		modelCounts,
+	};
+}
+
+export function stopModelRegistry(): void {
+	if (state?.refreshTimer) {
+		clearInterval(state.refreshTimer);
+		state.refreshTimer = null;
+	}
+	state = null;
+}

--- a/packages/daemon/src/pipeline/model-registry.ts
+++ b/packages/daemon/src/pipeline/model-registry.ts
@@ -64,14 +64,15 @@ const KNOWN_MODELS: Record<string, ModelRegistryEntry[]> = {
 // ---------------------------------------------------------------------------
 
 /**
- * Parse a version number from a model ID for comparison.
- * Examples: "claude-opus-4-6" → 4.6, "gpt-5.3-codex" → 5.3
+ * Parse a version from a model ID as a comparable integer.
+ * Uses major * 1000 + minor to avoid float comparison bugs with
+ * double-digit minor versions (e.g. 4.12 vs 4.6).
+ * Examples: "claude-opus-4-6" → 4006, "gpt-5.3-codex" → 5003
  */
 function parseModelVersion(modelId: string): number | null {
-	// Match patterns like 4.6, 4-6, 5.3
 	const match = modelId.match(/(\d+)[.\-](\d+)/);
 	if (!match) return null;
-	return Number.parseFloat(`${match[1]}.${match[2]}`);
+	return Number.parseInt(match[1], 10) * 1000 + Number.parseInt(match[2], 10);
 }
 
 /**
@@ -96,8 +97,8 @@ function cleanModelLabel(raw: string): string {
 	// If the label is still a raw model ID, humanise it
 	if (/^claude-/.test(label)) {
 		label = label
+			.replace(/-(\d+)-(\d+)/, " $1.$2") // version before prefix strip
 			.replace(/^claude-/, "Claude ")
-			.replace(/-(\d+)-(\d+)/, " $1.$2")
 			.replace(/-/g, " ")
 			.replace(/\b\w/g, (c) => c.toUpperCase());
 	}

--- a/packages/daemon/src/pipeline/worker.ts
+++ b/packages/daemon/src/pipeline/worker.ts
@@ -1025,11 +1025,12 @@ export function startWorker(
 			: provider;
 
 		// Run extraction — strength controls max tokens and timeout scaling
-		const strengthMaxTokens: Record<string, number> = { low: 1024, medium: 2048, high: 4096 };
-		const strengthTimeoutMultiplier: Record<string, number> = { low: 1, medium: 1.5, high: 2.5 };
-		const extractionMaxTokens = strengthMaxTokens[pipelineCfg.extraction.strength] ?? 1024;
+		const strengthMaxTokens = { low: 1024, medium: 2048, high: 4096 } as const;
+		const strengthTimeoutMultiplier = { low: 1, medium: 1.5, high: 2.5 } as const;
+		const strength = pipelineCfg.extraction.strength;
+		const extractionMaxTokens = strengthMaxTokens[strength] ?? 1024;
 		const extractionTimeout = Math.round(
-			pipelineCfg.extraction.timeout * (strengthTimeoutMultiplier[pipelineCfg.extraction.strength] ?? 1),
+			pipelineCfg.extraction.timeout * (strengthTimeoutMultiplier[strength] ?? 1),
 		);
 		const extractionStart = Date.now();
 		const rawExtraction = await extractFactsAndEntities(

--- a/packages/daemon/src/pipeline/worker.ts
+++ b/packages/daemon/src/pipeline/worker.ts
@@ -1034,7 +1034,7 @@ export function startWorker(
 		);
 		// Cap timeout to half the lease timeout to prevent duplicate job processing
 		// when escalation triggers two sequential LLM calls
-		const leaseLimit = Math.floor(pipelineCfg.worker.leaseTimeoutMs / 2);
+		const leaseLimit = Math.max(Math.floor(pipelineCfg.worker.leaseTimeoutMs / 2), 30_000);
 		const extractionTimeout = Math.min(rawExtractionTimeout, leaseLimit);
 		const extractionStart = Date.now();
 		const rawExtraction = await extractFactsAndEntities(

--- a/packages/daemon/src/pipeline/worker.ts
+++ b/packages/daemon/src/pipeline/worker.ts
@@ -1024,12 +1024,18 @@ export function startWorker(
 				}
 			: provider;
 
-		// Run extraction
+		// Run extraction — strength controls max tokens and timeout scaling
+		const strengthMaxTokens: Record<string, number> = { low: 1024, medium: 2048, high: 4096 };
+		const strengthTimeoutMultiplier: Record<string, number> = { low: 1, medium: 1.5, high: 2.5 };
+		const extractionMaxTokens = strengthMaxTokens[pipelineCfg.extraction.strength] ?? 1024;
+		const extractionTimeout = Math.round(
+			pipelineCfg.extraction.timeout * (strengthTimeoutMultiplier[pipelineCfg.extraction.strength] ?? 1),
+		);
 		const extractionStart = Date.now();
 		const rawExtraction = await extractFactsAndEntities(
 			row.content,
 			instrumentedProvider,
-			{ timeoutMs: pipelineCfg.extraction.timeout },
+			{ timeoutMs: extractionTimeout, maxTokens: extractionMaxTokens },
 		);
 		const extractionMs = Date.now() - extractionStart;
 
@@ -1047,7 +1053,7 @@ export function startWorker(
 			accessor,
 			"default",
 			escalationThresholds,
-			{ timeoutMs: pipelineCfg.extraction.timeout },
+			{ timeoutMs: extractionTimeout, maxTokens: extractionMaxTokens },
 		);
 
 		const extraction = escalated.result;

--- a/packages/daemon/src/pipeline/worker.ts
+++ b/packages/daemon/src/pipeline/worker.ts
@@ -1029,9 +1029,13 @@ export function startWorker(
 		const strengthTimeoutMultiplier = { low: 1, medium: 1.5, high: 2.5 } as const;
 		const strength = pipelineCfg.extraction.strength;
 		const extractionMaxTokens = strengthMaxTokens[strength] ?? 1024;
-		const extractionTimeout = Math.round(
+		const rawExtractionTimeout = Math.round(
 			pipelineCfg.extraction.timeout * (strengthTimeoutMultiplier[strength] ?? 1),
 		);
+		// Cap timeout to half the lease timeout to prevent duplicate job processing
+		// when escalation triggers two sequential LLM calls
+		const leaseLimit = Math.floor(pipelineCfg.worker.leaseTimeoutMs / 2);
+		const extractionTimeout = Math.min(rawExtractionTimeout, leaseLimit);
 		const extractionStart = Date.now();
 		const rawExtraction = await extractFactsAndEntities(
 			row.content,


### PR DESCRIPTION
## Summary

- **Dynamic model registry**: Auto-discovers available models from each LLM provider (Ollama via `/api/tags`, Anthropic via `/v1/models`) and maintains a live registry with periodic refresh. New models appear in the dashboard dropdown without code changes.
- **Updated provider model lists**: Codex (GPT 5.4, 5.3 Codex, 5.3 Codex Spark, Codex Mini), Claude Code/Anthropic (Opus 4.6, Sonnet 4.6, Haiku 4.5, 3.5 Haiku), OpenCode (Opus 4.6, Sonnet 4.6, Haiku 4.5, Gemini 2.5 Flash).
- **Extraction strength setting**: New low/medium/high control that scales max tokens (1024/2048/4096) and timeout multiplier (1x/1.5x/2.5x). High shows a cost warning. Token budget displayed when selected (always visible, defaults to "low").
- **Dashboard fixes**: Model dropdown now shows human-readable labels instead of raw IDs (e.g. "Claude Haiku 4.5" not "claude-haiku-4-5-20251001"). Custom model input works correctly. Placeholders changed from garbled unicode to "None selected".

## How

- New `packages/daemon/src/pipeline/model-registry.ts` — registry state, Ollama/Anthropic discovery, version-based auto-deprecation, periodic refresh, serialized refreshes, re-init guard, null-safe shutdown
- `packages/core/src/types.ts` — Added `ModelRegistryEntry`, `PipelineModelRegistryConfig`, `strength` field on `PipelineExtractionConfig`
- `packages/core/src/index.ts` — Export `ModelRegistryEntry` and `PipelineModelRegistryConfig`
- `packages/daemon/src/daemon.ts` — Registry init + API routes (`/api/pipeline/models`, `/by-provider`, `/refresh`); `resolveRegistryOllamaBaseUrl` helper for consistent URL resolution; independent Anthropic key resolution for registry
- `packages/daemon/src/memory-config.ts` — Strength config resolution with `isExtractionStrength` type guard (no `as` cast)
- `packages/daemon/src/pipeline/worker.ts` — Strength→maxTokens/timeout mapping with `as const` for type safety; extraction timeout capped to half lease timeout to prevent duplicate job processing
- `packages/daemon/src/pipeline/extraction.ts` — Accept and forward `maxTokens` option
- `packages/daemon/src/pipeline/extraction-escalation.ts` — Forward `maxTokens` through Level 2 escalation via opts object
- `packages/cli/dashboard/src/lib/api.ts` — Import `ModelRegistryEntry` from `@signet/core` (no local redeclaration)
- `packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte` — Updated fallback presets, strength UI with always-visible token count label, label display helper, custom model fix, "None selected" clears stored model

## Why

Hardcoded model lists required code changes every time a provider shipped a new model. The registry eliminates that maintenance burden. Extraction strength gives users control over API cost vs extraction depth tradeoff. The dashboard label fixes improve UX by showing clean model names.

## Review feedback addressed

- **Round 1**: Forward `maxTokens` to Level 2 escalation (was silently dropped); use resolved Ollama URL instead of hardcoded localhost; clear model on "None selected"; import `ModelRegistryEntry` from core; immutable `markDeprecatedVersions`; type guard for strength parsing; `as const` for strength maps
- **Round 2**: Resolve Anthropic API key independently for registry init; null guard after await in refreshRegistry; log refresh failures instead of silent catch; stop overwriting claude-code entries with dated Anthropic IDs
- **Round 3**: Guard re-initialization to clear old timers; serialize refreshes to prevent stale writes; defensive array copies from getAvailableModels; `markDeprecatedVersions` on all fallback paths; cap extraction timeout to half lease timeout; always show token-count label

## Test plan

- [ ] Select each provider in Settings > Pipeline and verify model dropdown shows current models with clean labels
- [ ] Select "custom" model option and verify text input appears
- [ ] Change extraction strength and verify token count label updates
- [ ] Select "high" strength and verify warning appears
- [ ] Select "None selected" and verify model is cleared
- [ ] Verify token count label shows by default (1024 for "low")
- [ ] Run `bun test` — 809 tests pass
- [ ] Run `bun run typecheck` — core, daemon, cli all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Model Registry for dynamic model discovery and management across providers.
  * Introduced Extraction Strength setting (Low/Medium/High) with automatic token limit adjustment.
  * Enabled model registry refresh to discover and update available models.
  * Enhanced model selection UI with dynamic registry-driven presets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->