### PR TITLE
fix(cli) support localhost and tailscale daemon hosting

### DIFF
--- a/packages/cli/dashboard/src/lib/api.ts
+++ b/packages/cli/dashboard/src/lib/api.ts
@@ -3,14 +3,13 @@
  * Handles communication with the Signet daemon
  */
 
-import { marked } from "marked";
 import type { ModelRegistryEntry } from "@signet/core";
+import { marked } from "marked";
 
 // When served by the daemon, use relative URLs.
 // When served by Tauri (frontendDist) or Vite dev server, use absolute URL.
 const isDev = import.meta.env.DEV;
-const isTauri =
-	typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+const isTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 export const API_BASE = isDev || isTauri ? "http://localhost:3850" : "";
 
 export interface Memory {
@@ -107,6 +106,8 @@ export interface DaemonStatus {
 	startedAt: string;
 	port: number;
 	host: string;
+	bindHost: string;
+	networkMode: "localhost" | "tailscale";
 	agentsDir: string;
 	memoryDb: boolean;
 	activeSessions?: number;
@@ -203,19 +204,13 @@ export async function fetchSessions(): Promise<SessionListResponse> {
 	}
 }
 
-export async function toggleSessionBypass(
-	key: string,
-	enabled: boolean,
-): Promise<SessionBypassResponse | null> {
+export async function toggleSessionBypass(key: string, enabled: boolean): Promise<SessionBypassResponse | null> {
 	try {
-		const response = await fetch(
-			`${API_BASE}/api/sessions/${encodeURIComponent(key)}/bypass`,
-			{
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ enabled }),
-			},
-		);
+		const response = await fetch(`${API_BASE}/api/sessions/${encodeURIComponent(key)}/bypass`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ enabled }),
+		});
 		if (!response.ok) return null;
 		return await response.json();
 	} catch {
@@ -295,11 +290,7 @@ export async function getMemories(limit = 100, offset = 0): Promise<{ memories: 
 function buildTimelineFallback(memories: readonly Memory[]): MemoryTimelineResponse {
 	const MS_PER_DAY = 24 * 60 * 60 * 1000;
 	const now = new Date();
-	const nowStart = new Date(
-		now.getFullYear(),
-		now.getMonth(),
-		now.getDate(),
-	).getTime();
+	const nowStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
 
 	const ranges = [
 		{ eraIndex: 0 as const, rangeKey: "today" as const, label: "Today" as const, lookbackDays: 1 },
@@ -327,18 +318,13 @@ function buildTimelineFallback(memories: readonly Memory[]): MemoryTimelineRespo
 	for (const memory of memories) {
 		const ts = Date.parse(memory.created_at);
 		if (!Number.isFinite(ts)) continue;
-		const matchingBuckets = buckets.filter(
-			(entry) => ts >= entry.start && ts <= entry.end,
-		);
+		const matchingBuckets = buckets.filter((entry) => ts >= entry.start && ts <= entry.end);
 		if (matchingBuckets.length === 0) continue;
 
 		for (const bucket of matchingBuckets) {
 			bucket.memoriesAdded += 1;
 			if (memory.pinned) bucket.pinned += 1;
-			if (
-				typeof memory.importance === "number" &&
-				Number.isFinite(memory.importance)
-			) {
+			if (typeof memory.importance === "number" && Number.isFinite(memory.importance)) {
 				bucket.importanceSum += memory.importance;
 				bucket.importanceCount += 1;
 			}
@@ -428,9 +414,7 @@ function buildTimelineFallback(memories: readonly Memory[]): MemoryTimelineRespo
 			recovered: 0,
 			avgImportance:
 				bucket.importanceCount > 0
-					? Number(
-							Math.min(1, Math.max(0, bucket.importanceSum / bucket.importanceCount)).toFixed(3),
-						)
+					? Number(Math.min(1, Math.max(0, bucket.importanceSum / bucket.importanceCount)).toFixed(3))
 					: 0,
 			pinned: bucket.pinned,
 			typeBreakdown: toMetrics(bucket.typeMap),
@@ -976,17 +960,15 @@ export async function syncConnectorFull(id: string): Promise<SyncResult> {
 export async function resyncConnectors(): Promise<BulkConnectorSyncResult> {
 	try {
 		const response = await fetch(`${API_BASE}/api/connectors/resync`, { method: "POST" });
-		const body = (await response.json().catch(() => null)) as
-			| {
-					status?: unknown;
-					total?: unknown;
-					started?: unknown;
-					alreadySyncing?: unknown;
-					unsupported?: unknown;
-					failed?: unknown;
-					error?: unknown;
-			  }
-			| null;
+		const body = (await response.json().catch(() => null)) as {
+			status?: unknown;
+			total?: unknown;
+			started?: unknown;
+			alreadySyncing?: unknown;
+			unsupported?: unknown;
+			failed?: unknown;
+			error?: unknown;
+		} | null;
 
 		const status = typeof body?.status === "string" ? body.status : response.ok ? "ok" : "error";
 		const total = typeof body?.total === "number" ? body.total : 0;
@@ -994,12 +976,7 @@ export async function resyncConnectors(): Promise<BulkConnectorSyncResult> {
 		const alreadySyncing = typeof body?.alreadySyncing === "number" ? body.alreadySyncing : 0;
 		const unsupported = typeof body?.unsupported === "number" ? body.unsupported : 0;
 		const failed = typeof body?.failed === "number" ? body.failed : 0;
-		const error =
-			typeof body?.error === "string"
-				? body.error
-				: response.ok
-					? undefined
-					: `HTTP ${response.status}`;
+		const error = typeof body?.error === "string" ? body.error : response.ok ? undefined : `HTTP ${response.status}`;
 
 		return {
 			status,
@@ -2044,13 +2021,15 @@ export interface EntityHealth {
 	trend: "improving" | "stable" | "declining";
 }
 
-export async function getKnowledgeEntities(filters: {
-	type?: string;
-	query?: string;
-	limit?: number;
-	offset?: number;
-	agentId?: string;
-} = {}): Promise<{ items: KnowledgeEntityListItem[]; limit: number; offset: number }> {
+export async function getKnowledgeEntities(
+	filters: {
+		type?: string;
+		query?: string;
+		limit?: number;
+		offset?: number;
+		agentId?: string;
+	} = {},
+): Promise<{ items: KnowledgeEntityListItem[]; limit: number; offset: number }> {
 	try {
 		const params = new URLSearchParams();
 		if (filters.type) params.set("type", filters.type);
@@ -2078,10 +2057,7 @@ export async function getKnowledgeEntity(id: string, agentId = "default"): Promi
 	}
 }
 
-export async function getKnowledgeAspects(
-	entityId: string,
-	agentId = "default",
-): Promise<KnowledgeAspectWithCounts[]> {
+export async function getKnowledgeAspects(entityId: string, agentId = "default"): Promise<KnowledgeAspectWithCounts[]> {
 	try {
 		const res = await fetch(
 			`${API_BASE}/api/knowledge/entities/${encodeURIComponent(entityId)}/aspects?agent_id=${encodeURIComponent(agentId)}`,
@@ -2161,13 +2137,9 @@ export async function getKnowledgeTraversalStatus(): Promise<TraversalStatusSnap
 	}
 }
 
-export async function getPinnedKnowledgeEntities(
-	agentId = "default",
-): Promise<PinnedEntity[]> {
+export async function getPinnedKnowledgeEntities(agentId = "default"): Promise<PinnedEntity[]> {
 	try {
-		const res = await fetch(
-			`${API_BASE}/api/knowledge/entities/pinned?agent_id=${encodeURIComponent(agentId)}`,
-		);
+		const res = await fetch(`${API_BASE}/api/knowledge/entities/pinned?agent_id=${encodeURIComponent(agentId)}`);
 		if (!res.ok) throw new Error("Failed to fetch pinned entities");
 		return await res.json();
 	} catch {
@@ -2191,10 +2163,7 @@ export async function pinKnowledgeEntity(
 	}
 }
 
-export async function unpinKnowledgeEntity(
-	id: string,
-	agentId = "default",
-): Promise<boolean> {
+export async function unpinKnowledgeEntity(id: string, agentId = "default"): Promise<boolean> {
 	try {
 		const res = await fetch(
 			`${API_BASE}/api/knowledge/entities/${encodeURIComponent(id)}/pin?agent_id=${encodeURIComponent(agentId)}`,
@@ -2220,9 +2189,7 @@ export async function getKnowledgeEntityHealth(
 		if (typeof filters.minComparisons === "number") {
 			params.set("min_comparisons", String(filters.minComparisons));
 		}
-		const res = await fetch(
-			`${API_BASE}/api/knowledge/entities/health?${params.toString()}`,
-		);
+		const res = await fetch(`${API_BASE}/api/knowledge/entities/health?${params.toString()}`);
 		if (!res.ok) throw new Error("Failed to fetch entity health");
 		return await res.json();
 	} catch {
@@ -2324,12 +2291,8 @@ export interface MarkdownDoc {
 }
 
 function extractReadmeOverview(content: string): string {
-	const localFirstMatch = content.match(
-		/Signet is a local-first[\s\S]*?without ever reading their values\./,
-	);
-	const whyMatch = content.match(
-		/Most AI tools build memory silos\.[\s\S]*?unless you configure it to\./,
-	);
+	const localFirstMatch = content.match(/Signet is a local-first[\s\S]*?without ever reading their values\./);
+	const whyMatch = content.match(/Most AI tools build memory silos\.[\s\S]*?unless you configure it to\./);
 
 	const normalizeParagraph = (text: string): string =>
 		text
@@ -2355,9 +2318,7 @@ async function fetchRawGithubMarkdown(
 	transform?: (content: string) => string,
 ): Promise<MarkdownDoc | null> {
 	try {
-		const res = await fetch(
-			`https://raw.githubusercontent.com/Signet-AI/signetai/main/${filename}`,
-		);
+		const res = await fetch(`https://raw.githubusercontent.com/Signet-AI/signetai/main/${filename}`);
 		if (!res.ok) return null;
 		const raw = await res.text();
 		const content = transform ? transform(raw) : raw;
@@ -2529,9 +2490,10 @@ export async function installMcp(options: InstallMcpOptions): Promise<InstallMcp
 		});
 		if (!response.ok) {
 			const body = await response.json().catch(() => ({}));
-			const error = typeof (body as Record<string, unknown>).error === "string"
-				? (body as Record<string, unknown>).error as string
-				: `Install failed (HTTP ${response.status})`;
+			const error =
+				typeof (body as Record<string, unknown>).error === "string"
+					? ((body as Record<string, unknown>).error as string)
+					: `Install failed (HTTP ${response.status})`;
 			return { ok: false, widgetId: "", manifest: null, error };
 		}
 		return await response.json();
@@ -2544,5 +2506,3 @@ export async function installMcp(options: InstallMcpOptions): Promise<InstallMcp
 		};
 	}
 }
-
-

--- a/packages/cli/dashboard/src/lib/components/tabs/SettingsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/SettingsTab.svelte
@@ -1,154 +1,162 @@
 <script lang="ts">
-	import type { ConfigFile } from "$lib/api";
-	import { st } from "$lib/stores/settings.svelte";
-	import { setSettingsDirty } from "$lib/stores/unsaved-changes.svelte";
-	import { untrack } from "svelte";
-	import AgentSection from "./settings/AgentSection.svelte";
-	import AuthSection from "./settings/AuthSection.svelte";
-	import EmbeddingsSection from "./settings/EmbeddingsSection.svelte";
-	import MemorySection from "./settings/MemorySection.svelte";
-	import PipelineSection from "./settings/PipelineSection.svelte";
-	import SearchSection from "./settings/SearchSection.svelte";
-	import TrustSection from "./settings/TrustSection.svelte";
-	import AppearanceSection from "./settings/AppearanceSection.svelte";
-	import IdentityPanel from "$lib/components/config/IdentityPanel.svelte";
-	import PageBanner from "$lib/components/layout/PageBanner.svelte";
-	import TabGroupBar from "$lib/components/layout/TabGroupBar.svelte";
-	import { ENGINE_TAB_ITEMS } from "$lib/components/layout/page-headers";
-	import { nav } from "$lib/stores/navigation.svelte";
-	import { focusEngineTab } from "$lib/stores/tab-group-focus.svelte";
-	import { invalidateAll } from "$app/navigation";
+import { invalidateAll } from "$app/navigation";
+import type { ConfigFile } from "$lib/api";
+import type IdentityPanel from "$lib/components/config/IdentityPanel.svelte";
+import PageBanner from "$lib/components/layout/PageBanner.svelte";
+import TabGroupBar from "$lib/components/layout/TabGroupBar.svelte";
+import { ENGINE_TAB_ITEMS } from "$lib/components/layout/page-headers";
+import { nav } from "$lib/stores/navigation.svelte";
+import { st } from "$lib/stores/settings.svelte";
+import { focusEngineTab } from "$lib/stores/tab-group-focus.svelte";
+import { setSettingsDirty } from "$lib/stores/unsaved-changes.svelte";
+import { untrack } from "svelte";
+import AgentSection from "./settings/AgentSection.svelte";
+import AppearanceSection from "./settings/AppearanceSection.svelte";
+import AuthSection from "./settings/AuthSection.svelte";
+import EmbeddingsSection from "./settings/EmbeddingsSection.svelte";
+import MemorySection from "./settings/MemorySection.svelte";
+import NetworkSection from "./settings/NetworkSection.svelte";
+import PipelineSection from "./settings/PipelineSection.svelte";
+import SearchSection from "./settings/SearchSection.svelte";
+import TrustSection from "./settings/TrustSection.svelte";
 
-	interface Props {
-		configFiles: ConfigFile[];
+interface Props {
+	configFiles: ConfigFile[];
+}
+
+const { configFiles }: Props = $props();
+
+interface SectionDef {
+	id: string;
+	title: string;
+	paths: string[][];
+	source: "agent" | "config";
+}
+
+const sectionDefs: SectionDef[] = [
+	{
+		id: "agent",
+		title: "Agent",
+		source: "agent",
+		paths: [["agent", "name"], ["agent", "description"], ["harnesses"]],
+	},
+	{
+		id: "network",
+		title: "Network",
+		source: "agent",
+		paths: [["network"]],
+	},
+	{
+		id: "embeddings",
+		title: "Embeddings",
+		source: "config",
+		paths: [["embedding"], ["memory", "embeddings"], ["embeddings"]],
+	},
+	{
+		id: "memory",
+		title: "Memory",
+		source: "config",
+		paths: [["memory", "session_budget"], ["memory", "current_md_budget"], ["memory", "decay_rate"], ["paths"]],
+	},
+	{
+		id: "search",
+		title: "Search",
+		source: "config",
+		paths: [["search"]],
+	},
+	{
+		id: "pipeline",
+		title: "Pipeline",
+		source: "agent",
+		paths: [["memory", "pipelineV2"]],
+	},
+	{
+		id: "trust",
+		title: "Trust",
+		source: "agent",
+		paths: [["trust"]],
+	},
+	{
+		id: "auth",
+		title: "Auth",
+		source: "config",
+		paths: [["auth"]],
+	},
+	{
+		id: "appearance",
+		title: "Appearance",
+		source: "config",
+		paths: [],
+	},
+];
+
+const tabBtn =
+	"px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.06em] rounded-md transition-colors duration-150 border-none cursor-pointer whitespace-nowrap";
+const tabActive = `${tabBtn} text-[var(--sig-highlight)] bg-[color-mix(in_srgb,var(--sig-highlight),var(--sig-bg)_90%)] border border-[color-mix(in_srgb,var(--sig-highlight),transparent_85%)]`;
+const tabInactive = `${tabBtn} bg-transparent text-[var(--sig-text-muted)] hover:text-[var(--sig-highlight)] hover:bg-[color-mix(in_srgb,var(--sig-highlight),var(--sig-bg)_94%)]`;
+
+const activeSection = $state("agent");
+let discardDialogOpen = $state(false);
+const identityPanel = $state<IdentityPanel | null>(null);
+const identityDirty = $state(false);
+
+const sections = $derived(
+	sectionDefs.map((def) => ({
+		id: def.id,
+		title: def.title,
+		dirty: st.isAnyPathDirty(def.source, def.paths),
+	})),
+);
+
+const combinedDirty = $derived(st.isDirty || identityDirty);
+
+$effect(() => {
+	const files = configFiles;
+	untrack(() => st.init(files));
+});
+
+$effect(() => {
+	setSettingsDirty(combinedDirty);
+	return () => {
+		setSettingsDirty(false);
+	};
+});
+
+async function saveAll(): Promise<void> {
+	const promises: Promise<void>[] = [];
+	if (st.isDirty) promises.push(st.save());
+	if (identityDirty && identityPanel) promises.push(identityPanel.save());
+	await Promise.all(promises);
+	// Refresh page-level configFiles so IdentityPanel gets fresh data
+	await invalidateAll();
+}
+
+function handleDiscard(): void {
+	discardDialogOpen = true;
+}
+
+function confirmDiscard(): void {
+	st.reset();
+	identityPanel?.discard();
+	discardDialogOpen = false;
+}
+
+function handleGlobalKey(e: KeyboardEvent): void {
+	if (e.key === "s" && (e.metaKey || e.ctrlKey)) {
+		e.preventDefault();
+		if (combinedDirty && !st.saving) saveAll();
+		return;
 	}
+}
 
-	const { configFiles }: Props = $props();
-
-	interface SectionDef {
-		id: string;
-		title: string;
-		paths: string[][];
-		source: "agent" | "config";
+function formatSavedAt(raw: string | null): string {
+	if (!raw) return "";
+	try {
+		return `Last saved ${new Date(raw).toLocaleTimeString()}`;
+	} catch {
+		return "";
 	}
-
-	const sectionDefs: SectionDef[] = [
-		{
-			id: "agent",
-			title: "Agent",
-			source: "agent",
-			paths: [["agent", "name"], ["agent", "description"], ["harnesses"]],
-		},
-		{
-			id: "embeddings",
-			title: "Embeddings",
-			source: "config",
-			paths: [["embedding"], ["memory", "embeddings"], ["embeddings"]],
-		},
-		{
-			id: "memory",
-			title: "Memory",
-			source: "config",
-			paths: [["memory", "session_budget"], ["memory", "current_md_budget"], ["memory", "decay_rate"], ["paths"]],
-		},
-		{
-			id: "search",
-			title: "Search",
-			source: "config",
-			paths: [["search"]],
-		},
-		{
-			id: "pipeline",
-			title: "Pipeline",
-			source: "agent",
-			paths: [["memory", "pipelineV2"]],
-		},
-		{
-			id: "trust",
-			title: "Trust",
-			source: "agent",
-			paths: [["trust"]],
-		},
-		{
-			id: "auth",
-			title: "Auth",
-			source: "config",
-			paths: [["auth"]],
-		},
-		{
-			id: "appearance",
-			title: "Appearance",
-			source: "config",
-			paths: [],
-		},
-	];
-
-	const tabBtn = "px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.06em] rounded-md transition-colors duration-150 border-none cursor-pointer whitespace-nowrap";
-	const tabActive = `${tabBtn} text-[var(--sig-highlight)] bg-[color-mix(in_srgb,var(--sig-highlight),var(--sig-bg)_90%)] border border-[color-mix(in_srgb,var(--sig-highlight),transparent_85%)]`;
-	const tabInactive = `${tabBtn} bg-transparent text-[var(--sig-text-muted)] hover:text-[var(--sig-highlight)] hover:bg-[color-mix(in_srgb,var(--sig-highlight),var(--sig-bg)_94%)]`;
-
-	let activeSection = $state("agent");
-	let discardDialogOpen = $state(false);
-	let identityPanel = $state<IdentityPanel | null>(null);
-	let identityDirty = $state(false);
-
-	let sections = $derived(
-		sectionDefs.map((def) => ({
-			id: def.id,
-			title: def.title,
-			dirty: st.isAnyPathDirty(def.source, def.paths),
-		})),
-	);
-
-	let combinedDirty = $derived(st.isDirty || identityDirty);
-
-	$effect(() => {
-		const files = configFiles;
-		untrack(() => st.init(files));
-	});
-
-	$effect(() => {
-		setSettingsDirty(combinedDirty);
-		return () => {
-			setSettingsDirty(false);
-		};
-	});
-
-	async function saveAll(): Promise<void> {
-		const promises: Promise<void>[] = [];
-		if (st.isDirty) promises.push(st.save());
-		if (identityDirty && identityPanel) promises.push(identityPanel.save());
-		await Promise.all(promises);
-		// Refresh page-level configFiles so IdentityPanel gets fresh data
-		await invalidateAll();
-	}
-
-	function handleDiscard(): void {
-		discardDialogOpen = true;
-	}
-
-	function confirmDiscard(): void {
-		st.reset();
-		identityPanel?.discard();
-		discardDialogOpen = false;
-	}
-
-	function handleGlobalKey(e: KeyboardEvent): void {
-		if (e.key === "s" && (e.metaKey || e.ctrlKey)) {
-			e.preventDefault();
-			if (combinedDirty && !st.saving) saveAll();
-			return;
-		}
-	}
-
-	function formatSavedAt(raw: string | null): string {
-		if (!raw) return "";
-		try {
-			return `Last saved ${new Date(raw).toLocaleTimeString()}`;
-		} catch {
-			return "";
-		}
-	}
+}
 </script>
 
 <svelte:window onkeydown={handleGlobalKey} />
@@ -187,6 +195,8 @@
 			<div class="section-content">
 				{#if activeSection === "agent"}
 					<AgentSection />
+				{:else if activeSection === "network"}
+					<NetworkSection />
 				{:else if activeSection === "embeddings"}
 					<EmbeddingsSection />
 				{:else if activeSection === "search"}

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/NetworkSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/NetworkSection.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+import FormField from "$lib/components/config/FormField.svelte";
+import FormSection from "$lib/components/config/FormSection.svelte";
+import * as Select from "$lib/components/ui/select/index.js";
+import { st } from "$lib/stores/settings.svelte";
+import { NETWORK_MODES } from "@signet/core";
+
+const selectTriggerClass =
+	"font-[family-name:var(--font-mono)] text-[11px] text-[var(--sig-text)] bg-[var(--sig-bg)] border-[var(--sig-border-strong)] rounded-lg w-full h-auto min-h-[30px] px-2 py-[5px] box-border focus-visible:border-[var(--sig-accent)]";
+const selectContentClass =
+	"font-[family-name:var(--font-mono)] text-[11px] bg-[var(--sig-bg)] text-[var(--sig-text)] border-[var(--sig-border-strong)] rounded-lg";
+const selectItemClass = "font-[family-name:var(--font-mono)] text-[11px] rounded-lg";
+
+function setMode(value: string | undefined): void {
+	st.aSetStr(["network", "mode"], value ?? "localhost");
+}
+
+function modeLabel(value: string): string {
+	if (value === "tailscale") return "tailscale";
+	return "localhost";
+}
+</script>
+
+{#if st.agentFile}
+	<FormSection description="Daemon bind mode. localhost keeps Signet on 127.0.0.1 only. tailscale keeps localhost working and also binds 0.0.0.0 so other devices on your tailnet can reach it. Restart the daemon after saving.">
+		<FormField label="Hosting mode" description="If auth.mode is local, anyone on your trusted tailnet can access the dashboard and API when tailscale mode is enabled.">
+			<Select.Root
+				type="single"
+				value={st.aStr(["network", "mode"]) || "localhost"}
+				onValueChange={setMode}
+			>
+				<Select.Trigger class={selectTriggerClass}>
+					{modeLabel(st.aStr(["network", "mode"]) || "localhost")}
+				</Select.Trigger>
+				<Select.Content class={selectContentClass}>
+					{#each NETWORK_MODES as value (value)}
+						<Select.Item class={selectItemClass} value={value} label={modeLabel(value)} />
+					{/each}
+				</Select.Content>
+			</Select.Root>
+		</FormField>
+	</FormSection>
+{/if}

--- a/packages/cli/src/commands/app.ts
+++ b/packages/cli/src/commands/app.ts
@@ -6,6 +6,7 @@ interface SetupOptions {
 	nonInteractive?: boolean;
 	name?: string;
 	description?: string;
+	networkMode?: string;
 	harness?: string[];
 	embeddingProvider?: string;
 	embeddingModel?: string;
@@ -45,6 +46,7 @@ export function registerAppCommands(program: Command, deps: AppDeps): void {
 		.option("--non-interactive", "Run setup without prompts")
 		.option("--name <name>", "Agent name (non-interactive mode)")
 		.option("--description <description>", "Agent description (non-interactive mode)")
+		.option("--network-mode <mode>", "Daemon network mode in non-interactive mode (localhost, tailscale)")
 		.option(
 			"--harness <harness>",
 			"Harness to configure (repeatable or comma-separated: claude-code, codex, opencode, openclaw)",

--- a/packages/cli/src/features/configure.ts
+++ b/packages/cli/src/features/configure.ts
@@ -1,7 +1,7 @@
-import { checkbox, confirm, input, select } from "@inquirer/prompts";
-import chalk from "chalk";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { checkbox, confirm, input, select } from "@inquirer/prompts";
+import chalk from "chalk";
 
 interface Deps {
 	readonly agentsDir: string;
@@ -11,6 +11,7 @@ interface Deps {
 
 const sections = [
 	{ value: "agent", name: "👤 Agent identity (name, description)" },
+	{ value: "network", name: "🌐 Network access" },
 	{ value: "harnesses", name: "[link] Harnesses (AI platforms)" },
 	{ value: "embedding", name: "🧠 Embedding provider" },
 	{ value: "search", name: "🔍 Search settings" },
@@ -53,6 +54,15 @@ export async function configureAgent(deps: Deps): Promise<void> {
 			yaml = await configureIdentity(yaml);
 			writeFileSync(path, yaml);
 			console.log(chalk.green("  ✓ Agent identity updated"));
+			console.log();
+			continue;
+		}
+
+		if (section === "network") {
+			yaml = await configureNetwork(yaml);
+			writeFileSync(path, yaml);
+			console.log(chalk.green("  ✓ Network settings updated"));
+			console.log(chalk.dim("    Restart the daemon to apply the new bind mode."));
 			console.log();
 			continue;
 		}
@@ -107,6 +117,19 @@ function readValue(yaml: string, key: string, fallback: string): string {
 	return match ? match[1].trim().replace(/^["']|["']$/g, "") : fallback;
 }
 
+function readNetworkMode(yaml: string): string {
+	const match = yaml.match(/^network:\n(?: {2}.+\n)*? {2}mode:\s*(.+)$/m);
+	return match ? match[1].trim().replace(/^["']|["']$/g, "") : "localhost";
+}
+
+function writeNetworkSection(yaml: string, mode: string): string {
+	const block = `network:\n  mode: ${mode}\n`;
+	if (yaml.match(/^network:\n(?: {2}.+\n)*/m)) {
+		return yaml.replace(/^network:\n(?: {2}.+\n)*/m, block);
+	}
+	return `${yaml.trimEnd()}\n\n${block}`;
+}
+
 async function configureIdentity(yaml: string): Promise<string> {
 	const name = await input({
 		message: "Agent name:",
@@ -122,6 +145,19 @@ async function configureIdentity(yaml: string): Promise<string> {
 	next = next.replace(/^(\s*description:)\s*.+$/m, `$1 "${description}"`);
 	next = next.replace(/^(\s*updated:)\s*.+$/m, `$1 "${new Date().toISOString()}"`);
 	return next;
+}
+
+async function configureNetwork(yaml: string): Promise<string> {
+	const mode = await select({
+		message: "How should the daemon be hosted?",
+		choices: [
+			{ value: "localhost", name: "localhost only (127.0.0.1)" },
+			{ value: "tailscale", name: "Tailscale / remote (bind 0.0.0.0)" },
+		],
+		default: readNetworkMode(yaml),
+	});
+
+	return writeNetworkSection(yaml, mode);
 }
 
 async function configureHarnesses(yaml: string, deps: Deps): Promise<string> {

--- a/packages/cli/src/features/daemon.ts
+++ b/packages/cli/src/features/daemon.ts
@@ -1,13 +1,14 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { confirm } from "@inquirer/prompts";
 import { OpenClawConnector } from "@signet/connector-openclaw";
 import { detectSchema, ensureUnifiedSchema, parseSimpleYaml, runMigrations } from "@signet/core";
 import chalk from "chalk";
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
-import { spawnSync } from "node:child_process";
 import open from "open";
 import ora from "ora";
 import type { LogOptions, PathOptions, RestartOptions } from "../commands/shared.js";
+import { daemonAccessLines } from "../lib/network.js";
 import Database from "../sqlite.js";
 
 interface DaemonStatus {
@@ -15,6 +16,9 @@ interface DaemonStatus {
 	readonly pid: number | null;
 	readonly uptime: number | null;
 	readonly version: string | null;
+	readonly host: string | null;
+	readonly bindHost: string | null;
+	readonly networkMode: string | null;
 }
 
 interface LogEntry {
@@ -122,7 +126,9 @@ export async function migrateSchema(options: PathOptions, deps: Deps): Promise<v
 		printMigrationErrors(result.errors);
 
 		if (result.migrated) {
-			console.log(chalk.green(`  ✓ Migrated ${result.memoriesMigrated} memories from ${result.fromSchema} to ${result.toSchema}`));
+			console.log(
+				chalk.green(`  ✓ Migrated ${result.memoriesMigrated} memories from ${result.fromSchema} to ${result.toSchema}`),
+			);
 		} else {
 			console.log(chalk.dim("  No migration needed"));
 		}
@@ -189,7 +195,10 @@ export async function doStart(options: PathOptions, deps: Deps): Promise<void> {
 	const started = await deps.startDaemon(basePath);
 	if (started) {
 		spinner.succeed("Daemon started");
-		console.log(chalk.dim(`  Dashboard: http://localhost:${deps.defaultPort}`));
+		const status = await deps.getDaemonStatus();
+		for (const line of daemonAccessLines(deps.defaultPort, status)) {
+			console.log(chalk.dim(`  ${line}`));
+		}
 		return;
 	}
 
@@ -234,7 +243,10 @@ export async function doRestart(options: RestartOptions, deps: Deps): Promise<vo
 
 	if (started) {
 		spinner.succeed(running ? "Daemon restarted" : "Daemon started");
-		console.log(chalk.dim(`  Dashboard: http://localhost:${deps.defaultPort}`));
+		const status = await deps.getDaemonStatus();
+		for (const line of daemonAccessLines(deps.defaultPort, status)) {
+			console.log(chalk.dim(`  ${line}`));
+		}
 	} else {
 		spinner.fail("Failed to restart daemon");
 		return;

--- a/packages/cli/src/features/health.ts
+++ b/packages/cli/src/features/health.ts
@@ -1,6 +1,7 @@
+import { join } from "node:path";
 import { detectSchema, getMissingIdentityFiles, hasValidIdentity } from "@signet/core";
 import chalk from "chalk";
-import { join } from "node:path";
+import { daemonAccessLines } from "../lib/network.js";
 import Database from "../sqlite.js";
 
 interface Existing {
@@ -15,6 +16,9 @@ interface DaemonStatus {
 	readonly pid: number | null;
 	readonly uptime: number | null;
 	readonly version: string | null;
+	readonly host: string | null;
+	readonly bindHost: string | null;
+	readonly networkMode: string | null;
 }
 
 interface DbReport {
@@ -116,10 +120,7 @@ export async function getStatusReport(basePath: string, deps: StatusDeps): Promi
 	}
 }
 
-export async function showStatus(
-	options: { path?: string; json?: boolean },
-	deps: StatusDeps,
-): Promise<void> {
+export async function showStatus(options: { path?: string; json?: boolean }, deps: StatusDeps): Promise<void> {
 	const basePath = deps.normalizeAgentPath(deps.extractPathOption(options) ?? deps.agentsDir);
 	const report = await getStatusReport(basePath, deps);
 
@@ -143,7 +144,9 @@ export async function showStatus(
 		console.log(`  ${chalk.green("●")} Daemon ${chalk.green("running")}${chalk.dim(ver)}`);
 		console.log(chalk.dim(`    PID: ${report.daemon.pid}`));
 		console.log(chalk.dim(`    Uptime: ${deps.formatUptime(report.daemon.uptime || 0)}`));
-		console.log(chalk.dim(`    Dashboard: http://localhost:${deps.defaultPort}`));
+		for (const line of daemonAccessLines(deps.defaultPort, report.daemon)) {
+			console.log(chalk.dim(`    ${line}`));
+		}
 	} else {
 		console.log(`  ${chalk.red("○")} Daemon ${chalk.red("stopped")}`);
 	}
@@ -181,10 +184,7 @@ export async function showStatus(
 	console.log();
 }
 
-export async function showDoctor(
-	options: { path?: string; json?: boolean },
-	deps: StatusDeps,
-): Promise<void> {
+export async function showDoctor(options: { path?: string; json?: boolean }, deps: StatusDeps): Promise<void> {
 	const basePath = deps.normalizeAgentPath(deps.extractPathOption(options) ?? deps.agentsDir);
 	const report = await getStatusReport(basePath, deps);
 	const findings = getDoctorFindings(report);

--- a/packages/cli/src/features/setup-fresh.ts
+++ b/packages/cli/src/features/setup-fresh.ts
@@ -1,15 +1,11 @@
-import {
-	ensureUnifiedSchema,
-	formatYaml,
-	resolvePrimaryPackageManager,
-	runMigrations,
-} from "@signet/core";
-import chalk from "chalk";
 import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { OpenClawConnector } from "@signet/connector-openclaw";
+import { ensureUnifiedSchema, formatYaml, resolvePrimaryPackageManager, runMigrations } from "@signet/core";
+import chalk from "chalk";
 import open from "open";
 import ora from "ora";
-import { OpenClawConnector } from "@signet/connector-openclaw";
+import { daemonAccessLines } from "../lib/network.js";
 import Database from "../sqlite.js";
 import { readErr, readRecord } from "./setup-shared.js";
 import type { FreshSetupConfig, SetupDeps } from "./setup-types.js";
@@ -81,6 +77,9 @@ export async function runFreshSetup(cfg: FreshSetupConfig, deps: SetupDeps): Pro
 				description: cfg.agentDescription,
 				created: now,
 				updated: now,
+			},
+			network: {
+				mode: cfg.networkMode,
 			},
 			harnesses: cfg.harnesses,
 			install: {
@@ -205,7 +204,10 @@ export async function runFreshSetup(cfg: FreshSetupConfig, deps: SetupDeps): Pro
 
 		if (daemonStarted) {
 			console.log();
-			console.log(chalk.green(`  ● Daemon running at http://localhost:${deps.DEFAULT_PORT}`));
+			console.log(chalk.green("  ● Daemon running"));
+			for (const line of daemonAccessLines(deps.DEFAULT_PORT, cfg.networkMode)) {
+				console.log(chalk.dim(`    ${line}`));
+			}
 		}
 
 		console.log();

--- a/packages/cli/src/features/setup-migrate.ts
+++ b/packages/cli/src/features/setup-migrate.ts
@@ -1,24 +1,33 @@
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { confirm } from "@inquirer/prompts";
 import {
 	Database as CoreDatabase,
+	type ImportResult,
+	type SetupDetection,
+	type SkillsResult,
 	ensureUnifiedSchema,
 	formatYaml,
 	importMemoryLogs,
 	resolvePrimaryPackageManager,
 	runMigrations,
-	type ImportResult,
-	type SetupDetection,
-	type SkillsResult,
 	unifySkills,
 } from "@signet/core";
+import { readNetworkMode } from "@signet/core";
 import chalk from "chalk";
-import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import open from "open";
 import ora from "ora";
+import { daemonAccessLines } from "../lib/network.js";
 import Database from "../sqlite.js";
-import { getEmbeddingDimensions, readErr, readRecord, readString, type EmbeddingProviderChoice, type ExtractionProviderChoice } from "./setup-shared.js";
+import {
+	type EmbeddingProviderChoice,
+	type ExtractionProviderChoice,
+	getEmbeddingDimensions,
+	readErr,
+	readRecord,
+	readString,
+} from "./setup-shared.js";
 import type { SetupDeps } from "./setup-types.js";
 
 export async function runExistingSetupWizard(
@@ -94,9 +103,13 @@ export async function runExistingSetupWizard(
 			schema: "signet/v1",
 			agent: {
 				name: agentName,
-				description: readString(existingConfig.description) ?? readString(existingAgent.description) ?? "Personal AI assistant",
+				description:
+					readString(existingConfig.description) ?? readString(existingAgent.description) ?? "Personal AI assistant",
 				created: now,
 				updated: now,
+			},
+			network: {
+				mode: readNetworkMode(existingConfig),
 			},
 			harnesses: detectedHarnesses,
 			install: {
@@ -125,7 +138,9 @@ export async function runExistingSetupWizard(
 		};
 
 		if (options?.embeddingProvider && options.embeddingProvider !== "none") {
-			const model = options.embeddingModel || (options.embeddingProvider === "openai" ? "text-embedding-3-small" : "nomic-embed-text");
+			const model =
+				options.embeddingModel ||
+				(options.embeddingProvider === "openai" ? "text-embedding-3-small" : "nomic-embed-text");
 			config.embedding = {
 				provider: options.embeddingProvider,
 				model,
@@ -247,7 +262,9 @@ export async function runExistingSetupWizard(
 		}
 
 		if (skillsResult && (skillsResult.imported > 0 || skillsResult.symlinked > 0)) {
-			console.log(chalk.dim(`  Skills unified: ${skillsResult.imported} imported, ${skillsResult.symlinked} symlinked`));
+			console.log(
+				chalk.dim(`  Skills unified: ${skillsResult.imported} imported, ${skillsResult.symlinked} symlinked`),
+			);
 		}
 
 		if (configuredHarnesses.length > 0) {
@@ -260,7 +277,10 @@ export async function runExistingSetupWizard(
 
 		if (daemonStarted) {
 			console.log();
-			console.log(chalk.green(`  ● Daemon running at http://localhost:${deps.DEFAULT_PORT}`));
+			console.log(chalk.green("  ● Daemon running"));
+			for (const line of daemonAccessLines(deps.DEFAULT_PORT, readNetworkMode(config))) {
+				console.log(chalk.dim(`    ${line}`));
+			}
 		}
 
 		if (options?.skipGit !== true && gitEnabled) {

--- a/packages/cli/src/features/setup-types.ts
+++ b/packages/cli/src/features/setup-types.ts
@@ -6,6 +6,7 @@ export interface SetupWizardOptions {
 	nonInteractive?: boolean;
 	name?: string;
 	description?: string;
+	networkMode?: string;
 	harness?: string[];
 	embeddingProvider?: string;
 	embeddingModel?: string;
@@ -56,6 +57,7 @@ export interface FreshSetupConfig {
 	readonly basePath: string;
 	readonly agentName: string;
 	readonly agentDescription: string;
+	readonly networkMode: "localhost" | "tailscale";
 	readonly harnesses: string[];
 	readonly openclawRuntimePath: OpenClawRuntimeChoice;
 	readonly configureOpenClawWs: boolean;

--- a/packages/cli/src/features/setup.ts
+++ b/packages/cli/src/features/setup.ts
@@ -1,20 +1,22 @@
-import { checkbox, confirm, input, select } from "@inquirer/prompts";
-import { OpenClawConnector } from "@signet/connector-openclaw";
-import {
-	parseSimpleYaml,
-	type SetupDetection,
-} from "@signet/core";
-import chalk from "chalk";
 import { copyFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { checkbox, confirm, input, select } from "@inquirer/prompts";
+import { OpenClawConnector } from "@signet/connector-openclaw";
+import { NETWORK_MODES, type NetworkMode, type SetupDetection, parseSimpleYaml, readNetworkMode } from "@signet/core";
+import chalk from "chalk";
 import open from "open";
 import ora from "ora";
-import { hasCommand, preflightOllamaEmbedding, promptOpenAIEmbeddingModel } from "./setup-providers.js";
 import { runFreshSetup } from "./setup-fresh.js";
+import { runExistingSetupWizard } from "./setup-migrate.js";
+import { hasCommand, preflightOllamaEmbedding, promptOpenAIEmbeddingModel } from "./setup-providers.js";
 import {
 	EMBEDDING_PROVIDER_CHOICES,
 	EXTRACTION_PROVIDER_CHOICES,
+	type EmbeddingProviderChoice,
+	type ExtractionProviderChoice,
+	type HarnessChoice,
 	OPENCLAW_RUNTIME_CHOICES,
+	type OpenClawRuntimeChoice,
 	SETUP_HARNESS_CHOICES,
 	detectPreferredOpenClawWorkspace,
 	failNonInteractiveSetup,
@@ -26,12 +28,7 @@ import {
 	readHarnesses,
 	readRecord,
 	readString,
-	type EmbeddingProviderChoice,
-	type ExtractionProviderChoice,
-	type HarnessChoice,
-	type OpenClawRuntimeChoice,
 } from "./setup-shared.js";
-import { runExistingSetupWizard } from "./setup-migrate.js";
 import type { SetupDeps, SetupWizardOptions } from "./setup-types.js";
 
 export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps): Promise<void> {
@@ -91,8 +88,10 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 	const existingPipeline = readRecord(existingMemory.pipelineV2);
 	const existingExtraction = readRecord(existingPipeline.extraction);
 	const existingName = readString(existingConfig.name) ?? readString(existingAgent.name) ?? "My Agent";
-	const existingDesc = readString(existingConfig.description) ?? readString(existingAgent.description) ?? "Personal AI assistant";
+	const existingDesc =
+		readString(existingConfig.description) ?? readString(existingAgent.description) ?? "Personal AI assistant";
 	const existingHarnesses = readHarnesses(existingConfig.harnesses);
+	const existingNetworkMode = readNetworkMode(existingConfig);
 
 	if (existing.agentsDir && existing.memoryDb) {
 		console.log(chalk.green("  ✓ Existing Signet installation detected"));
@@ -344,6 +343,29 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 				default: existingDesc,
 			});
 
+	let networkMode: NetworkMode;
+	if (nonInteractive) {
+		networkMode = deps.normalizeChoice(options.networkMode, NETWORK_MODES) ?? existingNetworkMode;
+	} else {
+		console.log();
+		networkMode = await select({
+			message: "How should the daemon be hosted?",
+			choices: [
+				{
+					value: "localhost",
+					name: "localhost only (default)",
+					description: "Bind to 127.0.0.1 only",
+				},
+				{
+					value: "tailscale",
+					name: "Tailscale / remote",
+					description: "Keep localhost working and also bind 0.0.0.0",
+				},
+			],
+			default: existingNetworkMode,
+		});
+	}
+
 	const requestedEmbeddingProvider = deps.normalizeChoice(options.embeddingProvider, EMBEDDING_PROVIDER_CHOICES);
 	const requestedExtractionProvider = deps.normalizeChoice(options.extractionProvider, EXTRACTION_PROVIDER_CHOICES);
 
@@ -383,7 +405,9 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 	} else if (embeddingProvider === "ollama") {
 		if (nonInteractive) {
 			const configuredModel =
-				deps.normalizeStringValue(options.embeddingModel) || deps.normalizeStringValue(existingEmbedding.model) || "nomic-embed-text";
+				deps.normalizeStringValue(options.embeddingModel) ||
+				deps.normalizeStringValue(existingEmbedding.model) ||
+				"nomic-embed-text";
 			embeddingModel = configuredModel;
 			embeddingDimensions = getEmbeddingDimensions(configuredModel);
 		} else {
@@ -420,7 +444,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 	const existingSearchBalance = deps.parseSearchBalanceValue(existingSearch.alpha);
 	const requestedSearchBalance = deps.parseSearchBalanceValue(options.searchBalance);
 	const searchBalance = nonInteractive
-		? requestedSearchBalance ?? existingSearchBalance ?? 0.7
+		? (requestedSearchBalance ?? existingSearchBalance ?? 0.7)
 		: await select({
 				message: "Search style (semantic vs keyword matching):",
 				choices: [
@@ -642,6 +666,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		basePath,
 		agentName,
 		agentDescription,
+		networkMode,
 		harnesses,
 		openclawRuntimePath,
 		configureOpenClawWs,

--- a/packages/cli/src/lib/network.test.ts
+++ b/packages/cli/src/lib/network.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { daemonAccessLines, resolveDaemonNetwork } from "./network.js";
+
+const DIRS: string[] = [];
+
+afterEach(() => {
+	for (const dir of DIRS.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+function makeDir(): string {
+	const dir = join(tmpdir(), `signet-network-test-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+	mkdirSync(dir, { recursive: true });
+	DIRS.push(dir);
+	return dir;
+}
+
+describe("resolveDaemonNetwork", () => {
+	test("uses tailscale mode from agent.yaml while keeping localhost as the primary host", () => {
+		const dir = makeDir();
+		writeFileSync(join(dir, "agent.yaml"), "network:\n  mode: tailscale\n");
+
+		const net = resolveDaemonNetwork(dir, {});
+
+		expect(net.host).toBe("127.0.0.1");
+		expect(net.bind).toBe("0.0.0.0");
+		expect(net.mode).toBe("tailscale");
+	});
+
+	test("prefers explicit environment overrides", () => {
+		const dir = makeDir();
+		writeFileSync(join(dir, "agent.yaml"), "network:\n  mode: tailscale\n");
+
+		const net = resolveDaemonNetwork(dir, {
+			SIGNET_HOST: "127.0.0.1",
+			SIGNET_BIND: "127.0.0.1",
+		});
+
+		expect(net.host).toBe("127.0.0.1");
+		expect(net.bind).toBe("127.0.0.1");
+		expect(net.mode).toBe("localhost");
+	});
+});
+
+describe("daemonAccessLines", () => {
+	test("includes a tailnet hint when the daemon is remotely bound", () => {
+		expect(daemonAccessLines(3850, { bindHost: "0.0.0.0" })).toEqual([
+			"Dashboard: http://localhost:3850",
+			"Tailnet: this machine's Tailscale IP on port 3850 (bind 0.0.0.0)",
+		]);
+	});
+});

--- a/packages/cli/src/lib/network.ts
+++ b/packages/cli/src/lib/network.ts
@@ -1,0 +1,72 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	type NetworkMode,
+	networkModeFromBindHost,
+	parseSimpleYaml,
+	readNetworkMode,
+	resolveNetworkBinding,
+} from "@signet/core";
+
+export interface DaemonNetworkInfo {
+	readonly bindHost?: string | null;
+	readonly networkMode?: string | null;
+}
+
+function readEnv(value: string | undefined): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+export function readConfiguredNetworkMode(dir: string): NetworkMode {
+	for (const name of ["agent.yaml", "AGENT.yaml"]) {
+		const path = join(dir, name);
+		if (!existsSync(path)) continue;
+		try {
+			return readNetworkMode(parseSimpleYaml(readFileSync(path, "utf8")));
+		} catch {
+			// Ignore malformed config and keep scanning fallbacks.
+		}
+	}
+
+	return "localhost";
+}
+
+export function resolveDaemonNetwork(
+	dir: string,
+	env: Record<string, string | undefined>,
+): {
+	readonly host: string;
+	readonly bind: string;
+	readonly mode: NetworkMode;
+} {
+	const cfg = resolveNetworkBinding(readConfiguredNetworkMode(dir));
+	const host = readEnv(env.SIGNET_HOST) ?? cfg.host;
+	const bind = readEnv(env.SIGNET_BIND) ?? (readEnv(env.SIGNET_HOST) ? host : cfg.bind);
+
+	return {
+		host,
+		bind,
+		mode: networkModeFromBindHost(bind),
+	};
+}
+
+export function daemonAccessLines(port: number, info?: DaemonNetworkInfo | NetworkMode | null): string[] {
+	const mode =
+		typeof info === "string"
+			? info
+			: typeof info?.networkMode === "string"
+				? info.networkMode === "tailscale"
+					? "tailscale"
+					: "localhost"
+				: info?.bindHost
+					? networkModeFromBindHost(info.bindHost)
+					: "localhost";
+
+	const lines = [`Dashboard: http://localhost:${port}`];
+	if (mode === "tailscale") {
+		lines.push(`Tailnet: this machine's Tailscale IP on port ${port} (bind 0.0.0.0)`);
+	}
+	return lines;
+}

--- a/packages/cli/src/lib/runtime.ts
+++ b/packages/cli/src/lib/runtime.ts
@@ -1,11 +1,23 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { appendFileSync, chmodSync, closeSync, existsSync, mkdirSync, openSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+	appendFileSync,
+	chmodSync,
+	closeSync,
+	existsSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	rmSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseSimpleYaml } from "@signet/core";
 import chalk from "chalk";
+import { resolveDaemonNetwork } from "./network.js";
 
 export const AGENTS_DIR = process.env.SIGNET_PATH || join(homedir(), ".agents");
 export const DEFAULT_PORT = 3850;
@@ -16,6 +28,9 @@ interface DaemonInstance {
 	readonly pid: number | null;
 	readonly uptime: number | null;
 	readonly version: string | null;
+	readonly host: string | null;
+	readonly bindHost: string | null;
+	readonly networkMode: string | null;
 }
 
 const __filename = fileURLToPath(import.meta.url);
@@ -58,12 +73,18 @@ async function getDaemonInstances(): Promise<DaemonInstance[]> {
 						pid?: number;
 						uptime?: number;
 						version?: string;
+						host?: string;
+						bindHost?: string;
+						networkMode?: string;
 					};
 					return {
 						baseUrl,
 						pid: data.pid ?? null,
 						uptime: data.uptime ?? null,
 						version: data.version ?? null,
+						host: data.host ?? null,
+						bindHost: data.bindHost ?? null,
+						networkMode: data.networkMode ?? null,
 					};
 				}
 			} catch {
@@ -75,6 +96,9 @@ async function getDaemonInstances(): Promise<DaemonInstance[]> {
 				pid: null,
 				uptime: null,
 				version: null,
+				host: null,
+				bindHost: null,
+				networkMode: null,
 			};
 		}),
 	);
@@ -90,6 +114,9 @@ export async function getDaemonStatus(): Promise<{
 	pid: number | null;
 	uptime: number | null;
 	version: string | null;
+	host: string | null;
+	bindHost: string | null;
+	networkMode: string | null;
 }> {
 	const instances = await getDaemonInstances();
 	if (instances.length > 0) {
@@ -99,10 +126,21 @@ export async function getDaemonStatus(): Promise<{
 			pid: preferred.pid,
 			uptime: preferred.uptime,
 			version: preferred.version,
+			host: preferred.host,
+			bindHost: preferred.bindHost,
+			networkMode: preferred.networkMode,
 		};
 	}
 
-	return { running: false, pid: null, uptime: null, version: null };
+	return {
+		running: false,
+		pid: null,
+		uptime: null,
+		version: null,
+		host: null,
+		bindHost: null,
+		networkMode: null,
+	};
 }
 
 async function downloadDaemonBinary(): Promise<void> {
@@ -150,15 +188,15 @@ async function downloadDaemonBinary(): Promise<void> {
 		const buf = Buffer.from(bytes);
 		const actualHash = sha256(buf);
 		if (actualHash !== expectedHash) {
-			process.stdout.write(` skipped (checksum mismatch — possible tampering)\n`);
+			process.stdout.write(" skipped (checksum mismatch — possible tampering)\n");
 			return;
 		}
 
 		writeFileSync(dest, buf);
 		if (plat !== "win32") chmodSync(dest, 0o755);
-		process.stdout.write(` done\n`);
+		process.stdout.write(" done\n");
 	} catch {
-		process.stdout.write(` skipped (download failed)\n`);
+		process.stdout.write(" skipped (download failed)\n");
 		try {
 			unlinkSync(dest);
 		} catch {
@@ -182,6 +220,8 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR): Promise<boole
 	} catch {
 		// Non-fatal — agent.yaml may not exist yet.
 	}
+
+	const net = resolveDaemonNetwork(agentsDir, process.env);
 
 	const daemonDir = join(agentsDir, ".daemon");
 	const logDir = join(daemonDir, "logs");
@@ -229,7 +269,8 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR): Promise<boole
 		env: {
 			...process.env,
 			SIGNET_PORT: DEFAULT_PORT.toString(),
-			SIGNET_HOST: process.env.SIGNET_HOST || "127.0.0.1",
+			SIGNET_HOST: net.host,
+			SIGNET_BIND: net.bind,
 			SIGNET_PATH: agentsDir,
 		},
 	});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -79,6 +79,14 @@ export { parseManifest, generateManifest } from "./manifest";
 export { parseSoul, generateSoul } from "./soul";
 export { parseMemory, generateMemory } from "./memory";
 export {
+	NETWORK_MODES,
+	normalizeNetworkMode,
+	networkModeFromBindHost,
+	readNetworkMode,
+	resolveNetworkBinding,
+} from "./network";
+export type { NetworkMode } from "./network";
+export {
 	search,
 	vectorSearch,
 	keywordSearch,

--- a/packages/core/src/network.ts
+++ b/packages/core/src/network.ts
@@ -1,0 +1,39 @@
+export const NETWORK_MODES = ["localhost", "tailscale"] as const;
+export type NetworkMode = (typeof NETWORK_MODES)[number];
+
+const LOCAL_BINDS = new Set(["127.0.0.1", "localhost", "::1", "::ffff:127.0.0.1"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+export function normalizeNetworkMode(value: unknown): NetworkMode | null {
+	return value === "localhost" || value === "tailscale" ? value : null;
+}
+
+export function readNetworkMode(raw: unknown): NetworkMode {
+	if (!isRecord(raw)) return "localhost";
+	if (!isRecord(raw.network)) return "localhost";
+	return normalizeNetworkMode(raw.network.mode) ?? "localhost";
+}
+
+export function networkModeFromBindHost(bind: string): NetworkMode {
+	return LOCAL_BINDS.has(bind.trim().toLowerCase()) ? "localhost" : "tailscale";
+}
+
+export function resolveNetworkBinding(mode: NetworkMode): {
+	readonly host: string;
+	readonly bind: string;
+} {
+	if (mode === "tailscale") {
+		return {
+			host: "127.0.0.1",
+			bind: "0.0.0.0",
+		};
+	}
+
+	return {
+		host: "127.0.0.1",
+		bind: "127.0.0.1",
+	};
+}

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5,9 +5,9 @@
  */
 
 import type { Database } from "bun:sqlite";
-import { type ChildProcess, execFileSync, spawn } from "child_process";
-import { copyFileSync } from "fs";
-import { createHash } from "crypto";
+import { type ChildProcess, execFileSync, spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { copyFileSync } from "node:fs";
 import {
 	appendFileSync,
 	existsSync,
@@ -18,24 +18,27 @@ import {
 	statSync,
 	unlinkSync,
 	writeFileSync,
-} from "fs";
-import { homedir } from "os";
-import { basename, dirname, join } from "path";
-import { fileURLToPath } from "url";
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { serve } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
 import {
+	CONNECTOR_PROVIDERS,
+	type ConnectorConfig,
+	SIGNET_GIT_PROTECTED_PATHS,
+	type SyncCursor,
 	buildArchitectureDoc,
 	buildSignetBlock,
 	keywordSearch,
-	parseSimpleYaml,
-	SIGNET_GIT_PROTECTED_PATHS,
-	stripSignetBlock,
 	mergeSignetGitignoreEntries,
+	networkModeFromBindHost,
+	parseSimpleYaml,
+	readNetworkMode,
+	resolveNetworkBinding,
+	stripSignetBlock,
 	vectorSearch,
-	CONNECTOR_PROVIDERS,
-	type ConnectorConfig,
-	type SyncCursor,
 } from "@signet/core";
 import { watch } from "chokidar";
 import { type Context, Hono } from "hono";
@@ -56,6 +59,7 @@ import {
 	requireRateLimit,
 	requireScope,
 } from "./auth";
+import { migrateConfig } from "./config-migration";
 import { createFilesystemConnector } from "./connectors/filesystem";
 import {
 	getConnector,
@@ -91,37 +95,32 @@ import {
 } from "./diagnostics";
 import {
 	fetchEmbedding,
-	resolveEmbeddingBaseUrl,
 	resolveEmbeddingApiKey,
-	setNativeFallbackToOllama,
+	resolveEmbeddingBaseUrl,
 	resolveOllamaUrl,
+	setNativeFallbackToOllama,
 } from "./embedding-fetch";
-import { detectDrift } from "./predictor-comparison";
-import { getPredictorState } from "./predictor-state";
 import { buildEmbeddingHealth } from "./embedding-health";
 import { type EmbeddingTrackerHandle, startEmbeddingTracker } from "./embedding-tracker";
 import { getAllFeatureFlags, initFeatureFlags } from "./feature-flags";
-import { closeLlmProvider, getLlmProvider, initLlmProvider } from "./llm";
-import { closeSynthesisProvider, initSynthesisProvider } from "./synthesis-llm";
-import { closeWidgetProvider, initWidgetProvider } from "./widget-llm";
-import { type LogEntry, logger } from "./logger";
-import { migrateConfig } from "./config-migration";
-import { type EmbeddingConfig, loadMemoryConfig } from "./memory-config";
 import {
 	getAttributesForAspectFiltered,
-	getKnowledgeGraphForConstellation,
 	getEntityAspectsWithCounts,
 	getEntityDependenciesDetailed,
 	getEntityHealth,
-	getPinnedEntities,
 	getKnowledgeEntityDetail,
+	getKnowledgeGraphForConstellation,
 	getKnowledgeStats,
-	pinEntity,
+	getPinnedEntities,
 	listKnowledgeEntities,
+	pinEntity,
 	unpinEntity,
 } from "./knowledge-graph";
-import { buildMemoryTimeline } from "./memory-timeline";
+import { closeLlmProvider, getLlmProvider, initLlmProvider } from "./llm";
+import { type LogEntry, logger } from "./logger";
+import { type EmbeddingConfig, loadMemoryConfig } from "./memory-config";
 import { type RecallParams, hybridRecall } from "./memory-search";
+import { buildMemoryTimeline } from "./memory-timeline";
 import { ONEPASSWORD_SERVICE_ACCOUNT_SECRET, importOnePasswordSecrets, listOnePasswordVaults } from "./onepassword.js";
 import {
 	DEFAULT_RETENTION,
@@ -135,6 +134,7 @@ import {
 	startRetentionWorker,
 	stopPipeline,
 } from "./pipeline";
+import { getFeedbackTelemetry } from "./pipeline/aspect-feedback";
 import { getGraphBoostIds } from "./pipeline/graph-search";
 import {
 	getTraversalStatus,
@@ -142,8 +142,14 @@ import {
 	resolveFocalEntities,
 	traverseKnowledgeGraph,
 } from "./pipeline/graph-traversal";
-import { getFeedbackTelemetry } from "./pipeline/aspect-feedback";
-import { type PredictorClient, createPredictorClient, resolvePredictorCheckpointPath } from "./predictor-client";
+import {
+	getAvailableModels,
+	getModelsByProvider,
+	getRegistryStatus,
+	initModelRegistry,
+	refreshRegistry,
+	stopModelRegistry,
+} from "./pipeline/model-registry";
 import {
 	createAnthropicProvider,
 	createClaudeCodeProvider,
@@ -155,25 +161,26 @@ import {
 	resolveDefaultOllamaFallbackMaxContextTokens,
 	stopOpenCodeServer,
 } from "./pipeline/provider";
-import {
-	initModelRegistry,
-	getAvailableModels,
-	getModelsByProvider,
-	getRegistryStatus,
-	refreshRegistry,
-	stopModelRegistry,
-} from "./pipeline/model-registry";
 import { type RerankCandidate, noopReranker, rerank } from "./pipeline/reranker";
 import { createEmbeddingReranker } from "./pipeline/reranker-embedding";
+import { type PredictorClient, createPredictorClient, resolvePredictorCheckpointPath } from "./predictor-client";
+import { detectDrift } from "./predictor-comparison";
+import {
+	getComparisonsByEntity,
+	getComparisonsByProject,
+	listComparisons,
+	listTrainingRuns,
+} from "./predictor-comparisons";
+import { getPredictorState } from "./predictor-state";
 import {
 	type RepairContext,
 	type RepairResult,
+	backfillSkippedSessions,
 	checkFtsConsistency,
 	cleanOrphanedEmbeddings,
 	createRateLimiter,
 	deduplicateMemories,
 	getDedupStats,
-	backfillSkippedSessions,
 	getEmbeddingGapStats,
 	pruneChunkGroupEntities,
 	pruneSingletonExtractedEntities,
@@ -185,12 +192,6 @@ import {
 	structuralBackfill,
 	triggerRetentionSweep,
 } from "./repair-actions";
-import {
-	getComparisonsByEntity,
-	getComparisonsByProject,
-	listComparisons,
-	listTrainingRuns,
-} from "./predictor-comparisons";
 import {
 	CRON_PRESETS,
 	computeNextRun,
@@ -210,6 +211,7 @@ import {
 	redactCheckpointRow,
 } from "./session-checkpoints";
 import { parseFeedback, recordAgentFeedback } from "./session-memories";
+import { closeSynthesisProvider, initSynthesisProvider } from "./synthesis-llm";
 import { type TelemetryCollector, type TelemetryEventType, createTelemetryCollector } from "./telemetry";
 import { type TimelineSources, buildTimeline } from "./timeline";
 import {
@@ -236,6 +238,7 @@ import {
 	stopUpdateTimer,
 } from "./update-system";
 import { createAgentsWatcherIgnoreMatcher } from "./watcher-ignore";
+import { closeWidgetProvider, initWidgetProvider } from "./widget-llm";
 
 // Paths
 const AGENTS_DIR = process.env.SIGNET_PATH || join(homedir(), ".agents");
@@ -260,6 +263,23 @@ function normalizeBaseUrl(url: string | undefined): string | undefined {
 
 function normalizeLoopbackHost(host: string): string {
 	return host === "localhost" || host === "::1" ? "127.0.0.1" : host;
+}
+
+function readConfiguredNetworkBinding(agentsDir: string): {
+	readonly host: string;
+	readonly bind: string;
+} {
+	for (const name of ["agent.yaml", "AGENT.yaml"]) {
+		const path = join(agentsDir, name);
+		if (!existsSync(path)) continue;
+		try {
+			return resolveNetworkBinding(readNetworkMode(parseSimpleYaml(readFileSync(path, "utf-8"))));
+		} catch {
+			// Ignore malformed config and keep scanning fallbacks.
+		}
+	}
+
+	return resolveNetworkBinding("localhost");
 }
 
 function parsePort(raw: string | undefined, fallback: number): number {
@@ -298,9 +318,7 @@ function isManagedOpenCodeLocalEndpoint(baseUrl: string): boolean {
 	try {
 		const parsed = new URL(baseUrl);
 		const isLoopbackHost =
-			parsed.hostname === "127.0.0.1" ||
-			parsed.hostname === "localhost" ||
-			parsed.hostname === "::1";
+			parsed.hostname === "127.0.0.1" || parsed.hostname === "localhost" || parsed.hostname === "::1";
 		if (!isLoopbackHost) return false;
 		if (parsed.protocol !== "http:") return false;
 		const port = parsed.port.length > 0 ? Number.parseInt(parsed.port, 10) : 80;
@@ -325,10 +343,11 @@ function redactUrlForLogs(url: string | undefined): string | undefined {
 }
 
 const PORT = parsePort(readEnvTrimmed("SIGNET_PORT"), 3850);
-const HOST = normalizeLoopbackHost(readEnvTrimmed("SIGNET_HOST") ?? "127.0.0.1");
-const BIND_HOST = normalizeLoopbackHost(readEnvTrimmed("SIGNET_BIND") ?? HOST);
-const INTERNAL_SELF_HOST =
-	BIND_HOST === "0.0.0.0" || BIND_HOST === "::" ? "127.0.0.1" : BIND_HOST;
+const NET = readConfiguredNetworkBinding(AGENTS_DIR);
+const HOST = normalizeLoopbackHost(readEnvTrimmed("SIGNET_HOST") ?? NET.host);
+const BIND_HOST = normalizeLoopbackHost(readEnvTrimmed("SIGNET_BIND") ?? NET.bind);
+const NETWORK_MODE = networkModeFromBindHost(BIND_HOST);
+const INTERNAL_SELF_HOST = BIND_HOST === "0.0.0.0" || BIND_HOST === "::" ? "127.0.0.1" : BIND_HOST;
 
 type RuntimeProviderName = "ollama" | "claude-code" | "opencode" | "codex" | "anthropic";
 
@@ -371,12 +390,10 @@ let shadowProcess: ChildProcess | null = null;
 let skillReconcilerHandle: ReconcilerHandle | null = null;
 let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
 let checkpointPruneTimer: ReturnType<typeof setInterval> | undefined;
-let diagnosticsCache:
-	| {
-			readonly report: DiagnosticsReport;
-			readonly expiresAt: number;
-	  }
-	| null = null;
+let diagnosticsCache: {
+	readonly report: DiagnosticsReport;
+	readonly expiresAt: number;
+} | null = null;
 const DIAGNOSTICS_CACHE_TTL_MS = 2000;
 
 // Prevents concurrent UMAP computations for the same dimension count
@@ -392,7 +409,7 @@ let authForgetLimiter = new AuthRateLimiter(60_000, 30);
 let authModifyLimiter = new AuthRateLimiter(60_000, 60);
 let authBatchForgetLimiter = new AuthRateLimiter(60_000, 5);
 let authAdminLimiter = new AuthRateLimiter(60_000, 10);
-let authCrossAgentMessageLimiter = new AuthRateLimiter(60_000, 120);
+const authCrossAgentMessageLimiter = new AuthRateLimiter(60_000, 120);
 
 function hasMemoriesSessionIdColumn(db: Database): boolean {
 	if (hasMemoriesSessionIdColumnCache !== null) {
@@ -469,9 +486,7 @@ function setupShadowDb(agentsDir: string): string {
 
 	const mainDb = join(agentsDir, "memory", "memories.db");
 	const shadowDb = join(shadowMemDir, "memories.db");
-	const stale =
-		!existsSync(shadowDb) ||
-		Date.now() - statSync(shadowDb).mtimeMs > 24 * 60 * 60 * 1000;
+	const stale = !existsSync(shadowDb) || Date.now() - statSync(shadowDb).mtimeMs > 24 * 60 * 60 * 1000;
 	if (stale && existsSync(mainDb)) {
 		// Copy WAL and SHM alongside the main DB so the shadow starts from a
 		// consistent snapshot — without them it may see uncheckpointed pages as missing.
@@ -494,7 +509,7 @@ function setupShadowDb(agentsDir: string): string {
 
 function appendDivergence(agentsDir: string, entry: Record<string, unknown>) {
 	const logPath = join(agentsDir, ".daemon", "logs", "shadow-divergences.jsonl");
-	appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), ...entry }) + "\n");
+	appendFileSync(logPath, `${JSON.stringify({ ts: new Date().toISOString(), ...entry })}\n`);
 }
 
 /**
@@ -560,7 +575,7 @@ function buildPredictorHealthParams(): PredictorHealthParams {
 
 	return {
 		enabled: true,
-		sidecarAlive: client !== null && client.isAlive(),
+		sidecarAlive: client?.isAlive(),
 		crashCount: client?.crashCount ?? 0,
 		crashDisabled: client?.crashDisabled ?? false,
 		modelVersion,
@@ -737,11 +752,7 @@ function getConfiguredProviderHints(agentsDir: string): {
 	readonly extraction: string | null;
 	readonly synthesis: string | null;
 } {
-	const paths = [
-		join(agentsDir, "agent.yaml"),
-		join(agentsDir, "AGENT.yaml"),
-		join(agentsDir, "config.yaml"),
-	];
+	const paths = [join(agentsDir, "agent.yaml"), join(agentsDir, "AGENT.yaml"), join(agentsDir, "config.yaml")];
 	let extraction: string | null = null;
 	let synthesis: string | null = null;
 
@@ -759,10 +770,7 @@ function getConfiguredProviderHints(agentsDir: string): {
 					: typeof extractionObj?.provider === "string"
 						? extractionObj.provider
 						: null;
-			const synthesisInFile =
-				typeof synthesisObj?.provider === "string"
-					? synthesisObj.provider
-					: null;
+			const synthesisInFile = typeof synthesisObj?.provider === "string" ? synthesisObj.provider : null;
 			if (extraction === null && extractionInFile !== null) {
 				extraction = extractionInFile;
 			}
@@ -772,9 +780,7 @@ function getConfiguredProviderHints(agentsDir: string): {
 			if (extraction !== null && synthesis !== null) {
 				break;
 			}
-		} catch {
-			continue;
-		}
+		} catch {}
 	}
 
 	return { extraction, synthesis };
@@ -964,13 +970,7 @@ async function runLegacyEmbeddingsExport(
 		// Bun's spawn() silently ignores `timeout` — enforce manually
 		const timer = setTimeout(() => {
 			proc.kill();
-			resolve(
-				defaultLegacyEmbeddingsResponse(
-					limit,
-					offset,
-					`Legacy embeddings export timed out after ${timeout}ms`,
-				),
-			);
+			resolve(defaultLegacyEmbeddingsResponse(limit, offset, `Legacy embeddings export timed out after ${timeout}ms`));
 		}, timeout);
 
 		let stdout = "";
@@ -1232,10 +1232,13 @@ const ALLOWED_ORIGINS = new Set([
 	"tauri://localhost",
 	"http://tauri.localhost",
 ]);
-app.use("*", cors({
-	origin: (origin) => ALLOWED_ORIGINS.has(origin) ? origin : null,
-	credentials: true,
-}));
+app.use(
+	"*",
+	cors({
+		origin: (origin) => (ALLOWED_ORIGINS.has(origin) ? origin : null),
+		credentials: true,
+	}),
+);
 
 // Auth middleware — reads from module-level authConfig/authSecret
 // which are initialized properly in main(). In local mode this is a no-op.
@@ -1647,7 +1650,9 @@ app.get("/api/logs/stream", (c) => {
 				if (dead) return;
 				dead = true;
 				logger.off("log", onLog);
-				try { controller.close(); } catch {}
+				try {
+					controller.close();
+				} catch {}
 			};
 
 			const onLog = (entry: LogEntry) => {
@@ -1852,9 +1857,7 @@ app.get("/api/memory/timeline", (c) => {
 	try {
 		const raw = Number.parseInt(c.req.query("tzOffset") || "0", 10);
 		const tzOffsetMin = Number.isNaN(raw) ? 0 : Math.max(-840, Math.min(840, raw));
-		const timeline = getDbAccessor().withReadDb((db) =>
-			buildMemoryTimeline(db, { tzOffsetMin }),
-		);
+		const timeline = getDbAccessor().withReadDb((db) => buildMemoryTimeline(db, { tzOffsetMin }));
 		return c.json(timeline);
 	} catch (e) {
 		logger.error("memory", "Error building memory timeline", e as Error);
@@ -1922,7 +1925,7 @@ function buildWhereRaw(p: FilterParams): { clause: string; args: unknown[] } {
 		args.push(p.since);
 	}
 
-	const clause = parts.length ? " AND " + parts.join(" AND ") : "";
+	const clause = parts.length ? ` AND ${parts.join(" AND ")}` : "";
 	return { clause, args };
 }
 
@@ -1960,7 +1963,7 @@ function buildWhere(p: FilterParams): { clause: string; args: unknown[] } {
 		args.push(p.since);
 	}
 
-	const clause = parts.length ? " AND " + parts.join(" AND ") : "";
+	const clause = parts.length ? ` AND ${parts.join(" AND ")}` : "";
 	return { clause, args };
 }
 
@@ -2576,7 +2579,7 @@ app.post("/api/memory/remember", async (c) => {
 				// Dedup check + insert
 				const inserted = getDbAccessor().withWriteTx((db) => {
 					const byHash = db
-						.prepare(`SELECT id FROM memories WHERE content_hash = ? AND is_deleted = 0 LIMIT 1`)
+						.prepare("SELECT id FROM memories WHERE content_hash = ? AND is_deleted = 0 LIMIT 1")
 						.get(chunkNormalized.contentHash) as { id: string } | undefined;
 					if (byHash) return false;
 
@@ -2646,7 +2649,7 @@ app.post("/api/memory/remember", async (c) => {
 									now,
 								);
 								syncVecInsert(db, embId, vec);
-								db.prepare(`UPDATE memories SET embedding_model = ? WHERE id = ?`).run(
+								db.prepare("UPDATE memories SET embedding_model = ? WHERE id = ?").run(
 									fullCfg.embedding.model,
 									chunkId,
 								);
@@ -2849,7 +2852,7 @@ app.post("/api/memory/remember", async (c) => {
 						VALUES (?, ?, ?, ?, 'memory', ?, ?, ?)
 					`).run(embId, hash, blob, vec.length, id, normalizedContent.storageContent, now);
 					syncVecInsert(db, embId, vec);
-					db.prepare(`UPDATE memories SET embedding_model = ? WHERE id = ?`).run(cfg.embedding.model, id);
+					db.prepare("UPDATE memories SET embedding_model = ? WHERE id = ?").run(cfg.embedding.model, id);
 				});
 				embedded = true;
 			}
@@ -2972,7 +2975,7 @@ app.get("/api/memory/:id/history", (c) => {
 	const limit = Math.min(parseOptionalInt(c.req.query("limit")) ?? 200, 1000);
 
 	const exists = getDbAccessor().withReadDb((db) => {
-		return db.prepare(`SELECT id FROM memories WHERE id = ?`).get(memoryId) as { id: string } | undefined;
+		return db.prepare("SELECT id FROM memories WHERE id = ?").get(memoryId) as { id: string } | undefined;
 	});
 	if (!exists) {
 		return c.json({ error: "Not found", memoryId }, 404);
@@ -4740,9 +4743,9 @@ app.get("/api/connectors/:id/health", (c) => {
 	}
 });
 
+import { type ReconcilerHandle, startReconciler } from "./pipeline/skill-reconciler.js";
 // Skills routes (extracted to routes/skills.ts)
 import { mountSkillsRoutes, setFetchEmbedding } from "./routes/skills.js";
-import { startReconciler, type ReconcilerHandle } from "./pipeline/skill-reconciler.js";
 mountSkillsRoutes(app);
 setFetchEmbedding(fetchEmbedding);
 
@@ -5332,16 +5335,16 @@ app.post("/api/hooks/session-end", async (c) => {
 			return c.json({ memoriesSaved: 0, bypassed: true });
 		}
 
-	try {
-		const result = await handleSessionEnd(body);
-		return c.json(result);
-	} finally {
-		// Always release session claim and agent presence, even if extraction throws
-		if (sessionKey) {
-			releaseSession(sessionKey);
-			removeAgentPresence(sessionKey);
+		try {
+			const result = await handleSessionEnd(body);
+			return c.json(result);
+		} finally {
+			// Always release session claim and agent presence, even if extraction throws
+			if (sessionKey) {
+				releaseSession(sessionKey);
+				removeAgentPresence(sessionKey);
+			}
 		}
-	}
 	} catch (e) {
 		logger.error("hooks", "Session end hook failed", e as Error);
 		return c.json({ error: "Hook execution failed" }, 500);
@@ -5779,7 +5782,9 @@ app.get("/api/cross-agent/stream", (c) => {
 				dead = true;
 				clearInterval(keepAlive);
 				unsubscribe();
-				try { controller.close(); } catch {}
+				try {
+					controller.close();
+				} catch {}
 			};
 
 			const writeEvent = (event: unknown) => {
@@ -6014,7 +6019,10 @@ app.get("/api/sessions/summaries", (c) => {
 	const project = c.req.query("project");
 	const depthRaw = c.req.query("depth");
 	const depthNum = depthRaw !== undefined ? Number(depthRaw) : undefined;
-	if (depthNum !== undefined && (Number.isNaN(depthNum) || !Number.isInteger(depthNum) || depthNum < 0 || depthRaw?.trim() === "")) {
+	if (
+		depthNum !== undefined &&
+		(Number.isNaN(depthNum) || !Number.isInteger(depthNum) || depthNum < 0 || depthRaw?.trim() === "")
+	) {
 		return c.json({ error: "depth must be a non-negative integer" }, 400);
 	}
 	const limitParsed = Number.parseInt(c.req.query("limit") ?? "50", 10);
@@ -6024,11 +6032,7 @@ app.get("/api/sessions/summaries", (c) => {
 
 	// Check table exists
 	const tableExists = accessor.withReadDb((db) =>
-		db
-			.prepare(
-				`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'session_summaries'`,
-			)
-			.get(),
+		db.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'session_summaries'`).get(),
 	);
 	if (!tableExists) {
 		return c.json({ summaries: [], total: 0 });
@@ -6047,11 +6051,9 @@ app.get("/api/sessions/summaries", (c) => {
 			params.push(depthNum);
 		}
 
-		const countRow = db
-			.prepare(
-				`SELECT COUNT(*) as cnt FROM session_summaries ${where}`,
-			)
-			.get(...params) as { cnt: number } | undefined;
+		const countRow = db.prepare(`SELECT COUNT(*) as cnt FROM session_summaries ${where}`).get(...params) as
+			| { cnt: number }
+			| undefined;
 
 		const summaries = db
 			.prepare(
@@ -6064,14 +6066,10 @@ app.get("/api/sessions/summaries", (c) => {
 			)
 			.all(...params, limit, offset) as Array<Record<string, unknown>>;
 
-		const childCountStmt = db.prepare(
-			`SELECT COUNT(*) as cnt FROM session_summary_children WHERE parent_id = ?`,
-		);
+		const childCountStmt = db.prepare("SELECT COUNT(*) as cnt FROM session_summary_children WHERE parent_id = ?");
 
 		const enriched = summaries.map((s) => {
-			const childRow = childCountStmt.get(s.id) as
-				| { cnt: number }
-				| undefined;
+			const childRow = childCountStmt.get(s.id) as { cnt: number } | undefined;
 			return { ...s, childCount: childRow?.cnt ?? 0 };
 		});
 
@@ -6709,10 +6707,7 @@ app.get("/api/status", (c) => {
 	const config = loadMemoryConfig(AGENTS_DIR);
 	const configuredLogFile = readEnvTrimmed("SIGNET_LOG_FILE");
 	const configuredLogDir = readEnvTrimmed("SIGNET_LOG_DIR") ?? LOG_DIR;
-	const datedLogFile = join(
-		configuredLogDir,
-		`signet-${new Date().toISOString().slice(0, 10)}.log`,
-	);
+	const datedLogFile = join(configuredLogDir, `signet-${new Date().toISOString().slice(0, 10)}.log`);
 
 	let health: { score: number; status: string } | undefined;
 	try {
@@ -6750,6 +6745,7 @@ app.get("/api/status", (c) => {
 		port: PORT,
 		host: HOST,
 		bindHost: BIND_HOST,
+		networkMode: NETWORK_MODE,
 		agentsDir: AGENTS_DIR,
 		memoryDb: existsSync(MEMORY_DB),
 		pipelineV2: config.pipelineV2,
@@ -6955,34 +6951,38 @@ const REFRESH_COOLDOWN_MS = 60_000;
 app.post("/api/pipeline/models/refresh", async (c) => {
 	const now = Date.now();
 	if (now - lastRefreshRequestAt < REFRESH_COOLDOWN_MS) {
-		return c.json({
-			models: getModelsByProvider(),
-			registry: getRegistryStatus(),
-			throttled: true,
-		}, 429);
+		return c.json(
+			{
+				models: getModelsByProvider(),
+				registry: getRegistryStatus(),
+				throttled: true,
+			},
+			429,
+		);
 	}
 	lastRefreshRequestAt = now;
 	const cfg = loadMemoryConfig(AGENTS_DIR);
 	let anthropicKey: string | undefined = process.env.ANTHROPIC_API_KEY;
 	if (!anthropicKey) {
 		try {
-			anthropicKey = await getSecret("ANTHROPIC_API_KEY") ?? undefined;
-		} catch { /* ignore */ }
+			anthropicKey = (await getSecret("ANTHROPIC_API_KEY")) ?? undefined;
+		} catch {
+			/* ignore */
+		}
 	}
 	let openRouterKey: string | undefined = process.env.OPENROUTER_API_KEY;
 	if (!openRouterKey) {
 		try {
-			openRouterKey = await getSecret("OPENROUTER_API_KEY") ?? undefined;
-		} catch { /* ignore */ }
+			openRouterKey = (await getSecret("OPENROUTER_API_KEY")) ?? undefined;
+		} catch {
+			/* ignore */
+		}
 	}
 	await refreshRegistry(
 		resolveRegistryOllamaBaseUrl(cfg.pipelineV2.extraction.provider, cfg.pipelineV2.extraction.endpoint),
 		anthropicKey,
 		openRouterKey,
-		resolveRegistryOpenRouterBaseUrl(
-			cfg.pipelineV2.extraction.provider,
-			cfg.pipelineV2.extraction.endpoint,
-		),
+		resolveRegistryOpenRouterBaseUrl(cfg.pipelineV2.extraction.provider, cfg.pipelineV2.extraction.endpoint),
 	);
 	return c.json({
 		models: getModelsByProvider(),
@@ -7269,43 +7269,47 @@ app.post("/api/repair/structural-backfill", async (c) => {
 
 app.get("/api/repair/cold-stats", (c) => {
 	const accessor = getDbAccessor();
-	return c.json(accessor.withReadDb((db) => {
-		// Check if table exists
-		const tableExists = db
-			.prepare(
-				`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memories_cold'`,
-			)
-			.get();
+	return c.json(
+		accessor.withReadDb((db) => {
+			// Check if table exists
+			const tableExists = db
+				.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memories_cold'`)
+				.get();
 
-		if (!tableExists) {
-			return { count: 0, message: "Cold tier not yet initialized (migration pending)" };
-		}
+			if (!tableExists) {
+				return { count: 0, message: "Cold tier not yet initialized (migration pending)" };
+			}
 
-		const stats = db.prepare(`
+			const stats = db
+				.prepare(`
 			SELECT
 				COUNT(*) as total,
 				MIN(archived_at) as oldest,
 				MAX(archived_at) as newest,
 				SUM(LENGTH(CAST(content AS BLOB)) + LENGTH(CAST(COALESCE(original_row_json, '') AS BLOB))) as total_bytes
 			FROM memories_cold
-		`).get() as { total: number; oldest: string | null; newest: string | null; total_bytes: number | null } | undefined;
+		`)
+				.get() as
+				| { total: number; oldest: string | null; newest: string | null; total_bytes: number | null }
+				| undefined;
 
-		const byReason = db.prepare(`
+			const byReason = db
+				.prepare(`
 			SELECT archived_reason, COUNT(*) as count
 			FROM memories_cold
 			GROUP BY archived_reason
-		`).all() as Array<{ archived_reason: string | null; count: number }>;
+		`)
+				.all() as Array<{ archived_reason: string | null; count: number }>;
 
-		return {
-			count: stats?.total ?? 0,
-			oldest: stats?.oldest ?? null,
-			newest: stats?.newest ?? null,
-			totalBytes: stats?.total_bytes ?? 0,
-			byReason: Object.fromEntries(
-				byReason.map((r) => [r.archived_reason ?? "unknown", r.count]),
-			),
-		};
-	}));
+			return {
+				count: stats?.total ?? 0,
+				oldest: stats?.oldest ?? null,
+				newest: stats?.newest ?? null,
+				totalBytes: stats?.total_bytes ?? 0,
+				byReason: Object.fromEntries(byReason.map((r) => [r.archived_reason ?? "unknown", r.count])),
+			};
+		}),
+	);
 });
 
 // ============================================================================
@@ -7313,18 +7317,18 @@ app.get("/api/repair/cold-stats", (c) => {
 // ============================================================================
 
 const TROUBLESHOOT_COMMANDS: Record<string, readonly [string, ReadonlyArray<string>]> = {
-	"status": ["signet", ["status"]],
+	status: ["signet", ["status"]],
 	"daemon-status": ["signet", ["daemon", "status"]],
 	"daemon-logs": ["signet", ["daemon", "logs", "--lines", "50"]],
 	"embed-audit": ["signet", ["embed", "audit"]],
 	"embed-backfill": ["signet", ["embed", "backfill"]],
-	"sync": ["signet", ["sync"]],
+	sync: ["signet", ["sync"]],
 	"recall-test": ["signet", ["recall", "test query"]],
 	"skill-list": ["signet", ["skill", "list"]],
 	"secret-list": ["signet", ["secret", "list"]],
 	"daemon-stop": ["signet", ["daemon", "stop"]],
 	"daemon-restart": ["signet", ["daemon", "restart"]],
-	"update": ["signet", ["update", "install"]],
+	update: ["signet", ["update", "install"]],
 };
 
 app.get("/api/troubleshoot/commands", (c) => {
@@ -7373,7 +7377,9 @@ app.post("/api/troubleshoot/exec", async (c) => {
 					write({ type: "stdout", data: "Dashboard will lose connection.\n" });
 				}
 				write({ type: "exit", code: 0 });
-				try { controller.close(); } catch {}
+				try {
+					controller.close();
+				} catch {}
 
 				// Give the response time to flush, then trigger graceful shutdown.
 				// SIGTERM triggers cleanup() which handles PID file, DB, watchers.
@@ -7427,7 +7433,9 @@ app.post("/api/troubleshoot/exec", async (c) => {
 					write({ type: "stdout", data: chunk.toString("utf-8") });
 				} catch {
 					clearTimeout(killTimer);
-					try { child.kill("SIGTERM"); } catch {}
+					try {
+						child.kill("SIGTERM");
+					} catch {}
 				}
 			});
 
@@ -7436,28 +7444,38 @@ app.post("/api/troubleshoot/exec", async (c) => {
 					write({ type: "stderr", data: chunk.toString("utf-8") });
 				} catch {
 					clearTimeout(killTimer);
-					try { child.kill("SIGTERM"); } catch {}
+					try {
+						child.kill("SIGTERM");
+					} catch {}
 				}
 			});
 
 			// 60s timeout — SIGTERM first, force kill after 5s
 			const killTimer = setTimeout(() => {
-				try { child.kill("SIGTERM"); } catch {}
+				try {
+					child.kill("SIGTERM");
+				} catch {}
 				setTimeout(() => {
-					try { child.kill(); } catch {}
+					try {
+						child.kill();
+					} catch {}
 				}, 5_000);
 			}, 60_000);
 
 			child.on("close", (code) => {
 				clearTimeout(killTimer);
 				write({ type: "exit", code: code ?? 1 });
-				try { controller.close(); } catch {}
+				try {
+					controller.close();
+				} catch {}
 			});
 
 			child.on("error", (err) => {
 				clearTimeout(killTimer);
 				write({ type: "error", message: err.message });
-				try { controller.close(); } catch {}
+				try {
+					controller.close();
+				} catch {}
 			});
 		},
 	});
@@ -8930,9 +8948,7 @@ const COMMIT_DEBOUNCE_MS = 5000; // Wait 5 seconds after last change before comm
 
 function ensureProtectedGitignore(dir: string): void {
 	const gitignorePath = join(dir, ".gitignore");
-	const existingContent = existsSync(gitignorePath)
-		? readFileSync(gitignorePath, "utf-8")
-		: "";
+	const existingContent = existsSync(gitignorePath) ? readFileSync(gitignorePath, "utf-8") : "";
 	const nextContent = mergeSignetGitignoreEntries(existingContent);
 	if (nextContent !== existingContent) {
 		writeFileSync(gitignorePath, nextContent, "utf-8");
@@ -8941,18 +8957,11 @@ function ensureProtectedGitignore(dir: string): void {
 
 async function gitUntrackProtectedFiles(dir: string): Promise<void> {
 	return new Promise((resolve) => {
-		const proc = spawn(
-			"git",
-			[
-				"rm",
-				"--cached",
-				"--ignore-unmatch",
-				"--quiet",
-				"--",
-				...SIGNET_GIT_PROTECTED_PATHS,
-			],
-			{ cwd: dir, stdio: "pipe", windowsHide: true },
-		);
+		const proc = spawn("git", ["rm", "--cached", "--ignore-unmatch", "--quiet", "--", ...SIGNET_GIT_PROTECTED_PATHS], {
+			cwd: dir,
+			stdio: "pipe",
+			windowsHide: true,
+		});
 		proc.on("close", () => resolve());
 		proc.on("error", () => resolve());
 	});
@@ -8971,7 +8980,7 @@ async function gitAutoCommit(dir: string, changedFiles: string[]): Promise<void>
 		ensureProtectedGitignore(dir);
 		await gitUntrackProtectedFiles(dir);
 
-		const fileList = changedFiles.map((f) => f.replace(dir + "/", "")).join(", ");
+		const fileList = changedFiles.map((f) => f.replace(`${dir}/`, "")).join(", ");
 		const now = new Date();
 		const timestamp = now.toISOString().replace(/[:.]/g, "-").slice(0, 19);
 		const message = `${timestamp}_auto_${fileList.slice(0, 50)}`;
@@ -9027,7 +9036,9 @@ async function gitAutoCommit(dir: string, changedFiles: string[]): Promise<void>
 		const timeout = new Promise<void>((resolve) => {
 			timer = setTimeout(() => {
 				logger.warn("git", "Auto-commit timed out after 30s");
-				try { active?.kill("SIGTERM"); } catch {}
+				try {
+					active?.kill("SIGTERM");
+				} catch {}
 				resolve();
 			}, GIT_AUTOCOMMIT_TIMEOUT_MS);
 		});
@@ -9200,10 +9211,18 @@ function startFileWatcher() {
 				if (!cfg.auth.rateLimits) throw new Error("Missing rateLimits in auth config");
 				authConfig = cfg.auth;
 				const rl = authConfig.rateLimits;
-				authForgetLimiter = rl.forget ? new AuthRateLimiter(rl.forget.windowMs, rl.forget.max) : new AuthRateLimiter(60_000, 30);
-				authModifyLimiter = rl.modify ? new AuthRateLimiter(rl.modify.windowMs, rl.modify.max) : new AuthRateLimiter(60_000, 60);
-				authBatchForgetLimiter = rl.batchForget ? new AuthRateLimiter(rl.batchForget.windowMs, rl.batchForget.max) : new AuthRateLimiter(60_000, 5);
-				authAdminLimiter = rl.admin ? new AuthRateLimiter(rl.admin.windowMs, rl.admin.max) : new AuthRateLimiter(60_000, 10);
+				authForgetLimiter = rl.forget
+					? new AuthRateLimiter(rl.forget.windowMs, rl.forget.max)
+					: new AuthRateLimiter(60_000, 30);
+				authModifyLimiter = rl.modify
+					? new AuthRateLimiter(rl.modify.windowMs, rl.modify.max)
+					: new AuthRateLimiter(60_000, 60);
+				authBatchForgetLimiter = rl.batchForget
+					? new AuthRateLimiter(rl.batchForget.windowMs, rl.batchForget.max)
+					: new AuthRateLimiter(60_000, 5);
+				authAdminLimiter = rl.admin
+					? new AuthRateLimiter(rl.admin.windowMs, rl.admin.max)
+					: new AuthRateLimiter(60_000, 10);
 				logger.info("config", "Auth config reloaded from disk");
 			} catch (e) {
 				logger.error("config", "Failed to reload auth config", e as Error);
@@ -9219,7 +9238,11 @@ function startFileWatcher() {
 		// Ingest memory markdown files (excluding MEMORY.md index)
 		// Normalize path separators for Windows compatibility (watcher returns backslashes on Windows)
 		const normalizedPath = path.replace(/\\/g, "/");
-		if (normalizedPath.includes("/memory/") && normalizedPath.endsWith(".md") && !normalizedPath.endsWith("MEMORY.md")) {
+		if (
+			normalizedPath.includes("/memory/") &&
+			normalizedPath.endsWith(".md") &&
+			!normalizedPath.endsWith("MEMORY.md")
+		) {
 			ingestMemoryMarkdown(path).catch((e) =>
 				logger.error("watcher", "Ingestion failed", undefined, {
 					path,
@@ -9245,7 +9268,11 @@ function startFileWatcher() {
 		// Ingest new memory markdown files
 		// Normalize path separators for Windows compatibility
 		const normalizedAddPath = path.replace(/\\/g, "/");
-		if (normalizedAddPath.includes("/memory/") && normalizedAddPath.endsWith(".md") && !normalizedAddPath.endsWith("MEMORY.md")) {
+		if (
+			normalizedAddPath.includes("/memory/") &&
+			normalizedAddPath.endsWith(".md") &&
+			!normalizedAddPath.endsWith("MEMORY.md")
+		) {
 			ingestMemoryMarkdown(path).catch((e) =>
 				logger.error("watcher", "Ingestion failed", undefined, {
 					path,
@@ -9836,7 +9863,6 @@ async function main() {
 	// Migrations may have created traversal tables — clear the cache
 	invalidateTraversalCache();
 
-
 	// Write PID file
 	writeFileSync(PID_FILE, process.pid.toString());
 	logger.info("daemon", "Process ID", { pid: process.pid });
@@ -9883,21 +9909,8 @@ async function main() {
 	if (rl.admin) authAdminLimiter = new AuthRateLimiter(rl.admin.windowMs, rl.admin.max);
 
 	const providerHints = getConfiguredProviderHints(AGENTS_DIR);
-	const validExtractionProviders = new Set([
-		"ollama",
-		"claude-code",
-		"opencode",
-		"codex",
-		"anthropic",
-		"openrouter",
-	]);
-	const validSynthesisProviders = new Set([
-		"ollama",
-		"claude-code",
-		"opencode",
-		"anthropic",
-		"openrouter",
-	]);
+	const validExtractionProviders = new Set(["ollama", "claude-code", "opencode", "codex", "anthropic", "openrouter"]);
+	const validSynthesisProviders = new Set(["ollama", "claude-code", "opencode", "anthropic", "openrouter"]);
 
 	providerRuntimeResolution.extraction = {
 		configured: providerHints.extraction,
@@ -9934,9 +9947,7 @@ async function main() {
 		"http://127.0.0.1:11434",
 	);
 	const extractionOllamaFallbackBaseUrl =
-		memoryCfg.pipelineV2.extraction.provider === "opencode"
-			? "http://127.0.0.1:11434"
-			: extractionOllamaBaseUrl;
+		memoryCfg.pipelineV2.extraction.provider === "opencode" ? "http://127.0.0.1:11434" : extractionOllamaBaseUrl;
 	const extractionOpenCodeBaseUrl = normalizeRuntimeBaseUrl(
 		memoryCfg.pipelineV2.extraction.endpoint,
 		"http://127.0.0.1:4096",
@@ -9945,11 +9956,8 @@ async function main() {
 		memoryCfg.pipelineV2.extraction.endpoint,
 		"https://openrouter.ai/api/v1",
 	);
-	const ollamaFallbackMaxContextTokens =
-		resolveDefaultOllamaFallbackMaxContextTokens();
-	const extractionOpenCodeShouldManage = isManagedOpenCodeLocalEndpoint(
-		extractionOpenCodeBaseUrl,
-	);
+	const ollamaFallbackMaxContextTokens = resolveDefaultOllamaFallbackMaxContextTokens();
+	const extractionOpenCodeShouldManage = isManagedOpenCodeLocalEndpoint(extractionOpenCodeBaseUrl);
 	if (effectiveExtractionProvider === "opencode") {
 		if (extractionOpenCodeShouldManage) {
 			const serverReady = await ensureOpenCodeServer(4096);
@@ -10018,7 +10026,7 @@ async function main() {
 		let key = process.env[name];
 		if (!key) {
 			try {
-				key = await getSecret(name) ?? undefined;
+				key = (await getSecret(name)) ?? undefined;
 			} catch {
 				logger.warn("config", `Failed to resolve ${name} from secrets store`);
 			}
@@ -10030,12 +10038,14 @@ async function main() {
 	// Resolve Anthropic API key once — shared by extraction and synthesis
 	let anthropicApiKey: string | undefined;
 	const needsAnthropicForSynthesis =
-		memoryCfg.pipelineV2.synthesis.enabled &&
-		memoryCfg.pipelineV2.synthesis.provider === "anthropic";
+		memoryCfg.pipelineV2.synthesis.enabled && memoryCfg.pipelineV2.synthesis.provider === "anthropic";
 	if (effectiveExtractionProvider === "anthropic" || needsAnthropicForSynthesis) {
 		anthropicApiKey = await getKey("ANTHROPIC_API_KEY");
 		if (!anthropicApiKey) {
-			logger.error("config", "ANTHROPIC_API_KEY not found — falling back to ollama. Set via env or `signet secrets set ANTHROPIC_API_KEY`");
+			logger.error(
+				"config",
+				"ANTHROPIC_API_KEY not found — falling back to ollama. Set via env or `signet secrets set ANTHROPIC_API_KEY`",
+			);
 			if (effectiveExtractionProvider === "anthropic") {
 				effectiveExtractionProvider = "ollama";
 			}
@@ -10045,12 +10055,8 @@ async function main() {
 	// Resolve OpenRouter API key once — shared by extraction and synthesis
 	let openRouterApiKey: string | undefined;
 	const needsOpenRouterForSynthesis =
-		memoryCfg.pipelineV2.synthesis.enabled &&
-		memoryCfg.pipelineV2.synthesis.provider === "openrouter";
-	if (
-		effectiveExtractionProvider === "openrouter" ||
-		needsOpenRouterForSynthesis
-	) {
+		memoryCfg.pipelineV2.synthesis.enabled && memoryCfg.pipelineV2.synthesis.provider === "openrouter";
+	if (effectiveExtractionProvider === "openrouter" || needsOpenRouterForSynthesis) {
 		openRouterApiKey = await getKey("OPENROUTER_API_KEY");
 		if (!openRouterApiKey) {
 			logger.error(
@@ -10070,8 +10076,7 @@ async function main() {
 		effectiveExtractionModel = undefined;
 	}
 	const usingExtractionOllamaFallback =
-		effectiveExtractionProvider === "ollama" &&
-		memoryCfg.pipelineV2.extraction.provider !== "ollama";
+		effectiveExtractionProvider === "ollama" && memoryCfg.pipelineV2.extraction.provider !== "ollama";
 	providerRuntimeResolution.extraction = {
 		configured: providerHints.extraction,
 		resolved: memoryCfg.pipelineV2.extraction.provider,
@@ -10095,7 +10100,7 @@ async function main() {
 					? extractionOpenCodeBaseUrl
 					: effectiveExtractionProvider === "openrouter"
 						? extractionOpenRouterBaseUrl
-					: undefined,
+						: undefined,
 		),
 	});
 
@@ -10116,53 +10121,46 @@ async function main() {
 						title: readEnvTrimmed("OPENROUTER_TITLE"),
 						defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 					})
-			: effectiveExtractionProvider === "opencode"
-				? createOpenCodeProvider({
-						model: effectiveExtractionModel || "anthropic/claude-haiku-4-5-20251001",
-						baseUrl: extractionOpenCodeBaseUrl,
-						ollamaFallbackBaseUrl: extractionOllamaFallbackBaseUrl,
-						ollamaFallbackMaxContextTokens:
-							ollamaFallbackMaxContextTokens,
-						defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
-					})
-				: effectiveExtractionProvider === "claude-code"
-					? createClaudeCodeProvider({
-							model: effectiveExtractionModel || "haiku",
+				: effectiveExtractionProvider === "opencode"
+					? createOpenCodeProvider({
+							model: effectiveExtractionModel || "anthropic/claude-haiku-4-5-20251001",
+							baseUrl: extractionOpenCodeBaseUrl,
+							ollamaFallbackBaseUrl: extractionOllamaFallbackBaseUrl,
+							ollamaFallbackMaxContextTokens: ollamaFallbackMaxContextTokens,
 							defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 						})
-					: effectiveExtractionProvider === "codex"
-						? createCodexProvider({
-								model: effectiveExtractionModel || "gpt-5.3-codex",
+					: effectiveExtractionProvider === "claude-code"
+						? createClaudeCodeProvider({
+								model: effectiveExtractionModel || "haiku",
 								defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 							})
-						: createOllamaProvider({
-								...(effectiveExtractionModel
-									? { model: effectiveExtractionModel }
-									: {}),
-								baseUrl: extractionOllamaFallbackBaseUrl,
-								defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
-								...(usingExtractionOllamaFallback
-									? {
-										maxContextTokens:
-											ollamaFallbackMaxContextTokens,
-									}
-									: {}),
-							});
+						: effectiveExtractionProvider === "codex"
+							? createCodexProvider({
+									model: effectiveExtractionModel || "gpt-5.3-codex",
+									defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
+								})
+							: createOllamaProvider({
+									...(effectiveExtractionModel ? { model: effectiveExtractionModel } : {}),
+									baseUrl: extractionOllamaFallbackBaseUrl,
+									defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
+									...(usingExtractionOllamaFallback
+										? {
+												maxContextTokens: ollamaFallbackMaxContextTokens,
+											}
+										: {}),
+								});
 	initLlmProvider(llmProvider);
 
 	// Initialize model registry for dynamic model discovery
 	if (memoryCfg.pipelineV2.modelRegistry.enabled) {
-		const registryAnthropicApiKey = anthropicApiKey ?? await getKey("ANTHROPIC_API_KEY");
-		const registryOpenRouterApiKey =
-			openRouterApiKey ?? await getKey("OPENROUTER_API_KEY");
+		const registryAnthropicApiKey = anthropicApiKey ?? (await getKey("ANTHROPIC_API_KEY"));
+		const registryOpenRouterApiKey = openRouterApiKey ?? (await getKey("OPENROUTER_API_KEY"));
 		initModelRegistry(
 			memoryCfg.pipelineV2.modelRegistry,
 			effectiveExtractionProvider === "ollama" ? extractionOllamaBaseUrl : undefined,
 			registryAnthropicApiKey,
 			registryOpenRouterApiKey,
-			effectiveExtractionProvider === "openrouter"
-				? extractionOpenRouterBaseUrl
-				: undefined,
+			effectiveExtractionProvider === "openrouter" ? extractionOpenRouterBaseUrl : undefined,
 		);
 	}
 
@@ -10175,9 +10173,7 @@ async function main() {
 			"http://127.0.0.1:11434",
 		);
 		const synthesisOllamaFallbackBaseUrl =
-			memoryCfg.pipelineV2.synthesis.provider === "opencode"
-				? "http://127.0.0.1:11434"
-				: synthesisOllamaBaseUrl;
+			memoryCfg.pipelineV2.synthesis.provider === "opencode" ? "http://127.0.0.1:11434" : synthesisOllamaBaseUrl;
 		const synthesisOpenCodeBaseUrl = normalizeRuntimeBaseUrl(
 			memoryCfg.pipelineV2.synthesis.endpoint,
 			"http://127.0.0.1:4096",
@@ -10186,9 +10182,7 @@ async function main() {
 			memoryCfg.pipelineV2.synthesis.endpoint,
 			"https://openrouter.ai/api/v1",
 		);
-		const synthesisOpenCodeShouldManage = isManagedOpenCodeLocalEndpoint(
-			synthesisOpenCodeBaseUrl,
-		);
+		const synthesisOpenCodeShouldManage = isManagedOpenCodeLocalEndpoint(synthesisOpenCodeBaseUrl);
 		if (effectiveSynthesisProvider === "opencode") {
 			if (synthesisOpenCodeShouldManage) {
 				const serverReady = await ensureOpenCodeServer(4096);
@@ -10258,7 +10252,7 @@ async function main() {
 						? synthesisOpenCodeBaseUrl
 						: effectiveSynthesisProvider === "openrouter"
 							? synthesisOpenRouterBaseUrl
-						: undefined,
+							: undefined,
 			),
 		});
 
@@ -10268,8 +10262,7 @@ async function main() {
 			effectiveSynthesisModel = undefined;
 		}
 		const usingSynthesisOllamaFallback =
-			effectiveSynthesisProvider === "ollama" &&
-			memoryCfg.pipelineV2.synthesis.provider !== "ollama";
+			effectiveSynthesisProvider === "ollama" && memoryCfg.pipelineV2.synthesis.provider !== "ollama";
 
 		const synthesisProvider =
 			effectiveSynthesisProvider === "anthropic" && anthropicApiKey
@@ -10287,33 +10280,29 @@ async function main() {
 							title: readEnvTrimmed("OPENROUTER_TITLE"),
 							defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
 						})
-				: effectiveSynthesisProvider === "opencode"
-					? createOpenCodeProvider({
-							model: effectiveSynthesisModel || "anthropic/claude-haiku-4-5-20251001",
-							baseUrl: synthesisOpenCodeBaseUrl,
-							ollamaFallbackBaseUrl: synthesisOllamaFallbackBaseUrl,
-							ollamaFallbackMaxContextTokens:
-								ollamaFallbackMaxContextTokens,
-							defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
-						})
-					: effectiveSynthesisProvider === "claude-code"
-						? createClaudeCodeProvider({
-								model: effectiveSynthesisModel || "haiku",
+					: effectiveSynthesisProvider === "opencode"
+						? createOpenCodeProvider({
+								model: effectiveSynthesisModel || "anthropic/claude-haiku-4-5-20251001",
+								baseUrl: synthesisOpenCodeBaseUrl,
+								ollamaFallbackBaseUrl: synthesisOllamaFallbackBaseUrl,
+								ollamaFallbackMaxContextTokens: ollamaFallbackMaxContextTokens,
 								defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
 							})
-					: createOllamaProvider({
-							...(effectiveSynthesisModel
-								? { model: effectiveSynthesisModel }
-								: {}),
-							baseUrl: synthesisOllamaFallbackBaseUrl,
-							defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
-							...(usingSynthesisOllamaFallback
-								? {
-									maxContextTokens:
-										ollamaFallbackMaxContextTokens,
-								}
-								: {}),
-						});
+						: effectiveSynthesisProvider === "claude-code"
+							? createClaudeCodeProvider({
+									model: effectiveSynthesisModel || "haiku",
+									defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
+								})
+							: createOllamaProvider({
+									...(effectiveSynthesisModel ? { model: effectiveSynthesisModel } : {}),
+									baseUrl: synthesisOllamaFallbackBaseUrl,
+									defaultTimeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
+									...(usingSynthesisOllamaFallback
+										? {
+												maxContextTokens: ollamaFallbackMaxContextTokens,
+											}
+										: {}),
+								});
 		initSynthesisProvider(synthesisProvider);
 		// Widget provider defaults to synthesis provider (needs smart model for HTML gen)
 		initWidgetProvider(synthesisProvider);


### PR DESCRIPTION
## Summary
- add a persisted `network.mode` setting with `localhost` as the default and `tailscale` mapping to a `0.0.0.0` bind
- wire the CLI setup/configure/start/status flows to read that mode and surface localhost plus tailnet access clearly
- add a dashboard settings section for network hosting mode and expose the selected bind mode in daemon status

## Testing
- `bun test packages/cli/src/lib/network.test.ts packages/cli/src/lib/daemon.test.ts`
- `bun run build:core`
- `cd packages/cli && bun run build:cli`
- `cd packages/daemon && bun run build`
- `cd packages/cli/dashboard && bun run check` *(fails on pre-existing unrelated dashboard type/a11y issues in AgentHeader.svelte, SystemInfoCard.svelte, KnowledgeTab.svelte, SessionList.svelte, and other existing files)*
