### PR TITLE
refactor(memory): align recall and remember surfaces

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2003,7 +2003,8 @@ compatibility fields during the transition period:
     "totalReturned": 0,
     "hasSupplementary": false,
     "noHits": true
-  }
+  },
+  "message": "No matching memories found."
 }
 ```
 
@@ -2014,7 +2015,9 @@ Special no-op cases preserve the same shape and add a flag:
 
 `memories` and `count` are legacy compatibility aliases for older hook
 consumers and will mirror `results` and `results.length` during the
-transition period.
+transition period. `message` is the canonical formatted recall brief used by
+thin harness hooks so connectors do not reimplement ranking or presentation
+rules.
 
 ### POST /api/hooks/pre-compaction
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -49,7 +49,9 @@ Tool Reference
 --------------
 
 All tools are defined in `packages/daemon/src/mcp/tools.ts`. Tool handlers
-call the daemon's HTTP API internally — they don't duplicate business logic.
+call the daemon's HTTP API internally and use the shared recall/remember
+surface helpers from `@signet/core` so MCP, CLI, and harness integrations do
+not drift into separate request shapes or result formatting.
 
 ### memory_search
 
@@ -108,8 +110,9 @@ context, and no-hit handling. The tool still reads from
 
 ### memory_store
 
-Save a new memory to the database. Tags are prepended in `[tag1,tag2]: `
-format before being sent to the daemon.
+Save a new memory to the database. Tags, structured graph payloads, hints,
+and transcripts are forwarded as request metadata instead of being folded into
+memory text. This keeps MCP aligned with CLI and harness remember behavior.
 
 **Parameters:**
 
@@ -119,6 +122,10 @@ format before being sent to the daemon.
 | `type` | string | no | Memory type (`fact`, `preference`, `decision`, etc.) |
 | `importance` | number | no | Importance score 0–1 |
 | `tags` | string | no | Comma-separated tags for categorization |
+| `pinned` | boolean | no | Pin this memory so it bypasses decay |
+| `hints` | string[] | no | Prospective recall hints and alternate phrasings |
+| `transcript` | string | no | Raw source text to preserve alongside the extracted memory |
+| `structured` | object | no | Pre-extracted entity/aspect/attribute graph data for structured remembering |
 
 **Returns:** The created memory object with its assigned ID.
 

--- a/packages/adapters/openclaw/src/index.test.ts
+++ b/packages/adapters/openclaw/src/index.test.ts
@@ -343,7 +343,7 @@ describe("signet-memory-openclaw lifecycle hooks", () => {
 		expect(getHits("/api/hooks/session-start")).toBe(1);
 	});
 
-	it("normalizes memory_store tags to a comma string", async () => {
+	it("forwards memory_store tags as request metadata", async () => {
 		const id = await memoryStore("save this", {
 			daemonUrl: "http://daemon.test",
 			tags: ["alpha", " beta ", ""],
@@ -1103,11 +1103,11 @@ describe("signet-memory-openclaw lifecycle hooks", () => {
 
 		await beforePromptBuild?.(
 			{
-				prompt: "real user question\n<signet-memory source=\"bad\">truncated injected text",
+				prompt: 'real user question\n<signet-memory source="bad">truncated injected text',
 				messages: [
 					{
 						role: "user",
-						content: "real user question\n<signet-memory source=\"bad\">truncated injected text",
+						content: 'real user question\n<signet-memory source="bad">truncated injected text',
 					},
 				],
 			},
@@ -1812,9 +1812,7 @@ describe("injectBillingBlock", () => {
 	it("prepends billing block to array system field", () => {
 		const body: Record<string, unknown> = {
 			model: "claude-sonnet-4-20250514",
-			system: [
-				{ type: "text", text: "You are a helpful assistant." },
-			],
+			system: [{ type: "text", text: "You are a helpful assistant." }],
 			messages: [{ role: "user", content: "hello" }],
 		};
 		expect(injectBillingBlock(body)).toBeTrue();
@@ -2040,14 +2038,14 @@ describe("swapAuthHeaders", () => {
 		};
 		swapAuthHeaders(headers, "sk-ant-oat01-oauth-token");
 		expect(headers["x-api-key"]).toBeUndefined();
-		expect(headers["authorization"]).toBe("Bearer sk-ant-oat01-oauth-token");
+		expect(headers.authorization).toBe("Bearer sk-ant-oat01-oauth-token");
 		expect(headers["content-type"]).toBe("application/json");
 	});
 
 	it("sets bearer token even without existing api key", () => {
 		const headers: Record<string, string> = {};
 		swapAuthHeaders(headers, "sk-ant-oat01-token");
-		expect(headers["authorization"]).toBe("Bearer sk-ant-oat01-token");
+		expect(headers.authorization).toBe("Bearer sk-ant-oat01-token");
 	});
 });
 
@@ -2134,9 +2132,7 @@ describe("installFetchSanitizer", () => {
 			});
 			expect(capturedHeaders).toHaveLength(1);
 			// No OAuth token in test env → original x-api-key must be preserved
-			expect(
-				capturedHeaders[0]["x-api-key"] ?? capturedHeaders[0]["authorization"],
-			).toBeDefined();
+			expect(capturedHeaders[0]["x-api-key"] ?? capturedHeaders[0].authorization).toBeDefined();
 		} finally {
 			remove();
 		}
@@ -2203,9 +2199,10 @@ describe("installSdkSanitizer", () => {
 		}
 	});
 
-	it("resolveAnthropicBase returns undefined in test environment", () => {
+	it("installSdkSanitizer is safe when the SDK is absent or present", () => {
 		const { resolveAnthropicBase, installSdkSanitizer } = _sanitization;
-		expect(resolveAnthropicBase()).toBeUndefined();
+		const base = resolveAnthropicBase();
+		expect(base === undefined || typeof base === "function").toBeTrue();
 		const cleanup = installSdkSanitizer();
 		cleanup();
 	});
@@ -2229,7 +2226,10 @@ describe("cleanupTimedMap regression", () => {
 		cleanupTimedMap(empty, 1000, 500);
 		expect(empty.size).toBe(0);
 
-		const allExpired = new Map<string, number>([["a", 100], ["b", 200]]);
+		const allExpired = new Map<string, number>([
+			["a", 100],
+			["b", 200],
+		]);
 		cleanupTimedMap(allExpired, 1000, 500);
 		expect(allExpired.size).toBe(0);
 	});

--- a/packages/adapters/openclaw/src/index.ts
+++ b/packages/adapters/openclaw/src/index.ts
@@ -14,9 +14,15 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import {
 	STATIC_IDENTITY_SESSION_START_TIMEOUT_STATUS,
+	applyRecallScoreThreshold,
+	buildRecallRequestBody,
+	buildRememberRequestBody,
+	formatRecallText,
+	parseRecallPayload,
 	readStaticIdentity,
 	resolveSessionStartTimeoutMs,
 } from "@signet/core";
+import type { RecallPayload, RecallRow } from "@signet/core";
 import { Type } from "@sinclair/typebox";
 import type {
 	OpenClawPluginApi,
@@ -287,15 +293,6 @@ interface MemoryRecord {
 	who: string | null;
 	created_at: string;
 	updated_at: string;
-}
-
-interface RecallResult {
-	id: string;
-	content: string;
-	type: string;
-	importance: number;
-	score: number;
-	created_at: string;
 }
 
 interface MarketplaceToolEntry {
@@ -630,6 +627,27 @@ export async function onSessionEnd(
 // Tool operations (call v2 daemon memory APIs directly)
 // ============================================================================
 
+export async function memoryRecall(
+	query: string,
+	options: {
+		daemonUrl?: string;
+		limit?: number;
+		type?: string;
+		minScore?: number;
+	} = {},
+): Promise<RecallPayload | null> {
+	const daemonUrl = options.daemonUrl || DEFAULT_DAEMON_URL;
+	const result = await daemonFetch<unknown>(daemonUrl, "/api/memory/recall", {
+		method: "POST",
+		body: buildRecallRequestBody(query, {
+			limit: options.limit ?? 10,
+			type: options.type,
+		}),
+		timeout: READ_TIMEOUT,
+	});
+	return result ? (applyRecallScoreThreshold(result, options.minScore) as RecallPayload) : null;
+}
+
 export async function memorySearch(
 	query: string,
 	options: {
@@ -638,21 +656,10 @@ export async function memorySearch(
 		type?: string;
 		minScore?: number;
 	} = {},
-): Promise<RecallResult[]> {
-	const daemonUrl = options.daemonUrl || DEFAULT_DAEMON_URL;
-	const result = await daemonFetch<{ results: RecallResult[] }>(daemonUrl, "/api/memory/recall", {
-		method: "POST",
-		body: {
-			query,
-			limit: options.limit || 10,
-			type: options.type,
-			min_score: options.minScore,
-		},
-		timeout: READ_TIMEOUT,
-	});
-	return result?.results || [];
+): Promise<RecallRow[]> {
+	const result = await memoryRecall(query, options);
+	return result ? parseRecallPayload(result).rows : [];
 }
-
 export async function memoryStore(
 	content: string,
 	options: {
@@ -666,19 +673,12 @@ export async function memoryStore(
 	const daemonUrl = options.daemonUrl || DEFAULT_DAEMON_URL;
 	const result = await daemonFetch<{ id?: string; memoryId?: string }>(daemonUrl, "/api/memory/remember", {
 		method: "POST",
-		body: {
-			content,
+		body: buildRememberRequestBody(content, {
 			type: options.type,
 			importance: options.importance,
-			tags:
-				typeof options.tags === "string"
-					? options.tags
-					: options.tags
-							?.map((tag) => tag.trim())
-							.filter((tag) => tag.length > 0)
-							.join(","),
+			tags: options.tags,
 			who: options.who || "openclaw",
-		},
+		}),
 		timeout: WRITE_TIMEOUT,
 	});
 	return result?.id || result?.memoryId || null;
@@ -837,7 +837,7 @@ export async function recall(
 		type?: string;
 		minScore?: number;
 	} = {},
-): Promise<RecallResult[]> {
+): Promise<RecallRow[]> {
 	return memorySearch(query, options);
 }
 
@@ -941,11 +941,7 @@ function injectBillingBlock(body: Record<string, unknown>): boolean {
 	if (Array.isArray(system)) {
 		// Check if already injected
 		const first = system[0] as Record<string, unknown> | undefined;
-		if (
-			first &&
-			typeof first.text === "string" &&
-			first.text.includes("x-anthropic-billing-header")
-		) {
+		if (first && typeof first.text === "string" && first.text.includes("x-anthropic-billing-header")) {
 			return false;
 		}
 		system.unshift({ ...BILLING_BLOCK });
@@ -953,10 +949,7 @@ function injectBillingBlock(body: Record<string, unknown>): boolean {
 	}
 	if (typeof system === "string") {
 		// Convert string form to array with billing block prepended
-		body.system = [
-			{ ...BILLING_BLOCK },
-			{ type: "text", text: system },
-		];
+		body.system = [{ ...BILLING_BLOCK }, { type: "text", text: system }];
 		return true;
 	}
 	// No system field — add one with just the routing block
@@ -1075,15 +1068,14 @@ function swapAuthHeaders(headers: Record<string, string>, oauthToken: string): v
 			delete headers[key];
 		}
 	}
-	headers["authorization"] = `Bearer ${oauthToken}`;
+	headers.authorization = `Bearer ${oauthToken}`;
 }
 
 function installFetchSanitizer(): () => void {
 	const original = globalThis.fetch;
 	const sanitized: typeof globalThis.fetch = (input, init) => {
 		if (init?.body && typeof init.body === "string") {
-			const url = typeof input === "string" ? input
-				: input instanceof URL ? input.href : input.url;
+			const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
 			if (isAnthropicApiUrl(url)) {
 				const carrier = { body: init.body };
 				sanitizeRequest(carrier);
@@ -1095,9 +1087,13 @@ function installFetchSanitizer(): () => void {
 				const headers: Record<string, string> = {};
 				if (init.headers) {
 					if (init.headers instanceof Headers) {
-						init.headers.forEach((v, k) => { if (!skip.has(k.toLowerCase())) headers[k] = v; });
+						init.headers.forEach((v, k) => {
+							if (!skip.has(k.toLowerCase())) headers[k] = v;
+						});
 					} else if (Array.isArray(init.headers)) {
-						for (const pair of init.headers) { if (!skip.has(pair[0].toLowerCase())) headers[pair[0]] = pair[1]; }
+						for (const pair of init.headers) {
+							if (!skip.has(pair[0].toLowerCase())) headers[pair[0]] = pair[1];
+						}
 					} else {
 						for (const [k, v] of Object.entries(init.headers as Record<string, string>)) {
 							if (!skip.has(k.toLowerCase())) headers[k] = v;
@@ -1140,9 +1136,7 @@ function resolveAnthropicBase(): (new (...args: unknown[]) => unknown) | undefin
 				const mod = cache[key];
 				const exports = mod?.exports as Record<string, unknown> | undefined;
 				if (!exports) continue;
-				const Base = (exports.BaseAnthropic ?? exports.Anthropic) as
-					| (new (...args: unknown[]) => unknown)
-					| undefined;
+				const Base = (exports.BaseAnthropic ?? exports.Anthropic) as (new (...args: unknown[]) => unknown) | undefined;
 				if (Base?.prototype && typeof Base.prototype.prepareRequest === "function") {
 					return Base;
 				}
@@ -1154,9 +1148,7 @@ function resolveAnthropicBase(): (new (...args: unknown[]) => unknown) | undefin
 	try {
 		// eslint-disable-next-line @typescript-eslint/no-require-imports
 		const sdk = require("@anthropic-ai/sdk") as Record<string, unknown>;
-		const Base = (sdk.BaseAnthropic ?? sdk.Anthropic) as
-			| (new (...args: unknown[]) => unknown)
-			| undefined;
+		const Base = (sdk.BaseAnthropic ?? sdk.Anthropic) as (new (...args: unknown[]) => unknown) | undefined;
 		if (Base?.prototype && typeof Base.prototype.prepareRequest === "function") {
 			return Base;
 		}
@@ -1167,10 +1159,7 @@ function resolveAnthropicBase(): (new (...args: unknown[]) => unknown) | undefin
 }
 
 function installSdkSanitizer(): () => void {
-	type PrepareRequestFn = (
-		request: RequestInit,
-		context: { url: string; options: unknown },
-	) => Promise<void>;
+	type PrepareRequestFn = (request: RequestInit, context: { url: string; options: unknown }) => Promise<void>;
 
 	let Base: (new (...args: unknown[]) => unknown) | undefined;
 	let original: PrepareRequestFn | undefined;
@@ -1180,13 +1169,14 @@ function installSdkSanitizer(): () => void {
 		const found = resolveAnthropicBase();
 		if (!found) return false;
 		Base = found;
-		original = Base.prototype.prepareRequest as PrepareRequestFn;
+		const previous = Base.prototype.prepareRequest as PrepareRequestFn;
+		original = previous;
 		Base.prototype.prepareRequest = async function (
 			request: RequestInit,
 			context: { url: string; options: unknown },
 		): Promise<void> {
 			sanitizeRequest(request as { body?: unknown });
-			return original!.call(this, request, context);
+			return previous.call(this, request, context);
 		};
 		return true;
 	}
@@ -1198,13 +1188,19 @@ function installSdkSanitizer(): () => void {
 		timer = setInterval(() => {
 			attempts++;
 			if (applyPatch() || attempts >= 30) {
-				if (timer) { clearInterval(timer); timer = null; }
+				if (timer) {
+					clearInterval(timer);
+					timer = null;
+				}
 			}
 		}, 200);
 	}
 
 	return () => {
-		if (timer) { clearInterval(timer); timer = null; }
+		if (timer) {
+			clearInterval(timer);
+			timer = null;
+		}
 		if (Base && original) {
 			Base.prototype.prepareRequest = original;
 		}
@@ -1524,648 +1520,663 @@ const signetPlugin = {
 			writeRegistered(true);
 			claimed = true;
 
-		// Request normalization — two layers for coverage: fetch wrapper +
-		// SDK prototype patch.
-		const removeFetchSanitizer = installFetchSanitizer();
-		const removeSdkSanitizer = installSdkSanitizer();
+			// Request normalization — two layers for coverage: fetch wrapper +
+			// SDK prototype patch.
+			const removeFetchSanitizer = installFetchSanitizer();
+			const removeSdkSanitizer = installSdkSanitizer();
 
-		// Instance-scoped health state (safe for multi-register)
-		let daemonReachable = true;
-		let knownPid: number | null = null;
-		let healthTimer: ReturnType<typeof setInterval> | null = null;
-		let marketplaceProxyTimer: ReturnType<typeof setInterval> | null = null;
-		const marketplaceProxyNames = new Set<string>();
+			// Instance-scoped health state (safe for multi-register)
+			let daemonReachable = true;
+			let knownPid: number | null = null;
+			let healthTimer: ReturnType<typeof setInterval> | null = null;
+			let marketplaceProxyTimer: ReturnType<typeof setInterval> | null = null;
+			const marketplaceProxyNames = new Set<string>();
 
-		api.logger.info(`signet-memory: registered (daemon: ${daemonUrl})`);
+			api.logger.info(`signet-memory: registered (daemon: ${daemonUrl})`);
 
-		// Fire-and-forget startup health check (also captures initial PID)
-		getDaemonPid(daemonUrl).then((pid) => {
-			daemonReachable = pid !== null;
-			knownPid = pid;
-			if (!daemonReachable) {
-				api.logger.warn(
-					`signet-memory: daemon unreachable at ${daemonUrl}. Memory tools will silently no-op until daemon is running.`,
-				);
-			}
-		});
-
-		// ==================================================================
-		// Tools
-		// ==================================================================
-
-		api.registerTool(
-			{
-				name: "memory_search",
-				label: "Memory Search",
-				description: "Search memories using hybrid vector + keyword search",
-				parameters: Type.Object({
-					query: Type.String({ description: "Search query text" }),
-					limit: Type.Optional(
-						Type.Number({
-							description: "Max results to return (default 10)",
-						}),
-					),
-					type: Type.Optional(
-						Type.String({
-							description: "Filter by memory type",
-						}),
-					),
-					min_score: Type.Optional(
-						Type.Number({
-							description: "Minimum relevance score threshold",
-						}),
-					),
-				}),
-				async execute(_toolCallId, params) {
-					const { query, limit, type, min_score } = params as {
-						query: string;
-						limit?: number;
-						type?: string;
-						min_score?: number;
-					};
-					try {
-						const results = await memorySearch(query, {
-							...opts,
-							limit,
-							type,
-							minScore: min_score,
-						});
-						if (results.length === 0) {
-							return textResult("No relevant memories found.", {
-								count: 0,
-							});
-						}
-						const text = results
-							.map((r, i) => `${i + 1}. ${r.content} (score: ${((r.score ?? 0) * 100).toFixed(0)}%, id: ${r.id})`)
-							.join("\n");
-						return textResult(`Found ${results.length} memories:\n\n${text}`, {
-							count: results.length,
-							memories: results,
-						});
-					} catch (err) {
-						return textResult(`Memory search failed: ${String(err)}`, { error: String(err) });
-					}
-				},
-			},
-			{ name: "memory_search" },
-		);
-
-		api.registerTool(
-			{
-				name: "memory_store",
-				label: "Memory Store",
-				description: "Save a new memory",
-				parameters: Type.Object({
-					content: Type.String({
-						description: "Memory content to save",
-					}),
-					type: Type.Optional(
-						Type.String({
-							description: "Memory type (fact, preference, decision, etc.)",
-						}),
-					),
-					importance: Type.Optional(
-						Type.Number({
-							description: "Importance score 0-1",
-						}),
-					),
-					tags: Type.Optional(
-						Type.String({
-							description: "Comma-separated tags for categorization",
-						}),
-					),
-				}),
-				async execute(_toolCallId, params) {
-					const { content, type, importance, tags } = params as {
-						content: string;
-						type?: string;
-						importance?: number;
-						tags?: string;
-					};
-					try {
-						const id = await memoryStore(content, {
-							...opts,
-							type,
-							importance,
-							tags,
-						});
-						if (id) {
-							return textResult(`Memory saved successfully (id: ${id})`, { id });
-						}
-						return textResult("Failed to save memory.", {
-							error: "no id returned",
-						});
-					} catch (err) {
-						return textResult(`Memory store failed: ${String(err)}`, { error: String(err) });
-					}
-				},
-			},
-			{ name: "memory_store" },
-		);
-
-		api.registerTool(
-			{
-				name: "memory_get",
-				label: "Memory Get",
-				description: "Get a single memory by its ID",
-				parameters: Type.Object({
-					id: Type.String({
-						description: "Memory ID to retrieve",
-					}),
-				}),
-				async execute(_toolCallId, params) {
-					const { id } = params as { id: string };
-					try {
-						const memory = await memoryGet(id, opts);
-						if (memory) {
-							return textResult(JSON.stringify(memory, null, 2), {
-								memory,
-							});
-						}
-						return textResult(`Memory ${id} not found.`, {
-							error: "not found",
-						});
-					} catch (err) {
-						return textResult(`Memory get failed: ${String(err)}`, { error: String(err) });
-					}
-				},
-			},
-			{ name: "memory_get" },
-		);
-
-		api.registerTool(
-			{
-				name: "memory_list",
-				label: "Memory List",
-				description: "List memories with optional filters",
-				parameters: Type.Object({
-					limit: Type.Optional(
-						Type.Number({
-							description: "Max results (default 50, max 50)",
-						}),
-					),
-					offset: Type.Optional(Type.Number({ description: "Pagination offset" })),
-					type: Type.Optional(
-						Type.String({
-							description: "Filter by memory type",
-						}),
-					),
-				}),
-				async execute(_toolCallId, params) {
-					const { limit, offset, type } = params as {
-						limit?: number;
-						offset?: number;
-						type?: string;
-					};
-					const ITEM_CHAR_LIMIT = 500;
-					const TOTAL_CHAR_BUDGET = 8000;
-					try {
-						const result = await memoryList({
-							...opts,
-							limit: Math.min(limit ?? 50, 50),
-							offset,
-							type,
-						});
-						const lines: string[] = [];
-						let totalChars = 0;
-						for (const m of result.memories) {
-							const content =
-								m.content.length > ITEM_CHAR_LIMIT ? `${m.content.slice(0, ITEM_CHAR_LIMIT)}[truncated]` : m.content;
-							const line = `- [${m.type}] ${content} (id: ${m.id})`;
-							if (totalChars + line.length > TOTAL_CHAR_BUDGET) break;
-							lines.push(line);
-							totalChars += line.length;
-						}
-						return textResult(`${lines.length} of ${result.memories.length} memories:\n\n${lines.join("\n")}`, {
-							count: result.memories.length,
-							shown: lines.length,
-							stats: result.stats,
-						});
-					} catch (err) {
-						return textResult(`Memory list failed: ${String(err)}`, { error: String(err) });
-					}
-				},
-			},
-			{ name: "memory_list" },
-		);
-
-		api.registerTool(
-			{
-				name: "memory_modify",
-				label: "Memory Modify",
-				description: "Edit an existing memory by ID",
-				parameters: Type.Object({
-					id: Type.String({
-						description: "Memory ID to modify",
-					}),
-					reason: Type.String({
-						description: "Why this edit is being made",
-					}),
-					content: Type.Optional(Type.String({ description: "New content" })),
-					type: Type.Optional(Type.String({ description: "New type" })),
-					importance: Type.Optional(Type.Number({ description: "New importance" })),
-					tags: Type.Optional(
-						Type.String({
-							description: "New tags (comma-separated)",
-						}),
-					),
-				}),
-				async execute(_toolCallId, params) {
-					const { id, reason, content, type, importance, tags } = params as {
-						id: string;
-						reason: string;
-						content?: string;
-						type?: string;
-						importance?: number;
-						tags?: string;
-					};
-					try {
-						const ok = await memoryModify(id, { content, type, importance, tags, reason }, opts);
-						return textResult(ok ? `Memory ${id} updated.` : `Failed to update memory ${id}.`, { success: ok });
-					} catch (err) {
-						return textResult(`Memory modify failed: ${String(err)}`, { error: String(err) });
-					}
-				},
-			},
-			{ name: "memory_modify" },
-		);
-
-		api.registerTool(
-			{
-				name: "memory_forget",
-				label: "Memory Forget",
-				description: "Soft-delete a memory by ID",
-				parameters: Type.Object({
-					id: Type.String({
-						description: "Memory ID to forget",
-					}),
-					reason: Type.String({
-						description: "Why this memory should be forgotten",
-					}),
-				}),
-				async execute(_toolCallId, params) {
-					const { id, reason } = params as {
-						id: string;
-						reason: string;
-					};
-					try {
-						const ok = await memoryForget(id, {
-							...opts,
-							reason,
-						});
-						return textResult(ok ? `Memory ${id} forgotten.` : `Failed to forget memory ${id}.`, { success: ok });
-					} catch (err) {
-						return textResult(`Memory forget failed: ${String(err)}`, { error: String(err) });
-					}
-				},
-			},
-			{ name: "memory_forget" },
-		);
-
-		api.registerTool(
-			{
-				name: "mcp_server_list",
-				label: "Tool Server List",
-				description: "List installed external Tool Servers (MCP) and discover routed tools.",
-				parameters: Type.Object({
-					refresh: Type.Optional(
-						Type.Boolean({
-							description: "Refresh live tool catalogs",
-						}),
-					),
-				}),
-				async execute(_toolCallId, params) {
-					const refresh = (params as { refresh?: boolean }).refresh;
-					try {
-						const result = await marketplaceToolList({
-							...opts,
-							refresh,
-						});
-						if (!result) {
-							return textResult("Failed to load Tool Server catalog.", {
-								error: "daemon unavailable",
-							});
-						}
-
-						const lines = result.tools
-							.slice(0, 30)
-							.map((tool) => `${tool.serverId}:${tool.toolName} - ${tool.description}`);
-
-						return textResult(
-							result.tools.length > 0
-								? `Available routed tools (${result.tools.length}):\n\n${lines.join("\n")}`
-								: "No routed tool server tools are currently available.",
-							{
-								count: result.count,
-								servers: result.servers,
-								tools: result.tools,
-							},
-						);
-					} catch (err) {
-						return textResult(`Tool server list failed: ${String(err)}`, {
-							error: String(err),
-						});
-					}
-				},
-			},
-			{ name: "mcp_server_list" },
-		);
-
-		api.registerTool(
-			{
-				name: "mcp_server_call",
-				label: "Tool Server Call",
-				description: "Invoke a routed tool from an installed external Tool Server (MCP).",
-				parameters: Type.Object({
-					server_id: Type.String({
-						description: "Installed Tool Server id",
-					}),
-					tool: Type.String({
-						description: "Tool name exposed by that server",
-					}),
-					args: Type.Optional(Type.Object({}, { additionalProperties: true })),
-				}),
-				async execute(_toolCallId, params) {
-					const payload = params as {
-						server_id: string;
-						tool: string;
-						args?: Record<string, unknown>;
-					};
-					try {
-						const result = await marketplaceToolCall(payload.server_id, payload.tool, payload.args ?? {}, opts);
-						if (!result?.success) {
-							return textResult(`Tool server call failed: ${result?.error ?? "unknown error"}`, {
-								error: result?.error ?? "unknown",
-							});
-						}
-
-						const text = typeof result.result === "string" ? result.result : JSON.stringify(result.result, null, 2);
-						return textResult(text, { result: result.result });
-					} catch (err) {
-						return textResult(`Tool server call failed: ${String(err)}`, {
-							error: String(err),
-						});
-					}
-				},
-			},
-			{ name: "mcp_server_call" },
-		);
-
-		const marketplaceProxyNameByToolKey = new Map<string, string>();
-
-		const refreshMarketplaceProxyTools = (): Promise<void> =>
-			registerMarketplaceProxyTools(api, opts, marketplaceProxyNames, marketplaceProxyNameByToolKey)
-				.then((result) => {
-					if (result.registeredNow > 0) {
-						api.logger.info(
-							`signet-memory: registered ${result.registeredNow} marketplace proxy tools (${result.total} total)`,
-						);
-					}
-				})
-				.catch((error) => {
-					api.logger.warn(`signet-memory: failed to register marketplace proxy tools: ${String(error)}`);
-				});
-
-		void refreshMarketplaceProxyTools();
-		marketplaceProxyTimer = setInterval(() => {
-			void refreshMarketplaceProxyTools();
-		}, 15_000);
-
-		// ==================================================================
-		// Lifecycle hooks
-		// ==================================================================
-
-		const claimedSessions = new Set<string>();
-		const sessionlessSessionStarts = new Map<string, number>();
-		// Maps scoped agent/session keys → {count, at} for per-turn idempotency. Entries are
-		// evicted on agent_end or lazily after SESSION_TURN_TTL_MS so crash/
-		// SIGKILL sessions don't accumulate indefinitely.
-		const SESSION_TURN_TTL_MS = 4 * 60 * 60 * 1000;
-		const injectedTurns = new Map<string, { count: number; at: number }>();
-		// Tracks turn signatures currently in-flight — provides a synchronous
-		// guard so concurrent before_prompt_build / before_agent_start calls on
-		// the same event-loop tick don't both pass the guard before either await
-		// completes (injectedTurns is only written after the daemon responds).
-		const inFlightTurns = new Set<string>();
-		const beforeCompactions = new Map<string, number>();
-		const afterCompactions = new Map<string, number>();
-
-		// Mid-session checkpoint extraction: track turns per session and
-		// fire a checkpoint extract after every N turns. Prevents long-lived
-		// sessions (Discord bots, persistent agents) from going invisible.
-		const CHECKPOINT_TURN_THRESHOLD = 20;
-		// State per scoped session key: turn count, last seen message count (for
-		// dedup), and timestamp (for TTL eviction when agent_end never fires).
-		const checkpointTurns = new Map<string, { count: number; lastMsgCount: number | undefined; at: number }>();
-		// Legacy dedup: when both before_prompt_build and before_agent_start fire
-		// on the same turn without the messages field (older OpenClaw), only one
-		// should count the turn. Generation counters: bpb increments bpbGen each
-		// call; bas tracks the last generation it consumed in basGen. If
-		// basGen < bpbGen, bas is covered and skips the count (then syncs basGen).
-		// Avoids the stale-flag problem where a missed bas leaves the flag set
-		// for the next turn.
-		const bpbGen = new Map<string, number>();
-		const basGen = new Map<string, number>();
-
-		const maybeFireCheckpoint = (
-			sessionKey: string | undefined,
-			agentId: string | undefined,
-			project: string | undefined,
-			sessionFile: string | undefined,
-			msgCount: number | undefined,
-			messages: readonly unknown[] | undefined,
-		): void => {
-			const scopedKey = buildScopedSessionKey(sessionKey, agentId);
-			if (!scopedKey || !sessionKey) return;
-
-			const now = Date.now();
-			const state = checkpointTurns.get(scopedKey);
-
-			// Lazy TTL: evict stale entries for sessions that ended without agent_end.
-			if (state && now - state.at > SESSION_TURN_TTL_MS) {
-				checkpointTurns.delete(scopedKey);
-			}
-
-			// Dedup: before_agent_start and before_prompt_build both fire on the
-			// same turn when both are registered. Use message count when available
-			// (modern OpenClaw). Legacy path relies on bpbFired flag — see below.
-			if (msgCount !== undefined && checkpointTurns.get(scopedKey)?.lastMsgCount === msgCount) return;
-
-			const newCount = (checkpointTurns.get(scopedKey)?.count ?? 0) + 1;
-			checkpointTurns.set(scopedKey, {
-				count: newCount >= CHECKPOINT_TURN_THRESHOLD ? 0 : newCount,
-				lastMsgCount: msgCount,
-				at: now,
+			// Fire-and-forget startup health check (also captures initial PID)
+			getDaemonPid(daemonUrl).then((pid) => {
+				daemonReachable = pid !== null;
+				knownPid = pid;
+				if (!daemonReachable) {
+					api.logger.warn(
+						`signet-memory: daemon unreachable at ${daemonUrl}. Memory tools will silently no-op until daemon is running.`,
+					);
+				}
 			});
 
-			if (newCount < CHECKPOINT_TURN_THRESHOLD) return;
+			// ==================================================================
+			// Tools
+			// ==================================================================
 
-			// Inline transcript fallback: when sessionFile is absent (typed-only
-			// OpenClaw without extra event fields), serialize event.messages as JSONL
-			// so the daemon always has a transcript source for delta extraction.
-			const inlineTranscript =
-				!sessionFile && Array.isArray(messages) && messages.length > 0
-					? messages.map((m) => JSON.stringify(m)).join("\n")
-					: undefined;
-			// Fire-and-forget — don't block the hook response.
-			// Counter restore policy (CAS-guarded):
-			//   skipped:true  → restore to threshold-1 (nothing extracted, retry next turn)
-			//   queued:false  → treat as success (Rust Phase 5 stub: delta found, no job yet;
-			//                   counter stays at 0 to prevent per-turn retries against stub)
-			//   HTTP error    → restore to threshold-1 (retry next turn)
-			void daemonFetch(daemonUrl, "/api/hooks/session-checkpoint-extract", {
-				method: "POST",
-				body: {
-					harness: "openclaw",
-					sessionKey,
-					agentId,
-					project,
-					transcriptPath: sessionFile,
-					...(inlineTranscript && { transcript: inlineTranscript }),
-					runtimePath: RUNTIME_PATH,
+			api.registerTool(
+				{
+					name: "memory_search",
+					label: "Memory Search",
+					description: "Search memories using hybrid vector + keyword search",
+					parameters: Type.Object({
+						query: Type.String({ description: "Search query text" }),
+						limit: Type.Optional(
+							Type.Number({
+								description: "Max results to return (default 10)",
+							}),
+						),
+						type: Type.Optional(
+							Type.String({
+								description: "Filter by memory type",
+							}),
+						),
+						min_score: Type.Optional(
+							Type.Number({
+								description: "Minimum relevance score threshold",
+							}),
+						),
+					}),
+					async execute(_toolCallId, params) {
+						const { query, limit, type, min_score } = params as {
+							query: string;
+							limit?: number;
+							type?: string;
+							min_score?: number;
+						};
+						try {
+							const recall = await memoryRecall(query, {
+								...opts,
+								limit,
+								type,
+								minScore: min_score,
+							});
+							const parsed = parseRecallPayload(recall);
+							if (parsed.rows.length === 0) {
+								return textResult("No relevant memories found.", {
+									count: 0,
+								});
+							}
+							return textResult(formatRecallText(recall), {
+								count: parsed.rows.length,
+								memories: parsed.rows,
+								meta: parsed.meta,
+							});
+						} catch (err) {
+							return textResult(`Memory search failed: ${String(err)}`, { error: String(err) });
+						}
+					},
 				},
-				timeout: WRITE_TIMEOUT,
-			})
-				.then((resp) => {
-					// Restore counter only on skipped:true (nothing extracted — delta
-					// too small, no transcript, or bypassed). queued:false is the Rust
-					// Phase 5 stub response meaning "valid delta seen, no job queued"
-					// — treat it as success (counter stays at 0) so the next trigger
-					// waits another N turns rather than firing on every subsequent turn.
-					if (isRecord(resp) && resp.skipped === true) {
-						// CAS guard: only restore if the counter hasn't advanced past
-						// threshold-1 by new turns arriving during the async round-trip.
-						// Prevents a stale callback from overwriting newer accumulated count.
+				{ name: "memory_search" },
+			);
+
+			api.registerTool(
+				{
+					name: "memory_store",
+					label: "Memory Store",
+					description: "Save a new memory",
+					parameters: Type.Object({
+						content: Type.String({
+							description: "Memory content to save",
+						}),
+						type: Type.Optional(
+							Type.String({
+								description: "Memory type (fact, preference, decision, etc.)",
+							}),
+						),
+						importance: Type.Optional(
+							Type.Number({
+								description: "Importance score 0-1",
+							}),
+						),
+						tags: Type.Optional(
+							Type.String({
+								description: "Comma-separated tags for categorization",
+							}),
+						),
+					}),
+					async execute(_toolCallId, params) {
+						const { content, type, importance, tags } = params as {
+							content: string;
+							type?: string;
+							importance?: number;
+							tags?: string;
+						};
+						try {
+							const id = await memoryStore(content, {
+								...opts,
+								type,
+								importance,
+								tags,
+							});
+							if (id) {
+								return textResult(`Memory saved successfully (id: ${id})`, { id });
+							}
+							return textResult("Failed to save memory.", {
+								error: "no id returned",
+							});
+						} catch (err) {
+							return textResult(`Memory store failed: ${String(err)}`, { error: String(err) });
+						}
+					},
+				},
+				{ name: "memory_store" },
+			);
+
+			api.registerTool(
+				{
+					name: "memory_get",
+					label: "Memory Get",
+					description: "Get a single memory by its ID",
+					parameters: Type.Object({
+						id: Type.String({
+							description: "Memory ID to retrieve",
+						}),
+					}),
+					async execute(_toolCallId, params) {
+						const { id } = params as { id: string };
+						try {
+							const memory = await memoryGet(id, opts);
+							if (memory) {
+								return textResult(JSON.stringify(memory, null, 2), {
+									memory,
+								});
+							}
+							return textResult(`Memory ${id} not found.`, {
+								error: "not found",
+							});
+						} catch (err) {
+							return textResult(`Memory get failed: ${String(err)}`, { error: String(err) });
+						}
+					},
+				},
+				{ name: "memory_get" },
+			);
+
+			api.registerTool(
+				{
+					name: "memory_list",
+					label: "Memory List",
+					description: "List memories with optional filters",
+					parameters: Type.Object({
+						limit: Type.Optional(
+							Type.Number({
+								description: "Max results (default 50, max 50)",
+							}),
+						),
+						offset: Type.Optional(Type.Number({ description: "Pagination offset" })),
+						type: Type.Optional(
+							Type.String({
+								description: "Filter by memory type",
+							}),
+						),
+					}),
+					async execute(_toolCallId, params) {
+						const { limit, offset, type } = params as {
+							limit?: number;
+							offset?: number;
+							type?: string;
+						};
+						const ITEM_CHAR_LIMIT = 500;
+						const TOTAL_CHAR_BUDGET = 8000;
+						try {
+							const result = await memoryList({
+								...opts,
+								limit: Math.min(limit ?? 50, 50),
+								offset,
+								type,
+							});
+							const lines: string[] = [];
+							let totalChars = 0;
+							for (const m of result.memories) {
+								const content =
+									m.content.length > ITEM_CHAR_LIMIT ? `${m.content.slice(0, ITEM_CHAR_LIMIT)}[truncated]` : m.content;
+								const line = `- [${m.type}] ${content} (id: ${m.id})`;
+								if (totalChars + line.length > TOTAL_CHAR_BUDGET) break;
+								lines.push(line);
+								totalChars += line.length;
+							}
+							return textResult(`${lines.length} of ${result.memories.length} memories:\n\n${lines.join("\n")}`, {
+								count: result.memories.length,
+								shown: lines.length,
+								stats: result.stats,
+							});
+						} catch (err) {
+							return textResult(`Memory list failed: ${String(err)}`, { error: String(err) });
+						}
+					},
+				},
+				{ name: "memory_list" },
+			);
+
+			api.registerTool(
+				{
+					name: "memory_modify",
+					label: "Memory Modify",
+					description: "Edit an existing memory by ID",
+					parameters: Type.Object({
+						id: Type.String({
+							description: "Memory ID to modify",
+						}),
+						reason: Type.String({
+							description: "Why this edit is being made",
+						}),
+						content: Type.Optional(Type.String({ description: "New content" })),
+						type: Type.Optional(Type.String({ description: "New type" })),
+						importance: Type.Optional(Type.Number({ description: "New importance" })),
+						tags: Type.Optional(
+							Type.String({
+								description: "New tags (comma-separated)",
+							}),
+						),
+					}),
+					async execute(_toolCallId, params) {
+						const { id, reason, content, type, importance, tags } = params as {
+							id: string;
+							reason: string;
+							content?: string;
+							type?: string;
+							importance?: number;
+							tags?: string;
+						};
+						try {
+							const ok = await memoryModify(id, { content, type, importance, tags, reason }, opts);
+							return textResult(ok ? `Memory ${id} updated.` : `Failed to update memory ${id}.`, { success: ok });
+						} catch (err) {
+							return textResult(`Memory modify failed: ${String(err)}`, { error: String(err) });
+						}
+					},
+				},
+				{ name: "memory_modify" },
+			);
+
+			api.registerTool(
+				{
+					name: "memory_forget",
+					label: "Memory Forget",
+					description: "Soft-delete a memory by ID",
+					parameters: Type.Object({
+						id: Type.String({
+							description: "Memory ID to forget",
+						}),
+						reason: Type.String({
+							description: "Why this memory should be forgotten",
+						}),
+					}),
+					async execute(_toolCallId, params) {
+						const { id, reason } = params as {
+							id: string;
+							reason: string;
+						};
+						try {
+							const ok = await memoryForget(id, {
+								...opts,
+								reason,
+							});
+							return textResult(ok ? `Memory ${id} forgotten.` : `Failed to forget memory ${id}.`, { success: ok });
+						} catch (err) {
+							return textResult(`Memory forget failed: ${String(err)}`, { error: String(err) });
+						}
+					},
+				},
+				{ name: "memory_forget" },
+			);
+
+			api.registerTool(
+				{
+					name: "mcp_server_list",
+					label: "Tool Server List",
+					description: "List installed external Tool Servers (MCP) and discover routed tools.",
+					parameters: Type.Object({
+						refresh: Type.Optional(
+							Type.Boolean({
+								description: "Refresh live tool catalogs",
+							}),
+						),
+					}),
+					async execute(_toolCallId, params) {
+						const refresh = (params as { refresh?: boolean }).refresh;
+						try {
+							const result = await marketplaceToolList({
+								...opts,
+								refresh,
+							});
+							if (!result) {
+								return textResult("Failed to load Tool Server catalog.", {
+									error: "daemon unavailable",
+								});
+							}
+
+							const lines = result.tools
+								.slice(0, 30)
+								.map((tool) => `${tool.serverId}:${tool.toolName} - ${tool.description}`);
+
+							return textResult(
+								result.tools.length > 0
+									? `Available routed tools (${result.tools.length}):\n\n${lines.join("\n")}`
+									: "No routed tool server tools are currently available.",
+								{
+									count: result.count,
+									servers: result.servers,
+									tools: result.tools,
+								},
+							);
+						} catch (err) {
+							return textResult(`Tool server list failed: ${String(err)}`, {
+								error: String(err),
+							});
+						}
+					},
+				},
+				{ name: "mcp_server_list" },
+			);
+
+			api.registerTool(
+				{
+					name: "mcp_server_call",
+					label: "Tool Server Call",
+					description: "Invoke a routed tool from an installed external Tool Server (MCP).",
+					parameters: Type.Object({
+						server_id: Type.String({
+							description: "Installed Tool Server id",
+						}),
+						tool: Type.String({
+							description: "Tool name exposed by that server",
+						}),
+						args: Type.Optional(Type.Object({}, { additionalProperties: true })),
+					}),
+					async execute(_toolCallId, params) {
+						const payload = params as {
+							server_id: string;
+							tool: string;
+							args?: Record<string, unknown>;
+						};
+						try {
+							const result = await marketplaceToolCall(payload.server_id, payload.tool, payload.args ?? {}, opts);
+							if (!result?.success) {
+								return textResult(`Tool server call failed: ${result?.error ?? "unknown error"}`, {
+									error: result?.error ?? "unknown",
+								});
+							}
+
+							const text = typeof result.result === "string" ? result.result : JSON.stringify(result.result, null, 2);
+							return textResult(text, { result: result.result });
+						} catch (err) {
+							return textResult(`Tool server call failed: ${String(err)}`, {
+								error: String(err),
+							});
+						}
+					},
+				},
+				{ name: "mcp_server_call" },
+			);
+
+			const marketplaceProxyNameByToolKey = new Map<string, string>();
+
+			const refreshMarketplaceProxyTools = (): Promise<void> =>
+				registerMarketplaceProxyTools(api, opts, marketplaceProxyNames, marketplaceProxyNameByToolKey)
+					.then((result) => {
+						if (result.registeredNow > 0) {
+							api.logger.info(
+								`signet-memory: registered ${result.registeredNow} marketplace proxy tools (${result.total} total)`,
+							);
+						}
+					})
+					.catch((error) => {
+						api.logger.warn(`signet-memory: failed to register marketplace proxy tools: ${String(error)}`);
+					});
+
+			void refreshMarketplaceProxyTools();
+			marketplaceProxyTimer = setInterval(() => {
+				void refreshMarketplaceProxyTools();
+			}, 15_000);
+
+			// ==================================================================
+			// Lifecycle hooks
+			// ==================================================================
+
+			const claimedSessions = new Set<string>();
+			const sessionlessSessionStarts = new Map<string, number>();
+			// Maps scoped agent/session keys → {count, at} for per-turn idempotency. Entries are
+			// evicted on agent_end or lazily after SESSION_TURN_TTL_MS so crash/
+			// SIGKILL sessions don't accumulate indefinitely.
+			const SESSION_TURN_TTL_MS = 4 * 60 * 60 * 1000;
+			const injectedTurns = new Map<string, { count: number; at: number }>();
+			// Tracks turn signatures currently in-flight — provides a synchronous
+			// guard so concurrent before_prompt_build / before_agent_start calls on
+			// the same event-loop tick don't both pass the guard before either await
+			// completes (injectedTurns is only written after the daemon responds).
+			const inFlightTurns = new Set<string>();
+			const beforeCompactions = new Map<string, number>();
+			const afterCompactions = new Map<string, number>();
+
+			// Mid-session checkpoint extraction: track turns per session and
+			// fire a checkpoint extract after every N turns. Prevents long-lived
+			// sessions (Discord bots, persistent agents) from going invisible.
+			const CHECKPOINT_TURN_THRESHOLD = 20;
+			// State per scoped session key: turn count, last seen message count (for
+			// dedup), and timestamp (for TTL eviction when agent_end never fires).
+			const checkpointTurns = new Map<string, { count: number; lastMsgCount: number | undefined; at: number }>();
+			// Legacy dedup: when both before_prompt_build and before_agent_start fire
+			// on the same turn without the messages field (older OpenClaw), only one
+			// should count the turn. Generation counters: bpb increments bpbGen each
+			// call; bas tracks the last generation it consumed in basGen. If
+			// basGen < bpbGen, bas is covered and skips the count (then syncs basGen).
+			// Avoids the stale-flag problem where a missed bas leaves the flag set
+			// for the next turn.
+			const bpbGen = new Map<string, number>();
+			const basGen = new Map<string, number>();
+
+			const maybeFireCheckpoint = (
+				sessionKey: string | undefined,
+				agentId: string | undefined,
+				project: string | undefined,
+				sessionFile: string | undefined,
+				msgCount: number | undefined,
+				messages: readonly unknown[] | undefined,
+			): void => {
+				const scopedKey = buildScopedSessionKey(sessionKey, agentId);
+				if (!scopedKey || !sessionKey) return;
+
+				const now = Date.now();
+				const state = checkpointTurns.get(scopedKey);
+
+				// Lazy TTL: evict stale entries for sessions that ended without agent_end.
+				if (state && now - state.at > SESSION_TURN_TTL_MS) {
+					checkpointTurns.delete(scopedKey);
+				}
+
+				// Dedup: before_agent_start and before_prompt_build both fire on the
+				// same turn when both are registered. Use message count when available
+				// (modern OpenClaw). Legacy path relies on bpbFired flag — see below.
+				if (msgCount !== undefined && checkpointTurns.get(scopedKey)?.lastMsgCount === msgCount) return;
+
+				const newCount = (checkpointTurns.get(scopedKey)?.count ?? 0) + 1;
+				checkpointTurns.set(scopedKey, {
+					count: newCount >= CHECKPOINT_TURN_THRESHOLD ? 0 : newCount,
+					lastMsgCount: msgCount,
+					at: now,
+				});
+
+				if (newCount < CHECKPOINT_TURN_THRESHOLD) return;
+
+				// Inline transcript fallback: when sessionFile is absent (typed-only
+				// OpenClaw without extra event fields), serialize event.messages as JSONL
+				// so the daemon always has a transcript source for delta extraction.
+				const inlineTranscript =
+					!sessionFile && Array.isArray(messages) && messages.length > 0
+						? messages.map((m) => JSON.stringify(m)).join("\n")
+						: undefined;
+				// Fire-and-forget — don't block the hook response.
+				// Counter restore policy (CAS-guarded):
+				//   skipped:true  → restore to threshold-1 (nothing extracted, retry next turn)
+				//   queued:false  → treat as success (Rust Phase 5 stub: delta found, no job yet;
+				//                   counter stays at 0 to prevent per-turn retries against stub)
+				//   HTTP error    → restore to threshold-1 (retry next turn)
+				void daemonFetch(daemonUrl, "/api/hooks/session-checkpoint-extract", {
+					method: "POST",
+					body: {
+						harness: "openclaw",
+						sessionKey,
+						agentId,
+						project,
+						transcriptPath: sessionFile,
+						...(inlineTranscript && { transcript: inlineTranscript }),
+						runtimePath: RUNTIME_PATH,
+					},
+					timeout: WRITE_TIMEOUT,
+				})
+					.then((resp) => {
+						// Restore counter only on skipped:true (nothing extracted — delta
+						// too small, no transcript, or bypassed). queued:false is the Rust
+						// Phase 5 stub response meaning "valid delta seen, no job queued"
+						// — treat it as success (counter stays at 0) so the next trigger
+						// waits another N turns rather than firing on every subsequent turn.
+						if (isRecord(resp) && resp.skipped === true) {
+							// CAS guard: only restore if the counter hasn't advanced past
+							// threshold-1 by new turns arriving during the async round-trip.
+							// Prevents a stale callback from overwriting newer accumulated count.
+							const cur = checkpointTurns.get(scopedKey);
+							if (cur && cur.count < CHECKPOINT_TURN_THRESHOLD - 1)
+								checkpointTurns.set(scopedKey, { ...cur, count: CHECKPOINT_TURN_THRESHOLD - 1 });
+						}
+					})
+					.catch((err) => {
+						api.logger.warn(
+							`signet-memory: checkpoint extract failed: ${err instanceof Error ? err.message : String(err)}`,
+						);
+						// CAS guard: same protection as the .then() path.
 						const cur = checkpointTurns.get(scopedKey);
 						if (cur && cur.count < CHECKPOINT_TURN_THRESHOLD - 1)
 							checkpointTurns.set(scopedKey, { ...cur, count: CHECKPOINT_TURN_THRESHOLD - 1 });
-					}
-				})
-				.catch((err) => {
-					api.logger.warn(
-						`signet-memory: checkpoint extract failed: ${err instanceof Error ? err.message : String(err)}`,
-					);
-					// CAS guard: same protection as the .then() path.
-					const cur = checkpointTurns.get(scopedKey);
-					if (cur && cur.count < CHECKPOINT_TURN_THRESHOLD - 1)
-						checkpointTurns.set(scopedKey, { ...cur, count: CHECKPOINT_TURN_THRESHOLD - 1 });
-				});
-		};
-
-		const resolveCompactionProject = (event: Record<string, unknown>, resolved: ResolvedCtx): string | undefined => {
-			const compaction = isRecord(event.compaction) ? event.compaction : undefined;
-			const sessionFile = resolveCompactionSessionFile(event, resolved.sessionFile);
-			return firstNonEmptyString(
-				event.cwd,
-				event.project,
-				event.workspace,
-				compaction?.project,
-				compaction?.cwd,
-				compaction?.workspace,
-				resolved.project,
-				readSessionFileProject(sessionFile),
-			);
-		};
-
-		const dedupeCompaction = (map: Map<string, number>, key: string): boolean => {
-			const now = Date.now();
-			cleanupTimedMap(map, now, COMPACTION_HOOK_DEDUPE_MS);
-			const seenAt = map.get(key);
-			if (typeof seenAt === "number" && now - seenAt <= COMPACTION_HOOK_DEDUPE_MS) {
-				return true;
-			}
-			map.set(key, now);
-			return false;
-		};
-
-		const handleBeforeCompaction = async (event: Record<string, unknown>, ctx: unknown): Promise<unknown> => {
-			if (!cfg.enabled || !daemonReachable) return undefined;
-			const resolved = resolveCtx(event, ctx);
-			const messageCount =
-				typeof event.messageCount === "number"
-					? event.messageCount
-					: typeof event.compactingCount === "number"
-						? event.compactingCount
-						: typeof event.compactedCount === "number"
-							? event.compactedCount
-							: isRecord(event.compaction) && typeof event.compaction.compactingCount === "number"
-								? event.compaction.compactingCount
-								: isRecord(event.compaction) && typeof event.compaction.compactedCount === "number"
-									? event.compaction.compactedCount
-									: undefined;
-			const dedupeKey = buildCompactionEventKey(event, {
-				agentId: resolved.agentId,
-				sessionKey: resolved.sessionKey,
-			});
-			if (dedupeCompaction(beforeCompactions, dedupeKey)) {
-				return undefined;
-			}
-
-			const result = await onPreCompaction("openclaw", {
-				...opts,
-				sessionKey: resolved.sessionKey,
-				messageCount,
-			});
-			const parts = [result?.summaryPrompt, result?.guidelines].filter(
-				(value) => typeof value === "string" && value.length > 0,
-			);
-			if (parts.length === 0) {
-				return undefined;
-			}
-			return {
-				prependContext: parts.join("\n\n"),
+					});
 			};
-		};
 
-		const handleAfterCompaction = async (event: Record<string, unknown>, ctx: unknown): Promise<void> => {
-			if (!cfg.enabled || !daemonReachable) return;
-			const resolved = resolveCtx(event, ctx);
-			const scopedKey = buildScopedSessionKey(resolved.sessionKey, resolved.agentId);
-			if (scopedKey) {
-				injectedTurns.delete(scopedKey);
-				// Compaction resets the message count, so the checkpoint turn-dedup
-				// (keyed on lastMsgCount) would falsely skip the first post-compaction
-				// turn if it happens to share the same count as a pre-compaction turn.
-				// Reset the checkpoint state so dedup starts fresh after compaction.
-				checkpointTurns.delete(scopedKey);
-			}
-			const sessionFile = resolveCompactionSessionFile(event, resolved.sessionFile);
-			const summary = extractCompactionSummary(event, sessionFile);
-			if (!summary) {
-				api.logger.warn(
-					`signet-memory: compaction summary unavailable, skipping save${sessionFile ? ` (${sessionFile})` : ""}`,
+			const resolveCompactionProject = (event: Record<string, unknown>, resolved: ResolvedCtx): string | undefined => {
+				const compaction = isRecord(event.compaction) ? event.compaction : undefined;
+				const sessionFile = resolveCompactionSessionFile(event, resolved.sessionFile);
+				return firstNonEmptyString(
+					event.cwd,
+					event.project,
+					event.workspace,
+					compaction?.project,
+					compaction?.cwd,
+					compaction?.workspace,
+					resolved.project,
+					readSessionFileProject(sessionFile),
 				);
-				return;
-			}
+			};
 
-			const dedupeKey = buildCompactionEventKey(event, {
-				agentId: resolved.agentId,
-				sessionKey: resolved.sessionKey,
-				summary,
-			});
-			if (dedupeCompaction(afterCompactions, dedupeKey)) {
-				return;
-			}
-
-			await onCompactionComplete("openclaw", summary, {
-				...opts,
-				agentId: resolved.agentId,
-				project: resolveCompactionProject(event, resolved),
-				sessionKey: resolved.sessionKey,
-			});
-		};
-
-		const ensureSessionStarted = async (
-			event: Record<string, unknown>,
-			sessionKey: string | undefined,
-			agentId: string | undefined,
-		): Promise<void> => {
-			if (!sessionKey) {
+			const dedupeCompaction = (map: Map<string, number>, key: string): boolean => {
 				const now = Date.now();
-				cleanupTimedMap(sessionlessSessionStarts, now);
-				const sessionlessKey = buildSessionlessTurnKey(event, agentId);
-				const recentStartAt = sessionlessSessionStarts.get(sessionlessKey);
-				if (typeof recentStartAt === "number" && now - recentStartAt <= SESSIONLESS_DEDUPE_MS) {
+				cleanupTimedMap(map, now, COMPACTION_HOOK_DEDUPE_MS);
+				const seenAt = map.get(key);
+				if (typeof seenAt === "number" && now - seenAt <= COMPACTION_HOOK_DEDUPE_MS) {
+					return true;
+				}
+				map.set(key, now);
+				return false;
+			};
+
+			const handleBeforeCompaction = async (event: Record<string, unknown>, ctx: unknown): Promise<unknown> => {
+				if (!cfg.enabled || !daemonReachable) return undefined;
+				const resolved = resolveCtx(event, ctx);
+				const messageCount =
+					typeof event.messageCount === "number"
+						? event.messageCount
+						: typeof event.compactingCount === "number"
+							? event.compactingCount
+							: typeof event.compactedCount === "number"
+								? event.compactedCount
+								: isRecord(event.compaction) && typeof event.compaction.compactingCount === "number"
+									? event.compaction.compactingCount
+									: isRecord(event.compaction) && typeof event.compaction.compactedCount === "number"
+										? event.compaction.compactedCount
+										: undefined;
+				const dedupeKey = buildCompactionEventKey(event, {
+					agentId: resolved.agentId,
+					sessionKey: resolved.sessionKey,
+				});
+				if (dedupeCompaction(beforeCompactions, dedupeKey)) {
+					return undefined;
+				}
+
+				const result = await onPreCompaction("openclaw", {
+					...opts,
+					sessionKey: resolved.sessionKey,
+					messageCount,
+				});
+				const parts = [result?.summaryPrompt, result?.guidelines].filter(
+					(value) => typeof value === "string" && value.length > 0,
+				);
+				if (parts.length === 0) {
+					return undefined;
+				}
+				return {
+					prependContext: parts.join("\n\n"),
+				};
+			};
+
+			const handleAfterCompaction = async (event: Record<string, unknown>, ctx: unknown): Promise<void> => {
+				if (!cfg.enabled || !daemonReachable) return;
+				const resolved = resolveCtx(event, ctx);
+				const scopedKey = buildScopedSessionKey(resolved.sessionKey, resolved.agentId);
+				if (scopedKey) {
+					injectedTurns.delete(scopedKey);
+					// Compaction resets the message count, so the checkpoint turn-dedup
+					// (keyed on lastMsgCount) would falsely skip the first post-compaction
+					// turn if it happens to share the same count as a pre-compaction turn.
+					// Reset the checkpoint state so dedup starts fresh after compaction.
+					checkpointTurns.delete(scopedKey);
+				}
+				const sessionFile = resolveCompactionSessionFile(event, resolved.sessionFile);
+				const summary = extractCompactionSummary(event, sessionFile);
+				if (!summary) {
+					api.logger.warn(
+						`signet-memory: compaction summary unavailable, skipping save${sessionFile ? ` (${sessionFile})` : ""}`,
+					);
+					return;
+				}
+
+				const dedupeKey = buildCompactionEventKey(event, {
+					agentId: resolved.agentId,
+					sessionKey: resolved.sessionKey,
+					summary,
+				});
+				if (dedupeCompaction(afterCompactions, dedupeKey)) {
+					return;
+				}
+
+				await onCompactionComplete("openclaw", summary, {
+					...opts,
+					agentId: resolved.agentId,
+					project: resolveCompactionProject(event, resolved),
+					sessionKey: resolved.sessionKey,
+				});
+			};
+
+			const ensureSessionStarted = async (
+				event: Record<string, unknown>,
+				sessionKey: string | undefined,
+				agentId: string | undefined,
+			): Promise<void> => {
+				if (!sessionKey) {
+					const now = Date.now();
+					cleanupTimedMap(sessionlessSessionStarts, now);
+					const sessionlessKey = buildSessionlessTurnKey(event, agentId);
+					const recentStartAt = sessionlessSessionStarts.get(sessionlessKey);
+					if (typeof recentStartAt === "number" && now - recentStartAt <= SESSIONLESS_DEDUPE_MS) {
+						return;
+					}
+
+					const startResult = await onSessionStart("openclaw", {
+						...opts,
+						sessionKey,
+						agentId,
+					});
+					if (startResult) {
+						sessionlessSessionStarts.set(sessionlessKey, Date.now());
+					}
+					return;
+				}
+
+				const scopedKey = buildScopedSessionKey(sessionKey, agentId);
+				if (scopedKey && claimedSessions.has(scopedKey)) {
 					return;
 				}
 
@@ -2174,247 +2185,232 @@ const signetPlugin = {
 					sessionKey,
 					agentId,
 				});
-				if (startResult) {
-					sessionlessSessionStarts.set(sessionlessKey, Date.now());
+				if (startResult && scopedKey) {
+					claimedSessions.add(scopedKey);
 				}
-				return;
-			}
+			};
 
-			const scopedKey = buildScopedSessionKey(sessionKey, agentId);
-			if (scopedKey && claimedSessions.has(scopedKey)) {
-				return;
-			}
+			const runPromptInjection = async (
+				event: Record<string, unknown>,
+				sessionKey: string | undefined,
+				agentId: string | undefined,
+			): Promise<unknown> => {
+				// Skip immediately if daemon is known-unreachable — avoids a 5-second
+				// ECONNREFUSED hang on every message turn when the daemon is down.
+				if (!daemonReachable) return undefined;
 
-			const startResult = await onSessionStart("openclaw", {
-				...opts,
-				sessionKey,
-				agentId,
-			});
-			if (startResult && scopedKey) {
-				claimedSessions.add(scopedKey);
-			}
-		};
-
-		const runPromptInjection = async (
-			event: Record<string, unknown>,
-			sessionKey: string | undefined,
-			agentId: string | undefined,
-		): Promise<unknown> => {
-			// Skip immediately if daemon is known-unreachable — avoids a 5-second
-			// ECONNREFUSED hang on every message turn when the daemon is down.
-			if (!daemonReachable) return undefined;
-
-			// Prefer the clean last user message from the structured messages
-			// array. The prompt field carries platform metadata wrappers
-			// (Discord JSON, untrusted-context blocks) that pollute recall.
-			const rawPrompt = typeof event.prompt === "string" ? event.prompt : undefined;
-			const prompt = extractLastUserMessage(event.messages) ?? (rawPrompt ? extractUserMessage(rawPrompt) : undefined);
-			if (!prompt || prompt.length <= 3) {
-				return undefined;
-			}
-
-			// Deduplicate by (sessionKey, messageCount): both before_prompt_build
-			// and before_agent_start fire on the same turn; only the first should
-			// call the daemon. Sessionless agents (no sessionKey) cannot be
-			// reliably correlated and are allowed to fall through rather than
-			// risk cross-suppressing concurrent independent sessions.
-			const count = Array.isArray(event.messages) ? event.messages.length : undefined;
-			const scopedKey = buildScopedSessionKey(sessionKey, agentId);
-			// sig is only defined when we have both a stable scoped session identity
-			// and a message count — the two values that make dedup meaningful.
-			const sig = scopedKey && typeof count === "number" ? `${scopedKey}|${count}` : undefined;
-			// Lazy TTL sweep: evict entries from sessions that ended without agent_end.
-			if (sig) {
-				const now = Date.now();
-				for (const [k, v] of injectedTurns) {
-					if (now - v.at > SESSION_TURN_TTL_MS) injectedTurns.delete(k);
+				// Prefer the clean last user message from the structured messages
+				// array. The prompt field carries platform metadata wrappers
+				// (Discord JSON, untrusted-context blocks) that pollute recall.
+				const rawPrompt = typeof event.prompt === "string" ? event.prompt : undefined;
+				const prompt =
+					extractLastUserMessage(event.messages) ?? (rawPrompt ? extractUserMessage(rawPrompt) : undefined);
+				if (!prompt || prompt.length <= 3) {
+					return undefined;
 				}
-			}
-			if (
-				sig &&
-				(inFlightTurns.has(sig) || (scopedKey !== undefined && injectedTurns.get(scopedKey)?.count === count))
-			) {
-				return undefined;
-			}
-			// Mark in-flight synchronously before any await so concurrent
-			// invocations in the same event-loop tick see the guard immediately.
-			if (sig) inFlightTurns.add(sig);
 
-			const lastAssistantMessage = extractLastAssistantMessage(event);
-			const result = await onUserPromptSubmit("openclaw", {
-				...opts,
-				agentId,
-				userMessage: prompt,
-				lastAssistantMessage,
-				sessionKey,
-			});
+				// Deduplicate by (sessionKey, messageCount): both before_prompt_build
+				// and before_agent_start fire on the same turn; only the first should
+				// call the daemon. Sessionless agents (no sessionKey) cannot be
+				// reliably correlated and are allowed to fall through rather than
+				// risk cross-suppressing concurrent independent sessions.
+				const count = Array.isArray(event.messages) ? event.messages.length : undefined;
+				const scopedKey = buildScopedSessionKey(sessionKey, agentId);
+				// sig is only defined when we have both a stable scoped session identity
+				// and a message count — the two values that make dedup meaningful.
+				const sig = scopedKey && typeof count === "number" ? `${scopedKey}|${count}` : undefined;
+				// Lazy TTL sweep: evict entries from sessions that ended without agent_end.
+				if (sig) {
+					const now = Date.now();
+					for (const [k, v] of injectedTurns) {
+						if (now - v.at > SESSION_TURN_TTL_MS) injectedTurns.delete(k);
+					}
+				}
+				if (
+					sig &&
+					(inFlightTurns.has(sig) || (scopedKey !== undefined && injectedTurns.get(scopedKey)?.count === count))
+				) {
+					return undefined;
+				}
+				// Mark in-flight synchronously before any await so concurrent
+				// invocations in the same event-loop tick see the guard immediately.
+				if (sig) inFlightTurns.add(sig);
 
-			// Always clear in-flight regardless of outcome.
-			if (sig) inFlightTurns.delete(sig);
-			if (!result) {
-				// daemonFetch already logged the specific error (ECONNREFUSED or HTTP status).
-				return undefined;
-			}
-			// Record the completed turn so the other hook sees it on arrival.
-			if (scopedKey && typeof count === "number") {
-				injectedTurns.set(scopedKey, { count, at: Date.now() });
-			}
-			return buildInjectionResult(result);
-		};
+				const lastAssistantMessage = extractLastAssistantMessage(event);
+				const result = await onUserPromptSubmit("openclaw", {
+					...opts,
+					agentId,
+					userMessage: prompt,
+					lastAssistantMessage,
+					sessionKey,
+				});
 
-		// Preferred lifecycle hook in modern OpenClaw versions.
-		api.on(
-			"before_prompt_build",
-			async (event: Record<string, unknown>, ctx: unknown): Promise<unknown> => {
+				// Always clear in-flight regardless of outcome.
+				if (sig) inFlightTurns.delete(sig);
+				if (!result) {
+					// daemonFetch already logged the specific error (ECONNREFUSED or HTTP status).
+					return undefined;
+				}
+				// Record the completed turn so the other hook sees it on arrival.
+				if (scopedKey && typeof count === "number") {
+					injectedTurns.set(scopedKey, { count, at: Date.now() });
+				}
+				return buildInjectionResult(result);
+			};
+
+			// Preferred lifecycle hook in modern OpenClaw versions.
+			api.on(
+				"before_prompt_build",
+				async (event: Record<string, unknown>, ctx: unknown): Promise<unknown> => {
+					if (!cfg.enabled) return undefined;
+
+					const resolved = resolveCtx(event, ctx);
+					await ensureSessionStarted(event, resolved.sessionKey, resolved.agentId);
+					const result = await runPromptInjection(event, resolved.sessionKey, resolved.agentId);
+					// Count every turn unconditionally — checkpoint should fire based on
+					// conversation progress, not on whether recall injection succeeded.
+					const msgs = Array.isArray(event.messages) ? (event.messages as readonly unknown[]) : undefined;
+					const msgCount = msgs?.length;
+					// Legacy dedup: increment bpbGen so bas can detect if bpb ran this turn.
+					const bpbKey = buildScopedSessionKey(resolved.sessionKey, resolved.agentId);
+					if (bpbKey) bpbGen.set(bpbKey, (bpbGen.get(bpbKey) ?? 0) + 1);
+					maybeFireCheckpoint(
+						resolved.sessionKey,
+						resolved.agentId,
+						resolved.project,
+						resolved.sessionFile,
+						msgCount,
+						msgs,
+					);
+					return result;
+				},
+				{ priority: 20 },
+			);
+
+			// Legacy fallback for older OpenClaw runtimes.
+			api.on("before_agent_start", async (event: Record<string, unknown>, ctx: unknown): Promise<unknown> => {
 				if (!cfg.enabled) return undefined;
 
 				const resolved = resolveCtx(event, ctx);
 				await ensureSessionStarted(event, resolved.sessionKey, resolved.agentId);
 				const result = await runPromptInjection(event, resolved.sessionKey, resolved.agentId);
-				// Count every turn unconditionally — checkpoint should fire based on
-				// conversation progress, not on whether recall injection succeeded.
 				const msgs = Array.isArray(event.messages) ? (event.messages as readonly unknown[]) : undefined;
 				const msgCount = msgs?.length;
-				// Legacy dedup: increment bpbGen so bas can detect if bpb ran this turn.
-				const bpbKey = buildScopedSessionKey(resolved.sessionKey, resolved.agentId);
-				if (bpbKey) bpbGen.set(bpbKey, (bpbGen.get(bpbKey) ?? 0) + 1);
-				maybeFireCheckpoint(
-					resolved.sessionKey,
-					resolved.agentId,
-					resolved.project,
-					resolved.sessionFile,
-					msgCount,
-					msgs,
-				);
+				// When messages absent, check generation counters to see if bpb already
+				// counted this turn. If basGen < bpbGen, bas is covered; sync basGen.
+				const basKey = buildScopedSessionKey(resolved.sessionKey, resolved.agentId);
+				const latestBpb = basKey ? (bpbGen.get(basKey) ?? 0) : 0;
+				const lastConsumed = basKey ? (basGen.get(basKey) ?? 0) : 0;
+				const coveredByBpb = latestBpb > lastConsumed;
+				if (basKey && coveredByBpb) basGen.set(basKey, latestBpb);
+				if (!coveredByBpb || msgCount !== undefined) {
+					maybeFireCheckpoint(
+						resolved.sessionKey,
+						resolved.agentId,
+						resolved.project,
+						resolved.sessionFile,
+						msgCount,
+						msgs,
+					);
+				}
 				return result;
-			},
-			{ priority: 20 },
-		);
-
-		// Legacy fallback for older OpenClaw runtimes.
-		api.on("before_agent_start", async (event: Record<string, unknown>, ctx: unknown): Promise<unknown> => {
-			if (!cfg.enabled) return undefined;
-
-			const resolved = resolveCtx(event, ctx);
-			await ensureSessionStarted(event, resolved.sessionKey, resolved.agentId);
-			const result = await runPromptInjection(event, resolved.sessionKey, resolved.agentId);
-			const msgs = Array.isArray(event.messages) ? (event.messages as readonly unknown[]) : undefined;
-			const msgCount = msgs?.length;
-			// When messages absent, check generation counters to see if bpb already
-			// counted this turn. If basGen < bpbGen, bas is covered; sync basGen.
-			const basKey = buildScopedSessionKey(resolved.sessionKey, resolved.agentId);
-			const latestBpb = basKey ? (bpbGen.get(basKey) ?? 0) : 0;
-			const lastConsumed = basKey ? (basGen.get(basKey) ?? 0) : 0;
-			const coveredByBpb = latestBpb > lastConsumed;
-			if (basKey && coveredByBpb) basGen.set(basKey, latestBpb);
-			if (!coveredByBpb || msgCount !== undefined) {
-				maybeFireCheckpoint(
-					resolved.sessionKey,
-					resolved.agentId,
-					resolved.project,
-					resolved.sessionFile,
-					msgCount,
-					msgs,
-				);
-			}
-			return result;
-		});
-
-		api.on("agent_end", async (event: Record<string, unknown>, ctx: unknown): Promise<unknown> => {
-			if (!cfg.enabled) return undefined;
-
-			const resolved = resolveCtx(event, ctx);
-			const scopedKey = buildScopedSessionKey(resolved.sessionKey, resolved.agentId);
-
-			// Inline transcript fallback: same pattern as maybeFireCheckpoint —
-			// when sessionFile is absent (typed-only ctx), serialize event.messages
-			// so the daemon has a transcript source for session-end extraction.
-			const endMsgs = Array.isArray(event.messages) ? (event.messages as readonly unknown[]) : undefined;
-			const endTranscript =
-				!resolved.sessionFile && endMsgs && endMsgs.length > 0
-					? endMsgs.map((m) => JSON.stringify(m)).join("\n")
-					: undefined;
-			await onSessionEnd("openclaw", {
-				...opts,
-				agentId: resolved.agentId,
-				cwd: resolved.project,
-				sessionId: resolved.sessionId,
-				sessionKey: resolved.sessionKey,
-				transcriptPath: resolved.sessionFile,
-				...(endTranscript && { transcript: endTranscript }),
 			});
-			if (scopedKey) {
-				claimedSessions.delete(scopedKey);
-				injectedTurns.delete(scopedKey);
-				checkpointTurns.delete(scopedKey);
-				bpbGen.delete(scopedKey);
-				basGen.delete(scopedKey);
-			}
-			return undefined;
-		});
 
-		api.on("before_compaction", async (event: Record<string, unknown>, ctx: unknown): Promise<unknown> => {
-			return handleBeforeCompaction(event, ctx);
-		});
+			api.on("agent_end", async (event: Record<string, unknown>, ctx: unknown): Promise<unknown> => {
+				if (!cfg.enabled) return undefined;
 
-		api.on("after_compaction", async (event: Record<string, unknown>, ctx: unknown): Promise<unknown> => {
-			await handleAfterCompaction(event, ctx);
-			return undefined;
-		});
+				const resolved = resolveCtx(event, ctx);
+				const scopedKey = buildScopedSessionKey(resolved.sessionKey, resolved.agentId);
 
-		// NOTE: session:compact:before / session:compact:after are not yet
-		// recognized by OpenClaw (as of 2026.3.28). The legacy hooks above
-		// (before_compaction / after_compaction) cover the same logic. Re-add
-		// the modern names when OpenClaw ships support for them.
+				// Inline transcript fallback: same pattern as maybeFireCheckpoint —
+				// when sessionFile is absent (typed-only ctx), serialize event.messages
+				// so the daemon has a transcript source for session-end extraction.
+				const endMsgs = Array.isArray(event.messages) ? (event.messages as readonly unknown[]) : undefined;
+				const endTranscript =
+					!resolved.sessionFile && endMsgs && endMsgs.length > 0
+						? endMsgs.map((m) => JSON.stringify(m)).join("\n")
+						: undefined;
+				await onSessionEnd("openclaw", {
+					...opts,
+					agentId: resolved.agentId,
+					cwd: resolved.project,
+					sessionId: resolved.sessionId,
+					sessionKey: resolved.sessionKey,
+					transcriptPath: resolved.sessionFile,
+					...(endTranscript && { transcript: endTranscript }),
+				});
+				if (scopedKey) {
+					claimedSessions.delete(scopedKey);
+					injectedTurns.delete(scopedKey);
+					checkpointTurns.delete(scopedKey);
+					bpbGen.delete(scopedKey);
+					basGen.delete(scopedKey);
+				}
+				return undefined;
+			});
 
-		// ==================================================================
-		// Service
-		// ==================================================================
+			api.on("before_compaction", async (event: Record<string, unknown>, ctx: unknown): Promise<unknown> => {
+				return handleBeforeCompaction(event, ctx);
+			});
+
+			api.on("after_compaction", async (event: Record<string, unknown>, ctx: unknown): Promise<unknown> => {
+				await handleAfterCompaction(event, ctx);
+				return undefined;
+			});
+
+			// NOTE: session:compact:before / session:compact:after are not yet
+			// recognized by OpenClaw (as of 2026.3.28). The legacy hooks above
+			// (before_compaction / after_compaction) cover the same logic. Re-add
+			// the modern names when OpenClaw ships support for them.
+
+			// ==================================================================
+			// Service
+			// ==================================================================
 
 			api.registerService({
 				id: "signet-memory-openclaw",
-			start() {
-				api.logger.info(`signet-memory: service started (daemon: ${daemonUrl})`);
-				healthTimer = setInterval(async () => {
-					const pid = await getDaemonPid(daemonUrl);
-					const ok = pid !== null;
-					if (ok !== daemonReachable) {
-						daemonReachable = ok;
-						if (ok) {
-							api.logger.info("signet-memory: daemon reconnected");
-						} else {
-							api.logger.warn("signet-memory: daemon became unreachable");
+				start() {
+					api.logger.info(`signet-memory: service started (daemon: ${daemonUrl})`);
+					healthTimer = setInterval(async () => {
+						const pid = await getDaemonPid(daemonUrl);
+						const ok = pid !== null;
+						if (ok !== daemonReachable) {
+							daemonReachable = ok;
+							if (ok) {
+								api.logger.info("signet-memory: daemon reconnected");
+							} else {
+								api.logger.warn("signet-memory: daemon became unreachable");
+							}
 						}
+						// Daemon restarted (PID changed). Evict all claimed sessions so
+						// ensureSessionStarted re-inits on next turn, restoring identity
+						// blocks and memory context transparently.
+						if (ok && knownPid !== null && pid !== knownPid) {
+							api.logger.info(`signet-memory: daemon restarted (pid ${knownPid} -> ${pid}), re-initializing sessions`);
+							claimedSessions.clear();
+						}
+						knownPid = pid;
+					}, 60_000);
+				},
+				stop() {
+					api.logger.info("signet-memory: service stopped");
+					try {
+						removeFetchSanitizer();
+						removeSdkSanitizer();
+						if (healthTimer) {
+							clearInterval(healthTimer);
+							healthTimer = null;
+						}
+						if (marketplaceProxyTimer) {
+							clearInterval(marketplaceProxyTimer);
+							marketplaceProxyTimer = null;
+						}
+					} finally {
+						// Always release the process-level registration guard so a
+						// later full registration pass can reinitialize cleanly.
+						writeRegistered(false);
 					}
-					// Daemon restarted (PID changed). Evict all claimed sessions so
-					// ensureSessionStarted re-inits on next turn, restoring identity
-					// blocks and memory context transparently.
-					if (ok && knownPid !== null && pid !== knownPid) {
-						api.logger.info(`signet-memory: daemon restarted (pid ${knownPid} -> ${pid}), re-initializing sessions`);
-						claimedSessions.clear();
-					}
-					knownPid = pid;
-				}, 60_000);
-			},
-			stop() {
-				api.logger.info("signet-memory: service stopped");
-				try {
-					removeFetchSanitizer();
-					removeSdkSanitizer();
-					if (healthTimer) {
-						clearInterval(healthTimer);
-						healthTimer = null;
-					}
-					if (marketplaceProxyTimer) {
-						clearInterval(marketplaceProxyTimer);
-						marketplaceProxyTimer = null;
-					}
-				} finally {
-					// Always release the process-level registration guard so a
-					// later full registration pass can reinitialize cleanly.
-					writeRegistered(false);
-				}
-			},
+				},
 			});
 		} catch (err) {
 			if (claimed) {

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -1,4 +1,10 @@
-import { applyRecallScoreThreshold, partitionRecallRows } from "@signet/core";
+import {
+	applyRecallScoreThreshold,
+	buildRecallRequestBody,
+	buildRememberRequestBody,
+	formatRecallText,
+	parseRecallPayload,
+} from "@signet/core";
 import chalk from "chalk";
 import type { Command } from "commander";
 import ora from "ora";
@@ -18,87 +24,6 @@ interface MemoryDeps {
 	}>;
 }
 
-interface RecallMeta {
-	readonly totalReturned: number;
-	readonly hasSupplementary: boolean;
-	readonly noHits: boolean;
-}
-
-interface RecallRow {
-	readonly content: string;
-	readonly created_at?: string;
-	readonly score?: number;
-	readonly source?: string;
-	readonly who?: string;
-	readonly type?: string;
-	readonly tags?: string | null;
-	readonly pinned?: boolean;
-	readonly project?: string | null;
-	readonly supplementary?: boolean;
-}
-
-interface ParsedRecallResult {
-	readonly rows: RecallRow[];
-	readonly meta: RecallMeta;
-	readonly query?: string;
-	readonly method?: string;
-}
-
-function parseRecallMeta(raw: unknown, fallbackCount: number): RecallMeta {
-	if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
-		return {
-			totalReturned: fallbackCount,
-			hasSupplementary: false,
-			noHits: fallbackCount === 0,
-		};
-	}
-	const totalReturned =
-		"totalReturned" in raw && typeof raw.totalReturned === "number" ? raw.totalReturned : fallbackCount;
-	const hasSupplementary = "hasSupplementary" in raw && raw.hasSupplementary === true;
-	const noHits = "noHits" in raw ? raw.noHits === true : totalReturned === 0;
-	return { totalReturned, hasSupplementary, noHits };
-}
-
-function parseRecallResult(raw: unknown): ParsedRecallResult {
-	const result = typeof raw === "object" && raw !== null ? raw : {};
-	const rows = "results" in result && Array.isArray(result.results) ? (result.results as RecallRow[]) : [];
-	const meta = parseRecallMeta("meta" in result ? result.meta : undefined, rows.length);
-	const query = "query" in result && typeof result.query === "string" ? result.query : undefined;
-	const method = "method" in result && typeof result.method === "string" ? result.method : undefined;
-	return { rows, meta, query, method };
-}
-
-function formatRecallRows(rows: ReadonlyArray<RecallRow>): string[] {
-	const { primary, supporting } = partitionRecallRows(rows);
-	const sections: Array<{ heading?: string; rows: ReadonlyArray<RecallRow> }> = [];
-	if (primary.length > 0) sections.push({ rows: primary });
-	if (supporting.length > 0) sections.push({ heading: "  Supporting context:\n", rows: supporting });
-
-	const lines: string[] = [];
-	for (const section of sections) {
-		if (section.heading) lines.push(chalk.bold(section.heading));
-		for (const row of section.rows) {
-			const content = typeof row.content === "string" ? row.content : "";
-			const createdAt = typeof row.created_at === "string" ? row.created_at : "";
-			const scoreValue = typeof row.score === "number" ? row.score : 0;
-			const source = typeof row.source === "string" ? row.source : "unknown";
-			const who = typeof row.who === "string" && row.who.length > 0 ? row.who : "unknown";
-			const type = typeof row.type === "string" ? row.type : "memory";
-			const tags = typeof row.tags === "string" ? row.tags : "";
-			const pinned = row.pinned === true;
-			const date = createdAt.slice(0, 10) || "unknown";
-			const score = chalk.dim(`[${(scoreValue * 100).toFixed(0)}%]`);
-			const critical = pinned ? chalk.red("★") : "";
-			const tagLabel = tags ? chalk.dim(` [${tags}]`) : "";
-			const displayContent = content.length > 120 ? `${content.slice(0, 117)}...` : content;
-
-			lines.push(`  ${chalk.dim(date)} ${score} ${critical}${displayContent}${tagLabel}`);
-			lines.push(chalk.dim(`      ${type} · ${source} · by ${who}`));
-		}
-	}
-	return lines;
-}
-
 export function registerMemoryCommands(program: Command, deps: MemoryDeps): void {
 	program
 		.command("remember <content>")
@@ -113,15 +38,18 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 			if (!(await deps.ensureDaemonForSecrets())) return;
 
 			const spinner = ora("Saving memory...").start();
-			const { ok, data } = await deps.secretApiCall("POST", "/api/memory/remember", {
-				content,
-				who: options.who,
-				tags: options.tags,
-				importance: options.importance,
-				pinned: options.critical,
-				...(options.agent ? { agentId: options.agent } : {}),
-				...(options.private ? { visibility: "private" } : {}),
-			});
+			const { ok, data } = await deps.secretApiCall(
+				"POST",
+				"/api/memory/remember",
+				buildRememberRequestBody(content, {
+					who: options.who,
+					tags: options.tags,
+					importance: options.importance,
+					pinned: options.critical,
+					agentId: options.agent,
+					visibility: options.private ? "private" : undefined,
+				}),
+			);
 
 			const err = typeof data === "object" && data !== null && "error" in data ? data.error : undefined;
 			if (!ok || typeof err === "string") {
@@ -169,21 +97,20 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 			const { ok, data } = await deps.secretApiCall(
 				"POST",
 				"/api/memory/recall",
-				{
-					query,
+				buildRecallRequestBody(query, {
 					keywordQuery: options.keywordQuery,
 					limit: options.limit,
 					project: options.project,
 					type: options.type,
 					tags: options.tags,
 					who: options.who,
-					pinned: options.pinned === true ? true : undefined,
+					pinned: options.pinned,
 					importance_min: options.importanceMin,
 					since: options.since,
 					until: options.until,
-					expand: options.expand === true ? true : undefined,
-					...(options.agent ? { agentId: options.agent } : {}),
-				},
+					expand: options.expand,
+					agentId: options.agent,
+				}),
 				MEMORY_RECALL_TIMEOUT_MS,
 			);
 
@@ -197,7 +124,7 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 			// Score thresholds trim ranked matches, but intentionally keep
 			// unscored supporting context in-band.
 			const filtered = applyRecallScoreThreshold(data, options.minScore);
-			const parsed = parseRecallResult(filtered);
+			const parsed = parseRecallPayload(filtered);
 
 			if (options.json) {
 				console.log(JSON.stringify(filtered, null, 2));
@@ -210,14 +137,7 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 				return;
 			}
 
-			const summarySuffix: string[] = [];
-			if (parsed.method) summarySuffix.push(parsed.method);
-			if (parsed.meta.hasSupplementary) summarySuffix.push("includes supporting context");
-			const summary = summarySuffix.length > 0 ? ` ${chalk.dim(`(${summarySuffix.join(" · ")})`)}` : "";
-			const noun = parsed.meta.totalReturned === 1 ? "memory" : "memories";
-			console.log(chalk.bold(`\n  Found ${parsed.meta.totalReturned} ${noun}:${summary}\n`));
-			for (const line of formatRecallRows(parsed.rows)) console.log(line);
-			console.log();
+			console.log(`\n${formatRecallText(filtered)}\n`);
 		});
 
 	const embedCmd = program.command("embed").description("Embedding management (audit, backfill)");

--- a/packages/connector-openclaw/src/index.ts
+++ b/packages/connector-openclaw/src/index.ts
@@ -1144,50 +1144,34 @@ async function fetchDaemon(path, body) {
   return res.json();
 }
 
-function formatRecallMessage(data) {
+let sharedRecallFormatter;
+async function recallMessage(data) {
+  if (typeof data?.message === "string") return data.message;
   const rows = Array.isArray(data?.results) ? data.results : [];
-  const meta = typeof data?.meta === "object" && data?.meta !== null
-    ? data.meta
-    : {
-        totalReturned: rows.length,
-        hasSupplementary: rows.some((row) => row?.supplementary === true),
-        noHits: rows.length === 0,
-      };
-
-  if (meta.noHits || rows.length === 0) {
+  if (rows.length === 0) {
     return "No matching memories found.";
   }
 
-  const primary = rows.filter((row) => row?.supplementary !== true);
-  const supporting = rows.filter((row) => row?.supplementary === true);
-  const parts = [
-    \`Found \${meta.totalReturned} memories\${data?.method ? \` (\${data.method})\` : ""}.\`,
-    "",
-    "Primary matches:",
-    ...primary.map((row) => {
-      const score = typeof row?.score === "number" ? \`[\${Math.round(row.score * 100)}%] \` : "";
-      const source = typeof row?.source === "string" ? row.source : "unknown";
-      const type = typeof row?.type === "string" ? row.type : "memory";
-      const createdAt = typeof row?.created_at === "string" ? row.created_at.slice(0, 10) : "unknown";
-      return \`- \${score}\${row?.content || ""} (\${type}, \${source}, \${createdAt})\`;
-    }),
-  ];
-
-  if (supporting.length > 0) {
-    parts.push("", "Supporting context:");
-    parts.push(
-      ...supporting.map((row) => {
-        const source = typeof row?.source === "string" ? row.source : "unknown";
-        const type = typeof row?.type === "string" ? row.type : "memory";
-        const createdAt = typeof row?.created_at === "string" ? row.created_at.slice(0, 10) : "unknown";
-        return \`- \${row?.content || ""} (\${type}, \${source}, \${createdAt})\`;
-      })
-    );
+  try {
+    sharedRecallFormatter ??= (await import("@signet/core")).formatRecallText;
+    if (typeof sharedRecallFormatter === "function") {
+      return sharedRecallFormatter(data);
+    }
+  } catch {
+    // Older standalone hook installs may not have @signet/core resolvable.
+    // Keep a compact compatibility path instead of dumping raw JSON into
+    // the prompt.
   }
 
-  return parts.join("\\n");
+  const method = typeof data?.method === "string" ? data.method : "hybrid";
+  const lines = [\`Found \${rows.length} \${rows.length === 1 ? "memory" : "memories"} (\${method}).\`];
+  for (const row of rows.slice(0, 8)) {
+    const score = typeof row?.score === "number" ? \`[\${Math.round(row.score * 100)}%] \` : "";
+    const id = typeof row?.id === "string" && row.id ? \`id: \${row.id}; \` : "";
+    lines.push(\`- \${score}\${id}\${row?.content ?? ""}\`);
+  }
+  return lines.join("\\n");
 }
-
 const handler = async (event) => {
   // When the plugin runtime path is active, legacy hooks are disabled
   // to prevent duplicate capture/recall. Set SIGNET_RUNTIME_PATH=plugin
@@ -1213,7 +1197,7 @@ const handler = async (event) => {
         const data = await fetchDaemon("/api/hooks/recall", {
           harness: "openclaw", query: args.trim(),
         });
-        event.messages.push(formatRecallMessage(data));
+        event.messages.push(await recallMessage(data));
       } catch (e) { event.messages.push(\`Error: \${e.message}\`); }
       break;
     case "context":

--- a/packages/connector-openclaw/test/index.test.ts
+++ b/packages/connector-openclaw/test/index.test.ts
@@ -57,11 +57,15 @@ describe("OpenClawConnector config patching", () => {
 			throw new Error("Expected installHookFiles() to write hooks/agent-memory/handler.js");
 		}
 		const handlerJs = readFileSync(handlerPath, "utf-8");
-		expect(handlerJs).toContain("function formatRecallMessage(data)");
+		expect(handlerJs).toContain("async function recallMessage(data)");
+		expect(handlerJs).toContain('if (typeof data?.message === "string") return data.message;');
+		expect(handlerJs).toContain('await import("@signet/core")');
 		expect(handlerJs).toContain('return "No matching memories found.";');
-		expect(handlerJs).toContain("Primary matches:");
-		expect(handlerJs).toContain("Supporting context:");
-		expect(handlerJs).toContain("event.messages.push(formatRecallMessage(data));");
+		expect(handlerJs).toContain("Keep a compact compatibility path");
+		expect(handlerJs).toContain("rows.slice(0, 8)");
+		expect(handlerJs).not.toContain("JSON.stringify(data, null, 2)");
+		expect(handlerJs).toContain("event.messages.push(await recallMessage(data));");
+		expect(handlerJs).not.toContain("Supporting context:");
 		expect(handlerJs).not.toContain('data.results.map(r => `- ${r.content}`).join("\\\\n")');
 	});
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -114,8 +114,27 @@ export {
 	type VectorSearchOptions,
 	type HybridSearchOptions,
 } from "./search";
-export { applyRecallScoreThreshold, partitionRecallRows } from "./recall";
-export type { RecallPartitionableRow } from "./recall";
+export {
+	applyRecallScoreThreshold,
+	buildRecallRequestBody,
+	buildRememberRequestBody,
+	emptyHookRecallResponse,
+	formatRecallText,
+	normalizeStructuredMemoryPayload,
+	parseRecallMeta,
+	parseRecallPayload,
+	partitionRecallRows,
+	withHookRecallCompat,
+} from "./recall";
+export type {
+	RecallMeta,
+	RecallPartitionableRow,
+	RecallPayload,
+	RecallRequestOptions,
+	RecallRow,
+	RecallScoreFilterRow,
+	RememberRequestOptions,
+} from "./recall";
 export {
 	createMemoriesFts,
 	memoriesFtsNeedsTokenizerRepair,

--- a/packages/core/src/recall.test.ts
+++ b/packages/core/src/recall.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "bun:test";
+import {
+	buildRecallRequestBody,
+	buildRememberRequestBody,
+	formatRecallText,
+	parseRecallPayload,
+	withHookRecallCompat,
+} from "./recall";
+
+describe("recall surface helpers", () => {
+	it("formats daemon recall payloads with primary and supporting context", () => {
+		const text = formatRecallText({
+			method: "hybrid",
+			results: [
+				{
+					id: "mem-1",
+					content: "Nicholai likes filesystem-shaped graph navigation.",
+					score: 0.91,
+					source: "hybrid",
+					type: "preference",
+					created_at: "2026-04-20T12:00:00.000Z",
+					who: "ant",
+				},
+				{
+					id: "ctx-1",
+					content: "SEC adds supporting evidence.",
+					source: "graph",
+					type: "rationale",
+					created_at: "2026-04-19T12:00:00.000Z",
+					supplementary: true,
+				},
+			],
+			meta: { totalReturned: 2, hasSupplementary: true, noHits: false },
+		});
+
+		expect(text).toContain("Found 2 memories (hybrid).");
+		expect(text).toContain("Primary matches:");
+		expect(text).toContain("id: mem-1; Nicholai likes filesystem-shaped graph navigation.");
+		expect(text).toContain("(preference, hybrid, 2026-04-20, by ant)");
+		expect(text).toContain("Supporting context:");
+		expect(text).toContain("id: ctx-1; SEC adds supporting evidence.");
+	});
+
+	it("builds recall request bodies without forwarding client-side score thresholds", () => {
+		expect(
+			buildRecallRequestBody("graph", {
+				limit: 5,
+				keyword_query: "graph OR entity",
+				pinned: false,
+				expand: false,
+				agentId: "default",
+			}),
+		).toEqual({
+			query: "graph",
+			keywordQuery: "graph OR entity",
+			limit: 5,
+			agentId: "default",
+		});
+	});
+
+	it("normalizes legacy structured aspect tuples for remember callers", () => {
+		const body = buildRememberRequestBody("Remember this", {
+			tags: ["graph", "parity"],
+			structured: {
+				aspects: [
+					{
+						entity: "Nicholai",
+						aspect: "memory architecture",
+						value: "prefers entity/aspect/attribute graph structure",
+						groupKey: "knowledge_graph",
+						claimKey: "preferred_graph_shape",
+						confidence: 0.95,
+					},
+				],
+			},
+		});
+
+		expect(body.tags).toBe("graph,parity");
+		expect(body.structured).toEqual({
+			aspects: [
+				{
+					entityName: "Nicholai",
+					aspect: "memory architecture",
+					attributes: [
+						{
+							content: "prefers entity/aspect/attribute graph structure",
+							groupKey: "knowledge_graph",
+							claimKey: "preferred_graph_shape",
+							confidence: 0.95,
+						},
+					],
+				},
+			],
+		});
+	});
+
+	it("adds legacy hook aliases plus canonical message", () => {
+		const result = withHookRecallCompat({
+			query: "filesystem graph",
+			method: "hybrid",
+			results: [
+				{
+					id: "mem-1",
+					content: "A graph can be navigated like folders and rooms.",
+					source: "hybrid",
+					type: "fact",
+					created_at: "2026-04-20T12:00:00.000Z",
+				},
+			],
+			meta: { totalReturned: 1, hasSupplementary: false, noHits: false },
+		});
+
+		expect(result.memories).toBe(result.results);
+		expect(result.count).toBe(1);
+		expect(result.message).toContain("Found 1 memory (hybrid).");
+		expect(parseRecallPayload(result).rows).toHaveLength(1);
+	});
+});

--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -1,4 +1,4 @@
-interface RecallScoreFilterRow {
+export interface RecallScoreFilterRow {
 	readonly score?: number;
 	readonly supplementary?: boolean;
 }
@@ -7,8 +7,106 @@ export interface RecallPartitionableRow {
 	readonly supplementary?: boolean;
 }
 
+export interface RecallRow extends RecallPartitionableRow {
+	readonly id?: string;
+	readonly content?: string;
+	readonly created_at?: string;
+	readonly score?: number;
+	readonly source?: string;
+	readonly who?: string;
+	readonly type?: string;
+	readonly tags?: string | null;
+	readonly pinned?: boolean | number;
+	readonly project?: string | null;
+	readonly importance?: number;
+}
+
+export interface RecallMeta {
+	readonly totalReturned: number;
+	readonly hasSupplementary: boolean;
+	readonly noHits: boolean;
+}
+
+export interface RecallPayload {
+	readonly query?: string;
+	readonly method?: string;
+	readonly results?: ReadonlyArray<RecallRow>;
+	readonly meta?: Partial<RecallMeta>;
+	readonly memories?: ReadonlyArray<RecallRow>;
+	readonly count?: number;
+	readonly message?: string;
+}
+
 interface RecallScoreFilterPayload {
 	readonly results?: ReadonlyArray<RecallScoreFilterRow>;
+	readonly meta?: unknown;
+}
+
+export interface RecallRequestOptions {
+	readonly keywordQuery?: string;
+	readonly keyword_query?: string;
+	readonly limit?: number;
+	readonly project?: string;
+	readonly type?: string;
+	readonly tags?: string;
+	readonly who?: string;
+	readonly pinned?: boolean;
+	readonly importance_min?: number;
+	readonly since?: string;
+	readonly until?: string;
+	readonly expand?: boolean;
+	readonly agentId?: string;
+	readonly scope?: "global" | "agent" | "session";
+}
+
+export interface RememberRequestOptions {
+	readonly type?: string;
+	readonly importance?: number;
+	readonly tags?: string | readonly string[];
+	readonly who?: string;
+	readonly pinned?: boolean;
+	readonly sourceType?: string;
+	readonly sourceId?: string;
+	readonly createdAt?: string;
+	readonly hints?: readonly string[];
+	readonly transcript?: string;
+	readonly structured?: unknown;
+	readonly agentId?: string;
+	readonly visibility?: "global" | "private" | "archived";
+	readonly mode?: "auto" | "sync" | "async";
+	readonly idempotencyKey?: string;
+	readonly runtimePath?: string;
+	readonly harness?: string;
+	readonly source?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function withDefined<T extends Record<string, unknown>>(value: T): Partial<T> {
+	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined)) as Partial<T>;
+}
+
+function normalizeRememberTags(tags: string | readonly string[] | undefined): string | undefined {
+	if (typeof tags === "string") {
+		const value = tags
+			.split(",")
+			.map((tag) => tag.trim())
+			.filter((tag) => tag.length > 0)
+			.join(",");
+		return value.length > 0 ? value : undefined;
+	}
+
+	if (Array.isArray(tags)) {
+		const value = tags
+			.map((tag) => tag.trim())
+			.filter((tag) => tag.length > 0)
+			.join(",");
+		return value.length > 0 ? value : undefined;
+	}
+
+	return undefined;
 }
 
 export function partitionRecallRows<T extends RecallPartitionableRow>(
@@ -20,6 +118,44 @@ export function partitionRecallRows<T extends RecallPartitionableRow>(
 	return {
 		primary: rows.filter((row) => row.supplementary !== true),
 		supporting: rows.filter((row) => row.supplementary === true),
+	};
+}
+
+export function parseRecallMeta(raw: unknown, fallbackCount: number): RecallMeta {
+	if (!isRecord(raw)) {
+		return {
+			totalReturned: fallbackCount,
+			hasSupplementary: false,
+			noHits: fallbackCount === 0,
+		};
+	}
+
+	const totalReturned = typeof raw.totalReturned === "number" ? raw.totalReturned : fallbackCount;
+	const hasSupplementary = raw.hasSupplementary === true;
+	const noHits = "noHits" in raw ? raw.noHits === true : totalReturned === 0;
+	return { totalReturned, hasSupplementary, noHits };
+}
+
+export function parseRecallPayload(raw: unknown): {
+	readonly query?: string;
+	readonly method?: string;
+	readonly rows: RecallRow[];
+	readonly meta: RecallMeta;
+	readonly message?: string;
+} {
+	const payload = isRecord(raw) ? raw : {};
+	const results = Array.isArray(payload.results)
+		? payload.results
+		: Array.isArray(payload.memories)
+			? payload.memories
+			: [];
+	const rows = results.filter(isRecord) as RecallRow[];
+	return {
+		query: typeof payload.query === "string" ? payload.query : undefined,
+		method: typeof payload.method === "string" ? payload.method : undefined,
+		rows,
+		meta: parseRecallMeta(payload.meta, rows.length),
+		message: typeof payload.message === "string" ? payload.message : undefined,
 	};
 }
 
@@ -49,5 +185,166 @@ export function applyRecallScoreThreshold(raw: unknown, minScore?: number): unkn
 			hasSupplementary: filtered.some((row) => row.supplementary === true),
 			noHits: filtered.length === 0,
 		},
+	};
+}
+
+function formatDate(value: unknown): string {
+	return typeof value === "string" && value.length > 0 ? value.slice(0, 10) : "unknown";
+}
+
+function formatRecallRow(row: RecallRow, options?: { readonly includeIndex?: number }): string {
+	const score = typeof row.score === "number" ? `[${(row.score * 100).toFixed(0)}%] ` : "";
+	const source = typeof row.source === "string" ? row.source : "unknown";
+	const type = typeof row.type === "string" ? row.type : "memory";
+	const who = typeof row.who === "string" && row.who.length > 0 ? `, by ${row.who}` : "";
+	const createdAt = formatDate(row.created_at);
+	const id = typeof row.id === "string" && row.id.length > 0 ? `id: ${row.id}; ` : "";
+	const prefix = options?.includeIndex ? `${options.includeIndex}. ` : "- ";
+	return `${prefix}${score}${id}${row.content ?? ""} (${type}, ${source}, ${createdAt}${who})`;
+}
+
+export function formatRecallText(raw: unknown): string {
+	if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+		return typeof raw === "string" ? raw : JSON.stringify(raw, null, 2);
+	}
+
+	const payload = raw as RecallPayload;
+	const parsed = parseRecallPayload(payload);
+	if (parsed.message && parsed.rows.length === 0) return parsed.message;
+	if (parsed.meta.noHits || parsed.rows.length === 0) return "No matching memories found.";
+
+	const { primary, supporting } = partitionRecallRows(parsed.rows);
+	const noun = parsed.meta.totalReturned === 1 ? "memory" : "memories";
+	const parts = [`Found ${parsed.meta.totalReturned} ${noun}${parsed.method ? ` (${parsed.method})` : ""}.`];
+
+	if (primary.length > 0) {
+		parts.push("", "Primary matches:", ...primary.map((row) => formatRecallRow(row)));
+	}
+
+	if (supporting.length > 0) {
+		parts.push("", "Supporting context:", ...supporting.map((row) => formatRecallRow(row)));
+	}
+
+	return parts.join("\n");
+}
+
+export function buildRecallRequestBody(query: string, options: RecallRequestOptions = {}): Record<string, unknown> {
+	return withDefined({
+		query,
+		keywordQuery: options.keywordQuery ?? options.keyword_query,
+		limit: options.limit,
+		project: options.project,
+		type: options.type,
+		tags: options.tags,
+		who: options.who,
+		pinned: options.pinned === true ? true : undefined,
+		importance_min: options.importance_min,
+		since: options.since,
+		until: options.until,
+		expand: options.expand === true ? true : undefined,
+		agentId: options.agentId,
+		scope: options.scope,
+	});
+}
+
+export function normalizeStructuredMemoryPayload(value: unknown): unknown {
+	if (!isRecord(value)) return value;
+	const aspects = value.aspects;
+	if (!Array.isArray(aspects)) return value;
+
+	return {
+		...value,
+		aspects: aspects.map((aspect) => {
+			if (!isRecord(aspect)) return aspect;
+			if (typeof aspect.entityName === "string" && Array.isArray(aspect.attributes)) return aspect;
+			if (typeof aspect.entity === "string" && typeof aspect.aspect === "string" && typeof aspect.value === "string") {
+				return {
+					entityName: aspect.entity,
+					aspect: aspect.aspect,
+					attributes: [
+						withDefined({
+							content: aspect.value,
+							groupKey: typeof aspect.groupKey === "string" ? aspect.groupKey : undefined,
+							claimKey: typeof aspect.claimKey === "string" ? aspect.claimKey : undefined,
+							confidence: typeof aspect.confidence === "number" ? aspect.confidence : undefined,
+							importance: typeof aspect.importance === "number" ? aspect.importance : undefined,
+						}),
+					],
+				};
+			}
+			return aspect;
+		}),
+	};
+}
+
+export function buildRememberRequestBody(
+	content: string,
+	options: RememberRequestOptions = {},
+): Record<string, unknown> {
+	return withDefined({
+		content,
+		type: options.type,
+		importance: options.importance,
+		tags: normalizeRememberTags(options.tags),
+		who: options.who,
+		pinned: options.pinned === true ? true : undefined,
+		sourceType: options.sourceType,
+		sourceId: options.sourceId,
+		createdAt: options.createdAt,
+		hints: options.hints,
+		transcript: options.transcript,
+		structured: normalizeStructuredMemoryPayload(options.structured),
+		agentId: options.agentId,
+		visibility: options.visibility,
+		mode: options.mode,
+		idempotencyKey: options.idempotencyKey,
+		runtimePath: options.runtimePath,
+		harness: options.harness,
+		source: options.source,
+	});
+}
+
+export function withHookRecallCompat<T extends { readonly results: ReadonlyArray<unknown> }>(
+	result: T,
+): T & { readonly memories: T["results"]; readonly count: number; readonly message: string } {
+	return {
+		...result,
+		memories: result.results,
+		count: result.results.length,
+		message: formatRecallText(result),
+	};
+}
+
+export function emptyHookRecallResponse(
+	query: string,
+	extras?: { readonly bypassed?: boolean; readonly internal?: boolean },
+): {
+	readonly results: [];
+	readonly memories: [];
+	readonly count: 0;
+	readonly query: string;
+	readonly method: "hybrid";
+	readonly meta: RecallMeta;
+	readonly message: string;
+	readonly bypassed?: boolean;
+	readonly internal?: boolean;
+} {
+	const response = {
+		results: [] as [],
+		memories: [] as [],
+		count: 0 as const,
+		query,
+		method: "hybrid" as const,
+		meta: {
+			totalReturned: 0,
+			hasSupplementary: false,
+			noHits: true,
+		},
+		message: "No matching memories found.",
+	};
+	return {
+		...response,
+		...(extras?.bypassed ? { bypassed: true } : {}),
+		...(extras?.internal ? { internal: true } : {}),
 	};
 }

--- a/packages/daemon/src/hooks-recall.test.ts
+++ b/packages/daemon/src/hooks-recall.test.ts
@@ -1,8 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import type { Hono } from "hono";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { Hono } from "hono";
 
 let app: Hono;
 let dir = "";
@@ -69,6 +69,7 @@ describe("/api/hooks/recall", () => {
 		expect(body.meta?.noHits).toBeTrue();
 		expect(body.memories).toEqual(body.results);
 		expect(body.count).toBe(body.results.length);
+		expect(body.message).toBe("No matching memories found.");
 	});
 
 	it("rejects requests missing harness", async () => {
@@ -117,6 +118,7 @@ describe("/api/hooks/recall", () => {
 				hasSupplementary: false,
 				noHits: true,
 			},
+			message: "No matching memories found.",
 			internal: true,
 		});
 	});
@@ -147,6 +149,7 @@ describe("/api/hooks/recall", () => {
 				hasSupplementary: false,
 				noHits: true,
 			},
+			message: "No matching memories found.",
 			bypassed: true,
 		});
 	});

--- a/packages/daemon/src/mcp/tools.test.ts
+++ b/packages/daemon/src/mcp/tools.test.ts
@@ -238,7 +238,7 @@ describe("createMcpServer", () => {
 			expect(result.content[0]?.text).toContain("Primary matches:");
 			expect(result.content[0]?.text).not.toContain("Supporting context:");
 			expect(result.content[0]?.text).not.toContain("supporting rationale");
-			expect(result.content[0]?.text).toContain("test (fact, hybrid, 2026-04-07)");
+			expect(result.content[0]?.text).toContain("id: 1; test (fact, hybrid, 2026-04-07)");
 		});
 
 		it("returns error on fetch failure", async () => {
@@ -354,7 +354,7 @@ describe("createMcpServer", () => {
 			expect(result.isError).toBeUndefined();
 		});
 
-		it("prepends tags when provided", async () => {
+		it("passes tags as structured request metadata", async () => {
 			const cap: { body?: string } = {};
 			mockFetch(200, { id: "abc-456" }, cap);
 
@@ -364,7 +364,8 @@ describe("createMcpServer", () => {
 			});
 
 			const body = JSON.parse(cap.body ?? "{}");
-			expect(body.content).toBe("[foo,bar]: tagged memory");
+			expect(body.content).toBe("tagged memory");
+			expect(body.tags).toBe("foo,bar");
 		});
 
 		it("passes pinned through to request body", async () => {

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -7,7 +7,12 @@
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { applyRecallScoreThreshold, partitionRecallRows } from "@signet/core";
+import {
+	applyRecallScoreThreshold,
+	buildRecallRequestBody,
+	buildRememberRequestBody,
+	formatRecallText,
+} from "@signet/core";
 import { z } from "zod";
 
 // ---------------------------------------------------------------------------
@@ -97,36 +102,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function normalizeStructuredMemoryPayload(value: unknown): unknown {
-	if (!isRecord(value)) return value;
-	const aspects = value.aspects;
-	if (!Array.isArray(aspects)) return value;
-
-	return {
-		...value,
-		aspects: aspects.map((aspect) => {
-			if (!isRecord(aspect)) return aspect;
-			if (typeof aspect.entityName === "string" && Array.isArray(aspect.attributes)) return aspect;
-			if (typeof aspect.entity === "string" && typeof aspect.aspect === "string" && typeof aspect.value === "string") {
-				return {
-					entityName: aspect.entity,
-					aspect: aspect.aspect,
-					attributes: [
-						{
-							content: aspect.value,
-							...(typeof aspect.groupKey === "string" ? { groupKey: aspect.groupKey } : {}),
-							...(typeof aspect.claimKey === "string" ? { claimKey: aspect.claimKey } : {}),
-							...(typeof aspect.confidence === "number" ? { confidence: aspect.confidence } : {}),
-							...(typeof aspect.importance === "number" ? { importance: aspect.importance } : {}),
-						},
-					],
-				};
-			}
-			return aspect;
-		}),
-	};
-}
-
 interface DaemonResponse<T> {
 	readonly ok: true;
 	readonly data: T;
@@ -139,32 +114,6 @@ interface DaemonError {
 }
 
 type FetchResult<T> = DaemonResponse<T> | DaemonError;
-
-interface RecallToolRow {
-	readonly content: string;
-	readonly created_at?: string;
-	readonly score?: number;
-	readonly source?: string;
-	readonly type?: string;
-	readonly tags?: string | null;
-	readonly who?: string;
-	readonly pinned?: boolean;
-	readonly project?: string | null;
-	readonly supplementary?: boolean;
-}
-
-interface RecallToolMeta {
-	readonly totalReturned: number;
-	readonly hasSupplementary: boolean;
-	readonly noHits: boolean;
-}
-
-interface RecallToolPayload {
-	readonly query?: string;
-	readonly method?: string;
-	readonly results?: ReadonlyArray<RecallToolRow>;
-	readonly meta?: RecallToolMeta;
-}
 
 const BASE_TOOL_NAMES = new Set<string>([
 	"memory_search",
@@ -268,58 +217,6 @@ function textResult(value: unknown): { content: Array<{ type: "text"; text: stri
 			},
 		],
 	};
-}
-
-function formatRecallToolResult(value: unknown): string {
-	if (typeof value !== "object" || value === null || Array.isArray(value)) {
-		return typeof value === "string" ? value : JSON.stringify(value, null, 2);
-	}
-
-	const payload = value as RecallToolPayload;
-	const rows = Array.isArray(payload.results) ? payload.results : [];
-	const meta =
-		payload.meta && typeof payload.meta === "object"
-			? payload.meta
-			: {
-					totalReturned: rows.length,
-					hasSupplementary: rows.some((row) => row.supplementary === true),
-					noHits: rows.length === 0,
-				};
-
-	if (meta.noHits || rows.length === 0) {
-		return "No matching memories found.";
-	}
-
-	const { primary, supporting } = partitionRecallRows(rows);
-	const noun = meta.totalReturned === 1 ? "memory" : "memories";
-	const parts = [`Found ${meta.totalReturned} ${noun}${payload.method ? ` (${payload.method})` : ""}.`];
-
-	if (primary.length > 0) {
-		parts.push("", "Primary matches:");
-		parts.push(
-			...primary.map((row) => {
-				const score = typeof row.score === "number" ? `[${(row.score * 100).toFixed(0)}%] ` : "";
-				const source = typeof row.source === "string" ? row.source : "unknown";
-				const type = typeof row.type === "string" ? row.type : "memory";
-				const createdAt = typeof row.created_at === "string" ? row.created_at.slice(0, 10) : "unknown";
-				return `- ${score}${row.content} (${type}, ${source}, ${createdAt})`;
-			}),
-		);
-	}
-
-	if (supporting.length > 0) {
-		parts.push("", "Supporting context:");
-		parts.push(
-			...supporting.map((row) => {
-				const source = typeof row.source === "string" ? row.source : "unknown";
-				const type = typeof row.type === "string" ? row.type : "memory";
-				const createdAt = typeof row.created_at === "string" ? row.created_at.slice(0, 10) : "unknown";
-				return `- ${row.content} (${type}, ${source}, ${createdAt})`;
-			}),
-		);
-	}
-
-	return parts.join("\n");
 }
 
 function errorResult(msg: string): {
@@ -686,9 +583,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 		}) => {
 			const result = await daemonFetch<unknown>(baseUrl, "/api/memory/recall", {
 				method: "POST",
-				body: {
-					query,
-					keywordQuery: keyword_query,
+				body: buildRecallRequestBody(query, {
+					keyword_query,
 					limit: limit ?? 10,
 					project,
 					type,
@@ -698,8 +594,8 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 					importance_min: importance_min ?? min_score,
 					since,
 					until,
-					expand: expand === true ? true : undefined,
-				},
+					expand,
+				}),
 			});
 
 			if (!result.ok) {
@@ -707,7 +603,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 			}
 			// Score thresholds trim ranked matches, but intentionally keep
 			// unscored supporting context in-band.
-			return textResult(formatRecallToolResult(applyRecallScoreThreshold(result.data, score_min)));
+			return textResult(formatRecallText(applyRecallScoreThreshold(result.data, score_min)));
 		},
 	);
 
@@ -798,24 +694,18 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 			annotations: { readOnlyHint: false },
 		},
 		async ({ content, type, importance, tags, hints, transcript, structured, pinned, createdAt }) => {
-			// Prepend tags prefix if provided (daemon parses [tag1,tag2]: format)
-			let body = content;
-			if (tags) {
-				body = `[${tags}]: ${content}`;
-			}
-			const normalizedStructured = normalizeStructuredMemoryPayload(structured);
-
 			const result = await daemonFetch<unknown>(baseUrl, "/api/memory/remember", {
 				method: "POST",
-				body: {
-					content: body,
+				body: buildRememberRequestBody(content, {
+					type,
 					importance,
+					tags,
 					hints,
 					transcript,
-					structured: normalizedStructured,
+					structured,
 					pinned,
 					createdAt,
-				},
+				}),
 			});
 
 			if (!result.ok) {

--- a/packages/daemon/src/routes/hooks-routes.ts
+++ b/packages/daemon/src/routes/hooks-routes.ts
@@ -1,5 +1,6 @@
 import type { Database } from "bun:sqlite";
 import { existsSync } from "node:fs";
+import { emptyHookRecallResponse, withHookRecallCompat } from "@signet/core";
 import type { Context } from "hono";
 import type { Hono } from "hono";
 import { getAgentScope, resolveAgentId } from "../agent-id";
@@ -55,7 +56,15 @@ import {
 	renewSession,
 } from "../session-tracker.js";
 import { upsertThreadHead } from "../thread-heads";
-import { AGENTS_DIR, INTERNAL_SELF_HOST, MEMORY_DB, PORT, authConfig, authCrossAgentMessageLimiter, harnessLastSeen } from "./state";
+import {
+	AGENTS_DIR,
+	INTERNAL_SELF_HOST,
+	MEMORY_DB,
+	PORT,
+	authConfig,
+	authCrossAgentMessageLimiter,
+	harnessLastSeen,
+} from "./state";
 import {
 	parseOptionalBoolean,
 	parseOptionalInt,
@@ -111,51 +120,6 @@ function checkBypass(body?: { sessionKey?: string; sessionId?: string }): boolea
 	return isSessionBypassed(key);
 }
 
-function emptyHookRecallResponse(
-	query: string,
-	extras?: { readonly bypassed?: boolean; readonly internal?: boolean },
-): {
-	results: [];
-	memories: [];
-	count: 0;
-	query: string;
-	method: "hybrid";
-	meta: {
-		totalReturned: 0;
-		hasSupplementary: false;
-		noHits: true;
-	};
-	bypassed?: boolean;
-	internal?: boolean;
-} {
-	return {
-		results: [],
-		memories: [],
-		count: 0,
-		query,
-		method: "hybrid",
-		meta: {
-			totalReturned: 0,
-			hasSupplementary: false,
-			noHits: true,
-		},
-		...(extras?.bypassed ? { bypassed: true } : {}),
-		...(extras?.internal ? { internal: true } : {}),
-	};
-}
-
-function withHookRecallCompat<
-	T extends {
-		readonly results: ReadonlyArray<unknown>;
-	},
->(result: T): T & { memories: T["results"]; count: number } {
-	return {
-		...result,
-		memories: result.results,
-		count: result.results.length,
-	};
-}
-
 export function listLiveSessions(agentId: string): Array<{
 	key: string;
 	runtimePath: string;
@@ -163,7 +127,10 @@ export function listLiveSessions(agentId: string): Array<{
 	expiresAt: string | null;
 	bypassed: boolean;
 }> {
-	const byKey = new Map<string, { key: string; runtimePath: string; claimedAt: string; expiresAt: string | null; bypassed: boolean }>(
+	const byKey = new Map<
+		string,
+		{ key: string; runtimePath: string; claimedAt: string; expiresAt: string | null; bypassed: boolean }
+	>(
 		getActiveSessions()
 			.filter((s) => s.agentId === agentId)
 			.map((session) => [session.key, session] as const),

--- a/packages/opencode-plugin/src/tools.ts
+++ b/packages/opencode-plugin/src/tools.ts
@@ -6,11 +6,59 @@
  */
 
 import { tool } from "@opencode-ai/plugin";
+import {
+	applyRecallScoreThreshold,
+	buildRecallRequestBody,
+	buildRememberRequestBody,
+	formatRecallText,
+} from "@signet/core";
 import type { DaemonClient } from "./daemon-client.js";
 import { HARNESS, READ_TIMEOUT, WRITE_TIMEOUT } from "./types.js";
-import type { MemoryRecord, RecallResult } from "./types.js";
+import type { MemoryRecord } from "./types.js";
 
 const DAEMON_OFFLINE_MSG = "Signet daemon not running. Start with: signet daemon start";
+
+async function searchMemory(
+	client: DaemonClient,
+	args: { readonly query: string; readonly limit?: number; readonly type?: string; readonly min_score?: number },
+): Promise<string> {
+	const result = await client.post<unknown>(
+		"/api/memory/recall",
+		buildRecallRequestBody(args.query, {
+			limit: args.limit ?? 10,
+			type: args.type,
+		}),
+		READ_TIMEOUT,
+	);
+
+	if (result === null) return DAEMON_OFFLINE_MSG;
+	return formatRecallText(applyRecallScoreThreshold(result, args.min_score));
+}
+
+async function storeMemory(
+	client: DaemonClient,
+	args: {
+		readonly content: string;
+		readonly type?: string;
+		readonly importance?: number;
+		readonly tags?: readonly string[];
+		readonly pinned?: boolean;
+	},
+): Promise<{ readonly offline: true } | { readonly offline: false; readonly id?: string; readonly memoryId?: string }> {
+	const result = await client.post<{ readonly id?: string; readonly memoryId?: string }>(
+		"/api/memory/remember",
+		buildRememberRequestBody(args.content, {
+			type: args.type,
+			importance: args.importance,
+			tags: args.tags,
+			pinned: args.pinned,
+			who: HARNESS,
+		}),
+		WRITE_TIMEOUT,
+	);
+
+	return result === null ? { offline: true } : { offline: false, ...result };
+}
 
 // ============================================================================
 // Tool factory
@@ -27,24 +75,9 @@ export function createTools(client: DaemonClient): Record<string, ReturnType<typ
 				min_score: tool.schema.number().optional().describe("Minimum relevance score threshold"),
 			},
 			async execute(args): Promise<string> {
-				const result = await client.post<{ results: RecallResult[] }>(
-					"/api/memory/recall",
-					{
-						query: args.query,
-						limit: args.limit ?? 10,
-						type: args.type,
-						min_score: args.min_score,
-					},
-					READ_TIMEOUT,
-				);
-
-				if (result === null) return DAEMON_OFFLINE_MSG;
-				if (!result.results.length) return "No memories found.";
-
-				return result.results.map((r) => `[${r.type}] (score: ${r.score.toFixed(2)}) ${r.content}`).join("\n");
+				return searchMemory(client, args);
 			},
 		}),
-
 		memory_store: tool({
 			description: "Save a new memory",
 			args: {
@@ -55,20 +88,8 @@ export function createTools(client: DaemonClient): Record<string, ReturnType<typ
 				pinned: tool.schema.boolean().optional().describe("Pin this memory — prevents decay"),
 			},
 			async execute(args): Promise<string> {
-				const result = await client.post<{ id?: string; memoryId?: string }>(
-					"/api/memory/remember",
-					{
-						content: args.content,
-						type: args.type,
-						importance: args.importance,
-						tags: args.tags,
-						pinned: args.pinned,
-						who: HARNESS,
-					},
-					WRITE_TIMEOUT,
-				);
-
-				if (result === null) return DAEMON_OFFLINE_MSG;
+				const result = await storeMemory(client, args);
+				if (result.offline) return DAEMON_OFFLINE_MSG;
 				const id = result.id ?? result.memoryId;
 				return id ? `Memory saved${args.pinned ? " (pinned)" : ""} (id: ${id})` : "Memory saved.";
 			},
@@ -176,20 +197,8 @@ export function createTools(client: DaemonClient): Record<string, ReturnType<typ
 				pinned: tool.schema.boolean().optional().describe("Pin this memory — prevents decay"),
 			},
 			async execute(args): Promise<string> {
-				const result = await client.post<{ id?: string; memoryId?: string }>(
-					"/api/memory/remember",
-					{
-						content: args.content,
-						type: args.type,
-						importance: args.importance,
-						tags: args.tags,
-						pinned: args.pinned,
-						who: HARNESS,
-					},
-					WRITE_TIMEOUT,
-				);
-
-				if (result === null) return DAEMON_OFFLINE_MSG;
+				const result = await storeMemory(client, args);
+				if (result.offline) return DAEMON_OFFLINE_MSG;
 				const id = result.id ?? result.memoryId;
 				return id ? `Saved${args.pinned ? " (pinned)" : ""}: ${args.content.slice(0, 50)}` : "Saved.";
 			},
@@ -202,16 +211,7 @@ export function createTools(client: DaemonClient): Record<string, ReturnType<typ
 				limit: tool.schema.number().optional().describe("Max results"),
 			},
 			async execute(args): Promise<string> {
-				const result = await client.post<{ results: RecallResult[] }>(
-					"/api/memory/recall",
-					{ query: args.query, limit: args.limit ?? 10 },
-					READ_TIMEOUT,
-				);
-
-				if (result === null) return DAEMON_OFFLINE_MSG;
-				if (!result.results.length) return "No memories found.";
-
-				return result.results.map((r) => `- ${r.content}`).join("\n");
+				return searchMemory(client, args);
 			},
 		}),
 	};

--- a/packages/opencode-plugin/src/types.ts
+++ b/packages/opencode-plugin/src/types.ts
@@ -1,8 +1,8 @@
 /**
  * Standalone types for the Signet OpenCode plugin.
  *
- * No @signet/* dependencies — this package must be independently
- * distributable.
+ * Keep runtime behavior routed through shared @signet/core helpers where
+ * possible so OpenCode stays aligned with CLI, MCP, and harness surfaces.
  */
 
 export const DAEMON_URL_DEFAULT = "http://localhost:3850";
@@ -29,13 +29,4 @@ export interface MemoryRecord {
 	readonly who: string | null;
 	readonly created_at: string;
 	readonly updated_at: string;
-}
-
-export interface RecallResult {
-	readonly id: string;
-	readonly content: string;
-	readonly type: string;
-	readonly importance: number;
-	readonly score: number;
-	readonly created_at: string;
 }

--- a/packages/pi-extension/index.test.ts
+++ b/packages/pi-extension/index.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join, relative } from "node:path";
+import { parseRecallPayload } from "@signet/core";
 import SignetPiExtension, { loadConfig, parseRememberArgs, recallMemories, rememberContent } from "./src/index.js";
 
 // ============================================================================
@@ -220,12 +221,13 @@ describe("recallMemories", () => {
 		});
 		servers.push(server);
 
-		const results = await recallMemories(`http://127.0.0.1:${server.port}`, "bun");
+		const result = await recallMemories(`http://127.0.0.1:${server.port}`, "bun");
+		const rows = parseRecallPayload(result).rows;
 		expect(capturedMethod).toBe("POST");
 		expect(capturedPath).toBe("/api/memory/recall");
