### PR TITLE
feat: bring Codex connector to parity with Claude Code / OpenCode

### DIFF
--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -174,9 +174,29 @@ Codex always loads Signet identity context.
 | Hook | Supported | Notes |
 |------|-----------|-------|
 | session-start | yes | Context injected via `model_instructions_file` |
-| user-prompt-submit | no | Codex has no mid-session hook support |
+| user-prompt-submit | best-effort | Live recall via transcript watcher (see below) |
 | pre-compaction | no | Codex has no mid-session hook support |
 | session-end | yes | Transcript path passed to daemon for memory extraction |
+
+### Live recall (transcript watcher)
+
+For interactive Codex sessions (`codex` without `exec`), the daemon
+watches the session transcript file in real-time. When a new user
+message is detected, the daemon runs a hybrid memory recall and writes
+the results to `~/.codex/.signet-live-context.md`. The model
+instructions file includes an instruction for Codex to read this file
+before each response.
+
+This is **best-effort** — Codex follows the file-read instruction most
+of the time but not always. The feature is enabled by default and can
+be disabled in `agent.yaml`:
+
+```yaml
+memory:
+  pipelineV2:
+    codexLiveRecall:
+      enabled: false
+```
 
 ### Memory commands
 

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -195,7 +195,8 @@ be disabled in `agent.yaml`:
 memory:
   pipelineV2:
     codexLiveRecall:
