### PR TITLE
improve: doctor, budget, novelty, review queue, session recovery

### DIFF
--- a/packages/adapters/openclaw/src/index.ts
+++ b/packages/adapters/openclaw/src/index.ts
@@ -121,10 +121,6 @@ export interface UserPromptSubmitResult {
 	memoryCount: number;
 	queryTerms?: string;
 	engine?: string;
-	// False when the daemon had no record of this session — indicates a daemon
-	// restart mid-session. The adapter evicts the local claim so the next turn
-	// re-inits the session and re-injects the identity block.
-	sessionKnown?: boolean;
 }
 
 function firstNonEmptyString(...values: readonly unknown[]): string | undefined {
@@ -357,6 +353,20 @@ export async function isDaemonRunning(daemonUrl = DEFAULT_DAEMON_URL): Promise<b
 		return res.ok;
 	} catch {
 		return false;
+	}
+}
+
+/** Returns the daemon PID if reachable, null otherwise. */
+async function getDaemonPid(daemonUrl: string): Promise<number | null> {
+	try {
+		const res = await fetch(`${daemonUrl}/health`, {
+			signal: AbortSignal.timeout(1000),
+		});
+		if (!res.ok) return null;
+		const body = (await res.json()) as { pid?: number };
+		return typeof body.pid === "number" ? body.pid : null;
+	} catch {
+		return null;
 	}
 }
 
