### PR TITLE
feat(dashboard): feature official marketplace skills

### DIFF
--- a/docs/research/technical/RESEARCH-MARKETPLACE-OFFICIAL-SKILLS.md
+++ b/docs/research/technical/RESEARCH-MARKETPLACE-OFFICIAL-SKILLS.md
@@ -44,8 +44,9 @@ The marketplace should do two things simultaneously:
 - Add a dedicated featured strip for official Signet skills at the top
   of the browse view when the user is not actively searching.
 - Cap the featured strip so it highlights a handful of curated skills,
-  with built-in skills ordered first and the rest by existing
-  popularity score.
+  with built-in skills ordered first, then usage-aware ordering
+  inside the built-in and non-built-in groups, with popularity as the
+  fallback.
 - Keep the main catalog below the strip and remove duplicate cards so
   featured entries are not shown twice in the same viewport.
 - Expose `Signet` as a provider filter anywhere the marketplace embeds

--- a/docs/research/technical/RESEARCH-MARKETPLACE-OFFICIAL-SKILLS.md
+++ b/docs/research/technical/RESEARCH-MARKETPLACE-OFFICIAL-SKILLS.md
@@ -1,0 +1,54 @@
+---
+title: "Marketplace Official Skills Featuring"
+question: "How should the dashboard marketplace spotlight Signet official skills without hiding the broader community catalog?"
+date: "2026-03-30"
+status: "complete"
+---
+
+# Marketplace official skills featuring
+
+## What this research answers
+
+This note captures the current marketplace behavior and the smallest
+product contract needed to make Signet's official skills feel like a
+first-party offering instead of just another provider in the list.
+
+## Current state
+
+1. The daemon already exposes Signet-maintained skills through the
+   `/api/skills/browse` and `/api/skills/search` endpoints with
+   `provider = "signet"`, `official = true`, and optional `builtin`
+   metadata.
+2. The browse API already de-duplicates by skill name so official
+   Signet skills win over duplicate third-party entries.
+3. The dashboard marketplace embeds the shared skills browser, but the
+   marketplace-specific provider filter omits the `signet` provider.
+   That means official skills exist in the catalog but cannot be
+   explicitly filtered from the main marketplace rail.
+4. The current browse grid treats official skills the same as every
+   other result. They may sort near the top, but there is no clear
+   first-party featured section.
+
+## Product direction
+
+The marketplace should do two things simultaneously:
+
+1. Preserve the open catalog. Signet official skills should be featured,
+   not turned into a walled garden.
+2. Make the first-party path obvious. Official skills need a dedicated,
+   high-visibility section in the browse experience plus an explicit
+   Signet provider filter in the marketplace rail.
+
+## Recommended contract
+
+- Add a dedicated featured strip for official Signet skills at the top
+  of the browse view when the user is not actively searching.
+- Cap the featured strip so it highlights a handful of curated skills,
+  with built-in skills ordered first and the rest by existing
+  popularity score.
+- Keep the main catalog below the strip and remove duplicate cards so
+  featured entries are not shown twice in the same viewport.
+- Expose `Signet` as a provider filter anywhere the marketplace embeds
+  skills browsing controls.
+- Preserve existing install and detail flows. This is a presentation and
+  discoverability change, not a backend distribution change.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -139,6 +139,7 @@ and market subdirectories). Reference repos live in `references/`.
 | `docker-self-hosting-stack` | RESEARCH-DOCKER-SELF-HOSTING | What deployment contract keeps Docker self-hosting reproducible, persistent, and secure by default? |
 | `openclaw-workspace-protection-plan`, `openclaw-workspace-protection` | RESEARCH-OPENCLAW-WORKSPACE-PROTECTION | How should Signet prevent data loss when OpenClaw uninstall deletes a workspace that points at `.agents`? |
 | `dogfood-hardening-2026-03-29` | RESEARCH-DOGFOOD-HARDENING-2026-03-29 | Which runtime, MCP, and knowledge-surface regressions from the March 29, 2026 dogfood run need durable hardening? |
+| `marketplace-official-skills` | RESEARCH-MARKETPLACE-OFFICIAL-SKILLS | How should the dashboard marketplace spotlight Signet official skills without hiding the broader community catalog? |
 
 ### Research Adoption Ledger (high-impact)
 
@@ -607,6 +608,8 @@ Phase ordering based on hard dependencies and integration contracts.
   - GitHub-authenticated PR workflow for skills/servers and JSON review artifacts
 - **Adaptive Skill Lifecycle** (`adaptive-skill-lifecycle`)
   - passive/continuous skill maintenance with outcome feedback loops
