### PR TITLE
fix(cli): use wall-clock deadline for daemon startup poll and exit non-zero on failure

### DIFF
--- a/packages/cli/src/features/daemon.test.ts
+++ b/packages/cli/src/features/daemon.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "bun:test";
-import { doRestart, doStop, requestPipelinePauseApi, summarizePipelineToggle } from "./daemon.js";
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { doRestart, doStart, doStop, requestPipelinePauseApi, summarizePipelineToggle } from "./daemon.js";
 
 describe("requestPipelinePauseApi", () => {
 	it("uses the live daemon pause endpoint when available", async () => {
@@ -119,5 +119,64 @@ describe("daemon lifecycle recovery", () => {
 		await doStop({}, deps);
 
 		expect(stopped).toBe(true);
+	});
+});
+
+// Regression: #429 — failure paths must exit non-zero
+describe("daemon exit codes on failure", () => {
+	let exitSpy: ReturnType<typeof spyOn>;
+
+	afterEach(() => {
+		exitSpy?.mockRestore();
+	});
+
+	it("doStart exits with code 1 when startDaemon returns false", async () => {
+		exitSpy = spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("EXIT_1");
+		});
+
+		const deps = makeDeps({ startDaemon: async () => false });
+
+		await expect(doStart({}, deps)).rejects.toThrow("EXIT_1");
+		expect(exitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it("doStop exits with code 1 when stopDaemon returns false", async () => {
+		exitSpy = spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("EXIT_1");
+		});
+
+		const deps = makeDeps({
+			isDaemonRunning: async () => true,
+			stopDaemon: async () => false,
+		});
+
+		await expect(doStop({}, deps)).rejects.toThrow("EXIT_1");
+		expect(exitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it("doRestart exits with code 1 when startDaemon returns false", async () => {
+		exitSpy = spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("EXIT_1");
+		});
+
+		const deps = makeDeps({ startDaemon: async () => false });
+
+		await expect(doRestart({ openclaw: false }, deps)).rejects.toThrow("EXIT_1");
+		expect(exitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it("doRestart exits with code 1 when stopDaemon returns false during restart", async () => {
+		exitSpy = spyOn(process, "exit").mockImplementation(() => {
+			throw new Error("EXIT_1");
+		});
+
+		const deps = makeDeps({
+			isDaemonRunning: async () => true,
+			stopDaemon: async () => false,
+		});
+
+		await expect(doRestart({ openclaw: false }, deps)).rejects.toThrow("EXIT_1");
+		expect(exitSpy).toHaveBeenCalledWith(1);
 	});
 });

--- a/packages/cli/src/features/daemon.ts
+++ b/packages/cli/src/features/daemon.ts
@@ -205,6 +205,7 @@ export async function doStart(options: PathOptions, deps: Deps): Promise<void> {
 	}
 
 	spinner.fail("Failed to start daemon");
+	process.exit(1);
 }
 
 export async function doStop(options: PathOptions, deps: Deps): Promise<void> {
@@ -225,6 +226,7 @@ export async function doStop(options: PathOptions, deps: Deps): Promise<void> {
 	}
 
 	spinner.fail("Failed to stop daemon");
+	process.exit(1);
 }
 
 export async function doRestart(options: RestartOptions, deps: Deps): Promise<void> {
@@ -238,7 +240,7 @@ export async function doRestart(options: RestartOptions, deps: Deps): Promise<vo
 		const stopped = await deps.stopDaemon(basePath);
 		if (!stopped) {
 			spinner.fail("Failed to stop daemon");
-			return;
+			process.exit(1);
 		}
 		await deps.sleep(500);
 	}
@@ -253,7 +255,7 @@ export async function doRestart(options: RestartOptions, deps: Deps): Promise<vo
 		}
 	} else {
 		spinner.fail("Failed to restart daemon");
-		return;
+		process.exit(1);
 	}
 
 	if (options.openclaw === false || !isOpenClawDetected()) {

--- a/packages/cli/src/lib/runtime.ts
+++ b/packages/cli/src/lib/runtime.ts
@@ -454,13 +454,27 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR): Promise<boole
 		}
 	});
 
+	// Track process exit so the poll loop can short-circuit on fast failures
+	// (port conflict, missing binary, bad config) rather than waiting the
+	// full deadline.
+	let procExited = false;
+	proc.on("exit", () => {
+		procExited = true;
+	});
+
 	proc.unref();
 	if (stderrFd !== null) {
 		closeSync(stderrFd);
 	}
 
-	for (let i = 0; i < 20; i += 1) {
+	// Use wall-clock deadline instead of iteration count so the budget
+	// is always ~15 real seconds regardless of how long each health
+	// probe takes (connection-refused can stall up to 1.2s per probe).
+	// If the spawned process exits early (fast failure), break immediately.
+	const deadline = Date.now() + 15_000;
+	while (Date.now() < deadline) {
 		await sleep(250);
+		if (procExited) break;
 		if (await isDaemonRunning()) {
 			return true;
 		}


### PR DESCRIPTION
## Summary

Fix false "Failed to start daemon" message caused by a poll timeout that was shorter than actual daemon startup time, and add missing non-zero exit codes on all daemon lifecycle failure paths.

## Context

`signet daemon start` (and `signet start`) always reports "Failed to start daemon" on systems where the daemon takes more than ~5 seconds to start — even though the daemon starts successfully. The root cause is a hardcoded 20-iteration poll loop (20 x 250ms = 5s nominal budget) in `startDaemon()`, but each `isDaemonRunning()` call includes a 1.2s `AbortSignal.timeout` on the health probe. Under connection-refused conditions, each iteration can consume up to ~1.45s, exhausting the loop in as few as 3-4 polls — well before many systems finish starting (~8s observed on Ubuntu 24.04 VM).

Additionally, `doStart()`, `doStop()`, and `doRestart()` all printed failure messages but returned with exit code 0, misleading scripts and users.

Reported in #429 (tracked internally as #331).

## Changes

### 1. Wall-clock deadline for startup polling (`packages/cli/src/lib/runtime.ts`)

Replaced the fixed `for (let i = 0; i < 20; ...)` loop with a deadline-based `while (Date.now() < deadline)` loop using a 15-second wall-clock budget. This guarantees ~15 real seconds of polling regardless of how long each health probe takes, handling both fast-reject (TCP RST) and slow-timeout scenarios correctly.

### 2. Non-zero exit codes on failure (`packages/cli/src/features/daemon.ts`)

Added `process.exit(1)` to four failure paths that previously returned normally:

| Function | Failure message |
|---|---|
| `doStart` | "Failed to start daemon" |
| `doStop` | "Failed to stop daemon" |
| `doRestart` | "Failed to stop daemon" (during restart) |
| `doRestart` | "Failed to restart daemon" |

`launchDashboard` already had `process.exit(1)` — no change needed.

## Testing

All 6 existing daemon tests pass:

```bash
bun test packages/cli/src/features/daemon.test.ts
```

Manual verification:
1. `signet daemon stop`
2. `signet daemon start` — should no longer show false failure on systems with >5s startup
3. On actual failure (e.g. port conflict), CLI now exits with code 1

## Links

- Closes #429
