### PR TITLE
fix: support provider: none for extraction and synthesis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -371,7 +371,8 @@ bun run uninstall:service # Uninstall system service
 ```
 SIGNET_PATH    # Override ~/.agents/ data directory
 SIGNET_PORT    # Override daemon port (default: 3850)
-SIGNET_HOST    # Override daemon host (default: localhost)
+SIGNET_HOST    # Override daemon client connection address (default: 127.0.0.1)
+SIGNET_BIND    # Override daemon listen/bind address (default: 127.0.0.1, use 0.0.0.0 for containers)
 SIGNET_BYPASS  # Set to 1 to bypass all hooks (CLI exits immediately, daemon never contacted)
 OPENAI_API_KEY # Used when embedding provider is openai
 ```

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -150,6 +150,7 @@ export interface PipelineEscalationConfig {
 
 export interface PipelineExtractionConfig {
 	readonly provider:
+		| "none"
 		| "ollama"
 		| "claude-code"
 		| "opencode"
@@ -323,6 +324,7 @@ export interface PipelineEmbeddingTrackerConfig {
 export interface PipelineSynthesisConfig {
 	readonly enabled: boolean;
 	readonly provider:
+		| "none"
 		| "ollama"
 		| "claude-code"
 		| "opencode"

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -10795,7 +10795,9 @@ async function main() {
 
 	// Create synthesis provider — separate from extraction because synthesis
 	// needs a smarter model that can reason across long context
-	if (memoryCfg.pipelineV2.synthesis.enabled && memoryCfg.pipelineV2.synthesis.provider !== "none") {
+	if (memoryCfg.pipelineV2.synthesis.provider === "none") {
+		logger.info("config", "Synthesis provider set to 'none', synthesis disabled");
+	} else if (memoryCfg.pipelineV2.synthesis.enabled) {
 		let effectiveSynthesisProvider = memoryCfg.pipelineV2.synthesis.provider;
 		const synthesisOllamaBaseUrl = normalizeRuntimeBaseUrl(
 			memoryCfg.pipelineV2.synthesis.endpoint,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -10533,8 +10533,8 @@ async function main() {
 	if (rl.admin) authAdminLimiter = new AuthRateLimiter(rl.admin.windowMs, rl.admin.max);
 
 	const providerHints = getConfiguredProviderHints(AGENTS_DIR);
-	const validExtractionProviders = new Set(["ollama", "claude-code", "opencode", "codex", "anthropic", "openrouter"]);
-	const validSynthesisProviders = new Set(["ollama", "claude-code", "opencode", "anthropic", "openrouter"]);
+	const validExtractionProviders = new Set(["none", "ollama", "claude-code", "opencode", "codex", "anthropic", "openrouter"]);
+	const validSynthesisProviders = new Set(["none", "ollama", "claude-code", "opencode", "anthropic", "openrouter"]);
 
 	providerRuntimeResolution.extraction = {
 		configured: providerHints.extraction,
@@ -10582,7 +10582,9 @@ async function main() {
 	);
 	const ollamaFallbackMaxContextTokens = resolveDefaultOllamaFallbackMaxContextTokens();
 	const extractionOpenCodeShouldManage = isManagedOpenCodeLocalEndpoint(extractionOpenCodeBaseUrl);
-	if (effectiveExtractionProvider === "opencode") {
+	if (effectiveExtractionProvider === "none") {
+		logger.info("config", "Extraction provider set to 'none', pipeline LLM disabled");
+	} else if (effectiveExtractionProvider === "opencode") {
 		if (extractionOpenCodeShouldManage) {
 			const serverReady = await ensureOpenCodeServer(4096);
 			if (!serverReady) {
@@ -10729,8 +10731,9 @@ async function main() {
 	});
 
 	// Create LLM provider once, register as daemon-wide singleton
-	const llmProvider =
-		effectiveExtractionProvider === "anthropic" && anthropicApiKey
+	const llmProvider = effectiveExtractionProvider === "none"
+		? null
+		: effectiveExtractionProvider === "anthropic" && anthropicApiKey
 			? createAnthropicProvider({
 					model: effectiveExtractionModel || "haiku",
 					apiKey: anthropicApiKey,
@@ -10773,7 +10776,9 @@ async function main() {
 											}
 										: {}),
 								});
-	initLlmProvider(llmProvider);
+	if (llmProvider) {
+		initLlmProvider(llmProvider);
+	}
 
 	// Initialize model registry for dynamic model discovery
 	if (memoryCfg.pipelineV2.modelRegistry.enabled) {
@@ -10790,7 +10795,7 @@ async function main() {
 
 	// Create synthesis provider — separate from extraction because synthesis
 	// needs a smarter model that can reason across long context
-	if (memoryCfg.pipelineV2.synthesis.enabled) {
+	if (memoryCfg.pipelineV2.synthesis.enabled && memoryCfg.pipelineV2.synthesis.provider !== "none") {
 		let effectiveSynthesisProvider = memoryCfg.pipelineV2.synthesis.provider;
 		const synthesisOllamaBaseUrl = normalizeRuntimeBaseUrl(
 			memoryCfg.pipelineV2.synthesis.endpoint,
@@ -10987,9 +10992,9 @@ async function main() {
 		);
 	}
 
-	// Start extraction pipeline only when explicitly enabled.
+	// Start extraction pipeline only when explicitly enabled and an LLM is available.
 	// shadowMode controls behavior inside the enabled pipeline.
-	if (memoryCfg.pipelineV2.enabled) {
+	if (memoryCfg.pipelineV2.enabled && effectiveExtractionProvider !== "none") {
 		startPipeline(
 			getDbAccessor(),
 			memoryCfg.pipelineV2,

--- a/packages/daemon/src/memory-config.ts
+++ b/packages/daemon/src/memory-config.ts
@@ -295,6 +295,7 @@ export function loadPipelineConfig(
 	const flatModel = raw.extractionModel;
 
 	type ProviderKind =
+		| "none"
 		| "ollama"
 		| "claude-code"
 		| "opencode"
@@ -302,7 +303,7 @@ export function loadPipelineConfig(
 		| "anthropic"
 		| "openrouter";
 	const VALID_PROVIDERS: ReadonlySet<string> = new Set<ProviderKind>([
-		"codex", "opencode", "claude-code", "ollama", "anthropic", "openrouter",
+		"none", "codex", "opencode", "claude-code", "ollama", "anthropic", "openrouter",
 	]);
 
 	function isValidProvider(v: unknown): v is ProviderKind {
@@ -734,6 +735,7 @@ export function loadPipelineConfig(
 			provider: (() => {
 				const p = synthesisRaw?.provider;
 				if (
+					p === "none" ||
 					p === "ollama" ||
 					p === "claude-code" ||
 					p === "opencode" ||

--- a/packages/daemon/src/pipeline/index.ts
+++ b/packages/daemon/src/pipeline/index.ts
@@ -149,7 +149,7 @@ export function startPipeline(
 	}
 
 	// Synthesis worker — session-activity-based MEMORY.md regeneration
-	if (!synthesisWorkerHandle && pipelineCfg.synthesis.enabled) {
+	if (!synthesisWorkerHandle && pipelineCfg.synthesis.enabled && pipelineCfg.synthesis.provider !== "none") {
 		synthesisWorkerHandle = startSynthesisWorker(pipelineCfg.synthesis);
 	}
 

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -1011,6 +1011,8 @@ async function resolveProvider(cfg: ReturnType<typeof loadMemoryConfig>): Promis
 	const ollamaFallbackMaxContextTokens =
 		resolveDefaultOllamaFallbackMaxContextTokens();
 	switch (p) {
+		case "none":
+			throw new Error("Summary worker requires an LLM provider but synthesis.provider is 'none'");
 		case "anthropic": {
 			let apiKey = process.env.ANTHROPIC_API_KEY;
 			if (!apiKey) {


### PR DESCRIPTION
## Summary

- Adds `"none"` to extraction and synthesis provider type unions, config validation, and daemon startup guards
- When provider is `"none"`, the daemon starts cleanly with no pipeline or LLM initialization
- Embeddings, manual `/remember`, and `/recall` continue to work independently

Supersedes #213 (PatchyToes) with a clean implementation on current main. The original PR had merge conflicts and bundled unrelated threshold changes.

Closes #213.

## Test plan

- [ ] Set `extraction.provider: none` and `synthesis.provider: none` in agent.yaml
- [ ] Verify daemon starts without pipeline errors
- [ ] Verify `/remember` and `/recall` still work
- [ ] Verify existing configs without `"none"` are unaffected


Generated with [Claude Code](https://claude.com/claude-code)