### PR TITLE
fix(daemon): stop skill reconcile and codex provider loops

### DIFF
--- a/packages/daemon/src/pipeline/provider.test.ts
+++ b/packages/daemon/src/pipeline/provider.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { afterEach, describe, expect, it, mock } from "bun:test";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -336,7 +336,7 @@ describe("createCodexProvider", () => {
 		expect(typeof capturedEnv?.CODEX_HOME).toBe("string");
 	});
 
-	it("spawns Codex with a sterile temp home and copied auth", async () => {
+	it("spawns Codex with a sterile temp home and linked auth", async () => {
 		const root = join(tmpdir(), `signet-codex-provider-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		const home = join(root, "home");
 		const codex = join(home, ".codex");
@@ -352,12 +352,13 @@ describe("createCodexProvider", () => {
 			capturedEnv = opts?.env;
 			const srcAuth = join(homedir(), ".codex", "auth.json");
 			const srcVersion = join(homedir(), ".codex", "version.json");
+			const dstAuth = join(capturedEnv?.CODEX_HOME ?? "", "auth.json");
 			expect(capturedEnv?.CODEX_HOME).toBe(join(capturedEnv?.HOME ?? "", ".codex"));
-			expect(existsSync(join(capturedEnv?.CODEX_HOME ?? "", "auth.json"))).toBe(existsSync(srcAuth));
+			expect(capturedEnv?.HOME?.startsWith(tmpdir())).toBe(true);
+			expect(existsSync(dstAuth)).toBe(existsSync(srcAuth));
 			if (existsSync(srcAuth)) {
-				expect(readFileSync(join(capturedEnv?.CODEX_HOME ?? "", "auth.json"), "utf8")).toBe(
-					readFileSync(srcAuth, "utf8"),
-				);
+				expect(lstatSync(dstAuth).isSymbolicLink()).toBe(true);
+				expect(readFileSync(dstAuth, "utf8")).toBe(readFileSync(srcAuth, "utf8"));
 			}
 			expect(existsSync(join(capturedEnv?.CODEX_HOME ?? "", "version.json"))).toBe(existsSync(srcVersion));
 			return {

--- a/packages/daemon/src/pipeline/provider.test.ts
+++ b/packages/daemon/src/pipeline/provider.test.ts
@@ -339,19 +339,21 @@ describe("createCodexProvider", () => {
 	it("spawns Codex with a sterile temp home and readonly copied auth", async () => {
 		const root = join(tmpdir(), `signet-codex-provider-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		const home = join(root, "home");
-		const codex = join(home, ".codex");
-		mkdirSync(codex, { recursive: true });
-		writeFileSync(join(codex, "auth.json"), '{"provider":"test"}');
-		writeFileSync(join(codex, "version.json"), '{"version":"1"}');
+		const liveCodex = join(root, "live-codex");
+		mkdirSync(liveCodex, { recursive: true });
+		writeFileSync(join(liveCodex, "auth.json"), '{"provider":"test"}');
+		writeFileSync(join(liveCodex, "version.json"), '{"version":"1"}');
 
 		const prevHome = process.env.HOME;
+		const prevCodexHome = process.env.CODEX_HOME;
 		process.env.HOME = home;
+		process.env.CODEX_HOME = liveCodex;
 
 		let capturedEnv: Record<string, string | undefined> | undefined;
 		Bun.spawn = mock((args: string[], opts?: { env?: Record<string, string | undefined> }) => {
 			capturedEnv = opts?.env;
-			const srcAuth = join(homedir(), ".codex", "auth.json");
-			const srcVersion = join(homedir(), ".codex", "version.json");
+			const srcAuth = join(liveCodex, "auth.json");
+			const srcVersion = join(liveCodex, "version.json");
 			const dstAuth = join(capturedEnv?.CODEX_HOME ?? "", "auth.json");
 			expect(capturedEnv?.CODEX_HOME).toBe(join(capturedEnv?.HOME ?? "", ".codex"));
 			expect(capturedEnv?.HOME?.startsWith(tmpdir())).toBe(true);
@@ -389,6 +391,11 @@ describe("createCodexProvider", () => {
 				delete process.env.HOME;
 			} else {
 				process.env.HOME = prevHome;
+			}
+			if (prevCodexHome === undefined) {
+				delete process.env.CODEX_HOME;
+			} else {
+				process.env.CODEX_HOME = prevCodexHome;
 			}
 			rmSync(root, { recursive: true, force: true });
 		}

--- a/packages/daemon/src/pipeline/provider.test.ts
+++ b/packages/daemon/src/pipeline/provider.test.ts
@@ -357,7 +357,7 @@ describe("createCodexProvider", () => {
 			expect(capturedEnv?.HOME?.startsWith(tmpdir())).toBe(true);
 			expect(existsSync(dstAuth)).toBe(existsSync(srcAuth));
 			if (existsSync(srcAuth)) {
-				expect(lstatSync(dstAuth).isSymbolicLink()).toBe(true);
+				expect(lstatSync(dstAuth).isSymbolicLink() || lstatSync(dstAuth).nlink > 1).toBe(true);
 				expect(readFileSync(dstAuth, "utf8")).toBe(readFileSync(srcAuth, "utf8"));
 			}
 			expect(existsSync(join(capturedEnv?.CODEX_HOME ?? "", "version.json"))).toBe(existsSync(srcVersion));

--- a/packages/daemon/src/pipeline/provider.test.ts
+++ b/packages/daemon/src/pipeline/provider.test.ts
@@ -394,6 +394,43 @@ describe("createCodexProvider", () => {
 		}
 	});
 
+	it("does not delete sibling sterile homes while Codex is running", async () => {
+		const root = join(tmpdir(), "signet-codex-home");
+		mkdirSync(root, { recursive: true });
+		const sibling = join(root, `home-sibling-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		const marker = join(sibling, "marker.txt");
+		mkdirSync(sibling, { recursive: true });
+		writeFileSync(marker, "keep");
+
+		let capturedEnv: Record<string, string | undefined> | undefined;
+		Bun.spawn = mock((args: string[], opts?: { env?: Record<string, string | undefined> }) => {
+			capturedEnv = opts?.env;
+			expect(existsSync(marker)).toBe(true);
+			expect(capturedEnv?.HOME).not.toBe(sibling);
+			return {
+				stdout: streamFromString(
+					'{"type":"item.completed","item":{"type":"agent_message","text":"done"}}\n{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}\n',
+				),
+				stderr: streamFromString(""),
+				exited: Promise.resolve(0),
+				kill() {},
+			};
+		}) as typeof Bun.spawn;
+
+		try {
+			const provider = createCodexProvider({ model: "gpt-5.3-codex" });
+			if (!provider.generateWithUsage) {
+				throw new Error("expected generateWithUsage on Codex provider");
+			}
+
+			await provider.generateWithUsage("test");
+
+			expect(existsSync(marker)).toBe(true);
+		} finally {
+			rmSync(sibling, { recursive: true, force: true });
+		}
+	});
+
 	it("generate() throws on non-zero exit", async () => {
 		Bun.spawn = mock((_args: string[]) => ({
 			stdout: streamFromString(""),

--- a/packages/daemon/src/pipeline/provider.test.ts
+++ b/packages/daemon/src/pipeline/provider.test.ts
@@ -336,7 +336,7 @@ describe("createCodexProvider", () => {
 		expect(typeof capturedEnv?.CODEX_HOME).toBe("string");
 	});
 
-	it("spawns Codex with a sterile temp home and linked auth", async () => {
+	it("spawns Codex with a sterile temp home and readonly copied auth", async () => {
 		const root = join(tmpdir(), `signet-codex-provider-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		const home = join(root, "home");
 		const codex = join(home, ".codex");
@@ -357,8 +357,9 @@ describe("createCodexProvider", () => {
 			expect(capturedEnv?.HOME?.startsWith(tmpdir())).toBe(true);
 			expect(existsSync(dstAuth)).toBe(existsSync(srcAuth));
 			if (existsSync(srcAuth)) {
-				expect(lstatSync(dstAuth).isSymbolicLink() || lstatSync(dstAuth).nlink > 1).toBe(true);
+				expect(lstatSync(dstAuth).isSymbolicLink()).toBe(false);
 				expect(readFileSync(dstAuth, "utf8")).toBe(readFileSync(srcAuth, "utf8"));
+				expect(lstatSync(dstAuth).mode & 0o200).toBe(0);
 			}
 			expect(existsSync(join(capturedEnv?.CODEX_HOME ?? "", "version.json"))).toBe(existsSync(srcVersion));
 			return {

--- a/packages/daemon/src/pipeline/provider.test.ts
+++ b/packages/daemon/src/pipeline/provider.test.ts
@@ -6,7 +6,7 @@
 
 import { afterEach, describe, expect, it, mock } from "bun:test";
 import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { homedir, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
 	DEFAULT_OLLAMA_FALLBACK_MAX_CONTEXT_TOKENS,

--- a/packages/daemon/src/pipeline/provider.test.ts
+++ b/packages/daemon/src/pipeline/provider.test.ts
@@ -4,7 +4,7 @@
  * OllamaProvider uses the Ollama HTTP API, so we mock global fetch.
  */
 
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, describe, expect, it, mock } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";

--- a/packages/daemon/src/pipeline/provider.test.ts
+++ b/packages/daemon/src/pipeline/provider.test.ts
@@ -384,7 +384,7 @@ describe("createCodexProvider", () => {
 			expect(capturedEnv?.XDG_CONFIG_HOME).toBe(join(capturedEnv?.HOME ?? "", ".config"));
 		} finally {
 			if (prevHome === undefined) {
-				process.env.HOME = undefined;
+				delete process.env.HOME;
 			} else {
 				process.env.HOME = prevHome;
 			}

--- a/packages/daemon/src/pipeline/provider.test.ts
+++ b/packages/daemon/src/pipeline/provider.test.ts
@@ -4,12 +4,15 @@
  * OllamaProvider uses the Ollama HTTP API, so we mock global fetch.
  */
 
-import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
 import {
 	DEFAULT_OLLAMA_FALLBACK_MAX_CONTEXT_TOKENS,
-	createOllamaProvider,
 	createClaudeCodeProvider,
 	createCodexProvider,
+	createOllamaProvider,
 	createOpenCodeProvider,
 	createOpenRouterProvider,
 	resolveDefaultOllamaFallbackMaxContextTokens,
@@ -305,8 +308,10 @@ describe("createCodexProvider", () => {
 
 	it("generateWithUsage() parses JSONL agent output and usage", async () => {
 		let capturedArgs: string[] = [];
-		Bun.spawn = mock((args: string[]) => {
+		let capturedEnv: Record<string, string | undefined> | undefined;
+		Bun.spawn = mock((args: string[], opts?: { env?: Record<string, string | undefined> }) => {
 			capturedArgs = args;
+			capturedEnv = opts?.env;
 			return {
 				stdout: streamFromString(
 					'{"type":"thread.started","thread_id":"abc"}\n{"type":"item.completed","item":{"type":"agent_message","text":"done"}}\n{"type":"turn.completed","usage":{"input_tokens":12,"cached_input_tokens":5,"output_tokens":7}}\n',
@@ -324,6 +329,67 @@ describe("createCodexProvider", () => {
 		expect(result.usage?.cacheReadTokens).toBe(5);
 		expect(result.usage?.outputTokens).toBe(7);
 		expect(capturedArgs).not.toContain("-a");
+		expect(capturedArgs).toContain("--ephemeral");
+		expect(capturedArgs).toContain("mcp_servers.signet.enabled=false");
+		expect(typeof capturedEnv?.HOME).toBe("string");
+		expect(capturedEnv?.HOME).not.toBe(process.env.HOME);
+		expect(typeof capturedEnv?.CODEX_HOME).toBe("string");
+	});
+
+	it("spawns Codex with a sterile temp home and copied auth", async () => {
+		const root = join(tmpdir(), `signet-codex-provider-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		const home = join(root, "home");
+		const codex = join(home, ".codex");
+		mkdirSync(codex, { recursive: true });
+		writeFileSync(join(codex, "auth.json"), '{"provider":"test"}');
+		writeFileSync(join(codex, "version.json"), '{"version":"1"}');
+
+		const prevHome = process.env.HOME;
+		process.env.HOME = home;
+
+		let capturedEnv: Record<string, string | undefined> | undefined;
+		Bun.spawn = mock((args: string[], opts?: { env?: Record<string, string | undefined> }) => {
+			capturedEnv = opts?.env;
+			const srcAuth = join(homedir(), ".codex", "auth.json");
+			const srcVersion = join(homedir(), ".codex", "version.json");
+			expect(capturedEnv?.CODEX_HOME).toBe(join(capturedEnv?.HOME ?? "", ".codex"));
+			expect(existsSync(join(capturedEnv?.CODEX_HOME ?? "", "auth.json"))).toBe(existsSync(srcAuth));
+			if (existsSync(srcAuth)) {
+				expect(readFileSync(join(capturedEnv?.CODEX_HOME ?? "", "auth.json"), "utf8")).toBe(
+					readFileSync(srcAuth, "utf8"),
+				);
+			}
+			expect(existsSync(join(capturedEnv?.CODEX_HOME ?? "", "version.json"))).toBe(existsSync(srcVersion));
+			return {
+				stdout: streamFromString(
+					'{"type":"item.completed","item":{"type":"agent_message","text":"done"}}\n{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}\n',
+				),
+				stderr: streamFromString(""),
+				exited: Promise.resolve(0),
+				kill() {},
+			};
+		}) as typeof Bun.spawn;
+
+		try {
+			const provider = createCodexProvider({ model: "gpt-5.3-codex" });
+			if (!provider.generateWithUsage) {
+				throw new Error("expected generateWithUsage on Codex provider");
+			}
+
+			await provider.generateWithUsage("test");
+
+			expect(capturedEnv?.HOME).toBeDefined();
+			expect(capturedEnv?.HOME).not.toBe(home);
+			expect(capturedEnv?.CODEX_HOME).toBe(join(capturedEnv?.HOME ?? "", ".codex"));
+			expect(capturedEnv?.XDG_CONFIG_HOME).toBe(join(capturedEnv?.HOME ?? "", ".config"));
+		} finally {
+			if (prevHome === undefined) {
+				process.env.HOME = undefined;
+			} else {
+				process.env.HOME = prevHome;
+			}
+			rmSync(root, { recursive: true, force: true });
+		}
 	});
 
 	it("generate() throws on non-zero exit", async () => {

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -8,7 +8,7 @@
 // On Windows, use node:child_process spawn with windowsHide to prevent
 // console window flashing. Bun.spawn doesn't support windowsHide.
 import { spawn as nodeSpawn } from "node:child_process";
-import { cpSync, existsSync, linkSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { Readable } from "node:stream";
@@ -202,24 +202,21 @@ function createSterileCodexEnv(baseEnv: Record<string, string | undefined>): {
 	readonly env: Record<string, string | undefined>;
 	cleanup(): void;
 } {
-	const root = join(tmpdir(), "signet-codex-home-");
+	const root = join(tmpdir(), "signet-codex-home");
 	mkdirSync(root, { recursive: true });
-	const home = mkdtempSync(root);
+	for (const name of readdirSync(root)) {
+		if (!name.startsWith("home-")) continue;
+		rmSync(join(root, name), { recursive: true, force: true });
+	}
+	const home = mkdtempSync(join(root, "home-"));
 	const codexHome = join(home, ".codex");
 	mkdirSync(codexHome, { recursive: true });
 
 	const auth = join(homedir(), ".codex", "auth.json");
 	if (existsSync(auth)) {
 		const authDst = join(codexHome, "auth.json");
-		try {
-			if (process.platform === "win32") {
-				linkSync(auth, authDst);
-			} else {
-				symlinkSync(auth, authDst);
-			}
-		} catch {
-			cpSync(auth, authDst);
-		}
+		cpSync(auth, authDst);
+		chmodSync(authDst, 0o400);
 	}
 
 	const version = join(homedir(), ".codex", "version.json");

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -207,15 +207,16 @@ function createSterileCodexEnv(baseEnv: Record<string, string | undefined>): {
 	const home = mkdtempSync(join(root, "home-"));
 	const codexHome = join(home, ".codex");
 	mkdirSync(codexHome, { recursive: true });
+	const liveCodexHome = baseEnv.CODEX_HOME ?? join(homedir(), ".codex");
 
-	const auth = join(homedir(), ".codex", "auth.json");
+	const auth = join(liveCodexHome, "auth.json");
 	if (existsSync(auth)) {
 		const authDst = join(codexHome, "auth.json");
 		cpSync(auth, authDst);
 		chmodSync(authDst, 0o400);
 	}
 
-	const version = join(homedir(), ".codex", "version.json");
+	const version = join(liveCodexHome, "version.json");
 	if (existsSync(version)) {
 		cpSync(version, join(codexHome, "version.json"));
 	}

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -8,8 +8,8 @@
 // On Windows, use node:child_process spawn with windowsHide to prevent
 // console window flashing. Bun.spawn doesn't support windowsHide.
 import { spawn as nodeSpawn } from "node:child_process";
-import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
-import { homedir } from "node:os";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { Readable } from "node:stream";
 import type { LlmGenerateResult, LlmProvider } from "@signet/core";
@@ -202,15 +202,15 @@ function createSterileCodexEnv(baseEnv: Record<string, string | undefined>): {
 	readonly env: Record<string, string | undefined>;
 	cleanup(): void;
 } {
-	const root = join(homedir(), ".cache", "signet");
+	const root = join(tmpdir(), "signet-codex-home-");
 	mkdirSync(root, { recursive: true });
-	const home = mkdtempSync(join(root, "codex-home-"));
+	const home = mkdtempSync(root);
 	const codexHome = join(home, ".codex");
 	mkdirSync(codexHome, { recursive: true });
 
 	const auth = join(homedir(), ".codex", "auth.json");
 	if (existsSync(auth)) {
-		cpSync(auth, join(codexHome, "auth.json"));
+		symlinkSync(auth, join(codexHome, "auth.json"));
 	}
 
 	const version = join(homedir(), ".codex", "version.json");

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -207,7 +207,8 @@ function createSterileCodexEnv(baseEnv: Record<string, string | undefined>): {
 	const home = mkdtempSync(join(root, "home-"));
 	const codexHome = join(home, ".codex");
 	mkdirSync(codexHome, { recursive: true });
-	const liveCodexHome = baseEnv.CODEX_HOME ?? join(homedir(), ".codex");
+	const liveHome = baseEnv.HOME ?? homedir();
+	const liveCodexHome = baseEnv.CODEX_HOME ?? join(liveHome, ".codex");
 
 	const auth = join(liveCodexHome, "auth.json");
 	if (existsSync(auth)) {

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -8,8 +8,9 @@
 // On Windows, use node:child_process spawn with windowsHide to prevent
 // console window flashing. Bun.spawn doesn't support windowsHide.
 import { spawn as nodeSpawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
+import { join } from "node:path";
 import { Readable } from "node:stream";
 import type { LlmGenerateResult, LlmProvider } from "@signet/core";
 import { logger } from "../logger";
@@ -193,6 +194,43 @@ function spawnHidden(cmd: string[], options?: { env?: Record<string, string | un
 				logger.warn("pipeline", `Unknown signal "${signal}", defaulting to SIGTERM`);
 			}
 			proc.kill(sigNum ?? 15);
+		},
+	};
+}
+
+function createSterileCodexEnv(baseEnv: Record<string, string | undefined>): {
+	readonly env: Record<string, string | undefined>;
+	cleanup(): void;
+} {
+	const root = join(homedir(), ".cache", "signet");
+	mkdirSync(root, { recursive: true });
+	const home = mkdtempSync(join(root, "codex-home-"));
+	const codexHome = join(home, ".codex");
+	mkdirSync(codexHome, { recursive: true });
+
+	const auth = join(homedir(), ".codex", "auth.json");
+	if (existsSync(auth)) {
+		cpSync(auth, join(codexHome, "auth.json"));
+	}
+
+	const version = join(homedir(), ".codex", "version.json");
+	if (existsSync(version)) {
+		cpSync(version, join(codexHome, "version.json"));
+	}
+
+	let cleaned = false;
+
+	return {
+		env: {
+			...baseEnv,
+			HOME: home,
+			CODEX_HOME: codexHome,
+			XDG_CONFIG_HOME: join(home, ".config"),
+		},
+		cleanup() {
+			if (cleaned) return;
+			cleaned = true;
+			rmSync(home, { recursive: true, force: true });
 		},
 	};
 }
@@ -1206,8 +1244,11 @@ export function createCodexProvider(config?: Partial<CodexProviderConfig>): LlmP
 				"exec",
 				"--skip-git-repo-check",
 				"--json",
+				"--ephemeral",
 				"--sandbox",
 				"read-only",
+				"-c",
+				"mcp_servers.signet.enabled=false",
 				"-C",
 				cfg.workingDirectory,
 				"--model",
@@ -1216,14 +1257,22 @@ export function createCodexProvider(config?: Partial<CodexProviderConfig>): LlmP
 			];
 
 			const { SIGNET_NO_HOOKS: _, SIGNET_CODEX_BYPASS_WRAPPER: __, ...cleanEnv } = process.env;
-			const proc = spawnHidden(["codex", ...args], {
-				env: {
-					...cleanEnv,
-					NO_COLOR: "1",
-					SIGNET_NO_HOOKS: "1",
-					SIGNET_CODEX_BYPASS_WRAPPER: "1",
-				},
-			});
+			const sterile = createSterileCodexEnv(cleanEnv);
+			let proc: SpawnResult;
+			try {
+				proc = spawnHidden(["codex", ...args], {
+					env: {
+						...sterile.env,
+						NO_COLOR: "1",
+						SIGNET_NO_HOOKS: "1",
+						SIGNET_CODEX_BYPASS_WRAPPER: "1",
+					},
+				});
+			} catch (e) {
+				sterile.cleanup();
+				throw e;
+			}
+			proc.exited.finally(() => sterile.cleanup());
 
 			// Race the subprocess against a timeout. On timeout we kill the
 			// process and reject immediately instead of waiting for streams

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -8,7 +8,7 @@
 // On Windows, use node:child_process spawn with windowsHide to prevent
 // console window flashing. Bun.spawn doesn't support windowsHide.
 import { spawn as nodeSpawn } from "node:child_process";
-import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { Readable } from "node:stream";
@@ -204,10 +204,6 @@ function createSterileCodexEnv(baseEnv: Record<string, string | undefined>): {
 } {
 	const root = join(tmpdir(), "signet-codex-home");
 	mkdirSync(root, { recursive: true });
-	for (const name of readdirSync(root)) {
-		if (!name.startsWith("home-")) continue;
-		rmSync(join(root, name), { recursive: true, force: true });
-	}
 	const home = mkdtempSync(join(root, "home-"));
 	const codexHome = join(home, ".codex");
 	mkdirSync(codexHome, { recursive: true });

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -8,7 +8,7 @@
 // On Windows, use node:child_process spawn with windowsHide to prevent
 // console window flashing. Bun.spawn doesn't support windowsHide.
 import { spawn as nodeSpawn } from "node:child_process";
-import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { cpSync, existsSync, linkSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { Readable } from "node:stream";
@@ -210,7 +210,16 @@ function createSterileCodexEnv(baseEnv: Record<string, string | undefined>): {
 
 	const auth = join(homedir(), ".codex", "auth.json");
 	if (existsSync(auth)) {
-		symlinkSync(auth, join(codexHome, "auth.json"));
+		const authDst = join(codexHome, "auth.json");
+		try {
+			if (process.platform === "win32") {
+				linkSync(auth, authDst);
+			} else {
+				symlinkSync(auth, authDst);
+			}
+		} catch {
+			cpSync(auth, authDst);
+		}
 	}
 
 	const version = join(homedir(), ".codex", "version.json");

--- a/packages/daemon/src/pipeline/skill-graph.test.ts
+++ b/packages/daemon/src/pipeline/skill-graph.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
 import { DEFAULT_PIPELINE_V2, type EmbeddingConfig, type PipelineV2Config } from "../memory-config";
-import { installSkillNode } from "./skill-graph";
+import { installSkillNode, skillEmbeddingHash } from "./skill-graph";
 
 function dbPath(): string {
 	const dir = join(tmpdir(), `signet-skill-graph-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -79,5 +79,16 @@ describe("installSkillNode", () => {
 		);
 		expect(row?.entity_id).toBe(id);
 		expect(row?.uninstalled_at).toBeNull();
+	});
+
+	it("scopes skill embedding hashes by entity id", () => {
+		const frontmatter = {
+			name: "shared-skill",
+			description: "same metadata",
+			version: "1.0.0",
+		} as const;
+		expect(skillEmbeddingHash("skill:default:shared-skill", frontmatter)).not.toBe(
+			skillEmbeddingHash("skill:other:shared-skill", frontmatter),
+		);
 	});
 });

--- a/packages/daemon/src/pipeline/skill-graph.ts
+++ b/packages/daemon/src/pipeline/skill-graph.ts
@@ -77,6 +77,14 @@ function buildEmbeddingText(fm: SkillFrontmatter): string {
 	return parts.join(" — ");
 }
 
+export function skillFingerprint(fm: SkillFrontmatter): string {
+	return buildEmbeddingText(fm);
+}
+
+export function skillFingerprintHash(fm: SkillFrontmatter): string {
+	return contentHash(skillFingerprint(fm));
+}
+
 function contentHash(text: string): string {
 	const h = new Bun.CryptoHasher("sha256");
 	h.update(text);
@@ -99,6 +107,7 @@ export async function installSkillNode(
 	let entityId = skillEntityId(agentId, input.frontmatter.name);
 	const now = new Date().toISOString();
 	const procCfg = config.procedural;
+	const rawHash = skillFingerprintHash(input.frontmatter);
 
 	let fm = input.frontmatter;
 	let enriched = false;
@@ -253,7 +262,6 @@ export async function installSkillNode(
 
 	if (embVec && embVec.length > 0) {
 		const embId = crypto.randomUUID();
-		const hash = contentHash(embeddingText);
 		const blob = vectorToBlob(embVec);
 
 		accessor.withWriteTx((db) => {
@@ -280,11 +288,11 @@ export async function installSkillNode(
 				   dimensions = excluded.dimensions,
 				   source_id = excluded.source_id,
 				   chunk_text = excluded.chunk_text`,
-			).run(embId, hash, blob, embVec.length, entityId, embeddingText, now);
+			).run(embId, rawHash, blob, embVec.length, entityId, embeddingText, now);
 
 			// Query back the actual row id — on conflict SQLite keeps the
 			// existing id, not the one we generated above.
-			const actualRow = db.prepare("SELECT id FROM embeddings WHERE content_hash = ?").get(hash) as { id: string };
+			const actualRow = db.prepare("SELECT id FROM embeddings WHERE content_hash = ?").get(rawHash) as { id: string };
 			syncVecInsert(db, actualRow.id, embVec);
 		});
 

--- a/packages/daemon/src/pipeline/skill-graph.ts
+++ b/packages/daemon/src/pipeline/skill-graph.ts
@@ -77,8 +77,23 @@ function buildEmbeddingText(fm: SkillFrontmatter): string {
 	return parts.join(" — ");
 }
 
+function normalizeList(values: readonly string[] | undefined): readonly string[] {
+	if (!values || values.length === 0) return [];
+	return [...values];
+}
+
 export function skillFingerprint(fm: SkillFrontmatter): string {
-	return buildEmbeddingText(fm);
+	return JSON.stringify({
+		name: fm.name,
+		description: fm.description,
+		version: fm.version ?? null,
+		author: fm.author ?? null,
+		license: fm.license ?? null,
+		triggers: normalizeList(fm.triggers),
+		tags: normalizeList(fm.tags),
+		permissions: normalizeList(fm.permissions),
+		role: fm.role ?? null,
+	});
 }
 
 export function skillFingerprintHash(fm: SkillFrontmatter): string {

--- a/packages/daemon/src/pipeline/skill-graph.ts
+++ b/packages/daemon/src/pipeline/skill-graph.ts
@@ -100,6 +100,10 @@ export function skillFingerprintHash(fm: SkillFrontmatter): string {
 	return contentHash(skillFingerprint(fm));
 }
 
+export function skillEmbeddingHash(entityId: string, fm: SkillFrontmatter): string {
+	return contentHash(`${entityId}\n${skillFingerprint(fm)}`);
+}
+
 function contentHash(text: string): string {
 	const h = new Bun.CryptoHasher("sha256");
 	h.update(text);
@@ -122,7 +126,6 @@ export async function installSkillNode(
 	let entityId = skillEntityId(agentId, input.frontmatter.name);
 	const now = new Date().toISOString();
 	const procCfg = config.procedural;
-	const rawHash = skillFingerprintHash(input.frontmatter);
 
 	let fm = input.frontmatter;
 	let enriched = false;
@@ -278,6 +281,7 @@ export async function installSkillNode(
 	if (embVec && embVec.length > 0) {
 		const embId = crypto.randomUUID();
 		const blob = vectorToBlob(embVec);
+		const embHash = skillEmbeddingHash(entityId, input.frontmatter);
 
 		accessor.withWriteTx((db) => {
 			// Remove any old skill embeddings
@@ -303,11 +307,11 @@ export async function installSkillNode(
 				   dimensions = excluded.dimensions,
 				   source_id = excluded.source_id,
 				   chunk_text = excluded.chunk_text`,
-			).run(embId, rawHash, blob, embVec.length, entityId, embeddingText, now);
+			).run(embId, embHash, blob, embVec.length, entityId, embeddingText, now);
 
 			// Query back the actual row id — on conflict SQLite keeps the
 			// existing id, not the one we generated above.
-			const actualRow = db.prepare("SELECT id FROM embeddings WHERE content_hash = ?").get(rawHash) as { id: string };
+			const actualRow = db.prepare("SELECT id FROM embeddings WHERE content_hash = ?").get(embHash) as { id: string };
 			syncVecInsert(db, actualRow.id, embVec);
 		});
 

--- a/packages/daemon/src/pipeline/skill-reconciler.test.ts
+++ b/packages/daemon/src/pipeline/skill-reconciler.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
+import { DEFAULT_PIPELINE_V2, type EmbeddingConfig, type PipelineV2Config } from "../memory-config";
+import type { LlmProvider } from "./provider";
+import { installSkillNode, skillFingerprintHash } from "./skill-graph";
+import { reconcileOnce } from "./skill-reconciler";
+
+function setup(): { root: string; db: string } {
+	const root = join(tmpdir(), `signet-skill-reconciler-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	mkdirSync(root, { recursive: true });
+	return { root, db: join(root, "memories.db") };
+}
+
+function cfg(): PipelineV2Config {
+	return {
+		...DEFAULT_PIPELINE_V2,
+		graph: { ...DEFAULT_PIPELINE_V2.graph, enabled: false },
+		procedural: { ...DEFAULT_PIPELINE_V2.procedural, enrichOnInstall: true },
+	};
+}
+
+function provider(raw: string): LlmProvider {
+	return {
+		name: "mock",
+		async available() {
+			return true;
+		},
+		async generate() {
+			return raw;
+		},
+	};
+}
+
+const emb: EmbeddingConfig = {
+	model: "test",
+	dimensions: 3,
+	provider: "ollama",
+	base_url: "http://127.0.0.1:11434",
+};
+
+let root = "";
+let db = "";
+
+afterEach(() => {
+	closeDbAccessor();
+	if (root) rmSync(root, { recursive: true, force: true });
+	root = "";
+	db = "";
+});
+
+describe("reconcileOnce", () => {
+	it("does not loop forever after install-time enrichment changes the embedding text", async () => {
+		const paths = setup();
+		root = paths.root;
+		db = paths.db;
+		initDbAccessor(db);
+
+		const skill = "loop-skill";
+		const dir = join(root, "skills", skill);
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(
+			join(dir, "SKILL.md"),
+			`---
+name: ${skill}
+description: tiny
+---
+this skill helps with reconciliation loop debugging and metadata enrichment.`,
+		);
+
+		const raw = {
+			name: skill,
+			description: "tiny",
+		} as const;
+
+		const result = await installSkillNode(
+			{
+				frontmatter: raw,
+				body: "this skill helps with reconciliation loop debugging and metadata enrichment.",
+				source: "reconciler",
+				fsPath: join(dir, "SKILL.md"),
+			},
+			getDbAccessor(),
+			cfg(),
+			emb,
+			async () => [0.1, 0.2, 0.3],
+			provider(
+				'{"description":"debug a reconciliation loop in signet and inspect skill metadata drift","triggers":["debug skill reconcile loop","inspect skill metadata drift"],"tags":["debugging","skills"]}',
+			),
+		);
+
+		const row = getDbAccessor().withReadDb(
+			(dbh) =>
+				dbh
+					.prepare("SELECT content_hash, chunk_text FROM embeddings WHERE source_type = 'skill' AND source_id = ?")
+					.get(result.entityId) as
+					| {
+							content_hash: string;
+							chunk_text: string;
+					  }
+					| undefined,
+		);
+
+		expect(row?.content_hash).toBe(skillFingerprintHash(raw));
+		expect(row?.chunk_text).toContain("debug a reconciliation loop");
+
+		const pass = await reconcileOnce({
+			accessor: getDbAccessor(),
+			pipelineConfig: cfg(),
+			embeddingConfig: emb,
+			fetchEmbedding: async () => {
+				throw new Error("reconcileOnce should not reinstall unchanged enriched skills");
+			},
+			getProvider: () => null,
+			agentsDir: root,
+		});
+
+		expect(pass).toEqual({ installed: 0, updated: 0, removed: 0 });
+	});
+});

--- a/packages/daemon/src/pipeline/skill-reconciler.test.ts
+++ b/packages/daemon/src/pipeline/skill-reconciler.test.ts
@@ -119,4 +119,98 @@ this skill helps with reconciliation loop debugging and metadata enrichment.`,
 
 		expect(pass).toEqual({ installed: 0, updated: 0, removed: 0 });
 	});
+
+	it("updates skill metadata when a non-embedding frontmatter field changes on disk", async () => {
+		const paths = setup();
+		root = paths.root;
+		db = paths.db;
+		initDbAccessor(db);
+
+		const skill = "meta-skill";
+		const dir = join(root, "skills", skill);
+		const file = join(dir, "SKILL.md");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(
+			file,
+			`---
+name: ${skill}
+description: metadata drift test
+version: 1.0.0
+author: nicholai
+---
+this skill helps verify metadata reconciliation.`,
+		);
+
+		const raw = {
+			name: skill,
+			description: "metadata drift test",
+			version: "1.0.0",
+			author: "nicholai",
+		} as const;
+
+		const first = await installSkillNode(
+			{
+				frontmatter: raw,
+				body: "this skill helps verify metadata reconciliation.",
+				source: "reconciler",
+				fsPath: file,
+			},
+			getDbAccessor(),
+			cfg(),
+			emb,
+			async () => [0.1, 0.2, 0.3],
+			null,
+		);
+
+		expect(
+			getDbAccessor().withReadDb(
+				(dbh) =>
+					dbh
+						.prepare("SELECT content_hash FROM embeddings WHERE source_type = 'skill' AND source_id = ?")
+						.get(first.entityId) as { content_hash: string } | undefined,
+			)?.content_hash,
+		).toBe(skillFingerprintHash(raw));
+
+		writeFileSync(
+			file,
+			`---
+name: ${skill}
+description: metadata drift test
+version: 1.0.1
+author: nicholai
+---
+this skill helps verify metadata reconciliation.`,
+		);
+
+		let calls = 0;
+		const pass = await reconcileOnce({
+			accessor: getDbAccessor(),
+			pipelineConfig: cfg(),
+			embeddingConfig: emb,
+			fetchEmbedding: async () => {
+				calls++;
+				return [0.4, 0.5, 0.6];
+			},
+			getProvider: () => null,
+			agentsDir: root,
+		});
+
+		expect(pass).toEqual({ installed: 0, updated: 1, removed: 0 });
+		expect(calls).toBe(1);
+		expect(
+			getDbAccessor().withReadDb(
+				(dbh) =>
+					dbh
+						.prepare(
+							"SELECT content_hash FROM embeddings WHERE source_type = 'skill' AND source_id = ?",
+						)
+						.get(first.entityId) as { content_hash: string } | undefined,
+			)?.content_hash,
+		).toBe(
+			skillFingerprintHash({
+				...raw,
+				version: "1.0.1",
+			}),
+		);
+	});
 });

--- a/packages/daemon/src/pipeline/skill-reconciler.test.ts
+++ b/packages/daemon/src/pipeline/skill-reconciler.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
 import { DEFAULT_PIPELINE_V2, type EmbeddingConfig, type PipelineV2Config } from "../memory-config";
 import type { LlmProvider } from "./provider";
-import { installSkillNode, skillFingerprintHash } from "./skill-graph";
+import { installSkillNode, skillEmbeddingHash } from "./skill-graph";
 import { reconcileOnce } from "./skill-reconciler";
 
 function setup(): { root: string; db: string } {
@@ -103,7 +103,7 @@ this skill helps with reconciliation loop debugging and metadata enrichment.`,
 					| undefined,
 		);
 
-		expect(row?.content_hash).toBe(skillFingerprintHash(raw));
+		expect(row?.content_hash).toBe(skillEmbeddingHash(result.entityId, raw));
 		expect(row?.chunk_text).toContain("debug a reconciliation loop");
 
 		const pass = await reconcileOnce({
@@ -169,7 +169,7 @@ this skill helps verify metadata reconciliation.`,
 						.prepare("SELECT content_hash FROM embeddings WHERE source_type = 'skill' AND source_id = ?")
 						.get(first.entityId) as { content_hash: string } | undefined,
 			)?.content_hash,
-		).toBe(skillFingerprintHash(raw));
+		).toBe(skillEmbeddingHash(first.entityId, raw));
 
 		writeFileSync(
 			file,
@@ -205,9 +205,9 @@ this skill helps verify metadata reconciliation.`,
 							"SELECT content_hash FROM embeddings WHERE source_type = 'skill' AND source_id = ?",
 						)
 						.get(first.entityId) as { content_hash: string } | undefined,
-			)?.content_hash,
+					)?.content_hash,
 		).toBe(
-			skillFingerprintHash({
+			skillEmbeddingHash(first.entityId, {
 				...raw,
 				version: "1.0.1",
 			}),

--- a/packages/daemon/src/pipeline/skill-reconciler.ts
+++ b/packages/daemon/src/pipeline/skill-reconciler.ts
@@ -10,15 +10,15 @@
  * Idempotent — matched by canonical name + frontmatter content hash.
  */
 
-import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { join, basename, dirname } from "node:path";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
 import { watch } from "chokidar";
 import type { DbAccessor } from "../db-accessor.js";
+import { logger } from "../logger.js";
 import type { EmbeddingConfig, PipelineV2Config } from "../memory-config.js";
 import type { LlmProvider } from "./provider.js";
 import { parseSkillFile } from "./skill-frontmatter.js";
-import { installSkillNode, uninstallSkillNode } from "./skill-graph.js";
-import { logger } from "../logger.js";
+import { installSkillNode, skillFingerprintHash, uninstallSkillNode } from "./skill-graph.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -123,21 +123,15 @@ export async function reconcileOnce(deps: ReconcilerDeps): Promise<{
 				const storedEmb = deps.accessor.withReadDb(
 					(db) =>
 						db
-							.prepare("SELECT chunk_text FROM embeddings WHERE source_type = 'skill' AND source_id = ?")
-							.get(actualId) as { chunk_text: string } | undefined,
+							.prepare("SELECT content_hash FROM embeddings WHERE source_type = 'skill' AND source_id = ?")
+							.get(actualId) as { content_hash: string } | undefined,
 				);
+				const rawHash = skillFingerprintHash(parsed.frontmatter);
 
-				// Compare fingerprints: if the embedding text would be different,
-				// the skill has been updated on disk
-				const currentEmbText = [
-					parsed.frontmatter.name,
-					parsed.frontmatter.description,
-					...(parsed.frontmatter.triggers && parsed.frontmatter.triggers.length > 0
-						? [parsed.frontmatter.triggers.join(", ")]
-						: []),
-				].join(" — ");
-
-				if (storedEmb && storedEmb.chunk_text !== currentEmbText) {
+				// Compare the raw on-disk frontmatter fingerprint. Installs may
+				// enrich description/triggers before generating embeddings, so
+				// comparing against chunk_text causes infinite update loops.
+				if (storedEmb && storedEmb.content_hash !== rawHash) {
 					await installSkillNode(
 						{
 							frontmatter: parsed.frontmatter,
@@ -296,15 +290,8 @@ async function reconcileSkill(skillName: string, mdPath: string, deps: Reconcile
 		const parsed = parseSkillFile(content);
 		if (!parsed) return;
 
-		// Skip if frontmatter hasn't changed (avoid redundant embedding work)
 		const entityId = `skill:default:${skillName}`;
-		const currentEmbText = [
-			parsed.frontmatter.name,
-			parsed.frontmatter.description,
-			...(parsed.frontmatter.triggers && parsed.frontmatter.triggers.length > 0
-				? [parsed.frontmatter.triggers.join(", ")]
-				: []),
-		].join(" — ");
+		const rawHash = skillFingerprintHash(parsed.frontmatter);
 
 		// Look up by id or name (entity may have been adopted from extraction)
 		const existingEntity = deps.accessor.withReadDb(
@@ -317,12 +304,12 @@ async function reconcileSkill(skillName: string, mdPath: string, deps: Reconcile
 
 		const storedEmb = deps.accessor.withReadDb(
 			(db) =>
-				db.prepare("SELECT chunk_text FROM embeddings WHERE source_type = 'skill' AND source_id = ?").get(lookupId) as
-					| { chunk_text: string }
+				db.prepare("SELECT content_hash FROM embeddings WHERE source_type = 'skill' AND source_id = ?").get(lookupId) as
+					| { content_hash: string }
 					| undefined,
 		);
 
-		if (storedEmb && storedEmb.chunk_text === currentEmbText) {
+		if (storedEmb && storedEmb.content_hash === rawHash) {
 			logger.debug("reconciler", "Skill unchanged, skipping", { skill: skillName });
 			return;
 		}

--- a/packages/daemon/src/pipeline/skill-reconciler.ts
+++ b/packages/daemon/src/pipeline/skill-reconciler.ts
@@ -18,7 +18,7 @@ import { logger } from "../logger.js";
 import type { EmbeddingConfig, PipelineV2Config } from "../memory-config.js";
 import type { LlmProvider } from "./provider.js";
 import { parseSkillFile } from "./skill-frontmatter.js";
-import { installSkillNode, skillFingerprintHash, uninstallSkillNode } from "./skill-graph.js";
+import { installSkillNode, skillEmbeddingHash, uninstallSkillNode } from "./skill-graph.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -126,7 +126,7 @@ export async function reconcileOnce(deps: ReconcilerDeps): Promise<{
 							.prepare("SELECT content_hash FROM embeddings WHERE source_type = 'skill' AND source_id = ?")
 							.get(actualId) as { content_hash: string } | undefined,
 				);
-				const rawHash = skillFingerprintHash(parsed.frontmatter);
+				const rawHash = skillEmbeddingHash(actualId, parsed.frontmatter);
 
 				// Compare the raw on-disk frontmatter fingerprint. Installs may
 				// enrich description/triggers before generating embeddings, so
@@ -291,7 +291,6 @@ async function reconcileSkill(skillName: string, mdPath: string, deps: Reconcile
 		if (!parsed) return;
 
 		const entityId = `skill:default:${skillName}`;
-		const rawHash = skillFingerprintHash(parsed.frontmatter);
 
 		// Look up by id or name (entity may have been adopted from extraction)
 		const existingEntity = deps.accessor.withReadDb(
@@ -301,7 +300,7 @@ async function reconcileSkill(skillName: string, mdPath: string, deps: Reconcile
 					.get(entityId, skillName) as { id: string } | undefined,
 		);
 		const lookupId = existingEntity?.id ?? entityId;
-
+		const rawHash = skillEmbeddingHash(lookupId, parsed.frontmatter);
 		const storedEmb = deps.accessor.withReadDb(
 			(db) =>
 				db.prepare("SELECT content_hash FROM embeddings WHERE source_type = 'skill' AND source_id = ?").get(lookupId) as


### PR DESCRIPTION
## Summary

Fix two daemon-side feedback loop regressions:

1. procedural skill reconciliation could re-install unchanged skills forever when install-time enrichment changed the stored embedding text
2. provider-spawned Codex extraction runs inherited the live user Codex environment, which let pipeline workers see Signet MCP and user skills

Together these could create noisy repeated reconcile work and make Codex-backed extraction runs much heavier and more self-referential than intended.

## Changes

- fingerprint raw `SKILL.md` frontmatter for skill change detection instead of comparing against enriched embedding text
- store an entity-scoped skill embedding hash so reconciliation stays stable without cross-entity collisions
- add regression tests covering the skill reconciler infinite update loop and metadata-only updates
- run provider-spawned Codex extraction in a sterile temporary `HOME` / `CODEX_HOME` rooted in `tmpdir()`
- copy Codex auth into that temporary home as a read-only file, copy version state, and avoid deleting sibling temp homes so concurrent provider runs stay isolated
- force provider-spawned Codex runs to use `--ephemeral` and `-c mcp_servers.signet.enabled=false`
- add regression coverage asserting the Codex provider launch args and sterile environment behavior

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A, no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [ ] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [ ] Rollback / compatibility note included in PR description

N/A for parity in this PR: the Rust shadow currently does not implement Codex extraction provider execution (`packages/daemon-rs/crates/signet-daemon/src/main.rs` asserts `worker_supports_extraction_provider("codex") == false`) and does not implement the procedural skill reconciler path changed here.

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Validation run:

- `bun test`
- `bun run typecheck`
- `bun test packages/daemon/src/pipeline/provider.test.ts`
- `bun test packages/daemon/src/pipeline/skill-reconciler.test.ts packages/daemon/src/pipeline/skill-graph.test.ts`
- targeted `biome check` on touched provider / skill reconciler files
- live local Codex probes verifying sterile temp-home runs preserve auth while removing MCP and user-skill inheritance

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

- No API surface or migration changes.
- The Codex provider fix intentionally reduces inherited state for pipeline worker runs only. It does not change the normal interactive user Codex environment.
- Full-repo `bun run lint` still fails because of unrelated existing repo-wide baseline diagnostics, mostly formatter/style issues outside the touched files. Targeted checks for touched files passed.

