### PR TITLE
Superseded: fix(hermes): scope Signet memory to named agents

### DIFF
--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -677,9 +677,13 @@ Hermes lifecycle.
 
 | Tool | Description |
 |------|-------------|
-| `signet_search` | Hybrid memory search (keyword + semantic + knowledge graph) |
-| `signet_store` | Store a fact/preference/decision with auto entity extraction |
-| `signet_profile` | Broad overview of stored memories and working context |
+| `memory_search` | Hybrid memory search (keyword + semantic + knowledge graph) |
+| `memory_store` | Store a fact/preference/decision with auto entity extraction |
+| `memory_get` | Retrieve a memory by ID |
+| `memory_list` | List memories with optional filters |
+| `memory_modify` | Edit an existing memory |
+| `memory_forget` | Soft-delete a memory |
+| `recall` / `remember` | Compatibility aliases for search/store |
 
 ### Supported hooks
 

--- a/packages/cli/src/commands/memory.test.ts
+++ b/packages/cli/src/commands/memory.test.ts
@@ -47,11 +47,13 @@ describe("registerMemoryCommands recall", () => {
 		};
 
 		let capturedBody: unknown;
+		let capturedTimeout: number | undefined;
 		const program = new Command();
 		registerMemoryCommands(program, {
 			ensureDaemonForSecrets: async () => true,
-			secretApiCall: async (_method, _path, body) => {
+			secretApiCall: async (_method, _path, body, timeoutMs) => {
 				capturedBody = body;
+				capturedTimeout = timeoutMs;
 				return {
 					ok: true,
 					data: {
@@ -113,6 +115,7 @@ describe("registerMemoryCommands recall", () => {
 			until: "2026-04-01",
 			expand: true,
 		});
+		expect(capturedTimeout).toBe(30_000);
 		expect(lines).toHaveLength(1);
 		expect(lines[0]).toContain('"high score row"');
 		expect(lines[0]).not.toContain('"low score row"');

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -3,6 +3,8 @@ import chalk from "chalk";
 import type { Command } from "commander";
 import ora from "ora";
 
+const MEMORY_RECALL_TIMEOUT_MS = 30_000;
+
 interface MemoryDeps {
 	readonly ensureDaemonForSecrets: () => Promise<boolean>;
 	readonly secretApiCall: (
@@ -164,21 +166,26 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 			if (!(await deps.ensureDaemonForSecrets())) return;
 
 			const spinner = ora("Searching memories...").start();
-			const { ok, data } = await deps.secretApiCall("POST", "/api/memory/recall", {
-				query,
-				keywordQuery: options.keywordQuery,
-				limit: options.limit,
-				project: options.project,
-				type: options.type,
-				tags: options.tags,
-				who: options.who,
-				pinned: options.pinned === true ? true : undefined,
-				importance_min: options.importanceMin,
-				since: options.since,
-				until: options.until,
-				expand: options.expand === true ? true : undefined,
-				...(options.agent ? { agentId: options.agent } : {}),
-			});
+			const { ok, data } = await deps.secretApiCall(
+				"POST",
+				"/api/memory/recall",
+				{
+					query,
+					keywordQuery: options.keywordQuery,
+					limit: options.limit,
+					project: options.project,
+					type: options.type,
+					tags: options.tags,
+					who: options.who,
+					pinned: options.pinned === true ? true : undefined,
+					importance_min: options.importanceMin,
+					since: options.since,
+					until: options.until,
+					expand: options.expand === true ? true : undefined,
+					...(options.agent ? { agentId: options.agent } : {}),
+				},
+				MEMORY_RECALL_TIMEOUT_MS,
+			);
 
 			const err = typeof data === "object" && data !== null && "error" in data ? data.error : undefined;
 			if (!ok || typeof err === "string") {

--- a/packages/connector-hermes-agent/hermes-plugin/README.md
+++ b/packages/connector-hermes-agent/hermes-plugin/README.md
@@ -24,16 +24,20 @@ signet start   # ensure daemon is running
 Environment variables:
 - `SIGNET_DAEMON_URL` — Full daemon URL (default: `http://localhost:3850`)
 - `SIGNET_HOST` / `SIGNET_PORT` — Host and port separately
-- `SIGNET_AGENT_ID` — Agent scope identifier (default: `default`)
+- `SIGNET_AGENT_ID` — Agent scope identifier (default: `hermes-agent`)
 - `SIGNET_AGENT_WORKSPACE` — Optional named-agent workspace path (for example `~/.agents/agents/dot`)
 
 ## Tools
 
 | Tool | Description |
 |------|-------------|
-| `signet_search` | Hybrid memory search (keyword + semantic + knowledge graph) |
-| `signet_store` | Store a fact, preference, or decision to memory |
-| `signet_profile` | Broad overview of stored memories and context |
+| `memory_search` | Hybrid memory search (keyword + semantic + knowledge graph) |
+| `memory_store` | Store a fact, preference, or decision to memory |
+| `memory_get` | Retrieve a memory by ID |
+| `memory_list` | List memories with optional filters |
+| `memory_modify` | Edit an existing memory |
+| `memory_forget` | Soft-delete a memory |
+| `recall` / `remember` | Compatibility aliases for search/store |
 
 ## How It Works
 
@@ -45,4 +49,4 @@ The plugin bridges Hermes Agent's memory lifecycle to the Signet daemon:
 
 3. **Session end** — Sends the conversation transcript to Signet's session-end hook, which queues it for the memory pipeline: extraction, knowledge graph updates, retention decay, and MEMORY.md synthesis.
 
-4. **Explicit tools** — The agent can call `signet_search`, `signet_store`, and `signet_profile` directly during conversation for on-demand memory operations.
+4. **Explicit tools** — The agent can call canonical Signet tools such as `memory_search` and `memory_store` directly during conversation for on-demand memory operations. Legacy `signet_*` names are handled for compatibility but are not advertised to the model.

--- a/packages/connector-hermes-agent/hermes-plugin/README.md
+++ b/packages/connector-hermes-agent/hermes-plugin/README.md
@@ -25,6 +25,7 @@ Environment variables:
 - `SIGNET_DAEMON_URL` — Full daemon URL (default: `http://localhost:3850`)
 - `SIGNET_HOST` / `SIGNET_PORT` — Host and port separately
 - `SIGNET_AGENT_ID` — Agent scope identifier (default: `default`)
+- `SIGNET_AGENT_WORKSPACE` — Optional named-agent workspace path (for example `~/.agents/agents/dot`)
 
 ## Tools
 

--- a/packages/connector-hermes-agent/hermes-plugin/__init__.py
+++ b/packages/connector-hermes-agent/hermes-plugin/__init__.py
@@ -13,6 +13,7 @@ Config:
   - SIGNET_HOST / SIGNET_PORT env vars (default: localhost:3850)
   - SIGNET_DAEMON_URL env var for full URL override
   - SIGNET_AGENT_ID env var for agent scoping (default: "hermes-agent")
+  - SIGNET_AGENT_WORKSPACE env var for the active named-agent workspace
 """
 
 from __future__ import annotations
@@ -102,6 +103,32 @@ PROFILE_SCHEMA = {
 }
 
 ALL_TOOL_SCHEMAS = [SEARCH_SCHEMA, STORE_SCHEMA, PROFILE_SCHEMA]
+
+
+def _sanitize_env(value: str) -> str:
+    return value.strip().replace("\r", "").replace("\n", "")
+
+
+def _resolve_agent_workspace(agent_id: str, kwargs: Dict[str, Any]) -> str:
+    """Resolve the project/workspace path sent to Signet hooks.
+
+    Named Signet agents can have their own workspace at
+    $SIGNET_PATH/agents/{agent_id}. Prefer that workspace so daemon
+    session-start can load the agent's scoped identity files.
+    """
+    explicit = _sanitize_env(os.environ.get("SIGNET_AGENT_WORKSPACE", ""))
+    if explicit:
+        return str(Path(explicit).expanduser())
+
+    signet_path = _sanitize_env(os.environ.get("SIGNET_PATH", ""))
+    agents_root = Path(signet_path).expanduser() if signet_path else Path.home() / ".agents"
+    if agent_id and agent_id != "default":
+        candidate = agents_root / "agents" / agent_id
+        if candidate.exists():
+            return str(candidate)
+
+    fallback = kwargs.get("cwd", kwargs.get("project", os.getcwd()))
+    return str(Path(str(fallback)).expanduser())
 
 
 # ---------------------------------------------------------------------------
@@ -209,7 +236,7 @@ class SignetMemoryProvider(MemoryProvider):
             return
 
         self._session_key = session_id or "hermes-default"
-        self._project = kwargs.get("cwd", kwargs.get("project", os.getcwd()))
+        self._project = _resolve_agent_workspace(agent_id, kwargs)
 
         # Call session-start hook — get identity + memories + inject
         result = self._client.session_start(

--- a/packages/connector-hermes-agent/hermes-plugin/__init__.py
+++ b/packages/connector-hermes-agent/hermes-plugin/__init__.py
@@ -5,9 +5,11 @@ Bridges Hermes Agent's memory provider interface to the Signet daemon
 predictive recall, cross-session memory, and the full Signet pipeline
 (extraction, knowledge graph, retention decay, synthesis).
 
-The 3 tools (signet_search, signet_store, signet_profile) are exposed
-through the MemoryProvider interface. The daemon handles all heavy lifting:
-embedding, reranking, knowledge graph traversal, and predictive scoring.
+Canonical Signet memory tools (memory_search, memory_store, memory_get,
+memory_list, memory_modify, memory_forget, plus recall/remember aliases) are
+exposed through the MemoryProvider interface. The daemon handles all heavy
+lifting: embedding, reranking, knowledge graph traversal, and predictive
+scoring.
 
 Config:
   - SIGNET_HOST / SIGNET_PORT env vars (default: localhost:3850)
@@ -39,71 +41,129 @@ logger = logging.getLogger(__name__)
 # Tool schemas
 # ---------------------------------------------------------------------------
 
-SEARCH_SCHEMA = {
-    "name": "signet_search",
-    "description": (
-        "Search Signet's memory using hybrid recall (keyword + semantic + "
-        "knowledge graph). Returns relevant memories ranked by predicted "
-        "usefulness. Use when you need to find past context, decisions, "
-        "preferences, or project knowledge."
-    ),
+MEMORY_SEARCH_SCHEMA = {
+    "name": "memory_search",
+    "description": "Search Signet memories using hybrid vector + keyword search.",
     "parameters": {
         "type": "object",
         "properties": {
-            "query": {
-                "type": "string",
-                "description": "What to search for in memory.",
+            "query": {"type": "string", "description": "Search query text."},
+            "limit": {"type": "integer", "description": "Max results to return (default 10, max 50)."},
+            "project": {"type": "string", "description": "Optional project path filter."},
+            "expand": {"type": "boolean", "description": "Include lossless session transcripts as sources."},
+            "type": {"type": "string", "description": "Filter by memory type."},
+            "tags": {"type": "string", "description": "Filter by tags, comma-separated."},
+            "who": {"type": "string", "description": "Filter by author."},
+            "since": {"type": "string", "description": "Only include memories created after this date."},
+            "until": {"type": "string", "description": "Only include memories created before this date."},
+            "keyword_query": {"type": "string", "description": "Override the keyword/FTS query used for recall."},
+            "pinned": {"type": "boolean", "description": "Only return pinned memories."},
+            "importance_min": {"type": "number", "description": "Minimum memory importance threshold."},
+            "min_score": {
+                "type": "number",
+                "description": "Deprecated compatibility alias for importance_min; ignored when importance_min is set.",
             },
-            "limit": {
-                "type": "integer",
-                "description": "Max results to return (default: 10, max: 50).",
-            },
+            "score_min": {"type": "number", "description": "Minimum recall score threshold, applied client-side."},
         },
         "required": ["query"],
     },
 }
 
-STORE_SCHEMA = {
-    "name": "signet_store",
-    "description": (
-        "Store a memory in Signet. The daemon handles embedding, entity "
-        "extraction, knowledge graph linking, and deduplication automatically. "
-        "Use for explicit facts, preferences, decisions, or corrections the "
-        "user wants remembered across sessions."
-    ),
+MEMORY_STORE_SCHEMA = {
+    "name": "memory_store",
+    "description": "Save a new memory to Signet.",
     "parameters": {
         "type": "object",
         "properties": {
-            "content": {
-                "type": "string",
-                "description": "The memory content to store.",
-            },
-            "importance": {
-                "type": "number",
-                "description": "Importance score 0-1 (default: 0.5). Higher = more likely to surface.",
-            },
-            "tags": {
-                "type": "string",
-                "description": "Comma-separated tags for categorization (optional).",
-            },
+            "content": {"type": "string", "description": "Memory content to save."},
+            "type": {"type": "string", "description": "Memory type, e.g. fact, preference, decision."},
+            "importance": {"type": "number", "description": "Importance score 0-1."},
+            "tags": {"type": "string", "description": "Comma-separated tags for categorization."},
+            "pinned": {"type": "boolean", "description": "Pin this memory so it does not decay."},
+            "project": {"type": "string", "description": "Optional project path. Defaults to the active Hermes Signet workspace."},
         },
         "required": ["content"],
     },
 }
 
-PROFILE_SCHEMA = {
-    "name": "signet_profile",
-    "description": (
-        "Retrieve the user's memory profile from Signet — recent memories, "
-        "key facts, and working context (MEMORY.md). Fast overview without "
-        "a specific search query. Use at conversation start or when you need "
-        "a broad snapshot of what Signet knows."
-    ),
-    "parameters": {"type": "object", "properties": {}, "required": []},
+MEMORY_GET_SCHEMA = {
+    "name": "memory_get",
+    "description": "Get a single memory by its ID.",
+    "parameters": {
+        "type": "object",
+        "properties": {"id": {"type": "string", "description": "Memory ID to retrieve."}},
+        "required": ["id"],
+    },
 }
 
-ALL_TOOL_SCHEMAS = [SEARCH_SCHEMA, STORE_SCHEMA, PROFILE_SCHEMA]
+MEMORY_LIST_SCHEMA = {
+    "name": "memory_list",
+    "description": "List memories with optional filters.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "limit": {"type": "integer", "description": "Max results to return, default 100."},
+            "offset": {"type": "integer", "description": "Pagination offset."},
+            "type": {"type": "string", "description": "Filter by memory type."},
+        },
+        "required": [],
+    },
+}
 
+MEMORY_MODIFY_SCHEMA = {
+    "name": "memory_modify",
+    "description": "Edit an existing memory by ID.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "id": {"type": "string", "description": "Memory ID to modify."},
+            "content": {"type": "string", "description": "New content."},
+            "type": {"type": "string", "description": "New memory type."},
+            "importance": {"type": "number", "description": "New importance score 0-1."},
+            "tags": {"type": "string", "description": "New tags, comma-separated."},
+            "pinned": {"type": "boolean", "description": "Pin or unpin this memory."},
+            "reason": {"type": "string", "description": "Why this edit is being made."},
+        },
+        "required": ["id", "reason"],
+    },
+}
+
+MEMORY_FORGET_SCHEMA = {
+    "name": "memory_forget",
+    "description": "Soft-delete a memory by ID.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "id": {"type": "string", "description": "Memory ID to forget."},
+            "reason": {"type": "string", "description": "Why this memory should be forgotten."},
+            "force": {"type": "boolean", "description": "Hard-delete instead of soft-delete, when supported."},
+        },
+        "required": ["id", "reason"],
+    },
+}
+
+RECALL_ALIAS_SCHEMA = {
+    "name": "recall",
+    "description": "Alias for memory_search.",
+    "parameters": MEMORY_SEARCH_SCHEMA["parameters"],
+}
+
+REMEMBER_ALIAS_SCHEMA = {
+    "name": "remember",
+    "description": "Alias for memory_store.",
+    "parameters": MEMORY_STORE_SCHEMA["parameters"],
+}
+
+ALL_TOOL_SCHEMAS = [
+    MEMORY_SEARCH_SCHEMA,
+    MEMORY_STORE_SCHEMA,
+    MEMORY_GET_SCHEMA,
+    MEMORY_LIST_SCHEMA,
+    MEMORY_MODIFY_SCHEMA,
+    MEMORY_FORGET_SCHEMA,
+    RECALL_ALIAS_SCHEMA,
+    REMEMBER_ALIAS_SCHEMA,
+]
 
 def _sanitize_env(value: str) -> str:
     return value.strip().replace("\r", "").replace("\n", "")
@@ -281,8 +341,9 @@ class SignetMemoryProvider(MemoryProvider):
         return (
             "# Signet Memory\n"
             "Active. Memories are auto-recalled each turn via hybrid search. "
-            "Use signet_search to query memory, signet_store to save facts, "
-            "signet_profile for a broad overview."
+            "Use memory_search to query memory, memory_store to save facts, "
+            "and memory_get/memory_list/memory_modify/memory_forget for direct "
+            "memory management."
         )
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
@@ -593,55 +654,135 @@ class SignetMemoryProvider(MemoryProvider):
         if not self._client:
             return json.dumps({"error": "Signet daemon is not connected."})
 
-        try:
-            if tool_name == "signet_search":
-                query = args.get("query", "")
-                if not query:
-                    return json.dumps({"error": "Missing required parameter: query"})
-                limit = min(int(args.get("limit", 10)), 50)
-                result = self._client.recall(query, limit=limit)
-                if not result:
-                    return json.dumps({"result": "No relevant memories found."})
-                # Extract memories from recall response
-                memories = result.get("results", result.get("memories", []))
-                if not memories:
-                    return json.dumps({"result": "No relevant memories found."})
-                items = []
-                for m in memories:
-                    items.append({
-                        "content": m.get("content", ""),
-                        "type": m.get("type", ""),
-                        "importance": m.get("importance", 0),
-                        "created_at": m.get("created_at", ""),
-                    })
-                return json.dumps({"results": items, "count": len(items)})
+        def _as_int(value: Any, default: int, *, minimum: int = 0, maximum: int = 10_000) -> int:
+            try:
+                parsed = int(value)
+            except (TypeError, ValueError):
+                parsed = default
+            return max(minimum, min(maximum, parsed))
 
-            elif tool_name == "signet_store":
-                content = args.get("content", "")
-                if not content:
-                    return json.dumps({"error": "Missing required parameter: content"})
-                importance = float(args.get("importance", 0.5))
-                importance = max(0.0, min(1.0, importance))
-                tags_str = args.get("tags", "")
-                tags = [t.strip() for t in tags_str.split(",") if t.strip()] if tags_str else None
-                result = self._client.remember(content, importance=importance, tags=tags)
-                if result:
-                    return json.dumps({"result": "Memory stored.", "id": result.get("id", "")})
+        def _as_float(value: Any) -> Optional[float]:
+            if value is None or value == "":
+                return None
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                return None
+
+        def _tags(value: Any) -> Optional[List[str]]:
+            if value is None or value == "":
+                return None
+            if isinstance(value, list):
+                return [str(t).strip() for t in value if str(t).strip()]
+            if isinstance(value, str):
+                return [t.strip() for t in value.split(",") if t.strip()]
+            return [str(value).strip()] if str(value).strip() else None
+
+        def _search(search_args: Dict[str, Any]) -> str:
+            query = str(search_args.get("query", "")).strip()
+            if not query:
+                return json.dumps({"error": "Missing required parameter: query"})
+
+            importance_min = _as_float(search_args.get("importance_min"))
+            if importance_min is None:
+                importance_min = _as_float(search_args.get("min_score"))
+
+            result = self._client.recall(
+                query,
+                limit=_as_int(search_args.get("limit"), 10, minimum=1, maximum=50),
+                project=str(search_args.get("project", "") or ""),
+                memory_type=str(search_args.get("type", "") or ""),
+                tags=str(search_args.get("tags", "") or ""),
+                who=str(search_args.get("who", "") or ""),
+                pinned=search_args.get("pinned") if isinstance(search_args.get("pinned"), bool) else None,
+                importance_min=importance_min,
+                since=str(search_args.get("since", "") or ""),
+                until=str(search_args.get("until", "") or ""),
+                keyword_query=str(search_args.get("keyword_query", "") or ""),
+                expand=bool(search_args.get("expand", False)),
+                score_min=_as_float(search_args.get("score_min")),
+            )
+            if not result:
+                return json.dumps({"error": "Search failed or Signet daemon returned no response.", "results": []})
+            return json.dumps(result)
+
+        def _store(store_args: Dict[str, Any]) -> str:
+            content = str(store_args.get("content", "")).strip()
+            if not content:
+                return json.dumps({"error": "Missing required parameter: content"})
+            importance = _as_float(store_args.get("importance"))
+            if importance is None:
+                importance = 0.5
+            importance = max(0.0, min(1.0, importance))
+            result = self._client.remember(
+                content,
+                importance=importance,
+                tags=_tags(store_args.get("tags")),
+                memory_type=str(store_args.get("type", "") or ""),
+                pinned=store_args.get("pinned") if isinstance(store_args.get("pinned"), bool) else None,
+                project=str(store_args.get("project", "") or self._project),
+                who="hermes-agent",
+            )
+            if not result:
                 return json.dumps({"error": "Failed to store memory."})
+            return json.dumps({"result": "Memory saved.", "id": result.get("id", result.get("memoryId", ""))})
 
-            elif tool_name == "signet_profile":
-                # Fetch recent memories and working context
-                result = self._client.recall("user profile preferences context", limit=15)
-                if not result:
-                    return json.dumps({"result": "No memories stored yet."})
-                memories = result.get("results", result.get("memories", []))
-                if not memories:
-                    return json.dumps({"result": "No memories stored yet."})
-                lines = [m.get("content", "") for m in memories if m.get("content")]
-                return json.dumps({
-                    "result": "\n".join(f"- {l}" for l in lines),
-                    "count": len(lines),
-                })
+        try:
+            if tool_name in ("memory_search", "recall", "signet_search"):
+                return _search(args)
+
+            if tool_name in ("memory_store", "remember", "signet_store"):
+                return _store(args)
+
+            if tool_name == "signet_profile":
+                return _search({"query": "user profile preferences context", "limit": 15})
+
+            if tool_name == "memory_get":
+                memory_id = str(args.get("id", "")).strip()
+                if not memory_id:
+                    return json.dumps({"error": "Missing required parameter: id"})
+                result = self._client.get_memory(memory_id)
+                return json.dumps(result if result else {"error": "Memory not found."})
+
+            if tool_name == "memory_list":
+                result = self._client.list_memories(
+                    limit=_as_int(args.get("limit"), 100, minimum=1, maximum=500),
+                    offset=_as_int(args.get("offset"), 0, minimum=0, maximum=1_000_000),
+                    memory_type=str(args.get("type", "") or ""),
+                )
+                return json.dumps(result if result else {"memories": [], "result": "No memories found."})
+
+            if tool_name == "memory_modify":
+                memory_id = str(args.get("id", "")).strip()
+                reason = str(args.get("reason", "")).strip()
+                if not memory_id:
+                    return json.dumps({"error": "Missing required parameter: id"})
+                if not reason:
+                    return json.dumps({"error": "Missing required parameter: reason"})
+                result = self._client.modify_memory(
+                    memory_id,
+                    content=str(args.get("content", "") or ""),
+                    memory_type=str(args.get("type", "") or ""),
+                    importance=_as_float(args.get("importance")),
+                    tags=str(args.get("tags", "") or ""),
+                    pinned=args.get("pinned") if isinstance(args.get("pinned"), bool) else None,
+                    reason=reason,
+                )
+                return json.dumps(result if result else {"error": "Failed to modify memory."})
+
+            if tool_name == "memory_forget":
+                memory_id = str(args.get("id", "")).strip()
+                reason = str(args.get("reason", "")).strip()
+                if not memory_id:
+                    return json.dumps({"error": "Missing required parameter: id"})
+                if not reason:
+                    return json.dumps({"error": "Missing required parameter: reason"})
+                result = self._client.forget_memory(
+                    memory_id,
+                    reason=reason,
+                    force=bool(args.get("force", False)),
+                )
+                return json.dumps(result if result else {"error": "Failed to forget memory."})
 
             return json.dumps({"error": f"Unknown tool: {tool_name}"})
 

--- a/packages/connector-hermes-agent/hermes-plugin/client.py
+++ b/packages/connector-hermes-agent/hermes-plugin/client.py
@@ -25,6 +25,7 @@ _DEFAULT_HOST = "localhost"
 _DEFAULT_PORT = 3850
 _TIMEOUT_SECS = 5
 _LONG_TIMEOUT_SECS = 15
+_RECALL_TIMEOUT_SECS = 30
 
 
 def _sanitize(value: str) -> str:
@@ -195,6 +196,7 @@ class SignetClient:
                 "agentId": self._agent_id,
                 "project": project,
             },
+            timeout=_LONG_TIMEOUT_SECS,
         )
 
     def session_end(
@@ -360,7 +362,7 @@ class SignetClient:
         if agent_scoped and self._agent_id:
             body["agentId"] = self._agent_id
 
-        result = self._post("/api/memory/recall", body)
+        result = self._post("/api/memory/recall", body, timeout=_RECALL_TIMEOUT_SECS)
         if (
             result
             and score_min is not None

--- a/packages/connector-hermes-agent/hermes-plugin/client.py
+++ b/packages/connector-hermes-agent/hermes-plugin/client.py
@@ -115,6 +115,40 @@ class SignetClient:
             logger.debug("Signet GET %s failed: %s", path, e)
             return None
 
+    def _patch(
+        self,
+        path: str,
+        body: Dict[str, Any],
+        *,
+        timeout: float = _TIMEOUT_SECS,
+    ) -> Optional[Dict[str, Any]]:
+        """PATCH JSON to the daemon. Returns parsed response or None on failure."""
+        url = f"{self._base_url}{path}"
+        data = json.dumps(body).encode("utf-8")
+        req = urllib.request.Request(url, data=data, headers=self._headers(), method="PATCH")
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except (urllib.error.HTTPError, urllib.error.URLError, OSError, TimeoutError) as e:
+            logger.debug("Signet PATCH %s failed: %s", path, e)
+            return None
+
+    def _delete(
+        self,
+        path: str,
+        *,
+        timeout: float = _TIMEOUT_SECS,
+    ) -> Optional[Dict[str, Any]]:
+        """DELETE from the daemon. Returns parsed response or None on failure."""
+        url = f"{self._base_url}{path}"
+        req = urllib.request.Request(url, headers=self._headers(), method="DELETE")
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except (urllib.error.HTTPError, urllib.error.URLError, OSError, TimeoutError) as e:
+            logger.debug("Signet DELETE %s failed: %s", path, e)
+            return None
+
     # -- Health ---------------------------------------------------------------
 
     def is_available(self) -> bool:
@@ -257,15 +291,27 @@ class SignetClient:
         *,
         importance: float = 0.5,
         tags: Optional[List[str]] = None,
+        memory_type: str = "",
+        pinned: Optional[bool] = None,
+        project: str = "",
+        who: str = "hermes-agent",
     ) -> Optional[Dict[str, Any]]:
         """Store a memory via the daemon API."""
         body: Dict[str, Any] = {
             "content": content,
             "importance": importance,
-            "agentId": self._agent_id,
+            "who": who,
         }
+        if self._agent_id:
+            body["agentId"] = self._agent_id
+        if memory_type:
+            body["type"] = memory_type
         if tags:
             body["tags"] = tags
+        if pinned is not None:
+            body["pinned"] = pinned
+        if project:
+            body["project"] = project
         return self._post("/api/memory/remember", body)
 
     def recall(
@@ -273,17 +319,116 @@ class SignetClient:
         query: str,
         *,
         limit: int = 10,
-        min_score: float = 0.0,
+        project: str = "",
+        memory_type: str = "",
+        tags: str = "",
+        who: str = "",
+        pinned: Optional[bool] = None,
+        importance_min: Optional[float] = None,
+        since: str = "",
+        until: str = "",
+        keyword_query: str = "",
+        expand: bool = False,
+        score_min: Optional[float] = None,
+        agent_scoped: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """Search memories via hybrid recall."""
         body: Dict[str, Any] = {
             "query": query,
             "limit": limit,
-            "agentId": self._agent_id,
         }
-        if min_score > 0.0:
-            body["minScore"] = min_score
-        return self._post("/api/memory/recall", body)
+        if project:
+            body["project"] = project
+        if memory_type:
+            body["type"] = memory_type
+        if tags:
+            body["tags"] = tags
+        if who:
+            body["who"] = who
+        if pinned is not None:
+            body["pinned"] = pinned
+        if importance_min is not None:
+            body["importance_min"] = importance_min
+        if since:
+            body["since"] = since
+        if until:
+            body["until"] = until
+        if keyword_query:
+            body["keywordQuery"] = keyword_query
+        if expand:
+            body["expand"] = True
+        if agent_scoped and self._agent_id:
+            body["agentId"] = self._agent_id
+
+        result = self._post("/api/memory/recall", body)
+        if (
+            result
+            and score_min is not None
+            and isinstance(result.get("results"), list)
+        ):
+            kept = [
+                row for row in result["results"]
+                if not isinstance(row, dict) or float(row.get("score", 0.0)) >= score_min
+            ]
+            result = dict(result)
+            result["results"] = kept
+            meta = result.get("meta")
+            if isinstance(meta, dict):
+                result["meta"] = {**meta, "totalReturned": len(kept)}
+        return result
+
+    def get_memory(self, memory_id: str) -> Optional[Dict[str, Any]]:
+        """Retrieve a single memory by ID."""
+        return self._get(f"/api/memory/{urllib.parse.quote(memory_id)}")
+
+    def list_memories(
+        self,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+        memory_type: str = "",
+    ) -> Optional[Dict[str, Any]]:
+        """List memories with optional filters."""
+        params = f"?limit={limit}&offset={offset}"
+        if memory_type:
+            params += f"&type={urllib.parse.quote(memory_type)}"
+        return self._get(f"/api/memories{params}")
+
+    def modify_memory(
+        self,
+        memory_id: str,
+        *,
+        content: str = "",
+        memory_type: str = "",
+        importance: Optional[float] = None,
+        tags: str = "",
+        pinned: Optional[bool] = None,
+        reason: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Edit an existing memory by ID."""
+        body: Dict[str, Any] = {"reason": reason}
+        if content:
+            body["content"] = content
+        if memory_type:
+            body["type"] = memory_type
+        if importance is not None:
+            body["importance"] = importance
+        if tags:
+            body["tags"] = tags
+        if pinned is not None:
+            body["pinned"] = pinned
+        return self._patch(f"/api/memory/{urllib.parse.quote(memory_id)}", body)
+
+    def forget_memory(
+        self,
+        memory_id: str,
+        *,
+        reason: str,
+        force: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        """Soft-delete a memory by ID."""
+        params = urllib.parse.urlencode({"reason": reason, **({"force": "true"} if force else {})})
+        return self._delete(f"/api/memory/{urllib.parse.quote(memory_id)}?{params}")
 
     def search(
         self,

--- a/packages/connector-hermes-agent/index.test.ts
+++ b/packages/connector-hermes-agent/index.test.ts
@@ -9,6 +9,7 @@ const originalEnv = {
 	HERMES_REPO: process.env.HERMES_REPO,
 	HERMES_HOME: process.env.HERMES_HOME,
 	SIGNET_AGENT_ID: process.env.SIGNET_AGENT_ID,
+	SIGNET_AGENT_WORKSPACE: process.env.SIGNET_AGENT_WORKSPACE,
 	SIGNET_DAEMON_URL: process.env.SIGNET_DAEMON_URL,
 };
 
@@ -32,6 +33,8 @@ beforeEach(() => {
 	delete process.env.HERMES_HOME;
 	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.SIGNET_AGENT_ID;
+	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
+	delete process.env.SIGNET_AGENT_WORKSPACE;
 	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.SIGNET_DAEMON_URL;
 });
@@ -114,6 +117,23 @@ describe("HermesAgentConnector.install()", () => {
 		expect(existsSync(envPath)).toBe(true);
 		const envContent = await Bun.file(envPath).text();
 		expect(envContent).toContain("SIGNET_DAEMON_URL=http://127.0.0.1:9999");
+	});
+
+	it("derives SIGNET_AGENT_WORKSPACE for named agents", async () => {
+		const hermesRepo = join(tmpRoot, "hermes-agent");
+		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
+		mkdirSync(join(tmpRoot, "agents", "dot"), { recursive: true });
+		const hermesHome = join(tmpRoot, ".hermes");
+		process.env.HERMES_REPO = hermesRepo;
+		process.env.HERMES_HOME = hermesHome;
+		process.env.SIGNET_AGENT_ID = "dot";
+
+		const result = await new HermesAgentConnector().install(tmpRoot);
+
+		const envContent = await Bun.file(join(hermesHome, ".env")).text();
+		expect(result.configsPatched).toContain(join(hermesHome, ".env"));
+		expect(envContent).toContain("SIGNET_AGENT_ID=dot");
+		expect(envContent).toContain(`SIGNET_AGENT_WORKSPACE=${join(tmpRoot, "agents", "dot")}`);
 	});
 });
 

--- a/packages/connector-hermes-agent/index.test.ts
+++ b/packages/connector-hermes-agent/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { HermesAgentConnector } from "./src/index.js";
@@ -11,6 +11,7 @@ const originalEnv = {
 	SIGNET_AGENT_ID: process.env.SIGNET_AGENT_ID,
 	SIGNET_AGENT_WORKSPACE: process.env.SIGNET_AGENT_WORKSPACE,
 	SIGNET_DAEMON_URL: process.env.SIGNET_DAEMON_URL,
+	SIGNET_SKIP_AGENT_REGISTER: process.env.SIGNET_SKIP_AGENT_REGISTER,
 };
 
 let tmpRoot = "";
@@ -37,6 +38,7 @@ beforeEach(() => {
 	delete process.env.SIGNET_AGENT_WORKSPACE;
 	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.SIGNET_DAEMON_URL;
+	process.env.SIGNET_SKIP_AGENT_REGISTER = "1";
 });
 
 afterEach(() => {
@@ -45,6 +47,7 @@ afterEach(() => {
 	restoreEnv("HERMES_HOME");
 	restoreEnv("SIGNET_AGENT_ID");
 	restoreEnv("SIGNET_DAEMON_URL");
+	restoreEnv("SIGNET_SKIP_AGENT_REGISTER");
 	if (tmpRoot) {
 		rmSync(tmpRoot, { recursive: true, force: true });
 	}
@@ -134,6 +137,27 @@ describe("HermesAgentConnector.install()", () => {
 		expect(result.configsPatched).toContain(join(hermesHome, ".env"));
 		expect(envContent).toContain("SIGNET_AGENT_ID=dot");
 		expect(envContent).toContain(`SIGNET_AGENT_WORKSPACE=${join(tmpRoot, "agents", "dot")}`);
+	});
+});
+
+describe("Hermes Agent bundled plugin", () => {
+	it("advertises canonical Signet memory tool names", () => {
+		const plugin = readFileSync(join(import.meta.dir, "hermes-plugin", "__init__.py"), "utf-8");
+
+		expect(plugin).toContain('"name": "memory_search"');
+		expect(plugin).toContain('"name": "memory_store"');
+		expect(plugin).toContain('"name": "memory_get"');
+		expect(plugin).toContain('"name": "memory_list"');
+		expect(plugin).not.toContain('"name": "signet_search"');
+		expect(plugin).toContain('if tool_name in ("memory_search", "recall", "signet_search")');
+	});
+
+	it("does not force agentId into explicit recall requests", () => {
+		const client = readFileSync(join(import.meta.dir, "hermes-plugin", "client.py"), "utf-8");
+
+		expect(client).toContain("if agent_scoped and self._agent_id:");
+		expect(client).toContain('body["agentId"] = self._agent_id');
+		expect(client).not.toContain('"agentId": self._agent_id,\\n        }\\n        if min_score');
 	});
 });
 

--- a/packages/connector-hermes-agent/index.test.ts
+++ b/packages/connector-hermes-agent/index.test.ts
@@ -159,6 +159,14 @@ describe("Hermes Agent bundled plugin", () => {
 		expect(client).toContain('body["agentId"] = self._agent_id');
 		expect(client).not.toContain('"agentId": self._agent_id,\\n        }\\n        if min_score');
 	});
+
+	it("uses longer timeouts for recall paths", () => {
+		const client = readFileSync(join(import.meta.dir, "hermes-plugin", "client.py"), "utf-8");
+
+		expect(client).toContain("_RECALL_TIMEOUT_SECS = 30");
+		expect(client).toContain('timeout=_LONG_TIMEOUT_SECS,');
+		expect(client).toContain('self._post("/api/memory/recall", body, timeout=_RECALL_TIMEOUT_SECS)');
+	});
 });
 
 describe("HermesAgentConnector.uninstall()", () => {

--- a/packages/connector-hermes-agent/src/index.ts
+++ b/packages/connector-hermes-agent/src/index.ts
@@ -133,6 +133,48 @@ function isProviderConfigured(hermesHome: string): boolean {
 	);
 }
 
+async function ensureNamedAgentRegistered(
+	daemonUrl: string,
+	agentId: string,
+	warnings: string[],
+): Promise<void> {
+	if (!agentId || agentId === "default" || agentId === "hermes-agent") return;
+	if (process.env.SIGNET_SKIP_AGENT_REGISTER === "1") return;
+
+	const baseUrl = daemonUrl.replace(/\/+$/, "");
+	try {
+		const getResp = await fetch(`${baseUrl}/api/agents/${encodeURIComponent(agentId)}`, {
+			signal: AbortSignal.timeout(1_000),
+		});
+		if (getResp.ok) return;
+	} catch {
+		// Daemon may be offline; the POST below will produce the user-facing warning.
+	}
+
+	try {
+		const resp = await fetch(`${baseUrl}/api/agents`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				name: agentId,
+				read_policy: "shared",
+				policy_group: null,
+			}),
+			signal: AbortSignal.timeout(1_000),
+		});
+		if (!resp.ok) {
+			const body = await resp.text();
+			warnings.push(`Could not register Signet agent '${agentId}' with shared memory policy: ${body.slice(0, 200)}`);
+		}
+	} catch (e) {
+		const msg = e instanceof Error ? e.message : String(e);
+		warnings.push(
+			`Could not register Signet agent '${agentId}' because the daemon was unreachable. ` +
+				`Run: signet agent create ${agentId} --memory shared (${msg})`,
+		);
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Connector
 // ---------------------------------------------------------------------------
@@ -186,6 +228,11 @@ export class HermesAgentConnector extends BaseConnector {
 
 		// 2. Write env config for the Signet daemon connection
 		const envPath = join(hermesHome, ".env");
+		let configuredSignetAgentId = "hermes-agent";
+		const configuredDaemonUrl = (process.env.SIGNET_DAEMON_URL?.trim() || "http://localhost:3850").replace(
+			/[\r\n]+/g,
+			"",
+		);
 		try {
 			let envContent = "";
 			if (existsSync(envPath)) {
@@ -200,6 +247,7 @@ export class HermesAgentConnector extends BaseConnector {
 			// Always write SIGNET_AGENT_ID — never allow the plugin to fall back to the
 			// shared "default" scope (AGENTS.md: never hardcode "default" for scoped paths).
 			const signetAgentId = (process.env.SIGNET_AGENT_ID?.trim() || "hermes-agent").replace(/[\r\n]+/g, "");
+			configuredSignetAgentId = signetAgentId;
 			signetVars.SIGNET_AGENT_ID = signetAgentId;
 
 			const explicitAgentWorkspace = process.env.SIGNET_AGENT_WORKSPACE?.trim();
@@ -246,6 +294,8 @@ export class HermesAgentConnector extends BaseConnector {
 			const msg = e instanceof Error ? e.message : String(e);
 			warnings.push(`Failed to update .env: ${msg}`);
 		}
+
+		await ensureNamedAgentRegistered(configuredDaemonUrl, configuredSignetAgentId, warnings);
 
 		// 3. Provide guidance on completing setup
 		if (!isProviderConfigured(hermesHome)) {

--- a/packages/connector-hermes-agent/src/index.ts
+++ b/packages/connector-hermes-agent/src/index.ts
@@ -199,7 +199,18 @@ export class HermesAgentConnector extends BaseConnector {
 			}
 			// Always write SIGNET_AGENT_ID — never allow the plugin to fall back to the
 			// shared "default" scope (AGENTS.md: never hardcode "default" for scoped paths).
-			signetVars.SIGNET_AGENT_ID = (process.env.SIGNET_AGENT_ID?.trim() || "hermes-agent").replace(/[\r\n]+/g, "");
+			const signetAgentId = (process.env.SIGNET_AGENT_ID?.trim() || "hermes-agent").replace(/[\r\n]+/g, "");
+			signetVars.SIGNET_AGENT_ID = signetAgentId;
+
+			const explicitAgentWorkspace = process.env.SIGNET_AGENT_WORKSPACE?.trim();
+			if (explicitAgentWorkspace) {
+				signetVars.SIGNET_AGENT_WORKSPACE = expandHome(explicitAgentWorkspace).replace(/[\r\n]+/g, "");
+			} else if (signetAgentId && signetAgentId !== "hermes-agent" && signetAgentId !== "default") {
+				const agentWorkspace = join(expandedBasePath, "agents", signetAgentId);
+				if (existsSync(agentWorkspace)) {
+					signetVars.SIGNET_AGENT_WORKSPACE = agentWorkspace;
+				}
+			}
 
 			// Persist auth token so Hermes can reach a non-localhost daemon.
 			// Warn if absent and SIGNET_DAEMON_URL points to a remote host.
@@ -276,7 +287,7 @@ export class HermesAgentConnector extends BaseConnector {
 			try {
 				let envContent = readFileSync(envPath, "utf-8");
 				let changed = false;
-				for (const key of ["SIGNET_DAEMON_URL", "SIGNET_AGENT_ID"]) {
+				for (const key of ["SIGNET_DAEMON_URL", "SIGNET_AGENT_ID", "SIGNET_AGENT_WORKSPACE"]) {
 					const pattern = new RegExp(`^${key}=.*\n?`, "gm");
 					if (pattern.test(envContent)) {
 						envContent = envContent.replace(pattern, "");

--- a/packages/core/src/__tests__/identity.test.ts
+++ b/packages/core/src/__tests__/identity.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildAgentMemoryConfig, normalizeAgentRosterEntry } from "../agents";
+import { buildAgentMemoryConfig, getAgentIdentityFiles, normalizeAgentRosterEntry } from "../agents";
 import {
 	STATIC_IDENTITY_SESSION_START_TIMEOUT_STATUS,
 	readStaticIdentity,
@@ -105,6 +105,20 @@ describe("parseSimpleYaml", () => {
 });
 
 describe("agent roster helpers", () => {
+	test("resolves agent-local identity files before root fallbacks", () => {
+		mkdirSync(join(TMP, "agents", "dot"), { recursive: true });
+		writeFileSync(join(TMP, "AGENTS.md"), "root agents");
+		writeFileSync(join(TMP, "USER.md"), "root user");
+		writeFileSync(join(TMP, "agents", "dot", "AGENTS.md"), "dot agents");
+		writeFileSync(join(TMP, "agents", "dot", "IDENTITY.md"), "dot identity");
+
+		expect(getAgentIdentityFiles("dot", TMP)).toMatchObject({
+			"AGENTS.md": join(TMP, "agents", "dot", "AGENTS.md"),
+			"IDENTITY.md": join(TMP, "agents", "dot", "IDENTITY.md"),
+			"USER.md": join(TMP, "USER.md"),
+		});
+	});
+
 	test("normalizes canonical nested memory policies", () => {
 		expect(
 			normalizeAgentRosterEntry({

--- a/packages/core/src/agents.ts
+++ b/packages/core/src/agents.ts
@@ -17,11 +17,17 @@ export interface NormalizedAgentRosterEntry {
 	readonly policyGroup: string | null;
 }
 
-/** Identity files that inherit from agent subdir (fall back to root). */
-const AGENT_SPECIFIC = new Set(["SOUL.md", "IDENTITY.md"]);
-
-/** All recognized shared identity files. */
-const SHARED_FILES = ["AGENTS.md", "USER.md", "TOOLS.md", "HEARTBEAT.md", "MEMORY.md", "BOOTSTRAP.md"];
+/** Standard identity files that may be overridden by a named agent. */
+const IDENTITY_FILES = [
+	"AGENTS.md",
+	"SOUL.md",
+	"IDENTITY.md",
+	"USER.md",
+	"TOOLS.md",
+	"HEARTBEAT.md",
+	"MEMORY.md",
+	"BOOTSTRAP.md",
+];
 
 /**
  * Scans {agentsDir}/agents/* subdirectories and returns a minimal
@@ -56,24 +62,18 @@ export function scaffoldAgent(name: string, agentsDir: string): void {
  * exists on disk for the given agent.
  *
  * Inheritance rules:
- * - `SOUL.md` and `IDENTITY.md`: agent subdir first, fall back to root.
- * - All other files (`AGENTS.md`, `USER.md`, `TOOLS.md`, `HEARTBEAT.md`,
- *   `MEMORY.md`, `BOOTSTRAP.md`): always use root (shared by all agents).
+ * - Check `~/.agents/agents/{name}/{file}` first.
+ * - Fall back to root-level `~/.agents/{file}` when the agent has no override.
  */
 export function getAgentIdentityFiles(name: string, agentsDir: string): Record<string, string> {
 	const result: Record<string, string> = {};
 	const agentDir = join(agentsDir, "agents", name);
 
-	for (const file of AGENT_SPECIFIC) {
+	for (const file of IDENTITY_FILES) {
 		const specific = join(agentDir, file);
 		const fallback = join(agentsDir, file);
 		if (existsSync(specific)) result[file] = specific;
 		else if (existsSync(fallback)) result[file] = fallback;
-	}
-
-	for (const file of SHARED_FILES) {
-		const path = join(agentsDir, file);
-		if (existsSync(path)) result[file] = path;
 	}
 
 	return result;

--- a/packages/daemon/src/hooks.test.ts
+++ b/packages/daemon/src/hooks.test.ts
@@ -1,11 +1,12 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import {
 	applyTokenBudget,
 	buildSignetSystemPrompt,
+	handleSessionStart,
 	normalizeCodexTranscript,
 	normalizeJsonConversationTranscript,
 	normalizeSessionTranscript,
@@ -26,6 +27,56 @@ describe("buildSignetSystemPrompt", () => {
 		expect(prompt).toContain("mcp__signet__secret_list");
 		expect(prompt).toContain("mcp__signet__secret_exec");
 		expect(prompt).toContain("linked summary and transcript artifacts");
+	});
+});
+
+describe("handleSessionStart multi-agent identity", () => {
+	let agentsDir = "";
+	let previousSignetPath: string | undefined;
+
+	beforeAll(() => {
+		previousSignetPath = process.env.SIGNET_PATH;
+		agentsDir = mkdtempSync(join(tmpdir(), "signet-hooks-agent-identity-"));
+	});
+
+	beforeEach(() => {
+		closeDbAccessor();
+		rmSync(agentsDir, { recursive: true, force: true });
+		mkdirSync(join(agentsDir, "agents", "dot"), { recursive: true });
+		process.env.SIGNET_PATH = agentsDir;
+		initDbAccessor(join(agentsDir, "memory", "memories.db"), { agentsDir });
+		writeFileSync(join(agentsDir, "AGENTS.md"), "You are Rose.");
+		writeFileSync(join(agentsDir, "IDENTITY.md"), "name: Rose\nrole: Solvr Assistant\n");
+		writeFileSync(join(agentsDir, "agents", "dot", "AGENTS.md"), "You are Dot.");
+		writeFileSync(join(agentsDir, "agents", "dot", "IDENTITY.md"), 'You are Dorothy "Dot" Ashby.\n');
+	});
+
+	afterEach(() => {
+		closeDbAccessor();
+	});
+
+	afterAll(() => {
+		rmSync(agentsDir, { recursive: true, force: true });
+		if (previousSignetPath === undefined) {
+			Reflect.deleteProperty(process.env, "SIGNET_PATH");
+			return;
+		}
+		process.env.SIGNET_PATH = previousSignetPath;
+	});
+
+	it("loads agent-scoped identity files for session-start", async () => {
+		const result = await handleSessionStart({
+			harness: "hermes-agent",
+			sessionKey: `dot-test-${Date.now()}`,
+			agentId: "dot",
+			project: join(agentsDir, "agents", "dot"),
+			runtimePath: "plugin",
+		});
+
+		expect(result.identity.name).toBe('Dorothy "Dot" Ashby');
+		expect(result.inject).toContain("You are Dot.");
+		expect(result.inject).toContain('You are Dorothy "Dot" Ashby.');
+		expect(result.inject).not.toContain("You are Rose.");
 	});
 });
 

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -15,7 +15,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { parseSimpleYaml } from "@signet/core";
+import { getAgentIdentityFiles, parseSimpleYaml } from "@signet/core";
 import { getAgentScope, resolveAgentId } from "./agent-id";
 import { extractAnchorTerms } from "./anchor-terms";
 import {
@@ -624,9 +624,10 @@ export function isDuplicate(db: Database, content: string, agentId: string): boo
 	return false;
 }
 
-function readIdentityFile(fileName: string, charBudget: number): string | undefined {
-	const filePath = join(getAgentsDir(), fileName);
-	if (!existsSync(filePath)) return undefined;
+type IdentityFileMap = Record<string, string>;
+
+function readIdentityPath(filePath: string | undefined, charBudget: number): string | undefined {
+	if (!filePath || !existsSync(filePath)) return undefined;
 
 	try {
 		const content = readFileSync(filePath, "utf-8").trim();
@@ -638,22 +639,25 @@ function readIdentityFile(fileName: string, charBudget: number): string | undefi
 	}
 }
 
-function readMemoryMd(charBudget: number): string | undefined {
-	return readIdentityFile("MEMORY.md", charBudget);
+function readIdentityFile(
+	fileName: string,
+	charBudget: number,
+	identityFiles?: IdentityFileMap,
+): string | undefined {
+	return readIdentityPath(identityFiles?.[fileName] ?? join(getAgentsDir(), fileName), charBudget);
 }
 
-function readAgentsMd(charBudget: number): string | undefined {
-	const agentsMd = join(getAgentsDir(), "AGENTS.md");
-	if (!existsSync(agentsMd)) return undefined;
+function readMemoryMd(charBudget: number, identityFiles?: IdentityFileMap): string | undefined {
+	return readIdentityFile("MEMORY.md", charBudget, identityFiles);
+}
 
-	try {
-		const content = readFileSync(agentsMd, "utf-8").trim();
-		if (!content) return undefined;
-		if (content.length <= charBudget) return content;
-		return `${content.slice(0, charBudget)}\n[truncated]`;
-	} catch {
-		return undefined;
-	}
+function readAgentsMd(charBudget: number, identityFiles?: IdentityFileMap): string | undefined {
+	return readIdentityFile("AGENTS.md", charBudget, identityFiles);
+}
+
+function resolveIdentityFiles(agentId: string): IdentityFileMap {
+	if (!agentId || agentId === "default") return {};
+	return getAgentIdentityFiles(agentId, getAgentsDir());
 }
 
 export interface ScoredMemory {
@@ -1069,7 +1073,25 @@ function isAgentConfig(value: unknown): value is AgentConfig {
 // Identity Loading
 // ============================================================================
 
-function loadIdentity(): { name: string; description?: string } {
+function parseIdentityMarkdown(content: string): { name: string; description?: string } {
+	const nameMatch = content.match(/name:\s*(.+)/i);
+	const youAreMatch = content.match(/(?:^|\n)\s*(?:#+\s*)?you are\s+([^\n.]+)\.?/i);
+	const descMatch = content.match(/creature:\s*(.+)/i) || content.match(/role:\s*(.+)/i);
+
+	return {
+		name: (nameMatch?.[1] ?? youAreMatch?.[1] ?? "Agent").trim(),
+		description: descMatch?.[1]?.trim(),
+	};
+}
+
+function loadIdentity(identityFiles?: IdentityFileMap): { name: string; description?: string } {
+	const identityMd = identityFiles?.["IDENTITY.md"];
+	if (identityMd && existsSync(identityMd)) {
+		try {
+			return parseIdentityMarkdown(readFileSync(identityMd, "utf-8"));
+		} catch {}
+	}
+
 	const agentYaml = join(getAgentsDir(), "agent.yaml");
 	if (existsSync(agentYaml)) {
 		try {
@@ -1085,16 +1107,10 @@ function loadIdentity(): { name: string; description?: string } {
 		} catch {}
 	}
 
-	const identityMd = join(getAgentsDir(), "IDENTITY.md");
-	if (existsSync(identityMd)) {
+	const rootIdentityMd = join(getAgentsDir(), "IDENTITY.md");
+	if (existsSync(rootIdentityMd)) {
 		try {
-			const content = readFileSync(identityMd, "utf-8");
-			const nameMatch = content.match(/name:\s*(.+)/i);
-			const descMatch = content.match(/creature:\s*(.+)/i) || content.match(/role:\s*(.+)/i);
-			return {
-				name: nameMatch?.[1]?.trim() || "Agent",
-				description: descMatch?.[1]?.trim(),
-			};
+			return parseIdentityMarkdown(readFileSync(rootIdentityMd, "utf-8"));
 		} catch {}
 	}
 
@@ -1246,13 +1262,14 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 		initContinuity(req.sessionKey, req.harness, req.project);
 	}
 
-	const identity = includeIdentity ? loadIdentity() : { name: "Agent" };
+	const identityFiles = resolveIdentityFiles(resolveAgentId(req));
+	const identity = includeIdentity ? loadIdentity(identityFiles) : { name: "Agent" };
 
 	// Read AGENTS.md first so harness instructions precede synthesized memory
-	const agentsMdContent = includeIdentity ? readAgentsMd(12000) : undefined;
+	const agentsMdContent = includeIdentity ? readAgentsMd(12000, identityFiles) : undefined;
 
 	// Read MEMORY.md with 10k char budget
-	const memoryMdContent = readMemoryMd(10000);
+	const memoryMdContent = readMemoryMd(10000, identityFiles);
 
 	const memoryCfg = loadMemoryConfig(getAgentsDir());
 	const traversalCfg = memoryCfg.pipelineV2.traversal;
@@ -1695,9 +1712,9 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	}
 
 	// Inject additional identity files
-	const soulContent = includeIdentity ? readIdentityFile("SOUL.md", 4000) : undefined;
-	const identityContent = includeIdentity ? readIdentityFile("IDENTITY.md", 2000) : undefined;
-	const userContent = includeIdentity ? readIdentityFile("USER.md", 6000) : undefined;
+	const soulContent = includeIdentity ? readIdentityFile("SOUL.md", 4000, identityFiles) : undefined;
+	const identityContent = includeIdentity ? readIdentityFile("IDENTITY.md", 2000, identityFiles) : undefined;
+	const userContent = includeIdentity ? readIdentityFile("USER.md", 6000, identityFiles) : undefined;
 
 	if (soulContent) {
 		injectParts.push("\n## Soul\n");


### PR DESCRIPTION
## Summary

Fixes Hermes Signet memory setup for named agents. A Hermes process configured as `dot` now loads Dot's scoped identity files instead of falling back to the root workspace identity.

## Changes

- Expanded named-agent identity resolution in `@signet/core` so agents can override the full identity file set, including `AGENTS.md`, `IDENTITY.md`, `MEMORY.md`, `USER.md`, and related files.
- Updated daemon session-start to resolve identity files from `agentId` before reading prompt identity content.
- Added Markdown identity parsing for `You are ...` style identity files in addition to `name:` metadata.
- Added `SIGNET_AGENT_WORKSPACE` support to the Hermes memory plugin.
- Updated the Hermes connector installer to persist the derived named-agent workspace when `SIGNET_AGENT_ID` points at an existing agent.
- Added regression coverage for core identity inheritance, daemon session-start, and Hermes connector env generation.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [x] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A, no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No migrations touched.

- [ ] Migration is idempotent
- [ ] Daemon Rust parity reviewed or explicitly N/A
- [ ] Rollback / compatibility note included in PR description

## Testing

- [x] `bun test packages/core/src/__tests__/identity.test.ts packages/daemon/src/hooks.test.ts packages/connector-hermes-agent/index.test.ts`
- [x] `python3 -m py_compile packages/connector-hermes-agent/hermes-plugin/__init__.py`
- [x] `bun run --filter '@signet/connector-hermes-agent' typecheck`
- [x] `bun run build:core`
- [x] `bun run --filter '@signet/connector-hermes-agent' build`
- [x] Tested against running daemon

Also smoke-tested on the Solvr Mac with Hermes configured as Dot. Session-start returned `Dorothy "Dot" Ashby`, used `/Users/solvrmac/.agents/agents/dot` as project, and did not inject `You are Rose`.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Root cause: Hermes provided an agent id, but the memory plugin still sent the current Hermes process directory as `project`, while daemon session-start read root identity files. This let a named Hermes agent receive root identity instructions. The fix aligns Hermes with Signet's existing multi-agent model instead of adding a memory-only identity workaround.
