### PR TITLE
feat(memory): index native harness memories

### DIFF
--- a/docs/research/technical/RESEARCH-NATIVE-HARNESS-MEMORY-BRIDGE.md
+++ b/docs/research/technical/RESEARCH-NATIVE-HARNESS-MEMORY-BRIDGE.md
@@ -1,0 +1,23 @@
+---
+title: "Native Harness Memory Bridge Research"
+question: "How should Signet make harness-native memories portable without duplicating each harness's memory pipeline?"
+date: 2026-04-22
+---
+
+# Native Harness Memory Bridge Research
+
+Codex now ships a native memory system that writes consolidated memory
+artifacts under `~/.codex/memories/` and supports extension inputs under
+`~/.codex/memories_extensions/<extension>/`. The relevant stable surface for
+Signet is the filesystem artifact layer, not Codex's internal SQLite state.
+
+The integration posture should be adapter-based: harnesses that already have
+memory remain the source of truth for their native memories, while Signet
+indexes those artifacts with provenance so they can be recalled from other
+harnesses. Signet-authored memories continue to flow through existing Signet
+hooks and recall injection.
+
+For Codex v1, read `memory_summary.md`, `MEMORY.md`, `raw_memories.md`, and
+`rollout_summaries/*.md`. Do not write Codex state DB rows. Use Codex memory
+extensions only as a future native export surface if prompt injection is not
+sufficient for a specific workflow.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -151,6 +151,7 @@ and market subdirectories). Reference repos live in `references/`.
 | `markdown-embedding-normalization-hardening` | RESEARCH-MARKDOWN-EMBEDDING-NORMALIZATION | How should Signet preserve structured markdown for embeddings while preventing repeated poison-pill retries from malformed or provider-sensitive payloads? |
 | `connector-forgecode` | RESEARCH-REFERENCE-REPOS | How should Signet bridge its portable identity, skills, and MCP surfaces into ForgeCode's `~/forge` environment without relying on unavailable lifecycle hooks? |
 | `dreaming-memory-consolidation` | LCM-PATTERNS, memory-pipeline-plan, knowledge-architecture-schema | How should Signet consolidate accumulated session knowledge into a cleaner entity graph during idle periods? |
+| `native-harness-memory-bridge` | RESEARCH-NATIVE-HARNESS-MEMORY-BRIDGE | How should Signet make harness-native memories portable without duplicating each harness's memory pipeline? |
 | `model-provider-router` | RESEARCH-INFERENCE-CONTROL-PLANE, RESEARCH-COMPETITIVE-SYSTEMS | How should Signet centralize inference across harnesses, daemon workloads, and heterogeneous provider backends under one policy surface? |
 
 ### Research Adoption Ledger (high-impact)
@@ -756,6 +757,7 @@ Legend:
 | `engram-informed-predictor-track` | planning | `docs/specs/planning/engram-informed-predictor-track.md` | `predictive-memory-scorer` | `ssm-temporal-backbone` | Engram-pattern translation lane for scorer ablations and SSM handoff contracts |
 | `ssm-temporal-backbone` | planning | `docs/specs/planning/ssm-temporal-backbone.md` | `ssm-foundation-evaluation`, `ontology-evolution-core`, `session-continuity-protocol` | `ssm-graph-traversal-model` | Shadow-mode temporal state model with fallback |
 | `ssm-graph-traversal-model` | planning | `docs/specs/planning/ssm-graph-traversal-model.md` | `ssm-temporal-backbone`, `desire-paths-epic`, `knowledge-architecture-schema` | - | SSM-assisted traversal path ranking |
+| `native-harness-memory-bridge` | approved | `docs/specs/approved/native-harness-memory-bridge.md` | `memory-md-rolling-window-lineage`, `signet-runtime` | - | Indexes native harness memory artifacts into Signet recall without materializing duplicate Signet-authored memory rows; Codex is the first adapter. |
 | `distributed-harness-orchestration` | planning | `docs/specs/planning/distributed-harness-orchestration.md` | `multi-agent-support`, `signet-runtime` | `signet-native-harness` | Stub: multi-remote harness/agent/memory orchestration |
 | `signet-native-harness` | planning | `docs/specs/planning/signet-native-harness.md` | `distributed-harness-orchestration`, `signet-runtime` | - | Stub: first-party harness track (Hermes-agent informed) |
 | `remember-recall-skill-parity` | planning | `docs/specs/planning/remember-recall-skill-parity.md` | `procedural-memory-plan` | - | Stub: /remember and /recall architecture/schema parity |

--- a/docs/specs/approved/native-harness-memory-bridge.md
+++ b/docs/specs/approved/native-harness-memory-bridge.md
@@ -1,0 +1,33 @@
+---
+title: "Native Harness Memory Bridge"
+id: native-harness-memory-bridge
+status: approved
+informed_by:
+  - docs/research/technical/RESEARCH-NATIVE-HARNESS-MEMORY-BRIDGE.md
+section: "Connectors"
+depends_on:
+  - "memory-md-rolling-window-lineage"
+  - "signet-runtime"
+success_criteria:
+  - "Memories written by a native-memory harness are recallable through Signet from other harnesses without becoming Signet-authored memory rows"
+  - "Codex native memory artifacts are indexed with harness/source provenance"
+  - "Codex MCP registration avoids exposing duplicate Signet memory tools by default"
+scope_boundary: "Indexes harness-native memory artifacts and bridges them into recall; does not replace native memory systems, write their internal databases, or add a second extraction pipeline"
+---
+
+# Native Harness Memory Bridge
+
+Signet provides one portable memory interface across harnesses. When a harness
+already has its own memory system, Signet indexes that harness's native memory
+artifacts as external provenance-bearing artifacts rather than re-extracting,
+rewriting, or claiming ownership of those memories.
+
+V1 implements the generic source abstraction with Codex as the first adapter.
+Codex memory files under `~/.codex/memories/` are indexed into Signet's
+artifact search layer and surfaced through recall as `native_memory` results.
+Normal Signet hooks remain the write path for Signet memories created from
+Hermes, OpenClaw, OpenCode, Claude Code, and Codex sessions.
+
+Codex's MCP registration keeps hooks and non-duplicative Signet capabilities,
+but filters Signet memory tools by default so native memory plus hook-driven
+recall do not create two competing memory UXs.

