### PR TITLE
feat(web): Discord community CTAs + /join opt-in page

### DIFF
--- a/web/functions/api/optin.ts
+++ b/web/functions/api/optin.ts
@@ -1,6 +1,8 @@
 interface Env {
 	RESEND_API_KEY: string;
+	RESEND_AUDIENCE_ID: string;
 	GHL_API_KEY: string;
+	RATE_LIMITER: RateLimit;
 	// Email address to receive applicant notifications (e.g. team@signetai.sh)
 	NOTIFY_EMAIL?: string;
 	// Verified sending address in Resend (e.g. noreply@signetai.sh)
@@ -8,10 +10,19 @@ interface Env {
 }
 
 const ALLOWED_ORIGINS = ["https://signetai.sh", "https://www.signetai.sh"];
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 function corsHeaders(origin: string): Record<string, string> {
 	if (!origin || !ALLOWED_ORIGINS.includes(origin)) return {};
 	return { "Access-Control-Allow-Origin": origin };
+}
+
+function escapeHtml(s: string): string {
+	return s
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;");
 }
 
 export const onRequestPost: PagesFunction<Env> = async (context) => {
@@ -20,6 +31,16 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 		...corsHeaders(origin),
 		"Content-Type": "application/json",
 	};
+
+	// Rate limit by IP — 10 submissions per 60 seconds
+	const ip = context.request.headers.get("CF-Connecting-IP") ?? "unknown";
+	const { success } = await context.env.RATE_LIMITER.limit({ key: ip });
+	if (!success) {
+		return new Response(JSON.stringify({ error: "Too many requests" }), {
+			status: 429,
+			headers,
+		});
+	}
 
 	try {
 		const body = (await context.request.json()) as {
@@ -43,8 +64,16 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 			});
 		}
 
-		if (email && !email.includes("@")) {
+		if (email && !EMAIL_RE.test(email)) {
 			return new Response(JSON.stringify({ error: "Invalid email address" }), {
+				status: 400,
+				headers,
+			});
+		}
+
+		const phoneDigits = phone.replace(/\D/g, "");
+		if (phoneDigits && phoneDigits.length !== 10) {
+			return new Response(JSON.stringify({ error: "Phone must be a 10-digit US number" }), {
 				status: 400,
 				headers,
 			});
@@ -52,19 +81,22 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 
 		// Add to Resend contacts audience only when email is provided
 		if (email) {
-			const contactRes = await fetch("https://api.resend.com/contacts", {
-				method: "POST",
-				headers: {
-					Authorization: `Bearer ${context.env.RESEND_API_KEY}`,
-					"Content-Type": "application/json",
+			const contactRes = await fetch(
+				`https://api.resend.com/audiences/${context.env.RESEND_AUDIENCE_ID}/contacts`,
+				{
+					method: "POST",
+					headers: {
+						Authorization: `Bearer ${context.env.RESEND_API_KEY}`,
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify({
+						email,
+						first_name: firstName,
+						last_name: lastName,
+						unsubscribed: !optin,
+					}),
 				},
-				body: JSON.stringify({
-					email,
-					first_name: firstName,
-					last_name: lastName,
-					unsubscribed: !optin,
-				}),
-			});
+			);
 
 			if (!contactRes.ok) {
 				const err = await contactRes.text();
@@ -78,8 +110,6 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 
 		// Create/update contact in GoHighLevel
 		if (context.env.GHL_API_KEY) {
-			// Phone digits only — prepend +1 for US numbers (form enforces 10-digit US format)
-			const ghlPhone = phone.replace(/\D/g, '');
 			const ghlRes = await fetch("https://rest.gohighlevel.com/v1/contacts/", {
 				method: "POST",
 				headers: {
@@ -90,7 +120,8 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 					firstName,
 					lastName,
 					...(email ? { email } : {}),
-					...(ghlPhone ? { phone: `+1${ghlPhone}` } : {}),
+					// Phone digits only, prepend +1 for US (form enforces 10-digit US format)
+					...(phoneDigits ? { phone: `+1${phoneDigits}` } : {}),
 					tags: ["community-optin"],
 					source: "signetai.sh",
 					// Requires a custom field named "newsletter_optin" in your GHL account
@@ -113,6 +144,11 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 		const fromEmail = context.env.FROM_EMAIL ?? "noreply@signetai.sh";
 
 		if (notifyEmail) {
+			// Escape all user values before HTML interpolation
+			const safeName = `${escapeHtml(firstName)} ${escapeHtml(lastName)}`;
+			const safeEmail = escapeHtml(email);
+			const safePhone = escapeHtml(phone);
+
 			const emailRes = await fetch("https://api.resend.com/emails", {
 				method: "POST",
 				headers: {
@@ -122,11 +158,11 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 				body: JSON.stringify({
 					from: `Signet Community <${fromEmail}>`,
 					to: [notifyEmail],
-					subject: `New community applicant: ${firstName} ${lastName}`,
+					subject: `New community applicant: ${safeName}`,
 					html: `
-						<p><strong>Name:</strong> ${firstName} ${lastName}</p>
-						<p><strong>Email:</strong> ${email || "—"}</p>
-						<p><strong>Phone:</strong> ${phone || "—"}</p>
+						<p><strong>Name:</strong> ${safeName}</p>
+						<p><strong>Email:</strong> ${safeEmail || "—"}</p>
+						<p><strong>Phone:</strong> ${safePhone || "—"}</p>
 						<p><strong>Newsletter opt-in:</strong> ${optin ? "Yes" : "No"}</p>
 					`.trim(),
 				}),

--- a/web/functions/api/optin.ts
+++ b/web/functions/api/optin.ts
@@ -80,7 +80,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 					...(email ? { email } : {}),
 					// Phone digits only, prepend +1 for US (form enforces 10-digit US format)
 					...(phoneDigits ? { phone: `+1${phoneDigits}` } : {}),
-					tags: ["community-optin"],
+					tags: ["signet new lead"],
 					source: "signetai.sh",
 					// Requires a custom field named "newsletter_optin" in your GHL account
 					customField: [{ id: "newsletter_optin", value: optin ? "yes" : "no" }],

--- a/web/functions/api/optin.ts
+++ b/web/functions/api/optin.ts
@@ -1,5 +1,6 @@
 interface Env {
 	GHL_API_KEY: string;
+	GHL_LOCATION_ID: string;
 	RATE_LIMITER: RateLimit;
 }
 
@@ -7,10 +8,14 @@ const ALLOWED_ORIGINS = ["https://signetai.sh", "https://www.signetai.sh"];
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 function corsHeaders(origin: string): Record<string, string> {
-	if (!origin || !ALLOWED_ORIGINS.includes(origin)) return {};
-	return { "Access-Control-Allow-Origin": origin };
+	if (!origin) return {};
+	if (ALLOWED_ORIGINS.includes(origin)) return { "Access-Control-Allow-Origin": origin };
+	// Allow localhost and Tailscale origins for local dev
+	if (origin.startsWith("http://localhost:") || origin.startsWith("http://100.")) {
+		return { "Access-Control-Allow-Origin": origin };
+	}
+	return {};
 }
-
 
 export const onRequestPost: PagesFunction<Env> = async (context) => {
 	const origin = context.request.headers.get("Origin") ?? "";
@@ -20,13 +25,15 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 	};
 
 	// Rate limit by IP — 10 submissions per 60 seconds
-	const ip = context.request.headers.get("CF-Connecting-IP") ?? "unknown";
-	const { success } = await context.env.RATE_LIMITER.limit({ key: ip });
-	if (!success) {
-		return new Response(JSON.stringify({ error: "Too many requests" }), {
-			status: 429,
-			headers,
-		});
+	if (context.env.RATE_LIMITER) {
+		const ip = context.request.headers.get("CF-Connecting-IP") ?? "unknown";
+		const { success } = await context.env.RATE_LIMITER.limit({ key: ip });
+		if (!success) {
+			return new Response(JSON.stringify({ error: "Too many requests" }), {
+				status: 429,
+				headers,
+			});
+		}
 	}
 
 	try {
@@ -66,35 +73,43 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 			});
 		}
 
-		// Create/update contact in GoHighLevel
-		if (context.env.GHL_API_KEY) {
-			const ghlRes = await fetch("https://rest.gohighlevel.com/v1/contacts/", {
-				method: "POST",
-				headers: {
-					Authorization: `Bearer ${context.env.GHL_API_KEY}`,
-					"Content-Type": "application/json",
-				},
-				body: JSON.stringify({
-					firstName,
-					lastName,
-					...(email ? { email } : {}),
-					// Phone digits only, prepend +1 for US (form enforces 10-digit US format)
-					...(phoneDigits ? { phone: `+1${phoneDigits}` } : {}),
-					tags: ["signet new lead"],
-					source: "signetai.sh",
-					// Requires a custom field named "newsletter_optin" in your GHL account
-					customField: [{ id: "newsletter_optin", value: optin ? "yes" : "no" }],
-				}),
-			});
+		// Create/update contact in GoHighLevel (v2 API)
+		if (!context.env.GHL_API_KEY || !context.env.GHL_LOCATION_ID) {
+			console.error("Missing GHL_API_KEY or GHL_LOCATION_ID");
+			return new Response(
+				JSON.stringify({ error: "Server misconfigured", detail: "Missing GHL credentials" }),
+				{ status: 500, headers },
+			);
+		}
 
-			if (!ghlRes.ok) {
-				const err = await ghlRes.text();
-				console.error("GHL contacts error:", ghlRes.status, err);
-				return new Response(JSON.stringify({ error: "Signup failed" }), {
-					status: 502,
-					headers,
-				});
-			}
+		const ghlRes = await fetch("https://services.leadconnectorhq.com/contacts/upsert", {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${context.env.GHL_API_KEY}`,
+				"Content-Type": "application/json",
+				Version: "2021-07-28",
+			},
+			body: JSON.stringify({
+				locationId: context.env.GHL_LOCATION_ID,
+				firstName,
+				lastName,
+				...(email ? { email } : {}),
+				...(phoneDigits ? { phone: `+1${phoneDigits}` } : {}),
+				tags: ["signet new lead"],
+				source: "signetai.sh",
+				customFields: [
+					{ key: "newsletter_optin", field_value: optin ? "yes" : "no" },
+				],
+			}),
+		});
+
+		if (!ghlRes.ok) {
+			const err = await ghlRes.text();
+			console.error("GHL error:", ghlRes.status, err);
+			return new Response(
+				JSON.stringify({ error: "Signup failed", detail: err }),
+				{ status: 502, headers },
+			);
 		}
 
 		return new Response(JSON.stringify({ ok: true }), { status: 200, headers });

--- a/web/functions/api/optin.ts
+++ b/web/functions/api/optin.ts
@@ -45,10 +45,10 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 			optin?: boolean;
 		};
 
-		const firstName = body.firstName?.trim() ?? "";
-		const lastName = body.lastName?.trim() ?? "";
-		const phone = body.phone?.trim() ?? "";
-		const email = body.email?.trim().toLowerCase() ?? "";
+		const firstName = (body.firstName?.trim() ?? "").slice(0, 50);
+		const lastName = (body.lastName?.trim() ?? "").slice(0, 50);
+		const phone = (body.phone?.trim() ?? "").slice(0, 20);
+		const email = (body.email?.trim().toLowerCase() ?? "").slice(0, 254);
 		const optin = body.optin === true;
 
 		if (!firstName || !lastName) {

--- a/web/functions/api/optin.ts
+++ b/web/functions/api/optin.ts
@@ -1,12 +1,6 @@
 interface Env {
-	RESEND_API_KEY: string;
-	RESEND_AUDIENCE_ID: string;
 	GHL_API_KEY: string;
 	RATE_LIMITER: RateLimit;
-	// Email address to receive applicant notifications (e.g. team@signetai.sh)
-	NOTIFY_EMAIL?: string;
-	// Verified sending address in Resend (e.g. noreply@signetai.sh)
-	FROM_EMAIL?: string;
 }
 
 const ALLOWED_ORIGINS = ["https://signetai.sh", "https://www.signetai.sh"];
@@ -17,13 +11,6 @@ function corsHeaders(origin: string): Record<string, string> {
 	return { "Access-Control-Allow-Origin": origin };
 }
 
-function escapeHtml(s: string): string {
-	return s
-		.replace(/&/g, "&amp;")
-		.replace(/</g, "&lt;")
-		.replace(/>/g, "&gt;")
-		.replace(/"/g, "&quot;");
-}
 
 export const onRequestPost: PagesFunction<Env> = async (context) => {
 	const origin = context.request.headers.get("Origin") ?? "";
@@ -79,35 +66,6 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 			});
 		}
 
-		// Add to Resend contacts audience only when email is provided
-		if (email) {
-			const contactRes = await fetch(
-				`https://api.resend.com/audiences/${context.env.RESEND_AUDIENCE_ID}/contacts`,
-				{
-					method: "POST",
-					headers: {
-						Authorization: `Bearer ${context.env.RESEND_API_KEY}`,
-						"Content-Type": "application/json",
-					},
-					body: JSON.stringify({
-						email,
-						first_name: firstName,
-						last_name: lastName,
-						unsubscribed: !optin,
-					}),
-				},
-			);
-
-			if (!contactRes.ok) {
-				const err = await contactRes.text();
-				console.error("Resend contacts error:", contactRes.status, err);
-				return new Response(JSON.stringify({ error: "Signup failed" }), {
-					status: 502,
-					headers,
-				});
-			}
-		}
-
 		// Create/update contact in GoHighLevel
 		if (context.env.GHL_API_KEY) {
 			const ghlRes = await fetch("https://rest.gohighlevel.com/v1/contacts/", {
@@ -136,41 +94,6 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 					status: 502,
 					headers,
 				});
-			}
-		}
-
-		// Send notification email with all fields if NOTIFY_EMAIL is configured
-		const notifyEmail = context.env.NOTIFY_EMAIL;
-		const fromEmail = context.env.FROM_EMAIL ?? "noreply@signetai.sh";
-
-		if (notifyEmail) {
-			// Escape all user values before HTML interpolation
-			const safeName = `${escapeHtml(firstName)} ${escapeHtml(lastName)}`;
-			const safeEmail = escapeHtml(email);
-			const safePhone = escapeHtml(phone);
-
-			const emailRes = await fetch("https://api.resend.com/emails", {
-				method: "POST",
-				headers: {
-					Authorization: `Bearer ${context.env.RESEND_API_KEY}`,
-					"Content-Type": "application/json",
-				},
-				body: JSON.stringify({
-					from: `Signet Community <${fromEmail}>`,
-					to: [notifyEmail],
-					subject: `New community applicant: ${safeName}`,
-					html: `
-						<p><strong>Name:</strong> ${safeName}</p>
-						<p><strong>Email:</strong> ${safeEmail || "—"}</p>
-						<p><strong>Phone:</strong> ${safePhone || "—"}</p>
-						<p><strong>Newsletter opt-in:</strong> ${optin ? "Yes" : "No"}</p>
-					`.trim(),
-				}),
-			});
-
-			if (!emailRes.ok) {
-				// Non-fatal — contact was already stored
-				console.error("Resend notification error:", emailRes.status, await emailRes.text());
 			}
 		}
 

--- a/web/functions/api/optin.ts
+++ b/web/functions/api/optin.ts
@@ -1,0 +1,161 @@
+interface Env {
+	RESEND_API_KEY: string;
+	GHL_API_KEY: string;
+	// Email address to receive applicant notifications (e.g. team@signetai.sh)
+	NOTIFY_EMAIL?: string;
+	// Verified sending address in Resend (e.g. noreply@signetai.sh)
+	FROM_EMAIL?: string;
+}
+
+const ALLOWED_ORIGINS = ["https://signetai.sh", "https://www.signetai.sh"];
+
+function corsHeaders(origin: string): Record<string, string> {
+	if (!origin || !ALLOWED_ORIGINS.includes(origin)) return {};
+	return { "Access-Control-Allow-Origin": origin };
+}
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+	const origin = context.request.headers.get("Origin") ?? "";
+	const headers = {
+		...corsHeaders(origin),
+		"Content-Type": "application/json",
+	};
+
+	try {
+		const body = (await context.request.json()) as {
+			firstName?: string;
+			lastName?: string;
+			phone?: string;
+			email?: string;
+			optin?: boolean;
+		};
+
+		const firstName = body.firstName?.trim() ?? "";
+		const lastName = body.lastName?.trim() ?? "";
+		const phone = body.phone?.trim() ?? "";
+		const email = body.email?.trim().toLowerCase() ?? "";
+		const optin = body.optin === true;
+
+		if (!firstName || !lastName) {
+			return new Response(JSON.stringify({ error: "First name and last name required" }), {
+				status: 400,
+				headers,
+			});
+		}
+
+		if (email && !email.includes("@")) {
+			return new Response(JSON.stringify({ error: "Invalid email address" }), {
+				status: 400,
+				headers,
+			});
+		}
+
+		// Add to Resend contacts audience only when email is provided
+		if (email) {
+			const contactRes = await fetch("https://api.resend.com/contacts", {
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${context.env.RESEND_API_KEY}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					email,
+					first_name: firstName,
+					last_name: lastName,
+					unsubscribed: !optin,
+				}),
+			});
+
+			if (!contactRes.ok) {
+				const err = await contactRes.text();
+				console.error("Resend contacts error:", contactRes.status, err);
+				return new Response(JSON.stringify({ error: "Signup failed" }), {
+					status: 502,
+					headers,
+				});
+			}
+		}
+
+		// Create/update contact in GoHighLevel
+		if (context.env.GHL_API_KEY) {
+			// Phone digits only — prepend +1 for US numbers (form enforces 10-digit US format)
+			const ghlPhone = phone.replace(/\D/g, '');
+			const ghlRes = await fetch("https://rest.gohighlevel.com/v1/contacts/", {
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${context.env.GHL_API_KEY}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					firstName,
+					lastName,
+					...(email ? { email } : {}),
+					...(ghlPhone ? { phone: `+1${ghlPhone}` } : {}),
+					tags: ["community-optin"],
+					source: "signetai.sh",
+					// Requires a custom field named "newsletter_optin" in your GHL account
+					customField: [{ id: "newsletter_optin", value: optin ? "yes" : "no" }],
+				}),
+			});
+
+			if (!ghlRes.ok) {
+				const err = await ghlRes.text();
+				console.error("GHL contacts error:", ghlRes.status, err);
+				return new Response(JSON.stringify({ error: "Signup failed" }), {
+					status: 502,
+					headers,
+				});
+			}
+		}
+
+		// Send notification email with all fields if NOTIFY_EMAIL is configured
+		const notifyEmail = context.env.NOTIFY_EMAIL;
+		const fromEmail = context.env.FROM_EMAIL ?? "noreply@signetai.sh";
+
+		if (notifyEmail) {
+			const emailRes = await fetch("https://api.resend.com/emails", {
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${context.env.RESEND_API_KEY}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					from: `Signet Community <${fromEmail}>`,
+					to: [notifyEmail],
+					subject: `New community applicant: ${firstName} ${lastName}`,
+					html: `
+						<p><strong>Name:</strong> ${firstName} ${lastName}</p>
+						<p><strong>Email:</strong> ${email || "—"}</p>
+						<p><strong>Phone:</strong> ${phone || "—"}</p>
+						<p><strong>Newsletter opt-in:</strong> ${optin ? "Yes" : "No"}</p>
+					`.trim(),
+				}),
+			});
+
+			if (!emailRes.ok) {
+				// Non-fatal — contact was already stored
+				console.error("Resend notification error:", emailRes.status, await emailRes.text());
+			}
+		}
+
+		return new Response(JSON.stringify({ ok: true }), { status: 200, headers });
+	} catch (e) {
+		console.error("Optin error:", e);
+		return new Response(JSON.stringify({ error: "Server error" }), {
+			status: 500,
+			headers,
+		});
+	}
+};
+
+export const onRequestOptions: PagesFunction = async (context) => {
+	const origin = context.request.headers.get("Origin") ?? "";
+	return new Response(null, {
+		status: 204,
+		headers: {
+			...corsHeaders(origin),
+			"Access-Control-Allow-Methods": "POST, OPTIONS",
+			"Access-Control-Allow-Headers": "Content-Type",
+		},
+	});
+};

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,8 @@
 		"dev": "astro dev",
 		"build": "astro build",
 		"preview": "astro preview",
-		"deploy": "wrangler deploy"
+		"deploy": "wrangler deploy",
+		"dev:full": "astro build && wrangler pages dev ./dist --ip 0.0.0.0"
 	},
 	"dependencies": {
 		"@astrojs/mdx": "^4.3.13",

--- a/web/src/components/Nav.astro
+++ b/web/src/components/Nav.astro
@@ -30,6 +30,8 @@ import NavSearch from "./NavSearch.tsx";
       </button>
     </div>
 
+    <a href="/join" class="nav-join">Join</a>
+
     <a href="https://github.com/Signet-AI/signetai" class="nav-github">
       GitHub
       <svg class="nav-github-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M7 17L17 7M17 7H7M17 7v10"/></svg>
@@ -45,6 +47,7 @@ import NavSearch from "./NavSearch.tsx";
     <div class="nav-mobile-links">
       <a href="/docs" class="nav-mobile-link">Docs</a>
       <a href="/blog" class="nav-mobile-link">Blog</a>
+      <a href="/join" class="nav-mobile-link">Join Community</a>
       <a href="https://github.com/Signet-AI/signetai" class="nav-mobile-link">
         GitHub
         <svg class="nav-mobile-link-arrow" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M7 17L17 7M17 7H7M17 7v10"/></svg>

--- a/web/src/components/landing/Hero.astro
+++ b/web/src/components/landing/Hero.astro
@@ -68,10 +68,15 @@ const animatedAscii = rawAscii.replace(/█/g, () => {
             </svg>
           </button>
         </div>
+        <div class="hero-cta-row">
+          <a href="/join" class="btn btn-primary hero-discord-btn">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
+            Join Discord
+          </a>
+          <a href="https://github.com/Signet-AI/signetai" target="_blank" rel="noopener noreferrer" class="btn btn-ghost">GitHub</a>
+        </div>
         <div class="hero-actions">
           <span class="hero-install-alt">or <a href="https://www.npmjs.com/package/signetai">npm install -g signetai</a></span>
-          <span class="install-final-sep mx-2">•</span>
-          <a href="https://discord.gg/pHa5scah9C" target="_blank" rel="noopener noreferrer" class="hero-install-alt">Join Discord</a>
         </div>
       </div>
 
@@ -126,6 +131,21 @@ const animatedAscii = rawAscii.replace(/█/g, () => {
   }
 
   .mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
+
+  .hero-cta-row {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-top: var(--space-md);
+  }
+
+  .hero-discord-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+  }
 </style>
 
 <script>

--- a/web/src/components/landing/InstallCta.astro
+++ b/web/src/components/landing/InstallCta.astro
@@ -56,6 +56,7 @@
         <span>Local-first</span>
       </div>
       <div class="install-final-links">
+        <a href="/join" class="btn btn-primary">Join Community</a>
         <a href="/docs/quickstart" class="btn btn-ghost">Quickstart docs</a>
         <a href="https://github.com/Signet-AI/signetai" class="btn btn-ghost">GitHub</a>
       </div>

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -32,6 +32,7 @@ const imageUrl = new URL(image, Astro.site ?? "https://signetai.sh");
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="generator" content={Astro.generator} />
+    <script>if(typeof crypto!=="undefined"&&!crypto.randomUUID){crypto.randomUUID=function(){return([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g,function(c){return(c^crypto.getRandomValues(new Uint8Array(1))[0]&15>>c/4).toString(16)})};}</script>
     <!-- Meta Pixel Code -->
     <script>
     !function(f,b,e,v,n,t,s)
@@ -55,8 +56,7 @@ const imageUrl = new URL(image, Astro.site ?? "https://signetai.sh");
     </script>
     <!-- DO NOT MODIFY UNLESS TO REPLACE A USER IDENTIFIER -->
     <!-- End Reddit Pixel -->
-    <meta name="facebook-domain-verification" content="rgwxwhzzfpfry68kxw5nld9jo5r0sq" /> 
-    <script>if(typeof crypto!=="undefined"&&!crypto.randomUUID){crypto.randomUUID=function(){return([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g,function(c){return(c^crypto.getRandomValues(new Uint8Array(1))[0]&15>>c/4).toString(16)})};}</script>
+    <meta name="facebook-domain-verification" content="rgwxwhzzfpfry68kxw5nld9jo5r0sq" />
     <title>{title}</title>
     <meta name="description" content={description} />
     <link rel="canonical" href={canonicalUrl.href} />

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -56,6 +56,7 @@ const imageUrl = new URL(image, Astro.site ?? "https://signetai.sh");
     <!-- DO NOT MODIFY UNLESS TO REPLACE A USER IDENTIFIER -->
     <!-- End Reddit Pixel -->
     <meta name="facebook-domain-verification" content="rgwxwhzzfpfry68kxw5nld9jo5r0sq" /> 
+    <script>if(typeof crypto!=="undefined"&&!crypto.randomUUID){crypto.randomUUID=function(){return([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g,function(c){return(c^crypto.getRandomValues(new Uint8Array(1))[0]&15>>c/4).toString(16)})};}</script>
     <title>{title}</title>
     <meta name="description" content={description} />
     <link rel="canonical" href={canonicalUrl.href} />

--- a/web/src/pages/join.astro
+++ b/web/src/pages/join.astro
@@ -220,11 +220,13 @@ import "../styles/landing.css";
         if (formWrap) formWrap.hidden = true;
         if (success) success.hidden = false;
       } else {
-        btn.textContent = 'Try Again';
+        const body = await res.json().catch(() => null);
+        const detail = body?.detail ?? body?.error ?? '';
+        btn.textContent = detail ? `Error: ${detail.slice(0, 60)}` : 'Try Again';
         btn.disabled = false;
       }
-    } catch {
-      btn.textContent = 'Try Again';
+    } catch (err) {
+      btn.textContent = `Network error — try again`;
       btn.disabled = false;
     }
   });

--- a/web/src/pages/join.astro
+++ b/web/src/pages/join.astro
@@ -1,0 +1,527 @@
+---
+import Base from "../layouts/Base.astro";
+import Nav from "../components/Nav.astro";
+import Footer from "../components/Footer.astro";
+import "../styles/landing.css";
+---
+
+<Base title="Join the Community — Signet AI" description="Get early access updates and connect with builders shipping AI agent memory. Join the Signet Discord and explore the open source codebase.">
+  <Nav />
+  <main class="join-page">
+    <section class="container join-section">
+      <div class="join-panel reveal">
+        <div class="join-panel-barcode" aria-hidden="true"></div>
+
+        <div id="join-form-wrap">
+          <div class="join-eyebrow">EARLY ACCESS</div>
+          <h1 class="join-title">Join the Community</h1>
+          <p class="join-desc">
+            Connect with builders shipping AI agent memory. Get early access updates
+            and a seat in the Discord — plus the open source codebase is yours.
+          </p>
+
+          <form id="join-form" class="join-form" novalidate>
+            <div class="join-name-row">
+              <div class="join-field">
+                <input
+                  id="join-first"
+                  name="firstName"
+                  type="text"
+                  class="join-input"
+                  placeholder="First name"
+                  required
+                  autocomplete="given-name"
+                />
+                <p class="join-error" id="err-first" hidden>First name required</p>
+              </div>
+              <div class="join-field">
+                <input
+                  id="join-last"
+                  name="lastName"
+                  type="text"
+                  class="join-input"
+                  placeholder="Last name"
+                  required
+                  autocomplete="family-name"
+                />
+                <p class="join-error" id="err-last" hidden>Last name required</p>
+              </div>
+            </div>
+            <div class="join-field">
+              <input
+                id="join-phone"
+                name="phone"
+                type="tel"
+                class="join-input"
+                placeholder="(555) 555-5555"
+                autocomplete="tel"
+                maxlength="14"
+              />
+              <p class="join-error" id="err-phone" hidden>Enter a valid 10-digit number</p>
+            </div>
+            <div class="join-field">
+              <input
+                id="join-email"
+                name="email"
+                type="email"
+                class="join-input"
+                placeholder="Email address (optional)"
+                autocomplete="email"
+              />
+              <p class="join-error" id="err-email" hidden>Enter a valid email address</p>
+            </div>
+            <label class="join-checkbox-label">
+              <input
+                id="join-optin"
+                name="optin"
+                type="checkbox"
+                class="join-checkbox"
+              />
+              <span class="join-checkbox-indicator" aria-hidden="true"></span>
+              <span class="join-checkbox-text">I'd like to receive news and updates from Signet AI</span>
+            </label>
+            <button type="submit" class="btn btn-primary join-submit-btn">Get Access</button>
+            <p class="join-note">No spam. Unsubscribe anytime.</p>
+          </form>
+        </div>
+
+        <div id="join-success" class="join-success" hidden>
+          <div class="join-success-mark" aria-hidden="true">✓</div>
+          <h2 class="join-success-title">You're in.</h2>
+          <p class="join-success-desc">Here's where to go next.</p>
+          <div class="join-links">
+            <a
+              href="https://discord.gg/pHa5scah9C"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="join-link-card join-link-discord"
+            >
+              <div class="join-link-icon" aria-hidden="true">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
+              </div>
+              <div class="join-link-body">
+                <span class="join-link-label">Discord Community</span>
+                <span class="join-link-hint">Chat with the team and other builders →</span>
+              </div>
+            </a>
+
+            <a
+              href="https://github.com/Signet-AI/signetai"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="join-link-card join-link-github"
+            >
+              <div class="join-link-icon" aria-hidden="true">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0 0 22 12.017C22 6.484 17.522 2 12 2z" /></svg>
+              </div>
+              <div class="join-link-body">
+                <span class="join-link-label">GitHub Repository</span>
+                <span class="join-link-hint">Browse the source, open issues, contribute →</span>
+              </div>
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+    <Footer />
+  </main>
+</Base>
+
+<script src="../scripts/interactions.ts"></script>
+
+<script>
+  // --- Phone formatting: (555) 555-5555 ---
+  const phoneInput = document.getElementById('join-phone') as HTMLInputElement | null;
+  phoneInput?.addEventListener('input', () => {
+    const digits = phoneInput.value.replace(/\D/g, '').slice(0, 10);
+    let formatted = '';
+    if (digits.length <= 3) {
+      formatted = digits.length ? `(${digits}` : '';
+    } else if (digits.length <= 6) {
+      formatted = `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
+    } else {
+      formatted = `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
+    }
+    phoneInput.value = formatted;
+  });
+
+  // --- Email: trim + lowercase on blur ---
+  const emailInput = document.getElementById('join-email') as HTMLInputElement | null;
+  emailInput?.addEventListener('blur', () => {
+    emailInput.value = emailInput.value.trim().toLowerCase();
+  });
+
+  // --- Name: trim + capitalize on blur ---
+  function capitalize(s: string) {
+    return s.trim().replace(/\b\w/g, c => c.toUpperCase());
+  }
+  const firstInput = document.getElementById('join-first') as HTMLInputElement | null;
+  const lastInput = document.getElementById('join-last') as HTMLInputElement | null;
+  firstInput?.addEventListener('blur', () => { firstInput.value = capitalize(firstInput.value); });
+  lastInput?.addEventListener('blur', () => { lastInput.value = capitalize(lastInput.value); });
+
+  // --- Helpers ---
+  function setError(inputId: string, errId: string, show: boolean) {
+    const input = document.getElementById(inputId) as HTMLInputElement | null;
+    const err = document.getElementById(errId);
+    input?.classList.toggle('is-error', show);
+    if (err) err.hidden = !show;
+  }
+
+  function isValidEmail(v: string) {
+    return v === '' || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v);
+  }
+
+  function isValidPhone(v: string) {
+    // Allow empty (optional) or exactly 10 digits
+    const digits = v.replace(/\D/g, '');
+    return digits.length === 0 || digits.length === 10;
+  }
+
+  // Clear error state on input
+  document.querySelectorAll<HTMLInputElement>('.join-input').forEach(input => {
+    input.addEventListener('input', () => input.classList.remove('is-error'));
+  });
+
+  // --- Submit ---
+  const form = document.getElementById('join-form') as HTMLFormElement | null;
+  const formWrap = document.getElementById('join-form-wrap');
+  const success = document.getElementById('join-success');
+
+  form?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+
+    const firstName = firstInput?.value.trim() ?? '';
+    const lastName = lastInput?.value.trim() ?? '';
+    const phone = phoneInput?.value.trim() ?? '';
+    const email = emailInput?.value.trim().toLowerCase() ?? '';
+    const optin = (document.getElementById('join-optin') as HTMLInputElement | null)?.checked ?? false;
+
+    // Validate
+    let hasError = false;
+    if (!firstName) { setError('join-first', 'err-first', true); hasError = true; }
+    if (!lastName)  { setError('join-last',  'err-last',  true); hasError = true; }
+    if (email && !isValidEmail(email)) { setError('join-email', 'err-email', true); hasError = true; }
+    if (!isValidPhone(phone)) { setError('join-phone', 'err-phone', true); hasError = true; }
+    if (hasError) return;
+
+    const btn = form.querySelector('.join-submit-btn') as HTMLButtonElement;
+    btn.textContent = 'Submitting...';
+    btn.disabled = true;
+
+    try {
+      const res = await fetch('/api/optin', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ firstName, lastName, phone, email, optin }),
+      });
+
+      if (res.ok) {
+        if (formWrap) formWrap.hidden = true;
+        if (success) success.hidden = false;
+      } else {
+        btn.textContent = 'Try Again';
+        btn.disabled = false;
+      }
+    } catch {
+      btn.textContent = 'Try Again';
+      btn.disabled = false;
+    }
+  });
+</script>
+
+<style>
+  .join-page {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .join-section {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding-top: 120px;
+    padding-bottom: var(--space-3xl);
+  }
+
+  .join-panel {
+    position: relative;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border-strong);
+    border-radius: 12px;
+    padding: var(--space-2xl) var(--space-2xl);
+    max-width: 520px;
+    width: 100%;
+    box-shadow:
+      0 0 0 1px rgba(255, 255, 255, 0.03),
+      0 8px 32px rgba(0, 0, 0, 0.4);
+    overflow: hidden;
+  }
+
+  .join-panel-barcode {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: repeating-linear-gradient(
+      90deg,
+      var(--color-accent) 0px,
+      var(--color-accent) 2px,
+      transparent 2px,
+      transparent 6px
+    );
+    opacity: 0.6;
+  }
+
+  .join-eyebrow {
+    font-family: var(--font-mono);
+    font-size: 0.625rem;
+    letter-spacing: 0.2em;
+    color: var(--color-accent);
+    margin-bottom: var(--space-md);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .join-eyebrow::before {
+    content: "";
+    display: block;
+    width: 20px;
+    height: 1px;
+    background: var(--color-accent);
+  }
+
+  .join-title {
+    font-family: var(--font-display);
+    font-size: clamp(1.6rem, 4vw, 2.4rem);
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    color: var(--color-text-bright);
+    margin-bottom: var(--space-md);
+    line-height: 1.1;
+  }
+
+  .join-desc {
+    font-size: 0.9375rem;
+    line-height: 1.7;
+    color: var(--color-text);
+    margin-bottom: var(--space-xl);
+  }
+
+  .join-form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .join-name-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+  }
+
+  .join-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .join-error {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.06em;
+    color: #f87171;
+    padding-left: 2px;
+  }
+
+  .join-input {
+    width: 100%;
+    height: 44px;
+    padding: 0 16px;
+    background: var(--color-surface-raised);
+    border: 1px solid var(--color-border-strong);
+    border-radius: 8px;
+    color: var(--color-text-bright);
+    font-family: var(--font-mono);
+    font-size: 13px;
+    outline: none;
+    transition: border-color 0.2s var(--ease);
+    box-sizing: border-box;
+  }
+  .join-input::placeholder {
+    color: var(--color-text-muted);
+  }
+  .join-input:focus {
+    border-color: var(--color-accent);
+  }
+  .join-input.is-error {
+    border-color: #f87171;
+  }
+
+  .join-checkbox-label {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    cursor: pointer;
+    margin-top: 2px;
+  }
+
+  /* hide native, keep accessible */
+  .join-checkbox {
+    position: absolute;
+    opacity: 0;
+    width: 16px;
+    height: 16px;
+    margin: 0;
+    cursor: pointer;
+  }
+
+  .join-checkbox-indicator {
+    flex-shrink: 0;
+    width: 16px;
+    height: 16px;
+    margin-top: 1px;
+    border: 1px solid var(--color-border-strong);
+    border-radius: 3px;
+    background: var(--color-surface-raised);
+    transition: background 0.15s var(--ease), border-color 0.15s var(--ease);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .join-checkbox:checked + .join-checkbox-indicator {
+    background: var(--color-accent);
+    border-color: var(--color-accent);
+  }
+
+  .join-checkbox:checked + .join-checkbox-indicator::after {
+    content: '';
+    display: block;
+    width: 9px;
+    height: 5px;
+    border-left: 2px solid var(--color-bg);
+    border-bottom: 2px solid var(--color-bg);
+    transform: rotate(-45deg) translateY(-1px);
+  }
+
+  .join-checkbox:focus-visible + .join-checkbox-indicator {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+  }
+
+  .join-checkbox-label:hover .join-checkbox-indicator {
+    border-color: var(--color-accent);
+  }
+
+  .join-checkbox-text {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    color: var(--color-text-muted);
+    line-height: 1.5;
+  }
+
+  .join-submit-btn {
+    width: 100%;
+    height: 44px;
+    margin-top: 4px;
+  }
+
+  .join-note {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    color: var(--color-text-muted);
+  }
+
+  /* Success state */
+  .join-success {
+    text-align: center;
+  }
+
+  .join-success-mark {
+    font-size: 2rem;
+    color: var(--color-accent);
+    margin-bottom: var(--space-md);
+  }
+
+  .join-success-title {
+    font-family: var(--font-display);
+    font-size: clamp(1.4rem, 3vw, 2rem);
+    font-weight: 700;
+    text-transform: uppercase;
+    color: var(--color-text-bright);
+    margin-bottom: var(--space-sm);
+  }
+
+  .join-success-desc {
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+    margin-bottom: var(--space-xl);
+  }
+
+  .join-links {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .join-link-card {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 16px 20px;
+    border: 1px solid var(--color-border-strong);
+    border-radius: 10px;
+    text-decoration: none;
+    background: var(--color-surface-raised);
+    transition: all 0.2s var(--ease);
+    text-align: left;
+  }
+  .join-link-card:hover {
+    transform: translateY(-2px);
+    border-color: var(--color-accent);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  }
+
+  .join-link-discord .join-link-icon {
+    color: #5865f2;
+  }
+  .join-link-github .join-link-icon {
+    color: var(--color-text-bright);
+  }
+
+  .join-link-body {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .join-link-label {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-text-bright);
+  }
+
+  .join-link-hint {
+    font-size: 12px;
+    color: var(--color-text-muted);
+  }
+
+  @media (max-width: 580px) {
+    .join-panel {
+      padding: var(--space-xl) var(--space-lg);
+    }
+    .join-name-row {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -699,6 +699,30 @@ section {
 	transform: translateY(-1px);
 }
 
+.nav-join {
+	display: inline-flex;
+	align-items: center;
+	height: 36px;
+	padding: 0 16px;
+	border-radius: 8px;
+	background: var(--color-accent);
+	border: 1px solid var(--color-accent);
+	color: var(--color-bg);
+	font-size: 11px;
+	font-family: var(--font-mono);
+	letter-spacing: 0.1em;
+	text-transform: uppercase;
+	font-weight: 600;
+	text-decoration: none;
+	flex-shrink: 0;
+	transition: all 0.2s var(--ease);
+}
+.nav-join:hover {
+	background: var(--color-text-bright);
+	border-color: var(--color-text-bright);
+	transform: translateY(-1px);
+}
+
 .nav-theme-switch {
 	display: inline-flex;
 	align-items: center;
@@ -949,6 +973,7 @@ html.nav-open #nav-line-2 {
 	.nav-divider,
 	.nav-search,
 	.nav-github,
+	.nav-join,
 	.nav-theme-switch {
 		display: none;
 	}

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -4,5 +4,13 @@
 	"account_id": "a19f770b9be1b20e78b8d25bdcfd3bbd",
 	"compatibility_date": "2026-02-19",
 	"assets": { "directory": "./dist" },
-	"observability": { "enabled": true }
+	"observability": { "enabled": true },
+	"rate_limiting": [
+		{
+			"name": "RATE_LIMITER",
+			"threshold": 10,
+			"period": 60,
+			"action": "block"
+		}
+	]
 }


### PR DESCRIPTION
## Summary

- **Hero**: upgrades "Join Discord" from a buried text link to a primary button with Discord icon; adds GitHub ghost button alongside it
- **Nav**: accent-colored "Join" button on desktop, "Join Community" in mobile menu — both route to `/join`
- **InstallCta**: "Join Community" primary button added to the get-started footer links
- **New `/join` page**: opt-in form collecting first name, last name, phone (live `(555) 555-5555` mask), optional email, and newsletter checkbox with custom styled UI; reveals Discord invite + GitHub links on success
- **New `/api/optin` endpoint**: validates inputs server-side (length bounds, email regex, phone digit count), creates/upserts contact in GoHighLevel CRM v2, rate-limited via Cloudflare

## Test plan

- [ ] Visit `/join` — form renders with all fields
- [ ] Submit with missing first/last name — inline errors appear, form does not submit
- [ ] Type in phone field — auto-formats to `(555) 555-5555`
- [ ] Submit with a bad email — inline error appears
- [ ] Valid submit — success state reveals Discord and GitHub cards
- [ ] Check GoHighLevel CRM for new contact with "signet new lead" tag
- [ ] Hero Discord button and nav "Join" link visible on landing page