### PR TITLE
fix: normalize remember tags across daemon and openclaw

### DIFF
--- a/packages/adapters/openclaw/src/index.test.ts
+++ b/packages/adapters/openclaw/src/index.test.ts
@@ -275,11 +275,11 @@ describe("signet-memory-openclaw lifecycle hooks", () => {
 		expect(id).toBe("mem-1");
 		expect(lastRememberBody).toEqual({
 			content: "save this",
-			type: undefined,
-			importance: undefined,
 			tags: "alpha,beta",
 			who: "openclaw",
 		});
+		expect(lastRememberBody).not.toHaveProperty("type");
+		expect(lastRememberBody).not.toHaveProperty("importance");
 	});
 
 	it("deduplicates session-start for sessionless turns when both hooks fire", async () => {

--- a/packages/adapters/openclaw/src/index.test.ts
+++ b/packages/adapters/openclaw/src/index.test.ts
@@ -8,7 +8,9 @@ mock.module("@signet/core", () => ({
 }));
 
 // Import after mock so the module picks up the stub.
-const signetPlugin = (await import("./index")).default;
+const signet = await import("./index");
+const signetPlugin = signet.default;
+const { memoryStore } = signet;
 
 type HookHandler = (event: Record<string, unknown>, ctx: unknown) => Promise<unknown> | unknown;
 type ToolRegistration = { name: string; label?: string; description?: string };
@@ -25,6 +27,7 @@ let failSessionStartCount = 0;
 let failPromptSubmitCount = 0;
 let delaySessionStartMs = 0;
 let delayPromptSubmitMs = 0;
+let lastRememberBody: unknown = null;
 
 function hit(path: string): void {
 	pathCounts.set(path, (pathCounts.get(path) ?? 0) + 1);
@@ -120,9 +123,10 @@ beforeEach(() => {
 	failPromptSubmitCount = 0;
 	delaySessionStartMs = 0;
 	delayPromptSubmitMs = 0;
+	lastRememberBody = null;
 
 	const mockFetch = Object.assign(
-		async (input: RequestInfo | URL): Promise<Response> => {
+		async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
 			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
 			const path = new URL(url).pathname;
 			hit(path);
@@ -154,6 +158,9 @@ beforeEach(() => {
 					});
 				case "/api/hooks/session-end":
 					return jsonResponse({ memoriesSaved: 0 });
+				case "/api/memory/remember":
+					lastRememberBody = init?.body ? JSON.parse(String(init.body)) : null;
+					return jsonResponse({ id: "mem-1" });
 				case "/api/marketplace/mcp/tools":
 					return jsonResponse({
 						count: 2,
@@ -257,6 +264,22 @@ describe("signet-memory-openclaw lifecycle hooks", () => {
 		expect(getPrependContext(result)).toContain("turn-memory");
 		expect(getHits("/api/hooks/user-prompt-submit")).toBe(1);
 		expect(getHits("/api/hooks/session-start")).toBe(1);
+	});
+
+	it("normalizes memory_store tags to a comma string", async () => {
+		const id = await memoryStore("save this", {
+			daemonUrl: "http://daemon.test",
+			tags: ["alpha", " beta ", ""],
+		});
+
+		expect(id).toBe("mem-1");
+		expect(lastRememberBody).toEqual({
+			content: "save this",
+			type: undefined,
+			importance: undefined,
+			tags: "alpha,beta",
+			who: "openclaw",
+		});
 	});
 
 	it("deduplicates session-start for sessionless turns when both hooks fire", async () => {

--- a/packages/adapters/openclaw/src/index.ts
+++ b/packages/adapters/openclaw/src/index.ts
@@ -533,7 +533,7 @@ export async function memoryStore(
 		daemonUrl?: string;
 		type?: string;
 		importance?: number;
-		tags?: string[];
+		tags?: string | readonly string[];
 		who?: string;
 	} = {},
 ): Promise<string | null> {
@@ -544,7 +544,10 @@ export async function memoryStore(
 			content,
 			type: options.type,
 			importance: options.importance,
-			tags: options.tags,
+			tags:
+				typeof options.tags === "string"
+					? options.tags
+					: options.tags?.map((tag) => tag.trim()).filter((tag) => tag.length > 0).join(","),
 			who: options.who || "openclaw",
 		},
 		timeout: WRITE_TIMEOUT,
@@ -690,7 +693,7 @@ export async function remember(
 		daemonUrl?: string;
 		type?: string;
 		importance?: number;
-		tags?: string[];
+		tags?: string | readonly string[];
 		who?: string;
 	} = {},
 ): Promise<string | null> {
@@ -1003,7 +1006,7 @@ const signetPlugin = {
 							...opts,
 							type,
 							importance,
-							tags: tags ? tags.split(",").map((t) => t.trim()) : undefined,
+							tags,
 						});
 						if (id) {
 							return textResult(`Memory saved successfully (id: ${id})`, { id });

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/write.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/write.rs
@@ -74,14 +74,20 @@ fn parse_remember_tags(value: Option<Value>) -> Result<Vec<String>, &'static str
             .filter(|tag| !tag.is_empty())
             .map(str::to_string)
             .collect()),
-        Value::Array(tags) => Ok(tags
-            .into_iter()
-            .filter_map(|tag| match tag {
-                Value::String(tag) => Some(tag.trim().to_string()),
-                _ => None,
-            })
-            .filter(|tag| !tag.is_empty())
-            .collect()),
+        Value::Array(tags) => {
+            if tags.iter().any(|tag| !matches!(tag, Value::String(_))) {
+                return Err("tags must be a string, string array, or null");
+            }
+
+            Ok(tags
+                .into_iter()
+                .filter_map(|tag| match tag {
+                    Value::String(tag) => Some(tag.trim().to_string()),
+                    _ => None,
+                })
+                .filter(|tag| !tag.is_empty())
+                .collect())
+        }
         _ => Err("tags must be a string, string array, or null"),
     }
 }
@@ -192,6 +198,9 @@ mod tests {
     #[test]
     fn remember_tags_rejects_invalid_payloads() {
         let err = parse_remember_tags(Some(json!(42))).unwrap_err();
+        assert_eq!(err, "tags must be a string, string array, or null");
+
+        let err = parse_remember_tags(Some(json!(["alpha", 42]))).unwrap_err();
         assert_eq!(err, "tags must be a string, string array, or null");
     }
 }

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/write.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/write.rs
@@ -7,6 +7,7 @@ use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use serde::Deserialize;
+use serde_json::Value;
 use tracing::warn;
 
 use signet_core::db::Priority;
@@ -52,12 +53,37 @@ pub struct RememberBody {
     pub who: Option<String>,
     pub project: Option<String>,
     pub importance: Option<f64>,
-    pub tags: Option<String>,
+    pub tags: Option<Value>,
     pub pinned: Option<bool>,
     pub source_type: Option<String>,
     pub source_id: Option<String>,
     #[serde(rename = "type")]
     pub memory_type: Option<String>,
+}
+
+fn parse_remember_tags(value: Option<Value>) -> Result<Vec<String>, &'static str> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+
+    match value {
+        Value::Null => Ok(Vec::new()),
+        Value::String(tags) => Ok(tags
+            .split(',')
+            .map(str::trim)
+            .filter(|tag| !tag.is_empty())
+            .map(str::to_string)
+            .collect()),
+        Value::Array(tags) => Ok(tags
+            .into_iter()
+            .filter_map(|tag| match tag {
+                Value::String(tag) => Some(tag.trim().to_string()),
+                _ => None,
+            })
+            .filter(|tag| !tag.is_empty())
+            .collect()),
+        _ => Err("tags must be a string, string array, or null"),
+    }
 }
 
 pub async fn remember(
@@ -78,11 +104,16 @@ pub async fn remember(
             .into_response();
     }
 
-    let tags: Vec<String> = body
-        .tags
-        .as_deref()
-        .map(|t| t.split(',').map(|s| s.trim().to_string()).collect())
-        .unwrap_or_default();
+    let tags = match parse_remember_tags(body.tags) {
+        Ok(tags) => tags,
+        Err(error) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": error })),
+            )
+                .into_response();
+        }
+    };
 
     let who = body.who;
     let project = body.project;
@@ -138,6 +169,30 @@ pub async fn remember(
             )
                 .into_response()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_remember_tags;
+    use serde_json::json;
+
+    #[test]
+    fn remember_tags_accepts_comma_separated_strings() {
+        let tags = parse_remember_tags(Some(json!("alpha, beta"))).unwrap();
+        assert_eq!(tags, vec!["alpha".to_string(), "beta".to_string()]);
+    }
+
+    #[test]
+    fn remember_tags_accepts_string_arrays() {
+        let tags = parse_remember_tags(Some(json!(["alpha", "beta"]))).unwrap();
+        assert_eq!(tags, vec!["alpha".to_string(), "beta".to_string()]);
+    }
+
+    #[test]
+    fn remember_tags_rejects_invalid_payloads() {
+        let err = parse_remember_tags(Some(json!(42))).unwrap_err();
+        assert_eq!(err, "tags must be a string, string array, or null");
     }
 }
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2577,7 +2577,7 @@ app.post("/api/memory/remember", async (c) => {
 		who?: string;
 		project?: string;
 		importance?: number;
-		tags?: string;
+		tags?: unknown;
 		pinned?: boolean;
 		sourceType?: string;
 		sourceId?: string;
@@ -2615,6 +2615,11 @@ app.post("/api/memory/remember", async (c) => {
 	const raw = body.content?.trim();
 	if (!raw) return c.json({ error: "content is required" }, 400);
 	const scope = body.scope ?? null;
+	const hasBodyTags = Object.prototype.hasOwnProperty.call(body, "tags");
+	const bodyTags = hasBodyTags ? parseTagsMutation(body.tags) : undefined;
+	if (hasBodyTags && bodyTags === undefined) {
+		return c.json({ error: "tags must be a string, string array, or null" }, 400);
+	}
 
 	// Pipeline v2 kill switch: refuse writes when mutations are frozen
 	const fullCfg = loadMemoryConfig(AGENTS_DIR);
@@ -2640,7 +2645,7 @@ app.post("/api/memory/remember", async (c) => {
 		const parsedPrefixes = parsePrefixes(raw);
 		const importance = body.importance ?? parsedPrefixes.importance;
 		const pinned = (body.pinned ?? parsedPrefixes.pinned) ? 1 : 0;
-		const tags = body.tags ?? parsedPrefixes.tags;
+		const tags = hasBodyTags ? bodyTags : parsedPrefixes.tags;
 		const pipelineEnqueueEnabled = pipelineCfg.enabled;
 
 		const groupId = crypto.randomUUID();
@@ -2818,7 +2823,7 @@ app.post("/api/memory/remember", async (c) => {
 	// Body-level overrides for importance/tags/pinned
 	const importance = body.importance ?? parsed.importance;
 	const pinned = (body.pinned ?? parsed.pinned) ? 1 : 0;
-	const tags = body.tags ?? parsed.tags;
+	const tags = hasBodyTags ? bodyTags : parsed.tags;
 	const memType = inferType(parsed.content);
 
 	const id = crypto.randomUUID();

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2275,8 +2275,10 @@ function parseTagsMutation(value: unknown): string | null | undefined {
 		return trimmed.length > 0 ? trimmed : null;
 	}
 	if (Array.isArray(value)) {
+		if (value.some((entry) => typeof entry !== "string")) {
+			return undefined;
+		}
 		const tags = value
-			.filter((entry): entry is string => typeof entry === "string")
 			.map((tag) => tag.trim())
 			.filter((tag) => tag.length > 0)
 			.join(",");

--- a/packages/daemon/src/mutation-api.test.ts
+++ b/packages/daemon/src/mutation-api.test.ts
@@ -106,6 +106,51 @@ describe("mutation API routes", () => {
 		rmSync(agentsDir, { recursive: true, force: true });
 	});
 
+	it("POST /api/memory/remember accepts comma-separated tags", async () => {
+		const res = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: "Memory with string tags",
+				tags: "alpha, beta",
+			}),
+		});
+		const json = (await res.json()) as { tags?: string | null };
+
+		expect(res.status).toBe(200);
+		expect(json.tags).toBe("alpha,beta");
+	});
+
+	it("POST /api/memory/remember accepts string-array tags", async () => {
+		const res = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: "Memory with array tags",
+				tags: ["alpha", "beta"],
+			}),
+		});
+		const json = (await res.json()) as { tags?: string | null };
+
+		expect(res.status).toBe(200);
+		expect(json.tags).toBe("alpha,beta");
+	});
+
+	it("POST /api/memory/remember rejects invalid tag payloads", async () => {
+		const res = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: "Memory with invalid tags",
+				tags: 42,
+			}),
+		});
+		const json = (await res.json()) as { error?: string };
+
+		expect(res.status).toBe(400);
+		expect(json.error).toBe("tags must be a string, string array, or null");
+	});
+
 	it("PATCH /api/memory/:id requires reason", async () => {
 		seedMemory({
 			id: "mem-1",

--- a/packages/daemon/src/mutation-api.test.ts
+++ b/packages/daemon/src/mutation-api.test.ts
@@ -137,18 +137,20 @@ describe("mutation API routes", () => {
 	});
 
 	it("POST /api/memory/remember rejects invalid tag payloads", async () => {
-		const res = await app.request("http://localhost/api/memory/remember", {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({
-				content: "Memory with invalid tags",
-				tags: 42,
-			}),
-		});
-		const json = (await res.json()) as { error?: string };
+		for (const tags of [42, ["alpha", 42]]) {
+			const res = await app.request("http://localhost/api/memory/remember", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					content: "Memory with invalid tags",
+					tags,
+				}),
+			});
+			const json = (await res.json()) as { error?: string };
 
-		expect(res.status).toBe(400);
-		expect(json.error).toBe("tags must be a string, string array, or null");
+			expect(res.status).toBe(400);
+			expect(json.error).toBe("tags must be a string, string array, or null");
+		}
 	});
 
 	it("PATCH /api/memory/:id requires reason", async () => {


### PR DESCRIPTION
## summary
- accept `tags` as either a comma string or string array in the daemon remember route
- return a `400` for invalid tag payloads instead of bubbling a sqlite bind error
- normalize openclaw memory writes back to comma-separated strings before POSTing
- mirror the same tag parsing behavior in `daemon-rs`
- add coverage for daemon and openclaw remember tag handling

## root cause
`signet-memory-openclaw` was POSTing `tags` as `string[]` to `/api/memory/remember`, while the daemon write path still treated `tags` as a string field and passed it through to sqlite. that produced 500s on memory writes even though recall/search still worked.

## testing
- `bun test packages/daemon/src/mutation-api.test.ts --test-name-pattern 'POST /api/memory/remember'`
- `bun test packages/adapters/openclaw/src/index.test.ts`
- `cargo test -p signet-daemon routes::write -- --nocapture`
- `bun run --filter '@signet/daemon' build`
- `bun run --filter '@signetai/signet-memory-openclaw' build`