-      enabled: false
+      enabled: false   # disable live recall
+      debounceMs: 300  # ms to wait after transcript change before recalling
 ```
 
 ### Memory commands

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -138,33 +138,57 @@ This gives Claude Code direct access to `memory_search`, `memory_store`,
 
 Codex is OpenAI's terminal coding agent. Signet integrates with Codex by
 installing a shell wrapper that fires Signet lifecycle hooks around local
-`codex` sessions and injects session-start context through Codex's
-`model_instructions_file` setting.
+`codex` sessions, generating a persistent identity file, patching
+`config.toml`, and symlinking skills.
 
 ### Files managed by Signet
 
 | File | Description |
 |------|-------------|
 | `~/.config/signet/bin/codex` | Signet-managed Codex wrapper script |
+| `~/.codex/CODEX.md` | Auto-generated identity + Signet context (from `~/.agents/` files) |
+| `~/.codex/skills/` | Symlinked skills directory (from `~/.agents/skills/`) |
+| `~/.codex/config.toml` | Patched with `model_instructions_file` pointing to CODEX.md |
 | `~/.zshrc` / `~/.bashrc` / `~/.bash_profile` | PATH snippet that prioritizes the wrapper |
 
 ### How it works
 
-1. The wrapper calls `signet hook session-start -H codex` before launching Codex.
-2. The returned Signet context is written to a temporary instructions file.
-3. Codex is launched with `-c model_instructions_file=...` so the session starts with Signet context loaded.
-4. When Codex exits, the wrapper finds the newest `~/.codex/sessions/*.jsonl` transcript and calls `signet hook session-end -H codex`.
+1. On install, Signet generates `~/.codex/CODEX.md` from identity files
+   (AGENTS.md, SOUL.md, IDENTITY.md, USER.md, MEMORY.md) and patches
+   `config.toml` to always load it as `model_instructions_file`.
+2. The wrapper calls `signet hook session-start -H codex` before launching Codex.
+3. The returned dynamic context (memories, recall) is merged with the
+   persistent CODEX.md into a temporary instructions file.
+4. Codex is launched with `-c model_instructions_file=...` so the session
+   starts with full Signet context: identity + live memories.
+5. When Codex exits, the wrapper finds the newest `~/.codex/sessions/*.jsonl`
+   transcript and calls `signet hook session-end -H codex`.
 
 This gives Codex the same durable memory lifecycle as Claude Code without
-requiring Codex-specific database or schema changes.
+requiring Codex-specific database or schema changes. Even without the
+wrapper (e.g., running `codex` directly), the config.toml patch ensures
+Codex always loads Signet identity context.
 
 ### Supported hooks
 
-| Hook | Supported |
-|------|-----------|
-| session-start | yes — context injected via `model_instructions_file` |
-| user-prompt-submit | no |
-| session-end | yes — transcript path passed to daemon for memory extraction |
+| Hook | Supported | Notes |
+|------|-----------|-------|
+| session-start | yes | Context injected via `model_instructions_file` |
+| user-prompt-submit | no | Codex has no mid-session hook support |
+| pre-compaction | no | Codex has no mid-session hook support |
+| session-end | yes | Transcript path passed to daemon for memory extraction |
+
+### Memory commands
+
+Codex does not support MCP, so the Signet MCP tools are unavailable.
+Instead, the agent can use CLI commands via shell:
+
+```bash
+signet remember "context to save"
+signet recall "query"
+```
+
+These are documented in the generated CODEX.md file.
 
 ### Extraction provider
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6121,6 +6121,44 @@ hookCmd
 		}
 	});
 
+// signet hook codex-watch-start — register Codex session for live recall
+hookCmd
+	.command("codex-watch-start")
+	.description("Start live recall watcher for a Codex session")
+	.requiredOption("-H, --harness <harness>", "Harness name")
+	.action(async () => {
+		let body: Record<string, string> = {};
+		try {
+			const chunks: Buffer[] = [];
+			for await (const chunk of process.stdin) {
+				chunks.push(chunk);
+			}
+			const input = Buffer.concat(chunks).toString("utf-8").trim();
+			if (input) {
+				body = JSON.parse(input);
+			}
+		} catch {
+			// No stdin or invalid JSON
+		}
+
+		const data = await fetchFromDaemon<{
+			success?: boolean;
+			error?: string;
+		}>("/api/hooks/codex-watch-start", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				sessionKey: body.sessionKey || body.session_key,
+				project: body.project || body.cwd,
+			}),
+		});
+
+		if (!data) {
+			// Daemon not running — fail silently (fire-and-forget from wrapper)
+			process.exit(0);
+		}
+	});
+
 // signet hook pre-compaction
 hookCmd
 	.command("pre-compaction")

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6125,7 +6125,7 @@ hookCmd
 hookCmd
 	.command("codex-watch-start")
 	.description("Start live recall watcher for a Codex session")
-	.requiredOption("-H, --harness <harness>", "Harness name")
+	.option("-H, --harness <harness>", "Harness name")
 	.action(async () => {
 		let body: Record<string, string> = {};
 		try {

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -1,18 +1,8 @@
 import { spawnSync } from "node:child_process";
-import {
-	existsSync,
-	mkdirSync,
-	readFileSync,
-	rmSync,
-	writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import {
-	BaseConnector,
-	type InstallResult,
-	type UninstallResult,
-} from "@signet/connector-base";
+import { BaseConnector, type InstallResult, type UninstallResult } from "@signet/connector-base";
 
 const SHELL_BLOCK_START = "# >>> signet codex >>>";
 const SHELL_BLOCK_END = "# <<< signet codex <<<";
@@ -26,6 +16,8 @@ fi
 ${SHELL_BLOCK_END}
 `;
 
+const TOML_COMMENT = "# Added by Signet — points to generated identity file";
+
 function stripBlock(content: string): string {
 	const start = content.indexOf(SHELL_BLOCK_START);
 	if (start < 0) return content;
@@ -33,7 +25,7 @@ function stripBlock(content: string): string {
 	if (end < 0) return content;
 	const after = content.slice(end + SHELL_BLOCK_END.length);
 	const before = content.slice(0, start).trimEnd();
-	return `${before}${before ? "\n\n" : ""}${after.trimStart()}`.trimEnd() + "\n";
+	return `${`${before}${before ? "\n\n" : ""}${after.trimStart()}`.trimEnd()}\n`;
 }
 
 function appendBlock(content: string): string {
@@ -73,13 +65,24 @@ session_start() {
 	: > "$START_MARKER"
 	SESSION_KEY="$(uuidgen 2>/dev/null || printf "codex-%s-%s" "$(date +%s)" "$$")"
 
+	# Start with persistent identity context if available
+	CODEX_MD="\${HOME}/.codex/CODEX.md"
+	if [ -f "$CODEX_MD" ]; then
+		cp "$CODEX_MD" "$INSTRUCTIONS_FILE"
+		printf '\\n\\n---\\n\\n' >> "$INSTRUCTIONS_FILE"
+	fi
+
+	# Append dynamic session context (live memories, recall results)
+	DYNAMIC="$TMP_ROOT/dynamic.md"
 	payload="$(printf '{"session_id":"%s","cwd":"%s"}' "$(json_escape "$SESSION_KEY")" "$(json_escape "$PWD")")"
-	if printf "%s" "$payload" | "$SIGNET_BIN" hook session-start -H codex --project "$PWD" > "$INSTRUCTIONS_FILE" 2>/dev/null; then
-		if [ ! -s "$INSTRUCTIONS_FILE" ]; then
-			rm -f "$INSTRUCTIONS_FILE"
-			INSTRUCTIONS_FILE=""
+	if printf "%s" "$payload" | "$SIGNET_BIN" hook session-start -H codex --project "$PWD" > "$DYNAMIC" 2>/dev/null; then
+		if [ -s "$DYNAMIC" ]; then
+			cat "$DYNAMIC" >> "$INSTRUCTIONS_FILE"
 		fi
-	else
+	fi
+
+	# If nothing was written at all, clear
+	if [ ! -s "$INSTRUCTIONS_FILE" ]; then
 		rm -f "$INSTRUCTIONS_FILE"
 		INSTRUCTIONS_FILE=""
 	fi
@@ -172,16 +175,27 @@ set "TMP_ROOT=%TEMP%\\signet-codex-%RANDOM%"
 mkdir "%TMP_ROOT%" >nul 2>&1
 set "INSTRUCTIONS_FILE=%TMP_ROOT%\\model-instructions.md"
 
-REM Session-start hook: build JSON via ConvertTo-Json for safe escaping of paths containing ", &, |, %
+REM Start with persistent identity context if available
+set "CODEX_MD=%USERPROFILE%\\.codex\\CODEX.md"
+if exist "%CODEX_MD%" (
+	copy /y "%CODEX_MD%" "%INSTRUCTIONS_FILE%" >nul 2>&1
+	echo. >> "%INSTRUCTIONS_FILE%"
+	echo --- >> "%INSTRUCTIONS_FILE%"
+	echo. >> "%INSTRUCTIONS_FILE%"
+)
+
+REM Session-start hook: append dynamic context
+set "DYNAMIC=%TMP_ROOT%\\dynamic.md"
 set "HOOK_OK=0"
 for /f "delims=" %%j in ('powershell ${psFlags} -Command "ConvertTo-Json @{session_id=$env:SESSION_KEY;cwd=$PWD.Path} -Compress"') do (
-	echo %%j| "%SIGNET_BIN%" hook session-start -H codex --project "%CD%" > "%INSTRUCTIONS_FILE%" 2>nul && set "HOOK_OK=1"
+	echo %%j| "%SIGNET_BIN%" hook session-start -H codex --project "%CD%" > "%DYNAMIC%" 2>nul && set "HOOK_OK=1"
 )
-if "%HOOK_OK%"=="0" (
-	set "INSTRUCTIONS_FILE="
-) else (
-	for %%A in ("%INSTRUCTIONS_FILE%") do if %%~zA==0 set "INSTRUCTIONS_FILE="
+if "%HOOK_OK%"=="1" (
+	for %%A in ("%DYNAMIC%") do if not %%~zA==0 type "%DYNAMIC%" >> "%INSTRUCTIONS_FILE%"
 )
+
+REM If nothing was written, clear instructions file
+for %%A in ("%INSTRUCTIONS_FILE%") do if %%~zA==0 set "INSTRUCTIONS_FILE="
 
 if defined INSTRUCTIONS_FILE (
 	"%REAL_CODEX_BIN%" -c "model_instructions_file=%INSTRUCTIONS_FILE%" %*
@@ -220,6 +234,10 @@ export class CodexConnector extends BaseConnector {
 		return join(homedir(), ".codex");
 	}
 
+	private getCodexMdPath(): string {
+		return join(this.getCodexHome(), "CODEX.md");
+	}
+
 	private getWrapperDir(): string {
 		return join(homedir(), ".config", "signet", "bin");
 	}
@@ -231,11 +249,7 @@ export class CodexConnector extends BaseConnector {
 
 	private getShellConfigPaths(): string[] {
 		if (process.platform === "win32") return [];
-		return [
-			join(homedir(), ".zshrc"),
-			join(homedir(), ".bashrc"),
-			join(homedir(), ".bash_profile"),
-		];
+		return [join(homedir(), ".zshrc"), join(homedir(), ".bashrc"), join(homedir(), ".bash_profile")];
 	}
 
 	getConfigPath(): string {
@@ -263,26 +277,156 @@ export class CodexConnector extends BaseConnector {
 		return null;
 	}
 
+	/**
+	 * Generate ~/.codex/CODEX.md from identity files.
+	 *
+	 * Follows the same pattern as the OpenCode connector's generateAgentsMd():
+	 * header + Signet block + user AGENTS.md content + identity extras.
+	 * Also includes CLI memory commands since Codex has no MCP support.
+	 */
+	private generateCodexMd(basePath: string): string | null {
+		const source = join(basePath, "AGENTS.md");
+		if (!existsSync(source)) return null;
+
+		const raw = readFileSync(source, "utf-8");
+		const content = this.stripSignetBlock(raw);
+		const header = this.generateHeader(source);
+		const block = this.buildSignetBlock();
+		const extras = this.composeIdentityExtras(basePath);
+
+		// Codex has no MCP — include CLI memory commands
+		const cliHint = `
+## Memory Commands (CLI)
+
+Codex does not support MCP tools. Use these shell commands instead:
+
+\`\`\`bash
+signet remember "context to save"
+signet recall "query"
+\`\`\`
+`;
+
+		const codexMd = join(this.getCodexHome(), "CODEX.md");
+		mkdirSync(this.getCodexHome(), { recursive: true });
+		writeFileSync(codexMd, header + block + content + extras + cliHint);
+		return codexMd;
+	}
+
+	/**
+	 * Patch ~/.codex/config.toml to set model_instructions_file.
+	 *
+	 * Safe behavior:
+	 * - If absent: append the key pointing to CODEX.md
+	 * - If already points to CODEX.md: no-op
+	 * - If points elsewhere: skip and return a warning
+	 */
+	private patchConfigToml(): { patched: boolean; warning?: string } {
+		const toml = this.getConfigPath();
+		const codexMd = this.getCodexMdPath();
+
+		mkdirSync(this.getCodexHome(), { recursive: true });
+
+		const existing = existsSync(toml) ? readFileSync(toml, "utf-8") : "";
+		const lines = existing.split("\n");
+
+		// Find existing model_instructions_file (only at top level, before any [section])
+		let found = false;
+		let alreadyCorrect = false;
+		let userOwned = false;
+
+		for (const line of lines) {
+			const trimmed = line.trim();
+			// Stop scanning at first section header
+			if (trimmed.startsWith("[")) break;
+			const match = trimmed.match(/^model_instructions_file\s*=\s*"?([^"]*)"?$/);
+			if (match) {
+				found = true;
+				const val = match[1].trim();
+				if (val === codexMd) {
+					alreadyCorrect = true;
+				} else {
+					userOwned = true;
+				}
+				break;
+			}
+		}
+
+		if (alreadyCorrect) return { patched: false };
+
+		if (userOwned) {
+			return {
+				patched: false,
+				warning: `config.toml already has model_instructions_file set to a custom value. Skipped patching — set it to "${codexMd}" manually to use Signet context.`,
+			};
+		}
+
+		if (!found) {
+			// Append at the top (before first section or at end if no sections)
+			let insertIdx = 0;
+			for (let i = 0; i < lines.length; i++) {
+				if (lines[i].trim().startsWith("[")) {
+					insertIdx = i;
+					break;
+				}
+				insertIdx = i + 1;
+			}
+
+			const entry = `${TOML_COMMENT}\nmodel_instructions_file = "${codexMd}"`;
+			lines.splice(insertIdx, 0, entry);
+			writeFileSync(toml, lines.join("\n"));
+			return { patched: true };
+		}
+
+		return { patched: false };
+	}
+
+	/**
+	 * Remove model_instructions_file line from config.toml if it points to CODEX.md.
+	 */
+	private unpatchConfigToml(): boolean {
+		const toml = this.getConfigPath();
+		if (!existsSync(toml)) return false;
+
+		const codexMd = this.getCodexMdPath();
+		const content = readFileSync(toml, "utf-8");
+		const lines = content.split("\n");
+		const filtered = lines.filter((line) => {
+			const trimmed = line.trim();
+			if (trimmed === TOML_COMMENT) return false;
+			const match = trimmed.match(/^model_instructions_file\s*=\s*"?([^"]*)"?$/);
+			if (match && match[1].trim() === codexMd) return false;
+			return true;
+		});
+
+		if (filtered.length === lines.length) return false;
+
+		writeFileSync(toml, filtered.join("\n"));
+		return true;
+	}
+
 	async install(basePath: string): Promise<InstallResult> {
 		const filesWritten: string[] = [];
 		const configsPatched: string[] = [];
+		const warnings: string[] = [];
 		const isWindows = process.platform === "win32";
+		const expanded = basePath.startsWith("~") ? join(homedir(), basePath.slice(1)) : basePath;
 
+		// 1. Resolve real Codex binary
 		const realCodexBin = this.resolveRealCodexBin();
 		if (!realCodexBin) {
 			throw new Error("Could not find Codex CLI on PATH");
 		}
 
+		// 2. Write shell wrapper
 		const wrapperDir = this.getWrapperDir();
 		mkdirSync(wrapperDir, { recursive: true });
 
 		const wrapperPath = this.getWrapperPath();
-		const wrapperContent = isWindows
-			? buildWindowsWrapper(realCodexBin)
-			: buildWrapper(realCodexBin);
+		const wrapperContent = isWindows ? buildWindowsWrapper(realCodexBin) : buildWrapper(realCodexBin);
 		writeFileSync(wrapperPath, wrapperContent, isWindows ? {} : { mode: 0o755 });
 		filesWritten.push(wrapperPath);
 
+		// 3. Patch shell configs with PATH block
 		for (const shellPath of this.getShellConfigPaths()) {
 			const existing = existsSync(shellPath) ? readFileSync(shellPath, "utf-8") : "";
 			const next = appendBlock(existing);
@@ -292,11 +436,32 @@ export class CodexConnector extends BaseConnector {
 			}
 		}
 
+		// 4. Generate CODEX.md identity file
+		const codexMd = this.generateCodexMd(expanded);
+		if (codexMd) {
+			filesWritten.push(codexMd);
+		}
+
+		// 5. Symlink skills directory
+		const sourceSkills = join(expanded, "skills");
+		const targetSkills = join(this.getCodexHome(), "skills");
+		this.symlinkSkills(sourceSkills, targetSkills);
+
+		// 6. Patch config.toml with model_instructions_file
+		const toml = this.patchConfigToml();
+		if (toml.patched) {
+			configsPatched.push(this.getConfigPath());
+		}
+		if (toml.warning) {
+			warnings.push(toml.warning);
+		}
+
 		return {
 			success: true,
 			message: "Codex integration installed successfully",
 			filesWritten,
 			configsPatched,
+			warnings: warnings.length > 0 ? warnings : undefined,
 		};
 	}
 
