### PR TITLE
fix(daemon): harden pipeline parsers and skill reconciler idempotency

### DIFF
--- a/packages/daemon/src/pipeline/contradiction.test.ts
+++ b/packages/daemon/src/pipeline/contradiction.test.ts
@@ -45,4 +45,20 @@ describe("detectSemanticContradiction", () => {
 		expect(result.detected).toBe(false);
 		expect(result.confidence).toBe(0.8);
 	});
+
+	it("prefers the final contradiction object over earlier examples", async () => {
+		const provider = mockProvider(
+			'Example: {"contradicts": false, "confidence": 0.2, "reasoning": "example"}\nFinal: {"contradicts": true, "confidence": 0.95, "reasoning": "actual answer"}',
+		);
+
+		const result = await detectSemanticContradiction(
+			"Dark mode is enabled by default",
+			"Light mode is the default theme",
+			provider,
+		);
+
+		expect(result.detected).toBe(true);
+		expect(result.confidence).toBe(0.95);
+		expect(result.reasoning).toContain("actual answer");
+	});
 });

--- a/packages/daemon/src/pipeline/contradiction.test.ts
+++ b/packages/daemon/src/pipeline/contradiction.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { detectSemanticContradiction } from "./contradiction";
+import type { LlmProvider } from "./provider";
+
+function mockProvider(raw: string): LlmProvider {
+	return {
+		name: "mock",
+		async available() {
+			return true;
+		},
+		async generate() {
+			return raw;
+		},
+	};
+}
+
+describe("detectSemanticContradiction", () => {
+	it("parses JSON wrapped in explanatory prose", async () => {
+		const provider = mockProvider(
+			'We should compare these carefully.\n{"contradicts": true, "confidence": 0.91, "reasoning": "Default theme changed from dark to light."}\nThis is my final answer.',
+		);
+
+		const result = await detectSemanticContradiction(
+			"Dark mode is enabled by default",
+			"Light mode is the default theme",
+			provider,
+		);
+
+		expect(result.detected).toBe(true);
+		expect(result.confidence).toBe(0.91);
+		expect(result.reasoning).toContain("theme");
+	});
+
+	it("parses fenced JSON with trailing commas", async () => {
+		const provider = mockProvider(`\`\`\`json
+{
+  "contradicts": false,
+  "confidence": 0.8,
+  "reasoning": "These statements are complementary.",
+}
+\`\`\``);
+
+		const result = await detectSemanticContradiction("The API uses REST", "The API endpoint returns JSON", provider);
+
+		expect(result.detected).toBe(false);
+		expect(result.confidence).toBe(0.8);
+	});
+});

--- a/packages/daemon/src/pipeline/contradiction.ts
+++ b/packages/daemon/src/pipeline/contradiction.ts
@@ -10,6 +10,7 @@
  */
 
 import { logger } from "../logger";
+import { extractBalancedJsonObject, stripFences, tryParseJson } from "./extraction";
 import type { LlmProvider } from "./provider";
 
 // ---------------------------------------------------------------------------
@@ -60,27 +61,45 @@ export async function detectSemanticContradiction(
 	try {
 		const prompt = buildPrompt(factContent, targetContent);
 		const raw = await provider.generate(prompt, { timeoutMs });
-
-		let jsonStr = raw.trim();
-		const fenceMatch = jsonStr.match(/```(?:json)?\s*([\s\S]*?)```/);
-		if (fenceMatch) jsonStr = fenceMatch[1].trim();
-		jsonStr = jsonStr.replace(/<think>[\s\S]*?<\/think>/g, "").trim();
-
-		const parsed = JSON.parse(jsonStr) as Record<string, unknown>;
+		const parsed = parseSemanticContradiction(raw);
+		if (parsed === null) {
+			throw new Error("Invalid contradiction response payload");
+		}
 
 		const detected = parsed.contradicts === true;
-		const confidence =
-			typeof parsed.confidence === "number"
-				? Math.max(0, Math.min(1, parsed.confidence))
-				: 0.5;
-		const reasoning =
-			typeof parsed.reasoning === "string" ? parsed.reasoning : "";
+		const confidence = normalizeConfidence(parsed.confidence);
+		const reasoning = typeof parsed.reasoning === "string" ? parsed.reasoning : "";
 
 		return { detected, confidence, reasoning };
 	} catch (e) {
 		logger.warn("pipeline", "Semantic contradiction check failed", {
-			error: (e as Error).message,
+			error: e instanceof Error ? e.message : String(e),
 		});
 		return noContradiction;
 	}
+}
+
+function parseSemanticContradiction(raw: string): Record<string, unknown> | null {
+	const stripped = stripFences(raw);
+	const candidates = [raw.trim(), stripped];
+	const rawObj = extractBalancedJsonObject(raw);
+	if (rawObj) candidates.push(rawObj);
+	const strippedObj = extractBalancedJsonObject(stripped);
+	if (strippedObj) candidates.push(strippedObj);
+
+	for (const candidate of candidates) {
+		const parsed = tryParseJson(candidate);
+		if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+			continue;
+		}
+		return parsed;
+	}
+
+	return null;
+}
+
+function normalizeConfidence(value: unknown): number {
+	if (typeof value !== "number") return 0.5;
+	if (Number.isNaN(value)) return 0.5;
+	return Math.max(0, Math.min(1, value));
 }

