### PR TITLE
fix(ci): repair desktop self-signed signing failures on release builds

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -183,6 +183,8 @@ jobs:
           CERT_NAME="Signet Desktop Self-Signed"
           TMP_DIR="${RUNNER_TEMP}/signet-selfsign"
           KEYCHAIN="${RUNNER_TEMP}/signet-selfsign.keychain-db"
+          KEYCHAIN_PASS="signet-selfsign"
+          P12_PASS="signet-selfsign"
           mkdir -p "${TMP_DIR}"
 
           openssl req -x509 -newkey rsa:2048 \
@@ -195,12 +197,12 @@ jobs:
             -inkey "${TMP_DIR}/key.pem" \
             -in "${TMP_DIR}/cert.pem" \
             -out "${TMP_DIR}/cert.p12" \
-            -passout pass:
+            -passout pass:"${P12_PASS}"
 
-          security create-keychain -p "" "${KEYCHAIN}"
-          security unlock-keychain -p "" "${KEYCHAIN}"
-          security import "${TMP_DIR}/cert.p12" -k "${KEYCHAIN}" -P "" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple: -s -k "" "${KEYCHAIN}"
+          security create-keychain -p "${KEYCHAIN_PASS}" "${KEYCHAIN}"
+          security unlock-keychain -p "${KEYCHAIN_PASS}" "${KEYCHAIN}"
+          security import "${TMP_DIR}/cert.p12" -k "${KEYCHAIN}" -P "${P12_PASS}" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "${KEYCHAIN_PASS}" "${KEYCHAIN}"
           security default-keychain -s "${KEYCHAIN}"
           security list-keychains -d user -s "${KEYCHAIN}" $(security list-keychains -d user | tr -d '"')
 
@@ -224,6 +226,14 @@ jobs:
             [Convert]::FromBase64String($env:WINDOWS_CERTIFICATE)
           )
 
+          $signTool = Get-ChildItem "C:/Program Files (x86)/Windows Kits/10/bin/*/x64/signtool.exe" -ErrorAction SilentlyContinue |
+            Sort-Object FullName -Descending |
+            Select-Object -First 1
+          if (-not $signTool) {
+            Write-Error "signtool.exe not found under Windows Kits"
+            exit 1
+          }
+
           $msiFiles = Get-ChildItem -Path "packages/tray/src-tauri/target/$env:TARGET/release/bundle/msi" -Filter *.msi -Recurse
           if ($msiFiles.Count -eq 0) {
             Write-Error "No MSI artifacts found for signing"
@@ -231,7 +241,7 @@ jobs:
           }
 
           foreach ($msi in $msiFiles) {
-            & signtool sign `
+            & $signTool.FullName sign `
               /f "$certPath" `
               /p "$env:WINDOWS_CERTIFICATE_PASSWORD" `
               /fd SHA256 `
@@ -260,6 +270,14 @@ jobs:
             -CertStoreLocation "Cert:\CurrentUser\My" `
             -NotAfter (Get-Date).AddDays(7)
 
+          $signTool = Get-ChildItem "C:/Program Files (x86)/Windows Kits/10/bin/*/x64/signtool.exe" -ErrorAction SilentlyContinue |
+            Sort-Object FullName -Descending |
+            Select-Object -First 1
+          if (-not $signTool) {
+            Write-Error "signtool.exe not found under Windows Kits"
+            exit 1
+          }
+
           $thumb = $cert.Thumbprint
           $msiFiles = Get-ChildItem -Path "packages/tray/src-tauri/target/$env:TARGET/release/bundle/msi" -Filter *.msi -Recurse
           if ($msiFiles.Count -eq 0) {
@@ -268,7 +286,7 @@ jobs:
           }
 
           foreach ($msi in $msiFiles) {
-            & signtool sign `
+            & $signTool.FullName sign `
               /sha1 "$thumb" `
               /s My `
               /fd SHA256 `


### PR DESCRIPTION
## Summary

Fixes the desktop release CI failures introduced after merging desktop packaging updates.

- macOS self-signed path now exports/imports PKCS12 with an explicit non-empty password
- windows signing steps now resolve `signtool.exe` from Windows Kits and invoke it by absolute path
- keeps HTTPS timestamping for official windows signing

## Why CI was failing

Observed in Desktop Build run:
- https://github.com/Signet-AI/signetai/actions/runs/23693598536

Failures:
1. **macOS self-signed build**
   - `security: SecKeychainItemImport: MAC verification failed during PKCS12 import (wrong password?)`
   - Root cause: PKCS12 export/import used blank password flow that fails on runner OpenSSL/security combo.
2. **windows self-signed signing**
   - `The term 'signtool' is not recognized ...`
   - Root cause: `signtool` is not guaranteed to be in PATH on `windows-latest`.

## Validation

- Verified failure signatures from the run logs above.
- Workflow updated to fail fast with explicit message if `signtool.exe` cannot be discovered.

## Spec alignment

- Existing approved spec remains accurate: `docs/specs/approved/desktop-packaging-distribution.md`.
- No contract/path/status changes needed.
