### PR TITLE
fix(daemon): remove propertyNames from MCP tool schemas for OpenAI compat

### DIFF
--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -752,10 +752,9 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 			inputSchema: z.object({
 				session_key: z.string().describe("Current session key"),
 				agent_id: z.string().optional().describe("Agent id scope (default: default)"),
-				ratings: z.record(z.string(), z.number()).describe("Map of memory ID to relevance score (-1 to 1)"),
+				ratings: z.record(z.number()).describe("Map of memory ID to relevance score (-1 to 1)"),
 				paths: z
 					.record(
-						z.string(),
 						z.object({
 							entity_ids: z.array(z.string()).optional(),
 							aspect_ids: z.array(z.string()).optional(),
@@ -766,7 +765,6 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 					.describe("Optional path provenance keyed by memory id"),
 				rewards: z
 					.record(
-						z.string(),
 						z.object({
 							forward_citation: z.number().optional(),
 							update_after_retrieval: z.number().optional(),
@@ -1299,7 +1297,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 			inputSchema: z.object({
 				server_id: z.string().describe("Installed Tool Server id"),
 				tool: z.string().describe("Tool name exposed by that server"),
-				args: z.record(z.string(), z.unknown()).optional().describe("Tool argument object"),
+				args: z.record(z.unknown()).optional().describe("Tool argument object"),
 			}),
 			annotations: { readOnlyHint: false },
 		},


### PR DESCRIPTION
## Summary

Remove `propertyNames` from MCP tool JSON Schemas so Signet works with OpenAI/Codex models, not just Claude.

## Context

Zod's `z.record(KeyType, ValueType)` two-argument form emits a `propertyNames: { type: "string" }` constraint in the generated JSON Schema. Anthropic's Claude silently accepts this keyword. OpenAI's function-calling API rejects it outright with a 400:

```
"Invalid schema for function 'mcp_signet_tool_mcp_server_call':
 In context=('properties', 'args'), 'propertyNames' is not permitted."
```

This causes ForgeCode (and any other harness that forwards tool schemas to an OpenAI-compatible endpoint) to fail hard at startup when using Codex/GPT models — no tool calls can be made at all. It worked on Claude models because Anthropic is lenient about extra JSON Schema keywords.

## Changes

Drop the explicit key-type argument on all affected `z.record()` calls in `packages/daemon/src/mcp/tools.ts`:

- `z.record(z.string(), z.number())` → `z.record(z.number())`
- `z.record(z.string(), z.object({...}))` → `z.record(z.object({...}))`
- `z.record(z.string(), z.unknown())` → `z.record(z.unknown())`

`z.record(ValueType)` produces `{ type: "object", additionalProperties: {...} }` with no `propertyNames` — accepted by both Claude and OpenAI.

**Affected tools (4 fields across 2 tools):**
- `memory_feedback`: `ratings`, `paths`, `rewards`
- `mcp_server_call`: `args`

The Rust shadow (`daemon-rs`) was already clean — its `mcp_server_call` schema uses a bare `{ "type": "object" }` with no `propertyNames`.

## Testing

```bash
# Run MCP tools unit tests
bun test packages/daemon/src/mcp/tools.test.ts

# Verify no TypeScript errors
bun run typecheck
```

All 23 MCP tools tests pass. Typecheck clean.

To verify the fix end-to-end: run ForgeCode with a Codex/GPT model after the daemon restart — the 400 error should be gone and all `mcp_signet_tool_*` functions should be callable.
