### PR TITLE
fix: prevent CMD window flashing on Windows and fix workspace path matching

### DIFF
--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -105,6 +105,10 @@ interface SpawnResult {
 	kill(signal?: string): void;
 }
 
+// Module-level helper to avoid allocating a new closure per spawnHidden call.
+const toWebStream = (nodeStream: import("node:stream").Readable): ReadableStream<Uint8Array> =>
+	Readable.toWeb(nodeStream) as ReadableStream<Uint8Array>;
+
 function spawnHidden(cmd: string[], options?: { env?: Record<string, string | undefined> }): SpawnResult {
 	// Resolve the binary via Bun.which() so that .cmd wrappers on Windows
 	// are found correctly (mirrors scheduler/spawn.ts pattern).
@@ -123,15 +127,15 @@ function spawnHidden(cmd: string[], options?: { env?: Record<string, string | un
 	// On Windows, use node:child_process with windowsHide to prevent
 	// console window flashing. Bun.spawn doesn't support windowsHide.
 	if (process.platform === "win32") {
+		// .cmd wrappers (e.g. claude.cmd, codex.cmd from npm) are shell scripts,
+		// not PE executables — node:child_process requires shell: true to run them.
+		const useShell = resolvedBin.endsWith(".cmd");
 		const child = nodeSpawn(resolvedBin, args, {
 			stdio: ["ignore", "pipe", "pipe"],
 			env: options?.env ? sanitizedEnv : undefined,
 			windowsHide: true,
+			shell: useShell,
 		});
-
-		// Convert Node.js Readable streams to Web ReadableStreams
-		const toWebStream = (nodeStream: import("node:stream").Readable): ReadableStream<Uint8Array> =>
-			Readable.toWeb(nodeStream) as ReadableStream<Uint8Array>;
 
 		const exitPromise = new Promise<number>((resolve, reject) => {
 			child.on("exit", (code) => resolve(code ?? 1));

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -127,15 +127,26 @@ function spawnHidden(cmd: string[], options?: { env?: Record<string, string | un
 	// On Windows, use node:child_process with windowsHide to prevent
 	// console window flashing. Bun.spawn doesn't support windowsHide.
 	if (process.platform === "win32") {
-		// .cmd wrappers (e.g. claude.cmd, codex.cmd from npm) are shell scripts,
-		// not PE executables — node:child_process requires shell: true to run them.
-		const useShell = resolvedBin.endsWith(".cmd");
-		const child = nodeSpawn(resolvedBin, args, {
-			stdio: ["ignore", "pipe", "pipe"],
-			env: options?.env ? sanitizedEnv : undefined,
-			windowsHide: true,
-			shell: useShell,
-		});
+		// .cmd wrappers (e.g. claude.cmd, codex.cmd from npm) are batch scripts,
+		// not PE executables. Instead of shell: true (which exposes args to
+		// cmd.exe metacharacter interpretation — injection risk), invoke cmd.exe
+		// explicitly with properly quoted arguments.
+		let child: import("node:child_process").ChildProcess;
+		if (resolvedBin.endsWith(".cmd")) {
+			const quote = (s: string) => `"${s.replace(/"/g, '""')}"`;
+			const cmdLine = [quote(resolvedBin), ...args.map(quote)].join(" ");
+			child = nodeSpawn(process.env.COMSPEC || "cmd.exe", ["/d", "/s", "/c", `"${cmdLine}"`], {
+				stdio: ["ignore", "pipe", "pipe"],
+				env: options?.env ? sanitizedEnv : undefined,
+				windowsHide: true,
+			});
+		} else {
+			child = nodeSpawn(resolvedBin, args, {
+				stdio: ["ignore", "pipe", "pipe"],
+				env: options?.env ? sanitizedEnv : undefined,
+				windowsHide: true,
+			});
+		}
 
 		const exitPromise = new Promise<number>((resolve, reject) => {
 			child.on("exit", (code) => resolve(code ?? 1));

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -133,7 +133,7 @@ function spawnHidden(cmd: string[], options?: { env?: Record<string, string | un
 		// explicitly with properly quoted arguments.
 		let child: import("node:child_process").ChildProcess;
 		if (resolvedBin.endsWith(".cmd")) {
-			const quote = (s: string) => `"${s.replace(/"/g, '""')}"`;
+			const quote = (s: string) => `"${s.replace(/%/g, "%%").replace(/"/g, '""')}"`;
 			const cmdLine = [quote(resolvedBin), ...args.map(quote)].join(" ");
 			child = nodeSpawn(process.env.COMSPEC || "cmd.exe", ["/d", "/s", "/c", `"${cmdLine}"`], {
 				stdio: ["ignore", "pipe", "pipe"],


### PR DESCRIPTION
## Summary

Fixes console window popups ("CMD flash") on Windows when the Signet daemon spawns subprocesses, and fixes workspace scope matching for Windows-style backslash paths.

## What

- Added `windowsHide: true` to all remaining `spawn`/`execSync` calls that were missing it:
  - `detectGitBranch()` in `daemon.ts` (2 execSync calls)
  - Shadow daemon spawn in `daemon.ts`
  - Predictor sidecar spawn in `predictor-client.ts`
- Rewrote `spawnHidden()` in `pipeline/provider.ts` to use `node:child_process` on Windows instead of `Bun.spawn`, since Bun.spawn does not support `windowsHide`
  - Converts Node.js Readable streams to Web ReadableStreams for interface compatibility
  - Added null guards and error rejection for robustness
- Normalized backslash (`\`) to forward slash (`/`) in marketplace workspace scope matching (`marketplace.ts` and `marketplace.rs`)

## How

**CMD flash prevention:** On Windows, any `child_process.spawn()` or `execSync()` without `windowsHide: true` opens a visible console window. This PR audits every spawn site in the daemon and adds the flag where missing.

**`spawnHidden()` refactor:** `Bun.spawn` doesn't expose a `windowsHide` option, so on Windows the function now branches to `node:child_process.spawn` with `windowsHide: true` and wraps the Node streams via `Readable.toWeb()`. Non-Windows platforms continue using `Bun.spawn` directly.

**Path normalization:** Windows paths use `\` separators, but marketplace scope entries may use `/`. Both the TypeScript and Rust scope-matching logic now normalize to `/` before comparison, so workspace scopes match correctly on Windows.

## Why

On Windows (including ARM64), every subprocess the daemon launches — git operations, predictor sidecar, shadow daemon, LLM provider CLI calls — was flashing a visible CMD window. This is disruptive and makes the daemon feel broken on Windows desktops. The workspace scope matching was also silently failing because `C:\Users\...` never matched `C:/Users/...`.

## Test plan

- [ ] Verify no CMD window flash when daemon starts on Windows x64
- [ ] Verify no CMD window flash when daemon starts on Windows ARM64
- [ ] Verify predictor sidecar launches without visible window
- [ ] Verify `spawnHidden()` CLI calls (Claude/Codex) work correctly on Windows
- [ ] Verify marketplace workspace scope matching works with backslash paths
- [ ] Verify non-Windows platforms are unaffected (Bun.spawn path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)