### PR TITLE
fix(codex): prevent session-start hook timeouts

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -846,7 +846,7 @@ Environment Variables
 | `SIGNET_LOG_FILE` | Explicit daemon log file path | unset |
 | `SIGNET_LOG_DIR` | Daemon log directory override | `$SIGNET_WORKSPACE/.daemon/logs` |
 | `SIGNET_SQLITE_PATH` | macOS explicit SQLite dylib override used by the daemon before opening the database | unset |
-| `SIGNET_SESSION_START_TIMEOUT` | Session-start hook timeout in ms for Signet-managed clients and generated Claude Code hook configs | `15000` |
+| `SIGNET_SESSION_START_TIMEOUT` | Session-start daemon wait budget in ms for Signet-managed clients. Generated Claude Code hook config writes this value directly. Generated Codex hook config rounds up to seconds and adds 5 seconds of harness grace | `15000` |
 | `SIGNET_FETCH_TIMEOUT` | Legacy fallback for session-start timeout in ms when `SIGNET_SESSION_START_TIMEOUT` is unset | `15000` |
 | `SIGNET_PROMPT_SUBMIT_TIMEOUT` | Prompt-submit daemon wait budget in ms; OpenCode uses this value directly, generated Claude Code hook config writes this value + 2000 ms grace | `5000` |
 | `SIGNET_BYPASS` | Skip all hook processing (exit immediately) | unset |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -833,10 +833,17 @@ harness session:
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `recallLimit` | `10` | Number of memories to inject |
+| `recallLimit` | `50` | Number of memories to inject |
+| `candidatePoolLimit` | `100` | Number of candidate memories to rank before token budgeting |
 | `includeIdentity` | `true` | Include agent name and description |
 | `includeRecentContext` | `true` | Include `MEMORY.md` content |
 | `recencyBias` | `0.7` | Weight toward recent vs. important memories (0-1) |
+| `maxInjectTokens` | `12000` | Maximum session-start injection budget after context assembly |
+
+Predicted context from recent session summaries is scoped to the active
+project. If the harness does not provide a project path, Signet skips
+predicted-context FTS at session start to avoid global broad-term scans
+over large memory stores.
 
 `hooks.preCompaction` controls what is included when the harness triggers
 a pre-compaction summary:
@@ -873,7 +880,7 @@ editing the config file is impractical.
 | `SIGNET_LOG_FILE` | — | Optional explicit daemon log file path |
 | `SIGNET_LOG_DIR` | `$SIGNET_WORKSPACE/.daemon/logs` | Optional daemon log directory override |
 | `SIGNET_SQLITE_PATH` | — | macOS explicit SQLite dylib override used before Bun opens the database |
-| `SIGNET_SESSION_START_TIMEOUT` | `15000` | Session-start hook timeout in ms for Signet-managed clients and generated Claude Code hook configs |
+| `SIGNET_SESSION_START_TIMEOUT` | `15000` | Session-start daemon wait budget in ms for Signet-managed clients. Generated Claude Code hook config writes this value directly. Generated Codex hook config rounds up to seconds and adds 5 seconds of harness grace |
 | `SIGNET_FETCH_TIMEOUT` | `15000` | Legacy fallback for session-start timeout in ms when `SIGNET_SESSION_START_TIMEOUT` is unset |
 | `SIGNET_PROMPT_SUBMIT_TIMEOUT` | `5000` | Prompt-submit daemon wait budget in ms; OpenCode uses this value directly, generated Claude Code hook config writes this value + 2000 ms grace |
 | `SIGNET_TRUSTED_PROVIDER_ENDPOINT_HOSTS` | — | Comma-separated host allowlist for Anthropic endpoint overrides used during credentialed startup preflight (supports entries like `proxy.example.com` and `*.example.com`) |

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -245,6 +245,12 @@ registers as an MCP server so Codex can call `signet_remember` and
 4. On session end, Codex fires `Stop` → calls `signet hook session-end -H codex` → Signet extracts memories from the transcript.
 5. The MCP server exposes `memory_store`, `memory_search`, and other memory tools that Codex can invoke directly during sessions.
 
