### PR TITLE
fix(worker): exclude exhausted jobs from watchdog stall detector query (#339)

### DIFF
--- a/packages/daemon/src/pipeline/worker.test.ts
+++ b/packages/daemon/src/pipeline/worker.test.ts
@@ -1992,6 +1992,39 @@ describe("recoverMemoryJobs", () => {
 		const { updated } = recoverMemoryJobs(accessor);
 		expect(updated).toBe(0);
 	});
+
+	it("recovers jobs exhausted by lowered maxRetries even if max_attempts column is higher", () => {
+		// Regression: operator lowers maxRetries from 5 to 3 after rows were
+		// inserted with max_attempts=5. jobs with attempts=3 are now above the
+		// runtime limit (maxRetries=3) but below the stored column (max_attempts=5).
+		// Without the MIN(max_attempts, maxRetries) fix these jobs stay stuck in
+		// 'pending' forever: leaseJob() won't pick them up and recoverMemoryJobs
+		// without maxRetries won't mark them dead.
+		const now = new Date().toISOString();
+		// attempts=3 >= maxRetries=3, but max_attempts=5 — should become dead
+		db.prepare(
+			`INSERT INTO memory_jobs (id, memory_id, job_type, status, attempts, max_attempts, created_at, updated_at)
+			 VALUES ('job-runtime-exhausted', NULL, 'extract', 'pending', 3, 5, ?, ?)`,
+		).run(now, now);
+		// attempts=2 < maxRetries=3 — should stay pending
+		db.prepare(
+			`INSERT INTO memory_jobs (id, memory_id, job_type, status, attempts, max_attempts, created_at, updated_at)
+			 VALUES ('job-still-eligible', NULL, 'extract', 'pending', 2, 5, ?, ?)`,
+		).run(now, now);
+
+		const { updated } = recoverMemoryJobs(accessor, 3); // maxRetries lowered to 3
+		expect(updated).toBe(1);
+
+		const dead = db
+			.prepare("SELECT status FROM memory_jobs WHERE id = 'job-runtime-exhausted'")
+			.get() as { status: string } | undefined;
+		const active = db
+			.prepare("SELECT status FROM memory_jobs WHERE id = 'job-still-eligible'")
+			.get() as { status: string } | undefined;
+
+		expect(dead?.status).toBe("dead");
+		expect(active?.status).toBe("pending");
+	});
 });
 
 describe("watchdog pendingCount — exhausted jobs excluded", () => {

--- a/packages/daemon/src/pipeline/worker.ts
+++ b/packages/daemon/src/pipeline/worker.ts
@@ -925,25 +925,50 @@ interface MemoryRecoveryResult {
 }
 
 /**
- * Mark memory_jobs that are stuck in 'pending' with attempts >= max_attempts
- * as 'dead'. The tick loop requires attempts < max_attempts, so these jobs
- * are silently skipped forever without this recovery step, causing the stall
- * detector to fire on every interval.
+ * Mark memory_jobs that are stuck in 'pending' with attempts >= their
+ * effective retry limit as 'dead'. The effective limit is the lesser of the
+ * stored max_attempts column and the current runtime maxRetries value, so
+ * that jobs are also recovered when the operator lowers maxRetries after rows
+ * were originally inserted with a higher max_attempts value.
+ *
+ * @param accessor - DB accessor
+ * @param maxRetries - runtime retry limit from pipelineCfg.worker.maxRetries
  */
-export function recoverMemoryJobs(accessor: DbAccessor): MemoryRecoveryResult {
+export function recoverMemoryJobs(
+	accessor: DbAccessor,
+	maxRetries?: number,
+): MemoryRecoveryResult {
 	return accessor.withWriteTx((db) => {
 		const table = db
 			.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memory_jobs'")
 			.get() as { name: string } | undefined;
 		if (!table) return { updated: 0 };
 
-		const updated = countChanges(
-			db.prepare(
-				`UPDATE memory_jobs
-				 SET status = 'dead'
-				 WHERE status = 'pending' AND attempts >= max_attempts`,
-			).run(),
-		);
+		// Use MIN(max_attempts, maxRetries) so that both the DB-stored limit and
+		// the current runtime limit are honoured. When maxRetries is undefined
+		// (e.g. called from tests without a pipeline config) fall back to the
+		// column value only.
+		const updated =
+			maxRetries !== undefined
+				? countChanges(
+						db
+							.prepare(
+								`UPDATE memory_jobs
+							 SET status = 'dead'
+							 WHERE status = 'pending'
+							   AND attempts >= MIN(max_attempts, ?)`,
+							)
+							.run(maxRetries),
+					)
+				: countChanges(
+						db
+							.prepare(
+								`UPDATE memory_jobs
+							 SET status = 'dead'
+							 WHERE status = 'pending' AND attempts >= max_attempts`,
+							)
+							.run(),
+					);
 		return { updated };
 	});
 }
@@ -1660,12 +1685,14 @@ export function startWorker(
 	}, WATCHDOG_INTERVAL);
 
 	// Startup recovery: mark memory_jobs that are pending but have exhausted
-	// all attempts as dead. These are skipped by the tick loop (requires
-	// attempts < max_attempts) but stay in 'pending' forever, causing the
-	// stall detector to fire on every interval. Same pattern as summary-worker's
-	// recoverSummaryJobs for summary_jobs.
+	// their effective retry limit as dead. The effective limit is the lesser of
+	// the stored max_attempts column and the current runtime maxRetries value,
+	// so jobs are also recovered when the operator lowers maxRetries after rows
+	// were inserted with a higher max_attempts value. These jobs are silently
+	// skipped by the tick loop (requires attempts < maxRetries) and cause the
+	// stall detector to fire every interval without this cleanup step.
 	try {
-		const { updated } = recoverMemoryJobs(accessor);
+		const { updated } = recoverMemoryJobs(accessor, pipelineCfg.worker.maxRetries);
 		if (updated > 0) logger.info("pipeline", `Startup recovery: marked ${updated} exhausted pending job(s) as dead`);
 	} catch (e) {
 		logger.warn("pipeline", "Startup recovery failed (non-fatal)", {


### PR DESCRIPTION
## Problem

The watchdog stall detector and `pendingCount()` both used an unfiltered query:

```sql
SELECT COUNT(*) as cnt FROM memory_jobs WHERE job_type = 'extract' AND status = 'pending'
```

This counted jobs with `attempts >= maxRetries` as pending, even though `leaseJob()` skips them with `attempts < pipelineCfg.worker.maxRetries`. Result: any job that exhausted retries before startup recovery ran would trigger the stall watchdog every 60s indefinitely.

## Fix

Align watchdog SELECT and `pendingCount()` to use the same eligibility criterion as `leaseJob()`:

```sql
SELECT COUNT(*) as cnt FROM memory_jobs WHERE job_type = 'extract' AND status = 'pending' AND attempts < ?
```

bound to `pipelineCfg.worker.maxRetries` — not the DB column `max_attempts`, which can diverge from the runtime setting.

## Tests

Added 2 tests in `watchdog pendingCount — exhausted jobs excluded`:
- `stats.pending` excludes exhausted jobs (attempts === maxRetries)
- `stats.pending` is 0 when only exhausted jobs remain

Pre-existing test suite: 41 pass (2 failures are pre-existing and unrelated to this PR).

Fixes #339