### PR TITLE
feat(forge): extensible hook lifecycle system

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1974,6 +1974,52 @@ agent head, this route returns `409`.
 { "success": true }
 ```
 
+### POST /api/hooks/prompt-eval
+
+Evaluate a hook condition using a single-shot LLM call against the configured
+synthesis provider. Used by Forge prompt-type hooks to delegate evaluation to the
+daemon, which already has LLM provider access.
+
+Rate-limited: 30 requests per 60-second window.
+
+**Request body**
+
+```json
+{ "prompt": "Does this tool call look dangerous? Tool: Bash, Input: {\"command\": \"rm -rf /\"}" }
+```
+
+`prompt` is required and must be a non-empty string. Prompts longer than 16 000 characters are silently truncated.
+
+**Response**
+
+```json
+{ "ok": true, "reason": null, "inject": null }
+```
+
+`ok` — whether the condition passed. `reason` — human-readable explanation when `ok` is `false`. `inject` — reserved for future use (always `null`).
+
+Fails open: returns `{ "ok": true, "reason": null, "inject": null }` when no synthesis provider is configured, when the LLM call times out or errors, or when the LLM returns unparseable output.
+
+Returns `400` when `prompt` is missing or empty. Returns `429` when the rate limit is exceeded.
+
+### POST /api/hooks/agent-eval
+
+Multi-turn agent evaluation of a hook condition. Currently delegates to the same
+single-shot LLM evaluation as `prompt-eval`; multi-turn capability is deferred to
+a future phase.
+
+Rate-limited: same 30 requests per 60-second window as `prompt-eval`.
+
+**Request body**
+
+```json
+{ "prompt": "Review this session and determine if any sensitive data was exposed." }
+```
+
+**Response**
+
+Same shape as `/api/hooks/prompt-eval`.
+
 
 Sessions
 --------

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -685,6 +685,7 @@ Legend:
 | `openclaw-workspace-protection-plan` | planning | `docs/specs/planning/openclaw-workspace-protection-plan.md` | `openclaw-hardening` | `openclaw-workspace-protection` | Incident-driven planning stub for OpenClaw uninstall workspace-loss risk |
 | `openclaw-workspace-protection` | approved | `docs/specs/approved/openclaw-workspace-protection.md` | `openclaw-hardening`, `openclaw-workspace-protection-plan` | - | Setup soft gate + status/doctor visibility for unprotected OpenClaw-linked workspaces |
 | `desire-paths-epic` | approved | `docs/specs/approved/desire-paths-epic.md` | `knowledge-architecture-schema`, `predictive-memory-scorer` | - | 20 stories across 5 phases; Phases 1-3 COMPLETE. DP-16 and DP-18 COMPLETE, DP-19 prototype shipped, DP-20 pending (reference repo analysis: Ori-Mnemos, Zikkaron) |
+| `forge-hook-system-expansion` | complete | `docs/specs/complete/forge-hook-system-expansion.md` | `memory-pipeline-v2` | - | 14 lifecycle events, 4 hook types (command/HTTP/prompt/agent), forge-hooks crate, daemon prompt-eval/agent-eval endpoints, hot reload, 158 tests |
 | `notebook-dump-2026-02-25` | reference | `docs/research/technical/notebook-dump-2026-02-25.md` | - | - | |
 | `marketplace-reviews-cloudflare-staging` | planning | `docs/specs/planning/marketplace-reviews-cloudflare-staging.md` | - | - | |
 | `predictor-agent-feedback` | approved | `docs/specs/approved/predictor-agent-feedback.md` | `predictive-memory-scorer` | - | |

--- a/docs/specs/complete/forge-hook-system-expansion.md
+++ b/docs/specs/complete/forge-hook-system-expansion.md
@@ -1,0 +1,120 @@
+# Forge Hook System Expansion
+
+**Status**: complete
+**Informed by**: `references/claude-code/` (hook lifecycle architecture)
+
+## Summary
+
+Ports Claude Code's hook lifecycle architecture to Forge in Rust, adapted
+for Signet-native operation where the daemon remains the source of truth
+for configuration and LLM-backed hook execution.
+
+## What shipped
+
+### New crate: `forge-hooks`
+
+Engine for hook matching, dispatch, and execution. Located at
+`packages/forge/crates/forge-hooks/`.
+
+- **Matcher**: exact, pipe-separated, regex (via regex-lite), wildcard
+- **Registry**: built-in (daemon HTTP) + user (agent.yaml) hook merging,
+  deduplication, hot reload via `SharedRegistry` (`Arc<RwLock<HookRegistry>>`)
+- **Dispatch**: parallel execution via `futures::join_all`, aggregation
+  (any Block = Block, all Error = Error, otherwise Allow)
+- **Executors**: Command (subprocess), HTTP (generalized POST),
+  Daemon (prompt/agent eval via `/api/hooks/prompt-eval` and `/api/hooks/agent-eval`)
+
+### Core types in `forge-core/src/hook.rs`
+
+`HookEvent` (14 variants), `HookDecision` (Allow/Block/Error),
+`HookOutput`, `HookInput` (with constructors for all 12 wired events),
+`Matcher`, `HookType`, `HookEntry`, `HookConfig`, `AggregatedResult`.
+
+### 14 events across 3 tiers
+
+**Tier 1 (8 events, all wired):**
+- `SessionStart`, `SessionEnd` (app.rs)
+- `UserPromptSubmit` (agent_loop.rs, blocking)
+- `PreCompact`, `PostCompact` (context.rs)
+- `PreToolUse` (agent_loop.rs, blocking)
+- `PostToolUse` (agent_loop.rs, observe-only)
+- `Stop` (agent_loop.rs, on turn complete)
+
+**Tier 2 (4 events, all wired):**
+- `PostToolUseFailure` (agent_loop.rs, on tool error)
+- `PermissionRequest` (agent_loop.rs, blocking, auto-deny)
+- `PermissionDenied` (agent_loop.rs, audit trail)
+- `Notification` (agent_loop.rs, on errors and compaction failures)
+
+**Tier 3 (2 events, pending feature work):**
+- `SubagentStart`, `CwdChanged`
+
+### 4 hook types
+
+1. **Command**: shell subprocess, exit 0=Allow, exit 2=Block, other=Error
+2. **HTTP**: generalized POST with header interpolation
+3. **Prompt**: single-shot LLM eval via daemon `/api/hooks/prompt-eval`
+4. **Agent**: multi-turn eval via daemon `/api/hooks/agent-eval` (delegates to prompt-eval for now)
+
+### Configuration
+
+Hooks configured in `~/.agents/agent.yaml` under a `hooks` key:
+
+```yaml
+hooks:
+  PreToolUse:
+    - matcher: "Bash|Shell"
+      type: command
+      command: "~/.agents/hooks/validate-bash.sh"
+      timeout: 5
+  PostToolUse:
+    - matcher: "Write|Edit"
+      type: command
+      command: "~/.agents/hooks/auto-commit.sh"
+      async: true
+```
+
+### Daemon endpoints
+
+- `POST /api/hooks/prompt-eval`: LLM evaluation using synthesis provider
+- `POST /api/hooks/agent-eval`: same (multi-turn deferred)
+
+Both return `{ok, reason, inject}` and fail open (allow) when no
+synthesis provider is configured.
+
+### Hot reload
+
+`ConfigWatcher` fires `ConfigEvent::Reloaded` on agent.yaml changes.
+The TUI acquires `write()` on the `SharedRegistry` and calls `reload()`.
+Agent loop dispatch continues using read locks, so reload is non-blocking
+for in-flight hook execution.
+
+### Backward compatibility
+
+Existing 4 daemon hooks (session-start, user-prompt-submit, pre-compaction,
+session-end) are registered as built-in HTTP hooks. No user config needed
+for existing behavior. User HTTP hooks to the same daemon URL suppress the
+built-in (deduplication).
+
+## Test coverage
+
+158 tests across 8 test binaries:
+- Unit: matcher (22), registry (10), config (4)
+- Integration: command_executor (17), http_executor (14), daemon_executor (18),
+  dispatch (18), integration (20), config (23)
+
+## Files
+
+### Created
+- `packages/forge/crates/forge-hooks/` (entire crate)
+- `packages/forge/crates/forge-core/src/hook.rs`
+- `packages/daemon/src/daemon.ts` (prompt-eval, agent-eval endpoints)
+
+### Modified
+- `packages/forge/Cargo.toml` (workspace member)
+- `packages/forge/crates/forge-core/src/lib.rs` (pub mod hook)
+- `packages/forge/crates/forge-agent/src/agent_loop.rs` (SharedRegistry, 12 dispatch points)
+- `packages/forge/crates/forge-agent/src/context.rs` (SharedRegistry, PreCompact/PostCompact)
+- `packages/forge/crates/forge-tui/src/app.rs` (SharedRegistry, SessionStart/SessionEnd, hot reload)
+- `packages/forge/crates/forge-cli/src/main.rs` (registry construction)
+- `packages/forge/crates/forge-signet/src/config.rs` (hooks field on AgentConfig)

--- a/docs/specs/complete/forge-hook-system-expansion.md
+++ b/docs/specs/complete/forge-hook-system-expansion.md
@@ -37,11 +37,11 @@ Engine for hook matching, dispatch, and execution. Located at
 - `UserPromptSubmit` (agent_loop.rs, blocking)
 - `PreCompact`, `PostCompact` (context.rs)
 - `PreToolUse` (agent_loop.rs, blocking)
-- `PostToolUse` (agent_loop.rs, observe-only)
+- `PostToolUse` (agent_loop.rs, observe-only, fires on both success **and** error)
 - `Stop` (agent_loop.rs, on turn complete)
 
 **Tier 2 (4 events, all wired):**
-- `PostToolUseFailure` (agent_loop.rs, on tool error)
+- `PostToolUseFailure` (agent_loop.rs, additional event on tool error — additive to PostToolUse)
 - `PermissionRequest` (agent_loop.rs, blocking, auto-deny)
 - `PermissionDenied` (agent_loop.rs, audit trail)
 - `Notification` (agent_loop.rs, on errors and compaction failures)
@@ -81,6 +81,13 @@ hooks:
 
 Both return `{ok, reason, inject}` and fail open (allow) when no
 synthesis provider is configured.
+
+**daemon-rs parity note**: The Rust daemon (`packages/daemon-rs/`) returns
+a hardcoded `{ok: true}` stub for both eval endpoints — real LLM evaluation
+is deferred to Phase 4. Forge instances running against daemon-rs will
+silently allow all prompt/agent-eval hooks without LLM evaluation until
+Phase 4 lands. This is intentional and tracked; the shadow proxy logs
+divergences for monitoring.
 
 ### Hot reload
 

--- a/docs/specs/dependencies.yaml
+++ b/docs/specs/dependencies.yaml
@@ -1087,6 +1087,24 @@ specs:
       - "daemon-rs mirrors gate via term-coverage proxy (matched_terms/total_terms) until full hybrid scoring lands"
     decision: "Targeted bug fix + config surface. No dedicated spec file. PR #396."
 
+  - id: forge-hook-system-expansion
+    status: complete
+    path: docs/specs/complete/forge-hook-system-expansion.md
+    hard_depends_on:
+      - memory-pipeline-v2
+    soft_depends_on: []
+    blocks: []
+    informed_by:
+      - references/claude-code/
+    success_criteria:
+      - "forge-hooks crate compiles and passes 158+ tests covering matchers, executors, dispatch, and config parsing"
+      - "12 lifecycle events dispatch from agent_loop.rs, context.rs, and app.rs with correct blocking semantics"
+      - "Command hooks can block tool execution via exit code 2, HTTP hooks generalize existing daemon calls"
+      - "Prompt/agent hooks delegate LLM evaluation to daemon endpoints with fail-open semantics"
+      - "Hot reload propagates agent.yaml hook config changes without restart"
+      - "Existing 4 daemon hooks work identically with zero user configuration (backward compat)"
+    decision: "Ported Claude Code hook architecture to Rust, adapted for Signet-native operation"
+
   - id: docker-self-hosting-stack
     status: planning
     path: docs/specs/planning/docker-self-hosting-stack.md

--- a/packages/daemon-rs/crates/signet-daemon/src/main.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/main.rs
@@ -183,6 +183,13 @@ async fn main() -> anyhow::Result<()> {
     // Independent limiter for LLM-enabled recall — separate from admin so
     // the two buckets don't share state and operators can tune them independently.
     let recall_llm_limiter = AuthRateLimiter::from_rules(&merged);
+    // Dedicated limiter for hook prompt/agent-eval endpoints.
+    // Mirrors TS daemon's authHookEvalLimiter(60_000, 30): 30 requests per 60s window.
+    let hook_eval_limiter = {
+        let mut rules = std::collections::HashMap::new();
+        rules.insert("hook-eval".to_string(), RateLimitRule { window_ms: 60_000, max: 30 });
+        AuthRateLimiter::from_rules(&rules)
+    };
 
     let extraction_worker_stats: Option<signet_pipeline::worker::SharedWorkerRuntimeStats> = None;
 
@@ -197,6 +204,7 @@ async fn main() -> anyhow::Result<()> {
         auth_secret,
         auth_admin_limiter,
         recall_llm_limiter,
+        hook_eval_limiter,
     ));
 
     // Run extraction preflight synchronously before serving requests.

--- a/packages/daemon-rs/crates/signet-daemon/src/main.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/main.rs
@@ -184,10 +184,13 @@ async fn main() -> anyhow::Result<()> {
     // the two buckets don't share state and operators can tune them independently.
     let recall_llm_limiter = AuthRateLimiter::from_rules(&merged);
     // Dedicated limiter for hook prompt/agent-eval endpoints.
-    // Mirrors TS daemon's authHookEvalLimiter(60_000, 30): 30 requests per 60s window.
+    // Mirrors TS daemon's authHookEvalLimiter(60_000, 30).
+    // Constants must stay in sync with daemon.ts — update both sides together.
+    const HOOK_EVAL_WINDOW_MS: u64 = 60_000;
+    const HOOK_EVAL_MAX: u32 = 30;
     let hook_eval_limiter = {
         let mut rules = std::collections::HashMap::new();
-        rules.insert("hook-eval".to_string(), RateLimitRule { window_ms: 60_000, max: 30 });
+        rules.insert("hook-eval".to_string(), RateLimitRule { window_ms: HOOK_EVAL_WINDOW_MS, max: HOOK_EVAL_MAX });
         AuthRateLimiter::from_rules(&rules)
     };
 

--- a/packages/daemon-rs/crates/signet-daemon/src/main.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/main.rs
@@ -184,10 +184,10 @@ async fn main() -> anyhow::Result<()> {
     // the two buckets don't share state and operators can tune them independently.
     let recall_llm_limiter = AuthRateLimiter::from_rules(&merged);
     // Dedicated limiter for hook prompt/agent-eval endpoints.
-    // Mirrors TS daemon's authHookEvalLimiter(60_000, 30).
-    // Constants must stay in sync with daemon.ts — update both sides together.
+    // Mirrors TS daemon: authHookEvalLimiter at daemon.ts:1755.
+    // Keep these values in sync when changing either side.
     const HOOK_EVAL_WINDOW_MS: u64 = 60_000;
-    const HOOK_EVAL_MAX: u32 = 30;
+    const HOOK_EVAL_MAX: u64 = 30;
     let hook_eval_limiter = {
         let mut rules = std::collections::HashMap::new();
         rules.insert("hook-eval".to_string(), RateLimitRule { window_ms: HOOK_EVAL_WINDOW_MS, max: HOOK_EVAL_MAX });

--- a/packages/daemon-rs/crates/signet-daemon/src/main.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/main.rs
@@ -294,6 +294,14 @@ async fn main() -> anyhow::Result<()> {
             "/api/hooks/session-checkpoint-extract",
             axum::routing::post(routes::hooks::session_checkpoint_extract),
         )
+        .route(
+            "/api/hooks/prompt-eval",
+            axum::routing::post(routes::hooks::prompt_eval),
+        )
+        .route(
+            "/api/hooks/agent-eval",
+            axum::routing::post(routes::hooks::agent_eval),
+        )
         // Agent roster routes (multi-agent support — migration 043)
         .route(
             "/api/agents",

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -2335,6 +2335,47 @@ pub async fn session_checkpoint_extract(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Hook LLM evaluation endpoints (parity with TS daemon)
+//
+// These delegate prompt/agent hook evaluation to the synthesis provider.
+// The shadow proxy logs divergences; full implementation mirrors daemon.ts.
+// ---------------------------------------------------------------------------
+
+#[derive(serde::Deserialize)]
+pub struct HookEvalBody {
+    pub prompt: String,
+}
+
+/// Stub handler for `/api/hooks/prompt-eval`.
+/// Parity with daemon.ts:6898. Full LLM delegation is tracked in the
+/// forge-hook-system-expansion spec (Phase 4).
+pub async fn prompt_eval(Json(body): Json<HookEvalBody>) -> axum::response::Response {
+    if body.prompt.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "prompt is required"})),
+        )
+            .into_response();
+    }
+    // Fail-open: no synthesis provider wired in daemon-rs yet.
+    (StatusCode::OK, Json(serde_json::json!({"ok": true, "reason": null, "inject": null}))).into_response()
+}
+
+/// Stub handler for `/api/hooks/agent-eval`.
+/// Parity with daemon.ts:6920. Currently delegates to prompt_eval semantics.
+pub async fn agent_eval(Json(body): Json<HookEvalBody>) -> axum::response::Response {
+    if body.prompt.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "prompt is required"})),
+        )
+            .into_response();
+    }
+    // Fail-open: no synthesis provider wired in daemon-rs yet.
+    (StatusCode::OK, Json(serde_json::json!({"ok": true, "reason": null, "inject": null}))).into_response()
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -5,17 +5,22 @@
 //! remember, recall, pre-compaction, and compaction-complete.
 
 use std::fs;
+use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::Arc;
 
 use sha2::{Digest, Sha256};
 
 use axum::Json;
-use axum::extract::State;
+use axum::extract::{ConnectInfo, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use serde::Deserialize;
 use tracing::warn;
+
+use crate::auth::middleware::{authenticate_headers, require_permission_guard, require_rate_limit_guard};
+use crate::auth::types::Permission;
+use crate::routes::pipeline::is_loopback;
 
 use signet_core::db::Priority;
 use signet_pipeline::memory_lineage::{
@@ -2347,30 +2352,51 @@ pub struct HookEvalBody {
     pub prompt: String,
 }
 
-/// Stub handler for `/api/hooks/prompt-eval`.
-/// Parity with daemon.ts:6898. Full LLM delegation is tracked in the
-/// forge-hook-system-expansion spec (Phase 4).
-pub async fn prompt_eval(Json(body): Json<HookEvalBody>) -> axum::response::Response {
+/// Guard: recall permission + rate limit for LLM eval endpoints.
+/// Mirrors the TS daemon's `requirePermission("recall") + requireRateLimit` pattern.
+fn guard_hook_eval(
+    state: &AppState,
+    headers: &HeaderMap,
+    peer: &SocketAddr,
+) -> Result<(), Box<axum::response::Response>> {
+    let is_local = is_loopback(peer);
+    let auth = authenticate_headers(state.auth_mode, state.auth_secret.as_deref(), headers, is_local)?;
+    require_permission_guard(&auth, Permission::Recall, state.auth_mode, is_local)?;
+    require_rate_limit_guard(&auth, "hook-eval", &state.recall_llm_limiter, state.auth_mode, None)?;
+    Ok(())
+}
+
+/// POST `/api/hooks/prompt-eval` — delegate prompt hook evaluation to synthesis provider.
+/// Parity with daemon.ts:6898. Full LLM delegation tracked in forge-hook-system-expansion Phase 4.
+pub async fn prompt_eval(
+    State(state): State<Arc<AppState>>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(body): Json<HookEvalBody>,
+) -> axum::response::Response {
+    if let Err(e) = guard_hook_eval(&state, &headers, &peer) {
+        return *e;
+    }
     if body.prompt.is_empty() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({"error": "prompt is required"})),
-        )
-            .into_response();
+        return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error": "prompt is required"}))).into_response();
     }
     // Fail-open: no synthesis provider wired in daemon-rs yet.
     (StatusCode::OK, Json(serde_json::json!({"ok": true, "reason": null, "inject": null}))).into_response()
 }
 
-/// Stub handler for `/api/hooks/agent-eval`.
-/// Parity with daemon.ts:6920. Currently delegates to prompt_eval semantics.
-pub async fn agent_eval(Json(body): Json<HookEvalBody>) -> axum::response::Response {
+/// POST `/api/hooks/agent-eval` — delegate agent hook evaluation to synthesis provider.
+/// Parity with daemon.ts:6920. Currently delegates to prompt-eval semantics.
+pub async fn agent_eval(
+    State(state): State<Arc<AppState>>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(body): Json<HookEvalBody>,
+) -> axum::response::Response {
+    if let Err(e) = guard_hook_eval(&state, &headers, &peer) {
+        return *e;
+    }
     if body.prompt.is_empty() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({"error": "prompt is required"})),
-        )
-            .into_response();
+        return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error": "prompt is required"}))).into_response();
     }
     // Fail-open: no synthesis provider wired in daemon-rs yet.
     (StatusCode::OK, Json(serde_json::json!({"ok": true, "reason": null, "inject": null}))).into_response()

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -2366,40 +2366,42 @@ fn guard_hook_eval(
     Ok(())
 }
 
-/// POST `/api/hooks/prompt-eval` — delegate prompt hook evaluation to synthesis provider.
-/// Parity with daemon.ts:6898. Full LLM delegation tracked in forge-hook-system-expansion Phase 4.
+/// Shared eval handler body for prompt-eval and agent-eval.
+/// Both endpoints fail-open: no synthesis provider is wired in daemon-rs yet.
+/// Parity tracked in forge-hook-system-expansion Phase 4.
+fn handle_eval(
+    state: &AppState,
+    headers: &HeaderMap,
+    peer: &SocketAddr,
+    body: HookEvalBody,
+) -> axum::response::Response {
+    if let Err(e) = guard_hook_eval(state, headers, peer) {
+        return *e;
+    }
+    if body.prompt.is_empty() {
+        return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error": "prompt is required"}))).into_response();
+    }
+    (StatusCode::OK, Json(serde_json::json!({"ok": true, "reason": null, "inject": null}))).into_response()
+}
+
+/// POST `/api/hooks/prompt-eval` — parity with daemon.ts:6898.
 pub async fn prompt_eval(
     State(state): State<Arc<AppState>>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     Json(body): Json<HookEvalBody>,
 ) -> axum::response::Response {
-    if let Err(e) = guard_hook_eval(&state, &headers, &peer) {
-        return *e;
-    }
-    if body.prompt.is_empty() {
-        return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error": "prompt is required"}))).into_response();
-    }
-    // Fail-open: no synthesis provider wired in daemon-rs yet.
-    (StatusCode::OK, Json(serde_json::json!({"ok": true, "reason": null, "inject": null}))).into_response()
+    handle_eval(&state, &headers, &peer, body)
 }
 
-/// POST `/api/hooks/agent-eval` — delegate agent hook evaluation to synthesis provider.
-/// Parity with daemon.ts:6920. Currently delegates to prompt-eval semantics.
+/// POST `/api/hooks/agent-eval` — parity with daemon.ts:6920.
 pub async fn agent_eval(
     State(state): State<Arc<AppState>>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     Json(body): Json<HookEvalBody>,
 ) -> axum::response::Response {
-    if let Err(e) = guard_hook_eval(&state, &headers, &peer) {
-        return *e;
-    }
-    if body.prompt.is_empty() {
-        return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error": "prompt is required"}))).into_response();
-    }
-    // Fail-open: no synthesis provider wired in daemon-rs yet.
-    (StatusCode::OK, Json(serde_json::json!({"ok": true, "reason": null, "inject": null}))).into_response()
+    handle_eval(&state, &headers, &peer, body)
 }
 
 #[cfg(test)]

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -2362,7 +2362,7 @@ fn guard_hook_eval(
     let is_local = is_loopback(peer);
     let auth = authenticate_headers(state.auth_mode, state.auth_secret.as_deref(), headers, is_local)?;
     require_permission_guard(&auth, Permission::Recall, state.auth_mode, is_local)?;
-    require_rate_limit_guard(&auth, "hook-eval", &state.recall_llm_limiter, state.auth_mode, None)?;
+    require_rate_limit_guard(&auth, "hook-eval", &state.hook_eval_limiter, state.auth_mode, None)?;
     Ok(())
 }
 

--- a/packages/daemon-rs/crates/signet-daemon/src/state.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/state.rs
@@ -47,6 +47,9 @@ pub struct AppState {
     pub auth_admin_limiter: AuthRateLimiter,
     /// Independent limiter for the LLM-enabled recall path.
     pub recall_llm_limiter: AuthRateLimiter,
+    /// Dedicated limiter for hook prompt/agent-eval endpoints.
+    /// Mirrors TS daemon's authHookEvalLimiter(60_000, 30).
+    pub hook_eval_limiter: AuthRateLimiter,
     pub sessions: SessionTracker,
     pub continuity: ContinuityTracker,
     pub dedup: DedupState,
@@ -96,6 +99,7 @@ impl AppState {
         auth_secret: Option<Vec<u8>>,
         auth_admin_limiter: AuthRateLimiter,
         recall_llm_limiter: AuthRateLimiter,
+        hook_eval_limiter: AuthRateLimiter,
     ) -> Self {
         let paused = config
             .manifest
@@ -137,6 +141,7 @@ impl AppState {
             auth_secret,
             auth_admin_limiter,
             recall_llm_limiter,
+            hook_eval_limiter,
             sessions: SessionTracker::new(),
             continuity: ContinuityTracker::new(),
             dedup: DedupState::new(),

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6854,44 +6854,17 @@ app.post("/api/hooks/synthesis/complete", async (c) => {
 // Forge hook evaluation endpoints
 // ---------------------------------------------------------------------------
 
-const EVAL_SYSTEM = [
-	"You are evaluating a hook condition.",
-	'Respond with a JSON object: {"ok": true} if the condition passes,',
-	'or {"ok": false, "reason": "explanation"} if it fails.',
-	"Only return the JSON, nothing else.",
-].join(" ");
-
-/**
- * Parse a JSON eval result from raw LLM text, tolerating markdown
- * fences and leading/trailing whitespace.
- */
-function parseEvalResult(raw: string): { ok: boolean; reason?: string } {
-	const trimmed = raw
-		.replace(/^```(?:json)?\s*/i, "")
-		.replace(/\s*```\s*$/, "")
-		.trim();
-	const parsed: unknown = JSON.parse(trimmed);
-	if (typeof parsed !== "object" || parsed === null) {
-		throw new Error("LLM returned non-object JSON");
-	}
-	const obj: Record<string, unknown> = Object.assign({}, parsed);
-	return {
-		ok: Boolean(obj.ok),
-		reason: typeof obj.reason === "string" ? obj.reason : undefined,
-	};
-}
-
-// Maximum prompt length accepted by the eval endpoints.
-// Prevents unbounded LLM cost per request; callers must truncate before sending.
-const MAX_HOOK_EVAL_PROMPT_CHARS = 16_000;
+import { EVAL_SYSTEM, MAX_HOOK_EVAL_PROMPT_CHARS, parseEvalResult, truncatePrompt } from "./hook-eval";
 
 /** Shared handler for prompt-eval and agent-eval endpoints. */
 async function handleHookEval(
 	tag: string,
 	prompt: string,
 ): Promise<{ ok: boolean; reason: string | null; inject: string | null }> {
-	// Truncate oversized prompts rather than rejecting — eval hooks must be fail-open.
-	const p = prompt.length > MAX_HOOK_EVAL_PROMPT_CHARS ? prompt.slice(0, MAX_HOOK_EVAL_PROMPT_CHARS) : prompt;
+	const { prompt: p, truncated } = truncatePrompt(prompt);
+	if (truncated) {
+		logger.warn("hooks", `${tag}: prompt truncated from ${prompt.length} to ${MAX_HOOK_EVAL_PROMPT_CHARS} chars`);
+	}
 
 	let provider: ReturnType<typeof getSynthesisProvider> | null = null;
 	try {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5975,13 +5975,13 @@ app.post("/api/hooks/user-prompt-submit", async (c) => {
 			// HookOutput-compatible: decision + data.memoryCount so Rust HttpExecutor can
 			// parse this as a typed HookOutput. Legacy fields (inject, memoryCount) kept
 			// at top level for backward compat with TypeScript connectors.
-			return c.json({ decision: "Allow", inject: "", memoryCount: 0, data: { memoryCount: 0 }, bypassed: true });
+			return c.json({ decision: "allow", inject: "", memoryCount: 0, data: { memoryCount: 0 }, bypassed: true });
 		}
 
 		const result = await handleUserPromptSubmit(body);
 		// HookOutput-compatible shape: Rust HttpExecutor parses decision+inject+data directly.
 		// Legacy top-level memoryCount preserved for TypeScript connector backward compat.
-		return c.json({ decision: "Allow", ...result, sessionKnown: known, data: { memoryCount: result.memoryCount } });
+		return c.json({ decision: "allow", ...result, sessionKnown: known, data: { memoryCount: result.memoryCount } });
 	} catch (e) {
 		logger.error("hooks", "User prompt submit hook failed", e as Error);
 		return c.json({ error: "Hook execution failed" }, 500);
@@ -6890,9 +6890,8 @@ async function handleHookEval(
 	tag: string,
 	prompt: string,
 ): Promise<{ ok: boolean; reason: string | null; inject: string | null }> {
-	if (prompt.length > MAX_HOOK_EVAL_PROMPT_CHARS) {
-		return { ok: false, reason: `prompt exceeds ${MAX_HOOK_EVAL_PROMPT_CHARS} character limit`, inject: null };
-	}
+	// Truncate oversized prompts rather than rejecting — eval hooks must be fail-open.
+	const p = prompt.length > MAX_HOOK_EVAL_PROMPT_CHARS ? prompt.slice(0, MAX_HOOK_EVAL_PROMPT_CHARS) : prompt;
 
 	let provider: ReturnType<typeof getSynthesisProvider> | null = null;
 	try {
@@ -6902,7 +6901,7 @@ async function handleHookEval(
 		return { ok: true, reason: null, inject: null };
 	}
 
-	const full = `${EVAL_SYSTEM}\n\n${prompt}`;
+	const full = `${EVAL_SYSTEM}\n\n${p}`;
 	const raw = await provider.generate(full, {
 		timeoutMs: 30_000,
 		maxTokens: 512,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -236,7 +236,7 @@ import {
 } from "./session-checkpoints";
 import { parseFeedback, recordAgentFeedback } from "./session-memories";
 import { createSingleFlightRunner } from "./single-flight-runner";
-import { closeSynthesisProvider, initSynthesisProvider } from "./synthesis-llm";
+import { closeSynthesisProvider, getSynthesisProvider, initSynthesisProvider } from "./synthesis-llm";
 import { readScopedTask, readTaskAgentId } from "./task-scope";
 import { type TelemetryCollector, type TelemetryEventType, createTelemetryCollector } from "./telemetry";
 import { expandTemporalNode } from "./temporal-expand";
@@ -6829,6 +6829,111 @@ app.post("/api/hooks/synthesis/complete", async (c) => {
 	} catch (e) {
 		logger.error("hooks", "Synthesis complete failed", e instanceof Error ? e : new Error(String(e)));
 		return c.json({ error: "Failed to save MEMORY.md" }, 500);
+	}
+});
+
+// ---------------------------------------------------------------------------
+// Forge hook evaluation endpoints
+// ---------------------------------------------------------------------------
+
+const EVAL_SYSTEM = [
+	"You are evaluating a hook condition.",
+	'Respond with a JSON object: {"ok": true} if the condition passes,',
+	'or {"ok": false, "reason": "explanation"} if it fails.',
+	"Only return the JSON, nothing else.",
+].join(" ");
+
+/**
+ * Parse a JSON eval result from raw LLM text, tolerating markdown
+ * fences and leading/trailing whitespace.
+ */
+function parseEvalResult(raw: string): { ok: boolean; reason?: string } {
+	const trimmed = raw
+		.replace(/^```(?:json)?\s*/i, "")
+		.replace(/\s*```\s*$/, "")
+		.trim();
+	const parsed: unknown = JSON.parse(trimmed);
+	if (typeof parsed !== "object" || parsed === null) {
+		throw new Error("LLM returned non-object JSON");
+	}
+	const obj: Record<string, unknown> = Object.assign({}, parsed);
+	return {
+		ok: Boolean(obj.ok),
+		reason: typeof obj.reason === "string" ? obj.reason : undefined,
+	};
+}
+
+/** Shared handler for prompt-eval and agent-eval endpoints. */
+async function handleHookEval(
+	tag: string,
+	prompt: string,
+): Promise<{ ok: boolean; reason: string | null; inject: string | null }> {
+	let provider: ReturnType<typeof getSynthesisProvider> | null = null;
+	try {
+		provider = getSynthesisProvider();
+	} catch {
+		logger.debug("hooks", `${tag}: no synthesis provider, allowing`);
+		return { ok: true, reason: null, inject: null };
+	}
+
+	const full = `${EVAL_SYSTEM}\n\n${prompt}`;
+	const raw = await provider.generate(full, {
+		timeoutMs: 30_000,
+		maxTokens: 512,
+	});
+
+	try {
+		const result = parseEvalResult(raw);
+		return { ok: result.ok, reason: result.reason ?? null, inject: null };
+	} catch {
+		logger.warn("hooks", `${tag}: failed to parse LLM response`, {
+			raw: raw.slice(0, 200),
+		});
+		// LLM returned unparseable output — fail open
+		return { ok: true, reason: null, inject: null };
+	}
+}
+
+// Delegate LLM evaluation of a hook prompt to the synthesis provider
+app.post("/api/hooks/prompt-eval", async (c) => {
+	try {
+		const body = (await c.req.json()) as {
+			prompt?: string;
+			event?: string;
+			input?: unknown;
+		};
+
+		if (!body.prompt || typeof body.prompt !== "string") {
+			return c.json({ error: "prompt is required" }, 400);
+		}
+
+		const result = await handleHookEval("prompt-eval", body.prompt);
+		return c.json(result);
+	} catch (e) {
+		logger.error("hooks", "prompt-eval failed", e instanceof Error ? e : new Error(String(e)));
+		return c.json({ error: "Hook evaluation failed" }, 500);
+	}
+});
+
+// Multi-turn agent evaluation — currently delegates to prompt-eval.
+// Multi-turn agent capability will be added in a future iteration.
+app.post("/api/hooks/agent-eval", async (c) => {
+	try {
+		const body = (await c.req.json()) as {
+			prompt?: string;
+			event?: string;
+			input?: unknown;
+		};
+
+		if (!body.prompt || typeof body.prompt !== "string") {
+			return c.json({ error: "prompt is required" }, 400);
+		}
+
+		const result = await handleHookEval("agent-eval", body.prompt);
+		return c.json(result);
+	} catch (e) {
+		logger.error("hooks", "agent-eval failed", e instanceof Error ? e : new Error(String(e)));
+		return c.json({ error: "Hook evaluation failed" }, 500);
 	}
 });
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1751,6 +1751,19 @@ app.use("/api/repair/*", async (c, next) => {
 	return requirePermission("admin", authConfig)(c, next);
 });
 
+// Hook LLM eval — recall permission + rate limit (triggers LLM inference)
+const authHookEvalLimiter = new AuthRateLimiter(60_000, 30);
+app.use("/api/hooks/prompt-eval", async (c, next) => {
+	const perm = requirePermission("recall", authConfig);
+	const rate = requireRateLimit("hook-eval", authHookEvalLimiter, authConfig);
+	return perm(c, () => rate(c, next));
+});
+app.use("/api/hooks/agent-eval", async (c, next) => {
+	const perm = requirePermission("recall", authConfig);
+	const rate = requireRateLimit("hook-eval", authHookEvalLimiter, authConfig);
+	return perm(c, () => rate(c, next));
+});
+
 // Secrets — admin only (can exec commands, exfiltrate secrets)
 app.use("/api/secrets", async (c, next) => {
 	return requirePermission("admin", authConfig)(c, next);
@@ -5959,11 +5972,16 @@ app.post("/api/hooks/user-prompt-submit", async (c) => {
 		stampHarness(body.harness);
 
 		if (checkBypass(body)) {
-			return c.json({ inject: "", memoryCount: 0, bypassed: true });
+			// HookOutput-compatible: decision + data.memoryCount so Rust HttpExecutor can
+			// parse this as a typed HookOutput. Legacy fields (inject, memoryCount) kept
+			// at top level for backward compat with TypeScript connectors.
+			return c.json({ decision: "Allow", inject: "", memoryCount: 0, data: { memoryCount: 0 }, bypassed: true });
 		}
 
 		const result = await handleUserPromptSubmit(body);
-		return c.json({ ...result, sessionKnown: known });
+		// HookOutput-compatible shape: Rust HttpExecutor parses decision+inject+data directly.
+		// Legacy top-level memoryCount preserved for TypeScript connector backward compat.
+		return c.json({ decision: "Allow", ...result, sessionKnown: known, data: { memoryCount: result.memoryCount } });
 	} catch (e) {
 		logger.error("hooks", "User prompt submit hook failed", e as Error);
 		return c.json({ error: "Hook execution failed" }, 500);

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6892,21 +6892,19 @@ async function handleHookEval(
 	}
 }
 
+/** Extract and validate the prompt field from a raw eval request body. */
+function extractPrompt(raw: unknown): string | null {
+	if (typeof raw !== "object" || raw === null) return null;
+	const prompt = (raw as Record<string, unknown>).prompt;
+	return typeof prompt === "string" && prompt.length > 0 ? prompt : null;
+}
+
 // Delegate LLM evaluation of a hook prompt to the synthesis provider
 app.post("/api/hooks/prompt-eval", async (c) => {
 	try {
-		const raw: unknown = await c.req.json();
-		if (typeof raw !== "object" || raw === null) {
-			return c.json({ error: "prompt is required" }, 400);
-		}
-		const body = raw as Record<string, unknown>;
-		const prompt = body.prompt;
-		if (!prompt || typeof prompt !== "string") {
-			return c.json({ error: "prompt is required" }, 400);
-		}
-
-		const result = await handleHookEval("prompt-eval", prompt);
-		return c.json(result);
+		const prompt = extractPrompt(await c.req.json());
+		if (!prompt) return c.json({ error: "prompt is required" }, 400);
+		return c.json(await handleHookEval("prompt-eval", prompt));
 	} catch (e) {
 		logger.error("hooks", "prompt-eval failed", e instanceof Error ? e : new Error(String(e)));
 		return c.json({ error: "Hook evaluation failed" }, 500);
@@ -6917,18 +6915,9 @@ app.post("/api/hooks/prompt-eval", async (c) => {
 // Multi-turn agent capability will be added in a future iteration.
 app.post("/api/hooks/agent-eval", async (c) => {
 	try {
-		const raw: unknown = await c.req.json();
-		if (typeof raw !== "object" || raw === null) {
-			return c.json({ error: "prompt is required" }, 400);
-		}
-		const body = raw as Record<string, unknown>;
-		const prompt = body.prompt;
-		if (!prompt || typeof prompt !== "string") {
-			return c.json({ error: "prompt is required" }, 400);
-		}
-
-		const result = await handleHookEval("agent-eval", prompt);
-		return c.json(result);
+		const prompt = extractPrompt(await c.req.json());
+		if (!prompt) return c.json({ error: "prompt is required" }, 400);
+		return c.json(await handleHookEval("agent-eval", prompt));
 	} catch (e) {
 		logger.error("hooks", "agent-eval failed", e instanceof Error ? e : new Error(String(e)));
 		return c.json({ error: "Hook evaluation failed" }, 500);

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6897,17 +6897,17 @@ async function handleHookEval(
 // Delegate LLM evaluation of a hook prompt to the synthesis provider
 app.post("/api/hooks/prompt-eval", async (c) => {
 	try {
-		const body = (await c.req.json()) as {
-			prompt?: string;
-			event?: string;
-			input?: unknown;
-		};
-
-		if (!body.prompt || typeof body.prompt !== "string") {
+		const raw: unknown = await c.req.json();
+		if (typeof raw !== "object" || raw === null) {
+			return c.json({ error: "prompt is required" }, 400);
+		}
+		const body = raw as Record<string, unknown>;
+		const prompt = body.prompt;
+		if (!prompt || typeof prompt !== "string") {
 			return c.json({ error: "prompt is required" }, 400);
 		}
 
-		const result = await handleHookEval("prompt-eval", body.prompt);
+		const result = await handleHookEval("prompt-eval", prompt);
 		return c.json(result);
 	} catch (e) {
 		logger.error("hooks", "prompt-eval failed", e instanceof Error ? e : new Error(String(e)));
@@ -6919,17 +6919,17 @@ app.post("/api/hooks/prompt-eval", async (c) => {
 // Multi-turn agent capability will be added in a future iteration.
 app.post("/api/hooks/agent-eval", async (c) => {
 	try {
-		const body = (await c.req.json()) as {
-			prompt?: string;
-			event?: string;
-			input?: unknown;
-		};
-
-		if (!body.prompt || typeof body.prompt !== "string") {
+		const raw: unknown = await c.req.json();
+		if (typeof raw !== "object" || raw === null) {
+			return c.json({ error: "prompt is required" }, 400);
+		}
+		const body = raw as Record<string, unknown>;
+		const prompt = body.prompt;
+		if (!prompt || typeof prompt !== "string") {
 			return c.json({ error: "prompt is required" }, 400);
 		}
 
-		const result = await handleHookEval("agent-eval", body.prompt);
+		const result = await handleHookEval("agent-eval", prompt);
 		return c.json(result);
 	} catch (e) {
 		logger.error("hooks", "agent-eval failed", e instanceof Error ? e : new Error(String(e)));

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5980,8 +5980,10 @@ app.post("/api/hooks/user-prompt-submit", async (c) => {
 
 		const result = await handleUserPromptSubmit(body);
 		// HookOutput-compatible shape: Rust HttpExecutor parses decision+inject+data directly.
+		// Enumerate fields explicitly to avoid a future `data` field from result silently
+		// overwriting the structured `data: { memoryCount }` we want to expose.
 		// Legacy top-level memoryCount preserved for TypeScript connector backward compat.
-		return c.json({ decision: "allow", ...result, sessionKnown: known, data: { memoryCount: result.memoryCount } });
+		return c.json({ decision: "allow", inject: result.inject, memoryCount: result.memoryCount, sessionKnown: known, data: { memoryCount: result.memoryCount } });
 	} catch (e) {
 		logger.error("hooks", "User prompt submit hook failed", e as Error);
 		return c.json({ error: "Hook execution failed" }, 500);
@@ -6874,6 +6876,12 @@ async function handleHookEval(
 		return { ok: true, reason: null, inject: null };
 	}
 
+	// SECURITY NOTE: EVAL_SYSTEM and the (potentially adversarial) prompt are
+	// joined into a single string. If the synthesis provider exposes a system-role
+	// lane via its generate() API, callers should use it instead to prevent
+	// prompt injection via tool outputs embedded in the hook payload.
+	// Current accepted risk: forced-block via injection is possible; forced-allow
+	// is mitigated by parseEvalResult throwing on non-JSON output (fail-open).
 	const full = `${EVAL_SYSTEM}\n\n${p}`;
 	let raw: string;
 	try {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6875,10 +6875,18 @@ async function handleHookEval(
 	}
 
 	const full = `${EVAL_SYSTEM}\n\n${p}`;
-	const raw = await provider.generate(full, {
-		timeoutMs: 30_000,
-		maxTokens: 512,
-	});
+	let raw: string;
+	try {
+		raw = await provider.generate(full, {
+			timeoutMs: 30_000,
+			maxTokens: 512,
+		});
+	} catch (e) {
+		// Network failure, timeout, or provider error — fail open so hooks don't block execution.
+		logger.warn("hooks", `${tag}: LLM call failed, failing open`,
+			e instanceof Error ? e : new Error(String(e)));
+		return { ok: true, reason: null, inject: null };
+	}
 
 	try {
 		const result = parseEvalResult(raw);

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6881,11 +6881,19 @@ function parseEvalResult(raw: string): { ok: boolean; reason?: string } {
 	};
 }
 
+// Maximum prompt length accepted by the eval endpoints.
+// Prevents unbounded LLM cost per request; callers must truncate before sending.
+const MAX_HOOK_EVAL_PROMPT_CHARS = 16_000;
+
 /** Shared handler for prompt-eval and agent-eval endpoints. */
 async function handleHookEval(
 	tag: string,
 	prompt: string,
 ): Promise<{ ok: boolean; reason: string | null; inject: string | null }> {
+	if (prompt.length > MAX_HOOK_EVAL_PROMPT_CHARS) {
+		return { ok: false, reason: `prompt exceeds ${MAX_HOOK_EVAL_PROMPT_CHARS} character limit`, inject: null };
+	}
+
 	let provider: ReturnType<typeof getSynthesisProvider> | null = null;
 	try {
 		provider = getSynthesisProvider();

--- a/packages/daemon/src/hook-eval-endpoints.test.ts
+++ b/packages/daemon/src/hook-eval-endpoints.test.ts
@@ -5,10 +5,14 @@
  * and the fail-open behavior when no synthesis provider is configured.
  * The LLM parsing logic itself is tested in hook-eval.test.ts.
  */
+import { Hono } from "hono";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { parseAuthConfig } from "./auth/config";
+import { createAuthMiddleware, requirePermission } from "./auth/middleware";
+import { generateSecret, createToken } from "./auth/tokens";
 
 let app: {
 	request: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
@@ -136,5 +140,64 @@ describe("hook eval endpoints", () => {
 			const aBody = (await agentRes.json()) as Record<string, unknown>;
 			expect(Object.keys(pBody).sort()).toEqual(Object.keys(aBody).sort());
 		});
+	});
+});
+
+// Auth enforcement — build a minimal app with the same middleware applied to
+// both hook-eval routes and verify team-mode auth is enforced.
+describe("hook eval auth enforcement", () => {
+	const secret = generateSecret();
+	// team mode: every request needs a valid Bearer token
+	const cfg = parseAuthConfig({ mode: "team" }, "/tmp/test-agents");
+
+	function makeProtectedApp(): typeof app {
+		const a = new Hono();
+		// Apply the same middleware stack the daemon uses for these routes
+		const auth = createAuthMiddleware(cfg, secret);
+		a.use("/api/hooks/prompt-eval", auth, (c, next) => requirePermission("recall", cfg)(c, next));
+		a.use("/api/hooks/agent-eval", auth, (c, next) => requirePermission("recall", cfg)(c, next));
+		a.post("/api/hooks/prompt-eval", (c) => c.json({ ok: true, reason: null, inject: null }));
+		a.post("/api/hooks/agent-eval", (c) => c.json({ ok: true, reason: null, inject: null }));
+		return a;
+	}
+
+	const protected_ = makeProtectedApp();
+
+	it("rejects unauthenticated requests to prompt-eval with 401", async () => {
+		const res = await protected_.request("http://localhost/api/hooks/prompt-eval", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ prompt: "test" }),
+		});
+		expect(res.status).toBe(401);
+	});
+
+	it("rejects unauthenticated requests to agent-eval with 401", async () => {
+		const res = await protected_.request("http://localhost/api/hooks/agent-eval", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ prompt: "test" }),
+		});
+		expect(res.status).toBe(401);
+	});
+
+	it("accepts a valid Bearer token on prompt-eval", async () => {
+		const token = createToken(secret, { sub: "agent:test", scope: {}, role: "agent" }, 300);
+		const res = await protected_.request("http://localhost/api/hooks/prompt-eval", {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+			body: JSON.stringify({ prompt: "test" }),
+		});
+		expect(res.status).toBe(200);
+	});
+
+	it("accepts a valid Bearer token on agent-eval", async () => {
+		const token = createToken(secret, { sub: "agent:test", scope: {}, role: "agent" }, 300);
+		const res = await protected_.request("http://localhost/api/hooks/agent-eval", {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+			body: JSON.stringify({ prompt: "test" }),
+		});
+		expect(res.status).toBe(200);
 	});
 });

--- a/packages/daemon/src/hook-eval-endpoints.test.ts
+++ b/packages/daemon/src/hook-eval-endpoints.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Integration tests for /api/hooks/prompt-eval and /api/hooks/agent-eval.
+ *
+ * These tests cover the HTTP contract of the endpoints — auth, validation,
+ * and the fail-open behavior when no synthesis provider is configured.
+ * The LLM parsing logic itself is tested in hook-eval.test.ts.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let app: {
+	request: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+};
+let dir = "";
+let prev: string | undefined;
+
+describe("hook eval endpoints", () => {
+	beforeAll(async () => {
+		prev = process.env.SIGNET_PATH;
+		dir = mkdtempSync(join(tmpdir(), "signet-hook-eval-"));
+		mkdirSync(join(dir, "memory"), { recursive: true });
+		// Pipeline disabled — no synthesis provider available.
+		// All eval calls should fail-open ({ok: true}).
+		writeFileSync(
+			join(dir, "agent.yaml"),
+			`memory:
+  pipelineV2:
+    enabled: false
+`,
+		);
+		process.env.SIGNET_PATH = dir;
+		const daemon = await import("./daemon");
+		app = daemon.app;
+	});
+
+	afterAll(() => {
+		if (prev === undefined) delete process.env.SIGNET_PATH;
+		else process.env.SIGNET_PATH = prev;
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	describe("POST /api/hooks/prompt-eval", () => {
+		it("returns 400 when prompt is missing", async () => {
+			const res = await app.request("http://localhost/api/hooks/prompt-eval", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({}),
+			});
+			expect(res.status).toBe(400);
+			const body = (await res.json()) as { error: string };
+			expect(body.error).toBeTruthy();
+		});
+
+		it("returns 400 when prompt is empty string", async () => {
+			const res = await app.request("http://localhost/api/hooks/prompt-eval", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ prompt: "" }),
+			});
+			expect(res.status).toBe(400);
+		});
+
+		it("returns 400 when body is not JSON object", async () => {
+			const res = await app.request("http://localhost/api/hooks/prompt-eval", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify("just a string"),
+			});
+			expect(res.status).toBe(400);
+		});
+
+		it("fails open (ok:true) when no synthesis provider configured", async () => {
+			const res = await app.request("http://localhost/api/hooks/prompt-eval", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ prompt: "should this tool call be allowed?" }),
+			});
+			expect(res.status).toBe(200);
+			const body = (await res.json()) as { ok: boolean; reason: unknown; inject: unknown };
+			expect(body.ok).toBe(true);
+			expect(body.reason).toBeNull();
+			expect(body.inject).toBeNull();
+		});
+
+		it("response shape matches documented contract", async () => {
+			const res = await app.request("http://localhost/api/hooks/prompt-eval", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ prompt: "test prompt" }),
+			});
+			expect(res.status).toBe(200);
+			const body = (await res.json()) as Record<string, unknown>;
+			// Must have these fields — not optional — so Forge's DaemonExecutor can parse
+			expect("ok" in body).toBe(true);
+			expect("reason" in body).toBe(true);
+			expect("inject" in body).toBe(true);
+		});
+	});
+
+	describe("POST /api/hooks/agent-eval", () => {
+		it("returns 400 when prompt is missing", async () => {
+			const res = await app.request("http://localhost/api/hooks/agent-eval", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({}),
+			});
+			expect(res.status).toBe(400);
+		});
+
+		it("fails open (ok:true) when no synthesis provider configured", async () => {
+			const res = await app.request("http://localhost/api/hooks/agent-eval", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ prompt: "evaluate this agent action" }),
+			});
+			expect(res.status).toBe(200);
+			const body = (await res.json()) as { ok: boolean };
+			expect(body.ok).toBe(true);
+		});
+
+		it("response shape is identical to prompt-eval", async () => {
+			const promptRes = await app.request("http://localhost/api/hooks/prompt-eval", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ prompt: "same prompt" }),
+			});
+			const agentRes = await app.request("http://localhost/api/hooks/agent-eval", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ prompt: "same prompt" }),
+			});
+			// Both endpoints should return the same field set
+			const pBody = (await promptRes.json()) as Record<string, unknown>;
+			const aBody = (await agentRes.json()) as Record<string, unknown>;
+			expect(Object.keys(pBody).sort()).toEqual(Object.keys(aBody).sort());
+		});
+	});
+});

--- a/packages/daemon/src/hook-eval-rate-limit-parity.test.ts
+++ b/packages/daemon/src/hook-eval-rate-limit-parity.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Asserts that the hook-eval rate limit constants in daemon.ts and
+ * packages/daemon-rs match. Catches silent drift between the TS and Rust
+ * daemons — both must enforce the same limit or the shadow-proxy divergence
+ * log will fill with false positives.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
+
+const ROOT = join(import.meta.dir, "..", "..", "..");
+
+function readFile(rel: string): string {
+	return readFileSync(join(ROOT, rel), "utf8");
+}
+
+describe("hook-eval rate limit parity (daemon.ts ↔ daemon-rs)", () => {
+	it("daemon.ts defines authHookEvalLimiter(60_000, 30)", () => {
+		const ts = readFile("packages/daemon/src/daemon.ts");
+		expect(ts).toContain("authHookEvalLimiter = new AuthRateLimiter(60_000, 30)");
+	});
+
+	it("daemon-rs defines HOOK_EVAL_WINDOW_MS = 60_000", () => {
+		const rs = readFile("packages/daemon-rs/crates/signet-daemon/src/main.rs");
+		expect(rs).toContain("HOOK_EVAL_WINDOW_MS: u64 = 60_000");
+	});
+
+	it("daemon-rs defines HOOK_EVAL_MAX = 30", () => {
+		const rs = readFile("packages/daemon-rs/crates/signet-daemon/src/main.rs");
+		expect(rs).toContain("HOOK_EVAL_MAX: u64 = 30");
+	});
+});

--- a/packages/daemon/src/hook-eval.test.ts
+++ b/packages/daemon/src/hook-eval.test.ts
@@ -50,10 +50,10 @@ describe("parseEvalResult", () => {
 		expect(() => parseEvalResult("not json at all")).toThrow();
 	});
 
-	it("coerces JSON array to ok:false (no ok field)", () => {
-		// Object.assign({}, [true]) gives {0: true} — no "ok" key, coerces to false
-		const result = parseEvalResult("[true]");
-		expect(result.ok).toBe(false);
+	it("throws on JSON array (not a valid eval response)", () => {
+		// Arrays pass typeof/null checks but are not valid eval objects.
+		// Without Array.isArray guard they'd coerce to ok:false which violates fail-open.
+		expect(() => parseEvalResult("[true]")).toThrow();
 	});
 });
 

--- a/packages/daemon/src/hook-eval.test.ts
+++ b/packages/daemon/src/hook-eval.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+import { MAX_HOOK_EVAL_PROMPT_CHARS, parseEvalResult, truncatePrompt } from "./hook-eval";
+
+describe("parseEvalResult", () => {
+	it("parses ok:true response", () => {
+		const result = parseEvalResult('{"ok": true}');
+		expect(result.ok).toBe(true);
+		expect(result.reason).toBeUndefined();
+	});
+
+	it("parses ok:false with reason", () => {
+		const result = parseEvalResult('{"ok": false, "reason": "denied by policy"}');
+		expect(result.ok).toBe(false);
+		expect(result.reason).toBe("denied by policy");
+	});
+
+	it("strips markdown code fences", () => {
+		const result = parseEvalResult("```json\n{\"ok\": true}\n```");
+		expect(result.ok).toBe(true);
+	});
+
+	it("strips markdown fences without language tag", () => {
+		const result = parseEvalResult("```\n{\"ok\": false, \"reason\": \"blocked\"}\n```");
+		expect(result.ok).toBe(false);
+		expect(result.reason).toBe("blocked");
+	});
+
+	it("handles leading/trailing whitespace", () => {
+		const result = parseEvalResult("  \n  {\"ok\": true}  \n  ");
+		expect(result.ok).toBe(true);
+	});
+
+	it("coerces reason to undefined when not a string", () => {
+		const result = parseEvalResult('{"ok": false, "reason": 42}');
+		expect(result.ok).toBe(false);
+		expect(result.reason).toBeUndefined();
+	});
+
+	it("coerces ok to boolean", () => {
+		// LLM may return truthy values
+		const result = parseEvalResult('{"ok": 1}');
+		expect(result.ok).toBe(true);
+	});
+
+	it("throws on non-object JSON", () => {
+		expect(() => parseEvalResult('"just a string"')).toThrow();
+	});
+
+	it("throws on invalid JSON", () => {
+		expect(() => parseEvalResult("not json at all")).toThrow();
+	});
+
+	it("coerces JSON array to ok:false (no ok field)", () => {
+		// Object.assign({}, [true]) gives {0: true} — no "ok" key, coerces to false
+		const result = parseEvalResult("[true]");
+		expect(result.ok).toBe(false);
+	});
+});
+
+describe("truncatePrompt", () => {
+	it("returns original prompt when within limit", () => {
+		const { prompt, truncated } = truncatePrompt("short prompt");
+		expect(prompt).toBe("short prompt");
+		expect(truncated).toBe(false);
+	});
+
+	it("truncates at MAX_HOOK_EVAL_PROMPT_CHARS", () => {
+		const long = "x".repeat(MAX_HOOK_EVAL_PROMPT_CHARS + 500);
+		const { prompt, truncated } = truncatePrompt(long);
+		expect(prompt.length).toBe(MAX_HOOK_EVAL_PROMPT_CHARS);
+		expect(truncated).toBe(true);
+	});
+
+	it("returns truncated:false at exactly the limit", () => {
+		const exact = "x".repeat(MAX_HOOK_EVAL_PROMPT_CHARS);
+		const { prompt, truncated } = truncatePrompt(exact);
+		expect(prompt.length).toBe(MAX_HOOK_EVAL_PROMPT_CHARS);
+		expect(truncated).toBe(false);
+	});
+
+	it("preserves content up to limit", () => {
+		const content = "abc".repeat(MAX_HOOK_EVAL_PROMPT_CHARS);
+		const { prompt } = truncatePrompt(content);
+		expect(prompt).toBe(content.slice(0, MAX_HOOK_EVAL_PROMPT_CHARS));
+	});
+});

