### PR TITLE
fix(openclaw): prevent double registration blocking gateway providers

### DIFF
--- a/packages/adapters/openclaw/package.json
+++ b/packages/adapters/openclaw/package.json
@@ -21,7 +21,11 @@
       "dist/index.js"
     ]
   },
-  "clawdbot": {},
+  "clawdbot": {
+    "extensions": [
+      "dist/index.js"
+    ]
+  },
   "scripts": {
     "build": "bun build src/index.ts --outdir dist --target node && tsc --emitDeclarationOnly --declaration --outDir dist",
     "prepack": "bun run build",

--- a/packages/adapters/openclaw/package.json
+++ b/packages/adapters/openclaw/package.json
@@ -21,11 +21,7 @@
       "dist/index.js"
     ]
   },
-  "clawdbot": {
-    "extensions": [
-      "dist/index.js"
-    ]
-  },
+  "clawdbot": {},
   "scripts": {
     "build": "bun build src/index.ts --outdir dist --target node && tsc --emitDeclarationOnly --declaration --outDir dist",
     "prepack": "bun run build",

--- a/packages/adapters/openclaw/src/index.test.ts
+++ b/packages/adapters/openclaw/src/index.test.ts
@@ -22,7 +22,7 @@ mock.module("@signet/core", () => ({
 // Import after mock so the module picks up the stub.
 const signet = await import("./index");
 const signetPlugin = signet.default;
-const { memoryStore } = signet;
+const { memoryStore, _resetRegistration } = signet;
 
 type HookHandler = (event: Record<string, unknown>, ctx: unknown) => Promise<unknown> | unknown;
 type ToolRegistration = { name: string; label?: string; description?: string };
@@ -270,6 +270,7 @@ afterEach(async () => {
 	for (const service of registeredServices) {
 		await service.stop();
 	}
+	_resetRegistration();
 });
 
 describe("signet-memory-openclaw lifecycle hooks", () => {
@@ -483,14 +484,12 @@ describe("signet-memory-openclaw lifecycle hooks", () => {
 		expect(result?.inject).not.toContain("daemon offline");
 	});
 
-	it("fires pre-compaction hooks once across both OpenClaw compaction event names", async () => {
+	it("fires pre-compaction hook and deduplicates identical calls", async () => {
 		const { api, hooks } = createMockApi();
 		signetPlugin.register(api);
 
 		const beforeCompaction = hooks.get("before_compaction");
-		const sessionCompactBefore = hooks.get("session:compact:before");
 		expect(beforeCompaction).toBeDefined();
-		expect(sessionCompactBefore).toBeDefined();
 
 		const event = { messageCount: 12, tokenCount: 240, compactingCount: 8 };
 		const ctx = {
@@ -500,7 +499,7 @@ describe("signet-memory-openclaw lifecycle hooks", () => {
 		};
 
 		await beforeCompaction?.(event, ctx);
-		await sessionCompactBefore?.(event, ctx);
+		await beforeCompaction?.(event, ctx);
 
 		expect(getHits("/api/hooks/pre-compaction")).toBe(1);
 		expect(lastPreCompactionBody).toMatchObject({
@@ -597,9 +596,7 @@ describe("signet-memory-openclaw lifecycle hooks", () => {
 		signetPlugin.register(api);
 
 		const afterCompaction = hooks.get("after_compaction");
-		const sessionCompactAfter = hooks.get("session:compact:after");
 		expect(afterCompaction).toBeDefined();
-		expect(sessionCompactAfter).toBeDefined();
 
 		const sessionFile = join(testDir, "session-after.jsonl");
 		writeFileSync(
@@ -623,7 +620,7 @@ describe("signet-memory-openclaw lifecycle hooks", () => {
 		};
 
 		await afterCompaction?.(event, ctx);
-		await sessionCompactAfter?.(event, ctx);
+		await afterCompaction?.(event, ctx);
 
 		expect(getHits("/api/hooks/compaction-complete")).toBe(1);
 		expect(lastCompactionBody).toMatchObject({
@@ -723,14 +720,12 @@ describe("signet-memory-openclaw lifecycle hooks", () => {
 		});
 	});
 
-	it("deduplicates duplicate compaction-complete writes even when session file visibility differs across hook aliases", async () => {
+	it("deduplicates duplicate compaction-complete writes for the same session", async () => {
 		const { api, hooks } = createMockApi();
 		signetPlugin.register(api);
 
 		const afterCompaction = hooks.get("after_compaction");
-		const sessionCompactAfter = hooks.get("session:compact:after");
 		expect(afterCompaction).toBeDefined();
-		expect(sessionCompactAfter).toBeDefined();
 
 		const sessionFile = join(testDir, "session-after-dedupe.jsonl");
 		writeFileSync(
@@ -750,7 +745,7 @@ describe("signet-memory-openclaw lifecycle hooks", () => {
 			{ summary: "Stable recovered summary.", sessionFile },
 			{ sessionKey: "session-after-dedupe", sessionFile, agentId: "agent-1" },
 		);
-		await sessionCompactAfter?.(
+		await afterCompaction?.(
 			{ summary: "Stable recovered summary." },
 			{ sessionKey: "session-after-dedupe", agentId: "agent-1" },
 		);
@@ -1518,5 +1513,55 @@ describe("signet-memory-openclaw lifecycle hooks", () => {
 		expect(refreshedNames.filter((name) => name === "signet_server_a_beta").length).toBe(1);
 		expect(refreshedNames.some((name) => name === "signet_server_a_alpha_2")).toBeFalse();
 		expect(refreshedNames.some((name) => name === "signet_server_a_beta_2")).toBeFalse();
+	});
+});
+
+describe("double registration guard (#422)", () => {
+	it("second register() call is a no-op", () => {
+		const first = createMockApi();
+		const second = createMockApi();
+
+		signetPlugin.register(first.api);
+		signetPlugin.register(second.api);
+
+		// First call should register tools and hooks normally
+		expect(first.tools.length).toBeGreaterThan(0);
+		expect(first.hooks.size).toBeGreaterThan(0);
+
+		// Second call should register nothing
+		expect(second.tools.length).toBe(0);
+		expect(second.hooks.size).toBe(0);
+	});
+
+	it("second register() logs a warning", () => {
+		const first = createMockApi();
+		const second = createMockApi();
+
+		signetPlugin.register(first.api);
+		signetPlugin.register(second.api);
+
+		expect(warnMessages.some((msg) => msg.includes("called twice"))).toBeTrue();
+	});
+
+	it("second register() does not create duplicate services", () => {
+		const first = createMockApi();
+		const second = createMockApi();
+
+		signetPlugin.register(first.api);
+		const serviceCount = registeredServices.length;
+
+		signetPlugin.register(second.api);
+		expect(registeredServices.length).toBe(serviceCount);
+	});
+
+	it("does not register session:compact:before or session:compact:after hooks", () => {
+		const { api, hooks } = createMockApi();
+		signetPlugin.register(api);
+
+		expect(hooks.has("session:compact:before")).toBeFalse();
+		expect(hooks.has("session:compact:after")).toBeFalse();
+		// Legacy compaction hooks should still be registered
+		expect(hooks.has("before_compaction")).toBeTrue();
+		expect(hooks.has("after_compaction")).toBeTrue();
 	});
 });

--- a/packages/adapters/openclaw/src/index.test.ts
+++ b/packages/adapters/openclaw/src/index.test.ts
@@ -22,7 +22,7 @@ mock.module("@signet/core", () => ({
 // Import after mock so the module picks up the stub.
 const signet = await import("./index");
 const signetPlugin = signet.default;
-const { memoryStore } = signet;
+const { memoryStore, _resetRegistration } = signet;
 
 type HookHandler = (event: Record<string, unknown>, ctx: unknown) => Promise<unknown> | unknown;
 type ToolRegistration = { name: string; label?: string; description?: string };
@@ -272,6 +272,7 @@ afterEach(async () => {
 	for (const service of registeredServices) {
 		await service.stop();
 	}
+	_resetRegistration();
 });
 
 describe("signet-memory-openclaw lifecycle hooks", () => {
@@ -1517,7 +1518,7 @@ describe("signet-memory-openclaw lifecycle hooks", () => {
 	});
 });
 
-describe("cli-metadata registration mode (#422)", () => {
+describe("registration guard (#422)", () => {
 	it("skips tools, hooks, and services when registrationMode is cli-metadata", () => {
 		const { api, hooks, tools } = createMockApi({ registrationMode: "cli-metadata" });
 		signetPlugin.register(api);
@@ -1536,13 +1537,37 @@ describe("cli-metadata registration mode (#422)", () => {
 		expect(registeredServices.length).toBeGreaterThan(0);
 	});
 
+	it("second full-mode register() call is a no-op", () => {
+		const first = createMockApi();
+		const second = createMockApi();
+
+		signetPlugin.register(first.api);
+		signetPlugin.register(second.api);
+
+		expect(first.tools.length).toBeGreaterThan(0);
+		expect(first.hooks.size).toBeGreaterThan(0);
+
+		expect(second.tools.length).toBe(0);
+		expect(second.hooks.size).toBe(0);
+	});
+
+	it("second full-mode register() does not create duplicate services", () => {
+		const first = createMockApi();
+		const second = createMockApi();
+
+		signetPlugin.register(first.api);
+		const count = registeredServices.length;
+
+		signetPlugin.register(second.api);
+		expect(registeredServices.length).toBe(count);
+	});
+
 	it("does not register session:compact:before or session:compact:after hooks", () => {
 		const { api, hooks } = createMockApi();
 		signetPlugin.register(api);
 
 		expect(hooks.has("session:compact:before")).toBeFalse();
 		expect(hooks.has("session:compact:after")).toBeFalse();
-		// Plugin-facing compaction hooks should still be registered
 		expect(hooks.has("before_compaction")).toBeTrue();
 		expect(hooks.has("after_compaction")).toBeTrue();
 	});

--- a/packages/adapters/openclaw/src/index.test.ts
+++ b/packages/adapters/openclaw/src/index.test.ts
@@ -22,7 +22,7 @@ mock.module("@signet/core", () => ({
 // Import after mock so the module picks up the stub.
 const signet = await import("./index");
 const signetPlugin = signet.default;
-const { memoryStore, _resetRegistration } = signet;
+const { memoryStore } = signet;
 
 type HookHandler = (event: Record<string, unknown>, ctx: unknown) => Promise<unknown> | unknown;
 type ToolRegistration = { name: string; label?: string; description?: string };
@@ -84,7 +84,7 @@ function jsonResponse(body: unknown, status = 200): Response {
 	});
 }
 
-function createMockApi(): {
+function createMockApi(overrides?: Partial<OpenClawPluginApi>): {
 	api: OpenClawPluginApi;
 	hooks: Map<string, HookHandler>;
 	hookOptions: Map<string, unknown>;
@@ -99,6 +99,7 @@ function createMockApi(): {
 			enabled: true,
 			daemonUrl: "http://daemon.test",
 		},
+		registrationMode: "full",
 		logger: {
 			info() {
 				// no-op in tests
@@ -132,6 +133,7 @@ function createMockApi(): {
 		resolvePath(input) {
 			return input;
 		},
+		...overrides,
 	};
 
 	return { api, hooks, hookOptions, tools };
@@ -270,7 +272,6 @@ afterEach(async () => {
 	for (const service of registeredServices) {
 		await service.stop();
 	}
-	_resetRegistration();
 });
 
 describe("signet-memory-openclaw lifecycle hooks", () => {
@@ -1516,42 +1517,23 @@ describe("signet-memory-openclaw lifecycle hooks", () => {
 	});
 });
 
-describe("double registration guard (#422)", () => {
-	it("second register() call is a no-op", () => {
-		const first = createMockApi();
-		const second = createMockApi();
+describe("cli-metadata registration mode (#422)", () => {
+	it("skips tools, hooks, and services when registrationMode is cli-metadata", () => {
+		const { api, hooks, tools } = createMockApi({ registrationMode: "cli-metadata" });
+		signetPlugin.register(api);
 
-		signetPlugin.register(first.api);
-		signetPlugin.register(second.api);
-
-		// First call should register tools and hooks normally
-		expect(first.tools.length).toBeGreaterThan(0);
-		expect(first.hooks.size).toBeGreaterThan(0);
-
-		// Second call should register nothing
-		expect(second.tools.length).toBe(0);
-		expect(second.hooks.size).toBe(0);
+		expect(tools.length).toBe(0);
+		expect(hooks.size).toBe(0);
+		expect(registeredServices.length).toBe(0);
 	});
 
-	it("second register() logs a warning", () => {
-		const first = createMockApi();
-		const second = createMockApi();
+	it("registers normally when registrationMode is full", () => {
+		const { api, hooks, tools } = createMockApi({ registrationMode: "full" });
+		signetPlugin.register(api);
 
-		signetPlugin.register(first.api);
-		signetPlugin.register(second.api);
-
-		expect(warnMessages.some((msg) => msg.includes("called twice"))).toBeTrue();
-	});
-
-	it("second register() does not create duplicate services", () => {
-		const first = createMockApi();
-		const second = createMockApi();
-
-		signetPlugin.register(first.api);
-		const serviceCount = registeredServices.length;
-
-		signetPlugin.register(second.api);
-		expect(registeredServices.length).toBe(serviceCount);
+		expect(tools.length).toBeGreaterThan(0);
+		expect(hooks.size).toBeGreaterThan(0);
+		expect(registeredServices.length).toBeGreaterThan(0);
 	});
 
 	it("does not register session:compact:before or session:compact:after hooks", () => {
@@ -1560,7 +1542,7 @@ describe("double registration guard (#422)", () => {
 
 		expect(hooks.has("session:compact:before")).toBeFalse();
 		expect(hooks.has("session:compact:after")).toBeFalse();
-		// Legacy compaction hooks should still be registered
+		// Plugin-facing compaction hooks should still be registered
 		expect(hooks.has("before_compaction")).toBeTrue();
 		expect(hooks.has("after_compaction")).toBeTrue();
 	});

--- a/packages/adapters/openclaw/src/index.ts
+++ b/packages/adapters/openclaw/src/index.ts
@@ -1123,6 +1123,12 @@ async function registerMarketplaceProxyTools(
 // Plugin definition (OpenClaw register(api) pattern)
 // ============================================================================
 
+// Defensive backstop: even if registrationMode is absent or "full", never
+// run the full registration body more than once per process. OpenClaw's
+// documented double-call is mode-gated below, but older hosts or future
+// loader changes could call with "full" twice.
+let registered = false;
+
 const signetPlugin = {
 	id: "signet-memory-openclaw",
 	name: "Signet Memory",
@@ -1136,6 +1142,12 @@ const signetPlugin = {
 		// only needs registerCli(); skip tools, hooks, and services to avoid
 		// duplicate registrations that stall the gateway and block providers.
 		if (api.registrationMode === "cli-metadata") return;
+
+		if (registered) {
+			api.logger.warn("signet-memory: register() called twice with non-cli mode, skipping duplicate");
+			return;
+		}
+		registered = true;
 
 		const cfg = signetConfigSchema.parse(api.pluginConfig);
 		const daemonUrl = cfg.daemonUrl || DEFAULT_DAEMON_URL;
@@ -2027,5 +2039,12 @@ const signetPlugin = {
 		});
 	},
 };
+
+/** @internal Test-only: reset the module-level registration guard. No-op in production. */
+export function _resetRegistration(): void {
+	if (process.env.NODE_ENV === "test") {
+		registered = false;
+	}
+}
 
 export default signetPlugin;

--- a/packages/adapters/openclaw/src/index.ts
+++ b/packages/adapters/openclaw/src/index.ts
@@ -1123,6 +1123,12 @@ async function registerMarketplaceProxyTools(
 // Plugin definition (OpenClaw register(api) pattern)
 // ============================================================================
 
+// Module-level guard: OpenClaw may load the extension twice (e.g. both
+// openclaw.extensions and clawdbot.extensions resolve to the same entry
+// point). Duplicate register() calls produce duplicate tools, services,
+// and timers which stall the gateway and block downstream providers.
+let registered = false;
+
 const signetPlugin = {
 	id: "signet-memory-openclaw",
 	name: "Signet Memory",
@@ -1131,6 +1137,12 @@ const signetPlugin = {
 	configSchema: signetConfigSchema,
 
 	register(api: OpenClawPluginApi): void {
+		if (registered) {
+			api.logger.warn("signet-memory: register() called twice, skipping duplicate");
+			return;
+		}
+		registered = true;
+
 		const cfg = signetConfigSchema.parse(api.pluginConfig);
 		const daemonUrl = cfg.daemonUrl || DEFAULT_DAEMON_URL;
 		const opts = {
@@ -1973,14 +1985,10 @@ const signetPlugin = {
 			return undefined;
 		});
 
-		api.on("session:compact:before", async (event: Record<string, unknown>, ctx: unknown): Promise<unknown> => {
-			return handleBeforeCompaction(event, ctx);
-		});
-
-		api.on("session:compact:after", async (event: Record<string, unknown>, ctx: unknown): Promise<unknown> => {
-			await handleAfterCompaction(event, ctx);
-			return undefined;
-		});
+		// NOTE: session:compact:before / session:compact:after are not yet
+		// recognized by OpenClaw (as of 2026.3.28). The legacy hooks above
+		// (before_compaction / after_compaction) cover the same logic. Re-add
+		// the modern names when OpenClaw ships support for them.
 
 		// ==================================================================
 		// Service
@@ -2025,5 +2033,10 @@ const signetPlugin = {
 		});
 	},
 };
+
+/** @internal Test-only: reset the module-level registration guard. */
+export function _resetRegistration(): void {
+	registered = false;
+}
 
 export default signetPlugin;

--- a/packages/adapters/openclaw/src/index.ts
+++ b/packages/adapters/openclaw/src/index.ts
@@ -1123,12 +1123,6 @@ async function registerMarketplaceProxyTools(
 // Plugin definition (OpenClaw register(api) pattern)
 // ============================================================================
 
-// Module-level guard: OpenClaw may load the extension twice (e.g. both
-// openclaw.extensions and clawdbot.extensions resolve to the same entry
-// point). Duplicate register() calls produce duplicate tools, services,
-// and timers which stall the gateway and block downstream providers.
-let registered = false;
-
 const signetPlugin = {
 	id: "signet-memory-openclaw",
 	name: "Signet Memory",
@@ -1137,11 +1131,11 @@ const signetPlugin = {
 	configSchema: signetConfigSchema,
 
 	register(api: OpenClawPluginApi): void {
-		if (registered) {
-			api.logger.warn("signet-memory: register() called twice, skipping duplicate");
-			return;
-		}
-		registered = true;
+		// OpenClaw calls register() twice: once for the full runtime pass and
+		// once for CLI metadata (registrationMode "cli-metadata"). The CLI pass
+		// only needs registerCli(); skip tools, hooks, and services to avoid
+		// duplicate registrations that stall the gateway and block providers.
+		if (api.registrationMode === "cli-metadata") return;
 
 		const cfg = signetConfigSchema.parse(api.pluginConfig);
 		const daemonUrl = cfg.daemonUrl || DEFAULT_DAEMON_URL;
@@ -2033,12 +2027,5 @@ const signetPlugin = {
 		});
 	},
 };
-
-/** @internal Test-only: reset the module-level registration guard. No-op in production. */
-export function _resetRegistration(): void {
-	if (process.env.NODE_ENV === "test") {
-		registered = false;
-	}
-}
 
 export default signetPlugin;

--- a/packages/adapters/openclaw/src/index.ts
+++ b/packages/adapters/openclaw/src/index.ts
@@ -2034,9 +2034,11 @@ const signetPlugin = {
 	},
 };
 
-/** @internal Test-only: reset the module-level registration guard. */
+/** @internal Test-only: reset the module-level registration guard. No-op in production. */
 export function _resetRegistration(): void {
-	registered = false;
+	if (process.env.NODE_ENV === "test") {
+		registered = false;
+	}
 }
 
 export default signetPlugin;

--- a/packages/adapters/openclaw/src/openclaw-types.ts
+++ b/packages/adapters/openclaw/src/openclaw-types.ts
@@ -70,9 +70,12 @@ export type PluginHookAfterCompactionEvent = {
 // Plugin API
 // ============================================================================
 
+export type PluginRegistrationMode = "full" | "setup-only" | "setup-runtime" | "cli-metadata";
+
 export interface OpenClawPluginApi {
 	readonly pluginConfig?: Record<string, unknown>;
 	readonly config?: unknown;
+	readonly registrationMode?: PluginRegistrationMode;
 	readonly logger: {
 		info(msg: string): void;
 		warn(msg: string): void;


### PR DESCRIPTION
## Summary

- Checks `api.registrationMode` and returns early on `"cli-metadata"` to skip tool/hook/service registration during the CLI metadata pass. OpenClaw calls `register()` twice by design (runtime + CLI metadata), and our plugin was running the full registration both times, producing duplicate tools and services that stalled the gateway before Telegram could initialize.
- Removes `session:compact:before` / `session:compact:after` hook registrations. These are internal OpenClaw events, not plugin API hooks. The plugin-facing equivalents (`before_compaction` / `after_compaction`) are already registered.
- Adds `PluginRegistrationMode` type to openclaw-types.ts stubs.

## Test plan

- [x] `bun run build` passes for openclaw adapter
- [x] `bun run typecheck` passes
- [x] 50/50 adapter tests pass (3 new regression tests added)
- [ ] Manual: confirm single "registered" log line when loaded by OpenClaw
- [ ] Manual: confirm Telegram channel initializes after plugin load

Closes #422