### PR TITLE
fix: add sharp to optionalDependencies for Windows ARM64

### DIFF
--- a/packages/signetai/package.json
+++ b/packages/signetai/package.json
@@ -67,7 +67,8 @@
   },
   "optionalDependencies": {
     "@1password/sdk": "^0.3.0",
-    "better-sqlite3": "^12.0.0"
+    "better-sqlite3": "^12.0.0",
+    "sharp": "^0.34.1"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",


### PR DESCRIPTION
## Summary

- Adds `sharp` (`^0.34.1`) to `optionalDependencies` in `packages/signetai/package.json`
- Fixes runtime crash on Windows ARM64 when the daemon starts

## Problem

`@huggingface/transformers` is marked as `external` in the build and imports `sharp` at the top level. The build-time shim (`packages/daemon/src/shims/sharp.ts`) only applies to bundled code — it has no effect on externalized packages loaded from `node_modules` at runtime.

When `signetai` is installed via `npm install -g signetai` on Windows ARM64, `sharp`'s platform-specific native binary (`@img/sharp-win32-arm64`) is not installed because `sharp` isn't listed as a dependency of the published package. This causes a runtime crash when `@huggingface/transformers` tries to load `sharp`.

## Fix

Adding `sharp` to `optionalDependencies` ensures npm resolves and installs the correct platform-specific native binaries during install. Using `optionalDependencies` (rather than `dependencies`) means installation won't fail on platforms where sharp binaries aren't available.

## Test plan

- [ ] `npm install -g signetai` on Windows ARM64 — verify `@img/sharp-win32-arm64` is installed
- [ ] `signet daemon restart` — verify daemon starts without sharp-related errors
- [ ] `npm install -g signetai` on macOS/Linux — verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)