--- a/packages/daemon/src/pipeline/contradiction.ts
+++ b/packages/daemon/src/pipeline/contradiction.ts
@@ -10,7 +10,7 @@
  */
 
 import { logger } from "../logger";
-import { extractBalancedJsonObject, stripFences, tryParseJson } from "./extraction";
+import { extractBalancedJsonObjects, stripFences, tryParseJson } from "./extraction";
 import type { LlmProvider } from "./provider";
 
 // ---------------------------------------------------------------------------
@@ -81,18 +81,26 @@ export async function detectSemanticContradiction(
 
 function parseSemanticContradiction(raw: string): Record<string, unknown> | null {
 	const stripped = stripFences(raw);
-	const candidates = [raw.trim(), stripped];
-	const rawObj = extractBalancedJsonObject(raw);
-	if (rawObj) candidates.push(rawObj);
-	const strippedObj = extractBalancedJsonObject(stripped);
-	if (strippedObj) candidates.push(strippedObj);
+	const candidates: string[] = [raw.trim(), stripped];
+	const rawObjs = extractBalancedJsonObjects(raw);
+	for (let i = rawObjs.length - 1; i >= 0; i--) {
+		candidates.push(rawObjs[i]);
+	}
+	const strippedObjs = extractBalancedJsonObjects(stripped);
+	for (let i = strippedObjs.length - 1; i >= 0; i--) {
+		candidates.push(strippedObjs[i]);
+	}
 
+	const seen = new Set<string>();
 	for (const candidate of candidates) {
+		const text = candidate.trim();
+		if (!text || seen.has(text)) continue;
+		seen.add(text);
 		const parsed = tryParseJson(candidate);
 		if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
 			continue;
 		}
-		return parsed;
+		if ("contradicts" in parsed) return parsed as Record<string, unknown>;
 	}
 
 	return null;

--- a/packages/daemon/src/pipeline/extraction.ts
+++ b/packages/daemon/src/pipeline/extraction.ts
@@ -127,15 +127,14 @@ export function tryParseJson(candidate: string): unknown | null {
 	return null;
 }
 
-export function extractBalancedJsonObject(raw: string): string | null {
-	const start = raw.indexOf("{");
-	if (start < 0) return null;
-
+export function extractBalancedJsonObjects(raw: string): string[] {
+	const out: string[] = [];
 	let depth = 0;
 	let inString = false;
 	let escaping = false;
+	let start = -1;
 
-	for (let i = start; i < raw.length; i++) {
+	for (let i = 0; i < raw.length; i++) {
 		const ch = raw[i];
 
 		if (inString) {
@@ -158,16 +157,25 @@ export function extractBalancedJsonObject(raw: string): string | null {
 			continue;
 		}
 
-		if (ch === "{") depth++;
+		if (ch === "{") {
+			if (depth === 0) start = i;
+			depth++;
+		}
 		if (ch === "}") {
 			depth--;
-			if (depth === 0) {
-				return raw.slice(start, i + 1);
+			if (depth === 0 && start >= 0) {
+				out.push(raw.slice(start, i + 1));
+				start = -1;
 			}
 		}
 	}
 
-	return null;
+	return out;
+}
+
+export function extractBalancedJsonObject(raw: string): string | null {
+	const list = extractBalancedJsonObjects(raw);
+	return list.length > 0 ? list[0] : null;
 }
 
 /**

--- a/packages/daemon/src/pipeline/extraction.ts
+++ b/packages/daemon/src/pipeline/extraction.ts
@@ -127,7 +127,7 @@ export function tryParseJson(candidate: string): unknown | null {
 	return null;
 }
 
-function extractBalancedJsonObject(raw: string): string | null {
+export function extractBalancedJsonObject(raw: string): string | null {
 	const start = raw.indexOf("{");
 	if (start < 0) return null;
 
@@ -188,13 +188,22 @@ export function extractBalancedJsonArray(raw: string): string | null {
 		const ch = raw[i];
 
 		if (inString) {
-			if (escaping) { escaping = false; continue; }
-			if (ch === "\\") { escaping = true; continue; }
+			if (escaping) {
+				escaping = false;
+				continue;
+			}
+			if (ch === "\\") {
+				escaping = true;
+				continue;
+			}
 			if (ch === '"') inString = false;
 			continue;
 		}
 
-		if (ch === '"') { inString = true; continue; }
+		if (ch === '"') {
+			inString = true;
+			continue;
+		}
 		if (ch === "[") {
 			if (depth === 0) last = i;
 			depth++;
@@ -213,13 +222,22 @@ export function extractBalancedJsonArray(raw: string): string | null {
 		const ch = raw[i];
 
 		if (inString) {
-			if (escaping) { escaping = false; continue; }
-			if (ch === "\\") { escaping = true; continue; }
+			if (escaping) {
+				escaping = false;
+				continue;
+			}
+			if (ch === "\\") {
+				escaping = true;
+				continue;
+			}
 			if (ch === '"') inString = false;
 			continue;
 		}
 
-		if (ch === '"') { inString = true; continue; }
+		if (ch === '"') {
+			inString = true;
+			continue;
+		}
 		if (ch === "[") depth++;
 		if (ch === "]") {
 			depth--;

--- a/packages/daemon/src/pipeline/skill-enrichment.test.ts
+++ b/packages/daemon/src/pipeline/skill-enrichment.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+import type { LlmProvider } from "./provider";
+import { enrichSkillFrontmatter } from "./skill-enrichment";
+
+function mockProvider(raw: string): LlmProvider {
+	return {
+		name: "mock",
+		async available() {
+			return true;
+		},
+		async generate() {
+			return raw;
+		},
+	};
+}
+
+describe("enrichSkillFrontmatter", () => {
+	it("parses enrichment JSON wrapped in prose", async () => {
+		const provider = mockProvider(
+			'We need to output JSON only.\n\n{"description":"Best practices for Remotion video creation and dynamic media generation.","triggers":["build remotion animation","make video composition"],"tags":["video","animation"]}',
+		);
+
+		const result = await enrichSkillFrontmatter(
+			{
+				name: "remotion-best-practices",
+				description: "",
+				body: "Skill about Remotion workflows and animation patterns.",
+			},
+			provider,
+		);
+
+		expect(result).not.toBeNull();
+		expect(result?.description).toContain("Remotion");
+		expect(result?.triggers).toContain("build remotion animation");
+		expect(result?.tags).toContain("video");
+	});
+
+	it("parses fenced JSON with trailing commas", async () => {
+		const provider = mockProvider(`\`\`\`json
+{
+  "description": "Guidance for creating and optimizing Remotion compositions.",
+  "triggers": ["render remotion videos", "optimize remotion compositions",],
+  "tags": ["video", "performance",]
+}
+\`\`\``);
+
+		const result = await enrichSkillFrontmatter(
+			{
+				name: "remotion-best-practices",
+				description: "",
+				body: "Skill details",
+			},
+			provider,
+		);
+
+		expect(result).not.toBeNull();
+		expect(result?.triggers.length).toBe(2);
+		expect(result?.tags).toContain("performance");
+	});
+});

--- a/packages/daemon/src/pipeline/skill-enrichment.test.ts
+++ b/packages/daemon/src/pipeline/skill-enrichment.test.ts
@@ -57,4 +57,23 @@ describe("enrichSkillFrontmatter", () => {
 		expect(result?.triggers.length).toBe(2);
 		expect(result?.tags).toContain("performance");
 	});
+
+	it("prefers final enrichment object over earlier example objects", async () => {
+		const provider = mockProvider(
+			'Example: {"description":"","triggers":[],"tags":[]}\nFinal: {"description":"Practical guidance for producing Remotion compositions with reusable patterns.","triggers":["build remotion video"],"tags":["video"]}',
+		);
+
+		const result = await enrichSkillFrontmatter(
+			{
+				name: "remotion-best-practices",
+				description: "",
+				body: "Skill details",
+			},
+			provider,
+		);
+
+		expect(result).not.toBeNull();
+		expect(result?.description).toContain("Remotion");
+		expect(result?.triggers).toContain("build remotion video");
+	});
 });

--- a/packages/daemon/src/pipeline/skill-enrichment.ts
+++ b/packages/daemon/src/pipeline/skill-enrichment.ts
@@ -8,8 +8,9 @@
  * Lives alongside the other extraction/decision prompts in pipeline/.
  */
 
-import type { LlmProvider } from "./provider";
 import { logger } from "../logger";
+import { extractBalancedJsonObject, stripFences, tryParseJson } from "./extraction";
+import type { LlmProvider } from "./provider";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -32,9 +33,7 @@ export interface SkillEnrichmentResult {
 // ---------------------------------------------------------------------------
 
 function buildEnrichmentPrompt(input: SkillEnrichmentInput): string {
-	const bodyPreview = input.body.length > 3000
-		? `${input.body.slice(0, 3000)}\n[truncated]`
-		: input.body;
+	const bodyPreview = input.body.length > 3000 ? `${input.body.slice(0, 3000)}\n[truncated]` : input.body;
 
 	return `You are analyzing an AI agent skill to generate discovery metadata.
 
@@ -57,27 +56,27 @@ Return ONLY a JSON object with these three keys. No other text.
 // JSON parsing
 // ---------------------------------------------------------------------------
 
-const THINK_RE = /<think>[\s\S]*?<\/think>\s*/g;
-const FENCE_RE = /```(?:json)?\s*([\s\S]*?)```/;
-
 function parseEnrichmentOutput(raw: string): SkillEnrichmentResult | null {
-	const stripped = raw.replace(THINK_RE, "").trim();
-	const fenceMatch = stripped.match(FENCE_RE);
-	const jsonStr = fenceMatch ? fenceMatch[1].trim() : stripped;
+	const stripped = stripFences(raw);
+	const candidates = [raw.trim(), stripped];
+	const rawObj = extractBalancedJsonObject(raw);
+	if (rawObj) candidates.push(rawObj);
+	const strippedObj = extractBalancedJsonObject(stripped);
+	if (strippedObj) candidates.push(strippedObj);
 
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(jsonStr);
-	} catch {
-		return null;
+	let obj: Record<string, unknown> | null = null;
+	for (const candidate of candidates) {
+		const parsed = tryParseJson(candidate);
+		if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+			continue;
+		}
+		obj = parsed as Record<string, unknown>;
+		break;
 	}
 
-	if (typeof parsed !== "object" || parsed === null) return null;
-	const obj = parsed as Record<string, unknown>;
+	if (obj === null) return null;
 
-	const description = typeof obj.description === "string"
-		? obj.description.trim()
-		: "";
+	const description = typeof obj.description === "string" ? obj.description.trim() : "";
 
 	const triggers = Array.isArray(obj.triggers)
 		? obj.triggers.filter((t): t is string => typeof t === "string" && t.trim().length > 0)

--- a/packages/daemon/src/pipeline/skill-enrichment.ts
+++ b/packages/daemon/src/pipeline/skill-enrichment.ts
@@ -9,7 +9,7 @@
  */
 
 import { logger } from "../logger";
-import { extractBalancedJsonObject, stripFences, tryParseJson } from "./extraction";
+import { extractBalancedJsonObjects, stripFences, tryParseJson } from "./extraction";
 import type { LlmProvider } from "./provider";
 
 // ---------------------------------------------------------------------------
@@ -58,37 +58,38 @@ Return ONLY a JSON object with these three keys. No other text.
 
 function parseEnrichmentOutput(raw: string): SkillEnrichmentResult | null {
 	const stripped = stripFences(raw);
-	const candidates = [raw.trim(), stripped];
-	const rawObj = extractBalancedJsonObject(raw);
-	if (rawObj) candidates.push(rawObj);
-	const strippedObj = extractBalancedJsonObject(stripped);
-	if (strippedObj) candidates.push(strippedObj);
+	const candidates: string[] = [raw.trim(), stripped];
+	const rawObjs = extractBalancedJsonObjects(raw);
+	for (let i = rawObjs.length - 1; i >= 0; i--) {
+		candidates.push(rawObjs[i]);
+	}
+	const strippedObjs = extractBalancedJsonObjects(stripped);
+	for (let i = strippedObjs.length - 1; i >= 0; i--) {
+		candidates.push(strippedObjs[i]);
+	}
 
-	let obj: Record<string, unknown> | null = null;
+	const seen = new Set<string>();
 	for (const candidate of candidates) {
+		const text = candidate.trim();
+		if (!text || seen.has(text)) continue;
+		seen.add(text);
 		const parsed = tryParseJson(candidate);
 		if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
 			continue;
 		}
-		obj = parsed as Record<string, unknown>;
-		break;
+		const obj = parsed as Record<string, unknown>;
+		const description = typeof obj.description === "string" ? obj.description.trim() : "";
+		const triggers = Array.isArray(obj.triggers)
+			? obj.triggers.filter((t): t is string => typeof t === "string" && t.trim().length > 0)
+			: [];
+		const tags = Array.isArray(obj.tags)
+			? obj.tags.filter((t): t is string => typeof t === "string" && t.trim().length > 0)
+			: [];
+		if (!description && triggers.length === 0) continue;
+		return { description, triggers, tags };
 	}
 
-	if (obj === null) return null;
-
-	const description = typeof obj.description === "string" ? obj.description.trim() : "";
-
-	const triggers = Array.isArray(obj.triggers)
-		? obj.triggers.filter((t): t is string => typeof t === "string" && t.trim().length > 0)
-		: [];
-
-	const tags = Array.isArray(obj.tags)
-		? obj.tags.filter((t): t is string => typeof t === "string" && t.trim().length > 0)
-		: [];
-
-	if (!description && triggers.length === 0) return null;
-
-	return { description, triggers, tags };
+	return null;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/pipeline/skill-graph.test.ts
+++ b/packages/daemon/src/pipeline/skill-graph.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
+import { DEFAULT_PIPELINE_V2, type EmbeddingConfig, type PipelineV2Config } from "../memory-config";
+import { installSkillNode } from "./skill-graph";
+
+function dbPath(): string {
+	const dir = join(tmpdir(), `signet-skill-graph-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	mkdirSync(dir, { recursive: true });
+	return join(dir, "memories.db");
+}
+
+function cfg(): PipelineV2Config {
+	return {
+		...DEFAULT_PIPELINE_V2,
+		graph: { ...DEFAULT_PIPELINE_V2.graph, enabled: false },
+		procedural: { ...DEFAULT_PIPELINE_V2.procedural, enrichOnInstall: false },
+	};
+}
+
+const emb: EmbeddingConfig = {
+	model: "test",
+	dimensions: 768,
+	provider: "ollama",
+	base_url: "http://127.0.0.1:11434",
+};
+
+let path = "";
+
+afterEach(() => {
+	closeDbAccessor();
+	if (path) {
+		rmSync(path, { force: true });
+		rmSync(`${path}-wal`, { force: true });
+		rmSync(`${path}-shm`, { force: true });
+	}
+	path = "";
+});
+
+describe("installSkillNode", () => {
+	it("upserts skill_meta when a duplicate entity_id row already exists", async () => {
+		path = dbPath();
+		initDbAccessor(path);
+		const now = new Date().toISOString();
+		const id = "skill:default:astro-portfolio-site";
+
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO skill_meta
+				 (entity_id, agent_id, source, role, installed_at, fs_path, enriched)
+				 VALUES (?, 'default', 'reconciler', 'utility', ?, ?, 0)`,
+			).run(id, now, "/tmp/skills/astro-portfolio-site/SKILL.md");
+		});
+
+		await installSkillNode(
+			{
+				frontmatter: {
+					name: "astro-portfolio-site",
+					description: "Build Astro portfolio websites from brand assets.",
+				},
+				body: "Skill body",
+				source: "reconciler",
+				fsPath: "/tmp/skills/astro-portfolio-site/SKILL.md",
+			},
+			getDbAccessor(),
+			cfg(),
+			emb,
+			async () => null,
+			null,
+		);
+
+		const row = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT entity_id, uninstalled_at FROM skill_meta WHERE entity_id = ?").get(id) as
+					| { entity_id: string; uninstalled_at: string | null }
+					| undefined,
+		);
+		expect(row?.entity_id).toBe(id);
+		expect(row?.uninstalled_at).toBeNull();
+	});
+});

--- a/packages/daemon/src/pipeline/skill-graph.ts
+++ b/packages/daemon/src/pipeline/skill-graph.ts
@@ -10,14 +10,14 @@
  */
 
 import type { DbAccessor, WriteDb } from "../db-accessor";
+import { syncVecDeleteByEmbeddingIds, syncVecInsert, vectorToBlob } from "../db-helpers";
+import { logger } from "../logger";
 import type { EmbeddingConfig, PipelineV2Config } from "../memory-config";
-import type { LlmProvider } from "./provider";
-import { enrichSkillFrontmatter } from "./skill-enrichment";
 import { extractFactsAndEntities } from "./extraction";
 import { txPersistEntities } from "./graph-transactions";
 import { invalidateTraversalCache } from "./graph-traversal";
-import { vectorToBlob, syncVecInsert, syncVecDeleteByEmbeddingIds } from "../db-helpers";
-import { logger } from "../logger";
+import type { LlmProvider } from "./provider";
+import { enrichSkillFrontmatter } from "./skill-enrichment";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -105,8 +105,7 @@ export async function installSkillNode(
 
 	// Step 1: Enrich if needed
 	const needsEnrichment =
-		fm.description.length < procCfg.enrichMinDescription ||
-		!fm.triggers || fm.triggers.length === 0;
+		fm.description.length < procCfg.enrichMinDescription || !fm.triggers || fm.triggers.length === 0;
 
 	if (procCfg.enrichOnInstall && needsEnrichment && provider === null) {
 		logger.warn("pipeline", "Skill enrichment skipped — LLM provider not available", {
@@ -125,12 +124,8 @@ export async function installSkillNode(
 			fm = {
 				...fm,
 				description: enrichResult.description || fm.description,
-				triggers: enrichResult.triggers.length > 0
-					? enrichResult.triggers
-					: fm.triggers,
-				tags: enrichResult.tags.length > 0
-					? enrichResult.tags
-					: fm.tags,
+				triggers: enrichResult.triggers.length > 0 ? enrichResult.triggers : fm.triggers,
+				tags: enrichResult.tags.length > 0 ? enrichResult.tags : fm.tags,
 			};
 			enriched = true;
 		}
@@ -139,9 +134,9 @@ export async function installSkillNode(
 	// Step 2: Create entity + skill_meta in a write transaction
 	accessor.withWriteTx((db) => {
 		// Check if entity already exists by id or name (idempotent)
-		const existing = db.prepare(
-			"SELECT id FROM entities WHERE id = ? OR (name = ? AND agent_id = ?)",
-		).get(entityId, fm.name, agentId) as { id: string } | undefined;
+		const existing = db
+			.prepare("SELECT id FROM entities WHERE id = ? OR (name = ? AND agent_id = ?)")
+			.get(entityId, fm.name, agentId) as { id: string } | undefined;
 
 		if (existing) {
 			// If matched by name (collision), adopt that entity's id
@@ -149,9 +144,11 @@ export async function installSkillNode(
 				entityId = existing.id;
 			}
 			// Update existing entity
-			db.prepare(
-				`UPDATE entities SET entity_type = 'skill', description = ?, updated_at = ? WHERE id = ?`,
-			).run(fm.description, now, entityId);
+			db.prepare(`UPDATE entities SET entity_type = 'skill', description = ?, updated_at = ? WHERE id = ?`).run(
+				fm.description,
+				now,
+				entityId,
+			);
 
 			// Upsert skill_meta (may not exist if entity was from extraction)
 			db.prepare(
@@ -199,25 +196,35 @@ export async function installSkillNode(
 
 				// Name collision — an extracted entity already owns this name.
 				// Claim it as a skill entity and reuse its id.
-				const collision = db.prepare(
-					"SELECT id FROM entities WHERE name = ? LIMIT 1",
-				).get(fm.name) as { id: string } | undefined;
+				const collision = db
+					.prepare("SELECT id FROM entities WHERE name = ? AND agent_id = ? LIMIT 1")
+					.get(fm.name, agentId) as { id: string } | undefined;
 
 				if (!collision) throw e;
 
-				db.prepare(
-					`UPDATE entities SET entity_type = 'skill', description = ?, updated_at = ? WHERE id = ?`,
-				).run(fm.description, now, collision.id);
+				db.prepare(`UPDATE entities SET entity_type = 'skill', description = ?, updated_at = ? WHERE id = ?`).run(
+					fm.description,
+					now,
+					collision.id,
+				);
 				entityId = collision.id;
 			}
 
-			// Insert skill_meta
+			// Upsert skill_meta. Reconciler startup, periodic passes, and watcher
+			// can overlap; avoid UNIQUE(entity_id) races under concurrent installs.
 			db.prepare(
 				`INSERT INTO skill_meta
 				 (entity_id, agent_id, version, author, license, source,
 				  role, triggers, tags, permissions, enriched,
 				  installed_at, importance, decay_rate, fs_path)
-				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				 ON CONFLICT(entity_id) DO UPDATE SET
+					version = excluded.version, author = excluded.author,
+					license = excluded.license, source = excluded.source,
+					role = excluded.role, triggers = excluded.triggers,
+					tags = excluded.tags, permissions = excluded.permissions,
+					enriched = excluded.enriched, fs_path = excluded.fs_path,
+					uninstalled_at = NULL, updated_at = ?`,
 			).run(
 				entityId,
 				agentId,
@@ -234,6 +241,7 @@ export async function installSkillNode(
 				procCfg.importanceOnInstall,
 				procCfg.decayRate,
 				input.fsPath,
+				now,
 			);
 		}
 	});
@@ -250,15 +258,16 @@ export async function installSkillNode(
 
 		accessor.withWriteTx((db) => {
 			// Remove any old skill embeddings
-			const oldEmbs = db.prepare(
-				`SELECT id FROM embeddings WHERE source_type = 'skill' AND source_id = ?`,
-			).all(entityId) as Array<{ id: string }>;
+			const oldEmbs = db
+				.prepare(`SELECT id FROM embeddings WHERE source_type = 'skill' AND source_id = ?`)
+				.all(entityId) as Array<{ id: string }>;
 
 			if (oldEmbs.length > 0) {
-				syncVecDeleteByEmbeddingIds(db, oldEmbs.map((e) => e.id));
-				db.prepare(
-					`DELETE FROM embeddings WHERE source_type = 'skill' AND source_id = ?`,
-				).run(entityId);
+				syncVecDeleteByEmbeddingIds(
+					db,
+					oldEmbs.map((e) => e.id),
+				);
+				db.prepare(`DELETE FROM embeddings WHERE source_type = 'skill' AND source_id = ?`).run(entityId);
 			}
 
 			// Insert new embedding (ON CONFLICT may keep the existing row id)
@@ -275,9 +284,7 @@ export async function installSkillNode(
 
 			// Query back the actual row id — on conflict SQLite keeps the
 			// existing id, not the one we generated above.
-			const actualRow = db
-				.prepare("SELECT id FROM embeddings WHERE content_hash = ?")
-				.get(hash) as { id: string };
+			const actualRow = db.prepare("SELECT id FROM embeddings WHERE content_hash = ?").get(hash) as { id: string };
 			syncVecInsert(db, actualRow.id, embVec);
 		});
 
@@ -325,16 +332,12 @@ export async function installSkillNode(
 // Uninstall: remove entity + skill_meta + embeddings + relations
 // ---------------------------------------------------------------------------
 
-export function uninstallSkillNode(
-	input: SkillUninstallInput,
-	accessor: DbAccessor,
-): SkillUninstallResult {
+export function uninstallSkillNode(input: SkillUninstallInput, accessor: DbAccessor): SkillUninstallResult {
 	const agentId = input.agentId ?? "default";
 	const entityId = skillEntityId(agentId, input.skillName);
 
-	const exists = accessor.withReadDb((db) =>
-		db.prepare("SELECT id FROM entities WHERE id = ?")
-			.get(entityId) as { id: string } | undefined,
+	const exists = accessor.withReadDb(
+		(db) => db.prepare("SELECT id FROM entities WHERE id = ?").get(entityId) as { id: string } | undefined,
 	);
 
 	if (!exists) {
@@ -349,20 +352,19 @@ export function uninstallSkillNode(
 		).run(entityId, entityId);
 
 		// 2. Remove skill mention links
-		db.prepare(
-			`DELETE FROM memory_entity_mentions WHERE entity_id = ?`,
-		).run(entityId);
+		db.prepare("DELETE FROM memory_entity_mentions WHERE entity_id = ?").run(entityId);
 
 		// 3. Remove embeddings + vec sync
-		const embRows = db.prepare(
-			`SELECT id FROM embeddings WHERE source_type = 'skill' AND source_id = ?`,
-		).all(entityId) as Array<{ id: string }>;
+		const embRows = db
+			.prepare(`SELECT id FROM embeddings WHERE source_type = 'skill' AND source_id = ?`)
+			.all(entityId) as Array<{ id: string }>;
 
 		if (embRows.length > 0) {
-			syncVecDeleteByEmbeddingIds(db, embRows.map((e) => e.id));
-			db.prepare(
-				`DELETE FROM embeddings WHERE source_type = 'skill' AND source_id = ?`,
-			).run(entityId);
+			syncVecDeleteByEmbeddingIds(
+				db,
+				embRows.map((e) => e.id),
+			);
+			db.prepare(`DELETE FROM embeddings WHERE source_type = 'skill' AND source_id = ?`).run(entityId);
 		}
 
 		// 4. Hard-delete skill_meta + entity in same transaction


### PR DESCRIPTION
## Summary

Fix recurring daemon log warnings by hardening JSON parse recovery in pipeline enrich/contradiction paths and making skill reconciliation writes idempotent.

## Changes

- Hardened semantic contradiction output parsing to recover JSON from prose/fences/trailing commas.
- Hardened skill enrichment output parsing with the same recovery path.
- Exported `extractBalancedJsonObject` for shared parser recovery.
- Made `skill_meta` writes conflict-safe with `ON CONFLICT(entity_id) DO UPDATE` in install flow.
- Scoped entity name-collision adoption by `agent_id`.
- Added regression tests for:
  - prose-wrapped/fenced contradiction output,
  - prose-wrapped/fenced skill enrichment output,
  - duplicate `skill_meta.entity_id` reconcile/install path.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

N/A, no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [ ] Security checks applied to admin/mutation endpoints
- [ ] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [ ] Lint/typecheck/tests pass locally

Notes:
- Security/admin endpoints: N/A, no auth/admin/mutation route changes.
- Docs/spec/API: N/A, no API/schema/behavior contract change requiring docs updates.
- Full workspace typecheck currently fails on pre-existing `@signet/connector-oh-my-pi` and `@signet/oh-my-pi-extension` node typings; unaffected by this PR.

## Migration Notes (if applicable)

No migrations in this PR.

- [ ] Migration is idempotent
- [ ] Daemon Rust parity reviewed or explicitly N/A
- [ ] Rollback / compatibility note included in PR description

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Executed (targeted):

```bash
bunx biome check packages/daemon/src/pipeline/contradiction.ts \
  packages/daemon/src/pipeline/extraction.ts \
  packages/daemon/src/pipeline/skill-enrichment.ts \
  packages/daemon/src/pipeline/skill-graph.ts \
  packages/daemon/src/pipeline/contradiction.test.ts \
  packages/daemon/src/pipeline/skill-enrichment.test.ts \
  packages/daemon/src/pipeline/skill-graph.test.ts

bun test packages/daemon/src/pipeline/contradiction.test.ts \
  packages/daemon/src/pipeline/skill-enrichment.test.ts \
  packages/daemon/src/pipeline/skill-graph.test.ts
```

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

This PR addresses warnings observed in production logs:
- `Semantic contradiction check failed` (`Unexpected identifier "We"`)
- `Failed to parse skill enrichment output`
- `Failed to reconcile skill` (`UNIQUE constraint failed: skill_meta.entity_id`)