### PR TITLE
fix: complete DP-9 path feedback propagation pipeline

### DIFF
--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -392,7 +392,7 @@ Phase ordering based on hard dependencies and integration contracts.
   single-hop 66.7% (2/3). Precision 26.3%, recall 100%, NDCG 0.639.
 - **Desire Paths Phase 4**: path learning
   - DP-8: Predictor bug fixes (cache invalidation) — COMPLETE
-  - DP-9: Path feedback propagation + co-occurrence growth + Q-value rewards — NOT STARTED
+  - DP-9: Path feedback propagation + co-occurrence growth + Q-value rewards — COMPLETE
   - DP-10: Path scoring (predictor evolution) — NOT STARTED
   - DP-11: Temporal reinforcement + intent-aware routing — NOT STARTED
 - **Desire Paths Phase 5**: emergence

--- a/docs/specs/dependencies.yaml
+++ b/docs/specs/dependencies.yaml
@@ -1,5 +1,5 @@
 version: 3
-updated_at: "2026-03-18"
+updated_at: "2026-03-23"
 
 specs:
   - id: memory-pipeline-v2

--- a/packages/core/src/migrations/041-path-feedback.ts
+++ b/packages/core/src/migrations/041-path-feedback.ts
@@ -1,0 +1,84 @@
+import type { MigrationDb } from "./index";
+
+function addColumnIfMissing(
+	db: MigrationDb,
+	table: string,
+	column: string,
+	definition: string,
+): void {
+	const cols = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+	if (!cols.some((c) => c.name === column)) {
+		db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+	}
+}
+
+export function up(db: MigrationDb): void {
+	addColumnIfMissing(db, "session_memories", "path_json", "TEXT");
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS path_feedback_events (
+			id TEXT PRIMARY KEY,
+			agent_id TEXT NOT NULL,
+			session_key TEXT NOT NULL,
+			memory_id TEXT NOT NULL,
+			path_hash TEXT NOT NULL,
+			path_json TEXT NOT NULL,
+			rating REAL NOT NULL,
+			reward REAL NOT NULL DEFAULT 0,
+			reward_forward REAL NOT NULL DEFAULT 0,
+			reward_update REAL NOT NULL DEFAULT 0,
+			reward_downstream REAL NOT NULL DEFAULT 0,
+			reward_dead_end REAL NOT NULL DEFAULT 0,
+			created_at TEXT NOT NULL
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_path_feedback_events_agent_path
+			ON path_feedback_events(agent_id, path_hash);
+		CREATE INDEX IF NOT EXISTS idx_path_feedback_events_session
+			ON path_feedback_events(session_key);
+		CREATE INDEX IF NOT EXISTS idx_path_feedback_events_memory
+			ON path_feedback_events(memory_id);
+
+		CREATE TABLE IF NOT EXISTS path_feedback_stats (
+			agent_id TEXT NOT NULL,
+			path_hash TEXT NOT NULL,
+			path_json TEXT NOT NULL,
+			q_value REAL NOT NULL DEFAULT 0,
+			sample_count INTEGER NOT NULL DEFAULT 0,
+			positive_count INTEGER NOT NULL DEFAULT 0,
+			negative_count INTEGER NOT NULL DEFAULT 0,
+			neutral_count INTEGER NOT NULL DEFAULT 0,
+			updated_at TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			PRIMARY KEY (agent_id, path_hash)
+		);
+
+		CREATE TABLE IF NOT EXISTS entity_retrieval_stats (
+			agent_id TEXT NOT NULL,
+			entity_id TEXT NOT NULL,
+			session_count INTEGER NOT NULL DEFAULT 0,
+			last_session_key TEXT,
+			updated_at TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			PRIMARY KEY (agent_id, entity_id)
+		);
+
+		CREATE TABLE IF NOT EXISTS entity_cooccurrence (
+			agent_id TEXT NOT NULL,
+			source_entity_id TEXT NOT NULL,
+			target_entity_id TEXT NOT NULL,
+			session_count INTEGER NOT NULL DEFAULT 0,
+			last_session_key TEXT,
+			updated_at TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			PRIMARY KEY (agent_id, source_entity_id, target_entity_id)
+		);
+
+		CREATE TABLE IF NOT EXISTS path_feedback_sessions (
+			agent_id TEXT NOT NULL,
+			session_key TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			PRIMARY KEY (agent_id, session_key)
+		);
+	`);
+}

--- a/packages/core/src/migrations/041-path-feedback.ts
+++ b/packages/core/src/migrations/041-path-feedback.ts
@@ -1,11 +1,8 @@
 import type { MigrationDb } from "./index";
 
-function addColumnIfMissing(
-	db: MigrationDb,
-	table: string,
-	column: string,
-	definition: string,
-): void {
+function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): void {
+	// SQLite PRAGMA/ALTER identifiers are not parameterizable.
+	// This helper is only called with internal constant identifiers.
 	const cols = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
 	if (!cols.some((c) => c.name === column)) {
 		db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);

--- a/packages/core/src/migrations/042-session-memories-agent-id.ts
+++ b/packages/core/src/migrations/042-session-memories-agent-id.ts
@@ -1,0 +1,122 @@
+import type { MigrationDb } from "./index";
+
+function addColumnIfMissing(
+	db: MigrationDb,
+	table: string,
+	column: string,
+	definition: string,
+): void {
+	const cols = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<
+		Record<string, unknown>
+	>;
+	if (cols.some((col) => col.name === column)) return;
+	db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+}
+
+/**
+ * Migration 042: Add agent scoping to session_memories
+ *
+ * Rebuilds session_memories so rows are keyed by
+ * (session_key, agent_id, memory_id), enabling agent-scoped writes/reads
+ * when multiple agents reuse a session key.
+ */
+export function up(db: MigrationDb): void {
+	// Defensive: older repaired DBs may have stamped versions without columns.
+	// Ensure all columns referenced by the copy query exist before rebuild.
+	addColumnIfMissing(db, "session_memories", "entity_slot", "INTEGER");
+	addColumnIfMissing(db, "session_memories", "aspect_slot", "INTEGER");
+	addColumnIfMissing(
+		db,
+		"session_memories",
+		"is_constraint",
+		"INTEGER NOT NULL DEFAULT 0",
+	);
+	addColumnIfMissing(db, "session_memories", "structural_density", "INTEGER");
+	addColumnIfMissing(db, "session_memories", "predictor_rank", "INTEGER");
+	addColumnIfMissing(db, "session_memories", "agent_relevance_score", "REAL");
+	addColumnIfMissing(
+		db,
+		"session_memories",
+		"agent_feedback_count",
+		"INTEGER DEFAULT 0",
+	);
+	addColumnIfMissing(db, "session_memories", "path_json", "TEXT");
+
+	const cols = db.prepare("PRAGMA table_info(session_memories)").all() as ReadonlyArray<
+		Record<string, unknown>
+	>;
+	const hasAgent = cols.some((col) => col.name === "agent_id");
+	const agentExpr = hasAgent
+		? "COALESCE(NULLIF(agent_id, ''), 'default')"
+		: "'default'";
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS session_memories_new (
+			id TEXT PRIMARY KEY,
+			session_key TEXT NOT NULL,
+			agent_id TEXT NOT NULL DEFAULT 'default',
+			memory_id TEXT NOT NULL,
+			source TEXT NOT NULL,
+			effective_score REAL,
+			predictor_score REAL,
+			final_score REAL NOT NULL,
+			rank INTEGER NOT NULL,
+			was_injected INTEGER NOT NULL,
+			relevance_score REAL,
+			fts_hit_count INTEGER NOT NULL DEFAULT 0,
+			agent_preference TEXT,
+			created_at TEXT NOT NULL,
+			entity_slot INTEGER,
+			aspect_slot INTEGER,
+			is_constraint INTEGER NOT NULL DEFAULT 0,
+			structural_density INTEGER,
+			predictor_rank INTEGER,
+			agent_relevance_score REAL,
+			agent_feedback_count INTEGER DEFAULT 0,
+			path_json TEXT,
+			UNIQUE(session_key, agent_id, memory_id)
+		);
+
+		INSERT INTO session_memories_new
+			(id, session_key, agent_id, memory_id, source,
+			 effective_score, predictor_score, final_score, rank,
+			 was_injected, relevance_score, fts_hit_count,
+			 agent_preference, created_at, entity_slot, aspect_slot,
+			 is_constraint, structural_density, predictor_rank,
+			 agent_relevance_score, agent_feedback_count, path_json)
+		SELECT
+			id,
+			session_key,
+			${agentExpr},
+			memory_id,
+			source,
+			effective_score,
+			predictor_score,
+			final_score,
+			rank,
+			was_injected,
+			relevance_score,
+			fts_hit_count,
+			agent_preference,
+			created_at,
+			entity_slot,
+			aspect_slot,
+			COALESCE(is_constraint, 0),
+			structural_density,
+			predictor_rank,
+			agent_relevance_score,
+			COALESCE(agent_feedback_count, 0),
+			path_json
+		FROM session_memories;
+
+		DROP TABLE session_memories;
+		ALTER TABLE session_memories_new RENAME TO session_memories;
+
+		CREATE INDEX IF NOT EXISTS idx_session_memories_session
+			ON session_memories(session_key);
+		CREATE INDEX IF NOT EXISTS idx_session_memories_memory
+			ON session_memories(memory_id);
+		CREATE INDEX IF NOT EXISTS idx_session_memories_agent_session
+			ON session_memories(agent_id, session_key);
+	`);
+}

--- a/packages/core/src/migrations/index.ts
+++ b/packages/core/src/migrations/index.ts
@@ -47,6 +47,7 @@ import { up as memoryHints } from "./038-memory-hints";
 import { up as dedupEntityDependencies } from "./039-dedup-entity-dependencies";
 import { up as sessionTranscripts } from "./040-session-transcripts";
 import { up as pathFeedback } from "./041-path-feedback";
+import { up as sessionMemoriesAgentId } from "./042-session-memories-agent-id";
 
 // -- Public interface consumed by Database.init() --
 
@@ -409,6 +410,14 @@ export const MIGRATIONS: readonly Migration[] = [
 				"path_feedback_sessions",
 			],
 			columns: [{ table: "session_memories", column: "path_json" }],
+		},
+	},
+	{
+		version: 42,
+		name: "session-memories-agent-id",
+		up: sessionMemoriesAgentId,
+		artifacts: {
+			columns: [{ table: "session_memories", column: "agent_id" }],
 		},
 	},
 ];

--- a/packages/core/src/migrations/index.ts
+++ b/packages/core/src/migrations/index.ts
@@ -46,6 +46,7 @@ import { up as entityCommunities } from "./037-entity-communities";
 import { up as memoryHints } from "./038-memory-hints";
 import { up as dedupEntityDependencies } from "./039-dedup-entity-dependencies";
 import { up as sessionTranscripts } from "./040-session-transcripts";
+import { up as pathFeedback } from "./041-path-feedback";
 
 // -- Public interface consumed by Database.init() --
 
@@ -394,6 +395,21 @@ export const MIGRATIONS: readonly Migration[] = [
 		name: "session-transcripts",
 		up: sessionTranscripts,
 		artifacts: { tables: ["session_transcripts"] },
+	},
+	{
+		version: 41,
+		name: "path-feedback",
+		up: pathFeedback,
+		artifacts: {
+			tables: [
+				"path_feedback_events",
+				"path_feedback_stats",
+				"entity_retrieval_stats",
+				"entity_cooccurrence",
+				"path_feedback_sessions",
+			],
+			columns: [{ table: "session_memories", column: "path_json" }],
+		},
 	},
 ];
 

--- a/packages/core/src/migrations/migrations.test.ts
+++ b/packages/core/src/migrations/migrations.test.ts
@@ -221,6 +221,42 @@ describe("migration framework", () => {
 		expect(cols.map((col) => col.name)).toContain("path_json");
 	});
 
