### PR TITLE
Fix Codex hook fallback integration

### DIFF
--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -236,14 +236,17 @@ registers as an MCP server so Codex can call `signet_remember` and
 | `~/.codex/hooks.json` | Native Codex hooks — SessionStart, UserPromptSubmit, Stop |
 | `~/.codex/config.toml` | MCP server registration (`[mcp_servers.signet]`) |
 | `~/.codex/skills` | Symlink to `$SIGNET_WORKSPACE/skills` |
+| `~/.local/bin/codex` | Signet-managed wrapper fallback for Codex builds that skip native hooks |
+| `~/.local/bin/codex-signet-watch.js` | Session watcher that replays prompt-submit logging through Signet |
 
 ### How it works
 
-1. Codex reads `~/.codex/hooks.json` at startup and registers three hooks.
+1. Codex reads `~/.codex/hooks.json` at startup and registers three hooks when the current Codex build honors native hooks.
 2. On session start, Codex fires `SessionStart` → calls `signet hook session-start -H codex` → Signet returns Codex hook JSON with `hookSpecificOutput.additionalContext` containing identity + memories.
-3. On every user prompt, Codex fires `UserPromptSubmit` → calls `signet hook user-prompt-submit -H codex` → Signet returns Codex hook JSON with `hookSpecificOutput.additionalContext` containing per-prompt recalled memories. This is blocking — Codex waits for the hook before sending to the model.
+3. On every user prompt, Codex fires `UserPromptSubmit` → calls `signet hook user-prompt-submit -H codex` → Signet returns Codex hook JSON with `hookSpecificOutput.additionalContext` containing per-prompt recalled memories. This is blocking when native hooks are active.
 4. On session end, Codex fires `Stop` → calls `signet hook session-end -H codex` → Signet extracts memories from the transcript.
-5. The MCP server exposes `memory_store`, `memory_search`, and other memory tools that Codex can invoke directly during sessions.
+5. If a Codex build skips native hooks, the Signet-managed `~/.local/bin/codex` wrapper injects identity via workspace `AGENTS.md`, emits explicit fallback log markers, calls the real session-start and session-end hooks, and uses `codex-signet-watch.js` to replay prompt-submit hooks from the session JSONL stream.
+6. The MCP server exposes `memory_store`, `memory_search`, and other memory tools that Codex can invoke directly during sessions.
 
 Codex matches the session-start, prompt-submit, and session-end path, but
 it does **not** currently expose the same compaction lifecycle fidelity as
@@ -253,9 +256,9 @@ Claude Code or OpenCode.
 
 | Hook | Supported |
 |------|-----------|
-| session-start | yes — identity + memories via `hookSpecificOutput.additionalContext` |
-| user-prompt-submit | yes — per-prompt recall via `hookSpecificOutput.additionalContext` |
-| session-end | yes — transcript extraction via `Stop` hook |
+| session-start | yes — native hooks when available, wrapper fallback otherwise |
+| user-prompt-submit | yes — native hooks when available, session watcher fallback otherwise |
+| session-end | yes — native hooks when available, wrapper fallback otherwise |
 
 ### MCP tools
 

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -240,8 +240,8 @@ registers as an MCP server so Codex can call `signet_remember` and
 ### How it works
 
 1. Codex reads `~/.codex/hooks.json` at startup and registers three hooks.
-2. On session start, Codex fires `SessionStart` → calls `signet hook session-start -H codex` → Signet returns identity + memories as `additional_context` injected into the model's context window.
-3. On every user prompt, Codex fires `UserPromptSubmit` → calls `signet hook user-prompt-submit -H codex` → Signet returns per-prompt recalled memories as `additional_context`. This is blocking — Codex waits for the hook before sending to the model.
+2. On session start, Codex fires `SessionStart` → calls `signet hook session-start -H codex` → Signet returns Codex hook JSON with `hookSpecificOutput.additionalContext` containing identity + memories.
+3. On every user prompt, Codex fires `UserPromptSubmit` → calls `signet hook user-prompt-submit -H codex` → Signet returns Codex hook JSON with `hookSpecificOutput.additionalContext` containing per-prompt recalled memories. This is blocking — Codex waits for the hook before sending to the model.
 4. On session end, Codex fires `Stop` → calls `signet hook session-end -H codex` → Signet extracts memories from the transcript.
 5. The MCP server exposes `memory_store`, `memory_search`, and other memory tools that Codex can invoke directly during sessions.
 
@@ -253,8 +253,8 @@ Claude Code or OpenCode.
 
 | Hook | Supported |
 |------|-----------|
-| session-start | yes — identity + memories via `additional_context` |
-| user-prompt-submit | yes — per-prompt recall via `additional_context` |
+| session-start | yes — identity + memories via `hookSpecificOutput.additionalContext` |
+| user-prompt-submit | yes — per-prompt recall via `hookSpecificOutput.additionalContext` |
 | session-end | yes — transcript extraction via `Stop` hook |
 
 ### MCP tools

--- a/packages/cli/src/commands/hook.test.ts
+++ b/packages/cli/src/commands/hook.test.ts
@@ -189,6 +189,36 @@ describe("buildUserPromptSubmitBody", () => {
 		expect(seen[0]?.body).toContain('"harness":"claude-code"');
 		expect(lines).toContain("recalled context");
 	});
+
+	test("hook command emits Codex wire format for user-prompt-submit", async () => {
+		const lines: string[] = [];
+		console.log = (line?: unknown) => {
+			lines.push(String(line ?? ""));
+		};
+
+		const program = new Command();
+		registerHookCommands(program, {
+			AGENTS_DIR: "/tmp/agents",
+			fetchDaemonResult: async () => ({
+				ok: true,
+				data: {
+					inject: "  recalled context  ",
+				},
+			}),
+			readStaticIdentity: () => null,
+		});
+
+		await program.parseAsync(["node", "test", "hook", "user-prompt-submit", "-H", "codex"]);
+
+		expect(lines).toHaveLength(1);
+		expect(JSON.parse(lines[0] ?? "")).toEqual({
+			continue: true,
+			hookSpecificOutput: {
+				hookEventName: "UserPromptSubmit",
+				additionalContext: "recalled context",
+			},
+		});
+	});
 });
 
 describe("Codex hook wire output", () => {
@@ -218,6 +248,46 @@ describe("Codex hook wire output", () => {
 			hookSpecificOutput: {
 				hookEventName: "SessionStart",
 				additionalContext: null,
+			},
+		});
+	});
+
+	test("trims surrounding whitespace in Codex injection", () => {
+		expect(buildCodexSessionStartOutput("  hello  ")).toEqual({
+			continue: true,
+			hookSpecificOutput: {
+				hookEventName: "SessionStart",
+				additionalContext: "hello",
+			},
+		});
+	});
+
+	test("Codex harness output takes precedence over --json on session-start", async () => {
+		const lines: string[] = [];
+		console.log = (line?: unknown) => {
+			lines.push(String(line ?? ""));
+		};
+
+		const program = new Command();
+		registerHookCommands(program, {
+			AGENTS_DIR: "/tmp/agents",
+			fetchDaemonResult: async () => ({
+				ok: true,
+				data: {
+					inject: "session context",
+				},
+			}),
+			readStaticIdentity: () => null,
+		});
+
+		await program.parseAsync(["node", "test", "hook", "session-start", "-H", "codex", "--json"]);
+
+		expect(lines).toHaveLength(1);
+		expect(JSON.parse(lines[0] ?? "")).toEqual({
+			continue: true,
+			hookSpecificOutput: {
+				hookEventName: "SessionStart",
+				additionalContext: "session context",
 			},
 		});
 	});

--- a/packages/cli/src/commands/hook.test.ts
+++ b/packages/cli/src/commands/hook.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { Command } from "commander";
 import {
+	buildCodexSessionStartOutput,
+	buildCodexUserPromptSubmitOutput,
 	buildCompactionCompleteBody,
 	buildSessionEndBody,
 	buildSessionStartFallback,
@@ -186,6 +188,38 @@ describe("buildUserPromptSubmitBody", () => {
 		expect(seen[0]?.path).toBe("/api/hooks/user-prompt-submit");
 		expect(seen[0]?.body).toContain('"harness":"claude-code"');
 		expect(lines).toContain("recalled context");
+	});
+});
+
+describe("Codex hook wire output", () => {
+	test("wraps session-start injection in Codex hook JSON", () => {
+		expect(buildCodexSessionStartOutput("hello")).toEqual({
+			continue: true,
+			hookSpecificOutput: {
+				hookEventName: "SessionStart",
+				additionalContext: "hello",
+			},
+		});
+	});
+
+	test("wraps prompt-submit injection in Codex hook JSON", () => {
+		expect(buildCodexUserPromptSubmitOutput("prompt ctx")).toEqual({
+			continue: true,
+			hookSpecificOutput: {
+				hookEventName: "UserPromptSubmit",
+				additionalContext: "prompt ctx",
+			},
+		});
+	});
+
+	test("normalizes empty Codex injection to null", () => {
+		expect(buildCodexSessionStartOutput("")).toEqual({
+			continue: true,
+			hookSpecificOutput: {
+				hookEventName: "SessionStart",
+				additionalContext: null,
+			},
+		});
 	});
 });
 

