### PR TITLE
fix(migrations): post-merge review improvements

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6,6 +6,7 @@
 
 import { spawn, spawnSync } from "child_process";
 import {
+	appendFileSync,
 	closeSync,
 	copyFileSync,
 	existsSync,
@@ -434,9 +435,19 @@ async function startDaemon(agentsDir: string = AGENTS_DIR): Promise<boolean> {
 		},
 	});
 
-	// Suppress unhandled 'error' events (e.g., bun not found) so the
-	// readiness poll below produces a clean failure instead of a crash.
-	proc.on("error", () => {});
+	// Prevent unhandled 'error' crash (e.g. bun not on PATH). Spawn-level
+	// errors never reach the child's stderr fd — write them to startup.log
+	// so the diagnostic tail below surfaces them alongside normal stderr.
+	proc.on("error", (err) => {
+		if (startupLogPath) {
+			try {
+				appendFileSync(startupLogPath, `[spawn error] ${err.message}\n`);
+			} catch {
+				// Best effort — if we can't write, the readiness poll will still
+				// time out and report a clean failure.
+			}
+		}
+	});
 
 	proc.unref();
 	if (stderrFd !== null) closeSync(stderrFd);


### PR DESCRIPTION
## Summary

Follow-up to #199. All changes address Greptile and CodeRabbit feedback received after the original PR merged.

**Migration artifact completeness:**
- v3: Remove incorrect artifact declarations (`why`/`project` are v1 baseline columns, not v3 — v3 only creates an index)
- v13: Add `memories.source_path` and `memories.source_section` column artifacts
- v15: Add `session_scores.confidence` and `session_scores.continuity_reasoning` column artifacts
- v20: Add four `session_memories` column artifacts (`entity_slot`, `aspect_slot`, `is_constraint`, `structural_density`)
- v22: Add `entities.pinned_at` (was missing alongside `pinned`)
- v24: Add all 6 `predictor_comparisons` columns (only `scorer_confidence` was declared)

**Performance:**
- `repairPhantomMigrations` now returns the post-repair applied `Set` so `runMigrations` reuses it instead of issuing a redundant `appliedVersions()` query
- `hasPendingMigrations` derives the bogus-version check from the already-fetched applied set, eliminating a second `SELECT MAX(version)` query on every daemon startup

**Bug fix:**
- `proc.on('error')` in daemon startup now appends spawn-level errors (ENOENT, EACCES) to `startup.log` — previously these were silently discarded and the diagnostic tail showed nothing when `bun` wasn't on PATH

**Tests:**
- Replace all hardcoded `26` migration counts with `MIGRATIONS.length`
- Replace `as Array<{...}>` casts in new test blocks with typed `db.query<T, P>()` calls
- Add audit history preservation assertions to phantom-repair tests
- Fix test comment to document the full cascade scope when dropping `session_memories`
- Skip only v1 (not v1+v2) in phantom detection so v2 is detectable as a phantom

Closes no new issue — all changes are review-driven improvements to #199.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in the CLI startup process by capturing and logging initialization errors to a startup log file. Error messages are now properly recorded with a graceful fallback mechanism, ensuring critical diagnostic information is preserved even if the primary logging mechanism encounters issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->