@@ -304,12 +469,14 @@ export class CodexConnector extends BaseConnector {
 		const filesRemoved: string[] = [];
 		const configsPatched: string[] = [];
 
+		// Remove wrapper
 		const wrapperPath = this.getWrapperPath();
 		if (existsSync(wrapperPath)) {
 			rmSync(wrapperPath, { force: true });
 			filesRemoved.push(wrapperPath);
 		}
 
+		// Remove shell PATH blocks
 		for (const shellPath of this.getShellConfigPaths()) {
 			if (!existsSync(shellPath)) continue;
 			const existing = readFileSync(shellPath, "utf-8");
@@ -318,6 +485,18 @@ export class CodexConnector extends BaseConnector {
 				writeFileSync(shellPath, next);
 				configsPatched.push(shellPath);
 			}
+		}
+
+		// Remove CODEX.md
+		const codexMd = this.getCodexMdPath();
+		if (existsSync(codexMd)) {
+			rmSync(codexMd, { force: true });
+			filesRemoved.push(codexMd);
+		}
+
+		// Unpatch config.toml
+		if (this.unpatchConfigToml()) {
+			configsPatched.push(this.getConfigPath());
 		}
 
 		return { filesRemoved, configsPatched };

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -81,10 +81,14 @@ session_start() {
 		fi
 	fi
 
-	# Append live recall instruction for interactive sessions
-	if [ -n "$INSTRUCTIONS_FILE" ] || [ -f "$CODEX_MD" ]; then
-		# Ensure file exists even if previous steps wrote nothing
-		: >> "$INSTRUCTIONS_FILE"
+	# If nothing was written at all, clear
+	if [ ! -s "$INSTRUCTIONS_FILE" ]; then
+		rm -f "$INSTRUCTIONS_FILE"
+		INSTRUCTIONS_FILE=""
+	fi
+
+	# Append live recall instruction only when there is real content
+	if [ -n "$INSTRUCTIONS_FILE" ] && [ -s "$INSTRUCTIONS_FILE" ]; then
 		cat >> "$INSTRUCTIONS_FILE" << 'LIVE_RECALL'
 
 ## Live Memory (Auto-Updated by Signet)
@@ -96,12 +100,6 @@ updated after each user message. If the file exists and has content,
 incorporate any relevant memories into your response. The file includes
 a timestamp — ignore it if older than 60 seconds.
 LIVE_RECALL
-	fi
-
-	# If nothing was written at all, clear
-	if [ ! -s "$INSTRUCTIONS_FILE" ]; then
-		rm -f "$INSTRUCTIONS_FILE"
-		INSTRUCTIONS_FILE=""
 	fi
 }
 
@@ -205,7 +203,9 @@ set "CODEX_MD=%USERPROFILE%\\.codex\\CODEX.md"
 if exist "%CODEX_MD%" (
 	copy /y "%CODEX_MD%" "%INSTRUCTIONS_FILE%" >nul 2>&1
 	echo. >> "%INSTRUCTIONS_FILE%"
+	echo. >> "%INSTRUCTIONS_FILE%"
 	echo --- >> "%INSTRUCTIONS_FILE%"
+	echo. >> "%INSTRUCTIONS_FILE%"
 	echo. >> "%INSTRUCTIONS_FILE%"
 )
 
@@ -378,7 +378,9 @@ signet recall "query"
 			const trimmed = line.trim();
 			// Stop scanning at first section header
 			if (trimmed.startsWith("[")) break;
-			const match = trimmed.match(/^model_instructions_file\s*=\s*"?([^"]*)"?$/);
+			// Strip inline comments before matching (TOML allows `key = "val" # comment`)
+			const stripped = trimmed.replace(/\s*#.*$/, "").trim();
+			const match = stripped.match(/^model_instructions_file\s*=\s*"?([^"]*?)"?$/);
 			if (match) {
 				found = true;
 				const val = match[1].trim();
@@ -417,6 +419,7 @@ signet recall "query"
 			return { patched: true };
 		}
 
