### PR TITLE
fix(pipeline): support Copilot models via OpenCode structured output

### DIFF
--- a/packages/daemon/src/pipeline/extraction.test.ts
+++ b/packages/daemon/src/pipeline/extraction.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from "bun:test";
-import { extractFactsAndEntities } from "./extraction";
+import { extractFactsAndEntities, stripFences } from "./extraction";
 import type { LlmProvider } from "./provider";
 
 // ---------------------------------------------------------------------------
@@ -320,5 +320,47 @@ ${VALID_RESPONSE}
 
 		expect(result.facts).toHaveLength(0);
 		expect(result.entities).toHaveLength(0);
+	});
+
+	it("parses JSON when Copilot model prefixes with explanation text", async () => {
+		const copilotStyle = `Sure, here is the extracted data from the text:\n\n${VALID_RESPONSE}`;
+		const provider = mockProvider([copilotStyle]);
+		const result = await extractFactsAndEntities("User prefers dark mode and uses vim keybindings", provider);
+
+		expect(result.facts).toHaveLength(2);
+		expect(result.entities).toHaveLength(1);
+		expect(result.warnings).toHaveLength(0);
+	});
+
+	it("parses JSON when model adds verbose preamble without code fence", async () => {
+		const verbose = `I've analyzed the text and extracted the following facts and entities. Here is the result:\n${VALID_RESPONSE}`;
+		const provider = mockProvider([verbose]);
+		const result = await extractFactsAndEntities("User prefers dark mode and uses vim keybindings", provider);
+
+		expect(result.facts).toHaveLength(2);
+		expect(result.entities).toHaveLength(1);
+	});
+});
+
+describe("stripFences", () => {
+	it("strips leading non-JSON text before first brace", () => {
+		const input = 'Here is the JSON output:\n{"key": "value"}';
+		const result = stripFences(input);
+		expect(result).toBe('{"key": "value"}');
+	});
+
+	it("returns input unchanged when it starts with a brace", () => {
+		const input = '{"key": "value"}';
+		expect(stripFences(input)).toBe('{"key": "value"}');
+	});
+
+	it("still prefers code fence extraction over leading-text stripping", () => {
+		const input = 'explanation\n```json\n{"fenced": true}\n```\nmore text';
+		expect(stripFences(input)).toBe('{"fenced": true}');
+	});
+
+	it("strips think blocks from reasoning models", () => {
+		const input = '<think>reasoning here</think>{"key": "value"}';
+		expect(stripFences(input)).toBe('{"key": "value"}');
 	});
 });

