### PR TITLE
fix: scope sub-agent memory dedupe and synthesis

### DIFF
--- a/packages/cli/src/commands/agent.test.ts
+++ b/packages/cli/src/commands/agent.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+import { registerAgentCommands } from "./agent";
+
+const prevLog = console.log;
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	console.log = prevLog;
+	while (tempDirs.length > 0) {
+		const dir = tempDirs.pop();
+		if (!dir) continue;
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("registerAgentCommands", () => {
+	test("agent add writes canonical nested roster memory config", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "signet-agent-command-"));
+		tempDirs.push(dir);
+		console.log = () => {};
+
+		const program = new Command();
+		registerAgentCommands(program, {
+			AGENTS_DIR: dir,
+			fetchFromDaemon: async () => null,
+		});
+
+		await program.parseAsync(["node", "test", "agent", "add", "writer", "--memory", "group", "--group", "writers"]);
+
+		const yaml = readFileSync(join(dir, "agent.yaml"), "utf-8");
+		expect(yaml).toContain("- name: writer");
+		expect(yaml).toContain("type: group");
+		expect(yaml).toContain("group: writers");
+		expect(existsSync(join(dir, "agents", "writer", "SOUL.md"))).toBe(true);
+		expect(existsSync(join(dir, "agents", "writer", "IDENTITY.md"))).toBe(true);
+	});
+
+	test("agent list reads canonical nested roster memory config while daemon is offline", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "signet-agent-command-"));
+		tempDirs.push(dir);
+		console.log = () => {};
+
+		const addProgram = new Command();
+		registerAgentCommands(addProgram, {
+			AGENTS_DIR: dir,
+			fetchFromDaemon: async () => null,
+		});
+		await addProgram.parseAsync(["node", "test", "agent", "add", "writer", "--memory", "group", "--group", "writers"]);
+
+		const lines: string[] = [];
+		console.log = (line?: unknown) => {
+			lines.push(String(line ?? ""));
+		};
+		const listProgram = new Command();
+		registerAgentCommands(listProgram, {
+			AGENTS_DIR: dir,
+			fetchFromDaemon: async () => null,
+		});
+
+		await listProgram.parseAsync(["node", "test", "agent", "list"]);
+
+		expect(lines.some((line) => line.includes("Daemon offline"))).toBe(true);
+		expect(lines.some((line) => line.includes("writer") && line.includes("group") && line.includes("writers"))).toBe(
+			true,
+		);
+	});
+});

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -1,6 +1,13 @@
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { formatYaml, getAgentIdentityFiles, parseSimpleYaml, scaffoldAgent } from "@signet/core";
+import {
+	buildAgentMemoryConfig,
+	formatYaml,
+	getAgentIdentityFiles,
+	normalizeAgentRosterEntry,
+	parseSimpleYaml,
+	scaffoldAgent,
+} from "@signet/core";
 import chalk from "chalk";
 import type { Command } from "commander";
 import ora from "ora";
@@ -39,8 +46,10 @@ function addToRoster(dir: string, name: string, policy: string, group: string | 
 	const filtered = roster.filter(
 		(e: unknown) => typeof e !== "object" || e === null || (e as Record<string, unknown>).name !== name,
 	);
-	const entry: Record<string, unknown> = { name, read_policy: policy };
-	if (group) entry.policy_group = group;
+	const entry: Record<string, unknown> = {
+		name,
+		memory: buildAgentMemoryConfig(policy === "shared" ? "shared" : policy === "group" ? "group" : "isolated", group),
+	};
 	filtered.push(entry);
 	cfg.agents = { ...agents, roster: filtered };
 	writeYaml(dir, cfg);
@@ -95,10 +104,18 @@ export function registerAgentCommands(program: Command, deps: AgentDeps): void {
 				const cfg = readYaml(deps.AGENTS_DIR);
 				const agents = cfg.agents as Record<string, unknown> | undefined;
 				const roster = Array.isArray(agents?.roster) ? agents.roster : [];
-				rows = roster.filter(
-					(e): e is Row =>
-						typeof e === "object" && e !== null && typeof (e as Record<string, unknown>).name === "string",
-				);
+				rows = roster.flatMap((entry) => {
+					const normalized = normalizeAgentRosterEntry(entry);
+					if (!normalized) return [];
+					return [
+						{
+							id: normalized.name,
+							name: normalized.name,
+							read_policy: normalized.readPolicy,
+							policy_group: normalized.policyGroup ?? undefined,
+						},
+					];
+				});
 			}
 
 			if (rows.length === 0) {

--- a/packages/core/src/__tests__/identity.test.ts
+++ b/packages/core/src/__tests__/identity.test.ts
@@ -119,6 +119,14 @@ describe("agent roster helpers", () => {
 		});
 	});
 
+	test("normalizes legacy flat roster group policies for backward compatibility", () => {
+		expect(normalizeAgentRosterEntry({ name: "writer", read_policy: "group", policy_group: "writers" })).toEqual({
+			name: "writer",
+			readPolicy: "group",
+			policyGroup: "writers",
+		});
+	});
+
 	test("builds canonical nested memory config for group policies", () => {
 		expect(buildAgentMemoryConfig("group", "writers")).toEqual({
 			read_policy: { type: "group", group: "writers" },

--- a/packages/core/src/__tests__/identity.test.ts
+++ b/packages/core/src/__tests__/identity.test.ts
@@ -127,6 +127,16 @@ describe("agent roster helpers", () => {
 		});
 	});
 
+	test("preserves legacy flat group policy inside a memory block", () => {
+		expect(
+			normalizeAgentRosterEntry({ name: "writer", memory: { read_policy: "group", policy_group: "writers" } }),
+		).toEqual({
+			name: "writer",
+			readPolicy: "group",
+			policyGroup: "writers",
+		});
+	});
+
 	test("builds canonical nested memory config for group policies", () => {
 		expect(buildAgentMemoryConfig("group", "writers")).toEqual({
 			read_policy: { type: "group", group: "writers" },

--- a/packages/core/src/__tests__/identity.test.ts
+++ b/packages/core/src/__tests__/identity.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { buildAgentMemoryConfig, normalizeAgentRosterEntry } from "../agents";
 import {
 	STATIC_IDENTITY_SESSION_START_TIMEOUT_STATUS,
 	readStaticIdentity,
@@ -93,6 +94,35 @@ describe("readStaticIdentity", () => {
 		expect(result).toContain("## Identity");
 		expect(result).toContain("## About Your User");
 		expect(result).toContain("## Working Memory");
+	});
+});
+
+describe("agent roster helpers", () => {
+	test("normalizes canonical nested memory policies", () => {
+		expect(
+			normalizeAgentRosterEntry({
+				name: "writer",
+				memory: { read_policy: { type: "group", group: "writers" } },
+			}),
+		).toEqual({
+			name: "writer",
+			readPolicy: "group",
+			policyGroup: "writers",
+		});
+	});
+
+	test("normalizes legacy flat roster policies for backward compatibility", () => {
+		expect(normalizeAgentRosterEntry({ name: "writer", read_policy: "shared", policy_group: "ignored" })).toEqual({
+			name: "writer",
+			readPolicy: "shared",
+			policyGroup: null,
+		});
+	});
+
+	test("builds canonical nested memory config for group policies", () => {
+		expect(buildAgentMemoryConfig("group", "writers")).toEqual({
+			read_policy: { type: "group", group: "writers" },
+		});
 	});
 });
 

--- a/packages/core/src/__tests__/identity.test.ts
+++ b/packages/core/src/__tests__/identity.test.ts
@@ -142,6 +142,12 @@ describe("agent roster helpers", () => {
 			read_policy: { type: "group", group: "writers" },
 		});
 	});
+
+	test("fails closed to isolated when group policy is missing its group", () => {
+		expect(buildAgentMemoryConfig("group", null)).toEqual({
+			read_policy: "isolated",
+		});
+	});
 });
 
 describe("resolveSessionStartTimeoutMs", () => {

--- a/packages/core/src/__tests__/identity.test.ts
+++ b/packages/core/src/__tests__/identity.test.ts
@@ -9,6 +9,7 @@ import {
 	resolvePromptSubmitTimeoutMs,
 	resolveSessionStartTimeoutMs,
 } from "../identity";
+import { parseSimpleYaml } from "../yaml";
 
 const TMP = join(tmpdir(), `signet-identity-test-${Date.now()}`);
 
@@ -94,6 +95,12 @@ describe("readStaticIdentity", () => {
 		expect(result).toContain("## Identity");
 		expect(result).toContain("## About Your User");
 		expect(result).toContain("## Working Memory");
+	});
+});
+
+describe("parseSimpleYaml", () => {
+	test("degrades malformed YAML to an empty object", () => {
+		expect(parseSimpleYaml("agent:\n  name: [unterminated")).toEqual({});
 	});
 });
 

--- a/packages/core/src/agents.ts
+++ b/packages/core/src/agents.ts
@@ -7,7 +7,15 @@
 
 import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import type { AgentDefinition } from "./types";
+import type { AgentDefinition, ReadPolicy } from "./types";
+
+export type AgentRosterReadPolicy = "isolated" | "shared" | "group";
+
+export interface NormalizedAgentRosterEntry {
+	readonly name: string;
+	readonly readPolicy: AgentRosterReadPolicy;
+	readonly policyGroup: string | null;
+}
 
 /** Identity files that inherit from agent subdir (fall back to root). */
 const AGENT_SPECIFIC = new Set(["SOUL.md", "IDENTITY.md"]);
@@ -69,6 +77,54 @@ export function getAgentIdentityFiles(name: string, agentsDir: string): Record<s
 	}
 
 	return result;
