### PR TITLE
docs: align generated site metadata

### DIFF
--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -10,9 +10,9 @@ interface Props {
 }
 
 const SITE_NAME = "SignetAI";
-const DEFAULT_TITLE = "SignetAI — Your Agent's Memory. Your Machine. Every Platform.";
+const DEFAULT_TITLE = "SignetAI | Portable Agent State for AI Agents";
 const DEFAULT_DESCRIPTION =
-	"Signet is local-first agent infrastructure. Portable memory and identity that lives on your machine — not locked inside someone else's API. Encrypted secrets your agent can use but never read.";
+	"Local-first identity, memory, and secrets for AI agents. Portable state across models and harnesses.";
 const DEFAULT_IMAGE = "/signetposter-01.jpg";
 
 const {

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -10,7 +10,7 @@ interface Props {
 }
 
 const SITE_NAME = "SignetAI";
-const DEFAULT_TITLE = "SignetAI | Portable Agent State for AI Agents";
+const DEFAULT_TITLE = "SignetAI | Portable Agent State";
 const DEFAULT_DESCRIPTION =
 	"Local-first identity, memory, and secrets for AI agents. Portable state across models and harnesses.";
 const DEFAULT_IMAGE = "/signetposter-01.jpg";

--- a/web/src/pages/llms-full.txt.ts
+++ b/web/src/pages/llms-full.txt.ts
@@ -15,7 +15,7 @@ export async function GET(context: APIContext) {
 	const sections: string[] = [
 		"# SignetAI — Full Documentation",
 		"",
-		"> Signet is local-first agent infrastructure. Portable memory, encrypted secrets, and identity that lives on your machine — not locked inside someone else's API.",
+		"> Local-first identity, memory, and secrets for AI agents. Portable state across models and harnesses.",
 		"",
 		`Source: ${site}`,
 		"",

--- a/web/src/pages/llms.txt.ts
+++ b/web/src/pages/llms.txt.ts
@@ -11,7 +11,7 @@ export async function GET(context: APIContext) {
 	const lines: string[] = [
 		"# SignetAI",
 		"",
-		"> Signet is local-first agent infrastructure. Portable memory, encrypted secrets, and identity that lives on your machine — not locked inside someone else's API.",
+		"> Local-first identity, memory, and secrets for AI agents. Portable state across models and harnesses.",
 		"",
 		`Full documentation: ${site}/llms-full.txt`,
 		"",

--- a/web/src/pages/rss.xml.ts
+++ b/web/src/pages/rss.xml.ts
@@ -1,9 +1,9 @@
-import rss from "@astrojs/rss";
-import { getCollection } from "astro:content";
-import type { APIContext } from "astro";
 import { readdirSync, statSync } from "node:fs";
-import { resolve, dirname } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { getCollection } from "astro:content";
+import rss from "@astrojs/rss";
+import type { APIContext } from "astro";
 
 export const prerender = true;
 
@@ -71,8 +71,7 @@ export async function GET(context: APIContext) {
 
 	return rss({
 		title: "SignetAI",
-		description:
-			"Signet is local-first agent infrastructure. Portable memory, encrypted secrets, and identity that lives on your machine.",
+		description: "Local-first identity, memory, and secrets for AI agents. Portable state across models and harnesses.",
 		site: context.site?.toString() ?? "https://signetai.sh",
 		items,
 		customData: "<language>en-us</language>",


### PR DESCRIPTION
## Summary

This follow-up aligns remaining generated/public website metadata with the new portable agent state positioning.

Changes include:

- Update the default site title and description used by Open Graph/Twitter metadata.
- Update `/llms.txt` and `/llms-full.txt` summary copy.
- Update the RSS feed description.

## Readiness checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) (N/A: metadata-only copy update, no spec-governed behavior)
- [x] Agent scoping verified on all new/changed data queries (N/A: no data queries)
- [x] Input/config validation and bounds checks added (N/A: no runtime inputs or config paths)
- [x] Error handling and fallback paths tested (no silent swallow) (N/A: no error/fallback paths changed)
- [x] Security checks applied to admin/mutation endpoints (N/A: no endpoints changed)
- [x] Docs updated for API/spec/status changes (N/A: no API/spec/status behavior changed)
- [x] Regression tests added for each bug fix (N/A: no bug fix)
- [x] Lint/typecheck/tests pass locally

Notes: this is generated website metadata only. The checklist stays checked because the repository CI requires these exact checked items, with inapplicable items marked explicitly above.

## Validation

- `rg -n "Your Agent's Memory|Portable memory and identity|Portable memory, encrypted secrets|not locked inside|persistent memory|home directory|Predictive Scorer|predictive scorer|persistent cognition" web/src/layouts web/src/pages web/src/components --glob '!web/dist/**' || true`
- `bunx @biomejs/biome check web/src/layouts/Base.astro web/src/pages/llms.txt.ts web/src/pages/llms-full.txt.ts web/src/pages/rss.xml.ts`
- `git diff --check`
- `cd web && bun run build`