### PR TITLE
fix(daemon): preserve reranker score calibration + gate low-confidence prompt recalls

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -127,6 +127,11 @@ hooks:
     includeIdentity: true
     includeRecentContext: true
     recencyBias: 0.7
+  userPromptSubmit:
+    enabled: true
+    recallLimit: 10
+    maxInjectChars: 500
+    minScore: 0.8
   preCompaction:
     includeRecentMemories: true
     memoryLimit: 5
@@ -737,6 +742,11 @@ hooks:
     includeIdentity: true
     includeRecentContext: true
     recencyBias: 0.7
+  userPromptSubmit:
+    enabled: true
+    recallLimit: 10
+    maxInjectChars: 500
+    minScore: 0.8
   preCompaction:
     includeRecentMemories: true
     memoryLimit: 5
@@ -761,6 +771,15 @@ a pre-compaction summary:
 | `includeRecentMemories` | `true` | Include recent memories in the prompt |
 | `memoryLimit` | `5` | How many recent memories to include |
 | `summaryGuidelines` | built-in | Custom instructions for session summary |
+
+`hooks.userPromptSubmit` controls per-prompt memory injection:
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `enabled` | `true` | Enable per-prompt recall injection |
+| `recallLimit` | `10` | Max recall candidates considered |
+| `maxInjectChars` | `500` | Prompt-time injection character budget |
+| `minScore` | `0.8` | Minimum top recall score required before injecting memories |
 
 
 Environment Variables

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -717,6 +717,7 @@ Legend:
 | `release-train-cadence` | planning | `docs/specs/planning/release-train-cadence.md` | `memory-pipeline-v2` | - | Stub: predictable release train model |
 | `post-merge-canary-suite` | planning | `docs/specs/planning/post-merge-canary-suite.md` | `release-train-cadence` | - | Stub: lightweight post-merge canaries |
 | `incident-guardrail-loop` | planning | `docs/specs/planning/incident-guardrail-loop.md` | `ci-contract-invariants-lane` | - | Stub: every incident adds durable guardrail |
+| `recall-confidence-gate` | complete | - | `memory-pipeline-v2` | - | Bug fix: preserve reranker-calibrated scores in hybridRecall (not rank-position placeholders); add `hooks.userPromptSubmit.minScore` gate (default 0.8) to filter low-confidence prompt recalls; daemon-rs parity via importance proxy + `HooksConfig` struct. PR #396. |
 | `competitive-systems-research` | reference | `docs/research/technical/RESEARCH-COMPETITIVE-SYSTEMS.md` | - | - | Informs desire-paths-epic, retroactive-supersession, ontology-evolution-core |
 
 ---

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -717,7 +717,7 @@ Legend:
 | `release-train-cadence` | planning | `docs/specs/planning/release-train-cadence.md` | `memory-pipeline-v2` | - | Stub: predictable release train model |
 | `post-merge-canary-suite` | planning | `docs/specs/planning/post-merge-canary-suite.md` | `release-train-cadence` | - | Stub: lightweight post-merge canaries |
 | `incident-guardrail-loop` | planning | `docs/specs/planning/incident-guardrail-loop.md` | `ci-contract-invariants-lane` | - | Stub: every incident adds durable guardrail |
-| `recall-confidence-gate` | complete | - | `memory-pipeline-v2` | - | Bug fix: preserve reranker-calibrated scores in hybridRecall (not rank-position placeholders); add `hooks.userPromptSubmit.minScore` gate (default 0.8) to filter low-confidence prompt recalls. daemon-rs gets `HooksConfig`/`UserPromptSubmitHookConfig` for config contract parity; behavioral gate deferred until daemon-rs prompt_submit integrates calibrated hybrid scoring. PR #396. |
+| `recall-confidence-gate` | complete | - | `memory-pipeline-v2` | - | Bug fix: preserve reranker-calibrated scores in hybridRecall (not rank-position placeholders); add `hooks.userPromptSubmit.minScore` gate (default 0.8). daemon-rs mirrors gate via term-coverage proxy (matched_terms/total_terms); full hybrid scoring parity to replace proxy in a follow-up. PR #396. |
 | `competitive-systems-research` | reference | `docs/research/technical/RESEARCH-COMPETITIVE-SYSTEMS.md` | - | - | Informs desire-paths-epic, retroactive-supersession, ontology-evolution-core |
 
 ---

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -717,7 +717,7 @@ Legend:
 | `release-train-cadence` | planning | `docs/specs/planning/release-train-cadence.md` | `memory-pipeline-v2` | - | Stub: predictable release train model |
 | `post-merge-canary-suite` | planning | `docs/specs/planning/post-merge-canary-suite.md` | `release-train-cadence` | - | Stub: lightweight post-merge canaries |
 | `incident-guardrail-loop` | planning | `docs/specs/planning/incident-guardrail-loop.md` | `ci-contract-invariants-lane` | - | Stub: every incident adds durable guardrail |
