### PR TITLE
fix(pipeline) harden extraction provider defaults and warnings

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -140,6 +140,14 @@ Non-interactive behavior:
 - extraction provider must be explicitly provided via `--extraction-provider`
 - git: enabled unless `--skip-git` is passed
 
+Extraction safety note:
+
+- intended usage is `claude-code` on Haiku, `codex` on GPT Mini with a
+  Pro/Max subscription, or local `ollama` with at least `qwen3:4b`
+- set `--extraction-provider none` on a VPS if you do not want
+  background extraction
+- remote API extraction can create extreme usage fees fast
+
 Wizard steps:
 
 1. **Agent Name** - What to call your agent

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -108,8 +108,8 @@ memory:
     enabled: true
     shadowMode: false
     extraction:
-      provider: claude-code
-      model: haiku
+      provider: ollama
+      model: qwen3:4b
     graph:
       enabled: true
     autonomous:
@@ -300,17 +300,31 @@ Controls the LLM-based extraction stage. Supports multiple providers.
 
 | Field | Default | Range | Description |
 |-------|---------|-------|-------------|
-| `provider` | `"claude-code"` | — | `"ollama"`, `"openai"`, `"claude-code"`, `"opencode"`, `"codex"`, or `"native"` |
-| `model` | `"haiku"` | — | Model name for the configured provider |
+| `provider` | `"ollama"` | — | `"none"`, `"ollama"`, `"claude-code"`, `"opencode"`, `"codex"`, `"anthropic"`, or `"openrouter"` |
+| `model` | `"qwen3:4b"` | — | Model name for the configured provider |
 | `timeout` | `45000` | 5000-300000 ms | Extraction call timeout |
 | `minConfidence` | `0.7` | 0.0-1.0 | Confidence threshold; facts below this are dropped |
 
+For safety, the intended extraction setups are:
+
+- `claude-code` on a Haiku model
+- `codex` on a GPT Mini model
+- local `ollama` with at least `qwen3:4b`
+
+Set `provider: none` to disable extraction entirely, which is the
+recommended default for VPS installs that should not make background LLM
+calls.
+
+Remote API extraction can accumulate extreme fees quickly because the
+pipeline runs continuously in the background. Use `anthropic`,
+`openrouter`, or remote OpenCode routes only when you explicitly want
+that billing behavior.
+
 When using `ollama`, the model must be available locally. When using
 `claude-code`, the Claude Code CLI must be on PATH. `codex` uses the
-Codex harness as the extraction provider. `native` uses the
-`@signet/native` Rust/NAPI module for local vector operations. Lower
-`minConfidence` to capture more facts at the cost of noise; raise it
-to write only high-confidence facts.
+Codex CLI as the extraction provider. Lower `minConfidence` to capture
+more facts at the cost of noise; raise it to write only high-confidence
+facts.
 
 
 ### Worker (`worker`)

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -948,10 +948,19 @@ telemetryEnabled                    false
 
 ### Nested sub-objects and defaults
 
+Extraction safety note:
+
+- intended usage is Claude Code on Haiku, Codex CLI on GPT Mini with a
+  Pro/Max subscription, or local Ollama with at least `qwen3:4b`
+- set `provider: none` on a VPS if you do not want background
+  extraction
+- remote API extraction can accumulate extreme fees quickly
+  (`anthropic`, `openrouter`, or remote OpenCode routes)
+
 ```yaml
 extraction:
-  provider: claude-code          # "ollama" | "claude-code" | "opencode"
-  model: haiku
+  provider: ollama               # "none" | "ollama" | "claude-code" | "codex" | "opencode" | "anthropic" | "openrouter"
+  model: qwen3:4b
   timeout: 45000                 # ms, range 5000–300000
   minConfidence: 0.7             # fraction 0.0–1.0
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -124,6 +124,14 @@ signet setup --non-interactive \
 In non-interactive mode, agents should ask the user to choose both
 providers first, then pass those choices explicitly.
 
+Extraction safety note:
+
+- intended usage is Claude Code on Haiku, Codex CLI on GPT Mini with a
+  Pro/Max subscription, or local Ollama with at least `qwen3:4b`
+- on a VPS, set extraction to `none` unless you explicitly want
+  background LLM calls
+- remote API extraction can rack up extreme fees fast
+
 ---
 
 Setup Wizard
@@ -218,8 +226,11 @@ across all your AI tools. The core features:
 
 - **[[pipeline|Memory pipeline]]** — conversations are processed automatically by
   Pipeline V2, which extracts meaningful facts and decisions using a
-  local LLM (default: `qwen3:4b` via Ollama). Memories accumulate over
-  time and are recalled in future sessions.
+  configured extraction backend. The safe intended setups are Claude
+  Code on Haiku, Codex on GPT Mini, or local Ollama with at least
+  `qwen3:4b`. Set the extraction provider to `none` if you want Signet
+  without background extraction. Memories accumulate over time and are
+  recalled in future sessions.
 - **Hybrid search** — recall combines semantic and keyword search so
   you find relevant memories even when phrasing varies.
 - **Connectors** — platform adapters for Claude Code, OpenCode, and

--- a/docs/SELF-HOSTING.md
+++ b/docs/SELF-HOSTING.md
@@ -446,14 +446,28 @@ switch back to `team` mode.
 
 ### Pipeline not processing
 
-The memory extraction pipeline requires Ollama running locally with the
-extraction model pulled. Confirm:
+First check whether extraction is intentionally disabled:
+
+```yaml
+memory:
+  pipelineV2:
+    enabled: false
+    extraction:
+      provider: none
+```
+
+If `provider: none` is set, or `enabled: false`, the pipeline staying
+idle is expected. This is the recommended configuration for VPS installs
+that should not make background LLM calls.
+
+If extraction is enabled and using Ollama, confirm the server is
+running and the model is pulled:
 
 ```bash
 curl -s http://localhost:11434/api/tags | jq '.models[].name'
 ```
 
-The default model is `qwen3:4b`. If it is not listed:
+The recommended local floor is `qwen3:4b`. If it is not listed:
 
 ```bash
 ollama pull qwen3:4b
