### PR TITLE
feat: homepage spotlights, dynamic insights, and health consistency

### DIFF
--- a/packages/cli/dashboard/src/lib/components/home/MarketplaceSpotlights.svelte
+++ b/packages/cli/dashboard/src/lib/components/home/MarketplaceSpotlights.svelte
@@ -57,7 +57,8 @@
 		return null;
 	}
 
-	function handleClick(entry: SpotlightEntry): void {
+	function handleClick(_entry: SpotlightEntry): void {
+		// Both skills and MCP servers live on the "skills" (Marketplace) tab
 		nav.activeTab = "skills";
 	}
 </script>

--- a/packages/cli/dashboard/src/lib/components/home/MarketplaceSpotlights.svelte
+++ b/packages/cli/dashboard/src/lib/components/home/MarketplaceSpotlights.svelte
@@ -1,0 +1,264 @@
+<script lang="ts">
+	import type { SkillSearchResult, MarketplaceMcpCatalogEntry } from "$lib/api";
+	import { getMonogram, getMonogramBg, getAvatarUrl, getAvatarFromSource } from "$lib/card-utils";
+	import { fetchCatalog, sk } from "$lib/stores/skills.svelte";
+	import { fetchMarketplaceMcpCatalog, mcpMarket } from "$lib/stores/marketplace-mcp.svelte";
+	import { nav } from "$lib/stores/navigation.svelte";
+	import { SvelteSet } from "svelte/reactivity";
+	import { onMount } from "svelte";
+
+	type SpotlightEntry =
+		| { readonly kind: "skill"; readonly item: SkillSearchResult }
+		| { readonly kind: "mcp"; readonly item: MarketplaceMcpCatalogEntry };
+
+	const TOTAL = 6;
+
+	let loaded = $state(false);
+	const avatarErrors = new SvelteSet<string>();
+
+	onMount(async () => {
+		await Promise.allSettled([fetchCatalog(), fetchMarketplaceMcpCatalog(5)]);
+		loaded = true;
+	});
+
+	const spotlights = $derived.by((): SpotlightEntry[] => {
+		const skills: SpotlightEntry[] = sk.catalog
+			.slice(0, 3)
+			.map((item) => ({ kind: "skill" as const, item }));
+		const mcps: SpotlightEntry[] = mcpMarket.catalog
+			.slice(0, 3)
+			.map((item) => ({ kind: "mcp" as const, item }));
+		return [...skills, ...mcps].slice(0, TOTAL);
+	});
+
+	function spotlightId(entry: SpotlightEntry): string {
+		return entry.kind === "skill" ? `sk:${entry.item.name}` : `mcp:${entry.item.id}`;
+	}
+
+	function spotlightName(entry: SpotlightEntry): string {
+		return entry.item.name;
+	}
+
+	function spotlightDesc(entry: SpotlightEntry): string {
+		return entry.item.description;
+	}
+
+	function spotlightBadge(entry: SpotlightEntry): string {
+		return entry.kind === "skill" ? "SKILL" : "MCP";
+	}
+
+	function spotlightAvatar(entry: SpotlightEntry): string | null {
+		if (entry.kind === "mcp") {
+			return getAvatarFromSource(entry.item.source, entry.item.catalogId)
+				?? getAvatarUrl(entry.item.sourceUrl);
+		}
+		const maintainer = entry.item.maintainer;
+		if (maintainer) return `https://github.com/${maintainer.split("/")[0]}.png?size=40`;
+		return null;
+	}
+
+	function handleClick(entry: SpotlightEntry): void {
+		nav.activeTab = "skills";
+	}
+</script>
+
+<div class="spotlights-panel sig-panel">
+	<div class="spotlights-header sig-panel-header">
+		<span class="spotlights-title">MOST USED SKILLS & SERVERS</span>
+		<span class="spotlights-count">{spotlights.length} TOP PICKS</span>
+	</div>
+
+	{#if !loaded && spotlights.length === 0}
+		<div class="empty-state">LOADING CATALOG...</div>
+	{:else if spotlights.length === 0}
+		<div class="empty-state">NO CATALOG DATA</div>
+	{:else}
+		<div class="spotlights-grid">
+			{#each spotlights as entry (spotlightId(entry))}
+				{@const avatar = spotlightAvatar(entry)}
+				{@const id = spotlightId(entry)}
+				<button
+					type="button"
+					class="spotlight-card"
+					onclick={() => handleClick(entry)}
+				>
+					<div class="spotlight-top">
+						<div
+							class="spotlight-icon"
+							style="background: {avatar && !avatarErrors.has(id) ? 'transparent' : getMonogramBg(spotlightName(entry))};"
+						>
+							{#if avatar && !avatarErrors.has(id)}
+								<img
+									src={avatar}
+									alt={spotlightName(entry)}
+									class="spotlight-avatar"
+									onerror={() => { avatarErrors.add(id); }}
+								/>
+							{:else}
+								{getMonogram(spotlightName(entry))}
+							{/if}
+						</div>
+						<div class="spotlight-meta">
+							<span class="spotlight-name">{spotlightName(entry)}</span>
+							<span class="spotlight-badge">{spotlightBadge(entry)}</span>
+						</div>
+					</div>
+					<p class="spotlight-desc">{spotlightDesc(entry)}</p>
+				</button>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.spotlights-panel {
+		display: flex;
+		flex-direction: column;
+		background: var(--sig-surface);
+	}
+
+	.spotlights-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--space-sm) var(--space-md);
+		flex-shrink: 0;
+	}
+
+	.spotlights-title {
+		font-family: var(--font-display);
+		font-size: 11px;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--sig-text-bright);
+	}
+
+	.spotlights-count {
+		font-family: var(--font-mono);
+		font-size: 8px;
+		letter-spacing: 0.1em;
+		color: var(--sig-text-muted);
+	}
+
+	.spotlights-grid {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+		gap: var(--space-xs);
+		padding: var(--space-sm) var(--space-md) var(--space-sm);
+		align-content: start;
+	}
+
+	.spotlight-card {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		padding: var(--space-xs) var(--space-sm);
+		border: 1px solid var(--sig-border);
+		border-radius: var(--radius);
+		background: var(--sig-surface);
+		cursor: pointer;
+		text-align: left;
+		min-width: 0;
+		transition: border-color var(--dur) var(--ease), background var(--dur) var(--ease);
+	}
+
+	.spotlight-card:hover {
+		border-color: var(--sig-border-strong);
+		background: var(--sig-surface-raised);
+	}
+
+	.spotlight-card:focus-visible {
+		outline: 2px solid var(--sig-highlight);
+		outline-offset: 1px;
+	}
+
+	.spotlight-top {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.spotlight-icon {
+		width: 22px;
+		height: 22px;
+		border-radius: 3px;
+		border: 1px solid var(--sig-icon-border);
+		display: grid;
+		place-items: center;
+		font-family: var(--font-mono);
+		font-size: 8px;
+		font-weight: 700;
+		color: var(--sig-icon-fg);
+		text-transform: uppercase;
+		flex-shrink: 0;
+		overflow: hidden;
+	}
+
+	.spotlight-avatar {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+
+	.spotlight-meta {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		min-width: 0;
+		flex: 1;
+	}
+
+	.spotlight-name {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		font-weight: 600;
+		color: var(--sig-text-bright);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		flex: 1;
+		min-width: 0;
+	}
+
+	.spotlight-badge {
+		flex-shrink: 0;
+		font-family: var(--font-mono);
+		font-size: 8px;
+		padding: 1px 4px;
+		border: 1px solid var(--sig-border-strong);
+		color: var(--sig-text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+	}
+
+	.spotlight-desc {
+		font-family: var(--font-mono);
+		font-size: 9px;
+		color: var(--sig-text-muted);
+		line-height: 1.4;
+		margin: 0;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+
+	.empty-state {
+		flex: 1;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-family: var(--font-mono);
+		font-size: 9px;
+		letter-spacing: 0.1em;
+		color: var(--sig-text-muted);
+	}
+
+</style>

--- a/packages/cli/dashboard/src/lib/components/home/PinnedEntityCluster.svelte
+++ b/packages/cli/dashboard/src/lib/components/home/PinnedEntityCluster.svelte
@@ -28,10 +28,10 @@
 				const data = await res.json();
 				const results = (data.memories ?? []) as SpotlightMemory[];
 				const valid = results
-					.filter((r) => typeof r.id === "string" && r.id.length > 0)
+					.filter((r) => typeof r.id === "string" && r.id.length > 0 && typeof r.content === "string")
 					.map((r) => ({
 						id: r.id,
-						content: r.content,
+						content: r.content ?? "",
 						access_count: r.access_count ?? 0,
 						importance: r.importance ?? 0.5,
 					}));

--- a/packages/cli/dashboard/src/lib/components/home/PinnedEntityCluster.svelte
+++ b/packages/cli/dashboard/src/lib/components/home/PinnedEntityCluster.svelte
@@ -1,65 +1,98 @@
 <script lang="ts">
+	import type { Memory } from "$lib/api";
 	import { setTab } from "$lib/stores/navigation.svelte";
-	import Network from "@lucide/svelte/icons/network";
+	import { API_BASE } from "$lib/api";
+	import Brain from "@lucide/svelte/icons/brain";
 	import { onMount } from "svelte";
 
-	const isDev = import.meta.env.DEV;
-	const API_BASE = isDev ? "http://localhost:3850" : "";
-
-	interface PinnedEntity {
-		id: string;
-		name: string;
-		type?: string;
-		mentionCount?: number;
+	interface Props {
+		memories: Memory[];
 	}
 
-	let entities = $state<PinnedEntity[]>([]);
+	const { memories }: Props = $props();
+
+	interface SpotlightMemory {
+		id: string;
+		content: string;
+		access_count: number;
+		importance: number;
+	}
+
+	let items = $state<SpotlightMemory[]>([]);
 	let loaded = $state(false);
 
-	async function fetchPinned(): Promise<void> {
+	async function fetchMostUsed(): Promise<void> {
 		try {
-			const res = await fetch(`${API_BASE}/api/knowledge/entities?pinned=true&limit=6`);
+			const res = await fetch(`${API_BASE}/api/memories/most-used?limit=50`);
 			if (res.ok) {
 				const data = await res.json();
-				entities = data.entities ?? data.items ?? [];
+				const results = data.memories ?? [];
+				if (results.length > 0) {
+					items = results;
+					loaded = true;
+					return;
+				}
 			}
 		} catch {
 			// endpoint may not exist yet
 		}
+
+		// Fallback: use prop memories sorted by importance
+		items = memories
+			.map((m) => ({
+				id: m.id,
+				content: m.content,
+				access_count: 0,
+				importance: m.importance ?? 0.5,
+			}))
+			.sort((a, b) => b.importance - a.importance)
+			.slice(0, 50);
 		loaded = true;
 	}
 
 	onMount(() => {
-		fetchPinned();
+		fetchMostUsed();
 	});
+
+	function label(m: SpotlightMemory): string {
+		const text = m.content.trim();
+		const first = text.split("\n")[0] ?? text;
+		return first.length > 60 ? `${first.slice(0, 57)}...` : first;
+	}
+
+	function importanceColor(imp: number): string {
+		if (imp >= 0.8) return "var(--sig-danger)";
+		if (imp >= 0.5) return "var(--sig-warning)";
+		return "var(--sig-success)";
+	}
 </script>
 
 <div class="panel sig-panel">
 	<div class="panel-header sig-panel-header">
 		<span class="panel-title">SPOTLIGHT</span>
-		<span class="panel-count">{entities.length} PINNED</span>
+		<span class="panel-count">{items.length} RECALLED</span>
 	</div>
 
 	<div class="panel-body">
 		{#if !loaded}
 			<div class="empty-state">LOADING</div>
-		{:else if entities.length === 0}
+		{:else if items.length === 0}
 			<div class="empty-state">
-				<Network class="empty-icon" />
-				<span>PIN AN ENTITY IN KNOWLEDGE<br/>TO SET YOUR SPOTLIGHT</span>
+				<Brain class="empty-icon" />
+				<span>NO MEMORIES YET</span>
 			</div>
 		{:else}
 			<div class="entity-list">
-				{#each entities as entity, idx (entity.id ?? `entity-${idx}`)}
+				{#each items as memory, idx (memory.id)}
 					<div class="entity-row">
 						<span class="entity-idx">{String(idx + 1).padStart(2, "0")}</span>
 						<span
 							class="entity-dot"
-							style="background: var(--sig-highlight)"
+							style="background: {importanceColor(memory.importance)}"
 						></span>
-						<span class="entity-name">{entity.name}</span>
-						{#if entity.mentionCount !== undefined}
-							<span class="entity-count">{entity.mentionCount}</span>
+						<span class="entity-name">{label(memory)}</span>
+						{#if memory.access_count > 0}
+							<span class="entity-count" title="times recalled">{memory.access_count}</span>
 						{/if}
 					</div>
 				{/each}
@@ -68,8 +101,8 @@
 	</div>
 
 	<div class="panel-footer sig-panel-footer">
-		<button class="panel-link" onclick={() => setTab("knowledge")}>
-			VIEW IN KNOWLEDGE
+		<button class="panel-link" onclick={() => setTab("memory")}>
+			VIEW IN MEMORY
 		</button>
 	</div>
 </div>

--- a/packages/cli/dashboard/src/lib/components/home/PinnedEntityCluster.svelte
+++ b/packages/cli/dashboard/src/lib/components/home/PinnedEntityCluster.svelte
@@ -27,13 +27,16 @@
 			if (res.ok) {
 				const data = await res.json();
 				const results = (data.memories ?? []) as SpotlightMemory[];
-				if (results.length > 0) {
-					items = results.map((r) => ({
+				const valid = results
+					.filter((r) => typeof r.id === "string" && r.id.length > 0)
+					.map((r) => ({
 						id: r.id,
 						content: r.content,
 						access_count: r.access_count ?? 0,
 						importance: r.importance ?? 0.5,
 					}));
+				if (valid.length > 0) {
+					items = valid;
 					loaded = true;
 					return;
 				}

--- a/packages/cli/dashboard/src/lib/components/home/PinnedEntityCluster.svelte
+++ b/packages/cli/dashboard/src/lib/components/home/PinnedEntityCluster.svelte
@@ -26,9 +26,14 @@
 			const res = await fetch(`${API_BASE}/api/memories/most-used?limit=50`);
 			if (res.ok) {
 				const data = await res.json();
-				const results = data.memories ?? [];
+				const results = (data.memories ?? []) as SpotlightMemory[];
 				if (results.length > 0) {
-					items = results;
+					items = results.map((r) => ({
+						id: r.id,
+						content: r.content,
+						access_count: r.access_count ?? 0,
+						importance: r.importance ?? 0.5,
+					}));
 					loaded = true;
 					return;
 				}

--- a/packages/cli/dashboard/src/lib/components/home/PredictorSplitBar.svelte
+++ b/packages/cli/dashboard/src/lib/components/home/PredictorSplitBar.svelte
@@ -39,7 +39,18 @@
 
 	const alpha = $derived(health?.alpha ?? 0.6);
 	const successRate = $derived(health?.successRate ?? 0);
-	const healthStatus = $derived(health?.status ?? "unknown");
+	const healthStatus = $derived.by(() => {
+		// Use composite diagnostic score for overall status
+		// instead of predictor-specific status (predictor is optional)
+		if (diagnostics?.composite) {
+			const score = diagnostics.composite.score;
+			if (score >= 0.7) return "healthy";
+			if (score >= 0.4) return "degraded";
+			return "unhealthy";
+		}
+		// Fall back to predictor status only if diagnostics unavailable
+		return health?.status ?? "unknown";
+	});
 
 	const embeddingCoverage = $derived(
 		diagnostics?.index?.embeddingCoverage ?? 0,

--- a/packages/cli/dashboard/src/lib/components/home/SuggestedInsights.svelte
+++ b/packages/cli/dashboard/src/lib/components/home/SuggestedInsights.svelte
@@ -15,6 +15,10 @@
 
 	let actedIds = $state<Set<string>>(new Set());
 	let displayOffset = $state(0);
+	let listEl: HTMLDivElement | undefined = $state();
+	let visibleCount = $state(3);
+
+	const ENTRY_HEIGHT = 90; // approximate height per insight entry
 
 	function scoreMemory(m: Memory): number {
 		const now = Date.now();
@@ -57,10 +61,21 @@
 
 	const displayCards = $derived.by(() => {
 		if (scoredPool.length === 0) return [];
+		const count = Math.min(visibleCount, scoredPool.length);
 		const start = displayOffset % scoredPool.length;
-		return Array.from({ length: Math.min(3, scoredPool.length) }, (_, i) =>
+		return Array.from({ length: count }, (_, i) =>
 			scoredPool[(start + i) % scoredPool.length].memory,
 		);
+	});
+
+	$effect(() => {
+		if (!listEl) return;
+		const observer = new ResizeObserver((entries) => {
+			const height = entries[0]?.contentRect.height ?? 0;
+			visibleCount = Math.max(1, Math.floor(height / ENTRY_HEIGHT));
+		});
+		observer.observe(listEl);
+		return () => observer.disconnect();
 	});
 
 	function importanceColor(imp: number): string {
@@ -125,7 +140,7 @@
 	}
 
 	function handleRefresh(): void {
-		displayOffset = (displayOffset + 3) % Math.max(1, scoredPool.length);
+		displayOffset = (displayOffset + visibleCount) % Math.max(1, scoredPool.length);
 	}
 </script>
 
@@ -146,7 +161,7 @@
 			<span>NO INSIGHTS TO CURATE</span>
 		</div>
 	{:else}
-		<div class="insights-list">
+		<div class="insights-list" bind:this={listEl}>
 			{#each displayCards as m, i (m.id)}
 				<div class="insight-entry">
 					<!-- Index + date row -->

--- a/packages/cli/dashboard/src/lib/components/tabs/HomeTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/HomeTab.svelte
@@ -20,6 +20,7 @@
 	import SuggestedInsights from "$lib/components/home/SuggestedInsights.svelte";
 	import PredictorSplitBar from "$lib/components/home/PredictorSplitBar.svelte";
 	import PinnedEntityCluster from "$lib/components/home/PinnedEntityCluster.svelte";
+	import MarketplaceSpotlights from "$lib/components/home/MarketplaceSpotlights.svelte";
 	import { onMount } from "svelte";
 
 	interface Props {
@@ -73,11 +74,14 @@
 			{memoryStats}
 		/>
 	</div>
+	<div class="area-spotlights">
+		<MarketplaceSpotlights />
+	</div>
 	<div class="area-insights">
 		<SuggestedInsights {memories} />
 	</div>
 	<div class="area-sidebar">
-		<PinnedEntityCluster />
+		<PinnedEntityCluster {memories} />
 		<PredictorSplitBar {daemonStatus} />
 	</div>
 </div>
@@ -87,10 +91,11 @@
 	.home-grid {
 		display: grid;
 		grid-template-columns: 1.6fr 1fr;
-		grid-template-rows: auto 1fr;
+		grid-template-rows: auto minmax(auto, max-content) 1fr;
 		grid-template-areas:
-			"banner  banner"
-			"insights sidebar";
+			"banner     banner"
+			"spotlights sidebar"
+			"insights   sidebar";
 		gap: var(--space-sm);
 		flex: 1;
 		min-height: 0;
@@ -102,6 +107,12 @@
 		grid-area: banner;
 	}
 
+	.area-spotlights {
+		grid-area: spotlights;
+		min-height: 0;
+		overflow: hidden;
+	}
+
 	.area-insights {
 		grid-area: insights;
 		min-height: 0;
@@ -110,6 +121,7 @@
 
 	.area-sidebar {
 		grid-area: sidebar;
+		grid-row: 2 / 4;
 		display: flex;
 		flex-direction: column;
 		gap: var(--space-sm);

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1726,6 +1726,27 @@ app.get("/api/memories", (c) => {
 	}
 });
 
+app.get("/api/memories/most-used", (c) => {
+	try {
+		const limit = Number.parseInt(c.req.query("limit") || "6", 10);
+		const memories = getDbAccessor().withReadDb((db) =>
+			db
+				.prepare(`
+					SELECT id, content, access_count, importance, type, tags
+					FROM memories
+					WHERE access_count > 0
+					ORDER BY access_count DESC, importance DESC
+					LIMIT ?
+				`)
+				.all(limit),
+		);
+		return c.json({ memories });
+	} catch (e) {
+		logger.error("memory", "Error loading most-used memories", e as Error);
+		return c.json({ memories: [] });
+	}
+});
+
 app.get("/api/memory/timeline", (c) => {
 	try {
 		const timeline = getDbAccessor().withReadDb((db) => buildMemoryTimeline(db));

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1728,7 +1728,8 @@ app.get("/api/memories", (c) => {
 
 app.get("/api/memories/most-used", (c) => {
 	try {
-		const limit = Number.parseInt(c.req.query("limit") || "6", 10);
+		const raw = Number.parseInt(c.req.query("limit") || "6", 10);
+		const limit = Number.isNaN(raw) || raw < 1 ? 6 : Math.min(raw, 200);
 		const memories = getDbAccessor().withReadDb((db) =>
 			db
 				.prepare(`


### PR DESCRIPTION
## Summary

Three homepage improvements and one health status consistency fix.

### 1. "Most Used Skills & Servers" section (new)
- New `MarketplaceSpotlights` component renders the top 3 agent skills + top 3 MCP servers by popularity from existing catalog stores
- Uses `auto-fill` CSS grid (`minmax(140px, 1fr)`) that adapts card columns to available width — no manual breakpoints needed
- Positioned between the banner and insights panel, aligned with the left column (stops at the sidebar boundary)
- Cards show provider avatar (unmodified — no hue-rotate), name, badge (SKILL/MCP), and 2-line description

### 2. Spotlight panel reworked (right sidebar)
- Previously fetched pinned knowledge graph entities which were often empty
- Now shows the **most frequently recalled memories** ranked by `access_count` from the database
- New backend endpoint `GET /api/memories/most-used?limit=N` queries `memories WHERE access_count > 0 ORDER BY access_count DESC`
- Falls back to importance-sorted memories from props when the endpoint isn't available (pre-rebuild compatibility)
- Fetches up to 50 entries — the list fills available vertical space and scrolls for more as the user extends the window

### 3. Dynamic Suggested Insights
- Previously hardcoded to always show exactly 3 insights regardless of window size
- Now uses `ResizeObserver` on the list container to calculate how many ~90px insight entries fit
- Shows more cards when the window is tall, fewer when compact — refresh button cycles by the dynamic count

### 4. Health status consistency fix
- `Memory Scoring` card was showing "UNHEALTHY" (from optional predictor sidecar) while `AgentHeader` showed "HEALTHY" (from composite diagnostic score)
- Fixed by deriving Memory Scoring status from the same composite diagnostic score: >= 70% = healthy, >= 40% = degraded, < 40% = unhealthy
- No more contradicting health indicators on the same page

## Changes

| File | Change |
|------|--------|
| `MarketplaceSpotlights.svelte` | New component — top skills & servers grid |
| `PinnedEntityCluster.svelte` | Reworked to show most-recalled memories |
| `PredictorSplitBar.svelte` | Health status derived from composite score |
| `SuggestedInsights.svelte` | Dynamic card count via ResizeObserver |
| `HomeTab.svelte` | Grid layout updated for new spotlights area |
| `daemon.ts` | New `/api/memories/most-used` endpoint |

## Test plan

- [ ] Homepage shows "Most Used Skills & Servers" with cards that reflow on resize
- [ ] Spotlight panel shows most-recalled memories (or fallback by importance)
- [ ] Suggested Insights shows more/fewer cards as window resizes
- [ ] Memory Scoring health status matches AgentHeader health status
- [ ] Shrinking the window down doesn't smush or hide any section
- [ ] Expanding the window reveals more spotlight memories and insight cards

Generated with [Claude Code](https://claude.com/claude-code)
