### PR TITLE
fix: 5 critical memory and injection stability fixes

### DIFF
--- a/packages/adapters/openclaw/src/index.ts
+++ b/packages/adapters/openclaw/src/index.ts
@@ -1358,6 +1358,10 @@ const signetPlugin = {
 			sessionKey: string | undefined,
 			agentId: string | undefined,
 		): Promise<unknown> => {
+			// Skip immediately if daemon is known-unreachable — avoids a 5-second
+			// ECONNREFUSED hang on every message turn when the daemon is down.
+			if (!daemonReachable) return undefined;
+
 			const rawPrompt = typeof event.prompt === "string" ? event.prompt : undefined;
 			const prompt = rawPrompt ? extractUserMessage(rawPrompt) : undefined;
 			if (!prompt || prompt.length <= 3) {

--- a/packages/adapters/openclaw/src/index.ts
+++ b/packages/adapters/openclaw/src/index.ts
@@ -251,7 +251,6 @@ interface MarketplaceExposurePolicy {
 	readonly updatedAt: string;
 }
 
-const PROMPT_DEDUPE_WINDOW_MS = 1_000;
 
 function sanitizeToolSegment(value: string): string {
 	const normalized = value
@@ -740,22 +739,16 @@ function textResult(text: string, details?: Record<string, unknown>): OpenClawTo
 	};
 }
 
-function cleanupRecentPromptTurns(recentTurns: Map<string, number>, now: number): void {
-	for (const [key, ts] of recentTurns) {
-		if (now - ts > PROMPT_DEDUPE_WINDOW_MS) {
-			recentTurns.delete(key);
+// Dedup window for sessionless session-start calls (time-based; these don't
+// have a stable messageCount to key on).
+const SESSIONLESS_DEDUPE_MS = 1_000;
+
+function cleanupTimedMap(map: Map<string, number>, now: number): void {
+	for (const [key, ts] of map) {
+		if (now - ts > SESSIONLESS_DEDUPE_MS) {
+			map.delete(key);
 		}
 	}
-}
-
-function buildPromptTurnKey(params: {
-	sessionKey?: string;
-	agentId?: string;
-	prompt: string;
-	messageCount?: number;
-}): string {
-	const normalizedPrompt = params.prompt.trim().replace(/\s+/g, " ").slice(0, 240);
-	return `${params.sessionKey ?? "-"}|${params.agentId ?? "-"}|${params.messageCount ?? -1}|${normalizedPrompt}`;
 }
 
 function buildInjectionResult(result: UserPromptSubmitResult): { prependContext: string } | undefined {
@@ -1296,7 +1289,8 @@ const signetPlugin = {
 
 		const claimedSessions = new Set<string>();
 		const sessionlessSessionStarts = new Map<string, number>();
-		const recentPromptTurns = new Map<string, number>();
+		// Maps sessionKey → last injected messageCount for per-turn idempotency.
+		const injectedTurns = new Map<string, number>();
 
 		const resolveHookContext = (
 			ctx: unknown,
@@ -1321,10 +1315,10 @@ const signetPlugin = {
 		): Promise<void> => {
 			if (!sessionKey) {
 				const now = Date.now();
-				cleanupRecentPromptTurns(sessionlessSessionStarts, now);
+				cleanupTimedMap(sessionlessSessionStarts, now);
 				const sessionlessKey = buildSessionlessTurnKey(event, agentId);
 				const recentStartAt = sessionlessSessionStarts.get(sessionlessKey);
-				if (typeof recentStartAt === "number" && now - recentStartAt <= PROMPT_DEDUPE_WINDOW_MS) {
+				if (typeof recentStartAt === "number" && now - recentStartAt <= SESSIONLESS_DEDUPE_MS) {
 					return;
 				}
 
@@ -1368,17 +1362,13 @@ const signetPlugin = {
 				return undefined;
 			}
 
-			const now = Date.now();
-			cleanupRecentPromptTurns(recentPromptTurns, now);
-			const messageCount = Array.isArray(event.messages) ? event.messages.length : undefined;
-			const promptTurnKey = buildPromptTurnKey({
-				sessionKey,
-				agentId,
-				prompt,
-				messageCount,
-			});
-			const recentTs = recentPromptTurns.get(promptTurnKey);
-			if (typeof recentTs === "number" && now - recentTs <= PROMPT_DEDUPE_WINDOW_MS) {
+			// Deduplicate by (sessionKey, messageCount): both before_prompt_build
+			// and before_agent_start fire on the same turn; only the first should
+			// call the daemon. When messageCount is unavailable we fall through
+			// rather than risk suppressing a valid injection.
+			const count = Array.isArray(event.messages) ? event.messages.length : undefined;
+			const key = sessionKey ?? "";
+			if (typeof count === "number" && injectedTurns.get(key) === count) {
 				return undefined;
 			}
 
@@ -1394,7 +1384,9 @@ const signetPlugin = {
 				// daemonFetch already logged the specific error (ECONNREFUSED or HTTP status).
 				return undefined;
 			}
-			recentPromptTurns.set(promptTurnKey, Date.now());
+			if (typeof count === "number") {
+				injectedTurns.set(key, count);
+			}
 			return buildInjectionResult(result);
 		};
 

--- a/packages/adapters/openclaw/src/index.ts
+++ b/packages/adapters/openclaw/src/index.ts
@@ -1289,8 +1289,11 @@ const signetPlugin = {
 
 		const claimedSessions = new Set<string>();
 		const sessionlessSessionStarts = new Map<string, number>();
-		// Maps sessionKey → last injected messageCount for per-turn idempotency.
-		const injectedTurns = new Map<string, number>();
+		// Maps sessionKey → {count, at} for per-turn idempotency. Entries are
+		// evicted on agent_end or lazily after SESSION_TURN_TTL_MS so crash/
+		// SIGKILL sessions don't accumulate indefinitely.
+		const SESSION_TURN_TTL_MS = 4 * 60 * 60 * 1000;
+		const injectedTurns = new Map<string, { count: number; at: number }>();
 		// Tracks turn signatures currently in-flight — provides a synchronous
 		// guard so concurrent before_prompt_build / before_agent_start calls on
 		// the same event-loop tick don't both pass the guard before either await
@@ -1376,7 +1379,14 @@ const signetPlugin = {
 			// sig is only defined when we have both a stable session identity and
 			// a message count — the two values that make dedup meaningful.
 			const sig = sessionKey && typeof count === "number" ? `${sessionKey}|${count}` : undefined;
-			if (sig && (inFlightTurns.has(sig) || (sessionKey !== undefined && injectedTurns.get(sessionKey) === count))) {
+			// Lazy TTL sweep: evict entries from sessions that ended without agent_end.
+			if (sig) {
+				const now = Date.now();
+				for (const [k, v] of injectedTurns) {
+					if (now - v.at > SESSION_TURN_TTL_MS) injectedTurns.delete(k);
+				}
+			}
+			if (sig && (inFlightTurns.has(sig) || (sessionKey !== undefined && injectedTurns.get(sessionKey)?.count === count))) {
 				return undefined;
 			}
 			// Mark in-flight synchronously before any await so concurrent
@@ -1400,7 +1410,7 @@ const signetPlugin = {
 			}
 			// Record the completed turn so the other hook sees it on arrival.
 			if (sessionKey && typeof count === "number") {
-				injectedTurns.set(sessionKey, count);
+				injectedTurns.set(sessionKey, { count, at: Date.now() });
 			}
 			return buildInjectionResult(result);
 		};

--- a/packages/adapters/openclaw/src/index.ts
+++ b/packages/adapters/openclaw/src/index.ts
@@ -1291,6 +1291,11 @@ const signetPlugin = {
 		const sessionlessSessionStarts = new Map<string, number>();
 		// Maps sessionKey → last injected messageCount for per-turn idempotency.
 		const injectedTurns = new Map<string, number>();
+		// Tracks turn signatures currently in-flight — provides a synchronous
+		// guard so concurrent before_prompt_build / before_agent_start calls on
+		// the same event-loop tick don't both pass the guard before either await
+		// completes (injectedTurns is only written after the daemon responds).
+		const inFlightTurns = new Set<string>();
 
 		const resolveHookContext = (
 			ctx: unknown,
@@ -1364,13 +1369,19 @@ const signetPlugin = {
 
 			// Deduplicate by (sessionKey, messageCount): both before_prompt_build
 			// and before_agent_start fire on the same turn; only the first should
-			// call the daemon. When messageCount is unavailable we fall through
-			// rather than risk suppressing a valid injection.
+			// call the daemon. Sessionless agents (no sessionKey) cannot be
+			// reliably correlated and are allowed to fall through rather than
+			// risk cross-suppressing concurrent independent sessions.
 			const count = Array.isArray(event.messages) ? event.messages.length : undefined;
-			const key = sessionKey ?? "";
-			if (typeof count === "number" && injectedTurns.get(key) === count) {
+			// sig is only defined when we have both a stable session identity and
+			// a message count — the two values that make dedup meaningful.
+			const sig = sessionKey && typeof count === "number" ? `${sessionKey}|${count}` : undefined;
+			if (sig && (inFlightTurns.has(sig) || (sessionKey !== undefined && injectedTurns.get(sessionKey) === count))) {
 				return undefined;
 			}
+			// Mark in-flight synchronously before any await so concurrent
+			// invocations in the same event-loop tick see the guard immediately.
+			if (sig) inFlightTurns.add(sig);
 
 			const lastAssistantMessage = extractLastAssistantMessage(event);
 			const result = await onUserPromptSubmit("openclaw", {
@@ -1380,12 +1391,16 @@ const signetPlugin = {
 				lastAssistantMessage,
 				sessionKey,
 			});
+
+			// Always clear in-flight regardless of outcome.
+			if (sig) inFlightTurns.delete(sig);
 			if (!result) {
 				// daemonFetch already logged the specific error (ECONNREFUSED or HTTP status).
 				return undefined;
 			}
-			if (typeof count === "number") {
-				injectedTurns.set(key, count);
+			// Record the completed turn so the other hook sees it on arrival.
+			if (sessionKey && typeof count === "number") {
+				injectedTurns.set(sessionKey, count);
 			}
 			return buildInjectionResult(result);
 		};
@@ -1420,6 +1435,7 @@ const signetPlugin = {
 			await onSessionEnd("openclaw", { ...opts, sessionKey });
 			if (sessionKey) {
 				claimedSessions.delete(sessionKey);
+				injectedTurns.delete(sessionKey);
 			}
 			return undefined;
 		});

--- a/packages/connector-openclaw/src/index.ts
+++ b/packages/connector-openclaw/src/index.ts
@@ -359,7 +359,10 @@ export class OpenClawConnector extends BaseConnector {
 					internal: {
 						entries: {
 							"signet-memory": {
-								enabled: true,
+								// Disable the legacy hook when using the plugin path to
+								// prevent dual-system operation (duplicate memories, 2x
+								// token burn, session-tracker 409 conflicts).
+								enabled: runtimePath !== "plugin",
 							},
 						},
 					},

--- a/packages/daemon/src/memory-search.ts
+++ b/packages/daemon/src/memory-search.ts
@@ -291,7 +291,7 @@ export async function hybridRecall(
 					   ORDER BY raw_score LIMIT ?`;
 
 				const agentId = params.agentId ?? "default";
-			const args = scoped
+				const args = scoped
 					? [keywordQuery, agentId, params.scope, cfg.search.top_k]
 					: [keywordQuery, agentId, cfg.search.top_k];
 

--- a/packages/daemon/src/memory-search.ts
+++ b/packages/daemon/src/memory-search.ts
@@ -307,11 +307,13 @@ export async function hybridRecall(
 				for (const row of rows) {
 					const hint = Math.abs(row.raw_score) / normalizer;
 					const content = bm25Map.get(row.id) ?? 0;
-					// Blend content (70%) and hint (30%) when both exist;
-					// content-only or hint-only memories keep their score.
+					// Blend content (70%) and hint (30%) when both exist.
+					// Hint-only memories score on their own merit (0-1) — capping
+					// at 0.3 placed them exactly at the min_score cliff, filtering
+					// out the memories hints were designed to rescue.
 					const blended = content > 0
 						? content * 0.7 + hint * 0.3
-						: hint * 0.3;
+						: hint;
 					bm25Map.set(row.id, Math.max(content, blended));
 				}
 			});

--- a/packages/daemon/src/memory-search.ts
+++ b/packages/daemon/src/memory-search.ts
@@ -290,9 +290,10 @@ export async function hybridRecall(
 					   WHERE memory_hints_fts MATCH ? AND h.agent_id = ?
 					   ORDER BY raw_score LIMIT ?`;
 
-				const args = scoped
-					? [keywordQuery, "default", params.scope, cfg.search.top_k]
-					: [keywordQuery, "default", cfg.search.top_k];
+				const agentId = params.agentId ?? "default";
+			const args = scoped
+					? [keywordQuery, agentId, params.scope, cfg.search.top_k]
+					: [keywordQuery, agentId, cfg.search.top_k];
 
 				const rows = (db.prepare(sql) as any).all(...args) as Array<{
 					id: string;


### PR DESCRIPTION
## Summary

Five critical bugs affecting memory search correctness, injection reliability, and dual-system conflicts — all isolated, each with a focused commit.

### Critical #1 — Dual-system install (connector-openclaw)
When `runtimePath === "plugin"`, `configureHooks` was writing `enabled: true` for the legacy hook, activating both paths simultaneously. Result: duplicate memories, 2× token burn, and 409 session-tracker conflicts. Fixed by setting `enabled: runtimePath !== "plugin"`.

### Critical #2 — Daemon-unreachable guard (adapter-openclaw)
`runPromptInjection` never checked `daemonReachable` before calling `daemonFetch`, causing a 5-second ECONNREFUSED hang on every message turn when the daemon is down. Fixed by early-returning `undefined` when `!daemonReachable`.

### Critical #3 — Hints FTS agentId hardcoded (daemon)
The prospective-hints FTS5 query passed `"default"` as the agentId for every agent, so hint recall was always scoped to the default agent regardless of who was asking. Fixed by extracting `params.agentId ?? "default"` and threading it into both the scoped and unscoped arg arrays.

### Critical #4 — Hint-only score capped at 30% (daemon)
The blending formula `hint * 0.3` applied even when there was no content score, capping hint-only memories at 30% relevance before `min_score` filtering. Those memories could never surface. Fixed by using `hint` directly for the hint-only branch.

### Critical #5 — Unreliable time-based prompt dedup (adapter-openclaw)
The 1-second `PROMPT_DEDUPE_WINDOW_MS` window was race-prone — under load, both `before_prompt_build` and `before_agent_start` could fire outside the window and both call the daemon. Replaced with a `Map<sessionKey, messageCount>` idempotency tracker: the first hook for each `(sessionKey, messageCount)` pair runs; subsequent ones return `undefined` immediately.

## Test plan
- [ ] Install with `runtimePath: "plugin"` — verify `signet-memory` hook has `enabled: false` in config
- [ ] Stop daemon → send a prompt → verify no 5-second hang
- [ ] Query memories for a non-default agentId — verify hint recall is scoped correctly
- [ ] Search for hint-only memories — verify they rank at full score, not capped at 30%
- [ ] Send a prompt that fires both hooks — verify daemon receives exactly one injection call per turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)