+- **Marketplace Official Skills Featuring** (`marketplace-official-skills`)
+  - dashboard browse UX that foregrounds Signet official skills without hiding the wider catalog
 - **Cryptographic Identity Roadmap** (`cryptographic-identity-roadmap`)
 - **Connector: Py Agent** (`connector-py-agent`)
 - **Connector: Hermes Agent** (`connector-hermes-agent`)
@@ -697,6 +700,7 @@ Legend:
 | `mcp-cli-bridge-and-usage-analytics` | approved | `docs/specs/planning/mcp-cli-bridge-and-usage-analytics.md` | `signet-runtime` | - | Phase 1: CLI bridge, invocation tracking, analytics API, dashboard panel |
 | `git-marketplace-monorepo` | planning | `docs/specs/planning/git-marketplace-monorepo.md` | `predictor-agent-feedback` | - | Stub: GitHub-authenticated PR marketplace for skills and MCP servers |
 | `adaptive-skill-lifecycle` | planning | `docs/specs/planning/adaptive-skill-lifecycle.md` | `procedural-memory-plan`, `predictor-agent-feedback` | - | Stub: passive continuous skill creation/maintenance loop |
+| `marketplace-official-skills` | planning | `docs/specs/planning/marketplace-official-skills.md` | `procedural-memory-plan` | - | Stub: feature Signet official skills prominently in the dashboard marketplace |
 | `cryptographic-identity-roadmap` | planning | `docs/specs/planning/cryptographic-identity-roadmap.md` | `multi-agent-support` | - | Stub: signed identity and artifact trust roadmap |
 | `connector-py-agent` | planning | `docs/specs/planning/connector-py-agent.md` | `signet-runtime` | - | Stub: Py Agent connector |
 | `connector-hermes-agent` | planning | `docs/specs/planning/connector-hermes-agent.md` | `signet-runtime` | - | Stub: Hermes Agent connector |

--- a/docs/specs/dependencies.yaml
+++ b/docs/specs/dependencies.yaml
@@ -1,5 +1,5 @@
 version: 3
-updated_at: "2026-03-29"
+updated_at: "2026-03-30"
 
 specs:
   - id: memory-pipeline-v2
@@ -720,6 +720,21 @@ specs:
     informed_by: []
     success_criteria:
       - "GitHub-authenticated pull-request workflow supports publishing and reviewing skills and MCP servers"
+    decision: null
+
+  - id: marketplace-official-skills
+    status: planning
+    path: docs/specs/planning/marketplace-official-skills.md
+    hard_depends_on:
+      - procedural-memory-plan
+    soft_depends_on: []
+    blocks: []
+    informed_by:
+      - docs/research/technical/RESEARCH-MARKETPLACE-OFFICIAL-SKILLS.md
+    success_criteria:
+      - "Dashboard marketplace browse view shows a dedicated featured section for official Signet skills when users are exploring the skills catalog"
+      - "Marketplace filter controls can explicitly narrow the skills catalog to the Signet provider"
+      - "Featured official skills do not render as duplicate cards again in the same initial catalog viewport"
     decision: null
 
 

