### PR TITLE
fix(daemon): honour maxInjectChars config in session-start hook

### DIFF
--- a/packages/daemon/src/hooks.test.ts
+++ b/packages/daemon/src/hooks.test.ts
@@ -392,4 +392,14 @@ describe("applyTokenBudget", () => {
 	it("returns empty string when mainBudget is negative", () => {
 		expect(applyTokenBudget(TEXT, -1)).toBe("");
 	});
+
+	it("never exceeds budget when budget is smaller than marker token count", async () => {
+		// Regression: marker is ~5 tokens; budgets in [1, TRUNCATED_MARKER_TOKENS) must
+		// not overflow by appending the full marker after truncation.
+		const { countTokens } = await import("./pipeline/tokenizer");
+		for (const budget of [1, 2, 3, 4]) {
+			const result = applyTokenBudget(TEXT, budget);
+			expect(countTokens(result)).toBeLessThanOrEqual(budget);
+		}
+	});
 });

--- a/packages/daemon/src/hooks.test.ts
+++ b/packages/daemon/src/hooks.test.ts
@@ -9,6 +9,7 @@ import {
 	normalizeJsonConversationTranscript,
 	normalizeSessionTranscript,
 	queryAnchorsMissingFromRecall,
+	selectWithTokenBudget,
 	writeMemoryMd,
 } from "./hooks";
 
@@ -330,5 +331,35 @@ describe("normalizeSessionTranscript", () => {
 			'{"role":"assistant","content":"Ship it by Friday."}',
 		].join("\n");
 		expect(normalizeSessionTranscript("opencode", json)).toBe("User: What's the plan?\nAssistant: Ship it by Friday.");
+	});
+});
+
+describe("selectWithTokenBudget", () => {
+	const rows = [
+		{ content: "alpha ".repeat(50) },   // ~50 tokens
+		{ content: "beta ".repeat(50) },    // ~50 tokens
+		{ content: "gamma ".repeat(200) },  // ~200 tokens
+	];
+
+	it("selects rows up to the token budget", () => {
+		const result = selectWithTokenBudget(rows, 120);
+		expect(result).toHaveLength(2);
+		expect(result[0]).toBe(rows[0]);
+		expect(result[1]).toBe(rows[1]);
+	});
+
+	it("returns all rows when budget is not exceeded", () => {
+		const result = selectWithTokenBudget(rows, 10000);
+		expect(result).toHaveLength(3);
+	});
+
+	it("returns empty array when budget is too small for any row", () => {
+		const result = selectWithTokenBudget(rows, 1);
+		expect(result).toHaveLength(0);
+	});
+
+	it("returns empty array for zero budget", () => {
+		const result = selectWithTokenBudget(rows, 0);
+		expect(result).toHaveLength(0);
 	});
 });

--- a/packages/daemon/src/hooks.test.ts
+++ b/packages/daemon/src/hooks.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import {
+	applyTokenBudget,
 	buildSignetSystemPrompt,
 	normalizeCodexTranscript,
 	normalizeJsonConversationTranscript,
@@ -366,5 +367,29 @@ describe("selectWithTokenBudget", () => {
 	it("handles negative budget the same as zero", () => {
 		const result = selectWithTokenBudget(rows, -100);
 		expect(result).toHaveLength(0);
+	});
+});
+
+describe("applyTokenBudget", () => {
+	const TEXT = "word ".repeat(500); // ~500 tokens
+
+	it("returns inject unchanged when it fits within budget", () => {
+		expect(applyTokenBudget("hello world", 1000)).toBe("hello world");
+	});
+
+	it("truncates and appends marker when inject exceeds budget", async () => {
+		const result = applyTokenBudget(TEXT, 50);
+		expect(result).toContain("[context truncated]");
+		// total tokens must not exceed budget (marker tokens pre-subtracted)
+		const { countTokens } = await import("./pipeline/tokenizer");
+		expect(countTokens(result)).toBeLessThanOrEqual(50);
+	});
+
+	it("returns empty string when mainBudget is zero (reserved sections exhausted budget)", () => {
+		expect(applyTokenBudget(TEXT, 0)).toBe("");
+	});
+
+	it("returns empty string when mainBudget is negative", () => {
+		expect(applyTokenBudget(TEXT, -1)).toBe("");
 	});
 });

--- a/packages/daemon/src/hooks.test.ts
+++ b/packages/daemon/src/hooks.test.ts
@@ -362,4 +362,9 @@ describe("selectWithTokenBudget", () => {
 		const result = selectWithTokenBudget(rows, 0);
 		expect(result).toHaveLength(0);
 	});
+
+	it("handles negative budget the same as zero", () => {
+		const result = selectWithTokenBudget(rows, -100);
+		expect(result).toHaveLength(0);
+	});
 });

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -212,7 +212,11 @@ export interface HooksConfig {
 		recencyBias?: number;
 		query?: string;
 		maxInjectTokens?: number;
-		/** @deprecated renamed to maxInjectTokens — will be ignored */
+		/**
+		 * @deprecated Renamed to `maxInjectTokens`. If set without `maxInjectTokens`,
+		 * the value is auto-migrated using `Math.round(maxInjectChars / 4)` (~4 chars/token
+		 * for ASCII; code or Unicode content may be 1–2 chars/token, so migrate explicitly.
+		 */
 		maxInjectChars?: number;
 	};
 	userPromptSubmit?: {
@@ -504,15 +508,15 @@ const TRUNCATED_MARKER_TOKENS = countTokens(TRUNCATED_MARKER);
 /**
  * Truncate `inject` to fit within `mainBudget` tokens.
  * Returns an empty string when budget is zero (reserved sections exhausted it).
- * Appends a truncation marker whose tokens are pre-subtracted from the budget.
+ * Appends a truncation marker when budget permits; omits it when the budget is
+ * too small to fit the marker itself (avoids overflow in that range).
  */
 export function applyTokenBudget(inject: string, mainBudget: number): string {
 	if (mainBudget <= 0) return "";
 	if (countTokens(inject) <= mainBudget) return inject;
-	return (
-		truncateToTokens(inject, Math.max(1, mainBudget - TRUNCATED_MARKER_TOKENS)) +
-		TRUNCATED_MARKER
-	);
+	// Budget too tight to fit content + marker — truncate without marker
+	if (mainBudget <= TRUNCATED_MARKER_TOKENS) return truncateToTokens(inject, mainBudget);
+	return truncateToTokens(inject, mainBudget - TRUNCATED_MARKER_TOKENS) + TRUNCATED_MARKER;
 }
 
 /** Build a brief "since your last session" summary for temporal awareness */

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -1474,10 +1474,16 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	});
 
 	// Apply budget to select what we actually inject (on re-ranked order)
-	if (config.maxInjectChars !== undefined) {
-		logger.warn("hooks", "hooks.sessionStart.maxInjectChars is ignored — rename to maxInjectTokens in agent.yaml");
+	if (config.maxInjectChars !== undefined && config.maxInjectTokens === undefined) {
+		logger.warn(
+			"hooks",
+			"hooks.sessionStart.maxInjectChars is deprecated — migrating to maxInjectTokens automatically. Rename it in agent.yaml to silence this warning.",
+			{ maxInjectChars: config.maxInjectChars, derivedTokens: Math.round(config.maxInjectChars / 4) },
+		);
 	}
-	const rawTokenBudget = config.maxInjectTokens ?? 20000;
+	const rawTokenBudget =
+		config.maxInjectTokens ??
+		(config.maxInjectChars ? Math.round(config.maxInjectChars / 4) : 20000);
 	if (rawTokenBudget <= 0) {
 		logger.warn("hooks", "maxInjectTokens must be positive — clamping to 1", {
 			configured: rawTokenBudget,
@@ -1762,7 +1768,9 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	}
 
 	const duration = Date.now() - start;
-	const maxTokens = config.maxInjectTokens ?? 20000;
+	const maxTokens =
+		config.maxInjectTokens ??
+		(config.maxInjectChars ? Math.round(config.maxInjectChars / 4) : 20000);
 	// Pre-reserve space for constraints + recovery so they are never truncated
 	const reservedTokens =
 		countTokens(recoverySection) + countTokens(constraintsSection);

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -1455,7 +1455,13 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	});
 
 	// Apply budget to select what we actually inject (on re-ranked order)
-	const tokenBudget = config.maxInjectTokens ?? 20000;
+	const rawTokenBudget = config.maxInjectTokens ?? 20000;
+	if (rawTokenBudget <= 0) {
+		logger.warn("hooks", "maxInjectTokens must be positive — clamping to 1", {
+			configured: rawTokenBudget,
+		});
+	}
+	const tokenBudget = Math.max(1, rawTokenBudget);
 	const memories = selectWithTokenBudget(sortedCandidates, tokenBudget);
 
 	// Get predicted context from recent session analysis (~30% of budget)

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -1438,7 +1438,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	});
 
 	// Apply budget to select what we actually inject (on re-ranked order)