+	test("session_memories has agent_id and agent-scoped uniqueness after migration 042", () => {
+		db = createFreshDb();
+		runMigrations(db);
+
+		const cols = db.query("PRAGMA table_info(session_memories)").all() as Array<{
+			name: string;
+		}>;
+		expect(cols.map((col) => col.name)).toContain("agent_id");
+
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO session_memories
+			 (id, session_key, agent_id, memory_id, source, effective_score,
+			  final_score, rank, was_injected, fts_hit_count, created_at)
+			 VALUES (?, ?, ?, ?, 'effective', 0.9, 0.9, 0, 1, 0, ?)`,
+		).run("sm-1", "session-x", "agent-a", "mem-x", now);
+
+		expect(() =>
+			db
+				.prepare(
+					`INSERT INTO session_memories
+					 (id, session_key, agent_id, memory_id, source, effective_score,
+					  final_score, rank, was_injected, fts_hit_count, created_at)
+					 VALUES (?, ?, ?, ?, 'effective', 0.9, 0.9, 0, 1, 0, ?)`,
+				)
+				.run("sm-2", "session-x", "agent-a", "mem-x", now),
+		).toThrow();
+
+		db.prepare(
+			`INSERT INTO session_memories
+			 (id, session_key, agent_id, memory_id, source, effective_score,
+			  final_score, rank, was_injected, fts_hit_count, created_at)
+			 VALUES (?, ?, ?, ?, 'effective', 0.9, 0.9, 0, 1, 0, ?)`,
+		).run("sm-3", "session-x", "agent-b", "mem-x", now);
+	});
+
 	test("entities table has pinning columns after migration 022", () => {
 		db = createFreshDb();
 		runMigrations(db);

--- a/packages/core/src/migrations/migrations.test.ts
+++ b/packages/core/src/migrations/migrations.test.ts
@@ -201,6 +201,26 @@ describe("migration framework", () => {
 		expect(colNames).toContain("structural_density");
 	});
 
+	test("path feedback tables and session path_json column exist after migration 041", () => {
+		db = createFreshDb();
+		runMigrations(db);
+
+		const tableRows = db.query("SELECT name FROM sqlite_master WHERE type='table'").all() as Array<{
+			name: string;
+		}>;
+		const tableNames = new Set(tableRows.map((row) => row.name));
+		expect(tableNames.has("path_feedback_events")).toBe(true);
+		expect(tableNames.has("path_feedback_stats")).toBe(true);
+		expect(tableNames.has("entity_retrieval_stats")).toBe(true);
+		expect(tableNames.has("entity_cooccurrence")).toBe(true);
+		expect(tableNames.has("path_feedback_sessions")).toBe(true);
+
+		const cols = db.query("PRAGMA table_info(session_memories)").all() as Array<{
+			name: string;
+		}>;
+		expect(cols.map((col) => col.name)).toContain("path_json");
+	});
+
 	test("entities table has pinning columns after migration 022", () => {
 		db = createFreshDb();
 		runMigrations(db);

--- a/packages/daemon-rs/contracts/parity-rules.json
+++ b/packages/daemon-rs/contracts/parity-rules.json
@@ -74,8 +74,8 @@
         "ignoreFields": []
       },
       "POST /api/memory/feedback": {
-        "deterministic": ["ok", "recorded", "accepted", "propagated"],
-        "ignoreFields": ["cooccurrenceUpdated", "dependenciesUpdated"],
+        "deterministic": ["ok", "recorded", "accepted"],
+        "ignoreFields": ["propagated", "cooccurrenceUpdated", "dependenciesUpdated"],
         "note": "Rust currently applies feedback to session memories; full path propagation parity is pending."
       },
       "DELETE /api/memory/:id": {

--- a/packages/daemon-rs/contracts/parity-rules.json
+++ b/packages/daemon-rs/contracts/parity-rules.json
@@ -73,6 +73,11 @@
         "deterministic": ["modified"],
         "ignoreFields": []
       },
+      "POST /api/memory/feedback": {
+        "deterministic": ["ok", "recorded", "accepted", "propagated"],
+        "ignoreFields": ["cooccurrenceUpdated", "dependenciesUpdated"],
+        "note": "Rust currently applies feedback to session memories; full path propagation parity is pending."
+      },
       "DELETE /api/memory/:id": {
         "deterministic": ["deleted"],
         "ignoreFields": []

--- a/packages/daemon-rs/crates/signet-daemon/src/feedback.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/feedback.rs
@@ -1,0 +1,42 @@
+//! Shared parsing helpers for memory feedback payloads.
+
+pub fn parse_scores(raw: Option<&serde_json::Value>) -> Option<Vec<(String, f64)>> {
+    let obj = raw?.as_object()?;
+    let mut out = Vec::new();
+    for (id, score) in obj {
+        if id.is_empty() {
+            continue;
+        }
+        let Some(v) = score.as_f64() else {
+            continue;
+        };
+        if !v.is_finite() {
+            continue;
+        }
+        out.push((id.clone(), v.clamp(-1.0, 1.0)));
+    }
+    if out.is_empty() { None } else { Some(out) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_scores;
+    use serde_json::json;
+
+    #[test]
+    fn parse_scores_accepts_and_clamps_scores() {
+        let parsed = parse_scores(Some(&json!({"a": 2.5, "b": -3.0, "c": 0.5}))).unwrap();
+        assert_eq!(parsed.len(), 3);
+        assert_eq!(parsed[0], ("a".to_string(), 1.0));
+        assert_eq!(parsed[1], ("b".to_string(), -1.0));
+        assert_eq!(parsed[2], ("c".to_string(), 0.5));
+    }
+
+    #[test]
+    fn parse_scores_rejects_invalid_maps() {
+        assert!(parse_scores(None).is_none());
+        assert!(parse_scores(Some(&json!(null))).is_none());
+        assert!(parse_scores(Some(&json!({"a": "bad"}))).is_none());
+        assert!(parse_scores(Some(&json!({}))).is_none());
+    }
+}

--- a/packages/daemon-rs/crates/signet-daemon/src/feedback.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/feedback.rs
@@ -25,7 +25,8 @@ mod tests {
 
     #[test]
     fn parse_scores_accepts_and_clamps_scores() {
-        let parsed = parse_scores(Some(&json!({"a": 2.5, "b": -3.0, "c": 0.5}))).unwrap();
+        let mut parsed = parse_scores(Some(&json!({"a": 2.5, "b": -3.0, "c": 0.5}))).unwrap();
+        parsed.sort_by(|a, b| a.0.cmp(&b.0));
         assert_eq!(parsed.len(), 3);
         assert_eq!(parsed[0], ("a".to_string(), 1.0));
         assert_eq!(parsed[1], ("b".to_string(), -1.0));

--- a/packages/daemon-rs/crates/signet-daemon/src/main.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/main.rs
@@ -132,6 +132,10 @@ async fn main() -> anyhow::Result<()> {
             "/api/memory/modify",
             axum::routing::post(routes::write::modify_batch),
         )
+        .route(
+            "/api/memory/feedback",
+            axum::routing::post(routes::memory::feedback),
+        )
         // Config routes
         .route(
             "/api/config",

--- a/packages/daemon-rs/crates/signet-daemon/src/main.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/main.rs
@@ -10,6 +10,7 @@ use tracing::info;
 
 #[allow(dead_code)] // Auth module built but not wired into routes until later phases
 mod auth;
+mod feedback;
 mod mcp;
 mod routes;
 mod service;

--- a/packages/daemon-rs/crates/signet-daemon/src/mcp/tools.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/mcp/tools.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use super::protocol::{ToolCallResult, ToolDefinition};
 use crate::state::AppState;
+use signet_core::db::Priority;
 
 // ---------------------------------------------------------------------------
 // Tool registry
@@ -300,10 +301,10 @@ pub async fn execute(
         "memory_get" => exec_memory_get(state, args).await,
         "memory_list" => exec_memory_list(state, args).await,
         "memory_forget" => exec_memory_forget(state, args).await,
+        "memory_feedback" => exec_memory_feedback(state, args).await,
         "session_bypass" => exec_session_bypass(state, args).await,
         // Tools that need further service integration
         "memory_modify"
-        | "memory_feedback"
         | "knowledge_expand"
         | "agent_peers"
         | "agent_message_send"
@@ -500,6 +501,75 @@ async fn exec_memory_forget(state: &Arc<AppState>, args: &serde_json::Value) -> 
     match result {
         Ok(val) => ToolCallResult::success(val.to_string()),
         Err(e) => ToolCallResult::error(format!("forget failed: {e}")),
+    }
+}
+
+fn parse_ratings(raw: Option<&serde_json::Value>) -> Option<Vec<(String, f64)>> {
+    let obj = raw?.as_object()?;
+    let mut out = Vec::new();
+    for (id, score) in obj {
+        if id.is_empty() {
+            continue;
+        }
+        let Some(v) = score.as_f64() else {
+            continue;
+        };
+        if !v.is_finite() {
+            continue;
+        }
+        out.push((id.clone(), v.clamp(-1.0, 1.0)));
+    }
+    if out.is_empty() { None } else { Some(out) }
+}
+
+async fn exec_memory_feedback(state: &Arc<AppState>, args: &serde_json::Value) -> ToolCallResult {
+    let session_key = match args.get("session_key").and_then(|v| v.as_str()) {
+        Some(v) if !v.is_empty() => v.to_string(),
+        _ => return ToolCallResult::error("missing required parameter: session_key"),
+    };
+    let Some(ratings) = parse_ratings(args.get("ratings")) else {
+        return ToolCallResult::error(
+            "invalid ratings: expected map of memory ID to score (-1 to 1)",
+        );
+    };
+    let recorded = ratings.len() as i64;
+
+    let result = state
+        .pool
+        .write(Priority::High, move |conn| {
+            let mut stmt = conn.prepare_cached(
+                "UPDATE session_memories
+                 SET agent_relevance_score = CASE
+                         WHEN agent_relevance_score IS NULL THEN ?1
+                         ELSE (agent_relevance_score * agent_feedback_count + ?1) / (agent_feedback_count + 1)
+                     END,
+                     agent_feedback_count = COALESCE(agent_feedback_count, 0) + 1
+                 WHERE session_key = ?2 AND memory_id = ?3",
+            )?;
+            let mut accepted = 0_i64;
+            for (memory_id, score) in ratings {
+                let changed = stmt.execute(rusqlite::params![score, session_key, memory_id])?;
+                accepted += changed as i64;
+            }
+            Ok(serde_json::json!({ "accepted": accepted }))
+        })
+        .await;
+
+    match result {
+        Ok(val) => {
+            let accepted = val.get("accepted").and_then(|v| v.as_i64()).unwrap_or(0);
+            let body = serde_json::json!({
+                "ok": true,
+                "recorded": recorded,
+                "accepted": accepted,
+                "propagated": accepted,
+                "cooccurrenceUpdated": 0,
+                "dependenciesUpdated": 0
+            });
+            let text = serde_json::to_string_pretty(&body).unwrap_or_default();
+            ToolCallResult::success(text)
+        }
+        Err(e) => ToolCallResult::error(format!("feedback failed: {e}")),
     }
 }
 

--- a/packages/daemon-rs/crates/signet-daemon/src/mcp/tools.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/mcp/tools.rs
@@ -98,11 +98,23 @@ pub fn definitions() -> Vec<ToolDefinition> {
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "memory_id": { "type": "string" },
-                    "rating": { "type": "string", "enum": ["helpful", "not_helpful", "wrong"] },
-                    "context": { "type": "string" },
+                    "session_key": { "type": "string", "description": "Current session key" },
+                    "agent_id": { "type": "string", "description": "Agent id scope (default: default)" },
+                    "ratings": {
+                        "type": "object",
+                        "additionalProperties": { "type": "number" },
+                        "description": "Map of memory ID to score (-1 to 1)"
+                    },
+                    "paths": {
+                        "type": "object",
+                        "description": "Optional path provenance keyed by memory id"
+                    },
+                    "rewards": {
+                        "type": "object",
+                        "description": "Optional reward signals keyed by memory id"
+                    }
                 },
-                "required": ["memory_id", "rating"],
+                "required": ["session_key", "ratings"],
             }),
         },
         // Knowledge graph (1)

--- a/packages/daemon-rs/crates/signet-daemon/src/mcp/tools.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/mcp/tools.rs
@@ -5,6 +5,7 @@
 use std::sync::Arc;
 
 use super::protocol::{ToolCallResult, ToolDefinition};
+use crate::feedback::parse_scores;
 use crate::state::AppState;
 use signet_core::db::Priority;
 
@@ -504,30 +505,12 @@ async fn exec_memory_forget(state: &Arc<AppState>, args: &serde_json::Value) -> 
     }
 }
 
-fn parse_ratings(raw: Option<&serde_json::Value>) -> Option<Vec<(String, f64)>> {
-    let obj = raw?.as_object()?;
-    let mut out = Vec::new();
-    for (id, score) in obj {
-        if id.is_empty() {
-            continue;
-        }
-        let Some(v) = score.as_f64() else {
-            continue;
-        };
-        if !v.is_finite() {
-            continue;
-        }
-        out.push((id.clone(), v.clamp(-1.0, 1.0)));
-    }
-    if out.is_empty() { None } else { Some(out) }
-}
-
 async fn exec_memory_feedback(state: &Arc<AppState>, args: &serde_json::Value) -> ToolCallResult {
     let session_key = match args.get("session_key").and_then(|v| v.as_str()) {
         Some(v) if !v.is_empty() => v.to_string(),
         _ => return ToolCallResult::error("missing required parameter: session_key"),
     };
-    let Some(ratings) = parse_ratings(args.get("ratings")) else {
+    let Some(ratings) = parse_scores(args.get("ratings")) else {
         return ToolCallResult::error(
             "invalid ratings: expected map of memory ID to score (-1 to 1)",
         );
@@ -562,7 +545,7 @@ async fn exec_memory_feedback(state: &Arc<AppState>, args: &serde_json::Value) -
                 "ok": true,
                 "recorded": recorded,
                 "accepted": accepted,
-                "propagated": accepted,
+                "propagated": 0,
                 "cooccurrenceUpdated": 0,
                 "dependenciesUpdated": 0
             });

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/memory.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/memory.rs
@@ -7,6 +7,9 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use signet_core::db::Priority;
 
 use crate::state::AppState;
 
@@ -230,5 +233,137 @@ pub async fn history(
             Json(serde_json::json!({"error": "Not found"})),
         )
             .into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/memory/feedback
+// ---------------------------------------------------------------------------
+
+fn parse_feedback(raw: &Value) -> Option<Vec<(String, f64)>> {
+    let obj = raw.as_object()?;
+    let mut out = Vec::new();
+    for (id, score) in obj {
+        if id.is_empty() {
+            continue;
+        }
+        let Some(v) = score.as_f64() else {
+            continue;
+        };
+        if !v.is_finite() {
+            continue;
+        }
+        out.push((id.clone(), v.clamp(-1.0, 1.0)));
+    }
+    if out.is_empty() { None } else { Some(out) }
+}
+
+pub async fn feedback(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<Value>,
+) -> impl IntoResponse {
+    let Some(obj) = payload.as_object() else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "Invalid JSON body"})),
+        )
+            .into_response();
+    };
+
+    let session = obj
+        .get("sessionKey")
+        .and_then(Value::as_str)
+        .or_else(|| obj.get("session_key").and_then(Value::as_str));
+    let raw = obj.get("feedback").or_else(|| obj.get("ratings"));
+
+    let Some(session) = session else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "sessionKey and feedback required"})),
+        )
+            .into_response();
+    };
+    let Some(raw) = raw else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "sessionKey and feedback required"})),
+        )
+            .into_response();
+    };
+
+    let Some(feedback) = parse_feedback(raw) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "Invalid feedback format — expected map of ID to number (-1 to 1)"})),
+        )
+            .into_response();
+    };
+
+    let session = session.to_string();
+    let recorded = feedback.len() as i64;
+    let updated = state
+        .pool
+        .write(Priority::High, move |conn| {
+            let mut stmt = conn.prepare_cached(
+                "UPDATE session_memories
+                 SET agent_relevance_score = CASE
+                         WHEN agent_relevance_score IS NULL THEN ?1
+                         ELSE (agent_relevance_score * agent_feedback_count + ?1) / (agent_feedback_count + 1)
+                     END,
+                     agent_feedback_count = COALESCE(agent_feedback_count, 0) + 1
+                 WHERE session_key = ?2 AND memory_id = ?3",
+            )?;
+            let mut accepted = 0_i64;
+            for (memory_id, score) in feedback {
+                let changed = stmt.execute(rusqlite::params![score, session, memory_id])?;
+                accepted += changed as i64;
+            }
+            Ok(serde_json::json!({ "accepted": accepted }))
+        })
+        .await;
+
+    match updated {
+        Ok(val) => {
+            let accepted = val.get("accepted").and_then(Value::as_i64).unwrap_or(0);
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "ok": true,
+                    "recorded": recorded,
+                    "accepted": accepted,
+                    "propagated": accepted,
+                    "cooccurrenceUpdated": 0,
+                    "dependenciesUpdated": 0
+                })),
+            )
+                .into_response()
+        }
+        Err(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "Failed to record feedback"})),
+        )
+            .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_feedback;
+    use serde_json::json;
+
+    #[test]
+    fn parse_feedback_accepts_and_clamps_scores() {
+        let parsed = parse_feedback(&json!({"a": 2.5, "b": -3.0, "c": 0.5})).unwrap();
+        assert_eq!(parsed.len(), 3);
+        assert_eq!(parsed[0], ("a".to_string(), 1.0));
+        assert_eq!(parsed[1], ("b".to_string(), -1.0));
+        assert_eq!(parsed[2], ("c".to_string(), 0.5));
+    }
+
+    #[test]
+    fn parse_feedback_rejects_invalid_maps() {
+        assert!(parse_feedback(&json!(null)).is_none());
+        assert!(parse_feedback(&json!({"a": "bad"})).is_none());
+        assert!(parse_feedback(&json!({})).is_none());
     }
 }

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/memory.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/memory.rs
@@ -11,6 +11,7 @@ use serde_json::Value;
 
 use signet_core::db::Priority;
 
+use crate::feedback::parse_scores;
 use crate::state::AppState;
 
 // ---------------------------------------------------------------------------
@@ -240,24 +241,6 @@ pub async fn history(
 // POST /api/memory/feedback
 // ---------------------------------------------------------------------------
 
-fn parse_feedback(raw: &Value) -> Option<Vec<(String, f64)>> {
-    let obj = raw.as_object()?;
-    let mut out = Vec::new();
-    for (id, score) in obj {
-        if id.is_empty() {
-            continue;
-        }
-        let Some(v) = score.as_f64() else {
-            continue;
-        };
-        if !v.is_finite() {
-            continue;
-        }
-        out.push((id.clone(), v.clamp(-1.0, 1.0)));
-    }
-    if out.is_empty() { None } else { Some(out) }
-}
-
 pub async fn feedback(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<Value>,
@@ -279,19 +262,19 @@ pub async fn feedback(
     let Some(session) = session else {
         return (
             StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({"error": "sessionKey and feedback required"})),
+            Json(serde_json::json!({"error": "sessionKey required"})),
         )
             .into_response();
     };
     let Some(raw) = raw else {
         return (
             StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({"error": "sessionKey and feedback required"})),
+            Json(serde_json::json!({"error": "feedback required"})),
         )
             .into_response();
     };
 
-    let Some(feedback) = parse_feedback(raw) else {
+    let Some(feedback) = parse_scores(Some(raw)) else {
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({"error": "Invalid feedback format — expected map of ID to number (-1 to 1)"})),
@@ -331,7 +314,7 @@ pub async fn feedback(
                     "ok": true,
                     "recorded": recorded,
                     "accepted": accepted,
-                    "propagated": accepted,
+                    "propagated": 0,
                     "cooccurrenceUpdated": 0,
                     "dependenciesUpdated": 0
                 })),
@@ -343,27 +326,5 @@ pub async fn feedback(
             Json(serde_json::json!({"error": "Failed to record feedback"})),
         )
             .into_response(),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::parse_feedback;
-    use serde_json::json;
-
-    #[test]
-    fn parse_feedback_accepts_and_clamps_scores() {
-        let parsed = parse_feedback(&json!({"a": 2.5, "b": -3.0, "c": 0.5})).unwrap();
-        assert_eq!(parsed.len(), 3);
-        assert_eq!(parsed[0], ("a".to_string(), 1.0));
-        assert_eq!(parsed[1], ("b".to_string(), -1.0));
-        assert_eq!(parsed[2], ("c".to_string(), 0.5));
-    }
-
-    #[test]
-    fn parse_feedback_rejects_invalid_maps() {
-        assert!(parse_feedback(&json!(null)).is_none());
-        assert!(parse_feedback(&json!({"a": "bad"})).is_none());
-        assert!(parse_feedback(&json!({})).is_none());
     }
 }

--- a/packages/daemon-rs/crates/signet-daemon/tests/contract_replay.rs
+++ b/packages/daemon-rs/crates/signet-daemon/tests/contract_replay.rs
@@ -258,6 +258,32 @@ async fn search_endpoints() {
 
 #[tokio::test]
 #[ignore = "requires built daemon binary"]
+async fn feedback_endpoint() {
+    let server = TestServer::start().await;
+
+    let bad = server
+        .post("/api/memory/feedback", json!({"sessionKey": "sess-1"}))
+        .await;
+    assert_eq!(bad.status(), 400);
+
+    let ok = server
+        .post(
+            "/api/memory/feedback",
+            json!({
+                "sessionKey": "sess-1",
+                "feedback": { "missing-memory": 1 }
+            }),
+        )
+        .await;
+    assert_eq!(ok.status(), 200);
+    let body = server.json(ok).await;
+    assert_eq!(body["ok"], true);
+    assert_eq!(body["recorded"], 1);
+    assert_eq!(body["accepted"], 0);
+}
+
+#[tokio::test]
+#[ignore = "requires built daemon binary"]
 async fn knowledge_endpoints() {
     let server = TestServer::start().await;
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -214,6 +214,7 @@ import {
 	redactCheckpointRow,
 } from "./session-checkpoints";
 import { parseFeedback, recordAgentFeedback } from "./session-memories";
+import { recordPathFeedback } from "./path-feedback";
 import { closeSynthesisProvider, initSynthesisProvider } from "./synthesis-llm";
 import { type TelemetryCollector, type TelemetryEventType, createTelemetryCollector } from "./telemetry";
 import { type TimelineSources, buildTimeline } from "./timeline";
@@ -3751,8 +3752,33 @@ app.post("/api/memory/feedback", async (c) => {
 		return c.json({ error: "Invalid feedback format — expected map of ID to number (-1 to 1)" }, 400);
 	}
 
-	recordAgentFeedback(sessionKey, parsed);
-	return c.json({ ok: true, recorded: Object.keys(parsed).length });
+	const agentId = parseOptionalString(payload.agentId) ?? "default";
+	const cfg = loadMemoryConfig(AGENTS_DIR).pipelineV2.feedback;
+	try {
+		const result = recordPathFeedback(getDbAccessor(), {
+			sessionKey,
+			agentId,
+			ratings: parsed,
+			paths: payload.paths,
+			rewards: payload.rewards,
+			maxAspectWeight: cfg.maxAspectWeight,
+			minAspectWeight: cfg.minAspectWeight,
+		});
+		return c.json({
+			ok: true,
+			recorded: result.recorded,
+			propagated: result.propagated,
+			cooccurrenceUpdated: result.cooccurrenceUpdated,
+			dependenciesUpdated: result.dependenciesUpdated,
+		});
+	} catch (error) {
+		recordAgentFeedback(sessionKey, parsed);
+		logger.warn("daemon", "Path feedback failed; fell back to legacy feedback", {
+			error: error instanceof Error ? error.message : String(error),
+			sessionKey,
+		});
+		return c.json({ ok: true, recorded: Object.keys(parsed).length, fallback: true });
+	}
 });
 
 app.post("/api/memory/forget", async (c) => {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3761,12 +3761,13 @@ app.post("/api/memory/feedback", async (c) => {
 			ratings: parsed,
 			paths: payload.paths,
 			rewards: payload.rewards,
-			maxAspectWeight: cfg.maxAspectWeight,
-			minAspectWeight: cfg.minAspectWeight,
+			maxAspectWeight: cfg?.maxAspectWeight,
+			minAspectWeight: cfg?.minAspectWeight,
 		});
 		return c.json({
 			ok: true,
-			recorded: result.recorded,
+			recorded: Object.keys(parsed).length,
+			accepted: result.accepted,
 			propagated: result.propagated,
 			cooccurrenceUpdated: result.cooccurrenceUpdated,
 			dependenciesUpdated: result.dependenciesUpdated,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3773,7 +3773,7 @@ app.post("/api/memory/feedback", async (c) => {
 			dependenciesUpdated: result.dependenciesUpdated,
 		});
 	} catch (error) {
-		recordAgentFeedback(sessionKey, parsed);
+		recordAgentFeedback(sessionKey, parsed, agentId);
 		logger.warn("daemon", "Path feedback failed; fell back to legacy feedback", {
 			error: error instanceof Error ? error.message : String(error),
 			sessionKey,

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -1314,7 +1314,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 				};
 			}),
 	];
-	recordSessionCandidates(req.sessionKey, candidatesForRecording, injectedSet);
+	recordSessionCandidates(req.sessionKey, candidatesForRecording, injectedSet, agentId);
 
 	// Format inject text
 	const injectParts: string[] = [];
@@ -1846,7 +1846,7 @@ export async function handleUserPromptSubmit(req: UserPromptSubmitRequest): Prom
 		try {
 			const parsed = parseFeedback(req.memory_feedback);
 			if (parsed) {
-				recordAgentFeedback(req.sessionKey, parsed);
+				recordAgentFeedback(req.sessionKey, parsed, req.agentId ?? "default");
 			} else {
 				logger.warn("hooks", "Invalid memory_feedback format, skipping", {
 					sessionKey: req.sessionKey,
@@ -1938,7 +1938,7 @@ export async function handleUserPromptSubmit(req: UserPromptSubmitRequest): Prom
 
 		// Track FTS hits for predictive scorer data collection (full results, pre-dedup)
 		const allMatchedIds = recall.results.map((result) => result.id);
-		trackFtsHits(req.sessionKey, allMatchedIds);
+		trackFtsHits(req.sessionKey, allMatchedIds, req.agentId ?? "default");
 
 		// Filter out memories already injected within the sliding window
 		let selected = budgetSelected;

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -38,7 +38,13 @@ import {
 	runPredictorScoring,
 } from "./predictor-scoring";
 import { propagateMemoryStatus } from "./knowledge-graph";
-import { invalidateTraversalCache, resolveFocalEntities, setTraversalStatus, traverseKnowledgeGraph } from "./pipeline/graph-traversal";
+import {
+	type TraversalPath,
+	invalidateTraversalCache,
+	resolveFocalEntities,
+	setTraversalStatus,
+	traverseKnowledgeGraph,
+} from "./pipeline/graph-traversal";
 import {
 	applyFtsOverlapFeedback,
 	decayAspectWeights,
@@ -114,6 +120,18 @@ function sanitizePeerPromptField(value: string | undefined): string {
 		.replace(/[\r\n`*#[\]<>]/g, " ")
 		.replace(/\s+/g, " ")
 		.trim();
+}
+
+function toUnique(values: ReadonlyArray<string>): string[] {
+	return [...new Set(values.filter((value) => typeof value === "string" && value.length > 0))];
+}
+
+function serializeTraversalPath(path: TraversalPath): string {
+	return JSON.stringify({
+		entity_ids: toUnique(path.entityIds),
+		aspect_ids: toUnique(path.aspectIds),
+		dependency_ids: toUnique(path.dependencyIds),
+	});
 }
 
 // ============================================================================
@@ -998,6 +1016,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	let traversalConstraints = 0;
 	let traversalTimedOut = false;
 	let traversalActiveAspectIds: ReadonlyArray<string> = [];
+	const traversalPathById = new Map<string, string>();
 	let constraintsForInject: ReadonlyArray<{
 		readonly entityName: string;
 		readonly content: string;
@@ -1026,6 +1045,9 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 				constraintsForInject = traversalResult.constraints;
 				traversalConstraints = traversalResult.constraints.length;
 				traversalActiveAspectIds = traversalResult.activeAspectIds;
+				for (const [memoryId, path] of traversalResult.memoryPaths) {
+					traversalPathById.set(memoryId, serializeTraversalPath(path));
+				}
 
 				for (const memoryId of traversalResult.memoryIds) {
 					if (!candidateById.has(memoryId)) {
@@ -1270,6 +1292,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 				aspectSlot: sf?.aspectSlot ?? 0,
 				isConstraint: sf?.isConstraint ?? 0,
 				structuralDensity: sf?.structuralDensity ?? 0,
+				pathJson: traversalPathById.get(c.id) ?? null,
 			};
 		}),
 		...predictedMemories
@@ -1287,6 +1310,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 					aspectSlot: sf?.aspectSlot ?? 0,
 					isConstraint: sf?.isConstraint ?? 0,
 					structuralDensity: sf?.structuralDensity ?? 0,
+					pathJson: traversalPathById.get(m.id) ?? null,
 				};
 			}),
 	];

--- a/packages/daemon/src/mcp/tools.test.ts
+++ b/packages/daemon/src/mcp/tools.test.ts
@@ -241,6 +241,42 @@ describe("createMcpServer", () => {
 		});
 	});
 
+	describe("memory_feedback", () => {
+		it("posts ratings with optional path and reward payload", async () => {
+			const cap: { method?: string; body?: string } = {};
+			mockFetch(200, { ok: true, recorded: 2 }, cap);
+
+			await callTool(server, "memory_feedback", {
+				session_key: "sess-1",
+				agent_id: "default",
+				ratings: { mem1: 1, mem2: -0.5 },
+				paths: {
+					mem1: {
+						entity_ids: ["ent-a", "ent-b"],
+						aspect_ids: ["asp-a"],
+						dependency_ids: ["dep-a"],
+					},
+				},
+				rewards: {
+					mem1: {
+						forward_citation: 1,
+						update_after_retrieval: 0.5,
+						downstream_creation: 0,
+						dead_end: 0,
+					},
+				},
+			});
+
+			expect(cap.method).toBe("POST");
+			const body = JSON.parse(cap.body ?? "{}");
+			expect(body.sessionKey).toBe("sess-1");
+			expect(body.agentId).toBe("default");
+			expect(body.feedback.mem1).toBe(1);
+			expect(body.paths.mem1.entity_ids[0]).toBe("ent-a");
+			expect(body.rewards.mem1.forward_citation).toBe(1);
+		});
+	});
+
 	describe("cross-agent tools", () => {
 		it("agent_peers calls presence endpoint with defaults", async () => {
 			const cap: { url?: string } = {};

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -750,14 +750,44 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 				"Scores from -1 (harmful) to 1 (directly helpful). 0 = unused.",
 			inputSchema: z.object({
 				session_key: z.string().describe("Current session key"),
+				agent_id: z.string().optional().describe("Agent id scope (default: default)"),
 				ratings: z.record(z.string(), z.number()).describe("Map of memory ID to relevance score (-1 to 1)"),
+				paths: z
+					.record(
+						z.string(),
+						z.object({
+							entity_ids: z.array(z.string()).optional(),
+							aspect_ids: z.array(z.string()).optional(),
+							dependency_ids: z.array(z.string()).optional(),
+						}),
+					)
+					.optional()
+					.describe("Optional path provenance keyed by memory id"),
+				rewards: z
+					.record(
+						z.string(),
+						z.object({
+							forward_citation: z.number().optional(),
+							update_after_retrieval: z.number().optional(),
+							downstream_creation: z.number().optional(),
+							dead_end: z.number().optional(),
+						}),
+					)
+					.optional()
+					.describe("Optional reward signals keyed by memory id"),
 			}),
 			annotations: { readOnlyHint: false },
 		},
-		async ({ session_key, ratings }) => {
+		async ({ session_key, agent_id, ratings, paths, rewards }) => {
 			const result = await daemonFetch<{ ok: boolean; recorded: number }>(baseUrl, "/api/memory/feedback", {
 				method: "POST",
-				body: { sessionKey: session_key, feedback: ratings },
+				body: {
+					sessionKey: session_key,
+					agentId: agent_id,
+					feedback: ratings,
+					paths,
+					rewards,
+				},
 			});
 			if (!result.ok) {
 				return errorResult(`Feedback failed: ${result.error}`);

--- a/packages/daemon/src/memory-feedback-api.test.ts
+++ b/packages/daemon/src/memory-feedback-api.test.ts
@@ -1,0 +1,112 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+
+let app: {
+	request: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+};
+let agentsDir = "";
+const dbFiles = ["memories.db", "memories.db-shm", "memories.db-wal"];
+let originalSignetPath: string | undefined;
+
+function resetDbFiles(): void {
+	for (const file of dbFiles) {
+		rmSync(join(agentsDir, "memory", file), { force: true });
+	}
+}
+
+function seedSessionMemory(args: { id: string; sessionKey: string; memoryId: string }): void {
+	const now = new Date().toISOString();
+	getDbAccessor().withWriteTx((db) => {
+		db.prepare(
+			`INSERT INTO session_memories
+			 (id, session_key, memory_id, source, effective_score, final_score, rank, was_injected, fts_hit_count, created_at, path_json)
+			 VALUES (?, ?, ?, 'ka_traversal', 0.8, 0.8, 0, 1, 0, ?, NULL)`,
+		).run(args.id, args.sessionKey, args.memoryId, now);
+	});
+}
+
+describe("memory feedback API", () => {
+	beforeAll(async () => {
+		originalSignetPath = process.env.SIGNET_PATH;
+		agentsDir = mkdtempSync(join(tmpdir(), "signet-daemon-feedback-api-"));
+		mkdirSync(join(agentsDir, "memory"), { recursive: true });
+		writeFileSync(
+			join(agentsDir, "agent.yaml"),
+			`memory:
+  pipelineV2:
+    enabled: false
+    shadowMode: false
+    allowUpdateDelete: true
+`,
+		);
+		process.env.SIGNET_PATH = agentsDir;
+
+		const daemon = await import("./daemon");
+		app = daemon.app;
+	});
+
+	beforeEach(() => {
+		closeDbAccessor();
+		resetDbFiles();
+		initDbAccessor(join(agentsDir, "memory", "memories.db"));
+	});
+
+	afterEach(() => {
+		closeDbAccessor();
+	});
+
+	afterAll(() => {
+		closeDbAccessor();
+		if (originalSignetPath === undefined) {
+			process.env.SIGNET_PATH = undefined;
+		} else {
+			process.env.SIGNET_PATH = originalSignetPath;
+		}
+		rmSync(agentsDir, { recursive: true, force: true });
+	});
+
+	it("returns recorded total and accepted subset for mixed feedback ids", async () => {
+		seedSessionMemory({
+			id: "sm-feedback-1",
+			sessionKey: "sess-feedback",
+			memoryId: "mem-feedback-1",
+		});
+
+		const res = await app.request("http://localhost/api/memory/feedback", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				sessionKey: "sess-feedback",
+				feedback: {
+					"mem-feedback-1": 1,
+					"mem-feedback-missing": -1,
+				},
+				paths: {
+					"mem-feedback-1": {
+						entity_ids: ["ent-a"],
+					},
+					"mem-feedback-missing": {
+						entity_ids: ["ent-b"],
+					},
+				},
+			}),
+		});
+		const json = (await res.json()) as {
+			ok?: boolean;
+			recorded?: number;
+			accepted?: number;
+			propagated?: number;
+			fallback?: boolean;
+		};
+
+		expect(res.status).toBe(200);
+		expect(json.ok).toBe(true);
+		expect(json.recorded).toBe(2);
+		expect(json.accepted).toBe(1);
+		expect(json.propagated).toBe(1);
+		expect(json.fallback).toBeUndefined();
+	});
+});

--- a/packages/daemon/src/path-feedback.test.ts
+++ b/packages/daemon/src/path-feedback.test.ts
@@ -1,0 +1,163 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { runMigrations } from "@signet/core";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const TEST_DIR = join(tmpdir(), `signet-path-feedback-test-${Date.now()}`);
+process.env.SIGNET_PATH = TEST_DIR;
+
+const { initDbAccessor, closeDbAccessor, getDbAccessor } = await import("./db-accessor");
+const { recordPathFeedback } = await import("./path-feedback");
+
+function ensureDir(path: string): void {
+	mkdirSync(path, { recursive: true });
+}
+
+function setupDb(): Database {
+	const dbPath = join(TEST_DIR, "memory", "memories.db");
+	ensureDir(join(TEST_DIR, "memory"));
+	if (existsSync(dbPath)) rmSync(dbPath);
+
+	const db = new Database(dbPath);
+	db.exec("PRAGMA busy_timeout = 5000");
+	runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+	closeDbAccessor();
+	initDbAccessor(dbPath);
+	return db;
+}
+
+function seedGraph(db: Database): void {
+	const ts = new Date().toISOString();
+	db.prepare(
+		`INSERT INTO memories
+		 (id, type, content, confidence, importance, created_at, updated_at, updated_by, vector_clock, is_deleted)
+		 VALUES (?, 'fact', ?, 1.0, 0.5, ?, ?, 'test', '{}', 0)`,
+	).run("mem-a", "A memory", ts, ts);
+	db.prepare(
+		`INSERT INTO entities
+		 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+		 VALUES (?, ?, ?, 'project', 'default', 1, ?, ?)`,
+	).run("ent-a", "Entity A", "entity a", ts, ts);
+	db.prepare(
+		`INSERT INTO entities
+		 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+		 VALUES (?, ?, ?, 'project', 'default', 1, ?, ?)`,
+	).run("ent-b", "Entity B", "entity b", ts, ts);
+	db.prepare(
+		`INSERT INTO entity_aspects
+		 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+		 VALUES (?, ?, 'default', 'timeline', 'timeline', 0.5, ?, ?)`,
+	).run("asp-a", "ent-a", ts, ts);
+	db.prepare(
+		`INSERT INTO entity_attributes
+		 (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, confidence, importance, status, created_at, updated_at)
+		 VALUES (?, ?, 'default', ?, 'attribute', 'x', 'x', 1, 0.8, 'active', ?, ?)`,
+	).run("attr-a", "asp-a", "mem-a", ts, ts);
+	db.prepare(
+		`INSERT INTO entity_dependencies
+		 (id, source_entity_id, target_entity_id, agent_id, dependency_type, strength, confidence, reason, created_at, updated_at)
+		 VALUES (?, ?, ?, 'default', 'related_to', 0.5, 0.7, 'single-memory', ?, ?)`,
+	).run("dep-a", "ent-a", "ent-b", ts, ts);
+	db.prepare(
+		`INSERT INTO session_memories
+		 (id, session_key, memory_id, source, effective_score, final_score, rank, was_injected, fts_hit_count, created_at, path_json)
+		 VALUES (?, ?, ?, 'ka_traversal', 0.8, 0.8, 0, 1, 0, ?, ?)`,
+	).run(
+		"sm-a",
+		"sess-a",
+		"mem-a",
+		ts,
+		JSON.stringify({
+			entity_ids: ["ent-a", "ent-b"],
+			aspect_ids: ["asp-a"],
+			dependency_ids: ["dep-a"],
+		}),
+	);
+}
+
+let db: Database;
+
+beforeEach(() => {
+	if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true, force: true });
+	ensureDir(TEST_DIR);
+	db = setupDb();
+	seedGraph(db);
+});
+
+afterEach(() => {
+	db.close();
+	closeDbAccessor();
+	if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe("recordPathFeedback", () => {
+	it("writes event/stats and propagates aspect + dependency updates", () => {
+		const result = recordPathFeedback(getDbAccessor(), {
+			sessionKey: "sess-a",
+			agentId: "default",
+			ratings: { "mem-a": 1 },
+			rewards: { "mem-a": { forward_citation: 1 } },
+		});
+
+		expect(result.recorded).toBe(1);
+		expect(result.propagated).toBe(1);
+
+		const event = db
+			.prepare("SELECT rating, reward_forward FROM path_feedback_events WHERE memory_id = ?")
+			.get("mem-a") as { rating: number; reward_forward: number } | undefined;
+		expect(event).toBeDefined();
+		expect(event?.rating).toBe(1);
+		expect(event?.reward_forward).toBe(1);
+
+		const stats = db
+			.prepare("SELECT sample_count, positive_count FROM path_feedback_stats LIMIT 1")
+			.get() as { sample_count: number; positive_count: number } | undefined;
+		expect(stats?.sample_count).toBe(1);
+		expect(stats?.positive_count).toBe(1);
+
+		const aspect = db
+			.prepare("SELECT weight FROM entity_aspects WHERE id = 'asp-a'")
+			.get() as { weight: number } | undefined;
+		expect(aspect?.weight).toBeGreaterThan(0.5);
+
+		const dep = db
+			.prepare("SELECT strength, reason FROM entity_dependencies WHERE id = 'dep-a'")
+			.get() as { strength: number; reason: string } | undefined;
+		expect(dep?.strength).toBeGreaterThan(0.5);
+		expect(dep?.reason).toBe("pattern-matched");
+	});
+
+	it("promotes co-occurrence edge after repeated sessions", () => {
+		for (const key of ["sess-co-1", "sess-co-2", "sess-co-3"]) {
+			recordPathFeedback(getDbAccessor(), {
+				sessionKey: key,
+				agentId: "default",
+				ratings: { "mem-a": 1 },
+				paths: {
+					"mem-a": {
+						entity_ids: ["ent-a", "ent-b"],
+						aspect_ids: [],
+						dependency_ids: [],
+					},
+				},
+			});
+		}
+
+		const edge = db
+			.prepare(
+				`SELECT reason, confidence
+				 FROM entity_dependencies
+				 WHERE source_entity_id = 'ent-a'
+				   AND target_entity_id = 'ent-b'
+				   AND dependency_type = 'related_to'
+				 ORDER BY updated_at DESC
+				 LIMIT 1`,
+			)
+			.get() as { reason: string; confidence: number } | undefined;
+		expect(edge).toBeDefined();
+		expect(edge?.reason).toBe("pattern-matched");
+		expect(edge?.confidence).toBeGreaterThanOrEqual(0.5);
+	});
+});

--- a/packages/daemon/src/path-feedback.test.ts
+++ b/packages/daemon/src/path-feedback.test.ts
@@ -77,13 +77,19 @@ function seedGraph(db: Database): void {
 	);
 }
 
-function seedSessionMemory(db: Database, sessionKey: string, memoryId: string, pathJson: string | null = null): void {
+function seedSessionMemory(
+	db: Database,
+	sessionKey: string,
+	memoryId: string,
+	pathJson: string | null = null,
+	agentId = "default",
+): void {
 	const ts = new Date().toISOString();
 	db.prepare(
 		`INSERT INTO session_memories
-		 (id, session_key, memory_id, source, effective_score, final_score, rank, was_injected, fts_hit_count, created_at, path_json)
-		 VALUES (?, ?, ?, 'ka_traversal', 0.8, 0.8, 0, 1, 0, ?, ?)`,
-	).run(`sm-${sessionKey}-${memoryId}`, sessionKey, memoryId, ts, pathJson);
+		 (id, session_key, agent_id, memory_id, source, effective_score, final_score, rank, was_injected, fts_hit_count, created_at, path_json)
+		 VALUES (?, ?, ?, ?, 'ka_traversal', 0.8, 0.8, 0, 1, 0, ?, ?)`,
+	).run(`sm-${sessionKey}-${memoryId}-${agentId}`, sessionKey, agentId, memoryId, ts, pathJson);
 }
 
 let db: Database;
@@ -159,6 +165,26 @@ describe("recordPathFeedback", () => {
 			| { cnt: number }
 			| undefined;
 		expect(events?.cnt).toBe(0);
+	});
+
+	it("skips IDs recorded for a different agent with same session key", () => {
+		seedSessionMemory(db, "sess-shared", "mem-a", null, "agent-b");
+
+		const result = recordPathFeedback(getDbAccessor(), {
+			sessionKey: "sess-shared",
+			agentId: "agent-a",
+			ratings: { "mem-a": 1 },
+			paths: {
+				"mem-a": {
+					entity_ids: ["ent-a"],
+					aspect_ids: ["asp-a"],
+					dependency_ids: ["dep-a"],
+				},
+			},
+		});
+
+		expect(result.accepted).toBe(0);
+		expect(result.propagated).toBe(0);
 	});
 
 	it("assigns a default reason when positive feedback hits NULL reason", () => {

--- a/packages/daemon/src/path-feedback.test.ts
+++ b/packages/daemon/src/path-feedback.test.ts
@@ -1,9 +1,9 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { runMigrations } from "@signet/core";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { runMigrations } from "@signet/core";
 
 const TEST_DIR = join(tmpdir(), `signet-path-feedback-test-${Date.now()}`);
 process.env.SIGNET_PATH = TEST_DIR;
@@ -77,6 +77,15 @@ function seedGraph(db: Database): void {
 	);
 }
 
+function seedSessionMemory(db: Database, sessionKey: string, memoryId: string, pathJson: string | null = null): void {
+	const ts = new Date().toISOString();
+	db.prepare(
+		`INSERT INTO session_memories
+		 (id, session_key, memory_id, source, effective_score, final_score, rank, was_injected, fts_hit_count, created_at, path_json)
+		 VALUES (?, ?, ?, 'ka_traversal', 0.8, 0.8, 0, 1, 0, ?, ?)`,
+	).run(`sm-${sessionKey}-${memoryId}`, sessionKey, memoryId, ts, pathJson);
+}
+
 let db: Database;
 
 beforeEach(() => {
@@ -101,7 +110,7 @@ describe("recordPathFeedback", () => {
 			rewards: { "mem-a": { forward_citation: 1 } },
 		});
 
-		expect(result.recorded).toBe(1);
+		expect(result.accepted).toBe(1);
 		expect(result.propagated).toBe(1);
 
 		const event = db
@@ -111,26 +120,80 @@ describe("recordPathFeedback", () => {
 		expect(event?.rating).toBe(1);
 		expect(event?.reward_forward).toBe(1);
 
-		const stats = db
-			.prepare("SELECT sample_count, positive_count FROM path_feedback_stats LIMIT 1")
-			.get() as { sample_count: number; positive_count: number } | undefined;
+		const stats = db.prepare("SELECT sample_count, positive_count FROM path_feedback_stats LIMIT 1").get() as
+			| { sample_count: number; positive_count: number }
+			| undefined;
 		expect(stats?.sample_count).toBe(1);
 		expect(stats?.positive_count).toBe(1);
 
-		const aspect = db
-			.prepare("SELECT weight FROM entity_aspects WHERE id = 'asp-a'")
-			.get() as { weight: number } | undefined;
+		const aspect = db.prepare("SELECT weight FROM entity_aspects WHERE id = 'asp-a'").get() as
+			| { weight: number }
+			| undefined;
 		expect(aspect?.weight).toBeGreaterThan(0.5);
 
-		const dep = db
-			.prepare("SELECT strength, reason FROM entity_dependencies WHERE id = 'dep-a'")
-			.get() as { strength: number; reason: string } | undefined;
+		const dep = db.prepare("SELECT strength, reason FROM entity_dependencies WHERE id = 'dep-a'").get() as
+			| { strength: number; reason: string }
+			| undefined;
 		expect(dep?.strength).toBeGreaterThan(0.5);
 		expect(dep?.reason).toBe("pattern-matched");
 	});
 
+	it("skips IDs that do not belong to the rated session", () => {
+		const result = recordPathFeedback(getDbAccessor(), {
+			sessionKey: "sess-a",
+			agentId: "default",
+			ratings: { ghost: 1 },
+			paths: {
+				ghost: {
+					entity_ids: ["ent-a", "ent-b"],
+					aspect_ids: ["asp-a"],
+					dependency_ids: ["dep-a"],
+				},
+			},
+		});
+
+		expect(result.accepted).toBe(0);
+		expect(result.propagated).toBe(0);
+
+		const events = db.prepare("SELECT COUNT(*) AS cnt FROM path_feedback_events WHERE memory_id = 'ghost'").get() as
+			| { cnt: number }
+			| undefined;
+		expect(events?.cnt).toBe(0);
+	});
+
+	it("assigns a default reason when positive feedback hits NULL reason", () => {
+		const ts = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO entity_dependencies
+			 (id, source_entity_id, target_entity_id, agent_id, dependency_type, strength, confidence, reason, created_at, updated_at)
+			 VALUES ('dep-null', 'ent-a', 'ent-b', 'default', 'depends_on', 0.4, 0.4, NULL, ?, ?)`,
+		).run(ts, ts);
+
+		const result = recordPathFeedback(getDbAccessor(), {
+			sessionKey: "sess-a",
+			agentId: "default",
+			ratings: { "mem-a": 1 },
+			paths: {
+				"mem-a": {
+					entity_ids: ["ent-a", "ent-b"],
+					aspect_ids: [],
+					dependency_ids: ["dep-null"],
+				},
+			},
+		});
+		expect(result.accepted).toBe(1);
+		expect(result.propagated).toBe(1);
+
+		const dep = db.prepare("SELECT reason, confidence FROM entity_dependencies WHERE id = 'dep-null'").get() as
+			| { reason: string | null; confidence: number }
+			| undefined;
+		expect(dep?.reason).toBe("single-memory");
+		expect(dep?.confidence).toBeGreaterThanOrEqual(0.7);
+	});
+
 	it("promotes co-occurrence edge after repeated sessions", () => {
 		for (const key of ["sess-co-1", "sess-co-2", "sess-co-3"]) {
+			seedSessionMemory(db, key, "mem-a");
 			recordPathFeedback(getDbAccessor(), {
 				sessionKey: key,
 				agentId: "default",
@@ -145,7 +208,7 @@ describe("recordPathFeedback", () => {
 			});
 		}
 
-		const edge = db
+		const forward = db
 			.prepare(
 				`SELECT reason, confidence
 				 FROM entity_dependencies
@@ -156,8 +219,23 @@ describe("recordPathFeedback", () => {
 				 LIMIT 1`,
 			)
 			.get() as { reason: string; confidence: number } | undefined;
-		expect(edge).toBeDefined();
-		expect(edge?.reason).toBe("pattern-matched");
-		expect(edge?.confidence).toBeGreaterThanOrEqual(0.5);
+		expect(forward).toBeDefined();
+		expect(forward?.reason).toBe("pattern-matched");
+		expect(forward?.confidence).toBeGreaterThanOrEqual(0.5);
+
+		const reverse = db
+			.prepare(
+				`SELECT reason, confidence
+				 FROM entity_dependencies
+				 WHERE source_entity_id = 'ent-b'
+				   AND target_entity_id = 'ent-a'
+				   AND dependency_type = 'related_to'
+				 ORDER BY updated_at DESC
+				 LIMIT 1`,
+			)
+			.get() as { reason: string; confidence: number } | undefined;
+		expect(reverse).toBeDefined();
+		expect(reverse?.reason).toBe("pattern-matched");
+		expect(reverse?.confidence).toBeGreaterThanOrEqual(0.5);
 	});
 });

--- a/packages/daemon/src/path-feedback.ts
+++ b/packages/daemon/src/path-feedback.ts
@@ -171,6 +171,7 @@ function inferPath(db: WriteDb, memoryId: string, agentId: string): FeedbackPath
 function loadSessionData(
 	db: WriteDb,
 	sessionKey: string,
+	agentId: string,
 	memoryIds: ReadonlyArray<string>,
 ): {
 	readonly sessionIds: Set<string>;
@@ -188,9 +189,10 @@ function loadSessionData(
 			`SELECT memory_id, path_json
 			 FROM session_memories
 			 WHERE session_key = ?
+			   AND agent_id = ?
 			   AND memory_id IN (${ph})`,
 		)
-		.all(sessionKey, ...memoryIds) as Array<{ memory_id: string; path_json: string | null }>;
+		.all(sessionKey, agentId, ...memoryIds) as Array<{ memory_id: string; path_json: string | null }>;
 	const sessionIds = new Set<string>();
 	const storedById = new Map<string, FeedbackPath>();
 	for (const row of rows) {
@@ -549,10 +551,10 @@ export function recordPathFeedback(
 	};
 
 	return accessor.withWriteTx((db) => {
-		recordAgentFeedbackInner(db, input.sessionKey, input.ratings);
+		recordAgentFeedbackInner(db, input.sessionKey, input.ratings, input.agentId);
 		const ts = new Date().toISOString();
 		const ids = Object.keys(input.ratings);
-		const sessionData = loadSessionData(db, input.sessionKey, ids);
+		const sessionData = loadSessionData(db, input.sessionKey, input.agentId, ids);
 		const sessionIds = sessionData.sessionIds;
 		const storedById = sessionData.storedById;
 		db.prepare(

--- a/packages/daemon/src/path-feedback.ts
+++ b/packages/daemon/src/path-feedback.ts
@@ -16,7 +16,7 @@ export interface FeedbackReward {
 }
 
 export interface PathFeedbackResult {
-	readonly recorded: number;
+	readonly accepted: number;
 	readonly propagated: number;
 	readonly cooccurrenceUpdated: number;
 	readonly dependenciesUpdated: number;
@@ -131,12 +131,14 @@ function reasonConfidence(reason: string | null): number {
 
 function nextReason(reason: string | null, rating: number): string | null {
 	if (rating > 0) {
+		if (reason === null) return "single-memory";
 		if (reason === "llm-uncertain") return "single-memory";
 		if (reason === "single-memory") return "pattern-matched";
 		if (reason === "pattern-matched") return "multi-memory";
 		return reason;
 	}
 	if (rating < 0) {
+		if (reason === null) return "llm-uncertain";
 		if (reason === "multi-memory") return "pattern-matched";
 		if (reason === "pattern-matched") return "single-memory";
 		if (reason === "single-memory") return "llm-uncertain";
@@ -166,11 +168,7 @@ function inferPath(db: WriteDb, memoryId: string, agentId: string): FeedbackPath
 	};
 }
 
-function loadStoredPaths(
-	db: WriteDb,
-	sessionKey: string,
-	memoryIds: ReadonlyArray<string>,
-): Map<string, FeedbackPath> {
+function loadStoredPaths(db: WriteDb, sessionKey: string, memoryIds: ReadonlyArray<string>): Map<string, FeedbackPath> {
 	if (memoryIds.length === 0) return new Map();
 	const ph = memoryIds.map(() => "?").join(", ");
 	const rows = db
@@ -208,6 +206,20 @@ function parsePathMap(raw: unknown): Map<string, FeedbackPath> {
 		map.set(id, path);
 	}
 	return map;
+}
+
+function loadSessionMembership(db: WriteDb, sessionKey: string, memoryIds: ReadonlyArray<string>): Set<string> {
+	if (memoryIds.length === 0) return new Set();
+	const ph = memoryIds.map(() => "?").join(", ");
+	const rows = db
+		.prepare(
+			`SELECT memory_id
+			 FROM session_memories
+			 WHERE session_key = ?
+			   AND memory_id IN (${ph})`,
+		)
+		.all(sessionKey, ...memoryIds) as Array<{ memory_id: string }>;
+	return new Set(rows.map((row) => row.memory_id));
 }
 
 function parseRewardMap(raw: unknown): Map<string, FeedbackReward> {
@@ -339,9 +351,9 @@ function upsertPathStats(
 }
 
 function sessionCount(db: WriteDb, agentId: string): number {
-	const row = db
-		.prepare("SELECT COUNT(*) AS cnt FROM path_feedback_sessions WHERE agent_id = ?")
-		.get(agentId) as { cnt: number } | undefined;
+	const row = db.prepare("SELECT COUNT(*) AS cnt FROM path_feedback_sessions WHERE agent_id = ?").get(agentId) as
+		| { cnt: number }
+		| undefined;
 	return Number(row?.cnt ?? 0);
 }
 
@@ -409,11 +421,17 @@ function countAutoEdges(db: WriteDb, agentId: string, source: string): number {
 	return Number(row?.cnt ?? 0);
 }
 
-function maybePromotePair(
+function canonicalPair(a: string, b: string): readonly [string, string] {
+	return a < b ? [a, b] : [b, a];
+}
+
+function maybePromoteDirected(
 	db: WriteDb,
 	agentId: string,
-	source: string,
-	target: string,
+	pairSource: string,
+	pairTarget: string,
+	edgeSource: string,
+	edgeTarget: string,
 	total: number,
 	cfg: PathFeedbackConfig,
 	ts: string,
@@ -427,7 +445,7 @@ function maybePromotePair(
 			   AND source_entity_id = ?
 			   AND target_entity_id = ?`,
 		)
-		.get(agentId, source, target) as { session_count: number } | undefined;
+		.get(agentId, pairSource, pairTarget) as { session_count: number } | undefined;
 	const src = db
 		.prepare(
 			`SELECT session_count
@@ -435,7 +453,7 @@ function maybePromotePair(
 			 WHERE agent_id = ?
 			   AND entity_id = ?`,
 		)
-		.get(agentId, source) as { session_count: number } | undefined;
+		.get(agentId, edgeSource) as { session_count: number } | undefined;
 	const tgt = db
 		.prepare(
 			`SELECT session_count
@@ -443,7 +461,7 @@ function maybePromotePair(
 			 WHERE agent_id = ?
 			   AND entity_id = ?`,
 		)
-		.get(agentId, target) as { session_count: number } | undefined;
+		.get(agentId, edgeTarget) as { session_count: number } | undefined;
 	const co = Number(pair?.session_count ?? 0);
 	const sx = Number(src?.session_count ?? 0);
 	const sy = Number(tgt?.session_count ?? 0);
@@ -466,16 +484,16 @@ function maybePromotePair(
 			   AND dependency_type = 'related_to'
 			 LIMIT 1`,
 		)
-		.get(agentId, source, target) as { id: string; strength: number; confidence: number } | undefined;
+		.get(agentId, edgeSource, edgeTarget) as { id: string; strength: number; confidence: number } | undefined;
 	const strength = clamp(0.3 + npmi * 0.5, 0.3, 0.9);
 	if (!existing) {
-		if (countAutoEdges(db, agentId, source) >= cfg.autoEdgeCap) return false;
+		if (countAutoEdges(db, agentId, edgeSource) >= cfg.autoEdgeCap) return false;
 		db.prepare(
 			`INSERT INTO entity_dependencies
 			 (id, source_entity_id, target_entity_id, agent_id, aspect_id,
 			  dependency_type, strength, confidence, reason, created_at, updated_at)
 			 VALUES (?, ?, ?, ?, NULL, 'related_to', ?, 0.5, 'pattern-matched', ?, ?)`,
-		).run(crypto.randomUUID(), source, target, agentId, strength, ts, ts);
+		).run(crypto.randomUUID(), edgeSource, edgeTarget, agentId, strength, ts, ts);
 		return true;
 	}
 	db.prepare(
@@ -488,6 +506,26 @@ function maybePromotePair(
 		   AND agent_id = ?`,
 	).run(Math.max(existing.strength, strength), Math.max(existing.confidence, 0.5), ts, existing.id, agentId);
 	return true;
+}
+
+function maybePromotePair(
+	db: WriteDb,
+	agentId: string,
+	source: string,
+	target: string,
+	total: number,
+	cfg: PathFeedbackConfig,
+	ts: string,
+): number {
+	const [pairSource, pairTarget] = canonicalPair(source, target);
+	let count = 0;
+	if (maybePromoteDirected(db, agentId, pairSource, pairTarget, source, target, total, cfg, ts)) {
+		count++;
+	}
+	if (maybePromoteDirected(db, agentId, pairSource, pairTarget, target, source, total, cfg, ts)) {
+		count++;
+	}
+	return count;
 }
 
 export function recordPathFeedback(
@@ -514,23 +552,23 @@ export function recordPathFeedback(
 		recordAgentFeedbackInner(db, input.sessionKey, input.ratings);
 		const ts = new Date().toISOString();
 		const ids = Object.keys(input.ratings);
+		const sessionIds = loadSessionMembership(db, input.sessionKey, ids);
 		const storedById = loadStoredPaths(db, input.sessionKey, ids);
 		db.prepare(
 			`INSERT OR IGNORE INTO path_feedback_sessions (agent_id, session_key, created_at)
 			 VALUES (?, ?, ?)`,
 		).run(input.agentId, input.sessionKey, ts);
 
-		let recorded = 0;
+		let accepted = 0;
 		let propagated = 0;
 		let dependenciesUpdated = 0;
 		const entitySet = new Set<string>();
 
 		for (const [memoryId, ratingRaw] of Object.entries(input.ratings)) {
+			if (!sessionIds.has(memoryId)) continue;
+			accepted++;
 			const rating = clamp(ratingRaw, -1, 1);
-			const path =
-				pathById.get(memoryId) ??
-				storedById.get(memoryId) ??
-				inferPath(db, memoryId, input.agentId);
+			const path = pathById.get(memoryId) ?? storedById.get(memoryId) ?? inferPath(db, memoryId, input.agentId);
 			if (!path) continue;
 			const reward = rewardById.get(memoryId) ?? normalizeReward(null);
 			const score = rewardScore(reward);
@@ -565,7 +603,6 @@ export function recordPathFeedback(
 			updateAspects(db, input.agentId, path, rating, cfg, ts);
 			dependenciesUpdated += updateDependencies(db, input.agentId, path, rating, cfg, ts);
 			propagated++;
-			recorded++;
 
 			if (rating > 0) {
 				for (const entityId of path.entityIds) entitySet.add(entityId);
@@ -591,12 +628,13 @@ export function recordPathFeedback(
 		const total = sessionCount(db, input.agentId);
 		let cooccurrenceUpdated = 0;
 		for (const [source, target] of pairs) {
-			if (maybePromotePair(db, input.agentId, source, target, total, cfg, ts)) {
+			const promoted = maybePromotePair(db, input.agentId, source, target, total, cfg, ts);
+			if (promoted > 0) {
 				cooccurrenceUpdated++;
-				dependenciesUpdated++;
+				dependenciesUpdated += promoted;
 			}
 		}
 
-		return { recorded, propagated, cooccurrenceUpdated, dependenciesUpdated };
+		return { accepted, propagated, cooccurrenceUpdated, dependenciesUpdated };
 	});
 }

--- a/packages/daemon/src/path-feedback.ts
+++ b/packages/daemon/src/path-feedback.ts
@@ -1,0 +1,602 @@
+import { createHash } from "node:crypto";
+import type { DbAccessor, WriteDb } from "./db-accessor";
+import { recordAgentFeedbackInner } from "./session-memories";
+
+export interface FeedbackPath {
+	readonly entityIds: ReadonlyArray<string>;
+	readonly aspectIds: ReadonlyArray<string>;
+	readonly dependencyIds: ReadonlyArray<string>;
+}
+
+export interface FeedbackReward {
+	readonly forwardCitation: number;
+	readonly updateAfterRetrieval: number;
+	readonly downstreamCreation: number;
+	readonly deadEnd: number;
+}
+
+export interface PathFeedbackResult {
+	readonly recorded: number;
+	readonly propagated: number;
+	readonly cooccurrenceUpdated: number;
+	readonly dependenciesUpdated: number;
+}
+
+interface PathFeedbackConfig {
+	readonly aspectDelta: number;
+	readonly edgeDelta: number;
+	readonly confidenceDelta: number;
+	readonly qAlpha: number;
+	readonly minEdgeStrength: number;
+	readonly minConfidence: number;
+	readonly npmiThreshold: number;
+	readonly minCoSessions: number;
+	readonly autoEdgeCap: number;
+	readonly maxAspectWeight: number;
+	readonly minAspectWeight: number;
+}
+
+const DEFAULT_CFG: PathFeedbackConfig = {
+	aspectDelta: 0.02,
+	edgeDelta: 0.04,
+	confidenceDelta: 0.05,
+	qAlpha: 0.1,
+	minEdgeStrength: 0.1,
+	minConfidence: 0.2,
+	npmiThreshold: 0.15,
+	minCoSessions: 3,
+	autoEdgeCap: 20,
+	maxAspectWeight: 1,
+	minAspectWeight: 0.1,
+};
+
+function toRecord(raw: unknown): Record<string, unknown> | null {
+	if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return null;
+	return raw as Record<string, unknown>;
+}
+
+function toUniqueIds(raw: unknown): string[] {
+	if (!Array.isArray(raw)) return [];
+	return [...new Set(raw.filter((value) => typeof value === "string" && value.length > 0))];
+}
+
+function normalizePath(raw: unknown): FeedbackPath | null {
+	const rec = toRecord(raw);
+	if (!rec) return null;
+	const entityIds = toUniqueIds(rec.entity_ids ?? rec.entityIds);
+	const aspectIds = toUniqueIds(rec.aspect_ids ?? rec.aspectIds);
+	const dependencyIds = toUniqueIds(rec.dependency_ids ?? rec.dependencyIds);
+	if (entityIds.length === 0 && aspectIds.length === 0 && dependencyIds.length === 0) return null;
+	return { entityIds, aspectIds, dependencyIds };
+}
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.max(min, Math.min(max, value));
+}
+
+function toFraction(raw: unknown): number {
+	if (typeof raw === "boolean") return raw ? 1 : 0;
+	if (typeof raw !== "number" || !Number.isFinite(raw)) return 0;
+	return clamp(raw, 0, 1);
+}
+
+function normalizeReward(raw: unknown): FeedbackReward {
+	const rec = toRecord(raw);
+	if (!rec) {
+		return {
+			forwardCitation: 0,
+			updateAfterRetrieval: 0,
+			downstreamCreation: 0,
+			deadEnd: 0,
+		};
+	}
+	return {
+		forwardCitation: toFraction(rec.forward_citation ?? rec.forwardCitation),
+		updateAfterRetrieval: toFraction(rec.update_after_retrieval ?? rec.updateAfterRetrieval),
+		downstreamCreation: toFraction(rec.downstream_creation ?? rec.downstreamCreation),
+		deadEnd: toFraction(rec.dead_end ?? rec.deadEnd),
+	};
+}
+
+function rewardScore(reward: FeedbackReward): number {
+	return (
+		reward.forwardCitation * 1.0 +
+		reward.updateAfterRetrieval * 0.5 +
+		reward.downstreamCreation * 0.6 -
+		reward.deadEnd * 0.15
+	);
+}
+
+function pathHash(path: FeedbackPath): string {
+	const digest = createHash("sha1");
+	digest.update(
+		JSON.stringify({
+			entity_ids: path.entityIds,
+			aspect_ids: path.aspectIds,
+			dependency_ids: path.dependencyIds,
+		}),
+	);
+	return digest.digest("hex");
+}
+
+function reasonConfidence(reason: string | null): number {
+	if (reason === "user-asserted") return 1.0;
+	if (reason === "multi-memory") return 0.9;
+	if (reason === "single-memory") return 0.7;
+	if (reason === "pattern-matched") return 0.5;
+	if (reason === "inferred") return 0.4;
+	if (reason === "llm-uncertain") return 0.3;
+	return 0.7;
+}
+
+function nextReason(reason: string | null, rating: number): string | null {
+	if (rating > 0) {
+		if (reason === "llm-uncertain") return "single-memory";
+		if (reason === "single-memory") return "pattern-matched";
+		if (reason === "pattern-matched") return "multi-memory";
+		return reason;
+	}
+	if (rating < 0) {
+		if (reason === "multi-memory") return "pattern-matched";
+		if (reason === "pattern-matched") return "single-memory";
+		if (reason === "single-memory") return "llm-uncertain";
+		return reason;
+	}
+	return reason;
+}
+
+function inferPath(db: WriteDb, memoryId: string, agentId: string): FeedbackPath | null {
+	const rows = db
+		.prepare(
+			`SELECT asp.entity_id, ea.aspect_id
+			 FROM entity_attributes ea
+			 JOIN entity_aspects asp ON asp.id = ea.aspect_id
+			 WHERE ea.memory_id = ?
+			   AND ea.agent_id = ?
+			   AND ea.status = 'active'
+			 ORDER BY ea.importance DESC
+			 LIMIT 5`,
+		)
+		.all(memoryId, agentId) as Array<{ entity_id: string; aspect_id: string }>;
+	if (rows.length === 0) return null;
+	return {
+		entityIds: [...new Set(rows.map((row) => row.entity_id))],
+		aspectIds: [...new Set(rows.map((row) => row.aspect_id))],
+		dependencyIds: [],
+	};
+}
+
+function loadStoredPaths(
+	db: WriteDb,
+	sessionKey: string,
+	memoryIds: ReadonlyArray<string>,
+): Map<string, FeedbackPath> {
+	if (memoryIds.length === 0) return new Map();
+	const ph = memoryIds.map(() => "?").join(", ");
+	const rows = db
+		.prepare(
+			`SELECT memory_id, path_json
+			 FROM session_memories
+			 WHERE session_key = ?
+			   AND memory_id IN (${ph})`,
+		)
+		.all(sessionKey, ...memoryIds) as Array<{ memory_id: string; path_json: string | null }>;
+	const map = new Map<string, FeedbackPath>();
+	for (const row of rows) {
+		if (typeof row.path_json !== "string" || row.path_json.length === 0) continue;
+		let raw: unknown = null;
+		try {
+			raw = JSON.parse(row.path_json);
+		} catch {
+			raw = null;
+		}
+		const parsed = normalizePath(raw);
+		if (!parsed) continue;
+		map.set(row.memory_id, parsed);
+	}
+	return map;
+}
+
+function parsePathMap(raw: unknown): Map<string, FeedbackPath> {
+	const rec = toRecord(raw);
+	if (!rec) return new Map();
+	const map = new Map<string, FeedbackPath>();
+	for (const [id, value] of Object.entries(rec)) {
+		if (id.length === 0) continue;
+		const path = normalizePath(value);
+		if (!path) continue;
+		map.set(id, path);
+	}
+	return map;
+}
+
+function parseRewardMap(raw: unknown): Map<string, FeedbackReward> {
+	const rec = toRecord(raw);
+	if (!rec) return new Map();
+	const map = new Map<string, FeedbackReward>();
+	for (const [id, value] of Object.entries(rec)) {
+		if (id.length === 0) continue;
+		map.set(id, normalizeReward(value));
+	}
+	return map;
+}
+
+function updateAspects(
+	db: WriteDb,
+	agentId: string,
+	path: FeedbackPath,
+	rating: number,
+	cfg: PathFeedbackConfig,
+	ts: string,
+): void {
+	if (rating === 0 || path.aspectIds.length === 0) return;
+	const delta = cfg.aspectDelta * Math.abs(rating) * (rating > 0 ? 1 : -1);
+	const stmt = db.prepare(
+		`UPDATE entity_aspects
+		 SET weight = MIN(?, MAX(?, weight + ?)),
+		     updated_at = ?
+		 WHERE id = ?
+		   AND agent_id = ?`,
+	);
+	for (const aspectId of path.aspectIds) {
+		stmt.run(cfg.maxAspectWeight, cfg.minAspectWeight, delta, ts, aspectId, agentId);
+	}
+}
+
+function updateDependencies(
+	db: WriteDb,
+	agentId: string,
+	path: FeedbackPath,
+	rating: number,
+	cfg: PathFeedbackConfig,
+	ts: string,
+): number {
+	if (rating === 0 || path.dependencyIds.length === 0) return 0;
+	const select = db.prepare(
+		`SELECT id, strength, confidence, reason
+		 FROM entity_dependencies
+		 WHERE id = ?
+		   AND agent_id = ?
+		 LIMIT 1`,
+	);
+	const update = db.prepare(
+		`UPDATE entity_dependencies
+		 SET strength = ?,
+		     confidence = ?,
+		     reason = ?,
+		     updated_at = ?
+		 WHERE id = ?
+		   AND agent_id = ?`,
+	);
+	let count = 0;
+	for (const depId of path.dependencyIds) {
+		const row = select.get(depId, agentId) as
+			| { id: string; strength: number; confidence: number; reason: string | null }
+			| undefined;
+		if (!row) continue;
+		const mag = Math.abs(rating);
+		const next = nextReason(row.reason, rating);
+		const base = reasonConfidence(next);
+		const strength =
+			rating > 0
+				? clamp(row.strength + cfg.edgeDelta * mag, cfg.minEdgeStrength, 1)
+				: clamp(row.strength - cfg.edgeDelta * mag, cfg.minEdgeStrength, 1);
+		const confidence =
+			rating > 0
+				? clamp(Math.max(row.confidence + cfg.confidenceDelta * mag, base), cfg.minConfidence, 1)
+				: clamp(Math.min(row.confidence - cfg.confidenceDelta * mag, base), cfg.minConfidence, 1);
+		update.run(strength, confidence, next, ts, depId, agentId);
+		count++;
+	}
+	return count;
+}
+
+function upsertPathStats(
+	db: WriteDb,
+	agentId: string,
+	hash: string,
+	path: FeedbackPath,
+	rating: number,
+	reward: number,
+	cfg: PathFeedbackConfig,
+	ts: string,
+): void {
+	const cat = rating > 0 ? "positive" : rating < 0 ? "negative" : "neutral";
+	const pathJson = JSON.stringify({
+		entity_ids: path.entityIds,
+		aspect_ids: path.aspectIds,
+		dependency_ids: path.dependencyIds,
+	});
+	db.prepare(
+		`INSERT INTO path_feedback_stats
+		 (agent_id, path_hash, path_json, q_value, sample_count,
+		  positive_count, negative_count, neutral_count, updated_at, created_at)
+		 VALUES (?, ?, ?, ?, 1, ?, ?, ?, ?, ?)
+		 ON CONFLICT(agent_id, path_hash) DO UPDATE SET
+		  path_json = excluded.path_json,
+		  q_value = path_feedback_stats.q_value + (? - path_feedback_stats.q_value) * ?,
+		  sample_count = path_feedback_stats.sample_count + 1,
+		  positive_count = path_feedback_stats.positive_count + ?,
+		  negative_count = path_feedback_stats.negative_count + ?,
+		  neutral_count = path_feedback_stats.neutral_count + ?,
+		  updated_at = excluded.updated_at`,
+	).run(
+		agentId,
+		hash,
+		pathJson,
+		reward,
+		cat === "positive" ? 1 : 0,
+		cat === "negative" ? 1 : 0,
+		cat === "neutral" ? 1 : 0,
+		ts,
+		ts,
+		reward,
+		cfg.qAlpha,
+		cat === "positive" ? 1 : 0,
+		cat === "negative" ? 1 : 0,
+		cat === "neutral" ? 1 : 0,
+	);
+}
+
+function sessionCount(db: WriteDb, agentId: string): number {
+	const row = db
+		.prepare("SELECT COUNT(*) AS cnt FROM path_feedback_sessions WHERE agent_id = ?")
+		.get(agentId) as { cnt: number } | undefined;
+	return Number(row?.cnt ?? 0);
+}
+
+function updateEntityStats(
+	db: WriteDb,
+	agentId: string,
+	sessionKey: string,
+	entityIds: ReadonlyArray<string>,
+	ts: string,
+): void {
+	const stmt = db.prepare(
+		`INSERT INTO entity_retrieval_stats
+		 (agent_id, entity_id, session_count, last_session_key, updated_at, created_at)
+		 VALUES (?, ?, 1, ?, ?, ?)
+		 ON CONFLICT(agent_id, entity_id) DO UPDATE SET
+		  session_count = CASE
+		    WHEN entity_retrieval_stats.last_session_key = excluded.last_session_key
+		      THEN entity_retrieval_stats.session_count
+		    ELSE entity_retrieval_stats.session_count + 1
+		  END,
+		  last_session_key = excluded.last_session_key,
+		  updated_at = excluded.updated_at`,
+	);
+	for (const entityId of entityIds) {
+		stmt.run(agentId, entityId, sessionKey, ts, ts);
+	}
+}
+
+function updatePairStats(
+	db: WriteDb,
+	agentId: string,
+	sessionKey: string,
+	pairs: ReadonlyArray<readonly [string, string]>,
+	ts: string,
+): void {
+	const stmt = db.prepare(
+		`INSERT INTO entity_cooccurrence
+		 (agent_id, source_entity_id, target_entity_id, session_count, last_session_key, updated_at, created_at)
+		 VALUES (?, ?, ?, 1, ?, ?, ?)
+		 ON CONFLICT(agent_id, source_entity_id, target_entity_id) DO UPDATE SET
+		  session_count = CASE
+		    WHEN entity_cooccurrence.last_session_key = excluded.last_session_key
+		      THEN entity_cooccurrence.session_count
+		    ELSE entity_cooccurrence.session_count + 1
+		  END,
+		  last_session_key = excluded.last_session_key,
+		  updated_at = excluded.updated_at`,
+	);
+	for (const [source, target] of pairs) {
+		stmt.run(agentId, source, target, sessionKey, ts, ts);
+	}
+}
+
+function countAutoEdges(db: WriteDb, agentId: string, source: string): number {
+	const row = db
+		.prepare(
+			`SELECT COUNT(*) AS cnt
+			 FROM entity_dependencies
+			 WHERE agent_id = ?
+			   AND source_entity_id = ?
+			   AND dependency_type = 'related_to'
+			   AND reason = 'pattern-matched'`,
+		)
+		.get(agentId, source) as { cnt: number } | undefined;
+	return Number(row?.cnt ?? 0);
+}
+
+function maybePromotePair(
+	db: WriteDb,
+	agentId: string,
+	source: string,
+	target: string,
+	total: number,
+	cfg: PathFeedbackConfig,
+	ts: string,
+): boolean {
+	if (total <= 1) return false;
+	const pair = db
+		.prepare(
+			`SELECT session_count
+			 FROM entity_cooccurrence
+			 WHERE agent_id = ?
+			   AND source_entity_id = ?
+			   AND target_entity_id = ?`,
+		)
+		.get(agentId, source, target) as { session_count: number } | undefined;
+	const src = db
+		.prepare(
+			`SELECT session_count
+			 FROM entity_retrieval_stats
+			 WHERE agent_id = ?
+			   AND entity_id = ?`,
+		)
+		.get(agentId, source) as { session_count: number } | undefined;
+	const tgt = db
+		.prepare(
+			`SELECT session_count
+			 FROM entity_retrieval_stats
+			 WHERE agent_id = ?
+			   AND entity_id = ?`,
+		)
+		.get(agentId, target) as { session_count: number } | undefined;
+	const co = Number(pair?.session_count ?? 0);
+	const sx = Number(src?.session_count ?? 0);
+	const sy = Number(tgt?.session_count ?? 0);
+	if (co < cfg.minCoSessions || sx === 0 || sy === 0) return false;
+
+	const pxy = co / total;
+	const px = sx / total;
+	const py = sy / total;
+	if (pxy <= 0 || px <= 0 || py <= 0) return false;
+	const npmi = pxy >= 1 ? 1 : Math.log(pxy / (px * py)) / -Math.log(pxy);
+	if (!Number.isFinite(npmi) || npmi < cfg.npmiThreshold) return false;
+
+	const existing = db
+		.prepare(
+			`SELECT id, strength, confidence
+			 FROM entity_dependencies
+			 WHERE agent_id = ?
+			   AND source_entity_id = ?
+			   AND target_entity_id = ?
+			   AND dependency_type = 'related_to'
+			 LIMIT 1`,
+		)
+		.get(agentId, source, target) as { id: string; strength: number; confidence: number } | undefined;
+	const strength = clamp(0.3 + npmi * 0.5, 0.3, 0.9);
+	if (!existing) {
+		if (countAutoEdges(db, agentId, source) >= cfg.autoEdgeCap) return false;
+		db.prepare(
+			`INSERT INTO entity_dependencies
+			 (id, source_entity_id, target_entity_id, agent_id, aspect_id,
+			  dependency_type, strength, confidence, reason, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, NULL, 'related_to', ?, 0.5, 'pattern-matched', ?, ?)`,
+		).run(crypto.randomUUID(), source, target, agentId, strength, ts, ts);
+		return true;
+	}
+	db.prepare(
+		`UPDATE entity_dependencies
+		 SET strength = ?,
+		     confidence = ?,
+		     reason = 'pattern-matched',
+		     updated_at = ?
+		 WHERE id = ?
+		   AND agent_id = ?`,
+	).run(Math.max(existing.strength, strength), Math.max(existing.confidence, 0.5), ts, existing.id, agentId);
+	return true;
+}
+
+export function recordPathFeedback(
+	accessor: DbAccessor,
+	input: {
+		readonly sessionKey: string;
+		readonly agentId: string;
+		readonly ratings: Readonly<Record<string, number>>;
+		readonly paths?: unknown;
+		readonly rewards?: unknown;
+		readonly maxAspectWeight?: number;
+		readonly minAspectWeight?: number;
+	},
+): PathFeedbackResult {
+	const pathById = parsePathMap(input.paths);
+	const rewardById = parseRewardMap(input.rewards);
+	const cfg: PathFeedbackConfig = {
+		...DEFAULT_CFG,
+		maxAspectWeight: input.maxAspectWeight ?? DEFAULT_CFG.maxAspectWeight,
+		minAspectWeight: input.minAspectWeight ?? DEFAULT_CFG.minAspectWeight,
+	};
+
+	return accessor.withWriteTx((db) => {
+		recordAgentFeedbackInner(db, input.sessionKey, input.ratings);
+		const ts = new Date().toISOString();
+		const ids = Object.keys(input.ratings);
+		const storedById = loadStoredPaths(db, input.sessionKey, ids);
+		db.prepare(
+			`INSERT OR IGNORE INTO path_feedback_sessions (agent_id, session_key, created_at)
+			 VALUES (?, ?, ?)`,
+		).run(input.agentId, input.sessionKey, ts);
+
+		let recorded = 0;
+		let propagated = 0;
+		let dependenciesUpdated = 0;
+		const entitySet = new Set<string>();
+
+		for (const [memoryId, ratingRaw] of Object.entries(input.ratings)) {
+			const rating = clamp(ratingRaw, -1, 1);
+			const path =
+				pathById.get(memoryId) ??
+				storedById.get(memoryId) ??
+				inferPath(db, memoryId, input.agentId);
+			if (!path) continue;
+			const reward = rewardById.get(memoryId) ?? normalizeReward(null);
+			const score = rewardScore(reward);
+			const hash = pathHash(path);
+			const pathJson = JSON.stringify({
+				entity_ids: path.entityIds,
+				aspect_ids: path.aspectIds,
+				dependency_ids: path.dependencyIds,
+			});
+
+			db.prepare(
+				`INSERT INTO path_feedback_events
+				 (id, agent_id, session_key, memory_id, path_hash, path_json, rating,
+				  reward, reward_forward, reward_update, reward_downstream, reward_dead_end, created_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			).run(
+				crypto.randomUUID(),
+				input.agentId,
+				input.sessionKey,
+				memoryId,
+				hash,
+				pathJson,
+				rating,
+				score,
+				reward.forwardCitation,
+				reward.updateAfterRetrieval,
+				reward.downstreamCreation,
+				reward.deadEnd,
+				ts,
+			);
+			upsertPathStats(db, input.agentId, hash, path, rating, score, cfg, ts);
+			updateAspects(db, input.agentId, path, rating, cfg, ts);
+			dependenciesUpdated += updateDependencies(db, input.agentId, path, rating, cfg, ts);
+			propagated++;
+			recorded++;
+
+			if (rating > 0) {
+				for (const entityId of path.entityIds) entitySet.add(entityId);
+			}
+		}
+
+		const entities = [...entitySet];
+		if (entities.length > 0) {
+			updateEntityStats(db, input.agentId, input.sessionKey, entities, ts);
+		}
+		const pairs: Array<readonly [string, string]> = [];
+		for (let i = 0; i < entities.length; i++) {
+			for (let j = i + 1; j < entities.length; j++) {
+				const a = entities[i];
+				const b = entities[j];
+				if (!a || !b) continue;
+				pairs.push(a < b ? [a, b] : [b, a]);
+			}
+		}
+		if (pairs.length > 0) {
+			updatePairStats(db, input.agentId, input.sessionKey, pairs, ts);
+		}
+		const total = sessionCount(db, input.agentId);
+		let cooccurrenceUpdated = 0;
+		for (const [source, target] of pairs) {
+			if (maybePromotePair(db, input.agentId, source, target, total, cfg, ts)) {
+				cooccurrenceUpdated++;
+				dependenciesUpdated++;
+			}
+		}
+
+		return { recorded, propagated, cooccurrenceUpdated, dependenciesUpdated };
+	});
+}

--- a/packages/daemon/src/path-feedback.ts
+++ b/packages/daemon/src/path-feedback.ts
@@ -168,8 +168,20 @@ function inferPath(db: WriteDb, memoryId: string, agentId: string): FeedbackPath
 	};
 }
 
-function loadStoredPaths(db: WriteDb, sessionKey: string, memoryIds: ReadonlyArray<string>): Map<string, FeedbackPath> {
-	if (memoryIds.length === 0) return new Map();
+function loadSessionData(
+	db: WriteDb,
+	sessionKey: string,
+	memoryIds: ReadonlyArray<string>,
+): {
+	readonly sessionIds: Set<string>;
+	readonly storedById: Map<string, FeedbackPath>;
+} {
+	if (memoryIds.length === 0) {
+		return {
+			sessionIds: new Set(),
+			storedById: new Map(),
+		};
+	}
 	const ph = memoryIds.map(() => "?").join(", ");
 	const rows = db
 		.prepare(
@@ -179,8 +191,10 @@ function loadStoredPaths(db: WriteDb, sessionKey: string, memoryIds: ReadonlyArr
 			   AND memory_id IN (${ph})`,
 		)
 		.all(sessionKey, ...memoryIds) as Array<{ memory_id: string; path_json: string | null }>;
-	const map = new Map<string, FeedbackPath>();
+	const sessionIds = new Set<string>();
+	const storedById = new Map<string, FeedbackPath>();
 	for (const row of rows) {
+		sessionIds.add(row.memory_id);
 		if (typeof row.path_json !== "string" || row.path_json.length === 0) continue;
 		let raw: unknown = null;
 		try {
@@ -190,9 +204,9 @@ function loadStoredPaths(db: WriteDb, sessionKey: string, memoryIds: ReadonlyArr
 		}
 		const parsed = normalizePath(raw);
 		if (!parsed) continue;
-		map.set(row.memory_id, parsed);
+		storedById.set(row.memory_id, parsed);
 	}
-	return map;
+	return { sessionIds, storedById };
 }
 
 function parsePathMap(raw: unknown): Map<string, FeedbackPath> {
@@ -206,20 +220,6 @@ function parsePathMap(raw: unknown): Map<string, FeedbackPath> {
 		map.set(id, path);
 	}
 	return map;
-}
-
-function loadSessionMembership(db: WriteDb, sessionKey: string, memoryIds: ReadonlyArray<string>): Set<string> {
-	if (memoryIds.length === 0) return new Set();
-	const ph = memoryIds.map(() => "?").join(", ");
-	const rows = db
-		.prepare(
-			`SELECT memory_id
-			 FROM session_memories
-			 WHERE session_key = ?
-			   AND memory_id IN (${ph})`,
-		)
-		.all(sessionKey, ...memoryIds) as Array<{ memory_id: string }>;
-	return new Set(rows.map((row) => row.memory_id));
 }
 
 function parseRewardMap(raw: unknown): Map<string, FeedbackReward> {
@@ -552,8 +552,9 @@ export function recordPathFeedback(
 		recordAgentFeedbackInner(db, input.sessionKey, input.ratings);
 		const ts = new Date().toISOString();
 		const ids = Object.keys(input.ratings);
-		const sessionIds = loadSessionMembership(db, input.sessionKey, ids);
-		const storedById = loadStoredPaths(db, input.sessionKey, ids);
+		const sessionData = loadSessionData(db, input.sessionKey, ids);
+		const sessionIds = sessionData.sessionIds;
+		const storedById = sessionData.storedById;
 		db.prepare(
 			`INSERT OR IGNORE INTO path_feedback_sessions (agent_id, session_key, created_at)
 			 VALUES (?, ?, ?)`,

--- a/packages/daemon/src/pipeline/continuity-scoring.test.ts
+++ b/packages/daemon/src/pipeline/continuity-scoring.test.ts
@@ -63,6 +63,7 @@ function insertSessionMemory(
 	sessionKey: string,
 	memoryId: string,
 	opts: {
+		agentId?: string;
 		wasInjected?: number;
 		rank?: number;
 		effectiveScore?: number;
@@ -72,12 +73,13 @@ function insertSessionMemory(
 	const now = new Date().toISOString();
 	db.prepare(
 		`INSERT INTO session_memories
-		 (id, session_key, memory_id, source, effective_score,
+		 (id, session_key, agent_id, memory_id, source, effective_score,
 		  final_score, rank, was_injected, fts_hit_count, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?)`,
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)`,
 	).run(
 		crypto.randomUUID(),
 		sessionKey,
+		opts.agentId ?? "default",
 		memoryId,
 		opts.source ?? "effective",
 		opts.effectiveScore ?? 0.8,
@@ -135,13 +137,27 @@ describe("session_memories table", () => {
 		expect(colNames).toContain("structural_density");
 	});
 
-	it("enforces UNIQUE(session_key, memory_id)", () => {
+	it("enforces UNIQUE(session_key, agent_id, memory_id)", () => {
 		insertMemory(db, "mem-1", "Test memory");
 		insertSessionMemory(db, "session-1", "mem-1");
 
 		expect(() => {
 			insertSessionMemory(db, "session-1", "mem-1");
 		}).toThrow();
+	});
+
+	it("allows same session+memory for different agents", () => {
+		insertMemory(db, "mem-1", "Test memory");
+		insertSessionMemory(db, "session-1", "mem-1", { agentId: "agent-a" });
+		insertSessionMemory(db, "session-1", "mem-1", { agentId: "agent-b" });
+
+		const count = db
+			.prepare(
+				"SELECT COUNT(*) as cnt FROM session_memories WHERE session_key = ? AND memory_id = ?",
+			)
+			.get("session-1", "mem-1") as { cnt: number };
+
+		expect(count.cnt).toBe(2);
 	});
 
 	it("allows same memory in different sessions", () => {

--- a/packages/daemon/src/pipeline/graph-traversal.ts
+++ b/packages/daemon/src/pipeline/graph-traversal.ts
@@ -1,10 +1,18 @@
 import type { ReadDb } from "../db-accessor";
 
+export interface TraversalPath {
+	readonly entityIds: ReadonlyArray<string>;
+	readonly aspectIds: ReadonlyArray<string>;
+	readonly dependencyIds: ReadonlyArray<string>;
+}
+
 export interface TraversalResult {
 	/** Memory IDs collected from entity_attributes.memory_id */
 	readonly memoryIds: Set<string>;
 	/** Structural importance score per memory (max importance across aspects) */
 	readonly memoryScores: ReadonlyMap<string, number>;
+	/** Provenance path per memory (for DP-9 feedback propagation). */
+	readonly memoryPaths: ReadonlyMap<string, TraversalPath>;
 	/** Constraint content that must always be surfaced */
 	readonly constraints: ReadonlyArray<{
 		readonly entityName: string;
@@ -306,6 +314,7 @@ export function traverseKnowledgeGraph(
 	const empty: TraversalResult = {
 		memoryIds: new Set<string>(),
 		memoryScores: new Map<string, number>(),
+		memoryPaths: new Map<string, TraversalPath>(),
 		constraints: [],
 		entityCount: 0,
 		timedOut: false,
@@ -321,6 +330,7 @@ export function traverseKnowledgeGraph(
 
 		const memoryIds = new Set<string>();
 		const memoryScores = new Map<string, number>();
+		const memoryPaths = new Map<string, TraversalPath>();
 		const constraints: Array<{
 			entityName: string;
 			content: string;
@@ -342,7 +352,48 @@ export function traverseKnowledgeGraph(
 
 		const budget = config.maxTraversalPaths;
 
-		const collectForEntity = (entityId: string): void => {
+		const toPath = (
+			entityId: string,
+			sourceEntityId?: string,
+			aspectId?: string,
+			dependencyId?: string,
+		): TraversalPath => {
+			const entityIds =
+				typeof sourceEntityId === "string" &&
+				sourceEntityId.length > 0 &&
+				sourceEntityId !== entityId
+					? [sourceEntityId, entityId]
+					: [entityId];
+			const aspectIds = typeof aspectId === "string" && aspectId.length > 0 ? [aspectId] : [];
+			const dependencyIds =
+				typeof dependencyId === "string" && dependencyId.length > 0
+					? [dependencyId]
+					: [];
+			return { entityIds, aspectIds, dependencyIds };
+		};
+
+		const pathSize = (path: TraversalPath): number =>
+			path.entityIds.length + path.aspectIds.length + path.dependencyIds.length;
+
+		const recordPath = (
+			memoryId: string,
+			entityId: string,
+			sourceEntityId?: string,
+			aspectId?: string,
+			dependencyId?: string,
+		): void => {
+			const next = toPath(entityId, sourceEntityId, aspectId, dependencyId);
+			const prev = memoryPaths.get(memoryId);
+			if (!prev || pathSize(next) > pathSize(prev)) {
+				memoryPaths.set(memoryId, next);
+			}
+		};
+
+		const collectForEntity = (
+			entityId: string,
+			sourceEntityId?: string,
+			dependencyId?: string,
+		): void => {
 			if (timedOut || visitedEntities.has(entityId)) return;
 			if (memoryIds.size >= budget) return;
 			visitedEntities.add(entityId);
@@ -437,6 +488,7 @@ export function traverseKnowledgeGraph(
 				for (const row of attributeRows) {
 					if (!row.memory_id) continue;
 					memoryIds.add(row.memory_id);
+					recordPath(row.memory_id, entityId, sourceEntityId, aspect.id, dependencyId);
 					const current = memoryScores.get(row.memory_id);
 					if (current === undefined || row.importance > current) {
 						memoryScores.set(row.memory_id, row.importance);
@@ -484,6 +536,7 @@ export function traverseKnowledgeGraph(
 
 			for (const row of mentionRows) {
 				memoryIds.add(row.memory_id);
+				recordPath(row.memory_id, entityId, sourceEntityId, undefined, dependencyId);
 				const current = memoryScores.get(row.memory_id);
 				if (current === undefined || row.importance > current) {
 					memoryScores.set(row.memory_id, row.importance);
@@ -500,7 +553,7 @@ export function traverseKnowledgeGraph(
 			const dependencyPlaceholders = focalIds.map(() => "?").join(", ");
 			const dependencyRows = db
 				.prepare(
-					`SELECT target_entity_id FROM entity_dependencies
+					`SELECT id, source_entity_id, target_entity_id FROM entity_dependencies
 					 WHERE agent_id = ?
 					   AND source_entity_id IN (${dependencyPlaceholders})
 					   AND (COALESCE(confidence, 0.7) * strength) >= ?
@@ -514,11 +567,11 @@ export function traverseKnowledgeGraph(
 					config.minDependencyStrength,
 					config.minConfidence,
 					config.maxBranching * focalIds.length,
-				) as Array<{ target_entity_id: string }>;
+				) as Array<{ id: string; source_entity_id: string; target_entity_id: string }>;
 
 			for (const row of dependencyRows) {
 				if (checkDeadline() || memoryIds.size >= budget) break;
-				collectForEntity(row.target_entity_id);
+				collectForEntity(row.target_entity_id, row.source_entity_id, row.id);
 			}
 		}
 
@@ -527,6 +580,7 @@ export function traverseKnowledgeGraph(
 		return {
 			memoryIds,
 			memoryScores,
+			memoryPaths,
 			constraints,
 			entityCount: visitedEntities.size,
 			timedOut,

--- a/packages/daemon/src/predictor-comparison.ts
+++ b/packages/daemon/src/predictor-comparison.ts
@@ -159,9 +159,10 @@ export function runSessionComparison(
 				        was_injected, relevance_score, fts_hit_count,
 				        entity_slot, is_constraint
 				 FROM session_memories
-				 WHERE session_key = ?`,
+				 WHERE session_key = ?
+				   AND agent_id = ?`,
 			)
-			.all(sessionKey) as ReadonlyArray<SessionMemoryRow>;
+			.all(sessionKey, agentId) as ReadonlyArray<SessionMemoryRow>;
 	});
 
 	if (sessionMemories.length === 0) {

--- a/packages/daemon/src/predictor-training-pairs.ts
+++ b/packages/daemon/src/predictor-training-pairs.ts
@@ -185,7 +185,7 @@ export function collectTrainingPairs(
 function collectTrainingPairsFromDb(
 	db: ReadDb,
 	sessionKey: string,
-	_agentId: string,
+	agentId: string,
 ): ReadonlyArray<TrainingPair> {
 	// Load session memories for this session
 	const sessionMemories = db
@@ -195,9 +195,10 @@ function collectTrainingPairsFromDb(
 			        agent_relevance_score
 			 FROM session_memories
 			 WHERE session_key = ?
+			   AND agent_id = ?
 			 ORDER BY rank ASC`,
 		)
-		.all(sessionKey) as ReadonlyArray<SessionMemoryRow>;
+		.all(sessionKey, agentId) as ReadonlyArray<SessionMemoryRow>;
 
 	if (sessionMemories.length === 0) return [];
 

--- a/packages/daemon/src/session-memories.test.ts
+++ b/packages/daemon/src/session-memories.test.ts
@@ -68,6 +68,7 @@ function getSessionMemoryRows(
 ): Array<{
 	id: string;
 	session_key: string;
+	agent_id: string;
 	memory_id: string;
 	source: string;
 	effective_score: number | null;
@@ -80,13 +81,14 @@ function getSessionMemoryRows(
 }> {
 	return db
 		.prepare(
-			`SELECT id, session_key, memory_id, source, effective_score,
+			`SELECT id, session_key, agent_id, memory_id, source, effective_score,
 			        final_score, rank, was_injected, relevance_score, fts_hit_count, path_json
 			 FROM session_memories WHERE session_key = ? ORDER BY rank ASC`,
 		)
 		.all(sessionKey) as Array<{
 		id: string;
 		session_key: string;
+		agent_id: string;
 		memory_id: string;
 		source: string;
 		effective_score: number | null;
@@ -208,6 +210,21 @@ describe("recordSessionCandidates", () => {
 		expect(rows[0].path_json).toContain("entity_ids");
 	});
 
+	it("stores provided agent_id", () => {
+		const candidates = [
+			{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const },
+		];
+
+		recordSessionCandidates("session-agent-001", candidates, new Set(["mem-aaa-111"]), "agent-a");
+
+		const testDb = openTestDb();
+		const rows = getSessionMemoryRows(testDb, "session-agent-001");
+		testDb.close();
+
+		expect(rows.length).toBe(1);
+		expect(rows[0].agent_id).toBe("agent-a");
+	});
+
 	it("is idempotent (INSERT OR IGNORE on duplicate session+memory)", () => {
 		const candidates = [
 			{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const },
@@ -317,6 +334,41 @@ describe("trackFtsHits", () => {
 		testDb.close();
 
 		expect(rows[0].fts_hit_count).toBe(3);
+	});
+
+	it("tracks fts hits per agent for same session+memory", () => {
+		recordSessionCandidates(
+			"session-fts-agent",
+			[{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }],
+			new Set(["mem-aaa-111"]),
+			"agent-a",
+		);
+		recordSessionCandidates(
+			"session-fts-agent",
+			[{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }],
+			new Set(["mem-aaa-111"]),
+			"agent-b",
+		);
+
+		trackFtsHits("session-fts-agent", ["mem-aaa-111"], "agent-a");
+		trackFtsHits("session-fts-agent", ["mem-aaa-111"], "agent-a");
+		trackFtsHits("session-fts-agent", ["mem-aaa-111"], "agent-b");
+
+		const testDb = openTestDb();
+		const rows = testDb
+			.prepare(
+				`SELECT agent_id, fts_hit_count
+				 FROM session_memories
+				 WHERE session_key = ? AND memory_id = ?
+				 ORDER BY agent_id ASC`,
+			)
+			.all("session-fts-agent", "mem-aaa-111") as Array<{ agent_id: string; fts_hit_count: number }>;
+		testDb.close();
+
+		expect(rows).toEqual([
+			{ agent_id: "agent-a", fts_hit_count: 2 },
+			{ agent_id: "agent-b", fts_hit_count: 1 },
+		]);
 	});
 
 	it("creates fts_only rows for memories not in candidate pool", () => {
@@ -447,14 +499,15 @@ function getFeedbackColumns(
 	testDb: Database,
 	sessionKey: string,
 	memoryId: string,
+	agentId = "default",
 ): { agent_relevance_score: number | null; agent_feedback_count: number } | undefined {
 	return testDb
 		.prepare(
 			`SELECT agent_relevance_score, agent_feedback_count
 			 FROM session_memories
-			 WHERE session_key = ? AND memory_id = ?`,
+			 WHERE session_key = ? AND agent_id = ? AND memory_id = ?`,
 		)
-		.get(sessionKey, memoryId) as
+		.get(sessionKey, agentId, memoryId) as
 		| { agent_relevance_score: number | null; agent_feedback_count: number }
 		| undefined;
 }
@@ -584,6 +637,31 @@ describe("recordAgentFeedbackInner", () => {
 		testDb.close();
 
 		expect(a!.agent_relevance_score).toBeCloseTo(0.7, 6);
+		expect(b!.agent_relevance_score).toBeNull();
+	});
+
+	it("feedback is scoped by agent_id", () => {
+		recordSessionCandidates(
+			"session-fb-agent",
+			[{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }],
+			new Set(["mem-aaa-111"]),
+			"agent-a",
+		);
+		recordSessionCandidates(
+			"session-fb-agent",
+			[{ id: "mem-aaa-111", effScore: 0.9, source: "effective" as const }],
+			new Set(["mem-aaa-111"]),
+			"agent-b",
+		);
+
+		const testDb = openTestDb();
+		recordAgentFeedbackInner(testDb, "session-fb-agent", { "mem-aaa-111": 0.9 }, "agent-a");
+
+		const a = getFeedbackColumns(testDb, "session-fb-agent", "mem-aaa-111", "agent-a");
+		const b = getFeedbackColumns(testDb, "session-fb-agent", "mem-aaa-111", "agent-b");
+		testDb.close();
+
+		expect(a!.agent_relevance_score).toBeCloseTo(0.9, 6);
 		expect(b!.agent_relevance_score).toBeNull();
 	});
 

--- a/packages/daemon/src/session-memories.test.ts
+++ b/packages/daemon/src/session-memories.test.ts
@@ -76,11 +76,12 @@ function getSessionMemoryRows(
 	was_injected: number;
 	relevance_score: number | null;
 	fts_hit_count: number;
+	path_json: string | null;
 }> {
 	return db
 		.prepare(
 			`SELECT id, session_key, memory_id, source, effective_score,
-			        final_score, rank, was_injected, relevance_score, fts_hit_count
+			        final_score, rank, was_injected, relevance_score, fts_hit_count, path_json
 			 FROM session_memories WHERE session_key = ? ORDER BY rank ASC`,
 		)
 		.all(sessionKey) as Array<{
@@ -94,6 +95,7 @@ function getSessionMemoryRows(
 		was_injected: number;
 		relevance_score: number | null;
 		fts_hit_count: number;
+		path_json: string | null;
 	}>;
 }
 
@@ -180,6 +182,30 @@ describe("recordSessionCandidates", () => {
 
 		expect(rows[0].effective_score).toBeCloseTo(0.85, 2);
 		expect(rows[0].final_score).toBeCloseTo(0.85, 2);
+	});
+
+	it("stores path_json when provided", () => {
+		const candidates = [
+			{
+				id: "mem-aaa-111",
+				effScore: 0.9,
+				source: "ka_traversal" as const,
+				pathJson: JSON.stringify({
+					entity_ids: ["ent-a"],
+					aspect_ids: ["asp-a"],
+					dependency_ids: ["dep-a"],
+				}),
+			},
+		];
+
+		recordSessionCandidates("session-path-001", candidates, new Set(["mem-aaa-111"]));
+
+		const testDb = openTestDb();
+		const rows = getSessionMemoryRows(testDb, "session-path-001");
+		testDb.close();
+
+		expect(rows.length).toBe(1);
+		expect(rows[0].path_json).toContain("entity_ids");
 	});
 
 	it("is idempotent (INSERT OR IGNORE on duplicate session+memory)", () => {

--- a/packages/daemon/src/session-memories.ts
+++ b/packages/daemon/src/session-memories.ts
@@ -52,6 +52,7 @@ export function recordSessionCandidates(
 	sessionKey: string | undefined,
 	candidates: ReadonlyArray<SessionMemoryCandidate>,
 	injectedIds: ReadonlySet<string>,
+	agentId = "default",
 ): void {
 	if (!sessionKey || candidates.length === 0 || !existsSync(getMemoryDbPath())) return;
 
@@ -59,9 +60,9 @@ export function recordSessionCandidates(
 		getDbAccessor().withWriteTx((db) => {
 			const now = new Date().toISOString();
 			const CHUNK_SIZE = 50;
-			const ROW = "(?,?,?,?,?,?,?,?,?,0,?,?,?,?,?,?,?)";
+			const ROW = "(?,?,?,?,?,?,?,?,?,?,0,?,?,?,?,?,?,?)";
 			const BASE_SQL = `INSERT OR IGNORE INTO session_memories
-					 (id, session_key, memory_id, source, effective_score,
+					 (id, session_key, agent_id, memory_id, source, effective_score,
 					  predictor_score, final_score, rank, was_injected,
 					  fts_hit_count, created_at,
 					  entity_slot, aspect_slot, is_constraint, structural_density,
@@ -93,6 +94,7 @@ export function recordSessionCandidates(
 					values.push(
 						crypto.randomUUID(),
 						sessionKey,
+						agentId,
 						c.id,
 						c.source,
 						c.effScore,
@@ -139,21 +141,25 @@ export function recordSessionCandidates(
  * Optimization: Uses SQLite UPSERT (INSERT ... ON CONFLICT DO UPDATE) to
  * collapse two queries into one, reducing roundtrips.
  */
-export function trackFtsHits(sessionKey: string | undefined, matchedIds: ReadonlyArray<string>): void {
+export function trackFtsHits(
+	sessionKey: string | undefined,
+	matchedIds: ReadonlyArray<string>,
+	agentId = "default",
+): void {
 	if (!sessionKey || matchedIds.length === 0 || !existsSync(getMemoryDbPath())) return;
 
 	try {
 		getDbAccessor().withWriteTx((db) => {
 			const now = new Date().toISOString();
 			const CHUNK_SIZE = 50;
-			// Each row contributes 4 params: id, session_key, memory_id, created_at
-			const ROW = "(?, ?, ?, 'fts_only', 0, 0, 0, 0, 1, ?)";
+			// Each row contributes 5 params: id, session_key, agent_id, memory_id, created_at
+			const ROW = "(?, ?, ?, ?, 'fts_only', 0, 0, 0, 0, 1, ?)";
 			const BASE_SQL = `INSERT INTO session_memories
-				 (id, session_key, memory_id, source, effective_score,
+				 (id, session_key, agent_id, memory_id, source, effective_score,
 				  final_score, rank, was_injected, fts_hit_count, created_at)
 				 VALUES `;
 			const CONFLICT_CLAUSE = `
-				 ON CONFLICT(session_key, memory_id) DO UPDATE SET
+				 ON CONFLICT(session_key, agent_id, memory_id) DO UPDATE SET
 				  fts_hit_count = fts_hit_count + 1`;
 
 			// Pre-compile the full-chunk UPSERT statement once to avoid
@@ -181,7 +187,7 @@ export function trackFtsHits(sessionKey: string | undefined, matchedIds: Readonl
 
 				const values: unknown[] = [];
 				for (const id of chunk) {
-					values.push(crypto.randomUUID(), sessionKey, id, now);
+					values.push(crypto.randomUUID(), sessionKey, agentId, id, now);
 				}
 
 				stmt.run(...values);
@@ -233,6 +239,7 @@ export function recordAgentFeedbackInner(
 	db: WriteDb,
 	sessionKey: string,
 	feedback: Readonly<Record<string, number>>,
+	agentId = "default",
 ): void {
 	// Single-row UPDATE with running mean calculation.
 	// CASE handles NULL (first feedback) vs existing score.
@@ -243,11 +250,11 @@ export function recordAgentFeedbackInner(
 				ELSE (agent_relevance_score * agent_feedback_count + ?) / (agent_feedback_count + 1)
 			END,
 			agent_feedback_count = COALESCE(agent_feedback_count, 0) + 1
-		WHERE session_key = ? AND memory_id = ?
+		WHERE session_key = ? AND agent_id = ? AND memory_id = ?
 	`);
 
 	for (const [memoryId, score] of Object.entries(feedback)) {
-		stmt.run(score, score, sessionKey, memoryId);
+		stmt.run(score, score, sessionKey, agentId, memoryId);
 	}
 }
 
@@ -258,12 +265,13 @@ export function recordAgentFeedbackInner(
 export function recordAgentFeedback(
 	sessionKey: string | undefined,
 	feedback: Readonly<Record<string, number>>,
+	agentId = "default",
 ): void {
 	if (!sessionKey || Object.keys(feedback).length === 0 || !existsSync(getMemoryDbPath())) return;
 
 	try {
 		getDbAccessor().withWriteTx((db) => {
-			recordAgentFeedbackInner(db, sessionKey, feedback);
+			recordAgentFeedbackInner(db, sessionKey, feedback, agentId);
 		});
 
 		logger.debug("session-memories", "Recorded agent feedback", {

--- a/packages/daemon/src/session-memories.ts
+++ b/packages/daemon/src/session-memories.ts
@@ -32,6 +32,7 @@ export interface SessionMemoryCandidate {
 	readonly aspectSlot?: number;
 	readonly isConstraint?: number;
 	readonly structuralDensity?: number;
+	readonly pathJson?: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -58,13 +59,13 @@ export function recordSessionCandidates(
 		getDbAccessor().withWriteTx((db) => {
 			const now = new Date().toISOString();
 			const CHUNK_SIZE = 50;
-			const ROW = "(?,?,?,?,?,?,?,?,?,0,?,?,?,?,?,?)";
+			const ROW = "(?,?,?,?,?,?,?,?,?,0,?,?,?,?,?,?,?)";
 			const BASE_SQL = `INSERT OR IGNORE INTO session_memories
 					 (id, session_key, memory_id, source, effective_score,
 					  predictor_score, final_score, rank, was_injected,
 					  fts_hit_count, created_at,
 					  entity_slot, aspect_slot, is_constraint, structural_density,
-					  predictor_rank)
+					  predictor_rank, path_json)
 					 VALUES `;
 
 			// Pre-compile the full-chunk statement once to avoid recompiling
@@ -105,6 +106,7 @@ export function recordSessionCandidates(
 						c.isConstraint ?? 0,
 						c.structuralDensity ?? null,
 						c.predictorRank ?? null,
+						c.pathJson ?? null,
 					);
 				}
 


### PR DESCRIPTION
## Summary
This PR implements the DP-9 path feedback slice end-to-end:
- path-level feedback propagation from `memory_feedback`
- co-occurrence edge growth with NPMI gating + homeostasis cap
- Q-value reward tracking for path learning
- backward-compatible API/tool changes

It also updates spec tracking to mark DP-9 complete in `docs/specs/INDEX.md`.

## Why
We had coarse feedback signals (mostly FTS overlap + memory-level ratings), but no durable path-level learning loop between:
1. what retrieval path produced context,
2. what the agent rated useful/harmful,
3. how graph structure should adapt over time.

This PR closes that loop so DP-10 path scoring has real training signals and retrieval can improve structurally rather than only through flat memory scoring.

## What changed

### 1) New schema for DP-9 feedback/history
Added migration **041-path-feedback**:
- `session_memories.path_json` for storing provenance per candidate
- `path_feedback_events` for immutable event history (rating + reward components)
- `path_feedback_stats` for per-path aggregates + EMA Q-value
- `entity_retrieval_stats` for per-entity retrieval session counts
- `entity_cooccurrence` for pairwise co-retrieval counts
- `path_feedback_sessions` for session cardinality used in NPMI calculations

Migration is wired in `packages/core/src/migrations/index.ts` and covered in migration tests.

### 2) Path provenance from traversal into session candidates
- `graph-traversal.ts` now returns `memoryPaths` alongside `memoryIds`
- traversal path shape includes `entityIds`, `aspectIds`, and `dependencyIds`
- `hooks.ts` serializes traversal paths and attaches them to candidate records
- `session-memories.ts` persists the payload in `session_memories.path_json`

This gives the feedback endpoint deterministic provenance even when the client sends ratings only.

### 3) New path feedback propagation engine
Added `packages/daemon/src/path-feedback.ts`:
- still records legacy `agent_relevance_score` via `recordAgentFeedbackInner`
- resolves provenance path in priority order:
  1. explicit `paths` payload
  2. stored `session_memories.path_json`
  3. inference from active attributes
- writes `path_feedback_events`
- updates `path_feedback_stats` (EMA with alpha=0.1)
- propagates rating to:
  - aspect weights (`entity_aspects.weight`)
  - dependency strength/confidence/reason (`entity_dependencies`)
- performs co-occurrence updates and conditional edge promotion:
  - requires min co-session count
  - requires NPMI threshold
  - promotes/updates `related_to` edges with `reason='pattern-matched'`
  - enforces per-source auto-edge cap (homeostasis)

### 4) API + MCP updates (backward compatible)
`POST /api/memory/feedback` now accepts optional:
- `agentId`
- `paths`
- `rewards`

If path propagation fails, endpoint falls back to legacy memory feedback recording (fail-open behavior preserved).

`memory_feedback` MCP tool schema now supports optional `agent_id`, `paths`, and `rewards` and forwards them through.

### 5) docs + parity touch
- `docs/specs/INDEX.md` updated to mark DP-9 complete
- `docs/specs/dependencies.yaml` updated timestamp
- Rust shadow parity: updated daemon-rs MCP `memory_feedback` input schema to match new payload shape

## Behavioral notes
- Existing clients that only send `{session_key, ratings}` continue working.
- Positive rating upgrades dependency reason confidence ladder over time.
- Negative rating weakens path dependencies/aspects with floors (no catastrophic drops).
- Q-value reward supports richer signals (`forward_citation`, `update_after_retrieval`, `downstream_creation`, `dead_end`).

## Validation
Ran:
- `bun scripts/spec-deps-check.ts`
- `bun test packages/core/src/migrations/migrations.test.ts packages/daemon/src/session-memories.test.ts packages/daemon/src/path-feedback.test.ts packages/daemon/src/mcp/tools.test.ts`

All above passed.

## Scope boundaries
- This PR implements DP-9 infrastructure and propagation.
- It does **not** yet switch predictor ranking to path-native features (that remains DP-10).
