### PR TITLE
fix(hooks): prompt agents to check memory before acting

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -17,8 +17,8 @@ Hooks are HTTP endpoints exposed by the Signet [[daemon]]. Harnesses call them a
 
 | Hook | When | Purpose |
 |------|------|---------|
-| `session-start` | New session begins | Inject memories and identity into context |
-| `user-prompt-submit` | Before each user turn | Prefer structured recall, then temporal fallback, then transcript fallback when needed |
+| `session-start` | New session begins | Inject memories, identity, and the Memory Check Loop into context |
+| `user-prompt-submit` | Before each user turn | Inject lightweight per-turn Memory Check guidance plus structured, temporal, or transcript recall when needed |
 | `session-end` | Session finishes | Persist transcript lineage and queue session summary |
 | `pre-compaction` | Before context compaction | Get summary guidelines |
 | `compaction-complete` | After compaction | Save a first-class compaction artifact into the temporal DAG |
@@ -108,7 +108,12 @@ Called when a new agent session begins. Returns memories and context formatted f
 }
 ```
 
-The `inject` field is ready-to-use text for prepending to the system prompt. It includes identity, memories, and recent context formatted as markdown.
+The `inject` field is ready-to-use text for prepending to the system prompt. It includes identity, memories, recent context, and the Memory Check Loop formatted as markdown.
+
+The Memory Check Loop tells agents when prior context may matter, how to run
+1-3 targeted recalls, what pitfalls to avoid, and how to verify they are
+grounded before acting. It is intentionally behavioral prompt shaping, not a
+new hook schema or recall algorithm.
 
 ### Configuration
 
@@ -126,6 +131,31 @@ hooks:
 Memory scoring uses: `score = importance × (1 - recencyBias) + recency × recencyBias`
 
 where recency is `1 / (1 + age_in_days)`.
+
+---
+
+## User Prompt Submit Hook
+
+**`POST /api/hooks/user-prompt-submit`**
+
+Called before each user turn is handed to the model. Returns lightweight
+context for the current prompt.
+
+The hook always includes current date/time metadata and per-turn Memory Check
+guidance unless the session is bypassed. When automatic recall finds useful
+context, the response also includes a `## Relevant Memory` block. When no
+strong automatic match is found, the response says so explicitly and reminds
+the agent to run targeted Signet recall before acting if the request depends
+on prior context, preferences, project history, or unresolved work.
+
+Recall order is:
+
+1. structured memory recall,
+2. temporal thread-head fallback,
+3. transcript fallback.
+
+The guidance is meant to prevent agents from treating an empty automatic
+inject as proof that no prior context exists.
 
 ---
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -146,7 +146,9 @@ guidance unless the session is bypassed. When automatic recall finds useful
 context, the response also includes a `## Relevant Memory` block. When no
 strong automatic match is found, the response says so explicitly and reminds
 the agent to run targeted Signet recall before acting if the request depends
-on prior context, preferences, project history, or unresolved work.
+on prior context, preferences, project history, or unresolved work. Both
+matched and no-strong-match paths also remind the agent to save durable facts
+with `/remember` or `memory_store`.
 
 Recall order is:
 

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -110,6 +110,12 @@ fn build_signet_system_prompt() -> &'static str {
     "[signet active]\n\
 You have persistent memory managed by Signet.\n\
 \n\
+Memory Check Loop:\n\
+- when to use: before commands, file edits, architectural choices, bug fixes, continuation work, user-preference-sensitive answers, or anything that may depend on prior decisions\n\
+- procedure: check injected context first, then run 1-3 targeted recalls with mcp__signet__memory_search; expand session lineage with mcp__signet__lcm_expand or known entities with mcp__signet__knowledge_expand and mcp__signet__knowledge_expand_session when needed\n\
+- pitfalls: do not treat a missing automatic memory match as proof no prior context exists; do not trust memory blindly when repo, files, or live system state can verify it; do not spam broad recalls for trivial self-contained prompts\n\
+- verification: before acting, know what context you found, what remains unknown, and whether it is safe to proceed\n\
+\n\
 Memory tools:\n\
 - mcp__signet__memory_search: search stored memories by keyword or meaning\n\
 - mcp__signet__lcm_expand: expand a session summary into its full lineage and linked memories\n\
@@ -812,6 +818,11 @@ fn build_prompt_recall_inject(metadata_header: &str, sources: &[String]) -> Stri
     let mut parts = vec![
         metadata_header.trim_end().to_string(),
         String::new(),
+        "## Memory Check".to_string(),
+        String::new(),
+        "Use the memories below as starting context before acting. If the task depends on prior context and anything is missing, run 1-3 targeted recalls with /recall or memory_search, then expand with lcm_expand or knowledge_expand when needed."
+            .to_string(),
+        String::new(),
         "## Relevant Memory".to_string(),
         String::new(),
     ];
