### PR TITLE
fix(daemon): preserve multiline markdown for embeddings

### DIFF
--- a/docs/research/technical/RESEARCH-MARKDOWN-EMBEDDING-NORMALIZATION.md
+++ b/docs/research/technical/RESEARCH-MARKDOWN-EMBEDDING-NORMALIZATION.md
@@ -1,0 +1,67 @@
+---
+title: RESEARCH-MARKDOWN-EMBEDDING-NORMALIZATION
+question: How should Signet preserve structured markdown for embeddings while preventing repeated poison-pill retries from malformed or provider-sensitive payloads?
+date: 2026-03-30
+---
+
+# RESEARCH-MARKDOWN-EMBEDDING-NORMALIZATION
+
+## Trigger
+
+Issue #418 reports that imported OpenClaw Session Logs markdown tables can
+be flattened onto a single line before embedding. The flattened payload
+causes Ollama `/api/embeddings` to return HTTP 500 for
+`mxbai-embed-large`, and the daemon continues retrying the same row,
+creating repeated warning spam.
+
+## Observed code paths
+
+- `packages/daemon/src/content-normalization.ts`
+- `packages/native/src/normalization.rs`
+- `packages/daemon-rs/crates/signet-services/src/normalize.rs`
+- `packages/daemon/src/embedding-tracker.ts`
+- `packages/daemon/src/daemon.ts`
+
+The current normalization contract collapses all whitespace for storage,
+which includes real newlines. That is safe for plain prose dedupe, but it
+destroys markdown table structure before embedding and makes provider
+behavior depend on an implementation detail rather than on the original
+user content.
+
+## Findings
+
+1. **Storage normalization is too aggressive**
+   - `replace(/\s+/g, " ")` converts multiline markdown into one line.
+   - The native Rust addon and daemon-rs shadow normalization mirror the
+     same behavior, so the bug exists across parity paths.
+
+2. **The dedupe goal is valid, but belongs in semantic normalization**
+   - Deduplication wants whitespace-insensitive comparison and hashing.
+   - Embedding and display want preserved line structure.
+   - These are different contracts and should not share the same
+     normalization step.
+
+3. **Retry behavior lacks durable suppression**
+   - The embedding tracker continues revisiting rows with no embedding.
+   - A persistent provider-sensitive payload can therefore generate
+     recurring warnings indefinitely.
+
+## Decision direction
+
+Split the normalization contract into two layers:
+
+- **Storage content**: preserve line structure, normalize line endings, trim
+  outer whitespace only.
+- **Normalized/hash content**: collapse semantic whitespace and strip
+  trailing punctuation for dedupe and equality.
+
+Then add bounded retry suppression in the embedding tracker so a single bad
+payload cannot create continuous warning spam.
+
+## Implications
+
+- Regression tests are required for multiline markdown tables.
+- Rust parity must be updated in both `packages/native` and
+  `packages/daemon-rs`.
+- The incident should leave a durable guardrail in the spec system and the
+  test suite.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -140,6 +140,7 @@ and market subdirectories). Reference repos live in `references/`.
 | `openclaw-workspace-protection-plan`, `openclaw-workspace-protection` | RESEARCH-OPENCLAW-WORKSPACE-PROTECTION | How should Signet prevent data loss when OpenClaw uninstall deletes a workspace that points at `.agents`? |
 | `dogfood-hardening-2026-03-29` | RESEARCH-DOGFOOD-HARDENING-2026-03-29 | Which runtime, MCP, and knowledge-surface regressions from the March 29, 2026 dogfood run need durable hardening? |
 | `marketplace-official-skills` | RESEARCH-MARKETPLACE-OFFICIAL-SKILLS | How should the dashboard marketplace spotlight Signet official skills without hiding the broader community catalog? |
+| `markdown-embedding-normalization-hardening` | RESEARCH-MARKDOWN-EMBEDDING-NORMALIZATION | How should Signet preserve structured markdown for embeddings while preventing repeated poison-pill retries from malformed or provider-sensitive payloads? |
 
 ### Research Adoption Ledger (high-impact)
 
