### PR TITLE
Fix Codex hook integration

### DIFF
--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -240,8 +240,8 @@ registers as an MCP server so Codex can call `signet_remember` and
 ### How it works
 
 1. Codex reads `~/.codex/hooks.json` at startup and registers three hooks.
-2. On session start, Codex fires `SessionStart` → calls `signet hook session-start -H codex` → Signet returns identity + memories as `additional_context` injected into the model's context window.
-3. On every user prompt, Codex fires `UserPromptSubmit` → calls `signet hook user-prompt-submit -H codex` → Signet returns per-prompt recalled memories as `additional_context`. This is blocking — Codex waits for the hook before sending to the model.
+2. On session start, Codex fires `SessionStart` → calls `signet hook session-start -H codex` → Signet returns Codex hook JSON with `hookSpecificOutput.additionalContext` containing identity + memories.
+3. On every user prompt, Codex fires `UserPromptSubmit` → calls `signet hook user-prompt-submit -H codex` → Signet returns Codex hook JSON with `hookSpecificOutput.additionalContext` containing per-prompt recalled memories. This is blocking — Codex waits for the hook before sending to the model.
 4. On session end, Codex fires `Stop` → calls `signet hook session-end -H codex` → Signet extracts memories from the transcript.
 5. The MCP server exposes `memory_store`, `memory_search`, and other memory tools that Codex can invoke directly during sessions.
 
@@ -253,8 +253,8 @@ Claude Code or OpenCode.
 
 | Hook | Supported |
 |------|-----------|
-| session-start | yes — identity + memories via `additional_context` |
-| user-prompt-submit | yes — per-prompt recall via `additional_context` |
+| session-start | yes — identity + memories via `hookSpecificOutput.additionalContext` |
+| user-prompt-submit | yes — per-prompt recall via `hookSpecificOutput.additionalContext` |
 | session-end | yes — transcript extraction via `Stop` hook |
 
 ### MCP tools

--- a/packages/cli/src/commands/hook.test.ts
+++ b/packages/cli/src/commands/hook.test.ts
@@ -189,6 +189,36 @@ describe("buildUserPromptSubmitBody", () => {
 		expect(seen[0]?.body).toContain('"harness":"claude-code"');
 		expect(lines).toContain("recalled context");
 	});
+
+	test("hook command emits Codex wire format for user-prompt-submit", async () => {
+		const lines: string[] = [];
+		console.log = (line?: unknown) => {
+			lines.push(String(line ?? ""));
+		};
+
+		const program = new Command();
+		registerHookCommands(program, {
+			AGENTS_DIR: "/tmp/agents",
+			fetchDaemonResult: async () => ({
+				ok: true,
+				data: {
+					inject: "  recalled context  ",
+				},
+			}),
+			readStaticIdentity: () => null,
+		});
+
+		await program.parseAsync(["node", "test", "hook", "user-prompt-submit", "-H", "codex"]);
+
+		expect(lines).toHaveLength(1);
+		expect(JSON.parse(lines[0] ?? "")).toEqual({
+			continue: true,
+			hookSpecificOutput: {
+				hookEventName: "UserPromptSubmit",
+				additionalContext: "recalled context",
+			},
+		});
+	});
 });
 
 describe("Codex hook wire output", () => {
@@ -218,6 +248,46 @@ describe("Codex hook wire output", () => {
 			hookSpecificOutput: {
 				hookEventName: "SessionStart",
 				additionalContext: null,
+			},
+		});
+	});
+
+	test("trims surrounding whitespace in Codex injection", () => {
+		expect(buildCodexSessionStartOutput("  hello  ")).toEqual({
+			continue: true,
+			hookSpecificOutput: {
+				hookEventName: "SessionStart",
+				additionalContext: "hello",
+			},
+		});
+	});
+
+	test("Codex harness output takes precedence over --json on session-start", async () => {
+		const lines: string[] = [];
+		console.log = (line?: unknown) => {
+			lines.push(String(line ?? ""));
+		};
+
+		const program = new Command();
+		registerHookCommands(program, {
+			AGENTS_DIR: "/tmp/agents",
+			fetchDaemonResult: async () => ({
+				ok: true,
+				data: {
+					inject: "session context",
+				},
+			}),
+			readStaticIdentity: () => null,
+		});
+
+		await program.parseAsync(["node", "test", "hook", "session-start", "-H", "codex", "--json"]);
+
+		expect(lines).toHaveLength(1);
+		expect(JSON.parse(lines[0] ?? "")).toEqual({
+			continue: true,
+			hookSpecificOutput: {
+				hookEventName: "SessionStart",
+				additionalContext: "session context",
 			},
 		});
 	});

