### PR TITLE
fix(pipeline) recover stale leases and retry hint failures

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2046,12 +2046,19 @@ after resolving a pipeline configuration issue.
 ### POST /api/repair/release-leases
 
 Release stale pipeline job leases that have exceeded their timeout. Run this
-if pipeline workers crashed and left jobs locked.
+if pipeline workers crashed and left jobs locked. Stale jobs that still have
+remaining retries are returned to `pending`. Stale jobs that have already
+reached `max_attempts` are moved to `dead` instead of being requeued again.
 
 **Response**
 
 ```json
-{ "action": "releaseStaleLeases", "success": true, "affected": 3, "message": "..." }
+{
+  "action": "releaseStaleLeases",
+  "success": true,
+  "affected": 3,
+  "message": "released 2 stale lease(s) back to pending and dead-lettered 1 exhausted job(s)"
+}
 ```
 
 ### POST /api/repair/check-fts

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -249,8 +249,10 @@ curl -X POST http://localhost:3850/api/repair/requeue-dead \
 
 ### POST /api/repair/release-leases
 
-Releases jobs stuck in `leased` status past the lease timeout back to
-`pending`. The cutoff is `now - leaseTimeoutMs` (default: 5 minutes).
+Releases jobs stuck in `leased` status past the lease timeout. Jobs with
+remaining retries move back to `pending`. Jobs whose `attempts` already meet
+or exceed `max_attempts` are dead-lettered instead. The cutoff is
+`now - leaseTimeoutMs` (default: 5 minutes).
 
 - Cooldown: `repairRequeueCooldownMs` (default: 1 minute)
 - Hourly budget: `repairRequeueHourlyBudget` (default: 50)

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/repair.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/repair.rs
@@ -68,26 +68,49 @@ pub async fn release_leases(State(state): State<Arc<AppState>>) -> impl IntoResp
     let result = state
         .pool
         .write(signet_core::db::Priority::Low, |conn| {
-            let count = conn.execute(
-                "UPDATE memory_jobs SET status = 'pending', leased_at = NULL, updated_at = datetime('now')
-                 WHERE status = 'leased' AND leased_at < datetime('now', '-5 minutes')",
+            let dead = conn.execute(
+                "UPDATE memory_jobs
+                 SET status = 'dead',
+                     leased_at = NULL,
+                     failed_at = datetime('now'),
+                     error = COALESCE(error, 'lease expired before completion'),
+                     updated_at = datetime('now')
+                 WHERE status = 'leased'
+                   AND leased_at < datetime('now', '-5 minutes')
+                   AND attempts >= max_attempts",
                 [],
             )?;
-            Ok(serde_json::json!(count))
+            let pending = conn.execute(
+                "UPDATE memory_jobs
+                 SET status = 'pending',
+                     leased_at = NULL,
+                     updated_at = datetime('now')
+                 WHERE status = 'leased'
+                   AND leased_at < datetime('now', '-5 minutes')
+                   AND attempts < max_attempts",
+                [],
+            )?;
+            Ok(serde_json::json!({
+                "pending": pending,
+                "dead": dead,
+                "total": pending + dead,
+            }))
         })
         .await;
 
     match result {
         Ok(count) => {
-            let n = count.as_u64().unwrap_or(0) as usize;
+            let pending = count["pending"].as_u64().unwrap_or(0) as usize;
+            let dead = count["dead"].as_u64().unwrap_or(0) as usize;
+            let n = count["total"].as_u64().unwrap_or(0) as usize;
+            let msg = if dead > 0 {
+                format!("{pending} stale leases released, {dead} exhausted jobs dead-lettered")
+            } else {
+                format!("{pending} stale leases released")
+            };
             (
                 StatusCode::OK,
-                Json(repair_result(
-                    "release_leases",
-                    true,
-                    n,
-                    &format!("{n} stale leases released"),
-                )),
+                Json(repair_result("release_leases", true, n, &msg)),
             )
         }
         Err(e) => (

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/repair.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/repair.rs
@@ -25,6 +25,19 @@ fn repair_result(action: &str, success: bool, affected: usize, message: &str) ->
     })
 }
 