@@ -722,6 +723,7 @@ Legend:
 | `api-contract-snapshots` | planning | `docs/specs/planning/api-contract-snapshots.md` | `signet-runtime` | - | Stub: response contract snapshot guards |
 | `developer-doctor-command` | planning | `docs/specs/planning/developer-doctor-command.md` | `signet-runtime` | - | Stub: one-command local health checks |
 | `macos-sqlite-runtime-discovery` | planning | `docs/specs/planning/macos-sqlite-runtime-discovery.md` | `signet-runtime` | - | Incident-driven stub for issue #336: broaden macOS SQLite dylib discovery and surface explicit degraded-mode guidance |
+| `markdown-embedding-normalization-hardening` | planning | `docs/specs/planning/markdown-embedding-normalization-hardening.md` | `memory-pipeline-v2` | - | Incident-driven stub for issue #418: preserve multiline markdown for embeddings and bound poison-pill retry spam |
 | `desktop-packaging-distribution` | approved | `docs/specs/approved/desktop-packaging-distribution.md` | `signet-runtime` | - | Desktop packaging contract for macOS/Windows/Ubuntu/Arch, bundled daemon fallback path, signing-mode resolution (official/self-signed), and Arch package validation |
 | `golden-path-docs` | planning | `docs/specs/planning/golden-path-docs.md` | `developer-doctor-command` | - | Stub: short contributor golden paths |
 | `code-ownership-sla` | planning | `docs/specs/planning/code-ownership-sla.md` | `multi-agent-support` | - | Stub: ownership map and review SLA |

--- a/docs/specs/dependencies.yaml
+++ b/docs/specs/dependencies.yaml
@@ -975,6 +975,21 @@ specs:
       - "Regression tests lock the macOS SQLite discovery order and degraded-mode messaging"
     decision: null
 
+  - id: markdown-embedding-normalization-hardening
+    status: planning
+    path: docs/specs/planning/markdown-embedding-normalization-hardening.md
+    hard_depends_on:
+      - memory-pipeline-v2
+    soft_depends_on: []
+    blocks: []
+    informed_by:
+      - docs/research/technical/RESEARCH-MARKDOWN-EMBEDDING-NORMALIZATION.md
+    success_criteria:
+      - "Stored memory content preserves multiline markdown structure needed for embedding providers and downstream rendering"
+      - "Semantic dedupe/hash normalization remains whitespace-insensitive so newline-preserving storage does not create duplicate memories"
+      - "Persistent embedding failures are retried with bounded backoff and include enough row context to identify the poison-pill payload"
+    decision: null
+
   - id: desktop-packaging-distribution
     status: approved
     path: docs/specs/approved/desktop-packaging-distribution.md

--- a/docs/specs/planning/markdown-embedding-normalization-hardening.md
+++ b/docs/specs/planning/markdown-embedding-normalization-hardening.md
@@ -1,0 +1,69 @@
+---
+id: markdown-embedding-normalization-hardening
+title: Markdown Embedding Normalization Hardening
+status: planning
+informed_by:
+  - docs/research/technical/RESEARCH-MARKDOWN-EMBEDDING-NORMALIZATION.md
+---
+
+# Markdown Embedding Normalization Hardening
+
+## Why this exists
+
+Issue #418 exposed a contract bug in memory normalization. Signet currently
+collapses all whitespace before storing memory content, which flattens
+multiline markdown tables into a single line before embedding. Some
+embedding providers reject that malformed shape, and the embedding tracker
+can keep retrying the same row, creating warning spam.
+
+This is an incident-driven planning stub. The implementation must harden
+both content handling and retry behavior.
+
+## Scope
+
+- Preserve multiline markdown structure in stored memory content.
+- Keep dedupe/hash behavior whitespace-insensitive.
+- Mirror the normalization change in Rust parity paths.
+- Add bounded failure suppression in the embedding tracker.
+- Add regression tests for multiline markdown tables and retry suppression.
+
+## Non-goals
+
+- No new user-facing configuration surface.
+- No schema migration unless implementation proves one is required.
+- No provider-specific markdown table parser beyond what is needed to stop
+  flattening and uncontrolled retries.
+
+## Contracts
+
+### Content normalization
+
+- `storageContent` must preserve real line breaks.
+- `normalizedContent` and `contentHash` may collapse semantic whitespace for
+  dedupe.
+- Storage normalization and semantic normalization are distinct contracts and
+  must not be merged again.
+
+### Retry behavior
+
+- Persistent embedding failures must not trigger unbounded repeated attempts
+  on every tracker cycle.
+- Failure logs must include row context sufficient to identify the bad
+  payload.
+
+### Parity
+
+- `packages/daemon/src/content-normalization.ts`
+- `packages/native/src/normalization.rs`
+- `packages/daemon-rs/crates/signet-services/src/normalize.rs`
+
+All three paths must preserve equivalent normalization semantics.
+
+## Success criteria
+
+1. Multiline markdown tables remain multiline in stored memory content and
+   during embedding requests.
+2. Whitespace-only formatting differences still dedupe to the same semantic
+   hash.
+3. Repeated embedding failures are retried with bounded suppression and do
+   not generate warning spam every tracker cycle.

