### PR TITLE
fix(daemon): hint-only memories score on full merit instead of 30% cap

### DIFF
--- a/packages/daemon/src/memory-search.ts
+++ b/packages/daemon/src/memory-search.ts
@@ -306,11 +306,13 @@ export async function hybridRecall(
 				for (const row of rows) {
 					const hint = Math.abs(row.raw_score) / normalizer;
 					const content = bm25Map.get(row.id) ?? 0;
-					// Blend content (70%) and hint (30%) when both exist;
-					// content-only or hint-only memories keep their score.
+					// Blend content (70%) and hint (30%) when both exist.
+					// Hint-only memories score on their own merit (0-1) — capping
+					// at 0.3 placed them exactly at the min_score cliff, filtering
+					// out the memories hints were designed to rescue.
 					const blended = content > 0
 						? content * 0.7 + hint * 0.3
-						: hint * 0.3;
+						: hint;
 					bm25Map.set(row.id, Math.max(content, blended));
 				}
 			});


### PR DESCRIPTION
## Summary

- The hint blending formula applied `hint * 0.3` to hint-only memories (no content match), capping a perfect hint score at exactly `0.3`
- With the default `min_score = 0.3`, these memories land exactly at the threshold — any config with `min_score` slightly above 0.3 drops **all** hint-only memories
- This defeats the purpose of prospective hints, which exist specifically to retrieve memories **not** findable by direct content matching
- Fix: hint-only branch now returns `hint` (full 0–1 range); blended scoring when both content and hint match is unchanged

**File**: `packages/daemon/src/memory-search.ts:311-313`

**Before**: `hint * 0.3` → max 0.3, filtered at min_score threshold  
**After**: `hint` → 0–1, scored on own merit

## Test plan

- [ ] Write a memory with a hint that doesn't appear in the memory content
- [ ] Query using hint vocabulary — verify the memory is returned with score > 0.3
- [ ] Verify memories with both content + hint match still use the 70/30 blend
- [ ] Verify min_score filtering still works for genuinely low-scoring results

🤖 Generated with [Claude Code](https://claude.com/claude-code)