### PR TITLE
fix(hermes): scope Signet memory to named agents

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1058,10 +1058,15 @@ The default agent uses `shared` policy for backward compatibility — existing
 installs see all their memories unchanged.
 
 **Identity inheritance** — each agent can have its own identity files under
-`$SIGNET_WORKSPACE/agents/{name}/`. Only `SOUL.md` and `IDENTITY.md` are
-expected to be overridden; all other files (`AGENTS.md`, `USER.md`, etc.)
-inherit from the workspace root. The daemon's file watcher monitors
-`$SIGNET_WORKSPACE/agents/` and triggers a harness sync on change.
+`$SIGNET_WORKSPACE/agents/{name}/`. On session start, the daemon checks the
+agent directory first for the standard identity files (`AGENTS.md`, `SOUL.md`,
+`IDENTITY.md`, `USER.md`, `TOOLS.md`, `HEARTBEAT.md`, `MEMORY.md`,
+`BOOTSTRAP.md`) and falls back to the workspace root when an agent-local file
+does not exist. This lets named agents override prompt identity and working
+memory without copying the whole workspace. If no agent-local `MEMORY.md`
+exists, the shared root `MEMORY.md` remains the working-memory projection for
+that agent. The daemon's file watcher monitors `$SIGNET_WORKSPACE/agents/`
+and triggers a harness sync on change.
 
 **OpenClaw session keys** — OpenClaw encodes the agent ID in session keys as
 `agent:{id}:{rest}`. The daemon's `resolveAgentId()` helper auto-parses this

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -123,7 +123,7 @@ Options:
 | `--name <name>` | Agent name in non-interactive mode |
 | `--description <description>` | Agent description in non-interactive mode |
 | `--deployment-type <type>` | Deployment context (`local`, `vps`, `server`) used for interactive guidance and non-interactive inferred defaults |
-| `--harness <harness>` | Repeatable/comma-separated harness list (`claude-code`, `opencode`, `openclaw`, `oh-my-pi`, `pi`, `codex`, `forge`) |
+| `--harness <harness>` | Repeatable/comma-separated harness list (`claude-code`, `opencode`, `openclaw`, `hermes-agent`, `oh-my-pi`, `pi`, `codex`, `forge`) |
 | `--embedding-provider <provider>` | Non-interactive embedding provider (`ollama`, `openai`, `native`, `none`) |
 | `--embedding-model <model>` | Non-interactive embedding model |
 | `--extraction-provider <provider>` | Non-interactive extraction provider (`claude-code`, `codex`, `ollama`, `opencode`, `openrouter`, `none`) |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -173,9 +173,13 @@ Wizard steps:
 1. **Agent Name** - What to call your agent
 2. **Harnesses** - Which AI platforms you use:
    - Claude Code (Anthropic CLI)
+   - Codex
    - OpenCode
    - OpenClaw
-   - Codex
+   - Oh My Pi
+   - Pi
+   - Hermes Agent
+   - Forge
 3. **OpenClaw Workspace** - Appears only when an existing OpenClaw config
    is detected; workspace is patched only if you opt in, and setup warns
    that uninstalling OpenClaw can delete this workspace unless backups exist

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -742,7 +742,8 @@ All harnesses target the same model:
 
 - one agent
 - many sessions / branches
-- one shared `MEMORY.md` head
+- one shared root `MEMORY.md` head, with optional agent-local `MEMORY.md`
+  overrides for named agents
 - structured retrieval first
 - transcripts as fallback / deep history
 - compaction artifacts feeding the same temporal DAG

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -683,9 +683,13 @@ Hermes lifecycle.
 
 | Tool | Description |
 |------|-------------|
-| `signet_search` | Hybrid memory search (keyword + semantic + knowledge graph) |
-| `signet_store` | Store a fact/preference/decision with auto entity extraction |
-| `signet_profile` | Broad overview of stored memories and working context |
+| `memory_search` | Hybrid memory search (keyword + semantic + knowledge graph) |
+| `memory_store` | Store a fact/preference/decision with auto entity extraction |
+| `memory_get` | Retrieve a memory by ID |
+| `memory_list` | List memories with optional filters |
+| `memory_modify` | Edit an existing memory |
+| `memory_forget` | Soft-delete a memory |
+| `recall` / `remember` | Compatibility aliases for search/store |
 
 ### Supported hooks
 