--- a/packages/daemon-rs/crates/signet-services/src/normalize.rs
+++ b/packages/daemon-rs/crates/signet-services/src/normalize.rs
@@ -1,8 +1,8 @@
 //! Content normalization and hashing for memory deduplication.
 //!
 //! Mirrors the TS `normalizeAndHashContent` logic:
-//! 1. Storage normalization: trim + collapse whitespace
-//! 2. Semantic normalization: lowercase + strip trailing punctuation
+//! 1. Storage normalization: normalize line endings + trim outer whitespace
+//! 2. Semantic normalization: lowercase + collapse whitespace + strip trailing punctuation
 //! 3. Hash basis: semantic normalized, or storage lowercased if empty
 //! 4. SHA-256 hex digest of the hash basis
 
@@ -21,11 +21,11 @@ pub struct NormalizedContent {
 
 /// Normalize content and compute its hash.
 pub fn normalize_and_hash(content: &str) -> NormalizedContent {
-    // Step 1: Storage normalization — trim + collapse whitespace
-    let storage = collapse_whitespace(content.trim());
+    // Step 1: Storage normalization — preserve line structure
+    let storage = normalize_storage(content);
 
-    // Step 2: Semantic normalization — lowercase + strip trailing punctuation
-    let lowered = storage.to_lowercase();
+    // Step 2: Semantic normalization — lowercase + collapse whitespace
+    let lowered = collapse_whitespace(&storage.to_lowercase());
     let normalized = strip_trailing_punct(&lowered).trim().to_string();
 
     // Step 3: Hash basis
@@ -45,6 +45,10 @@ pub fn normalize_and_hash(content: &str) -> NormalizedContent {
         normalized,
         hash,
     }
+}
+
+fn normalize_storage(s: &str) -> String {
+    s.replace("\r\n", "\n").replace('\r', "\n").trim().to_string()
 }
 
 fn collapse_whitespace(s: &str) -> String {
@@ -75,7 +79,7 @@ mod tests {
     #[test]
     fn basic_normalization() {
         let r = normalize_and_hash("  Hello   World!  ");
-        assert_eq!(r.storage, "Hello World!");
+        assert_eq!(r.storage, "Hello   World!");
         assert_eq!(r.normalized, "hello world");
         assert!(!r.hash.is_empty());
         assert_eq!(r.hash.len(), 64); // SHA-256 hex
@@ -109,5 +113,18 @@ mod tests {
         assert!(r.normalized.is_empty());
         // Hash is based on lowered storage
         assert!(!r.hash.is_empty());
+    }
+
+    #[test]
+    fn storage_preserves_multiline_markdown() {
+        let r = normalize_and_hash("  ## Session Logs\r\n\r\n| id | kind |\r\n|----|------|\r\n| a | summary |\r\n");
+        assert_eq!(
+            r.storage,
+            "## Session Logs\n\n| id | kind |\n|----|------|\n| a | summary |"
+        );
+        assert_eq!(
+            r.normalized,
+            "## session logs | id | kind | |----|------| | a | summary |"
+        );
     }
 }

--- a/packages/daemon/src/content-normalization.test.ts
+++ b/packages/daemon/src/content-normalization.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { normalizeAndHashContent, normalizeContentForStorage } from "./content-normalization";
+
+describe("content normalization", () => {
+	it("preserves multiline markdown tables in storage content", () => {
+		const input = ["  ## Session Logs", "", "| id | kind |", "|----|------|", "| a | summary |", ""].join("\n");
+
+		const result = normalizeContentForStorage(input);
+
+		expect(result).toBe(["## Session Logs", "", "| id | kind |", "|----|------|", "| a | summary |"].join("\n"));
+		expect(result.includes("\n| id | kind |")).toBe(true);
+	});
+
+	it("keeps semantic hashes stable across formatting-only whitespace differences", () => {
+		const multi = ["## Session Logs", "", "| id | kind |", "|----|------|", "| a | summary |"].join("\n");
+		const flat = "## Session Logs | id | kind | |----|------| | a | summary |";
+
+		const left = normalizeAndHashContent(multi);
+		const right = normalizeAndHashContent(flat);
+
+		expect(left.storageContent).toContain("\n");
+		expect(right.storageContent).not.toContain("\n");
+		expect(left.normalizedContent).toBe(right.normalizedContent);
+		expect(left.contentHash).toBe(right.contentHash);
+	});
+});

--- a/packages/daemon/src/content-normalization.ts
+++ b/packages/daemon/src/content-normalization.ts
@@ -18,14 +18,16 @@ try {
 }
 
 const TRAILING_PUNCTUATION = /[.,!?;:]+$/;
+const CRLF = /\r\n?/g;
+const COLLAPSE_WHITESPACE = /\s+/g;
 
 function tsNormalizeContentForStorage(content: string): string {
-	return content.trim().replace(/\s+/g, " ");
+	return content.replace(CRLF, "\n").trim();
 }
 
 function tsDeriveNormalizedContent(storageContent: string): string {
 	const lowered = storageContent.toLowerCase();
-	return lowered.replace(TRAILING_PUNCTUATION, "").trim();
+	return lowered.replace(COLLAPSE_WHITESPACE, " ").replace(TRAILING_PUNCTUATION, "").trim();
 }
 
 function tsNormalizeAndHashContent(content: string): NormalizedMemoryContent {

--- a/packages/daemon/src/embedding-tracker.test.ts
+++ b/packages/daemon/src/embedding-tracker.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import { computeEmbeddingRetryBackoffMs } from "./embedding-tracker";
+
+describe("computeEmbeddingRetryBackoffMs", () => {
+	it("backs off aggressively for repeated failures", () => {
+		expect(computeEmbeddingRetryBackoffMs(1, 1_000)).toBe(60_000);
+		expect(computeEmbeddingRetryBackoffMs(2, 1_000)).toBe(5 * 60_000);
+		expect(computeEmbeddingRetryBackoffMs(3, 1_000)).toBe(30 * 60_000);
+		expect(computeEmbeddingRetryBackoffMs(4, 1_000)).toBe(60 * 60_000);
+	});
+
+	it("respects larger poll intervals when they exceed the floor", () => {
+		expect(computeEmbeddingRetryBackoffMs(1, 20_000)).toBe(100_000);
+		expect(computeEmbeddingRetryBackoffMs(2, 20_000)).toBe(500_000);
+	});
+});

--- a/packages/daemon/src/embedding-tracker.test.ts
+++ b/packages/daemon/src/embedding-tracker.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { computeEmbeddingRetryBackoffMs } from "./embedding-tracker";
+import { computeEmbeddingRetryBackoffMs, processEmbeddingCycle } from "./embedding-tracker";
+
+const cfg = {
+	provider: "ollama",
+	model: "mxbai-embed-large",
+	dimensions: 1024,
+	base_url: "http://localhost:11434",
+} as const;
 
 describe("computeEmbeddingRetryBackoffMs", () => {
 	it("backs off aggressively for repeated failures", () => {
@@ -12,5 +19,74 @@ describe("computeEmbeddingRetryBackoffMs", () => {
 	it("respects larger poll intervals when they exceed the floor", () => {
 		expect(computeEmbeddingRetryBackoffMs(1, 20_000)).toBe(100_000);
 		expect(computeEmbeddingRetryBackoffMs(2, 20_000)).toBe(500_000);
+	});
+});
+
+describe("processEmbeddingCycle", () => {
+	it("suppresses repeated attempts across cycles for the same failed payload", async () => {
+		const failures = new Map<string, { count: number; retryAt: number }>();
+		const rows = [{ id: "mem-1", content: "bad", contentHash: "hash-a", currentModel: null }] as const;
+		let calls = 0;
+
+		const fetchEmbeddingFn = async () => {
+			calls++;
+			return null;
+		};
+
+		const first = await processEmbeddingCycle(rows, failures, cfg, 1_000, fetchEmbeddingFn, 1_000);
+		const second = await processEmbeddingCycle(rows, failures, cfg, 1_000, fetchEmbeddingFn, 2_000);
+
+		expect(first.failed).toBe(1);
+		expect(second.failed).toBe(0);
+		expect(second.queueDepth).toBe(0);
+		expect(calls).toBe(1);
+	});
+
+	it("does not suppress a new content hash for the same memory id", async () => {
+		const failures = new Map<string, { count: number; retryAt: number }>();
+		const fetchCalls: string[] = [];
+		const fetchEmbeddingFn = async (text: string) => {
+			fetchCalls.push(text);
+			return null;
+		};
+
+		await processEmbeddingCycle(
+			[{ id: "mem-1", content: "bad-old", contentHash: "hash-old", currentModel: null }],
+			failures,
+			cfg,
+			1_000,
+			fetchEmbeddingFn,
+			1_000,
+		);
+		const next = await processEmbeddingCycle(
+			[{ id: "mem-1", content: "good-new-shape", contentHash: "hash-new", currentModel: null }],
+			failures,
+			cfg,
+			1_000,
+			fetchEmbeddingFn,
+			2_000,
+		);
+
+		expect(next.queueDepth).toBe(1);
+		expect(fetchCalls).toEqual(["bad-old", "good-new-shape"]);
+	});
+
+	it("clears suppression on success", async () => {
+		const failures = new Map<string, { count: number; retryAt: number }>();
+		let ok = false;
+		const fetchEmbeddingFn = async () => {
+			if (!ok) return null;
+			return [0.1, 0.2, 0.3];
+		};
+		const rows = [{ id: "mem-1", content: "retry-me", contentHash: "hash-a", currentModel: null }] as const;
+
+		await processEmbeddingCycle(rows, failures, cfg, 1_000, fetchEmbeddingFn, 1_000);
+		ok = true;
+		const retry = await processEmbeddingCycle(rows, failures, cfg, 1_000, fetchEmbeddingFn, 70_000);
+		const after = await processEmbeddingCycle(rows, failures, cfg, 1_000, fetchEmbeddingFn, 71_000);
+
+		expect(retry.results).toHaveLength(1);
+		expect(after.results).toHaveLength(1);
+		expect(after.failed).toBe(0);
 	});
 });

--- a/packages/daemon/src/embedding-tracker.ts
+++ b/packages/daemon/src/embedding-tracker.ts
@@ -44,6 +44,18 @@ interface StaleRow {
 	readonly currentModel: string | null;
 }
 
+interface FailureState {
+	readonly count: number;
+	readonly retryAt: number;
+}
+
+export function computeEmbeddingRetryBackoffMs(count: number, pollMs: number): number {
+	if (count <= 1) return Math.max(pollMs * 5, 60_000);
+	if (count === 2) return Math.max(pollMs * 25, 5 * 60_000);
+	if (count === 3) return Math.max(pollMs * 150, 30 * 60_000);
+	return Math.max(pollMs * 300, 60 * 60_000);
+}
+
 // ---------------------------------------------------------------------------
 // Main entry point
 // ---------------------------------------------------------------------------
@@ -64,6 +76,7 @@ export function startEmbeddingTracker(
 	let skippedCycles = 0;
 	let lastCycleAt: string | null = null;
 	let lastQueueDepth = 0;
+	const failures = new Map<string, FailureState>();
 
 	async function tick(): Promise<void> {
 		if (!running) return;
@@ -80,11 +93,18 @@ export function startEmbeddingTracker(
 			const staleRows = accessor.withReadDb((db) => {
 				return listStaleEmbeddingRows(db, embeddingCfg.model, trackerCfg.batchSize) as StaleRow[];
 			});
+			const now = Date.now();
+			const readyRows = staleRows.filter((row) => {
+				const state = failures.get(row.id);
+				if (!state) return true;
+				if (state.retryAt <= now) return true;
+				return false;
+			});
 
-			lastQueueDepth = staleRows.length;
+			lastQueueDepth = readyRows.length;
 			lastCycleAt = new Date().toISOString();
 
-			if (staleRows.length === 0) return;
+			if (readyRows.length === 0) return;
 
 			// 3. Fetch embeddings sequentially (outside transaction, 30s timeout each)
 			const results: Array<{
@@ -93,13 +113,26 @@ export function startEmbeddingTracker(
 				readonly contentHash: string;
 			}> = [];
 
-			for (const row of staleRows) {
+			for (const row of readyRows) {
 				if (!running) break;
 				const vec = await fetchEmbeddingFn(row.content, embeddingCfg);
 				if (vec !== null) {
 					results.push({ row, vector: vec, contentHash: row.contentHash });
+					failures.delete(row.id);
 				} else {
 					failed++;
+					const next = (failures.get(row.id)?.count ?? 0) + 1;
+					const wait = computeEmbeddingRetryBackoffMs(next, trackerCfg.pollMs);
+					failures.set(row.id, {
+						count: next,
+						retryAt: now + wait,
+					});
+					logger.warn("embedding-tracker", "Embedding refresh failed, suppressing retries", {
+						memoryId: row.id,
+						contentHash: row.contentHash,
+						attempt: next,
+						retryAfterMs: wait,
+					});
 				}
 			}
 

--- a/packages/daemon/src/embedding-tracker.ts
+++ b/packages/daemon/src/embedding-tracker.ts
@@ -49,11 +49,86 @@ interface FailureState {
 	readonly retryAt: number;
 }
 
+type FailureMap = Map<string, FailureState>;
+
+interface CycleSuccess {
+	readonly row: StaleRow;
+	readonly vector: readonly number[];
+	readonly contentHash: string;
+}
+
+interface CycleResult {
+	readonly queueDepth: number;
+	readonly failed: number;
+	readonly results: readonly CycleSuccess[];
+}
+
 export function computeEmbeddingRetryBackoffMs(count: number, pollMs: number): number {
 	if (count <= 1) return Math.max(pollMs * 5, 60_000);
 	if (count === 2) return Math.max(pollMs * 25, 5 * 60_000);
 	if (count === 3) return Math.max(pollMs * 150, 30 * 60_000);
 	return Math.max(pollMs * 300, 60 * 60_000);
+}
+
+function failureKey(row: StaleRow, model: string): string {
+	return `${row.id}:${row.contentHash}:${model}`;
+}
+
+function clearRowFailures(failures: FailureMap, row: StaleRow, model: string): void {
+	const prefix = `${row.id}:`;
+	for (const key of failures.keys()) {
+		if (!key.startsWith(prefix)) continue;
+		if (!key.endsWith(`:${model}`)) continue;
+		failures.delete(key);
+	}
+}
+
+export async function processEmbeddingCycle(
+	rows: readonly StaleRow[],
+	failures: FailureMap,
+	embeddingCfg: EmbeddingConfig,
+	pollMs: number,
+	fetchEmbeddingFn: (text: string, cfg: EmbeddingConfig) => Promise<number[] | null>,
+	now: number = Date.now(),
+): Promise<CycleResult> {
+	const readyRows = rows.filter((row) => {
+		const state = failures.get(failureKey(row, embeddingCfg.model));
+		if (!state) return true;
+		return state.retryAt <= now;
+	});
+
+	const results: CycleSuccess[] = [];
+	let failed = 0;
+
+	for (const row of readyRows) {
+		const key = failureKey(row, embeddingCfg.model);
+		const vec = await fetchEmbeddingFn(row.content, embeddingCfg);
+		if (vec !== null) {
+			clearRowFailures(failures, row, embeddingCfg.model);
+			results.push({ row, vector: vec, contentHash: row.contentHash });
+			continue;
+		}
+
+		failed++;
+		const next = (failures.get(key)?.count ?? 0) + 1;
+		const wait = computeEmbeddingRetryBackoffMs(next, pollMs);
+		failures.set(key, {
+			count: next,
+			retryAt: now + wait,
+		});
+		logger.warn("embedding-tracker", "Embedding refresh failed, suppressing retries", {
+			memoryId: row.id,
+			contentHash: row.contentHash,
+			attempt: next,
+			retryAfterMs: wait,
+		});
+	}
+
+	return {
+		queueDepth: readyRows.length,
+		failed,
+		results,
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -93,54 +168,18 @@ export function startEmbeddingTracker(
 			const staleRows = accessor.withReadDb((db) => {
 				return listStaleEmbeddingRows(db, embeddingCfg.model, trackerCfg.batchSize) as StaleRow[];
 			});
-			const now = Date.now();
-			const readyRows = staleRows.filter((row) => {
-				const state = failures.get(row.id);
-				if (!state) return true;
-				if (state.retryAt <= now) return true;
-				return false;
-			});
+			const cycle = await processEmbeddingCycle(staleRows, failures, embeddingCfg, trackerCfg.pollMs, fetchEmbeddingFn);
 
-			lastQueueDepth = readyRows.length;
+			lastQueueDepth = cycle.queueDepth;
 			lastCycleAt = new Date().toISOString();
 
-			if (readyRows.length === 0) return;
+			failed += cycle.failed;
 
-			// 3. Fetch embeddings sequentially (outside transaction, 30s timeout each)
-			const results: Array<{
-				readonly row: StaleRow;
-				readonly vector: readonly number[];
-				readonly contentHash: string;
-			}> = [];
-
-			for (const row of readyRows) {
-				if (!running) break;
-				const vec = await fetchEmbeddingFn(row.content, embeddingCfg);
-				if (vec !== null) {
-					results.push({ row, vector: vec, contentHash: row.contentHash });
-					failures.delete(row.id);
-				} else {
-					failed++;
-					const next = (failures.get(row.id)?.count ?? 0) + 1;
-					const wait = computeEmbeddingRetryBackoffMs(next, trackerCfg.pollMs);
-					failures.set(row.id, {
-						count: next,
-						retryAt: now + wait,
-					});
-					logger.warn("embedding-tracker", "Embedding refresh failed, suppressing retries", {
-						memoryId: row.id,
-						contentHash: row.contentHash,
-						attempt: next,
-						retryAfterMs: wait,
-					});
-				}
-			}
-
-			if (results.length === 0) return;
+			if (cycle.results.length === 0) return;
 
 			// 4. Batch write in a single write transaction
 			accessor.withWriteTx((db) => {
-				for (const { row, vector, contentHash } of results) {
+				for (const { row, vector, contentHash } of cycle.results) {
 					// Delete stale embeddings for this source
 					syncVecDeleteBySourceExceptHash(db, "memory", row.id, contentHash);
 
@@ -173,7 +212,7 @@ export function startEmbeddingTracker(
 				}
 			});
 
-			logger.debug("embedding-tracker", `Refreshed ${results.length} embeddings`);
+			logger.debug("embedding-tracker", `Refreshed ${cycle.results.length} embeddings`);
 		} catch (err) {
 			logger.warn("embedding-tracker", "Cycle error", err instanceof Error ? err : new Error(String(err)));
 		}

--- a/packages/native/src/normalization.rs
+++ b/packages/native/src/normalization.rs
@@ -13,28 +13,12 @@ pub struct NormalizedMemoryContent {
 
 #[napi]
 pub fn normalize_content_for_storage(content: String) -> String {
-    let trimmed = content.trim();
-    let mut result = String::with_capacity(trimmed.len());
-    let mut prev_whitespace = false;
-
-    for ch in trimmed.chars() {
-        if ch.is_whitespace() {
-            if !prev_whitespace {
-                result.push(' ');
-            }
-            prev_whitespace = true;
-        } else {
-            result.push(ch);
-            prev_whitespace = false;
-        }
-    }
-
-    result
+    content.replace("\r\n", "\n").replace('\r', "\n").trim().to_string()
 }
 
 #[napi]
 pub fn derive_normalized_content(storage_content: String) -> String {
-    let lowered = storage_content.to_lowercase();
+    let lowered = collapse_whitespace(&storage_content.to_lowercase());
     // Parity: TS uses /[.,!?;:]+$/ regex. trim_end_matches char-by-char
     // is equivalent here since input is already trimmed of whitespace.
     let trimmed = lowered.trim_end_matches(|c: char| matches!(c, '.' | ',' | '!' | '?' | ';' | ':'));
@@ -61,5 +45,59 @@ pub fn normalize_and_hash_content(content: String) -> NormalizedMemoryContent {
         normalized_content,
         hash_basis,
         content_hash,
+    }
+}
+
+fn collapse_whitespace(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut prev_whitespace = false;
+
+    for ch in input.chars() {
+        if ch.is_whitespace() {
+            if !prev_whitespace {
+                out.push(' ');
+            }
+            prev_whitespace = true;
+        } else {
+            out.push(ch);
+            prev_whitespace = false;
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{derive_normalized_content, normalize_and_hash_content, normalize_content_for_storage};
+
+    #[test]
+    fn storage_preserves_multiline_markdown() {
+        let input = "  ## Session Logs\r\n\r\n| id | kind |\r\n|----|------|\r\n| a | summary |\r\n";
+        let result = normalize_content_for_storage(input.to_string());
+        assert_eq!(
+            result,
+            "## Session Logs\n\n| id | kind |\n|----|------|\n| a | summary |"
+        );
+    }
+
+    #[test]
+    fn semantic_normalization_collapses_whitespace() {
+        let result = derive_normalized_content("## Session Logs\n\n| a | b |".to_string());
+        assert_eq!(result, "## session logs | a | b |");
+    }
+
+    #[test]
+    fn formatting_only_differences_keep_same_hash() {
+        let multi = normalize_and_hash_content(
+            "## Session Logs\n\n| id | kind |\n|----|------|\n| a | summary |".to_string(),
+        );
+        let flat = normalize_and_hash_content(
+            "## Session Logs | id | kind | |----|------| | a | summary |".to_string(),
+        );
+
+        assert!(multi.storage_content.contains('\n'));
+        assert_eq!(multi.normalized_content, flat.normalized_content);
+        assert_eq!(multi.content_hash, flat.content_hash);
     }
 }


### PR DESCRIPTION
## summary
- preserve multiline markdown in stored memory content so markdown tables are not flattened before embedding
- keep semantic normalization whitespace-insensitive for dedupe/hash parity across TS, native Rust, and daemon-rs
- add bounded embedding retry backoff plus regression coverage for issue #418

## testing
- bun run build:native
- bun test packages/daemon/src/content-normalization.test.ts packages/daemon/src/embedding-tracker.test.ts packages/daemon/src/embedding-fetch.test.ts
- cd packages/native && cargo test normalization
- cd packages/daemon-rs && cargo test -p signet-services normalize
- bun run typecheck
- bunx biome check docs/research/technical/RESEARCH-MARKDOWN-EMBEDDING-NORMALIZATION.md docs/specs/planning/markdown-embedding-normalization-hardening.md docs/specs/dependencies.yaml docs/specs/INDEX.md packages/daemon/src/content-normalization.ts packages/daemon/src/content-normalization.test.ts packages/daemon/src/embedding-tracker.ts packages/daemon/src/embedding-tracker.test.ts

## notes
- adds an incident-driven research/spec planning stub per repo protocol before implementation
- full repo lint and spec-deps-check still report unrelated pre-existing failures outside this change

closes #418
