### PR TITLE
fix: wire agent_id and visibility through memory write and recall

### DIFF
--- a/packages/daemon-rs/crates/signet-core/src/queries/memory.rs
+++ b/packages/daemon-rs/crates/signet-core/src/queries/memory.rs
@@ -554,6 +554,8 @@ mod tests {
             runtime_path: None,
             now: "2024-01-01T00:00:00Z",
             updated_by: "test",
+            agent_id: "default",
+            visibility: "global",
         }
     }
 

--- a/packages/daemon-rs/crates/signet-core/src/queries/memory.rs
+++ b/packages/daemon-rs/crates/signet-core/src/queries/memory.rs
@@ -169,6 +169,8 @@ pub struct InsertMemory<'a> {
     pub runtime_path: Option<&'a str>,
     pub now: &'a str,
     pub updated_by: &'a str,
+    pub agent_id: &'a str,
+    pub visibility: &'a str,
 }
 
 /// Insert a new memory row. Returns the ID.
@@ -179,8 +181,8 @@ pub fn insert(conn: &Connection, m: &InsertMemory) -> Result<String, CoreError> 
           who, why, project, importance, pinned, is_deleted,
           extraction_status, embedding_model, extraction_model,
           source_type, source_id, idempotency_key, runtime_path,
-          confidence, created_at, updated_at, updated_by)
-         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,0,?12,?13,?14,?15,?16,?17,?18,?10,?19,?19,?20)",
+          confidence, created_at, updated_at, updated_by, agent_id, visibility)
+         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,0,?12,?13,?14,?15,?16,?17,?18,?10,?19,?19,?20,?21,?22)",
         params![
             m.id,
             m.content,
@@ -202,6 +204,8 @@ pub fn insert(conn: &Connection, m: &InsertMemory) -> Result<String, CoreError> 
             m.runtime_path,
             m.now,
             m.updated_by,
+            m.agent_id,
+            m.visibility,
         ],
     )?;
     Ok(m.id.to_string())

--- a/packages/daemon-rs/crates/signet-daemon/src/mcp/tools.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/mcp/tools.rs
@@ -412,6 +412,8 @@ async fn exec_memory_store(state: &Arc<AppState>, args: &serde_json::Value) -> T
                 idempotency_key: None,
                 runtime_path: None,
                 actor: "mcp-server",
