### PR TITLE
fix: use npm tauri CLI instead of cargo plugin in tray scripts

### DIFF
--- a/packages/tray/package.json
+++ b/packages/tray/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "build:dashboard": "cd ../cli/dashboard && bun run build",
     "build:ts": "rm -rf dist && bun build src-ts/index.ts --outfile dist/tray.js --target browser --minify && bun run build:dashboard && cp -r ../cli/dashboard/build/* dist/ && cp tray.html dist/tray.html && cp capture.html dist/capture.html && cp search.html dist/search.html",
-    "dev": "cargo tauri dev",
-    "build": "cargo tauri build",
-    "tauri": "cargo tauri"
+    "dev": "tauri dev",
+    "build": "tauri build",
+    "tauri": "tauri"
   },
   "dependencies": {
     "@signet/sdk": "workspace:*",


### PR DESCRIPTION
## Summary
- Desktop Build CI failing on all 4 targets (macOS x86/arm64, Linux, Windows) with `error: no such command: tauri`
- Root cause: tray `package.json` scripts called `cargo tauri` which requires the `cargo-tauri` plugin — not installed in CI
- Fix: point scripts directly at the `@tauri-apps/cli` npm binary (already a devDependency) instead of going through cargo

## Test plan
- [ ] Verify Desktop Build workflow passes on all 4 matrix targets after merge
- [ ] Confirm `bun tauri dev` still works locally in `packages/tray/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)