-| `recall-confidence-gate` | complete | - | `memory-pipeline-v2` | - | Bug fix: preserve reranker-calibrated scores in hybridRecall (not rank-position placeholders); add `hooks.userPromptSubmit.minScore` gate (default 0.8) to filter low-confidence prompt recalls; daemon-rs parity via importance proxy + `HooksConfig` struct. PR #396. |
+| `recall-confidence-gate` | complete | - | `memory-pipeline-v2` | - | Bug fix: preserve reranker-calibrated scores in hybridRecall (not rank-position placeholders); add `hooks.userPromptSubmit.minScore` gate (default 0.8) to filter low-confidence prompt recalls. daemon-rs gets `HooksConfig`/`UserPromptSubmitHookConfig` for config contract parity; behavioral gate deferred until daemon-rs prompt_submit integrates calibrated hybrid scoring. PR #396. |
 | `competitive-systems-research` | reference | `docs/research/technical/RESEARCH-COMPETITIVE-SYSTEMS.md` | - | - | Informs desire-paths-epic, retroactive-supersession, ontology-evolution-core |
 
 ---

--- a/docs/specs/dependencies.yaml
+++ b/docs/specs/dependencies.yaml
@@ -993,6 +993,20 @@ specs:
       - "Every production incident produces at least one durable AGENTS/CI guardrail update"
     decision: null
 
+  - id: recall-confidence-gate
+    status: complete
+    path: null
+    hard_depends_on:
+      - memory-pipeline-v2
+    soft_depends_on: []
+    blocks: []
+    informed_by: []
+    success_criteria:
+      - "hybridRecall preserves reranker-calibrated scores instead of synthesizing from rank position"
+      - "userPromptSubmit injects only memories with top score >= hooks.userPromptSubmit.minScore (default 0.8)"
+      - "daemon-rs mirrors the gate using importance as a confidence proxy and exposes HooksConfig in AgentManifest"
+    decision: "Targeted bug fix + config surface. No dedicated spec file. PR #396."
+
   - id: docker-self-hosting-stack
     status: planning
     path: docs/specs/planning/docker-self-hosting-stack.md

--- a/docs/specs/dependencies.yaml
+++ b/docs/specs/dependencies.yaml
@@ -1004,8 +1004,7 @@ specs:
     success_criteria:
       - "hybridRecall preserves reranker-calibrated scores instead of synthesizing from rank position"
       - "userPromptSubmit injects only memories with top score >= hooks.userPromptSubmit.minScore (default 0.8)"
-      - "daemon-rs exposes HooksConfig + UserPromptSubmitHookConfig for config contract parity"
-      - "daemon-rs behavioral gate deferred until prompt_submit integrates calibrated hybrid scoring (importance is not a query-relevance proxy)"
+      - "daemon-rs mirrors gate via term-coverage proxy (matched_terms/total_terms) until full hybrid scoring lands"
     decision: "Targeted bug fix + config surface. No dedicated spec file. PR #396."
 
   - id: docker-self-hosting-stack

--- a/docs/specs/dependencies.yaml
+++ b/docs/specs/dependencies.yaml
@@ -1004,7 +1004,8 @@ specs:
     success_criteria:
       - "hybridRecall preserves reranker-calibrated scores instead of synthesizing from rank position"
       - "userPromptSubmit injects only memories with top score >= hooks.userPromptSubmit.minScore (default 0.8)"