+                agent_id: "default",
+                visibility: "global",
             };
             let result = signet_services::transactions::ingest(conn, &input)?;
             Ok(serde_json::json!({

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -442,6 +442,8 @@ pub async fn remember(
                     idempotency_key: idempotency_key.as_deref(),
                     runtime_path: runtime_path_str.as_deref(),
                     actor: "hook",
+                    agent_id: "default",
+                    visibility: "global",
                 },
             )?;
 
@@ -726,6 +728,8 @@ pub async fn compaction_complete(
                     idempotency_key: None,
                     runtime_path: None,
                     actor: "compaction",
+                    agent_id: "default",
+                    visibility: "global",
                 },
             )?;
 

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/search.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/search.rs
@@ -25,7 +25,6 @@ pub struct RecallBody {
     pub query: String,
     pub keyword_query: Option<String>,
     pub limit: Option<usize>,
-    #[allow(dead_code)] // Used in Phase 3 for agent scoping
     pub agent_id: Option<String>,
     #[serde(rename = "type")]
     pub memory_type: Option<String>,
@@ -105,6 +104,7 @@ pub async fn recall(
     let importance_min = body.importance_min;
     let since = body.since.clone();
     let until = body.until.clone();
+    let agent_id = body.agent_id.clone();
     let query_for_response = query.clone();
 
     let result = state
@@ -141,27 +141,83 @@ pub async fn recall(
                 });
             }
 
-            // Fetch full rows
+            // Fetch full rows with agent scope filtering
             let ids: Vec<&str> = scored.iter().map(|s| s.id.as_str()).collect();
+            let id_count = ids.len();
             let placeholders: String = ids
                 .iter()
                 .enumerate()
                 .map(|(i, _)| format!("?{}", i + 1))
                 .collect::<Vec<_>>()
                 .join(",");
+
+            // Build agent scope clause
+            let (agent_clause, agent_params) = if let Some(ref aid) = agent_id {
+                // Look up agent's read_policy
+                let policy: String = conn
+                    .query_row(
+                        "SELECT read_policy FROM agents WHERE id = ?1",
+                        rusqlite::params![aid],
+                        |row| row.get(0),
+                    )
+                    .unwrap_or_else(|_| "isolated".to_string());
+
+                match policy.as_str() {
+                    "shared" => (
+                        format!(
+                            " AND (visibility = 'global' OR agent_id = ?{}) AND visibility != 'archived'",
+                            id_count + 1
+                        ),
+                        vec![aid.clone()],
+                    ),
+                    "group" => {
+                        let group: Option<String> = conn
+                            .query_row(
+                                "SELECT policy_group FROM agents WHERE id = ?1",
+                                rusqlite::params![aid],
+                                |row| row.get(0),
+                            )
+                            .ok()
+                            .flatten();
+                        (
+                            format!(
+                                " AND ((visibility = 'global' AND agent_id IN (SELECT id FROM agents WHERE policy_group = ?{})) OR agent_id = ?{}) AND visibility != 'archived'",
+                                id_count + 1,
+                                id_count + 2,
+                            ),
+                            vec![group.unwrap_or_default(), aid.clone()],
+                        )
+                    }
+                    _ => (
+                        format!(
+                            " AND agent_id = ?{} AND visibility != 'archived'",
+                            id_count + 1
+                        ),
+                        vec![aid.clone()],
+                    ),
+                }
+            } else {
+                (String::new(), vec![])
+            };
+
             let sql = format!(
                 "SELECT id, content, type, tags, pinned, importance, who, project, created_at
-                 FROM memories WHERE id IN ({placeholders})"
+                 FROM memories WHERE id IN ({placeholders}){agent_clause}"
             );
 
             let mut stmt = conn.prepare(&sql)?;
-            let refs: Vec<&dyn rusqlite::types::ToSql> = ids
+            let mut refs: Vec<Box<dyn rusqlite::types::ToSql>> = ids
                 .iter()
-                .map(|s| s as &dyn rusqlite::types::ToSql)
+                .map(|s| Box::new(s.to_string()) as Box<dyn rusqlite::types::ToSql>)
                 .collect();
+            for p in &agent_params {
+                refs.push(Box::new(p.clone()));
+            }
+            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                refs.iter().map(|b| b.as_ref()).collect();
 
             let rows: std::collections::HashMap<String, RecallHit> = stmt
-                .query_map(refs.as_slice(), |row| {
+                .query_map(param_refs.as_slice(), |row| {
                     let content: String = row.get(1)?;
                     let len = content.len();
                     let is_truncated = len > truncate;

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/search.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/search.rs
@@ -179,14 +179,25 @@ pub async fn recall(
                             )
                             .ok()
                             .flatten();
-                        (
-                            format!(
-                                " AND ((visibility = 'global' AND agent_id IN (SELECT id FROM agents WHERE policy_group = ?{})) OR agent_id = ?{}) AND visibility != 'archived'",
-                                id_count + 1,
-                                id_count + 2,
-                            ),
-                            vec![group.unwrap_or_default(), aid.clone()],
-                        )
+                        if let Some(g) = group {
+                            (
+                                format!(
+                                    " AND ((visibility = 'global' AND agent_id IN (SELECT id FROM agents WHERE policy_group = ?{})) OR agent_id = ?{}) AND visibility != 'archived'",
+                                    id_count + 1,
+                                    id_count + 2,
+                                ),
+                                vec![g, aid.clone()],
+                            )
+                        } else {
+                            // No group configured — fall back to isolated (own memories only)
+                            (
+                                format!(
+                                    " AND agent_id = ?{} AND visibility != 'archived'",
+                                    id_count + 1
+                                ),
+                                vec![aid.clone()],
+                            )
+                        }
                     }
                     _ => (
                         format!(

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/write.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/write.rs
@@ -59,6 +59,8 @@ pub struct RememberBody {
     pub source_id: Option<String>,
     #[serde(rename = "type")]
     pub memory_type: Option<String>,
+    pub agent_id: Option<String>,
+    pub visibility: Option<String>,
 }
 
 fn parse_remember_tags(value: Option<Value>) -> Result<Vec<String>, &'static str> {
@@ -128,6 +130,12 @@ pub async fn remember(
     let source_type = body.source_type;
     let source_id = body.source_id;
     let memory_type = body.memory_type.unwrap_or_else(|| "fact".into());
+    let agent_id = body.agent_id.unwrap_or_else(|| "default".into());
+    let visibility = match body.visibility.as_deref() {
+        Some("private") => "private",
+        _ => "global",
+    }
+    .to_string();
 
     let result = state
         .pool
@@ -148,6 +156,8 @@ pub async fn remember(
                     idempotency_key: None,
                     runtime_path: None,
                     actor: "api",
+                    agent_id: &agent_id,
+                    visibility: &visibility,
                 },
             )?;
 

--- a/packages/daemon-rs/crates/signet-services/src/transactions.rs
+++ b/packages/daemon-rs/crates/signet-services/src/transactions.rs
@@ -30,6 +30,8 @@ pub struct IngestInput<'a> {
     pub idempotency_key: Option<&'a str>,
     pub runtime_path: Option<&'a str>,
     pub actor: &'a str,
+    pub agent_id: &'a str,
+    pub visibility: &'a str,
 }
 
 pub struct IngestResult {
@@ -77,6 +79,8 @@ pub fn ingest(conn: &Connection, input: &IngestInput) -> Result<IngestResult, Co
             runtime_path: input.runtime_path,
             now: &now,
             updated_by: input.actor,
+            agent_id: input.agent_id,
+            visibility: input.visibility,
         },
     )?;
 

--- a/packages/daemon-rs/crates/signet-services/src/transactions.rs
+++ b/packages/daemon-rs/crates/signet-services/src/transactions.rs
@@ -398,6 +398,8 @@ mod tests {
                 idempotency_key: None,
                 runtime_path: None,
                 actor: "test",
+                agent_id: "default",
+                visibility: "global",
             },
         )
         .unwrap();
@@ -420,6 +422,8 @@ mod tests {
                 idempotency_key: None,
                 runtime_path: None,
                 actor: "test",
+                agent_id: "default",
+                visibility: "global",
             },
         )
         .unwrap();
@@ -446,6 +450,8 @@ mod tests {
                 idempotency_key: None,
                 runtime_path: None,
                 actor: "test",
+                agent_id: "default",
+                visibility: "global",
             },
         )
         .unwrap();
@@ -492,6 +498,8 @@ mod tests {
                 idempotency_key: None,
                 runtime_path: None,
                 actor: "test",
+                agent_id: "default",
+                visibility: "global",
             },
         )
         .unwrap();
