### PR TITLE
fix: upgrade banner persistence, changelog link, mobile overlap

### DIFF
--- a/packages/cli/dashboard/src/lib/components/UpgradeBanner.svelte
+++ b/packages/cli/dashboard/src/lib/components/UpgradeBanner.svelte
@@ -32,19 +32,20 @@
 	// Fetch changelog and extract up to 3 items for the current version
 	$effect(() => {
 		if (!version || version === "0.0.0") return;
-		fetchChangelog().then((doc) => {
-			if (!doc?.html) return;
-			// Find the section for this version and grab list items
-			const anchor = doc.html.indexOf(`[${version}]`);
-			const slice = anchor >= 0
-				? doc.html.slice(anchor)
-				: doc.html;
-			const items = slice.match(/<li[^>]*>([\s\S]*?)<\/li>/gi);
-			if (!items) return;
-			notes = items.slice(0, 3).map((li) =>
-				li.replace(/<[^>]+>/g, "").trim(),
-			);
-		});
+		const v = version;
+		fetchChangelog()
+			.then((doc) => {
+				if (!doc?.html || version !== v) return;
+				const anchor = doc.html.indexOf(`[${v}]`);
+				if (anchor < 0) return;
+				const slice = doc.html.slice(anchor);
+				const items = slice.match(/<li[^>]*>([\s\S]*?)<\/li>/gi);
+				if (!items) return;
+				notes = items.slice(0, 3).map((li) =>
+					li.replace(/<[^>]+>/g, "").trim(),
+				);
+			})
+			.catch(() => {});
 	});
 
 	const visible = $derived(

--- a/packages/cli/dashboard/src/lib/components/UpgradeBanner.svelte
+++ b/packages/cli/dashboard/src/lib/components/UpgradeBanner.svelte
@@ -29,8 +29,16 @@
 		dismissed = localStorage.getItem(key) === "true";
 	});
 
+	function stripTags(html: string): string {
+		if (!browser) return html.replace(/<[^>]*>/g, "");
+		const el = document.createElement("div");
+		el.innerHTML = html;
+		return el.textContent ?? "";
+	}
+
 	// Fetch changelog and extract up to 3 items for the current version
 	$effect(() => {
+		notes = [];
 		if (!version || version === "0.0.0") return;
 		const v = version;
 		fetchChangelog()
@@ -42,10 +50,14 @@
 				const items = slice.match(/<li[^>]*>([\s\S]*?)<\/li>/gi);
 				if (!items) return;
 				notes = items.slice(0, 3).map((li) =>
-					li.replace(/<[^>]+>/g, "").trim(),
+					stripTags(li).trim(),
 				);
 			})
