### PR TITLE
fix(codex): emit structured hook JSON

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -978,7 +978,7 @@ Environment Variables
 | `SIGNET_SQLITE_PATH` | macOS explicit SQLite dylib override used by the daemon before opening the database | unset |
 | `SIGNET_SESSION_START_TIMEOUT` | Session-start daemon wait budget in ms for Signet-managed clients. Generated Claude Code hook config writes this value directly. Generated Codex hook config rounds up to seconds and adds 5 seconds of harness grace | `15000` |
 | `SIGNET_FETCH_TIMEOUT` | Legacy fallback for session-start timeout in ms when `SIGNET_SESSION_START_TIMEOUT` is unset | `15000` |
-| `SIGNET_PROMPT_SUBMIT_TIMEOUT` | Prompt-submit daemon wait budget in ms; OpenCode uses this value directly, generated Claude Code hook config writes this value + 2000 ms grace | `5000` |
+| `SIGNET_PROMPT_SUBMIT_TIMEOUT` | Prompt-submit daemon wait budget in ms; OpenCode uses this value directly, generated Claude Code hook config writes this value + 2000 ms grace, and generated Codex hook config rounds up to seconds and adds 2 seconds of harness grace | `5000` |
 | `SIGNET_BYPASS` | Skip all hook processing (exit immediately) | unset |
 
 ---

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1112,7 +1112,7 @@ editing the config file is impractical.
 | `SIGNET_SQLITE_PATH` | — | macOS explicit SQLite dylib override used before Bun opens the database |
 | `SIGNET_SESSION_START_TIMEOUT` | `15000` | Session-start daemon wait budget in ms for Signet-managed clients. Generated Claude Code hook config writes this value directly. Generated Codex hook config rounds up to seconds and adds 5 seconds of harness grace |
 | `SIGNET_FETCH_TIMEOUT` | `15000` | Legacy fallback for session-start timeout in ms when `SIGNET_SESSION_START_TIMEOUT` is unset |
-| `SIGNET_PROMPT_SUBMIT_TIMEOUT` | `5000` | Prompt-submit daemon wait budget in ms; OpenCode uses this value directly, generated Claude Code hook config writes this value + 2000 ms grace |
+| `SIGNET_PROMPT_SUBMIT_TIMEOUT` | `5000` | Prompt-submit daemon wait budget in ms; OpenCode uses this value directly, generated Claude Code hook config writes this value + 2000 ms grace, and generated Codex hook config rounds up to seconds and adds 2 seconds of harness grace |
 | `SIGNET_TRUSTED_PROVIDER_ENDPOINT_HOSTS` | — | Comma-separated host allowlist for Anthropic endpoint overrides used during credentialed startup preflight (supports entries like `proxy.example.com` and `*.example.com`) |
 | `OPENAI_API_KEY` | — | OpenAI key when embedding provider is `openai` |
 

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -240,16 +240,18 @@ registers as an MCP server so Codex can call `signet_remember` and
 ### How it works
 
 1. Codex reads `~/.codex/hooks.json` at startup and registers three hooks.
-2. On session start, Codex fires `SessionStart` → calls `signet hook session-start -H codex` → Signet returns identity + memories as `additional_context` injected into the model's context window.
-3. On every user prompt, Codex fires `UserPromptSubmit` → calls `signet hook user-prompt-submit -H codex` → Signet returns per-prompt recalled memories as `additional_context`. This is blocking — Codex waits for the hook before sending to the model.
+2. On session start, Codex fires `SessionStart` → calls `signet hook session-start -H codex --codex-json` → Signet returns identity + memories as `hookSpecificOutput.additionalContext` with `suppressOutput: true`, injected into the model's context window without printing the hook payload to the user transcript.
+3. On every user prompt, Codex fires `UserPromptSubmit` → calls `signet hook user-prompt-submit -H codex --codex-json` → Signet returns per-prompt recalled memories as `hookSpecificOutput.additionalContext` with `suppressOutput: true` so the context is model-visible but not printed into the user transcript. This is blocking — Codex waits for the hook before sending to the model.
 4. On session end, Codex fires `Stop` → calls `signet hook session-end -H codex` → Signet extracts memories from the transcript.
 5. The MCP server exposes `memory_store`, `memory_search`, and other memory tools that Codex can invoke directly during sessions.
 
 Codex `SessionStart` hook timeout defaults to 20 seconds: the Signet CLI
 waits up to `SIGNET_SESSION_START_TIMEOUT` (`15000` ms by default) for
 the daemon, and the generated Codex hook config adds 5 seconds of harness