+fn lease_timeout_ms(state: &AppState) -> u64 {
+    // Match the TypeScript repair endpoint's resolved fallback until the
+    // Rust daemon shares the same config resolution path.
+    state
+        .config
+        .manifest
+        .memory
+        .as_ref()
+        .and_then(|cfg| cfg.pipeline_v2.as_ref())
+        .map(|cfg| cfg.worker.lease_timeout_ms)
+        .unwrap_or(300_000)
+}
+
 // ---------------------------------------------------------------------------
 // Repair endpoints
 // ---------------------------------------------------------------------------
@@ -65,30 +78,34 @@ pub async fn requeue_dead(State(state): State<Arc<AppState>>) -> impl IntoRespon
 
 /// POST /api/repair/release-leases — release stale job leases.
 pub async fn release_leases(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let lease_ms = lease_timeout_ms(&state).min(i64::MAX as u64) as i64;
+    let now = chrono::Utc::now();
+    let now_s = now.to_rfc3339();
+    let cutoff = (now - chrono::Duration::milliseconds(lease_ms)).to_rfc3339();
     let result = state
         .pool
-        .write(signet_core::db::Priority::Low, |conn| {
+        .write(signet_core::db::Priority::Low, move |conn| {
             let dead = conn.execute(
                 "UPDATE memory_jobs
                  SET status = 'dead',
                      leased_at = NULL,
-                     failed_at = datetime('now'),
+                     failed_at = ?1,
                      error = COALESCE(error, 'lease expired before completion'),
-                     updated_at = datetime('now')
+                     updated_at = ?1
                  WHERE status = 'leased'
-                   AND leased_at < datetime('now', '-5 minutes')
+                   AND leased_at < ?2
                    AND attempts >= max_attempts",
-                [],
+                rusqlite::params![now_s, cutoff],
             )?;
             let pending = conn.execute(
                 "UPDATE memory_jobs
                  SET status = 'pending',
                      leased_at = NULL,
-                     updated_at = datetime('now')
+                     updated_at = ?1
                  WHERE status = 'leased'
-                   AND leased_at < datetime('now', '-5 minutes')
+                   AND leased_at < ?2
                    AND attempts < max_attempts",
-                [],
+                rusqlite::params![now_s, cutoff],
             )?;
             Ok(serde_json::json!({
                 "pending": pending,
@@ -104,9 +121,11 @@ pub async fn release_leases(State(state): State<Arc<AppState>>) -> impl IntoResp
             let dead = count["dead"].as_u64().unwrap_or(0) as usize;
             let n = count["total"].as_u64().unwrap_or(0) as usize;
             let msg = if dead > 0 {
-                format!("{pending} stale leases released, {dead} exhausted jobs dead-lettered")
+                format!(
+                    "released {pending} stale lease(s) back to pending and dead-lettered {dead} exhausted job(s)"
+                )
             } else {
-                format!("{pending} stale leases released")
+                format!("released {pending} stale lease(s) back to pending")
             };
             (
                 StatusCode::OK,

--- a/packages/daemon/src/pipeline/prospective-index.test.ts
+++ b/packages/daemon/src/pipeline/prospective-index.test.ts
@@ -12,11 +12,7 @@ import { runMigrations } from "@signet/core";
 import type { LlmProvider } from "./provider";
 import type { DbAccessor, WriteDb, ReadDb } from "../db-accessor";
 import type { PipelineHintsConfig } from "@signet/core";
-import {
-	generateHints,
-	enqueueHintsJob,
-	startHintsWorker,
-} from "./prospective-index";
+import { generateHints, enqueueHintsJob, startHintsWorker } from "./prospective-index";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -64,9 +60,9 @@ const HINTS_CFG: PipelineHintsConfig = {
 
 function getHints(db: Database, memoryId: string): string[] {
 	return (
-		db
-			.prepare(`SELECT hint FROM memory_hints WHERE memory_id = ? ORDER BY hint`)
-			.all(memoryId) as Array<{ hint: string }>
+		db.prepare(`SELECT hint FROM memory_hints WHERE memory_id = ? ORDER BY hint`).all(memoryId) as Array<{
+			hint: string;
+		}>
 	).map((r) => r.hint);
 }
 
@@ -86,13 +82,27 @@ function getHintsFts(db: Database, query: string): string[] {
 function getJob(
 	db: Database,
 	memoryId: string,
-): { status: string; attempts: number } | undefined {
+):
+	| {
+			status: string;
+			attempts: number;
+			leased_at: string | null;
+			failed_at: string | null;
+	  }
+	| undefined {
 	return db
 		.prepare(
-			`SELECT status, attempts FROM memory_jobs
+			`SELECT status, attempts, leased_at, failed_at FROM memory_jobs
 			 WHERE memory_id = ? AND job_type = 'prospective_index'`,
 		)
-		.get(memoryId) as { status: string; attempts: number } | undefined;
+		.get(memoryId) as
+		| {
+				status: string;
+				attempts: number;
+				leased_at: string | null;
+				failed_at: string | null;
+		  }
+		| undefined;
 }
 
 /** Shared pipeline config with hints enabled. */
@@ -105,8 +115,23 @@ function pipelineCfg(hints = HINTS_CFG) {
 		worker: { pollMs: 10, maxRetries: 3, leaseTimeoutMs: 300000 },
 		graph: { enabled: false, boostWeight: 0, boostTimeoutMs: 500 },
 		reranker: { enabled: false, model: "", topN: 20, timeoutMs: 2000 },
-		autonomous: { enabled: false, frozen: false, allowUpdateDelete: false, maintenanceIntervalMs: 0, maintenanceMode: "observe" as const },
-		repair: { reembedCooldownMs: 0, reembedHourlyBudget: 0, requeueCooldownMs: 0, requeueHourlyBudget: 0, dedupCooldownMs: 0, dedupHourlyBudget: 0, dedupSemanticThreshold: 0.92, dedupBatchSize: 100 },
+		autonomous: {
+			enabled: false,
+			frozen: false,
+			allowUpdateDelete: false,
+			maintenanceIntervalMs: 0,
+			maintenanceMode: "observe" as const,
+		},
+		repair: {
+			reembedCooldownMs: 0,
+			reembedHourlyBudget: 0,
+			requeueCooldownMs: 0,
+			requeueHourlyBudget: 0,
+			dedupCooldownMs: 0,
+			dedupHourlyBudget: 0,
+			dedupSemanticThreshold: 0.92,
+			dedupBatchSize: 100,
+		},
 		documents: { workerIntervalMs: 10000, chunkSize: 2000, chunkOverlap: 200, maxContentBytes: 10_000_000 },
 		guardrails: { maxContentChars: 500, chunkTargetChars: 300, recallTruncateChars: 500 },
 		structural: { enabled: false, classifyBatchSize: 8, dependencyBatchSize: 5, pollIntervalMs: 10000 },
@@ -302,9 +327,7 @@ describe("prospective-index", () => {
 		});
 
 		it("propagates provider errors", async () => {
-			await expect(
-				generateHints(throwingProvider(), "test", HINTS_CFG),
-			).rejects.toThrow("Ollama timeout");
+			await expect(generateHints(throwingProvider(), "test", HINTS_CFG)).rejects.toThrow("Ollama timeout");
 		});
 
 		it("filters lines shorter than 11 characters", async () => {
@@ -451,6 +474,30 @@ describe("prospective-index", () => {
 			// Same hints should not duplicate due to UNIQUE(memory_id, hint)
 			const hints = getHints(db, mid);
 			expect(hints.length).toBe(5);
+		});
+
+		it("requeues throwing jobs immediately instead of leaving them leased for the reaper", async () => {
+			const mid = crypto.randomUUID();
+			insertMemory(db, mid, "test content");
+
+			accessor.withWriteTx((wdb) => {
+				enqueueHintsJob(wdb, mid, "test content");
+			});
+
+			const handle = startHintsWorker({
+				accessor,
+				provider: throwingProvider(),
+				pipelineCfg: pipelineCfg(),
+			});
+
+			await new Promise((r) => setTimeout(r, 200));
+			await handle.stop();
+
+			const job = getJob(db, mid);
+			expect(job).toBeDefined();
+			expect(job?.status).toBe("pending");
+			expect(job?.attempts).toBe(1);
+			expect(job?.failed_at).not.toBeNull();
 		});
 	});
 

--- a/packages/daemon/src/pipeline/prospective-index.ts
+++ b/packages/daemon/src/pipeline/prospective-index.ts
@@ -193,12 +193,13 @@ export function startHintsWorker(deps: {
 				schedule();
 				return;
 			}
+			const j = job;
 
 			let payload: HintPayload;
 			try {
-				payload = JSON.parse(job.payload) as HintPayload;
+				payload = JSON.parse(j.payload) as HintPayload;
 			} catch {
-				accessor.withWriteTx((db) => failJob(db, job.id, "invalid payload"));
+				accessor.withWriteTx((db) => failJob(db, j.id, "invalid payload"));
 				schedule();
 				return;
 			}
@@ -209,27 +210,28 @@ export function startHintsWorker(deps: {
 			if (hints.length > 0) {
 				accessor.withWriteTx((db) => {
 					writeHints(db, payload.memoryId, "default", hints);
-					completeJob(db, job.id);
+					completeJob(db, j.id);
 				});
 				logger.info("pipeline", "Prospective hints generated", {
 					memoryId: payload.memoryId,
 					hints: hints.length,
 				});
 			} else {
-				accessor.withWriteTx((db) => completeJob(db, job.id));
+				accessor.withWriteTx((db) => completeJob(db, j.id));
 				logger.debug("pipeline", "No hints generated (empty LLM response)", {
 					memoryId: payload.memoryId,
 				});
 			}
 		} catch (e) {
 			if (job) {
+				const j = job;
 				const msg = e instanceof Error ? e.message : String(e);
-				accessor.withWriteTx((db) => failJob(db, job.id, msg));
+				accessor.withWriteTx((db) => failJob(db, j.id, msg));
 				logger.warn("pipeline", "Hints worker job failed", {
-					jobId: job.id,
-					memoryId: job.memory_id,
+					jobId: j.id,
+					memoryId: j.memory_id,
 					error: msg,
-					attempt: job.attempts,
+					attempt: j.attempts,
 				});
 			}
 			logger.warn("pipeline", "Hints worker tick failed", {

--- a/packages/daemon/src/pipeline/prospective-index.ts
+++ b/packages/daemon/src/pipeline/prospective-index.ts
@@ -120,7 +120,7 @@ function leaseJob(db: WriteDb, maxAttempts: number): HintJobRow | null {
 		 WHERE id = ?`,
 	).run(now, now, row.id);
 
-	return row;
+	return { ...row, attempts: row.attempts + 1 };
 }
 
 function completeJob(db: WriteDb, jobId: string): void {
@@ -186,8 +186,9 @@ export function startHintsWorker(deps: {
 	async function tick(): Promise<void> {
 		if (!running) return;
 
+		let job: HintJobRow | null = null;
 		try {
-			const job = accessor.withWriteTx((db) => leaseJob(db, 3));
+			job = accessor.withWriteTx((db) => leaseJob(db, 3));
 			if (!job) {
 				schedule();
 				return;
@@ -221,6 +222,16 @@ export function startHintsWorker(deps: {
 				});
 			}
 		} catch (e) {
+			if (job) {
+				const msg = e instanceof Error ? e.message : String(e);
+				accessor.withWriteTx((db) => failJob(db, job.id, msg));
+				logger.warn("pipeline", "Hints worker job failed", {
+					jobId: job.id,
+					memoryId: job.memory_id,
+					error: msg,
+					attempt: job.attempts,
+				});
+			}
 			logger.warn("pipeline", "Hints worker tick failed", {
 				error: e instanceof Error ? e.message : String(e),
 			});

--- a/packages/daemon/src/pipeline/stale-leases.test.ts
+++ b/packages/daemon/src/pipeline/stale-leases.test.ts
@@ -4,11 +4,22 @@ import { runMigrations } from "@signet/core";
 import type { WriteDb } from "../db-accessor";
 import { recoverStaleLeases } from "./stale-leases";
 
+function insertMemory(db: Database, id: string): void {
+	const now = new Date().toISOString();
+	db.prepare(
+		`INSERT INTO memories
+		 (id, type, content, confidence, importance, created_at, updated_at,
+		  updated_by, vector_clock, is_deleted, extraction_status)
+		 VALUES (?, 'fact', ?, 1.0, 0.5, ?, ?, 'test', '{}', 0, 'none')`,
+	).run(id, `content for ${id}`, now, now);
+}
+
 describe("recoverStaleLeases", () => {
 	let db: Database;
 
 	beforeEach(() => {
 		db = new Database(":memory:");
+		db.exec("PRAGMA foreign_keys = ON");
 		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
 	});
 
@@ -22,6 +33,10 @@ describe("recoverStaleLeases", () => {
 		const freshAt = new Date("2026-03-25T00:14:30.000Z").toISOString();
 		const now = new Date("2026-03-25T00:15:00.000Z").toISOString();
 		const cutoff = new Date("2026-03-25T00:10:00.000Z").toISOString();
+
+		insertMemory(db, "mem-1");
+		insertMemory(db, "mem-2");
+		insertMemory(db, "mem-3");
 
 		db.prepare(
 			`INSERT INTO memory_jobs

--- a/packages/daemon/src/pipeline/stale-leases.test.ts
+++ b/packages/daemon/src/pipeline/stale-leases.test.ts
@@ -1,0 +1,105 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { runMigrations } from "@signet/core";
+import type { WriteDb } from "../db-accessor";
+import { recoverStaleLeases } from "./stale-leases";
+
+describe("recoverStaleLeases", () => {
+	let db: Database;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("requeues stale leased jobs and dead-letters exhausted leases", () => {
+		const createdAt = new Date("2026-03-25T00:00:00.000Z").toISOString();
+		const staleAt = new Date("2026-03-25T00:05:00.000Z").toISOString();
+		const freshAt = new Date("2026-03-25T00:14:30.000Z").toISOString();
+		const now = new Date("2026-03-25T00:15:00.000Z").toISOString();
+		const cutoff = new Date("2026-03-25T00:10:00.000Z").toISOString();
+
+		db.prepare(
+			`INSERT INTO memory_jobs
+			 (id, memory_id, job_type, status, attempts, max_attempts, leased_at, created_at, updated_at)
+			 VALUES (?, ?, 'prospective_index', 'leased', ?, ?, ?, ?, ?)`,
+		).run("job-stale", "mem-1", 1, 3, staleAt, createdAt, staleAt);
+
+		db.prepare(
+			`INSERT INTO memory_jobs
+			 (id, memory_id, job_type, status, attempts, max_attempts, leased_at, created_at, updated_at)
+			 VALUES (?, ?, 'prospective_index', 'leased', ?, ?, ?, ?, ?)`,
+		).run("job-dead", "mem-2", 3, 3, staleAt, createdAt, staleAt);
+
+		db.prepare(
+			`INSERT INTO memory_jobs
+			 (id, memory_id, job_type, status, attempts, max_attempts, leased_at, created_at, updated_at)
+			 VALUES (?, ?, 'prospective_index', 'leased', ?, ?, ?, ?, ?)`,
+		).run("job-fresh", "mem-3", 1, 3, freshAt, createdAt, freshAt);
+
+		const result = recoverStaleLeases(db as unknown as WriteDb, {
+			cutoff,
+			now,
+		});
+
+		expect(result).toEqual({
+			pending: 1,
+			dead: 1,
+			total: 2,
+		});
+
+		const stale = db
+			.prepare(
+				`SELECT status, leased_at, failed_at, error
+				 FROM memory_jobs WHERE id = 'job-stale'`,
+			)
+			.get() as
+			| {
+					status: string;
+					leased_at: string | null;
+					failed_at: string | null;
+					error: string | null;
+			  }
+			| undefined;
+		expect(stale?.status).toBe("pending");
+		expect(stale?.leased_at).toBeNull();
+		expect(stale?.failed_at).toBeNull();
+		expect(stale?.error).toBeNull();
+
+		const dead = db
+			.prepare(
+				`SELECT status, leased_at, failed_at, error
+				 FROM memory_jobs WHERE id = 'job-dead'`,
+			)
+			.get() as
+			| {
+					status: string;
+					leased_at: string | null;
+					failed_at: string | null;
+					error: string | null;
+			  }
+			| undefined;
+		expect(dead?.status).toBe("dead");
+		expect(dead?.leased_at).toBeNull();
+		expect(dead?.failed_at).toBe(now);
+		expect(dead?.error).toBe("lease expired before completion");
+
+		const fresh = db
+			.prepare(
+				`SELECT status, leased_at
+				 FROM memory_jobs WHERE id = 'job-fresh'`,
+			)
+			.get() as
+			| {
+					status: string;
+					leased_at: string | null;
+			  }
+			| undefined;
+		expect(fresh?.status).toBe("leased");
+		expect(fresh?.leased_at).toBe(freshAt);
+	});
+});

--- a/packages/daemon/src/pipeline/stale-leases.ts
+++ b/packages/daemon/src/pipeline/stale-leases.ts
@@ -1,0 +1,53 @@
+import type { WriteDb } from "../db-accessor";
+import { countChanges } from "../db-helpers";
+
+export interface StaleLeaseRecovery {
+	readonly pending: number;
+	readonly dead: number;
+	readonly total: number;
+}
+
+interface RecoverOpts {
+	readonly cutoff: string;
+	readonly now: string;
+}
+
+const LEASE_EXPIRED = "lease expired before completion";
+
+export function recoverStaleLeases(db: WriteDb, opts: RecoverOpts): StaleLeaseRecovery {
+	const dead = countChanges(
+		db
+			.prepare(
+				`UPDATE memory_jobs
+				 SET status = 'dead',
+				     leased_at = NULL,
+				     failed_at = ?,
+				     error = COALESCE(error, ?),
+				     updated_at = ?
+				 WHERE status = 'leased'
+				   AND leased_at < ?
+				   AND attempts >= max_attempts`,
+			)
+			.run(opts.now, LEASE_EXPIRED, opts.now, opts.cutoff),
+	);
+
+	const pending = countChanges(
+		db
+			.prepare(
+				`UPDATE memory_jobs
+				 SET status = 'pending',
+				     leased_at = NULL,
+				     updated_at = ?
+				 WHERE status = 'leased'
+				   AND leased_at < ?
+				   AND attempts < max_attempts`,
+			)
+			.run(opts.now, opts.cutoff),
+	);
+
+	return {
+		pending,
+		dead,
+		total: pending + dead,
+	};
+}

--- a/packages/daemon/src/pipeline/worker.ts
+++ b/packages/daemon/src/pipeline/worker.ts
@@ -27,6 +27,7 @@ import { enqueueHintsJob } from "./prospective-index";
 import type { AnalyticsCollector } from "../analytics";
 import type { TelemetryCollector } from "../telemetry";
 import { generateWithTracking } from "./provider";
+import { recoverStaleLeases, type StaleLeaseRecovery } from "./stale-leases";
 import {
 	PROSPECTIVE_ANTONYM_PAIRS,
 	tokenize,
@@ -769,18 +770,14 @@ function applyPhaseCWrites(
 // Stale lease reaper
 // ---------------------------------------------------------------------------
 
-function reapStaleLeases(accessor: DbAccessor, timeoutMs: number): number {
+function reapStaleLeases(
+	accessor: DbAccessor,
+	timeoutMs: number,
+): StaleLeaseRecovery {
 	return accessor.withWriteTx((db) => {
 		const cutoff = new Date(Date.now() - timeoutMs).toISOString();
 		const now = new Date().toISOString();
-		const result = db
-			.prepare(
-				`UPDATE memory_jobs
-				 SET status = 'pending', updated_at = ?
-				 WHERE status = 'leased' AND leased_at < ?`,
-			)
-			.run(now, cutoff);
-		return countChanges(result);
+		return recoverStaleLeases(db, { cutoff, now });
 	});
 }
 
@@ -1496,8 +1493,12 @@ export function startWorker(
 		if (!running) return;
 		try {
 			const reaped = reapStaleLeases(accessor, pipelineCfg.worker.leaseTimeoutMs);
-			if (reaped > 0) {
-				logger.info("pipeline", "Reaped stale leases", { count: reaped });
+			if (reaped.total > 0) {
+				logger.info("pipeline", "Reaped stale leases", {
+					count: reaped.total,
+					pending: reaped.pending,
+					dead: reaped.dead,
+				});
 			}
 		} catch (e) {
 			logger.warn("pipeline", "Lease reaper error", {

--- a/packages/daemon/src/repair-actions.test.ts
+++ b/packages/daemon/src/repair-actions.test.ts
@@ -144,12 +144,21 @@ function insertMemory(db: Database, id: string): void {
 	).run(id, `content for ${id}`, "fact", now, now, "test");
 }
 
-function insertJob(db: Database, id: string, memId: string, status: string, leasedAt?: string): void {
+function insertJob(
+	db: Database,
+	id: string,
+	memId: string,
+	status: string,
+	leasedAt?: string,
+	attempts = 0,
+	maxAttempts = 3,
+): void {
 	const now = new Date().toISOString();
 	db.prepare(
-		`INSERT INTO memory_jobs (id, memory_id, job_type, status, leased_at, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-	).run(id, memId, "extract", status, leasedAt ?? null, now, now);
+		`INSERT INTO memory_jobs
+		 (id, memory_id, job_type, status, attempts, max_attempts, leased_at, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	).run(id, memId, "extract", status, attempts, maxAttempts, leasedAt ?? null, now, now);
 }
 
 function ensureVecTable(db: Database): void {
@@ -382,11 +391,45 @@ describe("releaseStaleLeases", () => {
 		expect(result.success).toBe(true);
 		expect(result.affected).toBe(1);
 
-		const stale = db.prepare("SELECT status FROM memory_jobs WHERE id = 'job-stale'").get() as { status: string };
+		const stale = db.prepare("SELECT status, leased_at FROM memory_jobs WHERE id = 'job-stale'").get() as {
+			status: string;
+			leased_at: string | null;
+		};
 		expect(stale.status).toBe("pending");
+		expect(stale.leased_at).toBeNull();
 
 		const fresh = db.prepare("SELECT status FROM memory_jobs WHERE id = 'job-fresh'").get() as { status: string };
 		expect(fresh.status).toBe("leased");
+	});
+
+	it("dead-letters stale leases that already exhausted max attempts", () => {
+		insertMemory(db, "mem-4");
+
+		const staleAt = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+		insertJob(db, "job-exhausted", "mem-4", "leased", staleAt, 3, 3);
+
+		const cfg = { ...TEST_CFG, worker: { ...TEST_CFG.worker, leaseTimeoutMs: 5 * 60 * 1000 } };
+		const limiter = createRateLimiter();
+		const result = releaseStaleLeases(accessor, cfg, CTX_OPERATOR, limiter);
+
+		expect(result.success).toBe(true);
+		expect(result.affected).toBe(1);
+		expect(result.message).toContain("dead-lettered 1 exhausted job(s)");
+
+		const job = db
+			.prepare("SELECT status, leased_at, failed_at, error FROM memory_jobs WHERE id = 'job-exhausted'")
+			.get() as
+			| {
+					status: string;
+					leased_at: string | null;
+					failed_at: string | null;
+					error: string | null;
+			  }
+			| undefined;
+		expect(job?.status).toBe("dead");
+		expect(job?.leased_at).toBeNull();
+		expect(job?.failed_at).not.toBeNull();
+		expect(job?.error).toBe("lease expired before completion");
 	});
 });
 

--- a/packages/daemon/src/repair-actions.ts
+++ b/packages/daemon/src/repair-actions.ts
@@ -19,6 +19,7 @@ import {
 import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
 import type { PipelineV2Config } from "./memory-config";
+import { recoverStaleLeases } from "./pipeline/stale-leases";
 import { insertHistoryEvent } from "./transactions";
 
 // ---------------------------------------------------------------------------
@@ -295,25 +296,25 @@ export function releaseStaleLeases(
 
 	const cutoff = new Date(Date.now() - cfg.worker.leaseTimeoutMs).toISOString();
 
-	const affected = accessor.withWriteTx((db) => {
+	const result = accessor.withWriteTx((db) => {
 		const now = new Date().toISOString();
-		const result = db
-			.prepare(
-				`UPDATE memory_jobs
-				 SET status = 'pending', leased_at = NULL, updated_at = ?
-				 WHERE status = 'leased' AND leased_at < ?`,
-			)
-			.run(now, cutoff);
-
-		const count = countChanges(result);
-		const msg = `released ${count} stale lease(s) back to pending`;
-		writeRepairAudit(db, action, ctx, count, msg);
-		return count;
+		const recovered = recoverStaleLeases(db, { cutoff, now });
+		const msg =
+			recovered.dead > 0
+				? `released ${recovered.pending} stale lease(s) back to pending and dead-lettered ${recovered.dead} exhausted job(s)`
+				: `released ${recovered.pending} stale lease(s) back to pending`;
+		writeRepairAudit(db, action, ctx, recovered.total, msg);
+		return {
+			msg,
+			recovered,
+		};
 	});
 
 	limiter.record(action);
 	logger.info("pipeline", "repair: released stale leases", {
-		affected,
+		affected: result.recovered.total,
+		pending: result.recovered.pending,
+		dead: result.recovered.dead,
 		cutoff,
 		actor: ctx.actor,
 		reason: ctx.reason,
@@ -322,8 +323,8 @@ export function releaseStaleLeases(
 	return {
 		action,
 		success: true,
-		affected,
-		message: `released ${affected} stale lease(s) back to pending`,
+		affected: result.recovered.total,
+		message: result.msg,
 	};
 }
 
@@ -1998,12 +1999,18 @@ export function forgetDeadMemories(accessor: DbAccessor, ids: readonly string[])
 		for (const id of ids) {
 			total += countChanges(stmt.run(now, id));
 		}
-		writeRepairAudit(db, "forget-dead-memories", {
-			actor: "api",
-			reason: "dead-memory hygiene",
-			actorType: "system",
-			requestId: null,
-		}, total, `soft-deleted ${total} dead memories`);
+		writeRepairAudit(
+			db,
+			"forget-dead-memories",
+			{
+				actor: "api",
+				reason: "dead-memory hygiene",
+				actorType: "system",
+				requestId: null,
+			},
+			total,
+			`soft-deleted ${total} dead memories`,
+		);
 		return total;
 	});
 }


### PR DESCRIPTION
## Summary

Recover stale leased pipeline jobs correctly, dead-letter exhausted leases,
and stop `prospective_index` jobs from waiting on the stale-lease reaper
when provider calls fail.

## Changes

- add shared stale-lease recovery logic for `memory_jobs`
- requeue stale leases only while `attempts < max_attempts`
- dead-letter stale leases that already exhausted `max_attempts`
- clear `leased_at` during stale-lease recovery and surface pending/dead counts
- send `prospective_index` provider failures through `failJob()` immediately
- mirror the repair-route stale-lease behavior in `daemon-rs`
- document the updated `/api/repair/release-leases` behavior in `docs/API.md` and `docs/DIAGNOSTICS.md`
- add regression tests for stale lease recovery and hints-worker failure handling

## Type

- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage
- [ ] `feat` — new user-facing feature (bumps minor)

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: `packages/daemon-rs`

## Screenshots

N/A

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [ ] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [ ] Rollback / compatibility note included in PR description

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Targeted validation run for this PR:

- `bun test packages/daemon/src/pipeline/stale-leases.test.ts packages/daemon/src/pipeline/prospective-index.test.ts packages/daemon/src/repair-actions.test.ts`
- `bunx tsc --noEmit -p packages/core/tsconfig.json`

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Closes #318.

Repo-wide `bun run typecheck` is still failing on pre-existing unrelated issues,
first in `@signet/opencode-plugin`, so this PR uses the checklist exception label
instead of claiming a green full-workspace typecheck.

Checklist exception reason: full-workspace typecheck is already failing outside this PR.