--- a/packages/cli/src/commands/app.ts
+++ b/packages/cli/src/commands/app.ts
@@ -57,7 +57,7 @@ export function registerAppCommands(program: Command, deps: AppDeps): void {
 		.option("--network-mode <mode>", "Daemon network mode in non-interactive mode (localhost, tailscale)")
 		.option(
 			"--harness <harness>",
-			"Harness to configure (repeatable or comma-separated: claude-code, codex, opencode, openclaw, oh-my-pi, forge)",
+			"Harness to configure (repeatable or comma-separated: claude-code, codex, opencode, openclaw, oh-my-pi, pi, hermes-agent, forge)",
 			deps.collectListOption,
 			[],
 		)

--- a/packages/cli/src/commands/memory.test.ts
+++ b/packages/cli/src/commands/memory.test.ts
@@ -47,11 +47,13 @@ describe("registerMemoryCommands recall", () => {
 		};
 
 		let capturedBody: unknown;
+		let capturedTimeout: number | undefined;
 		const program = new Command();
 		registerMemoryCommands(program, {
 			ensureDaemonForSecrets: async () => true,
-			secretApiCall: async (_method, _path, body) => {
+			secretApiCall: async (_method, _path, body, timeoutMs) => {
 				capturedBody = body;
+				capturedTimeout = timeoutMs;
 				return {
 					ok: true,
 					data: {
@@ -113,6 +115,7 @@ describe("registerMemoryCommands recall", () => {
 			until: "2026-04-01",
 			expand: true,
 		});
+		expect(capturedTimeout).toBe(30_000);
 		expect(lines).toHaveLength(1);
 		expect(lines[0]).toContain('"high score row"');
 		expect(lines[0]).not.toContain('"low score row"');

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -3,6 +3,8 @@ import chalk from "chalk";
 import type { Command } from "commander";
 import ora from "ora";
 
+const MEMORY_RECALL_TIMEOUT_MS = 30_000;
+
 interface MemoryDeps {
 	readonly ensureDaemonForSecrets: () => Promise<boolean>;
 	readonly secretApiCall: (
@@ -164,21 +166,26 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 			if (!(await deps.ensureDaemonForSecrets())) return;
 
 			const spinner = ora("Searching memories...").start();
-			const { ok, data } = await deps.secretApiCall("POST", "/api/memory/recall", {
-				query,
-				keywordQuery: options.keywordQuery,
-				limit: options.limit,
-				project: options.project,
-				type: options.type,
-				tags: options.tags,
-				who: options.who,
-				pinned: options.pinned === true ? true : undefined,
-				importance_min: options.importanceMin,
-				since: options.since,
-				until: options.until,
-				expand: options.expand === true ? true : undefined,
-				...(options.agent ? { agentId: options.agent } : {}),
-			});
+			const { ok, data } = await deps.secretApiCall(
+				"POST",
+				"/api/memory/recall",
+				{
+					query,
+					keywordQuery: options.keywordQuery,
+					limit: options.limit,
+					project: options.project,
+					type: options.type,
+					tags: options.tags,
+					who: options.who,
+					pinned: options.pinned === true ? true : undefined,
+					importance_min: options.importanceMin,
+					since: options.since,
+					until: options.until,
+					expand: options.expand === true ? true : undefined,
+					...(options.agent ? { agentId: options.agent } : {}),
+				},
+				MEMORY_RECALL_TIMEOUT_MS,
+			);
 
 			const err = typeof data === "object" && data !== null && "error" in data ? data.error : undefined;
 			if (!ok || typeof err === "string") {

--- a/packages/cli/src/features/setup-migrate.ts
+++ b/packages/cli/src/features/setup-migrate.ts
@@ -121,6 +121,7 @@ export async function runExistingSetupWizard(
 		if (detection.harnesses.openclaw) detectedHarnesses.push("openclaw");
 		if (detection.harnesses.opencode) detectedHarnesses.push("opencode");
 		if (detection.harnesses.codex) detectedHarnesses.push("codex");
+		if (detection.harnesses.hermesAgent) detectedHarnesses.push("hermes-agent");
 		const configuredHarnessList = readHarnesses(existingConfig.harnesses);
 		if (detection.harnesses.ohMyPi || configuredHarnessList.includes("oh-my-pi")) detectedHarnesses.push("oh-my-pi");
 		if (detection.harnesses.pi || configuredHarnessList.includes("pi")) detectedHarnesses.push("pi");

--- a/packages/cli/src/features/setup-shared.test.ts
+++ b/packages/cli/src/features/setup-shared.test.ts
@@ -1,16 +1,30 @@
 import { describe, expect, it } from "bun:test";
 import {
 	DEPLOYMENT_TYPE_CHOICES,
+	SETUP_HARNESS_CHOICES,
 	defaultEmbeddingProviderForDeployment,
 	defaultExtractionProviderForDeployment,
 	detectExtractionProviderFromAvailable,
 	getDeploymentExtractionGuidance,
+	normalizeHarnessList,
 	resolveSetupExtractionProvider,
 } from "./setup-shared.js";
 
 describe("setup deployment defaults", () => {
 	it("supports local, vps, and server deployment choices", () => {
 		expect(DEPLOYMENT_TYPE_CHOICES).toEqual(["local", "vps", "server"]);
+	});
+
+	it("supports Hermes Agent as a setup harness choice", () => {
+		expect(SETUP_HARNESS_CHOICES).toContain("hermes-agent");
+		expect(
+			normalizeHarnessList(["hermes-agent,claude-code"], {
+				normalizeChoice: (value, allowed) => {
+					const s = String(value);
+					return (allowed as readonly string[]).includes(s) ? (s as (typeof allowed)[number]) : null;
+				},
+			}),
+		).toEqual(["hermes-agent", "claude-code"]);
 	});
 
 	it("defaults embedding provider to native across deployment types", () => {

--- a/packages/cli/src/features/setup.ts
+++ b/packages/cli/src/features/setup.ts
@@ -418,6 +418,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		{ value: "openclaw", name: "OpenClaw", checked: existingHarnesses.includes("openclaw") },
 		{ value: "oh-my-pi", name: "Oh My Pi", checked: existingHarnesses.includes("oh-my-pi") },
 		{ value: "pi", name: "Pi", checked: existingHarnesses.includes("pi") },
+		{ value: "hermes-agent", name: "Hermes Agent", checked: existingHarnesses.includes("hermes-agent") },
 		{
 			value: "forge",
 			name: "Forge (native Signet harness)",

--- a/packages/connector-hermes-agent/hermes-plugin/README.md
+++ b/packages/connector-hermes-agent/hermes-plugin/README.md
@@ -39,6 +39,13 @@ Environment variables:
 | `memory_forget` | Soft-delete a memory |
 | `recall` / `remember` | Compatibility aliases for search/store |
 
+`memory_store` exposes the full Signet remember surface, including:
+
+- `content`, `type`, `importance`, `tags`, `pinned`, and `project`
+- `hints` for prospective recall hints and alternate phrasings
+- `transcript` for lossless source text alongside the saved memory
+- `structured.entities`, `structured.aspects`, and `structured.hints` for callers that already extracted graph-ready memory metadata
+
 ## How It Works
 
 The plugin bridges Hermes Agent's memory lifecycle to the Signet daemon:

--- a/packages/connector-hermes-agent/hermes-plugin/README.md
+++ b/packages/connector-hermes-agent/hermes-plugin/README.md
@@ -24,16 +24,20 @@ signet start   # ensure daemon is running
 Environment variables:
 - `SIGNET_DAEMON_URL` — Full daemon URL (default: `http://localhost:3850`)
 - `SIGNET_HOST` / `SIGNET_PORT` — Host and port separately
-- `SIGNET_AGENT_ID` — Agent scope identifier (default: `default`)
+- `SIGNET_AGENT_ID` — Agent scope identifier (default: `hermes-agent`)
 - `SIGNET_AGENT_WORKSPACE` — Optional named-agent workspace path (for example `~/.agents/agents/dot`)
 
 ## Tools
 
 | Tool | Description |
 |------|-------------|
-| `signet_search` | Hybrid memory search (keyword + semantic + knowledge graph) |
-| `signet_store` | Store a fact, preference, or decision to memory |
-| `signet_profile` | Broad overview of stored memories and context |
+| `memory_search` | Hybrid memory search (keyword + semantic + knowledge graph) |
+| `memory_store` | Store a fact, preference, or decision to memory |
+| `memory_get` | Retrieve a memory by ID |
+| `memory_list` | List memories with optional filters |
+| `memory_modify` | Edit an existing memory |
+| `memory_forget` | Soft-delete a memory |
+| `recall` / `remember` | Compatibility aliases for search/store |
 
 ## How It Works
 
@@ -45,4 +49,4 @@ The plugin bridges Hermes Agent's memory lifecycle to the Signet daemon:
 
 3. **Session end** — Sends the conversation transcript to Signet's session-end hook, which queues it for the memory pipeline: extraction, knowledge graph updates, retention decay, and MEMORY.md synthesis.
 
-4. **Explicit tools** — The agent can call `signet_search`, `signet_store`, and `signet_profile` directly during conversation for on-demand memory operations.
+4. **Explicit tools** — The agent can call canonical Signet tools such as `memory_search` and `memory_store` directly during conversation for on-demand memory operations. Legacy `signet_*` names are handled for compatibility but are not advertised to the model.

--- a/packages/connector-hermes-agent/hermes-plugin/README.md
+++ b/packages/connector-hermes-agent/hermes-plugin/README.md
@@ -26,6 +26,8 @@ Environment variables:
 - `SIGNET_HOST` / `SIGNET_PORT` — Host and port separately
 - `SIGNET_AGENT_ID` — Agent scope identifier (default: `hermes-agent`)
 - `SIGNET_AGENT_WORKSPACE` — Optional named-agent workspace path (for example `~/.agents/agents/dot`)
+- `SIGNET_AGENT_READ_POLICY` — Optional named-agent memory policy for first registration: `shared` (default), `isolated`, or `group`
+- `SIGNET_AGENT_POLICY_GROUP` — Required when `SIGNET_AGENT_READ_POLICY=group`
 
 ## Tools
 

--- a/packages/connector-hermes-agent/hermes-plugin/README.md
+++ b/packages/connector-hermes-agent/hermes-plugin/README.md
@@ -25,6 +25,7 @@ Environment variables:
 - `SIGNET_DAEMON_URL` — Full daemon URL (default: `http://localhost:3850`)
 - `SIGNET_HOST` / `SIGNET_PORT` — Host and port separately
 - `SIGNET_AGENT_ID` — Agent scope identifier (default: `default`)
+- `SIGNET_AGENT_WORKSPACE` — Optional named-agent workspace path (for example `~/.agents/agents/dot`)
 
 ## Tools
 

--- a/packages/connector-hermes-agent/hermes-plugin/__init__.py
+++ b/packages/connector-hermes-agent/hermes-plugin/__init__.py
@@ -13,6 +13,7 @@ Config:
   - SIGNET_HOST / SIGNET_PORT env vars (default: localhost:3850)
   - SIGNET_DAEMON_URL env var for full URL override
   - SIGNET_AGENT_ID env var for agent scoping (default: "hermes-agent")
+  - SIGNET_AGENT_WORKSPACE env var for the active named-agent workspace
 """
 
 from __future__ import annotations
@@ -102,6 +103,32 @@ PROFILE_SCHEMA = {
 }
 
 ALL_TOOL_SCHEMAS = [SEARCH_SCHEMA, STORE_SCHEMA, PROFILE_SCHEMA]
+
+
+def _sanitize_env(value: str) -> str:
+    return value.strip().replace("\r", "").replace("\n", "")
+
+
+def _resolve_agent_workspace(agent_id: str, kwargs: Dict[str, Any]) -> str:
+    """Resolve the project/workspace path sent to Signet hooks.
+
+    Named Signet agents can have their own workspace at
+    $SIGNET_PATH/agents/{agent_id}. Prefer that workspace so daemon
+    session-start can load the agent's scoped identity files.
+    """
+    explicit = _sanitize_env(os.environ.get("SIGNET_AGENT_WORKSPACE", ""))
+    if explicit:
+        return str(Path(explicit).expanduser())
+
+    signet_path = _sanitize_env(os.environ.get("SIGNET_PATH", ""))
+    agents_root = Path(signet_path).expanduser() if signet_path else Path.home() / ".agents"
+    if agent_id and agent_id != "default":
+        candidate = agents_root / "agents" / agent_id
+        if candidate.exists():
+            return str(candidate)
+
+    fallback = kwargs.get("cwd", kwargs.get("project", os.getcwd()))
+    return str(Path(str(fallback)).expanduser())
 
 
 # ---------------------------------------------------------------------------
@@ -209,7 +236,7 @@ class SignetMemoryProvider(MemoryProvider):
             return
 
         self._session_key = session_id or "hermes-default"
-        self._project = kwargs.get("cwd", kwargs.get("project", os.getcwd()))
+        self._project = _resolve_agent_workspace(agent_id, kwargs)
 
         # Call session-start hook — get identity + memories + inject
         result = self._client.session_start(

--- a/packages/connector-hermes-agent/hermes-plugin/__init__.py
+++ b/packages/connector-hermes-agent/hermes-plugin/__init__.py
@@ -249,7 +249,7 @@ def _resolve_agent_workspace(agent_id: str, kwargs: Dict[str, Any]) -> str:
 
     signet_path = _sanitize_env(os.environ.get("SIGNET_PATH", ""))
     agents_root = Path(signet_path).expanduser() if signet_path else Path.home() / ".agents"
-    if agent_id and agent_id != "default":
+    if agent_id and agent_id not in ("default", "hermes-agent"):
         candidate = agents_root / "agents" / agent_id
         if candidate.exists():
             return str(candidate)

--- a/packages/connector-hermes-agent/hermes-plugin/__init__.py
+++ b/packages/connector-hermes-agent/hermes-plugin/__init__.py
@@ -69,6 +69,43 @@ MEMORY_SEARCH_SCHEMA = {
     },
 }
 
+STRUCTURED_ENTITY_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "source": {"type": "string", "description": "Source entity name."},
+        "sourceType": {"type": "string", "description": "Optional source entity type."},
+        "relationship": {"type": "string", "description": "Relationship from source to target."},
+        "target": {"type": "string", "description": "Target entity name."},
+        "targetType": {"type": "string", "description": "Optional target entity type."},
+        "confidence": {"type": "number", "description": "Optional confidence score 0-1."},
+    },
+    "required": ["source", "relationship", "target"],
+}
+
+STRUCTURED_ATTRIBUTE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "content": {"type": "string", "description": "Attribute or constraint text."},
+        "confidence": {"type": "number", "description": "Optional confidence score 0-1."},
+        "importance": {"type": "number", "description": "Optional importance score 0-1."},
+    },
+    "required": ["content"],
+}
+
+STRUCTURED_ASPECT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "entityName": {"type": "string", "description": "Entity the aspect belongs to."},
+        "aspect": {"type": "string", "description": "Aspect name, e.g. preference, workflow, constraint."},
+        "attributes": {
+            "type": "array",
+            "items": STRUCTURED_ATTRIBUTE_SCHEMA,
+            "description": "Facts, constraints, or attributes for this aspect.",
+        },
+    },
+    "required": ["entityName", "aspect", "attributes"],
+}
+
 MEMORY_STORE_SCHEMA = {
     "name": "memory_store",
     "description": "Save a new memory to Signet.",
@@ -81,6 +118,36 @@ MEMORY_STORE_SCHEMA = {
             "tags": {"type": "string", "description": "Comma-separated tags for categorization."},
             "pinned": {"type": "boolean", "description": "Pin this memory so it does not decay."},
             "project": {"type": "string", "description": "Optional project path. Defaults to the active Hermes Signet workspace."},
+            "hints": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Prospective recall hints and alternate phrasings for retrieving this memory later.",
+            },
+            "transcript": {
+                "type": "string",
+                "description": "Raw source text or conversation transcript to preserve alongside this memory.",
+            },
+            "structured": {
+                "type": "object",
+                "description": "Pre-extracted structured data. When provided, Signet can persist graph links and hints directly.",
+                "properties": {
+                    "entities": {
+                        "type": "array",
+                        "items": STRUCTURED_ENTITY_SCHEMA,
+                        "description": "Entity relationships to link to this memory.",
+                    },
+                    "aspects": {
+                        "type": "array",
+                        "items": STRUCTURED_ASPECT_SCHEMA,
+                        "description": "Entity aspects and attributes to persist for graph recall.",
+                    },
+                    "hints": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Prospective recall hints and alternate phrasings.",
+                    },
+                },
+            },
         },
         "required": ["content"],
     },
@@ -678,6 +745,17 @@ class SignetMemoryProvider(MemoryProvider):
                 return [t.strip() for t in value.split(",") if t.strip()]
             return [str(value).strip()] if str(value).strip() else None
 
+        def _string_list(value: Any) -> Optional[List[str]]:
+            if value is None or value == "":
+                return None
+            if isinstance(value, list):
+                items = [str(item).strip() for item in value if str(item).strip()]
+                return items or None
+            if isinstance(value, str):
+                stripped = value.strip()
+                return [stripped] if stripped else None
+            return None
+
         def _search(search_args: Dict[str, Any]) -> str:
             query = str(search_args.get("query", "")).strip()
             if not query:
@@ -714,6 +792,9 @@ class SignetMemoryProvider(MemoryProvider):
             if importance is None:
                 importance = 0.5
             importance = max(0.0, min(1.0, importance))
+            structured = store_args.get("structured")
+            if not isinstance(structured, dict):
+                structured = None
             result = self._client.remember(
                 content,
                 importance=importance,
@@ -721,6 +802,9 @@ class SignetMemoryProvider(MemoryProvider):
                 memory_type=str(store_args.get("type", "") or ""),
                 pinned=store_args.get("pinned") if isinstance(store_args.get("pinned"), bool) else None,
                 project=str(store_args.get("project", "") or self._project),
+                hints=_string_list(store_args.get("hints")),
+                transcript=str(store_args.get("transcript", "") or ""),
+                structured=structured,
                 who="hermes-agent",
             )
             if not result:

--- a/packages/connector-hermes-agent/hermes-plugin/__init__.py
+++ b/packages/connector-hermes-agent/hermes-plugin/__init__.py
@@ -64,6 +64,10 @@ MEMORY_SEARCH_SCHEMA = {
                 "description": "Deprecated compatibility alias for importance_min; ignored when importance_min is set.",
             },
             "score_min": {"type": "number", "description": "Minimum recall score threshold, applied client-side."},
+            "agent_scoped": {
+                "type": "boolean",
+                "description": "When true, scope recall to SIGNET_AGENT_ID instead of searching shared effective memory.",
+            },
         },
         "required": ["query"],
     },
@@ -778,6 +782,7 @@ class SignetMemoryProvider(MemoryProvider):
                 keyword_query=str(search_args.get("keyword_query", "") or ""),
                 expand=bool(search_args.get("expand", False)),
                 score_min=_as_float(search_args.get("score_min")),
+                agent_scoped=bool(search_args.get("agent_scoped", False)),
             )
             if not result:
                 return json.dumps({"error": "Search failed or Signet daemon returned no response.", "results": []})

--- a/packages/connector-hermes-agent/hermes-plugin/__init__.py
+++ b/packages/connector-hermes-agent/hermes-plugin/__init__.py
@@ -203,7 +203,6 @@ MEMORY_FORGET_SCHEMA = {
         "properties": {
             "id": {"type": "string", "description": "Memory ID to forget."},
             "reason": {"type": "string", "description": "Why this memory should be forgotten."},
-            "force": {"type": "boolean", "description": "Hard-delete instead of soft-delete, when supported."},
         },
         "required": ["id", "reason"],
     },
@@ -864,7 +863,6 @@ class SignetMemoryProvider(MemoryProvider):
                 result = self._client.forget_memory(
                     memory_id,
                     reason=reason,
-                    force=bool(args.get("force", False)),
                 )
                 return json.dumps(result if result else {"error": "Failed to forget memory."})
 

--- a/packages/connector-hermes-agent/hermes-plugin/__init__.py
+++ b/packages/connector-hermes-agent/hermes-plugin/__init__.py
@@ -5,9 +5,11 @@ Bridges Hermes Agent's memory provider interface to the Signet daemon
 predictive recall, cross-session memory, and the full Signet pipeline
 (extraction, knowledge graph, retention decay, synthesis).
 
-The 3 tools (signet_search, signet_store, signet_profile) are exposed
-through the MemoryProvider interface. The daemon handles all heavy lifting:
-embedding, reranking, knowledge graph traversal, and predictive scoring.
+Canonical Signet memory tools (memory_search, memory_store, memory_get,
+memory_list, memory_modify, memory_forget, plus recall/remember aliases) are
+exposed through the MemoryProvider interface. The daemon handles all heavy
+lifting: embedding, reranking, knowledge graph traversal, and predictive
+scoring.
 
 Config:
   - SIGNET_HOST / SIGNET_PORT env vars (default: localhost:3850)
@@ -39,71 +41,129 @@ logger = logging.getLogger(__name__)
 # Tool schemas
 # ---------------------------------------------------------------------------
 
-SEARCH_SCHEMA = {
-    "name": "signet_search",
-    "description": (
-        "Search Signet's memory using hybrid recall (keyword + semantic + "
-        "knowledge graph). Returns relevant memories ranked by predicted "
-        "usefulness. Use when you need to find past context, decisions, "
-        "preferences, or project knowledge."
-    ),
+MEMORY_SEARCH_SCHEMA = {
+    "name": "memory_search",
+    "description": "Search Signet memories using hybrid vector + keyword search.",
     "parameters": {
         "type": "object",
         "properties": {
-            "query": {
-                "type": "string",
-                "description": "What to search for in memory.",
+            "query": {"type": "string", "description": "Search query text."},
+            "limit": {"type": "integer", "description": "Max results to return (default 10, max 50)."},
+            "project": {"type": "string", "description": "Optional project path filter."},
+            "expand": {"type": "boolean", "description": "Include lossless session transcripts as sources."},
+            "type": {"type": "string", "description": "Filter by memory type."},
+            "tags": {"type": "string", "description": "Filter by tags, comma-separated."},
+            "who": {"type": "string", "description": "Filter by author."},
+            "since": {"type": "string", "description": "Only include memories created after this date."},
+            "until": {"type": "string", "description": "Only include memories created before this date."},
+            "keyword_query": {"type": "string", "description": "Override the keyword/FTS query used for recall."},
+            "pinned": {"type": "boolean", "description": "Only return pinned memories."},
+            "importance_min": {"type": "number", "description": "Minimum memory importance threshold."},
+            "min_score": {
+                "type": "number",
+                "description": "Deprecated compatibility alias for importance_min; ignored when importance_min is set.",
             },
-            "limit": {
-                "type": "integer",
-                "description": "Max results to return (default: 10, max: 50).",
-            },
+            "score_min": {"type": "number", "description": "Minimum recall score threshold, applied client-side."},
         },
         "required": ["query"],
     },
 }
 
-STORE_SCHEMA = {
-    "name": "signet_store",
-    "description": (
-        "Store a memory in Signet. The daemon handles embedding, entity "
-        "extraction, knowledge graph linking, and deduplication automatically. "
-        "Use for explicit facts, preferences, decisions, or corrections the "
-        "user wants remembered across sessions."
-    ),
+MEMORY_STORE_SCHEMA = {
+    "name": "memory_store",
+    "description": "Save a new memory to Signet.",
     "parameters": {
         "type": "object",
         "properties": {
-            "content": {
-                "type": "string",
-                "description": "The memory content to store.",
-            },
-            "importance": {
-                "type": "number",
-                "description": "Importance score 0-1 (default: 0.5). Higher = more likely to surface.",
-            },
-            "tags": {
-                "type": "string",
-                "description": "Comma-separated tags for categorization (optional).",
-            },
+            "content": {"type": "string", "description": "Memory content to save."},
+            "type": {"type": "string", "description": "Memory type, e.g. fact, preference, decision."},
+            "importance": {"type": "number", "description": "Importance score 0-1."},
+            "tags": {"type": "string", "description": "Comma-separated tags for categorization."},
+            "pinned": {"type": "boolean", "description": "Pin this memory so it does not decay."},
+            "project": {"type": "string", "description": "Optional project path. Defaults to the active Hermes Signet workspace."},
         },
         "required": ["content"],
     },
 }
 
-PROFILE_SCHEMA = {
-    "name": "signet_profile",
-    "description": (
-        "Retrieve the user's memory profile from Signet — recent memories, "
-        "key facts, and working context (MEMORY.md). Fast overview without "
-        "a specific search query. Use at conversation start or when you need "
-        "a broad snapshot of what Signet knows."
-    ),
-    "parameters": {"type": "object", "properties": {}, "required": []},
+MEMORY_GET_SCHEMA = {
+    "name": "memory_get",
+    "description": "Get a single memory by its ID.",
+    "parameters": {
+        "type": "object",
+        "properties": {"id": {"type": "string", "description": "Memory ID to retrieve."}},
+        "required": ["id"],
+    },
 }
 
-ALL_TOOL_SCHEMAS = [SEARCH_SCHEMA, STORE_SCHEMA, PROFILE_SCHEMA]
+MEMORY_LIST_SCHEMA = {
+    "name": "memory_list",
+    "description": "List memories with optional filters.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "limit": {"type": "integer", "description": "Max results to return, default 100."},
+            "offset": {"type": "integer", "description": "Pagination offset."},
+            "type": {"type": "string", "description": "Filter by memory type."},
+        },
+        "required": [],
+    },
+}
 
+MEMORY_MODIFY_SCHEMA = {
+    "name": "memory_modify",
+    "description": "Edit an existing memory by ID.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "id": {"type": "string", "description": "Memory ID to modify."},
+            "content": {"type": "string", "description": "New content."},
+            "type": {"type": "string", "description": "New memory type."},
+            "importance": {"type": "number", "description": "New importance score 0-1."},
+            "tags": {"type": "string", "description": "New tags, comma-separated."},
+            "pinned": {"type": "boolean", "description": "Pin or unpin this memory."},
+            "reason": {"type": "string", "description": "Why this edit is being made."},
+        },
+        "required": ["id", "reason"],
+    },
+}
+
+MEMORY_FORGET_SCHEMA = {
+    "name": "memory_forget",
+    "description": "Soft-delete a memory by ID.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "id": {"type": "string", "description": "Memory ID to forget."},
+            "reason": {"type": "string", "description": "Why this memory should be forgotten."},
+            "force": {"type": "boolean", "description": "Hard-delete instead of soft-delete, when supported."},
+        },
+        "required": ["id", "reason"],
+    },
+}
+
+RECALL_ALIAS_SCHEMA = {
+    "name": "recall",
+    "description": "Alias for memory_search.",
+    "parameters": MEMORY_SEARCH_SCHEMA["parameters"],
+}
+
+REMEMBER_ALIAS_SCHEMA = {
+    "name": "remember",
+    "description": "Alias for memory_store.",
+    "parameters": MEMORY_STORE_SCHEMA["parameters"],
+}
+
+ALL_TOOL_SCHEMAS = [
+    MEMORY_SEARCH_SCHEMA,
+    MEMORY_STORE_SCHEMA,
+    MEMORY_GET_SCHEMA,
+    MEMORY_LIST_SCHEMA,
+    MEMORY_MODIFY_SCHEMA,
+    MEMORY_FORGET_SCHEMA,
+    RECALL_ALIAS_SCHEMA,
+    REMEMBER_ALIAS_SCHEMA,
+]
 
 def _sanitize_env(value: str) -> str:
     return value.strip().replace("\r", "").replace("\n", "")
@@ -281,8 +341,9 @@ class SignetMemoryProvider(MemoryProvider):
         return (
             "# Signet Memory\n"
             "Active. Memories are auto-recalled each turn via hybrid search. "
-            "Use signet_search to query memory, signet_store to save facts, "
-            "signet_profile for a broad overview."
+            "Use memory_search to query memory, memory_store to save facts, "
+            "and memory_get/memory_list/memory_modify/memory_forget for direct "
+            "memory management."
         )
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
@@ -593,55 +654,135 @@ class SignetMemoryProvider(MemoryProvider):
         if not self._client:
             return json.dumps({"error": "Signet daemon is not connected."})
 
-        try:
-            if tool_name == "signet_search":
-                query = args.get("query", "")
-                if not query:
-                    return json.dumps({"error": "Missing required parameter: query"})
-                limit = min(int(args.get("limit", 10)), 50)
-                result = self._client.recall(query, limit=limit)
-                if not result:
-                    return json.dumps({"result": "No relevant memories found."})
-                # Extract memories from recall response
-                memories = result.get("results", result.get("memories", []))
-                if not memories:
-                    return json.dumps({"result": "No relevant memories found."})
-                items = []
-                for m in memories:
-                    items.append({
-                        "content": m.get("content", ""),
-                        "type": m.get("type", ""),
-                        "importance": m.get("importance", 0),
-                        "created_at": m.get("created_at", ""),
-                    })
-                return json.dumps({"results": items, "count": len(items)})
+        def _as_int(value: Any, default: int, *, minimum: int = 0, maximum: int = 10_000) -> int:
+            try:
+                parsed = int(value)
+            except (TypeError, ValueError):
+                parsed = default
+            return max(minimum, min(maximum, parsed))
 
-            elif tool_name == "signet_store":
-                content = args.get("content", "")
-                if not content:
-                    return json.dumps({"error": "Missing required parameter: content"})
-                importance = float(args.get("importance", 0.5))
-                importance = max(0.0, min(1.0, importance))
-                tags_str = args.get("tags", "")
-                tags = [t.strip() for t in tags_str.split(",") if t.strip()] if tags_str else None
-                result = self._client.remember(content, importance=importance, tags=tags)
-                if result:
-                    return json.dumps({"result": "Memory stored.", "id": result.get("id", "")})
+        def _as_float(value: Any) -> Optional[float]:
+            if value is None or value == "":
+                return None
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                return None
+
+        def _tags(value: Any) -> Optional[List[str]]:
+            if value is None or value == "":
+                return None
+            if isinstance(value, list):
+                return [str(t).strip() for t in value if str(t).strip()]
+            if isinstance(value, str):
+                return [t.strip() for t in value.split(",") if t.strip()]
+            return [str(value).strip()] if str(value).strip() else None
+
+        def _search(search_args: Dict[str, Any]) -> str:
+            query = str(search_args.get("query", "")).strip()
+            if not query:
+                return json.dumps({"error": "Missing required parameter: query"})
+
+            importance_min = _as_float(search_args.get("importance_min"))
+            if importance_min is None:
+                importance_min = _as_float(search_args.get("min_score"))
+
+            result = self._client.recall(
+                query,
+                limit=_as_int(search_args.get("limit"), 10, minimum=1, maximum=50),
+                project=str(search_args.get("project", "") or ""),
+                memory_type=str(search_args.get("type", "") or ""),
+                tags=str(search_args.get("tags", "") or ""),
+                who=str(search_args.get("who", "") or ""),
+                pinned=search_args.get("pinned") if isinstance(search_args.get("pinned"), bool) else None,
+                importance_min=importance_min,
+                since=str(search_args.get("since", "") or ""),
+                until=str(search_args.get("until", "") or ""),
+                keyword_query=str(search_args.get("keyword_query", "") or ""),
+                expand=bool(search_args.get("expand", False)),
+                score_min=_as_float(search_args.get("score_min")),
+            )
+            if not result:
+                return json.dumps({"error": "Search failed or Signet daemon returned no response.", "results": []})
+            return json.dumps(result)
+
+        def _store(store_args: Dict[str, Any]) -> str:
+            content = str(store_args.get("content", "")).strip()
+            if not content:
+                return json.dumps({"error": "Missing required parameter: content"})
+            importance = _as_float(store_args.get("importance"))
+            if importance is None:
+                importance = 0.5
+            importance = max(0.0, min(1.0, importance))
+            result = self._client.remember(
+                content,
+                importance=importance,
+                tags=_tags(store_args.get("tags")),
+                memory_type=str(store_args.get("type", "") or ""),
+                pinned=store_args.get("pinned") if isinstance(store_args.get("pinned"), bool) else None,
+                project=str(store_args.get("project", "") or self._project),
+                who="hermes-agent",
+            )
+            if not result:
                 return json.dumps({"error": "Failed to store memory."})
+            return json.dumps({"result": "Memory saved.", "id": result.get("id", result.get("memoryId", ""))})
 
-            elif tool_name == "signet_profile":
-                # Fetch recent memories and working context
-                result = self._client.recall("user profile preferences context", limit=15)
-                if not result:
-                    return json.dumps({"result": "No memories stored yet."})
-                memories = result.get("results", result.get("memories", []))
-                if not memories:
-                    return json.dumps({"result": "No memories stored yet."})
-                lines = [m.get("content", "") for m in memories if m.get("content")]
-                return json.dumps({
-                    "result": "\n".join(f"- {l}" for l in lines),
-                    "count": len(lines),
-                })
+        try:
+            if tool_name in ("memory_search", "recall", "signet_search"):
+                return _search(args)
+
+            if tool_name in ("memory_store", "remember", "signet_store"):
+                return _store(args)
+
+            if tool_name == "signet_profile":
+                return _search({"query": "user profile preferences context", "limit": 15})
+
+            if tool_name == "memory_get":
+                memory_id = str(args.get("id", "")).strip()
+                if not memory_id:
+                    return json.dumps({"error": "Missing required parameter: id"})
+                result = self._client.get_memory(memory_id)
+                return json.dumps(result if result else {"error": "Memory not found."})
+
+            if tool_name == "memory_list":
+                result = self._client.list_memories(
+                    limit=_as_int(args.get("limit"), 100, minimum=1, maximum=500),
+                    offset=_as_int(args.get("offset"), 0, minimum=0, maximum=1_000_000),
+                    memory_type=str(args.get("type", "") or ""),
+                )
+                return json.dumps(result if result else {"memories": [], "result": "No memories found."})
+
+            if tool_name == "memory_modify":
+                memory_id = str(args.get("id", "")).strip()
+                reason = str(args.get("reason", "")).strip()
+                if not memory_id:
+                    return json.dumps({"error": "Missing required parameter: id"})
+                if not reason:
+                    return json.dumps({"error": "Missing required parameter: reason"})
+                result = self._client.modify_memory(
+                    memory_id,
+                    content=str(args.get("content", "") or ""),
+                    memory_type=str(args.get("type", "") or ""),
+                    importance=_as_float(args.get("importance")),
+                    tags=str(args.get("tags", "") or ""),
+                    pinned=args.get("pinned") if isinstance(args.get("pinned"), bool) else None,
+                    reason=reason,
+                )
+                return json.dumps(result if result else {"error": "Failed to modify memory."})
+
+            if tool_name == "memory_forget":
+                memory_id = str(args.get("id", "")).strip()
+                reason = str(args.get("reason", "")).strip()
+                if not memory_id:
+                    return json.dumps({"error": "Missing required parameter: id"})
+                if not reason:
+                    return json.dumps({"error": "Missing required parameter: reason"})
+                result = self._client.forget_memory(
+                    memory_id,
+                    reason=reason,
+                    force=bool(args.get("force", False)),
+                )
+                return json.dumps(result if result else {"error": "Failed to forget memory."})
 
             return json.dumps({"error": f"Unknown tool: {tool_name}"})
 

--- a/packages/connector-hermes-agent/hermes-plugin/client.py
+++ b/packages/connector-hermes-agent/hermes-plugin/client.py
@@ -51,6 +51,14 @@ def _read_json_response(resp) -> Dict[str, Any]:
     return json.loads(body.decode("utf-8"))
 
 
+def _safe_score(value: Any) -> float:
+    """Coerce daemon result scores without failing recall on malformed rows."""
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 class SignetClient:
     """HTTP client for the Signet daemon API."""
 
@@ -387,7 +395,7 @@ class SignetClient:
         ):
             kept = [
                 row for row in result["results"]
-                if not isinstance(row, dict) or float(row.get("score") or 0.0) >= score_min
+                if not isinstance(row, dict) or _safe_score(row.get("score")) >= score_min
             ]
             result = dict(result)
             result["results"] = kept

--- a/packages/connector-hermes-agent/hermes-plugin/client.py
+++ b/packages/connector-hermes-agent/hermes-plugin/client.py
@@ -25,6 +25,7 @@ _DEFAULT_HOST = "localhost"
 _DEFAULT_PORT = 3850
 _TIMEOUT_SECS = 5
 _LONG_TIMEOUT_SECS = 15
+_RECALL_TIMEOUT_SECS = 30
 
 
 def _sanitize(value: str) -> str:
@@ -195,6 +196,7 @@ class SignetClient:
                 "agentId": self._agent_id,
                 "project": project,
             },
+            timeout=_LONG_TIMEOUT_SECS,
         )
 
     def session_end(
@@ -360,7 +362,7 @@ class SignetClient:
         if agent_scoped and self._agent_id:
             body["agentId"] = self._agent_id
 
-        result = self._post("/api/memory/recall", body)
+        result = self._post("/api/memory/recall", body, timeout=_RECALL_TIMEOUT_SECS)
         if (
             result
             and score_min is not None

--- a/packages/connector-hermes-agent/hermes-plugin/client.py
+++ b/packages/connector-hermes-agent/hermes-plugin/client.py
@@ -43,6 +43,14 @@ def _resolve_base_url() -> str:
     return f"http://{host}:{port}"
 
 
+def _read_json_response(resp) -> Dict[str, Any]:
+    """Read a daemon response, treating empty successful bodies as an empty object."""
+    body = resp.read()
+    if not body:
+        return {}
+    return json.loads(body.decode("utf-8"))
+
+
 class SignetClient:
     """HTTP client for the Signet daemon API."""
 
@@ -87,7 +95,7 @@ class SignetClient:
         req = urllib.request.Request(url, data=data, headers=headers, method="POST")
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
-                return json.loads(resp.read().decode("utf-8"))
+                return _read_json_response(resp)
         except urllib.error.HTTPError as e:
             body_text = ""
             try:
@@ -96,7 +104,7 @@ class SignetClient:
                 logger.debug("Signet POST %s: failed to read error body: %s", path, read_err)
             logger.debug("Signet POST %s returned %d: %s", path, e.code, body_text)
             return None
-        except (urllib.error.URLError, OSError, TimeoutError) as e:
+        except (urllib.error.URLError, OSError, TimeoutError, ValueError) as e:
             logger.debug("Signet POST %s failed: %s", path, e)
             return None
 
@@ -111,8 +119,8 @@ class SignetClient:
         req = urllib.request.Request(url, headers=self._headers(), method="GET")
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
-                return json.loads(resp.read().decode("utf-8"))
-        except (urllib.error.HTTPError, urllib.error.URLError, OSError, TimeoutError) as e:
+                return _read_json_response(resp)
+        except (urllib.error.HTTPError, urllib.error.URLError, OSError, TimeoutError, ValueError) as e:
             logger.debug("Signet GET %s failed: %s", path, e)
             return None
 
@@ -129,8 +137,8 @@ class SignetClient:
         req = urllib.request.Request(url, data=data, headers=self._headers(), method="PATCH")
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
-                return json.loads(resp.read().decode("utf-8"))
-        except (urllib.error.HTTPError, urllib.error.URLError, OSError, TimeoutError) as e:
+                return _read_json_response(resp)
+        except (urllib.error.HTTPError, urllib.error.URLError, OSError, TimeoutError, ValueError) as e:
             logger.debug("Signet PATCH %s failed: %s", path, e)
             return None
 
@@ -145,8 +153,8 @@ class SignetClient:
         req = urllib.request.Request(url, headers=self._headers(), method="DELETE")
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
-                return json.loads(resp.read().decode("utf-8"))
-        except (urllib.error.HTTPError, urllib.error.URLError, OSError, TimeoutError) as e:
+                return _read_json_response(resp)
+        except (urllib.error.HTTPError, urllib.error.URLError, OSError, TimeoutError, ValueError) as e:
             logger.debug("Signet DELETE %s failed: %s", path, e)
             return None
 
@@ -379,7 +387,7 @@ class SignetClient:
         ):
             kept = [
                 row for row in result["results"]
-                if not isinstance(row, dict) or float(row.get("score", 0.0)) >= score_min
+                if not isinstance(row, dict) or float(row.get("score") or 0.0) >= score_min
             ]
             result = dict(result)
             result["results"] = kept

--- a/packages/connector-hermes-agent/hermes-plugin/client.py
+++ b/packages/connector-hermes-agent/hermes-plugin/client.py
@@ -115,6 +115,40 @@ class SignetClient:
             logger.debug("Signet GET %s failed: %s", path, e)
             return None
 
+    def _patch(
+        self,
+        path: str,
+        body: Dict[str, Any],
+        *,
+        timeout: float = _TIMEOUT_SECS,
+    ) -> Optional[Dict[str, Any]]:
+        """PATCH JSON to the daemon. Returns parsed response or None on failure."""
+        url = f"{self._base_url}{path}"
+        data = json.dumps(body).encode("utf-8")
+        req = urllib.request.Request(url, data=data, headers=self._headers(), method="PATCH")
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except (urllib.error.HTTPError, urllib.error.URLError, OSError, TimeoutError) as e:
+            logger.debug("Signet PATCH %s failed: %s", path, e)
+            return None
+
+    def _delete(
+        self,
+        path: str,
+        *,
+        timeout: float = _TIMEOUT_SECS,
+    ) -> Optional[Dict[str, Any]]:
+        """DELETE from the daemon. Returns parsed response or None on failure."""
+        url = f"{self._base_url}{path}"
+        req = urllib.request.Request(url, headers=self._headers(), method="DELETE")
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except (urllib.error.HTTPError, urllib.error.URLError, OSError, TimeoutError) as e:
+            logger.debug("Signet DELETE %s failed: %s", path, e)
+            return None
+
     # -- Health ---------------------------------------------------------------
 
     def is_available(self) -> bool:
@@ -257,15 +291,27 @@ class SignetClient:
         *,
         importance: float = 0.5,
         tags: Optional[List[str]] = None,
+        memory_type: str = "",
+        pinned: Optional[bool] = None,
+        project: str = "",
+        who: str = "hermes-agent",
     ) -> Optional[Dict[str, Any]]:
         """Store a memory via the daemon API."""
         body: Dict[str, Any] = {
             "content": content,
             "importance": importance,
-            "agentId": self._agent_id,
+            "who": who,
         }
+        if self._agent_id:
+            body["agentId"] = self._agent_id
+        if memory_type:
+            body["type"] = memory_type
         if tags:
             body["tags"] = tags
+        if pinned is not None:
+            body["pinned"] = pinned
+        if project:
+            body["project"] = project
         return self._post("/api/memory/remember", body)
 
     def recall(
@@ -273,17 +319,116 @@ class SignetClient:
         query: str,
         *,
         limit: int = 10,
-        min_score: float = 0.0,
+        project: str = "",
+        memory_type: str = "",
+        tags: str = "",
+        who: str = "",
+        pinned: Optional[bool] = None,
+        importance_min: Optional[float] = None,
+        since: str = "",
+        until: str = "",
+        keyword_query: str = "",
+        expand: bool = False,
+        score_min: Optional[float] = None,
+        agent_scoped: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """Search memories via hybrid recall."""
         body: Dict[str, Any] = {
             "query": query,
             "limit": limit,
-            "agentId": self._agent_id,
         }
-        if min_score > 0.0:
-            body["minScore"] = min_score
-        return self._post("/api/memory/recall", body)
+        if project:
+            body["project"] = project
+        if memory_type:
+            body["type"] = memory_type
+        if tags:
+            body["tags"] = tags
+        if who:
+            body["who"] = who
+        if pinned is not None:
+            body["pinned"] = pinned
+        if importance_min is not None:
+            body["importance_min"] = importance_min
+        if since:
+            body["since"] = since
+        if until:
+            body["until"] = until
+        if keyword_query:
+            body["keywordQuery"] = keyword_query
+        if expand:
+            body["expand"] = True
+        if agent_scoped and self._agent_id:
+            body["agentId"] = self._agent_id
+
+        result = self._post("/api/memory/recall", body)
+        if (
+            result
+            and score_min is not None
+            and isinstance(result.get("results"), list)
+        ):
+            kept = [
+                row for row in result["results"]
+                if not isinstance(row, dict) or float(row.get("score", 0.0)) >= score_min
+            ]
+            result = dict(result)
+            result["results"] = kept
+            meta = result.get("meta")
+            if isinstance(meta, dict):
+                result["meta"] = {**meta, "totalReturned": len(kept)}
+        return result
+
+    def get_memory(self, memory_id: str) -> Optional[Dict[str, Any]]:
+        """Retrieve a single memory by ID."""
+        return self._get(f"/api/memory/{urllib.parse.quote(memory_id)}")
+
+    def list_memories(
+        self,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+        memory_type: str = "",
+    ) -> Optional[Dict[str, Any]]:
+        """List memories with optional filters."""
+        params = f"?limit={limit}&offset={offset}"
+        if memory_type:
+            params += f"&type={urllib.parse.quote(memory_type)}"
+        return self._get(f"/api/memories{params}")
+
+    def modify_memory(
+        self,
+        memory_id: str,
+        *,
+        content: str = "",
+        memory_type: str = "",
+        importance: Optional[float] = None,
+        tags: str = "",
+        pinned: Optional[bool] = None,
+        reason: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Edit an existing memory by ID."""
+        body: Dict[str, Any] = {"reason": reason}
+        if content:
+            body["content"] = content
+        if memory_type:
+            body["type"] = memory_type
+        if importance is not None:
+            body["importance"] = importance
+        if tags:
+            body["tags"] = tags
+        if pinned is not None:
+            body["pinned"] = pinned
+        return self._patch(f"/api/memory/{urllib.parse.quote(memory_id)}", body)
+
+    def forget_memory(
+        self,
+        memory_id: str,
+        *,
+        reason: str,
+        force: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        """Soft-delete a memory by ID."""
+        params = urllib.parse.urlencode({"reason": reason, **({"force": "true"} if force else {})})
+        return self._delete(f"/api/memory/{urllib.parse.quote(memory_id)}?{params}")
 
     def search(
         self,

--- a/packages/connector-hermes-agent/hermes-plugin/client.py
+++ b/packages/connector-hermes-agent/hermes-plugin/client.py
@@ -296,6 +296,9 @@ class SignetClient:
         memory_type: str = "",
         pinned: Optional[bool] = None,
         project: str = "",
+        hints: Optional[List[str]] = None,
+        transcript: str = "",
+        structured: Optional[Dict[str, Any]] = None,
         who: str = "hermes-agent",
     ) -> Optional[Dict[str, Any]]:
         """Store a memory via the daemon API."""
@@ -314,7 +317,13 @@ class SignetClient:
             body["pinned"] = pinned
         if project:
             body["project"] = project
-        return self._post("/api/memory/remember", body)
+        if hints:
+            body["hints"] = hints
+        if transcript:
+            body["transcript"] = transcript
+        if structured:
+            body["structured"] = structured
+        return self._post("/api/memory/remember", body, timeout=_LONG_TIMEOUT_SECS)
 
     def recall(
         self,

--- a/packages/connector-hermes-agent/hermes-plugin/client.py
+++ b/packages/connector-hermes-agent/hermes-plugin/client.py
@@ -393,7 +393,7 @@ class SignetClient:
             result["results"] = kept
             meta = result.get("meta")
             if isinstance(meta, dict):
-                result["meta"] = {**meta, "totalReturned": len(kept)}
+                result["meta"] = {**meta, "totalReturned": len(kept), "noHits": len(kept) == 0}
         return result
 
     def get_memory(self, memory_id: str) -> Optional[Dict[str, Any]]:

--- a/packages/connector-hermes-agent/hermes-plugin/client.py
+++ b/packages/connector-hermes-agent/hermes-plugin/client.py
@@ -204,7 +204,7 @@ class SignetClient:
                 "agentId": self._agent_id,
                 "project": project,
             },
-            timeout=_LONG_TIMEOUT_SECS,
+            timeout=_RECALL_TIMEOUT_SECS,
         )
 
     def session_end(
@@ -443,10 +443,9 @@ class SignetClient:
         memory_id: str,
         *,
         reason: str,
-        force: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """Soft-delete a memory by ID."""
-        params = urllib.parse.urlencode({"reason": reason, **({"force": "true"} if force else {})})
+        params = urllib.parse.urlencode({"reason": reason})
         return self._delete(f"/api/memory/{urllib.parse.quote(memory_id)}?{params}")
 
     def search(

--- a/packages/connector-hermes-agent/index.test.ts
+++ b/packages/connector-hermes-agent/index.test.ts
@@ -9,6 +9,7 @@ const originalEnv = {
 	HERMES_REPO: process.env.HERMES_REPO,
 	HERMES_HOME: process.env.HERMES_HOME,
 	SIGNET_AGENT_ID: process.env.SIGNET_AGENT_ID,
+	SIGNET_AGENT_WORKSPACE: process.env.SIGNET_AGENT_WORKSPACE,
 	SIGNET_DAEMON_URL: process.env.SIGNET_DAEMON_URL,
 };
 
@@ -32,6 +33,8 @@ beforeEach(() => {
 	delete process.env.HERMES_HOME;
 	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.SIGNET_AGENT_ID;
+	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
+	delete process.env.SIGNET_AGENT_WORKSPACE;
 	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.SIGNET_DAEMON_URL;
 });
@@ -114,6 +117,23 @@ describe("HermesAgentConnector.install()", () => {
 		expect(existsSync(envPath)).toBe(true);
 		const envContent = await Bun.file(envPath).text();
 		expect(envContent).toContain("SIGNET_DAEMON_URL=http://127.0.0.1:9999");
+	});
+
+	it("derives SIGNET_AGENT_WORKSPACE for named agents", async () => {
+		const hermesRepo = join(tmpRoot, "hermes-agent");
+		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
+		mkdirSync(join(tmpRoot, "agents", "dot"), { recursive: true });
+		const hermesHome = join(tmpRoot, ".hermes");
+		process.env.HERMES_REPO = hermesRepo;
+		process.env.HERMES_HOME = hermesHome;
+		process.env.SIGNET_AGENT_ID = "dot";
+
+		const result = await new HermesAgentConnector().install(tmpRoot);
+
+		const envContent = await Bun.file(join(hermesHome, ".env")).text();
+		expect(result.configsPatched).toContain(join(hermesHome, ".env"));
+		expect(envContent).toContain("SIGNET_AGENT_ID=dot");
+		expect(envContent).toContain(`SIGNET_AGENT_WORKSPACE=${join(tmpRoot, "agents", "dot")}`);
 	});
 });
 

--- a/packages/connector-hermes-agent/index.test.ts
+++ b/packages/connector-hermes-agent/index.test.ts
@@ -246,6 +246,14 @@ describe("Hermes Agent bundled plugin", () => {
 		expect(client).not.toContain('"agentId": self._agent_id,\\n        }\\n        if min_score');
 	});
 
+	it("lets explicit recall requests opt into agent scoping", () => {
+		const plugin = readFileSync(join(import.meta.dir, "hermes-plugin", "__init__.py"), "utf-8");
+
+		expect(plugin).toContain('"agent_scoped"');
+		expect(plugin).toContain("scope recall to SIGNET_AGENT_ID");
+		expect(plugin).toContain('agent_scoped=bool(search_args.get("agent_scoped", False))');
+	});
+
 	it("uses longer timeouts for recall paths", () => {
 		const client = readFileSync(join(import.meta.dir, "hermes-plugin", "client.py"), "utf-8");
 
@@ -308,6 +316,34 @@ describe("HermesAgentConnector.uninstall()", () => {
 		const pluginDir = join(hermesRepo, "plugins", "memory", "signet");
 		expect(result.filesRemoved).toContain(pluginDir);
 		expect(connector.isInstalled()).toBe(false);
+	});
+
+	it("removes persisted Signet env vars including SIGNET_TOKEN", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(hermesHome, { recursive: true });
+		const envPath = join(hermesHome, ".env");
+		writeFileSync(
+			envPath,
+			[
+				"KEEP_ME=1",
+				"SIGNET_DAEMON_URL=http://localhost:3850",
+				"SIGNET_AGENT_ID=dot",
+				"SIGNET_AGENT_WORKSPACE=/tmp/dot",
+				"SIGNET_TOKEN=secret-token",
+				"",
+			].join("\n"),
+		);
+		process.env.HERMES_HOME = hermesHome;
+
+		const result = await new HermesAgentConnector().uninstall();
+
+		expect(result.configsPatched).toContain(envPath);
+		const envContent = readFileSync(envPath, "utf-8");
+		expect(envContent).toContain("KEEP_ME=1");
+		expect(envContent).not.toContain("SIGNET_DAEMON_URL");
+		expect(envContent).not.toContain("SIGNET_AGENT_ID");
+		expect(envContent).not.toContain("SIGNET_AGENT_WORKSPACE");
+		expect(envContent).not.toContain("SIGNET_TOKEN");
 	});
 });
 

--- a/packages/connector-hermes-agent/index.test.ts
+++ b/packages/connector-hermes-agent/index.test.ts
@@ -11,6 +11,10 @@ const originalEnv = {
 	SIGNET_AGENT_ID: process.env.SIGNET_AGENT_ID,
 	SIGNET_AGENT_WORKSPACE: process.env.SIGNET_AGENT_WORKSPACE,
 	SIGNET_DAEMON_URL: process.env.SIGNET_DAEMON_URL,
+	SIGNET_TOKEN: process.env.SIGNET_TOKEN,
+	SIGNET_AGENT_READ_POLICY: process.env.SIGNET_AGENT_READ_POLICY,
+	SIGNET_AGENT_MEMORY_POLICY: process.env.SIGNET_AGENT_MEMORY_POLICY,
+	SIGNET_AGENT_POLICY_GROUP: process.env.SIGNET_AGENT_POLICY_GROUP,
 	SIGNET_SKIP_AGENT_REGISTER: process.env.SIGNET_SKIP_AGENT_REGISTER,
 };
 
@@ -38,6 +42,14 @@ beforeEach(() => {
 	delete process.env.SIGNET_AGENT_WORKSPACE;
 	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.SIGNET_DAEMON_URL;
+	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
+	delete process.env.SIGNET_TOKEN;
+	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
+	delete process.env.SIGNET_AGENT_READ_POLICY;
+	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
+	delete process.env.SIGNET_AGENT_MEMORY_POLICY;
+	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
+	delete process.env.SIGNET_AGENT_POLICY_GROUP;
 	process.env.SIGNET_SKIP_AGENT_REGISTER = "1";
 });
 
@@ -46,7 +58,12 @@ afterEach(() => {
 	restoreEnv("HERMES_REPO");
 	restoreEnv("HERMES_HOME");
 	restoreEnv("SIGNET_AGENT_ID");
+	restoreEnv("SIGNET_AGENT_WORKSPACE");
 	restoreEnv("SIGNET_DAEMON_URL");
+	restoreEnv("SIGNET_TOKEN");
+	restoreEnv("SIGNET_AGENT_READ_POLICY");
+	restoreEnv("SIGNET_AGENT_MEMORY_POLICY");
+	restoreEnv("SIGNET_AGENT_POLICY_GROUP");
 	restoreEnv("SIGNET_SKIP_AGENT_REGISTER");
 	if (tmpRoot) {
 		rmSync(tmpRoot, { recursive: true, force: true });
@@ -138,6 +155,46 @@ describe("HermesAgentConnector.install()", () => {
 		expect(envContent).toContain("SIGNET_AGENT_ID=dot");
 		expect(envContent).toContain(`SIGNET_AGENT_WORKSPACE=${join(tmpRoot, "agents", "dot")}`);
 	});
+
+	it("uses SIGNET_TOKEN and configured read policy when registering named agents", async () => {
+		const originalFetch = globalThis.fetch;
+		const calls: Array<{ url: string; init?: RequestInit }> = [];
+		globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			calls.push({ url: String(url), init });
+			if (String(url).endsWith("/api/agents/dot")) {
+				return new Response(JSON.stringify({ error: "not found" }), { status: 404 });
+			}
+			return new Response(JSON.stringify({ id: "dot" }), { status: 201 });
+		}) as typeof fetch;
+
+		try {
+			const hermesRepo = join(tmpRoot, "hermes-agent");
+			mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
+			const hermesHome = join(tmpRoot, ".hermes");
+			process.env.HERMES_REPO = hermesRepo;
+			process.env.HERMES_HOME = hermesHome;
+			process.env.SIGNET_AGENT_ID = "dot";
+			process.env.SIGNET_TOKEN = " test-token \n";
+			process.env.SIGNET_AGENT_READ_POLICY = "isolated";
+			// biome-ignore lint/performance/noDelete: this test exercises registration
+			delete process.env.SIGNET_SKIP_AGENT_REGISTER;
+
+			const result = await new HermesAgentConnector().install(tmpRoot);
+
+			expect(result.success).toBe(true);
+			expect(calls).toHaveLength(2);
+			for (const call of calls) {
+				expect(new Headers(call.init?.headers).get("Authorization")).toBe("Bearer test-token");
+			}
+			expect(JSON.parse(String(calls[1]?.init?.body))).toMatchObject({
+				name: "dot",
+				read_policy: "isolated",
+				policy_group: null,
+			});
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
 });
 
 describe("Hermes Agent bundled plugin", () => {
@@ -164,7 +221,7 @@ describe("Hermes Agent bundled plugin", () => {
 		const client = readFileSync(join(import.meta.dir, "hermes-plugin", "client.py"), "utf-8");
 
 		expect(client).toContain("_RECALL_TIMEOUT_SECS = 30");
-		expect(client).toContain('timeout=_LONG_TIMEOUT_SECS,');
+		expect(client).toContain("timeout=_LONG_TIMEOUT_SECS,");
 		expect(client).toContain('self._post("/api/memory/recall", body, timeout=_RECALL_TIMEOUT_SECS)');
 	});
 
@@ -185,6 +242,8 @@ describe("Hermes Agent bundled plugin", () => {
 		expect(client).toContain('body["hints"] = hints');
 		expect(client).toContain('body["transcript"] = transcript');
 		expect(client).toContain('body["structured"] = structured');
+		expect(client).toContain("def _read_json_response");
+		expect(client).toContain('float(row.get("score") or 0.0)');
 	});
 });
 

--- a/packages/connector-hermes-agent/index.test.ts
+++ b/packages/connector-hermes-agent/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { HermesAgentConnector } from "./src/index.js";
@@ -11,6 +11,7 @@ const originalEnv = {
 	SIGNET_AGENT_ID: process.env.SIGNET_AGENT_ID,
 	SIGNET_AGENT_WORKSPACE: process.env.SIGNET_AGENT_WORKSPACE,
 	SIGNET_DAEMON_URL: process.env.SIGNET_DAEMON_URL,
+	SIGNET_SKIP_AGENT_REGISTER: process.env.SIGNET_SKIP_AGENT_REGISTER,
 };
 
 let tmpRoot = "";
@@ -37,6 +38,7 @@ beforeEach(() => {
 	delete process.env.SIGNET_AGENT_WORKSPACE;
 	// biome-ignore lint/performance/noDelete: ensure no stale value from outer env
 	delete process.env.SIGNET_DAEMON_URL;
+	process.env.SIGNET_SKIP_AGENT_REGISTER = "1";
 });
 
 afterEach(() => {
@@ -45,6 +47,7 @@ afterEach(() => {
 	restoreEnv("HERMES_HOME");
 	restoreEnv("SIGNET_AGENT_ID");
 	restoreEnv("SIGNET_DAEMON_URL");
+	restoreEnv("SIGNET_SKIP_AGENT_REGISTER");
 	if (tmpRoot) {
 		rmSync(tmpRoot, { recursive: true, force: true });
 	}
@@ -134,6 +137,27 @@ describe("HermesAgentConnector.install()", () => {
 		expect(result.configsPatched).toContain(join(hermesHome, ".env"));
 		expect(envContent).toContain("SIGNET_AGENT_ID=dot");
 		expect(envContent).toContain(`SIGNET_AGENT_WORKSPACE=${join(tmpRoot, "agents", "dot")}`);
+	});
+});
+
+describe("Hermes Agent bundled plugin", () => {
+	it("advertises canonical Signet memory tool names", () => {
+		const plugin = readFileSync(join(import.meta.dir, "hermes-plugin", "__init__.py"), "utf-8");
+
+		expect(plugin).toContain('"name": "memory_search"');
+		expect(plugin).toContain('"name": "memory_store"');
+		expect(plugin).toContain('"name": "memory_get"');
+		expect(plugin).toContain('"name": "memory_list"');
+		expect(plugin).not.toContain('"name": "signet_search"');
+		expect(plugin).toContain('if tool_name in ("memory_search", "recall", "signet_search")');
+	});
+
+	it("does not force agentId into explicit recall requests", () => {
+		const client = readFileSync(join(import.meta.dir, "hermes-plugin", "client.py"), "utf-8");
+
+		expect(client).toContain("if agent_scoped and self._agent_id:");
+		expect(client).toContain('body["agentId"] = self._agent_id');
+		expect(client).not.toContain('"agentId": self._agent_id,\\n        }\\n        if min_score');
 	});
 });
 

--- a/packages/connector-hermes-agent/index.test.ts
+++ b/packages/connector-hermes-agent/index.test.ts
@@ -195,6 +195,35 @@ describe("HermesAgentConnector.install()", () => {
 			globalThis.fetch = originalFetch;
 		}
 	});
+
+	it("does not try to create a named agent when the existence check fails with non-404", async () => {
+		const originalFetch = globalThis.fetch;
+		const calls: Array<{ url: string; init?: RequestInit }> = [];
+		globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			calls.push({ url: String(url), init });
+			return new Response("unauthorized", { status: 401 });
+		}) as typeof fetch;
+
+		try {
+			const hermesRepo = join(tmpRoot, "hermes-agent");
+			mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
+			const hermesHome = join(tmpRoot, ".hermes");
+			process.env.HERMES_REPO = hermesRepo;
+			process.env.HERMES_HOME = hermesHome;
+			process.env.SIGNET_AGENT_ID = "dot";
+			// biome-ignore lint/performance/noDelete: this test exercises registration
+			delete process.env.SIGNET_SKIP_AGENT_REGISTER;
+
+			const result = await new HermesAgentConnector().install(tmpRoot);
+
+			expect(result.success).toBe(true);
+			expect(calls).toHaveLength(1);
+			expect(calls[0]?.url).toContain("/api/agents/dot");
+			expect(result.warnings.some((w) => w.includes("HTTP 401"))).toBe(true);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
 });
 
 describe("Hermes Agent bundled plugin", () => {
@@ -243,7 +272,11 @@ describe("Hermes Agent bundled plugin", () => {
 		expect(client).toContain('body["transcript"] = transcript');
 		expect(client).toContain('body["structured"] = structured');
 		expect(client).toContain("def _read_json_response");
+		expect(client).toContain("if not body:");
+		expect(client).toContain("TimeoutError, ValueError");
 		expect(client).toContain('float(row.get("score") or 0.0)');
+		expect(client).toContain('"noHits": len(kept) == 0');
+		expect(plugin).toContain('agent_id not in ("default", "hermes-agent")');
 	});
 });
 

--- a/packages/connector-hermes-agent/index.test.ts
+++ b/packages/connector-hermes-agent/index.test.ts
@@ -167,6 +167,25 @@ describe("Hermes Agent bundled plugin", () => {
 		expect(client).toContain('timeout=_LONG_TIMEOUT_SECS,');
 		expect(client).toContain('self._post("/api/memory/recall", body, timeout=_RECALL_TIMEOUT_SECS)');
 	});
+
+	it("exposes the complete Signet memory_store schema", () => {
+		const plugin = readFileSync(join(import.meta.dir, "hermes-plugin", "__init__.py"), "utf-8");
+		const client = readFileSync(join(import.meta.dir, "hermes-plugin", "client.py"), "utf-8");
+
+		expect(plugin).toContain('"hints"');
+		expect(plugin).toContain('"transcript"');
+		expect(plugin).toContain('"structured"');
+		expect(plugin).toContain('"entityName"');
+		expect(plugin).toContain('"attributes"');
+		expect(plugin).toContain("Prospective recall hints");
+		expect(plugin).toContain('hints=_string_list(store_args.get("hints"))');
+		expect(plugin).toContain('transcript=str(store_args.get("transcript", "") or "")');
+		expect(plugin).toContain("structured=structured");
+		expect(client).toContain("hints: Optional[List[str]] = None");
+		expect(client).toContain('body["hints"] = hints');
+		expect(client).toContain('body["transcript"] = transcript');
+		expect(client).toContain('body["structured"] = structured');
+	});
 });
 
 describe("HermesAgentConnector.uninstall()", () => {

--- a/packages/connector-hermes-agent/index.test.ts
+++ b/packages/connector-hermes-agent/index.test.ts
@@ -159,6 +159,14 @@ describe("Hermes Agent bundled plugin", () => {
 		expect(client).toContain('body["agentId"] = self._agent_id');
 		expect(client).not.toContain('"agentId": self._agent_id,\\n        }\\n        if min_score');
 	});
+
+	it("uses longer timeouts for recall paths", () => {
+		const client = readFileSync(join(import.meta.dir, "hermes-plugin", "client.py"), "utf-8");
+
+		expect(client).toContain("_RECALL_TIMEOUT_SECS = 30");
+		expect(client).toContain('timeout=_LONG_TIMEOUT_SECS,');
+		expect(client).toContain('self._post("/api/memory/recall", body, timeout=_RECALL_TIMEOUT_SECS)');
+	});
 });
 
 describe("HermesAgentConnector.uninstall()", () => {

--- a/packages/connector-hermes-agent/index.test.ts
+++ b/packages/connector-hermes-agent/index.test.ts
@@ -263,6 +263,14 @@ describe("Hermes Agent bundled plugin", () => {
 		expect(client).toContain('self._post("/api/memory/recall", body, timeout=_RECALL_TIMEOUT_SECS)');
 	});
 
+	it("treats malformed recall scores as zero during score_min filtering", () => {
+		const client = readFileSync(join(import.meta.dir, "hermes-plugin", "client.py"), "utf-8");
+
+		expect(client).toContain("def _safe_score(value: Any) -> float:");
+		expect(client).toContain("except (TypeError, ValueError):");
+		expect(client).toContain('if not isinstance(row, dict) or _safe_score(row.get("score")) >= score_min');
+	});
+
 	it("does not expose hard-delete force to Hermes memory_forget", () => {
 		const plugin = readFileSync(join(import.meta.dir, "hermes-plugin", "__init__.py"), "utf-8");
 		const client = readFileSync(join(import.meta.dir, "hermes-plugin", "client.py"), "utf-8");
@@ -295,7 +303,7 @@ describe("Hermes Agent bundled plugin", () => {
 		expect(client).toContain("def _read_json_response");
 		expect(client).toContain("if not body:");
 		expect(client).toContain("TimeoutError, ValueError");
-		expect(client).toContain('float(row.get("score") or 0.0)');
+		expect(client).toContain('_safe_score(row.get("score"))');
 		expect(client).toContain('"noHits": len(kept) == 0');
 		expect(plugin).toContain('agent_id not in ("default", "hermes-agent")');
 	});

--- a/packages/connector-hermes-agent/index.test.ts
+++ b/packages/connector-hermes-agent/index.test.ts
@@ -251,7 +251,20 @@ describe("Hermes Agent bundled plugin", () => {
 
 		expect(client).toContain("_RECALL_TIMEOUT_SECS = 30");
 		expect(client).toContain("timeout=_LONG_TIMEOUT_SECS,");
+		expect(client).toMatch(/def user_prompt_submit[\s\S]+timeout=_RECALL_TIMEOUT_SECS,/);
 		expect(client).toContain('self._post("/api/memory/recall", body, timeout=_RECALL_TIMEOUT_SECS)');
+	});
+
+	it("does not expose hard-delete force to Hermes memory_forget", () => {
+		const plugin = readFileSync(join(import.meta.dir, "hermes-plugin", "__init__.py"), "utf-8");
+		const client = readFileSync(join(import.meta.dir, "hermes-plugin", "client.py"), "utf-8");
+
+		expect(plugin).toContain('"description": "Soft-delete a memory by ID."');
+		expect(plugin).not.toContain('"force"');
+		expect(plugin).not.toContain("force=bool");
+		expect(client).toContain("def forget_memory(");
+		expect(client).not.toContain("force: bool");
+		expect(client).not.toContain('"force": "true"');
 	});
 
 	it("exposes the complete Signet memory_store schema", () => {

--- a/packages/connector-hermes-agent/src/index.ts
+++ b/packages/connector-hermes-agent/src/index.ts
@@ -133,6 +133,48 @@ function isProviderConfigured(hermesHome: string): boolean {
 	);
 }
 
+async function ensureNamedAgentRegistered(
+	daemonUrl: string,
+	agentId: string,
+	warnings: string[],
+): Promise<void> {
+	if (!agentId || agentId === "default" || agentId === "hermes-agent") return;
+	if (process.env.SIGNET_SKIP_AGENT_REGISTER === "1") return;
+
+	const baseUrl = daemonUrl.replace(/\/+$/, "");
+	try {
+		const getResp = await fetch(`${baseUrl}/api/agents/${encodeURIComponent(agentId)}`, {
+			signal: AbortSignal.timeout(1_000),
+		});
+		if (getResp.ok) return;
+	} catch {
+		// Daemon may be offline; the POST below will produce the user-facing warning.
+	}
+
+	try {
+		const resp = await fetch(`${baseUrl}/api/agents`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				name: agentId,
+				read_policy: "shared",
+				policy_group: null,
+			}),
+			signal: AbortSignal.timeout(1_000),
+		});
+		if (!resp.ok) {
+			const body = await resp.text();
+			warnings.push(`Could not register Signet agent '${agentId}' with shared memory policy: ${body.slice(0, 200)}`);
+		}
+	} catch (e) {
+		const msg = e instanceof Error ? e.message : String(e);
+		warnings.push(
+			`Could not register Signet agent '${agentId}' because the daemon was unreachable. ` +
+				`Run: signet agent create ${agentId} --memory shared (${msg})`,
+		);
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Connector
 // ---------------------------------------------------------------------------
@@ -186,6 +228,11 @@ export class HermesAgentConnector extends BaseConnector {
 
 		// 2. Write env config for the Signet daemon connection
 		const envPath = join(hermesHome, ".env");
+		let configuredSignetAgentId = "hermes-agent";
+		const configuredDaemonUrl = (process.env.SIGNET_DAEMON_URL?.trim() || "http://localhost:3850").replace(
+			/[\r\n]+/g,
+			"",
+		);
 		try {
 			let envContent = "";
 			if (existsSync(envPath)) {
@@ -200,6 +247,7 @@ export class HermesAgentConnector extends BaseConnector {
 			// Always write SIGNET_AGENT_ID — never allow the plugin to fall back to the
 			// shared "default" scope (AGENTS.md: never hardcode "default" for scoped paths).
 			const signetAgentId = (process.env.SIGNET_AGENT_ID?.trim() || "hermes-agent").replace(/[\r\n]+/g, "");
+			configuredSignetAgentId = signetAgentId;
 			signetVars.SIGNET_AGENT_ID = signetAgentId;
 
 			const explicitAgentWorkspace = process.env.SIGNET_AGENT_WORKSPACE?.trim();
@@ -246,6 +294,8 @@ export class HermesAgentConnector extends BaseConnector {
 			const msg = e instanceof Error ? e.message : String(e);
 			warnings.push(`Failed to update .env: ${msg}`);
 		}
+
+		await ensureNamedAgentRegistered(configuredDaemonUrl, configuredSignetAgentId, warnings);
 
 		// 3. Provide guidance on completing setup
 		if (!isProviderConfigured(hermesHome)) {

--- a/packages/connector-hermes-agent/src/index.ts
+++ b/packages/connector-hermes-agent/src/index.ts
@@ -374,7 +374,7 @@ export class HermesAgentConnector extends BaseConnector {
 			try {
 				let envContent = readFileSync(envPath, "utf-8");
 				let changed = false;
-				for (const key of ["SIGNET_DAEMON_URL", "SIGNET_AGENT_ID", "SIGNET_AGENT_WORKSPACE"]) {
+				for (const key of ["SIGNET_DAEMON_URL", "SIGNET_AGENT_ID", "SIGNET_AGENT_WORKSPACE", "SIGNET_TOKEN"]) {
 					const pattern = new RegExp(`^${key}=.*\n?`, "gm");
 					if (pattern.test(envContent)) {
 						envContent = envContent.replace(pattern, "");

--- a/packages/connector-hermes-agent/src/index.ts
+++ b/packages/connector-hermes-agent/src/index.ts
@@ -199,7 +199,18 @@ export class HermesAgentConnector extends BaseConnector {
 			}
 			// Always write SIGNET_AGENT_ID — never allow the plugin to fall back to the
 			// shared "default" scope (AGENTS.md: never hardcode "default" for scoped paths).
-			signetVars.SIGNET_AGENT_ID = (process.env.SIGNET_AGENT_ID?.trim() || "hermes-agent").replace(/[\r\n]+/g, "");
+			const signetAgentId = (process.env.SIGNET_AGENT_ID?.trim() || "hermes-agent").replace(/[\r\n]+/g, "");
+			signetVars.SIGNET_AGENT_ID = signetAgentId;
+
+			const explicitAgentWorkspace = process.env.SIGNET_AGENT_WORKSPACE?.trim();
+			if (explicitAgentWorkspace) {
+				signetVars.SIGNET_AGENT_WORKSPACE = expandHome(explicitAgentWorkspace).replace(/[\r\n]+/g, "");
+			} else if (signetAgentId && signetAgentId !== "hermes-agent" && signetAgentId !== "default") {
+				const agentWorkspace = join(expandedBasePath, "agents", signetAgentId);
+				if (existsSync(agentWorkspace)) {
+					signetVars.SIGNET_AGENT_WORKSPACE = agentWorkspace;
+				}
+			}
 
 			// Persist auth token so Hermes can reach a non-localhost daemon.
 			// Warn if absent and SIGNET_DAEMON_URL points to a remote host.
@@ -276,7 +287,7 @@ export class HermesAgentConnector extends BaseConnector {
 			try {
 				let envContent = readFileSync(envPath, "utf-8");
 				let changed = false;
-				for (const key of ["SIGNET_DAEMON_URL", "SIGNET_AGENT_ID"]) {
+				for (const key of ["SIGNET_DAEMON_URL", "SIGNET_AGENT_ID", "SIGNET_AGENT_WORKSPACE"]) {
 					const pattern = new RegExp(`^${key}=.*\n?`, "gm");
 					if (pattern.test(envContent)) {
 						envContent = envContent.replace(pattern, "");

--- a/packages/connector-hermes-agent/src/index.ts
+++ b/packages/connector-hermes-agent/src/index.ts
@@ -133,17 +133,33 @@ function isProviderConfigured(hermesHome: string): boolean {
 	);
 }
 
-async function ensureNamedAgentRegistered(
-	daemonUrl: string,
-	agentId: string,
-	warnings: string[],
-): Promise<void> {
+function sanitizedEnv(name: string): string {
+	return (process.env[name]?.trim() || "").replace(/[\r\n]+/g, "");
+}
+
+type AgentReadPolicy = "isolated" | "shared" | "group";
+
+function configuredAgentReadPolicy(warnings: string[]): AgentReadPolicy {
+	const raw = sanitizedEnv("SIGNET_AGENT_READ_POLICY") || sanitizedEnv("SIGNET_AGENT_MEMORY_POLICY");
+	if (!raw) return "shared";
+	if (raw === "isolated" || raw === "shared" || raw === "group") return raw;
+	warnings.push(`Ignoring unsupported SIGNET_AGENT_READ_POLICY '${raw}'. Expected one of: isolated, shared, group.`);
+	return "shared";
+}
+
+async function ensureNamedAgentRegistered(daemonUrl: string, agentId: string, warnings: string[]): Promise<void> {
 	if (!agentId || agentId === "default" || agentId === "hermes-agent") return;
 	if (process.env.SIGNET_SKIP_AGENT_REGISTER === "1") return;
 
 	const baseUrl = daemonUrl.replace(/\/+$/, "");
+	const token = sanitizedEnv("SIGNET_TOKEN");
+	const headers: Record<string, string> = {};
+	if (token) {
+		headers.Authorization = `Bearer ${token}`;
+	}
 	try {
 		const getResp = await fetch(`${baseUrl}/api/agents/${encodeURIComponent(agentId)}`, {
+			headers,
 			signal: AbortSignal.timeout(1_000),
 		});
 		if (getResp.ok) return;
@@ -151,26 +167,40 @@ async function ensureNamedAgentRegistered(
 		// Daemon may be offline; the POST below will produce the user-facing warning.
 	}
 
+	const readPolicy = configuredAgentReadPolicy(warnings);
+	const policyGroup = readPolicy === "group" ? sanitizedEnv("SIGNET_AGENT_POLICY_GROUP") || null : null;
+	if (readPolicy === "group" && !policyGroup) {
+		warnings.push(
+			`SIGNET_AGENT_READ_POLICY=group requires SIGNET_AGENT_POLICY_GROUP. Registering '${agentId}' with isolated memory instead.`,
+		);
+	}
+	const effectiveReadPolicy: AgentReadPolicy = readPolicy === "group" && !policyGroup ? "isolated" : readPolicy;
+	const policyHint =
+		effectiveReadPolicy === "shared"
+			? `Run: signet agent create ${agentId} --memory shared, or use --memory isolated for private memory.`
+			: `Run: signet agent create ${agentId} --memory ${effectiveReadPolicy}.`;
+
 	try {
 		const resp = await fetch(`${baseUrl}/api/agents`, {
 			method: "POST",
-			headers: { "Content-Type": "application/json" },
+			headers: { "Content-Type": "application/json", ...headers },
 			body: JSON.stringify({
 				name: agentId,
-				read_policy: "shared",
-				policy_group: null,
+				read_policy: effectiveReadPolicy,
+				policy_group: policyGroup,
 			}),
 			signal: AbortSignal.timeout(1_000),
 		});
 		if (!resp.ok) {
 			const body = await resp.text();
-			warnings.push(`Could not register Signet agent '${agentId}' with shared memory policy: ${body.slice(0, 200)}`);
+			warnings.push(
+				`Could not register Signet agent '${agentId}' with ${effectiveReadPolicy} memory policy: ${body.slice(0, 200)}. ${policyHint}`,
+			);
 		}
 	} catch (e) {
 		const msg = e instanceof Error ? e.message : String(e);
 		warnings.push(
-			`Could not register Signet agent '${agentId}' because the daemon was unreachable. ` +
-				`Run: signet agent create ${agentId} --memory shared (${msg})`,
+			`Could not register Signet agent '${agentId}' because the daemon was unreachable. ` + `${policyHint} (${msg})`,
 		);
 	}
 }
@@ -242,11 +272,11 @@ export class HermesAgentConnector extends BaseConnector {
 			const signetVars: Record<string, string> = {};
 
 			if (process.env.SIGNET_DAEMON_URL) {
-				signetVars.SIGNET_DAEMON_URL = process.env.SIGNET_DAEMON_URL.replace(/[\r\n]+/g, "");
+				signetVars.SIGNET_DAEMON_URL = sanitizedEnv("SIGNET_DAEMON_URL");
 			}
 			// Always write SIGNET_AGENT_ID — never allow the plugin to fall back to the
 			// shared "default" scope (AGENTS.md: never hardcode "default" for scoped paths).
-			const signetAgentId = (process.env.SIGNET_AGENT_ID?.trim() || "hermes-agent").replace(/[\r\n]+/g, "");
+			const signetAgentId = sanitizedEnv("SIGNET_AGENT_ID") || "hermes-agent";
 			configuredSignetAgentId = signetAgentId;
 			signetVars.SIGNET_AGENT_ID = signetAgentId;
 
@@ -263,7 +293,7 @@ export class HermesAgentConnector extends BaseConnector {
 			// Persist auth token so Hermes can reach a non-localhost daemon.
 			// Warn if absent and SIGNET_DAEMON_URL points to a remote host.
 			if (process.env.SIGNET_TOKEN) {
-				signetVars.SIGNET_TOKEN = process.env.SIGNET_TOKEN.replace(/[\r\n]+/g, "");
+				signetVars.SIGNET_TOKEN = sanitizedEnv("SIGNET_TOKEN");
 			} else if (
 				process.env.SIGNET_DAEMON_URL &&
 				!process.env.SIGNET_DAEMON_URL.includes("localhost") &&

--- a/packages/connector-hermes-agent/src/index.ts
+++ b/packages/connector-hermes-agent/src/index.ts
@@ -163,6 +163,13 @@ async function ensureNamedAgentRegistered(daemonUrl: string, agentId: string, wa
 			signal: AbortSignal.timeout(1_000),
 		});
 		if (getResp.ok) return;
+		if (getResp.status !== 404) {
+			const body = await getResp.text();
+			warnings.push(
+				`Could not check Signet agent '${agentId}' before registration: HTTP ${getResp.status} ${body.slice(0, 200)}`,
+			);
+			return;
+		}
 	} catch {
 		// Daemon may be offline; the POST below will produce the user-facing warning.
 	}

--- a/packages/core/src/__tests__/identity.test.ts
+++ b/packages/core/src/__tests__/identity.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildAgentMemoryConfig, getAgentIdentityFiles, normalizeAgentRosterEntry } from "../agents";
+import { buildAgentMemoryConfig, getAgentIdentityFiles, normalizeAgentRosterEntry, scaffoldAgent } from "../agents";
 import {
 	STATIC_IDENTITY_SESSION_START_TIMEOUT_STATUS,
 	detectExistingSetup,
@@ -139,6 +139,16 @@ describe("agent roster helpers", () => {
 			"IDENTITY.md": join(TMP, "agents", "dot", "IDENTITY.md"),
 			"USER.md": join(TMP, "USER.md"),
 		});
+	});
+
+	test("scaffolds only SOUL.md and IDENTITY.md for named agents", () => {
+		scaffoldAgent("dot", TMP);
+		const agentDir = join(TMP, "agents", "dot");
+
+		expect(existsSync(join(agentDir, "SOUL.md"))).toBe(true);
+		expect(existsSync(join(agentDir, "IDENTITY.md"))).toBe(true);
+		expect(existsSync(join(agentDir, "AGENTS.md"))).toBe(false);
+		expect(existsSync(join(agentDir, "MEMORY.md"))).toBe(false);
 	});
 
 	test("normalizes canonical nested memory policies", () => {

--- a/packages/core/src/__tests__/identity.test.ts
+++ b/packages/core/src/__tests__/identity.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildAgentMemoryConfig, normalizeAgentRosterEntry } from "../agents";
+import { buildAgentMemoryConfig, getAgentIdentityFiles, normalizeAgentRosterEntry } from "../agents";
 import {
 	STATIC_IDENTITY_SESSION_START_TIMEOUT_STATUS,
 	readStaticIdentity,
@@ -105,6 +105,20 @@ describe("parseSimpleYaml", () => {
 });
 
 describe("agent roster helpers", () => {
+	test("resolves agent-local identity files before root fallbacks", () => {
+		mkdirSync(join(TMP, "agents", "dot"), { recursive: true });
+		writeFileSync(join(TMP, "AGENTS.md"), "root agents");
+		writeFileSync(join(TMP, "USER.md"), "root user");
+		writeFileSync(join(TMP, "agents", "dot", "AGENTS.md"), "dot agents");
+		writeFileSync(join(TMP, "agents", "dot", "IDENTITY.md"), "dot identity");
+
+		expect(getAgentIdentityFiles("dot", TMP)).toMatchObject({
+			"AGENTS.md": join(TMP, "agents", "dot", "AGENTS.md"),
+			"IDENTITY.md": join(TMP, "agents", "dot", "IDENTITY.md"),
+			"USER.md": join(TMP, "USER.md"),
+		});
+	});
+
 	test("normalizes canonical nested memory policies", () => {
 		expect(
 			normalizeAgentRosterEntry({

--- a/packages/core/src/__tests__/identity.test.ts
+++ b/packages/core/src/__tests__/identity.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { buildAgentMemoryConfig, getAgentIdentityFiles, normalizeAgentRosterEntry } from "../agents";
 import {
 	STATIC_IDENTITY_SESSION_START_TIMEOUT_STATUS,
+	detectExistingSetup,
 	readStaticIdentity,
 	resolvePromptSubmitTimeoutMs,
 	resolveSessionStartTimeoutMs,
@@ -12,9 +13,18 @@ import {
 import { parseSimpleYaml } from "../yaml";
 
 const TMP = join(tmpdir(), `signet-identity-test-${Date.now()}`);
+const ORIGINAL_HERMES_REPO = process.env.HERMES_REPO;
 
 beforeEach(() => mkdirSync(TMP, { recursive: true }));
-afterEach(() => rmSync(TMP, { recursive: true, force: true }));
+afterEach(() => {
+	if (ORIGINAL_HERMES_REPO === undefined) {
+		// biome-ignore lint/performance/noDelete: assigning undefined stores the string "undefined"
+		delete process.env.HERMES_REPO;
+	} else {
+		process.env.HERMES_REPO = ORIGINAL_HERMES_REPO;
+	}
+	rmSync(TMP, { recursive: true, force: true });
+});
 
 describe("readStaticIdentity", () => {
 	test("returns null when dir does not exist", () => {
@@ -101,6 +111,18 @@ describe("readStaticIdentity", () => {
 describe("parseSimpleYaml", () => {
 	test("degrades malformed YAML to an empty object", () => {
 		expect(parseSimpleYaml("agent:\n  name: [unterminated")).toEqual({});
+	});
+});
+
+describe("detectExistingSetup", () => {
+	test("detects Hermes Agent before the Signet memory plugin is installed", () => {
+		const hermesRepo = join(TMP, "hermes-agent");
+		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
+		process.env.HERMES_REPO = hermesRepo;
+
+		const detection = detectExistingSetup(TMP);
+
+		expect(detection.harnesses.hermesAgent).toBe(true);
 	});
 });
 

--- a/packages/core/src/agents.ts
+++ b/packages/core/src/agents.ts
@@ -17,11 +17,17 @@ export interface NormalizedAgentRosterEntry {
 	readonly policyGroup: string | null;
 }
 
-/** Identity files that inherit from agent subdir (fall back to root). */
-const AGENT_SPECIFIC = new Set(["SOUL.md", "IDENTITY.md"]);
-
-/** All recognized shared identity files. */
-const SHARED_FILES = ["AGENTS.md", "USER.md", "TOOLS.md", "HEARTBEAT.md", "MEMORY.md", "BOOTSTRAP.md"];
+/** Standard identity files that may be overridden by a named agent. */
+const IDENTITY_FILES = [
+	"AGENTS.md",
+	"SOUL.md",
+	"IDENTITY.md",
+	"USER.md",
+	"TOOLS.md",
+	"HEARTBEAT.md",
+	"MEMORY.md",
+	"BOOTSTRAP.md",
+];
 
 /**
  * Scans {agentsDir}/agents/* subdirectories and returns a minimal
@@ -56,24 +62,18 @@ export function scaffoldAgent(name: string, agentsDir: string): void {
  * exists on disk for the given agent.
  *
  * Inheritance rules:
- * - `SOUL.md` and `IDENTITY.md`: agent subdir first, fall back to root.
- * - All other files (`AGENTS.md`, `USER.md`, `TOOLS.md`, `HEARTBEAT.md`,
- *   `MEMORY.md`, `BOOTSTRAP.md`): always use root (shared by all agents).
+ * - Check `~/.agents/agents/{name}/{file}` first.
+ * - Fall back to root-level `~/.agents/{file}` when the agent has no override.
  */
 export function getAgentIdentityFiles(name: string, agentsDir: string): Record<string, string> {
 	const result: Record<string, string> = {};
 	const agentDir = join(agentsDir, "agents", name);
 
-	for (const file of AGENT_SPECIFIC) {
+	for (const file of IDENTITY_FILES) {
 		const specific = join(agentDir, file);
 		const fallback = join(agentsDir, file);
 		if (existsSync(specific)) result[file] = specific;
 		else if (existsSync(fallback)) result[file] = fallback;
-	}
-
-	for (const file of SHARED_FILES) {
-		const path = join(agentsDir, file);
-		if (existsSync(path)) result[file] = path;
 	}
 
 	return result;

--- a/packages/core/src/identity.ts
+++ b/packages/core/src/identity.ts
@@ -371,6 +371,40 @@ export function hermesAgentCandidateDirs(): readonly string[] {
 }
 
 /**
+ * Resolve the Hermes Agent repo directory.
+ *
+ * This detects a Hermes install before the Signet plugin has been copied in.
+ * It checks for the repo's `plugins/memory` tree rather than the Signet plugin
+ * file, so setup can offer and install the Hermes connector on first run.
+ */
+export function resolveHermesRepoPath(): string | null {
+	const hermesRepo = process.env.HERMES_REPO?.trim();
+	if (hermesRepo && existsSync(join(hermesRepo, "plugins", "memory"))) {
+		return hermesRepo;
+	}
+
+	for (const base of hermesAgentCandidateDirs()) {
+		if (existsSync(join(base, "plugins", "memory"))) return base;
+	}
+
+	try {
+		const hermesPath = execFileSync("which", ["hermes"], {
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "ignore"],
+			timeout: 3000,
+		}).trim();
+		if (hermesPath) {
+			const repoDir = dirname(realpathSync(hermesPath));
+			if (existsSync(join(repoDir, "plugins", "memory"))) return repoDir;
+		}
+	} catch {
+		// hermes not in PATH
+	}
+
+	return null;
+}
+
+/**
  * Resolve the path to the Signet plugin file inside the Hermes Agent repo.
  *
  * Checks (in order): `HERMES_REPO` env var, four common install paths, then
@@ -385,30 +419,10 @@ export function hermesAgentCandidateDirs(): readonly string[] {
 export function resolveHermesRepoPluginPath(): string | null {
 	const pluginFile = join("plugins", "memory", "signet", "__init__.py");
 
-	const hermesRepo = process.env.HERMES_REPO?.trim();
-	if (hermesRepo) {
+	const hermesRepo = resolveHermesRepoPath();
+	if (hermesRepo !== null) {
 		const candidate = join(hermesRepo, pluginFile);
 		if (existsSync(candidate)) return candidate;
-	}
-
-	for (const base of hermesAgentCandidateDirs()) {
-		const candidate = join(base, pluginFile);
-		if (existsSync(candidate)) return candidate;
-	}
-
-	// Last resort: resolve hermes CLI → repo root via which(1)
-	try {
-		const hermesPath = execFileSync("which", ["hermes"], {
-			encoding: "utf-8",
-			stdio: ["ignore", "pipe", "ignore"],
-			timeout: 3000,
-		}).trim();
-		if (hermesPath) {
-			const candidate = join(dirname(realpathSync(hermesPath)), pluginFile);
-			if (existsSync(candidate)) return candidate;
-		}
-	} catch {
-		// hermes not in PATH
 	}
 
 	return null;
@@ -465,7 +479,7 @@ export function detectExistingSetup(basePath: string): SetupDetection {
 			ohMyPi: isSignetManagedOhMyPiInstall() || existsSync(resolveOhMyPiAgentDir()),
 			pi: isSignetManagedPiInstall() || existsSync(resolvePiAgentDir()),
 			forge: isForgeInstalled(basePath, home),
-			hermesAgent: resolveHermesRepoPluginPath() !== null,
+			hermesAgent: resolveHermesRepoPath() !== null,
 		},
 	};
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -199,6 +199,7 @@ export {
 	STATIC_IDENTITY_SESSION_START_TIMEOUT_STATUS,
 	resolveSignetForgeManagedPath,
 	resolveAgentBasePath,
+	resolveHermesRepoPath,
 	resolveHermesRepoPluginPath,
 	hermesAgentCandidateDirs,
 } from "./identity";

--- a/packages/daemon/src/hooks.test.ts
+++ b/packages/daemon/src/hooks.test.ts
@@ -1,11 +1,12 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import {
 	applyTokenBudget,
 	buildSignetSystemPrompt,
+	handleSessionStart,
 	normalizeCodexTranscript,
 	normalizeJsonConversationTranscript,
 	normalizeSessionTranscript,
@@ -31,6 +32,56 @@ describe("buildSignetSystemPrompt", () => {
 		expect(prompt).toContain("run 1-3 targeted recalls with mcp__signet__memory_search");
 		expect(prompt).toContain("do not treat a missing automatic memory match as proof no prior context exists");
 		expect(prompt).toContain("before acting, know what context you found");
+	});
+});
+
+describe("handleSessionStart multi-agent identity", () => {
+	let agentsDir = "";
+	let previousSignetPath: string | undefined;
+
+	beforeAll(() => {
+		previousSignetPath = process.env.SIGNET_PATH;
+		agentsDir = mkdtempSync(join(tmpdir(), "signet-hooks-agent-identity-"));
+	});
+
+	beforeEach(() => {
+		closeDbAccessor();
+		rmSync(agentsDir, { recursive: true, force: true });
+		mkdirSync(join(agentsDir, "agents", "dot"), { recursive: true });
+		process.env.SIGNET_PATH = agentsDir;
+		initDbAccessor(join(agentsDir, "memory", "memories.db"), { agentsDir });
+		writeFileSync(join(agentsDir, "AGENTS.md"), "You are Rose.");
+		writeFileSync(join(agentsDir, "IDENTITY.md"), "name: Rose\nrole: Solvr Assistant\n");
+		writeFileSync(join(agentsDir, "agents", "dot", "AGENTS.md"), "You are Dot.");
+		writeFileSync(join(agentsDir, "agents", "dot", "IDENTITY.md"), 'You are Dorothy "Dot" Ashby.\n');
+	});
+
+	afterEach(() => {
+		closeDbAccessor();
+	});
+
+	afterAll(() => {
+		rmSync(agentsDir, { recursive: true, force: true });
+		if (previousSignetPath === undefined) {
+			Reflect.deleteProperty(process.env, "SIGNET_PATH");
+			return;
+		}
+		process.env.SIGNET_PATH = previousSignetPath;
+	});
+
+	it("loads agent-scoped identity files for session-start", async () => {
+		const result = await handleSessionStart({
+			harness: "hermes-agent",
+			sessionKey: `dot-test-${Date.now()}`,
+			agentId: "dot",
+			project: join(agentsDir, "agents", "dot"),
+			runtimePath: "plugin",
+		});
+
+		expect(result.identity.name).toBe('Dorothy "Dot" Ashby');
+		expect(result.inject).toContain("You are Dot.");
+		expect(result.inject).toContain('You are Dorothy "Dot" Ashby.');
+		expect(result.inject).not.toContain("You are Rose.");
 	});
 });
 

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -16,7 +16,7 @@ import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { Worker } from "node:worker_threads";
-import { parseSimpleYaml } from "@signet/core";
+import { getAgentIdentityFiles, parseSimpleYaml } from "@signet/core";
 import { getAgentScope, resolveAgentId } from "./agent-id";
 import { extractAnchorTerms } from "./anchor-terms";
 import {
@@ -749,9 +749,10 @@ export function isDuplicate(db: Database, content: string, agentId: string): boo
 	return false;
 }
 
-function readIdentityFile(fileName: string, charBudget: number): string | undefined {
-	const filePath = join(getAgentsDir(), fileName);
-	if (!existsSync(filePath)) return undefined;
+type IdentityFileMap = Record<string, string>;
+
+function readIdentityPath(filePath: string | undefined, charBudget: number): string | undefined {
+	if (!filePath || !existsSync(filePath)) return undefined;
 
 	try {
 		const content = readFileSync(filePath, "utf-8").trim();
@@ -763,22 +764,25 @@ function readIdentityFile(fileName: string, charBudget: number): string | undefi
 	}
 }
 
-function readMemoryMd(charBudget: number): string | undefined {
-	return readIdentityFile("MEMORY.md", charBudget);
+function readIdentityFile(
+	fileName: string,
+	charBudget: number,
+	identityFiles?: IdentityFileMap,
+): string | undefined {
+	return readIdentityPath(identityFiles?.[fileName] ?? join(getAgentsDir(), fileName), charBudget);
 }
 
-function readAgentsMd(charBudget: number): string | undefined {
-	const agentsMd = join(getAgentsDir(), "AGENTS.md");
-	if (!existsSync(agentsMd)) return undefined;
+function readMemoryMd(charBudget: number, identityFiles?: IdentityFileMap): string | undefined {
+	return readIdentityFile("MEMORY.md", charBudget, identityFiles);
+}
 
-	try {
-		const content = readFileSync(agentsMd, "utf-8").trim();
-		if (!content) return undefined;
-		if (content.length <= charBudget) return content;
-		return `${content.slice(0, charBudget)}\n[truncated]`;
-	} catch {
-		return undefined;
-	}
+function readAgentsMd(charBudget: number, identityFiles?: IdentityFileMap): string | undefined {
+	return readIdentityFile("AGENTS.md", charBudget, identityFiles);
+}
+
+function resolveIdentityFiles(agentId: string): IdentityFileMap {
+	if (!agentId || agentId === "default") return {};
+	return getAgentIdentityFiles(agentId, getAgentsDir());
 }
 
 export interface ScoredMemory {
@@ -1189,7 +1193,25 @@ function isAgentConfig(value: unknown): value is AgentConfig {
 // Identity Loading
 // ============================================================================
 
-function loadIdentity(): { name: string; description?: string } {
+function parseIdentityMarkdown(content: string): { name: string; description?: string } {
+	const nameMatch = content.match(/name:\s*(.+)/i);
+	const youAreMatch = content.match(/(?:^|\n)\s*(?:#+\s*)?you are\s+([^\n.]+)\.?/i);
+	const descMatch = content.match(/creature:\s*(.+)/i) || content.match(/role:\s*(.+)/i);
+
+	return {
+		name: (nameMatch?.[1] ?? youAreMatch?.[1] ?? "Agent").trim(),
+		description: descMatch?.[1]?.trim(),
+	};
+}
+
+function loadIdentity(identityFiles?: IdentityFileMap): { name: string; description?: string } {
+	const identityMd = identityFiles?.["IDENTITY.md"];
+	if (identityMd && existsSync(identityMd)) {
+		try {
+			return parseIdentityMarkdown(readFileSync(identityMd, "utf-8"));
+		} catch {}
+	}
+
 	const agentYaml = join(getAgentsDir(), "agent.yaml");
 	if (existsSync(agentYaml)) {
 		try {
@@ -1205,16 +1227,10 @@ function loadIdentity(): { name: string; description?: string } {
 		} catch {}
 	}
 
-	const identityMd = join(getAgentsDir(), "IDENTITY.md");
-	if (existsSync(identityMd)) {
+	const rootIdentityMd = join(getAgentsDir(), "IDENTITY.md");
+	if (existsSync(rootIdentityMd)) {
 		try {
-			const content = readFileSync(identityMd, "utf-8");
-			const nameMatch = content.match(/name:\s*(.+)/i);
-			const descMatch = content.match(/creature:\s*(.+)/i) || content.match(/role:\s*(.+)/i);
-			return {
-				name: nameMatch?.[1]?.trim() || "Agent",
-				description: descMatch?.[1]?.trim(),
-			};
+			return parseIdentityMarkdown(readFileSync(rootIdentityMd, "utf-8"));
 		} catch {}
 	}
 
@@ -1366,13 +1382,14 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 		initContinuity(req.sessionKey, req.harness, req.project);
 	}
 
-	const identity = includeIdentity ? loadIdentity() : { name: "Agent" };
+	const identityFiles = resolveIdentityFiles(resolveAgentId(req));
+	const identity = includeIdentity ? loadIdentity(identityFiles) : { name: "Agent" };
 
 	// Read AGENTS.md first so harness instructions precede synthesized memory
-	const agentsMdContent = includeIdentity ? readAgentsMd(12000) : undefined;
+	const agentsMdContent = includeIdentity ? readAgentsMd(12000, identityFiles) : undefined;
 
 	// Read MEMORY.md with 10k char budget
-	const memoryMdContent = readMemoryMd(10000);
+	const memoryMdContent = readMemoryMd(10000, identityFiles);
 
 	const memoryCfg = loadMemoryConfig(getAgentsDir());
 	const traversalCfg = memoryCfg.pipelineV2.traversal;
@@ -1820,9 +1837,9 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	}
 
 	// Inject additional identity files
-	const soulContent = includeIdentity ? readIdentityFile("SOUL.md", 4000) : undefined;
-	const identityContent = includeIdentity ? readIdentityFile("IDENTITY.md", 2000) : undefined;
-	const userContent = includeIdentity ? readIdentityFile("USER.md", 6000) : undefined;
+	const soulContent = includeIdentity ? readIdentityFile("SOUL.md", 4000, identityFiles) : undefined;
+	const identityContent = includeIdentity ? readIdentityFile("IDENTITY.md", 2000, identityFiles) : undefined;
+	const userContent = includeIdentity ? readIdentityFile("USER.md", 6000, identityFiles) : undefined;
 
 	if (soulContent) {
 		injectParts.push("\n## Soul\n");

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -764,11 +764,7 @@ function readIdentityPath(filePath: string | undefined, charBudget: number): str
 	}
 }
 
-function readIdentityFile(
-	fileName: string,
-	charBudget: number,
-	identityFiles?: IdentityFileMap,
-): string | undefined {
+function readIdentityFile(fileName: string, charBudget: number, identityFiles?: IdentityFileMap): string | undefined {
 	return readIdentityPath(identityFiles?.[fileName] ?? join(getAgentsDir(), fileName), charBudget);
 }
 

--- a/packages/daemon/src/mcp/tools.test.ts
+++ b/packages/daemon/src/mcp/tools.test.ts
@@ -366,6 +366,34 @@ describe("createMcpServer", () => {
 			expect(body.structured.aspects[0].entityName).toBe("Nicholai");
 			expect(body.structured.aspects[0].attributes[0].content).toBe("prefers Signet memory tools");
 		});
+
+		it("normalizes legacy structured aspect tuples before forwarding to remember", async () => {
+			const cap: { body?: string } = {};
+			mockFetch(200, { id: "legacy-structured-1", structured: true }, cap);
+
+			await callTool(server, "memory_store", {
+				content: "Legacy structured tuple.",
+				structured: {
+					aspects: [
+						{
+							entity: "Nicholai",
+							aspect: "memory preference",
+							value: "prefers Signet memory tools",
+							confidence: 0.9,
+						},
+					],
+				},
+			});
+
+			const body = JSON.parse(cap.body ?? "{}");
+			expect(body.structured.aspects).toEqual([
+				{
+					entityName: "Nicholai",
+					aspect: "memory preference",
+					attributes: [{ content: "prefers Signet memory tools", confidence: 0.9 }],
+				},
+			]);
+		});
 	});
 
 	describe("memory_get", () => {

--- a/packages/daemon/src/mcp/tools.test.ts
+++ b/packages/daemon/src/mcp/tools.test.ts
@@ -330,6 +330,42 @@ describe("createMcpServer", () => {
 			const body = JSON.parse(cap.body ?? "{}");
 			expect(body.pinned).toBe(true);
 		});
+
+		it("passes hints, transcript, and structured graph payloads through to remember", async () => {
+			const cap: { body?: string } = {};
+			mockFetch(200, { id: "structured-1", hints_written: 2, structured: true }, cap);
+
+			await callTool(server, "memory_store", {
+				content: "Nicholai prefers Signet memory tools.",
+				hints: ["durable memory preference", "which memory tools should be used"],
+				transcript: "user: please use Signet memory tools only",
+				structured: {
+					entities: [
+						{
+							source: "Nicholai",
+							relationship: "prefers",
+							target: "Signet memory tools",
+							confidence: 0.95,
+						},
+					],
+					aspects: [
+						{
+							entityName: "Nicholai",
+							aspect: "memory preference",
+							attributes: [{ content: "prefers Signet memory tools", confidence: 0.95 }],
+						},
+					],
+					hints: ["Nicholai durable facts"],
+				},
+			});
+
+			const body = JSON.parse(cap.body ?? "{}");
+			expect(body.hints).toEqual(["durable memory preference", "which memory tools should be used"]);
+			expect(body.transcript).toBe("user: please use Signet memory tools only");
+			expect(body.structured.entities[0].target).toBe("Signet memory tools");
+			expect(body.structured.aspects[0].entityName).toBe("Nicholai");
+			expect(body.structured.aspects[0].attributes[0].content).toBe("prefers Signet memory tools");
+		});
 	});
 
 	describe("memory_get", () => {

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -677,6 +677,10 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 				importance: z.number().optional().describe("Importance score 0-1"),
 				tags: z.string().optional().describe("Comma-separated tags for categorization"),
 				pinned: z.boolean().optional().describe("Pin this memory — prevents decay, bypasses 0.95^days aging"),
+				hints: z
+					.array(z.string())
+					.optional()
+					.describe("Prospective recall hints and alternate phrasings for retrieving this memory later"),
 				transcript: z
 					.string()
 					.optional()
@@ -698,10 +702,15 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 						aspects: z
 							.array(
 								z.object({
-									entity: z.string(),
+									entityName: z.string(),
 									aspect: z.string(),
-									value: z.string(),
-									confidence: z.number().optional(),
+									attributes: z.array(
+										z.object({
+											content: z.string(),
+											confidence: z.number().optional(),
+											importance: z.number().optional(),
+										}),
+									),
 								}),
 							)
 							.optional(),
@@ -714,7 +723,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 			}),
 			annotations: { readOnlyHint: false },
 		},
-		async ({ content, type, importance, tags, transcript, structured, pinned }) => {
+		async ({ content, type, importance, tags, hints, transcript, structured, pinned }) => {
 			// Prepend tags prefix if provided (daemon parses [tag1,tag2]: format)
 			let body = content;
 			if (tags) {
@@ -726,6 +735,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 				body: {
 					content: body,
 					importance,
+					hints,
 					transcript,
 					structured,
 					pinned,

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -93,6 +93,38 @@ interface MarketplaceProxyState {
 	contextKey: string;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeStructuredMemoryPayload(value: unknown): unknown {
+	if (!isRecord(value)) return value;
+	const aspects = value.aspects;
+	if (!Array.isArray(aspects)) return value;
+
+	return {
+		...value,
+		aspects: aspects.map((aspect) => {
+			if (!isRecord(aspect)) return aspect;
+			if (typeof aspect.entityName === "string" && Array.isArray(aspect.attributes)) return aspect;
+			if (typeof aspect.entity === "string" && typeof aspect.aspect === "string" && typeof aspect.value === "string") {
+				return {
+					entityName: aspect.entity,
+					aspect: aspect.aspect,
+					attributes: [
+						{
+							content: aspect.value,
+							...(typeof aspect.confidence === "number" ? { confidence: aspect.confidence } : {}),
+							...(typeof aspect.importance === "number" ? { importance: aspect.importance } : {}),
+						},
+					],
+				};
+			}
+			return aspect;
+		}),
+	};
+}
+
 interface DaemonResponse<T> {
 	readonly ok: true;
 	readonly data: T;
@@ -701,17 +733,26 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 							.optional(),
 						aspects: z
 							.array(
-								z.object({
-									entityName: z.string(),
-									aspect: z.string(),
-									attributes: z.array(
-										z.object({
-											content: z.string(),
-											confidence: z.number().optional(),
-											importance: z.number().optional(),
-										}),
-									),
-								}),
+								z.union([
+									z.object({
+										entityName: z.string(),
+										aspect: z.string(),
+										attributes: z.array(
+											z.object({
+												content: z.string(),
+												confidence: z.number().optional(),
+												importance: z.number().optional(),
+											}),
+										),
+									}),
+									z.object({
+										entity: z.string(),
+										aspect: z.string(),
+										value: z.string(),
+										confidence: z.number().optional(),
+										importance: z.number().optional(),
+									}),
+								]),
 							)
 							.optional(),
 						hints: z.array(z.string()).optional(),
@@ -729,6 +770,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 			if (tags) {
 				body = `[${tags}]: ${content}`;
 			}
+			const normalizedStructured = normalizeStructuredMemoryPayload(structured);
 
 			const result = await daemonFetch<unknown>(baseUrl, "/api/memory/remember", {
 				method: "POST",
@@ -737,7 +779,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 					importance,
 					hints,
 					transcript,
-					structured,
+					structured: normalizedStructured,
 					pinned,
 				},
 			});


### PR DESCRIPTION
## Summary

Fixes Hermes Signet integration in three related ways:

- Scopes Hermes Signet memory and identity to the named agent workspace instead of falling back to the generic Hermes identity.
- Gives Signet recall paths enough time to complete on larger memory stores, avoiding false daemon reachability failures when recall takes longer than the generic 5s HTTP timeout.
- Exposes the complete Signet memory write schema to Hermes and MCP callers, including prospective hints, transcript, and structured graph payloads.

## Changes

- Adds Hermes connector support for named-agent scoping through `SIGNET_AGENT_ID` and `SIGNET_AGENT_WORKSPACE`.
- Makes Hermes Agent a first-class `signet setup` harness in interactive setup, non-interactive help text, migration detection, and setup docs.
- Keeps explicit recall requests unscoped by default and exposes `agent_scoped` so callers can opt into named-agent scoped recall.
- Extends the bundled Hermes plugin recall timeout to 30s.
- Uses the 30s recall timeout for per-turn `user-prompt-submit` recall hooks.
- Extends `signet recall` CLI timeout to 30s for `/api/memory/recall`.
- Keeps Hermes `memory_forget` soft-delete only by not exposing the daemon hard-delete `force` option to model-callable tools.
- Adds `hints`, `transcript`, and `structured` support to the Hermes `memory_store` schema and daemon payload forwarding.
- Aligns the MCP `memory_store` schema and payload forwarding with the daemon remember endpoint for hints, transcript, and structured graph metadata.
- Documents the full Hermes `memory_store` surface.
- Adds regression coverage for Hermes connector scoping, setup harness availability, Hermes install detection, recall timeout behavior, explicit `agent_scoped` recall opt-in, schema completeness, MCP structured memory writes, auth-bearing agent registration, non-404 registration checks, bundled Python client compatibility, malformed recall score filtering, soft-delete-only Hermes forget behavior, uninstall credential cleanup, and legacy structured payload compatibility.

## Type

- [ ] `feat` - new user-facing feature (bumps minor)
- [x] `fix` - bug fix
- [ ] `refactor` - restructure without behavior change
- [ ] `chore` - build, deps, config, docs
- [ ] `perf` - performance improvement
- [ ] `test` - test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [x] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

Readiness caveat: repo-wide validator, lint, and typecheck caveats are documented in the Testing section below. Targeted checks for this PR pass.

## Migration Notes (if applicable)

N/A. No database migrations touched.

- [ ] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Compatibility note: these changes are additive to existing Hermes and MCP schemas. Existing memory tool calls remain valid, including legacy structured aspect tuples using `{entity, aspect, value}`. Named agents may provide agent-local identity overrides for the standard identity files, including `MEMORY.md`; if no agent-local file exists, the root workspace file remains the fallback. Hermes model-callable `memory_forget` remains soft-delete only and does not expose hard-delete `force`. Hermes uninstall removes persisted Signet env vars, including `SIGNET_TOKEN`.

## Testing

- [x] `bun test` passes for touched regression suites
- [ ] `bun run typecheck` passes repo-wide
- [ ] `bun run lint` passes repo-wide
- [x] Touched package typechecks pass
- [x] Tested against running daemon
- [ ] N/A

Commands run locally:

```bash
bun run build:core
bun test packages/connector-hermes-agent/index.test.ts packages/daemon/src/mcp/tools.test.ts packages/cli/src/commands/memory.test.ts packages/core/src/__tests__/identity.test.ts packages/daemon/src/hooks.test.ts packages/cli/src/features/setup-shared.test.ts
python3 -m py_compile packages/connector-hermes-agent/hermes-plugin/__init__.py packages/connector-hermes-agent/hermes-plugin/client.py
bunx biome check packages/connector-hermes-agent/index.test.ts packages/connector-hermes-agent/src/index.ts packages/core/src/__tests__/identity.test.ts packages/daemon/src/mcp/tools.ts packages/daemon/src/mcp/tools.test.ts packages/daemon/src/hooks.ts packages/daemon/src/hooks.test.ts packages/cli/src/commands/memory.ts packages/cli/src/commands/memory.test.ts packages/cli/src/features/setup.ts packages/cli/src/features/setup-migrate.ts packages/cli/src/features/setup-shared.test.ts packages/cli/src/commands/app.ts docs/ARCHITECTURE.md docs/CLI.md docs/HARNESSES.md
bun run --filter '@signet/core' typecheck
bun run --filter '@signet/connector-hermes-agent' typecheck
git diff --check
```

Result:

```text
@signet/core build passed
124 pass
0 fail
Hermes plugin py_compile passed
Targeted Biome check passed
@signet/core typecheck passed
@signet/connector-hermes-agent typecheck passed
git diff --check passed
```

Full-suite caveats:

- `bun run typecheck` was attempted. It exits 2 on an existing repo-wide desktop package issue: `@signet/desktop` cannot find the `electron` type definition file. The packages touched by this PR that expose typecheck scripts pass.
- `bun run lint` was attempted. It exits 1 on the current repo-wide Biome baseline, mainly package manifest formatting diagnostics outside this PR. Targeted Biome checks for this PR's changed TypeScript and docs files pass.
- `bun scripts/spec-deps-check.ts` was attempted. It currently fails on an existing unrelated dependency entry: `informed_by path does not exist for engram-informed-predictor-track: references/Engram`. This PR does not touch `docs/specs/`.

Manual validation:

- `signet recall --json "Nicholai durable facts Signet memory"` succeeds locally after increasing the timeout.
- Hermes bundled Signet plugin smoke test connects to the daemon, exposes `memory_search`, and returns recall results instead of timing out.
- Local Hermes plugin schema now exposes `hints`, `transcript`, and `structured` on `memory_store`.
- Local Hermes gateway restarted and is running.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used

## Notes

The broader recall ranking issue is separate from this schema fix. This PR makes the fields available and forwarded correctly so callers can provide retrieval-friendly hints instead of being limited to content, type, importance, tags, pinned, and project.


