### PR TITLE
fix(publish): block leaked workspace deps in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,15 +310,20 @@ jobs:
       - name: Build
         run: bun run build
 
+      - name: Resolve workspace protocols
+        run: bun scripts/version-sync.ts --to "$NEW_VERSION"
+
+      - name: Validate publish manifests
+        run: bun scripts/check-publish-manifests.ts
+
       - name: Publish release
-        # Undraft first so predictor assets are publicly accessible before
-        # any npm install can trigger the postinstall downloader.
+        # Undraft only after publish manifests pass, so a broken npm package
+        # cannot slip through behind a green release job.
+        # Assets must still be public before npm publish can expose any
+        # postinstall downloader paths to users.
         run: gh release edit "v${NEW_VERSION}" --draft=false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Resolve workspace protocols
-        run: bun scripts/version-sync.ts --to "$NEW_VERSION"
 
       - name: Publish to npm
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,12 @@ Prevent these proactively:
 cd packages/cli/dashboard && bun run check
 ```
 
+9. **Publish/install integrity drift**
+   - Publishable packages must not ship runtime dependencies on
+     unpublished workspace packages.
+   - Validate publish manifests after version rewriting and before npm
+     publish.
+
 ## PR checklist
 
 Before opening a PR, verify:
@@ -109,6 +115,8 @@ Before opening a PR, verify:
 - Error handling and fallback paths are tested.
 - Security checks exist on admin or mutation endpoints.
 - Docs were updated for API, spec, schema, or status changes.
+- Publish manifests were validated if the PR changes a package that gets
+  published to npm.
 - Each bug fix has a regression test.
 - Lint, typecheck, and tests pass locally.
 

--- a/packages/signetai/package.json
+++ b/packages/signetai/package.json
@@ -1,81 +1,61 @@
 {
-  "name": "signetai",
-  "version": "0.98.8",
-  "description": "Portable AI agent identity - own your agent, bring it anywhere",
-  "type": "module",
-  "bin": {
-    "signet": "bin/signet.js",
-    "signet-mcp": "dist/mcp-stdio.js"
-  },
-  "files": [
-    "bin",
-    "dist",
-    "dashboard",
-    "templates",
-    "skills",
-    "README.md",
-    "LICENSE"
-  ],
-  "scripts": {
-    "build": "bun run build:cli && bun run build:daemon && bun run build:dashboard",
-    "build:cli": "bun build ../cli/src/cli.ts --outfile ./dist/cli.js --target node --external better-sqlite3",
-    "build:daemon": "bun run build-daemon.ts",
-    "build:dashboard": "bun ../../scripts/prepare-dashboard-bundle.ts .",
-    "copy:skills": "rm -rf skills && cp -r ../../skills skills",
-    "prebuild": "bun run copy:skills",
-    "prepublishOnly": "bun run build"
-  },
-  "keywords": [
-    "ai",
-    "agent",
-    "identity",
-    "memory",
-    "llm",
-    "claude",
-    "openai",
-    "portable",
-    "signet"
-  ],
-  "author": "Signet AI <hello@signetai.sh>",
-  "license": "Apache-2.0",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Signet-AI/signetai.git"
-  },
-  "homepage": "https://signetai.sh",
-  "bugs": {
-    "url": "https://github.com/Signet-AI/signetai/issues"
-  },
-  "engines": {
-    "node": ">=18"
-  },
-  "os": [
-    "darwin",
-    "linux",
-    "win32"
-  ],
-  "dependencies": {
-    "@hono/node-server": "^1.14.0",
-    "@inquirer/prompts": "^7.0.0",
-    "@signet/connector-pi": "workspace:*",
-    "chalk": "^5.3.0",
-    "chokidar": "^4.0.0",
-    "commander": "^12.0.0",
-    "hono": "^4.8.0",
-    "libsodium-wrappers": "^0.8.2",
-    "open": "^10.0.0",
-    "ora": "^8.0.0",
-    "sqlite-vec": "^0.1.7-alpha.2",
-    "onnxruntime-node": "1.21.0",
-    "@huggingface/transformers": "^3.4.0"
-  },
-  "optionalDependencies": {
-    "@1password/sdk": "^0.3.0",
-    "better-sqlite3": "^12.0.0",
-    "sharp": "^0.34.1"
-  },
-  "devDependencies": {
-    "@types/better-sqlite3": "^7.6.0",
-    "@types/libsodium-wrappers": "^0.8.2"
-  }
+	"name": "signetai",
+	"version": "0.98.8",
+	"description": "Portable AI agent identity - own your agent, bring it anywhere",
+	"type": "module",
+	"bin": {
+		"signet": "bin/signet.js",
+		"signet-mcp": "dist/mcp-stdio.js"
+	},
+	"files": ["bin", "dist", "dashboard", "templates", "skills", "README.md", "LICENSE"],
+	"scripts": {
+		"build": "bun run build:cli && bun run build:daemon && bun run build:dashboard",
+		"build:cli": "bun build ../cli/src/cli.ts --outfile ./dist/cli.js --target node --external better-sqlite3",
+		"build:daemon": "bun run build-daemon.ts",
+		"build:dashboard": "bun ../../scripts/prepare-dashboard-bundle.ts .",
+		"copy:skills": "rm -rf skills && cp -r ../../skills skills",
+		"prebuild": "bun run copy:skills",
+		"prepublishOnly": "bun run build"
+	},
+	"keywords": ["ai", "agent", "identity", "memory", "llm", "claude", "openai", "portable", "signet"],
+	"author": "Signet AI <hello@signetai.sh>",
+	"license": "Apache-2.0",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Signet-AI/signetai.git"
+	},
+	"homepage": "https://signetai.sh",
+	"bugs": {
+		"url": "https://github.com/Signet-AI/signetai/issues"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"engines": {
+		"node": ">=18"
+	},
+	"os": ["darwin", "linux", "win32"],
+	"dependencies": {
+		"@hono/node-server": "^1.14.0",
+		"@inquirer/prompts": "^7.0.0",
+		"chalk": "^5.3.0",
+		"chokidar": "^4.0.0",
+		"commander": "^12.0.0",
+		"hono": "^4.8.0",
+		"libsodium-wrappers": "^0.8.2",
+		"open": "^10.0.0",
+		"ora": "^8.0.0",
+		"sqlite-vec": "^0.1.7-alpha.2",
+		"onnxruntime-node": "1.21.0",
+		"@huggingface/transformers": "^3.4.0"
+	},
+	"optionalDependencies": {
+		"@1password/sdk": "^0.3.0",
+		"better-sqlite3": "^12.0.0",
+		"sharp": "^0.34.1"
+	},
+	"devDependencies": {
+		"@types/better-sqlite3": "^7.6.0",
+		"@types/libsodium-wrappers": "^0.8.2"
+	}
 }

--- a/scripts/check-publish-manifests.test.ts
+++ b/scripts/check-publish-manifests.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+	collectManifestIssues,
+	collectWorkspacePackages,
+	isPublishableWorkspacePackage,
+	listPublishableManifestTargets,
+} from "./check-publish-manifests";
+
+function writeJson(file: string, value: unknown): void {
+	writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+describe("check-publish-manifests", () => {
+	test("treats manifests with publishConfig.access public as publishable", () => {
+		expect(
+			isPublishableWorkspacePackage({
+				name: "signetai",
+				publishConfig: { access: "public" },
+			}),
+		).toBe(true);
+	});
+
+	test("discovers publishable manifest targets from workspace files", () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-publish-manifests-"));
+		try {
+			const signetaiDir = join(root, "packages", "signetai");
+			const adapterDir = join(root, "packages", "adapters", "openclaw");
+			const connectorDir = join(root, "packages", "connector-pi");
+			mkdirSync(signetaiDir, { recursive: true });
+			mkdirSync(adapterDir, { recursive: true });
+			mkdirSync(connectorDir, { recursive: true });
+
+			const signetaiFile = join(signetaiDir, "package.json");
+			const adapterFile = join(adapterDir, "package.json");
+			const connectorFile = join(connectorDir, "package.json");
+
+			writeJson(signetaiFile, {
+				name: "signetai",
+				publishConfig: { access: "public" },
+			});
+			writeJson(adapterFile, {
+				name: "@signetai/signet-memory-openclaw",
+				publishConfig: { access: "public" },
+			});
+			writeJson(connectorFile, {
+				name: "@signet/connector-pi",
+			});
+
+			expect(listPublishableManifestTargets([signetaiFile, adapterFile, connectorFile])).toEqual([
+				signetaiFile,
+				adapterFile,
+			]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("flags runtime dependencies on unpublished workspace packages", () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-publish-manifests-"));
+		try {
+			const signetaiDir = join(root, "packages", "signetai");
+			const connectorPiDir = join(root, "packages", "connector-pi");
+			mkdirSync(signetaiDir, { recursive: true });
+			mkdirSync(connectorPiDir, { recursive: true });
+
+			const signetaiFile = join(signetaiDir, "package.json");
+			const connectorPiFile = join(connectorPiDir, "package.json");
+
+			writeJson(signetaiFile, {
+				name: "signetai",
+				version: "1.2.3",
+				dependencies: {
+					"@signet/connector-pi": "1.2.3",
+				},
+			});
+			writeJson(connectorPiFile, {
+				name: "@signet/connector-pi",
+				version: "1.2.3",
+			});
+
+			const workspacePackages = collectWorkspacePackages([signetaiFile, connectorPiFile]);
+			const issues = collectManifestIssues([signetaiFile], workspacePackages);
+
+			expect(issues).toHaveLength(1);
+			expect(issues[0]?.reason).toContain("not published");
+			expect(issues[0]?.dep).toBe("@signet/connector-pi");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("flags workspace protocol in runtime dependency fields", () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-publish-manifests-"));
+		try {
+			const signetaiDir = join(root, "packages", "signetai");
+			mkdirSync(signetaiDir, { recursive: true });
+
+			const signetaiFile = join(signetaiDir, "package.json");
+			writeJson(signetaiFile, {
+				name: "signetai",
+				version: "1.2.3",
+				dependencies: {
+					"@signet/connector-pi": "workspace:*",
+				},
+			});
+
+			const workspacePackages = collectWorkspacePackages([signetaiFile]);
+			const issues = collectManifestIssues([signetaiFile], workspacePackages);
+
+			expect(issues).toHaveLength(1);
+			expect(issues[0]?.reason).toContain("workspace protocol");
+			expect(issues[0]?.field).toBe("dependencies");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("allows runtime dependencies on publishable workspace packages", () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-publish-manifests-"));
+		try {
+			const signetaiDir = join(root, "packages", "signetai");
+			const adapterDir = join(root, "packages", "adapters", "openclaw");
+			mkdirSync(signetaiDir, { recursive: true });
+			mkdirSync(adapterDir, { recursive: true });
+
+			const signetaiFile = join(signetaiDir, "package.json");
+			const adapterFile = join(adapterDir, "package.json");
+
+			writeJson(signetaiFile, {
+				name: "signetai",
+				version: "1.2.3",
+				publishConfig: { access: "public" },
+				dependencies: {
+					"@signetai/signet-memory-openclaw": "1.2.3",
+				},
+			});
+			writeJson(adapterFile, {
+				name: "@signetai/signet-memory-openclaw",
+				version: "1.2.3",
+				publishConfig: { access: "public" },
+			});
+
+			const workspacePackages = collectWorkspacePackages([signetaiFile, adapterFile]);
+			const issues = collectManifestIssues([signetaiFile], workspacePackages);
+
+			expect(issues).toHaveLength(0);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("ignores devDependencies on workspace packages for publish checks", () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-publish-manifests-"));
+		try {
+			const adapterDir = join(root, "packages", "adapters", "openclaw");
+			const coreDir = join(root, "packages", "core");
+			mkdirSync(adapterDir, { recursive: true });
+			mkdirSync(coreDir, { recursive: true });
+
+			const adapterFile = join(adapterDir, "package.json");
+			const coreFile = join(coreDir, "package.json");
+
+			writeJson(adapterFile, {
+				name: "@signetai/signet-memory-openclaw",
+				version: "1.2.3",
+				publishConfig: { access: "public" },
+				dependencies: {
+					"@sinclair/typebox": "0.34.47",
+				},
+				devDependencies: {
+					"@signet/core": "workspace:*",
+				},
+			});
+			writeJson(coreFile, {
+				name: "@signet/core",
+				version: "1.2.3",
+			});
+
+			const workspacePackages = collectWorkspacePackages([adapterFile, coreFile]);
+			const issues = collectManifestIssues([adapterFile], workspacePackages);
+
+			expect(issues).toHaveLength(0);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/scripts/check-publish-manifests.ts
+++ b/scripts/check-publish-manifests.ts
@@ -1,0 +1,170 @@
+#!/usr/bin/env bun
+
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const RUNTIME_FIELDS = ["dependencies", "optionalDependencies", "peerDependencies"] as const;
+
+type RuntimeField = (typeof RUNTIME_FIELDS)[number];
+
+type PackageJson = {
+	readonly name?: unknown;
+	readonly private?: unknown;
+	readonly publishConfig?: unknown;
+	readonly dependencies?: unknown;
+	readonly optionalDependencies?: unknown;
+	readonly peerDependencies?: unknown;
+};
+
+type WorkspacePackage = {
+	readonly file: string;
+	readonly name: string;
+	readonly publishable: boolean;
+};
+
+type ManifestIssue = {
+	readonly file: string;
+	readonly packageName: string;
+	readonly field: RuntimeField;
+	readonly dep: string;
+	readonly spec: string;
+	readonly reason: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function readPackageJson(file: string): PackageJson {
+	return JSON.parse(readFileSync(file, "utf8")) as PackageJson;
+}
+
+function getPackageName(file: string, pkg: PackageJson): string {
+	if (typeof pkg.name !== "string" || pkg.name.length === 0) {
+		throw new Error(`Missing package name in ${file}`);
+	}
+
+	return pkg.name;
+}
+
+export function isPublishableWorkspacePackage(pkg: PackageJson): boolean {
+	if (pkg.private === true) return false;
+
+	if (!isRecord(pkg.publishConfig)) return false;
+
+	return pkg.publishConfig.access === "public";
+}
+
+export function listWorkspacePackageFiles(): string[] {
+	const output = execSync("git ls-files package.json 'packages/**/package.json'", {
+		encoding: "utf8",
+	});
+
+	return output
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean);
+}
+
+export function collectWorkspacePackages(
+	files: readonly string[] = listWorkspacePackageFiles(),
+): Map<string, WorkspacePackage> {
+	const packages = new Map<string, WorkspacePackage>();
+
+	for (const file of files) {
+		const pkg = readPackageJson(file);
+		const name = getPackageName(file, pkg);
+		packages.set(name, {
+			file,
+			name,
+			publishable: isPublishableWorkspacePackage(pkg),
+		});
+	}
+
+	return packages;
+}
+
+export function listPublishableManifestTargets(files: readonly string[] = listWorkspacePackageFiles()): string[] {
+	return files.filter((file) => {
+		const pkg = readPackageJson(file);
+		return isPublishableWorkspacePackage(pkg);
+	});
+}
+
+function getRuntimeDependencies(pkg: PackageJson, field: RuntimeField): Array<readonly [string, string]> {
+	const value = pkg[field];
+	if (!isRecord(value)) return [];
+
+	return Object.entries(value).flatMap(([name, spec]) => (typeof spec === "string" ? ([[name, spec]] as const) : []));
+}
+
+export function collectManifestIssues(
+	targets: readonly string[],
+	workspacePackages: ReadonlyMap<string, WorkspacePackage>,
+): ManifestIssue[] {
+	const issues: ManifestIssue[] = [];
+
+	for (const file of targets) {
+		const pkg = readPackageJson(file);
+		const packageName = getPackageName(file, pkg);
+
+		for (const field of RUNTIME_FIELDS) {
+			for (const [dep, spec] of getRuntimeDependencies(pkg, field)) {
+				if (spec.startsWith("workspace:")) {
+					issues.push({
+						file,
+						packageName,
+						field,
+						dep,
+						spec,
+						reason: "runtime dependency still uses workspace protocol",
+					});
+					continue;
+				}
+
+				const workspaceDep = workspacePackages.get(dep);
+				if (workspaceDep && !workspaceDep.publishable) {
+					issues.push({
+						file,
+						packageName,
+						field,
+						dep,
+						spec,
+						reason: `depends on internal workspace package ${dep}, which is not published`,
+					});
+				}
+			}
+		}
+	}
+
+	return issues;
+}
+
+function formatIssues(issues: readonly ManifestIssue[]): string {
+	const lines = issues.map(
+		(issue) => `- ${issue.file} (${issue.packageName}) ${issue.field}.${issue.dep}=${issue.spec} -> ${issue.reason}`,
+	);
+
+	return `Publish manifest validation failed:\n${lines.join("\n")}`;
+}
+
+export function getManifestTargets(argv: readonly string[]): string[] {
+	return argv.length > 0 ? [...argv] : listPublishableManifestTargets();
+}
+
+function main(): void {
+	const targets = getManifestTargets(process.argv.slice(2));
+	const workspacePackages = collectWorkspacePackages();
+	const issues = collectManifestIssues(targets, workspacePackages);
+
+	if (issues.length > 0) {
+		console.error(formatIssues(issues));
+		process.exit(1);
+	}
+
+	console.log(`Publish manifest check passed for ${targets.length} package(s).`);
+}
+
+if (import.meta.main) {
+	main();
+}


### PR DESCRIPTION
## Summary
- remove the unpublished `@signet/connector-pi` runtime dependency from the published `signetai` manifest while keeping the connector in the CLI codepath
- add a publish-manifest guard that fails if a publishable package ships `workspace:` runtime deps or depends on an internal workspace package that is not published to npm
- run that guard in the release workflow before undrafting the GitHub release, and document the rule in `AGENTS.md`

## Root cause
`signetai@0.98.8` shipped `@signet/connector-pi` in `dependencies` as `workspace:*`.
That package is an internal workspace connector and is not published on npm, so `bun add -g signetai` failed during dependency resolution.

The important distinction is that `@signet/connector-pi` is required in the repo and in the bundled CLI, but it is not part of the published npm dependency surface for `signetai`. Previous releases already followed that contract for the other connector packages.

## Validation
- `npm view signetai@0.98.8 dependencies --json` shows the broken published dep: `@signet/connector-pi=workspace:*`
- `bun test ./scripts/check-publish-manifests.test.ts`
- `bun scripts/check-publish-manifests.ts packages/signetai/package.json packages/adapters/openclaw/package.json`
- `npm pack --json --ignore-scripts ./packages/signetai` and inspected `package/package.json` from the tarball to confirm the leaked connector dep is gone
