### PR TITLE
fix: make memory_jobs.memory_id nullable for document ingest

### DIFF
--- a/packages/core/src/migrations/030-nullable-memory-job-memory-id.ts
+++ b/packages/core/src/migrations/030-nullable-memory-job-memory-id.ts
@@ -1,0 +1,61 @@
+import type { MigrationDb } from "./index";
+
+/**
+ * Migration 030: Make memory_jobs.memory_id nullable
+ *
+ * The memory_jobs table was created in 002 with `memory_id TEXT NOT NULL`.
+ * Migration 007 added document_id for document_ingest jobs, but those jobs
+ * don't have a memory_id at creation time — they produce memories later.
+ * The NOT NULL constraint causes POST /api/documents to fail with:
+ *   SQLiteError: NOT NULL constraint failed: memory_jobs.memory_id
+ *
+ * SQLite doesn't support ALTER COLUMN, so we rebuild the table.
+ */
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS memory_jobs_new (
+			id TEXT PRIMARY KEY,
+			memory_id TEXT,
+			job_type TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'pending',
+			payload TEXT,
+			result TEXT,
+			attempts INTEGER DEFAULT 0,
+			max_attempts INTEGER DEFAULT 3,
+			leased_at TEXT,
+			completed_at TEXT,
+			failed_at TEXT,
+			error TEXT,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			document_id TEXT,
+			FOREIGN KEY (memory_id) REFERENCES memories(id)
+		)
+	`);
+
+	db.exec(`
+		INSERT INTO memory_jobs_new
+			(id, memory_id, job_type, status, payload, result,
+			 attempts, max_attempts, leased_at, completed_at, failed_at,
+			 error, created_at, updated_at, document_id)
+		SELECT
+			id, memory_id, job_type, status, payload, result,
+			attempts, max_attempts, leased_at, completed_at, failed_at,
+			error, created_at, updated_at, document_id
+		FROM memory_jobs
+	`);
+
+	db.exec("DROP TABLE memory_jobs");
+	db.exec("ALTER TABLE memory_jobs_new RENAME TO memory_jobs");
+
+	db.exec(`
+		CREATE INDEX IF NOT EXISTS idx_memory_jobs_status
+			ON memory_jobs(status);
+		CREATE INDEX IF NOT EXISTS idx_memory_jobs_memory_id
+			ON memory_jobs(memory_id);
+		CREATE INDEX IF NOT EXISTS idx_memory_jobs_completed_at
+			ON memory_jobs(completed_at);
+		CREATE INDEX IF NOT EXISTS idx_memory_jobs_failed_at
+			ON memory_jobs(failed_at);
+	`);
+}

--- a/packages/core/src/migrations/030-nullable-memory-job-memory-id.ts
+++ b/packages/core/src/migrations/030-nullable-memory-job-memory-id.ts
@@ -10,6 +10,10 @@ import type { MigrationDb } from "./index";
  *   SQLiteError: NOT NULL constraint failed: memory_jobs.memory_id
  *
  * SQLite doesn't support ALTER COLUMN, so we rebuild the table.
+ *
+ * No artifacts declared: this migration modifies an existing table's
+ * constraint (not a new table/column). The memory_jobs table is already
+ * tracked by migration 002's artifacts, so phantom detection still works.
  */
 export function up(db: MigrationDb): void {
 	db.exec(`
@@ -45,7 +49,7 @@ export function up(db: MigrationDb): void {
 		FROM memory_jobs
 	`);
 
-	db.exec("DROP TABLE memory_jobs");
+	db.exec("DROP TABLE IF EXISTS memory_jobs");
 	db.exec("ALTER TABLE memory_jobs_new RENAME TO memory_jobs");
 
 	db.exec(`

--- a/packages/core/src/migrations/index.ts
+++ b/packages/core/src/migrations/index.ts
@@ -35,6 +35,7 @@ import { up as predictorTrainingPairs } from "./026-predictor-training-pairs";
 import { up as backfillCanonicalNames } from "./027-backfill-canonical-names";
 import { up as losslessRetention } from "./028-lossless-retention";
 import { up as sessionSummaryDag } from "./029-session-summary-dag";
+import { up as nullableMemoryJobMemoryId } from "./030-nullable-memory-job-memory-id";
 
 // -- Public interface consumed by Database.init() --
 
@@ -300,6 +301,11 @@ export const MIGRATIONS: readonly Migration[] = [
 		version: 29,
 		name: "session-summary-dag",
 		up: sessionSummaryDag,
+	},
+	{
+		version: 30,
+		name: "nullable-memory-job-memory-id",
+		up: nullableMemoryJobMemoryId,
 	},
 ];
 


### PR DESCRIPTION
## Summary

- **Fixes** `POST /api/documents` returning HTTP 500 with `SQLiteError: NOT NULL constraint failed: memory_jobs.memory_id`
- Migration 030 rebuilds `memory_jobs` table with `memory_id` as nullable, preserving all existing data and indexes
- Document ingest jobs legitimately have no `memory_id` at creation time — they produce memories during processing

## Context

Reported by Zetoniak (v0.55.0, OpenClaw-integrated setup). Both file and URL document ingestion were completely broken. Normal memory write/read APIs unaffected.

## Test plan

- [x] Migration tests pass (18/18)
- [x] Pipeline worker tests pass (24/24)
- [x] Diagnostics tests pass (19/19)
- [x] Full build succeeds
- [x] Typecheck clean for core and daemon
- [ ] Manual: `POST /api/documents` with file and URL sources returns 201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Database migration making the memory reference on memory jobs optional, rebuilding the table while preserving other constraints and adding relevant indices for status, memory, completion, and failure.
  * Migration registered in the system migration list for deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->