### PR TITLE
fix: harden troubleshooter lifecycle commands

### DIFF
--- a/packages/cli/dashboard/src/lib/components/cortex/TroubleshooterPanel.svelte
+++ b/packages/cli/dashboard/src/lib/components/cortex/TroubleshooterPanel.svelte
@@ -8,7 +8,7 @@
 	import Info from "@lucide/svelte/icons/info";
 	import Terminal from "@lucide/svelte/icons/terminal";
 	import ChevronDown from "@lucide/svelte/icons/chevron-down";
-	import { tick } from "svelte";
+	import { tick, onDestroy } from "svelte";
 
 	type CmdKind = "cli" | "api";
 
@@ -28,6 +28,8 @@
 		readonly color: string;
 		readonly commands: readonly CommandDef[];
 	}
+
+	const HEALTH_PATH = "/health";
 
 	const groupDefs: readonly GroupDef[] = [
 		{
@@ -52,7 +54,7 @@
 			icon: Activity,
 			color: "var(--sig-highlight)",
 			commands: [
-				{ label: "Health", kind: "api", method: "GET", path: "/health" },
+				{ label: "Health", kind: "api", method: "GET", path: HEALTH_PATH },
 				{ label: "Diagnostics", kind: "api", method: "GET", path: "/api/diagnostics" },
 				{ label: "Pipeline", kind: "api", method: "GET", path: "/api/pipeline/status" },
 				{ label: "Predictor", kind: "api", method: "GET", path: "/api/predictor/status" },
@@ -89,8 +91,8 @@
 				{ label: "Reclassify", kind: "api", method: "POST", path: "/api/repair/reclassify-entities" },
 				{ label: "Prune Chunks", kind: "api", method: "POST", path: "/api/repair/prune-chunk-groups" },
 				{ label: "Prune Singletons", kind: "api", method: "POST", path: "/api/repair/prune-singleton-entities" },
-				{ label: "Stop Daemon", kind: "cli", key: "daemon-stop" },
-				{ label: "Restart Daemon", kind: "cli", key: "daemon-restart" },
+				{ label: "Stop Daemon", kind: "cli", key: "daemon-stop", danger: true },
+				{ label: "Restart Daemon", kind: "cli", key: "daemon-restart", danger: true },
 				{ label: "Update Signet", kind: "cli", key: "update" },
 			],
 		},
@@ -107,6 +109,14 @@
 	let panels = $state<Record<string, GroupState>>(
 		Object.fromEntries(groupDefs.map(g => [g.id, { lines: [], running: false, expanded: true, selected: 0 }]))
 	);
+
+	// Track in-flight requests so we can abort on unmount
+	const inflight = new Set<AbortController>();
+
+	onDestroy(() => {
+		for (const c of inflight) c.abort();
+		inflight.clear();
+	});
 
 	const termRefs: Record<string, HTMLDivElement | undefined> = {};
 
@@ -146,6 +156,7 @@
 		await scrollGroup(gid);
 
 		const abort = new AbortController();
+		inflight.add(abort);
 		let initiated = false;
 		try {
 			const res = await fetch(`${API_BASE}/api/troubleshoot/exec`, {
@@ -231,23 +242,29 @@
 		}
 
 		// Restart: poll until daemon comes back (only if restart was actually initiated)
-		if (cmd.key === "daemon-restart" && initiated) {
+		if (cmd.key === "daemon-restart" && initiated && !abort.signal.aborted) {
 			appendLine(gid, "\x1b[90mWaiting for daemon to restart...\x1b[0m");
 			await scrollGroup(gid);
 			let ok = false;
 			for (let i = 0; i < 15; i++) {
+				if (abort.signal.aborted) break;
 				await new Promise<void>(r => setTimeout(r, 1000));
 				try {
-					const h = await fetch(`${API_BASE}/health`);
+					const h = await fetch(`${API_BASE}${HEALTH_PATH}`, { signal: abort.signal });
 					if (h.ok) { ok = true; break; }
-				} catch { /* still down */ }
+				} catch {
+					if (abort.signal.aborted) break;
+				}
 			}
-			appendLine(gid, ok
-				? "\x1b[32m✓ Daemon restarted\x1b[0m"
-				: "\x1b[31m✗ Daemon did not restart within 15s\x1b[0m");
-			await scrollGroup(gid);
+			if (!abort.signal.aborted) {
+				appendLine(gid, ok
+					? "\x1b[32m✓ Daemon restarted\x1b[0m"
+					: "\x1b[31m✗ Daemon did not restart within 15s\x1b[0m");
+				await scrollGroup(gid);
+			}
 		}
 
+		inflight.delete(abort);
 		appendLine(gid, "");
 		gs.running = false;
 		await scrollGroup(gid);
@@ -287,9 +304,27 @@
 		await scrollGroup(gid);
 	}
 
+	// Confirmation gate for dangerous commands
+	let pending = $state<{ gid: string; cmd: CommandDef } | null>(null);
+
 	function exec(gid: string, cmd: CommandDef): void {
+		if (cmd.danger) {
+			pending = { gid, cmd };
+			return;
+		}
+		run(gid, cmd);
+	}
+
+	function run(gid: string, cmd: CommandDef): void {
 		if (cmd.kind === "cli") void execCli(gid, cmd);
 		else void execApi(gid, cmd);
+	}
+
+	function confirmExec(): void {
+		if (!pending) return;
+		const { gid, cmd } = pending;
+		pending = null;
+		run(gid, cmd);
 	}
 
 	function escapeHtml(s: string): string {
@@ -408,6 +443,37 @@
 	{/each}
 </div>
 
+{#if pending}
+	<div
+		class="ts-overlay"
+		role="button"
+		tabindex="0"
+		onclick={(e) => { if (e.target === e.currentTarget) pending = null; }}
+		onkeydown={(e) => { if (e.key === "Escape") pending = null; }}
+	>
+		<div class="ts-dialog" role="dialog" aria-modal="true" aria-labelledby="ts-confirm-title">
+			<div class="ts-dialog-title" id="ts-confirm-title">{pending.cmd.label}?</div>
+			<div class="ts-dialog-body">
+				{#if pending.cmd.key === "daemon-stop"}
+					This will stop the daemon. The dashboard will lose connection and cannot recover from the UI.
+				{:else if pending.cmd.key === "daemon-restart"}
+					This will restart the daemon. The dashboard will briefly lose connection.
+				{:else}
+					This is a destructive operation. Are you sure?
+				{/if}
+			</div>
+			<div class="ts-dialog-actions">
+				<button type="button" class="ts-dialog-btn ts-dialog-cancel" onclick={() => pending = null}>
+					Cancel
+				</button>
+				<button type="button" class="ts-dialog-btn ts-dialog-danger" onclick={confirmExec}>
+					{pending.cmd.label}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
 <style>
 	.ts-root {
 		display: grid;
@@ -418,12 +484,6 @@
 		padding: var(--space-md);
 		gap: 10px;
 		align-items: stretch;
-	}
-
-	@media (min-width: 900px) {
-		.ts-root {
-			grid-template-columns: 1fr 1fr;
-		}
 	}
 
 	@media (max-width: 480px) {
@@ -670,4 +730,78 @@
 
 	:global(.ts-spin) { animation: ts-spin 0.8s linear infinite; }
 	@keyframes ts-spin { to { transform: rotate(360deg); } }
+
+	/* ── Confirmation dialog ── */
+	.ts-overlay {
+		position: fixed;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: rgba(0, 0, 0, 0.6);
+		z-index: 100;
+	}
+
+	.ts-dialog {
+		width: 360px;
+		max-width: 90vw;
+		background: var(--sig-surface-raised);
+		border: 1px solid var(--sig-border-strong, var(--sig-border));
+		border-radius: 8px;
+		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+	}
+
+	.ts-dialog-title {
+		padding: 16px 16px 0;
+		font-family: var(--font-display);
+		font-size: 13px;
+		font-weight: 700;
+		color: var(--sig-text-bright);
+	}
+
+	.ts-dialog-body {
+		padding: 10px 16px 16px;
+		font-family: var(--font-mono);
+		font-size: 11px;
+		line-height: 1.5;
+		color: var(--sig-text-muted);
+	}
+
+	.ts-dialog-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 8px;
+		padding: 0 16px 16px;
+	}
+
+	.ts-dialog-btn {
+		padding: 6px 14px;
+		border-radius: 6px;
+		font-family: var(--font-mono);
+		font-size: 10px;
+		font-weight: 600;
+		letter-spacing: 0.04em;
+		cursor: pointer;
+		transition: all 0.15s ease;
+	}
+
+	.ts-dialog-cancel {
+		background: var(--sig-surface);
+		border: 1px solid var(--sig-border);
+		color: var(--sig-text);
+	}
+
+	.ts-dialog-cancel:hover {
+		background: var(--sig-surface-raised);
+	}
+
+	.ts-dialog-danger {
+		background: var(--sig-danger, #ef4444);
+		border: 1px solid var(--sig-danger, #ef4444);
+		color: white;
+	}
+
+	.ts-dialog-danger:hover {
+		filter: brightness(1.1);
+	}
 </style>

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -7249,7 +7249,9 @@ app.post("/api/troubleshoot/exec", async (c) => {
 				const write = (event: unknown): void => {
 					try {
 						controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
-					} catch {}
+					} catch (err) {
+						logger.debug("troubleshoot", "SSE enqueue failed", err);
+					}
 				};
 
 				write({ type: "started", key, command: `signet daemon ${action}` });
@@ -7261,22 +7263,21 @@ app.post("/api/troubleshoot/exec", async (c) => {
 				try { controller.close(); } catch {}
 
 				// Give the response time to flush, then trigger graceful shutdown.
-				// SIGTERM triggers cleanup() which handles PID file, DB, watchers.
+				// Spawn the replacement daemon BEFORE sending SIGTERM — the child
+				// is detached+unref'd so it survives parent exit. A short delay
+				// after spawn lets the fork commit before we self-terminate.
 				setTimeout(async () => {
 					if (key === "daemon-restart") {
 						const { spawn: nodeSpawn } = await import("node:child_process");
-						// Use array form — no shell, so paths with spaces are safe.
-						// Inner delay lets cleanup() finish before the new daemon starts.
-						setTimeout(() => {
-							const child = nodeSpawn(resolved, ["daemon", "start"], {
-								detached: true,
-								stdio: "ignore",
-								env: { ...baseEnv, SIGNET_NO_HOOKS: "1" } as NodeJS.ProcessEnv,
-							});
-							child.unref();
-						}, 1000);
+						const child = nodeSpawn(resolved, ["daemon", "start"], {
+							detached: true,
+							stdio: "ignore",
+							env: { ...baseEnv, SIGNET_NO_HOOKS: "1" } as NodeJS.ProcessEnv,
+						});
+						child.unref();
 					}
-					process.kill(process.pid, "SIGTERM");
+					// Let the fork fully settle before cleanup tears everything down
+					setTimeout(() => process.kill(process.pid, "SIGTERM"), 300);
 				}, 1000);
 			},
 		});
@@ -7285,7 +7286,6 @@ app.post("/api/troubleshoot/exec", async (c) => {
 			headers: {
 				"content-type": "text/event-stream",
 				"cache-control": "no-cache",
-				connection: "keep-alive",
 			},
 		});
 	}

--- a/packages/daemon/src/troubleshoot-exec.test.ts
+++ b/packages/daemon/src/troubleshoot-exec.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for the troubleshooter exec endpoint.
+ *
+ * Verifies command validation, lifecycle SSE structure, and the
+ * critical spawn-before-kill ordering for daemon restart.
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SRC = readFileSync(join(__dirname, "daemon.ts"), "utf-8");
+
+// ---------------------------------------------------------------------------
+// Extract the route handler source for targeted assertions
+// ---------------------------------------------------------------------------
+
+function extract(pattern: RegExp): string {
+	const match = SRC.match(pattern);
+	if (!match) throw new Error(`Pattern not found: ${pattern}`);
+	return match[0];
+}
+
+const execRoute = extract(/app\.post\("\/api\/troubleshoot\/exec"[\s\S]*?\n\}\);/);
+
+const commands = extract(/const TROUBLESHOOT_COMMANDS[\s\S]*?\n\};/);
+
+// ---------------------------------------------------------------------------
+// Command validation
+// ---------------------------------------------------------------------------
+
+describe("troubleshoot exec: command validation", () => {
+	it("defines TROUBLESHOOT_COMMANDS as a known set", () => {
+		expect(commands).toContain('"daemon-stop"');
+		expect(commands).toContain('"daemon-restart"');
+		expect(commands).toContain('"status"');
+		expect(commands).toContain('"daemon-status"');
+	});
+
+	it("rejects unknown keys with 400", () => {
+		expect(execRoute).toContain("Unknown command");
+		expect(execRoute).toContain("400");
+	});
+
+	it("returns 500 when binary is not found", () => {
+		expect(execRoute).toContain("Binary not found");
+		expect(execRoute).toContain("500");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Lifecycle SSE structure
+// ---------------------------------------------------------------------------
+
+describe("troubleshoot exec: lifecycle commands", () => {
+	it("handles daemon-stop and daemon-restart as lifecycle commands", () => {
+		expect(execRoute).toContain('key === "daemon-stop" || key === "daemon-restart"');
+	});
+
+	it("emits SSE events: started, stdout, exit", () => {
+		expect(execRoute).toContain('type: "started"');
+		expect(execRoute).toContain('type: "stdout"');
+		expect(execRoute).toContain('type: "exit"');
+	});
+
+	it("returns text/event-stream content type for lifecycle", () => {
+		expect(execRoute).toContain('"text/event-stream"');
+	});
+
+	it("warns about dashboard disconnect on daemon-stop", () => {
+		expect(execRoute).toContain("Dashboard will lose connection");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// C1: Spawn-before-kill ordering (critical race condition fix)
+// ---------------------------------------------------------------------------
+
+describe("troubleshoot exec: restart spawn ordering", () => {
+	it("spawns detached child BEFORE sending SIGTERM", () => {
+		const block = extract(/setTimeout\(async \(\) => \{[\s\S]*?daemon-restart[\s\S]*?\}, 1000\);/);
+
+		const spawnIdx = block.indexOf("nodeSpawn(resolved");
+		const killIdx = block.indexOf("process.kill(process.pid");
+		expect(spawnIdx).toBeGreaterThan(-1);
+		expect(killIdx).toBeGreaterThan(-1);
+		expect(spawnIdx).toBeLessThan(killIdx);
+	});
+
+	it("does not nest spawn inside a separate setTimeout", () => {
+		const block = extract(/if \(key === "daemon-restart"\) \{[\s\S]*?child\.unref\(\)/);
+
+		// The old bug: spawn was inside a nested setTimeout that fired
+		// after SIGTERM. Verify there's no setTimeout wrapping the spawn.
+		const inner = block.match(/setTimeout\(\s*\(\)\s*=>\s*\{[\s\S]*?nodeSpawn/);
+		expect(inner).toBeNull();
+	});
+
+	it("spawns with detached: true and stdio: ignore", () => {
+		expect(execRoute).toContain("detached: true");
+		expect(execRoute).toContain('stdio: "ignore"');
+	});
+
+	it("unrefs the child so parent can exit", () => {
+		expect(execRoute).toContain("child.unref()");
+	});
+
+	it("strips SIGNET_NO_HOOKS from env and re-adds it for restart", () => {
+		// Env destructuring strips the flag
+		expect(execRoute).toContain("SIGNET_NO_HOOKS: _");
+		// Re-added in spawn env
+		expect(execRoute).toContain('SIGNET_NO_HOOKS: "1"');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// M3: No connection: keep-alive header
+// ---------------------------------------------------------------------------
+
+describe("troubleshoot exec: SSE headers", () => {
+	it("does not include connection: keep-alive on lifecycle SSE response", () => {
+		const headers = extract(/new Response\(lifecycle[\s\S]*?headers:[\s\S]*?\}/);
+		expect(headers).not.toContain("keep-alive");
+	});
+});


### PR DESCRIPTION
## Summary

- **Critical race condition fix**: daemon restart spawned the replacement child *after* SIGTERM, but `cleanup()` → `process.exit()` killed the timer before it fired. Child now spawns **before** SIGTERM with a 300ms settle delay.
- **Abort on unmount**: TroubleshooterPanel now tracks in-flight AbortControllers and aborts all requests on component destroy — prevents stale state updates and leaked fetches during SSE streaming and health polling.
- **Confirmation dialog**: `daemon-stop` and `daemon-restart` now require explicit confirmation via a modal dialog (uses existing `danger` property on CommandDef).
- **13 structural tests**: command validation, SSE structure, spawn-before-kill ordering, and header cleanup — all verified against source.
- **Cleanup**: empty catch → debug logging, removed redundant CSS media query, removed forbidden `connection: keep-alive` header, extracted `HEALTH_PATH` constant.

## Test plan

- [x] `bun test packages/daemon/src/troubleshoot-exec.test.ts` — 13 pass
- [ ] Manual: trigger daemon restart from dashboard, verify daemon comes back within 15s
- [ ] Manual: navigate away during streaming command, verify no console warnings
- [ ] Manual: click "Stop Daemon", verify confirmation dialog appears before execution
- [ ] Manual: click "Restart Daemon", verify confirmation dialog with correct messaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)