### PR TITLE
feat(pipeline): add live pause controls

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -108,6 +108,7 @@ composite health score derived from diagnostics.
   "memoryDb": true,
   "pipelineV2": {
     "enabled": true,
+    "paused": false,
     "shadowMode": false,
     "mutationsFrozen": false,
     "graphEnabled": false,
@@ -2195,6 +2196,9 @@ Composite pipeline status snapshot for dashboard visualization. Returns
 worker status, job queue counts (memory and summary), diagnostics, latency
 histograms, error summary, and the current pipeline mode.
 
+Known `mode` values: `controlled-write`, `shadow`, `frozen`, `paused`,
+`disabled`.
+
 **Response**
 
 ```json
@@ -2211,7 +2215,46 @@ histograms, error summary, and the current pipeline mode.
 }
 ```
 
-Mode is one of: `disabled`, `frozen`, `shadow`, `controlled-write`.
+Mode is one of: `disabled`, `frozen`, `shadow`, `paused`, `controlled-write`.
+
+### POST /api/pipeline/pause
+
+Pause the extraction runtime in-place without restarting the daemon.
+Requires `admin` permission and uses the admin rate limit bucket.
+
+Returns `409` if another pause/resume transition is already running.
+
+**Response**
+
+```json
+{
+  "success": true,
+  "changed": true,
+  "paused": true,
+  "file": "/home/user/.agents/agent.yaml",
+  "mode": "paused"
+}
+```
+
+### POST /api/pipeline/resume
+
+Resume the extraction runtime in-place without restarting the daemon.
+Requires `admin` permission and uses the admin rate limit bucket.
+
+**Response**
+
+```json
+{
+  "success": true,
+  "changed": true,
+  "paused": false,
+  "file": "/home/user/.agents/agent.yaml",
+  "mode": "controlled-write"
+}
+```
+
+`changed` is `false` when the persisted pause flag already matches the
+requested state.
 
 
 Checkpoints

--- a/docs/research/technical/RESEARCH-PIPELINE-PAUSE-CONTROL.md
+++ b/docs/research/technical/RESEARCH-PIPELINE-PAUSE-CONTROL.md
@@ -1,0 +1,105 @@
+---
+title: "Pipeline Pause Control Research"
+question: "How should Signet let an operator temporarily stop extraction work to free local resources without dropping queued memory capture?"
+---
+
+# Pipeline Pause Control Research
+
+## Question
+
+How should Signet let an operator temporarily stop extraction work to free
+local resources without dropping queued memory capture?
+
+## Current behavior
+
+Signet already has several pipeline-adjacent switches, but none match the
+operator need cleanly:
+
+1. `memory.pipelineV2.enabled = false`
+   - fully disables pipeline enqueue/start behavior
+   - reduces work, but new memories stop entering the extraction queue
+   - not a good fit for "pause now, catch up later"
+
+2. `memory.pipelineV2.shadowMode = true`
+   - still runs extraction and decision stages
+   - preserves observability, but does not reduce model/runtime pressure
+
+3. `memory.pipelineV2.mutationsFrozen = true`
+   - blocks writes and destructive actions
+   - extraction still runs, so local compute and provider pressure remain
+
+The missing mode is operational pause:
+
+- keep raw memory capture working
+- allow pending jobs to accumulate safely
+- stop worker activity so the machine gets relief
+- resume later and drain backlog with existing pipeline behavior
+
+## Constraints from the current codebase
+
+### Daemon startup
+
+`packages/daemon/src/daemon.ts` decides whether to start the extraction
+pipeline at startup. If the pipeline does not start, Signet already falls
+back to retention-only background work.
+
+### Enqueue behavior
+
+Remember/session-end paths check `pipelineV2.enabled` before enqueueing
+jobs. That means a pause mechanism must remain distinct from `enabled`
+if we want backlog preservation.
+
+### Worker lifecycle
+
+`packages/daemon/src/pipeline/index.ts` already exposes a clean
+`startPipeline()` / `stopPipeline()` split. This is a strong fit for a
+paused state because the worker graph is already centralized.
+
+## Recommended design
+
+Add a dedicated persisted flag:
+
+```yaml
+memory:
+  pipelineV2:
+    paused: true
+```
+
+Semantics:
+
+1. `enabled = true`, `paused = false`
+   - normal operation
+
+2. `enabled = true`, `paused = true`
+   - keep enqueue behavior
+   - do not start extraction workers
+   - surface pipeline mode as `paused`
+
+3. `enabled = false`
+   - fully disabled, regardless of paused flag
+
+This gives users a real "pause/resume" control instead of overloading
+`enabled` or `mutationsFrozen`.
+
+## Recommendation for CLI behavior
+
+Expose operator-first commands:
+
+- `signet daemon pause`
+- `signet daemon resume`
+
+The CLI should:
+
+1. persist the `paused` flag in the active config file
+2. restart the daemon so the running process picks up the new state
+3. report whether queued work will resume later
+
+Restart-on-toggle is acceptable for the first implementation because the
+current daemon does not hot-reload pipeline runtime state from `agent.yaml`.
+
+## Non-goals
+
+- no scheduler or timed auto-resume
+- no per-worker selective pause
+- no change to memory retention semantics
+- no dropping or reclassifying existing queued jobs

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -630,6 +630,7 @@ Legend:
 | `predictive-memory-scorer` | approved | `docs/specs/approved/predictive-memory-scorer.md` | `memory-pipeline-v2`, `knowledge-architecture-schema`, `session-continuity-protocol` | - | |
 | `multi-agent-support` | approved | `docs/specs/approved/multi-agent-support.md` | `memory-pipeline-v2` | - | |
 | `signet-runtime` | approved | `docs/specs/approved/signet-runtime.md` | `memory-pipeline-v2` | - | |
+| `pipeline-pause-control` | complete | `docs/specs/complete/pipeline-pause-control.md` | `memory-pipeline-v2` | - | CLI and dashboard pause/resume shipped on top of live daemon pause/resume API, paused-mode observability, and local Ollama unload |
 | `daemon-refactor` | planning | `docs/specs/planning/daemon-refactor.md` | - | `daemon-refactor-plan` | |
 | `daemon-refactor-plan` | planning | `docs/specs/planning/daemon-refactor-plan.md` | `daemon-refactor` | - | |
 | `daemon-rust-rewrite` | planning | `docs/specs/planning/daemon-rust-rewrite.md` | `memory-pipeline-v2` | - | deferred — complexity cost exceeds current benefit |
@@ -698,6 +699,11 @@ search alone.
 **predictive-memory-scorer**: Session-start context relevance
 improves over time without manual curation. NDCG@10 on continuity
 scores is the quantitative metric.
+
+**pipeline-pause-control**: Operators can pause extraction work from
+the CLI or dashboard to free resources without dropping future backlog
+processing, then resume normal draining later, with live daemon
+control when available.
 
 **desire-paths-epic**: Graph traversal discovers relevant memories
 that embedding search alone misses. Path feedback propagates learning

--- a/docs/specs/complete/pipeline-pause-control.md
+++ b/docs/specs/complete/pipeline-pause-control.md
@@ -1,0 +1,135 @@
+---
+title: "Pipeline Pause Control"
+informed_by:
+  - docs/research/technical/RESEARCH-PIPELINE-PAUSE-CONTROL.md
+success_criteria:
+  - "Operators can pause extraction work from the CLI or dashboard without losing later backlog processing"
+  - "While paused, new memories still persist and queue for later extraction instead of being dropped"
+  - "Resuming restores normal worker startup and backlog draining with no schema migration"
+scope_boundary: "Temporary operator control for background pipeline activity only; does not add schedules, per-stage pausing, or new memory semantics"
+---
+
+# Pipeline Pause Control
+
+Status: Complete (v2)
+
+Spec metadata:
+- ID: `pipeline-pause-control`
+- Status: `complete`
+- Hard depends on: `memory-pipeline-v2`
+- Registry: `docs/specs/INDEX.md`
+
+Related docs:
+- `docs/research/technical/RESEARCH-PIPELINE-PAUSE-CONTROL.md`
+- `packages/cli/src/commands/daemon.ts`
+- `packages/cli/src/features/daemon.ts`
+- `packages/daemon/src/daemon.ts`
+- `packages/daemon/src/pipeline/index.ts`
+- `packages/daemon/src/memory-config.ts`
+- `packages/cli/src/features/pipeline-pause.ts`
+- `packages/cli/src/features/pipeline-pause.test.ts`
+- `packages/cli/dashboard/src/lib/api.ts`
+- `packages/cli/dashboard/src/lib/api.pipeline.test.js`
+- `packages/cli/dashboard/src/lib/components/tabs/PipelineTab.svelte`
+
+## 1) Problem
+
+Users sometimes need Signet to get out of the way for a while. Today the
+available switches are too blunt:
+
+- `enabled = false` stops future enqueueing
+- `shadowMode = true` still burns extraction resources
+- `mutationsFrozen = true` still runs extraction
+
+There is no operator control for "stop the workers now, keep the daemon
+alive, and let queued extraction catch up later."
+
+## 2) Goals
+
+1. Add a first-class paused state for the extraction pipeline.
+2. Expose it as an obvious CLI and dashboard operator control.
+3. Preserve queued work while paused.
+4. Surface paused status in daemon observability.
+
+## 3) Delivered capability set
+
+### A) Persisted config flag
+
+Signet now persists `memory.pipelineV2.paused: boolean`, default `false`.
+
+### B) Startup behavior
+
+When `enabled = true` and `paused = true`:
+
+- do not start extraction workers
+- do not start synthesis, predictor, embedding-tracker, structural backfill,
+  or procedural reconciler background work
+- do keep retention-only startup behavior
+- do report pipeline mode as `paused`
+
+### C) CLI control
+
+Add:
+
+- `signet daemon pause`
+- `signet daemon resume`
+- root aliases `signet pause` and `signet resume`
+
+The shipped implementation now prefers live daemon pause/resume endpoints so
+runtime state flips in-place without a daemon restart when the API is
+available. The CLI still falls back to the original config-write + restart path
+for older daemons or auth-protected setups it cannot control directly, and on
+pause still attempts to unload local Ollama models so VRAM is released
+promptly.
+
+### D) Dashboard control
+
+The pipeline tab now exposes a pause/resume control that calls the live daemon
+API directly, disables itself while a transition is in flight, and refreshes
+status after each successful mutation.
+
+### E) Backlog contract
+
+Pause is not disable. New memories still enqueue extraction work while the
+pipeline is paused, then drain after resume.
+
+## 4) Non-goals
+
+- no cron-based pause windows
+- no per-agent partial pause
+- no predictor-specific tuning work beyond what naturally follows from
+  extraction workers being offline
+- no remote-provider lifecycle control beyond local loopback Ollama unload
+
+## 5) Integration contracts
+
+**Pause <-> Memory Pipeline v2**
+- `paused` is orthogonal to `enabled`
+- `enabled=false` still wins and means fully disabled
+
+**Pause <-> CLI**
+- CLI prefers live daemon pause/resume when available
+- CLI falls back to persisted flag write + daemon restart when live control is
+  unavailable
+- CLI reports whether local Ollama model unload succeeded
+
+**Pause <-> Dashboard**
+- the pipeline tab uses the live daemon pause/resume endpoints directly
+- the control must guard against duplicate clicks while a transition is active
+- successful mutations trigger a fresh status poll so the badge reflects the
+  new mode immediately
+
+**Pause <-> Observability**
+- `/api/pipeline/status` reports `mode = "paused"` when applicable
+- `/api/pipeline/pause` and `/api/pipeline/resume` expose live operator control
+  with structured mutation responses
+
+## 6) Validation and tests
+
+- Config parsing preserves explicit `paused: true`
+- CLI toggle writes `memory.pipelineV2.paused`
+- Pause unloads local loopback Ollama models through the generate API with
+  `keep_alive: 0`
+- Paused mode reports correctly in status/observability
+- Resume clears the flag and restores normal startup path
+- Dashboard pause/resume helpers surface structured success and error results

--- a/docs/specs/dependencies.yaml
+++ b/docs/specs/dependencies.yaml
@@ -1,5 +1,5 @@
 version: 3
-updated_at: "2026-03-24"
+updated_at: "2026-03-25"
 
 specs:
   - id: memory-pipeline-v2
@@ -106,6 +106,21 @@ specs:
     informed_by: []
     success_criteria:
       - "Signet operates as a standalone runtime channel independent of harness-specific connectors"
+    decision: null
+
+  - id: pipeline-pause-control
+    status: complete
+    path: docs/specs/complete/pipeline-pause-control.md
+    hard_depends_on:
+      - memory-pipeline-v2
+    soft_depends_on: []
+    blocks: []
+    informed_by:
+      - docs/research/technical/RESEARCH-PIPELINE-PAUSE-CONTROL.md
+    success_criteria:
+      - "Operators can pause extraction work from the CLI or dashboard without losing later backlog processing"
+      - "While paused, new memories still persist and queue for later extraction instead of being dropped"
+      - "Resuming restores normal worker startup and backlog draining with no schema migration"
     decision: null
 
   - id: daemon-refactor

--- a/packages/cli/dashboard/src/lib/api.pipeline.test.js
+++ b/packages/cli/dashboard/src/lib/api.pipeline.test.js
@@ -1,0 +1,69 @@
+// @ts-nocheck
+import { afterEach, describe, expect, it } from "bun:test";
+import { pausePipeline, resumePipeline } from "./api";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+describe("pipeline pause api helpers", () => {
+	it("returns structured pause success data", async () => {
+		globalThis.fetch = async (input, init) => {
+			expect(String(input).endsWith("/api/pipeline/pause")).toBe(true);
+			expect(init?.method).toBe("POST");
+			return new Response(
+				JSON.stringify({
+					success: true,
+					changed: true,
+					paused: true,
+					file: "/tmp/agent.yaml",
+					mode: "paused",
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		};
+
+		const res = await pausePipeline();
+
+		expect(res).toEqual({
+			success: true,
+			changed: true,
+			paused: true,
+			file: "/tmp/agent.yaml",
+			mode: "paused",
+		});
+	});
+
+	it("returns daemon resume errors without throwing", async () => {
+		globalThis.fetch = async (input, init) => {
+			expect(String(input).endsWith("/api/pipeline/resume")).toBe(true);
+			expect(init?.method).toBe("POST");
+			return new Response(
+				JSON.stringify({ error: "Pipeline transition already in progress" }),
+				{ status: 409, headers: { "Content-Type": "application/json" } },
+			);
+		};
+
+		const res = await resumePipeline();
+
+		expect(res).toEqual({
+			success: false,
+			error: "Pipeline transition already in progress",
+		});
+	});
+
+	it("falls back to thrown fetch errors", async () => {
+		globalThis.fetch = async () => {
+			throw new Error("offline");
+		};
+
+		const res = await pausePipeline();
+
+		expect(res).toEqual({
+			success: false,
+			error: "Error: offline",
+		});
+	});
+});

--- a/packages/cli/dashboard/src/lib/api.ts
+++ b/packages/cli/dashboard/src/lib/api.ts
@@ -1863,6 +1863,56 @@ export interface PipelineStatus {
 	};
 }
 
+export interface PipelinePauseResult {
+	success: boolean;
+	changed?: boolean;
+	paused?: boolean;
+	file?: string;
+	mode?: string;
+	error?: string;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function readPipelinePauseResult(
+	body: unknown,
+	fallback: string,
+): PipelinePauseResult {
+	if (!isObject(body)) return { success: false, error: fallback };
+	if (body.success !== true) {
+		return {
+			success: false,
+			error: typeof body.error === "string" ? body.error : fallback,
+		};
+	}
+
+	return {
+		success: true,
+		changed: typeof body.changed === "boolean" ? body.changed : undefined,
+		paused: typeof body.paused === "boolean" ? body.paused : undefined,
+		file: typeof body.file === "string" ? body.file : undefined,
+		mode: typeof body.mode === "string" ? body.mode : undefined,
+	};
+}
+
+async function updatePipelineMode(
+	mode: "pause" | "resume",
+): Promise<PipelinePauseResult> {
+	try {
+		const res = await fetch(`${API_BASE}/api/pipeline/${mode}`, {
+			method: "POST",
+		});
+		const body = await res.json().catch(() => null);
+		const fallback = `Request failed (${res.status})`;
+		if (!res.ok) return readPipelinePauseResult(body, fallback);
+		return readPipelinePauseResult(body, "Malformed pipeline response");
+	} catch (e) {
+		return { success: false, error: String(e) };
+	}
+}
+
 export async function getPipelineStatus(): Promise<PipelineStatus | null> {
 	try {
 		const res = await fetch(`${API_BASE}/api/pipeline/status`);
@@ -1871,6 +1921,14 @@ export async function getPipelineStatus(): Promise<PipelineStatus | null> {
 	} catch {
 		return null;
 	}
+}
+
+export async function pausePipeline(): Promise<PipelinePauseResult> {
+	return updatePipelineMode("pause");
+}
+
+export async function resumePipeline(): Promise<PipelinePauseResult> {
+	return updatePipelineMode("resume");
 }
 
 export interface KnowledgeEntityListItem {

--- a/packages/cli/dashboard/src/lib/components/home/AgentHeader.svelte
+++ b/packages/cli/dashboard/src/lib/components/home/AgentHeader.svelte
@@ -97,8 +97,9 @@
 
 	const pipelineMode = $derived.by(() => {
 		if (!pipelineStatus) return "UNKNOWN";
-		const mode = (pipelineStatus as Record<string, unknown>).mode;
-		if (typeof mode === "string") return mode.toUpperCase();
+		if (typeof pipelineStatus.mode === "string") {
+			return pipelineStatus.mode.toUpperCase();
+		}
 		return "ACTIVE";
 	});
 

--- a/packages/cli/dashboard/src/lib/components/home/SystemInfoCard.svelte
+++ b/packages/cli/dashboard/src/lib/components/home/SystemInfoCard.svelte
@@ -42,8 +42,7 @@
 
 	const pipelineMode = $derived.by(() => {
 		if (!pipelineStatus) return "unknown";
-		const mode = (pipelineStatus as Record<string, unknown>).mode;
-		if (typeof mode === "string") return mode;
+		if (typeof pipelineStatus.mode === "string") return pipelineStatus.mode;
 		return "active";
 	});
 

--- a/packages/cli/dashboard/src/lib/components/pipeline/pipeline-store.svelte.ts
+++ b/packages/cli/dashboard/src/lib/components/pipeline/pipeline-store.svelte.ts
@@ -186,10 +186,10 @@ function applyQueueCounts(
 	}
 }
 
-export async function pollStatus(): Promise<void> {
+export async function pollStatus(): Promise<boolean> {
 	try {
 		const status = await getPipelineStatus();
-		if (!status) return;
+		if (!status) return false;
 
 		pipeline.mode = status.mode;
 		pipeline.lastPoll = new Date().toISOString();
@@ -235,15 +235,18 @@ export async function pollStatus(): Promise<void> {
 				}
 			}
 		}
+		return true;
 	} catch {
-		// silently ignore poll failures
+		return false;
 	}
 }
 
 export function startPolling(intervalMs = 5000): void {
 	if (pollInterval) return;
-	pollStatus();
-	pollInterval = setInterval(pollStatus, intervalMs);
+	void pollStatus();
+	pollInterval = setInterval(() => {
+		void pollStatus();
+	}, intervalMs);
 }
 
 export function stopPolling(): void {

--- a/packages/cli/dashboard/src/lib/components/sessions/SessionList.svelte
+++ b/packages/cli/dashboard/src/lib/components/sessions/SessionList.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { Badge } from "$lib/components/ui/badge/index.js";
-import * as Switch from "$lib/components/ui/switch/index.js";
+import { Switch } from "$lib/components/ui/switch/index.js";
 import { fetchSessions, toggleSessionBypass, type SessionInfo } from "$lib/api";
 import { toast } from "$lib/stores/toast.svelte";
 
@@ -90,14 +90,12 @@ $effect(() => {
 						<span class="sig-meta" class:text-[var(--sig-text-muted)]={!session.bypassed} class:text-[var(--sig-accent)]={session.bypassed}>
 							{session.bypassed ? "bypassed" : "active"}
 						</span>
-						<Switch.Root
+						<Switch
 							checked={session.bypassed}
 							disabled={pending.has(session.key)}
 							onCheckedChange={(checked: boolean) => handleToggle(session, checked)}
-							aria-label="Bypass session {session.key}"
-						>
-							<Switch.Thumb />
-						</Switch.Root>
+							aria-label={`Bypass session ${session.key}`}
+						/>
 					</div>
 				</div>
 			{/each}

--- a/packages/cli/dashboard/src/lib/components/tabs/KnowledgeTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/KnowledgeTab.svelte
@@ -426,51 +426,52 @@ onMount(() => {
 									Select an entity to inspect its structure.
 								</div>
 							{:else}
+								{@const entity = entityDetail.entity}
 								<div class="space-y-4">
 									<div class="space-y-2 border-b border-[var(--sig-border)] pb-3">
 										<div class="flex items-start justify-between gap-3">
 											<div>
 												<div class="flex items-center gap-2">
-													<span class={`size-2 rounded-full ${healthToneClass(entityDetail.entity.id)}`}></span>
+													<span class={`size-2 rounded-full ${healthToneClass(entity.id)}`}></span>
 													<h3 class="sig-heading text-[14px] uppercase tracking-[0.08em]">
-														{entityDetail.entity.name}
+														{entity.name}
 													</h3>
-													{#if entityDetail.entity.pinned}
+													{#if entity.pinned}
 														<Badge variant="outline" class={metricClass("accent")}>
 															pinned
 														</Badge>
 													{/if}
 												</div>
 												<p class="sig-label text-[var(--sig-text-muted)]">
-													{entityDetail.entity.canonicalName ?? entityDetail.entity.name}
+													{entity.canonicalName ?? entity.name}
 												</p>
 											</div>
 											<div class="flex items-center gap-2">
 												<Badge variant="outline" class={metricClass("accent")}>
-													{entityDetail.entity.entityType}
+													{entity.entityType}
 												</Badge>
 												<Button
 													variant="outline"
 													size="sm"
 													class="h-8 px-2"
-													disabled={pinBusyEntityId === entityDetail.entity.id}
+													disabled={pinBusyEntityId === entity.id}
 													onclick={() =>
 														void togglePin(
-															entityDetail.entity.id,
-															entityDetail.entity.pinned ?? false,
+															entity.id,
+															entity.pinned ?? false,
 														)}
 												>
 													<Pin class="mr-1 size-3.5" />
-													{entityDetail.entity.pinned ? "Unpin" : "Pin"}
+													{entity.pinned ? "Unpin" : "Pin"}
 												</Button>
 											</div>
 										</div>
 										<div class="flex flex-wrap gap-1.5">
 											<Badge variant="outline" class={metricClass()}>
-												mentions {entityDetail.entity.mentions ?? 0}
+												mentions {entity.mentions ?? 0}
 											</Badge>
 											<Badge variant="outline" class={metricClass()}>
-												in {formatDate(entityDetail.entity.updatedAt)}
+												in {formatDate(entity.updatedAt)}
 											</Badge>
 										</div>
 									</div>

--- a/packages/cli/dashboard/src/lib/components/tabs/PipelineTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/PipelineTab.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from "svelte";
+	import { pausePipeline, resumePipeline } from "$lib/api";
 	import { Badge } from "$lib/components/ui/badge/index.js";
 	import { Button } from "$lib/components/ui/button/index.js";
 	import * as Switch from "$lib/components/ui/switch/index.js";
@@ -11,6 +12,7 @@
 		pipeline,
 		connectSSE,
 		disconnectSSE,
+		pollStatus,
 		startPolling,
 		stopPolling,
 		selectNode,
@@ -22,12 +24,13 @@
 	import { ENGINE_TAB_ITEMS } from "$lib/components/layout/page-headers";
 	import { nav } from "$lib/stores/navigation.svelte";
 	import { focusEngineTab } from "$lib/stores/tab-group-focus.svelte";
-
-
+	import { toast } from "$lib/stores/toast.svelte";
 
 	function handleSelectNode(id: string) {
 		selectNode(pipeline.selectedNodeId === id ? null : id);
 	}
+
+	let op = $state<"pause" | "resume" | null>(null);
 
 	let feedViewport: HTMLElement | null = $state(null);
 	let autoScroll = $state(true);
@@ -116,6 +119,40 @@
 		mobileFeedActionsOpen = false;
 	}
 
+	async function handleModeToggle(): Promise<void> {
+		if (op) return;
+		if (pipeline.mode === "disabled") {
+			toast("Pipeline is disabled in config", "warning");
+			return;
+		}
+
+		const next = pipeline.mode === "paused" ? "resume" : "pause";
+		op = next;
+
+		try {
+			const res = next === "pause" ? await pausePipeline() : await resumePipeline();
+			if (!res.success) {
+				toast(res.error ?? `Failed to ${next} pipeline`, "error");
+				return;
+			}
+
+			if (res.mode) {
+				pipeline.mode = res.mode;
+				pipeline.lastPoll = new Date().toISOString();
+			}
+			await pollStatus();
+
+			if (res.changed === false) {
+				toast(next === "pause" ? "Pipeline already paused" : "Pipeline already running");
+				return;
+			}
+
+			toast(next === "pause" ? "Pipeline paused" : "Pipeline resumed", "success");
+		} finally {
+			op = null;
+		}
+	}
+
 	function getEntryDataKeySummary(data?: Record<string, unknown>): string {
 		if (!data) return "";
 		const keys = Object.keys(data);
@@ -155,6 +192,7 @@
 		"controlled-write": "border-[#4ade80] text-[#4ade80]",
 		shadow: "border-[#fbbf24] text-[#fbbf24]",
 		frozen: "border-[#94a3b8] text-[#94a3b8]",
+		paused: "border-[#60a5fa] text-[#60a5fa]",
 		disabled: "border-[#f87171] text-[#f87171]",
 		unknown: "border-[var(--sig-border)] text-[var(--sig-text-muted)]",
 	};
@@ -382,6 +420,29 @@
 				<span class="sig-meta">
 					polled {formatTime(pipeline.lastPoll)}
 				</span>
+			{/if}
+			{#if pipeline.mode === "disabled"}
+				<span class="sig-meta text-[var(--sig-text-muted)]">
+					pipeline disabled in config
+				</span>
+			{:else}
+				<Button
+					variant="outline"
+					size="sm"
+					class="sig-meta uppercase tracking-[0.08em] px-2.5 py-[5px] h-auto hover:text-[var(--sig-text)] hover:border-[var(--sig-border-strong)]"
+					disabled={op !== null}
+					onclick={handleModeToggle}
+				>
+					{#if op === "pause"}
+						Pausing...
+					{:else if op === "resume"}
+						Resuming...
+					{:else if pipeline.mode === "paused"}
+						Resume
+					{:else}
+						Pause
+					{/if}
+				</Button>
 			{/if}
 		</div>
 	</div>

--- a/packages/cli/dashboard/src/lib/components/tabs/PipelineTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/PipelineTab.svelte
@@ -140,10 +140,18 @@
 				pipeline.mode = res.mode;
 				pipeline.lastPoll = new Date().toISOString();
 			}
-			await pollStatus();
+			const refreshed = await pollStatus();
 
 			if (res.changed === false) {
 				toast(next === "pause" ? "Pipeline already paused" : "Pipeline already running");
+				return;
+			}
+
+			if (!refreshed) {
+				toast(
+					`${next === "pause" ? "Pipeline paused" : "Pipeline resumed"}, but live status refresh failed`,
+					"warning",
+				);
 				return;
 			}
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -97,24 +97,7 @@ import {
 	startDaemon,
 	stopDaemon,
 } from "./lib/runtime.js";
-import {
-	type CondaInfo,
-	type PyenvInfo,
-	type PythonInfo,
-	checkZvecInstalled,
-	createCondaEnv,
-	createVenv,
-	detectBestPython,
-	detectConda,
-	detectPyenv,
-	detectSystemPython,
-	getCondaPython,
-	getPyenvPython,
-	installDeps,
-	installPyenvPython,
-	isZvecCompatible,
-} from "./python.js";
-import Database from "./sqlite.js";
+import "./sqlite.js";
 
 // Template directory location (relative to built CLI)
 function getTemplatesDir() {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,8 +4,8 @@
  * Own your agent. Bring it anywhere.
  */
 
-import { spawnSync } from "child_process";
-import { createHash } from "crypto";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
 	chmodSync,
 	closeSync,
@@ -22,10 +22,10 @@ import {
 	statSync,
 	symlinkSync,
 	writeFileSync,
-} from "fs";
-import { homedir, tmpdir } from "os";
-import { dirname, join, resolve as resolvePath } from "path";
-import { fileURLToPath } from "url";
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
 import { ClaudeCodeConnector } from "@signet/connector-claude-code";
 import { CodexConnector } from "@signet/connector-codex";
 import { OpenClawConnector } from "@signet/connector-openclaw";
@@ -40,21 +40,63 @@ import {
 	detectExistingSetup as detectExistingSetupCore,
 	formatYaml,
 	getGlobalInstallCommand,
-	resolveGlobalPackagePath,
 	getMissingIdentityFiles,
 	getSkillsRunnerCommand,
 	hasValidIdentity,
 	importMemoryLogs,
 	loadSqliteVec,
 	parseSimpleYaml,
+	readStaticIdentity,
+	resolveGlobalPackagePath,
 	resolvePrimaryPackageManager,
 	symlinkSkills,
-	readStaticIdentity,
 	unifySkills,
 } from "@signet/core";
 import chalk from "chalk";
 import { Command } from "commander";
 import ora from "ora";
+import { registerBrowseCommand } from "./browse.js";
+import { registerAgentCommands } from "./commands/agent.js";
+import { registerAppCommands } from "./commands/app.js";
+import { registerDaemonCommands } from "./commands/daemon.js";
+import { registerGitCommands } from "./commands/git.js";
+import { registerHookCommands } from "./commands/hook.js";
+import { registerMemoryCommands } from "./commands/memory.js";
+import { registerPortableCommands } from "./commands/portable.js";
+import { registerSecretCommands } from "./commands/secret.js";
+import { registerSessionCommands } from "./commands/session.js";
+import { registerSkillCommands } from "./commands/skill.js";
+import { registerUpdateCommands } from "./commands/update.js";
+import { registerVectorCommands } from "./commands/vector.js";
+import { registerWorkspaceCommands } from "./commands/workspace.js";
+import { configureAgent } from "./features/configure.js";
+import {
+	doPause,
+	doRestart,
+	doResume,
+	doStart,
+	doStop,
+	launchDashboard,
+	migrateSchema,
+	showLogs,
+} from "./features/daemon.js";
+import { getStatusReport, showDoctor, showStatus } from "./features/health.js";
+import { importFromGitHub } from "./features/import.js";
+import { setupWizard } from "./features/setup.js";
+import { syncTemplates } from "./features/sync.js";
+import { createDaemonClient, ensureDaemonRunning } from "./lib/daemon.js";
+import { gitAddAndCommit, gitInit, isGitRepo } from "./lib/git.js";
+import {
+	AGENTS_DIR,
+	DEFAULT_PORT,
+	formatUptime,
+	getDaemonStatus,
+	getReachableDaemonUrls,
+	isDaemonRunning,
+	sleep,
+	startDaemon,
+	stopDaemon,
+} from "./lib/runtime.js";
 import {
 	type CondaInfo,
 	type PyenvInfo,
@@ -73,39 +115,6 @@ import {
 	isZvecCompatible,
 } from "./python.js";
 import Database from "./sqlite.js";
-import { registerBrowseCommand } from "./browse.js";
-import { registerAgentCommands } from "./commands/agent.js";
-import { registerAppCommands } from "./commands/app.js";
-import { registerDaemonCommands } from "./commands/daemon.js";
-import { registerGitCommands } from "./commands/git.js";
-import { registerHookCommands } from "./commands/hook.js";
-import { registerMemoryCommands } from "./commands/memory.js";
-import { registerPortableCommands } from "./commands/portable.js";
-import { registerSecretCommands } from "./commands/secret.js";
-import { registerSessionCommands } from "./commands/session.js";
-import { registerSkillCommands } from "./commands/skill.js";
-import { registerUpdateCommands } from "./commands/update.js";
-import { registerVectorCommands } from "./commands/vector.js";
-import { registerWorkspaceCommands } from "./commands/workspace.js";
-import { configureAgent } from "./features/configure.js";
-import { doRestart, doStart, doStop, launchDashboard, migrateSchema, showLogs } from "./features/daemon.js";
-import { getStatusReport, showDoctor, showStatus } from "./features/health.js";
-import { importFromGitHub } from "./features/import.js";
-import { setupWizard } from "./features/setup.js";
-import { syncTemplates } from "./features/sync.js";
-import { createDaemonClient, ensureDaemonRunning } from "./lib/daemon.js";
-import { gitAddAndCommit, gitInit, isGitRepo } from "./lib/git.js";
-import {
-	AGENTS_DIR,
-	DEFAULT_PORT,
-	formatUptime,
-	getDaemonStatus,
-	getReachableDaemonUrls,
-	isDaemonRunning,
-	sleep,
-	startDaemon,
-	stopDaemon,
-} from "./lib/runtime.js";
 
 // Template directory location (relative to built CLI)
 function getTemplatesDir() {
@@ -1181,7 +1190,7 @@ program.hook("preAction", async (_thisCommand, actionCommand) => {
 	let current: Command | null = actionCommand;
 	let topLevelCommand = "";
 
-	while (current && current.parent) {
+	while (current?.parent) {
 		if (current.parent.name() === "signet") {
 			topLevelCommand = current.name();
 			break;
@@ -1283,7 +1292,9 @@ registerAppCommands(program, {
 });
 
 registerDaemonCommands(program, {
+	doPause: (options) => doPause(options, daemonDeps),
 	doRestart: (options) => doRestart(options, daemonDeps),
+	doResume: (options) => doResume(options, daemonDeps),
 	doStart: (options) => doStart(options, daemonDeps),
 	doStop: (options) => doStop(options, daemonDeps),
 	showLogs: (options) => showLogs(options, daemonDeps),

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -10,7 +10,9 @@ import {
 } from "./shared.js";
 
 interface DaemonDeps {
+	readonly doPause: (options?: PathOptions) => Promise<void>;
 	readonly doRestart: (options?: RestartOptions) => Promise<void>;
+	readonly doResume: (options?: PathOptions) => Promise<void>;
 	readonly doStart: (options?: PathOptions) => Promise<void>;
 	readonly doStop: (options?: PathOptions) => Promise<void>;
 	readonly showLogs: (options: LogOptions) => Promise<void>;
@@ -32,6 +34,18 @@ export function registerDaemonCommands(program: Command, deps: DaemonDeps): void
 		.option("--no-openclaw", "Skip OpenClaw restart prompt")
 		.action(deps.doRestart);
 	withPath(restart);
+
+	const pause = daemonCmd
+		.command("pause")
+		.description("Pause extraction workers and free local pipeline resources")
+		.action(deps.doPause);
+	withPath(pause);
+
+	const resume = daemonCmd
+		.command("resume")
+		.description("Resume extraction workers after a pause")
+		.action(deps.doResume);
+	withPath(resume);
 
 	const status = daemonCmd.command("status").description("Show daemon status").action(deps.showStatus);
 	withJson(withPath(status));
@@ -57,6 +71,18 @@ export function registerDaemonCommands(program: Command, deps: DaemonDeps): void
 		.option("--no-openclaw", "Skip OpenClaw restart prompt")
 		.action(deps.doRestart);
 	withPath(restartAlias);
+
+	const pauseAlias = program
+		.command("pause")
+		.description("Pause extraction workers (alias for: signet daemon pause)")
+		.action(deps.doPause);
+	withPath(pauseAlias);
+
+	const resumeAlias = program
+		.command("resume")
+		.description("Resume extraction workers (alias for: signet daemon resume)")
+		.action(deps.doResume);
+	withPath(resumeAlias);
 
 	const logsAlias = program
 		.command("logs")

--- a/packages/cli/src/features/daemon.test.ts
+++ b/packages/cli/src/features/daemon.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { requestPipelinePauseApi } from "./daemon.js";
+import { requestPipelinePauseApi, summarizePipelineToggle } from "./daemon.js";
 
 describe("requestPipelinePauseApi", () => {
 	it("uses the live daemon pause endpoint when available", async () => {
@@ -47,5 +47,14 @@ describe("requestPipelinePauseApi", () => {
 				});
 			}),
 		).rejects.toThrow("Pipeline transition already in progress");
+	});
+});
+
+describe("summarizePipelineToggle", () => {
+	it("reports resume as still disabled when the pause flag clears under disabled mode", () => {
+		expect(summarizePipelineToggle(false, "disabled", true)).toEqual({
+			title: "Pipeline pause cleared, still disabled",
+			detail: "  Pause flag cleared, but the pipeline is still disabled in config. Enable it before extraction can run.",
+		});
 	});
 });

--- a/packages/cli/src/features/daemon.test.ts
+++ b/packages/cli/src/features/daemon.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import { requestPipelinePauseApi } from "./daemon.js";
+
+describe("requestPipelinePauseApi", () => {
+	it("uses the live daemon pause endpoint when available", async () => {
+		const result = await requestPipelinePauseApi(3850, true, async (input, init) => {
+			expect(String(input)).toBe("http://localhost:3850/api/pipeline/pause");
+			expect(init?.method).toBe("POST");
+			return new Response(
+				JSON.stringify({
+					success: true,
+					changed: true,
+					paused: true,
+					file: "/tmp/agent.yaml",
+					mode: "paused",
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		});
+
+		expect(result).toEqual({
+			kind: "ok",
+			data: {
+				success: true,
+				changed: true,
+				paused: true,
+				file: "/tmp/agent.yaml",
+				mode: "paused",
+			},
+		});
+	});
+
+	it("falls back when the live endpoint is unavailable", async () => {
+		const result = await requestPipelinePauseApi(3850, false, async () => {
+			return new Response("{}", { status: 404, headers: { "Content-Type": "application/json" } });
+		});
+
+		expect(result).toEqual({ kind: "fallback" });
+	});
+
+	it("surfaces daemon API errors instead of silently falling back", async () => {
+		await expect(
+			requestPipelinePauseApi(3850, true, async () => {
+				return new Response(JSON.stringify({ error: "Pipeline transition already in progress" }), {
+					status: 409,
+					headers: { "Content-Type": "application/json" },
+				});
+			}),
+		).rejects.toThrow("Pipeline transition already in progress");
+	});
+});

--- a/packages/cli/src/features/daemon.ts
+++ b/packages/cli/src/features/daemon.ts
@@ -10,6 +10,7 @@ import ora from "ora";
 import type { LogOptions, PathOptions, RestartOptions } from "../commands/shared.js";
 import { daemonAccessLines } from "../lib/network.js";
 import Database from "../sqlite.js";
+import { readPipelinePauseState, releaseOllamaModels, setPipelinePaused } from "./pipeline-pause.js";
 
 interface DaemonStatus {
 	readonly running: boolean;
@@ -265,8 +266,222 @@ export async function doRestart(options: RestartOptions, deps: Deps): Promise<vo
 	}
 }
 
+export async function doPause(options: PathOptions, deps: Deps): Promise<void> {
+	await togglePipelinePause(options, deps, true);
+}
+
+export async function doResume(options: PathOptions, deps: Deps): Promise<void> {
+	await togglePipelinePause(options, deps, false);
+}
+
 function readPath(options: PathOptions, deps: Deps): string {
 	return deps.normalizeAgentPath(deps.extractPathOption(options) ?? deps.agentsDir);
+}
+
+interface PipelinePauseApiResponse {
+	readonly changed: boolean;
+	readonly file: string | null;
+	readonly mode: string;
+	readonly paused: boolean;
+	readonly success: boolean;
+}
+
+type PipelinePauseApiResult =
+	| {
+			readonly kind: "fallback";
+	  }
+	| {
+			readonly data: PipelinePauseApiResponse;
+			readonly kind: "ok";
+	  };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readPipelinePauseApiResponse(value: unknown): PipelinePauseApiResponse | null {
+	if (!isRecord(value)) return null;
+	if (value.success !== true) return null;
+	if (typeof value.changed !== "boolean") return null;
+	if (typeof value.paused !== "boolean") return null;
+	if (value.file !== null && typeof value.file !== "string") return null;
+	if (typeof value.mode !== "string") return null;
+	return {
+		changed: value.changed,
+		file: value.file,
+		mode: value.mode,
+		paused: value.paused,
+		success: true,
+	};
+}
+
+function readApiError(value: unknown, fallback: string): string {
+	if (!isRecord(value)) return fallback;
+	return typeof value.error === "string" && value.error.length > 0 ? value.error : fallback;
+}
+
+export async function requestPipelinePauseApi(
+	port: number,
+	paused: boolean,
+	doFetch: typeof fetch = fetch,
+): Promise<PipelinePauseApiResult> {
+	let res: Response;
+	try {
+		res = await doFetch(`http://localhost:${port}/api/pipeline/${paused ? "pause" : "resume"}`, {
+			method: "POST",
+		});
+	} catch {
+		return { kind: "fallback" };
+	}
+
+	if (res.status === 401 || res.status === 403 || res.status === 404) {
+		return { kind: "fallback" };
+	}
+
+	let body: unknown = null;
+	try {
+		body = await res.json();
+	} catch {
+		body = null;
+	}
+
+	if (!res.ok) {
+		throw new Error(readApiError(body, `Daemon returned HTTP ${res.status}`));
+	}
+
+	const data = readPipelinePauseApiResponse(body);
+	if (data === null) {
+		throw new Error("Daemon returned an invalid pause response");
+	}
+
+	return { kind: "ok", data };
+}
+
+function printReleaseResults(results: readonly Awaited<ReturnType<typeof releaseOllamaModels>>[number][]): void {
+	if (results.length === 0) return;
+	const ok = results.filter((item) => item.ok).length;
+	const failed = results.length - ok;
+	if (ok > 0) {
+		console.log(chalk.dim(`  Released ${ok} local Ollama model${ok === 1 ? "" : "s"} from memory.`));
+	}
+	for (const item of results.filter((entry) => !entry.ok)) {
+		console.log(chalk.yellow(`  Failed to release ${item.label} model ${item.model}: ${item.error ?? "unknown error"}`));
+	}
+	if (failed === 0) {
+		console.log(chalk.dim("  Local Ollama VRAM should clear as those models unload."));
+	}
+}
+
+async function togglePipelinePause(options: PathOptions, deps: Deps, paused: boolean): Promise<void> {
+	console.log(deps.signetLogo());
+	const basePath = readPath(options, deps);
+
+	let state: ReturnType<typeof readPipelinePauseState>;
+	try {
+		state = readPipelinePauseState(basePath);
+	} catch (err) {
+		console.log(chalk.red(`  ${readErr(err)}`));
+		return;
+	}
+
+	if (!state.exists) {
+		console.log(chalk.red("  No Signet config file found."));
+		console.log(chalk.dim("  Run `signet setup` first."));
+		return;
+	}
+
+	if (paused && state.enabled === false) {
+		console.log(chalk.yellow("  Pipeline is disabled in config, nothing to pause."));
+		return;
+	}
+
+	if (!paused && state.enabled === false && state.paused === false) {
+		console.log(chalk.yellow("  Pipeline is disabled in config. Enable it before resuming."));
+		return;
+	}
+
+	if (state.paused === paused) {
+		console.log(
+			chalk.yellow(paused ? "  Extraction pipeline is already paused." : "  Extraction pipeline is already active."),
+		);
+		return;
+	}
+
+	const spinner = ora(paused ? "Pausing extraction pipeline..." : "Resuming extraction pipeline...").start();
+
+	try {
+		const running = await deps.isDaemonRunning();
+		if (running) {
+			const live = await requestPipelinePauseApi(deps.defaultPort, paused);
+			if (live.kind === "ok") {
+				const released = paused ? await releaseOllamaModels(basePath) : [];
+				spinner.succeed(paused ? "Extraction pipeline paused" : "Extraction pipeline resumed");
+				if (live.data.file) {
+					console.log(chalk.dim(`  Config: ${live.data.file}`));
+				}
+				const status = await deps.getDaemonStatus();
+				for (const line of daemonAccessLines(deps.defaultPort, status)) {
+					console.log(chalk.dim(`  ${line}`));
+				}
+				printReleaseResults(released);
+				console.log(
+					chalk.dim(
+						paused
+							? "  New memories can still queue for later extraction while workers stay offline."
+							: "  Queued extraction work can drain again now that the pipeline is active.",
+					),
+				);
+				return;
+			}
+		}
+
+		const next = setPipelinePaused(basePath, paused);
+		if (!running) {
+			spinner.succeed(paused ? "Pipeline pause recorded" : "Pipeline resume recorded");
+			console.log(chalk.dim(`  Config: ${next.file}`));
+			console.log(
+				chalk.dim(
+					paused
+						? "  The daemon is not running. New extraction work will stay paused on next start."
+						: "  The daemon is not running. Normal extraction will resume on next start.",
+				),
+			);
+			return;
+		}
+
+		const stopped = await deps.stopDaemon(basePath);
+		if (!stopped) {
+			spinner.fail("Failed to restart daemon after updating config");
+			return;
+		}
+
+		const released = paused ? await releaseOllamaModels(basePath) : [];
+		await deps.sleep(500);
+
+		const started = await deps.startDaemon(basePath);
+		if (!started) {
+			spinner.fail("Config updated, but daemon failed to restart");
+			return;
+		}
+
+		spinner.succeed(paused ? "Extraction pipeline paused" : "Extraction pipeline resumed");
+		console.log(chalk.dim(`  Config: ${next.file}`));
+		const status = await deps.getDaemonStatus();
+		for (const line of daemonAccessLines(deps.defaultPort, status)) {
+			console.log(chalk.dim(`  ${line}`));
+		}
+		printReleaseResults(released);
+		console.log(
+			chalk.dim(
+				paused
+					? "  New memories can still queue for later extraction while workers stay offline."
+					: "  Queued extraction work can drain again now that the pipeline is active.",
+			),
+		);
+	} catch (err) {
+		spinner.fail(paused ? "Failed to pause extraction pipeline" : "Failed to resume extraction pipeline");
+		console.log(chalk.red(`  ${readErr(err)}`));
+	}
 }
 
 function printMigrationErrors(errors: readonly string[]): void {

--- a/packages/cli/src/features/daemon.ts
+++ b/packages/cli/src/features/daemon.ts
@@ -372,6 +372,43 @@ function printReleaseResults(results: readonly Awaited<ReturnType<typeof release
 	}
 }
 
+function readPipelineMode(state: { readonly enabled: boolean; readonly paused: boolean }): string {
+	if (state.enabled === false) return "disabled";
+	if (state.paused) return "paused";
+	return "controlled-write";
+}
+
+export function summarizePipelineToggle(
+	paused: boolean,
+	mode: string,
+	running: boolean,
+): { readonly detail: string; readonly title: string } {
+	if (paused) {
+		return {
+			title: running ? "Extraction pipeline paused" : "Pipeline pause recorded",
+			detail: running
+				? "  New memories can still queue for later extraction while workers stay offline."
+				: "  The daemon is not running. New extraction work will stay paused on next start.",
+		};
+	}
+
+	if (mode === "disabled") {
+		return {
+			title: running ? "Pipeline pause cleared, still disabled" : "Pipeline pause cleared",
+			detail: running
+				? "  Pause flag cleared, but the pipeline is still disabled in config. Enable it before extraction can run."
+				: "  The daemon is not running, and the pipeline is still disabled in config. Enable it before extraction can resume on next start.",
+		};
+	}
+
+	return {
+		title: running ? "Extraction pipeline resumed" : "Pipeline resume recorded",
+		detail: running
+			? "  Queued extraction work can drain again now that the pipeline is active."
+			: "  The daemon is not running. Normal extraction will resume on next start.",
+	};
+}
+
 async function togglePipelinePause(options: PathOptions, deps: Deps, paused: boolean): Promise<void> {
 	console.log(deps.signetLogo());
 	const basePath = readPath(options, deps);
@@ -414,8 +451,9 @@ async function togglePipelinePause(options: PathOptions, deps: Deps, paused: boo
 		if (running) {
 			const live = await requestPipelinePauseApi(deps.defaultPort, paused);
 			if (live.kind === "ok") {
+				const summary = summarizePipelineToggle(paused, live.data.mode, true);
 				const released = paused ? await releaseOllamaModels(basePath) : [];
-				spinner.succeed(paused ? "Extraction pipeline paused" : "Extraction pipeline resumed");
+				spinner.succeed(summary.title);
 				if (live.data.file) {
 					console.log(chalk.dim(`  Config: ${live.data.file}`));
 				}
@@ -424,28 +462,17 @@ async function togglePipelinePause(options: PathOptions, deps: Deps, paused: boo
 					console.log(chalk.dim(`  ${line}`));
 				}
 				printReleaseResults(released);
-				console.log(
-					chalk.dim(
-						paused
-							? "  New memories can still queue for later extraction while workers stay offline."
-							: "  Queued extraction work can drain again now that the pipeline is active.",
-					),
-				);
+				console.log(chalk.dim(summary.detail));
 				return;
 			}
 		}
 
 		const next = setPipelinePaused(basePath, paused);
 		if (!running) {
-			spinner.succeed(paused ? "Pipeline pause recorded" : "Pipeline resume recorded");
+			const summary = summarizePipelineToggle(paused, readPipelineMode(next), false);
+			spinner.succeed(summary.title);
 			console.log(chalk.dim(`  Config: ${next.file}`));
-			console.log(
-				chalk.dim(
-					paused
-						? "  The daemon is not running. New extraction work will stay paused on next start."
-						: "  The daemon is not running. Normal extraction will resume on next start.",
-				),
-			);
+			console.log(chalk.dim(summary.detail));
 			return;
 		}
 
@@ -464,20 +491,15 @@ async function togglePipelinePause(options: PathOptions, deps: Deps, paused: boo
 			return;
 		}
 
-		spinner.succeed(paused ? "Extraction pipeline paused" : "Extraction pipeline resumed");
+		const summary = summarizePipelineToggle(paused, readPipelineMode(next), true);
+		spinner.succeed(summary.title);
 		console.log(chalk.dim(`  Config: ${next.file}`));
 		const status = await deps.getDaemonStatus();
 		for (const line of daemonAccessLines(deps.defaultPort, status)) {
 			console.log(chalk.dim(`  ${line}`));
 		}
 		printReleaseResults(released);
-		console.log(
-			chalk.dim(
-				paused
-					? "  New memories can still queue for later extraction while workers stay offline."
-					: "  Queued extraction work can drain again now that the pipeline is active.",
-			),
-		);
+		console.log(chalk.dim(summary.detail));
 	} catch (err) {
 		spinner.fail(paused ? "Failed to pause extraction pipeline" : "Failed to resume extraction pipeline");
 		console.log(chalk.red(`  ${readErr(err)}`));

--- a/packages/cli/src/features/daemon.ts
+++ b/packages/cli/src/features/daemon.ts
@@ -295,12 +295,12 @@ type PipelinePauseApiResult =
 			readonly kind: "ok";
 	  };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+function isPipelinePauseRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function readPipelinePauseApiResponse(value: unknown): PipelinePauseApiResponse | null {
-	if (!isRecord(value)) return null;
+	if (!isPipelinePauseRecord(value)) return null;
 	if (value.success !== true) return null;
 	if (typeof value.changed !== "boolean") return null;
 	if (typeof value.paused !== "boolean") return null;

--- a/packages/cli/src/features/pipeline-pause.test.ts
+++ b/packages/cli/src/features/pipeline-pause.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	readOllamaReleaseTargets,
+	readPipelinePauseState,
+	releaseOllamaModels,
+	setPipelinePaused,
+} from "./pipeline-pause.js";
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+	while (tmpDirs.length > 0) {
+		const dir = tmpDirs.pop();
+		if (!dir) continue;
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+function makeTempDir(prefix: string): string {
+	const dir = mkdtempSync(join(tmpdir(), prefix));
+	tmpDirs.push(dir);
+	return dir;
+}
+
+describe("pipeline pause config", () => {
+	it("writes paused state into agent.yaml", () => {
+		const dir = makeTempDir("signet-pipeline-pause-");
+		writeFileSync(join(dir, "agent.yaml"), "memory:\n  pipelineV2:\n    enabled: true\n");
+
+		const next = setPipelinePaused(dir, true);
+		const raw = readFileSync(join(dir, "agent.yaml"), "utf-8");
+
+		expect(next.exists).toBe(true);
+		expect(next.enabled).toBe(true);
+		expect(next.paused).toBe(true);
+		expect(raw).toContain("paused: true");
+	});
+
+	it("preserves explicit disabled state while clearing pause", () => {
+		const dir = makeTempDir("signet-pipeline-resume-");
+		writeFileSync(join(dir, "agent.yaml"), "memory:\n  pipelineV2:\n    enabled: false\n    paused: true\n");
+
+		const next = setPipelinePaused(dir, false);
+
+		expect(next.enabled).toBe(false);
+		expect(next.paused).toBe(false);
+	});
+
+	it("reads fallback config files", () => {
+		const dir = makeTempDir("signet-pipeline-pause-fallback-");
+		writeFileSync(join(dir, "AGENT.yaml"), "memory:\n  pipelineV2:\n    paused: true\n");
+
+		const state = readPipelinePauseState(dir);
+
+		expect(state.exists).toBe(true);
+		expect(state.enabled).toBe(true);
+		expect(state.paused).toBe(true);
+		expect(state.file?.endsWith("AGENT.yaml")).toBe(true);
+	});
+
+	it("collects unique local ollama release targets", () => {
+		const dir = makeTempDir("signet-pipeline-pause-targets-");
+		writeFileSync(
+			join(dir, "agent.yaml"),
+			[
+				"embedding:",
+				"  provider: ollama",
+				"  model: nomic-embed-text",
+				"memory:",
+				"  pipelineV2:",
+				"    extraction:",
+				"      provider: ollama",
+				"      model: qwen3.5:4b",
+				"      endpoint: http://127.0.0.1:11434",
+				"    synthesis:",
+				"      provider: ollama",
+				"      model: qwen3.5:4b",
+				"      endpoint: http://127.0.0.1:11434/",
+				"",
+			].join("\n"),
+		);
+
+		const targets = readOllamaReleaseTargets(dir);
+
+		expect(targets).toEqual([
+			{
+				label: "extraction",
+				model: "qwen3.5:4b",
+				baseUrl: "http://127.0.0.1:11434",
+			},
+			{
+				label: "embedding",
+				model: "nomic-embed-text",
+				baseUrl: "http://127.0.0.1:11434",
+			},
+		]);
+	});
+
+	it("releases local ollama models through the generate API", async () => {
+		const dir = makeTempDir("signet-pipeline-pause-release-");
+		writeFileSync(
+			join(dir, "agent.yaml"),
+			["memory:", "  pipelineV2:", "    extraction:", "      provider: ollama", "      model: qwen3.5:4b", ""].join(
+				"\n",
+			),
+		);
+
+		const seen: Array<{ readonly body: string; readonly url: string }> = [];
+		const results = await releaseOllamaModels(dir, async (input, init) => {
+			seen.push({
+				url: String(input),
+				body: String(init?.body ?? ""),
+			});
+			return new Response("{}", { status: 200 });
+		});
+
+		expect(results).toEqual([
+			{
+				label: "extraction",
+				model: "qwen3.5:4b",
+				baseUrl: "http://127.0.0.1:11434",
+				ok: true,
+			},
+		]);
+		expect(seen).toEqual([
+			{
+				url: "http://127.0.0.1:11434/api/generate",
+				body: JSON.stringify({
+					model: "qwen3.5:4b",
+					keep_alive: 0,
+				}),
+			},
+		]);
+	});
+});

--- a/packages/cli/src/features/pipeline-pause.test.ts
+++ b/packages/cli/src/features/pipeline-pause.test.ts
@@ -99,6 +99,57 @@ describe("pipeline pause config", () => {
 		]);
 	});
 
+	it("falls back to a valid ollama synthesis model", () => {
+		const dir = makeTempDir("signet-pipeline-pause-synthesis-");
+		writeFileSync(
+			join(dir, "agent.yaml"),
+			[
+				"memory:",
+				"  pipelineV2:",
+				"    synthesis:",
+				"      provider: ollama",
+				"      endpoint: http://127.0.0.1:11434",
+				"",
+			].join("\n"),
+		);
+
+		const targets = readOllamaReleaseTargets(dir);
+
+		expect(targets).toEqual([
+			{
+				label: "synthesis",
+				model: "qwen3:4b",
+				baseUrl: "http://127.0.0.1:11434",
+			},
+		]);
+	});
+
+	it("normalizes wildcard ollama endpoints to loopback", () => {
+		const dir = makeTempDir("signet-pipeline-pause-wildcard-");
+		writeFileSync(
+			join(dir, "agent.yaml"),
+			[
+				"memory:",
+				"  pipelineV2:",
+				"    extraction:",
+				"      provider: ollama",
+				"      model: qwen3.5:4b",
+				"      endpoint: http://0.0.0.0:11434",
+				"",
+			].join("\n"),
+		);
+
+		const targets = readOllamaReleaseTargets(dir);
+
+		expect(targets).toEqual([
+			{
+				label: "extraction",
+				model: "qwen3.5:4b",
+				baseUrl: "http://127.0.0.1:11434",
+			},
+		]);
+	});
+
 	it("releases local ollama models through the generate API", async () => {
 		const dir = makeTempDir("signet-pipeline-pause-release-");
 		writeFileSync(

--- a/packages/cli/src/features/pipeline-pause.ts
+++ b/packages/cli/src/features/pipeline-pause.ts
@@ -1,0 +1,185 @@
+import { readFileSync } from "node:fs";
+import {
+	findPipelineConfigFile,
+	parseSimpleYaml,
+	readPipelinePauseState,
+	setPipelinePaused,
+} from "@signet/core";
+
+const DEFAULT_OLLAMA_URL = "http://127.0.0.1:11434";
+const DEFAULT_EXTRACTION_MODEL = "qwen3.5:4b";
+const DEFAULT_SYNTHESIS_MODEL = "haiku";
+const DEFAULT_EMBEDDING_MODEL = "nomic-embed-text-v1.5";
+
+export { readPipelinePauseState, setPipelinePaused };
+export type { PipelinePauseState } from "@signet/core";
+
+export interface OllamaReleaseTarget {
+	readonly baseUrl: string;
+	readonly label: "embedding" | "extraction" | "synthesis";
+	readonly model: string;
+}
+
+export interface OllamaReleaseResult extends OllamaReleaseTarget {
+	readonly error?: string;
+	readonly ok: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function trimText(raw: unknown): string | undefined {
+	if (typeof raw !== "string") return undefined;
+	const text = raw.trim();
+	return text.length > 0 ? text : undefined;
+}
+
+function trimSlash(url: string): string {
+	return url.replace(/\/+$/, "");
+}
+
+function normalizeUrl(raw: unknown, fallback: string): string {
+	const text = trimText(raw);
+	return trimSlash(text ?? fallback);
+}
+
+function isLoopback(url: string): boolean {
+	try {
+		const parsed = new URL(url);
+		return (
+			parsed.hostname === "127.0.0.1" ||
+			parsed.hostname === "localhost" ||
+			parsed.hostname === "::1" ||
+			parsed.hostname === "[::1]" ||
+			parsed.hostname === "0.0.0.0" ||
+			parsed.hostname === "::"
+		);
+	} catch {
+		return false;
+	}
+}
+
+function readCfg(dir: string): { readonly cfg: Record<string, unknown> | null; readonly file: string | null } {
+	const file = findPipelineConfigFile(dir);
+	if (file === null) {
+		return { file: null, cfg: null };
+	}
+	const cfg = parseSimpleYaml(readFileSync(file, "utf-8"));
+	return { file, cfg: isRecord(cfg) ? cfg : {} };
+}
+
+function readMem(cfg: Record<string, unknown>): Record<string, unknown> | null {
+	return isRecord(cfg.memory) ? cfg.memory : null;
+}
+
+function readPipeline(cfg: Record<string, unknown>): Record<string, unknown> | null {
+	const mem = readMem(cfg);
+	return mem && isRecord(mem.pipelineV2) ? mem.pipelineV2 : null;
+}
+
+function addTarget(
+	list: OllamaReleaseTarget[],
+	seen: Set<string>,
+	label: OllamaReleaseTarget["label"],
+	model: string,
+	baseUrl: string,
+): void {
+	if (!isLoopback(baseUrl)) return;
+	const key = [baseUrl, model].join("\u0000");
+	if (seen.has(key)) return;
+	seen.add(key);
+	list.push({ label, model, baseUrl });
+}
+
+export function readOllamaReleaseTargets(dir: string): readonly OllamaReleaseTarget[] {
+	const { cfg } = readCfg(dir);
+	if (cfg === null) return [];
+
+	const out: OllamaReleaseTarget[] = [];
+	const seen = new Set<string>();
+	const mem = readMem(cfg);
+	const p2 = readPipeline(cfg);
+
+	const extraction = p2 && isRecord(p2.extraction) ? p2.extraction : null;
+	if (extraction?.provider === "ollama") {
+		addTarget(
+			out,
+			seen,
+			"extraction",
+			trimText(extraction.model) ?? DEFAULT_EXTRACTION_MODEL,
+			normalizeUrl(extraction.endpoint ?? extraction.base_url, DEFAULT_OLLAMA_URL),
+		);
+	}
+
+	const synthesis = p2 && isRecord(p2.synthesis) ? p2.synthesis : null;
+	if (synthesis?.provider === "ollama") {
+		addTarget(
+			out,
+			seen,
+			"synthesis",
+			trimText(synthesis.model) ?? DEFAULT_SYNTHESIS_MODEL,
+			normalizeUrl(synthesis.endpoint ?? synthesis.base_url, DEFAULT_OLLAMA_URL),
+		);
+	}
+
+	const embedding = isRecord(cfg.embedding)
+		? cfg.embedding
+		: mem && isRecord(mem.embeddings)
+			? mem.embeddings
+			: isRecord(cfg.embeddings)
+				? cfg.embeddings
+				: null;
+	if (embedding?.provider === "ollama") {
+		addTarget(
+			out,
+			seen,
+			"embedding",
+			trimText(embedding.model) ?? DEFAULT_EMBEDDING_MODEL,
+			normalizeUrl(embedding.base_url ?? embedding.endpoint ?? embedding.url, DEFAULT_OLLAMA_URL),
+		);
+	}
+
+	return out;
+}
+
+export async function releaseOllamaModels(
+	dir: string,
+	doFetch: typeof fetch = fetch,
+): Promise<readonly OllamaReleaseResult[]> {
+	const targets = readOllamaReleaseTargets(dir);
+	const out: OllamaReleaseResult[] = [];
+
+	for (const target of targets) {
+		try {
+			const res = await doFetch(`${target.baseUrl}/api/generate`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					model: target.model,
+					keep_alive: 0,
+				}),
+			});
+
+			if (!res.ok) {
+				const body = await res.text().catch(() => "");
+				out.push({
+					...target,
+					ok: false,
+					error: body ? `HTTP ${res.status}: ${body.slice(0, 200)}` : `HTTP ${res.status}`,
+				});
+				continue;
+			}
+
+			out.push({ ...target, ok: true });
+		} catch (err) {
+			out.push({
+				...target,
+				ok: false,
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+	}
+
+	return out;
+}

--- a/packages/cli/src/features/pipeline-pause.ts
+++ b/packages/cli/src/features/pipeline-pause.ts
@@ -1,14 +1,12 @@
-import { readFileSync } from "node:fs";
 import {
-	findPipelineConfigFile,
-	parseSimpleYaml,
+	readPipelineConfigData,
 	readPipelinePauseState,
 	setPipelinePaused,
 } from "@signet/core";
 
 const DEFAULT_OLLAMA_URL = "http://127.0.0.1:11434";
 const DEFAULT_EXTRACTION_MODEL = "qwen3.5:4b";
-const DEFAULT_SYNTHESIS_MODEL = "haiku";
+const DEFAULT_SYNTHESIS_MODEL = "qwen3:4b";
 const DEFAULT_EMBEDDING_MODEL = "nomic-embed-text-v1.5";
 
 export { readPipelinePauseState, setPipelinePaused };
@@ -25,7 +23,7 @@ export interface OllamaReleaseResult extends OllamaReleaseTarget {
 	readonly ok: boolean;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+function isObject(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
@@ -41,7 +39,28 @@ function trimSlash(url: string): string {
 
 function normalizeUrl(raw: unknown, fallback: string): string {
 	const text = trimText(raw);
-	return trimSlash(text ?? fallback);
+	const url = trimSlash(text ?? fallback);
+
+	try {
+		const parsed = new URL(url);
+		if (parsed.hostname === "0.0.0.0") {
+			parsed.hostname = "127.0.0.1";
+			return trimSlash(parsed.toString());
+		}
+
+		if (parsed.hostname === "::" || parsed.hostname === "[::]") {
+			const auth =
+				parsed.username.length > 0
+					? `${parsed.username}${parsed.password.length > 0 ? `:${parsed.password}` : ""}@`
+					: "";
+			const port = parsed.port.length > 0 ? `:${parsed.port}` : "";
+			return trimSlash(`${parsed.protocol}//${auth}[::1]${port}${parsed.pathname}${parsed.search}${parsed.hash}`);
+		}
+
+		return trimSlash(parsed.toString());
+	} catch {
+		return url;
+	}
 }
 
 function isLoopback(url: string): boolean {
@@ -51,31 +70,11 @@ function isLoopback(url: string): boolean {
 			parsed.hostname === "127.0.0.1" ||
 			parsed.hostname === "localhost" ||
 			parsed.hostname === "::1" ||
-			parsed.hostname === "[::1]" ||
-			parsed.hostname === "0.0.0.0" ||
-			parsed.hostname === "::"
+			parsed.hostname === "[::1]"
 		);
 	} catch {
 		return false;
 	}
-}
-
-function readCfg(dir: string): { readonly cfg: Record<string, unknown> | null; readonly file: string | null } {
-	const file = findPipelineConfigFile(dir);
-	if (file === null) {
-		return { file: null, cfg: null };
-	}
-	const cfg = parseSimpleYaml(readFileSync(file, "utf-8"));
-	return { file, cfg: isRecord(cfg) ? cfg : {} };
-}
-
-function readMem(cfg: Record<string, unknown>): Record<string, unknown> | null {
-	return isRecord(cfg.memory) ? cfg.memory : null;
-}
-
-function readPipeline(cfg: Record<string, unknown>): Record<string, unknown> | null {
-	const mem = readMem(cfg);
-	return mem && isRecord(mem.pipelineV2) ? mem.pipelineV2 : null;
 }
 
 function addTarget(
@@ -93,15 +92,13 @@ function addTarget(
 }
 
 export function readOllamaReleaseTargets(dir: string): readonly OllamaReleaseTarget[] {
-	const { cfg } = readCfg(dir);
-	if (cfg === null) return [];
+	const { root, memory, pipeline } = readPipelineConfigData(dir);
+	if (root === null) return [];
 
 	const out: OllamaReleaseTarget[] = [];
 	const seen = new Set<string>();
-	const mem = readMem(cfg);
-	const p2 = readPipeline(cfg);
 
-	const extraction = p2 && isRecord(p2.extraction) ? p2.extraction : null;
+	const extraction = pipeline && isObject(pipeline.extraction) ? pipeline.extraction : null;
 	if (extraction?.provider === "ollama") {
 		addTarget(
 			out,
@@ -112,7 +109,7 @@ export function readOllamaReleaseTargets(dir: string): readonly OllamaReleaseTar
 		);
 	}
 
-	const synthesis = p2 && isRecord(p2.synthesis) ? p2.synthesis : null;
+	const synthesis = pipeline && isObject(pipeline.synthesis) ? pipeline.synthesis : null;
 	if (synthesis?.provider === "ollama") {
 		addTarget(
 			out,
@@ -123,12 +120,12 @@ export function readOllamaReleaseTargets(dir: string): readonly OllamaReleaseTar
 		);
 	}
 
-	const embedding = isRecord(cfg.embedding)
-		? cfg.embedding
-		: mem && isRecord(mem.embeddings)
-			? mem.embeddings
-			: isRecord(cfg.embeddings)
-				? cfg.embeddings
+	const embedding = isObject(root.embedding)
+		? root.embedding
+		: memory && isObject(memory.embeddings)
+			? memory.embeddings
+			: isObject(root.embeddings)
+				? root.embeddings
 				: null;
 	if (embedding?.provider === "ollama") {
 		addTarget(

--- a/packages/cli/templates/agent.yaml.template
+++ b/packages/cli/templates/agent.yaml.template
@@ -103,6 +103,10 @@ memory:
     # When false, shadowMode is ignored and the pipeline is fully disabled.
     enabled: true
 
+    # Temporary operator pause. Keeps queueing raw work, but workers stay offline
+    # until you run `signet daemon resume`.
+    # paused: false
+
     # Shadow mode: extract but don't write to DB (dry-run for testing)
     # shadowMode: false
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -209,6 +209,13 @@ export {
 
 // YAML utilities
 export { parseSimpleYaml, formatYaml } from "./yaml";
+export {
+	PIPELINE_CONFIG_FILES,
+	findPipelineConfigFile,
+	readPipelinePauseState,
+	setPipelinePaused,
+} from "./pipeline-pause";
+export type { PipelinePauseState } from "./pipeline-pause";
 
 // Symlink utilities
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -212,10 +212,11 @@ export { parseSimpleYaml, formatYaml } from "./yaml";
 export {
 	PIPELINE_CONFIG_FILES,
 	findPipelineConfigFile,
+	readPipelineConfigData,
 	readPipelinePauseState,
 	setPipelinePaused,
 } from "./pipeline-pause";
-export type { PipelinePauseState } from "./pipeline-pause";
+export type { PipelineConfigData, PipelinePauseState } from "./pipeline-pause";
 
 // Symlink utilities
 export {

--- a/packages/core/src/pipeline-pause.ts
+++ b/packages/core/src/pipeline-pause.ts
@@ -11,6 +11,13 @@ export interface PipelinePauseState {
 	readonly paused: boolean;
 }
 
+export interface PipelineConfigData {
+	readonly file: string | null;
+	readonly root: Record<string, unknown> | null;
+	readonly memory: Record<string, unknown> | null;
+	readonly pipeline: Record<string, unknown> | null;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -43,32 +50,43 @@ function readPipeline(cfg: Record<string, unknown>): Record<string, unknown> | n
 	return mem && isRecord(mem.pipelineV2) ? mem.pipelineV2 : null;
 }
 
+export function readPipelineConfigData(dir: string): PipelineConfigData {
+	const { cfg: root, file } = readCfg(dir);
+	if (root === null) {
+		return { file: null, root: null, memory: null, pipeline: null };
+	}
+
+	const memory = readMem(root);
+	return {
+		file,
+		root,
+		memory,
+		pipeline: readPipeline(root),
+	};
+}
+
 export function readPipelinePauseState(dir: string): PipelinePauseState {
-	const { cfg, file } = readCfg(dir);
-	if (cfg === null) {
+	const { file, pipeline } = readPipelineConfigData(dir);
+	if (file === null) {
 		return { file: null, exists: false, enabled: false, paused: false };
 	}
 
-	const p2 = readPipeline(cfg);
 	return {
 		file,
 		exists: true,
-		enabled: p2?.enabled !== false,
-		paused: p2?.paused === true,
+		enabled: pipeline?.enabled !== false,
+		paused: pipeline?.paused === true,
 	};
 }
 
 export function setPipelinePaused(dir: string, paused: boolean): PipelinePauseState {
-	const { cfg, file } = readCfg(dir);
-	if (file === null) {
+	const { file, root, memory, pipeline } = readPipelineConfigData(dir);
+	if (file === null || root === null) {
 		throw new Error("No Signet config file found. Run `signet setup` first.");
 	}
 
-	const root = cfg ?? {};
-	const mem = isRecord(root.memory) ? root.memory : {};
-	const p2 = isRecord(mem.pipelineV2) ? mem.pipelineV2 : {};
-	const nextP2 = { ...p2, paused };
-	const nextMem = { ...mem, pipelineV2: nextP2 };
+	const nextP2 = { ...(pipeline ?? {}), paused };
+	const nextMem = { ...(memory ?? {}), pipelineV2: nextP2 };
 	const next = { ...root, memory: nextMem };
 
 	writeFileSync(file, formatYaml(next));
@@ -76,7 +94,7 @@ export function setPipelinePaused(dir: string, paused: boolean): PipelinePauseSt
 	return {
 		file,
 		exists: true,
-		enabled: p2.enabled !== false,
+		enabled: pipeline?.enabled !== false,
 		paused,
 	};
 }

--- a/packages/core/src/pipeline-pause.ts
+++ b/packages/core/src/pipeline-pause.ts
@@ -1,0 +1,82 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { formatYaml, parseSimpleYaml } from "./yaml";
+
+export const PIPELINE_CONFIG_FILES = ["agent.yaml", "AGENT.yaml", "config.yaml"] as const;
+
+export interface PipelinePauseState {
+	readonly file: string | null;
+	readonly exists: boolean;
+	readonly enabled: boolean;
+	readonly paused: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function findPipelineConfigFile(dir: string): string | null {
+	for (const name of PIPELINE_CONFIG_FILES) {
+		const file = join(dir, name);
+		if (existsSync(file)) {
+			return file;
+		}
+	}
+	return null;
+}
+
+function readCfg(dir: string): { readonly cfg: Record<string, unknown> | null; readonly file: string | null } {
+	const file = findPipelineConfigFile(dir);
+	if (file === null) {
+		return { file: null, cfg: null };
+	}
+	const parsed = parseSimpleYaml(readFileSync(file, "utf-8"));
+	return { file, cfg: isRecord(parsed) ? parsed : {} };
+}
+
+function readMem(cfg: Record<string, unknown>): Record<string, unknown> | null {
+	return isRecord(cfg.memory) ? cfg.memory : null;
+}
+
+function readPipeline(cfg: Record<string, unknown>): Record<string, unknown> | null {
+	const mem = readMem(cfg);
+	return mem && isRecord(mem.pipelineV2) ? mem.pipelineV2 : null;
+}
+
+export function readPipelinePauseState(dir: string): PipelinePauseState {
+	const { cfg, file } = readCfg(dir);
+	if (cfg === null) {
+		return { file: null, exists: false, enabled: false, paused: false };
+	}
+
+	const p2 = readPipeline(cfg);
+	return {
+		file,
+		exists: true,
+		enabled: p2?.enabled !== false,
+		paused: p2?.paused === true,
+	};
+}
+
+export function setPipelinePaused(dir: string, paused: boolean): PipelinePauseState {
+	const { cfg, file } = readCfg(dir);
+	if (file === null) {
+		throw new Error("No Signet config file found. Run `signet setup` first.");
+	}
+
+	const root = cfg ?? {};
+	const mem = isRecord(root.memory) ? root.memory : {};
+	const p2 = isRecord(mem.pipelineV2) ? mem.pipelineV2 : {};
+	const nextP2 = { ...p2, paused };
+	const nextMem = { ...mem, pipelineV2: nextP2 };
+	const next = { ...root, memory: nextMem };
+
+	writeFileSync(file, formatYaml(next));
+
+	return {
+		file,
+		exists: true,
+		enabled: p2.enabled !== false,
+		paused,
+	};
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -37,10 +37,7 @@ export interface LlmProvider {
  * - "shared": all global memories + own private
  * - { type: "group" }: global memories from group members + own private
  */
-export type ReadPolicy =
-	| "isolated"
-	| "shared"
-	| { readonly type: "group"; readonly group: string };
+export type ReadPolicy = "isolated" | "shared" | { readonly type: "group"; readonly group: string };
 
 /** A named agent entry in the roster. */
 export interface AgentDefinition {
@@ -163,6 +160,7 @@ export interface AgentConfig {
 
 export const PIPELINE_FLAGS = [
 	"enabled",
+	"paused",
 	"shadowMode",
 	"mutationsFrozen",
 	"graph.enabled",
@@ -185,14 +183,7 @@ export interface PipelineEscalationConfig {
 }
 
 export interface PipelineExtractionConfig {
-	readonly provider:
-		| "none"
-		| "ollama"
-		| "claude-code"
-		| "opencode"
-		| "codex"
-		| "anthropic"
-		| "openrouter";
+	readonly provider: "none" | "ollama" | "claude-code" | "opencode" | "codex" | "anthropic" | "openrouter";
 	readonly model: string;
 	readonly strength: "low" | "medium" | "high";
 	readonly endpoint?: string;
@@ -287,6 +278,7 @@ export interface PipelineContinuityConfig {
 export interface PipelineV2Config {
 	// Master switches (flat)
 	readonly enabled: boolean;
+	readonly paused: boolean;
 	readonly shadowMode: boolean;
 	readonly nativeShadowEnabled: boolean;
 	readonly mutationsFrozen: boolean;
@@ -359,13 +351,7 @@ export interface PipelineEmbeddingTrackerConfig {
 
 export interface PipelineSynthesisConfig {
 	readonly enabled: boolean;
-	readonly provider:
-		| "none"
-		| "ollama"
-		| "claude-code"
-		| "opencode"
-		| "anthropic"
-		| "openrouter";
+	readonly provider: "none" | "ollama" | "claude-code" | "opencode" | "anthropic" | "openrouter";
 	readonly model: string;
 	readonly endpoint?: string;
 	readonly timeout: number;
@@ -661,16 +647,31 @@ export type AttributeStatus = (typeof ATTRIBUTE_STATUSES)[number];
 
 export const DEPENDENCY_TYPES = [
 	// core
-	"uses", "requires", "owned_by", "blocks", "informs",
+	"uses",
+	"requires",
+	"owned_by",
+	"blocks",
+	"informs",
 	// knowledge
-	"built", "depends_on", "related_to", "learned_from",
-	"teaches", "knows", "assumes",
+	"built",
+	"depends_on",
+	"related_to",
+	"learned_from",
+	"teaches",
+	"knows",
+	"assumes",
 	// structural
-	"contradicts", "supersedes", "part_of",
+	"contradicts",
+	"supersedes",
+	"part_of",
 	// temporal / execution flow
-	"precedes", "follows", "triggers",
+	"precedes",
+	"follows",
+	"triggers",
 	// impact
-	"impacts", "produces", "consumes",
+	"impacts",
+	"produces",
+	"consumes",
 ] as const;
 export type DependencyType = (typeof DEPENDENCY_TYPES)[number];
 

--- a/packages/daemon-rs/Cargo.lock
+++ b/packages/daemon-rs/Cargo.lock
@@ -1548,6 +1548,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "serde_yml",
  "sha2",
  "signet-core",
  "signet-pipeline",

--- a/packages/daemon-rs/crates/signet-core/src/config.rs
+++ b/packages/daemon-rs/crates/signet-core/src/config.rs
@@ -274,6 +274,7 @@ pub struct RateLimitConfig {
 #[serde(default, rename_all = "camelCase")]
 pub struct PipelineV2Config {
     pub enabled: bool,
+    pub paused: bool,
     pub shadow_mode: bool,
     /// Spawn the native Rust daemon as a shadow on :3851. Distinct from
     /// `shadow_mode` (extract-without-write). Only meaningful when read
@@ -309,6 +310,7 @@ impl Default for PipelineV2Config {
     fn default() -> Self {
         Self {
             enabled: true,
+            paused: false,
             shadow_mode: false,
             native_shadow_enabled: false,
             mutations_frozen: false,

--- a/packages/daemon-rs/crates/signet-daemon/Cargo.toml
+++ b/packages/daemon-rs/crates/signet-daemon/Cargo.toml
@@ -19,6 +19,7 @@ tower-http = { workspace = true }
 rusqlite = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yml = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 anyhow = { workspace = true }

--- a/packages/daemon-rs/crates/signet-daemon/src/auth/middleware.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/auth/middleware.rs
@@ -50,64 +50,85 @@ pub struct AuthConfig {
     pub secret: Option<Vec<u8>>,
 }
 
-// ---------------------------------------------------------------------------
-// Auth middleware (validates token, sets AuthState in extensions)
-// ---------------------------------------------------------------------------
-
-pub async fn auth_middleware(auth_cfg: AuthConfig, mut req: Request<Body>, next: Next) -> Response {
-    let headers = req.headers();
-
-    // Local mode: no auth required
-    if auth_cfg.mode == AuthMode::Local {
-        req.extensions_mut().insert(AuthState {
+pub fn authenticate_headers(
+    mode: AuthMode,
+    secret: Option<&[u8]>,
+    headers: &HeaderMap,
+    is_local: bool,
+) -> Result<AuthState, Box<Response>> {
+    if mode == AuthMode::Local {
+        return Ok(AuthState {
             result: AuthResult::unauthenticated(),
         });
-        return next.run(req).await;
     }
 
-    // Hybrid mode: localhost skips token requirement
-    if auth_cfg.mode == AuthMode::Hybrid && is_localhost(headers) {
-        let result = if let Some(token) = extract_bearer(headers)
-            && let Some(secret) = &auth_cfg.secret
-        {
-            verify_token(secret, token)
+    if mode == AuthMode::Hybrid && is_local {
+        let result = if let Some(token) = extract_bearer(headers) {
+            if let Some(secret) = secret {
+                verify_token(secret, token)
+            } else {
+                AuthResult::unauthenticated()
+            }
         } else {
             AuthResult::unauthenticated()
         };
-        req.extensions_mut().insert(AuthState { result });
-        return next.run(req).await;
+
+        return Ok(AuthState { result });
     }
 
-    // Team mode (or hybrid+remote): token required
     let Some(token) = extract_bearer(headers) else {
-        return (
-            StatusCode::UNAUTHORIZED,
-            [("www-authenticate", "Bearer")],
-            Json(serde_json::json!({"error": "authentication required"})),
-        )
-            .into_response();
+        return Err(Box::new(
+            (
+                StatusCode::UNAUTHORIZED,
+                [("www-authenticate", "Bearer")],
+                Json(serde_json::json!({"error": "authentication required"})),
+            )
+                .into_response(),
+        ));
     };
 
-    let Some(secret) = &auth_cfg.secret else {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": "auth secret not configured"})),
-        )
-            .into_response();
+    let Some(secret) = secret else {
+        return Err(Box::new(
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "auth secret not configured"})),
+            )
+                .into_response(),
+        ));
     };
 
     let result = verify_token(secret, token);
     if !result.authenticated {
         let err = result.error.as_deref().unwrap_or("invalid token");
-        return (
-            StatusCode::UNAUTHORIZED,
-            [("www-authenticate", "Bearer")],
-            Json(serde_json::json!({"error": err})),
-        )
-            .into_response();
+        return Err(Box::new(
+            (
+                StatusCode::UNAUTHORIZED,
+                [("www-authenticate", "Bearer")],
+                Json(serde_json::json!({"error": err})),
+            )
+                .into_response(),
+        ));
     }
 
-    req.extensions_mut().insert(AuthState { result });
+    Ok(AuthState { result })
+}
+
+// ---------------------------------------------------------------------------
+// Auth middleware (validates token, sets AuthState in extensions)
+// ---------------------------------------------------------------------------
+
+pub async fn auth_middleware(auth_cfg: AuthConfig, mut req: Request<Body>, next: Next) -> Response {
+    let auth = match authenticate_headers(
+        auth_cfg.mode,
+        auth_cfg.secret.as_deref(),
+        req.headers(),
+        auth_cfg.mode == AuthMode::Hybrid && is_localhost(req.headers()),
+    ) {
+        Ok(auth) => auth,
+        Err(resp) => return *resp,
+    };
+
+    req.extensions_mut().insert(auth);
     next.run(req).await
 }
 

--- a/packages/daemon-rs/crates/signet-daemon/src/main.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/main.rs
@@ -84,11 +84,23 @@ async fn main() -> anyhow::Result<()> {
     let (pool, writer_handle) = DbPool::open(&config.db_path).context("failed to open database")?;
 
     // Initialize embedding provider
-    let embedding = config
+    let pipeline_paused = config
         .manifest
-        .embedding
+        .memory
         .as_ref()
-        .map(|cfg| signet_pipeline::embedding::from_config(cfg, None));
+        .and_then(|m| m.pipeline_v2.as_ref())
+        .map(|p| p.paused)
+        .unwrap_or(false);
+    let embedding = if pipeline_paused {
+        info!("pipeline paused; embedding provider startup deferred");
+        None
+    } else {
+        config
+            .manifest
+            .embedding
+            .as_ref()
+            .map(|cfg| signet_pipeline::embedding::from_config(cfg, None))
+    };
 
     // Build app state
     let state = Arc::new(AppState::new(config.clone(), pool, embedding));
@@ -232,6 +244,14 @@ async fn main() -> anyhow::Result<()> {
         )
         // Pipeline routes
         .route("/api/pipeline/status", get(routes::pipeline::status))
+        .route(
+            "/api/pipeline/pause",
+            axum::routing::post(routes::pipeline::pause),
+        )
+        .route(
+            "/api/pipeline/resume",
+            axum::routing::post(routes::pipeline::resume),
+        )
         .route("/api/pipeline/models", get(routes::pipeline::models))
         .route(
             "/api/pipeline/models/by-provider",

--- a/packages/daemon-rs/crates/signet-daemon/src/main.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/main.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -16,7 +18,45 @@ mod routes;
 mod service;
 mod state;
 
+use auth::rate_limiter::{AuthRateLimiter, RateLimitRule, default_limits};
+use auth::tokens::load_or_create_secret;
+use auth::types::AuthMode;
 use state::AppState;
+
+fn read_auth_mode(config: &DaemonConfig) -> AuthMode {
+    config
+        .manifest
+        .auth
+        .as_ref()
+        .and_then(|auth| auth.mode.as_deref())
+        .map(AuthMode::from_str_lossy)
+        .unwrap_or_default()
+}
+
+fn merge_rate_limits(config: &DaemonConfig) -> HashMap<String, RateLimitRule> {
+    let mut rules = default_limits();
+
+    let Some(auth) = config.manifest.auth.as_ref() else {
+        return rules;
+    };
+    let Some(raw) = auth.rate_limits.as_ref() else {
+        return rules;
+    };
+
+    for (name, cfg) in raw {
+        let Some(rule) = rules.get_mut(name) else {
+            continue;
+        };
+        if let Some(window_ms) = cfg.window_ms.filter(|n| *n > 0) {
+            rule.window_ms = window_ms;
+        }
+        if let Some(max) = cfg.max.filter(|n| *n > 0) {
+            rule.max = max;
+        }
+    }
+
+    rules
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -102,8 +142,25 @@ async fn main() -> anyhow::Result<()> {
             .map(|cfg| signet_pipeline::embedding::from_config(cfg, None))
     };
 
+    let auth_mode = read_auth_mode(&config);
+    let auth_secret = if auth_mode == AuthMode::Local {
+        info!("auth mode local, admin routes unrestricted on loopback runtime");
+        None
+    } else {
+        let path = config.base_path.join(".daemon").join("auth-secret");
+        Some(load_or_create_secret(&path).context("failed to load auth secret")?)
+    };
+    let auth_admin_limiter = AuthRateLimiter::from_rules(&merge_rate_limits(&config));
+
     // Build app state
-    let state = Arc::new(AppState::new(config.clone(), pool, embedding));
+    let state = Arc::new(AppState::new(
+        config.clone(),
+        pool,
+        embedding,
+        auth_mode,
+        auth_secret,
+        auth_admin_limiter,
+    ));
 
     // Build router
     let app = Router::new()
@@ -186,7 +243,10 @@ async fn main() -> anyhow::Result<()> {
             axum::routing::post(routes::hooks::compaction_complete),
         )
         // Agent roster routes (multi-agent support — migration 043)
-        .route("/api/agents", get(routes::agents::list).post(routes::agents::create))
+        .route(
+            "/api/agents",
+            get(routes::agents::list).post(routes::agents::create),
+        )
         .route(
             "/api/agents/{name}",
             get(routes::agents::get).delete(routes::agents::delete),
@@ -490,10 +550,13 @@ async fn main() -> anyhow::Result<()> {
     info!(%addr, "listening");
 
     // Serve with graceful shutdown
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
-        .await
-        .context("server error")?;
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown_signal())
+    .await
+    .context("server error")?;
 
     info!("shutting down");
 

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/pipeline.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/pipeline.rs
@@ -1,16 +1,22 @@
 //! Pipeline status and model management routes.
 
+use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
 use axum::{
-    extract::State,
-    http::StatusCode,
-    response::{IntoResponse, Json},
+    extract::{ConnectInfo, State},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Json, Response},
 };
-use signet_core::config::PipelineV2Config;
 use serde_yml::{Mapping, Value};
+use signet_core::config::PipelineV2Config;
 
+use crate::auth::middleware::{
+    authenticate_headers, require_permission_guard, require_rate_limit_guard,
+};
+use crate::auth::types::Permission;
 use crate::state::AppState;
 
 const PIPELINE_CONFIG_FILES: [&str; 3] = ["agent.yaml", "AGENT.yaml", "config.yaml"];
@@ -46,11 +52,12 @@ fn read_pipeline_mode_from_value(
     value: &Value,
     fallback: Option<&PipelineV2Config>,
 ) -> PipelineMode {
+    let fallback = fallback.cloned().unwrap_or_default();
     let mut mode = PipelineMode {
-        enabled: fallback.map(|cfg| cfg.enabled).unwrap_or(false),
-        paused: fallback.map(|cfg| cfg.paused).unwrap_or(false),
-        frozen: fallback.map(|cfg| cfg.mutations_frozen).unwrap_or(false),
-        shadow: fallback.map(|cfg| cfg.shadow_mode).unwrap_or(false),
+        enabled: fallback.enabled,
+        paused: fallback.paused,
+        frozen: fallback.mutations_frozen,
+        shadow: fallback.shadow_mode,
     };
 
     let Some(root) = value.as_mapping() else {
@@ -147,6 +154,71 @@ fn set_pipeline_paused(
     ))
 }
 
+fn is_loopback(addr: &SocketAddr) -> bool {
+    match addr.ip() {
+        IpAddr::V4(ip) => ip.is_loopback(),
+        IpAddr::V6(ip) => {
+            ip.is_loopback()
+                || ip
+                    .to_ipv4_mapped()
+                    .map(|mapped| mapped.is_loopback())
+                    .unwrap_or(false)
+        }
+    }
+}
+
+fn live_pipeline_mode(state: &AppState) -> PipelineMode {
+    let pipeline = state
+        .config
+        .manifest
+        .memory
+        .as_ref()
+        .and_then(|m| m.pipeline_v2.as_ref());
+    let mut mode = read_pipeline_mode(state.config.base_path.as_path(), pipeline);
+    mode.paused = state.pipeline_paused();
+    mode
+}
+
+fn build_embedding(
+    state: &AppState,
+) -> Option<Arc<dyn signet_pipeline::embedding::EmbeddingProvider>> {
+    state
+        .config
+        .manifest
+        .embedding
+        .as_ref()
+        .map(|cfg| signet_pipeline::embedding::from_config(cfg, None))
+}
+
+async fn apply_pause_state(state: &AppState, paused: bool) {
+    state.pipeline_paused.store(paused, Ordering::SeqCst);
+    let next = if paused { None } else { build_embedding(state) };
+    *state.embedding.write().await = next;
+}
+
+fn guard_admin(
+    state: &AppState,
+    headers: &HeaderMap,
+    peer: &SocketAddr,
+) -> Result<(), Box<Response>> {
+    let is_local = is_loopback(peer);
+    let auth = authenticate_headers(
+        state.auth_mode,
+        state.auth_secret.as_deref(),
+        headers,
+        is_local,
+    )?;
+    require_permission_guard(&auth, Permission::Admin, state.auth_mode, is_local)?;
+    require_rate_limit_guard(
+        &auth,
+        "admin",
+        &state.auth_admin_limiter,
+        state.auth_mode,
+        None,
+    )?;
+    Ok(())
+}
+
 /// GET /api/pipeline/status — pipeline worker and queue status.
 pub async fn status(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
     let queues = state
@@ -188,7 +260,6 @@ pub async fn status(State(state): State<Arc<AppState>>) -> Json<serde_json::Valu
                 )
                 .unwrap_or(0);
 
-            // Summary queue (table may not exist yet)
             let summary_pending: i64 = conn
                 .query_row(
                     "SELECT COUNT(*) FROM summary_jobs WHERE status = 'pending'",
@@ -229,17 +300,9 @@ pub async fn status(State(state): State<Arc<AppState>>) -> Json<serde_json::Valu
         .await
         .unwrap_or_else(|_| serde_json::json!({}));
 
-    let pipeline = state
-        .config
-        .manifest
-        .memory
-        .as_ref()
-        .and_then(|m| m.pipeline_v2.as_ref());
-    let mode = format_pipeline_mode(read_pipeline_mode(state.config.base_path.as_path(), pipeline));
-
     Json(serde_json::json!({
         "queues": queues,
-        "mode": mode,
+        "mode": format_pipeline_mode(live_pipeline_mode(&state)),
         "predictor": {
             "running": false,
             "modelReady": false,
@@ -296,19 +359,46 @@ pub async fn models_by_provider(State(state): State<Arc<AppState>>) -> Json<serd
 
 /// POST /api/pipeline/models/refresh — refresh model registry.
 pub async fn models_refresh(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
-    // TODO: Query Ollama /api/tags and Anthropic for available models
     models(State(state)).await
 }
 
-pub async fn pause(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    toggle_pause(state, true).await
+pub async fn pause(
+    State(state): State<Arc<AppState>>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    toggle_pause(state, headers, peer, true).await
 }
 
-pub async fn resume(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    toggle_pause(state, false).await
+pub async fn resume(
+    State(state): State<Arc<AppState>>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    toggle_pause(state, headers, peer, false).await
 }
 
-async fn toggle_pause(state: Arc<AppState>, paused: bool) -> impl IntoResponse {
+async fn toggle_pause(
+    state: Arc<AppState>,
+    headers: HeaderMap,
+    peer: SocketAddr,
+    paused: bool,
+) -> Response {
+    if let Err(resp) = guard_admin(state.as_ref(), &headers, &peer) {
+        return *resp;
+    }
+
+    if state.pipeline_transition.swap(true, Ordering::SeqCst) {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "success": false,
+                "error": "Pipeline transition already in progress",
+            })),
+        )
+            .into_response();
+    }
+
     let base = state.config.base_path.clone();
     let fallback = state
         .config
@@ -322,18 +412,23 @@ async fn toggle_pause(state: Arc<AppState>, paused: bool) -> impl IntoResponse {
     })
     .await;
 
+    state.pipeline_transition.store(false, Ordering::SeqCst);
+
     match res {
-        Ok(Ok((file, changed, mode))) => (
-            StatusCode::OK,
-            Json(serde_json::json!({
-                "success": true,
-                "changed": changed,
-                "paused": paused,
-                "file": file,
-                "mode": format_pipeline_mode(mode),
-            })),
-        )
-            .into_response(),
+        Ok(Ok((file, changed, _))) => {
+            apply_pause_state(state.as_ref(), paused).await;
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "success": true,
+                    "changed": changed,
+                    "paused": paused,
+                    "file": file,
+                    "mode": format_pipeline_mode(live_pipeline_mode(&state)),
+                })),
+            )
+                .into_response()
+        }
         Ok(Err(err)) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({
@@ -355,15 +450,187 @@ async fn toggle_pause(state: Arc<AppState>, paused: bool) -> impl IntoResponse {
 
 #[cfg(test)]
 mod tests {
-    use tempfile::tempdir;
+    use std::collections::HashMap;
+    use std::net::SocketAddr;
+    use std::sync::Arc;
+    use std::sync::atomic::Ordering;
 
-    use super::{find_config_file, format_pipeline_mode, read_pipeline_mode, set_pipeline_paused};
+    use axum::Router;
+    use axum::body::{Body, to_bytes};
+    use axum::extract::connect_info::ConnectInfo;
+    use axum::http::{Method, Request, StatusCode};
+    use axum::routing::{get, post};
+    use signet_core::config::{
+        AgentIdentity, AgentManifest, AuthConfig as ManifestAuthConfig, DaemonConfig,
+        EmbeddingConfig, MemoryManifestConfig, PipelineV2Config, RateLimitConfig,
+    };
+    use signet_core::db::DbPool;
+    use tempfile::{TempDir, tempdir};
+    use tower::ServiceExt;
+
+    use crate::auth::rate_limiter::{AuthRateLimiter, default_limits};
+    use crate::auth::tokens::{create_token, generate_secret};
+    use crate::auth::types::{AuthMode, TokenRole, TokenScope};
+    use crate::state::AppState;
+
+    use super::{
+        find_config_file, format_pipeline_mode, pause, read_pipeline_mode, resume,
+        set_pipeline_paused, status,
+    };
+
+    struct TestState {
+        state: Arc<AppState>,
+        secret: Option<Vec<u8>>,
+        _dir: TempDir,
+    }
+
+    fn mode_name(mode: AuthMode) -> String {
+        match mode {
+            AuthMode::Local => "local",
+            AuthMode::Team => "team",
+            AuthMode::Hybrid => "hybrid",
+        }
+        .to_string()
+    }
+
+    fn build_state(mode: AuthMode, paused: bool, admin_max: u64) -> TestState {
+        let dir = tempdir().expect("tempdir");
+        let db = dir.path().join("memory").join("memories.db");
+        std::fs::create_dir_all(db.parent().expect("db parent")).expect("create memory dir");
+        std::fs::write(
+            dir.path().join("agent.yaml"),
+            format!(
+                "memory:\n  pipelineV2:\n    enabled: true\n    paused: {}\n",
+                if paused { "true" } else { "false" }
+            ),
+        )
+        .expect("write config");
+
+        let (pool, _writer) = DbPool::open(&db).expect("open db");
+
+        let mut limits = HashMap::new();
+        limits.insert(
+            "admin".to_string(),
+            RateLimitConfig {
+                window_ms: Some(60_000),
+                max: Some(admin_max),
+            },
+        );
+
+        let manifest = AgentManifest {
+            agent: AgentIdentity {
+                name: "test-agent".to_string(),
+                description: None,
+                created: None,
+                updated: None,
+            },
+            embedding: Some(EmbeddingConfig::default()),
+            memory: Some(MemoryManifestConfig {
+                database: None,
+                vectors: None,
+                session_budget: None,
+                decay_rate: None,
+                pipeline_v2: Some(PipelineV2Config {
+                    paused,
+                    ..Default::default()
+                }),
+            }),
+            auth: Some(ManifestAuthConfig {
+                method: "token".to_string(),
+                chain_id: None,
+                mode: Some(mode_name(mode)),
+                rate_limits: Some(limits),
+            }),
+            ..Default::default()
+        };
+
+        let secret = if mode == AuthMode::Local {
+            None
+        } else {
+            Some(generate_secret())
+        };
+        let embedding = if paused {
+            None
+        } else {
+            manifest
+                .embedding
+                .as_ref()
+                .map(|cfg| signet_pipeline::embedding::from_config(cfg, None))
+        };
+
+        let mut rules = default_limits();
+        if let Some(rule) = rules.get_mut("admin") {
+            rule.max = admin_max;
+        }
+
+        let state = Arc::new(AppState::new(
+            DaemonConfig {
+                base_path: dir.path().to_path_buf(),
+                db_path: db,
+                port: 3850,
+                host: "127.0.0.1".to_string(),
+                bind: Some("127.0.0.1".to_string()),
+                manifest,
+            },
+            pool,
+            embedding,
+            mode,
+            secret.clone(),
+            AuthRateLimiter::from_rules(&rules),
+        ));
+
+        TestState {
+            state,
+            secret,
+            _dir: dir,
+        }
+    }
+
+    fn app(state: Arc<AppState>) -> Router {
+        Router::new()
+            .route("/pause", post(pause))
+            .route("/resume", post(resume))
+            .route("/status", get(status))
+            .with_state(state)
+    }
+
+    async fn call(
+        app: Router,
+        method: Method,
+        path: &str,
+        peer: SocketAddr,
+        token: Option<&str>,
+    ) -> (StatusCode, serde_json::Value) {
+        let mut req = Request::builder()
+            .method(method)
+            .uri(path)
+            .body(Body::empty())
+            .expect("build request");
+        if let Some(token) = token {
+            req.headers_mut().insert(
+                "authorization",
+                format!("Bearer {token}").parse().expect("auth header"),
+            );
+        }
+        req.extensions_mut().insert(ConnectInfo(peer));
+
+        let resp = app.oneshot(req).await.expect("send request");
+        let status = resp.status();
+        let body = to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let json = serde_json::from_slice(&body).expect("json body");
+        (status, json)
+    }
 
     #[test]
     fn finds_fallback_config_files() {
         let dir = tempdir().expect("tempdir");
-        std::fs::write(dir.path().join("AGENT.yaml"), "memory:\n  pipelineV2:\n    paused: true\n")
-            .expect("write config");
+        std::fs::write(
+            dir.path().join("AGENT.yaml"),
+            "memory:\n  pipelineV2:\n    paused: true\n",
+        )
+        .expect("write config");
 
         let file = find_config_file(dir.path()).expect("config file");
 
@@ -398,5 +665,117 @@ mod tests {
         let mode = read_pipeline_mode(dir.path(), None);
 
         assert_eq!(format_pipeline_mode(mode), "paused");
+    }
+
+    #[tokio::test]
+    async fn team_pause_requires_admin_token() {
+        let test = build_state(AuthMode::Team, false, 10);
+        let peer = SocketAddr::from(([10, 0, 0, 8], 9000));
+
+        let (status, body) =
+            call(app(test.state.clone()), Method::POST, "/pause", peer, None).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(body["error"], "authentication required");
+
+        let secret = test.secret.as_ref().expect("team secret");
+        let token = create_token(
+            secret,
+            "agent-1",
+            TokenScope::default(),
+            TokenRole::Agent,
+            3600,
+        );
+        let (status, body) = call(
+            app(test.state.clone()),
+            Method::POST,
+            "/pause",
+            peer,
+            Some(&token),
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert!(
+            body["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("permission")
+        );
+    }
+
+    #[tokio::test]
+    async fn pause_and_resume_flip_live_runtime_state() {
+        let test = build_state(AuthMode::Local, false, 10);
+        let peer = SocketAddr::from(([127, 0, 0, 1], 3850));
+
+        assert!(test.state.embedding.read().await.is_some());
+        assert!(!test.state.pipeline_paused());
+
+        let (status, body) =
+            call(app(test.state.clone()), Method::POST, "/pause", peer, None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["paused"], true);
+        assert_eq!(body["mode"], "paused");
+        assert!(test.state.pipeline_paused());
+        assert!(test.state.embedding.read().await.is_none());
+
+        let (status, body) =
+            call(app(test.state.clone()), Method::GET, "/status", peer, None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["mode"], "paused");
+
+        let (status, body) =
+            call(app(test.state.clone()), Method::POST, "/resume", peer, None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["paused"], false);
+        assert_eq!(body["mode"], "controlled-write");
+        assert!(!test.state.pipeline_paused());
+        assert!(test.state.embedding.read().await.is_some());
+    }
+
+    #[tokio::test]
+    async fn team_pause_rate_limits_admin_requests() {
+        let test = build_state(AuthMode::Team, false, 1);
+        let peer = SocketAddr::from(([10, 0, 0, 9], 9001));
+        let secret = test.secret.as_ref().expect("team secret");
+        let token = create_token(
+            secret,
+            "admin-1",
+            TokenScope::default(),
+            TokenRole::Admin,
+            3600,
+        );
+
+        let (status, _) = call(
+            app(test.state.clone()),
+            Method::POST,
+            "/pause",
+            peer,
+            Some(&token),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+
+        let (status, body) = call(
+            app(test.state.clone()),
+            Method::POST,
+            "/resume",
+            peer,
+            Some(&token),
+        )
+        .await;
+        assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(body["error"], "rate limit exceeded");
+    }
+
+    #[tokio::test]
+    async fn pause_returns_conflict_when_transition_is_active() {
+        let test = build_state(AuthMode::Local, false, 10);
+        let peer = SocketAddr::from(([127, 0, 0, 1], 3850));
+        test.state.pipeline_transition.store(true, Ordering::SeqCst);
+
+        let (status, body) =
+            call(app(test.state.clone()), Method::POST, "/pause", peer, None).await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(body["error"], "Pipeline transition already in progress");
     }
 }

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/pipeline.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/pipeline.rs
@@ -1,10 +1,151 @@
 //! Pipeline status and model management routes.
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use axum::{extract::State, response::Json};
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Json},
+};
+use signet_core::config::PipelineV2Config;
+use serde_yml::{Mapping, Value};
 
 use crate::state::AppState;
+
+const PIPELINE_CONFIG_FILES: [&str; 3] = ["agent.yaml", "AGENT.yaml", "config.yaml"];
+
+#[derive(Clone, Copy)]
+struct PipelineMode {
+    enabled: bool,
+    frozen: bool,
+    paused: bool,
+    shadow: bool,
+}
+
+fn find_config_file(base: &Path) -> Option<PathBuf> {
+    PIPELINE_CONFIG_FILES
+        .iter()
+        .map(|name| base.join(name))
+        .find(|path| path.exists())
+}
+
+fn key(name: &str) -> Value {
+    Value::String(name.to_string())
+}
+
+fn read_mapping<'a>(map: &'a Mapping, name: &str) -> Option<&'a Mapping> {
+    map.get(&key(name)).and_then(Value::as_mapping)
+}
+
+fn read_bool(map: &Mapping, name: &str) -> Option<bool> {
+    map.get(&key(name)).and_then(Value::as_bool)
+}
+
+fn read_pipeline_mode_from_value(
+    value: &Value,
+    fallback: Option<&PipelineV2Config>,
+) -> PipelineMode {
+    let mut mode = PipelineMode {
+        enabled: fallback.map(|cfg| cfg.enabled).unwrap_or(false),
+        paused: fallback.map(|cfg| cfg.paused).unwrap_or(false),
+        frozen: fallback.map(|cfg| cfg.mutations_frozen).unwrap_or(false),
+        shadow: fallback.map(|cfg| cfg.shadow_mode).unwrap_or(false),
+    };
+
+    let Some(root) = value.as_mapping() else {
+        return mode;
+    };
+    let Some(mem) = read_mapping(root, "memory") else {
+        return mode;
+    };
+    let Some(p2) = read_mapping(mem, "pipelineV2") else {
+        return mode;
+    };
+
+    if let Some(enabled) = read_bool(p2, "enabled") {
+        mode.enabled = enabled;
+    }
+    if let Some(paused) = read_bool(p2, "paused") {
+        mode.paused = paused;
+    }
+    if let Some(frozen) = read_bool(p2, "mutationsFrozen") {
+        mode.frozen = frozen;
+    }
+    if let Some(shadow) = read_bool(p2, "shadowMode") {
+        mode.shadow = shadow;
+    }
+
+    mode
+}
+
+fn read_pipeline_mode(base: &Path, fallback: Option<&PipelineV2Config>) -> PipelineMode {
+    let Some(path) = find_config_file(base) else {
+        return read_pipeline_mode_from_value(&Value::Null, fallback);
+    };
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return read_pipeline_mode_from_value(&Value::Null, fallback);
+    };
+    let Ok(value) = serde_yml::from_str::<Value>(&raw) else {
+        return read_pipeline_mode_from_value(&Value::Null, fallback);
+    };
+    read_pipeline_mode_from_value(&value, fallback)
+}
+
+fn format_pipeline_mode(mode: PipelineMode) -> &'static str {
+    if !mode.enabled {
+        return "disabled";
+    }
+    if mode.paused {
+        return "paused";
+    }
+    if mode.frozen {
+        return "frozen";
+    }
+    if mode.shadow {
+        return "shadow";
+    }
+    "controlled-write"
+}
+
+fn set_pipeline_paused(
+    base: &Path,
+    paused: bool,
+    fallback: Option<&PipelineV2Config>,
+) -> Result<(String, bool, PipelineMode), String> {
+    let path = find_config_file(base)
+        .ok_or_else(|| "No Signet config file found. Run `signet setup` first.".to_string())?;
+    let raw = std::fs::read_to_string(&path).map_err(|err| err.to_string())?;
+    let value = serde_yml::from_str::<Value>(&raw).map_err(|err| err.to_string())?;
+
+    let mut root = match value {
+        Value::Mapping(map) => map,
+        _ => Mapping::new(),
+    };
+    let mut mem = match root.remove(&key("memory")) {
+        Some(Value::Mapping(map)) => map,
+        _ => Mapping::new(),
+    };
+    let mut p2 = match mem.remove(&key("pipelineV2")) {
+        Some(Value::Mapping(map)) => map,
+        _ => Mapping::new(),
+    };
+
+    let prev = read_bool(&p2, "paused").unwrap_or(false);
+    p2.insert(key("paused"), Value::Bool(paused));
+    mem.insert(key("pipelineV2"), Value::Mapping(p2));
+    root.insert(key("memory"), Value::Mapping(mem));
+
+    let next = Value::Mapping(root);
+    let body = serde_yml::to_string(&next).map_err(|err| err.to_string())?;
+    std::fs::write(&path, body).map_err(|err| err.to_string())?;
+
+    Ok((
+        path.to_string_lossy().to_string(),
+        prev != paused,
+        read_pipeline_mode_from_value(&next, fallback),
+    ))
+}
 
 /// GET /api/pipeline/status — pipeline worker and queue status.
 pub async fn status(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
@@ -94,13 +235,7 @@ pub async fn status(State(state): State<Arc<AppState>>) -> Json<serde_json::Valu
         .memory
         .as_ref()
         .and_then(|m| m.pipeline_v2.as_ref());
-
-    let mode = match pipeline {
-        Some(p) if p.mutations_frozen => "frozen",
-        Some(p) if p.shadow_mode => "shadow",
-        Some(p) if p.enabled => "controlled-write",
-        _ => "disabled",
-    };
+    let mode = format_pipeline_mode(read_pipeline_mode(state.config.base_path.as_path(), pipeline));
 
     Json(serde_json::json!({
         "queues": queues,
@@ -163,4 +298,105 @@ pub async fn models_by_provider(State(state): State<Arc<AppState>>) -> Json<serd
 pub async fn models_refresh(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
     // TODO: Query Ollama /api/tags and Anthropic for available models
     models(State(state)).await
+}
+
+pub async fn pause(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    toggle_pause(state, true).await
+}
+
+pub async fn resume(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    toggle_pause(state, false).await
+}
+
+async fn toggle_pause(state: Arc<AppState>, paused: bool) -> impl IntoResponse {
+    let base = state.config.base_path.clone();
+    let fallback = state
+        .config
+        .manifest
+        .memory
+        .as_ref()
+        .and_then(|m| m.pipeline_v2.clone());
+
+    let res = tokio::task::spawn_blocking(move || {
+        set_pipeline_paused(base.as_path(), paused, fallback.as_ref())
+    })
+    .await;
+
+    match res {
+        Ok(Ok((file, changed, mode))) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "success": true,
+                "changed": changed,
+                "paused": paused,
+                "file": file,
+                "mode": format_pipeline_mode(mode),
+            })),
+        )
+            .into_response(),
+        Ok(Err(err)) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "success": false,
+                "error": err,
+            })),
+        )
+            .into_response(),
+        Err(err) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "success": false,
+                "error": err.to_string(),
+            })),
+        )
+            .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::{find_config_file, format_pipeline_mode, read_pipeline_mode, set_pipeline_paused};
+
+    #[test]
+    fn finds_fallback_config_files() {
+        let dir = tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("AGENT.yaml"), "memory:\n  pipelineV2:\n    paused: true\n")
+            .expect("write config");
+
+        let file = find_config_file(dir.path()).expect("config file");
+
+        assert!(file.ends_with("AGENT.yaml"));
+    }
+
+    #[test]
+    fn writes_paused_state_and_reports_mode() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("agent.yaml");
+        std::fs::write(&path, "memory:\n  pipelineV2:\n    enabled: true\n").expect("write config");
+
+        let (file, changed, mode) =
+            set_pipeline_paused(dir.path(), true, None).expect("toggle paused");
+        let raw = std::fs::read_to_string(path).expect("read config");
+
+        assert_eq!(file, dir.path().join("agent.yaml").to_string_lossy());
+        assert!(changed);
+        assert_eq!(format_pipeline_mode(mode), "paused");
+        assert!(raw.contains("paused: true"));
+    }
+
+    #[test]
+    fn reads_paused_mode_from_config_file() {
+        let dir = tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("agent.yaml"),
+            "memory:\n  pipelineV2:\n    enabled: true\n    paused: true\n",
+        )
+        .expect("write config");
+
+        let mode = read_pipeline_mode(dir.path(), None);
+
+        assert_eq!(format_pipeline_mode(mode), "paused");
+    }
 }

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/search.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/search.rs
@@ -89,7 +89,8 @@ pub async fn recall(
         .unwrap_or(50_000);
 
     // Embed query if we have a provider
-    let query_vec = if let Some(ref provider) = state.embedding {
+    let provider = state.embedding.read().await.clone();
+    let query_vec = if let Some(provider) = provider {
         provider.embed(&query).await
     } else {
         None

--- a/packages/daemon-rs/crates/signet-daemon/src/service.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/service.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 
 // ---------------------------------------------------------------------------
 // Paths
@@ -15,7 +15,9 @@ fn home() -> PathBuf {
         .or_else(|_| std::env::var("USERPROFILE"))
         .map(PathBuf::from)
         .unwrap_or_else(|_| {
-            eprintln!("warning: neither HOME nor USERPROFILE is set; falling back to current directory");
+            eprintln!(
+                "warning: neither HOME nor USERPROFILE is set; falling back to current directory"
+            );
             PathBuf::from(".")
         })
 }

--- a/packages/daemon-rs/crates/signet-daemon/src/state.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/state.rs
@@ -1,15 +1,25 @@
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use signet_core::config::DaemonConfig;
 use signet_core::db::DbPool;
 use signet_pipeline::embedding::EmbeddingProvider;
 use signet_services::session::{ContinuityTracker, DedupState, SessionTracker};
+use tokio::sync::RwLock;
+
+use crate::auth::rate_limiter::AuthRateLimiter;
+use crate::auth::types::AuthMode;
 
 /// Shared application state passed to all route handlers.
 pub struct AppState {
     pub config: DaemonConfig,
     pub pool: DbPool,
-    pub embedding: Option<Arc<dyn EmbeddingProvider>>,
+    pub embedding: RwLock<Option<Arc<dyn EmbeddingProvider>>>,
+    pub pipeline_paused: AtomicBool,
+    pub pipeline_transition: AtomicBool,
+    pub auth_mode: AuthMode,
+    pub auth_secret: Option<Vec<u8>>,
+    pub auth_admin_limiter: AuthRateLimiter,
     pub sessions: SessionTracker,
     pub continuity: ContinuityTracker,
     pub dedup: DedupState,
@@ -20,14 +30,34 @@ impl AppState {
         config: DaemonConfig,
         pool: DbPool,
         embedding: Option<Arc<dyn EmbeddingProvider>>,
+        auth_mode: AuthMode,
+        auth_secret: Option<Vec<u8>>,
+        auth_admin_limiter: AuthRateLimiter,
     ) -> Self {
+        let paused = config
+            .manifest
+            .memory
+            .as_ref()
+            .and_then(|m| m.pipeline_v2.as_ref())
+            .map(|p| p.paused)
+            .unwrap_or(false);
+
         Self {
             config,
             pool,
-            embedding,
+            embedding: RwLock::new(embedding),
+            pipeline_paused: AtomicBool::new(paused),
+            pipeline_transition: AtomicBool::new(false),
+            auth_mode,
+            auth_secret,
+            auth_admin_limiter,
             sessions: SessionTracker::new(),
             continuity: ContinuityTracker::new(),
             dedup: DedupState::new(),
         }
+    }
+
+    pub fn pipeline_paused(&self) -> bool {
+        self.pipeline_paused.load(Ordering::SeqCst)
     }
 }

--- a/packages/daemon-rs/crates/signet-daemon/tests/contract_replay.rs
+++ b/packages/daemon-rs/crates/signet-daemon/tests/contract_replay.rs
@@ -306,6 +306,19 @@ async fn pipeline_endpoints() {
     assert_eq!(resp.status(), 200);
     let body = server.json(resp).await;
     assert!(body["pending"].is_number() || body["enabled"].is_boolean());
+
+    let resp = server.post("/api/pipeline/pause", json!({})).await;
+    assert_eq!(resp.status(), 200);
+    let body = server.json(resp).await;
+    assert_eq!(body["success"], true);
+    assert_eq!(body["paused"], true);
+    assert_eq!(body["mode"], "paused");
+
+    let resp = server.post("/api/pipeline/resume", json!({})).await;
+    assert_eq!(resp.status(), 200);
+    let body = server.json(resp).await;
+    assert_eq!(body["success"], true);
+    assert_eq!(body["paused"], false);
 }
 
 #[tokio::test]

--- a/packages/daemon-rs/crates/signet-daemon/tests/contract_replay.rs
+++ b/packages/daemon-rs/crates/signet-daemon/tests/contract_replay.rs
@@ -305,7 +305,8 @@ async fn pipeline_endpoints() {
     let resp = server.get("/api/pipeline/status").await;
     assert_eq!(resp.status(), 200);
     let body = server.json(resp).await;
-    assert!(body["pending"].is_number() || body["enabled"].is_boolean());
+    assert!(body["queues"].is_object());
+    assert!(body["mode"].is_string());
 
     let resp = server.post("/api/pipeline/pause", json!({})).await;
     assert_eq!(resp.status(), 200);

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -37,7 +37,9 @@ import {
 	networkModeFromBindHost,
 	parseSimpleYaml,
 	readNetworkMode,
+	readPipelinePauseState,
 	resolveNetworkBinding,
+	setPipelinePaused,
 	stripSignetBlock,
 	vectorSearch,
 } from "@signet/core";
@@ -120,7 +122,7 @@ import {
 } from "./knowledge-graph";
 import { closeLlmProvider, getLlmProvider, initLlmProvider } from "./llm";
 import { type LogEntry, logger } from "./logger";
-import { type EmbeddingConfig, loadMemoryConfig } from "./memory-config";
+import { type EmbeddingConfig, type ResolvedMemoryConfig, loadMemoryConfig } from "./memory-config";
 import { walkImpact } from "./graph-impact";
 import { buildMemoryTimeline } from "./memory-timeline";
 import { type RecallParams, hybridRecall } from "./memory-search";
@@ -131,11 +133,11 @@ import {
 	enqueueDocumentIngestJob,
 	enqueueExtractionJob,
 	getPipelineWorkerStatus,
+	ensureRetentionWorker,
 	getSynthesisWorker,
 	nudgeExtractionWorker,
 	readLastSynthesisTime,
 	startPipeline,
-	startRetentionWorker,
 	stopPipeline,
 } from "./pipeline";
 import { clusterEntities } from "./pipeline/community-detection";
@@ -403,7 +405,22 @@ const BIND_HOST = normalizeLoopbackHost(readEnvTrimmed("SIGNET_BIND") ?? NET.bin
 const NETWORK_MODE = networkModeFromBindHost(BIND_HOST);
 const INTERNAL_SELF_HOST = BIND_HOST === "0.0.0.0" || BIND_HOST === "::" ? "127.0.0.1" : BIND_HOST;
 
-type RuntimeProviderName = "ollama" | "claude-code" | "opencode" | "codex" | "anthropic";
+type RuntimeProviderName =
+	| "none"
+	| "ollama"
+	| "claude-code"
+	| "opencode"
+	| "codex"
+	| "anthropic"
+	| "openrouter";
+
+type RuntimeSynthesisProviderName =
+	| "none"
+	| "ollama"
+	| "claude-code"
+	| "opencode"
+	| "anthropic"
+	| "openrouter";
 
 interface ProviderRuntimeResolution {
 	extraction: {
@@ -413,8 +430,8 @@ interface ProviderRuntimeResolution {
 	};
 	synthesis: {
 		configured: string | null;
-		resolved: "ollama" | "claude-code" | "opencode" | "anthropic" | null;
-		effective: "ollama" | "claude-code" | "opencode" | "anthropic" | null;
+		resolved: RuntimeSynthesisProviderName | null;
+		effective: RuntimeSynthesisProviderName | null;
 	};
 }
 
@@ -442,6 +459,8 @@ let embeddingTrackerHandle: EmbeddingTrackerHandle | null = null;
 let predictorClientRef: PredictorClient | null = null;
 let shadowProcess: ChildProcess | null = null;
 let skillReconcilerHandle: ReconcilerHandle | null = null;
+let structuralBackfillTimer: ReturnType<typeof setTimeout> | null = null;
+let pipelineTransition = false;
 let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
 let checkpointPruneTimer: ReturnType<typeof setInterval> | undefined;
 let httpServer: ReturnType<typeof serve> | null = null;
@@ -7466,13 +7485,7 @@ app.get("/api/pipeline/status", (c) => {
 	const diagnostics = getCachedDiagnosticsReport();
 
 	const pipelineV2 = cfg.pipelineV2;
-	const mode = !pipelineV2.enabled
-		? "disabled"
-		: pipelineV2.mutationsFrozen
-			? "frozen"
-			: pipelineV2.shadowMode
-				? "shadow"
-				: "controlled-write";
+	const mode = readPipelineMode(pipelineV2);
 
 	// Predictor sidecar snapshot for pipeline overview
 	const predictorHealth = diagnostics.predictor;
@@ -7500,8 +7513,63 @@ app.get("/api/pipeline/status", (c) => {
 	});
 });
 
+const pipelineAdminGuard = async (c: Context, next: () => Promise<void>): Promise<Response | void> => {
+	const perm = requirePermission("admin", authConfig);
+	const rate = requireRateLimit("admin", authAdminLimiter, authConfig);
+	return perm(c, async () => rate(c, next));
+};
+
+async function togglePipelinePause(c: Context, paused: boolean): Promise<Response> {
+	if (shuttingDown) {
+		return c.json({ error: "Daemon is shutting down" }, 503);
+	}
+	if (pipelineTransition) {
+		return c.json({ error: "Pipeline transition already in progress" }, 409);
+	}
+
+	const prev = readPipelinePauseState(AGENTS_DIR);
+	if (!prev.exists) {
+		return c.json({ error: "No Signet config file found" }, 404);
+	}
+
+	pipelineTransition = true;
+	try {
+		const changed = prev.paused !== paused;
+		const next = changed ? setPipelinePaused(AGENTS_DIR, paused) : prev;
+		if (changed) {
+			await restartPipelineRuntime(loadMemoryConfig(AGENTS_DIR), telemetryRef);
+		}
+		const liveCfg = loadMemoryConfig(AGENTS_DIR);
+		return c.json({
+			success: true,
+			changed,
+			paused: next.paused,
+			file: next.file,
+			mode: readPipelineMode(liveCfg.pipelineV2),
+		});
+	} catch (err) {
+		logger.error("pipeline", paused ? "Failed to pause pipeline" : "Failed to resume pipeline", err);
+		return c.json(
+			{ error: err instanceof Error ? err.message : String(err) },
+			500,
+		);
+	} finally {
+		pipelineTransition = false;
+	}
+}
+
+app.use("/api/pipeline/pause", pipelineAdminGuard);
+app.use("/api/pipeline/resume", pipelineAdminGuard);
 app.use("/api/pipeline/nudge", async (c, next) => {
 	return requirePermission("admin", authConfig)(c, next);
+});
+
+app.post("/api/pipeline/pause", (c) => {
+	return togglePipelinePause(c, true);
+});
+
+app.post("/api/pipeline/resume", (c) => {
+	return togglePipelinePause(c, false);
 });
 
 app.post("/api/pipeline/nudge", (c) => {
@@ -10789,42 +10857,6 @@ async function cleanup() {
 		telemetryRef = undefined;
 	}
 
-	// Stop skill reconciler
-	if (skillReconcilerHandle) {
-		skillReconcilerHandle.stop();
-		skillReconcilerHandle = null;
-	}
-
-	// Kill shadow daemon if running
-	if (shadowProcess) {
-		try {
-			shadowProcess.kill();
-		} catch {
-			// best-effort
-		}
-		shadowProcess = null;
-	}
-
-	// Stop predictor sidecar before pipeline/DB teardown
-	if (predictorClientRef) {
-		try {
-			await predictorClientRef.stop();
-		} catch {
-			// best-effort
-		}
-		predictorClientRef = null;
-	}
-
-	// Stop embedding tracker before pipeline/DB teardown
-	if (embeddingTrackerHandle) {
-		try {
-			await embeddingTrackerHandle.stop();
-		} catch {
-			// best-effort
-		}
-		embeddingTrackerHandle = null;
-	}
-
 	// Flush any pending checkpoint writes before closing DB
 	try {
 		flushPendingCheckpoints();
@@ -10832,12 +10864,7 @@ async function cleanup() {
 		// best-effort
 	}
 
-	// Drain pipeline before closing DB so in-flight jobs finish writes
-	try {
-		await stopPipeline();
-	} catch {
-		// best-effort
-	}
+	await stopPipelineRuntime();
 
 	// Shut down native embedding WASM runtime
 	try {
@@ -10846,12 +10873,6 @@ async function cleanup() {
 	} catch {
 		// best-effort — module may not have been loaded
 	}
-
-	closeLlmProvider();
-	closeSynthesisProvider();
-	closeWidgetProvider();
-	stopOpenCodeServer();
-	stopModelRegistry();
 
 	// ------------------------------------------------------------------
 	// Phase 2: Release all session claims and presence so other daemons
@@ -10959,48 +10980,78 @@ function syncAgentRoster(agentsDir: string): void {
 	logger.info("daemon", "Agent roster synced", { count: roster.length });
 }
 
-async function main() {
-	logger.info("daemon", "Signet Daemon starting");
-	logger.info("daemon", "Agents directory", { path: AGENTS_DIR });
-	logger.info("daemon", "Network configured", { port: PORT, host: HOST, bindHost: BIND_HOST });
 
-	// Ensure daemon directory exists
-	mkdirSync(DAEMON_DIR, { recursive: true });
-	mkdirSync(LOG_DIR, { recursive: true });
+function readPipelineMode(cfg: ResolvedMemoryConfig["pipelineV2"]): string {
+	if (!cfg.enabled) return "disabled";
+	if (cfg.paused) return "paused";
+	if (cfg.mutationsFrozen) return "frozen";
+	if (cfg.shadowMode) return "shadow";
+	return "controlled-write";
+}
 
-	// Initialise singleton DB accessor (opens write connection, sets pragmas,
-	// runs migrations). This is the sole schema authority.
-	initDbAccessor(MEMORY_DB);
+function clearStructuralBackfillTimer(): void {
+	if (!structuralBackfillTimer) return;
+	clearTimeout(structuralBackfillTimer);
+	structuralBackfillTimer = null;
+}
 
-	// Sync agent roster from manifest into the agents table.
-	syncAgentRoster(AGENTS_DIR);
+async function stopPipelineRuntime(): Promise<void> {
+	clearStructuralBackfillTimer();
 
-	// Migrations may have created traversal tables — clear the cache
-	invalidateTraversalCache();
-
-	// Write PID file
-	writeFileSync(PID_FILE, process.pid.toString());
-	logger.info("daemon", "Process ID", { pid: process.pid });
-
-	// Migrate config defaults before watcher starts (one-time, guarded by configVersion)
-	try {
-		migrateConfig(AGENTS_DIR);
-	} catch (err) {
-		logger.warn("config-migration", "Config migration failed; continuing startup", {
-			error: err instanceof Error ? err.message : String(err),
-		});
+	if (skillReconcilerHandle) {
+		skillReconcilerHandle.stop();
+		skillReconcilerHandle = null;
 	}
 
-	// Start file watcher
-	startFileWatcher();
-	logger.info("watcher", "File watcher started");
+	if (shadowProcess) {
+		try {
+			shadowProcess.kill();
+		} catch {
+			// best-effort
+		}
+		shadowProcess = null;
+	}
 
-	// Ensure SIGNET-ARCHITECTURE.md exists on startup (file watcher uses
-	// ignoreInitial:true so it won't recreate missing files on its own)
-	ensureArchitectureDoc();
+	if (predictorClientRef) {
+		try {
+			await predictorClientRef.stop();
+		} catch {
+			// best-effort
+		}
+		predictorClientRef = null;
+	}
 
-	// Load config and log resolved embedding settings for diagnostics
-	const memoryCfg = loadMemoryConfig(AGENTS_DIR);
+	if (embeddingTrackerHandle) {
+		try {
+			await embeddingTrackerHandle.stop();
+		} catch {
+			// best-effort
+		}
+		embeddingTrackerHandle = null;
+	}
+
+	try {
+		await stopPipeline();
+	} catch {
+		// best-effort
+	}
+
+	closeLlmProvider();
+	closeSynthesisProvider();
+	closeWidgetProvider();
+	stopOpenCodeServer();
+	stopModelRegistry();
+	invalidateDiagnosticsCache();
+}
+
+async function restartPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?: TelemetryCollector): Promise<void> {
+	await stopPipelineRuntime();
+	await startPipelineRuntime(memoryCfg, telemetry);
+}
+
+async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?: TelemetryCollector): Promise<void> {
+	const pipelinePaused = memoryCfg.pipelineV2.paused;
+	clearStructuralBackfillTimer();
 	logger.info("config", "Resolved embedding config", {
 		provider: memoryCfg.embedding.provider,
 		model: memoryCfg.embedding.model,
@@ -11073,7 +11124,10 @@ async function main() {
 	);
 	const ollamaFallbackMaxContextTokens = resolveDefaultOllamaFallbackMaxContextTokens();
 	const extractionOpenCodeShouldManage = isManagedOpenCodeLocalEndpoint(extractionOpenCodeBaseUrl);
-	if (effectiveExtractionProvider === "none") {
+	if (pipelinePaused) {
+		logger.info("config", "Pipeline paused; extraction provider startup deferred");
+		effectiveExtractionProvider = "none";
+	} else if (effectiveExtractionProvider === "none") {
 		logger.info("config", "Extraction provider set to 'none', pipeline LLM disabled");
 	} else if (effectiveExtractionProvider === "opencode") {
 		if (extractionOpenCodeShouldManage) {
@@ -11272,7 +11326,7 @@ async function main() {
 	}
 
 	// Initialize model registry for dynamic model discovery
-	if (memoryCfg.pipelineV2.modelRegistry.enabled) {
+	if (memoryCfg.pipelineV2.modelRegistry.enabled && !pipelinePaused) {
 		const registryAnthropicApiKey = anthropicApiKey ?? (await getKey("ANTHROPIC_API_KEY"));
 		const registryOpenRouterApiKey = openRouterApiKey ?? (await getKey("OPENROUTER_API_KEY"));
 		initModelRegistry(
@@ -11286,7 +11340,14 @@ async function main() {
 
 	// Create synthesis provider — separate from extraction because synthesis
 	// needs a smarter model that can reason across long context
-	if (memoryCfg.pipelineV2.synthesis.provider === "none") {
+	if (pipelinePaused) {
+		providerRuntimeResolution.synthesis = {
+			configured: providerHints.synthesis,
+			resolved: memoryCfg.pipelineV2.synthesis.enabled ? memoryCfg.pipelineV2.synthesis.provider : null,
+			effective: null,
+		};
+		logger.info("config", "Pipeline paused; synthesis provider startup deferred");
+	} else if (memoryCfg.pipelineV2.synthesis.provider === "none") {
 		logger.info("config", "Synthesis provider set to 'none', synthesis disabled");
 	} else if (memoryCfg.pipelineV2.synthesis.enabled) {
 		let effectiveSynthesisProvider = memoryCfg.pipelineV2.synthesis.provider;
@@ -11437,57 +11498,9 @@ async function main() {
 		logger.info("config", "Synthesis disabled");
 	}
 
-	// Telemetry collector (opt-in, anonymous)
-	let telemetryCollector: TelemetryCollector | undefined;
-	if (memoryCfg.pipelineV2.telemetryEnabled) {
-		// Resolve PostHog API key: secrets first, then inline config
-		const secretKey = !memoryCfg.pipelineV2.telemetry.posthogApiKey
-			? (getSecret("POSTHOG_API_KEY") ?? "")
-			: memoryCfg.pipelineV2.telemetry.posthogApiKey;
-		const resolvedTelemetryCfg = {
-			...memoryCfg.pipelineV2.telemetry,
-			posthogApiKey: secretKey,
-		};
-		telemetryCollector = createTelemetryCollector(getDbAccessor(), resolvedTelemetryCfg, CURRENT_VERSION);
-		telemetryCollector.start();
-		telemetryRef = telemetryCollector;
-
-		// Heartbeat: record daemon stats every 5 minutes
-		const daemonStartTime = Date.now();
-		heartbeatTimer = setInterval(
-			() => {
-				if (!telemetryRef) return;
-				try {
-					const memoryCount = getDbAccessor().withReadDb((db) => {
-						const row = db
-							.prepare("SELECT COUNT(*) as cnt FROM memories WHERE is_deleted = 0 OR is_deleted IS NULL")
-							.get() as { cnt: number } | undefined;
-						return row?.cnt ?? 0;
-					});
-					const connectors = listConnectors();
-					telemetryRef.record("daemon.heartbeat", {
-						uptimeMs: Date.now() - daemonStartTime,
-						memoryCount,
-						connectorsActive: connectors.filter((cn) => cn.status === "active").length,
-						pipelineMode: memoryCfg.pipelineV2.enabled
-							? memoryCfg.pipelineV2.shadowMode
-								? "shadow"
-								: "controlled-write"
-							: "disabled",
-						extractionProvider: memoryCfg.pipelineV2.extraction.provider,
-						embeddingProvider: memoryCfg.embedding.provider,
-					});
-				} catch {
-					// best effort
-				}
-			},
-			5 * 60 * 1000,
-		);
-	}
-
 	// Start extraction pipeline only when explicitly enabled and an LLM is available.
 	// shadowMode controls behavior inside the enabled pipeline.
-	if (memoryCfg.pipelineV2.enabled && effectiveExtractionProvider !== "none") {
+	if (memoryCfg.pipelineV2.enabled && !pipelinePaused && effectiveExtractionProvider !== "none") {
 		startPipeline(
 			getDbAccessor(),
 			memoryCfg.pipelineV2,
@@ -11496,16 +11509,16 @@ async function main() {
 			memoryCfg.search,
 			providerTracker,
 			analyticsCollector,
-			telemetryCollector,
+			telemetry,
 		);
 	} else {
 		// Retention worker runs unconditionally — cleans up tombstones,
 		// expired history, and dead jobs even without the full pipeline.
-		startRetentionWorker(getDbAccessor(), DEFAULT_RETENTION);
+		ensureRetentionWorker(getDbAccessor(), DEFAULT_RETENTION);
 	}
 
 	// Start embedding tracker if provider is configured and tracker enabled
-	if (memoryCfg.embedding.provider !== "none" && memoryCfg.pipelineV2.embeddingTracker.enabled) {
+	if (memoryCfg.embedding.provider !== "none" && memoryCfg.pipelineV2.embeddingTracker.enabled && !pipelinePaused) {
 		embeddingTrackerHandle = startEmbeddingTracker(
 			getDbAccessor(),
 			memoryCfg.embedding,
@@ -11518,13 +11531,14 @@ async function main() {
 	// One-time structural backfill: populate entity_aspects/attributes for
 	// existing entities that predate the knowledge architecture migrations.
 	// Runs in the background, rate-limited, so it doesn't block startup.
-	if (memoryCfg.pipelineV2.graph.enabled && memoryCfg.pipelineV2.structural.enabled) {
+	if (memoryCfg.pipelineV2.graph.enabled && memoryCfg.pipelineV2.structural.enabled && !pipelinePaused) {
 		const backfillCtx: RepairContext = {
 			reason: "post-upgrade structural backfill",
 			actor: "daemon",
 			actorType: "daemon",
 		};
-		setTimeout(() => {
+		structuralBackfillTimer = setTimeout(() => {
+			structuralBackfillTimer = null;
 			try {
 				const result = structuralBackfill(getDbAccessor(), memoryCfg.pipelineV2, backfillCtx, repairLimiter, {
 					batchSize: 50,
@@ -11540,18 +11554,17 @@ async function main() {
 					error: err instanceof Error ? err.message : String(err),
 				});
 			}
-		}, 10_000); // 10s delay — let the pipeline warm up first
+		}, 10_000);
 	}
 
 	// Spawn predictor sidecar if enabled
-	if (memoryCfg.pipelineV2.predictor?.enabled) {
+	if (memoryCfg.pipelineV2.predictor?.enabled && !pipelinePaused) {
 		const predictorCfg = memoryCfg.pipelineV2.predictor;
 		try {
 			const client = createPredictorClient(predictorCfg, "default", memoryCfg.embedding.dimensions);
 			await client.start();
 			predictorClientRef = client;
 			logger.info("predictor", "Predictor sidecar started");
-
 		} catch (err) {
 			// Fail open: predictor is optional
 			logger.warn("predictor", "Failed to start predictor sidecar (non-fatal)", {
@@ -11581,7 +11594,7 @@ async function main() {
 	}
 
 	// Start skill reconciler if procedural memory is enabled
-	if (memoryCfg.pipelineV2.procedural.enabled) {
+	if (memoryCfg.pipelineV2.procedural.enabled && !pipelinePaused) {
 		skillReconcilerHandle = startReconciler({
 			accessor: getDbAccessor(),
 			pipelineConfig: memoryCfg.pipelineV2,
@@ -11597,6 +11610,98 @@ async function main() {
 			agentsDir: AGENTS_DIR,
 		});
 	}
+
+	invalidateDiagnosticsCache();
+}
+
+async function main() {
+	logger.info("daemon", "Signet Daemon starting");
+	logger.info("daemon", "Agents directory", { path: AGENTS_DIR });
+	logger.info("daemon", "Network configured", { port: PORT, host: HOST, bindHost: BIND_HOST });
+
+	// Ensure daemon directory exists
+	mkdirSync(DAEMON_DIR, { recursive: true });
+	mkdirSync(LOG_DIR, { recursive: true });
+
+	// Initialise singleton DB accessor (opens write connection, sets pragmas,
+	// runs migrations). This is the sole schema authority.
+	initDbAccessor(MEMORY_DB);
+
+	// Sync agent roster from manifest into the agents table.
+	syncAgentRoster(AGENTS_DIR);
+
+	// Migrations may have created traversal tables — clear the cache
+	invalidateTraversalCache();
+
+	// Write PID file
+	writeFileSync(PID_FILE, process.pid.toString());
+	logger.info("daemon", "Process ID", { pid: process.pid });
+
+	// Migrate config defaults before watcher starts (one-time, guarded by configVersion)
+	try {
+		migrateConfig(AGENTS_DIR);
+	} catch (err) {
+		logger.warn("config-migration", "Config migration failed; continuing startup", {
+			error: err instanceof Error ? err.message : String(err),
+		});
+	}
+
+	// Start file watcher
+	startFileWatcher();
+	logger.info("watcher", "File watcher started");
+
+	// Ensure SIGNET-ARCHITECTURE.md exists on startup (file watcher uses
+	// ignoreInitial:true so it won't recreate missing files on its own)
+	ensureArchitectureDoc();
+
+	// Load config and initialize telemetry before starting runtime.
+	const memoryCfg = loadMemoryConfig(AGENTS_DIR);
+	let telemetryCollector: TelemetryCollector | undefined;
+	if (memoryCfg.pipelineV2.telemetryEnabled) {
+		let posthogApiKey = memoryCfg.pipelineV2.telemetry.posthogApiKey;
+		if (!posthogApiKey) {
+			try {
+				posthogApiKey = await getSecret("POSTHOG_API_KEY");
+			} catch {
+				posthogApiKey = "";
+			}
+		}
+		const resolvedTelemetryCfg = {
+			...memoryCfg.pipelineV2.telemetry,
+			posthogApiKey,
+		};
+		telemetryCollector = createTelemetryCollector(getDbAccessor(), resolvedTelemetryCfg, CURRENT_VERSION);
+		telemetryCollector.start();
+		telemetryRef = telemetryCollector;
+
+		// Heartbeat: record daemon stats every 5 minutes using live config.
+		const daemonStartTime = Date.now();
+		heartbeatTimer = setInterval(() => {
+			if (!telemetryRef) return;
+			try {
+				const liveCfg = loadMemoryConfig(AGENTS_DIR);
+				const memoryCount = getDbAccessor().withReadDb((db) => {
+					const row = db
+						.prepare("SELECT COUNT(*) as cnt FROM memories WHERE is_deleted = 0 OR is_deleted IS NULL")
+						.get() as { cnt: number } | undefined;
+					return row?.cnt ?? 0;
+				});
+				const connectors = listConnectors();
+				telemetryRef.record("daemon.heartbeat", {
+					uptimeMs: Date.now() - daemonStartTime,
+					memoryCount,
+					connectorsActive: connectors.filter((cn) => cn.status === "active").length,
+					pipelineMode: readPipelineMode(liveCfg.pipelineV2),
+					extractionProvider: liveCfg.pipelineV2.extraction.provider,
+					embeddingProvider: liveCfg.embedding.provider,
+				});
+			} catch {
+				// best-effort
+			}
+		}, 5 * 60 * 1000);
+	}
+
+	await startPipelineRuntime(memoryCfg, telemetryCollector);
 
 	// Initialize checkpoint flush queue for continuity protocol
 	initCheckpointFlush(getDbAccessor());

--- a/packages/daemon/src/memory-config.test.ts
+++ b/packages/daemon/src/memory-config.test.ts
@@ -2,11 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-	DEFAULT_PIPELINE_V2,
-	loadMemoryConfig,
-	loadPipelineConfig,
-} from "./memory-config";
+import { DEFAULT_PIPELINE_V2, loadMemoryConfig, loadPipelineConfig } from "./memory-config";
 
 const tmpDirs: string[] = [];
 
@@ -106,10 +102,7 @@ describe("loadMemoryConfig", () => {
 
 	it("defaults ollama base_url to localhost:11434 when not specified", () => {
 		const agentsDir = makeTempAgentsDir();
-		writeFileSync(
-			join(agentsDir, "agent.yaml"),
-			"embedding:\n  provider: ollama\n  model: nomic-embed-text\n",
-		);
+		writeFileSync(join(agentsDir, "agent.yaml"), "embedding:\n  provider: ollama\n  model: nomic-embed-text\n");
 		const cfg = loadMemoryConfig(agentsDir);
 		expect(cfg.embedding.provider).toBe("ollama");
 		expect(cfg.embedding.base_url).toBe("http://localhost:11434");
@@ -141,7 +134,7 @@ describe("loadMemoryConfig", () => {
 		const agentsDir = makeTempAgentsDir();
 		writeFileSync(
 			join(agentsDir, "agent.yaml"),
-			"embedding:\n  provider: ollama\n  model: nomic-embed-text\n  base_url: \"\"\n",
+			'embedding:\n  provider: ollama\n  model: nomic-embed-text\n  base_url: ""\n',
 		);
 		const cfg = loadMemoryConfig(agentsDir);
 		expect(cfg.embedding.provider).toBe("ollama");
@@ -150,10 +143,7 @@ describe("loadMemoryConfig", () => {
 
 	it("defaults openai base_url to the official API endpoint when not specified", () => {
 		const agentsDir = makeTempAgentsDir();
-		writeFileSync(
-			join(agentsDir, "agent.yaml"),
-			"embedding:\n  provider: openai\n  model: text-embedding-3-small\n",
-		);
+		writeFileSync(join(agentsDir, "agent.yaml"), "embedding:\n  provider: openai\n  model: text-embedding-3-small\n");
 		const cfg = loadMemoryConfig(agentsDir);
 		expect(cfg.embedding.provider).toBe("openai");
 		expect(cfg.embedding.base_url).toBe("https://api.openai.com/v1");
@@ -517,13 +507,9 @@ describe("loadPipelineConfig", () => {
 
 		expect(result.worker.pollMs).toBe(DEFAULT_PIPELINE_V2.worker.pollMs);
 		expect(result.worker.maxRetries).toBe(DEFAULT_PIPELINE_V2.worker.maxRetries);
-		expect(result.extraction.timeout).toBe(
-			DEFAULT_PIPELINE_V2.extraction.timeout,
-		);
+		expect(result.extraction.timeout).toBe(DEFAULT_PIPELINE_V2.extraction.timeout);
 		expect(result.worker.leaseTimeoutMs).toBe(DEFAULT_PIPELINE_V2.worker.leaseTimeoutMs);
-		expect(result.extraction.minConfidence).toBe(
-			DEFAULT_PIPELINE_V2.extraction.minConfidence,
-		);
+		expect(result.extraction.minConfidence).toBe(DEFAULT_PIPELINE_V2.extraction.minConfidence);
 	});
 
 	it("accepts valid numeric values within range (flat keys)", () => {
@@ -626,6 +612,28 @@ describe("loadPipelineConfig", () => {
 		});
 
 		expect(result.autonomous.maintenanceMode).toBe(DEFAULT_PIPELINE_V2.autonomous.maintenanceMode);
+	});
+
+	it("defaults paused to false when absent", () => {
+		const result = loadPipelineConfig({
+			memory: { pipelineV2: { enabled: true } },
+		});
+
+		expect(result.paused).toBe(false);
+	});
+
+	it("loads explicit paused state", () => {
+		const result = loadPipelineConfig({
+			memory: {
+				pipelineV2: {
+					enabled: true,
+					paused: true,
+				},
+			},
+		});
+
+		expect(result.enabled).toBe(true);
+		expect(result.paused).toBe(true);
 	});
 
 	it("preserves explicit false values over defaults", () => {

--- a/packages/daemon/src/memory-config.ts
+++ b/packages/daemon/src/memory-config.ts
@@ -30,6 +30,7 @@ export type { PipelineFlag, PipelineV2Config };
 
 export const DEFAULT_PIPELINE_V2: PipelineV2Config = {
 	enabled: true,
+	paused: false,
 	shadowMode: false,
 	nativeShadowEnabled: false,
 	mutationsFrozen: false,
@@ -333,6 +334,7 @@ export function loadPipelineConfig(
 
 	return {
 		enabled: typeof raw.enabled === "boolean" ? raw.enabled : d.enabled,
+		paused: typeof raw.paused === "boolean" ? raw.paused : d.paused,
 		shadowMode: typeof raw.shadowMode === "boolean" ? raw.shadowMode : d.shadowMode,
 		nativeShadowEnabled: typeof raw.nativeShadowEnabled === "boolean" ? raw.nativeShadowEnabled : d.nativeShadowEnabled,
 		mutationsFrozen:

--- a/packages/daemon/src/pipeline/index.ts
+++ b/packages/daemon/src/pipeline/index.ts
@@ -10,15 +10,15 @@ import { logger } from "../logger";
 import type { EmbeddingConfig, PipelineV2Config } from "../memory-config";
 import type { TelemetryCollector } from "../telemetry";
 import type { DecisionConfig } from "./decision";
+import { type DependencySynthesisHandle, startDependencySynthesisWorker } from "./dependency-synthesis";
 import { type DocumentWorkerHandle, startDocumentWorker } from "./document-worker";
 import { type MaintenanceHandle, startMaintenanceWorker } from "./maintenance-worker";
+import { type HintsWorkerHandle, startHintsWorker } from "./prospective-index";
 import { DEFAULT_RETENTION, type RetentionHandle, startRetentionWorker } from "./retention-worker";
-import { type SummaryWorkerHandle, startSummaryWorker } from "./summary-worker";
 import { type StructuralClassifyHandle, startStructuralClassifyWorker } from "./structural-classify";
 import { type StructuralDependencyHandle, startStructuralDependencyWorker } from "./structural-dependency";
-import { type DependencySynthesisHandle, startDependencySynthesisWorker } from "./dependency-synthesis";
+import { type SummaryWorkerHandle, startSummaryWorker } from "./summary-worker";
 import { type SynthesisWorkerHandle, startSynthesisWorker } from "./synthesis-worker";
-import { type HintsWorkerHandle, startHintsWorker } from "./prospective-index";
 import { type WorkerHandle, type WorkerStats, startWorker } from "./worker";
 
 export { enqueueExtractionJob } from "./worker";
@@ -60,10 +60,7 @@ let dependencySynthesisHandle: DependencySynthesisHandle | null = null;
 let hintsWorkerHandle: HintsWorkerHandle | null = null;
 
 /** Snapshot of running state for each worker — used by /api/pipeline/status */
-export function getPipelineWorkerStatus(): Record<
-	string,
-	{ running: boolean; stats?: WorkerStats }
-> {
+export function getPipelineWorkerStatus(): Record<string, { running: boolean; stats?: WorkerStats }> {
 	return {
 		extraction: {
 			running: workerHandle !== null,
@@ -88,6 +85,11 @@ export function nudgeExtractionWorker(): boolean {
 	return true;
 }
 
+export function ensureRetentionWorker(accessor: DbAccessor, cfg: RetentionConfig = DEFAULT_RETENTION): void {
+	if (retentionHandle) return;
+	retentionHandle = startRetentionWorker(accessor, cfg);
+}
+
 // ---------------------------------------------------------------------------
 // Start / Stop
 // ---------------------------------------------------------------------------
@@ -110,6 +112,10 @@ export function startPipeline(
 		logger.info("pipeline", "Pipeline disabled; worker start skipped");
 		return;
 	}
+	if (pipelineCfg.paused) {
+		logger.info("pipeline", "Pipeline paused; worker start skipped");
+		return;
+	}
 
 	const provider = getLlmProvider();
 
@@ -124,9 +130,7 @@ export function startPipeline(
 
 	// Retention worker also managed here when pipeline is active;
 	// standalone retention is started separately in main() for non-pipeline users.
-	if (!retentionHandle) {
-		retentionHandle = startRetentionWorker(accessor, DEFAULT_RETENTION);
-	}
+	ensureRetentionWorker(accessor, DEFAULT_RETENTION);
 
 	// Maintenance worker (F3) — runs alongside retention
 	if (!maintenanceHandle && providerTracker) {
@@ -156,11 +160,7 @@ export function startPipeline(
 	// Structural assignment workers (KA-2) — classify aspects and extract
 	// dependencies from entity-linked facts. Gate on both structural.enabled
 	// and graph.enabled since they depend on the entity graph.
-	if (
-		pipelineCfg.structural.enabled &&
-		pipelineCfg.graph.enabled &&
-		!pipelineCfg.mutationsFrozen
-	) {
+	if (pipelineCfg.structural.enabled && pipelineCfg.graph.enabled && !pipelineCfg.mutationsFrozen) {
 		if (!structuralClassifyHandle) {
 			structuralClassifyHandle = startStructuralClassifyWorker({
 				accessor,


### PR DESCRIPTION
## Summary
- add live daemon pause/resume endpoints and shared persisted pause config handling
- add CLI pause/resume commands with live API preference, restart fallback, and local Ollama unload on pause
- add dashboard pause/resume controls plus targeted dashboard typecheck cleanup so `bun run check` is green again
- update API/spec docs and add regression coverage for CLI, config, and dashboard pause flows

## Testing
- bun test packages/cli/src/features/pipeline-pause.test.ts packages/cli/src/features/daemon.test.ts packages/daemon/src/memory-config.test.ts packages/cli/dashboard/src/lib/api.pipeline.test.js
- cd packages/core && bun run build
- cd packages/daemon && bun run build
- cd packages/cli/dashboard && bun run check
- cd packages/cli/dashboard && bun run build