@@ -547,6 +555,8 @@ mod tests {
                 idempotency_key: None,
                 runtime_path: None,
                 actor: "test",
+                agent_id: "default",
+                visibility: "global",
             },
         )
         .unwrap();

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2737,7 +2737,7 @@ app.post("/api/memory/remember", async (c) => {
 		sourceId?: string;
 		scope?: string | null;
 		agentId?: string;
-		visibility?: string;
+		visibility?: "global" | "private" | "archived";
 		hints?: string[];
 		transcript?: string;
 		structured?: {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2736,6 +2736,8 @@ app.post("/api/memory/remember", async (c) => {
 		sourceType?: string;
 		sourceId?: string;
 		scope?: string | null;
+		agentId?: string;
+		visibility?: string;
 		hints?: string[];
 		transcript?: string;
 		structured?: {
@@ -2769,6 +2771,8 @@ app.post("/api/memory/remember", async (c) => {
 	const raw = body.content?.trim();
 	if (!raw) return c.json({ error: "content is required" }, 400);
 	const scope = body.scope ?? null;
+	const agentId = resolveAgentId({ agentId: body.agentId, sessionKey: c.req.header("x-signet-session-key") });
+	const visibility = body.visibility === "private" ? "private" : "global";
 	const hasBodyTags = Object.prototype.hasOwnProperty.call(body, "tags");
 	const bodyTags = hasBodyTags ? parseTagsMutation(body.tags) : undefined;
 	if (hasBodyTags && bodyTags === undefined) {
@@ -2812,8 +2816,8 @@ app.post("/api/memory/remember", async (c) => {
 				db.prepare(
 					`INSERT INTO entities
 					 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
-					 VALUES (?, ?, ?, 'chunk_group', 'default', 0, ?, ?)`,
-				).run(groupId, `chunk-group:${groupId}`, `chunk-group:${groupId}`, now, now);
+					 VALUES (?, ?, ?, 'chunk_group', ?, 0, ?, ?)`,
+				).run(groupId, `chunk-group:${groupId}`, `chunk-group:${groupId}`, agentId, now, now);
 			});
 		} catch (e) {
 			logger.error("memory", "Failed to create chunk group entity", e as Error);
@@ -2859,6 +2863,8 @@ app.post("/api/memory/remember", async (c) => {
 						sourceType: "chunk",
 						sourceId: groupId,
 						scope,
+						agentId,
+						visibility,
 						createdAt: now,
 					});
 
@@ -3053,6 +3059,8 @@ app.post("/api/memory/remember", async (c) => {
 				sourceType,
 				sourceId,
 				scope,
+				agentId,
+				visibility,
 				createdAt: now,
 			});
 			return { deduped: false as const };

--- a/packages/daemon/src/memory-search.ts
+++ b/packages/daemon/src/memory-search.ts
@@ -948,10 +948,10 @@ export async function hybridRecall(
 							 WHERE mem.entity_id IN (${ePlaceholders})
 							   AND m.type = 'rationale'
 							   AND m.is_deleted = 0
-							   ${scopeClause}
+							   ${scopeClause}${agentScope.sql}
 							 LIMIT 10`,
 					)
-					.all(...eIds, ...scopeArgs) as Array<{
+					.all(...eIds, ...scopeArgs, ...agentScope.args) as Array<{
 					id: string;
 					content: string;
 					type: string;

--- a/packages/daemon/src/memory-search.ts
+++ b/packages/daemon/src/memory-search.ts
@@ -842,6 +842,8 @@ export async function hybridRecall(
 	// --- Fetch full memory rows ---
 	// Scope filter on hydration catches any results that bypassed
 	// the FTS filter clause (e.g. unscoped graph boost results).
+	// Agent scope filter also applied here to catch vector/traversal
+	// results that bypass FTS-level agent filtering.
 	const scopeClause =
 		params.scope !== undefined
 			? params.scope === null
@@ -849,17 +851,21 @@ export async function hybridRecall(
 				: " AND scope = ?"
 			: " AND scope IS NULL";
 	const scopeArgs: unknown[] = params.scope !== undefined && params.scope !== null ? [params.scope] : [];
+	const agentScope =
+		params.agentId && params.readPolicy
+			? buildAgentScopeClause(params.agentId, params.readPolicy, params.policyGroup ?? null)
+			: { sql: "", args: [] };
 	const placeholders = topIds.map(() => "?").join(", ");
 
 	const rows = getDbAccessor().withReadDb(
 		(db) =>
 			db
 				.prepare(
-					`SELECT id, content, source_id, type, tags, pinned, importance, who, project, created_at
-        FROM memories
-        WHERE id IN (${placeholders})${scopeClause}`,
+					`SELECT m.id, m.content, m.source_id, m.type, m.tags, m.pinned, m.importance, m.who, m.project, m.created_at
+        FROM memories m
+        WHERE m.id IN (${placeholders})${scopeClause}${agentScope.sql}`,
 				)
-				.all(...topIds, ...scopeArgs) as Array<{
+				.all(...topIds, ...scopeArgs, ...agentScope.args) as Array<{
 				id: string;
 				content: string;
 				source_id: string | null;

--- a/packages/daemon/src/memory-search.ts
+++ b/packages/daemon/src/memory-search.ts
@@ -847,9 +847,9 @@ export async function hybridRecall(
 	const scopeClause =
 		params.scope !== undefined
 			? params.scope === null
-				? " AND scope IS NULL"
-				: " AND scope = ?"
-			: " AND scope IS NULL";
+				? " AND m.scope IS NULL"
+				: " AND m.scope = ?"
+			: " AND m.scope IS NULL";
 	const scopeArgs: unknown[] = params.scope !== undefined && params.scope !== null ? [params.scope] : [];
 	const agentScope =
 		params.agentId && params.readPolicy

--- a/packages/daemon/src/transactions.ts
+++ b/packages/daemon/src/transactions.ts
@@ -34,7 +34,7 @@ export interface IngestEnvelope {
 	sourceId: string | null;
 	scope?: string | null;
 	agentId?: string;
-	visibility?: string;
+	visibility?: "global" | "private" | "archived";
 	createdAt: string;
 }
 

--- a/packages/daemon/src/transactions.ts
+++ b/packages/daemon/src/transactions.ts
@@ -33,6 +33,8 @@ export interface IngestEnvelope {
 	sourceType: string;
 	sourceId: string | null;
 	scope?: string | null;
+	agentId?: string;
+	visibility?: string;
 	createdAt: string;
 }
 
@@ -216,8 +218,8 @@ export function txIngestEnvelope(db: WriteDb, mem: IngestEnvelope): string {
 		 (id, content, normalized_content, content_hash, who, why, project,
 		  importance, type, tags, pinned, is_deleted, extraction_status,
 		  embedding_model, extraction_model, created_at, updated_at, updated_by,
-		  source_type, source_id, scope)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		  source_type, source_id, scope, agent_id, visibility)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 	).run(
 		mem.id,
 		mem.content,
@@ -240,6 +242,8 @@ export function txIngestEnvelope(db: WriteDb, mem: IngestEnvelope): string {
 		mem.sourceType,
 		mem.sourceId,
 		mem.scope ?? null,
+		mem.agentId ?? "default",
+		mem.visibility ?? "global",
 	);
 
 	// FTS sync handled by memories_ai AFTER INSERT trigger (migration 001)


### PR DESCRIPTION
## Summary

- **Write path**: The remember endpoint accepted `agentId` and `visibility` in the request body but never passed them through to `txIngestEnvelope`, so all memories were stored as `agent_id='default'`, `visibility='global'` regardless of CLI flags (`--agent`, `--private`)
- **Read path**: The recall hydration query (where FTS, vector, and traversal results converge) did not apply `buildAgentScopeClause`, so vector/traversal results bypassed agent visibility filtering — private memories from one agent were visible to others
- Fixes both paths across `daemon.ts`, `transactions.ts`, and `memory-search.ts`

## Test plan

- [x] `signet remember "test" --agent dot --private` stores with `agent_id='dot'`, `visibility='private'` (verified on solvr)
- [x] `signet recall "test" --agent dot` returns dot's private + global memories
- [x] `signet recall "test" --agent miles` does NOT return dot's private memory
- [x] `signet recall "test"` (no agent) returns only global memories
- [ ] `bun test` passes
- [ ] `bun run build` succeeds