--- a/packages/cli/src/commands/hook.ts
+++ b/packages/cli/src/commands/hook.ts
@@ -36,6 +36,38 @@ export function buildSessionStartFallback(
 	return readStaticIdentity(agentsDir);
 }
 
+interface CodexCommandOutput {
+	continue: true;
+	hookSpecificOutput?: {
+		hookEventName: "SessionStart" | "UserPromptSubmit";
+		additionalContext: string | null;
+	};
+}
+
+function emitCodexOutput(output: CodexCommandOutput): void {
+	console.log(JSON.stringify(output));
+}
+
+export function buildCodexSessionStartOutput(inject?: string): CodexCommandOutput {
+	return {
+		continue: true,
+		hookSpecificOutput: {
+			hookEventName: "SessionStart",
+			additionalContext: inject?.trim() ? inject : null,
+		},
+	};
+}
+
+export function buildCodexUserPromptSubmitOutput(inject?: string): CodexCommandOutput {
+	return {
+		continue: true,
+		hookSpecificOutput: {
+			hookEventName: "UserPromptSubmit",
+			additionalContext: inject?.trim() ? inject : null,
+		},
+	};
+}
+
 function formatHookFailure(
 	name: string,
 	res: {
@@ -123,6 +155,8 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 					}
 					if (options.json) {
 						console.log(JSON.stringify({ inject: fallback, identity: { name: "signet" }, memories: [] }));
+					} else if (options.harness === "codex") {
+						emitCodexOutput(buildCodexSessionStartOutput(fallback));
 					} else {
 						console.log(fallback);
 					}
@@ -143,6 +177,8 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 			}
 			if (options.json) {
 				console.log(JSON.stringify(data, null, 2));
+			} else if (options.harness === "codex") {
+				emitCodexOutput(buildCodexSessionStartOutput(data.inject));
 			} else if (data.inject) {
 				console.log(data.inject);
 			}
@@ -169,7 +205,11 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 			if (!data) {
 				process.exit(0);
 			}
-			if (data.inject) console.log(data.inject);
+			if (options.harness === "codex") {
+				emitCodexOutput(buildCodexUserPromptSubmitOutput(data.inject));
+			} else if (data.inject) {
+				console.log(data.inject);
+			}
 		});
 
 	hookCmd
@@ -186,6 +226,10 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 			});
 			if (!data) {
 				process.exit(0);
+			}
+			if (options.harness === "codex") {
+				console.log(JSON.stringify({ continue: true }));
+				return;
 			}
 			if ((data.memoriesSaved ?? 0) > 0) {
 				process.stderr.write(`[signet] ${data.memoriesSaved} memories saved\n`);

--- a/packages/cli/src/commands/hook.ts
+++ b/packages/cli/src/commands/hook.ts
@@ -48,12 +48,17 @@ function emitCodexOutput(output: CodexCommandOutput): void {
 	console.log(JSON.stringify(output));
 }
 
+function normalizeCodexAdditionalContext(inject?: string): string | null {
+	const normalized = inject?.trim();
+	return normalized ? normalized : null;
+}
+
 export function buildCodexSessionStartOutput(inject?: string): CodexCommandOutput {
 	return {
 		continue: true,
 		hookSpecificOutput: {
 			hookEventName: "SessionStart",
-			additionalContext: inject?.trim() ? inject : null,
+			additionalContext: normalizeCodexAdditionalContext(inject),
 		},
 	};
 }
@@ -63,7 +68,7 @@ export function buildCodexUserPromptSubmitOutput(inject?: string): CodexCommandO
 		continue: true,
 		hookSpecificOutput: {
 			hookEventName: "UserPromptSubmit",
-			additionalContext: inject?.trim() ? inject : null,
+			additionalContext: normalizeCodexAdditionalContext(inject),
 		},
 	};
 }
@@ -153,10 +158,10 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 					if (res.reason === "offline") {
 						process.stderr.write("[signet] daemon offline — using static identity\n");
 					}
-					if (options.json) {
-						console.log(JSON.stringify({ inject: fallback, identity: { name: "signet" }, memories: [] }));
-					} else if (options.harness === "codex") {
+					if (options.harness === "codex") {
 						emitCodexOutput(buildCodexSessionStartOutput(fallback));
+					} else if (options.json) {
+						console.log(JSON.stringify({ inject: fallback, identity: { name: "signet" }, memories: [] }));
 					} else {
 						console.log(fallback);
 					}
@@ -175,10 +180,10 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 				console.error(chalk.red(`Error: ${data.error}`));
 				process.exit(1);
 			}