+Codex `SessionStart` hook timeout defaults to 20 seconds: the Signet CLI
+waits up to `SIGNET_SESSION_START_TIMEOUT` (`15000` ms by default) for
+the daemon, and the generated Codex hook config adds 5 seconds of harness
+grace. Rerun `signet setup` or `signet connect codex` after upgrading to
+rewrite an existing `~/.codex/hooks.json`.
+
 Codex matches the session-start, prompt-submit, and session-end path, but
 it does **not** currently expose the same compaction lifecycle fidelity as
 Claude Code or OpenCode.

--- a/packages/connector-codex/src/config-toml.test.ts
+++ b/packages/connector-codex/src/config-toml.test.ts
@@ -344,6 +344,31 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		expect(startHandler.timeout).toBe(20);
 	});
 
+	test("preserves unrelated top-level keys when refreshing only Signet hooks", async () => {
+		writeFileSync(
+			hooksPath,
+			JSON.stringify({
+				_signet: true,
+				version: 1,
+				metadata: { owner: "third-party" },
+				hooks: {
+					SessionStart: [
+						{ _signet: true, hooks: [{ type: "command", command: "signet hook session-start -H codex", timeout: 10 }] },
+					],
+				},
+			}),
+		);
+
+		await connector().install(tempHome);
+		const json = readHooksJson();
+		const hooks = json.hooks as Record<string, Record<string, unknown>[]>;
+		const startHandler = ((hooks.SessionStart[0] as Record<string, unknown>).hooks as Record<string, unknown>[])[0];
+
+		expect(json.version).toBe(1);
+		expect(json.metadata).toEqual({ owner: "third-party" });
+		expect(startHandler.timeout).toBe(20);
+	});
+
 	test("refreshes node-shim Signet hook commands without duplicating entries", async () => {
 		writeFileSync(
 			hooksPath,

--- a/packages/connector-codex/src/config-toml.test.ts
+++ b/packages/connector-codex/src/config-toml.test.ts
@@ -24,8 +24,22 @@ let tempHome: string;
 let codexDir: string;
 let configPath: string;
 let hooksPath: string;
+let previousSessionStartTimeout: string | undefined;
+let previousFetchTimeout: string | undefined;
+
+function restoreEnv(name: string, value: string | undefined): void {
+	if (value === undefined) {
+		Reflect.deleteProperty(process.env, name);
+		return;
+	}
+	process.env[name] = value;
+}
 
 beforeEach(() => {
+	previousSessionStartTimeout = process.env.SIGNET_SESSION_START_TIMEOUT;
+	previousFetchTimeout = process.env.SIGNET_FETCH_TIMEOUT;
+	Reflect.deleteProperty(process.env, "SIGNET_SESSION_START_TIMEOUT");
+	Reflect.deleteProperty(process.env, "SIGNET_FETCH_TIMEOUT");
 	tempHome = join(tmpdir(), `signet-codex-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	codexDir = join(tempHome, ".codex");
 	configPath = join(codexDir, "config.toml");
@@ -34,6 +48,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+	restoreEnv("SIGNET_SESSION_START_TIMEOUT", previousSessionStartTimeout);
+	restoreEnv("SIGNET_FETCH_TIMEOUT", previousFetchTimeout);
 	rmSync(tempHome, { recursive: true, force: true });
 });
 
@@ -267,7 +283,7 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		expect(typeof handler.command).toBe("string");
 		expect(handler.command as string).toContain("hook session-start");
 		expect(handler.command as string).toContain("-H codex");
-		expect(handler.timeout).toBe(10);
+		expect(handler.timeout).toBe(20);
 	});
 
 	test("sets correct timeouts per event", async () => {
@@ -276,7 +292,7 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		const hooks = json.hooks as Record<string, Record<string, unknown>[]>;
 
 		const startHandler = ((hooks.SessionStart[0] as Record<string, unknown>).hooks as Record<string, unknown>[])[0];
-		expect(startHandler.timeout).toBe(10);
+		expect(startHandler.timeout).toBe(20);
 
 		const promptHandler = (
 			(hooks.UserPromptSubmit[0] as Record<string, unknown>).hooks as Record<string, unknown>[]
@@ -285,6 +301,81 @@ describe("CodexConnector.install — hooks.json schema", () => {
 
 		const stopHandler = ((hooks.Stop[0] as Record<string, unknown>).hooks as Record<string, unknown>[])[0];
 		expect(stopHandler.timeout).toBe(30);
+	});
+
+	test("sets Codex session-start timeout to Signet timeout plus grace", async () => {
+		process.env.SIGNET_SESSION_START_TIMEOUT = "18000";
+
+		await connector().install(tempHome);
+		const json = readHooksJson();
+		const hooks = json.hooks as Record<string, Record<string, unknown>[]>;
+		const startHandler = ((hooks.SessionStart[0] as Record<string, unknown>).hooks as Record<string, unknown>[])[0];
+
+		expect(startHandler.timeout).toBe(23);
+	});
+
+	test("refreshes existing Signet-owned hooks to current timeouts", async () => {
+		writeFileSync(
+			hooksPath,
+			JSON.stringify({
+				_signet: true,
+				hooks: {
+					SessionStart: [
+						{ _signet: true, hooks: [{ type: "command", command: "signet hook session-start -H codex", timeout: 10 }] },
+					],
+					UserPromptSubmit: [
+						{
+							_signet: true,
+							hooks: [{ type: "command", command: "signet hook user-prompt-submit -H codex", timeout: 5 }],
+						},
+					],
+					Stop: [
+						{ _signet: true, hooks: [{ type: "command", command: "signet hook session-end -H codex", timeout: 30 }] },
+					],
+				},
+			}),
+		);
+
+		await connector().install(tempHome);
+		const json = readHooksJson();
+		const hooks = json.hooks as Record<string, Record<string, unknown>[]>;
+		const startHandler = ((hooks.SessionStart[0] as Record<string, unknown>).hooks as Record<string, unknown>[])[0];
+
+		expect(startHandler.timeout).toBe(20);
+	});
+
+	test("refreshes node-shim Signet hook commands without duplicating entries", async () => {
+		writeFileSync(
+			hooksPath,
+			JSON.stringify({
+				hooks: {
+					SessionStart: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command: "/usr/bin/node /tmp/signet/bin/signet.js hook session-start -H codex",
+									timeout: 10,
+								},
+							],
+						},
+					],
+				},
+			}),
+		);
+
+		await connector().install(tempHome);
+		const json = readHooksJson();
+		const hooks = json.hooks as Record<string, Record<string, unknown>[]>;
+		const startGroups = hooks.SessionStart;
+		const signetHandlers = startGroups.flatMap((group) =>
+			((group as Record<string, unknown>).hooks as Record<string, unknown>[]).filter((handler) =>
+				(handler.command as string).includes("hook session-start"),
+			),
+		);
+
+		expect(signetHandlers.length).toBe(1);
+		expect(signetHandlers[0]?.timeout).toBe(20);
 	});
 
 	test("does not use array-form command (regression: issue #481)", async () => {

--- a/packages/connector-codex/src/config-toml.test.ts
+++ b/packages/connector-codex/src/config-toml.test.ts
@@ -378,6 +378,39 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		expect(signetHandlers[0]?.timeout).toBe(20);
 	});
 
+	test("preserves third-party commands that only mention hook subcommands", async () => {
+		writeFileSync(
+			hooksPath,
+			JSON.stringify({
+				hooks: {
+					SessionStart: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command: "python ./scripts/custom-reviewer.py --note ' hook session-start '",
+									timeout: 7,
+								},
+							],
+						},
+					],
+				},
+			}),
+		);
+
+		await connector().install(tempHome);
+		const json = readHooksJson();
+		const hooks = json.hooks as Record<string, Record<string, unknown>[]>;
+		const commands = hooks.SessionStart.flatMap((group) =>
+			((group as Record<string, unknown>).hooks as Record<string, unknown>[]).map(
+				(handler) => handler.command as string,
+			),
+		);
+
+		expect(commands).toContain("python ./scripts/custom-reviewer.py --note ' hook session-start '");
+		expect(commands.some((command) => command === "signet hook session-start -H codex")).toBe(true);
+	});
+
 	test("does not use array-form command (regression: issue #481)", async () => {
 		await connector().install(tempHome);
 		const json = readHooksJson();

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { BaseConnector, type InstallResult, type UninstallResult, atomicWriteJson } from "@signet/connector-base";
-import { expandHome } from "@signet/core";
+import { expandHome, resolveSessionStartTimeoutMs } from "@signet/core";
 
 // ---------------------------------------------------------------------------
 // Signet command resolution
@@ -47,6 +47,9 @@ function resolveSignetMcp(): { command: string; args: string[] } {
 // ---------------------------------------------------------------------------
 
 const HOOK_EVENT_KEYS = ["SessionStart", "UserPromptSubmit", "Stop"] as const;
+const CODEX_SESSION_START_GRACE_SECONDS = 5;
+const PROMPT_SUBMIT_TIMEOUT_SECONDS = 5;
+const SESSION_END_TIMEOUT_SECONDS = 30;
 
 interface MatcherGroup {
 	_signet?: boolean;
@@ -66,6 +69,16 @@ interface HooksFile {
 	[key: string]: unknown;
 }
 
+function readTimeoutEnv(name: string): string {
+	const value = process.env[name];
+	return typeof value === "string" ? value.trim() : "";
+}
+
+function resolveCodexSessionStartTimeoutSeconds(): number {
+	const raw = readTimeoutEnv("SIGNET_SESSION_START_TIMEOUT") || readTimeoutEnv("SIGNET_FETCH_TIMEOUT");
+	return Math.ceil(resolveSessionStartTimeoutMs(raw) / 1000) + CODEX_SESSION_START_GRACE_SECONDS;
+}
+
 function buildHooksFile(signetArgs: string[]): HooksFile {
 	const cmd = (subcommand: string, secs: number): MatcherGroup => ({
 		_signet: true,
@@ -74,9 +87,9 @@ function buildHooksFile(signetArgs: string[]): HooksFile {
 	return {
 		_signet: true,
 		hooks: {
-			SessionStart: [cmd("session-start", 10)],
-			UserPromptSubmit: [cmd("user-prompt-submit", 5)],
-			Stop: [cmd("session-end", 30)],
+			SessionStart: [cmd("session-start", resolveCodexSessionStartTimeoutSeconds())],
+			UserPromptSubmit: [cmd("user-prompt-submit", PROMPT_SUBMIT_TIMEOUT_SECONDS)],
+			Stop: [cmd("session-end", SESSION_END_TIMEOUT_SECONDS)],
 		},
 	};
 }
@@ -107,6 +120,13 @@ const SIGNET_HOOK_PREFIXES = [
 	"signet hook user-prompt-submit",
 	"signet hook session-end",
 ] as const;
+const SIGNET_HOOK_COMMAND_MARKERS = [" hook session-start", " hook user-prompt-submit", " hook session-end"] as const;
+
+function isSignetHookCommand(cmd: string): boolean {
+	return (
+		SIGNET_HOOK_PREFIXES.some((s) => cmd.startsWith(s)) || SIGNET_HOOK_COMMAND_MARKERS.some((s) => cmd.includes(s))
+	);
+}
 
 function isSignetMatcherGroup(group: unknown): boolean {
 	if (typeof group !== "object" || group === null) return false;
@@ -117,7 +137,7 @@ function isSignetMatcherGroup(group: unknown): boolean {
 		if (typeof handler !== "object" || handler === null) continue;
 		const cmd = (handler as Record<string, unknown>).command;
 		if (typeof cmd !== "string") continue;
-		if (SIGNET_HOOK_PREFIXES.some((s) => cmd.startsWith(s))) return true;
+		if (isSignetHookCommand(cmd)) return true;
 	}
 	return false;
 }
@@ -131,7 +151,7 @@ function isLegacySignetMatcherGroup(group: unknown): boolean {
 		const cmd = (handler as Record<string, unknown>).command;
 		if (Array.isArray(cmd)) {
 			const joined = cmd.join(" ");
-			if (SIGNET_HOOK_PREFIXES.some((s) => joined.startsWith(s))) return true;
+			if (isSignetHookCommand(joined)) return true;
 		}
 	}
 	return false;
@@ -313,13 +333,12 @@ export class CodexConnector extends BaseConnector {
 
 		if (existing) {
 			const migrated = migrateLegacyHooksFile(existing, signetArgs);
-			const hasHooks = migrated.hooks && Object.keys(migrated.hooks).length > 0;
-			if (isSignetOwned(migrated) && hasHooks) {
-				writeHooksFile(hooksPath, migrated);
-			} else if (!isSignetOwned(migrated) && hasHooks) {
+			const cleaned = removeSignetEntries(migrated);
+			const hasHooks = cleaned.hooks && Object.keys(cleaned.hooks).length > 0;
+			if (hasHooks) {
 				const signet = buildHooksFile(signetArgs);
-				const merged: HooksFile = { ...migrated, _signet: true };
-				merged.hooks = { ...(migrated.hooks as Record<string, MatcherGroup[]>) };
+				const merged: HooksFile = { ...cleaned, _signet: true };
+				merged.hooks = { ...(cleaned.hooks as Record<string, MatcherGroup[]>) };
 				for (const key of HOOK_EVENT_KEYS) {
 					const current = merged.hooks[key] ?? [];
 					const ours = signet.hooks?.[key] ?? [];

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -115,17 +115,28 @@ function writeHooksFile(path: string, file: HooksFile): void {
 	atomicWriteJson(path, file);
 }
 
-const SIGNET_HOOK_PREFIXES = [
-	"signet hook session-start",
-	"signet hook user-prompt-submit",
-	"signet hook session-end",
-] as const;
-const SIGNET_HOOK_COMMAND_MARKERS = [" hook session-start", " hook user-prompt-submit", " hook session-end"] as const;
+const SIGNET_HOOK_SUBCOMMANDS = ["session-start", "user-prompt-submit", "session-end"] as const;
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 function isSignetHookCommand(cmd: string): boolean {
-	return (
-		SIGNET_HOOK_PREFIXES.some((s) => cmd.startsWith(s)) || SIGNET_HOOK_COMMAND_MARKERS.some((s) => cmd.includes(s))
-	);
+	const normalized = cmd.trim().replace(/\s+/g, " ");
+	return SIGNET_HOOK_SUBCOMMANDS.some((subcommand) => {
+		const hook = `hook\\s+${escapeRegExp(subcommand)}\\b`;
+		const bare = new RegExp(`^(?:signet|signet\\.(?:cmd|ps1|bat|exe))\\s+${hook}`, "i");
+		if (bare.test(normalized)) return true;
+
+		const quotedBare = new RegExp(`^["'][^"']*[\\\\/]signet(?:\\.(?:cmd|ps1|bat|exe))?["']\\s+${hook}`, "i");
+		if (quotedBare.test(normalized)) return true;
+
+		const nodeShim = new RegExp(
+			`^(?:"[^"]*[\\\\/]?node(?:\\.exe)?"|'[^']*[\\\\/]?node(?:\\.exe)?'|\\S*[\\\\/]?node(?:\\.exe)?)\\s+(?:"[^"]*[\\\\/]signet\\.js"|'[^']*[\\\\/]signet\\.js'|\\S*[\\\\/]signet\\.js)\\s+${hook}`,
+			"i",
+		);
+		return nodeShim.test(normalized);
+	});
 }
 
 function isSignetMatcherGroup(group: unknown): boolean {

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -358,7 +358,8 @@ export class CodexConnector extends BaseConnector {
 				writeHooksFile(hooksPath, merged);
 				warnings.push("Merged Signet hooks into existing hooks.json — existing hooks preserved");
 			} else {
-				writeHooksFile(hooksPath, buildHooksFile(signetArgs));
+				const signet = buildHooksFile(signetArgs);
+				writeHooksFile(hooksPath, { ...cleaned, _signet: true, hooks: signet.hooks });
 			}
 		} else {
 			writeHooksFile(hooksPath, buildHooksFile(signetArgs));

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -122,6 +122,54 @@ function getMemoryDbPath(): string {
 /** Tracks which sessions have already received a full session-start inject. */
 const sessionStartSeen = new Map<string, number>();
 
+const DEFAULT_SESSION_START_MAX_INJECT_TOKENS = 12_000;
+const PREDICTED_CONTEXT_TERM_LIMIT = 6;
+const PREDICTED_CONTEXT_STOPWORDS: ReadonlySet<string> = new Set([
+	"able",
+	"about",
+	"after",
+	"again",
+	"also",
+	"back",
+	"been",
+	"before",
+	"being",
+	"check",
+	"code",
+	"could",
+	"from",
+	"have",
+	"into",
+	"issue",
+	"just",
+	"like",
+	"more",
+	"need",
+	"only",
+	"path",
+	"should",
+	"that",
+	"their",
+	"them",
+	"then",
+	"there",
+	"these",
+	"they",
+	"this",
+	"time",
+	"user",
+	"want",
+	"were",
+	"what",
+	"when",
+	"where",
+	"which",
+	"with",
+	"work",
+	"would",
+	"your",
+]);
+
 /** Sliding window of recently-injected memory IDs per session (prompt-submit). */
 const PROMPT_DEDUP_WINDOW = 5;
 const promptDedupRecent = new Map<string, Array<Set<string>>>();
@@ -882,26 +930,19 @@ function getPredictedContextMemories(
 	policyGroup: string | null = null,
 ): ScoredMemory[] {
 	if (!existsSync(getMemoryDbPath())) return [];
+	if (!project || project.trim().length === 0) return [];
 
 	try {
-		// Get recent session summaries for this project
+		// Get recent session summaries for this project only. Global predictive
+		// FTS is too broad for session-start latency on large memory stores.
 		const summaryRows = getDbAccessor().withReadDb((db) => {
-			if (project) {
-				return db
-					.prepare(
-						`SELECT transcript FROM summary_jobs
-						 WHERE project = ? AND status = 'completed' AND agent_id = ?
-						 ORDER BY created_at DESC LIMIT 5`,
-					)
-					.all(project, agentId) as Array<{ transcript: string }>;
-			}
 			return db
 				.prepare(
 					`SELECT transcript FROM summary_jobs
-					 WHERE status = 'completed' AND agent_id = ?
+					 WHERE project = ? AND status = 'completed' AND agent_id = ?
 					 ORDER BY created_at DESC LIMIT 5`,
 				)
-				.all(agentId) as Array<{ transcript: string }>;
+				.all(project, agentId) as Array<{ transcript: string }>;
 		});
 
 		if (summaryRows.length === 0) return [];
@@ -914,7 +955,7 @@ function getPredictedContextMemories(
 				.toLowerCase()
 				.replace(/[^a-z0-9\s]/g, " ")
 				.split(/\s+/)
-				.filter((w) => w.length >= 4);
+				.filter((w) => w.length >= 4 && !PREDICTED_CONTEXT_STOPWORDS.has(w));
 			const seen = new Set<string>();
 			for (const w of words) {
 				if (seen.has(w)) continue;
@@ -927,7 +968,7 @@ function getPredictedContextMemories(
 		const recurring = [...termFreq.entries()]
 			.filter(([_, count]) => count >= 2)
 			.sort((a, b) => b[1] - a[1])
-			.slice(0, 10)
+			.slice(0, PREDICTED_CONTEXT_TERM_LIMIT)
 			.map(([term]) => term);
 
 		if (recurring.length === 0) return [];
@@ -946,11 +987,12 @@ function getPredictedContextMemories(
 						 JOIN memories m ON memories_fts.rowid = m.rowid
 						 WHERE memories_fts MATCH ?
 						   AND m.is_deleted = 0
+						   AND m.project = ?
 						   ${scope.sql}
 						 ORDER BY bm25(memories_fts)
 						 LIMIT ?`,
 					)
-					.all(ftsQuery, ...scope.args, limit * 2) as Array<{
+					.all(ftsQuery, project, ...scope.args, limit * 2) as Array<{
 					id: string;
 					content: string;
 					type: string;
@@ -1065,6 +1107,7 @@ function getDefaultConfig(): HooksConfig {
 			includeIdentity: true,
 			includeRecentContext: true,
 			recencyBias: 0.7,
+			maxInjectTokens: DEFAULT_SESSION_START_MAX_INJECT_TOKENS,
 		},
 		userPromptSubmit: {
 			enabled: true,
@@ -1544,7 +1587,8 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 		);
 	}
 	const rawTokenBudget =
-		config.maxInjectTokens ?? (config.maxInjectChars ? Math.round(config.maxInjectChars / 4) : 20000);
+		config.maxInjectTokens ??
+		(config.maxInjectChars ? Math.round(config.maxInjectChars / 4) : DEFAULT_SESSION_START_MAX_INJECT_TOKENS);
 	if (rawTokenBudget <= 0) {
 		logger.warn("hooks", "maxInjectTokens must be positive — clamping to 1", {
 			configured: rawTokenBudget,
@@ -1858,7 +1902,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 		traversalConstraints,
 		traversalTimedOut,
 		injectTokens: countTokens(inject),
-		inject,
+		injectChars: inject.length,
 		durationMs: duration,
 	});
 

--- a/packages/daemon/test/hooks.test.ts
+++ b/packages/daemon/test/hooks.test.ts
@@ -862,6 +862,7 @@ hooks:
 	});
 
 	test.serial("predictive context honors shared visibility", async () => {
+		const project = "/tmp/shared-prediction";
 		createMemoryDb([
 			...Array.from({ length: 51 }, (_, i) => ({
 				content: `Noise memory ${i}`,
@@ -874,6 +875,7 @@ hooks:
 				importance: 0.2,
 				agent_id: "agent-owner",
 				visibility: "global",
+				project,
 			},
 		]);
 		upsertAgent("agent-shared", "shared");
@@ -888,7 +890,7 @@ hooks:
 			"job-1",
 			"sess-1",
 			"codex",
-			null,
+			project,
 			"agent-shared",
 			"We discussed shardaware rollout planning for the release train.",
 			"2026-03-25T10:00:00.000Z",
@@ -903,7 +905,7 @@ hooks:
 			"job-2",
 			"sess-2",
 			"codex",
-			null,
+			project,
 			"agent-shared",
 			"We revisited shardaware rollout coordination and deployment notes.",
 			"2026-03-25T11:00:00.000Z",
@@ -914,9 +916,91 @@ hooks:
 		const result = await handleSessionStart({
 			harness: "test",
 			agentId: "agent-shared",
+			project,
 		});
 
 		expect(result.memories.some((memory) => memory.content === "Shared shardaware rollout memory")).toBe(true);
+	});
+
+	test.serial("predictive context ignores recurring stopwords", async () => {
+		const project = "/tmp/stopword-prediction";
+		createMemoryDb([
+			{
+				content: "user path issue check this that with only",
+				importance: 0.1,
+				project,
+			},
+		]);
+
+		const db = openTestDb();
+		for (let i = 1; i <= 2; i += 1) {
+			db.prepare(
+				`INSERT INTO summary_jobs (
+					id, session_key, harness, project, agent_id, transcript,
+					status, attempts, max_attempts, created_at, completed_at
+				) VALUES (?, ?, ?, ?, 'default', ?, 'completed', 1, 3, ?, ?)`,
+			).run(
+				`stopword-job-${i}`,
+				`stopword-sess-${i}`,
+				"codex",
+				project,
+				"user path issue check this that with only",
+				`2026-03-25T1${i}:00:00.000Z`,
+				`2026-03-25T1${i}:01:00.000Z`,
+			);
+		}
+		db.close();
+
+		const result = await handleSessionStart({ harness: "test", project });
+
+		expect(result.memories.some((memory) => memory.content === "user path issue check this that with only")).toBe(
+			false,
+		);
+	});
+
+	test.serial("predictive context is scoped to the active project", async () => {
+		const projectA = "/tmp/prediction-a";
+		const projectB = "/tmp/prediction-b";
+		createMemoryDb([
+			...Array.from({ length: 51 }, (_, i) => ({
+				content: `High priority noise ${i}`,
+				importance: 0.95,
+			})),
+			{
+				content: "Project A shardaware rollout memory",
+				importance: 0.1,
+				project: projectA,
+			},
+			{
+				content: "Project B shardaware rollout memory",
+				importance: 0.1,
+				project: projectB,
+			},
+		]);
+
+		const db = openTestDb();
+		for (let i = 1; i <= 2; i += 1) {
+			db.prepare(
+				`INSERT INTO summary_jobs (
+					id, session_key, harness, project, agent_id, transcript,
+					status, attempts, max_attempts, created_at, completed_at
+				) VALUES (?, ?, ?, ?, 'default', ?, 'completed', 1, 3, ?, ?)`,
+			).run(
+				`project-job-${i}`,
+				`project-sess-${i}`,
+				"codex",
+				projectA,
+				"shardaware rollout coordination stayed active across sessions.",
+				`2026-03-25T1${i}:00:00.000Z`,
+				`2026-03-25T1${i}:01:00.000Z`,
+			);
+		}
+		db.close();
+
+		const result = await handleSessionStart({ harness: "test", project: projectA });
+
+		expect(result.memories.some((memory) => memory.content === "Project A shardaware rollout memory")).toBe(true);
+		expect(result.memories.some((memory) => memory.content === "Project B shardaware rollout memory")).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## Summary

Fixes Codex session-start hook timeouts caused by broad predicted-context memory scans. The daemon was healthy and eventually completed, but session-start could block the event loop long enough for Codex to fall back to static identity.

Root cause: predicted context extracted broad recurring terms from recent summaries, then ran a global `memories_fts MATCH ... ORDER BY bm25(...)` query. On a large memory store, terms like `user`, `with`, `this`, `check`, `path`, and `issue` matched tens of thousands of rows.

## Changes

- Scope predicted-context FTS to the active project and skip it when no project is available.
- Filter broad stopword-like recurring terms before building the predicted-context FTS query.
- Reduce the default session-start inject budget from `20000` to `12000` tokens.
- Stop logging the full session-start inject at info level, replacing it with `injectChars`.
- Align generated Codex `SessionStart` hook timeout with `SIGNET_SESSION_START_TIMEOUT`, rounded to seconds, plus 5 seconds of grace.
- Refresh existing Signet-owned Codex hook entries on reinstall so stale 10 second timeouts are replaced.
- Add regression coverage for stopword-only predicted context, project scoping, Codex timeout generation, and stale hook refresh.
- Update CLI, configuration, and harness docs.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [x] `perf` — performance improvement
- [x] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [x] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: docs

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`). N/A for routine bug fix; validator caveat noted below.
- [x] Agent scoping verified on all new/changed data queries.
- [x] Input/config validation and bounds checks added.
- [x] Error handling and fallback paths tested (no silent swallow).
- [x] Security checks applied to admin/mutation endpoints. N/A, no admin or mutation endpoints changed.
- [x] Docs updated for API/spec/status changes.
- [x] Regression tests added for each bug fix.
- [x] Lint/typecheck/tests pass locally for affected files and packages. Full-repo caveats noted below.

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

No database migrations. Existing Codex users should rerun `signet setup` or `signet connect codex` after upgrading so `~/.codex/hooks.json` is rewritten with the refreshed timeout.

## Testing

- [x] `bun test packages/daemon/test/hooks.test.ts -t "handleSessionStart"`
- [x] `bun test packages/connector-codex/src/config-toml.test.ts`
- [x] `bunx biome check packages/daemon/src/hooks.ts packages/daemon/test/hooks.test.ts packages/connector-codex/src/index.ts packages/connector-codex/src/config-toml.test.ts`
- [x] `bun run --filter @signet/connector-codex typecheck`
- [x] `bun run --filter @signet/connector-codex build`
- [x] `bun run --filter @signet/daemon build`
- [x] Tested against running daemon on `SIGNET_PORT=3851` with a copied real memory DB. Session-start API completed in `4.19s`, returning `103` memories and `45498` injected chars.
- [ ] `bun run lint` full repo: fails on pre-existing package.json formatting drift across unrelated packages.
- [ ] `bun run typecheck` full repo: fails on pre-existing package resolution/type errors in Pi and Oh My Pi packages.
- [ ] `bun scripts/spec-deps-check.ts`: fails on pre-existing `recall-confidence-gate` spec metadata drift.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Before this change, profiling showed `getPredictedContextMemories` dominating session-start time, with the global FTS query taking roughly 25 seconds on a large memory database. The patched daemon path completed the same session-start shape in about 4.2 seconds against a copied real database.

The generated Codex hook timeout now defaults to 20 seconds: 15 seconds for Signet's daemon wait budget plus 5 seconds of harness grace.