-		expect(results).toHaveLength(1);
-		expect(results[0]?.content).toBe("use bun");
-		expect(results[0]?.importance).toBe(0.9);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.content).toBe("use bun");
+		expect(rows[0]?.importance).toBe(0.9);
 	});
 
 	it("returns empty array when results field is absent", async () => {
@@ -237,11 +239,11 @@ describe("recallMemories", () => {
 		});
 		servers.push(server);
 
-		const results = await recallMemories(`http://127.0.0.1:${server.port}`, "nothing");
-		expect(results).toEqual([]);
+		const result = await recallMemories(`http://127.0.0.1:${server.port}`, "nothing");
+		expect(parseRecallPayload(result).rows).toEqual([]);
 	});
 
-	it("deserializes comma-separated string tags into an array", async () => {
+	it("preserves daemon recall rows without local reshaping", async () => {
 		const server = Bun.serve({
 			port: 0,
 			async fetch() {
@@ -265,8 +267,8 @@ describe("recallMemories", () => {
 		});
 		servers.push(server);
 
-		const [mem] = await recallMemories(`http://127.0.0.1:${server.port}`, "x");
-		expect(mem?.tags).toEqual(["a", "b", "c"]);
+		const result = await recallMemories(`http://127.0.0.1:${server.port}`, "x");
+		expect(parseRecallPayload(result).rows[0]?.tags).toBe("a,b,c");
 	});
 
 	it("does not send a scope field by default (preserves daemon unscoped-memory path)", async () => {
@@ -328,7 +330,7 @@ describe("rememberContent", () => {
 		});
 		expect(capturedBody.content).toBe("test memory");
 		expect(capturedBody.pinned).toBe(true);
-		expect(capturedBody.tags).toEqual(["tag1", "tag2"]);
+		expect(capturedBody.tags).toBe("tag1,tag2");
 	});
 
 	it("throws when the daemon returns an error status", async () => {
@@ -531,10 +533,7 @@ describe("SignetPiExtension", () => {
 		);
 
 		expect(result).toBeUndefined();
-		expect(requests.map((req) => req.path)).toEqual([
-			"/api/hooks/session-start",
-			"/api/hooks/pre-compaction",
-		]);
+		expect(requests.map((req) => req.path)).toEqual(["/api/hooks/session-start", "/api/hooks/pre-compaction"]);
 		expect(requests[1]?.body).toEqual({
 			harness: "pi",
 			sessionKey: "session-pi-compact-1",

--- a/packages/pi-extension/src/index.ts
+++ b/packages/pi-extension/src/index.ts
@@ -1,6 +1,13 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { resolvePiAgentDir } from "@signet/core";
+import {
+	buildRecallRequestBody,
+	buildRememberRequestBody,
+	formatRecallText,
+	parseRecallPayload,
+	resolvePiAgentDir,
+} from "@signet/core";
+import type { RecallPayload } from "@signet/core";
 import { readRuntimeEnv, readTrimmedRuntimeEnv, readTrimmedString } from "@signet/pi-extension-base";
 import { Type } from "@sinclair/typebox";
 import { createDaemonClient } from "./daemon-client.js";
@@ -118,18 +125,19 @@ export async function recallMemories(
 		agentId?: string;
 		scope?: "global" | "agent" | "session";
 	} = {},
-): Promise<Array<{ id: string; content: string; importance?: number; tags?: string[] }>> {
+): Promise<RecallPayload> {
 	const { limit = 10, agentId, scope } = options;
 
 	const response = await fetch(`${daemonUrl}/api/memory/recall`, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({
-			query,
-			limit,
-			agentId,
-			...(scope !== undefined && { scope }),
-		}),
+		body: JSON.stringify(
+			buildRecallRequestBody(query, {
+				limit,
+				agentId,
+				scope,
+			}),
+		),
 		signal: AbortSignal.timeout(READ_TIMEOUT),
 	});
 
@@ -138,23 +146,8 @@ export async function recallMemories(
 		throw new Error(`Recall failed: ${error}`);
 	}
 
-	const data = (await response.json()) as {
-		results?: Array<{ id: string; content: string; importance?: number; tags?: string | null }>;
-	};
-	return (data.results ?? []).map((r) => ({
-		id: r.id,
-		content: r.content,
-		importance: r.importance,
-		tags:
-			typeof r.tags === "string"
-				? r.tags
-						.split(",")
-						.map((t) => t.trim())
-						.filter(Boolean)
-				: undefined,
-	}));
+	return (await response.json()) as RecallPayload;
 }
-
 export async function rememberContent(
 	daemonUrl: string,
 	content: string,
@@ -169,14 +162,16 @@ export async function rememberContent(
 	const response = await fetch(`${daemonUrl}/api/hooks/remember`, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({
-			harness: HARNESS,
-			content,
-			pinned: critical,
-			tags,
-			agentId,
-			source: "pi-extension",
-		}),
+		body: JSON.stringify(
+			buildRememberRequestBody(content, {
+				harness: HARNESS,
+				pinned: critical,
+				tags,
+				agentId,
+				source: "pi-extension",
+				runtimePath: RUNTIME_PATH,
+			}),
+		),
 		signal: AbortSignal.timeout(WRITE_TIMEOUT),
 	});
 
@@ -185,7 +180,6 @@ export async function rememberContent(
 		throw new Error(`Remember failed: ${error}`);
 	}
 }
-
 export async function sendMemoryFeedback(
 	daemonUrl: string,
 	sessionKey: string,
@@ -373,25 +367,19 @@ function registerCommandsAndTools(pi: PiExtensionApi, daemonUrl: string, agentId
 			ctx.ui.notify(`Recalling: "${args}"...`, "info");
 
 			try {
-				const memories = await recallMemories(daemonUrl, args, { limit: 5, agentId });
+				const recall = await recallMemories(daemonUrl, args, { limit: 5, agentId });
+				const parsed = parseRecallPayload(recall);
 
-				if (memories.length === 0) {
+				if (parsed.rows.length === 0) {
 					ctx.ui.notify("No relevant memories found", "info");
 					return;
 				}
 
 				state.lastRecall = new Date().toISOString();
-				state.memoryCount = memories.length;
+				state.memoryCount = parsed.rows.length;
 				updateStatus(ctx);
 
-				const formatted = memories
-					.map((m, i) => {
-						const tags = m.tags?.length ? `[${m.tags.join(", ")}] ` : "";
-						return `${i + 1}. [${m.id}] ${tags}${m.content}`;
-					})
-					.join("\n");
-
-				ctx.ui.notify(`Found ${memories.length} memories:\n${formatted}`, "success");
+				ctx.ui.notify(formatRecallText(recall), "success");
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				ctx.ui.notify(`Recall failed: ${message}`, "error");
@@ -490,9 +478,10 @@ function registerCommandsAndTools(pi: PiExtensionApi, daemonUrl: string, agentId
 			try {
 				const query = String(params.query || "");
 				const limit = typeof params.limit === "number" ? params.limit : 5;
-				const memories = await recallMemories(daemonUrl, query, { limit, agentId });
+				const recall = await recallMemories(daemonUrl, query, { limit, agentId });
+				const parsed = parseRecallPayload(recall);
 
-				if (memories.length === 0) {
+				if (parsed.rows.length === 0) {
 					return {
 						content: [{ type: "text", text: "No relevant memories found for this query." }],
 						details: { memoriesFound: 0 },
@@ -500,23 +489,12 @@ function registerCommandsAndTools(pi: PiExtensionApi, daemonUrl: string, agentId
 				}
 
 				state.lastRecall = new Date().toISOString();
-				state.memoryCount = memories.length;
+				state.memoryCount = parsed.rows.length;
 				updateStatus(ctx);
 
-				const formatted = memories.map((m, i) => {
-					const tags = m.tags?.length ? `[tags: ${m.tags.join(", ")}]` : "";
-					const importance = m.importance ? `[importance: ${m.importance.toFixed(2)}]` : "";
-					return `${i + 1}. [id: ${m.id}] ${m.content} ${tags} ${importance}`.trim();
-				});
-
 				return {
-					content: [
-						{
-							type: "text",
-							text: `Found ${memories.length} relevant memories:\n\n${formatted.join("\n")}`,
-						},
-					],
-					details: { memoriesFound: memories.length, memories },
+					content: [{ type: "text", text: formatRecallText(recall) }],
+					details: { memoriesFound: parsed.rows.length, memories: parsed.rows, meta: parsed.meta },
 				};
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary

Align the CLI, MCP, hook, and harness recall/remember surfaces around shared `@signet/core` helpers so benchmark-era recall behavior is not duplicated across adapters.

This applies the MemoryBench lessons to the surfaces developers and agents actually use: daemon recall owns the canonical payload and formatted message, while harnesses stay thin and avoid local ranking/presentation drift.

## Changes

- Added shared recall/remember surface helpers in `@signet/core` for request construction, structured remember normalization, score threshold filtering, payload parsing, hook compatibility, and canonical recall text formatting.
- Routed CLI memory commands, daemon MCP tools, `/api/hooks/recall`, OpenCode tools, Pi extension tools, OpenClaw generated hooks, and the OpenClaw runtime adapter through the shared helpers.
- Updated MCP remember behavior so tags and structured metadata are forwarded as metadata instead of being folded into memory text.
- Updated docs for the canonical hook recall `message` and MCP memory metadata behavior.
- Added/updated regression coverage for the shared helpers and affected surfaces.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [x] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [x] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: `@signet/opencode-plugin`, `@signet/pi-extension`, `packages/adapters/openclaw`

## Screenshots

N/A, no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A, no migrations touched.

## Testing

- [x] `bun scripts/spec-deps-check.ts`
- [x] Targeted test set: `bun test packages/adapters/openclaw/src/index.test.ts packages/core/src/recall.test.ts packages/daemon/src/mcp/tools.test.ts packages/daemon/src/hooks-recall.test.ts packages/cli/src/commands/memory.test.ts packages/connector-openclaw/test/index.test.ts packages/pi-extension/index.test.ts`
- [x] Targeted Biome check on changed files
- [x] `bun run typecheck`
- [x] `bun run build`
- [ ] `bun run lint` passes
- [ ] Tested against running daemon

Note: full repo `bun run lint` remains noisy with preexisting Biome/package formatting failures outside this slice. Changed files passed a targeted Biome check.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The SDK and Python-only Hermes connector remain follow-up candidates because this slice intentionally avoids adding new publish-time coupling or duplicating TypeScript core logic in Python.