-	const memories = selectWithBudget(sortedCandidates, 2000);
+	const memories = selectWithBudget(sortedCandidates, config.maxInjectChars ?? 2000);
 
 	// Get predicted context from recent session analysis (~30% of budget)
 	const existingIds = new Set(memories.map((m) => m.id));

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -88,6 +88,7 @@ import { getSessionTranscriptContent, searchTranscriptFallback, upsertSessionTra
 import { type StructuralFeatures, buildCandidateFeatures, getStructuralFeatures } from "./structural-features";
 import { searchTemporalFallback } from "./temporal-fallback";
 import { writeTranscriptAudit } from "./transcript-audit";
+import { countTokens, truncateToTokens } from "./pipeline/tokenizer";
 import { getUpdateSummary } from "./update-system";
 
 function getAgentsDir(): string {
@@ -210,7 +211,7 @@ export interface HooksConfig {
 		includeRecentContext?: boolean;
 		recencyBias?: number;
 		query?: string;
-		maxInjectChars?: number;
+		maxInjectTokens?: number;
 	};
 	userPromptSubmit?: {
 		/** Set to false to disable per-prompt memory injection entirely. Default: true. */
@@ -475,6 +476,22 @@ export function selectWithBudget<T extends { content: string }>(rows: ReadonlyAr
 		if (used + row.content.length > charBudget) break;
 		selected.push(row);
 		used += row.content.length;
+	}
+	return selected;
+}
+
+/** Truncate rows to fit a token budget using BPE token counts. */
+export function selectWithTokenBudget<T extends { content: string }>(
+	rows: ReadonlyArray<T>,
+	tokenBudget: number,
+): T[] {
+	const selected: T[] = [];
+	let used = 0;
+	for (const row of rows) {
+		const cost = countTokens(row.content);
+		if (used + cost > tokenBudget) break;
+		selected.push(row);
+		used += cost;
 	}
 	return selected;
 }
@@ -1438,7 +1455,8 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	});
 
 	// Apply budget to select what we actually inject (on re-ranked order)
-	const memories = selectWithBudget(sortedCandidates, config.maxInjectChars ?? 2000);
+	const tokenBudget = config.maxInjectTokens ?? 20000;
+	const memories = selectWithTokenBudget(sortedCandidates, tokenBudget);
 
 	// Get predicted context from recent session analysis (~30% of budget)
 	const existingIds = new Set(memories.map((m) => m.id));
@@ -1716,13 +1734,14 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	}
 
 	const duration = Date.now() - start;
-	const maxInject = config.maxInjectChars ?? 24000;
+	const maxTokens = config.maxInjectTokens ?? 20000;
 	// Pre-reserve space for constraints + recovery so they are never truncated
-	const reservedChars = recoverySection.length + constraintsSection.length;
-	const mainBudget = Math.max(0, maxInject - reservedChars);
+	const reservedTokens =
+		countTokens(recoverySection) + countTokens(constraintsSection);
+	const mainBudget = Math.max(0, maxTokens - reservedTokens);
 	let inject = injectParts.join("\n");
-	if (inject.length > mainBudget) {
-		inject = `${inject.slice(0, mainBudget)}\n[context truncated]`;
+	if (countTokens(inject) > mainBudget) {
+		inject = `${truncateToTokens(inject, mainBudget)}\n[context truncated]`;
 	}
 	if (constraintsSection) {
 		inject += constraintsSection;
@@ -1740,7 +1759,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 		traversalMemories,
 		traversalConstraints,
 		traversalTimedOut,
-		injectChars: inject.length,
+		injectTokens: countTokens(inject),
 		inject,
 		durationMs: duration,
 	});

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -212,6 +212,8 @@ export interface HooksConfig {
 		recencyBias?: number;
 		query?: string;
 		maxInjectTokens?: number;
+		/** @deprecated renamed to maxInjectTokens — will be ignored */
+		maxInjectChars?: number;
 	};
 	userPromptSubmit?: {
 		/** Set to false to disable per-prompt memory injection entirely. Default: true. */
@@ -1455,6 +1457,9 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	});
 
 	// Apply budget to select what we actually inject (on re-ranked order)
