### PR TITLE
fix: move @signet/core to devDependencies in openclaw plugin

### DIFF
--- a/packages/adapters/openclaw/package.json
+++ b/packages/adapters/openclaw/package.json
@@ -32,8 +32,10 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@signet/core": "workspace:*",
     "@sinclair/typebox": "0.34.47"
+  },
+  "devDependencies": {
+    "@signet/core": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=0.1.0"


### PR DESCRIPTION
## Summary

- `@signet/core` is workspace-only and never published to npm, but the openclaw plugin listed it as a runtime dependency
- `signet sync` failed with `@signet/core@0.65.2 failed to resolve` when trying to refresh the plugin
- Since `bun build` already bundles `@signet/core` into `dist/`, moved to `devDependencies`

*Binary asset name fix landed separately via #236.*

## Test plan

- [ ] Verify `signet sync` no longer errors on `@signet/core` resolution
- [ ] Verify openclaw plugin still builds: `cd packages/adapters/openclaw && bun run build`