### PR TITLE
fix(tray): unblock desktop CI and linux AppImage runtime fallback

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -180,33 +180,9 @@ jobs:
           TARGET: ${{ matrix.target }}
         run: |
           set -euo pipefail
-          CERT_NAME="Signet Desktop Self-Signed"
-          TMP_DIR="${RUNNER_TEMP}/signet-selfsign"
-          KEYCHAIN="${RUNNER_TEMP}/signet-selfsign.keychain-db"
-          KEYCHAIN_PASS="signet-selfsign"
-          P12_PASS="signet-selfsign"
-          mkdir -p "${TMP_DIR}"
-
-          openssl req -x509 -newkey rsa:2048 \
-            -keyout "${TMP_DIR}/key.pem" \
-            -out "${TMP_DIR}/cert.pem" \
-            -days 7 -nodes \
-            -subj "/CN=${CERT_NAME}"
-
-          openssl pkcs12 -export \
-            -inkey "${TMP_DIR}/key.pem" \
-            -in "${TMP_DIR}/cert.pem" \
-            -out "${TMP_DIR}/cert.p12" \
-            -passout pass:"${P12_PASS}"
-
-          security create-keychain -p "${KEYCHAIN_PASS}" "${KEYCHAIN}"
-          security unlock-keychain -p "${KEYCHAIN_PASS}" "${KEYCHAIN}"
-          security import "${TMP_DIR}/cert.p12" -k "${KEYCHAIN}" -P "${P12_PASS}" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple: -s -k "${KEYCHAIN_PASS}" "${KEYCHAIN}"
-          security default-keychain -s "${KEYCHAIN}"
-          security list-keychains -d user -s "${KEYCHAIN}" $(security list-keychains -d user | tr -d '"')
-
-          export APPLE_SIGNING_IDENTITY="${CERT_NAME}"
+          # Use ad-hoc signing in CI when official Apple certs are unavailable.
+          # This keeps artifact generation deterministic without keychain state.
+          export APPLE_SIGNING_IDENTITY="-"
           cd packages/tray && bun tauri build --target "${TARGET}"
 
       - name: Sign Windows MSI artifacts (official certificate)

--- a/docs/TRAY.md
+++ b/docs/TRAY.md
@@ -70,17 +70,19 @@ Eleven Tauri commands are registered:
 A `DaemonManager` platform trait abstracts start/stop/is_running.
 All three platform managers are implemented.
 
-Start order prefers existing system-installed runtimes (`signet`,
-`signet-daemon`, or Bun+daemon script) for parity with current installs.
-If no system runtime is available, the tray falls back to a bundled
-daemon sidecar (`signet-daemon*`) shipped with the desktop app.
+Start order prefers an existing systemd user service when configured.
+Otherwise, the tray launches its bundled daemon sidecar
+(`signet-daemon*`) first so desktop builds stay self-contained. If the
+sidecar is unavailable, it falls back to system-installed runtimes
+(`signet`, `signet-daemon`, or Bun+daemon script).
 
 **Linux process management:**
 
 Start order: check for `~/.config/systemd/user/signet.service` — if
-present, use `systemctl --user start signet`. Otherwise: try installed
-`signet daemon start` first, then Bun-driven fallbacks
-(`signet-daemon`, `daemon.js`, `bun x signetai daemon start`).
+present, use `systemctl --user start signet`. Otherwise: launch bundled
+`signet-daemon*` first, then try installed `signet daemon start`, then
+Bun-driven fallbacks (`signet-daemon`, `daemon.js`,
+`bun x signetai daemon start`).
 
 Stop: send SIGTERM, poll at 100ms intervals up to 3 seconds, then clean
 up the PID file.

--- a/packages/tray/src-tauri/src/platform/linux.rs
+++ b/packages/tray/src-tauri/src/platform/linux.rs
@@ -100,6 +100,11 @@ impl DaemonManager for LinuxManager {
             return Ok(());
         }
 
+        if let Some(bin) = super::find_bundled_daemon() {
+            Command::new(&bin).spawn()?;
+            return Ok(());
+        }
+
         if let Some(signet) = self.find_signet_cli() {
             Command::new(&signet).args(["daemon", "start"]).spawn()?;
             return Ok(());
@@ -125,11 +130,6 @@ impl DaemonManager for LinuxManager {
             Command::new(&bun)
                 .args(["x", "signetai", "daemon", "start"])
                 .spawn()?;
-            return Ok(());
-        }
-
-        if let Some(bin) = super::find_bundled_daemon() {
-            Command::new(&bin).spawn()?;
             return Ok(());
         }
 


### PR DESCRIPTION
## Summary

This hotfix addresses two post-merge desktop regressions:

- macOS desktop CI no longer depends on ephemeral keychain cert import in fallback mode
  - self-signed fallback now uses ad-hoc identity (`APPLE_SIGNING_IDENTITY="-"`)
- Linux tray startup now prefers the bundled daemon sidecar before system `signet`/bun paths
  - avoids runtime coupling to host/node/OpenSSL mismatches in AppImage environments

## Incident details

Current release failures (v0.82.5):
- https://github.com/Signet-AI/signetai/actions/runs/23696127692
- macOS jobs fail at codesign with: `The specified item could not be found in the keychain.`

Reported runtime issue on Linux AppImage:
- `node ... libcrypto.so.3: version OPENSSL_3.2.0/3.4.0 not found`
- caused by launching host/system `signet` path before bundled sidecar.

## Validation

```bash
cd packages/tray/src-tauri
cargo check
```

## Docs/spec

- Updated `docs/TRAY.md` startup order to match implementation.
- No spec status/path changes required.