--- a/packages/cli/src/commands/hook.test.ts
+++ b/packages/cli/src/commands/hook.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { Command } from "commander";
 import {
+	buildCodexSessionStartOutput,
+	buildCodexUserPromptSubmitOutput,
 	buildCompactionCompleteBody,
 	buildSessionEndBody,
 	buildSessionStartFallback,
@@ -186,6 +188,38 @@ describe("buildUserPromptSubmitBody", () => {
 		expect(seen[0]?.path).toBe("/api/hooks/user-prompt-submit");
 		expect(seen[0]?.body).toContain('"harness":"claude-code"');
 		expect(lines).toContain("recalled context");
+	});
+});
+
+describe("Codex hook wire output", () => {
+	test("wraps session-start injection in Codex hook JSON", () => {
+		expect(buildCodexSessionStartOutput("hello")).toEqual({
+			continue: true,
+			hookSpecificOutput: {
+				hookEventName: "SessionStart",
+				additionalContext: "hello",
+			},
+		});
+	});
+
+	test("wraps prompt-submit injection in Codex hook JSON", () => {
+		expect(buildCodexUserPromptSubmitOutput("prompt ctx")).toEqual({
+			continue: true,
+			hookSpecificOutput: {
+				hookEventName: "UserPromptSubmit",
+				additionalContext: "prompt ctx",
+			},
+		});
+	});
+
+	test("normalizes empty Codex injection to null", () => {
+		expect(buildCodexSessionStartOutput("")).toEqual({
+			continue: true,
+			hookSpecificOutput: {
+				hookEventName: "SessionStart",
+				additionalContext: null,
+			},
+		});
 	});
 });
 

--- a/packages/cli/src/commands/hook.ts
+++ b/packages/cli/src/commands/hook.ts
@@ -36,6 +36,38 @@ export function buildSessionStartFallback(
 	return readStaticIdentity(agentsDir);
 }
 
+interface CodexCommandOutput {
+	continue: true;
+	hookSpecificOutput?: {
+		hookEventName: "SessionStart" | "UserPromptSubmit";
+		additionalContext: string | null;
+	};
+}
+
+function emitCodexOutput(output: CodexCommandOutput): void {
+	console.log(JSON.stringify(output));
+}
+
+export function buildCodexSessionStartOutput(inject?: string): CodexCommandOutput {
+	return {
+		continue: true,
+		hookSpecificOutput: {
+			hookEventName: "SessionStart",
+			additionalContext: inject?.trim() ? inject : null,
+		},
+	};
+}
+
+export function buildCodexUserPromptSubmitOutput(inject?: string): CodexCommandOutput {
+	return {
+		continue: true,
+		hookSpecificOutput: {
+			hookEventName: "UserPromptSubmit",
+			additionalContext: inject?.trim() ? inject : null,
+		},
+	};
+}
+
 function formatHookFailure(
 	name: string,
 	res: {
@@ -123,6 +155,8 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 					}
 					if (options.json) {
 						console.log(JSON.stringify({ inject: fallback, identity: { name: "signet" }, memories: [] }));
+					} else if (options.harness === "codex") {
+						emitCodexOutput(buildCodexSessionStartOutput(fallback));
 					} else {
 						console.log(fallback);
 					}
@@ -143,6 +177,8 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 			}
 			if (options.json) {
 				console.log(JSON.stringify(data, null, 2));
+			} else if (options.harness === "codex") {
+				emitCodexOutput(buildCodexSessionStartOutput(data.inject));
 			} else if (data.inject) {
 				console.log(data.inject);
 			}
@@ -169,7 +205,11 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 			if (!data) {
 				process.exit(0);
 			}
