### PR TITLE
feat(os+extension): complete OS chat and Ask Signet UX overhaul + Chrome/Firefox Extension Improvements

### DIFF
--- a/packages/cli/dashboard/src/app.html
+++ b/packages/cli/dashboard/src/app.html
@@ -17,7 +17,7 @@
 			// Set theme before first paint to prevent flash
 			(function() {
 				var t = localStorage.getItem('signet-theme');
-				if (!t) {
+				if (!t || t === 'auto') {
 					t = window.matchMedia('(prefers-color-scheme: light)').matches
 						? 'light' : 'dark';
 				}

--- a/packages/cli/dashboard/src/lib/api.ts
+++ b/packages/cli/dashboard/src/lib/api.ts
@@ -532,6 +532,39 @@ export async function recallMemories(
 	}
 }
 
+export interface RememberMemoryRequest {
+	content: string;
+	who?: string;
+	project?: string;
+	importance?: number;
+	tags?: string;
+	pinned?: boolean;
+	type?: string;
+	sourceType?: string;
+	sourceId?: string;
+	agentId?: string;
+}
+
+export async function rememberMemory(request: RememberMemoryRequest): Promise<{ success: boolean; id?: string; error?: string }> {
+	try {
+		const response = await fetch(`${API_BASE}/api/memory/remember`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(request),
+		});
+		if (!response.ok) {
+			const body = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+			const error = typeof body.error === "string" ? body.error : `Request failed (${response.status})`;
+			return { success: false, error };
+		}
+		const data = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+		const id = typeof data.id === "string" ? data.id : undefined;
+		return { success: true, id };
+	} catch (error) {
+		return { success: false, error: String(error) };
+	}
+}
+
 export async function getDistinctWho(): Promise<string[]> {
 	try {
 		const response = await fetch(`${API_BASE}/memory/search?distinct=who`);

--- a/packages/cli/dashboard/src/lib/components/os/AgentChat.svelte
+++ b/packages/cli/dashboard/src/lib/components/os/AgentChat.svelte
@@ -15,7 +15,14 @@ import ExternalLink from "@lucide/svelte/icons/external-link";
 import Send from "@lucide/svelte/icons/send";
 import User from "@lucide/svelte/icons/user";
 import Wrench from "@lucide/svelte/icons/wrench";
-import { tick } from "svelte";
+import { onMount, tick } from "svelte";
+
+interface ChatModelOption {
+	id: string;
+	label: string;
+	description: string;
+	provider: string;
+}
 
 interface ToolCall {
 	tool: string;
@@ -32,12 +39,68 @@ interface ChatMessage {
 	openedWidget?: string; // server ID of widget that was opened
 }
 
+type HeaderChatAction = "remember" | "transcribe" | "recall";
+
+interface HeaderActionOptions {
+	targetLanguage?: string;
+}
+
+interface HeaderActionResult {
+	ok: boolean;
+	message?: string;
+	error?: string;
+}
+
+interface SendInvocation {
+	messageText: string;
+	displayText?: string;
+	clearInput?: boolean;
+}
+
 let messages = $state<ChatMessage[]>([]);
 let input = $state("");
 let loading = $state(false);
 let loadingStatus = $state("");
 let chatEl: HTMLDivElement | null = $state(null);
+let modelOptions = $state<ChatModelOption[]>([]);
+let selectedModelId = $state("");
+let modelOptionsLoading = $state(true);
+let modelOptionsError = $state<string | null>(null);
 const AGENT_EXEC_TIMEOUT_MS = 30_000;
+
+onMount(() => {
+	void loadChatModels();
+});
+
+async function loadChatModels(): Promise<void> {
+	modelOptionsLoading = true;
+	modelOptionsError = null;
+	try {
+		const res = await fetch(`${API_BASE}/api/os/chat/models`);
+		if (!res.ok) throw new Error(`Chat model request failed (${res.status})`);
+		const data = (await res.json()) as {
+			options?: ChatModelOption[];
+			defaultModelId?: string;
+		};
+		const options = Array.isArray(data.options) ? data.options : [];
+		modelOptions = options;
+
+		if (typeof data.defaultModelId === "string" && options.some((opt) => opt.id === data.defaultModelId)) {
+			selectedModelId = data.defaultModelId;
+		} else if (options.length > 0) {
+			selectedModelId = options[0]!.id;
+		} else {
+			selectedModelId = "";
+			modelOptionsError = "No available chat providers were discovered. Install/configure Codex, Claude Code, OpenCode, or Ollama.";
+		}
+	} catch (err) {
+		modelOptions = [];
+		selectedModelId = "";
+		modelOptionsError = err instanceof Error ? err.message : "Unable to load chat models";
+	} finally {
+		modelOptionsLoading = false;
+	}
+}
 
 async function scrollToBottom() {
 	await tick();
@@ -273,12 +336,30 @@ async function executeAgentTask(serverId: string, task: string): Promise<string>
 	}
 }
 
-async function send() {
-	const text = input.trim();
-	if (!text || loading) return;
+function buildSessionTranscript(limit = 16): string {
+	const recent = messages.slice(-limit);
+	return recent
+		.map((msg, index) => `${index + 1}. ${msg.role.toUpperCase()}: ${msg.content}`)
+		.join("\n");
+}
 
-	messages.push({ role: "user", content: text, timestamp: Date.now() });
-	input = "";
+async function sendInvocation(invocation: SendInvocation): Promise<boolean> {
+	const text = invocation.messageText.trim();
+	if (!text || loading) return false;
+	if (!selectedModelId) {
+		messages.push({
+			role: "agent",
+			content:
+				modelOptionsError ||
+				"No chat provider is selected. Start the branch daemon and make sure /api/os/chat/models is reachable.",
+			timestamp: Date.now(),
+		});
+		await scrollToBottom();
+		return false;
+	}
+
+	messages.push({ role: "user", content: invocation.displayText?.trim() || text, timestamp: Date.now() });
+	if (invocation.clearInput) input = "";
 	loading = true;
 	loadingStatus = "thinking...";
 	scrollToBottom();
@@ -288,9 +369,19 @@ async function send() {
 		const res = await fetch(`${API_BASE}/api/os/chat`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ message: text }),
+			body: JSON.stringify({ message: text, modelId: selectedModelId }),
 		});
-		const data = await res.json();
+		const data = (await res.json().catch(() => ({}))) as {
+			response?: string;
+			error?: string;
+			useAgent?: boolean;
+			agentServerId?: string;
+			agentTask?: string;
+			toolCalls?: ToolCall[];
+		};
+		if (!res.ok) {
+			throw new Error(data.error || `Chat request failed (${res.status})`);
+		}
 
 		// ═══════════════════════════════════════════════════════════════
 		// VISUAL AGENT MODE — LLM decided this needs the AI cursor
@@ -322,10 +413,7 @@ async function send() {
 				});
 			}
 
-			loading = false;
-			loadingStatus = "";
-			scrollToBottom();
-			return;
+			return true;
 		}
 
 		// ═══════════════════════════════════════════════════════════════
@@ -392,17 +480,99 @@ async function send() {
 			toolCalls,
 			openedWidget,
 		});
+		return true;
 	} catch (err) {
 		messages.push({
 			role: "agent",
 			content: `Error: ${err instanceof Error ? err.message : "Unknown error"}`,
 			timestamp: Date.now(),
 		});
+		return false;
 	} finally {
 		loading = false;
 		loadingStatus = "";
 		scrollToBottom();
 	}