-grace. Rerun `signet setup` or `signet connect codex` after upgrading to
-rewrite an existing `~/.codex/hooks.json`.
+grace. Codex `UserPromptSubmit` defaults to 7 seconds: `SIGNET_PROMPT_SUBMIT_TIMEOUT`
+(`5000` ms by default) plus 2 seconds of harness grace. Rerun `signet setup`
+or `signet connect codex` after upgrading to rewrite an existing
+`~/.codex/hooks.json`.
 
 Codex matches the session-start, prompt-submit, and session-end path, but
 it does **not** currently expose the same compaction lifecycle fidelity as
@@ -259,8 +261,8 @@ Claude Code or OpenCode.
 
 | Hook | Supported |
 |------|-----------|
-| session-start | yes — identity + memories via `additional_context` |
-| user-prompt-submit | yes — per-prompt recall via `additional_context` |
+| session-start | yes — identity + memories via `hookSpecificOutput.additionalContext` |
+| user-prompt-submit | yes — per-prompt recall via `hookSpecificOutput.additionalContext` |
 | session-end | yes — transcript extraction via `Stop` hook |
 
 ### MCP tools

--- a/packages/cli/src/commands/hook.test.ts
+++ b/packages/cli/src/commands/hook.test.ts
@@ -1,12 +1,14 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { Command } from "commander";
 import {
+	buildCodexHookOutput,
 	buildCompactionCompleteBody,
 	buildSessionEndBody,
 	buildSessionStartFallback,
 	buildUserPromptSubmitBody,
 	pickSessionKey,
 	registerHookCommands,
+	resolvePromptSubmitTimeout,
 	resolveSessionStartTimeout,
 	shouldReadCompactionInput,
 } from "./hook";
@@ -38,6 +40,22 @@ describe("pickSessionKey", () => {
 	});
 });
 
+describe("resolvePromptSubmitTimeout", () => {
+	test("uses prompt-submit timeout env when valid", () => {
+		const prev = process.env.SIGNET_PROMPT_SUBMIT_TIMEOUT;
+		process.env.SIGNET_PROMPT_SUBMIT_TIMEOUT = "9000";
+		expect(resolvePromptSubmitTimeout()).toBe(9000);
+		process.env.SIGNET_PROMPT_SUBMIT_TIMEOUT = prev;
+	});
+
+	test("falls back to the default when env is invalid or too small", () => {
+		const prev = process.env.SIGNET_PROMPT_SUBMIT_TIMEOUT;
+		process.env.SIGNET_PROMPT_SUBMIT_TIMEOUT = "200";
+		expect(resolvePromptSubmitTimeout()).toBe(5000);
+		process.env.SIGNET_PROMPT_SUBMIT_TIMEOUT = prev;
+	});
+});
+
 describe("resolveSessionStartTimeout", () => {
 	test("uses the dedicated session-start timeout env when valid", () => {
 		const prev = process.env.SIGNET_SESSION_START_TIMEOUT;
@@ -51,6 +69,29 @@ describe("resolveSessionStartTimeout", () => {
 		process.env.SIGNET_SESSION_START_TIMEOUT = "200";
 		expect(resolveSessionStartTimeout()).toBe(15000);
 		process.env.SIGNET_SESSION_START_TIMEOUT = prev;
+	});
+});
+
+describe("buildCodexHookOutput", () => {
+	test("formats Codex additional context using hookSpecificOutput", () => {
+		expect(buildCodexHookOutput("SessionStart", " recalled context ")).toEqual({
+			continue: true,
+			suppressOutput: true,
+			hookSpecificOutput: {
+				hookEventName: "SessionStart",
+				additionalContext: "recalled context",
+			},
+		});
+	});
+
+	test("emits a valid no-op Codex hook output when context is empty", () => {
+		expect(buildCodexHookOutput("UserPromptSubmit", " ")).toEqual({
+			continue: true,
+			suppressOutput: true,
+			hookSpecificOutput: {
+				hookEventName: "UserPromptSubmit",
+			},
+		});
 	});
 });
 
@@ -159,7 +200,7 @@ describe("buildUserPromptSubmitBody", () => {
 	});
 
 	test("hook command uses daemon result transport for user-prompt-submit", async () => {
-		const seen: Array<{ path: string; body: string; runtimePath: string | null }> = [];
+		const seen: Array<{ path: string; body: string; runtimePath: string | null; timeout?: number }> = [];
 		const lines: string[] = [];
 		console.log = (line?: unknown) => {
 			lines.push(String(line ?? ""));
@@ -173,6 +214,7 @@ describe("buildUserPromptSubmitBody", () => {
 					path,
 					body: typeof opts?.body === "string" ? opts.body : "",
 					runtimePath: new Headers(opts?.headers).get("x-signet-runtime-path"),
+					timeout: opts?.timeout,
 				});
 				return {
 					ok: true,
@@ -191,7 +233,36 @@ describe("buildUserPromptSubmitBody", () => {
 		expect(seen[0]?.body).toContain('"harness":"claude-code"');
 		expect(seen[0]?.body).toContain('"runtimePath":"legacy"');
 		expect(seen[0]?.runtimePath).toBe("legacy");
+		expect(seen[0]?.timeout).toBe(5000);
 		expect(lines).toContain("recalled context");
+	});
+
+	test("hook command can emit Codex user-prompt-submit JSON", async () => {
+		const lines: string[] = [];
+		console.log = (line?: unknown) => {
+			lines.push(String(line ?? ""));
+		};
+
+		const program = new Command();
+		registerHookCommands(program, {
+			AGENTS_DIR: "/tmp/agents",
+			fetchDaemonResult: async () => ({
+				ok: true,
+				data: { inject: "recalled context" },
+			}),
+			readStaticIdentity: () => null,
+		});
+
+		await program.parseAsync(["node", "test", "hook", "user-prompt-submit", "-H", "codex", "--codex-json"]);
+
+		expect(JSON.parse(lines[0] ?? "{}")).toEqual({
+			continue: true,
+			suppressOutput: true,
+			hookSpecificOutput: {
+				hookEventName: "UserPromptSubmit",
+				additionalContext: "recalled context",
+			},
+		});
 	});
 });
 

--- a/packages/cli/src/commands/hook.ts
+++ b/packages/cli/src/commands/hook.ts
@@ -1,4 +1,8 @@
-import { STATIC_IDENTITY_SESSION_START_TIMEOUT_STATUS, resolveSessionStartTimeoutMs } from "@signet/core";
+import {
+	STATIC_IDENTITY_SESSION_START_TIMEOUT_STATUS,
+	resolvePromptSubmitTimeoutMs,
+	resolveSessionStartTimeoutMs,
+} from "@signet/core";
 import chalk from "chalk";
 import type { Command } from "commander";
 import type { DaemonFetchResult } from "../lib/daemon.js";
@@ -13,6 +17,7 @@ interface HookDeps {
 }
 
 const SESSION_START_TIMEOUT_MS = resolveSessionStartTimeout();
+const PROMPT_SUBMIT_TIMEOUT_MS = resolvePromptSubmitTimeout();
 const LEGACY_RUNTIME_PATH = "legacy" as const;
 
 function legacyHookHeaders(headers?: HeadersInit): Headers {
@@ -30,6 +35,38 @@ function readTimeoutEnv(name: string): string {
 export function resolveSessionStartTimeout(): number {
 	const raw = readTimeoutEnv("SIGNET_SESSION_START_TIMEOUT") || readTimeoutEnv("SIGNET_FETCH_TIMEOUT");
 	return resolveSessionStartTimeoutMs(raw);
+}
+
+export function resolvePromptSubmitTimeout(): number {
+	return resolvePromptSubmitTimeoutMs(readTimeoutEnv("SIGNET_PROMPT_SUBMIT_TIMEOUT"));
+}
+
+type CodexHookEventName = "SessionStart" | "UserPromptSubmit";
+
+export function buildCodexHookOutput(
+	hookEventName: CodexHookEventName,
+	additionalContext?: string,
+): {
+	readonly continue: true;
+	readonly suppressOutput: true;
+	readonly hookSpecificOutput: {
+		readonly hookEventName: CodexHookEventName;
+		readonly additionalContext?: string;
+	};
+} {
+	const trimmed = additionalContext?.trim();
+	return {
+		continue: true,
+		suppressOutput: true,
+		hookSpecificOutput: {
+			hookEventName,
+			...(trimmed ? { additionalContext: trimmed } : {}),
+		},
+	};
+}
+
+function printCodexHookOutput(hookEventName: CodexHookEventName, additionalContext?: string): void {
+	console.log(JSON.stringify(buildCodexHookOutput(hookEventName, additionalContext)));
 }
 
 export function buildSessionStartFallback(
@@ -95,6 +132,7 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 		.option("--agent-id <id>", "Agent ID")
 		.option("--context <context>", "Additional context")
 		.option("--json", "Output as JSON")
+		.option("--codex-json", "Output Codex hook JSON")
 		.action(async (options) => {
 			const input = await readJson();
 			const sessionKey = pickSessionKey(input);
@@ -133,7 +171,9 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 					if (res.reason === "offline") {
 						process.stderr.write("[signet] daemon offline — using static identity\n");
 					}
-					if (options.json) {
+					if (options.codexJson) {
+						printCodexHookOutput("SessionStart", fallback);
+					} else if (options.json) {
 						console.log(JSON.stringify({ inject: fallback, identity: { name: "signet" }, memories: [] }));
 					} else {
 						console.log(fallback);
@@ -146,6 +186,7 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 				if (res.reason === "offline") {
 					process.stderr.write("[signet] daemon not running, no identity files found\n");
 				}
+				if (options.codexJson) printCodexHookOutput("SessionStart");
 				process.exit(0);
 			}
 			const data = res.data;
@@ -153,7 +194,9 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 				console.error(chalk.red(`Error: ${data.error}`));
 				process.exit(1);
 			}
-			if (options.json) {
+			if (options.codexJson) {
+				printCodexHookOutput("SessionStart", data.inject);
+			} else if (options.json) {
 				console.log(JSON.stringify(data, null, 2));
 			} else if (data.inject) {
 				console.log(data.inject);
@@ -165,6 +208,8 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 		.description("Get relevant memories for a user prompt")
 		.requiredOption("-H, --harness <harness>", "Harness name")
 		.option("--project <project>", "Project path")
+		.option("--json", "Output as JSON")
+		.option("--codex-json", "Output Codex hook JSON")
 		.action(async (options) => {
 			const input = await readJson();
 			const stdinProject = pickString(input?.cwd);
@@ -176,12 +221,20 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify(buildUserPromptSubmitBody(input, options.harness, options.project || stdinProject)),
+					timeout: PROMPT_SUBMIT_TIMEOUT_MS,
 				},
 			);
 			if (!data) {
+				if (options.codexJson) printCodexHookOutput("UserPromptSubmit");
 				process.exit(0);
 			}
-			if (data.inject) console.log(data.inject);
+			if (options.codexJson) {
+				printCodexHookOutput("UserPromptSubmit", data.inject);
+			} else if (options.json) {
+				console.log(JSON.stringify(data, null, 2));
+			} else if (data.inject) {
+				console.log(data.inject);
+			}
 		});
 
 	hookCmd

--- a/packages/connector-codex/src/config-toml.test.ts
+++ b/packages/connector-codex/src/config-toml.test.ts
@@ -26,6 +26,7 @@ let configPath: string;
 let hooksPath: string;
 let previousSessionStartTimeout: string | undefined;
 let previousFetchTimeout: string | undefined;
+let previousPromptSubmitTimeout: string | undefined;
 
 function restoreEnv(name: string, value: string | undefined): void {
 	if (value === undefined) {
@@ -38,8 +39,10 @@ function restoreEnv(name: string, value: string | undefined): void {
 beforeEach(() => {
 	previousSessionStartTimeout = process.env.SIGNET_SESSION_START_TIMEOUT;
 	previousFetchTimeout = process.env.SIGNET_FETCH_TIMEOUT;
+	previousPromptSubmitTimeout = process.env.SIGNET_PROMPT_SUBMIT_TIMEOUT;
 	Reflect.deleteProperty(process.env, "SIGNET_SESSION_START_TIMEOUT");
 	Reflect.deleteProperty(process.env, "SIGNET_FETCH_TIMEOUT");
+	Reflect.deleteProperty(process.env, "SIGNET_PROMPT_SUBMIT_TIMEOUT");
 	tempHome = join(tmpdir(), `signet-codex-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	codexDir = join(tempHome, ".codex");
 	configPath = join(codexDir, "config.toml");
@@ -50,6 +53,7 @@ beforeEach(() => {
 afterEach(() => {
 	restoreEnv("SIGNET_SESSION_START_TIMEOUT", previousSessionStartTimeout);
 	restoreEnv("SIGNET_FETCH_TIMEOUT", previousFetchTimeout);
+	restoreEnv("SIGNET_PROMPT_SUBMIT_TIMEOUT", previousPromptSubmitTimeout);
 	rmSync(tempHome, { recursive: true, force: true });
 });
 
@@ -285,6 +289,7 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		expect(typeof handler.command).toBe("string");
 		expect(handler.command as string).toContain("hook session-start");
 		expect(handler.command as string).toContain("-H codex");
+		expect(handler.command as string).toContain("--codex-json");
 		expect(handler.timeout).toBe(20);
 	});
 
@@ -299,7 +304,7 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		const promptHandler = (
 			(hooks.UserPromptSubmit[0] as Record<string, unknown>).hooks as Record<string, unknown>[]
 		)[0];
-		expect(promptHandler.timeout).toBe(5);
+		expect(promptHandler.timeout).toBe(7);
 
 		const stopHandler = ((hooks.Stop[0] as Record<string, unknown>).hooks as Record<string, unknown>[])[0];
 		expect(stopHandler.timeout).toBe(30);
@@ -314,6 +319,19 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		const startHandler = ((hooks.SessionStart[0] as Record<string, unknown>).hooks as Record<string, unknown>[])[0];
 
 		expect(startHandler.timeout).toBe(23);
+	});
+
+	test("sets Codex prompt-submit timeout to Signet timeout plus grace", async () => {
+		process.env.SIGNET_PROMPT_SUBMIT_TIMEOUT = "9000";
+
+		await connector().install(tempHome);
+		const json = readHooksJson();
+		const hooks = json.hooks as Record<string, Record<string, unknown>[]>;
+		const promptHandler = (
+			(hooks.UserPromptSubmit[0] as Record<string, unknown>).hooks as Record<string, unknown>[]
+		)[0];
+
+		expect(promptHandler.timeout).toBe(11);
 	});
 
 	test("refreshes existing Signet-owned hooks to current timeouts", async () => {
@@ -435,7 +453,7 @@ describe("CodexConnector.install — hooks.json schema", () => {
 		);
 
 		expect(commands).toContain("python ./scripts/custom-reviewer.py --note ' hook session-start '");
-		expect(commands.some((command) => command === "signet hook session-start -H codex")).toBe(true);
+		expect(commands.some((command) => command === "signet hook session-start -H codex --codex-json")).toBe(true);
 	});
 
 	test("does not use array-form command (regression: issue #481)", async () => {

--- a/packages/connector-codex/src/index.ts
+++ b/packages/connector-codex/src/index.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { BaseConnector, type InstallResult, type UninstallResult, atomicWriteJson } from "@signet/connector-base";
-import { expandHome, resolveSessionStartTimeoutMs } from "@signet/core";
+import { expandHome, resolvePromptSubmitTimeoutMs, resolveSessionStartTimeoutMs } from "@signet/core";
 
 // ---------------------------------------------------------------------------
 // Signet command resolution
@@ -48,7 +48,7 @@ function resolveSignetMcp(): { command: string; args: string[] } {
 
 const HOOK_EVENT_KEYS = ["SessionStart", "UserPromptSubmit", "Stop"] as const;
 const CODEX_SESSION_START_GRACE_SECONDS = 5;
-const PROMPT_SUBMIT_TIMEOUT_SECONDS = 5;
+const CODEX_PROMPT_SUBMIT_GRACE_SECONDS = 2;
 const SESSION_END_TIMEOUT_SECONDS = 30;
 
 interface MatcherGroup {
@@ -79,17 +79,30 @@ function resolveCodexSessionStartTimeoutSeconds(): number {
 	return Math.ceil(resolveSessionStartTimeoutMs(raw) / 1000) + CODEX_SESSION_START_GRACE_SECONDS;
 }
 
+function resolveCodexPromptSubmitTimeoutSeconds(): number {
+	return (
+		Math.ceil(resolvePromptSubmitTimeoutMs(readTimeoutEnv("SIGNET_PROMPT_SUBMIT_TIMEOUT")) / 1000) +
+		CODEX_PROMPT_SUBMIT_GRACE_SECONDS
+	);
+}
+
 function buildHooksFile(signetArgs: string[]): HooksFile {
-	const cmd = (subcommand: string, secs: number): MatcherGroup => ({
+	const cmd = (subcommand: string, secs: number, codexJson = true): MatcherGroup => ({
 		_signet: true,
-		hooks: [{ type: "command", command: [...signetArgs, "hook", subcommand, "-H", "codex"].join(" "), timeout: secs }],
+		hooks: [
+			{
+				type: "command",
+				command: [...signetArgs, "hook", subcommand, "-H", "codex", ...(codexJson ? ["--codex-json"] : [])].join(" "),
+				timeout: secs,
+			},
+		],
 	});
 	return {
 		_signet: true,
 		hooks: {
 			SessionStart: [cmd("session-start", resolveCodexSessionStartTimeoutSeconds())],
-			UserPromptSubmit: [cmd("user-prompt-submit", PROMPT_SUBMIT_TIMEOUT_SECONDS)],
-			Stop: [cmd("session-end", SESSION_END_TIMEOUT_SECONDS)],
+			UserPromptSubmit: [cmd("user-prompt-submit", resolveCodexPromptSubmitTimeoutSeconds())],
+			Stop: [cmd("session-end", SESSION_END_TIMEOUT_SECONDS, false)],
 		},
 	};
 }


### PR DESCRIPTION
## Summary

Fixes Codex lifecycle hook output so Signet emits Codex's structured hook JSON contract instead of plain text for `SessionStart` and `UserPromptSubmit` context injection.

Root cause: the generated Codex hooks called `signet hook ... -H codex` without a Codex-specific output mode, so the CLI printed raw injected context. Current Codex parses hook stdout as JSON and reads context from `hookSpecificOutput.additionalContext`, causing session-start to fail as invalid JSON. Once JSON output was added, Codex also displayed that hook context unless the universal hook output set `suppressOutput: true`.

## Changes

- Add `--codex-json` output mode for `signet hook session-start` and `signet hook user-prompt-submit`, including `suppressOutput: true` so injected context is model-visible without being printed to the user transcript.
- Generate Codex hooks that call `--codex-json` and preserve plain output for other harnesses.
- Add prompt-submit timeout handling to the CLI hook path and write Codex prompt-submit hooks with 2 seconds of harness grace.
- Update Codex harness docs and timeout docs.
- Add regression tests for Codex hook JSON shape and generated hook timeout/config behavior.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [x] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

N/A, no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — N/A, routine connector/CLI bug fix within existing hook contracts.
- [x] Agent scoping verified on all new/changed data queries — N/A, no data queries changed.
- [x] Input/config validation and bounds checks added — reused existing timeout resolver and added prompt-submit timeout coverage.
- [x] Error handling and fallback paths tested (no silent swallow) — Codex no-op JSON fallback and prompt-submit transport paths covered.
- [x] Security checks applied to admin/mutation endpoints — N/A, no endpoints changed.
- [x] Docs updated for API/spec/status changes — Codex harness and timeout docs updated.
- [x] Regression tests added for each bug fix.
- [x] Lint/typecheck/tests pass locally — targeted lint/tests pass; connector-codex typecheck/build passes. Workspace typecheck has pre-existing unrelated package failures noted below.

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [ ] Daemon Rust parity reviewed or explicitly N/A
- [ ] Rollback / compatibility note included in PR description

N/A, no migrations.

## Testing

- [x] `bun test packages/connector-codex/src/config-toml.test.ts packages/cli/src/commands/hook.test.ts`
- [x] `bunx biome check packages/cli/src/commands/hook.ts packages/cli/src/commands/hook.test.ts packages/connector-codex/src/index.ts packages/connector-codex/src/config-toml.test.ts`
- [x] `bun run build` in `packages/connector-codex`
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

After this lands, users need to rerun `signet connect codex` or `signet setup` so existing `~/.codex/hooks.json` entries are rewritten with `--codex-json` and the updated prompt-submit timeout.

Local validation note: `packages/cli` has no package-level `typecheck` script. `bun run build:cli` is currently blocked in this checkout by unresolved workspace connector imports (`@signet/connector-forge`, `@signet/connector-gemini`, `@signet/connector-pi`, etc.). Full workspace typecheck also reports unrelated existing failures in desktop/electron and several connector package resolution/bundle declaration paths. `@signet/connector-codex` build and type declarations pass.