-			if (options.json) {
-				console.log(JSON.stringify(data, null, 2));
-			} else if (options.harness === "codex") {
+			if (options.harness === "codex") {
 				emitCodexOutput(buildCodexSessionStartOutput(data.inject));
+			} else if (options.json) {
+				console.log(JSON.stringify(data, null, 2));
 			} else if (data.inject) {
 				console.log(data.inject);
 			}

--- a/packages/connector-codex/src/config-toml.test.ts
+++ b/packages/connector-codex/src/config-toml.test.ts
@@ -268,11 +268,19 @@ describe("CodexConnector.install — hooks.json registration", () => {
 describe("CodexConnector.install — wrapper fallback", () => {
 	test("installs Signet-managed Codex wrapper and watcher", async () => {
 		const result = await connector().install(tempHome);
+		const wrapper = readFileSync(wrapperPath, "utf-8");
+		const watcher = readFileSync(watcherPath, "utf-8");
 
 		expect(result.filesWritten).toContain(wrapperPath);
 		expect(result.filesWritten).toContain(watcherPath);
-		expect(readFileSync(wrapperPath, "utf-8")).toContain("SIGNET-CODEX-FALLBACK");
-		expect(readFileSync(watcherPath, "utf-8")).toContain("SIGNET-CODEX-FALLBACK");
+		expect(wrapper).toContain("SIGNET-CODEX-FALLBACK");
+		expect(wrapper).toContain('readonly SIGNET_LOG_DIR="$SIGNET_WORKSPACE/.daemon/logs"');
+		expect(wrapper).not.toContain("python3 - <<'PY'");
+		expect(wrapper).toContain('"$WATCHER_BIN" "$root" "$launch_ms" "$SIGNET_WORKSPACE"');
+		expect(watcher).toContain("SIGNET-CODEX-FALLBACK");
+		expect(watcher).toContain('const signetWorkspace = process.argv[4] || path.join(os.homedir(), ".agents");');
+		expect(watcher).toContain('const logDir = path.join(signetWorkspace, ".daemon", "logs");');
+		expect(watcher).toContain("timeout: 8000");
 	});
 
 	test("does not replace a non-Signet codex wrapper", async () => {

--- a/packages/connector-codex/src/config-toml.test.ts
+++ b/packages/connector-codex/src/config-toml.test.ts
@@ -280,6 +280,8 @@ describe("CodexConnector.install — wrapper fallback", () => {
 		expect(wrapper).toContain("LC_ALL=C tr -d '\\001-\\010\\013\\014\\016-\\037'");
 		expect(wrapper).toContain('"$WATCHER_BIN" "$root" "$launch_ms" "$SIGNET_WORKSPACE"');
 		expect(wrapper).toContain('trigger_session_end "$root"');
+		expect(wrapper).toContain(`printf '%s' "$payload" | signet hook session-end -H codex`);
+		expect(wrapper).toContain(`payload="$(printf '{"cwd":"%s","reason":"%s"}'`);
 		expect(wrapper).toContain("trap 'exit 130' INT TERM");
 		expect(watcher).toContain("SIGNET-CODEX-FALLBACK");
 		expect(watcher).toContain('const signetWorkspace = process.argv[4] || path.join(os.homedir(), ".agents");');

--- a/packages/connector-codex/src/config-toml.test.ts
+++ b/packages/connector-codex/src/config-toml.test.ts
@@ -18,19 +18,29 @@ class TempConnector extends CodexConnector {
 	protected override getCodexHome(): string {
 		return join(this.home, ".codex");
 	}
+	protected override getLocalBinDir(): string {
+		return join(this.home, ".local", "bin");
+	}
 }
 
 let tempHome: string;
 let codexDir: string;
 let configPath: string;
 let hooksPath: string;
+let localBinDir: string;
+let wrapperPath: string;
+let watcherPath: string;
 
 beforeEach(() => {
 	tempHome = join(tmpdir(), `signet-codex-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	codexDir = join(tempHome, ".codex");
 	configPath = join(codexDir, "config.toml");
 	hooksPath = join(codexDir, "hooks.json");
+	localBinDir = join(tempHome, ".local", "bin");
+	wrapperPath = join(localBinDir, "codex");
+	watcherPath = join(localBinDir, "codex-signet-watch.js");
 	mkdirSync(codexDir, { recursive: true });
+	mkdirSync(localBinDir, { recursive: true });
 });
 
 afterEach(() => {
@@ -252,6 +262,38 @@ describe("CodexConnector.install — hooks.json registration", () => {
 				],
 			},
 		]);
+	});
+});
+
+describe("CodexConnector.install — wrapper fallback", () => {
+	test("installs Signet-managed Codex wrapper and watcher", async () => {
+		const result = await connector().install(tempHome);
+
+		expect(result.filesWritten).toContain(wrapperPath);
+		expect(result.filesWritten).toContain(watcherPath);
+		expect(readFileSync(wrapperPath, "utf-8")).toContain("SIGNET-CODEX-FALLBACK");
+		expect(readFileSync(watcherPath, "utf-8")).toContain("SIGNET-CODEX-FALLBACK");
+	});
+
+	test("does not replace a non-Signet codex wrapper", async () => {
+		writeFileSync(wrapperPath, "#!/bin/zsh\necho user-wrapper\n", "utf-8");
+
+		const result = await connector().install(tempHome);
+
+		expect(readFileSync(wrapperPath, "utf-8")).toContain("user-wrapper");
+		expect(result.warnings).toContain(`Skipped installing Codex wrapper at ${wrapperPath} — existing file is not Signet-managed`);
+		expect(readFileSync(watcherPath, "utf-8")).toContain("SIGNET-CODEX-FALLBACK");
+	});
+
+	test("uninstall removes Signet-managed wrapper files", async () => {
+		await connector().install(tempHome);
+
+		const result = await connector().uninstall();
+
+		expect(result.filesRemoved).toContain(wrapperPath);
+		expect(result.filesRemoved).toContain(watcherPath);
+		expect(existsSync(wrapperPath)).toBe(false);
+		expect(existsSync(watcherPath)).toBe(false);
 	});
 });
 

--- a/packages/connector-codex/src/config-toml.test.ts
+++ b/packages/connector-codex/src/config-toml.test.ts
@@ -279,9 +279,12 @@ describe("CodexConnector.install — wrapper fallback", () => {
 		expect(wrapper).not.toContain("python3 - <<'PY'");
 		expect(wrapper).toContain("LC_ALL=C tr -d '\\001-\\010\\013\\014\\016-\\037'");
 		expect(wrapper).toContain('"$WATCHER_BIN" "$root" "$launch_ms" "$SIGNET_WORKSPACE"');
-		expect(wrapper).toContain('trigger_session_end "$root"');
+		expect(wrapper).toContain('trigger_session_end "$SIGNET_TRAP_ROOT" "$SIGNET_TRAP_EXIT_CODE"');
 		expect(wrapper).toContain(`printf '%s' "$payload" | signet hook session-end -H codex`);
 		expect(wrapper).toContain(`payload="$(printf '{"cwd":"%s","reason":"%s"}'`);
+		expect(wrapper).toContain(`typeset -g SIGNET_TRAP_ROOT="$root"`);
+		expect(wrapper).toContain(`typeset -g SIGNET_TRAP_WATCHER_PID="$watcher_pid"`);
+		expect(wrapper).toContain(`typeset -g SIGNET_TRAP_EXIT_CODE="terminated"`);
 		expect(wrapper).toContain("trap 'exit 130' INT TERM");
 		expect(watcher).toContain("SIGNET-CODEX-FALLBACK");
 		expect(watcher).toContain('const signetWorkspace = process.argv[4] || path.join(os.homedir(), ".agents");');

--- a/packages/connector-codex/src/config-toml.test.ts
+++ b/packages/connector-codex/src/config-toml.test.ts
@@ -277,11 +277,13 @@ describe("CodexConnector.install — wrapper fallback", () => {
 		expect(wrapper).toContain("SIGNET-CODEX-FALLBACK");
 		expect(wrapper).toContain('readonly SIGNET_LOG_DIR="$SIGNET_WORKSPACE/.daemon/logs"');
 		expect(wrapper).not.toContain("python3 - <<'PY'");
+		expect(wrapper).toContain("LC_ALL=C tr -d '\\001-\\010\\013\\014\\016-\\037'");
 		expect(wrapper).toContain('"$WATCHER_BIN" "$root" "$launch_ms" "$SIGNET_WORKSPACE"');
 		expect(watcher).toContain("SIGNET-CODEX-FALLBACK");
 		expect(watcher).toContain('const signetWorkspace = process.argv[4] || path.join(os.homedir(), ".agents");');
 		expect(watcher).toContain('const logDir = path.join(signetWorkspace, ".daemon", "logs");');
 		expect(watcher).toContain("timeout: 8000");
+		expect(watcher).not.toContain("{ prompt }");
 	});
 
 	test("does not replace a non-Signet codex wrapper", async () => {

--- a/packages/connector-codex/src/config-toml.test.ts
+++ b/packages/connector-codex/src/config-toml.test.ts
@@ -30,6 +30,7 @@ let hooksPath: string;
 let localBinDir: string;
 let wrapperPath: string;
 let watcherPath: string;
+const originalPath = process.env.PATH;
 
 beforeEach(() => {
 	tempHome = join(tmpdir(), `signet-codex-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -291,6 +292,23 @@ describe("CodexConnector.install — wrapper fallback", () => {
 		expect(readFileSync(wrapperPath, "utf-8")).toContain("user-wrapper");
 		expect(result.warnings).toContain(`Skipped installing Codex wrapper at ${wrapperPath} — existing file is not Signet-managed`);
 		expect(readFileSync(watcherPath, "utf-8")).toContain("SIGNET-CODEX-FALLBACK");
+	});
+
+	test("skips wrapper install when no real codex binary is found outside local bin", async () => {
+		process.env.PATH = localBinDir;
+
+		try {
+			const result = await connector().install(tempHome);
+
+			expect(existsSync(wrapperPath)).toBe(false);
+			expect(result.filesWritten).not.toContain(wrapperPath);
+			expect(result.warnings).toContain(
+				"Skipped installing Codex wrapper — no real codex binary found in PATH outside ~/.local/bin; run `signet connect codex` again after installing Codex",
+			);
+			expect(readFileSync(watcherPath, "utf-8")).toContain("SIGNET-CODEX-FALLBACK");
+		} finally {
+			process.env.PATH = originalPath;
+		}
 	});
 
 	test("uninstall removes Signet-managed wrapper files", async () => {

--- a/packages/connector-codex/src/config-toml.test.ts
+++ b/packages/connector-codex/src/config-toml.test.ts
@@ -279,6 +279,8 @@ describe("CodexConnector.install — wrapper fallback", () => {
 		expect(wrapper).not.toContain("python3 - <<'PY'");
 		expect(wrapper).toContain("LC_ALL=C tr -d '\\001-\\010\\013\\014\\016-\\037'");
 		expect(wrapper).toContain('"$WATCHER_BIN" "$root" "$launch_ms" "$SIGNET_WORKSPACE"');
+		expect(wrapper).toContain('trigger_session_end "$root"');
+		expect(wrapper).toContain("trap 'exit 130' INT TERM");
 		expect(watcher).toContain("SIGNET-CODEX-FALLBACK");
 		expect(watcher).toContain('const signetWorkspace = process.argv[4] || path.join(os.homedir(), ".agents");');
 		expect(watcher).toContain('const logDir = path.join(signetWorkspace, ".daemon", "logs");');

--- a/packages/connector-codex/src/config-toml.test.ts
+++ b/packages/connector-codex/src/config-toml.test.ts
@@ -23,11 +23,13 @@ class TempConnector extends CodexConnector {
 let tempHome: string;
 let codexDir: string;
 let configPath: string;
+let hooksPath: string;
 
 beforeEach(() => {
 	tempHome = join(tmpdir(), `signet-codex-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	codexDir = join(tempHome, ".codex");
 	configPath = join(codexDir, "config.toml");
+	hooksPath = join(codexDir, "hooks.json");
 	mkdirSync(codexDir, { recursive: true });
 });
 
@@ -136,6 +138,120 @@ describe("CodexConnector.install — config.toml MCP registration", () => {
 
 		const content = readFileSync(configPath, "utf-8");
 		expect(content.match(/\[mcp_servers\.signet\]/g)?.length).toBe(1);
+	});
+});
+
+describe("CodexConnector.install — hooks.json registration", () => {
+	test("writes Codex 0.118+ hook schema with command hooks", async () => {
+		await connector().install(tempHome);
+
+		const hooks = JSON.parse(readFileSync(hooksPath, "utf-8")) as Record<string, unknown>;
+		expect(hooks._signet).toBe(true);
+		expect(hooks.SessionStart).toBeArray();
+		expect(hooks.UserPromptSubmit).toBeArray();
+		expect(hooks.Stop).toBeArray();
+
+		const sessionStartEntry = (hooks.SessionStart as Array<Record<string, unknown>>)[0];
+		const sessionStartHook = (sessionStartEntry.hooks as Array<Record<string, unknown>>)[0];
+		expect(sessionStartHook.type).toBe("command");
+		expect(sessionStartHook.command).toBe("signet hook session-start -H codex");
+		expect(sessionStartHook.timeout).toBe(10);
+	});
+
+	test("merges Signet hooks into existing modern hooks.json without replacing user hooks", async () => {
+		writeFileSync(
+			hooksPath,
+			JSON.stringify(
+				{
+					SessionStart: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command: "echo existing-hook",
+									timeout: 3,
+								},
+							],
+						},
+					],
+				},
+				null,
+				2,
+			),
+		);
+
+		const result = await connector().install(tempHome);
+		const hooks = JSON.parse(readFileSync(hooksPath, "utf-8")) as Record<string, unknown>;
+		const sessionStart = hooks.SessionStart as Array<Record<string, unknown>>;
+
+		expect(result.warnings).toContain("Merged Signet hooks into existing hooks.json — existing hooks preserved");
+		expect(sessionStart).toHaveLength(2);
+		expect(((sessionStart[0]?.hooks as Array<Record<string, unknown>>)[0]?.command)).toBe("echo existing-hook");
+		expect(((sessionStart[1]?.hooks as Array<Record<string, unknown>>)[0]?.command)).toBe(
+			"signet hook session-start -H codex",
+		);
+	});
+
+	test("uninstall removes legacy lowercase and modern uppercase Signet hook blocks", async () => {
+		writeFileSync(
+			hooksPath,
+			JSON.stringify(
+				{
+					_signet: true,
+					sessionStart: [
+						{
+							handlers: [
+								{
+									command: ["signet", "hook", "session-start", "-H", "codex"],
+									timeout: 10,
+								},
+							],
+						},
+					],
+					SessionStart: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command: "signet hook session-start -H codex",
+									timeout: 10,
+								},
+							],
+						},
+					],
+					Stop: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command: "echo keep-me",
+									timeout: 3,
+								},
+							],
+						},
+					],
+				},
+				null,
+				2,
+			),
+		);
+
+		await connector().uninstall();
+
+		const hooks = JSON.parse(readFileSync(hooksPath, "utf-8")) as Record<string, unknown>;
+		expect(hooks.sessionStart).toBeUndefined();
+		expect(hooks.SessionStart).toBeUndefined();
+		expect(hooks.Stop).toEqual([
+			{
+				hooks: [
+					{
+						type: "command",
+						command: "echo keep-me",
+						timeout: 3,
+					},
+				],
+			},
+		]);
 	});
 });
 

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -8,24 +8,30 @@ import { expandHome } from "@signet/core";
 // Signet command resolution
 // ---------------------------------------------------------------------------
 
-/** Resolve signet command for hook invocation. Returns shell-ready string form for hooks.json.
- *  Windows: navigates from argv[1] (e.g. <pkg>/bin/signet.js) up two levels to find
- *  the bin directory. Falls back to bare "signet" if the layout doesn't match (shims, junctions). */
-function resolveSignetCommand(): string {
-	if (process.platform !== "win32") return "signet";
+function resolvePackagedBin(relativePaths: string[]): string | null {
 	const entry = process.argv[1] || "";
-	const signetJs = join(entry, "..", "..", "bin", "signet.js");
-	if (existsSync(signetJs)) return `"${process.execPath}" "${signetJs}"`;
+	if (!entry) return null;
+	for (const relativePath of relativePaths) {
+		const candidate = join(entry, "..", "..", relativePath);
+		if (existsSync(candidate)) return candidate;
+	}
+	return null;
+}
+
+/** Resolve signet command for hook invocation. Returns shell-ready string form for hooks.json.
+ *  Prefer the installed package's absolute bin path so Codex hooks do not depend on PATH.
+ *  Falls back to bare "signet" only when the packaged layout is unavailable. */
+function resolveSignetCommand(): string {
+	const signetJs = resolvePackagedBin(["bin/signet.js"]);
+	if (signetJs) return `"${process.execPath}" "${signetJs}"`;
 	return "signet";
 }
 
 /** Resolve signet-mcp as { command, args } for Codex config.toml.
  *  Codex expects `command` as a string and `args` as a separate array. */
 function resolveSignetMcp(): { command: string; args: string[] } {
-	if (process.platform !== "win32") return { command: "signet-mcp", args: [] };
-	const entry = process.argv[1] || "";
-	const mcpJs = join(entry, "..", "..", "bin", "mcp-stdio.js");
-	if (existsSync(mcpJs)) return { command: process.execPath, args: [mcpJs] };
+	const mcpJs = resolvePackagedBin(["dist/mcp-stdio.js", "bin/mcp-stdio.js"]);
+	if (mcpJs) return { command: process.execPath, args: [mcpJs] };
 	return { command: "signet-mcp", args: [] };
 }
 

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -144,7 +144,7 @@ function extractPrompt(record) {
 }
 
 function emitPromptHook(prompt) {
-  appendDaemonLog("Codex native prompt hook unavailable — using wrapper fallback", { prompt });
+  appendDaemonLog("Codex native prompt hook unavailable — using wrapper fallback");
   spawnSync("signet", ["hook", "user-prompt-submit", "-H", "codex", "--project", project], {
     input: JSON.stringify({ cwd: project, prompt, userMessage: prompt }),
     stdio: ["pipe", "ignore", "ignore"],
@@ -213,6 +213,7 @@ readonly SIGNET_LOG_DIR="$SIGNET_WORKSPACE/.daemon/logs"
 
 json_escape() {
   local value="$1"
+  value="$(printf '%s' "$value" | LC_ALL=C tr -d '\\001-\\010\\013\\014\\016-\\037')"
   value="\${value//\\/\\\\}"
   value="\${value//\"/\\\"}"
   value="\${value//$'\\n'/\\n}"

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { BaseConnector, type InstallResult, type UninstallResult, atomicWriteJson } from "@signet/connector-base";
@@ -13,6 +13,16 @@ function resolvePackagedBin(relativePaths: string[]): string | null {
 	if (!entry) return null;
 	for (const relativePath of relativePaths) {
 		const candidate = join(entry, "..", "..", relativePath);
+		if (existsSync(candidate)) return candidate;
+	}
+	return null;
+}
+
+function findPathExecutable(name: string, excludeDirs: string[] = []): string | null {
+	const pathValue = process.env.PATH || "";
+	for (const dir of pathValue.split(":")) {
+		if (!dir || excludeDirs.includes(dir)) continue;
+		const candidate = join(dir, name);
 		if (existsSync(candidate)) return candidate;
 	}
 	return null;
@@ -39,6 +49,318 @@ function resolveSignetMcp(): { command: string; args: string[] } {
 	const mcpJs = resolvePackagedBin(["dist/mcp-stdio.js", "bin/mcp-stdio.js"]);
 	if (mcpJs) return { command: process.execPath, args: [mcpJs] };
 	return { command: "signet-mcp", args: [] };
+}
+
+const WRAPPER_MARKER = "SIGNET-CODEX-FALLBACK";
+const WRAPPER_LOG_SOURCE = "codex-wrapper-fallback";
+
+function buildWatcherScript(): string {
+	return `#!/usr/bin/env node
+// ${WRAPPER_MARKER}
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const project = process.argv[2];
+const launchMs = Number(process.argv[3] || Date.now());
+if (!project) process.exit(1);
+
+const sessionsRoot = path.join(os.homedir(), ".codex", "sessions");
+const logDir = path.join(os.homedir(), ".agents", ".daemon", "logs");
+
+let watchedFile = null;
+let lineCount = 0;
+
+function walk(dir, results = []) {
+  if (!fs.existsSync(dir)) return results;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, results);
+    else if (entry.isFile() && entry.name.endsWith(".jsonl")) results.push(full);
+  }
+  return results;
+}
+
+function latestSessionFile() {
+  const files = walk(sessionsRoot);
+  let best = null;
+  let bestMtime = -1;
+  for (const file of files) {
+    const stat = fs.statSync(file);
+    if (stat.mtimeMs + 1000 < launchMs) continue;
+    try {
+      const firstLine = fs.readFileSync(file, "utf8").split("\\n", 1)[0];
+      const record = JSON.parse(firstLine);
+      const startedAt = Date.parse(record?.payload?.timestamp || "");
+      if (!Number.isFinite(startedAt) || startedAt + 1000 < launchMs) continue;
+    } catch {
+      continue;
+    }
+    if (stat.mtimeMs > bestMtime) {
+      best = file;
+      bestMtime = stat.mtimeMs;
+    }
+  }
+  return best;
+}
+
+function appendDaemonLog(message, extra = {}) {
+  fs.mkdirSync(logDir, { recursive: true });
+  const stamp = new Date().toISOString();
+  const file = path.join(logDir, \`signet-\${stamp.slice(0, 10)}.log\`);
+  const line = {
+    timestamp: stamp,
+    level: "info",
+    category: "hooks",
+    message,
+    data: {
+      harness: "codex",
+      project,
+      source: "${WRAPPER_LOG_SOURCE}",
+      nativeHooks: false,
+      ...extra,
+    },
+  };
+  fs.appendFileSync(file, \`\${JSON.stringify(line)}\\n\`);
+}
+
+function extractPrompt(record) {
+  if (record?.type !== "response_item") return null;
+  const payload = record.payload;
+  if (payload?.type !== "message" || payload?.role !== "user") return null;
+  const texts = [];
+  for (const item of payload.content || []) {
+    if (item?.type === "input_text" && typeof item.text === "string") texts.push(item.text);
+  }
+  if (texts.length === 0) return null;
+  const text = texts.join("\\n").trim();
+  if (!text) return null;
+  if (text.includes("<INSTRUCTIONS>")) return null;
+  if (text.startsWith("<environment_context>")) return null;
+  return text;
+}
+
+function emitPromptHook(prompt) {
+  appendDaemonLog("Codex native prompt hook unavailable — using wrapper fallback", { prompt });
+  spawnSync("signet", ["hook", "user-prompt-submit", "-H", "codex", "--project", project], {
+    input: JSON.stringify({ cwd: project, prompt, userMessage: prompt }),
+    stdio: ["pipe", "ignore", "ignore"],
+  });
+}
+
+function poll() {
+  if (!watchedFile) {
+    watchedFile = latestSessionFile();
+    if (!watchedFile) return;
+  }
+
+  let content;
+  try {
+    content = fs.readFileSync(watchedFile, "utf8");
+  } catch {
+    return;
+  }
+
+  const lines = content.split("\\n").filter(Boolean);
+  if (lines.length <= lineCount) return;
+  for (const line of lines.slice(lineCount)) {
+    try {
+      const record = JSON.parse(line);
+      const prompt = extractPrompt(record);
+      if (prompt) emitPromptHook(prompt);
+    } catch {
+      // Ignore malformed lines while the file is still being written.
+    }
+  }
+  lineCount = lines.length;
+}
+
+setInterval(poll, 250);
+
+process.on("SIGTERM", () => {
+  poll();
+  process.exit(0);
+});
+
+process.on("SIGINT", () => {
+  poll();
+  process.exit(0);
+});
+`;
+}
+
+function buildCodexWrapperScript(realCodexPath: string, watcherPath: string): string {
+	return `#!/bin/zsh
+
+set -euo pipefail
+
+readonly REAL_CODEX=${tomlQuote(realCodexPath).replace(/^'|'$/g, '"')}
+readonly WATCHER_BIN=${tomlQuote(watcherPath).replace(/^'|'$/g, '"')}
+readonly SIGNET_WORKSPACE="\${SIGNET_WORKSPACE:-$HOME/.agents}"
+readonly MARKER_START="<!-- ${WRAPPER_MARKER}:START -->"
+readonly MARKER_END="<!-- ${WRAPPER_MARKER}:END -->"
+readonly SIGNET_LOG_DIR="$HOME/.agents/.daemon/logs"
+
+daemon_log_path() {
+  printf '%s/signet-%s.log\\n' "$SIGNET_LOG_DIR" "$(date +%F)"
+}
+
+append_daemon_log() {
+  local message="$1"
+  local project="$2"
+  local log_path payload
+
+  mkdir -p "$SIGNET_LOG_DIR"
+  log_path="$(daemon_log_path)"
+  payload="$(printf '{"timestamp":"%s","level":"info","category":"hooks","message":"%s","data":{"harness":"codex","project":"%s","source":"${WRAPPER_LOG_SOURCE}","nativeHooks":false}}' \\
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \\
+    "$message" \\
+    "$project")"
+  printf '%s\\n' "$payload" >>"$log_path"
+}
+
+trigger_session_start() {
+  local project="$1"
+
+  append_daemon_log "Codex native hooks unavailable — using wrapper fallback" "$project"
+  signet hook session-start -H codex --project "$project" >/dev/null 2>/dev/null || true
+}
+
+trigger_session_end() {
+  local project="$1"
+
+  append_daemon_log "Codex native stop hook unavailable — using wrapper fallback" "$project"
+  signet hook session-end -H codex >/dev/null 2>/dev/null || true
+}
+
+workspace_root() {
+  local root
+  if root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    printf '%s\\n' "$root"
+  else
+    pwd
+  fi
+}
+
+compose_block() {
+  local source content
+
+  printf '%s\\n' "$MARKER_START"
+  printf '%s\\n\\n' "# Signet Codex Fallback"
+  printf '%s\\n\\n' "This block is generated by the local Signet Codex wrapper because Codex native hooks are unreliable on this machine."
+  printf '%s\\n\\n' "Treat the following content as your persistent identity baseline for this session."
+
+  for source in AGENTS.md SOUL.md IDENTITY.md USER.md MEMORY.md; do
+    if [[ ! -f "$SIGNET_WORKSPACE/$source" ]]; then
+      continue
+    fi
+    content="$(<"$SIGNET_WORKSPACE/$source")"
+    content="\${content%"\${content##*[!$'\\n']}"}"
+    if [[ -z "$content" ]]; then
+      continue
+    fi
+    printf '%s\\n\\n' "## $source"
+    printf '%s\\n\\n' "$content"
+  done
+
+  printf '%s\\n' "$MARKER_END"
+}
+
+ensure_git_ignored() {
+  local root="$1"
+  local exclude
+
+  if [[ ! -d "$root/.git" ]]; then
+    return 0
+  fi
+
+  if git -C "$root" ls-files --error-unmatch AGENTS.md >/dev/null 2>&1; then
+    return 0
+  fi
+
+  exclude="$root/.git/info/exclude"
+  mkdir -p "\${exclude:h}"
+  touch "$exclude"
+  if ! grep -Fxq "AGENTS.md" "$exclude"; then
+    printf '\\n# Signet Codex fallback\\nAGENTS.md\\n' >>"$exclude"
+  fi
+}
+
+sync_agents_file() {
+  local root="$1"
+  local target="$root/AGENTS.md"
+  local block existing
+
+  block="$(compose_block)"
+
+  if [[ ! -f "$target" ]]; then
+    printf '%s\\n' "$block" >"$target"
+    ensure_git_ignored "$root"
+    return 0
+  fi
+
+  existing="$(<"$target")"
+
+  if [[ "$existing" == *"$MARKER_START"* && "$existing" == *"$MARKER_END"* ]]; then
+    existing="\${existing%%$MARKER_START*}"
+    existing="\${existing%"\${existing##*[!$'\\n']}"}"
+    if [[ -n "$existing" ]]; then
+      printf '%s\\n\\n%s\\n' "$existing" "$block" >"$target"
+    else
+      printf '%s\\n' "$block" >"$target"
+    fi
+    ensure_git_ignored "$root"
+    return 0
+  fi
+
+  if git -C "$root" rev-parse --show-toplevel >/dev/null 2>&1; then
+    if git -C "$root" ls-files --error-unmatch AGENTS.md >/dev/null 2>&1; then
+      return 0
+    fi
+  fi
+}
+
+main() {
+  local root launch_ms watcher_pid child_pid exit_code
+  root="$(workspace_root)"
+  launch_ms="$(python3 - <<'PY'
+import time
+print(int(time.time() * 1000))
+PY
+)"
+
+  if [[ -d "$SIGNET_WORKSPACE" ]]; then
+    sync_agents_file "$root"
+  fi
+
+  trigger_session_start "$root"
+  if [[ -x "$WATCHER_BIN" ]]; then
+    "$WATCHER_BIN" "$root" "$launch_ms" >/dev/null 2>/dev/null &
+    watcher_pid=$!
+  else
+    watcher_pid=""
+  fi
+
+  "$REAL_CODEX" "$@" &
+  child_pid=$!
+  trap 'kill -TERM "$child_pid" >/dev/null 2>&1 || true' INT TERM
+  wait "$child_pid"
+  exit_code=$?
+
+  if [[ -n "\${watcher_pid:-}" ]]; then
+    sleep 1
+    kill -TERM "$watcher_pid" >/dev/null 2>&1 || true
+    wait "$watcher_pid" >/dev/null 2>&1 || true
+  fi
+
+  trigger_session_end "$root"
+  exit "$exit_code"
+}
+
+main "$@"
+`;
 }
 
 // ---------------------------------------------------------------------------
@@ -259,6 +581,56 @@ export class CodexConnector extends BaseConnector {
 		return join(this.getCodexHome(), "config.toml");
 	}
 
+	protected getLocalBinDir(): string {
+		return join(homedir(), ".local", "bin");
+	}
+
+	protected getCodexWrapperPath(): string {
+		return join(this.getLocalBinDir(), "codex");
+	}
+
+	protected getCodexWatcherPath(): string {
+		return join(this.getLocalBinDir(), "codex-signet-watch.js");
+	}
+
+	private isManagedWrapper(path: string): boolean {
+		if (!existsSync(path)) return false;
+		return readFileSync(path, "utf-8").includes(WRAPPER_MARKER);
+	}
+
+	private installWrapperFiles(filesWritten: string[], warnings: string[]): void {
+		const localBinDir = this.getLocalBinDir();
+		const wrapperPath = this.getCodexWrapperPath();
+		const watcherPath = this.getCodexWatcherPath();
+		const realCodexPath = findPathExecutable("codex", [localBinDir]) || "codex";
+
+		mkdirSync(localBinDir, { recursive: true });
+
+		if (existsSync(wrapperPath) && !this.isManagedWrapper(wrapperPath)) {
+			warnings.push(`Skipped installing Codex wrapper at ${wrapperPath} — existing file is not Signet-managed`);
+		} else {
+			writeFileSync(wrapperPath, buildCodexWrapperScript(realCodexPath, watcherPath), "utf-8");
+			chmodSync(wrapperPath, 0o755);
+			filesWritten.push(wrapperPath);
+		}
+
+		if (existsSync(watcherPath) && !this.isManagedWrapper(watcherPath)) {
+			warnings.push(`Skipped installing Codex watcher at ${watcherPath} — existing file is not Signet-managed`);
+		} else {
+			writeFileSync(watcherPath, buildWatcherScript(), "utf-8");
+			chmodSync(watcherPath, 0o755);
+			filesWritten.push(watcherPath);
+		}
+	}
+
+	private uninstallWrapperFiles(filesRemoved: string[]): void {
+		for (const path of [this.getCodexWrapperPath(), this.getCodexWatcherPath()]) {
+			if (!existsSync(path) || !this.isManagedWrapper(path)) continue;
+			rmSync(path, { force: true });
+			filesRemoved.push(path);
+		}
+	}
+
 	async install(basePath: string): Promise<InstallResult> {
 		const filesWritten: string[] = [];
 		const configsPatched: string[] = [];
@@ -307,9 +679,12 @@ export class CodexConnector extends BaseConnector {
 			configsPatched.push(this.getConfigPath());
 		}
 
+		// 4. Install wrapper fallback for Codex builds that skip native hooks.
+		this.installWrapperFiles(filesWritten, warnings);
+
 		return {
 			success: true,
-			message: "Codex integration installed — native hooks + MCP server",
+			message: "Codex integration installed — native hooks + MCP server + wrapper fallback",
 			filesWritten,
 			configsPatched,
 			warnings,
@@ -355,6 +730,9 @@ export class CodexConnector extends BaseConnector {
 		if (unpatchConfigToml(this.getConfigPath())) {
 			configsPatched.push(this.getConfigPath());
 		}
+
+		// 4. Remove Signet-managed fallback wrapper files.
+		this.uninstallWrapperFiles(filesRemoved);
 
 		return { filesRemoved, configsPatched };
 	}

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -622,12 +622,16 @@ export class CodexConnector extends BaseConnector {
 		const localBinDir = this.getLocalBinDir();
 		const wrapperPath = this.getCodexWrapperPath();
 		const watcherPath = this.getCodexWatcherPath();
-		const realCodexPath = findPathExecutable("codex", [localBinDir]) || "codex";
+		const realCodexPath = findPathExecutable("codex", [localBinDir]);
 
 		mkdirSync(localBinDir, { recursive: true });
 
 		if (existsSync(wrapperPath) && !this.isManagedWrapper(wrapperPath)) {
 			warnings.push(`Skipped installing Codex wrapper at ${wrapperPath} — existing file is not Signet-managed`);
+		} else if (!realCodexPath) {
+			warnings.push(
+				"Skipped installing Codex wrapper — no real codex binary found in PATH outside ~/.local/bin; run `signet connect codex` again after installing Codex",
+			);
 		} else {
 			writeFileSync(wrapperPath, buildCodexWrapperScript(realCodexPath, watcherPath), "utf-8");
 			chmodSync(wrapperPath, 0o755);

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -252,9 +252,14 @@ trigger_session_start() {
 
 trigger_session_end() {
   local project="$1"
+  local reason="$2"
+  local payload
 
   append_daemon_log "Codex native stop hook unavailable — using wrapper fallback" "$project"
-  signet hook session-end -H codex >/dev/null 2>/dev/null || true
+  payload="$(printf '{"cwd":"%s","reason":"%s"}' \
+    "$(json_escape "$project")" \
+    "$(json_escape "$reason")")"
+  printf '%s' "$payload" | signet hook session-end -H codex >/dev/null 2>/dev/null || true
 }
 
 workspace_root() {
@@ -370,7 +375,7 @@ main() {
       kill -TERM "$watcher_pid" >/dev/null 2>&1 || true
       wait "$watcher_pid" >/dev/null 2>&1 || true
     fi
-    trigger_session_end "$root"
+    trigger_session_end "$root" "\${exit_code:-terminated}"
   ' EXIT
   trap 'exit 130' INT TERM
 

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -369,19 +369,24 @@ main() {
     watcher_pid=""
   fi
 
+  typeset -g SIGNET_TRAP_ROOT="$root"
+  typeset -g SIGNET_TRAP_WATCHER_PID="$watcher_pid"
+  typeset -g SIGNET_TRAP_EXIT_CODE="terminated"
+
   trap '
     set +e
-    trigger_session_end "$root" "\${exit_code:-terminated}"
-    if [[ -n "\${watcher_pid:-}" ]]; then
+    trigger_session_end "$SIGNET_TRAP_ROOT" "$SIGNET_TRAP_EXIT_CODE"
+    if [[ -n "\${SIGNET_TRAP_WATCHER_PID:-}" ]]; then
       sleep 1
-      kill -TERM "$watcher_pid" >/dev/null 2>&1 || true
-      wait "$watcher_pid" >/dev/null 2>&1 || true
+      kill -TERM "$SIGNET_TRAP_WATCHER_PID" >/dev/null 2>&1 || true
+      wait "$SIGNET_TRAP_WATCHER_PID" >/dev/null 2>&1 || true
     fi
   ' EXIT
   trap 'exit 130' INT TERM
 
   "$REAL_CODEX" "$@"
   exit_code=$?
+  SIGNET_TRAP_EXIT_CODE="$exit_code"
 
   exit "$exit_code"
 }

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -8,15 +8,15 @@ import { expandHome } from "@signet/core";
 // Signet command resolution
 // ---------------------------------------------------------------------------
 
-/** Resolve signet command for hook invocation. Returns array form for hooks.json command field.
+/** Resolve signet command for hook invocation. Returns shell-ready string form for hooks.json.
  *  Windows: navigates from argv[1] (e.g. <pkg>/bin/signet.js) up two levels to find
  *  the bin directory. Falls back to bare "signet" if the layout doesn't match (shims, junctions). */
-function resolveSignetArgs(): string[] {
-	if (process.platform !== "win32") return ["signet"];
+function resolveSignetCommand(): string {
+	if (process.platform !== "win32") return "signet";
 	const entry = process.argv[1] || "";
 	const signetJs = join(entry, "..", "..", "bin", "signet.js");
-	if (existsSync(signetJs)) return [process.execPath, signetJs];
-	return ["signet"];
+	if (existsSync(signetJs)) return `"${process.execPath}" "${signetJs}"`;
+	return "signet";
 }
 
 /** Resolve signet-mcp as { command, args } for Codex config.toml.
@@ -35,40 +35,43 @@ function resolveSignetMcp(): { command: string; args: string[] } {
 
 interface HooksJson {
 	_signet?: boolean;
-	sessionStart?: unknown[];
-	userPromptSubmit?: unknown[];
-	stop?: unknown[];
+	SessionStart?: unknown[];
+	UserPromptSubmit?: unknown[];
+	Stop?: unknown[];
 	[key: string]: unknown;
 }
 
-function buildHooksJson(signetArgs: string[]): HooksJson {
+function buildHooksJson(signetCommand: string): HooksJson {
 	return {
 		_signet: true,
-		sessionStart: [
+		SessionStart: [
 			{
-				handlers: [
+				hooks: [
 					{
-						command: [...signetArgs, "hook", "session-start", "-H", "codex"],
+						type: "command",
+						command: `${signetCommand} hook session-start -H codex`,
 						timeout: 10,
 					},
 				],
 			},
 		],
-		userPromptSubmit: [
+		UserPromptSubmit: [
 			{
-				handlers: [
+				hooks: [
 					{
-						command: [...signetArgs, "hook", "user-prompt-submit", "-H", "codex"],
+						type: "command",
+						command: `${signetCommand} hook user-prompt-submit -H codex`,
 						timeout: 5,
 					},
 				],
 			},
 		],
-		stop: [
+		Stop: [
 			{
-				handlers: [
+				hooks: [
 					{
-						command: [...signetArgs, "hook", "session-end", "-H", "codex"],
+						type: "command",
+						command: `${signetCommand} hook session-end -H codex`,
 						timeout: 30,
 					},
 				],
@@ -102,21 +105,31 @@ const SIGNET_HOOK_CMDS = ["hook session-start", "hook user-prompt-submit", "hook
 
 function isSignetHandler(entry: unknown): boolean {
 	if (typeof entry !== "object" || entry === null) return false;
+	const hooks = (entry as Record<string, unknown>).hooks;
+	if (Array.isArray(hooks)) {
+		for (const hook of hooks) {
+			if (typeof hook !== "object" || hook === null) continue;
+			const cmd = (hook as Record<string, unknown>).command;
+			if (typeof cmd === "string" && SIGNET_HOOK_CMDS.some((s) => cmd.includes(s))) return true;
+		}
+	}
 	const handlers = (entry as Record<string, unknown>).handlers;
-	if (!Array.isArray(handlers)) return false;
-	for (const handler of handlers) {
-		if (typeof handler !== "object" || handler === null) continue;
-		const cmd = (handler as Record<string, unknown>).command;
-		if (!Array.isArray(cmd)) continue;
-		const joined = cmd.join(" ");
-		if (SIGNET_HOOK_CMDS.some((s) => joined.includes(s))) return true;
+	if (Array.isArray(handlers)) {
+		for (const handler of handlers) {
+			if (typeof handler !== "object" || handler === null) continue;
+			const cmd = (handler as Record<string, unknown>).command;
+			if (Array.isArray(cmd)) {
+				const joined = cmd.join(" ");
+				if (SIGNET_HOOK_CMDS.some((s) => joined.includes(s))) return true;
+			}
+		}
 	}
 	return false;
 }
 
 function removeSignetHooks(hooks: HooksJson): HooksJson {
 	const cleaned = { ...hooks };
-	for (const key of ["sessionStart", "userPromptSubmit", "stop"] as const) {
+	for (const key of ["SessionStart", "UserPromptSubmit", "Stop", "sessionStart", "userPromptSubmit", "stop"] as const) {
 		if (!Array.isArray(cleaned[key])) continue;
 		const filtered = (cleaned[key] as unknown[]).filter((e) => !isSignetHandler(e));
 		if (filtered.length === 0) {
@@ -126,7 +139,7 @@ function removeSignetHooks(hooks: HooksJson): HooksJson {
 		}
 	}
 	// Only remove marker if no Signet entries remain
-	const hasSignet = ["sessionStart", "userPromptSubmit", "stop"].some(
+	const hasSignet = ["SessionStart", "UserPromptSubmit", "Stop", "sessionStart", "userPromptSubmit", "stop"].some(
 		(k) => Array.isArray(cleaned[k]) && (cleaned[k] as unknown[]).some(isSignetHandler),
 	);
 	if (!hasSignet) delete cleaned._signet;
@@ -247,7 +260,7 @@ export class CodexConnector extends BaseConnector {
 		const codexHome = this.getCodexHome();
 		mkdirSync(codexHome, { recursive: true });
 
-		const signetArgs = resolveSignetArgs();
+		const signetCommand = resolveSignetCommand();
 
 		// 1. Install hooks.json (native Codex hook system)
 		const hooksPath = this.getHooksJsonPath();
@@ -255,10 +268,10 @@ export class CodexConnector extends BaseConnector {
 
 		if (existing && !isSignetOwned(existing)) {
 			// User has their own hooks.json — merge Signet hooks in
-			const signetHooks = buildHooksJson(signetArgs);
+			const signetHooks = buildHooksJson(signetCommand);
 			const merged: HooksJson = { ...existing };
 			merged._signet = true;
-			for (const key of ["sessionStart", "userPromptSubmit", "stop"] as const) {
+			for (const key of ["SessionStart", "UserPromptSubmit", "Stop"] as const) {
 				const current = Array.isArray(merged[key]) ? (merged[key] as unknown[]) : [];
 				const signet = signetHooks[key] as unknown[];
 				merged[key] = [...current, ...signet];
@@ -266,7 +279,7 @@ export class CodexConnector extends BaseConnector {
 			writeHooksJson(hooksPath, merged);
 			warnings.push("Merged Signet hooks into existing hooks.json — existing hooks preserved");
 		} else {
-			writeHooksJson(hooksPath, buildHooksJson(signetArgs));
+			writeHooksJson(hooksPath, buildHooksJson(signetCommand));
 		}
 		filesWritten.push(hooksPath);
 
@@ -301,7 +314,7 @@ export class CodexConnector extends BaseConnector {
 		if (existing) {
 			// Check marker first; fall back to handler scan if marker was stripped
 			const hasMarker = isSignetOwned(existing);
-			const hasHandlers = ["sessionStart", "userPromptSubmit", "stop"].some(
+			const hasHandlers = ["SessionStart", "UserPromptSubmit", "Stop", "sessionStart", "userPromptSubmit", "stop"].some(
 				(k) =>
 					Array.isArray((existing as Record<string, unknown>)[k]) &&
 					((existing as Record<string, unknown>)[k] as unknown[]).some(isSignetHandler),
@@ -337,7 +350,7 @@ export class CodexConnector extends BaseConnector {
 	isInstalled(): boolean {
 		const hooks = readHooksJson(this.getHooksJsonPath());
 		if (!hooks) return false;
-		return ["sessionStart", "userPromptSubmit", "stop"].some(
+		return ["SessionStart", "UserPromptSubmit", "Stop", "sessionStart", "userPromptSubmit", "stop"].some(
 			(k) =>
 				Array.isArray((hooks as Record<string, unknown>)[k]) &&
 				((hooks as Record<string, unknown>)[k] as unknown[]).some(isSignetHandler),

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -32,10 +32,6 @@ function shellDoubleQuote(value: string): string {
 	return `"${value.replace(/"/g, '\\"')}"`;
 }
 
-function shellSingleQuote(value: string): string {
-	return `'${value.replace(/'/g, `'\"'\"'`)}'`;
-}
-
 /** Resolve signet command for hook invocation. hooks.json only supports a command string,
  *  so keep the longstanding non-Windows "signet" path and only use the packaged absolute
  *  entrypoint on Windows where PATH lookup is the historical failure mode. */
@@ -202,8 +198,14 @@ function buildCodexWrapperScript(realCodexPath: string, watcherPath: string): st
 
 set -euo pipefail
 
-readonly REAL_CODEX=${shellSingleQuote(realCodexPath)}
-readonly WATCHER_BIN=${shellSingleQuote(watcherPath)}
+readonly REAL_CODEX="$(cat <<'__SIGNET_REAL_CODEX__'
+${realCodexPath}
+__SIGNET_REAL_CODEX__
+)"
+readonly WATCHER_BIN="$(cat <<'__SIGNET_WATCHER_BIN__'
+${watcherPath}
+__SIGNET_WATCHER_BIN__
+)"
 readonly SIGNET_WORKSPACE="\${SIGNET_WORKSPACE:-$HOME/.agents}"
 readonly MARKER_START="<!-- ${WRAPPER_MARKER}:START -->"
 readonly MARKER_END="<!-- ${WRAPPER_MARKER}:END -->"

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -32,6 +32,10 @@ function shellDoubleQuote(value: string): string {
 	return `"${value.replace(/"/g, '\\"')}"`;
 }
 
+function shellSingleQuote(value: string): string {
+	return `'${value.replace(/'/g, `'\"'\"'`)}'`;
+}
+
 /** Resolve signet command for hook invocation. hooks.json only supports a command string,
  *  so keep the longstanding non-Windows "signet" path and only use the packaged absolute
  *  entrypoint on Windows where PATH lookup is the historical failure mode. */
@@ -65,10 +69,11 @@ const { spawnSync } = require("child_process");
 
 const project = process.argv[2];
 const launchMs = Number(process.argv[3] || Date.now());
+const signetWorkspace = process.argv[4] || path.join(os.homedir(), ".agents");
 if (!project) process.exit(1);
 
 const sessionsRoot = path.join(os.homedir(), ".codex", "sessions");
-const logDir = path.join(os.homedir(), ".agents", ".daemon", "logs");
+const logDir = path.join(signetWorkspace, ".daemon", "logs");
 
 let watchedFile = null;
 let lineCount = 0;
@@ -147,6 +152,7 @@ function emitPromptHook(prompt) {
   spawnSync("signet", ["hook", "user-prompt-submit", "-H", "codex", "--project", project], {
     input: JSON.stringify({ cwd: project, prompt, userMessage: prompt }),
     stdio: ["pipe", "ignore", "ignore"],
+    timeout: 8000,
   });
 }
 
@@ -196,12 +202,22 @@ function buildCodexWrapperScript(realCodexPath: string, watcherPath: string): st
 
 set -euo pipefail
 
-readonly REAL_CODEX=${tomlQuote(realCodexPath).replace(/^'|'$/g, '"')}
-readonly WATCHER_BIN=${tomlQuote(watcherPath).replace(/^'|'$/g, '"')}
+readonly REAL_CODEX=${shellSingleQuote(realCodexPath)}
+readonly WATCHER_BIN=${shellSingleQuote(watcherPath)}
 readonly SIGNET_WORKSPACE="\${SIGNET_WORKSPACE:-$HOME/.agents}"
 readonly MARKER_START="<!-- ${WRAPPER_MARKER}:START -->"
 readonly MARKER_END="<!-- ${WRAPPER_MARKER}:END -->"
-readonly SIGNET_LOG_DIR="$HOME/.agents/.daemon/logs"
+readonly SIGNET_LOG_DIR="$SIGNET_WORKSPACE/.daemon/logs"
+
+json_escape() {
+  local value="$1"
+  value="\${value//\\/\\\\}"
+  value="\${value//\"/\\\"}"
+  value="\${value//$'\\n'/\\n}"
+  value="\${value//$'\\r'/\\r}"
+  value="\${value//$'\\t'/\\t}"
+  printf '%s' "$value"
+}
 
 daemon_log_path() {
   printf '%s/signet-%s.log\\n' "$SIGNET_LOG_DIR" "$(date +%F)"
@@ -210,14 +226,17 @@ daemon_log_path() {
 append_daemon_log() {
   local message="$1"
   local project="$2"
-  local log_path payload
+  local log_path payload message_json project_json
+
+  message_json="$(json_escape "$message")"
+  project_json="$(json_escape "$project")"
 
   mkdir -p "$SIGNET_LOG_DIR"
   log_path="$(daemon_log_path)"
   payload="$(printf '{"timestamp":"%s","level":"info","category":"hooks","message":"%s","data":{"harness":"codex","project":"%s","source":"${WRAPPER_LOG_SOURCE}","nativeHooks":false}}' \\
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \\
-    "$message" \\
-    "$project")"
+    "$message_json" \\
+    "$project_json")"
   printf '%s\\n' "$payload" >>"$log_path"
 }
 
@@ -317,19 +336,18 @@ sync_agents_file() {
 
   if git -C "$root" rev-parse --show-toplevel >/dev/null 2>&1; then
     if git -C "$root" ls-files --error-unmatch AGENTS.md >/dev/null 2>&1; then
+      append_daemon_log "Signet fallback AGENTS sync skipped — repository already tracks AGENTS.md" "$root"
       return 0
     fi
   fi
+
+  append_daemon_log "Signet fallback AGENTS sync skipped — existing AGENTS.md is not Signet-managed" "$root"
 }
 
 main() {
   local root launch_ms watcher_pid child_pid exit_code
   root="$(workspace_root)"
-  launch_ms="$(python3 - <<'PY'
-import time
-print(int(time.time() * 1000))
-PY
-)"
+  launch_ms="$(( $(date +%s) * 1000 ))"
 
   if [[ -d "$SIGNET_WORKSPACE" ]]; then
     sync_agents_file "$root"
@@ -337,7 +355,7 @@ PY
 
   trigger_session_start "$root"
   if [[ -x "$WATCHER_BIN" ]]; then
-    "$WATCHER_BIN" "$root" "$launch_ms" >/dev/null 2>/dev/null &
+    "$WATCHER_BIN" "$root" "$launch_ms" "$SIGNET_WORKSPACE" >/dev/null 2>/dev/null &
     watcher_pid=$!
   else
     watcher_pid=""

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -348,7 +348,7 @@ sync_agents_file() {
 }
 
 main() {
-  local root launch_ms watcher_pid child_pid exit_code
+  local root launch_ms watcher_pid exit_code
   root="$(workspace_root)"
   launch_ms="$(( $(date +%s) * 1000 ))"
 
@@ -364,19 +364,19 @@ main() {
     watcher_pid=""
   fi
 
-  "$REAL_CODEX" "$@" &
-  child_pid=$!
-  trap 'kill -TERM "$child_pid" >/dev/null 2>&1 || true' INT TERM
-  wait "$child_pid"
+  trap '
+    if [[ -n "\${watcher_pid:-}" ]]; then
+      sleep 1
+      kill -TERM "$watcher_pid" >/dev/null 2>&1 || true
+      wait "$watcher_pid" >/dev/null 2>&1 || true
+    fi
+    trigger_session_end "$root"
+  ' EXIT
+  trap 'exit 130' INT TERM
+
+  "$REAL_CODEX" "$@"
   exit_code=$?
 
-  if [[ -n "\${watcher_pid:-}" ]]; then
-    sleep 1
-    kill -TERM "$watcher_pid" >/dev/null 2>&1 || true
-    wait "$watcher_pid" >/dev/null 2>&1 || true
-  fi
-
-  trigger_session_end "$root"
   exit "$exit_code"
 }
 

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -370,12 +370,13 @@ main() {
   fi
 
   trap '
+    set +e
+    trigger_session_end "$root" "\${exit_code:-terminated}"
     if [[ -n "\${watcher_pid:-}" ]]; then
       sleep 1
       kill -TERM "$watcher_pid" >/dev/null 2>&1 || true
       wait "$watcher_pid" >/dev/null 2>&1 || true
     fi
-    trigger_session_end "$root" "\${exit_code:-terminated}"
   ' EXIT
   trap 'exit 130' INT TERM
 

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -18,18 +18,24 @@ function resolvePackagedBin(relativePaths: string[]): string | null {
 	return null;
 }
 
-/** Resolve signet command for hook invocation. Returns shell-ready string form for hooks.json.
- *  Prefer the installed package's absolute bin path so Codex hooks do not depend on PATH.
- *  Falls back to bare "signet" only when the packaged layout is unavailable. */
+function shellDoubleQuote(value: string): string {
+	return `"${value.replace(/"/g, '\\"')}"`;
+}
+
+/** Resolve signet command for hook invocation. hooks.json only supports a command string,
+ *  so keep the longstanding non-Windows "signet" path and only use the packaged absolute
+ *  entrypoint on Windows where PATH lookup is the historical failure mode. */
 function resolveSignetCommand(): string {
+	if (process.platform !== "win32") return "signet";
 	const signetJs = resolvePackagedBin(["bin/signet.js"]);
-	if (signetJs) return `"${process.execPath}" "${signetJs}"`;
+	if (signetJs) return `${shellDoubleQuote(process.execPath)} ${shellDoubleQuote(signetJs)}`;
 	return "signet";
 }
 
 /** Resolve signet-mcp as { command, args } for Codex config.toml.
  *  Codex expects `command` as a string and `args` as a separate array. */
 function resolveSignetMcp(): { command: string; args: string[] } {
+	if (process.platform !== "win32") return { command: "signet-mcp", args: [] };
 	const mcpJs = resolvePackagedBin(["dist/mcp-stdio.js", "bin/mcp-stdio.js"]);
 	if (mcpJs) return { command: process.execPath, args: [mcpJs] };
 	return { command: "signet-mcp", args: [] };


### PR DESCRIPTION
## Summary
- keep the native Codex hook and MCP fixes from the earlier branch, but add a Signet-managed `~/.local/bin/codex` wrapper fallback for Codex builds that skip native hooks entirely
- install a `codex-signet-watch.js` sidecar that tails the new Codex session JSONL and replays `user-prompt-submit` through the real Signet hook path with explicit fallback logging
- preserve repo-owned `AGENTS.md` files while generating fallback workspace instructions only for unmanaged workspaces, and add regression coverage for wrapper install/uninstall safety
- update Codex harness docs to describe the native-hook path and the wrapper fallback path honestly

## Validation
- `cd packages/cli && bun test ./src/commands/hook.test.ts`
- `cd packages/connector-codex && bun test ./src/config-toml.test.ts`
- `cd packages/connector-codex && bun run typecheck`
- `cd packages/connector-codex && bun run build`

## Notes
- This supersedes #476. The previous PR fixed the Codex hook wire format and packaged entrypoint resolution, but it did not address the reproduced Codex 0.118.0 behavior where fresh processes could skip native hooks entirely.
- The wrapper fallback is explicit in the daemon logs: it emits a fallback marker, then runs the real `session-start`, `user-prompt-submit`, and `session-end` Signet hook handlers where possible.
- Prompt-submit fallback currently depends on Codex continuing to write session JSONL with the current `response_item`/`message` user-turn shape.

## PR Readiness Checklist
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally
