### PR TITLE
fix: harden transcript capture and summary inputs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1746,8 +1746,9 @@ Releases the session's runtime path claim.
 ```
 
 `harness` is required.
-`transcriptPath` or inline `transcript` may be provided for lossless transcript
-capture.
+`transcriptPath` or inline `transcript` may be provided for transcript
+capture. Signet stores a cleaned conversation-only transcript in memory
+surfaces and may retain raw auditable traces separately in daemon logs.
 
 When transcript text is available, the daemon first writes canonical
 workspace-root-relative markdown lineage files under

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -184,11 +184,14 @@ Gated on `hints.enabled` in pipeline config.
 writes complete. A failure here is non-fatal — it logs a warning and
 does not revert the extracted memories.
 
-**Lossless transcripts**: at session end, the raw conversation text
-is stored in `session_transcripts` (migration 040) alongside the
-extracted memories. This preserves context that extraction may
-discard. The recall endpoint's `expand: true` flag joins transcript
-content back into search results via `source_id`.
+**Lossless transcripts**: Signet stores a cleaned conversation-only
+transcript in `session_transcripts` (migration 040) alongside the
+extracted memories. Tool calls, tool outputs, and thinking traces are
+kept out of this memory surface so retrieval and summarization operate
+on the human/agent exchange. Raw auditable traces may still be written
+to daemon logs outside the memory lineage. The recall endpoint's
+`expand: true` flag joins transcript content back into search results
+via `source_id`.
 
 **Shadow mode**: when `shadowMode = true`, all proposals are logged
 to `memory_history` under the `pipeline-shadow` actor but no
@@ -658,11 +661,12 @@ reappear.
 **session_transcripts** (migration 040)
 
 Lossless session transcript storage. Fields: `session_key` (PK),
-`content` (raw conversation text), `harness`, `project`, `agent_id`,
-`created_at`. Written at session end alongside extracted memories.
-The recall endpoint supports `expand: true` to join transcript
-content back into results via `source_id`, preserving facts that
-extraction may drop. Indexed on `project` and `created_at`.
+`content` (cleaned conversation transcript), `harness`, `project`,
+`agent_id`, `created_at`. The transcript keeps only user/assistant
+conversation turns for memory use. Raw tool traces may be retained in
+daemon logs for audit. The recall endpoint supports `expand: true` to
+join transcript content back into results via `source_id`, preserving
+facts that extraction may drop. Indexed on `project` and `created_at`.
 
 **umap_cache**
 

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -894,10 +894,13 @@ are re-sorted by adjusted score descending.
 Lossless Session Transcripts
 ---
 
-After the summary worker extracts facts from a session, it also writes
-the raw transcript to the `session_transcripts` table (migration 040).
-This preserves completeness — extraction creates the search surface, but
-the full conversation text is never lost.
+After the summary worker extracts facts from a session, Signet also
+stores a cleaned conversation-only transcript in the
+`session_transcripts` table (migration 040). Tool calls, tool outputs,
+and thinking traces are removed from this memory surface so retrieval
+and summarization stay focused on the actual conversation. Raw
+auditable traces may still be written to daemon logs outside the memory
+lineage.
 
 The table schema (`session_key TEXT PRIMARY KEY, content TEXT NOT NULL,
 harness TEXT, project TEXT, agent_id TEXT, created_at TEXT`) is indexed
@@ -907,7 +910,7 @@ session via `INSERT OR IGNORE`, keyed on `session_key`.
 The `/api/memory/remember` endpoint accepts an optional `transcript`
 field. When present and a `sourceId` (session key) is available, the
 transcript is written to `session_transcripts` in a separate write
-transaction. This allows connectors to push the raw conversation text
+transaction. This allows connectors to push cleaned conversation text
 alongside memories without waiting for session-end summary processing.
 
 At recall time, the `/api/memory/recall` endpoint supports `expand:

--- a/docs/specs/approved/desire-paths-epic.md
+++ b/docs/specs/approved/desire-paths-epic.md
@@ -106,7 +106,8 @@ regardless of content significance.
 3. Call from `worker.ts` after session transcript is received, before
    extraction. If all three checks indicate low significance, emit
    `session_skipped` telemetry event and return.
-4. Raw transcript still persisted (lossless retention applies).
+4. A cleaned conversation transcript still persists in memory surfaces,
+   and raw auditable traces may persist separately in daemon logs.
 
 **Config additions** (in `PipelineV2Config`):
 - `pipeline.minTurns` (default 5)

--- a/docs/specs/approved/lossless-working-memory-runtime.md
+++ b/docs/specs/approved/lossless-working-memory-runtime.md
@@ -121,10 +121,11 @@ Throughout the session lifecycle:
   distillation pipeline
 - prompt-submit retrieval should prefer the structured memory body when
   available
-- transcripts are the fallback source until structural state catches up
+- cleaned conversation transcripts are the fallback source until
+  structural state catches up
 
 This keeps prompt-time retrieval focused on the most relevant context
-without making raw transcripts the default source of truth.
+without making raw tool traces the default source of truth.
 
 ## Harness Realization
 

--- a/docs/specs/approved/memory-md-temporal-head.md
+++ b/docs/specs/approved/memory-md-temporal-head.md
@@ -37,7 +37,8 @@ higher-order condensed nodes, and drill-down lineage.
 `MEMORY.md` is the rendered temporal head of Signet's lossless working
 memory system.
 
-- transcript context is retained losslessly in `session_transcripts`
+- transcript context is retained in `session_transcripts` as a cleaned
+  conversation-only view for retrieval and continuity
 - temporal abstractions are stored in `session_summaries`
 - `MEMORY.md` is a materialized working document rendered from scored
   database state, not assembled from markdown files

--- a/docs/specs/approved/system-prompt-extraction.md
+++ b/docs/specs/approved/system-prompt-extraction.md
@@ -101,7 +101,7 @@ For deeper exploration:
 
   mcp__signet__lcm_expand — drill into a session summary node.
   Returns parent/child lineage, linked memories, and optionally the
-  raw transcript. Use this when memory_search returns a session
+  cleaned transcript. Use this when memory_search returns a session
   reference you want to expand.
 
   mcp__signet__knowledge_expand — drill into an entity's aspects,
@@ -109,6 +109,10 @@ For deeper exploration:
 
   mcp__signet__knowledge_expand_session — find session summaries
   linked to a specific entity.
+
+Cross-session history is also available through linked summary and
+transcript artifacts in the Signet workspace. Inspect those artifacts
+directly when MEMORY.md or recall snippets are not enough.
 
 To store a memory explicitly:
 

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -266,7 +266,7 @@ fn normalize_project(raw: Option<&str>) -> Option<String> {
     Some(s.replace('\\', "/").trim_end_matches('/').to_string())
 }
 
-fn normalize_session_transcript(harness: &str, raw: &str) -> String {
+fn normalize_session_transcript(raw: &str) -> String {
     let lines = raw
         .lines()
         .map(str::trim)
@@ -288,7 +288,6 @@ fn normalize_session_transcript(harness: &str, raw: &str) -> String {
         }
     }
 
-    let _ = harness;
 
     // Fall back to raw only when the input does not look like JSONL
     // conversation data. If it is JSONL and we extracted zero turns, return
@@ -884,38 +883,77 @@ pub async fn prompt_submit(
         let mut raw_transcript = body.transcript.clone().unwrap_or_default();
         if raw_transcript.is_empty()
             && let Some(path) = body.transcript_path.as_deref()
-            && std::path::Path::new(path).exists()
+            && !path.trim().is_empty()
         {
-            match fs::read_to_string(path) {
+            let canonical = match fs::canonicalize(path) {
+                Ok(value) => value,
+                Err(e) => {
+                    warn!(path, error = %e, "prompt-submit: transcript_path unresolvable");
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(serde_json::json!({"error": format!("transcript_path unresolvable: {e}")})),
+                    )
+                        .into_response();
+                }
+            };
+            if !transcript_path_allowed(&canonical) {
+                warn!(path = %canonical.display(), "prompt-submit: transcript_path outside allowed roots");
+                return (
+                    StatusCode::FORBIDDEN,
+                    Json(serde_json::json!({"error": "transcript_path outside allowed workspace roots"})),
+                )
+                    .into_response();
+            }
+            match fs::read_to_string(&canonical) {
                 Ok(content) => raw_transcript = content,
-                Err(e) => warn!(path, error = %e, "prompt-submit: transcript read failed"),
+                Err(e) => warn!(path = %canonical.display(), error = %e, "prompt-submit: transcript read failed"),
             }
         }
 
-        let normalized = normalize_session_transcript(harness, &raw_transcript);
+        let normalized = normalize_session_transcript(&raw_transcript);
         if !normalized.trim().is_empty() {
             let harness_value = harness.to_string();
             let project_value = body.project.clone();
             let agent_value = agent_id.clone();
-            let session_key_for_write = session_key_value.clone();
-            let normalized_for_write = normalized.clone();
-            if let Err(e) = state
+            let session_key_for_read = session_key_value.clone();
+            let agent_for_read = agent_id.clone();
+            let normalized_len = normalized.len();
+            let should_write = match state
                 .pool
-                .write(Priority::Low, move |conn| {
-                    upsert_session_transcript(
-                        conn,
-                        &session_key_for_write,
-                        &normalized_for_write,
-                        &harness_value,
-                        project_value.as_deref(),
-                        &agent_value,
-                    )
-                    .map(|_| serde_json::Value::Null)
-                    .map_err(|err| signet_core::error::CoreError::Migration(err.to_string()))
+                .read(move |conn| {
+                    session_transcript_content(conn, &session_key_for_read, &agent_for_read)
+                        .map(|prev| prev.is_none_or(|value| normalized_len >= value.len()))
+                        .map_err(|err| signet_core::error::CoreError::Migration(err.to_string()))
                 })
                 .await
             {
-                warn!(error = %e, session_key = %session_key_value, "prompt-submit: transcript upsert failed");
+                Ok(value) => value,
+                Err(e) => {
+                    warn!(error = %e, session_key = %session_key_value, "prompt-submit: transcript length check failed");
+                    false
+                }
+            };
+            if should_write {
+                let session_key_for_write = session_key_value.clone();
+                let normalized_for_write = normalized.clone();
+                if let Err(e) = state
+                    .pool
+                    .write(Priority::Low, move |conn| {
+                        upsert_session_transcript(
+                            conn,
+                            &session_key_for_write,
+                            &normalized_for_write,
+                            &harness_value,
+                            project_value.as_deref(),
+                            &agent_value,
+                        )
+                        .map(|_| serde_json::Value::Null)
+                        .map_err(|err| signet_core::error::CoreError::Migration(err.to_string()))
+                    })
+                    .await
+                {
+                    warn!(error = %e, session_key = %session_key_value, "prompt-submit: transcript upsert failed");
+                }
             }
         }
 
@@ -1514,7 +1552,7 @@ pub async fn session_end(
 
     // Normalized view used for LLM inputs (summary job) and the legacy DB
     // upsert.  The canonical artifact above gets the raw original.
-    let mut normalized = normalize_session_transcript(harness, &transcript);
+    let mut normalized = normalize_session_transcript(&transcript);
     if !session_key.trim().is_empty() {
         let session_key_value = session_key.clone();
         let agent_value = agent_id.clone();
@@ -2955,9 +2993,103 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn prompt_submit_rejects_transcript_path_outside_allowed_roots() {
+        let (state, writer, tmp) = test_state("hooks-prompt-submit-path-guard");
+        let transcript_path = tmp.path().join("prompt-transcript.txt");
+        std::fs::write(&transcript_path, "User: hi\nAssistant: hello").unwrap();
+
+        let resp = prompt_submit(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(PromptSubmitBody {
+                harness: Some("test".to_string()),
+                project: Some("packages/daemon-rs".to_string()),
+                agent_id: Some("agent-a".to_string()),
+                user_message: Some("review the release checklist".to_string()),
+                user_prompt: None,
+                last_assistant_message: None,
+                session_key: Some("sess-prompt-denied".to_string()),
+                transcript: None,
+                transcript_path: Some(transcript_path.display().to_string()),
+                runtime_path: None,
+            }),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let body = test_json(resp).await;
+        assert_eq!(
+            body["error"],
+            serde_json::Value::String("transcript_path outside allowed workspace roots".to_string())
+        );
+
+        drop(state);
+        let _ = writer.await;
+    }
+
+    #[tokio::test]
+    async fn prompt_submit_keeps_longer_stored_transcript_snapshot() {
+        let (state, writer, _tmp) = test_state("hooks-prompt-submit-length-guard");
+        state
+            .pool
+            .write(Priority::Low, move |conn| {
+                upsert_session_transcript(
+                    conn,
+                    "sess-prompt-guard",
+                    &"User: longer transcript\nAssistant: still longer\n".repeat(6),
+                    "test",
+                    Some("packages/daemon-rs"),
+                    "agent-a",
+                )?;
+                Ok(serde_json::Value::Null)
+            })
+            .await
+            .unwrap();
+
+        let resp = prompt_submit(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(PromptSubmitBody {
+                harness: Some("test".to_string()),
+                project: Some("packages/daemon-rs".to_string()),
+                agent_id: Some("agent-a".to_string()),
+                user_message: Some("review the release checklist".to_string()),
+                user_prompt: None,
+                last_assistant_message: None,
+                session_key: Some("sess-prompt-guard".to_string()),
+                transcript: Some("User: short\nAssistant: short".to_string()),
+                transcript_path: None,
+                runtime_path: None,
+            }),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let stored = state
+            .pool
+            .read(|conn| {
+                session_transcript_content(conn, "sess-prompt-guard", "agent-a")
+                    .map_err(|err| signet_core::error::CoreError::Migration(err.to_string()))
+            })
+            .await
+            .unwrap()
+            .unwrap_or_default();
+        assert!(stored.contains("longer transcript"));
+        assert!(!stored.contains("User: short\nAssistant: short"));
+
+        drop(state);
+        let _ = writer.await;
+    }
+
+    #[tokio::test]
     async fn prompt_submit_writes_transcript_audit_and_live_snapshot() {
         let (state, writer, tmp) = test_state("hooks-prompt-submit-audit");
-        let transcript_path = tmp.path().join("prompt-transcript.txt");
+        let stage_dir = std::path::Path::new("/tmp/signet");
+        std::fs::create_dir_all(stage_dir).unwrap();
+        let transcript_path = stage_dir.join(format!(
+            "prompt-transcript-{}.txt",
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
         std::fs::write(
             &transcript_path,
             "User: review the release checklist
@@ -3009,6 +3141,7 @@ Assistant: here's the checklist",
                 .and_then(|name| name.to_str())
                 .is_some_and(|name| name.ends_with("--latest.log"))
         }));
+        let _ = std::fs::remove_file(&transcript_path);
 
         drop(state);
         let _ = writer.await;
@@ -3317,7 +3450,7 @@ Assistant: here's the checklist",
         ]
         .join("\n");
         assert_eq!(
-            normalize_session_transcript("codex", &raw),
+            normalize_session_transcript(&raw),
             "User: Hello\nAssistant: Hi"
         );
     }
@@ -3329,7 +3462,7 @@ Assistant: here's the checklist",
             r#"{"type":"response_item","payload":{"type":"function_call_output","output":"README.md"}}"#,
         ]
         .join("\n");
-        assert_eq!(normalize_session_transcript("opencode", &raw), "");
+        assert_eq!(normalize_session_transcript(&raw), "");
     }
 
     #[test]

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -288,7 +288,6 @@ fn normalize_session_transcript(raw: &str) -> String {
         }
     }
 
-
     // Fall back to raw only when the input does not look like JSONL
     // conversation data. If it is JSONL and we extracted zero turns, return
     // the empty normalized view so tool-only logs do not pollute summaries.
@@ -303,11 +302,7 @@ fn normalize_json_transcript_line(value: &serde_json::Value) -> Option<String> {
     if value.get("type").and_then(serde_json::Value::as_str) == Some("item.completed") {
         let item = value.get("item")?;
         if item.get("type").and_then(serde_json::Value::as_str) == Some("agent_message") {
-            let text = item
-                .get("text")
-                .or_else(|| item.get("message"))
-                .or_else(|| item.get("content"))
-                .and_then(serde_json::Value::as_str)?;
+            let text = extract_json_message_text(item)?;
             return Some(format!("Assistant: {text}"));
         }
     }
@@ -456,8 +451,8 @@ fn resolve_audit_token(
     } else {
         let mut digest = Sha256::new();
         digest.update(raw.as_bytes());
-        let bytes = digest.finalize();
-        bytes[..16]
+        digest
+            .finalize()
             .iter()
             .map(|b| format!("{b:02x}"))
             .collect::<String>()
@@ -906,7 +901,9 @@ pub async fn prompt_submit(
             }
             match fs::read_to_string(&canonical) {
                 Ok(content) => raw_transcript = content,
-                Err(e) => warn!(path = %canonical.display(), error = %e, "prompt-submit: transcript read failed"),
+                Err(e) => {
+                    warn!(path = %canonical.display(), error = %e, "prompt-submit: transcript read failed")
+                }
             }
         }
 
@@ -915,45 +912,32 @@ pub async fn prompt_submit(
             let harness_value = harness.to_string();
             let project_value = body.project.clone();
             let agent_value = agent_id.clone();
-            let session_key_for_read = session_key_value.clone();
-            let agent_for_read = agent_id.clone();
-            let normalized_len = normalized.len();
-            let should_write = match state
+            let session_key_for_write = session_key_value.clone();
+            let normalized_for_write = normalized.clone();
+            let normalized_len = normalized_for_write.len();
+            if let Err(e) = state
                 .pool
-                .read(move |conn| {
-                    session_transcript_content(conn, &session_key_for_read, &agent_for_read)
-                        .map(|prev| prev.is_none_or(|value| normalized_len >= value.len()))
-                        .map_err(|err| signet_core::error::CoreError::Migration(err.to_string()))
+                .write(Priority::Low, move |conn| {
+                    let should_write =
+                        session_transcript_content(conn, &session_key_for_write, &agent_value)?
+                            .is_none_or(|value| normalized_len >= value.len());
+                    if !should_write {
+                        return Ok(serde_json::Value::Bool(false));
+                    }
+                    upsert_session_transcript(
+                        conn,
+                        &session_key_for_write,
+                        &normalized_for_write,
+                        &harness_value,
+                        project_value.as_deref(),
+                        &agent_value,
+                    )
+                    .map(|_| serde_json::Value::Bool(true))
+                    .map_err(|err| signet_core::error::CoreError::Migration(err.to_string()))
                 })
                 .await
             {
-                Ok(value) => value,
-                Err(e) => {
-                    warn!(error = %e, session_key = %session_key_value, "prompt-submit: transcript length check failed");
-                    false
-                }
-            };
-            if should_write {
-                let session_key_for_write = session_key_value.clone();
-                let normalized_for_write = normalized.clone();
-                if let Err(e) = state
-                    .pool
-                    .write(Priority::Low, move |conn| {
-                        upsert_session_transcript(
-                            conn,
-                            &session_key_for_write,
-                            &normalized_for_write,
-                            &harness_value,
-                            project_value.as_deref(),
-                            &agent_value,
-                        )
-                        .map(|_| serde_json::Value::Null)
-                        .map_err(|err| signet_core::error::CoreError::Migration(err.to_string()))
-                    })
-                    .await
-                {
-                    warn!(error = %e, session_key = %session_key_value, "prompt-submit: transcript upsert failed");
-                }
+                warn!(error = %e, session_key = %session_key_value, "prompt-submit: transcript upsert failed");
             }
         }
 
@@ -2752,6 +2736,7 @@ mod tests {
     use axum::extract::State;
     use axum::http::{HeaderMap, StatusCode};
     use serde_json::Value;
+    use sha2::{Digest, Sha256};
     use signet_core::config::{
         AgentManifest, DaemonConfig, MemoryManifestConfig, PipelineV2Config,
     };
@@ -2766,9 +2751,9 @@ mod tests {
         CHECKPOINT_MIN_DELTA, CompactionCompleteBody, PromptSubmitBody, SessionEndBody,
         build_signet_system_prompt, compaction_complete, extract_delta,
         normalize_session_transcript, parse_visibility, prompt_submit,
-        require_session_scope_for_write, resolve_compaction_project, resolve_remember_agent,
-        session_agent_id, session_end, session_transcript_content, strip_untrusted_metadata,
-        upsert_session_transcript,
+        require_session_scope_for_write, resolve_audit_token, resolve_compaction_project,
+        resolve_remember_agent, session_agent_id, session_end, session_transcript_content,
+        strip_untrusted_metadata, upsert_session_transcript,
     };
     use signet_services::session::{RuntimePath, SessionTracker};
 
@@ -3020,7 +3005,9 @@ mod tests {
         let body = test_json(resp).await;
         assert_eq!(
             body["error"],
-            serde_json::Value::String("transcript_path outside allowed workspace roots".to_string())
+            serde_json::Value::String(
+                "transcript_path outside allowed workspace roots".to_string()
+            )
         );
 
         drop(state);
@@ -3079,6 +3066,48 @@ mod tests {
 
         drop(state);
         let _ = writer.await;
+    }
+
+    #[test]
+    fn normalize_session_transcript_normalizes_item_completed_text() {
+        let raw = [
+            r#"{"type":"item.completed","item":{"type":"agent_message","text":"line one\r\nline two"}}"#,
+            r#"{"type":"event_msg","payload":{"type":"user_message","message":"done"}}"#,
+        ]
+        .join("\n");
+
+        let normalized = normalize_session_transcript(&raw);
+
+        assert!(normalized.contains("Assistant: line one  line two"));
+        assert!(normalized.contains("User: done"));
+    }
+
+    #[test]
+    fn resolve_audit_token_uses_full_raw_hash_when_session_identity_missing() {
+        let raw = "User: audit me\nAssistant: on it";
+        let raw_hash = {
+            let mut digest = Sha256::new();
+            digest.update(raw.as_bytes());
+            digest
+                .finalize()
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect::<String>()
+        };
+        let expected = {
+            let mut digest = Sha256::new();
+            digest.update(b"agent-a");
+            digest.update(b":");
+            digest.update(raw_hash.as_bytes());
+            digest
+                .finalize()
+                .iter()
+                .take(8)
+                .map(|b| format!("{b:02x}"))
+                .collect::<String>()
+        };
+
+        assert_eq!(resolve_audit_token("agent-a", "", None, raw), expected);
     }
 
     #[tokio::test]

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -429,9 +429,9 @@ fn audit_fs_timestamp(iso: &str) -> String {
 
 fn is_safe_audit_name(value: &str) -> bool {
     !value.is_empty()
-        && value.bytes().all(|byte| {
-            byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.')
-        })
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
 }
 
 fn build_audit_path(root: &Path, file_name: &str) -> std::io::Result<PathBuf> {
@@ -494,10 +494,10 @@ fn write_transcript_audit(
         let final_path = build_audit_path(
             root,
             &format!(
-            "{}--{}--raw-transcript.log",
-            audit_fs_timestamp(captured_at),
-            token
-        ),
+                "{}--{}--raw-transcript.log",
+                audit_fs_timestamp(captured_at),
+                token
+            ),
         )?;
         fs::write(final_path, raw_transcript)?;
     }
@@ -571,7 +571,10 @@ fn enqueue_summary_job(
         rusqlite::params![agent_id, session_id, trigger],
         |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
     ) {
-        if existing_status == "pending" || existing_status == "leased" || existing_status == "processing" {
+        if existing_status == "pending"
+            || existing_status == "leased"
+            || existing_status == "processing"
+        {
             // Update the transcript so retries with fresher content are used.
             let _ = conn.execute(
                 "UPDATE summary_jobs SET transcript = ?1, updated_at = ?2 WHERE id = ?3",
@@ -644,7 +647,8 @@ pub async fn session_start(
 
     // Session claim
     if let Some(p) = path
-        && let ClaimResult::Conflict { claimed_by } = state.sessions.claim(&session_key, p, &agent_id)
+        && let ClaimResult::Conflict { claimed_by } =
+            state.sessions.claim(&session_key, p, &agent_id)
     {
         return conflict_response(claimed_by);
     }
@@ -748,6 +752,8 @@ pub struct PromptSubmitBody {
     #[allow(dead_code)] // Will be used for context-aware search in Phase 5
     pub last_assistant_message: Option<String>,
     pub session_key: Option<String>,
+    pub transcript: Option<String>,
+    pub transcript_path: Option<String>,
     pub runtime_path: Option<String>,
 }
 
@@ -859,6 +865,10 @@ pub async fn prompt_submit(
         .collect();
     let query_terms = terms.join(" ");
     let metadata_header = format_metadata_header();
+    let agent_id = body
+        .agent_id
+        .clone()
+        .unwrap_or_else(|| "default".to_string());
 
     // Record in continuity tracker
     if let Some(key) = &body.session_key {
@@ -868,6 +878,59 @@ pub async fn prompt_submit(
             cleaned.as_str()
         };
         state.continuity.record_prompt(key, &query_terms, snippet);
+    }
+
+    if let Some(session_key_value) = body.session_key.clone() {
+        let mut raw_transcript = body.transcript.clone().unwrap_or_default();
+        if raw_transcript.is_empty()
+            && let Some(path) = body.transcript_path.as_deref()
+            && std::path::Path::new(path).exists()
+        {
+            match fs::read_to_string(path) {
+                Ok(content) => raw_transcript = content,
+                Err(e) => warn!(path, error = %e, "prompt-submit: transcript read failed"),
+            }
+        }
+
+        let normalized = normalize_session_transcript(harness, &raw_transcript);
+        if !normalized.trim().is_empty() {
+            let harness_value = harness.to_string();
+            let project_value = body.project.clone();
+            let agent_value = agent_id.clone();
+            let session_key_for_write = session_key_value.clone();
+            let normalized_for_write = normalized.clone();
+            if let Err(e) = state
+                .pool
+                .write(Priority::Low, move |conn| {
+                    upsert_session_transcript(
+                        conn,
+                        &session_key_for_write,
+                        &normalized_for_write,
+                        &harness_value,
+                        project_value.as_deref(),
+                        &agent_value,
+                    )
+                    .map(|_| serde_json::Value::Null)
+                    .map_err(|err| signet_core::error::CoreError::Migration(err.to_string()))
+                })
+                .await
+            {
+                warn!(error = %e, session_key = %session_key_value, "prompt-submit: transcript upsert failed");
+            }
+        }
+
+        if !raw_transcript.trim().is_empty()
+            && let Err(e) = write_transcript_audit(
+                &state.config.base_path,
+                &agent_id,
+                &session_key_value,
+                Some(session_key_value.as_str()),
+                &raw_transcript,
+                None,
+            )
+        {
+            warn!(error = %e, session_key = %session_key_value, "prompt-submit: transcript audit write failed");
+        }
     }
 
     if query_terms.is_empty() {
@@ -884,10 +947,6 @@ pub async fn prompt_submit(
 
     let project = body.project.clone();
     let session_key = body.session_key.clone();
-    let agent_id = body
-        .agent_id
-        .clone()
-        .unwrap_or_else(|| "default".to_string());
     let query_terms_for_resp = query_terms.clone();
     // Mirror TS hooks.userPromptSubmit.minScore confidence gate. The TS path
     // uses calibrated hybridRecall + reranker scores; here we use term-coverage
@@ -1303,7 +1362,9 @@ pub async fn session_end(
     // being written under a different agent than the one that opened the session.
     let agent_id = match resolve_remember_agent(
         body.agent_id.as_deref(),
-        headers.get("x-signet-agent-id").and_then(|v| v.to_str().ok()),
+        headers
+            .get("x-signet-agent-id")
+            .and_then(|v| v.to_str().ok()),
         if session_key.trim().is_empty() {
             None
         } else {
@@ -1362,7 +1423,9 @@ pub async fn session_end(
                 state.dedup.clear(&session_key);
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({"error": format!("transcript_path unresolvable: {e}")})),
+                    Json(
+                        serde_json::json!({"error": format!("transcript_path unresolvable: {e}")}),
+                    ),
                 )
                     .into_response();
             }
@@ -1380,7 +1443,9 @@ pub async fn session_end(
             state.dedup.clear(&session_key);
             return (
                 StatusCode::FORBIDDEN,
-                Json(serde_json::json!({"error": "transcript_path outside allowed workspace roots"})),
+                Json(
+                    serde_json::json!({"error": "transcript_path outside allowed workspace roots"}),
+                ),
             )
                 .into_response();
         }
@@ -1603,7 +1668,9 @@ pub async fn session_end(
             state.dedup.clear(&session_key);
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": format!("transcript artifact write failed: {e}")})),
+                Json(
+                    serde_json::json!({"error": format!("transcript artifact write failed: {e}")}),
+                ),
             )
                 .into_response();
         }
@@ -1981,12 +2048,7 @@ pub async fn recall(
     // Previously the handler used a hardcoded default of 10 and applied no min_score
     // filter; the TS endpoint was updated to pass cfg through hybridRecall which
     // uses cfg.search.top_k and cfg.search.min_score.  Mirror those semantics here.
-    let search_cfg = state
-        .config
-        .manifest
-        .search
-        .clone()
-        .unwrap_or_default();
+    let search_cfg = state.config.manifest.search.clone().unwrap_or_default();
     let limit = body.limit.unwrap_or(search_cfg.top_k).min(50);
     let min_score = search_cfg.min_score;
     let query = query.to_string();
@@ -2226,7 +2288,9 @@ pub async fn compaction_complete(
     // compaction lineage can't be attributed to an arbitrary caller-supplied id.
     let agent_id = match resolve_remember_agent(
         body.agent_id.as_deref(),
-        headers.get("x-signet-agent-id").and_then(|v| v.to_str().ok()),
+        headers
+            .get("x-signet-agent-id")
+            .and_then(|v| v.to_str().ok()),
         body.session_key.as_deref(),
     ) {
         Ok(id) => id,
@@ -2287,10 +2351,7 @@ pub async fn compaction_complete(
                     h.update(b":");
                     h.update(summary_value.as_bytes());
                     let digest = h.finalize();
-                    let hex: String = digest[..8]
-                        .iter()
-                        .map(|b| format!("{b:02x}"))
-                        .collect();
+                    let hex: String = digest[..8].iter().map(|b| format!("{b:02x}")).collect();
                     format!("compaction:{hex}")
                 });
                 let noise = is_noise_session(
@@ -2338,7 +2399,9 @@ pub async fn compaction_complete(
         Err(e) => {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": format!("compaction artifact write failed: {e}")})),
+                Json(
+                    serde_json::json!({"error": format!("compaction artifact write failed: {e}")}),
+                ),
             )
                 .into_response();
         }
@@ -2662,12 +2725,12 @@ mod tests {
     use crate::state::AppState;
 
     use super::{
-        CHECKPOINT_MIN_DELTA, CompactionCompleteBody, SessionEndBody,
+        CHECKPOINT_MIN_DELTA, CompactionCompleteBody, PromptSubmitBody, SessionEndBody,
         build_signet_system_prompt, compaction_complete, extract_delta,
-        normalize_session_transcript, parse_visibility,
-        require_session_scope_for_write, resolve_compaction_project,
-        resolve_remember_agent, session_agent_id, session_end,
-        strip_untrusted_metadata, upsert_session_transcript,
+        normalize_session_transcript, parse_visibility, prompt_submit,
+        require_session_scope_for_write, resolve_compaction_project, resolve_remember_agent,
+        session_agent_id, session_end, session_transcript_content, strip_untrusted_metadata,
+        upsert_session_transcript,
     };
     use signet_services::session::{RuntimePath, SessionTracker};
 
@@ -2886,6 +2949,66 @@ mod tests {
             .unwrap();
         let manifest_text = std::fs::read_to_string(manifest).unwrap();
         assert!(manifest_text.contains("compaction_path: memory/"));
+
+        drop(state);
+        let _ = writer.await;
+    }
+
+    #[tokio::test]
+    async fn prompt_submit_writes_transcript_audit_and_live_snapshot() {
+        let (state, writer, tmp) = test_state("hooks-prompt-submit-audit");
+        let transcript_path = tmp.path().join("prompt-transcript.txt");
+        std::fs::write(
+            &transcript_path,
+            "User: review the release checklist
+Assistant: here's the checklist",
+        )
+        .unwrap();
+
+        let resp = prompt_submit(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(PromptSubmitBody {
+                harness: Some("test".to_string()),
+                project: Some("packages/daemon-rs".to_string()),
+                agent_id: Some("agent-a".to_string()),
+                user_message: Some("review the release checklist".to_string()),
+                user_prompt: None,
+                last_assistant_message: None,
+                session_key: Some("sess-prompt-audit".to_string()),
+                transcript: None,
+                transcript_path: Some(transcript_path.display().to_string()),
+                runtime_path: None,
+            }),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let stored = state
+            .pool
+            .read(|conn| {
+                session_transcript_content(conn, "sess-prompt-audit", "agent-a")
+                    .map_err(|err| signet_core::error::CoreError::Migration(err.to_string()))
+            })
+            .await
+            .unwrap();
+        assert!(
+            stored
+                .as_deref()
+                .is_some_and(|value| value.contains("review the release checklist"))
+        );
+
+        let audit_dir = tmp.path().join(".daemon/logs/transcripts");
+        let audit_entries = std::fs::read_dir(&audit_dir)
+            .unwrap()
+            .filter_map(|entry| entry.ok().map(|value| value.path()))
+            .collect::<Vec<_>>();
+        assert!(audit_entries.iter().any(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.ends_with("--latest.log"))
+        }));
 
         drop(state);
         let _ = writer.await;
@@ -3146,10 +3269,14 @@ mod tests {
                     .query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))
                     .unwrap_or(0);
                 let summaries: i64 = conn
-                    .query_row("SELECT COUNT(*) FROM session_summaries", [], |row| row.get(0))
+                    .query_row("SELECT COUNT(*) FROM session_summaries", [], |row| {
+                        row.get(0)
+                    })
                     .unwrap_or(0);
                 let heads: i64 = conn
-                    .query_row("SELECT COUNT(*) FROM memory_thread_heads", [], |row| row.get(0))
+                    .query_row("SELECT COUNT(*) FROM memory_thread_heads", [], |row| {
+                        row.get(0)
+                    })
                     .unwrap_or(0);
                 Ok((artifacts, memories, summaries, heads))
             })

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -323,7 +323,7 @@ fn normalize_json_transcript_line(value: &serde_json::Value) -> Option<String> {
 
     if let Some(message) = value.get("message").and_then(serde_json::Value::as_object) {
         let role = extract_json_string_from_map(message, &["role", "speaker"]);
-        let text = extract_json_message_text(&serde_json::Value::Object(message.clone()));
+        let text = extract_json_message_text_from_map(message);
         match (role.as_deref(), text) {
             (Some("user"), Some(text)) => return Some(format!("User: {text}")),
             (Some("assistant"), Some(text)) => return Some(format!("Assistant: {text}")),
@@ -364,6 +364,21 @@ fn extract_json_message_text(value: &serde_json::Value) -> Option<String> {
     }
 
     let content = value.get("content")?.as_array()?;
+    extract_json_text_parts(content)
+}
+
+fn extract_json_message_text_from_map(
+    obj: &serde_json::Map<String, serde_json::Value>,
+) -> Option<String> {
+    if let Some(text) = extract_json_string_from_map(obj, &["content", "text", "message"]) {
+        return Some(text);
+    }
+
+    let content = obj.get("content")?.as_array()?;
+    extract_json_text_parts(content)
+}
+
+fn extract_json_text_parts(content: &[serde_json::Value]) -> Option<String> {
     let parts = content
         .iter()
         .filter_map(|item| {
@@ -1492,7 +1507,24 @@ pub async fn session_end(
             format!("session-end:{hex}")
         });
 
-    // Gate before any writes — no-op sessions don't need artifact/job work.
+    if let Err(e) = write_transcript_audit(
+        &state.config.base_path,
+        &agent_id,
+        &session_id,
+        if session_key.trim().is_empty() {
+            None
+        } else {
+            Some(session_key.as_str())
+        },
+        &transcript,
+        Some(&ended_at),
+    ) {
+        warn!(error = %e, "session-end: transcript audit write failed");
+    }
+
+    // Gate before canonical artifact/job work — raw audit traces are still
+    // preserved for non-empty transcripts even when normalization produces no
+    // conversation turns.
     if normalized.trim().is_empty() {
         if !session_key.trim().is_empty() {
             let session_key_value = session_key.clone();
@@ -1526,21 +1558,6 @@ pub async fn session_end(
         Some(session_key.as_str()),
         Some(harness),
     );
-
-    if let Err(e) = write_transcript_audit(
-        &state.config.base_path,
-        &agent_id,
-        &session_id,
-        if session_key.trim().is_empty() {
-            None
-        } else {
-            Some(session_key.as_str())
-        },
-        &transcript,
-        Some(&ended_at),
-    ) {
-        warn!(error = %e, "session-end: transcript audit write failed");
-    }
 
     // Canonical artifact always written before pipeline gates — it is the
     // lineage source of truth regardless of pipeline_enabled or shadow_mode.

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -401,7 +401,32 @@ fn transcript_audit_dir(root: &Path) -> PathBuf {
 }
 
 fn audit_fs_timestamp(iso: &str) -> String {
-    iso.replace(':', "-")
+    iso.chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+fn is_safe_audit_name(value: &str) -> bool {
+    !value.is_empty()
+        && value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.')
+        })
+}
+
+fn build_audit_path(root: &Path, file_name: &str) -> std::io::Result<PathBuf> {
+    if !is_safe_audit_name(file_name) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "invalid transcript audit file name",
+        ));
+    }
+    Ok(transcript_audit_dir(root).join(file_name))
 }
 
 fn resolve_audit_token(
@@ -448,14 +473,17 @@ fn write_transcript_audit(
     let dir = transcript_audit_dir(root);
     fs::create_dir_all(&dir)?;
     let token = resolve_audit_token(agent_id, session_id, session_key, raw_transcript);
-    let latest = dir.join(format!("{token}--latest.log"));
+    let latest = build_audit_path(root, &format!("{token}--latest.log"))?;
     fs::write(latest, raw_transcript)?;
     if let Some(captured_at) = captured_at {
-        let final_path = dir.join(format!(
+        let final_path = build_audit_path(
+            root,
+            &format!(
             "{}--{}--raw-transcript.log",
             audit_fs_timestamp(captured_at),
             token
-        ));
+        ),
+        )?;
         fs::write(final_path, raw_transcript)?;
     }
     Ok(())

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -5,7 +5,7 @@
 //! remember, recall, pre-compaction, and compaction-complete.
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use sha2::{Digest, Sha256};
@@ -15,7 +15,7 @@ use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use serde::Deserialize;
-use tracing::warn;
+use tracing::{info, warn};
 
 use signet_core::db::Priority;
 use signet_pipeline::memory_lineage::{
@@ -116,6 +116,10 @@ Memory tools:\n\
 - mcp__signet__knowledge_expand: expand a known entity into its aspects, attributes, and dependencies\n\
 - mcp__signet__knowledge_expand_session: find sessions linked to a known entity\n\
 - mcp__signet__memory_store: save something to memory explicitly\n\
+\n\
+Cross-session history:\n\
+- linked summary and transcript artifacts in your Signet workspace are inspectable across sessions\n\
+- use transcript and summary artifacts when you need deeper history than MEMORY.md or recall snippets provide\n\
 \n\
 Identity files in your Signet workspace:\n\
 - AGENTS.md: how you operate (maintain this)\n\
@@ -263,10 +267,6 @@ fn normalize_project(raw: Option<&str>) -> Option<String> {
 }
 
 fn normalize_session_transcript(harness: &str, raw: &str) -> String {
-    if harness.trim().eq_ignore_ascii_case("codex") {
-        return raw.to_string();
-    }
-
     let lines = raw
         .lines()
         .map(str::trim)
@@ -288,11 +288,12 @@ fn normalize_session_transcript(harness: &str, raw: &str) -> String {
         }
     }
 
-    // Fall back to raw if fewer than 60% of lines parsed as JSON, OR if we
-    // parsed enough JSON but extracted zero messages (valid-but-unrecognized
-    // JSONL format).  An empty normalized string would silently discard all
-    // input content; raw is always preferable to silence.
-    if parsed * 10 < lines.len() * 6 || normalized.is_empty() {
+    let _ = harness;
+
+    // Fall back to raw only when the input does not look like JSONL
+    // conversation data. If it is JSONL and we extracted zero turns, return
+    // the empty normalized view so tool-only logs do not pollute summaries.
+    if parsed * 10 < lines.len() * 6 {
         raw.to_string()
     } else {
         normalized.join("\n")
@@ -315,29 +316,149 @@ fn normalize_json_transcript_line(value: &serde_json::Value) -> Option<String> {
     if value.get("type").and_then(serde_json::Value::as_str) == Some("event_msg") {
         let payload = value.get("payload")?;
         if payload.get("type").and_then(serde_json::Value::as_str) == Some("user_message") {
-            let text = payload
-                .get("message")
-                .or_else(|| payload.get("text"))
-                .or_else(|| payload.get("content"))
-                .and_then(serde_json::Value::as_str)?;
+            let text = extract_json_string(payload, &["message", "text", "content"])?;
             return Some(format!("User: {text}"));
         }
     }
 
-    let role = value
-        .get("role")
-        .or_else(|| value.get("speaker"))
-        .and_then(serde_json::Value::as_str);
-    let text = value
-        .get("content")
-        .or_else(|| value.get("text"))
-        .or_else(|| value.get("message"))
-        .and_then(serde_json::Value::as_str);
-    match (role, text) {
+    if let Some(message) = value.get("message").and_then(serde_json::Value::as_object) {
+        let role = extract_json_string_from_map(message, &["role", "speaker"]);
+        let text = extract_json_message_text(&serde_json::Value::Object(message.clone()));
+        match (role.as_deref(), text) {
+            (Some("user"), Some(text)) => return Some(format!("User: {text}")),
+            (Some("assistant"), Some(text)) => return Some(format!("Assistant: {text}")),
+            _ => {}
+        }
+    }
+
+    let role = extract_json_string(value, &["role", "speaker"]);
+    let text = extract_json_message_text(value);
+    match (role.as_deref(), text) {
         (Some("user"), Some(text)) => Some(format!("User: {text}")),
         (Some("assistant"), Some(text)) => Some(format!("Assistant: {text}")),
         _ => None,
     }
+}
+
+fn extract_json_string(value: &serde_json::Value, keys: &[&str]) -> Option<String> {
+    let obj = value.as_object()?;
+    extract_json_string_from_map(obj, keys)
+}
+
+fn extract_json_string_from_map(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    keys: &[&str],
+) -> Option<String> {
+    keys.iter().find_map(|key| {
+        obj.get(*key)
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+            .map(|text| text.replace(['\r', '\n'], " "))
+    })
+}
+
+fn extract_json_message_text(value: &serde_json::Value) -> Option<String> {
+    if let Some(text) = extract_json_string(value, &["content", "text", "message"]) {
+        return Some(text);
+    }
+
+    let content = value.get("content")?.as_array()?;
+    let parts = content
+        .iter()
+        .filter_map(|item| {
+            let obj = item.as_object()?;
+            if obj.get("type").and_then(serde_json::Value::as_str) != Some("text") {
+                return None;
+            }
+            extract_json_string_from_map(obj, &["text", "content"])
+        })
+        .collect::<Vec<_>>();
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(" "))
+    }
+}
+
+fn session_transcript_content(
+    conn: &rusqlite::Connection,
+    session_key: &str,
+    agent_id: &str,
+) -> rusqlite::Result<Option<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT content FROM session_transcripts WHERE session_key = ?1 AND agent_id = ?2 LIMIT 1",
+    )?;
+    let mut rows = stmt.query(rusqlite::params![session_key, agent_id])?;
+    if let Some(row) = rows.next()? {
+        return row.get(0).map(Some);
+    }
+    Ok(None)
+}
+
+fn transcript_audit_dir(root: &Path) -> PathBuf {
+    root.join(".daemon").join("logs").join("transcripts")
+}
+
+fn audit_fs_timestamp(iso: &str) -> String {
+    iso.replace(':', "-")
+}
+
+fn resolve_audit_token(
+    agent_id: &str,
+    session_id: &str,
+    session_key: Option<&str>,
+    raw: &str,
+) -> String {
+    let scoped = if !session_id.trim().is_empty() {
+        session_id.trim().to_string()
+    } else if let Some(key) = session_key.map(str::trim).filter(|key| !key.is_empty()) {
+        key.to_string()
+    } else {
+        let mut digest = Sha256::new();
+        digest.update(raw.as_bytes());
+        let bytes = digest.finalize();
+        bytes[..16]
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<String>()
+    };
+    let mut digest = Sha256::new();
+    digest.update(agent_id.as_bytes());
+    digest.update(b":");
+    digest.update(scoped.as_bytes());
+    let bytes = digest.finalize();
+    bytes[..8]
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<String>()
+}
+
+fn write_transcript_audit(
+    root: &Path,
+    agent_id: &str,
+    session_id: &str,
+    session_key: Option<&str>,
+    raw_transcript: &str,
+    captured_at: Option<&str>,
+) -> std::io::Result<()> {
+    if raw_transcript.trim().is_empty() {
+        return Ok(());
+    }
+    let dir = transcript_audit_dir(root);
+    fs::create_dir_all(&dir)?;
+    let token = resolve_audit_token(agent_id, session_id, session_key, raw_transcript);
+    let latest = dir.join(format!("{token}--latest.log"));
+    fs::write(latest, raw_transcript)?;
+    if let Some(captured_at) = captured_at {
+        let final_path = dir.join(format!(
+            "{}--{}--raw-transcript.log",
+            audit_fs_timestamp(captured_at),
+            token
+        ));
+        fs::write(final_path, raw_transcript)?;
+    }
+    Ok(())
 }
 
 fn upsert_session_transcript(
@@ -1285,7 +1406,29 @@ pub async fn session_end(
 
     // Normalized view used for LLM inputs (summary job) and the legacy DB
     // upsert.  The canonical artifact above gets the raw original.
-    let normalized = normalize_session_transcript(harness, &transcript);
+    let mut normalized = normalize_session_transcript(harness, &transcript);
+    if !session_key.trim().is_empty() {
+        let session_key_value = session_key.clone();
+        let agent_value = agent_id.clone();
+        if let Ok(Some(stored)) = state
+            .pool
+            .read(move |conn| {
+                session_transcript_content(conn, &session_key_value, &agent_value)
+                    .map_err(|err| signet_core::error::CoreError::Migration(err.to_string()))
+            })
+            .await
+            && !stored.trim().is_empty()
+            && (normalized.trim().is_empty() || stored.len() > normalized.len())
+        {
+            info!(
+                session_key,
+                live_chars = stored.len(),
+                final_chars = normalized.len(),
+                "session-end: using stored transcript snapshot"
+            );
+            normalized = stored;
+        }
+    }
 
     // Resolve session_id now that transcript is available for the content-hash
     // fallback.  Priority: explicit body.session_id → session_key → content hash.
@@ -1322,7 +1465,7 @@ pub async fn session_end(
         });
 
     // Gate before any writes — no-op sessions don't need artifact/job work.
-    if transcript.trim().is_empty() {
+    if normalized.trim().is_empty() {
         if !session_key.trim().is_empty() {
             let session_key_value = session_key.clone();
             let agent_value = agent_id.clone();
@@ -1356,12 +1499,27 @@ pub async fn session_end(
         Some(harness),
     );
 
+    if let Err(e) = write_transcript_audit(
+        &state.config.base_path,
+        &agent_id,
+        &session_id,
+        if session_key.trim().is_empty() {
+            None
+        } else {
+            Some(session_key.as_str())
+        },
+        &transcript,
+        Some(&ended_at),
+    ) {
+        warn!(error = %e, "session-end: transcript audit write failed");
+    }
+
     // Canonical artifact always written before pipeline gates — it is the
     // lineage source of truth regardless of pipeline_enabled or shadow_mode.
     // This matches compaction_complete, which also writes artifacts unconditionally
     // so manifests and backlinks never reference transcripts that don't exist.
     if !noise {
-        let transcript_value = transcript.clone();
+        let transcript_value = normalized.clone();
         let root = state.config.base_path.clone();
         let session_key_value = if session_key.trim().is_empty() {
             None
@@ -2459,9 +2617,11 @@ mod tests {
     use crate::state::AppState;
 
     use super::{
-        CHECKPOINT_MIN_DELTA, CompactionCompleteBody, SessionEndBody, compaction_complete,
-        extract_delta, parse_visibility, require_session_scope_for_write,
-        resolve_compaction_project, resolve_remember_agent, session_agent_id, session_end,
+        CHECKPOINT_MIN_DELTA, CompactionCompleteBody, SessionEndBody,
+        build_signet_system_prompt, compaction_complete, extract_delta,
+        normalize_session_transcript, parse_visibility,
+        require_session_scope_for_write, resolve_compaction_project,
+        resolve_remember_agent, session_agent_id, session_end,
         strip_untrusted_metadata, upsert_session_transcript,
     };
     use signet_services::session::{RuntimePath, SessionTracker};
@@ -2772,6 +2932,136 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn session_end_falls_back_to_stored_live_transcript_when_final_input_missing() {
+        let (state, writer, tmp) = test_state("hooks-session-end-live-fallback");
+        let now = chrono::Utc::now().to_rfc3339();
+        state
+            .pool
+            .write(Priority::Low, move |conn| {
+                conn.execute(
+                    "INSERT INTO session_transcripts (session_key, content, harness, project, agent_id, created_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                    rusqlite::params![
+                        "agent:agent-a:sess-live-fallback",
+                        "User: keep the live transcript if session-end falls over.\nAssistant: using the stored live transcript avoids losing the session.\n"
+                            .repeat(8),
+                        "test",
+                        "packages/daemon-rs",
+                        "agent-a",
+                        now
+                    ],
+                )?;
+                Ok(serde_json::Value::Null)
+            })
+            .await
+            .unwrap();
+
+        let resp = session_end(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(SessionEndBody {
+                harness: Some("test".to_string()),
+                transcript: None,
+                transcript_path: None,
+                session_id: Some("sess-live-fallback".to_string()),
+                session_key: Some("agent:agent-a:sess-live-fallback".to_string()),
+                cwd: Some("packages/daemon-rs".to_string()),
+                reason: None,
+                runtime_path: None,
+                agent_id: Some("agent-a".to_string()),
+            }),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = test_json(resp).await;
+        assert_eq!(body["queued"], serde_json::Value::Bool(true));
+
+        let transcript = std::fs::read_dir(tmp.path().join("memory"))
+            .unwrap()
+            .filter_map(|entry| entry.ok().map(|value| value.path()))
+            .find(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.ends_with("--transcript.md"))
+            })
+            .map(|path| std::fs::read_to_string(path).unwrap())
+            .unwrap();
+        assert!(transcript.contains("keep the live transcript if session-end falls over"));
+        assert!(transcript.contains("using the stored live transcript avoids losing the session"));
+
+        drop(state);
+        let _ = writer.await;
+    }
+
+    #[tokio::test]
+    async fn session_end_writes_raw_audit_logs_but_keeps_canonical_transcript_clean() {
+        let (state, writer, tmp) = test_state("hooks-session-end-audit");
+        let transcript = [
+            r#"{"type":"event_msg","payload":{"type":"user_message","message":"Run diagnostics"}}"#,
+            r#"{"type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{\"cmd\":\"ls\"}"}}"#,
+            r#"{"type":"response_item","payload":{"type":"function_call_output","output":"README.md"}}"#,
+            r#"{"type":"item.completed","item":{"type":"agent_message","text":"Diagnostics complete"}}"#,
+        ]
+        .join("\n")
+            + "\n";
+        let transcript = transcript.repeat(20);
+
+        let resp = session_end(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(SessionEndBody {
+                harness: Some("codex".to_string()),
+                transcript: Some(transcript),
+                transcript_path: None,
+                session_id: Some("sess-audit".to_string()),
+                session_key: Some("agent:agent-a:sess-audit".to_string()),
+                cwd: Some("packages/daemon-rs".to_string()),
+                reason: None,
+                runtime_path: None,
+                agent_id: Some("agent-a".to_string()),
+            }),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = test_json(resp).await;
+        assert_eq!(body["queued"], serde_json::Value::Bool(true));
+
+        let canonical = std::fs::read_dir(tmp.path().join("memory"))
+            .unwrap()
+            .filter_map(|entry| entry.ok().map(|value| value.path()))
+            .find(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.ends_with("--transcript.md"))
+            })
+            .map(|path| std::fs::read_to_string(path).unwrap())
+            .unwrap();
+        assert!(canonical.contains("User: Run diagnostics"));
+        assert!(canonical.contains("Assistant: Diagnostics complete"));
+        assert!(!canonical.contains("function_call"));
+        assert!(!canonical.contains("README.md"));
+
+        let audit_dir = tmp.path().join(".daemon").join("logs").join("transcripts");
+        let audit = std::fs::read_dir(audit_dir)
+            .unwrap()
+            .filter_map(|entry| entry.ok().map(|value| value.path()))
+            .find(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.ends_with("--raw-transcript.log"))
+            })
+            .map(|path| std::fs::read_to_string(path).unwrap())
+            .unwrap();
+        assert!(audit.contains("\"type\":\"function_call\""));
+        assert!(audit.contains("README.md"));
+
+        drop(state);
+        let _ = writer.await;
+    }
+
+    #[tokio::test]
     async fn compaction_complete_skips_noise_session_writes() {
         let (state, writer, tmp) = test_state("hooks-compaction-noise");
 
@@ -2838,6 +3128,36 @@ mod tests {
             Some("alpha")
         );
         assert_eq!(session_agent_id(Some("session:sess-1")), None);
+    }
+
+    #[test]
+    fn build_signet_system_prompt_mentions_transcript_artifacts() {
+        assert!(build_signet_system_prompt().contains("linked summary and transcript artifacts"));
+    }
+
+    #[test]
+    fn normalize_session_transcript_strips_codex_tool_turns() {
+        let raw = [
+            r#"{"type":"event_msg","payload":{"type":"user_message","message":"Hello"}}"#,
+            r#"{"type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{\"cmd\":\"ls\"}"}}"#,
+            r#"{"type":"response_item","payload":{"type":"function_call_output","output":"README.md"}}"#,
+            r#"{"type":"item.completed","item":{"type":"agent_message","text":"Hi"}}"#,
+        ]
+        .join("\n");
+        assert_eq!(
+            normalize_session_transcript("codex", &raw),
+            "User: Hello\nAssistant: Hi"
+        );
+    }
+
+    #[test]
+    fn normalize_session_transcript_returns_empty_for_tool_only_jsonl() {
+        let raw = [
+            r#"{"type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{\"cmd\":\"ls\"}"}}"#,
+            r#"{"type":"response_item","payload":{"type":"function_call_output","output":"README.md"}}"#,
+        ]
+        .join("\n");
+        assert_eq!(normalize_session_transcript("opencode", &raw), "");
     }
 
     #[test]

--- a/packages/daemon-rs/crates/signet-pipeline/src/summary.rs
+++ b/packages/daemon-rs/crates/signet-pipeline/src/summary.rs
@@ -498,13 +498,13 @@ fn parse_llm_response(raw: &str) -> Result<LlmSummaryEnvelope, String> {
 
 fn build_prompt(transcript: &str, date: &str) -> String {
     format!(
-        "You are a session librarian. Summarize this coding session as a dated markdown note and extract key durable facts.\n\nReturn ONLY a JSON object:\n{{\n  \"summary\": \"# {date} Session Notes\\n\\n## Topic Name\\n\\nProse summary...\",\n  \"facts\": [{{\"content\": \"...\", \"importance\": 0.3, \"tags\": \"tag1,tag2\", \"type\": \"fact\"}}]\n}}\n\nSummary guidelines:\n- Start with \"# {date} Session Notes\"\n- Use ## headings for distinct topics\n- Include what was worked on, key decisions, and open threads\n- Be concise but complete\n\nFact guidelines:\n- durable, self-contained knowledge only\n- include concrete subject names in every fact\n- max 15 facts\n\nConversation:\n{transcript}"
+        "You are reviewing a cleaned transcript from one coding session. The transcript already contains only the human/agent conversation turns, with tool calls, tool outputs, and thinking removed.\n\nUse judgment. Focus on what actually mattered.\n\nReturn ONLY a JSON object:\n{{\n  \"summary\": \"# {date} Session Notes\\n\\n## Topic Name\\n\\nFree-form session note...\",\n  \"facts\": [{{\"content\": \"...\", \"importance\": 0.3, \"tags\": \"tag1,tag2\", \"type\": \"fact\"}}]\n}}\n\nSummary:\n- Start with \"# {date} Session Notes\"\n- Use ## headings for distinct topics\n- Cover what was worked on, key decisions, unresolved threads, and anything likely to matter later\n- Prefer concrete names, files, systems, or people when they matter\n- Write in past tense, third person\n\nFacts:\n- each fact must be self-contained and understandable without this conversation\n- include the specific subject in every fact\n- keep only durable knowledge, preferences, rules, or decisions\n- types: fact, preference, decision, learning, rule, issue\n- importance: 0.3 (routine) to 0.5 (significant)\n- max 15 facts\n\nConversation:\n{transcript}"
     )
 }
 
 fn build_chunk_prompt(chunk: &str, idx: usize, total: usize, date: &str) -> String {
     format!(
-        "You are a session librarian. This is chunk {} of {} from a long coding session on {}. Summarize this segment and extract key durable facts.\n\nReturn ONLY a JSON object:\n{{\n  \"summary\": \"Prose summary of this segment...\",\n  \"facts\": [{{\"content\": \"...\", \"importance\": 0.3, \"tags\": \"tag1,tag2\", \"type\": \"fact\"}}]\n}}\n\nConversation segment:\n{}",
+        "You are reviewing chunk {} of {} from one cleaned coding-session transcript on {}. Tool calls, tool outputs, and thinking have already been removed.\n\nUse judgment. Focus on what mattered in this segment.\n\nReturn ONLY a JSON object:\n{{\n  \"summary\": \"Free-form summary of this segment...\",\n  \"facts\": [{{\"content\": \"...\", \"importance\": 0.3, \"tags\": \"tag1,tag2\", \"type\": \"fact\"}}]\n}}\n\nSummary:\n- summarize what was discussed or worked on in this segment\n- capture decisions, important context, and unresolved threads\n- write in past tense, third person\n\nFacts:\n- each fact must be self-contained and understandable without this conversation\n- include the specific subject in every fact\n- keep only durable knowledge worth carrying forward\n- types: fact, preference, decision, learning, rule, issue\n- importance: 0.3 (routine) to 0.5 (significant)\n- max 10 facts\n\nConversation segment:\n{}",
         idx + 1,
         total,
         date,
@@ -526,8 +526,13 @@ fn build_combine_prompt(leaves: &[String], facts: &[SummaryFact], date: &str) ->
         .collect::<Vec<_>>()
         .join("\n");
     format!(
-        "You are a session librarian. Combine the segment summaries below into one session summary for {} and deduplicate the durable facts.\n\nReturn ONLY a JSON object:\n{{\n  \"summary\": \"# {} Session Notes\\n\\n## Topic Name\\n\\nProse summary...\",\n  \"facts\": [{{\"content\": \"...\", \"importance\": 0.3, \"tags\": \"tag1,tag2\", \"type\": \"fact\"}}]\n}}\n\nSegment summaries:\n{}\n\nFacts:\n{}",
-        date, date, summary_blocks, fact_lines
+        "You are combining {} segment summaries from one cleaned coding-session transcript on {}. Produce one coherent session note and one deduplicated durable fact list.\n\nReturn ONLY a JSON object:\n{{\n  \"summary\": \"# {} Session Notes\\n\\n## Topic Name\\n\\nFree-form session note...\",\n  \"facts\": [{{\"content\": \"...\", \"importance\": 0.3, \"tags\": \"tag1,tag2\", \"type\": \"fact\"}}]\n}}\n\nSummary:\n- Start with \"# {} Session Notes\"\n- Use ## headings for each distinct topic discussed\n- merge overlapping content from segments without repeating yourself\n- keep the note coherent, concrete, and useful for future continuity\n- write in past tense, third person\n\nFacts:\n- deduplicate facts that say the same thing in different words\n- keep the most specific version of each fact\n- max 15 facts total\n\nSegment summaries:\n{}\n\nFacts:\n{}",
+        leaves.len(),
+        date,
+        date,
+        date,
+        summary_blocks,
+        fact_lines
     )
 }
 

--- a/packages/daemon/src/hooks.test.ts
+++ b/packages/daemon/src/hooks.test.ts
@@ -23,6 +23,7 @@ describe("buildSignetSystemPrompt", () => {
 		expect(prompt).toContain("mcp__signet__memory_store");
 		expect(prompt).toContain("mcp__signet__secret_list");
 		expect(prompt).toContain("mcp__signet__secret_exec");
+		expect(prompt).toContain("linked summary and transcript artifacts");
 	});
 });
 

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -36,14 +36,13 @@ import { logger } from "./logger";
 import { loadMemoryConfig } from "./memory-config";
 import { writeMemoryHead } from "./memory-head";
 import {
-	appendSynthesisIndexBlock as appendRenderedIndexBlock,
 	NOISE_PURGE_REASON,
+	appendSynthesisIndexBlock as appendRenderedIndexBlock,
 	purgeCanonicalNoiseSessionsOnce,
 	renderMemoryProjection,
 	writeTranscriptArtifact,
 } from "./memory-lineage";
 import { buildAgentScopeClause, hybridRecall } from "./memory-search";
-import { isNoiseSession } from "./session-noise";
 import {
 	applyFtsOverlapFeedback,
 	decayAspectWeights,
@@ -83,10 +82,12 @@ import {
 	writeCheckpoint,
 } from "./session-checkpoints";
 import { parseFeedback, recordAgentFeedback, recordSessionCandidates, trackFtsHits } from "./session-memories";
+import { isNoiseSession } from "./session-noise";
 import { getExpiryWarning } from "./session-tracker";
 import { getSessionTranscriptContent, searchTranscriptFallback, upsertSessionTranscript } from "./session-transcripts";
 import { type StructuralFeatures, buildCandidateFeatures, getStructuralFeatures } from "./structural-features";
 import { searchTemporalFallback } from "./temporal-fallback";
+import { writeTranscriptAudit } from "./transcript-audit";
 import { getUpdateSummary } from "./update-system";
 
 function getAgentsDir(): string {
@@ -166,6 +167,10 @@ Memory tools:
 - mcp__signet__knowledge_expand: expand a known entity into its aspects, attributes, and dependencies
 - mcp__signet__knowledge_expand_session: find sessions linked to a known entity
 - mcp__signet__memory_store: save something to memory explicitly
+
+Cross-session history:
+- linked summary and transcript artifacts in your Signet workspace are inspectable across sessions
+- use transcript and summary artifacts when you need deeper history than MEMORY.md or recall snippets provide
 
 Identity files in your Signet workspace:
 - AGENTS.md: how you operate (maintain this)
@@ -2241,26 +2246,47 @@ export async function handleUserPromptSubmit(
 	}
 
 	if (req.sessionKey) {
+		let rawTranscript = "";
 		let transcript = "";
 		if (req.transcriptPath && existsSync(req.transcriptPath)) {
 			try {
-				const raw = readFileSync(req.transcriptPath, "utf-8");
-				transcript = normalizeSessionTranscript(req.harness, raw);
+				rawTranscript = readFileSync(req.transcriptPath, "utf-8");
+				transcript = normalizeSessionTranscript(req.harness, rawTranscript);
 			} catch {
 				deps.logger.warn("hooks", "Could not read prompt transcript", {
 					path: req.transcriptPath,
 				});
 			}
 		} else if (req.transcript) {
-			transcript = normalizeSessionTranscript(req.harness, req.transcript);
+			rawTranscript = req.transcript;
+			transcript = normalizeSessionTranscript(req.harness, rawTranscript);
 		}
 
 		if (transcript) {
 			try {
-				deps.upsertSessionTranscript(req.sessionKey, transcript, req.harness, req.project ?? null, agentId);
+				const prev = getSessionTranscriptContent(req.sessionKey, agentId);
+				if (!prev || transcript.length >= prev.length) {
+					deps.upsertSessionTranscript(req.sessionKey, transcript, req.harness, req.project ?? null, agentId);
+				}
 			} catch (error) {
 				deps.logger.warn("hooks", "Prompt transcript write failed", {
 					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+		}
+
+		if (rawTranscript) {
+			try {
+				writeTranscriptAudit({
+					agentId,
+					sessionId: req.sessionKey,
+					sessionKey: req.sessionKey,
+					rawTranscript,
+				});
+			} catch (error) {
+				deps.logger.warn("hooks", "Prompt transcript audit write failed", {
+					error: error instanceof Error ? error.message : String(error),
+					sessionKey: req.sessionKey,
 				});
 			}
 		}
@@ -2595,10 +2621,11 @@ export function handleSessionEnd(req: SessionEndRequest): SessionEndResponse {
 	}
 
 	// Read transcript: prefer file path, fall back to inline body
+	let rawTranscript = "";
 	let transcript = "";
 	if (req.transcriptPath && existsSync(req.transcriptPath)) {
 		try {
-			const rawTranscript = readFileSync(req.transcriptPath, "utf-8");
+			rawTranscript = readFileSync(req.transcriptPath, "utf-8");
 			transcript = normalizeSessionTranscript(req.harness, rawTranscript);
 		} catch {
 			logger.warn("hooks", "Could not read transcript", {
@@ -2606,7 +2633,35 @@ export function handleSessionEnd(req: SessionEndRequest): SessionEndResponse {
 			});
 		}
 	} else if (req.transcript) {
-		transcript = normalizeSessionTranscript(req.harness, req.transcript);
+		rawTranscript = req.transcript;
+		transcript = normalizeSessionTranscript(req.harness, rawTranscript);
+	}
+
+	const storedTranscript = sessionKey ? (getSessionTranscriptContent(sessionKey, agentId) ?? "") : "";
+	if (storedTranscript.length > 0 && (transcript.length === 0 || storedTranscript.length > transcript.length)) {
+		logger.info("hooks", "Session end using stored transcript snapshot", {
+			sessionKey,
+			liveChars: storedTranscript.length,
+			finalChars: transcript.length,
+		});
+		transcript = storedTranscript;
+	}
+
+	if (rawTranscript) {
+		try {
+			writeTranscriptAudit({
+				agentId,
+				sessionId: req.sessionId?.trim() || sessionKey || "",
+				sessionKey: sessionKey ?? null,
+				rawTranscript,
+				capturedAt: endedAt,
+			});
+		} catch (error) {
+			logger.warn("hooks", "Session end transcript audit write failed", {
+				error: error instanceof Error ? error.message : String(error),
+				sessionKey,
+			});
+		}
 	}
 	// Derive a stable session identity for artifact paths.  When the
 	// transcript is empty and no explicit sessionId was provided,

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -2278,6 +2278,7 @@ export async function handleUserPromptSubmit(
 		if (rawTranscript) {
 			try {
 				writeTranscriptAudit({
+					basePath: getAgentsDir(),
 					agentId,
 					sessionId: req.sessionKey,
 					sessionKey: req.sessionKey,
@@ -2660,6 +2661,7 @@ export function handleSessionEnd(req: SessionEndRequest): SessionEndResponse {
 	if (rawTranscript) {
 		try {
 			writeTranscriptAudit({
+				basePath: getAgentsDir(),
 				agentId,
 				sessionId: req.sessionId?.trim() || sessionKey || "",
 				sessionKey: sessionKey ?? null,

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -2637,7 +2637,17 @@ export function handleSessionEnd(req: SessionEndRequest): SessionEndResponse {
 		transcript = normalizeSessionTranscript(req.harness, rawTranscript);
 	}
 
-	const storedTranscript = sessionKey ? (getSessionTranscriptContent(sessionKey, agentId) ?? "") : "";
+	let storedTranscript = "";
+	if (sessionKey) {
+		try {
+			storedTranscript = getSessionTranscriptContent(sessionKey, agentId) ?? "";
+		} catch (error) {
+			logger.warn("hooks", "Failed to read stored transcript for fallback", {
+				error: error instanceof Error ? error.message : String(error),
+				sessionKey,
+			});
+		}
+	}
 	if (storedTranscript.length > 0 && (transcript.length === 0 || storedTranscript.length > transcript.length)) {
 		logger.info("hooks", "Session end using stored transcript snapshot", {
 			sessionKey,

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -153,26 +153,27 @@ const CHUNK_TARGET_CHARS = 20_000;
 // ---------------------------------------------------------------------------
 
 function buildPrompt(transcript: string, date: string): string {
-	return `You are a session librarian. Summarize this coding session as a dated markdown note and extract key durable facts.
+	return `You are reviewing a cleaned transcript from one coding session. The transcript already contains only the human/agent conversation turns, with tool calls, tool outputs, and thinking removed.
+
+Use judgment. Focus on what actually mattered.
 
 Return ONLY a JSON object (no markdown fences, no other text):
 {
-  "summary": "# ${date} Session Notes\\n\\n## Topic Name\\n\\nProse summary...",
+  "summary": "# ${date} Session Notes\\n\\n## Topic Name\\n\\nFree-form session note...",
   "facts": [{"content": "...", "importance": 0.3, "tags": "tag1,tag2", "type": "fact"}]
 }
 
-Summary guidelines:
+Summary:
 - Start with "# ${date} Session Notes"
 - Use ## headings for each distinct topic discussed
-- Include: what was worked on, key decisions, open threads
-- Be concise but complete (200-500 words)
+- Cover what was worked on, key decisions, unresolved threads, and anything likely to matter later
+- Prefer concrete names, files, systems, or people when they matter
 - Write in past tense, third person
 
-Fact extraction guidelines:
+Facts:
 - Each fact must be self-contained and understandable without this conversation
 - Include the specific subject (package name, file path, tool, component) in every fact
-- BAD: "switched to a reactive pattern" → GOOD: "The EmbeddingCanvas2D component switched from polling to a reactive requestRedraw pattern for GPU efficiency"
-- Only durable, reusable knowledge (skip ephemeral details)
+- Keep only durable knowledge, preferences, rules, or decisions
 - Types: fact, preference, decision, learning, rule, issue
 - Importance: 0.3 (routine) to 0.5 (significant)
 - Max 15 facts
@@ -182,23 +183,25 @@ ${transcript}`;
 }
 
 function buildChunkPrompt(chunk: string, index: number, total: number, date: string): string {
-	return `You are a session librarian. This is chunk ${index + 1} of ${total} from a long coding session on ${date}. Summarize this segment and extract key facts.
+	return `You are reviewing chunk ${index + 1} of ${total} from one cleaned coding-session transcript on ${date}. Tool calls, tool outputs, and thinking have already been removed.
+
+Use judgment. Focus on what mattered in this segment.
 
 Return ONLY a JSON object (no markdown fences, no other text):
 {
-  "summary": "Prose summary of this segment (100-300 words)...",
+  "summary": "Free-form summary of this segment...",
   "facts": [{"content": "...", "importance": 0.3, "tags": "tag1,tag2", "type": "fact"}]
 }
 
-Summary guidelines:
-- Summarize what was discussed/worked on in this segment
-- Be concise but capture key decisions and context
+Summary:
+- Summarize what was discussed or worked on in this segment
+- Capture decisions, important context, and unresolved threads
 - Write in past tense, third person
 
-Fact extraction guidelines:
+Facts:
 - Each fact must be self-contained and understandable without this conversation
 - Include the specific subject (package name, file path, tool, component) in every fact
-- Only durable, reusable knowledge (skip ephemeral details)
+- Keep only durable knowledge worth carrying forward
 - Types: fact, preference, decision, learning, rule, issue
 - Importance: 0.3 (routine) to 0.5 (significant)
 - Max 10 facts per chunk
@@ -217,23 +220,22 @@ function buildCombinePrompt(
 		.map((f) => `- ${f.content}`)
 		.join("\n");
 
-	return `You are a session librarian. Below are summaries of ${summaries.length} consecutive segments from one coding session on ${date}, plus extracted facts. Produce a unified session summary and deduplicated fact list.
+	return `You are combining ${summaries.length} segment summaries from one cleaned coding-session transcript on ${date}. Produce one coherent session note and one deduplicated durable fact list.
 
 Return ONLY a JSON object (no markdown fences, no other text):
 {
-  "summary": "# ${date} Session Notes\\n\\n## Topic Name\\n\\nProse summary...",
+  "summary": "# ${date} Session Notes\\n\\n## Topic Name\\n\\nFree-form session note...",
   "facts": [{"content": "...", "importance": 0.3, "tags": "tag1,tag2", "type": "fact"}]
 }
 
-Summary guidelines:
+Summary:
 - Start with "# ${date} Session Notes"
 - Use ## headings for each distinct topic discussed
-- Merge overlapping content from segments — don't repeat
-- Include: what was worked on, key decisions, open threads
-- Be concise but complete (200-500 words)
+- Merge overlapping content from segments without repeating yourself
+- Keep the note coherent, concrete, and useful for future continuity
 - Write in past tense, third person
 
-Fact guidelines:
+Facts:
 - Deduplicate facts that say the same thing in different words
 - Keep the most specific version of each fact
 - Max 15 facts total

--- a/packages/daemon/src/transcript-audit.ts
+++ b/packages/daemon/src/transcript-audit.ts
@@ -8,7 +8,18 @@ function getTranscriptAuditDir(): string {
 }
 
 function fsTimestamp(iso: string): string {
-	return iso.replace(/:/g, "-");
+	return Array.from(iso, (char) => (/^[A-Za-z0-9._-]$/.test(char) ? char : "-")).join("");
+}
+
+function isSafeAuditName(value: string): boolean {
+	return value.length > 0 && /^[A-Za-z0-9._-]+$/.test(value);
+}
+
+function buildAuditPath(dir: string, fileName: string): string {
+	if (!isSafeAuditName(fileName)) {
+		throw new Error("invalid transcript audit file name");
+	}
+	return join(dir, fileName);
 }
 
 function resolveAuditToken(agentId: string, sessionId: string, sessionKey: string | null, raw: string): string {
@@ -36,14 +47,14 @@ export function writeTranscriptAudit(params: {
 	}
 
 	const token = resolveAuditToken(params.agentId, params.sessionId, params.sessionKey, params.rawTranscript);
-	const latestPath = join(dir, `${token}--latest.log`);
+	const latestPath = buildAuditPath(dir, `${token}--latest.log`);
 	writeFileSync(latestPath, params.rawTranscript, "utf8");
 
 	if (!params.capturedAt) {
 		return { latestPath };
 	}
 
-	const finalPath = join(dir, `${fsTimestamp(params.capturedAt)}--${token}--raw-transcript.log`);
+	const finalPath = buildAuditPath(dir, `${fsTimestamp(params.capturedAt)}--${token}--raw-transcript.log`);
 	writeFileSync(finalPath, params.rawTranscript, "utf8");
 	return { latestPath, finalPath };
 }

--- a/packages/daemon/src/transcript-audit.ts
+++ b/packages/daemon/src/transcript-audit.ts
@@ -3,8 +3,8 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { resolveDefaultBasePath } from "@signet/core";
 
-function getTranscriptAuditDir(): string {
-	return join(resolveDefaultBasePath(), ".daemon", "logs", "transcripts");
+function getTranscriptAuditDir(basePath: string): string {
+	return join(basePath, ".daemon", "logs", "transcripts");
 }
 
 function fsTimestamp(iso: string): string {
@@ -33,6 +33,7 @@ export interface TranscriptAuditWrite {
 }
 
 export function writeTranscriptAudit(params: {
+	readonly basePath?: string;
 	readonly agentId: string;
 	readonly sessionId: string;
 	readonly sessionKey: string | null;
@@ -41,7 +42,7 @@ export function writeTranscriptAudit(params: {
 }): TranscriptAuditWrite | null {
 	if (params.rawTranscript.trim().length === 0) return null;
 
-	const dir = getTranscriptAuditDir();
+	const dir = getTranscriptAuditDir(params.basePath ?? process.env.SIGNET_PATH ?? resolveDefaultBasePath());
 	if (!existsSync(dir)) {
 		mkdirSync(dir, { recursive: true });
 	}

--- a/packages/daemon/src/transcript-audit.ts
+++ b/packages/daemon/src/transcript-audit.ts
@@ -1,0 +1,53 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+function getAgentsDir(): string {
+	return process.env.SIGNET_PATH || join(homedir(), ".agents");
+}
+
+function getTranscriptAuditDir(): string {
+	return join(getAgentsDir(), ".daemon", "logs", "transcripts");
+}
+
+function fsTimestamp(iso: string): string {
+	return iso.replace(/:/g, "-");
+}
+
+function resolveAuditToken(agentId: string, sessionId: string, sessionKey: string | null, raw: string): string {
+	const scoped = sessionId.trim() || sessionKey?.trim() || createHash("sha256").update(raw, "utf8").digest("hex");
+	return createHash("sha256").update(`${agentId}:${scoped}`, "utf8").digest("hex").slice(0, 16);
+}
+
+export interface TranscriptAuditWrite {
+	readonly latestPath: string;
+	readonly finalPath?: string;
+}
+
+export function writeTranscriptAudit(params: {
+	readonly agentId: string;
+	readonly sessionId: string;
+	readonly sessionKey: string | null;
+	readonly rawTranscript: string;
+	readonly capturedAt?: string;
+}): TranscriptAuditWrite | null {
+	if (params.rawTranscript.trim().length === 0) return null;
+
+	const dir = getTranscriptAuditDir();
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true });
+	}
+
+	const token = resolveAuditToken(params.agentId, params.sessionId, params.sessionKey, params.rawTranscript);
+	const latestPath = join(dir, `${token}--latest.log`);
+	writeFileSync(latestPath, params.rawTranscript, "utf8");
+
+	if (!params.capturedAt) {
+		return { latestPath };
+	}
+
+	const finalPath = join(dir, `${fsTimestamp(params.capturedAt)}--${token}--raw-transcript.log`);
+	writeFileSync(finalPath, params.rawTranscript, "utf8");
+	return { latestPath, finalPath };
+}

--- a/packages/daemon/src/transcript-audit.ts
+++ b/packages/daemon/src/transcript-audit.ts
@@ -1,14 +1,10 @@
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
-
-function getAgentsDir(): string {
-	return process.env.SIGNET_PATH || join(homedir(), ".agents");
-}
+import { resolveDefaultBasePath } from "@signet/core";
 
 function getTranscriptAuditDir(): string {
-	return join(getAgentsDir(), ".daemon", "logs", "transcripts");
+	return join(resolveDefaultBasePath(), ".daemon", "logs", "transcripts");
 }
 
 function fsTimestamp(iso: string): string {

--- a/packages/daemon/test/hooks.test.ts
+++ b/packages/daemon/test/hooks.test.ts
@@ -7,6 +7,7 @@
 
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -1861,6 +1862,27 @@ describe("handleSessionEnd", () => {
 		expect(finalPath?.startsWith(auditDir)).toBe(true);
 		expect(auditName).toMatch(/^[A-Za-z0-9._-]+$/);
 		expect(finalPath).not.toContain("/tmp/evil");
+	});
+
+	test.serial("uses the full raw transcript hash when audit ids are missing", () => {
+		const rawTranscript = "User: audit me\nAssistant: on it";
+		const result = writeTranscriptAudit({
+			basePath: TEST_DIR,
+			agentId: "agent-a",
+			sessionId: "",
+			sessionKey: null,
+			rawTranscript,
+		});
+
+		expect(result).not.toBeNull();
+		const latestPath = result?.latestPath ?? "";
+		const latestName = latestPath.split("/").pop() ?? "";
+		const scoped = createHash("sha256").update(rawTranscript, "utf8").digest("hex");
+		const expectedToken = createHash("sha256")
+			.update(`agent-a:${scoped}`, "utf8")
+			.digest("hex")
+			.slice(0, 16);
+		expect(latestName).toBe(`${expectedToken}--latest.log`);
 	});
 
 	test.serial(

--- a/packages/daemon/test/hooks.test.ts
+++ b/packages/daemon/test/hooks.test.ts
@@ -1845,6 +1845,7 @@ describe("handleSessionEnd", () => {
 
 	test.serial("sanitizes transcript audit filenames to stay within the audit directory", () => {
 		const result = writeTranscriptAudit({
+			basePath: TEST_DIR,
 			agentId: "default",
 			sessionId: "sess-audit-safe",
 			sessionKey: "sess-audit-safe",

--- a/packages/daemon/test/hooks.test.ts
+++ b/packages/daemon/test/hooks.test.ts
@@ -1755,6 +1755,92 @@ describe("handleSessionEnd", () => {
 		expect(manifest).toContain('transcript_path: "memory/');
 	});
 
+	test.serial("falls back to the stored live transcript when session-end input is missing", async () => {
+		createMemoryDb([]);
+		const db = openTestDb();
+		try {
+			const now = new Date().toISOString();
+			db.prepare(
+				`INSERT INTO session_transcripts (
+					session_key, content, harness, project, agent_id, created_at, updated_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			).run(
+				"sess-live-fallback",
+				"User: keep the live transcript if session-end falls over.\nAssistant: using the stored live transcript avoids losing the session.\n".repeat(
+					8,
+				),
+				"test",
+				"/home/user/signetai",
+				"default",
+				now,
+				now,
+			);
+		} finally {
+			db.close();
+		}
+
+		const result = await handleSessionEnd({
+			harness: "test",
+			transcriptPath: "/nonexistent/path.txt",
+			sessionKey: "sess-live-fallback",
+			sessionId: "sess-live-fallback",
+			cwd: "/home/user/signetai",
+		});
+
+		expect(result.queued).toBe(true);
+
+		const files = readdirSync(join(TEST_DIR, "memory")).sort();
+		const transcriptFile = files.find((name) => name.endsWith("--transcript.md"));
+		expect(transcriptFile).toBeDefined();
+		const transcript = readFileSync(join(TEST_DIR, "memory", transcriptFile ?? ""), "utf-8");
+		expect(transcript).toContain("keep the live transcript if session-end falls over");
+		expect(transcript).toContain("using the stored live transcript avoids losing the session");
+	});
+
+	test.serial("writes raw audit logs while keeping the canonical transcript conversation-only", async () => {
+		createMemoryDb([]);
+		const transcriptPath = join(TEST_DIR, "codex-transcript.jsonl");
+		writeFileSync(
+			transcriptPath,
+			[
+				'{"type":"event_msg","payload":{"type":"user_message","message":"Run diagnostics"}}',
+				'{"type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{\\"cmd\\":\\"ls\\"}"}}',
+				'{"type":"response_item","payload":{"type":"function_call_output","output":"README.md"}}',
+				'{"type":"item.completed","item":{"type":"agent_message","text":"Diagnostics complete"}}',
+			]
+				.join("\n")
+				.concat("\n")
+				.repeat(20),
+		);
+
+		const result = await handleSessionEnd({
+			harness: "codex",
+			transcriptPath,
+			sessionKey: "sess-audit",
+			sessionId: "sess-audit",
+			cwd: "/home/user/signetai",
+		});
+
+		expect(result.queued).toBe(true);
+
+		const memoryFiles = readdirSync(join(TEST_DIR, "memory")).sort();
+		const transcriptFile = memoryFiles.find((name) => name.endsWith("--transcript.md"));
+		expect(transcriptFile).toBeDefined();
+		const transcript = readFileSync(join(TEST_DIR, "memory", transcriptFile ?? ""), "utf-8");
+		expect(transcript).toContain("User: Run diagnostics");
+		expect(transcript).toContain("Assistant: Diagnostics complete");
+		expect(transcript).not.toContain("function_call");
+		expect(transcript).not.toContain("README.md");
+
+		const auditDir = join(TEST_DIR, ".daemon", "logs", "transcripts");
+		const auditFiles = readdirSync(auditDir).sort();
+		expect(auditFiles.some((name) => name.endsWith("--raw-transcript.log"))).toBe(true);
+		const finalAudit = auditFiles.find((name) => name.endsWith("--raw-transcript.log"));
+		const audit = readFileSync(join(auditDir, finalAudit ?? ""), "utf-8");
+		expect(audit).toContain('"type":"function_call"');
+		expect(audit).toContain("README.md");
+	});
+
 	test.serial(
 		"creates fresh canonical artifacts when distinct session-end events reuse the same sessionKey",
 		async () => {
@@ -1774,46 +1860,46 @@ describe("handleSessionEnd", () => {
 				),
 			);
 
-		const first = await handleSessionEnd({
-			harness: "test",
-			transcriptPath: transcriptAPath,
-			sessionKey: "agent:main:main",
-			cwd: "/home/user/signetai",
-		});
-		const second = await handleSessionEnd({
-			harness: "test",
-			transcriptPath: transcriptBPath,
-			sessionKey: "agent:main:main",
-			cwd: "/home/user/signetai",
-		});
+			const first = await handleSessionEnd({
+				harness: "test",
+				transcriptPath: transcriptAPath,
+				sessionKey: "agent:main:main",
+				cwd: "/home/user/signetai",
+			});
+			const second = await handleSessionEnd({
+				harness: "test",
+				transcriptPath: transcriptBPath,
+				sessionKey: "agent:main:main",
+				cwd: "/home/user/signetai",
+			});
 
-		expect(first.queued).toBe(true);
-		expect(second.queued).toBe(true);
+			expect(first.queued).toBe(true);
+			expect(second.queued).toBe(true);
 
-		const files = readdirSync(join(TEST_DIR, "memory")).sort();
-		expect(files.filter((name) => name.endsWith("--transcript.md"))).toHaveLength(2);
-		expect(files.filter((name) => name.endsWith("--manifest.md"))).toHaveLength(2);
+			const files = readdirSync(join(TEST_DIR, "memory")).sort();
+			expect(files.filter((name) => name.endsWith("--transcript.md"))).toHaveLength(2);
+			expect(files.filter((name) => name.endsWith("--manifest.md"))).toHaveLength(2);
 
-		const db = openTestDb();
-		try {
-			const sessionIds = db
-				.prepare("SELECT session_id FROM summary_jobs ORDER BY created_at ASC")
-				.all() as Array<{ session_id: string | null }>;
-			expect(sessionIds).toHaveLength(2);
-			// Path-based fallback IDs include a content digest suffix so
-			// rotating log files that reuse the same path produce distinct IDs.
-			expect(sessionIds[0]?.session_id).toMatch(
-				new RegExp(`^session-end:path:${transcriptAPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}:[0-9a-f]{16}$`),
-			);
-			expect(sessionIds[1]?.session_id).toMatch(
-				new RegExp(`^session-end:path:${transcriptBPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}:[0-9a-f]{16}$`),
-			);
-			expect(sessionIds[0]?.session_id).not.toBe(sessionIds[1]?.session_id);
-		} finally {
-			db.close();
-		}
-	},
-);
+			const db = openTestDb();
+			try {
+				const sessionIds = db.prepare("SELECT session_id FROM summary_jobs ORDER BY created_at ASC").all() as Array<{
+					session_id: string | null;
+				}>;
+				expect(sessionIds).toHaveLength(2);
+				// Path-based fallback IDs include a content digest suffix so
+				// rotating log files that reuse the same path produce distinct IDs.
+				expect(sessionIds[0]?.session_id).toMatch(
+					new RegExp(`^session-end:path:${transcriptAPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}:[0-9a-f]{16}$`),
+				);
+				expect(sessionIds[1]?.session_id).toMatch(
+					new RegExp(`^session-end:path:${transcriptBPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}:[0-9a-f]{16}$`),
+				);
+				expect(sessionIds[0]?.session_id).not.toBe(sessionIds[1]?.session_id);
+			} finally {
+				db.close();
+			}
+		},
+	);
 
 	test("adds a random suffix when transcript context is unavailable", () => {
 		const first = deriveSessionEndFallbackId("agent:main:main", undefined, "");

--- a/packages/daemon/test/hooks.test.ts
+++ b/packages/daemon/test/hooks.test.ts
@@ -17,6 +17,7 @@ process.env.SIGNET_PATH = TEST_DIR;
 const { initDbAccessor, closeDbAccessor } = await import("../src/db-accessor");
 const hooks = await import("../src/hooks");
 const lineage = await import("../src/memory-lineage");
+const transcriptAudit = await import("../src/transcript-audit");
 const {
 	handleSessionStart,
 	handlePreCompaction,
@@ -49,6 +50,7 @@ const {
 	writeSummaryArtifact,
 	writeTranscriptArtifact,
 } = lineage;
+const { writeTranscriptAudit } = transcriptAudit;
 
 // ============================================================================
 // Helpers
@@ -1839,6 +1841,25 @@ describe("handleSessionEnd", () => {
 		const audit = readFileSync(join(auditDir, finalAudit ?? ""), "utf-8");
 		expect(audit).toContain('"type":"function_call"');
 		expect(audit).toContain("README.md");
+	});
+
+	test.serial("sanitizes transcript audit filenames to stay within the audit directory", () => {
+		const result = writeTranscriptAudit({
+			agentId: "default",
+			sessionId: "sess-audit-safe",
+			sessionKey: "sess-audit-safe",
+			rawTranscript: "raw transcript",
+			capturedAt: "../../../../tmp/evil",
+		});
+
+		expect(result).not.toBeNull();
+		const finalPath = result?.finalPath;
+		expect(finalPath).toBeDefined();
+		const auditDir = join(TEST_DIR, ".daemon", "logs", "transcripts");
+		const auditName = finalPath ? finalPath.slice(auditDir.length + 1) : "";
+		expect(finalPath?.startsWith(auditDir)).toBe(true);
+		expect(auditName).toMatch(/^[A-Za-z0-9._-]+$/);
+		expect(finalPath).not.toContain("/tmp/evil");
 	});
 
 	test.serial(


### PR DESCRIPTION
## what changed

This PR hardens transcript capture so Signet keeps a clean conversation-only canonical transcript for memory and continuity, while preserving raw auditable transcript traces separately in daemon logs.

It also improves session-end reliability by falling back to the stored live transcript snapshot when final transcript input is missing or shorter than what was already captured during prompt flow.

On top of that, it updates the Signet system prompt to explicitly remind agents that linked transcript and summary artifacts are inspectable across sessions, and loosens the session summary prompts so they operate on cleaned conversation context instead of bureaucratic tool exhaust.

## why

We were relying too much on session-end transcript capture, which made interruptions and bad transcript paths too easy to lose context on. We were also feeding summaries with noisier transcript surfaces than necessary.

That led to two real problems:

- canonical transcript artifacts could miss conversational context when sessions ended badly
- summary generation had to fight through tool calls, tool outputs, and other non-conversational noise

## impact

- canonical `--transcript.md` artifacts now reflect only user and assistant conversation
- raw transcript traces are retained under `.daemon/logs/transcripts/` for audit and debugging
- session-end is more resilient when final transcript input is missing or truncated
- agents now get a clearer reminder that cross-session transcript and summary artifacts are available
- rust and ts behavior are closer again instead of drifting apart

## compatibility note

This changes Codex canonical transcript behavior. Codex sessions no longer bypass normalization, so canonical `--transcript.md` artifacts now follow the same conversation-only filtering as other harnesses. If a Codex deployment depended on raw JSONL or partially-recognized event shapes appearing in the canonical transcript artifact, it will now receive the cleaned conversation view instead, and tool-only or unrecognized JSONL can normalize to an empty canonical transcript while the raw audit log is still preserved under `.daemon/logs/transcripts/`.

## validation

- `bun test packages/daemon/src/hooks.test.ts packages/daemon/test/hooks.test.ts packages/daemon/src/pipeline/summary-worker.test.ts`
- targeted rust tests for transcript normalization, prompt reminder, live transcript fallback, and raw-audit-vs-canonical behavior
- `bunx @biomejs/biome check packages/daemon/src/hooks.ts packages/daemon/src/transcript-audit.ts packages/daemon/src/pipeline/summary-worker.ts packages/daemon/src/hooks.test.ts packages/daemon/test/hooks.test.ts docs/API.md docs/ARCHITECTURE.md docs/PIPELINE.md docs/specs/approved/system-prompt-extraction.md docs/specs/approved/memory-md-temporal-head.md docs/specs/approved/lossless-working-memory-runtime.md docs/specs/approved/desire-paths-epic.md`

## note

`bun scripts/spec-deps-check.ts` still fails in this repo, but the failure is pre-existing and unrelated to this PR:

- `recall-confidence-gate` path and status drift
- missing `references/Engram` path for `engram-informed-predictor-track`
