### PR TITLE
fix(daemon): dedupe summary fact hash collisions

### DIFF
--- a/packages/daemon/src/pipeline/summary-worker.test.ts
+++ b/packages/daemon/src/pipeline/summary-worker.test.ts
@@ -207,6 +207,31 @@ describe("insertSummaryFacts", () => {
 		expect((row?.content_hash ?? "").length).toBeGreaterThan(0);
 	});
 
+	it("treats content_hash collisions as deduplication instead of job failures", () => {
+		const saved = insertSummaryFacts(
+			accessor,
+			{
+				harness: "opencode",
+				project: null,
+				session_key: "sess-hash-collision",
+				session_id: "sess-hash-collision",
+				id: "job-hash-collision",
+				agent_id: "default",
+			},
+			[
+				{ content: "UI.", importance: 0.4, type: "fact" },
+				{ content: "UI!", importance: 0.4, type: "fact" },
+			],
+		);
+
+		expect(saved).toBe(1);
+
+		const row = db.prepare("SELECT COUNT(*) AS n FROM memories WHERE source_id = 'sess-hash-collision'").get() as {
+			n: number;
+		};
+		expect(row.n).toBe(1);
+	});
+
 	it("skips summary facts for temp sessions", () => {
 		const saved = insertSummaryFacts(
 			accessor,

--- a/packages/daemon/src/pipeline/summary-worker.ts
+++ b/packages/daemon/src/pipeline/summary-worker.ts
@@ -17,7 +17,7 @@ import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import type { LlmProvider } from "@signet/core";
 import { normalizeAndHashContent } from "../content-normalization";
-import type { DbAccessor } from "../db-accessor";
+import type { DbAccessor, WriteDb } from "../db-accessor";
 import { countChanges } from "../db-helpers";
 import { inferType, isDuplicate } from "../hooks";
 import { logger } from "../logger";
@@ -113,6 +113,25 @@ export function resolveFailedSummaryJobStatus(
 	maxAttempts: number,
 ): "dead" | "pending" {
 	return terminal || attempts >= maxAttempts ? "dead" : "pending";
+}
+
+function hasActiveContentHash(db: WriteDb, contentHash: string, agentId: string): boolean {
+	const row = db
+		.prepare(
+			`SELECT id FROM memories
+			 WHERE content_hash = ?
+			   AND COALESCE(NULLIF(agent_id, ''), 'default') = ?
+			   AND scope IS NULL
+			   AND is_deleted = 0
+			 LIMIT 1`,
+		)
+		.get(contentHash, agentId);
+	return typeof row === "object" && row !== null;
+}
+
+function isContentHashUniqueError(err: unknown): boolean {
+	if (!(err instanceof Error)) return false;
+	return err.message.includes("idx_memories_content_hash_unique") || err.message.includes("memories.content_hash");
 }
 
 // ---------------------------------------------------------------------------
@@ -1189,29 +1208,35 @@ export function insertSummaryFacts(
 			if (!item.content || typeof item.content !== "string") continue;
 
 			const importance = Math.min(item.importance ?? 0.3, 0.5);
+			const { contentHash } = normalizeAndHashContent(item.content);
 
+			if (hasActiveContentHash(db, contentHash, agentId)) continue;
 			if (isDuplicate(db as unknown as Database, item.content, agentId)) continue;
 
 			const id = crypto.randomUUID();
 			const type = item.type || inferType(item.content);
-			const { contentHash } = normalizeAndHashContent(item.content);
 
-			stmt.run(
-				id,
-				item.content,
-				contentHash,
-				type,
-				importance,
-				job.session_key || null,
-				"session_end",
-				job.harness,
-				item.tags || null,
-				job.project || null,
-				agentId,
-				now,
-				now,
-				SUMMARY_WORKER_UPDATED_BY,
-			);
+			try {
+				stmt.run(
+					id,
+					item.content,
+					contentHash,
+					type,
+					importance,
+					job.session_key || null,
+					"session_end",
+					job.harness,
+					item.tags || null,
+					job.project || null,
+					agentId,
+					now,
+					now,
+					SUMMARY_WORKER_UPDATED_BY,
+				);
+			} catch (err) {
+				if (isContentHashUniqueError(err)) continue;
+				throw err;
+			}
 			count++;
 		}
 		return count;


### PR DESCRIPTION
## Summary

Fixes #533.

The summary worker now treats duplicate summary fact content hashes as successful deduplication instead of failing the whole job. `insertSummaryFacts` now performs an exact active `content_hash` precheck for the current agent scope before the existing FTS overlap check, and it narrowly catches content-hash unique constraint races so concurrent inserts are skipped rather than reported as job failures.

## Root cause

Summary fact insertion relied on the fuzzy FTS overlap dedupe path before writing to `memories`. Some facts can normalize to the same `content_hash` without being caught by FTS, especially very short facts, so the insert could hit `idx_memories_content_hash_unique` and mark the summary job failed even though the database was correctly preventing duplicate data.

## Validation

- `bun run build:core`
- `bun test packages/daemon/src/pipeline/summary-worker.test.ts`
- `bunx biome check packages/daemon/src/pipeline/summary-worker.ts packages/daemon/src/pipeline/summary-worker.test.ts`
- `git diff --check`
- `bun run --filter @signet/daemon build`

Note: `bun run --filter @signet/daemon build:types` still fails on existing daemon/core `rootDir` and test readonly-property issues unrelated to this patch.
