### PR TITLE
fix(pipeline): pass maxContextTokens to direct Ollama synthesis (#426)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Signet are documented here.
 
+## [Unreleased]
+
+### Bug Fixes
+
+- **pipeline**: fix chunked session summarization failures when using direct Ollama synthesis (#426)
+  - Direct Ollama provider now sends `num_ctx` (default 8192) on every request, matching the fallback path
+  - Rust parity: `packages/daemon-rs` summary worker also passes `max_context_tokens` to the Ollama provider
+
+### Notes
+
+- `SIGNET_OLLAMA_FALLBACK_MAX_CTX` now controls the context window for **all** Ollama summary paths (direct and fallback), not just the fallback. If you previously set this variable to intentionally limit the fallback path, be aware it also applies when `synthesis.provider` is explicitly `ollama`.
+
 ## [0.91.3] - 2026-04-01
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,6 @@
 
 All notable changes to Signet are documented here.
 
-## [Unreleased]
-
-### Bug Fixes
-
-- **pipeline**: fix chunked session summarization failures when using direct Ollama synthesis (#426)
-  - Direct Ollama provider now sends `num_ctx` (default 8192) on every request, matching the fallback path
-  - Rust parity: `packages/daemon-rs` summary worker also passes `max_context_tokens` to the Ollama provider
-
-### Notes
-
-- `SIGNET_OLLAMA_FALLBACK_MAX_CTX` now controls the context window for **all** Ollama summary paths (direct and fallback), not just the fallback. If you previously set this variable to intentionally limit the fallback path, be aware it also applies when `synthesis.provider` is explicitly `ollama`.
-
 ## [0.91.3] - 2026-04-01
 
 ### Bug Fixes

--- a/packages/daemon-rs/crates/signet-daemon/src/main.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/main.rs
@@ -166,6 +166,7 @@ async fn main() -> anyhow::Result<()> {
                     base_url: endpoint,
                     api_key,
                     timeout_ms: Some(timeout),
+                    max_context_tokens: None,
                 },
             )
         });
@@ -848,6 +849,7 @@ async fn start_extraction_worker_inner(state: &AppState, dead_letter_on_blocked:
         base_url: runtime_endpoint,
         api_key,
         timeout_ms: Some(pipeline.extraction.timeout),
+        max_context_tokens: None,
     };
     let provider = signet_pipeline::provider::from_config(&provider_cfg);
     // Share the same provider with the recall handler for LLM reranking.
@@ -946,6 +948,7 @@ pub(crate) async fn start_summary_worker(state: &AppState) -> bool {
             base_url: pipeline.synthesis.endpoint.clone(),
             api_key: api_key_for_provider(&pipeline.synthesis.provider),
             timeout_ms: Some(pipeline.synthesis.timeout),
+            max_context_tokens: Some(signet_pipeline::provider::resolve_ollama_max_context_tokens()),
         });
     let semaphore = Arc::new(signet_pipeline::provider::LlmSemaphore::default());
     let handle = signet_pipeline::summary::start(
@@ -1020,6 +1023,7 @@ pub(crate) async fn start_synthesis_worker(state: &AppState) -> bool {
             base_url: pipeline.synthesis.endpoint.clone(),
             api_key: api_key_for_provider(&pipeline.synthesis.provider),
             timeout_ms: Some(pipeline.synthesis.timeout),
+            max_context_tokens: None,
         });
     let semaphore = Arc::new(signet_pipeline::provider::LlmSemaphore::default());
     let handle = signet_pipeline::synthesis::start(

--- a/packages/daemon-rs/crates/signet-pipeline/src/provider.rs
+++ b/packages/daemon-rs/crates/signet-pipeline/src/provider.rs
@@ -554,6 +554,11 @@ const DEFAULT_TIMEOUT_MS: u64 = 90_000;
 pub const DEFAULT_OLLAMA_MAX_CONTEXT_TOKENS: u32 = 8192;
 
 /// Resolve the Ollama context window size from env or default.
+///
+/// Reads `SIGNET_OLLAMA_FALLBACK_MAX_CTX` (kept for backwards compatibility).
+/// Despite the `FALLBACK` label, this value applies to **all** Ollama summary
+/// paths — both the degraded-fallback case and an explicitly-configured
+/// `synthesis.provider = ollama` deployment.
 pub fn resolve_ollama_max_context_tokens() -> u32 {
     std::env::var("SIGNET_OLLAMA_FALLBACK_MAX_CTX")
         .ok()

--- a/packages/daemon-rs/crates/signet-pipeline/src/provider.rs
+++ b/packages/daemon-rs/crates/signet-pipeline/src/provider.rs
@@ -115,6 +115,7 @@ pub struct OllamaLlmProvider {
     base_url: String,
     model: String,
     default_timeout_ms: u64,
+    max_context_tokens: Option<u32>,
     health: Mutex<HealthTracker>,
 }
 
@@ -131,6 +132,8 @@ struct OllamaGenRequest<'a> {
 struct OllamaGenOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     num_predict: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    num_ctx: Option<u32>,
 }
 
 #[derive(Deserialize)]
@@ -143,6 +146,10 @@ struct OllamaGenResponse {
 
 impl OllamaLlmProvider {
     pub fn new(base_url: &str, model: &str, timeout_ms: u64) -> Self {
+        Self::with_context(base_url, model, timeout_ms, None)
+    }
+
+    pub fn with_context(base_url: &str, model: &str, timeout_ms: u64, max_context_tokens: Option<u32>) -> Self {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_millis(timeout_ms.max(5000)))
             .build()
@@ -153,6 +160,7 @@ impl OllamaLlmProvider {
             base_url: base_url.trim_end_matches('/').to_string(),
             model: model.to_string(),
             default_timeout_ms: timeout_ms,
+            max_context_tokens,
             health: Mutex::new(HealthTracker::new()),
         }
     }
@@ -169,9 +177,14 @@ impl OllamaLlmProvider {
         let start = Instant::now();
         let timeout = Duration::from_millis(opts.timeout_ms.unwrap_or(self.default_timeout_ms));
 
-        let options = opts.max_tokens.map(|n| OllamaGenOptions {
-            num_predict: Some(n),
-        });
+        let options = if opts.max_tokens.is_some() || self.max_context_tokens.is_some() {
+            Some(OllamaGenOptions {
+                num_predict: opts.max_tokens,
+                num_ctx: self.max_context_tokens,
+            })
+        } else {
+            None
+        };
 
         let body = OllamaGenRequest {
             model: &self.model,
@@ -538,6 +551,16 @@ impl HealthTracker {
 
 const DEFAULT_OLLAMA_URL: &str = "http://localhost:11434";
 const DEFAULT_TIMEOUT_MS: u64 = 90_000;
+pub const DEFAULT_OLLAMA_MAX_CONTEXT_TOKENS: u32 = 8192;
+
+/// Resolve the Ollama context window size from env or default.
+pub fn resolve_ollama_max_context_tokens() -> u32 {
+    std::env::var("SIGNET_OLLAMA_FALLBACK_MAX_CTX")
+        .ok()
+        .and_then(|s| s.trim().parse::<u32>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_OLLAMA_MAX_CONTEXT_TOKENS)
+}
 
 /// LLM provider configuration.
 #[derive(Debug, Clone)]
@@ -547,6 +570,7 @@ pub struct LlmProviderConfig {
     pub base_url: Option<String>,
     pub api_key: Option<String>,
     pub timeout_ms: Option<u64>,
+    pub max_context_tokens: Option<u32>,
 }
 
 /// Create an LLM provider from config.
@@ -561,7 +585,7 @@ pub fn from_config(cfg: &LlmProviderConfig) -> Arc<dyn LlmProvider> {
                 .filter(|s| !s.is_empty())
                 .unwrap_or(DEFAULT_OLLAMA_URL);
             info!(provider = "ollama", model = %cfg.model, url, timeout_ms = timeout, "LLM provider initialized");
-            Arc::new(OllamaLlmProvider::new(url, &cfg.model, timeout))
+            Arc::new(OllamaLlmProvider::with_context(url, &cfg.model, timeout, cfg.max_context_tokens))
         }
         "anthropic" => {
             let key = cfg.api_key.as_deref().unwrap_or("");
@@ -578,7 +602,7 @@ pub fn from_config(cfg: &LlmProviderConfig) -> Arc<dyn LlmProvider> {
                 .as_deref()
                 .filter(|s| !s.is_empty())
                 .unwrap_or(DEFAULT_OLLAMA_URL);
-            Arc::new(OllamaLlmProvider::new(url, &cfg.model, timeout))
+            Arc::new(OllamaLlmProvider::with_context(url, &cfg.model, timeout, cfg.max_context_tokens))
         }
     }
 }

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -301,6 +301,10 @@ export function resolveDefaultOllamaFallbackModel(): string {
 	return DEFAULT_OLLAMA_FALLBACK_MODEL;
 }
 
+// Reads SIGNET_OLLAMA_FALLBACK_MAX_CTX (kept for backwards compatibility).
+// Despite the FALLBACK label, this value applies to all Ollama summary paths —
+// both the degraded-fallback case and an explicitly-configured
+// synthesis.provider=ollama deployment.
 export function resolveDefaultOllamaFallbackMaxContextTokens(): number {
 	return (
 		parseOptionalPositiveInt(process.env.SIGNET_OLLAMA_FALLBACK_MAX_CTX) ?? DEFAULT_OLLAMA_FALLBACK_MAX_CONTEXT_TOKENS

--- a/packages/daemon/src/pipeline/summary-worker.test.ts
+++ b/packages/daemon/src/pipeline/summary-worker.test.ts
@@ -542,11 +542,12 @@ describe("resolveSummaryProvider", () => {
 		// Intercept fetch to verify num_ctx is included in the request
 		const original = globalThis.fetch;
 		let captured: unknown = null;
-		globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+		const mockFetch: typeof fetch = async (_url, init) => {
 			if (typeof init?.body !== "string") throw new Error(`Expected string body, got: ${typeof init?.body}`);
 			captured = JSON.parse(init.body);
 			return new Response(JSON.stringify({ response: "{}", done: true }), { status: 200 });
-		}) as typeof fetch;
+		};
+		globalThis.fetch = mockFetch;
 
 		try {
 			await provider.generate("test prompt");

--- a/packages/daemon/src/pipeline/summary-worker.test.ts
+++ b/packages/daemon/src/pipeline/summary-worker.test.ts
@@ -556,11 +556,12 @@ describe("resolveSummaryProvider", () => {
 
 		expect(captured).not.toBeNull();
 		if (typeof captured !== "object" || captured === null) throw new Error("Expected object body");
-		const body = captured as Record<string, unknown>;
-		const options = body.options;
+		if (!("options" in captured)) throw new Error("Expected options field");
+		const { options } = captured;
 		if (typeof options !== "object" || options === null) throw new Error("Expected options object");
-		const opts = options as Record<string, unknown>;
-		expect(typeof opts.num_ctx).toBe("number");
-		expect(opts.num_ctx).toBeGreaterThanOrEqual(8192);
+		if (!("num_ctx" in options)) throw new Error("Expected num_ctx field");
+		const { num_ctx: numCtx } = options;
+		expect(typeof numCtx).toBe("number");
+		expect(numCtx).toBeGreaterThanOrEqual(8192);
 	});
 });

--- a/packages/daemon/src/pipeline/summary-worker.test.ts
+++ b/packages/daemon/src/pipeline/summary-worker.test.ts
@@ -541,9 +541,10 @@ describe("resolveSummaryProvider", () => {
 
 		// Intercept fetch to verify num_ctx is included in the request
 		const original = globalThis.fetch;
-		let captured: Record<string, unknown> | null = null;
+		let captured: unknown = null;
 		globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
-			captured = JSON.parse(init?.body as string) as Record<string, unknown>;
+			if (typeof init?.body !== "string") throw new Error(`Expected string body, got: ${typeof init?.body}`);
+			captured = JSON.parse(init.body);
 			return new Response(JSON.stringify({ response: "{}", done: true }), { status: 200 });
 		}) as typeof fetch;
 
@@ -554,9 +555,12 @@ describe("resolveSummaryProvider", () => {
 		}
 
 		expect(captured).not.toBeNull();
-		const options = captured?.options as Record<string, unknown> | undefined;
-		expect(options).toBeDefined();
-		expect(typeof options?.num_ctx).toBe("number");
-		expect((options?.num_ctx as number) > 0).toBe(true);
+		if (typeof captured !== "object" || captured === null) throw new Error("Expected object body");
+		const body = captured as Record<string, unknown>;
+		const options = body.options;
+		if (typeof options !== "object" || options === null) throw new Error("Expected options object");
+		const opts = options as Record<string, unknown>;
+		expect(typeof opts.num_ctx).toBe("number");
+		expect(opts.num_ctx).toBeGreaterThanOrEqual(8192);
 	});
 });

--- a/packages/daemon/src/pipeline/summary-worker.test.ts
+++ b/packages/daemon/src/pipeline/summary-worker.test.ts
@@ -528,4 +528,35 @@ describe("resolveSummaryProvider", () => {
 		const provider = await resolveSummaryProvider(loadMemoryConfig(dir));
 		expect(provider.name).toBe("ollama:qwen3.5:4b");
 	});
+
+	it("direct ollama provider sends num_ctx so chunks are not truncated (#426)", async () => {
+		const dir = makeAgentsDir(`memory:
+  pipelineV2:
+    extractionProvider: ollama
+    extractionModel: qwen3:4b
+`);
+
+		const provider = await resolveSummaryProvider(loadMemoryConfig(dir));
+		expect(provider.name).toBe("ollama:qwen3:4b");
+
+		// Intercept fetch to verify num_ctx is included in the request
+		const original = globalThis.fetch;
+		let captured: Record<string, unknown> | null = null;
+		globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+			captured = JSON.parse(init?.body as string) as Record<string, unknown>;
+			return new Response(JSON.stringify({ response: "{}", done: true }), { status: 200 });
+		}) as typeof fetch;
+
+		try {
+			await provider.generate("test prompt");
+		} finally {
+			globalThis.fetch = original;
+		}
+
+		expect(captured).not.toBeNull();
+		const options = captured?.options as Record<string, unknown> | undefined;
+		expect(options).toBeDefined();
+		expect(typeof options?.num_ctx).toBe("number");
+		expect((options?.num_ctx as number) > 0).toBe(true);
+	});
 });

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -1338,11 +1338,11 @@ export async function resolveSummaryProvider(cfg: ReturnType<typeof loadMemoryCo
 	const model = cfg.pipelineV2.synthesis.model;
 	const timeout = cfg.pipelineV2.synthesis.timeout;
 	const endpoint = cfg.pipelineV2.synthesis.endpoint;
-	const ollamaFallbackMaxContextTokens = resolveDefaultOllamaFallbackMaxContextTokens();
+	const ollamaMaxContextTokens = resolveDefaultOllamaFallbackMaxContextTokens();
 	const fallback = () =>
 		createOllamaProvider({
 			defaultTimeoutMs: timeout,
-			maxContextTokens: ollamaFallbackMaxContextTokens,
+			maxContextTokens: ollamaMaxContextTokens,
 		});
 	switch (p) {
 		case "none":
@@ -1407,7 +1407,7 @@ export async function resolveSummaryProvider(cfg: ReturnType<typeof loadMemoryCo
 				model: model || "anthropic/claude-haiku-4-5-20251001",
 				baseUrl: endpoint ?? "http://127.0.0.1:4096",
 				ollamaFallbackBaseUrl: "http://127.0.0.1:11434",
-				ollamaFallbackMaxContextTokens,
+				ollamaFallbackMaxContextTokens: ollamaMaxContextTokens,
 				defaultTimeoutMs: timeout,
 			});
 		default:
@@ -1415,7 +1415,7 @@ export async function resolveSummaryProvider(cfg: ReturnType<typeof loadMemoryCo
 				...(typeof model === "string" && model.trim().length > 0 ? { model } : {}),
 				...(endpoint ? { baseUrl: endpoint } : {}),
 				defaultTimeoutMs: timeout,
-				maxContextTokens: ollamaFallbackMaxContextTokens,
+				maxContextTokens: ollamaMaxContextTokens,
 			});
 	}
 }

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -774,6 +774,7 @@ async function processChunked(
 			logger.warn("summary-worker", "Chunk summarization failed, skipping", {
 				chunk: i + 1,
 				total: chunks.length,
+				responsePreview: raw.length > 0 ? raw.slice(0, 120) : "(empty)",
 			});
 		}
 	}