+	if (config.maxInjectChars !== undefined) {
+		logger.warn("hooks", "hooks.sessionStart.maxInjectChars is ignored — rename to maxInjectTokens in agent.yaml");
+	}
 	const rawTokenBudget = config.maxInjectTokens ?? 20000;
 	if (rawTokenBudget <= 0) {
 		logger.warn("hooks", "maxInjectTokens must be positive — clamping to 1", {
@@ -1746,8 +1751,16 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 		countTokens(recoverySection) + countTokens(constraintsSection);
 	const mainBudget = Math.max(0, maxTokens - reservedTokens);
 	let inject = injectParts.join("\n");
-	if (countTokens(inject) > mainBudget) {
-		inject = `${truncateToTokens(inject, mainBudget)}\n[context truncated]`;
+	if (mainBudget === 0) {
+		logger.warn("hooks", "Session-start reserved sections exhaust token budget — main inject cleared", {
+			maxTokens,
+			reservedTokens,
+		});
+		inject = "";
+	} else if (countTokens(inject) > mainBudget) {
+		const TRUNCATED_MARKER = "\n[context truncated]";
+		const markerTokens = countTokens(TRUNCATED_MARKER);
+		inject = truncateToTokens(inject, Math.max(1, mainBudget - markerTokens)) + TRUNCATED_MARKER;
 	}
 	if (constraintsSection) {
 		inject += constraintsSection;

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -498,6 +498,23 @@ export function selectWithTokenBudget<T extends { content: string }>(
 	return selected;
 }
 
+const TRUNCATED_MARKER = "\n[context truncated]";
+const TRUNCATED_MARKER_TOKENS = countTokens(TRUNCATED_MARKER);
+
+/**
+ * Truncate `inject` to fit within `mainBudget` tokens.
+ * Returns an empty string when budget is zero (reserved sections exhausted it).
+ * Appends a truncation marker whose tokens are pre-subtracted from the budget.
+ */
+export function applyTokenBudget(inject: string, mainBudget: number): string {
+	if (mainBudget <= 0) return "";
+	if (countTokens(inject) <= mainBudget) return inject;
+	return (
+		truncateToTokens(inject, Math.max(1, mainBudget - TRUNCATED_MARKER_TOKENS)) +
+		TRUNCATED_MARKER
+	);
+}
+
 /** Build a brief "since your last session" summary for temporal awareness */
 function getSessionGapSummary(): string | undefined {
 	if (!existsSync(getMemoryDbPath())) return undefined;
@@ -1756,12 +1773,8 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 			maxTokens,
 			reservedTokens,
 		});
-		inject = "";
-	} else if (countTokens(inject) > mainBudget) {
-		const TRUNCATED_MARKER = "\n[context truncated]";
-		const markerTokens = countTokens(TRUNCATED_MARKER);
-		inject = truncateToTokens(inject, Math.max(1, mainBudget - markerTokens)) + TRUNCATED_MARKER;
 	}
+	inject = applyTokenBudget(inject, mainBudget);
 	if (constraintsSection) {
 		inject += constraintsSection;
 	}
@@ -2375,6 +2388,8 @@ export async function handleUserPromptSubmit(
 	try {
 		const cfg = deps.loadMemoryConfig(getAgentsDir());
 		const recallLimit = submitCfg.recallLimit ?? 10;
+		// userPromptSubmit.maxInjectChars already reads from config — no hardcoded fallback here.
+		// Falls back to pipelineV2.guardrails.contextBudgetChars when not set in agent.yaml.
 		const injectBudget = submitCfg.maxInjectChars ?? cfg.pipelineV2.guardrails.contextBudgetChars;
 		const minScore = resolveUserPromptMinScore(submitCfg.minScore);
 		const queryTerms = vectorQuery.slice(0, 80);


### PR DESCRIPTION
## Summary

- Replaces all character-based budgeting in the session-start hook with accurate BPE token counts via `js-tiktoken` (already a daemon dependency)
- Adds `selectWithTokenBudget()` — same interface as `selectWithBudget()` but uses `countTokens()` per row
- Memory selection: was hardcoded 2000 chars, now uses `maxInjectTokens` token budget (default 20000)
- Total inject truncation: was char slice at 24000, now `truncateToTokens()` at 20000 tokens
- New config field: `hooks.sessionStart.maxInjectTokens` (default 20000); clamped to `Math.max(1, ...)` with a warn log if ≤ 0
- Logs `injectTokens` instead of `injectChars` in the session-start completion log
- Regression tests added for `selectWithTokenBudget`: budget enforcement, full pass, zero-budget, and sub-row-budget cases
- `userPromptSubmit.maxInjectChars` already reads from config correctly — no parity gap

**Example `agent.yaml`:**
```yaml
hooks:
  sessionStart:
    maxInjectTokens: 8000
```

## Why

Characters are a poor proxy for model context. A 2000-char memory budget was effectively arbitrary and often under-injected. Token counts via `cl100k_base` give accurate, model-aligned budget enforcement — the same encoding used everywhere else in the daemon.

## Test plan

- [x] `selectWithTokenBudget` unit tests (4 cases, all pass)
- [ ] Restart daemon, verify session-start logs show `injectTokens` field
- [ ] Set `maxInjectTokens: 4000` in `agent.yaml`, start new session, confirm inject is bounded
- [ ] Omit field, verify default 20000-token behaviour