### PR TITLE
fix(adapter-openclaw): guard runPromptInjection against known-unreachable daemon

### DIFF
--- a/packages/adapters/openclaw/src/index.ts
+++ b/packages/adapters/openclaw/src/index.ts
@@ -1358,6 +1358,10 @@ const signetPlugin = {
 			sessionKey: string | undefined,
 			agentId: string | undefined,
 		): Promise<unknown> => {
+			// Skip immediately if daemon is known-unreachable — avoids a 5-second
+			// ECONNREFUSED hang on every message turn when the daemon is down.
+			if (!daemonReachable) return undefined;
+
 			const rawPrompt = typeof event.prompt === "string" ? event.prompt : undefined;
 			const prompt = rawPrompt ? extractUserMessage(rawPrompt) : undefined;
 			if (!prompt || prompt.length <= 3) {


### PR DESCRIPTION
## Summary

- `daemonReachable` was tracked by a startup health check and 60-second periodic timer, but **never consulted** before making actual requests
- When the Signet daemon is down, every OpenClaw message turn executed `daemonFetch()` with a 5-second `AbortSignal` timeout, hitting ECONNREFUSED and silently blocking for ~5 seconds before every agent response
- Users blamed OpenClaw for slowness; the real cause was Signet's dead connection attempt
- Fix: add `if (!daemonReachable) return undefined` as the first check in `runPromptInjection()`, bypassing the fetch entirely when daemon is known-down

**File**: `packages/adapters/openclaw/src/index.ts`

The 60-second health timer continues to run and will restore `daemonReachable = true` once the daemon comes back up, at which point injection resumes automatically.

## Test plan

- [ ] Stop the Signet daemon; send a message in OpenClaw — verify no ~5s hang
- [ ] Restart the daemon; verify injection resumes on the next message (within ~60s health check window)
- [ ] With daemon running: verify normal memory injection still works
- [ ] Verify `daemonFetch` is not called when `daemonReachable === false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)