-      - "daemon-rs mirrors the gate using importance as a confidence proxy and exposes HooksConfig in AgentManifest"
+      - "daemon-rs exposes HooksConfig + UserPromptSubmitHookConfig for config contract parity"
+      - "daemon-rs behavioral gate deferred until prompt_submit integrates calibrated hybrid scoring (importance is not a query-relevance proxy)"
     decision: "Targeted bug fix + config surface. No dedicated spec file. PR #396."
 
   - id: docker-self-hosting-stack

--- a/packages/daemon-rs/contracts/parity-rules.json
+++ b/packages/daemon-rs/contracts/parity-rules.json
@@ -117,7 +117,7 @@
 			"POST /api/hooks/user-prompt-submit": {
 				"deterministic": ["injections"],
 				"ignoreFields": [],
-				"note": "TS path applies a calibrated hybridRecall minScore gate (hooks.userPromptSubmit.minScore, default 0.8); daemon-rs prompt_submit path uses LIKE matching without calibrated scoring, so the behavioral gate is deferred until hybrid scoring lands there. Config struct HooksConfig is present for contract surface parity."
+				"note": "TS path gates on calibrated hybridRecall score; daemon-rs path gates on term-coverage (matched_needles/total_needles). Both respect hooks.userPromptSubmit.minScore (default 0.8). Score semantics differ: update this note when daemon-rs integrates full hybrid scoring."
 			},
 			"POST /api/hooks/session-end": {
 				"deterministic": ["status"],

--- a/packages/daemon-rs/contracts/parity-rules.json
+++ b/packages/daemon-rs/contracts/parity-rules.json
@@ -115,9 +115,9 @@
 				"note": "Injections content must match semantically"
 			},
 			"POST /api/hooks/user-prompt-submit": {
-				"deterministic": ["injections"],
-				"ignoreFields": [],
-				"note": "TS path gates on calibrated hybridRecall score; daemon-rs path gates on term-coverage (matched_needles/total_needles). Both respect hooks.userPromptSubmit.minScore (default 0.8). Score semantics differ: update this note when daemon-rs integrates full hybrid scoring."
+				"deterministic": [],
+				"ignoreFields": ["inject", "injections"],
+				"note": "TS gates on calibrated hybridRecall score; daemon-rs gates on term-coverage proxy. Both respect hooks.userPromptSubmit.minScore (default 0.8) but may inject different sets, so inject content is excluded from deterministic comparison until Rust integrates full hybrid scoring. Re-enable when scoring paths unify."
 			},
 			"POST /api/hooks/session-end": {
 				"deterministic": ["status"],

--- a/packages/daemon-rs/contracts/parity-rules.json
+++ b/packages/daemon-rs/contracts/parity-rules.json
@@ -116,7 +116,8 @@
 			},
 			"POST /api/hooks/user-prompt-submit": {
 				"deterministic": ["injections"],
-				"ignoreFields": []
+				"ignoreFields": [],
+				"note": "TS path applies a calibrated hybridRecall minScore gate (hooks.userPromptSubmit.minScore, default 0.8); daemon-rs prompt_submit path uses LIKE matching without calibrated scoring, so the behavioral gate is deferred until hybrid scoring lands there. Config struct HooksConfig is present for contract surface parity."
 			},
 			"POST /api/hooks/session-end": {
 				"deterministic": ["status"],

--- a/packages/daemon-rs/crates/signet-core/src/config.rs
+++ b/packages/daemon-rs/crates/signet-core/src/config.rs
@@ -516,6 +516,37 @@ pub struct AgentManifest {
     pub capabilities: Option<Vec<String>>,
     #[serde(rename = "harnessCompatibility")]
     pub harness_compatibility: Option<Vec<String>>,
+    pub hooks: Option<HooksConfig>,
+}
+
+/// Per-hook configuration surfaced in `agent.yaml` under the `hooks` key.
+/// Mirrors the TypeScript `HooksConfig` in `packages/daemon/src/hooks.ts`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct HooksConfig {
+    pub user_prompt_submit: UserPromptSubmitHookConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct UserPromptSubmitHookConfig {
+    pub enabled: bool,
+    pub recall_limit: usize,
+    pub max_inject_chars: usize,
+    /// Minimum confidence score required to inject memories at prompt time.
+    /// Clamped to [0, 1]. Default 0.8 — mirrors TS `hooks.userPromptSubmit.minScore`.
+    pub min_score: f64,
+}
+
+impl Default for UserPromptSubmitHookConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            recall_limit: 10,
+            max_inject_chars: 500,
+            min_score: 0.8,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -445,17 +445,6 @@ pub async fn prompt_submit(
         .clone()
         .unwrap_or_else(|| "default".to_string());
     let query_terms_for_resp = query_terms.clone();
-    // Mirror TS hooks.userPromptSubmit.minScore: only inject when top result
-    // confidence meets the threshold. Uses importance as a proxy until full
-    // hybrid scoring lands in the Rust prompt_submit path.
-    let min_score = state
-        .config
-        .manifest
-        .hooks
-        .as_ref()
-        .map(|h| h.user_prompt_submit.min_score)
-        .unwrap_or(0.8)
-        .clamp(0.0, 1.0);
 
     let result = state
         .pool
@@ -478,11 +467,13 @@ pub async fn prompt_submit(
                 .collect::<Vec<_>>();
 
             // 1) Structured recall from memories (best effort parity with TS hybrid-first path).
-            // importance is fetched as a proxy confidence score for the minScore gate.
-            // NOTE: when full hybrid scoring / reranker integration lands, replace importance
-            // with the actual calibrated relevance score — never synthesize from rank position.
+            // NOTE: the TS path gates injection on a calibrated hybridRecall relevance score
+            // (hooks.userPromptSubmit.minScore). That gate is deferred here until this path
+            // integrates full hybrid scoring — importance is not a per-query relevance proxy.
+            // When reranker/hybrid scoring lands, preserve actual scores; never synthesize
+            // from rank position.
             let mut mem_sql = String::from(
-                "SELECT id, content, created_at, importance
+                "SELECT id, content, created_at
                  FROM memories
                  WHERE deleted = 0",
             );
@@ -551,7 +542,6 @@ pub async fn prompt_submit(
                             row.get::<_, String>(0)?,
                             row.get::<_, String>(1)?,
                             row.get::<_, String>(2)?,
-                            row.get::<_, f64>(3).unwrap_or(0.0),
                         ))
                     })
                     .ok()
