### PR TITLE
fix(daemon): stop re-ingesting pipeline artifacts as memories

### DIFF
--- a/packages/daemon-rs/crates/signet-pipeline/src/extraction.rs
+++ b/packages/daemon-rs/crates/signet-pipeline/src/extraction.rs
@@ -61,7 +61,7 @@ struct RawExtraction {
 
 const MAX_FACTS: usize = 20;
 const MAX_ENTITIES: usize = 15;
-const MIN_FACT_LEN: usize = 20;
+const MIN_FACT_LEN: usize = 80;
 const MAX_FACT_LEN: usize = 2000;
 const MAX_INPUT_CHARS: usize = 12_000;
 
@@ -90,7 +90,7 @@ pub fn build_prompt(content: &str) -> String {
         r#"Extract key facts and entity relationships from the following content.
 
 Return a JSON object with:
-- "facts": array of objects with "content" (string, 20-2000 chars, atomic and self-contained), "type" (one of: fact, preference, decision, rationale, procedural, semantic), "confidence" (0.0-1.0)
+- "facts": array of objects with "content" (string, 80-2000 chars, atomic and self-contained), "type" (one of: fact, preference, decision, rationale, procedural, semantic), "confidence" (0.0-1.0)
 - "entities": array of objects with "source" (string), "target" (string), "relationship" (string), "source_type" (optional string), "target_type" (optional string)
 
 Rules:
@@ -331,7 +331,7 @@ mod tests {
 
     #[test]
     fn parse_valid_extraction() {
-        let raw = r#"{"facts":[{"content":"The user prefers async/await over callbacks for all new code","type":"preference","confidence":0.9}],"entities":[{"source":"UserService","target":"Database","relationship":"queries"}]}"#;
+        let raw = r#"{"facts":[{"content":"The user prefers async/await over callbacks for all new TypeScript and Rust code in this project","type":"preference","confidence":0.9}],"entities":[{"source":"UserService","target":"Database","relationship":"queries"}]}"#;
 
         let result = parse(raw);
         assert_eq!(result.facts.len(), 1);
@@ -344,7 +344,7 @@ mod tests {
     #[test]
     fn parse_with_fences() {
         let raw = r#"```json
-{"facts":[{"content":"Rust 2024 edition supports let-chain syntax in if expressions","type":"fact","confidence":0.85}],"entities":[]}
+{"facts":[{"content":"Rust 2024 edition supports let-chain syntax in if-let expressions for cleaner pattern matching","type":"fact","confidence":0.85}],"entities":[]}
 ```"#;
 
         let result = parse(raw);
@@ -357,7 +357,7 @@ mod tests {
         let raw = r#"<think>
 Let me analyze the content...
 </think>
-{"facts":[{"content":"The daemon uses WAL mode for SQLite to improve concurrent read performance","type":"fact","confidence":0.95}],"entities":[]}"#;
+{"facts":[{"content":"The signet daemon uses WAL journal mode for SQLite to improve concurrent read performance under load","type":"fact","confidence":0.95}],"entities":[]}"#;
 
         let result = parse(raw);
         assert_eq!(result.facts.len(), 1);
@@ -374,7 +374,7 @@ Let me analyze the content...
 
     #[test]
     fn parse_normalizes_unknown_type() {
-        let raw = r#"{"facts":[{"content":"Some fact that is long enough to pass validation checks here","type":"unknown_type","confidence":0.5}],"entities":[]}"#;
+        let raw = r#"{"facts":[{"content":"Some fact about the project configuration that is long enough to pass the validation length gate","type":"unknown_type","confidence":0.5}],"entities":[]}"#;
 
         let result = parse(raw);
         assert_eq!(result.facts.len(), 1);
@@ -383,7 +383,7 @@ Let me analyze the content...
 
     #[test]
     fn parse_clamps_confidence() {
-        let raw = r#"{"facts":[{"content":"A fact with over-confident score that should be clamped to valid range","type":"fact","confidence":1.5}],"entities":[]}"#;
+        let raw = r#"{"facts":[{"content":"A fact about the signet daemon configuration with an over-confident score that should be clamped","type":"fact","confidence":1.5}],"entities":[]}"#;
 
         let result = parse(raw);
         assert_eq!(result.facts.len(), 1);

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -11154,7 +11154,7 @@ function chunkMarkdownHierarchically(
 // Artifact files written by the summary-worker / lineage system.
 // These are already distilled and inserted directly into the DB —
 // re-ingesting them through the chunker creates noisy duplicates.
-const ARTIFACT_FILENAME_RE = /--(?:summary|transcript|compaction|manifest)\.md$/;
+export const ARTIFACT_FILENAME_RE = /--(?:summary|transcript|compaction|manifest)\.md$/;
 
 async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 	// Skip MEMORY.md (index file, not content)
@@ -11199,8 +11199,12 @@ async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 	for (let i = 0; i < chunks.length; i++) {
 		const chunk = chunks[i];
 
-		// Skip chunks with insufficient non-header content
-		const body = chunk.header ? chunk.text.slice(chunk.header.length).trim() : chunk.text.trim();
+		// Skip chunks with insufficient non-header content.
+		// chunk.text is always constructed as `${header}\n\n${body}` when a
+		// header exists (see chunkMarkdownHierarchically), so startsWith holds.
+		const body = chunk.header && chunk.text.startsWith(chunk.header)
+			? chunk.text.slice(chunk.header.length).trim()
+			: chunk.text.trim();
 		if (body.length < 80) continue;
 
 		const chunkKey = `openclaw:${filename}:${createHash("sha256").update(chunk.text).digest("hex").slice(0, 16)}`;

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -11151,9 +11151,17 @@ function chunkMarkdownHierarchically(
  * @param filePath - Path to the memory markdown file
  * @returns Number of chunks inserted
  */
+// Artifact files written by the summary-worker / lineage system.
+// These are already distilled and inserted directly into the DB —
+// re-ingesting them through the chunker creates noisy duplicates.
+const ARTIFACT_FILENAME_RE = /--(?:summary|transcript|compaction|manifest)\.md$/;
+
 async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 	// Skip MEMORY.md (index file, not content)
 	if (filePath.endsWith("MEMORY.md")) return 0;
+
+	// Skip pipeline artifact files (summaries, transcripts, etc.)
+	if (ARTIFACT_FILENAME_RE.test(basename(filePath))) return 0;
 
 	// Read file content
 	let content: string;
@@ -11190,6 +11198,11 @@ async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 
 	for (let i = 0; i < chunks.length; i++) {
 		const chunk = chunks[i];
+
+		// Skip chunks with insufficient non-header content
+		const body = chunk.header ? chunk.text.slice(chunk.header.length).trim() : chunk.text.trim();
+		if (body.length < 80) continue;
+
 		const chunkKey = `openclaw:${filename}:${createHash("sha256").update(chunk.text).digest("hex").slice(0, 16)}`;
 		try {
 			const response = await fetch(`http://${INTERNAL_SELF_HOST}:${PORT}/api/memory/remember`, {

--- a/packages/daemon/src/memory-ingest-filter.test.ts
+++ b/packages/daemon/src/memory-ingest-filter.test.ts
@@ -7,10 +7,7 @@
  */
 
 import { describe, it, expect } from "bun:test";
-
-// The regex used in daemon.ts to skip artifact files.
-// Duplicated here for testing — the canonical copy lives in daemon.ts.
-const ARTIFACT_FILENAME_RE = /--(?:summary|transcript|compaction|manifest)\.md$/;
+import { ARTIFACT_FILENAME_RE } from "./daemon";
 
 describe("artifact filename exclusion", () => {
 	it("matches summary artifact filenames", () => {

--- a/packages/daemon/src/memory-ingest-filter.test.ts
+++ b/packages/daemon/src/memory-ingest-filter.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Regression tests for memory ingestion filtering.
+ *
+ * Verifies that pipeline artifact files (summaries, transcripts, etc.)
+ * are excluded from re-ingestion, and that short/degenerate chunks
+ * are filtered before hitting the memory API.
+ */
+
+import { describe, it, expect } from "bun:test";
+
+// The regex used in daemon.ts to skip artifact files.
+// Duplicated here for testing — the canonical copy lives in daemon.ts.
+const ARTIFACT_FILENAME_RE = /--(?:summary|transcript|compaction|manifest)\.md$/;
+
+describe("artifact filename exclusion", () => {
+	it("matches summary artifact filenames", () => {
+		expect(ARTIFACT_FILENAME_RE.test("2026-03-01T00-09-52.500Z--eej6phr2ekkn46eo--summary.md")).toBe(true);
+	});
+
+	it("matches transcript artifact filenames", () => {
+		expect(ARTIFACT_FILENAME_RE.test("2026-03-01T00-09-52.500Z--o4ebayj7w4fs3grh--transcript.md")).toBe(true);
+	});
+
+	it("matches compaction artifact filenames", () => {
+		expect(ARTIFACT_FILENAME_RE.test("2026-03-25T08-06-26.000Z--abc12345--compaction.md")).toBe(true);
+	});
+
+	it("matches manifest artifact filenames", () => {
+		expect(ARTIFACT_FILENAME_RE.test("2026-03-01T00-09-53.500Z--o4ebayj7w4fs3grh--manifest.md")).toBe(true);
+	});
+
+	it("does not match legacy dated memory files", () => {
+		expect(ARTIFACT_FILENAME_RE.test("2026-01-20.md")).toBe(false);
+	});
+
+	it("does not match named memory files", () => {
+		expect(ARTIFACT_FILENAME_RE.test("2026-02-10-signet.md")).toBe(false);
+	});
+
+	it("does not match descriptive session files", () => {
+		expect(ARTIFACT_FILENAME_RE.test("2026-02-22-dashboard-umap-projection-migration.md")).toBe(false);
+	});
+
+	it("does not match MEMORY.md", () => {
+		expect(ARTIFACT_FILENAME_RE.test("MEMORY.md")).toBe(false);
+	});
+
+	it("does not match files with artifact kind in the middle of the name", () => {
+		expect(ARTIFACT_FILENAME_RE.test("2026-03-01-phase-2-pre-compaction-capture-implementation-plan.md")).toBe(false);
+	});
+});
+
+describe("chunk content length gate", () => {
+	// Mirrors the filtering logic in ingestMemoryMarkdown: chunks with
+	// less than 80 chars of non-header body content should be skipped.
+
+	function bodyLength(text: string, header: string): number {
+		const body = header ? text.slice(header.length).trim() : text.trim();
+		return body.length;
+	}
+
+	it("rejects a chunk that is only a section header", () => {
+		expect(bodyLength("## Section Title", "## Section Title")).toBeLessThan(80);
+	});
+
+	it("rejects a chunk with header and short body", () => {
+		const text = "## Section Title\n\nShort content here.";
+		expect(bodyLength(text, "## Section Title")).toBeLessThan(80);
+	});
+
+	it("accepts a chunk with substantial body content", () => {
+		const text = "## Section Title\n\nThis chunk contains a meaningful amount of content that describes the system configuration and behavior in enough detail to be useful.";
+		expect(bodyLength(text, "## Section Title")).toBeGreaterThanOrEqual(80);
+	});
+
+	it("accepts a headerless chunk with enough content", () => {
+		const text = "This standalone paragraph contains enough detail about the project's architecture to be worth storing as a memory.";
+		expect(bodyLength(text, "")).toBeGreaterThanOrEqual(80);
+	});
+
+	it("rejects a headerless chunk that is too short", () => {
+		const text = "Just a brief note.";
+		expect(bodyLength(text, "")).toBeLessThan(80);
+	});
+});

--- a/packages/daemon/src/pipeline/extraction.test.ts
+++ b/packages/daemon/src/pipeline/extraction.test.ts
@@ -25,9 +25,9 @@ function mockProvider(responses: string[]): LlmProvider {
 
 const VALID_RESPONSE = JSON.stringify({
 	facts: [
-		{ content: "User prefers dark mode", type: "preference", confidence: 0.9 },
+		{ content: "User prefers dark mode for their terminal, editor, and all development tool interfaces", type: "preference", confidence: 0.9 },
 		{
-			content: "User uses vim keybindings in VS Code",
+			content: "User uses vim keybindings in VS Code and has customized their keybinding configuration extensively",
 			type: "preference",
 			confidence: 0.85,
 		},
@@ -70,7 +70,7 @@ describe("extractFactsAndEntities", () => {
 		const result = await extractFactsAndEntities("User prefers dark mode and uses vim keybindings", provider);
 
 		expect(result.facts).toHaveLength(2);
-		expect(result.facts[0].content).toBe("User prefers dark mode");
+		expect(result.facts[0].content).toBe("User prefers dark mode for their terminal, editor, and all development tool interfaces");
 		expect(result.facts[0].type).toBe("preference");
 		expect(result.facts[0].confidence).toBe(0.9);
 		expect(result.entities).toHaveLength(1);
@@ -115,7 +115,7 @@ ${VALID_RESPONSE}
 	it("parses JSON with trailing commas from fallback model", async () => {
 		const trailingCommaResponse = `{
 		  "facts": [
-		    {"content": "User prefers dark mode for terminal and editor interfaces", "type": "preference", "confidence": 0.9,},
+		    {"content": "User prefers dark mode for their terminal, editor, and all development tool interfaces in daily work", "type": "preference", "confidence": 0.9,},
 		  ],
 		  "entities": [
 		    {"source": "User", "relationship": "prefers", "target": "dark mode", "confidence": 0.9,},
@@ -132,7 +132,7 @@ ${VALID_RESPONSE}
 	it("truncates over-limit facts to 20", async () => {
 		// Generate 25 valid facts
 		const manyFacts = Array.from({ length: 25 }, (_, i) => ({
-			content: `Fact number ${i + 1} that is long enough to pass validation`,
+			content: `Fact number ${i + 1} extracted from the session transcript that contains enough detail to pass validation`,
 			type: "fact",
 			confidence: 0.8,
 		}));
@@ -144,12 +144,12 @@ ${VALID_RESPONSE}
 		expect(result.warnings.some((w) => w.includes("Truncated facts"))).toBe(true);
 	});
 
-	it("rejects trivial facts (< 10 chars) with a warning", async () => {
+	it("rejects trivial facts (< 80 chars) with a warning", async () => {
 		const response = JSON.stringify({
 			facts: [
-				{ content: "short", type: "fact", confidence: 0.9 },
+				{ content: "short fact that is under the minimum length threshold", type: "fact", confidence: 0.9 },
 				{
-					content: "This one is long enough to pass",
+					content: "This fact contains enough detail about the user's development environment preferences to pass validation",
 					type: "fact",
 					confidence: 0.8,
 				},
@@ -157,11 +157,11 @@ ${VALID_RESPONSE}
 			entities: [],
 		});
 		const provider = mockProvider([response]);
-		const result = await extractFactsAndEntities("Some content that is long enough", provider);
+		const result = await extractFactsAndEntities("Some content that is long enough to process through extraction", provider);
 
 		// Only the long fact should survive
 		expect(result.facts).toHaveLength(1);
-		expect(result.facts[0].content).toBe("This one is long enough to pass");
+		expect(result.facts[0].content).toBe("This fact contains enough detail about the user's development environment preferences to pass validation");
 		expect(result.warnings.some((w) => w.includes("too short"))).toBe(true);
 	});
 
@@ -169,7 +169,7 @@ ${VALID_RESPONSE}
 		const response = JSON.stringify({
 			facts: [
 				{
-					content: "Some fact that is definitely long enough",
+					content: "Some fact about the user's project configuration that is definitely long enough to pass the validation gate",
 					type: "bogustype",
 					confidence: 0.7,
 				},
@@ -197,12 +197,12 @@ ${VALID_RESPONSE}
 		const response = JSON.stringify({
 			facts: [
 				{
-					content: "Fact with confidence above one point zero",
+					content: "Fact with confidence above one point zero and enough detail about the project to satisfy the length gate",
 					type: "fact",
 					confidence: 1.5,
 				},
 				{
-					content: "Fact with negative confidence value here",
+					content: "Fact with negative confidence value here and enough additional context to satisfy the minimum length gate",
 					type: "fact",
 					confidence: -0.3,
 				},
@@ -224,9 +224,28 @@ ${VALID_RESPONSE}
 		expect(result.entities[0].confidence).toBe(1);
 	});
 
+	it("rejects facts in the 20-79 char range that previously passed with MIN_FACT_LENGTH=20", async () => {
+		const response = JSON.stringify({
+			facts: [
+				{ content: "User prefers dark mode in the editor", type: "preference", confidence: 0.9 },
+				{ content: "The daemon runs on port 3850 by default for HTTP serving", type: "fact", confidence: 0.85 },
+				{ content: "User's development environment runs Hyprland window manager on Arch Linux with custom keybindings configured", type: "fact", confidence: 0.8 },
+			],
+			entities: [],
+		});
+		const provider = mockProvider([response]);
+		const result = await extractFactsAndEntities("Some content that is long enough to process through extraction", provider);
+
+		// First two facts are 36 and 56 chars — both under 80, should be rejected
+		// Third fact is 108 chars — should pass
+		expect(result.facts).toHaveLength(1);
+		expect(result.facts[0].content).toContain("Hyprland");
+		expect(result.warnings.filter((w) => w.includes("too short"))).toHaveLength(2);
+	});
+
 	it("returns early with warning when input is too short", async () => {
 		const provider = mockProvider(["anything"]);
-		// Less than 20 chars
+		// Less than MIN_FACT_LENGTH chars
 		const result = await extractFactsAndEntities("short", provider);
 
 		expect(result.facts).toHaveLength(0);
@@ -297,7 +316,7 @@ ${VALID_RESPONSE}
 	it("accepts all valid memory types", async () => {
 		const validTypes = ["fact", "preference", "decision", "procedural", "semantic"];
 		const facts = validTypes.map((type) => ({
-			content: `A fact of type ${type} that is long enough`,
+			content: `A fact of type ${type} that contains enough descriptive detail about the system configuration to pass validation`,
 			type,
 			confidence: 0.8,
 		}));

--- a/packages/daemon/src/pipeline/extraction.test.ts
+++ b/packages/daemon/src/pipeline/extraction.test.ts
@@ -23,6 +23,10 @@ function mockProvider(responses: string[]): LlmProvider {
 	};
 }
 
+// Inputs must be >= MIN_FACT_LENGTH (80) chars to pass the early-return guard.
+const INPUT = "User prefers dark mode and uses vim keybindings in their VS Code development environment";
+const INPUT_GENERIC = "Some content that is long enough to pass the extraction input gate and be processed fully";
+
 const VALID_RESPONSE = JSON.stringify({
 	facts: [
 		{ content: "User prefers dark mode for their terminal, editor, and all development tool interfaces", type: "preference", confidence: 0.9 },
@@ -60,14 +64,14 @@ describe("extractFactsAndEntities", () => {
 			},
 		};
 
-		await extractFactsAndEntities("User prefers dark mode and uses vim keybindings", provider, { timeoutMs: 12345 });
+		await extractFactsAndEntities(INPUT, provider, { timeoutMs: 12345 });
 
 		expect(seenTimeout).toBe(12345);
 	});
 
 	it("parses valid JSON response correctly", async () => {
 		const provider = mockProvider([VALID_RESPONSE]);
-		const result = await extractFactsAndEntities("User prefers dark mode and uses vim keybindings", provider);
+		const result = await extractFactsAndEntities(INPUT, provider);
 
 		expect(result.facts).toHaveLength(2);
 		expect(result.facts[0].content).toBe("User prefers dark mode for their terminal, editor, and all development tool interfaces");
@@ -85,7 +89,7 @@ describe("extractFactsAndEntities", () => {
 ${VALID_RESPONSE}
 \`\`\``;
 		const provider = mockProvider([fenced]);
-		const result = await extractFactsAndEntities("User prefers dark mode and uses vim keybindings", provider);
+		const result = await extractFactsAndEntities(INPUT, provider);
 
 		expect(result.facts).toHaveLength(2);
 		expect(result.entities).toHaveLength(1);
@@ -97,7 +101,7 @@ ${VALID_RESPONSE}
 ${VALID_RESPONSE}
 \`\`\``;
 		const provider = mockProvider([fenced]);
-		const result = await extractFactsAndEntities("User prefers dark mode and uses vim keybindings", provider);
+		const result = await extractFactsAndEntities(INPUT, provider);
 
 		expect(result.facts).toHaveLength(2);
 	});
@@ -105,7 +109,7 @@ ${VALID_RESPONSE}
 	it("parses JSON when model adds prose before and after", async () => {
 		const wrapped = `Here is the extracted data:\n\n${VALID_RESPONSE}\n\nDone.`;
 		const provider = mockProvider([wrapped]);
-		const result = await extractFactsAndEntities("User prefers dark mode and uses vim keybindings", provider);
+		const result = await extractFactsAndEntities(INPUT, provider);
 
 		expect(result.facts).toHaveLength(2);
 		expect(result.entities).toHaveLength(1);
@@ -122,7 +126,7 @@ ${VALID_RESPONSE}
 		  ],
 		}`;
 		const provider = mockProvider([trailingCommaResponse]);
-		const result = await extractFactsAndEntities("User prefers dark mode and uses vim keybindings", provider);
+		const result = await extractFactsAndEntities(INPUT, provider);
 
 		expect(result.facts).toHaveLength(1);
 		expect(result.entities).toHaveLength(1);
@@ -138,7 +142,7 @@ ${VALID_RESPONSE}
 		}));
 		const response = JSON.stringify({ facts: manyFacts, entities: [] });
 		const provider = mockProvider([response]);
-		const result = await extractFactsAndEntities("Some long enough input text for extraction", provider);
+		const result = await extractFactsAndEntities(INPUT_GENERIC, provider);
 
 		expect(result.facts).toHaveLength(20);
 		expect(result.warnings.some((w) => w.includes("Truncated facts"))).toBe(true);
@@ -157,7 +161,7 @@ ${VALID_RESPONSE}
 			entities: [],
 		});
 		const provider = mockProvider([response]);
-		const result = await extractFactsAndEntities("Some content that is long enough to process through extraction", provider);
+		const result = await extractFactsAndEntities(INPUT_GENERIC, provider);
 
 		// Only the long fact should survive
 		expect(result.facts).toHaveLength(1);
@@ -177,7 +181,7 @@ ${VALID_RESPONSE}
 			entities: [],
 		});
 		const provider = mockProvider([response]);
-		const result = await extractFactsAndEntities("Some content that is long enough", provider);
+		const result = await extractFactsAndEntities(INPUT_GENERIC, provider);
 
 		expect(result.facts).toHaveLength(1);
 		expect(result.facts[0].type).toBe("fact");
@@ -186,7 +190,7 @@ ${VALID_RESPONSE}
 
 	it("returns empty with warning on total parse failure", async () => {
 		const provider = mockProvider(["this is not valid json at all"]);
-		const result = await extractFactsAndEntities("Some content that is long enough to process", provider);
+		const result = await extractFactsAndEntities(INPUT_GENERIC, provider);
 
 		expect(result.facts).toHaveLength(0);
 		expect(result.entities).toHaveLength(0);
@@ -217,7 +221,7 @@ ${VALID_RESPONSE}
 			],
 		});
 		const provider = mockProvider([response]);
-		const result = await extractFactsAndEntities("Some content that is long enough to process", provider);
+		const result = await extractFactsAndEntities(INPUT_GENERIC, provider);
 
 		expect(result.facts[0].confidence).toBe(1);
 		expect(result.facts[1].confidence).toBe(0);
@@ -234,7 +238,7 @@ ${VALID_RESPONSE}
 			entities: [],
 		});
 		const provider = mockProvider([response]);
-		const result = await extractFactsAndEntities("Some content that is long enough to process through extraction", provider);
+		const result = await extractFactsAndEntities(INPUT_GENERIC, provider);
 
 		// First two facts are 36 and 56 chars — both under 80, should be rejected
 		// Third fact is 108 chars — should pass
@@ -289,7 +293,7 @@ ${VALID_RESPONSE}
 			],
 		});
 		const provider = mockProvider([response]);
-		const result = await extractFactsAndEntities("Some content that is long enough to process", provider);
+		const result = await extractFactsAndEntities(INPUT_GENERIC, provider);
 
 		// Only the valid entity passes
 		expect(result.entities).toHaveLength(1);
@@ -308,7 +312,7 @@ ${VALID_RESPONSE}
 			},
 		};
 
-		await expect(extractFactsAndEntities("Some content that is long enough to process", errorProvider)).rejects.toThrow(
+		await expect(extractFactsAndEntities(INPUT_GENERIC, errorProvider)).rejects.toThrow(
 			"LLM extraction failed: connection refused",
 		);
 	});
@@ -322,7 +326,7 @@ ${VALID_RESPONSE}
 		}));
 		const response = JSON.stringify({ facts, entities: [] });
 		const provider = mockProvider([response]);
-		const result = await extractFactsAndEntities("Some content that is long enough to process", provider);
+		const result = await extractFactsAndEntities(INPUT_GENERIC, provider);
 
 		expect(result.facts).toHaveLength(validTypes.length);
 		for (let i = 0; i < validTypes.length; i++) {
@@ -335,7 +339,7 @@ ${VALID_RESPONSE}
 	it("handles non-array facts/entities gracefully", async () => {
 		const response = JSON.stringify({ facts: "not an array", entities: null });
 		const provider = mockProvider([response]);
-		const result = await extractFactsAndEntities("Some content that is long enough to process", provider);
+		const result = await extractFactsAndEntities(INPUT_GENERIC, provider);
 
 		expect(result.facts).toHaveLength(0);
 		expect(result.entities).toHaveLength(0);
@@ -344,7 +348,7 @@ ${VALID_RESPONSE}
 	it("parses JSON when Copilot model prefixes with explanation text", async () => {
 		const copilotStyle = `Sure, here is the extracted data from the text:\n\n${VALID_RESPONSE}`;
 		const provider = mockProvider([copilotStyle]);
-		const result = await extractFactsAndEntities("User prefers dark mode and uses vim keybindings", provider);
+		const result = await extractFactsAndEntities(INPUT, provider);
 
 		expect(result.facts).toHaveLength(2);
 		expect(result.entities).toHaveLength(1);
@@ -354,7 +358,7 @@ ${VALID_RESPONSE}
 	it("parses JSON when model adds verbose preamble without code fence", async () => {
 		const verbose = `I've analyzed the text and extracted the following facts and entities. Here is the result:\n${VALID_RESPONSE}`;
 		const provider = mockProvider([verbose]);
-		const result = await extractFactsAndEntities("User prefers dark mode and uses vim keybindings", provider);
+		const result = await extractFactsAndEntities(INPUT, provider);
 
 		expect(result.facts).toHaveLength(2);
 		expect(result.entities).toHaveLength(1);

--- a/packages/daemon/src/pipeline/extraction.ts
+++ b/packages/daemon/src/pipeline/extraction.ts
@@ -435,11 +435,11 @@ export async function extractFactsAndEntities(
 	opts?: { timeoutMs?: number; maxTokens?: number },
 ): Promise<ExtractionResult> {
 	const trimmed = input.trim().replace(/\s+/g, " ");
-	if (trimmed.length < 20) {
+	if (trimmed.length < MIN_FACT_LENGTH) {
 		return {
 			facts: [],
 			entities: [],
-			warnings: ["Input too short (< 20 chars)"],
+			warnings: [`Input too short (< ${MIN_FACT_LENGTH} chars)`],
 		};
 	}
 

--- a/packages/daemon/src/pipeline/extraction.ts
+++ b/packages/daemon/src/pipeline/extraction.ts
@@ -22,7 +22,7 @@ import type { LlmProvider } from "./provider";
 const MAX_FACTS = 20;
 const MAX_ENTITIES = 15;
 const MAX_FACT_LENGTH = 2000;
-const MIN_FACT_LENGTH = 20;
+const MIN_FACT_LENGTH = 80;
 const MAX_INPUT_CHARS = 12000;
 
 const VALID_TYPES = new Set<string>(MEMORY_TYPES);


### PR DESCRIPTION
## Summary

The memory database has been ballooning with low-quality transcript blobs. Root cause: a feedback loop where the summary-worker writes artifact `.md` files (transcripts, summaries, compactions, manifests) into `~/.agents/memory/` **and** inserts distilled facts directly into the DB via `insertSummaryFacts()`. The file watcher then picks up those same `.md` files, chunks them into 512-token blobs, and pushes them through the extraction pipeline a second time — producing thousands of noisy duplicate memories tagged `openclaw-memory`.

~3,188 artifact files out of ~3,957 total `.md` files in the memory directory were being re-ingested this way.

### Changes

- **Artifact exclusion** — `ingestMemoryMarkdown()` now skips files matching the artifact naming pattern (`*--summary.md`, `*--transcript.md`, etc.) since their content is already handled by the summary-worker's direct DB path
- **Chunk content gate** — markdown chunks with less than 80 chars of non-header body content are skipped before posting to `/api/memory/remember`
- **Raised MIN_FACT_LENGTH** — extraction pipeline minimum from 20 to 80 chars, filtering out section headers and sentence fragments that aren't useful as standalone memories

## Test plan

- [x] New regression test: facts in the 20-79 char range (previously accepted) are now rejected
- [x] New test file (`memory-ingest-filter.test.ts`): artifact filename regex matches all 4 artifact kinds, rejects legacy/named memory files
- [x] New test file: chunk body length gate accepts/rejects correctly
- [x] Updated existing extraction test fixtures for new 80-char minimum
- [x] All 42 extraction + ingest filter tests pass
- [x] Full suite: 39 pre-existing failures (Ollama timeouts), 0 new failures
- [ ] Manual: restart daemon, verify artifact files no longer appear in "Ingested memory file" logs