### PR TITLE
fix(ci): align desktop release build prerequisites

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,63 +1,59 @@
 {
-  "name": "@signet/daemon",
-  "version": "0.101.1",
-  "license": "Apache-2.0",
-  "description": "Background daemon for Signet - serves dashboard, API, and memory system",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "bin": {
-    "signet-daemon": "./dist/daemon.js",
-    "signet-mcp": "./dist/mcp-stdio.js"
-  },
-  "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
-    }
-  },
-  "files": [
-    "dist",
-    "dashboard",
-    "skills"
-  ],
-  "scripts": {
-    "copy:skills": "cp -r ../../skills ./skills",
-    "prebuild": "bun run copy:skills",
-    "build": "bun run prebuild && bun run build.ts && bun run build:dashboard",
-    "build:types": "tsc --emitDeclarationOnly --outDir dist",
-    "dev": "bun --watch src/daemon.ts",
-    "start": "cd ../core && bun run build && cd ../daemon && bun src/daemon.ts",
-    "install:service": "bun src/daemon.ts --install",
-    "uninstall:service": "bun src/daemon.ts --uninstall",
-    "test": "bun test",
-    "build:dashboard": "bun ../../scripts/prepare-dashboard-bundle.ts .",
-    "prepublishOnly": "bun run build"
-  },
-  "dependencies": {
-    "@1password/sdk": "^0.3.0",
-    "@hono/node-server": "^1.14.0",
-    "@huggingface/transformers": "^3.4.0",
-    "@modelcontextprotocol/sdk": "^1.26.0",
-    "@signet/core": "workspace:*",
-    "chokidar": "^4.0.0",
-    "graphology": "^0.26.0",
-    "graphology-communities-louvain": "^2.0.2",
-    "graphology-types": "^0.24.8",
-    "cron-parser": "^5.5.0",
-    "hono": "^4.8.0",
-    "js-tiktoken": "^1.0.21",
-    "libsodium-wrappers": "^0.8.2",
-    "onnxruntime-node": "1.21.0",
-    "sharp": "^0.34.1",
-    "umap-js": "^1.4.0",
-    "yaml": "^2.8.2",
-    "zod": "^4.3.6"
-  },
-  "optionalDependencies": {
-    "@signet/native": "workspace:*"
-  },
-  "devDependencies": {
-    "@types/libsodium-wrappers": "^0.8.2"
-  }
+	"name": "@signet/daemon",
+	"version": "0.101.1",
+	"license": "Apache-2.0",
+	"description": "Background daemon for Signet - serves dashboard, API, and memory system",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"bin": {
+		"signet-daemon": "./dist/daemon.js",
+		"signet-mcp": "./dist/mcp-stdio.js"
+	},
+	"exports": {
+		".": {
+			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}
+	},
+	"files": ["dist", "dashboard", "skills"],
+	"scripts": {
+		"copy:skills": "bun ../../scripts/copy-skills.ts",
+		"prebuild": "bun run copy:skills",
+		"build": "bun run prebuild && bun run build.ts && bun run build:dashboard",
+		"build:types": "tsc --emitDeclarationOnly --outDir dist",
+		"dev": "bun --watch src/daemon.ts",
+		"start": "cd ../core && bun run build && cd ../daemon && bun src/daemon.ts",
+		"install:service": "bun src/daemon.ts --install",
+		"uninstall:service": "bun src/daemon.ts --uninstall",
+		"test": "bun test",
+		"build:dashboard": "bun ../../scripts/prepare-dashboard-bundle.ts .",
+		"prepublishOnly": "bun run build"
+	},
+	"dependencies": {
+		"@1password/sdk": "^0.3.0",
+		"@hono/node-server": "^1.14.0",
+		"@huggingface/transformers": "^3.4.0",
+		"@modelcontextprotocol/sdk": "^1.26.0",
+		"@signet/core": "workspace:*",
+		"chokidar": "^4.0.0",
+		"graphology": "^0.26.0",
+		"graphology-communities-louvain": "^2.0.2",
+		"graphology-types": "^0.24.8",
+		"cron-parser": "^5.5.0",
+		"hono": "^4.8.0",
+		"js-tiktoken": "^1.0.21",
+		"libsodium-wrappers": "^0.8.2",
+		"onnxruntime-node": "1.21.0",
+		"sharp": "^0.34.1",
+		"umap-js": "^1.4.0",
+		"yaml": "^2.8.2",
+		"zod": "^4.3.6"
+	},
+	"optionalDependencies": {
+		"@signet/native": "workspace:*"
+	},
+	"devDependencies": {
+		"@types/libsodium-wrappers": "^0.8.2"
+	}
 }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,75 +1,67 @@
 {
-  "name": "@signet/desktop",
-  "version": "0.101.1",
-  "private": true,
-  "description": "Electron desktop distribution layer for Signet",
-  "type": "module",
-  "main": "dist/main.js",
-  "scripts": {
-    "build:tray": "cd ../tray && bun run build",
-    "build:dashboard": "cd ../daemon && bun run build:dashboard",
-    "build:daemon": "cd ../daemon && bun run build",
-    "build:main": "tsc -p tsconfig.json",
-    "stage:runtime": "node scripts/stage-runtime.mjs",
-    "build": "bun run build:main",
-    "build:desktop": "bun run build:tray && bun run build:daemon && bun run stage:runtime && bun run build:main && electron-builder",
-    "dev": "bun run build:tray && bun run build:dashboard && bun run build:main && electron .",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "bun test"
-  },
-  "dependencies": {
-    "@signet/tray": "workspace:*"
-  },
-  "devDependencies": {
-    "@types/node": "^24.5.2",
-    "electron": "^41.2.1",
-    "electron-builder": "^26.8.1",
-    "typescript": "^5.7.0"
-  },
-  "build": {
-    "appId": "ai.signet.app",
-    "productName": "Signet",
-    "artifactName": "Signet-${version}-${os}-${arch}.${ext}",
-    "asar": true,
-    "npmRebuild": false,
-    "files": [
-      "dist/**/*",
-      "package.json"
-    ],
-    "extraResources": [
-      {
-        "from": "resources",
-        "to": "."
-      },
-      {
-        "from": "icons",
-        "to": "icons"
-      }
-    ],
-    "mac": {
-      "category": "public.app-category.productivity",
-      "icon": "icons/icon.icns",
-      "target": [
-        "dmg"
-      ]
-    },
-    "win": {
-      "icon": "icons/icon.ico",
-      "target": [
-        "nsis"
-      ]
-    },
-    "linux": {
-      "category": "Utility",
-      "icon": "icons/icon.png",
-      "target": [
-        "AppImage",
-        "deb"
-      ]
-    },
-    "directories": {
-      "output": "release"
-    }
-  },
-  "author": "Signet AI <hello@signetai.sh>"
+	"name": "@signet/desktop",
+	"version": "0.101.1",
+	"private": true,
+	"description": "Electron desktop distribution layer for Signet",
+	"homepage": "https://signetai.sh",
+	"type": "module",
+	"main": "dist/main.js",
+	"scripts": {
+		"build:core": "cd ../core && bun run build",
+		"build:tray": "cd ../tray && bun run build",
+		"build:dashboard": "cd ../daemon && bun run build:dashboard",
+		"build:daemon": "cd ../daemon && bun run build",
+		"build:main": "tsc -p tsconfig.json",
+		"stage:runtime": "node scripts/stage-runtime.mjs",
+		"build": "bun run build:main",
+		"build:desktop": "bun run build:core && bun run build:tray && bun run build:daemon && bun run stage:runtime && bun run build:main && electron-builder",
+		"dev": "bun run build:tray && bun run build:dashboard && bun run build:main && electron .",
+		"typecheck": "tsc -p tsconfig.json --noEmit",
+		"test": "bun test"
+	},
+	"dependencies": {
+		"@signet/tray": "workspace:*"
+	},
+	"devDependencies": {
+		"@types/node": "^24.5.2",
+		"electron": "^41.2.1",
+		"electron-builder": "^26.8.1",
+		"typescript": "^5.7.0"
+	},
+	"build": {
+		"appId": "ai.signet.app",
+		"productName": "Signet",
+		"artifactName": "Signet-${version}-${os}-${arch}.${ext}",
+		"asar": true,
+		"npmRebuild": false,
+		"files": ["dist/**/*", "package.json"],
+		"extraResources": [
+			{
+				"from": "resources",
+				"to": "."
+			},
+			{
+				"from": "icons",
+				"to": "icons"
+			}
+		],
+		"mac": {
+			"category": "public.app-category.productivity",
+			"icon": "icons/icon.icns",
+			"target": ["dmg"]
+		},
+		"win": {
+			"icon": "icons/icon.ico",
+			"target": ["nsis"]
+		},
+		"linux": {
+			"category": "Utility",
+			"icon": "icons/icon.png",
+			"target": ["AppImage", "deb"]
+		},
+		"directories": {
+			"output": "release"
+		}
+	},
+	"author": "Signet AI <hello@signetai.sh>"
 }

