### PR TITLE
refactor(cli): prompt for sync after restart

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -737,7 +737,13 @@ function embeddingProvider(basePath: string): "native" | "llama-cpp" | "ollama" 
 			const direct = parsed.embedding;
 			if (isRecord(direct) && typeof direct.provider === "string") {
 				const provider = direct.provider;
-				if (provider === "native" || provider === "llama-cpp" || provider === "ollama" || provider === "openai" || provider === "none") {
+				if (
+					provider === "native" ||
+					provider === "llama-cpp" ||
+					provider === "ollama" ||
+					provider === "openai" ||
+					provider === "none"
+				) {
 					return provider;
 				}
 			}
@@ -746,7 +752,13 @@ function embeddingProvider(basePath: string): "native" | "llama-cpp" | "ollama" 
 				const nested = mem.embeddings;
 				if (isRecord(nested) && typeof nested.provider === "string") {
 					const provider = nested.provider;
-					if (provider === "native" || provider === "llama-cpp" || provider === "ollama" || provider === "openai" || provider === "none") {
+					if (
+						provider === "native" ||
+						provider === "llama-cpp" ||
+						provider === "ollama" ||
+						provider === "openai" ||
+						provider === "none"
+					) {
 						return provider;
 					}
 				}
@@ -754,7 +766,13 @@ function embeddingProvider(basePath: string): "native" | "llama-cpp" | "ollama" 
 			const legacy = parsed.embeddings;
 			if (isRecord(legacy) && typeof legacy.provider === "string") {
 				const provider = legacy.provider;
-				if (provider === "native" || provider === "llama-cpp" || provider === "ollama" || provider === "openai" || provider === "none") {
+				if (
+					provider === "native" ||
+					provider === "llama-cpp" ||
+					provider === "ollama" ||
+					provider === "openai" ||
+					provider === "none"
+				) {
 					return provider;
 				}
 			}
@@ -1250,6 +1268,19 @@ const healthDeps = {
 	signetLogo,
 };
 
+const runSyncTemplates = (basePath = AGENTS_DIR): Promise<void> =>
+	syncTemplates({
+		agentsDir: basePath,
+		configureHarnessHooks,
+		getSkillsSourceDir,
+		getTemplatesDir,
+		signetLogo,
+		syncBuiltinSkills,
+		syncNativeEmbeddingModel,
+		syncPredictorBinary,
+		syncWorkspaceSourceRepo: syncWorkspaceSourceRepoAsync,
+	});
+
 const daemonDeps = {
 	agentsDir: AGENTS_DIR,
 	defaultPort: DEFAULT_PORT,
@@ -1262,6 +1293,7 @@ const daemonDeps = {
 	sleep,
 	startDaemon,
 	stopDaemon,
+	syncTemplates: runSyncTemplates,
 };
 
 registerAppCommands(program, {
@@ -1307,18 +1339,7 @@ registerAppCommands(program, {
 		}),
 	showDoctor: (options) => showDoctor(options, healthDeps),
 	showStatus: (options) => showStatus(options, healthDeps),
-	syncTemplates: () =>
-		syncTemplates({
-			agentsDir: AGENTS_DIR,
-			configureHarnessHooks,
-			getSkillsSourceDir,
-			getTemplatesDir,
-			signetLogo,
-			syncBuiltinSkills,
-			syncNativeEmbeddingModel,
-			syncPredictorBinary,
-			syncWorkspaceSourceRepo: syncWorkspaceSourceRepoAsync,
-		}),
+	syncTemplates: runSyncTemplates,
 });
 
 registerDaemonCommands(program, {

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -31,7 +31,8 @@ export function registerDaemonCommands(program: Command, deps: DaemonDeps): void
 	const restart = daemonCmd
 		.command("restart")
 		.description("Restart the daemon")
-		.option("--no-openclaw", "Skip OpenClaw restart prompt")
+		.option("--no-sync", "Skip signet sync prompt")
+		.option("--no-openclaw", "Deprecated alias for --no-sync")
 		.action(deps.doRestart);
 	withPath(restart);
 
@@ -68,7 +69,8 @@ export function registerDaemonCommands(program: Command, deps: DaemonDeps): void
 	const restartAlias = program
 		.command("restart")
 		.description("Restart the daemon (alias for: signet daemon restart)")
-		.option("--no-openclaw", "Skip OpenClaw restart prompt")
+		.option("--no-sync", "Skip signet sync prompt")
+		.option("--no-openclaw", "Deprecated alias for --no-sync")
 		.action(deps.doRestart);
 	withPath(restartAlias);
 

--- a/packages/cli/src/commands/shared.ts
+++ b/packages/cli/src/commands/shared.ts
@@ -10,6 +10,7 @@ export interface StatusOptions extends PathOptions {
 
 export interface RestartOptions extends PathOptions {
 	openclaw?: boolean;
+	sync?: boolean;
 }
 
 export interface LogOptions extends PathOptions {

--- a/packages/cli/src/features/daemon.test.ts
+++ b/packages/cli/src/features/daemon.test.ts
@@ -101,7 +101,7 @@ describe("daemon lifecycle recovery", () => {
 			},
 		});
 
-		await doRestart({ openclaw: false }, deps);
+		await doRestart({ sync: false }, deps);
 
 		expect(calls).toEqual(["stop", "start"]);
 	});
@@ -119,6 +119,83 @@ describe("daemon lifecycle recovery", () => {
 		await doStop({}, deps);
 
 		expect(stopped).toBe(true);
+	});
+
+	it("restart runs signet sync when the user accepts the sync prompt", async () => {
+		let synced = false;
+		const deps = makeDeps({
+			isInteractive: () => true,
+			confirmRestartSync: async () => true,
+			syncTemplates: async () => {
+				synced = true;
+			},
+		});
+
+		await doRestart({}, deps);
+
+		expect(synced).toBe(true);
+	});
+
+	it("restart sync uses the resolved restart path", async () => {
+		let syncedPath: string | null = null;
+		const deps = makeDeps({
+			extractPathOption: () => "/tmp/custom-agents",
+			isInteractive: () => true,
+			confirmRestartSync: async () => true,
+			normalizeAgentPath: (pathValue) => `${pathValue}-normalized`,
+			syncTemplates: async (basePath) => {
+				syncedPath = basePath;
+			},
+		});
+
+		await doRestart({ path: "/tmp/custom-agents" }, deps);
+
+		expect(syncedPath).toBe("/tmp/custom-agents-normalized");
+	});
+
+	it("restart skips signet sync when the user declines the sync prompt", async () => {
+		let synced = false;
+		const deps = makeDeps({
+			isInteractive: () => true,
+			confirmRestartSync: async () => false,
+			syncTemplates: async () => {
+				synced = true;
+			},
+		});
+
+		await doRestart({}, deps);
+
+		expect(synced).toBe(false);
+	});
+
+	it("restart honors --no-sync even in an interactive terminal", async () => {
+		let synced = false;
+		const deps = makeDeps({
+			isInteractive: () => true,
+			confirmRestartSync: async () => true,
+			syncTemplates: async () => {
+				synced = true;
+			},
+		});
+
+		await doRestart({ sync: false }, deps);
+
+		expect(synced).toBe(false);
+	});
+
+	it("restart treats deprecated --no-openclaw as --no-sync", async () => {
+		let synced = false;
+		const deps = makeDeps({
+			isInteractive: () => true,
+			confirmRestartSync: async () => true,
+			syncTemplates: async () => {
+				synced = true;
+			},
+		});
+
+		await doRestart({ openclaw: false }, deps);
+
+		expect(synced).toBe(false);
 	});
 });
 
@@ -162,7 +239,7 @@ describe("daemon exit codes on failure", () => {
 
 		const deps = makeDeps({ startDaemon: async () => false });
 
-		await expect(doRestart({ openclaw: false }, deps)).rejects.toThrow("EXIT_1");
+		await expect(doRestart({ sync: false }, deps)).rejects.toThrow("EXIT_1");
 		expect(exitSpy).toHaveBeenCalledWith(1);
 	});
 
@@ -176,7 +253,7 @@ describe("daemon exit codes on failure", () => {
 			stopDaemon: async () => false,
 		});
 
-		await expect(doRestart({ openclaw: false }, deps)).rejects.toThrow("EXIT_1");
+		await expect(doRestart({ sync: false }, deps)).rejects.toThrow("EXIT_1");
 		expect(exitSpy).toHaveBeenCalledWith(1);
 	});
 });