@@ -1410,12 +1411,11 @@ export async function resolveSummaryProvider(cfg: ReturnType<typeof loadMemoryCo
 				defaultTimeoutMs: timeout,
 			});
 		default:
-			// Intentionally omit maxContextTokens here. When Ollama is explicitly
-			// configured (not fallback), users control context via model config.
 			return createOllamaProvider({
 				...(typeof model === "string" && model.trim().length > 0 ? { model } : {}),
 				...(endpoint ? { baseUrl: endpoint } : {}),
 				defaultTimeoutMs: timeout,
+				maxContextTokens: ollamaFallbackMaxContextTokens,
 			});
 	}
 }


### PR DESCRIPTION
## Summary

- Pass `maxContextTokens` (default 8192) to the direct Ollama provider in `resolveSummaryProvider()`, fixing chunked session summarization failures when Ollama defaults to 4096 context tokens
- Add `responsePreview` to chunk failure warning logs for easier diagnosis of future parse failures
- Add regression test verifying direct Ollama path includes `num_ctx` in API requests

Closes #426

## Test plan

- [x] Existing summary-worker tests pass (20/20)
- [x] New regression test verifies `num_ctx` is sent for direct Ollama path
- [x] Typecheck passes
- [ ] Manual: configure direct Ollama synthesis, run a long session (~100k chars), verify chunked summarization succeeds