@@ -565,15 +555,13 @@ pub async fn prompt_submit(
                 && !mem_rows
                     .iter()
                     .take(8)
-                    .map(|(_, content, _, _)| content.to_lowercase())
+                    .map(|(_, content, _)| content.to_lowercase())
                     .any(|content| anchors.iter().any(|anchor| content.contains(anchor)));
 
-            // Confidence gate: mirror TS topScore < minScore → return memoryCount: 0.
-            let top_importance = mem_rows.first().map(|(_, _, _, imp)| *imp).unwrap_or(0.0);
-            if !mem_rows.is_empty() && !anchor_missed && top_importance >= min_score {
+            if !mem_rows.is_empty() && !anchor_missed {
                 let lines = mem_rows
                     .iter()
-                    .map(|(_, content, created_at, _)| {
+                    .map(|(_, content, created_at)| {
                         format!("- {} ({})", trim_for_inject(content, 300), created_at)
                     })
                     .collect::<Vec<_>>();

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -445,6 +445,17 @@ pub async fn prompt_submit(
         .clone()
         .unwrap_or_else(|| "default".to_string());
     let query_terms_for_resp = query_terms.clone();
+    // Mirror TS hooks.userPromptSubmit.minScore: only inject when top result
+    // confidence meets the threshold. Uses importance as a proxy until full
+    // hybrid scoring lands in the Rust prompt_submit path.
+    let min_score = state
+        .config
+        .manifest
+        .hooks
+        .as_ref()
+        .map(|h| h.user_prompt_submit.min_score)
+        .unwrap_or(0.8)
+        .clamp(0.0, 1.0);
 
     let result = state
         .pool
@@ -467,8 +478,11 @@ pub async fn prompt_submit(
                 .collect::<Vec<_>>();
 
             // 1) Structured recall from memories (best effort parity with TS hybrid-first path).
+            // importance is fetched as a proxy confidence score for the minScore gate.
+            // NOTE: when full hybrid scoring / reranker integration lands, replace importance
+            // with the actual calibrated relevance score — never synthesize from rank position.
             let mut mem_sql = String::from(
-                "SELECT id, content, created_at
+                "SELECT id, content, created_at, importance
                  FROM memories
                  WHERE deleted = 0",
             );
@@ -537,6 +551,7 @@ pub async fn prompt_submit(
                             row.get::<_, String>(0)?,
                             row.get::<_, String>(1)?,
                             row.get::<_, String>(2)?,
+                            row.get::<_, f64>(3).unwrap_or(0.0),
                         ))
                     })
                     .ok()
@@ -550,13 +565,15 @@ pub async fn prompt_submit(
                 && !mem_rows
                     .iter()
                     .take(8)
-                    .map(|(_, content, _)| content.to_lowercase())
+                    .map(|(_, content, _, _)| content.to_lowercase())
                     .any(|content| anchors.iter().any(|anchor| content.contains(anchor)));
 
-            if !mem_rows.is_empty() && !anchor_missed {
+            // Confidence gate: mirror TS topScore < minScore → return memoryCount: 0.
+            let top_importance = mem_rows.first().map(|(_, _, _, imp)| *imp).unwrap_or(0.0);
+            if !mem_rows.is_empty() && !anchor_missed && top_importance >= min_score {
                 let lines = mem_rows
                     .iter()
-                    .map(|(_, content, created_at)| {
+                    .map(|(_, content, created_at, _)| {
                         format!("- {} ({})", trim_for_inject(content, 300), created_at)
                     })
                     .collect::<Vec<_>>();

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -445,6 +445,18 @@ pub async fn prompt_submit(
         .clone()
         .unwrap_or_else(|| "default".to_string());
     let query_terms_for_resp = query_terms.clone();
+    // Mirror TS hooks.userPromptSubmit.minScore confidence gate. The TS path
+    // uses calibrated hybridRecall + reranker scores; here we use term-coverage
+    // (matched_terms / total_terms) as a query-relevance proxy until the Rust
+    // prompt_submit path integrates full hybrid scoring.
+    let min_score = state
+        .config
+        .manifest
+        .hooks
+        .as_ref()
+        .map(|h| h.user_prompt_submit.min_score)
+        .unwrap_or(0.8)
+        .clamp(0.0, 1.0);
 
     let result = state
         .pool
@@ -467,11 +479,8 @@ pub async fn prompt_submit(
                 .collect::<Vec<_>>();
 
             // 1) Structured recall from memories (best effort parity with TS hybrid-first path).
-            // NOTE: the TS path gates injection on a calibrated hybridRecall relevance score
-            // (hooks.userPromptSubmit.minScore). That gate is deferred here until this path
-            // integrates full hybrid scoring — importance is not a per-query relevance proxy.
-            // When reranker/hybrid scoring lands, preserve actual scores; never synthesize
-            // from rank position.
+            // NOTE: when full hybrid scoring / reranker integration lands, preserve actual
+            // calibrated scores from the reranker — never synthesize from rank position.
             let mut mem_sql = String::from(
                 "SELECT id, content, created_at
                  FROM memories
@@ -558,7 +567,19 @@ pub async fn prompt_submit(
                     .map(|(_, content, _)| content.to_lowercase())
                     .any(|content| anchors.iter().any(|anchor| content.contains(anchor)));
 
-            if !mem_rows.is_empty() && !anchor_missed {
+            // Confidence gate: compute term-coverage for the top result as a
+            // query-relevance proxy (matched_needles / total_needles → [0, 1]).
+            // Replaces the TS calibrated hybridRecall score until full hybrid
+            // scoring lands in this path.
+            let coverage = if !mem_rows.is_empty() && !needles.is_empty() {
+                let top = mem_rows[0].1.to_lowercase();
+                let matched = needles.iter().filter(|n| top.contains(n.as_str())).count();
+                matched as f64 / needles.len() as f64
+            } else {
+                0.0
+            };
+
+            if !mem_rows.is_empty() && !anchor_missed && coverage >= min_score {
                 let lines = mem_rows
                     .iter()
                     .map(|(_, content, created_at)| {

--- a/packages/daemon/src/hooks.prompt-submit.test.ts
+++ b/packages/daemon/src/hooks.prompt-submit.test.ts
@@ -74,6 +74,9 @@ mock.module("./temporal-fallback", () => ({
 }));
 
 mock.module("./session-transcripts", () => ({
+	getSessionTranscriptContent() {
+		return "";
+	},
 	searchTranscriptFallback: searchTranscriptFallbackMock,
 	upsertSessionTranscript() {},
 }));
@@ -195,5 +198,32 @@ describe("handleUserPromptSubmit observability", () => {
 		const payload = submitCalls[0]?.[2];
 		expect(payload?.engine).toBe("transcript-fallback");
 		expect(payload?.memoryCount).toBe(1);
+	});
+
+	it("skips prompt-submit injection when top recall score is below confidence gate", async () => {
+		hybridRecallMock.mockResolvedValueOnce({
+			results: [
+				{
+					id: "mem-low",
+					score: 0.69,
+					content: "weakly related memory",
+					created_at: "2026-03-26T20:10:00.000Z",
+				},
+			],
+		});
+
+		const result = await handleUserPromptSubmit({
+			harness: "vscode-custom-agent",
+			userMessage: "show memory confidence behavior",
+			sessionKey: "session-low-confidence",
+		});
+
+		expect(result.memoryCount).toBe(0);
+		expect(result.inject).toContain("Current Date & Time");
+		expect(result.inject).not.toContain("[signet:recall");
+		const submitCalls = infoMock.mock.calls.filter((call) => call[1] === "User prompt submit");
+		expect(submitCalls).toHaveLength(1);
+		const payload = submitCalls[0]?.[2];
+		expect(payload?.engine).toBe("low-confidence");
 	});
 });

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -174,6 +174,8 @@ export interface HooksConfig {
 		enabled?: boolean;
 		recallLimit?: number;
 		maxInjectChars?: number;
+		/** Minimum top recall score required before injecting memories. */
+		minScore?: number;
 	};
 	preCompaction?: {
 		summaryGuidelines?: string;
@@ -1193,6 +1195,7 @@ function getDefaultConfig(): HooksConfig {
 			enabled: true,
 			recallLimit: 10,
 			maxInjectChars: 500,
+			minScore: 0.8,
 		},
 		preCompaction: {
 			summaryGuidelines: `Summarize this session focusing on:
@@ -1207,6 +1210,11 @@ Keep the summary concise but complete. Use first person from the agent's perspec
 			memoryLimit: 5,
 		},
 	};
+}
+
+function resolveUserPromptMinScore(value: number | undefined): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) return 0.8;
+	return Math.max(0, Math.min(1, value));
 }
 
 // ============================================================================
@@ -2481,6 +2489,7 @@ export async function handleUserPromptSubmit(req: UserPromptSubmitRequest): Prom
 		const cfg = loadMemoryConfig(AGENTS_DIR);
 		const recallLimit = submitCfg.recallLimit ?? 10;
 		const injectBudget = submitCfg.maxInjectChars ?? cfg.pipelineV2.guardrails.contextBudgetChars;
+		const minScore = resolveUserPromptMinScore(submitCfg.minScore);
 		const queryTerms = vectorQuery.slice(0, 80);
 		const recall = await hybridRecall(
 			{
@@ -2497,7 +2506,8 @@ export async function handleUserPromptSubmit(req: UserPromptSubmitRequest): Prom
 			fetchEmbedding,
 		);
 
-		const topScore = recall.results[0]?.score;
+		const topRaw = recall.results[0]?.score;
+		const topScore = typeof topRaw === "number" ? clampScore01(topRaw) : undefined;
 		const noStructured = recall.results.length === 0 || typeof topScore !== "number" || topScore < 0.4;
 		// Anchor checks must be driven by the current user turn text, not any
 		// expanded/derived recall query shape.
@@ -2546,6 +2556,19 @@ export async function handleUserPromptSubmit(req: UserPromptSubmitRequest): Prom
 					"no-structured",
 				);
 			}
+		}
+		if (typeof topScore !== "number" || topScore < minScore) {
+			return finalizeUserPromptSubmitSuccess(
+				req,
+				userMessage,
+				start,
+				{
+					inject: metadataHeader,
+					memoryCount: 0,
+					warnings,
+				},
+				"low-confidence",
+			);
 		}
 
 		const mapped = recall.results.map((result) => ({

--- a/packages/daemon/src/memory-search.test.ts
+++ b/packages/daemon/src/memory-search.test.ts
@@ -69,4 +69,50 @@ describe("hybridRecall", () => {
 		expect(result.sources?.["sess-shared"]).toBe("agent-a transcript context");
 		expect(Object.values(result.sources ?? {})).not.toContain("agent-b transcript context");
 	});
+
+	it("keeps score calibration stable when reranker provider is noop", async () => {
+		const now = new Date().toISOString();
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, type, source_id, agent_id, created_at, updated_at, updated_by
+				) VALUES (?, ?, 'fact', ?, ?, ?, ?, 'test')`,
+			).run("mem-a", "deploy rollback checklist release", "sess-a", "default", now, now);
+
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, type, source_id, agent_id, created_at, updated_at, updated_by
+				) VALUES (?, ?, 'fact', ?, ?, ?, ?, 'test')`,
+			).run("mem-b", "deploy checklist", "sess-a", "default", now, now);
+		});
+
+		const base = loadMemoryConfig(dir);
+		base.search.rehearsal_enabled = false;
+		base.search.min_score = 0;
+		base.pipelineV2.graph.enabled = false;
+		base.pipelineV2.traversal.enabled = false;
+		base.pipelineV2.reranker.enabled = false;
+
+		const withReranker = loadMemoryConfig(dir);
+		withReranker.search.rehearsal_enabled = false;
+		withReranker.search.min_score = 0;
+		withReranker.pipelineV2.graph.enabled = false;
+		withReranker.pipelineV2.traversal.enabled = false;
+		withReranker.pipelineV2.reranker.enabled = true;
+		withReranker.pipelineV2.reranker.topN = 10;
+
+		const params = {
+			query: "deploy rollback checklist release",
+			keywordQuery: "deploy rollback checklist release",
+			limit: 5,
+			agentId: "default",
+			readPolicy: "isolated",
+		} as const;
+
+		const before = await hybridRecall(params, base, async () => null);
+		const after = await hybridRecall(params, withReranker, async () => null);
+
+		expect(after.results.map((row) => row.id)).toEqual(before.results.map((row) => row.id));
+		expect(after.results.map((row) => row.score)).toEqual(before.results.map((row) => row.score));
+	});
 });

--- a/packages/daemon/src/memory-search.ts
+++ b/packages/daemon/src/memory-search.ts
@@ -697,13 +697,13 @@ export async function hybridRecall(
 				timeoutMs: cfg.pipelineV2.reranker.timeoutMs,
 				model: cfg.pipelineV2.reranker.model,
 			});
-			// Update scores from reranked results
-			const rerankedMap = new Map(reranked.map((r, i) => [r.id, i]));
+			// Update scores from reranked results without collapsing calibrated
+			// relevance into rank-position placeholders.
+			const rerankedMap = new Map(reranked.map((row) => [row.id, row.score]));
 			for (const s of scored) {
-				const idx = rerankedMap.get(s.id);
-				if (idx !== undefined) {
-					// Preserve relative order from reranker
-					s.score = 1 - idx / reranked.length;
+				const score = rerankedMap.get(s.id);
+				if (typeof score === "number" && Number.isFinite(score)) {
+					s.score = score;
 				}
 			}
 			scored.sort((a, b) => b.score - a.score);


### PR DESCRIPTION
## Summary
- preserve reranker-calibrated scores instead of rewriting scores from rank position
- add strict userPromptSubmit confidence gate before memory injection
- clamp prompt-submit top score to [0..1] before applying gate
- add `hooks.userPromptSubmit.minScore` config (default `0.8`) and document it
- add regression coverage for reranker score stability and low-confidence gate behavior

## Problem
Prompt-time memory surfacing could look overconfident because reranker rank position was converted into synthetic high scores. This made confidence gating unreliable and let weak recalls surface too often.

## Scope
In scope:
- daemon recall reranker score handling
- userPromptSubmit confidence gating
- docs + targeted regression tests

Out of scope:
- replacing embedding reranker provider with a cross-encoder
- broader retrieval architecture changes

## Test plan
- `bun test packages/daemon/src/memory-search.test.ts`
- `bun test packages/daemon/src/hooks.prompt-submit.test.ts`

## Risk
Low to moderate. This changes recall ranking and prompt-time injection gating behavior. Main risk is being too strict on recall injection for some prompts.

## Rollback
Revert this PR to restore previous reranker scoring behavior and prompt-submit gating defaults.
