### PR TITLE
fix(ci): externalize openclaw adapter sqlite dependency

### DIFF
--- a/packages/adapters/openclaw/package.json
+++ b/packages/adapters/openclaw/package.json
@@ -27,7 +27,7 @@
     ]
   },
   "scripts": {
-    "build": "bun build src/index.ts --outdir dist --target node && tsc --emitDeclarationOnly --declaration --outDir dist",
+    "build": "bun build src/index.ts --outdir dist --target node --external better-sqlite3 && tsc --emitDeclarationOnly --declaration --outDir dist",
     "prepack": "bun run build",
     "dev": "bun --watch src/index.ts",
     "test": "bun test"

--- a/tests/integration/docker-build-regression.test.ts
+++ b/tests/integration/docker-build-regression.test.ts
@@ -5,6 +5,20 @@ import { fileURLToPath } from "node:url";
 
 const rootDir = fileURLToPath(new URL("../../", import.meta.url));
 const dockerfile = readFileSync(join(rootDir, "deploy/docker/Dockerfile"), "utf8");
+const openclawPackageJson = JSON.parse(
+	readFileSync(join(rootDir, "packages/adapters/openclaw/package.json"), "utf8"),
+);
+const openclawBuild =
+	typeof openclawPackageJson === "object" &&
+	openclawPackageJson !== null &&
+	"scripts" in openclawPackageJson &&
+	typeof openclawPackageJson.scripts === "object" &&
+	openclawPackageJson.scripts !== null &&
+	"build" in openclawPackageJson.scripts &&
+	typeof openclawPackageJson.scripts.build === "string"
+		? openclawPackageJson.scripts.build
+		: undefined;
+const openclawEntry = readFileSync(join(rootDir, "packages/adapters/openclaw/src/index.ts"), "utf8");
 
 function getBuildCommands(source: string): string[] {
 	return source
@@ -31,5 +45,10 @@ describe("Docker build pipeline regression guard", () => {
 			"build:dashboard",
 			"build:signetai",
 		]);
+	});
+
+	it("keeps the OpenClaw adapter build Docker-safe when bundling @signet/core", () => {
+		expect(openclawEntry).toContain('from "@signet/core"');
+		expect(openclawBuild).toContain("--external better-sqlite3");
 	});
 });


### PR DESCRIPTION
## Summary
Fix Docker Smoke on `main` by making the OpenClaw adapter build safe for the shared dependency pipeline.

## Context
`main` now routes the Docker image build through the shared dependency build sequence, which was the right fix for the earlier Forge connector drift. That exposed a second issue: `@signetai/signet-memory-openclaw` bundles code from `@signet/core`, and its Docker build failed when Bun tried to resolve `better-sqlite3` from the core package during `build:deps`.

## Changes
- externalize `better-sqlite3` in the OpenClaw adapter build script so the adapter follows the same Docker-safe bundling pattern used by other node-targeted packages
- extend the Docker regression test to assert that if the OpenClaw adapter keeps bundling `@signet/core`, its build command must keep `better-sqlite3` externalized

### Key Implementation Details
The adapter entrypoint imports `@signet/core`, which pulls in runtime SQLite code paths. In the Docker build environment, that made Bun attempt to resolve `better-sqlite3` from the core package tree. Marking `better-sqlite3` as external keeps the adapter bundle aligned with the rest of the repo's Node builds and avoids baking an unavailable native dependency into the Docker build step.

## Testing
- `bun test ./tests/integration/docker-build-regression.test.ts`
- `docker build --target build -f deploy/docker/Dockerfile .`
