### PR TITLE
fix(dashboard): restore sidebar closing speed

### DIFF
--- a/packages/cli/dashboard/src/lib/components/ui/sheet/sheet-content.svelte
+++ b/packages/cli/dashboard/src/lib/components/ui/sheet/sheet-content.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" module>
 	import { tv, type VariantProps } from "tailwind-variants";
 	export const sheetVariants = tv({
-		base: "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+		base: "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-200 data-[state=open]:duration-200",
 		variants: {
 			side: {
 				top: "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",

--- a/packages/cli/dashboard/src/lib/hooks/is-mobile.svelte.ts
+++ b/packages/cli/dashboard/src/lib/hooks/is-mobile.svelte.ts
@@ -1,6 +1,6 @@
 import { MediaQuery } from "svelte/reactivity";
 
-const DEFAULT_MOBILE_BREAKPOINT = 1024;
+const DEFAULT_MOBILE_BREAKPOINT = 768;
 
 export class IsMobile extends MediaQuery {
 	constructor(breakpoint: number = DEFAULT_MOBILE_BREAKPOINT) {


### PR DESCRIPTION
## Summary

- Restores `DEFAULT_MOBILE_BREAKPOINT` from 1024px back to 768px — commit `45964ab1` bumped this, causing viewports 768-1023px to use the slow Sheet-based mobile sidebar instead of the fast desktop sidebar
- Reduces Sheet animation durations from 300ms/500ms to 200ms/200ms, matching the desktop sidebar and `--dur: 0.2s` global token

## Test plan

- [ ] Open dashboard at viewport >768px — sidebar should use fast desktop collapse (200ms)
- [ ] Open dashboard at viewport <768px — sidebar should use Sheet with snappy 200ms slide
- [ ] Toggle sidebar with Ctrl+B at various widths to confirm consistent behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)