### PR TITLE
fix(daemon): write named-agent MEMORY heads locally

### DIFF
--- a/packages/daemon/src/memory-head.test.ts
+++ b/packages/daemon/src/memory-head.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Tiktoken } from "js-tiktoken/lite";
@@ -14,6 +14,10 @@ let prevSignetPath: string | undefined;
 
 function readMemoryHead(): string {
 	return readFileSync(join(agentsDir, "MEMORY.md"), "utf-8");
+}
+
+function readAgentMemoryHead(agentId: string): string {
+	return readFileSync(join(agentsDir, "agents", agentId, "MEMORY.md"), "utf-8");
 }
 
 describe("writeMemoryHead", () => {
@@ -81,6 +85,37 @@ describe("writeMemoryHead", () => {
 			return result.n;
 		});
 		expect(otherCount).toBe(0);
+	});
+
+	it("writes named-agent projections to the agent-local MEMORY.md", () => {
+		initDbAccessor(join(agentsDir, "memory", "memories.db"), { agentsDir });
+
+		const result = writeMemoryHead("# MEMORY\n\n## Active\n- local to agent-a\n", {
+			agentId: "agent-a",
+			owner: "memory-head-test",
+		});
+		expect(result.ok).toBe(true);
+
+		const file = readAgentMemoryHead("agent-a");
+		expect(file.startsWith("<!-- generated ")).toBe(true);
+		expect(file).toContain("local to agent-a");
+		expect(existsSync(join(agentsDir, "MEMORY.md"))).toBe(false);
+	});
+
+	it("rejects unsafe agent ids before writing a projection", () => {
+		initDbAccessor(join(agentsDir, "memory", "memories.db"), { agentsDir });
+
+		const result = writeMemoryHead("# MEMORY\n\n## Active\n- should not write\n", {
+			agentId: "../agent-a",
+			owner: "memory-head-test",
+		});
+		expect(result).toEqual({
+			ok: false,
+			error: "Invalid agentId for MEMORY.md path: ../agent-a",
+			code: "invalid",
+		});
+		expect(existsSync(join(agentsDir, "MEMORY.md"))).toBe(false);
+		expect(existsSync(join(agentsDir, "agents"))).toBe(false);
 	});
 
 	it("truncates the tail of oversized MEMORY.md content to 5000 tokens", () => {

--- a/packages/daemon/src/memory-head.ts
+++ b/packages/daemon/src/memory-head.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { getDbAccessor } from "./db-accessor";
 import { countChanges } from "./db-helpers";
 import { loadMemoryConfig } from "./memory-config";
@@ -37,6 +37,20 @@ function projectMemoryMd(content: string): { readonly body: string; readonly fil
 	const budget = MEMORY_HEAD_MAX_TOKENS - countTokens(prefix);
 	const body = truncateToTokens(content, budget);
 	return { body, file: `${prefix}${body}` };
+}
+
+function normalizeAgentId(agentId?: string): string {
+	const next = agentId?.trim();
+	return next && next.length > 0 ? next : "default";
+}
+
+function isSafeAgentId(agentId: string): boolean {
+	return agentId === "default" || /^[a-z0-9][a-z0-9-]*$/.test(agentId);
+}
+
+function resolveMemoryHeadPath(agentsDir: string, agentId: string): string {
+	if (agentId === "default") return join(agentsDir, "MEMORY.md");
+	return join(agentsDir, "agents", agentId, "MEMORY.md");
 }
 
 function acquireHeadLease(agentId: string, owner: string, ttlMs: number): LeaseResult {
@@ -139,13 +153,15 @@ function releaseHeadLease(agentId: string, token: string): void {
 	}
 }
 
-function writeProjection(file: string): void {
+function writeProjection(file: string, agentId: string): void {
 	const agentsDir = getAgentsDir();
-	const path = join(agentsDir, "MEMORY.md");
+	const path = resolveMemoryHeadPath(agentsDir, agentId);
+	const dir = dirname(path);
+	mkdirSync(dir, { recursive: true });
 	if (existsSync(path)) {
 		const stamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
-		const backup = join(agentsDir, "memory", `MEMORY.backup-${stamp}.md`);
-		mkdirSync(join(agentsDir, "memory"), { recursive: true });
+		const backup = join(dir, "memory", `MEMORY.backup-${stamp}.md`);
+		mkdirSync(dirname(backup), { recursive: true });
 		writeFileSync(backup, readFileSync(path, "utf-8"));
 	}
 	writeFileSync(path, file);
@@ -172,7 +188,10 @@ export function writeMemoryHead(
 	}
 
 	const projected = projectMemoryMd(trimmed);
-	const agentId = opts?.agentId ?? "default";
+	const agentId = normalizeAgentId(opts?.agentId);
+	if (!isSafeAgentId(agentId)) {
+		return { ok: false, error: `Invalid agentId for MEMORY.md path: ${agentId}`, code: "invalid" };
+	}
 	const owner = opts?.owner ?? `memory-head:${process.pid}:${randomUUID().slice(0, 8)}`;
 	const ttlMs = loadMemoryConfig(getAgentsDir()).pipelineV2.worker.leaseTimeoutMs;
 	const lease = acquireHeadLease(agentId, owner, ttlMs);
@@ -183,7 +202,7 @@ export function writeMemoryHead(
 
 	if (!lease.ok) {
 		try {
-			writeProjection(projected.file);
+			writeProjection(projected.file, agentId);
 			return { ok: true, revision: 0 };
 		} catch (error) {
 			return {
@@ -201,7 +220,7 @@ export function writeMemoryHead(
 	}
 
 	try {
-		writeProjection(projected.file);
+		writeProjection(projected.file, agentId);
 		return { ok: true, revision: next };
 	} catch (error) {
 		return {


### PR DESCRIPTION
## Summary

- Route `writeMemoryHead()` disk projections by agent scope.
- Keep the default agent at `$SIGNET_WORKSPACE/MEMORY.md`.
- Write named-agent projections to `$SIGNET_WORKSPACE/agents/{agentId}/MEMORY.md`.
- Store projection backups beside the relevant MEMORY head.
- Reject unsafe agent IDs before constructing filesystem paths.

## Context

Issue #448 was mostly handled by #455, which fixed sub-agent dedupe, synthesis head metadata, and roster config drift. One gap remained: the DB row in `memory_md_heads` could be scoped to the named agent while the physical `MEMORY.md` file was still written to the root workspace. That meant sub-agents could have correct head metadata but no agent-local `MEMORY.md` file for identity injection.

## Validation

```bash
bun run build:core
bun test packages/daemon/src/memory-head.test.ts
bun test packages/daemon/src/pipeline/synthesis-worker.test.ts
bunx biome check packages/daemon/src/memory-head.ts packages/daemon/src/memory-head.test.ts
```

I also ran `bun test packages/daemon/src/hooks.test.ts`; it still has unrelated existing failures around prompt recall returning zero matches and one memory-lineage immutability expectation. Those paths are not touched by this PR.

## Related

- Addresses remaining file-projection gap from #448
- Follow-up to #455
