### PR TITLE
fix(mcp): expose pinned param in memory_store and memory_modify

### DIFF
--- a/packages/daemon-rs/crates/signet-daemon/src/mcp/tools.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/mcp/tools.rs
@@ -77,6 +77,7 @@ pub fn definitions() -> Vec<ToolDefinition> {
                     "agent_id": { "type": "string", "description": "Agent id scope (requires matching session_key for non-default)" },
                     "visibility": { "type": "string", "enum": ["global", "private", "archived"], "description": "Memory visibility (requires session_key for non-default)" },
                     "scope": { "type": "string", "description": "Optional scope partition key (requires session_key when set)" },
+                    "pinned": { "type": "boolean", "description": "Pin this memory — prevents decay, bypasses 0.95^days aging" },
                 },
                 "required": ["content"],
             }),
@@ -115,6 +116,7 @@ pub fn definitions() -> Vec<ToolDefinition> {
                     "content": { "type": "string", "description": "New content" },
                     "importance": { "type": "number" },
                     "tags": { "type": "array", "items": { "type": "string" } },
+                    "pinned": { "type": "boolean", "description": "Pin or unpin this memory" },
                 },
                 "required": ["id"],
             }),
@@ -465,6 +467,7 @@ async fn exec_memory_store(state: &Arc<AppState>, args: &serde_json::Value) -> T
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(str::to_string);
+    let pinned = args.get("pinned").and_then(|v| v.as_bool()).unwrap_or(false);
     if session_key.is_none() && (visibility != "global" || scope.is_some()) {
         return ToolCallResult::error(
             "non-default visibility/scope requires session_key".to_string(),
@@ -497,7 +500,7 @@ async fn exec_memory_store(state: &Arc<AppState>, args: &serde_json::Value) -> T
                 why: None,
                 project: None,
                 importance,
-                pinned: false,
+                pinned,
                 source_type: None,
                 source_id: None,
                 idempotency_key: None,
@@ -719,6 +722,7 @@ mod tests {
         assert!(props.contains_key("agent_id"));
         assert!(props.contains_key("visibility"));
         assert!(props.contains_key("scope"));
+        assert!(props.contains_key("pinned"));
     }
 
     #[test]

--- a/packages/daemon/src/mcp/tools.test.ts
+++ b/packages/daemon/src/mcp/tools.test.ts
@@ -317,6 +317,19 @@ describe("createMcpServer", () => {
 			const body = JSON.parse(cap.body ?? "{}");
 			expect(body.content).toBe("[foo,bar]: tagged memory");
 		});
+
+		it("passes pinned through to request body", async () => {
+			const cap: { body?: string } = {};
+			mockFetch(200, { id: "pin-1", deduped: false }, cap);
+
+			await callTool(server, "memory_store", {
+				content: "critical constraint",
+				pinned: true,
+			});
+
+			const body = JSON.parse(cap.body ?? "{}");
+			expect(body.pinned).toBe(true);
+		});
 	});
 
 	describe("memory_get", () => {
@@ -356,6 +369,21 @@ describe("createMcpServer", () => {
 			const body = JSON.parse(cap.body ?? "{}");
 			expect(body.content).toBe("updated content");
 			expect(body.reason).toBe("fixing typo");
+		});
+
+		it("passes pinned through to PATCH body", async () => {
+			const cap: { method?: string; body?: string } = {};
+			mockFetch(200, { status: "updated" }, cap);
+
+			await callTool(server, "memory_modify", {
+				id: "abc",
+				pinned: true,
+				reason: "promoting to pinned",
+			});
+
+			expect(cap.method).toBe("PATCH");
+			const body = JSON.parse(cap.body ?? "{}");
+			expect(body.pinned).toBe(true);
 		});
 	});
 

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -676,6 +676,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 				type: z.string().optional().describe("Memory type (fact, preference, decision, etc.)"),
 				importance: z.number().optional().describe("Importance score 0-1"),
 				tags: z.string().optional().describe("Comma-separated tags for categorization"),
+				pinned: z.boolean().optional().describe("Pin this memory — prevents decay, bypasses 0.95^days aging"),
 				transcript: z
 					.string()
 					.optional()
@@ -713,7 +714,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 			}),
 			annotations: { readOnlyHint: false },
 		},
-		async ({ content, type, importance, tags, transcript, structured }) => {
+		async ({ content, type, importance, tags, transcript, structured, pinned }) => {
 			// Prepend tags prefix if provided (daemon parses [tag1,tag2]: format)
 			let body = content;
 			if (tags) {
@@ -727,6 +728,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 					importance,
 					transcript,
 					structured,
+					pinned,
 				},
 			});
 
@@ -804,11 +806,12 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 				type: z.string().optional().describe("New type"),
 				importance: z.number().optional().describe("New importance"),
 				tags: z.string().optional().describe("New tags (comma-separated)"),
+				pinned: z.boolean().optional().describe("Pin or unpin this memory"),
 				reason: z.string().describe("Why this edit is being made"),
 			}),
 			annotations: { readOnlyHint: false },
 		},
-		async ({ id, content, type, importance, tags, reason }) => {
+		async ({ id, content, type, importance, tags, reason, pinned }) => {
 			const result = await daemonFetch<unknown>(baseUrl, `/api/memory/${encodeURIComponent(id)}`, {
 				method: "PATCH",
 				body: {
@@ -817,6 +820,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 					importance,
 					tags,
 					reason,
+					pinned,
 				},
 			});
 

--- a/packages/opencode-plugin/src/tools.ts
+++ b/packages/opencode-plugin/src/tools.ts
@@ -191,7 +191,7 @@ export function createTools(client: DaemonClient): Record<string, ReturnType<typ
 
 				if (result === null) return DAEMON_OFFLINE_MSG;
 				const id = result.id ?? result.memoryId;
-				return id ? `Saved: ${args.content.slice(0, 50)}` : "Saved.";
+				return id ? `Saved${args.pinned ? " (pinned)" : ""}: ${args.content.slice(0, 50)}` : "Saved.";
 			},
 		}),
 

--- a/packages/opencode-plugin/src/tools.ts
+++ b/packages/opencode-plugin/src/tools.ts
@@ -52,6 +52,7 @@ export function createTools(client: DaemonClient): Record<string, ReturnType<typ
 				type: tool.schema.string().optional().describe("Memory type (fact, preference, decision, etc.)"),
 				importance: tool.schema.number().optional().describe("Importance score 0-1"),
 				tags: tool.schema.array(tool.schema.string()).optional().describe("Tags for categorization"),
+				pinned: tool.schema.boolean().optional().describe("Pin this memory — prevents decay"),
 			},
 			async execute(args): Promise<string> {
 				const result = await client.post<{ id?: string; memoryId?: string }>(
@@ -61,6 +62,7 @@ export function createTools(client: DaemonClient): Record<string, ReturnType<typ
 						type: args.type,
 						importance: args.importance,
 						tags: args.tags,
+						pinned: args.pinned,
 						who: HARNESS,
 					},
 					WRITE_TIMEOUT,
@@ -68,7 +70,7 @@ export function createTools(client: DaemonClient): Record<string, ReturnType<typ
 
 				if (result === null) return DAEMON_OFFLINE_MSG;
 				const id = result.id ?? result.memoryId;
-				return id ? `Memory saved (id: ${id})` : "Memory saved.";
+				return id ? `Memory saved${args.pinned ? " (pinned)" : ""} (id: ${id})` : "Memory saved.";
 			},
 		}),
 
@@ -124,13 +126,14 @@ export function createTools(client: DaemonClient): Record<string, ReturnType<typ
 				tags: tool.schema.string().optional().describe("New tags comma-separated"),
 				reason: tool.schema.string().describe("Why this edit is being made"),
 				if_version: tool.schema.number().optional().describe("Optimistic lock version"),
+				pinned: tool.schema.boolean().optional().describe("Pin or unpin this memory"),
 			},
 			async execute(args): Promise<string> {
-				const { id, reason, content, type, importance, tags, if_version } = args;
+				const { id, reason, content, type, importance, tags, if_version, pinned } = args;
 
 				const result = await client.patch<{ success?: boolean }>(
 					`/api/memory/${encodeURIComponent(id)}`,
-					{ content, type, importance, tags, reason, if_version },
+					{ content, type, importance, tags, reason, if_version, pinned },
 					WRITE_TIMEOUT,
 				);
 
@@ -170,6 +173,7 @@ export function createTools(client: DaemonClient): Record<string, ReturnType<typ
 				type: tool.schema.string().optional().describe("Memory type"),
 				importance: tool.schema.number().optional().describe("Importance 0-1"),
 				tags: tool.schema.array(tool.schema.string()).optional().describe("Tags"),
+				pinned: tool.schema.boolean().optional().describe("Pin this memory — prevents decay"),
 			},
 			async execute(args): Promise<string> {
 				const result = await client.post<{ id?: string; memoryId?: string }>(
@@ -179,6 +183,7 @@ export function createTools(client: DaemonClient): Record<string, ReturnType<typ
 						type: args.type,
 						importance: args.importance,
 						tags: args.tags,
+						pinned: args.pinned,
 						who: HARNESS,
 					},
 					WRITE_TIMEOUT,


### PR DESCRIPTION
Closes #490

## Problem

The MCP tool schemas for `memory_store` and `memory_modify` did not include the `pinned` parameter. Agents using the MCP interface had no way to pin memories — they decayed at `0.95^days` like everything else, even when the agent protocol called for pinning critical constraints.

The REST API, database, CLI, and scoring already fully supported pinning. Only the MCP input schemas were missing the field.

## Changes

| File | What changed |
|---|---|
| `packages/daemon/src/mcp/tools.ts` | Added `pinned` to `memory_store` and `memory_modify` input schemas, handler destructuring, and fetch bodies |
| `packages/opencode-plugin/src/tools.ts` | Added `pinned` to `memory_store`, `memory_modify`, and `remember` alias (args, bodies, success message) |
| `packages/daemon-rs/crates/signet-daemon/src/mcp/tools.rs` | Added `pinned` to store/modify schemas, parsed in `exec_memory_store` handler, updated existing Rust test assertion |
| `packages/daemon/src/mcp/tools.test.ts` | Added 2 regression tests: `memory_store` and `memory_modify` pass `pinned: true` through to request body |

## PR checklist

- [x] Not spec-governed (narrow bug fix within existing contracts)
- [x] Agent scoping unchanged (pinned is orthogonal to scoping)
- [x] No new validation needed (`pinned` is `z.boolean().optional()`, defaults to `false`/omitted)
- [x] Error handling unchanged (existing fallback paths preserved)
- [x] No security surface change (pinned is a data attribute, not an auth gate)
- [x] No doc/API changes needed (`memory_search` already documents `pinned` as a filter — this PR makes write parity)
- [x] No publish manifest changes
- [x] Each fix has a regression test (2 new tests)
- [x] Lint, typecheck, and tests pass locally on changed files
- [x] Note: Rust daemon `memory_modify` handler is a stub (returns "not yet implemented" at line 344) — only the schema was updated, not the handler

## AI disclosure

This PR was authored with AI assistance per [AI_POLICY.md](https://github.com/Signet-AI/signetai/blob/main/AI_POLICY.md). All changes were human-reviewed and verified.