--- a/packages/cli/src/features/daemon.ts
+++ b/packages/cli/src/features/daemon.ts
@@ -1,9 +1,7 @@
-import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { confirm } from "@inquirer/prompts";
-import { OpenClawConnector } from "@signet/connector-openclaw";
-import { detectSchema, ensureUnifiedSchema, parseSimpleYaml, runMigrations } from "@signet/core";
+import { detectSchema, ensureUnifiedSchema, runMigrations } from "@signet/core";
 import chalk from "chalk";
 import open from "open";
 import ora from "ora";
@@ -53,6 +51,9 @@ interface Deps {
 	readonly sleep: (ms: number) => Promise<void>;
 	readonly startDaemon: (agentsDir?: string) => Promise<boolean>;
 	readonly stopDaemon: (agentsDir?: string) => Promise<boolean>;
+	readonly confirmRestartSync?: () => Promise<boolean>;
+	readonly isInteractive?: () => boolean;
+	readonly syncTemplates?: (basePath: string) => Promise<void>;
 }
 
 export async function launchDashboard(options: PathOptions, deps: Deps): Promise<void> {
@@ -258,16 +259,22 @@ export async function doRestart(options: RestartOptions, deps: Deps): Promise<vo
 		process.exit(1);
 	}
 
-	if (options.openclaw === false || !isOpenClawDetected()) {
+	if (options.openclaw === false) {
+		console.log(chalk.yellow("  --no-openclaw is deprecated; use --no-sync instead."));
+	}
+
+	if (
+		options.sync === false ||
+		options.openclaw === false ||
+		!deps.syncTemplates ||
+		!(deps.isInteractive ?? isInteractiveTerminal)()
+	) {
 		return;
 	}
 
-	const restart = await confirm({
-		message: "Restart connected OpenClaw instance?",
-		default: false,
-	});
-	if (restart) {
-		await restartOpenClaw(basePath);
+	const sync = await (deps.confirmRestartSync ?? confirmRestartSync)();
+	if (sync) {
+		await deps.syncTemplates(basePath);
 	}
 }
 
@@ -633,68 +640,15 @@ function formatLogEntry(entry: LogEntry): string {
 	return line;
 }
 
-function isOpenClawDetected(): boolean {
-	return new OpenClawConnector().getDiscoveredConfigPaths().length > 0;
+function isInteractiveTerminal(): boolean {
+	return process.stdin.isTTY === true && process.stdout.isTTY === true;
 }
 
-async function restartOpenClaw(basePath: string): Promise<boolean> {
-	const yamlPath = join(basePath, "agent.yaml");
-	let cmd: string | null = null;
-
-	try {
-		const yaml = readFileSync(yamlPath, "utf-8");
-		const cfg = parseSimpleYaml(yaml);
-		cmd = readRestartCommand(cfg);
-	} catch {
-		// Ignore
-	}
-
-	if (!cmd) {
-		console.log();
-		console.log(chalk.yellow("  No OpenClaw restart command configured."));
-		console.log(chalk.dim(`  Add to ${yamlPath}:`));
-		console.log(chalk.dim("    services:"));
-		console.log(chalk.dim("      openclaw:"));
-		console.log(chalk.dim('        restart_command: "systemctl --user restart openclaw"'));
-		return false;
-	}
-
-	// Validate command against known safe restart patterns to prevent
-	// injection via tampered agent.yaml (git sync, social engineering).
-	const SAFE_PATTERNS = [
-		/^systemctl\s+--user\s+restart\s+[\w.-]+$/,
-		/^launchctl\s+kickstart\s+-k\s+[\w.-]+(\/[\w.-]+)*$/,
-		/^brew\s+services\s+restart\s+[\w.-]+$/,
-		/^supervisorctl\s+restart\s+[\w.-]+$/,
-	];
-	if (!SAFE_PATTERNS.some((p) => p.test(cmd))) {
-		console.log();
-		console.log(chalk.red("  Restart command rejected — does not match safe patterns."));
-		console.log(chalk.dim(`  Command: ${cmd}`));
-		console.log(chalk.dim("  Allowed: systemctl --user restart <name>, launchctl kickstart -k <path>"));
-		return false;
-	}
-
-	const spinner = ora("Restarting OpenClaw...").start();
-	try {
-		const shell = process.platform === "win32" ? "cmd" : "sh";
-		const args = process.platform === "win32" ? ["/c", cmd] : ["-c", cmd];
-		const result = spawnSync(shell, args, {
-			timeout: 15_000,
-			stdio: "pipe",
-			windowsHide: true,
-		});
-		if (result.status === 0) {
-			spinner.succeed("OpenClaw restarted");
-			return true;
-		}
-		const stderr = readSpawnErr(result.stderr);
-		spinner.fail(`OpenClaw restart failed${stderr ? `: ${stderr}` : ""}`);
-		return false;
-	} catch {
-		spinner.fail("OpenClaw restart timed out");
-		return false;
-	}
+async function confirmRestartSync(): Promise<boolean> {
+	return confirm({
+		message: "Run `signet sync` now?",
+		default: false,
+	});
 }
 
 function readLogPayload(value: unknown): LogPayload | null {
@@ -765,31 +719,6 @@ function readLevel(value: unknown): LogEntry["level"] | null {
 		default:
 			return null;
 	}
-}
-
-function readRestartCommand(value: unknown): string | null {
-	if (!isRecord(value)) {
-		return null;
-	}
-	const services = value.services;
-	if (!isRecord(services)) {
-		return null;
-	}
-	const openclaw = services.openclaw;
-	if (!isRecord(openclaw)) {
-		return null;
-	}
-	return readString(openclaw.restart_command);
-}
-
-function readSpawnErr(value: string | Buffer | null): string {
-	if (typeof value === "string") {
-		return value.trim();
-	}
-	if (value instanceof Buffer) {
-		return value.toString("utf-8").trim();
-	}
-	return "";
 }
 
 function readString(value: unknown): string | null {


### PR DESCRIPTION
## Summary

- Remove the restart-time prompt for restarting a connected OpenClaw instance.
- Add an interactive restart prompt for running `signet sync` instead.
- Replace `--no-openclaw` with `--no-sync` on `signet daemon restart` and the `signet restart` alias.
- Reuse the same sync implementation behind the top-level `signet sync` command.
- Add regression coverage for accepting, declining, and bypassing the sync prompt.

## Why

The restart dialog should guide users toward refreshing Signet hooks, extensions, built-in templates, and skills after the daemon restarts, rather than trying to manage a connected OpenClaw process directly.

## Validation

- `bun test packages/cli/src/features/daemon.test.ts`
- `bunx biome check packages/cli/src/commands/shared.ts packages/cli/src/commands/daemon.ts packages/cli/src/features/daemon.ts packages/cli/src/features/daemon.test.ts packages/cli/src/cli.ts`
- `bun install --frozen-lockfile`

## Known validation blocker

`cd packages/cli && bun run build:cli` is currently blocked by unresolved existing workspace imports for `@signet/connector-hermes-agent` and `@signet/connector-pi`. Those imports pre-existed this change.