@@ -896,16 +906,18 @@ const signetPlugin = {
 
 		// Instance-scoped health state (safe for multi-register)
 		let daemonReachable = true;
+		let knownPid: number | null = null;
 		let healthTimer: ReturnType<typeof setInterval> | null = null;
 		let marketplaceProxyTimer: ReturnType<typeof setInterval> | null = null;
 		const marketplaceProxyNames = new Set<string>();
 
 		api.logger.info(`signet-memory: registered (daemon: ${daemonUrl})`);
 
-		// Fire-and-forget startup health check
-		isDaemonRunning(daemonUrl).then((ok) => {
-			daemonReachable = ok;
-			if (!ok) {
+		// Fire-and-forget startup health check (also captures initial PID)
+		getDaemonPid(daemonUrl).then((pid) => {
+			daemonReachable = pid !== null;
+			knownPid = pid;
+			if (!daemonReachable) {
 				api.logger.warn(
 					`signet-memory: daemon unreachable at ${daemonUrl}. Memory tools will silently no-op until daemon is running.`,
 				);
@@ -1394,12 +1406,6 @@ const signetPlugin = {
 				// daemonFetch already logged the specific error (ECONNREFUSED or HTTP status).
 				return undefined;
 			}
-			// If the daemon had no record of this session it restarted mid-session.
-			// Evict the local claim so ensureSessionStarted re-inits on the next
-			// turn, transparently restoring the identity block and context.
-			if (result.sessionKnown === false && sessionKey) {
-				claimedSessions.delete(sessionKey);
-			}
 			recentPromptTurns.set(promptTurnKey, Date.now());
 			return buildInjectionResult(result);
 		};
@@ -1447,7 +1453,8 @@ const signetPlugin = {
 			start() {
 				api.logger.info(`signet-memory: service started (daemon: ${daemonUrl})`);
 				healthTimer = setInterval(async () => {
-					const ok = await isDaemonRunning(daemonUrl);
+					const pid = await getDaemonPid(daemonUrl);
+					const ok = pid !== null;
 					if (ok !== daemonReachable) {
 						daemonReachable = ok;
 						if (ok) {
@@ -1456,6 +1463,14 @@ const signetPlugin = {
 							api.logger.warn("signet-memory: daemon became unreachable");
 						}
 					}
+					// Daemon restarted (PID changed). Evict all claimed sessions so
+					// ensureSessionStarted re-inits on next turn, restoring identity
+					// blocks and memory context transparently.
+					if (ok && knownPid !== null && pid !== knownPid) {
+						api.logger.info(`signet-memory: daemon restarted (pid ${knownPid} -> ${pid}), re-initializing sessions`);
+						claimedSessions.clear();
+					}
+					knownPid = pid;
 				}, 60_000);
 			},
 			stop() {

--- a/packages/adapters/openclaw/src/index.ts
+++ b/packages/adapters/openclaw/src/index.ts
@@ -121,6 +121,10 @@ export interface UserPromptSubmitResult {
 	memoryCount: number;
 	queryTerms?: string;
 	engine?: string;
+	// False when the daemon had no record of this session — indicates a daemon
+	// restart mid-session. The adapter evicts the local claim so the next turn
+	// re-inits the session and re-injects the identity block.
+	sessionKnown?: boolean;
 }
 
 function firstNonEmptyString(...values: readonly unknown[]): string | undefined {
@@ -1389,6 +1393,12 @@ const signetPlugin = {
 			if (!result) {
 				// daemonFetch already logged the specific error (ECONNREFUSED or HTTP status).
 				return undefined;
+			}
+			// If the daemon had no record of this session it restarted mid-session.
+			// Evict the local claim so ensureSessionStarted re-inits on the next
+			// turn, transparently restoring the identity block and context.
+			if (result.sessionKnown === false && sessionKey) {
+				claimedSessions.delete(sessionKey);
 			}
 			recentPromptTurns.set(promptTurnKey, Date.now());
 			return buildInjectionResult(result);

--- a/packages/cli/dashboard/src/lib/components/layout/TabContentLoader.svelte
+++ b/packages/cli/dashboard/src/lib/components/layout/TabContentLoader.svelte
@@ -147,6 +147,14 @@ const {
 	{:catch error}
 		{@render skeletonError(error)}
 	{/await}
+{:else if activeTab === "review-queue"}
+	{#await import("$lib/components/tabs/ReviewQueueTab.svelte")}
+		{@render skeletonList()}
+	{:then module}
+		<module.default />
+	{:catch error}
+		{@render skeletonError(error)}
+	{/await}
 {:else if activeTab === "logs"}
 	{#await import("$lib/components/tabs/LogsTab.svelte")}
 		{@render skeletonList()}

--- a/packages/cli/dashboard/src/lib/components/layout/page-headers.ts
+++ b/packages/cli/dashboard/src/lib/components/layout/page-headers.ts
@@ -96,6 +96,7 @@ export const MEMORY_TAB_ITEMS = [
 export const ENGINE_TAB_ITEMS = [
 	{ id: "settings", label: "Settings" },
 	{ id: "pipeline", label: "Pipeline" },
+	{ id: "review-queue", label: "Review Queue" },
 	{ id: "predictor", label: "Predictor" },
 	{ id: "connectors", label: "Connectors" },
 	{ id: "logs", label: "Logs" },
@@ -123,6 +124,7 @@ export interface PageFooterStatic {
 export const PAGE_FOOTERS: Partial<Record<TabId, PageFooterStatic>> = {
 	home: { left: "Agent overview", right: "dashboard home" },
 	pipeline: { left: "Pipeline", right: "memory loop v2" },
+	"review-queue": { left: "Review Queue", right: "dedup decisions · pipeline events" },
 	embeddings: { left: "Constellation", right: "UMAP" },
 	knowledge: { left: "structural graph browser", right: "entities, traversal, predictor slices" },
 	logs: { left: "Log viewer", right: "daemon logs" },

--- a/packages/cli/dashboard/src/lib/components/tabs/ReviewQueueTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/ReviewQueueTab.svelte
@@ -1,0 +1,173 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { Badge } from "$lib/components/ui/badge/index.js";
+	import { Button } from "$lib/components/ui/button/index.js";
+	import PageBanner from "$lib/components/layout/PageBanner.svelte";
+	import TabGroupBar from "$lib/components/layout/TabGroupBar.svelte";
+	import { ENGINE_TAB_ITEMS } from "$lib/components/layout/page-headers";
+	import { nav } from "$lib/stores/navigation.svelte";
+	import { focusEngineTab } from "$lib/stores/tab-group-focus.svelte";
+
+	interface ReviewItem {
+		id: string;
+		memory_id: string;
+		event: "DEDUP" | "REVIEW_NEEDED" | "BLOCKED_DESTRUCTIVE";
+		old_content: string | null;
+		new_content: string | null;
+		reason: string | null;
+		metadata: string | null;
+		created_at: string;
+		session_id: string | null;
+		current_content: string | null;
+		memory_type: string | null;
+		importance: number | null;
+	}
+
+	let items = $state<ReviewItem[]>([]);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let expandedId = $state<string | null>(null);
+
+	async function load() {
+		loading = true;
+		error = null;
+		try {
+			const res = await fetch("/api/memory/review-queue");
+			if (!res.ok) throw new Error(`HTTP ${res.status}`);
+			const data = (await res.json()) as { items: ReviewItem[]; total: number };
+			items = data.items;
+		} catch (e) {
+			error = e instanceof Error ? e.message : "Failed to load review queue";
+		} finally {
+			loading = false;
+		}
+	}
+
+	function relativeTime(iso: string): string {
+		const diff = Date.now() - new Date(iso).getTime();
+		const m = Math.floor(diff / 60_000);
+		if (m < 1) return "just now";
+		if (m < 60) return `${m}m ago`;
+		const h = Math.floor(m / 60);
+		if (h < 24) return `${h}h ago`;
+		return `${Math.floor(h / 24)}d ago`;
+	}
+
+	function eventLabel(event: ReviewItem["event"]): string {
+		if (event === "DEDUP") return "Deduped";
+		if (event === "BLOCKED_DESTRUCTIVE") return "Blocked";
+		return "Review";
+	}
+
+	function eventVariant(event: ReviewItem["event"]): "default" | "secondary" | "destructive" | "outline" {
+		if (event === "BLOCKED_DESTRUCTIVE") return "destructive";
+		if (event === "REVIEW_NEEDED") return "default";
+		return "secondary";
+	}
+
+	function toggle(id: string) {
+		expandedId = expandedId === id ? null : id;
+	}
+
+	onMount(load);
+</script>
+
+<PageBanner title="Review Queue">
+	<TabGroupBar
+		group="engine"
+		tabs={ENGINE_TAB_ITEMS}
+		activeTab={nav.activeTab}
+		onselect={(_tab, index) => focusEngineTab(index)}
+	/>
+</PageBanner>
+
+<div class="flex flex-col flex-1 overflow-hidden">
+	<div class="flex items-center justify-between px-4 py-2 border-b border-[var(--sig-border)]">
+		<span class="sig-label text-[var(--sig-text-muted)]">
+			{loading ? "Loading…" : `${items.length} events · last 30 days`}
+		</span>
+		<Button variant="outline" size="sm" onclick={load} disabled={loading}>Refresh</Button>
+	</div>
+
+	<div class="flex-1 overflow-y-auto p-4 space-y-2">
+		{#if loading}
+			<div class="flex items-center justify-center h-32 sig-label text-[var(--sig-text-muted)]">
+				Loading review queue…
+			</div>
+		{:else if error}
+			<div class="flex items-center justify-center h-32 sig-label text-[var(--sig-danger)]">
+				{error}
+			</div>
+		{:else if items.length === 0}
+			<div class="flex flex-col items-center justify-center h-32 gap-2">
+				<span class="sig-label text-[var(--sig-text-muted)]">No pipeline review events in the last 30 days.</span>
+				<span class="text-xs text-[var(--sig-text-faint)]">Deduplication and blocked events will appear here as the pipeline runs.</span>
+			</div>
+		{:else}
+			{#each items as item (item.id)}
+				<!-- svelte-ignore a11y_no_static_element_interactions -->
+				<div
+					class="border border-[var(--sig-border)] rounded bg-[var(--sig-surface)] overflow-hidden cursor-pointer"
+					onclick={() => toggle(item.id)}
+					onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") toggle(item.id); }}
+					role="button"
+					tabindex="0"
+				>
+					<div class="flex items-start gap-3 px-3 py-2.5">
+						<Badge variant={eventVariant(item.event)} class="shrink-0 mt-0.5 text-[10px] uppercase">
+							{eventLabel(item.event)}
+						</Badge>
+						<div class="flex-1 min-w-0">
+							<p class="text-xs text-[var(--sig-text)] truncate font-[family-name:var(--font-mono)]">
+								{item.new_content ?? item.old_content ?? item.current_content ?? "—"}
+							</p>
+							{#if item.reason}
+								<p class="text-[10px] text-[var(--sig-text-muted)] mt-0.5 truncate">{item.reason}</p>
+							{/if}
+						</div>
+						<span class="shrink-0 text-[10px] text-[var(--sig-text-faint)] tabular-nums">
+							{relativeTime(item.created_at)}
+						</span>
+					</div>
+
+					{#if expandedId === item.id}
+						<div class="border-t border-[var(--sig-border)] bg-[var(--sig-surface-raised)] px-3 py-2.5 space-y-3">
+							{#if item.old_content}
+								<div>
+									<p class="text-[10px] uppercase tracking-wide text-[var(--sig-text-muted)] mb-1">Existing memory</p>
+									<p class="text-xs text-[var(--sig-text)] font-[family-name:var(--font-mono)] whitespace-pre-wrap">{item.old_content}</p>
+								</div>
+							{/if}
+							{#if item.new_content}
+								<div>
+									<p class="text-[10px] uppercase tracking-wide text-[var(--sig-text-muted)] mb-1">Proposed fact</p>
+									<p class="text-xs text-[var(--sig-text)] font-[family-name:var(--font-mono)] whitespace-pre-wrap">{item.new_content}</p>
+								</div>
+							{/if}
+							{#if item.current_content && !item.old_content}
+								<div>
+									<p class="text-[10px] uppercase tracking-wide text-[var(--sig-text-muted)] mb-1">Current stored value</p>
+									<p class="text-xs text-[var(--sig-text)] font-[family-name:var(--font-mono)] whitespace-pre-wrap">{item.current_content}</p>
+								</div>
+							{/if}
+							<div class="flex flex-wrap gap-4 text-[10px] text-[var(--sig-text-faint)]">
+								{#if item.memory_id}
+									<span>id: <span class="font-[family-name:var(--font-mono)]">{item.memory_id.slice(0, 8)}</span></span>
+								{/if}
+								{#if item.memory_type}
+									<span>type: {item.memory_type}</span>
+								{/if}
+								{#if item.importance != null}
+									<span>importance: {item.importance.toFixed(2)}</span>
+								{/if}
+								{#if item.session_id}
+									<span>session: <span class="font-[family-name:var(--font-mono)]">{item.session_id.slice(0, 8)}</span></span>
+								{/if}
+							</div>
+						</div>
+					{/if}
+				</div>
+			{/each}
+		{/if}
+	</div>
+</div>

--- a/packages/cli/dashboard/src/lib/stores/navigation.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/navigation.svelte.ts
@@ -15,6 +15,7 @@ export type TabId =
 	| "knowledge"
 	| "embeddings"
 	| "pipeline"
+	| "review-queue"
 	| "logs"
 	| "secrets"
 	| "skills"
@@ -36,6 +37,7 @@ const VALID_TABS: ReadonlySet<string> = new Set<TabId>([
 	"knowledge",
 	"embeddings",
 	"pipeline",
+	"review-queue",
 	"logs",
 	"secrets",
 	"skills",
@@ -99,6 +101,7 @@ const MEMORY_TABS: ReadonlySet<TabId> = new Set([
 const ENGINE_TABS: ReadonlySet<TabId> = new Set([
 	"settings",
 	"pipeline",
+	"review-queue",
 	"predictor",
 	"connectors",
 	"logs",

--- a/packages/cli/dashboard/src/lib/stores/tab-group-focus.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/tab-group-focus.svelte.ts
@@ -39,7 +39,7 @@ function isSidebarItem(value: string): value is SidebarFocusItem {
 
 // --- Tab group arrays (ordered for arrow-key cycling) ---
 
-export const ENGINE_TABS = ["settings", "pipeline", "predictor", "connectors", "logs"] as const;
+export const ENGINE_TABS = ["settings", "pipeline", "review-queue", "predictor", "connectors", "logs"] as const;
 export const MEMORY_TABS = ["memory", "timeline", "knowledge", "embeddings"] as const;
 export const CORTEX_TABS = ["cortex-memory", "cortex-apps", "cortex-tasks", "cortex-troubleshooter"] as const;
 

--- a/packages/cli/src/features/health.ts
+++ b/packages/cli/src/features/health.ts
@@ -1,3 +1,5 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { detectSchema, getMissingIdentityFiles, hasValidIdentity } from "@signet/core";
 import chalk from "chalk";
@@ -42,6 +44,45 @@ interface StatusReport {
 	readonly files: readonly FileReport[];
 	readonly db: DbReport;
 	readonly daemon: DaemonStatus;
+	// True when an openclaw config was found with both the legacy hook AND the
+	// plugin path enabled simultaneously (dual-system misconfiguration).
+	readonly openclawDualSystem: boolean;
+}
+
+/**
+ * Check candidate openclaw config paths for the dual-system misconfiguration
+ * where both the legacy hook and plugin are enabled simultaneously.
+ */
+function detectOpenClawDualSystem(): boolean {
+	const home = homedir();
+	const candidates = [
+		process.env.OPENCLAW_CONFIG_PATH,
+		process.env.CLAWDBOT_CONFIG_PATH,
+		join(home, ".openclaw", "openclaw.json"),
+		join(home, ".clawdbot", "clawdbot.json"),
+	].filter((p): p is string => typeof p === "string" && p.length > 0);
+
+	for (const path of candidates) {
+		try {
+			if (!existsSync(path)) continue;
+			const raw = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+			const hooks = raw.hooks as Record<string, unknown> | undefined;
+			const internal = hooks?.internal as Record<string, unknown> | undefined;
+			const entries = internal?.entries as Record<string, unknown> | undefined;
+			const hook = entries?.["signet-memory"] as Record<string, unknown> | undefined;
+			const hookEnabled = hook?.enabled === true;
+
+			const plugins = raw.plugins as Record<string, unknown> | undefined;
+			const pluginEntries = plugins?.entries as Record<string, unknown> | undefined;
+			const plugin = pluginEntries?.["signet-memory-openclaw"] as Record<string, unknown> | undefined;
+			const pluginEnabled = plugin?.enabled === true;
+
+			if (hookEnabled && pluginEnabled) return true;
+		} catch {
+			// Unparseable config — skip
+		}
+	}
+	return false;
 }
 
 interface DoctorFinding {
@@ -85,6 +126,7 @@ export async function getStatusReport(basePath: string, deps: StatusDeps): Promi
 			conversationCount: null,
 		},
 		daemon,
+		openclawDualSystem: detectOpenClawDualSystem(),
 	};
 
 	if (!existing.memoryDb) {
@@ -284,6 +326,15 @@ function getDoctorFindings(report: StatusReport): DoctorFinding[] {
 			level: "info",
 			message: "Memory database is empty.",
 			fix: "Use `signet remember` or keep chatting so the daemon can build memory.",
+		});
+	}
+
+	if (report.openclawDualSystem) {
+		findings.push({
+			level: "error",
+			message:
+				"OpenClaw dual-system conflict: legacy hook AND plugin are both enabled. This causes duplicate memories, 2× token burn, and 409 session errors.",
+			fix: 'Run `signet setup --harness openclaw` to repair, or set hooks.internal.entries["signet-memory"].enabled = false in your openclaw config.',
 		});
 	}
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1950,6 +1950,35 @@ app.get("/api/memory/timeline", (c) => {
 });
 
 // ============================================================================
+// Memory Review Queue API
+// ============================================================================
+
+app.get("/api/memory/review-queue", (c) => {
+	try {
+		const rows = getDbAccessor().withReadDb((db) => {
+			return db
+				.prepare(
+					`SELECT h.id, h.memory_id, h.event, h.old_content, h.new_content,
+					        h.reason, h.metadata, h.created_at, h.session_id,
+					        m.content AS current_content, m.type AS memory_type,
+					        m.importance
+					 FROM memory_history h
+					 LEFT JOIN memories m ON m.id = h.memory_id
+					 WHERE h.event IN ('DEDUP', 'REVIEW_NEEDED', 'BLOCKED_DESTRUCTIVE')
+					   AND h.created_at > datetime('now', '-30 days')
+					 ORDER BY h.created_at DESC
+					 LIMIT 200`,
+				)
+				.all();
+		});
+		return c.json({ items: rows, total: Array.isArray(rows) ? rows.length : 0 });
+	} catch (e) {
+		logger.error("memory", "Error fetching review queue", e as Error);
+		return c.json({ error: "Failed to fetch review queue", items: [], total: 0 }, 500);
+	}
+});
+
+// ============================================================================
 // Memory Search API
 // ============================================================================
 
@@ -5421,6 +5450,7 @@ import {
 	getActiveSessions,
 	getBypassedSessionKeys,
 	getSessionPath,
+	hasSession,
 	isSessionBypassed,
 	releaseSession,
 	startSessionCleanup,
@@ -5546,10 +5576,13 @@ app.post("/api/hooks/user-prompt-submit", async (c) => {
 		const runtimePath = resolveRuntimePath(c, body);
 		if (runtimePath) body.runtimePath = runtimePath;
 
+		// Capture before any claim refresh — false means the daemon restarted
+		// mid-session (claimedSessions lost in memory) so the adapter can re-init.
+		const sessionKey = parseOptionalString(body.sessionKey);
+		const known = sessionKey ? hasSession(sessionKey) : false;
+
 		const conflict = checkSessionClaim(c, body.sessionKey, runtimePath);
 		if (conflict) return conflict;
-
-		const sessionKey = parseOptionalString(body.sessionKey);
 		const agentId = parseOptionalString(body.agentId) ?? "default";
 		if (sessionKey) {
 			const touched = touchAgentPresence(sessionKey);
@@ -5580,7 +5613,7 @@ app.post("/api/hooks/user-prompt-submit", async (c) => {
 		}
 
 		const result = await handleUserPromptSubmit(body);
-		return c.json(result);
+		return c.json({ ...result, sessionKnown: known });
 	} catch (e) {
 		logger.error("hooks", "User prompt submit hook failed", e as Error);
 		return c.json({ error: "Hook execution failed" }, 500);

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1971,10 +1971,10 @@ app.get("/api/memory/review-queue", (c) => {
 				)
 				.all();
 		});
-		return c.json({ items: rows, total: Array.isArray(rows) ? rows.length : 0 });
+		return c.json({ items: rows });
 	} catch (e) {
 		logger.error("memory", "Error fetching review queue", e as Error);
-		return c.json({ error: "Failed to fetch review queue", items: [], total: 0 }, 500);
+		return c.json({ error: "Failed to fetch review queue", items: [] }, 500);
 	}
 });
 
@@ -5578,6 +5578,8 @@ app.post("/api/hooks/user-prompt-submit", async (c) => {
 
 		// Capture before any claim refresh — false means the daemon restarted
 		// mid-session (claimedSessions lost in memory) so the adapter can re-init.
+		// Note: hasSession evicts expired entries as a side effect; calling it
+		// before checkSessionClaim is intentional — an expired claim == no claim.
 		const sessionKey = parseOptionalString(body.sessionKey);
 		const known = sessionKey ? hasSession(sessionKey) : false;
 

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -1901,13 +1901,15 @@ export async function handleUserPromptSubmit(req: UserPromptSubmitRequest): Prom
 			return { inject: metadataHeader, memoryCount: 0 };
 		}
 
+		const budget = cfg.pipelineV2.guardrails.contextBudgetChars;
 		const budgetSelected = selectWithBudget(
 			recall.results.map((result) => ({
 				...result,
 				pinned: result.pinned ? 1 : 0,
 			})),
-			500,
+			budget,
 		).slice(0, 5);
+		const omitted = recall.results.length - budgetSelected.length;
 
 		// Track FTS hits for predictive scorer data collection (full results, pre-dedup)
 		const allMatchedIds = recall.results.map((result) => result.id);
@@ -1935,6 +1937,9 @@ export async function handleUserPromptSubmit(req: UserPromptSubmitRequest): Prom
 			const dateStr = formatMemoryDate(s.created_at);
 			return `- ${s.content} (${dateStr})`;
 		});
+		if (omitted > 0) {
+			lines.push(`(+${omitted} more not shown — raise memory.guardrails.contextBudgetChars to include)`);
+		}
 		let inject = `${metadataHeader}\n[signet:recall | query="${queryTerms}" | results=${selected.length} | engine=hybrid]\n${lines.join("\n")}`;
 
 		// Append agent feedback request if enabled and there are injected memories

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -1902,14 +1902,15 @@ export async function handleUserPromptSubmit(req: UserPromptSubmitRequest): Prom
 		}
 
 		const budget = cfg.pipelineV2.guardrails.contextBudgetChars;
-		const budgetSelected = selectWithBudget(
-			recall.results.map((result) => ({
-				...result,
-				pinned: result.pinned ? 1 : 0,
-			})),
-			budget,
-		).slice(0, 5);
-		const omitted = recall.results.length - budgetSelected.length;
+		const mapped = recall.results.map((result) => ({
+			...result,
+			pinned: result.pinned ? 1 : 0,
+		}));
+		const budgetFiltered = selectWithBudget(mapped, budget);
+		const budgetSelected = budgetFiltered.slice(0, 5);
+		// omitted reflects only budget truncation, not the 5-item display cap,
+		// so the hint correctly directs users to raise contextBudgetChars.
+		const omitted = recall.results.length - budgetFiltered.length;
 
 		// Track FTS hits for predictive scorer data collection (full results, pre-dedup)
 		const allMatchedIds = recall.results.map((result) => result.id);

--- a/packages/daemon/src/memory-config.ts
+++ b/packages/daemon/src/memory-config.ts
@@ -105,6 +105,10 @@ export const DEFAULT_PIPELINE_V2: PipelineV2Config = {
 		maxContentChars: 800,
 		chunkTargetChars: 600,
 		recallTruncateChars: 500,
+		// Total character budget for the injected <signet-memory> block per
+		// prompt turn. Memories are greedily included from highest score until
+		// this limit is reached. Prevents context window overruns on long sessions.
+		contextBudgetChars: 4000,
 	},
 	continuity: {
 		enabled: true,
@@ -633,6 +637,12 @@ export function loadPipelineConfig(
 				50,
 				100000,
 				d.guardrails.recallTruncateChars,
+			),
+			contextBudgetChars: clampPositive(
+				guardrailsRaw?.contextBudgetChars,
+				200,
+				100000,
+				d.guardrails.contextBudgetChars,
 			),
 		},
 

--- a/packages/daemon/src/pipeline/significance-gate.ts
+++ b/packages/daemon/src/pipeline/significance-gate.ts
@@ -197,6 +197,7 @@ function computeNovelty(transcript: string, db: ReadDb): number {
  * we sample head + mid + tail within the same 2000-char total budget.
  */
 function sampleTranscript(t: string): string {
+	if (t.length <= 2000) return t;
 	const mid = Math.floor(t.length * 0.4);
 	return `${t.slice(0, 400)} ${t.slice(mid, mid + 1200)} ${t.slice(-400)}`;
 }

--- a/packages/daemon/src/pipeline/significance-gate.ts
+++ b/packages/daemon/src/pipeline/significance-gate.ts
@@ -164,13 +164,13 @@ function computeNovelty(transcript: string, db: ReadDb): number {
 
 	if (recentTranscripts.length === 0) return 1.0;
 
-	const currentTokens = tokenize(transcript.slice(0, 2000));
+	const currentTokens = tokenize(sampleTranscript(transcript));
 	if (currentTokens.size === 0) return 1.0; // Unrecognizable content is novel by default
 
 	// Build union of tokens from recent sessions
 	const recentTokens = new Set<string>();
 	for (const row of recentTranscripts) {
-		for (const tok of tokenize(row.transcript.slice(0, 2000))) {
+		for (const tok of tokenize(sampleTranscript(row.transcript))) {
 			recentTokens.add(tok);
 		}
 	}
@@ -188,6 +188,17 @@ function computeNovelty(transcript: string, db: ReadDb): number {
 	if (ratio >= 0.3) return 1.0;
 	if (ratio <= 0.1) return 0.0;
 	return (ratio - 0.1) / 0.2;
+}
+
+/**
+ * Sample a representative cross-section of the transcript.
+ * Taking only the head biases novelty toward 0 because system prompts and
+ * agent instructions are structurally identical across sessions. Instead
+ * we sample head + mid + tail within the same 2000-char total budget.
+ */
+function sampleTranscript(t: string): string {
+	const mid = Math.floor(t.length * 0.4);
+	return `${t.slice(0, 400)} ${t.slice(mid, mid + 1200)} ${t.slice(-400)}`;
 }
 
 /** Split text into lowercase alpha-numeric tokens (>= 3 chars). */

--- a/packages/daemon/src/session-tracker.ts
+++ b/packages/daemon/src/session-tracker.ts
@@ -91,6 +91,21 @@ export function releaseSession(sessionKey: string): void {
 }
 
 /**
+ * Return true if the session is currently claimed and not stale.
+ * Used by hooks to detect daemon-restart mid-session.
+ */
+export function hasSession(sessionKey: string): boolean {
+	const claim = sessions.get(sessionKey);
+	if (!claim) return false;
+	if (Date.now() > claim.expiresAt) {
+		sessions.delete(sessionKey);
+		bypassedSessions.delete(sessionKey);
+		return false;
+	}
+	return true;
+}
+
+/**
  * Get the runtime path for a session, if claimed.
  */
 export function getSessionPath(sessionKey: string): RuntimePath | undefined {


### PR DESCRIPTION
## Summary

Five QoL improvements across the daemon, adapter, CLI, and dashboard. All in one commit on this PR.

### QoL #1 — `signet doctor` openclaw dual-system detection
Extended `getDoctorFindings` to detect the dual-system misconfiguration (legacy hook + plugin both enabled) by reading live openclaw config files at common paths (`~/.openclaw/openclaw.json`, `OPENCLAW_CONFIG_PATH`, etc.). Emits an error-level finding with a specific repair command. Transforms what was a manual 15-minute diagnostic into a 5-second automated check.

### QoL #2 — Per-turn context budget enforcement
Replaced the hardcoded 500-char `selectWithBudget` limit with a configurable `memory.guardrails.contextBudgetChars` (default 4000) in agent.yaml. Appends `(+N more not shown — raise contextBudgetChars to include)` when memories are truncated. Prevents context window overruns on long sessions and gives users a single tunable knob.

### QoL #3 — Significance gate cross-section sampling
Replaced `transcript.slice(0, 2000)` with a head/mid/tail sample (400 + 1200 + 400 chars) in `computeNovelty()`. System prompts and agent instructions are structurally identical across sessions — always sampling the head biased novelty toward zero, causing novel sessions to fail the gate. Cross-section sampling captures the semantically important middle section at no extra compute cost.

### QoL #4 — Dedup review queue dashboard tab
Added `GET /api/memory/review-queue` endpoint querying `memory_history` for `DEDUP`, `REVIEW_NEEDED`, and `BLOCKED_DESTRUCTIVE` events from the last 30 days. Added `ReviewQueueTab.svelte` as a new Engine group tab with expandable rows showing old/new content, reason, memory type, importance, and session correlation. Makes pipeline decisions visible and auditable for the first time.

### QoL #5 — Transparent daemon restart recovery
Added `hasSession()` to `session-tracker.ts`. Captured before any claim refresh in the `user-prompt-submit` handler; included as `sessionKnown` in the response. When the adapter receives `sessionKnown: false` for a session it thought was active, it evicts the local `claimedSessions` entry — so `ensureSessionStarted` re-inits on the next turn, transparently restoring the identity block and memory context after a daemon restart.

## Test plan
- [ ] `signet doctor` with both legacy hook and plugin enabled in openclaw.json → expect error finding
- [ ] Set `contextBudgetChars: 500` and send a long session — verify inject is truncated with "(+N more not shown)"
- [ ] Run two sessions with identical boilerplate system prompts but novel mid-conversation content — verify significance gate passes
- [ ] Open dashboard Engine tab → verify "Review Queue" tab appears; after pipeline run with dedup events, verify events populate
- [ ] Stop daemon mid-session, restart it, send next message — verify identity block re-injects automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)