### PR TITLE
fix(codex): repair stale MCP config on setup instead of skipping

### DIFF
--- a/packages/connector-codex/src/config-toml.test.ts
+++ b/packages/connector-codex/src/config-toml.test.ts
@@ -9,7 +9,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { CodexConnector } from "./index.js";
+import { CodexConnector, buildMcpBlock } from "./index.js";
 
 class TempConnector extends CodexConnector {
 	constructor(private home: string) {
@@ -134,5 +134,37 @@ describe("CodexConnector.uninstall — config.toml cleanup", () => {
 		const content = readFileSync(configPath, "utf-8");
 		expect(content).toContain("[model]");
 		expect(content).not.toContain("[mcp_servers.signet]");
+	});
+});
+
+// buildMcpBlock is tested directly here because resolveSignetMcp() always
+// returns the non-Windows path on Linux, so Windows quoting can't be
+// exercised through install().
+describe("buildMcpBlock — TOML quoting", () => {
+	test("produces string command, not array", () => {
+		const block = buildMcpBlock({ command: "signet-mcp", args: [] });
+		expect(block).toContain("command = 'signet-mcp'");
+		expect(block).not.toContain("command = [");
+	});
+
+	test("Windows paths with backslashes are quoted correctly", () => {
+		const block = buildMcpBlock({
+			command: "C:\\Program Files\\node.exe",
+			args: ["C:\\signet\\mcp-stdio.js"],
+		});
+		// No single-quote in the path, so literal single-quote TOML strings are used
+		expect(block).toContain("command = 'C:\\Program Files\\node.exe'");
+		expect(block).toContain("args = ['C:\\signet\\mcp-stdio.js']");
+		expect(block).not.toContain("command = [");
+	});
+
+	test("omits args line when args is empty", () => {
+		const block = buildMcpBlock({ command: "signet-mcp", args: [] });
+		expect(block).not.toContain("args");
+	});
+
+	test("includes args line when args are present", () => {
+		const block = buildMcpBlock({ command: "node", args: ["mcp.js", "--port", "3000"] });
+		expect(block).toContain("args = ['mcp.js', '--port', '3000']");
 	});
 });

--- a/packages/connector-codex/src/config-toml.test.ts
+++ b/packages/connector-codex/src/config-toml.test.ts
@@ -135,6 +135,39 @@ describe("CodexConnector.uninstall — config.toml cleanup", () => {
 		expect(content).toContain("[model]");
 		expect(content).not.toContain("[mcp_servers.signet]");
 	});
+
+	test("handles multi-line TOML args without corrupting surrounding sections (regression: unpatchConfigToml)", async () => {
+		// A user who hand-edited args to multi-line form would have had
+		// continuation lines left in the file by the old section-end detection.
+		writeFileSync(
+			configPath,
+			[
+				"[other]",
+				"key = 'val'",
+				"",
+				"# Signet MCP server",
+				"[mcp_servers.signet]",
+				"command = 'signet-mcp'",
+				"args = [",
+				"  '--verbose'",
+				"]",
+				"",
+				"[after]",
+				"key = 'val'",
+				"",
+			].join("\n"),
+		);
+
+		const c = connector();
+		await c.uninstall();
+
+		const content = readFileSync(configPath, "utf-8");
+		expect(content).not.toContain("[mcp_servers.signet]");
+		// Continuation lines must not leak into the output
+		expect(content).not.toContain("--verbose");
+		expect(content).toContain("[other]");
+		expect(content).toContain("[after]");
+	});
 });
 
 // buildMcpBlock is tested directly here because resolveSignetMcp() always

--- a/packages/connector-codex/src/config-toml.test.ts
+++ b/packages/connector-codex/src/config-toml.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// The TOML patching functions are module-private, so we re-implement the
+// same logic inline to test the behavioral contract. These tests validate
+// that the connector's config.toml handling produces correct output for
+// Codex's Rust TOML parser, which expects `command` as a plain string.
+
+// ---------------------------------------------------------------------------
+// Extracted helpers (mirrored from index.ts for testability)
+// ---------------------------------------------------------------------------
+
+function tomlQuote(s: string): string {
+	if (!s.includes("'")) return `'${s}'`;
+	return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\r/g, "\\r").replace(/\n/g, "\\n")}"`;
+}
+
+function tomlInlineArray(items: string[]): string {
+	return `[${items.map(tomlQuote).join(", ")}]`;
+}
+
+function buildMcpBlock(mcp: { command: string; args: string[] }): string {
+	let block = `# Signet MCP server\n[mcp_servers.signet]\ncommand = ${tomlQuote(mcp.command)}\n`;
+	if (mcp.args.length > 0) {
+		block += `args = ${tomlInlineArray(mcp.args)}\n`;
+	}
+	return block;
+}
+
+function unpatchConfigToml(path: string): boolean {
+	if (!existsSync(path)) return false;
+	const content = readFileSync(path, "utf-8");
+	if (!content.includes("[mcp_servers.signet]")) return false;
+
+	const lines = content.split("\n");
+	const filtered: string[] = [];
+	let inSection = false;
+	for (const line of lines) {
+		if (line.trim() === "# Signet MCP server") continue;
+		if (line.trim() === "[mcp_servers.signet]") {
+			inSection = true;
+			continue;
+		}
+		if (inSection) {
+			if (line.match(/^\s*\w+\s*=/) || line.trim() === "") continue;
+			inSection = false;
+		}
+		filtered.push(line);
+	}
+	writeFileSync(
+		path,
+		filtered
+			.join("\n")
+			.replace(/\n{3,}/g, "\n\n")
+			.trimEnd() + "\n",
+	);
+	return true;
+}
+
+function patchConfigToml(path: string, mcp: { command: string; args: string[] }): boolean {
+	const dir = join(path, "..");
+	mkdirSync(dir, { recursive: true });
+
+	const block = buildMcpBlock(mcp);
+
+	if (!existsSync(path)) {
+		writeFileSync(path, block);
+		return true;
+	}
+
+	const content = readFileSync(path, "utf-8");
+
+	if (!content.includes("[mcp_servers.signet]")) {
+		writeFileSync(path, content.trimEnd() + "\n\n" + block);
+		return true;
+	}
+
+	// Section exists but may be stale (e.g. old array-format command).
+	// Remove and re-add with correct format.
+	unpatchConfigToml(path);
+	const updated = existsSync(path) ? readFileSync(path, "utf-8").trim() : "";
+	const prefix = updated.length > 0 ? updated + "\n\n" : "";
+	writeFileSync(path, prefix + block);
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const MCP = { command: "signet-mcp", args: [] as string[] };
+const MCP_WIN = { command: "C:\\Program Files\\node.exe", args: ["C:\\signet\\mcp-stdio.js"] };
+
+let dir: string;
+let configPath: string;
+
+beforeEach(() => {
+	dir = join(tmpdir(), `signet-codex-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	mkdirSync(dir, { recursive: true });
+	configPath = join(dir, "config.toml");
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+describe("patchConfigToml", () => {
+	test("creates config.toml when file does not exist", () => {
+		const result = patchConfigToml(configPath, MCP);
+		expect(result).toBe(true);
+		const content = readFileSync(configPath, "utf-8");
+		expect(content).toContain("[mcp_servers.signet]");
+		expect(content).toContain("command = 'signet-mcp'");
+	});
+
+	test("appends section when file exists without signet config", () => {
+		writeFileSync(configPath, '[model]\nname = "gpt-4o"\n');
+		patchConfigToml(configPath, MCP);
+		const content = readFileSync(configPath, "utf-8");
+		expect(content).toContain('[model]\nname = "gpt-4o"');
+		expect(content).toContain("command = 'signet-mcp'");
+	});
+
+	test("replaces stale array-format command (regression: #273)", () => {
+		// This is the exact config that caused "invalid transport" errors.
+		// Pre-#273 Signet wrote command as an array, which Codex's Rust
+		// parser rejects (expects Option<String>, gets array -> None).
+		writeFileSync(
+			configPath,
+			"# Signet MCP server\n[mcp_servers.signet]\ncommand = ['signet-mcp']\n",
+		);
+		patchConfigToml(configPath, MCP);
+		const content = readFileSync(configPath, "utf-8");
+		expect(content).toContain("command = 'signet-mcp'");
+		expect(content).not.toContain("['signet-mcp']");
+	});
+
+	test("preserves other config sections when replacing stale entry", () => {
+		writeFileSync(
+			configPath,
+			'[model]\nname = "gpt-4o"\n\n# Signet MCP server\n[mcp_servers.signet]\ncommand = [\'signet-mcp\']\n\n[history]\nenabled = true\n',
+		);
+		patchConfigToml(configPath, MCP);
+		const content = readFileSync(configPath, "utf-8");
+		expect(content).toContain('[model]\nname = "gpt-4o"');
+		expect(content).toContain("[history]\nenabled = true");
+		expect(content).toContain("command = 'signet-mcp'");
+		expect(content).not.toContain("['signet-mcp']");
+	});
+
+	test("idempotent: re-running on correct config produces identical output", () => {
+		patchConfigToml(configPath, MCP);
+		const first = readFileSync(configPath, "utf-8");
+		patchConfigToml(configPath, MCP);
+		const second = readFileSync(configPath, "utf-8");
+		expect(second).toBe(first);
+	});
+
+	test("handles Windows-style command with args", () => {
+		patchConfigToml(configPath, MCP_WIN);
+		const content = readFileSync(configPath, "utf-8");
+		// Windows paths without single quotes use single-quote TOML literals
+		expect(content).toContain("command = 'C:\\Program Files\\node.exe'");
+		expect(content).toContain("args = ['C:\\signet\\mcp-stdio.js']");
+	});
+});
+
+describe("unpatchConfigToml", () => {
+	test("removes signet section cleanly", () => {
+		writeFileSync(
+			configPath,
+			'[model]\nname = "gpt-4o"\n\n# Signet MCP server\n[mcp_servers.signet]\ncommand = \'signet-mcp\'\n',
+		);
+		unpatchConfigToml(configPath);
+		const content = readFileSync(configPath, "utf-8");
+		expect(content).not.toContain("[mcp_servers.signet]");
+		expect(content).toContain('[model]\nname = "gpt-4o"');
+	});
+
+	test("returns false when file does not exist", () => {
+		expect(unpatchConfigToml(configPath)).toBe(false);
+	});
+
+	test("returns false when section not present", () => {
+		writeFileSync(configPath, '[model]\nname = "gpt-4o"\n');
+		expect(unpatchConfigToml(configPath)).toBe(false);
+	});
+});
+
+describe("buildMcpBlock", () => {
+	test("produces string command, not array", () => {
+		const block = buildMcpBlock(MCP);
+		expect(block).toContain("command = 'signet-mcp'");
+		// Must not contain array-style command (the old broken format)
+		expect(block).not.toContain("command = [");
+	});
+
+	test("includes args when present", () => {
+		const block = buildMcpBlock(MCP_WIN);
+		expect(block).toContain("args = ");
+	});
+
+	test("omits args when empty", () => {
+		const block = buildMcpBlock(MCP);
+		expect(block).not.toContain("args");
+	});
+});

--- a/packages/connector-codex/src/config-toml.test.ts
+++ b/packages/connector-codex/src/config-toml.test.ts
@@ -1,209 +1,138 @@
+/**
+ * Integration tests for CodexConnector MCP config.toml management.
+ *
+ * Tests exercise real production code via CodexConnector.install() and
+ * CodexConnector.uninstall(). A subclass redirects getCodexHome() to a
+ * temp directory so the real ~/.codex is never touched.
+ */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { CodexConnector } from "./index.js";
 
-// The TOML patching functions are module-private, so we re-implement the
-// same logic inline to test the behavioral contract. These tests validate
-// that the connector's config.toml handling produces correct output for
-// Codex's Rust TOML parser, which expects `command` as a plain string.
-
-// ---------------------------------------------------------------------------
-// Extracted helpers (mirrored from index.ts for testability)
-// ---------------------------------------------------------------------------
-
-function tomlQuote(s: string): string {
-	if (!s.includes("'")) return `'${s}'`;
-	return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\r/g, "\\r").replace(/\n/g, "\\n")}"`;
-}
-
-function tomlInlineArray(items: string[]): string {
-	return `[${items.map(tomlQuote).join(", ")}]`;
-}
-
-function buildMcpBlock(mcp: { command: string; args: string[] }): string {
-	let block = `# Signet MCP server\n[mcp_servers.signet]\ncommand = ${tomlQuote(mcp.command)}\n`;
-	if (mcp.args.length > 0) {
-		block += `args = ${tomlInlineArray(mcp.args)}\n`;
+class TempConnector extends CodexConnector {
+	constructor(private home: string) {
+		super();
 	}
-	return block;
+	protected override getCodexHome(): string {
+		return join(this.home, ".codex");
+	}
 }
 
-function unpatchConfigToml(path: string): boolean {
-	if (!existsSync(path)) return false;
-	const content = readFileSync(path, "utf-8");
-	if (!content.includes("[mcp_servers.signet]")) return false;
-
-	const lines = content.split("\n");
-	const filtered: string[] = [];
-	let inSection = false;
-	for (const line of lines) {
-		if (line.trim() === "# Signet MCP server") continue;
-		if (line.trim() === "[mcp_servers.signet]") {
-			inSection = true;
-			continue;
-		}
-		if (inSection) {
-			if (line.match(/^\s*\w+\s*=/) || line.trim() === "") continue;
-			inSection = false;
-		}
-		filtered.push(line);
-	}
-	writeFileSync(
-		path,
-		filtered
-			.join("\n")
-			.replace(/\n{3,}/g, "\n\n")
-			.trimEnd() + "\n",
-	);
-	return true;
-}
-
-function patchConfigToml(path: string, mcp: { command: string; args: string[] }): boolean {
-	const dir = join(path, "..");
-	mkdirSync(dir, { recursive: true });
-
-	const block = buildMcpBlock(mcp);
-
-	if (!existsSync(path)) {
-		writeFileSync(path, block);
-		return true;
-	}
-
-	const content = readFileSync(path, "utf-8");
-
-	if (!content.includes("[mcp_servers.signet]")) {
-		writeFileSync(path, content.trimEnd() + "\n\n" + block);
-		return true;
-	}
-
-	// Section exists but may be stale (e.g. old array-format command).
-	// Remove and re-add with correct format.
-	unpatchConfigToml(path);
-	const updated = existsSync(path) ? readFileSync(path, "utf-8").trim() : "";
-	const prefix = updated.length > 0 ? updated + "\n\n" : "";
-	writeFileSync(path, prefix + block);
-	return true;
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
-const MCP = { command: "signet-mcp", args: [] as string[] };
-const MCP_WIN = { command: "C:\\Program Files\\node.exe", args: ["C:\\signet\\mcp-stdio.js"] };
-
-let dir: string;
+let tempHome: string;
+let codexDir: string;
 let configPath: string;
 
 beforeEach(() => {
-	dir = join(tmpdir(), `signet-codex-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-	mkdirSync(dir, { recursive: true });
-	configPath = join(dir, "config.toml");
+	tempHome = join(tmpdir(), `signet-codex-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	codexDir = join(tempHome, ".codex");
+	configPath = join(codexDir, "config.toml");
+	mkdirSync(codexDir, { recursive: true });
 });
 
 afterEach(() => {
-	rmSync(dir, { recursive: true, force: true });
+	rmSync(tempHome, { recursive: true, force: true });
 });
 
-describe("patchConfigToml", () => {
-	test("creates config.toml when file does not exist", () => {
-		const result = patchConfigToml(configPath, MCP);
-		expect(result).toBe(true);
+function connector(): TempConnector {
+	return new TempConnector(tempHome);
+}
+
+describe("CodexConnector.install — config.toml MCP registration", () => {
+	test("creates config.toml with string command when file does not exist", async () => {
+		await connector().install(tempHome);
+		expect(existsSync(configPath)).toBe(true);
 		const content = readFileSync(configPath, "utf-8");
 		expect(content).toContain("[mcp_servers.signet]");
 		expect(content).toContain("command = 'signet-mcp'");
+		// Must not be an array — Codex's Rust parser expects Option<String>
+		expect(content).not.toContain("command = [");
 	});
 
-	test("appends section when file exists without signet config", () => {
-		writeFileSync(configPath, '[model]\nname = "gpt-4o"\n');
-		patchConfigToml(configPath, MCP);
-		const content = readFileSync(configPath, "utf-8");
-		expect(content).toContain('[model]\nname = "gpt-4o"');
-		expect(content).toContain("command = 'signet-mcp'");
-	});
-
-	test("replaces stale array-format command (regression: #273)", () => {
-		// This is the exact config that caused "invalid transport" errors.
-		// Pre-#273 Signet wrote command as an array, which Codex's Rust
-		// parser rejects (expects Option<String>, gets array -> None).
+	test("repairs stale array-format command on re-install (regression: #273 / invalid transport)", async () => {
+		// This is the exact config that caused "invalid transport in 'mcp_servers.signet'"
+		// errors for users who installed before PR #273 fixed the array bug.
 		writeFileSync(
 			configPath,
 			"# Signet MCP server\n[mcp_servers.signet]\ncommand = ['signet-mcp']\n",
 		);
-		patchConfigToml(configPath, MCP);
+
+		await connector().install(tempHome);
+
 		const content = readFileSync(configPath, "utf-8");
 		expect(content).toContain("command = 'signet-mcp'");
-		expect(content).not.toContain("['signet-mcp']");
+		expect(content).not.toContain("command = [");
 	});
 
-	test("preserves other config sections when replacing stale entry", () => {
+	test("preserves other config sections when repairing stale entry", async () => {
 		writeFileSync(
 			configPath,
 			'[model]\nname = "gpt-4o"\n\n# Signet MCP server\n[mcp_servers.signet]\ncommand = [\'signet-mcp\']\n\n[history]\nenabled = true\n',
 		);
-		patchConfigToml(configPath, MCP);
+
+		await connector().install(tempHome);
+
 		const content = readFileSync(configPath, "utf-8");
-		expect(content).toContain('[model]\nname = "gpt-4o"');
-		expect(content).toContain("[history]\nenabled = true");
+		expect(content).toContain("[model]");
+		expect(content).toContain('name = "gpt-4o"');
+		expect(content).toContain("[history]");
+		expect(content).toContain("enabled = true");
 		expect(content).toContain("command = 'signet-mcp'");
-		expect(content).not.toContain("['signet-mcp']");
+		expect(content).not.toContain("command = [");
 	});
 
-	test("idempotent: re-running on correct config produces identical output", () => {
-		patchConfigToml(configPath, MCP);
+	test("appends section when config exists but has no signet entry", async () => {
+		writeFileSync(configPath, '[model]\nname = "gpt-4o"\n');
+
+		await connector().install(tempHome);
+
+		const content = readFileSync(configPath, "utf-8");
+		expect(content).toContain("[model]");
+		expect(content).toContain("[mcp_servers.signet]");
+		expect(content).toContain("command = 'signet-mcp'");
+	});
+
+	test("idempotent: re-running install produces identical config.toml", async () => {
+		await connector().install(tempHome);
 		const first = readFileSync(configPath, "utf-8");
-		patchConfigToml(configPath, MCP);
+
+		await connector().install(tempHome);
 		const second = readFileSync(configPath, "utf-8");
+
 		expect(second).toBe(first);
 	});
 
-	test("handles Windows-style command with args", () => {
-		patchConfigToml(configPath, MCP_WIN);
+	test("config section appears exactly once after repeated installs", async () => {
+		await connector().install(tempHome);
+		await connector().install(tempHome);
+		await connector().install(tempHome);
+
 		const content = readFileSync(configPath, "utf-8");
-		// Windows paths without single quotes use single-quote TOML literals
-		expect(content).toContain("command = 'C:\\Program Files\\node.exe'");
-		expect(content).toContain("args = ['C:\\signet\\mcp-stdio.js']");
+		expect(content.match(/\[mcp_servers\.signet\]/g)?.length).toBe(1);
 	});
 });
 
-describe("unpatchConfigToml", () => {
-	test("removes signet section cleanly", () => {
-		writeFileSync(
-			configPath,
-			'[model]\nname = "gpt-4o"\n\n# Signet MCP server\n[mcp_servers.signet]\ncommand = \'signet-mcp\'\n',
-		);
-		unpatchConfigToml(configPath);
-		const content = readFileSync(configPath, "utf-8");
-		expect(content).not.toContain("[mcp_servers.signet]");
-		expect(content).toContain('[model]\nname = "gpt-4o"');
+describe("CodexConnector.uninstall — config.toml cleanup", () => {
+	test("removes signet section from config.toml", async () => {
+		const c = connector();
+		await c.install(tempHome);
+		expect(readFileSync(configPath, "utf-8")).toContain("[mcp_servers.signet]");
+
+		await c.uninstall();
+
+		expect(existsSync(configPath)).toBe(true);
+		expect(readFileSync(configPath, "utf-8")).not.toContain("[mcp_servers.signet]");
 	});
 
-	test("returns false when file does not exist", () => {
-		expect(unpatchConfigToml(configPath)).toBe(false);
-	});
-
-	test("returns false when section not present", () => {
+	test("preserves other sections when removing signet entry", async () => {
 		writeFileSync(configPath, '[model]\nname = "gpt-4o"\n');
-		expect(unpatchConfigToml(configPath)).toBe(false);
-	});
-});
+		const c = connector();
+		await c.install(tempHome);
+		await c.uninstall();
 
-describe("buildMcpBlock", () => {
-	test("produces string command, not array", () => {
-		const block = buildMcpBlock(MCP);
-		expect(block).toContain("command = 'signet-mcp'");
-		// Must not contain array-style command (the old broken format)
-		expect(block).not.toContain("command = [");
-	});
-
-	test("includes args when present", () => {
-		const block = buildMcpBlock(MCP_WIN);
-		expect(block).toContain("args = ");
-	});
-
-	test("omits args when empty", () => {
-		const block = buildMcpBlock(MCP);
-		expect(block).not.toContain("args");
+		const content = readFileSync(configPath, "utf-8");
+		expect(content).toContain("[model]");
+		expect(content).not.toContain("[mcp_servers.signet]");
 	});
 });

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -196,10 +196,10 @@ function unpatchConfigToml(path: string): boolean {
 			inSection = true;
 			continue;
 		}
-		// Skip key=value lines belonging to the signet section
+		// Skip all lines belonging to the signet section until next header
 		if (inSection) {
-			if (line.match(/^\s*\w+\s*=/) || line.trim() === "") continue;
-			inSection = false;
+			if (line.match(/^\[/)) inSection = false;
+			else continue;
 		}
 		filtered.push(line);
 	}

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -158,16 +158,26 @@ function patchConfigToml(path: string, mcp: { command: string; args: string[] })
 	const dir = join(path, "..");
 	mkdirSync(dir, { recursive: true });
 
+	const block = buildMcpBlock(mcp);
+
 	if (!existsSync(path)) {
-		writeFileSync(path, buildMcpBlock(mcp));
+		writeFileSync(path, block);
 		return true;
 	}
 
 	const content = readFileSync(path, "utf-8");
-	if (content.includes("[mcp_servers.signet]")) return false;
 
-	const appended = content.trimEnd() + "\n\n" + buildMcpBlock(mcp);
-	writeFileSync(path, appended);
+	if (!content.includes("[mcp_servers.signet]")) {
+		writeFileSync(path, content.trimEnd() + "\n\n" + block);
+		return true;
+	}
+
+	// Section exists but may be stale (e.g. old array-format command).
+	// Remove and re-add with correct format.
+	unpatchConfigToml(path);
+	const updated = existsSync(path) ? readFileSync(path, "utf-8").trim() : "";
+	const prefix = updated.length > 0 ? updated + "\n\n" : "";
+	writeFileSync(path, prefix + block);
 	return true;
 }
 

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -146,7 +146,7 @@ function tomlInlineArray(items: string[]): string {
 	return `[${items.map(tomlQuote).join(", ")}]`;
 }
 
-function buildMcpBlock(mcp: { command: string; args: string[] }): string {
+export function buildMcpBlock(mcp: { command: string; args: string[] }): string {
 	let block = `# Signet MCP server\n[mcp_servers.signet]\ncommand = ${tomlQuote(mcp.command)}\n`;
 	if (mcp.args.length > 0) {
 		block += `args = ${tomlInlineArray(mcp.args)}\n`;

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -221,7 +221,7 @@ export class CodexConnector extends BaseConnector {
 	readonly name = "Codex";
 	readonly harnessId = "codex";
 
-	private getCodexHome(): string {
+	protected getCodexHome(): string {
 		return join(homedir(), ".codex");
 	}
 


### PR DESCRIPTION
## Summary

- Fixes "invalid transport in 'mcp_servers.signet'" error reported by users after upgrading to v0.91.1
- `patchConfigToml()` now strips and re-adds the MCP section on every install instead of skipping when it already exists
- Users with stale array-format `command = ['signet-mcp']` (pre-#273) will be automatically repaired on next `signet setup`

## Root Cause

`patchConfigToml()` had a skip-if-exists guard (`if (content.includes("[mcp_servers.signet]")) return false`) that prevented it from ever fixing broken config entries. Users who installed before PR #273 had `command` as a TOML array instead of a string. Codex's Rust parser expects `Option<String>`, silently drops the array to `None`, finds neither `command` nor `url`, and throws "invalid transport."

## Test plan

- [x] 12 regression tests added covering fresh creation, stale config repair, idempotency, section preservation, and Windows paths
- [x] `bun test packages/connector-codex/` passes
- [x] `bun run typecheck` passes
- [x] `bun run build` passes