-			.catch(() => {});
+			.catch((e) => {
+				if (import.meta.env.DEV) {
+					console.warn("UpgradeBanner: changelog fetch failed", e);
+				}
+			});
 	});
 
 	const visible = $derived(

--- a/packages/cli/dashboard/src/lib/components/UpgradeBanner.svelte
+++ b/packages/cli/dashboard/src/lib/components/UpgradeBanner.svelte
@@ -1,35 +1,64 @@
 <script lang="ts">
 	import { browser } from "$app/environment";
-	import type { DaemonStatus } from "$lib/api";
+	import { fetchChangelog, type DaemonStatus } from "$lib/api";
+	import ExternalLink from "@lucide/svelte/icons/external-link";
 	import X from "@lucide/svelte/icons/x";
 
 	const STORAGE_KEY_PREFIX = "signet-upgrade-banner-dismissed-";
+	const CHANGELOG_URL =
+		"https://github.com/Signet-AI/signetai/blob/main/CHANGELOG.md";
 
 	interface Props {
 		daemonStatus: DaemonStatus | null;
+		showing?: boolean;
 	}
 
-	let { daemonStatus }: Props = $props();
+	let { daemonStatus, showing = $bindable(false) }: Props = $props();
 
 	let dismissed = $state(false);
+	let notes = $state<string[]>([]);
 
 	const version = $derived(daemonStatus?.version ?? null);
-	const storageKey = $derived(version ? `${STORAGE_KEY_PREFIX}${version}` : null);
+	const key = $derived(
+		version ? `${STORAGE_KEY_PREFIX}${version}` : null,
+	);
 
-	// Check if this version's banner was already dismissed
-	if (browser && storageKey) {
-		dismissed = localStorage.getItem(storageKey) === "true";
-	}
+	// Sync dismiss state from localStorage when version resolves
+	$effect(() => {
+		if (!browser || !key) return;
+		dismissed = localStorage.getItem(key) === "true";
+	});
 
-	// Show banner when version is known and not dismissed for this version
+	// Fetch changelog and extract up to 3 items for the current version
+	$effect(() => {
+		if (!version || version === "0.0.0") return;
+		fetchChangelog().then((doc) => {
+			if (!doc?.html) return;
+			// Find the section for this version and grab list items
+			const anchor = doc.html.indexOf(`[${version}]`);
+			const slice = anchor >= 0
+				? doc.html.slice(anchor)
+				: doc.html;
+			const items = slice.match(/<li[^>]*>([\s\S]*?)<\/li>/gi);
+			if (!items) return;
+			notes = items.slice(0, 3).map((li) =>
+				li.replace(/<[^>]+>/g, "").trim(),
+			);
+		});
+	});
+
 	const visible = $derived(
 		!!version && version !== "0.0.0" && !dismissed,
 	);
 
+	$effect(() => {
+		showing = visible;
+	});
+
 	function dismiss() {
 		dismissed = true;
-		if (browser && storageKey) {
-			localStorage.setItem(storageKey, "true");
+		if (browser && key) {
+			localStorage.setItem(key, "true");
 		}
 	}
 </script>
@@ -37,11 +66,35 @@
 {#if visible}
 	<div class="banner">
 		<span class="banner-accent" aria-hidden="true"></span>
-		<span class="banner-version">v{version}</span>
+		<a
+			href={CHANGELOG_URL}
+			target="_blank"
+			rel="noopener noreferrer"
+			class="banner-link"
+		>
+			<span class="banner-version">v{version}</span>
+			<ExternalLink class="size-2.5" />
+		</a>
 		<span class="banner-separator" aria-hidden="true"></span>
-		<span class="banner-text">
-			Knowledge graph, session continuity, constellation entity overlay
-		</span>
+		{#if notes.length > 0}
+			<span class="banner-notes">
+				{#each notes as note, i}
+					<span class="banner-note">{note}</span>
+					{#if i < notes.length - 1}
+						<span class="banner-dot" aria-hidden="true">&middot;</span>
+					{/if}
+				{/each}
+			</span>
+			<span class="banner-separator" aria-hidden="true"></span>
+		{/if}
+		<a
+			href={CHANGELOG_URL}
+			target="_blank"
+			rel="noopener noreferrer"
+			class="banner-changelog-link"
+		>
+			View changelog
+		</a>
 		<button
 			onclick={dismiss}
 			class="banner-dismiss"
@@ -75,11 +128,23 @@
 		flex-shrink: 0;
 	}
 
-	.banner-version {
+	.banner-link {
+		display: flex;
+		align-items: center;
+		gap: 4px;
 		color: var(--sig-highlight);
+		text-decoration: none;
+		flex-shrink: 0;
+		transition: opacity var(--dur) var(--ease);
+	}
+
+	.banner-link:hover {
+		opacity: 0.8;
+	}
+
+	.banner-version {
 		font-weight: 700;
 		text-transform: uppercase;
-		flex-shrink: 0;
 	}
 
 	.banner-separator {
@@ -89,12 +154,36 @@
 		flex-shrink: 0;
 	}
 
-	.banner-text {
+	.banner-notes {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		min-width: 0;
+		overflow: hidden;
+	}
+
+	.banner-note {
 		color: var(--sig-text-muted);
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
-		min-width: 0;
+	}
+
+	.banner-dot {
+		color: var(--sig-border-strong);
+		flex-shrink: 0;
+	}
+
+	.banner-changelog-link {
+		color: var(--sig-accent);
+		text-decoration: none;
+		white-space: nowrap;
+		flex-shrink: 0;
+		transition: color var(--dur) var(--ease);
+	}
+
+	.banner-changelog-link:hover {
+		color: var(--sig-text-bright);
 	}
 
 	.banner-dismiss {

--- a/packages/cli/dashboard/src/routes/+page.svelte
+++ b/packages/cli/dashboard/src/routes/+page.svelte
@@ -48,6 +48,7 @@ import { onMount } from "svelte";
 const activeTab = $derived(nav.activeTab);
 const { data } = $props();
 let daemonStatus = $state<DaemonStatus | null>(null);
+let bannerShowing = $state(false);
 let embeddingsPrefetchPromise: Promise<unknown[]> | null = null;
 let timelineGeneratedFor = $state("");
 
@@ -243,7 +244,7 @@ $effect(() => {
 	<Sidebar.Trigger
 		unstyled={true}
 		class="mobile-sidebar-trigger fixed z-40 size-5 p-0 bg-transparent border-none shadow-none rounded-sm hover:bg-[color-mix(in_srgb,var(--sig-surface-raised)_60%,transparent)] transition-all items-center justify-center flex"
-		style="top: calc(var(--titlebar-h, 0px) + var(--space-sm, 8px) + 3px); left: calc(var(--space-sm, 8px) + 1px);"
+		style="top: calc(var(--titlebar-h, 0px) + var(--space-sm, 8px) + 3px + {bannerShowing ? '24px' : '0px'}); left: calc(var(--space-sm, 8px) + 1px);"
 		mobileOnly={true}
 	>
 		<span
@@ -259,7 +260,7 @@ $effect(() => {
 	<main data-page-content="true" class="flex flex-1 flex-col min-w-0 min-h-0 overflow-hidden
 		bg-[var(--sig-bg)]">
 
-		<UpgradeBanner {daemonStatus} />
+		<UpgradeBanner {daemonStatus} bind:showing={bannerShowing} />
 		<ExtensionBanner />
 
 		<div class="flex flex-1 flex-col min-h-0 relative" data-tab-panel-active="true">


### PR DESCRIPTION
## Summary

- **Dismiss persists across refresh**: Moved localStorage check into a `$effect` so it runs reactively when the version resolves (was running at init when `storageKey` was still `null`, so dismissals never stuck)
- **Clickable changelog link**: Version badge and "View changelog" text link to the GitHub CHANGELOG.md with an external-link icon
- **Changelog summary notes**: Banner fetches changelog data and shows up to 3 quick notes from the current version before the "View changelog" link
- **Mobile trigger offset**: Exposed banner visibility via bindable `showing` prop; mobile sidebar trigger shifts down 24px when banner is visible to prevent overlap

## How

- `UpgradeBanner.svelte`: Replaced broken synchronous localStorage check with `$effect` that reacts to derived `key`. Added `fetchChangelog()` call to parse and display 3 list items for the current version. Exported `showing` bindable prop synced to internal `visible` state.
- `+page.svelte`: Bound `bannerShowing` to UpgradeBanner, used it in the mobile trigger's inline `top` calc to offset by banner height.

## Why

The upgrade banner was re-appearing on every page refresh because the dismiss check ran before the daemon status (and therefore version/storage key) was available. Users also had no way to view the full changelog from the banner, and the mobile sidebar trigger overlapped with the banner on small screens.

## Test plan

- [ ] Verify banner shows version + 3 changelog notes + "View changelog" link
- [ ] Click version badge or "View changelog" — opens GitHub CHANGELOG.md in new tab
- [ ] Click X to dismiss — banner disappears
- [ ] Refresh page — banner stays dismissed
- [ ] Clear localStorage for the key — banner reappears
- [ ] Mobile view: verify sidebar trigger does not overlap the banner
- [ ] Dismiss banner on mobile — trigger shifts back up

🤖 Generated with [Claude Code](https://claude.com/claude-code)