+}
+
+function normalizeReadPolicy(readPolicy: unknown, policyGroup: unknown): {
+	readonly readPolicy: AgentRosterReadPolicy;
+	readonly policyGroup: string | null;
+} {
+	if (readPolicy === "shared") return { readPolicy: "shared", policyGroup: null };
+	if (readPolicy === "isolated") return { readPolicy: "isolated", policyGroup: null };
+	if (
+		typeof readPolicy === "object" &&
+		readPolicy !== null &&
+		(readPolicy as { type?: unknown }).type === "group" &&
+		typeof (readPolicy as { group?: unknown }).group === "string"
+	) {
+		return {
+			readPolicy: "group",
+			policyGroup: (readPolicy as { group: string }).group,
+		};
+	}
+	if (readPolicy === "group" && typeof policyGroup === "string") {
+		return { readPolicy: "group", policyGroup };
+	}
+	return { readPolicy: "isolated", policyGroup: null };
+}
+
+export function normalizeAgentRosterEntry(entry: unknown): NormalizedAgentRosterEntry | null {
+	if (typeof entry !== "object" || entry === null) return null;
+	const record = entry as Record<string, unknown>;
+	if (typeof record.name !== "string" || record.name.length === 0) return null;
+	const memory =
+		typeof record.memory === "object" && record.memory !== null ? (record.memory as Record<string, unknown>) : null;
+	const policy = normalizeReadPolicy(memory?.read_policy ?? record.read_policy, record.policy_group);
+	return {
+		name: record.name,
+		readPolicy: policy.readPolicy,
+		policyGroup: policy.policyGroup,
+	};
+}
+
+export function buildAgentMemoryConfig(
+	readPolicy: AgentRosterReadPolicy,
+	policyGroup: string | null,
+): { readonly read_policy?: ReadPolicy } {
+	if (readPolicy === "shared") return { read_policy: "shared" };
+	if (readPolicy === "group" && typeof policyGroup === "string" && policyGroup.length > 0) {
+		return { read_policy: { type: "group", group: policyGroup } };
+	}
+	return { read_policy: "isolated" };
 }
 
 /**

--- a/packages/core/src/agents.ts
+++ b/packages/core/src/agents.ts
@@ -111,7 +111,10 @@ export function normalizeAgentRosterEntry(entry: unknown): NormalizedAgentRoster
 	if (typeof record.name !== "string" || record.name.length === 0) return null;
 	const memory =
 		typeof record.memory === "object" && record.memory !== null ? (record.memory as Record<string, unknown>) : null;
-	const policy = normalizeReadPolicy(memory?.read_policy ?? record.read_policy, record.policy_group);
+	const policy = normalizeReadPolicy(
+		memory?.read_policy ?? record.read_policy,
+		memory?.policy_group ?? record.policy_group,
+	);
 	return {
 		name: record.name,
 		readPolicy: policy.readPolicy,

--- a/packages/core/src/agents.ts
+++ b/packages/core/src/agents.ts
@@ -79,7 +79,10 @@ export function getAgentIdentityFiles(name: string, agentsDir: string): Record<s
 	return result;
 }
 
-function normalizeReadPolicy(readPolicy: unknown, policyGroup: unknown): {
+function normalizeReadPolicy(
+	readPolicy: unknown,
+	policyGroup: unknown,
+): {
 	readonly readPolicy: AgentRosterReadPolicy;
 	readonly policyGroup: string | null;
 } {
@@ -119,7 +122,7 @@ export function normalizeAgentRosterEntry(entry: unknown): NormalizedAgentRoster
 export function buildAgentMemoryConfig(
 	readPolicy: AgentRosterReadPolicy,
 	policyGroup: string | null,
-): { readonly read_policy?: ReadPolicy } {
+): { readonly read_policy: ReadPolicy } {
 	if (readPolicy === "shared") return { read_policy: "shared" };
 	if (readPolicy === "group" && typeof policyGroup === "string" && policyGroup.length > 0) {
 		return { read_policy: { type: "group", group: policyGroup } };

--- a/packages/core/src/agents.ts
+++ b/packages/core/src/agents.ts
@@ -130,6 +130,9 @@ export function buildAgentMemoryConfig(
 	if (readPolicy === "group" && typeof policyGroup === "string" && policyGroup.length > 0) {
 		return { read_policy: { type: "group", group: policyGroup } };
 	}
+	// CLI validation already rejects `group` without a concrete group name.
+	// Keep the fallback isolated here so malformed callers fail closed instead
+	// of widening access implicitly.
 	return { read_policy: "isolated" };
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -192,7 +192,10 @@ export {
 	scaffoldAgent,
 	getAgentIdentityFiles,
 	resolveAgentSkills,
+	buildAgentMemoryConfig,
+	normalizeAgentRosterEntry,
 } from "./agents";
+export type { AgentRosterReadPolicy, NormalizedAgentRosterEntry } from "./agents";
 
 // Skills unification
 export {

--- a/packages/core/src/migrations/056-agent-scoped-content-hash.ts
+++ b/packages/core/src/migrations/056-agent-scoped-content-hash.ts
@@ -1,0 +1,32 @@
+import type { MigrationDb } from "./index";
+
+function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): void {
+	const cols = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>;
+	if (cols.some((col) => col.name === column)) return;
+	db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+}
+
+/**
+ * Migration 056: Agent-aware content hash dedupe
+ *
+ * Summary facts and extracted memories may legitimately share identical
+ * content across different agent scopes. Tighten the unique partial index so
+ * duplicate content_hash values are only rejected within the same
+ * (agent_id, scope) tuple.
+ */
+export function up(db: MigrationDb): void {
+	// Defensive repair for stamped-but-partial databases.
+	addColumnIfMissing(db, "memories", "agent_id", "TEXT DEFAULT 'default'");
+	addColumnIfMissing(db, "memories", "scope", "TEXT");
+
+	db.exec("DROP INDEX IF EXISTS idx_memories_content_hash_unique");
+	db.exec(`
+		CREATE UNIQUE INDEX idx_memories_content_hash_unique
+		ON memories(
+			content_hash,
+			COALESCE(NULLIF(agent_id, ''), 'default'),
+			COALESCE(scope, '__NULL__')
+		)
+		WHERE content_hash IS NOT NULL AND is_deleted = 0
+	`);
+}