--- a/packages/daemon/src/hook-eval.ts
+++ b/packages/daemon/src/hook-eval.ts
@@ -39,9 +39,12 @@ export function parseEvalResult(raw: string): { ok: boolean; reason?: string } {
 
 /**
  * Truncate a prompt to the eval character limit.
+ * Uses Unicode code-point spread to avoid splitting UTF-16 surrogate pairs
+ * (emoji and some CJK characters occupy 2 JS code units / 1 code point).
  * Returns the original string if within bounds.
  */
 export function truncatePrompt(prompt: string): { prompt: string; truncated: boolean } {
-	if (prompt.length <= MAX_HOOK_EVAL_PROMPT_CHARS) return { prompt, truncated: false };
-	return { prompt: prompt.slice(0, MAX_HOOK_EVAL_PROMPT_CHARS), truncated: true };
+	const codePoints = [...prompt];
+	if (codePoints.length <= MAX_HOOK_EVAL_PROMPT_CHARS) return { prompt, truncated: false };
+	return { prompt: codePoints.slice(0, MAX_HOOK_EVAL_PROMPT_CHARS).join(""), truncated: true };
 }

--- a/packages/daemon/src/hook-eval.ts
+++ b/packages/daemon/src/hook-eval.ts
@@ -27,7 +27,7 @@ export function parseEvalResult(raw: string): { ok: boolean; reason?: string } {
 		.replace(/\s*```\s*$/, "")
 		.trim();
 	const parsed: unknown = JSON.parse(trimmed);
-	if (typeof parsed !== "object" || parsed === null) {
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
 		throw new Error("LLM returned non-object JSON");
 	}
 	const obj: Record<string, unknown> = Object.assign({}, parsed);

--- a/packages/daemon/src/hook-eval.ts
+++ b/packages/daemon/src/hook-eval.ts
@@ -1,0 +1,47 @@
+/**
+ * Hook LLM evaluation logic — prompt-eval and agent-eval endpoints.
+ *
+ * Extracted from daemon.ts to keep the logic unit-testable.
+ * The daemon registers the HTTP routes; this module provides the core logic.
+ */
+
+// Maximum prompt length forwarded to the LLM.
+// Oversized prompts are silently truncated (fail-open, not rejected) to
+// bound per-request cost while preserving hook semantics.
+export const MAX_HOOK_EVAL_PROMPT_CHARS = 16_000;
+
+export const EVAL_SYSTEM = [
+	"You are evaluating a hook condition.",
+	'Respond with a JSON object: {"ok": true} if the condition passes,',
+	'or {"ok": false, "reason": "explanation"} if it fails.',
+	"Only return the JSON, nothing else.",
+].join(" ");
+
+/**
+ * Parse a JSON eval result from raw LLM text, tolerating markdown
+ * fences and leading/trailing whitespace.
+ */
+export function parseEvalResult(raw: string): { ok: boolean; reason?: string } {
+	const trimmed = raw
+		.replace(/^```(?:json)?\s*/i, "")
+		.replace(/\s*```\s*$/, "")
+		.trim();
+	const parsed: unknown = JSON.parse(trimmed);
+	if (typeof parsed !== "object" || parsed === null) {
+		throw new Error("LLM returned non-object JSON");
+	}
+	const obj: Record<string, unknown> = Object.assign({}, parsed);
+	return {
+		ok: Boolean(obj.ok),
+		reason: typeof obj.reason === "string" ? obj.reason : undefined,
+	};
+}
+
+/**
+ * Truncate a prompt to the eval character limit.
+ * Returns the original string if within bounds.
+ */
+export function truncatePrompt(prompt: string): { prompt: string; truncated: boolean } {
+	if (prompt.length <= MAX_HOOK_EVAL_PROMPT_CHARS) return { prompt, truncated: false };
+	return { prompt: prompt.slice(0, MAX_HOOK_EVAL_PROMPT_CHARS), truncated: true };
+}

--- a/packages/forge/Cargo.lock
+++ b/packages/forge/Cargo.lock
@@ -765,6 +765,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fax"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,6 +859,7 @@ dependencies = [
  "chrono",
  "dirs",
  "forge-core",
+ "forge-hooks",
  "forge-mcp",
  "forge-provider",
  "forge-signet",
@@ -879,6 +886,7 @@ dependencies = [
  "dirs",
  "forge-agent",
  "forge-core",
+ "forge-hooks",
  "forge-provider",
  "forge-signet",
  "forge-tools",
@@ -902,6 +910,24 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "uuid",
+]
+
+[[package]]
+name = "forge-hooks"
+version = "1.1.14"
+dependencies = [
+ "async-trait",
+ "forge-core",
+ "forge-signet",
+ "futures",
+ "regex-lite",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_yml",
+ "tempfile",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -994,6 +1020,7 @@ dependencies = [
  "dirs",
  "forge-agent",
  "forge-core",
+ "forge-hooks",
  "forge-mcp",
  "forge-provider",
  "forge-signet",
@@ -2488,7 +2515,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3124,6 +3151,19 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/packages/forge/Cargo.toml
+++ b/packages/forge/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/forge-signet",
     "crates/forge-agent",
     "crates/forge-tui",
+    "crates/forge-hooks",
     "crates/forge-cli",
 ]
 resolver = "2"
@@ -79,6 +80,7 @@ forge-provider = { path = "crates/forge-provider" }
 forge-tools = { path = "crates/forge-tools" }
 forge-mcp = { path = "crates/forge-mcp" }
 forge-signet = { path = "crates/forge-signet" }
+forge-hooks = { path = "crates/forge-hooks" }
 forge-agent = { path = "crates/forge-agent" }
 forge-tui = { path = "crates/forge-tui", default-features = false }
 

--- a/packages/forge/crates/forge-agent/Cargo.toml
+++ b/packages/forge/crates/forge-agent/Cargo.toml
@@ -9,6 +9,7 @@ forge-provider = { workspace = true }
 forge-tools = { workspace = true }
 forge-mcp = { workspace = true }
 forge-signet = { workspace = true }
+forge-hooks = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/packages/forge/crates/forge-agent/src/agent_loop.rs
+++ b/packages/forge/crates/forge-agent/src/agent_loop.rs
@@ -155,6 +155,16 @@ impl AgentLoop {
 
             let (recall_result, _) = tokio::join!(recall_future, preconnect_future);
 
+            // UserPromptSubmit supports blocking — a Block decision aborts the turn.
+            if recall_result.decision == HookDecision::Block {
+                let reason = recall_result
+                    .reason
+                    .unwrap_or_else(|| "Blocked by UserPromptSubmit hook".to_string());
+                let _ = self.event_tx.send(AgentEvent::Error(reason)).await;
+                let _ = self.event_tx.send(AgentEvent::TurnComplete).await;
+                return;
+            }
+
             if let Some(injection) = &recall_result.inject {
                 if !injection.is_empty() {
                     // Daemon endpoint returns HookOutput-shaped JSON with data.memoryCount.

--- a/packages/forge/crates/forge-agent/src/agent_loop.rs
+++ b/packages/forge/crates/forge-agent/src/agent_loop.rs
@@ -3,7 +3,7 @@ use crate::permissions::{PermissionManager, PermissionRequest, PermissionRespons
 use crate::session::SharedSession;
 use forge_core::{Message, MessageContent, ToolCall, ToolDefinition, TokenUsage};
 use forge_provider::{CompletionOpts, Provider, ReasoningEffort, StreamEvent};
-use forge_hooks::SharedRegistry;
+use forge_hooks::{self, SharedRegistry};
 use forge_core::hook::{HookDecision, HookEvent, HookInput};
 use forge_tools::{self, Tool as _};
 use futures::StreamExt;
@@ -151,7 +151,7 @@ impl AgentLoop {
             let input = HookInput::prompt_submit(&session_id, user_input);
             let reg = Arc::clone(registry);
             let recall_future = async move {
-                reg.read().await.dispatch(HookEvent::UserPromptSubmit, input).await
+                forge_hooks::dispatch(&reg, HookEvent::UserPromptSubmit, input).await
             };
             let preconnect_future = self.provider.preconnect();
 
@@ -239,7 +239,7 @@ impl AgentLoop {
                     // Notification hook — surface provider errors externally
                     if let Some(registry) = &self.hooks {
                         let input = HookInput::notification(&e.to_string(), "error");
-                        registry.read().await.dispatch(HookEvent::Notification, input).await;
+                        forge_hooks::dispatch(registry, HookEvent::Notification, input).await;
                     }
                     return;
                 }
@@ -327,7 +327,7 @@ impl AgentLoop {
                         let _ = self.event_tx.send(AgentEvent::Error(e.clone())).await;
                         if let Some(registry) = &self.hooks {
                             let input = HookInput::notification(&e, "error");
-                            registry.read().await.dispatch(HookEvent::Notification, input).await;
+                            forge_hooks::dispatch(registry, HookEvent::Notification, input).await;
                         }
                         return;
                     }
@@ -370,7 +370,7 @@ impl AgentLoop {
                         s.id.clone()
                     };
                     let input = HookInput::stop(&session_id);
-                    registry.read().await.dispatch(HookEvent::Stop, input).await;
+                    forge_hooks::dispatch(registry, HookEvent::Stop, input).await;
                 }
 
                 let estimated_tokens = {
@@ -390,7 +390,7 @@ impl AgentLoop {
                         warn!("Context compaction failed: {e}");
                         if let Some(registry) = &self.hooks {
                             let input = HookInput::notification(&e, "warning");
-                            registry.read().await.dispatch(HookEvent::Notification, input).await;
+                            forge_hooks::dispatch(registry, HookEvent::Notification, input).await;
                         }
                     }
                 }
@@ -418,7 +418,7 @@ impl AgentLoop {
                     // Notification hook — surface doom-loop errors externally
                     if let Some(registry) = &self.hooks {
                         let input = HookInput::notification(&msg, "error");
-                        registry.read().await.dispatch(HookEvent::Notification, input).await;
+                        forge_hooks::dispatch(registry, HookEvent::Notification, input).await;
                     }
                     let _ = self.event_tx.send(AgentEvent::TurnComplete).await;
                     return;
@@ -457,7 +457,7 @@ impl AgentLoop {
                     if let Some(registry) = &self.hooks {
                         let level = format!("{:?}", permission_level);
                         let input = HookInput::permission_request(&tc.name, &tc.input, &level);
-                        let hook_result = registry.read().await.dispatch(HookEvent::PermissionRequest, input).await;
+                        let hook_result = forge_hooks::dispatch(registry, HookEvent::PermissionRequest, input).await;
                         if hook_result.decision == HookDecision::Block {
                             let reason = hook_result.reason.unwrap_or_else(|| "Denied by policy hook".to_string());
                             let result = forge_core::ToolResult::error(&tc.id, &reason);
@@ -510,7 +510,7 @@ impl AgentLoop {
                             // PermissionDenied hook — audit trail
                             if let Some(registry) = &self.hooks {
                                 let input = HookInput::permission_denied(&tc.name, &tc.input);
-                                registry.read().await.dispatch(HookEvent::PermissionDenied, input).await;
+                                forge_hooks::dispatch(registry, HookEvent::PermissionDenied, input).await;
                             }
                             let result = forge_core::ToolResult::error(
                                 &tc.id,
@@ -540,7 +540,7 @@ impl AgentLoop {
                 // PreToolUse hook — allows external hooks to block tool execution
                 if let Some(registry) = &self.hooks {
                     let input = HookInput::pre_tool_use(&tc.name, &tc.input, &tc.id);
-                    let pre = registry.read().await.dispatch(HookEvent::PreToolUse, input).await;
+                    let pre = forge_hooks::dispatch(registry, HookEvent::PreToolUse, input).await;
                     if pre.decision == HookDecision::Block {
                         let reason = pre
                             .reason
@@ -586,7 +586,7 @@ impl AgentLoop {
                 // regardless of success/failure. PostToolUseFailure is additive, not a replacement.
                 if let Some(registry) = &self.hooks {
                     let input = HookInput::post_tool_use(&tc.name, &tc.input, &result);
-                    registry.read().await.dispatch(HookEvent::PostToolUse, input).await;
+                    forge_hooks::dispatch(registry, HookEvent::PostToolUse, input).await;
                 }
 
                 // PostToolUseFailure hook — fires when tool execution returned an error.
@@ -595,7 +595,7 @@ impl AgentLoop {
                         let input = HookInput::post_tool_use_failure(
                             &tc.name, &tc.input, &result.content, &tc.id,
                         );
-                        registry.read().await.dispatch(HookEvent::PostToolUseFailure, input).await;
+                        forge_hooks::dispatch(registry, HookEvent::PostToolUseFailure, input).await;
                     }
                 }
 

--- a/packages/forge/crates/forge-agent/src/agent_loop.rs
+++ b/packages/forge/crates/forge-agent/src/agent_loop.rs
@@ -33,8 +33,10 @@ pub enum AgentEvent {
     Usage(TokenUsage),
     /// Agent turn complete
     TurnComplete,
-    /// Error occurred
+    /// Error occurred (provider failure, doom-loop, etc.)
     Error(String),
+    /// Turn was blocked by a hook decision (distinct from errors — user-visible, not a crash)
+    Blocked(String),
     /// Retroactive detail for a running tool call (e.g. file path, command)
     ToolDetail { id: String, name: String, detail: String },
     /// Thinking/status message
@@ -160,7 +162,7 @@ impl AgentLoop {
                 let reason = recall_result
                     .reason
                     .unwrap_or_else(|| "Blocked by UserPromptSubmit hook".to_string());
-                let _ = self.event_tx.send(AgentEvent::Error(reason)).await;
+                let _ = self.event_tx.send(AgentEvent::Blocked(reason)).await;
                 let _ = self.event_tx.send(AgentEvent::TurnComplete).await;
                 return;
             }

--- a/packages/forge/crates/forge-agent/src/agent_loop.rs
+++ b/packages/forge/crates/forge-agent/src/agent_loop.rs
@@ -157,9 +157,11 @@ impl AgentLoop {
 
             if let Some(injection) = &recall_result.inject {
                 if !injection.is_empty() {
+                    // Daemon returns "memoryCount" (camelCase) in the response body,
+                    // stored in AggregatedResult.data by the HTTP executor fallback path.
                     let count = recall_result
                         .data
-                        .get("memory_count")
+                        .get("memoryCount")
                         .and_then(|v| v.as_u64())
                         .unwrap_or(0) as usize;
                     debug!(
@@ -566,13 +568,16 @@ impl AgentLoop {
                     })
                 };
 
-                // PostToolUse hook — observe-only, never blocks
+                // PostToolUse hook — observe-only, never blocks.
+                // Intentional: both PostToolUse and PostToolUseFailure fire on error so that
+                // observers subscribed to PostToolUse always see the full tool result stream
+                // regardless of success/failure. PostToolUseFailure is additive, not a replacement.
                 if let Some(registry) = &self.hooks {
                     let input = HookInput::post_tool_use(&tc.name, &tc.input, &result);
                     registry.read().await.dispatch(HookEvent::PostToolUse, input).await;
                 }
 
-                // PostToolUseFailure hook — fires when tool execution returned an error
+                // PostToolUseFailure hook — fires when tool execution returned an error.
                 if result.is_error {
                     if let Some(registry) = &self.hooks {
                         let input = HookInput::post_tool_use_failure(

--- a/packages/forge/crates/forge-agent/src/agent_loop.rs
+++ b/packages/forge/crates/forge-agent/src/agent_loop.rs
@@ -3,7 +3,8 @@ use crate::permissions::{PermissionManager, PermissionRequest, PermissionRespons
 use crate::session::SharedSession;
 use forge_core::{Message, MessageContent, ToolCall, ToolDefinition, TokenUsage};
 use forge_provider::{CompletionOpts, Provider, ReasoningEffort, StreamEvent};
-use forge_signet::hooks::SessionHooks;
+use forge_hooks::SharedRegistry;
+use forge_core::hook::{HookDecision, HookEvent, HookInput};
 use forge_tools::{self, Tool as _};
 use futures::StreamExt;
 use std::collections::VecDeque;
@@ -45,7 +46,7 @@ pub enum AgentEvent {
 /// The core agentic loop
 pub struct AgentLoop {
     provider: Arc<dyn Provider>,
-    hooks: Option<SessionHooks>,
+    hooks: Option<SharedRegistry>,
     event_tx: mpsc::Sender<AgentEvent>,
     /// Channel for sending permission requests to the TUI
     permission_tx: mpsc::Sender<PermissionRequest>,
@@ -68,7 +69,7 @@ impl AgentLoop {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         provider: Arc<dyn Provider>,
-        hooks: Option<SessionHooks>,
+        hooks: Option<SharedRegistry>,
         event_tx: mpsc::Sender<AgentEvent>,
         permission_tx: mpsc::Sender<PermissionRequest>,
         permissions: Arc<Mutex<PermissionManager>>,
@@ -105,6 +106,11 @@ impl AgentLoop {
         }
     }
 
+    /// Get the hook registry (for reuse when rebuilding with a new provider)
+    pub fn hooks(&self) -> Option<SharedRegistry> {
+        self.hooks.clone()
+    }
+
     /// Refresh MCP tool definitions from connected servers
     pub async fn refresh_mcp_tools(&mut self) {
         for client in &self.mcp_clients {
@@ -129,20 +135,33 @@ impl AgentLoop {
 
         // 2. Run memory recall + provider preconnect in PARALLEL
         let mut memory_context = String::new();
-        if let Some(hooks) = &self.hooks {
+        if let Some(registry) = &self.hooks {
             let _ = self
                 .event_tx
                 .send(AgentEvent::Status("◇ Recalling memories...".to_string()))
                 .await;
 
             // Overlap: recall memories while warming the provider connection
-            let recall_future = hooks.prompt_submit(user_input);
+            let session_id = {
+                let s = session.lock().await;
+                s.id.clone()
+            };
+            let input = HookInput::prompt_submit(&session_id, user_input);
+            let reg = Arc::clone(registry);
+            let recall_future = async move {
+                reg.read().await.dispatch(HookEvent::UserPromptSubmit, input).await
+            };
             let preconnect_future = self.provider.preconnect();
 
             let (recall_result, _) = tokio::join!(recall_future, preconnect_future);
 
-            match recall_result {
-                Ok((injection, count)) if !injection.is_empty() => {
+            if let Some(injection) = &recall_result.inject {
+                if !injection.is_empty() {
+                    let count = recall_result
+                        .data
+                        .get("memory_count")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0) as usize;
                     debug!(
                         "Memory injection: {} bytes, {} memories",
                         injection.len(),
@@ -152,15 +171,11 @@ impl AgentLoop {
                         .event_tx
                         .send(AgentEvent::MemoryCount(count))
                         .await;
-                    memory_context = injection;
-                }
-                Ok(_) => {}
-                Err(e) => {
-                    debug!("Prompt hook failed (non-fatal): {e}");
+                    memory_context = injection.clone();
                 }
             }
         } else {
-            // No daemon — still preconnect to provider
+            // No hooks — still preconnect to provider
             self.provider.preconnect().await;
         }
 
@@ -207,6 +222,11 @@ impl AgentLoop {
                 Err(e) => {
                     error!("Provider error: {e}");
                     let _ = self.event_tx.send(AgentEvent::Error(e.to_string())).await;
+                    // Notification hook — surface provider errors externally
+                    if let Some(registry) = &self.hooks {
+                        let input = HookInput::notification(&e.to_string(), "error");
+                        registry.read().await.dispatch(HookEvent::Notification, input).await;
+                    }
                     return;
                 }
             };
@@ -290,7 +310,11 @@ impl AgentLoop {
                     }
                     StreamEvent::Done => break,
                     StreamEvent::Error(e) => {
-                        let _ = self.event_tx.send(AgentEvent::Error(e)).await;
+                        let _ = self.event_tx.send(AgentEvent::Error(e.clone())).await;
+                        if let Some(registry) = &self.hooks {
+                            let input = HookInput::notification(&e, "error");
+                            registry.read().await.dispatch(HookEvent::Notification, input).await;
+                        }
                         return;
                     }
                 }
@@ -323,8 +347,18 @@ impl AgentLoop {
                 s.add_message(assistant_msg);
             }
 
-            // 7. If no tool calls, we're done — check compaction first
+            // 7. If no tool calls, we're done — fire Stop hook, check compaction
             if tool_calls.is_empty() {
+                // Stop hook — signals turn complete to external observers
+                if let Some(registry) = &self.hooks {
+                    let session_id = {
+                        let s = session.lock().await;
+                        s.id.clone()
+                    };
+                    let input = HookInput::stop(&session_id);
+                    registry.read().await.dispatch(HookEvent::Stop, input).await;
+                }
+
                 let estimated_tokens = {
                     let s = session.lock().await;
                     ContextManager::estimate_tokens(&s.messages)
@@ -340,6 +374,10 @@ impl AgentLoop {
                         .await
                     {
                         warn!("Context compaction failed: {e}");
+                        if let Some(registry) = &self.hooks {
+                            let input = HookInput::notification(&e, "warning");
+                            registry.read().await.dispatch(HookEvent::Notification, input).await;
+                        }
                     }
                 }
                 let _ = self.event_tx.send(AgentEvent::TurnComplete).await;
@@ -362,7 +400,12 @@ impl AgentLoop {
                         output: msg.clone(),
                         is_error: true,
                     }).await;
-                    let _ = self.event_tx.send(AgentEvent::Error(msg)).await;
+                    let _ = self.event_tx.send(AgentEvent::Error(msg.clone())).await;
+                    // Notification hook — surface doom-loop errors externally
+                    if let Some(registry) = &self.hooks {
+                        let input = HookInput::notification(&msg, "error");
+                        registry.read().await.dispatch(HookEvent::Notification, input).await;
+                    }
                     let _ = self.event_tx.send(AgentEvent::TurnComplete).await;
                     return;
                 }
@@ -396,6 +439,29 @@ impl AgentLoop {
                 };
 
                 if !approved {
+                    // PermissionRequest hook — policy hooks can auto-deny
+                    if let Some(registry) = &self.hooks {
+                        let level = format!("{:?}", permission_level);
+                        let input = HookInput::permission_request(&tc.name, &tc.input, &level);
+                        let hook_result = registry.read().await.dispatch(HookEvent::PermissionRequest, input).await;
+                        if hook_result.decision == HookDecision::Block {
+                            let reason = hook_result.reason.unwrap_or_else(|| "Denied by policy hook".to_string());
+                            let result = forge_core::ToolResult::error(&tc.id, &reason);
+                            let _ = self.event_tx.send(AgentEvent::ToolResult {
+                                id: tc.id.clone(),
+                                name: tc.name.clone(),
+                                output: result.content.clone(),
+                                is_error: true,
+                            }).await;
+                            tool_results_content.push(MessageContent::ToolResult {
+                                tool_use_id: result.tool_use_id,
+                                content: result.content,
+                                is_error: result.is_error,
+                            });
+                            continue;
+                        }
+                    }
+
                     let _ = self
                         .event_tx
                         .send(AgentEvent::ToolApproval(
@@ -427,6 +493,11 @@ impl AgentLoop {
                             perms.approve_for_session(&tc.name);
                         }
                         PermissionResponse::Deny => {
+                            // PermissionDenied hook — audit trail
+                            if let Some(registry) = &self.hooks {
+                                let input = HookInput::permission_denied(&tc.name, &tc.input);
+                                registry.read().await.dispatch(HookEvent::PermissionDenied, input).await;
+                            }
                             let result = forge_core::ToolResult::error(
                                 &tc.id,
                                 "Permission denied by user",
@@ -452,6 +523,33 @@ impl AgentLoop {
 
                 info!("Executing tool: {} (id: {})", tc.name, tc.id);
 
+                // PreToolUse hook — allows external hooks to block tool execution
+                if let Some(registry) = &self.hooks {
+                    let input = HookInput::pre_tool_use(&tc.name, &tc.input, &tc.id);
+                    let pre = registry.read().await.dispatch(HookEvent::PreToolUse, input).await;
+                    if pre.decision == HookDecision::Block {
+                        let reason = pre
+                            .reason
+                            .unwrap_or_else(|| "Blocked by hook".to_string());
+                        let result = forge_core::ToolResult::error(&tc.id, &reason);
+                        let _ = self
+                            .event_tx
+                            .send(AgentEvent::ToolResult {
+                                id: tc.id.clone(),
+                                name: tc.name.clone(),
+                                output: result.content.clone(),
+                                is_error: true,
+                            })
+                            .await;
+                        tool_results_content.push(MessageContent::ToolResult {
+                            tool_use_id: result.tool_use_id,
+                            content: result.content,
+                            is_error: result.is_error,
+                        });
+                        continue;
+                    }
+                }
+
                 let result = if let Some(tool) = tool_impl {
                     tool.execute(tc).await
                 } else {
@@ -467,6 +565,22 @@ impl AgentLoop {
                         forge_core::ToolResult::error(&tc.id, format!("Unknown tool: {}", tc.name))
                     })
                 };
+
+                // PostToolUse hook — observe-only, never blocks
+                if let Some(registry) = &self.hooks {
+                    let input = HookInput::post_tool_use(&tc.name, &tc.input, &result);
+                    registry.read().await.dispatch(HookEvent::PostToolUse, input).await;
+                }
+
+                // PostToolUseFailure hook — fires when tool execution returned an error
+                if result.is_error {
+                    if let Some(registry) = &self.hooks {
+                        let input = HookInput::post_tool_use_failure(
+                            &tc.name, &tc.input, &result.content, &tc.id,
+                        );
+                        registry.read().await.dispatch(HookEvent::PostToolUseFailure, input).await;
+                    }
+                }
 
                 let _ = self
                     .event_tx

--- a/packages/forge/crates/forge-agent/src/agent_loop.rs
+++ b/packages/forge/crates/forge-agent/src/agent_loop.rs
@@ -460,6 +460,10 @@ impl AgentLoop {
                         let hook_result = forge_hooks::dispatch(registry, HookEvent::PermissionRequest, input).await;
                         if hook_result.decision == HookDecision::Block {
                             let reason = hook_result.reason.unwrap_or_else(|| "Denied by policy hook".to_string());
+                            // Fire PermissionDenied for audit trail — policy auto-deny is
+                            // symmetric with user interactive deny (both are denial events).
+                            let denied_input = HookInput::permission_denied(&tc.name, &tc.input);
+                            forge_hooks::dispatch(registry, HookEvent::PermissionDenied, denied_input).await;
                             let result = forge_core::ToolResult::error(&tc.id, &reason);
                             let _ = self.event_tx.send(AgentEvent::ToolResult {
                                 id: tc.id.clone(),

--- a/packages/forge/crates/forge-agent/src/agent_loop.rs
+++ b/packages/forge/crates/forge-agent/src/agent_loop.rs
@@ -157,8 +157,8 @@ impl AgentLoop {
 
             if let Some(injection) = &recall_result.inject {
                 if !injection.is_empty() {
-                    // Daemon returns "memoryCount" (camelCase) in the response body,
-                    // stored in AggregatedResult.data by the HTTP executor fallback path.
+                    // Daemon endpoint returns HookOutput-shaped JSON with data.memoryCount.
+                    // The top-level inject field carries the memory text; data carries metadata.
                     let count = recall_result
                         .data
                         .get("memoryCount")

--- a/packages/forge/crates/forge-agent/src/context.rs
+++ b/packages/forge/crates/forge-agent/src/context.rs
@@ -1,7 +1,7 @@
 use crate::session::SharedSession;
 use forge_core::Message;
 use forge_core::hook::{HookEvent, HookInput};
-use forge_hooks::SharedRegistry;
+use forge_hooks::{self, SharedRegistry};
 use forge_provider::{CompletionOpts, Provider};
 use futures::StreamExt;
 use std::sync::Arc;
@@ -64,7 +64,7 @@ impl ContextManager {
         // have their output silently ignored until this is wired up.
         let _hook_instructions = if let Some(registry) = hooks {
             let input = HookInput::pre_compact(&session_id);
-            let output = registry.read().await.dispatch(HookEvent::PreCompact, input).await;
+            let output = forge_hooks::dispatch(registry, HookEvent::PreCompact, input).await;
             match output.inject {
                 Some(instructions) if !instructions.is_empty() => {
                     debug!("Pre-compaction hook returned {} bytes", instructions.len());
@@ -160,7 +160,7 @@ impl ContextManager {
         // PostCompact hook — notify observers of successful compaction
         if let Some(registry) = hooks {
             let input = HookInput::post_compact(&summary_text, compacted_count);
-            registry.read().await.dispatch(HookEvent::PostCompact, input).await;
+            forge_hooks::dispatch(registry, HookEvent::PostCompact, input).await;
         }
 
         Ok(())

--- a/packages/forge/crates/forge-agent/src/context.rs
+++ b/packages/forge/crates/forge-agent/src/context.rs
@@ -58,6 +58,10 @@ impl ContextManager {
             let s = session.lock().await;
             s.id.clone()
         };
+        // TODO(forge-hooks): apply hook_instructions as a bias prompt to the
+        // compaction summarizer (e.g. prepend to the summarization system prompt).
+        // Currently collected but unused — PreCompact hooks that return inject text
+        // have their output silently ignored until this is wired up.
         let _hook_instructions = if let Some(registry) = hooks {
             let input = HookInput::pre_compact(&session_id);
             let output = registry.read().await.dispatch(HookEvent::PreCompact, input).await;

--- a/packages/forge/crates/forge-agent/src/context.rs
+++ b/packages/forge/crates/forge-agent/src/context.rs
@@ -58,11 +58,10 @@ impl ContextManager {
             let s = session.lock().await;
             s.id.clone()
         };
-        // TODO(forge-hooks): apply hook_instructions as a bias prompt to the
-        // compaction summarizer (e.g. prepend to the summarization system prompt).
-        // Currently collected but unused — PreCompact hooks that return inject text
-        // have their output silently ignored until this is wired up.
-        let _hook_instructions = if let Some(registry) = hooks {
+        // Pre-compaction hook: collect any bias instructions for the summarizer.
+        // Inject text is prepended to the compaction system prompt so that hooks
+        // can guide what the summarizer preserves (e.g. "always keep TODO items").
+        let hook_instructions = if let Some(registry) = hooks {
             let input = HookInput::pre_compact(&session_id);
             let output = forge_hooks::dispatch(registry, HookEvent::PreCompact, input).await;
             match output.inject {
@@ -111,13 +110,17 @@ impl ContextManager {
 
         let summary_messages = vec![Message::user(&summary_prompt)];
 
-        let opts = CompletionOpts {
-            system_prompt: Some(
-                "You are a conversation summarizer. Produce a concise summary \
+        let base_system = "You are a conversation summarizer. Produce a concise summary \
                  that preserves all technical details, decisions, file paths, \
-                 and code changes."
-                    .to_string(),
-            ),
+                 and code changes.";
+        let system_prompt = if hook_instructions.is_empty() {
+            base_system.to_string()
+        } else {
+            format!("{base_system}\n\n{hook_instructions}")
+        };
+
+        let opts = CompletionOpts {
+            system_prompt: Some(system_prompt),
             max_tokens: Some(2048),
             ..Default::default()
         };

--- a/packages/forge/crates/forge-agent/src/context.rs
+++ b/packages/forge/crates/forge-agent/src/context.rs
@@ -1,10 +1,11 @@
 use crate::session::SharedSession;
 use forge_core::Message;
+use forge_core::hook::{HookEvent, HookInput};
+use forge_hooks::SharedRegistry;
 use forge_provider::{CompletionOpts, Provider};
-use forge_signet::hooks::SessionHooks;
 use futures::StreamExt;
 use std::sync::Arc;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 /// Manages context window and handles compaction
 pub struct ContextManager {
@@ -48,21 +49,24 @@ impl ContextManager {
         &self,
         session: &SharedSession,
         provider: &Arc<dyn Provider>,
-        hooks: Option<&SessionHooks>,
+        hooks: Option<&SharedRegistry>,
     ) -> Result<(), String> {
         info!("Context compaction triggered");
 
         // Call pre-compaction hook if available
-        let _hook_instructions = if let Some(hooks) = hooks {
-            match hooks.pre_compaction().await {
-                Ok(instructions) => {
+        let session_id = {
+            let s = session.lock().await;
+            s.id.clone()
+        };
+        let _hook_instructions = if let Some(registry) = hooks {
+            let input = HookInput::pre_compact(&session_id);
+            let output = registry.read().await.dispatch(HookEvent::PreCompact, input).await;
+            match output.inject {
+                Some(instructions) if !instructions.is_empty() => {
                     debug!("Pre-compaction hook returned {} bytes", instructions.len());
                     instructions
                 }
-                Err(e) => {
-                    warn!("Pre-compaction hook failed: {e}");
-                    String::new()
-                }
+                _ => String::new(),
             }
         } else {
             String::new()
@@ -136,6 +140,7 @@ impl ContextManager {
             "[Context Summary]\n\n{summary_text}"
         ));
 
+        let compacted_count = to_summarize.len();
         {
             let mut s = session.lock().await;
             s.messages.clear();
@@ -143,9 +148,15 @@ impl ContextManager {
             s.messages.extend_from_slice(to_keep);
             info!(
                 "Compacted {} messages into summary + {} kept messages",
-                to_summarize.len(),
+                compacted_count,
                 to_keep.len()
             );
+        }
+
+        // PostCompact hook — notify observers of successful compaction
+        if let Some(registry) = hooks {
+            let input = HookInput::post_compact(&summary_text, compacted_count);
+            registry.read().await.dispatch(HookEvent::PostCompact, input).await;
         }
 
         Ok(())

--- a/packages/forge/crates/forge-cli/Cargo.toml
+++ b/packages/forge/crates/forge-cli/Cargo.toml
@@ -27,6 +27,7 @@ dirs = { workspace = true }
 reqwest = { workspace = true }
 serde_json = { workspace = true }
 base64 = "0.22"
+uuid = { workspace = true }
 
 [features]
 default = ["voice"]

--- a/packages/forge/crates/forge-cli/Cargo.toml
+++ b/packages/forge/crates/forge-cli/Cargo.toml
@@ -12,6 +12,7 @@ forge-core = { workspace = true }
 forge-provider = { workspace = true }
 forge-agent = { workspace = true }
 forge-signet = { workspace = true }
+forge-hooks = { workspace = true }
 forge-tui = { workspace = true, default-features = false }
 ratatui = { workspace = true }
 crossterm = { workspace = true }

--- a/packages/forge/crates/forge-cli/src/main.rs
+++ b/packages/forge/crates/forge-cli/src/main.rs
@@ -809,16 +809,8 @@ async fn run_non_interactive(
     use forge_tools;
     use futures::StreamExt;
 
-    // Collision-safe session identifier: 8 random bytes (hex) avoids the
-    // millisecond-precision collision risk under concurrent invocations.
-    let session_id = {
-        use std::io::Read;
-        let mut buf = [0u8; 8];
-        std::fs::File::open("/dev/urandom")
-            .and_then(|mut f| f.read_exact(&mut buf).map(|_| ()))
-            .unwrap_or(());
-        format!("ni-{}", buf.iter().map(|b| format!("{b:02x}")).collect::<String>())
-    };
+    // Collision-safe session identifier using UUID v4.
+    let session_id = format!("ni-{}", uuid::Uuid::new_v4());
 
     // SessionStart hook (non-blocking).
     if let Some(ref reg) = hooks {

--- a/packages/forge/crates/forge-cli/src/main.rs
+++ b/packages/forge/crates/forge-cli/src/main.rs
@@ -809,14 +809,16 @@ async fn run_non_interactive(
     use forge_tools;
     use futures::StreamExt;
 
-    // Stable session identifier for hook payloads.
-    let session_id = format!(
-        "ni-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis()
-    );
+    // Collision-safe session identifier: 8 random bytes (hex) avoids the
+    // millisecond-precision collision risk under concurrent invocations.
+    let session_id = {
+        use std::io::Read;
+        let mut buf = [0u8; 8];
+        std::fs::File::open("/dev/urandom")
+            .and_then(|mut f| f.read_exact(&mut buf).map(|_| ()))
+            .unwrap_or(());
+        format!("ni-{}", buf.iter().map(|b| format!("{b:02x}")).collect::<String>())
+    };
 
     // SessionStart hook (non-blocking).
     if let Some(ref reg) = hooks {
@@ -833,7 +835,7 @@ async fn run_non_interactive(
             let reason = result.reason.unwrap_or_else(|| "Blocked by hook".to_string());
             eprintln!("Blocked: {reason}");
             // SessionEnd before exit.
-            let end_input = HookInput::session_end(&session_id, "");
+            let end_input = HookInput::session_end(&session_id, &format!("User: {prompt}"));
             forge_hooks::dispatch(reg, HookEvent::SessionEnd, end_input).await;
             return Ok(());
         }
@@ -873,7 +875,8 @@ async fn run_non_interactive(
             StreamEvent::Error(e) => {
                 eprintln!("\nError: {e}");
                 if let Some(ref reg) = hooks {
-                    let input = HookInput::session_end(&session_id, &response_text);
+                    let transcript = format!("User: {prompt}\n\nAssistant: {response_text}");
+                    let input = HookInput::session_end(&session_id, &transcript);
                     forge_hooks::dispatch(reg, HookEvent::SessionEnd, input).await;
                 }
                 std::process::exit(1);
@@ -885,9 +888,11 @@ async fn run_non_interactive(
 
     println!();
 
-    // SessionEnd hook.
+    // SessionEnd hook — include both sides of the conversation so the daemon's
+    // session-end memory extraction has the full context (not just the AI response).
     if let Some(ref reg) = hooks {
-        let input = HookInput::session_end(&session_id, &response_text);
+        let transcript = format!("User: {prompt}\n\nAssistant: {response_text}");
+        let input = HookInput::session_end(&session_id, &transcript);
         forge_hooks::dispatch(reg, HookEvent::SessionEnd, input).await;
     }
 

--- a/packages/forge/crates/forge-cli/src/main.rs
+++ b/packages/forge/crates/forge-cli/src/main.rs
@@ -310,7 +310,7 @@ async fn main() -> Result<()> {
 
     // Non-interactive mode: send prompt, print response, exit
     if let Some(prompt) = prompt_arg {
-        return run_non_interactive(provider, signet_client, system_prompt, &prompt).await;
+        return run_non_interactive(provider, system_prompt, &prompt, Some(Arc::clone(&registry))).await;
     }
 
     // Interactive TUI mode
@@ -793,37 +793,89 @@ fn infer_provider_from_model(model: &str) -> &'static str {
     }
 }
 
-/// Non-interactive mode: single prompt → streamed response → exit
+/// Non-interactive mode: single prompt → streamed response → exit.
+///
+/// Fires SessionStart, UserPromptSubmit (blocking), and SessionEnd hooks so
+/// that daemon memory recall works identically to interactive mode.
 async fn run_non_interactive(
     provider: Arc<dyn forge_provider::Provider>,
-    _signet_client: Option<SignetClient>,
     system_prompt: String,
     prompt: &str,
+    hooks: Option<SharedRegistry>,
 ) -> Result<()> {
+    use forge_core::hook::{HookDecision, HookEvent, HookInput};
     use forge_core::Message;
     use forge_provider::{CompletionOpts, StreamEvent};
     use forge_tools;
     use futures::StreamExt;
 
+    // Stable session identifier for hook payloads.
+    let session_id = format!(
+        "ni-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+    );
+
+    // SessionStart hook (non-blocking).
+    if let Some(ref reg) = hooks {
+        let input = HookInput::session_start(&session_id, std::env::current_dir().ok().as_ref().and_then(|p| p.to_str()));
+        forge_hooks::dispatch(reg, HookEvent::SessionStart, input).await;
+    }
+
+    // UserPromptSubmit hook (blocking + memory injection).
+    let mut memory_context = String::new();
+    if let Some(ref reg) = hooks {
+        let input = HookInput::prompt_submit(&session_id, prompt);
+        let result = forge_hooks::dispatch(reg, HookEvent::UserPromptSubmit, input).await;
+        if result.decision == HookDecision::Block {
+            let reason = result.reason.unwrap_or_else(|| "Blocked by hook".to_string());
+            eprintln!("Blocked: {reason}");
+            // SessionEnd before exit.
+            let end_input = HookInput::session_end(&session_id, "");
+            forge_hooks::dispatch(reg, HookEvent::SessionEnd, end_input).await;
+            return Ok(());
+        }
+        if let Some(inject) = result.inject {
+            if !inject.is_empty() {
+                memory_context = inject;
+            }
+        }
+    }
+
+    // Prepend injected memories to the system prompt.
+    let effective_system = if memory_context.is_empty() {
+        system_prompt
+    } else {
+        format!("{system_prompt}\n\n{memory_context}")
+    };
+
     let messages = vec![Message::user(prompt)];
     let tools = forge_tools::all_definitions();
 
     let opts = CompletionOpts {
-        system_prompt: Some(system_prompt),
+        system_prompt: Some(effective_system),
         max_tokens: Some(8192),
         ..Default::default()
     };
 
+    let mut response_text = String::new();
     let stream = provider.complete(&messages, &tools, &opts).await?;
     let mut stream = std::pin::pin!(stream);
 
     while let Some(event) = stream.next().await {
         match event {
             StreamEvent::TextDelta(text) => {
+                response_text.push_str(&text);
                 print!("{text}");
             }
             StreamEvent::Error(e) => {
                 eprintln!("\nError: {e}");
+                if let Some(ref reg) = hooks {
+                    let input = HookInput::session_end(&session_id, &response_text);
+                    forge_hooks::dispatch(reg, HookEvent::SessionEnd, input).await;
+                }
                 std::process::exit(1);
             }
             StreamEvent::Done => break,
@@ -832,6 +884,13 @@ async fn run_non_interactive(
     }
 
     println!();
+
+    // SessionEnd hook.
+    if let Some(ref reg) = hooks {
+        let input = HookInput::session_end(&session_id, &response_text);
+        forge_hooks::dispatch(reg, HookEvent::SessionEnd, input).await;
+    }
+
     Ok(())
 }
 
@@ -863,8 +922,6 @@ fn build_hook_registry(
     signet_client: &Option<SignetClient>,
     config: &forge_signet::config::AgentConfig,
 ) -> SharedRegistry {
-    use forge_hooks::HookEvent;
-
     let mut registry = HookRegistry::new();
 
     // Register built-in daemon HTTP hooks (replicates SessionHooks endpoints)
@@ -872,28 +929,7 @@ fn build_hook_registry(
         let base = client.base_url();
         let headers = build_daemon_headers(client);
 
-        registry.register_builtin_http(
-            HookEvent::SessionStart,
-            &format!("{base}/api/hooks/session-start"),
-            headers.clone(),
-        );
-        registry.register_builtin_http(
-            HookEvent::UserPromptSubmit,
-            &format!("{base}/api/hooks/user-prompt-submit"),
-            headers.clone(),
-        );
-        registry.register_builtin_http(
-            HookEvent::PreCompact,
-            &format!("{base}/api/hooks/pre-compaction"),
-            headers.clone(),
-        );
-        registry.register_builtin_http(
-            HookEvent::SessionEnd,
-            &format!("{base}/api/hooks/session-end"),
-            headers,
-        );
-
-        info!("Registered 4 built-in daemon hooks at {base}");
+        registry.register_builtin(base, headers);
     }
 
     // Register user-configured hooks from agent.yaml

--- a/packages/forge/crates/forge-cli/src/main.rs
+++ b/packages/forge/crates/forge-cli/src/main.rs
@@ -10,6 +10,7 @@ use crossterm::{
     terminal,
 };
 use forge_provider::create_provider;
+use forge_hooks::{HookRegistry, SharedRegistry};
 use forge_signet::config::{build_agent_identity_prompt, build_identity_prompt, load_agent_config};
 use forge_signet::secrets::{
     apply_local_cli_auth_env, default_model_for_provider, discover_available_providers,
@@ -18,6 +19,7 @@ use forge_signet::secrets::{
 };
 use forge_signet::SignetClient;
 use forge_tui::App;
+use std::collections::HashMap;
 use std::io::{IsTerminal, Write};
 use std::sync::Arc;
 use tracing::{info, warn};
@@ -142,7 +144,7 @@ async fn main() -> Result<()> {
     std::env::set_var("FORGE_SIGNET_ACTOR_TYPE", "agent");
 
     // Load Signet agent config
-    let _agent_config = load_agent_config().unwrap_or_default();
+    let agent_config = load_agent_config().unwrap_or_default();
 
     // Connect to Signet daemon
     let signet_client = if cli.no_daemon {
@@ -303,6 +305,9 @@ async fn main() -> Result<()> {
         identity_prompt
     };
 
+    // Build HookRegistry — replaces direct SessionHooks construction
+    let registry = build_hook_registry(&signet_client, &agent_config);
+
     // Non-interactive mode: send prompt, print response, exit
     if let Some(prompt) = prompt_arg {
         return run_non_interactive(provider, signet_client, system_prompt, &prompt).await;
@@ -318,6 +323,7 @@ async fn main() -> Result<()> {
         &cli_with_defaults.theme,
         agent_arg,
         connected_providers,
+        Some(Arc::clone(&registry)),
     )
     .await;
 
@@ -846,4 +852,87 @@ fn find_cli_path(provider_name: &str, available: &[DiscoveredProvider]) -> Optio
 
 fn has_non_ollama_provider(available: &[DiscoveredProvider]) -> bool {
     available.iter().any(|p| p.provider != "ollama")
+}
+
+/// Build HookRegistry with built-in daemon hooks and user-configured hooks.
+///
+/// The 4 existing daemon endpoints (session-start, user-prompt-submit,
+/// pre-compaction, session-end) are registered as built-in HTTP hooks.
+/// User hooks from agent.yaml's `hooks` section are layered on top.
+fn build_hook_registry(
+    signet_client: &Option<SignetClient>,
+    config: &forge_signet::config::AgentConfig,
+) -> SharedRegistry {
+    use forge_hooks::HookEvent;
+
+    let mut registry = HookRegistry::new();
+
+    // Register built-in daemon HTTP hooks (replicates SessionHooks endpoints)
+    if let Some(client) = signet_client {
+        let base = client.base_url();
+        let headers = build_daemon_headers(client);
+
+        registry.register_builtin_http(
+            HookEvent::SessionStart,
+            &format!("{base}/api/hooks/session-start"),
+            headers.clone(),
+        );
+        registry.register_builtin_http(
+            HookEvent::UserPromptSubmit,
+            &format!("{base}/api/hooks/user-prompt-submit"),
+            headers.clone(),
+        );
+        registry.register_builtin_http(
+            HookEvent::PreCompact,
+            &format!("{base}/api/hooks/pre-compaction"),
+            headers.clone(),
+        );
+        registry.register_builtin_http(
+            HookEvent::SessionEnd,
+            &format!("{base}/api/hooks/session-end"),
+            headers,
+        );
+
+        info!("Registered 4 built-in daemon hooks at {base}");
+    }
+
+    // Register user-configured hooks from agent.yaml
+    if let Some(ref hook_config) = config.hooks {
+        registry.register_from_config(hook_config);
+        let count: usize = hook_config.events.values().map(|v| v.len()).sum();
+        if count > 0 {
+            info!("Registered {count} user hooks from agent.yaml");
+        }
+    }
+
+    Arc::new(tokio::sync::RwLock::new(registry))
+}
+
+/// Build auth headers matching what SignetClient uses for daemon calls.
+/// These are passed to the HttpExecutor for built-in hooks so they
+/// authenticate identically to the old SessionHooks.
+fn build_daemon_headers(client: &SignetClient) -> HashMap<String, String> {
+    let reqwest_headers = forge_signet::daemon_auth_headers(
+        std::env::var("FORGE_SIGNET_TOKEN").ok().as_deref(),
+        std::env::var("FORGE_SIGNET_ACTOR")
+            .ok()
+            .as_deref()
+            .or(client.agent_id()),
+        std::env::var("FORGE_SIGNET_ACTOR_TYPE").ok().as_deref(),
+    );
+
+    let mut headers = HashMap::new();
+    for (name, value) in &reqwest_headers {
+        if let Ok(v) = value.to_str() {
+            headers.insert(name.to_string(), v.to_string());
+        }
+    }
+
+    // Always include runtime path header — Forge is plugin-native
+    headers.insert(
+        "x-signet-runtime-path".to_string(),
+        "plugin".to_string(),
+    );
+
+    headers
 }

--- a/packages/forge/crates/forge-cli/src/main.rs
+++ b/packages/forge/crates/forge-cli/src/main.rs
@@ -855,7 +855,18 @@ async fn run_non_interactive(
     };
 
     let mut response_text = String::new();
-    let stream = provider.complete(&messages, &tools, &opts).await?;
+    let stream = match provider.complete(&messages, &tools, &opts).await {
+        Ok(s) => s,
+        Err(e) => {
+            // Fire SessionEnd before propagating — keeps the daemon's session
+            // tracker mutex in sync even when the provider fails at startup.
+            if let Some(ref reg) = hooks {
+                let input = HookInput::session_end(&session_id, &format!("User: {prompt}"));
+                forge_hooks::dispatch(reg, HookEvent::SessionEnd, input).await;
+            }
+            return Err(e.into());
+        }
+    };
     let mut stream = std::pin::pin!(stream);
 
     while let Some(event) = stream.next().await {

--- a/packages/forge/crates/forge-core/src/hook.rs
+++ b/packages/forge/crates/forge-core/src/hook.rs
@@ -131,8 +131,11 @@ impl HookInput {
         Self {
             event: HookEvent::SessionStart,
             tool_name: None,
+            // harness:"forge" satisfies the daemon's required field; sessionKey mirrors
+            // the daemon's expected field name for session tracking.
             payload: serde_json::json!({
-                "sessionId": session_id,
+                "harness": "forge",
+                "sessionKey": session_id,
                 "cwd": cwd,
             }),
         }
@@ -143,7 +146,8 @@ impl HookInput {
             event: HookEvent::SessionEnd,
             tool_name: None,
             payload: serde_json::json!({
-                "sessionId": session_id,
+                "harness": "forge",
+                "sessionKey": session_id,
                 "transcript": transcript,
             }),
         }
@@ -154,7 +158,8 @@ impl HookInput {
             event: HookEvent::UserPromptSubmit,
             tool_name: None,
             payload: serde_json::json!({
-                "sessionId": session_id,
+                "harness": "forge",
+                "sessionKey": session_id,
                 "userMessage": message,
             }),
         }
@@ -194,7 +199,8 @@ impl HookInput {
             event: HookEvent::PreCompact,
             tool_name: None,
             payload: serde_json::json!({
-                "sessionId": session_id,
+                "harness": "forge",
+                "sessionKey": session_id,
             }),
         }
     }

--- a/packages/forge/crates/forge-core/src/hook.rs
+++ b/packages/forge/crates/forge-core/src/hook.rs
@@ -221,7 +221,7 @@ impl HookInput {
             event: HookEvent::Stop,
             tool_name: None,
             payload: serde_json::json!({
-                "sessionId": session_id,
+                "sessionKey": session_id,
             }),
         }
     }

--- a/packages/forge/crates/forge-core/src/hook.rs
+++ b/packages/forge/crates/forge-core/src/hook.rs
@@ -1,0 +1,422 @@
+use serde::{Deserialize, Serialize};
+
+/// Lifecycle events that hooks can subscribe to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum HookEvent {
+    SessionStart,
+    SessionEnd,
+    UserPromptSubmit,
+    PreCompact,
+    PostCompact,
+    PreToolUse,
+    PostToolUse,
+    PostToolUseFailure,
+    Stop,
+    PermissionRequest,
+    PermissionDenied,
+    Notification,
+    SubagentStart,
+    CwdChanged,
+}
+
+impl HookEvent {
+    /// Whether this event supports blocking (returning Block to prevent the action).
+    pub fn supports_blocking(self) -> bool {
+        matches!(
+            self,
+            Self::PreToolUse | Self::UserPromptSubmit | Self::PermissionRequest
+        )
+    }
+}
+
+/// Decision returned by a hook execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HookDecision {
+    /// Proceed normally (exit code 0).
+    Allow,
+    /// Block the action (exit code 2).
+    Block,
+    /// Non-blocking error — log and continue.
+    Error,
+}
+
+impl Default for HookDecision {
+    fn default() -> Self {
+        Self::Allow
+    }
+}
+
+/// Output returned by a single hook execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookOutput {
+    #[serde(default)]
+    pub decision: HookDecision,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Text to inject into the conversation context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inject: Option<String>,
+    /// Event-specific structured data.
+    #[serde(default)]
+    pub data: serde_json::Value,
+}
+
+impl Default for HookOutput {
+    fn default() -> Self {
+        Self {
+            decision: HookDecision::Allow,
+            reason: None,
+            inject: None,
+            data: serde_json::Value::Null,
+        }
+    }
+}
+
+impl HookOutput {
+    pub fn allow() -> Self {
+        Self::default()
+    }
+
+    pub fn block(reason: impl Into<String>) -> Self {
+        Self {
+            decision: HookDecision::Block,
+            reason: Some(reason.into()),
+            ..Self::default()
+        }
+    }
+
+    pub fn error(reason: impl Into<String>) -> Self {
+        Self {
+            decision: HookDecision::Error,
+            reason: Some(reason.into()),
+            ..Self::default()
+        }
+    }
+
+    pub fn with_inject(mut self, text: impl Into<String>) -> Self {
+        self.inject = Some(text.into());
+        self
+    }
+
+    pub fn with_data(mut self, data: serde_json::Value) -> Self {
+        self.data = data;
+        self
+    }
+}
+
+/// Input passed to hook executors, containing event-specific data.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookInput {
+    pub event: HookEvent,
+    /// The tool name or other matchable identifier for this event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+    /// Event-specific payload as dynamic JSON.
+    #[serde(default)]
+    pub payload: serde_json::Value,
+}
+
+impl HookInput {
+    pub fn new(event: HookEvent) -> Self {
+        Self {
+            event,
+            tool_name: None,
+            payload: serde_json::Value::Null,
+        }
+    }
+
+    pub fn session_start(session_id: &str, cwd: Option<&str>) -> Self {
+        Self {
+            event: HookEvent::SessionStart,
+            tool_name: None,
+            payload: serde_json::json!({
+                "sessionId": session_id,
+                "cwd": cwd,
+            }),
+        }
+    }
+
+    pub fn session_end(session_id: &str, transcript: &str) -> Self {
+        Self {
+            event: HookEvent::SessionEnd,
+            tool_name: None,
+            payload: serde_json::json!({
+                "sessionId": session_id,
+                "transcript": transcript,
+            }),
+        }
+    }
+
+    pub fn prompt_submit(session_id: &str, message: &str) -> Self {
+        Self {
+            event: HookEvent::UserPromptSubmit,
+            tool_name: None,
+            payload: serde_json::json!({
+                "sessionId": session_id,
+                "userMessage": message,
+            }),
+        }
+    }
+
+    pub fn pre_tool_use(name: &str, input: &serde_json::Value, id: &str) -> Self {
+        Self {
+            event: HookEvent::PreToolUse,
+            tool_name: Some(name.to_string()),
+            payload: serde_json::json!({
+                "toolName": name,
+                "toolInput": input,
+                "toolUseId": id,
+            }),
+        }
+    }
+
+    pub fn post_tool_use(
+        name: &str,
+        input: &serde_json::Value,
+        result: &crate::ToolResult,
+    ) -> Self {
+        Self {
+            event: HookEvent::PostToolUse,
+            tool_name: Some(name.to_string()),
+            payload: serde_json::json!({
+                "toolName": name,
+                "toolInput": input,
+                "toolOutput": result.content,
+                "isError": result.is_error,
+            }),
+        }
+    }
+
+    pub fn pre_compact(session_id: &str) -> Self {
+        Self {
+            event: HookEvent::PreCompact,
+            tool_name: None,
+            payload: serde_json::json!({
+                "sessionId": session_id,
+            }),
+        }
+    }
+
+    pub fn post_compact(summary: &str, message_count: usize) -> Self {
+        Self {
+            event: HookEvent::PostCompact,
+            tool_name: None,
+            payload: serde_json::json!({
+                "summary": summary,
+                "messageCount": message_count,
+            }),
+        }
+    }
+
+    pub fn stop(session_id: &str) -> Self {
+        Self {
+            event: HookEvent::Stop,
+            tool_name: None,
+            payload: serde_json::json!({
+                "sessionId": session_id,
+            }),
+        }
+    }
+
+    pub fn post_tool_use_failure(name: &str, input: &serde_json::Value, error: &str, id: &str) -> Self {
+        Self {
+            event: HookEvent::PostToolUseFailure,
+            tool_name: Some(name.to_string()),
+            payload: serde_json::json!({
+                "toolName": name,
+                "toolInput": input,
+                "error": error,
+                "toolUseId": id,
+            }),
+        }
+    }
+
+    pub fn permission_request(tool_name: &str, tool_input: &serde_json::Value, permission_level: &str) -> Self {
+        Self {
+            event: HookEvent::PermissionRequest,
+            tool_name: Some(tool_name.to_string()),
+            payload: serde_json::json!({
+                "toolName": tool_name,
+                "toolInput": tool_input,
+                "permissionLevel": permission_level,
+            }),
+        }
+    }
+
+    pub fn permission_denied(tool_name: &str, tool_input: &serde_json::Value) -> Self {
+        Self {
+            event: HookEvent::PermissionDenied,
+            tool_name: Some(tool_name.to_string()),
+            payload: serde_json::json!({
+                "toolName": tool_name,
+                "toolInput": tool_input,
+            }),
+        }
+    }
+
+    pub fn notification(message: &str, level: &str) -> Self {
+        Self {
+            event: HookEvent::Notification,
+            tool_name: None,
+            payload: serde_json::json!({
+                "message": message,
+                "level": level,
+            }),
+        }
+    }
+
+    /// The matchable string for this input (tool name if present).
+    pub fn match_target(&self) -> Option<&str> {
+        self.tool_name.as_deref()
+    }
+}
+
+/// Matcher pattern for filtering which hooks fire on which inputs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Matcher {
+    /// Match everything (empty string, "*", or omitted).
+    All,
+    /// Pattern string: exact, pipe-separated, or regex.
+    Pattern(String),
+}
+
+impl Default for Matcher {
+    fn default() -> Self {
+        Self::All
+    }
+}
+
+/// How a hook is executed.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HookType {
+    Command,
+    Http,
+    Prompt,
+    Agent,
+}
+
+/// A single hook entry from configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookEntry {
+    #[serde(rename = "type")]
+    pub hook_type: HookType,
+    /// Shell command (for Command hooks).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    /// URL (for Http hooks).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// LLM prompt template (for Prompt hooks).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+    /// Matcher pattern.
+    #[serde(default)]
+    pub matcher: Matcher,
+    /// Timeout in seconds.
+    #[serde(default)]
+    pub timeout: Option<u64>,
+    /// Fire-and-forget mode (don't wait for completion).
+    #[serde(default, rename = "async")]
+    pub fire_and_forget: bool,
+}
+
+/// Top-level hook configuration from agent.yaml.
+/// Maps event names to lists of hook entries.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HookConfig {
+    #[serde(flatten)]
+    pub events: std::collections::HashMap<HookEvent, Vec<HookEntry>>,
+}
+
+/// Aggregated result from dispatching hooks for a single event.
+#[derive(Debug, Clone)]
+pub struct AggregatedResult {
+    pub decision: HookDecision,
+    pub reason: Option<String>,
+    /// Combined injection text from all hooks.
+    pub inject: Option<String>,
+    /// Structured data from the first hook that returned data.
+    pub data: serde_json::Value,
+    /// Individual outputs for inspection.
+    pub outputs: Vec<HookOutput>,
+}
+
+impl Default for AggregatedResult {
+    fn default() -> Self {
+        Self {
+            decision: HookDecision::Allow,
+            reason: None,
+            inject: None,
+            data: serde_json::Value::Null,
+            outputs: Vec::new(),
+        }
+    }
+}
+
+impl AggregatedResult {
+    /// Aggregate multiple hook outputs into a single result.
+    /// Any Block = Block. All Error (no Allow) = Error. Otherwise Allow.
+    pub fn aggregate(outputs: Vec<HookOutput>) -> Self {
+        if outputs.is_empty() {
+            return Self::default();
+        }
+
+        let mut decision = HookDecision::Allow;
+        let mut reason = None;
+        let mut injections = Vec::new();
+        let mut data = serde_json::Value::Null;
+
+        let mut has_allow = false;
+
+        for output in &outputs {
+            match output.decision {
+                HookDecision::Block => {
+                    decision = HookDecision::Block;
+                    if reason.is_none() {
+                        reason = output.reason.clone();
+                    }
+                }
+                HookDecision::Allow => {
+                    has_allow = true;
+                }
+                HookDecision::Error => {}
+            }
+
+            if let Some(ref text) = output.inject {
+                if !text.is_empty() {
+                    injections.push(text.clone());
+                }
+            }
+
+            if data.is_null() && !output.data.is_null() {
+                data = output.data.clone();
+            }
+        }
+
+        // If no Block and no Allow, all were Error
+        if decision != HookDecision::Block && !has_allow {
+            decision = HookDecision::Error;
+            reason = outputs
+                .iter()
+                .find_map(|o| o.reason.clone());
+        }
+
+        let inject = if injections.is_empty() {
+            None
+        } else {
+            Some(injections.join("\n\n"))
+        };
+
+        Self {
+            decision,
+            reason,
+            inject,
+            data,
+            outputs,
+        }
+    }
+}

--- a/packages/forge/crates/forge-core/src/lib.rs
+++ b/packages/forge/crates/forge-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod error;
+pub mod hook;
 pub mod message;
 pub mod tool;
 

--- a/packages/forge/crates/forge-hooks/Cargo.toml
+++ b/packages/forge/crates/forge-hooks/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "forge-hooks"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+forge-core = { workspace = true }
+forge-signet = { workspace = true }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yml = { workspace = true }
+reqwest = { workspace = true }
+regex-lite = { workspace = true }
+tracing = { workspace = true }
+async-trait = { workspace = true }
+futures = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/packages/forge/crates/forge-hooks/src/config.rs
+++ b/packages/forge/crates/forge-hooks/src/config.rs
@@ -1,0 +1,102 @@
+use forge_core::hook::HookConfig;
+use tracing::{debug, warn};
+
+/// Parse hook configuration from a YAML string (the full agent.yaml content).
+/// Extracts the `hooks` section. Returns empty config if missing or invalid.
+pub fn parse_hook_config(yaml: &str) -> HookConfig {
+    // Parse the full YAML to extract just the hooks section
+    let val: serde_json::Value = match serde_yml::from_str(yaml) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!("Failed to parse YAML for hooks config: {e}");
+            return HookConfig::default();
+        }
+    };
+
+    let hooks = match val.get("hooks") {
+        Some(h) => h.clone(),
+        None => {
+            debug!("No hooks section in agent.yaml");
+            return HookConfig::default();
+        }
+    };
+
+    match serde_json::from_value(hooks) {
+        Ok(config) => {
+            debug!("Parsed hook config");
+            config
+        }
+        Err(e) => {
+            warn!("Failed to parse hooks config: {e}");
+            HookConfig::default()
+        }
+    }
+}
+
+/// Load hook configuration from the agent.yaml file at the standard path.
+pub fn load_hook_config() -> HookConfig {
+    let path = forge_signet::config::agent_yaml_path();
+    match std::fs::read_to_string(&path) {
+        Ok(content) => parse_hook_config(&content),
+        Err(_) => {
+            debug!("No agent.yaml found for hooks config");
+            HookConfig::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use forge_core::hook::{HookEvent, HookType, Matcher};
+
+    #[test]
+    fn parse_valid_hooks() {
+        let yaml = r#"
+name: test
+hooks:
+  PreToolUse:
+    - matcher: "Bash|Shell"
+      type: command
+      command: "~/.agents/hooks/validate.sh"
+      timeout: 5
+    - matcher: "Write"
+      type: http
+      url: "http://localhost:3850/api/hooks/validate"
+  PostToolUse:
+    - type: command
+      command: "~/.agents/hooks/log.sh"
+      async: true
+"#;
+        let config = parse_hook_config(yaml);
+        let pre = config.events.get(&HookEvent::PreToolUse).unwrap();
+        assert_eq!(pre.len(), 2);
+        assert_eq!(pre[0].hook_type, HookType::Command);
+        assert_eq!(pre[0].matcher, Matcher::Pattern("Bash|Shell".into()));
+        assert_eq!(pre[0].timeout, Some(5));
+        assert_eq!(pre[1].hook_type, HookType::Http);
+
+        let post = config.events.get(&HookEvent::PostToolUse).unwrap();
+        assert_eq!(post.len(), 1);
+        assert!(post[0].fire_and_forget);
+    }
+
+    #[test]
+    fn missing_hooks_returns_empty() {
+        let yaml = "name: test\nmemory: {}\n";
+        let config = parse_hook_config(yaml);
+        assert!(config.events.is_empty());
+    }
+
+    #[test]
+    fn invalid_yaml_returns_empty() {
+        let config = parse_hook_config("{{invalid yaml");
+        assert!(config.events.is_empty());
+    }
+
+    #[test]
+    fn empty_string_returns_empty() {
+        let config = parse_hook_config("");
+        assert!(config.events.is_empty());
+    }
+}

--- a/packages/forge/crates/forge-hooks/src/dispatch.rs
+++ b/packages/forge/crates/forge-hooks/src/dispatch.rs
@@ -1,12 +1,76 @@
-use forge_core::hook::{AggregatedResult, HookEvent, HookInput};
+use std::sync::Arc;
 
-use crate::registry::HookRegistry;
+use forge_core::hook::{AggregatedResult, HookDecision, HookEvent, HookInput};
+use futures::future::join_all;
+use tokio::sync::RwLock;
+use tracing::{debug, warn};
 
-/// Convenience function: dispatch hooks for an event through a registry.
+use crate::matcher::matches;
+use crate::registry::{execute_hook, HookRegistry, RegisteredHook};
+
+/// Dispatch hooks for an event through a `SharedRegistry`.
+///
+/// The registry read lock is held only long enough to clone the matching hook
+/// entries, then released before any async execution begins. This prevents
+/// hot-reload write locks from blocking for the full hook timeout duration.
 pub async fn dispatch(
-    registry: &HookRegistry,
+    registry: &Arc<RwLock<HookRegistry>>,
     event: HookEvent,
     input: HookInput,
 ) -> AggregatedResult {
-    registry.dispatch(event, input).await
+    // Snapshot matching hooks under a brief read lock.
+    let (matching, daemon_url, total) = {
+        let reg = registry.read().await;
+        let hooks = reg.get(event);
+        if hooks.is_empty() {
+            return AggregatedResult::default();
+        }
+        let target = input.match_target().map(|s| s.to_string());
+        let matching: Vec<RegisteredHook> = hooks
+            .iter()
+            .filter(|h| matches(&h.entry.matcher, target.as_deref()))
+            .cloned()
+            .collect();
+        let daemon_url = reg.daemon_url().map(str::to_string);
+        let total = hooks.len();
+        (matching, daemon_url, total)
+    }; // Read lock released here — hot-reload can proceed.
+
+    if matching.is_empty() {
+        return AggregatedResult::default();
+    }
+
+    debug!(
+        "Dispatching {:?}: {} matching hooks (of {} registered)",
+        event,
+        matching.len(),
+        total
+    );
+
+    let futures: Vec<_> = matching
+        .iter()
+        .map(|hook| {
+            let input = input.clone();
+            let entry = hook.entry.clone();
+            let headers = hook.headers.clone();
+            let daemon = daemon_url.clone();
+            async move { execute_hook(&entry, &headers, &input, daemon.as_deref()).await }
+        })
+        .collect();
+
+    let outputs = join_all(futures).await;
+    let result = AggregatedResult::aggregate(outputs);
+
+    if result.decision == HookDecision::Block && !event.supports_blocking() {
+        warn!(
+            "Hook returned Block for {:?} which doesn't support blocking — treating as Allow",
+            event
+        );
+        return AggregatedResult {
+            decision: HookDecision::Allow,
+            ..result
+        };
+    }
+
+    result
 }

--- a/packages/forge/crates/forge-hooks/src/dispatch.rs
+++ b/packages/forge/crates/forge-hooks/src/dispatch.rs
@@ -8,38 +8,17 @@ use tracing::{debug, warn};
 use crate::matcher::matches;
 use crate::registry::{execute_hook, HookRegistry, RegisteredHook};
 
-/// Dispatch hooks for an event through a `SharedRegistry`.
-///
-/// The registry read lock is held only long enough to clone the matching hook
-/// entries, then released before any async execution begins. This prevents
-/// hot-reload write locks from blocking for the full hook timeout duration.
-pub async fn dispatch(
-    registry: &Arc<RwLock<HookRegistry>>,
+/// Core execution: run a pre-snapshotted set of matching hooks in parallel,
+/// aggregate results, and enforce non-blocking semantics for events that don't
+/// support blocking. Both the free `dispatch()` function and `HookRegistry::dispatch()`
+/// delegate here so the logic lives in exactly one place.
+pub(crate) async fn run_hooks(
+    matching: Vec<RegisteredHook>,
     event: HookEvent,
     input: HookInput,
+    daemon_url: Option<String>,
+    total: usize,
 ) -> AggregatedResult {
-    // Snapshot matching hooks under a brief read lock.
-    let (matching, daemon_url, total) = {
-        let reg = registry.read().await;
-        let hooks = reg.get(event);
-        if hooks.is_empty() {
-            return AggregatedResult::default();
-        }
-        let target = input.match_target().map(|s| s.to_string());
-        let matching: Vec<RegisteredHook> = hooks
-            .iter()
-            .filter(|h| matches(&h.entry.matcher, target.as_deref()))
-            .cloned()
-            .collect();
-        let daemon_url = reg.daemon_url().map(str::to_string);
-        let total = hooks.len();
-        (matching, daemon_url, total)
-    }; // Read lock released here — hot-reload can proceed.
-
-    if matching.is_empty() {
-        return AggregatedResult::default();
-    }
-
     debug!(
         "Dispatching {:?}: {} matching hooks (of {} registered)",
         event,
@@ -73,4 +52,39 @@ pub async fn dispatch(
     }
 
     result
+}
+
+/// Dispatch hooks for an event through a `SharedRegistry`.
+///
+/// The registry read lock is held only long enough to clone the matching hook
+/// entries, then released before any async execution begins. This prevents
+/// hot-reload write locks from blocking for the full hook timeout duration.
+pub async fn dispatch(
+    registry: &Arc<RwLock<HookRegistry>>,
+    event: HookEvent,
+    input: HookInput,
+) -> AggregatedResult {
+    // Snapshot matching hooks under a brief read lock.
+    let (matching, daemon_url, total) = {
+        let reg = registry.read().await;
+        let hooks = reg.get(event);
+        if hooks.is_empty() {
+            return AggregatedResult::default();
+        }
+        let target = input.match_target().map(|s| s.to_string());
+        let matching: Vec<RegisteredHook> = hooks
+            .iter()
+            .filter(|h| matches(&h.entry.matcher, target.as_deref()))
+            .cloned()
+            .collect();
+        let daemon_url = reg.daemon_url().map(str::to_string);
+        let total = hooks.len();
+        (matching, daemon_url, total)
+    }; // Read lock released here — hot-reload can proceed.
+
+    if matching.is_empty() {
+        return AggregatedResult::default();
+    }
+
+    run_hooks(matching, event, input, daemon_url, total).await
 }

--- a/packages/forge/crates/forge-hooks/src/dispatch.rs
+++ b/packages/forge/crates/forge-hooks/src/dispatch.rs
@@ -1,0 +1,12 @@
+use forge_core::hook::{AggregatedResult, HookEvent, HookInput};
+
+use crate::registry::HookRegistry;
+
+/// Convenience function: dispatch hooks for an event through a registry.
+pub async fn dispatch(
+    registry: &HookRegistry,
+    event: HookEvent,
+    input: HookInput,
+) -> AggregatedResult {
+    registry.dispatch(event, input).await
+}

--- a/packages/forge/crates/forge-hooks/src/executor/command.rs
+++ b/packages/forge/crates/forge-hooks/src/executor/command.rs
@@ -68,11 +68,12 @@ impl HookExecutor for CommandExecutor {
             return HookOutput::allow();
         }
 
-        // Read stdout/stderr handles before waiting (avoids ownership issue with kill)
+        // Take stdout/stderr handles — child stays outside the async block so
+        // we can call child.kill() if the timeout fires.
         let stdout_handle = child.stdout.take();
         let stderr_handle = child.stderr.take();
 
-        let read_output = async {
+        let read_streams = async move {
             let stdout = match stdout_handle {
                 Some(mut out) => {
                     let mut buf = Vec::new();
@@ -89,15 +90,13 @@ impl HookExecutor for CommandExecutor {
                 }
                 None => Vec::new(),
             };
-            let status = child.wait().await?;
-            Ok::<_, std::io::Error>((status, stdout, stderr))
+            Ok::<_, std::io::Error>((stdout, stderr))
         };
 
-        // Wait with timeout
-        let result = tokio::time::timeout(self.timeout, read_output).await;
-
-        match result {
+        match tokio::time::timeout(self.timeout, read_streams).await {
             Err(_) => {
+                // Kill the child to avoid zombie processes
+                let _ = child.kill().await;
                 warn!(
                     "Command hook timed out after {:?}: {}",
                     self.timeout, self.command
@@ -107,10 +106,12 @@ impl HookExecutor for CommandExecutor {
                     self.timeout.as_secs()
                 ))
             }
-            Ok(Err(e)) => {
-                HookOutput::error(format!("Command execution failed: {e}"))
-            }
-            Ok(Ok((status, stdout, stderr))) => {
+            Ok(Err(e)) => HookOutput::error(format!("Command execution failed: {e}")),
+            Ok(Ok((stdout, stderr))) => {
+                let status = match child.wait().await {
+                    Ok(s) => s,
+                    Err(e) => return HookOutput::error(format!("Failed to wait for command: {e}")),
+                };
                 let code = status.code().unwrap_or(-1);
                 let stdout = String::from_utf8_lossy(&stdout).to_string();
                 let stderr = String::from_utf8_lossy(&stderr).to_string();

--- a/packages/forge/crates/forge-hooks/src/executor/command.rs
+++ b/packages/forge/crates/forge-hooks/src/executor/command.rs
@@ -58,7 +58,9 @@ impl HookExecutor for CommandExecutor {
 
         // Write input to stdin
         if let Some(mut stdin) = child.stdin.take() {
-            let _ = stdin.write_all(json.as_bytes()).await;
+            if let Err(e) = stdin.write_all(json.as_bytes()).await {
+                debug!("Command hook: failed to write stdin (hook may not read it): {e}");
+            }
             drop(stdin);
         }
 

--- a/packages/forge/crates/forge-hooks/src/executor/command.rs
+++ b/packages/forge/crates/forge-hooks/src/executor/command.rs
@@ -95,8 +95,10 @@ impl HookExecutor for CommandExecutor {
 
         match tokio::time::timeout(self.timeout, read_streams).await {
             Err(_) => {
-                // Kill the child to avoid zombie processes
+                // Kill and wait to fully reap the child — kill() sends SIGKILL
+                // but wait() is required to remove the zombie entry.
                 let _ = child.kill().await;
+                let _ = child.wait().await;
                 warn!(
                     "Command hook timed out after {:?}: {}",
                     self.timeout, self.command

--- a/packages/forge/crates/forge-hooks/src/executor/command.rs
+++ b/packages/forge/crates/forge-hooks/src/executor/command.rs
@@ -1,0 +1,164 @@
+use async_trait::async_trait;
+use forge_core::hook::{HookInput, HookOutput};
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::process::Command;
+use tracing::{debug, warn};
+
+use super::HookExecutor;
+
+/// Executes hooks as shell subprocesses via `sh -c`.
+///
+/// - Pipes HookInput as JSON to stdin
+/// - Exit 0 = Allow (stdout parsed as JSON HookOutput, fallback to plain text)
+/// - Exit 2 = Block (stderr as reason)
+/// - Other = Error (non-blocking)
+/// - Supports fire-and-forget mode (spawn and don't wait)
+pub struct CommandExecutor {
+    command: String,
+    timeout: Duration,
+    fire_and_forget: bool,
+}
+
+impl CommandExecutor {
+    pub fn new(command: String, timeout_secs: Option<u64>, fire_and_forget: bool) -> Self {
+        Self {
+            command,
+            timeout: Duration::from_secs(timeout_secs.unwrap_or(10)),
+            fire_and_forget,
+        }
+    }
+}
+
+#[async_trait]
+impl HookExecutor for CommandExecutor {
+    async fn execute(&self, input: &HookInput) -> HookOutput {
+        let json = match serde_json::to_string(input) {
+            Ok(j) => j,
+            Err(e) => {
+                return HookOutput::error(format!("Failed to serialize hook input: {e}"));
+            }
+        };
+
+        debug!("Executing command hook: {}", self.command);
+
+        let mut child = match Command::new("sh")
+            .arg("-c")
+            .arg(&self.command)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+        {
+            Ok(c) => c,
+            Err(e) => {
+                return HookOutput::error(format!("Failed to spawn command: {e}"));
+            }
+        };
+
+        // Write input to stdin
+        if let Some(mut stdin) = child.stdin.take() {
+            let _ = stdin.write_all(json.as_bytes()).await;
+            drop(stdin);
+        }
+
+        // Fire-and-forget: don't wait for exit
+        if self.fire_and_forget {
+            debug!("Command hook fired (async): {}", self.command);
+            return HookOutput::allow();
+        }
+
+        // Read stdout/stderr handles before waiting (avoids ownership issue with kill)
+        let stdout_handle = child.stdout.take();
+        let stderr_handle = child.stderr.take();
+
+        let read_output = async {
+            let stdout = match stdout_handle {
+                Some(mut out) => {
+                    let mut buf = Vec::new();
+                    AsyncReadExt::read_to_end(&mut out, &mut buf).await?;
+                    buf
+                }
+                None => Vec::new(),
+            };
+            let stderr = match stderr_handle {
+                Some(mut err) => {
+                    let mut buf = Vec::new();
+                    AsyncReadExt::read_to_end(&mut err, &mut buf).await?;
+                    buf
+                }
+                None => Vec::new(),
+            };
+            let status = child.wait().await?;
+            Ok::<_, std::io::Error>((status, stdout, stderr))
+        };
+
+        // Wait with timeout
+        let result = tokio::time::timeout(self.timeout, read_output).await;
+
+        match result {
+            Err(_) => {
+                warn!(
+                    "Command hook timed out after {:?}: {}",
+                    self.timeout, self.command
+                );
+                HookOutput::error(format!(
+                    "Hook timed out after {}s",
+                    self.timeout.as_secs()
+                ))
+            }
+            Ok(Err(e)) => {
+                HookOutput::error(format!("Command execution failed: {e}"))
+            }
+            Ok(Ok((status, stdout, stderr))) => {
+                let code = status.code().unwrap_or(-1);
+                let stdout = String::from_utf8_lossy(&stdout).to_string();
+                let stderr = String::from_utf8_lossy(&stderr).to_string();
+
+                match code {
+                    0 => parse_stdout(&stdout),
+                    2 => {
+                        let reason = if stderr.is_empty() {
+                            "Blocked by hook".to_string()
+                        } else {
+                            stderr.trim().to_string()
+                        };
+                        HookOutput::block(reason)
+                    }
+                    _ => {
+                        let msg = if stderr.is_empty() {
+                            format!("Hook exited with code {code}")
+                        } else {
+                            format!("Hook exited with code {code}: {}", stderr.trim())
+                        };
+                        HookOutput::error(msg)
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Parse stdout as JSON HookOutput, falling back to raw JSON or plain text.
+fn parse_stdout(stdout: &str) -> HookOutput {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return HookOutput::allow();
+    }
+
+    // Try parsing as full HookOutput JSON (must have explicit "decision" field)
+    if let Ok(val) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        if val.get("decision").is_some() {
+            if let Ok(output) = serde_json::from_value::<HookOutput>(val.clone()) {
+                return output;
+            }
+        }
+        // Valid JSON but not HookOutput: store as data and inject as text
+        return HookOutput::allow()
+            .with_data(val)
+            .with_inject(trimmed.to_string());
+    }
+
+    // Not JSON: treat as plain text injection
+    HookOutput::allow().with_inject(trimmed.to_string())
+}

--- a/packages/forge/crates/forge-hooks/src/executor/daemon.rs
+++ b/packages/forge/crates/forge-hooks/src/executor/daemon.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use forge_core::hook::{HookInput, HookOutput};
 use reqwest::Client;
+use std::collections::HashMap;
 use std::time::Duration;
 use tracing::{debug, warn};
 
@@ -17,6 +18,7 @@ pub struct DaemonExecutor {
     client: Client,
     timeout: Duration,
     prompt_template: Option<String>,
+    headers: HashMap<String, String>,
 }
 
 impl DaemonExecutor {
@@ -36,7 +38,13 @@ impl DaemonExecutor {
             client: Client::new(),
             timeout: Duration::from_secs(timeout.unwrap_or(30)),
             prompt_template,
+            headers: HashMap::new(),
         }
+    }
+
+    pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
+        self.headers = headers;
+        self
     }
 
     /// Interpolate template placeholders with values from the hook input.
@@ -97,15 +105,17 @@ impl HookExecutor for DaemonExecutor {
             "input": input,
         });
 
-        let result = self
+        let mut req = self
             .client
             .post(&self.endpoint)
             .json(&body)
-            .timeout(self.timeout)
-            .send()
-            .await;
+            .timeout(self.timeout);
 
-        let resp = match result {
+        for (key, value) in &self.headers {
+            req = req.header(key, value);
+        }
+
+        let resp = match req.send().await {
             Ok(r) => r,
             Err(e) => {
                 if e.is_timeout() {
@@ -120,6 +130,7 @@ impl HookExecutor for DaemonExecutor {
             }
         };
 
+        let status = resp.status();
         let text = match resp.text().await {
             Ok(t) => t,
             Err(e) => {
@@ -127,6 +138,18 @@ impl HookExecutor for DaemonExecutor {
                 return HookOutput::error(format!("Response read failed: {e}"));
             }
         };
+
+        if !status.is_success() {
+            // Non-2xx (e.g. 401 Unauthorized) — log and return Error (non-blocking, fail-open).
+            // Without this check, a missing 'ok' field in the error body would silently allow.
+            warn!(
+                "Daemon hook returned {} for {}: body={:?}",
+                status,
+                self.endpoint,
+                &text[..text.len().min(200)]
+            );
+            return HookOutput::error(format!("Daemon hook returned {status}"));
+        }
 
         if text.is_empty() {
             return HookOutput::allow();

--- a/packages/forge/crates/forge-hooks/src/executor/daemon.rs
+++ b/packages/forge/crates/forge-hooks/src/executor/daemon.rs
@@ -1,0 +1,140 @@
+use async_trait::async_trait;
+use forge_core::hook::{HookInput, HookOutput};
+use reqwest::Client;
+use std::time::Duration;
+use tracing::{debug, warn};
+
+use super::HookExecutor;
+
+/// Daemon-delegated executor for Prompt and Agent hooks.
+///
+/// Routes to the Signet daemon at `/api/hooks/prompt-eval` (prompt hooks)
+/// and `/api/hooks/agent-eval` (agent hooks). The daemon already has
+/// LLM provider access for extraction/synthesis, so Forge delegates
+/// evaluation rather than running its own LLM call.
+pub struct DaemonExecutor {
+    endpoint: String,
+    client: Client,
+    timeout: Duration,
+    prompt_template: Option<String>,
+}
+
+impl DaemonExecutor {
+    pub fn new(
+        base_url: String,
+        prompt_template: Option<String>,
+        timeout: Option<u64>,
+        agent: bool,
+    ) -> Self {
+        let path = if agent {
+            "/api/hooks/agent-eval"
+        } else {
+            "/api/hooks/prompt-eval"
+        };
+        Self {
+            endpoint: format!("{base_url}{path}"),
+            client: Client::new(),
+            timeout: Duration::from_secs(timeout.unwrap_or(30)),
+            prompt_template,
+        }
+    }
+
+    /// Interpolate template placeholders with values from the hook input.
+    fn interpolate(template: &str, input: &HookInput) -> String {
+        let mut result = template.to_string();
+
+        result = result.replace("{{event}}", &format!("{:?}", input.event));
+
+        let name = input.tool_name.as_deref().unwrap_or("");
+        result = result.replace("{{tool_name}}", name);
+
+        let tool_input = input
+            .payload
+            .get("toolInput")
+            .map(|v| v.to_string())
+            .unwrap_or_default();
+        result = result.replace("{{tool_input}}", &tool_input);
+
+        result = result.replace("{{payload}}", &input.payload.to_string());
+
+        result
+    }
+}
+
+#[async_trait]
+impl HookExecutor for DaemonExecutor {
+    async fn execute(&self, input: &HookInput) -> HookOutput {
+        debug!("Executing daemon hook: POST {}", self.endpoint);
+
+        let prompt = match &self.prompt_template {
+            Some(tpl) => Self::interpolate(tpl, input),
+            None => serde_json::to_string(input).unwrap_or_default(),
+        };
+
+        let body = serde_json::json!({
+            "prompt": prompt,
+            "event": format!("{:?}", input.event),
+            "input": input,
+        });
+
+        let result = self
+            .client
+            .post(&self.endpoint)
+            .json(&body)
+            .timeout(self.timeout)
+            .send()
+            .await;
+
+        let resp = match result {
+            Ok(r) => r,
+            Err(e) => {
+                if e.is_timeout() {
+                    warn!("Daemon hook timed out: {}", self.endpoint);
+                    return HookOutput::error(format!(
+                        "Daemon hook timed out after {}s",
+                        self.timeout.as_secs()
+                    ));
+                }
+                warn!("Daemon hook request failed: {e}");
+                return HookOutput::error(format!("Request failed: {e}"));
+            }
+        };
+
+        let text = match resp.text().await {
+            Ok(t) => t,
+            Err(e) => {
+                warn!("Daemon hook response read failed: {e}");
+                return HookOutput::error(format!("Response read failed: {e}"));
+            }
+        };
+
+        if text.is_empty() {
+            return HookOutput::allow();
+        }
+
+        // Try to parse as daemon response: {ok, reason, inject}
+        let val = match serde_json::from_str::<serde_json::Value>(&text) {
+            Ok(v) => v,
+            Err(_) => {
+                // Non-JSON — treat as inject text
+                return HookOutput::allow().with_inject(text);
+            }
+        };
+
+        let ok = val.get("ok").and_then(|v| v.as_bool()).unwrap_or(true);
+        if !ok {
+            let reason = val
+                .get("reason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Denied by daemon evaluation")
+                .to_string();
+            return HookOutput::block(reason);
+        }
+
+        let mut output = HookOutput::allow();
+        if let Some(inject) = val.get("inject").and_then(|v| v.as_str()) {
+            output = output.with_inject(inject.to_string());
+        }
+        output.with_data(val)
+    }
+}

--- a/packages/forge/crates/forge-hooks/src/executor/daemon.rs
+++ b/packages/forge/crates/forge-hooks/src/executor/daemon.rs
@@ -40,24 +40,44 @@ impl DaemonExecutor {
     }
 
     /// Interpolate template placeholders with values from the hook input.
+    ///
+    /// Uses a single left-to-right scan of the template so that substituted
+    /// values are never re-scanned. This prevents double-expansion when a
+    /// value (e.g. tool_input) itself contains a placeholder like `{{payload}}`.
     fn interpolate(template: &str, input: &HookInput) -> String {
-        let mut result = template.to_string();
-
-        result = result.replace("{{event}}", &format!("{:?}", input.event));
-
+        let event = format!("{:?}", input.event);
         let name = input.tool_name.as_deref().unwrap_or("");
-        result = result.replace("{{tool_name}}", name);
-
         let tool_input = input
             .payload
             .get("toolInput")
             .map(|v| v.to_string())
             .unwrap_or_default();
-        result = result.replace("{{tool_input}}", &tool_input);
+        let payload = input.payload.to_string();
 
-        result = result.replace("{{payload}}", &input.payload.to_string());
+        let replacements: &[(&str, &str)] = &[
+            ("{{event}}", &event),
+            ("{{tool_name}}", name),
+            ("{{tool_input}}", &tool_input),
+            ("{{payload}}", &payload),
+        ];
 
-        result
+        // Single-pass: scan template once, emit output without rescanning substitutions.
+        let mut out = String::with_capacity(template.len());
+        let mut rest = template;
+        'outer: while !rest.is_empty() {
+            for (placeholder, value) in replacements {
+                if rest.starts_with(placeholder) {
+                    out.push_str(value);
+                    rest = &rest[placeholder.len()..];
+                    continue 'outer;
+                }
+            }
+            // Advance one char at a time when no placeholder matches.
+            let ch = rest.chars().next().unwrap();
+            out.push(ch);
+            rest = &rest[ch.len_utf8()..];
+        }
+        out
     }
 }
 

--- a/packages/forge/crates/forge-hooks/src/executor/http.rs
+++ b/packages/forge/crates/forge-hooks/src/executor/http.rs
@@ -43,20 +43,27 @@ impl HttpExecutor {
 
     /// Interpolate environment variables in header values.
     /// Replaces `$VAR_NAME` with the env var value (empty string if missing).
+    /// Scans forward from after each substitution to avoid infinite loops when
+    /// a substituted value itself contains `$`.
     fn interpolate(value: &str) -> String {
         let mut result = value.to_string();
-        // Simple $VAR_NAME interpolation (word chars after $)
-        while let Some(pos) = result.find('$') {
+        let mut cursor = 0;
+        while let Some(rel) = result[cursor..].find('$') {
+            let pos = cursor + rel;
             let rest = &result[pos + 1..];
             let end = rest
                 .find(|c: char| !c.is_alphanumeric() && c != '_')
                 .unwrap_or(rest.len());
             if end == 0 {
-                break;
+                // Bare `$` with no valid var name — skip past it
+                cursor = pos + 1;
+                continue;
             }
             let var = &rest[..end];
             let val = std::env::var(var).unwrap_or_default();
             result = format!("{}{}{}", &result[..pos], val, &rest[end..]);
+            // Advance past the substituted value to avoid rescanning it
+            cursor = pos + val.len();
         }
         result
     }

--- a/packages/forge/crates/forge-hooks/src/executor/http.rs
+++ b/packages/forge/crates/forge-hooks/src/executor/http.rs
@@ -135,7 +135,16 @@ impl HookExecutor for HttpExecutor {
 
         debug!("HTTP hook response: status={}, body_len={}", status, body.len());
 
-        // Parse body as HookOutput regardless of status code
+        if !status.is_success() {
+            warn!(
+                "HTTP hook returned non-2xx status {} for {}: body={:?}",
+                status,
+                self.url,
+                &body[..body.len().min(200)]
+            );
+        }
+
+        // Parse body as HookOutput regardless of status code (mirrors Claude Code behavior)
         match serde_json::from_str::<HookOutput>(&body) {
             Ok(output) => output,
             Err(_) => {

--- a/packages/forge/crates/forge-hooks/src/executor/http.rs
+++ b/packages/forge/crates/forge-hooks/src/executor/http.rs
@@ -142,13 +142,23 @@ impl HookExecutor for HttpExecutor {
                 self.url,
                 &body[..body.len().min(200)]
             );
+            // On non-2xx, only accept a well-formed HookOutput JSON.
+            // Falling through to raw-text inject would pollute model context with
+            // error bodies like "Service Unavailable" from temporarily-down hooks.
+            return match serde_json::from_str::<HookOutput>(&body) {
+                Ok(output) => output,
+                Err(_) => HookOutput::error(format!(
+                    "HTTP hook returned status {}: {}",
+                    status,
+                    body.trim().chars().take(200).collect::<String>()
+                )),
+            };
         }
 
-        // Parse body as HookOutput regardless of status code (mirrors Claude Code behavior)
+        // 2xx: parse body as HookOutput, falling back to raw JSON or plain text.
         match serde_json::from_str::<HookOutput>(&body) {
             Ok(output) => output,
             Err(_) => {
-                // If not valid HookOutput JSON, try to extract inject/data from raw response
                 if let Ok(val) = serde_json::from_str::<serde_json::Value>(&body) {
                     let inject = val
                         .get("inject")

--- a/packages/forge/crates/forge-hooks/src/executor/http.rs
+++ b/packages/forge/crates/forge-hooks/src/executor/http.rs
@@ -1,0 +1,131 @@
+use async_trait::async_trait;
+use forge_core::hook::{HookInput, HookOutput};
+use reqwest::Client;
+use std::collections::HashMap;
+use std::time::Duration;
+use tracing::{debug, warn};
+
+use super::HookExecutor;
+
+/// Executes hooks as HTTP POST requests.
+///
+/// - POSTs HookInput as JSON to the configured URL
+/// - Parses response body as JSON HookOutput
+/// - Supports custom headers with env var interpolation ($VAR_NAME)
+/// - Connection errors return Error (non-blocking, not fatal)
+/// - Non-2xx still parses body (like Claude Code behavior)
+pub struct HttpExecutor {
+    url: String,
+    client: Client,
+    timeout: Duration,
+    headers: HashMap<String, String>,
+}
+
+impl HttpExecutor {
+    pub fn new(url: String, timeout_secs: Option<u64>) -> Self {
+        Self {
+            url,
+            client: Client::new(),
+            timeout: Duration::from_secs(timeout_secs.unwrap_or(10)),
+            headers: HashMap::new(),
+        }
+    }
+
+    pub fn with_client(mut self, client: Client) -> Self {
+        self.client = client;
+        self
+    }
+
+    pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
+        self.headers = headers;
+        self
+    }
+
+    /// Interpolate environment variables in header values.
+    /// Replaces `$VAR_NAME` with the env var value (empty string if missing).
+    fn interpolate(value: &str) -> String {
+        let mut result = value.to_string();
+        // Simple $VAR_NAME interpolation (word chars after $)
+        while let Some(pos) = result.find('$') {
+            let rest = &result[pos + 1..];
+            let end = rest
+                .find(|c: char| !c.is_alphanumeric() && c != '_')
+                .unwrap_or(rest.len());
+            if end == 0 {
+                break;
+            }
+            let var = &rest[..end];
+            let val = std::env::var(var).unwrap_or_default();
+            result = format!("{}{}{}", &result[..pos], val, &rest[end..]);
+        }
+        result
+    }
+}
+
+#[async_trait]
+impl HookExecutor for HttpExecutor {
+    async fn execute(&self, input: &HookInput) -> HookOutput {
+        debug!("Executing HTTP hook: POST {}", self.url);
+
+        let mut req = self
+            .client
+            .post(&self.url)
+            .json(input)
+            .timeout(self.timeout);
+
+        for (key, value) in &self.headers {
+            let interpolated = Self::interpolate(value);
+            req = req.header(key, interpolated);
+        }
+
+        let resp = match req.send().await {
+            Ok(r) => r,
+            Err(e) => {
+                if e.is_timeout() {
+                    warn!("HTTP hook timed out: {}", self.url);
+                    return HookOutput::error(format!(
+                        "HTTP hook timed out after {}s",
+                        self.timeout.as_secs()
+                    ));
+                }
+                warn!("HTTP hook connection error: {e}");
+                return HookOutput::error(format!("HTTP hook failed: {e}"));
+            }
+        };
+
+        let status = resp.status();
+        let body = match resp.text().await {
+            Ok(b) => b,
+            Err(e) => {
+                warn!("HTTP hook failed to read response body: {e}");
+                return HookOutput::error(format!("Failed to read response: {e}"));
+            }
+        };
+
+        debug!("HTTP hook response: status={}, body_len={}", status, body.len());
+
+        // Parse body as HookOutput regardless of status code
+        match serde_json::from_str::<HookOutput>(&body) {
+            Ok(output) => output,
+            Err(_) => {
+                // If not valid HookOutput JSON, try to extract inject/data from raw response
+                if let Ok(val) = serde_json::from_str::<serde_json::Value>(&body) {
+                    let inject = val
+                        .get("inject")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    HookOutput {
+                        decision: forge_core::hook::HookDecision::Allow,
+                        reason: None,
+                        inject,
+                        data: val,
+                    }
+                } else if !body.trim().is_empty() {
+                    HookOutput::allow().with_inject(body.trim().to_string())
+                } else {
+                    HookOutput::allow()
+                }
+            }
+        }
+    }
+}

--- a/packages/forge/crates/forge-hooks/src/executor/http.rs
+++ b/packages/forge/crates/forge-hooks/src/executor/http.rs
@@ -14,6 +14,24 @@ use super::HookExecutor;
 /// - Supports custom headers with env var interpolation ($VAR_NAME)
 /// - Connection errors return Error (non-blocking, not fatal)
 /// - Non-2xx still parses body (like Claude Code behavior)
+/// Build the HTTP request body for a hook: flatten `input.payload` fields to
+/// the top level and add an `event` key.  Daemon endpoints (session-start,
+/// user-prompt-submit, etc.) parse their expected fields directly from the body
+/// root; the extra `event` key is ignored by them but available to user hooks.
+fn flatten_payload(input: &HookInput) -> serde_json::Value {
+    let event = format!("{:?}", input.event);
+    let mut map = match &input.payload {
+        serde_json::Value::Object(m) => m.clone(),
+        other => {
+            let mut m = serde_json::Map::new();
+            m.insert("payload".to_string(), other.clone());
+            m
+        }
+    };
+    map.insert("event".to_string(), serde_json::Value::String(event));
+    serde_json::Value::Object(map)
+}
+
 pub struct HttpExecutor {
     url: String,
     client: Client,
@@ -74,10 +92,16 @@ impl HookExecutor for HttpExecutor {
     async fn execute(&self, input: &HookInput) -> HookOutput {
         debug!("Executing HTTP hook: POST {}", self.url);
 
+        // Send payload fields flattened at top level, plus an `event` discriminator.
+        // This matches the shape daemon endpoints expect (e.g. {harness, userMessage, …})
+        // while still letting user hooks identify the event type.
+        // Sending the full HookInput envelope would break built-in daemon endpoints that
+        // parse `body.harness` / `body.userMessage` at the root.
+        let body = flatten_payload(input);
         let mut req = self
             .client
             .post(&self.url)
-            .json(input)
+            .json(&body)
             .timeout(self.timeout);
 
         for (key, value) in &self.headers {

--- a/packages/forge/crates/forge-hooks/src/executor/mod.rs
+++ b/packages/forge/crates/forge-hooks/src/executor/mod.rs
@@ -1,0 +1,13 @@
+pub mod command;
+pub mod daemon;
+pub mod http;
+
+use async_trait::async_trait;
+use forge_core::hook::{HookInput, HookOutput};
+
+/// Trait for executing a hook and returning its output.
+/// Implementations handle command subprocess, HTTP POST, daemon delegation, etc.
+#[async_trait]
+pub trait HookExecutor: Send + Sync {
+    async fn execute(&self, input: &HookInput) -> HookOutput;
+}

--- a/packages/forge/crates/forge-hooks/src/lib.rs
+++ b/packages/forge/crates/forge-hooks/src/lib.rs
@@ -1,0 +1,16 @@
+pub mod config;
+pub mod dispatch;
+pub mod executor;
+pub mod matcher;
+pub mod registry;
+
+pub use config::parse_hook_config;
+pub use dispatch::dispatch;
+pub use matcher::matches;
+pub use registry::{HookRegistry, SharedRegistry};
+
+// Re-export core types for convenience
+pub use forge_core::hook::{
+    AggregatedResult, HookConfig, HookDecision, HookEntry, HookEvent, HookInput, HookOutput,
+    HookType, Matcher,
+};

--- a/packages/forge/crates/forge-hooks/src/lib.rs
+++ b/packages/forge/crates/forge-hooks/src/lib.rs
@@ -7,7 +7,7 @@ pub mod registry;
 pub use config::parse_hook_config;
 pub use dispatch::dispatch;
 pub use matcher::matches;
-pub use registry::{HookRegistry, SharedRegistry};
+pub use registry::{HookRegistry, RegisteredHook, SharedRegistry};
 
 // Re-export core types for convenience
 pub use forge_core::hook::{

--- a/packages/forge/crates/forge-hooks/src/matcher.rs
+++ b/packages/forge/crates/forge-hooks/src/matcher.rs
@@ -1,0 +1,119 @@
+use forge_core::hook::Matcher;
+use regex_lite::Regex;
+
+/// Test whether a matcher pattern matches a given target string.
+///
+/// Matching rules:
+/// - `Matcher::All` or `Pattern("*")` or empty pattern: matches everything
+/// - Simple alphanumeric (no special chars): exact match
+/// - Contains `|`: pipe-separated exact matches
+/// - Contains regex special chars: compiled as regex
+/// - All matching is case-sensitive
+pub fn matches(matcher: &Matcher, target: Option<&str>) -> bool {
+    match matcher {
+        Matcher::All => true,
+        Matcher::Pattern(pattern) => {
+            if pattern.is_empty() || pattern == "*" {
+                return true;
+            }
+            let target = match target {
+                Some(t) => t,
+                // No target to match against and pattern is specific
+                None => return false,
+            };
+            if pattern.contains('|') && !has_regex_chars_except_pipe(pattern) {
+                // Pipe-separated exact match
+                pattern.split('|').any(|p| p == target)
+            } else if has_regex_chars(pattern) {
+                // Regex match
+                match Regex::new(pattern) {
+                    Ok(re) => re.is_match(target),
+                    Err(_) => {
+                        tracing::warn!("Invalid regex in hook matcher: {pattern}");
+                        false
+                    }
+                }
+            } else {
+                // Simple exact match
+                pattern == target
+            }
+        }
+    }
+}
+
+/// Check if a string contains regex special characters (excluding pipe).
+fn has_regex_chars_except_pipe(s: &str) -> bool {
+    s.chars()
+        .any(|c| matches!(c, '^' | '$' | '.' | '+' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '\\' | '*'))
+}
+
+/// Check if a string contains any regex special characters.
+fn has_regex_chars(s: &str) -> bool {
+    s.chars()
+        .any(|c| matches!(c, '^' | '$' | '.' | '+' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '\\' | '*' | '|'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_matches_everything() {
+        assert!(matches(&Matcher::All, Some("Bash")));
+        assert!(matches(&Matcher::All, None));
+    }
+
+    #[test]
+    fn wildcard_matches_everything() {
+        let m = Matcher::Pattern("*".into());
+        assert!(matches(&m, Some("anything")));
+        assert!(matches(&m, None));
+    }
+
+    #[test]
+    fn empty_matches_everything() {
+        let m = Matcher::Pattern(String::new());
+        assert!(matches(&m, Some("anything")));
+        assert!(matches(&m, None));
+    }
+
+    #[test]
+    fn exact_match() {
+        let m = Matcher::Pattern("Bash".into());
+        assert!(matches(&m, Some("Bash")));
+        assert!(!matches(&m, Some("BashTool")));
+        assert!(!matches(&m, Some("bash")));
+        assert!(!matches(&m, None));
+    }
+
+    #[test]
+    fn pipe_separated() {
+        let m = Matcher::Pattern("Write|Edit|Bash".into());
+        assert!(matches(&m, Some("Write")));
+        assert!(matches(&m, Some("Edit")));
+        assert!(matches(&m, Some("Bash")));
+        assert!(!matches(&m, Some("ReadWrite")));
+        assert!(!matches(&m, Some("Delete")));
+    }
+
+    #[test]
+    fn regex_pattern() {
+        let m = Matcher::Pattern("^Write.*".into());
+        assert!(matches(&m, Some("Write")));
+        assert!(matches(&m, Some("WriteFile")));
+        assert!(!matches(&m, Some("ReadWrite")));
+    }
+
+    #[test]
+    fn case_sensitive() {
+        let m = Matcher::Pattern("bash".into());
+        assert!(matches(&m, Some("bash")));
+        assert!(!matches(&m, Some("Bash")));
+    }
+
+    #[test]
+    fn specific_pattern_no_target() {
+        let m = Matcher::Pattern("Bash".into());
+        assert!(!matches(&m, None));
+    }
+}

--- a/packages/forge/crates/forge-hooks/src/registry.rs
+++ b/packages/forge/crates/forge-hooks/src/registry.rs
@@ -239,7 +239,7 @@ impl HookRegistry {
 }
 
 /// Execute a single hook entry, building the appropriate executor.
-async fn execute_hook(
+pub(crate) async fn execute_hook(
     entry: &HookEntry,
     headers: &HashMap<String, String>,
     input: &HookInput,

--- a/packages/forge/crates/forge-hooks/src/registry.rs
+++ b/packages/forge/crates/forge-hooks/src/registry.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use forge_core::hook::{
-    AggregatedResult, HookConfig, HookDecision, HookEntry, HookEvent, HookInput, HookOutput,
+    AggregatedResult, HookConfig, HookEntry, HookEvent, HookInput, HookOutput,
     HookType, Matcher,
 };
 use tracing::{debug, info, warn};
@@ -173,7 +173,6 @@ impl HookRegistry {
     /// execution. This method is ergonomic for tests and single-owner contexts.
     pub async fn dispatch(&self, event: HookEvent, input: HookInput) -> AggregatedResult {
         use crate::matcher::matches;
-        use futures::future::join_all;
 
         let hooks = self.get(event);
         if hooks.is_empty() {
@@ -190,40 +189,9 @@ impl HookRegistry {
             return AggregatedResult::default();
         }
 
+        let total = hooks.len();
         let daemon_url = self.daemon_url().map(str::to_string);
-        debug!(
-            "Dispatching {:?}: {} matching hooks (of {} registered)",
-            event,
-            matching.len(),
-            hooks.len()
-        );
-
-        let futures: Vec<_> = matching
-            .iter()
-            .map(|hook| {
-                let input = input.clone();
-                let entry = hook.entry.clone();
-                let headers = hook.headers.clone();
-                let daemon = daemon_url.clone();
-                async move { execute_hook(&entry, &headers, &input, daemon.as_deref()).await }
-            })
-            .collect();
-
-        let outputs = join_all(futures).await;
-        let result = AggregatedResult::aggregate(outputs);
-
-        if result.decision == HookDecision::Block && !event.supports_blocking() {
-            warn!(
-                "Hook returned Block for {:?} which doesn't support blocking — treating as Allow",
-                event
-            );
-            return AggregatedResult {
-                decision: HookDecision::Allow,
-                ..result
-            };
-        }
-
-        result
+        crate::dispatch::run_hooks(matching, event, input, daemon_url, total).await
     }
 }
 

--- a/packages/forge/crates/forge-hooks/src/registry.rs
+++ b/packages/forge/crates/forge-hooks/src/registry.rs
@@ -19,11 +19,15 @@ pub enum HookSource {
     User,
 }
 
-/// A registered hook with its source and entry configuration.
+/// A registered hook with its source, entry configuration, and optional headers.
+/// Headers are stored separately from HookEntry (which is YAML-serializable) so
+/// that auth headers injected at runtime don't pollute the config schema.
 #[derive(Debug, Clone)]
 pub struct RegisteredHook {
     pub source: HookSource,
     pub entry: HookEntry,
+    /// Extra headers forwarded to HttpExecutor (e.g. daemon auth headers for built-ins).
+    pub headers: HashMap<String, String>,
 }
 
 /// Shared, hot-reloadable hook registry behind a tokio RwLock.
@@ -65,13 +69,10 @@ impl HookRegistry {
             timeout: Some(10),
             fire_and_forget: false,
         };
-        // Store headers alongside — we don't use them in the entry struct,
-        // but the HttpExecutor will use the URL. Headers are passed at
-        // execution time via the executor construction.
-        let _ = headers; // TODO: store headers for executor use
         self.hooks.entry(event).or_default().push(RegisteredHook {
             source: HookSource::Builtin,
             entry,
+            headers,
         });
         debug!("Registered built-in HTTP hook for {:?}: {}", event, url);
     }
@@ -131,6 +132,7 @@ impl HookRegistry {
                 registered.push(RegisteredHook {
                     source: HookSource::User,
                     entry: entry.clone(),
+                    headers: HashMap::new(),
                 });
                 count += 1;
             }
@@ -183,8 +185,9 @@ impl HookRegistry {
             .map(|hook| {
                 let input = input.clone();
                 let entry = hook.entry.clone();
+                let headers = hook.headers.clone();
                 let daemon = self.daemon_url.clone();
-                async move { execute_hook(&entry, &input, daemon.as_deref()).await }
+                async move { execute_hook(&entry, &headers, &input, daemon.as_deref()).await }
             })
             .collect();
 
@@ -235,6 +238,7 @@ impl HookRegistry {
 /// Execute a single hook entry, building the appropriate executor.
 async fn execute_hook(
     entry: &HookEntry,
+    headers: &HashMap<String, String>,
     input: &HookInput,
     daemon_url: Option<&str>,
 ) -> HookOutput {
@@ -252,7 +256,8 @@ async fn execute_hook(
                 Some(u) => u.clone(),
                 None => return HookOutput::error("HTTP hook missing 'url' field"),
             };
-            let executor = HttpExecutor::new(url, entry.timeout);
+            let executor = HttpExecutor::new(url, entry.timeout)
+                .with_headers(headers.clone());
             executor.execute(input).await
         }
         HookType::Prompt | HookType::Agent => {

--- a/packages/forge/crates/forge-hooks/src/registry.rs
+++ b/packages/forge/crates/forge-hooks/src/registry.rs
@@ -77,28 +77,31 @@ impl HookRegistry {
         debug!("Registered built-in HTTP hook for {:?}: {}", event, url);
     }
 
-    /// Register the 4 built-in Signet daemon HTTP hooks.
-    pub fn register_builtin(&mut self, base_url: &str) {
-        let empty = HashMap::new();
+    /// Register the 4 built-in Signet daemon HTTP hooks with auth headers.
+    ///
+    /// Pass the daemon auth headers (e.g. from `build_daemon_headers`) so that
+    /// the built-in hooks authenticate identically to direct daemon calls.
+    /// Pass `HashMap::new()` only in tests where auth is not needed.
+    pub fn register_builtin(&mut self, base_url: &str, headers: HashMap<String, String>) {
         self.register_builtin_http(
             HookEvent::SessionStart,
             &format!("{base_url}/api/hooks/session-start"),
-            empty.clone(),
+            headers.clone(),
         );
         self.register_builtin_http(
             HookEvent::UserPromptSubmit,
             &format!("{base_url}/api/hooks/user-prompt-submit"),
-            empty.clone(),
+            headers.clone(),
         );
         self.register_builtin_http(
             HookEvent::PreCompact,
             &format!("{base_url}/api/hooks/pre-compaction"),
-            empty.clone(),
+            headers.clone(),
         );
         self.register_builtin_http(
             HookEvent::SessionEnd,
             &format!("{base_url}/api/hooks/session-end"),
-            empty,
+            headers,
         );
         info!("Registered 4 built-in daemon hooks");
     }
@@ -285,7 +288,7 @@ mod tests {
     #[test]
     fn builtin_hooks_registered() {
         let mut reg = HookRegistry::new();
-        reg.register_builtin("http://localhost:3850");
+        reg.register_builtin("http://localhost:3850", HashMap::new());
         assert_eq!(reg.count(), 4);
 
         let start = reg.get(HookEvent::SessionStart);
@@ -296,7 +299,7 @@ mod tests {
     #[test]
     fn user_hooks_alongside_builtins() {
         let mut reg = HookRegistry::new();
-        reg.register_builtin("http://localhost:3850");
+        reg.register_builtin("http://localhost:3850", HashMap::new());
 
         let mut config = HookConfig::default();
         config.events.insert(
@@ -318,7 +321,7 @@ mod tests {
     #[test]
     fn user_http_suppresses_builtin() {
         let mut reg = HookRegistry::new();
-        reg.register_builtin("http://localhost:3850");
+        reg.register_builtin("http://localhost:3850", HashMap::new());
 
         let mut config = HookConfig::default();
         config.events.insert(
@@ -343,7 +346,7 @@ mod tests {
     #[test]
     fn reload_preserves_builtins() {
         let mut reg = HookRegistry::new();
-        reg.register_builtin("http://localhost:3850");
+        reg.register_builtin("http://localhost:3850", HashMap::new());
 
         let mut config = HookConfig::default();
         config.events.insert(

--- a/packages/forge/crates/forge-hooks/src/registry.rs
+++ b/packages/forge/crates/forge-hooks/src/registry.rs
@@ -1,0 +1,378 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use forge_core::hook::{
+    AggregatedResult, HookConfig, HookEntry, HookEvent, HookInput, HookOutput, HookType, Matcher,
+};
+use tracing::{debug, info, warn};
+
+use crate::executor::command::CommandExecutor;
+use crate::executor::daemon::DaemonExecutor;
+use crate::executor::http::HttpExecutor;
+use crate::executor::HookExecutor;
+use crate::matcher::matches;
+
+/// Source of a registered hook (built-in vs user-configured).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookSource {
+    Builtin,
+    User,
+}
+
+/// A registered hook with its source and entry configuration.
+#[derive(Debug, Clone)]
+pub struct RegisteredHook {
+    pub source: HookSource,
+    pub entry: HookEntry,
+}
+
+/// Shared, hot-reloadable hook registry behind a tokio RwLock.
+pub type SharedRegistry = Arc<tokio::sync::RwLock<HookRegistry>>;
+
+/// Central registry of all hooks, supporting built-in and user-configured hooks.
+pub struct HookRegistry {
+    hooks: HashMap<HookEvent, Vec<RegisteredHook>>,
+    daemon_url: Option<String>,
+}
+
+impl HookRegistry {
+    pub fn new() -> Self {
+        Self {
+            hooks: HashMap::new(),
+            daemon_url: None,
+        }
+    }
+
+    /// Set the daemon base URL for Prompt/Agent hook delegation.
+    pub fn with_daemon_url(mut self, url: String) -> Self {
+        self.daemon_url = Some(url);
+        self
+    }
+
+    /// Register a single built-in HTTP hook for a specific event.
+    pub fn register_builtin_http(
+        &mut self,
+        event: HookEvent,
+        url: &str,
+        headers: HashMap<String, String>,
+    ) {
+        let entry = HookEntry {
+            hook_type: HookType::Http,
+            command: None,
+            url: Some(url.to_string()),
+            prompt: None,
+            matcher: Matcher::All,
+            timeout: Some(10),
+            fire_and_forget: false,
+        };
+        // Store headers alongside — we don't use them in the entry struct,
+        // but the HttpExecutor will use the URL. Headers are passed at
+        // execution time via the executor construction.
+        let _ = headers; // TODO: store headers for executor use
+        self.hooks.entry(event).or_default().push(RegisteredHook {
+            source: HookSource::Builtin,
+            entry,
+        });
+        debug!("Registered built-in HTTP hook for {:?}: {}", event, url);
+    }
+
+    /// Register the 4 built-in Signet daemon HTTP hooks.
+    pub fn register_builtin(&mut self, base_url: &str) {
+        let empty = HashMap::new();
+        self.register_builtin_http(
+            HookEvent::SessionStart,
+            &format!("{base_url}/api/hooks/session-start"),
+            empty.clone(),
+        );
+        self.register_builtin_http(
+            HookEvent::UserPromptSubmit,
+            &format!("{base_url}/api/hooks/user-prompt-submit"),
+            empty.clone(),
+        );
+        self.register_builtin_http(
+            HookEvent::PreCompact,
+            &format!("{base_url}/api/hooks/pre-compaction"),
+            empty.clone(),
+        );
+        self.register_builtin_http(
+            HookEvent::SessionEnd,
+            &format!("{base_url}/api/hooks/session-end"),
+            empty,
+        );
+        info!("Registered 4 built-in daemon hooks");
+    }
+
+    /// Register hooks from user configuration (agent.yaml hooks section).
+    /// User HTTP hooks to the same URL as a built-in suppress the built-in.
+    pub fn register_from_config(&mut self, config: &HookConfig) {
+        let mut count = 0;
+
+        for (event, entries) in &config.events {
+            let registered = self.hooks.entry(*event).or_default();
+
+            for entry in entries {
+                // Check if a user HTTP hook targets the same URL as a built-in
+                if entry.hook_type == HookType::Http {
+                    if let Some(url) = &entry.url {
+                        let suppressed = registered.iter().position(|h| {
+                            h.source == HookSource::Builtin
+                                && h.entry.url.as_deref() == Some(url)
+                        });
+                        if let Some(idx) = suppressed {
+                            debug!(
+                                "User HTTP hook suppresses built-in for {:?}: {}",
+                                event, url
+                            );
+                            registered.remove(idx);
+                        }
+                    }
+                }
+
+                registered.push(RegisteredHook {
+                    source: HookSource::User,
+                    entry: entry.clone(),
+                });
+                count += 1;
+            }
+        }
+
+        if count > 0 {
+            info!("Registered {count} user hooks from config");
+        }
+    }
+
+    /// Hot-reload: clear user hooks and re-register from new config.
+    /// Built-in hooks are preserved.
+    pub fn reload(&mut self, config: &HookConfig) {
+        for hooks in self.hooks.values_mut() {
+            hooks.retain(|h| h.source == HookSource::Builtin);
+        }
+        self.register_from_config(config);
+        debug!("Hot-reloaded hook registry");
+    }
+
+    /// Dispatch hooks for an event: find matching hooks, run in parallel, aggregate.
+    pub async fn dispatch(&self, event: HookEvent, input: HookInput) -> AggregatedResult {
+        let hooks = match self.hooks.get(&event) {
+            Some(h) if !h.is_empty() => h,
+            _ => return AggregatedResult::default(),
+        };
+
+        let target = input.match_target().map(|s| s.to_string());
+
+        // Filter to matching hooks
+        let matching: Vec<_> = hooks
+            .iter()
+            .filter(|h| matches(&h.entry.matcher, target.as_deref()))
+            .collect();
+
+        if matching.is_empty() {
+            return AggregatedResult::default();
+        }
+
+        debug!(
+            "Dispatching {:?}: {} matching hooks (of {} registered)",
+            event,
+            matching.len(),
+            hooks.len()
+        );
+
+        // Build executors and run in parallel
+        let futures: Vec<_> = matching
+            .iter()
+            .map(|hook| {
+                let input = input.clone();
+                let entry = hook.entry.clone();
+                let daemon = self.daemon_url.clone();
+                async move { execute_hook(&entry, &input, daemon.as_deref()).await }
+            })
+            .collect();
+
+        let outputs = futures::future::join_all(futures).await;
+        let result = AggregatedResult::aggregate(outputs);
+
+        // Warn if blocking on an event that doesn't support it
+        if result.decision == forge_core::hook::HookDecision::Block
+            && !event.supports_blocking()
+        {
+            warn!(
+                "Hook returned Block for {:?} which doesn't support blocking — treating as Allow",
+                event
+            );
+            return AggregatedResult {
+                decision: forge_core::hook::HookDecision::Allow,
+                ..result
+            };
+        }
+
+        result
+    }
+
+    /// Get all registered hooks for a given event.
+    pub fn get(&self, event: HookEvent) -> &[RegisteredHook] {
+        self.hooks.get(&event).map(|v| v.as_slice()).unwrap_or(&[])
+    }
+
+    /// Total number of registered hooks across all events.
+    pub fn count(&self) -> usize {
+        self.hooks.values().map(|v| v.len()).sum()
+    }
+}
+
+impl Default for HookRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Access daemon_url for external callers (e.g. dispatch module).
+impl HookRegistry {
+    pub fn daemon_url(&self) -> Option<&str> {
+        self.daemon_url.as_deref()
+    }
+}
+
+/// Execute a single hook entry, building the appropriate executor.
+async fn execute_hook(
+    entry: &HookEntry,
+    input: &HookInput,
+    daemon_url: Option<&str>,
+) -> HookOutput {
+    match entry.hook_type {
+        HookType::Command => {
+            let cmd = match &entry.command {
+                Some(c) => c.clone(),
+                None => return HookOutput::error("Command hook missing 'command' field"),
+            };
+            let executor = CommandExecutor::new(cmd, entry.timeout, entry.fire_and_forget);
+            executor.execute(input).await
+        }
+        HookType::Http => {
+            let url = match &entry.url {
+                Some(u) => u.clone(),
+                None => return HookOutput::error("HTTP hook missing 'url' field"),
+            };
+            let executor = HttpExecutor::new(url, entry.timeout);
+            executor.execute(input).await
+        }
+        HookType::Prompt | HookType::Agent => {
+            let base = match daemon_url {
+                Some(u) => u.to_string(),
+                None => {
+                    warn!("Prompt/Agent hook requires daemon_url but none configured");
+                    return HookOutput::error(
+                        "Prompt/Agent hook requires daemon_url configuration",
+                    );
+                }
+            };
+            let agent = entry.hook_type == HookType::Agent;
+            let executor =
+                DaemonExecutor::new(base, entry.prompt.clone(), entry.timeout, agent);
+            executor.execute(input).await
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_hooks_registered() {
+        let mut reg = HookRegistry::new();
+        reg.register_builtin("http://localhost:3850");
+        assert_eq!(reg.count(), 4);
+
+        let start = reg.get(HookEvent::SessionStart);
+        assert_eq!(start.len(), 1);
+        assert_eq!(start[0].source, HookSource::Builtin);
+    }
+
+    #[test]
+    fn user_hooks_alongside_builtins() {
+        let mut reg = HookRegistry::new();
+        reg.register_builtin("http://localhost:3850");
+
+        let mut config = HookConfig::default();
+        config.events.insert(
+            HookEvent::PreToolUse,
+            vec![HookEntry {
+                hook_type: HookType::Command,
+                command: Some("echo test".into()),
+                url: None,
+                prompt: None,
+                matcher: Matcher::Pattern("Bash".into()),
+                timeout: Some(5),
+                fire_and_forget: false,
+            }],
+        );
+        reg.register_from_config(&config);
+        assert_eq!(reg.count(), 5);
+    }
+
+    #[test]
+    fn user_http_suppresses_builtin() {
+        let mut reg = HookRegistry::new();
+        reg.register_builtin("http://localhost:3850");
+
+        let mut config = HookConfig::default();
+        config.events.insert(
+            HookEvent::SessionStart,
+            vec![HookEntry {
+                hook_type: HookType::Http,
+                command: None,
+                url: Some("http://localhost:3850/api/hooks/session-start".into()),
+                prompt: None,
+                matcher: Matcher::All,
+                timeout: Some(15),
+                fire_and_forget: false,
+            }],
+        );
+        reg.register_from_config(&config);
+
+        let start = reg.get(HookEvent::SessionStart);
+        assert_eq!(start.len(), 1);
+        assert_eq!(start[0].source, HookSource::User);
+    }
+
+    #[test]
+    fn reload_preserves_builtins() {
+        let mut reg = HookRegistry::new();
+        reg.register_builtin("http://localhost:3850");
+
+        let mut config = HookConfig::default();
+        config.events.insert(
+            HookEvent::PreToolUse,
+            vec![HookEntry {
+                hook_type: HookType::Command,
+                command: Some("echo v1".into()),
+                url: None,
+                prompt: None,
+                matcher: Matcher::All,
+                timeout: None,
+                fire_and_forget: false,
+            }],
+        );
+        reg.register_from_config(&config);
+        assert_eq!(reg.count(), 5);
+
+        let mut new_config = HookConfig::default();
+        new_config.events.insert(
+            HookEvent::Stop,
+            vec![HookEntry {
+                hook_type: HookType::Command,
+                command: Some("echo v2".into()),
+                url: None,
+                prompt: None,
+                matcher: Matcher::All,
+                timeout: None,
+                fire_and_forget: false,
+            }],
+        );
+        reg.reload(&new_config);
+
+        assert_eq!(reg.count(), 5);
+        assert!(reg.get(HookEvent::PreToolUse).is_empty());
+        assert_eq!(reg.get(HookEvent::Stop).len(), 1);
+    }
+}

--- a/packages/forge/crates/forge-hooks/src/registry.rs
+++ b/packages/forge/crates/forge-hooks/src/registry.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use forge_core::hook::{
-    AggregatedResult, HookConfig, HookEntry, HookEvent, HookInput, HookOutput, HookType, Matcher,
+    HookConfig, HookEntry, HookEvent, HookInput, HookOutput, HookType, Matcher,
 };
 use tracing::{debug, info, warn};
 
@@ -10,7 +10,6 @@ use crate::executor::command::CommandExecutor;
 use crate::executor::daemon::DaemonExecutor;
 use crate::executor::http::HttpExecutor;
 use crate::executor::HookExecutor;
-use crate::matcher::matches;
 
 /// Source of a registered hook (built-in vs user-configured).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -156,64 +155,6 @@ impl HookRegistry {
         debug!("Hot-reloaded hook registry");
     }
 
-    /// Dispatch hooks for an event: find matching hooks, run in parallel, aggregate.
-    pub async fn dispatch(&self, event: HookEvent, input: HookInput) -> AggregatedResult {
-        let hooks = match self.hooks.get(&event) {
-            Some(h) if !h.is_empty() => h,
-            _ => return AggregatedResult::default(),
-        };
-
-        let target = input.match_target().map(|s| s.to_string());
-
-        // Filter to matching hooks
-        let matching: Vec<_> = hooks
-            .iter()
-            .filter(|h| matches(&h.entry.matcher, target.as_deref()))
-            .collect();
-
-        if matching.is_empty() {
-            return AggregatedResult::default();
-        }
-
-        debug!(
-            "Dispatching {:?}: {} matching hooks (of {} registered)",
-            event,
-            matching.len(),
-            hooks.len()
-        );
-
-        // Build executors and run in parallel
-        let futures: Vec<_> = matching
-            .iter()
-            .map(|hook| {
-                let input = input.clone();
-                let entry = hook.entry.clone();
-                let headers = hook.headers.clone();
-                let daemon = self.daemon_url.clone();
-                async move { execute_hook(&entry, &headers, &input, daemon.as_deref()).await }
-            })
-            .collect();
-
-        let outputs = futures::future::join_all(futures).await;
-        let result = AggregatedResult::aggregate(outputs);
-
-        // Warn if blocking on an event that doesn't support it
-        if result.decision == forge_core::hook::HookDecision::Block
-            && !event.supports_blocking()
-        {
-            warn!(
-                "Hook returned Block for {:?} which doesn't support blocking — treating as Allow",
-                event
-            );
-            return AggregatedResult {
-                decision: forge_core::hook::HookDecision::Allow,
-                ..result
-            };
-        }
-
-        result
-    }
-
     /// Get all registered hooks for a given event.
     pub fn get(&self, event: HookEvent) -> &[RegisteredHook] {
         self.hooks.get(&event).map(|v| v.as_slice()).unwrap_or(&[])
@@ -274,8 +215,8 @@ pub(crate) async fn execute_hook(
                 }
             };
             let agent = entry.hook_type == HookType::Agent;
-            let executor =
-                DaemonExecutor::new(base, entry.prompt.clone(), entry.timeout, agent);
+            let executor = DaemonExecutor::new(base, entry.prompt.clone(), entry.timeout, agent)
+                .with_headers(headers.clone());
             executor.execute(input).await
         }
     }

--- a/packages/forge/crates/forge-hooks/src/registry.rs
+++ b/packages/forge/crates/forge-hooks/src/registry.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use forge_core::hook::{
-    HookConfig, HookEntry, HookEvent, HookInput, HookOutput, HookType, Matcher,
+    AggregatedResult, HookConfig, HookDecision, HookEntry, HookEvent, HookInput, HookOutput,
+    HookType, Matcher,
 };
 use tracing::{debug, info, warn};
 
@@ -163,6 +164,66 @@ impl HookRegistry {
     /// Total number of registered hooks across all events.
     pub fn count(&self) -> usize {
         self.hooks.values().map(|v| v.len()).sum()
+    }
+
+    /// Dispatch hooks for an event directly on an owned/borrowed registry.
+    ///
+    /// For production code behind a `SharedRegistry` (Arc<RwLock<>>), prefer
+    /// the free `dispatch()` function which releases the read lock before async
+    /// execution. This method is ergonomic for tests and single-owner contexts.
+    pub async fn dispatch(&self, event: HookEvent, input: HookInput) -> AggregatedResult {
+        use crate::matcher::matches;
+        use futures::future::join_all;
+
+        let hooks = self.get(event);
+        if hooks.is_empty() {
+            return AggregatedResult::default();
+        }
+        let target = input.match_target().map(|s| s.to_string());
+        let matching: Vec<RegisteredHook> = hooks
+            .iter()
+            .filter(|h| matches(&h.entry.matcher, target.as_deref()))
+            .cloned()
+            .collect();
+
+        if matching.is_empty() {
+            return AggregatedResult::default();
+        }
+
+        let daemon_url = self.daemon_url().map(str::to_string);
+        debug!(
+            "Dispatching {:?}: {} matching hooks (of {} registered)",
+            event,
+            matching.len(),
+            hooks.len()
+        );
+
+        let futures: Vec<_> = matching
+            .iter()
+            .map(|hook| {
+                let input = input.clone();
+                let entry = hook.entry.clone();
+                let headers = hook.headers.clone();
+                let daemon = daemon_url.clone();
+                async move { execute_hook(&entry, &headers, &input, daemon.as_deref()).await }
+            })
+            .collect();
+
+        let outputs = join_all(futures).await;
+        let result = AggregatedResult::aggregate(outputs);
+
+        if result.decision == HookDecision::Block && !event.supports_blocking() {
+            warn!(
+                "Hook returned Block for {:?} which doesn't support blocking — treating as Allow",
+                event
+            );
+            return AggregatedResult {
+                decision: HookDecision::Allow,
+                ..result
+            };
+        }
+
+        result
     }
 }
 

--- a/packages/forge/crates/forge-hooks/tests/command_executor.rs
+++ b/packages/forge/crates/forge-hooks/tests/command_executor.rs
@@ -1,0 +1,238 @@
+use forge_core::hook::{HookDecision, HookInput};
+use forge_hooks::executor::command::CommandExecutor;
+use forge_hooks::executor::HookExecutor;
+use std::path::PathBuf;
+
+fn fixture(name: &str) -> String {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests/fixtures");
+    path.push(name);
+    path.to_string_lossy().to_string()
+}
+
+fn sample_input() -> HookInput {
+    HookInput::pre_tool_use("Bash", &serde_json::json!({"command": "ls"}), "tool-1")
+}
+
+mod exit_codes {
+    use super::*;
+
+    #[tokio::test]
+    async fn exit_0_returns_allow() {
+        let exec = CommandExecutor::new(fixture("allow-hook.sh"), None, false);
+        let out = exec.execute(&sample_input()).await;
+        assert_eq!(out.decision, HookDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn exit_0_parses_json_stdout() {
+        let exec = CommandExecutor::new(fixture("allow-hook.sh"), None, false);
+        let out = exec.execute(&sample_input()).await;
+        // allow-hook.sh outputs valid HookOutput JSON with decision "allow"
+        assert_eq!(out.decision, HookDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn exit_2_returns_block() {
+        let exec = CommandExecutor::new(fixture("block-hook.sh"), None, false);
+        let out = exec.execute(&sample_input()).await;
+        assert_eq!(out.decision, HookDecision::Block);
+    }
+
+    #[tokio::test]
+    async fn exit_2_captures_stderr_as_reason() {
+        let exec = CommandExecutor::new(fixture("block-hook.sh"), None, false);
+        let out = exec.execute(&sample_input()).await;
+        assert_eq!(out.decision, HookDecision::Block);
+        let reason = out.reason.expect("Block should have a reason");
+        assert!(
+            reason.contains("Blocked by test hook"),
+            "Expected stderr reason, got: {reason}"
+        );
+    }
+
+    #[tokio::test]
+    async fn exit_1_returns_error() {
+        let cmd = "exit 1".to_string();
+        let exec = CommandExecutor::new(cmd, None, false);
+        let out = exec.execute(&sample_input()).await;
+        assert_eq!(out.decision, HookDecision::Error);
+    }
+
+    #[tokio::test]
+    async fn exit_1_is_nonblocking() {
+        // Error should not be Block — it's a non-blocking failure
+        let cmd = "echo 'oops' >&2; exit 1".to_string();
+        let exec = CommandExecutor::new(cmd, None, false);
+        let out = exec.execute(&sample_input()).await;
+        assert_eq!(out.decision, HookDecision::Error);
+        assert_ne!(out.decision, HookDecision::Block);
+    }
+
+    #[tokio::test]
+    async fn exit_137_returns_error() {
+        let cmd = "exit 137".to_string();
+        let exec = CommandExecutor::new(cmd, None, false);
+        let out = exec.execute(&sample_input()).await;
+        assert_eq!(out.decision, HookDecision::Error);
+    }
+}
+
+mod timeout {
+    use super::*;
+
+    #[tokio::test]
+    async fn timeout_kills_subprocess_returns_error() {
+        let exec = CommandExecutor::new(fixture("slow-hook.sh"), Some(1), false);
+        let start = std::time::Instant::now();
+        let out = exec.execute(&sample_input()).await;
+        let elapsed = start.elapsed();
+
+        assert_eq!(out.decision, HookDecision::Error);
+        let reason = out.reason.expect("Timeout should have a reason");
+        assert!(
+            reason.contains("timed out"),
+            "Expected timeout reason, got: {reason}"
+        );
+        // Should complete in ~1s, not 30s
+        assert!(
+            elapsed.as_secs() < 5,
+            "Timeout should have killed the process, took {:?}",
+            elapsed
+        );
+    }
+}
+
+mod async_mode {
+    use super::*;
+
+    #[tokio::test]
+    async fn fire_and_forget_returns_immediately() {
+        // async-hook.sh sleeps 1s, but fire_and_forget should return instantly
+        let exec = CommandExecutor::new(fixture("async-hook.sh"), None, true);
+        let start = std::time::Instant::now();
+        let out = exec.execute(&sample_input()).await;
+        let elapsed = start.elapsed();
+
+        assert_eq!(out.decision, HookDecision::Allow);
+        assert!(
+            elapsed.as_millis() < 500,
+            "Async mode should return immediately, took {:?}",
+            elapsed
+        );
+    }
+
+    #[tokio::test]
+    async fn fire_and_forget_slow_hook_does_not_block() {
+        let exec = CommandExecutor::new(fixture("slow-hook.sh"), None, true);
+        let start = std::time::Instant::now();
+        let out = exec.execute(&sample_input()).await;
+        let elapsed = start.elapsed();
+
+        assert_eq!(out.decision, HookDecision::Allow);
+        assert!(
+            elapsed.as_secs() < 2,
+            "Async slow hook should not block, took {:?}",
+            elapsed
+        );
+    }
+}
+
+mod stdout_parsing {
+    use super::*;
+
+    #[tokio::test]
+    async fn malformed_json_falls_back_to_plain_text_inject() {
+        let cmd = r#"echo 'not valid json at all'"#.to_string();
+        let exec = CommandExecutor::new(cmd, None, false);
+        let out = exec.execute(&sample_input()).await;
+        assert_eq!(out.decision, HookDecision::Allow);
+        // Plain text should be injected
+        let inject = out.inject.expect("Non-JSON stdout should become inject text");
+        assert_eq!(inject, "not valid json at all");
+    }
+
+    #[tokio::test]
+    async fn empty_stdout_returns_default_allow() {
+        let cmd = "true".to_string(); // exit 0, no output
+        let exec = CommandExecutor::new(cmd, None, false);
+        let out = exec.execute(&sample_input()).await;
+        assert_eq!(out.decision, HookDecision::Allow);
+        assert!(out.inject.is_none(), "Empty stdout should not produce inject");
+    }
+
+    #[tokio::test]
+    async fn valid_json_hook_output_parsed() {
+        let cmd = r#"echo '{"decision":"allow","inject":"hello from hook","data":{"key":"val"}}'"#
+            .to_string();
+        let exec = CommandExecutor::new(cmd, None, false);
+        let out = exec.execute(&sample_input()).await;
+        assert_eq!(out.decision, HookDecision::Allow);
+        assert_eq!(out.inject.as_deref(), Some("hello from hook"));
+        assert_eq!(out.data["key"], "val");
+    }
+
+    #[tokio::test]
+    async fn large_stdout_handled_without_panic() {
+        // Generate ~1MB of output
+        let cmd = "head -c 1048576 /dev/urandom | base64; exit 0".to_string();
+        let exec = CommandExecutor::new(cmd, Some(10), false);
+        let out = exec.execute(&sample_input()).await;
+        // Should not panic — either parses or falls back
+        assert_eq!(out.decision, HookDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn large_stderr_handled_without_panic() {
+        let cmd = "head -c 1048576 /dev/urandom | base64 >&2; exit 1".to_string();
+        let exec = CommandExecutor::new(cmd, Some(10), false);
+        let out = exec.execute(&sample_input()).await;
+        assert_eq!(out.decision, HookDecision::Error);
+    }
+}
+
+mod stdin_piping {
+    use super::*;
+
+    #[tokio::test]
+    async fn hook_receives_correct_json_on_stdin() {
+        // echo-hook.sh cats stdin back to stdout
+        let exec = CommandExecutor::new(fixture("echo-hook.sh"), None, false);
+        let input = HookInput::pre_tool_use(
+            "Bash",
+            &serde_json::json!({"command": "ls -la"}),
+            "tool-42",
+        );
+        let out = exec.execute(&input).await;
+
+        // The echoed input should be in inject (since it's valid JSON but not HookOutput format)
+        // or parsed as data. Either way, we can verify the tool name appears.
+        assert_eq!(out.decision, HookDecision::Allow);
+        // The echo-hook returns the input JSON, which has an "event" field.
+        // It won't parse as HookOutput (no "decision" field), so it falls back
+        // to raw JSON in inject or data.
+        let data_str = serde_json::to_string(&out.data).unwrap_or_default();
+        let inject_str = out.inject.unwrap_or_default();
+        let combined = format!("{data_str}{inject_str}");
+        assert!(
+            combined.contains("Bash") || combined.contains("tool-42"),
+            "Hook should have received the input JSON containing tool info"
+        );
+    }
+
+    #[tokio::test]
+    async fn session_start_input_piped_correctly() {
+        let exec = CommandExecutor::new(fixture("echo-hook.sh"), None, false);
+        let input = HookInput::session_start("sess-123", Some("/home/user"));
+        let out = exec.execute(&input).await;
+        assert_eq!(out.decision, HookDecision::Allow);
+
+        let data_str = serde_json::to_string(&out.data).unwrap_or_default();
+        let inject_str = out.inject.unwrap_or_default();
+        let combined = format!("{data_str}{inject_str}");
+        assert!(
+            combined.contains("sess-123"),
+            "Session ID should be in piped input"
+        );
+    }
+}

--- a/packages/forge/crates/forge-hooks/tests/config.rs
+++ b/packages/forge/crates/forge-hooks/tests/config.rs
@@ -1,0 +1,407 @@
+use forge_core::hook::{HookConfig, HookEvent, HookType, Matcher};
+
+mod yaml_parsing {
+    use super::*;
+
+    #[test]
+    fn valid_hooks_section_parses_all_fields() {
+        let yaml = r#"
+PreToolUse:
+  - type: command
+    command: "~/.agents/hooks/validate.sh"
+    matcher: "Bash|Shell"
+    timeout: 5
+    async: false
+  - type: http
+    url: "http://localhost:3850/api/hooks/check"
+    timeout: 10
+"#;
+        let config: HookConfig = serde_yml::from_str(yaml).unwrap();
+
+        let entries = config.events.get(&HookEvent::PreToolUse).unwrap();
+        assert_eq!(entries.len(), 2);
+
+        let first = &entries[0];
+        assert_eq!(first.hook_type, HookType::Command);
+        assert_eq!(first.command.as_deref(), Some("~/.agents/hooks/validate.sh"));
+        assert_eq!(first.timeout, Some(5));
+        assert!(!first.fire_and_forget);
+
+        if let Matcher::Pattern(ref p) = first.matcher {
+            assert_eq!(p, "Bash|Shell");
+        } else {
+            panic!("Expected Pattern matcher, got All");
+        }
+
+        let second = &entries[1];
+        assert_eq!(second.hook_type, HookType::Http);
+        assert_eq!(
+            second.url.as_deref(),
+            Some("http://localhost:3850/api/hooks/check")
+        );
+        assert_eq!(second.timeout, Some(10));
+    }
+
+    #[test]
+    fn multiple_events_parsed() {
+        let yaml = r#"
+PreToolUse:
+  - type: command
+    command: "echo pre"
+PostToolUse:
+  - type: command
+    command: "echo post"
+    async: true
+Stop:
+  - type: http
+    url: "http://localhost:3850/api/hooks/stop"
+"#;
+        let config: HookConfig = serde_yml::from_str(yaml).unwrap();
+
+        assert!(config.events.contains_key(&HookEvent::PreToolUse));
+        assert!(config.events.contains_key(&HookEvent::PostToolUse));
+        assert!(config.events.contains_key(&HookEvent::Stop));
+        assert_eq!(config.events.len(), 3);
+
+        let post = &config.events[&HookEvent::PostToolUse][0];
+        assert!(post.fire_and_forget);
+    }
+
+    #[test]
+    fn empty_hooks_section_parses_to_empty() {
+        let yaml = "{}";
+        let config: HookConfig = serde_yml::from_str(yaml).unwrap();
+        assert!(config.events.is_empty());
+    }
+
+    #[test]
+    fn missing_hooks_returns_default() {
+        let config = HookConfig::default();
+        assert!(config.events.is_empty());
+    }
+}
+
+mod hook_entry_defaults {
+    use super::*;
+
+    #[test]
+    fn omitted_timeout_is_none() {
+        let yaml = r#"
+PreToolUse:
+  - type: command
+    command: "true"
+"#;
+        let config: HookConfig = serde_yml::from_str(yaml).unwrap();
+        let entry = &config.events[&HookEvent::PreToolUse][0];
+        assert_eq!(entry.timeout, None);
+    }
+
+    #[test]
+    fn omitted_async_defaults_to_false() {
+        let yaml = r#"
+PreToolUse:
+  - type: command
+    command: "true"
+"#;
+        let config: HookConfig = serde_yml::from_str(yaml).unwrap();
+        let entry = &config.events[&HookEvent::PreToolUse][0];
+        assert!(!entry.fire_and_forget);
+    }
+
+    #[test]
+    fn omitted_matcher_defaults_to_all() {
+        let yaml = r#"
+PreToolUse:
+  - type: command
+    command: "true"
+"#;
+        let config: HookConfig = serde_yml::from_str(yaml).unwrap();
+        let entry = &config.events[&HookEvent::PreToolUse][0];
+        assert_eq!(entry.matcher, Matcher::All);
+    }
+
+    #[test]
+    fn hook_with_only_required_fields() {
+        let yaml = r#"
+Stop:
+  - type: command
+    command: "echo done"
+"#;
+        let config: HookConfig = serde_yml::from_str(yaml).unwrap();
+        let entry = &config.events[&HookEvent::Stop][0];
+        assert_eq!(entry.hook_type, HookType::Command);
+        assert_eq!(entry.command.as_deref(), Some("echo done"));
+        assert_eq!(entry.url, None);
+        assert_eq!(entry.prompt, None);
+        assert_eq!(entry.timeout, None);
+        assert!(!entry.fire_and_forget);
+    }
+}
+
+mod matcher_syntax_variants {
+    use super::*;
+
+    #[test]
+    fn exact_string() {
+        let yaml = r#"
+PreToolUse:
+  - type: command
+    command: "true"
+    matcher: "Bash"
+"#;
+        let config: HookConfig = serde_yml::from_str(yaml).unwrap();
+        let entry = &config.events[&HookEvent::PreToolUse][0];
+        assert_eq!(entry.matcher, Matcher::Pattern("Bash".into()));
+    }
+
+    #[test]
+    fn pipe_separated() {
+        let yaml = r#"
+PreToolUse:
+  - type: command
+    command: "true"
+    matcher: "Write|Edit|Bash"
+"#;
+        let config: HookConfig = serde_yml::from_str(yaml).unwrap();
+        let entry = &config.events[&HookEvent::PreToolUse][0];
+        assert_eq!(entry.matcher, Matcher::Pattern("Write|Edit|Bash".into()));
+    }
+
+    #[test]
+    fn regex_pattern() {
+        let yaml = r#"
+PreToolUse:
+  - type: command
+    command: "true"
+    matcher: "^Write.*"
+"#;
+        let config: HookConfig = serde_yml::from_str(yaml).unwrap();
+        let entry = &config.events[&HookEvent::PreToolUse][0];
+        assert_eq!(entry.matcher, Matcher::Pattern("^Write.*".into()));
+    }
+
+    #[test]
+    fn wildcard() {
+        let yaml = r#"
+PreToolUse:
+  - type: command
+    command: "true"
+    matcher: "*"
+"#;
+        let config: HookConfig = serde_yml::from_str(yaml).unwrap();
+        let entry = &config.events[&HookEvent::PreToolUse][0];
+        assert_eq!(entry.matcher, Matcher::Pattern("*".into()));
+    }
+}
+
+mod all_hook_types {
+    use super::*;
+
+    #[test]
+    fn command_type() {
+        let yaml = r#"
+PreToolUse:
+  - type: command
+    command: "echo test"
+"#;
+        let config: HookConfig = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(
+            config.events[&HookEvent::PreToolUse][0].hook_type,
+            HookType::Command
+        );
+    }
+
+    #[test]
+    fn http_type() {
+        let yaml = r#"
+PreToolUse:
+  - type: http
+    url: "http://localhost:3850/hook"
+"#;
+        let config: HookConfig = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(
+            config.events[&HookEvent::PreToolUse][0].hook_type,
+            HookType::Http
+        );
+    }
+
+    #[test]
+    fn prompt_type() {
+        let yaml = r#"
+PreToolUse:
+  - type: prompt
+    prompt: "Is this safe? {{tool_input}}"
+"#;
+        let config: HookConfig = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(
+            config.events[&HookEvent::PreToolUse][0].hook_type,
+            HookType::Prompt
+        );
+        assert_eq!(
+            config.events[&HookEvent::PreToolUse][0].prompt.as_deref(),
+            Some("Is this safe? {{tool_input}}")
+        );
+    }
+
+    #[test]
+    fn agent_type() {
+        let yaml = r#"
+PreToolUse:
+  - type: agent
+    prompt: "Evaluate this tool call"
+"#;
+        let config: HookConfig = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(
+            config.events[&HookEvent::PreToolUse][0].hook_type,
+            HookType::Agent
+        );
+    }
+
+    #[test]
+    fn invalid_type_fails() {
+        let yaml = r#"
+PreToolUse:
+  - type: invalid_type
+    command: "echo"
+"#;
+        let result = serde_yml::from_str::<HookConfig>(yaml);
+        assert!(
+            result.is_err(),
+            "Invalid hook type should produce parse error"
+        );
+    }
+}
+
+mod all_event_names {
+    use super::*;
+
+    #[test]
+    fn all_tier1_events_parse() {
+        let yaml = r#"
+SessionStart:
+  - type: command
+    command: "echo start"
+SessionEnd:
+  - type: command
+    command: "echo end"
+UserPromptSubmit:
+  - type: command
+    command: "echo prompt"
+PreCompact:
+  - type: command
+    command: "echo pre-compact"
+PostCompact:
+  - type: command
+    command: "echo post-compact"
+PreToolUse:
+  - type: command
+    command: "echo pre-tool"
+PostToolUse:
+  - type: command
+    command: "echo post-tool"
+Stop:
+  - type: command
+    command: "echo stop"
+"#;
+        let config: HookConfig = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(config.events.len(), 8);
+        assert!(config.events.contains_key(&HookEvent::SessionStart));
+        assert!(config.events.contains_key(&HookEvent::SessionEnd));
+        assert!(config.events.contains_key(&HookEvent::UserPromptSubmit));
+        assert!(config.events.contains_key(&HookEvent::PreCompact));
+        assert!(config.events.contains_key(&HookEvent::PostCompact));
+        assert!(config.events.contains_key(&HookEvent::PreToolUse));
+        assert!(config.events.contains_key(&HookEvent::PostToolUse));
+        assert!(config.events.contains_key(&HookEvent::Stop));
+    }
+
+    #[test]
+    fn tier2_events_parse() {
+        let yaml = r#"
+PostToolUseFailure:
+  - type: command
+    command: "echo failure"
+PermissionRequest:
+  - type: command
+    command: "echo perm-req"
+PermissionDenied:
+  - type: command
+    command: "echo denied"
+Notification:
+  - type: command
+    command: "echo notify"
+"#;
+        let config: HookConfig = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(config.events.len(), 4);
+        assert!(config.events.contains_key(&HookEvent::PostToolUseFailure));
+        assert!(config.events.contains_key(&HookEvent::PermissionRequest));
+        assert!(config.events.contains_key(&HookEvent::PermissionDenied));
+        assert!(config.events.contains_key(&HookEvent::Notification));
+    }
+}
+
+mod serialization_roundtrip {
+    use super::*;
+
+    #[test]
+    fn hook_config_roundtrips_through_yaml() {
+        let yaml = r#"
+PreToolUse:
+  - type: command
+    command: "echo test"
+    matcher: "Bash"
+    timeout: 5
+    async: true
+"#;
+        let config: HookConfig = serde_yml::from_str(yaml).unwrap();
+        let serialized = serde_yml::to_string(&config).unwrap();
+        let reparsed: HookConfig = serde_yml::from_str(&serialized).unwrap();
+
+        let entry = &reparsed.events[&HookEvent::PreToolUse][0];
+        assert_eq!(entry.hook_type, HookType::Command);
+        assert_eq!(entry.command.as_deref(), Some("echo test"));
+        assert_eq!(entry.timeout, Some(5));
+        assert!(entry.fire_and_forget);
+    }
+}
+
+mod hook_event_properties {
+    use super::*;
+
+    #[test]
+    fn supports_blocking_correct() {
+        // Only PreToolUse, UserPromptSubmit, PermissionRequest support blocking
+        assert!(HookEvent::PreToolUse.supports_blocking());
+        assert!(HookEvent::UserPromptSubmit.supports_blocking());
+        assert!(HookEvent::PermissionRequest.supports_blocking());
+
+        // All others are observe-only
+        assert!(!HookEvent::PostToolUse.supports_blocking());
+        assert!(!HookEvent::PostToolUseFailure.supports_blocking());
+        assert!(!HookEvent::SessionStart.supports_blocking());
+        assert!(!HookEvent::SessionEnd.supports_blocking());
+        assert!(!HookEvent::PreCompact.supports_blocking());
+        assert!(!HookEvent::PostCompact.supports_blocking());
+        assert!(!HookEvent::Stop.supports_blocking());
+        assert!(!HookEvent::PermissionDenied.supports_blocking());
+        assert!(!HookEvent::Notification.supports_blocking());
+        assert!(!HookEvent::SubagentStart.supports_blocking());
+        assert!(!HookEvent::CwdChanged.supports_blocking());
+    }
+
+    #[test]
+    fn hook_decision_default_is_allow() {
+        use forge_core::hook::HookDecision;
+        assert_eq!(HookDecision::default(), HookDecision::Allow);
+    }
+
+    #[test]
+    fn hook_output_default_is_allow() {
+        use forge_core::hook::HookOutput;
+        let out = HookOutput::default();
+        assert_eq!(out.decision, forge_core::hook::HookDecision::Allow);
+        assert!(out.reason.is_none());
+        assert!(out.inject.is_none());
+        assert!(out.data.is_null());
+    }
+}

--- a/packages/forge/crates/forge-hooks/tests/daemon_executor.rs
+++ b/packages/forge/crates/forge-hooks/tests/daemon_executor.rs
@@ -1,0 +1,323 @@
+use forge_core::hook::{HookDecision, HookInput};
+use forge_hooks::executor::daemon::DaemonExecutor;
+use forge_hooks::executor::HookExecutor;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+fn sample_input() -> HookInput {
+    HookInput::pre_tool_use("Bash", &serde_json::json!({"command": "ls -la"}), "tool-1")
+}
+
+/// Start a mock server returning the given body. Also captures the request
+/// and returns it via a oneshot channel so tests can inspect the POST.
+async fn mock_daemon(body: &str) -> (String, tokio::sync::oneshot::Receiver<String>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let body = body.to_string();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    tokio::spawn(async move {
+        if let Ok((mut stream, _)) = listener.accept().await {
+            let mut buf = vec![0u8; 65536];
+            let n = stream.read(&mut buf).await.unwrap_or(0);
+            let raw = String::from_utf8_lossy(&buf[..n]).to_string();
+
+            // Capture the full HTTP request (including path) for endpoint checks
+            let _ = tx.send(raw);
+
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = stream.write_all(response.as_bytes()).await;
+            let _ = stream.shutdown().await;
+        }
+    });
+
+    (format!("http://127.0.0.1:{}", addr.port()), rx)
+}
+
+/// Mock server that never responds (for timeout tests).
+async fn hanging_server() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        if let Ok((mut stream, _)) = listener.accept().await {
+            let mut buf = vec![0u8; 8192];
+            let _ = stream.read(&mut buf).await;
+            tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+            drop(stream);
+        }
+    });
+
+    format!("http://127.0.0.1:{}", addr.port())
+}
+
+mod ok_field {
+    use super::*;
+
+    #[tokio::test]
+    async fn ok_true_returns_allow() {
+        let (url, _rx) = mock_daemon(r#"{"ok": true}"#).await;
+        let exec = DaemonExecutor::new(url, None, Some(5), false);
+        let out = exec.execute(&sample_input()).await;
+        assert_eq!(out.decision, HookDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn ok_false_returns_block() {
+        let (url, _rx) = mock_daemon(r#"{"ok": false}"#).await;
+        let exec = DaemonExecutor::new(url, None, Some(5), false);
+        let out = exec.execute(&sample_input()).await;
+        assert_eq!(out.decision, HookDecision::Block);
+    }
+
+    #[tokio::test]
+    async fn ok_false_with_reason() {
+        let (url, _rx) =
+            mock_daemon(r#"{"ok": false, "reason": "Dangerous command detected"}"#).await;
+        let exec = DaemonExecutor::new(url, None, Some(5), false);
+        let out = exec.execute(&sample_input()).await;
+        assert_eq!(out.decision, HookDecision::Block);
+        assert_eq!(out.reason.as_deref(), Some("Dangerous command detected"));
+    }
+
+    #[tokio::test]
+    async fn ok_false_default_reason() {
+        let (url, _rx) = mock_daemon(r#"{"ok": false}"#).await;
+        let exec = DaemonExecutor::new(url, None, Some(5), false);
+        let out = exec.execute(&sample_input()).await;
+        assert_eq!(out.decision, HookDecision::Block);
+        assert_eq!(
+            out.reason.as_deref(),
+            Some("Denied by daemon evaluation")
+        );
+    }
+
+    #[tokio::test]
+    async fn ok_true_with_inject() {
+        let (url, _rx) =
+            mock_daemon(r#"{"ok": true, "inject": "relevant context here"}"#).await;
+        let exec = DaemonExecutor::new(url, None, Some(5), false);
+        let out = exec.execute(&sample_input()).await;
+        assert_eq!(out.decision, HookDecision::Allow);
+        assert_eq!(out.inject.as_deref(), Some("relevant context here"));
+    }
+}
+
+mod interpolation {
+    use super::*;
+
+    #[tokio::test]
+    async fn tool_name_interpolated() {
+        let (url, rx) = mock_daemon(r#"{"ok": true}"#).await;
+        let exec = DaemonExecutor::new(
+            url,
+            Some("Tool is {{tool_name}}".to_string()),
+            Some(5),
+            false,
+        );
+        let out = exec.execute(&sample_input()).await;
+        assert_eq!(out.decision, HookDecision::Allow);
+
+        let req = rx.await.unwrap();
+        assert!(
+            req.contains("Tool is Bash"),
+            "Expected interpolated tool_name, got: {req}"
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_input_interpolated() {
+        let (url, rx) = mock_daemon(r#"{"ok": true}"#).await;
+        let exec = DaemonExecutor::new(
+            url,
+            Some("Input: {{tool_input}}".to_string()),
+            Some(5),
+            false,
+        );
+        let input = HookInput::pre_tool_use(
+            "Bash",
+            &serde_json::json!({"command": "rm -rf /"}),
+            "t-1",
+        );
+        let _ = exec.execute(&input).await;
+
+        let req = rx.await.unwrap();
+        // toolInput from the payload should be interpolated
+        assert!(
+            req.contains("rm -rf"),
+            "Expected interpolated tool_input, got: {req}"
+        );
+    }
+
+    #[tokio::test]
+    async fn event_interpolated() {
+        let (url, rx) = mock_daemon(r#"{"ok": true}"#).await;
+        let exec = DaemonExecutor::new(
+            url,
+            Some("Event: {{event}}".to_string()),
+            Some(5),
+            false,
+        );
+        let _ = exec.execute(&sample_input()).await;
+
+        let req = rx.await.unwrap();
+        assert!(
+            req.contains("Event: PreToolUse"),
+            "Expected interpolated event, got: {req}"
+        );
+    }
+
+    #[tokio::test]
+    async fn payload_interpolated() {
+        let (url, rx) = mock_daemon(r#"{"ok": true}"#).await;
+        let exec = DaemonExecutor::new(
+            url,
+            Some("Payload: {{payload}}".to_string()),
+            Some(5),
+            false,
+        );
+        let _ = exec.execute(&sample_input()).await;
+
+        let req = rx.await.unwrap();
+        assert!(
+            req.contains("toolName"),
+            "Expected payload JSON in request, got: {req}"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_template_sends_raw_input() {
+        let (url, rx) = mock_daemon(r#"{"ok": true}"#).await;
+        let exec = DaemonExecutor::new(url, None, Some(5), false);
+        let _ = exec.execute(&sample_input()).await;
+
+        let req = rx.await.unwrap();
+        // Without a template, the prompt field is the serialized HookInput
+        assert!(
+            req.contains("PreToolUse"),
+            "Expected raw input with event, got: {req}"
+        );
+        assert!(
+            req.contains("Bash"),
+            "Expected raw input with tool_name, got: {req}"
+        );
+    }
+}
+
+mod endpoint {
+    use super::*;
+
+    #[tokio::test]
+    async fn prompt_uses_prompt_eval_endpoint() {
+        let (url, rx) = mock_daemon(r#"{"ok": true}"#).await;
+        let exec = DaemonExecutor::new(url, None, Some(5), false);
+        let _ = exec.execute(&sample_input()).await;
+
+        let req = rx.await.unwrap();
+        assert!(
+            req.contains("/api/hooks/prompt-eval"),
+            "Expected prompt-eval path, got first line: {}",
+            req.lines().next().unwrap_or("")
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_uses_agent_eval_endpoint() {
+        let (url, rx) = mock_daemon(r#"{"ok": true}"#).await;
+        let exec = DaemonExecutor::new(url, None, Some(5), true);
+        let _ = exec.execute(&sample_input()).await;
+
+        let req = rx.await.unwrap();
+        assert!(
+            req.contains("/api/hooks/agent-eval"),
+            "Expected agent-eval path, got first line: {}",
+            req.lines().next().unwrap_or("")
+        );
+    }
+}
+
+mod errors {
+    use super::*;
+
+    #[tokio::test]
+    async fn timeout_returns_error() {
+        let url = hanging_server().await;
+        let exec = DaemonExecutor::new(url, None, Some(1), false);
+        let start = std::time::Instant::now();
+        let out = exec.execute(&sample_input()).await;
+        let elapsed = start.elapsed();
+
+        assert_eq!(out.decision, HookDecision::Error);
+        let reason = out.reason.expect("Timeout should have a reason");
+        assert!(
+            reason.contains("timed out") || reason.contains("failed"),
+            "Expected timeout reason, got: {reason}"
+        );
+        assert!(
+            elapsed.as_secs() < 5,
+            "Should time out quickly, took {:?}",
+            elapsed
+        );
+    }
+
+    #[tokio::test]
+    async fn connection_refused_returns_error() {
+        let exec = DaemonExecutor::new(
+            "http://127.0.0.1:1".to_string(),
+            None,
+            Some(2),
+            false,
+        );
+        let out = exec.execute(&sample_input()).await;
+
+        assert_eq!(out.decision, HookDecision::Error);
+        assert!(
+            out.reason.is_some(),
+            "Connection error should have a reason"
+        );
+    }
+}
+
+mod response_parsing {
+    use super::*;
+
+    #[tokio::test]
+    async fn empty_response_returns_allow() {
+        let (url, _rx) = mock_daemon("").await;
+        let exec = DaemonExecutor::new(url, None, Some(5), false);
+        let out = exec.execute(&sample_input()).await;
+        assert_eq!(out.decision, HookDecision::Allow);
+        assert!(out.inject.is_none());
+    }
+
+    #[tokio::test]
+    async fn plain_text_response_becomes_inject() {
+        let (url, _rx) = mock_daemon("some plain text").await;
+        let exec = DaemonExecutor::new(url, None, Some(5), false);
+        let out = exec.execute(&sample_input()).await;
+        assert_eq!(out.decision, HookDecision::Allow);
+        assert_eq!(out.inject.as_deref(), Some("some plain text"));
+    }
+
+    #[tokio::test]
+    async fn missing_ok_field_defaults_to_allow() {
+        let (url, _rx) = mock_daemon(r#"{"inject": "context"}"#).await;
+        let exec = DaemonExecutor::new(url, None, Some(5), false);
+        let out = exec.execute(&sample_input()).await;
+        assert_eq!(out.decision, HookDecision::Allow);
+        assert_eq!(out.inject.as_deref(), Some("context"));
+    }
+
+    #[tokio::test]
+    async fn data_preserved_in_output() {
+        let (url, _rx) =
+            mock_daemon(r#"{"ok": true, "inject": "ctx", "score": 0.95}"#).await;
+        let exec = DaemonExecutor::new(url, None, Some(5), false);
+        let out = exec.execute(&sample_input()).await;
+        assert_eq!(out.decision, HookDecision::Allow);
+        assert_eq!(out.data["score"], 0.95);
+    }
+}

--- a/packages/forge/crates/forge-hooks/tests/dispatch.rs
+++ b/packages/forge/crates/forge-hooks/tests/dispatch.rs
@@ -1,0 +1,379 @@
+use forge_core::hook::{
+    AggregatedResult, HookConfig, HookDecision, HookEntry, HookEvent, HookInput, HookOutput,
+    HookType, Matcher,
+};
+use forge_hooks::HookRegistry;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+fn fixture(name: &str) -> String {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests/fixtures");
+    path.push(name);
+    path.to_string_lossy().to_string()
+}
+
+fn sample_input() -> HookInput {
+    HookInput::pre_tool_use("Bash", &serde_json::json!({"command": "ls"}), "tool-1")
+}
+
+fn make_entry(cmd: &str) -> HookEntry {
+    HookEntry {
+        hook_type: HookType::Command,
+        command: Some(cmd.to_string()),
+        url: None,
+        prompt: None,
+        matcher: Matcher::All,
+        timeout: None,
+        fire_and_forget: false,
+    }
+}
+
+mod aggregation {
+    use super::*;
+
+    #[test]
+    fn empty_outputs_returns_allow() {
+        let result = AggregatedResult::aggregate(vec![]);
+        assert_eq!(result.decision, HookDecision::Allow);
+    }
+
+    #[test]
+    fn single_allow() {
+        let result = AggregatedResult::aggregate(vec![HookOutput::allow()]);
+        assert_eq!(result.decision, HookDecision::Allow);
+    }
+
+    #[test]
+    fn single_block() {
+        let result =
+            AggregatedResult::aggregate(vec![HookOutput::block("reason")]);
+        assert_eq!(result.decision, HookDecision::Block);
+        assert_eq!(result.reason.as_deref(), Some("reason"));
+    }
+
+    #[test]
+    fn any_block_results_in_block() {
+        let result = AggregatedResult::aggregate(vec![
+            HookOutput::allow(),
+            HookOutput::allow(),
+            HookOutput::block("blocked"),
+        ]);
+        assert_eq!(result.decision, HookDecision::Block);
+    }
+
+    #[test]
+    fn all_error_no_allow_returns_error() {
+        let result = AggregatedResult::aggregate(vec![
+            HookOutput::error("err1"),
+            HookOutput::error("err2"),
+        ]);
+        assert_eq!(result.decision, HookDecision::Error);
+    }
+
+    #[test]
+    fn allow_plus_error_returns_allow() {
+        let result = AggregatedResult::aggregate(vec![
+            HookOutput::allow(),
+            HookOutput::error("some error"),
+        ]);
+        assert_eq!(result.decision, HookDecision::Allow);
+    }
+
+    #[test]
+    fn inject_text_concatenated() {
+        let result = AggregatedResult::aggregate(vec![
+            HookOutput::allow().with_inject("first"),
+            HookOutput::allow().with_inject("second"),
+        ]);
+        let inject = result.inject.expect("Should have combined inject");
+        assert!(inject.contains("first"));
+        assert!(inject.contains("second"));
+    }
+
+    #[test]
+    fn data_from_first_non_null_hook() {
+        let result = AggregatedResult::aggregate(vec![
+            HookOutput::allow(), // null data
+            HookOutput::allow().with_data(serde_json::json!({"key": "val"})),
+            HookOutput::allow().with_data(serde_json::json!({"other": "data"})),
+        ]);
+        assert_eq!(result.data["key"], "val");
+    }
+}
+
+mod dispatch_execution {
+    use super::*;
+
+    #[tokio::test]
+    async fn multiple_matching_hooks_all_execute() {
+        let mut registry = HookRegistry::new();
+        let config = HookConfig {
+            events: {
+                let mut m = HashMap::new();
+                m.insert(
+                    HookEvent::PreToolUse,
+                    vec![
+                        make_entry("echo hook1"),
+                        make_entry("echo hook2"),
+                        make_entry("echo hook3"),
+                    ],
+                );
+                m
+            },
+        };
+        registry.register_from_config(&config);
+
+        let result = registry
+            .dispatch(HookEvent::PreToolUse, sample_input())
+            .await;
+
+        assert_eq!(
+            result.outputs.len(),
+            3,
+            "All three hooks should execute, got {}",
+            result.outputs.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn any_block_blocks_overall() {
+        let mut registry = HookRegistry::new();
+        let config = HookConfig {
+            events: {
+                let mut m = HashMap::new();
+                m.insert(
+                    HookEvent::PreToolUse,
+                    vec![
+                        make_entry("true"),                             // Allow
+                        make_entry("true"),                             // Allow
+                        make_entry(&fixture("block-hook.sh")),          // Block
+                    ],
+                );
+                m
+            },
+        };
+        registry.register_from_config(&config);
+
+        let result = registry
+            .dispatch(HookEvent::PreToolUse, sample_input())
+            .await;
+
+        assert_eq!(
+            result.decision,
+            HookDecision::Block,
+            "Any Block should make overall result Block"
+        );
+    }
+
+    #[tokio::test]
+    async fn all_error_does_not_block() {
+        let mut registry = HookRegistry::new();
+        let config = HookConfig {
+            events: {
+                let mut m = HashMap::new();
+                m.insert(
+                    HookEvent::PreToolUse,
+                    vec![
+                        make_entry("exit 1"), // Error
+                        make_entry("exit 1"), // Error
+                    ],
+                );
+                m
+            },
+        };
+        registry.register_from_config(&config);
+
+        let result = registry
+            .dispatch(HookEvent::PreToolUse, sample_input())
+            .await;
+
+        assert_ne!(
+            result.decision,
+            HookDecision::Block,
+            "Error-only results should not block"
+        );
+        assert_eq!(result.decision, HookDecision::Error);
+    }
+
+    #[tokio::test]
+    async fn timeout_on_one_hook_does_not_prevent_others() {
+        let mut registry = HookRegistry::new();
+        let config = HookConfig {
+            events: {
+                let mut m = HashMap::new();
+                m.insert(
+                    HookEvent::PreToolUse,
+                    vec![
+                        // Fast hook — completes immediately
+                        HookEntry {
+                            hook_type: HookType::Command,
+                            command: Some("echo fast".to_string()),
+                            url: None,
+                            prompt: None,
+                            matcher: Matcher::All,
+                            timeout: Some(5),
+                            fire_and_forget: false,
+                        },
+                        // Slow hook — will timeout at 1s
+                        HookEntry {
+                            hook_type: HookType::Command,
+                            command: Some(fixture("slow-hook.sh")),
+                            url: None,
+                            prompt: None,
+                            matcher: Matcher::All,
+                            timeout: Some(1),
+                            fire_and_forget: false,
+                        },
+                    ],
+                );
+                m
+            },
+        };
+        registry.register_from_config(&config);
+
+        let result = registry
+            .dispatch(HookEvent::PreToolUse, sample_input())
+            .await;
+
+        // Both should have outputs (one Allow from fast, one Error from timeout)
+        assert_eq!(
+            result.outputs.len(),
+            2,
+            "Both hooks should produce output, got {}",
+            result.outputs.len()
+        );
+
+        // Overall should be Allow because fast hook succeeded and timeout is Error (not Block)
+        assert_eq!(result.decision, HookDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn empty_hook_list_returns_allow() {
+        let registry = HookRegistry::new();
+        let result = registry
+            .dispatch(HookEvent::PreToolUse, sample_input())
+            .await;
+        assert_eq!(result.decision, HookDecision::Allow);
+        assert!(result.outputs.is_empty());
+    }
+}
+
+mod blocking_semantics {
+    use super::*;
+
+    #[tokio::test]
+    async fn pre_tool_use_block_returns_block_decision() {
+        let mut registry = HookRegistry::new();
+        let config = HookConfig {
+            events: {
+                let mut m = HashMap::new();
+                m.insert(
+                    HookEvent::PreToolUse,
+                    vec![HookEntry {
+                        hook_type: HookType::Command,
+                        command: Some(fixture("block-hook.sh")),
+                        url: None,
+                        prompt: None,
+                        matcher: Matcher::All,
+                        timeout: None,
+                        fire_and_forget: false,
+                    }],
+                );
+                m
+            },
+        };
+        registry.register_from_config(&config);
+
+        let result = registry
+            .dispatch(HookEvent::PreToolUse, sample_input())
+            .await;
+
+        assert_eq!(result.decision, HookDecision::Block);
+    }
+
+    #[tokio::test]
+    async fn post_tool_use_block_is_observe_only() {
+        // PostToolUse should never block — even if hook exits 2, the event
+        // doesn't support blocking per supports_blocking().
+        // The registry should enforce this by downgrading Block to Allow/Error
+        // for non-blocking events, or the hook still returns Block but the
+        // caller (agent_loop) ignores it. We test the event's contract.
+        assert!(
+            !HookEvent::PostToolUse.supports_blocking(),
+            "PostToolUse should not support blocking"
+        );
+        assert!(
+            HookEvent::PreToolUse.supports_blocking(),
+            "PreToolUse should support blocking"
+        );
+    }
+
+    #[tokio::test]
+    async fn stop_does_not_support_blocking() {
+        assert!(
+            !HookEvent::Stop.supports_blocking(),
+            "Stop should not support blocking"
+        );
+    }
+
+    #[tokio::test]
+    async fn user_prompt_submit_supports_blocking() {
+        assert!(
+            HookEvent::UserPromptSubmit.supports_blocking(),
+            "UserPromptSubmit should support blocking"
+        );
+    }
+}
+
+mod matcher_filtering {
+    use super::*;
+
+    #[tokio::test]
+    async fn matcher_filters_by_tool_name() {
+        let mut registry = HookRegistry::new();
+        let config = HookConfig {
+            events: {
+                let mut m = HashMap::new();
+                m.insert(
+                    HookEvent::PreToolUse,
+                    vec![HookEntry {
+                        hook_type: HookType::Command,
+                        command: Some("true".to_string()),
+                        url: None,
+                        prompt: None,
+                        matcher: Matcher::Pattern("Write".into()),
+                        timeout: None,
+                        fire_and_forget: false,
+                    }],
+                );
+                m
+            },
+        };
+        registry.register_from_config(&config);
+
+        // Bash tool — should not match Write matcher
+        let result = registry
+            .dispatch(
+                HookEvent::PreToolUse,
+                HookInput::pre_tool_use("Bash", &serde_json::json!({}), "t1"),
+            )
+            .await;
+        assert!(
+            result.outputs.is_empty(),
+            "Write matcher should not fire for Bash tool"
+        );
+
+        // Write tool — should match
+        let result = registry
+            .dispatch(
+                HookEvent::PreToolUse,
+                HookInput::pre_tool_use("Write", &serde_json::json!({}), "t2"),
+            )
+            .await;
+        assert!(
+            !result.outputs.is_empty(),
+            "Write matcher should fire for Write tool"
+        );
+    }
+}

--- a/packages/forge/crates/forge-hooks/tests/fixtures/allow-hook.sh
+++ b/packages/forge/crates/forge-hooks/tests/fixtures/allow-hook.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Reads stdin (hook input JSON), outputs allow decision
+input=$(cat)
+echo '{"decision": "allow", "reason": null, "inject": null, "data": {}}'
+exit 0

--- a/packages/forge/crates/forge-hooks/tests/fixtures/async-hook.sh
+++ b/packages/forge/crates/forge-hooks/tests/fixtures/async-hook.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo '{"async": true}'
+# Background work
+sleep 1
+exit 0

--- a/packages/forge/crates/forge-hooks/tests/fixtures/block-hook.sh
+++ b/packages/forge/crates/forge-hooks/tests/fixtures/block-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+input=$(cat)
+echo '{"reason": "Blocked by test hook"}' >&2
+exit 2

--- a/packages/forge/crates/forge-hooks/tests/fixtures/echo-hook.sh
+++ b/packages/forge/crates/forge-hooks/tests/fixtures/echo-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Echo back the input for inspection
+cat
+exit 0

--- a/packages/forge/crates/forge-hooks/tests/fixtures/slow-hook.sh
+++ b/packages/forge/crates/forge-hooks/tests/fixtures/slow-hook.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sleep 30
+exit 0

--- a/packages/forge/crates/forge-hooks/tests/http_executor.rs
+++ b/packages/forge/crates/forge-hooks/tests/http_executor.rs
@@ -1,0 +1,321 @@
+use forge_core::hook::{HookDecision, HookInput};
+use forge_hooks::executor::http::HttpExecutor;
+use forge_hooks::executor::HookExecutor;
+use std::collections::HashMap;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+fn sample_input() -> HookInput {
+    HookInput::pre_tool_use("Bash", &serde_json::json!({"command": "ls"}), "tool-1")
+}
+
+/// Start a mock HTTP server that returns the given response body with the given status code.
+/// Returns the URL to connect to.
+async fn mock_server(status: u16, body: &str) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let body = body.to_string();
+
+    tokio::spawn(async move {
+        // Accept one connection
+        if let Ok((mut stream, _)) = listener.accept().await {
+            let mut buf = vec![0u8; 8192];
+            let _ = stream.read(&mut buf).await;
+
+            let response = format!(
+                "HTTP/1.1 {status} OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = stream.write_all(response.as_bytes()).await;
+            let _ = stream.shutdown().await;
+        }
+    });
+
+    format!("http://127.0.0.1:{}", addr.port())
+}
+
+/// Start a mock server that captures the request body and returns it via a channel.
+async fn capturing_server(
+    status: u16,
+    response_body: &str,
+) -> (String, tokio::sync::oneshot::Receiver<String>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let body = response_body.to_string();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    tokio::spawn(async move {
+        if let Ok((mut stream, _)) = listener.accept().await {
+            let mut buf = vec![0u8; 65536];
+            let n = stream.read(&mut buf).await.unwrap_or(0);
+            let req = String::from_utf8_lossy(&buf[..n]).to_string();
+
+            // Extract body from HTTP request (after double CRLF)
+            let req_body = req
+                .split("\r\n\r\n")
+                .nth(1)
+                .unwrap_or("")
+                .to_string();
+            let _ = tx.send(req_body);
+
+            let response = format!(
+                "HTTP/1.1 {status} OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = stream.write_all(response.as_bytes()).await;
+            let _ = stream.shutdown().await;
+        }
+    });
+
+    (format!("http://127.0.0.1:{}", addr.port()), rx)
+}
+
+/// Start a mock server that deliberately hangs (never responds).
+async fn hanging_server() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        if let Ok((mut stream, _)) = listener.accept().await {
+            // Read the request but never respond
+            let mut buf = vec![0u8; 8192];
+            let _ = stream.read(&mut buf).await;
+            // Sleep forever
+            tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+            drop(stream);
+        }
+    });
+
+    format!("http://127.0.0.1:{}", addr.port())
+}
+
+mod success {
+    use super::*;
+
+    #[tokio::test]
+    async fn successful_post_returns_parsed_hook_output() {
+        let body = r#"{"decision":"allow","inject":"memory injected","data":{"count":5}}"#;
+        let url = mock_server(200, body).await;
+
+        let exec = HttpExecutor::new(url, None);
+        let out = exec.execute(&sample_input()).await;
+
+        assert_eq!(out.decision, HookDecision::Allow);
+        assert_eq!(out.inject.as_deref(), Some("memory injected"));
+        assert_eq!(out.data["count"], 5);
+    }
+
+    #[tokio::test]
+    async fn block_response_parsed() {
+        let body = r#"{"decision":"block","reason":"Dangerous tool"}"#;
+        let url = mock_server(200, body).await;
+
+        let exec = HttpExecutor::new(url, None);
+        let out = exec.execute(&sample_input()).await;
+
+        assert_eq!(out.decision, HookDecision::Block);
+        assert_eq!(out.reason.as_deref(), Some("Dangerous tool"));
+    }
+
+    #[tokio::test]
+    async fn sends_input_as_json_post() {
+        let resp = r#"{"decision":"allow"}"#;
+        let (url, rx) = capturing_server(200, resp).await;
+
+        let exec = HttpExecutor::new(url, None);
+        let input = HookInput::pre_tool_use(
+            "Bash",
+            &serde_json::json!({"command": "echo hi"}),
+            "t-1",
+        );
+        let _ = exec.execute(&input).await;
+
+        let req_body = rx.await.expect("Should receive captured request");
+        assert!(
+            req_body.contains("Bash"),
+            "Request body should contain tool name, got: {req_body}"
+        );
+        assert!(
+            req_body.contains("PreToolUse"),
+            "Request body should contain event name, got: {req_body}"
+        );
+    }
+}
+
+mod non_2xx {
+    use super::*;
+
+    #[tokio::test]
+    async fn status_500_still_parses_body() {
+        let body = r#"{"decision":"error","reason":"Internal server error"}"#;
+        let url = mock_server(500, body).await;
+
+        let exec = HttpExecutor::new(url, None);
+        let out = exec.execute(&sample_input()).await;
+
+        // Non-2xx should still parse the response body as HookOutput
+        assert_eq!(out.decision, HookDecision::Error);
+        assert_eq!(out.reason.as_deref(), Some("Internal server error"));
+    }
+
+    #[tokio::test]
+    async fn status_403_with_block() {
+        let body = r#"{"decision":"block","reason":"Forbidden"}"#;
+        let url = mock_server(403, body).await;
+
+        let exec = HttpExecutor::new(url, None);
+        let out = exec.execute(&sample_input()).await;
+
+        assert_eq!(out.decision, HookDecision::Block);
+    }
+}
+
+mod timeout {
+    use super::*;
+
+    #[tokio::test]
+    async fn timeout_returns_error() {
+        let url = hanging_server().await;
+
+        let exec = HttpExecutor::new(url, Some(1));
+        let start = std::time::Instant::now();
+        let out = exec.execute(&sample_input()).await;
+        let elapsed = start.elapsed();
+
+        assert_eq!(out.decision, HookDecision::Error);
+        let reason = out.reason.expect("Timeout should have a reason");
+        assert!(
+            reason.contains("timed out") || reason.contains("failed"),
+            "Expected timeout-related reason, got: {reason}"
+        );
+        assert!(
+            elapsed.as_secs() < 5,
+            "Should time out quickly, took {:?}",
+            elapsed
+        );
+    }
+}
+
+mod connection_error {
+    use super::*;
+
+    #[tokio::test]
+    async fn connection_refused_returns_error_not_fatal() {
+        // Use a port that's almost certainly not listening
+        let exec = HttpExecutor::new("http://127.0.0.1:1".to_string(), Some(2));
+        let out = exec.execute(&sample_input()).await;
+
+        assert_eq!(out.decision, HookDecision::Error);
+        assert!(out.reason.is_some(), "Connection error should have a reason");
+        // The key contract: this is non-fatal (Error, not panic)
+    }
+
+    #[tokio::test]
+    async fn invalid_url_returns_error() {
+        let exec = HttpExecutor::new("not-a-url".to_string(), Some(2));
+        let out = exec.execute(&sample_input()).await;
+        assert_eq!(out.decision, HookDecision::Error);
+    }
+}
+
+mod headers {
+    use super::*;
+
+    #[tokio::test]
+    async fn custom_headers_sent() {
+        // We can't easily inspect headers with our simple mock, but we can verify
+        // the executor doesn't fail when headers are provided
+        let body = r#"{"decision":"allow"}"#;
+        let url = mock_server(200, body).await;
+
+        let mut headers = HashMap::new();
+        headers.insert("X-Custom".to_string(), "test-value".to_string());
+        headers.insert("Authorization".to_string(), "Bearer token123".to_string());
+
+        let exec = HttpExecutor::new(url, None).with_headers(headers);
+        let out = exec.execute(&sample_input()).await;
+
+        assert_eq!(out.decision, HookDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn env_var_interpolation_in_headers() {
+        let body = r#"{"decision":"allow"}"#;
+        let url = mock_server(200, body).await;
+
+        // Set a test env var
+        std::env::set_var("FORGE_TEST_TOKEN", "secret123");
+
+        let mut headers = HashMap::new();
+        headers.insert(
+            "Authorization".to_string(),
+            "Bearer $FORGE_TEST_TOKEN".to_string(),
+        );
+
+        let exec = HttpExecutor::new(url, None).with_headers(headers);
+        let out = exec.execute(&sample_input()).await;
+
+        assert_eq!(out.decision, HookDecision::Allow);
+
+        std::env::remove_var("FORGE_TEST_TOKEN");
+    }
+
+    #[tokio::test]
+    async fn missing_env_var_interpolated_to_empty() {
+        let body = r#"{"decision":"allow"}"#;
+        let url = mock_server(200, body).await;
+
+        // Ensure this var doesn't exist
+        std::env::remove_var("FORGE_NONEXISTENT_VAR");
+
+        let mut headers = HashMap::new();
+        headers.insert(
+            "Authorization".to_string(),
+            "Bearer $FORGE_NONEXISTENT_VAR".to_string(),
+        );
+
+        let exec = HttpExecutor::new(url, None).with_headers(headers);
+        let out = exec.execute(&sample_input()).await;
+
+        // Should not fail — missing vars become empty string
+        assert_eq!(out.decision, HookDecision::Allow);
+    }
+}
+
+mod response_parsing {
+    use super::*;
+
+    #[tokio::test]
+    async fn empty_response_body_returns_default_allow() {
+        let url = mock_server(200, "").await;
+
+        let exec = HttpExecutor::new(url, None);
+        let out = exec.execute(&sample_input()).await;
+
+        assert_eq!(out.decision, HookDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn non_hook_output_json_treated_as_data() {
+        let body = r#"{"inject":"some context","extra":"field"}"#;
+        let url = mock_server(200, body).await;
+
+        let exec = HttpExecutor::new(url, None);
+        let out = exec.execute(&sample_input()).await;
+
+        // Should parse as Allow with inject extracted from the JSON
+        assert_eq!(out.decision, HookDecision::Allow);
+        assert_eq!(out.inject.as_deref(), Some("some context"));
+    }
+
+    #[tokio::test]
+    async fn plain_text_response_becomes_inject() {
+        let url = mock_server(200, "plain text response").await;
+
+        let exec = HttpExecutor::new(url, None);
+        let out = exec.execute(&sample_input()).await;
+
+        assert_eq!(out.decision, HookDecision::Allow);
+        assert_eq!(out.inject.as_deref(), Some("plain text response"));
+    }
+}

--- a/packages/forge/crates/forge-hooks/tests/integration.rs
+++ b/packages/forge/crates/forge-hooks/tests/integration.rs
@@ -336,7 +336,7 @@ mod hook_input_constructors {
     fn session_start_has_session_id() {
         let input = HookInput::session_start("sess-abc", Some("/home"));
         assert_eq!(input.event, HookEvent::SessionStart);
-        assert_eq!(input.payload["sessionId"], "sess-abc");
+        assert_eq!(input.payload["sessionKey"], "sess-abc");
         assert_eq!(input.payload["cwd"], "/home");
     }
 

--- a/packages/forge/crates/forge-hooks/tests/integration.rs
+++ b/packages/forge/crates/forge-hooks/tests/integration.rs
@@ -1,0 +1,466 @@
+use forge_core::hook::{
+    HookConfig, HookDecision, HookEntry, HookEvent, HookInput, HookType, Matcher,
+};
+use forge_core::ToolResult;
+use forge_hooks::HookRegistry;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+fn fixture(name: &str) -> String {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests/fixtures");
+    path.push(name);
+    path.to_string_lossy().to_string()
+}
+
+/// Start a mock HTTP server that returns a HookOutput JSON.
+async fn mock_hook_server(response: &str) -> (String, tokio::sync::oneshot::Receiver<String>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let body = response.to_string();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    tokio::spawn(async move {
+        if let Ok((mut stream, _)) = listener.accept().await {
+            let mut buf = vec![0u8; 65536];
+            let n = stream.read(&mut buf).await.unwrap_or(0);
+            let req = String::from_utf8_lossy(&buf[..n]).to_string();
+            let req_body = req.split("\r\n\r\n").nth(1).unwrap_or("").to_string();
+            let _ = tx.send(req_body);
+
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = stream.write_all(response.as_bytes()).await;
+            let _ = stream.shutdown().await;
+        }
+    });
+
+    (format!("http://127.0.0.1:{}", addr.port()), rx)
+}
+
+mod command_hook_blocks_dangerous_tools {
+    use super::*;
+
+    #[tokio::test]
+    async fn blocks_bash_calls_containing_rm_rf() {
+        let mut registry = HookRegistry::new();
+
+        // Register a command hook that blocks rm -rf via shell logic
+        let script = r#"
+            input=$(cat)
+            if echo "$input" | grep -q 'rm -rf'; then
+                echo 'Blocked rm -rf' >&2
+                exit 2
+            fi
+            exit 0
+        "#;
+
+        let config = HookConfig {
+            events: {
+                let mut m = HashMap::new();
+                m.insert(
+                    HookEvent::PreToolUse,
+                    vec![HookEntry {
+                        hook_type: HookType::Command,
+                        command: Some(script.to_string()),
+                        url: None,
+                        prompt: None,
+                        matcher: Matcher::Pattern("Bash".into()),
+                        timeout: Some(5),
+                        fire_and_forget: false,
+                    }],
+                );
+                m
+            },
+        };
+        registry.register_from_config(&config);
+
+        // Dispatch with rm -rf in tool input
+        let input = HookInput::pre_tool_use(
+            "Bash",
+            &serde_json::json!({"command": "rm -rf /"}),
+            "tool-danger",
+        );
+        let result = registry.dispatch(HookEvent::PreToolUse, input).await;
+
+        assert_eq!(
+            result.decision,
+            HookDecision::Block,
+            "Hook should block rm -rf command"
+        );
+
+        // Safe command should pass
+        let input = HookInput::pre_tool_use(
+            "Bash",
+            &serde_json::json!({"command": "ls -la"}),
+            "tool-safe",
+        );
+        let result = registry.dispatch(HookEvent::PreToolUse, input).await;
+
+        assert_eq!(
+            result.decision,
+            HookDecision::Allow,
+            "Safe command should be allowed"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_matching_tool_name_skips_hook() {
+        let mut registry = HookRegistry::new();
+
+        let config = HookConfig {
+            events: {
+                let mut m = HashMap::new();
+                m.insert(
+                    HookEvent::PreToolUse,
+                    vec![HookEntry {
+                        hook_type: HookType::Command,
+                        command: Some(fixture("block-hook.sh")),
+                        url: None,
+                        prompt: None,
+                        matcher: Matcher::Pattern("Bash".into()),
+                        timeout: None,
+                        fire_and_forget: false,
+                    }],
+                );
+                m
+            },
+        };
+        registry.register_from_config(&config);
+
+        // Write tool should not trigger Bash-only hook
+        let input = HookInput::pre_tool_use(
+            "Write",
+            &serde_json::json!({"path": "/tmp/test"}),
+            "tool-write",
+        );
+        let result = registry.dispatch(HookEvent::PreToolUse, input).await;
+
+        assert_eq!(result.decision, HookDecision::Allow);
+        assert!(result.outputs.is_empty());
+    }
+}
+
+mod async_post_tool_use {
+    use super::*;
+
+    #[tokio::test]
+    async fn async_hook_writes_to_temp_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("hook-executed");
+        let marker_path = marker.to_string_lossy().to_string();
+
+        let mut registry = HookRegistry::new();
+        let config = HookConfig {
+            events: {
+                let mut m = HashMap::new();
+                m.insert(
+                    HookEvent::PostToolUse,
+                    vec![HookEntry {
+                        hook_type: HookType::Command,
+                        command: Some(format!("touch {marker_path}")),
+                        url: None,
+                        prompt: None,
+                        matcher: Matcher::All,
+                        timeout: None,
+                        fire_and_forget: true,
+                    }],
+                );
+                m
+            },
+        };
+        registry.register_from_config(&config);
+
+        let input = HookInput::post_tool_use("Bash", &serde_json::json!({}), &ToolResult::success("t1", "ok"));
+        let result = registry.dispatch(HookEvent::PostToolUse, input).await;
+
+        // Async mode returns immediately with Allow
+        assert_eq!(result.decision, HookDecision::Allow);
+
+        // Wait briefly for the background process to complete
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        assert!(
+            marker.exists(),
+            "Async hook should have created marker file at {}",
+            marker_path
+        );
+    }
+}
+
+mod http_hook_round_trip {
+    use super::*;
+
+    #[tokio::test]
+    async fn http_hook_receives_request_and_returns_output() {
+        let resp = r#"{"decision":"allow","inject":"memory: user prefers vim","data":{"count":3}}"#;
+        let (url, rx) = mock_hook_server(resp).await;
+
+        let mut registry = HookRegistry::new();
+        let config = HookConfig {
+            events: {
+                let mut m = HashMap::new();
+                m.insert(
+                    HookEvent::UserPromptSubmit,
+                    vec![HookEntry {
+                        hook_type: HookType::Http,
+                        command: None,
+                        url: Some(url),
+                        prompt: None,
+                        matcher: Matcher::All,
+                        timeout: Some(5),
+                        fire_and_forget: false,
+                    }],
+                );
+                m
+            },
+        };
+        registry.register_from_config(&config);
+
+        let input = HookInput::prompt_submit("sess-1", "open my config");
+        let result = registry
+            .dispatch(HookEvent::UserPromptSubmit, input)
+            .await;
+
+        assert_eq!(result.decision, HookDecision::Allow);
+        assert_eq!(
+            result.inject.as_deref(),
+            Some("memory: user prefers vim")
+        );
+
+        // Verify the mock server received the request
+        let req_body = rx.await.expect("Mock server should have received request");
+        assert!(
+            req_body.contains("UserPromptSubmit"),
+            "Request should contain event name"
+        );
+        assert!(
+            req_body.contains("open my config"),
+            "Request should contain user message"
+        );
+    }
+}
+
+mod mixed_hook_types {
+    use super::*;
+
+    #[tokio::test]
+    async fn command_and_http_on_same_event_both_execute() {
+        let resp = r#"{"decision":"allow","inject":"from http"}"#;
+        let (url, _rx) = mock_hook_server(resp).await;
+
+        let mut registry = HookRegistry::new();
+        let config = HookConfig {
+            events: {
+                let mut m = HashMap::new();
+                m.insert(
+                    HookEvent::PreToolUse,
+                    vec![
+                        HookEntry {
+                            hook_type: HookType::Command,
+                            command: Some(
+                                r#"echo '{"decision":"allow","inject":"from cmd"}'"#.to_string(),
+                            ),
+                            url: None,
+                            prompt: None,
+                            matcher: Matcher::All,
+                            timeout: None,
+                            fire_and_forget: false,
+                        },
+                        HookEntry {
+                            hook_type: HookType::Http,
+                            command: None,
+                            url: Some(url),
+                            prompt: None,
+                            matcher: Matcher::All,
+                            timeout: Some(5),
+                            fire_and_forget: false,
+                        },
+                    ],
+                );
+                m
+            },
+        };
+        registry.register_from_config(&config);
+
+        let input = HookInput::pre_tool_use("Bash", &serde_json::json!({}), "t1");
+        let result = registry.dispatch(HookEvent::PreToolUse, input).await;
+
+        assert_eq!(
+            result.outputs.len(),
+            2,
+            "Both command and HTTP hook should execute"
+        );
+        assert_eq!(result.decision, HookDecision::Allow);
+
+        // Combined inject should contain text from both hooks
+        let inject = result.inject.expect("Should have combined inject text");
+        assert!(inject.contains("from cmd"), "Should contain command inject");
+        assert!(inject.contains("from http"), "Should contain HTTP inject");
+    }
+}
+
+mod builtin_daemon_hooks {
+    use super::*;
+
+    #[tokio::test]
+    async fn builtin_http_hook_with_mock_produces_inject() {
+        let resp = r#"{"decision":"allow","inject":"relevant memories injected","data":{"count":2}}"#;
+        let (url, _rx) = mock_hook_server(resp).await;
+
+        let mut registry = HookRegistry::new();
+        registry.register_builtin_http(HookEvent::UserPromptSubmit, &url, HashMap::new());
+
+        let input = HookInput::prompt_submit("sess-1", "what do I prefer?");
+        let result = registry
+            .dispatch(HookEvent::UserPromptSubmit, input)
+            .await;
+
+        assert_eq!(result.decision, HookDecision::Allow);
+        assert_eq!(
+            result.inject.as_deref(),
+            Some("relevant memories injected")
+        );
+        assert_eq!(result.data["count"], 2);
+    }
+}
+
+mod hook_input_constructors {
+    use super::*;
+
+    #[test]
+    fn session_start_has_session_id() {
+        let input = HookInput::session_start("sess-abc", Some("/home"));
+        assert_eq!(input.event, HookEvent::SessionStart);
+        assert_eq!(input.payload["sessionId"], "sess-abc");
+        assert_eq!(input.payload["cwd"], "/home");
+    }
+
+    #[test]
+    fn session_end_has_transcript() {
+        let input = HookInput::session_end("sess-abc", "conversation text");
+        assert_eq!(input.event, HookEvent::SessionEnd);
+        assert_eq!(input.payload["transcript"], "conversation text");
+    }
+
+    #[test]
+    fn pre_tool_use_has_tool_info() {
+        let input = HookInput::pre_tool_use("Bash", &serde_json::json!({"cmd": "ls"}), "t1");
+        assert_eq!(input.event, HookEvent::PreToolUse);
+        assert_eq!(input.tool_name.as_deref(), Some("Bash"));
+        assert_eq!(input.payload["toolName"], "Bash");
+        assert_eq!(input.payload["toolUseId"], "t1");
+    }
+
+    #[test]
+    fn post_tool_use_has_output() {
+        let result = ToolResult::success("t1", "success");
+        let input = HookInput::post_tool_use("Write", &serde_json::json!({}), &result);
+        assert_eq!(input.event, HookEvent::PostToolUse);
+        assert_eq!(input.tool_name.as_deref(), Some("Write"));
+        assert_eq!(input.payload["toolOutput"], "success");
+        assert_eq!(input.payload["isError"], false);
+    }
+
+    #[test]
+    fn post_compact_has_summary() {
+        let input = HookInput::post_compact("summary text", 42);
+        assert_eq!(input.event, HookEvent::PostCompact);
+        assert_eq!(input.payload["summary"], "summary text");
+        assert_eq!(input.payload["messageCount"], 42);
+    }
+
+    #[test]
+    fn stop_has_session_id() {
+        let input = HookInput::stop("sess-xyz");
+        assert_eq!(input.event, HookEvent::Stop);
+        assert_eq!(input.payload["sessionId"], "sess-xyz");
+    }
+
+    #[test]
+    fn prompt_submit_has_message() {
+        let input = HookInput::prompt_submit("s1", "hello world");
+        assert_eq!(input.event, HookEvent::UserPromptSubmit);
+        assert_eq!(input.payload["userMessage"], "hello world");
+    }
+
+    #[test]
+    fn match_target_returns_tool_name() {
+        let input = HookInput::pre_tool_use("Bash", &serde_json::json!({}), "t1");
+        assert_eq!(input.match_target(), Some("Bash"));
+
+        let input = HookInput::stop("s1");
+        assert_eq!(input.match_target(), None);
+    }
+}
+
+mod tier2_input_constructors {
+    use super::*;
+
+    #[test]
+    fn post_tool_use_failure_has_error_info() {
+        let input = HookInput::post_tool_use_failure(
+            "Bash",
+            &serde_json::json!({"command": "bad-cmd"}),
+            "command not found",
+            "t-fail-1",
+        );
+        assert_eq!(input.event, HookEvent::PostToolUseFailure);
+        assert_eq!(input.tool_name.as_deref(), Some("Bash"));
+        assert_eq!(input.payload["toolName"], "Bash");
+        assert_eq!(input.payload["error"], "command not found");
+        assert_eq!(input.payload["toolUseId"], "t-fail-1");
+        assert_eq!(input.payload["toolInput"]["command"], "bad-cmd");
+    }
+
+    #[test]
+    fn permission_request_has_level() {
+        let input = HookInput::permission_request(
+            "Write",
+            &serde_json::json!({"path": "/etc/passwd"}),
+            "Write",
+        );
+        assert_eq!(input.event, HookEvent::PermissionRequest);
+        assert_eq!(input.tool_name.as_deref(), Some("Write"));
+        assert_eq!(input.payload["toolName"], "Write");
+        assert_eq!(input.payload["permissionLevel"], "Write");
+        assert_eq!(input.payload["toolInput"]["path"], "/etc/passwd");
+    }
+
+    #[test]
+    fn permission_denied_has_tool_info() {
+        let input = HookInput::permission_denied(
+            "Bash",
+            &serde_json::json!({"command": "rm -rf /"}),
+        );
+        assert_eq!(input.event, HookEvent::PermissionDenied);
+        assert_eq!(input.tool_name.as_deref(), Some("Bash"));
+        assert_eq!(input.payload["toolName"], "Bash");
+        assert_eq!(input.payload["toolInput"]["command"], "rm -rf /");
+    }
+
+    #[test]
+    fn notification_has_message_and_level() {
+        let input = HookInput::notification("Loop detected", "error");
+        assert_eq!(input.event, HookEvent::Notification);
+        assert!(input.tool_name.is_none());
+        assert_eq!(input.payload["message"], "Loop detected");
+        assert_eq!(input.payload["level"], "error");
+    }
+
+    #[test]
+    fn notification_match_target_is_none() {
+        let input = HookInput::notification("test", "info");
+        assert_eq!(input.match_target(), None);
+    }
+
+    #[test]
+    fn permission_request_match_target_is_tool_name() {
+        let input = HookInput::permission_request("Bash", &serde_json::json!({}), "Read");
+        assert_eq!(input.match_target(), Some("Bash"));
+    }
+}

--- a/packages/forge/crates/forge-hooks/tests/matcher.rs
+++ b/packages/forge/crates/forge-hooks/tests/matcher.rs
@@ -1,0 +1,177 @@
+use forge_core::hook::Matcher;
+use forge_hooks::matches;
+
+mod all_matcher {
+    use super::*;
+
+    #[test]
+    fn matches_any_string() {
+        assert!(matches(&Matcher::All, Some("Bash")));
+        assert!(matches(&Matcher::All, Some("Write")));
+        assert!(matches(&Matcher::All, Some("")));
+    }
+
+    #[test]
+    fn matches_none_target() {
+        assert!(matches(&Matcher::All, None));
+    }
+}
+
+mod wildcard {
+    use super::*;
+
+    #[test]
+    fn star_matches_everything() {
+        let m = Matcher::Pattern("*".into());
+        assert!(matches(&m, Some("anything")));
+        assert!(matches(&m, Some("Bash")));
+    }
+
+    #[test]
+    fn star_matches_none_target() {
+        let m = Matcher::Pattern("*".into());
+        assert!(matches(&m, None));
+    }
+}
+
+mod empty_pattern {
+    use super::*;
+
+    #[test]
+    fn empty_string_matches_everything() {
+        let m = Matcher::Pattern(String::new());
+        assert!(matches(&m, Some("anything")));
+    }
+
+    #[test]
+    fn empty_string_matches_none_target() {
+        let m = Matcher::Pattern(String::new());
+        assert!(matches(&m, None));
+    }
+}
+
+mod exact_match {
+    use super::*;
+
+    #[test]
+    fn matches_exactly() {
+        let m = Matcher::Pattern("Bash".into());
+        assert!(matches(&m, Some("Bash")));
+    }
+
+    #[test]
+    fn does_not_match_prefix() {
+        let m = Matcher::Pattern("Bash".into());
+        assert!(!matches(&m, Some("BashTool")));
+    }
+
+    #[test]
+    fn does_not_match_suffix() {
+        let m = Matcher::Pattern("Bash".into());
+        assert!(!matches(&m, Some("MyBash")));
+    }
+
+    #[test]
+    fn does_not_match_none() {
+        let m = Matcher::Pattern("Bash".into());
+        assert!(!matches(&m, None));
+    }
+}
+
+mod pipe_separated {
+    use super::*;
+
+    #[test]
+    fn matches_first_option() {
+        let m = Matcher::Pattern("Write|Edit".into());
+        assert!(matches(&m, Some("Write")));
+    }
+
+    #[test]
+    fn matches_second_option() {
+        let m = Matcher::Pattern("Write|Edit".into());
+        assert!(matches(&m, Some("Edit")));
+    }
+
+    #[test]
+    fn does_not_match_partial() {
+        let m = Matcher::Pattern("Write|Edit".into());
+        assert!(!matches(&m, Some("ReadWrite")));
+    }
+
+    #[test]
+    fn does_not_match_combined() {
+        let m = Matcher::Pattern("Write|Edit".into());
+        assert!(!matches(&m, Some("WriteEdit")));
+    }
+
+    #[test]
+    fn three_options() {
+        let m = Matcher::Pattern("Write|Edit|Bash".into());
+        assert!(matches(&m, Some("Write")));
+        assert!(matches(&m, Some("Edit")));
+        assert!(matches(&m, Some("Bash")));
+        assert!(!matches(&m, Some("Delete")));
+    }
+}
+
+mod regex_patterns {
+    use super::*;
+
+    #[test]
+    fn caret_prefix_match() {
+        let m = Matcher::Pattern("^Write.*".into());
+        assert!(matches(&m, Some("Write")));
+        assert!(matches(&m, Some("WriteFile")));
+        assert!(!matches(&m, Some("ReadWrite")));
+    }
+
+    #[test]
+    fn dollar_suffix_match() {
+        let m = Matcher::Pattern(".*File$".into());
+        assert!(matches(&m, Some("WriteFile")));
+        assert!(matches(&m, Some("ReadFile")));
+        assert!(!matches(&m, Some("FileReader")));
+    }
+
+    #[test]
+    fn dot_star_matches_substring() {
+        let m = Matcher::Pattern(".*ool.*".into());
+        assert!(matches(&m, Some("BashTool")));
+        assert!(matches(&m, Some("ToolBox")));
+    }
+
+    #[test]
+    fn character_class() {
+        let m = Matcher::Pattern("[BW]ash".into());
+        assert!(matches(&m, Some("Bash")));
+        assert!(matches(&m, Some("Wash")));
+        assert!(!matches(&m, Some("Cash")));
+    }
+
+    #[test]
+    fn invalid_regex_returns_false() {
+        let m = Matcher::Pattern("[unclosed".into());
+        // Should not panic, just return false
+        assert!(!matches(&m, Some("anything")));
+    }
+}
+
+mod case_sensitivity {
+    use super::*;
+
+    #[test]
+    fn exact_match_is_case_sensitive() {
+        let m = Matcher::Pattern("bash".into());
+        assert!(matches(&m, Some("bash")));
+        assert!(!matches(&m, Some("Bash")));
+        assert!(!matches(&m, Some("BASH")));
+    }
+
+    #[test]
+    fn pipe_separated_is_case_sensitive() {
+        let m = Matcher::Pattern("write|edit".into());
+        assert!(matches(&m, Some("write")));
+        assert!(!matches(&m, Some("Write")));
+    }
+}

--- a/packages/forge/crates/forge-hooks/tests/registry.rs
+++ b/packages/forge/crates/forge-hooks/tests/registry.rs
@@ -1,0 +1,370 @@
+use forge_core::hook::{
+    HookConfig, HookDecision, HookEntry, HookEvent, HookInput, HookType, Matcher,
+};
+use forge_hooks::HookRegistry;
+use std::collections::HashMap;
+
+fn sample_input() -> HookInput {
+    HookInput::pre_tool_use("Bash", &serde_json::json!({"command": "ls"}), "tool-1")
+}
+
+mod new_registry {
+    use super::*;
+
+    #[tokio::test]
+    async fn empty_registry_returns_allow() {
+        let registry = HookRegistry::new();
+        let result = registry
+            .dispatch(HookEvent::PreToolUse, sample_input())
+            .await;
+        assert_eq!(result.decision, HookDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn empty_registry_no_outputs() {
+        let registry = HookRegistry::new();
+        let result = registry
+            .dispatch(HookEvent::SessionStart, HookInput::session_start("s1", None))
+            .await;
+        assert_eq!(result.decision, HookDecision::Allow);
+        assert!(result.outputs.is_empty());
+    }
+}
+
+mod builtin_registration {
+    use super::*;
+
+    #[tokio::test]
+    async fn register_builtin_http_fires_on_matching_event() {
+        let mut registry = HookRegistry::new();
+        // Register a built-in that would need a real server — we test registration only.
+        // Since no server is listening, the HTTP executor will return Error (non-blocking).
+        registry.register_builtin_http(
+            HookEvent::SessionStart,
+            "http://127.0.0.1:1/test",
+            HashMap::new(),
+        );
+
+        let result = registry
+            .dispatch(
+                HookEvent::SessionStart,
+                HookInput::session_start("s1", None),
+            )
+            .await;
+
+        // Should have tried to execute (connection refused = Error, not empty)
+        assert!(!result.outputs.is_empty(), "Built-in hook should have fired");
+        // Connection refused is a non-blocking Error
+        assert_eq!(result.decision, HookDecision::Error);
+    }
+
+    #[tokio::test]
+    async fn builtin_does_not_fire_on_other_events() {
+        let mut registry = HookRegistry::new();
+        registry.register_builtin_http(
+            HookEvent::SessionStart,
+            "http://127.0.0.1:1/test",
+            HashMap::new(),
+        );
+
+        let result = registry
+            .dispatch(HookEvent::Stop, HookInput::stop("s1"))
+            .await;
+
+        assert!(
+            result.outputs.is_empty(),
+            "Hook registered for SessionStart should not fire on Stop"
+        );
+        assert_eq!(result.decision, HookDecision::Allow);
+    }
+}
+
+mod config_registration {
+    use super::*;
+
+    fn make_config(event: HookEvent, entries: Vec<HookEntry>) -> HookConfig {
+        let mut events = HashMap::new();
+        events.insert(event, entries);
+        HookConfig { events }
+    }
+
+    #[tokio::test]
+    async fn register_from_config_command_hook() {
+        let mut registry = HookRegistry::new();
+        let config = make_config(
+            HookEvent::PreToolUse,
+            vec![HookEntry {
+                hook_type: HookType::Command,
+                command: Some("true".to_string()),
+                url: None,
+                prompt: None,
+                matcher: Matcher::All,
+                timeout: Some(5),
+                fire_and_forget: false,
+            }],
+        );
+
+        registry.register_from_config(&config);
+
+        let result = registry
+            .dispatch(HookEvent::PreToolUse, sample_input())
+            .await;
+
+        assert!(!result.outputs.is_empty(), "Config hook should fire");
+        assert_eq!(result.decision, HookDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn multiple_hooks_on_same_event_all_fire() {
+        let mut registry = HookRegistry::new();
+        // Use distinct commands so deduplication doesn't collapse them
+        let config = make_config(
+            HookEvent::PreToolUse,
+            vec![
+                HookEntry {
+                    hook_type: HookType::Command,
+                    command: Some("echo hook-a".to_string()),
+                    url: None,
+                    prompt: None,
+                    matcher: Matcher::All,
+                    timeout: None,
+                    fire_and_forget: false,
+                },
+                HookEntry {
+                    hook_type: HookType::Command,
+                    command: Some("echo hook-b".to_string()),
+                    url: None,
+                    prompt: None,
+                    matcher: Matcher::All,
+                    timeout: None,
+                    fire_and_forget: false,
+                },
+            ],
+        );
+
+        registry.register_from_config(&config);
+
+        let result = registry
+            .dispatch(HookEvent::PreToolUse, sample_input())
+            .await;
+
+        assert!(
+            result.outputs.len() >= 2,
+            "Both hooks should fire, got {} outputs",
+            result.outputs.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn hooks_on_different_events_only_matching_fires() {
+        let mut registry = HookRegistry::new();
+
+        let mut events = HashMap::new();
+        events.insert(
+            HookEvent::PreToolUse,
+            vec![HookEntry {
+                hook_type: HookType::Command,
+                command: Some("echo pre-tool".to_string()),
+                url: None,
+                prompt: None,
+                matcher: Matcher::All,
+                timeout: None,
+                fire_and_forget: false,
+            }],
+        );
+        events.insert(
+            HookEvent::Stop,
+            vec![HookEntry {
+                hook_type: HookType::Command,
+                command: Some("echo stop".to_string()),
+                url: None,
+                prompt: None,
+                matcher: Matcher::All,
+                timeout: None,
+                fire_and_forget: false,
+            }],
+        );
+
+        registry.register_from_config(&HookConfig { events });
+
+        let result = registry
+            .dispatch(HookEvent::PreToolUse, sample_input())
+            .await;
+        assert_eq!(result.outputs.len(), 1, "Only PreToolUse hook should fire");
+
+        let result = registry
+            .dispatch(HookEvent::Stop, HookInput::stop("s1"))
+            .await;
+        assert_eq!(result.outputs.len(), 1, "Only Stop hook should fire");
+    }
+}
+
+mod user_suppresses_builtin {
+    use super::*;
+
+    #[tokio::test]
+    async fn user_http_same_url_suppresses_builtin() {
+        let mut registry = HookRegistry::new();
+
+        // Register a built-in HTTP hook
+        registry.register_builtin_http(
+            HookEvent::SessionStart,
+            "http://127.0.0.1:3850/api/hooks/session-start",
+            HashMap::new(),
+        );
+
+        // Register a user hook to the same URL
+        let config = HookConfig {
+            events: {
+                let mut m = HashMap::new();
+                m.insert(
+                    HookEvent::SessionStart,
+                    vec![HookEntry {
+                        hook_type: HookType::Http,
+                        command: None,
+                        url: Some("http://127.0.0.1:3850/api/hooks/session-start".to_string()),
+                        prompt: None,
+                        matcher: Matcher::All,
+                        timeout: None,
+                        fire_and_forget: false,
+                    }],
+                );
+                m
+            },
+        };
+
+        registry.register_from_config(&config);
+
+        let result = registry
+            .dispatch(
+                HookEvent::SessionStart,
+                HookInput::session_start("s1", None),
+            )
+            .await;
+
+        // Should fire only once (user suppresses built-in at same URL)
+        assert_eq!(
+            result.outputs.len(),
+            1,
+            "Duplicate URL should be deduplicated, got {} outputs",
+            result.outputs.len()
+        );
+    }
+}
+
+mod reload {
+    use super::*;
+
+    #[tokio::test]
+    async fn reload_replaces_user_hooks() {
+        let mut registry = HookRegistry::new();
+
+        // Register initial config
+        let config1 = HookConfig {
+            events: {
+                let mut m = HashMap::new();
+                m.insert(
+                    HookEvent::PreToolUse,
+                    vec![HookEntry {
+                        hook_type: HookType::Command,
+                        command: Some("echo first".to_string()),
+                        url: None,
+                        prompt: None,
+                        matcher: Matcher::All,
+                        timeout: None,
+                        fire_and_forget: false,
+                    }],
+                );
+                m
+            },
+        };
+        registry.register_from_config(&config1);
+
+        // Reload with different config
+        let config2 = HookConfig {
+            events: {
+                let mut m = HashMap::new();
+                m.insert(
+                    HookEvent::Stop,
+                    vec![HookEntry {
+                        hook_type: HookType::Command,
+                        command: Some("echo second".to_string()),
+                        url: None,
+                        prompt: None,
+                        matcher: Matcher::All,
+                        timeout: None,
+                        fire_and_forget: false,
+                    }],
+                );
+                m
+            },
+        };
+        registry.reload(&config2);
+
+        // Old hook should not fire
+        let result = registry
+            .dispatch(HookEvent::PreToolUse, sample_input())
+            .await;
+        assert!(
+            result.outputs.is_empty(),
+            "Old PreToolUse hook should be gone after reload"
+        );
+
+        // New hook should fire
+        let result = registry
+            .dispatch(HookEvent::Stop, HookInput::stop("s1"))
+            .await;
+        assert!(
+            !result.outputs.is_empty(),
+            "New Stop hook should fire after reload"
+        );
+    }
+
+    #[tokio::test]
+    async fn reload_keeps_builtins() {
+        let mut registry = HookRegistry::new();
+
+        // Register a built-in
+        registry.register_builtin_http(
+            HookEvent::SessionStart,
+            "http://127.0.0.1:1/builtin",
+            HashMap::new(),
+        );
+
+        // Register user config
+        let config1 = HookConfig {
+            events: {
+                let mut m = HashMap::new();
+                m.insert(
+                    HookEvent::PreToolUse,
+                    vec![HookEntry {
+                        hook_type: HookType::Command,
+                        command: Some("true".to_string()),
+                        url: None,
+                        prompt: None,
+                        matcher: Matcher::All,
+                        timeout: None,
+                        fire_and_forget: false,
+                    }],
+                );
+                m
+            },
+        };
+        registry.register_from_config(&config1);
+
+        // Reload with empty config
+        registry.reload(&HookConfig::default());
+
+        // Built-in should still fire
+        let result = registry
+            .dispatch(
+                HookEvent::SessionStart,
+                HookInput::session_start("s1", None),
+            )
+            .await;
+        assert!(
+            !result.outputs.is_empty(),
+            "Built-in hooks should survive reload"
+        );
+    }
+}

--- a/packages/forge/crates/forge-signet/src/config.rs
+++ b/packages/forge/crates/forge-signet/src/config.rs
@@ -1,3 +1,4 @@
+use forge_core::hook::HookConfig;
 use forge_core::ForgeError;
 use serde::Deserialize;
 use std::path::PathBuf;
@@ -26,6 +27,11 @@ pub struct AgentConfig {
     pub memory: Option<MemoryConfig>,
     #[serde(default)]
     pub embedding: Option<EmbeddingConfig>,
+    /// User-configured hooks from the `hooks` section of agent.yaml.
+    /// Maps HookEvent names to lists of HookEntry definitions.
+    /// Optional — omitting it entirely is the default (no user hooks).
+    #[serde(default)]
+    pub hooks: Option<HookConfig>,
     // Flat keys written by dashboard (take precedence over nested)
     #[serde(default, rename = "extractionProvider")]
     pub extraction_provider_flat: Option<String>,

--- a/packages/forge/crates/forge-signet/src/hooks.rs
+++ b/packages/forge/crates/forge-signet/src/hooks.rs
@@ -6,6 +6,15 @@ use tracing::debug;
 
 /// Manages Signet session lifecycle hooks.
 ///
+/// **DEPRECATED**: This struct is being replaced by `forge_hooks::HookRegistry`,
+/// which provides a generalized hook system supporting command, HTTP, prompt,
+/// and agent hook types with matching and parallel dispatch. The existing
+/// daemon HTTP endpoints are registered as built-in HTTP hooks in the registry.
+///
+/// During the migration window, both `SessionHooks` and `HookRegistry` may
+/// coexist. Once all call sites in `forge-agent` and `forge-tui` are migrated
+/// to use `HookRegistry`, this struct will be removed.
+///
 /// These hooks communicate with the Signet daemon to:
 /// - Inject memories at session start and per-prompt
 /// - Trigger extraction pipeline on session end

--- a/packages/forge/crates/forge-tui/Cargo.toml
+++ b/packages/forge/crates/forge-tui/Cargo.toml
@@ -8,6 +8,7 @@ forge-core = { workspace = true }
 forge-agent = { workspace = true }
 forge-provider = { workspace = true }
 forge-signet = { workspace = true }
+forge-hooks = { workspace = true }
 ratatui = { workspace = true }
 crossterm = { workspace = true }
 tokio = { workspace = true }

--- a/packages/forge/crates/forge-tui/src/app.rs
+++ b/packages/forge/crates/forge-tui/src/app.rs
@@ -18,7 +18,7 @@ use forge_agent::{
 };
 use forge_provider::{self, Provider};
 use forge_core::hook::{HookEvent, HookInput};
-use forge_hooks::SharedRegistry;
+use forge_hooks::{self, SharedRegistry};
 use forge_signet::secrets::{
     apply_local_cli_auth_env, discover_available_providers, refresh_daemon_model_registry,
     resolve_api_key,
@@ -442,7 +442,7 @@ impl App {
         let mut memories_injected = 0;
         if let Some(registry) = &hooks {
             let input = HookInput::session_start(&session_id, cwd.as_deref());
-            let output = registry.read().await.dispatch(HookEvent::SessionStart, input).await;
+            let output = forge_hooks::dispatch(registry, HookEvent::SessionStart, input).await;
             if let Some(context) = &output.inject {
                 if !context.is_empty() {
                     let count = output
@@ -2667,7 +2667,7 @@ impl App {
 
         if let Some(registry) = &self.hook_registry {
             let input = HookInput::session_end(&session_id, &transcript);
-            let output = registry.read().await.dispatch(HookEvent::SessionEnd, input).await;
+            let output = forge_hooks::dispatch(registry, HookEvent::SessionEnd, input).await;
             if output.decision == forge_core::hook::HookDecision::Error {
                 let reason = output.reason.unwrap_or_else(|| "unknown".to_string());
                 info!("Session-end hook failed (non-fatal): {reason}");

--- a/packages/forge/crates/forge-tui/src/app.rs
+++ b/packages/forge/crates/forge-tui/src/app.rs
@@ -2613,6 +2613,16 @@ impl App {
             AgentEvent::MemoryCount(count) => {
                 self.memories_injected = count;
             }
+            AgentEvent::Blocked(reason) => {
+                // Hook policy denial — shown as a status notice, not an error,
+                // so the user understands it was intentional rather than a crash.
+                self.streaming_text.clear();
+                self.pending_text.clear();
+                self.turn_complete_pending = false;
+                self.entries.push(ChatEntry::Status(format!("↯ Blocked: {reason}")));
+                self.processing = false;
+                self.processing_phase = ProcessingPhase::Idle;
+            }
         }
     }
 

--- a/packages/forge/crates/forge-tui/src/app.rs
+++ b/packages/forge/crates/forge-tui/src/app.rs
@@ -17,7 +17,8 @@ use forge_agent::{
     SessionStore, SharedSession,
 };
 use forge_provider::{self, Provider};
-use forge_signet::hooks::SessionHooks;
+use forge_core::hook::{HookEvent, HookInput};
+use forge_hooks::SharedRegistry;
 use forge_signet::secrets::{
     apply_local_cli_auth_env, discover_available_providers, refresh_daemon_model_registry,
     resolve_api_key,
@@ -229,6 +230,8 @@ pub struct App {
     speculative_handle: Option<tokio::task::JoinHandle<()>>,
     last_keystroke: std::time::Instant,
     recall_cache: forge_signet::recall_cache::RecallCache,
+    /// Hook registry (built by CLI, shared with agent loop)
+    hook_registry: Option<SharedRegistry>,
     /// Pipeline summary (extraction + embedding models)
     pipeline_info: String,
     /// Agent display name from IDENTITY.md
@@ -409,6 +412,7 @@ impl App {
         theme_name: &str,
         active_agent: Option<String>,
         connected_providers: Vec<String>,
+        hook_registry: Option<SharedRegistry>,
     ) -> Self {
         let model = provider.model().to_string();
         let provider_name = provider.name().to_string();
@@ -424,18 +428,9 @@ impl App {
         let (event_tx, event_rx) = mpsc::channel::<AgentEvent>(256);
         let (permission_tx, permission_rx) = mpsc::channel::<PermissionRequest>(8);
 
-        // Shared recall cache — used by both agent hooks and TUI speculative recall
-        let recall_cache = forge_signet::recall_cache::RecallCache::new();
-
-        // Set up session hooks if daemon is available
-        let hooks = signet_client.as_ref().map(|client| {
-            SessionHooks::with_cache(
-                client.clone(),
-                session_id,
-                cwd.clone(),
-                recall_cache.clone(),
-            )
-        });
+        // Hook registry is built by the CLI and passed in.
+        // Clone for the agent; keep the original for App's own field.
+        let hooks = hook_registry.clone();
 
         let daemon_healthy = if let Some(client) = &signet_client {
             client.is_available().await
@@ -445,17 +440,18 @@ impl App {
 
         // Call session-start hook to get initial context
         let mut memories_injected = 0;
-        if let Some(hooks) = &hooks {
-            match hooks.session_start().await {
-                Ok((context, count)) if !context.is_empty() => {
+        if let Some(registry) = &hooks {
+            let input = HookInput::session_start(&session_id, cwd.as_deref());
+            let output = registry.read().await.dispatch(HookEvent::SessionStart, input).await;
+            if let Some(context) = &output.inject {
+                if !context.is_empty() {
+                    let count = output
+                        .data
+                        .get("memory_count")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0) as usize;
                     debug!("Session start: {} bytes, {} memories", context.len(), count);
                     memories_injected = count;
-                }
-                Ok(_) => {
-                    debug!("Session start hook returned empty context");
-                }
-                Err(e) => {
-                    debug!("Session start hook failed (non-fatal): {e}");
                 }
             }
         }
@@ -505,6 +501,8 @@ impl App {
                 None
             }
         };
+
+        let recall_cache = forge_signet::recall_cache::RecallCache::new();
 
         // Load pipeline info from agent config
         let pipeline_info = forge_signet::config::load_agent_config()
@@ -590,6 +588,7 @@ impl App {
             speculative_handle: None,
             last_keystroke: std::time::Instant::now(),
             recall_cache,
+            hook_registry,
             voice_recorder: None,
             voice_recording: false,
             voice_model_path: None,
@@ -758,7 +757,13 @@ impl App {
                     match event {
                         ConfigEvent::Reloaded(config) => {
                             self.pipeline_info = config.pipeline_summary();
-                            // Silent update — no chat spam
+                            // Hot-reload hooks from updated config
+                            if let Some(registry) = &self.hook_registry {
+                                if let Some(hook_config) = &config.hooks {
+                                    registry.write().await.reload(hook_config);
+                                    debug!("Hot-reloaded hooks from config change");
+                                }
+                            }
                         }
                         ConfigEvent::Error(_) => {
                             // Ignore config errors silently
@@ -2384,15 +2389,8 @@ impl App {
             }
         };
 
-        // Rebuild agent with new provider
-        let cwd = std::env::current_dir()
-            .ok()
-            .map(|p| p.display().to_string());
-        let session_id = self.session.lock().await.id.clone();
-
-        let hooks = self.signet_client.as_ref().map(|client| {
-            SessionHooks::new(client.clone(), session_id, cwd)
-        });
+        // Rebuild agent with new provider, reuse existing hook registry
+        let hooks = self.agent.hooks();
 
         let (event_tx, event_rx) = mpsc::channel::<AgentEvent>(256);
         let (permission_tx, permission_rx) = mpsc::channel::<PermissionRequest>(8);
@@ -2655,13 +2653,14 @@ impl App {
 
         let transcript = s.transcript();
         let session_id = s.id.clone();
-        let project = s.project.clone();
         drop(s); // Release lock before async call
 
-        if let Some(client) = &self.signet_client {
-            let hooks = SessionHooks::new(client.clone(), session_id, project);
-            if let Err(e) = hooks.session_end(&transcript).await {
-                info!("Session-end hook failed (non-fatal): {e}");
+        if let Some(registry) = &self.hook_registry {
+            let input = HookInput::session_end(&session_id, &transcript);
+            let output = registry.read().await.dispatch(HookEvent::SessionEnd, input).await;
+            if output.decision == forge_core::hook::HookDecision::Error {
+                let reason = output.reason.unwrap_or_else(|| "unknown".to_string());
+                info!("Session-end hook failed (non-fatal): {reason}");
             }
         }
     }


### PR DESCRIPTION
## Summary

- Ports Claude Code's hook lifecycle architecture to Forge in Rust, adapted for Signet-native operation where the daemon remains the source of truth for LLM-backed evaluation
- Adds new `forge-hooks` crate with matcher engine, parallel dispatch, and three executor types (command subprocess, generalized HTTP, daemon-delegated LLM eval)
- Wires 12 lifecycle events across `agent_loop.rs`, `context.rs`, and `app.rs` with correct blocking semantics (PreToolUse/PermissionRequest can block, PostToolUse/Notification are observe-only)
- Daemon gains `/api/hooks/prompt-eval` and `/api/hooks/agent-eval` endpoints using the synthesis provider with fail-open semantics
- Hot reload via `SharedRegistry` (`Arc<RwLock<HookRegistry>>`) propagates `agent.yaml` hook config changes without restart
- 158 tests across 8 binaries covering executors, matchers, dispatch aggregation, config parsing, and end-to-end integration
- Existing 4 daemon hooks register as built-in HTTP hooks for full backward compatibility with zero user configuration

## PR Readiness Checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Test plan

- [x] `cargo check --workspace --no-default-features` passes (0 errors, 0 warnings)
- [x] `cargo test -p forge-hooks` passes (158/158)
- [x] `bun run build` in packages/daemon succeeds
- [ ] Manual: run forge with daemon, verify session-start/end memories still inject
- [ ] Manual: add a PreToolUse command hook in agent.yaml, verify blocking works
- [ ] Manual: change agent.yaml hooks while forge is running, verify hot reload picks up changes

Generated with [Claude Code](https://claude.com/claude-code)