@@ -820,11 +831,17 @@ fn build_prompt_recall_inject(metadata_header: &str, sources: &[String]) -> Stri
     parts.push(String::new());
 
     parts.push(
-        "if you need deeper history, use /recall or memory_search. if you learn something durable, save it with /remember or memory_store."
-            .to_string(),
+        "If you learn something durable, save it with /remember or memory_store.".to_string(),
     );
 
     format!("{}\n", parts.join("\n").trim_end())
+}
+
+fn build_no_strong_memory_match_inject(metadata_header: &str) -> String {
+    format!(
+        "{}\n\n## Memory Check\n\nNo strong automatic memory match was injected for this turn. If the request depends on prior context, preferences, project history, or unresolved work, run 1-3 targeted Signet recalls before executing commands, editing files, or making decisions.\n",
+        metadata_header.trim_end()
+    )
 }
 
 pub async fn prompt_submit(
@@ -980,7 +997,7 @@ pub async fn prompt_submit(
         return (
             StatusCode::OK,
             Json(serde_json::json!({
-                "inject": metadata_header,
+                "inject": build_no_strong_memory_match_inject(&metadata_header),
                 "memoryCount": 0,
                 "queryTerms": query_terms,
             })),
@@ -1256,7 +1273,7 @@ pub async fn prompt_submit(
             }
 
             Ok(serde_json::json!({
-                "inject": metadata_header,
+                "inject": build_no_strong_memory_match_inject(&metadata_header),
                 "memoryCount": 0,
                 "queryTerms": query_terms_for_resp,
             }))
@@ -3122,10 +3139,16 @@ mod tests {
             body["engine"],
             serde_json::Value::String("temporal-fallback".to_string())
         );
+        assert!(inject.contains("## Memory Check"));
         assert!(inject.contains("## Relevant Memory"));
         assert!(inject.contains("[thread node-1]"));
-        assert!(inject.contains("prompt submit observability review now uses structured recall formatting"));
-        assert!(inject.contains("if you need deeper history, use /recall or memory_search"));
+        assert!(
+            inject.contains(
+                "prompt submit observability review now uses structured recall formatting"
+            )
+        );
+        assert!(inject.contains("Use the memories below as starting context before acting"));
+        assert!(inject.contains("run 1-3 targeted recalls with /recall or memory_search"));
         assert!(!inject.contains("[signet:recall"));
 
         drop(state);
@@ -3530,7 +3553,12 @@ Assistant: here's the checklist",
 
     #[test]
     fn build_signet_system_prompt_mentions_transcript_artifacts() {
-        assert!(build_signet_system_prompt().contains("linked summary and transcript artifacts"));
+        let prompt = build_signet_system_prompt();
+        assert!(prompt.contains("linked summary and transcript artifacts"));
+        assert!(prompt.contains("Memory Check Loop"));
+        assert!(prompt.contains("before commands, file edits, architectural choices"));
+        assert!(prompt.contains("run 1-3 targeted recalls with mcp__signet__memory_search"));
+        assert!(prompt.contains("missing automatic memory match as proof no prior context exists"));
     }
 
     #[test]

--- a/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/packages/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -839,7 +839,7 @@ fn build_prompt_recall_inject(metadata_header: &str, sources: &[String]) -> Stri
 
 fn build_no_strong_memory_match_inject(metadata_header: &str) -> String {
     format!(
-        "{}\n\n## Memory Check\n\nNo strong automatic memory match was injected for this turn. If the request depends on prior context, preferences, project history, or unresolved work, run 1-3 targeted Signet recalls before executing commands, editing files, or making decisions.\n",
+        "{}\n\n## Memory Check\n\nNo strong automatic memory match was injected for this turn. If the request depends on prior context, preferences, project history, or unresolved work, run 1-3 targeted Signet recalls before executing commands, editing files, or making decisions.\n\nIf you learn something durable, save it with /remember or memory_store.\n",
         metadata_header.trim_end()
     )
 }
@@ -2769,8 +2769,8 @@ mod tests {
 
     use super::{
         CHECKPOINT_MIN_DELTA, CompactionCompleteBody, PromptSubmitBody, SessionEndBody,
-        build_signet_system_prompt, compaction_complete, extract_delta,
-        normalize_session_transcript, parse_visibility, prompt_submit,
+        build_no_strong_memory_match_inject, build_signet_system_prompt, compaction_complete,
+        extract_delta, normalize_session_transcript, parse_visibility, prompt_submit,
         require_session_scope_for_write, resolve_audit_token, resolve_compaction_project,
         resolve_remember_agent, session_agent_id, session_end, session_transcript_content,
         strip_untrusted_metadata, upsert_session_transcript,
@@ -2793,6 +2793,16 @@ mod tests {
             }
             path.extension().and_then(|ext| ext.to_str()) == Some("md")
         })
+    }
+
+    #[test]
+    fn no_strong_memory_match_inject_keeps_save_hint() {
+        let inject = build_no_strong_memory_match_inject("# Current Date & Time\nnow\n");
+
+        assert!(inject.contains("## Memory Check"));
+        assert!(inject.contains("No strong automatic memory match was injected"));
+        assert!(inject.contains("run 1-3 targeted Signet recalls before executing commands"));
+        assert!(inject.contains("save it with /remember or memory_store"));
     }
 
     fn test_state(name: &str) -> (Arc<AppState>, tokio::task::JoinHandle<()>, TempDir) {

--- a/packages/daemon/src/hooks.prompt-submit.test.ts
+++ b/packages/daemon/src/hooks.prompt-submit.test.ts
@@ -133,6 +133,7 @@ describe("handleUserPromptSubmit observability", () => {
 		expect(result.inject).toContain("## Memory Check");
 		expect(result.inject).toContain("No strong automatic memory match was injected");
 		expect(result.inject).toContain("run 1-3 targeted Signet recalls before executing commands");
+		expect(result.inject).toContain("save it with /remember or memory_store");
 		const submitCalls = infoMock.mock.calls.filter((call) => call[1] === "User prompt submit");
 		expect(submitCalls).toHaveLength(1);
 		const payload = submitCalls[0]?.[2];
@@ -311,10 +312,32 @@ describe("handleUserPromptSubmit observability", () => {
 		expect(result.inject).toContain("Current Date & Time");
 		expect(result.inject).toContain("## Memory Check");
 		expect(result.inject).toContain("No strong automatic memory match was injected");
+		expect(result.inject).toContain("save it with /remember or memory_store");
 		expect(result.inject).not.toContain("[signet:recall");
 		const submitCalls = infoMock.mock.calls.filter((call) => call[1] === "User prompt submit");
 		expect(submitCalls).toHaveLength(1);
 		const payload = submitCalls[0]?.[2];
 		expect(payload?.engine).toBe("low-confidence");
+	});
+
+	it("returns Memory Check guidance when hybrid recall fails", async () => {
+		hybridRecallMock.mockRejectedValueOnce(new Error("synthetic recall failure"));
+
+		const result = await handleUserPromptSubmit(
+			{
+				harness: "vscode-custom-agent",
+				userMessage: "show memory failure behavior",
+				sessionKey: "session-recall-failure",
+			},
+			makeDeps(),
+		);
+
+		expect(result.memoryCount).toBe(0);
+		expect(result.inject).toContain("Current Date & Time");
+		expect(result.inject).toContain("## Memory Check");
+		expect(result.inject).toContain("No strong automatic memory match was injected");
+		expect(result.inject).toContain("run 1-3 targeted Signet recalls before executing commands");
+		expect(result.inject).toContain("save it with /remember or memory_store");
+		expect(errorMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/daemon/src/hooks.prompt-submit.test.ts
+++ b/packages/daemon/src/hooks.prompt-submit.test.ts
@@ -130,6 +130,9 @@ describe("handleUserPromptSubmit observability", () => {
 		);
 
 		expect(result.engine).toBeUndefined();
+		expect(result.inject).toContain("## Memory Check");
+		expect(result.inject).toContain("No strong automatic memory match was injected");
+		expect(result.inject).toContain("run 1-3 targeted Signet recalls before executing commands");
 		const submitCalls = infoMock.mock.calls.filter((call) => call[1] === "User prompt submit");
 		expect(submitCalls).toHaveLength(1);
 		const payload = submitCalls[0]?.[2];
@@ -163,9 +166,11 @@ describe("handleUserPromptSubmit observability", () => {
 		expect(payload?.engine).toBe("temporal-fallback");
 		expect(payload?.memoryCount).toBe(1);
 		expect(searchTranscriptFallbackMock).not.toHaveBeenCalled();
+		expect(result.inject).toContain("## Memory Check");
 		expect(result.inject).toContain("## Relevant Memory");
 		expect(result.inject).toContain("[thread node-1]");
-		expect(result.inject).toContain("if you need deeper history, use /recall or memory_search");
+		expect(result.inject).toContain("Use the memories below as starting context before acting");
+		expect(result.inject).toContain("run 1-3 targeted recalls with /recall or memory_search");
 		expect(result.inject).not.toContain("[signet:recall");
 	});
 
@@ -194,6 +199,7 @@ describe("handleUserPromptSubmit observability", () => {
 		const payload = submitCalls[0]?.[2];
 		expect(payload?.engine).toBe("transcript-fallback");
 		expect(payload?.memoryCount).toBe(1);
+		expect(result.inject).toContain("## Memory Check");
 		expect(result.inject).toContain("## Relevant Memory");
 		expect(result.inject).toContain("[transcript session-2]");
 		expect(result.inject).toContain("save it with /remember or memory_store");
@@ -229,9 +235,11 @@ describe("handleUserPromptSubmit observability", () => {
 
 		expect(result.engine).toBe("hybrid");
 		expect(result.memoryCount).toBe(2);
+		expect(result.inject).toContain("## Memory Check");
 		expect(result.inject).toContain("## Relevant Memory");
 		expect(result.inject).toContain("[memory] prompt submit observability now logs fallback engine transitions");
-		expect(result.inject).toContain("if you need deeper history, use /recall or memory_search");
+		expect(result.inject).toContain("Use the memories below as starting context before acting");
+		expect(result.inject).toContain("run 1-3 targeted recalls with /recall or memory_search");
 		expect(result.inject).not.toContain("[signet:recall");
 	});
 
@@ -269,6 +277,7 @@ describe("handleUserPromptSubmit observability", () => {
 
 			expect(result.engine).toBe("hybrid");
 			expect(result.memoryCount).toBe(1);
+			expect(result.inject).toContain("## Memory Check");
 			expect(result.inject).toContain("## Relevant Memory");
 			expect(result.inject).toContain("i am so proud of you");
 			expect(result.inject).not.toContain("workspace migration checklist");
@@ -300,6 +309,8 @@ describe("handleUserPromptSubmit observability", () => {
 
 		expect(result.memoryCount).toBe(0);
 		expect(result.inject).toContain("Current Date & Time");
+		expect(result.inject).toContain("## Memory Check");
+		expect(result.inject).toContain("No strong automatic memory match was injected");
 		expect(result.inject).not.toContain("[signet:recall");
 		const submitCalls = infoMock.mock.calls.filter((call) => call[1] === "User prompt submit");
 		expect(submitCalls).toHaveLength(1);

--- a/packages/daemon/src/hooks.test.ts
+++ b/packages/daemon/src/hooks.test.ts
@@ -26,6 +26,11 @@ describe("buildSignetSystemPrompt", () => {
 		expect(prompt).toContain("mcp__signet__secret_list");
 		expect(prompt).toContain("mcp__signet__secret_exec");
 		expect(prompt).toContain("linked summary and transcript artifacts");
+		expect(prompt).toContain("Memory Check Loop");
+		expect(prompt).toContain("before commands, file edits, architectural choices");
+		expect(prompt).toContain("run 1-3 targeted recalls with mcp__signet__memory_search");
+		expect(prompt).toContain("do not treat a missing automatic memory match as proof no prior context exists");
+		expect(prompt).toContain("before acting, know what context you found");
 	});
 });
 
@@ -337,9 +342,9 @@ describe("normalizeSessionTranscript", () => {
 
 describe("selectWithTokenBudget", () => {
 	const rows = [
-		{ content: "alpha ".repeat(50) },   // ~50 tokens
-		{ content: "beta ".repeat(50) },    // ~50 tokens
-		{ content: "gamma ".repeat(200) },  // ~200 tokens
+		{ content: "alpha ".repeat(50) }, // ~50 tokens
+		{ content: "beta ".repeat(50) }, // ~50 tokens
+		{ content: "gamma ".repeat(200) }, // ~200 tokens
 	];
 
 	it("selects rows up to the token budget", () => {

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -556,6 +556,8 @@ function buildNoStrongMemoryMatchInject(metadataHeader: string): string {
 ## Memory Check
 
 No strong automatic memory match was injected for this turn. If the request depends on prior context, preferences, project history, or unresolved work, run 1-3 targeted Signet recalls before executing commands, editing files, or making decisions.
+
+If you learn something durable, save it with /remember or memory_store.
 `;
 }
 
@@ -2523,6 +2525,8 @@ export async function handleUserPromptSubmit(
 		);
 	}
 
+	// `metadataHeader` is deliberately built before this try/catch so even
+	// recall failures can return the per-turn Memory Check guidance.
 	try {
 		const cfg = deps.loadMemoryConfig(getAgentsDir());
 		const recallLimit = submitCfg.recallLimit ?? 10;

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -162,6 +162,12 @@ export function buildSignetSystemPrompt(): string {
 	return `[signet active]
 You have persistent memory managed by Signet.
 
+Memory Check Loop:
+- when to use: before commands, file edits, architectural choices, bug fixes, continuation work, user-preference-sensitive answers, or anything that may depend on prior decisions
+- procedure: check injected context first, then run 1-3 targeted recalls with mcp__signet__memory_search; expand session lineage with mcp__signet__lcm_expand or known entities with mcp__signet__knowledge_expand and mcp__signet__knowledge_expand_session when needed
+- pitfalls: do not treat a missing automatic memory match as proof no prior context exists; do not trust memory blindly when repo, files, or live system state can verify it; do not spam broad recalls for trivial self-contained prompts
+- verification: before acting, know what context you found, what remains unknown, and whether it is safe to proceed
+
 Memory tools:
 - mcp__signet__memory_search: search stored memories by keyword or meaning
 - mcp__signet__lcm_expand: expand a session summary into its full lineage and linked memories
@@ -528,13 +534,29 @@ export function applyTokenBudget(inject: string, mainBudget: number): string {
 function buildPromptRecallInject(metadataHeader: string, lines: ReadonlyArray<string>): string {
 	// Keep formatting behavior aligned with daemon-rs
 	// `build_prompt_recall_inject()` in `packages/daemon-rs/.../routes/hooks.rs`.
-	const parts = [metadataHeader.trimEnd(), "", "## Relevant Memory", ""];
+	const parts = [
+		metadataHeader.trimEnd(),
+		"",
+		"## Memory Check",
+		"",
+		"Use the memories below as starting context before acting. If the task depends on prior context and anything is missing, run 1-3 targeted recalls with /recall or memory_search, then expand with lcm_expand or knowledge_expand when needed.",
+		"",
+		"## Relevant Memory",
+		"",
+	];
 	parts.push(...lines);
 	parts.push("");
-	parts.push(
-		"if you need deeper history, use /recall or memory_search. if you learn something durable, save it with /remember or memory_store.",
-	);
+	parts.push("If you learn something durable, save it with /remember or memory_store.");
 	return `${parts.join("\n").trimEnd()}\n`;
+}
+
+function buildNoStrongMemoryMatchInject(metadataHeader: string): string {
+	return `${metadataHeader.trimEnd()}
+
+## Memory Check
+
+No strong automatic memory match was injected for this turn. If the request depends on prior context, preferences, project history, or unresolved work, run 1-3 targeted Signet recalls before executing commands, editing files, or making decisions.
+`;
 }
 
 /** Build a brief "since your last session" summary for temporal awareness */
@@ -2477,7 +2499,7 @@ export async function handleUserPromptSubmit(
 			userMessage,
 			start,
 			{
-				inject: metadataHeader,
+				inject: buildNoStrongMemoryMatchInject(metadataHeader),
 				memoryCount: 0,
 				warnings,
 			},
@@ -2492,7 +2514,7 @@ export async function handleUserPromptSubmit(
 			userMessage,
 			start,
 			{
-				inject: metadataHeader,
+				inject: buildNoStrongMemoryMatchInject(metadataHeader),
 				memoryCount: 0,
 				warnings,
 			},
@@ -2569,7 +2591,7 @@ export async function handleUserPromptSubmit(
 					userMessage,
 					start,
 					{
-						inject: metadataHeader,
+						inject: buildNoStrongMemoryMatchInject(metadataHeader),
 						memoryCount: 0,
 						warnings,
 					},
@@ -2584,7 +2606,7 @@ export async function handleUserPromptSubmit(
 				userMessage,
 				start,
 				{
-					inject: metadataHeader,
+					inject: buildNoStrongMemoryMatchInject(metadataHeader),
 					memoryCount: 0,
 					warnings,
 				},
@@ -2636,7 +2658,7 @@ export async function handleUserPromptSubmit(
 				userMessage,
 				start,
 				{
-					inject: metadataHeader,
+					inject: buildNoStrongMemoryMatchInject(metadataHeader),
 					memoryCount: 0,
 					warnings,
 				},
@@ -2692,7 +2714,7 @@ export async function handleUserPromptSubmit(
 		);
 	} catch (e) {
 		deps.logger.error("hooks", "User prompt submit failed", e as Error);
-		return { inject: "", memoryCount: 0, warnings };
+		return { inject: buildNoStrongMemoryMatchInject(metadataHeader), memoryCount: 0, warnings };
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a Memory Check Loop to session-start system prompt injection
- add per-turn Memory Check guidance to user-prompt-submit injection, including no strong match paths
- mirror the prompt shaping in daemon-rs shadow hook handling
- document the new hook behavior and add regression coverage

## Why

Agents were being told that memory tools exist, but not given an explicit pre-execution habit for using them. This makes it too easy for an agent to skip recall before touching context-sensitive work. The new prompt shape gives agents a compact trigger, procedure, pitfalls, and verification loop.

## Validation

- `bun run build:core`
- `bun test packages/daemon/src/hooks.test.ts packages/daemon/src/hooks.prompt-submit.test.ts`
- `cargo test -p signet-daemon hooks`
- `bunx biome check packages/daemon/src/hooks.ts packages/daemon/src/hooks.test.ts packages/daemon/src/hooks.prompt-submit.test.ts docs/HOOKS.md`
- `rustfmt --edition 2024 --check crates/signet-daemon/src/routes/hooks.rs`
- `git diff --check`

## Notes

`bun run --filter '@signet/daemon' build:types` still fails on pre-existing broader daemon type issues, including rootDir/core source inclusion, logger category mismatches, and unrelated route/test typing errors. Those failures were not introduced by this prompt-shaping patch.


## PR readiness checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) (routine bug-fix/docs/test follow-up; no spec-governed contract changed)
- [x] Agent scoping verified on all new/changed data queries (no new data queries added)
- [x] Input/config validation and bounds checks added (not applicable; no new external input/config surface)
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints (not applicable; no admin/mutation endpoint changes)
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally
