### PR TITLE
fix(cli): protect OpenClaw-linked workspaces from unprotected data loss

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -132,6 +132,8 @@ Options:
 | `--configure-openclaw-workspace` | Patch discovered OpenClaw configs to `$SIGNET_WORKSPACE` |
 | `--open-dashboard` | Open dashboard after non-interactive setup |
 | `--skip-git` | Skip git initialization/commits in non-interactive mode |
+| `--create-local-backup` | If OpenClaw points at this workspace and no origin exists, create a local snapshot automatically |
+| `--allow-unprotected-workspace` | Explicitly allow setup to finish without origin or snapshot in non-interactive mode |
 
 Non-interactive behavior:
 
@@ -139,6 +141,9 @@ Non-interactive behavior:
 - embedding provider must be explicitly provided via `--embedding-provider`
 - extraction provider must be explicitly provided via `--extraction-provider`
 - git: enabled unless `--skip-git` is passed
+- when OpenClaw points at this workspace and no `origin` remote exists, setup
+  requires either backup creation (`--create-local-backup`) or explicit bypass
+  (`--allow-unprotected-workspace`)
 
 Extraction safety note:
 
@@ -157,7 +162,8 @@ Wizard steps:
    - OpenClaw
    - Codex
 3. **OpenClaw Workspace** - Appears only when an existing OpenClaw config
-   is detected; workspace is patched only if you opt in
+   is detected; workspace is patched only if you opt in, and setup warns
+   that uninstalling OpenClaw can delete this workspace unless backups exist
 4. **Description** - Short agent description
 5. **Embedding Provider**:
    - Built-in (recommended, no setup required)

--- a/docs/COMMUNITY-ANNOUNCEMENT-OPENCLAW-WORKSPACE-RISK-2026-03-27.md
+++ b/docs/COMMUNITY-ANNOUNCEMENT-OPENCLAW-WORKSPACE-RISK-2026-03-27.md
@@ -1,0 +1,32 @@
+# Community Announcement: Critical OpenClaw Workspace Risk
+
+OpenClaw uninstall can delete your configured agent workspace.
+
+If your OpenClaw workspace points to your Signet `.agents` directory, an
+uninstall may remove:
+
+- Signet identity files
+- memory database and session history
+- local git history
+
+If you do not have a remote repository or external backup, recovery may be
+impossible.
+
+## What to do right now
+
+Before uninstalling OpenClaw:
+
+1. Configure `origin` on your Signet workspace git repo (private repo
+   recommended), or
+2. Create a full backup of your workspace outside that directory.
+
+## What we are shipping now
+
+Immediate hardening is being added to setup and diagnostics:
+
+- setup soft-gates unprotected OpenClaw-linked workspaces
+- setup supports local snapshot backup creation
+- status/doctor flags warn when workspace is unprotected
+
+Until upstream uninstall behavior is changed, treat this as critical data-loss
+risk.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -134,6 +134,11 @@ signet setup --non-interactive \
 In non-interactive mode, agents should ask the user to choose both
 providers first, then pass those choices explicitly.
 
+If OpenClaw is configured to use the same workspace path, setup now enforces
+backup posture before finishing. In automation, either configure a git
+`origin` remote ahead of time, or pass `--create-local-backup` (or
+`--allow-unprotected-workspace` if you intentionally accept the risk).
+
 Extraction safety note:
 
 - intended usage is Claude Code on Haiku, Codex CLI on GPT Mini with a

--- a/docs/research/technical/RESEARCH-OPENCLAW-WORKSPACE-PROTECTION.md
+++ b/docs/research/technical/RESEARCH-OPENCLAW-WORKSPACE-PROTECTION.md
@@ -1,0 +1,53 @@
+---
+title: "OpenClaw Workspace Protection Research"
+question: "How should Signet prevent data loss when OpenClaw uninstall deletes a workspace that points at .agents?"
+---
+
+# OpenClaw Workspace Protection Research
+
+## Question
+
+How should Signet prevent data loss when OpenClaw uninstall deletes a
+workspace that points at `.agents`?
+
+## Incident
+
+Community reports confirmed a critical failure mode: uninstalling OpenClaw
+can remove the configured workspace directory. When that workspace is also the
+Signet agent directory, users can lose identity files, memory database
+contents, and local git history in one action.
+
+If no remote repository or external backup exists, recovery is effectively
+impossible.
+
+## Current state
+
+- Signet setup can patch OpenClaw workspace to the Signet path.
+- Setup encourages git initialization, but does not require or strongly nudge
+  remote origin configuration.
+- Status and doctor do not flag this specific backup risk.
+
+## Risk model
+
+High risk condition:
+
+1. OpenClaw config workspace resolves to the Signet workspace path.
+2. The workspace has no `origin` remote.
+3. User uninstalls OpenClaw or otherwise deletes that workspace tree.
+
+## Recommended guardrails
+
+1. Add a setup soft gate when the high risk condition is detected.
+2. Treat either of these as acceptable immediate protection:
+   - configured git `origin` remote, or
+   - freshly created local snapshot outside the workspace.
+3. Add non-interactive flags so automation cannot silently proceed in an
+   unprotected state.
+4. Surface the condition in `signet status` and `signet doctor`.
+5. Make OpenClaw workspace patch prompts explicitly mention uninstall risk.
+
+## Practical requirement
+
+This is an incident-driven reliability and data safety patch, not a UI polish
+change. The prevention loop must include durable code guardrails plus explicit
+operator messaging.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -135,6 +135,7 @@ and market subdirectories). Reference repos live in `references/`.
 | `ssm-foundation-evaluation`, `ssm-temporal-backbone`, `ssm-graph-traversal-model` | RESEARCH-SSM-INTEGRATION, SSM-GRAPH-INTERSECTION, SSM-LITERATURE-REVIEW, SYNTHETIC-DATA-GENERATION | How should SSM research translate into benchmarked, staged deployment without violating retrieval invariants? |
 | `engram-informed-predictor-track` | references/Engram, RESEARCH-SSM-INTEGRATION, ssm-foundation-evaluation | How should Engram design patterns be translated into Signet scorer and SSM architecture decisions? |
 | `macos-sqlite-runtime-discovery` | RESEARCH-MACOS-SQLITE-RUNTIME-DISCOVERY | How should Signet select a compatible SQLite runtime on macOS so Bun can load sqlite-vec? |
+| `openclaw-workspace-protection-plan`, `openclaw-workspace-protection` | RESEARCH-OPENCLAW-WORKSPACE-PROTECTION | How should Signet prevent data loss when OpenClaw uninstall deletes a workspace that points at `.agents`? |
 
 ### Research Adoption Ledger (high-impact)
 
@@ -662,6 +663,8 @@ Legend:
 | `openclaw-integration-strategy` | complete | `docs/specs/complete/openclaw-integration-strategy.md` | - | `openclaw-importance-scoring-pr` | |
 | `openclaw-importance-scoring-pr` | complete | `docs/specs/complete/openclaw-importance-scoring-pr.md` | `openclaw-integration-strategy` | - | |
 | `openclaw-hardening` | complete | `docs/specs/complete/openclaw-hardening.md` | `openclaw-importance-scoring-pr` | - | temporal index previews, typed hooks, mid-session extraction (PR #369) |
+| `openclaw-workspace-protection-plan` | planning | `docs/specs/planning/openclaw-workspace-protection-plan.md` | `openclaw-hardening` | `openclaw-workspace-protection` | Incident-driven planning stub for OpenClaw uninstall workspace-loss risk |
+| `openclaw-workspace-protection` | approved | `docs/specs/approved/openclaw-workspace-protection.md` | `openclaw-hardening`, `openclaw-workspace-protection-plan` | - | Setup soft gate + status/doctor visibility for unprotected OpenClaw-linked workspaces |
 | `desire-paths-epic` | approved | `docs/specs/approved/desire-paths-epic.md` | `knowledge-architecture-schema`, `predictive-memory-scorer` | - | 20 stories across 5 phases; Phases 1-3 COMPLETE. DP-16 through DP-20 added from reference repo analysis (Ori-Mnemos, Zikkaron) |
 | `notebook-dump-2026-02-25` | reference | `docs/research/technical/notebook-dump-2026-02-25.md` | - | - | |
 | `marketplace-reviews-cloudflare-staging` | planning | `docs/specs/planning/marketplace-reviews-cloudflare-staging.md` | - | - | |

--- a/docs/specs/approved/openclaw-workspace-protection.md
+++ b/docs/specs/approved/openclaw-workspace-protection.md
@@ -1,0 +1,58 @@
+---
+title: "OpenClaw Workspace Protection"
+id: openclaw-workspace-protection
+status: approved
+informed_by:
+  - docs/research/technical/RESEARCH-OPENCLAW-WORKSPACE-PROTECTION.md
+  - docs/specs/planning/openclaw-workspace-protection-plan.md
+section: "OpenClaw"
+depends_on:
+  - "openclaw-hardening"
+  - "openclaw-workspace-protection-plan"
+success_criteria:
+  - "Setup refuses to complete silently for OpenClaw-linked workspaces without backup posture"
+  - "Interactive setup requires explicit user action: set origin, create snapshot, or explicit bypass acknowledgement"
+  - "Non-interactive setup errors unless origin exists or explicit backup/bypass flags are provided"
+  - "Status and doctor report OpenClaw-linked unprotected workspace risk"
+scope_boundary: "Signet CLI guardrails only; upstream OpenClaw uninstall behavior remains unchanged"
+---
+
+# OpenClaw Workspace Protection
+
+Spec metadata:
+- ID: `openclaw-workspace-protection`
+- Status: `approved`
+- Hard depends on: `openclaw-hardening`, `openclaw-workspace-protection-plan`
+- Registry: `docs/specs/INDEX.md`
+
+## Contract
+
+### Setup contract
+
+1. Detect when OpenClaw workspace resolves to the active Signet workspace.
+2. Detect backup posture through git `origin` remote presence.
+3. If linked + unprotected:
+   - show critical warning
+   - require one protection action before completion:
+     - set origin remote, or
+     - create local snapshot outside workspace, or
+     - explicit bypass acknowledgement (soft gate)
+
+### Non-interactive contract
+
+If linked + unprotected, non-interactive setup must fail unless caller passes
+an explicit protection flag:
+
+- backup action flag (create local snapshot), or
+- explicit bypass flag.
+
+### Operational visibility contract
+
+`signet status` and `signet doctor` must surface this risk condition with
+actionable remediation guidance.
+
+## Validation requirements
+
+1. Regression tests for non-interactive failure path, backup path, and bypass
+   path.
+2. Tests that status reporting marks unprotected linked workspaces correctly.

--- a/docs/specs/dependencies.yaml
+++ b/docs/specs/dependencies.yaml
@@ -1,5 +1,5 @@
 version: 3
-updated_at: "2026-03-26"
+updated_at: "2026-03-27"
 
 specs:
   - id: memory-pipeline-v2
@@ -285,6 +285,40 @@ specs:
       - "OpenClaw plugin compiles and passes tests against typed hook interfaces"
       - "Mid-session checkpoint extraction fires after N turns for long-lived sessions"
       - "Rust daemon implements cursor-tracking parity for session-checkpoint-extract"
+    decision: null
+
+  - id: openclaw-workspace-protection-plan
+    status: planning
+    path: docs/specs/planning/openclaw-workspace-protection-plan.md
+    hard_depends_on:
+      - openclaw-hardening
+    soft_depends_on: []
+    blocks:
+      - openclaw-workspace-protection
+    informed_by:
+      - docs/research/technical/RESEARCH-OPENCLAW-WORKSPACE-PROTECTION.md
+    success_criteria:
+      - "Setup blocks silent completion when OpenClaw points at the Signet workspace and no remote backup is configured"
+      - "Users can satisfy setup protection by configuring git origin or creating an out-of-workspace local snapshot"
+      - "Status and doctor surfaces flag unprotected OpenClaw-linked workspaces with remediation commands"
+    decision: null
+
+  - id: openclaw-workspace-protection
+    status: approved
+    path: docs/specs/approved/openclaw-workspace-protection.md
+    hard_depends_on:
+      - openclaw-hardening
+      - openclaw-workspace-protection-plan
+    soft_depends_on: []
+    blocks: []
+    informed_by:
+      - docs/research/technical/RESEARCH-OPENCLAW-WORKSPACE-PROTECTION.md
+      - docs/specs/planning/openclaw-workspace-protection-plan.md
+    success_criteria:
+      - "Setup refuses to complete silently for OpenClaw-linked workspaces without backup posture"
+      - "Interactive setup requires explicit user action: set origin, create snapshot, or explicit bypass acknowledgement"
+      - "Non-interactive setup errors unless origin exists or explicit backup/bypass flags are provided"
+      - "Status and doctor report OpenClaw-linked unprotected workspace risk"
     decision: null
 
   - id: desire-paths-epic

--- a/docs/specs/planning/openclaw-workspace-protection-plan.md
+++ b/docs/specs/planning/openclaw-workspace-protection-plan.md
@@ -1,0 +1,44 @@
+---
+title: "OpenClaw Workspace Protection Plan"
+id: openclaw-workspace-protection-plan
+status: planning
+informed_by:
+  - docs/research/technical/RESEARCH-OPENCLAW-WORKSPACE-PROTECTION.md
+section: "OpenClaw"
+depends_on:
+  - "openclaw-hardening"
+success_criteria:
+  - "Setup blocks silent completion when OpenClaw points at the Signet workspace and no remote backup is configured"
+  - "Users can satisfy setup protection by configuring git origin or creating an out-of-workspace local snapshot"
+  - "Status and doctor surfaces flag unprotected OpenClaw-linked workspaces with remediation commands"
+scope_boundary: "CLI setup/status/doctor guardrails only; no OpenClaw uninstall behavior changes in upstream OpenClaw runtime"
+draft_quality: "incident-driven planning stub"
+---
+
+# OpenClaw Workspace Protection Plan
+
+Spec metadata:
+- ID: `openclaw-workspace-protection-plan`
+- Status: `planning`
+- Hard depends on: `openclaw-hardening`
+- Registry: `docs/specs/INDEX.md`
+
+## Problem
+
+When OpenClaw workspace is set to the Signet workspace, uninstalling OpenClaw
+can delete user memory and identity state. Current setup flow does not enforce
+backup posture before finishing.
+
+## Goals
+
+1. Prevent silent unprotected setups in this risk state.
+2. Keep automation usable with explicit escape hatches.
+3. Add durable diagnostics so risk remains visible after setup.
+
+## Proposed guardrails
+
+1. Setup soft gate with explicit critical warning text.
+2. Protection satisfied by git `origin` remote or immediate local snapshot.
+3. Non-interactive setup requires explicit backup or bypass flags.
+4. `signet status` and `signet doctor` report the risk condition.
+5. OpenClaw workspace patch prompt explicitly describes uninstall risk.

--- a/packages/cli/src/commands/app.ts
+++ b/packages/cli/src/commands/app.ts
@@ -17,6 +17,8 @@ interface SetupOptions {
 	configureOpenclawWorkspace?: boolean;
 	openDashboard?: boolean;
 	skipGit?: boolean;
+	allowUnprotectedWorkspace?: boolean;
+	createLocalBackup?: boolean;
 }
 
 interface PathOptions {
@@ -71,6 +73,14 @@ export function registerAppCommands(program: Command, deps: AppDeps): void {
 		)
 		.option("--open-dashboard", "Open dashboard after setup in non-interactive mode")
 		.option("--skip-git", "Skip git initialization and setup commits in non-interactive mode")
+		.option(
+			"--allow-unprotected-workspace",
+			"Allow setup to finish without remote origin or local snapshot when OpenClaw points at this workspace",
+		)
+		.option(
+			"--create-local-backup",
+			"Create a local snapshot backup automatically when OpenClaw points at this workspace and no origin remote exists",
+		)
 		.action(deps.setupWizard);
 
 	const dashboard = program

--- a/packages/cli/src/features/health.test.ts
+++ b/packages/cli/src/features/health.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getStatusReport } from "./health.js";
+
+const originalOpenClawConfig = process.env.OPENCLAW_CONFIG_PATH;
+
+afterEach(() => {
+	if (originalOpenClawConfig === undefined) {
+		process.env.OPENCLAW_CONFIG_PATH = undefined;
+	} else {
+		process.env.OPENCLAW_CONFIG_PATH = originalOpenClawConfig;
+	}
+});
+
+function depsFor(basePath: string) {
+	return {
+		agentsDir: basePath,
+		defaultPort: 3850,
+		detectExistingSetup: () => ({
+			agentsDir: true,
+			agentsMd: true,
+			agentYaml: true,
+			memoryDb: false,
+		}),
+		extractPathOption: () => null,
+		formatUptime: () => "0s",
+		getDaemonStatus: async () => ({
+			running: false,
+			pid: null,
+			uptime: null,
+			version: null,
+			host: null,
+			bindHost: null,
+			networkMode: null,
+		}),
+		normalizeAgentPath: (pathValue: string) => pathValue,
+		parseIntegerValue: (value: unknown) => (typeof value === "number" ? value : null),
+		signetLogo: () => "signet",
+	};
+}
+
+describe("status report openclaw backup risk", () => {
+	it("marks workspace as unprotected when openclaw is linked and origin is missing", async () => {
+		const root = mkdtempSync(join(tmpdir(), "health-risk-"));
+		const workspace = join(root, "agents");
+		try {
+			mkdirSync(workspace, { recursive: true });
+			spawnSync("git", ["init"], { cwd: workspace, windowsHide: true });
+			const cfgPath = join(root, "openclaw.json");
+			writeFileSync(
+				cfgPath,
+				JSON.stringify({
+					agents: {
+						defaults: {
+							workspace,
+						},
+					},
+				}),
+			);
+			process.env.OPENCLAW_CONFIG_PATH = cfgPath;
+			const report = await getStatusReport(workspace, depsFor(workspace));
+			expect(report.openclawWorkspaceLinked).toBe(true);
+			expect(report.openclawWorkspaceUnprotected).toBe(true);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("clears unprotected flag when origin exists", async () => {
+		const root = mkdtempSync(join(tmpdir(), "health-risk-"));
+		const workspace = join(root, "agents");
+		try {
+			mkdirSync(workspace, { recursive: true });
+			spawnSync("git", ["init"], { cwd: workspace, windowsHide: true });
+			spawnSync("git", ["remote", "add", "origin", "git@github.com:test/private.git"], {
+				cwd: workspace,
+				windowsHide: true,
+			});
+			const cfgPath = join(root, "openclaw.json");
+			writeFileSync(
+				cfgPath,
+				JSON.stringify({
+					agents: {
+						defaults: {
+							workspace,
+						},
+					},
+				}),
+			);
+			process.env.OPENCLAW_CONFIG_PATH = cfgPath;
+			const report = await getStatusReport(workspace, depsFor(workspace));
+			expect(report.openclawWorkspaceLinked).toBe(true);
+			expect(report.openclawWorkspaceUnprotected).toBe(false);
+			expect(report.git.origin).toContain("private.git");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/cli/src/features/health.ts
+++ b/packages/cli/src/features/health.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { detectSchema, getMissingIdentityFiles, hasValidIdentity } from "@signet/core";
 import chalk from "chalk";
 import { daemonAccessLines } from "../lib/network.js";
+import { getGitRemoteState, hasOpenClawWorkspaceLink } from "../lib/workspace-protection.js";
 import Database from "../sqlite.js";
 
 interface Existing {
@@ -44,9 +45,15 @@ interface StatusReport {
 	readonly files: readonly FileReport[];
 	readonly db: DbReport;
 	readonly daemon: DaemonStatus;
+	readonly git: {
+		readonly isRepo: boolean;
+		readonly origin: string | null;
+	};
 	// True when an openclaw config was found with both the legacy hook AND the
 	// plugin path enabled simultaneously (dual-system misconfiguration).
 	readonly openclawDualSystem: boolean;
+	readonly openclawWorkspaceLinked: boolean;
+	readonly openclawWorkspaceUnprotected: boolean;
 }
 
 /**
@@ -112,6 +119,8 @@ export async function getStatusReport(basePath: string, deps: StatusDeps): Promi
 		{ name: "memories.db", exists: existing.memoryDb },
 	];
 	const daemon = await deps.getDaemonStatus();
+	const git = getGitRemoteState(basePath);
+	const openclawWorkspaceLinked = hasOpenClawWorkspaceLink(basePath);
 	const report: StatusReport = {
 		basePath,
 		installed,
@@ -126,7 +135,10 @@ export async function getStatusReport(basePath: string, deps: StatusDeps): Promi
 			conversationCount: null,
 		},
 		daemon,
+		git,
 		openclawDualSystem: detectOpenClawDualSystem(),
+		openclawWorkspaceLinked,
+		openclawWorkspaceUnprotected: openclawWorkspaceLinked && git.origin === null,
 	};
 
 	if (!existing.memoryDb) {
@@ -223,6 +235,10 @@ export async function showStatus(options: { path?: string; json?: boolean }, dep
 
 	console.log();
 	console.log(chalk.dim(`  Path: ${report.basePath}`));
+	if (report.openclawWorkspaceUnprotected) {
+		console.log(chalk.red("  ⚠ OpenClaw workspace protection: unprotected"));
+		console.log(chalk.dim("    No origin remote detected for this workspace."));
+	}
 	console.log();
 }
 
@@ -335,6 +351,15 @@ function getDoctorFindings(report: StatusReport): DoctorFinding[] {
 			message:
 				"OpenClaw dual-system conflict: legacy hook AND plugin are both enabled. This causes duplicate memories, 2× token burn, and 409 session errors.",
 			fix: 'Run `signet setup --harness openclaw` to repair, or set hooks.internal.entries["signet-memory"].enabled = false in your openclaw config.',
+		});
+	}
+
+	if (report.openclawWorkspaceUnprotected) {
+		findings.push({
+			level: "warn",
+			message:
+				"OpenClaw points at this Signet workspace, but no git origin remote is configured. Uninstalling OpenClaw can leave this workspace unrecoverable without backup.",
+			fix: "Run `git -C <workspace> remote add origin <private-repo-url>` or rerun `signet setup` and create a local snapshot backup.",
 		});
 	}
 

--- a/packages/cli/src/features/setup-fresh.ts
+++ b/packages/cli/src/features/setup-fresh.ts
@@ -9,6 +9,7 @@ import { daemonAccessLines } from "../lib/network.js";
 import Database from "../sqlite.js";
 import { installForge, managedForgeInstallSupportedOnCurrentPlatform } from "./forge.js";
 import { buildSetupPipeline } from "./setup-pipeline.js";
+import { enforceSetupProtection, printSetupProtectionSummary } from "./setup-protection.js";
 import { readErr, readRecord } from "./setup-shared.js";
 import type { FreshSetupConfig, SetupDeps } from "./setup-types.js";
 
@@ -221,6 +222,13 @@ export async function runFreshSetup(cfg: FreshSetupConfig, deps: SetupDeps): Pro
 			}
 		}
 
+		const protection = await enforceSetupProtection({
+			basePath: cfg.basePath,
+			nonInteractive: cfg.nonInteractive,
+			allowUnprotectedWorkspace: cfg.allowUnprotectedWorkspace,
+			createLocalBackup: cfg.createLocalBackup,
+		});
+
 		if (cfg.nonInteractive) {
 			if (cfg.openDashboard) {
 				await open(`http://localhost:${deps.DEFAULT_PORT}`);
@@ -235,9 +243,14 @@ export async function runFreshSetup(cfg: FreshSetupConfig, deps: SetupDeps): Pro
 		}
 
 		console.log();
+		printSetupProtectionSummary(protection);
+		console.log();
 		console.log(chalk.cyan("  → Next step: Say '/onboarding' to personalize your agent"));
 		console.log(chalk.dim("    This will walk you through setting up your agent's personality,"));
 		console.log(chalk.dim("    communication style, and your preferences."));
+		if (protection.state === "bypass") {
+			console.log(chalk.red("    Backup warning: this workspace is still unprotected."));
+		}
 	} catch (err) {
 		spinner.fail(chalk.red("Setup failed"));
 		console.error(err);

--- a/packages/cli/src/features/setup-migrate.ts
+++ b/packages/cli/src/features/setup-migrate.ts
@@ -23,6 +23,7 @@ import { daemonAccessLines } from "../lib/network.js";
 import Database from "../sqlite.js";
 import { installForge, managedForgeInstallSupportedOnCurrentPlatform } from "./forge.js";
 import { buildSetupPipeline, defaultExtractionModel } from "./setup-pipeline.js";
+import { enforceSetupProtection, printSetupProtectionSummary } from "./setup-protection.js";
 import {
 	type EmbeddingProviderChoice,
 	type ExtractionProviderChoice,
@@ -43,6 +44,8 @@ export async function runExistingSetupWizard(
 		nonInteractive?: boolean;
 		openDashboard?: boolean;
 		skipGit?: boolean;
+		allowUnprotectedWorkspace?: boolean;
+		createLocalBackup?: boolean;
 		embeddingProvider?: EmbeddingProviderChoice;
 		embeddingModel?: string;
 		extractionProvider?: ExtractionProviderChoice;
@@ -299,6 +302,15 @@ export async function runExistingSetupWizard(
 			}
 		}
 
+		const protection = await enforceSetupProtection({
+			basePath,
+			nonInteractive: options?.nonInteractive === true,
+			allowUnprotectedWorkspace: options?.allowUnprotectedWorkspace === true,
+			createLocalBackup: options?.createLocalBackup === true,
+		});
+
+		console.log();
+		printSetupProtectionSummary(protection);
 		console.log();
 		if (options?.nonInteractive === true) {
 			if (options.openDashboard === true) {
@@ -315,6 +327,9 @@ export async function runExistingSetupWizard(
 		console.log(chalk.cyan("  → Next step: Say '/onboarding' to personalize your agent"));
 		console.log(chalk.dim("    This will walk you through setting up your agent's personality,"));
 		console.log(chalk.dim("    communication style, and your preferences."));
+		if (protection.state === "bypass") {
+			console.log(chalk.red("    Backup warning: this workspace is still unprotected."));
+		}
 	} catch (err) {
 		spinner.fail(chalk.red("Setup failed"));
 		console.error(err);

--- a/packages/cli/src/features/setup-protection.test.ts
+++ b/packages/cli/src/features/setup-protection.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { enforceSetupProtection } from "./setup-protection.js";
+
+const originalEnv = {
+	OPENCLAW_CONFIG_PATH: process.env.OPENCLAW_CONFIG_PATH,
+	HOME: process.env.HOME,
+};
+
+afterEach(() => {
+	if (originalEnv.OPENCLAW_CONFIG_PATH === undefined) {
+		process.env.OPENCLAW_CONFIG_PATH = undefined;
+	} else {
+		process.env.OPENCLAW_CONFIG_PATH = originalEnv.OPENCLAW_CONFIG_PATH;
+	}
+
+	if (originalEnv.HOME === undefined) {
+		process.env.HOME = undefined;
+	} else {
+		process.env.HOME = originalEnv.HOME;
+	}
+});
+
+function setupRepo(): {
+	root: string;
+	workspace: string;
+	configPath: string;
+} {
+	const root = mkdtempSync(join(tmpdir(), "setup-protection-"));
+	const workspace = join(root, "agents");
+	mkdirSync(workspace, { recursive: true });
+	writeFileSync(join(workspace, "AGENTS.md"), "# test\n");
+	spawnSync("git", ["init"], { cwd: workspace, windowsHide: true });
+
+	const configPath = join(root, "openclaw.json");
+	writeFileSync(
+		configPath,
+		JSON.stringify({
+			agents: {
+				defaults: {
+					workspace,
+				},
+			},
+		}),
+	);
+	process.env.OPENCLAW_CONFIG_PATH = configPath;
+	process.env.HOME = root;
+	return { root, workspace, configPath };
+}
+
+describe("setup protection soft gate", () => {
+	it("fails non-interactive setup when workspace is linked and unprotected", async () => {
+		const { root, workspace } = setupRepo();
+		try {
+			await expect(
+				enforceSetupProtection({
+					basePath: workspace,
+					nonInteractive: true,
+					allowUnprotectedWorkspace: false,
+					createLocalBackup: false,
+				}),
+			).rejects.toThrow("OpenClaw workspace is linked");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("creates a local snapshot in non-interactive mode when requested", async () => {
+		const { root, workspace } = setupRepo();
+		try {
+			const result = await enforceSetupProtection({
+				basePath: workspace,
+				nonInteractive: true,
+				allowUnprotectedWorkspace: false,
+				createLocalBackup: true,
+			});
+			expect(result.state).toBe("snapshot");
+			expect(result.snapshotPath).not.toBeNull();
+			if (result.snapshotPath) {
+				expect(existsSync(result.snapshotPath)).toBe(true);
+			}
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("allows explicit bypass in non-interactive mode", async () => {
+		const { root, workspace } = setupRepo();
+		try {
+			const result = await enforceSetupProtection({
+				basePath: workspace,
+				nonInteractive: true,
+				allowUnprotectedWorkspace: true,
+				createLocalBackup: false,
+			});
+			expect(result.state).toBe("bypass");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("passes immediately when origin remote is configured", async () => {
+		const { root, workspace } = setupRepo();
+		try {
+			spawnSync("git", ["remote", "add", "origin", "git@github.com:test/private.git"], {
+				cwd: workspace,
+				windowsHide: true,
+			});
+			const result = await enforceSetupProtection({
+				basePath: workspace,
+				nonInteractive: true,
+				allowUnprotectedWorkspace: false,
+				createLocalBackup: false,
+			});
+			expect(result.state).toBe("remote");
+			expect(result.origin).toContain("github.com:test/private.git");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/cli/src/features/setup-protection.ts
+++ b/packages/cli/src/features/setup-protection.ts
@@ -1,0 +1,149 @@
+import { confirm, input, select } from "@inquirer/prompts";
+import chalk from "chalk";
+import {
+	createWorkspaceSnapshot,
+	getGitRemoteState,
+	hasOpenClawWorkspaceLink,
+	setOriginRemote,
+} from "../lib/workspace-protection.js";
+
+export interface SetupProtectionOptions {
+	readonly basePath: string;
+	readonly nonInteractive: boolean;
+	readonly allowUnprotectedWorkspace: boolean;
+	readonly createLocalBackup: boolean;
+}
+
+export interface SetupProtectionResult {
+	readonly state: "not-applicable" | "remote" | "snapshot" | "bypass";
+	readonly openclawLinked: boolean;
+	readonly origin: string | null;
+	readonly snapshotPath: string | null;
+}
+
+export function printSetupProtectionSummary(result: SetupProtectionResult): void {
+	if (result.state === "not-applicable") {
+		return;
+	}
+	if (result.state === "remote") {
+		console.log(chalk.green("  ✓ Workspace protection: origin remote configured"));
+		console.log(chalk.dim(`    origin: ${result.origin}`));
+		return;
+	}
+	if (result.state === "snapshot") {
+		console.log(chalk.yellow("  ⚠ Workspace protection: local snapshot created"));
+		console.log(chalk.dim(`    snapshot: ${result.snapshotPath}`));
+		return;
+	}
+	console.log(chalk.red("  ⚠ Workspace protection bypassed"));
+	console.log(chalk.dim("    Configure a git origin or create an out-of-workspace backup immediately."));
+}
+
+function printRisk(path: string): void {
+	console.log();
+	console.log(chalk.red.bold("  CRITICAL: OpenClaw uninstall can delete this workspace."));
+	console.log(chalk.red(`  Workspace: ${path}`));
+	console.log(chalk.dim("  If no remote backup exists, your Signet identity and memory history may be unrecoverable."));
+}
+
+export async function enforceSetupProtection(opts: SetupProtectionOptions): Promise<SetupProtectionResult> {
+	const openclawLinked = hasOpenClawWorkspaceLink(opts.basePath);
+	const remote = getGitRemoteState(opts.basePath);
+	if (!openclawLinked) {
+		return {
+			state: "not-applicable",
+			openclawLinked: false,
+			origin: remote.origin,
+			snapshotPath: null,
+		};
+	}
+
+	if (remote.origin) {
+		return {
+			state: "remote",
+			openclawLinked: true,
+			origin: remote.origin,
+			snapshotPath: null,
+		};
+	}
+
+	if (opts.nonInteractive) {
+		if (opts.createLocalBackup) {
+			const snap = createWorkspaceSnapshot(opts.basePath);
+			return {
+				state: "snapshot",
+				openclawLinked: true,
+				origin: null,
+				snapshotPath: snap.path,
+			};
+		}
+		if (opts.allowUnprotectedWorkspace) {
+			return {
+				state: "bypass",
+				openclawLinked: true,
+				origin: null,
+				snapshotPath: null,
+			};
+		}
+		throw new Error(
+			"OpenClaw workspace is linked to this Signet path without an origin remote. Re-run setup with --create-local-backup or --allow-unprotected-workspace.",
+		);
+	}
+
+	printRisk(opts.basePath);
+
+	while (true) {
+		const action = await select({
+			message: "Protect this workspace before setup completes:",
+			choices: [
+				{ value: "remote", name: "Set git origin now (recommended)" },
+				{ value: "snapshot", name: "Create local snapshot backup now" },
+				{ value: "bypass", name: "Continue anyway (I understand the risk)" },
+			],
+		});
+
+		if (action === "remote") {
+			const url = await input({
+				message: "Origin URL (ssh or https):",
+				validate: (value) => (value.trim().length > 0 ? true : "Origin URL is required"),
+			});
+			setOriginRemote(opts.basePath, url.trim());
+			const updated = getGitRemoteState(opts.basePath);
+			if (updated.origin) {
+				return {
+					state: "remote",
+					openclawLinked: true,
+					origin: updated.origin,
+					snapshotPath: null,
+				};
+			}
+			console.log(chalk.yellow("  Could not verify origin. Please try again."));
+			continue;
+		}
+
+		if (action === "snapshot") {
+			const snap = createWorkspaceSnapshot(opts.basePath);
+			console.log(chalk.green(`  ✓ Snapshot created at ${snap.path}`));
+			return {
+				state: "snapshot",
+				openclawLinked: true,
+				origin: null,
+				snapshotPath: snap.path,
+			};
+		}
+
+		const proceed = await confirm({
+			message: "Continue without remote or snapshot backup?",
+			default: false,
+		});
+		if (!proceed) {
+			continue;
+		}
+		return {
+			state: "bypass",
+			openclawLinked: true,
+			origin: null,
+			snapshotPath: null,
+		};
+	}
+}

--- a/packages/cli/src/features/setup-types.ts
+++ b/packages/cli/src/features/setup-types.ts
@@ -17,6 +17,8 @@ export interface SetupWizardOptions {
 	openDashboard?: boolean;
 	openclawRuntimePath?: string;
 	configureOpenclawWorkspace?: boolean;
+	allowUnprotectedWorkspace?: boolean;
+	createLocalBackup?: boolean;
 }
 
 export interface SetupDeps {
@@ -75,4 +77,6 @@ export interface FreshSetupConfig {
 	readonly existingAgentsDir: boolean;
 	readonly nonInteractive: boolean;
 	readonly openDashboard: boolean;
+	readonly allowUnprotectedWorkspace: boolean;
+	readonly createLocalBackup: boolean;
 }

--- a/packages/cli/src/features/setup.ts
+++ b/packages/cli/src/features/setup.ts
@@ -195,6 +195,8 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 				nonInteractive: true,
 				openDashboard: options.openDashboard === true,
 				skipGit: options.skipGit === true,
+				allowUnprotectedWorkspace: options.allowUnprotectedWorkspace === true,
+				createLocalBackup: options.createLocalBackup === true,
 				embeddingProvider: migrationEmbeddingProvider,
 				embeddingModel: deps.normalizeStringValue(options.embeddingModel) || undefined,
 				extractionProvider: migrationExtractionProvider,
@@ -229,7 +231,10 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 				return;
 			}
 		} else {
-			await runExistingSetupWizard(basePath, existing, existingConfig, deps);
+			await runExistingSetupWizard(basePath, existing, existingConfig, deps, {
+				allowUnprotectedWorkspace: false,
+				createLocalBackup: false,
+			});
 			return;
 		}
 	} else {
@@ -330,7 +335,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 			if (existingConfigs.length > 0) {
 				console.log();
 				configureOpenClawWs = await confirm({
-					message: `Set OpenClaw workspace to ${basePath} in ${existingConfigs.length} config file(s)?`,
+					message: `Set OpenClaw workspace to ${basePath} in ${existingConfigs.length} config file(s)? This can be destructive on OpenClaw uninstall unless backups are configured.`,
 					default: true,
 				});
 			}
@@ -704,6 +709,8 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		existingAgentsDir: existing.agentsDir,
 		nonInteractive,
 		openDashboard: options.openDashboard === true,
+		allowUnprotectedWorkspace: options.allowUnprotectedWorkspace === true,
+		createLocalBackup: options.createLocalBackup === true,
 	};
 
 	await runFreshSetup(cfg, deps);

--- a/packages/cli/src/lib/workspace-protection.ts
+++ b/packages/cli/src/lib/workspace-protection.ts
@@ -1,0 +1,122 @@
+import { spawnSync } from "node:child_process";
+import { cpSync, existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import { OpenClawConnector } from "@signet/connector-openclaw";
+
+export interface GitRemoteState {
+	readonly isRepo: boolean;
+	readonly origin: string | null;
+}
+
+export interface SnapshotResult {
+	readonly path: string;
+	readonly root: string;
+}
+
+function readOutput(value: string | Buffer | null): string {
+	if (typeof value === "string") {
+		return value.trim();
+	}
+	if (value instanceof Buffer) {
+		return value.toString("utf-8").trim();
+	}
+	return "";
+}
+
+function sanitize(name: string): string {
+	const trimmed = name.trim().toLowerCase();
+	if (trimmed.length === 0) {
+		return "workspace";
+	}
+	return trimmed.replace(/[^a-z0-9._-]+/g, "-");
+}
+
+export function getGitRemoteState(dir: string): GitRemoteState {
+	const path = resolve(dir);
+	const probe = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
+		cwd: path,
+		encoding: "utf-8",
+		windowsHide: true,
+	});
+	const isRepo = probe.status === 0;
+	if (!isRepo) {
+		return { isRepo: false, origin: null };
+	}
+
+	const remote = spawnSync("git", ["remote", "get-url", "origin"], {
+		cwd: path,
+		encoding: "utf-8",
+		windowsHide: true,
+	});
+	if (remote.status !== 0) {
+		return { isRepo: true, origin: null };
+	}
+	const origin = readOutput(remote.stdout);
+	if (origin.length === 0) {
+		return { isRepo: true, origin: null };
+	}
+	return { isRepo: true, origin };
+}
+
+export function hasOpenClawWorkspaceLink(basePath: string): boolean {
+	const target = resolve(basePath);
+	const connector = new OpenClawConnector();
+	const workspaces = connector.getDiscoveredWorkspacePaths();
+	return workspaces.some((path) => resolve(path) === target);
+}
+
+export function defaultBackupRoot(): string {
+	return join(homedir(), ".signet", "backups");
+}
+
+export function createWorkspaceSnapshot(basePath: string, backupRoot = defaultBackupRoot()): SnapshotResult {
+	const root = resolve(backupRoot);
+	const source = resolve(basePath);
+	mkdirSync(root, { recursive: true });
+
+	const stamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\..+$/, "Z");
+	const dir = sanitize(basename(source));
+	const target = join(root, `${dir}-${stamp}`);
+
+	cpSync(source, target, {
+		recursive: true,
+		errorOnExist: true,
+		force: false,
+	});
+
+	if (!existsSync(target)) {
+		throw new Error(`Snapshot copy failed: ${target}`);
+	}
+
+	return { path: target, root };
+}
+
+export function setOriginRemote(dir: string, url: string): void {
+	const path = resolve(dir);
+	const state = getGitRemoteState(path);
+	if (!state.isRepo) {
+		throw new Error(`Not a git repository: ${path}`);
+	}
+	if (state.origin) {
+		const set = spawnSync("git", ["remote", "set-url", "origin", url], {
+			cwd: path,
+			encoding: "utf-8",
+			windowsHide: true,
+		});
+		if (set.status === 0) {
+			return;
+		}
+		throw new Error(readOutput(set.stderr) || "Failed to update origin remote");
+	}
+
+	const add = spawnSync("git", ["remote", "add", "origin", url], {
+		cwd: path,
+		encoding: "utf-8",
+		windowsHide: true,
+	});
+	if (add.status === 0) {
+		return;
+	}
+	throw new Error(readOutput(add.stderr) || "Failed to add origin remote");
+}


### PR DESCRIPTION
## Summary

This incident hardening patch adds a setup soft gate and diagnostics for a critical OpenClaw workspace-loss risk:

- OpenClaw can uninstall-delete its configured workspace
- if that workspace is Signet's `.agents` path and no backup exists, identity/memory/history can be lost

### What changed

- Added setup protection flow for OpenClaw-linked workspaces:
  - accepts safety posture when `origin` remote exists
  - otherwise requires one action:
    - set `origin` now, or
    - create local snapshot backup, or
    - explicitly bypass (soft gate)
- Added non-interactive flags:
  - `--create-local-backup`
  - `--allow-unprotected-workspace`
- Hardened OpenClaw workspace patch prompt text with explicit uninstall risk warning
- Added `signet status` / `signet doctor` warnings for OpenClaw-linked unprotected workspaces
- Added post-setup protection summary output
- Added incident docs:
  - research + planning + approved spec
  - dependency/index updates
  - community announcement draft

## Files of interest

- `packages/cli/src/lib/workspace-protection.ts`
- `packages/cli/src/features/setup-protection.ts`
- `packages/cli/src/features/setup.ts`
- `packages/cli/src/features/setup-fresh.ts`
- `packages/cli/src/features/setup-migrate.ts`
- `packages/cli/src/features/health.ts`

## Validation

Ran:

- `bun test packages/cli/src/features/setup-protection.test.ts packages/cli/src/features/health.test.ts`
- `bun run typecheck`
- `bun run build`

Notes:

- `bun run lint` currently fails due to repo-wide pre-existing biome drift (not introduced by this patch)
- `bun scripts/spec-deps-check.ts` currently fails due to pre-existing `references/Engram` path mismatch in another spec

## Why this is a `fix:`

This is incident hardening and data-loss prevention for existing setup/diagnostics behavior, not a new user-facing feature surface.
