### PR TITLE
fix(tray): cross-platform build script for Windows CI

### DIFF
--- a/packages/tray/build-ts.mjs
+++ b/packages/tray/build-ts.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform build script for tray TypeScript assets.
+ * Replaces Unix-only rm -rf / cp -r in package.json scripts.
+ */
+import { rmSync, cpSync, copyFileSync, readdirSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { join } from "node:path";
+
+// Clean dist
+rmSync("dist", { recursive: true, force: true });
+
+// Bundle TypeScript
+execSync("bun build src-ts/index.ts --outfile dist/tray.js --target browser --minify", { stdio: "inherit" });
+
+// Build dashboard
+execSync("bun run build:dashboard", { stdio: "inherit" });
+
+// Copy dashboard build contents into dist (not the directory itself)
+const src = "../cli/dashboard/build";
+for (const entry of readdirSync(src)) {
+	cpSync(join(src, entry), join("dist", entry), { recursive: true });
+}
+
+// Copy HTML files
+for (const file of ["tray.html", "capture.html", "search.html"]) {
+	copyFileSync(file, `dist/${file}`);
+}

--- a/packages/tray/package.json
+++ b/packages/tray/package.json
@@ -5,7 +5,7 @@
   "description": "Signet desktop application",
   "scripts": {
     "build:dashboard": "cd ../cli/dashboard && bun run build",
-    "build:ts": "rm -rf dist && bun build src-ts/index.ts --outfile dist/tray.js --target browser --minify && bun run build:dashboard && cp -r ../cli/dashboard/build/* dist/ && cp tray.html dist/tray.html && cp capture.html dist/capture.html && cp search.html dist/search.html",
+    "build:ts": "node build-ts.mjs",
     "dev": "tauri dev",
     "build": "tauri build",
     "tauri": "tauri"


### PR DESCRIPTION
## Why

Desktop Build CI passes on macOS and Linux but fails on Windows with `cp: illegal option -- r`. The `build:ts` npm script uses Unix-only commands (`rm -rf`, `cp -r`) that don't exist on Windows `cmd`.

## What Changed

Extracted the build:ts logic into `build-ts.mjs` using Node.js fs APIs:
- `fs.rmSync(dir, {recursive: true, force: true})` replaces `rm -rf`
- `fs.cpSync(src, dest, {recursive: true})` replaces `cp -r`
- `fs.copyFileSync()` replaces `cp`

Tested locally — produces correct `dist/` with tray.js, HTML files, and all dashboard assets.

## Test Plan

- [ ] Desktop Build CI passes on Windows (the actual validation)
- [ ] macOS and Linux continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)