### PR TITLE
fix(desktop): bind install to configured workspace

### DIFF
--- a/packages/cli/dashboard/src/lib/desktop-shell.ts
+++ b/packages/cli/dashboard/src/lib/desktop-shell.ts
@@ -16,6 +16,8 @@ export interface SignetDesktopBridge {
 		| "cygwin"
 		| "netbsd";
 	readonly daemonPort: number;
+	readonly daemonBaseUrl?: string;
+	readonly workspacePath?: string | null;
 	readonly nativeFrame: boolean;
 	minimize(): Promise<void>;
 	toggleMaximize(): Promise<void>;
@@ -45,6 +47,7 @@ export function isDesktopShell(): boolean {
 export function desktopApiBase(): string {
 	const shell = getDesktopShell();
 	if (!shell) return "";
+	if (shell.daemonBaseUrl) return shell.daemonBaseUrl;
 	const port = Number.isFinite(shell.daemonPort) && shell.daemonPort > 0 ? shell.daemonPort : 3850;
 	return `http://localhost:${port}`;
 }

--- a/packages/cli/src/commands/desktop.ts
+++ b/packages/cli/src/commands/desktop.ts
@@ -16,7 +16,10 @@ export function registerDesktopCommands(program: Command, deps: DesktopDeps): vo
 	desktop
 		.command("build")
 		.description("Build the Signet Electron desktop app from a source checkout")
-		.option("--repo <path>", "Signet source checkout path (defaults to cwd, SIGNET_SOURCE_DIR, or ~/signet/signetai)")
+		.option(
+			"--repo <path>",
+			"Signet source checkout path (defaults to SIGNET_SOURCE_DIR, <configured workspace>/signetai, or cwd)",
+		)
 		.action((options: { readonly repo?: string }) => {
 			try {
 				console.log(chalk.cyan("Building Signet desktop from source..."));
@@ -34,7 +37,10 @@ export function registerDesktopCommands(program: Command, deps: DesktopDeps): vo
 	desktop
 		.command("install")
 		.description("Build and install the Signet Electron desktop app")
-		.option("--repo <path>", "Signet source checkout path (defaults to cwd, SIGNET_SOURCE_DIR, or ~/signet/signetai)")
+		.option(
+			"--repo <path>",
+			"Signet source checkout path (defaults to SIGNET_SOURCE_DIR, <configured workspace>/signetai, or cwd)",
+		)
 		.option("--skip-build", "Install the newest existing desktop artifact without rebuilding")
 		.action((options: { readonly repo?: string; readonly skipBuild?: boolean }) => {
 			try {
@@ -49,6 +55,7 @@ export function registerDesktopCommands(program: Command, deps: DesktopDeps): vo
 				console.log(chalk.dim(`  AppImage: ${result.appImage}`));
 				console.log(chalk.dim(`  Launcher: ${result.binary}`));
 				console.log(chalk.dim(`  Desktop:  ${result.desktopEntry}`));
+				console.log(chalk.dim(`  Workspace: ${result.workspace}`));
 				console.log(chalk.cyan("\n  Run: signet-desktop"));
 			} catch (err) {
 				console.error(chalk.red("Signet desktop install failed"));

--- a/packages/cli/src/features/desktop.test.ts
+++ b/packages/cli/src/features/desktop.test.ts
@@ -5,7 +5,7 @@ import {
 	mkdirSync,
 	mkdtempSync,
 	readFileSync,
-	readlinkSync,
+	renameSync,
 	rmSync,
 	symlinkSync,
 	utimesSync,
@@ -40,9 +40,83 @@ describe("desktop source checkout resolution", () => {
 		const root = makeCheckout();
 		try {
 			const cwd = join(root, "packages", "desktop");
-			expect(resolveDesktopSourceCheckout(undefined, { cwd, home: join(root, "home"), env: {} })).toBe(root);
+			expect(
+				resolveDesktopSourceCheckout(undefined, {
+					cwd,
+					env: { SIGNET_PATH: join(root, "missing-workspace") },
+				}),
+			).toBe(root);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("finds the checkout under the configured workspace", () => {
+		const home = mkdtempSync(join(tmpdir(), "signet-desktop-home-"));
+		const workspace = join(home, "workspace");
+		const checkout = makeCheckout();
+		const repo = join(workspace, "signetai");
+		const outside = join(home, "outside");
+		try {
+			mkdirSync(workspace, { recursive: true });
+			mkdirSync(outside, { recursive: true });
+			rmSync(repo, { recursive: true, force: true });
+			mkdirSync(repo, { recursive: true });
+			for (const entry of ["package.json", "packages"]) {
+				renameSync(join(checkout, entry), join(repo, entry));
+			}
+
+			expect(resolveDesktopSourceCheckout(undefined, { cwd: outside, env: { SIGNET_PATH: workspace } })).toBe(repo);
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+			rmSync(checkout, { recursive: true, force: true });
+		}
+	});
+
+	test("finds the checkout under the workspace config path", () => {
+		const home = mkdtempSync(join(tmpdir(), "signet-desktop-home-"));
+		const configHome = join(home, "config");
+		const workspace = join(home, "configured-workspace");
+		const repo = join(workspace, "signetai");
+		const checkout = makeCheckout();
+		const outside = join(home, "outside");
+		try {
+			mkdirSync(join(configHome, "signet"), { recursive: true });
+			mkdirSync(workspace, { recursive: true });
+			mkdirSync(outside, { recursive: true });
+			writeFileSync(join(configHome, "signet", "workspace.json"), JSON.stringify({ version: 1, workspace }));
+			mkdirSync(repo, { recursive: true });
+			for (const entry of ["package.json", "packages"]) {
+				renameSync(join(checkout, entry), join(repo, entry));
+			}
+
+			expect(resolveDesktopSourceCheckout(undefined, { cwd: outside, env: { XDG_CONFIG_HOME: configHome } })).toBe(
+				repo,
+			);
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+			rmSync(checkout, { recursive: true, force: true });
+		}
+	});
+
+	test("honors SIGNET_SOURCE_DIR before the configured workspace", () => {
+		const explicit = makeCheckout();
+		const workspaceRepo = makeCheckout();
+		const home = mkdtempSync(join(tmpdir(), "signet-desktop-home-"));
+		const workspace = join(home, "workspace");
+		try {
+			mkdirSync(workspace, { recursive: true });
+			rmSync(join(workspace, "signetai"), { recursive: true, force: true });
+			renameSync(workspaceRepo, join(workspace, "signetai"));
+			expect(
+				resolveDesktopSourceCheckout(undefined, {
+					cwd: home,
+					env: { SIGNET_PATH: workspace, SIGNET_SOURCE_DIR: explicit },
+				}),
+			).toBe(explicit);
+		} finally {
+			rmSync(explicit, { recursive: true, force: true });
+			rmSync(home, { recursive: true, force: true });
 		}
 	});
 
@@ -117,13 +191,19 @@ describe("linux desktop install", () => {
 			utimesSync(wrongArchArtifact, new Date(3_000), new Date(3_000));
 			utimesSync(nestedArtifact, new Date(4_000), new Date(4_000));
 
-			const result = installLinuxDesktopApp(root, home);
+			const workspace = join(home, "workspace");
+			const result = installLinuxDesktopApp(root, home, workspace);
 
 			expect(readFileSync(result.appImage, "utf8")).toBe("new");
-			expect(readlinkSync(result.binary)).toBe(result.appImage);
+			expect(lstatSync(result.binary).isSymbolicLink()).toBe(false);
+			const launcher = readFileSync(result.binary, "utf8");
+			expect(launcher).toContain("# signet-desktop managed launcher");
+			expect(launcher).toContain(`export SIGNET_PATH='${workspace}'`);
+			expect(launcher).toContain(`exec '${result.appImage}' "$@"`);
 			expect(readFileSync(result.desktopEntry, "utf8")).toContain("Name=Signet");
 			expect(readFileSync(result.desktopEntry, "utf8")).toContain(`Exec=\"${result.binary}\" %U`);
 			expect(existsSync(result.icon)).toBe(true);
+			expect(result.workspace).toBe(workspace);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 			rmSync(home, { recursive: true, force: true });
@@ -142,7 +222,9 @@ describe("linux desktop install", () => {
 			const existing = join(binDir, "signet-desktop");
 			writeFileSync(existing, "custom launcher");
 
-			expect(() => installLinuxDesktopApp(root, home)).toThrow("Refusing to replace existing non-symlink launcher");
+			expect(() => installLinuxDesktopApp(root, home, join(home, "workspace"))).toThrow(
+				"Refusing to replace existing non-managed launcher",
+			);
 			expect(readFileSync(existing, "utf8")).toBe("custom launcher");
 		} finally {
 			rmSync(root, { recursive: true, force: true });
@@ -166,10 +248,10 @@ describe("linux desktop install", () => {
 			const binary = join(binDir, "signet-desktop");
 			symlinkSync(oldTarget, binary);
 
-			const result = installLinuxDesktopApp(root, home);
+			const result = installLinuxDesktopApp(root, home, join(home, "workspace"));
 
-			expect(lstatSync(result.binary).isSymbolicLink()).toBe(true);
-			expect(readlinkSync(result.binary)).toBe(result.appImage);
+			expect(lstatSync(result.binary).isSymbolicLink()).toBe(false);
+			expect(readFileSync(result.binary, "utf8")).toContain(`exec '${result.appImage}' "$@"`);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 			rmSync(home, { recursive: true, force: true });
@@ -188,6 +270,7 @@ describe("linux desktop install", () => {
 				{ repo: root, skipBuild: true },
 				{
 					home,
+					env: { SIGNET_PATH: join(home, "workspace") },
 					platform: "linux",
 					runner: () => {
 						throw new Error("runner should not be called");

--- a/packages/cli/src/features/desktop.ts
+++ b/packages/cli/src/features/desktop.ts
@@ -10,12 +10,13 @@ import {
 	readlinkSync,
 	rmSync,
 	statSync,
-	symlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveWorkspaceSourceRepoPath } from "@signet/core";
+import { resolveAgentsDir } from "../lib/workspace.js";
 
 export interface DesktopCommandOptions {
 	readonly repo?: string;
@@ -35,6 +36,7 @@ export interface DesktopLinuxInstallResult extends DesktopBuildResult {
 	readonly binary: string;
 	readonly desktopEntry: string;
 	readonly icon: string;
+	readonly workspace: string;
 }
 
 interface DesktopCommandContext {
@@ -69,14 +71,7 @@ export function resolveDesktopSourceCheckout(
 	ctx: Pick<DesktopCommandContext, "cwd" | "env" | "home"> = {},
 ): string {
 	const explicit = repo?.trim() || ctx.env?.SIGNET_SOURCE_DIR?.trim();
-	const candidates = explicit
-		? [explicit]
-		: [
-				ctx.cwd ?? process.cwd(),
-				dirname(fileURLToPath(import.meta.url)),
-				join(ctx.home ?? homedir(), "signet", "signetai"),
-				join(ctx.home ?? homedir(), "signet", "signetai4"),
-			].flatMap((candidate) => ancestorCandidates(candidate));
+	const candidates = explicit ? [explicit] : desktopSourceCheckoutCandidates(ctx);
 
 	for (const candidate of candidates) {
 		const resolved = resolve(candidate);
@@ -87,8 +82,24 @@ export function resolveDesktopSourceCheckout(
 
 	const hint = explicit
 		? `Not a Signet source checkout: ${resolve(explicit)}`
-		: "Could not find a Signet source checkout. Run from the repo root, set SIGNET_SOURCE_DIR, or pass --repo <path>.";
+		: "Could not find a Signet source checkout. Run from the repo root, set SIGNET_SOURCE_DIR, pass --repo <path>, or keep the checkout at <configured Signet workspace>/signetai.";
 	throw new Error(hint);
+}
+
+function desktopSourceCheckoutCandidates(ctx: Pick<DesktopCommandContext, "cwd" | "env">): string[] {
+	const seen = new Set<string>();
+	const candidates = [
+		resolveWorkspaceSourceRepoPath(resolveAgentsDir(ctx.env ?? process.env).path),
+		...[ctx.cwd ?? process.cwd(), dirname(fileURLToPath(import.meta.url))].flatMap((candidate) =>
+			ancestorCandidates(candidate),
+		),
+	];
+	return candidates.filter((candidate) => {
+		const resolved = resolve(candidate);
+		if (seen.has(resolved)) return false;
+		seen.add(resolved);
+		return true;
+	});
 }
 
 export function buildDesktopFromSource(
@@ -110,6 +121,7 @@ export function installDesktopFromSource(
 	ctx: DesktopCommandContext = {},
 ): DesktopLinuxInstallResult {
 	const repo = resolveDesktopSourceCheckout(options.repo, ctx);
+	const workspace = resolveAgentsDir(ctx.env ?? process.env).path;
 	if (!options.skipBuild) {
 		buildDesktopFromSource({ repo }, ctx);
 	}
@@ -121,10 +133,14 @@ export function installDesktopFromSource(
 		);
 	}
 
-	return installLinuxDesktopApp(repo, ctx.home ?? homedir());
+	return installLinuxDesktopApp(repo, ctx.home ?? homedir(), workspace);
 }
 
-export function installLinuxDesktopApp(repo: string, home: string): DesktopLinuxInstallResult {
+export function installLinuxDesktopApp(
+	repo: string,
+	home: string,
+	workspace = resolveAgentsDir().path,
+): DesktopLinuxInstallResult {
 	const releaseDir = desktopReleaseDir(repo);
 	const source = findLinuxAppImage(releaseDir, process.arch);
 	if (!source) {
@@ -150,12 +166,12 @@ export function installLinuxDesktopApp(repo: string, home: string): DesktopLinux
 	copyFileSync(join(repo, "packages", "desktop", "icons", "icon.png"), icon);
 
 	const binary = join(binDir, "signet-desktop");
-	replaceSymlink(binary, appImage);
+	writeManagedLauncher(binary, appImage, workspace);
 
 	const desktopEntry = join(applicationsDir, "signet.desktop");
 	writeFileSync(desktopEntry, desktopEntryContent(binary, icon));
 
-	return { repo, releaseDir, appImage, binary, desktopEntry, icon };
+	return { repo, releaseDir, appImage, binary, desktopEntry, icon, workspace };
 }
 
 function ancestorCandidates(path: string): string[] {
@@ -266,31 +282,44 @@ function linuxArtifactArchNames(arch: string): ReadonlySet<string> {
 	}
 }
 
-function replaceSymlink(path: string, target: string): void {
+const MANAGED_LAUNCHER_MARKER = "# signet-desktop managed launcher";
+
+function writeManagedLauncher(path: string, target: string, workspace: string): void {
+	const appDir = dirname(target);
 	try {
 		const stat = lstatSync(path);
-		if (!stat.isSymbolicLink()) {
+		if (stat.isSymbolicLink()) {
+			const current = resolve(dirname(path), readlinkSync(path));
+			if (current !== target && !current.startsWith(`${appDir}/`)) {
+				throw new Error(
+					`Refusing to replace launcher symlink at ${path} because it does not point at Signet's desktop install directory.`,
+				);
+			}
+			rmSync(path, { force: true });
+		} else if (readFileSync(path, "utf8").includes(MANAGED_LAUNCHER_MARKER)) {
+			rmSync(path, { force: true });
+		} else {
 			throw new Error(
-				`Refusing to replace existing non-symlink launcher at ${path}. Remove it first if it is not needed.`,
+				`Refusing to replace existing non-managed launcher at ${path}. Remove it first if it is not needed.`,
 			);
 		}
-
-		const current = resolve(dirname(path), readlinkSync(path));
-		const ownedDir = dirname(target);
-		if (current !== target && !current.startsWith(`${ownedDir}/`)) {
-			throw new Error(
-				`Refusing to replace launcher symlink at ${path} because it does not point at Signet's desktop install directory.`,
-			);
-		}
-
-		rmSync(path, { force: true });
 	} catch (err) {
 		const code = err && typeof err === "object" && "code" in err ? err.code : undefined;
 		if (code !== "ENOENT") {
 			throw err;
 		}
 	}
-	symlinkSync(target, path);
+	writeFileSync(path, launcherContent(target, workspace), { mode: 0o755 });
+	chmodSync(path, 0o755);
+}
+
+function launcherContent(target: string, workspace: string): string {
+	return `#!/usr/bin/env sh
+${MANAGED_LAUNCHER_MARKER}
+export SIGNET_PATH=${quoteShellPath(workspace)}
+export SIGNET_WORKSPACE="$SIGNET_PATH"
+exec ${quoteShellPath(target)} "$@"
+`;
 }
 
 function desktopEntryContent(binary: string, icon: string): string {
@@ -308,4 +337,8 @@ StartupWMClass=Signet
 
 function quoteDesktopPath(path: string): string {
 	return `"${path.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+}
+
+function quoteShellPath(path: string): string {
+	return `'${path.replaceAll("'", "'\\''")}'`;
 }

--- a/packages/desktop/src/daemon-manager.test.ts
+++ b/packages/desktop/src/daemon-manager.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import { healthWorkspaceMismatch } from "./daemon-workspace.js";
+
+describe("desktop daemon workspace matching", () => {
+	test("accepts matching health agentsDir", () => {
+		expect(healthWorkspaceMismatch("/tmp/signet", "/tmp/signet")).toBeNull();
+	});
+
+	test("reports mismatched daemon workspaces", () => {
+		expect(healthWorkspaceMismatch("/tmp/expected", "/tmp/actual")).toEqual({
+			expected: resolve("/tmp/expected"),
+			actual: resolve("/tmp/actual"),
+		});
+	});
+
+	test("treats missing agentsDir as a mismatch", () => {
+		expect(healthWorkspaceMismatch("/tmp/expected", null)).toEqual({
+			expected: resolve("/tmp/expected"),
+			actual: "unknown",
+		});
+	});
+});

--- a/packages/desktop/src/daemon-manager.test.ts
+++ b/packages/desktop/src/daemon-manager.test.ts
@@ -14,10 +14,7 @@ describe("desktop daemon workspace matching", () => {
 		});
 	});
 
-	test("treats missing agentsDir as a mismatch", () => {
-		expect(healthWorkspaceMismatch("/tmp/expected", null)).toEqual({
-			expected: resolve("/tmp/expected"),
-			actual: "unknown",
-		});
+	test("allows missing agentsDir for older health payloads", () => {
+		expect(healthWorkspaceMismatch("/tmp/expected", null)).toBeNull();
 	});
 });

--- a/packages/desktop/src/daemon-manager.ts
+++ b/packages/desktop/src/daemon-manager.ts
@@ -1,13 +1,15 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { type WriteStream, createWriteStream, existsSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { app } from "electron";
+import { type WorkspaceMismatch, healthWorkspaceMismatch } from "./daemon-workspace.js";
 import { bunPath, daemonEntry, daemonRoot } from "./paths.js";
 
 export interface HealthStatus {
 	readonly version: string;
 	readonly pid: number;
 	readonly uptime: number;
+	readonly agentsDir: string | null;
 }
 
 export interface DesktopDaemonStatus {
@@ -18,6 +20,12 @@ export interface DesktopDaemonStatus {
 	readonly uptime: number | null;
 	readonly port: number;
 	readonly baseUrl: string;
+	readonly workspacePath: string;
+	readonly mismatch: WorkspaceMismatch | null;
+}
+
+export interface DaemonManagerOptions {
+	readonly workspacePath: string;
 }
 
 function readPort(): number {
@@ -49,13 +57,27 @@ function stringOrNull(value: unknown): string | null {
 export class DaemonManager {
 	readonly port = readPort();
 	readonly baseUrl = `http://localhost:${this.port}`;
+	readonly #workspacePath: string;
 	#child: ChildProcess | null = null;
 	#owned = false;
 	#startPromise: Promise<DesktopDaemonStatus> | null = null;
 	#stdout: WriteStream | null = null;
 	#stderr: WriteStream | null = null;
+	#lastMismatch: WorkspaceMismatch | null = null;
+
+	constructor(options: DaemonManagerOptions) {
+		this.#workspacePath = resolve(options.workspacePath);
+		process.env.SIGNET_DESKTOP_DAEMON_BASE_URL = this.baseUrl;
+	}
 
 	async probe(timeoutMs = 1200): Promise<HealthStatus | null> {
+		const health = await this.#probeRaw(timeoutMs);
+		const mismatch = health ? healthWorkspaceMismatch(this.#workspacePath, health.agentsDir) : null;
+		this.#lastMismatch = mismatch;
+		return mismatch ? null : health;
+	}
+
+	async #probeRaw(timeoutMs = 1200): Promise<HealthStatus | null> {
 		const { signal, cancel } = controllerSignal(timeoutMs);
 		try {
 			const response = await fetch(`${this.baseUrl}/health`, { signal });
@@ -66,6 +88,7 @@ export class DaemonManager {
 				version: stringOrNull(data.version) ?? "unknown",
 				pid: pid ?? 0,
 				uptime: numberOrNull(data.uptime) ?? 0,
+				agentsDir: stringOrNull(data.agentsDir),
 			};
 		} catch {
 			return null;
@@ -84,6 +107,8 @@ export class DaemonManager {
 			uptime: health?.uptime ?? null,
 			port: this.port,
 			baseUrl: this.baseUrl,
+			workspacePath: this.#workspacePath,
+			mismatch: this.#lastMismatch,
 		};
 	}
 
@@ -98,7 +123,15 @@ export class DaemonManager {
 	}
 
 	async #ensureStarted(): Promise<DesktopDaemonStatus> {
-		const existing = await this.probe();
+		const raw = await this.#probeRaw();
+		const mismatch = raw ? healthWorkspaceMismatch(this.#workspacePath, raw.agentsDir) : null;
+		this.#lastMismatch = mismatch;
+		if (mismatch) {
+			throw new Error(
+				`Signet daemon on ${this.baseUrl} is using workspace ${mismatch.actual}, expected ${mismatch.expected}. Stop that daemon or start it with the configured workspace before opening the desktop app.`,
+			);
+		}
+		const existing = raw;
 		if (existing) {
 			this.#owned = false;
 			return this.status();
@@ -193,6 +226,8 @@ export class DaemonManager {
 			env: {
 				...process.env,
 				SIGNET_PORT: String(this.port),
+				SIGNET_PATH: this.#workspacePath,
+				SIGNET_WORKSPACE: this.#workspacePath,
 				SIGNET_DESKTOP: "1",
 			},
 		});

--- a/packages/desktop/src/daemon-workspace.ts
+++ b/packages/desktop/src/daemon-workspace.ts
@@ -6,12 +6,7 @@ export interface WorkspaceMismatch {
 }
 
 export function healthWorkspaceMismatch(expected: string, actual: string | null): WorkspaceMismatch | null {
-	if (!actual) {
-		return {
-			expected: resolve(expected),
-			actual: "unknown",
-		};
-	}
+	if (!actual) return null;
 
 	const normalizedExpected = resolve(expected);
 	const normalizedActual = resolve(actual);

--- a/packages/desktop/src/daemon-workspace.ts
+++ b/packages/desktop/src/daemon-workspace.ts
@@ -1,0 +1,24 @@
+import { resolve } from "node:path";
+
+export interface WorkspaceMismatch {
+	readonly expected: string;
+	readonly actual: string;
+}
+
+export function healthWorkspaceMismatch(expected: string, actual: string | null): WorkspaceMismatch | null {
+	if (!actual) {
+		return {
+			expected: resolve(expected),
+			actual: "unknown",
+		};
+	}
+
+	const normalizedExpected = resolve(expected);
+	const normalizedActual = resolve(actual);
+	return normalizedExpected === normalizedActual
+		? null
+		: {
+				expected: normalizedExpected,
+				actual: normalizedActual,
+			};
+}

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -11,6 +11,8 @@ const daemon = new DaemonManager({ workspacePath: workspace.path });
 let mainWindow: BrowserWindow | null = null;
 let tray: DesktopTray | null = null;
 let quitting = false;
+let daemonStartupError: string | null = null;
+let loadedMainWindowUrl: string | null = null;
 
 function enableGpuRendering(): void {
 	if (process.env.SIGNET_DESKTOP_DISABLE_GPU === "1") return;
@@ -124,22 +126,101 @@ function createMainWindow(): BrowserWindow {
 		mainWindow = null;
 	});
 
-	mainWindow.loadURL("app://signet/").catch((err) => {
-		console.error("Failed to load dashboard", err);
-	});
 	return mainWindow;
 }
 
 function showDashboard(): void {
+	void showDashboardReady();
+}
+
+async function showDashboardReady(): Promise<void> {
+	await prepareDaemonForDashboard();
 	const win = createMainWindow();
+	loadMainWindow(win);
 	if (win.isMinimized()) win.restore();
 	win.show();
 	win.focus();
 }
 
+async function prepareDaemonForDashboard(): Promise<void> {
+	try {
+		await daemon.ensureStarted();
+		daemonStartupError = null;
+	} catch (err) {
+		daemonStartupError = errorMessage(err);
+		console.error(err);
+	}
+}
+
+async function assertDaemonUsable(): Promise<void> {
+	try {
+		await daemon.ensureStarted();
+		daemonStartupError = null;
+	} catch (err) {
+		daemonStartupError = errorMessage(err);
+		throw err;
+	}
+}
+
+function loadMainWindow(win: BrowserWindow): void {
+	const url = daemonStartupError ? startupErrorUrl(daemonStartupError) : "app://signet/";
+	if (loadedMainWindowUrl === url) return;
+	loadedMainWindowUrl = url;
+	win.loadURL(url).catch((err) => {
+		console.error(daemonStartupError ? "Failed to load startup error" : "Failed to load dashboard", err);
+	});
+}
+
+function startupErrorUrl(message: string): string {
+	return `data:text/html;charset=utf-8,${encodeURIComponent(startupErrorHtml(message))}`;
+}
+
+function startupErrorHtml(message: string): string {
+	const safeMessage = escapeHtml(message);
+	const safeWorkspace = escapeHtml(workspace.path);
+	return `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Signet daemon blocked</title>
+<style>
+body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #0f0f0f; color: #f2f2f2; font: 14px ui-monospace, SFMono-Regular, Menlo, monospace; }
+main { max-width: 720px; padding: 40px; border: 1px solid #333; background: #151515; box-shadow: 0 24px 80px rgba(0,0,0,.45); }
+h1 { margin: 0 0 16px; font-size: 22px; letter-spacing: .08em; text-transform: uppercase; }
+p { line-height: 1.6; color: #cfcfcf; }
+code { color: #b7ff00; word-break: break-all; }
+.error { color: #ff8f8f; white-space: pre-wrap; }
+</style>
+</head>
+<body>
+<main>
+<h1>Daemon workspace mismatch</h1>
+<p>Signet blocked the dashboard because the daemon on the configured port is not confirmed to be using this desktop workspace.</p>
+<p>Expected workspace: <code>${safeWorkspace}</code></p>
+<p class="error">${safeMessage}</p>
+<p>Stop the other daemon or restart it with the configured workspace, then reopen Signet.</p>
+</main>
+</body>
+</html>`;
+}
+
+function escapeHtml(value: string): string {
+	return value
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll('"', "&quot;")
+		.replaceAll("'", "&#39;");
+}
+
+function errorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
 async function quickCapture(content: string): Promise<void> {
 	const trimmed = content.trim();
 	if (!trimmed) throw new Error("content is required");
+	await assertDaemonUsable();
 	const response = await fetch(`${daemon.baseUrl}/api/memory/remember`, {
 		method: "POST",
 		headers: { "content-type": "application/json" },
@@ -151,6 +232,7 @@ async function quickCapture(content: string): Promise<void> {
 async function searchMemories(query: string, limit?: number): Promise<string> {
 	const trimmed = query.trim();
 	if (!trimmed) throw new Error("query is required");
+	await assertDaemonUsable();
 	const response = await fetch(`${daemon.baseUrl}/api/memory/recall`, {
 		method: "POST",
 		headers: { "content-type": "application/json" },
@@ -171,9 +253,17 @@ function registerIpc(): void {
 	});
 	ipcMain.handle("desktop:close", () => focusedWindow()?.close());
 	ipcMain.handle("desktop:isMaximized", () => focusedWindow()?.isMaximized() ?? false);
-	ipcMain.handle("desktop:startDaemon", () => daemon.start());
+	ipcMain.handle("desktop:startDaemon", async () => {
+		const status = await daemon.start();
+		daemonStartupError = null;
+		return status;
+	});
 	ipcMain.handle("desktop:stopDaemon", () => daemon.stop());
-	ipcMain.handle("desktop:restartDaemon", () => daemon.restart());
+	ipcMain.handle("desktop:restartDaemon", async () => {
+		const status = await daemon.restart();
+		daemonStartupError = null;
+		return status;
+	});
 	ipcMain.handle("desktop:getDaemonStatus", () => daemon.status());
 	ipcMain.handle("desktop:openDashboard", () => showDashboard());
 	ipcMain.handle("desktop:quickCapture", (_event, content: string) => quickCapture(content));
@@ -196,11 +286,6 @@ app.whenReady().then(async () => {
 	registerIpc();
 	tray = new DesktopTray(daemon, showDashboard);
 	tray.start();
-	try {
-		await daemon.ensureStarted();
-	} catch (err) {
-		console.error(err);
-	}
 	showDashboard();
 
 	app.on("activate", () => showDashboard());

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -4,8 +4,10 @@ import { BrowserWindow, Menu, app, ipcMain, protocol, shell } from "electron";
 import { DaemonManager } from "./daemon-manager.js";
 import { dashboardRoot, preloadPath } from "./paths.js";
 import { DesktopTray } from "./tray.js";
+import { applyDesktopWorkspaceEnv, resolveDesktopWorkspace } from "./workspace.js";
 
-const daemon = new DaemonManager();
+const workspace = applyDesktopWorkspaceEnv(resolveDesktopWorkspace());
+const daemon = new DaemonManager({ workspacePath: workspace.path });
 let mainWindow: BrowserWindow | null = null;
 let tray: DesktopTray | null = null;
 let quitting = false;

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -1,8 +1,13 @@
 import { contextBridge, ipcRenderer } from "electron";
 
+const daemonPort = Number.parseInt(process.env.SIGNET_PORT ?? "3850", 10);
+const daemonBaseUrl = process.env.SIGNET_DESKTOP_DAEMON_BASE_URL ?? `http://localhost:${daemonPort}`;
+
 contextBridge.exposeInMainWorld("signetDesktop", {
 	platform: process.platform,
-	daemonPort: Number.parseInt(process.env.SIGNET_PORT ?? "3850", 10),
+	daemonPort,
+	daemonBaseUrl,
+	workspacePath: process.env.SIGNET_PATH ?? process.env.SIGNET_WORKSPACE ?? null,
 	nativeFrame: process.env.SIGNET_DESKTOP_NATIVE_FRAME === "1",
 	minimize: () => ipcRenderer.invoke("desktop:minimize"),
 	toggleMaximize: () => ipcRenderer.invoke("desktop:toggleMaximize"),

--- a/packages/desktop/src/workspace.test.ts
+++ b/packages/desktop/src/workspace.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { applyDesktopWorkspaceEnv, resolveDesktopWorkspace } from "./workspace.js";
+
+describe("desktop workspace resolution", () => {
+	test("uses SIGNET_PATH before workspace config", () => {
+		const home = mkdtempSync(join(tmpdir(), "signet-desktop-workspace-"));
+		try {
+			const configHome = join(home, "config");
+			const envWorkspace = join(home, "env-workspace");
+			const configuredWorkspace = join(home, "configured-workspace");
+			mkdirSync(join(configHome, "signet"), { recursive: true });
+			writeFileSync(
+				join(configHome, "signet", "workspace.json"),
+				JSON.stringify({ version: 1, workspace: configuredWorkspace }),
+			);
+
+			const result = resolveDesktopWorkspace({ SIGNET_PATH: envWorkspace, XDG_CONFIG_HOME: configHome }, home);
+
+			expect(result.path).toBe(resolve(envWorkspace));
+			expect(result.source).toBe("env");
+			expect(result.configuredPath).toBe(resolve(configuredWorkspace));
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
+	test("uses workspace config when SIGNET_PATH is not set", () => {
+		const home = mkdtempSync(join(tmpdir(), "signet-desktop-workspace-"));
+		try {
+			const configHome = join(home, "config");
+			const configuredWorkspace = join(home, "configured-workspace");
+			mkdirSync(join(configHome, "signet"), { recursive: true });
+			writeFileSync(
+				join(configHome, "signet", "workspace.json"),
+				JSON.stringify({ version: 1, workspace: configuredWorkspace }),
+			);
+
+			const result = resolveDesktopWorkspace({ XDG_CONFIG_HOME: configHome }, home);
+
+			expect(result.path).toBe(resolve(configuredWorkspace));
+			expect(result.source).toBe("config");
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
+	test("falls back to the home directory .agents workspace", () => {
+		const home = mkdtempSync(join(tmpdir(), "signet-desktop-workspace-"));
+		try {
+			const result = resolveDesktopWorkspace({}, home);
+
+			expect(result.path).toBe(join(home, ".agents"));
+			expect(result.source).toBe("default");
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
+	test("applies resolved workspace to both runtime env names", () => {
+		const env: NodeJS.ProcessEnv = {};
+		const resolution = {
+			path: "/tmp/signet-workspace",
+			source: "env" as const,
+			configPath: "/tmp/config/signet/workspace.json",
+			configuredPath: null,
+		};
+
+		expect(applyDesktopWorkspaceEnv(resolution, env)).toBe(resolution);
+		expect(env.SIGNET_PATH).toBe(resolution.path);
+		expect(env.SIGNET_WORKSPACE).toBe(resolution.path);
+	});
+});

--- a/packages/desktop/src/workspace.test.ts
+++ b/packages/desktop/src/workspace.test.ts
@@ -27,6 +27,19 @@ describe("desktop workspace resolution", () => {
 		}
 	});
 
+	test("uses SIGNET_WORKSPACE when SIGNET_PATH is not set", () => {
+		const home = mkdtempSync(join(tmpdir(), "signet-desktop-workspace-"));
+		try {
+			const workspace = join(home, "workspace-env-alias");
+			const result = resolveDesktopWorkspace({ SIGNET_WORKSPACE: workspace }, home);
+
+			expect(result.path).toBe(resolve(workspace));
+			expect(result.source).toBe("env");
+		} finally {
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
 	test("uses workspace config when SIGNET_PATH is not set", () => {
 		const home = mkdtempSync(join(tmpdir(), "signet-desktop-workspace-"));
 		try {

--- a/packages/desktop/src/workspace.ts
+++ b/packages/desktop/src/workspace.ts
@@ -59,10 +59,13 @@ export function applyDesktopWorkspaceEnv(
 }
 
 function readEnvPath(env: NodeJS.ProcessEnv, home: string): string | null {
-	const raw = env.SIGNET_PATH;
-	if (typeof raw !== "string") return null;
-	const trimmed = raw.trim();
-	return trimmed.length > 0 ? normalizeWorkspacePath(trimmed, home) : null;
+	for (const key of ["SIGNET_PATH", "SIGNET_WORKSPACE"] as const) {
+		const raw = env[key];
+		if (typeof raw !== "string") continue;
+		const trimmed = raw.trim();
+		if (trimmed.length > 0) return normalizeWorkspacePath(trimmed, home);
+	}
+	return null;
 }
 
 function getWorkspaceConfigPath(env: NodeJS.ProcessEnv, home: string): string {

--- a/packages/desktop/src/workspace.ts
+++ b/packages/desktop/src/workspace.ts
@@ -1,0 +1,93 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+export type DesktopWorkspaceSource = "env" | "config" | "default";
+
+export interface DesktopWorkspaceResolution {
+	readonly path: string;
+	readonly source: DesktopWorkspaceSource;
+	readonly configPath: string;
+	readonly configuredPath: string | null;
+}
+
+export function normalizeWorkspacePath(pathValue: string, home = homedir()): string {
+	return resolve(expandHome(pathValue.trim(), home));
+}
+
+export function resolveDesktopWorkspace(
+	env: NodeJS.ProcessEnv = process.env,
+	home = homedir(),
+): DesktopWorkspaceResolution {
+	const configPath = getWorkspaceConfigPath(env, home);
+	const envPath = readEnvPath(env, home);
+	const configPathValue = readWorkspaceFromConfig(configPath, home);
+
+	if (envPath) {
+		return {
+			path: envPath,
+			source: "env",
+			configPath,
+			configuredPath: configPathValue,
+		};
+	}
+
+	if (configPathValue) {
+		return {
+			path: configPathValue,
+			source: "config",
+			configPath,
+			configuredPath: configPathValue,
+		};
+	}
+
+	return {
+		path: join(home, ".agents"),
+		source: "default",
+		configPath,
+		configuredPath: null,
+	};
+}
+
+export function applyDesktopWorkspaceEnv(
+	resolution: DesktopWorkspaceResolution,
+	env: NodeJS.ProcessEnv = process.env,
+): DesktopWorkspaceResolution {
+	env.SIGNET_PATH = resolution.path;
+	env.SIGNET_WORKSPACE = resolution.path;
+	return resolution;
+}
+
+function readEnvPath(env: NodeJS.ProcessEnv, home: string): string | null {
+	const raw = env.SIGNET_PATH;
+	if (typeof raw !== "string") return null;
+	const trimmed = raw.trim();
+	return trimmed.length > 0 ? normalizeWorkspacePath(trimmed, home) : null;
+}
+
+function getWorkspaceConfigPath(env: NodeJS.ProcessEnv, home: string): string {
+	const raw = env.XDG_CONFIG_HOME;
+	if (typeof raw !== "string") return join(home, ".config", "signet", "workspace.json");
+	const trimmed = raw.trim();
+	const configHome = trimmed.length > 0 ? normalizeWorkspacePath(trimmed, home) : join(home, ".config");
+	return join(configHome, "signet", "workspace.json");
+}
+
+function readWorkspaceFromConfig(path: string, home: string): string | null {
+	if (!existsSync(path)) return null;
+	try {
+		const raw: unknown = JSON.parse(readFileSync(path, "utf8"));
+		if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+		const workspace = Reflect.get(raw, "workspace");
+		if (typeof workspace !== "string") return null;
+		const trimmed = workspace.trim();
+		return trimmed.length > 0 ? normalizeWorkspacePath(trimmed, home) : null;
+	} catch {
+		return null;
+	}
+}
+
+function expandHome(pathValue: string, home: string): string {
+	if (pathValue === "~") return home;
+	return pathValue.startsWith("~/") || pathValue.startsWith("~\\") ? join(home, pathValue.slice(2)) : pathValue;
+}

--- a/packages/desktop/tsconfig.json
+++ b/packages/desktop/tsconfig.json
@@ -13,5 +13,6 @@
 		"types": ["node", "electron"],
 		"declarationMap": false
 	},
-	"include": ["src/**/*.ts"]
+	"include": ["src/**/*.ts"],
+	"exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

- resolve `signet desktop build/install` from the configured Signet workspace checkout before falling back to local source ancestors
- install a managed Linux launcher wrapper that exports `SIGNET_PATH` and `SIGNET_WORKSPACE` before launching the AppImage
- make the Electron shell resolve the same workspace, pass it to spawned daemons, and reject daemons running against a different `agentsDir`

## Readiness

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Validation

- `bunx biome check packages/cli/src/commands/desktop.ts packages/cli/src/features/desktop.ts packages/cli/src/features/desktop.test.ts packages/desktop/src/workspace.ts packages/desktop/src/workspace.test.ts packages/desktop/src/daemon-workspace.ts packages/desktop/src/daemon-manager.ts packages/desktop/src/daemon-manager.test.ts packages/desktop/src/main.ts packages/desktop/src/preload.ts packages/desktop/tsconfig.json packages/cli/dashboard/src/lib/desktop-shell.ts`
- `bun test packages/cli/src/features/desktop.test.ts packages/desktop/src/workspace.test.ts packages/desktop/src/daemon-manager.test.ts`
- `bun run --filter '@signet/cli' build:cli`
- `cd packages/desktop && bun run build:main`
- `cd packages/cli/dashboard && bun run check`
