### PR TITLE
fix(ci): macOS-safe desktop asset upload step

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -332,7 +332,10 @@ jobs:
         run: |
           set -euo pipefail
           ROOT="packages/tray/src-tauri/target/${{ matrix.target }}/release/bundle"
-          mapfile -t FILES < <(find "${ROOT}" -type f \( -name '*.dmg' -o -name '*.AppImage' -o -name '*.deb' -o -name '*.msi' \) | sort)
+          FILES=()
+          while IFS= read -r file; do
+            FILES+=("${file}")
+          done < <(find "${ROOT}" -type f \( -name '*.dmg' -o -name '*.AppImage' -o -name '*.deb' -o -name '*.msi' \) | sort)
 
           if [ "${#FILES[@]}" -eq 0 ]; then
             echo "::error::No desktop artifacts found to upload for target ${{ matrix.target }}"


### PR DESCRIPTION
## Summary

Fixes the release CI failure on macOS runners by replacing `mapfile`
with a POSIX-safe read loop when collecting release assets.

## Failure details

Run: https://github.com/Signet-AI/signetai/actions/runs/23698076910 (`v0.82.6`)

Error in macOS `Upload desktop release assets` step:
- `mapfile: command not found`
- exit code `127`

Root cause: GitHub macOS runner uses Bash 3.2, which does not provide `mapfile`.

## Change

- Replaced:
  - `mapfile -t FILES < <(...)`
- With:
  - `FILES=(); while IFS= read -r file; do FILES+=("$file"); done < <(...)`

This keeps behavior identical and works on Bash 3.2+.
