### PR TITLE
fix: vec_embeddings backfill race on daemon restart

### DIFF
--- a/packages/daemon/src/db-accessor.ts
+++ b/packages/daemon/src/db-accessor.ts
@@ -297,22 +297,9 @@ function ensureVecTable(db: Database): void {
 }
 
 function backfillVecEmbeddings(db: Database): void {
-	const vecCount = (
-		db.prepare("SELECT count(*) as n FROM vec_embeddings").get() as {
-			n: number;
-		}
-	).n;
-
-	const embCount = (
-		db.prepare("SELECT count(*) as n FROM embeddings").get() as {
-			n: number;
-		}
-	).n;
-
-	// Skip if vec_embeddings already has all rows (or no embeddings exist)
-	if (embCount === 0 || vecCount >= embCount) return;
-
-	// Only fetch embeddings missing from vec_embeddings
+	// Directly query for missing rows instead of comparing counts.
+	// Count comparison is racy — a row can exist in embeddings but not
+	// vec_embeddings even when counts match (e.g. after a crash mid-sync).
 	const rows = db
 		.prepare(
 			`SELECT e.id, e.vector FROM embeddings e
@@ -320,6 +307,8 @@ function backfillVecEmbeddings(db: Database): void {
 			 WHERE v.id IS NULL`,
 		)
 		.all() as Array<{ id: string; vector: Buffer }>;
+
+	if (rows.length === 0) return;
 
 	const insert = db.prepare(
 		"INSERT OR REPLACE INTO vec_embeddings (id, embedding) VALUES (?, ?)",


### PR DESCRIPTION
## Summary
- `backfillVecEmbeddings()` used two separate `SELECT count(*)` queries to decide whether to skip backfill
- If `vecCount >= embCount`, it returned early — even when individual rows were missing from `vec_embeddings`
- This happens after a daemon crash between embedding insert and vec sync: embeddings table has the row, vec_embeddings doesn't, but counts can still match
- **Fix**: Skip the count comparison entirely and directly query for missing rows via `LEFT JOIN` (which was already the next step in the function)

## Root cause
The count comparison is not atomic — between the two `SELECT count(*)` queries, the embedding-tracker can insert/delete rows, making the counts unreliable. A row in `embeddings` without a corresponding `vec_embeddings` entry means that memory is invisible to semantic search.

## Test plan
- [x] `bun test packages/daemon/src/db-accessor` — 5/5 pass
- [x] `bun run build` — clean
- [x] `bun run typecheck` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)