### PR TITLE
feat(cli): add desktop source install command

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -48,6 +48,7 @@ Commands Overview
 | `signet doctor` | Run local health checks |
 | `signet dashboard` | Open web UI in browser |
 | `signet daemon` | Grouped daemon subcommands |
+| `signet desktop` | Build and install the Electron desktop app from source |
 | `signet daemon start` | Start the daemon |
 | `signet daemon stop` | Stop the daemon |
 | `signet daemon restart` | Restart the daemon |
@@ -97,6 +98,29 @@ Use explicit commands for interactive flows:
 - `signet setup` — initialize or migrate a workspace
 - `signet configure` — edit agent settings interactively
 - `signet doctor` — troubleshoot local issues
+
+---
+
+`signet desktop`
+---
+
+Builds the official Electron desktop app from an existing Signet source
+checkout. The command never clones over local work; run it from the repo root,
+set `SIGNET_SOURCE_DIR`, or pass `--repo <path>`.
+
+```bash
+signet desktop build
+signet desktop install
+signet desktop install --repo ~/signet/signetai
+signet desktop install --skip-build
+```
+
+`signet desktop install` runs `bun install`, then `bun run build:desktop`, then
+installs the newest built artifact. Linux/Arch currently installs a user-level
+AppImage launcher at `~/.local/bin/signet-desktop` and a desktop entry under
+`~/.local/share/applications/signet.desktop`. macOS and Windows builds are
+produced by the desktop package, with native installer automation still guarded
+until those platform installers are wired.
 
 ---
 

--- a/docs/specs/approved/desktop-packaging-distribution.md
+++ b/docs/specs/approved/desktop-packaging-distribution.md
@@ -10,6 +10,7 @@ success_criteria:
   - "Arch package metadata (PKGBUILD and .SRCINFO) is generated from release AppImage + checksum"
   - "Arch CI validates generated PKGBUILD by building a .pkg.tar.* artifact in an Arch Linux environment"
   - "Desktop release jobs resolve a signing mode (official or self-signed) before publish"
+  - "The supported source-build path is exposed through `signet desktop build` and `signet desktop install`"
 scope_boundary: "Desktop packaging, runtime bundling preference, CI workflows, and Arch metadata generation. Does not replace npm package publishing flows."
 ---
 
@@ -43,11 +44,16 @@ Arch.
    URL, and checksum.
 5. Arch packaging must be validated in CI by building from the generated
    `PKGBUILD`.
+6. The official local source-build entrypoint is `signet desktop build`;
+   `signet desktop install` builds from the same source checkout and installs
+   a native launcher where the platform implementation exists.
 
 ## Integration notes
 
 - Depends on `signet-runtime` for daemon behavior contracts.
 - Desktop packaging remains independent of npm release train mechanics.
+- The CLI source-build path uses the already-pulled Signet checkout. It must
+  not clone over local work or silently switch branches.
 - Generated AUR metadata is emitted as CI artifacts and can be pushed by
   a separate credentialed job.
 - `packages/daemon-rs` remains the shadow daemon rewrite. Desktop sidecar usage is intentionally bound to the current Bun daemon.

--- a/docs/specs/dependencies.yaml
+++ b/docs/specs/dependencies.yaml
@@ -1136,6 +1136,7 @@ specs:
       - "Arch package metadata (PKGBUILD and .SRCINFO) is generated from release AppImage + checksum"
       - "Arch CI validates generated PKGBUILD by building a .pkg.tar.* artifact in an Arch Linux environment"
       - "Desktop release jobs resolve a signing mode (official or self-signed) before publish"
+      - "The supported source-build path is exposed through `signet desktop build` and `signet desktop install`"
     decision: null
 
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -67,6 +67,7 @@ import { registerBrowseCommand } from "./browse.js";
 import { registerAgentCommands } from "./commands/agent.js";
 import { registerAppCommands } from "./commands/app.js";
 import { registerDaemonCommands } from "./commands/daemon.js";
+import { registerDesktopCommands } from "./commands/desktop.js";
 import { registerDreamCommands } from "./commands/dream.js";
 import { registerForgeCommands } from "./commands/forge.js";
 import { registerGitCommands } from "./commands/git.js";
@@ -93,6 +94,7 @@ import {
 	migrateSchema,
 	showLogs,
 } from "./features/daemon.js";
