### PR TITLE
fix(cli): run Bun global installs with Bun

### DIFF
--- a/packages/signetai/bin/runtime.js
+++ b/packages/signetai/bin/runtime.js
@@ -1,0 +1,40 @@
+import { homedir } from "node:os";
+import { join, normalize, sep } from "node:path";
+
+function stripTrailingSeparator(path) {
+	const normalized = normalize(path);
+	return normalized.length > 1 && normalized.endsWith(sep) ? normalized.slice(0, -1) : normalized;
+}
+
+function containsPath(root, path) {
+	const normalizedRoot = stripTrailingSeparator(root);
+	const normalizedPath = stripTrailingSeparator(path);
+	return normalizedPath === normalizedRoot || normalizedPath.startsWith(`${normalizedRoot}${sep}`);
+}
+
+export function bunGlobalPackageRoots(env = process.env, homeDir = homedir()) {
+	const roots = [];
+	const bunInstall = typeof env.BUN_INSTALL === "string" ? env.BUN_INSTALL.trim() : "";
+
+	if (bunInstall) {
+		roots.push(join(bunInstall, "install", "global", "node_modules", "signetai"));
+	}
+
+	roots.push(join(homeDir, ".bun", "install", "global", "node_modules", "signetai"));
+
+	return Array.from(new Set(roots.map(stripTrailingSeparator)));
+}
+
+export function isBunGlobalPackageDir(packageDir, env = process.env, homeDir = homedir()) {
+	return bunGlobalPackageRoots(env, homeDir).some((root) => containsPath(root, packageDir));
+}
+
+export function shouldRunCliWithBun({
+	isBunRuntime,
+	packageDir,
+	bunAvailable,
+	env = process.env,
+	homeDir = homedir(),
+}) {
+	return !isBunRuntime && bunAvailable && isBunGlobalPackageDir(packageDir, env, homeDir);
+}

--- a/packages/signetai/bin/runtime.js
+++ b/packages/signetai/bin/runtime.js
@@ -1,15 +1,24 @@
 import { homedir } from "node:os";
-import { join, normalize, sep } from "node:path";
+import { join, normalize } from "node:path";
 
 function stripTrailingSeparator(path) {
-	const normalized = normalize(path);
-	return normalized.length > 1 && normalized.endsWith(sep) ? normalized.slice(0, -1) : normalized;
+	const normalized = normalize(path.replaceAll("\\", "/")).replaceAll("\\", "/");
+	return normalized.length > 1 && normalized.endsWith("/") ? normalized.slice(0, -1) : normalized;
 }
 
