### PR TITLE
fix: resolve daemon path in published bundle

### DIFF
--- a/packages/cli/src/lib/runtime.ts
+++ b/packages/cli/src/lib/runtime.ts
@@ -193,10 +193,10 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR): Promise<boole
 	// __dirname already points at dist/ — check it first to handle the
 	// bundled layout where cliDir overshoots to the package root.
 	const daemonLocations = [
-		join(__dirname, "daemon.js"),
-		join(cliDir, "daemon.js"),
-		join(pkgDir, "..", "daemon", "dist", "daemon.js"),
-		join(pkgDir, "..", "daemon", "src", "daemon.ts"),
+		join(__dirname, "daemon.js"), // bundled: dist/daemon.js (same dir as cli.js)
+		join(cliDir, "daemon.js"), // dev only: src/daemon.js (dead in bundle — cliDir overshoots)
+		join(pkgDir, "..", "daemon", "dist", "daemon.js"), // dev: packages/daemon/dist/daemon.js
+		join(pkgDir, "..", "daemon", "src", "daemon.ts"), // dev: packages/daemon/src/daemon.ts
 	];
 
 	let daemonPath: string | null = null;

--- a/packages/cli/src/lib/runtime.ts
+++ b/packages/cli/src/lib/runtime.ts
@@ -188,7 +188,12 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR): Promise<boole
 	mkdirSync(daemonDir, { recursive: true });
 	mkdirSync(logDir, { recursive: true });
 
+	// In dev, runtime.ts lives in lib/ so cliDir (dirname(__dirname)) = src/.
+	// In the published bundle, everything flattens into dist/cli.js so
+	// __dirname already points at dist/ — check it first to handle the
+	// bundled layout where cliDir overshoots to the package root.
 	const daemonLocations = [
+		join(__dirname, "daemon.js"),
 		join(cliDir, "daemon.js"),
 		join(pkgDir, "..", "daemon", "dist", "daemon.js"),
 		join(pkgDir, "..", "daemon", "src", "daemon.ts"),


### PR DESCRIPTION
## Summary

- `signet daemon restart` fails with "Daemon not found" in v0.72.4 because the daemon path resolution overshoots in the published bundle
- `runtime.ts` defines `cliDir = dirname(__dirname)` which works in dev (navigates from `lib/` to `src/`) but in the published bundle where `cli.js` and `daemon.js` are siblings in `dist/`, `cliDir` resolves to the package root instead
- Adds `__dirname` as the first search path so the bundled layout finds `daemon.js` directly in `dist/`

## Test plan

- [x] `bun run build` succeeds — verified `__dirname5` (dist/) is checked first in bundled output
- [x] `bun test` — 932 tests pass
- [ ] Install from published package and verify `signet daemon restart` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)