### PR TITLE
fix: predictor sidecar binary distribution for Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,6 +180,7 @@ jobs:
           & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe" `
             modify --installPath "${env:ProgramFiles}\Microsoft Visual Studio\2022\Enterprise" `
             --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --quiet --norestart | Out-Null
+          if ($LASTEXITCODE -notin @(0, 3010)) { exit $LASTEXITCODE }
 
       - name: Build predictor
         run: cargo build --release --target "$RELEASE_TARGET"
@@ -248,6 +249,7 @@ jobs:
           & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe" `
             modify --installPath "${env:ProgramFiles}\Microsoft Visual Studio\2022\Enterprise" `
             --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --quiet --norestart | Out-Null
+          if ($LASTEXITCODE -notin @(0, 3010)) { exit $LASTEXITCODE }
 
       - name: Build daemon
         run: cargo build --release --target "$RELEASE_TARGET" -p signet-daemon

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,9 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             asset: signet-predictor-win32-x64.exe
+          - os: windows-latest
+            target: aarch64-pc-windows-msvc
+            asset: signet-predictor-win32-arm64.exe
     runs-on: ${{ matrix.os }}
     env:
       RELEASE_VERSION: ${{ needs.release.outputs.version }}
@@ -180,9 +183,13 @@ jobs:
           EXT=""
           [ "$RUNNER_OS" = "Windows" ] && EXT=".exe"
           BINARY="packages/predictor/target/${RELEASE_TARGET}/release/signet-predictor${EXT}"
-          openssl dgst -sha256 -hex "${BINARY}" | awk '{print $NF}' > "${BINARY}.sha256"
-          gh release upload "v${RELEASE_VERSION}" "${BINARY}#${RELEASE_ASSET}" --clobber
-          gh release upload "v${RELEASE_VERSION}" "${BINARY}.sha256#${RELEASE_ASSET}.sha256" --clobber
+          # Rename binary to the platform-specific asset name so gh uses it as
+          # the release asset name (not just the label). This fixes the bug where
+          # all matrix legs uploaded as "signet-predictor" and overwrote each other.
+          cp "${BINARY}" "${RELEASE_ASSET}"
+          openssl dgst -sha256 -hex "${RELEASE_ASSET}" | awk '{print $NF}' > "${RELEASE_ASSET}.sha256"
+          gh release upload "v${RELEASE_VERSION}" "${RELEASE_ASSET}" --clobber
+          gh release upload "v${RELEASE_VERSION}" "${RELEASE_ASSET}.sha256" --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -208,6 +215,9 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             asset: signet-daemon-win32-x64.exe
+          - os: windows-latest
+            target: aarch64-pc-windows-msvc
+            asset: signet-daemon-win32-arm64.exe
     runs-on: ${{ matrix.os }}
     env:
       RELEASE_VERSION: ${{ needs.release.outputs.version }}
@@ -229,9 +239,10 @@ jobs:
           EXT=""
           [ "$RUNNER_OS" = "Windows" ] && EXT=".exe"
           BINARY="packages/daemon-rs/target/${RELEASE_TARGET}/release/signet-daemon${EXT}"
-          openssl dgst -sha256 -hex "${BINARY}" | awk '{print $NF}' > "${BINARY}.sha256"
-          gh release upload "v${RELEASE_VERSION}" "${BINARY}#${RELEASE_ASSET}" --clobber
-          gh release upload "v${RELEASE_VERSION}" "${BINARY}.sha256#${RELEASE_ASSET}.sha256" --clobber
+          cp "${BINARY}" "${RELEASE_ASSET}"
+          openssl dgst -sha256 -hex "${RELEASE_ASSET}" | awk '{print $NF}' > "${RELEASE_ASSET}.sha256"
+          gh release upload "v${RELEASE_VERSION}" "${RELEASE_ASSET}" --clobber
+          gh release upload "v${RELEASE_VERSION}" "${RELEASE_ASSET}.sha256" --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,6 +173,14 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install MSVC ARM64 toolchain
+        if: matrix.target == 'aarch64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe" `
+            modify --installPath "${env:ProgramFiles}\Microsoft Visual Studio\2022\Enterprise" `
+            --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --quiet --norestart | Out-Null
+
       - name: Build predictor
         run: cargo build --release --target "$RELEASE_TARGET"
         working-directory: packages/predictor
@@ -183,13 +191,15 @@ jobs:
           EXT=""
           [ "$RUNNER_OS" = "Windows" ] && EXT=".exe"
           BINARY="packages/predictor/target/${RELEASE_TARGET}/release/signet-predictor${EXT}"
-          # Rename binary to the platform-specific asset name so gh uses it as
-          # the release asset name (not just the label). This fixes the bug where
-          # all matrix legs uploaded as "signet-predictor" and overwrote each other.
-          cp "${BINARY}" "${RELEASE_ASSET}"
-          openssl dgst -sha256 -hex "${RELEASE_ASSET}" | awk '{print $NF}' > "${RELEASE_ASSET}.sha256"
-          gh release upload "v${RELEASE_VERSION}" "${RELEASE_ASSET}" --clobber
-          gh release upload "v${RELEASE_VERSION}" "${RELEASE_ASSET}.sha256" --clobber
+          # Copy binary with the platform-specific asset name into a temp
+          # directory so gh uploads it under the correct name (not just as a
+          # label) and we don't leave artifacts in the repo root.
+          STAGING="${RUNNER_TEMP}/upload"
+          mkdir -p "${STAGING}"
+          cp "${BINARY}" "${STAGING}/${RELEASE_ASSET}"
+          openssl dgst -sha256 -hex "${STAGING}/${RELEASE_ASSET}" | awk '{print $NF}' > "${STAGING}/${RELEASE_ASSET}.sha256"
+          gh release upload "v${RELEASE_VERSION}" "${STAGING}/${RELEASE_ASSET}" --clobber
+          gh release upload "v${RELEASE_VERSION}" "${STAGING}/${RELEASE_ASSET}.sha256" --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -230,6 +240,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Install MSVC ARM64 toolchain
+        if: matrix.target == 'aarch64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe" `
+            modify --installPath "${env:ProgramFiles}\Microsoft Visual Studio\2022\Enterprise" `
+            --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --quiet --norestart | Out-Null
+
       - name: Build daemon
         run: cargo build --release --target "$RELEASE_TARGET" -p signet-daemon
         working-directory: packages/daemon-rs
@@ -239,10 +258,15 @@ jobs:
           EXT=""
           [ "$RUNNER_OS" = "Windows" ] && EXT=".exe"
           BINARY="packages/daemon-rs/target/${RELEASE_TARGET}/release/signet-daemon${EXT}"
-          cp "${BINARY}" "${RELEASE_ASSET}"
-          openssl dgst -sha256 -hex "${RELEASE_ASSET}" | awk '{print $NF}' > "${RELEASE_ASSET}.sha256"
-          gh release upload "v${RELEASE_VERSION}" "${RELEASE_ASSET}" --clobber
-          gh release upload "v${RELEASE_VERSION}" "${RELEASE_ASSET}.sha256" --clobber
+          # Copy binary with the platform-specific asset name into a temp
+          # directory so gh uploads it under the correct name (not just as a
+          # label) and we don't leave artifacts in the repo root.
+          STAGING="${RUNNER_TEMP}/upload"
+          mkdir -p "${STAGING}"
+          cp "${BINARY}" "${STAGING}/${RELEASE_ASSET}"
+          openssl dgst -sha256 -hex "${STAGING}/${RELEASE_ASSET}" | awk '{print $NF}' > "${STAGING}/${RELEASE_ASSET}.sha256"
+          gh release upload "v${RELEASE_VERSION}" "${STAGING}/${RELEASE_ASSET}" --clobber
+          gh release upload "v${RELEASE_VERSION}" "${STAGING}/${RELEASE_ASSET}.sha256" --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -393,7 +393,7 @@ async function downloadDaemonBinary(): Promise<void> {
 
 	const plat = process.platform;
 	const arch = process.arch;
-	const supported = new Set(["linux:x64", "darwin:x64", "darwin:arm64", "win32:x64"]);
+	const supported = new Set(["linux:x64", "darwin:x64", "darwin:arm64", "win32:x64", "win32:arm64"]);
 	if (!supported.has(`${plat}:${arch}`)) return;
 
 	const ext = plat === "win32" ? ".exe" : "";
@@ -830,7 +830,7 @@ function predictorBinaryName():
 	const host = process.platform;
 	const cpu = process.arch;
 	const tuple = `${host}:${cpu}`;
-	const supported = new Set(["linux:x64", "darwin:x64", "darwin:arm64", "win32:x64"]);
+	const supported = new Set(["linux:x64", "darwin:x64", "darwin:arm64", "win32:x64", "win32:arm64"]);
 	if (!supported.has(tuple)) {
 		return null;
 	}


### PR DESCRIPTION
## Summary

- **Fixes asset naming bug in CI**: `gh release upload` was using the on-disk filename (`signet-predictor` / `signet-daemon`) as the release asset name, with the platform-specific name (e.g. `signet-predictor-win32-x64.exe`) only set as the *label*. Since all matrix legs produced the same filename, they overwrote each other — only one binary survived per release. Fixed by copying the binary to the expected asset name before uploading.
- **Adds `aarch64-pc-windows-msvc` to build matrices**: Both `build-predictor` and `build-daemon` now build for ARM64 Windows in addition to x64 Windows.
- **Adds `win32:arm64` to CLI supported tuples**: `predictorBinaryName()` and `downloadDaemonBinary()` now recognize ARM64 Windows so `signet sync` downloads the correct binary.

## What was broken

The predictor sidecar has never worked on any Windows install (x64 or arm64). The daemon log shows:

```json
{"level":"warn","category":"predictor","message":"Predictor binary not found, sidecar not started"}
```

**Root cause**: The `gh release upload "${BINARY}#${RELEASE_ASSET}"` syntax sets `RELEASE_ASSET` as the asset *label*, not the asset *name*. The asset name comes from the filename on disk (`signet-predictor.exe`), so all 4 matrix jobs (linux-x64, darwin-arm64, darwin-x64, win32-x64) uploaded files with the same name and overwrote each other. The `signet sync` downloader and `predictor-client.ts` both resolve binaries by the platform-specific name (e.g. `signet-predictor-win32-x64.exe`), which never existed as a release asset.

## How it was fixed

1. **CI upload step** (`release.yml`): Copy the built binary to the platform-specific asset name (`cp "${BINARY}" "${RELEASE_ASSET}"`) before uploading, so each matrix leg produces a uniquely-named release asset.
2. **Build matrix** (`release.yml`): Added `aarch64-pc-windows-msvc` entries for both predictor and daemon.
3. **CLI platform gate** (`cli.ts`): Added `"win32:arm64"` to both `predictorBinaryName()` and `downloadDaemonBinary()` supported sets.

## Why this approach

- **No changes to macOS or Linux**: The fix only adds Windows targets and changes the upload naming strategy. Existing darwin/linux builds are unaffected — they just get correctly-named assets now instead of colliding.
- **No daemon/predictor-client changes needed**: The TypeScript binary resolution code (`npmLocalBinaryCandidate`, `syncedBinaryCandidate`) already constructs the correct platform-specific filenames. The only problem was that those files never existed on disk because CI wasn't producing them with the right names.
- **No database changes**: This is purely a build/distribution fix.

## Test plan

- [ ] Verify CI builds pass for all 6 predictor targets (linux-x64, darwin-x64, darwin-arm64, win32-x64, win32-arm64) 
- [ ] Verify release assets are named correctly (e.g. `signet-predictor-win32-x64.exe`, not `signet-predictor.exe`)
- [ ] Run `signet sync` on Windows x64 — confirm predictor binary downloads to `~/.agents/.daemon/bin/`
- [ ] Run `signet sync` on Windows ARM64 — confirm predictor binary downloads
- [ ] Verify `signet status` shows predictor as online after daemon restart on Windows
- [ ] Verify macOS/Linux behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)