### PR TITLE
fix: resolve CLI binary paths on Windows for extraction

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -9559,6 +9559,7 @@ async function main() {
 			});
 		}
 	} else if (effectiveExtractionProvider === "claude-code") {
+		// Resolve full path so .cmd wrappers on Windows are found correctly.
 		const resolvedClaude = Bun.which("claude");
 		if (resolvedClaude === null) {
 			logger.warn("config", "Claude Code CLI not found, falling back to ollama for extraction");
@@ -9807,6 +9808,7 @@ async function main() {
 				effectiveSynthesisProvider = "ollama";
 			}
 		} else if (effectiveSynthesisProvider === "claude-code") {
+			// Re-resolve here; extraction and synthesis may use different providers.
 			const resolvedClaude = Bun.which("claude");
 			if (resolvedClaude === null) {
 				logger.warn("config", "Claude Code CLI not found, falling back to ollama for synthesis");

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -112,6 +112,10 @@ function spawnHidden(cmd: string[], options?: { env?: Record<string, string | un
 	const [bin, ...args] = cmd;
 	const resolvedBin = Bun.which(bin);
 	if (resolvedBin === null) {
+		// Throws synchronously — same behaviour as Bun.spawn with a missing
+		// binary. All call sites are guarded: available() wraps in try/catch,
+		// and callClaude/callCodex run inside withSemaphore whose try/finally
+		// releases the semaphore before the rejection propagates.
 		throw new Error(`spawnHidden: binary "${bin}" not found on PATH`);
 	}
 	const sanitizedEnv: Record<string, string> = {};


### PR DESCRIPTION
## Summary

- Uses `Bun.which()` to resolve `claude` and `codex` binary paths before spawning, fixing Windows `.cmd` wrapper resolution
- Applies the same pattern already used in `scheduler/spawn.ts` to extraction/synthesis provider code
- Fixes 7 call sites: 3 validation spawns in `daemon.ts`, 4 provider spawns via `spawnHidden()` in `provider.ts`

## Problem

On Windows, globally installed npm packages (like `@anthropic-ai/claude-code`) create `.cmd` wrapper scripts, not bare executables. Both `node:child_process spawn("claude", ...)` and `Bun.spawn(["claude", ...])` cannot resolve `.cmd` wrappers without `shell: true`, causing the daemon to log:

```
"Claude Code CLI not found, falling back to ollama for extraction"
```

...even when the CLI is properly installed and on PATH.

## Fix

`Bun.which(bin)` resolves binary names to full paths cross-platform — returning `/usr/local/bin/claude` on macOS/Linux and `C:\...\claude.cmd` on Windows. Passing the resolved path to `spawn()` works on all platforms.

This is the same pattern already proven in `packages/daemon/src/scheduler/spawn.ts`:
```typescript
const resolvedBin = Bun.which(bin);
if (resolvedBin === null) { return { error: `CLI binary "${bin}" not found on PATH` }; }
const child = nodeSpawn(resolvedBin, args, { ... });
```

## Files changed

- `packages/daemon/src/pipeline/provider.ts` — `spawnHidden()` now resolves binary via `Bun.which()` before `Bun.spawn()` (fixes all 4 provider call sites)
- `packages/daemon/src/daemon.ts` — extraction and synthesis validation spawns use `Bun.which()` to pre-resolve `claude`/`codex` before `node:child_process spawn()` (3 sites)

## Test plan

- [ ] Windows: install Claude Code CLI globally, `signet daemon restart` — verify extraction uses `claude-code` (not ollama fallback)
- [ ] Windows ARM64: same verification
- [ ] macOS/Linux: verify no regression — `Bun.which("claude")` returns existing binary paths
- [ ] Uninstall claude: verify graceful fallback to ollama with appropriate log message
- [ ] End-to-end: trigger memory extraction on Windows, verify it completes via Claude Code CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)