### PR TITLE
fix: codex MCP config uses string command, not array

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Everything runs locally. You own the data. The agent is yours.
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | **Supported** | Hooks + CLAUDE.md sync |
 | [OpenCode](https://github.com/sst/opencode) | **Supported** | Plugin + AGENTS.md sync |
 | [OpenClaw](https://github.com/openclaw/openclaw) | **Supported** | Runtime plugin + NemoClaw compatible |
-| [Codex](https://github.com/openai/codex) | In progress | WIP |
+| [Codex](https://github.com/openai/codex) | **Supported** | Hooks + MCP server |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Planned | — |
 
 ## Install

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -28,13 +28,14 @@ function resolveSignetArgs(): string[] {
 	return ["signet"];
 }
 
-/** Resolve signet-mcp command as array for TOML inline array format. */
-function resolveSignetMcpArgs(): string[] {
-	if (process.platform !== "win32") return ["signet-mcp"];
+/** Resolve signet-mcp as { command, args } for Codex config.toml.
+ *  Codex expects `command` as a string and `args` as a separate array. */
+function resolveSignetMcp(): { command: string; args: string[] } {
+	if (process.platform !== "win32") return { command: "signet-mcp", args: [] };
 	const entry = process.argv[1] || "";
 	const mcpJs = join(entry, "..", "..", "bin", "mcp-stdio.js");
-	if (existsSync(mcpJs)) return [process.execPath, mcpJs];
-	return ["signet-mcp"];
+	if (existsSync(mcpJs)) return { command: process.execPath, args: [mcpJs] };
+	return { command: "signet-mcp", args: [] };
 }
 
 // ---------------------------------------------------------------------------
@@ -133,30 +134,37 @@ function removeSignetHooks(hooks: HooksJson): HooksJson {
 // MCP server registration (config.toml)
 // ---------------------------------------------------------------------------
 
-function tomlInlineArray(args: string[]): string {
-	// TOML inline array with literal strings (single-quoted, no escape processing)
-	// to safely handle Windows backslash paths
-	const items = args.map((a) => {
-		if (!a.includes("'")) return `'${a}'`;
-		return `"${a.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
-	});
-	return `[${items.join(", ")}]`;
+function tomlQuote(s: string): string {
+	// Use TOML literal strings (single-quoted) to avoid backslash escaping
+	if (!s.includes("'")) return `'${s}'`;
+	return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }
 
-function patchConfigToml(path: string, mcpArgs: string[]): boolean {
+function tomlInlineArray(items: string[]): string {
+	return `[${items.map(tomlQuote).join(", ")}]`;
+}
+
+function buildMcpBlock(mcp: { command: string; args: string[] }): string {
+	let block = `# Signet MCP server\n[mcp_servers.signet]\ncommand = ${tomlQuote(mcp.command)}\n`;
+	if (mcp.args.length > 0) {
+		block += `args = ${tomlInlineArray(mcp.args)}\n`;
+	}
+	return block;
+}
+
+function patchConfigToml(path: string, mcp: { command: string; args: string[] }): boolean {
 	const dir = join(path, "..");
 	mkdirSync(dir, { recursive: true });
 
-	const value = tomlInlineArray(mcpArgs);
 	if (!existsSync(path)) {
-		writeFileSync(path, `# Signet MCP server\n[mcp_servers.signet]\ncommand = ${value}\n`);
+		writeFileSync(path, buildMcpBlock(mcp));
 		return true;
 	}
 
 	const content = readFileSync(path, "utf-8");
 	if (content.includes("[mcp_servers.signet]")) return false;
 
-	const appended = content.trimEnd() + `\n\n# Signet MCP server\n[mcp_servers.signet]\ncommand = ${value}\n`;
+	const appended = content.trimEnd() + "\n\n" + buildMcpBlock(mcp);
 	writeFileSync(path, appended);
 	return true;
 }
@@ -245,8 +253,8 @@ export class CodexConnector extends BaseConnector {
 		}
 
 		// 3. Register MCP server in config.toml
-		const mcpArgs = resolveSignetMcpArgs();
-		if (patchConfigToml(this.getConfigPath(), mcpArgs)) {
+		const mcp = resolveSignetMcp();
+		if (patchConfigToml(this.getConfigPath(), mcp)) {
 			configsPatched.push(this.getConfigPath());
 		}
 

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -137,7 +137,7 @@ function removeSignetHooks(hooks: HooksJson): HooksJson {
 function tomlQuote(s: string): string {
 	// Use TOML literal strings (single-quoted) to avoid backslash escaping
 	if (!s.includes("'")) return `'${s}'`;
-	return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+	return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\r/g, "\\r").replace(/\n/g, "\\n")}"`;
 }
 
 function tomlInlineArray(items: string[]): string {


### PR DESCRIPTION
## Summary

- **Bug**: Codex connector wrote `command = ['signet-mcp']` (TOML array) but Codex CLI expects `command = 'signet-mcp'` (string). This broke **all** `codex` CLI operations with: `invalid type: sequence, expected a string in mcp_servers.signet.command`
- **Fix**: `patchConfigToml` now writes `command` as a quoted string with a separate `args` array for Windows multi-part commands
- **README**: Updated Codex from "In progress | WIP" to "Supported | Hooks + MCP server"

### Verified
```
$ codex mcp list
Name    Command     Args  Env  Cwd  Status   Auth
signet  signet-mcp  -     -    -    enabled  Unsupported
```

## Test plan

- [x] `bun run build` passes
- [x] `codex mcp list` succeeds with fixed format
- [ ] `signet setup` → select Codex → verify config.toml format
- [ ] Run a Codex session → verify MCP tools are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)