--- a/scripts/copy-skills.ts
+++ b/scripts/copy-skills.ts
@@ -1,0 +1,22 @@
+import { access, cp, mkdir, rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("../", import.meta.url));
+const source = join(root, "skills");
+const target = join(root, "packages/daemon/skills");
+
+try {
+	await access(source);
+} catch (err) {
+	console.error(`Skills source directory does not exist: ${source}`);
+	if (err instanceof Error) {
+		console.error(err.message);
+	}
+	process.exit(1);
+}
+
+await rm(target, { recursive: true, force: true });
+await mkdir(dirname(target), { recursive: true });
+await cp(source, target, { recursive: true, force: true });
+console.log(`Copied skills from ${source} to ${target}`);

--- a/tests/integration/docker-build-regression.test.ts
+++ b/tests/integration/docker-build-regression.test.ts
@@ -5,9 +5,9 @@ import { fileURLToPath } from "node:url";
 
 const rootDir = fileURLToPath(new URL("../../", import.meta.url));
 const dockerfile = readFileSync(join(rootDir, "deploy/docker/Dockerfile"), "utf8");
-const openclawPackageJson = JSON.parse(
-	readFileSync(join(rootDir, "packages/adapters/openclaw/package.json"), "utf8"),
-);
+const openclawPackageJson = JSON.parse(readFileSync(join(rootDir, "packages/adapters/openclaw/package.json"), "utf8"));
+const daemonPackageJson = JSON.parse(readFileSync(join(rootDir, "packages/daemon/package.json"), "utf8"));
+const desktopPackageJson = JSON.parse(readFileSync(join(rootDir, "packages/desktop/package.json"), "utf8"));
 const openclawBuild =
 	typeof openclawPackageJson === "object" &&
 	openclawPackageJson !== null &&
