### PR TITLE
fix(release): rebuild changelog with readable highlights

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,9 @@ jobs:
         run: |
           NOTES=$(bun scripts/extract-changelog-section.ts "$NEW_VERSION")
           if [ -z "$NOTES" ] || [ "$NOTES" = "No changelog section found for v$NEW_VERSION" ]; then
+            # This runs after the version bump commit and tag are pushed. If it
+            # fails, recover by creating the draft release manually with
+            # `gh release create "v$NEW_VERSION" --draft --notes-file <notes>`.
             echo "::error::Missing CHANGELOG.md section for v$NEW_VERSION"
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,8 +111,8 @@ jobs:
           echo "bump_level=$BUMP" >> $GITHUB_OUTPUT
           rm -f .bump-level
 
-          PACKAGE_FILES=$(git ls-files package.json 'packages/**/package.json' | grep -v '^packages/cli/dashboard/package.json$')
-          for file in $PACKAGE_FILES; do
+          mapfile -t PACKAGE_FILES < <(git ls-files package.json 'packages/**/package.json' | grep -v '^packages/cli/dashboard/package.json$')
+          for file in "${PACKAGE_FILES[@]}"; do
             jq --arg v "$NEW_VERSION" '.version = $v' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
           done
 
@@ -122,7 +122,7 @@ jobs:
           # (Docker smoke and consumer builds) stay deterministic.
           bun install
 
-          git add $PACKAGE_FILES bun.lock CHANGELOG.md
+          git add -- "${PACKAGE_FILES[@]}" bun.lock CHANGELOG.md
           git commit -m "chore: release $NEW_VERSION"
           git tag "v$NEW_VERSION"
 
@@ -137,7 +137,7 @@ jobs:
         if: steps.changes.outputs.skip != 'true'
         run: |
           NOTES=$(bun scripts/extract-changelog-section.ts "$NEW_VERSION")
-          if [ -z "$NOTES" ] || printf '%s' "$NOTES" | grep -q "^No changelog section found for v$NEW_VERSION$"; then
+          if [ -z "$NOTES" ] || [ "$NOTES" = "No changelog section found for v$NEW_VERSION" ]; then
             echo "::error::Missing CHANGELOG.md section for v$NEW_VERSION"
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
           BASE_VERSION=$(printf '%s\n%s\n' "$LOCAL_VERSION" "$REMOTE_VERSION" | sort -V | tail -n1)
           IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
 
-          bun scripts/changelog.ts
+          bun scripts/changelog.ts --bump-only
 
           BUMP=$(cat .bump-level 2>/dev/null || echo "patch")
           case "$BUMP" in
@@ -115,6 +115,8 @@ jobs:
           for file in $PACKAGE_FILES; do
             jq --arg v "$NEW_VERSION" '.version = $v' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
           done
+
+          bun scripts/changelog.ts --version "$NEW_VERSION"
 
           # Keep lockfile aligned with workspace version bumps so frozen installs
           # (Docker smoke and consumer builds) stay deterministic.
@@ -134,7 +136,11 @@ jobs:
         id: create_release
         if: steps.changes.outputs.skip != 'true'
         run: |
-          NOTES=$(bun scripts/extract-changelog-section.ts "$NEW_VERSION" 2>/dev/null || echo "See CHANGELOG.md for details")
+          NOTES=$(bun scripts/extract-changelog-section.ts "$NEW_VERSION")
+          if [ -z "$NOTES" ] || printf '%s' "$NOTES" | grep -q "^No changelog section found for v$NEW_VERSION$"; then
+            echo "::error::Missing CHANGELOG.md section for v$NEW_VERSION"
+            exit 1
+          fi
           # Create as draft — predictor assets are uploaded by build-predictor
           # before the publish job promotes this to non-draft and publishes npm.
           gh release create "v$NEW_VERSION" --draft --title "v$NEW_VERSION" --notes "$NOTES"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,63 +2,123 @@
 
 All notable changes to Signet are documented here.
 
+## Recent Highlights
+
+Surface summary of the most recent release dates. See the release ledger below for exact version-by-version history.
+
+### 2026-04-09
+- Bug fixes: improve docs search and docs navigation.
+
+### 2026-04-08
+- Bug fixes: honour maxInjectChars config in session-start hook.
+- Refactoring: align recall surfaces and validate prospective hint retrieval.
+- Docs: sync root-derived docs.
+
+### 2026-04-07
+- Features: manage workspace source checkout; add token-bucket rate limiting for remote LLM providers; Discord community CTAs + /join opt-in page.
+- Bug fixes: harden transcript capture and summary inputs.
+- Refactoring: extract routes from daemon.ts into separate modules.
+
+### 2026-04-06
+- Features: add Hermes Agent memory provider integration; OpenClaw adapter request normalization.
+
+### 2026-04-04
+- Bug fixes: scope sub-agent memory dedupe and synthesis; prevent summary-worker retries on shared session-end keys.
+
+### 2026-04-03
+- Features: add ForgeCode connector.
+- Bug fixes: auto-migrate legacy-only OpenClaw runtime; ignore generated MEMORY backup markdown files.
+
+## Release Ledger
+
 ## [0.98.8] - 2026-04-09
 