--- a/packages/daemon/src/pipeline/extraction.ts
+++ b/packages/daemon/src/pipeline/extraction.ts
@@ -100,7 +100,15 @@ export function stripFences(raw: string): string {
 	const arr = extractBalancedJsonArray(stripped);
 	if (arr) return arr;
 
-	return stripped.trim();
+	// Strip leading non-JSON text before the first '{'.
+	// Handles models (Copilot, GPT) that prefix JSON with explanatory prose.
+	const trimmed = stripped.trim();
+	const brace = trimmed.indexOf("{");
+	if (brace > 0) {
+		return trimmed.slice(brace);
+	}
+
+	return trimmed;
 }
 
 export function tryParseJson(candidate: string): unknown | null {
@@ -382,7 +390,8 @@ export function parseRawExtractionOutput(rawOutput: string): ExtractionResult {
 	if (parsed === null) {
 		const jsonStr = stripFences(rawOutput);
 		logger.warn("pipeline", "Failed to parse extraction JSON", {
-			preview: jsonStr.slice(0, 200),
+			preview: jsonStr.slice(0, 500),
+			length: rawOutput.length,
 		});
 		return { facts: [], entities: [], warnings: ["Failed to parse LLM output as JSON"] };
 	}

--- a/packages/daemon/src/pipeline/model-registry.ts
+++ b/packages/daemon/src/pipeline/model-registry.ts
@@ -89,6 +89,28 @@ const KNOWN_MODELS: Record<string, ModelRegistryEntry[]> = {
 			deprecated: false,
 		},
 		{ id: "google/gemini-2.5-flash", provider: "opencode", label: "Gemini 2.5 Flash", tier: "low", deprecated: false },
+		{ id: "github-copilot/gpt-4o", provider: "opencode", label: "GPT-4o (Copilot)", tier: "mid", deprecated: false },
+		{
+			id: "github-copilot/gpt-4o-mini",
+			provider: "opencode",
+			label: "GPT-4o Mini (Copilot)",
+			tier: "low",
+			deprecated: false,
+		},
+		{
+			id: "github-copilot/o3-mini",
+			provider: "opencode",
+			label: "O3 Mini (Copilot)",
+			tier: "mid",
+			deprecated: false,
+		},
+		{
+			id: "github-copilot/claude-sonnet-4",
+			provider: "opencode",
+			label: "Claude Sonnet 4 (Copilot)",
+			tier: "mid",
+			deprecated: false,
+		},
 	],
 	openrouter: [
 		// Keep these slugs valid for no-discovery fallback mode.

--- a/packages/daemon/src/pipeline/provider.test.ts
+++ b/packages/daemon/src/pipeline/provider.test.ts
@@ -937,9 +937,9 @@ describe("createOpenCodeProvider", () => {
 		expect(JSON.parse(result).description).toBe("test skill");
 	});
 
-	it("generate() disables structured output on 400 and retries without format", async () => {
+	it("generate() disables structured output on 422 and retries without format", async () => {
 		let attempts = 0;
-		let lastBody: Record<string, unknown> = {};
+		const bodies: Record<string, unknown>[] = [];
 		mockFetch(async (url, init) => {
 			if (url.includes("/session") && !url.includes("/message")) {
 				return Response.json({
@@ -952,18 +952,50 @@ describe("createOpenCodeProvider", () => {
 				});
 			}
 			attempts++;
-			lastBody = JSON.parse(init?.body as string);
+			bodies.push(JSON.parse(init?.body as string));
 			if (attempts === 1) {
-				return new Response('{"error":"validation failed for format field"}', { status: 400 });
+				// 422 with "format" JSON key — signals structured output unsupported
+				return new Response('{"issues":[{"path":["format"],"message":"Unrecognized key"}]}', { status: 422 });
 			}
 			return Response.json(openCodeResponse("fallback works"));
 		});
 
 		const provider = createOpenCodeProvider({ baseUrl: "http://localhost:9999" });
-		const result = await provider.generate("test");
-		expect(result).toBe("fallback works");
-		// After disabling, subsequent calls should not include format
-		expect(lastBody.format).toBeUndefined();
+		const first = await provider.generate("test");
+		expect(first).toBe("fallback works");
+		// The retry within the same call should omit format
+		expect(bodies[1]?.format).toBeUndefined();
+
+		// A subsequent call should also omit format (structured output stays disabled)
+		await provider.generate("second call");
+		expect(bodies[2]?.format).toBeUndefined();
+	});
+
+	it("generate() does not disable structured output on an unrelated 400", async () => {
+		let attempts = 0;
+		mockFetch(async (url, init) => {
+			if (url.includes("/session") && !url.includes("/message")) {
+				return Response.json({
+					id: `ses_unrelated_${attempts}`,
+					slug: "test",
+					projectID: "p",
+					directory: "/tmp",
+					title: "test",
+					version: "1",
+				});
+			}
+			attempts++;
+			if (attempts === 1) {
+				// 400 with "format" word but not a structured-output rejection
+				return new Response('{"error":"Invalid request format: parts array is missing"}', { status: 400 });
+			}
+			return Response.json(openCodeResponse("ok"));
+		});
+
+		const provider = createOpenCodeProvider({ baseUrl: "http://localhost:9999" });
+		// Should throw, not silently disable structured output and retry
+		await expect(provider.generate("test")).rejects.toThrow(/OpenCode HTTP 400/);
+		expect(attempts).toBe(1);
 	});
 
 	it("generate() preserves error body on non-format 400", async () => {

--- a/packages/daemon/src/pipeline/provider.test.ts
+++ b/packages/daemon/src/pipeline/provider.test.ts
@@ -706,6 +706,13 @@ describe("createOpenCodeProvider", () => {
 
 		expect(capturedBody.parts).toEqual([{ type: "text", text: "my prompt" }]);
 		expect(capturedBody.model).toEqual({ providerID: "google", modelID: "gemini-2.5-flash" });
+		// Structured output fields are included by default
+		expect(capturedBody.format).toEqual({
+			type: "json_schema",
+			schema: { type: "object", additionalProperties: true },
+			retryCount: 1,
+		});
+		expect(typeof capturedBody.system).toBe("string");
 	});
 
 	it("generate() joins multiple text parts", async () => {
@@ -865,6 +872,103 @@ describe("createOpenCodeProvider", () => {
 		expect(seenUrls).toContain("http://172.17.0.1:11434/api/generate");
 		const fallbackOptions = fallbackBody ? getObjectField(fallbackBody, "options") : undefined;
 		expect(fallbackOptions ? getNumberField(fallbackOptions, "num_ctx") : undefined).toBe(2048);
+	});
+
+	it("generate() prefers info.structured over text parts", async () => {
+		mockFetch(async (url) => {
+			if (url.includes("/session") && !url.includes("/message")) {
+				return Response.json({
+					id: "ses_structured",
+					slug: "test",
+					projectID: "p",
+					directory: "/tmp",
+					title: "test",
+					version: "1",
+				});
+			}
+			return Response.json({
+				info: {
+					role: "assistant",
+					id: "msg_s",
+					sessionID: "ses_structured",
+					cost: 0,
+					tokens: { input: 10, output: 5 },
+					structured: { facts: [{ content: "from structured", type: "fact", confidence: 0.9 }], entities: [] },
+				},
+				parts: [
+					{ type: "text", text: "ignore this text", id: "p1", sessionID: "ses_structured", messageID: "msg_s" },
+				],
+			});
+		});
+
+		const provider = createOpenCodeProvider({ baseUrl: "http://localhost:9999" });
+		const result = await provider.generate("test");
+		const parsed = JSON.parse(result);
+		expect(parsed.facts[0].content).toBe("from structured");
+	});
+
+	it("generate() returns info.structured as string when it is a string", async () => {
+		mockFetch(async (url) => {
+			if (url.includes("/session") && !url.includes("/message")) {
+				return Response.json({
+					id: "ses_str",
+					slug: "test",
+					projectID: "p",
+					directory: "/tmp",
+					title: "test",
+					version: "1",
+				});
+			}
+			return Response.json({
+				info: {
+					role: "assistant",
+					id: "msg_str",
+					sessionID: "ses_str",
+					cost: 0,
+					tokens: { input: 0, output: 0 },
+					structured: '{"description":"test skill","triggers":["run tests"],"tags":["testing"]}',
+				},
+				parts: [],
+			});
+		});
+
+		const provider = createOpenCodeProvider({ baseUrl: "http://localhost:9999" });
+		const result = await provider.generate("test");
+		expect(JSON.parse(result).description).toBe("test skill");
+	});
+
+	it("generate() disables structured output on 400 and retries without format", async () => {
+		let attempts = 0;
+		let lastBody: Record<string, unknown> = {};
+		mockFetch(async (url, init) => {
+			if (url.includes("/session") && !url.includes("/message")) {
+				return Response.json({
+					id: `ses_compat_${attempts}`,
+					slug: "test",
+					projectID: "p",
+					directory: "/tmp",
+					title: "test",
+					version: "1",
+				});
+			}
+			attempts++;
+			lastBody = JSON.parse(init?.body as string);
+			if (attempts === 1) {
+				return new Response('{"error":"validation failed for format field"}', { status: 400 });
+			}
+			return Response.json(openCodeResponse("fallback works"));
+		});
+
+		const provider = createOpenCodeProvider({ baseUrl: "http://localhost:9999" });
+		const result = await provider.generate("test");
+		expect(result).toBe("fallback works");
+		// After disabling, subsequent calls should not include format
+		expect(lastBody.format).toBeUndefined();
+	});
+
+	it("generate() parses github-copilot provider/model format", () => {
+		const provider = createOpenCodeProvider({ model: "github-copilot/gpt-4o" });
+		expect(provider.name).toBe("opencode:github-copilot/gpt-4o");
 	});
 });
 

--- a/packages/daemon/src/pipeline/provider.test.ts
+++ b/packages/daemon/src/pipeline/provider.test.ts
@@ -966,6 +966,25 @@ describe("createOpenCodeProvider", () => {
 		expect(lastBody.format).toBeUndefined();
 	});
 
+	it("generate() preserves error body on non-format 400", async () => {
+		mockFetch(async (url) => {
+			if (url.includes("/session") && !url.includes("/message")) {
+				return Response.json({
+					id: "ses_400",
+					slug: "test",
+					projectID: "p",
+					directory: "/tmp",
+					title: "test",
+					version: "1",
+				});
+			}
+			return new Response("bad request: missing required field", { status: 400 });
+		});
+
+		const provider = createOpenCodeProvider({ baseUrl: "http://localhost:9999" });
+		await expect(provider.generate("test")).rejects.toThrow(/bad request: missing required field/);
+	});
+
 	it("generate() parses github-copilot provider/model format", () => {
 		const provider = createOpenCodeProvider({ model: "github-copilot/gpt-4o" });
 		expect(provider.name).toBe("opencode:github-copilot/gpt-4o");

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -1915,15 +1915,10 @@ export function createOpenCodeProvider(config?: Partial<OpenCodeProviderConfig>)
 				// future body shape changes that happen to contain "format" elsewhere.
 				const isFormatRejection = (() => {
 					try {
-						const parsed = JSON.parse(consumedBody) as Record<string, unknown>;
+						const parsed: unknown = JSON.parse(consumedBody);
+						if (!isRecord(parsed)) return false;
 						const issues = Array.isArray(parsed.issues) ? parsed.issues : [];
-						return issues.some(
-							(i): boolean =>
-								typeof i === "object" &&
-								i !== null &&
-								Array.isArray((i as Record<string, unknown>).path) &&
-								((i as Record<string, unknown>).path as unknown[])[0] === "format",
-						);
+						return issues.some((i): boolean => isRecord(i) && Array.isArray(i.path) && i.path[0] === "format");
 					} catch {
 						return false;
 					}

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -1910,9 +1910,25 @@ export function createOpenCodeProvider(config?: Partial<OpenCodeProviderConfig>)
 			// fall through to the throw path.
 			if (!res.ok && res.status === 422) {
 				consumedBody = await res.text().catch(() => "");
-				// Match Hono/Zod's path array notation: {"path":["format"],...}
-				// Avoids triggering on error messages that contain "format" as a value.
-				if (consumedBody.includes('["format"]')) {
+				// Parse the Hono/Zod rejection body to check whether "format" is the
+				// offending field. Unambiguous vs. substring matching and immune to
+				// future body shape changes that happen to contain "format" elsewhere.
+				const isFormatRejection = (() => {
+					try {
+						const parsed = JSON.parse(consumedBody) as Record<string, unknown>;
+						const issues = Array.isArray(parsed.issues) ? parsed.issues : [];
+						return issues.some(
+							(i): boolean =>
+								typeof i === "object" &&
+								i !== null &&
+								Array.isArray((i as Record<string, unknown>).path) &&
+								((i as Record<string, unknown>).path as unknown[])[0] === "format",
+						);
+					} catch {
+						return false;
+					}
+				})();
+				if (isFormatRejection) {
 					if (structuredOutputSupported) {
 						logger.info("pipeline", "OpenCode does not support structured output format, disabling", {
 							status: res.status,

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -1900,10 +1900,12 @@ export function createOpenCodeProvider(config?: Partial<OpenCodeProviderConfig>)
 			let consumedBody: string | null = null;
 
 			// Older OpenCode versions may not support the format field.
-			// If we get a validation error, disable structured output and retry.
-			if (!res.ok && structuredOutputSupported && (res.status === 400 || res.status === 422)) {
+			// 422 is the Hono/Zod schema validation rejection for unknown fields.
+			// Only trigger on 422 to avoid false-positives from unrelated 400 errors
+			// (e.g. missing model, bad parts) that contain common words like "format".
+			if (!res.ok && structuredOutputSupported && res.status === 422) {
 				consumedBody = await res.text().catch(() => "");
-				if (consumedBody.includes("format") || consumedBody.includes("schema") || consumedBody.includes("validation")) {
+				if (consumedBody.includes('"format"')) {
 					logger.info("pipeline", "OpenCode does not support structured output format, disabling", {
 						status: res.status,
 					});

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -1910,7 +1910,9 @@ export function createOpenCodeProvider(config?: Partial<OpenCodeProviderConfig>)
 			// fall through to the throw path.
 			if (!res.ok && res.status === 422) {
 				consumedBody = await res.text().catch(() => "");
-				if (consumedBody.includes('"format"')) {
+				// Match Hono/Zod's path array notation: {"path":["format"],...}
+				// Avoids triggering on error messages that contain "format" as a value.
+				if (consumedBody.includes('["format"]')) {
 					if (structuredOutputSupported) {
 						logger.info("pipeline", "OpenCode does not support structured output format, disabling", {
 							status: res.status,

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -1901,15 +1901,19 @@ export function createOpenCodeProvider(config?: Partial<OpenCodeProviderConfig>)
 
 			// Older OpenCode versions may not support the format field.
 			// 422 is the Hono/Zod schema validation rejection for unknown fields.
-			// Only trigger on 422 to avoid false-positives from unrelated 400 errors
-			// (e.g. missing model, bad parts) that contain common words like "format".
-			if (!res.ok && structuredOutputSupported && res.status === 422) {
+			// Check status/body before reading structuredOutputSupported so that
+			// concurrent callers both hitting 422 both retry correctly — if A sets
+			// structuredOutputSupported=false first, B must still retry rather than
+			// fall through to the throw path.
+			if (!res.ok && res.status === 422) {
 				consumedBody = await res.text().catch(() => "");
 				if (consumedBody.includes('"format"')) {
-					logger.info("pipeline", "OpenCode does not support structured output format, disabling", {
-						status: res.status,
-					});
-					structuredOutputSupported = false;
+					if (structuredOutputSupported) {
+						logger.info("pipeline", "OpenCode does not support structured output format, disabling", {
+							status: res.status,
+						});
+						structuredOutputSupported = false;
+					}
 					sessionId = null;
 					consumedBody = null;
 					const retrySid = await getOrCreateSession();

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -1528,7 +1528,6 @@ const OPENCODE_JSON_SCHEMA: Record<string, unknown> = {
 	additionalProperties: true,
 };
 
-
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;
 }
@@ -1628,9 +1627,7 @@ function hasUsableOpenCodeText(data: OpenCodeMessageResponse): boolean {
  */
 function extractOpenCodeText(data: OpenCodeMessageResponse): string {
 	if (data.info.structured !== undefined) {
-		return typeof data.info.structured === "string"
-			? data.info.structured
-			: JSON.stringify(data.info.structured);
+		return typeof data.info.structured === "string" ? data.info.structured : JSON.stringify(data.info.structured);
 	}
 	const textParts: string[] = [];
 	for (const part of data.parts) {
@@ -1794,7 +1791,8 @@ export function createOpenCodeProvider(config?: Partial<OpenCodeProviderConfig>)
 			model: { providerID, modelID },
 		};
 		if (structured && structuredOutputSupported) {
-			body.system = "You are a structured data extraction system. Return ONLY valid JSON matching the requested schema. No explanations, no markdown, no code fences.";
+			body.system =
+				"You are a structured data extraction system. Return ONLY valid JSON matching the requested schema. No explanations, no markdown, no code fences.";
 			body.format = {
 				type: "json_schema",
 				schema: OPENCODE_JSON_SCHEMA,
@@ -1899,29 +1897,31 @@ export function createOpenCodeProvider(config?: Partial<OpenCodeProviderConfig>)
 			};
 
 			let res = await postMessage(sid);
+			let consumedBody: string | null = null;
 
 			// Older OpenCode versions may not support the format field.
 			// If we get a validation error, disable structured output and retry.
 			if (!res.ok && structuredOutputSupported && (res.status === 400 || res.status === 422)) {
-				const body = await res.text().catch(() => "");
-				if (body.includes("format") || body.includes("schema") || body.includes("validation")) {
+				consumedBody = await res.text().catch(() => "");
+				if (consumedBody.includes("format") || consumedBody.includes("schema") || consumedBody.includes("validation")) {
 					logger.info("pipeline", "OpenCode does not support structured output format, disabling", {
 						status: res.status,
 					});
 					structuredOutputSupported = false;
 					sessionId = null;
+					consumedBody = null;
 					const retrySid = await getOrCreateSession();
 					res = await fetch(`${cfg.baseUrl}/session/${retrySid}/message`, {
 						method: "POST",
 						headers: { "Content-Type": "application/json" },
-						body: buildMessageBody(prompt, true),
+						body: buildMessageBody(prompt, false),
 						signal: controller.signal,
 					});
 				}
 			}
 
 			if (!res.ok) {
-				const body = await res.text().catch(() => "");
+				const body = consumedBody ?? (await res.text().catch(() => ""));
 				// Session expired/invalid — reset and retry once
 				if (res.status === 404 || res.status === 410) {
 					sessionId = null;

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -1935,6 +1935,10 @@ export function createOpenCodeProvider(config?: Partial<OpenCodeProviderConfig>)
 					// each get their own session, preventing message ordering issues from
 					// two callers POSTing to the same session ID simultaneously.
 					const retrySid = await createSession();
+					// Known: concurrent callers both writing sessionId here is a benign
+					// last-writer-wins race — each caller uses its own retrySid local for
+					// the fetch below, so both retries are safe. The losing session is
+					// abandoned on the server (resource waste, not a correctness issue).
 					sessionId = retrySid;
 					res = await fetch(`${cfg.baseUrl}/session/${retrySid}/message`, {
 						method: "POST",

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -1507,6 +1507,7 @@ interface OpenCodeAssistantMessage {
 	readonly role?: string;
 	readonly cost?: number;
 	readonly tokens?: OpenCodeTokens;
+	readonly structured?: unknown;
 }
 
 interface OpenCodeMessageResponse {
@@ -1515,6 +1516,18 @@ interface OpenCodeMessageResponse {
 }
 
 const OPENCODE_EXTRACTION_FALLBACK = '{"facts":[],"entities":[]}';
+
+/**
+ * Permissive JSON schema for OpenCode's structured output.
+ * Accepts any JSON object — the pipeline's own validation handles
+ * schema enforcement. The value here is forcing the model to use
+ * OpenCode's StructuredOutput tool rather than free-text responding.
+ */
+const OPENCODE_JSON_SCHEMA: Record<string, unknown> = {
+	type: "object",
+	additionalProperties: true,
+};
+
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;
@@ -1557,6 +1570,7 @@ function parseOpenCodeMessageResponse(value: unknown): OpenCodeMessageResponse |
 		...(typeof infoRecord.role === "string" ? { role: infoRecord.role } : {}),
 		...(typeof infoRecord.cost === "number" ? { cost: infoRecord.cost } : {}),
 		...(parseOpenCodeTokens(infoRecord.tokens) ? { tokens: parseOpenCodeTokens(infoRecord.tokens) } : {}),
+		...(infoRecord.structured !== undefined ? { structured: infoRecord.structured } : {}),
 	};
 
 	return { info, parts };
@@ -1598,6 +1612,7 @@ function buildOpenCodeFallbackResponse(): OpenCodeMessageResponse {
 }
 
 function hasUsableOpenCodeText(data: OpenCodeMessageResponse): boolean {
+	if (data.info.structured !== undefined) return true;
 	for (const part of data.parts) {
 		if (part.type !== "text") continue;
 		if (typeof part.text !== "string") continue;
@@ -1608,10 +1623,15 @@ function hasUsableOpenCodeText(data: OpenCodeMessageResponse): boolean {
 
 /**
  * Extract assistant text from an OpenCode message response.
- * Response shape: `{ info: AssistantMessage, parts: Part[] }`
- * Text lives in parts where `type === "text"`.
+ * Prefers `info.structured` (set when json_schema format is used),
+ * falls back to concatenating `type === "text"` parts.
  */
 function extractOpenCodeText(data: OpenCodeMessageResponse): string {
+	if (data.info.structured !== undefined) {
+		return typeof data.info.structured === "string"
+			? data.info.structured
+			: JSON.stringify(data.info.structured);
+	}
 	const textParts: string[] = [];
 	for (const part of data.parts) {
 		if (part.type === "text" && typeof part.text === "string") {
@@ -1766,11 +1786,22 @@ export function createOpenCodeProvider(config?: Partial<OpenCodeProviderConfig>)
 		return id;
 	}
 
-	function buildMessageBody(prompt: string): string {
-		return JSON.stringify({
+	let structuredOutputSupported = true;
+
+	function buildMessageBody(prompt: string, structured?: boolean): string {
+		const body: Record<string, unknown> = {
 			parts: [{ type: "text", text: prompt }],
 			model: { providerID, modelID },
-		});
+		};
+		if (structured && structuredOutputSupported) {
+			body.system = "You are a structured data extraction system. Return ONLY valid JSON matching the requested schema. No explanations, no markdown, no code fences.";
+			body.format = {
+				type: "json_schema",
+				schema: OPENCODE_JSON_SCHEMA,
+				retryCount: 1,
+			};
+		}
+		return JSON.stringify(body);
 	}
 
 	async function sendMessage(
@@ -1788,7 +1819,7 @@ export function createOpenCodeProvider(config?: Partial<OpenCodeProviderConfig>)
 				fetch(`${cfg.baseUrl}/session/${sid}/message`, {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: buildMessageBody(prompt),
+					body: buildMessageBody(prompt, true),
 					signal: controller.signal,
 				});
 
@@ -1867,7 +1898,27 @@ export function createOpenCodeProvider(config?: Partial<OpenCodeProviderConfig>)
 				return pollForAssistantMessage(forSessionId);
 			};
 
-			const res = await postMessage(sid);
+			let res = await postMessage(sid);
+
+			// Older OpenCode versions may not support the format field.
+			// If we get a validation error, disable structured output and retry.
+			if (!res.ok && structuredOutputSupported && (res.status === 400 || res.status === 422)) {
+				const body = await res.text().catch(() => "");
+				if (body.includes("format") || body.includes("schema") || body.includes("validation")) {
+					logger.info("pipeline", "OpenCode does not support structured output format, disabling", {
+						status: res.status,
+					});
+					structuredOutputSupported = false;
+					sessionId = null;
+					const retrySid = await getOrCreateSession();
+					res = await fetch(`${cfg.baseUrl}/session/${retrySid}/message`, {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: buildMessageBody(prompt, true),
+						signal: controller.signal,
+					});
+				}
+			}
 
 			if (!res.ok) {
 				const body = await res.text().catch(() => "");

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -1758,9 +1758,7 @@ export function createOpenCodeProvider(config?: Partial<OpenCodeProviderConfig>)
 		}
 	}
 
-	async function getOrCreateSession(): Promise<string> {
-		if (sessionId) return sessionId;
-
+	async function createSession(): Promise<string> {
 		const res = await fetch(`${cfg.baseUrl}/session`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
@@ -1778,9 +1776,14 @@ export function createOpenCodeProvider(config?: Partial<OpenCodeProviderConfig>)
 		if (typeof id !== "string") {
 			throw new Error("OpenCode session response missing 'id' field");
 		}
-		sessionId = id;
 		logger.debug("pipeline", "OpenCode session created", { id });
 		return id;
+	}
+
+	async function getOrCreateSession(): Promise<string> {
+		if (sessionId) return sessionId;
+		sessionId = await createSession();
+		return sessionId;
 	}
 
 	let structuredOutputSupported = true;
@@ -1914,9 +1917,12 @@ export function createOpenCodeProvider(config?: Partial<OpenCodeProviderConfig>)
 						});
 						structuredOutputSupported = false;
 					}
-					sessionId = null;
 					consumedBody = null;
-					const retrySid = await getOrCreateSession();
+					// Use createSession() (not getOrCreateSession()) so concurrent callers
+					// each get their own session, preventing message ordering issues from
+					// two callers POSTing to the same session ID simultaneously.
+					const retrySid = await createSession();
+					sessionId = retrySid;
 					res = await fetch(`${cfg.baseUrl}/session/${retrySid}/message`, {
 						method: "POST",
 						headers: { "Content-Type": "application/json" },

--- a/packages/daemon/src/pipeline/skill-enrichment.ts
+++ b/packages/daemon/src/pipeline/skill-enrichment.ts
@@ -109,7 +109,8 @@ export async function enrichSkillFrontmatter(
 		if (!result) {
 			logger.warn("pipeline", "Failed to parse skill enrichment output", {
 				skill: input.name,
-				preview: raw.slice(0, 200),
+				preview: raw.slice(0, 500),
+			length: raw.length,
 			});
 			return null;
 		}

--- a/packages/daemon/src/pipeline/skill-enrichment.ts
+++ b/packages/daemon/src/pipeline/skill-enrichment.ts
@@ -110,7 +110,7 @@ export async function enrichSkillFrontmatter(
 			logger.warn("pipeline", "Failed to parse skill enrichment output", {
 				skill: input.name,
 				preview: raw.slice(0, 500),
-			length: raw.length,
+				length: raw.length,
 			});
 			return null;
 		}


### PR DESCRIPTION
## Summary

- Use OpenCode's native `json_schema` structured output format for all pipeline LLM requests, which forces models to use the `StructuredOutput` tool and returns parsed JSON in `info.structured`
- Add `github-copilot/gpt-4o`, `gpt-4o-mini`, `o3-mini`, `claude-sonnet-4` to the OpenCode model registry
- Improve parsing robustness: strip leading non-JSON text, better diagnostic logging

Fixes parsing failures reported by a user when using free Copilot models through OpenCode as the extraction/synthesis provider. The root cause was that weaker models don't reliably produce clean JSON in text output, but OpenCode already supports structured output with auto-retry, which we weren't using.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun test packages/daemon/src/pipeline/provider.test.ts` (53 tests pass, 4 new)
- [x] `bun test packages/daemon/src/pipeline/extraction.test.ts` (23 tests pass, 6 new)
- [x] `bun run build` succeeds
- [ ] Manual: configure `extraction.provider: opencode` with `model: github-copilot/gpt-4o`, verify extraction works and `info.structured` is used