### PR TITLE
feat(forge): require explicit dev-warning acknowledgement on install and launch

### DIFF
--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -81,6 +81,14 @@ Managed installs place the binary in `~/.config/signet/bin`. Add that directory 
 Managed binary downloads currently support macOS arm64, macOS x64, Linux x64, and Linux arm64.
 On other platforms, install Forge from source or use a local standalone build.
 
+Install/update commands prompt for an explicit development warning
+acknowledgement. For automation:
+
+```bash
+signet forge install --yes
+signet forge update --yes
+```
+
 ### Runtime role
 
 - first-party native harness

--- a/packages/cli/src/commands/forge.ts
+++ b/packages/cli/src/commands/forge.ts
@@ -7,6 +7,7 @@ interface ForgeStatusOptions {
 
 interface ForgeInstallOptions {
 	version?: string;
+	yes?: boolean;
 }
 
 interface ForgeDeps {
@@ -23,12 +24,14 @@ export function registerForgeCommands(program: Command, deps: ForgeDeps): void {
 		.command("install")
 		.description("Install Forge from Signet first-party releases")
 		.option("--version <version>", "Install a specific Forge version")
+		.option("-y, --yes", "Acknowledge Forge development warning and continue without prompt")
 		.action(deps.installForge);
 
 	forgeCmd
 		.command("update")
 		.description("Update Forge to the latest managed release")
 		.option("--version <version>", "Update to a specific Forge version")
+		.option("-y, --yes", "Acknowledge Forge development warning and continue without prompt")
 		.action(deps.updateForge);
 
 	const status = forgeCmd.command("status").description("Show Forge installation status").action(deps.showForgeStatus);

--- a/packages/cli/src/features/forge.test.ts
+++ b/packages/cli/src/features/forge.test.ts
@@ -7,6 +7,7 @@ import {
 	loadForgeManifest,
 	managedForgeAssetNameForPlatform,
 	managedForgeInstallSupportedForPlatform,
+	parseYesNoAnswer,
 	readForgeVersionFromBinaryMetadata,
 	selectLatestStableForgeRelease,
 	withManagedForgeInstallLock,
@@ -256,5 +257,25 @@ describe("Forge version metadata parsing", () => {
 		} finally {
 			rmSync(tempHome, { recursive: true, force: true });
 		}
+	});
+});
+
+describe("parseYesNoAnswer", () => {
+	it("accepts yes variants", () => {
+		expect(parseYesNoAnswer("yes")).toBe(true);
+		expect(parseYesNoAnswer("Y")).toBe(true);
+		expect(parseYesNoAnswer("  YeS  ")).toBe(true);
+	});
+
+	it("accepts no variants", () => {
+		expect(parseYesNoAnswer("no")).toBe(false);
+		expect(parseYesNoAnswer("N")).toBe(false);
+		expect(parseYesNoAnswer("  No  ")).toBe(false);
+	});
+
+	it("rejects unknown answers", () => {
+		expect(parseYesNoAnswer("")).toBeNull();
+		expect(parseYesNoAnswer("maybe")).toBeNull();
+		expect(parseYesNoAnswer("1")).toBeNull();
 	});
 });

--- a/packages/cli/src/features/forge.ts
+++ b/packages/cli/src/features/forge.ts
@@ -14,6 +14,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { createInterface } from "node:readline/promises";
 import { fileURLToPath } from "node:url";
 import { findSignetForgeBinary, isSignetForgeBinary, resolveSignetForgeManagedPath } from "@signet/core";
 import chalk from "chalk";
@@ -31,6 +32,7 @@ export interface ForgeStatusOptions {
 
 export interface ForgeInstallOptions {
 	version?: string;
+	yes?: boolean;
 }
 
 interface ForgeRelease {
@@ -575,7 +577,70 @@ function buildStatusPayload(deps: ForgeDeps, manifest: ForgeManifest): ForgeStat
 	};
 }
 
+function printForgeDevelopmentWarning(context: "install" | "update"): void {
+	console.log();
+	console.log(chalk.bold("Forge Development Warning"));
+	console.log();
+	console.log(
+		`  Forge is ${chalk.yellow("under active development")} and is currently used strictly for ${chalk.yellow("Signet bug testing")}.`,
+	);
+	console.log(`  It should ${chalk.yellow("not replace your active harness")}.`);
+	console.log(`  You may run into ${chalk.yellow("bugs or issues")} while using it.`);
+	console.log();
+	console.log(chalk.dim(`  Action requested: signet forge ${context}`));
+	console.log();
+}
+
+export function parseYesNoAnswer(input: string): boolean | null {
+	const normalized = input.trim().toLowerCase();
+	if (normalized === "yes" || normalized === "y") return true;
+	if (normalized === "no" || normalized === "n") return false;
+	return null;
+}
+
+async function promptYesNo(question: string): Promise<boolean> {
+	const rl = createInterface({
+		input: process.stdin,
+		output: process.stderr,
+	});
+	try {
+		while (true) {
+			const parsed = parseYesNoAnswer(await rl.question(question));
+			if (parsed !== null) return parsed;
+			console.log("Please answer yes or no.");
+		}
+	} finally {
+		rl.close();
+	}
+}
+
+async function requireForgeWarningAcceptance(
+	context: "install" | "update",
+	options: ForgeInstallOptions,
+): Promise<"accepted" | "cancelled" | "missing-ack"> {
+	if (options.yes === true) return "accepted";
+
+	printForgeDevelopmentWarning(context);
+	if (!process.stdin.isTTY || !process.stderr.isTTY) {
+		return "missing-ack";
+	}
+
+	return (await promptYesNo("  Continue? [yes/no]: ")) ? "accepted" : "cancelled";
+}
+
 export async function installForge(options: ForgeInstallOptions, deps: ForgeDeps): Promise<void> {
+	const warning = await requireForgeWarningAcceptance("install", options);
+	if (warning === "missing-ack") {
+		console.error(chalk.red("Non-interactive mode requires explicit acknowledgement."));
+		console.error(chalk.dim("Re-run with: signet forge install --yes"));
+		process.exitCode = 1;
+		return;
+	}
+	if (warning === "cancelled") {
+		console.log(chalk.yellow("Forge install cancelled."));
+		return;
+	}
+
 	const manifest = loadForgeManifest(deps.getTemplatesDir);
 	const result = await installForgeBinary(deps, manifest, options.version);
 	console.log(chalk.green(`✓ Forge ${result.version} installed`));
@@ -585,6 +650,18 @@ export async function installForge(options: ForgeInstallOptions, deps: ForgeDeps
 }
 
 export async function updateForge(options: ForgeInstallOptions, deps: ForgeDeps): Promise<void> {
+	const warning = await requireForgeWarningAcceptance("update", options);
+	if (warning === "missing-ack") {
+		console.error(chalk.red("Non-interactive mode requires explicit acknowledgement."));
+		console.error(chalk.dim("Re-run with: signet forge update --yes"));
+		process.exitCode = 1;
+		return;
+	}
+	if (warning === "cancelled") {
+		console.log(chalk.yellow("Forge update cancelled."));
+		return;
+	}
+
 	const manifest = loadForgeManifest(deps.getTemplatesDir);
 	const status = buildStatusPayload(deps, manifest);
 	if (!status.managedRecord) {

--- a/packages/forge/README.md
+++ b/packages/forge/README.md
@@ -36,6 +36,14 @@ Managed installs place the binary in `~/.config/signet/bin`. Add that directory 
 
 Managed binary downloads currently support macOS arm64, macOS x64, Linux x64, and Linux arm64. On other platforms, build Forge from source or use a local standalone install.
 
+`signet forge install` and `signet forge update` require an explicit
+development warning acknowledgement. For automation/non-interactive runs:
+
+```bash
+signet forge install --yes
+signet forge update --yes
+```
+
 ### Update from source
 
 ```bash
@@ -50,6 +58,13 @@ Start Forge:
 
 ```bash
 forge
+```
+
+Forge launch shows a development warning and asks for `[yes]/[no]`
+before opening the interactive harness. For non-interactive launch flows:
+
+```bash
+forge --yes
 ```
 
 Open the auth flow:

--- a/packages/forge/crates/forge-cli/src/main.rs
+++ b/packages/forge/crates/forge-cli/src/main.rs
@@ -18,7 +18,7 @@ use forge_signet::secrets::{
 };
 use forge_signet::SignetClient;
 use forge_tui::App;
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 use std::sync::Arc;
 use tracing::{info, warn};
 
@@ -76,6 +76,10 @@ struct Cli {
     /// Agent name (uses per-agent identity files from ~/.agents/agents/<name>/)
     #[arg(long)]
     agent: Option<String>,
+
+    /// Acknowledge Forge development warning and continue without prompt
+    #[arg(short = 'y', long)]
+    yes: bool,
 }
 
 #[tokio::main]
@@ -115,6 +119,11 @@ async fn main() -> Result<()> {
         if cli.auth_only {
             return Ok(());
         }
+    }
+
+    // Safety warning gate for entering the interactive harness.
+    if cli.prompt.is_none() && !confirm_forge_launch_warning(cli.yes)? {
+        return Ok(());
     }
 
     // Signet onboarding — check install, run setup, start daemon
@@ -487,6 +496,94 @@ async fn ensure_signet(daemon_url: &str) {
     }
 
     eprintln!();
+}
+
+fn print_forge_warning() {
+    eprintln!();
+    eprintln!("  {}", "Forge Development Warning".bold());
+    eprintln!();
+    eprintln!(
+        "  Forge is {} and is currently used strictly for {}.",
+        "under active development".yellow(),
+        "Signet bug testing".yellow()
+    );
+    eprintln!(
+        "  It should {}.",
+        "not replace your active harness".yellow()
+    );
+    eprintln!(
+        "  You may run into {} while using it.",
+        "bugs or issues".yellow()
+    );
+    eprintln!();
+}
+
+fn confirm_forge_launch_warning(accepted_via_flag: bool) -> Result<bool> {
+    if accepted_via_flag {
+        return Ok(true);
+    }
+
+    print_forge_warning();
+
+    if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
+        anyhow::bail!("Non-interactive launch requires explicit acknowledgement. Re-run with: forge --yes");
+    }
+
+    loop {
+        eprint!("  Continue to launch Forge? [yes/no]: ");
+        let _ = std::io::stderr().flush();
+
+        let mut input = String::new();
+        if std::io::stdin().read_line(&mut input).is_err() {
+            return Ok(false);
+        }
+
+        if let Some(accept) = parse_yes_no_answer(&input) {
+            if accept {
+                return Ok(true);
+            }
+            eprintln!("  Launch cancelled.");
+            return Ok(false);
+        }
+        eprintln!("  Please answer yes or no.");
+    }
+}
+
+fn parse_yes_no_answer(input: &str) -> Option<bool> {
+    let normalized = input.trim().to_lowercase();
+    if normalized == "yes" || normalized == "y" {
+        return Some(true);
+    }
+    if normalized == "no" || normalized == "n" {
+        return Some(false);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_yes_no_answer;
+
+    #[test]
+    fn parse_yes_variants() {
+        assert_eq!(parse_yes_no_answer("yes"), Some(true));
+        assert_eq!(parse_yes_no_answer("Y"), Some(true));
+        assert_eq!(parse_yes_no_answer("  YeS  "), Some(true));
+    }
+
+    #[test]
+    fn parse_no_variants() {
+        assert_eq!(parse_yes_no_answer("no"), Some(false));
+        assert_eq!(parse_yes_no_answer("N"), Some(false));
+        assert_eq!(parse_yes_no_answer("  No  "), Some(false));
+    }
+
+    #[test]
+    fn parse_unknown_variants() {
+        assert_eq!(parse_yes_no_answer(""), None);
+        assert_eq!(parse_yes_no_answer("maybe"), None);
+        assert_eq!(parse_yes_no_answer("1"), None);
+    }
 }
 
 /// Determine which provider and model to use based on CLI args and available keys

--- a/packages/forge/install.sh
+++ b/packages/forge/install.sh
@@ -1,16 +1,81 @@
 #!/bin/bash
 # Forge installer from the Signet monorepo releases
 # Usage: curl -sSL https://raw.githubusercontent.com/Signet-AI/signetai/main/packages/forge/install.sh | bash
+# Non-interactive: curl -sSL https://raw.githubusercontent.com/Signet-AI/signetai/main/packages/forge/install.sh | bash -s -- --yes
 
 set -euo pipefail
 
 REPO="Signet-AI/signetai"
 BINARY="forge"
 TAG_PREFIX="forge-v"
+ASSUME_YES=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -y|--yes)
+      ASSUME_YES=1
+      shift
+      ;;
+    *)
+      echo "Error: unknown option: $1"
+      echo "Usage: install.sh [--yes]"
+      exit 1
+      ;;
+  esac
+done
+
+prompt_yes_no() {
+  local prompt="$1"
+  local answer
+
+  while true; do
+    if [ -r /dev/tty ] && [ -w /dev/tty ]; then
+      printf "%s" "$prompt" > /dev/tty
+      if ! IFS= read -r answer < /dev/tty; then
+        return 1
+      fi
+    elif [ -t 0 ]; then
+      printf "%s" "$prompt"
+      if ! IFS= read -r answer; then
+        return 1
+      fi
+    else
+      return 2
+    fi
+
+    answer=$(echo "$answer" | tr '[:upper:]' '[:lower:]' | xargs)
+    case "$answer" in
+      y|yes) return 0 ;;
+      n|no) return 1 ;;
+      *) echo "Please answer yes or no." ;;
+    esac
+  done
+}
 
 echo "Forge Installer"
 echo "==============="
 echo ""
+echo "Forge Development Warning"
+echo ""
+echo "  Forge is under active development and is currently used strictly for Signet bug testing."
+echo "  It should not replace your active harness."
+echo "  You may run into bugs or issues while using it."
+echo ""
+
+if [ "$ASSUME_YES" -ne 1 ]; then
+  if prompt_yes_no "Continue with Forge install? [yes/no]: "; then
+    :
+  else
+    status=$?
+    if [ "$status" -eq 2 ]; then
+      echo "Error: non-interactive install requires explicit acknowledgement."
+      echo "Re-run with --yes."
+      exit 1
+    fi
+    echo "Install cancelled."
+    exit 0
+  fi
+fi
 
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)


### PR DESCRIPTION
## Summary

Adds an explicit `[yes]/[no]` safety acknowledgement for Forge install/update/launch paths so users are clearly warned before using Forge in its current testing-focused state.

### What changed

- Added warning gate for:
  - `signet forge install`
  - `signet forge update`
  - `forge` interactive launch entry (including `forge --auth` handoff into TUI)
  - `packages/forge/install.sh`
- Added non-interactive acknowledgement flag support:
  - `signet forge install --yes`
  - `signet forge update --yes`
  - `forge --yes`
  - `install.sh --yes`
- Added yes/no parser regression tests:
  - `packages/cli/src/features/forge.test.ts` (TS)
  - `packages/forge/crates/forge-cli/src/main.rs` (Rust unit tests)
- Updated docs:
  - `packages/forge/README.md`
  - `docs/HARNESSES.md`

## Behavior

- If user answers **no** at an interactive prompt: command exits gracefully (no install/launch), status code `0`.
- If running non-interactively without `--yes`: command fails fast with clear instructions to rerun with `--yes`.
- For `forge --auth` (without `--auth-only`): one launch warning is shown before opening the TUI.

## Validation

- `cd packages/cli && bun run build:core && bun run --filter '@signet/connector-*' build && bun run build:cli`
- `cd packages/cli && bun test src/features/forge.test.ts`
- `cd packages/forge && cargo check -p forge-cli`
- `cd packages/forge && cargo test -p forge-cli --bin forge`
- `cd packages/forge && bash -n install.sh`
- `bunx biome check packages/cli/src/commands/forge.ts packages/cli/src/features/forge.ts packages/cli/src/features/forge.test.ts docs/HARNESSES.md packages/forge/README.md`

## PR Readiness Checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally
