### PR TITLE
fix: address 9 security and stability issues

### DIFF
--- a/packages/daemon/src/auth/tokens.ts
+++ b/packages/daemon/src/auth/tokens.ts
@@ -33,7 +33,9 @@ export function loadOrCreateSecret(secretPath: string): Buffer {
 	if (existsSync(secretPath)) {
 		const secret = readFileSync(secretPath);
 		if (secret.length !== SECRET_LENGTH) {
-			// Corrupted or truncated — regenerate
+			console.warn(
+				`[auth] Secret at ${secretPath} has unexpected length ${secret.length} — regenerating. All existing tokens will be invalidated.`,
+			);
 			const fresh = generateSecret();
 			writeFileSync(secretPath, fresh, { mode: 0o600 });
 			return fresh;

--- a/packages/daemon/src/auth/tokens.ts
+++ b/packages/daemon/src/auth/tokens.ts
@@ -27,9 +27,18 @@ export function generateSecret(): Buffer {
 	return randomBytes(32);
 }
 
+const SECRET_LENGTH = 32;
+
 export function loadOrCreateSecret(secretPath: string): Buffer {
 	if (existsSync(secretPath)) {
-		return readFileSync(secretPath);
+		const secret = readFileSync(secretPath);
+		if (secret.length !== SECRET_LENGTH) {
+			// Corrupted or truncated — regenerate
+			const fresh = generateSecret();
+			writeFileSync(secretPath, fresh, { mode: 0o600 });
+			return fresh;
+		}
+		return secret;
 	}
 	const dir = dirname(secretPath);
 	if (!existsSync(dir)) {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -105,7 +105,7 @@ import { closeSynthesisProvider, initSynthesisProvider } from "./synthesis-llm";
 import { closeWidgetProvider, initWidgetProvider } from "./widget-llm";
 import { type LogEntry, logger } from "./logger";
 import { migrateConfig } from "./config-migration";
-import { type EmbeddingConfig, loadMemoryConfig } from "./memory-config";
+import { type EmbeddingConfig, loadMemoryConfig, DEFAULT_OLLAMA_BASE_URL } from "./memory-config";
 import {
 	getAttributesForAspectFiltered,
 	getKnowledgeGraphForConstellation,
@@ -899,7 +899,8 @@ function normalizeLegacyEmbeddingsPayload(
 		return defaultLegacyEmbeddingsResponse(limit, offset, "Legacy export returned invalid payload");
 	}
 
-	const data = payload as Record<string, unknown>;
+	const data: Record<string, unknown> = Object.create(null);
+	Object.assign(data, payload);
 	const rawEmbeddings = Array.isArray(data.embeddings) ? data.embeddings : [];
 	const embeddings = rawEmbeddings
 		.map((entry) => normalizeLegacyEmbeddingRow(entry, withVectors))
@@ -952,12 +953,24 @@ async function runLegacyEmbeddingsExport(
 	}
 
 	return await new Promise<LegacyEmbeddingsResponse>((resolve) => {
+		const timeout = withVectors ? 120000 : 30000;
 		const proc = spawn("python3", args, {
 			cwd: AGENTS_DIR,
 			stdio: "pipe",
-			timeout: withVectors ? 120000 : 30000,
 			windowsHide: true,
 		});
+
+		// Bun's spawn() silently ignores `timeout` — enforce manually
+		const timer = setTimeout(() => {
+			proc.kill();
+			resolve(
+				defaultLegacyEmbeddingsResponse(
+					limit,
+					offset,
+					`Legacy embeddings export timed out after ${timeout}ms`,
+				),
+			);
+		}, timeout);
 
 		let stdout = "";
 		let stderr = "";
@@ -971,6 +984,7 @@ async function runLegacyEmbeddingsExport(
 		});
 
 		proc.on("close", (code) => {
+			clearTimeout(timer);
 			if (code !== 0) {
 				resolve(
 					defaultLegacyEmbeddingsResponse(
@@ -1002,6 +1016,7 @@ async function runLegacyEmbeddingsExport(
 		});
 
 		proc.on("error", (error) => {
+			clearTimeout(timer);
 			resolve(defaultLegacyEmbeddingsResponse(limit, offset, error.message));
 		});
 	});
@@ -1049,7 +1064,8 @@ async function checkEmbeddingProvider(cfg: EmbeddingConfig): Promise<EmbeddingSt
 				// Native unavailable — check if ollama is available as fallback
 				logger.warn("embedding", `Native provider unavailable: ${nativeStatus.error ?? "unknown"}`);
 				try {
-					const ollamaRes = await fetch("http://127.0.0.1:11434/api/tags", {
+					const ollamaUrl = process.env.OLLAMA_HOST || DEFAULT_OLLAMA_BASE_URL;
+					const ollamaRes = await fetch(`${ollamaUrl.replace(/\/$/, "")}/api/tags`, {
 						method: "GET",
 						signal: AbortSignal.timeout(3000),
 					});

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -94,6 +94,7 @@ import {
 	resolveEmbeddingBaseUrl,
 	resolveEmbeddingApiKey,
 	setNativeFallbackToOllama,
+	resolveOllamaUrl,
 } from "./embedding-fetch";
 import { detectDrift } from "./predictor-comparison";
 import { getPredictorState } from "./predictor-state";
@@ -105,7 +106,7 @@ import { closeSynthesisProvider, initSynthesisProvider } from "./synthesis-llm";
 import { closeWidgetProvider, initWidgetProvider } from "./widget-llm";
 import { type LogEntry, logger } from "./logger";
 import { migrateConfig } from "./config-migration";
-import { type EmbeddingConfig, loadMemoryConfig, DEFAULT_OLLAMA_BASE_URL } from "./memory-config";
+import { type EmbeddingConfig, loadMemoryConfig } from "./memory-config";
 import {
 	getAttributesForAspectFiltered,
 	getKnowledgeGraphForConstellation,
@@ -1064,8 +1065,7 @@ async function checkEmbeddingProvider(cfg: EmbeddingConfig): Promise<EmbeddingSt
 				// Native unavailable — check if ollama is available as fallback
 				logger.warn("embedding", `Native provider unavailable: ${nativeStatus.error ?? "unknown"}`);
 				try {
-					const ollamaUrl = process.env.OLLAMA_HOST || DEFAULT_OLLAMA_BASE_URL;
-					const ollamaRes = await fetch(`${ollamaUrl.replace(/\/$/, "")}/api/tags`, {
+					const ollamaRes = await fetch(`${resolveOllamaUrl().replace(/\/$/, "")}/api/tags`, {
 						method: "GET",
 						signal: AbortSignal.timeout(3000),
 					});

--- a/packages/daemon/src/db-accessor.ts
+++ b/packages/daemon/src/db-accessor.ts
@@ -398,6 +398,7 @@ function createAccessor(writeConn: Database): DbAccessor {
 			return pooled;
 		}
 		if (readInUse.size >= MAX_READ_CONNECTIONS) {
+			console.warn(`[db] Read connection limit exceeded (${readInUse.size}/${MAX_READ_CONNECTIONS})`);
 			throw new Error("Read connection limit exceeded");
 		}
 		const conn = new Database(dbPath, { readonly: true });

--- a/packages/daemon/src/db-accessor.ts
+++ b/packages/daemon/src/db-accessor.ts
@@ -380,6 +380,7 @@ function backfillVecEmbeddings(db: Database): void {
 // ---------------------------------------------------------------------------
 
 const READ_POOL_SIZE = 4;
+const MAX_READ_CONNECTIONS = 16;
 
 function createAccessor(writeConn: Database): DbAccessor {
 	let closed = false;
@@ -395,6 +396,9 @@ function createAccessor(writeConn: Database): DbAccessor {
 		if (pooled) {
 			readInUse.add(pooled);
 			return pooled;
+		}
+		if (readInUse.size >= MAX_READ_CONNECTIONS) {
+			throw new Error("Read connection limit exceeded");
 		}
 		const conn = new Database(dbPath, { readonly: true });
 		conn.exec("PRAGMA busy_timeout = 5000");

--- a/packages/daemon/src/embedding-fetch.ts
+++ b/packages/daemon/src/embedding-fetch.ts
@@ -1,7 +1,11 @@
 import type { EmbeddingConfig } from "./memory-config";
-import { DEFAULT_OPENAI_BASE_URL } from "./memory-config";
+import { DEFAULT_OPENAI_BASE_URL, DEFAULT_OLLAMA_BASE_URL } from "./memory-config";
 import { logger } from "./logger";
 import { getSecret } from "./secrets.js";
+
+function resolveOllamaUrl(): string {
+	return process.env.OLLAMA_HOST || DEFAULT_OLLAMA_BASE_URL;
+}
 
 let cachedNativeEmbed: ((text: string) => Promise<number[]>) | null = null;
 let nativeFallbackToOllama = false;
@@ -75,7 +79,7 @@ export async function fetchEmbedding(
 			if (nativeFallbackToOllama) {
 				return await fetchOllamaEmbedding(
 					text,
-					"http://localhost:11434",
+					resolveOllamaUrl(),
 					"nomic-embed-text",
 				);
 			}
@@ -97,7 +101,7 @@ export async function fetchEmbedding(
 				try {
 					const result = await fetchOllamaEmbedding(
 						text,
-						"http://localhost:11434",
+						resolveOllamaUrl(),
 						"nomic-embed-text",
 					);
 					if (result !== null) {

--- a/packages/daemon/src/embedding-fetch.ts
+++ b/packages/daemon/src/embedding-fetch.ts
@@ -4,7 +4,15 @@ import { logger } from "./logger";
 import { getSecret } from "./secrets.js";
 
 function resolveOllamaUrl(): string {
-	return process.env.OLLAMA_HOST || DEFAULT_OLLAMA_BASE_URL;
+	const raw = process.env.OLLAMA_HOST;
+	if (!raw) return DEFAULT_OLLAMA_BASE_URL;
+	try {
+		new URL(raw);
+		return raw;
+	} catch {
+		logger.warn("embedding", `OLLAMA_HOST is not a valid URL ("${raw}"), falling back to default`);
+		return DEFAULT_OLLAMA_BASE_URL;
+	}
 }
 
 let cachedNativeEmbed: ((text: string) => Promise<number[]>) | null = null;

--- a/packages/daemon/src/embedding-fetch.ts
+++ b/packages/daemon/src/embedding-fetch.ts
@@ -3,7 +3,7 @@ import { DEFAULT_OPENAI_BASE_URL, DEFAULT_OLLAMA_BASE_URL } from "./memory-confi
 import { logger } from "./logger";
 import { getSecret } from "./secrets.js";
 
-function resolveOllamaUrl(): string {
+export function resolveOllamaUrl(): string {
 	const raw = process.env.OLLAMA_HOST;
 	if (!raw) return DEFAULT_OLLAMA_BASE_URL;
 	try {

--- a/packages/daemon/src/memory-search.ts
+++ b/packages/daemon/src/memory-search.ts
@@ -142,11 +142,11 @@ function buildFilterClause(params: RecallParams): FilterClause {
  * characters to prevent syntax errors.
  */
 function sanitizeFtsQuery(raw: string): string {
-	// Split on OR (preserved as FTS5 operator) and whitespace
+	// All tokens are treated as literals — FTS5 operators (OR, AND, NOT)
+	// are NOT preserved to prevent semantic manipulation of recall results
 	return raw
 		.split(/\s+/)
 		.map((token) => {
-			if (token === "OR" || token === "AND" || token === "NOT") return token;
 			// Strip characters that are FTS5 syntax: colons, quotes, parens, asterisks, carets
 			const cleaned = token.replace(/[":()^*]/g, "").trim();
 			if (!cleaned) return null;

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -15,12 +15,7 @@ export default defineConfig({
   integrations: [
     mdx(),
     react(),
-    sitemap({
-      serialize(item) {
-        item.lastmod = new Date();
-        return item;
-      },
-    }),
+    sitemap(),
     graphIndex(),
   ],
   vite: {

--- a/web/functions/api/waitlist.ts
+++ b/web/functions/api/waitlist.ts
@@ -2,10 +2,20 @@ interface Env {
 	RESEND_API_KEY: string;
 }
 
+const ALLOWED_ORIGINS = [
+	'https://signetai.sh',
+	'https://www.signetai.sh',
+];
+
+function isAllowedOrigin(origin: string): boolean {
+	if (!origin) return false;
+	return ALLOWED_ORIGINS.includes(origin);
+}
+
 export const onRequestPost: PagesFunction<Env> = async (context) => {
 	const origin = context.request.headers.get('Origin') ?? '';
 	const headers = {
-		'Access-Control-Allow-Origin': origin,
+		'Access-Control-Allow-Origin': isAllowedOrigin(origin) ? origin : '',
 		'Content-Type': 'application/json',
 	};
 
@@ -56,7 +66,7 @@ export const onRequestOptions: PagesFunction = async (context) => {
 	return new Response(null, {
 		status: 204,
 		headers: {
-			'Access-Control-Allow-Origin': origin,
+			'Access-Control-Allow-Origin': isAllowedOrigin(origin) ? origin : '',
 			'Access-Control-Allow-Methods': 'POST, OPTIONS',
 			'Access-Control-Allow-Headers': 'Content-Type',
 		},

--- a/web/functions/api/waitlist.ts
+++ b/web/functions/api/waitlist.ts
@@ -7,15 +7,15 @@ const ALLOWED_ORIGINS = [
 	'https://www.signetai.sh',
 ];
 
-function isAllowedOrigin(origin: string): boolean {
-	if (!origin) return false;
-	return ALLOWED_ORIGINS.includes(origin);
+function corsHeaders(origin: string): Record<string, string> {
+	if (!origin || !ALLOWED_ORIGINS.includes(origin)) return {};
+	return { 'Access-Control-Allow-Origin': origin };
 }
 
 export const onRequestPost: PagesFunction<Env> = async (context) => {
 	const origin = context.request.headers.get('Origin') ?? '';
 	const headers = {
-		'Access-Control-Allow-Origin': isAllowedOrigin(origin) ? origin : '',
+		...corsHeaders(origin),
 		'Content-Type': 'application/json',
 	};
 
@@ -66,7 +66,7 @@ export const onRequestOptions: PagesFunction = async (context) => {
 	return new Response(null, {
 		status: 204,
 		headers: {
-			'Access-Control-Allow-Origin': isAllowedOrigin(origin) ? origin : '',
+			...corsHeaders(origin),
 			'Access-Control-Allow-Methods': 'POST, OPTIONS',
 			'Access-Control-Allow-Headers': 'Content-Type',
 		},

--- a/web/functions/api/waitlist.ts
+++ b/web/functions/api/waitlist.ts
@@ -51,11 +51,12 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 	}
 };
 
-export const onRequestOptions: PagesFunction = async () => {
+export const onRequestOptions: PagesFunction = async (context) => {
+	const origin = context.request.headers.get('Origin') ?? '';
 	return new Response(null, {
 		status: 204,
 		headers: {
-			'Access-Control-Allow-Origin': '*',
+			'Access-Control-Allow-Origin': origin,
 			'Access-Control-Allow-Methods': 'POST, OPTIONS',
 			'Access-Control-Allow-Headers': 'Content-Type',
 		},

--- a/web/src/lib/remark-wikilinks.ts
+++ b/web/src/lib/remark-wikilinks.ts
@@ -15,6 +15,14 @@ import type { Root, Text } from "mdast";
 import type { Plugin } from "unified";
 import { visit } from "unist-util-visit";
 
+function escapeHtml(str: string): string {
+	return str
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;");
+}
+
 // All known doc slugs (filename without .md, lowercased)
 const DOC_SLUGS = new Set([
 	"agents",
@@ -138,17 +146,17 @@ const remarkWikilinks: Plugin<[], Root> = () => {
 				const resolved = resolveWikilink(rawSlug);
 				if (resolved) {
 					outgoingLinks.push(resolved.slug);
-					const text = displayText ?? defaultDisplayText(rawSlug);
+					const text = escapeHtml(displayText ?? defaultDisplayText(rawSlug));
 					children.push({
 						type: "html",
-						value: `<a href="${resolved.url}" class="wikilink" data-collection="${resolved.collection}">${text}</a>`,
+						value: `<a href="${escapeHtml(resolved.url)}" class="wikilink" data-collection="${escapeHtml(resolved.collection)}">${text}</a>`,
 					});
 				} else {
 					// Broken link — render with broken class
-					const text = displayText ?? defaultDisplayText(rawSlug);
+					const text = escapeHtml(displayText ?? defaultDisplayText(rawSlug));
 					children.push({
 						type: "html",
-						value: `<a class="wikilink broken" title="Page not found: ${rawSlug}">${text}</a>`,
+						value: `<a class="wikilink broken" title="Page not found: ${escapeHtml(rawSlug)}">${text}</a>`,
 					});
 				}
 


### PR DESCRIPTION
## Summary

- **Subprocess timeout** (CRITICAL): Bun's `spawn()` silently ignores the `timeout` option — replaced with manual `setTimeout` + `proc.kill()` with proper cleanup via `clearTimeout` on all exit paths
- **HTML injection** (HIGH): Wikilink renderer interpolated user-controlled markdown content (`rawSlug`, `text`) directly into raw HTML — added `escapeHtml()` for all user-controlled values (`<`, `>`, `&`, `"`)
- **Non-deterministic sitemap** (HIGH): Every build stamped ALL sitemap entries with `new Date()`, causing fake freshness signals to crawlers and non-reproducible builds — removed the `serialize` override entirely
- **Hardcoded Ollama endpoint** (HIGH): `http://localhost:11434` was hardcoded in 3 locations across `embedding-fetch.ts` and `daemon.ts` — now resolves via `OLLAMA_HOST` env var with fallback to `DEFAULT_OLLAMA_BASE_URL`
- **Secret storage validation** (HIGH): `loadOrCreateSecret()` blindly loaded any file as the HMAC signing key regardless of length — added length validation that regenerates corrupted/truncated secrets
- **CORS wildcard** (MEDIUM): OPTIONS preflight handler used `'*'` while POST handler correctly reflected request origin — aligned both to use request origin
- **FTS5 operator injection** (MEDIUM): `sanitizeFtsQuery()` preserved `OR`, `AND`, `NOT` from raw user input, allowing semantic manipulation of recall results — now treats all tokens as literals
- **Connection pool** (MEDIUM): Read pool created unlimited new connections when exhausted — added `MAX_READ_CONNECTIONS = 16` cap with fail-fast error
- **Type assertion** (MEDIUM): `normalizeLegacyEmbeddingsPayload()` used `as Record<string, unknown>` cast — replaced with `Object.create(null)` + `Object.assign` for safe property copy

### Declined fix

- **YAML frontmatter parser** (#5 in review): The claimed bug (`indexOf(":")` truncating values at colons) is incorrect — `slice(colonIdx + 1)` correctly takes everything after the first colon. `title: "My Project: Overview"` parses correctly as `"My Project: Overview"`, not `"My Project"`.

## Test plan

- [x] `bun run build` — all packages build successfully
- [x] `bun run typecheck` — no new type errors (pre-existing opencode-plugin error unchanged)
- [x] `bun test` — 834 pass, 98 fail (all failures pre-existing, none in changed files)
- [x] `bun test packages/daemon/src/auth/` — 69 pass, 0 fail
- [x] `bun test packages/daemon/src/memory-config.test.ts` — 42 pass, 0 fail
- [x] `web/` build — passes compilation (pre-existing content schema error in `signet-os-spec.md` unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)