### PR TITLE
fix(tray): unblock macOS desktop CI after self-signing merge

### DIFF
--- a/packages/tray/src-tauri/src/platform/mod.rs
+++ b/packages/tray/src-tauri/src/platform/mod.rs
@@ -77,28 +77,16 @@ fn find_by_name(dir: &PathBuf, name: &str) -> Option<String> {
 pub fn find_bundled_daemon() -> Option<String> {
     let exe = std::env::current_exe().ok()?;
     let root = exe.parent()?;
-
-    #[cfg(target_os = "macos")]
-    {
-        let dirs = vec![
-            root.to_path_buf(),
-            root.join("../Resources"),
-        ];
-
-        for dir in dirs {
-            if let Some(path) = find_by_name(&dir, &preferred_name()) {
-                return Some(path);
-            }
-            if let Some(path) = find_by_name(&dir, &fallback_name()) {
-                return Some(path);
-            }
+    let dirs = {
+        #[cfg(target_os = "macos")]
+        {
+            vec![root.to_path_buf(), root.join("../Resources")]
         }
-
-        return None;
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    let dirs = vec![root.to_path_buf()];
+        #[cfg(not(target_os = "macos"))]
+        {
+            vec![root.to_path_buf()]
+        }
+    };
 
     for dir in dirs {
         if let Some(path) = find_by_name(&dir, &preferred_name()) {


### PR DESCRIPTION
## Summary

Fixes the macOS desktop CI failure introduced after the desktop signing changes were merged.

- rewrites `find_bundled_daemon()` directory selection to avoid cfg-scope leakage
- removes unreachable/invalid post-`return` path traversal logic
- keeps the same lookup contract: prefer target-specific sidecar name, then fallback name

## Failure this fixes

Desktop Build run for `v0.82.4` failed on both mac targets:
- https://github.com/Signet-AI/signetai/actions/runs/23694190828

Error:
- `error[E0423]: expected value, found crate 'dirs'`
- `packages/tray/src-tauri/src/platform/mod.rs`

## Validation

```bash
cd packages/tray/src-tauri
cargo check
```

Passes locally after this change.