+		// All branches (alreadyCorrect, userOwned, !found) return above
 		return { patched: false };
 	}
 
@@ -433,7 +436,9 @@ signet recall "query"
 		const filtered = lines.filter((line) => {
 			const trimmed = line.trim();
 			if (trimmed === TOML_COMMENT) return false;
-			const match = trimmed.match(/^model_instructions_file\s*=\s*"?([^"]*)"?$/);
+			// Strip inline comments before matching (TOML allows trailing `# comment`)
+			const stripped = trimmed.replace(/\s*#.*$/, "").trim();
+			const match = stripped.match(/^model_instructions_file\s*=\s*"?([^"]*?)"?$/);
 			if (match && match[1].trim() === codexMd) return false;
 			return true;
 		});
@@ -485,7 +490,11 @@ signet recall "query"
 		// 5. Symlink skills directory
 		const sourceSkills = join(expanded, "skills");
 		const targetSkills = join(this.getCodexHome(), "skills");
-		this.symlinkSkills(sourceSkills, targetSkills);
+		const symlink = this.symlinkSkills(sourceSkills, targetSkills);
+		if (symlink.errors.length > 0) {
+			const msgs = symlink.errors.map((e) => `${e.path}: ${e.error}`);
+			warnings.push(`Skills symlink failed: ${msgs.join("; ")}`);
+		}
 
 		// 6. Patch config.toml with model_instructions_file
 		const toml = this.patchConfigToml();

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -219,7 +219,10 @@ if "%HOOK_OK%"=="1" (
 	for %%A in ("%DYNAMIC%") do if not %%~zA==0 type "%DYNAMIC%" >> "%INSTRUCTIONS_FILE%"
 )
 
