### PR TITLE
fix(daemon): use actual agentId in hints FTS query instead of hardcoded "default"

### DIFF
--- a/packages/daemon/src/memory-search.ts
+++ b/packages/daemon/src/memory-search.ts
@@ -290,9 +290,10 @@ export async function hybridRecall(
 					   WHERE memory_hints_fts MATCH ? AND h.agent_id = ?
 					   ORDER BY raw_score LIMIT ?`;
 
-				const args = scoped
-					? [keywordQuery, "default", params.scope, cfg.search.top_k]
-					: [keywordQuery, "default", cfg.search.top_k];
+				const agentId = params.agentId ?? "default";
+			const args = scoped
+					? [keywordQuery, agentId, params.scope, cfg.search.top_k]
+					: [keywordQuery, agentId, cfg.search.top_k];
 
 				const rows = (db.prepare(sql) as any).all(...args) as Array<{
 					id: string;


### PR DESCRIPTION
## Summary

- The prospective hints FTS5 query in `hybridRecall()` hardcoded `"default"` as the `agent_id` filter for both scoped and unscoped variants
- For any deployment where `agentId != "default"`, the hints FTS returned zero rows — the bm25Map received no hint boosts, and recall quality silently degraded
- This affects all multi-agent deployments and any future named-agent setups
- Fix: extract `agentId = params.agentId ?? "default"` and use it in both query arg variants

**File**: `packages/daemon/src/memory-search.ts:293-295`

## Test plan

- [ ] Create a memory under a non-default `agentId` with associated hints
- [ ] Run `hybridRecall()` with that `agentId` — verify hint boosts appear in results
- [ ] Run with `agentId === "default"` — verify behavior unchanged
- [ ] Confirm no regression on default-agent installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)