### PR TITLE
fix: ignore generated MEMORY backup markdown files

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -11235,13 +11235,16 @@ function chunkMarkdownHierarchically(
 // These are already distilled and inserted directly into the DB —
 // re-ingesting them through the chunker creates noisy duplicates.
 export const ARTIFACT_FILENAME_RE = /--(?:summary|transcript|compaction|manifest)\.md$/;
+export const MEMORY_BACKUP_FILENAME_RE = /^MEMORY\.(?:backup|bak|pre)-.+\.md$/;
 
 async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 	// Skip MEMORY.md (index file, not content)
 	if (filePath.endsWith("MEMORY.md")) return 0;
 
-	// Skip pipeline artifact files (summaries, transcripts, etc.)
-	if (ARTIFACT_FILENAME_RE.test(basename(filePath))) return 0;
+	const filenameWithExt = basename(filePath);
+
+	// Skip generated MEMORY backups and pipeline artifacts.
+	if (MEMORY_BACKUP_FILENAME_RE.test(filenameWithExt) || ARTIFACT_FILENAME_RE.test(filenameWithExt)) return 0;
 
 	// Read file content
 	let content: string;

--- a/packages/daemon/src/memory-ingest-filter.test.ts
+++ b/packages/daemon/src/memory-ingest-filter.test.ts
@@ -1,15 +1,27 @@
 /**
  * Regression tests for memory ingestion filtering.
  *
- * Verifies that pipeline artifact files (summaries, transcripts, etc.)
- * are excluded from re-ingestion, and that short/degenerate chunks
- * are filtered before hitting the memory API.
+ * Verifies that generated backup/artifact markdown files are excluded from
+ * re-ingestion, and that short/degenerate chunks are filtered before
+ * hitting the memory API.
  */
 
-import { describe, it, expect } from "bun:test";
-import { ARTIFACT_FILENAME_RE } from "./daemon";
+import { describe, expect, it } from "bun:test";
+import { ARTIFACT_FILENAME_RE, MEMORY_BACKUP_FILENAME_RE } from "./daemon";
 
-describe("artifact filename exclusion", () => {
+describe("memory ingest filename exclusion", () => {
+	it("matches MEMORY backup filenames", () => {
+		expect(MEMORY_BACKUP_FILENAME_RE.test("MEMORY.backup-2026-03-31T21-17-05.md")).toBe(true);
+	});
+
+	it("matches MEMORY bak filenames", () => {
+		expect(MEMORY_BACKUP_FILENAME_RE.test("MEMORY.bak-2026-03-31T21-17-05.md")).toBe(true);
+	});
+
+	it("matches MEMORY pre filenames", () => {
+		expect(MEMORY_BACKUP_FILENAME_RE.test("MEMORY.pre-2026-03-31T21-17-05.md")).toBe(true);
+	});
+
 	it("matches summary artifact filenames", () => {
 		expect(ARTIFACT_FILENAME_RE.test("2026-03-01T00-09-52.500Z--eej6phr2ekkn46eo--summary.md")).toBe(true);
 	});
@@ -26,23 +38,30 @@ describe("artifact filename exclusion", () => {
 		expect(ARTIFACT_FILENAME_RE.test("2026-03-01T00-09-53.500Z--o4ebayj7w4fs3grh--manifest.md")).toBe(true);
 	});
 
+	it("does not match MEMORY.md", () => {
+		expect(MEMORY_BACKUP_FILENAME_RE.test("MEMORY.md")).toBe(false);
+		expect(ARTIFACT_FILENAME_RE.test("MEMORY.md")).toBe(false);
+	});
+
 	it("does not match legacy dated memory files", () => {
+		expect(MEMORY_BACKUP_FILENAME_RE.test("2026-01-20.md")).toBe(false);
 		expect(ARTIFACT_FILENAME_RE.test("2026-01-20.md")).toBe(false);
 	});
 
 	it("does not match named memory files", () => {
+		expect(MEMORY_BACKUP_FILENAME_RE.test("2026-02-10-signet.md")).toBe(false);
 		expect(ARTIFACT_FILENAME_RE.test("2026-02-10-signet.md")).toBe(false);
 	});
 
 	it("does not match descriptive session files", () => {
+		expect(MEMORY_BACKUP_FILENAME_RE.test("2026-02-22-dashboard-umap-projection-migration.md")).toBe(false);
 		expect(ARTIFACT_FILENAME_RE.test("2026-02-22-dashboard-umap-projection-migration.md")).toBe(false);
 	});
 
-	it("does not match MEMORY.md", () => {
-		expect(ARTIFACT_FILENAME_RE.test("MEMORY.md")).toBe(false);
-	});
-
 	it("does not match files with artifact kind in the middle of the name", () => {
+		expect(MEMORY_BACKUP_FILENAME_RE.test("2026-03-01-phase-2-pre-compaction-capture-implementation-plan.md")).toBe(
+			false,
+		);
 		expect(ARTIFACT_FILENAME_RE.test("2026-03-01-phase-2-pre-compaction-capture-implementation-plan.md")).toBe(false);
 	});
 });
@@ -66,12 +85,14 @@ describe("chunk content length gate", () => {
 	});
 
 	it("accepts a chunk with substantial body content", () => {
-		const text = "## Section Title\n\nThis chunk contains a meaningful amount of content that describes the system configuration and behavior in enough detail to be useful.";
+		const text =
+			"## Section Title\n\nThis chunk contains a meaningful amount of content that describes the system configuration and behavior in enough detail to be useful.";
 		expect(bodyLength(text, "## Section Title")).toBeGreaterThanOrEqual(80);
 	});
 
 	it("accepts a headerless chunk with enough content", () => {
-		const text = "This standalone paragraph contains enough detail about the project's architecture to be worth storing as a memory.";
+		const text =
+			"This standalone paragraph contains enough detail about the project's architecture to be worth storing as a memory.";
 		expect(bodyLength(text, "")).toBeGreaterThanOrEqual(80);
 	});
 


### PR DESCRIPTION
## Summary
Prevent generated `MEMORY.*-*.md` backup files from being re-ingested as memories.

## Context
`writeProjection()` writes timestamped backup files into `memory/` when refreshing `MEMORY.md`. The daemon watcher and startup importer treat markdown files in that directory as ingestible memory content, so those generated backups could create duplicate chunk memories and extraction backlog noise.

## Changes
- add a `MEMORY_BACKUP_FILENAME_RE` guard alongside the existing artifact filename filter
- skip generated `MEMORY.backup-*`, `MEMORY.bak-*`, and `MEMORY.pre-*` files before reading or chunking markdown content
- extend the regression tests to cover positive and negative backup filename cases while preserving the existing artifact coverage

## Testing
- `bun test packages/daemon/src/memory-ingest-filter.test.ts`
- `bun test packages/daemon/src/watcher-ignore.test.ts`
- `bunx @biomejs/biome check packages/daemon/src/memory-ingest-filter.test.ts`
- `bun run build` (from `packages/daemon`)

## Notes
- `bunx tsc -p packages/daemon/tsconfig.json --noEmit` still reports pre-existing unrelated typecheck failures in the daemon package and was not used as a passing gate for this fix.

## Links
- Closes #451