@@ -17,6 +17,33 @@ const openclawBuild =
 	"build" in openclawPackageJson.scripts &&
 	typeof openclawPackageJson.scripts.build === "string"
 		? openclawPackageJson.scripts.build
+		: undefined;
+const daemonCopySkills =
+	typeof daemonPackageJson === "object" &&
+	daemonPackageJson !== null &&
+	"scripts" in daemonPackageJson &&
+	typeof daemonPackageJson.scripts === "object" &&
+	daemonPackageJson.scripts !== null &&
+	"copy:skills" in daemonPackageJson.scripts &&
+	typeof daemonPackageJson.scripts["copy:skills"] === "string"
+		? daemonPackageJson.scripts["copy:skills"]
+		: undefined;
+const desktopBuild =
+	typeof desktopPackageJson === "object" &&
+	desktopPackageJson !== null &&
+	"scripts" in desktopPackageJson &&
+	typeof desktopPackageJson.scripts === "object" &&
+	desktopPackageJson.scripts !== null &&
+	"build:desktop" in desktopPackageJson.scripts &&
+	typeof desktopPackageJson.scripts["build:desktop"] === "string"
+		? desktopPackageJson.scripts["build:desktop"]
+		: undefined;
+const desktopHomepage =
+	typeof desktopPackageJson === "object" &&
+	desktopPackageJson !== null &&
+	"homepage" in desktopPackageJson &&
+	typeof desktopPackageJson.homepage === "string"
+		? desktopPackageJson.homepage
 		: undefined;
 const openclawEntry = readFileSync(join(rootDir, "packages/adapters/openclaw/src/index.ts"), "utf8");
 
