### PR TITLE
fix(runtime): harden hook and dashboard upgrade regressions

### DIFF
--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -663,6 +663,7 @@ Legend:
 | `signet-runtime` | approved | `docs/specs/approved/signet-runtime.md` | `memory-pipeline-v2` | - | |
 | `pipeline-pause-control` | complete | `docs/specs/complete/pipeline-pause-control.md` | `memory-pipeline-v2` | - | CLI and dashboard pause/resume shipped on top of live daemon pause/resume API, paused-mode observability, and local Ollama unload |
 | `daemon-startup-responsiveness` | planning | `docs/specs/planning/daemon-startup-responsiveness.md` | `memory-pipeline-v2` | - | Incident-driven stub for issue #331: keep /health responsive during large-db startup recovery and recover stale managed daemon processes cleanly |
+| `runtime-upgrade-regression-hardening` | planning | `docs/specs/planning/runtime-upgrade-regression-hardening.md` | `signet-runtime` | - | Incident-driven stub for the March 29, 2026 `0.83.0` → `0.85.3` runtime regressions: hook transport wiring and dashboard publish contract hardening |
 | `daemon-provider-fallback-status` | complete | `docs/specs/complete/daemon-provider-fallback-status.md` | `memory-pipeline-v2` | - | Issue #320 complete: extraction fallback/block state now persists in status surfaces with explicit fallbackProvider control and startup dead-lettering on hard block |
 | `daemon-refactor` | planning | `docs/specs/planning/daemon-refactor.md` | - | `daemon-refactor-plan` | |
 | `daemon-refactor-plan` | planning | `docs/specs/planning/daemon-refactor-plan.md` | `daemon-refactor` | - | |

--- a/docs/specs/dependencies.yaml
+++ b/docs/specs/dependencies.yaml
@@ -224,6 +224,20 @@ specs:
       - "CLI start/restart can recover from a stale managed daemon process that still owns the port after health probes fail"
     decision: null
 
+  - id: runtime-upgrade-regression-hardening
+    status: planning
+    path: docs/specs/planning/runtime-upgrade-regression-hardening.md
+    hard_depends_on:
+      - signet-runtime
+    soft_depends_on: []
+    blocks: []
+    informed_by: []
+    success_criteria:
+      - "CLI hook commands continue to reach daemon hook endpoints after runtime transport refactors"
+      - "Published daemon-bearing packages always include the bundled dashboard assets required for `/` to serve the UI"
+      - "Regression tests fail when `npm pack --dry-run` for `@signet/daemon` or `signetai` omits `dashboard/index.html`"
+    decision: null
+
   - id: daemon-provider-fallback-status
     status: complete
     path: docs/specs/complete/daemon-provider-fallback-status.md