-### Bug Fixes
-
-- **publish**: block leaked workspace deps in release (#486)
-
-
-## [0.98.7] - 2026-04-09
+Release summary: 1 bug fix.
+Tag range: `v0.98.7..v0.98.8`.
 
 ### Bug Fixes
 
 - **web**: improve docs search and docs navigation (#485)
 
+## [0.98.7] - 2026-04-08
 
-## [0.98.6] - 2026-04-08
+Release summary: 1 docs update.
+Tag range: `v0.98.6..v0.98.7`.
 
 ### Docs
 
 - **repo**: sync root-derived docs (#484)
 
+## [0.98.6] - 2026-04-08
 
-## [0.98.2] - 2026-04-08
+Release summary: internal maintenance release with no conventional commit entries captured.
+Tag range: `v0.98.5..v0.98.6`.
+
+No notable changes were captured from conventional commit subjects for this release.
+
+## [0.98.5] - 2026-04-08
+
+Release summary: internal maintenance release with no conventional commit entries captured.
+Tag range: `v0.98.4..v0.98.5`.
+
+No notable changes were captured from conventional commit subjects for this release.
+
+## [0.98.4] - 2026-04-08
+
+Release summary: internal maintenance release with no conventional commit entries captured.
+Tag range: `v0.98.3..v0.98.4`.
+
+No notable changes were captured from conventional commit subjects for this release.
+
+## [0.98.3] - 2026-04-08
+
+Release summary: 1 refactor.
+Tag range: `v0.98.2..v0.98.3`.
 
 ### Refactoring
 
 - align recall surfaces and validate prospective hint retrieval (#474)
 
+## [0.98.2] - 2026-04-08
 
-## [0.98.1] - 2026-04-08
+Release summary: 1 bug fix.
+Tag range: `v0.98.1..v0.98.2`.
 
 ### Bug Fixes
 
 - **daemon**: honour maxInjectChars config in session-start hook (#482)
 
+## [0.98.1] - 2026-04-07
 
-## [0.98.0] - 2026-04-07
+Release summary: 1 refactor.
+Tag range: `v0.98.0..v0.98.1`.
 
 ### Refactoring
 
 - **daemon**: extract routes from daemon.ts into separate modules (#473)
 
+## [0.98.0] - 2026-04-07
 
-## [0.97.0] - 2026-04-07
+Release summary: 1 feature.
+Tag range: `v0.97.0..v0.98.0`.
 
 ### Features
 
 - **cli**: manage workspace source checkout (#472)
 
+## [0.97.0] - 2026-04-07
 
-## [0.96.0] - 2026-04-07
+Release summary: 1 feature.
+Tag range: `v0.96.0..v0.97.0`.
 
 ### Features
 
 - **pipeline**: add token-bucket rate limiting for remote LLM providers (#469)
 
+## [0.96.0] - 2026-04-07
 
-## [0.95.0] - 2026-04-07
+Release summary: 1 feature and 1 bug fix.
+Tag range: `v0.95.0..v0.96.0`.
 
 ### Features
 
@@ -68,163 +128,230 @@ All notable changes to Signet are documented here.
 
 - harden transcript capture and summary inputs (#466)
 
+## [0.95.0] - 2026-04-06
 
-## [0.94.0] - 2026-04-06
+Release summary: 1 feature.
+Tag range: `v0.94.0..v0.95.0`.
 
 ### Features
 
 - **connector**: add Hermes Agent memory provider integration (#465)
 
+## [0.94.0] - 2026-04-06
 
-## [0.93.7] - 2026-04-06
+Release summary: 1 feature.
+Tag range: `v0.93.7..v0.94.0`.
 
 ### Features
 
 - OpenClaw adapter request normalization (#468)
 
+## [0.93.7] - 2026-04-05
 
-## [0.93.5] - 2026-04-04
+Release summary: internal maintenance release with no conventional commit entries captured.
+Tag range: `v0.93.6..v0.93.7`.
+
+No notable changes were captured from conventional commit subjects for this release.
+
+## [0.93.6] - 2026-04-04
+
+Release summary: 1 bug fix.
+Tag range: `v0.93.5..v0.93.6`.
 
 ### Bug Fixes
 
 - scope sub-agent memory dedupe and synthesis (#455)
 
+## [0.93.5] - 2026-04-04
 
-## [0.93.4] - 2026-04-04
+Release summary: 1 bug fix.
+Tag range: `v0.93.4..v0.93.5`.
 
 ### Bug Fixes
 
 - **daemon**: prevent summary-worker retries on shared session-end keys (#459)
 
+## [0.93.4] - 2026-04-03
 
-## [0.93.3] - 2026-04-03
+Release summary: 1 bug fix.
+Tag range: `v0.93.3..v0.93.4`.
 
 ### Bug Fixes
 
 - **cli**: auto-migrate legacy-only OpenClaw runtime (#446)
 
+## [0.93.3] - 2026-04-03
 
-## [0.93.2] - 2026-04-03
+Release summary: 1 bug fix.
+Tag range: `v0.93.2..v0.93.3`.
 
 ### Bug Fixes
 
 - **daemon**: ignore generated MEMORY backup markdown files (#452)
 
+## [0.93.2] - 2026-04-03
 
-## [0.92.0] - 2026-04-03
+Release summary: internal maintenance release with no conventional commit entries captured.
+Tag range: `v0.93.1..v0.93.2`.
+
+No notable changes were captured from conventional commit subjects for this release.
+
+## [0.93.1] - 2026-04-03
+
+Release summary: internal maintenance release with no conventional commit entries captured.
+Tag range: `v0.93.0..v0.93.1`.
+
+No notable changes were captured from conventional commit subjects for this release.
+
+## [0.93.0] - 2026-04-03
+
+Release summary: 1 feature.
+Tag range: `v0.92.0..v0.93.0`.
 
 ### Features
 
 - **connector-forge**: add ForgeCode connector (#444)
 
+## [0.92.0] - 2026-04-02
 
-## [0.91.12] - 2026-04-02
+Release summary: 1 feature.
+Tag range: `v0.91.12..v0.92.0`.
 
 ### Features
 
 - dreaming memory consolidation — periodic LLM-driven knowledge graph refinement (#442)
 
+## [0.91.12] - 2026-04-02
 
-## [0.91.11] - 2026-04-02
+Release summary: 1 bug fix.
+Tag range: `v0.91.11..v0.91.12`.
 
 ### Bug Fixes
 
 - **cli**: use wall-clock deadline for daemon startup poll and exit non-zero on failure (#445)
 
+## [0.91.11] - 2026-04-02
 
-## [0.91.10] - 2026-04-02
+Release summary: 1 bug fix.
+Tag range: `v0.91.10..v0.91.11`.
 
 ### Bug Fixes
 
 - enforce 5000-token MEMORY.md budget (#443)
 
+## [0.91.10] - 2026-04-02
 
-## [0.91.9] - 2026-04-02
+Release summary: 1 bug fix.
+Tag range: `v0.91.9..v0.91.10`.
 
 ### Bug Fixes
 
 - **daemon**: stop re-ingesting pipeline artifacts as memories (#439)
 
+## [0.91.9] - 2026-04-01
 
-## [0.91.8] - 2026-04-01
+Release summary: 1 bug fix.
+Tag range: `v0.91.8..v0.91.9`.
 
 ### Bug Fixes
 
 - **cli**: restore homedir import for workspace resolution
 
+## [0.91.8] - 2026-04-01
 
-## [0.91.7] - 2026-04-01
+Release summary: 1 refactor.
+Tag range: `v0.91.7..v0.91.8`.
 
 ### Refactoring
 
 - extract Signet system prompt from AGENTS.md into session-start inject (#440)
 
+## [0.91.7] - 2026-04-01
 
-## [0.91.6] - 2026-04-01
+Release summary: 2 bug fixes.
+Tag range: `v0.91.6..v0.91.7`.
 
 ### Bug Fixes
 
 - **ci**: prevent lockfile drift and restore openclaw build
 - **runtime**: hotfix issues #432 #433 #435 #437 (#438)
 
+## [0.91.6] - 2026-04-01
 
-## [0.91.5] - 2026-04-01
+Release summary: 1 bug fix.
+Tag range: `v0.91.5..v0.91.6`.
 
 ### Bug Fixes
 
 - **pipeline**: pass maxContextTokens to direct Ollama synthesis (#426) (#430)
 
+## [0.91.5] - 2026-04-01
 
-## [0.91.4] - 2026-04-01
+Release summary: 1 bug fix.
+Tag range: `v0.91.4..v0.91.5`.
 
 ### Bug Fixes
 
 - **daemon**: resolve ReferenceError in /api/hooks/recall endpoint (#436)
 
+## [0.91.4] - 2026-04-01
 
-## [0.91.3] - 2026-04-01
+Release summary: 1 bug fix.
+Tag range: `v0.91.3..v0.91.4`.
 
 ### Bug Fixes
 
 - **pipeline**: support Copilot models via OpenCode structured output (#425)
 
+## [0.91.3] - 2026-03-31
 
-## [0.91.2] - 2026-03-31
+Release summary: 1 bug fix.
+Tag range: `v0.91.2..v0.91.3`.
 
 ### Bug Fixes
 
 - **openclaw**: prevent double registration blocking gateway providers (#423)
 
+## [0.91.2] - 2026-03-31
 
-## [0.91.1] - 2026-03-31
+Release summary: 1 bug fix.
+Tag range: `v0.91.1..v0.91.2`.
 
 ### Bug Fixes
 
 - **codex**: repair stale MCP config on setup instead of skipping (#421)
 
+## [0.91.1] - 2026-03-31
 
-## [0.91.0] - 2026-03-31
+Release summary: 1 bug fix.
+Tag range: `v0.91.0..v0.91.1`.
 
 ### Bug Fixes
 
 - **daemon**: preserve multiline markdown for embeddings (#419)
 
+## [0.91.0] - 2026-03-31
 
-## [0.90.0] - 2026-03-31
+Release summary: 1 feature.
+Tag range: `v0.90.0..v0.91.0`.
 
 ### Features
 
 - **dashboard**: show real overview usage analytics (#416)
 
+## [0.90.0] - 2026-03-31
 
-## [0.89.0] - 2026-03-31
+Release summary: 1 feature.
+Tag range: `v0.89.0..v0.90.0`.
 
 ### Features
 
 - **dashboard**: feature official marketplace skills (#415)
 
+## [0.89.0] - 2026-03-31
 
-## [0.88.1] - 2026-03-31
+Release summary: 1 feature, 3 bug fixes, and 1 docs update.
+Tag range: `v0.88.1..v0.89.0`.
 
 ### Features
 
@@ -240,8 +367,10 @@ All notable changes to Signet are documented here.
 
 - add StarRank badge to README
 
+## [0.88.1] - 2026-03-30
 
-## [0.88.0] - 2026-03-30
+Release summary: 3 bug fixes.
+Tag range: `v0.88.0..v0.88.1`.
 
 ### Bug Fixes
 
@@ -249,8 +378,10 @@ All notable changes to Signet are documented here.
 - **skills**: add __pycache__/ to gitignore
 - **docker**: add skills/ to build context and runtime stage
 
+## [0.88.0] - 2026-03-30
 
-## [0.87.2] - 2026-03-30
+Release summary: 1 feature and 1 docs update.
+Tag range: `v0.87.2..v0.88.0`.
 
 ### Features
 
@@ -260,92 +391,125 @@ All notable changes to Signet are documented here.
 
 - add planning document for groundswell
 
+## [0.87.2] - 2026-03-30
 
-## [0.87.1] - 2026-03-30
+Release summary: 1 bug fix.
+Tag range: `v0.87.1..v0.87.2`.
 
 ### Bug Fixes
 
 - **repo**: recover rebase follow-ups and restore green checks (#410)
 
+## [0.87.1] - 2026-03-30
 
-## [0.87.0] - 2026-03-30
+Release summary: 1 bug fix.
+Tag range: `v0.87.0..v0.87.1`.
 
 ### Bug Fixes
 
 - **worker**: exclude exhausted jobs from watchdog stall detector query (#339) (#409)
 
+## [0.87.0] - 2026-03-30
 
-## [0.86.4] - 2026-03-30
+Release summary: 1 feature.
+Tag range: `v0.86.4..v0.87.0`.
 
 ### Features
 
 - MCP CLI bridge, invocation tracking, and analytics (Phase 1) (#407)
 
+## [0.86.4] - 2026-03-30
 
-## [0.86.3] - 2026-03-30
+Release summary: 1 bug fix.
+Tag range: `v0.86.3..v0.86.4`.
 
 ### Bug Fixes
 
 - **oh-my-pi**: persist hidden Signet recall as agent messages (#404)
 
+## [0.86.3] - 2026-03-29
 
-## [0.86.2] - 2026-03-29
+Release summary: 1 bug fix.
+Tag range: `v0.86.2..v0.86.3`.
 
 ### Bug Fixes
 
 - extraction-model reranker can synthesize recall summary (#402)
 
+## [0.86.2] - 2026-03-29
 
-## [0.86.1] - 2026-03-29
+Release summary: 1 bug fix.
+Tag range: `v0.86.1..v0.86.2`.
 
 ### Bug Fixes
 
 - **daemon**: harden dogfood runtime and MCP surfaces (#403)
 
+## [0.86.1] - 2026-03-29
 
-## [0.86.0] - 2026-03-29
+Release summary: 1 bug fix.
+Tag range: `v0.86.0..v0.86.1`.
 
 ### Bug Fixes
 
 - **daemon**: harden pipeline parsers and skill reconciler idempotency (#401)
 
+## [0.86.0] - 2026-03-29
 
-## [0.85.5] - 2026-03-29
+Release summary: 1 feature.
+Tag range: `v0.85.5..v0.86.0`.
 
 ### Features
 
 - **memory**: derive MEMORY.md from canonical lineage (#399)
 
+## [0.85.5] - 2026-03-29
 
-## [0.85.3] - 2026-03-29
+Release summary: internal maintenance release with no conventional commit entries captured.
+Tag range: `v0.85.4..v0.85.5`.
+
+No notable changes were captured from conventional commit subjects for this release.
+
+## [0.85.4] - 2026-03-29
+
+Release summary: 1 bug fix.
+Tag range: `v0.85.3..v0.85.4`.
 
 ### Bug Fixes
 
 - **pipeline**: harden dependency prompt auditability (#397)
 
+## [0.85.3] - 2026-03-29
 
-## [0.85.2] - 2026-03-29
+Release summary: 1 bug fix.
+Tag range: `v0.85.2..v0.85.3`.
 
 ### Bug Fixes
 
 - **core**: align Signet prompt with identity stewardship (#398)
 
+## [0.85.2] - 2026-03-29
 
-## [0.85.1] - 2026-03-29
+Release summary: 1 bug fix.
+Tag range: `v0.85.1..v0.85.2`.
 
 ### Bug Fixes
 
 - **daemon**: preserve reranker score calibration + gate low-confidence prompt recalls (#396)
 
+## [0.85.1] - 2026-03-29
 
-## [0.85.0] - 2026-03-29
+Release summary: 1 bug fix.
+Tag range: `v0.85.0..v0.85.1`.
 
 ### Bug Fixes
 
 - distinguish session-start timeouts from offline fallback (#395)
 
+## [0.85.0] - 2026-03-29
 
-## [0.84.2] - 2026-03-29
+Release summary: 1 feature and 2 docs updates.
+Tag range: `v0.84.2..v0.85.0`.
 
 ### Features
 
@@ -356,79 +520,108 @@ All notable changes to Signet are documented here.
 - add link to memscore in benchmarking documentation
 - add oh my pi connector to readme
 
+## [0.84.2] - 2026-03-29
 
-## [0.84.1] - 2026-03-29
+Release summary: 1 bug fix.
+Tag range: `v0.84.1..v0.84.2`.
 
 ### Bug Fixes
 
 - **daemon**: populate content_hash in summary facts, backfill write-back, exhausted job recovery (#372)
 
+## [0.84.1] - 2026-03-29
 
-## [0.84.0] - 2026-03-29
+Release summary: 1 bug fix.
+Tag range: `v0.84.0..v0.84.1`.
 
 ### Bug Fixes
 
 - **daemon-rs**: parity for PR #372 -- startup recovery + content_hash notes
 
+## [0.84.0] - 2026-03-29
 
-## [0.83.0] - 2026-03-29
+Release summary: 1 feature.
+Tag range: `v0.83.0..v0.84.0`.
 
 ### Features
 
 - **oh-my-pi**: add Oh My Pi support (#386)
 
+## [0.83.0] - 2026-03-29
 
-## [0.82.7] - 2026-03-29
+Release summary: 1 feature.
+Tag range: `v0.82.7..v0.83.0`.
 
 ### Features
 
 - **dashboard**: ontology constellation view (#393)
 
+## [0.82.7] - 2026-03-29
 
-## [0.82.6] - 2026-03-29
+Release summary: 1 bug fix.
+Tag range: `v0.82.6..v0.82.7`.
 
 ### Bug Fixes
 
 - **ci**: replace mapfile for macOS-compatible release uploads (#392)
 
+## [0.82.6] - 2026-03-29
 
-## [0.82.5] - 2026-03-29
+Release summary: 2 bug fixes.
+Tag range: `v0.82.5..v0.82.6`.
 
 ### Bug Fixes
 
 - **daemon**: prototype DP-19 adaptive write gate with scoped guards (#380)
 - **tray**: unblock mac self-signed CI and prefer bundled linux daemon (#388)
 
+## [0.82.5] - 2026-03-28
 
-## [0.82.4] - 2026-03-28
+Release summary: 1 bug fix.
+Tag range: `v0.82.4..v0.82.5`.
 
 ### Bug Fixes
 
 - **tray**: resolve macOS bundled-daemon path compile regression (#387)
 
+## [0.82.4] - 2026-03-28
 
-## [0.82.3] - 2026-03-28
+Release summary: 1 bug fix.
+Tag range: `v0.82.3..v0.82.4`.
 
 ### Bug Fixes
 
 - **ci**: harden self-signed desktop signing on macOS and windows (#384)
 
+## [0.82.3] - 2026-03-28
 
-## [0.82.2] - 2026-03-28
+Release summary: 1 bug fix.
+Tag range: `v0.82.2..v0.82.3`.
 
 ### Bug Fixes
 
 - **ci**: add self-signed desktop signing and arch package validation (#383)
 
+## [0.82.2] - 2026-03-28
 
-## [0.82.0] - 2026-03-28
+Release summary: internal maintenance release with no conventional commit entries captured.
+Tag range: `v0.82.1..v0.82.2`.
+
+No notable changes were captured from conventional commit subjects for this release.
+
+## [0.82.1] - 2026-03-28
+
+Release summary: 1 bug fix.
+Tag range: `v0.82.0..v0.82.1`.
 
 ### Bug Fixes
 
 - **cli**: protect OpenClaw-linked workspaces from unprotected data loss (#378)
 
+## [0.82.0] - 2026-03-28
 
-## [0.81.2] - 2026-03-28
+Release summary: 1 feature, 1 bug fix, and 2 docs updates.
+Tag range: `v0.81.2..v0.82.0`.
 
 ### Features
 
@@ -443,8 +636,10 @@ All notable changes to Signet are documented here.
 - add Groundswell implementation specs + PRD + SSM synthesis (#381)
 - **specs**: add Groundswell PRD and gap analyses for community knowledge graphs
 
+## [0.81.2] - 2026-03-28
 
-## [0.81.1] - 2026-03-28
+Release summary: 1 bug fix and 1 docs update.
+Tag range: `v0.81.1..v0.81.2`.
 
 ### Bug Fixes
 
@@ -454,33 +649,37 @@ All notable changes to Signet are documented here.
 
 - add alcar2364 to contributors
 
+## [0.81.1] - 2026-03-28
 
-## [0.81.0] - 2026-03-28
+Release summary: 1 bug fix.
+Tag range: `v0.81.0..v0.81.1`.
 
 ### Bug Fixes
 
 - **docker**: unblock post-merge smoke failures from #374 (#377)
 
+## [0.81.0] - 2026-03-27
 
-## [0.80.0] - 2026-03-27
+Release summary: 1 feature.
+Tag range: `v0.80.0..v0.81.0`.
 
 ### Features
 
 - **docker**: add first-party self-hosting stack (#374)
 
+## [0.80.0] - 2026-03-27
 
-## [0.79.0] - 2026-03-27
+Release summary: 1 feature.
+Tag range: `v0.79.0..v0.80.0`.
 
 ### Features
 
 - **pipeline**: add command extraction provider for summary worker control-plane path (#368)
-- **docker**: add first-party self-hosting stack (Compose + Caddy + token bootstrap) and GHCR image workflows
 
-### Docs
+## [0.79.0] - 2026-03-27
 
-- add Docker self-hosting quickstart and operations runbook updates
-
-## [0.78.4] - 2026-03-27
+Release summary: 1 feature and 2 docs updates.
+Tag range: `v0.78.4..v0.79.0`.
 
 ### Features
 
@@ -491,8 +690,10 @@ All notable changes to Signet are documented here.
 - add first-PR guide for new contributors
 - **research**: add agent loop comparison across Forge, Codex, Hermes
 
+## [0.78.4] - 2026-03-27
 
-## [0.78.3] - 2026-03-27
+Release summary: 1 bug fix and 1 docs update.
+Tag range: `v0.78.3..v0.78.4`.
 
 ### Bug Fixes
 
@@ -502,8 +703,10 @@ All notable changes to Signet are documented here.
 
 - add ddasgupta4 to contributors
 
+## [0.78.3] - 2026-03-27
 
-## [0.78.2] - 2026-03-27
+Release summary: 1 bug fix and 1 refactor.
+Tag range: `v0.78.2..v0.78.3`.
 
 ### Bug Fixes
 
@@ -513,86 +716,149 @@ All notable changes to Signet are documented here.
 
 - **dashboard**: stabilize IA and gate experimental surfaces (#364)
 
+## [0.78.2] - 2026-03-27
 
-## [0.78.1] - 2026-03-27
+Release summary: 1 bug fix.
+Tag range: `v0.78.1..v0.78.2`.
 
 ### Bug Fixes
 
 - **update**: verify installed version after install (#365)
 
+## [0.78.1] - 2026-03-27
 
-## [0.78.0] - 2026-03-27
+Release summary: 1 bug fix.
+Tag range: `v0.78.0..v0.78.1`.
 
 ### Bug Fixes
 
 - **daemon**: add prompt-submit success telemetry on all success paths (#360)
 
+## [0.78.0] - 2026-03-26
 
-## [0.77.7] - 2026-03-26
+Release summary: 1 feature and 1 bug fix.
+Tag range: `v0.77.7..v0.78.0`.
 
 ### Features
 
 - **forge**: require explicit dev-warning acknowledgement on install and launch (#359)
 
+### Bug Fixes
 
-## [0.77.5] - 2026-03-26
+- **forge**: switch reqwest to rustls and guard openssl regressions (#353)
+
+## [0.77.7] - 2026-03-26
+
+Release summary: internal maintenance release with no conventional commit entries captured.
+Tag range: `v0.77.6..v0.77.7`.
+
+No notable changes were captured from conventional commit subjects for this release.
+
+## [0.77.6] - 2026-03-26
+
+Release summary: 1 bug fix.
+Tag range: `v0.77.5..v0.77.6`.
 
 ### Bug Fixes
 
 - force event-driven MEMORY.md refresh after summary/compaction (#349)
 
+## [0.77.5] - 2026-03-26
 
-## [0.77.4] - 2026-03-26
+Release summary: 1 bug fix.
+Tag range: `v0.77.4..v0.77.5`.
 
 ### Bug Fixes
 
 - **memory**: close lossless working-memory runtime gaps (#344)
 
+## [0.77.4] - 2026-03-26
 
-## [0.77.3] - 2026-03-26
+Release summary: 2 bug fixes.
+Tag range: `v0.77.3..v0.77.4`.
 
 ### Bug Fixes
 
 - **daemon**: broaden macOS SQLite runtime discovery for sqlite-vec (#338)
 - **docs**: align Signet positioning around context selection (#342)
 
+## [0.77.3] - 2026-03-26
 
-## [0.77.1] - 2026-03-25
+Release summary: internal maintenance release with no conventional commit entries captured.
+Tag range: `v0.77.2..v0.77.3`.
+
+No notable changes were captured from conventional commit subjects for this release.
+
+## [0.77.2] - 2026-03-25
+
+Release summary: 1 bug fix.
+Tag range: `v0.77.1..v0.77.2`.
 
 ### Bug Fixes
 
 - **cli**: recover stale daemon processes on restart (#333)
 
+## [0.77.1] - 2026-03-25
 
-## [0.77.0] - 2026-03-25
+Release summary: 1 bug fix.
+Tag range: `v0.77.0..v0.77.1`.
 
 ### Bug Fixes
 
 - **daemon**: keep startup recovery responsive on large databases (#332)
 
+## [0.77.0] - 2026-03-25
 
-## [0.76.6] - 2026-03-25
+Release summary: 1 feature.
+Tag range: `v0.76.6..v0.77.0`.
 
 ### Features
 
 - **pipeline**: add live pause controls (#329)
 
+## [0.76.6] - 2026-03-25
 
-## [0.76.5] - 2026-03-25
+Release summary: 1 bug fix.
+Tag range: `v0.76.5..v0.76.6`.
 
 ### Bug Fixes
 
 - recover stuck processing summary_jobs on startup + fix embed backfill infinite cycle (#319)
 
+## [0.76.5] - 2026-03-25
 
-## [0.76.2] - 2026-03-24
+Release summary: internal maintenance release with no conventional commit entries captured.
+Tag range: `v0.76.4..v0.76.5`.
+
+No notable changes were captured from conventional commit subjects for this release.
+
+## [0.76.4] - 2026-03-25
+
+Release summary: internal maintenance release with no conventional commit entries captured.
+Tag range: `v0.76.3..v0.76.4`.
+
+No notable changes were captured from conventional commit subjects for this release.
+
+## [0.76.3] - 2026-03-24
+
+Release summary: 1 bug fix.
+Tag range: `v0.76.2..v0.76.3`.
 
 ### Bug Fixes
 
 - **memory**: raise contradiction timeout and guard embedding tracker null hashes
 
+## [0.76.2] - 2026-03-24
 
-## [0.76.0] - 2026-03-24
+Release summary: internal maintenance release with no conventional commit entries captured.
+Tag range: `v0.76.1..v0.76.2`.
+
+No notable changes were captured from conventional commit subjects for this release.
+
+## [0.76.1] - 2026-03-24
+
+Release summary: 1 bug fix and 1 docs update.
+Tag range: `v0.76.0..v0.76.1`.
 
 ### Bug Fixes
 
@@ -602,29 +868,37 @@ All notable changes to Signet are documented here.
 
 - spec and index for sub-agent context continuity (#315)
 
+## [0.76.0] - 2026-03-24
 
-## [0.75.3] - 2026-03-24
+Release summary: 1 feature.
+Tag range: `v0.75.3..v0.76.0`.
 
 ### Features
 
 - multi-agent support — scoped identity, memory, and OpenClaw routing (#316)
 
+## [0.75.3] - 2026-03-24
 
-## [0.75.2] - 2026-03-24
+Release summary: 1 bug fix.
+Tag range: `v0.75.2..v0.75.3`.
 
 ### Bug Fixes
 
 - session expiry, hooks config, dead-memory API, openclaw health (#295)
 
+## [0.75.2] - 2026-03-24
 
-## [0.75.1] - 2026-03-24
+Release summary: 1 bug fix.
+Tag range: `v0.75.1..v0.75.2`.
 
 ### Bug Fixes
 
 - **daemon**: graceful SIGTERM shutdown (#307)
 
+## [0.75.1] - 2026-03-24
 
-## [0.75.0] - 2026-03-24
+Release summary: 1 bug fix and 1 docs update.
+Tag range: `v0.75.0..v0.75.1`.
 
 ### Bug Fixes
 
@@ -634,22 +908,28 @@ All notable changes to Signet are documented here.
 
 - competitive systems research — 3-repo analysis with integration contracts (#309)
 
+## [0.75.0] - 2026-03-23
 
-## [0.74.1] - 2026-03-23
+Release summary: 1 feature.
+Tag range: `v0.74.1..v0.75.0`.
 
 ### Features
 
 - **cli**: add configurable Signet workspace path + migration (#302)
 
+## [0.74.1] - 2026-03-23
 
-## [0.74.0] - 2026-03-23
+Release summary: 1 bug fix.
+Tag range: `v0.74.0..v0.74.1`.
 
 ### Bug Fixes
 
 - **dashboard**: remove review-queue tab; fix knowledge tab load performance (#305)
 
+## [0.74.0] - 2026-03-23
 
-## [0.73.8] - 2026-03-23
+Release summary: 1 feature and 1 bug fix.
+Tag range: `v0.73.8..v0.74.0`.
 
 ### Features
 
@@ -659,276 +939,382 @@ All notable changes to Signet are documented here.
 
 - support provider: none for extraction and synthesis (#301)
 
+## [0.73.8] - 2026-03-23
 
-## [0.73.7] - 2026-03-23
+Release summary: 1 bug fix.
+Tag range: `v0.73.7..v0.73.8`.
 
 ### Bug Fixes
 
 - March 2026 codebase review (#294)
 
+## [0.73.7] - 2026-03-23
 
-## [0.73.6] - 2026-03-23
+Release summary: 1 bug fix.
+Tag range: `v0.73.6..v0.73.7`.
 
 ### Bug Fixes
 
 - wire marketplace reviews sync to production Worker endpoint (#293)
 
+## [0.73.6] - 2026-03-23
 
-## [0.73.4] - 2026-03-23
+Release summary: internal maintenance release with no conventional commit entries captured.
+Tag range: `v0.73.5..v0.73.6`.
+
+No notable changes were captured from conventional commit subjects for this release.
+
+## [0.73.5] - 2026-03-23
+
+Release summary: 1 bug fix.
+Tag range: `v0.73.4..v0.73.5`.
 
 ### Bug Fixes
 
 - 5 critical memory and injection stability fixes (#291)
 
+## [0.73.4] - 2026-03-23
 
-## [0.73.3] - 2026-03-23
+Release summary: 1 bug fix.
+Tag range: `v0.73.3..v0.73.4`.
 
 ### Bug Fixes
 
 - **daemon**: align embedding-tracker hash with normalizeAndHashContent (#286)
 
+## [0.73.3] - 2026-03-23
 
-## [0.73.2] - 2026-03-23
+Release summary: 1 bug fix.
+Tag range: `v0.73.2..v0.73.3`.
 
 ### Bug Fixes
 
 - normalize remember tags across daemon and openclaw (#285)
 
+## [0.73.2] - 2026-03-22
 
-## [0.73.1] - 2026-03-22
+Release summary: 1 bug fix.
+Tag range: `v0.73.1..v0.73.2`.
 
 ### Bug Fixes
 
 - **daemon**: normalize Claude Code transcript records (#284)
 
+## [0.73.1] - 2026-03-22
 
-## [0.73.0] - 2026-03-22
+Release summary: 1 bug fix.
+Tag range: `v0.73.0..v0.73.1`.
 
 ### Bug Fixes
 
 - task run output display — stdin close, chunk normalization, terminal rendering (#283)
 
+## [0.73.0] - 2026-03-22
 
-## [0.72.8] - 2026-03-22
+Release summary: 1 feature.
+Tag range: `v0.72.8..v0.73.0`.
 
 ### Features
 
 - desire paths retrieval + prospective indexing (#253)
 
+## [0.72.8] - 2026-03-22
 
-## [0.72.7] - 2026-03-22
+Release summary: 2 bug fixes.
+Tag range: `v0.72.7..v0.72.8`.
 
 ### Bug Fixes
 
 - **dashboard**: replace @signet/core runtime import with local constant
 - **openclaw**: dedupe marketplace proxy refresh (#281)
 
+## [0.72.7] - 2026-03-22
 
-## [0.72.6] - 2026-03-22
+Release summary: 1 bug fix.
+Tag range: `v0.72.6..v0.72.7`.
 
 ### Bug Fixes
 
 - security hardening — auth timing, SSRF, YAML injection, scope enforcement (#276)
 
+## [0.72.6] - 2026-03-22
 
-## [0.72.5] - 2026-03-22
+Release summary: 1 bug fix.
+Tag range: `v0.72.5..v0.72.6`.
 
 ### Bug Fixes
 
 - address 9 security and stability issues (#275)
 
+## [0.72.5] - 2026-03-22
 
-## [0.72.4] - 2026-03-22
+Release summary: 1 bug fix.
+Tag range: `v0.72.4..v0.72.5`.
 
 ### Bug Fixes
 
 - resolve daemon path in published bundle (#274)
 
+## [0.72.4] - 2026-03-22
 
-## [0.72.2] - 2026-03-22
+Release summary: internal maintenance release with no conventional commit entries captured.
+Tag range: `v0.72.3..v0.72.4`.
+
+No notable changes were captured from conventional commit subjects for this release.
+
+## [0.72.3] - 2026-03-22
+
+Release summary: 1 bug fix.
+Tag range: `v0.72.2..v0.72.3`.
 
 ### Bug Fixes
 
 - comprehensive security audit hardening (#271)
 
+## [0.72.2] - 2026-03-22
 
-## [0.72.1] - 2026-03-22
+Release summary: 2 bug fixes.
+Tag range: `v0.72.1..v0.72.2`.
 
 ### Bug Fixes
 
 - harden error handling and resource cleanup (#272)
 - codex MCP config uses string command, not array (#273)
 
+## [0.72.1] - 2026-03-22
 
-## [0.71.6] - 2026-03-22
+Release summary: internal maintenance release with no conventional commit entries captured.
+Tag range: `v0.72.0..v0.72.1`.
+
+No notable changes were captured from conventional commit subjects for this release.
+
+## [0.72.0] - 2026-03-22
+
+Release summary: 1 feature.
+Tag range: `v0.71.6..v0.72.0`.
 
 ### Features
 
 - **os**: Visual GUI Agent — Page-Agent Integration (#266)
 
+## [0.71.6] - 2026-03-21
 
-## [0.71.5] - 2026-03-21
+Release summary: 1 bug fix.
+Tag range: `v0.71.5..v0.71.6`.
 
 ### Bug Fixes
 
 - **troubleshooter**: handle daemon stop/restart lifecycle commands (#265)
 
+## [0.71.5] - 2026-03-21
 
-## [0.71.4] - 2026-03-21
+Release summary: 1 bug fix.
+Tag range: `v0.71.4..v0.71.5`.
 
 ### Bug Fixes
 
 - **tray**: add icon.ico for Windows build (#263)
 
+## [0.71.4] - 2026-03-21
 
-## [0.71.3] - 2026-03-21
+Release summary: 1 bug fix.
+Tag range: `v0.71.3..v0.71.4`.
 
 ### Bug Fixes
 
 - **tray**: cross-platform build script for Windows CI (#262)
 
+## [0.71.3] - 2026-03-21
 
-## [0.71.2] - 2026-03-21
+Release summary: 1 bug fix.
+Tag range: `v0.71.2..v0.71.3`.
 
 ### Bug Fixes
 
 - **tray**: restore npm tauri CLI + convert icons to RGBA (#261)
 
+## [0.71.2] - 2026-03-21
 
-## [0.71.1] - 2026-03-21
+Release summary: 1 bug fix.
+Tag range: `v0.71.1..v0.71.2`.
 
 ### Bug Fixes
 
 - pipeline worker stall after burst processing (#259)
 
+## [0.71.1] - 2026-03-21
 
-## [0.71.0] - 2026-03-21
+Release summary: 1 bug fix.
+Tag range: `v0.71.0..v0.71.1`.
 
 ### Bug Fixes
 
 - **tray**: revert to cargo tauri CLI, convert icons to RGBA (#260)
 
+## [0.71.0] - 2026-03-21
 
-## [0.70.0] - 2026-03-21
+Release summary: 1 feature.
+Tag range: `v0.70.0..v0.71.0`.
 
 ### Features
 
 - **connector-codex**: native hooks + MCP for full mid-session memory (#258)
 
+## [0.70.0] - 2026-03-21
 
-## [0.69.5] - 2026-03-21
+Release summary: 1 feature.
+Tag range: `v0.69.5..v0.70.0`.
 
 ### Features
 
 - **dashboard**: Cortex page — unified Memory, Apps, Tasks, Troubleshooter (#256)
 
+## [0.69.5] - 2026-03-21
 
-## [0.69.3] - 2026-03-21
+Release summary: internal maintenance release with no conventional commit entries captured.
+Tag range: `v0.69.4..v0.69.5`.
+
+No notable changes were captured from conventional commit subjects for this release.
+
+## [0.69.4] - 2026-03-21
+
+Release summary: 1 bug fix.
+Tag range: `v0.69.3..v0.69.4`.
 
 ### Bug Fixes
 
 - use npm tauri CLI instead of cargo plugin in tray scripts (#254)
 
+## [0.69.3] - 2026-03-20
 
-## [0.69.2] - 2026-03-20
+Release summary: 1 bug fix.
+Tag range: `v0.69.2..v0.69.3`.
 
 ### Bug Fixes
 
 - install tray deps explicitly in desktop build workflow
 
+## [0.69.2] - 2026-03-20
 
-## [0.69.1] - 2026-03-20
+Release summary: 1 bug fix.
+Tag range: `v0.69.1..v0.69.2`.
 
 ### Bug Fixes
 
 - use RELEASE_PAT in release workflow for branch protection bypass
 
+## [0.69.1] - 2026-03-20
 
-## [0.69.0] - 2026-03-20
+Release summary: 1 bug fix.
+Tag range: `v0.69.0..v0.69.1`.
 
 ### Bug Fixes
 
 - use local timezone for timeline Today boundaries (#252)
 
+## [0.69.0] - 2026-03-20
 
-## [0.68.3] - 2026-03-20
+Release summary: 1 feature.
+Tag range: `v0.68.3..v0.69.0`.
 
 ### Features
 
 - homepage spotlights, dynamic insights, and health consistency (#250)
 
+## [0.68.3] - 2026-03-20
 
-## [0.68.2] - 2026-03-20
+Release summary: 1 bug fix.
+Tag range: `v0.68.2..v0.68.3`.
 
 ### Bug Fixes
 
 - settings persist across refresh without daemon restart (#251)
 
+## [0.68.2] - 2026-03-20
 
-## [0.68.1] - 2026-03-20
+Release summary: 1 bug fix.
+Tag range: `v0.68.1..v0.68.2`.
 
 ### Bug Fixes
 
 - remove provider icon tinting and auto-sync pre-installed apps (#249)
 
+## [0.68.1] - 2026-03-20
 
-## [0.68.0] - 2026-03-20
+Release summary: 1 bug fix.
+Tag range: `v0.68.0..v0.68.1`.
 
 ### Bug Fixes
 
 - prevent CMD window flashing on Windows and fix workspace path matching (#247)
 
+## [0.68.0] - 2026-03-20
 
-## [0.67.0] - 2026-03-20
+Release summary: 1 feature.
+Tag range: `v0.67.0..v0.68.0`.
 
 ### Features
 
 - Signet OS v2 — sandboxed widget rendering, LLM auto-generation, MCP app dashboard
 
+## [0.67.0] - 2026-03-19
 
-## [0.66.1] - 2026-03-19
+Release summary: 1 feature.
+Tag range: `v0.66.1..v0.67.0`.
 
 ### Features
 
 - add scope column for memory isolation (#245)
 
+## [0.66.1] - 2026-03-19
 
-## [0.66.0] - 2026-03-19
+Release summary: 1 bug fix.
+Tag range: `v0.66.0..v0.66.1`.
 
 ### Bug Fixes
 
 - **openclaw**: harden plugin sync and patch plugins.allow (#246)
 
+## [0.66.0] - 2026-03-19
 
-## [0.65.9] - 2026-03-19
+Release summary: 1 feature.
+Tag range: `v0.65.9..v0.66.0`.
 
 ### Features
 
 - retroactive memory supersession (#244)
 
+## [0.65.9] - 2026-03-19
 
-## [0.65.8] - 2026-03-19
+Release summary: 1 bug fix.
+Tag range: `v0.65.8..v0.65.9`.
 
 ### Bug Fixes
 
 - MCP stdio server process leak on session end (#243)
 
+## [0.65.8] - 2026-03-19
 
-## [0.65.7] - 2026-03-19
+Release summary: 1 bug fix.
+Tag range: `v0.65.7..v0.65.8`.
 
 ### Bug Fixes
 
 - add missing --project option to pre-compaction hook (#242)
 
+## [0.65.7] - 2026-03-19
 
-## [0.65.6] - 2026-03-19
+Release summary: 1 bug fix.
+Tag range: `v0.65.6..v0.65.7`.
 
 ### Bug Fixes
 
 - prevent CMD window flashing and fix workspace path matching on Windows (#241)
 
+## [0.65.6] - 2026-03-19
 
-## [0.65.5] - 2026-03-19
+Release summary: 1 bug fix and 1 docs update.
+Tag range: `v0.65.5..v0.65.6`.
 
 ### Bug Fixes
 
@@ -938,29 +1324,37 @@ All notable changes to Signet are documented here.
 
 - add BusyBee3333, stephenwoska2-cpu, and PatchyToes to contributors (#240)
 
+## [0.65.5] - 2026-03-19
 
-## [0.65.4] - 2026-03-19
+Release summary: 1 bug fix.
+Tag range: `v0.65.4..v0.65.5`.
 
 ### Bug Fixes
 
 - use bash shell for cargo build steps on Windows runners (#239)
 
+## [0.65.4] - 2026-03-19
 
-## [0.65.3] - 2026-03-19
+Release summary: 1 bug fix.
+Tag range: `v0.65.3..v0.65.4`.
 
 ### Bug Fixes
 
 - move @signet/core to devDependencies in openclaw plugin (#237)
 
+## [0.65.3] - 2026-03-19
 
-## [0.65.2] - 2026-03-19
+Release summary: 1 bug fix.
+Tag range: `v0.65.2..v0.65.3`.
 
 ### Bug Fixes
 
 - predictor sidecar binary distribution for Windows (#236)
 
+## [0.65.2] - 2026-03-19
 
-## [0.65.1] - 2026-03-19
+Release summary: 4 bug fixes.
+Tag range: `v0.65.1..v0.65.2`.
 
 ### Bug Fixes
 
@@ -969,15 +1363,26 @@ All notable changes to Signet are documented here.
 - add migration for missing embeddings.vector column on older DBs
 - release pipeline — skip workspace-inherited Cargo versions and clobber duplicate assets
 
+## [0.65.1] - 2026-03-19
 
-## [0.64.0] - 2026-03-19
+Release summary: internal maintenance release with no conventional commit entries captured.
+Tag range: `v0.65.0..v0.65.1`.
+
+No notable changes were captured from conventional commit subjects for this release.
+
+## [0.65.0] - 2026-03-19
+
+Release summary: 1 feature.
+Tag range: `v0.64.0..v0.65.0`.
 
 ### Features
 
 - Signet OS — browser, MCP app dashboard, event bus, ambient awareness
 
+## [0.64.0] - 2026-03-19
 
-## [0.63.3] - 2026-03-19
+Release summary: 1 feature, 6 bug fixes, and 3 docs updates.
+Tag range: `v0.63.3..v0.64.0`.
 
 ### Features
 
@@ -998,8 +1403,10 @@ All notable changes to Signet are documented here.
 - refactor README and add Why Signet to quickstart
 - add AI policy, PR template, and GitHub Discussions setup
 
+## [0.63.3] - 2026-03-18
 
-## [0.63.2] - 2026-03-18
+Release summary: 4 bug fixes.
+Tag range: `v0.63.2..v0.63.3`.
 
 ### Bug Fixes
 
@@ -1008,22 +1415,28 @@ All notable changes to Signet are documented here.
 - address review — document spawnHidden throw safety, clarify Bun.which calls
 - resolve CLI binary paths on Windows for extraction/synthesis providers
 
+## [0.63.2] - 2026-03-18
 
-## [0.63.1] - 2026-03-18
+Release summary: 1 bug fix.
+Tag range: `v0.63.1..v0.63.2`.
 
 ### Bug Fixes
 
 - add sharp to optionalDependencies for Windows ARM64 support
 
+## [0.63.1] - 2026-03-18
 
-## [0.63.0] - 2026-03-18
+Release summary: 1 refactor.
+Tag range: `v0.63.0..v0.63.1`.
 
 ### Refactoring
 
 - **docs**: organize docs into research-to-implementation pipeline
 
+## [0.63.0] - 2026-03-18
 
-## [0.62.0] - 2026-03-18
+Release summary: 1 feature and 3 bug fixes.
+Tag range: `v0.62.0..v0.63.0`.
 
 ### Features
 
@@ -1035,8 +1448,10 @@ All notable changes to Signet are documented here.
 - **sync**: harden runtime artifact sync and warmup
 - **sync**: move runtime downloads from postinstall to signet sync
 
+## [0.62.0] - 2026-03-18
 
-## [0.61.0] - 2026-03-18
+Release summary: 3 features and 5 bug fixes.
+Tag range: `v0.61.0..v0.62.0`.
 
 ### Features
 
@@ -1052,8 +1467,10 @@ All notable changes to Signet are documented here.
 - **daemon-rs**: address round-2 review feedback
 - **daemon-rs**: address code review feedback
 
+## [0.61.0] - 2026-03-18
 
-## [0.60.1] - 2026-03-18
+Release summary: 1 feature and 1 bug fix.
+Tag range: `v0.60.1..v0.61.0`.
 
 ### Features
 
@@ -1063,15 +1480,19 @@ All notable changes to Signet are documented here.
 
 - **memory**: address openrouter review feedback
 
+## [0.60.1] - 2026-03-18
 
-## [0.60.0] - 2026-03-18
+Release summary: 1 bug fix.
+Tag range: `v0.60.0..v0.60.1`.
 
 ### Bug Fixes
 
 - vec_embeddings backfill race — use direct LEFT JOIN instead of count comparison
 
+## [0.60.0] - 2026-03-18
 
-## [0.59.0] - 2026-03-18
+Release summary: 2 features and 2 bug fixes.
+Tag range: `v0.59.0..v0.60.0`.
 
 ### Features
 
@@ -1083,8 +1504,10 @@ All notable changes to Signet are documented here.
 - eliminate budget duplication, fix CLI JSON shape (PR review)
 - fall back to static identity files when daemon is unreachable (#219)
 
+## [0.59.0] - 2026-03-17
 
-## [0.58.3] - 2026-03-17
+Release summary: 2 features and 12 bug fixes.
+Tag range: `v0.58.3..v0.59.0`.
 
 ### Features
 
@@ -1106,8 +1529,10 @@ All notable changes to Signet are documented here.
 - guard upsert pair with try/catch, cap aspect name length
 - derive prompt types from DEPENDENCY_TYPES, thread aspectId
 
+## [0.58.3] - 2026-03-16
 
-## [0.58.2] - 2026-03-16
+Release summary: 3 bug fixes.
+Tag range: `v0.58.2..v0.58.3`.
 
 ### Bug Fixes
 
@@ -1115,8 +1540,10 @@ All notable changes to Signet are documented here.
 - address review — widen locale regex, use locale-prefixed detail URLs
 - MCP catalog parser — third-party section boundary and mcpservers.org locale
 
+## [0.58.2] - 2026-03-15
 
-## [0.58.1] - 2026-03-15
+Release summary: 19 bug fixes and 1 refactor.
+Tag range: `v0.58.1..v0.58.2`.
 
 ### Bug Fixes
 
@@ -1144,8 +1571,10 @@ All notable changes to Signet are documented here.
 
 - extract shared card utils, tighten github validation, add docs
 
+## [0.58.1] - 2026-03-14
 
-## [0.58.0] - 2026-03-14
+Release summary: 20 bug fixes.
+Tag range: `v0.58.0..v0.58.1`.
 
 ### Bug Fixes
 
@@ -1170,8 +1599,10 @@ All notable changes to Signet are documented here.
 - address PR review feedback on sheet width and timeline overflow
 - dashboard UI improvements — mobile sidebar, banner spacing, and QOS
 
+## [0.58.0] - 2026-03-14
 
-## [0.57.1] - 2026-03-14
+Release summary: 2 features and 26 bug fixes.
+Tag range: `v0.57.1..v0.58.0`.
 
 ### Features
 
@@ -1207,16 +1638,20 @@ All notable changes to Signet are documented here.
 - auto-detect git sync branch instead of hardcoding "main"
 - **daemon**: sanitize session transcripts and remove truncation
 
+## [0.57.1] - 2026-03-14
 
-## [0.57.0] - 2026-03-14
+Release summary: 2 bug fixes.
+Tag range: `v0.57.0..v0.57.1`.
 
 ### Bug Fixes
 
 - address PR review feedback on migration 030
 - make memory_jobs.memory_id nullable for document ingest jobs
 
+## [0.57.0] - 2026-03-14
 
-## [0.56.2] - 2026-03-14
+Release summary: 1 feature and 2 docs updates.
+Tag range: `v0.56.2..v0.57.0`.
 
 ### Features
 
@@ -1227,8 +1662,10 @@ All notable changes to Signet are documented here.
 - add dashboard and constellation screenshots to README
 - refactor AGENTS.md into behavioral contract with backlinks
 
+## [0.56.2] - 2026-03-14
 
-## [0.56.1] - 2026-03-14
+Release summary: 11 bug fixes.
+Tag range: `v0.56.1..v0.56.2`.
 
 ### Bug Fixes
 
@@ -1244,16 +1681,20 @@ All notable changes to Signet are documented here.
 - **migrations**: address review feedback on PR #199
 - **migrations**: self-heal phantom migrations with artifact verification
 
+## [0.56.1] - 2026-03-14
 
-## [0.56.0] - 2026-03-14
+Release summary: 2 bug fixes.
+Tag range: `v0.56.0..v0.56.1`.
 
 ### Bug Fixes
 
 - **daemon**: harden ollama fallback max-context validation
 - **daemon**: remove hardcoded qwen fallback model
 
+## [0.56.0] - 2026-03-12
 
-## [0.55.0] - 2026-03-12
+Release summary: 1 feature, 5 bug fixes, and 1 performance improvement.
+Tag range: `v0.55.0..v0.56.0`.
 
 ### Features
 
@@ -1271,8 +1712,10 @@ All notable changes to Signet are documented here.
 
 - replace polling with onResized event listener in WindowTitlebar
 
+## [0.55.0] - 2026-03-12
 
-## [0.54.2] - 2026-03-12
+Release summary: 1 feature, 5 bug fixes, and 3 docs updates.
+Tag range: `v0.54.2..v0.55.0`.
 
 ### Features
 
@@ -1292,8 +1735,10 @@ All notable changes to Signet are documented here.
 - update RESEARCH-LCM-ACP.md frontmatter
 - add GitNexus pattern analysis and integrate into architecture docs
 
+## [0.54.2] - 2026-03-11
 
-## [0.54.1] - 2026-03-11
+Release summary: 3 bug fixes.
+Tag range: `v0.54.1..v0.54.2`.
 
 ### Bug Fixes
 
@@ -1301,15 +1746,19 @@ All notable changes to Signet are documented here.
 - address review feedback on contradiction timeout PR
 - make semantic contradiction timeout configurable
 
+## [0.54.1] - 2026-03-11
 
-## [0.54.0] - 2026-03-11
+Release summary: 1 bug fix.
+Tag range: `v0.54.0..v0.54.1`.
 
 ### Bug Fixes
 
 - enable positional options on secret command to prevent CLI crash
 
+## [0.54.0] - 2026-03-11
 
-## [0.53.4] - 2026-03-11
+Release summary: 1 feature and 21 bug fixes.
+Tag range: `v0.53.4..v0.54.0`.
 
 ### Features
 
@@ -1339,8 +1788,10 @@ All notable changes to Signet are documented here.
 - variadic exec args, null exit code, document secrets map
 - address review — add ok check in secret get, extend exec timeout
 
+## [0.53.4] - 2026-03-10
 
-## [0.53.3] - 2026-03-10
+Release summary: 6 bug fixes.
+Tag range: `v0.53.3..v0.53.4`.
 
 ### Bug Fixes
 
@@ -1351,8 +1802,10 @@ All notable changes to Signet are documented here.
 - **daemon**: address PR review regressions and doc gaps
 - **daemon**: harden VPS runtime config and pipeline behavior
 
+## [0.53.3] - 2026-03-10
 
-## [0.53.2] - 2026-03-10
+Release summary: 21 bug fixes.
+Tag range: `v0.53.2..v0.53.3`.
 
 ### Bug Fixes
 
@@ -1378,8 +1831,10 @@ All notable changes to Signet are documented here.
 - address reviewer feedback on Anthropic provider and subprocess handling
 - replace node:child_process with Bun.spawn for reliable subprocess I/O
 
+## [0.53.2] - 2026-03-10
 
-## [0.53.1] - 2026-03-10
+Release summary: 16 bug fixes.
+Tag range: `v0.53.1..v0.53.2`.
 
 ### Bug Fixes
 
@@ -1400,8 +1855,10 @@ All notable changes to Signet are documented here.
 - **pipeline**: address PR #180 review comments
 - **pipeline**: config resolution pairing, codex error capture, DAG upsert
 
+## [0.53.1] - 2026-03-09
 
-## [0.53.0] - 2026-03-09
+Release summary: 3 bug fixes.
+Tag range: `v0.53.0..v0.53.1`.
 
 ### Bug Fixes
 
@@ -1409,8 +1866,10 @@ All notable changes to Signet are documented here.
 - **sdk**: strict typescript discipline - remove unsafe casts, add type guards, discriminated unions
 - **sdk**: align sdk contracts with daemon responses
 
+## [0.53.0] - 2026-03-09
 
-## [0.52.0] - 2026-03-09
+Release summary: 1 feature and 6 bug fixes.
+Tag range: `v0.52.0..v0.53.0`.
 
 ### Features
 
@@ -1425,8 +1884,10 @@ All notable changes to Signet are documented here.
 - **lcm**: address greptile pass-2 findings
 - address Greptile review findings
 
+## [0.52.0] - 2026-03-09
 
-## [0.51.0] - 2026-03-09
+Release summary: 1 feature and 2 bug fixes.
+Tag range: `v0.51.0..v0.52.0`.
 
 ### Features
 
@@ -1437,8 +1898,10 @@ All notable changes to Signet are documented here.
 - address review feedback on prompt-submit hook
 - cap pendingInject map to prevent unbounded growth
 
+## [0.51.0] - 2026-03-09
 
-## [0.50.1] - 2026-03-09
+Release summary: 2 features and 2 bug fixes.
+Tag range: `v0.50.1..v0.51.0`.
 
 ### Features
 
@@ -1450,16 +1913,20 @@ All notable changes to Signet are documented here.
 - **tray**: address PR #172 round 2 feedback
 - **tray**: address PR #172 review feedback
 
+## [0.50.1] - 2026-03-09
 
-## [0.50.0] - 2026-03-09
+Release summary: 2 bug fixes.
+Tag range: `v0.50.0..v0.50.1`.
 
 ### Bug Fixes
 
 - match toCanonicalName() whitespace collapse in migration 027
 - resolve UNIQUE constraint crash in skill reconciler
 
+## [0.50.0] - 2026-03-09
 
-## [0.49.0] - 2026-03-09
+Release summary: 1 feature and 1 bug fix.
+Tag range: `v0.49.0..v0.50.0`.
 
 ### Features
 
@@ -1469,15 +1936,19 @@ All notable changes to Signet are documented here.
 
 - **native**: address Greptile review — epsilon parity and dead export TODO
 
+## [0.49.0] - 2026-03-09
 
-## [0.48.2] - 2026-03-09
+Release summary: 1 feature.
+Tag range: `v0.48.2..v0.49.0`.
 
 ### Features
 
 - inject date/time metadata on every user-prompt-submit hook
 
+## [0.48.2] - 2026-03-09
 
-## [0.48.1] - 2026-03-09
+Release summary: 3 bug fixes and 1 docs update.
+Tag range: `v0.48.1..v0.48.2`.
 
 ### Bug Fixes
 
@@ -1489,15 +1960,19 @@ All notable changes to Signet are documented here.
 
 - research docs, LCM patterns spec, ACP integration vision, README rewrite
 
+## [0.48.1] - 2026-03-09
 
-## [0.48.0] - 2026-03-09
+Release summary: 1 bug fix.
+Tag range: `v0.48.0..v0.48.1`.
 
 ### Bug Fixes
 
 - **dashboard**: center PageBanner title on pages without side slots (#170)
 
+## [0.48.0] - 2026-03-09
 
-## [0.47.2] - 2026-03-09
+Release summary: 1 feature, 5 bug fixes, and 1 docs update.
+Tag range: `v0.47.2..v0.48.0`.
 
 ### Features
 
@@ -1515,8 +1990,10 @@ All notable changes to Signet are documented here.
 
 - add PR screenshots for theme refresh
 
+## [0.47.2] - 2026-03-09
 
-## [0.47.1] - 2026-03-09
+Release summary: 5 bug fixes.
+Tag range: `v0.47.1..v0.47.2`.
 
 ### Bug Fixes
 
@@ -1526,15 +2003,19 @@ All notable changes to Signet are documented here.
 - **openclaw**: address PR review edge cases
 - **openclaw**: sync connector and adapter compatibility
 
+## [0.47.1] - 2026-03-08
 
-## [0.47.0] - 2026-03-08
+Release summary: 1 bug fix.
+Tag range: `v0.47.0..v0.47.1`.
 
 ### Bug Fixes
 
 - **mcp**: flatten agent_message_send schema and clarify agent_peers description
 
+## [0.47.0] - 2026-03-08
 
-## [0.46.0] - 2026-03-08
+Release summary: 1 feature, 4 bug fixes, and 2 docs updates.
+Tag range: `v0.46.0..v0.47.0`.
 
 ### Features
 
@@ -1552,8 +2033,10 @@ All notable changes to Signet are documented here.
 - add bypass toggle to API, CLI, hooks, MCP, and dashboard docs
 - add bypass toggle to API endpoints, env vars, and CLI docs
 
+## [0.46.0] - 2026-03-08
 
-## [0.45.2] - 2026-03-08
+Release summary: 1 feature and 3 bug fixes.
+Tag range: `v0.45.2..v0.46.0`.
 
 ### Features
 
@@ -1565,8 +2048,10 @@ All notable changes to Signet are documented here.
 - **daemon**: harden cross-agent prompt and routing safety
 - **daemon**: harden cross-agent auth and ACP relay
 
+## [0.45.2] - 2026-03-08
 
-## [0.45.1] - 2026-03-08
+Release summary: 1 bug fix and 1 refactor.
+Tag range: `v0.45.1..v0.45.2`.
 
 ### Bug Fixes
 
@@ -1576,8 +2061,10 @@ All notable changes to Signet are documented here.
 
 - **dashboard**: decompose +page.svelte into focused layout components
 
+## [0.45.1] - 2026-03-08
 
-## [0.45.0] - 2026-03-08
+Release summary: 4 bug fixes and 2 docs updates.
+Tag range: `v0.45.0..v0.45.1`.
 
 ### Bug Fixes
 
@@ -1591,8 +2078,10 @@ All notable changes to Signet are documented here.
 - delete duplicates
 - add frontmatter to docs missing metadata
 
+## [0.45.0] - 2026-03-08
 
-## [0.44.0] - 2026-03-08
+Release summary: 8 features, 36 bug fixes, 1 refactor, and 9 docs updates.
+Tag range: `v0.44.0..v0.45.0`.
 
 ### Features
 
@@ -1660,8 +2149,10 @@ All notable changes to Signet are documented here.
 - update KA spec for agent_id scoping, add KA-1 sprint brief
 - add frontmatter to IDEAL-SIGNET.md
 
+## [0.44.0] - 2026-03-08
 
-## [0.43.1] - 2026-03-08
+Release summary: 1 feature and 13 bug fixes.
+Tag range: `v0.43.1..v0.44.0`.
 
 ### Features
 
@@ -1683,8 +2174,10 @@ All notable changes to Signet are documented here.
 - address second wave of keyboard navigation review comments
 - address all keyboard navigation review comments
 
+## [0.43.1] - 2026-03-08
 
-## [0.43.0] - 2026-03-08
+Release summary: 3 bug fixes.
+Tag range: `v0.43.0..v0.43.1`.
 
 ### Bug Fixes
 
@@ -1692,8 +2185,10 @@ All notable changes to Signet are documented here.
 - address review feedback on windows-spawn-hide PR
 - **windows**: prevent console window flashing from spawn calls
 
+## [0.43.0] - 2026-03-08
 
-## [0.42.3] - 2026-03-08
+Release summary: 1 feature, 6 bug fixes, and 1 docs update.
+Tag range: `v0.42.3..v0.43.0`.
 
 ### Features
 
@@ -1712,15 +2207,19 @@ All notable changes to Signet are documented here.
 
 - **synthesis**: document drain() precondition on SynthesisWorkerHandle
 
+## [0.42.3] - 2026-03-06
 
-## [0.42.2] - 2026-03-06
+Release summary: 1 bug fix.
+Tag range: `v0.42.2..v0.42.3`.
 
 ### Bug Fixes
 
 - **codex**: address post-merge Greptile follow-ups (#153)
 
+## [0.42.2] - 2026-03-06
 
-## [0.42.1] - 2026-03-06
+Release summary: 4 bug fixes.
+Tag range: `v0.42.1..v0.42.2`.
 
 ### Bug Fixes
 
@@ -1729,8 +2228,10 @@ All notable changes to Signet are documented here.
 - **daemon**: use hybrid recall for prompt submit
 - **openclaw**: clean recall queries and refresh plugin runtime
 
+## [0.42.1] - 2026-03-06
 
-## [0.42.0] - 2026-03-06
+Release summary: 3 bug fixes.
+Tag range: `v0.42.0..v0.42.1`.
 
 ### Bug Fixes
 
@@ -1738,8 +2239,10 @@ All notable changes to Signet are documented here.
 - **synthesis**: filter session files by mtime for incremental merges
 - **synthesis**: read session summaries instead of raw DB facts
 
+## [0.42.0] - 2026-03-06
 
-## [0.41.0] - 2026-03-06
+Release summary: 1 feature, 4 bug fixes, and 1 docs update.
+Tag range: `v0.41.0..v0.42.0`.
 
 ### Features
 
@@ -1756,8 +2259,10 @@ All notable changes to Signet are documented here.
 
 - remediate P0/P1 drift from audit (2026-03)
 
+## [0.41.0] - 2026-03-06
 
-## [0.40.0] - 2026-03-06
+Release summary: 1 feature and 8 bug fixes.
+Tag range: `v0.40.0..v0.41.0`.
 
 ### Features
 
@@ -1774,8 +2279,10 @@ All notable changes to Signet are documented here.
 - **connectors**: harden wrapper payload handling
 - **codex**: address review feedback
 
+## [0.40.0] - 2026-03-06
 
-## [0.39.0] - 2026-03-06
+Release summary: 3 features and 9 bug fixes.
+Tag range: `v0.39.0..v0.40.0`.
 
 ### Features
 
@@ -1795,8 +2302,10 @@ All notable changes to Signet are documented here.
 - prevent rapid retry on synthesis failure, export PipelineSynthesisConfig
 - address greptile review — race guard and maxTokens in prompt
 
+## [0.39.0] - 2026-03-06
 
-## [0.38.6] - 2026-03-06
+Release summary: 2 features, 40 bug fixes, and 1 performance improvement.
+Tag range: `v0.38.6..v0.39.0`.
 
 ### Features
 
@@ -1850,15 +2359,19 @@ All notable changes to Signet are documented here.
 
 - hoist prepared statements and batch trackFtsHits
 
+## [0.38.6] - 2026-03-05
 
-## [0.38.5] - 2026-03-05
+Release summary: 1 bug fix.
+Tag range: `v0.38.5..v0.38.6`.
 
 ### Bug Fixes
 
 - **daemon**: harden SIGNET-ARCHITECTURE.md persistence (#137)
 
+## [0.38.5] - 2026-03-05
 
-## [0.38.4] - 2026-03-05
+Release summary: 3 bug fixes.
+Tag range: `v0.38.4..v0.38.5`.
 
 ### Bug Fixes
 
@@ -1866,8 +2379,10 @@ All notable changes to Signet are documented here.
 - **logs**: close stream edge cases and recent-read gaps
 - **logs**: ship refreshed UI with hardened stream behavior
 
+## [0.38.4] - 2026-03-05
 
-## [0.38.3] - 2026-03-05
+Release summary: 3 bug fixes.
+Tag range: `v0.38.3..v0.38.4`.
 
 ### Bug Fixes
 
@@ -1875,36 +2390,46 @@ All notable changes to Signet are documented here.
 - handle ollama base_url nullish defaulting consistently
 - default ollama embedding base_url to localhost:11434
 
+## [0.38.3] - 2026-03-04
 
-## [0.38.2] - 2026-03-04
+Release summary: 1 bug fix.
+Tag range: `v0.38.2..v0.38.3`.
 
 ### Bug Fixes
 
 - **daemon**: bump extraction timeout default from 45s to 90s
 
+## [0.38.2] - 2026-03-04
 
-## [0.38.1] - 2026-03-04
+Release summary: 1 bug fix.
+Tag range: `v0.38.1..v0.38.2`.
 
 ### Bug Fixes
 
 - **daemon**: replace `as Error` casts with proper narrowing in db-accessor
 
+## [0.38.1] - 2026-03-04
 
-## [0.38.0] - 2026-03-04
+Release summary: 1 bug fix.
+Tag range: `v0.38.0..v0.38.1`.
 
 ### Bug Fixes
 
 - **daemon**: replace self-fetch in search endpoint, add vec0 error logging
 
+## [0.38.0] - 2026-03-04
 
-## [0.37.2] - 2026-03-04
+Release summary: 1 feature.
+Tag range: `v0.37.2..v0.38.0`.
 
 ### Features
 
 - prompt to restart OpenClaw after daemon restart
 
+## [0.37.2] - 2026-03-04
 
-## [0.37.1] - 2026-03-04
+Release summary: 1 bug fix and 3 docs updates.
+Tag range: `v0.37.1..v0.37.2`.
 
 ### Bug Fixes
 
@@ -1916,16 +2441,20 @@ All notable changes to Signet are documented here.
 - the ideal signet
 - reorganize specs, add integration contract and sprint brief
 
+## [0.37.1] - 2026-03-04
 
-## [0.37.0] - 2026-03-04
+Release summary: 2 bug fixes.
+Tag range: `v0.37.0..v0.37.1`.
 
 ### Bug Fixes
 
 - replace type assertions with runtime narrowing in startConnectorSync
 - **connectors**: add harness and connector resync actions
 
+## [0.37.0] - 2026-03-04
 
-## [0.36.2] - 2026-03-04
+Release summary: 1 feature, 2 bug fixes, and 2 docs updates.
+Tag range: `v0.36.2..v0.37.0`.
 
 ### Features
 
@@ -1941,15 +2470,26 @@ All notable changes to Signet are documented here.
 - **web**: replace introducing signet blog post with architectural explainer
 - **web**: add positioning blog post and update hero copy
 
+## [0.36.2] - 2026-03-03
 
-## [0.36.0] - 2026-03-03
+Release summary: internal maintenance release with no conventional commit entries captured.
+Tag range: `v0.36.1..v0.36.2`.
+
+No notable changes were captured from conventional commit subjects for this release.
+
+## [0.36.1] - 2026-03-03
+
+Release summary: 1 docs update.
+Tag range: `v0.36.0..v0.36.1`.
 
 ### Docs
 
 - update documentation suite and add runtime spec
 
+## [0.36.0] - 2026-03-03
 
-## [0.35.4] - 2026-03-03
+Release summary: 2 features, 1 bug fix, and 1 docs update.
+Tag range: `v0.35.4..v0.36.0`.
 
 ### Features
 
@@ -1964,37 +2504,47 @@ All notable changes to Signet are documented here.
 
 - integrate addendum sections into knowledge architecture body
 
+## [0.35.4] - 2026-03-03
 
-## [0.35.3] - 2026-03-03
+Release summary: 2 bug fixes.
+Tag range: `v0.35.3..v0.35.4`.
 
 ### Bug Fixes
 
 - **embedding**: log ollama fallback failures for observability
 - **embedding**: resolve native embedding regression and restore ollama support
 
+## [0.35.3] - 2026-03-03
 
-## [0.35.2] - 2026-03-03
+Release summary: 1 bug fix.
+Tag range: `v0.35.2..v0.35.3`.
 
 ### Bug Fixes
 
 - resolve skills marketplace tab crash from duplicate each-block keys
 
+## [0.35.2] - 2026-03-03
 
-## [0.35.1] - 2026-03-03
+Release summary: 1 docs update.
+Tag range: `v0.35.1..v0.35.2`.
 
 ### Docs
 
 - update Patchy's credit link to Substack
 
+## [0.35.1] - 2026-03-03
 
-## [0.35.0] - 2026-03-03
+Release summary: 1 docs update.
+Tag range: `v0.35.0..v0.35.1`.
 
 ### Docs
 
 - add hyperlinks to author credits
 
+## [0.35.0] - 2026-03-03
 
-## [0.34.1] - 2026-03-03
+Release summary: 1 feature, 1 bug fix, and 3 docs updates.
+Tag range: `v0.34.1..v0.35.0`.
 
 ### Features
 
@@ -2010,78 +2560,100 @@ All notable changes to Signet are documented here.
 - credit Michael (PatchyToes) for entity/aspect/attribute framework contributions
 - constraint confidence, bounded context, and set-and-forget principle
 
+## [0.34.1] - 2026-03-03
 
-## [0.34.0] - 2026-03-03
+Release summary: 1 bug fix.
+Tag range: `v0.34.0..v0.34.1`.
 
 ### Bug Fixes
 
 - externalize @huggingface/transformers from bundler
 
+## [0.34.0] - 2026-03-03
 
-## [0.33.8] - 2026-03-03
+Release summary: 1 feature.
+Tag range: `v0.33.8..v0.34.0`.
 
 ### Features
 
 - **dashboard**: consolidate navigation from 10 items to 6 with grouped sub-tabs
 
+## [0.33.8] - 2026-03-03
 
-## [0.33.7] - 2026-03-03
+Release summary: 1 bug fix.
+Tag range: `v0.33.7..v0.33.8`.
 
 ### Bug Fixes
 
 - **embedding**: harden native transformers bootstrap path
 
+## [0.33.7] - 2026-03-03
 
-## [0.33.6] - 2026-03-03
+Release summary: 1 bug fix.
+Tag range: `v0.33.6..v0.33.7`.
 
 ### Bug Fixes
 
 - **daemon**: harden native embedding init for transformers exports
 
+## [0.33.6] - 2026-03-03
 
-## [0.33.5] - 2026-03-03
+Release summary: 1 bug fix.
+Tag range: `v0.33.5..v0.33.6`.
 
 ### Bug Fixes
 
 - **daemon**: alias sharp to empty shim via Bun.build() API
 
+## [0.33.5] - 2026-03-03
 
-## [0.33.4] - 2026-03-03
+Release summary: 1 bug fix.
+Tag range: `v0.33.4..v0.33.5`.
 
 ### Bug Fixes
 
 - **daemon**: externalize sharp to prevent native binary path errors
 
+## [0.33.4] - 2026-03-03
 
-## [0.33.3] - 2026-03-03
+Release summary: 1 bug fix.
+Tag range: `v0.33.3..v0.33.4`.
 
 ### Bug Fixes
 
 - **daemon**: fix native embedding init by properly externalizing onnxruntime-node
 
+## [0.33.3] - 2026-03-03
 
-## [0.33.2] - 2026-03-03
+Release summary: 1 bug fix.
+Tag range: `v0.33.2..v0.33.3`.
 
 ### Bug Fixes
 
 - **daemon**: externalize onnxruntime-node and huggingface/transformers from bundle
 
+## [0.33.2] - 2026-03-03
 
-## [0.33.1] - 2026-03-03
+Release summary: 1 bug fix.
+Tag range: `v0.33.1..v0.33.2`.
 
 ### Bug Fixes
 
 - **daemon**: lazy-load @1password/sdk to prevent WASM ENOENT crash
 
+## [0.33.1] - 2026-03-03
 
-## [0.33.0] - 2026-03-03
+Release summary: 1 bug fix.
+Tag range: `v0.33.0..v0.33.1`.
 
 ### Bug Fixes
 
 - **embeddings**: harden repair flows and surface live progress
 
+## [0.33.0] - 2026-03-03
 
-## [0.32.0] - 2026-03-03
+Release summary: 1 feature and 2 bug fixes.
+Tag range: `v0.32.0..v0.33.0`.
 
 ### Features
 
@@ -2092,8 +2664,10 @@ All notable changes to Signet are documented here.
 - **specs**: resolve package.json merge conflict cleanly
 - **daemon**: reset modelCached flag on native provider shutdown
 
+## [0.32.0] - 2026-03-03
 
-## [0.31.3] - 2026-03-03
+Release summary: 1 feature and 1 bug fix.
+Tag range: `v0.31.3..v0.32.0`.
 
 ### Features
 
@@ -2103,36 +2677,46 @@ All notable changes to Signet are documented here.
 
 - **daemon**: validate skill name against path traversal in task routes
 
+## [0.31.3] - 2026-03-03
 
-## [0.31.2] - 2026-03-03
+Release summary: 1 bug fix.
+Tag range: `v0.31.2..v0.31.3`.
 
 ### Bug Fixes
 
 - **dashboard**: persist active tab in URL hash across page refreshes
 
+## [0.31.2] - 2026-03-03
 
-## [0.31.1] - 2026-03-03
+Release summary: 1 bug fix.
+Tag range: `v0.31.1..v0.31.2`.
 
 ### Bug Fixes
 
 - dashboard config persistence, version display, auto-update self-restart, and docs cleanup
 
+## [0.31.1] - 2026-03-03
 
-## [0.31.0] - 2026-03-03
+Release summary: 1 bug fix.
+Tag range: `v0.31.0..v0.31.1`.
 
 ### Bug Fixes
 
 - **daemon**: ignore SQLite journal files in file watcher
 
+## [0.31.0] - 2026-03-03
 
-## [0.30.0] - 2026-03-03
+Release summary: 1 feature.
+Tag range: `v0.30.0..v0.31.0`.
 
 ### Features
 
 - **extension**: add browser extension for Chrome and Firefox
 
+## [0.30.0] - 2026-03-03
 
-## [0.29.0] - 2026-03-03
+Release summary: 2 features and 2 bug fixes.
+Tag range: `v0.29.0..v0.30.0`.
 
 ### Features
 
@@ -2144,15 +2728,19 @@ All notable changes to Signet are documented here.
 - **embeddings**: wire repair actions and vec resync
 - **secrets**: keep exec path non-blocking
 
+## [0.29.0] - 2026-03-03
 
-## [0.28.0] - 2026-03-03
+Release summary: 1 feature.
+Tag range: `v0.28.0..v0.29.0`.
 
 ### Features
 
 - **web**: update vision blog post - "It Learns Now"
 
+## [0.28.0] - 2026-03-03
 
-## [0.27.1] - 2026-03-03
+Release summary: 2 features, 3 bug fixes, and 1 docs update.
+Tag range: `v0.27.1..v0.28.0`.
 
 ### Features
 
@@ -2169,22 +2757,28 @@ All notable changes to Signet are documented here.
 
 - the database knows what you did last summer
 
+## [0.27.1] - 2026-03-03
 
-## [0.27.0] - 2026-03-03
+Release summary: 1 bug fix.
+Tag range: `v0.27.0..v0.27.1`.
 
 ### Bug Fixes
 
 - **daemon**: avoid marketplace MCP route shadowing
 
+## [0.27.0] - 2026-03-03
 
-## [0.26.0] - 2026-03-03
+Release summary: 1 feature.
+Tag range: `v0.26.0..v0.27.0`.
 
 ### Features
 
 - **mcp**: add scoped search-driven tool exposure
 
+## [0.26.0] - 2026-03-03
 
-## [0.25.2] - 2026-03-03
+Release summary: 1 feature, 7 bug fixes, and 1 refactor.
+Tag range: `v0.25.2..v0.26.0`.
 
 ### Features
 
@@ -2204,44 +2798,56 @@ All notable changes to Signet are documented here.
 
 - **dashboard**: polish settings page with single-section view
 
+## [0.25.2] - 2026-03-03
 
-## [0.25.1] - 2026-03-03
+Release summary: 1 bug fix.
+Tag range: `v0.25.1..v0.25.2`.
 
 ### Bug Fixes
 
 - use directory junctions on Windows for skill symlinks
 
+## [0.25.1] - 2026-03-03
 
-## [0.25.0] - 2026-03-03
+Release summary: 1 bug fix.
+Tag range: `v0.25.0..v0.25.1`.
 
 ### Bug Fixes
 
 - use file:// URL for ESM dynamic import on Windows
 
+## [0.25.0] - 2026-03-02
 
-## [0.24.0] - 2026-03-02
+Release summary: 1 feature.
+Tag range: `v0.24.0..v0.25.0`.
 
 ### Features
 
 - **mcp**: live refresh marketplace proxy tools
 
+## [0.24.0] - 2026-03-02
 
-## [0.23.0] - 2026-03-02
+Release summary: 1 feature.
+Tag range: `v0.23.0..v0.24.0`.
 
 ### Features
 
 - **dashboard**: add sync button for document connectors
 
+## [0.23.0] - 2026-03-02
 
-## [0.22.0] - 2026-03-02
+Release summary: 2 features.
+Tag range: `v0.22.0..v0.23.0`.
 
 ### Features
 
 - **dashboard**: add keyboard shortcuts for tasks tab
 - **dashboard**: add minimap for large embedding graphs
 
+## [0.22.0] - 2026-03-02
 
-## [0.21.0] - 2026-03-02
+Release summary: 1 feature and 1 performance improvement.
+Tag range: `v0.21.0..v0.22.0`.
 
 ### Features
 
@@ -2251,38 +2857,48 @@ All notable changes to Signet are documented here.
 
 - **dashboard**: lazy load EmbeddingCanvas3D and defer graph init
 
+## [0.21.0] - 2026-03-02
 
-## [0.20.2] - 2026-03-02
+Release summary: 1 feature.
+Tag range: `v0.20.2..v0.21.0`.
 
 ### Features
 
 - **marketplace**: add curated storefront and MCP server workflows
 
+## [0.20.2] - 2026-03-02
 
-## [0.20.1] - 2026-03-02
+Release summary: 1 refactor.
+Tag range: `v0.20.1..v0.20.2`.
 
 ### Refactoring
 
 - **dashboard**: add loading indicator during search debounce
 
+## [0.20.1] - 2026-03-02
 
-## [0.20.0] - 2026-03-02
+Release summary: 2 bug fixes.
+Tag range: `v0.20.0..v0.20.1`.
 
 ### Bug Fixes
 
 - **dashboard**: add keyboard navigation and delete confirmation for memory cards
 - **hooks**: sanitize per-prompt recall query context
 
+## [0.20.0] - 2026-03-02
 
-## [0.19.0] - 2026-03-02
+Release summary: 2 features.
+Tag range: `v0.19.0..v0.20.0`.
 
 ### Features
 
 - **web**: two-column blog layout with sticky TOC rail
 - **web**: improve blog readability, navigation, and add hero images
 
+## [0.19.0] - 2026-03-02
 
-## [0.18.0] - 2026-03-02
+Release summary: 1 feature and 2 bug fixes.
+Tag range: `v0.18.0..v0.19.0`.
 
 ### Features
 
@@ -2293,15 +2909,19 @@ All notable changes to Signet are documented here.
 - **dashboard**: close handleEdit brace and add error handling for edit failure
 - **dashboard**: remove as cast, properly type updates object in MemoryForm
 
+## [0.18.0] - 2026-03-02
 
-## [0.17.0] - 2026-03-02
+Release summary: 1 feature.
+Tag range: `v0.17.0..v0.18.0`.
 
 ### Features
 
 - **web**: add ChatGPT to Claude migration tutorial blog post
 
+## [0.17.0] - 2026-03-02
 
-## [0.16.0] - 2026-03-02
+Release summary: 1 feature and 2 docs updates.
+Tag range: `v0.16.0..v0.17.0`.
 
 ### Features
 
@@ -2312,8 +2932,10 @@ All notable changes to Signet are documented here.
 - update AGENTS.md
 - comprehensive audit and update for v0.14.5 codebase
 
+## [0.16.0] - 2026-03-02
 
-## [0.15.1] - 2026-03-02
+Release summary: 2 features and 1 performance improvement.
+Tag range: `v0.15.1..v0.16.0`.
 
 ### Features
 
@@ -2324,94 +2946,120 @@ All notable changes to Signet are documented here.
 
 - **dashboard**: cache skills catalog in localStorage for instant repeat loads
 
+## [0.15.1] - 2026-03-02
 
-## [0.15.0] - 2026-03-02
+Release summary: 1 bug fix.
+Tag range: `v0.15.0..v0.15.1`.
 
 ### Bug Fixes
 
 - **daemon**: use Homebrew SQLite on macOS for extension loading
 
+## [0.15.0] - 2026-03-01
 
-## [0.14.5] - 2026-03-01
+Release summary: 1 feature.
+Tag range: `v0.14.5..v0.15.0`.
 
 ### Features
 
 - **web**: add SEO and AEO infrastructure
 
+## [0.14.5] - 2026-03-01
 
-## [0.14.4] - 2026-03-01
+Release summary: 1 bug fix.
+Tag range: `v0.14.4..v0.14.5`.
 
 ### Bug Fixes
 
 - **dashboard{logs**: preserve reconnect counter across retries for correct exponential backoff (#68)
 
+## [0.14.4] - 2026-03-01
 
-## [0.14.3] - 2026-03-01
+Release summary: 1 bug fix.
+Tag range: `v0.14.3..v0.14.4`.
 
 ### Bug Fixes
 
 - **embeddings**: stabilize large constellation layouts and add physics tuning
 
+## [0.14.3] - 2026-03-01
 
-## [0.14.2] - 2026-03-01
+Release summary: 1 bug fix.
+Tag range: `v0.14.2..v0.14.3`.
 
 ### Bug Fixes
 
 - **daemon**: prevent tracker inserts from violating embeddings schema
 
+## [0.14.2] - 2026-03-01
 
-## [0.14.1] - 2026-03-01
+Release summary: 1 bug fix.
+Tag range: `v0.14.1..v0.14.2`.
 
 ### Bug Fixes
 
 - resolve embedding tracker dimensions constraint and prompt recall query issues
 
+## [0.14.1] - 2026-03-01
 
-## [0.14.0] - 2026-03-01
+Release summary: 1 bug fix.
+Tag range: `v0.14.0..v0.14.1`.
 
 ### Bug Fixes
 
 - use PreCompact hook key instead of PreCompaction for Claude Code
 
+## [0.14.0] - 2026-03-01
 
-## [0.13.0] - 2026-03-01
+Release summary: 1 feature.
+Tag range: `v0.13.0..v0.14.0`.
 
 ### Features
 
 - add incremental embedding refresh tracker
 
+## [0.13.0] - 2026-03-01
 
-## [0.12.3] - 2026-03-01
+Release summary: 2 features.
+Tag range: `v0.12.3..v0.13.0`.
 
 ### Features
 
 - pre-compaction capture + enriched passive checkpoints (Phase 2)
 - session continuity protocol (Phase 1)
 
+## [0.12.3] - 2026-03-01
 
-## [0.12.2] - 2026-03-01
+Release summary: 1 bug fix.
+Tag range: `v0.12.2..v0.12.3`.
 
 ### Bug Fixes
 
 - **daemon**: reorder secrets routes so /exec isn't swallowed by /:name
 
+## [0.12.2] - 2026-03-01
 
-## [0.12.1] - 2026-03-01
+Release summary: 1 bug fix.
+Tag range: `v0.12.1..v0.12.2`.
 
 ### Bug Fixes
 
 - **openclaw**: harden workspace path validation and add connector health visibility
 
+## [0.12.1] - 2026-03-01
 
-## [0.12.0] - 2026-03-01
+Release summary: 2 bug fixes.
+Tag range: `v0.12.0..v0.12.1`.
 
 ### Bug Fixes
 
 - **dashboard**: handle null editingId for new task creation
 - **dashboard**: prevent task form from resetting on auto-refresh
 
+## [0.12.0] - 2026-03-01
 
-## [0.11.2] - 2026-03-01
+Release summary: 5 features.
+Tag range: `v0.11.2..v0.12.0`.
 
 ### Features
 
@@ -2421,23 +3069,29 @@ All notable changes to Signet are documented here.
 - **web**: redesign landing page, add MDX testimonials, mobile optimization
 - **web**: add shadcn/ui component library with Tailwind v4
 
+## [0.11.2] - 2026-02-28
 
-## [0.11.1] - 2026-02-28
+Release summary: 1 bug fix.
+Tag range: `v0.11.1..v0.11.2`.
 
 ### Bug Fixes
 
 - **install**: harden agent setup instructions and add guard
 
+## [0.11.1] - 2026-02-28
 
-## [0.11.0] - 2026-02-28
+Release summary: 2 bug fixes.
+Tag range: `v0.11.0..v0.11.1`.
 
 ### Bug Fixes
 
 - **cli**: make logs path-aware for custom workspaces
 - **setup**: support existing OpenClaw workspace directories
 
+## [0.11.0] - 2026-02-28
 
-## [0.10.4] - 2026-02-28
+Release summary: 2 features and 5 bug fixes.
+Tag range: `v0.10.4..v0.11.0`.
 
 ### Features
 
@@ -2452,38 +3106,48 @@ All notable changes to Signet are documented here.
 - **dashboard**: improve config/settings save-state UX
 - **pipeline**: harden OpenCode extraction recovery
 
+## [0.10.4] - 2026-02-28
 
-## [0.10.3] - 2026-02-28
+Release summary: 2 bug fixes.
+Tag range: `v0.10.3..v0.10.4`.
 
 ### Bug Fixes
 
 - **dashboard**: remove sidebar and pipeline divider lines
 - **dashboard**: make settings collapsible sections clickable
 
+## [0.10.3] - 2026-02-28
 
-## [0.10.2] - 2026-02-28
+Release summary: 1 bug fix.
+Tag range: `v0.10.2..v0.10.3`.
 
 ### Bug Fixes
 
 - **dashboard**: improve expanded pipeline log visibility
 
+## [0.10.2] - 2026-02-28
 
-## [0.10.1] - 2026-02-28
+Release summary: 1 refactor.
+Tag range: `v0.10.1..v0.10.2`.
 
 ### Refactoring
 
 - **dashboard**: componentize settings tab and extract state
 
+## [0.10.1] - 2026-02-28
 
-## [0.10.0] - 2026-02-28
+Release summary: 2 bug fixes.
+Tag range: `v0.10.0..v0.10.1`.
 
 ### Bug Fixes
 
 - **dashboard**: improve pipeline live feed usability
 - **cli**: prevent CLI from hanging after daemon start/restart
 
+## [0.10.0] - 2026-02-28
 
-## [0.9.0] - 2026-02-28
+Release summary: 1 feature, 4 bug fixes, and 2 refactors.
+Tag range: `v0.9.0..v0.10.0`.
 
 ### Features
 
@@ -2501,8 +3165,10 @@ All notable changes to Signet are documented here.
 - **daemon**: extract skills routes into standalone module
 - **dashboard**: replace PageHero with compact top bar headers
 
+## [0.9.0] - 2026-02-27
 
-## [0.9.0] - 2026-02-28
+Release summary: 1 feature and 1 bug fix.
+Tag range: `v0.8.3..v0.9.0`.
 
 ### Features
 
@@ -2512,8 +3178,20 @@ All notable changes to Signet are documented here.
 
 - **config-ui**: box key config section titles
 
+## [0.8.3] - 2026-02-27
 
-## [0.8.1] - 2026-02-27
+Release summary: 2 bug fixes.
+Tag range: `v0.8.2..v0.8.3`.
+
+### Bug Fixes
+
+- **dashboard**: unify tab headers and constellation wordmark
+- **scheduler**: run overdue tasks using ISO time compare
+
+## [0.8.2] - 2026-02-27
+
+Release summary: 1 refactor and 1 docs update.
+Tag range: `v0.8.1..v0.8.2`.
 
 ### Refactoring
 
@@ -2523,15 +3201,19 @@ All notable changes to Signet are documented here.
 
 - clarify commit prefix guidance — reserve feat: for user-facing features
 
+## [0.8.1] - 2026-02-27
 
-## [0.8.0] - 2026-02-27
+Release summary: 1 bug fix.
+Tag range: `v0.8.0..v0.8.1`.
 
 ### Bug Fixes
 
 - **docs**: add missing frontmatter to daemon-rust-rewrite spec
 
+## [0.8.0] - 2026-02-27
 
-## [0.7.0] - 2026-02-27
+Release summary: 1 feature and 1 bug fix.
+Tag range: `v0.7.0..v0.8.0`.
 
 ### Features
 
@@ -2541,22 +3223,28 @@ All notable changes to Signet are documented here.
 
 - **predictor**: reject mismatched candidate_features instead of silent zero-fill
 
+## [0.7.0] - 2026-02-27
 
-## [0.6.3] - 2026-02-27
+Release summary: 1 feature.
+Tag range: `v0.6.3..v0.7.0`.
 
 ### Features
 
 - **predictor**: implement phase 1 scorer scaffold
 
+## [0.6.3] - 2026-02-27
 
-## [0.6.2] - 2026-02-27
+Release summary: 1 bug fix.
+Tag range: `v0.6.2..v0.6.3`.
 
 ### Bug Fixes
 
 - **defaults**: enable pipeline, graph, reranker, and autonomous by default
 
+## [0.6.2] - 2026-02-27
 
-## [0.6.1] - 2026-02-27
+Release summary: 1 bug fix and 1 performance improvement.
+Tag range: `v0.6.1..v0.6.2`.
 
 ### Bug Fixes
 
@@ -2566,29 +3254,37 @@ All notable changes to Signet are documented here.
 
 - **dashboard**: lazy-load tab content modules
 
+## [0.6.1] - 2026-02-27
 
-## [0.6.0] - 2026-02-27
+Release summary: 1 bug fix.
+Tag range: `v0.6.0..v0.6.1`.
 
 ### Bug Fixes
 
 - **scheduler**: strip CLAUDECODE env var when spawning tasks
 
+## [0.6.0] - 2026-02-27
 
-## [0.5.3] - 2026-02-27
+Release summary: 1 feature.
+Tag range: `v0.5.3..v0.6.0`.
 
 ### Features
 
 - **cli**: require explicit providers for non-interactive setup
 
+## [0.5.3] - 2026-02-27
 
-## [0.5.2] - 2026-02-27
+Release summary: 1 refactor.
+Tag range: `v0.5.2..v0.5.3`.
 
 ### Refactoring
 
 - **cli**: restrict setup wizard to supported connectors
 
+## [0.5.2] - 2026-02-27
 
-## [0.5.1] - 2026-02-27
+Release summary: 3 bug fixes.
+Tag range: `v0.5.1..v0.5.2`.
 
 ### Bug Fixes
 
@@ -2596,36 +3292,46 @@ All notable changes to Signet are documented here.
 - **tasks**: streamline edit flow and detail run state
 - **tasks**: stream live task runs and correct opencode execution
 
+## [0.5.1] - 2026-02-27
 
-## [0.5.0] - 2026-02-27
+Release summary: 1 bug fix.
+Tag range: `v0.5.0..v0.5.1`.
 
 ### Bug Fixes
 
 - **embeddings**: stop scope time-filter refresh loop
 
+## [0.5.0] - 2026-02-27
 
-## [0.4.2] - 2026-02-27
+Release summary: 1 feature.
+Tag range: `v0.4.2..v0.5.0`.
 
 ### Features
 
 - **embeddings**: add scoped projection filters and point window controls
 
+## [0.4.2] - 2026-02-27
 
-## [0.4.1] - 2026-02-27
+Release summary: 1 bug fix.
+Tag range: `v0.4.1..v0.4.2`.
 
 ### Bug Fixes
 
 - **connector-openclaw**: prevent temp workspace paths from leaking into config
 
+## [0.4.1] - 2026-02-27
 
-## [0.4.0] - 2026-02-27
+Release summary: 1 docs update.
+Tag range: `v0.4.0..v0.4.1`.
 
 ### Docs
 
 - add secrets API endpoints and MCP tools to CLAUDE.md
 
+## [0.4.0] - 2026-02-27
 
-## [0.3.0] - 2026-02-27
+Release summary: 2 features and 2 bug fixes.
+Tag range: `v0.2.1..v0.4.0`.
 
 ### Features
 
@@ -2637,18 +3343,26 @@ All notable changes to Signet are documented here.
 - **ci**: bump base version past deprecated 0.3.0 on npm
 - **publish**: convert postinstall to CJS for reliable npm install
 
+## [0.2.1] - 2026-02-26
 
-## [0.2.0] - 2026-02-26
+Release summary: 1 bug fix.
+Tag range: `v0.2.0..v0.2.1`.
 
 ### Bug Fixes
 
 - **pipeline**: propagate LLM failures and improve observability
 
+## [0.2.0] - 2026-02-25
 
-## [0.1.135] - 2026-02-25
+Release summary: 59 features, 55 bug fixes, 2 performance improvements, 6 refactors, and 28 docs updates.
+Tag range: `v0.1.53..v0.2.0`.
 
 ### Features
 
+- **release**: add release reliability and update safety system
+- **daemon**: add session memory recording for predictive scorer (Phase 0)
+- **web**: add React, GSAP, sitemap, RSS, search, and docs enhancements
+- **tray**: macOS auto-launch at login with branded template icons
 - **telemetry**: add anonymous opt-in telemetry with token tracking
 - **dashboard**: add interactive Pipeline visualization tab
 - **pipeline**: backwards deduplication pass for memory pipeline
@@ -2704,34 +3418,13 @@ All notable changes to Signet are documented here.
 - **cli**: sync built-in skills on setup/reconfigure
 - **update**: add unattended auto-update installs
 - **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
 
 ### Bug Fixes
 
+- **daemon**: close hook isolation gaps in remember/recall routes
+- **update**: fix 7 auto-update bugs and make better-sqlite3 optional
+- **daemon**: fix git sync credential resolution and cwd for non-GitHub remotes
+- **daemon**: pass agentsDir to loadMemoryConfig in hooks and summary-worker
 - **pipeline**: add per-job exponential backoff to prevent rapid retry cycling
 - **pipeline**: respect enabled=false master switch in summary worker
 - **hooks**: prevent recursive extraction loops in spawned agents
@@ -2783,34 +3476,6 @@ All notable changes to Signet are documented here.
 - **cli**: accept value arg in secret put
 - **opencode**: wire plugin and AGENTS-first inject
 - **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
 
 ### Performance
 
@@ -2819,16 +3484,17 @@ All notable changes to Signet are documented here.
 
 ### Refactoring
 
+- **daemon**: extract hybrid recall search into memory-search.ts
 - **ingest**: decouple extractors from Ollama, deduplicate shared utilities
 - **pipeline**: restructure PipelineV2Config into nested sub-objects
 - **daemon**: extract update system, add observability
 - **daemon**: expose LlmProvider as singleton
 - **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
 
 ### Docs
 
+- reorganize specs into approved/complete/planning structure
+- **skills**: expand daemon restart instructions in memory-debug skill
 - it learns now
 - add memory loop pipeline diagrams
 - teach agents they can't see their own infrastructure
@@ -2855,70 +3521,13 @@ All notable changes to Signet are documented here.
 - **readme**: add memory loop blueprint diagram
 - **readme**: add poster images
 - **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
 
+## [0.1.53] - 2026-02-19
 
-## [0.1.134] - 2026-02-25
+Release summary: 25 features, 28 bug fixes, 2 refactors, and 4 docs updates.
 
 ### Features
 
-- **dashboard**: add interactive Pipeline visualization tab
-- **pipeline**: backwards deduplication pass for memory pipeline
-- **hooks**: make Signet legible to its own agents
-- **dashboard**: full log payloads + config char budgets
-- **core**: add document ingestion pipeline
-- **skills**: add ClawHub provider and marketplace card grid UI
-- **daemon**: add unified embedding health check endpoint and dashboard UI
-- **daemon**: add memory content size guardrails
-- **web**: add curl install script for signetai.sh/install
-- **skills**: add /onboarding skill for interactive agent setup
-- add scheduled agent tasks with cron-based execution
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
 - **setup**: harden installer and setup flows
 - **core,daemon**: migrate vector search to sqlite-vec
 - **core,daemon**: add hierarchical chunking for memory ingestion
@@ -2947,55 +3556,6 @@ All notable changes to Signet are documented here.
 
 ### Bug Fixes
 
-- **hooks**: prevent recursive extraction loops in spawned agents
-- **dashboard**: resolve settings from daemon's config priority
-- **hooks**: prevent context overflow and filter deleted memories
-- **daemon**: fix 6 runtime bugs across summary worker, API routes, and DB accessor
-- **adapter**: add clawdbot compatibility to openclaw adapter
-- **connector-openclaw**: claim memory slot and disable native memorySearch
-- **openclaw**: rewrite adapter to OpenClaw register(api) plugin pattern
-- **skills**: move onboarding skill to signetai/templates/skills
-- **ci**: bump version to 0.1.116 to fix npm publish collision
-- **dashboard**: use let for $state binding in FormSection
-- **adapter-openclaw**: add openclaw.plugin.json manifest and use unscoped plugin id
-- **adapter-openclaw**: rename package scope from @signet to @signetai for npm publish
-- **dashboard**: move submit button back inside form element
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
 - **cli**: show agent.yaml in status checks
 - **skills**: update templates to use signet recall/remember CLI
 - **migration**: handle schema_migrations table without checksum column
@@ -3025,9103 +3585,14 @@ All notable changes to Signet are documented here.
 - **bin**: use spawnSync instead of spawn.sync
 - **cli**: daemon path resolution for published package
 
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
 ### Refactoring
 
-- **ingest**: decouple extractors from Ollama, deduplicate shared utilities
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
 - **cli**: remove Python/zvec setup in favor of sqlite-vec
 - **core,cli,daemon**: extract shared utilities and add connector-base
 
 ### Docs
 
-- it learns now
-- add memory loop pipeline diagrams
-- teach agents they can't see their own infrastructure
-- update AGENTS.md
-- **skill.md**: move /onboarding details to skill, keep as suggestion in install
-- **skill.md**: add /onboarding as Step 6 in installation flow
-- **skill.md**: add full /onboarding section to install guide
-- add contribution strategy
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
 - update memory commands to use signet remember/recall CLI
 - sync documentation with current implementation
 - update documentation for schema migration system
 - improve README with badges and clearer value prop
-
-
-## [0.1.133] - 2026-02-25
-
-### Features
-
-- **dashboard**: add interactive Pipeline visualization tab
-- **pipeline**: backwards deduplication pass for memory pipeline
-- **hooks**: make Signet legible to its own agents
-- **dashboard**: full log payloads + config char budgets
-- **core**: add document ingestion pipeline
-- **skills**: add ClawHub provider and marketplace card grid UI
-- **daemon**: add unified embedding health check endpoint and dashboard UI
-- **daemon**: add memory content size guardrails
-- **web**: add curl install script for signetai.sh/install
-- **skills**: add /onboarding skill for interactive agent setup
-- add scheduled agent tasks with cron-based execution
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **hooks**: prevent recursive extraction loops in spawned agents
-- **dashboard**: resolve settings from daemon's config priority
-- **hooks**: prevent context overflow and filter deleted memories
-- **daemon**: fix 6 runtime bugs across summary worker, API routes, and DB accessor
-- **adapter**: add clawdbot compatibility to openclaw adapter
-- **connector-openclaw**: claim memory slot and disable native memorySearch
-- **openclaw**: rewrite adapter to OpenClaw register(api) plugin pattern
-- **skills**: move onboarding skill to signetai/templates/skills
-- **ci**: bump version to 0.1.116 to fix npm publish collision
-- **dashboard**: use let for $state binding in FormSection
-- **adapter-openclaw**: add openclaw.plugin.json manifest and use unscoped plugin id
-- **adapter-openclaw**: rename package scope from @signet to @signetai for npm publish
-- **dashboard**: move submit button back inside form element
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **ingest**: decouple extractors from Ollama, deduplicate shared utilities
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- add memory loop pipeline diagrams
-- teach agents they can't see their own infrastructure
-- update AGENTS.md
-- **skill.md**: move /onboarding details to skill, keep as suggestion in install
-- **skill.md**: add /onboarding as Step 6 in installation flow
-- **skill.md**: add full /onboarding section to install guide
-- add contribution strategy
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.132] - 2026-02-25
-
-### Features
-
-- **pipeline**: backwards deduplication pass for memory pipeline
-- **hooks**: make Signet legible to its own agents
-- **dashboard**: full log payloads + config char budgets
-- **core**: add document ingestion pipeline
-- **skills**: add ClawHub provider and marketplace card grid UI
-- **daemon**: add unified embedding health check endpoint and dashboard UI
-- **daemon**: add memory content size guardrails
-- **web**: add curl install script for signetai.sh/install
-- **skills**: add /onboarding skill for interactive agent setup
-- add scheduled agent tasks with cron-based execution
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **dashboard**: resolve settings from daemon's config priority
-- **hooks**: prevent context overflow and filter deleted memories
-- **daemon**: fix 6 runtime bugs across summary worker, API routes, and DB accessor
-- **adapter**: add clawdbot compatibility to openclaw adapter
-- **connector-openclaw**: claim memory slot and disable native memorySearch
-- **openclaw**: rewrite adapter to OpenClaw register(api) plugin pattern
-- **skills**: move onboarding skill to signetai/templates/skills
-- **ci**: bump version to 0.1.116 to fix npm publish collision
-- **dashboard**: use let for $state binding in FormSection
-- **adapter-openclaw**: add openclaw.plugin.json manifest and use unscoped plugin id
-- **adapter-openclaw**: rename package scope from @signet to @signetai for npm publish
-- **dashboard**: move submit button back inside form element
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **ingest**: decouple extractors from Ollama, deduplicate shared utilities
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- add memory loop pipeline diagrams
-- teach agents they can't see their own infrastructure
-- update AGENTS.md
-- **skill.md**: move /onboarding details to skill, keep as suggestion in install
-- **skill.md**: add /onboarding as Step 6 in installation flow
-- **skill.md**: add full /onboarding section to install guide
-- add contribution strategy
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.131] - 2026-02-25
-
-### Features
-
-- **pipeline**: backwards deduplication pass for memory pipeline
-- **hooks**: make Signet legible to its own agents
-- **dashboard**: full log payloads + config char budgets
-- **core**: add document ingestion pipeline
-- **skills**: add ClawHub provider and marketplace card grid UI
-- **daemon**: add unified embedding health check endpoint and dashboard UI
-- **daemon**: add memory content size guardrails
-- **web**: add curl install script for signetai.sh/install
-- **skills**: add /onboarding skill for interactive agent setup
-- add scheduled agent tasks with cron-based execution
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **hooks**: prevent context overflow and filter deleted memories
-- **daemon**: fix 6 runtime bugs across summary worker, API routes, and DB accessor
-- **adapter**: add clawdbot compatibility to openclaw adapter
-- **connector-openclaw**: claim memory slot and disable native memorySearch
-- **openclaw**: rewrite adapter to OpenClaw register(api) plugin pattern
-- **skills**: move onboarding skill to signetai/templates/skills
-- **ci**: bump version to 0.1.116 to fix npm publish collision
-- **dashboard**: use let for $state binding in FormSection
-- **adapter-openclaw**: add openclaw.plugin.json manifest and use unscoped plugin id
-- **adapter-openclaw**: rename package scope from @signet to @signetai for npm publish
-- **dashboard**: move submit button back inside form element
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **ingest**: decouple extractors from Ollama, deduplicate shared utilities
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- add memory loop pipeline diagrams
-- teach agents they can't see their own infrastructure
-- update AGENTS.md
-- **skill.md**: move /onboarding details to skill, keep as suggestion in install
-- **skill.md**: add /onboarding as Step 6 in installation flow
-- **skill.md**: add full /onboarding section to install guide
-- add contribution strategy
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.130] - 2026-02-25
-
-### Features
-
-- **pipeline**: backwards deduplication pass for memory pipeline
-- **hooks**: make Signet legible to its own agents
-- **dashboard**: full log payloads + config char budgets
-- **core**: add document ingestion pipeline
-- **skills**: add ClawHub provider and marketplace card grid UI
-- **daemon**: add unified embedding health check endpoint and dashboard UI
-- **daemon**: add memory content size guardrails
-- **web**: add curl install script for signetai.sh/install
-- **skills**: add /onboarding skill for interactive agent setup
-- add scheduled agent tasks with cron-based execution
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **adapter**: add clawdbot compatibility to openclaw adapter
-- **connector-openclaw**: claim memory slot and disable native memorySearch
-- **openclaw**: rewrite adapter to OpenClaw register(api) plugin pattern
-- **skills**: move onboarding skill to signetai/templates/skills
-- **ci**: bump version to 0.1.116 to fix npm publish collision
-- **dashboard**: use let for $state binding in FormSection
-- **adapter-openclaw**: add openclaw.plugin.json manifest and use unscoped plugin id
-- **adapter-openclaw**: rename package scope from @signet to @signetai for npm publish
-- **dashboard**: move submit button back inside form element
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **ingest**: decouple extractors from Ollama, deduplicate shared utilities
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- add memory loop pipeline diagrams
-- teach agents they can't see their own infrastructure
-- update AGENTS.md
-- **skill.md**: move /onboarding details to skill, keep as suggestion in install
-- **skill.md**: add /onboarding as Step 6 in installation flow
-- **skill.md**: add full /onboarding section to install guide
-- add contribution strategy
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.129] - 2026-02-25
-
-### Features
-
-- **hooks**: make Signet legible to its own agents
-- **dashboard**: full log payloads + config char budgets
-- **core**: add document ingestion pipeline
-- **skills**: add ClawHub provider and marketplace card grid UI
-- **daemon**: add unified embedding health check endpoint and dashboard UI
-- **daemon**: add memory content size guardrails
-- **web**: add curl install script for signetai.sh/install
-- **skills**: add /onboarding skill for interactive agent setup
-- add scheduled agent tasks with cron-based execution
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **adapter**: add clawdbot compatibility to openclaw adapter
-- **connector-openclaw**: claim memory slot and disable native memorySearch
-- **openclaw**: rewrite adapter to OpenClaw register(api) plugin pattern
-- **skills**: move onboarding skill to signetai/templates/skills
-- **ci**: bump version to 0.1.116 to fix npm publish collision
-- **dashboard**: use let for $state binding in FormSection
-- **adapter-openclaw**: add openclaw.plugin.json manifest and use unscoped plugin id
-- **adapter-openclaw**: rename package scope from @signet to @signetai for npm publish
-- **dashboard**: move submit button back inside form element
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **ingest**: decouple extractors from Ollama, deduplicate shared utilities
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- add memory loop pipeline diagrams
-- teach agents they can't see their own infrastructure
-- update AGENTS.md
-- **skill.md**: move /onboarding details to skill, keep as suggestion in install
-- **skill.md**: add /onboarding as Step 6 in installation flow
-- **skill.md**: add full /onboarding section to install guide
-- add contribution strategy
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.128] - 2026-02-25
-
-### Features
-
-- **dashboard**: full log payloads + config char budgets
-- **core**: add document ingestion pipeline
-- **skills**: add ClawHub provider and marketplace card grid UI
-- **daemon**: add unified embedding health check endpoint and dashboard UI
-- **daemon**: add memory content size guardrails
-- **web**: add curl install script for signetai.sh/install
-- **skills**: add /onboarding skill for interactive agent setup
-- add scheduled agent tasks with cron-based execution
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **adapter**: add clawdbot compatibility to openclaw adapter
-- **connector-openclaw**: claim memory slot and disable native memorySearch
-- **openclaw**: rewrite adapter to OpenClaw register(api) plugin pattern
-- **skills**: move onboarding skill to signetai/templates/skills
-- **ci**: bump version to 0.1.116 to fix npm publish collision
-- **dashboard**: use let for $state binding in FormSection
-- **adapter-openclaw**: add openclaw.plugin.json manifest and use unscoped plugin id
-- **adapter-openclaw**: rename package scope from @signet to @signetai for npm publish
-- **dashboard**: move submit button back inside form element
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **ingest**: decouple extractors from Ollama, deduplicate shared utilities
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- add memory loop pipeline diagrams
-- teach agents they can't see their own infrastructure
-- update AGENTS.md
-- **skill.md**: move /onboarding details to skill, keep as suggestion in install
-- **skill.md**: add /onboarding as Step 6 in installation flow
-- **skill.md**: add full /onboarding section to install guide
-- add contribution strategy
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.127] - 2026-02-25
-
-### Features
-
-- **core**: add document ingestion pipeline
-- **skills**: add ClawHub provider and marketplace card grid UI
-- **daemon**: add unified embedding health check endpoint and dashboard UI
-- **daemon**: add memory content size guardrails
-- **web**: add curl install script for signetai.sh/install
-- **skills**: add /onboarding skill for interactive agent setup
-- add scheduled agent tasks with cron-based execution
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **adapter**: add clawdbot compatibility to openclaw adapter
-- **connector-openclaw**: claim memory slot and disable native memorySearch
-- **openclaw**: rewrite adapter to OpenClaw register(api) plugin pattern
-- **skills**: move onboarding skill to signetai/templates/skills
-- **ci**: bump version to 0.1.116 to fix npm publish collision
-- **dashboard**: use let for $state binding in FormSection
-- **adapter-openclaw**: add openclaw.plugin.json manifest and use unscoped plugin id
-- **adapter-openclaw**: rename package scope from @signet to @signetai for npm publish
-- **dashboard**: move submit button back inside form element
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **ingest**: decouple extractors from Ollama, deduplicate shared utilities
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- teach agents they can't see their own infrastructure
-- update AGENTS.md
-- **skill.md**: move /onboarding details to skill, keep as suggestion in install
-- **skill.md**: add /onboarding as Step 6 in installation flow
-- **skill.md**: add full /onboarding section to install guide
-- add contribution strategy
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.126] - 2026-02-24
-
-### Features
-
-- **core**: add document ingestion pipeline
-- **skills**: add ClawHub provider and marketplace card grid UI
-- **daemon**: add unified embedding health check endpoint and dashboard UI
-- **daemon**: add memory content size guardrails
-- **web**: add curl install script for signetai.sh/install
-- **skills**: add /onboarding skill for interactive agent setup
-- add scheduled agent tasks with cron-based execution
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **connector-openclaw**: claim memory slot and disable native memorySearch
-- **openclaw**: rewrite adapter to OpenClaw register(api) plugin pattern
-- **skills**: move onboarding skill to signetai/templates/skills
-- **ci**: bump version to 0.1.116 to fix npm publish collision
-- **dashboard**: use let for $state binding in FormSection
-- **adapter-openclaw**: add openclaw.plugin.json manifest and use unscoped plugin id
-- **adapter-openclaw**: rename package scope from @signet to @signetai for npm publish
-- **dashboard**: move submit button back inside form element
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **ingest**: decouple extractors from Ollama, deduplicate shared utilities
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- teach agents they can't see their own infrastructure
-- update AGENTS.md
-- **skill.md**: move /onboarding details to skill, keep as suggestion in install
-- **skill.md**: add /onboarding as Step 6 in installation flow
-- **skill.md**: add full /onboarding section to install guide
-- add contribution strategy
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.125] - 2026-02-24
-
-### Features
-
-- **skills**: add ClawHub provider and marketplace card grid UI
-- **daemon**: add unified embedding health check endpoint and dashboard UI
-- **daemon**: add memory content size guardrails
-- **web**: add curl install script for signetai.sh/install
-- **skills**: add /onboarding skill for interactive agent setup
-- add scheduled agent tasks with cron-based execution
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **connector-openclaw**: claim memory slot and disable native memorySearch
-- **openclaw**: rewrite adapter to OpenClaw register(api) plugin pattern
-- **skills**: move onboarding skill to signetai/templates/skills
-- **ci**: bump version to 0.1.116 to fix npm publish collision
-- **dashboard**: use let for $state binding in FormSection
-- **adapter-openclaw**: add openclaw.plugin.json manifest and use unscoped plugin id
-- **adapter-openclaw**: rename package scope from @signet to @signetai for npm publish
-- **dashboard**: move submit button back inside form element
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- teach agents they can't see their own infrastructure
-- update AGENTS.md
-- **skill.md**: move /onboarding details to skill, keep as suggestion in install
-- **skill.md**: add /onboarding as Step 6 in installation flow
-- **skill.md**: add full /onboarding section to install guide
-- add contribution strategy
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.124] - 2026-02-24
-
-### Features
-
-- **skills**: add ClawHub provider and marketplace card grid UI
-- **daemon**: add unified embedding health check endpoint and dashboard UI
-- **daemon**: add memory content size guardrails
-- **web**: add curl install script for signetai.sh/install
-- **skills**: add /onboarding skill for interactive agent setup
-- add scheduled agent tasks with cron-based execution
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **connector-openclaw**: claim memory slot and disable native memorySearch
-- **openclaw**: rewrite adapter to OpenClaw register(api) plugin pattern
-- **skills**: move onboarding skill to signetai/templates/skills
-- **ci**: bump version to 0.1.116 to fix npm publish collision
-- **dashboard**: use let for $state binding in FormSection
-- **adapter-openclaw**: add openclaw.plugin.json manifest and use unscoped plugin id
-- **adapter-openclaw**: rename package scope from @signet to @signetai for npm publish
-- **dashboard**: move submit button back inside form element
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- teach agents they can't see their own infrastructure
-- update AGENTS.md
-- **skill.md**: move /onboarding details to skill, keep as suggestion in install
-- **skill.md**: add /onboarding as Step 6 in installation flow
-- **skill.md**: add full /onboarding section to install guide
-- add contribution strategy
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.123] - 2026-02-24
-
-### Features
-
-- **daemon**: add unified embedding health check endpoint and dashboard UI
-- **daemon**: add memory content size guardrails
-- **web**: add curl install script for signetai.sh/install
-- **skills**: add /onboarding skill for interactive agent setup
-- add scheduled agent tasks with cron-based execution
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **connector-openclaw**: claim memory slot and disable native memorySearch
-- **openclaw**: rewrite adapter to OpenClaw register(api) plugin pattern
-- **skills**: move onboarding skill to signetai/templates/skills
-- **ci**: bump version to 0.1.116 to fix npm publish collision
-- **dashboard**: use let for $state binding in FormSection
-- **adapter-openclaw**: add openclaw.plugin.json manifest and use unscoped plugin id
-- **adapter-openclaw**: rename package scope from @signet to @signetai for npm publish
-- **dashboard**: move submit button back inside form element
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- teach agents they can't see their own infrastructure
-- update AGENTS.md
-- **skill.md**: move /onboarding details to skill, keep as suggestion in install
-- **skill.md**: add /onboarding as Step 6 in installation flow
-- **skill.md**: add full /onboarding section to install guide
-- add contribution strategy
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.122] - 2026-02-24
-
-### Features
-
-- **daemon**: add memory content size guardrails
-- **web**: add curl install script for signetai.sh/install
-- **skills**: add /onboarding skill for interactive agent setup
-- add scheduled agent tasks with cron-based execution
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **connector-openclaw**: claim memory slot and disable native memorySearch
-- **openclaw**: rewrite adapter to OpenClaw register(api) plugin pattern
-- **skills**: move onboarding skill to signetai/templates/skills
-- **ci**: bump version to 0.1.116 to fix npm publish collision
-- **dashboard**: use let for $state binding in FormSection
-- **adapter-openclaw**: add openclaw.plugin.json manifest and use unscoped plugin id
-- **adapter-openclaw**: rename package scope from @signet to @signetai for npm publish
-- **dashboard**: move submit button back inside form element
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- teach agents they can't see their own infrastructure
-- update AGENTS.md
-- **skill.md**: move /onboarding details to skill, keep as suggestion in install
-- **skill.md**: add /onboarding as Step 6 in installation flow
-- **skill.md**: add full /onboarding section to install guide
-- add contribution strategy
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.121] - 2026-02-24
-
-### Features
-
-- **web**: add curl install script for signetai.sh/install
-- **skills**: add /onboarding skill for interactive agent setup
-- add scheduled agent tasks with cron-based execution
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **openclaw**: rewrite adapter to OpenClaw register(api) plugin pattern
-- **skills**: move onboarding skill to signetai/templates/skills
-- **ci**: bump version to 0.1.116 to fix npm publish collision
-- **dashboard**: use let for $state binding in FormSection
-- **adapter-openclaw**: add openclaw.plugin.json manifest and use unscoped plugin id
-- **adapter-openclaw**: rename package scope from @signet to @signetai for npm publish
-- **dashboard**: move submit button back inside form element
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- teach agents they can't see their own infrastructure
-- update AGENTS.md
-- **skill.md**: move /onboarding details to skill, keep as suggestion in install
-- **skill.md**: add /onboarding as Step 6 in installation flow
-- **skill.md**: add full /onboarding section to install guide
-- add contribution strategy
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.120] - 2026-02-24
-
-### Features
-
-- **web**: add curl install script for signetai.sh/install
-- **skills**: add /onboarding skill for interactive agent setup
-- add scheduled agent tasks with cron-based execution
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **openclaw**: rewrite adapter to OpenClaw register(api) plugin pattern
-- **skills**: move onboarding skill to signetai/templates/skills
-- **ci**: bump version to 0.1.116 to fix npm publish collision
-- **dashboard**: use let for $state binding in FormSection
-- **adapter-openclaw**: add openclaw.plugin.json manifest and use unscoped plugin id
-- **adapter-openclaw**: rename package scope from @signet to @signetai for npm publish
-- **dashboard**: move submit button back inside form element
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- update AGENTS.md
-- **skill.md**: move /onboarding details to skill, keep as suggestion in install
-- **skill.md**: add /onboarding as Step 6 in installation flow
-- **skill.md**: add full /onboarding section to install guide
-- add contribution strategy
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.119] - 2026-02-24
-
-### Features
-
-- **web**: add curl install script for signetai.sh/install
-- **skills**: add /onboarding skill for interactive agent setup
-- add scheduled agent tasks with cron-based execution
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **openclaw**: rewrite adapter to OpenClaw register(api) plugin pattern
-- **skills**: move onboarding skill to signetai/templates/skills
-- **ci**: bump version to 0.1.116 to fix npm publish collision
-- **dashboard**: use let for $state binding in FormSection
-- **adapter-openclaw**: add openclaw.plugin.json manifest and use unscoped plugin id
-- **adapter-openclaw**: rename package scope from @signet to @signetai for npm publish
-- **dashboard**: move submit button back inside form element
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- **skill.md**: move /onboarding details to skill, keep as suggestion in install
-- **skill.md**: add /onboarding as Step 6 in installation flow
-- **skill.md**: add full /onboarding section to install guide
-- add contribution strategy
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.118] - 2026-02-24
-
-### Features
-
-- **web**: add curl install script for signetai.sh/install
-- **skills**: add /onboarding skill for interactive agent setup
-- add scheduled agent tasks with cron-based execution
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **skills**: move onboarding skill to signetai/templates/skills
-- **ci**: bump version to 0.1.116 to fix npm publish collision
-- **dashboard**: use let for $state binding in FormSection
-- **adapter-openclaw**: add openclaw.plugin.json manifest and use unscoped plugin id
-- **adapter-openclaw**: rename package scope from @signet to @signetai for npm publish
-- **dashboard**: move submit button back inside form element
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- **skill.md**: move /onboarding details to skill, keep as suggestion in install
-- **skill.md**: add /onboarding as Step 6 in installation flow
-- **skill.md**: add full /onboarding section to install guide
-- add contribution strategy
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.117] - 2026-02-24
-
-### Features
-
-- **web**: add curl install script for signetai.sh/install
-- **skills**: add /onboarding skill for interactive agent setup
-- add scheduled agent tasks with cron-based execution
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **ci**: bump version to 0.1.116 to fix npm publish collision
-- **dashboard**: use let for $state binding in FormSection
-- **adapter-openclaw**: add openclaw.plugin.json manifest and use unscoped plugin id
-- **adapter-openclaw**: rename package scope from @signet to @signetai for npm publish
-- **dashboard**: move submit button back inside form element
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- **skill.md**: move /onboarding details to skill, keep as suggestion in install
-- **skill.md**: add /onboarding as Step 6 in installation flow
-- **skill.md**: add full /onboarding section to install guide
-- add contribution strategy
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.114] - 2026-02-23
-
-### Features
-
-- add scheduled agent tasks with cron-based execution
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **dashboard**: use let for $state binding in FormSection
-- **adapter-openclaw**: add openclaw.plugin.json manifest and use unscoped plugin id
-- **adapter-openclaw**: rename package scope from @signet to @signetai for npm publish
-- **dashboard**: move submit button back inside form element
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- add contribution strategy
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.113] - 2026-02-23
-
-### Features
-
-- add scheduled agent tasks with cron-based execution
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **dashboard**: use let for $state binding in FormSection
-- **adapter-openclaw**: add openclaw.plugin.json manifest and use unscoped plugin id
-- **adapter-openclaw**: rename package scope from @signet to @signetai for npm publish
-- **dashboard**: move submit button back inside form element
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.112] - 2026-02-23
-
-### Features
-
-- add scheduled agent tasks with cron-based execution
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **adapter-openclaw**: add openclaw.plugin.json manifest and use unscoped plugin id
-- **adapter-openclaw**: rename package scope from @signet to @signetai for npm publish
-- **dashboard**: move submit button back inside form element
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.111] - 2026-02-23
-
-### Features
-
-- add scheduled agent tasks with cron-based execution
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **adapter-openclaw**: rename package scope from @signet to @signetai for npm publish
-- **dashboard**: move submit button back inside form element
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.110] - 2026-02-23
-
-### Features
-
-- **adapter-openclaw**: prepare package for npm publish
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **adapter-openclaw**: use DOM lib instead of node types for CI compat
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.109] - 2026-02-23
-
-### Features
-
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **connector-openclaw**: use object format for plugins config
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.108] - 2026-02-23
-
-### Features
-
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **dashboard**: clean up bloated pipeline settings UI
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.107] - 2026-02-23
-
-### Features
-
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **cli**: remove duplicate embed command registration
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.106] - 2026-02-23
-
-### Features
-
-- memory system roadmap — 8 features + docs
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **cli**: rename duplicate embedCmd variable to fix build
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.105] - 2026-02-23
-
-### Features
-
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **core**: pass Float32Array instead of Buffer to vec0 MATCH query
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.104] - 2026-02-23
-
-### Features
-
-- **daemon**: inject local date/time and timezone in session-start hook
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.103] - 2026-02-23
-
-### Features
-
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **connector-base**: add @types/node for node:fs and node:path imports
-- include SOUL.md, IDENTITY.md, USER.md in all harness config generation
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.102] - 2026-02-23
-
-### Features
-
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **connector-claude-code**: register MCP server in ~/.claude.json, not settings.json
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.101] - 2026-02-23
-
-### Features
-
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **core**: use npm root -g to find sqlite-vec when running under bun
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.100] - 2026-02-23
-
-### Features
-
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **core**: search well-known npm global paths for sqlite-vec extension
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.99] - 2026-02-23
-
-### Features
-
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **signetai**: add signet-mcp bin entry and build step to meta-package
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.98] - 2026-02-23
-
-### Features
-
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **cli**: drop stale vec_embeddings before recreating with correct dimensions
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.97] - 2026-02-23
-
-### Features
-
-- **daemon**: expose MCP server for native tool access from harnesses
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.96] - 2026-02-23
-
-### Features
-
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **embeddings**: read actual dimensions instead of hardcoding vec0 table size
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.95] - 2026-02-23
-
-### Features
-
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- require shadcn-svelte components for dashboard UI work
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.94] - 2026-02-23
-
-### Features
-
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **cli**: load sqlite-vec extension before CREATE VIRTUAL TABLE in migrate-vectors
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.93] - 2026-02-23
-
-### Features
-
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **pipeline**: restructure PipelineV2Config into nested sub-objects
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.92] - 2026-02-23
-
-### Features
-
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **core**: support sqlite-vec on macOS and other non-Linux platforms
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.91] - 2026-02-23
-
-### Features
-
-- **pipeline**: wire update + delete mutations in pipeline worker
-- **web**: add tabbed agent install prompt to hero and CTA
-- **pipeline**: enforce atomic memory extraction via prompt rewriting
-- **web**: add agent install skill at /skill.md
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **recall**: fix signet recall returning no results
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.90] - 2026-02-23
-
-### Features
-
-- **tray**: macOS menu bar app Phase 1 — rich stats, quick capture, search
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.89] - 2026-02-23
-
-### Features
-
-- **opencode**: add runtime plugin with full tool surface
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **dashboard**: fix embeddings effect cycle and perf
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.88] - 2026-02-23
-
-### Features
-
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **dashboard**: fix hover card stuck at origin
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.87] - 2026-02-23
-
-### Features
-
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: eliminate embeddings idle CPU burn
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.86] - 2026-02-23
-
-### Features
-
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **dashboard**: stabilize embeddings graph performance
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.85] - 2026-02-23
-
-### Features
-
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **dashboard**: restore embeddings inspector selection
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.84] - 2026-02-23
-
-### Features
-
-- **dashboard**: add shift lock for embeddings hover preview
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- fill documentation gaps from audit
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.83] - 2026-02-23
-
-### Features
-
-- **dashboard**: color code log levels in logs tab
-- **dashboard**: add embedding filter presets and cluster lens
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **cli**: force fresh update check on explicit commands
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.82] - 2026-02-23
-
-### Features
-
-- **skills**: add signet-design skill assets
-- **tray**: add system tray app (Tauri v2)
-- **web**: migrate to Astro, add /docs section
-- **dashboard**: migrate selects and date filter to shadcn components
-- **scripts**: add post-push release sync
-- **dashboard**: surface hook outputs in logs
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **daemon**: extract update system, add observability
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- update AGENTS.md for recent changes
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.81] - 2026-02-23
-
-### Features
-
-- add changelog + public roadmap
-- **dashboard**: make session logs scrollable and inspectable
-- **daemon**: add re-embed repair endpoint and CLI
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-- refine session end hook
-- **daemon**: add Claude Code headless LLM provider
-- **daemon**: add analytics and timeline (Phase K)
-- **daemon**: add auth module (Phase J)
-- **sdk**: rewrite as HTTP client for daemon API
-- **daemon**: phase H ingestion and connectors
-- **openclaw**: add plugin path option to setup
-- **daemon**: phase G plugin-first runtime
-- **daemon**: phase F autonomous maintenance
-- **daemon**: phase E graph + reranking
-- **web**: update hero and add secrets section
-- **daemon**: phase D2/D3 soft-delete and policy
-- **daemon**: phase B shadow extraction pipeline
-- **core,daemon**: phase A infrastructure hardening
-- **web**: integrate marketing website into workspace
-- **hooks**: migrate all hooks from memory.py to daemon API
-- **cli**: sync built-in skills on setup/reconfigure
-- **update**: add unattended auto-update installs
-- **embeddings**: speed up graph loading
-- **setup**: harden installer and setup flows
-- **core,daemon**: migrate vector search to sqlite-vec
-- **core,daemon**: add hierarchical chunking for memory ingestion
-- **daemon**: use system git credentials for sync
-- **cli**: add signet remember and signet recall commands
-- **daemon**: add embedding provider status check
-- **dashboard**: schematic monochrome graph aesthetic
-- **connectors**: add @signet/connector-openclaw
-- **connectors**: inject Signet system block into harness files
-- **core**: add database schema migration system
-- **core**: add runtime-detected SQLite and connector packages
-- **cli**: auto-detect Python and offer alternatives for zvec
-- sync existing Claude memories on daemon startup
-- auto-sync Claude Code project memories to Signet
-- add /api/hook/remember endpoint for Claude Code compatibility
-- add signet skill to teach agents how to use signet
-- add secrets to interactive menu, fix yaml parsing for existing config
-- symlink skills to harness dirs, use --system-site-packages for venv
-- **setup**: add 'Import from GitHub' option for fresh installs and existing
-- **cli**: add 'signet sync' command to sync templates and fix venv
-- **setup**: add .gitignore template (ignores .venv, .daemon, pycache)
-- **setup**: create venv for Python deps, daemon uses venv Python
-- **setup**: auto-install Python dependencies (PyYAML, zvec)
-- **dashboard**: add memory filter UI and similar search
-- initial monorepo scaffold
-
-### Bug Fixes
-
-- **dashboard**: break projection polling loop on error
-- **daemon**: handle bun:sqlite Uint8Array blobs
-- **core**: compute __dirname at runtime
-- **docs**: correct license to Apache-2.0 in READMEs
-- **daemon**: sync vec_embeddings on write
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction
-- **daemon**: repair vector search with sqlite-vec
-- pre-release safety fixes
-- **core**: repair v0.1.65 migration version collision
-- **test**: exclude references from test discovery
-- **cli**: accept value arg in secret put
-- **opencode**: wire plugin and AGENTS-first inject
-- **embeddings**: support legacy pagination paths
-- **cli**: show agent.yaml in status checks
-- **skills**: update templates to use signet recall/remember CLI
-- **migration**: handle schema_migrations table without checksum column
-- **build**: ensure connectors build before signetai meta-package
-- **connectors**: add @types/node for CI builds
-- **templates**: wrap Signet block in SIGNET:START/END delimiters
-- **build**: use relative import for @signet/core in CLI
-- **build**: ensure core builds before dependent packages
-- **ci**: mark @signet/core as external in CLI build
-- **ci**: use jq for version bump to avoid npm workspace issue
-- add missing dependencies for CI build
-- **ci**: remove frozen-lockfile for workspace compat
-- update lockfile
-- **cli**: use simple bin format for npm
-- **cli**: add shebang to build output and fix repository url
-- make zvec optional (requires Python 3.10-3.12)
-- add zvec back to requirements.txt
-- rename .gitignore to gitignore.template so npm includes it
-- better browser open messages, remove zvec dep, improve postinstall
-- **setup**: better venv/pip error messages with actual stderr output
-- **cli**: clear screen between menu iterations, add pause after output
-- **setup**: better venv error message with distro-specific install hints
-- **setup**: robust pip install with fallbacks and warning on failure
-- **setup**: load existing config values as defaults when reconfiguring
-- **daemon**: auto-init memory schema, add remember/recall skills
-- **cli**: replace emojis with text icons, handle Ctrl+C gracefully
-- **bin**: use spawnSync instead of spawn.sync
-- **cli**: daemon path resolution for published package
-
-### Performance
-
-- **dashboard**: move UMAP projection server-side
-
-### Refactoring
-
-- **daemon**: expose LlmProvider as singleton
-- **dashboard**: migrate to shadcn-svelte
-- **cli**: remove Python/zvec setup in favor of sqlite-vec
-- **core,cli,daemon**: extract shared utilities and add connector-base
-
-### Docs
-
-- **wip**: add daemon.ts refactor plan
-- **memory**: turn procedural memory plan into implementation spec
-- update procedural memory plan
-- update AGENTS.md with architecture gaps
-- update CLAUDE.md with Phase G pipeline docs
-- update frontmatter yaml on signet skill
-- embed vision into signet skill template
-- **daemon**: add procedural memory plan
-- the future remembers everything
-- the future remembers everything
-- **readme**: add how memory works section
-- **readme**: use HTML tables for layout
-- **readme**: add memory loop blueprint diagram
-- **readme**: add poster images
-- **repo**: refresh README and AGENTS guidance
-- update memory commands to use signet remember/recall CLI
-- sync documentation with current implementation
-- update documentation for schema migration system
-- improve README with badges and clearer value prop
-
-
-## [0.1.80] - 2026-02-22
-
-### Features
-- **dashboard**: make session logs scrollable and inspectable
-
-## [0.1.79] - 2026-02-22
-
-### Docs
-- update AGENTS.md with architecture gaps
-
-## [0.1.78] - 2026-02-21
-
-### Bug Fixes
-- **dashboard**: break projection polling loop on error
-
-## [0.1.77] - 2026-02-21
-
-### Bug Fixes
-- **daemon**: handle bun:sqlite Uint8Array blobs
-
-## [0.1.76] - 2026-02-21
-
-### Performance
-- **dashboard**: move UMAP projection server-side
-
-### Features
-- **daemon**: add re-embed repair endpoint and CLI
-
-## [0.1.75] - 2026-02-20
-
-### Refactoring
-- **dashboard**: migrate to shadcn-svelte
-
-### Features
-- **dashboard**: unify settings tab form
-- **dashboard**: redesign with shadcn sidebar and skills.sh integration
-
-## [0.1.74] - 2026-02-19
-
-### Features
-- refine session end hook
-
-### Bug Fixes
-- **core**: compute __dirname at runtime
-
-## [0.1.73] - 2026-02-19
-
-### Features
-- **daemon**: add Claude Code headless LLM provider
-
-## [0.1.72] - 2026-02-18
-
-### Bug Fixes
-- **docs**: correct license to Apache-2.0 in READMEs
-
-## [0.1.71] - 2026-02-18
-
-### Bug Fixes
-- **daemon**: sync vec_embeddings on write
-
-## [0.1.70] - 2026-02-17
-
-### Bug Fixes
-- **core**: add unique index on embeddings.content_hash
-- **daemon**: use Ollama HTTP API for extraction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to Signet are documented here.
 Surface summary of the most recent release dates. See the release ledger below for exact version-by-version history.
 
 ### 2026-04-09
-- Bug fixes: improve docs search and docs navigation.
+- Bug fixes: block leaked workspace deps in release; improve docs search and docs navigation.
 
 ### 2026-04-08
 - Bug fixes: honour maxInjectChars config in session-start hook.
@@ -25,11 +25,23 @@ Surface summary of the most recent release dates. See the release ledger below f
 ### 2026-04-04
 - Bug fixes: scope sub-agent memory dedupe and synthesis; prevent summary-worker retries on shared session-end keys.
 
-### 2026-04-03
-- Features: add ForgeCode connector.
-- Bug fixes: auto-migrate legacy-only OpenClaw runtime; ignore generated MEMORY backup markdown files.
-
 ## Release Ledger
+
+## [0.98.10] - 2026-04-10
+
+Release summary: internal maintenance release with no conventional commit entries captured.
+Tag range: `v0.98.9..v0.98.10`.
+
+No notable changes were captured from conventional commit subjects for this release.
+
+## [0.98.9] - 2026-04-09
+
+Release summary: 1 bug fix.
+Tag range: `v0.98.8..v0.98.9`.
+
+### Bug Fixes
+
+- **publish**: block leaked workspace deps in release (#486)
 
 ## [0.98.8] - 2026-04-09
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,8 +271,10 @@ or the push only changes non-code files (markdown, images, etc.).
    compares with remote, computes bump level from commit messages, and increments
    accordingly. All `package.json` files (except `packages/cli/dashboard/package.json`)
    are updated to the new version.
-3. **Changelog** — `bun scripts/changelog.ts` generates a new entry in `CHANGELOG.md`
-   from conventional commit subjects since the last tag.
+3. **Changelog** — `bun scripts/changelog.ts --bump-only` computes the bump level from
+   conventional commit subjects since the last tag, then
+   `bun scripts/changelog.ts --version <new-version>` writes the matching
+   `CHANGELOG.md` entry for the actual release version.
 4. **npm publish** — Publishes `signetai` and `@signetai/signet-memory-openclaw`
    to npm with the `next` tag, then promotes to `latest` (unless it's a major bump).
 5. **Commit and tag** — Commits the version bump and changelog as `chore: release <version>`,
@@ -298,7 +300,7 @@ All scripts live in `scripts/` and are written in TypeScript (run via
 
 | Script | Description |
 |--------|-------------|
-| `changelog.ts` | Generates a CHANGELOG.md entry from conventional commits since the last git tag. Groups commits by type (`feat`, `fix`, `perf`, `refactor`, `docs`). Also writes a `.bump-level` file used by CI to determine the semver bump. Called automatically during the release workflow. |
+| `changelog.ts` | Computes the semver bump from conventional commits since the last git tag, can prepend a CHANGELOG.md entry for an explicit release version, and can rebuild the full changelog from git tags. Generated entries include a short release summary, optional tag range, and grouped sections (`feat`, `fix`, `perf`, `refactor`, `docs`). Writes a `.bump-level` file used by CI to determine the semver bump. Called automatically during the release workflow. |
 | `bump-level.ts` | Exports `computeBumpLevel()` — scans commit subjects for `BREAKING CHANGE:` (→ major), `feat:` (→ minor), or defaults to patch. Used by `changelog.ts`. |
 | `version-sync.ts` | Aligns the `version` field in all workspace `package.json` files to match the reference version in `packages/signetai/package.json`. Run manually with `bun run version:sync` or pass `--to <version>` to set an explicit version. |
 | `extract-changelog-section.ts` | Extracts a single version's section from CHANGELOG.md. Used by CI to populate GitHub release notes. |
@@ -342,7 +344,9 @@ integrations, and operational safeguards.
 To run any script manually:
 
 ```bash
-bun scripts/changelog.ts
+bun scripts/changelog.ts --bump-only
+bun scripts/changelog.ts --version 1.2.3
+bun scripts/changelog.ts --rebuild
 bun scripts/version-sync.ts --to 1.2.3
 bun scripts/extract-changelog-section.ts 0.14.5
 bun scripts/check-install-guide.ts

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -280,8 +280,10 @@ or the push only changes non-code files (markdown, images, etc.).
    compares with remote, computes bump level from commit messages, and increments
    accordingly. All `package.json` files (except `packages/cli/dashboard/package.json`)
    are updated to the new version.
-3. **Changelog** — `bun scripts/changelog.ts` generates a new entry in `CHANGELOG.md`
-   from conventional commit subjects since the last tag.
+3. **Changelog** — `bun scripts/changelog.ts --bump-only` computes the bump level from
+   conventional commit subjects since the last tag, then
+   `bun scripts/changelog.ts --version <new-version>` writes the matching
+   `CHANGELOG.md` entry for the actual release version.
 4. **npm publish** — Publishes `signetai` and `@signetai/signet-memory-openclaw`
    to npm with the `next` tag, then promotes to `latest` (unless it's a major bump).
 5. **Commit and tag** — Commits the version bump and changelog as `chore: release <version>`,
@@ -307,7 +309,7 @@ All scripts live in `scripts/` and are written in TypeScript (run via
 
 | Script | Description |
 |--------|-------------|
-| `changelog.ts` | Generates a CHANGELOG.md entry from conventional commits since the last git tag. Groups commits by type (`feat`, `fix`, `perf`, `refactor`, `docs`). Also writes a `.bump-level` file used by CI to determine the semver bump. Called automatically during the release workflow. |
+| `changelog.ts` | Computes the semver bump from conventional commits since the last git tag, can prepend a CHANGELOG.md entry for an explicit release version, and can rebuild the full changelog from git tags. Generated entries include a short release summary, optional tag range, and grouped sections (`feat`, `fix`, `perf`, `refactor`, `docs`). Writes a `.bump-level` file used by CI to determine the semver bump. Called automatically during the release workflow. |
 | `bump-level.ts` | Exports `computeBumpLevel()` — scans commit subjects for `BREAKING CHANGE:` (→ major), `feat:` (→ minor), or defaults to patch. Used by `changelog.ts`. |
 | `version-sync.ts` | Aligns the `version` field in all workspace `package.json` files to match the reference version in `packages/signetai/package.json`. Run manually with `bun run version:sync` or pass `--to <version>` to set an explicit version. |
 | `extract-changelog-section.ts` | Extracts a single version's section from CHANGELOG.md. Used by CI to populate GitHub release notes. |
@@ -351,7 +353,9 @@ integrations, and operational safeguards.
 To run any script manually:
 
 ```bash
-bun scripts/changelog.ts
+bun scripts/changelog.ts --bump-only
+bun scripts/changelog.ts --version 1.2.3
+bun scripts/changelog.ts --rebuild
 bun scripts/version-sync.ts --to 1.2.3
 bun scripts/extract-changelog-section.ts 0.14.5
 bun scripts/check-install-guide.ts

--- a/packages/core/src/__tests__/changelog-script.test.ts
+++ b/packages/core/src/__tests__/changelog-script.test.ts
@@ -67,6 +67,10 @@ function makeTaggedReleaseRepo(): string {
 	return dir;
 }
 
+function countOccurrences(value: string, needle: string): number {
+	return value.split(needle).length - 1;
+}
+
 afterEach(() => {
 	for (const dir of tempDirs.splice(0)) {
 		rmSync(dir, { force: true, recursive: true });
@@ -123,5 +127,30 @@ describe("scripts/changelog.ts", () => {
 			"Release summary: internal maintenance release with no conventional commit entries captured.",
 		);
 		expect(changelog.indexOf("## [0.1.1] - ")).toBeLessThan(changelog.indexOf("## [0.1.0] - "));
+	});
+
+	test("prepends a release to an existing structured changelog without duplicating document sections", () => {
+		const dir = makePendingReleaseRepo();
+
+		run(["bun", changelogScript, "--version", "0.1.1", "--date", "2026-04-09"], dir);
+		run(["git", "add", "CHANGELOG.md", ".bump-level"], dir);
+		run(["git", "commit", "-m", "chore: release 0.1.1"], dir);
+		run(["git", "tag", "v0.1.1"], dir);
+
+		writeFileSync(join(dir, "API.md"), "api notes\n");
+		run(["git", "add", "API.md"], dir);
+		run(["git", "commit", "-m", "docs(api): document steady-state release flow"], dir);
+
+		run(["bun", changelogScript, "--version", "0.1.2", "--date", "2026-04-10"], dir);
+
+		const changelog = readFileSync(join(dir, "CHANGELOG.md"), "utf8");
+		expect(countOccurrences(changelog, "## Recent Highlights")).toBe(1);
+		expect(countOccurrences(changelog, "## Release Ledger")).toBe(1);
+		expect(changelog.indexOf("## [0.1.2] - 2026-04-10")).toBeLessThan(changelog.indexOf("## [0.1.1] - 2026-04-09"));
+		expect(changelog).toContain("Release summary: 1 docs update.");
+		expect(changelog).toContain("Tag range: `v0.1.1..v0.1.2`.");
+		expect(changelog).toContain("- **api**: document steady-state release flow");
+		expect(changelog).toContain("Tag range: `v0.1.0..v0.1.1`.");
+		expect(changelog).toContain("- **cli**: repair release notes ordering");
 	});
 });

--- a/packages/core/src/__tests__/changelog-script.test.ts
+++ b/packages/core/src/__tests__/changelog-script.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -79,6 +79,7 @@ describe("scripts/changelog.ts", () => {
 
 		run(["bun", changelogScript, "--bump-only"], dir);
 		expect(readFileSync(join(dir, ".bump-level"), "utf8").trim()).toBe("patch");
+		expect(existsSync(join(dir, "CHANGELOG.md"))).toBe(false);
 
 		run(["bun", changelogScript, "--version", "0.1.1", "--date", "2026-04-09"], dir);
 
@@ -109,7 +110,7 @@ describe("scripts/changelog.ts", () => {
 		const changelog = readFileSync(join(dir, "CHANGELOG.md"), "utf8");
 		expect(changelog).toContain("## Recent Highlights");
 		expect(changelog).toContain("## Release Ledger");
-		expect(changelog).toContain("### 2026-04-09");
+		expect(changelog).toMatch(/### \d{4}-\d{2}-\d{2}/);
 		expect(changelog).toContain("- Bug fixes: repair release notes ordering.");
 		expect(changelog).toContain("- Docs: document release flow.");
 		expect(changelog).toContain("## [0.1.1] - ");

--- a/packages/core/src/__tests__/changelog-script.test.ts
+++ b/packages/core/src/__tests__/changelog-script.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dir, "../../../../");
+const changelogScript = join(repoRoot, "scripts", "changelog.ts");
+const extractSectionScript = join(repoRoot, "scripts", "extract-changelog-section.ts");
+
+const tempDirs: string[] = [];
+
+function run(cmd: readonly string[], cwd: string): string {
+	const [file, ...args] = cmd;
+	const result = spawnSync(file, args, {
+		cwd,
+		encoding: "utf8",
+	});
+	if (result.status !== 0) {
+		throw new Error(
+			[`command failed: ${cmd.join(" ")}`, `stdout:\n${result.stdout}`, `stderr:\n${result.stderr}`].join("\n\n"),
+		);
+	}
+	return result.stdout;
+}
+
+function makeRepo(): string {
+	const dir = mkdtempSync(join(tmpdir(), "signet-changelog-test-"));
+	tempDirs.push(dir);
+
+	writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "tmp-root", version: "0.1.0" }, null, 2));
+	writeFileSync(join(dir, "bunfig.toml"), '[test]\nroot = "packages"\n');
+	mkdirSync(join(dir, "packages", "signetai"), { recursive: true });
+	writeFileSync(join(dir, ".gitignore"), "node_modules\n");
+	writeFileSync(
+		join(dir, "packages", "signetai", "package.json"),
+		JSON.stringify({ name: "signetai", version: "0.1.0" }, null, 2),
+	);
+
+	run(["git", "init"], dir);
+	run(["git", "config", "user.name", "Test User"], dir);
+	run(["git", "config", "user.email", "test@example.com"], dir);
+	run(["git", "add", "."], dir);
+	run(["git", "commit", "-m", "chore: bootstrap"], dir);
+	run(["git", "tag", "v0.1.0"], dir);
+
+	return dir;
+}
+
+function makePendingReleaseRepo(): string {
+	const dir = makeRepo();
+	writeFileSync(join(dir, "README.md"), "hello\n");
+	run(["git", "add", "README.md"], dir);
+	run(["git", "commit", "-m", "fix(cli): repair release notes ordering"], dir);
+	return dir;
+}
+
+function makeTaggedReleaseRepo(): string {
+	const dir = makeRepo();
+	writeFileSync(join(dir, "README.md"), "hello\n");
+	run(["git", "add", "README.md"], dir);
+	run(["git", "commit", "-m", "fix(cli): repair release notes ordering"], dir);
+	writeFileSync(join(dir, "NOTES.md"), "release notes\n");
+	run(["git", "add", "NOTES.md"], dir);
+	run(["git", "commit", "-m", "docs(repo): document release flow"], dir);
+	run(["git", "tag", "v0.1.1"], dir);
+	return dir;
+}
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { force: true, recursive: true });
+	}
+});
+
+describe("scripts/changelog.ts", () => {
+	test("writes the changelog section for the explicit release version instead of the pre-bump package version", () => {
+		const dir = makePendingReleaseRepo();
+
+		run(["bun", changelogScript, "--bump-only"], dir);
+		expect(readFileSync(join(dir, ".bump-level"), "utf8").trim()).toBe("patch");
+
+		run(["bun", changelogScript, "--version", "0.1.1", "--date", "2026-04-09"], dir);
+
+		const changelog = readFileSync(join(dir, "CHANGELOG.md"), "utf8");
+		expect(changelog).toContain("## Recent Highlights");
+		expect(changelog).toContain("## Release Ledger");
+		expect(changelog).toContain("### 2026-04-09");
+		expect(changelog).toContain("- Bug fixes: repair release notes ordering.");
+		expect(changelog).toContain("## [0.1.1] - 2026-04-09");
+		expect(changelog).not.toContain("## [0.1.0] - 2026-04-09");
+		expect(changelog).toContain("Release summary: 1 bug fix.");
+		expect(changelog).toContain("Tag range: `v0.1.0..v0.1.1`.");
+		expect(changelog).toContain("- **cli**: repair release notes ordering");
+
+		const section = run(["bun", extractSectionScript, "0.1.1"], dir).trim();
+		expect(section).toContain("## [0.1.1] - 2026-04-09");
+		expect(section).toContain("Release summary: 1 bug fix.");
+		expect(section).toContain("Tag range: `v0.1.0..v0.1.1`.");
+		expect(section).toContain("### Bug Fixes");
+		expect(section).toContain("- **cli**: repair release notes ordering");
+	});
+
+	test("rebuild regenerates the full changelog from tags with summaries and range lines", () => {
+		const dir = makeTaggedReleaseRepo();
+
+		run(["bun", changelogScript, "--rebuild"], dir);
+
+		const changelog = readFileSync(join(dir, "CHANGELOG.md"), "utf8");
+		expect(changelog).toContain("## Recent Highlights");
+		expect(changelog).toContain("## Release Ledger");
+		expect(changelog).toContain("### 2026-04-09");
+		expect(changelog).toContain("- Bug fixes: repair release notes ordering.");
+		expect(changelog).toContain("- Docs: document release flow.");
+		expect(changelog).toContain("## [0.1.1] - ");
+		expect(changelog).toContain("Release summary: 1 bug fix and 1 docs update.");
+		expect(changelog).toContain("Tag range: `v0.1.0..v0.1.1`.");
+		expect(changelog).toContain("- **cli**: repair release notes ordering");
+		expect(changelog).toContain("- **repo**: document release flow");
+		expect(changelog).toContain("## [0.1.0] - ");
+		expect(changelog).toContain(
+			"Release summary: internal maintenance release with no conventional commit entries captured.",
+		);
+		expect(changelog.indexOf("## [0.1.1] - ")).toBeLessThan(changelog.indexOf("## [0.1.0] - "));
+	});
+});

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -2,13 +2,21 @@
 
 import { execSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { computeBumpLevel } from "./bump-level";
+import { type BumpLevel, computeBumpLevel } from "./bump-level";
 
 const CHANGELOG_PATH = "CHANGELOG.md";
 const PACKAGE_JSON_PATH = "packages/signetai/package.json";
-const CHANGELOG_HEADER = "# Changelog\n\nAll notable changes to Signet are documented here.\n";
+const BUMP_LEVEL_PATH = ".bump-level";
+const CHANGELOG_HEADER = "# Changelog\n\nAll notable changes to Signet are documented here.";
+const HIGHLIGHT_DATE_LIMIT = 7;
+const RELEASE_LEDGER_HEADING = "## Release Ledger";
+const RECENT_HIGHLIGHTS_HEADING = "## Recent Highlights";
+const TAG_PATTERN = /^v\d+\.\d+\.\d+$/;
+const SECTION_ORDER = ["feat", "fix", "perf", "refactor", "docs"] as const;
+const RELEASE_SECTION_RE =
+	/^## \[(?<version>[^\]]+)\] - (?<date>\d{4}-\d{2}-\d{2})\n\n(?<body>[\s\S]*?)(?=^## \[|(?![\s\S]))/gm;
 
-const INCLUDE_TYPES: Record<string, string> = {
+const INCLUDE_TYPES: Record<(typeof SECTION_ORDER)[number], string> = {
 	feat: "Features",
 	fix: "Bug Fixes",
 	perf: "Performance",
@@ -16,48 +24,86 @@ const INCLUDE_TYPES: Record<string, string> = {
 	docs: "Docs",
 };
 
-interface ParsedCommit {
+const SUMMARY_LABELS: Record<(typeof SECTION_ORDER)[number], readonly [string, string]> = {
+	feat: ["feature", "features"],
+	fix: ["bug fix", "bug fixes"],
+	perf: ["performance improvement", "performance improvements"],
+	refactor: ["refactor", "refactors"],
+	docs: ["docs update", "docs updates"],
+};
+
+export interface ParsedCommit {
 	type: string;
 	scope: string | null;
 	subject: string;
 }
 
-function getPreviousTag(): string | null {
+export interface CliOptions {
+	readonly bumpOnly: boolean;
+	readonly rebuild: boolean;
+	readonly date?: string;
+	readonly version?: string;
+}
+
+export interface ReleaseEntryContext {
+	readonly currentTag?: string;
+	readonly previousTag?: string | null;
+}
+
+export interface ReleaseRecord {
+	readonly currentTag: string;
+	readonly date: string;
+	readonly groups: ReadonlyMap<string, readonly string[]>;
+	readonly previousTag: string | null;
+	readonly version: string;
+}
+
+export interface RenderedReleaseSection {
+	readonly body: string;
+	readonly date: string;
+	readonly version: string;
+}
+
+function execGit(command: string): string {
+	return execSync(command, {
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "ignore"],
+	});
+}
+
+export function getPreviousTag(): string | null {
 	try {
-		return execSync("git describe --tags --abbrev=0", {
-			encoding: "utf8",
-			stdio: ["ignore", "pipe", "ignore"],
-		}).trim();
+		return execGit("git describe --tags --abbrev=0").trim();
 	} catch {
 		return null;
 	}
 }
 
-function getCommitLog(since: string | null): string[] {
-	const range = since ? `${since}..HEAD` : "HEAD";
-	const output = execSync(`git log ${range} --format=%s`, {
-		encoding: "utf8",
-	});
+export function getCommitLog(range: string | null): string[] {
+	const ref = range ?? "HEAD";
+	const output = execGit(`git log ${ref} --format=%s`);
 	return output
 		.split("\n")
-		.map((l) => l.trim())
+		.map((line) => line.trim())
 		.filter(Boolean);
 }
 
-function parseCommit(line: string): ParsedCommit | null {
+export function getCommitLogForTags(previousTag: string | null, currentTag: string): string[] {
+	return getCommitLog(previousTag ? `${previousTag}..${currentTag}` : currentTag);
+}
+
+export function parseCommit(line: string): ParsedCommit | null {
 	const match = line.match(/^(\w+)(?:\(([^)]*)\))?: (.+)$/);
 	if (match === null) return null;
 
 	const type = match[1];
 	const scope = match[2] ?? null;
 	const subject = match[3];
-
 	if (type === undefined || subject === undefined) return null;
-
 	return { type, scope, subject };
 }
 
-function readVersion(): string {
+export function readVersion(): string {
 	const raw = readFileSync(PACKAGE_JSON_PATH, "utf8");
 	const parsed = JSON.parse(raw) as { version?: unknown };
 	if (typeof parsed.version !== "string") {
@@ -66,76 +112,317 @@ function readVersion(): string {
 	return parsed.version;
 }
 
-function formatEntry(commit: ParsedCommit): string {
+export function formatEntry(commit: ParsedCommit): string {
 	const prefix = commit.scope ? `**${commit.scope}**: ` : "";
 	return `- ${prefix}${commit.subject}`;
 }
 
-function buildSection(title: string, entries: string[]): string {
-	return `### ${title}\n\n${entries.join("\n")}\n`;
+export function buildSection(title: string, entries: readonly string[]): string {
+	return `### ${title}\n\n${entries.join("\n")}`;
 }
 
-function buildNewEntry(version: string, date: string, groups: Map<string, string[]>): string {
-	const sectionOrder = ["feat", "fix", "perf", "refactor", "docs"];
-	const sections: string[] = [];
-
-	for (const type of sectionOrder) {
-		const entries = groups.get(type);
-		const title = INCLUDE_TYPES[type];
-		if (entries && entries.length > 0 && title !== undefined) {
-			sections.push(buildSection(title, entries));
-		}
-	}
-
-	return `## [${version}] - ${date}\n\n${sections.join("\n")}\n`;
-}
-
-function main(): void {
-	const previousTag = getPreviousTag();
-	const lines = getCommitLog(previousTag);
-	const version = readVersion();
-	const date = new Date().toISOString().slice(0, 10);
-
+export function buildGroups(lines: readonly string[]): Map<string, string[]> {
 	const groups = new Map<string, string[]>();
-
 	for (const line of lines) {
 		if (line.startsWith("chore: release")) continue;
-
 		const commit = parseCommit(line);
 		if (commit === null) continue;
-		if (!(commit.type in INCLUDE_TYPES)) continue;
+		if (!Object.prototype.hasOwnProperty.call(INCLUDE_TYPES, commit.type)) continue;
 
 		const entry = formatEntry(commit);
 		const existing = groups.get(commit.type);
-		if (existing !== undefined) {
+		if (existing) {
 			existing.push(entry);
-		} else {
-			groups.set(commit.type, [entry]);
+			continue;
+		}
+		groups.set(commit.type, [entry]);
+	}
+	return groups;
+}
+
+export function countEntries(groups: ReadonlyMap<string, readonly string[]>): number {
+	return [...groups.values()].reduce((sum, entries) => sum + entries.length, 0);
+}
+
+export function computeAndWriteBumpLevel(lines: readonly string[]): BumpLevel {
+	const allSubjects = lines.filter((line) => !line.startsWith("chore: release"));
+	const bumpLevel = computeBumpLevel(allSubjects);
+	writeFileSync(BUMP_LEVEL_PATH, bumpLevel);
+	return bumpLevel;
+}
+
+export function pluralize(count: number, singular: string, plural: string): string {
+	return `${count} ${count === 1 ? singular : plural}`;
+}
+
+export function humanJoin(parts: readonly string[]): string {
+	if (parts.length === 0) return "";
+	if (parts.length === 1) return parts[0] ?? "";
+	if (parts.length === 2) return `${parts[0]} and ${parts[1]}`;
+	return `${parts.slice(0, -1).join(", ")}, and ${parts[parts.length - 1]}`;
+}
+
+export function buildReleaseSummary(groups: ReadonlyMap<string, readonly string[]>): string {
+	const parts = SECTION_ORDER.flatMap((type) => {
+		const count = groups.get(type)?.length ?? 0;
+		if (count === 0) return [];
+		const [singular, plural] = SUMMARY_LABELS[type];
+		return [pluralize(count, singular, plural)];
+	});
+
+	if (parts.length === 0) {
+		return "Release summary: internal maintenance release with no conventional commit entries captured.";
+	}
+
+	return `Release summary: ${humanJoin(parts)}.`;
+}
+
+export function buildTagRangeLine(
+	previousTag: string | null | undefined,
+	currentTag: string | undefined,
+): string | null {
+	if (!previousTag || !currentTag) return null;
+	return `Tag range: \`${previousTag}..${currentTag}\`.`;
+}
+
+export function buildEmptyReleaseNote(): string {
+	return "No notable changes were captured from conventional commit subjects for this release.";
+}
+
+export function buildNewEntry(
+	version: string,
+	date: string,
+	groups: ReadonlyMap<string, readonly string[]>,
+	ctx: ReleaseEntryContext = {},
+): string {
+	const metaLines = [buildReleaseSummary(groups)];
+	const rangeLine = buildTagRangeLine(ctx.previousTag, ctx.currentTag);
+	if (rangeLine) metaLines.push(rangeLine);
+
+	const parts = [`## [${version}] - ${date}`, metaLines.join("\n")];
+	if (countEntries(groups) === 0) {
+		parts.push(buildEmptyReleaseNote());
+		return `${parts.join("\n\n")}\n`;
+	}
+
+	const sections = SECTION_ORDER.flatMap((type) => {
+		const entries = groups.get(type);
+		const title = INCLUDE_TYPES[type];
+		if (!entries || entries.length === 0 || title === undefined) return [];
+		return [buildSection(title, entries)];
+	});
+
+	parts.push(sections.join("\n\n"));
+	return `${parts.join("\n\n")}\n`;
+}
+
+export function parseRenderedReleaseSections(content: string): RenderedReleaseSection[] {
+	const sections: RenderedReleaseSection[] = [];
+	for (const match of content.matchAll(RELEASE_SECTION_RE)) {
+		const version = match.groups?.version;
+		const date = match.groups?.date;
+		const body = match.groups?.body;
+		if (!version || !date || body === undefined) continue;
+		sections.push({ body: body.trim(), date, version });
+	}
+	return sections;
+}
+
+export function extractRenderedSectionStrings(content: string): string[] {
+	return parseRenderedReleaseSections(content).map(
+		(section) => `## [${section.version}] - ${section.date}\n\n${section.body}`,
+	);
+}
+
+export function stripHighlightNoise(line: string): string | null {
+	const trimmed = line.trim();
+	if (!trimmed.startsWith("- ")) return null;
+	return trimmed
+		.slice(2)
+		.replace(/^\*\*([^*]+)\*\*: /, "")
+		.replace(/ \(#\d+\)$/g, "")
+		.replace(/`/g, "")
+		.trim();
+}
+
+export function buildHighlightBullets(sections: readonly RenderedReleaseSection[]): string[] {
+	const byDate = new Map<string, Map<string, string[]>>();
+
+	for (const section of sections) {
+		const dateMap = byDate.get(section.date) ?? new Map<string, string[]>();
+		let currentHeading: string | null = null;
+		for (const line of section.body.split("\n")) {
+			if (line.startsWith("### ")) {
+				currentHeading = line.slice(4).trim();
+				continue;
+			}
+			const cleaned = stripHighlightNoise(line);
+			if (!cleaned || !currentHeading) continue;
+			const existing = dateMap.get(currentHeading) ?? [];
+			if (!existing.includes(cleaned)) {
+				existing.push(cleaned);
+			}
+			dateMap.set(currentHeading, existing);
+		}
+		if (!byDate.has(section.date)) byDate.set(section.date, dateMap);
+	}
+
+	const dates = [...byDate.keys()].sort((a, b) => (a < b ? 1 : -1)).slice(0, HIGHLIGHT_DATE_LIMIT);
+	const bullets: string[] = [];
+	for (const date of dates) {
+		const dateMap = byDate.get(date);
+		if (!dateMap) continue;
+
+		const dateLines = Object.values(INCLUDE_TYPES).flatMap((heading) => {
+			const entries = dateMap.get(heading);
+			if (!entries || entries.length === 0) return [];
+			const label = heading === "Bug Fixes" ? "Bug fixes" : heading;
+			return [`- ${label}: ${entries.join("; ")}.`];
+		});
+		if (dateLines.length === 0) continue;
+
+		bullets.push(`### ${date}`, ...dateLines, "");
+	}
+	return bullets;
+}
+
+export function buildRecentHighlights(sections: readonly string[]): string {
+	const parsed = parseRenderedReleaseSections(sections.join("\n\n"));
+	const bullets = buildHighlightBullets(parsed);
+	const intro =
+		"Surface summary of the most recent release dates. See the release ledger below for exact version-by-version history.";
+	if (bullets.length === 0) {
+		return `${RECENT_HIGHLIGHTS_HEADING}\n\n${intro}\n\n- No recent highlights available.`;
+	}
+	return `${RECENT_HIGHLIGHTS_HEADING}\n\n${intro}\n\n${bullets.join("\n")}`.trimEnd();
+}
+
+export function buildDocumentFromSections(sections: readonly string[]): string {
+	const highlights = buildRecentHighlights(sections);
+	const ledger = `${RELEASE_LEDGER_HEADING}\n\n${sections.join("\n\n")}`;
+	return `${CHANGELOG_HEADER}\n\n${highlights}\n\n${ledger}\n`;
+}
+
+export function prependChangelogEntry(newEntry: string): void {
+	const existing = existsSync(CHANGELOG_PATH) ? readFileSync(CHANGELOG_PATH, "utf8") : "";
+	const sections = extractRenderedSectionStrings(existing);
+	writeFileSync(CHANGELOG_PATH, buildDocumentFromSections([newEntry.trim(), ...sections]));
+}
+
+export function listVersionTags(): string[] {
+	const output = execGit("git tag --sort=v:refname");
+	return output
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => TAG_PATTERN.test(line));
+}
+
+export function getTagDate(tag: string): string {
+	return execGit(`git log -1 --format=%ad --date=short ${tag}`).trim();
+}
+
+export function buildReleaseRecord(previousTag: string | null, currentTag: string): ReleaseRecord {
+	const version = currentTag.slice(1);
+	const date = getTagDate(currentTag);
+	const groups = buildGroups(getCommitLogForTags(previousTag, currentTag));
+	return { currentTag, date, groups, previousTag, version };
+}
+
+export function buildFullChangelog(tags: readonly string[]): string {
+	const sections: string[] = [];
+	let previousTag: string | null = null;
+	for (const currentTag of tags) {
+		const record = buildReleaseRecord(previousTag, currentTag);
+		sections.push(
+			buildNewEntry(record.version, record.date, record.groups, {
+				currentTag: record.currentTag,
+				previousTag: record.previousTag,
+			}).trim(),
+		);
+		previousTag = currentTag;
+	}
+	return buildDocumentFromSections(sections.reverse());
+}
+
+export function writeFullChangelog(): number {
+	const tags = listVersionTags();
+	writeFileSync(CHANGELOG_PATH, buildFullChangelog(tags));
+	return tags.length;
+}
+
+export function parseCliArgs(argv: readonly string[]): CliOptions {
+	let bumpOnly = false;
+	let rebuild = false;
+	let date: string | undefined;
+	let version: string | undefined;
+
+	for (let i = 0; i < argv.length; i += 1) {
+		const arg = argv[i];
+		if (arg === "--bump-only") {
+			bumpOnly = true;
+			continue;
+		}
+		if (arg === "--rebuild") {
+			rebuild = true;
+			continue;
+		}
+		if (arg === "--version") {
+			const next = argv[i + 1];
+			if (!next) throw new Error("Missing value for --version");
+			version = next;
+			i += 1;
+			continue;
+		}
+		if (arg === "--date") {
+			const next = argv[i + 1];
+			if (!next) throw new Error("Missing value for --date");
+			date = next;
+			i += 1;
 		}
 	}
 
-	// Compute and write bump level for CI
-	const allSubjects = lines.filter((l) => !l.startsWith("chore: release"));
-	const bumpLevel = computeBumpLevel(allSubjects);
-	writeFileSync(".bump-level", bumpLevel);
-	console.log(`Bump level: ${bumpLevel}`);
-
-	const totalEntries = [...groups.values()].reduce((sum, arr) => sum + arr.length, 0);
-
-	if (totalEntries === 0) {
-		console.log("No notable commits found. CHANGELOG.md not modified.");
-		return;
+	if (bumpOnly && rebuild) {
+		throw new Error("--bump-only and --rebuild cannot be used together");
 	}
 
-	const newEntry = buildNewEntry(version, date, groups);
-
-	const existing = existsSync(CHANGELOG_PATH) ? readFileSync(CHANGELOG_PATH, "utf8") : "";
-
-	const body = existing.startsWith("# Changelog") ? existing.slice(CHANGELOG_HEADER.length) : existing;
-
-	writeFileSync(CHANGELOG_PATH, `${CHANGELOG_HEADER}\n${newEntry}${body}`);
-
-	console.log(`Prepended v${version} section to ${CHANGELOG_PATH}.`);
+	return { bumpOnly, rebuild, date, version };
 }
 
-main();
+export function resolveDate(explicitDate?: string): string {
+	return explicitDate ?? new Date().toISOString().slice(0, 10);
+}
+
+export function resolveVersion(explicitVersion?: string): string {
+	return explicitVersion ?? readVersion();
+}
+
+export function runChangelog(opts: CliOptions): { readonly bumpLevel: BumpLevel; readonly wroteEntry: boolean } {
+	if (opts.rebuild) {
+		const count = writeFullChangelog();
+		console.log(`Rebuilt ${CHANGELOG_PATH} from ${count} tags.`);
+		return { bumpLevel: "patch", wroteEntry: true };
+	}
+
+	const previousTag = getPreviousTag();
+	const lines = getCommitLog(previousTag ? `${previousTag}..HEAD` : "HEAD");
+	const bumpLevel = computeAndWriteBumpLevel(lines);
+	console.log(`Bump level: ${bumpLevel}`);
+	if (opts.bumpOnly) {
+		return { bumpLevel, wroteEntry: false };
+	}
+
+	const groups = buildGroups(lines);
+	const version = resolveVersion(opts.version);
+	const date = resolveDate(opts.date);
+	const newEntry = buildNewEntry(version, date, groups, {
+		currentTag: `v${version}`,
+		previousTag,
+	});
+	prependChangelogEntry(newEntry);
+	console.log(`Prepended v${version} section to ${CHANGELOG_PATH}.`);
+	return { bumpLevel, wroteEntry: true };
+}
+
+if (import.meta.main) {
+	runChangelog(parseCliArgs(process.argv.slice(2)));
+}


### PR DESCRIPTION
## Summary
- fix the release workflow so changelog entries are generated for the actual new version instead of the pre-bump package version
- rebuild `CHANGELOG.md` from semver tags and add a readable `Recent Highlights` layer above the exact release ledger
- add changelog regression coverage and update contributing docs for `--bump-only`, `--version`, and `--rebuild`

## Testing
- `bun test packages/core/src/__tests__/changelog-script.test.ts`
- `bunx @biomejs/biome check scripts/changelog.ts packages/core/src/__tests__/changelog-script.test.ts CONTRIBUTING.md docs/CONTRIBUTING.md .github/workflows/release.yml`
- `bun x tsc --noEmit --module esnext --target es2020 --skipLibCheck scripts/changelog.ts packages/core/src/__tests__/changelog-script.test.ts`
- `bun scripts/changelog.ts --rebuild`