-REM Append live recall instruction
+REM If nothing was written, clear instructions file
+for %%A in ("%INSTRUCTIONS_FILE%") do if %%~zA==0 set "INSTRUCTIONS_FILE="
+
+REM Append live recall instruction only when there is real content
 if defined INSTRUCTIONS_FILE (
 	echo. >> "%INSTRUCTIONS_FILE%"
 	echo ## Live Memory ^(Auto-Updated by Signet^) >> "%INSTRUCTIONS_FILE%"
@@ -228,9 +231,6 @@ if defined INSTRUCTIONS_FILE (
 	echo ~/.codex/.signet-live-context.md for memories relevant to the current >> "%INSTRUCTIONS_FILE%"
 	echo conversation. Incorporate relevant memories into your response. >> "%INSTRUCTIONS_FILE%"
 )
-
-REM If nothing was written, clear instructions file
-for %%A in ("%INSTRUCTIONS_FILE%") do if %%~zA==0 set "INSTRUCTIONS_FILE="
 
 REM Register for live recall watching (interactive mode only)
 if not "%1"=="exec" (

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -81,6 +81,23 @@ session_start() {
 		fi
 	fi
 
+	# Append live recall instruction for interactive sessions
+	if [ -n "$INSTRUCTIONS_FILE" ] || [ -f "$CODEX_MD" ]; then
+		# Ensure file exists even if previous steps wrote nothing
+		: >> "$INSTRUCTIONS_FILE"
+		cat >> "$INSTRUCTIONS_FILE" << 'LIVE_RECALL'
+
+## Live Memory (Auto-Updated by Signet)
+
+IMPORTANT: Before responding to each user message, read the file at
+~/.codex/.signet-live-context.md — it contains memories recalled by
+Signet that are relevant to the current conversation. This file is
+updated after each user message. If the file exists and has content,
+incorporate any relevant memories into your response. The file includes
+a timestamp — ignore it if older than 60 seconds.
+LIVE_RECALL
+	fi
+
 	# If nothing was written at all, clear
 	if [ ! -s "$INSTRUCTIONS_FILE" ]; then
 		rm -f "$INSTRUCTIONS_FILE"
@@ -118,6 +135,14 @@ fi
 trap 'cleanup' EXIT
 
 session_start
+
+# Register for live recall watching (interactive mode only, not codex exec)
+case "\${1:-}" in
+	exec) ;;
+	*)
+		printf '{"sessionKey":"%s","project":"%s"}' "$(json_escape "$SESSION_KEY")" "$(json_escape "$PWD")" | "$SIGNET_BIN" hook codex-watch-start -H codex >/dev/null 2>&1 &
+		;;
+esac
 
 set +e
 if [ -n "$INSTRUCTIONS_FILE" ]; then
@@ -194,8 +219,23 @@ if "%HOOK_OK%"=="1" (
 	for %%A in ("%DYNAMIC%") do if not %%~zA==0 type "%DYNAMIC%" >> "%INSTRUCTIONS_FILE%"
 )
 
+REM Append live recall instruction
+if defined INSTRUCTIONS_FILE (
+	echo. >> "%INSTRUCTIONS_FILE%"
+	echo ## Live Memory ^(Auto-Updated by Signet^) >> "%INSTRUCTIONS_FILE%"
+	echo. >> "%INSTRUCTIONS_FILE%"
+	echo IMPORTANT: Before responding to each user message, read the file at >> "%INSTRUCTIONS_FILE%"
+	echo ~/.codex/.signet-live-context.md for memories relevant to the current >> "%INSTRUCTIONS_FILE%"
+	echo conversation. Incorporate relevant memories into your response. >> "%INSTRUCTIONS_FILE%"
+)
+
 REM If nothing was written, clear instructions file
 for %%A in ("%INSTRUCTIONS_FILE%") do if %%~zA==0 set "INSTRUCTIONS_FILE="
+
+REM Register for live recall watching (interactive mode only)
+if not "%1"=="exec" (
+	powershell ${psFlags} -Command "ConvertTo-Json @{sessionKey=$env:SESSION_KEY;project=$PWD.Path} -Compress | & $env:SIGNET_BIN hook codex-watch-start -H codex" >nul 2>&1
+)
 
 if defined INSTRUCTIONS_FILE (
 	"%REAL_CODEX_BIN%" -c "model_instructions_file=%INSTRUCTIONS_FILE%" %*

--- a/packages/daemon/src/codex-transcript-watcher.ts
+++ b/packages/daemon/src/codex-transcript-watcher.ts
@@ -12,16 +12,7 @@
  *   extract user message → hybrid recall → atomic write to live file
  */
 
-import {
-	existsSync,
-	mkdirSync,
-	readFileSync,
-	readdirSync,
-	renameSync,
-	statSync,
-	unlinkSync,
-	writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { type FSWatcher, watch } from "chokidar";
@@ -35,15 +26,11 @@ import { logger } from "./logger";
 export interface CodexLiveRecallConfig {
 	readonly enabled: boolean;
 	readonly debounceMs: number;
-	readonly maxResults: number;
-	readonly charBudget: number;
 }
 
 const DEFAULTS: CodexLiveRecallConfig = {
 	enabled: true,
 	debounceMs: 300,
-	maxResults: 5,
-	charBudget: 800,
 };
 
 export function resolveConfig(raw?: Partial<CodexLiveRecallConfig>): CodexLiveRecallConfig {
@@ -51,8 +38,6 @@ export function resolveConfig(raw?: Partial<CodexLiveRecallConfig>): CodexLiveRe
 	return {
 		enabled: typeof raw.enabled === "boolean" ? raw.enabled : DEFAULTS.enabled,
 		debounceMs: typeof raw.debounceMs === "number" && raw.debounceMs > 0 ? raw.debounceMs : DEFAULTS.debounceMs,
-		maxResults: typeof raw.maxResults === "number" && raw.maxResults > 0 ? raw.maxResults : DEFAULTS.maxResults,
-		charBudget: typeof raw.charBudget === "number" && raw.charBudget > 0 ? raw.charBudget : DEFAULTS.charBudget,
 	};
 }
 
@@ -178,11 +163,7 @@ function writeLiveContext(memories: string, sessionKey: string): void {
 // Memory recall
 // ---------------------------------------------------------------------------
 
-async function recallForMessage(
-	message: string,
-	session: TrackedSession,
-	config: CodexLiveRecallConfig,
-): Promise<void> {
+async function recallForMessage(message: string, session: TrackedSession): Promise<void> {
 	// Dedup: skip if same message hash
 	const hash = simpleHash(message);
 	if (hash === session.lastUserHash) return;
@@ -227,39 +208,20 @@ function simpleHash(s: string): string {
 // ---------------------------------------------------------------------------
 
 /**
- * Find the newest JSONL file in the sessions directory that was created
- * after the session was registered.
+ * Try to associate a newly appeared JSONL file with an unbound session.
+ * Uses chokidar's `add` event rather than date-path inference, avoiding
+ * the midnight rollover bug where date directories change between
+ * session registration and transcript creation.
  */
-function discoverTranscript(session: TrackedSession): string | null {
-	if (session.transcriptPath && existsSync(session.transcriptPath)) {
-		return session.transcriptPath;
+function tryBindTranscript(path: string): TrackedSession | null {
+	// Find the most recently registered session without a transcript
+	for (const [, s] of sessions) {
+		if (!s.transcriptPath) {
+			s.transcriptPath = path;
+			return s;
+		}
 	}
-
-	const dir = sessionsDir();
-	if (!existsSync(dir)) return null;
-
-	// Walk the date-based directory structure to find the newest file
-	try {
-		const now = new Date();
-		const year = now.getFullYear().toString();
-		const month = String(now.getMonth() + 1).padStart(2, "0");
-		const day = String(now.getDate()).padStart(2, "0");
-		const todayDir = join(dir, year, month, day);
-
-		if (!existsSync(todayDir)) return null;
-
-		const files = readdirSync(todayDir)
-			.filter((f: string) => f.endsWith(".jsonl"))
-			.sort()
-			.reverse();
-
-		if (files.length === 0) return null;
-
-		// Return the newest file
-		return join(todayDir, files[0]);
-	} catch {
-		return null;
-	}
+	return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -281,17 +243,8 @@ function handleTranscriptChange(path: string): void {
 	}
 
 	if (!session) {
-		// Try to match by discovery (new file appeared)
-		for (const [, s] of sessions) {
-			if (!s.transcriptPath) {
-				const discovered = discoverTranscript(s);
-				if (discovered === path) {
-					s.transcriptPath = path;
-					session = s;
-					break;
-				}
-			}
-		}
+		// New file appeared — try to bind it to an unbound session
+		session = tryBindTranscript(path);
 	}
 
 	if (!session) return;
@@ -320,7 +273,7 @@ async function processTranscriptUpdate(path: string, session: TrackedSession): P
 
 	// Process the latest user message only (most relevant for recall)
 	const latest = messages[messages.length - 1];
-	await recallForMessage(latest, session, activeConfig);
+	await recallForMessage(latest, session);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/codex-transcript-watcher.ts
+++ b/packages/daemon/src/codex-transcript-watcher.ts
@@ -89,17 +89,17 @@ function extractNewUserMessages(path: string, session: TrackedSession): string[]
 
 	if (size <= session.lastOffset) return [];
 
-	let content: string;
+	let buf: Buffer;
 	try {
-		// Read full file and slice from last offset. The transcript is
-		// append-only so previously parsed bytes never change.
-		content = readFileSync(path, "utf-8");
+		// Read full file as buffer so offset tracking uses bytes (matching
+		// statSync.size) rather than UTF-16 code units from string.length.
+		buf = readFileSync(path);
 	} catch {
 		return [];
 	}
 
-	const chunk = content.slice(session.lastOffset);
-	session.lastOffset = content.length;
+	const chunk = buf.subarray(session.lastOffset).toString("utf-8");
+	session.lastOffset = buf.length;
 
 	const messages: string[] = [];
 	for (const line of chunk.split(/\r?\n/)) {
@@ -212,16 +212,33 @@ function simpleHash(s: string): string {
  * Uses chokidar's `add` event rather than date-path inference, avoiding
  * the midnight rollover bug where date directories change between
  * session registration and transcript creation.
+ *
+ * When multiple unbound sessions exist (rare — parallel interactive Codex
+ * windows), binds to the most recently registered one and logs a warning.
  */
 function tryBindTranscript(path: string): TrackedSession | null {
-	// Find the most recently registered session without a transcript
+	// Collect all unbound sessions (Map preserves insertion order)
+	let candidate: TrackedSession | null = null;
+	let unboundCount = 0;
 	for (const [, s] of sessions) {
 		if (!s.transcriptPath) {
-			s.transcriptPath = path;
-			return s;
+			candidate = s;
+			unboundCount++;
 		}
 	}
-	return null;
+
+	if (!candidate) return null;
+
+	if (unboundCount > 1) {
+		logger.warn("codex-watcher", "Multiple unbound sessions at bind time", {
+			unboundCount,
+			boundTo: candidate.sessionKey,
+			path,
+		});
+	}
+
+	candidate.transcriptPath = path;
+	return candidate;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/codex-transcript-watcher.ts
+++ b/packages/daemon/src/codex-transcript-watcher.ts
@@ -1,0 +1,453 @@
+/**
+ * Codex Transcript Watcher
+ *
+ * Watches Codex session transcript files in real-time and maintains a
+ * live context file (~/.codex/.signet-live-context.md) with relevant
+ * memories for the current conversation. Codex sessions are instructed
+ * to read this file before each response, providing best-effort
+ * per-prompt memory recall despite Codex having no native hook system.
+ *
+ * Architecture:
+ *   Codex writes JSONL → chokidar detects change → incremental parse →
+ *   extract user message → hybrid recall → atomic write to live file
+ */
+
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	readdirSync,
+	renameSync,
+	statSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { type FSWatcher, watch } from "chokidar";
+import { type UserPromptSubmitRequest, handleUserPromptSubmit } from "./hooks";
+import { logger } from "./logger";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export interface CodexLiveRecallConfig {
+	readonly enabled: boolean;
+	readonly debounceMs: number;
+	readonly maxResults: number;
+	readonly charBudget: number;
+}
+
+const DEFAULTS: CodexLiveRecallConfig = {
+	enabled: true,
+	debounceMs: 300,
+	maxResults: 5,
+	charBudget: 800,
+};
+
+export function resolveConfig(raw?: Partial<CodexLiveRecallConfig>): CodexLiveRecallConfig {
+	if (!raw) return DEFAULTS;
+	return {
+		enabled: typeof raw.enabled === "boolean" ? raw.enabled : DEFAULTS.enabled,
+		debounceMs: typeof raw.debounceMs === "number" && raw.debounceMs > 0 ? raw.debounceMs : DEFAULTS.debounceMs,
+		maxResults: typeof raw.maxResults === "number" && raw.maxResults > 0 ? raw.maxResults : DEFAULTS.maxResults,
+		charBudget: typeof raw.charBudget === "number" && raw.charBudget > 0 ? raw.charBudget : DEFAULTS.charBudget,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tracked session state
+// ---------------------------------------------------------------------------
+
+interface TrackedSession {
+	readonly sessionKey: string;
+	readonly project: string;
+	transcriptPath: string | null;
+	lastOffset: number;
+	lastUserHash: string;
+}
+
+const sessions = new Map<string, TrackedSession>();
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+function codexHome(): string {
+	return join(homedir(), ".codex");
+}
+
+function sessionsDir(): string {
+	return join(codexHome(), "sessions");
+}
+
+function liveContextPath(): string {
+	return join(codexHome(), ".signet-live-context.md");
+}
+
+// ---------------------------------------------------------------------------
+// JSONL parsing (incremental)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read new bytes appended to a JSONL file since the last offset,
+ * extract user messages, and return them.
+ */
+function extractNewUserMessages(path: string, session: TrackedSession): string[] {
+	let size: number;
+	try {
+		size = statSync(path).size;
+	} catch {
+		return [];
+	}
+
+	if (size <= session.lastOffset) return [];
+
+	let content: string;
+	try {
+		// Read full file and slice from last offset. The transcript is
+		// append-only so previously parsed bytes never change.
+		content = readFileSync(path, "utf-8");
+	} catch {
+		return [];
+	}
+
+	const chunk = content.slice(session.lastOffset);
+	session.lastOffset = content.length;
+
+	const messages: string[] = [];
+	for (const line of chunk.split(/\r?\n/)) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(trimmed);
+		} catch {
+			continue;
+		}
+
+		if (typeof parsed !== "object" || parsed === null) continue;
+		const event = parsed as Record<string, unknown>;
+
+		if (event.type !== "event_msg") continue;
+
+		const payload = event.payload;
+		if (typeof payload !== "object" || payload === null) continue;
+		const msg = payload as Record<string, unknown>;
+
+		if (msg.type === "user_message" && typeof msg.message === "string") {
+			const text = msg.message.trim();
+			if (text.length > 0) messages.push(text);
+		}
+	}
+
+	return messages;
+}
+
+// ---------------------------------------------------------------------------
+// Live context file writing (atomic)
+// ---------------------------------------------------------------------------
+
+function writeLiveContext(memories: string, sessionKey: string): void {
+	const dest = liveContextPath();
+	const tmp = `${dest}.tmp.${process.pid}`;
+	const timestamp = new Date().toISOString();
+
+	const content = `<!-- signet:live-context updated=${timestamp} session=${sessionKey} -->\n# Relevant Memories\n\n${memories}\n`;
+
+	try {
+		mkdirSync(dirname(dest), { recursive: true });
+		writeFileSync(tmp, content);
+		renameSync(tmp, dest);
+	} catch (e) {
+		logger.warn("codex-watcher", "Failed to write live context", {
+			error: e instanceof Error ? e.message : String(e),
+		});
+		// Clean up temp file on failure
+		try {
+			unlinkSync(tmp);
+		} catch {
+			// ignore
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Memory recall
+// ---------------------------------------------------------------------------
+
+async function recallForMessage(
+	message: string,
+	session: TrackedSession,
+	config: CodexLiveRecallConfig,
+): Promise<void> {
+	// Dedup: skip if same message hash
+	const hash = simpleHash(message);
+	if (hash === session.lastUserHash) return;
+	session.lastUserHash = hash;
+
+	const req: UserPromptSubmitRequest = {
+		harness: "codex",
+		project: session.project,
+		userMessage: message,
+		sessionKey: session.sessionKey,
+	};
+
+	try {
+		const result = await handleUserPromptSubmit(req);
+		if (result.memoryCount > 0) {
+			// Strip metadata header (date/time) — only keep memory lines
+			const lines = result.inject.split("\n");
+			const memoryLines = lines.filter((l) => l.startsWith("- ") || l.startsWith("[signet:recall"));
+			if (memoryLines.length > 0) {
+				writeLiveContext(memoryLines.join("\n"), session.sessionKey);
+			}
+		}
+	} catch (e) {
+		// Fail-open: log and continue
+		logger.warn("codex-watcher", "Recall failed for message", {
+			error: e instanceof Error ? e.message : String(e),
+			sessionKey: session.sessionKey,
+		});
+	}
+}
+
+function simpleHash(s: string): string {
+	let h = 0;
+	for (let i = 0; i < s.length; i++) {
+		h = ((h << 5) - h + s.charCodeAt(i)) | 0;
+	}
+	return h.toString(36);
+}
+
+// ---------------------------------------------------------------------------
+// Transcript file discovery
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the newest JSONL file in the sessions directory that was created
+ * after the session was registered.
+ */
+function discoverTranscript(session: TrackedSession): string | null {
+	if (session.transcriptPath && existsSync(session.transcriptPath)) {
+		return session.transcriptPath;
+	}
+
+	const dir = sessionsDir();
+	if (!existsSync(dir)) return null;
+
+	// Walk the date-based directory structure to find the newest file
+	try {
+		const now = new Date();
+		const year = now.getFullYear().toString();
+		const month = String(now.getMonth() + 1).padStart(2, "0");
+		const day = String(now.getDate()).padStart(2, "0");
+		const todayDir = join(dir, year, month, day);
+
+		if (!existsSync(todayDir)) return null;
+
+		const files = readdirSync(todayDir)
+			.filter((f: string) => f.endsWith(".jsonl"))
+			.sort()
+			.reverse();
+
+		if (files.length === 0) return null;
+
+		// Return the newest file
+		return join(todayDir, files[0]);
+	} catch {
+		return null;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Watcher lifecycle
+// ---------------------------------------------------------------------------
+
+let fsWatcher: FSWatcher | null = null;
+let activeConfig: CodexLiveRecallConfig = DEFAULTS;
+const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+function handleTranscriptChange(path: string): void {
+	// Find which session this transcript belongs to
+	let session: TrackedSession | null = null;
+	for (const [, s] of sessions) {
+		if (s.transcriptPath === path) {
+			session = s;
+			break;
+		}
+	}
+
+	if (!session) {
+		// Try to match by discovery (new file appeared)
+		for (const [, s] of sessions) {
+			if (!s.transcriptPath) {
+				const discovered = discoverTranscript(s);
+				if (discovered === path) {
+					s.transcriptPath = path;
+					session = s;
+					break;
+				}
+			}
+		}
+	}
+
+	if (!session) return;
+
+	// Debounce per-file
+	const existing = debounceTimers.get(path);
+	if (existing) clearTimeout(existing);
+
+	const captured = session;
+	debounceTimers.set(
+		path,
+		setTimeout(() => {
+			debounceTimers.delete(path);
+			processTranscriptUpdate(path, captured).catch((e) =>
+				logger.warn("codex-watcher", "Process failed", {
+					error: e instanceof Error ? e.message : String(e),
+				}),
+			);
+		}, activeConfig.debounceMs),
+	);
+}
+
+async function processTranscriptUpdate(path: string, session: TrackedSession): Promise<void> {
+	const messages = extractNewUserMessages(path, session);
+	if (messages.length === 0) return;
+
+	// Process the latest user message only (most relevant for recall)
+	const latest = messages[messages.length - 1];
+	await recallForMessage(latest, session, activeConfig);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Start the Codex transcript watcher. Call once at daemon startup.
+ */
+export function startCodexTranscriptWatcher(config?: Partial<CodexLiveRecallConfig>): void {
+	activeConfig = resolveConfig(config);
+
+	if (!activeConfig.enabled) {
+		logger.info("codex-watcher", "Codex live recall disabled");
+		return;
+	}
+
+	const dir = sessionsDir();
+	if (!existsSync(dir)) {
+		// Codex not installed — nothing to watch. The watcher will be
+		// started on first session registration instead.
+		logger.info("codex-watcher", "Sessions dir not found, deferring", {
+			path: dir,
+		});
+		return;
+	}
+
+	startWatcher();
+}
+
+function startWatcher(): void {
+	if (fsWatcher) return;
+
+	const dir = sessionsDir();
+	fsWatcher = watch(join(dir, "**", "*.jsonl"), {
+		persistent: true,
+		ignoreInitial: true,
+	});
+
+	fsWatcher.on("change", handleTranscriptChange);
+	fsWatcher.on("add", handleTranscriptChange);
+
+	logger.info("codex-watcher", "Transcript watcher started", {
+		dir,
+	});
+}
+
+/**
+ * Register a Codex session for live recall tracking.
+ * Called from the codex-watch-start hook endpoint.
+ */
+export function registerCodexSession(sessionKey: string, project: string): void {
+	if (!activeConfig.enabled) return;
+
+	sessions.set(sessionKey, {
+		sessionKey,
+		project,
+		transcriptPath: null,
+		lastOffset: 0,
+		lastUserHash: "",
+	});
+
+	// Ensure watcher is running (may have been deferred if sessions dir
+	// didn't exist at startup)
+	if (!fsWatcher && existsSync(sessionsDir())) {
+		startWatcher();
+	}
+
+	logger.info("codex-watcher", "Session registered", {
+		sessionKey,
+		project,
+	});
+}
+
+/**
+ * Unregister a Codex session and clean up.
+ * Called from the session-end hook handler.
+ */
+export function unregisterCodexSession(sessionKey: string): void {
+	const session = sessions.get(sessionKey);
+	if (!session) return;
+
+	sessions.delete(sessionKey);
+
+	// Clear any pending debounce timer
+	if (session.transcriptPath) {
+		const timer = debounceTimers.get(session.transcriptPath);
+		if (timer) {
+			clearTimeout(timer);
+			debounceTimers.delete(session.transcriptPath);
+		}
+	}
+
+	// Clean up live context file if no more active sessions
+	if (sessions.size === 0) {
+		removeLiveContextFile();
+	}
+
+	logger.info("codex-watcher", "Session unregistered", {
+		sessionKey,
+	});
+}
+
+/**
+ * Stop the watcher and clean up all state. Called on daemon shutdown.
+ */
+export function stopCodexTranscriptWatcher(): void {
+	if (fsWatcher) {
+		fsWatcher.close();
+		fsWatcher = null;
+	}
+
+	for (const timer of debounceTimers.values()) {
+		clearTimeout(timer);
+	}
+	debounceTimers.clear();
+	sessions.clear();
+	removeLiveContextFile();
+
+	logger.info("codex-watcher", "Transcript watcher stopped");
+}
+
+function removeLiveContextFile(): void {
+	try {
+		const path = liveContextPath();
+		if (existsSync(path)) unlinkSync(path);
+	} catch {
+		// ignore
+	}
+}

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5038,6 +5038,13 @@ import {
 	unbypassSession,
 } from "./session-tracker.js";
 
+import {
+	registerCodexSession,
+	startCodexTranscriptWatcher,
+	stopCodexTranscriptWatcher,
+	unregisterCodexSession,
+} from "./codex-transcript-watcher.js";
+
 /** Read the runtime path from header or body, preferring header. */
 function resolveRuntimePath(c: Context, body?: { runtimePath?: string }): RuntimePath | undefined {
 	const header = c.req.header("x-signet-runtime-path");
@@ -5232,10 +5239,28 @@ app.post("/api/hooks/session-end", async (c) => {
 		if (sessionKey) {
 			releaseSession(sessionKey);
 			removeAgentPresence(sessionKey);
+			unregisterCodexSession(sessionKey);
 		}
 	}
 	} catch (e) {
 		logger.error("hooks", "Session end hook failed", e as Error);
+		return c.json({ error: "Hook execution failed" }, 500);
+	}
+});
+
+// Codex live recall — register a session for transcript watching
+app.post("/api/hooks/codex-watch-start", async (c) => {
+	try {
+		const body = (await c.req.json()) as { sessionKey?: string; project?: string };
+		const sessionKey = body.sessionKey;
+		const project = body.project || "";
+		if (!sessionKey) {
+			return c.json({ error: "sessionKey is required" }, 400);
+		}
+		registerCodexSession(sessionKey, project);
+		return c.json({ success: true });
+	} catch (e) {
+		logger.error("hooks", "Codex watch start failed", e as Error);
 		return c.json({ error: "Hook execution failed" }, 500);
 	}
 });
@@ -9456,6 +9481,8 @@ async function cleanup() {
 
 	closeDbAccessor();
 
+	stopCodexTranscriptWatcher();
+
 	if (watcher) {
 		watcher.close();
 	}
@@ -9522,6 +9549,10 @@ async function main() {
 	// Start file watcher
 	startFileWatcher();
 	logger.info("watcher", "File watcher started");
+
+	// Start Codex transcript watcher for live recall
+	startCodexTranscriptWatcher();
+	logger.info("watcher", "Codex transcript watcher initialized");
 
 	// Ensure SIGNET-ARCHITECTURE.md exists on startup (file watcher uses
 	// ignoreInitial:true so it won't recreate missing files on its own)


### PR DESCRIPTION
## Why

Codex CLI currently only gets memories at session-start (frontloaded) and extracts them at session-end (after-carry). Unlike Claude Code — which gets per-prompt memory injection on every user message via native hooks — Codex has zero mid-session recall. Users running Codex sessions don't get the live memory experience that makes Signet valuable during conversations.

The Codex connector was also missing basic parity features: no skills symlink, no persistent identity file, no config.toml integration.

## How

**The core constraint:** Codex has no native mid-session hooks, no MCP, no IPC, no stdin. The `model_instructions_file` is read once at startup. We cannot directly inject context into a running Codex process.

**The workaround:** Codex CAN read files from disk during a session (it's a coding agent with file access). We instruct it to check a live-updating file before each response, and the daemon keeps that file current with relevant memories via real-time transcript watching.

### Layer 1: Connector Parity (reliable baseline)
- Generate persistent `~/.codex/CODEX.md` from identity files (AGENTS.md, SOUL.md, IDENTITY.md, USER.md, MEMORY.md) with Signet system block
- Patch `~/.codex/config.toml` with `model_instructions_file` pointing to CODEX.md — Codex always loads Signet context even without the wrapper
- Symlink skills directory (`~/.agents/skills` → `~/.codex/skills`)
- Enriched wrapper merges static CODEX.md + dynamic session-start memories into one file per session
- CLI memory commands (`signet remember`/`signet recall`) documented in CODEX.md since Codex has no MCP
- Safe config.toml handling: never overwrites user-set `model_instructions_file`, emits warning instead

### Layer 2: Live Per-Prompt Recall (best-effort, ~70-80% of turns)

```
User types message in Codex
  → Codex writes event to transcript JSONL (real-time)
  → Daemon transcript watcher detects new user_message (chokidar, 300ms debounce)
  → Daemon calls handleUserPromptSubmit internally (hybrid recall)
  → Daemon writes recalled memories to ~/.codex/.signet-live-context.md (atomic write-rename)
  → Codex (following model_instructions_file directive) reads the file before responding
```

- New `codex-transcript-watcher.ts` daemon module — incremental JSONL parsing, per-file offset tracking, debounced recall, atomic file writes, full session lifecycle management
- New endpoint: `POST /api/hooks/codex-watch-start` for session registration
- New CLI command: `signet hook codex-watch-start`
- Only activates for interactive `codex` sessions (skips `codex exec` one-shot mode)
- Enabled by default, fail-open on all error paths — if daemon is down or recall fails, Codex continues normally
- ~500ms total latency (300ms debounce + 200ms recall) vs Codex's 1-3s API round-trip

### What remains infeasible (needs upstream Codex changes)
- **Guaranteed per-prompt injection**: Codex has no native hook system — the file-read instruction is probabilistic
- **MCP server**: Codex doesn't support MCP
- **Pre-compaction**: No mid-session hooks

## Changes

| File | Change |
|------|--------|
| `packages/daemon/src/codex-transcript-watcher.ts` | **New** — Core watcher module (transcript parsing, recall, live file management) |
| `packages/daemon/src/daemon.ts` | Import watcher, add `/api/hooks/codex-watch-start` route, wire startup/shutdown lifecycle, add `unregisterCodexSession` to session-end cleanup |
| `packages/connector-codex/src/index.ts` | CODEX.md generation, config.toml patching, skills symlink, live recall instruction in wrapper, watch-start registration for interactive mode |
| `packages/cli/src/cli.ts` | `signet hook codex-watch-start` subcommand |
| `docs/HARNESSES.md` | Updated Codex section with new capabilities, live recall docs, and limitations |

## Test plan
- [ ] `bun run typecheck` passes
- [ ] `biome check` passes on changed files
- [ ] `signet install` → select Codex → verify CODEX.md, skills symlink, config.toml patch
- [ ] Run interactive Codex → verify `~/.codex/.signet-live-context.md` updates on each user message
- [ ] Run `codex exec "one shot"` → verify watch-start is NOT called
- [ ] End session → verify live context file is cleaned up
- [ ] Pre-existing `model_instructions_file` in config.toml → verify warning, no overwrite
- [ ] Uninstall removes CODEX.md and unpatches config.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)