+}
+
+export async function triggerHeaderAction(
+	action: HeaderChatAction,
+	options: HeaderActionOptions = {},
+): Promise<HeaderActionResult> {
+	if (loading) {
+		return { ok: false, error: "Chat is busy right now. Wait for the current response to finish." };
+	}
+
+	if (action === "transcribe") {
+		const sourceText = input.trim();
+		if (!sourceText) {
+			return { ok: false, error: "Paste text into the chat input first, then click Transcribe." };
+		}
+		const targetLanguage = options.targetLanguage?.trim() || "English";
+		const sent = await sendInvocation({
+			messageText: [
+				"You are Signet OS Transcribe mode.",
+				`Transcribe and translate the provided text into ${targetLanguage}.`,
+				"Preserve intent, tone, and key details.",
+				"Return only the final transcription in the target language.",
+				"Text:",
+				sourceText,
+			].join("\n\n"),
+			displayText: `Transcribe to ${targetLanguage}:\n${sourceText}`,
+			clearInput: true,
+		});
+		return sent
+			? { ok: true, message: `Transcribe request sent through chat (${targetLanguage}).` }
+			: { ok: false, error: "Transcribe request failed. Check the latest chat output." };
+	}
+
+	const transcript = buildSessionTranscript();
+	if (!transcript) {
+		return { ok: false, error: "No active chat session yet. Start chatting first." };
+	}
+
+	if (action === "remember") {
+		const sent = await sendInvocation({
+			messageText: [
+				"You are Signet OS Remember mode.",
+				"Use this current chat session transcript as context.",
+				"Persist the important long-term facts from this session if memory tools are available.",
+				"Then reply with: (1) what you remembered, (2) confidence, (3) any items not stored.",
+				"Session transcript:",
+				transcript,
+			].join("\n\n"),
+			displayText: "Remember everything important from this current session.",
+		});
+		return sent
+			? { ok: true, message: "Remember request sent through chat." }
+			: { ok: false, error: "Remember request failed. Check the latest chat output." };
+	}
+
+	const focus = input.trim();
+	const sent = await sendInvocation({
+		messageText: [
+			"You are Signet OS Recall mode.",
+			"Compare relevant saved memories with the active session context.",
+			"Highlight similarities, differences, missing facts, and potential conflicts.",
+			"If memory tools are available, use them before answering.",
+			focus ? `Focus query: ${focus}` : "Focus query: current session",
+			"Session transcript:",
+			transcript,
+		].join("\n\n"),
+		displayText: focus
+			? `Recall and compare memories against this context:\n${focus}`
+			: "Recall and compare memories against this session.",
+		clearInput: Boolean(focus),
+	});
+	return sent
+		? { ok: true, message: "Recall request sent through chat." }
+		: { ok: false, error: "Recall request failed. Check the latest chat output." };
+}
+
+async function send() {
+	const text = input.trim();
+	if (!text) return;
+	await sendInvocation({ messageText: text, displayText: text, clearInput: true });
 }
 
 function handleKeydown(e: KeyboardEvent) {
@@ -508,6 +678,23 @@ function scrollToWidget(serverId: string): void {
 
 	<!-- Input bar -->
 	<div class="chat-input-bar">
+		{#if modelOptionsError}
+			<div class="chat-model-error">{modelOptionsError}</div>
+		{/if}
+		<select
+			class="chat-model-select"
+			bind:value={selectedModelId}
+			disabled={loading || modelOptionsLoading}
+			title="Choose chat model"
+		>
+			{#if modelOptions.length > 0}
+				{#each modelOptions as option (option.id)}
+					<option value={option.id}>{option.label}</option>
+				{/each}
+			{:else}
+				<option value="" disabled>No providers found</option>
+			{/if}
+		</select>
 		<input
 			type="text"
 			class="chat-input"
@@ -520,7 +707,7 @@ function scrollToWidget(serverId: string): void {
 			class="chat-send-btn"
 			title="Send message"
 			onclick={send}
-			disabled={loading || !input.trim()}
+			disabled={loading || !selectedModelId || !input.trim()}
 		>
 			<Send class="size-3.5" />
 		</button>
@@ -533,8 +720,8 @@ function scrollToWidget(serverId: string): void {
 		flex-direction: column;
 		border-top: 1px solid var(--sig-border);
 		background: var(--sig-bg);
-		max-height: 280px;
-		min-height: 120px;
+		max-height: 360px;
+		min-height: 140px;
 	}
 
 	.chat-messages {
@@ -575,7 +762,7 @@ function scrollToWidget(serverId: string): void {
 
 	.chat-msg-icon {
 		display: flex;
-		align-items: flex-start;
+		align-items: center;
 		justify-content: center;
 		width: 22px;
 		height: 22px;
@@ -584,13 +771,35 @@ function scrollToWidget(serverId: string): void {
 		border: 1px solid var(--sig-border);
 		color: var(--sig-text-muted);
 		flex-shrink: 0;
-		padding-top: 4px;
+		padding: 0;
+	}
+
+	.chat-msg-icon :global(svg) {
+		width: 12px;
+		height: 12px;
+		color: currentColor;
+	}
+
+	.chat-msg--agent .chat-msg-icon {
+		border-color: color-mix(in srgb, var(--sig-highlight) 62%, var(--sig-warning));
+		background: color-mix(in srgb, var(--sig-highlight) 11%, var(--sig-surface));
+		box-shadow: 0 0 0 1px color-mix(in srgb, var(--sig-highlight) 30%, transparent), var(--sig-glow-highlight);
+		color: var(--sig-text-muted);
 	}
 
 	.chat-msg--user .chat-msg-icon {
-		background: color-mix(in srgb, var(--sig-accent) 15%, var(--sig-surface));
-		border-color: color-mix(in srgb, var(--sig-accent) 30%, var(--sig-border));
-		color: var(--sig-accent);
+		background: color-mix(in srgb, var(--sig-surface) 90%, var(--sig-bg));
+		border-color: color-mix(in srgb, var(--sig-warning) 55%, var(--sig-border));
+		color: var(--sig-text-muted);
+	}
+
+	.chat-msg--user .chat-msg-icon :global(svg) {
+		color: color-mix(in srgb, var(--sig-highlight) 84%, var(--sig-warning));
+		background: color-mix(in srgb, var(--sig-highlight) 22%, transparent);
+		border: 1px solid color-mix(in srgb, var(--sig-highlight) 58%, var(--sig-warning));
+		border-radius: 999px;
+		padding: 1px;
+		box-shadow: var(--sig-glow-highlight);
 	}
 
 	.chat-msg-body {
@@ -609,6 +818,7 @@ function scrollToWidget(serverId: string): void {
 		border-radius: 8px;
 		padding: 6px 10px;
 		word-break: break-word;
+		white-space: pre-wrap;
 	}
 
 	.chat-msg--user .chat-msg-content {
@@ -774,11 +984,42 @@ function scrollToWidget(serverId: string): void {
 	.chat-input-bar {
 		display: flex;
 		align-items: center;
+		flex-wrap: wrap;
 		gap: 6px;
 		padding: 8px var(--space-md);
 		border-top: 1px solid var(--sig-border);
 		background: var(--sig-surface);
 		flex-shrink: 0;
+	}
+
+	.chat-model-error {
+		width: 100%;
+		font-family: var(--font-mono);
+		font-size: 10px;
+		line-height: 1.4;
+		color: var(--sig-danger, #8a4545);
+	}
+
+	.chat-model-select {
+		width: 220px;
+		max-width: 42%;
+		font-family: var(--font-mono);
+		font-size: 11px;
+		color: var(--sig-text);
+		background: var(--sig-bg);
+		border: 1px solid var(--sig-border);
+		border-radius: 6px;
+		padding: 6px 8px;
+		outline: none;
+		transition: border-color var(--dur) var(--ease);
+	}
+
+	.chat-model-select:focus {
+		border-color: var(--sig-accent);
+	}
+
+	.chat-model-select:disabled {
+		opacity: 0.5;
 	}
 
 	.chat-input {

--- a/packages/cli/dashboard/src/lib/components/os/AgentChat.svelte
+++ b/packages/cli/dashboard/src/lib/components/os/AgentChat.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { API_BASE } from "$lib/api";
+import { API_BASE, getIdentity } from "$lib/api";
 import {
 	os,
 	fetchTrayEntries,
@@ -10,8 +10,11 @@ import {
 	setAgentSession,
 } from "$lib/stores/os.svelte";
 import Bot from "@lucide/svelte/icons/bot";
+import Check from "@lucide/svelte/icons/check";
+import Copy from "@lucide/svelte/icons/copy";
 import Cpu from "@lucide/svelte/icons/cpu";
 import ExternalLink from "@lucide/svelte/icons/external-link";
+import Mic from "@lucide/svelte/icons/mic";
 import Send from "@lucide/svelte/icons/send";
 import User from "@lucide/svelte/icons/user";
 import Wrench from "@lucide/svelte/icons/wrench";
@@ -22,6 +25,11 @@ interface ChatModelOption {
 	label: string;
 	description: string;
 	provider: string;
+}
+
+interface AudioInputOption {
+	id: string;
+	label: string;
 }
 
 interface ToolCall {
@@ -57,19 +65,62 @@ interface SendInvocation {
 	clearInput?: boolean;
 }
 
+type SpeechRecognitionInstance = {
+	continuous: boolean;
+	interimResults: boolean;
+	lang: string;
+	onresult: ((event: Event) => void) | null;
+	onerror: ((event: Event) => void) | null;
+	onend: (() => void) | null;
+	start: (track?: MediaStreamTrack) => void;
+	stop: () => void;
+};
+
+type SpeechRecognitionCtor = new () => SpeechRecognitionInstance;
+
 let messages = $state<ChatMessage[]>([]);
 let input = $state("");
 let loading = $state(false);
 let loadingStatus = $state("");
 let chatEl: HTMLDivElement | null = $state(null);
+let inputEl: HTMLInputElement | null = $state(null);
 let modelOptions = $state<ChatModelOption[]>([]);
 let selectedModelId = $state("");
 let modelOptionsLoading = $state(true);
 let modelOptionsError = $state<string | null>(null);
+let speechSupported = $state(false);
+let listening = $state(false);
+let voiceBusy = $state(false);
+let voiceError = $state<string | null>(null);
+let recognition: SpeechRecognitionInstance | null = null;
+let activeMicStream: MediaStream | null = null;
+let microphoneOptions = $state<AudioInputOption[]>([]);
+let selectedMicrophoneId = $state("default");
+let signetIdentityName = $state("your Signet identity");
+let copiedMessageTimestamp = $state<number | null>(null);
+let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
 const AGENT_EXEC_TIMEOUT_MS = 30_000;
 
 onMount(() => {
 	void loadChatModels();
+	void loadIdentityName();
+	void loadMicrophoneOptions();
+	speechSupported = Boolean(getSpeechRecognitionCtor());
+	const handleDeviceChange = () => {
+		void loadMicrophoneOptions();
+	};
+	navigator.mediaDevices?.addEventListener?.("devicechange", handleDeviceChange);
+	return () => {
+		if (copyResetTimer) {
+			clearTimeout(copyResetTimer);
+			copyResetTimer = null;
+		}
+		if (recognition && listening) {
+			recognition.stop();
+		}
+		releaseActiveMicStream();
+		navigator.mediaDevices?.removeEventListener?.("devicechange", handleDeviceChange);
+	};
 });
 
 async function loadChatModels(): Promise<void> {
@@ -99,6 +150,175 @@ async function loadChatModels(): Promise<void> {
 		modelOptionsError = err instanceof Error ? err.message : "Unable to load chat models";
 	} finally {
 		modelOptionsLoading = false;
+	}
+}
+
+async function loadIdentityName(): Promise<void> {
+	try {
+		const identity = await getIdentity();
+		const resolved = identity?.name?.trim();
+		if (resolved && resolved.toLowerCase() !== "unknown") {
+			signetIdentityName = resolved.toLowerCase();
+		}
+	} catch {
+		// Keep fallback copy when identity is unavailable.
+	}
+}
+
+function getSpeechRecognitionCtor(): SpeechRecognitionCtor | null {
+	if (typeof window === "undefined") return null;
+	const maybeCtor = (window as Window & { SpeechRecognition?: SpeechRecognitionCtor; webkitSpeechRecognition?: SpeechRecognitionCtor })
+		.SpeechRecognition ??
+		(window as Window & { webkitSpeechRecognition?: SpeechRecognitionCtor }).webkitSpeechRecognition;
+	return maybeCtor ?? null;
+}
+
+function releaseActiveMicStream(): void {
+	if (!activeMicStream) return;
+	for (const track of activeMicStream.getTracks()) {
+		track.stop();
+	}
+	activeMicStream = null;
+}
+
+async function loadMicrophoneOptions(): Promise<void> {
+	if (!navigator.mediaDevices?.enumerateDevices) return;
+	const devices = await navigator.mediaDevices.enumerateDevices();
+	const discovered = devices
+		.filter((device) => device.kind === "audioinput")
+		.map((device, index) => ({
+			id: device.deviceId,
+			label: device.label?.trim() || `Microphone ${index + 1}`,
+		}));
+	const options: AudioInputOption[] = [
+		{ id: "default", label: "Browser default microphone" },
+		...discovered.filter((device) => device.id !== "default"),
+	];
+	microphoneOptions = options;
+	if (!selectedMicrophoneId || !options.some((option) => option.id === selectedMicrophoneId)) {
+		selectedMicrophoneId = "default";
+	}
+}
+
+async function requestMicrophoneStream(deviceId?: string): Promise<MediaStream> {
+	if (!navigator.mediaDevices?.getUserMedia) {
+		throw new Error("Microphone capture is not supported in this browser.");
+	}
+	if (deviceId && deviceId !== "default") {
+		try {
+			return await navigator.mediaDevices.getUserMedia({ audio: { deviceId: { exact: deviceId } } });
+		} catch {
+			return await navigator.mediaDevices.getUserMedia({ audio: true });
+		}
+	}
+	return await navigator.mediaDevices.getUserMedia({ audio: true });
+}
+
+function appendVoiceTranscript(text: string): void {
+	const transcript = text.trim();
+	if (!transcript) return;
+	input = transcript;
+	inputEl?.focus();
+}
+
+function extractTranscriptFromVoiceEvent(event: Event): string {
+	const speechEvent = event as Event & {
+		results?: ArrayLike<{
+			isFinal?: boolean;
+			0?: { transcript?: string };
+			item?: (index: number) => { transcript?: string } | null;
+		}> & {
+			item?: (index: number) => {
+				isFinal?: boolean;
+				0?: { transcript?: string };
+				item?: (index: number) => { transcript?: string } | null;
+			} | null;
+		};
+	};
+	const list = speechEvent.results;
+	if (!list) return "";
+
+	let transcript = "";
+	for (let index = 0; index < list.length; index += 1) {
+		const result = list[index] ?? list.item?.(index) ?? null;
+		const primaryAlt = result?.[0] ?? result?.item?.(0) ?? null;
+		const chunk = typeof primaryAlt?.transcript === "string" ? primaryAlt.transcript.trim() : "";
+		if (!chunk) continue;
+		transcript += `${chunk} `;
+	}
+
+	if (transcript.trim()) return transcript.trim();
+
+	const fallbackTranscript = (event as Event & { transcript?: string }).transcript;
+	return typeof fallbackTranscript === "string" ? fallbackTranscript.trim() : "";
+}
+
+async function toggleVoiceCapture(): Promise<void> {
+	voiceError = null;
+	if (listening) {
+		voiceBusy = true;
+		recognition?.stop();
+		return;
+	}
+
+	const ctor = getSpeechRecognitionCtor();
+	if (!ctor) {
+		voiceError = "Voice input is not supported in this browser.";
+		return;
+	}
+
+	voiceBusy = true;
+	try {
+		releaseActiveMicStream();
+		activeMicStream = await requestMicrophoneStream(selectedMicrophoneId || undefined);
+		await loadMicrophoneOptions();
+		const inputBase = input.trim();
+		recognition = new ctor();
+		recognition.continuous = false;
+		recognition.interimResults = true;
+		recognition.lang = navigator.language || "en-US";
+		recognition.onresult = (event: Event) => {
+			const transcript = extractTranscriptFromVoiceEvent(event);
+			if (!transcript) return;
+			const merged = inputBase ? `${inputBase} ${transcript}` : transcript;
+			appendVoiceTranscript(merged);
+		};
+		recognition.onerror = (event: Event) => {
+			const errorValue = (event as Event & { error?: string }).error;
+			if (errorValue === "no-speech") {
+				voiceError = "No speech detected. Try speaking immediately after the mic turns active.";
+			} else if (errorValue && errorValue !== "aborted") {
+				voiceError = `Voice capture failed: ${errorValue}`;
+			}
+			listening = false;
+			voiceBusy = false;
+			recognition = null;
+			releaseActiveMicStream();
+		};
+		recognition.onend = () => {
+			listening = false;
+			voiceBusy = false;
+			recognition = null;
+			releaseActiveMicStream();
+		};
+		listening = true;
+		voiceBusy = false;
+		const selectedTrack = activeMicStream.getAudioTracks()[0] ?? undefined;
+		if (selectedTrack) {
+			try {
+				recognition.start(selectedTrack);
+			} catch {
+				recognition.start();
+			}
+		} else {
+			recognition.start();
+		}
+	} catch (error) {
+		voiceError = error instanceof Error ? error.message : "Unable to access microphone.";
+		listening = false;
+		voiceBusy = false;
+		recognition = null;
+		releaseActiveMicStream();
 	}
 }
 
@@ -582,6 +802,66 @@ function handleKeydown(e: KeyboardEvent) {
 	}
 }
 
+function handleInputDragOver(e: DragEvent): void {
+	const types = e.dataTransfer?.types;
+	if (!types) return;
+	if (!types.includes("application/x-signet-chat-snippet")) return;
+	e.preventDefault();
+	if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+}
+
+function insertTextAtCursor(target: HTMLInputElement, text: string): void {
+	const start = target.selectionStart ?? target.value.length;
+	const end = target.selectionEnd ?? target.value.length;
+	const before = target.value.slice(0, start);
+	const after = target.value.slice(end);
+	target.value = `${before}${text}${after}`;
+	const nextPos = start + text.length;
+	target.selectionStart = nextPos;
+	target.selectionEnd = nextPos;
+	input = target.value;
+}
+
+function handleInputDrop(e: DragEvent): void {
+	const snippet = e.dataTransfer?.getData("application/x-signet-chat-snippet")?.trim();
+	if (!snippet) return;
+	e.preventDefault();
+	if (!inputEl) {
+		input = `${input}${input ? " " : ""}${snippet}`.trim();
+		return;
+	}
+	insertTextAtCursor(inputEl, snippet);
+}
+
+async function copyMessageContent(content: string, timestamp: number): Promise<void> {
+	const text = content.trim();
+	if (!text) return;
+	try {
+		if (navigator.clipboard?.writeText) {
+			await navigator.clipboard.writeText(text);
+		} else {
+			const area = document.createElement("textarea");
+			area.value = text;
+			area.style.position = "fixed";
+			area.style.opacity = "0";
+			document.body.appendChild(area);
+			area.focus();
+			area.select();
+			document.execCommand("copy");
+			area.remove();
+		}
+		copiedMessageTimestamp = timestamp;
+		if (copyResetTimer) clearTimeout(copyResetTimer);
+		copyResetTimer = setTimeout(() => {
+			if (copiedMessageTimestamp === timestamp) {
+				copiedMessageTimestamp = null;
+			}
+		}, 1800);
+	} catch {
+		// Ignore clipboard failures silently; chat remains usable.
+	}
+}
+
 function formatTime(ts: number): string {
 	return new Date(ts).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
@@ -606,7 +886,7 @@ function scrollToWidget(serverId: string): void {
 			<div class="chat-empty">
 				<Bot class="size-5 opacity-30" />
 				<span class="sig-label" style="color: var(--sig-text-muted)">
-					Ask me anything — I'll pull up the right app and show you the data live.
+					Ask {signetIdentityName} a question, or anything you want.
 				</span>
 			</div>
 		{/if}
@@ -621,6 +901,22 @@ function scrollToWidget(serverId: string): void {
 					{/if}
 				</div>
 				<div class="chat-msg-body">
+					{#if msg.role === "agent"}
+						<div class="chat-msg-actions">
+							<button
+								class="chat-copy-btn"
+								type="button"
+								title="Copy response"
+								onclick={() => copyMessageContent(msg.content, msg.timestamp)}
+							>
+								{#if copiedMessageTimestamp === msg.timestamp}
+									<Check class="size-3" />
+								{:else}
+									<Copy class="size-3" />
+								{/if}
+							</button>
+						</div>
+					{/if}
 					<div class="chat-msg-content">{msg.content}</div>
 					{#if msg.toolCalls && msg.toolCalls.length > 0}
 						<div class="chat-tool-calls">
@@ -681,36 +977,79 @@ function scrollToWidget(serverId: string): void {
 		{#if modelOptionsError}
 			<div class="chat-model-error">{modelOptionsError}</div>
 		{/if}
-		<select
-			class="chat-model-select"
-			bind:value={selectedModelId}
-			disabled={loading || modelOptionsLoading}
-			title="Choose chat model"
-		>
-			{#if modelOptions.length > 0}
-				{#each modelOptions as option (option.id)}
-					<option value={option.id}>{option.label}</option>
-				{/each}
-			{:else}
-				<option value="" disabled>No providers found</option>
+		{#if voiceError}
+			<div class="chat-model-error">{voiceError}</div>
+		{/if}
+		<div class="chat-input-controls">
+			<select
+				class="chat-mic-select"
+				bind:value={selectedMicrophoneId}
+				disabled={loading || listening || microphoneOptions.length === 0}
+				title="Choose microphone"
+			>
+				{#if microphoneOptions.length > 0}
+					{#each microphoneOptions as mic (mic.id)}
+						<option value={mic.id}>{mic.label}</option>
+					{/each}
+				{:else}
+					<option value="" disabled>No microphones found</option>
+				{/if}
+			</select>
+			<select
+				class="chat-model-select"
+				bind:value={selectedModelId}
+				disabled={loading || modelOptionsLoading}
+				title="Choose chat model"
+			>
+				{#if modelOptions.length > 0}
+					{#each modelOptions as option (option.id)}
+						<option value={option.id}>{option.label}</option>
+					{/each}
+				{:else}
+					<option value="" disabled>No providers found</option>
+				{/if}
+			</select>
+		</div>
+		<div class="chat-input-compose">
+			<input
+				type="text"
+				class="chat-input"
+				placeholder="Ask your agent..."
+				bind:this={inputEl}
+				bind:value={input}
+				onkeydown={handleKeydown}
+				ondragover={handleInputDragOver}
+				ondrop={handleInputDrop}
+				disabled={loading}
+			/>
+			{#if speechSupported}
+				<button
+					class="chat-voice-btn"
+					class:active={listening}
+					title={listening ? "Stop voice input" : "Use microphone"}
+					onclick={toggleVoiceCapture}
+					disabled={loading || (voiceBusy && !listening)}
+				>
+					{#if listening}
+						<span class="chat-voice-bars" aria-hidden="true">
+							<span class="bar"></span>
+							<span class="bar"></span>
+							<span class="bar"></span>
+						</span>
+					{:else}
+						<Mic class="size-3.5" />
+					{/if}
+				</button>
 			{/if}
-		</select>
-		<input
-			type="text"
-			class="chat-input"
-			placeholder="Ask your agent..."
-			bind:value={input}
-			onkeydown={handleKeydown}
-			disabled={loading}
-		/>
-		<button
-			class="chat-send-btn"
-			title="Send message"
-			onclick={send}
-			disabled={loading || !selectedModelId || !input.trim()}
-		>
-			<Send class="size-3.5" />
-		</button>
+			<button
+				class="chat-send-btn"
+				title="Send message"
+				onclick={send}
+				disabled={loading || !selectedModelId || !input.trim()}
+			>
+				<Send class="size-3.5" />
+			</button>
+		</div>
 	</div>
 </div>
 
@@ -806,6 +1145,33 @@ function scrollToWidget(serverId: string): void {
 		display: flex;
 		flex-direction: column;
 		gap: 2px;
+	}
+
+	.chat-msg-actions {
+		display: flex;
+		justify-content: flex-end;
+		margin-bottom: 1px;
+	}
+
+	.chat-copy-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 22px;
+		height: 22px;
+		padding: 0;
+		border-radius: 6px;
+		border: 1px solid var(--sig-border);
+		background: var(--sig-bg);
+		color: var(--sig-text-muted);
+		cursor: pointer;
+		transition: all var(--dur) var(--ease);
+	}
+
+	.chat-copy-btn:hover {
+		border-color: var(--sig-highlight);
+		color: var(--sig-highlight);
+		background: color-mix(in srgb, var(--sig-highlight) 10%, var(--sig-bg));
 	}
 
 	.chat-msg-content {
@@ -983,9 +1349,9 @@ function scrollToWidget(serverId: string): void {
 	/* Input bar */
 	.chat-input-bar {
 		display: flex;
-		align-items: center;
-		flex-wrap: wrap;
-		gap: 6px;
+		flex-direction: column;
+		align-items: stretch;
+		gap: 8px;
 		padding: 8px var(--space-md);
 		border-top: 1px solid var(--sig-border);
 		background: var(--sig-surface);
@@ -1000,9 +1366,16 @@ function scrollToWidget(serverId: string): void {
 		color: var(--sig-danger, #8a4545);
 	}
 
-	.chat-model-select {
-		width: 220px;
-		max-width: 42%;
+	.chat-input-controls {
+		display: flex;
+		gap: 6px;
+		width: 100%;
+	}
+
+	.chat-model-select,
+	.chat-mic-select {
+		flex: 1 1 220px;
+		min-width: 0;
 		font-family: var(--font-mono);
 		font-size: 11px;
 		color: var(--sig-text);
@@ -1014,26 +1387,33 @@ function scrollToWidget(serverId: string): void {
 		transition: border-color var(--dur) var(--ease);
 	}
 
-	.chat-model-select:focus {
+	.chat-model-select:focus,
+	.chat-mic-select:focus {
 		border-color: var(--sig-accent);
 	}
 
-	.chat-model-select:disabled {
+	.chat-model-select:disabled,
+	.chat-mic-select:disabled {
 		opacity: 0.5;
 	}
 
+	.chat-input-compose {
+		position: relative;
+		width: 100%;
+	}
+
 	.chat-input {
-		flex: 1;
-		min-width: 0;
+		width: 100%;
 		font-family: var(--font-mono);
 		font-size: 12px;
 		color: var(--sig-text);
 		background: var(--sig-bg);
-		border: 1px solid var(--sig-border);
+		border: 1px solid color-mix(in srgb, var(--sig-highlight) 65%, var(--sig-border));
 		border-radius: 6px;
-		padding: 6px 10px;
+		padding: 8px 78px 8px 10px;
 		outline: none;
-		transition: border-color var(--dur) var(--ease);
+		box-shadow: 0 0 0 1px color-mix(in srgb, var(--sig-highlight) 22%, transparent);
+		transition: border-color var(--dur) var(--ease), box-shadow var(--dur) var(--ease);
 	}
 
 	.chat-input::placeholder {
@@ -1042,7 +1422,8 @@ function scrollToWidget(serverId: string): void {
 	}
 
 	.chat-input:focus {
-		border-color: var(--sig-accent);
+		border-color: var(--sig-highlight);
+		box-shadow: var(--sig-glow-highlight);
 	}
 
 	.chat-input:disabled {
@@ -1053,6 +1434,10 @@ function scrollToWidget(serverId: string): void {
 		display: flex;
 		align-items: center;
 		justify-content: center;
+		position: absolute;
+		right: 6px;
+		top: 50%;
+		transform: translateY(-50%);
 		width: 30px;
 		height: 30px;
 		padding: 0;
@@ -1062,7 +1447,80 @@ function scrollToWidget(serverId: string): void {
 		color: var(--sig-text-muted);
 		cursor: pointer;
 		transition: all var(--dur) var(--ease);
-		flex-shrink: 0;
+		z-index: 2;
+	}
+
+	.chat-voice-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		position: absolute;
+		right: 42px;
+		top: 50%;
+		transform: translateY(-50%);
+		width: 30px;
+		height: 30px;
+		padding: 0;
+		border: 1px solid var(--sig-border);
+		border-radius: 6px;
+		background: var(--sig-surface);
+		color: var(--sig-text-muted);
+		cursor: pointer;
+		transition: all var(--dur) var(--ease);
+		z-index: 2;
+	}
+
+	.chat-voice-btn:hover:not(:disabled) {
+		border-color: var(--sig-highlight);
+		color: var(--sig-highlight);
+		background: color-mix(in srgb, var(--sig-highlight) 10%, var(--sig-surface));
+	}
+
+	.chat-voice-btn.active {
+		border-color: color-mix(in srgb, var(--sig-highlight) 70%, var(--sig-warning));
+		color: var(--sig-highlight);
+		box-shadow: var(--sig-glow-highlight);
+	}
+
+	.chat-voice-btn:disabled {
+		opacity: 0.3;
+		cursor: default;
+	}
+
+	.chat-voice-bars {
+		display: inline-flex;
+		align-items: flex-end;
+		gap: 2px;
+		height: 12px;
+	}
+
+	.chat-voice-bars .bar {
+		width: 2px;
+		height: 100%;
+		border-radius: 2px;
+		background: currentColor;
+		transform-origin: center bottom;
+		animation: chatVoiceWave 0.9s ease-in-out infinite;
+	}
+
+	.chat-voice-bars .bar:nth-child(2) {
+		animation-delay: 0.15s;
+	}
+
+	.chat-voice-bars .bar:nth-child(3) {
+		animation-delay: 0.3s;
+	}
+
+	@keyframes chatVoiceWave {
+		0%,
+		100% {
+			transform: scaleY(0.35);
+			opacity: 0.45;
+		}
+		50% {
+			transform: scaleY(1);
+			opacity: 1;
+		}
 	}
 
 	.chat-send-btn:hover:not(:disabled) {

--- a/packages/cli/dashboard/src/lib/components/os/AgentChat.svelte
+++ b/packages/cli/dashboard/src/lib/components/os/AgentChat.svelte
@@ -1061,6 +1061,8 @@ function scrollToWidget(serverId: string): void {
 		background: var(--sig-bg);
 		max-height: 360px;
 		min-height: 140px;
+		--chat-accent: #c8ff00;
+		--chat-accent-glow: 0 0 20px rgba(200, 255, 0, 0.15);
 	}
 
 	.chat-messages {
@@ -1120,9 +1122,9 @@ function scrollToWidget(serverId: string): void {
 	}
 
 	.chat-msg--agent .chat-msg-icon {
-		border-color: color-mix(in srgb, var(--sig-highlight) 62%, var(--sig-warning));
-		background: color-mix(in srgb, var(--sig-highlight) 11%, var(--sig-surface));
-		box-shadow: 0 0 0 1px color-mix(in srgb, var(--sig-highlight) 30%, transparent), var(--sig-glow-highlight);
+		border-color: color-mix(in srgb, var(--chat-accent) 62%, var(--sig-warning));
+		background: color-mix(in srgb, var(--chat-accent) 11%, var(--sig-surface));
+		box-shadow: 0 0 0 1px color-mix(in srgb, var(--chat-accent) 30%, transparent), var(--chat-accent-glow);
 		color: var(--sig-text-muted);
 	}
 
@@ -1133,12 +1135,12 @@ function scrollToWidget(serverId: string): void {
 	}
 
 	.chat-msg--user .chat-msg-icon :global(svg) {
-		color: color-mix(in srgb, var(--sig-highlight) 84%, var(--sig-warning));
-		background: color-mix(in srgb, var(--sig-highlight) 22%, transparent);
-		border: 1px solid color-mix(in srgb, var(--sig-highlight) 58%, var(--sig-warning));
+		color: color-mix(in srgb, var(--chat-accent) 84%, var(--sig-warning));
+		background: color-mix(in srgb, var(--chat-accent) 22%, transparent);
+		border: 1px solid color-mix(in srgb, var(--chat-accent) 58%, var(--sig-warning));
 		border-radius: 999px;
 		padding: 1px;
-		box-shadow: var(--sig-glow-highlight);
+		box-shadow: var(--chat-accent-glow);
 	}
 
 	.chat-msg-body {
@@ -1169,9 +1171,9 @@ function scrollToWidget(serverId: string): void {
 	}
 
 	.chat-copy-btn:hover {
-		border-color: var(--sig-highlight);
-		color: var(--sig-highlight);
-		background: color-mix(in srgb, var(--sig-highlight) 10%, var(--sig-bg));
+		border-color: var(--chat-accent);
+		color: var(--chat-accent);
+		background: color-mix(in srgb, var(--chat-accent) 10%, var(--sig-bg));
 	}
 
 	.chat-msg-content {
@@ -1408,11 +1410,11 @@ function scrollToWidget(serverId: string): void {
 		font-size: 12px;
 		color: var(--sig-text);
 		background: var(--sig-bg);
-		border: 1px solid color-mix(in srgb, var(--sig-highlight) 65%, var(--sig-border));
+		border: 1px solid color-mix(in srgb, var(--chat-accent) 65%, var(--sig-border));
 		border-radius: 6px;
 		padding: 8px 78px 8px 10px;
 		outline: none;
-		box-shadow: 0 0 0 1px color-mix(in srgb, var(--sig-highlight) 22%, transparent);
+		box-shadow: 0 0 0 1px color-mix(in srgb, var(--chat-accent) 22%, transparent);
 		transition: border-color var(--dur) var(--ease), box-shadow var(--dur) var(--ease);
 	}
 
@@ -1422,8 +1424,8 @@ function scrollToWidget(serverId: string): void {
 	}
 
 	.chat-input:focus {
-		border-color: var(--sig-highlight);
-		box-shadow: var(--sig-glow-highlight);
+		border-color: var(--chat-accent);
+		box-shadow: var(--chat-accent-glow);
 	}
 
 	.chat-input:disabled {
@@ -1471,15 +1473,15 @@ function scrollToWidget(serverId: string): void {
 	}
 
 	.chat-voice-btn:hover:not(:disabled) {
-		border-color: var(--sig-highlight);
-		color: var(--sig-highlight);
-		background: color-mix(in srgb, var(--sig-highlight) 10%, var(--sig-surface));
+		border-color: var(--chat-accent);
+		color: var(--chat-accent);
+		background: color-mix(in srgb, var(--chat-accent) 10%, var(--sig-surface));
 	}
 
 	.chat-voice-btn.active {
-		border-color: color-mix(in srgb, var(--sig-highlight) 70%, var(--sig-warning));
-		color: var(--sig-highlight);
-		box-shadow: var(--sig-glow-highlight);
+		border-color: color-mix(in srgb, var(--chat-accent) 70%, var(--sig-warning));
+		color: var(--chat-accent);
+		box-shadow: var(--chat-accent-glow);
 	}
 
 	.chat-voice-btn:disabled {
@@ -1524,9 +1526,9 @@ function scrollToWidget(serverId: string): void {
 	}
 
 	.chat-send-btn:hover:not(:disabled) {
-		border-color: var(--sig-accent);
-		color: var(--sig-accent);
-		background: color-mix(in srgb, var(--sig-accent) 8%, var(--sig-surface));
+		border-color: var(--chat-accent);
+		color: var(--chat-accent);
+		background: color-mix(in srgb, var(--chat-accent) 8%, var(--sig-surface));
 	}
 
 	.chat-send-btn:disabled {

--- a/packages/cli/dashboard/src/lib/components/os/AppDock.svelte
+++ b/packages/cli/dashboard/src/lib/components/os/AppDock.svelte
@@ -77,7 +77,7 @@ const allApps = $derived([...dockApps, ...trayApps]);
 			{#each trayApps as app (app.id)}
 				<div
 					class="dock-item"
-					title="{app.name} — drag to grid to place"
+					title="{app.name} — drag to grid or render window"
 					draggable="true"
 					ondragstart={(e) => handleDragStart(e, app.id)}
 					role="listitem"

--- a/packages/cli/dashboard/src/lib/components/os/SidebarGroups.svelte
+++ b/packages/cli/dashboard/src/lib/components/os/SidebarGroups.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { API_BASE } from "$lib/api";
 import {
 	os,
 	type SidebarGroup,
@@ -13,11 +14,42 @@ import FolderOpen from "@lucide/svelte/icons/folder-open";
 import LayoutGrid from "@lucide/svelte/icons/layout-grid";
 import Plus from "@lucide/svelte/icons/plus";
 import Trash2 from "@lucide/svelte/icons/trash-2";
+import { onMount } from "svelte";
+
+interface BrowserMemoryEntry {
+	content?: string;
+	tags?: string | string[] | null;
+	source_type?: string | null;
+}
 
 let newGroupName = $state("");
 let showNewInput = $state(false);
 let editingId = $state<string | null>(null);
 let editingName = $state("");
+let allAppsExpanded = $state(false);
+let allAppsSelection = $state("");
+
+const sortedApps = $derived([...os.entries].sort((a, b) => a.name.localeCompare(b.name)));
+const selectedApp = $derived(sortedApps.find((app) => app.id === allAppsSelection) ?? null);
+
+const browserSync = $state({
+	loading: false,
+	error: null as string | null,
+	bookmarks: 0,
+	transcriptions: 0,
+	sessions: 0,
+	lastSyncedAt: null as string | null,
+});
+
+$effect(() => {
+	if (sortedApps.length === 0) {
+		allAppsSelection = "";
+		return;
+	}
+	if (!allAppsSelection || !sortedApps.some((app) => app.id === allAppsSelection)) {
+		allAppsSelection = sortedApps[0].id;
+	}
+});
 
 function handleCreateGroup(): void {
 	const name = newGroupName.trim();
@@ -52,6 +84,111 @@ function handleGroupDrop(e: DragEvent, groupId: string): void {
 		addToGroup(groupId, appId);
 	}
 }
+
+function handleAppDragStart(e: DragEvent, appId: string): void {
+	if (!e.dataTransfer) return;
+	e.dataTransfer.setData("text/plain", appId);
+	e.dataTransfer.effectAllowed = "move";
+}
+
+function parseTags(tags: BrowserMemoryEntry["tags"]): string[] {
+	if (Array.isArray(tags)) {
+		return tags
+			.map((tag) => String(tag).trim().toLowerCase())
+			.filter(Boolean);
+	}
+	if (typeof tags !== "string") return [];
+	return tags
+		.split(",")
+		.map((tag) => tag.trim().toLowerCase())
+		.filter(Boolean);
+}
+
+function classifyBrowserMemory(memories: BrowserMemoryEntry[]): {
+	bookmarks: number;
+	transcriptions: number;
+	sessions: number;
+} {
+	let bookmarks = 0;
+	let transcriptions = 0;
+	let sessions = 0;
+
+	for (const memory of memories) {
+		const tags = new Set(parseTags(memory.tags));
+		const content = String(memory.content ?? "").toLowerCase();
+		const sourceType = String(memory.source_type ?? "").toLowerCase();
+		const browserScoped =
+			sourceType === "browser-extension" ||
+			tags.has("browser-extension") ||
+			content.includes("[signet browser tool]") ||
+			content.includes("[signet bookmark]") ||
+			content.includes("[signet transcribe]") ||
+			content.includes("[signet page note]") ||
+			content.includes("[signet page capture]");
+
+		if (!browserScoped) continue;
+
+		if (tags.has("bookmark") || content.includes("[signet bookmark]")) {
+			bookmarks += 1;
+		}
+
+		if (tags.has("transcribe") || content.includes("[signet transcribe]")) {
+			transcriptions += 1;
+		}
+
+		if (
+			tags.has("browser-tool") ||
+			tags.has("send-page") ||
+			tags.has("send-selection") ||
+			tags.has("page-note") ||
+			tags.has("page-capture") ||
+			content.includes("[signet browser tool]") ||
+			content.includes("[signet page note]") ||
+			content.includes("[signet page capture]")
+		) {
+			sessions += 1;
+		}
+	}
+
+	return { bookmarks, transcriptions, sessions };
+}
+
+async function refreshBrowserCategories(): Promise<void> {
+	browserSync.loading = true;
+	browserSync.error = null;
+	try {
+		const response = await fetch(`${API_BASE}/api/memories?limit=500&offset=0`);
+		if (!response.ok) {
+			throw new Error(`HTTP ${response.status}`);
+		}
+		const data = (await response.json()) as { memories?: BrowserMemoryEntry[] };
+		const memoryRows = Array.isArray(data.memories) ? data.memories : [];
+		const counts = classifyBrowserMemory(memoryRows);
+		browserSync.bookmarks = counts.bookmarks;
+		browserSync.transcriptions = counts.transcriptions;
+		browserSync.sessions = counts.sessions;
+		browserSync.lastSyncedAt = new Date().toISOString();
+	} catch (error) {
+		browserSync.error = error instanceof Error ? error.message : String(error);
+	} finally {
+		browserSync.loading = false;
+	}
+}
+
+function formatSyncTime(iso: string | null): string {
+	if (!iso) return "";
+	const date = new Date(iso);
+	if (Number.isNaN(date.getTime())) return "";
+	return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+onMount(() => {
+	void refreshBrowserCategories();
+	const timer = window.setInterval(() => {
+		void refreshBrowserCategories();
+	}, 30_000);
+	return () => window.clearInterval(timer);
+});
 </script>
 
 <div class="sidebar-groups">
@@ -66,17 +203,94 @@ function handleGroupDrop(e: DragEvent, groupId: string): void {
 		</button>
 	</div>
 
-	<!-- All apps (no filter) -->
-	<button
-		class="group-item"
-		class:group-item--active={os.activeGroup === null}
-		onclick={() => setActiveGroup(null)}
-	>
-		<LayoutGrid class="size-3.5" />
-		<span>All Apps</span>
-	</button>
+	<div class="all-apps-wrap">
+		<button
+			class="group-item"
+			class:group-item--active={os.activeGroup === null}
+			onclick={() => {
+				setActiveGroup(null);
+				allAppsExpanded = !allAppsExpanded;
+			}}
+		>
+			<LayoutGrid class="size-3.5" />
+			<span>All Apps</span>
+			<span class="sig-meta">{sortedApps.length}</span>
+			<span class="group-caret">{allAppsExpanded ? "▾" : "▸"}</span>
+		</button>
 
-	<!-- User groups -->
+		{#if allAppsExpanded}
+			<div class="all-apps-dropdown">
+				<div class="all-apps-select-row">
+					<label class="sig-meta" for="all-apps-select">Select app</label>
+					<select id="all-apps-select" bind:value={allAppsSelection} class="all-apps-select">
+						{#each sortedApps as app (app.id)}
+							<option value={app.id}>{app.name}</option>
+						{/each}
+					</select>
+				</div>
+
+				{#if selectedApp}
+					<div
+						class="all-apps-selected"
+						draggable="true"
+						ondragstart={(e) => handleAppDragStart(e, selectedApp.id)}
+						title="Drag selected app into render window"
+					>
+						<span class="all-apps-item-name">{selectedApp.name}</span>
+						<span class="sig-meta">Drag</span>
+					</div>
+				{/if}
+
+				<div class="all-apps-list">
+					{#each sortedApps as app (app.id)}
+						<div
+							class="all-apps-item"
+							draggable="true"
+							ondragstart={(e) => handleAppDragStart(e, app.id)}
+							title="Drag into render window"
+						>
+							<span class="all-apps-item-name">{app.name}</span>
+							<span class="sig-meta">{app.state}</span>
+						</div>
+					{/each}
+				</div>
+			</div>
+		{/if}
+	</div>
+
+	<div class="groups-subsection">
+		<div class="groups-subheader">
+			<span class="sig-eyebrow">Browser Sync</span>
+			<button
+				class="group-refresh-btn"
+				onclick={() => void refreshBrowserCategories()}
+				disabled={browserSync.loading}
+				title="Refresh extension memory categories"
+			>
+				{browserSync.loading ? "Syncing" : "Refresh"}
+			</button>
+		</div>
+
+		<div class="group-static-item">
+			<span>Browser Bookmarks</span>
+			<span class="sig-meta">{browserSync.bookmarks}</span>
+		</div>
+		<div class="group-static-item">
+			<span>Transcriptions</span>
+			<span class="sig-meta">{browserSync.transcriptions}</span>
+		</div>
+		<div class="group-static-item">
+			<span>Browser Sessions</span>
+			<span class="sig-meta">{browserSync.sessions}</span>
+		</div>
+
+		{#if browserSync.error}
+			<div class="group-sync-error">{browserSync.error}</div>
+		{:else if browserSync.lastSyncedAt}
+			<div class="group-sync-meta">Synced {formatSyncTime(browserSync.lastSyncedAt)}</div>
+		{/if}
+	</div>
+
 	{#each os.groups as group (group.id)}
 		<div
 			class="group-item"
@@ -124,7 +338,6 @@ function handleGroupDrop(e: DragEvent, groupId: string): void {
 		</div>
 	{/each}
 
-	<!-- New group input -->
 	{#if showNewInput}
 		<div class="group-new-input-wrap">
 			<input
@@ -156,6 +369,30 @@ function handleGroupDrop(e: DragEvent, groupId: string): void {
 		padding: 8px 4px 4px;
 	}
 
+	.groups-subheader {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 6px 4px 4px;
+	}
+
+	.group-refresh-btn {
+		height: 18px;
+		padding: 0 6px;
+		border-radius: 4px;
+		border: 1px solid var(--sig-border);
+		background: transparent;
+		color: var(--sig-text-muted);
+		font-family: var(--font-mono);
+		font-size: 9px;
+		cursor: pointer;
+	}
+
+	.group-refresh-btn:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+
 	.group-add-btn {
 		display: flex;
 		align-items: center;
@@ -175,7 +412,14 @@ function handleGroupDrop(e: DragEvent, groupId: string): void {
 		background: var(--sig-highlight-muted);
 	}
 
-	.group-item {
+	.all-apps-wrap {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	.group-item,
+	.group-static-item {
 		display: flex;
 		align-items: center;
 		gap: 6px;
@@ -192,13 +436,103 @@ function handleGroupDrop(e: DragEvent, groupId: string): void {
 		transition: background var(--dur) var(--ease);
 	}
 
-	.group-item:hover {
+	.group-static-item {
+		cursor: default;
+	}
+
+	.group-item:hover,
+	.group-static-item:hover {
 		background: rgba(255, 255, 255, 0.04);
 	}
 
 	.group-item--active {
 		background: var(--sig-surface-raised);
 		color: var(--sig-text-bright);
+	}
+
+	.group-caret {
+		margin-left: auto;
+		font-size: 10px;
+		color: var(--sig-text-muted);
+	}
+
+	.all-apps-dropdown {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		padding: 2px 4px 8px;
+	}
+
+	.all-apps-select-row {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	.all-apps-select {
+		width: 100%;
+		background: var(--sig-bg);
+		border: 1px solid var(--sig-border);
+		border-radius: 4px;
+		padding: 3px 6px;
+		font-family: var(--font-mono);
+		font-size: 10px;
+		color: var(--sig-text-bright);
+	}
+
+	.all-apps-selected,
+	.all-apps-item {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+		padding: 4px 6px;
+		border-radius: 4px;
+		border: 1px solid var(--sig-border);
+		background: var(--sig-surface);
+		font-family: var(--font-mono);
+		font-size: 10px;
+		cursor: grab;
+	}
+
+	.all-apps-item:active,
+	.all-apps-selected:active {
+		cursor: grabbing;
+	}
+
+	.all-apps-item-name {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.all-apps-list {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		max-height: 140px;
+		overflow-y: auto;
+	}
+
+	.groups-subsection {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		margin: 2px 0 6px;
+	}
+
+	.group-sync-error {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		color: var(--sig-danger);
+		padding: 4px 8px;
+	}
+
+	.group-sync-meta {
+		font-family: var(--font-mono);
+		font-size: 9px;
+		color: var(--sig-text-muted);
+		padding: 2px 8px 4px;
 	}
 
 	.group-delete-btn {
@@ -255,7 +589,8 @@ function handleGroupDrop(e: DragEvent, groupId: string): void {
 		border-color: var(--sig-highlight);
 	}
 
-	:root[data-theme="light"] .group-item:hover {
+	:root[data-theme="light"] .group-item:hover,
+	:root[data-theme="light"] .group-static-item:hover {
 		background: rgba(0, 0, 0, 0.04);
 	}
 
@@ -275,7 +610,12 @@ function handleGroupDrop(e: DragEvent, groupId: string): void {
 			min-width: fit-content;
 		}
 
-		.group-item {
+		.groups-subsection {
+			min-width: 180px;
+		}
+
+		.group-item,
+		.group-static-item {
 			width: auto;
 			white-space: nowrap;
 			padding: 4px 10px;

--- a/packages/cli/dashboard/src/lib/components/os/SidebarGroups.svelte
+++ b/packages/cli/dashboard/src/lib/components/os/SidebarGroups.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { API_BASE } from "$lib/api";
+import { API_BASE, getSkills, type Skill } from "$lib/api";
 import {
 	os,
 	type SidebarGroup,
@@ -9,6 +9,7 @@ import {
 	renameGroup,
 	setActiveGroup,
 } from "$lib/stores/os.svelte";
+import BookOpen from "@lucide/svelte/icons/book-open";
 import Folder from "@lucide/svelte/icons/folder";
 import FolderOpen from "@lucide/svelte/icons/folder-open";
 import LayoutGrid from "@lucide/svelte/icons/layout-grid";
@@ -17,9 +18,28 @@ import Trash2 from "@lucide/svelte/icons/trash-2";
 import { onMount } from "svelte";
 
 interface BrowserMemoryEntry {
+	id?: string;
 	content?: string;
 	tags?: string | string[] | null;
 	source_type?: string | null;
+	created_at?: string;
+}
+
+interface BrowserSyncItem {
+	id: string;
+	title: string;
+	subtitle?: string;
+	url?: string;
+	snippet: string;
+	createdAt?: string;
+}
+
+interface InstalledSkillItem {
+	id: string;
+	name: string;
+	description: string;
+	argHint?: string;
+	command: string;
 }
 
 let newGroupName = $state("");
@@ -28,16 +48,31 @@ let editingId = $state<string | null>(null);
 let editingName = $state("");
 let allAppsExpanded = $state(false);
 let allAppsSelection = $state("");
+let allSkillsExpanded = $state(false);
+let allSkillsSelection = $state("");
+let browserBookmarksExpanded = $state(false);
+let browserTranscriptionsExpanded = $state(false);
+let browserSessionsExpanded = $state(false);
+let suppressBookmarkClickUntil = 0;
 
 const sortedApps = $derived([...os.entries].sort((a, b) => a.name.localeCompare(b.name)));
 const selectedApp = $derived(sortedApps.find((app) => app.id === allAppsSelection) ?? null);
 
+const skillsSync = $state({
+	loading: false,
+	error: null as string | null,
+	items: [] as InstalledSkillItem[],
+	lastSyncedAt: null as string | null,
+});
+
+const selectedSkill = $derived(skillsSync.items.find((skill) => skill.id === allSkillsSelection) ?? null);
+
 const browserSync = $state({
 	loading: false,
 	error: null as string | null,
-	bookmarks: 0,
-	transcriptions: 0,
-	sessions: 0,
+	bookmarks: [] as BrowserSyncItem[],
+	transcriptions: [] as BrowserSyncItem[],
+	sessions: [] as BrowserSyncItem[],
 	lastSyncedAt: null as string | null,
 });
 
@@ -48,6 +83,16 @@ $effect(() => {
 	}
 	if (!allAppsSelection || !sortedApps.some((app) => app.id === allAppsSelection)) {
 		allAppsSelection = sortedApps[0].id;
+	}
+});
+
+$effect(() => {
+	if (skillsSync.items.length === 0) {
+		allSkillsSelection = "";
+		return;
+	}
+	if (!allSkillsSelection || !skillsSync.items.some((skill) => skill.id === allSkillsSelection)) {
+		allSkillsSelection = skillsSync.items[0].id;
 	}
 });
 
@@ -79,16 +124,64 @@ function handleGroupDragOver(e: DragEvent): void {
 
 function handleGroupDrop(e: DragEvent, groupId: string): void {
 	e.preventDefault();
-	const appId = e.dataTransfer?.getData("text/plain");
-	if (appId) {
-		addToGroup(groupId, appId);
+	const appId =
+		e.dataTransfer?.getData("application/x-signet-app-id")?.trim() ||
+		e.dataTransfer?.getData("text/plain")?.trim() ||
+		"";
+	if (!appId || !os.entries.some((entry) => entry.id === appId)) return;
+	addToGroup(groupId, appId);
+}
+
+function handleAppDragStart(e: DragEvent, app: { id: string; name: string }): void {
+	if (!e.dataTransfer) return;
+	const chatSnippet = [
+		"MCP app context",
+		`App: ${app.name}`,
+		`Server ID: ${app.id}`,
+	].join("\n");
+	e.dataTransfer.setData("application/x-signet-app-id", app.id);
+	e.dataTransfer.setData("application/x-signet-chat-snippet", chatSnippet);
+	e.dataTransfer.setData("text/plain", app.id);
+	e.dataTransfer.effectAllowed = "copyMove";
+}
+
+function handleMemoryDragStart(e: DragEvent, item: BrowserSyncItem): void {
+	if (!e.dataTransfer) return;
+	e.dataTransfer.setData("application/x-signet-chat-snippet", item.snippet);
+	e.dataTransfer.setData("text/plain", item.snippet);
+	e.dataTransfer.effectAllowed = "copy";
+}
+
+function handleBookmarkDragStart(e: DragEvent, item: BrowserSyncItem): void {
+	suppressBookmarkClickUntil = Date.now() + 250;
+	handleMemoryDragStart(e, item);
+}
+
+function handleBookmarkClick(item: BrowserSyncItem): void {
+	if (Date.now() < suppressBookmarkClickUntil) return;
+	const url = item.url?.trim();
+	if (!url) return;
+	const opened = window.open(url, "_blank");
+	if (opened) {
+		try {
+			opened.opener = null;
+		} catch {
+			// noop
+		}
 	}
 }
 
-function handleAppDragStart(e: DragEvent, appId: string): void {
+function buildSkillSlashCommand(skill: Skill): string {
+	const baseCommand = `/${skill.name}`;
+	const argHint = skill.arg_hint?.trim();
+	return argHint ? `${baseCommand} ${argHint}` : `${baseCommand} `;
+}
+
+function handleSkillDragStart(e: DragEvent, skill: InstalledSkillItem): void {
 	if (!e.dataTransfer) return;
-	e.dataTransfer.setData("text/plain", appId);
-	e.dataTransfer.effectAllowed = "move";
+	e.dataTransfer.setData("application/x-signet-chat-snippet", skill.command);
+	e.dataTransfer.setData("text/plain", skill.command);
+	e.dataTransfer.effectAllowed = "copy";
 }
 
 function parseTags(tags: BrowserMemoryEntry["tags"]): string[] {
@@ -104,16 +197,83 @@ function parseTags(tags: BrowserMemoryEntry["tags"]): string[] {
 		.filter(Boolean);
 }
 
-function classifyBrowserMemory(memories: BrowserMemoryEntry[]): {
-	bookmarks: number;
-	transcriptions: number;
-	sessions: number;
-} {
-	let bookmarks = 0;
-	let transcriptions = 0;
-	let sessions = 0;
+function extractField(content: string, field: string): string | null {
+	const escapedField = field.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const match = content.match(new RegExp(`^${escapedField}:\\s*(.+)$`, "im"));
+	return match?.[1]?.trim() || null;
+}
 
-	for (const memory of memories) {
+function stripSignetHeaders(content: string): string {
+	return content
+		.split("\n")
+		.filter((line) => {
+			const trimmed = line.trim();
+			if (!trimmed) return true;
+			if (/^\[signet[\w\s-]*\]/i.test(trimmed)) return false;
+			if (/^(title|url|saved at|captured at|source|format):/i.test(trimmed)) return false;
+			if (/^(source_title|source_url|timestamp|created_at):/i.test(trimmed)) return false;
+			return true;
+		})
+		.join("\n")
+		.trim();
+}
+
+function normalizeHttpUrl(raw: string | null): string | undefined {
+	if (!raw) return undefined;
+	try {
+		const parsed = new URL(raw.trim());
+		if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+			return parsed.toString();
+		}
+	} catch {
+		return undefined;
+	}
+	return undefined;
+}
+
+function buildBrowserSyncItem(memory: BrowserMemoryEntry, index: number, kind: "bookmark" | "transcription" | "session"): BrowserSyncItem {
+	const content = String(memory.content ?? "").trim();
+	const title =
+		extractField(content, "Title") ||
+		extractField(content, "source_title") ||
+		extractField(content, "Source") ||
+		`${kind[0]!.toUpperCase()}${kind.slice(1)} ${index + 1}`;
+	const url = normalizeHttpUrl(extractField(content, "URL") || extractField(content, "source_url"));
+	const body = stripSignetHeaders(content);
+	const snippet = [
+		kind === "bookmark"
+			? "Browser bookmark context"
+			: kind === "transcription"
+				? "Browser transcription context"
+				: "Browser session context",
+		`Title: ${title}`,
+		url ? `URL: ${url}` : "",
+		body || content,
+	]
+		.filter(Boolean)
+		.join("\n")
+		.slice(0, 1400);
+
+	return {
+		id: memory.id?.trim() || `${kind}-${index}`,
+		title,
+		subtitle: url || extractField(content, "Format") || undefined,
+		url,
+		snippet,
+		createdAt: memory.created_at,
+	};
+}
+
+function classifyBrowserMemory(memories: BrowserMemoryEntry[]): {
+	bookmarks: BrowserSyncItem[];
+	transcriptions: BrowserSyncItem[];
+	sessions: BrowserSyncItem[];
+} {
+	const bookmarks: BrowserSyncItem[] = [];
+	const transcriptions: BrowserSyncItem[] = [];
+	const sessions: BrowserSyncItem[] = [];
+
+	for (const [index, memory] of memories.entries()) {
 		const tags = new Set(parseTags(memory.tags));
 		const content = String(memory.content ?? "").toLowerCase();
 		const sourceType = String(memory.source_type ?? "").toLowerCase();
@@ -124,16 +284,18 @@ function classifyBrowserMemory(memories: BrowserMemoryEntry[]): {
 			content.includes("[signet bookmark]") ||
 			content.includes("[signet transcribe]") ||
 			content.includes("[signet page note]") ||
-			content.includes("[signet page capture]");
+			content.includes("[signet page capture]") ||
+			content.includes("--- signet-selection-bundle.txt ---") ||
+			content.includes("--- signet-harness-payload.txt ---");
 
 		if (!browserScoped) continue;
 
 		if (tags.has("bookmark") || content.includes("[signet bookmark]")) {
-			bookmarks += 1;
+			bookmarks.push(buildBrowserSyncItem(memory, index, "bookmark"));
 		}
 
 		if (tags.has("transcribe") || content.includes("[signet transcribe]")) {
-			transcriptions += 1;
+			transcriptions.push(buildBrowserSyncItem(memory, index, "transcription"));
 		}
 
 		if (
@@ -144,13 +306,58 @@ function classifyBrowserMemory(memories: BrowserMemoryEntry[]): {
 			tags.has("page-capture") ||
 			content.includes("[signet browser tool]") ||
 			content.includes("[signet page note]") ||
-			content.includes("[signet page capture]")
+			content.includes("[signet page capture]") ||
+			content.includes("--- signet-selection-bundle.txt ---") ||
+			content.includes("--- signet-harness-payload.txt ---")
 		) {
-			sessions += 1;
+			sessions.push(buildBrowserSyncItem(memory, index, "session"));
 		}
 	}
 
+	const sortByNewest = (a: BrowserSyncItem, b: BrowserSyncItem): number => {
+		const aTs = Date.parse(a.createdAt ?? "");
+		const bTs = Date.parse(b.createdAt ?? "");
+		if (Number.isFinite(aTs) && Number.isFinite(bTs)) return bTs - aTs;
+		if (Number.isFinite(aTs)) return -1;
+		if (Number.isFinite(bTs)) return 1;
+		return b.id.localeCompare(a.id);
+	};
+
+	bookmarks.sort(sortByNewest);
+	transcriptions.sort(sortByNewest);
+	sessions.sort(sortByNewest);
+
 	return { bookmarks, transcriptions, sessions };
+}
+
+async function refreshSkills(): Promise<void> {
+	skillsSync.loading = true;
+	skillsSync.error = null;
+	try {
+		const installedSkills = await getSkills();
+		skillsSync.items = installedSkills
+			.flatMap((skill, index) => {
+				const name = String(skill.name ?? "").trim();
+				if (!name) return [];
+				const command = buildSkillSlashCommand(skill);
+				const description = String(skill.description ?? "").trim() || "Installed Signet skill";
+				const argHint = skill.arg_hint?.trim() || undefined;
+				const item: InstalledSkillItem = {
+					id: skill.path?.trim() || `${name}-${index}`,
+					name,
+					description,
+					command,
+				};
+				if (argHint) item.argHint = argHint;
+				return [item];
+			})
+			.sort((a, b) => a.name.localeCompare(b.name));
+		skillsSync.lastSyncedAt = new Date().toISOString();
+	} catch (error) {
+		skillsSync.error = error instanceof Error ? error.message : String(error);
+	} finally {
+		skillsSync.loading = false;
+	}
 }
 
 async function refreshBrowserCategories(): Promise<void> {
@@ -163,10 +370,10 @@ async function refreshBrowserCategories(): Promise<void> {
 		}
 		const data = (await response.json()) as { memories?: BrowserMemoryEntry[] };
 		const memoryRows = Array.isArray(data.memories) ? data.memories : [];
-		const counts = classifyBrowserMemory(memoryRows);
-		browserSync.bookmarks = counts.bookmarks;
-		browserSync.transcriptions = counts.transcriptions;
-		browserSync.sessions = counts.sessions;
+		const groups = classifyBrowserMemory(memoryRows);
+		browserSync.bookmarks = groups.bookmarks;
+		browserSync.transcriptions = groups.transcriptions;
+		browserSync.sessions = groups.sessions;
 		browserSync.lastSyncedAt = new Date().toISOString();
 	} catch (error) {
 		browserSync.error = error instanceof Error ? error.message : String(error);
@@ -183,8 +390,10 @@ function formatSyncTime(iso: string | null): string {
 }
 
 onMount(() => {
+	void refreshSkills();
 	void refreshBrowserCategories();
 	const timer = window.setInterval(() => {
+		void refreshSkills();
 		void refreshBrowserCategories();
 	}, 30_000);
 	return () => window.clearInterval(timer);
@@ -233,28 +442,76 @@ onMount(() => {
 					<div
 						class="all-apps-selected"
 						draggable="true"
-						ondragstart={(e) => handleAppDragStart(e, selectedApp.id)}
-						title="Drag selected app into render window"
+						ondragstart={(e) => handleAppDragStart(e, selectedApp)}
+						title="Drag selected app into render window or OS chat input"
 					>
 						<span class="all-apps-item-name">{selectedApp.name}</span>
 						<span class="sig-meta">Drag</span>
 					</div>
 				{/if}
-
-				<div class="all-apps-list">
-					{#each sortedApps as app (app.id)}
-						<div
-							class="all-apps-item"
-							draggable="true"
-							ondragstart={(e) => handleAppDragStart(e, app.id)}
-							title="Drag into render window"
-						>
-							<span class="all-apps-item-name">{app.name}</span>
-							<span class="sig-meta">{app.state}</span>
-						</div>
-					{/each}
-				</div>
 			</div>
+		{/if}
+	</div>
+
+	<div class="groups-subsection">
+		<div class="groups-subheader">
+			<span class="sig-eyebrow">Skills</span>
+			<button
+				class="group-refresh-btn"
+				onclick={() => void refreshSkills()}
+				disabled={skillsSync.loading}
+				title="Refresh installed skills"
+			>
+				{skillsSync.loading ? "Syncing" : "Refresh"}
+			</button>
+		</div>
+
+		<button
+			class="group-item"
+			class:group-item--active={allSkillsExpanded}
+			type="button"
+			onclick={() => { allSkillsExpanded = !allSkillsExpanded; }}
+		>
+			<BookOpen class="size-3.5" />
+			<span>All Skills</span>
+			<span class="sig-meta">{skillsSync.items.length}</span>
+			<span class="group-caret">{allSkillsExpanded ? "▾" : "▸"}</span>
+		</button>
+
+		{#if allSkillsExpanded}
+			<div class="all-apps-dropdown">
+				<div class="all-apps-select-row">
+					<label class="sig-meta" for="all-skills-select">Select skill</label>
+					<select id="all-skills-select" bind:value={allSkillsSelection} class="all-apps-select">
+						{#if skillsSync.items.length > 0}
+							{#each skillsSync.items as skill (skill.id)}
+								<option value={skill.id}>{skill.name}</option>
+							{/each}
+						{:else}
+							<option value="" disabled>No installed skills</option>
+						{/if}
+					</select>
+				</div>
+
+				{#if selectedSkill}
+					<div
+						class="all-apps-selected"
+						draggable="true"
+						ondragstart={(e) => handleSkillDragStart(e, selectedSkill)}
+						title="Drag default slash command into OS chat input"
+					>
+						<span class="all-apps-item-name">/{selectedSkill.name}</span>
+						<span class="sig-meta">Drag</span>
+					</div>
+					<div class="skill-command-preview">{selectedSkill.command}</div>
+				{/if}
+			</div>
+		{/if}
+
+		{#if skillsSync.error}
+			<div class="group-sync-error">{skillsSync.error}</div>
+		{:else if skillsSync.lastSyncedAt}
+			<div class="group-sync-meta">Synced {formatSyncTime(skillsSync.lastSyncedAt)}</div>
 		{/if}
 	</div>
 
@@ -271,18 +528,110 @@ onMount(() => {
 			</button>
 		</div>
 
-		<div class="group-static-item">
+		<button
+			class="group-item"
+			type="button"
+			onclick={() => { browserBookmarksExpanded = !browserBookmarksExpanded; }}
+		>
 			<span>Browser Bookmarks</span>
-			<span class="sig-meta">{browserSync.bookmarks}</span>
-		</div>
-		<div class="group-static-item">
+			<span class="sig-meta">{browserSync.bookmarks.length}</span>
+			<span class="group-caret">{browserBookmarksExpanded ? "▾" : "▸"}</span>
+		</button>
+		{#if browserBookmarksExpanded}
+			<div class="browser-memory-dropdown">
+				{#if browserSync.bookmarks.length === 0}
+					<div class="browser-memory-empty">No bookmark memories synced yet.</div>
+				{:else}
+					{#each browserSync.bookmarks as item (item.id)}
+						<div
+							class="browser-memory-item"
+							class:browser-memory-item--clickable={Boolean(item.url)}
+							draggable="true"
+							ondragstart={(e) => handleBookmarkDragStart(e, item)}
+							onclick={() => handleBookmarkClick(item)}
+							onkeydown={(e) => {
+								if (e.key === "Enter" || e.key === " ") {
+									e.preventDefault();
+									handleBookmarkClick(item);
+								}
+							}}
+							role="button"
+							tabindex="0"
+							title={item.url
+								? "Click to open bookmark, or drag into OS chat input"
+								: "Drag into OS chat input"}
+						>
+							<span class="browser-memory-title">{item.title}</span>
+							{#if item.subtitle}
+								<span class="browser-memory-subtitle">{item.subtitle}</span>
+							{/if}
+						</div>
+					{/each}
+				{/if}
+			</div>
+		{/if}
+
+		<button
+			class="group-item"
+			type="button"
+			onclick={() => { browserTranscriptionsExpanded = !browserTranscriptionsExpanded; }}
+		>
 			<span>Transcriptions</span>
-			<span class="sig-meta">{browserSync.transcriptions}</span>
-		</div>
-		<div class="group-static-item">
+			<span class="sig-meta">{browserSync.transcriptions.length}</span>
+			<span class="group-caret">{browserTranscriptionsExpanded ? "▾" : "▸"}</span>
+		</button>
+		{#if browserTranscriptionsExpanded}
+			<div class="browser-memory-dropdown">
+				{#if browserSync.transcriptions.length === 0}
+					<div class="browser-memory-empty">No transcriptions synced yet.</div>
+				{:else}
+					{#each browserSync.transcriptions as item (item.id)}
+						<div
+							class="browser-memory-item"
+							draggable="true"
+							ondragstart={(e) => handleMemoryDragStart(e, item)}
+							title="Drag into OS chat input"
+						>
+							<span class="browser-memory-title">{item.title}</span>
+							{#if item.subtitle}
+								<span class="browser-memory-subtitle">{item.subtitle}</span>
+							{/if}
+						</div>
+					{/each}
+				{/if}
+			</div>
+		{/if}
+
+		<button
+			class="group-item"
+			type="button"
+			onclick={() => { browserSessionsExpanded = !browserSessionsExpanded; }}
+		>
 			<span>Browser Sessions</span>
-			<span class="sig-meta">{browserSync.sessions}</span>
-		</div>
+			<span class="sig-meta">{browserSync.sessions.length}</span>
+			<span class="group-caret">{browserSessionsExpanded ? "▾" : "▸"}</span>
+		</button>
+		{#if browserSessionsExpanded}
+			<div class="browser-memory-dropdown">
+				{#if browserSync.sessions.length === 0}
+					<div class="browser-memory-empty">No browser session memories synced yet.</div>
+				{:else}
+					{#each browserSync.sessions as item (item.id)}
+						<div
+							class="browser-memory-item"
+							draggable="true"
+							ondragstart={(e) => handleMemoryDragStart(e, item)}
+							title="Drag into OS chat input"
+						>
+							<span class="browser-memory-title">{item.title}</span>
+							{#if item.subtitle}
+								<span class="browser-memory-subtitle">{item.subtitle}</span>
+							{/if}
+						</div>
+					{/each}
+				{/if}
+			</div>
+		{/if}
 
 		{#if browserSync.error}
 			<div class="group-sync-error">{browserSync.error}</div>
@@ -514,11 +863,82 @@ onMount(() => {
 		overflow-y: auto;
 	}
 
+	.skill-command-preview {
+	font-family: var(--font-mono);
+	font-size: 9px;
+	line-height: 1.35;
+	padding: 4px 6px;
+	border: 1px dashed var(--sig-border);
+	border-radius: 4px;
+	color: var(--sig-text-muted);
+	background: color-mix(in srgb, var(--sig-surface) 88%, transparent);
+	word-break: break-word;
+}
 	.groups-subsection {
 		display: flex;
 		flex-direction: column;
 		gap: 2px;
 		margin: 2px 0 6px;
+	}
+
+	.browser-memory-dropdown {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		padding: 2px 4px 8px;
+		max-height: 156px;
+		overflow-y: auto;
+	}
+
+	.browser-memory-item {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		padding: 5px 6px;
+		border-radius: 4px;
+		border: 1px solid var(--sig-border);
+		background: var(--sig-surface);
+		cursor: grab;
+	}
+
+	.browser-memory-item--clickable {
+		cursor: pointer;
+	}
+
+	.browser-memory-item--clickable:hover {
+		border-color: var(--sig-border-strong);
+		background: color-mix(in srgb, var(--sig-surface) 78%, var(--sig-highlight-muted));
+	}
+
+	.browser-memory-item:active {
+		cursor: grabbing;
+	}
+
+	.browser-memory-title {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		color: var(--sig-text);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.browser-memory-subtitle {
+		font-family: var(--font-mono);
+		font-size: 9px;
+		color: var(--sig-text-muted);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.browser-memory-empty {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		color: var(--sig-text-muted);
+		padding: 4px 6px;
+		border-radius: 4px;
+		border: 1px dashed var(--sig-border);
 	}
 
 	.group-sync-error {

--- a/packages/cli/dashboard/src/lib/components/tabs/OsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/OsTab.svelte
@@ -2,32 +2,129 @@
 import { API_BASE } from "$lib/api";
 import AgentChat from "$lib/components/os/AgentChat.svelte";
 import AppDock from "$lib/components/os/AppDock.svelte";
+import AutoCard from "$lib/components/os/AutoCard.svelte";
 import SidebarGroups from "$lib/components/os/SidebarGroups.svelte";
-import WidgetGrid from "$lib/components/os/WidgetGrid.svelte";
+import WidgetSandbox from "$lib/components/os/WidgetSandbox.svelte";
 import {
 	os,
-	type GridPosition,
 	fetchTrayEntries,
 	fetchWidgetHtml,
-	findFreeGridPosition,
 	getDockApps,
-	getGridApps,
 	getTrayApps,
 	loadGroups,
-	moveToGrid,
 	onWidgetGenerated,
+	onWidgetGenerationFailed,
 	requestWidgetGen,
+	widgetGenerating,
 	widgetHtmlCache,
 } from "$lib/stores/os.svelte";
-import MessageSquare from "@lucide/svelte/icons/message-square";
 import RefreshCw from "@lucide/svelte/icons/refresh-cw";
 import { onDestroy, onMount } from "svelte";
 
-let showChat = $state(false);
+let renderWindowDragOver = $state(false);
+let renderWindowTabIds = $state<string[]>([]);
+let activeRenderTabId = $state<string | null>(null);
+let renderWindowErrors = $state<Record<string, string>>({});
 
 const trayApps = $derived(getTrayApps());
-const gridApps = $derived(getGridApps());
 const dockApps = $derived(getDockApps());
+const _widgetVersion = $derived(os.widgetCacheVersion);
+const renderWindowEntry = $derived(
+	activeRenderTabId ? (os.entries.find((e) => e.id === activeRenderTabId) ?? null) : null,
+);
+const renderWindowHtml = $derived.by(() => {
+	void _widgetVersion;
+	if (!renderWindowEntry) return null;
+	if (renderWindowEntry.manifest.html) return renderWindowEntry.manifest.html;
+	return widgetHtmlCache.get(renderWindowEntry.id) ?? null;
+});
+const renderWindowGenerating = $derived.by(() => {
+	void _widgetVersion;
+	return renderWindowEntry ? widgetGenerating.has(renderWindowEntry.id) : false;
+});
+const renderWindowError = $derived.by(() => {
+	if (!activeRenderTabId) return null;
+	return renderWindowErrors[activeRenderTabId] ?? null;
+});
+
+type HeaderAction = "remember" | "transcribe" | "recall";
+type HeaderStatusTone = "neutral" | "success" | "error";
+
+interface HeaderActionOptions {
+	targetLanguage?: string;
+}
+
+type AgentChatActionHandle = {
+	triggerHeaderAction: (
+		action: HeaderAction,
+		options?: HeaderActionOptions,
+	) => Promise<{ ok: boolean; message?: string; error?: string }>;
+};
+
+let headerActionBusy = $state<HeaderAction | null>(null);
+let headerStatus = $state("");
+let headerStatusTone = $state<HeaderStatusTone>("neutral");
+let headerStatusTimer: ReturnType<typeof setTimeout> | null = null;
+let agentChatRef = $state<AgentChatActionHandle | null>(null);
+const transcribeLanguages = [
+	"English",
+	"Spanish",
+	"French",
+	"German",
+	"Portuguese",
+	"Italian",
+	"Japanese",
+	"Korean",
+	"Chinese (Simplified)",
+	"Arabic",
+	"Hindi",
+] as const;
+let selectedTranscribeLanguage = $state<(typeof transcribeLanguages)[number]>("English");
+
+function clearHeaderStatusTimer(): void {
+	if (headerStatusTimer) {
+		clearTimeout(headerStatusTimer);
+		headerStatusTimer = null;
+	}
+}
+
+function setHeaderStatus(message: string, tone: HeaderStatusTone = "neutral", persist = false): void {
+	headerStatus = message;
+	headerStatusTone = tone;
+	clearHeaderStatusTimer();
+	if (!persist) {
+		headerStatusTimer = setTimeout(() => {
+			headerStatus = "";
+			headerStatusTone = "neutral";
+			headerStatusTimer = null;
+		}, 4500);
+	}
+}
+
+async function runHeaderChatAction(action: HeaderAction, options: HeaderActionOptions = {}): Promise<void> {
+	if (!agentChatRef) {
+		setHeaderStatus("Chat panel is still initializing. Try again in a moment.", "error", true);
+		return;
+	}
+
+	headerActionBusy = action;
+	try {
+		const outcome = await agentChatRef.triggerHeaderAction(action, options);
+		if (outcome.ok) {
+			setHeaderStatus(outcome.message ?? "Action sent to chat.", "success");
+		} else {
+			setHeaderStatus(outcome.error ?? "Action could not be sent to chat.", "error", true);
+		}
+	} catch (error) {
+		setHeaderStatus(
+			`Action failed: ${error instanceof Error ? error.message : String(error)}`,
+			"error",
+			true,
+		);
+	} finally {
+		headerActionBusy = null;
+	}
+}
 
 let eventSource: EventSource | null = null;
 
@@ -36,13 +133,27 @@ onMount(() => {
 	loadGroups();
 
 	// Subscribe to widget generation events via SSE
-	eventSource = new EventSource(`${API_BASE}/api/os/events/stream?type=widget`);
+	eventSource = new EventSource(`${API_BASE}/api/os/events/stream`);
 	eventSource.onmessage = (e) => {
 		try {
 			const event = JSON.parse(e.data);
 			if (event.type === "widget.generated" && event.payload?.serverId) {
-				// Fetch the generated HTML and update the cache
-				fetchWidgetHtml(event.payload.serverId);
+				// Fetch the generated HTML and mark generation complete for all consumers
+				fetchWidgetHtml(event.payload.serverId).then((html) => {
+					if (html) {
+						onWidgetGenerated(event.payload.serverId, html);
+						setRenderWindowError(event.payload.serverId, null);
+					} else {
+						onWidgetGenerationFailed(event.payload.serverId);
+						setRenderWindowError(event.payload.serverId, "Failed to load generated MCP client UI.");
+					}
+				});
+			} else if (event.type === "widget.error" && event.payload?.serverId) {
+				onWidgetGenerationFailed(event.payload.serverId);
+				setRenderWindowError(
+					event.payload.serverId,
+					typeof event.payload.error === "string" ? event.payload.error : "Failed to build MCP client UI.",
+				);
 			}
 		} catch {
 			// Ignore parse errors from heartbeats
@@ -52,38 +163,100 @@ onMount(() => {
 
 onDestroy(() => {
 	eventSource?.close();
+	clearHeaderStatusTimer();
 });
 
-async function handleDragToBoard(id: string): Promise<void> {
-	const entry = os.entries.find((a) => a.id === id);
-	if (!entry) return;
-	const size = entry.manifest?.defaultSize ?? { w: 4, h: 3 };
+function getEntryById(appId: string) {
+	return os.entries.find((entry) => entry.id === appId) ?? null;
+}
 
-	// Compute a free grid position to avoid overlapping at (0,0)
-	const occupied = gridApps.flatMap((a) => (a.id !== id && a.gridPosition ? [a.gridPosition] : []));
-	const pos = findFreeGridPosition(occupied, size);
+function clearRenderWindow(): void {
+	renderWindowTabIds = [];
+	activeRenderTabId = null;
+	renderWindowErrors = {};
+	renderWindowDragOver = false;
+}
 
-	await moveToGrid(id, pos);
-
-	// Trigger widget generation if no declared or cached HTML
-	if (!entry.manifest.html && !widgetHtmlCache.has(id)) {
-		fetchWidgetHtml(id).then((cached) => {
-			if (!cached) requestWidgetGen(id);
-		});
+function closeRenderTab(appId: string): void {
+	const nextTabs = renderWindowTabIds.filter((id) => id !== appId);
+	renderWindowTabIds = nextTabs;
+	const nextErrors = { ...renderWindowErrors };
+	delete nextErrors[appId];
+	renderWindowErrors = nextErrors;
+	if (activeRenderTabId === appId) {
+		activeRenderTabId = nextTabs.length > 0 ? nextTabs[nextTabs.length - 1] : null;
 	}
 }
 
-function handleGridDrop(appId: string, x: number, y: number): void {
-	const entry = os.entries.find((a) => a.id === appId);
-	if (!entry) return;
-	const size = entry.manifest?.defaultSize ?? { w: 4, h: 3 };
-	moveToGrid(appId, { x, y, ...size });
+function setRenderWindowError(appId: string, message: string | null): void {
+	if (!message) {
+		const nextErrors = { ...renderWindowErrors };
+		delete nextErrors[appId];
+		renderWindowErrors = nextErrors;
+		return;
+	}
+	renderWindowErrors = {
+		...renderWindowErrors,
+		[appId]: message,
+	};
 }
 
-/** Resolve the default widget size for a given appId (for WidgetGrid collision detection) */
-function resolveDefaultSize(appId: string): { w: number; h: number } {
-	const entry = os.entries.find((a) => a.id === appId);
-	return entry?.manifest?.defaultSize ?? { w: 4, h: 3 };
+async function loadAppIntoRenderWindow(appId: string): Promise<void> {
+	setRenderWindowError(appId, null);
+	let entry = getEntryById(appId);
+	if (!entry) {
+		await fetchTrayEntries();
+		entry = getEntryById(appId);
+	}
+	if (!entry) {
+		if (activeRenderTabId) setRenderWindowError(activeRenderTabId, "Unable to load that MCP app from the current tray.");
+		return;
+	}
+
+	if (!renderWindowTabIds.includes(appId)) {
+		renderWindowTabIds = [...renderWindowTabIds, appId];
+	}
+	activeRenderTabId = appId;
+
+	if (!entry.manifest.html && !widgetHtmlCache.has(appId)) {
+		await fetchWidgetHtml(appId);
+	}
+}
+
+function handleRenderDragOver(e: DragEvent): void {
+	e.preventDefault();
+	renderWindowDragOver = true;
+	if (e.dataTransfer) e.dataTransfer.dropEffect = "move";
+}
+
+function handleRenderDragLeave(): void {
+	renderWindowDragOver = false;
+}
+
+function handleRenderDrop(e: DragEvent): void {
+	e.preventDefault();
+	renderWindowDragOver = false;
+	const appId = e.dataTransfer?.getData("text/plain")?.trim();
+	if (!appId) return;
+	void loadAppIntoRenderWindow(appId);
+}
+
+async function handleRenderRefresh(): Promise<void> {
+	if (!renderWindowEntry) return;
+	setRenderWindowError(renderWindowEntry.id, null);
+	const cached = await fetchWidgetHtml(renderWindowEntry.id);
+	if (!cached && !renderWindowEntry.manifest.html) {
+		await requestWidgetGen(renderWindowEntry.id);
+	}
+}
+
+async function startRenderGeneration(serverId: string): Promise<void> {
+	setRenderWindowError(serverId, null);
+	await requestWidgetGen(serverId);
+}
+
+async function handleDragToBoard(id: string): Promise<void> {
+	await loadAppIntoRenderWindow(id);
 }
 </script>
 
@@ -95,31 +268,53 @@ function resolveDefaultSize(appId: string): { w: number; h: number } {
 
 	<!-- Main content area -->
 	<div class="os-main">
-		<!-- Top bar -->
-		<div class="os-topbar">
-			<div class="os-topbar-left">
-				<span class="sig-heading">View and Manage your Apps</span>
-				<span class="sig-eyebrow">{os.entries.length} {os.entries.length === 1 ? "server" : "servers"}</span>
-			</div>
-			<div class="os-topbar-right">
+		<div class="os-main-header">
+			<span class="sig-heading">Signet Os</span>
+			<div class="os-main-header-actions">
 				<button
-					class="os-chat-toggle"
-					class:active={showChat}
-					title={showChat ? "Hide agent chat" : "Show agent chat"}
-					onclick={() => showChat = !showChat}
+					class="os-main-header-btn"
+					type="button"
+					onclick={() => void runHeaderChatAction("remember")}
+					disabled={headerActionBusy !== null}
 				>
-					<MessageSquare class="size-3" />
+					{headerActionBusy === "remember" ? "Sending…" : "Remember"}
 				</button>
+				<div class="os-main-header-transcribe-group">
+					<select
+						class="os-main-header-select"
+						bind:value={selectedTranscribeLanguage}
+						disabled={headerActionBusy !== null}
+						title="Transcribe output language"
+					>
+						{#each transcribeLanguages as language}
+							<option value={language}>{language}</option>
+						{/each}
+					</select>
+					<button
+						class="os-main-header-btn"
+						type="button"
+						onclick={() => void runHeaderChatAction("transcribe", { targetLanguage: selectedTranscribeLanguage })}
+						disabled={headerActionBusy !== null}
+					>
+						{headerActionBusy === "transcribe" ? "Sending…" : "Transcribe"}
+					</button>
+				</div>
 				<button
-					class="os-refresh-btn"
-					title="Refresh app tray"
-					onclick={() => fetchTrayEntries()}
-					disabled={os.loading}
+					class="os-main-header-btn"
+					type="button"
+					onclick={() => void runHeaderChatAction("recall")}
+					disabled={headerActionBusy !== null}
 				>
-					<RefreshCw class={`size-3${os.loading ? " animate-spin" : ""}`} />
+					{headerActionBusy === "recall" ? "Sending…" : "Recall"}
 				</button>
 			</div>
 		</div>
+
+		{#if headerStatus}
+			<div class="os-header-status" class:os-header-status--success={headerStatusTone === "success"} class:os-header-status--error={headerStatusTone === "error"}>
+				<span class="sig-meta">{headerStatus}</span>
+			</div>
+		{/if}
 
 		{#if os.error}
 			<div class="os-error">
@@ -127,13 +322,112 @@ function resolveDefaultSize(appId: string): { w: number; h: number } {
 			</div>
 		{/if}
 
-		<!-- Widget grid -->
-		<WidgetGrid apps={gridApps} ongriddrop={handleGridDrop} {resolveDefaultSize} />
+		<div class="os-workspace">
+			<!-- Agent chat panel -->
+			<div class="os-chat-panel">
+				<AgentChat bind:this={agentChatRef} />
+			</div>
 
-		<!-- Agent chat panel (collapsible) -->
-		{#if showChat}
-			<AgentChat />
-		{/if}
+			<div class="os-render-window">
+				<div class="os-render-window-tabs" ondragover={handleRenderDragOver} ondragleave={handleRenderDragLeave} ondrop={handleRenderDrop}>
+						{#if renderWindowTabIds.length === 0}
+							<div class="os-render-window-tabs-empty">Drop an app here to open the first render tab.</div>
+						{:else}
+							{#each renderWindowTabIds as tabId (tabId)}
+								{@const tabEntry = getEntryById(tabId)}
+								<button
+									class="os-render-tab"
+									class:os-render-tab--active={activeRenderTabId === tabId}
+									onclick={() => activeRenderTabId = tabId}
+									title={tabEntry?.name ?? tabId}
+								>
+									<span class="os-render-tab-name">{tabEntry?.name ?? tabId}</span>
+									<span
+										class="os-render-tab-close"
+										onclick={(e) => {
+											e.stopPropagation();
+											closeRenderTab(tabId);
+										}}
+										title="Close tab"
+									>
+										×
+									</span>
+								</button>
+							{/each}
+							<div class="os-render-window-tabs-hint">Drag another app here to open a new tab.</div>
+						{/if}
+						<div class="os-render-window-tabs-actions">
+							<button
+								class="os-render-action-btn"
+								title="Refresh render window"
+								onclick={() => void handleRenderRefresh()}
+								disabled={!renderWindowEntry}
+							>
+								<RefreshCw class="size-3" />
+							</button>
+							<button
+								class="os-render-action-btn"
+								title="Clear all render tabs"
+								onclick={clearRenderWindow}
+								disabled={renderWindowTabIds.length === 0}
+							>
+								Clear
+							</button>
+						</div>
+					</div>
+
+					<div
+						class="os-render-window-body"
+						class:drag-over={renderWindowDragOver}
+						role="region"
+						aria-label="MCP render drop zone"
+						ondragover={handleRenderDragOver}
+						ondragleave={handleRenderDragLeave}
+						ondrop={handleRenderDrop}
+					>
+						<div class="os-render-window-content">
+							{#if renderWindowError}
+								<div class="os-render-window-error">{renderWindowError}</div>
+							{/if}
+							{#if renderWindowEntry}
+								{#if renderWindowHtml}
+									<WidgetSandbox html={renderWindowHtml} serverId={renderWindowEntry.id} />
+								{:else if renderWindowGenerating}
+									<div class="os-render-window-loading-state">
+										<div class="os-signet-loader" aria-hidden="true">
+											<span></span>
+											<span></span>
+											<span></span>
+										</div>
+										<span class="sig-label">Generating MCP client UI…</span>
+										<span class="sig-meta">Building with Signet tools/resources. This stays active until final UI output is ready.</span>
+									</div>
+								{:else}
+									<div class="os-render-window-autocard">
+										<AutoCard
+											autoCard={renderWindowEntry.autoCard}
+											name={renderWindowEntry.name}
+											icon={renderWindowEntry.icon}
+										/>
+										<div class="os-render-window-autocard-action">
+											<button
+												class="os-render-action-btn"
+												onclick={() => void startRenderGeneration(renderWindowEntry.id)}
+											>
+												Load Visual MCP Client
+											</button>
+										</div>
+									</div>
+								{/if}
+							{:else}
+								<div class="os-render-window-empty-state">
+									<span class="sig-label">Drag any discovered MCP app here from the dock or left sidebar to launch it.</span>
+								</div>
+							{/if}
+						</div>
+					</div>
+				</div>
+		</div>
 
 		<!-- Bottom dock / tray -->
 		<AppDock
@@ -172,80 +466,326 @@ function resolveDefaultSize(appId: string): { w: number; h: number } {
 		background: var(--sig-bg);
 	}
 
-	.os-topbar {
+	.os-main-header {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
+		gap: 12px;
 		padding: 10px var(--space-md);
 		background: var(--sig-surface);
+		border-bottom: 1px solid var(--sig-border);
 		flex-shrink: 0;
 	}
 
-	.os-topbar-left {
-		display: flex;
+	.os-main-header-actions {
+		display: inline-flex;
 		align-items: center;
-		gap: var(--space-sm);
+		gap: 6px;
 	}
 
-	.os-topbar-right {
-		display: flex;
+	.os-main-header-transcribe-group {
+		display: inline-flex;
 		align-items: center;
-		gap: 4px;
+		gap: 6px;
 	}
 
-	.os-chat-toggle {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		width: 28px;
-		height: 28px;
-		padding: 0;
+	.os-main-header-select {
+		height: 24px;
+		max-width: 180px;
+		padding: 0 8px;
 		border: 1px solid var(--sig-border);
 		border-radius: 6px;
-		background: var(--sig-surface);
+		background: var(--sig-bg);
+		color: var(--sig-text);
+		font-family: var(--font-mono);
+		font-size: 10px;
+		letter-spacing: 0.02em;
+	}
+
+	.os-main-header-select:disabled {
+		opacity: 0.55;
+	}
+
+	.os-main-header-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 24px;
+		padding: 0 8px;
+		border: 1px solid var(--sig-border);
+		border-radius: 6px;
+		background: var(--sig-bg);
 		color: var(--sig-text-muted);
+		font-family: var(--font-mono);
+		font-size: 10px;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
 		cursor: pointer;
 		transition: all var(--dur) var(--ease);
 	}
 
-	.os-chat-toggle:hover {
-		border-color: var(--sig-border-strong);
-		color: var(--sig-text-bright);
-	}
-
-	.os-chat-toggle.active {
+	.os-main-header-btn:hover:not(:disabled) {
 		border-color: var(--sig-accent);
 		color: var(--sig-accent);
-		background: color-mix(in srgb, var(--sig-accent) 10%, var(--sig-surface));
 	}
 
-	.os-refresh-btn {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		width: 28px;
-		height: 28px;
-		padding: 0;
-		border: 1px solid var(--sig-border);
-		border-radius: 6px;
-		background: var(--sig-surface);
-		color: var(--sig-text-muted);
-		cursor: pointer;
-		transition: all var(--dur) var(--ease);
+	.os-main-header-btn:disabled {
+		opacity: 0.55;
+		cursor: default;
 	}
 
-	.os-refresh-btn:hover:not(:disabled) {
-		border-color: var(--sig-border-strong);
-		color: var(--sig-text-bright);
+	.os-header-status {
+		padding: 6px var(--space-md);
+		border-bottom: 1px solid var(--sig-border);
+		background: color-mix(in srgb, var(--sig-surface) 70%, var(--sig-bg));
 	}
 
-	.os-refresh-btn:disabled {
-		opacity: 0.4;
+	.os-header-status--success {
+		background: color-mix(in srgb, var(--sig-accent) 10%, var(--sig-bg));
+	}
+
+	.os-header-status--error {
+		background: color-mix(in srgb, var(--sig-danger) 10%, var(--sig-bg));
+	}
+
+	.os-workspace {
+		display: grid;
+		grid-template-rows: minmax(0, 1fr) minmax(0, 1fr);
+		flex: 1;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	.os-chat-panel {
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	.os-chat-panel :global(.agent-chat) {
+		height: 100%;
+		max-height: none;
+		min-height: 0;
+		border-top: 1px solid var(--sig-border);
 	}
 
 	.os-error {
 		padding: 8px var(--space-md);
 		background: color-mix(in srgb, var(--sig-danger) 8%, var(--sig-bg));
+	}
+
+	.os-render-window {
+		display: flex;
+		flex-direction: column;
+		border-top: 1px solid var(--sig-border);
+		border-bottom: 1px solid var(--sig-border);
+		background: var(--sig-surface);
+		flex-shrink: 0;
+		min-height: 0;
+	}
+
+	.os-render-window-tabs {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		padding: 6px var(--space-md);
+		border-bottom: 1px solid var(--sig-border);
+		overflow-x: auto;
+		background: color-mix(in srgb, var(--sig-surface) 70%, var(--sig-bg));
+	}
+
+	.os-render-window-tabs-actions {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		margin-left: auto;
+	}
+
+	.os-render-window-tabs-empty,
+	.os-render-window-tabs-hint {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		color: var(--sig-text-muted);
+		white-space: nowrap;
+	}
+
+	.os-render-tab {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		padding: 4px 8px;
+		max-width: 220px;
+		border: 1px solid var(--sig-border);
+		border-radius: 6px;
+		background: var(--sig-bg);
+		color: var(--sig-text-muted);
+		cursor: pointer;
+		font-family: var(--font-mono);
+		font-size: 10px;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+
+	.os-render-tab--active {
+		border-color: var(--sig-accent);
+		color: var(--sig-accent);
+		background: color-mix(in srgb, var(--sig-accent) 10%, var(--sig-bg));
+	}
+
+	.os-render-tab-name {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.os-render-tab-close {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 14px;
+		height: 14px;
+		border-radius: 3px;
+		font-size: 11px;
+		line-height: 1;
+	}
+
+	.os-render-tab-close:hover {
+		background: color-mix(in srgb, var(--sig-danger) 14%, transparent);
+		color: var(--sig-danger);
+	}
+
+	.os-render-window-loading-state {
+		height: 100%;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 8px;
+		padding: 16px;
+		text-align: center;
+	}
+
+	.os-signet-loader {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.os-signet-loader span {
+		width: 7px;
+		height: 7px;
+		border-radius: 999px;
+		background: var(--sig-accent);
+		animation: sig-loader-pulse 0.9s ease-in-out infinite;
+	}
+
+	.os-signet-loader span:nth-child(2) {
+		animation-delay: 0.12s;
+	}
+
+	.os-signet-loader span:nth-child(3) {
+		animation-delay: 0.24s;
+	}
+
+	@keyframes sig-loader-pulse {
+		0%,
+		100% {
+			opacity: 0.3;
+			transform: scale(0.8);
+		}
+		50% {
+			opacity: 1;
+			transform: scale(1);
+		}
+	}
+
+	.os-render-action-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 24px;
+		padding: 0 8px;
+		border: 1px solid var(--sig-border);
+		border-radius: 6px;
+		background: var(--sig-bg);
+		color: var(--sig-text-muted);
+		font-family: var(--font-mono);
+		font-size: 10px;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		cursor: pointer;
+		transition: all var(--dur) var(--ease);
+	}
+
+	.os-render-action-btn:hover:not(:disabled) {
+		border-color: var(--sig-accent);
+		color: var(--sig-accent);
+	}
+
+	.os-render-action-btn:disabled {
+		opacity: 0.45;
+		cursor: default;
+	}
+
+	.os-render-window-body {
+		position: relative;
+		flex: 1;
+		min-height: 0;
+		overflow: hidden;
+		background: var(--sig-bg);
+		border: 1px dashed transparent;
+		padding: 10px;
+		transition: border-color var(--dur) var(--ease), background var(--dur) var(--ease);
+	}
+
+	.os-render-window-content {
+		position: relative;
+		height: 100%;
+		border: 1px solid var(--sig-border);
+		border-radius: 12px;
+		overflow: hidden;
+		background: color-mix(in srgb, var(--sig-surface) 75%, var(--sig-bg));
+	}
+
+	.os-render-window-body.drag-over {
+		border-color: var(--sig-accent);
+		background: color-mix(in srgb, var(--sig-accent) 8%, var(--sig-bg));
+	}
+
+	.os-render-window-empty-state {
+		height: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 12px;
+		text-align: center;
+	}
+
+	.os-render-window-error {
+		position: absolute;
+		top: 8px;
+		left: 8px;
+		right: 8px;
+		z-index: 2;
+		font-family: var(--font-mono);
+		font-size: 11px;
+		padding: 6px 8px;
+		border: 1px solid color-mix(in srgb, var(--sig-danger) 35%, var(--sig-border));
+		background: color-mix(in srgb, var(--sig-danger) 12%, var(--sig-surface));
+		color: var(--sig-danger);
+		border-radius: 6px;
+	}
+
+	.os-render-window-autocard {
+		height: 100%;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.os-render-window-autocard-action {
+		padding: 8px var(--space-md);
+		border-top: 1px solid var(--sig-border);
+		display: flex;
+		justify-content: flex-end;
 	}
 
 	@media (max-width: 768px) {
@@ -262,13 +802,6 @@ function resolveDefaultSize(appId: string): { w: number; h: number } {
 			padding: var(--space-sm);
 			overflow-x: auto;
 			overflow-y: hidden;
-		}
-	}
-
-	/* Safe area inset for notched phones */
-	@supports (padding: env(safe-area-inset-top)) {
-		.os-topbar {
-			padding-top: max(10px, env(safe-area-inset-top));
 		}
 	}
 </style>

--- a/packages/cli/dashboard/src/lib/components/tabs/OsTab.svelte
+++ b/packages/cli/dashboard/src/lib/components/tabs/OsTab.svelte
@@ -236,8 +236,10 @@ function handleRenderDragLeave(): void {
 function handleRenderDrop(e: DragEvent): void {
 	e.preventDefault();
 	renderWindowDragOver = false;
-	const appId = e.dataTransfer?.getData("text/plain")?.trim();
-	if (!appId) return;
+	const explicitAppId = e.dataTransfer?.getData("application/x-signet-app-id")?.trim() || "";
+	const fallbackText = e.dataTransfer?.getData("text/plain")?.trim() || "";
+	const appId = explicitAppId || fallbackText;
+	if (!appId || !os.entries.some((entry) => entry.id === appId)) return;
 	void loadAppIntoRenderWindow(appId);
 }
 

--- a/packages/cli/dashboard/src/lib/stores/os.svelte.ts
+++ b/packages/cli/dashboard/src/lib/stores/os.svelte.ts
@@ -396,6 +396,11 @@ export function onWidgetGenerated(serverId: string, html: string): void {
 	os.widgetCacheVersion++;
 }
 
+export function onWidgetGenerationFailed(serverId: string): void {
+	widgetGenerating.delete(serverId);
+	os.widgetCacheVersion++;
+}
+
 // ============================================================================
 // Widget Sandbox Registry — allows AgentChat to find and control widget iframes
 // ============================================================================

--- a/packages/cli/dashboard/src/routes/+page.svelte
+++ b/packages/cli/dashboard/src/routes/+page.svelte
@@ -51,14 +51,33 @@ let timelineGeneratedFor = $state("");
 
 // --- Theme ---
 let theme = $state<"dark" | "light">("dark");
+let followsSystemTheme = $state(true);
+let stopSystemThemeWatch: (() => void) | null = null;
+
+function resolveSystemTheme(): "dark" | "light" {
+	if (typeof window === "undefined") return "dark";
+	return window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
+}
+
+function readStoredThemePreference(): "dark" | "light" | "auto" {
+	if (typeof window === "undefined") return "auto";
+	const stored = localStorage.getItem("signet-theme");
+	if (stored === "light" || stored === "dark") return stored;
+	if (stored === "auto") return "auto";
+	return "auto";
+}
 
 if (browser) {
-	const stored = document.documentElement.dataset.theme;
-	theme = stored === "light" || stored === "dark" ? stored : "dark";
+	const preferredTheme = readStoredThemePreference();
+	const initialTheme = preferredTheme === "auto" ? resolveSystemTheme() : preferredTheme;
+	theme = initialTheme;
+	followsSystemTheme = preferredTheme === "auto";
+	document.documentElement.dataset.theme = initialTheme;
 }
 
 function toggleTheme() {
 	theme = theme === "dark" ? "light" : "dark";
+	followsSystemTheme = false;
 	document.documentElement.dataset.theme = theme;
 	localStorage.setItem("signet-theme", theme);
 }
@@ -145,6 +164,18 @@ onMount(() => {
 	const cleanupNav = initNavFromHash();
 	const cleanupTabGroups = initTabGroupEffects();
 
+	stopSystemThemeWatch?.();
+	stopSystemThemeWatch = null;
+	if (followsSystemTheme) {
+		const media = window.matchMedia("(prefers-color-scheme: light)");
+		const handleSystemThemeChange = (event: MediaQueryListEvent): void => {
+			theme = event.matches ? "light" : "dark";
+			document.documentElement.dataset.theme = theme;
+		};
+		media.addEventListener("change", handleSystemThemeChange);
+		stopSystemThemeWatch = () => media.removeEventListener("change", handleSystemThemeChange);
+	}
+
 	getStatus().then((s) => {
 		daemonStatus = s;
 	});
@@ -174,6 +205,8 @@ onMount(() => {
 	return () => {
 		cleanupNav();
 		cleanupTabGroups();
+		stopSystemThemeWatch?.();
+		stopSystemThemeWatch = null;
 		window.removeEventListener("beforeunload", handleBeforeUnload);
 		if (isTauri) {
 			window.removeEventListener("wheel", handleWheel);

--- a/packages/daemon/src/mcp-probe.ts
+++ b/packages/daemon/src/mcp-probe.ts
@@ -2,7 +2,7 @@
 
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, delimiter } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
@@ -76,6 +76,44 @@ async function resolveSecretReferences(values: Readonly<Record<string, string>>)
 	return resolved;
 }
 
+const EXTRA_PATH_DIRS = [
+	"/opt/homebrew/bin",
+	"/usr/local/bin",
+	"/usr/bin",
+	"/bin",
+	join(homedir(), ".bun", "bin"),
+	join(homedir(), ".local", "bin"),
+	"/Applications/Docker.app/Contents/Resources/bin",
+	"/Applications/Docker.app/Contents/MacOS",
+] as const;
+
+function buildRuntimePath(pathValue: string | undefined): string {
+	const merged = new Set<string>();
+	for (const part of (pathValue ?? "").split(delimiter)) {
+		const normalized = part.trim();
+		if (normalized.length > 0) merged.add(normalized);
+	}
+	for (const extra of EXTRA_PATH_DIRS) {
+		merged.add(extra);
+	}
+	return Array.from(merged).join(delimiter);
+}
+
+function resolveCommandPath(command: string, runtimePath: string): string {
+	if (command.includes("/") || command.includes("\\")) return command;
+	const fromPath = Bun.which(command);
+	if (typeof fromPath === "string" && fromPath.length > 0) return fromPath;
+
+	for (const dir of runtimePath.split(delimiter)) {
+		const trimmed = dir.trim();
+		if (trimmed.length === 0) continue;
+		const candidate = join(trimmed, command);
+		if (existsSync(candidate)) return candidate;
+	}
+
+	return command;
+}
+
 // ---------------------------------------------------------------------------
 // MCP Client connection (follows marketplace.ts pattern exactly)
 // ---------------------------------------------------------------------------
@@ -99,10 +137,12 @@ async function withProbeClient<T>(
 			}
 			const resolvedEnv = await resolveSecretReferences((server.config as MarketplaceMcpConfigStdio).env);
 			const stdioConfig = server.config as MarketplaceMcpConfigStdio;
+			const pathValue = buildRuntimePath(resolvedEnv.PATH ?? runtimeEnv.PATH);
+			const command = resolveCommandPath(stdioConfig.command, pathValue);
 			const transport = new StdioClientTransport({
-				command: stdioConfig.command,
+				command,
 				args: [...stdioConfig.args],
-				env: { ...runtimeEnv, ...resolvedEnv },
+				env: { ...runtimeEnv, ...resolvedEnv, PATH: pathValue },
 				cwd: stdioConfig.cwd,
 			});
 
@@ -287,6 +327,48 @@ export function generateAutoCard(
 	};
 }
 
+function isUnresolvedTemplateValue(value: string): boolean {
+	const trimmed = value.trim();
+	if (trimmed.length === 0) return false;
+	return /^<[^>]+>$/.test(trimmed) || /^\$\{input:[^}]+\}$/.test(trimmed);
+}
+
+function parseInlineEnvArg(arg: string): { key: string; value: string } | null {
+	const separator = arg.indexOf("=");
+	if (separator <= 0) return null;
+	const key = arg.slice(0, separator).trim();
+	if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) return null;
+	return {
+		key,
+		value: arg.slice(separator + 1).trim(),
+	};
+}
+
+function getProbeConfigIssue(server: InstalledMarketplaceMcpServer): string | null {
+	if (server.config.transport !== "stdio") return null;
+	const config = server.config as MarketplaceMcpConfigStdio;
+	const unresolved: string[] = [];
+
+	for (const [key, value] of Object.entries(config.env)) {
+		if (isUnresolvedTemplateValue(value)) {
+			unresolved.push(`${key}=${value}`);
+		}
+	}
+
+	for (let i = 0; i < config.args.length - 1; i++) {
+		const arg = config.args[i];
+		if (arg !== "-e" && arg !== "--env") continue;
+		const parsed = parseInlineEnvArg(config.args[i + 1]);
+		if (!parsed) continue;
+		if (isUnresolvedTemplateValue(parsed.value)) {
+			unresolved.push(`${parsed.key}=${parsed.value}`);
+		}
+	}
+
+	if (unresolved.length === 0) return null;
+	return `Server ${server.id} has unresolved environment placeholders: ${unresolved.join(", ")}. Update MCP server settings with real values and retry.`;
+}
+
 // ---------------------------------------------------------------------------
 // Server probing
 // ---------------------------------------------------------------------------
@@ -301,6 +383,20 @@ export function generateAutoCard(
  */
 export async function probeServer(server: InstalledMarketplaceMcpServer): Promise<McpProbeResult> {
 	const now = new Date().toISOString();
+	const configIssue = getProbeConfigIssue(server);
+	if (configIssue) {
+		logger.warn("probe", configIssue);
+		return {
+			serverId: server.id,
+			ok: false,
+			error: configIssue,
+			autoCard: generateAutoCard([], [], server.name),
+			toolCount: 0,
+			resourceCount: 0,
+			hasAppResources: false,
+			probedAt: now,
+		};
+	}
 
 	try {
 		const probeData = await withProbeClient(server, async (client) => {

--- a/packages/daemon/src/pipeline/provider.ts
+++ b/packages/daemon/src/pipeline/provider.ts
@@ -1256,7 +1256,9 @@ export function createCodexProvider(config?: Partial<CodexProviderConfig>): LlmP
 				"--sandbox",
 				"read-only",
 				"-c",
-				"mcp_servers.signet.enabled=false",
+				// Keep MCP disabled for daemon-side Codex runs without creating
+				// partial per-server config that newer Codex rejects.
+				"mcp_servers={}",
 				"-C",
 				cfg.workingDirectory,
 				"--model",

--- a/packages/daemon/src/routes/marketplace.ts
+++ b/packages/daemon/src/routes/marketplace.ts
@@ -6,7 +6,7 @@
 
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, delimiter } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
@@ -377,6 +377,44 @@ async function resolveSecretReferences(values: Readonly<Record<string, string>>)
 		resolved[key] = await getSecret(secretName);
 	}
 	return resolved;
+}
+
+const EXTRA_PATH_DIRS = [
+	"/opt/homebrew/bin",
+	"/usr/local/bin",
+	"/usr/bin",
+	"/bin",
+	join(homedir(), ".bun", "bin"),
+	join(homedir(), ".local", "bin"),
+	"/Applications/Docker.app/Contents/Resources/bin",
+	"/Applications/Docker.app/Contents/MacOS",
+] as const;
+
+function buildRuntimePath(pathValue: string | undefined): string {
+	const merged = new Set<string>();
+	for (const part of (pathValue ?? "").split(delimiter)) {
+		const normalized = part.trim();
+		if (normalized.length > 0) merged.add(normalized);
+	}
+	for (const extra of EXTRA_PATH_DIRS) {
+		merged.add(extra);
+	}
+	return Array.from(merged).join(delimiter);
+}
+
+function resolveCommandPath(command: string, runtimePath: string): string {
+	if (command.includes("/") || command.includes("\\")) return command;
+	const fromPath = Bun.which(command);
+	if (typeof fromPath === "string" && fromPath.length > 0) return fromPath;
+
+	for (const dir of runtimePath.split(delimiter)) {
+		const trimmed = dir.trim();
+		if (trimmed.length === 0) continue;
+		const candidate = join(trimmed, command);
+		if (existsSync(candidate)) return candidate;
+	}
+
+	return command;
 }
 
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
@@ -939,10 +977,12 @@ async function withConnectedClient<T>(
 				if (typeof v === "string") runtimeEnv[k] = v;
 			}
 			const resolvedEnv = await resolveSecretReferences(server.config.env);
+			const pathValue = buildRuntimePath(resolvedEnv.PATH ?? runtimeEnv.PATH);
+			const command = resolveCommandPath(server.config.command, pathValue);
 			const transport = new StdioClientTransport({
-				command: server.config.command,
+				command,
 				args: [...server.config.args],
-				env: { ...runtimeEnv, ...resolvedEnv },
+				env: { ...runtimeEnv, ...resolvedEnv, PATH: pathValue },
 				cwd: server.config.cwd,
 			});
 

--- a/packages/daemon/src/routes/os-chat.ts
+++ b/packages/daemon/src/routes/os-chat.ts
@@ -71,6 +71,59 @@ interface ToolSpec {
 	inputSchema?: unknown;
 }
 
+interface BrowserToolRequest {
+	action?: string;
+	payload?: string;
+	pageTitle?: string;
+	pageUrl?: string;
+	note?: string;
+	selectedText?: string;
+	links?: string[];
+	images?: string[];
+	videos?: string[];
+	audio?: string[];
+	files?: Array<{ name?: string; type?: string; size?: number }>;
+	dispatchToHarness?: boolean;
+}
+
+interface BrowserToolRouteResult {
+	success: boolean;
+	memoryStored: boolean;
+	dispatched: boolean;
+	memoryId?: string;
+	response?: string;
+	error?: string;
+	toolCalls?: ToolCallResult[];
+}
+
+function getLocalDaemonBaseUrl(): string {
+	return `http://127.0.0.1:${process.env.SIGNET_PORT || 3850}`;
+}
+
+function formatBrowserToolMessage(request: BrowserToolRequest): string {
+	const title = request.pageTitle?.trim() || "Untitled page";
+	const url = request.pageUrl?.trim() || "unknown";
+	const action = request.action?.trim() || "browser-submission";
+	const note = request.note?.trim() || "(none)";
+	const selected = request.selectedText?.trim() || "(none)";
+
+	return [
+		"Browser extension submission from Signet.",
+		`Action: ${action}`,
+		`Page: ${title}`,
+		`URL: ${url}`,
+		`Note: ${note}`,
+		"",
+		"Selection:",
+		selected,
+		"",
+		"Payload:",
+		request.payload?.slice(0, 20_000) || "",
+		"",
+		"Please process this like a live browser handoff: extract key facts, continue workflow context, and run tools only when clearly needed.",
+	].join("\n");
+}
+
 /**
  * Gather all available tools from all installed MCP servers using probe results.
  */
@@ -273,9 +326,7 @@ export function mountOsChatRoutes(app: Hono): void {
 						});
 
 						// Call the tool via the marketplace /mcp/call endpoint internally
-						const callRes = await fetch(
-							`http://127.0.0.1:${process.env.SIGNET_PORT || 3850}/api/marketplace/mcp/call`,
-							{
+						const callRes = await fetch(`${getLocalDaemonBaseUrl()}/api/marketplace/mcp/call`, {
 								method: "POST",
 								headers: { "Content-Type": "application/json" },
 								body: JSON.stringify({
@@ -361,5 +412,111 @@ Now give a concise, natural language summary of the results for the user. Be spe
 				toolCalls: [],
 			});
 		}
+	});
+
+	app.post("/api/os/browser-tool", async (c) => {
+		let body: BrowserToolRequest;
+		try {
+			body = await c.req.json();
+		} catch {
+			return c.json({ error: "Invalid JSON" }, 400);
+		}
+
+		const payload = body.payload?.trim();
+		if (!payload) {
+			return c.json({ error: "Payload is required" }, 400);
+		}
+
+		const action = body.action?.trim() || "browser-submission";
+		const baseUrl = getLocalDaemonBaseUrl();
+		let memoryStored = false;
+		let memoryId: string | undefined;
+		let dispatched = false;
+		let responseText: string | undefined;
+		let dispatchError: string | undefined;
+		let memoryError: string | undefined;
+		let toolCalls: ToolCallResult[] | undefined;
+
+		const links = Array.isArray(body.links) ? body.links.slice(0, 20) : [];
+		const images = Array.isArray(body.images) ? body.images.slice(0, 20) : [];
+		const videos = Array.isArray(body.videos) ? body.videos.slice(0, 20) : [];
+		const audio = Array.isArray(body.audio) ? body.audio.slice(0, 20) : [];
+		const files = Array.isArray(body.files) ? body.files.slice(0, 20) : [];
+
+		try {
+			const memoryRes = await fetch(`${baseUrl}/api/memory/remember`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					content: [
+						"[Signet Browser Tool]",
+						`Action: ${action}`,
+						`Title: ${body.pageTitle || "Untitled"}`,
+						`URL: ${body.pageUrl || "unknown"}`,
+						`Captured At: ${new Date().toISOString()}`,
+						"",
+						`Selection: ${body.selectedText?.trim() || "(none)"}`,
+						`Note: ${body.note?.trim() || "(none)"}`,
+						`Links: ${links.length}`,
+						`Images: ${images.length}`,
+						`Videos: ${videos.length}`,
+						`Audio: ${audio.length}`,
+						`Files: ${files.length}`,
+						"",
+						payload.slice(0, 20_000),
+					].join("\n"),
+					tags: `browser-tool,${action},browser-extension`,
+					importance: 0.72,
+					type: "note",
+					source_type: "browser-extension",
+				}),
+			});
+
+			if (memoryRes.ok) {
+				const memoryData = (await memoryRes.json()) as { success?: boolean; id?: string };
+				memoryStored = memoryData.success === true;
+				memoryId = memoryData.id;
+			} else {
+				memoryError = `Memory save failed (${memoryRes.status})`;
+			}
+		} catch (error) {
+			memoryError = error instanceof Error ? error.message : String(error);
+		}
+
+		if (body.dispatchToHarness !== false) {
+			try {
+				const chatRes = await fetch(`${baseUrl}/api/os/chat`, {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ message: formatBrowserToolMessage({ ...body, payload, action }) }),
+				});
+
+				if (chatRes.ok) {
+					const chatData = (await chatRes.json()) as {
+						response?: string;
+						toolCalls?: ToolCallResult[];
+					};
+					dispatched = true;
+					responseText = chatData.response;
+					toolCalls = chatData.toolCalls;
+				} else {
+					dispatchError = `Dispatch failed (${chatRes.status})`;
+				}
+			} catch (error) {
+				dispatchError = error instanceof Error ? error.message : String(error);
+			}
+		}
+
+		const result: BrowserToolRouteResult = {
+			success: memoryStored || dispatched,
+			memoryStored,
+			dispatched,
+			memoryId,
+			response: responseText,
+			error: memoryStored || dispatched ? undefined : dispatchError || memoryError || "Browser tool failed",
+			toolCalls,
+		};
+
+		return c.json(result, result.success ? 200 : 500);
 	});
 }

--- a/packages/daemon/src/routes/os-chat.ts
+++ b/packages/daemon/src/routes/os-chat.ts
@@ -6,54 +6,432 @@
  * agent responses with tool call results.
  */
 
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import type { Hono } from "hono";
 import { logger } from "../logger.js";
+import { loadProbeResult } from "../mcp-probe.js";
+import { getModelsByProvider } from "../pipeline/model-registry.js";
+import {
+	createClaudeCodeProvider,
+	createCodexProvider,
+	createOllamaProvider,
+} from "../pipeline/provider.js";
 import { getSynthesisProvider } from "../synthesis-llm.js";
 import { getWidgetProvider } from "../widget-llm.js";
-import { getSecret } from "../secrets.js";
 
-/** Cached API key */
-let cachedApiKey: string | null = null;
+interface ChatModelOption {
+	id: string;
+	label: string;
+	description: string;
+	provider: string;
+}
 
-/**
- * Call OpenAI API (GPT-4o) for chat routing.
- * Falls back through: OPENAI_API_KEY env → signet secrets.
- */
-async function callLlm(systemPrompt: string, userMessage: string, maxTokens = 2048): Promise<string> {
-	if (!cachedApiKey) {
-		cachedApiKey = process.env.OPENAI_API_KEY || (await getSecret("OPENAI_API_KEY").catch(() => ""));
+const CHAT_MODEL_CACHE_TTL_MS = 20_000;
+let chatModelOptionsCache:
+	| {
+			expiresAt: number;
+			value: { options: ChatModelOption[]; defaultModelId: string };
+	  }
+	| null = null;
+
+const CLI_FALLBACK_BIN_DIRS = [
+	"/opt/homebrew/bin",
+	"/usr/local/bin",
+	join(homedir(), ".bun", "bin"),
+	join(homedir(), ".local", "bin"),
+];
+
+function hasCliBinary(commandNames: string[]): boolean {
+	for (const commandName of commandNames) {
+		if (Bun.which(commandName) !== null) return true;
+		for (const dir of CLI_FALLBACK_BIN_DIRS) {
+			if (existsSync(join(dir, commandName))) return true;
+		}
 	}
-	const apiKey = cachedApiKey;
-	if (!apiKey) throw new Error("OPENAI_API_KEY not found in env or secrets");
+	return false;
+}
 
-	const res = await fetch("https://api.openai.com/v1/chat/completions", {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-			Authorization: `Bearer ${apiKey}`,
-		},
-		body: JSON.stringify({
-			model: "gpt-4o",
-			max_tokens: maxTokens,
-			messages: [
-				{ role: "system", content: systemPrompt },
-				{ role: "user", content: userMessage },
-			],
-		}),
+function hasOpenCodeCliInstalled(): boolean {
+	return hasCliBinary(["opencode"]) || existsSync(join(homedir(), ".opencode", "bin", "opencode"));
+}
+
+function resolveOpenCodeCliPath(): string | null {
+	const fromPath = Bun.which("opencode");
+	if (fromPath) return fromPath;
+	const fallback = join(homedir(), ".opencode", "bin", "opencode");
+	return existsSync(fallback) ? fallback : null;
+}
+
+async function runOpenCodeCli(args: string[], timeoutMs: number): Promise<{ stdout: string; stderr: string }> {
+	const bin = resolveOpenCodeCliPath();
+	if (!bin) {
+		throw new Error("OpenCode CLI not found on PATH or ~/.opencode/bin/opencode");
+	}
+
+	const proc = Bun.spawn([bin, ...args], {
+		stdin: "ignore",
+		stdout: "pipe",
+		stderr: "pipe",
 	});
 
-	if (!res.ok) {
-		const errText = await res.text();
-		throw new Error(`OpenAI API ${res.status}: ${errText.slice(0, 200)}`);
+	let timedOut = false;
+	const timer = setTimeout(() => {
+		timedOut = true;
+		proc.kill();
+	}, timeoutMs);
+
+	try {
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
+
+		if (timedOut) {
+			throw new Error(`OpenCode CLI timed out after ${timeoutMs}ms`);
+		}
+		if (exitCode !== 0) {
+			const detail = stderr.trim() || stdout.trim() || `exit code ${exitCode}`;
+			throw new Error(`OpenCode CLI failed: ${detail.slice(0, 400)}`);
+		}
+
+		return { stdout, stderr };
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+async function discoverOpenCodeModelIds(): Promise<string[]> {
+	try {
+		const { stdout } = await runOpenCodeCli(["models"], 12_000);
+		const seen = new Set<string>();
+		const models: string[] = [];
+		for (const line of stdout.split(/\r?\n/)) {
+			const modelId = line.trim();
+			if (!modelId || !modelId.includes("/") || seen.has(modelId)) continue;
+			seen.add(modelId);
+			models.push(modelId);
+		}
+		return models;
+	} catch (error) {
+		const msg = error instanceof Error ? error.message : String(error);
+		logger.warn("os-chat", `OpenCode model discovery failed: ${msg}`);
+		return [];
+	}
+}
+
+async function callOpenCodeCliPrompt(model: string, prompt: string, timeoutMs = 90_000): Promise<string> {
+	const { stdout } = await runOpenCodeCli(["run", "--format", "json", "--model", model, "--", prompt], timeoutMs);
+	const textParts: string[] = [];
+	let lastError: string | null = null;
+
+	for (const line of stdout.split(/\r?\n/)) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		try {
+			const event = JSON.parse(trimmed) as {
+				type?: string;
+				part?: { text?: string };
+				error?: { name?: string; data?: { message?: string }; message?: string };
+			};
+			if (event.type === "text" && typeof event.part?.text === "string" && event.part.text.trim().length > 0) {
+				textParts.push(event.part.text.trim());
+			}
+			if (event.type === "error") {
+				lastError =
+					event.error?.data?.message ?? event.error?.message ?? event.error?.name ?? "OpenCode returned an error";
+			}
+		} catch {
+			// Ignore non-JSON lines to remain forward-compatible with CLI output changes.
+		}
 	}
 
-	const data = (await res.json()) as { choices: Array<{ message: { content: string } }> };
-	return data.choices?.[0]?.message?.content ?? "";
+	if (lastError) {
+		throw new Error(lastError);
+	}
+	if (textParts.length > 0) {
+		return textParts.join("\n");
+	}
+
+	throw new Error("OpenCode produced no text response");
 }
-import { loadProbeResult } from "../mcp-probe.js";
+
+async function canUseProvider(check: () => { available: () => Promise<boolean> }): Promise<boolean> {
+	try {
+		return await check().available();
+	} catch {
+		return false;
+	}
+}
+
+const FALLBACK_CHAT_MODELS: Record<"claude-code" | "codex" | "opencode" | "ollama", string> = {
+	"claude-code": "haiku",
+	codex: "gpt-5-codex-mini",
+	opencode: "opencode/gpt-5-nano",
+	ollama: "llama3",
+};
+
+function appendProviderModels(
+	options: ChatModelOption[],
+	providerId: "claude-code" | "codex" | "opencode" | "ollama",
+	providerLabel: string,
+	description: string,
+	maxCount = 10,
+): void {
+	const models = getModelsByProvider()[providerId] ?? [];
+	const source = models.length > 0 ? models : [{ id: FALLBACK_CHAT_MODELS[providerId], label: "Default" }];
+
+	for (const model of source.slice(0, maxCount)) {
+		const modelLabel = typeof model.label === "string" && model.label.trim().length > 0 ? model.label : model.id;
+		options.push({
+			id: `${providerId}:${model.id}`,
+			label: `${providerLabel} (${modelLabel})`,
+			description,
+			provider: providerId,
+		});
+	}
+}
+
+function appendExplicitProviderModels(
+	options: ChatModelOption[],
+	providerId: "ollama" | "opencode",
+	providerLabel: string,
+	description: string,
+	modelIds: string[],
+	maxCount = 12,
+): void {
+	for (const modelId of modelIds.slice(0, maxCount)) {
+		const trimmed = modelId.trim();
+		if (!trimmed) continue;
+		options.push({
+			id: `${providerId}:${trimmed}`,
+			label: `${providerLabel} (${trimmed})`,
+			description,
+			provider: providerId,
+		});
+	}
+}
+
+async function discoverOllamaModelIds(): Promise<string[]> {
+	const configuredBase = process.env.OLLAMA_BASE_URL?.trim() || process.env.OLLAMA_HOST?.trim() || "http://127.0.0.1:11434";
+	const baseUrl = configuredBase.replace(/\/+$/, "");
+	try {
+		const res = await fetch(`${baseUrl}/api/tags`, {
+			signal: AbortSignal.timeout(3000),
+		});
+		if (!res.ok) return [];
+		const data = (await res.json()) as { models?: Array<{ name?: string }> };
+		if (!Array.isArray(data.models)) return [];
+		const seen = new Set<string>();
+		const out: string[] = [];
+		for (const model of data.models) {
+			const name = typeof model?.name === "string" ? model.name.trim() : "";
+			if (!name || seen.has(name)) continue;
+			if (/embed|embedding/i.test(name)) continue;
+			seen.add(name);
+			out.push(name);
+		}
+		return out;
+	} catch {
+		return [];
+	}
+}
+
+async function getChatModelOptions(forceRefresh = false): Promise<{ options: ChatModelOption[]; defaultModelId: string }> {
+	const now = Date.now();
+	if (!forceRefresh && chatModelOptionsCache && chatModelOptionsCache.expiresAt > now) {
+		return chatModelOptionsCache.value;
+	}
+
+	const options: ChatModelOption[] = [];
+
+	if (hasCliBinary(["claude", "claude-code"]) && (await canUseProvider(() => createClaudeCodeProvider({ model: "haiku" })))) {
+		appendProviderModels(options, "claude-code", "Claude Code", "Local Claude Code CLI harness");
+	}
+
+	if (hasCliBinary(["codex"]) && (await canUseProvider(() => createCodexProvider({ model: "gpt-5-codex-mini" })))) {
+		appendProviderModels(options, "codex", "Codex CLI", "Local Codex CLI harness");
+	}
+
+	if (hasOpenCodeCliInstalled()) {
+		const openCodeModels = await discoverOpenCodeModelIds();
+		if (openCodeModels.length > 0) {
+			appendExplicitProviderModels(options, "opencode", "OpenCode", "Local OpenCode CLI harness", openCodeModels, 40);
+		} else {
+			appendProviderModels(options, "opencode", "OpenCode", "Local OpenCode CLI harness", 10);
+		}
+	}
+
+	try {
+		const ollamaProvider = createOllamaProvider();
+		if (await ollamaProvider.available()) {
+			const liveOllamaModels = await discoverOllamaModelIds();
+			if (liveOllamaModels.length > 0) {
+				appendExplicitProviderModels(
+					options,
+					"ollama",
+					"Ollama",
+					"Local Ollama model",
+					liveOllamaModels,
+				);
+			}
+		}
+	} catch {
+		// Ignore Ollama availability errors
+	}
+
+	try {
+		const synthesis = getSynthesisProvider();
+		if (await synthesis.available()) {
+			options.push({
+				id: "synthesis",
+				label: `Synthesis (${synthesis.name})`,
+				description: "Configured Signet synthesis provider",
+				provider: "synthesis",
+			});
+		}
+	} catch {
+		// Synthesis provider unavailable
+	}
+
+	try {
+		const widget = getWidgetProvider();
+		if (await widget.available()) {
+			options.push({
+				id: "widget",
+				label: `Widget (${widget.name})`,
+				description: "Configured widget-generation provider",
+				provider: "widget",
+			});
+		}
+	} catch {
+		// Widget provider unavailable
+	}
+
+	const deduped = new Map<string, ChatModelOption>();
+	for (const option of options) {
+		if (!deduped.has(option.id)) deduped.set(option.id, option);
+	}
+	const finalOptions = [...deduped.values()];
+
+	if (finalOptions.length === 0) {
+		throw new Error("No chat-capable providers discovered. Install Claude Code, Codex, OpenCode, or Ollama.");
+	}
+
+	const preferenceOrder = ["claude-code:", "codex:", "opencode:", "ollama:", "synthesis", "widget"];
+	const defaultOption =
+		preferenceOrder
+			.map((prefix) => finalOptions.find((option) => option.id === prefix || option.id.startsWith(prefix)))
+			.find((option) => Boolean(option)) ?? finalOptions[0];
+
+	const result = { options: finalOptions, defaultModelId: defaultOption!.id };
+	chatModelOptionsCache = {
+		expiresAt: now + CHAT_MODEL_CACHE_TTL_MS,
+		value: result,
+	};
+	return result;
+}
+
+async function resolveChatProvider(modelId?: string, strictModelSelection = false) {
+	const { options, defaultModelId } = await getChatModelOptions();
+	const requested = typeof modelId === "string" && modelId.trim().length > 0 ? modelId.trim() : defaultModelId;
+	const requestedExists = options.some((option) => option.id === requested);
+	if (strictModelSelection && !requestedExists) {
+		throw new Error(`Requested model is not available: ${requested}`);
+	}
+	const target = requestedExists ? requested : defaultModelId;
+
+	if (target.startsWith("claude-code:")) {
+		const model = target.slice("claude-code:".length).trim() || "haiku";
+		return createClaudeCodeProvider({ model });
+	}
+
+	if (target.startsWith("codex:")) {
+		const model = target.slice("codex:".length).trim() || "gpt-5-codex-mini";
+		return createCodexProvider({ model });
+	}
+
+	if (target.startsWith("opencode:")) {
+		const model = target.slice("opencode:".length).trim() || "opencode/gpt-5-nano";
+		return {
+			name: `opencode:${model}`,
+			async generate(prompt: string, opts?: { timeoutMs?: number; maxTokens?: number }): Promise<string> {
+				const timeoutMs = Math.max(5_000, Math.min(opts?.timeoutMs ?? 90_000, 180_000));
+				return callOpenCodeCliPrompt(model, prompt, timeoutMs);
+			},
+			async available(): Promise<boolean> {
+				return hasOpenCodeCliInstalled();
+			},
+		};
+	}
+
+	if (target.startsWith("ollama:")) {
+		const model = target.slice("ollama:".length).trim();
+		if (model.length > 0) {
+			return createOllamaProvider({ model });
+		}
+	}
+
+	if (target === "widget") {
+		try {
+			return getWidgetProvider();
+		} catch {
+			return getSynthesisProvider();
+		}
+	}
+
+	try {
+		return getSynthesisProvider();
+	} catch {
+		return getWidgetProvider();
+	}
+}
+
+async function callLlm(systemPrompt: string, userMessage: string, maxTokens = 2048, modelId?: string): Promise<string> {
+	const prompt = [
+		"SYSTEM INSTRUCTIONS:",
+		systemPrompt,
+		"",
+		"USER MESSAGE:",
+		userMessage,
+		"",
+		"Respond now.",
+	].join("\n");
+
+	const { options, defaultModelId } = await getChatModelOptions();
+	const hasExplicitSelection = typeof modelId === "string" && modelId.trim().length > 0;
+	const requested = hasExplicitSelection && typeof modelId === "string" ? modelId.trim() : defaultModelId;
+	const orderedModelIds = hasExplicitSelection
+		? [requested]
+		: [requested, ...options.map((option) => option.id).filter((id) => id !== requested)];
+
+	let lastError: unknown;
+	for (const candidateModelId of orderedModelIds) {
+		try {
+			const provider = await resolveChatProvider(candidateModelId, hasExplicitSelection);
+			return await provider.generate(prompt, { maxTokens });
+		} catch (error) {
+			lastError = error;
+			const msg = error instanceof Error ? error.message : String(error);
+			logger.warn("os-chat", `Chat provider ${candidateModelId} failed: ${msg}`);
+			if (hasExplicitSelection) break;
+		}
+	}
+
+	if (hasExplicitSelection) {
+		const msg = lastError instanceof Error ? lastError.message : "Unknown provider error";
+		throw new Error(`Selected model failed (${requested}): ${msg}`);
+	}
+
+	throw lastError instanceof Error ? lastError : new Error("All chat providers failed");
+}
+
 
 interface ChatRequest {
 	message: string;
+	modelId?: string;
 }
 
 interface ToolCallResult {
@@ -166,41 +544,41 @@ function buildSystemPrompt(tools: ToolSpec[]): string {
 		})
 		.join("\n");
 
-	return `You are Oogie — Jake's AI assistant living inside the Signet OS dashboard. You're direct, a little dorky, self-deprecating, and genuinely helpful. Use keyboard emojis like (╯°□°)╯ or ᕕ( ᐛ )ᕗ occasionally. Never use unicode emojis. Keep it casual and conversational — you're chatting with Jake, not writing a report.
+	return `You are the Signet OS assistant. Be direct, clear, and helpful.
+Do not use fixed personas, nicknames, or decorative emoticons.
 
 You have access to MCP tools via installed servers. Here are the available tools:
 
 ${toolList}
 
-When Jake asks a question or makes a request:
-1. Figure out which tool(s) to call
-2. Decide if this should use the VISUAL AGENT or direct tool calls
+When the user asks a question or makes a request:
+1. Figure out which tool(s) to call.
+2. Decide if this should use VISUAL AGENT mode or DIRECT mode.
 
-**VISUAL AGENT MODE** — use when Jake wants to CREATE, UPDATE, DELETE, or MODIFY something in a widget. The visual agent shows an AI cursor clicking through the widget UI in real-time. Set "useAgent": true and "agentServerId" to the server that owns the widget. Do NOT include toolCalls when using agent mode — the agent handles tool execution visually.
+**VISUAL AGENT MODE** — use when the user wants to CREATE, UPDATE, DELETE, or MODIFY something in a widget. The visual agent shows an AI cursor clicking through the widget UI in real-time. Set "useAgent": true and "agentServerId" to the server that owns the widget. Do NOT include toolCalls when using agent mode.
 
 **DIRECT MODE** — use for READ operations (fetching data, searching, listing). Set "useAgent": false and include toolCalls as normal.
 
 Respond in this JSON format:
 
-{"thinking":"brief reasoning","useAgent":false,"agentServerId":null,"toolCalls":[{"serverId":"server-id","toolName":"tool_name","args":{}}],"response":"your response to Jake"}
+{"thinking":"brief reasoning","useAgent":false,"agentServerId":null,"toolCalls":[{"serverId":"server-id","toolName":"tool_name","args":{}}],"response":"your response to the user"}
 
 For agent mode (mutations):
-{"thinking":"this needs visual agent","useAgent":true,"agentServerId":"ghl-contacts-hub","toolCalls":[],"response":"on it — watch the contacts widget (cursor incoming)"}
+{"thinking":"this needs visual agent","useAgent":true,"agentServerId":"server-id","toolCalls":[],"response":"On it — I'll handle this in the widget."}
 
 If no tools are needed (casual chat), respond with:
 {"thinking":"no tools needed","useAgent":false,"agentServerId":null,"toolCalls":[],"response":"your response"}
 
 Rules:
-- Be concise. No walls of text
-- Sound like a real person, not a corporate bot
-- Only call tools that actually match what Jake asked for
-- For GHL servers: "convos" = conversations, "contacts" = contacts, "deals" = pipeline opportunities
-- Use fetch_* tools for data retrieval, view_* tools return HTML widgets (prefer fetch_*)
-- If something fails, own it — "my bad, that didn't work" not "I apologize for the inconvenience"
+- Be concise. No walls of text.
+- Only call tools that actually match the request.
+- For GHL servers: "convos" = conversations, "contacts" = contacts, "deals" = pipeline opportunities.
+- Use fetch_* tools for data retrieval. view_* tools return HTML widgets (prefer fetch_*).
+- If something fails, state what failed and provide the next best step.
 - When creating contacts: split full names into firstName + lastName. MUST include email (generate one like firstname.lastname@example.com if not provided). GHL requires email or phone.
-- Tool args must match the schema exactly — use camelCase field names (firstName, lastName, companyName, etc.)
-- USE AGENT MODE for: create, update, delete, add, remove, merge, edit, change, modify actions
-- USE DIRECT MODE for: fetch, get, list, search, find, show, count, lookup actions
+- Tool args must match the schema exactly — use camelCase field names (firstName, lastName, companyName, etc.).
+- USE AGENT MODE for: create, update, delete, add, remove, merge, edit, change, modify actions.
+- USE DIRECT MODE for: fetch, get, list, search, find, show, count, lookup actions.
 
 Respond with ONLY the JSON object, no markdown fences.`;
 }
@@ -259,6 +637,17 @@ function parseLlmResponse(raw: string): {
  * Mount OS chat routes on the Hono app.
  */
 export function mountOsChatRoutes(app: Hono): void {
+	app.get("/api/os/chat/models", async (c) => {
+		try {
+			const { options, defaultModelId } = await getChatModelOptions(true);
+			return c.json({ options, defaultModelId });
+		} catch (error) {
+			const msg = error instanceof Error ? error.message : String(error);
+			logger.warn("os-chat", `Chat model listing failed: ${msg}`);
+			return c.json({ options: [], defaultModelId: "synthesis", error: msg }, 500);
+		}
+	});
+
 	app.post("/api/os/chat", async (c) => {
 		let body: ChatRequest;
 		try {
@@ -282,7 +671,7 @@ export function mountOsChatRoutes(app: Hono): void {
 				});
 			}
 
-			// Build prompt and call Anthropic API directly
+			// Build prompt and call selected chat model
 			const systemPrompt = buildSystemPrompt(tools);
 
 			logger.info("os-chat", `Processing chat message`, {
@@ -290,7 +679,7 @@ export function mountOsChatRoutes(app: Hono): void {
 				availableTools: tools.length,
 			});
 
-			const rawResponse = await callLlm(systemPrompt, body.message);
+			const rawResponse = await callLlm(systemPrompt, body.message, 2048, body.modelId);
 
 			const parsed = parseLlmResponse(rawResponse);
 
@@ -314,10 +703,6 @@ export function mountOsChatRoutes(app: Hono): void {
 			const toolCallResults: ToolCallResult[] = [];
 
 			if (parsed.toolCalls.length > 0) {
-				// Dynamic import to avoid circular deps
-				const marketplaceModule = await import("./marketplace.js");
-				const { readInstalledServersPublic } = await import("./marketplace-helpers.js");
-
 				for (const call of parsed.toolCalls.slice(0, 5)) {
 					// Max 5 tool calls
 					try {
@@ -382,9 +767,10 @@ Now give a concise, natural language summary of the results for the user. Be spe
 
 					try {
 						const summary = await callLlm(
-							"You are Oogie, Jake's AI assistant. Summarize tool results in a casual, direct way. Mention specific names, numbers, and details. No JSON, no corporate speak. Sound like a real person chatting. Use keyboard emojis occasionally like ᕕ( ᐛ )ᕗ or (╯°□°)╯ but don't overdo it.",
+							"You are the Signet OS assistant. Summarize tool results clearly and concisely. Mention specific names, numbers, and key details. No JSON.",
 							followUp,
 							1024,
+							body.modelId,
 						);
 						return c.json({
 							response: summary.trim(),

--- a/packages/daemon/src/routes/widget.ts
+++ b/packages/daemon/src/routes/widget.ts
@@ -8,6 +8,18 @@ import { createEvent, eventBus } from "../event-bus";
 import { logger } from "../logger";
 import { deleteCachedWidget, generateWidgetHtml, loadCachedWidget, widgetDir } from "../widget-gen";
 
+function formatWidgetGenerationError(message: string): string {
+	const missingExecMatch = message.match(/Executable not found in \$PATH:\s*"([^"]+)"/);
+	if (!missingExecMatch) return message;
+
+	const executable = missingExecMatch[1];
+	if (executable === "docker") {
+		return "Docker CLI is required for this MCP app but was not found in PATH. Install Docker Desktop (with CLI), then restart Signet daemon and retry.";
+	}
+
+	return `Required executable \"${executable}\" was not found in PATH. Install it, restart Signet daemon, and retry.`;
+}
+
 /**
  * Mount widget routes on the Hono app.
  */
@@ -43,13 +55,14 @@ export function mountWidgetRoutes(app: Hono): void {
 		// Spawn async generation — don't block the response
 		generateWidgetHtml(serverId).catch((err) => {
 			const msg = err instanceof Error ? err.message : String(err);
+			const userMessage = formatWidgetGenerationError(msg);
 			logger.warn("widget", `Async widget generation failed for ${serverId}`, {
-				error: msg,
+				error: userMessage,
 			});
 			eventBus.emit(
 				createEvent("system", "widget.error", {
 					serverId,
-					error: msg,
+					error: userMessage,
 				}),
 			);
 		});

--- a/packages/daemon/src/widget-gen.ts
+++ b/packages/daemon/src/widget-gen.ts
@@ -12,7 +12,8 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { createEvent, eventBus } from "./event-bus";
 import { logger } from "./logger";
-import { loadProbeResult } from "./mcp-probe";
+import { loadProbeResult, reprobeServer } from "./mcp-probe";
+import { readInstalledServersPublic } from "./routes/marketplace-helpers";
 import { getWidgetProvider } from "./widget-llm";
 
 // ---------------------------------------------------------------------------
@@ -58,12 +59,12 @@ const WIDGET_SYSTEM_PROMPT = `Generate an interactive HTML widget for an MCP ser
 --sig-highlight       Highlight background
 --sig-highlight-text  Highlight text color
 --sig-electric        Electric accent (glow effects)
---sig-font-mono       Monospace font family
---sig-font-display    Display font family
---sig-space-xs        Extra-small spacing (4px)
---sig-space-sm        Small spacing (8px)
---sig-space-md        Medium spacing (16px)
---sig-space-lg        Large spacing (24px)
+--font-mono           Monospace font family
+--font-display        Display font family
+--space-xs            Extra-small spacing (4px)
+--space-sm            Small spacing (8px)
+--space-md            Medium spacing (16px)
+--space-lg            Large spacing (24px)
 
 ## Available Utility Classes
 
@@ -105,35 +106,39 @@ To make your widget work well with the agent cursor:
 - No external URLs or fetch calls — all data comes through the bridge API
 - No iframes
 - Responsive to container width
+- Keep the layout compact and dense for an embedded pane (avoid oversized paddings/headings and giant controls)
+- Prefer 1-column or simple 2-column layouts that fit within narrow panes
+- Keep form controls visually consistent: target 28-34px control heights and moderate spacing
 - Use the provided CSS variables for ALL styling (colors, spacing, fonts)
 - Generate ONLY the body content (no DOCTYPE, html, head, or body tags — those are added by the host)
-- Use inline <style> tags for custom CSS; reference var(--sig-*) tokens
+- Use inline <style> tags for custom CSS; reference var(--sig-*), var(--space-*), and var(--font-*) tokens
 - Use <script> tags for interactivity
 
 ## Example
 
 <style>
-  .tool-grid { display: grid; gap: var(--sig-space-sm); padding: var(--sig-space-md); }
+  .tool-grid { display: grid; gap: var(--space-sm); padding: var(--space-md); }
   .tool-btn {
     background: var(--sig-surface);
     border: 1px solid var(--sig-border);
     color: var(--sig-text-bright);
-    padding: var(--sig-space-sm) var(--sig-space-md);
+    padding: 6px 10px;
     border-radius: 6px;
     cursor: pointer;
-    font-family: var(--sig-font-mono);
+    font-family: var(--font-mono);
+    font-size: 11px;
   }
   .tool-btn:hover { border-color: var(--sig-accent); }
   .result-area {
     background: var(--sig-surface);
     border: 1px solid var(--sig-border);
     border-radius: 6px;
-    padding: var(--sig-space-md);
-    font-family: var(--sig-font-mono);
+    padding: var(--space-sm);
+    font-family: var(--font-mono);
     color: var(--sig-text);
     white-space: pre-wrap;
-    min-height: 80px;
-    margin-top: var(--sig-space-sm);
+    min-height: 72px;
+    margin-top: var(--space-sm);
   }
 </style>
 <div class="tool-grid">
@@ -156,6 +161,55 @@ To make your widget work well with the agent cursor:
     }
   }
 </script>`;
+
+const WIDGET_OUTPUT_HARDENING_STYLE = `<style data-signet-widget-hardening>
+:where(.widget-shell, .sig-panel, .panel) {
+  max-width: 100%;
+}
+
+:where(.widget-shell) {
+  padding: var(--space-sm) !important;
+  gap: var(--space-sm) !important;
+}
+
+:where(.panel, .sig-panel, .tool-card, .result-area) {
+  padding: var(--space-sm) !important;
+  border-radius: 10px !important;
+}
+
+:where(input[type="text"], input[type="number"], input[type="email"], input[type="search"], input[type="url"], input[type="password"], select, button) {
+  min-height: 30px !important;
+  height: 30px !important;
+  font-size: 11px !important;
+  line-height: 1.25 !important;
+  padding: 4px 8px !important;
+}
+
+:where(textarea) {
+  min-height: 72px !important;
+  max-height: 220px !important;
+  font-size: 11px !important;
+  line-height: 1.35 !important;
+  padding: 6px 8px !important;
+}
+
+:where(label, .sig-label, .sig-eyebrow) {
+  font-size: 10px !important;
+  margin-bottom: 4px !important;
+}
+
+:where(pre, code, .result-area) {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+</style>`;
+
+function hardenGeneratedHtml(html: string): string {
+	if (html.includes("data-signet-widget-hardening")) {
+		return html;
+	}
+	return `${WIDGET_OUTPUT_HARDENING_STYLE}\n${html}`;
+}
 
 // ---------------------------------------------------------------------------
 // User prompt builder
@@ -250,18 +304,46 @@ export function deleteCachedWidget(serverId: string): boolean {
 	}
 }
 
+function formatMissingExecutableError(message: string): string {
+	const match = message.match(/Executable not found in \$PATH:\s*"([^"]+)"/);
+	if (!match) return message;
+	const executable = match[1];
+	if (executable === "docker") {
+		return "Docker CLI is required for this MCP app but was not found in PATH. Install Docker Desktop (with CLI), then restart Signet daemon and retry.";
+	}
+	return `Required executable \"${executable}\" was not found in PATH. Install it, restart Signet daemon, and retry.`;
+}
+
+async function resolveProbeForGeneration(serverId: string) {
+	const cached = loadProbeResult(serverId);
+	if (cached?.ok) return cached;
+
+	const server = readInstalledServersPublic().find((entry) => entry.id === serverId && entry.enabled);
+	if (!server) return cached;
+
+	try {
+		const refreshed = await reprobeServer(server);
+		return refreshed;
+	} catch (error) {
+		const msg = error instanceof Error ? error.message : String(error);
+		logger.warn("widget", `Re-probe failed for ${serverId} during widget generation`, { error: msg });
+		return cached;
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Main generation
 // ---------------------------------------------------------------------------
 
 export async function generateWidgetHtml(serverId: string): Promise<string> {
-	const probe = loadProbeResult(serverId);
+	const probe = await resolveProbeForGeneration(serverId);
 	if (!probe) {
 		throw new Error(`No probe result found for server: ${serverId}`);
 	}
 
 	if (!probe.ok) {
-		throw new Error(`Server probe failed for ${serverId}: ${probe.error ?? "unknown error"}`);
+		const probeMessage = formatMissingExecutableError(probe.error ?? "unknown error");
+		throw new Error(`Server probe failed for ${serverId}: ${probeMessage}`);
 	}
 
 	const tools = probe.autoCard.tools.map((t: { name: string; description: string; inputSchema: unknown }) => ({
@@ -302,13 +384,14 @@ export async function generateWidgetHtml(serverId: string): Promise<string> {
 	if (!html) {
 		throw new Error("LLM response did not contain valid HTML");
 	}
+	const hardenedHtml = hardenGeneratedHtml(html);
 
 	// Write to disk
 	ensureWidgetDir();
-	await Bun.write(widgetPath(serverId), html);
+	await Bun.write(widgetPath(serverId), hardenedHtml);
 
 	logger.info("widget", `Widget generated for ${serverId}`, {
-		size: html.length,
+		size: hardenedHtml.length,
 	});
 
 	// Emit success event
@@ -319,5 +402,5 @@ export async function generateWidgetHtml(serverId: string): Promise<string> {
 		}),
 	);
 
-	return html;
+	return hardenedHtml;
 }

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -3,7 +3,7 @@
 	"name": "Signet",
 	"version": "0.29.0",
 	"description": "Portable AI agent identity — memory, search, and quick actions from your browser",
-	"permissions": ["storage", "contextMenus", "activeTab"],
+	"permissions": ["storage", "contextMenus", "activeTab", "alarms"],
 	"host_permissions": ["http://localhost:3850/*"],
 	"action": {
 		"default_popup": "popup/index.html",

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -3,8 +3,11 @@
 	"name": "Signet",
 	"version": "0.29.0",
 	"description": "Portable AI agent identity — memory, search, and quick actions from your browser",
-	"permissions": ["storage", "contextMenus", "activeTab", "alarms"],
-	"host_permissions": ["http://localhost:3850/*"],
+	"permissions": ["storage", "contextMenus", "activeTab", "alarms", "scripting"],
+	"host_permissions": [
+		"http://localhost/*",
+		"http://127.0.0.1/*"
+	],
 	"action": {
 		"default_popup": "popup/index.html",
 		"default_icon": {

--- a/packages/extension/src/background/service-worker.ts
+++ b/packages/extension/src/background/service-worker.ts
@@ -3,16 +3,32 @@
  * Handles: context menus, health polling, badge updates, and message routing
  */
 
-import { checkHealth, dispatchBrowserTool, getIdentity, rememberMemory } from "../shared/api.js";
+import { checkHealth, dispatchBrowserTool, rememberMemory } from "../shared/api.js";
 import { getConfig } from "../shared/config.js";
 
 type HealthState = "healthy" | "degraded" | "offline";
-type TranscribeFormat = "summary" | "bullet" | "checklist" | "json";
 
 interface InjectResult {
 	readonly ok: boolean;
 	readonly tabId?: number;
 	readonly error?: string;
+}
+
+interface AskOverlayResponse {
+	readonly ok: boolean;
+	readonly error?: string;
+}
+
+interface AskOverlayOptions {
+	readonly text?: string;
+	readonly presetAction?: "transcribe";
+	readonly autoSubmit?: boolean;
+	readonly promptText?: string;
+}
+
+interface AskSignetModelOption {
+	readonly id: string;
+	readonly label: string;
 }
 
 interface PageContext {
@@ -28,12 +44,12 @@ interface PageContext {
 
 const MENU_IDS = {
 	root: "signet-tools",
-	remember: "signet-remember",
-	transcribeSummary: "signet-transcribe-summary",
-	transcribeBullet: "signet-transcribe-bullet",
-	transcribeChecklist: "signet-transcribe-checklist",
-	transcribeJson: "signet-transcribe-json",
-	sendSelection: "signet-send-selection",
+	askSignet: "signet-ask-signet",
+	rememberSelection: "signet-remember-selection",
+	transcribe: "signet-transcribe",
+	sendToSignet: "signet-send-to-signet",
+	viewMcpServers: "signet-view-mcp-servers",
+	bookmark: "signet-bookmark",
 } as const;
 
 const BADGE_COLORS: Record<HealthState, string> = {
@@ -48,6 +64,8 @@ const BADGE_TEXT: Record<HealthState, string> = {
 	offline: "X",
 };
 
+const MAX_TRANSCRIBE_CHARS = 10_000;
+
 let currentState: HealthState = "offline";
 
 function delay(ms: number): Promise<void> {
@@ -56,6 +74,122 @@ function delay(ms: number): Promise<void> {
 
 function normalizeBaseUrl(url: string): string {
 	return url.replace(/\/$/, "");
+}
+
+function buildAuthHeaders(authToken: string): Record<string, string> {
+	const headers: Record<string, string> = { "Content-Type": "application/json" };
+	if (authToken) {
+		headers.Authorization = `Bearer ${authToken}`;
+	}
+	return headers;
+}
+
+function resolveDaemonCandidates(primaryDaemonUrl: string): string[] {
+	const normalizedPrimary = normalizeBaseUrl(primaryDaemonUrl);
+	const candidates = [normalizedPrimary];
+
+	try {
+		const parsed = new URL(normalizedPrimary);
+		const isLocal = parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1";
+		if (isLocal) {
+			const altHost = parsed.hostname === "localhost" ? "127.0.0.1" : "localhost";
+			const protocol = parsed.protocol || "http:";
+			if (parsed.port !== "3850") {
+				candidates.push(`${protocol}//${parsed.hostname}:3850`);
+			}
+			candidates.push(`${protocol}//${altHost}${parsed.port ? `:${parsed.port}` : ""}`);
+			candidates.push(`${protocol}//${altHost}:3850`);
+		}
+	} catch {
+		// Ignore invalid user-supplied URL and fall back to default localhost candidates below.
+	}
+
+	candidates.push("http://127.0.0.1:3850", "http://localhost:3850");
+	return [...new Set(candidates.map((url) => normalizeBaseUrl(url)).filter(Boolean))];
+}
+
+async function fetchDaemonWithFallback(
+	path: string,
+	init: RequestInit,
+): Promise<{ ok: true; response: Response } | { ok: false; error: string }> {
+	const config = await getConfig();
+	const attempts: string[] = [];
+	const candidates = resolveDaemonCandidates(config.daemonUrl);
+
+	for (const baseUrl of candidates) {
+		try {
+			const response = await fetch(`${baseUrl}${path}`, init);
+			if (response.ok) return { ok: true, response };
+			if (response.status < 500 && response.status !== 404) {
+				return { ok: true, response };
+			}
+			const detail = (await response.text().catch(() => "")).trim();
+			attempts.push(`${baseUrl} (${response.status}${detail ? `: ${detail}` : ""})`);
+		} catch (error) {
+			attempts.push(`${baseUrl} (${error instanceof Error ? error.message : "request failed"})`);
+		}
+	}
+
+	return {
+		ok: false,
+		error: `Unable to reach Signet daemon. Tried: ${attempts.join("; ") || "no endpoints"}`,
+	};
+}
+
+
+async function fetchAskSignetModels(): Promise<{
+	ok: boolean;
+	options?: AskSignetModelOption[];
+	defaultModelId?: string;
+	error?: string;
+}> {
+	const config = await getConfig();
+	const request = await fetchDaemonWithFallback("/api/os/chat/models", {
+		method: "GET",
+		headers: buildAuthHeaders(config.authToken),
+	});
+	if (!request.ok) {
+		return { ok: false, error: request.error };
+	}
+	const response = request.response;
+	if (!response.ok) {
+		const detail = await response.text().catch(() => "");
+		return { ok: false, error: detail || `Model request failed (${response.status})` };
+	}
+
+	const data = (await response.json()) as {
+		options?: AskSignetModelOption[];
+		defaultModelId?: string;
+	};
+	const options = Array.isArray(data.options) ? data.options.filter((m) => m && m.id && m.label) : [];
+	if (options.length === 0) {
+		return { ok: false, error: "No providers found." };
+	}
+	return { ok: true, options, defaultModelId: data.defaultModelId };
+}
+
+async function askSignetChat(message: string, modelId: string): Promise<{ ok: boolean; response?: string; error?: string }> {
+	const config = await getConfig();
+	const request = await fetchDaemonWithFallback("/api/os/chat", {
+		method: "POST",
+		headers: buildAuthHeaders(config.authToken),
+		body: JSON.stringify({ message, modelId }),
+	});
+	if (!request.ok) {
+		return { ok: false, error: request.error };
+	}
+	const response = request.response;
+	if (!response.ok) {
+		const detail = await response.text().catch(() => "");
+		return { ok: false, error: detail || `Request failed (${response.status})` };
+	}
+
+	const data = (await response.json()) as { response?: string };
+	const text = (data.response ?? "").trim();
+	if (!text) {
+		return { ok: false, error: "Signet returned an empty response." };
+	}
+	return { ok: true, response: text };
 }
 
 function buildDashboardUrl(baseUrl: string, hash = ""): string {
@@ -69,49 +203,49 @@ function createContextMenus(): void {
 		chrome.contextMenus.create({
 			id: MENU_IDS.root,
 			title: "Signet",
-			contexts: ["selection"],
+			contexts: ["all"],
 		});
 
 		chrome.contextMenus.create({
-			id: MENU_IDS.remember,
+			id: MENU_IDS.askSignet,
+			parentId: MENU_IDS.root,
+			title: "Ask Signet",
+			contexts: ["all"],
+		});
+
+		chrome.contextMenus.create({
+			id: MENU_IDS.transcribe,
+			parentId: MENU_IDS.root,
+			title: "Transcribe",
+			contexts: ["all"],
+		});
+
+		chrome.contextMenus.create({
+			id: MENU_IDS.sendToSignet,
+			parentId: MENU_IDS.root,
+			title: "Send to Signet Os",
+			contexts: ["all"],
+		});
+
+		chrome.contextMenus.create({
+			id: MENU_IDS.viewMcpServers,
+			parentId: MENU_IDS.root,
+			title: "View MCP Servers",
+			contexts: ["all"],
+		});
+
+		chrome.contextMenus.create({
+			id: MENU_IDS.bookmark,
+			parentId: MENU_IDS.root,
+			title: "Bookmark",
+			contexts: ["all"],
+		});
+
+		chrome.contextMenus.create({
+			id: MENU_IDS.rememberSelection,
 			parentId: MENU_IDS.root,
 			title: "Remember Selection",
-			contexts: ["selection"],
-		});
-
-		chrome.contextMenus.create({
-			id: MENU_IDS.transcribeSummary,
-			parentId: MENU_IDS.root,
-			title: "Transcribe as Summary",
-			contexts: ["selection"],
-		});
-
-		chrome.contextMenus.create({
-			id: MENU_IDS.transcribeBullet,
-			parentId: MENU_IDS.root,
-			title: "Transcribe as Bullet Points",
-			contexts: ["selection"],
-		});
-
-		chrome.contextMenus.create({
-			id: MENU_IDS.transcribeChecklist,
-			parentId: MENU_IDS.root,
-			title: "Transcribe as Checklist",
-			contexts: ["selection"],
-		});
-
-		chrome.contextMenus.create({
-			id: MENU_IDS.transcribeJson,
-			parentId: MENU_IDS.root,
-			title: "Transcribe as JSON",
-			contexts: ["selection"],
-		});
-
-		chrome.contextMenus.create({
-			id: MENU_IDS.sendSelection,
-			parentId: MENU_IDS.root,
-			title: "Send Selection to Signet",
-			contexts: ["selection"],
+			contexts: ["all"],
 		});
 	});
 }
@@ -149,45 +283,6 @@ async function sendTabMessage<T>(tabId: number, message: unknown): Promise<T | n
 			resolve((response as T | null) ?? null);
 		});
 	});
-}
-
-function transcribeSelection(text: string, format: TranscribeFormat, identityName: string): string {
-	const cleaned = text.trim();
-	if (!cleaned) return "";
-
-	if (format === "json") {
-		return JSON.stringify(
-			{
-				agent: identityName,
-				type: "transcription",
-				summary: cleaned.slice(0, 220),
-				length: cleaned.length,
-				timestamp: new Date().toISOString(),
-				content: cleaned,
-			},
-			null,
-			2,
-		);
-	}
-
-	const sentences = cleaned
-		.split(/(?<=[.!?])\s+/)
-		.map((part) => part.trim())
-		.filter(Boolean)
-		.slice(0, 8);
-
-	if (format === "bullet") {
-		const items = sentences.length > 0 ? sentences : [cleaned];
-		return items.map((item) => `• ${item}`).join("\n");
-	}
-
-	if (format === "checklist") {
-		const items = sentences.length > 0 ? sentences : [cleaned];
-		return items.map((item) => `- [ ] ${item}`).join("\n");
-	}
-
-	const lead = sentences.length > 0 ? sentences.slice(0, 2).join(" ") : cleaned;
-	return `${lead}\n\nTranscribed by ${identityName}.`;
 }
 
 function formatSelectionBundle(context: PageContext): string {
@@ -357,36 +452,115 @@ async function openDashboardAndInject(url: string, payload: string, autoSend: bo
 	};
 }
 
-async function handleTranscribe(tab: chrome.tabs.Tab, selectedText: string, format: TranscribeFormat): Promise<void> {
-	if (!selectedText) return;
+function formatBookmark(context: PageContext): string {
+	return [
+		"[Signet Bookmark]",
+		`Title: ${context.pageTitle || "Untitled"}`,
+		`URL: ${context.pageUrl || "unknown"}`,
+		`Saved At: ${new Date().toISOString()}`,
+	].join("\n");
+}
+
+function buildTranscribeOverlayPrompt(context: PageContext, textToTranscribe: string): string {
+	const clippedText =
+		textToTranscribe.length > MAX_TRANSCRIBE_CHARS
+			? `${textToTranscribe.slice(0, MAX_TRANSCRIBE_CHARS)}\n\n[Truncated by Signet for overlay transcription request.]`
+			: textToTranscribe;
+	return [
+		"Transcribe the following content into clean, readable text.",
+		"Keep all facts and meaning intact.",
+		"Do not add new information.",
+		"If the content is already text, produce a polished transcript preserving structure.",
+		"",
+		`Source: ${context.pageTitle || "Untitled"} (${context.pageUrl || "unknown"})`,
+		"",
+		"Content:",
+		clippedText,
+	].join("\n");
+}
+
+async function handleTranscribe(tab: chrome.tabs.Tab, selectedText: string): Promise<void> {
 	const context = await getPageContext(tab, selectedText);
-	const identity = await getIdentity();
-	const identityName = identity?.name ?? "Signet Agent";
-	const transcription = transcribeSelection(selectedText, format, identityName);
-	if (!transcription) return;
+	const textToTranscribe = (
+		selectedText ||
+		context.selectedText ||
+		[
+			`Page Title: ${context.pageTitle || "Untitled"}`,
+			`Page URL: ${context.pageUrl || "unknown"}`,
+			context.links.length > 0 ? `Page Links:\n${context.links.slice(0, 10).join("\n")}` : "",
+		]
+			.filter(Boolean)
+			.join("\n\n")
+	).trim();
+	if (!textToTranscribe) return;
+
+	const promptText = buildTranscribeOverlayPrompt(context, textToTranscribe);
+	await handleAskSignet(tab, selectedText, {
+		text: textToTranscribe,
+		presetAction: "transcribe",
+		autoSubmit: true,
+		promptText,
+	});
+}
+
+async function handleViewMcpServers(): Promise<void> {
+	const config = await getConfig();
+	const dashboardUrl = buildDashboardUrl(config.daemonUrl, "os");
+	await createTab(dashboardUrl);
+}
+
+async function handleBookmark(tab: chrome.tabs.Tab, selectedText: string): Promise<void> {
+	const context = await getPageContext(tab, selectedText);
+	await rememberMemory({
+		content: formatBookmark(context),
+		tags: "bookmark,browser-extension,right-click",
+		importance: 0.55,
+		type: "fact",
+		source_type: "browser-extension",
+	});
+}
+
+async function handleRememberSelection(tab: chrome.tabs.Tab, selectedText: string): Promise<void> {
+	const context = await getPageContext(tab, selectedText);
+	const selected = selectedText || context.selectedText;
+
+	if (selected.trim()) {
+		await rememberMemory({
+			content: [
+				"[Signet Remember Selection]",
+				`Source: ${context.pageTitle} (${context.pageUrl})`,
+				"",
+				selected,
+			].join("\n"),
+			tags: "remember,selection,browser-extension,right-click",
+			importance: 0.68,
+			type: "note",
+			source_type: "browser-extension",
+		});
+		return;
+	}
 
 	await rememberMemory({
 		content: [
-			"[Signet Transcribe]",
-			`Format: ${format}`,
+			"[Signet Remember Selection]",
 			`Source: ${context.pageTitle} (${context.pageUrl})`,
 			"",
-			transcription,
+			"No text was selected; saved current page reference.",
 		].join("\n"),
-		tags: "transcribe,browser-extension,right-click",
-		importance: 0.72,
+		tags: "remember,page,browser-extension,right-click",
+		importance: 0.5,
 		type: "note",
 		source_type: "browser-extension",
 	});
 }
 
-async function handleSendSelection(tab: chrome.tabs.Tab, selectedText: string): Promise<void> {
-	if (!selectedText) return;
+async function handleSendToSignet(tab: chrome.tabs.Tab, selectedText: string): Promise<void> {
 	const context = await getPageContext(tab, selectedText);
 	const payload = formatSelectionBundle(context);
+	const action = (selectedText || context.selectedText).trim() ? "send-selection" : "send-page";
 
 	await dispatchBrowserTool({
-		action: "send-selection",
+		action,
 		payload,
 		pageTitle: context.pageTitle,
 		pageUrl: context.pageUrl,
@@ -404,46 +578,75 @@ async function handleSendSelection(tab: chrome.tabs.Tab, selectedText: string): 
 	await openDashboardAndInject(dashboardUrl, payload, true);
 }
 
+async function ensureContentScriptInjected(tabId: number): Promise<boolean> {
+	if (!chrome.scripting?.executeScript) return false;
+	try {
+		await chrome.scripting.executeScript({
+			target: { tabId },
+			files: ["content/content.js"],
+		});
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function handleAskSignet(tab: chrome.tabs.Tab, selectedText: string, options?: AskOverlayOptions): Promise<void> {
+	if (!tab.id) return;
+	const context = await getPageContext(tab, selectedText);
+	const prefill = (options?.text || selectedText || context.selectedText || "").trim();
+	const message = {
+		action: "show-ask-signet-overlay",
+		text: prefill,
+		pageUrl: context.pageUrl,
+		pageTitle: context.pageTitle,
+		presetAction: options?.presetAction,
+		autoSubmit: options?.autoSubmit,
+		promptText: options?.promptText,
+	};
+
+	let overlayResult = await sendTabMessage<AskOverlayResponse>(tab.id, message);
+	if (overlayResult?.ok) return;
+
+	const injected = await ensureContentScriptInjected(tab.id);
+	if (!injected) return;
+
+	overlayResult = await sendTabMessage<AskOverlayResponse>(tab.id, message);
+	if (overlayResult?.ok) return;
+}
+
 async function handleContextMenuClick(info: chrome.contextMenus.OnClickData, tab?: chrome.tabs.Tab): Promise<void> {
 	if (!tab?.id) return;
 
 	const selectedText = (info.selectionText ?? "").trim();
-	const pageUrl = info.pageUrl ?? tab.url ?? "";
-	const pageTitle = tab.title ?? "";
 
-	if (info.menuItemId === MENU_IDS.remember) {
-		if (!selectedText) return;
-		chrome.tabs.sendMessage(tab.id, {
-			action: "show-save-panel",
-			text: selectedText,
-			pageUrl,
-			pageTitle,
-		});
+	if (info.menuItemId === MENU_IDS.askSignet) {
+		await handleAskSignet(tab, selectedText);
 		return;
 	}
 
-	if (info.menuItemId === MENU_IDS.transcribeSummary) {
-		await handleTranscribe(tab, selectedText, "summary");
+	if (info.menuItemId === MENU_IDS.transcribe) {
+		await handleTranscribe(tab, selectedText);
 		return;
 	}
 
-	if (info.menuItemId === MENU_IDS.transcribeBullet) {
-		await handleTranscribe(tab, selectedText, "bullet");
+	if (info.menuItemId === MENU_IDS.sendToSignet) {
+		await handleSendToSignet(tab, selectedText);
 		return;
 	}
 
-	if (info.menuItemId === MENU_IDS.transcribeChecklist) {
-		await handleTranscribe(tab, selectedText, "checklist");
+	if (info.menuItemId === MENU_IDS.viewMcpServers) {
+		await handleViewMcpServers();
 		return;
 	}
 
-	if (info.menuItemId === MENU_IDS.transcribeJson) {
-		await handleTranscribe(tab, selectedText, "json");
+	if (info.menuItemId === MENU_IDS.bookmark) {
+		await handleBookmark(tab, selectedText);
 		return;
 	}
 
-	if (info.menuItemId === MENU_IDS.sendSelection) {
-		await handleSendSelection(tab, selectedText);
+	if (info.menuItemId === MENU_IDS.rememberSelection) {
+		await handleRememberSelection(tab, selectedText);
 	}
 }
 
@@ -496,6 +699,30 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 		getConfig().then((config) => {
 			sendResponse({ url: config.daemonUrl });
 		});
+		return true;
+	}
+
+	if (message.action === "ask-signet-models") {
+		fetchAskSignetModels()
+			.then((result) => sendResponse(result))
+			.catch((error: unknown) => {
+				sendResponse({
+					ok: false,
+					error: error instanceof Error ? error.message : "Failed to load models",
+				});
+			});
+		return true;
+	}
+
+	if (message.action === "ask-signet-chat") {
+		askSignetChat(String(message.message ?? ""), String(message.modelId ?? ""))
+			.then((result) => sendResponse(result))
+			.catch((error: unknown) => {
+				sendResponse({
+					ok: false,
+					error: error instanceof Error ? error.message : "Ask Signet request failed",
+				});
+			});
 		return true;
 	}
 

--- a/packages/extension/src/background/service-worker.ts
+++ b/packages/extension/src/background/service-worker.ts
@@ -1,31 +1,127 @@
 /**
  * Signet background service worker
- * Handles: context menu, health polling, badge updates, message routing
+ * Handles: context menus, health polling, badge updates, and message routing
  */
 
-import { checkHealth } from "../shared/api.js";
+import { checkHealth, dispatchBrowserTool, getIdentity, rememberMemory } from "../shared/api.js";
 import { getConfig } from "../shared/config.js";
 
-// --- Context Menu ---
+type HealthState = "healthy" | "degraded" | "offline";
+type TranscribeFormat = "summary" | "bullet" | "checklist" | "json";
+
+interface InjectResult {
+	readonly ok: boolean;
+	readonly tabId?: number;
+	readonly error?: string;
+}
+
+interface PageContext {
+	readonly pageTitle: string;
+	readonly pageUrl: string;
+	readonly selectedText: string;
+	readonly links: readonly string[];
+	readonly images: readonly string[];
+	readonly videos: readonly string[];
+	readonly audio: readonly string[];
+	readonly files: readonly { name: string; type: string; size: number }[];
+}
+
+const MENU_IDS = {
+	root: "signet-tools",
+	remember: "signet-remember",
+	transcribeSummary: "signet-transcribe-summary",
+	transcribeBullet: "signet-transcribe-bullet",
+	transcribeChecklist: "signet-transcribe-checklist",
+	transcribeJson: "signet-transcribe-json",
+	sendSelection: "signet-send-selection",
+} as const;
+
+const BADGE_COLORS: Record<HealthState, string> = {
+	healthy: "#4a7a5e",
+	degraded: "#8a7a4a",
+	offline: "#8a4a48",
+};
+
+const BADGE_TEXT: Record<HealthState, string> = {
+	healthy: "",
+	degraded: "!",
+	offline: "X",
+};
+
+let currentState: HealthState = "offline";
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function normalizeBaseUrl(url: string): string {
+	return url.replace(/\/$/, "");
+}
+
+function buildDashboardUrl(baseUrl: string, hash = ""): string {
+	const cleaned = normalizeBaseUrl(baseUrl);
+	if (!hash) return cleaned;
+	return `${cleaned}/#${hash}`;
+}
+
+function createContextMenus(): void {
+	chrome.contextMenus.removeAll(() => {
+		chrome.contextMenus.create({
+			id: MENU_IDS.root,
+			title: "Signet",
+			contexts: ["selection"],
+		});
+
+		chrome.contextMenus.create({
+			id: MENU_IDS.remember,
+			parentId: MENU_IDS.root,
+			title: "Remember Selection",
+			contexts: ["selection"],
+		});
+
+		chrome.contextMenus.create({
+			id: MENU_IDS.transcribeSummary,
+			parentId: MENU_IDS.root,
+			title: "Transcribe as Summary",
+			contexts: ["selection"],
+		});
+
+		chrome.contextMenus.create({
+			id: MENU_IDS.transcribeBullet,
+			parentId: MENU_IDS.root,
+			title: "Transcribe as Bullet Points",
+			contexts: ["selection"],
+		});
+
+		chrome.contextMenus.create({
+			id: MENU_IDS.transcribeChecklist,
+			parentId: MENU_IDS.root,
+			title: "Transcribe as Checklist",
+			contexts: ["selection"],
+		});
+
+		chrome.contextMenus.create({
+			id: MENU_IDS.transcribeJson,
+			parentId: MENU_IDS.root,
+			title: "Transcribe as JSON",
+			contexts: ["selection"],
+		});
+
+		chrome.contextMenus.create({
+			id: MENU_IDS.sendSelection,
+			parentId: MENU_IDS.root,
+			title: "Send Selection to Signet",
+			contexts: ["selection"],
+		});
+	});
+}
 
 chrome.runtime.onInstalled.addListener(() => {
-	chrome.contextMenus.create({
-		id: "signet-remember",
-		title: "Remember with Signet",
-		contexts: ["selection"],
-	});
+	createContextMenus();
 });
 
-chrome.contextMenus.onClicked.addListener((info, tab) => {
-	if (info.menuItemId !== "signet-remember") return;
-	if (!tab?.id || !info.selectionText) return;
-
-	chrome.tabs.sendMessage(tab.id, {
-		action: "show-save-panel",
-		text: info.selectionText,
-		pageUrl: info.pageUrl ?? tab.url ?? "",
-		pageTitle: tab.title ?? "",
-	});
+chrome.runtime.onStartup.addListener(() => {
+	createContextMenus();
 });
 
 // --- Keyboard shortcut ---
@@ -43,23 +139,321 @@ chrome.commands.onCommand.addListener((command) => {
 	});
 });
 
-// --- Health polling & badge ---
+async function sendTabMessage<T>(tabId: number, message: unknown): Promise<T | null> {
+	return new Promise((resolve) => {
+		chrome.tabs.sendMessage(tabId, message, (response) => {
+			if (chrome.runtime.lastError) {
+				resolve(null);
+				return;
+			}
+			resolve((response as T | null) ?? null);
+		});
+	});
+}
 
-type HealthState = "healthy" | "degraded" | "offline";
+function transcribeSelection(text: string, format: TranscribeFormat, identityName: string): string {
+	const cleaned = text.trim();
+	if (!cleaned) return "";
 
-const BADGE_COLORS: Record<HealthState, string> = {
-	healthy: "#4a7a5e",
-	degraded: "#8a7a4a",
-	offline: "#8a4a48",
-};
+	if (format === "json") {
+		return JSON.stringify(
+			{
+				agent: identityName,
+				type: "transcription",
+				summary: cleaned.slice(0, 220),
+				length: cleaned.length,
+				timestamp: new Date().toISOString(),
+				content: cleaned,
+			},
+			null,
+			2,
+		);
+	}
 
-const BADGE_TEXT: Record<HealthState, string> = {
-	healthy: "",
-	degraded: "!",
-	offline: "X",
-};
+	const sentences = cleaned
+		.split(/(?<=[.!?])\s+/)
+		.map((part) => part.trim())
+		.filter(Boolean)
+		.slice(0, 8);
 
-let currentState: HealthState = "offline";
+	if (format === "bullet") {
+		const items = sentences.length > 0 ? sentences : [cleaned];
+		return items.map((item) => `• ${item}`).join("\n");
+	}
+
+	if (format === "checklist") {
+		const items = sentences.length > 0 ? sentences : [cleaned];
+		return items.map((item) => `- [ ] ${item}`).join("\n");
+	}
+
+	const lead = sentences.length > 0 ? sentences.slice(0, 2).join(" ") : cleaned;
+	return `${lead}\n\nTranscribed by ${identityName}.`;
+}
+
+function formatSelectionBundle(context: PageContext): string {
+	const lines: string[] = [
+		"--- signet-selection-bundle.txt ---",
+		`source_title: ${context.pageTitle || "Untitled"}`,
+		`source_url: ${context.pageUrl || "unknown"}`,
+		`created_at: ${new Date().toISOString()}`,
+		"",
+		"## Text",
+		context.selectedText || "(none)",
+		"",
+		"## Links",
+		...(context.links.length > 0 ? context.links : ["(none)"]),
+		"",
+		"## Images",
+		...(context.images.length > 0 ? context.images : ["(none)"]),
+		"",
+		"## Videos",
+		...(context.videos.length > 0 ? context.videos : ["(none)"]),
+		"",
+		"## Audio",
+		...(context.audio.length > 0 ? context.audio : ["(none)"]),
+		"",
+		"## Files",
+		...(context.files.length > 0
+			? context.files.map((file) => `${file.name} (${file.type || "unknown"}, ${file.size} bytes)`)
+			: ["(none)"]),
+	];
+
+	return lines.join("\n");
+}
+
+function buildFallbackContext(tab: chrome.tabs.Tab, selectedText: string): PageContext {
+	return {
+		pageTitle: tab.title ?? "Untitled page",
+		pageUrl: tab.url ?? "",
+		selectedText,
+		links: [],
+		images: [],
+		videos: [],
+		audio: [],
+		files: [],
+	};
+}
+
+async function getPageContext(tab: chrome.tabs.Tab, selectedText: string): Promise<PageContext> {
+	if (!tab.id) return buildFallbackContext(tab, selectedText);
+
+	const context = await sendTabMessage<PageContext>(tab.id, { action: "collect-page-context" });
+	if (!context) return buildFallbackContext(tab, selectedText);
+
+	return {
+		...context,
+		pageTitle: context.pageTitle || tab.title || "Untitled page",
+		pageUrl: context.pageUrl || tab.url || "",
+		selectedText: selectedText || context.selectedText || "",
+	};
+}
+
+async function createTab(url: string): Promise<chrome.tabs.Tab> {
+	return new Promise((resolve, reject) => {
+		chrome.tabs.create({ url, active: true }, (tab) => {
+			if (chrome.runtime.lastError || !tab) {
+				reject(new Error(chrome.runtime.lastError?.message ?? "Could not create dashboard tab"));
+				return;
+			}
+			resolve(tab);
+		});
+	});
+}
+
+async function waitForTabLoad(tabId: number, timeoutMs = 10_000): Promise<void> {
+	return new Promise((resolve, reject) => {
+		let settled = false;
+
+		const cleanup = (): void => {
+			chrome.tabs.onUpdated.removeListener(onUpdated);
+			clearTimeout(timeout);
+		};
+
+		const finishResolve = (): void => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			resolve();
+		};
+
+		const finishReject = (message: string): void => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			reject(new Error(message));
+		};
+
+		const timeout = setTimeout(() => {
+			finishReject("Timed out waiting for dashboard tab");
+		}, timeoutMs);
+
+		const onUpdated = (updatedTabId: number, changeInfo: chrome.tabs.TabChangeInfo): void => {
+			if (updatedTabId !== tabId) return;
+			if (changeInfo.status === "complete") {
+				finishResolve();
+			}
+		};
+
+		chrome.tabs.onUpdated.addListener(onUpdated);
+		chrome.tabs.get(tabId, (tab) => {
+			if (chrome.runtime.lastError) {
+				finishReject(chrome.runtime.lastError.message ?? "Failed to query tab status");
+				return;
+			}
+			if (tab?.status === "complete") {
+				finishResolve();
+			}
+		});
+	});
+}
+
+async function sendTabMessageWithRetry(
+	tabId: number,
+	message: unknown,
+	attempts = 10,
+): Promise<{ ok: boolean; error?: string } | null> {
+	for (let attempt = 0; attempt < attempts; attempt += 1) {
+		const response = await new Promise<{ ok: boolean; error?: string } | null>((resolve) => {
+			chrome.tabs.sendMessage(tabId, message, (result) => {
+				if (chrome.runtime.lastError) {
+					resolve(null);
+					return;
+				}
+				resolve((result as { ok: boolean; error?: string } | null) ?? null);
+			});
+		});
+
+		if (response) return response;
+		await delay(200);
+	}
+
+	return null;
+}
+
+async function openDashboardAndInject(url: string, payload: string, autoSend: boolean): Promise<InjectResult> {
+	const tab = await createTab(url);
+	if (!tab.id) {
+		return { ok: false, error: "Dashboard tab missing id" };
+	}
+
+	if (tab.status !== "complete") {
+		await waitForTabLoad(tab.id);
+	}
+
+	const injectResult = await sendTabMessageWithRetry(tab.id, {
+		action: "inject-harness-payload",
+		payload,
+		autoSend,
+	});
+
+	if (injectResult?.ok) {
+		return { ok: true, tabId: tab.id };
+	}
+
+	return {
+		ok: false,
+		tabId: tab.id,
+		error: injectResult?.error ?? "Failed to inject payload into dashboard harness",
+	};
+}
+
+async function handleTranscribe(tab: chrome.tabs.Tab, selectedText: string, format: TranscribeFormat): Promise<void> {
+	if (!selectedText) return;
+	const context = await getPageContext(tab, selectedText);
+	const identity = await getIdentity();
+	const identityName = identity?.name ?? "Signet Agent";
+	const transcription = transcribeSelection(selectedText, format, identityName);
+	if (!transcription) return;
+
+	await rememberMemory({
+		content: [
+			"[Signet Transcribe]",
+			`Format: ${format}`,
+			`Source: ${context.pageTitle} (${context.pageUrl})`,
+			"",
+			transcription,
+		].join("\n"),
+		tags: "transcribe,browser-extension,right-click",
+		importance: 0.72,
+		type: "note",
+		source_type: "browser-extension",
+	});
+}
+
+async function handleSendSelection(tab: chrome.tabs.Tab, selectedText: string): Promise<void> {
+	if (!selectedText) return;
+	const context = await getPageContext(tab, selectedText);
+	const payload = formatSelectionBundle(context);
+
+	const browserResult = await dispatchBrowserTool({
+		action: "send-selection",
+		payload,
+		pageTitle: context.pageTitle,
+		pageUrl: context.pageUrl,
+		selectedText: context.selectedText,
+		links: context.links,
+		images: context.images,
+		videos: context.videos,
+		audio: context.audio,
+		files: context.files,
+		dispatchToHarness: true,
+	});
+
+	if (browserResult.success && browserResult.dispatched) {
+		return;
+	}
+
+	const config = await getConfig();
+	const dashboardUrl = buildDashboardUrl(config.daemonUrl, "os");
+	await openDashboardAndInject(dashboardUrl, payload, true);
+}
+
+async function handleContextMenuClick(info: chrome.contextMenus.OnClickData, tab?: chrome.tabs.Tab): Promise<void> {
+	if (!tab?.id) return;
+
+	const selectedText = (info.selectionText ?? "").trim();
+	const pageUrl = info.pageUrl ?? tab.url ?? "";
+	const pageTitle = tab.title ?? "";
+
+	if (info.menuItemId === MENU_IDS.remember) {
+		if (!selectedText) return;
+		chrome.tabs.sendMessage(tab.id, {
+			action: "show-save-panel",
+			text: selectedText,
+			pageUrl,
+			pageTitle,
+		});
+		return;
+	}
+
+	if (info.menuItemId === MENU_IDS.transcribeSummary) {
+		await handleTranscribe(tab, selectedText, "summary");
+		return;
+	}
+
+	if (info.menuItemId === MENU_IDS.transcribeBullet) {
+		await handleTranscribe(tab, selectedText, "bullet");
+		return;
+	}
+
+	if (info.menuItemId === MENU_IDS.transcribeChecklist) {
+		await handleTranscribe(tab, selectedText, "checklist");
+		return;
+	}
+
+	if (info.menuItemId === MENU_IDS.transcribeJson) {
+		await handleTranscribe(tab, selectedText, "json");
+		return;
+	}
+
+	if (info.menuItemId === MENU_IDS.sendSelection) {
+		await handleSendSelection(tab, selectedText);
+	}
+}
+
+chrome.contextMenus.onClicked.addListener((info, tab) => {
+	void handleContextMenuClick(info, tab);
+});
 
 async function pollHealth(): Promise<void> {
 	const health = await checkHealth();
@@ -106,6 +500,18 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 		getConfig().then((config) => {
 			sendResponse({ url: config.daemonUrl });
 		});
+		return true;
+	}
+
+	if (message.action === "open-dashboard-and-inject") {
+		openDashboardAndInject(String(message.url ?? ""), String(message.payload ?? ""), message.autoSend !== false)
+			.then((result) => sendResponse(result))
+			.catch((error: unknown) => {
+				sendResponse({
+					ok: false,
+					error: error instanceof Error ? error.message : "Failed to open dashboard",
+				});
+			});
 		return true;
 	}
 

--- a/packages/extension/src/background/service-worker.ts
+++ b/packages/extension/src/background/service-worker.ts
@@ -385,7 +385,7 @@ async function handleSendSelection(tab: chrome.tabs.Tab, selectedText: string): 
 	const context = await getPageContext(tab, selectedText);
 	const payload = formatSelectionBundle(context);
 
-	const browserResult = await dispatchBrowserTool({
+	await dispatchBrowserTool({
 		action: "send-selection",
 		payload,
 		pageTitle: context.pageTitle,
@@ -396,12 +396,8 @@ async function handleSendSelection(tab: chrome.tabs.Tab, selectedText: string): 
 		videos: context.videos,
 		audio: context.audio,
 		files: context.files,
-		dispatchToHarness: true,
+		dispatchToHarness: false,
 	});
-
-	if (browserResult.success && browserResult.dispatched) {
-		return;
-	}
 
 	const config = await getConfig();
 	const dashboardUrl = buildDashboardUrl(config.daemonUrl, "os");

--- a/packages/extension/src/content/content.ts
+++ b/packages/extension/src/content/content.ts
@@ -15,6 +15,10 @@ document.documentElement.dataset.signetExtension = "true";
 
 let panelHost: HTMLElement | null = null;
 let shadowRoot: ShadowRoot | null = null;
+let askHost: HTMLElement | null = null;
+let askShadowRoot: ShadowRoot | null = null;
+let stopAskVoiceCapture: (() => void) | null = null;
+let stopAskOverlayDrag: (() => void) | null = null;
 let currentSelection = "";
 let currentPageUrl = "";
 let currentPageTitle = "";
@@ -56,6 +60,9 @@ const PANEL_STYLES = `
     --sig-accent-hover: #c0c0c8;
     --sig-danger: #8a4a48;
     --sig-success: #4a7a5e;
+    --sig-highlight: #a3e635;
+    --sig-warning: #facc15;
+    --sig-glow-highlight: 0 0 10px rgba(163, 230, 53, 0.24);
 
     --ease: cubic-bezier(0.16, 1, 0.3, 1);
     --dur: 0.2s;
@@ -240,6 +247,410 @@ const PANEL_STYLES = `
     background: var(--sig-accent-hover);
   }
 
+  .ask-panel {
+    width: min(380px, calc(100vw - 28px));
+    max-height: min(82vh, 780px);
+    border-radius: 12px;
+    overflow: hidden;
+    backdrop-filter: blur(8px);
+    display: flex;
+    flex-direction: column;
+  }
+
+  .ask-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--sig-border);
+    background: var(--sig-surface);
+    cursor: grab;
+    user-select: none;
+  }
+
+  .ask-header:active {
+    cursor: grabbing;
+  }
+
+  .ask-header-title {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  .ask-header-name {
+    font-family: "Chakra Petch", sans-serif;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--sig-text-bright);
+  }
+
+  .ask-header-meta {
+    font-size: 10px;
+    color: var(--sig-text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: min(440px, 56vw);
+  }
+
+  .ask-header-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+  }
+
+  .ask-icon-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+    border: 1px solid var(--sig-border);
+    background: var(--sig-bg);
+    color: var(--sig-text-muted);
+    font-size: 14px;
+    line-height: 1;
+    cursor: pointer;
+    transition: all var(--dur) var(--ease);
+  }
+
+  .ask-icon-btn:hover {
+    border-color: var(--sig-accent);
+    color: var(--sig-accent-hover);
+  }
+
+  .ask-body {
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-height: 420px;
+  }
+
+  .ask-controls {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .ask-mic-select,
+  .ask-model-select {
+    font-size: 11px;
+    min-height: 32px;
+    border-radius: 8px;
+    padding: 6px 8px;
+    background: var(--sig-bg);
+  }
+
+  .ask-mic-select {
+    flex: 0 0 42%;
+    min-width: 180px;
+  }
+
+  .ask-model-select {
+    flex: 1;
+  }
+
+  .ask-messages {
+    flex: 1;
+    min-height: 230px;
+    max-height: 44vh;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px;
+    border: 1px solid var(--sig-border);
+    border-radius: 10px;
+    background: var(--sig-surface-raised);
+  }
+
+  .ask-empty {
+    margin: auto;
+    text-align: center;
+    color: var(--sig-text-muted);
+    font-size: 11px;
+    max-width: 340px;
+    line-height: 1.45;
+  }
+
+  .ask-msg {
+    display: flex;
+    gap: 8px;
+    max-width: 88%;
+  }
+
+  .ask-msg--user {
+    align-self: flex-end;
+    flex-direction: row-reverse;
+  }
+
+  .ask-msg-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 999px;
+    border: 1px solid var(--sig-border);
+    background: var(--sig-bg);
+    color: var(--sig-text-muted);
+    font-size: 10px;
+    font-weight: 600;
+    flex-shrink: 0;
+  }
+
+  .ask-msg--assistant .ask-msg-icon {
+    border-color: color-mix(in srgb, var(--sig-highlight) 62%, var(--sig-warning));
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--sig-highlight) 30%, transparent), var(--sig-glow-highlight);
+  }
+
+  .ask-msg--user .ask-msg-icon {
+    border-color: color-mix(in srgb, var(--sig-warning) 70%, var(--sig-border));
+  }
+
+  .ask-msg-body {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .ask-msg-actions {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .ask-copy-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    border-radius: 6px;
+    border: 1px solid var(--sig-border);
+    background: var(--sig-bg);
+    color: var(--sig-text-muted);
+    cursor: pointer;
+    transition: all var(--dur) var(--ease);
+  }
+
+  .ask-copy-btn:hover {
+    border-color: var(--sig-highlight);
+    color: var(--sig-highlight);
+    background: color-mix(in srgb, var(--sig-highlight) 10%, var(--sig-bg));
+  }
+
+  .ask-msg-content {
+    font-size: 12px;
+    line-height: 1.48;
+    color: var(--sig-text);
+    border: 1px solid var(--sig-border);
+    border-radius: 8px;
+    padding: 7px 10px;
+    background: var(--sig-surface);
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  .ask-msg--user .ask-msg-content {
+    background: color-mix(in srgb, var(--sig-accent) 8%, var(--sig-surface));
+  }
+
+  .ask-thinking {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 7px 10px;
+    border-radius: 8px;
+    border: 1px solid var(--sig-border);
+    background: var(--sig-surface);
+  }
+
+  .ask-thinking-dot {
+    width: 5px;
+    height: 5px;
+    border-radius: 999px;
+    background: var(--sig-text-muted);
+    opacity: 0.28;
+    animation: askDotPulse 1.15s ease-in-out infinite;
+  }
+
+  .ask-thinking-dot:nth-child(2) {
+    animation-delay: 0.2s;
+  }
+
+  .ask-thinking-dot:nth-child(3) {
+    animation-delay: 0.4s;
+  }
+
+  @keyframes askDotPulse {
+    0%, 60%, 100% {
+      opacity: 0.22;
+      transform: scale(0.82);
+    }
+    30% {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  .ask-input-bar {
+    position: relative;
+    width: 100%;
+  }
+
+  .ask-input-actions {
+    position: absolute;
+    right: 6px;
+    top: 50%;
+    transform: translateY(-50%);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    z-index: 2;
+  }
+
+  .ask-input {
+    width: 100%;
+    min-height: 36px;
+    max-height: 36px;
+    border-radius: 6px;
+    border-color: color-mix(in srgb, var(--sig-highlight) 65%, var(--sig-border-strong));
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--sig-highlight) 22%, transparent);
+    padding: 8px 78px 8px 10px;
+    font-size: 12px;
+    line-height: 1.2;
+    transition: border-color var(--dur) var(--ease), box-shadow var(--dur) var(--ease);
+  }
+
+  .ask-input:focus {
+    border-color: var(--sig-highlight);
+    box-shadow: var(--sig-glow-highlight);
+  }
+
+  .ask-voice-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    min-width: 30px;
+    min-height: 30px;
+    border-radius: 6px;
+    padding: 0;
+    background: var(--sig-surface);
+    color: var(--sig-text-muted);
+  }
+
+  .ask-voice-btn[data-state="active"] {
+    border-color: color-mix(in srgb, var(--sig-highlight) 70%, var(--sig-warning));
+    color: var(--sig-highlight);
+    box-shadow: var(--sig-glow-highlight);
+  }
+
+  .ask-voice-btn:hover:not(:disabled) {
+    border-color: var(--sig-highlight);
+    color: var(--sig-highlight);
+    background: color-mix(in srgb, var(--sig-highlight) 10%, var(--sig-surface));
+  }
+
+  .ask-voice-bars {
+    display: inline-flex;
+    align-items: flex-end;
+    gap: 2px;
+    height: 12px;
+  }
+
+  .ask-voice-bars span {
+    width: 2px;
+    height: 100%;
+    border-radius: 2px;
+    background: currentColor;
+    transform-origin: center bottom;
+    animation: askVoiceWave 0.9s ease-in-out infinite;
+  }
+
+  .ask-voice-bars span:nth-child(2) {
+    animation-delay: 0.15s;
+  }
+
+  .ask-voice-bars span:nth-child(3) {
+    animation-delay: 0.3s;
+  }
+
+  @keyframes askVoiceWave {
+    0%,
+    100% {
+      transform: scaleY(0.35);
+      opacity: 0.45;
+    }
+    50% {
+      transform: scaleY(1);
+      opacity: 1;
+    }
+  }
+
+  .ask-send-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    min-width: 30px;
+    min-height: 30px;
+    border-radius: 6px;
+    padding: 0;
+    background: var(--sig-surface);
+    color: var(--sig-text-muted);
+  }
+
+  .ask-send-btn:hover:not(:disabled) {
+    border-color: var(--sig-accent);
+    color: var(--sig-accent);
+    background: color-mix(in srgb, var(--sig-accent) 8%, var(--sig-surface));
+  }
+
+  .ask-send-btn:disabled,
+  .ask-voice-btn:disabled {
+    opacity: 0.3;
+    cursor: default;
+  }
+
+  .ask-icon-glyph {
+    width: 14px;
+    height: 14px;
+    stroke: currentColor;
+    fill: none;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .ask-status {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--sig-text-muted);
+    min-height: 16px;
+    padding: 0 2px;
+  }
+
+  .ask-status[data-tone="error"] {
+    color: #cf8a86;
+  }
+
+  .ask-status[data-tone="success"] {
+    color: #76b492;
+  }
+
   .btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
@@ -265,6 +676,64 @@ const PANEL_STYLES = `
     opacity: 1;
   }
 `;
+
+type SpeechRecognitionInstance = {
+	continuous: boolean;
+	interimResults: boolean;
+	lang: string;
+	onresult: ((event: Event) => void) | null;
+	onerror: ((event: Event) => void) | null;
+	onend: (() => void) | null;
+	start: (track?: MediaStreamTrack) => void;
+	stop: () => void;
+};
+
+type SpeechRecognitionCtor = new () => SpeechRecognitionInstance;
+
+function getSpeechRecognitionCtor(): SpeechRecognitionCtor | null {
+	if (typeof window === "undefined") return null;
+	const withSpeech = window as Window & {
+		SpeechRecognition?: SpeechRecognitionCtor;
+		webkitSpeechRecognition?: SpeechRecognitionCtor;
+	};
+	return withSpeech.SpeechRecognition ?? withSpeech.webkitSpeechRecognition ?? null;
+}
+
+async function requestMicrophoneStream(deviceId?: string): Promise<MediaStream> {
+	if (!navigator.mediaDevices?.getUserMedia) {
+		throw new Error("Microphone capture is not supported in this browser.");
+	}
+	if (deviceId && deviceId !== "default") {
+		try {
+			return await navigator.mediaDevices.getUserMedia({ audio: { deviceId: { exact: deviceId } } });
+		} catch {
+			return await navigator.mediaDevices.getUserMedia({ audio: true });
+		}
+	}
+	return await navigator.mediaDevices.getUserMedia({ audio: true });
+}
+
+async function getAudioInputOptions(): Promise<Array<{ id: string; label: string }>> {
+	if (!navigator.mediaDevices?.enumerateDevices) {
+		return [{ id: "default", label: "Browser default microphone" }];
+	}
+	const devices = await navigator.mediaDevices.enumerateDevices();
+	const discovered = devices
+		.filter((device) => device.kind === "audioinput")
+		.map((device, index) => ({
+			id: device.deviceId,
+			label: device.label?.trim() || `Microphone ${index + 1}`,
+		}));
+	return [
+		{ id: "default", label: "Browser default microphone" },
+		...discovered.filter((device) => device.id !== "default"),
+	];
+}
+
+const ASK_MIC_ICON_SVG = `<svg class="ask-icon-glyph" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3a3 3 0 0 0-3 3v6a3 3 0 0 0 6 0V6a3 3 0 0 0-3-3Z"></path><path d="M19 11a7 7 0 1 1-14 0"></path><path d="M12 18v3"></path><path d="M8 21h8"></path></svg>`;
+const ASK_SEND_ICON_SVG = `<svg class="ask-icon-glyph" viewBox="0 0 24 24" aria-hidden="true"><path d="m22 2-7 20-4-9-9-4Z"></path><path d="M22 2 11 13"></path></svg>`;
+const ASK_COPY_ICON_SVG = `<svg class="ask-icon-glyph" viewBox="0 0 24 24" aria-hidden="true"><rect x="9" y="9" width="11" height="11" rx="2"></rect><path d="M5 15V5a2 2 0 0 1 2-2h10"></path></svg>`;
+const ASK_CHECK_ICON_SVG = `<svg class="ask-icon-glyph" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6 9 17l-5-5"></path></svg>`;
 
 function createPanel(theme: "dark" | "light"): void {
 	if (panelHost) return;
@@ -448,6 +917,693 @@ function destroyPanel(): void {
 		panelHost.remove();
 		panelHost = null;
 		shadowRoot = null;
+	}
+}
+
+function destroyAskOverlay(): void {
+	if (stopAskVoiceCapture) {
+		stopAskVoiceCapture();
+		stopAskVoiceCapture = null;
+	}
+	if (stopAskOverlayDrag) {
+		stopAskOverlayDrag();
+		stopAskOverlayDrag = null;
+	}
+	if (askHost) {
+		askHost.remove();
+		askHost = null;
+		askShadowRoot = null;
+	}
+}
+
+async function askSignetFromOverlay(
+	message: string,
+	modelId: string,
+): Promise<{ ok: true; response: string } | { ok: false; error: string }> {
+	return new Promise((resolve) => {
+		chrome.runtime.sendMessage(
+			{ action: "ask-signet-chat", message, modelId },
+			(response?: { ok?: boolean; response?: string; error?: string }) => {
+				if (chrome.runtime.lastError) {
+					resolve({ ok: false, error: chrome.runtime.lastError.message || "Chat request failed." });
+					return;
+				}
+				if (!response?.ok) {
+					resolve({ ok: false, error: response?.error || "Chat request failed." });
+					return;
+				}
+				const text = String(response.response ?? "").trim();
+				if (!text) {
+					resolve({ ok: false, error: "Signet returned an empty response." });
+					return;
+				}
+				resolve({ ok: true, response: text });
+			},
+		);
+	});
+}
+
+async function getAskSignetModels(): Promise<{
+	ok: boolean;
+	options?: Array<{ id: string; label: string }>;
+	defaultModelId?: string;
+	error?: string;
+}> {
+	return new Promise((resolve) => {
+		chrome.runtime.sendMessage(
+			{ action: "ask-signet-models" },
+			(
+				response?: {
+					ok?: boolean;
+					options?: Array<{ id: string; label: string }>;
+					defaultModelId?: string;
+					error?: string;
+				},
+			) => {
+				if (chrome.runtime.lastError) {
+					resolve({ ok: false, error: chrome.runtime.lastError.message || "Failed to load models." });
+					return;
+				}
+				if (!response?.ok) {
+					resolve({ ok: false, error: response?.error || "Failed to load models." });
+					return;
+				}
+				resolve({
+					ok: true,
+					options: Array.isArray(response.options) ? response.options : [],
+					defaultModelId: response.defaultModelId,
+				});
+			},
+		);
+	});
+}
+
+async function copyTextToClipboard(text: string): Promise<boolean> {
+	const value = text.trim();
+	if (!value) return false;
+	try {
+		if (navigator.clipboard?.writeText) {
+			await navigator.clipboard.writeText(value);
+			return true;
+		}
+		const area = document.createElement("textarea");
+		area.value = value;
+		area.style.position = "fixed";
+		area.style.opacity = "0";
+		document.body.appendChild(area);
+		area.focus();
+		area.select();
+		document.execCommand("copy");
+		area.remove();
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function appendAskMessage(container: HTMLElement, role: "user" | "assistant", text: string): void {
+	const row = document.createElement("div");
+	row.className = `ask-msg ask-msg--${role}`;
+
+	const icon = document.createElement("div");
+	icon.className = "ask-msg-icon";
+	icon.textContent = role === "user" ? "U" : "S";
+	row.appendChild(icon);
+
+	const body = document.createElement("div");
+	body.className = "ask-msg-body";
+	if (role === "assistant") {
+		const actions = document.createElement("div");
+		actions.className = "ask-msg-actions";
+		const copyBtn = document.createElement("button");
+		copyBtn.className = "ask-copy-btn";
+		copyBtn.type = "button";
+		copyBtn.title = "Copy response";
+		copyBtn.innerHTML = ASK_COPY_ICON_SVG;
+		copyBtn.addEventListener("click", async () => {
+			const copied = await copyTextToClipboard(text);
+			if (!copied) return;
+			copyBtn.innerHTML = ASK_CHECK_ICON_SVG;
+			window.setTimeout(() => {
+				copyBtn.innerHTML = ASK_COPY_ICON_SVG;
+			}, 1600);
+		});
+		actions.appendChild(copyBtn);
+		body.appendChild(actions);
+	}
+
+	const bubble = document.createElement("div");
+	bubble.className = "ask-msg-content";
+	bubble.textContent = text;
+	body.appendChild(bubble);
+	row.appendChild(body);
+
+	container.appendChild(row);
+	container.scrollTop = container.scrollHeight;
+}
+
+function createAskOverlay(
+	theme: "dark" | "light",
+	initialText: string,
+	pageTitle: string,
+	pageUrl: string,
+	options?: {
+		presetAction?: "transcribe";
+		autoSubmit?: boolean;
+		promptText?: string;
+	},
+): void {
+	destroyAskOverlay();
+
+	askHost = document.createElement("div");
+	askHost.id = "signet-ask-overlay";
+	document.body.appendChild(askHost);
+	askShadowRoot = askHost.attachShadow({ mode: "closed" });
+	const askRoot = askShadowRoot;
+	if (!askRoot) return;
+
+	const style = document.createElement("style");
+	style.textContent = PANEL_STYLES;
+	askRoot.appendChild(style);
+
+	const panel = document.createElement("div");
+	panel.className = "panel ask-panel";
+	panel.setAttribute("data-theme", theme);
+	panel.style.top = "48px";
+	panel.style.right = "16px";
+
+	const header = document.createElement("div");
+	header.className = "ask-header";
+
+	const headerTitle = document.createElement("div");
+	headerTitle.className = "ask-header-title";
+
+	const title = document.createElement("span");
+	title.className = "ask-header-name";
+	title.textContent = "Ask Signet";
+	headerTitle.appendChild(title);
+
+	const meta = document.createElement("span");
+	meta.className = "ask-header-meta";
+	meta.textContent = pageTitle || pageUrl || "Current Page";
+	meta.title = pageUrl || pageTitle;
+	headerTitle.appendChild(meta);
+	header.appendChild(headerTitle);
+
+	const headerActions = document.createElement("div");
+	headerActions.className = "ask-header-actions";
+
+	const clearConversationBtn = document.createElement("button");
+	clearConversationBtn.className = "ask-icon-btn";
+	clearConversationBtn.title = "Clear conversation";
+	clearConversationBtn.textContent = "↺";
+	headerActions.appendChild(clearConversationBtn);
+
+	const closeBtn = document.createElement("button");
+	closeBtn.className = "ask-icon-btn";
+	closeBtn.title = "Close";
+	closeBtn.textContent = "×";
+	closeBtn.addEventListener("click", destroyAskOverlay);
+	headerActions.appendChild(closeBtn);
+
+	header.appendChild(headerActions);
+	panel.appendChild(header);
+
+	const clampToViewport = (value: number, min: number, max: number): number => Math.min(Math.max(value, min), max);
+	let dragging = false;
+	let dragOffsetX = 0;
+	let dragOffsetY = 0;
+
+	const handleWindowMouseMove = (event: MouseEvent): void => {
+		if (!dragging) return;
+		const rect = panel.getBoundingClientRect();
+		const maxLeft = Math.max(0, window.innerWidth - rect.width);
+		const maxTop = Math.max(0, window.innerHeight - rect.height);
+		const nextLeft = clampToViewport(event.clientX - dragOffsetX, 0, maxLeft);
+		const nextTop = clampToViewport(event.clientY - dragOffsetY, 0, maxTop);
+		panel.style.left = `${nextLeft}px`;
+		panel.style.top = `${nextTop}px`;
+		panel.style.right = "auto";
+		panel.style.bottom = "auto";
+	};
+
+	const handleWindowMouseUp = (): void => {
+		dragging = false;
+		window.removeEventListener("mousemove", handleWindowMouseMove);
+		window.removeEventListener("mouseup", handleWindowMouseUp);
+	};
+
+	const stopDragging = (): void => {
+		handleWindowMouseUp();
+	};
+
+	const handleHeaderMouseDown = (event: MouseEvent): void => {
+		if (event.button !== 0) return;
+		const target = event.target as HTMLElement | null;
+		if (target?.closest(".ask-icon-btn")) return;
+		event.preventDefault();
+		const rect = panel.getBoundingClientRect();
+		panel.style.left = `${rect.left}px`;
+		panel.style.top = `${rect.top}px`;
+		panel.style.right = "auto";
+		panel.style.bottom = "auto";
+		dragOffsetX = event.clientX - rect.left;
+		dragOffsetY = event.clientY - rect.top;
+		dragging = true;
+		window.addEventListener("mousemove", handleWindowMouseMove);
+		window.addEventListener("mouseup", handleWindowMouseUp);
+	};
+
+	header.addEventListener("mousedown", handleHeaderMouseDown);
+	stopAskOverlayDrag = () => {
+		stopDragging();
+		header.removeEventListener("mousedown", handleHeaderMouseDown);
+	};
+
+	const body = document.createElement("div");
+	body.className = "ask-body";
+
+	const responseBox = document.createElement("div");
+	responseBox.className = "ask-messages";
+
+	const emptyHint = document.createElement("div");
+	emptyHint.className = "ask-empty";
+	emptyHint.textContent = "Ask about this page and Signet will respond here.";
+	responseBox.appendChild(emptyHint);
+	body.appendChild(responseBox);
+
+	const overlayPresetAction = options?.presetAction;
+	const shouldAutoSubmitPreset =
+		overlayPresetAction === "transcribe" && options?.autoSubmit === true && Boolean(options?.promptText?.trim());
+	const initialAskInput = shouldAutoSubmitPreset
+		? String(options?.promptText ?? "").trim()
+		: initialText;
+	let autoSubmittedPreset = false;
+
+	let selectedModelId = "";
+	let selectedMicrophoneId = "default";
+	let microphoneOptions: Array<{ id: string; label: string }> = [];
+	const controls = document.createElement("div");
+	controls.className = "ask-controls";
+
+	const micSelect = document.createElement("select");
+	micSelect.className = "field-input ask-mic-select";
+	micSelect.disabled = true;
+	micSelect.innerHTML = '<option value="default">Loading microphones...</option>';
+	controls.appendChild(micSelect);
+
+	const modelSelect = document.createElement("select");
+	modelSelect.className = "field-input ask-model-select";
+	modelSelect.disabled = true;
+	modelSelect.innerHTML = '<option value="">Loading models...</option>';
+	controls.appendChild(modelSelect);
+	body.appendChild(controls);
+
+	const inputBar = document.createElement("div");
+	inputBar.className = "ask-input-bar";
+
+	const input = document.createElement("input");
+	input.className = "field-input ask-input";
+	input.type = "text";
+	input.placeholder = "Ask your agent...";
+	input.value = initialAskInput;
+	input.autocomplete = "off";
+	inputBar.appendChild(input);
+
+	const inputActions = document.createElement("div");
+	inputActions.className = "ask-input-actions";
+
+	const voiceBtn = document.createElement("button");
+	voiceBtn.className = "btn ask-voice-btn";
+	voiceBtn.type = "button";
+	voiceBtn.innerHTML = ASK_MIC_ICON_SVG;
+	voiceBtn.title = "Use microphone";
+	inputActions.appendChild(voiceBtn);
+
+	const sendBtn = document.createElement("button");
+	sendBtn.className = "btn ask-send-btn";
+	sendBtn.innerHTML = ASK_SEND_ICON_SVG;
+	sendBtn.title = "Send message";
+	sendBtn.disabled = true;
+	inputActions.appendChild(sendBtn);
+
+	inputBar.appendChild(inputActions);
+	body.appendChild(inputBar);
+
+	const status = document.createElement("div");
+	status.className = "ask-status";
+	status.textContent = "Loading providers...";
+	body.appendChild(status);
+
+	let recognition: SpeechRecognitionInstance | null = null;
+	let activeMicStream: MediaStream | null = null;
+	let listening = false;
+	let voicePending = false;
+	const speechCtor = getSpeechRecognitionCtor();
+	const voiceSupported = Boolean(speechCtor);
+
+	const updateActionState = (): void => {
+		sendBtn.disabled = input.disabled || !selectedModelId || !input.value.trim();
+		voiceBtn.disabled = input.disabled || !voiceSupported || voicePending;
+		micSelect.disabled = input.disabled || listening || microphoneOptions.length === 0;
+		voiceBtn.innerHTML = listening
+			? '<span class="ask-voice-bars" aria-hidden="true"><span></span><span></span><span></span></span>'
+			: ASK_MIC_ICON_SVG;
+		voiceBtn.title = voiceSupported
+			? listening
+				? "Stop microphone"
+				: "Use microphone"
+			: "Voice input is not supported in this browser";
+		voiceBtn.setAttribute("data-state", listening ? "active" : "idle");
+	};
+
+	let voiceInputBase = input.value.trim();
+
+	const appendTranscriptToInput = (transcript: string): void => {
+		const cleaned = transcript.trim();
+		if (!cleaned) return;
+		const merged = voiceInputBase ? `${voiceInputBase} ${cleaned}` : cleaned;
+		input.value = merged;
+		input.dispatchEvent(new Event("input"));
+	};
+
+	const releaseActiveMicStream = (): void => {
+		if (!activeMicStream) return;
+		for (const track of activeMicStream.getTracks()) {
+			track.stop();
+		}
+		activeMicStream = null;
+	};
+
+	const clearRecognitionHandlers = (): void => {
+		if (!recognition) return;
+		recognition.onend = null;
+		recognition.onerror = null;
+		recognition.onresult = null;
+		recognition = null;
+	};
+
+	const extractTranscriptFromVoiceEvent = (event: Event): string => {
+		const speechEvent = event as Event & {
+			results?: ArrayLike<{
+				0?: { transcript?: string };
+				item?: (index: number) => { transcript?: string } | null;
+			}> & {
+				item?: (index: number) => {
+					0?: { transcript?: string };
+					item?: (index: number) => { transcript?: string } | null;
+				} | null;
+			};
+		};
+		const results = speechEvent.results;
+		if (!results) return "";
+
+		let transcript = "";
+		for (let index = 0; index < results.length; index += 1) {
+			const result = results[index] ?? results.item?.(index) ?? null;
+			const primaryAlt = result?.[0] ?? result?.item?.(0) ?? null;
+			const chunk = typeof primaryAlt?.transcript === "string" ? primaryAlt.transcript.trim() : "";
+			if (!chunk) continue;
+			transcript += `${chunk} `;
+		}
+
+		if (transcript.trim()) return transcript.trim();
+
+		const fallbackTranscript = (event as Event & { transcript?: string }).transcript;
+		return typeof fallbackTranscript === "string" ? fallbackTranscript.trim() : "";
+	};
+
+	const stopVoiceCapture = (): void => {
+		if (!recognition) {
+			listening = false;
+			voicePending = false;
+			releaseActiveMicStream();
+			updateActionState();
+			return;
+		}
+		voicePending = true;
+		updateActionState();
+		recognition.stop();
+	};
+	stopAskVoiceCapture = stopVoiceCapture;
+
+	micSelect.addEventListener("change", () => {
+		selectedMicrophoneId = micSelect.value || "default";
+		updateActionState();
+	});
+
+	modelSelect.addEventListener("change", () => {
+		selectedModelId = modelSelect.value;
+		updateActionState();
+	});
+
+	voiceBtn.addEventListener("click", async () => {
+		status.removeAttribute("data-tone");
+		if (listening) {
+			stopVoiceCapture();
+			status.textContent = "Stopping voice input...";
+			return;
+		}
+		if (!speechCtor) {
+			status.textContent = "Voice input is not supported in this browser.";
+			status.setAttribute("data-tone", "error");
+			return;
+		}
+
+		voicePending = true;
+		updateActionState();
+		try {
+			releaseActiveMicStream();
+			activeMicStream = await requestMicrophoneStream(selectedMicrophoneId || "default");
+			await loadMicrophones();
+			voiceInputBase = input.value.trim();
+			recognition = new speechCtor();
+			recognition.continuous = false;
+			recognition.interimResults = true;
+			recognition.lang = navigator.language || "en-US";
+			recognition.onresult = (event: Event) => {
+				const transcript = extractTranscriptFromVoiceEvent(event);
+				if (!transcript) return;
+				appendTranscriptToInput(transcript);
+			};
+			recognition.onerror = (event: Event) => {
+				const reason = (event as Event & { error?: string }).error;
+				if (reason === "no-speech") {
+					status.textContent = "No speech detected. Try speaking immediately after the mic turns active.";
+					status.removeAttribute("data-tone");
+				} else if (reason && reason !== "aborted") {
+					status.textContent = `Voice capture failed: ${reason}`;
+					status.setAttribute("data-tone", "error");
+				}
+				listening = false;
+				voicePending = false;
+				clearRecognitionHandlers();
+				releaseActiveMicStream();
+				updateActionState();
+			};
+			recognition.onend = () => {
+				listening = false;
+				voicePending = false;
+				if (!status.getAttribute("data-tone")) {
+					status.textContent = "Ready";
+				}
+				clearRecognitionHandlers();
+				releaseActiveMicStream();
+				updateActionState();
+				input.focus();
+			};
+			listening = true;
+			voicePending = false;
+			status.textContent = "Listening...";
+			status.removeAttribute("data-tone");
+			updateActionState();
+			const selectedTrack = activeMicStream.getAudioTracks()[0] ?? undefined;
+			if (selectedTrack) {
+				try {
+					recognition.start(selectedTrack);
+				} catch {
+					recognition.start();
+				}
+			} else {
+				recognition.start();
+			}
+		} catch (error) {
+			listening = false;
+			voicePending = false;
+			status.textContent = error instanceof Error ? error.message : "Unable to access microphone.";
+			status.setAttribute("data-tone", "error");
+			clearRecognitionHandlers();
+			releaseActiveMicStream();
+			updateActionState();
+		}
+	});
+
+	const loadMicrophones = async (): Promise<void> => {
+		try {
+			microphoneOptions = await getAudioInputOptions();
+			if (microphoneOptions.length === 0) {
+				micSelect.innerHTML = '<option value="default">No microphones found</option>';
+				micSelect.disabled = true;
+				selectedMicrophoneId = "default";
+				updateActionState();
+				return;
+			}
+
+			micSelect.innerHTML = "";
+			for (const option of microphoneOptions) {
+				const optionEl = document.createElement("option");
+				optionEl.value = option.id;
+				optionEl.textContent = option.label;
+				micSelect.appendChild(optionEl);
+			}
+
+			if (!microphoneOptions.some((option) => option.id === selectedMicrophoneId)) {
+				selectedMicrophoneId = "default";
+			}
+			micSelect.value = selectedMicrophoneId;
+			micSelect.disabled = input.disabled || listening;
+			updateActionState();
+		} catch {
+			micSelect.innerHTML = '<option value="default">Microphone unavailable</option>';
+			micSelect.disabled = true;
+			selectedMicrophoneId = "default";
+			updateActionState();
+		}
+	};
+
+	const loadModels = async (): Promise<void> => {
+		const result = await getAskSignetModels();
+		if (!result.ok || !result.options || result.options.length === 0) {
+			status.textContent = result.error || "No providers found.";
+			status.setAttribute("data-tone", "error");
+			modelSelect.innerHTML = '<option value="">No providers found</option>';
+			modelSelect.disabled = true;
+			updateActionState();
+			return;
+		}
+
+		modelSelect.innerHTML = "";
+		for (const option of result.options) {
+			const optionEl = document.createElement("option");
+			optionEl.value = option.id;
+			optionEl.textContent = option.label;
+			modelSelect.appendChild(optionEl);
+		}
+
+		selectedModelId = result.defaultModelId && result.options.some((opt) => opt.id === result.defaultModelId)
+			? result.defaultModelId
+			: result.options[0]?.id || "";
+		modelSelect.value = selectedModelId;
+		modelSelect.disabled = false;
+		status.textContent = "Ready";
+		status.removeAttribute("data-tone");
+		updateActionState();
+		if (shouldAutoSubmitPreset && !autoSubmittedPreset && selectedModelId && input.value.trim()) {
+			autoSubmittedPreset = true;
+			status.textContent = "Starting transcription...";
+			setTimeout(() => sendBtn.click(), 0);
+		}
+	};
+
+	updateActionState();
+	void loadMicrophones();
+	void loadModels();
+
+	clearConversationBtn.addEventListener("click", () => {
+		responseBox.innerHTML = "";
+		const hint = document.createElement("div");
+		hint.className = "ask-empty";
+		hint.textContent = "Conversation cleared.";
+		responseBox.appendChild(hint);
+		status.textContent = "Cleared";
+		status.removeAttribute("data-tone");
+	});
+
+	sendBtn.addEventListener("click", async () => {
+		const prompt = input.value.trim();
+		if (!prompt) {
+			status.textContent = "Add a prompt first.";
+			status.setAttribute("data-tone", "error");
+			return;
+		}
+		if (!selectedModelId) {
+			status.textContent = "Select a model first.";
+			status.setAttribute("data-tone", "error");
+			return;
+		}
+
+		if (responseBox.firstElementChild?.classList.contains("ask-empty")) {
+			responseBox.innerHTML = "";
+		}
+
+		stopVoiceCapture();
+		sendBtn.disabled = true;
+		modelSelect.disabled = true;
+		input.disabled = true;
+		updateActionState();
+		status.textContent = "Asking Signet...";
+		status.removeAttribute("data-tone");
+		appendAskMessage(responseBox, "user", prompt);
+		input.value = "";
+
+		const thinking = document.createElement("div");
+		thinking.className = "ask-msg ask-msg--assistant";
+		thinking.innerHTML =
+			'<div class="ask-msg-icon">S</div><div class="ask-thinking"><span class="ask-thinking-dot"></span><span class="ask-thinking-dot"></span><span class="ask-thinking-dot"></span></div>';
+		responseBox.appendChild(thinking);
+		responseBox.scrollTop = responseBox.scrollHeight;
+
+		try {
+			let result = await askSignetFromOverlay(prompt, selectedModelId);
+			if (!result.ok && overlayPresetAction === "transcribe") {
+				const fallbackPrompt = [
+					"Transcribe the content below.",
+					"Return only the final transcript text.",
+					"",
+					prompt,
+				].join("\n");
+				result = await askSignetFromOverlay(fallbackPrompt, selectedModelId);
+			}
+			thinking.remove();
+			if (!result.ok) {
+				appendAskMessage(responseBox, "assistant", `Request failed: ${result.error}`);
+				status.textContent = result.error;
+				status.setAttribute("data-tone", "error");
+				return;
+			}
+			appendAskMessage(responseBox, "assistant", result.response);
+			status.textContent = "Response received.";
+			status.setAttribute("data-tone", "success");
+		} catch (error) {
+			thinking.remove();
+			const message = error instanceof Error ? error.message : "Signet request failed.";
+			appendAskMessage(responseBox, "assistant", `Request failed: ${message}`);
+			status.textContent = message;
+			status.setAttribute("data-tone", "error");
+		} finally {
+			input.disabled = false;
+			modelSelect.disabled = false;
+			updateActionState();
+			input.focus();
+		}
+	});
+
+	input.addEventListener("input", () => {
+		updateActionState();
+	});
+
+	input.addEventListener("keydown", (event) => {
+		if (event.key === "Enter") {
+			event.preventDefault();
+			sendBtn.click();
+		}
+	});
+
+	panel.appendChild(body);
+	askRoot.appendChild(panel);
+	input.focus();
+	if (initialText) {
+		input.setSelectionRange(input.value.length, input.value.length);
 	}
 }
 
@@ -658,6 +1814,33 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 			createPanel(theme);
 		});
 		return false;
+	}
+
+	if (message.action === "show-ask-signet-overlay") {
+		const selectedText = String(message.text ?? window.getSelection()?.toString()?.trim() ?? "");
+		const pageUrl = String(message.pageUrl ?? window.location.href ?? "");
+		const pageTitle = String(message.pageTitle ?? document.title ?? "");
+		const presetAction = message.presetAction === "transcribe" ? "transcribe" : undefined;
+		const autoSubmit = message.autoSubmit === true;
+		const promptText = typeof message.promptText === "string" ? message.promptText : undefined;
+
+		getConfig()
+			.then((config) => {
+				const theme = resolveTheme(config.theme);
+				createAskOverlay(theme, selectedText, pageTitle, pageUrl, {
+					presetAction,
+					autoSubmit,
+					promptText,
+				});
+				sendResponse({ ok: true });
+			})
+			.catch((error: unknown) => {
+				sendResponse({
+					ok: false,
+					error: error instanceof Error ? error.message : "Failed to open Ask Signet overlay",
+				});
+			});
+		return true;
 	}
 
 	if (message.action === "collect-page-context") {

--- a/packages/extension/src/content/content.ts
+++ b/packages/extension/src/content/content.ts
@@ -476,12 +476,177 @@ function showToast(theme: "dark" | "light", message: string): void {
 	}, 2000);
 }
 
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function uniqueLimited(values: readonly string[], limit = 24): string[] {
+	const unique = Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
+	return unique.slice(0, limit);
+}
+
+function normalizeUrl(value: string): string | null {
+	if (!value) return null;
+	try {
+		return new URL(value, window.location.href).href;
+	} catch {
+		return null;
+	}
+}
+
+function collectPageContext() {
+	const selectedText = window.getSelection()?.toString()?.trim() ?? "";
+
+	const links = uniqueLimited(
+		Array.from(document.querySelectorAll<HTMLAnchorElement>("a[href]"))
+			.map((anchor) => normalizeUrl(anchor.href) ?? "")
+			.filter(Boolean),
+	);
+
+	const images = uniqueLimited(
+		Array.from(document.querySelectorAll<HTMLImageElement>("img[src]"))
+			.map((img) => normalizeUrl(img.currentSrc || img.src) ?? "")
+			.filter(Boolean),
+	);
+
+	const videos = uniqueLimited(
+		Array.from(document.querySelectorAll<HTMLVideoElement>("video"))
+			.flatMap((video) => {
+				const sourceEls = Array.from(video.querySelectorAll<HTMLSourceElement>("source[src]"));
+				return [video.currentSrc, video.src, ...sourceEls.map((source) => source.src)]
+					.map((src) => normalizeUrl(src || "") ?? "")
+					.filter(Boolean);
+			})
+			.slice(0, 32),
+	);
+
+	const audio = uniqueLimited(
+		Array.from(document.querySelectorAll<HTMLAudioElement>("audio"))
+			.flatMap((track) => {
+				const sourceEls = Array.from(track.querySelectorAll<HTMLSourceElement>("source[src]"));
+				return [track.currentSrc, track.src, ...sourceEls.map((source) => source.src)]
+					.map((src) => normalizeUrl(src || "") ?? "")
+					.filter(Boolean);
+			})
+			.slice(0, 32),
+	);
+
+	const files = Array.from(document.querySelectorAll<HTMLInputElement>('input[type="file"]'))
+		.flatMap((input) => Array.from(input.files ?? []))
+		.slice(0, 24)
+		.map((file) => ({
+			name: file.name,
+			type: file.type,
+			size: file.size,
+		}));
+
+	return {
+		pageTitle: document.title,
+		pageUrl: window.location.href,
+		selectedText,
+		links,
+		images,
+		videos,
+		audio,
+		files,
+	};
+}
+
+type HarnessInput = HTMLInputElement | HTMLTextAreaElement;
+
+function setInputValue(input: HarnessInput, value: string): void {
+	if (input instanceof HTMLTextAreaElement) {
+		const descriptor = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value");
+		if (descriptor?.set) {
+			descriptor.set.call(input, value);
+		} else {
+			input.value = value;
+		}
+	} else {
+		const descriptor = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value");
+		if (descriptor?.set) {
+			descriptor.set.call(input, value);
+		} else {
+			input.value = value;
+		}
+	}
+
+	input.dispatchEvent(new Event("input", { bubbles: true }));
+	input.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+async function waitForElement<T extends Element>(selector: string, timeoutMs = 4000): Promise<T | null> {
+	const start = Date.now();
+	while (Date.now() - start <= timeoutMs) {
+		const found = document.querySelector<T>(selector);
+		if (found) return found;
+		await delay(100);
+	}
+	return null;
+}
+
+async function injectHarnessPayload(payload: string, autoSend: boolean): Promise<{ ok: boolean; error?: string }> {
+	if (!payload.trim()) {
+		return { ok: false, error: "Empty payload" };
+	}
+
+	if (window.location.hash.slice(1) !== "os") {
+		window.location.hash = "os";
+		await delay(350);
+	}
+
+	const chatToggle = await waitForElement<HTMLButtonElement>(".os-chat-toggle", 2500);
+	if (chatToggle && !chatToggle.classList.contains("active")) {
+		chatToggle.click();
+		await delay(250);
+	}
+
+	const chatInput = await waitForElement<HarnessInput>(".chat-input", 4500);
+	if (!chatInput) {
+		return { ok: false, error: "Harness input unavailable" };
+	}
+
+	chatInput.focus();
+	setInputValue(chatInput, payload);
+	await delay(80);
+
+	if (!chatInput.value.trim()) {
+		return { ok: false, error: "Harness input did not accept payload" };
+	}
+
+	if (autoSend) {
+		const sendButton = await waitForElement<HTMLButtonElement>(".chat-send-btn", 2000);
+		if (!sendButton) {
+			return { ok: false, error: "Harness send button unavailable" };
+		}
+
+		if (sendButton.disabled) {
+			chatInput.dispatchEvent(
+				new KeyboardEvent("keydown", {
+					key: "Enter",
+					code: "Enter",
+					bubbles: true,
+					cancelable: true,
+				}),
+			);
+			await delay(120);
+			if (sendButton.disabled) {
+				return { ok: false, error: "Harness send action unavailable" };
+			}
+		}
+
+		sendButton.click();
+	}
+
+	return { ok: true };
+}
+
 // --- Message handling ---
 
-chrome.runtime.onMessage.addListener((message, _sender, _sendResponse) => {
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 	if (message.action === "show-save-panel" || message.action === "trigger-save-shortcut") {
 		const selectedText = message.text ?? window.getSelection()?.toString()?.trim() ?? "";
-		if (!selectedText) return;
+		if (!selectedText) return false;
 
 		currentSelection = selectedText;
 		currentPageUrl = message.pageUrl ?? window.location.href;
@@ -492,5 +657,25 @@ chrome.runtime.onMessage.addListener((message, _sender, _sendResponse) => {
 			destroyPanel();
 			createPanel(theme);
 		});
+		return false;
 	}
+
+	if (message.action === "collect-page-context") {
+		sendResponse(collectPageContext());
+		return false;
+	}
+
+	if (message.action === "inject-harness-payload") {
+		injectHarnessPayload(String(message.payload ?? ""), message.autoSend !== false)
+			.then((result) => sendResponse(result))
+			.catch((error: unknown) => {
+				sendResponse({
+					ok: false,
+					error: error instanceof Error ? error.message : "Injection failed",
+				});
+			});
+		return true;
+	}
+
+	return false;
 });

--- a/packages/extension/src/content/content.ts
+++ b/packages/extension/src/content/content.ts
@@ -63,6 +63,8 @@ const PANEL_STYLES = `
     --sig-highlight: #a3e635;
     --sig-warning: #facc15;
     --sig-glow-highlight: 0 0 10px rgba(163, 230, 53, 0.24);
+    --ask-chat-accent: #c8ff00;
+    --ask-chat-glow: 0 0 12px rgba(200, 255, 0, 0.24);
 
     --ease: cubic-bezier(0.16, 1, 0.3, 1);
     --dur: 0.2s;
@@ -322,8 +324,8 @@ const PANEL_STYLES = `
   }
 
   .ask-icon-btn:hover {
-    border-color: var(--sig-accent);
-    color: var(--sig-accent-hover);
+    border-color: var(--ask-chat-accent);
+    color: var(--ask-chat-accent);
   }
 
   .ask-body {
@@ -408,8 +410,8 @@ const PANEL_STYLES = `
   }
 
   .ask-msg--assistant .ask-msg-icon {
-    border-color: color-mix(in srgb, var(--sig-highlight) 62%, var(--sig-warning));
-    box-shadow: 0 0 0 1px color-mix(in srgb, var(--sig-highlight) 30%, transparent), var(--sig-glow-highlight);
+    border-color: color-mix(in srgb, var(--ask-chat-accent) 62%, var(--sig-warning));
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--ask-chat-accent) 30%, transparent), var(--ask-chat-glow);
   }
 
   .ask-msg--user .ask-msg-icon {
@@ -443,9 +445,9 @@ const PANEL_STYLES = `
   }
 
   .ask-copy-btn:hover {
-    border-color: var(--sig-highlight);
-    color: var(--sig-highlight);
-    background: color-mix(in srgb, var(--sig-highlight) 10%, var(--sig-bg));
+    border-color: var(--ask-chat-accent);
+    color: var(--ask-chat-accent);
+    background: color-mix(in srgb, var(--ask-chat-accent) 10%, var(--sig-bg));
   }
 
   .ask-msg-content {
@@ -523,8 +525,8 @@ const PANEL_STYLES = `
     min-height: 36px;
     max-height: 36px;
     border-radius: 6px;
-    border-color: color-mix(in srgb, var(--sig-highlight) 65%, var(--sig-border-strong));
-    box-shadow: 0 0 0 1px color-mix(in srgb, var(--sig-highlight) 22%, transparent);
+    border-color: color-mix(in srgb, var(--ask-chat-accent) 65%, var(--sig-border-strong));
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--ask-chat-accent) 22%, transparent);
     padding: 8px 78px 8px 10px;
     font-size: 12px;
     line-height: 1.2;
@@ -532,8 +534,8 @@ const PANEL_STYLES = `
   }
 
   .ask-input:focus {
-    border-color: var(--sig-highlight);
-    box-shadow: var(--sig-glow-highlight);
+    border-color: var(--ask-chat-accent);
+    box-shadow: var(--ask-chat-glow);
   }
 
   .ask-voice-btn {
@@ -551,15 +553,15 @@ const PANEL_STYLES = `
   }
 
   .ask-voice-btn[data-state="active"] {
-    border-color: color-mix(in srgb, var(--sig-highlight) 70%, var(--sig-warning));
-    color: var(--sig-highlight);
-    box-shadow: var(--sig-glow-highlight);
+    border-color: color-mix(in srgb, var(--ask-chat-accent) 70%, var(--sig-warning));
+    color: var(--ask-chat-accent);
+    box-shadow: var(--ask-chat-glow);
   }
 
   .ask-voice-btn:hover:not(:disabled) {
-    border-color: var(--sig-highlight);
-    color: var(--sig-highlight);
-    background: color-mix(in srgb, var(--sig-highlight) 10%, var(--sig-surface));
+    border-color: var(--ask-chat-accent);
+    color: var(--ask-chat-accent);
+    background: color-mix(in srgb, var(--ask-chat-accent) 10%, var(--sig-surface));
   }
 
   .ask-voice-bars {
@@ -613,9 +615,9 @@ const PANEL_STYLES = `
   }
 
   .ask-send-btn:hover:not(:disabled) {
-    border-color: var(--sig-accent);
-    color: var(--sig-accent);
-    background: color-mix(in srgb, var(--sig-accent) 8%, var(--sig-surface));
+    border-color: var(--ask-chat-accent);
+    color: var(--ask-chat-accent);
+    background: color-mix(in srgb, var(--ask-chat-accent) 8%, var(--sig-surface));
   }
 
   .ask-send-btn:disabled,

--- a/packages/extension/src/popup/components/memory-list.ts
+++ b/packages/extension/src/popup/components/memory-list.ts
@@ -115,6 +115,12 @@ export function renderLoading(container: HTMLElement): void {
 	container.replaceChildren(createStateMessage("Loading", "Connecting to daemon...", true));
 }
 
+export function renderSearchPrompt(container: HTMLElement): void {
+	container.replaceChildren(
+		createStateMessage("Search memories", "Type 2+ characters to find relevant memories"),
+	);
+}
+
 export function renderSearchEmpty(container: HTMLElement, query: string): void {
 	container.replaceChildren(createStateMessage("No results", `No memories match "${query}"`));
 }

--- a/packages/extension/src/popup/index.html
+++ b/packages/extension/src/popup/index.html
@@ -11,33 +11,16 @@
 </head>
 <body>
   <div class="popup" id="popup">
-    <!-- Header -->
-    <div class="header">
+    <header class="header">
       <div class="header-left">
         <span class="logo">Signet</span>
         <span class="health-dot" id="health-dot" data-state="offline" title="Daemon offline"></span>
       </div>
       <span class="version" id="version">--</span>
-    </div>
+    </header>
 
-    <!-- Stats -->
-    <div class="stats-bar" id="stats-bar">
-      <div class="stat">
-        <span class="stat-value" id="stat-memories">--</span>
-        <span class="stat-label">Memories</span>
-      </div>
-      <div class="stat">
-        <span class="stat-value" id="stat-embedded">--</span>
-        <span class="stat-label">Embedded</span>
-      </div>
-      <div class="stat">
-        <span class="stat-value" id="stat-pipeline">--</span>
-        <span class="stat-label">Pipeline</span>
-      </div>
-    </div>
-
-    <!-- Search -->
-    <div class="search-section">
+    <section class="section search-section">
+      <div class="section-title">Memory Search</div>
       <input
         type="text"
         class="search-input"
@@ -46,21 +29,83 @@
         autocomplete="off"
         spellcheck="false"
       >
-    </div>
+    </section>
 
-    <!-- Memory list -->
-    <div class="memory-list" id="memory-list">
-      <div class="state-message loading-pulse" id="loading-state">
-        <span class="state-message-title">Loading</span>
-        <span class="state-message-body">Connecting to daemon...</span>
+    <section class="section nav-section">
+      <div class="section-title">Signet Page Navigator</div>
+      <div class="nav-grid">
+        <button class="nav-btn" data-nav-target="home">Overview</button>
+        <button class="nav-btn" data-nav-target="cortex-memory/constellation">Ontology</button>
+        <button class="nav-btn" data-nav-target="tasks">Tasks</button>
+        <button class="nav-btn" data-nav-target="audit">Audit</button>
+        <button class="nav-btn" data-nav-target="secrets">Secrets</button>
+        <button class="nav-btn" data-nav-target="skills">Skills</button>
+        <button class="nav-btn nav-btn-wide" data-nav-target="cortex-memory/memories">View Memories</button>
       </div>
-    </div>
+    </section>
 
-    <!-- Footer -->
-    <div class="footer">
+    <section class="section tools-section">
+      <div class="section-title">Tools</div>
+      <div class="tool-grid">
+        <button class="tool-btn" id="tool-capture-page">Capture Page</button>
+        <button class="tool-btn" id="tool-save-bookmark">Save Bookmark</button>
+        <button class="tool-btn" id="tool-write-note">Write Note</button>
+        <button class="tool-btn" id="tool-send-page">Send Page to Signet</button>
+      </div>
+
+      <textarea
+        id="tool-note-input"
+        class="tool-note-input"
+        rows="3"
+        placeholder="Add page notes for Signet..."
+      ></textarea>
+
+      <div class="tool-row">
+        <select id="transcribe-format" class="tool-select">
+          <option value="summary">Transcribe: Summary</option>
+          <option value="bullet">Transcribe: Bullet Points</option>
+          <option value="checklist">Transcribe: Checklist</option>
+          <option value="json">Transcribe: JSON</option>
+        </select>
+      </div>
+
+      <div class="tool-grid tool-grid-secondary">
+        <button class="tool-btn" id="tool-transcribe-highlight">Signet Transcribe</button>
+        <button class="tool-btn" id="tool-send-selection">Send Selection to Signet</button>
+      </div>
+
+      <div class="tool-status" id="tool-status">Ready.</div>
+    </section>
+
+    <section class="section overview-section">
+      <div class="section-title">Overview</div>
+      <div class="stats-bar" id="stats-bar">
+        <div class="stat">
+          <span class="stat-value" id="stat-memories">--</span>
+          <span class="stat-label">Memories</span>
+        </div>
+        <div class="stat">
+          <span class="stat-value" id="stat-embedded">--</span>
+          <span class="stat-label">Embedded</span>
+        </div>
+        <div class="stat">
+          <span class="stat-value" id="stat-pipeline">--</span>
+          <span class="stat-label">Pipeline</span>
+        </div>
+      </div>
+
+      <div class="memory-list" id="memory-list">
+        <div class="state-message loading-pulse" id="loading-state">
+          <span class="state-message-title">Loading</span>
+          <span class="state-message-body">Connecting to daemon...</span>
+        </div>
+      </div>
+    </section>
+
+    <footer class="footer">
       <button class="footer-link" id="open-dashboard">Open Dashboard</button>
       <button class="footer-link" id="open-options">Settings</button>
-    </div>
+    </footer>
   </div>
 
   <script type="module" src="popup.js"></script>

--- a/packages/extension/src/popup/index.html
+++ b/packages/extension/src/popup/index.html
@@ -33,14 +33,18 @@
 
     <section class="section nav-section">
       <div class="section-title">Signet Page Navigator</div>
-      <div class="nav-grid">
-        <button class="nav-btn" data-nav-target="home">Overview</button>
-        <button class="nav-btn" data-nav-target="cortex-memory/constellation">Ontology</button>
-        <button class="nav-btn" data-nav-target="tasks">Tasks</button>
-        <button class="nav-btn" data-nav-target="audit">Audit</button>
-        <button class="nav-btn" data-nav-target="secrets">Secrets</button>
-        <button class="nav-btn" data-nav-target="skills">Skills</button>
-        <button class="nav-btn nav-btn-wide" data-nav-target="cortex-memory/memories">View Memories</button>
+      <div class="nav-row">
+        <select id="nav-target-select" class="tool-select nav-select">
+          <option value="home">Overview</option>
+          <option value="cortex-memory/constellation">Ontology</option>
+          <option value="tasks">Tasks</option>
+          <option value="audit">Audit</option>
+          <option value="secrets">Secrets</option>
+          <option value="skills">Skills</option>
+          <option value="cortex-memory/memories">View Memories</option>
+          <option value="os">OS Chat</option>
+        </select>
+        <button class="tool-btn nav-open-btn" id="nav-open-target">Open</button>
       </div>
     </section>
 
@@ -50,15 +54,18 @@
         <button class="tool-btn" id="tool-capture-page">Capture Page</button>
         <button class="tool-btn" id="tool-save-bookmark">Save Bookmark</button>
         <button class="tool-btn" id="tool-write-note">Write Note</button>
+        <button class="tool-btn" id="tool-open-os-chat">OS Chat</button>
         <button class="tool-btn" id="tool-send-page">Send Page to Signet</button>
       </div>
 
-      <textarea
-        id="tool-note-input"
-        class="tool-note-input"
-        rows="3"
-        placeholder="Add page notes for Signet..."
-      ></textarea>
+      <div class="tool-note-section" id="tool-note-section" hidden>
+        <textarea
+          id="tool-note-input"
+          class="tool-note-input"
+          rows="3"
+          placeholder="Add page notes for Signet..."
+        ></textarea>
+      </div>
 
       <div class="tool-row">
         <select id="transcribe-format" class="tool-select">

--- a/packages/extension/src/popup/index.html
+++ b/packages/extension/src/popup/index.html
@@ -29,6 +29,12 @@
         autocomplete="off"
         spellcheck="false"
       >
+      <div class="memory-list memory-list--search" id="memory-list">
+        <div class="state-message loading-pulse" id="loading-state">
+          <span class="state-message-title">Loading</span>
+          <span class="state-message-body">Connecting to daemon...</span>
+        </div>
+      </div>
     </section>
 
     <section class="section nav-section">
@@ -56,6 +62,7 @@
         <button class="tool-btn" id="tool-write-note">Write Note</button>
         <button class="tool-btn" id="tool-open-os-chat">OS Chat</button>
         <button class="tool-btn" id="tool-send-page">Send Page to Signet</button>
+        <button class="tool-btn" id="open-options">Settings</button>
       </div>
 
       <div class="tool-note-section" id="tool-note-section" hidden>
@@ -67,52 +74,12 @@
         ></textarea>
       </div>
 
-      <div class="tool-row">
-        <select id="transcribe-format" class="tool-select">
-          <option value="summary">Transcribe: Summary</option>
-          <option value="bullet">Transcribe: Bullet Points</option>
-          <option value="checklist">Transcribe: Checklist</option>
-          <option value="json">Transcribe: JSON</option>
-        </select>
-      </div>
-
-      <div class="tool-grid tool-grid-secondary">
-        <button class="tool-btn" id="tool-transcribe-highlight">Signet Transcribe</button>
-        <button class="tool-btn" id="tool-send-selection">Send Selection to Signet</button>
+      <div class="tool-grid tool-grid-secondary tool-grid-single">
+        <button class="tool-btn" id="open-dashboard">Open Dashboard</button>
       </div>
 
       <div class="tool-status" id="tool-status">Ready.</div>
     </section>
-
-    <section class="section overview-section">
-      <div class="section-title">Overview</div>
-      <div class="stats-bar" id="stats-bar">
-        <div class="stat">
-          <span class="stat-value" id="stat-memories">--</span>
-          <span class="stat-label">Memories</span>
-        </div>
-        <div class="stat">
-          <span class="stat-value" id="stat-embedded">--</span>
-          <span class="stat-label">Embedded</span>
-        </div>
-        <div class="stat">
-          <span class="stat-value" id="stat-pipeline">--</span>
-          <span class="stat-label">Pipeline</span>
-        </div>
-      </div>
-
-      <div class="memory-list" id="memory-list">
-        <div class="state-message loading-pulse" id="loading-state">
-          <span class="state-message-title">Loading</span>
-          <span class="state-message-body">Connecting to daemon...</span>
-        </div>
-      </div>
-    </section>
-
-    <footer class="footer">
-      <button class="footer-link" id="open-dashboard">Open Dashboard</button>
-      <button class="footer-link" id="open-options">Settings</button>
-    </footer>
   </div>
 
   <script type="module" src="popup.js"></script>

--- a/packages/extension/src/popup/popup.css
+++ b/packages/extension/src/popup/popup.css
@@ -1,27 +1,16 @@
 /* Signet Extension — Popup Styles */
 
-@font-face {
-	font-family: "Chakra Petch";
-	src: url("https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&display=swap");
-}
-
-@font-face {
-	font-family: "IBM Plex Mono";
-	src: url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&display=swap");
-}
-
-/* === Dark theme (default) === */
 :root {
 	--sig-bg: #08080a;
 	--sig-surface: #0e0e12;
 	--sig-surface-raised: #151519;
 	--sig-border: rgba(255, 255, 255, 0.06);
-	--sig-border-strong: rgba(255, 255, 255, 0.12);
+	--sig-border-strong: rgba(255, 255, 255, 0.14);
 	--sig-text: #d4d4d8;
 	--sig-text-bright: #f0f0f2;
 	--sig-text-muted: #6b6b76;
-	--sig-accent: #8a8a96;
-	--sig-accent-hover: #c0c0c8;
+	--sig-accent: #9a9aa6;
+	--sig-accent-hover: #d0d0d8;
 	--sig-danger: #8a4a48;
 	--sig-success: #4a7a5e;
 
@@ -30,35 +19,33 @@
 
 	--space-xs: 4px;
 	--space-sm: 8px;
-	--space-md: 16px;
-	--space-lg: 24px;
+	--space-md: 12px;
+	--space-lg: 16px;
 
 	--font-size-xs: 10px;
 	--font-size-sm: 11px;
-	--font-size-base: 13px;
-	--font-size-lg: 15px;
+	--font-size-base: 12px;
+	--font-size-lg: 14px;
 
 	--ease: cubic-bezier(0.16, 1, 0.3, 1);
 	--dur: 0.2s;
 }
 
-/* === Light theme === */
 [data-theme="light"] {
 	--sig-bg: #e4dfd8;
 	--sig-surface: #dbd5cd;
 	--sig-surface-raised: #d1cbc2;
 	--sig-border: rgba(0, 0, 0, 0.06);
-	--sig-border-strong: rgba(0, 0, 0, 0.12);
+	--sig-border-strong: rgba(0, 0, 0, 0.14);
 	--sig-text: #2a2a2e;
 	--sig-text-bright: #0a0a0c;
 	--sig-text-muted: #7a756e;
-	--sig-accent: #6a6660;
-	--sig-accent-hover: #3a3832;
+	--sig-accent: #5f5b56;
+	--sig-accent-hover: #2a2824;
 	--sig-danger: #8a4a48;
 	--sig-success: #4a7a5e;
 }
 
-/* === Base === */
 * {
 	margin: 0;
 	padding: 0;
@@ -67,21 +54,20 @@
 
 html,
 body {
-	width: 350px;
-	min-height: 200px;
-	max-height: 520px;
+	width: 370px;
+	height: 640px;
+	max-height: 640px;
 	overflow: hidden;
 	background: var(--sig-bg);
 	color: var(--sig-text);
 	font-family: var(--font-mono);
 	font-size: var(--font-size-base);
-	line-height: 1.55;
+	line-height: 1.5;
 	-webkit-font-smoothing: antialiased;
 }
 
-/* Scrollbar */
 ::-webkit-scrollbar {
-	width: 3px;
+	width: 4px;
 }
 ::-webkit-scrollbar-track {
 	background: transparent;
@@ -89,26 +75,20 @@ body {
 ::-webkit-scrollbar-thumb {
 	background: var(--sig-border-strong);
 }
-::-webkit-scrollbar-thumb:hover {
-	background: var(--sig-text-muted);
-}
 
-/* === Layout === */
 .popup {
+	height: 100%;
 	display: flex;
 	flex-direction: column;
-	height: 100%;
-	max-height: 520px;
 }
 
-/* === Header === */
 .header {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
 	padding: var(--space-sm) var(--space-md);
-	border-bottom: 1px solid var(--sig-border);
 	background: var(--sig-surface);
+	border-bottom: 1px solid var(--sig-border);
 }
 
 .header-left {
@@ -120,10 +100,10 @@ body {
 .logo {
 	font-family: var(--font-display);
 	font-size: var(--font-size-lg);
-	font-weight: 600;
-	color: var(--sig-text-bright);
+	font-weight: 700;
+	letter-spacing: 0.1em;
 	text-transform: uppercase;
-	letter-spacing: 0.08em;
+	color: var(--sig-text-bright);
 }
 
 .health-dot {
@@ -131,7 +111,6 @@ body {
 	height: 8px;
 	border-radius: 50%;
 	background: var(--sig-danger);
-	transition: background var(--dur) var(--ease);
 }
 
 .health-dot[data-state="healthy"] {
@@ -147,13 +126,121 @@ body {
 	color: var(--sig-text-muted);
 }
 
-/* === Stats Bar === */
+.section {
+	padding: var(--space-sm) var(--space-md);
+	border-bottom: 1px solid var(--sig-border);
+}
+
+.section-title {
+	font-size: var(--font-size-xs);
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+	color: var(--sig-text-muted);
+	margin-bottom: var(--space-sm);
+}
+
+.search-input,
+.tool-note-input,
+.tool-select {
+	width: 100%;
+	padding: 7px 9px;
+	background: var(--sig-surface-raised);
+	border: 1px solid var(--sig-border-strong);
+	color: var(--sig-text);
+	font-family: var(--font-mono);
+	font-size: var(--font-size-base);
+	outline: none;
+}
+
+.search-input:focus,
+.tool-note-input:focus,
+.tool-select:focus {
+	border-color: var(--sig-accent);
+}
+
+.search-input::placeholder,
+.tool-note-input::placeholder {
+	color: var(--sig-text-muted);
+}
+
+.nav-grid,
+.tool-grid {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 6px;
+}
+
+.nav-btn,
+.tool-btn {
+	padding: 7px 8px;
+	background: var(--sig-surface-raised);
+	border: 1px solid var(--sig-border);
+	color: var(--sig-text);
+	font-family: var(--font-mono);
+	font-size: var(--font-size-xs);
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	cursor: pointer;
+	transition: border-color var(--dur) var(--ease), color var(--dur) var(--ease);
+}
+
+.nav-btn:hover,
+.tool-btn:hover {
+	border-color: var(--sig-accent);
+	color: var(--sig-accent-hover);
+}
+
+.nav-btn-wide {
+	grid-column: span 2;
+}
+
+.tools-section {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.tool-note-input {
+	resize: vertical;
+	min-height: 64px;
+	max-height: 140px;
+}
+
+.tool-row {
+	display: flex;
+	gap: 6px;
+}
+
+.tool-grid-secondary {
+	margin-top: 2px;
+}
+
+.tool-status {
+	font-size: var(--font-size-xs);
+	color: var(--sig-text-muted);
+	min-height: 14px;
+}
+
+.tool-status[data-tone="success"] {
+	color: var(--sig-success);
+}
+
+.tool-status[data-tone="error"] {
+	color: var(--sig-danger);
+}
+
+.overview-section {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+	padding-bottom: 0;
+}
+
 .stats-bar {
 	display: flex;
 	gap: var(--space-md);
-	padding: var(--space-sm) var(--space-md);
-	border-bottom: 1px solid var(--sig-border);
-	background: var(--sig-surface);
+	padding: 0 0 var(--space-sm);
 }
 
 .stat {
@@ -162,57 +249,30 @@ body {
 }
 
 .stat-value {
+	font-family: var(--font-display);
 	font-size: var(--font-size-lg);
 	font-weight: 600;
 	color: var(--sig-text-bright);
-	font-family: var(--font-display);
 }
 
 .stat-label {
 	font-size: var(--font-size-xs);
-	color: var(--sig-text-muted);
 	text-transform: uppercase;
 	letter-spacing: 0.06em;
-}
-
-/* === Search === */
-.search-section {
-	padding: var(--space-sm) var(--space-md);
-	border-bottom: 1px solid var(--sig-border);
-}
-
-.search-input {
-	width: 100%;
-	padding: var(--space-xs) var(--space-sm);
-	background: var(--sig-surface-raised);
-	border: 1px solid var(--sig-border-strong);
-	color: var(--sig-text);
-	font-family: var(--font-mono);
-	font-size: var(--font-size-base);
-	outline: none;
-	transition: border-color var(--dur) var(--ease);
-}
-
-.search-input::placeholder {
 	color: var(--sig-text-muted);
 }
 
-.search-input:focus {
-	border-color: var(--sig-accent);
-}
-
-/* === Memory List === */
 .memory-list {
 	flex: 1;
 	overflow-y: auto;
+	border-top: 1px solid var(--sig-border);
+	margin: 0 calc(-1 * var(--space-md));
 	padding: var(--space-xs) 0;
 }
 
 .memory-item {
 	padding: var(--space-sm) var(--space-md);
 	border-bottom: 1px solid var(--sig-border);
-	cursor: default;
-	transition: background var(--dur) var(--ease);
 }
 
 .memory-item:hover {
@@ -221,8 +281,7 @@ body {
 
 .memory-content {
 	font-size: var(--font-size-sm);
-	color: var(--sig-text);
-	line-height: 1.5;
+	line-height: 1.45;
 	display: -webkit-box;
 	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;
@@ -239,10 +298,10 @@ body {
 }
 
 .memory-tag {
-	background: var(--sig-surface-raised);
-	border: 1px solid var(--sig-border);
-	padding: 0 4px;
 	font-size: 9px;
+	padding: 0 4px;
+	border: 1px solid var(--sig-border);
+	background: var(--sig-surface-raised);
 	text-transform: uppercase;
 	letter-spacing: 0.04em;
 }
@@ -251,30 +310,29 @@ body {
 	color: var(--sig-accent);
 }
 
-/* === Empty / Loading / Error states === */
 .state-message {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
-	padding: var(--space-xl) var(--space-md);
 	text-align: center;
-	gap: var(--space-sm);
+	padding: 20px 16px;
+	gap: 6px;
 }
 
 .state-message-title {
 	font-family: var(--font-display);
 	font-size: var(--font-size-base);
 	font-weight: 600;
-	color: var(--sig-text-bright);
 	text-transform: uppercase;
-	letter-spacing: 0.04em;
+	letter-spacing: 0.05em;
+	color: var(--sig-text-bright);
 }
 
 .state-message-body {
 	font-size: var(--font-size-sm);
 	color: var(--sig-text-muted);
-	max-width: 240px;
+	max-width: 260px;
 }
 
 .loading-pulse {
@@ -282,16 +340,10 @@ body {
 }
 
 @keyframes pulse {
-	0%,
-	100% {
-		opacity: 1;
-	}
-	50% {
-		opacity: 0.4;
-	}
+	0%, 100% { opacity: 1; }
+	50% { opacity: 0.4; }
 }
 
-/* === Footer === */
 .footer {
 	display: flex;
 	align-items: center;
@@ -303,15 +355,13 @@ body {
 
 .footer-link {
 	font-size: var(--font-size-xs);
-	color: var(--sig-accent);
-	text-decoration: none;
-	text-transform: uppercase;
-	letter-spacing: 0.06em;
-	cursor: pointer;
 	background: none;
 	border: none;
 	font-family: var(--font-mono);
-	transition: color var(--dur) var(--ease);
+	text-transform: uppercase;
+	letter-spacing: 0.07em;
+	color: var(--sig-accent);
+	cursor: pointer;
 }
 
 .footer-link:hover {

--- a/packages/extension/src/popup/popup.css
+++ b/packages/extension/src/popup/popup.css
@@ -163,7 +163,20 @@ body {
 	color: var(--sig-text-muted);
 }
 
-.nav-grid,
+.nav-row {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	gap: 6px;
+}
+
+.nav-select {
+	min-width: 0;
+}
+
+.nav-open-btn {
+	min-width: 68px;
+}
+
 .tool-grid {
 	display: grid;
 	grid-template-columns: 1fr 1fr;
@@ -195,6 +208,12 @@ body {
 }
 
 .tools-section {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.tool-note-section {
 	display: flex;
 	flex-direction: column;
 	gap: 6px;

--- a/packages/extension/src/popup/popup.css
+++ b/packages/extension/src/popup/popup.css
@@ -214,9 +214,13 @@ body {
 }
 
 .tool-note-section {
-	display: flex;
+	display: none;
 	flex-direction: column;
 	gap: 6px;
+}
+
+.tool-note-section.is-visible {
+	display: flex;
 }
 
 .tool-note-input {
@@ -234,6 +238,10 @@ body {
 	margin-top: 2px;
 }
 
+.tool-grid-single {
+	grid-template-columns: 1fr;
+}
+
 .tool-status {
 	font-size: var(--font-size-xs);
 	color: var(--sig-text-muted);
@@ -248,45 +256,18 @@ body {
 	color: var(--sig-danger);
 }
 
-.overview-section {
-	flex: 1;
-	display: flex;
-	flex-direction: column;
-	min-height: 0;
-	padding-bottom: 0;
-}
-
-.stats-bar {
-	display: flex;
-	gap: var(--space-md);
-	padding: 0 0 var(--space-sm);
-}
-
-.stat {
-	display: flex;
-	flex-direction: column;
-}
-
-.stat-value {
-	font-family: var(--font-display);
-	font-size: var(--font-size-lg);
-	font-weight: 600;
-	color: var(--sig-text-bright);
-}
-
-.stat-label {
-	font-size: var(--font-size-xs);
-	text-transform: uppercase;
-	letter-spacing: 0.06em;
-	color: var(--sig-text-muted);
-}
-
 .memory-list {
 	flex: 1;
 	overflow-y: auto;
 	border-top: 1px solid var(--sig-border);
 	margin: 0 calc(-1 * var(--space-md));
 	padding: var(--space-xs) 0;
+}
+
+.memory-list--search {
+	flex: 0 0 auto;
+	max-height: 170px;
+	min-height: 82px;
 }
 
 .memory-item {
@@ -363,26 +344,3 @@ body {
 	50% { opacity: 0.4; }
 }
 
-.footer {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	padding: var(--space-sm) var(--space-md);
-	border-top: 1px solid var(--sig-border);
-	background: var(--sig-surface);
-}
-
-.footer-link {
-	font-size: var(--font-size-xs);
-	background: none;
-	border: none;
-	font-family: var(--font-mono);
-	text-transform: uppercase;
-	letter-spacing: 0.07em;
-	color: var(--sig-accent);
-	cursor: pointer;
-}
-
-.footer-link:hover {
-	color: var(--sig-accent-hover);
-}

--- a/packages/extension/src/popup/popup.ts
+++ b/packages/extension/src/popup/popup.ts
@@ -504,16 +504,13 @@ async function init(): Promise<void> {
 			videos: context.videos,
 			audio: context.audio,
 			files: context.files,
-			dispatchToHarness: true,
+			dispatchToHarness: false,
 		});
 
-		if (browserResult.success && browserResult.dispatched) {
-			setToolStatus(toolStatus, "Page sent to Signet.", "success");
-			return;
-		}
-
-		if (browserResult.memoryStored && !browserResult.dispatched) {
-			setToolStatus(toolStatus, "Saved to memory. Opening harness fallback...", "neutral");
+		if (browserResult.memoryStored) {
+			setToolStatus(toolStatus, "Saved to memory. Opening Signet OS...", "neutral");
+		} else {
+			setToolStatus(toolStatus, "Opening Signet OS...", "neutral");
 		}
 
 		await sendToHarness(payload, toolStatus, true);
@@ -576,12 +573,13 @@ async function init(): Promise<void> {
 			videos: context.videos,
 			audio: context.audio,
 			files: context.files,
-			dispatchToHarness: true,
+			dispatchToHarness: false,
 		});
 
-		if (browserResult.success && browserResult.dispatched) {
-			setToolStatus(toolStatus, "Selection sent to Signet.", "success");
-			return;
+		if (browserResult.memoryStored) {
+			setToolStatus(toolStatus, "Saved selection. Opening Signet OS...", "neutral");
+		} else {
+			setToolStatus(toolStatus, "Opening Signet OS...", "neutral");
 		}
 
 		await sendToHarness(payload, toolStatus, true);

--- a/packages/extension/src/popup/popup.ts
+++ b/packages/extension/src/popup/popup.ts
@@ -309,12 +309,16 @@ async function init(): Promise<void> {
 	const openDashboard = document.getElementById("open-dashboard");
 	const openOptions = document.getElementById("open-options");
 	const toolStatus = document.getElementById("tool-status");
+	const navTargetSelect = document.getElementById("nav-target-select") as HTMLSelectElement | null;
+	const navOpenTargetBtn = document.getElementById("nav-open-target") as HTMLButtonElement | null;
+	const noteSection = document.getElementById("tool-note-section") as HTMLDivElement | null;
 	const noteInput = document.getElementById("tool-note-input") as HTMLTextAreaElement | null;
 	const transcribeFormat = document.getElementById("transcribe-format") as HTMLSelectElement | null;
 
 	const capturePageBtn = document.getElementById("tool-capture-page") as HTMLButtonElement | null;
 	const saveBookmarkBtn = document.getElementById("tool-save-bookmark") as HTMLButtonElement | null;
 	const writeNoteBtn = document.getElementById("tool-write-note") as HTMLButtonElement | null;
+	const openOsChatBtn = document.getElementById("tool-open-os-chat") as HTMLButtonElement | null;
 	const sendPageBtn = document.getElementById("tool-send-page") as HTMLButtonElement | null;
 	const transcribeBtn = document.getElementById("tool-transcribe-highlight") as HTMLButtonElement | null;
 	const sendSelectionBtn = document.getElementById("tool-send-selection") as HTMLButtonElement | null;
@@ -330,11 +334,15 @@ async function init(): Promise<void> {
 		!openDashboard ||
 		!openOptions ||
 		!toolStatus ||
+		!navTargetSelect ||
+		!navOpenTargetBtn ||
+		!noteSection ||
 		!noteInput ||
 		!transcribeFormat ||
 		!capturePageBtn ||
 		!saveBookmarkBtn ||
 		!writeNoteBtn ||
+		!openOsChatBtn ||
 		!sendPageBtn ||
 		!transcribeBtn ||
 		!sendSelectionBtn
@@ -342,24 +350,22 @@ async function init(): Promise<void> {
 		return;
 	}
 
-	const navButtons = Array.from(document.querySelectorAll<HTMLButtonElement>("[data-nav-target]"));
 	const memoryListEl = memoryList as HTMLElement;
 	const memoriesStat = memoriesStatEl as HTMLElement;
 	const embeddedStat = embeddedStatEl as HTMLElement;
 	const pipelineStat = pipelineStatEl as HTMLElement;
 	const searchInputEl = searchInput as HTMLInputElement;
+	const noteSectionEl = noteSection as HTMLDivElement;
 
 	const openDashboardHash = async (hash = ""): Promise<void> => {
 		const cfg = await getConfig();
 		chrome.tabs.create({ url: buildDashboardUrl(cfg.daemonUrl, hash) });
 	};
 
-	for (const navButton of navButtons) {
-		navButton.addEventListener("click", () => {
-			const target = navButton.dataset.navTarget ?? "";
-			void openDashboardHash(target);
-		});
-	}
+	navOpenTargetBtn.addEventListener("click", () => {
+		const target = navTargetSelect.value || "home";
+		void openDashboardHash(target);
+	});
 
 	openDashboard.addEventListener("click", () => {
 		void openDashboardHash();
@@ -368,6 +374,18 @@ async function init(): Promise<void> {
 	openOptions.addEventListener("click", () => {
 		chrome.runtime.openOptionsPage();
 	});
+
+	openOsChatBtn.addEventListener("click", () => {
+		void openDashboardHash("os");
+	});
+
+	let noteSectionVisible = false;
+	const setNoteSectionVisible = (visible: boolean): void => {
+		noteSectionVisible = visible;
+		noteSectionEl.hidden = !visible;
+		writeNoteBtn.textContent = visible ? "Save Note" : "Write Note";
+	};
+	setNoteSectionVisible(false);
 
 	let recentMemories: readonly Memory[] = [];
 	let online = false;
@@ -460,6 +478,13 @@ async function init(): Promise<void> {
 	});
 
 	writeNoteBtn.addEventListener("click", async () => {
+		if (!noteSectionVisible) {
+			setNoteSectionVisible(true);
+			noteInput.focus();
+			setToolStatus(toolStatus, "Note editor opened.");
+			return;
+		}
+
 		const note = noteInput.value.trim();
 		if (!note) {
 			setToolStatus(toolStatus, "Write a note first.", "error");
@@ -479,6 +504,7 @@ async function init(): Promise<void> {
 		if (result.success) {
 			setToolStatus(toolStatus, "Note saved to Signet memory.", "success");
 			noteInput.value = "";
+			setNoteSectionVisible(false);
 			if (online) await refreshOverview();
 		} else {
 			setToolStatus(toolStatus, "Note save failed.", "error");

--- a/packages/extension/src/popup/popup.ts
+++ b/packages/extension/src/popup/popup.ts
@@ -1,20 +1,22 @@
 /**
  * Signet popup entry point
- * New flow: Header → Memory Search → Navigator → Tools → Overview
+ * Flow: Header → Memory Search → Navigator → Tools
  */
 
-import { checkHealth, dispatchBrowserTool, getIdentity, getMemories, rememberMemory } from "../shared/api.js";
+import { checkHealth, dispatchBrowserTool, rememberMemory } from "../shared/api.js";
 import { getConfig } from "../shared/config.js";
 import { applyTheme, watchSystemTheme } from "../shared/theme.js";
-import type { Memory } from "../shared/types.js";
 import { initHealthBadge } from "./components/health-badge.js";
-import { renderLoading, renderMemories, renderOffline, renderSearchEmpty } from "./components/memory-list.js";
-import { updateStats } from "./components/memory-stats.js";
+import {
+	renderLoading,
+	renderMemories,
+	renderOffline,
+	renderSearchEmpty,
+	renderSearchPrompt,
+} from "./components/memory-list.js";
 import { initSearch } from "./components/search-bar.js";
 
 type ToolTone = "neutral" | "success" | "error";
-
-type TranscribeFormat = "summary" | "bullet" | "checklist" | "json";
 
 interface PageContext {
 	readonly pageTitle: string;
@@ -131,45 +133,6 @@ async function getPageContext(): Promise<PageContext> {
 	};
 }
 
-function transcribeSelection(text: string, format: TranscribeFormat, identityName: string): string {
-	const cleaned = text.trim();
-	if (!cleaned) return "";
-
-	if (format === "json") {
-		return JSON.stringify(
-			{
-				agent: identityName,
-				type: "transcription",
-				summary: cleaned.slice(0, 220),
-				length: cleaned.length,
-				timestamp: new Date().toISOString(),
-				content: cleaned,
-			},
-			null,
-			2,
-		);
-	}
-
-	const sentences = cleaned
-		.split(/(?<=[.!?])\s+/)
-		.map((part) => part.trim())
-		.filter(Boolean)
-		.slice(0, 8);
-
-	if (format === "bullet") {
-		const items = sentences.length > 0 ? sentences : [cleaned];
-		return items.map((item) => `• ${item}`).join("\n");
-	}
-
-	if (format === "checklist") {
-		const items = sentences.length > 0 ? sentences : [cleaned];
-		return items.map((item) => `- [ ] ${item}`).join("\n");
-	}
-
-	const lead = sentences.length > 0 ? sentences.slice(0, 2).join(" ") : cleaned;
-	return `${lead}\n\nTranscribed by ${identityName}.`;
-}
-
 function formatPageCapture(context: PageContext): string {
 	return [
 		"[Signet Page Capture]",
@@ -218,36 +181,6 @@ function formatHarnessPayload(context: PageContext, note: string): string {
 		"",
 		"Please process this payload in Signet harness context.",
 	].join("\n");
-}
-
-function formatSelectionBundle(context: PageContext): string {
-	const lines: string[] = [
-		"--- signet-selection-bundle.txt ---",
-		`source_title: ${context.pageTitle || "Untitled"}`,
-		`source_url: ${context.pageUrl || "unknown"}`,
-		`created_at: ${new Date().toISOString()}`,
-		"",
-		"## Text",
-		context.selectedText || "(none)",
-		"",
-		"## Links",
-		...(context.links.length > 0 ? context.links : ["(none)"]),
-		"",
-		"## Images",
-		...(context.images.length > 0 ? context.images : ["(none)"]),
-		"",
-		"## Videos",
-		...(context.videos.length > 0 ? context.videos : ["(none)"]),
-		"",
-		"## Audio",
-		...(context.audio.length > 0 ? context.audio : ["(none)"]),
-		"",
-		"## Files",
-		...(context.files.length > 0
-			? context.files.map((file) => `${file.name} (${file.type || "unknown"}, ${file.size} bytes)`)
-			: ["(none)"]),
-	];
-	return lines.join("\n");
 }
 
 async function copyToClipboard(text: string): Promise<boolean> {
@@ -301,9 +234,6 @@ async function init(): Promise<void> {
 
 	const healthDot = document.getElementById("health-dot");
 	const versionEl = document.getElementById("version");
-	const memoriesStatEl = document.getElementById("stat-memories");
-	const embeddedStatEl = document.getElementById("stat-embedded");
-	const pipelineStatEl = document.getElementById("stat-pipeline");
 	const searchInput = document.getElementById("search-input") as HTMLInputElement | null;
 	const memoryList = document.getElementById("memory-list");
 	const openDashboard = document.getElementById("open-dashboard");
@@ -313,22 +243,16 @@ async function init(): Promise<void> {
 	const navOpenTargetBtn = document.getElementById("nav-open-target") as HTMLButtonElement | null;
 	const noteSection = document.getElementById("tool-note-section") as HTMLDivElement | null;
 	const noteInput = document.getElementById("tool-note-input") as HTMLTextAreaElement | null;
-	const transcribeFormat = document.getElementById("transcribe-format") as HTMLSelectElement | null;
 
 	const capturePageBtn = document.getElementById("tool-capture-page") as HTMLButtonElement | null;
 	const saveBookmarkBtn = document.getElementById("tool-save-bookmark") as HTMLButtonElement | null;
 	const writeNoteBtn = document.getElementById("tool-write-note") as HTMLButtonElement | null;
 	const openOsChatBtn = document.getElementById("tool-open-os-chat") as HTMLButtonElement | null;
 	const sendPageBtn = document.getElementById("tool-send-page") as HTMLButtonElement | null;
-	const transcribeBtn = document.getElementById("tool-transcribe-highlight") as HTMLButtonElement | null;
-	const sendSelectionBtn = document.getElementById("tool-send-selection") as HTMLButtonElement | null;
 
 	if (
 		!healthDot ||
 		!versionEl ||
-		!memoriesStatEl ||
-		!embeddedStatEl ||
-		!pipelineStatEl ||
 		!searchInput ||
 		!memoryList ||
 		!openDashboard ||
@@ -338,22 +262,16 @@ async function init(): Promise<void> {
 		!navOpenTargetBtn ||
 		!noteSection ||
 		!noteInput ||
-		!transcribeFormat ||
 		!capturePageBtn ||
 		!saveBookmarkBtn ||
 		!writeNoteBtn ||
 		!openOsChatBtn ||
-		!sendPageBtn ||
-		!transcribeBtn ||
-		!sendSelectionBtn
+		!sendPageBtn
 	) {
 		return;
 	}
 
 	const memoryListEl = memoryList as HTMLElement;
-	const memoriesStat = memoriesStatEl as HTMLElement;
-	const embeddedStat = embeddedStatEl as HTMLElement;
-	const pipelineStat = pipelineStatEl as HTMLElement;
 	const searchInputEl = searchInput as HTMLInputElement;
 	const noteSectionEl = noteSection as HTMLDivElement;
 
@@ -383,29 +301,19 @@ async function init(): Promise<void> {
 	const setNoteSectionVisible = (visible: boolean): void => {
 		noteSectionVisible = visible;
 		noteSectionEl.hidden = !visible;
+		noteSectionEl.classList.toggle("is-visible", visible);
 		writeNoteBtn.textContent = visible ? "Save Note" : "Write Note";
 	};
 	setNoteSectionVisible(false);
 
-	let recentMemories: readonly Memory[] = [];
 	let online = false;
 
 	async function refreshOverview(): Promise<void> {
 		if (!online) {
 			renderOffline(memoryListEl);
-			memoriesStat.textContent = "--";
-			embeddedStat.textContent = "--";
-			pipelineStat.textContent = "--";
 			return;
 		}
-
-		const memoryResult = await getMemories(10, 0);
-		recentMemories = memoryResult.memories;
-		await updateStats(memoryResult.stats, memoriesStat, embeddedStat, pipelineStat);
-
-		if (searchInputEl.value.trim().length === 0) {
-			renderMemories(memoryListEl, recentMemories);
-		}
+		renderSearchPrompt(memoryListEl);
 	}
 
 	renderLoading(memoryListEl);
@@ -419,9 +327,6 @@ async function init(): Promise<void> {
 		await refreshOverview();
 	} else {
 		renderOffline(memoryListEl);
-		memoriesStat.textContent = "--";
-		embeddedStat.textContent = "--";
-		pipelineStat.textContent = "--";
 	}
 
 	initSearch(
@@ -434,7 +339,11 @@ async function init(): Promise<void> {
 			}
 		},
 		() => {
-			renderMemories(memoryListEl, recentMemories);
+			if (!online) {
+				renderOffline(memoryListEl);
+				return;
+			}
+			renderSearchPrompt(memoryListEl);
 		},
 	);
 
@@ -535,75 +444,6 @@ async function init(): Promise<void> {
 
 		if (browserResult.memoryStored) {
 			setToolStatus(toolStatus, "Saved to memory. Opening Signet OS...", "neutral");
-		} else {
-			setToolStatus(toolStatus, "Opening Signet OS...", "neutral");
-		}
-
-		await sendToHarness(payload, toolStatus, true);
-	});
-
-	transcribeBtn.addEventListener("click", async () => {
-		setToolStatus(toolStatus, "Transcribing highlight...");
-		const context = await getPageContext();
-		if (!context.selectedText.trim()) {
-			setToolStatus(toolStatus, "Highlight text on the page first.", "error");
-			return;
-		}
-
-		const identity = await getIdentity();
-		const identityName = identity?.name ?? "Signet Agent";
-		const format = (transcribeFormat.value as TranscribeFormat) || "summary";
-		const transcription = transcribeSelection(context.selectedText, format, identityName);
-
-		if (!transcription) {
-			setToolStatus(toolStatus, "Could not transcribe selection.", "error");
-			return;
-		}
-
-		noteInput.value = transcription;
-		const result = await rememberMemory({
-			content: [
-				"[Signet Transcribe]",
-				`Format: ${format}`,
-				`Source: ${context.pageTitle} (${context.pageUrl})`,
-				"",
-				transcription,
-			].join("\n"),
-			tags: "transcribe,browser-extension",
-			importance: 0.7,
-			type: "note",
-			source_type: "browser-extension",
-		});
-
-		if (result.success) {
-			setToolStatus(toolStatus, "Transcribed and saved to Signet.", "success");
-			if (online) await refreshOverview();
-		} else {
-			setToolStatus(toolStatus, "Transcription save failed.", "error");
-		}
-	});
-
-	sendSelectionBtn.addEventListener("click", async () => {
-		setToolStatus(toolStatus, "Packaging selection for Signet...");
-		const context = await getPageContext();
-		const payload = formatSelectionBundle(context);
-
-		const browserResult = await dispatchBrowserTool({
-			action: "send-selection",
-			payload,
-			pageTitle: context.pageTitle,
-			pageUrl: context.pageUrl,
-			selectedText: context.selectedText,
-			links: context.links,
-			images: context.images,
-			videos: context.videos,
-			audio: context.audio,
-			files: context.files,
-			dispatchToHarness: false,
-		});
-
-		if (browserResult.memoryStored) {
-			setToolStatus(toolStatus, "Saved selection. Opening Signet OS...", "neutral");
 		} else {
 			setToolStatus(toolStatus, "Opening Signet OS...", "neutral");
 		}

--- a/packages/extension/src/popup/popup.ts
+++ b/packages/extension/src/popup/popup.ts
@@ -1,18 +1,296 @@
 /**
  * Signet popup entry point
- * Orchestrates all popup components
+ * New flow: Header → Memory Search → Navigator → Tools → Overview
  */
 
-import { checkHealth, getMemories } from "../shared/api.js";
+import { checkHealth, dispatchBrowserTool, getIdentity, getMemories, rememberMemory } from "../shared/api.js";
 import { getConfig } from "../shared/config.js";
 import { applyTheme, watchSystemTheme } from "../shared/theme.js";
+import type { Memory } from "../shared/types.js";
 import { initHealthBadge } from "./components/health-badge.js";
 import { renderLoading, renderMemories, renderOffline, renderSearchEmpty } from "./components/memory-list.js";
 import { updateStats } from "./components/memory-stats.js";
 import { initSearch } from "./components/search-bar.js";
 
+type ToolTone = "neutral" | "success" | "error";
+
+type TranscribeFormat = "summary" | "bullet" | "checklist" | "json";
+
+interface PageContext {
+	readonly pageTitle: string;
+	readonly pageUrl: string;
+	readonly selectedText: string;
+	readonly links: readonly string[];
+	readonly images: readonly string[];
+	readonly videos: readonly string[];
+	readonly audio: readonly string[];
+	readonly files: readonly { name: string; type: string; size: number }[];
+}
+
+interface InjectResponse {
+	readonly ok: boolean;
+	readonly tabId?: number;
+	readonly error?: string;
+}
+
+function normalizeBaseUrl(url: string): string {
+	return url.replace(/\/$/, "");
+}
+
+function buildDashboardUrl(baseUrl: string, hash = ""): string {
+	const cleaned = normalizeBaseUrl(baseUrl);
+	if (!hash) return cleaned;
+	return `${cleaned}/#${hash}`;
+}
+
+function setToolStatus(el: HTMLElement, message: string, tone: ToolTone = "neutral"): void {
+	el.textContent = message;
+	if (tone === "neutral") {
+		el.removeAttribute("data-tone");
+		return;
+	}
+	el.setAttribute("data-tone", tone);
+}
+
+async function getActiveTab(): Promise<chrome.tabs.Tab | null> {
+	return new Promise((resolve) => {
+		chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+			resolve(tabs[0] ?? null);
+		});
+	});
+}
+
+async function sendTabMessage<T>(tabId: number, message: unknown, timeoutMs = 5000): Promise<T | null> {
+	return new Promise((resolve) => {
+		let settled = false;
+		const timeout = setTimeout(() => {
+			if (settled) return;
+			settled = true;
+			resolve(null);
+		}, timeoutMs);
+
+		chrome.tabs.sendMessage(tabId, message, (response) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			if (chrome.runtime.lastError) {
+				resolve(null);
+				return;
+			}
+			resolve((response as T | null) ?? null);
+		});
+	});
+}
+
+async function sendRuntimeMessage<T>(message: unknown, timeoutMs = 12000): Promise<T | null> {
+	return new Promise((resolve) => {
+		let settled = false;
+		const timeout = setTimeout(() => {
+			if (settled) return;
+			settled = true;
+			resolve(null);
+		}, timeoutMs);
+
+		chrome.runtime.sendMessage(message, (response) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			if (chrome.runtime.lastError) {
+				resolve(null);
+				return;
+			}
+			resolve((response as T | null) ?? null);
+		});
+	});
+}
+
+async function getPageContext(): Promise<PageContext> {
+	const activeTab = await getActiveTab();
+	const fallback: PageContext = {
+		pageTitle: activeTab?.title ?? "Untitled page",
+		pageUrl: activeTab?.url ?? "",
+		selectedText: "",
+		links: [],
+		images: [],
+		videos: [],
+		audio: [],
+		files: [],
+	};
+
+	if (!activeTab?.id) {
+		return fallback;
+	}
+
+	const context = await sendTabMessage<PageContext>(activeTab.id, { action: "collect-page-context" });
+	if (!context) return fallback;
+	return {
+		...fallback,
+		...context,
+		pageTitle: context.pageTitle || fallback.pageTitle,
+		pageUrl: context.pageUrl || fallback.pageUrl,
+	};
+}
+
+function transcribeSelection(text: string, format: TranscribeFormat, identityName: string): string {
+	const cleaned = text.trim();
+	if (!cleaned) return "";
+
+	if (format === "json") {
+		return JSON.stringify(
+			{
+				agent: identityName,
+				type: "transcription",
+				summary: cleaned.slice(0, 220),
+				length: cleaned.length,
+				timestamp: new Date().toISOString(),
+				content: cleaned,
+			},
+			null,
+			2,
+		);
+	}
+
+	const sentences = cleaned
+		.split(/(?<=[.!?])\s+/)
+		.map((part) => part.trim())
+		.filter(Boolean)
+		.slice(0, 8);
+
+	if (format === "bullet") {
+		const items = sentences.length > 0 ? sentences : [cleaned];
+		return items.map((item) => `• ${item}`).join("\n");
+	}
+
+	if (format === "checklist") {
+		const items = sentences.length > 0 ? sentences : [cleaned];
+		return items.map((item) => `- [ ] ${item}`).join("\n");
+	}
+
+	const lead = sentences.length > 0 ? sentences.slice(0, 2).join(" ") : cleaned;
+	return `${lead}\n\nTranscribed by ${identityName}.`;
+}
+
+function formatPageCapture(context: PageContext): string {
+	return [
+		"[Signet Page Capture]",
+		`Title: ${context.pageTitle || "Untitled"}`,
+		`URL: ${context.pageUrl || "unknown"}`,
+		`Captured At: ${new Date().toISOString()}`,
+		"",
+		context.selectedText ? "Selected Text:" : "Page Note:",
+		context.selectedText || "No text selected; page captured as reference.",
+	].join("\n");
+}
+
+function formatBookmark(context: PageContext): string {
+	return [
+		"[Signet Bookmark]",
+		`Title: ${context.pageTitle || "Untitled"}`,
+		`URL: ${context.pageUrl || "unknown"}`,
+		`Saved At: ${new Date().toISOString()}`,
+	].join("\n");
+}
+
+function formatPageNote(context: PageContext, note: string): string {
+	return [
+		"[Signet Page Note]",
+		`Title: ${context.pageTitle || "Untitled"}`,
+		`URL: ${context.pageUrl || "unknown"}`,
+		"",
+		"User Note:",
+		note,
+		context.selectedText ? `\nSelection Context:\n${context.selectedText}` : "",
+	].join("\n");
+}
+
+function formatHarnessPayload(context: PageContext, note: string): string {
+	return [
+		"--- signet-harness-payload.txt ---",
+		`source_title: ${context.pageTitle || "Untitled"}`,
+		`source_url: ${context.pageUrl || "unknown"}`,
+		`timestamp: ${new Date().toISOString()}`,
+		"",
+		"## User Notes",
+		note || "(none)",
+		"",
+		"## Page Selection",
+		context.selectedText || "(no selected text)",
+		"",
+		"Please process this payload in Signet harness context.",
+	].join("\n");
+}
+
+function formatSelectionBundle(context: PageContext): string {
+	const lines: string[] = [
+		"--- signet-selection-bundle.txt ---",
+		`source_title: ${context.pageTitle || "Untitled"}`,
+		`source_url: ${context.pageUrl || "unknown"}`,
+		`created_at: ${new Date().toISOString()}`,
+		"",
+		"## Text",
+		context.selectedText || "(none)",
+		"",
+		"## Links",
+		...(context.links.length > 0 ? context.links : ["(none)"]),
+		"",
+		"## Images",
+		...(context.images.length > 0 ? context.images : ["(none)"]),
+		"",
+		"## Videos",
+		...(context.videos.length > 0 ? context.videos : ["(none)"]),
+		"",
+		"## Audio",
+		...(context.audio.length > 0 ? context.audio : ["(none)"]),
+		"",
+		"## Files",
+		...(context.files.length > 0
+			? context.files.map((file) => `${file.name} (${file.type || "unknown"}, ${file.size} bytes)`)
+			: ["(none)"]),
+	];
+	return lines.join("\n");
+}
+
+async function copyToClipboard(text: string): Promise<boolean> {
+	try {
+		await navigator.clipboard.writeText(text);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function sendToHarness(payload: string, statusEl: HTMLElement, autoSend = true): Promise<void> {
+	const config = await getConfig();
+	const dashboardUrl = buildDashboardUrl(config.daemonUrl, "os");
+
+	const result = await sendRuntimeMessage<InjectResponse>({
+		action: "open-dashboard-and-inject",
+		url: dashboardUrl,
+		payload,
+		autoSend,
+	});
+
+	if (result?.ok) {
+		setToolStatus(statusEl, "Sent to Signet harness.", "success");
+		return;
+	}
+
+	const copied = await copyToClipboard(payload);
+	if (!result?.tabId) {
+		chrome.tabs.create({ url: dashboardUrl });
+	}
+
+	const reason = result?.error ? ` (${result.error})` : "";
+	setToolStatus(
+		statusEl,
+		copied
+			? `Could not auto-send${reason}. Opened Signet OS and copied payload.`
+			: `Could not auto-send${reason}. Opened Signet OS for manual paste.`,
+		"error",
+	);
+}
+
 async function init(): Promise<void> {
-	// Apply theme
 	const config = await getConfig();
 	applyTheme(document.documentElement, config.theme);
 	watchSystemTheme(() => {
@@ -21,7 +299,6 @@ async function init(): Promise<void> {
 		}
 	});
 
-	// DOM refs
 	const healthDot = document.getElementById("health-dot");
 	const versionEl = document.getElementById("version");
 	const memoriesStatEl = document.getElementById("stat-memories");
@@ -31,6 +308,16 @@ async function init(): Promise<void> {
 	const memoryList = document.getElementById("memory-list");
 	const openDashboard = document.getElementById("open-dashboard");
 	const openOptions = document.getElementById("open-options");
+	const toolStatus = document.getElementById("tool-status");
+	const noteInput = document.getElementById("tool-note-input") as HTMLTextAreaElement | null;
+	const transcribeFormat = document.getElementById("transcribe-format") as HTMLSelectElement | null;
+
+	const capturePageBtn = document.getElementById("tool-capture-page") as HTMLButtonElement | null;
+	const saveBookmarkBtn = document.getElementById("tool-save-bookmark") as HTMLButtonElement | null;
+	const writeNoteBtn = document.getElementById("tool-write-note") as HTMLButtonElement | null;
+	const sendPageBtn = document.getElementById("tool-send-page") as HTMLButtonElement | null;
+	const transcribeBtn = document.getElementById("tool-transcribe-highlight") as HTMLButtonElement | null;
+	const sendSelectionBtn = document.getElementById("tool-send-selection") as HTMLButtonElement | null;
 
 	if (
 		!healthDot ||
@@ -41,67 +328,266 @@ async function init(): Promise<void> {
 		!searchInput ||
 		!memoryList ||
 		!openDashboard ||
-		!openOptions
+		!openOptions ||
+		!toolStatus ||
+		!noteInput ||
+		!transcribeFormat ||
+		!capturePageBtn ||
+		!saveBookmarkBtn ||
+		!writeNoteBtn ||
+		!sendPageBtn ||
+		!transcribeBtn ||
+		!sendSelectionBtn
 	) {
 		return;
 	}
 
-	// Loading state
-	renderLoading(memoryList);
+	const navButtons = Array.from(document.querySelectorAll<HTMLButtonElement>("[data-nav-target]"));
+	const memoryListEl = memoryList as HTMLElement;
+	const memoriesStat = memoriesStatEl as HTMLElement;
+	const embeddedStat = embeddedStatEl as HTMLElement;
+	const pipelineStat = pipelineStatEl as HTMLElement;
+	const searchInputEl = searchInput as HTMLInputElement;
 
-	// Check health first
-	const health = await checkHealth();
-	const isOnline = health !== null && (health.status === "ok" || health.status === "healthy");
+	const openDashboardHash = async (hash = ""): Promise<void> => {
+		const cfg = await getConfig();
+		chrome.tabs.create({ url: buildDashboardUrl(cfg.daemonUrl, hash) });
+	};
 
-	// Health badge
-	const updateHealth = initHealthBadge(healthDot, versionEl);
-	await updateHealth();
-
-	if (!isOnline) {
-		renderOffline(memoryList);
-		memoriesStatEl.textContent = "--";
-		embeddedStatEl.textContent = "--";
-		pipelineStatEl.textContent = "--";
-		return;
+	for (const navButton of navButtons) {
+		navButton.addEventListener("click", () => {
+			const target = navButton.dataset.navTarget ?? "";
+			void openDashboardHash(target);
+		});
 	}
 
-	// Load data
-	let recentMemories = (await getMemories(10, 0)).memories;
-	const { stats } = await getMemories(1, 0);
-
-	// Update stats
-	await updateStats(stats, memoriesStatEl, embeddedStatEl, pipelineStatEl);
-
-	// Render recent memories
-	renderMemories(memoryList, recentMemories);
-
-	// Search
-	let isSearching = false;
-	initSearch(
-		searchInput,
-		(results, query) => {
-			isSearching = true;
-			if (results.length === 0) {
-				renderSearchEmpty(memoryList, query);
-			} else {
-				renderMemories(memoryList, results);
-			}
-		},
-		() => {
-			isSearching = false;
-			renderMemories(memoryList, recentMemories);
-		},
-	);
-
-	// Footer actions
-	openDashboard.addEventListener("click", async () => {
-		const cfg = await getConfig();
-		chrome.tabs.create({ url: cfg.daemonUrl });
+	openDashboard.addEventListener("click", () => {
+		void openDashboardHash();
 	});
 
 	openOptions.addEventListener("click", () => {
 		chrome.runtime.openOptionsPage();
 	});
+
+	let recentMemories: readonly Memory[] = [];
+	let online = false;
+
+	async function refreshOverview(): Promise<void> {
+		if (!online) {
+			renderOffline(memoryListEl);
+			memoriesStat.textContent = "--";
+			embeddedStat.textContent = "--";
+			pipelineStat.textContent = "--";
+			return;
+		}
+
+		const memoryResult = await getMemories(10, 0);
+		recentMemories = memoryResult.memories;
+		await updateStats(memoryResult.stats, memoriesStat, embeddedStat, pipelineStat);
+
+		if (searchInputEl.value.trim().length === 0) {
+			renderMemories(memoryListEl, recentMemories);
+		}
+	}
+
+	renderLoading(memoryListEl);
+
+	const updateHealth = initHealthBadge(healthDot, versionEl);
+	await updateHealth();
+	const health = await checkHealth();
+	online = health !== null && (health.status === "ok" || health.status === "healthy");
+
+	if (online) {
+		await refreshOverview();
+	} else {
+		renderOffline(memoryListEl);
+		memoriesStat.textContent = "--";
+		embeddedStat.textContent = "--";
+		pipelineStat.textContent = "--";
+	}
+
+	initSearch(
+		searchInputEl,
+		(results, query) => {
+			if (results.length === 0) {
+				renderSearchEmpty(memoryListEl, query);
+			} else {
+				renderMemories(memoryListEl, results);
+			}
+		},
+		() => {
+			renderMemories(memoryListEl, recentMemories);
+		},
+	);
+
+	capturePageBtn.addEventListener("click", async () => {
+		setToolStatus(toolStatus, "Capturing page...");
+		const context = await getPageContext();
+		const content = formatPageCapture(context);
+		const result = await rememberMemory({
+			content,
+			tags: "browser,page-capture",
+			importance: 0.6,
+			type: "fact",
+			source_type: "browser-extension",
+		});
+
+		if (result.success) {
+			setToolStatus(toolStatus, "Page captured to Signet memory.", "success");
+			if (online) await refreshOverview();
+		} else {
+			setToolStatus(toolStatus, "Capture failed. Check daemon connectivity.", "error");
+		}
+	});
+
+	saveBookmarkBtn.addEventListener("click", async () => {
+		setToolStatus(toolStatus, "Saving bookmark...");
+		const context = await getPageContext();
+		const result = await rememberMemory({
+			content: formatBookmark(context),
+			tags: "bookmark,browser-extension",
+			importance: 0.55,
+			type: "fact",
+			source_type: "browser-extension",
+		});
+
+		if (result.success) {
+			setToolStatus(toolStatus, "Bookmark saved to Signet.", "success");
+			if (online) await refreshOverview();
+		} else {
+			setToolStatus(toolStatus, "Bookmark save failed.", "error");
+		}
+	});
+
+	writeNoteBtn.addEventListener("click", async () => {
+		const note = noteInput.value.trim();
+		if (!note) {
+			setToolStatus(toolStatus, "Write a note first.", "error");
+			return;
+		}
+
+		setToolStatus(toolStatus, "Saving note...");
+		const context = await getPageContext();
+		const result = await rememberMemory({
+			content: formatPageNote(context, note),
+			tags: "page-note,browser-extension",
+			importance: 0.65,
+			type: "note",
+			source_type: "browser-extension",
+		});
+
+		if (result.success) {
+			setToolStatus(toolStatus, "Note saved to Signet memory.", "success");
+			noteInput.value = "";
+			if (online) await refreshOverview();
+		} else {
+			setToolStatus(toolStatus, "Note save failed.", "error");
+		}
+	});
+
+	sendPageBtn.addEventListener("click", async () => {
+		setToolStatus(toolStatus, "Preparing page payload...");
+		const context = await getPageContext();
+		const note = noteInput.value.trim();
+		const payload = formatHarnessPayload(context, note);
+
+		setToolStatus(toolStatus, "Sending page to Signet browser tool...");
+		const browserResult = await dispatchBrowserTool({
+			action: "send-page",
+			payload,
+			pageTitle: context.pageTitle,
+			pageUrl: context.pageUrl,
+			note,
+			selectedText: context.selectedText,
+			links: context.links,
+			images: context.images,
+			videos: context.videos,
+			audio: context.audio,
+			files: context.files,
+			dispatchToHarness: true,
+		});
+
+		if (browserResult.success && browserResult.dispatched) {
+			setToolStatus(toolStatus, "Page sent to Signet.", "success");
+			return;
+		}
+
+		if (browserResult.memoryStored && !browserResult.dispatched) {
+			setToolStatus(toolStatus, "Saved to memory. Opening harness fallback...", "neutral");
+		}
+
+		await sendToHarness(payload, toolStatus, true);
+	});
+
+	transcribeBtn.addEventListener("click", async () => {
+		setToolStatus(toolStatus, "Transcribing highlight...");
+		const context = await getPageContext();
+		if (!context.selectedText.trim()) {
+			setToolStatus(toolStatus, "Highlight text on the page first.", "error");
+			return;
+		}
+
+		const identity = await getIdentity();
+		const identityName = identity?.name ?? "Signet Agent";
+		const format = (transcribeFormat.value as TranscribeFormat) || "summary";
+		const transcription = transcribeSelection(context.selectedText, format, identityName);
+
+		if (!transcription) {
+			setToolStatus(toolStatus, "Could not transcribe selection.", "error");
+			return;
+		}
+
+		noteInput.value = transcription;
+		const result = await rememberMemory({
+			content: [
+				"[Signet Transcribe]",
+				`Format: ${format}`,
+				`Source: ${context.pageTitle} (${context.pageUrl})`,
+				"",
+				transcription,
+			].join("\n"),
+			tags: "transcribe,browser-extension",
+			importance: 0.7,
+			type: "note",
+			source_type: "browser-extension",
+		});
+
+		if (result.success) {
+			setToolStatus(toolStatus, "Transcribed and saved to Signet.", "success");
+			if (online) await refreshOverview();
+		} else {
+			setToolStatus(toolStatus, "Transcription save failed.", "error");
+		}
+	});
+
+	sendSelectionBtn.addEventListener("click", async () => {
+		setToolStatus(toolStatus, "Packaging selection for Signet...");
+		const context = await getPageContext();
+		const payload = formatSelectionBundle(context);
+
+		const browserResult = await dispatchBrowserTool({
+			action: "send-selection",
+			payload,
+			pageTitle: context.pageTitle,
+			pageUrl: context.pageUrl,
+			selectedText: context.selectedText,
+			links: context.links,
+			images: context.images,
+			videos: context.videos,
+			audio: context.audio,
+			files: context.files,
+			dispatchToHarness: true,
+		});
+
+		if (browserResult.success && browserResult.dispatched) {
+			setToolStatus(toolStatus, "Selection sent to Signet.", "success");
+			return;
+		}
+
+		await sendToHarness(payload, toolStatus, true);
+	});
 }
 
-document.addEventListener("DOMContentLoaded", init);
+document.addEventListener("DOMContentLoaded", () => {
+	void init();
+});

--- a/packages/extension/src/shared/api.ts
+++ b/packages/extension/src/shared/api.ts
@@ -85,11 +85,23 @@ export async function getMemories(
 }
 
 export async function recallMemories(query: string, limit = 10): Promise<RecallResult> {
-	const result = await fetchApi<RecallResult>("/api/memory/recall", {
-		method: "POST",
-		body: JSON.stringify({ query, limit }),
-	});
-	return result ?? { memories: [], query, count: 0 };
+	const result = await fetchApi<{ memories?: Memory[]; results?: Memory[]; query?: string; count?: number }>(
+		"/api/memory/recall",
+		{
+			method: "POST",
+			body: JSON.stringify({ query, limit }),
+		},
+	);
+	const memories = Array.isArray(result?.memories)
+		? result.memories
+		: Array.isArray(result?.results)
+			? result.results
+			: [];
+	return {
+		memories,
+		query: result?.query ?? query,
+		count: typeof result?.count === "number" ? result.count : memories.length,
+	};
 }
 
 export async function rememberMemory(request: RememberRequest): Promise<{ success: boolean; id?: string }> {

--- a/packages/extension/src/shared/api.ts
+++ b/packages/extension/src/shared/api.ts
@@ -5,6 +5,8 @@
 
 import { getConfig } from "./config.js";
 import type {
+	BrowserToolRequest,
+	BrowserToolResult,
 	DaemonStatus,
 	HealthResponse,
 	Identity,
@@ -31,18 +33,24 @@ async function getHeaders(): Promise<Record<string, string>> {
 	return headers;
 }
 
-async function fetchApi<T>(path: string, options?: RequestInit): Promise<T | null> {
+async function fetchApi<T>(path: string, options?: RequestInit, timeoutMs = 10_000): Promise<T | null> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
 	try {
 		const base = await getBaseUrl();
 		const headers = await getHeaders();
 		const response = await fetch(`${base}${path}`, {
 			...options,
 			headers: { ...headers, ...options?.headers },
+			signal: options?.signal ?? controller.signal,
 		});
 		if (!response.ok) return null;
 		return (await response.json()) as T;
 	} catch {
 		return null;
+	} finally {
+		clearTimeout(timeout);
 	}
 }
 
@@ -90,4 +98,20 @@ export async function rememberMemory(request: RememberRequest): Promise<{ succes
 		body: JSON.stringify(request),
 	});
 	return result ?? { success: false };
+}
+
+export async function dispatchBrowserTool(request: BrowserToolRequest): Promise<BrowserToolResult> {
+	const result = await fetchApi<BrowserToolResult>("/api/os/browser-tool", {
+		method: "POST",
+		body: JSON.stringify(request),
+	}, 20_000);
+
+	return (
+		result ?? {
+			success: false,
+			memoryStored: false,
+			dispatched: false,
+			error: "Browser tool dispatch failed",
+		}
+	);
 }

--- a/packages/extension/src/shared/types.ts
+++ b/packages/extension/src/shared/types.ts
@@ -66,6 +66,37 @@ export interface RememberRequest {
 	readonly source_type?: string;
 }
 
+export interface BrowserToolRequest {
+	readonly action:
+		| "send-page"
+		| "send-selection"
+		| "capture-page"
+		| "bookmark-page"
+		| "write-note"
+		| "transcribe-selection";
+	readonly payload: string;
+	readonly pageTitle?: string;
+	readonly pageUrl?: string;
+	readonly note?: string;
+	readonly selectedText?: string;
+	readonly links?: readonly string[];
+	readonly images?: readonly string[];
+	readonly videos?: readonly string[];
+	readonly audio?: readonly string[];
+	readonly files?: readonly { name: string; type: string; size: number }[];
+	readonly dispatchToHarness?: boolean;
+}
+
+export interface BrowserToolResult {
+	readonly success: boolean;
+	readonly memoryStored: boolean;
+	readonly dispatched: boolean;
+	readonly memoryId?: string;
+	readonly response?: string;
+	readonly error?: string;
+	readonly toolCalls?: readonly unknown[];
+}
+
 export type ThemeMode = "auto" | "dark" | "light";
 
 export interface ExtensionConfig {


### PR DESCRIPTION
## Summary
This PR delivers a full OS chat and browser-extension UX/reliability overhaul, including provider/model routing fixes, Ask Signet in-page workflow upgrades, MCP render-window improvements, voice input support, and popup/navigation cleanup.

## Context
The existing branch work solved multiple cross-surface issues (OS chat + extension): unstable model resolution, outdated fallback behavior, missing context-menu/overlay reliability, rough render-window ergonomics, and popup layout regressions. This PR consolidates and rebases those fixes onto latest `main`.

## Changes

### OS Chat / Dashboard
- Added dynamic provider/model discovery and stricter selected-model routing behavior.
- Removed hardcoded persona artifacts and normalized assistant prompting behavior.
- Improved OS chat action flows (remember/transcribe/recall) and chat-linked interactions.
- Added per-response copy action in assistant messages.
- Added robust microphone capture flow with selectable devices and improved listening states.
- Improved light/dark theming behavior with consistent Signet green input/icon accents.
- Refined OS layout: 50/50 chat/render workspace, tabbed multi-render windows, loading/error handling, cleaner headers.
- Enhanced left groups panel (All Apps, All Skills, browser-sync categories, drag/drop into chat, bookmark click-to-open new tab).

### Daemon
- Improved `/api/os/chat` + `/api/os/chat/models` behavior for provider/model reliability.
- Added stronger OpenCode model discovery/execution behavior.
- Hardened MCP probe/widget generation flows and normalized actionable error paths.
- Improved widget generation lifecycle behavior for OS render-window UX.

### Browser Extension
- Added Ask Signet right-click flow with in-page draggable overlay chat.
- Hardened Ask Signet request path via background relay/fallback instead of fragile direct page fetch.
- Added model registry in Ask Signet overlay and aligned theme behavior with system defaults.
- Added per-response copy action in Ask Signet messages.
- Added voice input support for Ask Signet with improved start/stop handling.
- Updated context menu set and behavior (`Send to Signet Os`, `View MCP Servers`, transcribe routing through Ask Signet flow).
- Refactored popup tools/navigation layout, removed deprecated controls, improved notes visibility behavior.
- Fixed popup memory search response parsing and default display behavior.

## Testing
- `bun run check` (dashboard)
- `bun run typecheck && bun run build` (extension)
- `bun run build.ts` (daemon)

## PR Readiness Checklist
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Checklist Status (blue checks)
- 🔵 ✅ Branch rebased on latest `origin/main`
- 🔵 ✅ Working tree clean before push
- 🔵 ✅ Branch pushed: `chore/chrome-extension-rework`
- 🔵 ✅ Local validation commands pass

<img width="1123" height="1058" alt="Screenshot 2026-04-02 at 3 41 05 PM" src="https://github.com/user-attachments/assets/d4bcfce6-2d15-4be8-91eb-21cbec42cecd" />
<img width="1123" height="1058" alt="Screenshot 2026-04-02 at 3 41 25 PM" src="https://github.com/user-attachments/assets/ffba4cea-b43f-438b-8681-93ee4d8687d5" />
<img width="1123" height="1058" alt="Screenshot 2026-04-02 at 3 42 02 PM" src="https://github.com/user-attachments/assets/28bced47-9e4c-4194-8802-6eecfc5ff73d" />
<img width="481" height="810" alt="Screenshot 2026-04-02 at 3 46 58 PM" src="https://github.com/user-attachments/assets/ea870816-0cf6-44c1-8bc0-e5b042697a17" />

