### PR TITLE
fix(daemon): normalize Claude Code transcript records

### DIFF
--- a/packages/daemon/src/hooks.test.ts
+++ b/packages/daemon/src/hooks.test.ts
@@ -126,6 +126,30 @@ describe("normalizeJsonConversationTranscript", () => {
 		);
 	});
 
+	it("normalizes Claude Code records with nested message objects", () => {
+		const raw = [
+			'{"type":"user","message":{"role":"user","content":"Can you pull up the last ideation doc?"},"uuid":"1"}',
+			'{"message":{"role":"assistant","content":[{"type":"thinking","thinking":"checking"},{"type":"text","text":"Here is the latest ideation doc."}]},"uuid":"2"}',
+		].join("\n");
+
+		expect(normalizeJsonConversationTranscript(raw)).toBe(
+			"User: Can you pull up the last ideation doc?\nAssistant: Here is the latest ideation doc.",
+		);
+	});
+
+	it("ignores non-conversation Claude Code records while keeping real turns", () => {
+		const raw = [
+			'{"type":"progress","data":{"type":"hook_progress","message":"working"}}',
+			'{"type":"file-history-snapshot","snapshot":{"files":[]}}',
+			'{"type":"user","message":{"role":"user","content":"status?"},"uuid":"1"}',
+			'{"message":{"role":"assistant","content":[{"type":"text","text":"all good"}]},"uuid":"2"}',
+		].join("\n");
+
+		expect(normalizeJsonConversationTranscript(raw)).toBe(
+			"User: status?\nAssistant: all good",
+		);
+	});
+
 	it("returns empty string for empty input", () => {
 		expect(normalizeJsonConversationTranscript("")).toBe("");
 	});

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -2251,17 +2251,23 @@ function normalizeJsonConversationRecord(record: Record<string, unknown>): strin
 		}
 	}
 
+	if (isRecord(record.message)) {
+		const msg = record.message;
+		const role = extractString(msg, ["role", "speaker"]);
+		const text = extractMessageText(msg);
+		if (role && text) {
+			const lower = role.toLowerCase();
+			if (lower === "user") return `User: ${text}`;
+			if (lower === "assistant") return `Assistant: ${text}`;
+		}
+	}
+
 	const role = extractString(record, ["role", "speaker"]);
 	if (role) {
 		const lowerRole = role.toLowerCase();
-		if (lowerRole === "user") {
-			const text = extractString(record, ["content", "text", "message"]);
-			if (text) return `User: ${text}`;
-		}
-		if (lowerRole === "assistant") {
-			const text = extractString(record, ["content", "text", "message"]);
-			if (text) return `Assistant: ${text}`;
-		}
+		const text = extractMessageText(record);
+		if (lowerRole === "user" && text) return `User: ${text}`;
+		if (lowerRole === "assistant" && text) return `Assistant: ${text}`;
 	}
 
 	return "";
@@ -2280,6 +2286,22 @@ function extractString(record: Record<string, unknown>, keys: readonly string[])
 		}
 	}
 	return "";
+}
+
+function extractMessageText(record: Record<string, unknown>): string {
+	const direct = extractString(record, ["content", "text", "message"]);
+	if (direct) return direct;
+
+	const content = record.content;
+	if (!Array.isArray(content)) return "";
+
+	const parts = content.flatMap((item) => {
+		if (!isRecord(item) || item.type !== "text") return [];
+		const text = extractString(item, ["text", "content"]);
+		return text ? [text] : [];
+	});
+
+	return parts.join(" ");
 }
 
 export function normalizeCodexTranscript(raw: string): string {


### PR DESCRIPTION
## Summary
- normalize Claude Code transcript records that store `role` under nested `message`
- extract assistant text from Claude Code block-array content
- add regression coverage for Claude Code conversation and non-conversation JSONL records

## Testing
- bun test packages/daemon/src/hooks.test.ts
- cd packages/daemon && bun run build

Fixes #280