--- a/packages/core/src/migrations/056-agent-scoped-content-hash.ts
+++ b/packages/core/src/migrations/056-agent-scoped-content-hash.ts
@@ -1,6 +1,7 @@
 import type { MigrationDb } from "./index";
 
 function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): void {
+	// Internal migration helper: callers must pass trusted SQL identifier/type literals.
 	const cols = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>;
 	if (cols.some((col) => col.name === column)) return;
 	db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);

--- a/packages/core/src/migrations/056-agent-scoped-content-hash.ts
+++ b/packages/core/src/migrations/056-agent-scoped-content-hash.ts
@@ -1,10 +1,10 @@
 import type { MigrationDb } from "./index";
 
-function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): void {
-	// Internal migration helper: callers must pass trusted SQL identifier/type literals.
-	const cols = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>;
-	if (cols.some((col) => col.name === column)) return;
-	db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+function ensureMemoriesScopeColumns(db: MigrationDb): void {
+	const cols = db.prepare("PRAGMA table_info(memories)").all() as ReadonlyArray<Record<string, unknown>>;
+	const names = new Set(cols.map((col) => col.name).filter((name): name is string => typeof name === "string"));
+	if (!names.has("agent_id")) db.exec("ALTER TABLE memories ADD COLUMN agent_id TEXT DEFAULT 'default'");
+	if (!names.has("scope")) db.exec("ALTER TABLE memories ADD COLUMN scope TEXT");
 }
 
 /**
@@ -17,8 +17,7 @@ function addColumnIfMissing(db: MigrationDb, table: string, column: string, defi
  */
 export function up(db: MigrationDb): void {
 	// Defensive repair for stamped-but-partial databases.
-	addColumnIfMissing(db, "memories", "agent_id", "TEXT DEFAULT 'default'");
-	addColumnIfMissing(db, "memories", "scope", "TEXT");
+	ensureMemoriesScopeColumns(db);
 
 	db.exec("DROP INDEX IF EXISTS idx_memories_content_hash_unique");
 	db.exec(`

--- a/packages/core/src/migrations/index.ts
+++ b/packages/core/src/migrations/index.ts
@@ -61,6 +61,7 @@ import { up as mcpInvocations } from "./052-mcp-invocations";
 import { up as skillInvocations } from "./053-skill-invocations";
 import { up as taskAgentScope } from "./054-task-agent-scope";
 import { up as dreamingState } from "./055-dreaming-state";
+import { up as agentScopedContentHash } from "./056-agent-scoped-content-hash";
 
 // -- Public interface consumed by Database.init() --
 
@@ -533,6 +534,11 @@ export const MIGRATIONS: readonly Migration[] = [
 		artifacts: {
 			tables: ["dreaming_state", "dreaming_passes"],
 		},
+	},
+	{
+		version: 56,
+		name: "agent-scoped-content-hash",
+		up: agentScopedContentHash,
 	},
 ];
 

--- a/packages/core/src/migrations/migrations.test.ts
+++ b/packages/core/src/migrations/migrations.test.ts
@@ -564,37 +564,49 @@ describe("migration framework", () => {
 		expect(colNames).toContain("pinned_at");
 	});
 
-	test("unique partial index on content_hash rejects duplicates", () => {
+	test("unique partial index on content_hash is agent- and scope-aware", () => {
 		db = createFreshDb();
 		runMigrations(db);
 
 		const now = new Date().toISOString();
 		db.prepare(
-			`INSERT INTO memories (id, content, content_hash, type, created_at, updated_at, updated_by)
-			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		).run("a", "hello", "hash1", "fact", now, now, "test");
+			`INSERT INTO memories (id, content, content_hash, type, agent_id, scope, created_at, updated_at, updated_by)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run("a", "hello", "hash1", "fact", "default", null, now, now, "test");
 
-		// Same content_hash on a non-deleted row should fail
+		// Same content_hash in the same agent/scope tuple should fail.
 		expect(() =>
 			db
 				.prepare(
-					`INSERT INTO memories (id, content, content_hash, type, created_at, updated_at, updated_by)
-				 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+					`INSERT INTO memories (id, content, content_hash, type, agent_id, scope, created_at, updated_at, updated_by)
+					 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 				)
-				.run("b", "hello again", "hash1", "fact", now, now, "test"),
+				.run("b", "hello again", "hash1", "fact", "default", null, now, now, "test"),
 		).toThrow();
 
-		// NULL content_hash should not conflict
+		// A different agent may persist the same content hash.
+		db.prepare(
+			`INSERT INTO memories (id, content, content_hash, type, agent_id, scope, created_at, updated_at, updated_by)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run("c", "hello from agent a", "hash1", "fact", "agent-a", null, now, now, "test");
+
+		// A different benchmark scope may also persist the same content hash.
+		db.prepare(
+			`INSERT INTO memories (id, content, content_hash, type, agent_id, scope, created_at, updated_at, updated_by)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run("d", "hello from bench scope", "hash1", "fact", "default", "bench:run-1", now, now, "test");
+
+		// NULL content_hash should not conflict.
 		db.prepare(
 			`INSERT INTO memories (id, content, content_hash, type, created_at, updated_at, updated_by)
 			 VALUES (?, ?, NULL, ?, ?, ?, ?)`,
-		).run("c", "no hash", "fact", now, now, "test");
+		).run("e", "no hash", "fact", now, now, "test");
 
-		// Soft-deleted row with same hash should not conflict
+		// Soft-deleted row with the same hash should not conflict.
 		db.prepare(
-			`INSERT INTO memories (id, content, content_hash, is_deleted, type, created_at, updated_at, updated_by)
-			 VALUES (?, ?, ?, 1, ?, ?, ?, ?)`,
-		).run("d", "deleted", "hash1", "fact", now, now, "test");
+			`INSERT INTO memories (id, content, content_hash, is_deleted, type, agent_id, scope, created_at, updated_at, updated_by)
+			 VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?, ?)`,
+		).run("f", "deleted", "hash1", "fact", "default", null, now, now, "test");
 	});
 
 	test("migration 003 deduplicates existing content hashes", () => {

--- a/packages/core/src/yaml.ts
+++ b/packages/core/src/yaml.ts
@@ -14,6 +14,9 @@ export function parseSimpleYaml(text: string): Record<string, unknown> {
 
 /**
  * Format a JavaScript object as YAML.
+ *
+ * `_indent` is retained for internal call-site compatibility, but the
+ * shared YAML library always emits 2-space indentation here.
  */
 export function formatYaml(obj: Record<string, unknown>, _indent = 0): string {
 	return YAML.stringify(obj, {

--- a/packages/core/src/yaml.ts
+++ b/packages/core/src/yaml.ts
@@ -6,10 +6,17 @@ import YAML from "yaml";
 
 /**
  * Parse a YAML string into a JavaScript object.
+ *
+ * Malformed user-owned YAML should degrade to an empty object instead of
+ * propagating parser exceptions into daemon or CLI startup.
  */
 export function parseSimpleYaml(text: string): Record<string, unknown> {
-	const parsed = YAML.parse(text);
-	return typeof parsed === "object" && parsed !== null ? (parsed as Record<string, unknown>) : {};
+	try {
+		const parsed = YAML.parse(text);
+		return typeof parsed === "object" && parsed !== null ? (parsed as Record<string, unknown>) : {};
+	} catch {
+		return {};
+	}
 }
 
 /**

--- a/packages/core/src/yaml.ts
+++ b/packages/core/src/yaml.ts
@@ -1,152 +1,23 @@
 /**
  * @signet/core - YAML utilities
- *
- * Simple YAML parser and formatter for flat/shallow config files.
- * Handles the common patterns used in Signet config files (agent.yaml, config.yaml)
- * without requiring a full YAML library dependency.
- *
- * Limitations:
- * - Supports up to 3 levels of nesting
- * - No support for YAML anchors, aliases, or complex types
- * - Arrays are formatted in block style only
  */
+
+import YAML from "yaml";
 
 /**
- * Parse a simple YAML string into a JavaScript object.
- *
- * Supports:
- * - Comments (line and inline)
- * - Key: value pairs
- * - Up to 3 levels of nesting
- * - Basic type coercion (strings, numbers, booleans)
- * - Quoted strings (strips quotes)
- * - Multiline values with | indicator
+ * Parse a YAML string into a JavaScript object.
  */
 export function parseSimpleYaml(text: string): Record<string, unknown> {
-	const result: Record<string, unknown> = {};
-	const lines = text.split("\n");
-
-	// Stack tracks current nesting context
-	// Each entry: { indent: number, obj: the object at that level, key?: parent key }
-	const stack: Array<{
-		indent: number;
-		obj: Record<string, unknown>;
-		key?: string;
-	}> = [{ indent: -1, obj: result }];
-
-	for (const line of lines) {
-		// Skip empty lines and comments
-		const trimmedLine = line.trim();
-		if (!trimmedLine || trimmedLine.startsWith("#")) continue;
-
-		// Skip YAML document markers
-		if (trimmedLine === "---" || trimmedLine === "...") continue;
-
-		const indent = line.search(/\S/);
-
-		// Pop stack to correct level for this indent
-		while (stack.length > 1 && stack[stack.length - 1].indent >= indent) {
-			stack.pop();
-		}
-
-		const colonIdx = trimmedLine.indexOf(":");
-		if (colonIdx === -1) continue;
-
-		const key = trimmedLine.slice(0, colonIdx).trim();
-		let value = trimmedLine.slice(colonIdx + 1).trim();
-
-		const parent = stack[stack.length - 1].obj;
-
-		// Handle different value cases
-		if (value === "" || value === "|") {
-			// Nested object or multiline start
-			parent[key] = {};
-			stack.push({ indent, obj: parent[key] as Record<string, unknown>, key });
-		} else if (value.startsWith("|")) {
-			// Multiline string - this simplified parser just uses empty string
-			// A full implementation would collect following indented lines
-			parent[key] = "";
-		} else {
-			// Simple value - apply type coercion
-			parent[key] = coerceYamlValue(value);
-		}
-	}
-
-	return result;
+	const parsed = YAML.parse(text);
+	return typeof parsed === "object" && parsed !== null ? (parsed as Record<string, unknown>) : {};
 }
 
 /**
  * Format a JavaScript object as YAML.
- *
- * Supports:
- * - Nested objects
- * - Arrays (block style)
- * - Primitive values (string, number, boolean, null)
  */
-export function formatYaml(obj: Record<string, unknown>, indent = 0): string {
-	const pad = "  ".repeat(indent);
-	let result = "";
-
-	for (const [key, value] of Object.entries(obj)) {
-		if (value === undefined) continue;
-
-		if (Array.isArray(value)) {
-			result += `${pad}${key}:\n`;
-			for (const item of value) {
-				if (typeof item === "object" && item !== null) {
-					result += `${pad}  - ${JSON.stringify(item)}\n`;
-				} else {
-					result += `${pad}  - ${item}\n`;
-				}
-			}
-		} else if (typeof value === "object" && value !== null) {
-			result += `${pad}${key}:\n`;
-			result += formatYaml(value as Record<string, unknown>, indent + 1);
-		} else if (value === null) {
-			result += `${pad}${key}: null\n`;
-		} else if (typeof value === "string") {
-			if (
-				value.includes(":") ||
-				value.includes("#") ||
-				value.includes("\n") ||
-				value.includes('"') ||
-				value.includes("\\") ||
-				value.includes("\t") ||
-				/^\d/.test(value)
-			) {
-				const escaped = value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\t/g, "\\t");
-				result += `${pad}${key}: "${escaped}"\n`;
-			} else {
-				result += `${pad}${key}: ${value}\n`;
-			}
-		} else {
-			result += `${pad}${key}: ${value}\n`;
-		}
-	}
-
-	return result;
-}
-
-/**
- * Coerce a YAML value string to the appropriate JavaScript type.
- */
-function coerceYamlValue(value: string): unknown {
-	// Strip surrounding quotes
-	const unquoted = value.replace(/^["']|["']$/g, "");
-
-	// Boolean
-	if (unquoted === "true") return true;
-	if (unquoted === "false") return false;
-
-	// Null
-	if (unquoted === "null" || unquoted === "~") return null;
-
-	// Integer
-	if (/^-?\d+$/.test(unquoted)) return parseInt(unquoted, 10);
-
-	// Float
-	if (/^-?\d+\.\d+$/.test(unquoted)) return parseFloat(unquoted);
-
-	// String (return unquoted version)
-	return unquoted;
+export function formatYaml(obj: Record<string, unknown>, _indent = 0): string {
+	return YAML.stringify(obj, {
+		indent: 2,
+		simpleKeys: true,
+	});
 }

--- a/packages/daemon-rs/contracts/schema.sql
+++ b/packages/daemon-rs/contracts/schema.sql
@@ -67,7 +67,7 @@ CREATE TABLE "memories" (
   last_accessed   TEXT,
   access_count    INTEGER DEFAULT 0,
   pinned          INTEGER DEFAULT 0
-, content_hash TEXT, normalized_content TEXT, is_deleted INTEGER DEFAULT 0, deleted_at TEXT, extraction_status TEXT DEFAULT 'none', embedding_model TEXT, extraction_model TEXT, update_count INTEGER DEFAULT 0, idempotency_key TEXT, runtime_path TEXT, source_path TEXT, source_section TEXT, agent_id TEXT DEFAULT 'default', visibility TEXT DEFAULT 'global');
+, content_hash TEXT, normalized_content TEXT, is_deleted INTEGER DEFAULT 0, deleted_at TEXT, extraction_status TEXT DEFAULT 'none', embedding_model TEXT, extraction_model TEXT, update_count INTEGER DEFAULT 0, idempotency_key TEXT, runtime_path TEXT, source_path TEXT, source_section TEXT, scope TEXT, agent_id TEXT DEFAULT 'default', visibility TEXT DEFAULT 'global');
 CREATE INDEX idx_memories_type ON memories(type);
 CREATE INDEX idx_memories_category ON memories(category);
 CREATE INDEX idx_memories_source ON memories(source_type, source_id);

--- a/packages/daemon-rs/contracts/schema.sql
+++ b/packages/daemon-rs/contracts/schema.sql
@@ -163,7 +163,7 @@ CREATE INDEX idx_relations_target
 CREATE INDEX idx_memory_entity_mentions_entity
 			ON memory_entity_mentions(entity_id);
 CREATE UNIQUE INDEX idx_memories_content_hash_unique
-			ON memories(content_hash)
+			ON memories(content_hash, COALESCE(NULLIF(agent_id, ''), 'default'), COALESCE(scope, '__NULL__'))
 			WHERE content_hash IS NOT NULL AND is_deleted = 0
 	;
 CREATE INDEX idx_memories_deleted_at

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -35,6 +35,7 @@ import {
 	keywordSearch,
 	mergeSignetGitignoreEntries,
 	networkModeFromBindHost,
+	normalizeAgentRosterEntry,
 	parseSimpleYaml,
 	readNetworkMode,
 	readPipelinePauseState,
@@ -11554,18 +11555,16 @@ function syncAgentRoster(agentsDir: string): void {
 			   updated_at = excluded.updated_at`,
 		);
 		for (const entry of roster) {
-			const policy = entry.memory?.read_policy;
-			let readPolicy: string;
-			let group: string | null = null;
-			if (typeof policy === "string") {
-				readPolicy = policy;
-			} else if (policy && typeof policy === "object" && policy.type === "group") {
-				readPolicy = "group";
-				group = typeof policy.group === "string" ? policy.group : null;
-			} else {
-				readPolicy = "isolated";
-			}
-			stmt.run(entry.name, entry.name, readPolicy, group, now, now);
+			const normalized = normalizeAgentRosterEntry(entry);
+			if (!normalized) continue;
+			stmt.run(
+				normalized.name,
+				normalized.name,
+				normalized.readPolicy,
+				normalized.policyGroup,
+				now,
+				now,
+			);
 		}
 	});
 	logger.info("daemon", "Agent roster synced", { count: roster.length });

--- a/packages/daemon/src/hooks.test.ts
+++ b/packages/daemon/src/hooks.test.ts
@@ -50,7 +50,7 @@ describe("writeMemoryMd", () => {
 	afterAll(() => {
 		rmSync(agentsDir, { recursive: true, force: true });
 		if (previousSignetPath === undefined) {
-			process.env.SIGNET_PATH = undefined;
+			Reflect.deleteProperty(process.env, "SIGNET_PATH");
 			return;
 		}
 		process.env.SIGNET_PATH = previousSignetPath;

--- a/packages/daemon/src/hooks.test.ts
+++ b/packages/daemon/src/hooks.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import {
 	buildSignetSystemPrompt,
 	normalizeCodexTranscript,
 	normalizeJsonConversationTranscript,
 	normalizeSessionTranscript,
 	queryAnchorsMissingFromRecall,
+	writeMemoryMd,
 } from "./hooks";
 
 describe("buildSignetSystemPrompt", () => {
@@ -18,6 +23,64 @@ describe("buildSignetSystemPrompt", () => {
 		expect(prompt).toContain("mcp__signet__memory_store");
 		expect(prompt).toContain("mcp__signet__secret_list");
 		expect(prompt).toContain("mcp__signet__secret_exec");
+	});
+});
+
+describe("writeMemoryMd", () => {
+	let agentsDir = "";
+	let previousSignetPath: string | undefined;
+
+	beforeAll(() => {
+		previousSignetPath = process.env.SIGNET_PATH;
+		agentsDir = mkdtempSync(join(tmpdir(), "signet-hooks-write-memory-"));
+		process.env.SIGNET_PATH = agentsDir;
+	});
+
+	beforeEach(() => {
+		closeDbAccessor();
+		rmSync(agentsDir, { recursive: true, force: true });
+		mkdirSync(agentsDir, { recursive: true });
+		initDbAccessor(join(agentsDir, "memory", "memories.db"), { agentsDir });
+	});
+
+	afterEach(() => {
+		closeDbAccessor();
+	});
+
+	afterAll(() => {
+		rmSync(agentsDir, { recursive: true, force: true });
+		if (previousSignetPath === undefined) {
+			process.env.SIGNET_PATH = undefined;
+			return;
+		}
+		process.env.SIGNET_PATH = previousSignetPath;
+	});
+
+	it("forwards agent scope to the shared memory head writer", () => {
+		const result = writeMemoryMd("# MEMORY\n\n## Active\n- synthesized for agent-b\n", {
+			agentId: "agent-b",
+			owner: "hooks-test",
+		});
+		expect(result).toEqual({ ok: true });
+
+		const row = getDbAccessor().withReadDb((db) => {
+			return db.prepare("SELECT agent_id, content, revision FROM memory_md_heads WHERE agent_id = ?").get("agent-b") as
+				| { agent_id: string; content: string; revision: number }
+				| undefined;
+		});
+		expect(row).toEqual({
+			agent_id: "agent-b",
+			content: "# MEMORY\n\n## Active\n- synthesized for agent-b",
+			revision: 1,
+		});
+
+		const defaultCount = getDbAccessor().withReadDb((db) => {
+			const found = db.prepare("SELECT COUNT(*) as n FROM memory_md_heads WHERE agent_id = 'default'").get() as {
+				n: number;
+			};
+			return found.n;
+		});
+		expect(defaultCount).toBe(0);
 	});
 });
 

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -517,7 +517,7 @@ function getSessionGapSummary(): string | undefined {
 }
 
 /** Check if content overlaps 70%+ with existing memories via FTS */
-export function isDuplicate(db: Database, content: string): boolean {
+export function isDuplicate(db: Database, content: string, agentId = "default"): boolean {
 	const words = content
 		.toLowerCase()
 		.split(/\W+/)
@@ -527,8 +527,16 @@ export function isDuplicate(db: Database, content: string): boolean {
 	try {
 		const ftsQuery = words.slice(0, 10).join(" OR ");
 		const rows = db
-			.prepare("SELECT content FROM memories_fts WHERE memories_fts MATCH ? LIMIT 10")
-			.all(ftsQuery) as Array<{ content: string }>;
+			.prepare(
+				`SELECT m.content
+				 FROM memories_fts
+				 JOIN memories m ON memories_fts.rowid = m.rowid
+				 WHERE memories_fts MATCH ?
+				   AND m.is_deleted = 0
+				   AND m.agent_id = ?
+				 LIMIT 10`,
+			)
+			.all(ftsQuery, agentId) as Array<{ content: string }>;
 
 		const inputWords = new Set(words);
 		for (const row of rows) {

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -517,7 +517,7 @@ function getSessionGapSummary(): string | undefined {
 }
 
 /** Check if content overlaps 70%+ with existing memories via FTS */
-export function isDuplicate(db: Database, content: string, agentId = "default"): boolean {
+export function isDuplicate(db: Database, content: string, agentId: string): boolean {
 	const words = content
 		.toLowerCase()
 		.split(/\W+/)

--- a/packages/daemon/src/memory-head.test.ts
+++ b/packages/daemon/src/memory-head.test.ts
@@ -1,9 +1,10 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Tiktoken } from "js-tiktoken/lite";
 import cl100k_base from "js-tiktoken/ranks/cl100k_base";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import { MEMORY_HEAD_MAX_TOKENS, writeMemoryHead } from "./memory-head";
 
 const tok = new Tiktoken(cl100k_base);
@@ -23,14 +24,19 @@ describe("writeMemoryHead", () => {
 	});
 
 	beforeEach(() => {
+		closeDbAccessor();
 		rmSync(agentsDir, { recursive: true, force: true });
 		mkdirSync(agentsDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		closeDbAccessor();
 	});
 
 	afterAll(() => {
 		rmSync(agentsDir, { recursive: true, force: true });
 		if (prevSignetPath === undefined) {
-			delete process.env.SIGNET_PATH;
+			process.env.SIGNET_PATH = undefined;
 			return;
 		}
 		process.env.SIGNET_PATH = prevSignetPath;
@@ -48,9 +54,39 @@ describe("writeMemoryHead", () => {
 		expect(tok.encode(file).length).toBeLessThanOrEqual(MEMORY_HEAD_MAX_TOKENS);
 	});
 
+	it("stores memory head state under the requested agent scope", () => {
+		initDbAccessor(join(agentsDir, "memory", "memories.db"), { agentsDir });
+
+		const result = writeMemoryHead("# MEMORY\n\n## Active\n- agent-specific synthesis\n", {
+			agentId: "agent-a",
+			owner: "memory-head-test",
+		});
+		expect(result.ok).toBe(true);
+
+		const row = getDbAccessor().withReadDb((db) => {
+			return db.prepare("SELECT agent_id, content, revision FROM memory_md_heads WHERE agent_id = ?").get("agent-a") as
+				| { agent_id: string; content: string; revision: number }
+				| undefined;
+		});
+		expect(row).toEqual({
+			agent_id: "agent-a",
+			content: "# MEMORY\n\n## Active\n- agent-specific synthesis",
+			revision: 1,
+		});
+
+		const otherCount = getDbAccessor().withReadDb((db) => {
+			const result = db.prepare("SELECT COUNT(*) as n FROM memory_md_heads WHERE agent_id = 'default'").get() as {
+				n: number;
+			};
+			return result.n;
+		});
+		expect(otherCount).toBe(0);
+	});
+
 	it("truncates the tail of oversized MEMORY.md content to 5000 tokens", () => {
 		const keep = "# MEMORY\n\n## Active\n- retain this context\n\n";
-		const chunk = "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega\n";
+		const chunk =
+			"alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega\n";
 		const tail = "\n## Tail Marker\nthis section should be truncated away\n";
 		let content = keep;
 

--- a/packages/daemon/src/memory-head.test.ts
+++ b/packages/daemon/src/memory-head.test.ts
@@ -36,7 +36,7 @@ describe("writeMemoryHead", () => {
 	afterAll(() => {
 		rmSync(agentsDir, { recursive: true, force: true });
 		if (prevSignetPath === undefined) {
-			process.env.SIGNET_PATH = undefined;
+			Reflect.deleteProperty(process.env, "SIGNET_PATH");
 			return;
 		}
 		process.env.SIGNET_PATH = prevSignetPath;

--- a/packages/daemon/src/pipeline/summary-worker.test.ts
+++ b/packages/daemon/src/pipeline/summary-worker.test.ts
@@ -119,6 +119,28 @@ describe("insertSummaryFacts", () => {
 		expect(row?.updated_by).toBe(SUMMARY_WORKER_UPDATED_BY);
 	});
 
+	it("scopes duplicate detection to the fact owner's agent", () => {
+		const content = "Agent-scoped duplicate detection keeps this shared fact available to sub-agents.";
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO memories
+			 (id, content, type, importance, created_at, updated_at, updated_by, agent_id)
+			 VALUES (?, ?, 'fact', 0.4, ?, ?, 'test', 'default')`,
+		).run("mem-default", content, now, now);
+
+		const saved = insertSummaryFacts(
+			accessor,
+			{ harness: "claude-code", project: null, session_key: "sess-agent-a", agent_id: "agent-a" },
+			[{ content, importance: 0.4, type: "fact" }],
+		);
+
+		expect(saved).toBe(1);
+		const rows = db
+			.prepare("SELECT agent_id FROM memories WHERE content = ? ORDER BY agent_id ASC")
+			.all(content) as Array<{ agent_id: string }>;
+		expect(rows).toEqual([{ agent_id: "agent-a" }, { agent_id: "default" }]);
+	});
+
 	it("populates content_hash so the embedding tracker can index summary facts", () => {
 		// Regression: summary-worker previously inserted facts without content_hash,
 		// making them invisible to the embedding tracker (which skips NULL-hash rows)

--- a/packages/daemon/src/pipeline/summary-worker.test.ts
+++ b/packages/daemon/src/pipeline/summary-worker.test.ts
@@ -81,13 +81,14 @@ describe("insertSummaryFacts", () => {
 		db.close();
 	});
 
-	it("writes summary facts with updated_by metadata", () => {
+	it("writes summary facts with updated_by metadata and default agent scope", () => {
 		const saved = insertSummaryFacts(
 			accessor,
 			{
 				harness: "codex",
 				project: "/tmp/project",
 				session_key: "session-1",
+				agent_id: "",
 			},
 			[
 				{
@@ -101,12 +102,13 @@ describe("insertSummaryFacts", () => {
 
 		expect(saved).toBe(1);
 
-		const row = db.prepare("SELECT who, source_id, source_type, project, updated_by FROM memories").get() as
+		const row = db.prepare("SELECT who, source_id, source_type, project, agent_id, updated_by FROM memories").get() as
 			| {
 					who: string;
 					source_id: string | null;
 					source_type: string;
 					project: string | null;
+					agent_id: string;
 					updated_by: string;
 			  }
 			| undefined;
@@ -116,6 +118,7 @@ describe("insertSummaryFacts", () => {
 		expect(row?.source_id).toBe("session-1");
 		expect(row?.source_type).toBe("session_end");
 		expect(row?.project).toBe("/tmp/project");
+		expect(row?.agent_id).toBe("default");
 		expect(row?.updated_by).toBe(SUMMARY_WORKER_UPDATED_BY);
 	});
 

--- a/packages/daemon/src/pipeline/summary-worker.test.ts
+++ b/packages/daemon/src/pipeline/summary-worker.test.ts
@@ -121,20 +121,28 @@ describe("insertSummaryFacts", () => {
 
 	it("scopes duplicate detection to the fact owner's agent", () => {
 		const content = "Agent-scoped duplicate detection keeps this shared fact available to sub-agents.";
-		const now = new Date().toISOString();
-		db.prepare(
-			`INSERT INTO memories
-			 (id, content, type, importance, created_at, updated_at, updated_by, agent_id)
-			 VALUES (?, ?, 'fact', 0.4, ?, ?, 'test', 'default')`,
-		).run("mem-default", content, now, now);
 
-		const saved = insertSummaryFacts(
+		const firstSaved = insertSummaryFacts(
+			accessor,
+			{ harness: "claude-code", project: null, session_key: "sess-default", agent_id: "default" },
+			[{ content, importance: 0.4, type: "fact" }],
+		);
+		expect(firstSaved).toBe(1);
+
+		const duplicateSaved = insertSummaryFacts(
+			accessor,
+			{ harness: "claude-code", project: null, session_key: "sess-default-2", agent_id: "default" },
+			[{ content, importance: 0.4, type: "fact" }],
+		);
+		expect(duplicateSaved).toBe(0);
+
+		const crossAgentSaved = insertSummaryFacts(
 			accessor,
 			{ harness: "claude-code", project: null, session_key: "sess-agent-a", agent_id: "agent-a" },
 			[{ content, importance: 0.4, type: "fact" }],
 		);
+		expect(crossAgentSaved).toBe(1);
 
-		expect(saved).toBe(1);
 		const rows = db
 			.prepare("SELECT agent_id FROM memories WHERE content = ? ORDER BY agent_id ASC")
 			.all(content) as Array<{ agent_id: string }>;

--- a/packages/daemon/src/pipeline/summary-worker.test.ts
+++ b/packages/daemon/src/pipeline/summary-worker.test.ts
@@ -122,6 +122,32 @@ describe("insertSummaryFacts", () => {
 		expect(row?.updated_by).toBe(SUMMARY_WORKER_UPDATED_BY);
 	});
 
+	it("fails closed to the default agent scope when runtime rows contain null agent ids", () => {
+		const saved = insertSummaryFacts(
+			accessor,
+			{
+				harness: "codex",
+				project: "/tmp/project",
+				session_key: "session-null-agent",
+				agent_id: null,
+			} as unknown as Parameters<typeof insertSummaryFacts>[1],
+			[
+				{
+					content: "Null agent ids still persist summary facts under the default scope.",
+					importance: 0.4,
+					type: "fact",
+				},
+			],
+		);
+
+		expect(saved).toBe(1);
+
+		const row = db.prepare("SELECT agent_id FROM memories WHERE source_id = ?").get("session-null-agent") as
+			| { agent_id: string }
+			| undefined;
+		expect(row?.agent_id).toBe("default");
+	});
+
 	it("scopes duplicate detection to the fact owner's agent", () => {
 		const content = "Agent-scoped duplicate detection keeps this shared fact available to sub-agents.";
 

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -1140,7 +1140,7 @@ export function insertSummaryFacts(
 	facts: ReadonlyArray<LlmSummaryResult["facts"][number]>,
 ): number {
 	const now = new Date().toISOString();
-	const agentId = job.agent_id.length > 0 ? job.agent_id : "default";
+	const agentId = typeof job.agent_id === "string" && job.agent_id.length > 0 ? job.agent_id : "default";
 
 	return accessor.withWriteTx((db) => {
 		let count = 0;

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -1140,6 +1140,7 @@ export function insertSummaryFacts(
 	facts: ReadonlyArray<LlmSummaryResult["facts"][number]>,
 ): number {
 	const now = new Date().toISOString();
+	const agentId = job.agent_id.length > 0 ? job.agent_id : "default";
 
 	return accessor.withWriteTx((db) => {
 		let count = 0;
@@ -1159,7 +1160,7 @@ export function insertSummaryFacts(
 
 			const importance = Math.min(item.importance ?? 0.3, 0.5);
 
-			if (isDuplicate(db as unknown as Database, item.content, job.agent_id)) continue;
+			if (isDuplicate(db as unknown as Database, item.content, agentId)) continue;
 
 			const id = crypto.randomUUID();
 			const type = item.type || inferType(item.content);
@@ -1176,7 +1177,7 @@ export function insertSummaryFacts(
 				job.harness,
 				item.tags || null,
 				job.project || null,
-				job.agent_id,
+				agentId,
 				now,
 				now,
 				SUMMARY_WORKER_UPDATED_BY,

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -1159,7 +1159,7 @@ export function insertSummaryFacts(
 
 			const importance = Math.min(item.importance ?? 0.3, 0.5);
 
-			if (isDuplicate(db as unknown as Database, item.content)) continue;
+			if (isDuplicate(db as unknown as Database, item.content, job.agent_id)) continue;
 
 			const id = crypto.randomUUID();
 			const type = item.type || inferType(item.content);

--- a/packages/daemon/src/pipeline/synthesis-worker.test.ts
+++ b/packages/daemon/src/pipeline/synthesis-worker.test.ts
@@ -16,7 +16,7 @@ const mockHandleSynthesisRequest = mock(
 		indexBlock: "",
 	}),
 );
-const mockWriteMemoryMd = mock((_content: string, _opts?: { owner?: string }) => ({ ok: true as const }));
+const mockWriteMemoryMd = mock((_content: string, _opts?: { agentId?: string; owner?: string }) => ({ ok: true as const }));
 const mockActiveSessionCount = mock(() => 0);
 const baseCfg = {
 	enabled: true,
@@ -119,9 +119,12 @@ describe("synthesis-worker", () => {
 				reason: undefined,
 			});
 			expect(worker.isSynthesizing).toBe(false);
-			expect(mockWriteMemoryMd).toHaveBeenCalledWith("# MEMORY\n\nprojection for default", {
-				owner: "synthesis-worker",
-			});
+			expect(mockWriteMemoryMd).toHaveBeenCalledWith(
+				"# MEMORY\n\nprojection for default",
+				expect.objectContaining({
+					owner: "synthesis-worker",
+				}),
+			);
 		} finally {
 			worker.stop();
 			await worker.drain();
@@ -202,9 +205,12 @@ describe("synthesis-worker", () => {
 				reason: undefined,
 			});
 			expect(mockHandleSynthesisRequest).toHaveBeenCalledTimes(1);
-			expect(mockWriteMemoryMd).toHaveBeenCalledWith("# MEMORY\n\nprojection for default", {
-				owner: "synthesis-worker",
-			});
+			expect(mockWriteMemoryMd).toHaveBeenCalledWith(
+				"# MEMORY\n\nprojection for default",
+				expect.objectContaining({
+					owner: "synthesis-worker",
+				}),
+			);
 		} finally {
 			worker.stop();
 			expect(await worker.drain()).toBe("completed");
@@ -226,6 +232,13 @@ describe("synthesis-worker", () => {
 				}),
 				expect.objectContaining({
 					agentId: "agent-a",
+				}),
+			);
+			expect(mockWriteMemoryMd).toHaveBeenCalledWith(
+				"# MEMORY\n\nprojection for agent-a",
+				expect.objectContaining({
+					agentId: "agent-a",
+					owner: "synthesis-worker",
 				}),
 			);
 		} finally {

--- a/packages/daemon/src/pipeline/synthesis-worker.test.ts
+++ b/packages/daemon/src/pipeline/synthesis-worker.test.ts
@@ -124,6 +124,7 @@ describe("synthesis-worker", () => {
 			expect(mockWriteMemoryMd).toHaveBeenCalledWith(
 				"# MEMORY\n\nprojection for default",
 				expect.objectContaining({
+					agentId: "default",
 					owner: "synthesis-worker",
 				}),
 			);
@@ -210,6 +211,7 @@ describe("synthesis-worker", () => {
 			expect(mockWriteMemoryMd).toHaveBeenCalledWith(
 				"# MEMORY\n\nprojection for default",
 				expect.objectContaining({
+					agentId: "default",
 					owner: "synthesis-worker",
 				}),
 			);

--- a/packages/daemon/src/pipeline/synthesis-worker.test.ts
+++ b/packages/daemon/src/pipeline/synthesis-worker.test.ts
@@ -16,7 +16,9 @@ const mockHandleSynthesisRequest = mock(
 		indexBlock: "",
 	}),
 );
-const mockWriteMemoryMd = mock((_content: string, _opts?: { agentId?: string; owner?: string }) => ({ ok: true as const }));
+const mockWriteMemoryMd = mock((_content: string, _opts?: { agentId?: string; owner?: string }) => ({
+	ok: true as const,
+}));
 const mockActiveSessionCount = mock(() => 0);
 const baseCfg = {
 	enabled: true,

--- a/packages/daemon/src/pipeline/synthesis-worker.ts
+++ b/packages/daemon/src/pipeline/synthesis-worker.ts
@@ -191,10 +191,11 @@ async function runSynthesisWithDeps(
 	config: PipelineSynthesisConfig,
 	agentId?: string,
 ): Promise<SynthesisResult> {
+	const scopeAgentId = normalizeAgentId(agentId);
 	deps.logger.info("synthesis", "Starting scheduled synthesis", {
 		provider: config.provider,
 		model: config.model,
-		agentId: agentId ?? "default",
+		agentId: scopeAgentId,
 	});
 
 	try {
@@ -202,7 +203,7 @@ async function runSynthesisWithDeps(
 			{ trigger: "scheduled" },
 			{
 				maxTokens: config.maxTokens,
-				agentId,
+				agentId: scopeAgentId,
 			},
 		);
 
@@ -219,7 +220,7 @@ async function runSynthesisWithDeps(
 
 		// Write MEMORY.md via shared helper (handles backup)
 		const writeResult = deps.writeMemoryMd(finalText, {
-			agentId,
+			agentId: scopeAgentId,
 			owner: "synthesis-worker",
 		});
 		if (!writeResult.ok) {

--- a/packages/daemon/src/pipeline/synthesis-worker.ts
+++ b/packages/daemon/src/pipeline/synthesis-worker.ts
@@ -218,7 +218,10 @@ async function runSynthesisWithDeps(
 		const finalText = synthesisData.prompt.trimEnd();
 
 		// Write MEMORY.md via shared helper (handles backup)
-		const writeResult = deps.writeMemoryMd(finalText, { owner: "synthesis-worker" });
+		const writeResult = deps.writeMemoryMd(finalText, {
+			agentId,
+			owner: "synthesis-worker",
+		});
 		if (!writeResult.ok) {
 			if (writeResult.code === "busy") {
 				deps.logger.warn("synthesis", "MEMORY.md head busy, deferring synthesis write");

--- a/packages/daemon/test/hooks.test.ts
+++ b/packages/daemon/test/hooks.test.ts
@@ -568,7 +568,7 @@ describe("isDuplicate", () => {
 		]);
 
 		const db = openTestDb();
-		const result = isDuplicate(db, "The user prefers dark mode and vim keybindings");
+		const result = isDuplicate(db, "The user prefers dark mode and vim keybindings", "default");
 		db.close();
 
 		expect(result).toBe(true);
@@ -578,7 +578,7 @@ describe("isDuplicate", () => {
 		createMemoryDb([{ content: "Project uses TypeScript and Bun" }]);
 
 		const db = openTestDb();
-		const result = isDuplicate(db, "The weather is sunny and warm today");
+		const result = isDuplicate(db, "The weather is sunny and warm today", "default");
 		db.close();
 
 		expect(result).toBe(false);
@@ -588,7 +588,7 @@ describe("isDuplicate", () => {
 		createMemoryDb([]);
 
 		const db = openTestDb();
-		const result = isDuplicate(db, "Some new content here");
+		const result = isDuplicate(db, "Some new content here", "default");
 		db.close();
 
 		expect(result).toBe(false);
@@ -599,7 +599,7 @@ describe("isDuplicate", () => {
 
 		const db = openTestDb();
 		// All words < 3 chars, should return false (no words to match)
-		const result = isDuplicate(db, "is an a to or");
+		const result = isDuplicate(db, "is an a to or", "default");
 		db.close();
 
 		expect(result).toBe(false);


### PR DESCRIPTION
## Summary
Fix the multi-agent memory pipeline so sub-agents can persist their own extracted facts, retain their own synthesized MEMORY head state, and survive CLI/daemon roster round-trips without policy drift.

## Context
Issue #448 reported that OpenClaw sub-agents were ending sessions with almost no retained memories and no per-agent MEMORY head state, even though the default agent accumulated plenty of memory data.

The main failure modes here were:
- duplicate suppression comparing new sub-agent facts against all memories instead of the current agent scope,
- synthesis writes rendering with an agent scope but recording the resulting MEMORY head as `default`,
- CLI roster persistence using a different shape than daemon startup sync expected.

## Changes
- Scope summary-worker duplicate detection by `agent_id`
- Pass the requested `agentId` through scheduled/forced MEMORY synthesis writes
- Add shared roster normalization/build helpers in core
- Update CLI agent roster writes to use canonical nested `memory.read_policy` entries
- Update daemon roster sync to normalize both canonical and legacy roster entries
- Switch shared YAML utilities to the repo YAML serializer/parser so nested roster config round-trips correctly
- Add regression tests for dedupe, synthesis scoping, and roster serialization

### Key Implementation Details
Summary fact insertion now calls the duplicate checker with the job's `agent_id`, and the duplicate checker filters candidate matches to the same memory owner before overlap comparison.

Synthesis already rendered with the requested agent scope, but the write path dropped that scope. The write helper now receives the same `agentId`, which keeps `memory_md_heads` updates aligned with the agent being synthesized.

Roster handling is now centralized in core so the CLI and daemon share the same normalization rules for canonical nested entries and legacy flat entries. That preserves backward compatibility while making new writes consistent.

## Use Cases
- A sub-agent can save a fact even if the default agent already has the same fact.
- Forced synthesis after a sub-agent session updates that sub-agent's MEMORY head instead of overwriting `default` state.
- `signet agent add --memory group --group writers` survives daemon restarts without silently degrading back to isolated behavior.

## Testing
```bash
bun test packages/daemon/src/pipeline/summary-worker.test.ts packages/daemon/src/pipeline/synthesis-worker.test.ts packages/core/src/__tests__/identity.test.ts packages/cli/src/commands/agent.test.ts
```

Targeted regression tests pass locally.

I also attempted package-level TypeScript checks with:
- `bunx tsc --noEmit` in `packages/daemon`
- `bunx tsc --noEmit` in `packages/cli`

Those still report unrelated pre-existing workspace/typecheck issues outside this PR.

## Links
- Related issues: #448
