### PR TITLE
fix(daemon): dedupe automatic hooks by runtime path

### DIFF
--- a/packages/cli/src/commands/hook.test.ts
+++ b/packages/cli/src/commands/hook.test.ts
@@ -104,6 +104,7 @@ describe("buildSessionEndBody", () => {
 			sessionKey: "sess-1",
 			cwd: "/tmp/project",
 			reason: "shutdown",
+			runtimePath: "legacy",
 		});
 	});
 
@@ -125,6 +126,7 @@ describe("buildSessionEndBody", () => {
 			sessionKey: "sess-canonical-key",
 			transcript: "",
 			transcriptPath: "/tmp/session.txt",
+			runtimePath: "legacy",
 		});
 	});
 });
@@ -151,12 +153,13 @@ describe("buildUserPromptSubmitBody", () => {
 			sessionKey: "sess-2",
 			transcriptPath: "",
 			transcript: "user: hi",
+			runtimePath: "legacy",
 			lastAssistantMessage: "prior answer",
 		});
 	});
 
 	test("hook command uses daemon result transport for user-prompt-submit", async () => {
-		const seen: Array<{ path: string; body: string }> = [];
+		const seen: Array<{ path: string; body: string; runtimePath: string | null }> = [];
 		const lines: string[] = [];
 		console.log = (line?: unknown) => {
 			lines.push(String(line ?? ""));
@@ -169,6 +172,7 @@ describe("buildUserPromptSubmitBody", () => {
 				seen.push({
 					path,
 					body: typeof opts?.body === "string" ? opts.body : "",
+					runtimePath: new Headers(opts?.headers).get("x-signet-runtime-path"),
 				});
 				return {
 					ok: true,
@@ -185,6 +189,8 @@ describe("buildUserPromptSubmitBody", () => {
 		expect(seen).toHaveLength(1);
 		expect(seen[0]?.path).toBe("/api/hooks/user-prompt-submit");
 		expect(seen[0]?.body).toContain('"harness":"claude-code"');
+		expect(seen[0]?.body).toContain('"runtimePath":"legacy"');
+		expect(seen[0]?.runtimePath).toBe("legacy");
 		expect(lines).toContain("recalled context");
 	});
 });
@@ -208,6 +214,7 @@ describe("buildCompactionCompleteBody", () => {
 			agentId: "agent-7",
 			sessionKey: "sess-3",
 			project: "/tmp/explicit-project",
+			runtimePath: "legacy",
 		});
 	});
 
@@ -228,6 +235,7 @@ describe("buildCompactionCompleteBody", () => {
 			project: "/tmp/legacy-project",
 			sessionKey: "sess-legacy-id",
 			summary: "summary text",
+			runtimePath: "legacy",
 		});
 	});
 
@@ -235,6 +243,7 @@ describe("buildCompactionCompleteBody", () => {
 		expect(buildCompactionCompleteBody(null, "claude-code", "summary text")).toEqual({
 			harness: "claude-code",
 			summary: "summary text",
+			runtimePath: "legacy",
 		});
 	});
 });

--- a/packages/cli/src/commands/hook.ts
+++ b/packages/cli/src/commands/hook.ts
@@ -13,6 +13,14 @@ interface HookDeps {
 }
 
 const SESSION_START_TIMEOUT_MS = resolveSessionStartTimeout();
+const LEGACY_RUNTIME_PATH = "legacy" as const;
+
+function legacyHookHeaders(headers?: HeadersInit): Headers {
+	const merged = new Headers(headers);
+	if (!merged.has("Content-Type")) merged.set("Content-Type", "application/json");
+	merged.set("x-signet-runtime-path", LEGACY_RUNTIME_PATH);
+	return merged;
+}
 
 function readTimeoutEnv(name: string): string {
 	const value = process.env[name];
@@ -61,7 +69,10 @@ async function fetchHookData<T>(
 	path: string,
 	opts?: RequestInit & { timeout?: number },
 ): Promise<T | null> {
-	const res = await deps.fetchDaemonResult<T>(path, opts);
+	const res = await deps.fetchDaemonResult<T>(path, {
+		...opts,
+		headers: legacyHookHeaders(opts?.headers),
+	});
 	if (res.ok) return res.data;
 	process.stderr.write(formatHookFailure(name, res));
 	return null;
@@ -95,13 +106,14 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 				error?: string;
 			}>("/api/hooks/session-start", {
 				method: "POST",
-				headers: { "Content-Type": "application/json" },
+				headers: legacyHookHeaders(),
 				body: JSON.stringify({
 					harness: options.harness,
 					project: options.project || stdinProject,
 					agentId: options.agentId,
 					context: options.context,
 					sessionKey,
+					runtimePath: LEGACY_RUNTIME_PATH,
 				}),
 				timeout: SESSION_START_TIMEOUT_MS,
 			});
@@ -214,6 +226,7 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 						messageCount: options.messageCount,
 						sessionKey,
 						sessionContext,
+						runtimePath: LEGACY_RUNTIME_PATH,
 					}),
 				},
 			);
@@ -379,6 +392,7 @@ export function buildUserPromptSubmitBody(
 	transcriptPath: string;
 	transcript: string;
 	lastAssistantMessage?: string;
+	runtimePath: typeof LEGACY_RUNTIME_PATH;
 } {
 	const body = input;
 	const userPrompt = pickString(body?.prompt, body?.user_prompt, body?.userPrompt);
@@ -392,6 +406,7 @@ export function buildUserPromptSubmitBody(
 		sessionKey: pickSessionKey(body),
 		transcriptPath: pickString(body?.transcript_path, body?.transcriptPath),
 		transcript: pickString(body?.transcript),
+		runtimePath: LEGACY_RUNTIME_PATH,
 		...(lastAssistantMessage ? { lastAssistantMessage } : {}),
 	};
 }
@@ -411,6 +426,7 @@ export function buildCompactionCompleteBody(
 	agentId?: string;
 	sessionKey?: string;
 	project?: string;
+	runtimePath: typeof LEGACY_RUNTIME_PATH;
 } {
 	const body = input;
 	const agentId = pickString(overrides.agentId, body?.agent_id, body?.agentId);
@@ -422,6 +438,7 @@ export function buildCompactionCompleteBody(
 		...(agentId ? { agentId } : {}),
 		...(sessionKey ? { sessionKey } : {}),
 		...(project ? { project } : {}),
+		runtimePath: LEGACY_RUNTIME_PATH,
 	};
 }
 
@@ -436,6 +453,7 @@ export function buildSessionEndBody(
 	sessionKey: string;
 	cwd: string;
 	reason: string;
+	runtimePath: typeof LEGACY_RUNTIME_PATH;
 } {
 	const body = input ?? {};
 	const sessionKey = pickSessionKey(body);
@@ -448,6 +466,7 @@ export function buildSessionEndBody(
 		sessionKey,
 		cwd: pickString(body.cwd),
 		reason: pickString(body.reason),
+		runtimePath: LEGACY_RUNTIME_PATH,
 	};
 }
 

--- a/packages/daemon/src/hooks-recall.test.ts
+++ b/packages/daemon/src/hooks-recall.test.ts
@@ -296,6 +296,60 @@ describe("/api/hooks/recall", () => {
 		}
 	});
 
+	it("keeps unmarked session-end calls compatible after a marked runtime ended", async () => {
+		const sessionKey = "unmarked-session-end-after-owner";
+		try {
+			const first = await app.request("/api/hooks/user-prompt-submit", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-signet-runtime-path": "plugin",
+				},
+				body: JSON.stringify({
+					harness: "opencode",
+					userMessage: "deploy checklist",
+					sessionKey,
+				}),
+			});
+			expect(first.status).toBe(200);
+
+			const ownerEnd = await app.request("/api/hooks/session-end", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-signet-runtime-path": "plugin",
+				},
+				body: JSON.stringify({
+					harness: "opencode",
+					sessionKey,
+					transcript: "user: deploy checklist",
+				}),
+			});
+			expect(ownerEnd.status).toBe(200);
+			expect(getEndedSession?.(sessionKey)?.runtimePath).toBe("plugin");
+
+			const unmarkedEnd = await app.request("/api/hooks/session-end", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					harness: "unknown-client",
+					sessionKey,
+					transcript: "user: deploy checklist",
+				}),
+			});
+
+			expect(unmarkedEnd.status).toBe(200);
+			expect(await unmarkedEnd.json()).toMatchObject({
+				memoriesSaved: 0,
+			});
+			expect(getEndedSession?.(sessionKey)?.runtimePath).toBeUndefined();
+		} finally {
+			releaseSession?.(sessionKey);
+		}
+	});
+
 	it("skips duplicate session-end calls after the owning runtime already ended", async () => {
 		const sessionKey = "duplicate-session-end-after-owner";
 		try {

--- a/packages/daemon/src/hooks-recall.test.ts
+++ b/packages/daemon/src/hooks-recall.test.ts
@@ -10,6 +10,9 @@ let prev: string | undefined;
 let closeDbAccessor: (() => void) | undefined;
 let getDbAccessor: (() => import("./db-accessor").DbAccessor) | undefined;
 let bypassSession: ((sessionKey: string, opts?: { readonly allowUnknown?: boolean }) => boolean) | undefined;
+let releaseSession: ((sessionKey: string) => void) | undefined;
+let getSessionPath: ((sessionKey: string) => "plugin" | "legacy" | undefined) | undefined;
+let getEndedSession: ((sessionKey: string) => { readonly runtimePath?: "plugin" | "legacy" } | undefined) | undefined;
 
 describe("/api/hooks/recall", () => {
 	beforeAll(async () => {
@@ -31,6 +34,9 @@ describe("/api/hooks/recall", () => {
 		getDbAccessor = () => dbAccessor.getDbAccessor();
 		const tracker = await import("./session-tracker");
 		bypassSession = tracker.bypassSession;
+		releaseSession = tracker.releaseSession;
+		getSessionPath = tracker.getSessionPath;
+		getEndedSession = tracker.getEndedSession;
 
 		const daemon = await import("./daemon");
 		app = daemon.app;
@@ -152,6 +158,200 @@ describe("/api/hooks/recall", () => {
 			message: "No matching memories found.",
 			bypassed: true,
 		});
+	});
+
+	it("skips duplicate user-prompt-submit calls from a conflicting runtime path", async () => {
+		const sessionKey = "duplicate-runtime-session";
+		try {
+			const first = await app.request("/api/hooks/user-prompt-submit", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-signet-runtime-path": "plugin",
+				},
+				body: JSON.stringify({
+					harness: "opencode",
+					userMessage: "deploy checklist",
+					sessionKey,
+				}),
+			});
+
+			expect(first.status).toBe(200);
+			const firstBody = await first.json();
+			expect(firstBody.duplicateRuntimePath).not.toBe(true);
+
+			const duplicate = await app.request("/api/hooks/user-prompt-submit", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-signet-runtime-path": "legacy",
+				},
+				body: JSON.stringify({
+					harness: "claude-code",
+					userMessage: "deploy checklist",
+					sessionKey,
+				}),
+			});
+
+			expect(duplicate.status).toBe(200);
+			const duplicateBody = await duplicate.json();
+			expect(duplicateBody).toMatchObject({
+				inject: "",
+				memoryCount: 0,
+				skipped: true,
+				duplicateRuntimePath: true,
+				claimedBy: "plugin",
+				sessionKnown: true,
+			});
+		} finally {
+			releaseSession?.(sessionKey);
+		}
+	});
+
+	it("does not let a duplicate session-end release the owning runtime claim", async () => {
+		const sessionKey = "duplicate-session-end";
+		try {
+			const first = await app.request("/api/hooks/user-prompt-submit", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-signet-runtime-path": "plugin",
+				},
+				body: JSON.stringify({
+					harness: "opencode",
+					userMessage: "deploy checklist",
+					sessionKey,
+				}),
+			});
+
+			expect(first.status).toBe(200);
+			expect(getSessionPath?.(sessionKey)).toBe("plugin");
+
+			const duplicateEnd = await app.request("/api/hooks/session-end", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-signet-runtime-path": "legacy",
+				},
+				body: JSON.stringify({
+					harness: "claude-code",
+					sessionKey,
+					transcript: "user: deploy checklist",
+				}),
+			});
+
+			expect(duplicateEnd.status).toBe(200);
+			expect(await duplicateEnd.json()).toMatchObject({
+				memoriesSaved: 0,
+				skipped: true,
+				duplicateRuntimePath: true,
+				claimedBy: "plugin",
+			});
+			expect(getSessionPath?.(sessionKey)).toBe("plugin");
+		} finally {
+			releaseSession?.(sessionKey);
+		}
+	});
+
+	it("skips conflicting automatic lifecycle hooks without surfacing harness errors", async () => {
+		const sessionKey = "duplicate-lifecycle-hook";
+		try {
+			const first = await app.request("/api/hooks/user-prompt-submit", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-signet-runtime-path": "plugin",
+				},
+				body: JSON.stringify({
+					harness: "opencode",
+					userMessage: "deploy checklist",
+					sessionKey,
+				}),
+			});
+			expect(first.status).toBe(200);
+
+			const duplicate = await app.request("/api/hooks/pre-compaction", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-signet-runtime-path": "legacy",
+				},
+				body: JSON.stringify({
+					harness: "claude-code",
+					sessionKey,
+				}),
+			});
+
+			expect(duplicate.status).toBe(200);
+			expect(await duplicate.json()).toMatchObject({
+				guidelines: "",
+				instructions: "",
+				summaryPrompt: "",
+				skipped: true,
+				duplicateRuntimePath: true,
+				claimedBy: "plugin",
+			});
+		} finally {
+			releaseSession?.(sessionKey);
+		}
+	});
+
+	it("skips duplicate session-end calls after the owning runtime already ended", async () => {
+		const sessionKey = "duplicate-session-end-after-owner";
+		try {
+			const first = await app.request("/api/hooks/user-prompt-submit", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-signet-runtime-path": "plugin",
+				},
+				body: JSON.stringify({
+					harness: "opencode",
+					userMessage: "deploy checklist",
+					sessionKey,
+				}),
+			});
+			expect(first.status).toBe(200);
+
+			const ownerEnd = await app.request("/api/hooks/session-end", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-signet-runtime-path": "plugin",
+				},
+				body: JSON.stringify({
+					harness: "opencode",
+					sessionKey,
+					transcript: "user: deploy checklist",
+				}),
+			});
+			expect(ownerEnd.status).toBe(200);
+			expect(getSessionPath?.(sessionKey)).toBeUndefined();
+			expect(getEndedSession?.(sessionKey)?.runtimePath).toBe("plugin");
+
+			const duplicateEnd = await app.request("/api/hooks/session-end", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-signet-runtime-path": "legacy",
+				},
+				body: JSON.stringify({
+					harness: "claude-code",
+					sessionKey,
+					transcript: "user: deploy checklist",
+				}),
+			});
+
+			expect(duplicateEnd.status).toBe(200);
+			expect(await duplicateEnd.json()).toMatchObject({
+				memoriesSaved: 0,
+				skipped: true,
+				duplicateSessionEnd: true,
+				endedBy: "plugin",
+			});
+		} finally {
+			releaseSession?.(sessionKey);
+		}
 	});
 
 	it("treats project as project filtering instead of scope filtering", async () => {

--- a/packages/daemon/src/hooks.prompt-submit.test.ts
+++ b/packages/daemon/src/hooks.prompt-submit.test.ts
@@ -226,6 +226,11 @@ describe("handleUserPromptSubmit observability", () => {
 		const payload = submitCalls[0]?.[2];
 		expect(payload?.engine).toBe("transcript-fallback");
 		expect(payload?.memoryCount).toBe(1);
+		expect(searchTranscriptFallbackMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				allowScanFallback: false,
+			}),
+		);
 		expect(result.inject).toContain("## Memory Check");
 		expect(result.inject).toContain("## Relevant Memory");
 		expect(result.inject).toContain("[transcript session-2]");

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -2706,6 +2706,7 @@ export async function handleUserPromptSubmit(
 				sessionKey: req.sessionKey,
 				project: req.project,
 				limit: 3,
+				allowScanFallback: false,
 			});
 			if (transcriptHits.length > 0) {
 				return finalizeUserPromptSubmitSuccess(

--- a/packages/daemon/src/routes/hooks-routes.ts
+++ b/packages/daemon/src/routes/hooks-routes.ts
@@ -48,9 +48,11 @@ import {
 	type RuntimePath,
 	claimSession,
 	getActiveSessions,
+	getEndedSession,
 	getSessionPath,
 	hasSession,
 	isSessionBypassed,
+	markSessionEnded,
 	normalizeSessionKey,
 	releaseSession,
 	renewSession,
@@ -106,6 +108,68 @@ function checkSessionClaim(
 		return c.json({ error: `session claimed by ${owner} path` }, 409) as unknown as Response;
 	}
 	return null;
+}
+
+function claimAutomaticSessionOrSkip(
+	sessionKey: string | undefined,
+	runtimePath: RuntimePath | undefined,
+	agentId: string,
+	hook: string,
+	noop: Record<string, unknown>,
+): Record<string, unknown> | null {
+	if (!sessionKey || !runtimePath) return null;
+
+	const claim = claimSession(sessionKey, runtimePath, agentId);
+	if (claim.ok) return null;
+
+	logger.info("hooks", "Duplicate runtime hook skipped", {
+		hook,
+		sessionKey,
+		runtimePath,
+		claimedBy: claim.claimedBy,
+	});
+	return {
+		...noop,
+		skipped: true,
+		duplicateRuntimePath: true,
+		claimedBy: claim.claimedBy,
+	};
+}
+
+function skipConflictingSessionEnd(
+	sessionKey: string | undefined,
+	runtimePath: RuntimePath | undefined,
+): Record<string, unknown> | null {
+	if (!sessionKey) return null;
+	const ended = getEndedSession(sessionKey);
+	if (ended) {
+		logger.info("hooks", "Duplicate session-end skipped", {
+			sessionKey,
+			runtimePath,
+			endedBy: ended.runtimePath,
+		});
+		return {
+			memoriesSaved: 0,
+			skipped: true,
+			duplicateSessionEnd: true,
+			endedBy: ended.runtimePath ?? "unknown",
+		};
+	}
+	if (!runtimePath) return null;
+	const owner = getSessionPath(sessionKey);
+	if (!owner || owner === runtimePath) return null;
+
+	logger.info("hooks", "Duplicate runtime session-end skipped", {
+		sessionKey,
+		runtimePath,
+		claimedBy: owner,
+	});
+	return {
+		memoriesSaved: 0,
+		skipped: true,
+		duplicateRuntimePath: true,
+		claimedBy: owner,
+	};
 }
 
 // Guard against recursive hook calls from spawned agent contexts
@@ -234,9 +298,15 @@ function registerUserPromptSubmit(app: Hono): void {
 			const sessionKey = parseOptionalString(body.sessionKey);
 			const known = sessionKey ? hasSession(sessionKey) : false;
 
-			const conflict = checkSessionClaim(c, body.sessionKey, runtimePath);
-			if (conflict) return conflict;
 			const agentId = parseOptionalString(body.agentId) ?? "default";
+			const duplicate = claimAutomaticSessionOrSkip(sessionKey, runtimePath, agentId, "user-prompt-submit", {
+				inject: "",
+				memoryCount: 0,
+				sessionKnown: known,
+			});
+			if (duplicate) {
+				return c.json(duplicate);
+			}
 			if (sessionKey) {
 				const touched = touchAgentPresence(sessionKey);
 				if (!touched) {
@@ -293,21 +363,38 @@ function registerSessionEnd(app: Hono): void {
 			stampHarness(body.harness);
 
 			const sessionKey = body.sessionKey || body.sessionId;
+			const conflict = skipConflictingSessionEnd(sessionKey, runtimePath);
+			if (conflict) return c.json(conflict);
+			const duplicate = claimAutomaticSessionOrSkip(
+				sessionKey,
+				runtimePath,
+				parseOptionalString(body.agentId) ?? "default",
+				"session-end",
+				{
+					memoriesSaved: 0,
+				},
+			);
+			if (duplicate) return c.json(duplicate);
 
 			if (sessionKey && isSessionBypassed(sessionKey)) {
-				releaseSession(sessionKey);
+				markSessionEnded(sessionKey, runtimePath);
 				removeAgentPresence(sessionKey);
 				return c.json({ memoriesSaved: 0, bypassed: true });
 			}
 
 			try {
 				const result = handleSessionEnd(body);
+				if (sessionKey) {
+					markSessionEnded(sessionKey, runtimePath);
+					removeAgentPresence(sessionKey);
+				}
 				return c.json(result);
-			} finally {
+			} catch (e) {
 				if (sessionKey) {
 					releaseSession(sessionKey);
 					removeAgentPresence(sessionKey);
 				}
+				throw e;
 			}
 		} catch (e) {
 			logger.error("hooks", "Session end hook failed", e as Error);
@@ -332,8 +419,16 @@ function registerCheckpointExtract(app: Hono): void {
 			const runtimePath = resolveRuntimePath(c, body);
 			if (runtimePath) body.runtimePath = runtimePath;
 
-			const conflict = checkSessionClaim(c, body.sessionKey, runtimePath);
-			if (conflict) return conflict;
+			const duplicate = claimAutomaticSessionOrSkip(
+				body.sessionKey,
+				runtimePath,
+				parseOptionalString(body.agentId) ?? "default",
+				"session-checkpoint-extract",
+				{
+					skipped: true,
+				},
+			);
+			if (duplicate) return c.json(duplicate);
 
 			stampHarness(body.harness);
 
@@ -460,8 +555,18 @@ function registerPreCompaction(app: Hono): void {
 			const runtimePath = resolveRuntimePath(c, body);
 			if (runtimePath) body.runtimePath = runtimePath;
 
-			const conflict = checkSessionClaim(c, body.sessionKey, runtimePath);
-			if (conflict) return conflict;
+			const duplicate = claimAutomaticSessionOrSkip(
+				body.sessionKey,
+				runtimePath,
+				resolveAgentId({ sessionKey: body.sessionKey }),
+				"pre-compaction",
+				{
+					guidelines: "",
+					instructions: "",
+					summaryPrompt: "",
+				},
+			);
+			if (duplicate) return c.json(duplicate);
 
 			if (checkBypass(body)) {
 				return c.json({ instructions: "", bypassed: true });
@@ -494,8 +599,16 @@ function registerCompactionComplete(app: Hono): void {
 			}
 
 			const runtimePath = resolveRuntimePath(c, body);
-			const conflict = checkSessionClaim(c, body.sessionKey, runtimePath);
-			if (conflict) return conflict;
+			const duplicate = claimAutomaticSessionOrSkip(
+				body.sessionKey,
+				runtimePath,
+				parseOptionalString(body.agentId) ?? "default",
+				"compaction-complete",
+				{
+					success: true,
+				},
+			);
+			if (duplicate) return c.json(duplicate);
 
 			if (checkBypass(body)) {
 				return c.json({ success: true, bypassed: true });

--- a/packages/daemon/src/routes/hooks-routes.ts
+++ b/packages/daemon/src/routes/hooks-routes.ts
@@ -140,8 +140,9 @@ function skipConflictingSessionEnd(
 	sessionKey: string | undefined,
 	runtimePath: RuntimePath | undefined,
 ): Record<string, unknown> | null {
-	if (!sessionKey) return null;
+	if (!sessionKey || !runtimePath) return null;
 	const ended = getEndedSession(sessionKey);
+	if (ended && !ended.runtimePath) return null;
 	if (ended) {
 		logger.info("hooks", "Duplicate session-end skipped", {
 			sessionKey,
@@ -155,7 +156,6 @@ function skipConflictingSessionEnd(
 			endedBy: ended.runtimePath ?? "unknown",
 		};
 	}
-	if (!runtimePath) return null;
 	const owner = getSessionPath(sessionKey);
 	if (!owner || owner === runtimePath) return null;
 

--- a/packages/daemon/src/session-tracker.test.ts
+++ b/packages/daemon/src/session-tracker.test.ts
@@ -3,7 +3,9 @@ import {
 	bypassSession,
 	claimSession,
 	getBypassedSessionKeys,
+	getEndedSession,
 	isSessionBypassed,
+	markSessionEnded,
 	renewSession,
 	resetSessions,
 	runStaleCleanup,
@@ -140,5 +142,27 @@ describe("renewSession bypass TTL refresh", () => {
 
 		expect(isSessionBypassed("renew-no-bp")).toBe(false);
 		expect(getBypassedSessionKeys().has("renew-no-bp")).toBe(false);
+	});
+});
+
+describe("ended session tombstones", () => {
+	it("records a short-lived marker after a session is ended", () => {
+		claimSession("ended-sess", "plugin");
+
+		markSessionEnded("ended-sess", "plugin");
+
+		const ended = getEndedSession("ended-sess");
+		expect(ended).toBeDefined();
+		expect(ended?.key).toBe("ended-sess");
+		expect(ended?.runtimePath).toBe("plugin");
+	});
+
+	it("clears an ended marker when the session is claimed again", () => {
+		markSessionEnded("reused-sess", "legacy");
+		expect(getEndedSession("reused-sess")).toBeDefined();
+
+		claimSession("reused-sess", "plugin");
+
+		expect(getEndedSession("reused-sess")).toBeUndefined();
 	});
 });

--- a/packages/daemon/src/session-tracker.ts
+++ b/packages/daemon/src/session-tracker.ts
@@ -29,13 +29,28 @@ interface SessionClaim {
 	expiresAt: number;
 }
 
+export interface EndedSessionInfo {
+	readonly key: string;
+	readonly runtimePath?: RuntimePath;
+	readonly endedAt: string;
+	readonly expiresAt: string;
+}
+
+interface EndedSession {
+	readonly runtimePath?: RuntimePath;
+	readonly endedAt: string;
+	expiresAt: number;
+}
+
 type ClaimResult = { readonly ok: true } | { readonly ok: false; readonly claimedBy: RuntimePath };
 
 const STALE_SESSION_MS = 4 * 60 * 60 * 1000; // 4 hours
+const ENDED_SESSION_TOMBSTONE_MS = 30 * 60 * 1000; // 30 minutes
 const CLEANUP_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
 const WARN_BEFORE_MS = 30 * 60 * 1000; // warn 30 min before expiry
 
 const sessions = new Map<string, SessionClaim>();
+const endedSessions = new Map<string, EndedSession>();
 /** Key → expiresAt timestamp. Entries without a matching session claim are
  *  evicted by `cleanupStaleSessions` once their TTL elapses. */
 const bypassedSessions = new Map<string, number>();
@@ -61,6 +76,7 @@ export function normalizeSessionKey(sessionKey: string): string {
 export function claimSession(sessionKey: string, runtimePath: RuntimePath, agentId = "default"): ClaimResult {
 	const key = normalizeSessionKey(sessionKey);
 	const existing = sessions.get(key);
+	endedSessions.delete(key);
 
 	if (existing) {
 		if (existing.runtimePath === runtimePath) {
@@ -112,6 +128,20 @@ export function releaseSession(sessionKey: string): void {
 	}
 }
 
+export function markSessionEnded(sessionKey: string, runtimePath?: RuntimePath): void {
+	const key = normalizeSessionKey(sessionKey);
+	releaseSession(key);
+	endedSessions.set(key, {
+		runtimePath,
+		endedAt: new Date().toISOString(),
+		expiresAt: Date.now() + ENDED_SESSION_TOMBSTONE_MS,
+	});
+	logger.info("session-tracker", "Session ended", {
+		sessionKey: key,
+		runtimePath,
+	});
+}
+
 /**
  * Return true if the session is currently claimed and not stale.
  * Used by hooks to detect daemon-restart mid-session.
@@ -143,6 +173,24 @@ export function getSessionPath(sessionKey: string): RuntimePath | undefined {
 	}
 
 	return claim.runtimePath;
+}
+
+export function getEndedSession(sessionKey: string): EndedSessionInfo | undefined {
+	const key = normalizeSessionKey(sessionKey);
+	const ended = endedSessions.get(key);
+	if (!ended) return undefined;
+
+	if (Date.now() > ended.expiresAt) {
+		endedSessions.delete(key);
+		return undefined;
+	}
+
+	return {
+		key,
+		runtimePath: ended.runtimePath,
+		endedAt: ended.endedAt,
+		expiresAt: new Date(ended.expiresAt).toISOString(),
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -290,6 +338,13 @@ function cleanupStaleSessions(): void {
 		}
 	}
 
+	for (const [key, ended] of endedSessions) {
+		if (now > ended.expiresAt) {
+			endedSessions.delete(key);
+			cleaned++;
+		}
+	}
+
 	if (cleaned > 0) {
 		logger.info("session-tracker", "Cleaned stale sessions", {
 			cleaned,
@@ -345,6 +400,7 @@ export function activeSessionCount(): number {
 /** Reset all sessions (for testing). */
 export function resetSessions(): void {
 	sessions.clear();
+	endedSessions.clear();
 	bypassedSessions.clear();
 	warnedSessions.clear();
 }

--- a/packages/daemon/src/session-transcripts.ts
+++ b/packages/daemon/src/session-transcripts.ts
@@ -147,6 +147,7 @@ export function searchTranscriptFallback(params: {
 	readonly sessionKey?: string;
 	readonly project?: string;
 	readonly limit: number;
+	readonly allowScanFallback?: boolean;
 }): TranscriptHit[] {
 	const limit = Math.max(1, Math.min(8, Math.trunc(params.limit)));
 	if (!tableExists("session_transcripts")) return [];
@@ -193,12 +194,20 @@ export function searchTranscriptFallback(params: {
 						.slice(0, limit);
 					if (hits.length > 0) return hits;
 				} catch (error) {
-					logger.warn("transcripts", "Transcript FTS query failed, falling back to LIKE", {
-						error: error instanceof Error ? error.message : String(error),
-					});
+					logger.warn(
+						"transcripts",
+						params.allowScanFallback === false
+							? "Transcript FTS query failed, skipping scan fallback"
+							: "Transcript FTS query failed, falling back to LIKE",
+						{
+							error: error instanceof Error ? error.message : String(error),
+						},
+					);
 				}
 			}
 		}
+
+		if (params.allowScanFallback === false) return [];
 
 		const words = params.query
 			.toLowerCase()


### PR DESCRIPTION
## Summary

- make automatic hook processing claim session runtime ownership server-side and skip conflicting runtime callbacks with 200 no-op responses
- keep explicit `remember` and `recall` strict so real user-initiated memory actions still surface runtime conflicts
- add short-lived session-end tombstones so duplicate end hooks cannot reprocess a session after the owning runtime releases its live claim
- mark legacy CLI hooks with `runtimePath: "legacy"` in both body and `x-signet-runtime-path` headers
- disable synchronous transcript scan fallback on the prompt hot path while preserving indexed FTS transcript fallback

## Root cause

Issue #536 came from two compounding hot-path failures. OpenCode/plugin and legacy hook paths could both process the same `sessionKey`, because mid-session automatic hooks only checked an existing owner and did not claim unowned sessions. Legacy CLI hooks also did not consistently identify themselves as the legacy runtime path. When both paths ran, prompt-submit duplicated memory search and transcript fallback work. The transcript fallback path could then drop into a synchronous `LIKE` scan when FTS was unavailable or failed, which made the duplicate work much more expensive.

## Impact

Automatic lifecycle hooks now have one owner per session. Duplicate runtime callbacks are acknowledged as successful no-ops instead of doing duplicate memory work or creating harness-visible 409s. Existing setups should continue working because requests without a `sessionKey` or without a runtime marker retain the previous behavior, same-runtime repeated calls refresh the owner, and explicit `remember`/`recall` conflict behavior is unchanged.

Closes #536.

## Validation

- `bun test packages/cli/src/commands/hook.test.ts packages/daemon/src/hooks-recall.test.ts packages/daemon/src/hooks.prompt-submit.test.ts packages/daemon/src/session-tracker.test.ts`
- `bunx biome check packages/daemon/src/session-tracker.ts packages/daemon/src/session-tracker.test.ts packages/daemon/src/routes/hooks-routes.ts packages/daemon/src/hooks-recall.test.ts packages/daemon/src/hooks.ts packages/daemon/src/session-transcripts.ts packages/daemon/src/hooks.prompt-submit.test.ts packages/cli/src/commands/hook.ts packages/cli/src/commands/hook.test.ts`
- `git diff --check`
- `bun run typecheck`
- `bun run build`

Full `bun run lint` is currently blocked by unrelated repo-wide Biome formatting diagnostics in existing files, mostly package manifests. Changed-file Biome validation passes.
