### PR TITLE
fix: reduce auto-recall noise with stricter thresholds and keyword filtering

### DIFF
--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -1767,7 +1767,12 @@ function extractSubstantiveWords(text: string): string[] {
 	const words = cleaned
 		.toLowerCase()
 		.split(/\W+/)
-		.filter((word) => word.length >= 3 && !RECALL_STOPWORDS.has(word) && !/^\d+$/.test(word));
+		.filter((word) =>
+			word.length >= 3 &&
+			!RECALL_STOPWORDS.has(word) &&
+			!/^\d+$/.test(word) &&
+			!/\.(js|ts|py|md|txt|json|csv|yml|yaml|sh|css|html|jsx|tsx|sql|env)$/.test(word),
+		);
 
 	// Deduplicate: hyphenated first (more specific), then words
 	const seen = new Set<string>();
@@ -1896,13 +1901,13 @@ export async function handleUserPromptSubmit(req: UserPromptSubmitRequest): Prom
 				query: vectorQuery,
 				keywordQuery: keywordTerms.join(" OR "),
 				limit: 10,
-				importance_min: 0.3,
+				importance_min: 0.5,
 			},
 			cfg,
 			fetchEmbedding,
 		);
 
-		if (recall.results.length === 0 || typeof recall.results[0]?.score !== "number" || recall.results[0].score < 0.4) {
+		if (recall.results.length === 0 || typeof recall.results[0]?.score !== "number" || recall.results[0].score < 0.6) {
 			return { inject: metadataHeader, memoryCount: 0 };
 		}
 


### PR DESCRIPTION
## Problem

Auto-recall injects irrelevant memories on every prompt. For example, asking about Signet configuration consistently surfaces results like `gmail-filters.js` and `Email system uses a color-coded label taxonomy` — technically matching via BM25 keyword overlap but contextually useless.

## Root Cause

1. `importance_min: 0.3` too permissive
2. Top-score gate `< 0.4` too low for hybrid recall noise
3. File extensions in keyword extraction cause spurious BM25 matches

## Fix

- Raised `importance_min` from `0.3` to `0.5`
- Raised top-score gate from `0.4` to `0.6`
- Filter common file extensions from `extractSubstantiveWords()`

## Testing

Tested on OpenClaw deployment with 106 memories. Before: 3-5 noisy injections per prompt. After: 0-2 relevant injections.

## Changes

`packages/daemon/src/hooks.ts`: 1 file, +8/-3 lines. Backwards compatible.