### PR TITLE
feat(pipeline): add command extraction provider for summary worker control-plane path

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -343,6 +343,10 @@ its path is substituted into command arguments:
 - `$PROJECT` — project path (or empty string)
 - `$SIGNET_PATH` — active Signet workspace path
 
+The command's stdout/stderr are not used as extraction output. The
+external command is responsible for writing memories to Signet state
+(for example, writing rows to `memories.db`).
+
 After command extraction succeeds, the normal summary-worker lifecycle
 continues when a synthesis provider is configured (session summary
 generation, DAG write, continuity/predictor hooks, and synthesis

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -343,6 +343,11 @@ its path is substituted into command arguments:
 - `$PROJECT` — project path (or empty string)
 - `$SIGNET_PATH` — active Signet workspace path
 
+After command extraction succeeds, the normal summary-worker lifecycle
+continues when a synthesis provider is configured (session summary
+generation, DAG write, continuity/predictor hooks, and synthesis
+triggering).
+
 Example:
 
 ```yaml

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -347,10 +347,11 @@ The command's stdout/stderr are not used as extraction output. The
 external command is responsible for writing memories to Signet state
 (for example, writing rows to `memories.db`).
 
-After command extraction succeeds, the normal summary-worker lifecycle
-continues when a synthesis provider is configured (session summary
-generation, DAG write, continuity/predictor hooks, and synthesis
-triggering).
+After command extraction succeeds, synthesis-provider hooks can still run
+(summary generation for continuity/predictor + DAG + synthesis trigger),
+but summary markdown writes and `insertSummaryFacts` are skipped in
+command mode to avoid duplicate memory writes. The external command
+remains the source of truth for fact persistence.
 
 Example:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -367,8 +367,9 @@ Controls the provider used by the `summary-worker` for session summaries.
 This is separate from fact extraction once explicitly configured.
 
 If the `synthesis` block is omitted entirely, Signet falls back to the
-resolved extraction provider, model, endpoint, and timeout instead of
-using a hidden hardcoded provider.
+resolved extraction provider, model, endpoint, and timeout. Exception:
+when `extraction.provider: command`, synthesis falls back to synthesis
+defaults (`ollama` + default synthesis model/timeout) instead.
 
 | Field | Default | Range | Description |
 |-------|---------|-------|-------------|
@@ -380,6 +381,8 @@ using a hidden hardcoded provider.
 
 Set `provider: none` or `enabled: false` to disable background session
 summary synthesis entirely.
+
+`synthesis.provider: command` is invalid and rejected during config load.
 
 
 ### Worker (`worker`)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -306,10 +306,11 @@ Controls the LLM-based extraction stage. Supports multiple providers.
 
 | Field | Default | Range | Description |
 |-------|---------|-------|-------------|
-| `provider` | `"ollama"` | — | `"none"`, `"ollama"`, `"claude-code"`, `"opencode"`, `"codex"`, `"anthropic"`, or `"openrouter"` |
+| `provider` | `"ollama"` | — | `"none"`, `"ollama"`, `"claude-code"`, `"opencode"`, `"codex"`, `"anthropic"`, `"openrouter"`, or `"command"` |
 | `model` | `"qwen3:4b"` | — | Model name for the configured provider |
-| `timeout` | `45000` | 5000-300000 ms | Extraction call timeout |
+| `timeout` | `90000` | 5000-300000 ms | Extraction call timeout |
 | `minConfidence` | `0.7` | 0.0-1.0 | Confidence threshold; facts below this are dropped |
+| `command` | — | — | Command provider config (`bin`, `args[]`, optional `cwd`, optional `env`) |
 
 For safety, the intended extraction setups are:
 
@@ -331,6 +332,33 @@ When using `ollama`, the model must be available locally. When using
 Codex CLI as the extraction provider. Lower `minConfidence` to capture
 more facts at the cost of noise; raise it to write only high-confidence
 facts.
+
+For `provider: command`, the summary worker executes
+`memory.pipelineV2.extraction.command` in the summary job queue
+control-plane path. The transcript is written to a temporary file and
+its path is substituted into command arguments:
+
+- `$TRANSCRIPT` (alias `$TRANSCRIPT_PATH`) — temp transcript file path
+- `$SESSION_KEY` — session key (or empty string)
+- `$PROJECT` — project path (or empty string)
+- `$SIGNET_PATH` — active Signet workspace path
+
+Example:
+
+```yaml
+memory:
+  pipelineV2:
+    extraction:
+      provider: command
+      command:
+        bin: node
+        args:
+          - ./scripts/custom-extractor.mjs
+          - --transcript
+          - $TRANSCRIPT
+          - --session
+          - $SESSION_KEY
+```
 
 
 ### Session synthesis (`synthesis`)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -341,7 +341,13 @@ its path is substituted into command arguments:
 - `$TRANSCRIPT` (alias `$TRANSCRIPT_PATH`) — temp transcript file path
 - `$SESSION_KEY` — session key (or empty string)
 - `$PROJECT` — project path (or empty string)
+- `$AGENT_ID` — agent id for the queued job
 - `$SIGNET_PATH` — active Signet workspace path
+
+For safety, user-derived tokens (`$SESSION_KEY`, `$PROJECT`,
+`$TRANSCRIPT`) are intended for args/env substitution. Keep `bin` and
+`cwd` fixed (or use trusted `$SIGNET_PATH` / `$AGENT_ID`), so command
+path resolution is not driven by transcript/session metadata.
 
 The command's stdout/stderr are not used as extraction output. The
 external command is responsible for writing memories to Signet state

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -310,7 +310,7 @@ Controls the LLM-based extraction stage. Supports multiple providers.
 | `model` | `"qwen3:4b"` | — | Model name for the configured provider |
 | `timeout` | `90000` | 5000-300000 ms | Extraction call timeout |
 | `minConfidence` | `0.7` | 0.0-1.0 | Confidence threshold; facts below this are dropped |
-| `command` | — | — | Command provider config (`bin`, `args[]`, optional `cwd`, optional `env`) |
+| `command` | — | — | Command provider config (`bin`, `args[]`, optional `cwd`, optional `env`) — required when `provider: "command"` |
 
 For safety, the intended extraction setups are:
 

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -978,6 +978,7 @@ extraction:
     bin: node
     args: ["./extract.mjs", "--transcript", "$TRANSCRIPT", "--session", "$SESSION_KEY"]
     # tokens: $TRANSCRIPT (temp file path), $SESSION_KEY, $PROJECT, $SIGNET_PATH
+    # command stdout/stderr are ignored; command must write memories to Signet state directly
     # after command success, normal summary-worker lifecycle continues when synthesis provider is available
 
 synthesis:

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -970,10 +970,14 @@ Extraction safety note:
 
 ```yaml
 extraction:
-  provider: ollama               # "none" | "ollama" | "claude-code" | "codex" | "opencode" | "anthropic" | "openrouter"
+  provider: ollama               # "none" | "ollama" | "claude-code" | "codex" | "opencode" | "anthropic" | "openrouter" | "command"
   model: qwen3:4b
-  timeout: 45000                 # ms, range 5000–300000
+  timeout: 90000                 # ms, range 5000–300000
   minConfidence: 0.7             # fraction 0.0–1.0
+  command:                       # only used when provider: command
+    bin: node
+    args: ["./extract.mjs", "--transcript", "$TRANSCRIPT", "--session", "$SESSION_KEY"]
+    # tokens: $TRANSCRIPT (temp file path), $SESSION_KEY, $PROJECT, $SIGNET_PATH
 
 synthesis:
   enabled: true

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -974,7 +974,7 @@ extraction:
   model: qwen3:4b
   timeout: 90000                 # ms, range 5000–300000
   minConfidence: 0.7             # fraction 0.0–1.0
-  command:                       # only used when provider: command
+  command:                       # required when provider: command
     bin: node
     args: ["./extract.mjs", "--transcript", "$TRANSCRIPT", "--session", "$SESSION_KEY"]
     # tokens: $TRANSCRIPT (temp file path), $SESSION_KEY, $PROJECT, $SIGNET_PATH

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -976,8 +976,9 @@ extraction:
   minConfidence: 0.7             # fraction 0.0–1.0
   command:                       # required when provider: command
     bin: node
-    args: ["./extract.mjs", "--transcript", "$TRANSCRIPT", "--session", "$SESSION_KEY"]
-    # tokens: $TRANSCRIPT (temp file path), $SESSION_KEY, $PROJECT, $SIGNET_PATH
+    args: ["./extract.mjs", "--transcript", "$TRANSCRIPT", "--session", "$SESSION_KEY", "--agent", "$AGENT_ID"]
+    # tokens: $TRANSCRIPT (temp file path), $SESSION_KEY, $PROJECT, $AGENT_ID, $SIGNET_PATH
+    # keep bin/cwd fixed (or trusted $SIGNET_PATH/$AGENT_ID only); use args/env for session/project tokens
     # command stdout/stderr are ignored; command must write memories to Signet state directly
     # after command success, synthesis hooks can run when configured, but markdown/fact writes are skipped in command mode
 

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -981,10 +981,11 @@ extraction:
 
 synthesis:
   enabled: true
-  provider: ollama               # same provider choices as extraction
+  provider: ollama               # same provider choices as extraction, except "command"
   model: qwen3:4b
   timeout: 120000                # ms, range 5000–300000
-  # when omitted entirely, synthesis falls back to the resolved extraction provider/model
+  # when omitted entirely, synthesis falls back to extraction provider/model
+  # except extraction.provider=command, which falls back to synthesis defaults
 
 worker:
   pollMs: 2000                   # ms, range 100–60000

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -978,6 +978,7 @@ extraction:
     bin: node
     args: ["./extract.mjs", "--transcript", "$TRANSCRIPT", "--session", "$SESSION_KEY"]
     # tokens: $TRANSCRIPT (temp file path), $SESSION_KEY, $PROJECT, $SIGNET_PATH
+    # after command success, normal summary-worker lifecycle continues when synthesis provider is available
 
 synthesis:
   enabled: true

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -979,7 +979,7 @@ extraction:
     args: ["./extract.mjs", "--transcript", "$TRANSCRIPT", "--session", "$SESSION_KEY"]
     # tokens: $TRANSCRIPT (temp file path), $SESSION_KEY, $PROJECT, $SIGNET_PATH
     # command stdout/stderr are ignored; command must write memories to Signet state directly
-    # after command success, normal summary-worker lifecycle continues when synthesis provider is available
+    # after command success, synthesis hooks can run when configured, but markdown/fact writes are skipped in command mode
 
 synthesis:
   enabled: true

--- a/packages/core/src/pipeline-providers.ts
+++ b/packages/core/src/pipeline-providers.ts
@@ -6,6 +6,7 @@ export const PIPELINE_PROVIDER_CHOICES = [
 	"opencode",
 	"anthropic",
 	"openrouter",
+	"command",
 ] as const;
 
 export type PipelineProviderChoice = (typeof PIPELINE_PROVIDER_CHOICES)[number];
@@ -20,6 +21,7 @@ const MODEL_DEFAULTS = {
 	opencode: "anthropic/claude-haiku-4-5-20251001",
 	anthropic: "haiku",
 	openrouter: "openai/gpt-4o-mini",
+	command: "",
 } as const satisfies Record<PipelineProviderChoice, string>;
 
 const PIPELINE_PROVIDER_SET = new Set<string>(PIPELINE_PROVIDER_CHOICES);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -359,7 +359,7 @@ export interface PipelineEmbeddingTrackerConfig {
 
 export interface PipelineSynthesisConfig {
 	readonly enabled: boolean;
-	readonly provider: "none" | "ollama" | "claude-code" | "codex" | "opencode" | "anthropic" | "openrouter" | "command";
+	readonly provider: "none" | "ollama" | "claude-code" | "codex" | "opencode" | "anthropic" | "openrouter";
 	readonly model: string;
 	readonly endpoint?: string;
 	readonly timeout: number;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -182,13 +182,21 @@ export interface PipelineEscalationConfig {
 	readonly level2MaxEntities: number;
 }
 
+export interface PipelineCommandConfig {
+	readonly bin: string;
+	readonly args: ReadonlyArray<string>;
+	readonly cwd?: string;
+	readonly env?: Readonly<Record<string, string>>;
+}
+
 export interface PipelineExtractionConfig {
-	readonly provider: "none" | "ollama" | "claude-code" | "opencode" | "codex" | "anthropic" | "openrouter";
+	readonly provider: "none" | "ollama" | "claude-code" | "opencode" | "codex" | "anthropic" | "openrouter" | "command";
 	readonly model: string;
 	readonly strength: "low" | "medium" | "high";
 	readonly endpoint?: string;
 	readonly timeout: number;
 	readonly minConfidence: number;
+	readonly command?: PipelineCommandConfig;
 	readonly escalation?: PipelineEscalationConfig;
 }
 
@@ -351,7 +359,7 @@ export interface PipelineEmbeddingTrackerConfig {
 
 export interface PipelineSynthesisConfig {
 	readonly enabled: boolean;
-	readonly provider: "none" | "ollama" | "claude-code" | "codex" | "opencode" | "anthropic" | "openrouter";
+	readonly provider: "none" | "ollama" | "claude-code" | "codex" | "opencode" | "anthropic" | "openrouter" | "command";
 	readonly model: string;
 	readonly endpoint?: string;
 	readonly timeout: number;

--- a/packages/daemon-rs/crates/signet-core/src/config.rs
+++ b/packages/daemon-rs/crates/signet-core/src/config.rs
@@ -180,13 +180,14 @@ fn raw_u64(value: &serde_yml::Value, key: &str) -> Option<u64> {
 fn is_pipeline_provider(value: &str) -> bool {
     matches!(
         value,
-        "none" | "ollama" | "claude-code" | "opencode" | "codex" | "anthropic" | "openrouter"
+        "none" | "ollama" | "claude-code" | "opencode" | "codex" | "anthropic" | "openrouter" | "command"
     )
 }
 
 fn default_pipeline_model(provider: &str) -> &'static str {
     match provider {
         "none" => "",
+        "command" => "",
         "claude-code" | "anthropic" => "haiku",
         "codex" => "gpt-5-codex-mini",
         "opencode" => "anthropic/claude-haiku-4-5-20251001",
@@ -422,6 +423,56 @@ memory:
         assert_eq!(pipeline.synthesis.provider, "codex");
         assert_eq!(pipeline.synthesis.model, "gpt-5-codex-mini");
     }
+
+    #[test]
+    fn extraction_command_provider_parses_command_block() {
+        let manifest = parse_manifest(
+            r#"
+memory:
+  pipelineV2:
+    extraction:
+      provider: command
+      command:
+        bin: node
+        args:
+          - script.mjs
+          - --transcript
+          - $TRANSCRIPT
+        cwd: /tmp/signet
+        env:
+          SIGNET_MODE: pipeline
+"#,
+        )
+        .expect("parse manifest");
+
+        let pipeline = manifest
+            .memory
+            .and_then(|memory| memory.pipeline_v2)
+            .expect("pipeline config");
+
+        assert_eq!(pipeline.extraction.provider, "command");
+        let command = pipeline
+            .extraction
+            .command
+            .expect("command config should parse");
+        assert_eq!(command.bin, "node");
+        assert_eq!(
+            command.args,
+            vec![
+                "script.mjs".to_string(),
+                "--transcript".to_string(),
+                "$TRANSCRIPT".to_string()
+            ]
+        );
+        assert_eq!(command.cwd.as_deref(), Some("/tmp/signet"));
+        assert_eq!(
+            command
+                .env
+                .and_then(|env| env.get("SIGNET_MODE").cloned())
+                .as_deref(),
+            Some("pipeline")
+        );
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -574,7 +625,28 @@ pub struct ExtractionConfig {
     pub endpoint: Option<String>,
     pub timeout: u64,
     pub min_confidence: f64,
+    pub command: Option<ExtractionCommandConfig>,
     pub escalation: Option<EscalationConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct ExtractionCommandConfig {
+    pub bin: String,
+    pub args: Vec<String>,
+    pub cwd: Option<String>,
+    pub env: Option<HashMap<String, String>>,
+}
+
+impl Default for ExtractionCommandConfig {
+    fn default() -> Self {
+        Self {
+            bin: String::new(),
+            args: Vec::new(),
+            cwd: None,
+            env: None,
+        }
+    }
 }
 
 impl Default for ExtractionConfig {
@@ -586,6 +658,7 @@ impl Default for ExtractionConfig {
             endpoint: None,
             timeout: 30_000,
             min_confidence: 0.5,
+            command: None,
             escalation: Some(EscalationConfig::default()),
         }
     }

--- a/packages/daemon-rs/crates/signet-core/src/config.rs
+++ b/packages/daemon-rs/crates/signet-core/src/config.rs
@@ -29,7 +29,11 @@ impl DaemonConfig {
             Ok(Some(manifest)) => manifest,
             Ok(None) => AgentManifest::default(),
             Err(error) => {
-                panic!("Invalid agent.yaml: {error}");
+                tracing::warn!(
+                    error = %error,
+                    "invalid or unreadable agent.yaml; falling back to default manifest"
+                );
+                AgentManifest::default()
             }
         };
         let (cfg_host, cfg_bind) = resolve_network_binding(
@@ -453,7 +457,7 @@ impl Default for EmbeddingConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::{network_mode_from_bind, parse_manifest, resolve_network_binding};
+    use super::{network_mode_from_bind, parse_manifest, resolve_network_binding, PipelineV2Config};
 
     #[test]
     fn resolves_localhost_binding_by_default() {
@@ -624,6 +628,7 @@ memory:
             .expect("pipeline config");
 
         assert_eq!(pipeline.extraction.provider, "command");
+        assert_eq!(pipeline.extraction.timeout, 90_000);
         let command = pipeline
             .extraction
             .command
@@ -711,6 +716,12 @@ memory:
                 "$SESSION_KEY".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn extraction_timeout_default_matches_typescript_timeout() {
+        let pipeline = PipelineV2Config::default();
+        assert_eq!(pipeline.extraction.timeout, 90_000);
     }
 }
 
@@ -895,7 +906,7 @@ impl Default for ExtractionConfig {
             model: "qwen3:4b".to_string(),
             strength: "medium".to_string(),
             endpoint: None,
-            timeout: 30_000,
+            timeout: 90_000,
             min_confidence: 0.5,
             command: None,
             escalation: Some(EscalationConfig::default()),

--- a/packages/daemon-rs/crates/signet-core/src/config.rs
+++ b/packages/daemon-rs/crates/signet-core/src/config.rs
@@ -150,10 +150,6 @@ fn normalize_pipeline_extraction(
         return Ok(());
     }
 
-    if !is_pipeline_provider(&pipeline.extraction.provider) {
-        return Err("memory.pipelineV2.extraction.provider is invalid".to_string());
-    }
-
     if pipeline.extraction.command.is_none() {
         let legacy = raw.and_then(|value| raw_string(value, "extractionCommand"));
         pipeline.extraction.command = legacy.and_then(parse_command_argv);
@@ -499,7 +495,7 @@ memory:
         assert_eq!(pipeline.extraction.provider, "ollama");
         assert_eq!(pipeline.extraction.model, "qwen3.5:4b");
         assert_eq!(pipeline.synthesis.provider, "ollama");
-        assert_eq!(pipeline.synthesis.model, "qwen3:4b");
+        assert_eq!(pipeline.synthesis.model, "qwen3.5:4b");
         assert_eq!(pipeline.synthesis.timeout, pipeline.extraction.timeout);
     }
 
@@ -526,7 +522,7 @@ memory:
             .expect("pipeline config");
 
         assert_eq!(pipeline.synthesis.provider, "ollama");
-        assert_eq!(pipeline.synthesis.model, "qwen3:4b");
+        assert_eq!(pipeline.synthesis.model, "qwen3.5:4b");
         assert_eq!(
             pipeline.synthesis.endpoint.as_deref(),
             Some("http://127.0.0.1:11434")

--- a/packages/daemon-rs/crates/signet-core/src/config.rs
+++ b/packages/daemon-rs/crates/signet-core/src/config.rs
@@ -114,10 +114,11 @@ fn normalize_manifest(mut manifest: AgentManifest, raw: &serde_yml::Value) -> Ag
 fn normalize_pipeline_synthesis(pipeline: &mut PipelineV2Config, raw: Option<&serde_yml::Value>) {
     let extraction = pipeline.extraction.clone();
     let fallback = SynthesisConfig::default();
+    let inherits_extraction = extraction.provider != "command";
     let provider = raw
         .and_then(|value| raw_child(value, "synthesis"))
         .and_then(|value| raw_string(value, "provider"))
-        .filter(|value| is_pipeline_provider(value));
+        .filter(|value| is_synthesis_provider(value));
     let model = raw
         .and_then(|value| raw_child(value, "synthesis"))
         .and_then(|value| raw_string(value, "model"));
@@ -133,23 +134,31 @@ fn normalize_pipeline_synthesis(pipeline: &mut PipelineV2Config, raw: Option<&se
 
     pipeline.synthesis.provider = provider
         .map(ToOwned::to_owned)
-        .unwrap_or_else(|| extraction.provider.clone());
+        .unwrap_or_else(|| {
+            if inherits_extraction {
+                extraction.provider.clone()
+            } else {
+                fallback.provider.clone()
+            }
+        });
     pipeline.synthesis.model = model.map(ToOwned::to_owned).unwrap_or_else(|| {
         if provider_won {
             default_pipeline_model(&pipeline.synthesis.provider).to_string()
-        } else {
+        } else if inherits_extraction {
             extraction.model.clone()
+        } else {
+            fallback.model.clone()
         }
     });
     pipeline.synthesis.endpoint = endpoint.map(ToOwned::to_owned).or_else(|| {
-        if provider_won {
+        if provider_won || !inherits_extraction {
             None
         } else {
             extraction.endpoint.clone()
         }
     });
     pipeline.synthesis.timeout = timeout.unwrap_or_else(|| {
-        if provider_won {
+        if provider_won || !inherits_extraction {
             fallback.timeout
         } else {
             extraction.timeout
@@ -182,6 +191,10 @@ fn is_pipeline_provider(value: &str) -> bool {
         value,
         "none" | "ollama" | "claude-code" | "opencode" | "codex" | "anthropic" | "openrouter" | "command"
     )
+}
+
+fn is_synthesis_provider(value: &str) -> bool {
+    is_pipeline_provider(value) && value != "command"
 }
 
 fn default_pipeline_model(provider: &str) -> &'static str {
@@ -322,7 +335,7 @@ memory:
         assert_eq!(pipeline.extraction.provider, "ollama");
         assert_eq!(pipeline.extraction.model, "qwen3.5:4b");
         assert_eq!(pipeline.synthesis.provider, "ollama");
-        assert_eq!(pipeline.synthesis.model, "qwen3.5:4b");
+        assert_eq!(pipeline.synthesis.model, "qwen3:4b");
         assert_eq!(pipeline.synthesis.timeout, pipeline.extraction.timeout);
     }
 
@@ -349,7 +362,7 @@ memory:
             .expect("pipeline config");
 
         assert_eq!(pipeline.synthesis.provider, "ollama");
-        assert_eq!(pipeline.synthesis.model, "qwen3.5:4b");
+        assert_eq!(pipeline.synthesis.model, "qwen3:4b");
         assert_eq!(
             pipeline.synthesis.endpoint.as_deref(),
             Some("http://127.0.0.1:11434")
@@ -472,6 +485,32 @@ memory:
                 .as_deref(),
             Some("pipeline")
         );
+        assert_eq!(pipeline.synthesis.provider, "ollama");
+        assert_eq!(pipeline.synthesis.model, "qwen3:4b");
+    }
+
+    #[test]
+    fn synthesis_command_provider_is_ignored_for_safety() {
+        let manifest = parse_manifest(
+            r#"
+memory:
+  pipelineV2:
+    extraction:
+      provider: ollama
+      model: qwen3.5:4b
+    synthesis:
+      provider: command
+"#,
+        )
+        .expect("parse manifest");
+
+        let pipeline = manifest
+            .memory
+            .and_then(|memory| memory.pipeline_v2)
+            .expect("pipeline config");
+
+        assert_eq!(pipeline.synthesis.provider, "ollama");
+        assert_eq!(pipeline.synthesis.model, "qwen3.5:4b");
     }
 }
 

--- a/packages/daemon-rs/crates/signet-core/src/config.rs
+++ b/packages/daemon-rs/crates/signet-core/src/config.rs
@@ -97,24 +97,97 @@ fn load_manifest(base: &Path) -> Option<AgentManifest> {
 fn parse_manifest(content: &str) -> Option<AgentManifest> {
     let raw: serde_yml::Value = serde_yml::from_str(content).ok()?;
     let manifest: AgentManifest = serde_yml::from_str(content).ok()?;
-    Some(normalize_manifest(manifest, &raw))
+    normalize_manifest(manifest, &raw)
 }
 
-fn normalize_manifest(mut manifest: AgentManifest, raw: &serde_yml::Value) -> AgentManifest {
+fn normalize_manifest(mut manifest: AgentManifest, raw: &serde_yml::Value) -> Option<AgentManifest> {
     let Some(memory) = manifest.memory.as_mut() else {
-        return manifest;
+        return Some(manifest);
     };
     let Some(pipeline) = memory.pipeline_v2.as_mut() else {
-        return manifest;
+        return Some(manifest);
     };
-    normalize_pipeline_synthesis(pipeline, raw_child(raw, "memory").and_then(|value| raw_child(value, "pipelineV2")));
-    manifest
+    let raw_pipeline = raw_child(raw, "memory").and_then(|value| raw_child(value, "pipelineV2"));
+    normalize_pipeline_extraction(pipeline, raw_pipeline)?;
+    normalize_pipeline_synthesis(pipeline, raw_pipeline)?;
+    Some(manifest)
 }
 
-fn normalize_pipeline_synthesis(pipeline: &mut PipelineV2Config, raw: Option<&serde_yml::Value>) {
+fn normalize_pipeline_extraction(
+    pipeline: &mut PipelineV2Config,
+    raw: Option<&serde_yml::Value>,
+) -> Option<()> {
+    let extraction_raw = raw.and_then(|value| raw_child(value, "extraction"));
+    if pipeline.extraction.provider != "command" {
+        return Some(());
+    }
+
+    if !is_pipeline_provider(&pipeline.extraction.provider) {
+        return None;
+    }
+
+    if pipeline.extraction.command.is_none() {
+        let legacy = raw.and_then(|value| raw_string(value, "extractionCommand"));
+        pipeline.extraction.command = legacy.and_then(parse_command_argv);
+    }
+
+    let mut command = pipeline.extraction.command.clone()?;
+    command.bin = command.bin.trim().to_string();
+    if command.bin.is_empty() {
+        return None;
+    }
+    if command.args.iter().any(|arg| arg.trim().is_empty()) {
+        command.args.retain(|arg| !arg.trim().is_empty());
+    }
+
+    if command.env.is_none() {
+        if let Some(raw_env) = extraction_raw
+            .and_then(|value| raw_child(value, "command"))
+            .and_then(|value| raw_child(value, "env"))
+            .and_then(|value| value.as_mapping())
+        {
+            let mut env = HashMap::new();
+            for (key, value) in raw_env {
+                let Some(k) = key.as_str() else {
+                    continue;
+                };
+                if !is_valid_env_key(k) {
+                    continue;
+                }
+                let Some(v) = value.as_str() else {
+                    continue;
+                };
+                env.insert(k.to_string(), v.to_string());
+            }
+            if !env.is_empty() {
+                command.env = Some(env);
+            }
+        }
+    } else if let Some(env) = command.env.as_mut() {
+        env.retain(|key, _| is_valid_env_key(key));
+        if env.is_empty() {
+            command.env = None;
+        }
+    }
+
+    pipeline.extraction.command = Some(command);
+    Some(())
+}
+
+fn normalize_pipeline_synthesis(
+    pipeline: &mut PipelineV2Config,
+    raw: Option<&serde_yml::Value>,
+) -> Option<()> {
     let extraction = pipeline.extraction.clone();
     let fallback = SynthesisConfig::default();
     let inherits_extraction = extraction.provider != "command";
+    let synthesis_raw = raw.and_then(|value| raw_child(value, "synthesis"));
+    if synthesis_raw
+        .and_then(|value| raw_string(value, "provider"))
+        .is_some_and(|provider| provider == "command")
+    {
+        return None;
+    }
     let provider = raw
         .and_then(|value| raw_child(value, "synthesis"))
         .and_then(|value| raw_string(value, "provider"))
@@ -167,6 +240,7 @@ fn normalize_pipeline_synthesis(pipeline: &mut PipelineV2Config, raw: Option<&se
     if pipeline.synthesis.provider == "none" {
         pipeline.synthesis.enabled = false;
     }
+    Some(())
 }
 
 fn raw_child<'a>(value: &'a serde_yml::Value, key: &str) -> Option<&'a serde_yml::Value> {
@@ -184,6 +258,59 @@ fn raw_string<'a>(value: &'a serde_yml::Value, key: &str) -> Option<&'a str> {
 
 fn raw_u64(value: &serde_yml::Value, key: &str) -> Option<u64> {
     raw_child(value, key)?.as_u64()
+}
+
+fn parse_command_argv(raw: &str) -> Option<ExtractionCommandConfig> {
+    let mut tokens: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut quote: Option<char> = None;
+
+    for ch in raw.chars() {
+        match quote {
+            Some(q) if ch == q => quote = None,
+            Some(_) => current.push(ch),
+            None if ch == '"' || ch == '\'' => quote = Some(ch),
+            None if ch.is_whitespace() => {
+                if !current.is_empty() {
+                    tokens.push(std::mem::take(&mut current));
+                }
+            }
+            None => current.push(ch),
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    if tokens.is_empty() {
+        return None;
+    }
+
+    let bin = tokens.first()?.trim().to_string();
+    if bin.is_empty() {
+        return None;
+    }
+    let args = tokens
+        .iter()
+        .skip(1)
+        .map(|token| token.trim().to_string())
+        .filter(|token| !token.is_empty())
+        .collect::<Vec<_>>();
+
+    Some(ExtractionCommandConfig {
+        bin,
+        args,
+        cwd: None,
+        env: None,
+    })
+}
+
+fn is_valid_env_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    match chars.next() {
+        Some(ch) if ch == '_' || ch.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
 }
 
 fn is_pipeline_provider(value: &str) -> bool {
@@ -490,7 +617,7 @@ memory:
     }
 
     #[test]
-    fn synthesis_command_provider_is_ignored_for_safety() {
+    fn synthesis_command_provider_is_rejected() {
         let manifest = parse_manifest(
             r#"
 memory:
@@ -501,6 +628,33 @@ memory:
     synthesis:
       provider: command
 "#,
+        );
+        assert!(manifest.is_none());
+    }
+
+    #[test]
+    fn extraction_command_provider_rejects_missing_command_config() {
+        let manifest = parse_manifest(
+            r#"
+memory:
+  pipelineV2:
+    extraction:
+      provider: command
+"#,
+        );
+        assert!(manifest.is_none());
+    }
+
+    #[test]
+    fn extraction_command_provider_parses_legacy_extraction_command() {
+        let manifest = parse_manifest(
+            r#"
+memory:
+  pipelineV2:
+    extraction:
+      provider: command
+    extractionCommand: node ./extract.mjs --transcript "$TRANSCRIPT" --session "$SESSION_KEY"
+"#,
         )
         .expect("parse manifest");
 
@@ -509,8 +663,21 @@ memory:
             .and_then(|memory| memory.pipeline_v2)
             .expect("pipeline config");
 
-        assert_eq!(pipeline.synthesis.provider, "ollama");
-        assert_eq!(pipeline.synthesis.model, "qwen3.5:4b");
+        let command = pipeline
+            .extraction
+            .command
+            .expect("legacy extractionCommand should be normalized");
+        assert_eq!(command.bin, "node");
+        assert_eq!(
+            command.args,
+            vec![
+                "./extract.mjs".to_string(),
+                "--transcript".to_string(),
+                "$TRANSCRIPT".to_string(),
+                "--session".to_string(),
+                "$SESSION_KEY".to_string()
+            ]
+        );
     }
 }
 

--- a/packages/daemon-rs/crates/signet-core/src/config.rs
+++ b/packages/daemon-rs/crates/signet-core/src/config.rs
@@ -28,10 +28,10 @@ impl DaemonConfig {
         let manifest = match load_manifest(&base) {
             Ok(Some(manifest)) => manifest,
             Ok(None) => AgentManifest::default(),
-            Err(error) => {
-                if should_fail_startup_for_manifest_error(&error) {
-                    return Err(format!("Invalid agent.yaml: {error}"));
-                }
+            Err(ManifestLoadError::Fatal(error)) => {
+                return Err(format!("Invalid agent.yaml: {error}"));
+            }
+            Err(ManifestLoadError::Recoverable(error)) => {
                 tracing::warn!(
                     error = %error,
                     "invalid or unreadable agent.yaml; falling back to default manifest"
@@ -101,24 +101,51 @@ fn dirs_home() -> PathBuf {
         })
 }
 
-fn should_fail_startup_for_manifest_error(error: &str) -> bool {
-    error.contains("memory.pipelineV2.extraction.command")
+enum ManifestLoadError {
+    Recoverable(String),
+    Fatal(String),
+}
+
+fn should_fail_fast_for_manifest_error_context(raw: &serde_yml::Value, error: &str) -> bool {
+    let raw_pipeline = raw_child(raw, "memory").and_then(|value| raw_child(value, "pipelineV2"));
+    let extraction_provider = raw_pipeline
+        .and_then(|value| raw_child(value, "extraction"))
+        .and_then(|value| raw_string(value, "provider"))
+        .or_else(|| raw_pipeline.and_then(|value| raw_string(value, "extractionProvider")));
+    let synthesis_provider = raw_pipeline
+        .and_then(|value| raw_child(value, "synthesis"))
+        .and_then(|value| raw_string(value, "provider"))
+        .or_else(|| raw_pipeline.and_then(|value| raw_string(value, "synthesisProvider")));
+
+    extraction_provider.is_some_and(|provider| provider == "command")
+        || synthesis_provider.is_some_and(|provider| provider == "command")
+        || error.contains("memory.pipelineV2.extraction.command")
         || error.contains("memory.pipelineV2.synthesis.provider='command'")
 }
 
-fn load_manifest(base: &Path) -> Result<Option<AgentManifest>, String> {
+fn load_manifest(base: &Path) -> Result<Option<AgentManifest>, ManifestLoadError> {
     let path = base.join("agent.yaml");
     let content = match std::fs::read_to_string(&path) {
         Ok(content) => content,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(err) => {
-            return Err(format!(
+            return Err(ManifestLoadError::Recoverable(format!(
                 "failed to read {}: {err}",
                 path.to_string_lossy()
-            ))
+            )))
         }
     };
-    parse_manifest_result(&content).map(Some)
+    let raw: serde_yml::Value = serde_yml::from_str(&content)
+        .map_err(|err| ManifestLoadError::Recoverable(format!("YAML parse error: {err}")))?;
+    parse_manifest_from_raw(&content, &raw)
+        .map(Some)
+        .map_err(|error| {
+            if should_fail_fast_for_manifest_error_context(&raw, &error) {
+                ManifestLoadError::Fatal(error)
+            } else {
+                ManifestLoadError::Recoverable(error)
+            }
+        })
 }
 
 #[cfg(test)]
@@ -126,12 +153,20 @@ fn parse_manifest(content: &str) -> Option<AgentManifest> {
     parse_manifest_result(content).ok()
 }
 
+#[cfg(test)]
 fn parse_manifest_result(content: &str) -> Result<AgentManifest, String> {
     let raw: serde_yml::Value =
         serde_yml::from_str(content).map_err(|err| format!("YAML parse error: {err}"))?;
+    parse_manifest_from_raw(content, &raw)
+}
+
+fn parse_manifest_from_raw(
+    content: &str,
+    raw: &serde_yml::Value,
+) -> Result<AgentManifest, String> {
     let manifest: AgentManifest =
         serde_yml::from_str(content).map_err(|err| format!("manifest shape error: {err}"))?;
-    normalize_manifest(manifest, &raw)
+    normalize_manifest(manifest, raw)
 }
 
 fn normalize_manifest(
@@ -464,7 +499,7 @@ impl Default for EmbeddingConfig {
 mod tests {
     use super::{
         network_mode_from_bind, parse_manifest, resolve_network_binding,
-        should_fail_startup_for_manifest_error, PipelineV2Config,
+        should_fail_fast_for_manifest_error_context, PipelineV2Config,
     };
 
     #[test]
@@ -734,14 +769,39 @@ memory:
 
     #[test]
     fn startup_fail_fast_scopes_to_command_provider_manifest_errors() {
-        assert!(should_fail_startup_for_manifest_error(
-            "memory.pipelineV2.extraction.command is required when extraction.provider='command'"
+        let extraction_command_raw: serde_yml::Value = serde_yml::from_str(
+            r#"
+memory:
+  pipelineV2:
+    extraction:
+      provider: command
+      command: []
+"#,
+        )
+        .expect("raw parse");
+        assert!(should_fail_fast_for_manifest_error_context(
+            &extraction_command_raw,
+            "manifest shape error: invalid type: sequence, expected struct ExtractionCommandConfig"
         ));
-        assert!(should_fail_startup_for_manifest_error(
-            "memory.pipelineV2.synthesis.provider='command' is not supported. Use extraction.provider='command' instead."
+
+        let synthesis_command_raw: serde_yml::Value = serde_yml::from_str(
+            r#"
+memory:
+  pipelineV2:
+    synthesis:
+      provider: command
+"#,
+        )
+        .expect("raw parse");
+        assert!(should_fail_fast_for_manifest_error_context(
+            &synthesis_command_raw,
+            "memory.pipelineV2.synthesis.provider='command' is not supported"
         ));
-        assert!(!should_fail_startup_for_manifest_error("YAML parse error: invalid type"));
-        assert!(!should_fail_startup_for_manifest_error(
+
+        let generic_raw: serde_yml::Value =
+            serde_yml::from_str("agent:\n  name: default\n").expect("raw parse");
+        assert!(!should_fail_fast_for_manifest_error_context(
+            &generic_raw,
             "manifest shape error: missing field `agent`"
         ));
     }

--- a/packages/daemon-rs/crates/signet-core/src/config.rs
+++ b/packages/daemon-rs/crates/signet-core/src/config.rs
@@ -20,7 +20,7 @@ pub struct DaemonConfig {
 }
 
 impl DaemonConfig {
-    pub fn from_env() -> Self {
+    pub fn from_env() -> Result<Self, String> {
         let base = std::env::var("SIGNET_PATH")
             .map(PathBuf::from)
             .unwrap_or_else(|_| dirs_home().join(".agents"));
@@ -29,11 +29,7 @@ impl DaemonConfig {
             Ok(Some(manifest)) => manifest,
             Ok(None) => AgentManifest::default(),
             Err(error) => {
-                tracing::warn!(
-                    error = %error,
-                    "invalid or unreadable agent.yaml; falling back to default manifest"
-                );
-                AgentManifest::default()
+                return Err(format!("Invalid agent.yaml: {error}"));
             }
         };
         let (cfg_host, cfg_bind) = resolve_network_binding(
@@ -59,14 +55,14 @@ impl DaemonConfig {
             }
         });
 
-        Self {
+        Ok(Self {
             base_path: base,
             db_path: db,
             port,
             host,
             bind,
             manifest,
-        }
+        })
     }
 
     pub fn memory_dir(&self) -> PathBuf {
@@ -113,6 +109,7 @@ fn load_manifest(base: &Path) -> Result<Option<AgentManifest>, String> {
     parse_manifest_result(&content).map(Some)
 }
 
+#[cfg(test)]
 fn parse_manifest(content: &str) -> Option<AgentManifest> {
     parse_manifest_result(content).ok()
 }

--- a/packages/daemon-rs/crates/signet-core/src/config.rs
+++ b/packages/daemon-rs/crates/signet-core/src/config.rs
@@ -29,7 +29,14 @@ impl DaemonConfig {
             Ok(Some(manifest)) => manifest,
             Ok(None) => AgentManifest::default(),
             Err(error) => {
-                return Err(format!("Invalid agent.yaml: {error}"));
+                if should_fail_startup_for_manifest_error(&error) {
+                    return Err(format!("Invalid agent.yaml: {error}"));
+                }
+                tracing::warn!(
+                    error = %error,
+                    "invalid or unreadable agent.yaml; falling back to default manifest"
+                );
+                AgentManifest::default()
             }
         };
         let (cfg_host, cfg_bind) = resolve_network_binding(
@@ -92,6 +99,11 @@ fn dirs_home() -> PathBuf {
             );
             PathBuf::from(".")
         })
+}
+
+fn should_fail_startup_for_manifest_error(error: &str) -> bool {
+    error.contains("memory.pipelineV2.extraction.command")
+        || error.contains("memory.pipelineV2.synthesis.provider='command'")
 }
 
 fn load_manifest(base: &Path) -> Result<Option<AgentManifest>, String> {
@@ -450,7 +462,10 @@ impl Default for EmbeddingConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::{network_mode_from_bind, parse_manifest, resolve_network_binding, PipelineV2Config};
+    use super::{
+        network_mode_from_bind, parse_manifest, resolve_network_binding,
+        should_fail_startup_for_manifest_error, PipelineV2Config,
+    };
 
     #[test]
     fn resolves_localhost_binding_by_default() {
@@ -715,6 +730,20 @@ memory:
     fn extraction_timeout_default_matches_typescript_timeout() {
         let pipeline = PipelineV2Config::default();
         assert_eq!(pipeline.extraction.timeout, 90_000);
+    }
+
+    #[test]
+    fn startup_fail_fast_scopes_to_command_provider_manifest_errors() {
+        assert!(should_fail_startup_for_manifest_error(
+            "memory.pipelineV2.extraction.command is required when extraction.provider='command'"
+        ));
+        assert!(should_fail_startup_for_manifest_error(
+            "memory.pipelineV2.synthesis.provider='command' is not supported. Use extraction.provider='command' instead."
+        ));
+        assert!(!should_fail_startup_for_manifest_error("YAML parse error: invalid type"));
+        assert!(!should_fail_startup_for_manifest_error(
+            "manifest shape error: missing field `agent`"
+        ));
     }
 }
 

--- a/packages/daemon-rs/crates/signet-core/src/config.rs
+++ b/packages/daemon-rs/crates/signet-core/src/config.rs
@@ -25,7 +25,13 @@ impl DaemonConfig {
             .map(PathBuf::from)
             .unwrap_or_else(|_| dirs_home().join(".agents"));
 
-        let manifest = load_manifest(&base).unwrap_or_default();
+        let manifest = match load_manifest(&base) {
+            Ok(Some(manifest)) => manifest,
+            Ok(None) => AgentManifest::default(),
+            Err(error) => {
+                panic!("Invalid agent.yaml: {error}");
+            }
+        };
         let (cfg_host, cfg_bind) = resolve_network_binding(
             manifest
                 .network
@@ -88,42 +94,60 @@ fn dirs_home() -> PathBuf {
         })
 }
 
-fn load_manifest(base: &Path) -> Option<AgentManifest> {
+fn load_manifest(base: &Path) -> Result<Option<AgentManifest>, String> {
     let path = base.join("agent.yaml");
-    let content = std::fs::read_to_string(&path).ok()?;
-    parse_manifest(&content)
+    let content = match std::fs::read_to_string(&path) {
+        Ok(content) => content,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(format!(
+                "failed to read {}: {err}",
+                path.to_string_lossy()
+            ))
+        }
+    };
+    parse_manifest_result(&content).map(Some)
 }
 
 fn parse_manifest(content: &str) -> Option<AgentManifest> {
-    let raw: serde_yml::Value = serde_yml::from_str(content).ok()?;
-    let manifest: AgentManifest = serde_yml::from_str(content).ok()?;
+    parse_manifest_result(content).ok()
+}
+
+fn parse_manifest_result(content: &str) -> Result<AgentManifest, String> {
+    let raw: serde_yml::Value =
+        serde_yml::from_str(content).map_err(|err| format!("YAML parse error: {err}"))?;
+    let manifest: AgentManifest =
+        serde_yml::from_str(content).map_err(|err| format!("manifest shape error: {err}"))?;
     normalize_manifest(manifest, &raw)
 }
 
-fn normalize_manifest(mut manifest: AgentManifest, raw: &serde_yml::Value) -> Option<AgentManifest> {
+fn normalize_manifest(
+    mut manifest: AgentManifest,
+    raw: &serde_yml::Value,
+) -> Result<AgentManifest, String> {
     let Some(memory) = manifest.memory.as_mut() else {
-        return Some(manifest);
+        return Ok(manifest);
     };
     let Some(pipeline) = memory.pipeline_v2.as_mut() else {
-        return Some(manifest);
+        return Ok(manifest);
     };
     let raw_pipeline = raw_child(raw, "memory").and_then(|value| raw_child(value, "pipelineV2"));
     normalize_pipeline_extraction(pipeline, raw_pipeline)?;
     normalize_pipeline_synthesis(pipeline, raw_pipeline)?;
-    Some(manifest)
+    Ok(manifest)
 }
 
 fn normalize_pipeline_extraction(
     pipeline: &mut PipelineV2Config,
     raw: Option<&serde_yml::Value>,
-) -> Option<()> {
+) -> Result<(), String> {
     let extraction_raw = raw.and_then(|value| raw_child(value, "extraction"));
     if pipeline.extraction.provider != "command" {
-        return Some(());
+        return Ok(());
     }
 
     if !is_pipeline_provider(&pipeline.extraction.provider) {
-        return None;
+        return Err("memory.pipelineV2.extraction.provider is invalid".to_string());
     }
 
     if pipeline.extraction.command.is_none() {
@@ -131,10 +155,16 @@ fn normalize_pipeline_extraction(
         pipeline.extraction.command = legacy.and_then(parse_command_argv);
     }
 
-    let mut command = pipeline.extraction.command.clone()?;
+    let mut command = pipeline.extraction.command.clone().ok_or_else(|| {
+        "memory.pipelineV2.extraction.command is required when extraction.provider='command'"
+            .to_string()
+    })?;
     command.bin = command.bin.trim().to_string();
     if command.bin.is_empty() {
-        return None;
+        return Err(
+            "memory.pipelineV2.extraction.command.bin is required when extraction.provider='command'"
+                .to_string(),
+        );
     }
     if command.args.iter().any(|arg| arg.trim().is_empty()) {
         command.args.retain(|arg| !arg.trim().is_empty());
@@ -171,13 +201,13 @@ fn normalize_pipeline_extraction(
     }
 
     pipeline.extraction.command = Some(command);
-    Some(())
+    Ok(())
 }
 
 fn normalize_pipeline_synthesis(
     pipeline: &mut PipelineV2Config,
     raw: Option<&serde_yml::Value>,
-) -> Option<()> {
+) -> Result<(), String> {
     let extraction = pipeline.extraction.clone();
     let fallback = SynthesisConfig::default();
     let inherits_extraction = extraction.provider != "command";
@@ -186,7 +216,10 @@ fn normalize_pipeline_synthesis(
         .and_then(|value| raw_string(value, "provider"))
         .is_some_and(|provider| provider == "command")
     {
-        return None;
+        return Err(
+            "memory.pipelineV2.synthesis.provider='command' is not supported. Use extraction.provider='command' instead."
+                .to_string(),
+        );
     }
     let provider = raw
         .and_then(|value| raw_child(value, "synthesis"))
@@ -240,7 +273,7 @@ fn normalize_pipeline_synthesis(
     if pipeline.synthesis.provider == "none" {
         pipeline.synthesis.enabled = false;
     }
-    Some(())
+    Ok(())
 }
 
 fn raw_child<'a>(value: &'a serde_yml::Value, key: &str) -> Option<&'a serde_yml::Value> {

--- a/packages/daemon-rs/crates/signet-daemon/src/main.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/main.rs
@@ -64,7 +64,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Service management subcommands (no logging needed)
     if args.iter().any(|a| a == "--install-service") {
-        let config = DaemonConfig::from_env();
+        let config = DaemonConfig::from_env().map_err(anyhow::Error::msg)?;
         service::install(config.port)?;
         println!("signet service installed (port {})", config.port);
         return Ok(());
@@ -91,7 +91,7 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     // Load config
-    let config = DaemonConfig::from_env();
+    let config = DaemonConfig::from_env().map_err(anyhow::Error::msg)?;
 
     // --check-migrations: open DB, run migrations, exit (for benchmarking startup)
     if args.iter().any(|a| a == "--check-migrations") {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -419,15 +419,18 @@ type RuntimeProviderName =
 	| "opencode"
 	| "codex"
 	| "anthropic"
-	| "openrouter";
+	| "openrouter"
+	| "command";
 
 type RuntimeSynthesisProviderName =
 	| "none"
 	| "ollama"
 	| "claude-code"
+	| "codex"
 	| "opencode"
 	| "anthropic"
-	| "openrouter";
+	| "openrouter"
+	| "command";
 
 interface ProviderRuntimeResolution {
 	extraction: {
@@ -11274,8 +11277,26 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 	if (rl.admin) authAdminLimiter = new AuthRateLimiter(rl.admin.windowMs, rl.admin.max);
 
 	const providerHints = getConfiguredProviderHints(AGENTS_DIR);
-	const validExtractionProviders = new Set(["none", "ollama", "claude-code", "opencode", "codex", "anthropic", "openrouter"]);
-	const validSynthesisProviders = new Set(["none", "ollama", "claude-code", "codex", "opencode", "anthropic", "openrouter"]);
+	const validExtractionProviders = new Set([
+		"none",
+		"ollama",
+		"claude-code",
+		"opencode",
+		"codex",
+		"anthropic",
+		"openrouter",
+		"command",
+	]);
+	const validSynthesisProviders = new Set([
+		"none",
+		"ollama",
+		"claude-code",
+		"codex",
+		"opencode",
+		"anthropic",
+		"openrouter",
+		"command",
+	]);
 
 	providerRuntimeResolution.extraction = {
 		configured: providerHints.extraction,
@@ -11328,6 +11349,8 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 		effectiveExtractionProvider = "none";
 	} else if (effectiveExtractionProvider === "none") {
 		logger.info("config", "Extraction provider set to 'none', pipeline LLM disabled");
+	} else if (effectiveExtractionProvider === "command") {
+		logger.info("config", "Extraction provider set to 'command'; summary worker will execute pipelineV2.extraction.command");
 	} else if (effectiveExtractionProvider === "opencode") {
 		if (extractionOpenCodeShouldManage) {
 			const serverReady = await ensureOpenCodeServer(4096);

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -429,8 +429,7 @@ type RuntimeSynthesisProviderName =
 	| "codex"
 	| "opencode"
 	| "anthropic"
-	| "openrouter"
-	| "command";
+	| "openrouter";
 
 interface ProviderRuntimeResolution {
 	extraction: {
@@ -11295,7 +11294,6 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 		"opencode",
 		"anthropic",
 		"openrouter",
-		"command",
 	]);
 
 	providerRuntimeResolution.extraction = {

--- a/packages/daemon/src/memory-config.test.ts
+++ b/packages/daemon/src/memory-config.test.ts
@@ -607,6 +607,37 @@ describe("loadPipelineConfig", () => {
 		expect(() => loadMemoryConfig(agentsDir)).toThrow("synthesis.provider='command' is not supported");
 	});
 
+	it("rejects extraction.provider=command when extraction.command is missing", () => {
+		expect(() =>
+			loadPipelineConfig({
+				memory: {
+					pipelineV2: {
+						extraction: {
+							provider: "command",
+						},
+					},
+				},
+			}),
+		).toThrow("extraction.command is required when extraction.provider='command'");
+	});
+
+	it("loadMemoryConfig fails fast when extraction.provider=command is missing command config", () => {
+		const agentsDir = makeTempAgentsDir();
+		writeFileSync(
+			join(agentsDir, "agent.yaml"),
+			`memory:
+  pipelineV2:
+    extraction:
+      provider: command
+`,
+			"utf8",
+		);
+
+		expect(() => loadMemoryConfig(agentsDir)).toThrow(
+			"extraction.command is required when extraction.provider='command'",
+		);
+	});
+
 	it("loads all flags correctly when all set to true (flat keys)", () => {
 		const result = loadPipelineConfig({
 			memory: {

--- a/packages/daemon/src/memory-config.test.ts
+++ b/packages/daemon/src/memory-config.test.ts
@@ -520,6 +520,56 @@ describe("loadPipelineConfig", () => {
 		expect(result.extraction.model).toBe("gpt-5.3-codex");
 	});
 
+	it("accepts command extraction provider with argv-safe command config", () => {
+		const result = loadPipelineConfig({
+			memory: {
+				pipelineV2: {
+					extraction: {
+						provider: "command",
+						command: {
+							bin: "node",
+							args: ["script.mjs", "--transcript", "$TRANSCRIPT"],
+							cwd: "/tmp/signet",
+							env: {
+								SIGNET_MODE: "pipeline",
+								"NOT VALID": "skip-me",
+							},
+						},
+					},
+				},
+			},
+		});
+
+		expect(result.extraction.provider).toBe("command");
+		expect(result.extraction.command).toEqual({
+			bin: "node",
+			args: ["script.mjs", "--transcript", "$TRANSCRIPT"],
+			cwd: "/tmp/signet",
+			env: {
+				SIGNET_MODE: "pipeline",
+			},
+		});
+		// synthesis inherits extraction provider when not explicitly configured
+		expect(result.synthesis.provider).toBe("command");
+	});
+
+	it("parses legacy extraction.command string into argv", () => {
+		const result = loadPipelineConfig({
+			memory: {
+				pipelineV2: {
+					extractionProvider: "command",
+					extractionCommand: 'node ./extract.mjs --transcript "$TRANSCRIPT" --session "$SESSION_KEY"',
+				},
+			},
+		});
+
+		expect(result.extraction.provider).toBe("command");
+		expect(result.extraction.command).toEqual({
+			bin: "node",
+			args: ["./extract.mjs", "--transcript", "$TRANSCRIPT", "--session", "$SESSION_KEY"],
+		});
+	});
+
 	it("loads all flags correctly when all set to true (flat keys)", () => {
 		const result = loadPipelineConfig({
 			memory: {

--- a/packages/daemon/src/memory-config.test.ts
+++ b/packages/daemon/src/memory-config.test.ts
@@ -639,6 +639,24 @@ describe("loadPipelineConfig", () => {
 		).toThrow("extraction.command is required when extraction.provider='command'");
 	});
 
+	it("rejects extraction.command args that contain non-strings", () => {
+		expect(() =>
+			loadPipelineConfig({
+				memory: {
+					pipelineV2: {
+						extraction: {
+							provider: "command",
+							command: {
+								bin: "node",
+								args: ["script.mjs", 123],
+							},
+						},
+					},
+				},
+			}),
+		).toThrow("extraction.command is required when extraction.provider='command'");
+	});
+
 	it("loadMemoryConfig fails fast when extraction.provider=command is missing command config", () => {
 		const agentsDir = makeTempAgentsDir();
 		writeFileSync(

--- a/packages/daemon/src/memory-config.test.ts
+++ b/packages/daemon/src/memory-config.test.ts
@@ -621,6 +621,24 @@ describe("loadPipelineConfig", () => {
 		).toThrow("extraction.command is required when extraction.provider='command'");
 	});
 
+	it("rejects extraction.command object that omits bin", () => {
+		expect(() =>
+			loadPipelineConfig({
+				memory: {
+					pipelineV2: {
+						extraction: {
+							provider: "command",
+							command: {
+								command: "node",
+								args: ["script.mjs"],
+							},
+						},
+					},
+				},
+			}),
+		).toThrow("extraction.command is required when extraction.provider='command'");
+	});
+
 	it("loadMemoryConfig fails fast when extraction.provider=command is missing command config", () => {
 		const agentsDir = makeTempAgentsDir();
 		writeFileSync(

--- a/packages/daemon/src/memory-config.test.ts
+++ b/packages/daemon/src/memory-config.test.ts
@@ -549,8 +549,9 @@ describe("loadPipelineConfig", () => {
 				SIGNET_MODE: "pipeline",
 			},
 		});
-		// synthesis inherits extraction provider when not explicitly configured
-		expect(result.synthesis.provider).toBe("command");
+		// synthesis never accepts command provider; extraction command falls back to synthesis defaults
+		expect(result.synthesis.provider).toBe("ollama");
+		expect(result.synthesis.model).toBe("qwen3:4b");
 	});
 
 	it("parses legacy extraction.command string into argv", () => {
@@ -568,6 +569,42 @@ describe("loadPipelineConfig", () => {
 			bin: "node",
 			args: ["./extract.mjs", "--transcript", "$TRANSCRIPT", "--session", "$SESSION_KEY"],
 		});
+	});
+
+	it("rejects synthesis.provider=command with a clear validation error", () => {
+		expect(() =>
+			loadPipelineConfig({
+				memory: {
+					pipelineV2: {
+						extraction: {
+							provider: "ollama",
+							model: "qwen3:4b",
+						},
+						synthesis: {
+							provider: "command",
+						},
+					},
+				},
+			}),
+		).toThrow("synthesis.provider='command' is not supported");
+	});
+
+	it("loadMemoryConfig fails fast when synthesis.provider=command is configured", () => {
+		const agentsDir = makeTempAgentsDir();
+		writeFileSync(
+			join(agentsDir, "agent.yaml"),
+			`memory:
+  pipelineV2:
+    extraction:
+      provider: ollama
+      model: qwen3:4b
+    synthesis:
+      provider: command
+`,
+			"utf8",
+		);
+
+		expect(() => loadMemoryConfig(agentsDir)).toThrow("synthesis.provider='command' is not supported");
 	});
 
 	it("loads all flags correctly when all set to true (flat keys)", () => {

--- a/packages/daemon/src/memory-config.ts
+++ b/packages/daemon/src/memory-config.ts
@@ -31,6 +31,13 @@ export interface MemorySearchConfig {
 export { PIPELINE_FLAGS };
 export type { PipelineFlag, PipelineV2Config };
 
+class PipelineConfigValidationError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "PipelineConfigValidationError";
+	}
+}
+
 export const DEFAULT_PIPELINE_V2: PipelineV2Config = {
 	enabled: true,
 	paused: false,
@@ -349,6 +356,9 @@ export function loadPipelineConfig(yaml: Record<string, unknown>): PipelineV2Con
 	const flatModel = raw.extractionModel;
 
 	type ProviderKind = Parameters<typeof defaultPipelineModel>[0];
+	type SynthesisProviderKind = Exclude<ProviderKind, "command">;
+	const isSynthesisProvider = (value: unknown): value is SynthesisProviderKind =>
+		isPipelineProvider(value) && value !== "command";
 
 	function resolveModel(provider: ProviderKind, raw: unknown, fallback?: string): string {
 		if (typeof raw === "string" && raw.trim().length > 0) {
@@ -390,23 +400,35 @@ export function loadPipelineConfig(yaml: Record<string, unknown>): PipelineV2Con
 		300000,
 		d.extraction.timeout,
 	);
-	const synthesisProviderWon = isPipelineProvider(synthesisRaw?.provider);
-	const resolvedSynthesisProvider = synthesisProviderWon ? synthesisRaw.provider : resolvedProvider;
+	if (synthesisRaw?.provider === "command") {
+		throw new PipelineConfigValidationError(
+			"memory.pipelineV2.synthesis.provider='command' is not supported. Use memory.pipelineV2.extraction.provider='command' instead.",
+		);
+	}
+
+	const synthesisProviderWon = isSynthesisProvider(synthesisRaw?.provider);
+	const resolvedSynthesisProvider: SynthesisProviderKind = synthesisProviderWon
+		? synthesisRaw.provider
+		: resolvedProvider === "command"
+			? d.synthesis.provider
+			: resolvedProvider;
 	const resolvedSynthesisModel =
 		typeof synthesisRaw?.model === "string" && synthesisRaw.model.trim().length > 0
 			? synthesisRaw.model
 			: synthesisProviderWon
 				? defaultPipelineModel(resolvedSynthesisProvider)
-				: resolvedModel;
+				: resolvedProvider === "command"
+					? d.synthesis.model
+					: resolvedModel;
 	const resolvedSynthesisEndpoint =
 		parseOptionalUrl(synthesisRaw?.endpoint) ??
 		parseOptionalUrl(synthesisRaw?.base_url) ??
-		(synthesisProviderWon ? undefined : resolvedEndpoint);
+		(synthesisProviderWon || resolvedProvider === "command" ? undefined : resolvedEndpoint);
 	const resolvedSynthesisTimeout = clampPositive(
 		synthesisRaw?.timeout,
 		5000,
 		300000,
-		synthesisProviderWon ? d.synthesis.timeout : resolvedTimeout,
+		synthesisProviderWon || resolvedProvider === "command" ? d.synthesis.timeout : resolvedTimeout,
 	);
 	const resolvedSynthesisEnabled =
 		resolvedSynthesisProvider === "none" ? false : resolveBool(synthesisRaw?.enabled, undefined, d.synthesis.enabled);
@@ -683,13 +705,7 @@ export function loadPipelineConfig(yaml: Record<string, unknown>): PipelineV2Con
 
 		synthesis: {
 			enabled: resolvedSynthesisEnabled,
-			provider: (() => {
-				const p = synthesisRaw?.provider;
-				if (isPipelineProvider(p)) {
-					return p;
-				}
-				return resolvedSynthesisProvider;
-			})(),
+			provider: resolvedSynthesisProvider,
 			model: resolvedSynthesisModel,
 			endpoint: resolvedSynthesisEndpoint,
 			timeout: resolvedSynthesisTimeout,
@@ -913,7 +929,10 @@ export function loadMemoryConfig(agentsDir: string): ResolvedMemoryConfig {
 			defaults.auth = parseAuthConfig(yaml.auth, agentsDir);
 
 			break;
-		} catch {
+		} catch (error) {
+			if (error instanceof PipelineConfigValidationError) {
+				throw error;
+			}
 			// ignore parse errors, try next file
 		}
 	}

--- a/packages/daemon/src/memory-config.ts
+++ b/packages/daemon/src/memory-config.ts
@@ -283,7 +283,13 @@ function parseCommandConfig(raw: unknown): PipelineV2Config["extraction"]["comma
 	const bin = candidateBin.trim();
 	if (bin.length === 0) return undefined;
 
-	const args = Array.isArray(record.args) ? record.args.filter((item): item is string => typeof item === "string") : [];
+	let args: string[] = [];
+	if (Array.isArray(record.args)) {
+		if (record.args.some((item) => typeof item !== "string")) {
+			return undefined;
+		}
+		args = [...record.args];
+	}
 	const cwd = typeof record.cwd === "string" && record.cwd.trim().length > 0 ? record.cwd.trim() : undefined;
 
 	let env: Record<string, string> | undefined;

--- a/packages/daemon/src/memory-config.ts
+++ b/packages/daemon/src/memory-config.ts
@@ -1,10 +1,10 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
+	DEFAULT_PIPELINE_TIMEOUT_MS,
 	PIPELINE_FLAGS,
 	type PipelineFlag,
 	type PipelineV2Config,
-	DEFAULT_PIPELINE_TIMEOUT_MS,
 	defaultPipelineModel,
 	isPipelineProvider,
 	parseSimpleYaml,
@@ -46,6 +46,7 @@ export const DEFAULT_PIPELINE_V2: PipelineV2Config = {
 		endpoint: undefined,
 		timeout: DEFAULT_PIPELINE_TIMEOUT_MS,
 		minConfidence: 0.7,
+		command: undefined,
 		escalation: {
 			maxNewEntitiesPerChunk: 10,
 			maxNewAttributesPerEntity: 20,
@@ -241,6 +242,62 @@ function parseOptionalUrl(raw: unknown): string | undefined {
 	return trimmed.length > 0 ? trimmed : undefined;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseCommandArgv(raw: string): { bin: string; args: string[] } | null {
+	const tokens = raw.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g);
+	if (!tokens || tokens.length === 0) return null;
+	const argv = tokens.map((token) => token.replace(/^["']|["']$/g, "")).filter((token) => token.length > 0);
+	if (argv.length === 0) return null;
+	return {
+		bin: argv[0],
+		args: argv.slice(1),
+	};
+}
+
+function parseCommandConfig(raw: unknown): PipelineV2Config["extraction"]["command"] | undefined {
+	if (typeof raw === "string") {
+		const parsed = parseCommandArgv(raw);
+		if (!parsed) return undefined;
+		return {
+			bin: parsed.bin,
+			args: parsed.args,
+		};
+	}
+
+	if (!isRecord(raw)) {
+		return undefined;
+	}
+
+	const record = raw;
+	const candidateBin =
+		typeof record.bin === "string" ? record.bin : typeof record.command === "string" ? record.command : "";
+	const bin = candidateBin.trim();
+	if (bin.length === 0) return undefined;
+
+	const args = Array.isArray(record.args) ? record.args.filter((item): item is string => typeof item === "string") : [];
+	const cwd = typeof record.cwd === "string" && record.cwd.trim().length > 0 ? record.cwd.trim() : undefined;
+
+	let env: Record<string, string> | undefined;
+	if (typeof record.env === "object" && record.env !== null && !Array.isArray(record.env)) {
+		for (const [key, value] of Object.entries(record.env)) {
+			if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+			if (typeof value !== "string") continue;
+			if (!env) env = {};
+			env[key] = value;
+		}
+	}
+
+	return {
+		bin,
+		args,
+		cwd,
+		env,
+	};
+}
+
 /**
  * Load pipeline config from YAML, supporting both nested and flat key formats.
  * Flat extraction keys (dashboard-written) take precedence over nested keys.
@@ -352,9 +409,7 @@ export function loadPipelineConfig(yaml: Record<string, unknown>): PipelineV2Con
 		synthesisProviderWon ? d.synthesis.timeout : resolvedTimeout,
 	);
 	const resolvedSynthesisEnabled =
-		resolvedSynthesisProvider === "none"
-			? false
-			: resolveBool(synthesisRaw?.enabled, undefined, d.synthesis.enabled);
+		resolvedSynthesisProvider === "none" ? false : resolveBool(synthesisRaw?.enabled, undefined, d.synthesis.enabled);
 
 	// Normalize aspect weights: clamp independently, then enforce min <= max
 	const maxAW = clampFraction(feedbackRaw?.maxAspectWeight, d.feedback.maxAspectWeight);
@@ -392,6 +447,7 @@ export function loadPipelineConfig(yaml: Record<string, unknown>): PipelineV2Con
 				extractionRaw?.minConfidence ?? raw.minFactConfidenceForWrite,
 				d.extraction.minConfidence,
 			),
+			command: parseCommandConfig(extractionRaw?.command ?? raw.extractionCommand),
 			escalation: {
 				maxNewEntitiesPerChunk: clampPositive(
 					escalationRaw?.maxNewEntitiesPerChunk,

--- a/packages/daemon/src/memory-config.ts
+++ b/packages/daemon/src/memory-config.ts
@@ -279,8 +279,7 @@ function parseCommandConfig(raw: unknown): PipelineV2Config["extraction"]["comma
 	}
 
 	const record = raw;
-	const candidateBin =
-		typeof record.bin === "string" ? record.bin : typeof record.command === "string" ? record.command : "";
+	const candidateBin = typeof record.bin === "string" ? record.bin : "";
 	const bin = candidateBin.trim();
 	if (bin.length === 0) return undefined;
 

--- a/packages/daemon/src/memory-config.ts
+++ b/packages/daemon/src/memory-config.ts
@@ -400,6 +400,12 @@ export function loadPipelineConfig(yaml: Record<string, unknown>): PipelineV2Con
 		300000,
 		d.extraction.timeout,
 	);
+	const resolvedCommandConfig = parseCommandConfig(extractionRaw?.command ?? raw.extractionCommand);
+	if (resolvedProvider === "command" && !resolvedCommandConfig) {
+		throw new PipelineConfigValidationError(
+			"memory.pipelineV2.extraction.command is required when extraction.provider='command'.",
+		);
+	}
 	if (synthesisRaw?.provider === "command") {
 		throw new PipelineConfigValidationError(
 			"memory.pipelineV2.synthesis.provider='command' is not supported. Use memory.pipelineV2.extraction.provider='command' instead.",
@@ -469,7 +475,7 @@ export function loadPipelineConfig(yaml: Record<string, unknown>): PipelineV2Con
 				extractionRaw?.minConfidence ?? raw.minFactConfidenceForWrite,
 				d.extraction.minConfidence,
 			),
-			command: parseCommandConfig(extractionRaw?.command ?? raw.extractionCommand),
+			command: resolvedCommandConfig,
 			escalation: {
 				maxNewEntitiesPerChunk: clampPositive(
 					escalationRaw?.maxNewEntitiesPerChunk,

--- a/packages/daemon/src/pipeline/summary-worker.test.ts
+++ b/packages/daemon/src/pipeline/summary-worker.test.ts
@@ -215,7 +215,7 @@ describe("recoverSummaryJobs", () => {
 describe("runSummaryCommandProvider", () => {
 	it("executes argv-safe command mode with token substitution and temp cleanup", async () => {
 		const marker = join(tmpdir(), `signet-summary-marker-${Date.now()}-${Math.random()}.txt`);
-		const dir = makeAgentsDir("memory:\n  pipelineV2:\n    extraction:\n      provider: command\n");
+		const dir = makeAgentsDir("memory:\n  pipelineV2:\n    extraction:\n      provider: ollama\n");
 		const scriptPath = join(dir, "summary-command-success.mjs");
 		writeFileSync(
 			scriptPath,
@@ -268,7 +268,7 @@ writeFileSync(markerPath, transcriptPath, "utf8");
 	});
 
 	it("throws when command exits non-zero", async () => {
-		const dir = makeAgentsDir("memory:\n  pipelineV2:\n    extraction:\n      provider: command\n");
+		const dir = makeAgentsDir("memory:\n  pipelineV2:\n    extraction:\n      provider: ollama\n");
 		const scriptPath = join(dir, "summary-command-fail.mjs");
 		writeFileSync(scriptPath, "process.exit(7);\n", "utf8");
 

--- a/packages/daemon/src/pipeline/summary-worker.test.ts
+++ b/packages/daemon/src/pipeline/summary-worker.test.ts
@@ -8,7 +8,9 @@ import type { DbAccessor, ReadDb, WriteDb } from "../db-accessor";
 import { loadMemoryConfig } from "../memory-config";
 import {
 	SUMMARY_WORKER_UPDATED_BY,
+	hasCommandStageCompleted,
 	insertSummaryFacts,
+	markCommandStageCompleted,
 	recoverSummaryJobs,
 	resolveSummaryProvider,
 	runSummaryCommandProvider,
@@ -209,6 +211,49 @@ describe("recoverSummaryJobs", () => {
 
 		const after = db.prepare("SELECT status FROM summary_jobs WHERE id = 'job-startup'").get() as { status: string };
 		expect(after.status).toBe("pending");
+	});
+});
+
+describe("command stage completion marker", () => {
+	let db: Database;
+	let accessor: DbAccessor;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+		accessor = makeAccessor(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("persists command-stage completion so retries can skip command reruns", () => {
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO summary_jobs
+			 (id, session_key, harness, project, transcript, status, attempts, max_attempts, created_at, result)
+			 VALUES ('job-cmd-marker', NULL, 'codex', NULL, 'transcript', 'processing', 1, 3, ?, NULL)`,
+		).run(now);
+
+		expect(hasCommandStageCompleted(accessor, "job-cmd-marker")).toBe(false);
+
+		markCommandStageCompleted(accessor, "job-cmd-marker");
+
+		expect(hasCommandStageCompleted(accessor, "job-cmd-marker")).toBe(true);
+	});
+
+	it("does not mark command completion when the job is not in processing state", () => {
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO summary_jobs
+			 (id, session_key, harness, project, transcript, status, attempts, max_attempts, created_at, result)
+			 VALUES ('job-cmd-pending', NULL, 'codex', NULL, 'transcript', 'pending', 0, 3, ?, NULL)`,
+		).run(now);
+
+		markCommandStageCompleted(accessor, "job-cmd-pending");
+
+		expect(hasCommandStageCompleted(accessor, "job-cmd-pending")).toBe(false);
 	});
 });
 

--- a/packages/daemon/src/pipeline/summary-worker.test.ts
+++ b/packages/daemon/src/pipeline/summary-worker.test.ts
@@ -8,9 +8,12 @@ import type { DbAccessor, ReadDb, WriteDb } from "../db-accessor";
 import { loadMemoryConfig } from "../memory-config";
 import {
 	SUMMARY_WORKER_UPDATED_BY,
+	clearCommandStageRunning,
+	getCommandStageStatus,
 	hasCommandStageCompleted,
 	insertSummaryFacts,
 	markCommandStageCompleted,
+	markCommandStageRunning,
 	recoverSummaryJobs,
 	resolveSummaryProvider,
 	runSummaryCommandProvider,
@@ -217,16 +220,18 @@ describe("recoverSummaryJobs", () => {
 
 describe("shouldRunSignificanceGateForJob", () => {
 	it("runs significance gate for non-command extraction jobs", () => {
-		expect(shouldRunSignificanceGateForJob(false, false)).toBe(true);
-		expect(shouldRunSignificanceGateForJob(false, true)).toBe(true);
+		expect(shouldRunSignificanceGateForJob(false, "none")).toBe(true);
+		expect(shouldRunSignificanceGateForJob(false, "running")).toBe(true);
+		expect(shouldRunSignificanceGateForJob(false, "complete")).toBe(true);
 	});
 
 	it("runs significance gate before command stage has completed", () => {
-		expect(shouldRunSignificanceGateForJob(true, false)).toBe(true);
+		expect(shouldRunSignificanceGateForJob(true, "none")).toBe(true);
 	});
 
-	it("skips significance gate on retries after command stage completion", () => {
-		expect(shouldRunSignificanceGateForJob(true, true)).toBe(false);
+	it("skips significance gate for command retries once a stage checkpoint exists", () => {
+		expect(shouldRunSignificanceGateForJob(true, "running")).toBe(false);
+		expect(shouldRunSignificanceGateForJob(true, "complete")).toBe(false);
 	});
 });
 
@@ -244,7 +249,7 @@ describe("command stage completion marker", () => {
 		db.close();
 	});
 
-	it("persists command-stage completion so retries can skip command reruns", () => {
+	it("tracks running and completed stage checkpoints for command-mode retries", () => {
 		const now = new Date().toISOString();
 		db.prepare(
 			`INSERT INTO summary_jobs
@@ -252,14 +257,20 @@ describe("command stage completion marker", () => {
 			 VALUES ('job-cmd-marker', NULL, 'codex', NULL, 'transcript', 'processing', 1, 3, ?, NULL)`,
 		).run(now);
 
+		expect(getCommandStageStatus(accessor, "job-cmd-marker")).toBe("none");
+		expect(hasCommandStageCompleted(accessor, "job-cmd-marker")).toBe(false);
+
+		markCommandStageRunning(accessor, "job-cmd-marker");
+		expect(getCommandStageStatus(accessor, "job-cmd-marker")).toBe("running");
 		expect(hasCommandStageCompleted(accessor, "job-cmd-marker")).toBe(false);
 
 		markCommandStageCompleted(accessor, "job-cmd-marker");
 
+		expect(getCommandStageStatus(accessor, "job-cmd-marker")).toBe("complete");
 		expect(hasCommandStageCompleted(accessor, "job-cmd-marker")).toBe(true);
 	});
 
-	it("does not mark command completion when the job is not in processing state", () => {
+	it("does not mutate stage checkpoints when the job is not in processing state", () => {
 		const now = new Date().toISOString();
 		db.prepare(
 			`INSERT INTO summary_jobs
@@ -267,9 +278,27 @@ describe("command stage completion marker", () => {
 			 VALUES ('job-cmd-pending', NULL, 'codex', NULL, 'transcript', 'pending', 0, 3, ?, NULL)`,
 		).run(now);
 
+		markCommandStageRunning(accessor, "job-cmd-pending");
 		markCommandStageCompleted(accessor, "job-cmd-pending");
+		clearCommandStageRunning(accessor, "job-cmd-pending");
 
+		expect(getCommandStageStatus(accessor, "job-cmd-pending")).toBe("none");
 		expect(hasCommandStageCompleted(accessor, "job-cmd-pending")).toBe(false);
+	});
+
+	it("clears the running checkpoint when command execution fails", () => {
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO summary_jobs
+			 (id, session_key, harness, project, transcript, status, attempts, max_attempts, created_at, result)
+			 VALUES ('job-cmd-fail-reset', NULL, 'codex', NULL, 'transcript', 'processing', 1, 3, ?, NULL)`,
+		).run(now);
+
+		markCommandStageRunning(accessor, "job-cmd-fail-reset");
+		expect(getCommandStageStatus(accessor, "job-cmd-fail-reset")).toBe("running");
+
+		clearCommandStageRunning(accessor, "job-cmd-fail-reset");
+		expect(getCommandStageStatus(accessor, "job-cmd-fail-reset")).toBe("none");
 	});
 });
 

--- a/packages/daemon/src/pipeline/summary-worker.test.ts
+++ b/packages/daemon/src/pipeline/summary-worker.test.ts
@@ -305,6 +305,63 @@ writeFileSync(markerPath, transcriptPath, "utf8");
 			),
 		).rejects.toThrow("summary command exited with code 7");
 	});
+
+	it("waits for process exit after timeout before rejecting", async () => {
+		const marker = join(tmpdir(), `signet-summary-timeout-${Date.now()}-${Math.random()}.txt`);
+		const dir = makeAgentsDir("memory:\n  pipelineV2:\n    extraction:\n      provider: ollama\n");
+		const scriptPath = join(dir, "summary-command-timeout.mjs");
+		writeFileSync(
+			scriptPath,
+			`import { writeFileSync } from "node:fs";
+const marker = process.argv[2];
+process.on("SIGTERM", () => {
+  setTimeout(() => {
+    writeFileSync(marker, "terminated", "utf8");
+    process.exit(0);
+  }, 150);
+});
+setInterval(() => {}, 1000);
+`,
+			"utf8",
+		);
+
+		const cfg = loadMemoryConfig(dir);
+		const commandCfg = {
+			...cfg,
+			pipelineV2: {
+				...cfg.pipelineV2,
+				extraction: {
+					...cfg.pipelineV2.extraction,
+					timeout: 5000,
+					provider: "command",
+					command: {
+						bin: "node",
+						args: [scriptPath, marker],
+					},
+				},
+			},
+		};
+
+		await expect(
+			runSummaryCommandProvider(
+				{
+					id: "job-timeout",
+					session_key: "session-timeout",
+					harness: "codex",
+					project: "/tmp/project",
+					agent_id: "default",
+					transcript: "test",
+					attempts: 1,
+					max_attempts: 3,
+					created_at: new Date().toISOString(),
+				},
+				commandCfg,
+			),
+		).rejects.toThrow("summary command timed out after 5000ms");
+
+		expect(existsSync(marker)).toBe(true);
+		rmSync(marker, { force: true });
+	}, 15_000);
 });
 
 describe("resolveSummaryProvider", () => {

--- a/packages/daemon/src/pipeline/summary-worker.test.ts
+++ b/packages/daemon/src/pipeline/summary-worker.test.ts
@@ -220,12 +220,13 @@ describe("runSummaryCommandProvider", () => {
 		writeFileSync(
 			scriptPath,
 			`import { existsSync, readFileSync, writeFileSync } from "node:fs";
-const [transcriptPath, sessionKey, project, markerPath] = process.argv.slice(2);
+const [transcriptPath, sessionKey, project, agentId, markerPath] = process.argv.slice(2);
 if (!existsSync(transcriptPath)) process.exit(11);
 const text = readFileSync(transcriptPath, "utf8");
 if (!text.includes("hello command provider")) process.exit(12);
 if (sessionKey !== "session-123") process.exit(13);
 if (project !== "/tmp/project") process.exit(14);
+if (agentId !== "agent-abc") process.exit(15);
 writeFileSync(markerPath, transcriptPath, "utf8");
 `,
 			"utf8",
@@ -241,7 +242,7 @@ writeFileSync(markerPath, transcriptPath, "utf8");
 					provider: "command",
 					command: {
 						bin: "node",
-						args: [scriptPath, "$TRANSCRIPT", "$SESSION_KEY", "$PROJECT", marker],
+						args: [scriptPath, "$TRANSCRIPT", "$SESSION_KEY", "$PROJECT", "$AGENT_ID", marker],
 					},
 				},
 			},
@@ -252,7 +253,7 @@ writeFileSync(markerPath, transcriptPath, "utf8");
 				session_key: "session-123",
 				harness: "codex",
 				project: "/tmp/project",
-				agent_id: "default",
+				agent_id: "agent-abc",
 				transcript: "hello command provider",
 				attempts: 1,
 				max_attempts: 3,

--- a/packages/daemon/src/pipeline/summary-worker.test.ts
+++ b/packages/daemon/src/pipeline/summary-worker.test.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runMigrations } from "@signet/core";
@@ -11,6 +11,7 @@ import {
 	insertSummaryFacts,
 	recoverSummaryJobs,
 	resolveSummaryProvider,
+	runSummaryCommandProvider,
 	startSummaryWorker,
 } from "./summary-worker";
 
@@ -208,6 +209,100 @@ describe("recoverSummaryJobs", () => {
 
 		const after = db.prepare("SELECT status FROM summary_jobs WHERE id = 'job-startup'").get() as { status: string };
 		expect(after.status).toBe("pending");
+	});
+});
+
+describe("runSummaryCommandProvider", () => {
+	it("executes argv-safe command mode with token substitution and temp cleanup", async () => {
+		const marker = join(tmpdir(), `signet-summary-marker-${Date.now()}-${Math.random()}.txt`);
+		const dir = makeAgentsDir("memory:\n  pipelineV2:\n    extraction:\n      provider: command\n");
+		const scriptPath = join(dir, "summary-command-success.mjs");
+		writeFileSync(
+			scriptPath,
+			`import { existsSync, readFileSync, writeFileSync } from "node:fs";
+const [transcriptPath, sessionKey, project, markerPath] = process.argv.slice(2);
+if (!existsSync(transcriptPath)) process.exit(11);
+const text = readFileSync(transcriptPath, "utf8");
+if (!text.includes("hello command provider")) process.exit(12);
+if (sessionKey !== "session-123") process.exit(13);
+if (project !== "/tmp/project") process.exit(14);
+writeFileSync(markerPath, transcriptPath, "utf8");
+`,
+			"utf8",
+		);
+
+		const cfg = loadMemoryConfig(dir);
+		const commandCfg = {
+			...cfg,
+			pipelineV2: {
+				...cfg.pipelineV2,
+				extraction: {
+					...cfg.pipelineV2.extraction,
+					provider: "command",
+					command: {
+						bin: "node",
+						args: [scriptPath, "$TRANSCRIPT", "$SESSION_KEY", "$PROJECT", marker],
+					},
+				},
+			},
+		};
+		await runSummaryCommandProvider(
+			{
+				id: "job-1",
+				session_key: "session-123",
+				harness: "codex",
+				project: "/tmp/project",
+				agent_id: "default",
+				transcript: "hello command provider",
+				attempts: 1,
+				max_attempts: 3,
+				created_at: new Date().toISOString(),
+			},
+			commandCfg,
+		);
+
+		const transcriptPath = readFileSync(marker, "utf8").trim();
+		expect(transcriptPath.length).toBeGreaterThan(0);
+		expect(existsSync(transcriptPath)).toBe(false);
+		rmSync(marker, { force: true });
+	});
+
+	it("throws when command exits non-zero", async () => {
+		const dir = makeAgentsDir("memory:\n  pipelineV2:\n    extraction:\n      provider: command\n");
+		const scriptPath = join(dir, "summary-command-fail.mjs");
+		writeFileSync(scriptPath, "process.exit(7);\n", "utf8");
+
+		const cfg = loadMemoryConfig(dir);
+		const commandCfg = {
+			...cfg,
+			pipelineV2: {
+				...cfg.pipelineV2,
+				extraction: {
+					...cfg.pipelineV2.extraction,
+					provider: "command",
+					command: {
+						bin: "node",
+						args: [scriptPath],
+					},
+				},
+			},
+		};
+		await expect(
+			runSummaryCommandProvider(
+				{
+					id: "job-2",
+					session_key: "session-xyz",
+					harness: "codex",
+					project: "/tmp/project",
+					agent_id: "default",
+					transcript: "test",
+					attempts: 1,
+					max_attempts: 3,
+					created_at: new Date().toISOString(),
+				},
+				commandCfg,
+			),
+		).rejects.toThrow("summary command exited with code 7");
 	});
 });
 

--- a/packages/daemon/src/pipeline/summary-worker.test.ts
+++ b/packages/daemon/src/pipeline/summary-worker.test.ts
@@ -14,6 +14,7 @@ import {
 	recoverSummaryJobs,
 	resolveSummaryProvider,
 	runSummaryCommandProvider,
+	shouldRunSignificanceGateForJob,
 	startSummaryWorker,
 } from "./summary-worker";
 
@@ -211,6 +212,21 @@ describe("recoverSummaryJobs", () => {
 
 		const after = db.prepare("SELECT status FROM summary_jobs WHERE id = 'job-startup'").get() as { status: string };
 		expect(after.status).toBe("pending");
+	});
+});
+
+describe("shouldRunSignificanceGateForJob", () => {
+	it("runs significance gate for non-command extraction jobs", () => {
+		expect(shouldRunSignificanceGateForJob(false, false)).toBe(true);
+		expect(shouldRunSignificanceGateForJob(false, true)).toBe(true);
+	});
+
+	it("runs significance gate before command stage has completed", () => {
+		expect(shouldRunSignificanceGateForJob(true, false)).toBe(true);
+	});
+
+	it("skips significance gate on retries after command stage completion", () => {
+		expect(shouldRunSignificanceGateForJob(true, true)).toBe(false);
 	});
 });
 

--- a/packages/daemon/src/pipeline/summary-worker.test.ts
+++ b/packages/daemon/src/pipeline/summary-worker.test.ts
@@ -198,6 +198,22 @@ describe("recoverSummaryJobs", () => {
 		]);
 	});
 
+	it("clears in-flight command-stage-running marker during crash recovery but preserves completed checkpoint", () => {
+		const now = new Date().toISOString();
+		const stmt = db.prepare(
+			`INSERT INTO summary_jobs
+			 (id, session_key, harness, project, transcript, status, result, attempts, max_attempts, created_at)
+			 VALUES (?, NULL, 'codex', NULL, 'transcript', 'processing', ?, 0, 3, ?)`,
+		);
+		stmt.run("job-running", "command-stage-running", now);
+		stmt.run("job-complete", "command-stage-complete", now);
+
+		expect(recoverSummaryJobs(accessor, 10)).toEqual({ selected: 2, updated: 2 });
+
+		expect(getCommandStageStatus(accessor, "job-running")).toBe("none");
+		expect(getCommandStageStatus(accessor, "job-complete")).toBe("complete");
+	});
+
 	it("defers crash recovery off the synchronous startup path", async () => {
 		const now = new Date().toISOString();
 		db.prepare(

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -1329,14 +1329,18 @@ export function recoverSummaryJobs(accessor: DbAccessor, limit: number = RECOVER
 
 		const update = db.prepare(
 			`UPDATE summary_jobs
-			 SET status = ?
+			 SET status = ?,
+			     result = CASE
+			       WHEN result = ? THEN NULL
+			       ELSE result
+			     END
 			 WHERE id = ? AND status IN ('processing', 'leased')`,
 		);
 
 		let updated = 0;
 		for (const row of rows) {
 			const status = row.attempts >= row.max_attempts ? "dead" : "pending";
-			updated += countChanges(update.run(status, row.id));
+			updated += countChanges(update.run(status, COMMAND_STAGE_RUNNING_RESULT, row.id));
 		}
 
 		return { selected: rows.length, updated };

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -354,24 +354,29 @@ export async function runSummaryCommandProvider(
 	const transcriptPath = join(tempDir, "transcript.txt");
 	writeFileSync(transcriptPath, job.transcript, "utf-8");
 
-	const replacements: Record<string, string> = {
+	const tokenReplacements: Record<string, string> = {
 		$TRANSCRIPT: transcriptPath,
 		$TRANSCRIPT_PATH: transcriptPath,
 		$SESSION_KEY: job.session_key ?? "",
 		$PROJECT: job.project ?? "",
+		$AGENT_ID: job.agent_id,
 		$SIGNET_PATH: AGENTS_DIR,
 	};
-	const bin = substituteCommandTokens(command.bin, replacements).trim();
+	const locationReplacements: Record<string, string> = {
+		$AGENT_ID: job.agent_id,
+		$SIGNET_PATH: AGENTS_DIR,
+	};
+	const bin = substituteCommandTokens(command.bin, locationReplacements).trim();
 	if (bin.length === 0) {
 		throw new Error("pipelineV2.extraction.command.bin resolved to an empty value");
 	}
-	const args = command.args.map((arg) => substituteCommandTokens(arg, replacements));
+	const args = command.args.map((arg) => substituteCommandTokens(arg, tokenReplacements));
 	const timeoutMs = Math.max(5000, Math.min(300000, cfg.pipelineV2.extraction.timeout));
-	const cwd = command.cwd ? substituteCommandTokens(command.cwd, replacements).trim() : undefined;
+	const cwd = command.cwd ? substituteCommandTokens(command.cwd, locationReplacements).trim() : undefined;
 	const envFromConfig: Record<string, string> = {};
 	if (command.env) {
 		for (const [key, value] of Object.entries(command.env)) {
-			envFromConfig[key] = substituteCommandTokens(value, replacements);
+			envFromConfig[key] = substituteCommandTokens(value, tokenReplacements);
 		}
 	}
 
@@ -389,11 +394,18 @@ export async function runSummaryCommandProvider(
 			});
 
 			let settled = false;
+			let killTimer: ReturnType<typeof setTimeout> | null = null;
+			const clearKillTimer = (): void => {
+				if (killTimer) {
+					clearTimeout(killTimer);
+					killTimer = null;
+				}
+			};
 			const timeout = setTimeout(() => {
 				if (settled) return;
 				settled = true;
 				child.kill("SIGTERM");
-				setTimeout(() => {
+				killTimer = setTimeout(() => {
 					try {
 						child.kill("SIGKILL");
 					} catch {
@@ -404,6 +416,7 @@ export async function runSummaryCommandProvider(
 			}, timeoutMs);
 
 			child.on("error", (err) => {
+				clearKillTimer();
 				if (settled) return;
 				settled = true;
 				clearTimeout(timeout);
@@ -411,6 +424,7 @@ export async function runSummaryCommandProvider(
 			});
 
 			child.on("close", (code) => {
+				clearKillTimer();
 				if (settled) return;
 				settled = true;
 				clearTimeout(timeout);
@@ -1397,7 +1411,10 @@ export function startSummaryWorker(accessor: DbAccessor): SummaryWorkerHandle {
 			});
 
 			let providerForJob: LlmProvider | null = null;
-			if (cfg.pipelineV2.synthesis.enabled && cfg.pipelineV2.synthesis.provider !== "none") {
+			const requiresProviderForExtraction = cfg.pipelineV2.extraction.provider !== "command";
+			const requiresProviderForSynthesis =
+				cfg.pipelineV2.synthesis.enabled && cfg.pipelineV2.synthesis.provider !== "none";
+			if (requiresProviderForExtraction || requiresProviderForSynthesis) {
 				// Cache provider across jobs — re-resolve on config change, env
 				// key rotation, or TTL expiry. Env-var key changes invalidate
 				// immediately; secrets-store-only rotations rely on the 5-min TTL.

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -341,11 +341,6 @@ function substituteCommandTokens(input: string, replacements: Record<string, str
 	return output;
 }
 
-function trimOutput(value: string, maxChars: number): string {
-	if (value.length <= maxChars) return value;
-	return `${value.slice(0, maxChars)}…`;
-}
-
 export async function runSummaryCommandProvider(
 	job: SummaryJobRow,
 	cfg: ReturnType<typeof loadMemoryConfig>,
@@ -389,21 +384,8 @@ export async function runSummaryCommandProvider(
 					...envFromConfig,
 					SIGNET_PATH: AGENTS_DIR,
 				},
-				stdio: ["ignore", "pipe", "pipe"],
+				stdio: ["ignore", "ignore", "ignore"],
 				windowsHide: true,
-			});
-
-			let stdout = "";
-			let stderr = "";
-			const MAX_CAPTURE_CHARS = 4000;
-
-			child.stdout?.on("data", (chunk: Buffer) => {
-				if (stdout.length >= MAX_CAPTURE_CHARS) return;
-				stdout += chunk.toString("utf-8").slice(0, MAX_CAPTURE_CHARS - stdout.length);
-			});
-			child.stderr?.on("data", (chunk: Buffer) => {
-				if (stderr.length >= MAX_CAPTURE_CHARS) return;
-				stderr += chunk.toString("utf-8").slice(0, MAX_CAPTURE_CHARS - stderr.length);
 			});
 
 			let settled = false;
@@ -434,8 +416,7 @@ export async function runSummaryCommandProvider(
 				clearTimeout(timeout);
 				const exitCode = code ?? 1;
 				if (exitCode !== 0) {
-					const detail = stderr.trim().length > 0 ? stderr.trim() : stdout.trim();
-					reject(new Error(`summary command exited with code ${exitCode}: ${trimOutput(detail, 500)}`));
+					reject(new Error(`summary command exited with code ${exitCode}`));
 					return;
 				}
 				resolve();
@@ -461,7 +442,7 @@ async function processJob(
 		throw new Error("summary worker requires an LLM provider when extraction.provider is not 'command'");
 	}
 
-	if (!commandMode && provider) {
+	if (provider) {
 		const today = new Date().toISOString().slice(0, 10);
 		const genOpts = {
 			timeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
@@ -1414,7 +1395,7 @@ export function startSummaryWorker(accessor: DbAccessor): SummaryWorkerHandle {
 			});
 
 			let providerForJob: LlmProvider | null = null;
-			if (cfg.pipelineV2.extraction.provider !== "command") {
+			if (cfg.pipelineV2.synthesis.enabled && cfg.pipelineV2.synthesis.provider !== "none") {
 				// Cache provider across jobs — re-resolve on config change, env
 				// key rotation, or TTL expiry. Env-var key changes invalidate
 				// immediately; secrets-store-only rotations rely on the 5-min TTL.

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -453,193 +453,202 @@ async function processJob(
 	memoryCfg: ReturnType<typeof loadMemoryConfig>,
 ): Promise<void> {
 	if (!passesSignificanceGate(accessor, job, memoryCfg)) return;
-	if (memoryCfg.pipelineV2.extraction.provider === "command") {
+	const commandMode = memoryCfg.pipelineV2.extraction.provider === "command";
+	if (commandMode) {
 		await runSummaryCommandProvider(job, memoryCfg);
-		return;
 	}
-	if (!provider) {
+	if (!commandMode && !provider) {
 		throw new Error("summary worker requires an LLM provider when extraction.provider is not 'command'");
 	}
 
-	const today = new Date().toISOString().slice(0, 10);
-	const genOpts = {
-		timeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
-		maxTokens: memoryCfg.pipelineV2.synthesis.maxTokens,
-	};
+	if (!commandMode && provider) {
+		const today = new Date().toISOString().slice(0, 10);
+		const genOpts = {
+			timeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
+			maxTokens: memoryCfg.pipelineV2.synthesis.maxTokens,
+		};
 
-	const result =
-		job.transcript.length > CHUNK_TARGET_CHARS
-			? await processChunked(provider, job.transcript, today, genOpts)
-			: await processSingle(provider, job.transcript, today, genOpts);
+		const result =
+			job.transcript.length > CHUNK_TARGET_CHARS
+				? await processChunked(provider, job.transcript, today, genOpts)
+				: await processSingle(provider, job.transcript, today, genOpts);
 
-	if (!result) {
-		throw new Error("Failed to parse LLM summary response");
-	}
+		if (!result) {
+			throw new Error("Failed to parse LLM summary response");
+		}
 
-	// Write markdown file
-	mkdirSync(MEMORY_DIR, { recursive: true });
-	const slug = deriveSlug(result.summary, job.project);
-	const filename = uniqueFilename(MEMORY_DIR, `${today}-${slug}`, ".md");
-	writeFileSync(filename, result.summary, "utf-8");
+		// Write markdown file
+		mkdirSync(MEMORY_DIR, { recursive: true });
+		const slug = deriveSlug(result.summary, job.project);
+		const filename = uniqueFilename(MEMORY_DIR, `${today}-${slug}`, ".md");
+		writeFileSync(filename, result.summary, "utf-8");
 
-	logger.info("summary-worker", "Wrote session summary", {
-		path: filename,
-		sessionKey: job.session_key,
-		project: job.project,
-		summaryChars: result.summary.length,
-	});
-
-	const saved = insertSummaryFacts(accessor, job, result.facts);
-
-	logger.info("summary-worker", "Inserted session facts", {
-		total: result.facts.length,
-		saved,
-		deduplicated: result.facts.length - saved,
-		factsPreview: result.facts.slice(0, 10).map((fact) => fact.content),
-	});
-
-	// Lossless retention: preserve raw transcript alongside extracted facts
-	if (job.session_key) {
-		upsertSessionTranscript(job.session_key, job.transcript, job.harness, job.project, job.agent_id);
-	}
-
-	// Write to session_summaries DAG (depth 0 = session level)
-	try {
-		writeSummaryToDAG(accessor, job, result, job.agent_id);
-	} catch (e) {
-		logger.warn("summary-worker", "Failed to write session summary to DAG (non-fatal)", {
-			error: e instanceof Error ? e.message : String(e),
+		logger.info("summary-worker", "Wrote session summary", {
+			path: filename,
+			sessionKey: job.session_key,
+			project: job.project,
+			summaryChars: result.summary.length,
 		});
-	}
 
-	// --- Session continuity scoring ---
-	try {
-		await scoreContinuity(accessor, provider, job, result.summary, memoryCfg);
-	} catch (e) {
-		logger.warn("summary-worker", "Continuity scoring failed (non-fatal)", {
-			error: e instanceof Error ? e.message : String(e),
+		const saved = insertSummaryFacts(accessor, job, result.facts);
+
+		logger.info("summary-worker", "Inserted session facts", {
+			total: result.facts.length,
+			saved,
+			deduplicated: result.facts.length - saved,
+			factsPreview: result.facts.slice(0, 10).map((fact) => fact.content),
 		});
-	}
 
-	// --- Predictor comparison (Sprint 3) ---
-	// Runs after continuity scoring has written per-memory relevance scores
-	// and session_scores. Uses dynamic imports to avoid circular deps.
-	// memoryCfg already loaded at function entry (significance gate).
-	try {
-		if (memoryCfg.pipelineV2.predictor?.enabled && job.session_key) {
-			const { runSessionComparison, saveComparison, updateSuccessRate, shouldTriggerTraining, detectDrift } =
-				await import("../predictor-comparison");
-			const comparison = runSessionComparison(job.session_key, job.agent_id, accessor);
+		// Lossless retention: preserve raw transcript alongside extracted facts
+		if (job.session_key) {
+			upsertSessionTranscript(job.session_key, job.transcript, job.harness, job.project, job.agent_id);
+		}
 
-			if (comparison !== null) {
-				saveComparison(comparison, job.agent_id, accessor);
-				// Only update EMA when the predictor actually produced scores —
-				// otherwise predictorWon is deterministically false and the EMA
-				// accrues phantom losses during cold start or sidecar downtime.
-				if (comparison.hasPredictorScores) {
-					updateSuccessRate(job.agent_id, comparison.predictorWon, comparison.scorerConfidence);
-				}
+		// Write to session_summaries DAG (depth 0 = session level)
+		try {
+			writeSummaryToDAG(accessor, job, result, job.agent_id);
+		} catch (e) {
+			logger.warn("summary-worker", "Failed to write session summary to DAG (non-fatal)", {
+				error: e instanceof Error ? e.message : String(e),
+			});
+		}
 
-				// Drift detection
-				const driftResult = detectDrift(job.agent_id, accessor, memoryCfg.pipelineV2.predictor.driftResetWindow ?? 20);
-				if (driftResult.drifting) {
-					logger.warn("predictor", "Drift detected — resetting predictor state", {
-						recentWinRate: driftResult.recentWinRate,
-						windowSize: driftResult.windowSize,
-						agentId: job.agent_id,
-					});
+		// --- Session continuity scoring ---
+		try {
+			await scoreContinuity(accessor, provider, job, result.summary, memoryCfg);
+		} catch (e) {
+			logger.warn("summary-worker", "Continuity scoring failed (non-fatal)", {
+				error: e instanceof Error ? e.message : String(e),
+			});
+		}
 
-					// Reset alpha to 1.0 (full baseline weight) and EMA to neutral
-					const { updatePredictorState: resetState } = await import("../predictor-state");
-					resetState(job.agent_id, {
-						alpha: 1.0,
-						successRate: 0.5,
-					});
+		// --- Predictor comparison (Sprint 3) ---
+		// Runs after continuity scoring has written per-memory relevance scores
+		// and session_scores. Uses dynamic imports to avoid circular deps.
+		// memoryCfg already loaded at function entry (significance gate).
+		try {
+			if (memoryCfg.pipelineV2.predictor?.enabled && job.session_key) {
+				const { runSessionComparison, saveComparison, updateSuccessRate, shouldTriggerTraining, detectDrift } =
+					await import("../predictor-comparison");
+				const comparison = runSessionComparison(job.session_key, job.agent_id, accessor);
 
-					// Trigger retraining (non-fatal if it fails)
-					try {
-						const { getPredictorClient } = await import("../daemon");
-						const predictorClient = getPredictorClient();
-						if (predictorClient) {
-							const dbPath = join(AGENTS_DIR, "memory", "memories.db");
-							await predictorClient.trainFromDb({ db_path: dbPath });
-							logger.info("predictor", "Drift-triggered retraining complete");
-						}
-					} catch (trainErr) {
-						logger.warn("predictor", "Drift-triggered retraining failed", {
-							error: trainErr instanceof Error ? trainErr.message : String(trainErr),
+				if (comparison !== null) {
+					saveComparison(comparison, job.agent_id, accessor);
+					// Only update EMA when the predictor actually produced scores —
+					// otherwise predictorWon is deterministically false and the EMA
+					// accrues phantom losses during cold start or sidecar downtime.
+					if (comparison.hasPredictorScores) {
+						updateSuccessRate(job.agent_id, comparison.predictorWon, comparison.scorerConfidence);
+					}
+
+					// Drift detection
+					const driftResult = detectDrift(
+						job.agent_id,
+						accessor,
+						memoryCfg.pipelineV2.predictor.driftResetWindow ?? 20,
+					);
+					if (driftResult.drifting) {
+						logger.warn("predictor", "Drift detected — resetting predictor state", {
+							recentWinRate: driftResult.recentWinRate,
+							windowSize: driftResult.windowSize,
+							agentId: job.agent_id,
 						});
+
+						// Reset alpha to 1.0 (full baseline weight) and EMA to neutral
+						const { updatePredictorState: resetState } = await import("../predictor-state");
+						resetState(job.agent_id, {
+							alpha: 1.0,
+							successRate: 0.5,
+						});
+
+						// Trigger retraining (non-fatal if it fails)
+						try {
+							const { getPredictorClient } = await import("../daemon");
+							const predictorClient = getPredictorClient();
+							if (predictorClient) {
+								const dbPath = join(AGENTS_DIR, "memory", "memories.db");
+								await predictorClient.trainFromDb({ db_path: dbPath });
+								logger.info("predictor", "Drift-triggered retraining complete");
+							}
+						} catch (trainErr) {
+							logger.warn("predictor", "Drift-triggered retraining failed", {
+								error: trainErr instanceof Error ? trainErr.message : String(trainErr),
+							});
+						}
+					}
+
+					// Check training trigger
+					if (shouldTriggerTraining(job.agent_id, memoryCfg.pipelineV2.predictor, accessor)) {
+						try {
+							const { getPredictorClient } = await import("../daemon");
+							const predictorClient = getPredictorClient();
+							if (predictorClient) {
+								const dbPath = join(AGENTS_DIR, "memory", "memories.db");
+								await predictorClient.trainFromDb({ db_path: dbPath });
+
+								const { updatePredictorState } = await import("../predictor-state");
+								updatePredictorState(job.agent_id, { lastTrainingAt: new Date().toISOString() });
+
+								logger.info("predictor", "Training triggered after session comparison");
+							}
+						} catch (trainErr) {
+							logger.warn("predictor", "Training trigger failed (non-fatal)", {
+								error: trainErr instanceof Error ? trainErr.message : String(trainErr),
+							});
+						}
 					}
 				}
+			}
+		} catch (err) {
+			logger.warn("predictor", "Session comparison failed (non-fatal)", {
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
 
-				// Check training trigger
-				if (shouldTriggerTraining(job.agent_id, memoryCfg.pipelineV2.predictor, accessor)) {
-					try {
-						const { getPredictorClient } = await import("../daemon");
-						const predictorClient = getPredictorClient();
-						if (predictorClient) {
-							const dbPath = join(AGENTS_DIR, "memory", "memories.db");
-							await predictorClient.trainFromDb({ db_path: dbPath });
-
-							const { updatePredictorState } = await import("../predictor-state");
-							updatePredictorState(job.agent_id, { lastTrainingAt: new Date().toISOString() });
-
-							logger.info("predictor", "Training triggered after session comparison");
-						}
-					} catch (trainErr) {
-						logger.warn("predictor", "Training trigger failed (non-fatal)", {
-							error: trainErr instanceof Error ? trainErr.message : String(trainErr),
-						});
+		// --- Training pair collection for predictor federated learning ---
+		if (job.session_key) {
+			try {
+				if (memoryCfg.pipelineV2.predictorPipeline.trainingTelemetry) {
+					const { collectTrainingPairs, saveTrainingPairs } = await import("../predictor-training-pairs");
+					const pairs = collectTrainingPairs(accessor, job.session_key, job.agent_id);
+					if (pairs.length > 0) {
+						saveTrainingPairs(accessor, job.agent_id, job.session_key, pairs);
 					}
 				}
+			} catch (e) {
+				logger.warn("summary-worker", "Training pair collection failed (non-fatal)", {
+					error: e instanceof Error ? e.message : String(e),
+				});
 			}
 		}
-	} catch (err) {
-		logger.warn("predictor", "Session comparison failed (non-fatal)", {
-			error: err instanceof Error ? err.message : String(err),
-		});
-	}
 
-	// --- Training pair collection for predictor federated learning ---
-	if (job.session_key) {
 		try {
-			if (memoryCfg.pipelineV2.predictorPipeline.trainingTelemetry) {
-				const { collectTrainingPairs, saveTrainingPairs } = await import("../predictor-training-pairs");
-				const pairs = collectTrainingPairs(accessor, job.session_key, job.agent_id);
-				if (pairs.length > 0) {
-					saveTrainingPairs(accessor, job.agent_id, job.session_key, pairs);
-				}
-			}
+			const { getSynthesisWorker } = await import("./index");
+			void getSynthesisWorker()
+				?.triggerNow({
+					force: true,
+					source: "session-summary",
+					agentId: job.agent_id,
+				})
+				.then((result) => {
+					if (!result.skipped) return;
+					logger.info("summary-worker", "Skipped MEMORY.md synthesis after session summary", {
+						reason: result.reason,
+					});
+				})
+				.catch((error) => {
+					logger.warn("summary-worker", "Failed to trigger MEMORY.md synthesis after session summary", {
+						error: error instanceof Error ? error.message : String(error),
+					});
+				});
 		} catch (e) {
-			logger.warn("summary-worker", "Training pair collection failed (non-fatal)", {
+			logger.warn("summary-worker", "Could not load synthesis worker for post-summary trigger", {
 				error: e instanceof Error ? e.message : String(e),
 			});
 		}
 	}
-
-	try {
-		const { getSynthesisWorker } = await import("./index");
-		void getSynthesisWorker()
-			?.triggerNow({
-				force: true,
-				source: "session-summary",
-				agentId: job.agent_id,
-			})
-			.then((result) => {
-				if (!result.skipped) return;
-				logger.info("summary-worker", "Skipped MEMORY.md synthesis after session summary", {
-					reason: result.reason,
-				});
-			})
-			.catch((error) => {
-				logger.warn("summary-worker", "Failed to trigger MEMORY.md synthesis after session summary", {
-					error: error instanceof Error ? error.message : String(error),
-				});
-			});
-	} catch (error) {
-		logger.warn("summary-worker", "Could not load synthesis worker for post-summary trigger", {
-			error: error instanceof Error ? error.message : String(error),
-		});
+	if (commandMode && job.session_key) {
+		upsertSessionTranscript(job.session_key, job.transcript, job.harness, job.project, job.agent_id);
 	}
 }
 

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -11,8 +11,9 @@
  */
 
 import type { Database } from "bun:sqlite";
-import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
+import { spawn as nodeSpawn } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import type { LlmProvider } from "@signet/core";
 import type { DbAccessor } from "../db-accessor";
@@ -306,37 +307,161 @@ function parseLlmResponse(raw: string): LlmSummaryResult | null {
 // Core processing
 // ---------------------------------------------------------------------------
 
-async function processJob(
+function passesSignificanceGate(
 	accessor: DbAccessor,
-	provider: LlmProvider,
 	job: SummaryJobRow,
 	memoryCfg: ReturnType<typeof loadMemoryConfig>,
-): Promise<void> {
-	// --- Significance gate ---
+): boolean {
 	const significanceCfg: SignificanceConfig = memoryCfg.pipelineV2.significance ?? {
 		enabled: true,
 		minTurns: 5,
 		minEntityOverlap: 1,
 		noveltyThreshold: 0.15,
 	};
+	if (!significanceCfg.enabled) return true;
 
-	if (significanceCfg.enabled) {
-		const assessment = accessor.withReadDb((db) =>
-			assessSignificance(job.transcript, db, job.agent_id, significanceCfg),
-		);
+	const assessment = accessor.withReadDb((db) => assessSignificance(job.transcript, db, job.agent_id, significanceCfg));
 
-		if (!assessment.significant) {
-			logger.info("summary-worker", "Session below significance threshold — skipping extraction", {
-				sessionKey: job.session_key,
-				project: job.project,
-				scores: assessment.scores,
-				reason: assessment.reason,
-			});
-			// Job row and transcript are preserved (lossless retention).
-			// processJob caller marks it completed.
-			return;
+	if (assessment.significant) return true;
+
+	logger.info("summary-worker", "Session below significance threshold — skipping extraction", {
+		sessionKey: job.session_key,
+		project: job.project,
+		scores: assessment.scores,
+		reason: assessment.reason,
+	});
+	return false;
+}
+
+function substituteCommandTokens(input: string, replacements: Record<string, string>): string {
+	let output = input;
+	for (const [token, value] of Object.entries(replacements)) {
+		output = output.split(token).join(value);
+	}
+	return output;
+}
+
+function trimOutput(value: string, maxChars: number): string {
+	if (value.length <= maxChars) return value;
+	return `${value.slice(0, maxChars)}…`;
+}
+
+export async function runSummaryCommandProvider(
+	job: SummaryJobRow,
+	cfg: ReturnType<typeof loadMemoryConfig>,
+): Promise<void> {
+	const command = cfg.pipelineV2.extraction.command;
+	if (!command) {
+		throw new Error("pipelineV2.extraction.command is required when extraction.provider is 'command'");
+	}
+
+	const tempDir = mkdtempSync(join(tmpdir(), "signet-summary-command-"));
+	const transcriptPath = join(tempDir, "transcript.txt");
+	writeFileSync(transcriptPath, job.transcript, "utf-8");
+
+	const replacements: Record<string, string> = {
+		$TRANSCRIPT: transcriptPath,
+		$TRANSCRIPT_PATH: transcriptPath,
+		$SESSION_KEY: job.session_key ?? "",
+		$PROJECT: job.project ?? "",
+		$SIGNET_PATH: AGENTS_DIR,
+	};
+	const bin = substituteCommandTokens(command.bin, replacements).trim();
+	if (bin.length === 0) {
+		throw new Error("pipelineV2.extraction.command.bin resolved to an empty value");
+	}
+	const args = command.args.map((arg) => substituteCommandTokens(arg, replacements));
+	const timeoutMs = Math.max(5000, Math.min(300000, cfg.pipelineV2.extraction.timeout));
+	const cwd = command.cwd ? substituteCommandTokens(command.cwd, replacements).trim() : undefined;
+	const envFromConfig: Record<string, string> = {};
+	if (command.env) {
+		for (const [key, value] of Object.entries(command.env)) {
+			envFromConfig[key] = substituteCommandTokens(value, replacements);
 		}
 	}
+
+	try {
+		await new Promise<void>((resolve, reject) => {
+			const child = nodeSpawn(bin, args, {
+				cwd: cwd && cwd.length > 0 ? cwd : undefined,
+				env: {
+					...process.env,
+					...envFromConfig,
+					SIGNET_PATH: AGENTS_DIR,
+				},
+				stdio: ["ignore", "pipe", "pipe"],
+				windowsHide: true,
+			});
+
+			let stdout = "";
+			let stderr = "";
+			const MAX_CAPTURE_CHARS = 4000;
+
+			child.stdout?.on("data", (chunk: Buffer) => {
+				if (stdout.length >= MAX_CAPTURE_CHARS) return;
+				stdout += chunk.toString("utf-8").slice(0, MAX_CAPTURE_CHARS - stdout.length);
+			});
+			child.stderr?.on("data", (chunk: Buffer) => {
+				if (stderr.length >= MAX_CAPTURE_CHARS) return;
+				stderr += chunk.toString("utf-8").slice(0, MAX_CAPTURE_CHARS - stderr.length);
+			});
+
+			let settled = false;
+			const timeout = setTimeout(() => {
+				if (settled) return;
+				settled = true;
+				child.kill("SIGTERM");
+				setTimeout(() => {
+					try {
+						child.kill("SIGKILL");
+					} catch {
+						// Child is already gone.
+					}
+				}, 2000);
+				reject(new Error(`summary command timed out after ${timeoutMs}ms`));
+			}, timeoutMs);
+
+			child.on("error", (err) => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timeout);
+				reject(err);
+			});
+
+			child.on("close", (code) => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timeout);
+				const exitCode = code ?? 1;
+				if (exitCode !== 0) {
+					const detail = stderr.trim().length > 0 ? stderr.trim() : stdout.trim();
+					reject(new Error(`summary command exited with code ${exitCode}: ${trimOutput(detail, 500)}`));
+					return;
+				}
+
+				if (stdout.trim().length > 0 || stderr.trim().length > 0) {
+					logger.info("summary-worker", "Summary command completed", {
+						sessionKey: job.session_key,
+						project: job.project,
+						stdout: trimOutput(stdout.trim(), 500),
+						stderr: trimOutput(stderr.trim(), 500),
+					});
+				}
+				resolve();
+			});
+		});
+	} finally {
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+}
+
+async function processJob(
+	accessor: DbAccessor,
+	provider: LlmProvider,
+	job: SummaryJobRow,
+	memoryCfg: ReturnType<typeof loadMemoryConfig>,
+): Promise<void> {
+	if (!passesSignificanceGate(accessor, job, memoryCfg)) return;
 
 	const today = new Date().toISOString().slice(0, 10);
 	const genOpts = {
@@ -1183,6 +1308,12 @@ export async function resolveSummaryProvider(cfg: ReturnType<typeof loadMemoryCo
 			logger.warn("summary-worker", "Codex CLI not available for summary worker — falling back to ollama");
 			return fallback();
 		}
+		case "command":
+			logger.warn(
+				"summary-worker",
+				"synthesis.provider='command' is not used by the summary worker; use extraction.provider='command' instead. Falling back to ollama",
+			);
+			return fallback();
 		case "opencode":
 			return createOpenCodeProvider({
 				model: model || "anthropic/claude-haiku-4-5-20251001",
@@ -1281,19 +1412,25 @@ export function startSummaryWorker(accessor: DbAccessor): SummaryWorkerHandle {
 				project: job.project,
 			});
 
-			// Cache provider across jobs — re-resolve on config change, env
-			// key rotation, or TTL expiry. Env-var key changes invalidate
-			// immediately; secrets-store-only rotations rely on the 5-min TTL.
-			const envKey = process.env.ANTHROPIC_API_KEY ?? "";
-			const keyFingerprint = envKey ? new Bun.CryptoHasher("sha256").update(envKey).digest("hex").slice(0, 8) : "";
-			const providerKey = `${cfg.pipelineV2.synthesis.provider}:${cfg.pipelineV2.synthesis.model}:${cfg.pipelineV2.synthesis.timeout}:${keyFingerprint}`;
-			const cacheExpired = Date.now() - cachedProviderAt > PROVIDER_CACHE_TTL_MS;
-			if (!cachedProvider || providerKey !== cachedProviderKey || cacheExpired) {
-				cachedProvider = await resolveSummaryProvider(cfg);
-				cachedProviderKey = providerKey;
-				cachedProviderAt = Date.now();
+			if (cfg.pipelineV2.extraction.provider === "command") {
+				if (passesSignificanceGate(accessor, job, cfg)) {
+					await runSummaryCommandProvider(job, cfg);
+				}
+			} else {
+				// Cache provider across jobs — re-resolve on config change, env
+				// key rotation, or TTL expiry. Env-var key changes invalidate
+				// immediately; secrets-store-only rotations rely on the 5-min TTL.
+				const envKey = process.env.ANTHROPIC_API_KEY ?? "";
+				const keyFingerprint = envKey ? new Bun.CryptoHasher("sha256").update(envKey).digest("hex").slice(0, 8) : "";
+				const providerKey = `${cfg.pipelineV2.synthesis.provider}:${cfg.pipelineV2.synthesis.model}:${cfg.pipelineV2.synthesis.timeout}:${keyFingerprint}`;
+				const cacheExpired = Date.now() - cachedProviderAt > PROVIDER_CACHE_TTL_MS;
+				if (!cachedProvider || providerKey !== cachedProviderKey || cacheExpired) {
+					cachedProvider = await resolveSummaryProvider(cfg);
+					cachedProviderKey = providerKey;
+					cachedProviderAt = Date.now();
+				}
+				await processJob(accessor, cachedProvider, job, cfg);
 			}
-			await processJob(accessor, cachedProvider, job, cfg);
 
 			// Mark complete
 			accessor.withWriteTx((db) => {

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -1308,12 +1308,6 @@ export async function resolveSummaryProvider(cfg: ReturnType<typeof loadMemoryCo
 			logger.warn("summary-worker", "Codex CLI not available for summary worker — falling back to ollama");
 			return fallback();
 		}
-		case "command":
-			logger.warn(
-				"summary-worker",
-				"synthesis.provider='command' is not used by the summary worker; use extraction.provider='command' instead. Falling back to ollama",
-			);
-			return fallback();
 		case "opencode":
 			return createOpenCodeProvider({
 				model: model || "anthropic/claude-haiku-4-5-20251001",

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -394,6 +394,7 @@ export async function runSummaryCommandProvider(
 			});
 
 			let settled = false;
+			let timedOut = false;
 			let killTimer: ReturnType<typeof setTimeout> | null = null;
 			const clearKillTimer = (): void => {
 				if (killTimer) {
@@ -401,9 +402,10 @@ export async function runSummaryCommandProvider(
 					killTimer = null;
 				}
 			};
+			const timeoutError = new Error(`summary command timed out after ${timeoutMs}ms`);
 			const timeout = setTimeout(() => {
 				if (settled) return;
-				settled = true;
+				timedOut = true;
 				child.kill("SIGTERM");
 				killTimer = setTimeout(() => {
 					try {
@@ -412,7 +414,6 @@ export async function runSummaryCommandProvider(
 						// Child is already gone.
 					}
 				}, 2000);
-				reject(new Error(`summary command timed out after ${timeoutMs}ms`));
 			}, timeoutMs);
 
 			child.on("error", (err) => {
@@ -420,6 +421,10 @@ export async function runSummaryCommandProvider(
 				if (settled) return;
 				settled = true;
 				clearTimeout(timeout);
+				if (timedOut) {
+					reject(timeoutError);
+					return;
+				}
 				reject(err);
 			});
 
@@ -428,6 +433,10 @@ export async function runSummaryCommandProvider(
 				if (settled) return;
 				settled = true;
 				clearTimeout(timeout);
+				if (timedOut) {
+					reject(timeoutError);
+					return;
+				}
 				const exitCode = code ?? 1;
 				if (exitCode !== 0) {
 					reject(new Error(`summary command exited with code ${exitCode}`));

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -76,7 +76,9 @@ interface LlmSummaryResult {
 }
 
 export const SUMMARY_WORKER_UPDATED_BY = "summary-worker";
+const COMMAND_STAGE_RUNNING_RESULT = "command-stage-running";
 const COMMAND_STAGE_COMPLETED_RESULT = "command-stage-complete";
+type CommandStageStatus = "none" | "running" | "complete";
 
 // ---------------------------------------------------------------------------
 // Config
@@ -334,8 +336,8 @@ function passesSignificanceGate(
 	return false;
 }
 
-export function shouldRunSignificanceGateForJob(commandMode: boolean, commandStageCompleted: boolean): boolean {
-	return !commandMode || !commandStageCompleted;
+export function shouldRunSignificanceGateForJob(commandMode: boolean, commandStageStatus: CommandStageStatus): boolean {
+	return !commandMode || commandStageStatus === "none";
 }
 
 function substituteCommandTokens(input: string, replacements: Record<string, string>): string {
@@ -455,12 +457,42 @@ export async function runSummaryCommandProvider(
 	}
 }
 
-export function hasCommandStageCompleted(accessor: DbAccessor, jobId: string): boolean {
+export function getCommandStageStatus(accessor: DbAccessor, jobId: string): CommandStageStatus {
 	return accessor.withReadDb((db) => {
 		const row = db.prepare("SELECT result FROM summary_jobs WHERE id = ?").get(jobId) as
 			| { result: string | null }
 			| undefined;
-		return row?.result === COMMAND_STAGE_COMPLETED_RESULT;
+		if (row?.result === COMMAND_STAGE_COMPLETED_RESULT) {
+			return "complete";
+		}
+		if (row?.result === COMMAND_STAGE_RUNNING_RESULT) {
+			return "running";
+		}
+		return "none";
+	});
+}
+
+export function hasCommandStageCompleted(accessor: DbAccessor, jobId: string): boolean {
+	return getCommandStageStatus(accessor, jobId) === "complete";
+}
+
+export function markCommandStageRunning(accessor: DbAccessor, jobId: string): void {
+	accessor.withWriteTx((db) => {
+		db.prepare(
+			`UPDATE summary_jobs
+			 SET result = ?
+			 WHERE id = ? AND status = 'processing' AND (result IS NULL OR result = '')`,
+		).run(COMMAND_STAGE_RUNNING_RESULT, jobId);
+	});
+}
+
+export function clearCommandStageRunning(accessor: DbAccessor, jobId: string): void {
+	accessor.withWriteTx((db) => {
+		db.prepare(
+			`UPDATE summary_jobs
+			 SET result = NULL
+			 WHERE id = ? AND status = 'processing' AND result = ?`,
+		).run(jobId, COMMAND_STAGE_RUNNING_RESULT);
 	});
 }
 
@@ -469,8 +501,8 @@ export function markCommandStageCompleted(accessor: DbAccessor, jobId: string): 
 		db.prepare(
 			`UPDATE summary_jobs
 			 SET result = ?
-			 WHERE id = ? AND status = 'processing'`,
-		).run(COMMAND_STAGE_COMPLETED_RESULT, jobId);
+			 WHERE id = ? AND status = 'processing' AND (result = ? OR result IS NULL OR result = '')`,
+		).run(COMMAND_STAGE_COMPLETED_RESULT, jobId, COMMAND_STAGE_RUNNING_RESULT);
 	});
 }
 
@@ -481,26 +513,43 @@ async function processJob(
 	memoryCfg: ReturnType<typeof loadMemoryConfig>,
 ): Promise<void> {
 	const commandMode = memoryCfg.pipelineV2.extraction.provider === "command";
-	const commandAlreadyCompleted = commandMode && hasCommandStageCompleted(accessor, job.id);
+	const commandStageStatus: CommandStageStatus = commandMode ? getCommandStageStatus(accessor, job.id) : "none";
 
 	if (
-		shouldRunSignificanceGateForJob(commandMode, commandAlreadyCompleted) &&
+		shouldRunSignificanceGateForJob(commandMode, commandStageStatus) &&
 		!passesSignificanceGate(accessor, job, memoryCfg)
 	) {
 		return;
 	}
 
 	if (commandMode) {
-		if (!commandAlreadyCompleted) {
-			await runSummaryCommandProvider(job, memoryCfg);
+		if (commandStageStatus === "none") {
+			markCommandStageRunning(accessor, job.id);
+			try {
+				await runSummaryCommandProvider(job, memoryCfg);
+			} catch (error) {
+				clearCommandStageRunning(accessor, job.id);
+				throw error;
+			}
 			markCommandStageCompleted(accessor, job.id);
-		} else {
+		} else if (commandStageStatus === "complete") {
 			logger.info("summary-worker", "Command extraction already completed for this job attempt chain; skipping rerun", {
 				jobId: job.id,
 				attempt: job.attempts,
 				sessionKey: job.session_key,
 				project: job.project,
 			});
+		} else {
+			logger.warn(
+				"summary-worker",
+				"Command stage checkpoint indicates in-flight prior attempt; skipping rerun to avoid duplicate side effects",
+				{
+					jobId: job.id,
+					attempt: job.attempts,
+					sessionKey: job.session_key,
+					project: job.project,
+				},
+			);
 		}
 	}
 	if (!commandMode && !provider) {

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -76,6 +76,7 @@ interface LlmSummaryResult {
 }
 
 export const SUMMARY_WORKER_UPDATED_BY = "summary-worker";
+const COMMAND_STAGE_COMPLETED_RESULT = "command-stage-complete";
 
 // ---------------------------------------------------------------------------
 // Config
@@ -450,6 +451,25 @@ export async function runSummaryCommandProvider(
 	}
 }
 
+export function hasCommandStageCompleted(accessor: DbAccessor, jobId: string): boolean {
+	return accessor.withReadDb((db) => {
+		const row = db.prepare("SELECT result FROM summary_jobs WHERE id = ?").get(jobId) as
+			| { result: string | null }
+			| undefined;
+		return row?.result === COMMAND_STAGE_COMPLETED_RESULT;
+	});
+}
+
+export function markCommandStageCompleted(accessor: DbAccessor, jobId: string): void {
+	accessor.withWriteTx((db) => {
+		db.prepare(
+			`UPDATE summary_jobs
+			 SET result = ?
+			 WHERE id = ? AND status = 'processing'`,
+		).run(COMMAND_STAGE_COMPLETED_RESULT, jobId);
+	});
+}
+
 async function processJob(
 	accessor: DbAccessor,
 	provider: LlmProvider | null,
@@ -459,205 +479,207 @@ async function processJob(
 	if (!passesSignificanceGate(accessor, job, memoryCfg)) return;
 	const commandMode = memoryCfg.pipelineV2.extraction.provider === "command";
 	if (commandMode) {
-		await runSummaryCommandProvider(job, memoryCfg);
+		const commandAlreadyCompleted = hasCommandStageCompleted(accessor, job.id);
+		if (!commandAlreadyCompleted) {
+			await runSummaryCommandProvider(job, memoryCfg);
+			markCommandStageCompleted(accessor, job.id);
+		} else {
+			logger.info("summary-worker", "Command extraction already completed for this job attempt chain; skipping rerun", {
+				jobId: job.id,
+				attempt: job.attempts,
+				sessionKey: job.session_key,
+				project: job.project,
+			});
+		}
 	}
 	if (!commandMode && !provider) {
 		throw new Error("summary worker requires an LLM provider when extraction.provider is not 'command'");
 	}
 
 	if (provider) {
+		const today = new Date().toISOString().slice(0, 10);
+		const genOpts = {
+			timeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
+			maxTokens: memoryCfg.pipelineV2.synthesis.maxTokens,
+		};
+
+		const result =
+			job.transcript.length > CHUNK_TARGET_CHARS
+				? await processChunked(provider, job.transcript, today, genOpts)
+				: await processSingle(provider, job.transcript, today, genOpts);
+
+		if (!result) {
+			throw new Error("Failed to parse LLM summary response");
+		}
+
+		if (!commandMode) {
+			// Write markdown file
+			mkdirSync(MEMORY_DIR, { recursive: true });
+			const slug = deriveSlug(result.summary, job.project);
+			const filename = uniqueFilename(MEMORY_DIR, `${today}-${slug}`, ".md");
+			writeFileSync(filename, result.summary, "utf-8");
+
+			logger.info("summary-worker", "Wrote session summary", {
+				path: filename,
+				sessionKey: job.session_key,
+				project: job.project,
+				summaryChars: result.summary.length,
+			});
+
+			const saved = insertSummaryFacts(accessor, job, result.facts);
+
+			logger.info("summary-worker", "Inserted session facts", {
+				total: result.facts.length,
+				saved,
+				deduplicated: result.facts.length - saved,
+				factsPreview: result.facts.slice(0, 10).map((fact) => fact.content),
+			});
+		} else {
+			logger.info("summary-worker", "Command extraction mode: skipping summary markdown + fact insertion", {
+				sessionKey: job.session_key,
+				project: job.project,
+			});
+		}
+
+		// Write to session_summaries DAG (depth 0 = session level)
 		try {
-			const today = new Date().toISOString().slice(0, 10);
-			const genOpts = {
-				timeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
-				maxTokens: memoryCfg.pipelineV2.synthesis.maxTokens,
-			};
-
-			const result =
-				job.transcript.length > CHUNK_TARGET_CHARS
-					? await processChunked(provider, job.transcript, today, genOpts)
-					: await processSingle(provider, job.transcript, today, genOpts);
-
-			if (!result) {
-				throw new Error("Failed to parse LLM summary response");
-			}
-
-			if (!commandMode) {
-				// Write markdown file
-				mkdirSync(MEMORY_DIR, { recursive: true });
-				const slug = deriveSlug(result.summary, job.project);
-				const filename = uniqueFilename(MEMORY_DIR, `${today}-${slug}`, ".md");
-				writeFileSync(filename, result.summary, "utf-8");
-
-				logger.info("summary-worker", "Wrote session summary", {
-					path: filename,
-					sessionKey: job.session_key,
-					project: job.project,
-					summaryChars: result.summary.length,
-				});
-
-				const saved = insertSummaryFacts(accessor, job, result.facts);
-
-				logger.info("summary-worker", "Inserted session facts", {
-					total: result.facts.length,
-					saved,
-					deduplicated: result.facts.length - saved,
-					factsPreview: result.facts.slice(0, 10).map((fact) => fact.content),
-				});
-			} else {
-				logger.info("summary-worker", "Command extraction mode: skipping summary markdown + fact insertion", {
-					sessionKey: job.session_key,
-					project: job.project,
-				});
-			}
-
-			// Write to session_summaries DAG (depth 0 = session level)
-			try {
-				writeSummaryToDAG(accessor, job, result, job.agent_id);
-			} catch (e) {
-				logger.warn("summary-worker", "Failed to write session summary to DAG (non-fatal)", {
-					error: e instanceof Error ? e.message : String(e),
-				});
-			}
-
-			// --- Session continuity scoring ---
-			try {
-				await scoreContinuity(accessor, provider, job, result.summary, memoryCfg);
-			} catch (e) {
-				logger.warn("summary-worker", "Continuity scoring failed (non-fatal)", {
-					error: e instanceof Error ? e.message : String(e),
-				});
-			}
-
-			// --- Predictor comparison (Sprint 3) ---
-			// Runs after continuity scoring has written per-memory relevance scores
-			// and session_scores. Uses dynamic imports to avoid circular deps.
-			// memoryCfg already loaded at function entry (significance gate).
-			try {
-				if (memoryCfg.pipelineV2.predictor?.enabled && job.session_key) {
-					const { runSessionComparison, saveComparison, updateSuccessRate, shouldTriggerTraining, detectDrift } =
-						await import("../predictor-comparison");
-					const comparison = runSessionComparison(job.session_key, job.agent_id, accessor);
-
-					if (comparison !== null) {
-						saveComparison(comparison, job.agent_id, accessor);
-						// Only update EMA when the predictor actually produced scores —
-						// otherwise predictorWon is deterministically false and the EMA
-						// accrues phantom losses during cold start or sidecar downtime.
-						if (comparison.hasPredictorScores) {
-							updateSuccessRate(job.agent_id, comparison.predictorWon, comparison.scorerConfidence);
-						}
-
-						// Drift detection
-						const driftResult = detectDrift(
-							job.agent_id,
-							accessor,
-							memoryCfg.pipelineV2.predictor.driftResetWindow ?? 20,
-						);
-						if (driftResult.drifting) {
-							logger.warn("predictor", "Drift detected — resetting predictor state", {
-								recentWinRate: driftResult.recentWinRate,
-								windowSize: driftResult.windowSize,
-								agentId: job.agent_id,
-							});
-
-							// Reset alpha to 1.0 (full baseline weight) and EMA to neutral
-							const { updatePredictorState: resetState } = await import("../predictor-state");
-							resetState(job.agent_id, {
-								alpha: 1.0,
-								successRate: 0.5,
-							});
-
-							// Trigger retraining (non-fatal if it fails)
-							try {
-								const { getPredictorClient } = await import("../daemon");
-								const predictorClient = getPredictorClient();
-								if (predictorClient) {
-									const dbPath = join(AGENTS_DIR, "memory", "memories.db");
-									await predictorClient.trainFromDb({ db_path: dbPath });
-									logger.info("predictor", "Drift-triggered retraining complete");
-								}
-							} catch (trainErr) {
-								logger.warn("predictor", "Drift-triggered retraining failed", {
-									error: trainErr instanceof Error ? trainErr.message : String(trainErr),
-								});
-							}
-						}
-
-						// Check training trigger
-						if (shouldTriggerTraining(job.agent_id, memoryCfg.pipelineV2.predictor, accessor)) {
-							try {
-								const { getPredictorClient } = await import("../daemon");
-								const predictorClient = getPredictorClient();
-								if (predictorClient) {
-									const dbPath = join(AGENTS_DIR, "memory", "memories.db");
-									await predictorClient.trainFromDb({ db_path: dbPath });
-
-									const { updatePredictorState } = await import("../predictor-state");
-									updatePredictorState(job.agent_id, { lastTrainingAt: new Date().toISOString() });
-
-									logger.info("predictor", "Training triggered after session comparison");
-								}
-							} catch (trainErr) {
-								logger.warn("predictor", "Training trigger failed (non-fatal)", {
-									error: trainErr instanceof Error ? trainErr.message : String(trainErr),
-								});
-							}
-						}
-					}
-				}
-			} catch (err) {
-				logger.warn("predictor", "Session comparison failed (non-fatal)", {
-					error: err instanceof Error ? err.message : String(err),
-				});
-			}
-
-			// --- Training pair collection for predictor federated learning ---
-			if (job.session_key) {
-				try {
-					if (memoryCfg.pipelineV2.predictorPipeline.trainingTelemetry) {
-						const { collectTrainingPairs, saveTrainingPairs } = await import("../predictor-training-pairs");
-						const pairs = collectTrainingPairs(accessor, job.session_key, job.agent_id);
-						if (pairs.length > 0) {
-							saveTrainingPairs(accessor, job.agent_id, job.session_key, pairs);
-						}
-					}
-				} catch (e) {
-					logger.warn("summary-worker", "Training pair collection failed (non-fatal)", {
-						error: e instanceof Error ? e.message : String(e),
-					});
-				}
-			}
-
-			try {
-				const { getSynthesisWorker } = await import("./index");
-				void getSynthesisWorker()
-					?.triggerNow({
-						force: true,
-						source: "session-summary",
-						agentId: job.agent_id,
-					})
-					.then((result) => {
-						if (!result.skipped) return;
-						logger.info("summary-worker", "Skipped MEMORY.md synthesis after session summary", {
-							reason: result.reason,
-						});
-					})
-					.catch((error) => {
-						logger.warn("summary-worker", "Failed to trigger MEMORY.md synthesis after session summary", {
-							error: error instanceof Error ? error.message : String(error),
-						});
-					});
-			} catch (e) {
-				logger.warn("summary-worker", "Could not load synthesis worker for post-summary trigger", {
-					error: e instanceof Error ? e.message : String(e),
-				});
-			}
+			writeSummaryToDAG(accessor, job, result, job.agent_id);
 		} catch (e) {
-			if (!commandMode) {
-				throw e;
+			logger.warn("summary-worker", "Failed to write session summary to DAG (non-fatal)", {
+				error: e instanceof Error ? e.message : String(e),
+			});
+		}
+
+		// --- Session continuity scoring ---
+		try {
+			await scoreContinuity(accessor, provider, job, result.summary, memoryCfg);
+		} catch (e) {
+			logger.warn("summary-worker", "Continuity scoring failed (non-fatal)", {
+				error: e instanceof Error ? e.message : String(e),
+			});
+		}
+
+		// --- Predictor comparison (Sprint 3) ---
+		// Runs after continuity scoring has written per-memory relevance scores
+		// and session_scores. Uses dynamic imports to avoid circular deps.
+		// memoryCfg already loaded at function entry (significance gate).
+		try {
+			if (memoryCfg.pipelineV2.predictor?.enabled && job.session_key) {
+				const { runSessionComparison, saveComparison, updateSuccessRate, shouldTriggerTraining, detectDrift } =
+					await import("../predictor-comparison");
+				const comparison = runSessionComparison(job.session_key, job.agent_id, accessor);
+
+				if (comparison !== null) {
+					saveComparison(comparison, job.agent_id, accessor);
+					// Only update EMA when the predictor actually produced scores —
+					// otherwise predictorWon is deterministically false and the EMA
+					// accrues phantom losses during cold start or sidecar downtime.
+					if (comparison.hasPredictorScores) {
+						updateSuccessRate(job.agent_id, comparison.predictorWon, comparison.scorerConfidence);
+					}
+
+					// Drift detection
+					const driftResult = detectDrift(
+						job.agent_id,
+						accessor,
+						memoryCfg.pipelineV2.predictor.driftResetWindow ?? 20,
+					);
+					if (driftResult.drifting) {
+						logger.warn("predictor", "Drift detected — resetting predictor state", {
+							recentWinRate: driftResult.recentWinRate,
+							windowSize: driftResult.windowSize,
+							agentId: job.agent_id,
+						});
+
+						// Reset alpha to 1.0 (full baseline weight) and EMA to neutral
+						const { updatePredictorState: resetState } = await import("../predictor-state");
+						resetState(job.agent_id, {
+							alpha: 1.0,
+							successRate: 0.5,
+						});
+
+						// Trigger retraining (non-fatal if it fails)
+						try {
+							const { getPredictorClient } = await import("../daemon");
+							const predictorClient = getPredictorClient();
+							if (predictorClient) {
+								const dbPath = join(AGENTS_DIR, "memory", "memories.db");
+								await predictorClient.trainFromDb({ db_path: dbPath });
+								logger.info("predictor", "Drift-triggered retraining complete");
+							}
+						} catch (trainErr) {
+							logger.warn("predictor", "Drift-triggered retraining failed", {
+								error: trainErr instanceof Error ? trainErr.message : String(trainErr),
+							});
+						}
+					}
+
+					// Check training trigger
+					if (shouldTriggerTraining(job.agent_id, memoryCfg.pipelineV2.predictor, accessor)) {
+						try {
+							const { getPredictorClient } = await import("../daemon");
+							const predictorClient = getPredictorClient();
+							if (predictorClient) {
+								const dbPath = join(AGENTS_DIR, "memory", "memories.db");
+								await predictorClient.trainFromDb({ db_path: dbPath });
+
+								const { updatePredictorState } = await import("../predictor-state");
+								updatePredictorState(job.agent_id, { lastTrainingAt: new Date().toISOString() });
+
+								logger.info("predictor", "Training triggered after session comparison");
+							}
+						} catch (trainErr) {
+							logger.warn("predictor", "Training trigger failed (non-fatal)", {
+								error: trainErr instanceof Error ? trainErr.message : String(trainErr),
+							});
+						}
+					}
+				}
 			}
-			logger.warn("summary-worker", "Post-command synthesis flow failed after command extraction (non-fatal)", {
+		} catch (err) {
+			logger.warn("predictor", "Session comparison failed (non-fatal)", {
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+
+		// --- Training pair collection for predictor federated learning ---
+		if (job.session_key) {
+			try {
+				if (memoryCfg.pipelineV2.predictorPipeline.trainingTelemetry) {
+					const { collectTrainingPairs, saveTrainingPairs } = await import("../predictor-training-pairs");
+					const pairs = collectTrainingPairs(accessor, job.session_key, job.agent_id);
+					if (pairs.length > 0) {
+						saveTrainingPairs(accessor, job.agent_id, job.session_key, pairs);
+					}
+				}
+			} catch (e) {
+				logger.warn("summary-worker", "Training pair collection failed (non-fatal)", {
+					error: e instanceof Error ? e.message : String(e),
+				});
+			}
+		}
+
+		try {
+			const { getSynthesisWorker } = await import("./index");
+			void getSynthesisWorker()
+				?.triggerNow({
+					force: true,
+					source: "session-summary",
+					agentId: job.agent_id,
+				})
+				.then((result) => {
+					if (!result.skipped) return;
+					logger.info("summary-worker", "Skipped MEMORY.md synthesis after session summary", {
+						reason: result.reason,
+					});
+				})
+				.catch((error) => {
+					logger.warn("summary-worker", "Failed to trigger MEMORY.md synthesis after session summary", {
+						error: error instanceof Error ? error.message : String(error),
+					});
+				});
+		} catch (e) {
+			logger.warn("summary-worker", "Could not load synthesis worker for post-summary trigger", {
 				error: e instanceof Error ? e.message : String(e),
 			});
 		}

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -334,6 +334,10 @@ function passesSignificanceGate(
 	return false;
 }
 
+export function shouldRunSignificanceGateForJob(commandMode: boolean, commandStageCompleted: boolean): boolean {
+	return !commandMode || !commandStageCompleted;
+}
+
 function substituteCommandTokens(input: string, replacements: Record<string, string>): string {
 	let output = input;
 	for (const [token, value] of Object.entries(replacements)) {
@@ -476,10 +480,17 @@ async function processJob(
 	job: SummaryJobRow,
 	memoryCfg: ReturnType<typeof loadMemoryConfig>,
 ): Promise<void> {
-	if (!passesSignificanceGate(accessor, job, memoryCfg)) return;
 	const commandMode = memoryCfg.pipelineV2.extraction.provider === "command";
+	const commandAlreadyCompleted = commandMode && hasCommandStageCompleted(accessor, job.id);
+
+	if (
+		shouldRunSignificanceGateForJob(commandMode, commandAlreadyCompleted) &&
+		!passesSignificanceGate(accessor, job, memoryCfg)
+	) {
+		return;
+	}
+
 	if (commandMode) {
-		const commandAlreadyCompleted = hasCommandStageCompleted(accessor, job.id);
 		if (!commandAlreadyCompleted) {
 			await runSummaryCommandProvider(job, memoryCfg);
 			markCommandStageCompleted(accessor, job.id);

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -12,7 +12,7 @@
 
 import type { Database } from "bun:sqlite";
 import { spawn as nodeSpawn } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import type { LlmProvider } from "@signet/core";
@@ -438,15 +438,6 @@ export async function runSummaryCommandProvider(
 					reject(new Error(`summary command exited with code ${exitCode}: ${trimOutput(detail, 500)}`));
 					return;
 				}
-
-				if (stdout.trim().length > 0 || stderr.trim().length > 0) {
-					logger.info("summary-worker", "Summary command completed", {
-						sessionKey: job.session_key,
-						project: job.project,
-						stdout: trimOutput(stdout.trim(), 500),
-						stderr: trimOutput(stderr.trim(), 500),
-					});
-				}
 				resolve();
 			});
 		});
@@ -457,11 +448,18 @@ export async function runSummaryCommandProvider(
 
 async function processJob(
 	accessor: DbAccessor,
-	provider: LlmProvider,
+	provider: LlmProvider | null,
 	job: SummaryJobRow,
 	memoryCfg: ReturnType<typeof loadMemoryConfig>,
 ): Promise<void> {
 	if (!passesSignificanceGate(accessor, job, memoryCfg)) return;
+	if (memoryCfg.pipelineV2.extraction.provider === "command") {
+		await runSummaryCommandProvider(job, memoryCfg);
+		return;
+	}
+	if (!provider) {
+		throw new Error("summary worker requires an LLM provider when extraction.provider is not 'command'");
+	}
 
 	const today = new Date().toISOString().slice(0, 10);
 	const genOpts = {
@@ -1406,11 +1404,8 @@ export function startSummaryWorker(accessor: DbAccessor): SummaryWorkerHandle {
 				project: job.project,
 			});
 
-			if (cfg.pipelineV2.extraction.provider === "command") {
-				if (passesSignificanceGate(accessor, job, cfg)) {
-					await runSummaryCommandProvider(job, cfg);
-				}
-			} else {
+			let providerForJob: LlmProvider | null = null;
+			if (cfg.pipelineV2.extraction.provider !== "command") {
 				// Cache provider across jobs — re-resolve on config change, env
 				// key rotation, or TTL expiry. Env-var key changes invalidate
 				// immediately; secrets-store-only rotations rely on the 5-min TTL.
@@ -1423,8 +1418,9 @@ export function startSummaryWorker(accessor: DbAccessor): SummaryWorkerHandle {
 					cachedProviderKey = providerKey;
 					cachedProviderAt = Date.now();
 				}
-				await processJob(accessor, cachedProvider, job, cfg);
+				providerForJob = cachedProvider;
 			}
+			await processJob(accessor, providerForJob, job, cfg);
 
 			// Mark complete
 			accessor.withWriteTx((db) => {

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -458,31 +458,33 @@ async function processJob(
 			throw new Error("Failed to parse LLM summary response");
 		}
 
-		// Write markdown file
-		mkdirSync(MEMORY_DIR, { recursive: true });
-		const slug = deriveSlug(result.summary, job.project);
-		const filename = uniqueFilename(MEMORY_DIR, `${today}-${slug}`, ".md");
-		writeFileSync(filename, result.summary, "utf-8");
+		if (!commandMode) {
+			// Write markdown file
+			mkdirSync(MEMORY_DIR, { recursive: true });
+			const slug = deriveSlug(result.summary, job.project);
+			const filename = uniqueFilename(MEMORY_DIR, `${today}-${slug}`, ".md");
+			writeFileSync(filename, result.summary, "utf-8");
 
-		logger.info("summary-worker", "Wrote session summary", {
-			path: filename,
-			sessionKey: job.session_key,
-			project: job.project,
-			summaryChars: result.summary.length,
-		});
+			logger.info("summary-worker", "Wrote session summary", {
+				path: filename,
+				sessionKey: job.session_key,
+				project: job.project,
+				summaryChars: result.summary.length,
+			});
 
-		const saved = insertSummaryFacts(accessor, job, result.facts);
+			const saved = insertSummaryFacts(accessor, job, result.facts);
 
-		logger.info("summary-worker", "Inserted session facts", {
-			total: result.facts.length,
-			saved,
-			deduplicated: result.facts.length - saved,
-			factsPreview: result.facts.slice(0, 10).map((fact) => fact.content),
-		});
-
-		// Lossless retention: preserve raw transcript alongside extracted facts
-		if (job.session_key) {
-			upsertSessionTranscript(job.session_key, job.transcript, job.harness, job.project, job.agent_id);
+			logger.info("summary-worker", "Inserted session facts", {
+				total: result.facts.length,
+				saved,
+				deduplicated: result.facts.length - saved,
+				factsPreview: result.facts.slice(0, 10).map((fact) => fact.content),
+			});
+		} else {
+			logger.info("summary-worker", "Command extraction mode: skipping summary markdown + fact insertion", {
+				sessionKey: job.session_key,
+				project: job.project,
+			});
 		}
 
 		// Write to session_summaries DAG (depth 0 = session level)
@@ -628,7 +630,7 @@ async function processJob(
 			});
 		}
 	}
-	if (commandMode && job.session_key) {
+	if (job.session_key && (commandMode || provider)) {
 		upsertSessionTranscript(job.session_key, job.transcript, job.harness, job.project, job.agent_id);
 	}
 }

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -466,189 +466,198 @@ async function processJob(
 	}
 
 	if (provider) {
-		const today = new Date().toISOString().slice(0, 10);
-		const genOpts = {
-			timeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
-			maxTokens: memoryCfg.pipelineV2.synthesis.maxTokens,
-		};
-
-		const result =
-			job.transcript.length > CHUNK_TARGET_CHARS
-				? await processChunked(provider, job.transcript, today, genOpts)
-				: await processSingle(provider, job.transcript, today, genOpts);
-
-		if (!result) {
-			throw new Error("Failed to parse LLM summary response");
-		}
-
-		if (!commandMode) {
-			// Write markdown file
-			mkdirSync(MEMORY_DIR, { recursive: true });
-			const slug = deriveSlug(result.summary, job.project);
-			const filename = uniqueFilename(MEMORY_DIR, `${today}-${slug}`, ".md");
-			writeFileSync(filename, result.summary, "utf-8");
-
-			logger.info("summary-worker", "Wrote session summary", {
-				path: filename,
-				sessionKey: job.session_key,
-				project: job.project,
-				summaryChars: result.summary.length,
-			});
-
-			const saved = insertSummaryFacts(accessor, job, result.facts);
-
-			logger.info("summary-worker", "Inserted session facts", {
-				total: result.facts.length,
-				saved,
-				deduplicated: result.facts.length - saved,
-				factsPreview: result.facts.slice(0, 10).map((fact) => fact.content),
-			});
-		} else {
-			logger.info("summary-worker", "Command extraction mode: skipping summary markdown + fact insertion", {
-				sessionKey: job.session_key,
-				project: job.project,
-			});
-		}
-
-		// Write to session_summaries DAG (depth 0 = session level)
 		try {
-			writeSummaryToDAG(accessor, job, result, job.agent_id);
-		} catch (e) {
-			logger.warn("summary-worker", "Failed to write session summary to DAG (non-fatal)", {
-				error: e instanceof Error ? e.message : String(e),
-			});
-		}
+			const today = new Date().toISOString().slice(0, 10);
+			const genOpts = {
+				timeoutMs: memoryCfg.pipelineV2.synthesis.timeout,
+				maxTokens: memoryCfg.pipelineV2.synthesis.maxTokens,
+			};
 
-		// --- Session continuity scoring ---
-		try {
-			await scoreContinuity(accessor, provider, job, result.summary, memoryCfg);
-		} catch (e) {
-			logger.warn("summary-worker", "Continuity scoring failed (non-fatal)", {
-				error: e instanceof Error ? e.message : String(e),
-			});
-		}
+			const result =
+				job.transcript.length > CHUNK_TARGET_CHARS
+					? await processChunked(provider, job.transcript, today, genOpts)
+					: await processSingle(provider, job.transcript, today, genOpts);
 
-		// --- Predictor comparison (Sprint 3) ---
-		// Runs after continuity scoring has written per-memory relevance scores
-		// and session_scores. Uses dynamic imports to avoid circular deps.
-		// memoryCfg already loaded at function entry (significance gate).
-		try {
-			if (memoryCfg.pipelineV2.predictor?.enabled && job.session_key) {
-				const { runSessionComparison, saveComparison, updateSuccessRate, shouldTriggerTraining, detectDrift } =
-					await import("../predictor-comparison");
-				const comparison = runSessionComparison(job.session_key, job.agent_id, accessor);
-
-				if (comparison !== null) {
-					saveComparison(comparison, job.agent_id, accessor);
-					// Only update EMA when the predictor actually produced scores —
-					// otherwise predictorWon is deterministically false and the EMA
-					// accrues phantom losses during cold start or sidecar downtime.
-					if (comparison.hasPredictorScores) {
-						updateSuccessRate(job.agent_id, comparison.predictorWon, comparison.scorerConfidence);
-					}
-
-					// Drift detection
-					const driftResult = detectDrift(
-						job.agent_id,
-						accessor,
-						memoryCfg.pipelineV2.predictor.driftResetWindow ?? 20,
-					);
-					if (driftResult.drifting) {
-						logger.warn("predictor", "Drift detected — resetting predictor state", {
-							recentWinRate: driftResult.recentWinRate,
-							windowSize: driftResult.windowSize,
-							agentId: job.agent_id,
-						});
-
-						// Reset alpha to 1.0 (full baseline weight) and EMA to neutral
-						const { updatePredictorState: resetState } = await import("../predictor-state");
-						resetState(job.agent_id, {
-							alpha: 1.0,
-							successRate: 0.5,
-						});
-
-						// Trigger retraining (non-fatal if it fails)
-						try {
-							const { getPredictorClient } = await import("../daemon");
-							const predictorClient = getPredictorClient();
-							if (predictorClient) {
-								const dbPath = join(AGENTS_DIR, "memory", "memories.db");
-								await predictorClient.trainFromDb({ db_path: dbPath });
-								logger.info("predictor", "Drift-triggered retraining complete");
-							}
-						} catch (trainErr) {
-							logger.warn("predictor", "Drift-triggered retraining failed", {
-								error: trainErr instanceof Error ? trainErr.message : String(trainErr),
-							});
-						}
-					}
-
-					// Check training trigger
-					if (shouldTriggerTraining(job.agent_id, memoryCfg.pipelineV2.predictor, accessor)) {
-						try {
-							const { getPredictorClient } = await import("../daemon");
-							const predictorClient = getPredictorClient();
-							if (predictorClient) {
-								const dbPath = join(AGENTS_DIR, "memory", "memories.db");
-								await predictorClient.trainFromDb({ db_path: dbPath });
-
-								const { updatePredictorState } = await import("../predictor-state");
-								updatePredictorState(job.agent_id, { lastTrainingAt: new Date().toISOString() });
-
-								logger.info("predictor", "Training triggered after session comparison");
-							}
-						} catch (trainErr) {
-							logger.warn("predictor", "Training trigger failed (non-fatal)", {
-								error: trainErr instanceof Error ? trainErr.message : String(trainErr),
-							});
-						}
-					}
-				}
+			if (!result) {
+				throw new Error("Failed to parse LLM summary response");
 			}
-		} catch (err) {
-			logger.warn("predictor", "Session comparison failed (non-fatal)", {
-				error: err instanceof Error ? err.message : String(err),
-			});
-		}
 
-		// --- Training pair collection for predictor federated learning ---
-		if (job.session_key) {
+			if (!commandMode) {
+				// Write markdown file
+				mkdirSync(MEMORY_DIR, { recursive: true });
+				const slug = deriveSlug(result.summary, job.project);
+				const filename = uniqueFilename(MEMORY_DIR, `${today}-${slug}`, ".md");
+				writeFileSync(filename, result.summary, "utf-8");
+
+				logger.info("summary-worker", "Wrote session summary", {
+					path: filename,
+					sessionKey: job.session_key,
+					project: job.project,
+					summaryChars: result.summary.length,
+				});
+
+				const saved = insertSummaryFacts(accessor, job, result.facts);
+
+				logger.info("summary-worker", "Inserted session facts", {
+					total: result.facts.length,
+					saved,
+					deduplicated: result.facts.length - saved,
+					factsPreview: result.facts.slice(0, 10).map((fact) => fact.content),
+				});
+			} else {
+				logger.info("summary-worker", "Command extraction mode: skipping summary markdown + fact insertion", {
+					sessionKey: job.session_key,
+					project: job.project,
+				});
+			}
+
+			// Write to session_summaries DAG (depth 0 = session level)
 			try {
-				if (memoryCfg.pipelineV2.predictorPipeline.trainingTelemetry) {
-					const { collectTrainingPairs, saveTrainingPairs } = await import("../predictor-training-pairs");
-					const pairs = collectTrainingPairs(accessor, job.session_key, job.agent_id);
-					if (pairs.length > 0) {
-						saveTrainingPairs(accessor, job.agent_id, job.session_key, pairs);
-					}
-				}
+				writeSummaryToDAG(accessor, job, result, job.agent_id);
 			} catch (e) {
-				logger.warn("summary-worker", "Training pair collection failed (non-fatal)", {
+				logger.warn("summary-worker", "Failed to write session summary to DAG (non-fatal)", {
 					error: e instanceof Error ? e.message : String(e),
 				});
 			}
-		}
 
-		try {
-			const { getSynthesisWorker } = await import("./index");
-			void getSynthesisWorker()
-				?.triggerNow({
-					force: true,
-					source: "session-summary",
-					agentId: job.agent_id,
-				})
-				.then((result) => {
-					if (!result.skipped) return;
-					logger.info("summary-worker", "Skipped MEMORY.md synthesis after session summary", {
-						reason: result.reason,
-					});
-				})
-				.catch((error) => {
-					logger.warn("summary-worker", "Failed to trigger MEMORY.md synthesis after session summary", {
-						error: error instanceof Error ? error.message : String(error),
-					});
+			// --- Session continuity scoring ---
+			try {
+				await scoreContinuity(accessor, provider, job, result.summary, memoryCfg);
+			} catch (e) {
+				logger.warn("summary-worker", "Continuity scoring failed (non-fatal)", {
+					error: e instanceof Error ? e.message : String(e),
 				});
+			}
+
+			// --- Predictor comparison (Sprint 3) ---
+			// Runs after continuity scoring has written per-memory relevance scores
+			// and session_scores. Uses dynamic imports to avoid circular deps.
+			// memoryCfg already loaded at function entry (significance gate).
+			try {
+				if (memoryCfg.pipelineV2.predictor?.enabled && job.session_key) {
+					const { runSessionComparison, saveComparison, updateSuccessRate, shouldTriggerTraining, detectDrift } =
+						await import("../predictor-comparison");
+					const comparison = runSessionComparison(job.session_key, job.agent_id, accessor);
+
+					if (comparison !== null) {
+						saveComparison(comparison, job.agent_id, accessor);
+						// Only update EMA when the predictor actually produced scores —
+						// otherwise predictorWon is deterministically false and the EMA
+						// accrues phantom losses during cold start or sidecar downtime.
+						if (comparison.hasPredictorScores) {
+							updateSuccessRate(job.agent_id, comparison.predictorWon, comparison.scorerConfidence);
+						}
+
+						// Drift detection
+						const driftResult = detectDrift(
+							job.agent_id,
+							accessor,
+							memoryCfg.pipelineV2.predictor.driftResetWindow ?? 20,
+						);
+						if (driftResult.drifting) {
+							logger.warn("predictor", "Drift detected — resetting predictor state", {
+								recentWinRate: driftResult.recentWinRate,
+								windowSize: driftResult.windowSize,
+								agentId: job.agent_id,
+							});
+
+							// Reset alpha to 1.0 (full baseline weight) and EMA to neutral
+							const { updatePredictorState: resetState } = await import("../predictor-state");
+							resetState(job.agent_id, {
+								alpha: 1.0,
+								successRate: 0.5,
+							});
+
+							// Trigger retraining (non-fatal if it fails)
+							try {
+								const { getPredictorClient } = await import("../daemon");
+								const predictorClient = getPredictorClient();
+								if (predictorClient) {
+									const dbPath = join(AGENTS_DIR, "memory", "memories.db");
+									await predictorClient.trainFromDb({ db_path: dbPath });
+									logger.info("predictor", "Drift-triggered retraining complete");
+								}
+							} catch (trainErr) {
+								logger.warn("predictor", "Drift-triggered retraining failed", {
+									error: trainErr instanceof Error ? trainErr.message : String(trainErr),
+								});
+							}
+						}
+
+						// Check training trigger
+						if (shouldTriggerTraining(job.agent_id, memoryCfg.pipelineV2.predictor, accessor)) {
+							try {
+								const { getPredictorClient } = await import("../daemon");
+								const predictorClient = getPredictorClient();
+								if (predictorClient) {
+									const dbPath = join(AGENTS_DIR, "memory", "memories.db");
+									await predictorClient.trainFromDb({ db_path: dbPath });
+
+									const { updatePredictorState } = await import("../predictor-state");
+									updatePredictorState(job.agent_id, { lastTrainingAt: new Date().toISOString() });
+
+									logger.info("predictor", "Training triggered after session comparison");
+								}
+							} catch (trainErr) {
+								logger.warn("predictor", "Training trigger failed (non-fatal)", {
+									error: trainErr instanceof Error ? trainErr.message : String(trainErr),
+								});
+							}
+						}
+					}
+				}
+			} catch (err) {
+				logger.warn("predictor", "Session comparison failed (non-fatal)", {
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
+
+			// --- Training pair collection for predictor federated learning ---
+			if (job.session_key) {
+				try {
+					if (memoryCfg.pipelineV2.predictorPipeline.trainingTelemetry) {
+						const { collectTrainingPairs, saveTrainingPairs } = await import("../predictor-training-pairs");
+						const pairs = collectTrainingPairs(accessor, job.session_key, job.agent_id);
+						if (pairs.length > 0) {
+							saveTrainingPairs(accessor, job.agent_id, job.session_key, pairs);
+						}
+					}
+				} catch (e) {
+					logger.warn("summary-worker", "Training pair collection failed (non-fatal)", {
+						error: e instanceof Error ? e.message : String(e),
+					});
+				}
+			}
+
+			try {
+				const { getSynthesisWorker } = await import("./index");
+				void getSynthesisWorker()
+					?.triggerNow({
+						force: true,
+						source: "session-summary",
+						agentId: job.agent_id,
+					})
+					.then((result) => {
+						if (!result.skipped) return;
+						logger.info("summary-worker", "Skipped MEMORY.md synthesis after session summary", {
+							reason: result.reason,
+						});
+					})
+					.catch((error) => {
+						logger.warn("summary-worker", "Failed to trigger MEMORY.md synthesis after session summary", {
+							error: error instanceof Error ? error.message : String(error),
+						});
+					});
+			} catch (e) {
+				logger.warn("summary-worker", "Could not load synthesis worker for post-summary trigger", {
+					error: e instanceof Error ? e.message : String(e),
+				});
+			}
 		} catch (e) {
-			logger.warn("summary-worker", "Could not load synthesis worker for post-summary trigger", {
+			if (!commandMode) {
+				throw e;
+			}
+			logger.warn("summary-worker", "Post-command synthesis flow failed after command extraction (non-fatal)", {
 				error: e instanceof Error ? e.message : String(e),
 			});
 		}


### PR DESCRIPTION
## Summary

Implements issue #334 by adding a first-class `command` extraction provider that runs inside Signet's summary-worker control-plane path.

### What changed

- Added `"command"` as a valid extraction provider in pipeline config.
- Added structured extraction command config:
  - `memory.pipelineV2.extraction.command.bin`
  - `memory.pipelineV2.extraction.command.args[]`
  - optional `cwd`
  - optional `env`
- Added parsing support in daemon memory config, including legacy flat `extractionCommand` string parsing into argv.
- Added summary worker command execution path (`runSummaryCommandProvider`) when `extraction.provider === "command"`:
  - writes transcript to temp file
  - token substitution for `$TRANSCRIPT`/`$TRANSCRIPT_PATH`, `$SESSION_KEY`, `$PROJECT`, `$SIGNET_PATH`
  - executes via argv-safe `spawn` (no shell)
  - timeout clamp, non-zero exit propagation, and temp cleanup in `finally`
- Preserved significance gating and existing queue/retry/max-attempt behavior in the same job lifecycle.
- Added command-stage checkpointing to preserve downstream lifecycle on retries:
  - after command extraction succeeds, summary_jobs.result is marked as `command-stage-complete`
  - retries skip re-running external command side effects for that job
  - retries also skip significance re-evaluation once command stage is complete, so DAG/continuity/synthesis follow-up cannot be permanently bypassed by post-command DB mutations
- Added fail-fast validation for config mistakes:
  - reject `synthesis.provider: command`
  - reject `extraction.provider: command` when `extraction.command` is missing/invalid
- Removed command stdout/stderr success logging to reduce transcript-data exposure risk in logs.
- Added Rust config parity for extraction command config parsing.
- Updated docs in `docs/CONFIGURATION.md` and `docs/PIPELINE.md`.

## Why

This keeps custom extractors inside Signet’s queue/control plane (significance gate, retries, status telemetry) instead of requiring a second blind hook.

Closes #334.

## Validation

- `cd packages/core && bun run build`
- `cd packages/daemon && bun test src/memory-config.test.ts src/pipeline/summary-worker.test.ts`
- `cd packages/daemon-rs && cargo test -p signet-core extraction_command_provider_parses_command_block -- --nocapture`
- `bunx biome check docs/CONFIGURATION.md docs/PIPELINE.md packages/core/src/types.ts packages/daemon/src/memory-config.ts packages/daemon/src/memory-config.test.ts packages/daemon/src/pipeline/summary-worker.ts packages/daemon/src/pipeline/summary-worker.test.ts`

## PR Readiness Checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