-			if (data.inject) console.log(data.inject);
+			if (options.harness === "codex") {
+				emitCodexOutput(buildCodexUserPromptSubmitOutput(data.inject));
+			} else if (data.inject) {
+				console.log(data.inject);
+			}
 		});
 
 	hookCmd
@@ -186,6 +226,10 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 			});
 			if (!data) {
 				process.exit(0);
+			}
+			if (options.harness === "codex") {
+				console.log(JSON.stringify({ continue: true }));
+				return;
 			}
 			if ((data.memoriesSaved ?? 0) > 0) {
 				process.stderr.write(`[signet] ${data.memoriesSaved} memories saved\n`);

--- a/packages/cli/src/commands/hook.ts
+++ b/packages/cli/src/commands/hook.ts
@@ -48,12 +48,17 @@ function emitCodexOutput(output: CodexCommandOutput): void {
 	console.log(JSON.stringify(output));
 }
 
+function normalizeCodexAdditionalContext(inject?: string): string | null {
+	const normalized = inject?.trim();
+	return normalized ? normalized : null;
+}
+
 export function buildCodexSessionStartOutput(inject?: string): CodexCommandOutput {
 	return {
 		continue: true,
 		hookSpecificOutput: {
 			hookEventName: "SessionStart",
-			additionalContext: inject?.trim() ? inject : null,
+			additionalContext: normalizeCodexAdditionalContext(inject),
 		},
 	};
 }
@@ -63,7 +68,7 @@ export function buildCodexUserPromptSubmitOutput(inject?: string): CodexCommandO
 		continue: true,
 		hookSpecificOutput: {
 			hookEventName: "UserPromptSubmit",
-			additionalContext: inject?.trim() ? inject : null,
+			additionalContext: normalizeCodexAdditionalContext(inject),
 		},
 	};
 }
@@ -153,10 +158,10 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 					if (res.reason === "offline") {
 						process.stderr.write("[signet] daemon offline — using static identity\n");
 					}
-					if (options.json) {
-						console.log(JSON.stringify({ inject: fallback, identity: { name: "signet" }, memories: [] }));
-					} else if (options.harness === "codex") {
+					if (options.harness === "codex") {
 						emitCodexOutput(buildCodexSessionStartOutput(fallback));
+					} else if (options.json) {
+						console.log(JSON.stringify({ inject: fallback, identity: { name: "signet" }, memories: [] }));
 					} else {
 						console.log(fallback);
 					}
@@ -175,10 +180,10 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 				console.error(chalk.red(`Error: ${data.error}`));
 				process.exit(1);
 			}