-function containsPath(root, path) {
-	const normalizedRoot = stripTrailingSeparator(root);
-	const normalizedPath = stripTrailingSeparator(path);
-	return normalizedPath === normalizedRoot || normalizedPath.startsWith(`${normalizedRoot}${sep}`);
+function caseInsensitivePathPlatform(platform) {
+	return platform === "darwin" || platform === "win32";
+}
+
+function comparablePath(path, platform) {
+	const normalized = stripTrailingSeparator(path);
+	return caseInsensitivePathPlatform(platform) ? normalized.toLowerCase() : normalized;
+}
+
+function containsPath(root, path, platform) {
+	const normalizedRoot = comparablePath(root, platform);
+	const normalizedPath = comparablePath(path, platform);
+	return normalizedPath === normalizedRoot || normalizedPath.startsWith(`${normalizedRoot}/`);
 }
 
 export function bunGlobalPackageRoots(env = process.env, homeDir = homedir()) {
@@ -25,8 +34,8 @@ export function bunGlobalPackageRoots(env = process.env, homeDir = homedir()) {
 	return Array.from(new Set(roots.map(stripTrailingSeparator)));
 }
 
-export function isBunGlobalPackageDir(packageDir, env = process.env, homeDir = homedir()) {
-	return bunGlobalPackageRoots(env, homeDir).some((root) => containsPath(root, packageDir));
+export function isBunGlobalPackageDir(packageDir, env = process.env, homeDir = homedir(), platform = process.platform) {
+	return bunGlobalPackageRoots(env, homeDir).some((root) => containsPath(root, packageDir, platform));
 }
 
 export function shouldRunCliWithBun({
@@ -35,6 +44,7 @@ export function shouldRunCliWithBun({
 	bunAvailable,
 	env = process.env,
 	homeDir = homedir(),
+	platform = process.platform,
 }) {
-	return !isBunRuntime && bunAvailable && isBunGlobalPackageDir(packageDir, env, homeDir);
+	return !isBunRuntime && bunAvailable && isBunGlobalPackageDir(packageDir, env, homeDir, platform);
 }

--- a/packages/signetai/bin/signet.js
+++ b/packages/signetai/bin/signet.js
@@ -4,16 +4,20 @@
  *
  * Routes to the appropriate runtime based on command:
  * - Most commands: Node.js (cli.js)
+ * - Bun global installs: Bun (cli.js) - avoids unbuilt better-sqlite3 bindings
  * - Daemon start: Bun (daemon.js) - required for bun:sqlite
  */
 
 import { spawn, spawnSync } from "node:child_process";
+import { existsSync, realpathSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { existsSync } from "node:fs";
+import { shouldRunCliWithBun } from "./runtime.js";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+const entryPath = realpathSync(fileURLToPath(import.meta.url));
+const __dirname = dirname(entryPath);
 const distDir = join(__dirname, "..", "dist");
+const packageDir = join(__dirname, "..");
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -36,8 +40,10 @@ function hasBun() {
 	}
 }
 
+const bunAvailable = hasBun();
+
 // Run with appropriate runtime
-if (isDaemonCommand && !hasBun()) {
+if (isDaemonCommand && !bunAvailable) {
 	console.error("Error: Bun is required to run the Signet daemon.");
 	console.error("Install Bun: curl -fsSL https://bun.sh/install | bash");
 	process.exit(1);
@@ -52,8 +58,35 @@ if (!existsSync(cliPath)) {
 	process.exit(1);
 }
 
-// Import and run CLI
-import(pathToFileURL(cliPath).href).catch((err) => {
-	console.error("Failed to start Signet:", err.message);
-	process.exit(1);
-});
+if (
+	shouldRunCliWithBun({
+		isBunRuntime: typeof globalThis.Bun !== "undefined",
+		packageDir,
+		bunAvailable,
+	})
+) {
+	const child = spawn("bun", [cliPath, ...args], {
+		stdio: "inherit",
+		env: process.env,
+		windowsHide: true,
+	});
+
+	child.on("error", (err) => {
+		console.error("Failed to start Signet with Bun:", err.message);
+		process.exit(1);
+	});
+
+	child.on("exit", (code, signal) => {
+		if (signal) {
+			process.kill(process.pid, signal);
+			return;
+		}
+		process.exit(code ?? 1);
+	});
+} else {
+	// Import and run CLI
+	import(pathToFileURL(cliPath).href).catch((err) => {
+		console.error("Failed to start Signet:", err.message);
+		process.exit(1);
+	});
+}

--- a/packages/signetai/test/runtime.test.ts
+++ b/packages/signetai/test/runtime.test.ts
@@ -26,6 +26,26 @@ describe("signet bin runtime selection", () => {
 		).toBe(true);
 	});
 
+	it("matches Bun global paths case-insensitively on default case-insensitive platforms", () => {
+		expect(
+			isBunGlobalPackageDir("/Users/Jason/.bun/install/global/node_modules/signetai", {}, "/Users/jason", "darwin"),
+		).toBe(true);
+		expect(
+			isBunGlobalPackageDir(
+				"C:\\USERS\\JASON\\.bun\\install\\global\\node_modules\\signetai",
+				{},
+				"C:\\Users\\jason",
+				"win32",
+			),
+		).toBe(true);
+	});
+
+	it("keeps path matching case-sensitive on Linux", () => {
+		expect(
+			isBunGlobalPackageDir("/home/Jason/.bun/install/global/node_modules/signetai", {}, "/home/jason", "linux"),
+		).toBe(false);
+	});
+
 	it("does not treat npm global installs as Bun installs", () => {
 		expect(isBunGlobalPackageDir("/usr/local/lib/node_modules/signetai", {}, "/Users/jason")).toBe(false);
 	});

--- a/packages/signetai/test/runtime.test.ts
+++ b/packages/signetai/test/runtime.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { bunGlobalPackageRoots, isBunGlobalPackageDir, shouldRunCliWithBun } from "../bin/runtime.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const packageRoot = join(here, "..");
+
+describe("signet bin runtime selection", () => {
+	it("recognizes the default Bun global package path", () => {
+		expect(isBunGlobalPackageDir("/Users/jason/.bun/install/global/node_modules/signetai", {}, "/Users/jason")).toBe(
+			true,
+		);
+	});
+
+	it("recognizes custom BUN_INSTALL global package paths", () => {
+		expect(
+			isBunGlobalPackageDir(
+				"/opt/bun/install/global/node_modules/signetai",
+				{ BUN_INSTALL: "/opt/bun" },
+				"/Users/jason",
+			),
+		).toBe(true);
+	});
+
+	it("does not treat npm global installs as Bun installs", () => {
+		expect(isBunGlobalPackageDir("/usr/local/lib/node_modules/signetai", {}, "/Users/jason")).toBe(false);
+	});
+
+	it("re-runs the CLI with Bun only from Node in a Bun global install", () => {
+		const packageDir = "/Users/jason/.bun/install/global/node_modules/signetai";
+
+		expect(
+			shouldRunCliWithBun({
+				isBunRuntime: false,
+				packageDir,
+				bunAvailable: true,
+				env: {},
+				homeDir: "/Users/jason",
+			}),
+		).toBe(true);
+		expect(
+			shouldRunCliWithBun({
+				isBunRuntime: true,
+				packageDir,
+				bunAvailable: true,
+				env: {},
+				homeDir: "/Users/jason",
+			}),
+		).toBe(false);
+		expect(
+			shouldRunCliWithBun({
+				isBunRuntime: false,
+				packageDir,
+				bunAvailable: false,
+				env: {},
+				homeDir: "/Users/jason",
+			}),
+		).toBe(false);
+	});
+
+	it("deduplicates matching default and custom Bun install roots", () => {
+		expect(bunGlobalPackageRoots({ BUN_INSTALL: "/Users/jason/.bun" }, "/Users/jason")).toEqual([
+			"/Users/jason/.bun/install/global/node_modules/signetai",
+		]);
+	});
+
+	it("re-executes a Bun global install through the bun binary", () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-bun-global-"));
+		const pkg = join(root, "install", "global", "node_modules", "signetai");
+		const fakeBin = join(root, "bin");
+		const argsFile = join(root, "bun-args.txt");
+
+		try {
+			mkdirSync(join(pkg, "bin"), { recursive: true });
+			mkdirSync(join(pkg, "dist"), { recursive: true });
+			mkdirSync(fakeBin, { recursive: true });
+			copyFileSync(join(packageRoot, "bin", "signet.js"), join(pkg, "bin", "signet.js"));
+			copyFileSync(join(packageRoot, "bin", "runtime.js"), join(pkg, "bin", "runtime.js"));
+			writeFileSync(join(pkg, "dist", "cli.js"), "console.log('node cli should not run');\n");
+			writeFileSync(
+				join(fakeBin, "bun"),
+				`#!/usr/bin/env sh
+if [ "$1" = "--version" ]; then
+  echo "1.3.13"
+  exit 0
+fi
+printf '%s\\n' "$@" > "$SIGNET_TEST_BUN_ARGS"
+exit 17
+`,
+			);
+			chmodSync(join(fakeBin, "bun"), 0o755);
+
+			const result = spawnSync("node", [join(pkg, "bin", "signet.js"), "setup", "--non-interactive"], {
+				encoding: "utf8",
+				env: {
+					...process.env,
+					BUN_INSTALL: root,
+					PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+					SIGNET_TEST_BUN_ARGS: argsFile,
+				},
+			});
+
+			expect(result.status).toBe(17);
+			expect(readFileSync(argsFile, "utf8").trim().split("\n")).toEqual([
+				join(pkg, "dist", "cli.js"),
+				"setup",
+				"--non-interactive",
+			]);
+			expect(result.stdout).not.toContain("node cli should not run");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the Bun global install runtime mismatch reported in #538.

When `signetai` is installed with Bun, the `signet` binary still enters through the Node shebang. That made `signet setup` run the bundled CLI under Node, so database initialization selected the `better-sqlite3` fallback inside Bun's global package tree. On systems where Bun did not build those native bindings, setup crashed before completing.

This PR detects Bun global package installs, including custom `BUN_INSTALL` locations and the default `~/.bun` layout, and re-executes the bundled CLI with `bun` when the wrapper was launched by Node from that install tree. npm/global Node installs and local dev checkouts stay on the existing Node path.

## Validation

- `bun test packages/signetai/test/runtime.test.ts`
- `bunx biome check packages/signetai/bin/signet.js packages/signetai/bin/runtime.js packages/signetai/test/runtime.test.ts`
- `node packages/signetai/bin/signet.js --help`
- `bun packages/signetai/dist/cli.js --help`
- Packed `packages/signetai` with `npm pack`, installed the tarball into an isolated Bun global root with `bun add -g`, ran the packaged `signet --help`, and completed `signet setup --non-interactive` against a temporary workspace. The smoke test verified `agent.yaml` and `memory/memories.db` were created.