@@ -52,5 +79,22 @@ describe("Docker build pipeline regression guard", () => {
 	it("keeps the OpenClaw adapter build Docker-safe when bundling @signet/core", () => {
 		expect(openclawEntry).toContain('from "@signet/core"');
 		expect(openclawBuild).toContain("--external better-sqlite3");
+	});
+
+	it("keeps desktop release builds aligned with workspace dependency order", () => {
+		expect(desktopBuild).toBeDefined();
+		if (!desktopBuild) return;
+		expect(desktopBuild).toStartWith("bun run build:core");
+		expect(desktopBuild).toContain("bun run build:daemon");
+		expect(desktopBuild.indexOf("bun run build:core")).toBeLessThan(desktopBuild.indexOf("bun run build:daemon"));
+	});
+
+	it("uses a cross-platform skills copy script for daemon builds", () => {
+		expect(daemonCopySkills).toBe("bun ../../scripts/copy-skills.ts");
+		expect(daemonCopySkills).not.toContain("cp -r");
+	});
+
+	it("keeps desktop Linux package metadata complete for deb generation", () => {
+		expect(desktopHomepage).toBe("https://signetai.sh");
 	});
 });


### PR DESCRIPTION
## Summary

Fixes the failing tag-triggered Desktop Build workflow on main.

The release workflow was invoking `packages/desktop` directly, but that script built the daemon before building `@signet/core`. On clean CI runners, `@signet/core` had no `dist/` output yet, so daemon bundling failed with `Could not resolve: "@signet/core"`.

Windows also failed earlier in daemon prebuild because `copy:skills` used shell-specific `cp -r` from a Git Bash environment where that option was not accepted. After the first CI rerun got past those failures, Linux deb packaging exposed one more metadata guardrail: electron-builder requires package homepage metadata.

## Changes

- Add `packages/desktop` `build:core` and run it before `build:daemon` in `build:desktop`.
- Replace daemon `cp -r` skills copying with a cross-platform Bun script.
- Add desktop package homepage metadata required by Linux deb generation.
- Add regression coverage so desktop release builds keep `@signet/core` before daemon builds, daemon skills copying stays cross-platform, and Linux package metadata stays present.

## Validation

- `bunx biome check scripts/copy-skills.ts tests/integration/docker-build-regression.test.ts packages/desktop/package.json packages/daemon/package.json`
- `bun test ./tests/integration/docker-build-regression.test.ts`
- `cd packages/desktop && bun run build:core && bun run build:daemon && bun run stage:runtime && bun run build:main`
- `cd packages/desktop && bun run build:desktop -- --x64`

The Linux desktop packaging path now gets past the CI failure points locally. I also triggered the Desktop Build workflow manually on this branch to validate the OS matrix.

## Readiness checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
  - Routine CI/build fix, not spec-governed behavior.
- [x] Agent scoping verified on all new/changed data queries
  - No data queries changed.
- [x] Input/config validation and bounds checks added
  - No external inputs or config bounds changed.
- [x] Error handling and fallback paths tested (no silent swallow)
  - Copy script fails explicitly if the skills source directory is missing.
- [x] Security checks applied to admin/mutation endpoints
  - No endpoints changed.
- [x] Docs updated for API/spec/status changes
  - No API/spec/status behavior changed.
- [x] Regression tests added for each bug fix
  - Added guards for desktop build ordering, cross-platform skills copying, and desktop package homepage metadata.
- [x] Lint/typecheck/tests pass locally
  - See validation above.