### PR TITLE
feat: pipeline defaults everything ON by default

### DIFF
--- a/packages/cli/dashboard/src/lib/stores/settings.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/settings.svelte.ts
@@ -222,7 +222,50 @@ class SettingsStore {
 		return typeof v === "number" ? v : v ? Number(v) : "";
 	}
 	aBool(path: string[]) {
-		return Boolean(this.get(this.agent, ...path));
+		const val = this.get(this.agent, ...path);
+		if (val != null) return Boolean(val);
+		return this.pipelineDefault(path) ?? false;
+	}
+
+	private pipelineDefault(path: string[]): boolean | null {
+		// Pipeline defaults — must match DEFAULT_PIPELINE_V2 in memory-config.ts
+		const PIPELINE: Record<string, boolean> = {
+			enabled: true,
+			shadowMode: false,
+			mutationsFrozen: false,
+			allowUpdateDelete: true,
+			graphEnabled: true,
+			autonomousEnabled: true,
+			autonomousFrozen: false,
+			semanticContradictionEnabled: true,
+			rerankerEnabled: true,
+		};
+		const PREDICTOR: Record<string, boolean> = { enabled: true };
+		const PREDICTOR_PIPELINE: Record<string, boolean> = {
+			agentFeedback: true,
+			trainingTelemetry: false,
+		};
+		const SEARCH: Record<string, boolean> = { rehearsal_enabled: true };
+
+		if (path[0] === "memory" && path[1] === "pipelineV2") {
+			if (path.length === 3) {
+				const key = path[2];
+				if (key in PIPELINE) return PIPELINE[key];
+			}
+			if (path.length === 4 && path[2] === "predictor") {
+				const key = path[3];
+				if (key in PREDICTOR) return PREDICTOR[key];
+			}
+			if (path.length === 4 && path[2] === "predictorPipeline") {
+				const key = path[3];
+				if (key in PREDICTOR_PIPELINE) return PREDICTOR_PIPELINE[key];
+			}
+		}
+		if (path[0] === "search") {
+			const key = path[path.length - 1];
+			if (key in SEARCH) return SEARCH[key];
+		}
+		return null;
 	}
 	aSetStr(path: string[], val: string) {
 		this.set(this.agent, path, val);
@@ -243,7 +286,9 @@ class SettingsStore {
 		return typeof v === "number" ? v : v ? Number(v) : "";
 	}
 	sBool(path: string[]) {
-		return Boolean(this.get(this.sObj(), ...path));
+		const val = this.get(this.sObj(), ...path);
+		if (val != null) return Boolean(val);
+		return this.pipelineDefault(path) ?? false;
 	}
 	sSetStr(path: string[], val: string) {
 		this.set(this.sObj(), path, val);

--- a/packages/cli/dashboard/src/lib/stores/settings.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/settings.svelte.ts
@@ -221,9 +221,21 @@ class SettingsStore {
 		const v = this.get(this.agent, ...path);
 		return typeof v === "number" ? v : v ? Number(v) : "";
 	}
+	private toBool(val: YamlValue): boolean | null {
+		if (typeof val === "boolean") return val;
+		if (typeof val === "string") {
+			const s = val.trim().toLowerCase();
+			if (s === "true") return true;
+			if (s === "false") return false;
+		}
+		if (val === 1) return true;
+		if (val === 0) return false;
+		return null;
+	}
+
 	aBool(path: string[]) {
-		const val = this.get(this.agent, ...path);
-		if (val != null) return Boolean(val);
+		const parsed = this.toBool(this.get(this.agent, ...path));
+		if (parsed !== null) return parsed;
 		return this.pipelineDefault(path) ?? false;
 	}
 
@@ -286,8 +298,8 @@ class SettingsStore {
 		return typeof v === "number" ? v : v ? Number(v) : "";
 	}
 	sBool(path: string[]) {
-		const val = this.get(this.sObj(), ...path);
-		if (val != null) return Boolean(val);
+		const parsed = this.toBool(this.get(this.sObj(), ...path));
+		if (parsed !== null) return parsed;
 		return this.pipelineDefault(path) ?? false;
 	}
 	sSetStr(path: string[], val: string) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1866,6 +1866,13 @@ async function existingSetupWizard(
 						: options.extractionProvider === "opencode"
 							? "anthropic/claude-haiku-4-5-20251001"
 							: "glm-4.7-flash"),
+				semanticContradictionEnabled: true,
+				graphEnabled: true,
+				rerankerEnabled: true,
+				autonomousEnabled: true,
+				allowUpdateDelete: true,
+				predictor: { enabled: true },
+				predictorPipeline: { agentFeedback: true, trainingTelemetry: false },
 			};
 		}
 