--- a/docs/specs/planning/runtime-upgrade-regression-hardening.md
+++ b/docs/specs/planning/runtime-upgrade-regression-hardening.md
@@ -1,0 +1,67 @@
+---
+title: "Runtime Upgrade Regression Hardening"
+id: runtime-upgrade-regression-hardening
+status: planning
+informed_by: []
+section: "Runtime"
+depends_on:
+  - "signet-runtime"
+success_criteria:
+  - "CLI hook commands continue to reach daemon hook endpoints after runtime transport refactors"
+  - "Published daemon-bearing packages always include the bundled dashboard assets required for `/` to serve the UI"
+  - "Regression tests fail when `npm pack --dry-run` for `@signet/daemon` or `signetai` omits `dashboard/index.html`"
+scope_boundary: "Hook transport wiring and dashboard packaging guardrails only; does not redesign the runtime or dashboard app"
+draft_quality: "incident-driven planning stub"
+---
+
+# Runtime Upgrade Regression Hardening
+
+## Problem
+
+The March 29, 2026 upgrade path from `0.83.0` to `0.85.3` exposed two
+runtime regressions at once:
+
+1. `signet hook user-prompt-submit` could lose access to the daemon client
+   function it needed after the hook transport refactor.
+2. `@signet/daemon` package publishes could omit the bundled dashboard
+   entirely, leaving the daemon in API-only mode even though the runtime
+   expected dashboard assets to exist.
+
+Both failures broke core runtime surfaces immediately after upgrade and both
+escaped because the build and test contracts were too implicit.
+
+## Goals
+
+1. Keep CLI hook commands stable across daemon transport refactors.
+2. Make dashboard bundling an explicit publish-time contract for every
+   daemon-bearing package.
+3. Add regression checks that fail before publish when either contract drifts.
+
+## Proposed guardrails
+
+### 1) Hook transport contract
+
+Hook commands should depend on a single daemon fetch contract where possible.
+If session-start needs richer failure classification, the remaining hook
+commands must either use the same transport or be covered by an integration
+test that proves registration still provides the required client methods.
+
+### 2) Dashboard publish contract
+
+Any package that ships a daemon entrypoint and claims to serve the dashboard
+must build and copy dashboard assets as part of its own build pipeline. Silent
+"dashboard not built yet" success paths are not acceptable for publish flows.
+
+### 3) Pack-time regression checks
+
+`npm pack --dry-run --json` becomes the package-level source of truth for this
+incident class. Regression tests should assert that `dashboard/index.html` is
+present in the tarball for `@signet/daemon` and `signetai`.
+
+## Validation
+
+- Hook command regression tests prove `user-prompt-submit` still reaches the
+  daemon and prints returned injection content.
+- Package regression tests prove both daemon-bearing tarballs include
+  `dashboard/index.html`.
+- Build scripts fail fast when the dashboard bundle cannot be built or copied.

--- a/packages/cli/src/commands/hook.test.ts
+++ b/packages/cli/src/commands/hook.test.ts
@@ -1,13 +1,21 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { Command } from "commander";
 import {
-	buildSessionStartFallback,
 	buildCompactionCompleteBody,
 	buildSessionEndBody,
+	buildSessionStartFallback,
 	buildUserPromptSubmitBody,
 	pickSessionKey,
+	registerHookCommands,
 	resolveSessionStartTimeout,
 	shouldReadCompactionInput,
 } from "./hook";
+
+const prevLog = console.log;
+
+afterEach(() => {
+	console.log = prevLog;
+});
 
 describe("pickSessionKey", () => {
 	test("prefers canonical sessionKey fields before legacy session_id aliases", () => {
@@ -145,6 +153,39 @@ describe("buildUserPromptSubmitBody", () => {
 			transcript: "user: hi",
 			lastAssistantMessage: "prior answer",
 		});
+	});
+
+	test("hook command uses daemon result transport for user-prompt-submit", async () => {
+		const seen: Array<{ path: string; body: string }> = [];
+		const lines: string[] = [];
+		console.log = (line?: unknown) => {
+			lines.push(String(line ?? ""));
+		};
+
+		const program = new Command();
+		registerHookCommands(program, {
+			AGENTS_DIR: "/tmp/agents",
+			fetchDaemonResult: async (path, opts) => {
+				seen.push({
+					path,
+					body: typeof opts?.body === "string" ? opts.body : "",
+				});
+				return {
+					ok: true,
+					data: {
+						inject: "recalled context",
+					},
+				};
+			},
+			readStaticIdentity: () => null,
+		});
+
+		await program.parseAsync(["node", "test", "hook", "user-prompt-submit", "-H", "claude-code"]);
+
+		expect(seen).toHaveLength(1);
+		expect(seen[0]?.path).toBe("/api/hooks/user-prompt-submit");
+		expect(seen[0]?.body).toContain('"harness":"claude-code"');
+		expect(lines).toContain("recalled context");
 	});
 });
 

--- a/packages/cli/src/commands/hook.ts
+++ b/packages/cli/src/commands/hook.ts
@@ -1,9 +1,6 @@
+import { STATIC_IDENTITY_SESSION_START_TIMEOUT_STATUS, resolveSessionStartTimeoutMs } from "@signet/core";
 import chalk from "chalk";
 import type { Command } from "commander";
-import {
-	resolveSessionStartTimeoutMs,
-	STATIC_IDENTITY_SESSION_START_TIMEOUT_STATUS,
-} from "@signet/core";
 import type { DaemonFetchResult } from "../lib/daemon.js";
 
 interface HookDeps {
@@ -37,6 +34,37 @@ export function buildSessionStartFallback(
 	}
 	// offline, http error, invalid-json — all degrade to static identity
 	return readStaticIdentity(agentsDir);
+}
+
+function formatHookFailure(
+	name: string,
+	res: {
+		readonly reason: "offline" | "timeout" | "http" | "invalid-json";
+		readonly status?: number;
+	},
+): string {
+	if (res.reason === "http") {
+		return `[signet] daemon ${name} failed with HTTP ${res.status ?? "unknown"}, hook skipped\n`;
+	}
+	if (res.reason === "invalid-json") {
+		return `[signet] daemon ${name} returned invalid JSON, hook skipped\n`;
+	}
+	if (res.reason === "timeout") {
+		return `[signet] daemon ${name} timed out, hook skipped\n`;
+	}
+	return "[signet] daemon not running, hook skipped\n";
+}
+
+async function fetchHookData<T>(
+	deps: HookDeps,
+	name: string,
+	path: string,
+	opts?: RequestInit & { timeout?: number },
+): Promise<T | null> {
+	const res = await deps.fetchDaemonResult<T>(path, opts);
+	if (res.ok) return res.data;
+	process.stderr.write(formatHookFailure(name, res));
+	return null;
 }
 
 export function registerHookCommands(program: Command, deps: HookDeps): void {
@@ -79,15 +107,13 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 			});
 			if (!res.ok) {
 				if (res.reason === "http") {
-					process.stderr.write(`[signet] daemon session-start failed with HTTP ${res.status ?? "unknown"} — using static identity\n`);
+					process.stderr.write(
+						`[signet] daemon session-start failed with HTTP ${res.status ?? "unknown"} — using static identity\n`,
+					);
 				} else if (res.reason === "invalid-json") {
 					process.stderr.write("[signet] daemon session-start returned invalid JSON — using static identity\n");
 				}
-				const fallback = buildSessionStartFallback(
-					deps.readStaticIdentity,
-					deps.AGENTS_DIR,
-					res.reason,
-				);
+				const fallback = buildSessionStartFallback(deps.readStaticIdentity, deps.AGENTS_DIR, res.reason);
 				if (fallback) {
 					if (res.reason === "timeout") {
 						process.stderr.write("[signet] daemon session-start timed out — using static identity\n");
@@ -130,13 +156,17 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 		.action(async (options) => {
 			const input = await readJson();
 			const stdinProject = pickString(input?.cwd);
-			const data = await deps.fetchFromDaemon<{ inject?: string }>("/api/hooks/user-prompt-submit", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify(buildUserPromptSubmitBody(input, options.harness, options.project || stdinProject)),
-			});
+			const data = await fetchHookData<{ inject?: string }>(
+				deps,
+				"user-prompt-submit",
+				"/api/hooks/user-prompt-submit",
+				{
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify(buildUserPromptSubmitBody(input, options.harness, options.project || stdinProject)),
+				},
+			);
 			if (!data) {
-				process.stderr.write("[signet] daemon not running, hook skipped\n");
 				process.exit(0);
 			}
 			if (data.inject) console.log(data.inject);
@@ -148,14 +178,13 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 		.requiredOption("-H, --harness <harness>", "Harness name")
 		.action(async (options) => {
 			const body = (await readJson()) ?? {};
-			const data = await deps.fetchFromDaemon<{ memoriesSaved?: number }>("/api/hooks/session-end", {
+			const data = await fetchHookData<{ memoriesSaved?: number }>(deps, "session-end", "/api/hooks/session-end", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(buildSessionEndBody(body, options.harness)),
 				timeout: 60_000,
 			});
 			if (!data) {
-				process.stderr.write("[signet] daemon not running, hook skipped\n");
 				process.exit(0);
 			}
 			if ((data.memoriesSaved ?? 0) > 0) {
@@ -174,7 +203,9 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 			const input = await readJson();
 			const sessionKey = pickSessionKey(input);
 			const sessionContext = pickString(input?.session_context, input?.sessionContext);
-			const data = await deps.fetchFromDaemon<{ summaryPrompt?: string; guidelines?: string; error?: string }>(
+			const data = await fetchHookData<{ summaryPrompt?: string; guidelines?: string; error?: string }>(
+				deps,
+				"pre-compaction",
 				"/api/hooks/pre-compaction",
 				{
 					method: "POST",
@@ -186,6 +217,7 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 					}),
 				},
 			);
+			if (!data) return;
 			if (data?.error) {
 				console.error(chalk.red(`Error: ${data.error}`));
 				process.exit(1);
@@ -207,7 +239,9 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 		.option("--agent-id <id>", "Agent ID")
 		.action(async (options) => {
 			const input = shouldReadCompactionInput(process.stdin.isTTY, options) ? await readJson() : null;
-			const data = await deps.fetchFromDaemon<{ success?: boolean; memoryId?: number; error?: string }>(
+			const data = await fetchHookData<{ success?: boolean; memoryId?: number; error?: string }>(
+				deps,
+				"compaction-complete",
 				"/api/hooks/compaction-complete",
 				{
 					method: "POST",
@@ -220,6 +254,7 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 					),
 				},
 			);
+			if (!data) return;
 			if (data?.error) {
 				console.error(chalk.red(`Error: ${data.error}`));
 				process.exit(1);
@@ -235,16 +270,17 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 		.description("Request MEMORY.md synthesis (returns prompt for configured harness)")
 		.option("--json", "Output as JSON")
 		.action(async (options) => {
-			const data = await deps.fetchFromDaemon<{
+			const data = await fetchHookData<{
 				harness?: string;
 				model?: string;
 				prompt?: string;
 				fileCount?: number;
 				error?: string;
-			}>("/api/hooks/synthesis", {
+			}>(deps, "synthesis", "/api/hooks/synthesis", {
 				method: "POST",
 				body: JSON.stringify({ trigger: "manual" }),
 			});
+			if (!data) return;
 			if (data?.error) {
 				console.error(chalk.red(`Error: ${data.error}`));
 				process.exit(1);
@@ -265,10 +301,16 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 		.description("Save synthesized MEMORY.md content")
 		.requiredOption("-c, --content <content>", "Synthesized MEMORY.md content")
 		.action(async (options) => {
-			const data = await deps.fetchFromDaemon<{ success?: boolean; error?: string }>("/api/hooks/synthesis/complete", {
-				method: "POST",
-				body: JSON.stringify({ content: options.content }),
-			});
+			const data = await fetchHookData<{ success?: boolean; error?: string }>(
+				deps,
+				"synthesis-complete",
+				"/api/hooks/synthesis/complete",
+				{
+					method: "POST",
+					body: JSON.stringify({ content: options.content }),
+				},
+			);
+			if (!data) return;
 			if (data?.error) {
 				console.error(chalk.red(`Error: ${data.error}`));
 				process.exit(1);
@@ -292,6 +334,7 @@ export function shouldReadCompactionInput(
 
 async function readJson(): Promise<Record<string, unknown> | null> {
 	try {
+		if (process.stdin.isTTY) return null;
 		const chunks: Buffer[] = [];
 		for await (const chunk of process.stdin) {
 			chunks.push(chunk);
@@ -299,10 +342,16 @@ async function readJson(): Promise<Record<string, unknown> | null> {
 		const input = Buffer.concat(chunks).toString("utf-8").trim();
 		if (!input) return null;
 		const parsed = JSON.parse(input);
-		return typeof parsed === "object" && parsed !== null ? (parsed as Record<string, unknown>) : null;
+		return toRecord(parsed);
 	} catch {
 		return null;
 	}
+}
+
+function toRecord(value: unknown): Record<string, unknown> | null {
+	if (typeof value !== "object" || value === null) return null;
+	if (Array.isArray(value)) return null;
+	return Object.fromEntries(Object.entries(value));
 }
 
 function pickString(...values: unknown[]): string {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -21,13 +21,15 @@
     "dashboard"
   ],
   "scripts": {
-    "build": "bun run build.ts",
+    "build": "bun run build.ts && bun run build:dashboard",
     "build:types": "tsc --emitDeclarationOnly --outDir dist",
     "dev": "bun --watch src/daemon.ts",
     "start": "cd ../core && bun run build && cd ../daemon && bun src/daemon.ts",
     "install:service": "bun src/daemon.ts --install",
     "uninstall:service": "bun src/daemon.ts --uninstall",
-    "test": "bun test"
+    "test": "bun test",
+    "build:dashboard": "bun ../../scripts/prepare-dashboard-bundle.ts .",
+    "prepublishOnly": "bun run build"
   },
   "dependencies": {
     "@1password/sdk": "^0.3.0",

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1357,13 +1357,11 @@ function parsePrefixes(raw: string): ParsedMemory {
 	return { content, tags, pinned, importance };
 }
 
-// Resolve dashboard static files location
-function getDashboardPath(): string | null {
+function getDashboardCandidates(): string[] {
 	const __filename = fileURLToPath(import.meta.url);
 	const __dirname = dirname(__filename);
 
-	// Check various locations for the built dashboard
-	const candidates = [
+	return [
 		// When running from workspace
 		join(__dirname, "..", "..", "cli", "dashboard", "build"),
 		// When installed as package
@@ -1372,6 +1370,11 @@ function getDashboardPath(): string | null {
 		join(__dirname, "..", "dashboard"),
 		join(__dirname, "dashboard"),
 	];
+}
+
+// Resolve dashboard static files location
+function getDashboardPath(): string | null {
+	const candidates = getDashboardCandidates();
 
 	for (const candidate of candidates) {
 		if (existsSync(join(candidate, "index.html"))) {
@@ -9572,7 +9575,9 @@ function setupStaticServing() {
 			})(c, next);
 		});
 	} else {
-		logger.warn("daemon", "Dashboard not found - API-only mode");
+		logger.warn("daemon", "Dashboard not found - API-only mode", {
+			candidates: getDashboardCandidates(),
+		});
 		app.get("/", (c) => {
 			return c.html(`
         <!DOCTYPE html>

--- a/packages/daemon/src/package-bundle.test.ts
+++ b/packages/daemon/src/package-bundle.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const prepared = new Set<string>();
+
+function prepareDashboard(dir: string): void {
+	if (prepared.has(dir)) return;
+
+	const prep = spawnSync("bun", ["run", "build:dashboard"], {
+		cwd: dir,
+		encoding: "utf8",
+		env: {
+			...process.env,
+			TERM: process.env.TERM || "xterm",
+		},
+	});
+
+	if (prep.status !== 0) {
+		throw new Error(prep.stderr || prep.stdout || `dashboard prep failed in ${dir}`);
+	}
+
+	prepared.add(dir);
+}
+
+function packFiles(dir: string): string[] {
+	prepareDashboard(dir);
+
+	const res = spawnSync("npm", ["pack", "--dry-run", "--json"], {
+		cwd: dir,
+		encoding: "utf8",
+		env: {
+			...process.env,
+			TERM: process.env.TERM || "xterm",
+		},
+	});
+
+	if (res.status !== 0) {
+		throw new Error(res.stderr || res.stdout || `npm pack failed in ${dir}`);
+	}
+
+	const parsed = JSON.parse(res.stdout);
+	if (!Array.isArray(parsed)) {
+		throw new Error(`unexpected npm pack payload for ${dir}`);
+	}
+
+	const first = parsed[0];
+	if (typeof first !== "object" || first === null) {
+		throw new Error(`missing npm pack entry for ${dir}`);
+	}
+
+	const files = Reflect.get(first, "files");
+	if (!Array.isArray(files)) {
+		throw new Error(`missing npm pack files list for ${dir}`);
+	}
+
+	return files.flatMap((file) => {
+		if (typeof file !== "object" || file === null) return [];
+		const path = Reflect.get(file, "path");
+		return typeof path === "string" ? [path] : [];
+	});
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const root = resolve(__dirname, "..", "..", "..");
+
+describe("published package dashboard bundles", () => {
+	test("packages/daemon pack output includes dashboard assets", () => {
+		const files = packFiles(resolve(root, "packages", "daemon"));
+		expect(files).toContain("dashboard/index.html");
+	}, 60_000);
+
+	test("packages/signetai pack output includes dashboard assets", () => {
+		const files = packFiles(resolve(root, "packages", "signetai"));
+		expect(files).toContain("dashboard/index.html");
+	}, 60_000);
+});

--- a/packages/signetai/package.json
+++ b/packages/signetai/package.json
@@ -19,7 +19,7 @@
     "build": "bun run build:cli && bun run build:daemon && bun run build:dashboard",
     "build:cli": "bun build ../cli/src/cli.ts --outfile ./dist/cli.js --target node --external better-sqlite3",
     "build:daemon": "bun run build-daemon.ts",
-    "build:dashboard": "rm -rf ./dashboard && cp -r ../cli/dashboard/build ./dashboard 2>/dev/null || echo 'Dashboard not built yet'",
+    "build:dashboard": "bun ../../scripts/prepare-dashboard-bundle.ts .",
     "prepublishOnly": "bun run build"
   },
   "keywords": [

--- a/scripts/prepare-dashboard-bundle.ts
+++ b/scripts/prepare-dashboard-bundle.ts
@@ -1,0 +1,49 @@
+import { spawnSync } from "node:child_process";
+import { cpSync, existsSync, rmSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function fail(msg: string): never {
+	console.error(msg);
+	process.exit(1);
+}
+
+function run(cmd: string, args: readonly string[], cwd: string): void {
+	const res = spawnSync(cmd, args, {
+		cwd,
+		stdio: "inherit",
+		env: {
+			...process.env,
+			TERM: process.env.TERM || "xterm",
+		},
+	});
+	if (res.status === 0) return;
+	fail(`[dashboard-bundle] ${cmd} ${args.join(" ")} failed in ${cwd}`);
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const root = resolve(__dirname, "..");
+const targetArg = process.argv[2];
+
+if (!targetArg) {
+	fail("[dashboard-bundle] target package path is required");
+}
+
+const src = join(root, "packages", "cli", "dashboard");
+const build = join(src, "build");
+const target = resolve(process.cwd(), targetArg);
+const out = join(target, "dashboard");
+
+run("bun", ["run", "build"], src);
+
+if (!existsSync(join(build, "index.html"))) {
+	fail(`[dashboard-bundle] expected ${join(build, "index.html")} after dashboard build`);
+}
+
+rmSync(out, { recursive: true, force: true });
+cpSync(build, out, { recursive: true });
+
+if (!existsSync(join(out, "index.html"))) {
+	fail(`[dashboard-bundle] expected ${join(out, "index.html")} after copy`);
+}


### PR DESCRIPTION
## summary

this fixes the two runtime regressions reported after upgrading from `0.83.0` to `0.85.3` on March 29, 2026:

1. `user-prompt-submit` hook stopped working
2. daemon root path started serving the "dashboard is not installed" fallback page

## what changed

- fixed CLI hook command transport so `signet hook user-prompt-submit` uses the daemon result client path correctly after the hook refactor
- added shared dashboard bundle preparation via `scripts/prepare-dashboard-bundle.ts`
- made both daemon-bearing packages build and ship dashboard assets explicitly:
  - `@signet/daemon`
  - `signetai`
- improved daemon logging when dashboard asset resolution fails and it falls back to API-only mode
- added regression coverage for:
  - hook command wiring
  - `npm pack --dry-run` bundle contents for both published packages
- added the required incident-driven spec stub and index/dependency updates

## validation

passed:

- `bun test packages/cli/src/commands/hook.test.ts`
- `bun test packages/daemon/src/package-bundle.test.ts`
- `cd packages/daemon && bun run build`
- `cd packages/signetai && bun run build`
- targeted Biome check on changed files

## note

workspace-wide `bun run typecheck` still fails in `@signet/opencode-plugin` with `TS2688: Cannot find type definition file for 'node'`.
that issue is pre-existing and unrelated to this hotfix.
