### PR TITLE
fix(daemon): align embedding-tracker hash with normalizeAndHashContent

### DIFF
--- a/packages/daemon/src/embedding-tracker.ts
+++ b/packages/daemon/src/embedding-tracker.ts
@@ -9,7 +9,6 @@
 import { randomUUID } from "node:crypto";
 import type { PipelineEmbeddingTrackerConfig } from "@signet/core";
 import type { DbAccessor } from "./db-accessor";
-import { normalizeAndHashContent } from "./content-normalization";
 import { syncVecDeleteBySourceExceptHash, syncVecInsert, vectorToBlob } from "./db-helpers";
 import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
@@ -114,8 +113,7 @@ export function startEmbeddingTracker(
 				if (!running) break;
 				const vec = await fetchEmbeddingFn(row.content, embeddingCfg);
 				if (vec !== null) {
-					const { contentHash: hash } = normalizeAndHashContent(row.content);
-					results.push({ row, vector: vec, contentHash: hash });
+					results.push({ row, vector: vec, contentHash: row.contentHash });
 				} else {
 					failed++;
 				}

--- a/packages/daemon/src/embedding-tracker.ts
+++ b/packages/daemon/src/embedding-tracker.ts
@@ -7,9 +7,9 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { createHash } from "node:crypto";
 import type { PipelineEmbeddingTrackerConfig } from "@signet/core";
 import type { DbAccessor } from "./db-accessor";
+import { normalizeAndHashContent } from "./content-normalization";
 import { syncVecDeleteBySourceExceptHash, syncVecInsert, vectorToBlob } from "./db-helpers";
 import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
@@ -114,7 +114,7 @@ export function startEmbeddingTracker(
 				if (!running) break;
 				const vec = await fetchEmbeddingFn(row.content, embeddingCfg);
 				if (vec !== null) {
-					const hash = createHash("sha256").update(row.content).digest("hex");
+					const { contentHash: hash } = normalizeAndHashContent(row.content);
 					results.push({ row, vector: vec, contentHash: hash });
 				} else {
 					failed++;


### PR DESCRIPTION
## Summary

- **Root cause**: `embedding-tracker.ts` computed content hashes via raw `sha256(content)`, but `memories.content_hash` is set using `normalizeAndHashContent` (lowercased, whitespace-collapsed, trailing punctuation stripped). These never match for any content with case/whitespace/punctuation differences.
- **Effect**: The tracker detected 20+ memories as permanently stale, ran every 5s (batch 8), called `syncVecDeleteBySourceExceptHash` → deleted vec_embeddings entries, then failed to re-add them because the new hash still didn't match `memories.content_hash`. Result: `resync-vec` appeared to complete but reverted on the next tracker cycle.
- **Fix**: Use `normalizeAndHashContent(row.content).contentHash` — consistent with the pipeline worker, transactions, and every other write path that sets `content_hash` on embeddings.

## Changes

- `packages/daemon/src/embedding-tracker.ts`: swap raw `createHash("sha256")` for `normalizeAndHashContent`, remove now-unused `createHash` import

## Test plan

- [ ] Deploy to daemon, run `resync-vec`, verify the vec count stabilizes (no longer resets every 5s)
- [ ] Confirm `embeddingCoverage` in diagnostics reaches 100% over time as the tracker re-embeds the stale memories with the correct hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)