@@ -2838,6 +2845,7 @@ ${agentName} is a helpful assistant.
 					provider: extractionProvider,
 					model: extractionModel,
 				},
+				semanticContradictionEnabled: true,
 				graph: { enabled: true },
 				reranker: { enabled: true },
 				autonomous: {
@@ -2845,6 +2853,8 @@ ${agentName} is a helpful assistant.
 					allowUpdateDelete: true,
 					maintenanceMode: "execute",
 				},
+				predictor: { enabled: true },
+				predictorPipeline: { agentFeedback: true, trainingTelemetry: false },
 			};
 		}
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1856,21 +1856,25 @@ async function existingSetupWizard(
 		if (options?.extractionProvider && options.extractionProvider !== "none") {
 			(config.memory as Record<string, unknown>).pipelineV2 = {
 				enabled: true,
-				extractionProvider: options.extractionProvider,
-				extractionModel:
-					options.extractionModel ||
-					(options.extractionProvider === "claude-code"
-						? "haiku"
-						: options.extractionProvider === "codex"
-							? "gpt-5.3-codex"
-						: options.extractionProvider === "opencode"
-							? "anthropic/claude-haiku-4-5-20251001"
-							: "glm-4.7-flash"),
+				extraction: {
+					provider: options.extractionProvider,
+					model:
+						options.extractionModel ||
+						(options.extractionProvider === "claude-code"
+							? "haiku"
+							: options.extractionProvider === "codex"
+								? "gpt-5.3-codex"
+							: options.extractionProvider === "opencode"
+								? "anthropic/claude-haiku-4-5-20251001"
+								: "glm-4.7-flash"),
+				},
 				semanticContradictionEnabled: true,
-				graphEnabled: true,
-				rerankerEnabled: true,
-				autonomousEnabled: true,
-				allowUpdateDelete: true,
+				graph: { enabled: true },
+				reranker: { enabled: true },
+				autonomous: {
+					enabled: true,
+					allowUpdateDelete: true,
+				},
 				predictor: { enabled: true },
 				predictorPipeline: { agentFeedback: true, trainingTelemetry: false },
 			};

--- a/packages/cli/templates/agent.yaml.template
+++ b/packages/cli/templates/agent.yaml.template
@@ -137,6 +137,19 @@ memory:
       maintenanceMode: execute  # "execute" or "observe"
       # maintenanceIntervalMs: 1800000  # 30 min
 
+    # Semantic contradiction detection — flags conflicting memory updates
+    semanticContradictionEnabled: true
+
+    # Predictor — ML-based memory relevance scoring
+    predictor:
+      enabled: true
+
+    # Agent feedback loop for memory relevance
+    predictorPipeline:
+      agentFeedback: true
+      # Opt-in: contribute anonymized training data
+      trainingTelemetry: false
+
 # ============================================================================
 # Hooks Configuration
 # ============================================================================

--- a/packages/daemon/src/config-migration.ts
+++ b/packages/daemon/src/config-migration.ts
@@ -1,0 +1,112 @@
+/**
+ * One-time config migration for existing agent.yaml files.
+ * Flips pipeline subsystem defaults to ON (except trainingTelemetry → OFF).
+ * Guarded by `configVersion: 2` to prevent re-running.
+ */
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { logger } from "./logger";
+
+// Flat keys: flip false → true
+const FLIP_TRUE = [
+	"semanticContradictionEnabled",
+	"graphEnabled",
+	"rerankerEnabled",
+	"autonomousEnabled",
+	"allowUpdateDelete",
+	"rehearsal_enabled",
+	"agentFeedback",
+] as const;
+
+// Nested `enabled: false` under these parent keys → flip to true
+const NESTED_PARENTS = ["graph", "reranker", "autonomous", "predictor"] as const;
+
+// Note: regex-based — theoretically could match inside a YAML block scalar,
+// but the target key names (semanticContradictionEnabled, etc.) are specific
+// enough that false positives in description text are effectively impossible.
+function flip(text: string, key: string): string {
+	return text.replace(
+		new RegExp(`^(\\s*${key}:\\s*)false(\\s*(?:#.*)?)$`, "m"),
+		"$1true$2",
+	);
+}
+
+// Require 2+ leading spaces so we only match inside a nested block (pipelineV2),
+// not a top-level key that happens to share the same name.
+function flipNested(text: string, parent: string): string {
+	return text.replace(
+		new RegExp(
+			`(^[ ]{2,}${parent}:\\s*\\n(?:\\s+\\w+:.*\\n)*?\\s+enabled:\\s*)false`,
+			"m",
+		),
+		"$1true",
+	);
+}
+
+function flipTelemetryOff(text: string): string {
+	return text.replace(
+		/^(\s*trainingTelemetry:\s*)true(\s*(?:#.*)?)$/m,
+		"$1false$2",
+	);
+}
+
+export function migrateConfig(agentsDir: string): void {
+	const candidates = ["agent.yaml", "AGENT.yaml"];
+	let path: string | undefined;
+	for (const name of candidates) {
+		const p = join(agentsDir, name);
+		if (existsSync(p)) {
+			path = p;
+			break;
+		}
+	}
+	if (!path) return;
+
+	let text: string;
+	try {
+		text = readFileSync(path, "utf-8");
+	} catch {
+		return;
+	}
+
+	// Already migrated (any version >= 2)
+	const vMatch = /^configVersion:\s*(\d+)/m.exec(text);
+	if (vMatch && Number(vMatch[1]) >= 2) return;
+
+	const original = text;
+	const mutations: string[] = [];
+
+	for (const key of FLIP_TRUE) {
+		const before = text;
+		text = flip(text, key);
+		if (text !== before) mutations.push(`${key}: false → true`);
+	}
+
+	for (const parent of NESTED_PARENTS) {
+		const before = text;
+		text = flipNested(text, parent);
+		if (text !== before) mutations.push(`${parent}.enabled: false → true`);
+	}
+
+	{
+		const before = text;
+		text = flipTelemetryOff(text);
+		if (text !== before) mutations.push("trainingTelemetry: true → false");
+	}
+
+	// Stamp version — insert after `---` if present to keep valid YAML
+	if (text.startsWith("---\n") || text.startsWith("--- ")) {
+		const nl = text.indexOf("\n");
+		text = `${text.slice(0, nl + 1)}configVersion: 2\n${text.slice(nl + 1)}`;
+	} else {
+		text = `configVersion: 2\n${text}`;
+	}
+	writeFileSync(path, text, "utf-8");
+
+	if (mutations.length > 0) {
+		logger.info("config-migration", "Migrated agent.yaml defaults", {
+			mutations,
+			file: path,
+		});
+	}
+}

--- a/packages/daemon/src/config-migration.ts
+++ b/packages/daemon/src/config-migration.ts
@@ -51,7 +51,7 @@ function flipTelemetryOff(text: string): string {
 }
 
 export function migrateConfig(agentsDir: string): void {
-	const candidates = ["agent.yaml", "AGENT.yaml"];
+	const candidates = ["agent.yaml", "AGENT.yaml", "config.yaml"];
 	let path: string | undefined;
 	for (const name of candidates) {
 		const p = join(agentsDir, name);
@@ -73,7 +73,6 @@ export function migrateConfig(agentsDir: string): void {
 	const vMatch = /^configVersion:\s*(\d+)/m.exec(text);
 	if (vMatch && Number(vMatch[1]) >= 2) return;
 
-	const original = text;
 	const mutations: string[] = [];
 
 	for (const key of FLIP_TRUE) {
@@ -94,12 +93,14 @@ export function migrateConfig(agentsDir: string): void {
 		if (text !== before) mutations.push("trainingTelemetry: true → false");
 	}
 
-	// Stamp version — insert after `---` if present to keep valid YAML
-	if (text.startsWith("---\n") || text.startsWith("--- ")) {
+	// Stamp version — insert after `---` if present to keep valid YAML.
+	// Handle both LF and CRLF files.
+	const eol = text.includes("\r\n") ? "\r\n" : "\n";
+	if (/^---(?:\r?\n|[ \t])/.test(text)) {
 		const nl = text.indexOf("\n");
-		text = `${text.slice(0, nl + 1)}configVersion: 2\n${text.slice(nl + 1)}`;
+		text = `${text.slice(0, nl + 1)}configVersion: 2${eol}${text.slice(nl + 1)}`;
 	} else {
-		text = `configVersion: 2\n${text}`;
+		text = `configVersion: 2${eol}${text}`;
 	}
 	writeFileSync(path, text, "utf-8");
 

--- a/packages/daemon/src/config-migration.ts
+++ b/packages/daemon/src/config-migration.ts
@@ -2,8 +2,14 @@
  * One-time config migration for existing agent.yaml files.
  * Flips pipeline subsystem defaults to ON (except trainingTelemetry → OFF).
  * Guarded by `configVersion: 2` to prevent re-running.
+ *
+ * Regex-based — matches key names anywhere in the file. The target names
+ * (semanticContradictionEnabled, graphEnabled, agentFeedback, etc.) are
+ * specific enough that false positives in unrelated YAML sections are
+ * effectively impossible. Migration is restricted to agent.yaml/AGENT.yaml
+ * (not config.yaml) to limit blast radius.
  */
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { logger } from "./logger";
 
@@ -21,9 +27,6 @@ const FLIP_TRUE = [
 // Nested `enabled: false` under these parent keys → flip to true
 const NESTED_PARENTS = ["graph", "reranker", "autonomous", "predictor"] as const;
 
-// Note: regex-based — theoretically could match inside a YAML block scalar,
-// but the target key names (semanticContradictionEnabled, etc.) are specific
-// enough that false positives in description text are effectively impossible.
 function flip(text: string, key: string): string {
 	return text.replace(
 		new RegExp(`^(\\s*${key}:\\s*)false(\\s*(?:#.*)?)$`, "m"),
@@ -33,10 +36,11 @@ function flip(text: string, key: string): string {
 
 // Require 2+ leading spaces so we only match inside a nested block (pipelineV2),
 // not a top-level key that happens to share the same name.
+// Use \r?\n to handle both LF and CRLF files.
 function flipNested(text: string, parent: string): string {
 	return text.replace(
 		new RegExp(
-			`(^[ ]{2,}${parent}:\\s*\\n(?:\\s+\\w+:.*\\n)*?\\s+enabled:\\s*)false`,
+			`(^[ ]{2,}${parent}:\\s*(?:\\r?\\n)(?:\\s+\\w+:.*(?:\\r?\\n))*?\\s+enabled:\\s*)false`,
 			"m",
 		),
 		"$1true",
@@ -51,7 +55,9 @@ function flipTelemetryOff(text: string): string {
 }
 
 export function migrateConfig(agentsDir: string): void {
-	const candidates = ["agent.yaml", "AGENT.yaml", "config.yaml"];
+	// Only migrate agent.yaml/AGENT.yaml — config.yaml can contain arbitrary
+	// user sections where regex-based key matching would be unsafe.
+	const candidates = ["agent.yaml", "AGENT.yaml"];
 	let path: string | undefined;
 	for (const name of candidates) {
 		const p = join(agentsDir, name);
@@ -102,10 +108,14 @@ export function migrateConfig(agentsDir: string): void {
 	} else {
 		text = `configVersion: 2${eol}${text}`;
 	}
-	writeFileSync(path, text, "utf-8");
+
+	// Atomic write: temp file + rename to avoid partial writes on crash
+	const tmp = `${path}.migration.tmp`;
+	writeFileSync(tmp, text, "utf-8");
+	renameSync(tmp, path);
 
 	if (mutations.length > 0) {
-		logger.info("config-migration", "Migrated agent.yaml defaults", {
+		logger.info("config-migration", "Migrated config defaults", {
 			mutations,
 			file: path,
 		});

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -102,6 +102,7 @@ import { getAllFeatureFlags, initFeatureFlags } from "./feature-flags";
 import { closeLlmProvider, getLlmProvider, initLlmProvider } from "./llm";
 import { closeSynthesisProvider, initSynthesisProvider } from "./synthesis-llm";
 import { type LogEntry, logger } from "./logger";
+import { migrateConfig } from "./config-migration";
 import { type EmbeddingConfig, loadMemoryConfig } from "./memory-config";
 import {
 	getAttributesForAspectFiltered,
@@ -9186,6 +9187,9 @@ async function main() {
 	// Write PID file
 	writeFileSync(PID_FILE, process.pid.toString());
 	logger.info("daemon", "Process ID", { pid: process.pid });
+
+	// Migrate config defaults before watcher starts (one-time, guarded by configVersion)
+	migrateConfig(AGENTS_DIR);
 
 	// Start file watcher
 	startFileWatcher();

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -160,6 +160,7 @@ import {
 	createRateLimiter,
 	deduplicateMemories,
 	getDedupStats,
+	backfillSkippedSessions,
 	getEmbeddingGapStats,
 	pruneChunkGroupEntities,
 	pruneSingletonExtractedEntities,
@@ -6788,15 +6789,23 @@ app.post("/api/repair/deduplicate", async (c) => {
 	return c.json(result, repairHttpStatus(result));
 });
 
-app.post("/api/repair/backfill-skipped", (c) => {
-	return c.json(
-		{
-			error: "not_implemented",
-			message:
-				"Backfill-skipped re-enqueue logic is pending. This endpoint is reserved for future implementation.",
-		},
-		501,
-	);
+app.post("/api/repair/backfill-skipped", async (c) => {
+	const cfg = loadMemoryConfig(AGENTS_DIR);
+	const ctx = resolveRepairContext(c);
+	let limit = 50;
+	let dryRun = false;
+	try {
+		const body = await c.req.json();
+		if (typeof body?.limit === "number") limit = body.limit;
+		if (typeof body?.dryRun === "boolean") dryRun = body.dryRun;
+	} catch {
+		// no body or invalid JSON — use defaults
+	}
+	const result = backfillSkippedSessions(getDbAccessor(), cfg.pipelineV2, ctx, repairLimiter, {
+		limit,
+		dryRun,
+	});
+	return c.json(result, repairHttpStatus(result));
 });
 
 app.post("/api/repair/reclassify-entities", async (c) => {
@@ -9189,7 +9198,13 @@ async function main() {
 	logger.info("daemon", "Process ID", { pid: process.pid });
 
 	// Migrate config defaults before watcher starts (one-time, guarded by configVersion)
-	migrateConfig(AGENTS_DIR);
+	try {
+		migrateConfig(AGENTS_DIR);
+	} catch (err) {
+		logger.warn("config-migration", "Config migration failed; continuing startup", {
+			error: err instanceof Error ? err.message : String(err),
+		});
+	}
 
 	// Start file watcher
 	startFileWatcher();

--- a/packages/daemon/src/memory-config.ts
+++ b/packages/daemon/src/memory-config.ts
@@ -32,7 +32,7 @@ export const DEFAULT_PIPELINE_V2: PipelineV2Config = {
 	enabled: true,
 	shadowMode: false,
 	mutationsFrozen: false,
-	semanticContradictionEnabled: false,
+	semanticContradictionEnabled: true,
 	semanticContradictionTimeoutMs: 45000,
 	extraction: {
 		provider: "claude-code",
@@ -174,7 +174,7 @@ export const DEFAULT_PIPELINE_V2: PipelineV2Config = {
 	},
 	predictorPipeline: {
 		agentFeedback: true,
-		trainingTelemetry: true,
+		trainingTelemetry: false,
 	},
 };
 


### PR DESCRIPTION
## Summary

- Fix dashboard/daemon disagreement where pipeline features show OFF in the UI but the daemon treats them as ON (root cause: `Boolean(null)=false` for missing YAML keys)
- Flip `semanticContradictionEnabled` default to `true` and `trainingTelemetry` to `false` (opt-in)
- Add `config-migration.ts` — one-time startup migration that flips existing user configs to the new defaults, guarded by `configVersion: 2` stamp
- Dashboard `aBool`/`sBool` now fall back to a defaults map matching `DEFAULT_PIPELINE_V2` when YAML keys are missing
- Both CLI setup paths (fresh install + import) now write all critical pipeline flags including predictor and predictorPipeline
- Template updated with predictor, predictorPipeline, and semanticContradiction fields

## Test plan

- [ ] `bun run typecheck` — no new errors
- [ ] `bun run build` — clean build
- [ ] Create test agent.yaml with critical settings `false`, run daemon, verify migration flips them to `true` and `trainingTelemetry` to `false`
- [ ] Create test agent.yaml with MISSING keys, open dashboard, verify toggles show ON
- [ ] Run daemon twice — confirm migration doesn't re-run (configVersion: 2 guard)
- [ ] Toggle a setting OFF in dashboard, save, reload — confirm it persists as OFF
- [ ] Run `signet setup` fresh — confirm new agent.yaml has all flags ON
- [ ] Verify agent.yaml starting with `---` is handled correctly by migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled semantic contradiction detection and an ML-based memory predictor with agent-feedback and telemetry controls; setup now applies these memory options by default.

* **Chores**
  * Added a one-time config migration to update existing agent configs and introduced centralized defaults for memory-related boolean settings.

* **Bug Fixes**
  * Implemented a repair/backfill endpoint for skipped sessions and ensured migrations run at daemon startup without blocking launch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->