--- a/docs/specs/planning/marketplace-official-skills.md
+++ b/docs/specs/planning/marketplace-official-skills.md
@@ -1,0 +1,98 @@
+---
+title: "Marketplace Official Skills Featuring"
+id: marketplace-official-skills
+status: planning
+informed_by:
+  - docs/research/technical/RESEARCH-MARKETPLACE-OFFICIAL-SKILLS.md
+section: "Marketplace"
+depends_on:
+  - procedural-memory-plan
+success_criteria:
+  - "Dashboard marketplace browse view shows a dedicated featured section for official Signet skills when users are exploring the skills catalog"
+  - "Marketplace filter controls can explicitly narrow the skills catalog to the Signet provider"
+  - "Featured official skills do not render as duplicate cards again in the same initial catalog viewport"
+scope_boundary: "Dashboard marketplace discoverability for official Signet skills. Does not change marketplace publishing, install protocols, or external registry ranking logic."
+draft_quality: "implementation-ready stub"
+---
+
+# Marketplace Official Skills Featuring
+
+## Problem Statement
+
+Signet already ships and catalogs official skills, but the marketplace
+experience does not clearly present them as first-party capabilities.
+They appear inside the broader catalog, yet the embedded marketplace
+filter controls cannot explicitly switch to the `signet` provider, and
+there is no dedicated featured section that makes the official starting
+point obvious.
+
+The result is a weak first-run experience. Users can browse the catalog,
+but they are not clearly shown, "here are the official skills Signet
+ships and stands behind."
+
+## Goals
+
+1. Feature official Signet skills prominently in the marketplace browse
+   experience.
+2. Preserve the broader community catalog instead of replacing it.
+3. Keep official featured cards aligned with existing install/detail
+   flows and existing daemon catalog metadata.
+4. Prevent duplicate rendering of featured skills in the initial browse
+   layout.
+
+## Proposed Capability Set
+
+### A. Featured official strip
+
+When the marketplace is in skills browse mode and no active search is
+running, the dashboard renders a dedicated featured section above the
+main grid. The section sources its entries from catalog items where:
+
+- `provider = 'signet'`, or
+- `official = true`
+
+Ordering contract:
+
+1. built-in official skills first
+2. remaining official skills by existing popularity score
+3. stable name tie-break
+
+The section is capped to a small number of cards so it stays curated and
+scan-friendly.
+
+### B. Provider filter parity
+
+Any marketplace-owned provider selector that proxies the shared skills
+browser must expose `signet` alongside `skills.sh` and `clawhub`.
+
+### C. No duplicate cards in the initial browse viewport
+
+If an item is shown in the featured official strip, the same browse
+payload should not immediately repeat that card again in the primary
+catalog grid beneath it.
+
+## Non-Goals
+
+- New daemon endpoints or catalog schema changes
+- Marketplace publishing workflow changes
+- Community ranking changes
+- Review, trust, or package-signing changes
+
+## Integration Contracts
+
+- **Procedural Memory**: uses the existing skills browse/search catalog
+  surfaces and official metadata already emitted by the skills routes.
+- **Git Marketplace Monorepo**: complementary. This spec improves local
+  dashboard discoverability and does not define remote registry
+  publishing.
+- **Dashboard IA Refactor**: if the marketplace layout changes later,
+  the official featured contract still holds as a browse-surface
+  requirement.
+
+## Validation and Tests
+
+- Add a focused test for featured-skill partitioning and ordering.
+- Verify the embedded marketplace provider selector can choose
+  `Signet`.
+- Verify the browse grid hides featured items from the immediate main
+  grid list.

--- a/docs/specs/planning/marketplace-official-skills.md
+++ b/docs/specs/planning/marketplace-official-skills.md
@@ -54,8 +54,9 @@ main grid. The section sources its entries from catalog items where:
 Ordering contract:
 
 1. built-in official skills first
-2. remaining official skills by existing popularity score
-3. stable name tie-break
+2. within the built-in and non-built-in groups, prefer explicit featured or usage signals when present
+3. fall back to existing popularity score
+4. stable name tie-break
 
 The section is capped to a small number of cards so it stays curated and
 scan-friendly.

--- a/packages/cli/dashboard/src/lib/api.ts
+++ b/packages/cli/dashboard/src/lib/api.ts
@@ -1245,6 +1245,9 @@ export interface SkillSearchResult {
 	installs: string;
 	installsRaw?: number;
 	popularityScore?: number;
+	useCount?: number;
+	lastUsedAt?: string;
+	featuredScore?: number;
 	description: string;
 	installed: boolean;
 	provider?: "skills.sh" | "clawhub" | "signet";

--- a/packages/cli/dashboard/src/lib/components/skills/SkillGrid.svelte
+++ b/packages/cli/dashboard/src/lib/components/skills/SkillGrid.svelte
@@ -8,6 +8,7 @@ type EmptyStateKind = "installed" | "browse" | "search";
 type Props = {
 	items: (Skill | SkillSearchResult)[];
 	mode: "installed" | "browse";
+	featuredItems?: SkillSearchResult[];
 	selectedName?: string | null;
 	installing?: string | null;
 	uninstalling?: string | null;
@@ -25,9 +26,10 @@ type Props = {
 	}) => void | Promise<void>;
 };
 
