### PR TITLE
fix: comprehensive security audit hardening

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3642,10 +3642,18 @@ async function importFromGitHub(basePath: string) {
 		rmSync(tmpDir, { recursive: true });
 	}
 
+	// Validate URL scheme — reject file:// and bare local paths to prevent
+	// local filesystem reads and crafted repo content execution.
+	const SAFE_SCHEMES = /^(https?:\/\/|git@|ssh:\/\/|git:\/\/)/i;
+	if (!SAFE_SCHEMES.test(gitUrl)) {
+		console.log(chalk.red("  Invalid git URL — only https://, ssh://, and git:// are allowed"));
+		return;
+	}
+
 	const spinner = ora("Cloning repository...").start();
 
 	try {
-		const cloneResult = spawnSync("git", ["clone", "--depth", "1", gitUrl, tmpDir], {
+		const cloneResult = spawnSync("git", ["clone", "--depth", "1", "--single-branch", gitUrl, tmpDir], {
 			encoding: "utf-8",
 			stdio: ["pipe", "pipe", "pipe"],
 			windowsHide: true,
@@ -4237,11 +4245,20 @@ async function restartOpenClaw(basePath: string): Promise<boolean> {
 		return false;
 	}
 
+	// Parse command into argv to avoid sh -c shell injection.
+	// agent.yaml is user-controlled — a tampered file could inject
+	// arbitrary commands if passed directly to a shell wrapper.
+	const argv = restartCommand.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g);
+	if (!argv || argv.length === 0) {
+		console.log(chalk.red("  Invalid restart command"));
+		return false;
+	}
+	// Strip surrounding quotes from each arg
+	const cmd = argv.map((a: string) => a.replace(/^["']|["']$/g, ""));
+
 	const spinner = ora("Restarting OpenClaw...").start();
 	try {
-		const shell = process.platform === "win32" ? "cmd" : "sh";
-		const shellArgs = process.platform === "win32" ? ["/c", restartCommand] : ["-c", restartCommand];
-		const result = spawnSync(shell, shellArgs, {
+		const result = spawnSync(cmd[0], cmd.slice(1), {
 			timeout: 15_000,
 			stdio: "pipe",
 			windowsHide: true,

--- a/packages/connector-base/src/index.ts
+++ b/packages/connector-base/src/index.ts
@@ -32,7 +32,7 @@
  * ```
  */
 
-import { existsSync, readFileSync, writeFileSync, renameSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, renameSync, unlinkSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { randomBytes } from "node:crypto";
 import {
@@ -221,8 +221,13 @@ export abstract class BaseConnector {
 export function atomicWriteJson(path: string, data: unknown, indent: number | string = 2): void {
 	const content = `${JSON.stringify(data, null, indent)}\n`;
 	const tmp = join(dirname(path), `.${randomBytes(6).toString("hex")}.tmp`);
-	writeFileSync(tmp, content, "utf-8");
-	renameSync(tmp, path);
+	try {
+		writeFileSync(tmp, content, "utf-8");
+		renameSync(tmp, path);
+	} catch (err) {
+		try { unlinkSync(tmp); } catch {}
+		throw err;
+	}
 }
 
 // ============================================================================

--- a/packages/connector-base/src/index.ts
+++ b/packages/connector-base/src/index.ts
@@ -32,8 +32,9 @@
  * ```
  */
 
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readFileSync, writeFileSync, renameSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { randomBytes } from "node:crypto";
 import {
 	buildSignetBlock,
 	stripSignetBlock,
@@ -209,6 +210,19 @@ export abstract class BaseConnector {
 	 * Get the path to the harness's main config file.
 	 */
 	abstract getConfigPath(): string;
+}
+
+// ============================================================================
+// Atomic file write — prevents TOCTOU corruption when multiple
+// connector runs race on the same config file. Writes to a temp file
+// then renames (atomic on POSIX, near-atomic on Windows).
+// ============================================================================
+
+export function atomicWriteJson(path: string, data: unknown, indent: number | string = 2): void {
+	const content = `${JSON.stringify(data, null, indent)}\n`;
+	const tmp = join(dirname(path), `.${randomBytes(6).toString("hex")}.tmp`);
+	writeFileSync(tmp, content, "utf-8");
+	renameSync(tmp, path);
 }
 
 // ============================================================================

--- a/packages/connector-claude-code/src/index.ts
+++ b/packages/connector-claude-code/src/index.ts
@@ -16,6 +16,7 @@ import {
 	BaseConnector,
 	type InstallResult,
 	type UninstallResult,
+	atomicWriteJson,
 } from "@signet/connector-base";
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -158,7 +159,7 @@ export class ClaudeCodeConnector extends BaseConnector {
 				}
 			}
 
-			writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+			atomicWriteJson(settingsPath, settings);
 			filesRemoved.push(settingsPath);
 		} catch {
 			// If parsing fails, leave settings as-is
@@ -378,7 +379,7 @@ export class ClaudeCodeConnector extends BaseConnector {
 		// Migration: remove stale PreCompaction key from existing installs
 		delete (settings.hooks as Record<string, unknown>).PreCompaction;
 
-		writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+		atomicWriteJson(settingsPath, settings);
 
 		// Register Signet MCP server in ~/.claude.json (user scope)
 		this.registerMcpServer();
@@ -435,7 +436,7 @@ export class ClaudeCodeConnector extends BaseConnector {
 			},
 		};
 
-		writeFileSync(claudeJsonPath, JSON.stringify(config, null, 2));
+		atomicWriteJson(claudeJsonPath, config);
 	}
 
 	/**
@@ -463,7 +464,7 @@ export class ClaudeCodeConnector extends BaseConnector {
 			if (Object.keys(mcp).length === 0) {
 				delete config.mcpServers;
 			}
-			writeFileSync(claudeJsonPath, JSON.stringify(config, null, 2));
+			atomicWriteJson(claudeJsonPath, config);
 		}
 	}
 

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -11,6 +11,7 @@ import {
 	BaseConnector,
 	type InstallResult,
 	type UninstallResult,
+	atomicWriteJson,
 } from "@signet/connector-base";
 
 // ---------------------------------------------------------------------------
@@ -91,7 +92,7 @@ function isSignetOwned(hooks: HooksJson): boolean {
 
 function writeHooksJson(path: string, hooks: HooksJson): void {
 	mkdirSync(join(path, ".."), { recursive: true });
-	writeFileSync(path, JSON.stringify(hooks, null, 2) + "\n");
+	atomicWriteJson(path, hooks);
 }
 
 const SIGNET_HOOK_CMDS = ["hook session-start", "hook user-prompt-submit", "hook session-end"] as const;

--- a/packages/connector-openclaw/src/index.ts
+++ b/packages/connector-openclaw/src/index.ts
@@ -24,7 +24,7 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { delimiter, join, resolve } from "node:path";
-import { BaseConnector, type InstallResult, type UninstallResult } from "@signet/connector-base";
+import { BaseConnector, type InstallResult, type UninstallResult, atomicWriteJson } from "@signet/connector-base";
 import { parse as parseJson5 } from "json5";
 
 // ============================================================================
@@ -570,7 +570,7 @@ export class OpenClawConnector extends BaseConnector {
 				}
 
 				config.plugins = pluginsObj;
-				writeFileSync(configPath, JSON.stringify(config, null, indent));
+				atomicWriteJson(configPath, config, indent);
 				patched.push(configPath);
 			} catch (e) {
 				const message = e instanceof Error ? e.message : String(e);
@@ -866,7 +866,7 @@ export class OpenClawConnector extends BaseConnector {
 				config.plugins = pluginsObj;
 
 				deepMerge(config, patch);
-				writeFileSync(configPath, JSON.stringify(config, null, indent));
+				atomicWriteJson(configPath, config, indent);
 				patched.push(configPath);
 			} catch (e) {
 				const message = (e as Error).message || "unknown parse/write error";
@@ -912,7 +912,7 @@ export class OpenClawConnector extends BaseConnector {
 
 		const indent = this.detectIndent(raw);
 		deepMerge(config, patch);
-		writeFileSync(configPath, JSON.stringify(config, null, indent));
+		atomicWriteJson(configPath, config, indent);
 	}
 
 	/**
@@ -991,7 +991,7 @@ export class OpenClawConnector extends BaseConnector {
 
 				if (dirty) {
 					config.plugins = pluginsObj;
-					writeFileSync(configPath, JSON.stringify(config, null, indent));
+					atomicWriteJson(configPath, config, indent);
 					patched.push(configPath);
 				}
 			} catch (e) {
@@ -1131,7 +1131,7 @@ configured by rejecting session claims from the second path (HTTP 409).
 
 		writeFileSync(hookMdPath, hookMd);
 		writeFileSync(handlerJsPath, handlerJs);
-		writeFileSync(packageJsonPath, JSON.stringify({ name: "agent-memory", version: "1.0.0", type: "module" }, null, 2));
+		atomicWriteJson(packageJsonPath, { name: "agent-memory", version: "1.0.0", type: "module" });
 		writeFileSync(migrationMdPath, migrationMd);
 
 		return [hookMdPath, handlerJsPath, packageJsonPath, migrationMdPath];

--- a/packages/connector-opencode/src/index.ts
+++ b/packages/connector-opencode/src/index.ts
@@ -32,6 +32,7 @@ import {
 	BaseConnector,
 	type InstallResult,
 	type UninstallResult,
+	atomicWriteJson,
 } from "@signet/connector-base";
 import { hasValidIdentity } from "@signet/core";
 import { PLUGIN_BUNDLE } from "./plugin-bundle.js";
@@ -377,7 +378,7 @@ export class OpenCodeConnector extends BaseConnector {
 
 			const changed = this.removeMemoryMjsEntries(config);
 			if (changed) {
-				writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+				atomicWriteJson(configPath, config);
 			}
 		}
 	}
@@ -434,7 +435,7 @@ export class OpenCodeConnector extends BaseConnector {
 			const existing = toStringArray(config.plugin);
 			if (!existing.includes(pluginEntry)) {
 				config.plugin = [...existing, pluginEntry];
-				writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+				atomicWriteJson(configPath, config);
 			}
 			return;
 		}
@@ -457,7 +458,7 @@ export class OpenCodeConnector extends BaseConnector {
 			const filtered = existing.filter((entry) => entry !== pluginEntry);
 			if (filtered.length !== existing.length) {
 				config.plugin = filtered;
-				writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+				atomicWriteJson(configPath, config);
 			}
 			return;
 		}
@@ -500,7 +501,7 @@ export class OpenCodeConnector extends BaseConnector {
 					enabled: true,
 				},
 			};
-			writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+			atomicWriteJson(configPath, config);
 			return; // Only update first found config
 		}
 	}
@@ -525,7 +526,7 @@ export class OpenCodeConnector extends BaseConnector {
 				if (Object.keys(mcp).length === 0) {
 					delete config.mcp;
 				}
-				writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+				atomicWriteJson(configPath, config);
 			}
 		}
 	}

--- a/packages/core/src/symlinks.ts
+++ b/packages/core/src/symlinks.ts
@@ -10,7 +10,6 @@ import {
 	lstatSync,
 	mkdirSync,
 	readdirSync,
-	statSync,
 	symlinkSync,
 	unlinkSync,
 } from "node:fs";
@@ -93,9 +92,13 @@ export function symlinkSkills(
 		const srcPath = join(sourceDir, entry);
 		const destPath = join(targetDir, entry);
 
-		// Skip if not a directory
+		// Skip if not a real directory — use lstatSync (not statSync) to
+		// detect symlinks at the source. statSync follows symlinks, which
+		// would let an attacker replace srcPath with a symlink to a
+		// sensitive directory between the check and the link operation.
 		try {
-			if (!statSync(srcPath).isDirectory()) {
+			const src = lstatSync(srcPath);
+			if (src.isSymbolicLink() || !src.isDirectory()) {
 				result.skipped.push(srcPath);
 				continue;
 			}

--- a/packages/daemon/src/auth/middleware.ts
+++ b/packages/daemon/src/auth/middleware.ts
@@ -24,18 +24,24 @@ function extractBearerToken(header: string | undefined): string | null {
 	return parts[1] ?? null;
 }
 
-// Known limitation: checks Host header, not connection peer address.
-// Spoofable by remote clients in theory, but daemon typically binds to
-// localhost anyway. Hono doesn't expose peer IP portably. Acceptable
-// for v1; revisit if daemon gets exposed to untrusted networks.
+const LOOPBACK = new Set(["127.0.0.1", "::1", "::ffff:127.0.0.1"]);
+
+// Check actual TCP peer address first (not spoofable), fall back to Host
+// header only when socket info is unavailable (e.g. test environments).
 function isLocalhost(c: Context): boolean {
+	try {
+		// @hono/node-server stores the raw IncomingMessage in env bindings
+		const addr = (c.env as Record<string, unknown>)?.incoming as
+			| { socket?: { remoteAddress?: string } }
+			| undefined;
+		const remote = addr?.socket?.remoteAddress;
+		if (remote) return LOOPBACK.has(remote);
+	} catch {
+		// getConnInfo unavailable — fall through to Host header
+	}
 	const host = c.req.header("host") ?? "";
-	const hostWithoutPort = host.split(":")[0] ?? "";
-	return (
-		hostWithoutPort === "localhost" ||
-		hostWithoutPort === "127.0.0.1" ||
-		hostWithoutPort === "::1"
-	);
+	const bare = host.split(":")[0] ?? "";
+	return bare === "localhost" || bare === "127.0.0.1" || bare === "::1";
 }
 
 export function createAuthMiddleware(

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -10474,14 +10474,16 @@ async function main() {
 				if (bytes > REQUEST_BODY_LIMIT) {
 					aborted = true;
 					logger.warn("http", "Request body exceeded limit", { bytes, limit: REQUEST_BODY_LIMIT });
-					// Send a proper 413 before closing so clients get a structured
-					// error instead of ECONNRESET. Use res.end() to avoid aborting
-					// pipelined keep-alive requests on the same socket.
+					// Send a proper 413 then destroy the socket so Hono's handler
+					// doesn't try to write a second response (ERR_HTTP_HEADERS_SENT).
 					if (!res.headersSent) {
 						res.writeHead(413, { "Content-Type": "application/json" });
-						res.end(JSON.stringify({ error: "payload too large" }));
+						res.end(JSON.stringify({ error: "payload too large" }), () => {
+							// Destroy after the 413 is flushed — prevents Hono's
+							// pipeline from racing to write headers on a closed res.
+							req.socket?.destroy();
+						});
 					}
-					req.resume(); // drain remaining body to avoid backpressure
 				}
 			});
 		});

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -10479,8 +10479,9 @@ async function main() {
 					if (!res.headersSent) {
 						res.writeHead(413, { "Content-Type": "application/json" });
 						res.end(JSON.stringify({ error: "payload too large" }), () => {
-							// Destroy after the 413 is flushed — prevents Hono's
-							// pipeline from racing to write headers on a closed res.
+							// Destroy after flush so Hono's subsequent write fails
+							// silently on a closed socket rather than emitting
+							// ERR_HTTP_HEADERS_SENT on a finished response.
 							req.socket?.destroy();
 						});
 					}

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1207,12 +1207,29 @@ function getDashboardPath(): string | null {
 // Create the Hono app
 export const app = new Hono();
 
-// Middleware
-app.use("*", cors());
+// Middleware — restrict CORS to localhost origins only
+const ALLOWED_ORIGINS = new Set([
+	"http://localhost:3850",
+	"http://127.0.0.1:3850",
+	"http://localhost:5173",
+	"http://127.0.0.1:5173",
+	"tauri://localhost",
+	"http://tauri.localhost",
+]);
+app.use("*", cors({
+	origin: (origin) => ALLOWED_ORIGINS.has(origin) ? origin : "",
+	credentials: true,
+}));
 
 // Auth middleware — reads from module-level authConfig/authSecret
 // which are initialized properly in main(). In local mode this is a no-op.
+// Guard: reject requests if auth is required but secret isn't initialized yet
+// (startup race between middleware registration and main() completing).
 app.use("*", async (c, next) => {
+	if (authConfig.mode !== "local" && !authSecret) {
+		c.status(503);
+		return c.json({ error: "server initializing" });
+	}
 	const mw = createAuthMiddleware(authConfig, authSecret);
 	return mw(c, next);
 });
@@ -1510,6 +1527,32 @@ app.use("/api/repair/*", async (c, next) => {
 	return requirePermission("admin", authConfig)(c, next);
 });
 
+// Secrets — admin only (can exec commands, exfiltrate secrets)
+app.use("/api/secrets", async (c, next) => {
+	return requirePermission("admin", authConfig)(c, next);
+});
+app.use("/api/secrets/*", async (c, next) => {
+	return requirePermission("admin", authConfig)(c, next);
+});
+
+// Git operations — admin only (can push, change remotes)
+app.use("/api/git/*", async (c, next) => {
+	return requirePermission("admin", authConfig)(c, next);
+});
+
+// Troubleshooter — admin only (can stop/restart daemon, run CLI commands)
+app.use("/api/troubleshoot/*", async (c, next) => {
+	return requirePermission("admin", authConfig)(c, next);
+});
+
+// Config writes — admin only (can overwrite agent.yaml, AGENTS.md)
+app.use("/api/config", async (c, next) => {
+	if (c.req.method === "POST") {
+		return requirePermission("admin", authConfig)(c, next);
+	}
+	return next();
+});
+
 // Per-memory PATCH and DELETE need method-specific guards + scope check
 app.use("/api/memory/:id", async (c, next) => {
 	// Scope enforcement on mutations: if token has project scope, verify
@@ -1644,6 +1687,12 @@ app.post("/api/config", async (c) => {
 
 		if (!file || typeof content !== "string") {
 			return c.json({ error: "Invalid request" }, 400);
+		}
+
+		// Reject oversized payloads (1MB) to prevent disk exhaustion
+		const MAX_CONFIG_BYTES = 1_048_576;
+		if (content.length > MAX_CONFIG_BYTES) {
+			return c.json({ error: `Content exceeds ${MAX_CONFIG_BYTES} byte limit` }, 413);
 		}
 
 		if (file.includes("/") || file.includes("..")) {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -10465,12 +10465,23 @@ async function main() {
 	const { createServer: nodeCreateServer } = await import("node:http");
 	const createBoundedServer: typeof nodeCreateServer = (...args: Parameters<typeof nodeCreateServer>) => {
 		const server = nodeCreateServer(...args);
-		server.on("request", (req) => {
+		server.on("request", (req, res) => {
 			let bytes = 0;
+			let aborted = false;
 			req.on("data", (chunk: Buffer) => {
+				if (aborted) return;
 				bytes += chunk.length;
 				if (bytes > REQUEST_BODY_LIMIT) {
-					req.destroy();
+					aborted = true;
+					logger.warn("http", "Request body exceeded limit", { bytes, limit: REQUEST_BODY_LIMIT });
+					// Send a proper 413 before closing so clients get a structured
+					// error instead of ECONNRESET. Use res.end() to avoid aborting
+					// pipelined keep-alive requests on the same socket.
+					if (!res.headersSent) {
+						res.writeHead(413, { "Content-Type": "application/json" });
+						res.end(JSON.stringify({ error: "payload too large" }));
+					}
+					req.resume(); // drain remaining body to avoid backpressure
 				}
 			});
 		});

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1217,7 +1217,7 @@ const ALLOWED_ORIGINS = new Set([
 	"http://tauri.localhost",
 ]);
 app.use("*", cors({
-	origin: (origin) => ALLOWED_ORIGINS.has(origin) ? origin : "",
+	origin: (origin) => ALLOWED_ORIGINS.has(origin) ? origin : null,
 	credentials: true,
 }));
 
@@ -1546,8 +1546,14 @@ app.use("/api/troubleshoot/*", async (c, next) => {
 });
 
 // Config writes — admin only (can overwrite agent.yaml, AGENTS.md)
+// Pre-check content-length to reject oversized bodies before buffering
+const MAX_CONFIG_BYTES = 1_048_576;
 app.use("/api/config", async (c, next) => {
 	if (c.req.method === "POST") {
+		const len = Number(c.req.header("content-length") ?? 0);
+		if (len > MAX_CONFIG_BYTES) {
+			return c.json({ error: `payload exceeds ${MAX_CONFIG_BYTES} byte limit` }, 413);
+		}
 		return requirePermission("admin", authConfig)(c, next);
 	}
 	return next();
@@ -1689,10 +1695,9 @@ app.post("/api/config", async (c) => {
 			return c.json({ error: "Invalid request" }, 400);
 		}
 
-		// Reject oversized payloads (1MB) to prevent disk exhaustion
-		const MAX_CONFIG_BYTES = 1_048_576;
+		// Defense-in-depth: also check after parse (content-length can be absent)
 		if (content.length > MAX_CONFIG_BYTES) {
-			return c.json({ error: `Content exceeds ${MAX_CONFIG_BYTES} byte limit` }, 413);
+			return c.json({ error: `content exceeds ${MAX_CONFIG_BYTES} byte limit` }, 413);
 		}
 
 		if (file.includes("/") || file.includes("..")) {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1546,12 +1546,14 @@ app.use("/api/troubleshoot/*", async (c, next) => {
 });
 
 // Config writes — admin only (can overwrite agent.yaml, AGENTS.md)
-// Pre-check content-length to reject oversized bodies before buffering
+// Reject oversized bodies: content-length fast path + post-buffer check
+// for chunked encoding. The server-level REQUEST_BODY_LIMIT caps all
+// routes, but this gives a clear per-route error message.
 const MAX_CONFIG_BYTES = 1_048_576;
 app.use("/api/config", async (c, next) => {
 	if (c.req.method === "POST") {
-		const len = Number(c.req.header("content-length") ?? 0);
-		if (len > MAX_CONFIG_BYTES) {
+		const cl = c.req.header("content-length");
+		if (cl && Number(cl) > MAX_CONFIG_BYTES) {
 			return c.json({ error: `payload exceeds ${MAX_CONFIG_BYTES} byte limit` }, 413);
 		}
 		return requirePermission("admin", authConfig)(c, next);
@@ -10457,12 +10459,30 @@ async function main() {
 	initFeatureFlags(AGENTS_DIR);
 	startUpdateTimer();
 
-	// Start HTTP server
+	// Start HTTP server with global body size limit (10MB) to prevent
+	// OOM from chunked-encoding requests that bypass content-length checks.
+	const REQUEST_BODY_LIMIT = 10 * 1_048_576;
+	const { createServer: nodeCreateServer } = await import("node:http");
+	const createBoundedServer: typeof nodeCreateServer = (...args: Parameters<typeof nodeCreateServer>) => {
+		const server = nodeCreateServer(...args);
+		server.on("request", (req) => {
+			let bytes = 0;
+			req.on("data", (chunk: Buffer) => {
+				bytes += chunk.length;
+				if (bytes > REQUEST_BODY_LIMIT) {
+					req.destroy();
+				}
+			});
+		});
+		return server;
+	};
+
 	serve(
 		{
 			fetch: app.fetch,
 			port: PORT,
 			hostname: BIND_HOST,
+			createServer: createBoundedServer,
 		},
 		(info) => {
 			logger.info("daemon", "Server listening", {

--- a/packages/daemon/src/secrets.ts
+++ b/packages/daemon/src/secrets.ts
@@ -222,15 +222,23 @@ export function deleteSecret(name: string): boolean {
 	return true;
 }
 
+// Reject commands containing shell metacharacters that could enable
+// injection when passed to sh -c. The endpoint is admin-gated, but
+// defense-in-depth prevents a compromised token from pivoting.
+const SHELL_META = /[;&|`$(){}[\]<>!\\]/;
+
 /**
  * Spawn a subprocess with one or more secrets injected as environment
  * variables. The agent only supplies references (env var names), never
  * the actual values.
  *
- * @param command  Shell command string to execute
+ * @param command  Shell command string to execute (no shell metacharacters allowed)
  * @param secretRefs  Map of env var name → secret name, e.g. { OPENAI_API_KEY: "OPENAI_API_KEY" }
  */
 export async function execWithSecrets(command: string, secretRefs: Record<string, string>): Promise<ExecResult> {
+	if (SHELL_META.test(command)) {
+		return { stdout: "", stderr: "command contains disallowed shell metacharacters", code: 1 };
+	}
 	// Resolve all secret values up front so we can redact them from output
 	const resolved: Record<string, string> = {};
 	for (const [envVar, secretName] of Object.entries(secretRefs)) {

--- a/packages/daemon/src/secrets.ts
+++ b/packages/daemon/src/secrets.ts
@@ -222,9 +222,9 @@ export function deleteSecret(name: string): boolean {
 	return true;
 }
 
-// Reject commands containing shell metacharacters that could enable
-// injection when passed to sh -c. The endpoint is admin-gated, but
-// defense-in-depth prevents a compromised token from pivoting.
+// Belt-and-suspenders: reject obvious shell metacharacters even though
+// we no longer use sh -c. Catches injection attempts early with a
+// clear error message before argv parsing.
 const SHELL_META = /[;&|`$(){}[\]<>!\\]/;
 
 /**
@@ -232,13 +232,24 @@ const SHELL_META = /[;&|`$(){}[\]<>!\\]/;
  * variables. The agent only supplies references (env var names), never
  * the actual values.
  *
- * @param command  Shell command string to execute (no shell metacharacters allowed)
+ * Uses direct argv execution (no shell) to eliminate glob/tilde/pipe
+ * expansion. The command string is parsed into argv tokens.
+ *
+ * @param command  Command string to execute (parsed as argv, no shell)
  * @param secretRefs  Map of env var name → secret name, e.g. { OPENAI_API_KEY: "OPENAI_API_KEY" }
  */
 export async function execWithSecrets(command: string, secretRefs: Record<string, string>): Promise<ExecResult> {
 	if (SHELL_META.test(command)) {
 		return { stdout: "", stderr: "command contains disallowed shell metacharacters", code: 1 };
 	}
+
+	// Parse command into argv — no shell, so no glob/tilde/pipe expansion
+	const argv = command.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g);
+	if (!argv || argv.length === 0) {
+		return { stdout: "", stderr: "empty command", code: 1 };
+	}
+	const cmd = argv.map((a) => a.replace(/^["']|["']$/g, ""));
+
 	// Resolve all secret values up front so we can redact them from output
 	const resolved: Record<string, string> = {};
 	for (const [envVar, secretName] of Object.entries(secretRefs)) {
@@ -257,10 +268,8 @@ export async function execWithSecrets(command: string, secretRefs: Record<string
 		return out;
 	}
 
-	const shell = process.platform === "win32" ? "cmd" : "sh";
-	const shellArgs = process.platform === "win32" ? ["/c", command] : ["-c", command];
 	return new Promise((resolve, reject) => {
-		const proc = spawn(shell, shellArgs, {
+		const proc = spawn(cmd[0], cmd.slice(1), {
 			env: { ...process.env, ...resolved },
 			stdio: "pipe",
 			windowsHide: true,

--- a/packages/tray/src-tauri/tauri.conf.json
+++ b/packages/tray/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
     ],
     "security": {
       "capabilities": ["default"],
-      "csp": "default-src 'self' ipc: http://ipc.localhost http://localhost:*; script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:*; style-src 'self' 'unsafe-inline' http://localhost:* https://fonts.googleapis.com; img-src 'self' http://localhost:* data: blob:; font-src 'self' http://localhost:* https://fonts.gstatic.com data:; connect-src ipc: http://ipc.localhost http://localhost:* ws://localhost:* https://fonts.googleapis.com https://fonts.gstatic.com; frame-src http://localhost:*"
+      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' http://localhost:3850; style-src 'self' 'unsafe-inline' http://localhost:3850 https://fonts.googleapis.com; img-src 'self' http://localhost:3850 data: blob:; font-src 'self' http://localhost:3850 https://fonts.gstatic.com data:; connect-src ipc: http://ipc.localhost http://localhost:3850 ws://localhost:3850 https://fonts.googleapis.com https://fonts.gstatic.com; frame-src http://localhost:3850"
     },
     "trayIcon": {
       "iconPath": "icons/signet-stopped.png",


### PR DESCRIPTION
## Summary

Addresses 14 of 15 findings from a security audit of the daemon, CLI, connectors, and tray app. One finding (#6 — scoped token read bypass) requires deeper design work and is tracked as a follow-up.

### Critical fixes
- **#1 Unauthenticated secret endpoints**: `/api/secrets/*` now gated behind `requirePermission("admin")` — previously allowed any localhost process to exec commands with injected secrets
- **#2 Unauthenticated git operations**: `/api/git/*` now admin-only — push, pull, remote config changes were wide open
- **#3 Unauthenticated 1Password**: covered by #1 — all 1P endpoints under `/api/secrets/*`
- **#4 Host header spoofing**: `isLocalhost()` now checks actual TCP `socket.remoteAddress` first, falls back to Host header only when socket unavailable
- **#5 Unrestricted CORS**: replaced `cors()` wildcard with explicit origin allowlist (localhost:3850, 5173, tauri)
- **#8 Shell injection in secret exec**: added metacharacter filter rejecting `;`, `|`, `$`, backticks, etc.
- **#9 Auth init race**: middleware now returns 503 if auth secret hasn't initialized yet

### High priority fixes
- **#7 Shell injection via OpenClaw restart**: parsed command as argv array instead of passing to `sh -c`
- **#10 Config writes**: admin auth + 1MB content size limit
- **#11 Git URL validation**: reject `file://` and bare paths, added `--single-branch`

### Medium fixes
- **#12**: Already fixed (checksum verification exists)
- **#13 TOCTOU config corruption**: added `atomicWriteJson()` to connector-base (write-to-tmp + rename), updated all 4 connectors
- **#14 Unsafe CSP**: removed `unsafe-inline`/`unsafe-eval` from script-src, restricted localhost to port 3850
- **#15 Symlink TOCTOU**: use `lstatSync` instead of `statSync` for source check

### Known follow-up
- **#6 Scoped token read bypass**: requires query-level scope injection into hybridRecall — needs its own design + PR

## Files changed (11)

| File | Changes |
|------|---------|
| `packages/daemon/src/daemon.ts` | Auth middleware for secrets, git, troubleshooter, config; CORS restriction; auth init guard; config size limit |
| `packages/daemon/src/auth/middleware.ts` | TCP peer address check in isLocalhost() |
| `packages/daemon/src/secrets.ts` | Shell metacharacter filter |
| `packages/cli/src/cli.ts` | Argv parsing for restart command; git URL validation |
| `packages/tray/src-tauri/tauri.conf.json` | Tightened CSP |
| `packages/core/src/symlinks.ts` | lstatSync for source check |
| `packages/connector-base/src/index.ts` | atomicWriteJson utility |
| `packages/connector-claude-code/src/index.ts` | Atomic config writes |
| `packages/connector-codex/src/index.ts` | Atomic config writes |
| `packages/connector-openclaw/src/index.ts` | Atomic config writes |
| `packages/connector-opencode/src/index.ts` | Atomic config writes |

## Test plan

- [x] `bun run build` — full build succeeds
- [x] `bun test` — 34 daemon tests pass (Bun crash on full suite is pre-existing)
- [x] `bun run typecheck` — only pre-existing opencode-plugin error
- [ ] Verify unauthenticated POST to `/api/secrets/exec` returns 403
- [ ] Verify unauthenticated POST to `/api/git/push` returns 403
- [ ] Verify CORS blocks requests from non-localhost origins
- [ ] Verify `execWithSecrets("echo foo; rm -rf /", ...)` rejects with metachar error
- [ ] Verify tray app loads without CSP violations on port 3850

🤖 Generated with [Claude Code](https://claude.com/claude-code)