@@ -471,6 +485,11 @@ memory:
 `shadowMode: true` means the pipeline extracts but does not write to the
 database — useful for testing, but memories will not persist. Set it to
 `false` for production operation.
+
+Cost warning: the intended extraction setups are Claude Code on Haiku,
+Codex CLI on GPT Mini with a Pro/Max subscription, or local Ollama.
+Remote API extraction can create extreme fees quickly if left running in
+the background.
 
 ### High memory usage
 

--- a/packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { type ModelRegistryEntry, getModelsByProvider } from "$lib/api";
 import AdvancedSection from "$lib/components/config/AdvancedSection.svelte";
 import FormField from "$lib/components/config/FormField.svelte";
 import FormSection from "$lib/components/config/FormSection.svelte";
@@ -15,10 +16,6 @@ import {
 	PIPELINE_WORKER_NUMS,
 	st,
 } from "$lib/stores/settings.svelte";
-import {
-	getModelsByProvider,
-	type ModelRegistryEntry,
-} from "$lib/api";
 
 const selectTriggerClass =
 	"font-[family-name:var(--font-mono)] text-[11px] text-[var(--sig-text)] bg-[var(--sig-bg)] border-[var(--sig-border-strong)] rounded-lg w-full h-auto min-h-[30px] px-2 py-[5px] box-border focus-visible:border-[var(--sig-accent)]";
@@ -26,7 +23,11 @@ const selectContentClass =
 	"font-[family-name:var(--font-mono)] text-[11px] bg-[var(--sig-bg)] text-[var(--sig-text)] border-[var(--sig-border-strong)] rounded-lg";
 const selectItemClass = "font-[family-name:var(--font-mono)] text-[11px] rounded-lg";
 
+const EXTRACTION_SAFETY_TEXT =
+	"intended usage: claude code on haiku, codex cli on gpt mini with a pro/max subscription, or local ollama at qwen3:4b or larger. remote api extraction can stack up extreme fees fast. set provider to none on a vps if you do not want background extraction.";
+
 const EXTRACTION_PROVIDER_OPTIONS = [
+	{ value: "none", label: "none (disable extraction)" },
 	{ value: "ollama", label: "ollama" },
 	{ value: "claude-code", label: "claude-code" },
 	{ value: "codex", label: "codex" },
@@ -37,42 +38,42 @@ const EXTRACTION_PROVIDER_OPTIONS = [
 
 // Hardcoded fallback presets — used when the registry API is unavailable
 const FALLBACK_MODEL_PRESETS: Record<string, Array<{ value: string; label: string }>> = {
-	"ollama": [
-		{ value: "glm-4.7-flash", label: "glm-4.7-flash" },
+	ollama: [
 		{ value: "qwen3:4b", label: "qwen3:4b" },
+		{ value: "glm-4.7-flash", label: "glm-4.7-flash" },
 		{ value: "llama3", label: "llama3" },
 	],
 	"claude-code": [
-		{ value: "claude-opus-4-6", label: "Claude Opus 4.6" },
-		{ value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
 		{ value: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
 		{ value: "claude-3-5-haiku-20241022", label: "Claude 3.5 Haiku" },
+		{ value: "claude-opus-4-6", label: "Claude Opus 4.6" },
+		{ value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
 	],
-	"codex": [
+	codex: [
+		{ value: "gpt-5-codex-mini", label: "GPT Mini" },
 		{ value: "gpt-5.4", label: "GPT 5.4" },
 		{ value: "gpt-5.3-codex", label: "GPT 5.3 Codex" },
 		{ value: "gpt-5.3-codex-spark", label: "GPT 5.3 Codex Spark" },
 		{ value: "gpt-5-codex", label: "GPT 5 Codex" },
-		{ value: "codex-mini-latest", label: "Codex Mini" },
 	],
-	"opencode": [
-		{ value: "anthropic/claude-opus-4-6", label: "Claude Opus 4.6" },
-		{ value: "anthropic/claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+	opencode: [
 		{ value: "anthropic/claude-haiku-4-5-20251001", label: "Claude Haiku 4.5" },
 		{ value: "google/gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+		{ value: "anthropic/claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+		{ value: "anthropic/claude-opus-4-6", label: "Claude Opus 4.6" },
 	],
-	"anthropic": [
-		{ value: "claude-opus-4-6", label: "Claude Opus 4.6" },
-		{ value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+	anthropic: [
 		{ value: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5" },
 		{ value: "claude-3-5-haiku-20241022", label: "Claude 3.5 Haiku" },
+		{ value: "claude-opus-4-6", label: "Claude Opus 4.6" },
+		{ value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
 	],
-	"openrouter": [
+	openrouter: [
 		{ value: "openai/gpt-4o-mini", label: "GPT-4o Mini" },
-		{ value: "openai/gpt-4o", label: "GPT-4o" },
 		{ value: "anthropic/claude-haiku-4-5-20251001", label: "Claude Haiku 4.5" },
-		{ value: "anthropic/claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
 		{ value: "google/gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+		{ value: "anthropic/claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+		{ value: "openai/gpt-4o", label: "GPT-4o" },
 	],
 };
 
@@ -85,16 +86,20 @@ $effect(() => {
 	const _enabled = st.aBool(["memory", "pipelineV2", "modelRegistry", "enabled"]);
 	void _enabled;
 	let cancelled = false;
-	getModelsByProvider().then((models) => {
-		if (cancelled) return;
-		if (models && Object.keys(models).length > 0) {
-			dynamicModels = models;
-			registryLoaded = true;
-		}
-	}).catch(() => {
-		// Registry unavailable — fall back to static presets
-	});
-	return () => { cancelled = true; };
+	getModelsByProvider()
+		.then((models) => {
+			if (cancelled) return;
+			if (models && Object.keys(models).length > 0) {
+				dynamicModels = models;
+				registryLoaded = true;
+			}
+		})
+		.catch(() => {
+			// Registry unavailable — fall back to static presets
+		});
+	return () => {
+		cancelled = true;
+	};
 });
 
 function getModelPresets(provider: string): Array<{ value: string; label: string }> {
@@ -105,6 +110,37 @@ function getModelPresets(provider: string): Array<{ value: string; label: string
 		}));
 	}
 	return FALLBACK_MODEL_PRESETS[provider] ?? [];
+}
+
+function pickPreferredModel(provider: string, presets: Array<{ value: string; label: string }>): string {
+	const vals = presets.map((preset) => preset.value);
+	if (provider === "claude-code" || provider === "anthropic") {
+		return vals.find((v) => v.toLowerCase().includes("haiku")) ?? vals[0] ?? "";
+	}
+	if (provider === "codex") {
+		return vals.find((v) => v.toLowerCase().includes("mini")) ?? vals[0] ?? "";
+	}
+	if (provider === "ollama") {
+		return vals.find((v) => v === "qwen3:4b") ?? vals[0] ?? "";
+	}
+	if (provider === "opencode") {
+		return (
+			vals.find((v) => v.toLowerCase().includes("haiku")) ??
+			vals.find((v) => v.toLowerCase().includes("flash")) ??
+			vals[0] ??
+			""
+		);
+	}
+	if (provider === "openrouter") {
+		return (
+			vals.find((v) => v.toLowerCase().includes("gpt-4o-mini")) ??
+			vals.find((v) => v.toLowerCase().includes("haiku")) ??
+			vals.find((v) => v.toLowerCase().includes("flash")) ??
+			vals[0] ??
+			""
+		);
+	}
+	return vals[0] ?? "";
 }
 
 function extractionProvider(): string {
@@ -122,9 +158,7 @@ function extractionModelSelectValue(): string {
 	if (customModelActive) return "__custom__";
 	const model = st.aStr(["memory", "pipelineV2", "extractionModel"]);
 	if (!model) return "";
-	return extractionModelPresets().some((preset) => preset.value === model)
-		? model
-		: "__custom__";
+	return extractionModelPresets().some((preset) => preset.value === model) ? model : "__custom__";
 }
 
 function isKnownPreset(model: string): boolean {
@@ -139,7 +173,29 @@ function isKnownPreset(model: string): boolean {
 
 function defaultModelForProvider(provider: string): string {
 	const presets = getModelPresets(provider);
-	return presets[0]?.value ?? "";
+	return pickPreferredModel(provider, presets);
+}
+
+function extractionModel(): string {
+	return st.aStr(["memory", "pipelineV2", "extractionModel"]);
+}
+
+function extractionDisabled(): boolean {
+	return extractionProvider() === "none";
+}
+
+function extractionProviderRisky(): boolean {
+	const provider = extractionProvider();
+	return provider === "anthropic" || provider === "openrouter" || provider === "opencode";
+}
+
+function extractionModelNeedsCostWarning(): boolean {
+	const provider = extractionProvider();
+	const model = extractionModel().toLowerCase();
+	if (!model) return false;
+	if (provider === "claude-code") return !model.includes("haiku");
+	if (provider === "codex") return !model.includes("mini");
+	return false;
 }
 
 function setNum(path: string[]) {
@@ -208,7 +264,12 @@ function strengthMaxTokensLabel(): number {
 	return STRENGTH_MAX_TOKENS[s] ?? 1024;
 }
 
-const TOP_LEVEL_FEATURE_KEYS = ["allowUpdateDelete", "graphEnabled", "autonomousEnabled", "semanticContradictionEnabled"] as const;
+const TOP_LEVEL_FEATURE_KEYS = [
+	"allowUpdateDelete",
+	"graphEnabled",
+	"autonomousEnabled",
+	"semanticContradictionEnabled",
+] as const;
 const ADVANCED_FEATURE_KEYS = ["autonomousFrozen"] as const;
 </script>
 
@@ -219,21 +280,29 @@ const ADVANCED_FEATURE_KEYS = ["autonomousFrozen"] as const;
 		</FormField>
 
 		<FormField label="Extraction provider" description="LLM backend for fact extraction. Ollama runs locally; claude-code uses Claude Code CLI; codex uses the local Codex CLI; opencode uses the OpenCode server; anthropic uses direct API; openrouter uses the OpenRouter API.">
-			<Select.Root
-				type="single"
-				value={st.aStr(["memory", "pipelineV2", "extractionProvider"])}
-				onValueChange={setExtractionProvider}
-			>
-				<Select.Trigger class={selectTriggerClass}>
-					{st.aStr(["memory", "pipelineV2", "extractionProvider"]) || "None selected"}
-				</Select.Trigger>
-				<Select.Content class={selectContentClass}>
-					<Select.Item class={selectItemClass} value="" label="None selected" />
-					{#each EXTRACTION_PROVIDER_OPTIONS as option (option.value)}
-						<Select.Item class={selectItemClass} value={option.value} label={option.label} />
-					{/each}
-				</Select.Content>
-			</Select.Root>
+			<div class="flex flex-col gap-2">
+				<Select.Root
+					type="single"
+					value={st.aStr(["memory", "pipelineV2", "extractionProvider"])}
+					onValueChange={setExtractionProvider}
+				>
+					<Select.Trigger class={selectTriggerClass}>
+						{st.aStr(["memory", "pipelineV2", "extractionProvider"]) || "None selected"}
+					</Select.Trigger>
+					<Select.Content class={selectContentClass}>
+						<Select.Item class={selectItemClass} value="" label="None selected" />
+						{#each EXTRACTION_PROVIDER_OPTIONS as option (option.value)}
+							<Select.Item class={selectItemClass} value={option.value} label={option.label} />
+						{/each}
+					</Select.Content>
+				</Select.Root>
+				<span class="text-[9px] text-[var(--sig-warning)] tracking-wider uppercase">{EXTRACTION_SAFETY_TEXT}</span>
+				{#if extractionDisabled()}
+					<span class="text-[9px] text-[var(--sig-highlight)] tracking-wider uppercase">extraction disabled. no background provider calls will run.</span>
+				{:else if extractionProviderRisky()}
+					<span class="text-[9px] text-[var(--sig-danger)] tracking-wider uppercase">this provider usually means billed api usage. costs can snowball fast if you leave extraction on.</span>
+				{/if}
+			</div>
 		</FormField>
 
 		<FormField label="Extraction model" description={registryLoaded ? "Models auto-discovered from provider. Switch to custom for any supported model string." : "Choose a provider default or switch to custom. Models will auto-update when the registry connects."}>
@@ -261,6 +330,9 @@ const ADVANCED_FEATURE_KEYS = ["autonomousFrozen"] as const;
 				{/if}
 				{#if registryLoaded}
 					<span class="text-[9px] text-[var(--sig-text-muted)] tracking-wider uppercase">auto-discovered from registry</span>
+				{/if}
+				{#if extractionModelNeedsCostWarning()}
+					<span class="text-[9px] text-[var(--sig-danger)] tracking-wider uppercase">recommended safety default is haiku for claude-code and gpt mini for codex. larger models will burn more money.</span>
 				{/if}
 			</div>
 		</FormField>

--- a/packages/cli/src/features/setup-fresh.ts
+++ b/packages/cli/src/features/setup-fresh.ts
@@ -7,6 +7,7 @@ import open from "open";
 import ora from "ora";
 import { daemonAccessLines } from "../lib/network.js";
 import Database from "../sqlite.js";
+import { buildSetupPipeline } from "./setup-pipeline.js";
 import { readErr, readRecord } from "./setup-shared.js";
 import type { FreshSetupConfig, SetupDeps } from "./setup-types.js";
 
@@ -106,27 +107,9 @@ export async function runFreshSetup(cfg: FreshSetupConfig, deps: SetupDeps): Pro
 			};
 		}
 
-		if (cfg.extractionProvider !== "none") {
-			const memory = readRecord(config.memory);
-			memory.pipelineV2 = {
-				enabled: true,
-				extraction: {
-					provider: cfg.extractionProvider,
-					model: cfg.extractionModel,
-				},
-				semanticContradictionEnabled: true,
-				graph: { enabled: true },
-				reranker: { enabled: true },
-				autonomous: {
-					enabled: true,
-					allowUpdateDelete: true,
-					maintenanceMode: "execute",
-				},
-				predictor: { enabled: true },
-				predictorPipeline: { agentFeedback: true, trainingTelemetry: false },
-			};
-			config.memory = memory;
-		}
+		const memory = readRecord(config.memory);
+		memory.pipelineV2 = buildSetupPipeline(cfg.extractionProvider, cfg.extractionModel);
+		config.memory = memory;
 
 		writeFileSync(join(cfg.basePath, "agent.yaml"), formatYaml(config));
 

--- a/packages/cli/src/features/setup-migrate.ts
+++ b/packages/cli/src/features/setup-migrate.ts
@@ -20,6 +20,7 @@ import open from "open";
 import ora from "ora";
 import { daemonAccessLines } from "../lib/network.js";
 import Database from "../sqlite.js";
+import { buildSetupPipeline, defaultExtractionModel } from "./setup-pipeline.js";
 import {
 	type EmbeddingProviderChoice,
 	type ExtractionProviderChoice,
@@ -148,31 +149,12 @@ export async function runExistingSetupWizard(
 			};
 		}
 
-		if (options?.extractionProvider && options.extractionProvider !== "none") {
+		if (options?.extractionProvider) {
 			const memory = readRecord(config.memory);
-			memory.pipelineV2 = {
-				enabled: true,
-				extraction: {
-					provider: options.extractionProvider,
-					model:
-						options.extractionModel ||
-						(options.extractionProvider === "claude-code"
-							? "haiku"
-							: options.extractionProvider === "codex"
-								? "gpt-5.3-codex"
-								: options.extractionProvider === "opencode"
-									? "anthropic/claude-haiku-4-5-20251001"
-									: options.extractionProvider === "openrouter"
-										? "openai/gpt-4o-mini"
-										: "glm-4.7-flash"),
-				},
-				semanticContradictionEnabled: true,
-				graph: { enabled: true },
-				reranker: { enabled: true },
-				autonomous: { enabled: true, allowUpdateDelete: true },
-				predictor: { enabled: true },
-				predictorPipeline: { agentFeedback: true, trainingTelemetry: false },
-			};
+			memory.pipelineV2 = buildSetupPipeline(
+				options.extractionProvider,
+				options.extractionModel || defaultExtractionModel(options.extractionProvider),
+			);
 			config.memory = memory;
 		}
 

--- a/packages/cli/src/features/setup-pipeline.test.ts
+++ b/packages/cli/src/features/setup-pipeline.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import { buildSetupPipeline, defaultExtractionModel } from "./setup-pipeline";
+
+describe("defaultExtractionModel", () => {
+	it("prefers the cheap codex mini model", () => {
+		expect(defaultExtractionModel("codex")).toBe("gpt-5-codex-mini");
+	});
+
+	it("uses qwen3:4b as the ollama floor", () => {
+		expect(defaultExtractionModel("ollama")).toBe("qwen3:4b");
+	});
+});
+
+describe("buildSetupPipeline", () => {
+	it("writes an explicit disabled pipeline when extraction is turned off", () => {
+		expect(buildSetupPipeline("none")).toEqual({
+			enabled: false,
+			extraction: {
+				provider: "none",
+				model: "",
+			},
+		});
+	});
+
+	it("fills in safe defaults for enabled providers", () => {
+		expect(buildSetupPipeline("claude-code")).toEqual({
+			enabled: true,
+			extraction: {
+				provider: "claude-code",
+				model: "haiku",
+			},
+			semanticContradictionEnabled: true,
+			graph: { enabled: true },
+			reranker: { enabled: true },
+			autonomous: {
+				enabled: true,
+				allowUpdateDelete: true,
+				maintenanceMode: "execute",
+			},
+			predictor: { enabled: true },
+			predictorPipeline: {
+				agentFeedback: true,
+				trainingTelemetry: false,
+			},
+		});
+	});
+});

--- a/packages/cli/src/features/setup-pipeline.ts
+++ b/packages/cli/src/features/setup-pipeline.ts
@@ -1,0 +1,77 @@
+import type { ExtractionProviderChoice } from "./setup-shared.js";
+
+export const EXTRACTION_SAFETY_WARNING =
+	"Extraction is intended for Claude Code (Haiku), Codex CLI (GPT Mini) on a Pro/Max subscription, or local Ollama models at qwen3:4b or larger. Remote API extraction can rack up extreme usage fees fast. On a VPS, set the provider to none unless you explicitly want background extraction.";
+
+const MODEL_DEFAULTS = {
+	none: "",
+	"claude-code": "haiku",
+	codex: "gpt-5-codex-mini",
+	ollama: "qwen3:4b",
+	opencode: "anthropic/claude-haiku-4-5-20251001",
+	openrouter: "openai/gpt-4o-mini",
+} as const satisfies Record<ExtractionProviderChoice, string>;
+
+export interface SetupPipelineConfig {
+	readonly enabled: boolean;
+	readonly extraction: {
+		readonly provider: ExtractionProviderChoice;
+		readonly model: string;
+	};
+	readonly semanticContradictionEnabled?: boolean;
+	readonly graph?: {
+		readonly enabled: boolean;
+	};
+	readonly reranker?: {
+		readonly enabled: boolean;
+	};
+	readonly autonomous?: {
+		readonly enabled: boolean;
+		readonly allowUpdateDelete: boolean;
+		readonly maintenanceMode: "execute";
+	};
+	readonly predictor?: {
+		readonly enabled: boolean;
+	};
+	readonly predictorPipeline?: {
+		readonly agentFeedback: boolean;
+		readonly trainingTelemetry: boolean;
+	};
+}
+
+export function defaultExtractionModel(provider: ExtractionProviderChoice): string {
+	return MODEL_DEFAULTS[provider];
+}
+
+export function buildSetupPipeline(provider: ExtractionProviderChoice, model?: string): SetupPipelineConfig {
+	if (provider === "none") {
+		return {
+			enabled: false,
+			extraction: {
+				provider: "none",
+				model: "",
+			},
+		};
+	}
+
+	return {
+		enabled: true,
+		extraction: {
+			provider,
+			model: model?.trim() || defaultExtractionModel(provider),
+		},
+		semanticContradictionEnabled: true,
+		graph: { enabled: true },
+		reranker: { enabled: true },
+		autonomous: {
+			enabled: true,
+			allowUpdateDelete: true,
+			maintenanceMode: "execute",
+		},
+		predictor: { enabled: true },
+		predictorPipeline: {
+			agentFeedback: true,
+			trainingTelemetry: false,
+		},
+	};
+}

--- a/packages/cli/src/features/setup.ts
+++ b/packages/cli/src/features/setup.ts
@@ -8,6 +8,7 @@ import open from "open";
 import ora from "ora";
 import { runFreshSetup } from "./setup-fresh.js";
 import { runExistingSetupWizard } from "./setup-migrate.js";
+import { EXTRACTION_SAFETY_WARNING, defaultExtractionModel } from "./setup-pipeline.js";
 import { hasCommand, preflightOllamaEmbedding, promptOpenAIEmbeddingModel } from "./setup-providers.js";
 import {
 	EMBEDDING_PROVIDER_CHOICES,
@@ -459,13 +460,11 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		? "claude-code"
 		: hasCommand("codex")
 			? "codex"
-			: hasCommand("opencode")
-				? "opencode"
-				: deps.normalizeStringValue(process.env.OPENROUTER_API_KEY)
-					? "openrouter"
-					: hasCommand("ollama")
-						? "ollama"
-						: "none";
+			: hasCommand("ollama")
+				? "ollama"
+				: hasCommand("opencode")
+					? "opencode"
+					: "none";
 
 	let extractionProvider: ExtractionProviderChoice;
 	if (nonInteractive) {
@@ -475,28 +474,30 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		extractionProvider = requestedExtractionProvider ?? providerFromConfig ?? detectedProvider;
 	} else {
 		console.log();
+		console.log(chalk.yellow(`  Warning: ${EXTRACTION_SAFETY_WARNING}`));
+		console.log();
 		const choices = [
 			{
 				value: "claude-code",
-				name: `Claude Code (uses your Claude subscription via CLI)${detectedProvider === "claude-code" ? " — detected" : ""}`,
+				name: `Claude Code (Haiku, recommended if you already have Pro/Max)${detectedProvider === "claude-code" ? " — detected" : ""}`,
 			},
 			{
 				value: "codex",
-				name: `Codex (uses your OpenAI Codex CLI locally)${detectedProvider === "codex" ? " — detected" : ""}`,
-			},
-			{
-				value: "opencode",
-				name: `OpenCode (uses the OpenCode CLI or local server)${detectedProvider === "opencode" ? " — detected" : ""}`,
-			},
-			{
-				value: "openrouter",
-				name: `OpenRouter (cloud API, requires OPENROUTER_API_KEY)${detectedProvider === "openrouter" ? " — detected" : ""}`,
+				name: `Codex (GPT Mini, recommended if you already have Pro/Max)${detectedProvider === "codex" ? " — detected" : ""}`,
 			},
 			{
 				value: "ollama",
-				name: `Ollama (local, requires running Ollama server)${detectedProvider === "ollama" ? " — detected" : ""}`,
+				name: `Ollama (local, qwen3:4b minimum)${detectedProvider === "ollama" ? " — detected" : ""}`,
 			},
-			{ value: "none", name: "Skip extraction pipeline" },
+			{ value: "none", name: "Disable extraction pipeline" },
+			{
+				value: "opencode",
+				name: `OpenCode (advanced, can route to paid APIs)${detectedProvider === "opencode" ? " — detected" : ""}`,
+			},
+			{
+				value: "openrouter",
+				name: "OpenRouter (cloud API, billed usage, expensive if left running)",
+			},
 		];
 		extractionProvider = await select({
 			message: "Memory extraction provider (analyzes conversations):",
@@ -512,7 +513,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 				deps.normalizeStringValue(options.extractionModel) ||
 				deps.normalizeStringValue(existingPipeline.extractionModel) ||
 				deps.normalizeStringValue(existingExtraction.model) ||
-				"haiku";
+				defaultExtractionModel("claude-code");
 		} else {
 			console.log();
 			extractionModel = await select({
@@ -529,15 +530,15 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 				deps.normalizeStringValue(options.extractionModel) ||
 				deps.normalizeStringValue(existingPipeline.extractionModel) ||
 				deps.normalizeStringValue(existingExtraction.model) ||
-				"gpt-5.3-codex";
+				defaultExtractionModel("codex");
 		} else {
 			console.log();
 			extractionModel = await select({
 				message: "Which Codex model for extraction?",
 				choices: [
-					{ value: "gpt-5.3-codex", name: "gpt-5.3-codex (recommended)" },
+					{ value: "gpt-5-codex-mini", name: "gpt-5-codex-mini (GPT Mini, recommended)" },
+					{ value: "gpt-5.3-codex", name: "gpt-5.3-codex (higher usage)" },
 					{ value: "gpt-5-codex", name: "gpt-5-codex (stable fallback)" },
-					{ value: "gpt-5-codex-mini", name: "gpt-5-codex-mini (faster, lighter)" },
 				],
 			});
 		}
@@ -565,7 +566,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 				deps.normalizeStringValue(options.extractionModel) ||
 				deps.normalizeStringValue(existingPipeline.extractionModel) ||
 				deps.normalizeStringValue(existingExtraction.model) ||
-				"openai/gpt-4o-mini";
+				defaultExtractionModel("openrouter");
 		} else {
 			console.log();
 			extractionModel = await select({
@@ -584,14 +585,14 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 				deps.normalizeStringValue(options.extractionModel) ||
 				deps.normalizeStringValue(existingPipeline.extractionModel) ||
 				deps.normalizeStringValue(existingExtraction.model) ||
-				"glm-4.7-flash";
+				defaultExtractionModel("ollama");
 		} else {
 			console.log();
 			extractionModel = await select({
 				message: "Which Ollama model for extraction?",
 				choices: [
-					{ value: "glm-4.7-flash", name: "glm-4.7-flash (good quality, recommended)" },
-					{ value: "qwen3:4b", name: "qwen3:4b (lighter, faster)" },
+					{ value: "qwen3:4b", name: "qwen3:4b (minimum recommended local model)" },
+					{ value: "glm-4.7-flash", name: "glm-4.7-flash (alternative)" },
 					{ value: "llama3", name: "llama3 (general purpose)" },
 				],
 			});

--- a/packages/cli/templates/agent.yaml.template
+++ b/packages/cli/templates/agent.yaml.template
@@ -110,8 +110,14 @@ memory:
     # mutationsFrozen: false
 
     # Extraction provider and model
+    # Safety: on a VPS, set provider: none unless you explicitly want
+    # background extraction.
+    # Intended usage: Claude Code on haiku, Codex on GPT Mini with a
+    # Pro/Max subscription, or local Ollama at qwen3:4b or larger.
+    # Remote API extraction can rack up extreme fees fast.
     extraction:
-      # "claude-code" (Claude CLI), "codex" (Codex CLI), "opencode" (OpenCode), or "ollama" (local)
+      # "none", "claude-code" (Claude CLI), "codex" (Codex CLI),
+      # "opencode" (OpenCode), or "ollama" (local)
       provider: claude-code
       model: haiku
       # endpoint/base_url override (ollama base URL, or OpenCode server URL when provider=opencode)

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -11217,9 +11217,51 @@ async function main() {
 					? extractionOpenCodeBaseUrl
 					: effectiveExtractionProvider === "openrouter"
 						? extractionOpenRouterBaseUrl
-						: undefined,
+				: undefined,
 		),
 	});
+	const extractionModelName =
+		effectiveExtractionModel ?? memoryCfg.pipelineV2.extraction.model;
+	if (
+		effectiveExtractionProvider === "anthropic" ||
+		effectiveExtractionProvider === "openrouter" ||
+		effectiveExtractionProvider === "opencode"
+	) {
+		logger.warn(
+			"config",
+			"Extraction is intended for Claude Code (Haiku), Codex CLI (GPT Mini) on Pro/Max, or local Ollama qwen3:4b+. Remote API extraction can create extreme fees fast. Set provider to 'none' to disable it on a VPS.",
+			{
+				provider: effectiveExtractionProvider,
+				model: extractionModelName,
+			},
+		);
+	}
+	if (
+		effectiveExtractionProvider === "claude-code" &&
+		extractionModelName &&
+		!extractionModelName.toLowerCase().includes("haiku")
+	) {
+		logger.warn(
+			"config",
+			"Claude Code extraction is safest on Haiku. Larger models increase cost significantly.",
+			{
+				model: extractionModelName,
+			},
+		);
+	}
+	if (
+		effectiveExtractionProvider === "codex" &&
+		extractionModelName &&
+		!extractionModelName.toLowerCase().includes("mini")
+	) {
+		logger.warn(
+			"config",
+			"Codex extraction is safest on GPT Mini. Larger models increase cost significantly.",
+			{
+				model: extractionModelName,
+			},
+		);
+	}
 
 	// Create LLM provider once, register as daemon-wide singleton
 	const llmProvider = effectiveExtractionProvider === "none"
@@ -11254,7 +11296,7 @@ async function main() {
 							})
 						: effectiveExtractionProvider === "codex"
 							? createCodexProvider({
-									model: effectiveExtractionModel || "gpt-5.3-codex",
+									model: effectiveExtractionModel || "gpt-5-codex-mini",
 									defaultTimeoutMs: memoryCfg.pipelineV2.extraction.timeout,
 								})
 							: createOllamaProvider({

--- a/packages/daemon/src/memory-config.test.ts
+++ b/packages/daemon/src/memory-config.test.ts
@@ -2,11 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-	DEFAULT_PIPELINE_V2,
-	loadMemoryConfig,
-	loadPipelineConfig,
-} from "./memory-config";
+import { DEFAULT_PIPELINE_V2, loadMemoryConfig, loadPipelineConfig } from "./memory-config";
 
 const tmpDirs: string[] = [];
 
@@ -106,10 +102,7 @@ describe("loadMemoryConfig", () => {
 
 	it("defaults ollama base_url to localhost:11434 when not specified", () => {
 		const agentsDir = makeTempAgentsDir();
-		writeFileSync(
-			join(agentsDir, "agent.yaml"),
-			"embedding:\n  provider: ollama\n  model: nomic-embed-text\n",
-		);
+		writeFileSync(join(agentsDir, "agent.yaml"), "embedding:\n  provider: ollama\n  model: nomic-embed-text\n");
 		const cfg = loadMemoryConfig(agentsDir);
 		expect(cfg.embedding.provider).toBe("ollama");
 		expect(cfg.embedding.base_url).toBe("http://localhost:11434");
@@ -141,7 +134,7 @@ describe("loadMemoryConfig", () => {
 		const agentsDir = makeTempAgentsDir();
 		writeFileSync(
 			join(agentsDir, "agent.yaml"),
-			"embedding:\n  provider: ollama\n  model: nomic-embed-text\n  base_url: \"\"\n",
+			'embedding:\n  provider: ollama\n  model: nomic-embed-text\n  base_url: ""\n',
 		);
 		const cfg = loadMemoryConfig(agentsDir);
 		expect(cfg.embedding.provider).toBe("ollama");
@@ -150,10 +143,7 @@ describe("loadMemoryConfig", () => {
 
 	it("defaults openai base_url to the official API endpoint when not specified", () => {
 		const agentsDir = makeTempAgentsDir();
-		writeFileSync(
-			join(agentsDir, "agent.yaml"),
-			"embedding:\n  provider: openai\n  model: text-embedding-3-small\n",
-		);
+		writeFileSync(join(agentsDir, "agent.yaml"), "embedding:\n  provider: openai\n  model: text-embedding-3-small\n");
 		const cfg = loadMemoryConfig(agentsDir);
 		expect(cfg.embedding.provider).toBe("openai");
 		expect(cfg.embedding.base_url).toBe("https://api.openai.com/v1");
@@ -262,6 +252,24 @@ describe("loadMemoryConfig", () => {
 		const cfg = loadMemoryConfig(agentsDir);
 		expect(cfg.pipelineV2.extraction.provider).toBe("openrouter");
 		expect(cfg.pipelineV2.extraction.model).toBe("openai/gpt-4o-mini");
+	});
+
+	it("loads disabled extraction settings from agent.yaml", () => {
+		const agentsDir = makeTempAgentsDir();
+		writeFileSync(
+			join(agentsDir, "agent.yaml"),
+			`memory:
+  pipelineV2:
+    enabled: false
+    extractionProvider: none
+    extractionModel: ""
+`,
+		);
+
+		const cfg = loadMemoryConfig(agentsDir);
+		expect(cfg.pipelineV2.enabled).toBe(false);
+		expect(cfg.pipelineV2.extraction.provider).toBe("none");
+		expect(cfg.pipelineV2.extraction.model).toBe("");
 	});
 });
 
@@ -517,13 +525,9 @@ describe("loadPipelineConfig", () => {
 
 		expect(result.worker.pollMs).toBe(DEFAULT_PIPELINE_V2.worker.pollMs);
 		expect(result.worker.maxRetries).toBe(DEFAULT_PIPELINE_V2.worker.maxRetries);
-		expect(result.extraction.timeout).toBe(
-			DEFAULT_PIPELINE_V2.extraction.timeout,
-		);
+		expect(result.extraction.timeout).toBe(DEFAULT_PIPELINE_V2.extraction.timeout);
 		expect(result.worker.leaseTimeoutMs).toBe(DEFAULT_PIPELINE_V2.worker.leaseTimeoutMs);
-		expect(result.extraction.minConfidence).toBe(
-			DEFAULT_PIPELINE_V2.extraction.minConfidence,
-		);
+		expect(result.extraction.minConfidence).toBe(DEFAULT_PIPELINE_V2.extraction.minConfidence);
 	});
 
 	it("accepts valid numeric values within range (flat keys)", () => {

--- a/packages/daemon/src/memory-config.ts
+++ b/packages/daemon/src/memory-config.ts
@@ -1,12 +1,12 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
-	parseSimpleYaml,
 	PIPELINE_FLAGS,
 	type PipelineFlag,
 	type PipelineV2Config,
+	parseSimpleYaml,
 } from "@signet/core";
-import { parseAuthConfig, type AuthConfig } from "./auth/config";
+import { type AuthConfig, parseAuthConfig } from "./auth/config";
 
 export interface EmbeddingConfig {
 	provider: "native" | "ollama" | "openai" | "none";
@@ -37,7 +37,7 @@ export const DEFAULT_PIPELINE_V2: PipelineV2Config = {
 	semanticContradictionTimeoutMs: 120000,
 	extraction: {
 		provider: "ollama",
-		model: "qwen3.5:4b",
+		model: "qwen3:4b",
 		strength: "low",
 		endpoint: undefined,
 		timeout: 90000,

--- a/packages/daemon/src/pipeline/model-registry.ts
+++ b/packages/daemon/src/pipeline/model-registry.ts
@@ -42,11 +42,11 @@ const KNOWN_MODELS: Record<string, ModelRegistryEntry[]> = {
 		{ id: "claude-3-5-haiku-20241022", provider: "anthropic", label: "Claude 3.5 Haiku", tier: "low", deprecated: false },
 	],
 	codex: [
+		{ id: "gpt-5-codex-mini", provider: "codex", label: "GPT Mini", tier: "low", deprecated: false },
 		{ id: "gpt-5.4", provider: "codex", label: "GPT 5.4", tier: "high", deprecated: false },
 		{ id: "gpt-5.3-codex", provider: "codex", label: "GPT 5.3 Codex", tier: "high", deprecated: false },
 		{ id: "gpt-5.3-codex-spark", provider: "codex", label: "GPT 5.3 Codex Spark", tier: "high", deprecated: false },
 		{ id: "gpt-5-codex", provider: "codex", label: "GPT 5 Codex", tier: "mid", deprecated: false },
-		{ id: "codex-mini-latest", provider: "codex", label: "Codex Mini", tier: "low", deprecated: false },
 	],
 	opencode: [
 		{ id: "anthropic/claude-opus-4-6", provider: "opencode", label: "Claude Opus 4.6", tier: "high", deprecated: false },

--- a/packages/daemon/src/pipeline/provider.test.ts
+++ b/packages/daemon/src/pipeline/provider.test.ts
@@ -313,6 +313,11 @@ describe("createClaudeCodeProvider", () => {
 describe("createCodexProvider", () => {
 	afterEach(() => restoreSpawn());
 
+	it("uses the default model (gpt-5-codex-mini) when none is supplied", () => {
+		const provider = createCodexProvider();
+		expect(provider.name).toBe("codex:gpt-5-codex-mini");
+	});
+
 	it("returns a provider with the correct name", () => {
 		const provider = createCodexProvider({ model: "gpt-5.3-codex" });
 		expect(provider.name).toBe("codex:gpt-5.3-codex");

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -5,14 +5,13 @@
  * The LlmProvider interface itself lives in @signet/core so that the
  * ingestion pipeline and other consumers can accept any provider.
  */
-
-import type { LlmProvider, LlmGenerateResult } from "@signet/core";
-import { existsSync } from "node:fs";
-import { homedir } from "node:os";
 // On Windows, use node:child_process spawn with windowsHide to prevent
 // console window flashing. Bun.spawn doesn't support windowsHide.
 import { spawn as nodeSpawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
 import { Readable } from "node:stream";
+import type { LlmGenerateResult, LlmProvider } from "@signet/core";
 import { logger } from "../logger";
 import { trimTrailingSlash } from "./url";
 
@@ -1134,7 +1133,7 @@ export interface CodexProviderConfig {
 }
 
 const DEFAULT_CODEX_CONFIG: CodexProviderConfig = {
-	model: "gpt-5.3-codex",
+	model: "gpt-5-codex-mini",
 	defaultTimeoutMs: 60000,
 	workingDirectory: homedir(),
 };


### PR DESCRIPTION
## Summary

Hardens extraction provider setup for self-hosted and VPS installs.

This adds an explicit extraction disable path, steers users toward the
intended low-cost extraction setups, and warns much more aggressively
about the fee risk of remote API-backed extraction.

## Changes

- add explicit `provider: none` handling in setup and dashboard settings
- fix the setup regression where disabling extraction could later fall
  back to defaults and silently re-enable extraction
- default safe extraction models to:
  - Claude Code: `haiku`
  - Codex CLI: `gpt-5-codex-mini`
  - Ollama: `qwen3:4b`
- warn in CLI setup, dashboard settings, daemon startup, templates, and
  docs that intended extraction usage is:
  - Claude Code on Haiku
  - Codex CLI on GPT Mini with Pro/Max
  - local Ollama with at least `qwen3:4b`
- explicitly warn that remote API extraction can cause extreme fees
- add regression coverage for disabled extraction config loading
- add provider default coverage for Codex GPT Mini

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

Pending screenshot upload. UI delta is limited to the Pipeline settings
screen and adds:

- `none (disable extraction)` as an extraction provider option
- inline extraction safety and cost warnings
- extra warning copy when Claude Code is not on Haiku or Codex is not on Mini

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [ ] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A, no migrations touched.

## Testing

- [x] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Commands run:

- `bun test packages/cli/src/features/setup-pipeline.test.ts packages/daemon/src/memory-config.test.ts packages/daemon/src/pipeline/provider.test.ts`
- `bunx biome check packages/cli/src/features/setup-pipeline.ts packages/cli/src/features/setup-pipeline.test.ts packages/cli/src/features/setup.ts packages/cli/src/features/setup-fresh.ts packages/cli/src/features/setup-migrate.ts packages/cli/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte`
- `bun x tsc --noEmit -p packages/core/tsconfig.json`

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- full repo-wide typecheck/lint still has unrelated pre-existing failures
- screenshot is still pending upload
- unrelated logger work remains uncommitted in the workspace and is not part of this PR