+import { buildDesktopFromSource, installDesktopFromSource } from "./features/desktop.js";
 import { doctorForge, installForge, showForgeStatus, updateForge } from "./features/forge.js";
 import { getStatusReport, showDoctor, showStatus } from "./features/health.js";
 import { importFromGitHub } from "./features/import.js";
@@ -1354,6 +1356,11 @@ registerAppCommands(program, {
 	showDoctor: (options) => showDoctor(options, healthDeps),
 	showStatus: (options) => showStatus(options, healthDeps),
 	syncTemplates: () => runSyncTemplates(),
+});
+
+registerDesktopCommands(program, {
+	buildDesktopFromSource,
+	installDesktopFromSource,
 });
 
 registerDaemonCommands(program, {

--- a/packages/cli/src/commands/desktop.ts
+++ b/packages/cli/src/commands/desktop.ts
@@ -1,0 +1,59 @@
+import chalk from "chalk";
+import type { Command } from "commander";
+import type { DesktopBuildResult, DesktopLinuxInstallResult } from "../features/desktop.js";
+
+interface DesktopDeps {
+	readonly buildDesktopFromSource: (options?: { readonly repo?: string }) => DesktopBuildResult;
+	readonly installDesktopFromSource: (options?: {
+		readonly repo?: string;
+		readonly skipBuild?: boolean;
+	}) => DesktopLinuxInstallResult;
+}
+
+export function registerDesktopCommands(program: Command, deps: DesktopDeps): void {
+	const desktop = program.command("desktop").description("Build and install the Signet Electron desktop app");
+
+	desktop
+		.command("build")
+		.description("Build the Signet Electron desktop app from a source checkout")
+		.option("--repo <path>", "Signet source checkout path (defaults to cwd, SIGNET_SOURCE_DIR, or ~/signet/signetai)")
+		.action((options: { readonly repo?: string }) => {
+			try {
+				console.log(chalk.cyan("Building Signet desktop from source..."));
+				const result = deps.buildDesktopFromSource({ repo: options.repo });
+				console.log(chalk.green("✓ Signet desktop build complete"));
+				console.log(chalk.dim(`  Source:   ${result.repo}`));
+				console.log(chalk.dim(`  Artifacts: ${result.releaseDir}`));
+			} catch (err) {
+				console.error(chalk.red("Signet desktop build failed"));
+				console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+				process.exit(1);
+			}
+		});
+
+	desktop
+		.command("install")
+		.description("Build and install the Signet Electron desktop app")
+		.option("--repo <path>", "Signet source checkout path (defaults to cwd, SIGNET_SOURCE_DIR, or ~/signet/signetai)")
+		.option("--skip-build", "Install the newest existing desktop artifact without rebuilding")
+		.action((options: { readonly repo?: string; readonly skipBuild?: boolean }) => {
+			try {
+				console.log(
+					chalk.cyan(
+						options.skipBuild ? "Installing Signet desktop artifact..." : "Building and installing Signet desktop...",
+					),
+				);
+				const result = deps.installDesktopFromSource({ repo: options.repo, skipBuild: options.skipBuild });
+				console.log(chalk.green("✓ Signet desktop installed"));
+				console.log(chalk.dim(`  Source:   ${result.repo}`));
+				console.log(chalk.dim(`  AppImage: ${result.appImage}`));
+				console.log(chalk.dim(`  Launcher: ${result.binary}`));
+				console.log(chalk.dim(`  Desktop:  ${result.desktopEntry}`));
+				console.log(chalk.cyan("\n  Run: signet-desktop"));
+			} catch (err) {
+				console.error(chalk.red("Signet desktop install failed"));
+				console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+				process.exit(1);
+			}
+		});
+}

--- a/packages/cli/src/features/desktop.test.ts
+++ b/packages/cli/src/features/desktop.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
 	existsSync,
+	lstatSync,
 	mkdirSync,
 	mkdtempSync,
 	readFileSync,
 	readlinkSync,
 	rmSync,
+	symlinkSync,
 	utimesSync,
 	writeFileSync,
 } from "node:fs";
@@ -72,18 +74,24 @@ describe("desktop source build", () => {
 });
 
 describe("linux desktop install", () => {
-	test("installs the newest AppImage as a user launcher", () => {
+	test("installs the newest matching AppImage as a user launcher", () => {
 		const root = makeCheckout();
 		const home = mkdtempSync(join(tmpdir(), "signet-desktop-home-"));
 		try {
 			const release = join(root, "packages", "desktop", "release");
 			mkdirSync(join(release, "nested"), { recursive: true });
-			const oldArtifact = join(release, "Signet-old.AppImage");
-			const newArtifact = join(release, "nested", "Signet-new.AppImage");
+			const oldArtifact = join(release, "Signet-0.1.0-linux-x86_64.AppImage");
+			const newArtifact = join(release, "Signet-0.2.0-linux-x86_64.AppImage");
+			const wrongArchArtifact = join(release, "Signet-0.3.0-linux-arm64.AppImage");
+			const nestedArtifact = join(release, "nested", "Signet-0.4.0-linux-x86_64.AppImage");
 			writeFileSync(oldArtifact, "old");
 			writeFileSync(newArtifact, "new");
+			writeFileSync(wrongArchArtifact, "wrong-arch");
+			writeFileSync(nestedArtifact, "nested");
 			utimesSync(oldArtifact, new Date(1_000), new Date(1_000));
 			utimesSync(newArtifact, new Date(2_000), new Date(2_000));
+			utimesSync(wrongArchArtifact, new Date(3_000), new Date(3_000));
+			utimesSync(nestedArtifact, new Date(4_000), new Date(4_000));
 
 			const result = installLinuxDesktopApp(root, home);
 
@@ -98,13 +106,59 @@ describe("linux desktop install", () => {
 		}
 	});
 
+	test("does not overwrite an existing non-symlink launcher", () => {
+		const root = makeCheckout();
+		const home = mkdtempSync(join(tmpdir(), "signet-desktop-home-"));
+		try {
+			const release = join(root, "packages", "desktop", "release");
+			mkdirSync(release, { recursive: true });
+			writeFileSync(join(release, "Signet-0.1.0-linux-x86_64.AppImage"), "app");
+			const binDir = join(home, ".local", "bin");
+			mkdirSync(binDir, { recursive: true });
+			const existing = join(binDir, "signet-desktop");
+			writeFileSync(existing, "custom launcher");
+
+			expect(() => installLinuxDesktopApp(root, home)).toThrow("Refusing to replace existing non-symlink launcher");
+			expect(readFileSync(existing, "utf8")).toBe("custom launcher");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
+	test("replaces an existing Signet-owned launcher symlink", () => {
+		const root = makeCheckout();
+		const home = mkdtempSync(join(tmpdir(), "signet-desktop-home-"));
+		try {
+			const release = join(root, "packages", "desktop", "release");
+			mkdirSync(release, { recursive: true });
+			writeFileSync(join(release, "Signet-0.1.0-linux-x86_64.AppImage"), "app");
+			const appDir = join(home, ".local", "share", "signet", "desktop");
+			const binDir = join(home, ".local", "bin");
+			mkdirSync(appDir, { recursive: true });
+			mkdirSync(binDir, { recursive: true });
+			const oldTarget = join(appDir, "Old-Signet.AppImage");
+			writeFileSync(oldTarget, "old app");
+			const binary = join(binDir, "signet-desktop");
+			symlinkSync(oldTarget, binary);
+
+			const result = installLinuxDesktopApp(root, home);
+
+			expect(lstatSync(result.binary).isSymbolicLink()).toBe(true);
+			expect(readlinkSync(result.binary)).toBe(result.appImage);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
 	test("skip-build install does not run build commands", () => {
 		const root = makeCheckout();
 		const home = mkdtempSync(join(tmpdir(), "signet-desktop-home-"));
 		try {
 			const release = join(root, "packages", "desktop", "release");
 			mkdirSync(release, { recursive: true });
-			writeFileSync(join(release, "Signet.AppImage"), "app");
+			writeFileSync(join(release, "Signet-0.1.0-linux-x86_64.AppImage"), "app");
 
 			const result = installDesktopFromSource(
 				{ repo: root, skipBuild: true },

--- a/packages/cli/src/features/desktop.test.ts
+++ b/packages/cli/src/features/desktop.test.ts
@@ -23,8 +23,14 @@ import {
 function makeCheckout(): string {
 	const root = mkdtempSync(join(tmpdir(), "signet-desktop-test-"));
 	mkdirSync(join(root, "packages", "desktop", "icons"), { recursive: true });
-	writeFileSync(join(root, "package.json"), JSON.stringify({ name: "signet" }));
-	writeFileSync(join(root, "packages", "desktop", "package.json"), JSON.stringify({ name: "@signet/desktop" }));
+	writeFileSync(
+		join(root, "package.json"),
+		JSON.stringify({ name: "signet", workspaces: ["packages/*", "packages/cli/dashboard"] }),
+	);
+	writeFileSync(
+		join(root, "packages", "desktop", "package.json"),
+		JSON.stringify({ name: "@signet/desktop", main: "dist/main.js", build: { appId: "ai.signet.app" } }),
+	);
 	writeFileSync(join(root, "packages", "desktop", "icons", "icon.png"), "icon");
 	return root;
 }
@@ -43,6 +49,24 @@ describe("desktop source checkout resolution", () => {
 	test("rejects explicit non-checkout paths", () => {
 		const root = mkdtempSync(join(tmpdir(), "signet-desktop-missing-"));
 		try {
+			expect(() => resolveDesktopSourceCheckout(root, { env: {} })).toThrow("Not a Signet source checkout");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+	test("rejects lookalike checkouts before running source commands", () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-desktop-lookalike-"));
+		try {
+			mkdirSync(join(root, "packages", "desktop"), { recursive: true });
+			writeFileSync(
+				join(root, "package.json"),
+				JSON.stringify({ name: "signet", workspaces: ["packages/*", "packages/cli/dashboard"] }),
+			);
+			writeFileSync(
+				join(root, "packages", "desktop", "package.json"),
+				JSON.stringify({ name: "@signet/desktop", main: "dist/main.js", build: { appId: "wrong.app" } }),
+			);
+
 			expect(() => resolveDesktopSourceCheckout(root, { env: {} })).toThrow("Not a Signet source checkout");
 		} finally {
 			rmSync(root, { recursive: true, force: true });

--- a/packages/cli/src/features/desktop.test.ts
+++ b/packages/cli/src/features/desktop.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	readlinkSync,
+	rmSync,
+	utimesSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	buildDesktopFromSource,
+	installDesktopFromSource,
+	installLinuxDesktopApp,
+	resolveDesktopSourceCheckout,
+} from "./desktop.js";
+
+function makeCheckout(): string {
+	const root = mkdtempSync(join(tmpdir(), "signet-desktop-test-"));
+	mkdirSync(join(root, "packages", "desktop", "icons"), { recursive: true });
+	writeFileSync(join(root, "package.json"), JSON.stringify({ name: "signet" }));
+	writeFileSync(join(root, "packages", "desktop", "package.json"), JSON.stringify({ name: "@signet/desktop" }));
+	writeFileSync(join(root, "packages", "desktop", "icons", "icon.png"), "icon");
+	return root;
+}
+
+describe("desktop source checkout resolution", () => {
+	test("finds an ancestor checkout from cwd", () => {
+		const root = makeCheckout();
+		try {
+			const cwd = join(root, "packages", "desktop");
+			expect(resolveDesktopSourceCheckout(undefined, { cwd, home: join(root, "home"), env: {} })).toBe(root);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("rejects explicit non-checkout paths", () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-desktop-missing-"));
+		try {
+			expect(() => resolveDesktopSourceCheckout(root, { env: {} })).toThrow("Not a Signet source checkout");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("desktop source build", () => {
+	test("runs dependency install before desktop build", () => {
+		const root = makeCheckout();
+		const calls: string[] = [];
+		try {
+			const result = buildDesktopFromSource(
+				{ repo: root },
+				{
+					runner: (cmd, args, opts) => {
+						calls.push(`${cmd} ${args.join(" ")} @ ${opts.cwd}`);
+						return { status: 0 };
+					},
+				},
+			);
+
+			expect(result.releaseDir).toBe(join(root, "packages", "desktop", "release"));
+			expect(calls).toEqual([`bun install @ ${root}`, `bun run build:desktop @ ${root}`]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("linux desktop install", () => {
+	test("installs the newest AppImage as a user launcher", () => {
+		const root = makeCheckout();
+		const home = mkdtempSync(join(tmpdir(), "signet-desktop-home-"));
+		try {
+			const release = join(root, "packages", "desktop", "release");
+			mkdirSync(join(release, "nested"), { recursive: true });
+			const oldArtifact = join(release, "Signet-old.AppImage");
+			const newArtifact = join(release, "nested", "Signet-new.AppImage");
+			writeFileSync(oldArtifact, "old");
+			writeFileSync(newArtifact, "new");
+			utimesSync(oldArtifact, new Date(1_000), new Date(1_000));
+			utimesSync(newArtifact, new Date(2_000), new Date(2_000));
+
+			const result = installLinuxDesktopApp(root, home);
+
+			expect(readFileSync(result.appImage, "utf8")).toBe("new");
+			expect(readlinkSync(result.binary)).toBe(result.appImage);
+			expect(readFileSync(result.desktopEntry, "utf8")).toContain("Name=Signet");
+			expect(readFileSync(result.desktopEntry, "utf8")).toContain(`Exec=\"${result.binary}\" %U`);
+			expect(existsSync(result.icon)).toBe(true);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
+	test("skip-build install does not run build commands", () => {
+		const root = makeCheckout();
+		const home = mkdtempSync(join(tmpdir(), "signet-desktop-home-"));
+		try {
+			const release = join(root, "packages", "desktop", "release");
+			mkdirSync(release, { recursive: true });
+			writeFileSync(join(release, "Signet.AppImage"), "app");
+
+			const result = installDesktopFromSource(
+				{ repo: root, skipBuild: true },
+				{
+					home,
+					platform: "linux",
+					runner: () => {
+						throw new Error("runner should not be called");
+					},
+				},
+			);
+
+			expect(existsSync(result.appImage)).toBe(true);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/cli/src/features/desktop.ts
+++ b/packages/cli/src/features/desktop.ts
@@ -12,7 +12,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 export interface DesktopCommandOptions {

--- a/packages/cli/src/features/desktop.ts
+++ b/packages/cli/src/features/desktop.ts
@@ -6,6 +6,7 @@ import {
 	lstatSync,
 	mkdirSync,
 	readdirSync,
+	readlinkSync,
 	rmSync,
 	statSync,
 	symlinkSync,
@@ -124,9 +125,11 @@ export function installDesktopFromSource(
 
 export function installLinuxDesktopApp(repo: string, home: string): DesktopLinuxInstallResult {
 	const releaseDir = desktopReleaseDir(repo);
-	const source = findNewestFile(releaseDir, (path) => path.endsWith(".AppImage"));
+	const source = findLinuxAppImage(releaseDir, process.arch);
 	if (!source) {
-		throw new Error(`No AppImage found in ${releaseDir}. Run signet desktop build first.`);
+		throw new Error(
+			`No matching Linux ${process.arch} AppImage found in ${releaseDir}. Run signet desktop build first.`,
+		);
 	}
 
 	const appDir = join(home, ".local", "share", "signet", "desktop");
@@ -190,38 +193,55 @@ function runChecked(
 	}
 }
 
-function findNewestFile(root: string, accept: (path: string) => boolean): string | null {
-	if (!existsSync(root)) return null;
+function findLinuxAppImage(releaseDir: string, arch: string): string | null {
+	if (!existsSync(releaseDir)) return null;
 	let best: { path: string; mtime: number } | null = null;
-	const stack = [root];
-	while (stack.length > 0) {
-		const dir = stack.pop();
-		if (!dir) continue;
-		for (const entry of readdirSync(dir, { withFileTypes: true })) {
-			const path = join(dir, entry.name);
-			if (entry.isDirectory()) {
-				stack.push(path);
-				continue;
-			}
-			if (!entry.isFile() || !accept(path)) continue;
-			const mtime = statSync(path).mtimeMs;
-			if (!best || mtime > best.mtime) {
-				best = { path, mtime };
-			}
+	const allowedArchNames = linuxArtifactArchNames(arch);
+	for (const entry of readdirSync(releaseDir, { withFileTypes: true })) {
+		if (!entry.isFile()) continue;
+		const match = /^Signet-.+-linux-([^.]+)\.AppImage$/.exec(entry.name);
+		if (!match || !allowedArchNames.has(match[1])) continue;
+		const path = join(releaseDir, entry.name);
+		const mtime = statSync(path).mtimeMs;
+		if (!best || mtime > best.mtime) {
+			best = { path, mtime };
 		}
 	}
 	return best?.path ?? null;
 }
 
+function linuxArtifactArchNames(arch: string): ReadonlySet<string> {
+	switch (arch) {
+		case "x64":
+			return new Set(["x64", "x86_64", "amd64"]);
+		case "arm64":
+			return new Set(["arm64", "aarch64"]);
+		default:
+			return new Set([arch]);
+	}
+}
+
 function replaceSymlink(path: string, target: string): void {
 	try {
 		const stat = lstatSync(path);
-		if (stat.isDirectory()) {
-			throw new Error(`Cannot replace directory with launcher symlink: ${path}`);
+		if (!stat.isSymbolicLink()) {
+			throw new Error(
+				`Refusing to replace existing non-symlink launcher at ${path}. Remove it first if it is not needed.`,
+			);
 		}
+
+		const current = resolve(dirname(path), readlinkSync(path));
+		const ownedDir = dirname(target);
+		if (current !== target && !current.startsWith(`${ownedDir}/`)) {
+			throw new Error(
+				`Refusing to replace launcher symlink at ${path} because it does not point at Signet's desktop install directory.`,
+			);
+		}
+
 		rmSync(path, { force: true });
 	} catch (err) {
-		if (err instanceof Error && "code" in err && err.code !== "ENOENT") {
+		const code = err && typeof err === "object" && "code" in err ? err.code : undefined;
+		if (code !== "ENOENT") {
 			throw err;
 		}
 	}

--- a/packages/cli/src/features/desktop.ts
+++ b/packages/cli/src/features/desktop.ts
@@ -1,0 +1,246 @@
+import { spawnSync } from "node:child_process";
+import {
+	chmodSync,
+	copyFileSync,
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	readdirSync,
+	rmSync,
+	statSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface DesktopCommandOptions {
+	readonly repo?: string;
+}
+
+export interface DesktopInstallOptions extends DesktopCommandOptions {
+	readonly skipBuild?: boolean;
+}
+
+export interface DesktopBuildResult {
+	readonly repo: string;
+	readonly releaseDir: string;
+}
+
+export interface DesktopLinuxInstallResult extends DesktopBuildResult {
+	readonly appImage: string;
+	readonly binary: string;
+	readonly desktopEntry: string;
+	readonly icon: string;
+}
+
+interface DesktopCommandContext {
+	readonly cwd?: string;
+	readonly env?: NodeJS.ProcessEnv;
+	readonly home?: string;
+	readonly platform?: NodeJS.Platform;
+	readonly runner?: CommandRunner;
+}
+
+interface CommandResult {
+	readonly status: number | null;
+	readonly signal?: NodeJS.Signals | null;
+	readonly error?: Error;
+}
+
+type CommandRunner = (
+	cmd: string,
+	args: readonly string[],
+	opts: { readonly cwd: string; readonly env: NodeJS.ProcessEnv },
+) => CommandResult;
+
+const defaultRunner: CommandRunner = (cmd, args, opts) =>
+	spawnSync(cmd, [...args], {
+		cwd: opts.cwd,
+		env: opts.env,
+		stdio: "inherit",
+	});
+
+export function resolveDesktopSourceCheckout(
+	repo: string | undefined,
+	ctx: Pick<DesktopCommandContext, "cwd" | "env" | "home"> = {},
+): string {
+	const explicit = repo?.trim() || ctx.env?.SIGNET_SOURCE_DIR?.trim();
+	const candidates = explicit
+		? [explicit]
+		: [
+				ctx.cwd ?? process.cwd(),
+				dirname(fileURLToPath(import.meta.url)),
+				join(ctx.home ?? homedir(), "signet", "signetai"),
+				join(ctx.home ?? homedir(), "signet", "signetai4"),
+			].flatMap((candidate) => ancestorCandidates(candidate));
+
+	for (const candidate of candidates) {
+		const resolved = resolve(candidate);
+		if (isDesktopSourceCheckout(resolved)) {
+			return resolved;
+		}
+	}
+
+	const hint = explicit
+		? `Not a Signet source checkout: ${resolve(explicit)}`
+		: "Could not find a Signet source checkout. Run from the repo root, set SIGNET_SOURCE_DIR, or pass --repo <path>.";
+	throw new Error(hint);
+}
+
+export function buildDesktopFromSource(
+	options: DesktopCommandOptions = {},
+	ctx: DesktopCommandContext = {},
+): DesktopBuildResult {
+	const repo = resolveDesktopSourceCheckout(options.repo, ctx);
+	const runner = ctx.runner ?? defaultRunner;
+	const env = ctx.env ?? process.env;
+
+	runChecked(runner, "bun", ["install"], repo, env);
+	runChecked(runner, "bun", ["run", "build:desktop"], repo, env);
+
+	return { repo, releaseDir: desktopReleaseDir(repo) };
+}
+
+export function installDesktopFromSource(
+	options: DesktopInstallOptions = {},
+	ctx: DesktopCommandContext = {},
+): DesktopLinuxInstallResult {
+	const repo = resolveDesktopSourceCheckout(options.repo, ctx);
+	if (!options.skipBuild) {
+		buildDesktopFromSource({ repo }, ctx);
+	}
+
+	const platform = ctx.platform ?? process.platform;
+	if (platform !== "linux") {
+		throw new Error(
+			`signet desktop install currently installs native launchers on Linux/Arch only. Build artifacts are in ${desktopReleaseDir(repo)}.`,
+		);
+	}
+
+	return installLinuxDesktopApp(repo, ctx.home ?? homedir());
+}
+
+export function installLinuxDesktopApp(repo: string, home: string): DesktopLinuxInstallResult {
+	const releaseDir = desktopReleaseDir(repo);
+	const source = findNewestFile(releaseDir, (path) => path.endsWith(".AppImage"));
+	if (!source) {
+		throw new Error(`No AppImage found in ${releaseDir}. Run signet desktop build first.`);
+	}
+
+	const appDir = join(home, ".local", "share", "signet", "desktop");
+	const binDir = join(home, ".local", "bin");
+	const applicationsDir = join(home, ".local", "share", "applications");
+	const iconsDir = join(home, ".local", "share", "icons", "hicolor", "512x512", "apps");
+	mkdirSync(appDir, { recursive: true });
+	mkdirSync(binDir, { recursive: true });
+	mkdirSync(applicationsDir, { recursive: true });
+	mkdirSync(iconsDir, { recursive: true });
+
+	const appImage = join(appDir, "Signet.AppImage");
+	copyFileSync(source, appImage);
+	chmodSync(appImage, 0o755);
+
+	const icon = join(iconsDir, "signet.png");
+	copyFileSync(join(repo, "packages", "desktop", "icons", "icon.png"), icon);
+
+	const binary = join(binDir, "signet-desktop");
+	replaceSymlink(binary, appImage);
+
+	const desktopEntry = join(applicationsDir, "signet.desktop");
+	writeFileSync(desktopEntry, desktopEntryContent(binary, icon));
+
+	return { repo, releaseDir, appImage, binary, desktopEntry, icon };
+}
+
+function ancestorCandidates(path: string): string[] {
+	const out: string[] = [];
+	let current = resolve(path);
+	for (;;) {
+		out.push(current);
+		const parent = dirname(current);
+		if (parent === current) return out;
+		current = parent;
+	}
+}
+
+function isDesktopSourceCheckout(path: string): boolean {
+	return existsSync(join(path, "package.json")) && existsSync(join(path, "packages", "desktop", "package.json"));
+}
+
+function desktopReleaseDir(repo: string): string {
+	return join(repo, "packages", "desktop", "release");
+}
+
+function runChecked(
+	runner: CommandRunner,
+	cmd: string,
+	args: readonly string[],
+	cwd: string,
+	env: NodeJS.ProcessEnv,
+): void {
+	const result = runner(cmd, args, { cwd, env });
+	if (result.error) {
+		throw result.error;
+	}
+	if (result.status !== 0) {
+		const suffix = result.signal ? ` (signal ${result.signal})` : "";
+		throw new Error(`${cmd} ${args.join(" ")} failed with exit ${result.status ?? "unknown"}${suffix}`);
+	}
+}
+
+function findNewestFile(root: string, accept: (path: string) => boolean): string | null {
+	if (!existsSync(root)) return null;
+	let best: { path: string; mtime: number } | null = null;
+	const stack = [root];
+	while (stack.length > 0) {
+		const dir = stack.pop();
+		if (!dir) continue;
+		for (const entry of readdirSync(dir, { withFileTypes: true })) {
+			const path = join(dir, entry.name);
+			if (entry.isDirectory()) {
+				stack.push(path);
+				continue;
+			}
+			if (!entry.isFile() || !accept(path)) continue;
+			const mtime = statSync(path).mtimeMs;
+			if (!best || mtime > best.mtime) {
+				best = { path, mtime };
+			}
+		}
+	}
+	return best?.path ?? null;
+}
+
+function replaceSymlink(path: string, target: string): void {
+	try {
+		const stat = lstatSync(path);
+		if (stat.isDirectory()) {
+			throw new Error(`Cannot replace directory with launcher symlink: ${path}`);
+		}
+		rmSync(path, { force: true });
+	} catch (err) {
+		if (err instanceof Error && "code" in err && err.code !== "ENOENT") {
+			throw err;
+		}
+	}
+	symlinkSync(target, path);
+}
+
+function desktopEntryContent(binary: string, icon: string): string {
+	return `[Desktop Entry]
+Type=Application
+Name=Signet
+Comment=Local-first identity, memory, and secrets for AI agents
+Exec=${quoteDesktopPath(binary)} %U
+Icon=${icon}
+Terminal=false
+Categories=Utility;Development;
+StartupWMClass=Signet
+`;
+}
+
+function quoteDesktopPath(path: string): string {
+	return `"${path.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+}

--- a/packages/cli/src/features/desktop.ts
+++ b/packages/cli/src/features/desktop.ts
@@ -5,6 +5,7 @@ import {
 	existsSync,
 	lstatSync,
 	mkdirSync,
+	readFileSync,
 	readdirSync,
 	readlinkSync,
 	rmSync,
@@ -169,7 +170,51 @@ function ancestorCandidates(path: string): string[] {
 }
 
 function isDesktopSourceCheckout(path: string): boolean {
-	return existsSync(join(path, "package.json")) && existsSync(join(path, "packages", "desktop", "package.json"));
+	const rootPkgPath = join(path, "package.json");
+	const desktopPkgPath = join(path, "packages", "desktop", "package.json");
+	if (!existsSync(rootPkgPath) || !existsSync(desktopPkgPath)) {
+		return false;
+	}
+
+	const rootPkg = readJson(rootPkgPath);
+	const desktopPkg = readJson(desktopPkgPath);
+	if (jsonString(rootPkg, "name") !== "signet" || jsonString(desktopPkg, "name") !== "@signet/desktop") {
+		return false;
+	}
+
+	const workspaces = jsonStringArray(rootPkg, "workspaces");
+	return (
+		workspaces.includes("packages/*") &&
+		workspaces.includes("packages/cli/dashboard") &&
+		jsonString(desktopPkg, "main") === "dist/main.js" &&
+		jsonString(jsonObject(desktopPkg, "build"), "appId") === "ai.signet.app"
+	);
+}
+
+function readJson(path: string): unknown {
+	try {
+		return JSON.parse(readFileSync(path, "utf8"));
+	} catch {
+		return null;
+	}
+}
+
+function jsonObject(value: unknown, key: string): unknown {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+	const child = Reflect.get(value, key);
+	return child && typeof child === "object" && !Array.isArray(child) ? child : null;
+}
+
+function jsonString(value: unknown, key: string): string | null {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+	const child = Reflect.get(value, key);
+	return typeof child === "string" ? child : null;
+}
+
+function jsonStringArray(value: unknown, key: string): string[] {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+	const child = Reflect.get(value, key);
+	return Array.isArray(child) && child.every((item) => typeof item === "string") ? child : [];
 }
 
 function desktopReleaseDir(repo: string): string {


### PR DESCRIPTION
## Summary

Adds the official CLI entrypoint for building and installing the Signet Electron desktop app from an existing source checkout.

`signet desktop build` resolves the local checkout, runs `bun install`, and then runs `bun run build:desktop`.

`signet desktop install` uses the same build path, then installs the newest Linux AppImage as a user-level launcher with a desktop entry. This gives Arch Linux a working native install path now while keeping macOS and Windows guarded until their native installer automation is wired.

## Details

- Adds `signet desktop build` and `signet desktop install` command registration.
- Adds checkout resolution through cwd, `SIGNET_SOURCE_DIR`, `--repo`, and the existing `~/signet/signetai` workspace path.
- Installs Linux artifacts under `~/.local/share/signet/desktop`, `~/.local/bin/signet-desktop`, and `~/.local/share/applications/signet.desktop`.
- Documents the command in `docs/CLI.md`.
- Updates the approved desktop packaging spec and dependency metadata so the source-build command is part of the contract.

## Validation

- `bun test packages/cli/src/features/desktop.test.ts packages/cli/src/commands/app.test.ts`
- `bun scripts/spec-deps-check.ts`
- `bun run build:core`
- `bun run --filter '@signet/cli' build:cli`
- `node packages/cli/dist/cli.js desktop install --help`

## Readiness Checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally
