### PR TITLE
fix: use bash shell for cargo build steps on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,7 @@ jobs:
           if ($LASTEXITCODE -notin @(0, 3010)) { exit $LASTEXITCODE }
 
       - name: Build predictor
+        shell: bash
         run: cargo build --release --target "$RELEASE_TARGET"
         working-directory: packages/predictor
 
@@ -252,6 +253,7 @@ jobs:
           if ($LASTEXITCODE -notin @(0, 3010)) { exit $LASTEXITCODE }
 
       - name: Build daemon
+        shell: bash
         run: cargo build --release --target "$RELEASE_TARGET" -p signet-daemon
         working-directory: packages/daemon-rs
       - name: Upload to release


### PR DESCRIPTION
## Summary

- Windows runners default to PowerShell, which treats `$RELEASE_TARGET` as a PowerShell variable (empty) instead of the env var
- Cargo gets `--target ""` and fails with `error: target was empty`
- All 4 Windows build legs (predictor x64/arm64, daemon x64/arm64) fail every release
- Fix: add `shell: bash` to both cargo build steps, matching the upload steps which already use it

## Test plan

- [ ] Next release produces Windows binaries on the GitHub release page
- [ ] All 10 matrix legs pass (linux x64, darwin x64/arm64, win32 x64/arm64 for both predictor and daemon)