-let {
+const {
 	items,
 	mode,
+	featuredItems = [],
 	selectedName = null,
 	installing = null,
 	uninstalling = null,
@@ -86,6 +88,35 @@ const remainingCount = $derived(items.length - visibleCount);
 </script>
 
 <div class="grid-container">
+	{#if featuredItems.length > 0 && mode === "browse"}
+		<section class="featured-block">
+			<div class="featured-head">
+				<div>
+					<div class="featured-kicker">Official Signet Skills</div>
+					<h3 class="featured-title">Start with the first-party toolkit</h3>
+				</div>
+				<div class="featured-count">{featuredItems.length} featured</div>
+			</div>
+			<div class="grid featured-grid">
+				{#each featuredItems as item (skillKey(item))}
+					<SkillCard
+						{item}
+						{mode}
+						featured={true}
+						selected={selectedName === item.name}
+						installing={installing === item.name}
+						uninstalling={uninstalling === item.name}
+						compareSelected={compareSelectedKeys.includes(skillKey(item))}
+						onclick={() => onitemclick?.(item.name)}
+						oninstall={() => oninstall?.(item.name)}
+						onuninstall={() => onuninstall?.(item.name)}
+						oncomparetoggle={() => oncomparetoggle?.(skillKey(item))}
+					/>
+				{/each}
+			</div>
+		</section>
+	{/if}
+
 	{#if items.length > 0}
 		<!-- Main grid -->
 		<div class="grid">
@@ -114,7 +145,7 @@ const remainingCount = $derived(items.length - visibleCount);
 				Show more ({remainingCount} remaining)
 			</button>
 		{/if}
-	{:else}
+	{:else if featuredItems.length === 0}
 		{#if emptyState}
 			<SkillsEmptyState kind={emptyState} actions={emptyActions} />
 		{:else}
@@ -139,6 +170,46 @@ const remainingCount = $derived(items.length - visibleCount);
 		display: grid;
 		grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
 		gap: var(--space-sm);
+	}
+
+	.featured-block {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-sm);
+		padding: var(--space-sm);
+		border: 1px solid var(--sig-border-strong);
+		border-radius: 10px;
+		background:
+			linear-gradient(180deg, color-mix(in srgb, var(--sig-accent) 8%, transparent), transparent 60%),
+			var(--sig-surface);
+	}
+
+	.featured-head {
+		display: flex;
+		align-items: end;
+		justify-content: space-between;
+		gap: var(--space-sm);
+	}
+
+	.featured-kicker,
+	.featured-count {
+		font-family: var(--font-mono);
+		font-size: 9px;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--sig-text-muted);
+	}
+
+	.featured-title {
+		margin: 2px 0 0;
+		font-family: var(--font-display);
+		font-size: 14px;
+		line-height: 1.1;
+		color: var(--sig-text-bright);
+	}
+
+	.featured-grid {
+		grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
 	}
 
 	.show-more {

--- a/packages/cli/dashboard/src/lib/components/skills/featured-skills.test.ts
+++ b/packages/cli/dashboard/src/lib/components/skills/featured-skills.test.ts
@@ -1,0 +1,74 @@
+// @ts-nocheck
+import { describe, expect, it } from "bun:test";
+import { getFeaturedOfficialSkills, omitFeaturedSkills } from "./featured-skills";
+
+const items = [
+	{
+		name: "community-top",
+		fullName: "someone/community-top",
+		installs: "9.9K",
+		installsRaw: 9900,
+		popularityScore: 9900,
+		description: "community",
+		installed: false,
+		provider: "skills.sh",
+	},
+	{
+		name: "official-built-in",
+		fullName: "Signet-AI/signetai",
+		installs: "built-in",
+		installsRaw: 100000,
+		popularityScore: 200000,
+		useCount: 2,
+		description: "official built in",
+		installed: false,
+		provider: "signet",
+		official: true,
+		builtin: true,
+	},
+	{
+		name: "official-high",
+		fullName: "Signet-AI/signetai",
+		installs: "--",
+		installsRaw: 1000,
+		popularityScore: 50000,
+		useCount: 11,
+		description: "official high",
+		installed: false,
+		provider: "signet",
+		official: true,
+	},
+	{
+		name: "official-low",
+		fullName: "Signet-AI/signetai",
+		installs: "--",
+		installsRaw: 100,
+		popularityScore: 1000,
+		useCount: 1,
+		description: "official low",
+		installed: false,
+		provider: "signet",
+		official: true,
+	},
+];
+
+describe("featured official skills", () => {
+	it("prefers actual usage over fallback popularity and built-in status", () => {
+		const featured = getFeaturedOfficialSkills(items, 3);
+		expect(featured.map((item) => item.name)).toEqual(["official-high", "official-built-in", "official-low"]);
+	});
+
+	it("falls back to built-in plus popularity ordering when usage data is absent", () => {
+		const featured = getFeaturedOfficialSkills(
+			items.map((item) => ({ ...item, useCount: undefined, lastUsedAt: undefined })),
+			3,
+		);
+		expect(featured.map((item) => item.name)).toEqual(["official-built-in", "official-high", "official-low"]);
+	});
+
+	it("removes featured skills from the main browse grid", () => {
+		const featured = getFeaturedOfficialSkills(items, 2);
+		const rest = omitFeaturedSkills(items, featured);
+		expect(rest.map((item) => item.name)).toEqual(["community-top", "official-low"]);
+	});
+});

--- a/packages/cli/dashboard/src/lib/components/skills/featured-skills.test.ts
+++ b/packages/cli/dashboard/src/lib/components/skills/featured-skills.test.ts
@@ -14,13 +14,26 @@ const items = [
 		provider: "skills.sh",
 	},
 	{
-		name: "official-built-in",
+		name: "official-built-in-low",
 		fullName: "Signet-AI/signetai",
 		installs: "built-in",
 		installsRaw: 100000,
 		popularityScore: 200000,
 		useCount: 2,
-		description: "official built in",
+		description: "official built in low",
+		installed: false,
+		provider: "signet",
+		official: true,
+		builtin: true,
+	},
+	{
+		name: "official-built-in-high",
+		fullName: "Signet-AI/signetai",
+		installs: "built-in",
+		installsRaw: 100000,
+		popularityScore: 100000,
+		useCount: 8,
+		description: "official built in high",
 		installed: false,
 		provider: "signet",
 		official: true,
@@ -53,22 +66,32 @@ const items = [
 ];
 
 describe("featured official skills", () => {
-	it("prefers actual usage over fallback popularity and built-in status", () => {
-		const featured = getFeaturedOfficialSkills(items, 3);
-		expect(featured.map((item) => item.name)).toEqual(["official-high", "official-built-in", "official-low"]);
+	it("keeps built-in official skills ahead of other official skills", () => {
+		const featured = getFeaturedOfficialSkills(items, 4);
+		expect(featured.map((item) => item.name)).toEqual([
+			"official-built-in-high",
+			"official-built-in-low",
+			"official-high",
+			"official-low",
+		]);
 	});
 
-	it("falls back to built-in plus popularity ordering when usage data is absent", () => {
+	it("uses popularity fallback ordering when usage data is absent within each built-in bucket", () => {
 		const featured = getFeaturedOfficialSkills(
-			items.map((item) => ({ ...item, useCount: undefined, lastUsedAt: undefined })),
-			3,
+			items.map((item) => ({ ...item, useCount: undefined, lastUsedAt: undefined, featuredScore: undefined })),
+			4,
 		);
-		expect(featured.map((item) => item.name)).toEqual(["official-built-in", "official-high", "official-low"]);
+		expect(featured.map((item) => item.name)).toEqual([
+			"official-built-in-low",
+			"official-built-in-high",
+			"official-high",
+			"official-low",
+		]);
 	});
 
 	it("removes featured skills from the main browse grid", () => {
 		const featured = getFeaturedOfficialSkills(items, 2);
 		const rest = omitFeaturedSkills(items, featured);
-		expect(rest.map((item) => item.name)).toEqual(["community-top", "official-low"]);
+		expect(rest.map((item) => item.name)).toEqual(["community-top", "official-high", "official-low"]);
 	});
 });

--- a/packages/cli/dashboard/src/lib/components/skills/featured-skills.ts
+++ b/packages/cli/dashboard/src/lib/components/skills/featured-skills.ts
@@ -1,0 +1,43 @@
+import type { SkillSearchResult } from "$lib/api";
+
+export function isOfficialSkill(item: SkillSearchResult): boolean {
+	if (item.provider === "signet") return true;
+	return item.official === true;
+}
+
+function parseTime(input: string | undefined): number {
+	if (!input) return 0;
+	const time = Date.parse(input);
+	return Number.isFinite(time) ? time : 0;
+}
+
+function fallbackWeight(item: SkillSearchResult): number {
+	const builtIn = item.builtin ? 1 : 0;
+	const pop = item.popularityScore ?? item.installsRaw ?? 0;
+	return pop * 10 + builtIn;
+}
+
+export function getFeaturedOfficialSkills(items: readonly SkillSearchResult[], limit = 6): SkillSearchResult[] {
+	return [...items]
+		.filter(isOfficialSkill)
+		.sort((a, b) => {
+			const featuredDiff = (b.featuredScore ?? 0) - (a.featuredScore ?? 0);
+			if (featuredDiff !== 0) return featuredDiff;
+			const useDiff = (b.useCount ?? 0) - (a.useCount ?? 0);
+			if (useDiff !== 0) return useDiff;
+			const timeDiff = parseTime(b.lastUsedAt) - parseTime(a.lastUsedAt);
+			if (timeDiff !== 0) return timeDiff;
+			const fallbackDiff = fallbackWeight(b) - fallbackWeight(a);
+			if (fallbackDiff !== 0) return fallbackDiff;
+			return a.name.localeCompare(b.name);
+		})
+		.slice(0, limit);
+}
+
+export function omitFeaturedSkills(
+	items: readonly SkillSearchResult[],
+	featured: readonly SkillSearchResult[],
+): SkillSearchResult[] {
+	const names = new Set(featured.map((item) => item.name));
+	return items.filter((item) => !names.has(item.name));
+}

--- a/packages/cli/dashboard/src/lib/components/skills/featured-skills.ts
+++ b/packages/cli/dashboard/src/lib/components/skills/featured-skills.ts
@@ -12,24 +12,28 @@ function parseTime(input: string | undefined): number {
 }
 
 function fallbackWeight(item: SkillSearchResult): number {
-	const builtIn = item.builtin ? 1 : 0;
-	const pop = item.popularityScore ?? item.installsRaw ?? 0;
-	return pop * 10 + builtIn;
+	return item.popularityScore ?? item.installsRaw ?? 0;
+}
+
+function compareUsage(a: SkillSearchResult, b: SkillSearchResult): number {
+	const featuredDiff = (b.featuredScore ?? 0) - (a.featuredScore ?? 0);
+	if (featuredDiff !== 0) return featuredDiff;
+	const useDiff = (b.useCount ?? 0) - (a.useCount ?? 0);
+	if (useDiff !== 0) return useDiff;
+	const timeDiff = parseTime(b.lastUsedAt) - parseTime(a.lastUsedAt);
+	if (timeDiff !== 0) return timeDiff;
+	const fallbackDiff = fallbackWeight(b) - fallbackWeight(a);
+	if (fallbackDiff !== 0) return fallbackDiff;
+	return a.name.localeCompare(b.name);
 }
 
 export function getFeaturedOfficialSkills(items: readonly SkillSearchResult[], limit = 6): SkillSearchResult[] {
 	return [...items]
 		.filter(isOfficialSkill)
 		.sort((a, b) => {
-			const featuredDiff = (b.featuredScore ?? 0) - (a.featuredScore ?? 0);
-			if (featuredDiff !== 0) return featuredDiff;
-			const useDiff = (b.useCount ?? 0) - (a.useCount ?? 0);
-			if (useDiff !== 0) return useDiff;
-			const timeDiff = parseTime(b.lastUsedAt) - parseTime(a.lastUsedAt);
-			if (timeDiff !== 0) return timeDiff;
-			const fallbackDiff = fallbackWeight(b) - fallbackWeight(a);
-			if (fallbackDiff !== 0) return fallbackDiff;
-			return a.name.localeCompare(b.name);
+			const builtInDiff = Number(b.builtin === true) - Number(a.builtin === true);
+			if (builtInDiff !== 0) return builtInDiff;
+			return compareUsage(a, b);
 		})
 		.slice(0, limit);
 }

--- a/packages/cli/dashboard/src/lib/components/tabs/MarketplaceTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/MarketplaceTab.svelte
@@ -5,6 +5,7 @@ import { Button } from "$lib/components/ui/button/index.js";
 import * as Collapsible from "$lib/components/ui/collapsible/index.js";
 import * as Select from "$lib/components/ui/select/index.js";
 import { returnToSidebar } from "$lib/stores/focus.svelte";
+import { getSkillsProviderLabel, normalizeSkillsProviderFilter } from "$lib/components/tabs/marketplace-filters";
 import {
 	fetchMarketplaceMcpCatalog,
 	fetchMarketplaceMcpInstalled,
@@ -103,10 +104,7 @@ const activeSortLabel = $derived.by(() => {
 
 const activeSecondarySortLabel = $derived.by(() => {
 	if (section === "skills") {
-		if (sk.providerFilter === "signet") return "Signet";
-		if (sk.providerFilter === "skills.sh") return "skills.sh";
-		if (sk.providerFilter === "clawhub") return "ClawHub";
-		return "All providers";
+		return getSkillsProviderLabel(sk.providerFilter);
 	}
 	if (mcpMarket.source === "mcpservers.org") return "MCP Registry";
 	if (mcpMarket.source === "modelcontextprotocol/servers") return "MCP GitHub";
@@ -153,11 +151,7 @@ function applySort(value: string): void {
 
 function applySecondarySort(value: string): void {
 	if (section === "skills") {
-		if (value === "signet" || value === "skills.sh" || value === "clawhub") {
-			sk.providerFilter = value;
-			return;
-		}
-		sk.providerFilter = "all";
+		sk.providerFilter = normalizeSkillsProviderFilter(value);
 		return;
 	}
 	if (value === "mcpservers.org" || value === "modelcontextprotocol/servers" || value === "github") {

--- a/packages/cli/dashboard/src/lib/components/tabs/MarketplaceTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/MarketplaceTab.svelte
@@ -103,6 +103,7 @@ const activeSortLabel = $derived.by(() => {
 
 const activeSecondarySortLabel = $derived.by(() => {
 	if (section === "skills") {
+		if (sk.providerFilter === "signet") return "Signet";
 		if (sk.providerFilter === "skills.sh") return "skills.sh";
 		if (sk.providerFilter === "clawhub") return "ClawHub";
 		return "All providers";
@@ -152,7 +153,7 @@ function applySort(value: string): void {
 
 function applySecondarySort(value: string): void {
 	if (section === "skills") {
-		if (value === "skills.sh" || value === "clawhub") {
+		if (value === "signet" || value === "skills.sh" || value === "clawhub") {
 			sk.providerFilter = value;
 			return;
 		}
@@ -812,6 +813,7 @@ $effect(() => {
 							<Select.Content class="section-select-content">
 								{#if section === "skills"}
 									<Select.Item value="all" label="All providers" class="section-select-item" />
+									<Select.Item value="signet" label="Signet" class="section-select-item" />
 									<Select.Item value="skills.sh" label="skills.sh" class="section-select-item" />
 									<Select.Item value="clawhub" label="ClawHub" class="section-select-item" />
 								{:else}

--- a/packages/cli/dashboard/src/lib/components/tabs/SkillsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/SkillsTab.svelte
@@ -3,6 +3,7 @@ import type { SkillSearchResult } from "$lib/api";
 import SkillDetail from "$lib/components/skills/SkillDetail.svelte";
 import SkillGrid from "$lib/components/skills/SkillGrid.svelte";
 import SkillsComparePanel from "$lib/components/skills/SkillsComparePanel.svelte";
+import { getFeaturedOfficialSkills, omitFeaturedSkills } from "$lib/components/skills/featured-skills";
 import * as Select from "$lib/components/ui/select/index.js";
 import * as Tabs from "$lib/components/ui/tabs/index.js";
 import {
@@ -34,7 +35,7 @@ interface Props {
 	}) => void | Promise<void>;
 }
 
-let { embedded = false, showViewTabs = true, onreviewrequest }: Props = $props();
+const { embedded = false, showViewTabs = true, onreviewrequest }: Props = $props();
 
 const searchInputId = "skills-search-input";
 
@@ -117,6 +118,19 @@ const displayItems = $derived.by(() => {
 const displayMode = $derived<"installed" | "browse">(
 	sk.view === "installed" && !sk.query.trim() ? "installed" : "browse",
 );
+
+const featuredItems = $derived.by(() => {
+	if (displayMode !== "browse") return [];
+	if (sk.query.trim()) return [];
+	return getFeaturedOfficialSkills(getFilteredCatalog());
+});
+
+const gridItems = $derived.by(() => {
+	if (displayMode !== "browse") return displayItems;
+	if (sk.query.trim()) return displayItems;
+	if (featuredItems.length === 0) return displayItems;
+	return omitFeaturedSkills(getFilteredCatalog(), featuredItems);
+});
 
 const emptyState = $derived<"installed" | "browse" | "search" | null>(
 	sk.query.trim() && displayItems.length === 0
@@ -318,8 +332,9 @@ onMount(() => {
 		</div>
 	{:else}
 		<SkillGrid
-			items={displayItems}
+			items={gridItems}
 			mode={displayMode}
+			featuredItems={featuredItems}
 			selectedName={sk.selectedName}
 			installing={sk.installing}
 			uninstalling={sk.uninstalling}

--- a/packages/cli/dashboard/src/lib/components/tabs/marketplace-filters.test.ts
+++ b/packages/cli/dashboard/src/lib/components/tabs/marketplace-filters.test.ts
@@ -1,0 +1,49 @@
+// @ts-nocheck
+import { describe, expect, it } from "bun:test";
+import {
+	filterSkillsByProvider,
+	getSkillsProviderLabel,
+	normalizeSkillsProviderFilter,
+} from "./marketplace-filters";
+
+const items = [
+	{
+		name: "official-a",
+		fullName: "Signet-AI/signetai",
+		installs: "--",
+		installsRaw: 10,
+		popularityScore: 10,
+		description: "official",
+		installed: false,
+		provider: "signet",
+	},
+	{
+		name: "community-a",
+		fullName: "someone/community-a",
+		installs: "--",
+		installsRaw: 100,
+		popularityScore: 100,
+		description: "community",
+		installed: false,
+		provider: "skills.sh",
+	},
+];
+
+describe("marketplace skill provider filter", () => {
+	it("selects the signet provider and round-trips the rail label", () => {
+		const provider = normalizeSkillsProviderFilter("signet");
+		expect(provider).toBe("signet");
+		expect(getSkillsProviderLabel(provider)).toBe("Signet");
+		expect(filterSkillsByProvider(items, provider).map((item) => item.name)).toEqual(["official-a"]);
+	});
+
+	it("falls back to all providers for unknown values", () => {
+		const provider = normalizeSkillsProviderFilter("nope");
+		expect(provider).toBe("all");
+		expect(getSkillsProviderLabel(provider)).toBe("All providers");
+		expect(filterSkillsByProvider(items, provider).map((item) => item.name)).toEqual([
+			"official-a",
+			"community-a",
+		]);
+	});
+});

--- a/packages/cli/dashboard/src/lib/components/tabs/marketplace-filters.ts
+++ b/packages/cli/dashboard/src/lib/components/tabs/marketplace-filters.ts
@@ -1,0 +1,22 @@
+import type { SkillSearchResult } from "$lib/api";
+import type { ProviderFilter } from "$lib/stores/skills.svelte";
+
+export function getSkillsProviderLabel(value: ProviderFilter): string {
+	if (value === "signet") return "Signet";
+	if (value === "skills.sh") return "skills.sh";
+	if (value === "clawhub") return "ClawHub";
+	return "All providers";
+}
+
+export function normalizeSkillsProviderFilter(value: string): ProviderFilter {
+	if (value === "signet" || value === "skills.sh" || value === "clawhub") return value;
+	return "all";
+}
+
+export function filterSkillsByProvider(
+	items: readonly SkillSearchResult[],
+	provider: ProviderFilter,
+): SkillSearchResult[] {
+	if (provider === "all") return [...items];
+	return items.filter((item) => item.provider === provider);
+}


### PR DESCRIPTION
## Summary

Feature official Signet skills in the dashboard marketplace, add explicit Signet provider filtering, and make featured-skill ranking usage-aware so upcoming analytics can drive the ordering without another UI rewrite.

## Changes

- add a planning stub and research note for marketplace official-skill featuring, and sync `INDEX.md` + `dependencies.yaml`
- add a featured official-skills strip to the Marketplace skills browse view
- prevent featured official skills from duplicating immediately in the main browse grid
- add `Signet` to the marketplace provider filter controls
- make featured ranking prefer future usage fields (`featuredScore`, `useCount`, `lastUsedAt`) with clean popularity fallbacks
- add regression tests for featured ordering and dedup behavior

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: docs/specs

## Screenshots

Not attached from CLI. UI surface changed: Dashboard -> Marketplace -> Skills browse view, including the new featured official-skills strip and provider filter parity.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [ ] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [ ] Daemon Rust parity reviewed or explicitly N/A
- [ ] Rollback / compatibility note included in PR description

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Validation run for this branch:

- [x] `bun test`
- [x] `bun run typecheck`
- [x] `bun test packages/cli/dashboard/src/lib/components/skills/featured-skills.test.ts`
- [x] `cd packages/cli/dashboard && bun run check`

Known pre-existing workspace issues observed while validating:

- `bun run lint` fails on broad pre-existing repository formatting/lint debt unrelated to this change

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The marketplace ranking helper is intentionally forward-compatible with upcoming usage analytics: once the browse payload starts emitting usage fields, the featured strip will pick them up without another UI refactor.