--- a/docs/specs/dependencies.yaml
+++ b/docs/specs/dependencies.yaml
@@ -1293,3 +1293,18 @@ specs:
       - "Dreaming passes run as full sessions with transcript capture and self-improvement loop (Phase 2)"
       - "Pipeline V2 extraction is gated off when dreaming is enabled (Phase 2)"
     decision: null
+  - id: native-harness-memory-bridge
+    status: approved
+    path: docs/specs/approved/native-harness-memory-bridge.md
+    hard_depends_on:
+      - memory-md-rolling-window-lineage
+      - signet-runtime
+    soft_depends_on: []
+    blocks: []
+    informed_by:
+      - docs/research/technical/RESEARCH-NATIVE-HARNESS-MEMORY-BRIDGE.md
+    success_criteria:
+      - "Memories written by a native-memory harness are recallable through Signet from other harnesses without becoming Signet-authored memory rows"
+      - "Codex native memory artifacts are indexed with harness/source provenance"
+      - "Codex MCP registration avoids exposing duplicate Signet memory tools by default"
+    decision: null

--- a/packages/connector-codex/src/config-toml.test.ts
+++ b/packages/connector-codex/src/config-toml.test.ts
@@ -86,6 +86,7 @@ describe("CodexConnector.install — config.toml MCP registration", () => {
 		const content = readFileSync(configPath, "utf-8");
 		expect(content).toContain("[mcp_servers.signet]");
 		expect(content).toContain("command = 'signet-mcp'");
+		expect(content).toContain("disabled_tools = ['memory_search'");
 		// Must not be an array — Codex's Rust parser expects Option<String>
 		expect(content).not.toContain("command = [");
 	});
@@ -214,6 +215,7 @@ describe("buildMcpBlock — TOML quoting", () => {
 	test("produces string command, not array", () => {
 		const block = buildMcpBlock({ command: "signet-mcp", args: [] });
 		expect(block).toContain("command = 'signet-mcp'");
+		expect(block).toContain("disabled_tools = ['memory_search'");
 		expect(block).not.toContain("command = [");
 	});
 

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -241,6 +241,15 @@ export function buildMcpBlock(mcp: { command: string; args: string[] }): string 
 	if (mcp.args.length > 0) {
 		block += `args = ${tomlInlineArray(mcp.args)}\n`;
 	}
+	block += `disabled_tools = ${tomlInlineArray([
+		"memory_search",
+		"memory_store",
+		"memory_get",
+		"memory_list",
+		"memory_modify",
+		"memory_forget",
+		"memory_feedback",
+	])}\n`;
 	return block;
 }
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -48,6 +48,7 @@ import { closeInferenceProviderResolver, getInferenceProvider, initInferenceProv
 import { logger } from "./logger";
 import { type ResolvedMemoryConfig, loadMemoryConfig } from "./memory-config";
 import { registerGlobalMiddleware } from "./middleware";
+import { type NativeMemoryBridgeHandle, startNativeMemoryBridge } from "./native-memory-sources";
 import { DEFAULT_RETENTION, ensureRetentionWorker, setDreamingWorker, startPipeline, stopPipeline } from "./pipeline";
 import { type DreamingWorkerHandle, startDreamingWorker } from "./pipeline/dreaming-worker";
 import { invalidateTraversalCache } from "./pipeline/graph-traversal";
@@ -229,6 +230,7 @@ setupDashboardRoutes(app);
 // ============================================================================
 
 let watcher: ReturnType<typeof watch> | null = null;
+let nativeMemoryBridge: NativeMemoryBridgeHandle | null = null;
 
 // Track ingested files to avoid re-processing (path -> content hash)
 const ingestedMemoryFiles = new Map<string, string>();
@@ -1283,6 +1285,10 @@ async function cleanup() {
 		syncTimer = null;
 	}
 	stopMemoryImportPoller();
+	if (nativeMemoryBridge) {
+		await nativeMemoryBridge.close();
+		nativeMemoryBridge = null;
+	}
 
 	if (heartbeatTimer) {
 		clearInterval(heartbeatTimer);
@@ -1658,6 +1664,14 @@ async function main() {
 			logger.error("daemon", "Failed to import existing memory files", undefined, errDetails);
 		});
 		startMemoryImportPoller();
+
+		if (!nativeMemoryBridge) {
+			nativeMemoryBridge = startNativeMemoryBridge();
+		}
+		nativeMemoryBridge.syncExisting().catch((e) => {
+			const errDetails = e instanceof Error ? { message: e.message, stack: e.stack } : { error: String(e) };
+			logger.error("daemon", "Failed to sync native memory sources", undefined, errDetails);
+		});
 
 		const claudeProjectsDir = join(homedir(), ".claude", "projects");
 		if (existsSync(claudeProjectsDir)) {

--- a/packages/daemon/src/memory-lineage.test.ts
+++ b/packages/daemon/src/memory-lineage.test.ts
@@ -14,6 +14,7 @@ import {
 	resetProjectionPurgeState,
 	writeSummaryArtifact,
 } from "./memory-lineage";
+import { NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID } from "./native-memory-constants";
 
 const tok = new Tiktoken(cl100k_base);
 
@@ -198,9 +199,7 @@ describe("memory-lineage", () => {
 		const rows = getDbAccessor().withReadDb(
 			(db) =>
 				db
-					.prepare(
-						`SELECT COUNT(*) AS count FROM memory_artifacts WHERE session_id = ? AND source_kind = 'summary'`,
-					)
+					.prepare(`SELECT COUNT(*) AS count FROM memory_artifacts WHERE session_id = ? AND source_kind = 'summary'`)
 					.get("idem-test") as { count: number },
 		);
 		expect(rows.count).toBe(1);
@@ -323,6 +322,49 @@ describe("memory-lineage", () => {
 			);
 
 			expect(after).toEqual(before);
+		});
+
+		it("does not trust editable source_path frontmatter during canonical reindex", async () => {
+			await addSummary({ sessionId: "spoof-source", project: "/home/nicholai/signet/signetai", minutesAgo: 1 });
+			const row = getDbAccessor().withReadDb(
+				(db) =>
+					db
+						.prepare(
+							`SELECT source_path
+							 FROM memory_artifacts
+							 WHERE agent_id = ? AND session_id = ? AND source_kind = 'summary'`,
+						)
+						.get("default", "spoof-source") as { source_path: string },
+			);
+			const artifactPath = join(dir, row.source_path);
+			writeFileSync(
+				artifactPath,
+				readFileSync(artifactPath, "utf8").replace(
+					"\n---\n",
+					`\nsource_path: memory/spoofed-summary.md\nsource_node_id: ${NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID}\n---\n`,
+				),
+			);
+			getDbAccessor().withWriteTx((db) => {
+				db.prepare("DELETE FROM memory_artifacts WHERE agent_id = ?").run("default");
+			});
+
+			reindexMemoryArtifacts("default");
+
+			const rows = getDbAccessor().withReadDb(
+				(db) =>
+					db
+						.prepare(
+							`SELECT source_path, source_node_id
+							 FROM memory_artifacts
+							 WHERE agent_id = ?
+							 ORDER BY source_path ASC`,
+						)
+						.all("default") as Array<{ source_path: string; source_node_id: string | null }>,
+			);
+			expect(rows.some((candidate) => candidate.source_path === "memory/spoofed-summary.md")).toBe(false);
+			expect(
+				rows.some((candidate) => candidate.source_path === row.source_path && candidate.source_node_id === null),
+			).toBe(true);
 		});
 
 		it("new file added → picked up on next call", async () => {

--- a/packages/daemon/src/memory-lineage.ts
+++ b/packages/daemon/src/memory-lineage.ts
@@ -10,6 +10,7 @@ import { getDbAccessor } from "./db-accessor";
 import { logger } from "./logger";
 import { MEMORY_HEAD_MAX_TOKENS } from "./memory-head";
 import { buildAgentScopeClause } from "./memory-search";
+import { NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID } from "./native-memory-constants";
 import { isNoiseSession, isTempProject } from "./session-noise";
 
 function getAgentsDir(): string {
@@ -481,9 +482,13 @@ function upsertArtifactRow(
 	frontmatter: Record<string, unknown>,
 	body: string,
 	sourceMtimeMs = statSync(path).mtimeMs,
+	options: { readonly trustSourcePath?: boolean; readonly trustNativeMarker?: boolean } = {},
 ): void {
 	const agentId = typeof frontmatter.agent_id === "string" ? frontmatter.agent_id : "default";
-	const sourcePath = path.replace(`${getAgentsDir()}/`, "").replace(/\\/g, "/");
+	const sourcePath =
+		options.trustSourcePath && typeof frontmatter.source_path === "string"
+			? frontmatter.source_path.replace(/\\/g, "/")
+			: path.replace(`${getAgentsDir()}/`, "").replace(/\\/g, "/");
 	const sourceKind = typeof frontmatter.kind === "string" ? frontmatter.kind : "manifest";
 	const sessionId = typeof frontmatter.session_id === "string" ? frontmatter.session_id : sourcePath;
 	const sessionKey = typeof frontmatter.session_key === "string" ? frontmatter.session_key : null;
@@ -494,7 +499,9 @@ function upsertArtifactRow(
 	const startedAt = typeof frontmatter.started_at === "string" ? frontmatter.started_at : null;
 	const endedAt = typeof frontmatter.ended_at === "string" ? frontmatter.ended_at : null;
 	const manifestPath = typeof frontmatter.manifest_path === "string" ? frontmatter.manifest_path : null;
-	const sourceNodeId = typeof frontmatter.source_node_id === "string" ? frontmatter.source_node_id : null;
+	const rawSourceNodeId = typeof frontmatter.source_node_id === "string" ? frontmatter.source_node_id : null;
+	const sourceNodeId =
+		rawSourceNodeId === NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID && !options.trustNativeMarker ? null : rawSourceNodeId;
 	const memorySentence = typeof frontmatter.memory_sentence === "string" ? frontmatter.memory_sentence : null;
 	const quality = typeof frontmatter.memory_sentence_quality === "string" ? frontmatter.memory_sentence_quality : null;
 	const sourceSha =
@@ -551,6 +558,44 @@ function upsertArtifactRow(
 	});
 }
 
+export function indexExternalMemoryArtifact(input: {
+	readonly agentId?: string;
+	readonly sourcePath: string;
+	readonly sourceKind: string;
+	readonly harness: string;
+	readonly content: string;
+	readonly sourceMtimeMs: number;
+	readonly capturedAt?: string;
+	readonly project?: string | null;
+}): void {
+	const capturedAt =
+		input.capturedAt ??
+		(Number.isFinite(input.sourceMtimeMs) ? new Date(input.sourceMtimeMs).toISOString() : new Date().toISOString());
+	upsertArtifactRow(
+		input.sourcePath,
+		{
+			agent_id: input.agentId?.trim() || "default",
+			source_path: input.sourcePath.replace(/\\/g, "/"),
+			kind: input.sourceKind,
+			session_id: `native:${input.harness}:${input.sourcePath}`,
+			session_key: `native:${input.harness}`,
+			project: input.project ?? null,
+			harness: input.harness,
+			captured_at: capturedAt,
+			started_at: capturedAt,
+			ended_at: capturedAt,
+			updated_at: new Date().toISOString(),
+			source_node_id: NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID,
+			content_sha256: hashNormalizedBody(input.content),
+			memory_sentence: `Indexed ${input.harness} native memory from ${basename(input.sourcePath)}.`,
+			memory_sentence_quality: "fallback",
+		},
+		input.content,
+		input.sourceMtimeMs,
+		{ trustNativeMarker: true, trustSourcePath: true },
+	);
+}
+
 function canSeedColdCacheFromDbRow(currentMtimeMs: number, row: { readonly source_mtime_ms?: unknown }): boolean {
 	if (!Number.isFinite(currentMtimeMs)) return false;
 
@@ -570,14 +615,17 @@ function listCanonicalFiles(): string[] {
 		.sort();
 }
 
-function deleteArtifactRowsForPath(path: string, agentId: string | null): void {
+export function deleteArtifactRowsForPath(path: string, agentId: string | null): void {
 	const sourcePath = relativePath(path);
+	const absolutePath = path.replace(/\\/g, "/");
 	getDbAccessor().withWriteTx((db) => {
 		if (agentId) {
 			db.prepare("DELETE FROM memory_artifacts WHERE source_path = ? AND agent_id = ?").run(sourcePath, agentId);
+			db.prepare("DELETE FROM memory_artifacts WHERE source_path = ? AND agent_id = ?").run(absolutePath, agentId);
 			return;
 		}
 		db.prepare("DELETE FROM memory_artifacts WHERE source_path = ?").run(sourcePath);
+		db.prepare("DELETE FROM memory_artifacts WHERE source_path = ?").run(absolutePath);
 	});
 }
 

--- a/packages/daemon/src/memory-search.test.ts
+++ b/packages/daemon/src/memory-search.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import { type ResolvedMemoryConfig, loadMemoryConfig } from "./memory-config";
+import { indexExternalMemoryArtifact } from "./memory-lineage";
 import { buildAgentScopeClause, expandRecallKeywordQuery, hybridRecall, transcriptExcerpt } from "./memory-search";
 
 describe("hybridRecall", () => {
@@ -125,6 +127,143 @@ describe("hybridRecall", () => {
 			hasSupplementary: false,
 			noHits: true,
 		});
+	});
+
+	it("recalls indexed native harness memory artifacts without materializing memories", async () => {
+		const codexMemoryPath = join(dir, "codex", "memories", "MEMORY.md");
+		mkdirSync(join(dir, "codex", "memories"), { recursive: true });
+		writeFileSync(codexMemoryPath, "# Codex Memory\n\nNicholai prefers portable memory across Hermes and Codex.\n");
+		indexExternalMemoryArtifact({
+			agentId: "default",
+			sourcePath: codexMemoryPath,
+			sourceKind: "native_memory_registry",
+			harness: "codex",
+			content: readFileSync(codexMemoryPath, "utf-8"),
+			sourceMtimeMs: Date.now(),
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "portable memory Hermes Codex",
+				keywordQuery: "portable memory Hermes Codex",
+				limit: 5,
+				agentId: "default",
+				project: "/workspace/project",
+				readPolicy: "isolated",
+			},
+			loadMemoryConfig(dir),
+			async () => null,
+		);
+
+		expect(result.results[0]?.source).toBe("native_memory");
+		expect(result.results[0]?.source_id).toMatch(/^native:codex:native_memory_registry:[a-f0-9]{16}$/);
+		expect(result.results[0]?.source_id).not.toContain(codexMemoryPath);
+		expect(result.results[0]?.session_id).toBe(result.results[0]?.source_id);
+		expect(result.results[0]?.content).toContain("Native codex memory");
+		const materialized = getDbAccessor().withReadDb(
+			(db) => db.prepare("SELECT COUNT(*) AS count FROM memories").get() as { count: number },
+		);
+		expect(materialized.count).toBe(0);
+	});
+
+	it("does not classify native-looking artifacts without the bridge-owned provenance marker", async () => {
+		const codexMemoryPath = join(dir, "codex", "memories", "MEMORY.md");
+		mkdirSync(join(dir, "codex", "memories"), { recursive: true });
+		writeFileSync(codexMemoryPath, "# Codex Memory\n\nSpoofed native provenance marker should not surface.\n");
+		indexExternalMemoryArtifact({
+			agentId: "default",
+			sourcePath: codexMemoryPath,
+			sourceKind: "native_memory_registry",
+			harness: "codex",
+			content: readFileSync(codexMemoryPath, "utf-8"),
+			sourceMtimeMs: Date.now(),
+		});
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE memory_artifacts SET source_node_id = ?").run("spoofed-native-marker");
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "Spoofed native provenance marker",
+				keywordQuery: "Spoofed native provenance marker",
+				limit: 5,
+				agentId: "default",
+				readPolicy: "isolated",
+			},
+			loadMemoryConfig(dir),
+			async () => null,
+		);
+
+		expect(result.results.some((row) => row.source === "native_memory")).toBe(false);
+	});
+
+	it("dedupes native artifacts against their public recall source id", async () => {
+		const now = new Date().toISOString();
+		const codexMemoryPath = join(dir, "codex", "memories", "MEMORY.md");
+		const sourceId = `native:codex:native_memory_registry:${createHash("sha256").update(codexMemoryPath).digest("hex").slice(0, 16)}`;
+		mkdirSync(join(dir, "codex", "memories"), { recursive: true });
+		writeFileSync(codexMemoryPath, "# Codex Memory\n\nCodex remembered a duplicate native recall marker.\n");
+		indexExternalMemoryArtifact({
+			agentId: "default",
+			sourcePath: codexMemoryPath,
+			sourceKind: "native_memory_registry",
+			harness: "codex",
+			content: readFileSync(codexMemoryPath, "utf-8"),
+			sourceMtimeMs: Date.now(),
+		});
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, type, source_id, agent_id, created_at, updated_at, updated_by
+				) VALUES (?, ?, 'fact', ?, 'default', ?, ?, 'test')`,
+			).run("native-public-source", "Codex remembered a duplicate native recall marker.", sourceId, now, now);
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "duplicate native recall marker",
+				keywordQuery: "duplicate native recall marker",
+				limit: 2,
+				agentId: "default",
+				readPolicy: "isolated",
+			},
+			loadMemoryConfig(dir),
+			async () => null,
+		);
+
+		expect(result.results.map((row) => row.source_id).filter((id) => id === sourceId)).toHaveLength(1);
+		expect(result.results.some((row) => row.source === "native_memory" && row.source_id === sourceId)).toBe(false);
+	});
+
+	it("returns more than five native artifacts when they are the primary recall source", async () => {
+		const root = join(dir, "codex", "memories", "rollout_summaries");
+		mkdirSync(root, { recursive: true });
+		for (let i = 0; i < 6; i++) {
+			const file = join(root, `native-limit-${i}.md`);
+			writeFileSync(file, `# Codex Memory ${i}\n\nshared native bridge limit marker ${i}.\n`);
+			indexExternalMemoryArtifact({
+				agentId: "default",
+				sourcePath: file,
+				sourceKind: "native_rollout_summary",
+				harness: "codex",
+				content: readFileSync(file, "utf-8"),
+				sourceMtimeMs: Date.now() + i,
+			});
+		}
+
+		const result = await hybridRecall(
+			{
+				query: "shared native bridge limit marker",
+				keywordQuery: "shared native bridge limit marker",
+				limit: 6,
+				agentId: "default",
+				readPolicy: "isolated",
+			},
+			loadMemoryConfig(dir),
+			async () => null,
+		);
+
+		expect(result.results.filter((row) => row.source === "native_memory")).toHaveLength(6);
 	});
 
 	it("keeps score calibration stable when reranker provider is noop", async () => {

--- a/packages/daemon/src/memory-search.ts
+++ b/packages/daemon/src/memory-search.ts
@@ -12,6 +12,7 @@ import { getDbAccessor } from "./db-accessor";
 import { getLlmProvider } from "./llm";
 import { logger } from "./logger";
 import type { EmbeddingConfig, MemorySearchConfig, ResolvedMemoryConfig } from "./memory-config";
+import { NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID } from "./native-memory-constants";
 import { constructContextBlocks } from "./pipeline/context-construction";
 import { DEFAULT_DAMPENING, type ScoredRow, applyDampening } from "./pipeline/dampening";
 import { getGraphBoostIds, tokenizeGraphQuery } from "./pipeline/graph-search";
@@ -509,6 +510,32 @@ interface TranscriptRecallHit {
 	readonly rank: number;
 }
 
+interface NativeArtifactRecallHit {
+	readonly rowid: number;
+	readonly sourcePath: string;
+	readonly sourceKind: string;
+	readonly harness: string | null;
+	readonly project: string | null;
+	readonly updatedAt: string;
+	readonly content: string;
+	readonly rank: number;
+}
+
+function nativeIdSegment(value: string | null | undefined): string {
+	return (
+		value
+			?.trim()
+			.toLowerCase()
+			.replace(/[^a-z0-9_.-]+/g, "-")
+			.replace(/^-+|-+$/g, "") || "unknown"
+	);
+}
+
+function nativeArtifactPublicId(hit: NativeArtifactRecallHit): string {
+	const digest = createHash("sha256").update(hit.sourcePath).digest("hex").slice(0, 16);
+	return `native:${nativeIdSegment(hit.harness)}:${nativeIdSegment(hit.sourceKind)}:${digest}`;
+}
+
 function sessionIdFromSourceId(sourceId: string): string {
 	const index = sourceId.lastIndexOf(":");
 	return index >= 0 ? sourceId.slice(index + 1) : sourceId;
@@ -674,6 +701,74 @@ function buildTranscriptRecallHits(
 		});
 	} catch (e) {
 		logger.warn("memory", "Transcript recall fallback failed (non-fatal)", {
+			error: e instanceof Error ? e.message : String(e),
+		});
+		return [];
+	}
+}
+
+function buildNativeArtifactRecallHits(
+	params: RecallParams,
+	query: string,
+	existingSourceIds: ReadonlySet<string>,
+): NativeArtifactRecallHit[] {
+	const fts = sanitizeFtsQuery(query);
+	if (fts.length === 0) return [];
+
+	try {
+		return getDbAccessor().withReadDb((db) => {
+			const table = db
+				.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='memory_artifacts_fts'`)
+				.get();
+			if (!table) return [];
+
+			const parts = [
+				"SELECT ma.rowid, ma.source_path, ma.source_kind, ma.harness, ma.project,",
+				"COALESCE(ma.updated_at, ma.captured_at) AS updated_at, ma.content,",
+				"bm25(memory_artifacts_fts) AS rank",
+				"FROM memory_artifacts_fts",
+				"JOIN memory_artifacts ma ON ma.rowid = memory_artifacts_fts.rowid",
+				"WHERE memory_artifacts_fts MATCH ?",
+				"AND ma.agent_id = ?",
+				"AND ma.source_kind LIKE 'native_%'",
+				"AND ma.source_node_id = ?",
+				"AND ma.harness IS NOT NULL",
+			];
+			const args: unknown[] = [fts, params.agentId ?? "default", NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID];
+			if (params.project) {
+				parts.push("AND (ma.project = ? OR ma.project IS NULL)");
+				args.push(params.project);
+			}
+			parts.push("ORDER BY rank ASC, updated_at DESC LIMIT ?");
+			args.push(Math.max(2, Math.min(50, params.limit ?? 10) + existingSourceIds.size));
+
+			const rows = db.prepare(parts.join("\n")).all(...args) as Array<{
+				rowid: number;
+				source_path: string;
+				source_kind: string;
+				harness: string | null;
+				project: string | null;
+				updated_at: string;
+				content: string;
+				rank: number;
+			}>;
+
+			const maxRank = rows.reduce((max, row) => Math.max(max, Math.abs(row.rank)), 1);
+			return rows
+				.map((row) => ({
+					rowid: row.rowid,
+					sourcePath: row.source_path,
+					sourceKind: row.source_kind,
+					harness: row.harness,
+					project: row.project,
+					updatedAt: row.updated_at,
+					content: transcriptExcerpt(row.content, query, 900),
+					rank: maxRank > 0 ? Math.abs(row.rank) / maxRank : 0.2,
+				}))
+				.filter((row) => row.content.length > 0 && !existingSourceIds.has(nativeArtifactPublicId(row)));
+		});
+	} catch (e) {
+		logger.warn("memory", "Native artifact recall failed (non-fatal)", {
 			error: e instanceof Error ? e.message : String(e),
 		});
 		return [];
@@ -1496,6 +1591,42 @@ export async function hybridRecall(
 	const recallTruncate = cfg.pipelineV2.guardrails.recallTruncateChars;
 
 	if (topIds.length === 0) {
+		const nativeHits = buildNativeArtifactRecallHits(params, expandedQuery, new Set());
+		if (nativeHits.length > 0) {
+			const results = nativeHits.slice(0, limit).map((hit): RecallResult => {
+				const content = `[Native ${hit.harness ?? "harness"} memory]\n${hit.content}`;
+				const truncated = content.length > recallTruncate;
+				const sourceId = nativeArtifactPublicId(hit);
+				return {
+					id: `native-artifact:${hit.rowid}`,
+					content: truncated ? `${content.slice(0, recallTruncate)} [truncated]` : content,
+					content_length: content.length,
+					truncated,
+					score: Math.round(Math.max(0.01, Math.min(1.1, hit.rank)) * 100) / 100,
+					source: "native_memory",
+					source_id: sourceId,
+					session_id: sourceId,
+					type: hit.sourceKind,
+					tags: [hit.harness, "native-memory", hit.sourceKind].filter(Boolean).join(","),
+					pinned: false,
+					importance: 0.55,
+					who: hit.harness ?? "",
+					project: hit.project,
+					created_at: hit.updatedAt,
+					supplementary: true,
+				};
+			});
+			return {
+				results,
+				query,
+				method: "keyword",
+				meta: {
+					totalReturned: results.length,
+					hasSupplementary: true,
+					noHits: false,
+				},
+			};
+		}
 		const transcriptHits = buildTranscriptRecallHits(params, expandedQuery, new Set());
 		if (transcriptHits.length > 0) {
 			const transcriptSummaries = loadStructuredSummariesBySourceId(
@@ -1636,6 +1767,35 @@ export async function hybridRecall(
 				created_at: r.created_at,
 			};
 		});
+
+	if (results.length < limit) {
+		const existingSourceIds = new Set(results.map((row) => row.source_id).filter((id): id is string => !!id));
+		const nativeHits = buildNativeArtifactRecallHits(params, expandedQuery, existingSourceIds);
+		for (const hit of nativeHits) {
+			if (results.length >= limit) break;
+			const content = `[Native ${hit.harness ?? "harness"} memory]\n${hit.content}`;
+			const truncated = content.length > recallTruncate;
+			const sourceId = nativeArtifactPublicId(hit);
+			results.push({
+				id: `native-artifact:${hit.rowid}`,
+				content: truncated ? `${content.slice(0, recallTruncate)} [truncated]` : content,
+				content_length: content.length,
+				truncated,
+				score: Math.round(Math.max(0.01, Math.min(1, hit.rank * 0.85)) * 100) / 100,
+				source: "native_memory",
+				source_id: sourceId,
+				session_id: sourceId,
+				type: hit.sourceKind,
+				tags: [hit.harness, "native-memory", hit.sourceKind].filter(Boolean).join(","),
+				pinned: false,
+				importance: 0.55,
+				who: hit.harness ?? "",
+				project: hit.project,
+				created_at: hit.updatedAt,
+				supplementary: true,
+			});
+		}
+	}
 
 	// Generate LLM summary from the final recalled set (not pre-filter candidates).
 	// Skip when limit < 2: can't fit a summary card without evicting the only

--- a/packages/daemon/src/native-memory-constants.ts
+++ b/packages/daemon/src/native-memory-constants.ts
@@ -1,0 +1,1 @@
+export const NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID = "native-memory-bridge";

--- a/packages/daemon/src/native-memory-sources.test.ts
+++ b/packages/daemon/src/native-memory-sources.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import {
+	codexNativeMemorySource,
+	indexNativeMemoryFile,
+	removeNativeMemoryFile,
+	startNativeMemoryBridge,
+} from "./native-memory-sources";
+
+describe("native memory sources", () => {
+	let dir = "";
+	let prevSignetPath: string | undefined;
+	let prevSignetAgentId: string | undefined;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "signet-native-memory-"));
+		mkdirSync(join(dir, "memory"), { recursive: true });
+		writeFileSync(join(dir, "agent.yaml"), "name: NativeMemoryTest\n");
+		prevSignetPath = process.env.SIGNET_PATH;
+		prevSignetAgentId = process.env.SIGNET_AGENT_ID;
+		process.env.SIGNET_PATH = dir;
+		initDbAccessor(join(dir, "memory", "memories.db"));
+	});
+
+	afterEach(() => {
+		closeDbAccessor();
+		if (prevSignetPath === undefined) {
+			Reflect.deleteProperty(process.env, "SIGNET_PATH");
+		} else {
+			process.env.SIGNET_PATH = prevSignetPath;
+		}
+		if (prevSignetAgentId === undefined) {
+			Reflect.deleteProperty(process.env, "SIGNET_AGENT_ID");
+		} else {
+			process.env.SIGNET_AGENT_ID = prevSignetAgentId;
+		}
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("indexes Codex memory artifacts as external artifacts", async () => {
+		const root = join(dir, ".codex", "memories");
+		mkdirSync(join(root, "rollout_summaries"), { recursive: true });
+		const file = join(root, "rollout_summaries", "2026-04-22-test.md");
+		writeFileSync(file, "thread_id: abc\n\nCodex remembered the Hermes bridge decision.\n");
+
+		expect(await indexNativeMemoryFile(codexNativeMemorySource(root), file)).toBe(true);
+
+		const row = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT source_path, source_kind, harness, content FROM memory_artifacts").get() as {
+					source_path: string;
+					source_kind: string;
+					harness: string;
+					content: string;
+				},
+		);
+		expect(row.source_path).toBe(file);
+		expect(row.source_kind).toBe("native_rollout_summary");
+		expect(row.harness).toBe("codex");
+		expect(row.content).toContain("Hermes bridge decision");
+	});
+
+	it("uses the daemon agent id when no explicit agent id is provided", async () => {
+		process.env.SIGNET_AGENT_ID = "agent-native";
+		const root = join(dir, ".codex", "memories");
+		mkdirSync(root, { recursive: true });
+		const file = join(root, "memory_summary.md");
+		writeFileSync(file, "Codex remembered a non-default agent preference.\n");
+
+		expect(await indexNativeMemoryFile(codexNativeMemorySource(root), file)).toBe(true);
+
+		const row = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT agent_id FROM memory_artifacts").get() as {
+					agent_id: string;
+				},
+		);
+		expect(row.agent_id).toBe("agent-native");
+	});
+
+	it("clears the dedupe fingerprint when a native memory file is removed", async () => {
+		const root = join(dir, ".codex", "memories");
+		mkdirSync(root, { recursive: true });
+		const source = codexNativeMemorySource(root);
+		const file = join(root, "memory_summary.md");
+		const stamp = new Date("2026-04-22T12:00:00Z");
+		writeFileSync(file, "Codex remembered the same recreated file.\n");
+		utimesSync(file, stamp, stamp);
+
+		expect(await indexNativeMemoryFile(source, file, "agent-native")).toBe(true);
+		removeNativeMemoryFile(source, file, "agent-native");
+		writeFileSync(file, "Codex remembered the same recreated file.\n");
+		utimesSync(file, stamp, stamp);
+
+		expect(await indexNativeMemoryFile(source, file, "agent-native")).toBe(true);
+		const count = getDbAccessor().withReadDb(
+			(db) => db.prepare("SELECT COUNT(*) AS count FROM memory_artifacts").get() as { count: number },
+		).count;
+		expect(count).toBe(1);
+	});
+
+	it("does not cache a fingerprint when persistence fails", async () => {
+		const root = join(dir, ".codex", "memories");
+		mkdirSync(root, { recursive: true });
+		const source = codexNativeMemorySource(root);
+		const file = join(root, "memory_summary.md");
+		const stamp = new Date("2026-04-22T12:00:00Z");
+		writeFileSync(file, "Codex remembered a retryable persistence failure.\n");
+		utimesSync(file, stamp, stamp);
+
+		closeDbAccessor();
+		expect(await indexNativeMemoryFile(source, file, "agent-native")).toBe(false);
+
+		initDbAccessor(join(dir, "memory", "memories.db"));
+		expect(await indexNativeMemoryFile(source, file, "agent-native")).toBe(true);
+	});
+
+	it("reindexes unchanged native files when the artifact row is missing", async () => {
+		const root = join(dir, ".codex", "memories");
+		mkdirSync(root, { recursive: true });
+		const source = codexNativeMemorySource(root);
+		const file = join(root, "memory_summary.md");
+		const stamp = new Date("2026-04-22T12:00:00Z");
+		writeFileSync(file, "Codex remembered a deleted artifact row.\n");
+		utimesSync(file, stamp, stamp);
+
+		expect(await indexNativeMemoryFile(source, file, "agent-native")).toBe(true);
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("DELETE FROM memory_artifacts WHERE agent_id = ? AND source_path = ?").run("agent-native", file);
+		});
+
+		expect(await indexNativeMemoryFile(source, file, "agent-native")).toBe(true);
+		const count = getDbAccessor().withReadDb(
+			(db) => db.prepare("SELECT COUNT(*) AS count FROM memory_artifacts").get() as { count: number },
+		).count;
+		expect(count).toBe(1);
+	});
+
+	it("indexes native memories when the source root is created after bridge startup", async () => {
+		const root = join(dir, ".codex", "memories");
+		const handle = startNativeMemoryBridge([codexNativeMemorySource(root)], {
+			agentId: "agent-native",
+			pollIntervalMs: 25,
+		});
+		try {
+			mkdirSync(root, { recursive: true });
+			const file = join(root, "memory_summary.md");
+			writeFileSync(file, "Codex remembered a late-created native memory root.\n");
+
+			let indexed = false;
+			for (let i = 0; i < 20; i++) {
+				await Bun.sleep(25);
+				const count = getDbAccessor().withReadDb(
+					(db) => db.prepare("SELECT COUNT(*) AS count FROM memory_artifacts").get() as { count: number },
+				).count;
+				if (count > 0) {
+					indexed = true;
+					break;
+				}
+			}
+			expect(indexed).toBe(true);
+		} finally {
+			await handle.close();
+		}
+	});
+
+	it("skips files outside the declared native memory patterns", async () => {
+		const root = join(dir, ".codex", "memories");
+		mkdirSync(root, { recursive: true });
+		const file = join(root, "notes.md");
+		writeFileSync(file, "not a Codex native memory surface");
+
+		expect(await indexNativeMemoryFile(codexNativeMemorySource(root), file)).toBe(false);
+	});
+});

--- a/packages/daemon/src/native-memory-sources.ts
+++ b/packages/daemon/src/native-memory-sources.ts
@@ -1,0 +1,241 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import { watch } from "chokidar";
+import { resolveDaemonAgentId } from "./agent-id";
+import { getDbAccessor } from "./db-accessor";
+import { logger } from "./logger";
+import { deleteArtifactRowsForPath, indexExternalMemoryArtifact } from "./memory-lineage";
+
+export interface NativeMemorySource {
+	readonly harness: string;
+	readonly displayName: string;
+	readonly root: string;
+	readonly files: readonly NativeMemoryFilePattern[];
+}
+
+export interface NativeMemoryFilePattern {
+	readonly glob: string;
+	readonly kind: string;
+	readonly include?: (path: string) => boolean;
+}
+
+export interface NativeMemoryBridgeHandle {
+	readonly syncExisting: () => Promise<number>;
+	readonly close: () => Promise<void>;
+}
+
+export interface NativeMemoryBridgeOptions {
+	readonly agentId?: string;
+	readonly pollIntervalMs?: number;
+}
+
+const indexed = new Map<string, string>();
+
+function codexMemoryRoot(): string {
+	return join(homedir(), ".codex", "memories");
+}
+
+export function codexNativeMemorySource(root = codexMemoryRoot()): NativeMemorySource {
+	return {
+		harness: "codex",
+		displayName: "Codex",
+		root,
+		files: [
+			{ glob: "memory_summary.md", kind: "native_memory_summary" },
+			{ glob: "MEMORY.md", kind: "native_memory_registry" },
+			{ glob: "raw_memories.md", kind: "native_raw_memories" },
+			{
+				glob: "rollout_summaries/*.md",
+				kind: "native_rollout_summary",
+				include: (path) => path.replace(/\\/g, "/").includes("/rollout_summaries/"),
+			},
+		],
+	};
+}
+
+function walkMarkdownFiles(dir: string): string[] {
+	if (!existsSync(dir)) return [];
+	const out: string[] = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const path = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			out.push(...walkMarkdownFiles(path));
+		} else if (entry.isFile() && entry.name.endsWith(".md")) {
+			out.push(path);
+		}
+	}
+	return out.sort();
+}
+
+function matchesPattern(source: NativeMemorySource, filePath: string): NativeMemoryFilePattern | null {
+	const normalized = filePath.replace(/\\/g, "/");
+	const root = source.root.replace(/\\/g, "/").replace(/\/$/, "");
+	const rel = normalized.startsWith(`${root}/`) ? normalized.slice(root.length + 1) : normalized;
+	for (const pattern of source.files) {
+		if (pattern.include && !pattern.include(normalized)) continue;
+		if (pattern.glob === rel) return pattern;
+		if (pattern.glob.endsWith("/*.md")) {
+			const prefix = pattern.glob.slice(0, -"*.md".length);
+			if (rel.startsWith(prefix) && basename(rel).endsWith(".md")) return pattern;
+		}
+	}
+	return null;
+}
+
+function resolveBridgeAgentId(agentId?: string): string {
+	const trimmed = agentId?.trim();
+	return trimmed ? trimmed : resolveDaemonAgentId();
+}
+
+function fingerprintKey(source: NativeMemorySource, filePath: string, agentId: string): string {
+	return `${agentId}:${source.harness}:${filePath}`;
+}
+
+function nativeArtifactRowExists(filePath: string, agentId: string): boolean {
+	const sourcePath = filePath.replace(/\\/g, "/");
+	try {
+		return getDbAccessor().withReadDb((db) => {
+			const row = db
+				.prepare("SELECT 1 FROM memory_artifacts WHERE agent_id = ? AND source_path = ? LIMIT 1")
+				.get(agentId, sourcePath);
+			return !!row;
+		});
+	} catch {
+		return false;
+	}
+}
+
+export async function indexNativeMemoryFile(
+	source: NativeMemorySource,
+	filePath: string,
+	agentId = resolveDaemonAgentId(),
+): Promise<boolean> {
+	const pattern = matchesPattern(source, filePath);
+	if (!pattern) return false;
+
+	let content = "";
+	let mtimeMs = 0;
+	try {
+		const stat = statSync(filePath);
+		if (!stat.isFile()) return false;
+		mtimeMs = stat.mtimeMs;
+		content = readFileSync(filePath, "utf-8");
+	} catch (err) {
+		logger.warn("watcher", "Failed reading native memory artifact", {
+			harness: source.harness,
+			path: filePath,
+			error: err instanceof Error ? err.message : String(err),
+		});
+		return false;
+	}
+	if (!content.trim()) return false;
+
+	const key = fingerprintKey(source, filePath, agentId);
+	const fingerprint = `${mtimeMs}:${createHash("sha256").update(content).digest("hex")}`;
+	if (indexed.get(key) === fingerprint) {
+		if (nativeArtifactRowExists(filePath, agentId)) return false;
+		indexed.delete(key);
+	}
+
+	try {
+		indexExternalMemoryArtifact({
+			agentId,
+			sourcePath: filePath,
+			sourceKind: pattern.kind,
+			harness: source.harness,
+			content,
+			sourceMtimeMs: mtimeMs,
+		});
+		indexed.set(key, fingerprint);
+		logger.info("watcher", "Indexed native memory artifact", {
+			harness: source.harness,
+			kind: pattern.kind,
+			path: filePath,
+		});
+		return true;
+	} catch (err) {
+		logger.warn("watcher", "Failed indexing native memory artifact", {
+			harness: source.harness,
+			path: filePath,
+			error: err instanceof Error ? err.message : String(err),
+		});
+		return false;
+	}
+}
+
+export function removeNativeMemoryFile(
+	source: NativeMemorySource,
+	filePath: string,
+	agentId = resolveDaemonAgentId(),
+): void {
+	indexed.delete(fingerprintKey(source, filePath, agentId));
+	deleteArtifactRowsForPath(filePath, agentId);
+}
+
+export function startNativeMemoryBridge(
+	sources: readonly NativeMemorySource[] = [codexNativeMemorySource()],
+	options: NativeMemoryBridgeOptions = {},
+): NativeMemoryBridgeHandle {
+	const agentId = resolveBridgeAgentId(options.agentId);
+	const watchers = sources.map((source) => {
+		const patterns = source.files.map((file) => join(source.root, file.glob));
+		const watcher = watch(patterns, {
+			ignoreInitial: true,
+			persistent: true,
+		});
+		watcher.on("add", (path) => void indexNativeMemoryFile(source, path, agentId));
+		watcher.on("change", (path) => void indexNativeMemoryFile(source, path, agentId));
+		watcher.on("unlink", (path) => {
+			try {
+				removeNativeMemoryFile(source, path, agentId);
+			} catch (err) {
+				logger.warn("watcher", "Failed removing native memory artifact index row", {
+					harness: source.harness,
+					path,
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
+		});
+		return { source, watcher };
+	});
+
+	const syncExisting = async (): Promise<number> => {
+		let count = 0;
+		for (const source of sources) {
+			if (!existsSync(source.root)) continue;
+			for (const file of walkMarkdownFiles(source.root)) {
+				if (await indexNativeMemoryFile(source, file, agentId)) count++;
+			}
+		}
+		return count;
+	};
+	let polling = false;
+	const pollIntervalMs = options.pollIntervalMs ?? 10_000;
+	const pollTimer =
+		pollIntervalMs > 0
+			? setInterval(() => {
+					if (polling) return;
+					polling = true;
+					syncExisting()
+						.catch((err) => {
+							logger.warn("watcher", "Failed polling native memory sources", {
+								error: err instanceof Error ? err.message : String(err),
+							});
+						})
+						.finally(() => {
+							polling = false;
+						});
+				}, pollIntervalMs)
+			: null;
+	pollTimer?.unref?.();
+
+	return {
+		syncExisting,
+		async close(): Promise<void> {
+			if (pollTimer) clearInterval(pollTimer);
+			await Promise.all(watchers.map(({ watcher }) => watcher.close()));
+		},
+	};
+}


### PR DESCRIPTION
## Summary

This adds the first version of a native harness memory bridge. Codex native memory remains in Codex, while Signet indexes the relevant files as external memory artifacts with harness provenance so they can be recalled through Signet across connectors.

The implementation adds a generic native memory source layer in the daemon, Codex file discovery under `~/.codex/memories`, artifact indexing without materializing duplicate `memories` rows, recall hydration for native artifacts, daemon startup sync/watch wiring, and Codex MCP duplicate-tool filtering.

## Why

Users should be able to install Signet after using Codex and have their Codex memories show up through Signet without fighting Codex's native memory system. The same bridge shape should later support Hermes, OpenClaw, OpenCode, and other harnesses with their own native memory stores.

## Validation

```bash
bun test packages/daemon/src/native-memory-sources.test.ts packages/daemon/src/memory-search.test.ts packages/connector-codex/src/config-toml.test.ts
bun scripts/spec-deps-check.ts
```

Also checked staged diff whitespace with:

```bash
git diff --cached --check
```

## Notes

This intentionally indexes native harness memory as `memory_artifacts` instead of copying it into Signet-authored `memories`, so native memory stays native and provenance is preserved.
