### PR TITLE
fix(connector-openclaw): disable legacy hook when plugin path is active

### DIFF
--- a/packages/connector-openclaw/src/index.ts
+++ b/packages/connector-openclaw/src/index.ts
@@ -359,7 +359,10 @@ export class OpenClawConnector extends BaseConnector {
 					internal: {
 						entries: {
 							"signet-memory": {
-								enabled: true,
+								// Disable the legacy hook when using the plugin path to
+								// prevent dual-system operation (duplicate memories, 2x
+								// token burn, session-tracker 409 conflicts).
+								enabled: runtimePath !== "plugin",
 							},
 						},
 					},


### PR DESCRIPTION
## Summary

- `install()` was enabling both the legacy `signet-memory` hook AND the plugin slot simultaneously on every default `signet setup --harness openclaw` call
- This creates the dual-system condition: duplicate memories per session, 2x token burn from double context injection, session-tracker 409 conflicts on every prompt turn
- Fix: when `runtimePath === "plugin"`, the `configureHooks` block now writes `enabled: false` for the legacy hook entry (instead of `true`), disabling any pre-existing legacy hook on each idempotent re-run

**Root cause** (`connector-openclaw/src/index.ts:356`): `configureHooks` defaulted to `true` with no awareness of `runtimePath`, so both paths always fired.

**Every new Signet install on OpenClaw silently created this condition.**

## Test plan

- [ ] Run `signet setup --harness openclaw` on a clean config; verify `openclaw.json` has `hooks.internal.entries["signet-memory"].enabled === false` and plugin slot enabled
- [ ] Re-run setup on existing install; verify idempotent — legacy hook stays disabled
- [ ] Pass `{ runtimePath: "legacy" }` explicitly; verify legacy hook remains `enabled: true`
- [ ] Confirm no duplicate memory extractions per session after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)