-			if (options.json) {
-				console.log(JSON.stringify(data, null, 2));
-			} else if (options.harness === "codex") {
+			if (options.harness === "codex") {
 				emitCodexOutput(buildCodexSessionStartOutput(data.inject));
+			} else if (options.json) {
+				console.log(JSON.stringify(data, null, 2));
 			} else if (data.inject) {
 				console.log(data.inject);
 			}

--- a/packages/connector-codex/src/config-toml.test.ts
+++ b/packages/connector-codex/src/config-toml.test.ts
@@ -23,11 +23,13 @@ class TempConnector extends CodexConnector {
 let tempHome: string;
 let codexDir: string;
 let configPath: string;
+let hooksPath: string;
 
 beforeEach(() => {
 	tempHome = join(tmpdir(), `signet-codex-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	codexDir = join(tempHome, ".codex");
 	configPath = join(codexDir, "config.toml");
+	hooksPath = join(codexDir, "hooks.json");
 	mkdirSync(codexDir, { recursive: true });
 });
 
@@ -136,6 +138,120 @@ describe("CodexConnector.install — config.toml MCP registration", () => {
 
 		const content = readFileSync(configPath, "utf-8");
 		expect(content.match(/\[mcp_servers\.signet\]/g)?.length).toBe(1);
+	});
+});
+
+describe("CodexConnector.install — hooks.json registration", () => {
+	test("writes Codex 0.118+ hook schema with command hooks", async () => {
+		await connector().install(tempHome);
+
+		const hooks = JSON.parse(readFileSync(hooksPath, "utf-8")) as Record<string, unknown>;
+		expect(hooks._signet).toBe(true);
+		expect(hooks.SessionStart).toBeArray();
+		expect(hooks.UserPromptSubmit).toBeArray();
+		expect(hooks.Stop).toBeArray();
+
+		const sessionStartEntry = (hooks.SessionStart as Array<Record<string, unknown>>)[0];
+		const sessionStartHook = (sessionStartEntry.hooks as Array<Record<string, unknown>>)[0];
+		expect(sessionStartHook.type).toBe("command");
+		expect(sessionStartHook.command).toBe("signet hook session-start -H codex");
+		expect(sessionStartHook.timeout).toBe(10);
+	});
+
+	test("merges Signet hooks into existing modern hooks.json without replacing user hooks", async () => {
+		writeFileSync(
+			hooksPath,
+			JSON.stringify(
+				{
+					SessionStart: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command: "echo existing-hook",
+									timeout: 3,
+								},
+							],
+						},
+					],
+				},
+				null,
+				2,
+			),
+		);
+
+		const result = await connector().install(tempHome);
+		const hooks = JSON.parse(readFileSync(hooksPath, "utf-8")) as Record<string, unknown>;
+		const sessionStart = hooks.SessionStart as Array<Record<string, unknown>>;
+
+		expect(result.warnings).toContain("Merged Signet hooks into existing hooks.json — existing hooks preserved");
+		expect(sessionStart).toHaveLength(2);
+		expect(((sessionStart[0]?.hooks as Array<Record<string, unknown>>)[0]?.command)).toBe("echo existing-hook");
+		expect(((sessionStart[1]?.hooks as Array<Record<string, unknown>>)[0]?.command)).toBe(
+			"signet hook session-start -H codex",
+		);
+	});
+
+	test("uninstall removes legacy lowercase and modern uppercase Signet hook blocks", async () => {
+		writeFileSync(
+			hooksPath,
+			JSON.stringify(
+				{
+					_signet: true,
+					sessionStart: [
+						{
+							handlers: [
+								{
+									command: ["signet", "hook", "session-start", "-H", "codex"],
+									timeout: 10,
+								},
+							],
+						},
+					],
+					SessionStart: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command: "signet hook session-start -H codex",
+									timeout: 10,
+								},
+							],
+						},
+					],
+					Stop: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command: "echo keep-me",
+									timeout: 3,
+								},
+							],
+						},
+					],
+				},
+				null,
+				2,
+			),
+		);
+
+		await connector().uninstall();
+
+		const hooks = JSON.parse(readFileSync(hooksPath, "utf-8")) as Record<string, unknown>;
+		expect(hooks.sessionStart).toBeUndefined();
+		expect(hooks.SessionStart).toBeUndefined();
+		expect(hooks.Stop).toEqual([
+			{
+				hooks: [
+					{
+						type: "command",
+						command: "echo keep-me",
+						timeout: 3,
+					},
+				],
+			},
+		]);
 	});
 });
 

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -8,24 +8,30 @@ import { expandHome } from "@signet/core";
 // Signet command resolution
 // ---------------------------------------------------------------------------
 
-/** Resolve signet command for hook invocation. Returns shell-ready string form for hooks.json.
- *  Windows: navigates from argv[1] (e.g. <pkg>/bin/signet.js) up two levels to find
- *  the bin directory. Falls back to bare "signet" if the layout doesn't match (shims, junctions). */
-function resolveSignetCommand(): string {
-	if (process.platform !== "win32") return "signet";
+function resolvePackagedBin(relativePaths: string[]): string | null {
 	const entry = process.argv[1] || "";
-	const signetJs = join(entry, "..", "..", "bin", "signet.js");
-	if (existsSync(signetJs)) return `"${process.execPath}" "${signetJs}"`;
+	if (!entry) return null;
+	for (const relativePath of relativePaths) {
+		const candidate = join(entry, "..", "..", relativePath);
+		if (existsSync(candidate)) return candidate;
+	}
+	return null;
+}
+
+/** Resolve signet command for hook invocation. Returns shell-ready string form for hooks.json.
+ *  Prefer the installed package's absolute bin path so Codex hooks do not depend on PATH.
+ *  Falls back to bare "signet" only when the packaged layout is unavailable. */
+function resolveSignetCommand(): string {
+	const signetJs = resolvePackagedBin(["bin/signet.js"]);
+	if (signetJs) return `"${process.execPath}" "${signetJs}"`;
 	return "signet";
 }
 
 /** Resolve signet-mcp as { command, args } for Codex config.toml.
  *  Codex expects `command` as a string and `args` as a separate array. */
 function resolveSignetMcp(): { command: string; args: string[] } {
-	if (process.platform !== "win32") return { command: "signet-mcp", args: [] };
-	const entry = process.argv[1] || "";
-	const mcpJs = join(entry, "..", "..", "bin", "mcp-stdio.js");
-	if (existsSync(mcpJs)) return { command: process.execPath, args: [mcpJs] };
+	const mcpJs = resolvePackagedBin(["dist/mcp-stdio.js", "bin/mcp-stdio.js"]);
+	if (mcpJs) return { command: process.execPath, args: [mcpJs] };
 	return { command: "signet-mcp", args: [] };
 }
 

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -8,15 +8,15 @@ import { expandHome } from "@signet/core";
 // Signet command resolution
 // ---------------------------------------------------------------------------
 
-/** Resolve signet command for hook invocation. Returns array form for hooks.json command field.
+/** Resolve signet command for hook invocation. Returns shell-ready string form for hooks.json.
  *  Windows: navigates from argv[1] (e.g. <pkg>/bin/signet.js) up two levels to find
  *  the bin directory. Falls back to bare "signet" if the layout doesn't match (shims, junctions). */
-function resolveSignetArgs(): string[] {
-	if (process.platform !== "win32") return ["signet"];
+function resolveSignetCommand(): string {
+	if (process.platform !== "win32") return "signet";
 	const entry = process.argv[1] || "";
 	const signetJs = join(entry, "..", "..", "bin", "signet.js");
-	if (existsSync(signetJs)) return [process.execPath, signetJs];
-	return ["signet"];
+	if (existsSync(signetJs)) return `"${process.execPath}" "${signetJs}"`;
+	return "signet";
 }
 
 /** Resolve signet-mcp as { command, args } for Codex config.toml.
@@ -35,40 +35,43 @@ function resolveSignetMcp(): { command: string; args: string[] } {
 
 interface HooksJson {
 	_signet?: boolean;
-	sessionStart?: unknown[];
-	userPromptSubmit?: unknown[];
-	stop?: unknown[];
+	SessionStart?: unknown[];
+	UserPromptSubmit?: unknown[];
+	Stop?: unknown[];
 	[key: string]: unknown;
 }
 
-function buildHooksJson(signetArgs: string[]): HooksJson {
+function buildHooksJson(signetCommand: string): HooksJson {
 	return {
 		_signet: true,
-		sessionStart: [
+		SessionStart: [
 			{
-				handlers: [
+				hooks: [
 					{
-						command: [...signetArgs, "hook", "session-start", "-H", "codex"],
+						type: "command",
+						command: `${signetCommand} hook session-start -H codex`,
 						timeout: 10,
 					},
 				],
 			},
 		],
-		userPromptSubmit: [
+		UserPromptSubmit: [
 			{
-				handlers: [
+				hooks: [
 					{
-						command: [...signetArgs, "hook", "user-prompt-submit", "-H", "codex"],
+						type: "command",
+						command: `${signetCommand} hook user-prompt-submit -H codex`,
 						timeout: 5,
 					},
 				],
 			},
 		],
-		stop: [
+		Stop: [
 			{
-				handlers: [
+				hooks: [
 					{
-						command: [...signetArgs, "hook", "session-end", "-H", "codex"],
+						type: "command",
+						command: `${signetCommand} hook session-end -H codex`,
 						timeout: 30,
 					},
 				],
@@ -102,21 +105,31 @@ const SIGNET_HOOK_CMDS = ["hook session-start", "hook user-prompt-submit", "hook
 
 function isSignetHandler(entry: unknown): boolean {
 	if (typeof entry !== "object" || entry === null) return false;
+	const hooks = (entry as Record<string, unknown>).hooks;
+	if (Array.isArray(hooks)) {
+		for (const hook of hooks) {
+			if (typeof hook !== "object" || hook === null) continue;
+			const cmd = (hook as Record<string, unknown>).command;
+			if (typeof cmd === "string" && SIGNET_HOOK_CMDS.some((s) => cmd.includes(s))) return true;
+		}
+	}
 	const handlers = (entry as Record<string, unknown>).handlers;
-	if (!Array.isArray(handlers)) return false;
-	for (const handler of handlers) {
-		if (typeof handler !== "object" || handler === null) continue;
-		const cmd = (handler as Record<string, unknown>).command;
-		if (!Array.isArray(cmd)) continue;
-		const joined = cmd.join(" ");
-		if (SIGNET_HOOK_CMDS.some((s) => joined.includes(s))) return true;
+	if (Array.isArray(handlers)) {
+		for (const handler of handlers) {
+			if (typeof handler !== "object" || handler === null) continue;
+			const cmd = (handler as Record<string, unknown>).command;
+			if (Array.isArray(cmd)) {
+				const joined = cmd.join(" ");
+				if (SIGNET_HOOK_CMDS.some((s) => joined.includes(s))) return true;
+			}
+		}
 	}
 	return false;
 }
 
 function removeSignetHooks(hooks: HooksJson): HooksJson {
 	const cleaned = { ...hooks };
-	for (const key of ["sessionStart", "userPromptSubmit", "stop"] as const) {
+	for (const key of ["SessionStart", "UserPromptSubmit", "Stop", "sessionStart", "userPromptSubmit", "stop"] as const) {
 		if (!Array.isArray(cleaned[key])) continue;
 		const filtered = (cleaned[key] as unknown[]).filter((e) => !isSignetHandler(e));
 		if (filtered.length === 0) {
@@ -126,7 +139,7 @@ function removeSignetHooks(hooks: HooksJson): HooksJson {
 		}
 	}
 	// Only remove marker if no Signet entries remain
-	const hasSignet = ["sessionStart", "userPromptSubmit", "stop"].some(
+	const hasSignet = ["SessionStart", "UserPromptSubmit", "Stop", "sessionStart", "userPromptSubmit", "stop"].some(
 		(k) => Array.isArray(cleaned[k]) && (cleaned[k] as unknown[]).some(isSignetHandler),
 	);
 	if (!hasSignet) delete cleaned._signet;
@@ -247,7 +260,7 @@ export class CodexConnector extends BaseConnector {
 		const codexHome = this.getCodexHome();
 		mkdirSync(codexHome, { recursive: true });
 
-		const signetArgs = resolveSignetArgs();
+		const signetCommand = resolveSignetCommand();
 
 		// 1. Install hooks.json (native Codex hook system)
 		const hooksPath = this.getHooksJsonPath();
@@ -255,10 +268,10 @@ export class CodexConnector extends BaseConnector {
 
 		if (existing && !isSignetOwned(existing)) {
 			// User has their own hooks.json — merge Signet hooks in
-			const signetHooks = buildHooksJson(signetArgs);
+			const signetHooks = buildHooksJson(signetCommand);
 			const merged: HooksJson = { ...existing };
 			merged._signet = true;
-			for (const key of ["sessionStart", "userPromptSubmit", "stop"] as const) {
+			for (const key of ["SessionStart", "UserPromptSubmit", "Stop"] as const) {
 				const current = Array.isArray(merged[key]) ? (merged[key] as unknown[]) : [];
 				const signet = signetHooks[key] as unknown[];
 				merged[key] = [...current, ...signet];
@@ -266,7 +279,7 @@ export class CodexConnector extends BaseConnector {
 			writeHooksJson(hooksPath, merged);
 			warnings.push("Merged Signet hooks into existing hooks.json — existing hooks preserved");
 		} else {
-			writeHooksJson(hooksPath, buildHooksJson(signetArgs));
+			writeHooksJson(hooksPath, buildHooksJson(signetCommand));
 		}
 		filesWritten.push(hooksPath);
 
@@ -301,7 +314,7 @@ export class CodexConnector extends BaseConnector {
 		if (existing) {
 			// Check marker first; fall back to handler scan if marker was stripped
 			const hasMarker = isSignetOwned(existing);
-			const hasHandlers = ["sessionStart", "userPromptSubmit", "stop"].some(
+			const hasHandlers = ["SessionStart", "UserPromptSubmit", "Stop", "sessionStart", "userPromptSubmit", "stop"].some(
 				(k) =>
 					Array.isArray((existing as Record<string, unknown>)[k]) &&
 					((existing as Record<string, unknown>)[k] as unknown[]).some(isSignetHandler),
@@ -337,7 +350,7 @@ export class CodexConnector extends BaseConnector {
 	isInstalled(): boolean {
 		const hooks = readHooksJson(this.getHooksJsonPath());
 		if (!hooks) return false;
-		return ["sessionStart", "userPromptSubmit", "stop"].some(
+		return ["SessionStart", "UserPromptSubmit", "Stop", "sessionStart", "userPromptSubmit", "stop"].some(
 			(k) =>
 				Array.isArray((hooks as Record<string, unknown>)[k]) &&
 				((hooks as Record<string, unknown>)[k] as unknown[]).some(isSignetHandler),

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -18,18 +18,24 @@ function resolvePackagedBin(relativePaths: string[]): string | null {
 	return null;
 }
 
-/** Resolve signet command for hook invocation. Returns shell-ready string form for hooks.json.
- *  Prefer the installed package's absolute bin path so Codex hooks do not depend on PATH.
- *  Falls back to bare "signet" only when the packaged layout is unavailable. */
+function shellDoubleQuote(value: string): string {
+	return `"${value.replace(/"/g, '\\"')}"`;
+}
+
+/** Resolve signet command for hook invocation. hooks.json only supports a command string,
+ *  so keep the longstanding non-Windows "signet" path and only use the packaged absolute
+ *  entrypoint on Windows where PATH lookup is the historical failure mode. */
 function resolveSignetCommand(): string {
+	if (process.platform !== "win32") return "signet";
 	const signetJs = resolvePackagedBin(["bin/signet.js"]);
-	if (signetJs) return `"${process.execPath}" "${signetJs}"`;
+	if (signetJs) return `${shellDoubleQuote(process.execPath)} ${shellDoubleQuote(signetJs)}`;
 	return "signet";
 }
 
 /** Resolve signet-mcp as { command, args } for Codex config.toml.
  *  Codex expects `command` as a string and `args` as a separate array. */
 function resolveSignetMcp(): { command: string; args: string[] } {
+	if (process.platform !== "win32") return { command: "signet-mcp", args: [] };
 	const mcpJs = resolvePackagedBin(["dist/mcp-stdio.js", "bin/mcp-stdio.js"]);
 	if (mcpJs) return { command: process.execPath, args: [mcpJs] };
 	return { command: "signet-mcp", args: [] };


### PR DESCRIPTION
## Summary
- update the Codex connector to write the current `hooks.json` schema and clean up both modern and legacy Signet hook entries
- emit Codex command hook JSON from `signet hook ... -H codex` so `SessionStart` and `UserPromptSubmit` inject context through `hookSpecificOutput.additionalContext`
- resolve packaged Signet CLI/MCP entrypoints for Codex so fresh Codex processes do not depend on `PATH` containing `signet` or `signet-mcp`
- add regression coverage for the new Codex hook wire format and connector install/uninstall behavior, and update Codex harness docs

## Validation
- `cd packages/cli && bun test ./src/commands/hook.test.ts`
- `bun run build:core`
- `bun run build:connector-base`
- `cd packages/connector-codex && bun test ./src/config-toml.test.ts`
- `cd packages/connector-codex && bun run typecheck`
- `cd packages/connector-codex && bun run build`
- `bun run build:deps`

## Notes
- Reproduced against `codex-cli 0.118.0`: fresh Codex startup could miss Signet entirely when the startup environment did not include `signet` on `PATH`.
- `bun run build:signetai` in this worktree still fails on unrelated workspace resolution for `@signet/connector-oh-my-pi` during `packages/signetai build:cli`; this change does not touch that packaging path.

## PR Readiness Checklist
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally
