### PR TITLE
feat(daemon): add TurboQuant KV cache compression

### DIFF
--- a/packages/daemon/src/native-generation.test.ts
+++ b/packages/daemon/src/native-generation.test.ts
@@ -1,0 +1,985 @@
+/**
+ * Unit tests for native-generation.ts
+ *
+ * Mocks the transformers.js bindings and verifies:
+ * - Multi-model config registry (Qwen + Nemotron)
+ * - TurboQuant compression targets only attention layers (per model)
+ * - KV cache management across generation steps
+ * - Token sampling logic (greedy + temperature + top-p)
+ * - LlmProvider interface compliance for all model variants
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+	sampleToken,
+	KvCacheManager,
+	NATIVE_MODELS,
+	DEFAULT_MODEL_ID,
+	type NativeModelConfig,
+} from "./native-generation";
+import { TurboQuantKvCache } from "./turboquant-cache";
+
+// ---------------------------------------------------------------------------
+// Mock logger to suppress output during tests
+// ---------------------------------------------------------------------------
+vi.mock("./logger", () => ({
+	logger: {
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	},
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers — fake tensors and data
+// ---------------------------------------------------------------------------
+
+/** Minimal OnnxTensor-like object for tests. */
+function fakeTensor(
+	data: Float32Array,
+	dims: readonly number[],
+): { data: Float32Array; dims: readonly number[] } {
+	return { data, dims };
+}
+
+/** Create a tensor with shape [1, numHeads, seqLen, headDim] filled with `fillValue`. */
+function makeKvTensor(
+	numHeads: number,
+	seqLen: number,
+	headDim: number,
+	fillValue = 1.0,
+): { data: Float32Array; dims: readonly number[] } {
+	const data = new Float32Array(numHeads * seqLen * headDim);
+	data.fill(fillValue);
+	return fakeTensor(data, [1, numHeads, seqLen, headDim]);
+}
+
+/** Fake Tensor constructor that mirrors OnnxTensor interface. */
+class FakeTensor {
+	readonly data: Float32Array;
+	readonly dims: readonly number[];
+	constructor(_type: string, data: Float32Array, dims: readonly number[]) {
+		this.data = data;
+		this.dims = dims;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Model config constants for tests
+// ---------------------------------------------------------------------------
+
+// Qwen 3.5 4B architecture
+const QWEN_NUM_KV_HEADS = 4;
+const QWEN_HEAD_DIM = 256;
+const QWEN_ATTN_LAYERS = [3, 7, 11, 15, 19, 23, 27, 31];
+const QWEN_TOTAL_LAYERS = 32;
+const QWEN_LINEAR_LAYERS = Array.from({ length: QWEN_TOTAL_LAYERS }, (_, i) => i).filter(
+	(i) => !QWEN_ATTN_LAYERS.includes(i),
+);
+
+// Nemotron 3 Nano 4B architecture
+const NEMO_NUM_KV_HEADS = 8;
+const NEMO_HEAD_DIM = 128;
+const NEMO_ATTN_LAYERS = [12, 17, 24, 32];
+const NEMO_TOTAL_LAYERS = 42;
+const NEMO_NON_ATTN_LAYERS = Array.from({ length: NEMO_TOTAL_LAYERS }, (_, i) => i).filter(
+	(i) => !NEMO_ATTN_LAYERS.includes(i),
+);
+
+const RESIDUAL_WINDOW = 128;
+
+// ---------------------------------------------------------------------------
+// Helper: create a KvCacheManager for a given model config
+// ---------------------------------------------------------------------------
+
+function createManagerForModel(
+	config: NativeModelConfig,
+	residualWindowSize = RESIDUAL_WINDOW,
+): { manager: KvCacheManager; tqCache: TurboQuantKvCache } {
+	const tqCache = TurboQuantKvCache.create({
+		bits: 4,
+		headDim: config.headDim,
+		numHeads: config.numKvHeads,
+		residualWindowSize,
+	});
+	const manager = new KvCacheManager(
+		tqCache,
+		config.numKvHeads,
+		config.headDim,
+		config.attentionLayerIndices,
+	);
+	return { manager, tqCache };
+}
+
+// ---------------------------------------------------------------------------
+// Token sampling tests
+// ---------------------------------------------------------------------------
+
+describe("sampleToken", () => {
+	it("should return argmax in greedy mode (temperature=0)", () => {
+		const logits = new Float32Array([1.0, 3.0, 2.0, 0.5]);
+		const result = sampleToken(logits, 0, 0.9);
+		expect(result).toBe(1); // index of 3.0
+	});
+
+	it("should return argmax for very low temperature", () => {
+		const logits = new Float32Array([0.1, 0.2, 10.0, 0.3]);
+		const result = sampleToken(logits, 0, 1.0);
+		expect(result).toBe(2); // index of 10.0
+	});
+
+	it("should return a valid index with temperature > 0", () => {
+		const logits = new Float32Array([1.0, 2.0, 3.0]);
+		const result = sampleToken(logits, 0.7, 0.9);
+		expect(result).toBeGreaterThanOrEqual(0);
+		expect(result).toBeLessThan(3);
+	});
+
+	it("should handle uniform logits", () => {
+		const logits = new Float32Array(100);
+		logits.fill(1.0);
+		const result = sampleToken(logits, 1.0, 1.0);
+		expect(result).toBeGreaterThanOrEqual(0);
+		expect(result).toBeLessThan(100);
+	});
+
+	it("should handle single-element logits", () => {
+		const logits = new Float32Array([5.0]);
+		const result = sampleToken(logits, 1.0, 1.0);
+		expect(result).toBe(0);
+	});
+
+	it("should handle very large logit differences gracefully", () => {
+		const logits = new Float32Array([0, 0, 1000, 0]);
+		const result = sampleToken(logits, 1.0, 0.9);
+		expect(result).toBe(2);
+	});
+
+	it("should respect top-p filtering", () => {
+		// Create logits where one token dominates
+		const logits = new Float32Array([10.0, -100.0, -100.0, -100.0]);
+		// With very tight top-p, only the dominant token should be sampled
+		const result = sampleToken(logits, 1.0, 0.01);
+		expect(result).toBe(0);
+	});
+
+	it("should return consistent results in greedy mode", () => {
+		const logits = new Float32Array([1.5, 3.7, 2.1, 0.8]);
+		const results = new Set<number>();
+		for (let i = 0; i < 10; i++) {
+			results.add(sampleToken(logits, 0, 0.9));
+		}
+		// Greedy should always return the same index
+		expect(results.size).toBe(1);
+		expect(results.has(1)).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// NATIVE_MODELS registry tests
+// ---------------------------------------------------------------------------
+
+describe("NATIVE_MODELS registry", () => {
+	it("should have exactly 2 models", () => {
+		expect(NATIVE_MODELS.size).toBe(2);
+	});
+
+	it("should contain qwen3.5-4b with correct values", () => {
+		const config = NATIVE_MODELS.get("qwen3.5-4b");
+		expect(config).toBeDefined();
+		expect(config!.id).toBe("qwen3.5-4b");
+		expect(config!.onnxId).toBe("onnx-community/Qwen3.5-4B-ONNX");
+		expect(config!.dtype).toBe("q4f16");
+		expect(config!.architecture).toBe("qwen3_5");
+		expect(config!.totalLayers).toBe(32);
+		expect(config!.headDim).toBe(256);
+		expect(config!.numKvHeads).toBe(4);
+		expect(config!.eosTokenId).toBe(248044);
+		expect(config!.displayName).toBe("Qwen 3.5 4B");
+		expect(config!.attentionLayerIndices.size).toBe(8);
+		for (const idx of QWEN_ATTN_LAYERS) {
+			expect(config!.attentionLayerIndices.has(idx)).toBe(true);
+		}
+	});
+
+	it("should contain nemotron-3-nano-4b with correct values", () => {
+		const config = NATIVE_MODELS.get("nemotron-3-nano-4b");
+		expect(config).toBeDefined();
+		expect(config!.id).toBe("nemotron-3-nano-4b");
+		expect(config!.onnxId).toBe("onnx-community/NVIDIA-Nemotron-3-Nano-4B-BF16-ONNX");
+		expect(config!.dtype).toBe("q4f16");
+		expect(config!.architecture).toBe("nemotron_h");
+		expect(config!.totalLayers).toBe(42);
+		expect(config!.headDim).toBe(128);
+		expect(config!.numKvHeads).toBe(8);
+		expect(config!.eosTokenId).toBe(2);
+		expect(config!.displayName).toBe("Nemotron 3 Nano 4B");
+		expect(config!.attentionLayerIndices.size).toBe(4);
+		for (const idx of NEMO_ATTN_LAYERS) {
+			expect(config!.attentionLayerIndices.has(idx)).toBe(true);
+		}
+	});
+
+	it("should default to qwen3.5-4b", () => {
+		expect(DEFAULT_MODEL_ID).toBe("qwen3.5-4b");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// KvCacheManager — backward compat static method
+// ---------------------------------------------------------------------------
+
+describe("KvCacheManager.isFullAttentionLayer (backward compat)", () => {
+	it("should identify Qwen full_attention layers correctly", () => {
+		for (const idx of QWEN_ATTN_LAYERS) {
+			expect(KvCacheManager.isFullAttentionLayer(idx)).toBe(true);
+		}
+	});
+
+	it("should reject linear_attention layers", () => {
+		for (const idx of QWEN_LINEAR_LAYERS) {
+			expect(KvCacheManager.isFullAttentionLayer(idx)).toBe(false);
+		}
+	});
+
+	it("should reject out-of-range indices", () => {
+		expect(KvCacheManager.isFullAttentionLayer(32)).toBe(false);
+		expect(KvCacheManager.isFullAttentionLayer(-1)).toBe(false);
+		expect(KvCacheManager.isFullAttentionLayer(100)).toBe(false);
+	});
+
+	it("should identify exactly 8 full_attention layers", () => {
+		let count = 0;
+		for (let i = 0; i < 32; i++) {
+			if (KvCacheManager.isFullAttentionLayer(i)) count++;
+		}
+		expect(count).toBe(8);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// KvCacheManager — config-driven instance method (Qwen)
+// ---------------------------------------------------------------------------
+
+describe("KvCacheManager.isAttentionLayer (Qwen config)", () => {
+	it("should identify Qwen attention layers via instance method", () => {
+		const qwenConfig = NATIVE_MODELS.get("qwen3.5-4b")!;
+		const { manager } = createManagerForModel(qwenConfig);
+		for (const idx of QWEN_ATTN_LAYERS) {
+			expect(manager.isAttentionLayer(idx)).toBe(true);
+		}
+		for (const idx of QWEN_LINEAR_LAYERS) {
+			expect(manager.isAttentionLayer(idx)).toBe(false);
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// KvCacheManager — config-driven instance method (Nemotron)
+// ---------------------------------------------------------------------------
+
+describe("KvCacheManager.isAttentionLayer (Nemotron config)", () => {
+	it("should identify exactly 4 Nemotron attention layers", () => {
+		const nemoConfig = NATIVE_MODELS.get("nemotron-3-nano-4b")!;
+		const { manager } = createManagerForModel(nemoConfig);
+
+		let count = 0;
+		for (let i = 0; i < NEMO_TOTAL_LAYERS; i++) {
+			if (manager.isAttentionLayer(i)) count++;
+		}
+		expect(count).toBe(4);
+	});
+
+	it("should identify the correct Nemotron attention layer indices", () => {
+		const nemoConfig = NATIVE_MODELS.get("nemotron-3-nano-4b")!;
+		const { manager } = createManagerForModel(nemoConfig);
+
+		for (const idx of NEMO_ATTN_LAYERS) {
+			expect(manager.isAttentionLayer(idx)).toBe(true);
+		}
+	});
+
+	it("should reject Nemotron non-attention layers (mamba + mlp)", () => {
+		const nemoConfig = NATIVE_MODELS.get("nemotron-3-nano-4b")!;
+		const { manager } = createManagerForModel(nemoConfig);
+
+		for (const idx of NEMO_NON_ATTN_LAYERS) {
+			expect(manager.isAttentionLayer(idx)).toBe(false);
+		}
+	});
+
+	it("should expose attentionLayerIndices via getter", () => {
+		const nemoConfig = NATIVE_MODELS.get("nemotron-3-nano-4b")!;
+		const { manager } = createManagerForModel(nemoConfig);
+
+		const indices = manager.attentionLayerIndices;
+		expect(indices.size).toBe(4);
+		expect(indices.has(12)).toBe(true);
+		expect(indices.has(17)).toBe(true);
+		expect(indices.has(24)).toBe(true);
+		expect(indices.has(32)).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// KvCacheManager — prefill + compression tests (Qwen)
+// ---------------------------------------------------------------------------
+
+describe("KvCacheManager (Qwen)", () => {
+	let tqCache: TurboQuantKvCache;
+	let manager: KvCacheManager;
+
+	beforeEach(() => {
+		const qwenConfig = NATIVE_MODELS.get("qwen3.5-4b")!;
+		({ tqCache, manager } = createManagerForModel(qwenConfig));
+	});
+
+	it("should initialize with zero tokens", () => {
+		expect(manager.totalTokens).toBe(0);
+	});
+
+	it("should advance token counter", () => {
+		manager.advanceToken(10);
+		expect(manager.totalTokens).toBe(10);
+		manager.advanceToken();
+		expect(manager.totalTokens).toBe(11);
+	});
+
+	it("should initialize layer state from prefill", () => {
+		const seqLen = 5;
+		const keyTensor = makeKvTensor(QWEN_NUM_KV_HEADS, seqLen, QWEN_HEAD_DIM, 0.5);
+		const valTensor = makeKvTensor(QWEN_NUM_KV_HEADS, seqLen, QWEN_HEAD_DIM, 0.3);
+
+		manager.initLayerFromPrefill(3, keyTensor, valTensor);
+		manager.advanceToken(seqLen);
+
+		const stats = manager.getStats();
+		expect(stats.compressedLayers).toBe(1);
+		expect(stats.residualTokensPerLayer).toBe(seqLen);
+		expect(stats.compressedTokensPerLayer).toBe(0);
+	});
+
+	it("should not compress when within residual window", () => {
+		// Prefill with tokens under the residual window size
+		const seqLen = 10;
+		const keyTensor = makeKvTensor(QWEN_NUM_KV_HEADS, seqLen, QWEN_HEAD_DIM, 1.0);
+		const valTensor = makeKvTensor(QWEN_NUM_KV_HEADS, seqLen, QWEN_HEAD_DIM, 1.0);
+
+		manager.initLayerFromPrefill(7, keyTensor, valTensor);
+		manager.advanceToken(seqLen);
+
+		// Add a few more tokens (still under window)
+		for (let i = 0; i < 5; i++) {
+			const newKey = makeKvTensor(QWEN_NUM_KV_HEADS, 1, QWEN_HEAD_DIM, 2.0);
+			const newVal = makeKvTensor(QWEN_NUM_KV_HEADS, 1, QWEN_HEAD_DIM, 2.0);
+			manager.appendAndCompress(7, newKey, newVal);
+			manager.advanceToken();
+		}
+
+		const stats = manager.getStats();
+		// 10 + 5 = 15, which is under the 128-token window
+		expect(stats.residualTokensPerLayer).toBe(15);
+		expect(stats.compressedTokensPerLayer).toBe(0);
+	});
+
+	it("should start compressing once tokens exceed residual window", () => {
+		// Fill up the residual window
+		const seqLen = RESIDUAL_WINDOW;
+		const keyTensor = makeKvTensor(QWEN_NUM_KV_HEADS, seqLen, QWEN_HEAD_DIM, 1.0);
+		const valTensor = makeKvTensor(QWEN_NUM_KV_HEADS, seqLen, QWEN_HEAD_DIM, 1.0);
+
+		manager.initLayerFromPrefill(3, keyTensor, valTensor);
+		manager.advanceToken(seqLen);
+
+		// Add tokens that push beyond the window
+		const extraTokens = 10;
+		for (let i = 0; i < extraTokens; i++) {
+			const newKey = makeKvTensor(QWEN_NUM_KV_HEADS, 1, QWEN_HEAD_DIM, 2.0);
+			const newVal = makeKvTensor(QWEN_NUM_KV_HEADS, 1, QWEN_HEAD_DIM, 2.0);
+			manager.appendAndCompress(3, newKey, newVal);
+			manager.advanceToken();
+		}
+
+		const stats = manager.getStats();
+		// Should have compressed the overflow
+		expect(stats.compressedTokensPerLayer).toBe(extraTokens);
+		expect(stats.residualTokensPerLayer).toBe(RESIDUAL_WINDOW);
+	});
+
+	it("should reconstruct layer correctly from compressed + residual", () => {
+		const seqLen = 5;
+		const keyTensor = makeKvTensor(QWEN_NUM_KV_HEADS, seqLen, QWEN_HEAD_DIM, 1.0);
+		const valTensor = makeKvTensor(QWEN_NUM_KV_HEADS, seqLen, QWEN_HEAD_DIM, 0.5);
+
+		manager.initLayerFromPrefill(3, keyTensor, valTensor);
+		manager.advanceToken(seqLen);
+
+		const result = manager.reconstructLayer(3, FakeTensor as any);
+		expect(result).not.toBeNull();
+		expect(result!.key.dims).toEqual([1, QWEN_NUM_KV_HEADS, seqLen, QWEN_HEAD_DIM]);
+		expect(result!.value.dims).toEqual([1, QWEN_NUM_KV_HEADS, seqLen, QWEN_HEAD_DIM]);
+		expect(result!.key.data.length).toBe(QWEN_NUM_KV_HEADS * seqLen * QWEN_HEAD_DIM);
+		expect(result!.value.data.length).toBe(QWEN_NUM_KV_HEADS * seqLen * QWEN_HEAD_DIM);
+	});
+
+	it("should return null for uninitialized layers", () => {
+		const result = manager.reconstructLayer(99, FakeTensor as any);
+		expect(result).toBeNull();
+	});
+
+	it("should reset all state", () => {
+		const keyTensor = makeKvTensor(QWEN_NUM_KV_HEADS, 5, QWEN_HEAD_DIM, 1.0);
+		const valTensor = makeKvTensor(QWEN_NUM_KV_HEADS, 5, QWEN_HEAD_DIM, 1.0);
+		manager.initLayerFromPrefill(3, keyTensor, valTensor);
+		manager.advanceToken(5);
+
+		manager.reset();
+
+		expect(manager.totalTokens).toBe(0);
+		expect(manager.reconstructLayer(3, FakeTensor as any)).toBeNull();
+		const stats = manager.getStats();
+		expect(stats.compressedLayers).toBe(0);
+	});
+
+	it("should handle multiple full_attention layers independently", () => {
+		for (const layerIdx of QWEN_ATTN_LAYERS) {
+			const keyTensor = makeKvTensor(QWEN_NUM_KV_HEADS, 3, QWEN_HEAD_DIM, layerIdx * 0.1);
+			const valTensor = makeKvTensor(QWEN_NUM_KV_HEADS, 3, QWEN_HEAD_DIM, layerIdx * 0.1);
+			manager.initLayerFromPrefill(layerIdx, keyTensor, valTensor);
+		}
+
+		const stats = manager.getStats();
+		expect(stats.compressedLayers).toBe(QWEN_ATTN_LAYERS.length);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// KvCacheManager — Nemotron-specific tests
+// ---------------------------------------------------------------------------
+
+describe("KvCacheManager (Nemotron)", () => {
+	let tqCache: TurboQuantKvCache;
+	let manager: KvCacheManager;
+
+	beforeEach(() => {
+		const nemoConfig = NATIVE_MODELS.get("nemotron-3-nano-4b")!;
+		({ tqCache, manager } = createManagerForModel(nemoConfig));
+	});
+
+	it("should initialize with zero tokens", () => {
+		expect(manager.totalTokens).toBe(0);
+	});
+
+	it("should initialize Nemotron attention layers from prefill", () => {
+		for (const layerIdx of NEMO_ATTN_LAYERS) {
+			const keyTensor = makeKvTensor(NEMO_NUM_KV_HEADS, 5, NEMO_HEAD_DIM, 1.0);
+			const valTensor = makeKvTensor(NEMO_NUM_KV_HEADS, 5, NEMO_HEAD_DIM, 1.0);
+			manager.initLayerFromPrefill(layerIdx, keyTensor, valTensor);
+		}
+
+		const stats = manager.getStats();
+		expect(stats.compressedLayers).toBe(4);
+		expect(stats.residualTokensPerLayer).toBe(5);
+	});
+
+	it("should reconstruct Nemotron attention layer correctly", () => {
+		const seqLen = 3;
+		const keyTensor = makeKvTensor(NEMO_NUM_KV_HEADS, seqLen, NEMO_HEAD_DIM, 0.7);
+		const valTensor = makeKvTensor(NEMO_NUM_KV_HEADS, seqLen, NEMO_HEAD_DIM, 0.3);
+
+		manager.initLayerFromPrefill(12, keyTensor, valTensor);
+		manager.advanceToken(seqLen);
+
+		const result = manager.reconstructLayer(12, FakeTensor as any);
+		expect(result).not.toBeNull();
+		expect(result!.key.dims).toEqual([1, NEMO_NUM_KV_HEADS, seqLen, NEMO_HEAD_DIM]);
+		expect(result!.value.dims).toEqual([1, NEMO_NUM_KV_HEADS, seqLen, NEMO_HEAD_DIM]);
+		expect(result!.key.data.length).toBe(NEMO_NUM_KV_HEADS * seqLen * NEMO_HEAD_DIM);
+	});
+
+	it("should compress Nemotron KV cache beyond residual window", () => {
+		const seqLen = RESIDUAL_WINDOW;
+		const keyTensor = makeKvTensor(NEMO_NUM_KV_HEADS, seqLen, NEMO_HEAD_DIM, 1.0);
+		const valTensor = makeKvTensor(NEMO_NUM_KV_HEADS, seqLen, NEMO_HEAD_DIM, 1.0);
+
+		manager.initLayerFromPrefill(17, keyTensor, valTensor);
+		manager.advanceToken(seqLen);
+
+		// Add tokens that push beyond the window
+		for (let i = 0; i < 5; i++) {
+			const newKey = makeKvTensor(NEMO_NUM_KV_HEADS, 1, NEMO_HEAD_DIM, 2.0);
+			const newVal = makeKvTensor(NEMO_NUM_KV_HEADS, 1, NEMO_HEAD_DIM, 2.0);
+			manager.appendAndCompress(17, newKey, newVal);
+			manager.advanceToken();
+		}
+
+		const stats = manager.getStats();
+		expect(stats.compressedTokensPerLayer).toBe(5);
+		expect(stats.residualTokensPerLayer).toBe(RESIDUAL_WINDOW);
+	});
+
+	it("should not track non-attention Nemotron layers", () => {
+		// Mamba layer (index 0) should not be tracked
+		expect(manager.isAttentionLayer(0)).toBe(false);
+		expect(manager.reconstructLayer(0, FakeTensor as any)).toBeNull();
+		// MLP layer (index 1)
+		expect(manager.isAttentionLayer(1)).toBe(false);
+	});
+
+	it("should handle Nemotron compression with 8 KV heads × 128 headDim", () => {
+		const compressSpy = vi.spyOn(tqCache, "compressVector");
+		const smallWindow = 4;
+		const nemoConfig = NATIVE_MODELS.get("nemotron-3-nano-4b")!;
+		const { manager: smallMgr, tqCache: smallCache } = createManagerForModel(nemoConfig, smallWindow);
+		const spy = vi.spyOn(smallCache, "compressVector");
+
+		const prefillKey = makeKvTensor(NEMO_NUM_KV_HEADS, smallWindow, NEMO_HEAD_DIM, 1.0);
+		const prefillVal = makeKvTensor(NEMO_NUM_KV_HEADS, smallWindow, NEMO_HEAD_DIM, 1.0);
+		smallMgr.initLayerFromPrefill(24, prefillKey, prefillVal);
+		smallMgr.advanceToken(smallWindow);
+
+		// Add one token past window
+		const newKey = makeKvTensor(NEMO_NUM_KV_HEADS, 1, NEMO_HEAD_DIM, 2.0);
+		const newVal = makeKvTensor(NEMO_NUM_KV_HEADS, 1, NEMO_HEAD_DIM, 2.0);
+		smallMgr.appendAndCompress(24, newKey, newVal);
+
+		// compressVector: 1 token × 8 heads × 2 (key+val) = 16
+		expect(spy).toHaveBeenCalledTimes(NEMO_NUM_KV_HEADS * 2);
+
+		compressSpy.mockRestore();
+		spy.mockRestore();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// TurboQuant integration — compression round-trip (Qwen)
+// ---------------------------------------------------------------------------
+
+describe("TurboQuant compression round-trip via KvCacheManager (Qwen)", () => {
+	let tqCache: TurboQuantKvCache;
+	let manager: KvCacheManager;
+
+	beforeEach(() => {
+		tqCache = TurboQuantKvCache.create({
+			bits: 4,
+			headDim: QWEN_HEAD_DIM,
+			numHeads: QWEN_NUM_KV_HEADS,
+			residualWindowSize: 4, // Small window for testing
+		});
+		manager = new KvCacheManager(
+			tqCache,
+			QWEN_NUM_KV_HEADS,
+			QWEN_HEAD_DIM,
+			new Set(QWEN_ATTN_LAYERS),
+		);
+	});
+
+	it("should compress vectors and decompress with reasonable fidelity", () => {
+		// Create a random vector
+		const vec = new Float32Array(QWEN_HEAD_DIM);
+		for (let i = 0; i < QWEN_HEAD_DIM; i++) {
+			vec[i] = Math.sin(i * 0.1) * 2.0;
+		}
+
+		const compressed = tqCache.compressVector(vec);
+		const decompressed = tqCache.decompressVector(compressed);
+
+		expect(decompressed.length).toBe(QWEN_HEAD_DIM);
+
+		// Compute relative error — TurboQuant 4-bit should keep it under ~15%
+		let errorSq = 0;
+		let normSq = 0;
+		for (let i = 0; i < QWEN_HEAD_DIM; i++) {
+			errorSq += (vec[i] - decompressed[i]) ** 2;
+			normSq += vec[i] ** 2;
+		}
+		const relativeError = Math.sqrt(errorSq / normSq);
+		expect(relativeError).toBeLessThan(0.2); // generous threshold for 4-bit
+	});
+
+	it("should only compress tokens beyond the residual window", () => {
+		const windowSize = 4;
+
+		// Prefill with exactly the window size
+		const prefillKey = makeKvTensor(QWEN_NUM_KV_HEADS, windowSize, QWEN_HEAD_DIM, 1.0);
+		const prefillVal = makeKvTensor(QWEN_NUM_KV_HEADS, windowSize, QWEN_HEAD_DIM, 1.0);
+		manager.initLayerFromPrefill(3, prefillKey, prefillVal);
+		manager.advanceToken(windowSize);
+
+		let stats = manager.getStats();
+		expect(stats.compressedTokensPerLayer).toBe(0);
+		expect(stats.residualTokensPerLayer).toBe(windowSize);
+
+		// Add one more token — should push oldest out of window
+		const newKey = makeKvTensor(QWEN_NUM_KV_HEADS, 1, QWEN_HEAD_DIM, 2.0);
+		const newVal = makeKvTensor(QWEN_NUM_KV_HEADS, 1, QWEN_HEAD_DIM, 2.0);
+		manager.appendAndCompress(3, newKey, newVal);
+		manager.advanceToken();
+
+		stats = manager.getStats();
+		expect(stats.compressedTokensPerLayer).toBe(1);
+		expect(stats.residualTokensPerLayer).toBe(windowSize);
+	});
+
+	it("should maintain sequence length consistency after compression", () => {
+		const windowSize = 4;
+		const initialLen = 3;
+
+		const prefillKey = makeKvTensor(QWEN_NUM_KV_HEADS, initialLen, QWEN_HEAD_DIM, 1.0);
+		const prefillVal = makeKvTensor(QWEN_NUM_KV_HEADS, initialLen, QWEN_HEAD_DIM, 1.0);
+		manager.initLayerFromPrefill(3, prefillKey, prefillVal);
+		manager.advanceToken(initialLen);
+
+		// Add enough tokens to trigger compression
+		const extra = 10;
+		for (let i = 0; i < extra; i++) {
+			const newKey = makeKvTensor(QWEN_NUM_KV_HEADS, 1, QWEN_HEAD_DIM, i * 0.1);
+			const newVal = makeKvTensor(QWEN_NUM_KV_HEADS, 1, QWEN_HEAD_DIM, i * 0.1);
+			manager.appendAndCompress(3, newKey, newVal);
+			manager.advanceToken();
+		}
+
+		// Reconstruct and verify total sequence length
+		const result = manager.reconstructLayer(3, FakeTensor as any);
+		expect(result).not.toBeNull();
+		const expectedTotalSeq = initialLen + extra;
+		expect(result!.key.dims[2]).toBe(expectedTotalSeq);
+		expect(result!.value.dims[2]).toBe(expectedTotalSeq);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// TurboQuant compression round-trip (Nemotron)
+// ---------------------------------------------------------------------------
+
+describe("TurboQuant compression round-trip via KvCacheManager (Nemotron)", () => {
+	let tqCache: TurboQuantKvCache;
+	let manager: KvCacheManager;
+
+	beforeEach(() => {
+		tqCache = TurboQuantKvCache.create({
+			bits: 4,
+			headDim: NEMO_HEAD_DIM,
+			numHeads: NEMO_NUM_KV_HEADS,
+			residualWindowSize: 4,
+		});
+		manager = new KvCacheManager(
+			tqCache,
+			NEMO_NUM_KV_HEADS,
+			NEMO_HEAD_DIM,
+			new Set(NEMO_ATTN_LAYERS),
+		);
+	});
+
+	it("should compress Nemotron vectors (headDim=128) with reasonable fidelity", () => {
+		const vec = new Float32Array(NEMO_HEAD_DIM);
+		for (let i = 0; i < NEMO_HEAD_DIM; i++) {
+			vec[i] = Math.cos(i * 0.15) * 1.5;
+		}
+
+		const compressed = tqCache.compressVector(vec);
+		const decompressed = tqCache.decompressVector(compressed);
+
+		expect(decompressed.length).toBe(NEMO_HEAD_DIM);
+
+		let errorSq = 0;
+		let normSq = 0;
+		for (let i = 0; i < NEMO_HEAD_DIM; i++) {
+			errorSq += (vec[i] - decompressed[i]) ** 2;
+			normSq += vec[i] ** 2;
+		}
+		const relativeError = Math.sqrt(errorSq / normSq);
+		expect(relativeError).toBeLessThan(0.25); // slightly more generous for smaller dim
+	});
+
+	it("should maintain sequence length consistency with Nemotron dims", () => {
+		const windowSize = 4;
+		const initialLen = 3;
+
+		const prefillKey = makeKvTensor(NEMO_NUM_KV_HEADS, initialLen, NEMO_HEAD_DIM, 1.0);
+		const prefillVal = makeKvTensor(NEMO_NUM_KV_HEADS, initialLen, NEMO_HEAD_DIM, 1.0);
+		manager.initLayerFromPrefill(12, prefillKey, prefillVal);
+		manager.advanceToken(initialLen);
+
+		const extra = 8;
+		for (let i = 0; i < extra; i++) {
+			const newKey = makeKvTensor(NEMO_NUM_KV_HEADS, 1, NEMO_HEAD_DIM, i * 0.1);
+			const newVal = makeKvTensor(NEMO_NUM_KV_HEADS, 1, NEMO_HEAD_DIM, i * 0.1);
+			manager.appendAndCompress(12, newKey, newVal);
+			manager.advanceToken();
+		}
+
+		const result = manager.reconstructLayer(12, FakeTensor as any);
+		expect(result).not.toBeNull();
+		const expectedTotalSeq = initialLen + extra;
+		expect(result!.key.dims).toEqual([1, NEMO_NUM_KV_HEADS, expectedTotalSeq, NEMO_HEAD_DIM]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Provider interface compliance
+// ---------------------------------------------------------------------------
+
+describe("createNativeGenerationProvider (interface check)", () => {
+	// We can't fully test the provider without loading the model,
+	// but we can verify the shape of the returned object.
+
+	it("should be importable without side effects", async () => {
+		// Dynamically import to verify no immediate model loading
+		const mod = await import("./native-generation");
+		expect(typeof mod.createNativeGenerationProvider).toBe("function");
+		expect(typeof mod.createQwenProvider).toBe("function");
+		expect(typeof mod.createNemotronProvider).toBe("function");
+		expect(typeof mod.nativeGenerate).toBe("function");
+		expect(typeof mod.nativeGenerateWithUsage).toBe("function");
+		expect(typeof mod.checkNativeGenerationProvider).toBe("function");
+		expect(typeof mod.shutdownNativeGenerationProvider).toBe("function");
+		expect(typeof mod.getNativeGenerationStatus).toBe("function");
+		expect(typeof mod.DEFAULT_MODEL_ID).toBe("string");
+		expect(mod.NATIVE_MODELS).toBeInstanceOf(Map);
+	});
+
+	it("should return a Qwen provider with the correct shape (default)", async () => {
+		const mod = await import("./native-generation");
+		const provider = mod.createNativeGenerationProvider();
+
+		expect(provider.name).toBe("native-qwen3.5-4b");
+		expect(typeof provider.generate).toBe("function");
+		expect(typeof provider.generateWithUsage).toBe("function");
+		expect(typeof provider.available).toBe("function");
+	});
+
+	it("should return a Nemotron provider via convenience factory", async () => {
+		const mod = await import("./native-generation");
+		const provider = mod.createNemotronProvider();
+
+		expect(provider.name).toBe("native-nemotron-3-nano-4b");
+		expect(typeof provider.generate).toBe("function");
+		expect(typeof provider.generateWithUsage).toBe("function");
+		expect(typeof provider.available).toBe("function");
+	});
+
+	it("should return a Qwen provider via convenience factory", async () => {
+		const mod = await import("./native-generation");
+		const provider = mod.createQwenProvider();
+
+		expect(provider.name).toBe("native-qwen3.5-4b");
+	});
+
+	it("should return a Nemotron provider via modelId option", async () => {
+		const mod = await import("./native-generation");
+		const provider = mod.createNativeGenerationProvider({ modelId: "nemotron-3-nano-4b" });
+
+		expect(provider.name).toBe("native-nemotron-3-nano-4b");
+	});
+
+	it("should report unavailable before initialization", async () => {
+		const mod = await import("./native-generation");
+		const status = mod.getNativeGenerationStatus();
+		expect(status.initialized).toBe(false);
+		expect(status.initializing).toBe(false);
+	});
+
+	it("should accept custom generation options in the provider", async () => {
+		const mod = await import("./native-generation");
+		const provider = mod.createNativeGenerationProvider({
+			temperature: 0,
+			topP: 1.0,
+			maxTokens: 100,
+			turboQuantBits: 3,
+			residualWindowSize: 64,
+		});
+
+		expect(provider.name).toBe("native-qwen3.5-4b");
+		// The custom options are baked in — we just verify construction succeeds
+	});
+
+	it("should accept custom generation options in the Nemotron provider", async () => {
+		const mod = await import("./native-generation");
+		const provider = mod.createNemotronProvider({
+			temperature: 0.5,
+			maxTokens: 512,
+			turboQuantBits: 2,
+		});
+
+		expect(provider.name).toBe("native-nemotron-3-nano-4b");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Full_attention layer filtering in multi-layer scenario (Qwen)
+// ---------------------------------------------------------------------------
+
+describe("Attention layer selectivity (Qwen)", () => {
+	let tqCache: TurboQuantKvCache;
+	let manager: KvCacheManager;
+
+	beforeEach(() => {
+		const qwenConfig = NATIVE_MODELS.get("qwen3.5-4b")!;
+		({ tqCache, manager } = createManagerForModel(qwenConfig));
+	});
+
+	it("should initialize state only for attention layers passed to initLayerFromPrefill", () => {
+		// Simulate prefill output for all 32 layers
+		for (let i = 0; i < QWEN_TOTAL_LAYERS; i++) {
+			if (manager.isAttentionLayer(i)) {
+				const keyTensor = makeKvTensor(QWEN_NUM_KV_HEADS, 10, QWEN_HEAD_DIM, 1.0);
+				const valTensor = makeKvTensor(QWEN_NUM_KV_HEADS, 10, QWEN_HEAD_DIM, 1.0);
+				manager.initLayerFromPrefill(i, keyTensor, valTensor);
+			}
+		}
+
+		// Only attention layers should have state
+		for (let i = 0; i < QWEN_TOTAL_LAYERS; i++) {
+			const result = manager.reconstructLayer(i, FakeTensor as any);
+			if (manager.isAttentionLayer(i)) {
+				expect(result).not.toBeNull();
+				expect(result!.key.dims[2]).toBe(10);
+			} else {
+				expect(result).toBeNull();
+			}
+		}
+	});
+
+	it("should apply compression only to attention layers during generation", () => {
+		const compressSpy = vi.spyOn(tqCache, "compressVector");
+
+		// Initialize a full_attention layer (3) and exceed window
+		const windowSize = RESIDUAL_WINDOW;
+		const prefillKey = makeKvTensor(QWEN_NUM_KV_HEADS, windowSize, QWEN_HEAD_DIM, 1.0);
+		const prefillVal = makeKvTensor(QWEN_NUM_KV_HEADS, windowSize, QWEN_HEAD_DIM, 1.0);
+		manager.initLayerFromPrefill(3, prefillKey, prefillVal);
+		manager.advanceToken(windowSize);
+
+		// No compression yet since we're exactly at the window
+		expect(compressSpy).not.toHaveBeenCalled();
+
+		// Add a new token to layer 3 — should trigger compression
+		const newKey = makeKvTensor(QWEN_NUM_KV_HEADS, 1, QWEN_HEAD_DIM, 2.0);
+		const newVal = makeKvTensor(QWEN_NUM_KV_HEADS, 1, QWEN_HEAD_DIM, 2.0);
+		manager.appendAndCompress(3, newKey, newVal);
+
+		// compressVector called for keys + values × numHeads = 2 × 4 = 8
+		// (1 token compressed per head, for both key and value)
+		expect(compressSpy).toHaveBeenCalledTimes(QWEN_NUM_KV_HEADS * 2);
+
+		compressSpy.mockRestore();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Attention layer selectivity (Nemotron)
+// ---------------------------------------------------------------------------
+
+describe("Attention layer selectivity (Nemotron)", () => {
+	let tqCache: TurboQuantKvCache;
+	let manager: KvCacheManager;
+
+	beforeEach(() => {
+		const nemoConfig = NATIVE_MODELS.get("nemotron-3-nano-4b")!;
+		({ tqCache, manager } = createManagerForModel(nemoConfig));
+	});
+
+	it("should initialize state only for Nemotron attention layers", () => {
+		// Simulate: only init attention layers
+		for (let i = 0; i < NEMO_TOTAL_LAYERS; i++) {
+			if (manager.isAttentionLayer(i)) {
+				const keyTensor = makeKvTensor(NEMO_NUM_KV_HEADS, 8, NEMO_HEAD_DIM, 1.0);
+				const valTensor = makeKvTensor(NEMO_NUM_KV_HEADS, 8, NEMO_HEAD_DIM, 1.0);
+				manager.initLayerFromPrefill(i, keyTensor, valTensor);
+			}
+		}
+
+		// Only 4 attention layers should have state
+		let stateCount = 0;
+		for (let i = 0; i < NEMO_TOTAL_LAYERS; i++) {
+			const result = manager.reconstructLayer(i, FakeTensor as any);
+			if (manager.isAttentionLayer(i)) {
+				expect(result).not.toBeNull();
+				stateCount++;
+			} else {
+				expect(result).toBeNull();
+			}
+		}
+		expect(stateCount).toBe(4);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe("Edge cases", () => {
+	it("should handle empty prompt tokenization gracefully", () => {
+		// sampleToken should still work with minimal logits
+		const logits = new Float32Array([0.0]);
+		expect(sampleToken(logits, 0.7, 0.9)).toBe(0);
+	});
+
+	it("should handle negative logits correctly", () => {
+		const logits = new Float32Array([-10.0, -5.0, -1.0, -8.0]);
+		// Greedy: should pick index 2 (-1.0 is the highest)
+		expect(sampleToken(logits, 0, 0.9)).toBe(2);
+	});
+
+	it("should handle all-same logits in greedy mode", () => {
+		const logits = new Float32Array([3.0, 3.0, 3.0, 3.0]);
+		// With greedy, first index with max value
+		expect(sampleToken(logits, 0, 1.0)).toBe(0);
+	});
+
+	it("should handle large vocabulary in sampling", () => {
+		// Simulate a vocab of 250K (similar to Qwen)
+		const vocabSize = 250_000;
+		const logits = new Float32Array(vocabSize);
+		logits.fill(-100);
+		logits[123456] = 10.0; // One dominant token
+
+		const result = sampleToken(logits, 0, 0.9);
+		expect(result).toBe(123456);
+	});
+
+	it("KvCacheManager should handle zero-length prefill (Qwen)", () => {
+		const qwenConfig = NATIVE_MODELS.get("qwen3.5-4b")!;
+		const { manager: mgr } = createManagerForModel(qwenConfig);
+
+		// Prefill with zero-length sequence
+		const emptyKey = makeKvTensor(QWEN_NUM_KV_HEADS, 0, QWEN_HEAD_DIM, 0);
+		const emptyVal = makeKvTensor(QWEN_NUM_KV_HEADS, 0, QWEN_HEAD_DIM, 0);
+		mgr.initLayerFromPrefill(3, emptyKey, emptyVal);
+
+		const result = mgr.reconstructLayer(3, FakeTensor as any);
+		// Should return null for zero-length
+		expect(result).toBeNull();
+	});
+
+	it("KvCacheManager should handle zero-length prefill (Nemotron)", () => {
+		const nemoConfig = NATIVE_MODELS.get("nemotron-3-nano-4b")!;
+		const { manager: mgr } = createManagerForModel(nemoConfig);
+
+		const emptyKey = makeKvTensor(NEMO_NUM_KV_HEADS, 0, NEMO_HEAD_DIM, 0);
+		const emptyVal = makeKvTensor(NEMO_NUM_KV_HEADS, 0, NEMO_HEAD_DIM, 0);
+		mgr.initLayerFromPrefill(12, emptyKey, emptyVal);
+
+		const result = mgr.reconstructLayer(12, FakeTensor as any);
+		expect(result).toBeNull();
+	});
+
+	it("KvCacheManager backward compat: constructor without attentionLayerIndices uses Qwen defaults", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 4,
+			headDim: QWEN_HEAD_DIM,
+			numHeads: QWEN_NUM_KV_HEADS,
+			residualWindowSize: RESIDUAL_WINDOW,
+		});
+		// No attentionLayerIndices param — should default to Qwen layers
+		const mgr = new KvCacheManager(cache, QWEN_NUM_KV_HEADS, QWEN_HEAD_DIM);
+
+		for (const idx of QWEN_ATTN_LAYERS) {
+			expect(mgr.isAttentionLayer(idx)).toBe(true);
+		}
+		expect(mgr.isAttentionLayer(0)).toBe(false);
+		expect(mgr.isAttentionLayer(12)).toBe(false);
+	});
+});

--- a/packages/daemon/src/native-generation.ts
+++ b/packages/daemon/src/native-generation.ts
@@ -832,6 +832,12 @@ let initError: string | null = null;
 let modelCached = false;
 /** Tracks which model config is currently loaded. */
 let activeModelConfig: NativeModelConfig | null = null;
+/**
+ * Refcount of in-flight generation calls.  Hot-swapping is blocked
+ * while any generation is active to prevent swapping the model out
+ * from under an in-progress `runGeneration()`.
+ */
+let activeGenerations = 0;
 
 // ---------------------------------------------------------------------------
 // Cache directory
@@ -868,7 +874,14 @@ async function ensureInitialized(modelId?: NativeModelId): Promise<void> {
 	const targetConfig = resolveModelConfig(modelId);
 
 	// If a different model is fully loaded, shut down first (hot-swap).
+	// Block if there are in-flight generations using the current model.
 	if (activeModelConfig && activeModelConfig.id !== targetConfig.id) {
+		if (activeGenerations > 0) {
+			throw new Error(
+				`Cannot hot-swap from ${activeModelConfig.displayName} to ${targetConfig.displayName}: ` +
+					`${activeGenerations} generation(s) in progress. Wait for them to complete first.`,
+			);
+		}
 		logger.info(
 			"native-generation",
 			`Hot-swapping from ${activeModelConfig.displayName} to ${targetConfig.displayName}`,
@@ -1085,6 +1098,7 @@ async function runGeneration(
 	/** Running position counter for position_ids across decode steps. */
 	let currentPosition = promptLen;
 
+	activeGenerations++;
 	try {  // Ensure cleanup of pastKv + kvManager even on errors
 
 	// --- Step 1: Prefill ---
@@ -1392,6 +1406,7 @@ async function runGeneration(
 	} finally {
 		// Guaranteed cleanup — dispose remaining KV tensors and reset
 		// manager even if a forward pass or tensor operation throws.
+		activeGenerations = Math.max(0, activeGenerations - 1);
 		disposePastKv(pastKv);
 		pastKv = undefined;
 		kvManager.reset();
@@ -1508,22 +1523,16 @@ export function createNemotronProvider(
  * the model is loaded.
  */
 export async function checkNativeGenerationProvider(): Promise<NativeGenerationStatus> {
-	const currentId = activeModelConfig?.onnxId ?? resolveModelConfig().onnxId;
-	try {
-		await ensureInitialized();
-		return {
-			available: true,
-			modelId: currentId,
-			modelCached,
-		};
-	} catch {
-		return {
-			available: false,
-			error: initError ?? "Native generation provider not ready",
-			modelId: currentId,
-			modelCached: false,
-		};
-	}
+	// Passive check — does NOT call ensureInitialized() to avoid
+	// accidentally hot-swapping the active model just by probing status.
+	const currentId = activeModelConfig?.id ?? DEFAULT_MODEL_ID;
+	const isReady = model !== null && tokenizer !== null;
+	return {
+		available: isReady,
+		error: isReady ? undefined : (initError ?? "Native generation provider not initialized"),
+		modelId: currentId,
+		modelCached,
+	};
 }
 
 /**
@@ -1546,6 +1555,7 @@ export async function shutdownNativeGenerationProvider(): Promise<void> {
 		modelCached = false;
 		activeModelConfig = null;
 		pendingModelId = null;
+		activeGenerations = 0;
 		logger.info("native-generation", "Provider shut down");
 	}
 }

--- a/packages/daemon/src/native-generation.ts
+++ b/packages/daemon/src/native-generation.ts
@@ -1223,18 +1223,16 @@ async function runGeneration(
 			(stepInput as Record<string, unknown>).past_key_values = reconstructed;
 		}
 
-		// Dispose the reconstructed attention KV tensors from the input —
-		// they were created by us in reconstructLayer() and are consumed
-		// by the forward pass.  Non-attention entries are still owned by
-		// the previous pastKv reference.
+		// Capture the reconstructed KV tensors we created so we can
+		// dispose them AFTER the forward pass consumes them.
+		const reconstructedToDispose: OnnxTensor[] = [];
 		if ("past_key_values" in (stepInput as Record<string, unknown>)) {
 			const inputKv = (stepInput as Record<string, unknown>).past_key_values as PastKeyValues;
 			if (inputKv) {
 				for (let i = 0; i < inputKv.length; i++) {
 					if (kvManager.isAttentionLayer(i) && isKvEntry(inputKv[i])) {
 						const kv = inputKv[i] as { key: OnnxTensor; value: OnnxTensor };
-						disposeTensor(kv.key);
-						disposeTensor(kv.value);
+						reconstructedToDispose.push(kv.key, kv.value);
 					}
 				}
 			}
@@ -1242,6 +1240,12 @@ async function runGeneration(
 
 		// Forward pass
 		const stepOutput = await model(stepInput);
+
+		// NOW dispose the reconstructed input tensors — the forward pass
+		// has consumed them and produced new outputs.
+		for (const t of reconstructedToDispose) {
+			disposeTensor(t);
+		}
 
 		// Update KV cache from the new output
 		if (stepOutput.past_key_values) {
@@ -1455,8 +1459,8 @@ export function createNativeGenerationProvider(
 
 		async available(): Promise<boolean> {
 			try {
-				const status = await checkNativeGenerationProvider();
-				return status.available;
+				await ensureInitialized(modelId);
+				return true;
 			} catch {
 				return false;
 			}

--- a/packages/daemon/src/native-generation.ts
+++ b/packages/daemon/src/native-generation.ts
@@ -734,6 +734,14 @@ export class KvCacheManager {
 	 * decompressing the compressed region and concatenating with
 	 * the residual window.
 	 *
+	 * **Memory trade-off:** The reconstructed tensor is full float32
+	 * for the forward pass. TurboQuant's savings come from the
+	 * *persistent* compressed storage between steps (~4 bits/coord),
+	 * not the transient reconstruction buffer. Peak memory per step
+	 * includes one float32 reconstruction per attention layer, but
+	 * the compressed storage (which dominates for long sequences)
+	 * remains at ~4 bits/coord.
+	 *
 	 * @returns Tensors shaped [1, numHeads, totalSeqLen, headDim]
 	 */
 	reconstructLayer(
@@ -1160,6 +1168,21 @@ async function runGeneration(
 	// The prefill KV tensors for attention layers have been copied into
 	// KvCacheManager; non-attention layer KV is still referenced via pastKv.
 	disposeTensor(prefillOutput.logits);
+
+	// Respect maxTokens=0 — skip generation entirely
+	if (maxTokens <= 0) {
+		return {
+			text: "",
+			usage: {
+				inputTokens: promptLen,
+				outputTokens: 0,
+				cacheReadTokens: null,
+				cacheCreationTokens: null,
+				totalCost: null,
+				totalDurationMs: Date.now() - startTime,
+			},
+		};
+	}
 
 	let nextTokenIdx = sampleToken(lastLogits, temperature, topP);
 	let nextTokenId = BigInt(nextTokenIdx);

--- a/packages/daemon/src/native-generation.ts
+++ b/packages/daemon/src/native-generation.ts
@@ -1,0 +1,1542 @@
+/**
+ * Native text generation provider — runs ONNX models directly via
+ * @huggingface/transformers (WASM runtime) with TurboQuant KV cache
+ * compression.
+ *
+ * Supported models:
+ * - **Qwen 3.5 4B** (`qwen3.5-4b`): 32 layers, 8 full_attention + 24
+ *   linear_attention. Default model.
+ * - **NVIDIA Nemotron 3 Nano 4B** (`nemotron-3-nano-4b`): 42 layers,
+ *   4 attention + 23 mamba + 15 MLP. Hybrid Mamba-Attention architecture.
+ *
+ * Uses a manual token-by-token generation loop (not the built-in
+ * `pipeline("text-generation")`) so we can intercept and compress
+ * KV cache tensors between forward passes. Only attention layers
+ * produce traditional KV cache — those are compressed via TurboQuant
+ * while other layers (linear_attention, mamba, MLP) are passed through.
+ *
+ * Lazy-initialized singleton with mutex-based init to handle
+ * concurrent callers during model download. Supports hot-swapping
+ * between models (one loaded at a time).
+ *
+ * @module
+ */
+
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import type { LlmGenerateResult, LlmProvider } from "@signet/core";
+import { logger } from "./logger";
+import { TurboQuantKvCache } from "./turboquant-cache";
+import type { CompressedKvEntry } from "./turboquant-cache";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Selectable native model identifiers. */
+export type NativeModelId = "qwen3.5-4b" | "nemotron-3-nano-4b";
+
+/**
+ * Configuration for a native ONNX generative model.
+ * Abstracts architecture-specific details so the generation loop
+ * is model-agnostic.
+ */
+export interface NativeModelConfig {
+	/** Human-readable identifier used in logs and provider name. */
+	readonly id: string;
+	/** HuggingFace ONNX model repository. */
+	readonly onnxId: string;
+	/** Quantization dtype for from_pretrained. */
+	readonly dtype: "q4f16" | "fp16" | "q8";
+	/** Architecture tag for architecture-specific behaviour. */
+	readonly architecture: "qwen3_5" | "nemotron_h";
+	/**
+	 * Layer indices that produce standard KV cache (multi-head attention).
+	 * Only these layers participate in TurboQuant compression.
+	 * All other layers are passed through (linear_attention, mamba, mlp).
+	 */
+	readonly attentionLayerIndices: ReadonlySet<number>;
+	/** Total number of layers in the model. */
+	readonly totalLayers: number;
+	/** Dimension of each attention head. */
+	readonly headDim: number;
+	/** Number of key-value heads (GQA groups). */
+	readonly numKvHeads: number;
+	/** End-of-sequence token id. */
+	readonly eosTokenId: number;
+	/** Human-friendly display name for logs. */
+	readonly displayName: string;
+}
+
+/** Status snapshot returned by {@link checkNativeGenerationProvider}. */
+interface NativeGenerationStatus {
+	readonly available: boolean;
+	readonly error?: string;
+	readonly modelId: string;
+	readonly modelCached: boolean;
+}
+
+/** Lightweight snapshot returned by {@link getNativeGenerationStatus}. */
+interface NativeGenerationSnapshot {
+	readonly initialized: boolean;
+	readonly initializing: boolean;
+	readonly modelCached: boolean;
+}
+
+/** Options for the generation call. */
+export interface NativeGenerateOptions {
+	/** Maximum number of tokens to generate. @default 2048 */
+	readonly maxTokens?: number;
+	/** Abort after this many milliseconds. @default 120000 */
+	readonly timeoutMs?: number;
+	/** Sampling temperature. 0 = greedy. @default 0.7 */
+	readonly temperature?: number;
+	/** Nucleus sampling cutoff. @default 0.9 */
+	readonly topP?: number;
+	/** TurboQuant bit width for KV cache compression (1-4). @default 4 */
+	readonly turboQuantBits?: 1 | 2 | 3 | 4;
+	/** Number of recent tokens to keep uncompressed. @default 128 */
+	readonly residualWindowSize?: number;
+	/** Which native model to use. @default "qwen3.5-4b" */
+	readonly modelId?: NativeModelId;
+}
+
+/** Progress information from transformers.js model download. */
+interface ProgressInfo {
+	readonly status: string;
+	readonly progress?: number;
+	readonly file?: string;
+}
+
+/**
+ * Minimal tensor interface matching what transformers.js ONNX models
+ * produce. The actual Tensor class comes from the dynamic import, but
+ * we define this narrow contract for type safety.
+ *
+ * Note: `data` is typed as Float32Array for the common case (model outputs).
+ * For int64 inputs (input_ids, attention_mask, position_ids) we cast
+ * BigInt64Array via `as unknown as Float32Array` — transformers.js
+ * accepts both at runtime.
+ */
+interface OnnxTensor {
+	readonly data: Float32Array;
+	readonly dims: readonly number[];
+	dispose?: () => void;
+}
+
+/** Constructor for creating new tensors.
+ *  Accepts Float32Array for float32 or BigInt64Array (cast) for int64. */
+interface TensorConstructor {
+	new (type: string, data: Float32Array, dims: readonly number[]): OnnxTensor;
+}
+
+/**
+ * The transformers.js bindings we need for generation — broader than
+ * the embedding provider since we load model + tokenizer separately.
+ */
+interface GenerationBindings {
+	readonly env: Record<string, unknown>;
+	readonly AutoModelForCausalLM: {
+		from_pretrained(
+			model: string,
+			opts: {
+				dtype?: string;
+				progress_callback?: (p: ProgressInfo) => void;
+			},
+		): Promise<CausalLMModel>;
+	};
+	readonly AutoTokenizer: {
+		from_pretrained(model: string): Promise<Tokenizer>;
+	};
+	readonly Tensor: TensorConstructor;
+}
+
+/** Narrow interface for the loaded causal LM. */
+interface CausalLMModel {
+	(inputs: Record<string, OnnxTensor>): Promise<CausalLMOutput>;
+	dispose?: () => Promise<void>;
+	config?: Record<string, unknown>;
+}
+
+/** Output from a single forward pass. */
+interface CausalLMOutput {
+	readonly logits: OnnxTensor;
+	readonly past_key_values?: PastKeyValues;
+}
+
+/**
+ * past_key_values shape from transformers.js ONNX:
+ * Array of layers, each containing { key: Tensor, value: Tensor }
+ * with shape [batch, num_kv_heads, seq_len, head_dim].
+ *
+ * For hybrid architectures (Nemotron-H), non-attention layers may
+ * contain Mamba SSM state (plain Tensor) or null (MLP layers).
+ */
+type PastKeyValues = ReadonlyArray<
+	| { readonly key: OnnxTensor; readonly value: OnnxTensor }
+	| OnnxTensor
+	| null
+>;
+
+/** Tokenizer interface (subset of transformers.js AutoTokenizer). */
+interface Tokenizer {
+	(text: string, opts?: { return_tensor?: boolean }): {
+		input_ids: { data: BigInt64Array; dims: readonly number[] } | BigInt64Array;
+	};
+	decode(ids: bigint[] | BigInt64Array, opts?: { skip_special_tokens?: boolean }): string;
+	encode(text: string): bigint[];
+}
+
+// ---------------------------------------------------------------------------
+// Model Registry
+// ---------------------------------------------------------------------------
+
+/** Default model if none specified. */
+export const DEFAULT_MODEL_ID: NativeModelId = "qwen3.5-4b";
+
+/** Registry of all supported native generation models. */
+export const NATIVE_MODELS: ReadonlyMap<string, NativeModelConfig> = new Map([
+	[
+		"qwen3.5-4b",
+		{
+			id: "qwen3.5-4b",
+			onnxId: "onnx-community/Qwen3.5-4B-ONNX",
+			dtype: "q4f16",
+			architecture: "qwen3_5",
+			attentionLayerIndices: new Set([3, 7, 11, 15, 19, 23, 27, 31]),
+			totalLayers: 32,
+			headDim: 256,
+			numKvHeads: 4,
+			eosTokenId: 248044,
+			displayName: "Qwen 3.5 4B",
+		},
+	],
+	[
+		"nemotron-3-nano-4b",
+		{
+			id: "nemotron-3-nano-4b",
+			onnxId: "onnx-community/NVIDIA-Nemotron-3-Nano-4B-BF16-ONNX",
+			dtype: "q4f16",
+			architecture: "nemotron_h",
+			attentionLayerIndices: new Set([12, 17, 24, 32]),
+			totalLayers: 42,
+			headDim: 128,
+			numKvHeads: 8,
+			eosTokenId: 2,
+			displayName: "Nemotron 3 Nano 4B",
+		},
+	],
+]);
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default generation parameters. */
+const DEFAULT_MAX_TOKENS = 2048;
+const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_TEMPERATURE = 0.7;
+const DEFAULT_TOP_P = 0.9;
+const DEFAULT_TURBOQUANT_BITS = 4 as const;
+const DEFAULT_RESIDUAL_WINDOW = 128;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+/** Type guard for standard attention KV cache entries. */
+function isKvEntry(
+	entry: unknown,
+): entry is { key: OnnxTensor; value: OnnxTensor } {
+	return (
+		isRecord(entry) &&
+		"key" in entry &&
+		"value" in entry &&
+		isRecord(entry.key) &&
+		isRecord(entry.value) &&
+		"data" in (entry.key as Record<string, unknown>) &&
+		"dims" in (entry.key as Record<string, unknown>)
+	);
+}
+
+/** Best-effort dispose of an OnnxTensor to free ONNX runtime memory. */
+function disposeTensor(tensor: OnnxTensor | null | undefined): void {
+	if (tensor && typeof tensor.dispose === "function") {
+		try {
+			tensor.dispose();
+		} catch {
+			// best-effort — some tensors may already be disposed
+		}
+	}
+}
+
+/**
+ * Dispose all tensors in a past_key_values array.
+ *
+ * @param pastKv - The past_key_values array to dispose
+ * @param attentionOnly - If true, only dispose attention KV entries
+ *   (not Mamba SSM state or other non-attention tensors). Use this
+ *   during generation cleanup when non-attention state is still
+ *   referenced by the ONNX runtime.
+ * @param attentionIndices - Set of layer indices that are attention
+ *   layers (required when attentionOnly=true).
+ */
+function disposePastKv(
+	pastKv: PastKeyValues | undefined,
+	attentionOnly = false,
+	attentionIndices?: ReadonlySet<number>,
+): void {
+	if (!pastKv) return;
+	for (let i = 0; i < pastKv.length; i++) {
+		const entry = pastKv[i];
+		if (isKvEntry(entry)) {
+			if (!attentionOnly || attentionIndices?.has(i)) {
+				disposeTensor(entry.key);
+				disposeTensor(entry.value);
+			}
+		} else if (!attentionOnly && entry && isRecord(entry) && "data" in entry) {
+			// Mamba SSM state or other non-attention tensor — only dispose
+			// during full cleanup (not mid-generation).
+			disposeTensor(entry as OnnxTensor);
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TransformersBindings loader (mirrors native-embedding.ts pattern)
+// ---------------------------------------------------------------------------
+
+function readGenerationBindings(value: unknown): GenerationBindings | null {
+	if (!isRecord(value)) return null;
+	const env = value.env;
+	const autoModel = value.AutoModelForCausalLM;
+	const autoTok = value.AutoTokenizer;
+	const tensorCtor = value.Tensor;
+	if (
+		!isRecord(env) ||
+		!isRecord(autoModel) ||
+		typeof (autoModel as Record<string, unknown>).from_pretrained !== "function" ||
+		!isRecord(autoTok) ||
+		typeof (autoTok as Record<string, unknown>).from_pretrained !== "function" ||
+		typeof tensorCtor !== "function"
+	) {
+		return null;
+	}
+	return value as unknown as GenerationBindings;
+}
+
+/**
+ * Dynamically load @huggingface/transformers with the same candidate
+ * ladder used by native-embedding.ts (bundled runtime → npm package →
+ * web runtime).
+ */
+async function loadGenerationBindings(): Promise<GenerationBindings> {
+	const importBySpecifier = (specifier: string): Promise<unknown> => {
+		return import(specifier);
+	};
+
+	const resolveImportMetaSpecifier = (specifier: string): string => {
+		const resolver = Reflect.get(import.meta, "resolve");
+		if (typeof resolver !== "function") {
+			throw new Error("import.meta.resolve is not available");
+		}
+		return String(Reflect.apply(resolver, import.meta, [specifier]));
+	};
+
+	const loadTransformersWebRuntime = async (): Promise<unknown> => {
+		const packageJsonUrl = resolveImportMetaSpecifier(
+			"@huggingface/transformers/package.json",
+		);
+		const packageJsonPath = fileURLToPath(packageJsonUrl);
+		const webRuntimePath = join(
+			dirname(packageJsonPath),
+			"dist",
+			"transformers.web.js",
+		);
+		return import(pathToFileURL(webRuntimePath).href);
+	};
+
+	const importCandidates: ReadonlyArray<{
+		readonly source: string;
+		readonly load: () => Promise<unknown>;
+	}> = [
+		{
+			source: "bundled runtime",
+			load: () => import("./transformers-runtime"),
+		},
+		{
+			source: "@huggingface/transformers",
+			load: () => importBySpecifier("@huggingface/transformers"),
+		},
+		{
+			source: "@huggingface/transformers dist web runtime",
+			load: () => loadTransformersWebRuntime(),
+		},
+	];
+
+	const failures: string[] = [];
+
+	for (const candidate of importCandidates) {
+		let mod: unknown;
+		try {
+			mod = await candidate.load();
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			failures.push(`${candidate.source}: ${message}`);
+			continue;
+		}
+
+		const direct = readGenerationBindings(mod);
+		if (direct !== null) return direct;
+
+		if (isRecord(mod) && "default" in mod) {
+			const fromDefault = readGenerationBindings(mod.default);
+			if (fromDefault !== null) return fromDefault;
+		}
+
+		failures.push(
+			`${candidate.source}: unsupported export shape (missing AutoModelForCausalLM/AutoTokenizer/Tensor)`,
+		);
+	}
+
+	throw new Error(
+		`Failed to load @huggingface/transformers for generation: ${failures.join("; ")}`,
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Sampling utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Sample a token index from logits using temperature + top-p (nucleus)
+ * sampling. Returns the chosen token index.
+ *
+ * @param logits - Raw logits array (vocab-sized)
+ * @param temperature - Sampling temperature. 0 = greedy argmax.
+ * @param topP - Nucleus sampling probability cutoff.
+ */
+export function sampleToken(
+	logits: Float32Array,
+	temperature: number,
+	topP: number,
+): number {
+	const vocabSize = logits.length;
+
+	// Greedy: return argmax
+	if (temperature <= 0) {
+		let maxIdx = 0;
+		let maxVal = logits[0];
+		for (let i = 1; i < vocabSize; i++) {
+			if (logits[i] > maxVal) {
+				maxVal = logits[i];
+				maxIdx = i;
+			}
+		}
+		return maxIdx;
+	}
+
+	// Temperature scaling
+	const scaled = new Float32Array(vocabSize);
+	let maxLogit = -Infinity;
+	for (let i = 0; i < vocabSize; i++) {
+		scaled[i] = logits[i] / temperature;
+		if (scaled[i] > maxLogit) maxLogit = scaled[i];
+	}
+
+	// Softmax
+	let sumExp = 0;
+	for (let i = 0; i < vocabSize; i++) {
+		scaled[i] = Math.exp(scaled[i] - maxLogit);
+		sumExp += scaled[i];
+	}
+	for (let i = 0; i < vocabSize; i++) {
+		scaled[i] /= sumExp;
+	}
+
+	// Top-p filtering: sort by probability descending, keep cumulative ≤ topP
+	if (topP < 1.0) {
+		// Build index array sorted by probability descending
+		const indices = new Uint32Array(vocabSize);
+		for (let i = 0; i < vocabSize; i++) indices[i] = i;
+		indices.sort((a, b) => scaled[b] - scaled[a]);
+
+		let cumulative = 0;
+		let cutoff = vocabSize;
+		for (let i = 0; i < vocabSize; i++) {
+			cumulative += scaled[indices[i]];
+			if (cumulative > topP) {
+				cutoff = i + 1;
+				break;
+			}
+		}
+
+		// Zero out everything outside the nucleus
+		const kept = new Set<number>();
+		for (let i = 0; i < cutoff; i++) kept.add(indices[i]);
+
+		let newSum = 0;
+		for (let i = 0; i < vocabSize; i++) {
+			if (!kept.has(i)) {
+				scaled[i] = 0;
+			} else {
+				newSum += scaled[i];
+			}
+		}
+
+		// Renormalize
+		if (newSum > 0) {
+			for (let i = 0; i < vocabSize; i++) {
+				scaled[i] /= newSum;
+			}
+		}
+	}
+
+	// Sample from the distribution
+	const r = Math.random();
+	let cumulative = 0;
+	for (let i = 0; i < vocabSize; i++) {
+		cumulative += scaled[i];
+		if (r < cumulative) return i;
+	}
+
+	// Fallback: return last non-zero
+	return vocabSize - 1;
+}
+
+// ---------------------------------------------------------------------------
+// KV Cache management with TurboQuant
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-layer compressed KV state tracked across generation steps.
+ * For attention layers, old tokens get compressed; recent tokens
+ * stay as raw Float32Arrays in the residual window.
+ */
+interface LayerKvState {
+	/** Compressed key vectors per head (tokens outside residual window). */
+	readonly compressedKeys: CompressedKvEntry[][];
+	/** Compressed value vectors per head (tokens outside residual window). */
+	readonly compressedValues: CompressedKvEntry[][];
+	/** Residual window key data per head — raw Float32Arrays, one per token. */
+	readonly residualKeys: Float32Array[][];
+	/** Residual window value data per head — raw Float32Arrays, one per token. */
+	readonly residualValues: Float32Array[][];
+}
+
+/**
+ * Manages compressed + residual KV cache state across all layers
+ * during a generation run.
+ *
+ * Accepts a {@link NativeModelConfig} (or explicit attention layer
+ * indices) to determine which layers should be compressed vs passed
+ * through.
+ */
+export class KvCacheManager {
+	private readonly _cache: TurboQuantKvCache;
+	private readonly _numKvHeads: number;
+	private readonly _headDim: number;
+	private readonly _residualWindowSize: number;
+	/** Set of layer indices that use standard attention KV cache. */
+	private readonly _attentionLayerIndices: ReadonlySet<number>;
+	/** Map from layer index → per-head KV state. */
+	private readonly _layers: Map<number, LayerKvState>;
+	private _totalTokens: number;
+
+	constructor(
+		cache: TurboQuantKvCache,
+		numKvHeads: number,
+		headDim: number,
+		attentionLayerIndices?: ReadonlySet<number>,
+	) {
+		this._cache = cache;
+		this._numKvHeads = numKvHeads;
+		this._headDim = headDim;
+		this._residualWindowSize = cache.config.residualWindowSize;
+		this._attentionLayerIndices = attentionLayerIndices ??
+			// Backward-compat default: Qwen 3.5 4B attention layer indices
+			new Set([3, 7, 11, 15, 19, 23, 27, 31]);
+		this._layers = new Map();
+		this._totalTokens = 0;
+	}
+
+	/** Total tokens seen so far. */
+	get totalTokens(): number {
+		return this._totalTokens;
+	}
+
+	/** The underlying TurboQuant cache. */
+	get turboQuantCache(): TurboQuantKvCache {
+		return this._cache;
+	}
+
+	/** The attention layer indices used by this manager. */
+	get attentionLayerIndices(): ReadonlySet<number> {
+		return this._attentionLayerIndices;
+	}
+
+	/**
+	 * Check whether a given layer index is an attention layer that
+	 * should participate in KV cache compression.
+	 */
+	isAttentionLayer(layerIdx: number): boolean {
+		return this._attentionLayerIndices.has(layerIdx);
+	}
+
+	/** Qwen 3.5 4B attention layer indices — hoisted to avoid per-call allocation. */
+	private static readonly _QWEN_ATTN_LAYERS = new Set([3, 7, 11, 15, 19, 23, 27, 31]);
+
+	/**
+	 * @deprecated Use instance method `isAttentionLayer()` instead.
+	 * Kept for backward compatibility — uses Qwen 3.5 4B defaults.
+	 */
+	static isFullAttentionLayer(layerIdx: number): boolean {
+		return KvCacheManager._QWEN_ATTN_LAYERS.has(layerIdx);
+	}
+
+	/**
+	 * Initialize state tracking for a layer after prefill.
+	 * Extracts per-head vectors from the tensor and stores them in
+	 * the residual window (nothing compressed yet on first call).
+	 */
+	initLayerFromPrefill(
+		layerIdx: number,
+		keyTensor: OnnxTensor,
+		valueTensor: OnnxTensor,
+	): void {
+		const [_batch, tensorNumHeads, seqLen, tensorHeadDim] = keyTensor.dims;
+
+		// Use config-driven values for consistency with appendAndCompress/
+		// reconstructLayer.  Log a warning if the tensor shape disagrees
+		// (could indicate a model config mismatch).
+		const numHeads = this._numKvHeads;
+		const headDim = this._headDim;
+
+		if (tensorNumHeads !== numHeads || tensorHeadDim !== headDim) {
+			// Non-fatal: the tensor might use different conventions (e.g.
+			// broadcasting for GQA).  We trust the config but log for
+			// debugging.
+			logger.warn(
+				"native-generation",
+				`KV tensor shape mismatch in layer ${layerIdx}: ` +
+					`tensor [heads=${tensorNumHeads}, dim=${tensorHeadDim}] vs ` +
+					`config [heads=${numHeads}, dim=${headDim}]`,
+			);
+		}
+
+		const state: LayerKvState = {
+			compressedKeys: Array.from({ length: numHeads }, () => []),
+			compressedValues: Array.from({ length: numHeads }, () => []),
+			residualKeys: Array.from({ length: numHeads }, () => []),
+			residualValues: Array.from({ length: numHeads }, () => []),
+		};
+
+		// Extract per-head, per-token vectors — MUST copy (.slice) since the
+		// source tensor buffer may be reused/disposed by transformers.js on the
+		// next forward pass.  Using a view (new Float32Array(buffer, offset, len))
+		// would cause silent data corruption.
+		for (let h = 0; h < numHeads; h++) {
+			for (let t = 0; t < seqLen; t++) {
+				const offset = (h * seqLen + t) * headDim;
+				state.residualKeys[h].push(
+					keyTensor.data.slice(offset, offset + headDim),
+				);
+				state.residualValues[h].push(
+					valueTensor.data.slice(offset, offset + headDim),
+				);
+			}
+		}
+
+		this._layers.set(layerIdx, state);
+	}
+
+	/**
+	 * Append a new token's KV entry for a given layer, then compress
+	 * any tokens that have fallen outside the residual window.
+	 *
+	 * @param layerIdx - Layer index (must be an attention layer)
+	 * @param keyTensor - Key tensor for the new token [1, numHeads, 1, headDim]
+	 * @param valueTensor - Value tensor for the new token [1, numHeads, 1, headDim]
+	 */
+	appendAndCompress(
+		layerIdx: number,
+		keyTensor: OnnxTensor,
+		valueTensor: OnnxTensor,
+	): void {
+		let state = this._layers.get(layerIdx);
+		if (!state) {
+			// First time seeing this layer — initialize empty
+			state = {
+				compressedKeys: Array.from({ length: this._numKvHeads }, () => []),
+				compressedValues: Array.from({ length: this._numKvHeads }, () => []),
+				residualKeys: Array.from({ length: this._numKvHeads }, () => []),
+				residualValues: Array.from({ length: this._numKvHeads }, () => []),
+			};
+			this._layers.set(layerIdx, state);
+		}
+
+		// Use this._numKvHeads instead of tensor dims[1] for safety —
+		// the tensor might report a different head count if the model
+		// uses multi-query attention with broadcasting.
+		const headDim = this._headDim;
+		const numHeads = this._numKvHeads;
+
+		// Append the new token's per-head vectors to the residual window
+		for (let h = 0; h < numHeads; h++) {
+			const offset = h * headDim;
+			state.residualKeys[h].push(
+				keyTensor.data.slice(offset, offset + headDim),
+			);
+			state.residualValues[h].push(
+				valueTensor.data.slice(offset, offset + headDim),
+			);
+		}
+
+		// Compress tokens that have fallen outside the residual window
+		const totalPerHead = state.compressedKeys[0].length + state.residualKeys[0].length;
+		const windowStart = totalPerHead - this._residualWindowSize;
+
+		if (windowStart > 0) {
+			for (let h = 0; h < numHeads; h++) {
+				// How many tokens in the residual window need to be moved to compressed
+				const toCompress = state.residualKeys[h].length - this._residualWindowSize;
+				if (toCompress > 0) {
+					for (let i = 0; i < toCompress; i++) {
+						// Vectors in the residual window are already owned copies
+						// (from .slice() in append), so no need to copy again.
+						state.compressedKeys[h].push(this._cache.compressVector(state.residualKeys[h][i]));
+						state.compressedValues[h].push(this._cache.compressVector(state.residualValues[h][i]));
+					}
+					// Remove the compressed tokens from the residual window
+					state.residualKeys[h].splice(0, toCompress);
+					state.residualValues[h].splice(0, toCompress);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Advance the total token counter (call once per generated token,
+	 * not per layer).
+	 */
+	advanceToken(count = 1): void {
+		this._totalTokens += count;
+	}
+
+	/**
+	 * Reconstruct a full past_key_values tensor for a layer by
+	 * decompressing the compressed region and concatenating with
+	 * the residual window.
+	 *
+	 * @returns Tensors shaped [1, numHeads, totalSeqLen, headDim]
+	 */
+	reconstructLayer(
+		layerIdx: number,
+		TensorCtor: TensorConstructor,
+	): { key: OnnxTensor; value: OnnxTensor } | null {
+		const state = this._layers.get(layerIdx);
+		if (!state) return null;
+
+		const numHeads = state.residualKeys.length;
+		if (numHeads === 0) return null;
+
+		const headDim = this._headDim;
+		const numCompressed = state.compressedKeys[0].length;
+		const numResidual = state.residualKeys[0].length;
+		const totalSeqLen = numCompressed + numResidual;
+
+		if (totalSeqLen === 0) return null;
+
+		const keyData = new Float32Array(numHeads * totalSeqLen * headDim);
+		const valueData = new Float32Array(numHeads * totalSeqLen * headDim);
+
+		for (let h = 0; h < numHeads; h++) {
+			const headOffset = h * totalSeqLen * headDim;
+
+			// Decompress the compressed region
+			for (let t = 0; t < numCompressed; t++) {
+				const tokenOffset = headOffset + t * headDim;
+				const decompKey = this._cache.decompressVector(state.compressedKeys[h][t]);
+				const decompVal = this._cache.decompressVector(state.compressedValues[h][t]);
+				keyData.set(decompKey, tokenOffset);
+				valueData.set(decompVal, tokenOffset);
+			}
+
+			// Copy the residual window
+			for (let t = 0; t < numResidual; t++) {
+				const tokenOffset = headOffset + (numCompressed + t) * headDim;
+				keyData.set(state.residualKeys[h][t], tokenOffset);
+				valueData.set(state.residualValues[h][t], tokenOffset);
+			}
+		}
+
+		const dims = [1, numHeads, totalSeqLen, headDim] as const;
+		return {
+			key: new TensorCtor("float32", keyData, dims),
+			value: new TensorCtor("float32", valueData, dims),
+		};
+	}
+
+	/** Reset all state for a new generation. */
+	reset(): void {
+		this._layers.clear();
+		this._totalTokens = 0;
+		this._cache.reset();
+	}
+
+	/** Get compression stats. */
+	getStats(): {
+		totalTokens: number;
+		compressedLayers: number;
+		compressedTokensPerLayer: number;
+		residualTokensPerLayer: number;
+	} {
+		let compressedLayers = 0;
+		let compressedTokens = 0;
+		let residualTokens = 0;
+
+		for (const [, state] of this._layers) {
+			compressedLayers++;
+			if (state.compressedKeys.length > 0) {
+				compressedTokens = Math.max(compressedTokens, state.compressedKeys[0].length);
+			}
+			if (state.residualKeys.length > 0) {
+				residualTokens = Math.max(residualTokens, state.residualKeys[0].length);
+			}
+		}
+
+		return {
+			totalTokens: this._totalTokens,
+			compressedLayers,
+			compressedTokensPerLayer: compressedTokens,
+			residualTokensPerLayer: residualTokens,
+		};
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Singleton state
+// ---------------------------------------------------------------------------
+
+let model: CausalLMModel | null = null;
+let tokenizer: Tokenizer | null = null;
+let tensorCtor: TensorConstructor | null = null;
+let initPromise: Promise<void> | null = null;
+let initError: string | null = null;
+let modelCached = false;
+/** Tracks which model config is currently loaded. */
+let activeModelConfig: NativeModelConfig | null = null;
+
+// ---------------------------------------------------------------------------
+// Cache directory
+// ---------------------------------------------------------------------------
+
+function getCacheDir(): string {
+	const agentsDir = process.env.SIGNET_PATH || join(homedir(), ".agents");
+	return join(agentsDir, ".models");
+}
+
+// ---------------------------------------------------------------------------
+// Helper: resolve model config from id
+// ---------------------------------------------------------------------------
+
+function resolveModelConfig(modelId?: NativeModelId): NativeModelConfig {
+	const id = modelId ?? DEFAULT_MODEL_ID;
+	const config = NATIVE_MODELS.get(id);
+	if (!config) {
+		throw new Error(
+			`Unknown native model: ${id}. Available: ${[...NATIVE_MODELS.keys()].join(", ")}`,
+		);
+	}
+	return config;
+}
+
+// ---------------------------------------------------------------------------
+// Lazy init
+// ---------------------------------------------------------------------------
+
+/** Tracks which model config is being initialized (set before doInit resolves). */
+let pendingModelId: string | null = null;
+
+async function ensureInitialized(modelId?: NativeModelId): Promise<void> {
+	const targetConfig = resolveModelConfig(modelId);
+
+	// If a different model is fully loaded, shut down first (hot-swap).
+	if (activeModelConfig && activeModelConfig.id !== targetConfig.id) {
+		logger.info(
+			"native-generation",
+			`Hot-swapping from ${activeModelConfig.displayName} to ${targetConfig.displayName}`,
+		);
+		await shutdownNativeGenerationProvider();
+		pendingModelId = null;
+	}
+
+	// If already initialized with the correct model, done.
+	if (model && tokenizer && activeModelConfig?.id === targetConfig.id) return;
+
+	// If an init is already in progress for this same model, join it.
+	if (initPromise && pendingModelId === targetConfig.id) {
+		return initPromise;
+	}
+
+	// Start a new init.
+	pendingModelId = targetConfig.id;
+	initPromise = doInit(targetConfig);
+	return initPromise;
+}
+
+async function doInit(modelConfig: NativeModelConfig): Promise<void> {
+	try {
+		initError = null;
+
+		const cacheDir = getCacheDir();
+		mkdirSync(cacheDir, { recursive: true });
+
+		const transformers = await loadGenerationBindings();
+
+		// Configure cache directory
+		transformers.env.cacheDir = cacheDir;
+		transformers.env.allowLocalModels = true;
+
+		logger.info(
+			"native-generation",
+			`Initializing ${modelConfig.onnxId} (${modelConfig.dtype} quantization)`,
+		);
+		logger.info("native-generation", `Model cache: ${cacheDir}`);
+
+		// Load tokenizer
+		logger.info("native-generation", "Loading tokenizer...");
+		tokenizer = await transformers.AutoTokenizer.from_pretrained(modelConfig.onnxId);
+
+		// Load model
+		logger.info("native-generation", "Loading model...");
+		try {
+			const loadedModel = await transformers.AutoModelForCausalLM.from_pretrained(
+				modelConfig.onnxId,
+				{
+					dtype: modelConfig.dtype,
+					progress_callback: (progress: ProgressInfo) => {
+						if (
+							progress.status === "download" &&
+							typeof progress.progress === "number"
+						) {
+							logger.info(
+								"native-generation",
+								`Downloading ${progress.file ?? "model"}: ${Math.round(progress.progress)}%`,
+							);
+						} else if (progress.status === "ready") {
+							logger.info("native-generation", "Model shard ready");
+						}
+					},
+				},
+			);
+			model = loadedModel;
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			// Check for unsupported model architecture
+			if (
+				msg.includes("is not supported") ||
+				msg.includes("Unknown model class")
+			) {
+				const archName =
+					modelConfig.architecture === "nemotron_h"
+						? "NemotronHForCausalLM (Nemotron-H hybrid Mamba-Attention)"
+						: "Qwen3_5ForCausalLM";
+				throw new Error(
+					`transformers.js does not yet support the ${archName} model architecture. ` +
+						`Please update @huggingface/transformers to a version that includes ` +
+						`support. Original error: ${msg}`,
+				);
+			}
+			// Also catch the Qwen-specific error pattern for backward compat
+			if (msg.includes("Qwen3_5")) {
+				throw new Error(
+					`transformers.js does not yet support the Qwen3.5 model architecture. ` +
+						`Please update @huggingface/transformers to a version that includes ` +
+						`Qwen3_5ForConditionalGeneration support. Original error: ${msg}`,
+				);
+			}
+			throw err;
+		}
+
+		tensorCtor = transformers.Tensor;
+		modelCached = true;
+		activeModelConfig = modelConfig;
+
+		const attnCount = modelConfig.attentionLayerIndices.size;
+		logger.info(
+			"native-generation",
+			`Ready — ${modelConfig.displayName} loaded (${attnCount} attention layers ` +
+				`with TurboQuant, ${modelConfig.totalLayers} total layers)`,
+		);
+	} catch (err) {
+		initError = err instanceof Error ? err.message : String(err);
+		initPromise = null; // allow retry on next call
+		logger.error("native-generation", `Init failed: ${initError}`);
+		throw err;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Core generation loop
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a KvCacheManager configured for the given model.
+ */
+function createKvManager(
+	modelConfig: NativeModelConfig,
+	turboQuantBits: 1 | 2 | 3 | 4,
+	residualWindowSize: number,
+): KvCacheManager {
+	const tqCache = TurboQuantKvCache.create({
+		bits: turboQuantBits,
+		headDim: modelConfig.headDim,
+		numHeads: modelConfig.numKvHeads,
+		residualWindowSize,
+	});
+
+	return new KvCacheManager(
+		tqCache,
+		modelConfig.numKvHeads,
+		modelConfig.headDim,
+		modelConfig.attentionLayerIndices,
+	);
+}
+
+/**
+ * Run a complete generation using the manual token-by-token loop with
+ * TurboQuant KV cache compression.
+ *
+ * @param prompt - Input text to generate from
+ * @param opts - Generation options
+ * @returns The generated text and usage statistics
+ */
+async function runGeneration(
+	prompt: string,
+	opts: NativeGenerateOptions = {},
+): Promise<LlmGenerateResult> {
+	if (!model || !tokenizer || !tensorCtor || !activeModelConfig) {
+		throw new Error("Native generation model not initialized");
+	}
+
+	const config = activeModelConfig;
+	const maxTokens = opts.maxTokens ?? DEFAULT_MAX_TOKENS;
+	const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+	const temperature = opts.temperature ?? DEFAULT_TEMPERATURE;
+	const topP = opts.topP ?? DEFAULT_TOP_P;
+	const turboQuantBits = opts.turboQuantBits ?? DEFAULT_TURBOQUANT_BITS;
+	const residualWindowSize = opts.residualWindowSize ?? DEFAULT_RESIDUAL_WINDOW;
+
+	const startTime = Date.now();
+	const eosTokenId = BigInt(config.eosTokenId);
+
+	// Create config-driven KV cache manager
+	const kvManager = createKvManager(config, turboQuantBits, residualWindowSize);
+
+	// Tokenize
+	const encoded = tokenizer(prompt);
+	let inputIds: BigInt64Array;
+	if (encoded.input_ids instanceof BigInt64Array) {
+		inputIds = encoded.input_ids;
+	} else if (
+		isRecord(encoded.input_ids) &&
+		"data" in encoded.input_ids
+	) {
+		inputIds = (encoded.input_ids as { data: BigInt64Array }).data;
+	} else {
+		throw new Error("Unexpected tokenizer output format");
+	}
+
+	const promptLen = inputIds.length;
+	logger.info(
+		"native-generation",
+		`[${config.displayName}] Prompt tokenized: ${promptLen} tokens, generating up to ${maxTokens} tokens`,
+	);
+
+	// Build initial input tensor [1, seqLen] — use BigInt64Array for int64
+	// to avoid precision loss for token IDs > 2^24.
+	const inputInt64 = new BigInt64Array(promptLen);
+	for (let i = 0; i < promptLen; i++) {
+		inputInt64[i] = inputIds[i];
+	}
+
+	const TensorClass = tensorCtor;
+	const generatedTokens: bigint[] = [];
+	let pastKv: PastKeyValues | undefined;
+	/** Running position counter for position_ids across decode steps. */
+	let currentPosition = promptLen;
+
+	try {  // Ensure cleanup of pastKv + kvManager even on errors
+
+	// --- Step 1: Prefill ---
+	const prefillInput: Record<string, OnnxTensor> = {
+		input_ids: new TensorClass(
+			"int64",
+			inputInt64 as unknown as Float32Array, // transformers.js accepts BigInt64Array here
+			[1, promptLen],
+		),
+	};
+
+	// Build attention mask for prefill (int64)
+	const prefillMask = new BigInt64Array(promptLen);
+	prefillMask.fill(1n);
+	prefillInput.attention_mask = new TensorClass(
+		"int64",
+		prefillMask as unknown as Float32Array,
+		[1, promptLen],
+	);
+
+	// Build position_ids for prefill [1, seqLen]: 0, 1, 2, ..., seqLen-1
+	// Required for models with rotary embeddings (Qwen M-ROPE, Nemotron).
+	const prefillPositionIds = new BigInt64Array(promptLen);
+	for (let i = 0; i < promptLen; i++) {
+		prefillPositionIds[i] = BigInt(i);
+	}
+	prefillInput.position_ids = new TensorClass(
+		"int64",
+		prefillPositionIds as unknown as Float32Array,
+		[1, promptLen],
+	);
+
+	const prefillOutput = await model(prefillInput);
+	pastKv = prefillOutput.past_key_values;
+
+	// Initialize KV cache manager from prefill output
+	if (pastKv) {
+		for (let layerIdx = 0; layerIdx < pastKv.length; layerIdx++) {
+			if (kvManager.isAttentionLayer(layerIdx)) {
+				const entry = pastKv[layerIdx];
+				if (isKvEntry(entry)) {
+					kvManager.initLayerFromPrefill(layerIdx, entry.key, entry.value);
+				}
+			}
+			// Non-attention layers (mamba SSM state, MLP null) — pass through
+		}
+	}
+	kvManager.advanceToken(promptLen);
+
+	// Get logits for the last position and sample first token.
+	// Use .slice() instead of a buffer view to avoid aliasing issues
+	// if transformers.js reuses the underlying ArrayBuffer.
+	const prefillLogits = prefillOutput.logits;
+	const vocabSize = prefillLogits.dims[prefillLogits.dims.length - 1];
+	const lastPosOffset = (promptLen - 1) * vocabSize;
+	const lastLogits = prefillLogits.data.slice(lastPosOffset, lastPosOffset + vocabSize);
+
+	// Dispose prefill logits — we've extracted what we need via .slice().
+	// The prefill KV tensors for attention layers have been copied into
+	// KvCacheManager; non-attention layer KV is still referenced via pastKv.
+	disposeTensor(prefillOutput.logits);
+
+	let nextTokenIdx = sampleToken(lastLogits, temperature, topP);
+	let nextTokenId = BigInt(nextTokenIdx);
+
+	if (nextTokenId === eosTokenId) {
+		// Model immediately produced EOS — finally block handles cleanup
+		return {
+			text: "",
+			usage: {
+				inputTokens: promptLen,
+				outputTokens: 0,
+				cacheReadTokens: null,
+				cacheCreationTokens: null,
+				totalCost: null,
+				totalDurationMs: Date.now() - startTime,
+			},
+		};
+	}
+
+	generatedTokens.push(nextTokenId);
+
+	// --- Step 2: Decode loop ---
+	for (let step = 1; step < maxTokens; step++) {
+		// Check timeout
+		if (Date.now() - startTime > timeoutMs) {
+			logger.warn(
+				"native-generation",
+				`Generation timed out after ${step} tokens (${timeoutMs}ms)`,
+			);
+			break;
+		}
+
+		// Build single-token input (int64 via BigInt64Array)
+		const stepInput: Record<string, OnnxTensor> = {
+			input_ids: new TensorClass(
+				"int64",
+				new BigInt64Array([nextTokenId]) as unknown as Float32Array,
+				[1, 1],
+			),
+		};
+
+		// Attention mask: when using past_key_values the model only needs
+		// the mask for the NEW tokens (length 1).  The ONNX runtime
+		// infers the cached token count from past_key_values shape.
+		// This avoids a growing O(seqLen) allocation every step.
+		stepInput.attention_mask = new TensorClass(
+			"int64",
+			new BigInt64Array([1n]) as unknown as Float32Array,
+			[1, 1],
+		);
+
+		// position_ids for this decode step — must be the correct absolute
+		// position, not 0, so rotary embeddings compute the right frequencies.
+		stepInput.position_ids = new TensorClass(
+			"int64",
+			new BigInt64Array([BigInt(currentPosition)]) as unknown as Float32Array,
+			[1, 1],
+		);
+
+		// Reconstruct past_key_values:
+		// - Attention layers: reconstruct from compressed + residual
+		// - Mamba/linear_attention/MLP layers: pass through unchanged
+		if (pastKv) {
+			const reconstructed: Array<
+				| { key: OnnxTensor; value: OnnxTensor }
+				| OnnxTensor
+				| null
+			> = [];
+			for (let layerIdx = 0; layerIdx < pastKv.length; layerIdx++) {
+				const entry = pastKv[layerIdx];
+				if (kvManager.isAttentionLayer(layerIdx) && isKvEntry(entry)) {
+					const layer = kvManager.reconstructLayer(layerIdx, TensorClass);
+					if (layer) {
+						reconstructed.push(layer);
+					} else {
+						// Fallback: pass original
+						reconstructed.push(entry);
+					}
+				} else {
+					// Non-attention: mamba SSM state (Tensor), MLP (null),
+					// or linear_attention — pass through unchanged
+					reconstructed.push(entry as { key: OnnxTensor; value: OnnxTensor } | OnnxTensor | null);
+				}
+			}
+			// transformers.js models accept past_key_values as a direct property
+			// on the input object (not as a Tensor).
+			(stepInput as Record<string, unknown>).past_key_values = reconstructed;
+		}
+
+		// Dispose the reconstructed attention KV tensors from the input —
+		// they were created by us in reconstructLayer() and are consumed
+		// by the forward pass.  Non-attention entries are still owned by
+		// the previous pastKv reference.
+		if ("past_key_values" in (stepInput as Record<string, unknown>)) {
+			const inputKv = (stepInput as Record<string, unknown>).past_key_values as PastKeyValues;
+			if (inputKv) {
+				for (let i = 0; i < inputKv.length; i++) {
+					if (kvManager.isAttentionLayer(i) && isKvEntry(inputKv[i])) {
+						const kv = inputKv[i] as { key: OnnxTensor; value: OnnxTensor };
+						disposeTensor(kv.key);
+						disposeTensor(kv.value);
+					}
+				}
+			}
+		}
+
+		// Forward pass
+		const stepOutput = await model(stepInput);
+
+		// Update KV cache from the new output
+		if (stepOutput.past_key_values) {
+			for (let layerIdx = 0; layerIdx < stepOutput.past_key_values.length; layerIdx++) {
+				if (kvManager.isAttentionLayer(layerIdx)) {
+					const kvLayer = stepOutput.past_key_values[layerIdx];
+					if (!isKvEntry(kvLayer)) continue;
+
+					// The output has the full sequence; extract only the last position
+					const seqLen = kvLayer.key.dims[2];
+					const headDim = kvLayer.key.dims[3];
+					const numHeads = kvLayer.key.dims[1];
+
+					// Create tensors for just the last token
+					const lastKeyData = new Float32Array(numHeads * headDim);
+					const lastValData = new Float32Array(numHeads * headDim);
+
+					for (let h = 0; h < numHeads; h++) {
+						const srcOffset = (h * seqLen + (seqLen - 1)) * headDim;
+						const dstOffset = h * headDim;
+						lastKeyData.set(
+							kvLayer.key.data.slice(srcOffset, srcOffset + headDim),
+							dstOffset,
+						);
+						lastValData.set(
+							kvLayer.value.data.slice(srcOffset, srcOffset + headDim),
+							dstOffset,
+						);
+					}
+
+					const lastKeyTensor = new TensorClass(
+						"float32",
+						lastKeyData,
+						[1, numHeads, 1, headDim],
+					);
+					const lastValTensor = new TensorClass(
+						"float32",
+						lastValData,
+						[1, numHeads, 1, headDim],
+					);
+
+					kvManager.appendAndCompress(layerIdx, lastKeyTensor, lastValTensor);
+				}
+			}
+
+			// Dispose old attention KV tensors from the previous pastKv
+			// before overwriting the reference.  Non-attention layer
+			// tensors (mamba SSM state) are managed by the ONNX runtime
+			// and may be reused — only dispose attention entries we've
+			// fully consumed into KvCacheManager.
+			if (pastKv) {
+				for (let i = 0; i < pastKv.length; i++) {
+					if (kvManager.isAttentionLayer(i) && isKvEntry(pastKv[i])) {
+						const old = pastKv[i] as { key: OnnxTensor; value: OnnxTensor };
+						disposeTensor(old.key);
+						disposeTensor(old.value);
+					}
+				}
+			}
+
+			// Keep reference to the full output for non-attention layers
+			pastKv = stepOutput.past_key_values;
+		}
+
+		kvManager.advanceToken();
+		currentPosition++;
+
+		// Sample next token from the last logit position.
+		// Use .slice() for safety (avoid buffer aliasing).
+		const stepLogits = stepOutput.logits;
+		const stepVocabSize = stepLogits.dims[stepLogits.dims.length - 1];
+		// For single-token input, logits shape is [1, 1, vocabSize]
+		const tokenLogits = stepLogits.data.slice(0, stepVocabSize);
+
+		// Dispose step logits after extraction
+		disposeTensor(stepLogits);
+
+		nextTokenIdx = sampleToken(tokenLogits, temperature, topP);
+		nextTokenId = BigInt(nextTokenIdx);
+
+		if (nextTokenId === eosTokenId) {
+			break;
+		}
+
+		generatedTokens.push(nextTokenId);
+
+		// Periodic logging
+		if (step % 100 === 0) {
+			const stats = kvManager.getStats();
+			logger.info(
+				"native-generation",
+				`[${config.displayName}] Step ${step}: ${generatedTokens.length} tokens generated, ` +
+					`compressed=${stats.compressedTokensPerLayer}, ` +
+					`residual=${stats.residualTokensPerLayer}`,
+			);
+		}
+	}
+
+	// Decode output
+	const outputText = tokenizer.decode(
+		new BigInt64Array(generatedTokens),
+		{ skip_special_tokens: true },
+	);
+
+	const elapsed = Date.now() - startTime;
+	const stats = kvManager.getStats();
+
+	logger.info(
+		"native-generation",
+		`[${config.displayName}] Generation complete: ${generatedTokens.length} tokens in ${elapsed}ms ` +
+			`(${((generatedTokens.length / elapsed) * 1000).toFixed(1)} tok/s), ` +
+			`KV compressed=${stats.compressedTokensPerLayer} residual=${stats.residualTokensPerLayer}`,
+	);
+
+	return {
+		text: outputText,
+		usage: {
+			inputTokens: promptLen,
+			outputTokens: generatedTokens.length,
+			cacheReadTokens: null,
+			cacheCreationTokens: null,
+			totalCost: null,
+			totalDurationMs: elapsed,
+		},
+	};
+
+	} finally {
+		// Guaranteed cleanup — dispose remaining KV tensors and reset
+		// manager even if a forward pass or tensor operation throws.
+		disposePastKv(pastKv);
+		pastKv = undefined;
+		kvManager.reset();
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate text using a native ONNX model with TurboQuant KV cache
+ * compression.
+ *
+ * Lazily initializes the model on first call.
+ *
+ * @param prompt - Input text prompt
+ * @param opts - Generation options (temperature, maxTokens, modelId, etc.)
+ * @returns Generated text string
+ */
+export async function nativeGenerate(
+	prompt: string,
+	opts?: NativeGenerateOptions,
+): Promise<string> {
+	await ensureInitialized(opts?.modelId);
+	const result = await runGeneration(prompt, opts);
+	return result.text;
+}
+
+/**
+ * Generate text with full usage statistics.
+ *
+ * @param prompt - Input text prompt
+ * @param opts - Generation options
+ * @returns Generated text + usage info
+ */
+export async function nativeGenerateWithUsage(
+	prompt: string,
+	opts?: NativeGenerateOptions,
+): Promise<LlmGenerateResult> {
+	await ensureInitialized(opts?.modelId);
+	return runGeneration(prompt, opts);
+}
+
+/**
+ * Create an {@link LlmProvider} backed by a native ONNX model with
+ * TurboQuant compression.
+ *
+ * @param opts - Default generation options applied to all calls
+ *               (including modelId to select which model)
+ * @returns An LlmProvider instance
+ */
+export function createNativeGenerationProvider(
+	opts?: NativeGenerateOptions,
+): LlmProvider {
+	const defaults = opts ?? {};
+	const modelId = defaults.modelId ?? DEFAULT_MODEL_ID;
+	const providerName = `native-${modelId}`;
+
+	return {
+		name: providerName,
+
+		async generate(
+			prompt: string,
+			callOpts?: { timeoutMs?: number; maxTokens?: number },
+		): Promise<string> {
+			return nativeGenerate(prompt, {
+				...defaults,
+				...(callOpts ?? {}),
+			});
+		},
+
+		async generateWithUsage(
+			prompt: string,
+			callOpts?: { timeoutMs?: number; maxTokens?: number },
+		): Promise<LlmGenerateResult> {
+			return nativeGenerateWithUsage(prompt, {
+				...defaults,
+				...(callOpts ?? {}),
+			});
+		},
+
+		async available(): Promise<boolean> {
+			try {
+				const status = await checkNativeGenerationProvider();
+				return status.available;
+			} catch {
+				return false;
+			}
+		},
+	};
+}
+
+/**
+ * Convenience factory for a Qwen 3.5 4B provider.
+ */
+export function createQwenProvider(
+	opts?: Omit<NativeGenerateOptions, "modelId">,
+): LlmProvider {
+	return createNativeGenerationProvider({ ...opts, modelId: "qwen3.5-4b" });
+}
+
+/**
+ * Convenience factory for a Nemotron 3 Nano 4B provider.
+ */
+export function createNemotronProvider(
+	opts?: Omit<NativeGenerateOptions, "modelId">,
+): LlmProvider {
+	return createNativeGenerationProvider({ ...opts, modelId: "nemotron-3-nano-4b" });
+}
+
+/**
+ * Check whether the native generation provider is available and
+ * the model is loaded.
+ */
+export async function checkNativeGenerationProvider(): Promise<NativeGenerationStatus> {
+	const currentId = activeModelConfig?.onnxId ?? resolveModelConfig().onnxId;
+	try {
+		await ensureInitialized();
+		return {
+			available: true,
+			modelId: currentId,
+			modelCached,
+		};
+	} catch {
+		return {
+			available: false,
+			error: initError ?? "Native generation provider not ready",
+			modelId: currentId,
+			modelCached: false,
+		};
+	}
+}
+
+/**
+ * Shut down the native generation provider and release resources.
+ */
+export async function shutdownNativeGenerationProvider(): Promise<void> {
+	if (model) {
+		if (typeof model.dispose === "function") {
+			try {
+				await model.dispose();
+			} catch {
+				// best-effort
+			}
+		}
+		model = null;
+		tokenizer = null;
+		tensorCtor = null;
+		initPromise = null;
+		initError = null;
+		modelCached = false;
+		activeModelConfig = null;
+		pendingModelId = null;
+		logger.info("native-generation", "Provider shut down");
+	}
+}
+
+/**
+ * Get a lightweight snapshot of the provider's current state
+ * (non-async, no side effects).
+ */
+export function getNativeGenerationStatus(): NativeGenerationSnapshot {
+	return {
+		initialized: model !== null && tokenizer !== null,
+		initializing: initPromise !== null && model === null,
+		modelCached,
+	};
+}

--- a/packages/daemon/src/native-generation.ts
+++ b/packages/daemon/src/native-generation.ts
@@ -874,15 +874,27 @@ async function ensureInitialized(modelId?: NativeModelId): Promise<void> {
 			`Hot-swapping from ${activeModelConfig.displayName} to ${targetConfig.displayName}`,
 		);
 		await shutdownNativeGenerationProvider();
-		pendingModelId = null;
 	}
 
 	// If already initialized with the correct model, done.
 	if (model && tokenizer && activeModelConfig?.id === targetConfig.id) return;
 
-	// If an init is already in progress for this same model, join it.
-	if (initPromise && pendingModelId === targetConfig.id) {
-		return initPromise;
+	// If an init is already in progress, either join it or wait for it
+	// to finish before starting a new one (prevents concurrent doInit).
+	if (initPromise) {
+		if (pendingModelId === targetConfig.id) {
+			// Same model — join the existing init.
+			return initPromise;
+		}
+		// Different model is initializing — wait for it to finish
+		// (or fail), then shut it down and start the new one.
+		try {
+			await initPromise;
+		} catch {
+			// The pending init failed — that's fine, we'll start fresh.
+		}
+		// Shut down whatever the previous init loaded (if anything).
+		await shutdownNativeGenerationProvider();
 	}
 
 	// Start a new init.
@@ -1288,6 +1300,11 @@ async function runGeneration(
 					);
 
 					kvManager.appendAndCompress(layerIdx, lastKeyTensor, lastValTensor);
+
+					// Dispose the temporary single-token tensors — appendAndCompress
+					// has already .slice()'d the data it needs into owned copies.
+					disposeTensor(lastKeyTensor);
+					disposeTensor(lastValTensor);
 				}
 			}
 

--- a/packages/daemon/src/turboquant-cache.test.ts
+++ b/packages/daemon/src/turboquant-cache.test.ts
@@ -189,7 +189,6 @@ describe("compress/decompress roundtrip", () => {
 			const compressed = cache.compressVector(vec);
 			const restored = cache.decompressVector(compressed);
 			const sim = cosineSim(vec, restored);
-			// 4-bit should have > 0.99 cosine similarity for dim=64
 			expect(sim).toBeGreaterThan(0.95);
 		}
 	});
@@ -206,7 +205,6 @@ describe("compress/decompress roundtrip", () => {
 			const compressed = cache.compressVector(vec);
 			const restored = cache.decompressVector(compressed);
 			const sim = cosineSim(vec, restored);
-			// 3-bit should still be quite good
 			expect(sim).toBeGreaterThan(0.9);
 		}
 	});
@@ -222,7 +220,19 @@ describe("compress/decompress roundtrip", () => {
 		expect(compressed.norm).toBeCloseTo(l2Norm(vec), 5);
 	});
 
-	it("indices are valid (< numCentroids)", () => {
+	it("packedCodes has correct byte length for 4-bit", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 4,
+			headDim: DIM,
+			numHeads: 1,
+		});
+		const vec = randomVector(DIM, 7);
+		const compressed = cache.compressVector(vec);
+		// 4 bits * 64 dim = 256 bits = 32 bytes
+		expect(compressed.packedCodes.length).toBe(Math.ceil((DIM * 4) / 8));
+	});
+
+	it("packedCodes has correct byte length for 3-bit", () => {
 		const cache = TurboQuantKvCache.create({
 			bits: 3,
 			headDim: DIM,
@@ -230,9 +240,20 @@ describe("compress/decompress roundtrip", () => {
 		});
 		const vec = randomVector(DIM, 7);
 		const compressed = cache.compressVector(vec);
-		for (const idx of compressed.indices) {
-			expect(idx).toBeLessThan(cache.numCentroids);
-		}
+		// 3 bits * 64 dim = 192 bits = 24 bytes
+		expect(compressed.packedCodes.length).toBe(Math.ceil((DIM * 3) / 8));
+	});
+
+	it("packedCodes has correct byte length for 1-bit", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 1,
+			headDim: DIM,
+			numHeads: 1,
+		});
+		const vec = randomVector(DIM, 7);
+		const compressed = cache.compressVector(vec);
+		// 1 bit * 64 dim = 64 bits = 8 bytes
+		expect(compressed.packedCodes.length).toBe(Math.ceil((DIM * 1) / 8));
 	});
 
 	it("higher bits → lower MSE", () => {
@@ -301,7 +322,7 @@ describe("determinism", () => {
 		const r2 = c2.compressVector(vec);
 
 		expect(r1.norm).toBe(r2.norm);
-		expect(Array.from(r1.indices)).toEqual(Array.from(r2.indices));
+		expect(Array.from(r1.packedCodes)).toEqual(Array.from(r2.packedCodes));
 	});
 
 	it("different seeds produce different compression", () => {
@@ -322,12 +343,11 @@ describe("determinism", () => {
 		const r1 = c1.compressVector(vec);
 		const r2 = c2.compressVector(vec);
 
-		// Norms should match (same vector), but indices should differ
+		// Norms should match (same vector), but packed codes should differ
 		expect(r1.norm).toBeCloseTo(r2.norm, 5);
-		// Indices won't be identical with different rotation matrices
 		let anyDifferent = false;
-		for (let i = 0; i < r1.indices.length; i++) {
-			if (r1.indices[i] !== r2.indices[i]) {
+		for (let i = 0; i < r1.packedCodes.length; i++) {
+			if (r1.packedCodes[i] !== r2.packedCodes[i]) {
 				anyDifferent = true;
 				break;
 			}
@@ -386,8 +406,9 @@ describe("storeCompressed / getCompressedLayer", () => {
 		const v = randomVector(32, 2);
 
 		const result = cache.storeCompressed(0, 0, k, v);
-		expect(result.key.indices.length).toBe(32);
-		expect(result.value.indices.length).toBe(32);
+		// 4 bits * 32 dim = 128 bits = 16 bytes
+		expect(result.key.packedCodes.length).toBe(Math.ceil((32 * 4) / 8));
+		expect(result.value.packedCodes.length).toBe(Math.ceil((32 * 4) / 8));
 
 		const layer = cache.getCompressedLayer(0, 0);
 		expect(layer).toBeDefined();
@@ -395,7 +416,7 @@ describe("storeCompressed / getCompressedLayer", () => {
 		expect(layer?.values.length).toBe(1);
 	});
 
-	it("accumulates entries across calls", () => {
+	it("accumulates entries across calls (O(1) push, no copying)", () => {
 		const cache = TurboQuantKvCache.create({
 			bits: 4,
 			headDim: 32,
@@ -593,7 +614,6 @@ describe("quality at typical model dimensions", () => {
 			totalMse += mse(vec, restored);
 		}
 		const avgMse = totalMse / trials;
-		// At dim=128, 4-bit should be very accurate
 		expect(avgMse).toBeLessThan(0.01);
 	});
 

--- a/packages/daemon/src/turboquant-cache.test.ts
+++ b/packages/daemon/src/turboquant-cache.test.ts
@@ -189,6 +189,7 @@ describe("compress/decompress roundtrip", () => {
 			const compressed = cache.compressVector(vec);
 			const restored = cache.decompressVector(compressed);
 			const sim = cosineSim(vec, restored);
+			// 4-bit should have > 0.99 cosine similarity for dim=64
 			expect(sim).toBeGreaterThan(0.95);
 		}
 	});
@@ -205,6 +206,7 @@ describe("compress/decompress roundtrip", () => {
 			const compressed = cache.compressVector(vec);
 			const restored = cache.decompressVector(compressed);
 			const sim = cosineSim(vec, restored);
+			// 3-bit should still be quite good
 			expect(sim).toBeGreaterThan(0.9);
 		}
 	});
@@ -230,6 +232,8 @@ describe("compress/decompress roundtrip", () => {
 		const compressed = cache.compressVector(vec);
 		// 4 bits * 64 dim = 256 bits = 32 bytes
 		expect(compressed.packedCodes.length).toBe(Math.ceil((DIM * 4) / 8));
+		expect(compressed.dim).toBe(DIM);
+		expect(compressed.bits).toBe(4);
 	});
 
 	it("packedCodes has correct byte length for 3-bit", () => {
@@ -242,6 +246,18 @@ describe("compress/decompress roundtrip", () => {
 		const compressed = cache.compressVector(vec);
 		// 3 bits * 64 dim = 192 bits = 24 bytes
 		expect(compressed.packedCodes.length).toBe(Math.ceil((DIM * 3) / 8));
+	});
+
+	it("packedCodes has correct byte length for 2-bit", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 2,
+			headDim: DIM,
+			numHeads: 1,
+		});
+		const vec = randomVector(DIM, 7);
+		const compressed = cache.compressVector(vec);
+		// 2 bits * 64 dim = 128 bits = 16 bytes
+		expect(compressed.packedCodes.length).toBe(Math.ceil((DIM * 2) / 8));
 	});
 
 	it("packedCodes has correct byte length for 1-bit", () => {
@@ -345,6 +361,7 @@ describe("determinism", () => {
 
 		// Norms should match (same vector), but packed codes should differ
 		expect(r1.norm).toBeCloseTo(r2.norm, 5);
+		// Packed codes won't be identical with different rotation matrices
 		let anyDifferent = false;
 		for (let i = 0; i < r1.packedCodes.length; i++) {
 			if (r1.packedCodes[i] !== r2.packedCodes[i]) {
@@ -416,7 +433,7 @@ describe("storeCompressed / getCompressedLayer", () => {
 		expect(layer?.values.length).toBe(1);
 	});
 
-	it("accumulates entries across calls (O(1) push, no copying)", () => {
+	it("accumulates entries across calls", () => {
 		const cache = TurboQuantKvCache.create({
 			bits: 4,
 			headDim: 32,
@@ -614,6 +631,7 @@ describe("quality at typical model dimensions", () => {
 			totalMse += mse(vec, restored);
 		}
 		const avgMse = totalMse / trials;
+		// At dim=128, 4-bit should be very accurate
 		expect(avgMse).toBeLessThan(0.01);
 	});
 

--- a/packages/daemon/src/turboquant-cache.test.ts
+++ b/packages/daemon/src/turboquant-cache.test.ts
@@ -1,0 +1,618 @@
+import { describe, expect, it } from "bun:test";
+import {
+	DEFAULT_KV_CACHE_COMPRESSION,
+	OLLAMA_KV_CACHE_GUIDANCE,
+	TurboQuantKvCache,
+	parseKvCacheCompressionConfig,
+} from "./turboquant-cache";
+import type { CompressedKvEntry, KvCacheCompressionOption, TurboQuantKvCacheConfig } from "./turboquant-cache";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Generate a random Float32Array of given length with seeded values. */
+function randomVector(length: number, seed = 1): Float32Array {
+	const vec = new Float32Array(length);
+	let state = seed;
+	for (let i = 0; i < length; i++) {
+		// LCG for deterministic pseudo-random
+		state = (state * 1664525 + 1013904223) >>> 0;
+		vec[i] = (state / 4294967296) * 2 - 1; // [-1, 1]
+	}
+	return vec;
+}
+
+/** Compute L2 norm of a vector. */
+function l2Norm(v: Float32Array): number {
+	let sum = 0;
+	for (let i = 0; i < v.length; i++) sum += v[i] * v[i];
+	return Math.sqrt(sum);
+}
+
+/** Compute cosine similarity between two vectors. */
+function cosineSim(a: Float32Array, b: Float32Array): number {
+	let dot = 0;
+	let na = 0;
+	let nb = 0;
+	for (let i = 0; i < a.length; i++) {
+		dot += a[i] * b[i];
+		na += a[i] * a[i];
+		nb += b[i] * b[i];
+	}
+	const denom = Math.sqrt(na) * Math.sqrt(nb);
+	return denom > 0 ? dot / denom : 0;
+}
+
+/** Compute MSE between two vectors. */
+function mse(a: Float32Array, b: Float32Array): number {
+	let sum = 0;
+	for (let i = 0; i < a.length; i++) {
+		const diff = a[i] - b[i];
+		sum += diff * diff;
+	}
+	return sum / a.length;
+}
+
+// ---------------------------------------------------------------------------
+// TurboQuantKvCache creation
+// ---------------------------------------------------------------------------
+
+describe("TurboQuantKvCache.create", () => {
+	it("creates with valid config", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 4,
+			headDim: 64,
+			numHeads: 8,
+		});
+		expect(cache.config.bits).toBe(4);
+		expect(cache.config.headDim).toBe(64);
+		expect(cache.config.numHeads).toBe(8);
+		expect(cache.config.residualWindowSize).toBe(128);
+		expect(cache.config.seed).toBe(42);
+	});
+
+	it("accepts custom residualWindowSize and seed", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 3,
+			headDim: 128,
+			numHeads: 32,
+			residualWindowSize: 256,
+			seed: 99,
+		});
+		expect(cache.config.residualWindowSize).toBe(256);
+		expect(cache.config.seed).toBe(99);
+	});
+
+	it("rejects invalid bit width", () => {
+		expect(() =>
+			TurboQuantKvCache.create({
+				bits: 5 as 4,
+				headDim: 64,
+				numHeads: 8,
+			}),
+		).toThrow(/Invalid bit width/);
+	});
+
+	it("rejects headDim < 2", () => {
+		expect(() => TurboQuantKvCache.create({ bits: 4, headDim: 1, numHeads: 8 })).toThrow(/headDim must be >= 2/);
+	});
+
+	it("rejects numHeads < 1", () => {
+		expect(() => TurboQuantKvCache.create({ bits: 4, headDim: 64, numHeads: 0 })).toThrow(/numHeads must be >= 1/);
+	});
+
+	it("numCentroids matches 2^bits", () => {
+		for (const bits of [1, 2, 3, 4] as const) {
+			const cache = TurboQuantKvCache.create({
+				bits,
+				headDim: 32,
+				numHeads: 1,
+			});
+			expect(cache.numCentroids).toBe(2 ** bits);
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Codebook properties
+// ---------------------------------------------------------------------------
+
+describe("codebook", () => {
+	it("has correct number of centroids", () => {
+		for (const bits of [1, 2, 3, 4] as const) {
+			const cache = TurboQuantKvCache.create({
+				bits,
+				headDim: 64,
+				numHeads: 1,
+			});
+			expect(cache.codebook.length).toBe(2 ** bits);
+		}
+	});
+
+	it("centroids are sorted ascending", () => {
+		for (const bits of [1, 2, 3, 4] as const) {
+			const cache = TurboQuantKvCache.create({
+				bits,
+				headDim: 64,
+				numHeads: 1,
+			});
+			const cb = cache.codebook;
+			for (let i = 1; i < cb.length; i++) {
+				expect(cb[i]).toBeGreaterThan(cb[i - 1]);
+			}
+		}
+	});
+
+	it("centroids are symmetric around zero for even centroids", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 2,
+			headDim: 64,
+			numHeads: 1,
+		});
+		const cb = cache.codebook;
+		// Symmetric Beta → symmetric codebook
+		for (let i = 0; i < cb.length; i++) {
+			expect(cb[i] + cb[cb.length - 1 - i]).toBeCloseTo(0, 4);
+		}
+	});
+
+	it("all centroids are within [-1, 1]", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 4,
+			headDim: 128,
+			numHeads: 1,
+		});
+		for (const c of cache.codebook) {
+			expect(c).toBeGreaterThanOrEqual(-1);
+			expect(c).toBeLessThanOrEqual(1);
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Compress / decompress roundtrip
+// ---------------------------------------------------------------------------
+
+describe("compress/decompress roundtrip", () => {
+	const DIM = 64;
+
+	it("preserves vector direction (high cosine similarity) at 4-bit", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 4,
+			headDim: DIM,
+			numHeads: 1,
+		});
+
+		for (let seed = 1; seed <= 10; seed++) {
+			const vec = randomVector(DIM, seed);
+			const compressed = cache.compressVector(vec);
+			const restored = cache.decompressVector(compressed);
+			const sim = cosineSim(vec, restored);
+			// 4-bit should have > 0.99 cosine similarity for dim=64
+			expect(sim).toBeGreaterThan(0.95);
+		}
+	});
+
+	it("preserves vector direction at 3-bit", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 3,
+			headDim: DIM,
+			numHeads: 1,
+		});
+
+		for (let seed = 1; seed <= 10; seed++) {
+			const vec = randomVector(DIM, seed);
+			const compressed = cache.compressVector(vec);
+			const restored = cache.decompressVector(compressed);
+			const sim = cosineSim(vec, restored);
+			// 3-bit should still be quite good
+			expect(sim).toBeGreaterThan(0.9);
+		}
+	});
+
+	it("preserves norm", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 4,
+			headDim: DIM,
+			numHeads: 1,
+		});
+		const vec = randomVector(DIM, 42);
+		const compressed = cache.compressVector(vec);
+		expect(compressed.norm).toBeCloseTo(l2Norm(vec), 5);
+	});
+
+	it("indices are valid (< numCentroids)", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 3,
+			headDim: DIM,
+			numHeads: 1,
+		});
+		const vec = randomVector(DIM, 7);
+		const compressed = cache.compressVector(vec);
+		for (const idx of compressed.indices) {
+			expect(idx).toBeLessThan(cache.numCentroids);
+		}
+	});
+
+	it("higher bits → lower MSE", () => {
+		const vec = randomVector(DIM, 99);
+		const mseByBits: number[] = [];
+
+		for (const bits of [1, 2, 3, 4] as const) {
+			const cache = TurboQuantKvCache.create({
+				bits,
+				headDim: DIM,
+				numHeads: 1,
+			});
+			const compressed = cache.compressVector(vec);
+			const restored = cache.decompressVector(compressed);
+			mseByBits.push(mse(vec, restored));
+		}
+
+		// Each increase in bits should reduce MSE
+		for (let i = 1; i < mseByBits.length; i++) {
+			expect(mseByBits[i]).toBeLessThan(mseByBits[i - 1]);
+		}
+	});
+
+	it("handles zero vector gracefully", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 4,
+			headDim: DIM,
+			numHeads: 1,
+		});
+		const zero = new Float32Array(DIM);
+		const compressed = cache.compressVector(zero);
+		expect(compressed.norm).toBeCloseTo(0);
+		const restored = cache.decompressVector(compressed);
+		for (const v of restored) {
+			expect(Math.abs(v)).toBeLessThan(1e-6);
+		}
+	});
+
+	it("rejects wrong-length vector", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 4,
+			headDim: DIM,
+			numHeads: 1,
+		});
+		expect(() => cache.compressVector(new Float32Array(DIM + 1))).toThrow(/Vector length/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Determinism
+// ---------------------------------------------------------------------------
+
+describe("determinism", () => {
+	it("same seed produces identical compression", () => {
+		const config: TurboQuantKvCacheConfig = {
+			bits: 4,
+			headDim: 64,
+			numHeads: 1,
+			seed: 123,
+		};
+		const c1 = TurboQuantKvCache.create(config);
+		const c2 = TurboQuantKvCache.create(config);
+
+		const vec = randomVector(64, 7);
+		const r1 = c1.compressVector(vec);
+		const r2 = c2.compressVector(vec);
+
+		expect(r1.norm).toBe(r2.norm);
+		expect(Array.from(r1.indices)).toEqual(Array.from(r2.indices));
+	});
+
+	it("different seeds produce different compression", () => {
+		const vec = randomVector(64, 7);
+		const c1 = TurboQuantKvCache.create({
+			bits: 4,
+			headDim: 64,
+			numHeads: 1,
+			seed: 1,
+		});
+		const c2 = TurboQuantKvCache.create({
+			bits: 4,
+			headDim: 64,
+			numHeads: 1,
+			seed: 999,
+		});
+
+		const r1 = c1.compressVector(vec);
+		const r2 = c2.compressVector(vec);
+
+		// Norms should match (same vector), but indices should differ
+		expect(r1.norm).toBeCloseTo(r2.norm, 5);
+		// Indices won't be identical with different rotation matrices
+		let anyDifferent = false;
+		for (let i = 0; i < r1.indices.length; i++) {
+			if (r1.indices[i] !== r2.indices[i]) {
+				anyDifferent = true;
+				break;
+			}
+		}
+		expect(anyDifferent).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Residual window
+// ---------------------------------------------------------------------------
+
+describe("shouldCompress", () => {
+	it("does not compress tokens within residual window", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 4,
+			headDim: 64,
+			numHeads: 1,
+			residualWindowSize: 32,
+		});
+
+		// SeqLen = 100, window = 32 → tokens 0-67 compressed, 68-99 not
+		expect(cache.shouldCompress(0, 100)).toBe(true);
+		expect(cache.shouldCompress(67, 100)).toBe(true);
+		expect(cache.shouldCompress(68, 100)).toBe(false);
+		expect(cache.shouldCompress(99, 100)).toBe(false);
+	});
+
+	it("nothing compressed when seqLen <= windowSize", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 4,
+			headDim: 64,
+			numHeads: 1,
+			residualWindowSize: 128,
+		});
+
+		for (let pos = 0; pos < 128; pos++) {
+			expect(cache.shouldCompress(pos, 128)).toBe(false);
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Store / retrieve compressed entries
+// ---------------------------------------------------------------------------
+
+describe("storeCompressed / getCompressedLayer", () => {
+	it("stores and retrieves compressed KV pairs", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 4,
+			headDim: 32,
+			numHeads: 2,
+		});
+
+		const k = randomVector(32, 1);
+		const v = randomVector(32, 2);
+
+		const result = cache.storeCompressed(0, 0, k, v);
+		expect(result.key.indices.length).toBe(32);
+		expect(result.value.indices.length).toBe(32);
+
+		const layer = cache.getCompressedLayer(0, 0);
+		expect(layer).toBeDefined();
+		expect(layer?.keys.length).toBe(1);
+		expect(layer?.values.length).toBe(1);
+	});
+
+	it("accumulates entries across calls", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 4,
+			headDim: 32,
+			numHeads: 1,
+		});
+
+		for (let i = 0; i < 5; i++) {
+			cache.storeCompressed(0, 0, randomVector(32, i), randomVector(32, i + 100));
+		}
+
+		const layer = cache.getCompressedLayer(0, 0);
+		expect(layer?.keys.length).toBe(5);
+		expect(layer?.values.length).toBe(5);
+	});
+
+	it("separates layers and heads", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 4,
+			headDim: 32,
+			numHeads: 4,
+		});
+
+		cache.storeCompressed(0, 0, randomVector(32, 1), randomVector(32, 2));
+		cache.storeCompressed(0, 1, randomVector(32, 3), randomVector(32, 4));
+		cache.storeCompressed(1, 0, randomVector(32, 5), randomVector(32, 6));
+
+		expect(cache.getCompressedLayer(0, 0)?.keys.length).toBe(1);
+		expect(cache.getCompressedLayer(0, 1)?.keys.length).toBe(1);
+		expect(cache.getCompressedLayer(1, 0)?.keys.length).toBe(1);
+		expect(cache.getCompressedLayer(1, 1)).toBeUndefined();
+	});
+
+	it("returns undefined for missing layer/head", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 4,
+			headDim: 32,
+			numHeads: 1,
+		});
+		expect(cache.getCompressedLayer(99, 0)).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Sequence tracking and reset
+// ---------------------------------------------------------------------------
+
+describe("sequence tracking", () => {
+	it("tracks sequence length", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 4,
+			headDim: 32,
+			numHeads: 1,
+		});
+		expect(cache.sequenceLength).toBe(0);
+		cache.advanceSequence(10);
+		expect(cache.sequenceLength).toBe(10);
+		cache.advanceSequence();
+		expect(cache.sequenceLength).toBe(11);
+	});
+
+	it("reset clears everything", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 4,
+			headDim: 32,
+			numHeads: 1,
+		});
+		cache.storeCompressed(0, 0, randomVector(32, 1), randomVector(32, 2));
+		cache.advanceSequence(50);
+
+		cache.reset();
+		expect(cache.sequenceLength).toBe(0);
+		expect(cache.getCompressedLayer(0, 0)).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Memory statistics
+// ---------------------------------------------------------------------------
+
+describe("computeMemoryStats", () => {
+	it("computes reasonable compression ratio", () => {
+		const stats = TurboQuantKvCache.computeMemoryStats(
+			128, // headDim
+			4, // bits
+			32, // numHeads
+			24, // numLayers
+			896, // compressedTokens (1024 - 128)
+			128, // residualTokens
+		);
+
+		expect(stats.compressedBytes).toBeGreaterThan(0);
+		expect(stats.residualBytes).toBeGreaterThan(0);
+		expect(stats.totalBytes).toBe(stats.compressedBytes + stats.residualBytes);
+		expect(stats.compressionRatio).toBeGreaterThan(1);
+		expect(stats.uncompressedBytes).toBeGreaterThan(stats.totalBytes);
+	});
+
+	it("compression ratio increases with more compressed tokens", () => {
+		const stats1 = TurboQuantKvCache.computeMemoryStats(128, 4, 32, 24, 100, 128);
+		const stats2 = TurboQuantKvCache.computeMemoryStats(128, 4, 32, 24, 1000, 128);
+		expect(stats2.compressionRatio).toBeGreaterThan(stats1.compressionRatio);
+	});
+
+	it("lower bits → higher compression ratio", () => {
+		const stats3 = TurboQuantKvCache.computeMemoryStats(128, 3, 32, 24, 896, 128);
+		const stats4 = TurboQuantKvCache.computeMemoryStats(128, 4, 32, 24, 896, 128);
+		expect(stats3.compressionRatio).toBeGreaterThan(stats4.compressionRatio);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Config parsing
+// ---------------------------------------------------------------------------
+
+describe("parseKvCacheCompressionConfig", () => {
+	it("returns defaults for undefined/null", () => {
+		expect(parseKvCacheCompressionConfig(undefined)).toEqual(DEFAULT_KV_CACHE_COMPRESSION);
+		expect(parseKvCacheCompressionConfig(null)).toEqual(DEFAULT_KV_CACHE_COMPRESSION);
+	});
+
+	it("accepts boolean shorthand", () => {
+		const enabled = parseKvCacheCompressionConfig(true);
+		expect(enabled.enabled).toBe(true);
+		expect(enabled.bits).toBe(DEFAULT_KV_CACHE_COMPRESSION.bits);
+
+		const disabled = parseKvCacheCompressionConfig(false);
+		expect(disabled.enabled).toBe(false);
+	});
+
+	it("parses full config object", () => {
+		const result = parseKvCacheCompressionConfig({
+			enabled: true,
+			bits: 3,
+			residualWindowSize: 256,
+		});
+		expect(result.enabled).toBe(true);
+		expect(result.bits).toBe(3);
+		expect(result.residualWindowSize).toBe(256);
+	});
+
+	it("falls back for invalid bits", () => {
+		const result = parseKvCacheCompressionConfig({
+			enabled: true,
+			bits: 7,
+		});
+		expect(result.bits).toBe(DEFAULT_KV_CACHE_COMPRESSION.bits);
+	});
+
+	it("falls back for invalid residualWindowSize", () => {
+		const result = parseKvCacheCompressionConfig({
+			enabled: true,
+			residualWindowSize: -10,
+		});
+		expect(result.residualWindowSize).toBe(DEFAULT_KV_CACHE_COMPRESSION.residualWindowSize);
+	});
+
+	it("ignores non-object types", () => {
+		expect(parseKvCacheCompressionConfig("yes")).toEqual(DEFAULT_KV_CACHE_COMPRESSION);
+		expect(parseKvCacheCompressionConfig(42)).toEqual(DEFAULT_KV_CACHE_COMPRESSION);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Ollama guidance
+// ---------------------------------------------------------------------------
+
+describe("OLLAMA_KV_CACHE_GUIDANCE", () => {
+	it("has expected structure", () => {
+		expect(OLLAMA_KV_CACHE_GUIDANCE.envVar).toBe("OLLAMA_KV_CACHE_TYPE");
+		expect(OLLAMA_KV_CACHE_GUIDANCE.recommendedValue).toBe("q4_0");
+		expect(OLLAMA_KV_CACHE_GUIDANCE.alternativeValues).toContain("q8_0");
+		expect(OLLAMA_KV_CACHE_GUIDANCE.alternativeValues).toContain("f16");
+		expect(typeof OLLAMA_KV_CACHE_GUIDANCE.description).toBe("string");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Higher-dimension / batch quality tests
+// ---------------------------------------------------------------------------
+
+describe("quality at typical model dimensions", () => {
+	it("dim=128 (typical head_dim) has excellent quality at 4-bit", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 4,
+			headDim: 128,
+			numHeads: 1,
+		});
+
+		let totalMse = 0;
+		const trials = 50;
+		for (let i = 0; i < trials; i++) {
+			const vec = randomVector(128, i + 1000);
+			const compressed = cache.compressVector(vec);
+			const restored = cache.decompressVector(compressed);
+			totalMse += mse(vec, restored);
+		}
+		const avgMse = totalMse / trials;
+		// At dim=128, 4-bit should be very accurate
+		expect(avgMse).toBeLessThan(0.01);
+	});
+
+	it("dim=128, 3-bit still has good quality", () => {
+		const cache = TurboQuantKvCache.create({
+			bits: 3,
+			headDim: 128,
+			numHeads: 1,
+		});
+
+		let totalSim = 0;
+		const trials = 50;
+		for (let i = 0; i < trials; i++) {
+			const vec = randomVector(128, i + 2000);
+			const compressed = cache.compressVector(vec);
+			const restored = cache.decompressVector(compressed);
+			totalSim += cosineSim(vec, restored);
+		}
+		const avgSim = totalSim / trials;
+		expect(avgSim).toBeGreaterThan(0.95);
+	});
+});

--- a/packages/daemon/src/turboquant-cache.ts
+++ b/packages/daemon/src/turboquant-cache.ts
@@ -515,11 +515,21 @@ export class TurboQuantKvCache {
 			throw new Error(`numHeads must be >= 1, got ${String(config.numHeads)}`);
 		}
 
+		// Validate residualWindowSize if provided
+		const rawWindow = config.residualWindowSize;
+		if (rawWindow !== undefined) {
+			if (!Number.isFinite(rawWindow) || rawWindow < 0 || !Number.isInteger(rawWindow)) {
+				throw new Error(
+					`residualWindowSize must be a non-negative integer, got ${String(rawWindow)}`,
+				);
+			}
+		}
+
 		const resolved: Required<TurboQuantKvCacheConfig> = {
 			bits: config.bits,
 			headDim: config.headDim,
 			numHeads: config.numHeads,
-			residualWindowSize: config.residualWindowSize ?? 128,
+			residualWindowSize: rawWindow ?? 128,
 			seed: config.seed ?? 42,
 		};
 
@@ -647,6 +657,11 @@ export class TurboQuantKvCache {
 		key: Float32Array,
 		value: Float32Array,
 	): { readonly key: CompressedKvEntry; readonly value: CompressedKvEntry } {
+		if (headIdx < 0 || headIdx >= this._config.numHeads) {
+			throw new Error(
+				`headIdx ${String(headIdx)} out of range [0, ${String(this._config.numHeads)})`,
+			);
+		}
 		const compKey = this.compressVector(key);
 		const compValue = this.compressVector(value);
 
@@ -675,6 +690,9 @@ export class TurboQuantKvCache {
 
 	/** Advance the sequence position counter. */
 	advanceSequence(count = 1): void {
+		if (!Number.isFinite(count) || count < 0) {
+			throw new Error(`advanceSequence count must be a non-negative finite number, got ${String(count)}`);
+		}
 		this._seqLen += count;
 	}
 

--- a/packages/daemon/src/turboquant-cache.ts
+++ b/packages/daemon/src/turboquant-cache.ts
@@ -1,0 +1,666 @@
+/**
+ * TurboQuant KV Cache Compression
+ *
+ * Pure TypeScript implementation of Google's TurboQuant algorithm
+ * (arXiv:2504.19874, ICLR 2026) adapted for KV cache compression
+ * in local generative model inference.
+ *
+ * Compresses key/value cache tensors to 3-4 bits per coordinate with
+ * near-zero accuracy loss, enabling ~6x memory reduction for long
+ * context windows.
+ *
+ * ## Current integration status
+ *
+ * - **nomic-embed-text (encoder):** Does NOT use KV cache. No integration needed.
+ * - **Ollama / qwen3:4b:** Manages its own KV cache via llama.cpp. Cannot
+ *   integrate directly. Use `OLLAMA_KV_CACHE_TYPE=q4_0` env var for Ollama's
+ *   built-in KV cache quantization instead.
+ * - **Future HuggingFace transformers.js generative models:** This module is
+ *   ready to drop in. Wrap the model's `generate()` call with a
+ *   {@link TurboQuantKvCache} to compress past-token KV entries automatically.
+ *
+ * ## Algorithm overview
+ *
+ * 1. Generate a deterministic random rotation matrix via QR decomposition
+ * 2. Compute an optimal codebook from the Beta((d-1)/2, (d-1)/2) distribution
+ * 3. Quantize: rotate each KV vector, find nearest centroid per coordinate
+ * 4. Dequantize: centroid lookup → inverse rotation → rescale by norm
+ * 5. A "residual window" of the most recent N tokens stays in full precision
+ *
+ * @see https://arxiv.org/abs/2504.19874
+ * @module
+ */
+
+import { logger } from "./logger";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/** Valid quantization bit widths. */
+const VALID_BITS = [1, 2, 3, 4] as const;
+type BitWidth = (typeof VALID_BITS)[number];
+
+export interface TurboQuantKvCacheConfig {
+	/** Bits per coordinate (1-4). Higher = more accurate, less compression. */
+	readonly bits: BitWidth;
+	/** Head dimension of the model (e.g. 64, 128). */
+	readonly headDim: number;
+	/** Number of attention heads (key side). */
+	readonly numHeads: number;
+	/**
+	 * Number of recent tokens to keep in full precision.
+	 * Tokens outside this window are compressed.
+	 * @default 128
+	 */
+	readonly residualWindowSize?: number;
+	/** Random seed for deterministic rotation matrix. */
+	readonly seed?: number;
+}
+
+/**
+ * User-facing config option for agent.yaml `memory.kv_cache_compression`.
+ * Defaults to OFF — must be explicitly enabled.
+ */
+export interface KvCacheCompressionOption {
+	readonly enabled: boolean;
+	readonly bits?: BitWidth;
+	readonly residualWindowSize?: number;
+}
+
+export const DEFAULT_KV_CACHE_COMPRESSION: KvCacheCompressionOption = {
+	enabled: false,
+	bits: 4,
+	residualWindowSize: 128,
+};
+
+// ---------------------------------------------------------------------------
+// Math utilities — seeded PRNG, QR, matrix ops
+// ---------------------------------------------------------------------------
+
+/** Seeded xoshiro128** PRNG returning values in [0, 1). */
+function createRng(seed: number): () => number {
+	let s0 = seed >>> 0;
+	let s1 = (seed * 1597334677) >>> 0;
+	let s2 = (seed * 2654435761) >>> 0;
+	let s3 = (seed * 668265263) >>> 0;
+
+	for (let i = 0; i < 20; i++) {
+		const t = s1 << 9;
+		s2 ^= s0;
+		s3 ^= s1;
+		s1 ^= s2;
+		s0 ^= s3;
+		s2 ^= t;
+		s3 = (s3 << 11) | (s3 >>> 21);
+	}
+
+	return (): number => {
+		const result = Math.imul(s1 * 5, 1) >>> 0;
+		const rot = ((result << 7) | (result >>> 25)) >>> 0;
+		const t = s1 << 9;
+		s2 ^= s0;
+		s3 ^= s1;
+		s1 ^= s2;
+		s0 ^= s3;
+		s2 ^= t;
+		s3 = (s3 << 11) | (s3 >>> 21);
+		return (rot >>> 0) / 4294967296;
+	};
+}
+
+/** Generate a flat row-major matrix of standard normal samples (Box-Muller). */
+function randnMatrix(rows: number, cols: number, rng: () => number): Float32Array {
+	const data = new Float32Array(rows * cols);
+	for (let i = 0; i < data.length - 1; i += 2) {
+		const u1 = rng() || 1e-10;
+		const u2 = rng();
+		const r = Math.sqrt(-2 * Math.log(u1));
+		const theta = 2 * Math.PI * u2;
+		data[i] = r * Math.cos(theta);
+		data[i + 1] = r * Math.sin(theta);
+	}
+	if (data.length % 2 !== 0) {
+		const u1 = rng() || 1e-10;
+		const u2 = rng();
+		data[data.length - 1] = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+	}
+	return data;
+}
+
+/**
+ * QR decomposition via modified Gram-Schmidt.
+ * Returns Q (orthogonal) as a flat Float32Array (rows × cols, row-major).
+ */
+function qrQ(matrix: Float32Array, rows: number, cols: number): Float32Array {
+	const q = new Float32Array(matrix);
+
+	const getCol = (c: number): Float32Array => {
+		const col = new Float32Array(rows);
+		for (let r = 0; r < rows; r++) col[r] = q[r * cols + c];
+		return col;
+	};
+	const setCol = (c: number, col: Float32Array): void => {
+		for (let r = 0; r < rows; r++) q[r * cols + c] = col[r];
+	};
+	const dot = (a: Float32Array, b: Float32Array): number => {
+		let s = 0;
+		for (let i = 0; i < a.length; i++) s += a[i] * b[i];
+		return s;
+	};
+
+	for (let j = 0; j < cols; j++) {
+		const col = getCol(j);
+		for (let k = 0; k < j; k++) {
+			const qk = getCol(k);
+			const proj = dot(col, qk);
+			for (let i = 0; i < rows; i++) col[i] -= proj * qk[i];
+		}
+		const norm = Math.sqrt(dot(col, col));
+		if (norm > 1e-10) {
+			for (let i = 0; i < rows; i++) col[i] /= norm;
+		}
+		setCol(j, col);
+	}
+	return q;
+}
+
+/** Matrix-vector multiply: result = M @ v. M is (rows × cols) row-major. */
+function matVecMul(m: Float32Array, v: Float32Array, rows: number, cols: number): Float32Array {
+	const result = new Float32Array(rows);
+	for (let r = 0; r < rows; r++) {
+		let sum = 0;
+		const off = r * cols;
+		for (let c = 0; c < cols; c++) sum += m[off + c] * v[c];
+		result[r] = sum;
+	}
+	return result;
+}
+
+/** Transpose-multiply: result = M^T @ v. M is (rows × cols) row-major. */
+function matTVecMul(m: Float32Array, v: Float32Array, rows: number, cols: number): Float32Array {
+	const result = new Float32Array(cols);
+	for (let r = 0; r < rows; r++) {
+		const vi = v[r];
+		const off = r * cols;
+		for (let c = 0; c < cols; c++) result[c] += m[off + c] * vi;
+	}
+	return result;
+}
+
+// ---------------------------------------------------------------------------
+// Beta distribution utilities (codebook computation)
+// ---------------------------------------------------------------------------
+
+/** Log-gamma via Lanczos approximation. */
+function lgamma(x: number): number {
+	const c = [
+		0.99999999999980993, 676.5203681218851, -1259.1392167224028, 771.32342877765313, -176.61502916214059,
+		12.507343278686905, -0.13857109526572012, 9.9843695780195716e-6, 1.5056327351493116e-7,
+	];
+	if (x < 0.5) {
+		return Math.log(Math.PI / Math.sin(Math.PI * x)) - lgamma(1 - x);
+	}
+	const xm = x - 1;
+	let a = c[0];
+	const t = xm + 7.5;
+	for (let i = 1; i < 9; i++) a += c[i] / (xm + i);
+	return 0.5 * Math.log(2 * Math.PI) + (xm + 0.5) * Math.log(t) - t + Math.log(a);
+}
+
+/** Regularized incomplete beta I_x(a, b) via Lentz continued fraction. */
+function betaInc(x: number, a: number, b: number): number {
+	if (x <= 0) return 0;
+	if (x >= 1) return 1;
+	if (x > (a + 1) / (a + b + 2)) return 1 - betaInc(1 - x, b, a);
+
+	const lnBeta = lgamma(a) + lgamma(b) - lgamma(a + b);
+	const front = Math.exp(Math.log(x) * a + Math.log(1 - x) * b - lnBeta) / a;
+
+	let d = 1 - ((a + b) * x) / (a + 1);
+	if (Math.abs(d) < 1e-30) d = 1e-30;
+	d = 1 / d;
+	let f = d;
+	let c = 1;
+
+	for (let m = 1; m <= 200; m++) {
+		let num = (m * (b - m) * x) / ((a + 2 * m - 1) * (a + 2 * m));
+		d = 1 + num * d;
+		if (Math.abs(d) < 1e-30) d = 1e-30;
+		c = 1 + num / c;
+		if (Math.abs(c) < 1e-30) c = 1e-30;
+		d = 1 / d;
+		f *= c * d;
+
+		num = (-(a + m) * (a + b + m) * x) / ((a + 2 * m) * (a + 2 * m + 1));
+		d = 1 + num * d;
+		if (Math.abs(d) < 1e-30) d = 1e-30;
+		c = 1 + num / c;
+		if (Math.abs(c) < 1e-30) c = 1e-30;
+		d = 1 / d;
+		const delta = c * d;
+		f *= delta;
+		if (Math.abs(delta - 1) < 1e-10) break;
+	}
+
+	return front * f;
+}
+
+/** Beta PDF on [0, 1]. */
+function betaPdf(x: number, a: number, b: number): number {
+	if (x <= 0 || x >= 1) return 0;
+	const lnB = lgamma(a) + lgamma(b) - lgamma(a + b);
+	return Math.exp((a - 1) * Math.log(x) + (b - 1) * Math.log(1 - x) - lnB);
+}
+
+/** Inverse regularized incomplete beta via Newton's method. */
+function betaIncinv(a: number, b: number, p: number): number {
+	if (p <= 0) return 0;
+	if (p >= 1) return 1;
+	let x = 0.5;
+	for (let iter = 0; iter < 100; iter++) {
+		const fx = betaInc(x, a, b) - p;
+		if (Math.abs(fx) < 1e-12) break;
+		const lnB = lgamma(a) + lgamma(b) - lgamma(a + b);
+		const pdf = Math.exp((a - 1) * Math.log(x + 1e-15) + (b - 1) * Math.log(1 - x + 1e-15) - lnB);
+		if (pdf < 1e-15) break;
+		x = Math.max(1e-10, Math.min(1 - 1e-10, x - fx / pdf));
+	}
+	return x;
+}
+
+// ---------------------------------------------------------------------------
+// Codebook
+// ---------------------------------------------------------------------------
+
+/** Compute the optimal TurboQuant codebook for Beta((d-1)/2, (d-1)/2). */
+function computeCodebook(dim: number, bits: number): Float32Array {
+	const nCentroids = 2 ** bits;
+	const alpha = (dim - 1) / 2;
+
+	if (bits === 1) {
+		const c = Math.sqrt(2 / (Math.PI * dim));
+		return new Float32Array([-c, c]);
+	}
+
+	const boundaries: number[] = [];
+	for (let i = 1; i < nCentroids; i++) {
+		const q = betaIncinv(alpha, alpha, i / nCentroids);
+		boundaries.push(2 * q - 1);
+	}
+
+	const centroids = new Float32Array(nCentroids);
+	const nPoints = 500;
+
+	for (let i = 0; i < nCentroids; i++) {
+		const lower = i === 0 ? -1 : boundaries[i - 1];
+		const upper = i < boundaries.length ? boundaries[i] : 1;
+		const a01 = Math.max((lower + 1) / 2, 1e-10);
+		const b01 = Math.min((upper + 1) / 2, 1 - 1e-10);
+
+		let sumXPdf = 0;
+		let sumPdf = 0;
+		const dx = (b01 - a01) / nPoints;
+
+		for (let j = 0; j <= nPoints; j++) {
+			const x01 = a01 + j * dx;
+			const pdf = betaPdf(x01, alpha, alpha);
+			const w = j === 0 || j === nPoints ? 0.5 : 1;
+			sumXPdf += w * x01 * pdf;
+			sumPdf += w * pdf;
+		}
+
+		const exp01 = sumPdf > 1e-15 ? sumXPdf / sumPdf : (a01 + b01) / 2;
+		centroids[i] = 2 * exp01 - 1;
+	}
+
+	return centroids;
+}
+
+// ---------------------------------------------------------------------------
+// Compressed KV entry
+// ---------------------------------------------------------------------------
+
+/** A single compressed KV vector (one head, one token). */
+export interface CompressedKvEntry {
+	/** Quantization indices per coordinate. */
+	readonly indices: Uint8Array;
+	/** Original L2 norm of the vector. */
+	readonly norm: number;
+}
+
+/** Per-layer, per-head compressed KV cache. */
+export interface CompressedKvLayer {
+	/** Compressed key vectors (one per token outside residual window). */
+	readonly keys: readonly CompressedKvEntry[];
+	/** Compressed value vectors (one per token outside residual window). */
+	readonly values: readonly CompressedKvEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// TurboQuantKvCache — main class
+// ---------------------------------------------------------------------------
+
+/**
+ * Manages TurboQuant-compressed KV cache for a single attention head dimension.
+ *
+ * Usage pattern for future generative model integration:
+ *
+ * ```ts
+ * const cache = TurboQuantKvCache.create({
+ *   bits: 4,
+ *   headDim: 128,
+ *   numHeads: 32,
+ *   residualWindowSize: 128,
+ * });
+ *
+ * // After each decoder step, compress old KV entries:
+ * const compressed = cache.compressVector(keyVector);
+ * const restored = cache.decompressVector(compressed);
+ * ```
+ */
+export class TurboQuantKvCache {
+	private readonly _config: Readonly<Required<TurboQuantKvCacheConfig>>;
+	private readonly _rotation: Float32Array;
+	private readonly _codebook: Float32Array;
+	private readonly _numCentroids: number;
+
+	/** Compressed KV entries per layer → per head. */
+	private readonly _layers: Map<number, Map<number, CompressedKvLayer>>;
+	/** Current sequence position (tokens seen). */
+	private _seqLen: number;
+
+	private constructor(config: Readonly<Required<TurboQuantKvCacheConfig>>) {
+		this._config = config;
+		this._numCentroids = 2 ** config.bits;
+		this._layers = new Map();
+		this._seqLen = 0;
+
+		const rng = createRng(config.seed);
+		const gaussian = randnMatrix(config.headDim, config.headDim, rng);
+		this._rotation = qrQ(gaussian, config.headDim, config.headDim);
+		this._codebook = computeCodebook(config.headDim, config.bits);
+	}
+
+	/**
+	 * Create a new TurboQuantKvCache instance.
+	 * Validates configuration and precomputes rotation matrix + codebook.
+	 */
+	static create(config: TurboQuantKvCacheConfig): TurboQuantKvCache {
+		if (!VALID_BITS.includes(config.bits)) {
+			throw new Error(`Invalid bit width: ${String(config.bits)}. Must be one of: ${VALID_BITS.join(", ")}`);
+		}
+		if (config.headDim < 2) {
+			throw new Error(`headDim must be >= 2, got ${String(config.headDim)}`);
+		}
+		if (config.numHeads < 1) {
+			throw new Error(`numHeads must be >= 1, got ${String(config.numHeads)}`);
+		}
+
+		const resolved: Required<TurboQuantKvCacheConfig> = {
+			bits: config.bits,
+			headDim: config.headDim,
+			numHeads: config.numHeads,
+			residualWindowSize: config.residualWindowSize ?? 128,
+			seed: config.seed ?? 42,
+		};
+
+		logger.info(
+			"memory",
+			`[turboquant] Initialized: ${String(resolved.bits)}-bit, headDim=${String(resolved.headDim)}, ` +
+				`numHeads=${String(resolved.numHeads)}, residualWindow=${String(resolved.residualWindowSize)}`,
+		);
+
+		return new TurboQuantKvCache(resolved);
+	}
+
+	/** Current configuration (read-only). */
+	get config(): Readonly<Required<TurboQuantKvCacheConfig>> {
+		return this._config;
+	}
+
+	/** Number of centroids (2^bits). */
+	get numCentroids(): number {
+		return this._numCentroids;
+	}
+
+	/** Current sequence length. */
+	get sequenceLength(): number {
+		return this._seqLen;
+	}
+
+	/** Codebook centroids (read-only copy). */
+	get codebook(): Float32Array {
+		return new Float32Array(this._codebook);
+	}
+
+	/**
+	 * Compress a single KV vector (one head, one coordinate set).
+	 *
+	 * Steps:
+	 * 1. Compute and store the L2 norm
+	 * 2. Normalize to unit vector
+	 * 3. Apply random rotation
+	 * 4. Find nearest codebook centroid per coordinate
+	 */
+	compressVector(vector: Float32Array): CompressedKvEntry {
+		const dim = this._config.headDim;
+		if (vector.length !== dim) {
+			throw new Error(`Vector length ${String(vector.length)} != headDim ${String(dim)}`);
+		}
+
+		// Compute norm
+		let normSq = 0;
+		for (let i = 0; i < dim; i++) normSq += vector[i] * vector[i];
+		const norm = Math.sqrt(normSq);
+
+		// Normalize
+		const unit = new Float32Array(dim);
+		const invNorm = norm > 1e-10 ? 1 / norm : 0;
+		for (let i = 0; i < dim; i++) unit[i] = vector[i] * invNorm;
+
+		// Rotate: y = rotation @ unit
+		const rotated = matVecMul(this._rotation, unit, dim, dim);
+
+		// Quantize: find nearest centroid per coordinate
+		const indices = new Uint8Array(dim);
+		for (let i = 0; i < dim; i++) {
+			let bestIdx = 0;
+			let bestDist = Math.abs(rotated[i] - this._codebook[0]);
+			for (let c = 1; c < this._numCentroids; c++) {
+				const dist = Math.abs(rotated[i] - this._codebook[c]);
+				if (dist < bestDist) {
+					bestDist = dist;
+					bestIdx = c;
+				}
+			}
+			indices[i] = bestIdx;
+		}
+
+		return { indices, norm };
+	}
+
+	/**
+	 * Decompress a single KV vector from its compressed representation.
+	 *
+	 * Steps:
+	 * 1. Look up codebook centroids from indices
+	 * 2. Apply inverse rotation (rotation^T)
+	 * 3. Rescale by stored norm
+	 */
+	decompressVector(entry: CompressedKvEntry): Float32Array {
+		const dim = this._config.headDim;
+
+		// Centroid lookup
+		const rotated = new Float32Array(dim);
+		for (let i = 0; i < dim; i++) {
+			rotated[i] = this._codebook[entry.indices[i]];
+		}
+
+		// Inverse rotation: x_hat = rotation^T @ rotated
+		const vec = matTVecMul(this._rotation, rotated, dim, dim);
+
+		// Rescale
+		for (let i = 0; i < dim; i++) vec[i] *= entry.norm;
+
+		return vec;
+	}
+
+	/**
+	 * Determine whether a token at the given position should be compressed.
+	 * Tokens within the residual window (most recent N) stay full-precision.
+	 */
+	shouldCompress(tokenPosition: number, currentSeqLen: number): boolean {
+		const windowStart = currentSeqLen - this._config.residualWindowSize;
+		return tokenPosition < windowStart;
+	}
+
+	/**
+	 * Store a compressed KV entry for a specific layer/head/position.
+	 * This is the integration point: call after each forward pass for tokens
+	 * that fall outside the residual window.
+	 */
+	storeCompressed(
+		layerIdx: number,
+		headIdx: number,
+		key: Float32Array,
+		value: Float32Array,
+	): { readonly key: CompressedKvEntry; readonly value: CompressedKvEntry } {
+		const compKey = this.compressVector(key);
+		const compValue = this.compressVector(value);
+
+		let layerMap = this._layers.get(layerIdx);
+		if (!layerMap) {
+			layerMap = new Map();
+			this._layers.set(layerIdx, layerMap);
+		}
+
+		const existing = layerMap.get(headIdx);
+		const keys = existing ? [...existing.keys, compKey] : [compKey];
+		const values = existing ? [...existing.values, compValue] : [compValue];
+		layerMap.set(headIdx, { keys, values });
+
+		return { key: compKey, value: compValue };
+	}
+
+	/** Retrieve all compressed entries for a layer/head. */
+	getCompressedLayer(layerIdx: number, headIdx: number): CompressedKvLayer | undefined {
+		return this._layers.get(layerIdx)?.get(headIdx);
+	}
+
+	/** Advance the sequence position counter. */
+	advanceSequence(count = 1): void {
+		this._seqLen += count;
+	}
+
+	/** Reset the cache (e.g., on new generation). */
+	reset(): void {
+		this._layers.clear();
+		this._seqLen = 0;
+	}
+
+	/**
+	 * Compute memory usage statistics.
+	 */
+	static computeMemoryStats(
+		headDim: number,
+		bits: BitWidth,
+		numHeads: number,
+		numLayers: number,
+		compressedTokens: number,
+		residualTokens: number,
+	): {
+		readonly compressedBytes: number;
+		readonly residualBytes: number;
+		readonly totalBytes: number;
+		readonly uncompressedBytes: number;
+		readonly compressionRatio: number;
+		readonly bitsPerElement: number;
+	} {
+		// Compressed: indices (bits per dim) + norm (f32) per head per layer per token
+		// For keys + values (2x)
+		const indicesPerToken = (headDim * bits) / 8;
+		const normPerToken = 4; // float32
+		const bytesPerCompToken = (indicesPerToken + normPerToken) * numHeads * numLayers * 2;
+		const compressedBytes = Math.ceil(bytesPerCompToken * compressedTokens);
+
+		// Residual: full fp32 per dim per head per layer per token (keys + values)
+		const bytesPerResidualToken = headDim * 4 * numHeads * numLayers * 2;
+		const residualBytes = bytesPerResidualToken * residualTokens;
+
+		const totalBytes = compressedBytes + residualBytes;
+
+		// Uncompressed baseline: all tokens at fp16
+		const totalTokens = compressedTokens + residualTokens;
+		const uncompressedBytes = headDim * 2 * numHeads * numLayers * 2 * totalTokens;
+
+		const compressionRatio = uncompressedBytes > 0 ? uncompressedBytes / totalBytes : 0;
+		const bitsPerElement = totalTokens > 0 ? (totalBytes * 8) / (totalTokens * headDim * numHeads * numLayers * 2) : 0;
+
+		return {
+			compressedBytes,
+			residualBytes,
+			totalBytes,
+			uncompressedBytes,
+			compressionRatio,
+			bitsPerElement,
+		};
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Config parsing helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse `memory.kv_cache_compression` from the user's agent.yaml config.
+ * Returns defaults if absent or malformed.
+ */
+export function parseKvCacheCompressionConfig(raw: unknown): KvCacheCompressionOption {
+	if (raw === undefined || raw === null) return DEFAULT_KV_CACHE_COMPRESSION;
+
+	if (typeof raw === "boolean") {
+		return { ...DEFAULT_KV_CACHE_COMPRESSION, enabled: raw };
+	}
+
+	if (typeof raw !== "object") return DEFAULT_KV_CACHE_COMPRESSION;
+
+	const obj = raw as Record<string, unknown>;
+	const enabled = typeof obj.enabled === "boolean" ? obj.enabled : DEFAULT_KV_CACHE_COMPRESSION.enabled;
+
+	let bits = DEFAULT_KV_CACHE_COMPRESSION.bits;
+	if (typeof obj.bits === "number" && VALID_BITS.includes(obj.bits as BitWidth)) {
+		bits = obj.bits as BitWidth;
+	}
+
+	let residualWindowSize = DEFAULT_KV_CACHE_COMPRESSION.residualWindowSize;
+	if (
+		typeof obj.residualWindowSize === "number" &&
+		Number.isFinite(obj.residualWindowSize) &&
+		obj.residualWindowSize > 0
+	) {
+		residualWindowSize = Math.round(obj.residualWindowSize);
+	}
+
+	return { enabled, bits, residualWindowSize };
+}
+
+// ---------------------------------------------------------------------------
+// Ollama guidance
+// ---------------------------------------------------------------------------
+
+/**
+ * Guidance for Ollama KV cache quantization.
+ * Ollama/llama.cpp manages its own KV cache — TurboQuant cannot wrap it.
+ * Instead, use Ollama's built-in quantized KV cache support.
+ */
+export const OLLAMA_KV_CACHE_GUIDANCE = {
+	envVar: "OLLAMA_KV_CACHE_TYPE",
+	recommendedValue: "q4_0",
+	description:
+		"Set OLLAMA_KV_CACHE_TYPE=q4_0 before starting Ollama to enable " +
+		"4-bit KV cache quantization via llama.cpp. This is complementary " +
+		"to TurboQuant and applies to all Ollama-served models (e.g. qwen3:4b). " +
+		"Expected ~4x memory reduction for KV cache with minimal quality loss.",
+	alternativeValues: ["q8_0", "f16"] as const,
+} as const;

--- a/packages/daemon/src/turboquant-cache.ts
+++ b/packages/daemon/src/turboquant-cache.ts
@@ -78,12 +78,20 @@ export const DEFAULT_KV_CACHE_COMPRESSION: KvCacheCompressionOption = {
 // Math utilities — seeded PRNG, QR, matrix ops
 // ---------------------------------------------------------------------------
 
+/** splitmix32 for seed expansion (Fix C). */
+function splitmix32(s: number): number {
+	let t = (s + 0x9e3779b9) | 0;
+	t = Math.imul(t ^ (t >>> 16), 0x21f0aaad);
+	t = Math.imul(t ^ (t >>> 15), 0x735a2d97);
+	return (t ^ (t >>> 15)) >>> 0;
+}
+
 /** Seeded xoshiro128** PRNG returning values in [0, 1). */
 function createRng(seed: number): () => number {
-	let s0 = seed >>> 0;
-	let s1 = (seed * 1597334677) >>> 0;
-	let s2 = (seed * 2654435761) >>> 0;
-	let s3 = (seed * 668265263) >>> 0;
+	let s0 = splitmix32(seed);
+	let s1 = splitmix32(s0);
+	let s2 = splitmix32(s1);
+	let s3 = splitmix32(s2);
 
 	for (let i = 0; i < 20; i++) {
 		const t = s1 << 9;
@@ -96,8 +104,9 @@ function createRng(seed: number): () => number {
 	}
 
 	return (): number => {
-		const result = Math.imul(s1 * 5, 1) >>> 0;
-		const rot = ((result << 7) | (result >>> 25)) >>> 0;
+		const mul5 = Math.imul(s1, 5);
+		const rotl7 = ((mul5 << 7) | (mul5 >>> 25)) >>> 0;
+		const result = Math.imul(rotl7, 9) >>> 0;
 		const t = s1 << 9;
 		s2 ^= s0;
 		s3 ^= s1;
@@ -105,7 +114,7 @@ function createRng(seed: number): () => number {
 		s0 ^= s3;
 		s2 ^= t;
 		s3 = (s3 << 11) | (s3 >>> 21);
-		return (rot >>> 0) / 4294967296;
+		return result / 4294967296;
 	};
 }
 
@@ -186,6 +195,101 @@ function matTVecMul(m: Float32Array, v: Float32Array, rows: number, cols: number
 		for (let c = 0; c < cols; c++) result[c] += m[off + c] * vi;
 	}
 	return result;
+}
+
+// ---------------------------------------------------------------------------
+// Bit packing utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Pack an array of centroid indices into a compact Uint8Array.
+ * For 4-bit: two indices per byte (high nibble, low nibble).
+ * For other bit widths: generic bit-stream packing.
+ */
+function packIndices(indices: Uint8Array, bits: number): Uint8Array {
+	const totalBits = indices.length * bits;
+	const packed = new Uint8Array(Math.ceil(totalBits / 8));
+
+	if (bits === 4) {
+		// Fast path: two indices per byte
+		for (let i = 0; i < indices.length - 1; i += 2) {
+			packed[i >>> 1] = (indices[i] << 4) | indices[i + 1];
+		}
+		if (indices.length % 2 !== 0) {
+			packed[packed.length - 1] = indices[indices.length - 1] << 4;
+		}
+		return packed;
+	}
+
+	// Generic bit-stream packing for 1, 2, 3 bit widths
+	let bitPos = 0;
+	for (let i = 0; i < indices.length; i++) {
+		const val = indices[i];
+		const byteIdx = bitPos >>> 3;
+		const bitOffset = bitPos & 7;
+		packed[byteIdx] |= (val << bitOffset) & 0xff;
+		if (bitOffset + bits > 8) {
+			packed[byteIdx + 1] |= val >>> (8 - bitOffset);
+		}
+		bitPos += bits;
+	}
+	return packed;
+}
+
+/**
+ * Unpack centroid indices from a compact Uint8Array.
+ * Inverse of packIndices.
+ */
+function unpackIndices(packed: Uint8Array, dim: number, bits: number): Uint8Array {
+	const indices = new Uint8Array(dim);
+	const mask = (1 << bits) - 1;
+
+	if (bits === 4) {
+		// Fast path: two indices per byte
+		for (let i = 0; i < dim - 1; i += 2) {
+			const byte = packed[i >>> 1];
+			indices[i] = (byte >>> 4) & 0xf;
+			indices[i + 1] = byte & 0xf;
+		}
+		if (dim % 2 !== 0) {
+			indices[dim - 1] = (packed[packed.length - 1] >>> 4) & 0xf;
+		}
+		return indices;
+	}
+
+	// Generic bit-stream unpacking for 1, 2, 3 bit widths
+	let bitPos = 0;
+	for (let i = 0; i < dim; i++) {
+		const byteIdx = bitPos >>> 3;
+		const bitOffset = bitPos & 7;
+		let val = (packed[byteIdx] >>> bitOffset) & mask;
+		if (bitOffset + bits > 8) {
+			val |= (packed[byteIdx + 1] << (8 - bitOffset)) & mask;
+		}
+		indices[i] = val;
+		bitPos += bits;
+	}
+	return indices;
+}
+
+// ---------------------------------------------------------------------------
+// Binary search for nearest centroid (Fix D)
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the nearest centroid index using binary search on a sorted codebook.
+ * The codebook must be sorted ascending (which TurboQuant codebooks are).
+ */
+function findNearestCentroid(value: number, codebook: Float32Array): number {
+	let lo = 0;
+	let hi = codebook.length - 1;
+	while (lo < hi) {
+		const mid = (lo + hi) >>> 1;
+		const boundary = (codebook[mid] + codebook[mid + 1]) / 2;
+		if (value <= boundary) hi = mid;
+		else lo = mid + 1;
+	}
+	return lo;
 }
 
 // ---------------------------------------------------------------------------
@@ -323,10 +427,14 @@ function computeCodebook(dim: number, bits: number): Float32Array {
 
 /** A single compressed KV vector (one head, one token). */
 export interface CompressedKvEntry {
-	/** Quantization indices per coordinate. */
-	readonly indices: Uint8Array;
+	/** Bit-packed quantization codes. */
+	readonly packedCodes: Uint8Array;
 	/** Original L2 norm of the vector. */
 	readonly norm: number;
+	/** Original dimension (needed for unpacking). */
+	readonly dim: number;
+	/** Bit width used for packing. */
+	readonly bits: number;
 }
 
 /** Per-layer, per-head compressed KV cache. */
@@ -335,6 +443,16 @@ export interface CompressedKvLayer {
 	readonly keys: readonly CompressedKvEntry[];
 	/** Compressed value vectors (one per token outside residual window). */
 	readonly values: readonly CompressedKvEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Mutable internal storage type (Fix B)
+// ---------------------------------------------------------------------------
+
+/** Mutable internal representation for efficient append. */
+interface MutableCompressedKvLayer {
+	keys: CompressedKvEntry[];
+	values: CompressedKvEntry[];
 }
 
 // ---------------------------------------------------------------------------
@@ -365,8 +483,8 @@ export class TurboQuantKvCache {
 	private readonly _codebook: Float32Array;
 	private readonly _numCentroids: number;
 
-	/** Compressed KV entries per layer → per head. */
-	private readonly _layers: Map<number, Map<number, CompressedKvLayer>>;
+	/** Compressed KV entries per layer → per head (mutable internal storage). */
+	private readonly _layers: Map<number, Map<number, MutableCompressedKvLayer>>;
 	/** Current sequence position (tokens seen). */
 	private _seqLen: number;
 
@@ -441,10 +559,12 @@ export class TurboQuantKvCache {
 	 * 1. Compute and store the L2 norm
 	 * 2. Normalize to unit vector
 	 * 3. Apply random rotation
-	 * 4. Find nearest codebook centroid per coordinate
+	 * 4. Find nearest codebook centroid per coordinate (binary search)
+	 * 5. Pack indices into compact bit representation
 	 */
 	compressVector(vector: Float32Array): CompressedKvEntry {
 		const dim = this._config.headDim;
+		const bits = this._config.bits;
 		if (vector.length !== dim) {
 			throw new Error(`Vector length ${String(vector.length)} != headDim ${String(dim)}`);
 		}
@@ -462,39 +582,38 @@ export class TurboQuantKvCache {
 		// Rotate: y = rotation @ unit
 		const rotated = matVecMul(this._rotation, unit, dim, dim);
 
-		// Quantize: find nearest centroid per coordinate
+		// Quantize: find nearest centroid per coordinate using binary search
 		const indices = new Uint8Array(dim);
 		for (let i = 0; i < dim; i++) {
-			let bestIdx = 0;
-			let bestDist = Math.abs(rotated[i] - this._codebook[0]);
-			for (let c = 1; c < this._numCentroids; c++) {
-				const dist = Math.abs(rotated[i] - this._codebook[c]);
-				if (dist < bestDist) {
-					bestDist = dist;
-					bestIdx = c;
-				}
-			}
-			indices[i] = bestIdx;
+			indices[i] = findNearestCentroid(rotated[i], this._codebook);
 		}
 
-		return { indices, norm };
+		// Pack indices into compact bit representation
+		const packedCodes = packIndices(indices, bits);
+
+		return { packedCodes, norm, dim, bits };
 	}
 
 	/**
 	 * Decompress a single KV vector from its compressed representation.
 	 *
 	 * Steps:
-	 * 1. Look up codebook centroids from indices
-	 * 2. Apply inverse rotation (rotation^T)
-	 * 3. Rescale by stored norm
+	 * 1. Unpack indices from packed codes
+	 * 2. Look up codebook centroids from indices
+	 * 3. Apply inverse rotation (rotation^T)
+	 * 4. Rescale by stored norm
 	 */
 	decompressVector(entry: CompressedKvEntry): Float32Array {
-		const dim = this._config.headDim;
+		const dim = entry.dim;
+		const bits = entry.bits;
+
+		// Unpack indices
+		const indices = unpackIndices(entry.packedCodes, dim, bits);
 
 		// Centroid lookup
 		const rotated = new Float32Array(dim);
 		for (let i = 0; i < dim; i++) {
-			rotated[i] = this._codebook[entry.indices[i]];
+			rotated[i] = this._codebook[indices[i]];
 		}
 
 		// Inverse rotation: x_hat = rotation^T @ rotated
@@ -519,6 +638,8 @@ export class TurboQuantKvCache {
 	 * Store a compressed KV entry for a specific layer/head/position.
 	 * This is the integration point: call after each forward pass for tokens
 	 * that fall outside the residual window.
+	 *
+	 * Uses O(1) append instead of array spread (Fix B).
 	 */
 	storeCompressed(
 		layerIdx: number,
@@ -535,10 +656,14 @@ export class TurboQuantKvCache {
 			this._layers.set(layerIdx, layerMap);
 		}
 
-		const existing = layerMap.get(headIdx);
-		const keys = existing ? [...existing.keys, compKey] : [compKey];
-		const values = existing ? [...existing.values, compValue] : [compValue];
-		layerMap.set(headIdx, { keys, values });
+		let existing = layerMap.get(headIdx);
+		if (!existing) {
+			existing = { keys: [], values: [] };
+			layerMap.set(headIdx, existing);
+		}
+
+		existing.keys.push(compKey);
+		existing.values.push(compValue);
 
 		return { key: compKey, value: compValue };
 	}
@@ -577,7 +702,7 @@ export class TurboQuantKvCache {
 		readonly compressionRatio: number;
 		readonly bitsPerElement: number;
 	} {
-		// Compressed: indices (bits per dim) + norm (f32) per head per layer per token
+		// Compressed: packed indices (bits per dim) + norm (f32) per head per layer per token
 		// For keys + values (2x)
 		const indicesPerToken = (headDim * bits) / 8;
 		const normPerToken = 4; // float32


### PR DESCRIPTION
## TurboQuant KV Cache Compression + Native Generative Models

### What
Adds TurboQuant KV cache compression (`turboquant-cache.ts`) and a native generative inference module (`native-generation.ts`) that runs Qwen 3.5 4B and NVIDIA Nemotron 3 Nano 4B directly via `@huggingface/transformers` ONNX — no Ollama dependency required.

### Architecture

**TurboQuant** (arXiv:2504.19874, ICLR 2026):
- Random rotation → Beta-distribution codebook → per-coordinate quantization
- 3-4 bits per coordinate with near-zero accuracy loss
- ~6× KV cache memory reduction for long context windows
- Residual window keeps recent N tokens in full precision

**Native Generation** — custom token-by-token loop (not `pipeline()`) so we can intercept `past_key_values` between forward passes:

| Model | Layers | Attention Layers | KV Heads | Head Dim | Size (q4f16) |
|-------|--------|-----------------|----------|----------|-------------|
| Qwen 3.5 4B | 32 | 8 (DeltaNet + Attn) | 4 (GQA) | 256 | ~2.7 GB |
| Nemotron 3 Nano 4B | 42 | 4 (Mamba + Attn) | 8 (GQA) | 128 | ~2.2 GB |

TurboQuant compresses **only** the attention layers' KV cache. Linear attention (DeltaNet) and Mamba (SSM) state are passed through unchanged.

### Key Implementation Details
- `NativeModelConfig` registry — config-driven layer filtering, head dims, EOS tokens
- `KvCacheManager` — tracks compressed + residual KV per layer per head
- `BigInt64Array` for int64 tensors (input_ids, attention_mask, position_ids)
- `position_ids` tracking for rotary embedding correctness
- Proper tensor lifecycle (`dispose()` after consumption, `try/finally` cleanup)
- Temperature + top-p nucleus sampling
- Model hot-swapping with init mutex + `pendingModelId` race protection
- `LlmProvider` interface compliance (`@signet/core`)

### Tests
- **42 tests** for `turboquant-cache.ts` — roundtrip fidelity, codebook, packing, memory stats
- **59 tests** for `native-generation.ts` — both model configs, KvCacheManager for Qwen (8 attn layers) and Nemotron (4 attn layers), compression beyond residual window, sampling, provider interface, edge cases

### Review Notes (16 issues found & fixed during self-review)
Critical fixes applied before PR:
1. Buffer aliasing in prefill (silent data corruption via tensor view)
2. int64 dtype mismatch (Float32Array for BigInt64Array tokens)
3. Missing position_ids (broken rotary embeddings)
4. Memory leak — no tensor disposal during generation
5. No try/finally around generation loop
6. Early EOS return leaked pastKv
7. disposePastKv disposing Mamba state mid-generation
8. O(n) attention mask growth per decode step
9. Hot-swap race condition in ensureInitialized
10. initLayerFromPrefill/appendAndCompress head count mismatch