### PR TITLE
fix(daemon): bound prompt-submit embedding latency

### DIFF
--- a/packages/daemon/src/embedding-fetch.test.ts
+++ b/packages/daemon/src/embedding-fetch.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, mock } from "bun:test";
 import { fetchEmbedding, requiresOpenAiApiKey, setNativeFallbackProvider } from "./embedding-fetch";
 
 const originalFetch = globalThis.fetch;
+const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
 
 describe("requiresOpenAiApiKey", () => {
 	it("requires a key for official OpenAI endpoints", () => {
@@ -21,7 +22,11 @@ describe("fetchEmbedding", () => {
 	afterEach(() => {
 		globalThis.fetch = originalFetch;
 		setNativeFallbackProvider(null);
-		delete process.env.OPENAI_API_KEY;
+		if (originalOpenAiApiKey === undefined) {
+			Reflect.deleteProperty(process.env, "OPENAI_API_KEY");
+		} else {
+			process.env.OPENAI_API_KEY = originalOpenAiApiKey;
+		}
 	});
 
 	it("allows keyless requests for custom OpenAI-compatible endpoints", async () => {
@@ -42,6 +47,29 @@ describe("fetchEmbedding", () => {
 		expect(capturedHeaders).toEqual({
 			"Content-Type": "application/json",
 		});
+	});
+
+	it("passes caller abort signals through to provider fetches", async () => {
+		const controller = new AbortController();
+		let capturedSignal: AbortSignal | null | undefined;
+		globalThis.fetch = mock((_url: string | URL | Request, init?: RequestInit) => {
+			capturedSignal = init?.signal;
+			return Promise.resolve(Response.json({ data: [{ embedding: [0.1, 0.2, 0.3] }] }));
+		}) as unknown as typeof fetch;
+
+		const result = await fetchEmbedding(
+			"hello",
+			{
+				provider: "openai",
+				model: "text-embedding-3-small",
+				dimensions: 3,
+				base_url: "http://localhost:1234/v1",
+			},
+			{ signal: controller.signal },
+		);
+
+		expect(result).toEqual([0.1, 0.2, 0.3]);
+		expect(capturedSignal).toBe(controller.signal);
 	});
 
 	it("routes to ollama when nativeFallbackProvider is 'ollama'", async () => {

--- a/packages/daemon/src/embedding-fetch.test.ts
+++ b/packages/daemon/src/embedding-fetch.test.ts
@@ -49,11 +49,15 @@ describe("fetchEmbedding", () => {
 		});
 	});
 
-	it("passes caller abort signals through to provider fetches", async () => {
+	it("composes caller abort signals with provider timeouts", async () => {
 		const controller = new AbortController();
 		let capturedSignal: AbortSignal | null | undefined;
 		globalThis.fetch = mock((_url: string | URL | Request, init?: RequestInit) => {
 			capturedSignal = init?.signal;
+			expect(capturedSignal).not.toBe(controller.signal);
+			expect(capturedSignal?.aborted).toBe(false);
+			controller.abort();
+			expect(capturedSignal?.aborted).toBe(true);
 			return Promise.resolve(Response.json({ data: [{ embedding: [0.1, 0.2, 0.3] }] }));
 		}) as unknown as typeof fetch;
 
@@ -69,7 +73,7 @@ describe("fetchEmbedding", () => {
 		);
 
 		expect(result).toEqual([0.1, 0.2, 0.3]);
-		expect(capturedSignal).toBe(controller.signal);
+		expect(capturedSignal?.aborted).toBe(true);
 	});
 
 	it("routes to ollama when nativeFallbackProvider is 'ollama'", async () => {

--- a/packages/daemon/src/embedding-fetch.ts
+++ b/packages/daemon/src/embedding-fetch.ts
@@ -52,18 +52,62 @@ type EmbeddingFetchOptions = {
 	readonly signal?: AbortSignal;
 };
 
+type EmbeddingFetchSignal = {
+	readonly signal: AbortSignal;
+	readonly cleanup: () => void;
+};
+
+function createEmbeddingFetchSignal(opts: EmbeddingFetchOptions, timeoutMs: number): EmbeddingFetchSignal {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), timeoutMs);
+	let abortCaller: (() => void) | null = null;
+	if (opts.signal) {
+		if (opts.signal.aborted) {
+			controller.abort();
+		} else {
+			abortCaller = () => controller.abort();
+			opts.signal.addEventListener("abort", abortCaller, { once: true });
+		}
+	}
+	return {
+		signal: controller.signal,
+		cleanup: () => {
+			clearTimeout(timer);
+			if (abortCaller) opts.signal?.removeEventListener("abort", abortCaller);
+		},
+	};
+}
+
+async function fetchWithEmbeddingTimeout(
+	input: Parameters<typeof fetch>[0],
+	init: RequestInit,
+	opts: EmbeddingFetchOptions,
+	timeoutMs: number,
+): Promise<Response> {
+	const state = createEmbeddingFetchSignal(opts, timeoutMs);
+	try {
+		return await fetch(input, { ...init, signal: state.signal });
+	} finally {
+		state.cleanup();
+	}
+}
+
 async function fetchOllamaEmbedding(
 	text: string,
 	baseUrl: string,
 	model: string,
 	opts: EmbeddingFetchOptions = {},
 ): Promise<number[] | null> {
-	const res = await fetch(`${baseUrl.replace(/\/$/, "")}/api/embeddings`, {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ model, prompt: text }),
-		signal: opts.signal ?? AbortSignal.timeout(30000),
-	});
+	const res = await fetchWithEmbeddingTimeout(
+		`${baseUrl.replace(/\/$/, "")}/api/embeddings`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ model, prompt: text }),
+		},
+		opts,
+		30000,
+	);
 	if (!res.ok) {
 		logger.warn("embedding", "Ollama embedding request failed", {
 			status: res.status,
@@ -119,12 +163,16 @@ export async function fetchEmbedding(
 			}
 			if (nativeFallbackProvider === "llama-cpp") {
 				const fallbackModel = nativeFallbackModel ?? "nomic-embed-text";
-				const llamaCppRes = await fetch(`${DEFAULT_LLAMACPP_BASE_URL.replace(/\/$/, "")}/v1/embeddings`, {
-					method: "POST",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ input: text, model: fallbackModel }),
-					signal: opts.signal ?? AbortSignal.timeout(5000),
-				});
+				const llamaCppRes = await fetchWithEmbeddingTimeout(
+					`${DEFAULT_LLAMACPP_BASE_URL.replace(/\/$/, "")}/v1/embeddings`,
+					{
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ input: text, model: fallbackModel }),
+					},
+					opts,
+					5000,
+				);
 				if (llamaCppRes.ok) {
 					const data = (await llamaCppRes.json()) as { data?: Array<{ embedding: number[] }> };
 					if (data.data?.[0]?.embedding) return data.data[0].embedding;
@@ -149,12 +197,16 @@ export async function fetchEmbedding(
 					if (!discoveredModel) {
 						logger.warn("embedding", "llama.cpp server reachable but no supported embedding model loaded");
 					} else {
-						const llamaCppRes = await fetch(`${DEFAULT_LLAMACPP_BASE_URL.replace(/\/$/, "")}/v1/embeddings`, {
-							method: "POST",
-							headers: { "Content-Type": "application/json" },
-							body: JSON.stringify({ input: text, model: discoveredModel }),
-							signal: opts.signal ?? AbortSignal.timeout(5000),
-						});
+						const llamaCppRes = await fetchWithEmbeddingTimeout(
+							`${DEFAULT_LLAMACPP_BASE_URL.replace(/\/$/, "")}/v1/embeddings`,
+							{
+								method: "POST",
+								headers: { "Content-Type": "application/json" },
+								body: JSON.stringify({ input: text, model: discoveredModel }),
+							},
+							opts,
+							5000,
+						);
 						if (llamaCppRes.ok) {
 							nativeFallbackProvider = "llama-cpp";
 							nativeFallbackModel = discoveredModel;
@@ -194,12 +246,16 @@ export async function fetchEmbedding(
 
 		if (cfg.provider === "llama-cpp") {
 			const baseUrl = cfg.base_url.trim() || DEFAULT_LLAMACPP_BASE_URL;
-			const res = await fetch(`${baseUrl.replace(/\/$/, "")}/v1/embeddings`, {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ model: cfg.model, input: text }),
-				signal: opts.signal ?? AbortSignal.timeout(30000),
-			});
+			const res = await fetchWithEmbeddingTimeout(
+				`${baseUrl.replace(/\/$/, "")}/v1/embeddings`,
+				{
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ model: cfg.model, input: text }),
+				},
+				opts,
+				30000,
+			);
 			if (!res.ok) {
 				logger.warn("embedding", "llama.cpp embedding request failed", {
 					status: res.status,
@@ -217,15 +273,19 @@ export async function fetchEmbedding(
 			logger.warn("embedding", "No API key configured for OpenAI embeddings, skipping request to api.openai.com");
 			return null;
 		}
-		const res = await fetch(`${baseUrl.replace(/\/$/, "")}/embeddings`, {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+		const res = await fetchWithEmbeddingTimeout(
+			`${baseUrl.replace(/\/$/, "")}/embeddings`,
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+				},
+				body: JSON.stringify({ model: cfg.model, input: text }),
 			},
-			body: JSON.stringify({ model: cfg.model, input: text }),
-			signal: opts.signal ?? AbortSignal.timeout(30000),
-		});
+			opts,
+			30000,
+		);
 		if (!res.ok) {
 			logger.warn("embedding", "Embedding API request failed", {
 				status: res.status,

--- a/packages/daemon/src/embedding-fetch.ts
+++ b/packages/daemon/src/embedding-fetch.ts
@@ -48,12 +48,21 @@ export function setNativeFallbackProvider(
 	nativeFallbackModel = model ?? null;
 }
 
-async function fetchOllamaEmbedding(text: string, baseUrl: string, model: string): Promise<number[] | null> {
+type EmbeddingFetchOptions = {
+	readonly signal?: AbortSignal;
+};
+
+async function fetchOllamaEmbedding(
+	text: string,
+	baseUrl: string,
+	model: string,
+	opts: EmbeddingFetchOptions = {},
+): Promise<number[] | null> {
 	const res = await fetch(`${baseUrl.replace(/\/$/, "")}/api/embeddings`, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({ model, prompt: text }),
-		signal: AbortSignal.timeout(30000),
+		signal: opts.signal ?? AbortSignal.timeout(30000),
 	});
 	if (!res.ok) {
 		logger.warn("embedding", "Ollama embedding request failed", {
@@ -97,12 +106,16 @@ export async function resolveEmbeddingApiKey(rawApiKey: string | undefined): Pro
 	return configured || process.env.OPENAI_API_KEY || "";
 }
 
-export async function fetchEmbedding(text: string, cfg: EmbeddingConfig): Promise<number[] | null> {
+export async function fetchEmbedding(
+	text: string,
+	cfg: EmbeddingConfig,
+	opts: EmbeddingFetchOptions = {},
+): Promise<number[] | null> {
 	if (cfg.provider === "none") return null;
 	try {
 		if (cfg.provider === "native") {
 			if (nativeFallbackProvider === "ollama") {
-				return await fetchOllamaEmbedding(text, resolveOllamaUrl(), "nomic-embed-text");
+				return await fetchOllamaEmbedding(text, resolveOllamaUrl(), "nomic-embed-text", opts);
 			}
 			if (nativeFallbackProvider === "llama-cpp") {
 				const fallbackModel = nativeFallbackModel ?? "nomic-embed-text";
@@ -110,7 +123,7 @@ export async function fetchEmbedding(text: string, cfg: EmbeddingConfig): Promis
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({ input: text, model: fallbackModel }),
-					signal: AbortSignal.timeout(5000),
+					signal: opts.signal ?? AbortSignal.timeout(5000),
 				});
 				if (llamaCppRes.ok) {
 					const data = (await llamaCppRes.json()) as { data?: Array<{ embedding: number[] }> };
@@ -140,7 +153,7 @@ export async function fetchEmbedding(text: string, cfg: EmbeddingConfig): Promis
 							method: "POST",
 							headers: { "Content-Type": "application/json" },
 							body: JSON.stringify({ input: text, model: discoveredModel }),
-							signal: AbortSignal.timeout(5000),
+							signal: opts.signal ?? AbortSignal.timeout(5000),
 						});
 						if (llamaCppRes.ok) {
 							nativeFallbackProvider = "llama-cpp";
@@ -159,7 +172,7 @@ export async function fetchEmbedding(text: string, cfg: EmbeddingConfig): Promis
 					logger.warn("embedding", "llama.cpp fallback not reachable");
 				}
 				try {
-					const result = await fetchOllamaEmbedding(text, resolveOllamaUrl(), "nomic-embed-text");
+					const result = await fetchOllamaEmbedding(text, resolveOllamaUrl(), "nomic-embed-text", opts);
 					if (result !== null) {
 						nativeFallbackProvider = "ollama";
 						logger.info(
@@ -176,7 +189,7 @@ export async function fetchEmbedding(text: string, cfg: EmbeddingConfig): Promis
 			}
 		}
 		if (cfg.provider === "ollama") {
-			return await fetchOllamaEmbedding(text, cfg.base_url, cfg.model);
+			return await fetchOllamaEmbedding(text, cfg.base_url, cfg.model, opts);
 		}
 
 		if (cfg.provider === "llama-cpp") {
@@ -185,7 +198,7 @@ export async function fetchEmbedding(text: string, cfg: EmbeddingConfig): Promis
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ model: cfg.model, input: text }),
-				signal: AbortSignal.timeout(30000),
+				signal: opts.signal ?? AbortSignal.timeout(30000),
 			});
 			if (!res.ok) {
 				logger.warn("embedding", "llama.cpp embedding request failed", {
@@ -211,7 +224,7 @@ export async function fetchEmbedding(text: string, cfg: EmbeddingConfig): Promis
 				...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
 			},
 			body: JSON.stringify({ model: cfg.model, input: text }),
-			signal: AbortSignal.timeout(30000),
+			signal: opts.signal ?? AbortSignal.timeout(30000),
 		});
 		if (!res.ok) {
 			logger.warn("embedding", "Embedding API request failed", {

--- a/packages/daemon/src/hooks.prompt-submit.test.ts
+++ b/packages/daemon/src/hooks.prompt-submit.test.ts
@@ -332,6 +332,66 @@ describe("handleUserPromptSubmit observability", () => {
 		expect(result.inject).toContain("prompt submit timeout trace uses fast vector context");
 	});
 
+	it("preserves vector prompt-submit recall for concurrent fast embeddings", async () => {
+		const firstEmbedding = makePendingEmbedding();
+		const secondEmbedding = makePendingEmbedding();
+		fetchEmbeddingMock
+			.mockImplementationOnce(async () => firstEmbedding.promise)
+			.mockImplementationOnce(async () => secondEmbedding.promise);
+		hybridRecallMock.mockImplementation(async (_params, _cfg, embed) => {
+			const vector = await embed("prompt submit concurrent vector trace", {
+				provider: "ollama",
+				model: "nomic-embed-text",
+				dimensions: 768,
+				base_url: "http://localhost:11434",
+			});
+			return {
+				results: vector
+					? [
+							{
+								id: `mem-concurrent-${vector[0]}`,
+								score: 0.95,
+								content: `prompt submit concurrent vector recall ${vector[0]}`,
+								created_at: "2026-03-26T20:10:00.000Z",
+							},
+						]
+					: [],
+			};
+		});
+
+		const first = handleUserPromptSubmit(
+			{
+				harness: "vscode-custom-agent",
+				userMessage: "prompt submit concurrent vector trace",
+				sessionKey: "session-concurrent-fast-embedding-one",
+			},
+			makeDeps(),
+		);
+		const second = handleUserPromptSubmit(
+			{
+				harness: "vscode-custom-agent",
+				userMessage: "prompt submit concurrent vector trace",
+				sessionKey: "session-concurrent-fast-embedding-two",
+			},
+			makeDeps(),
+		);
+
+		firstEmbedding.resolve([0.1, 0.2, 0.3]);
+		secondEmbedding.resolve([0.4, 0.5, 0.6]);
+		const [firstResult, secondResult] = await Promise.all([first, second]);
+
+		expect(fetchEmbeddingMock).toHaveBeenCalledTimes(2);
+		expect(firstResult.memoryCount).toBe(1);
+		expect(firstResult.inject).toContain("prompt submit concurrent vector recall 0.1");
+		expect(secondResult.memoryCount).toBe(1);
+		expect(secondResult.inject).toContain("prompt submit concurrent vector recall 0.4");
+		expect(warnMock).not.toHaveBeenCalledWith(
+			"hooks",
+			"User prompt submit embedding already in flight, skipping vector recall",
+			expect.anything(),
+		);
+	});
+
 	it("bypasses prompt-submit embeddings when they exceed the hook budget", async () => {
 		const pending = makePendingEmbedding();
 		let signal: AbortSignal | undefined;

--- a/packages/daemon/src/hooks.prompt-submit.test.ts
+++ b/packages/daemon/src/hooks.prompt-submit.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { handleUserPromptSubmit } from "./hooks";
 import { SIGNET_SECRETS_PLUGIN_ID, getDefaultPluginHost, resetDefaultPluginHostForTests } from "./plugins/index";
 
-type PromptDeps = NonNullable<Parameters<typeof handleUserPromptSubmit>[1]>;
+type PromptDeps = Required<NonNullable<Parameters<typeof handleUserPromptSubmit>[1]>>;
 
 const originalSignetPath = process.env.SIGNET_PATH;
 const agentsDir = mkdtempSync(join(tmpdir(), "signet-hooks-prompt-submit-"));
@@ -21,7 +21,12 @@ const warnMock = mock((..._args: unknown[]) => {});
 const errorMock = mock((..._args: unknown[]) => {});
 const emptyHybridResults: Array<{ id: string; score: number; content: string; created_at: string; pinned?: boolean }> =
 	[];
-const hybridRecallMock = mock(async () => ({ results: emptyHybridResults }));
+const hybridRecallMock = mock(async (..._args: Parameters<PromptDeps["hybridRecall"]>) => ({
+	results: emptyHybridResults,
+}));
+const fetchEmbeddingMock = mock(
+	async (..._args: Parameters<PromptDeps["fetchEmbedding"]>): Promise<number[] | null> => null,
+);
 const emptyTemporalHits: Array<{
 	id: string;
 	latestAt: string;
@@ -42,6 +47,17 @@ function ensureMemoryDbExists(): void {
 	if (!existsSync(memoryDbPath)) {
 		writeFileSync(memoryDbPath, "");
 	}
+}
+
+function makePendingEmbedding(): {
+	readonly promise: Promise<number[] | null>;
+	readonly resolve: (value: number[] | null) => void;
+} {
+	let resolveEmbedding: (value: number[] | null) => void = () => {};
+	const promise = new Promise<number[] | null>((resolve) => {
+		resolveEmbedding = resolve;
+	});
+	return { promise, resolve: resolveEmbedding };
 }
 
 function makeDeps(): PromptDeps {
@@ -79,7 +95,7 @@ function makeDeps(): PromptDeps {
 			policyGroup: null,
 		}),
 		hybridRecall: hybridRecallMock,
-		fetchEmbedding: async () => null,
+		fetchEmbedding: fetchEmbeddingMock,
 		searchTemporalFallback: searchTemporalFallbackMock,
 		searchTranscriptFallback: searchTranscriptFallbackMock,
 		upsertSessionTranscript() {},
@@ -109,8 +125,12 @@ describe("handleUserPromptSubmit observability", () => {
 		warnMock.mockClear();
 		errorMock.mockClear();
 		hybridRecallMock.mockClear();
+		hybridRecallMock.mockImplementation(async () => ({ results: emptyHybridResults }));
+		fetchEmbeddingMock.mockClear();
 		searchTemporalFallbackMock.mockClear();
+		searchTemporalFallbackMock.mockImplementation(() => emptyTemporalHits);
 		searchTranscriptFallbackMock.mockClear();
+		searchTranscriptFallbackMock.mockImplementation(() => emptyTranscriptHits);
 		ensureMemoryDbExists();
 		resetDefaultPluginHostForTests();
 		getDefaultPluginHost().setEnabled(SIGNET_SECRETS_PLUGIN_ID, true);
@@ -273,6 +293,191 @@ describe("handleUserPromptSubmit observability", () => {
 		expect(result.inject).toContain("Use the memories below as starting context before acting");
 		expect(result.inject).toContain("run 1-3 targeted recalls with /recall or memory_search");
 		expect(result.inject).not.toContain("[signet:recall");
+	});
+
+	it("uses prompt-submit embeddings when they return within the hook budget", async () => {
+		fetchEmbeddingMock.mockResolvedValueOnce([0.1, 0.2, 0.3]);
+		hybridRecallMock.mockImplementationOnce(async (_params, _cfg, embed) => {
+			const vector = await embed("prompt submit timeout trace", {
+				provider: "ollama",
+				model: "nomic-embed-text",
+				dimensions: 768,
+				base_url: "http://localhost:11434",
+			});
+			return {
+				results: vector
+					? [
+							{
+								id: "mem-vector",
+								score: 0.95,
+								content: "prompt submit timeout trace uses fast vector context",
+								created_at: "2026-03-26T20:10:00.000Z",
+							},
+						]
+					: [],
+			};
+		});
+
+		const result = await handleUserPromptSubmit(
+			{
+				harness: "vscode-custom-agent",
+				userMessage: "prompt submit timeout trace",
+				sessionKey: "session-fast-embedding",
+			},
+			makeDeps(),
+		);
+
+		expect(fetchEmbeddingMock).toHaveBeenCalledTimes(1);
+		expect(result.memoryCount).toBe(1);
+		expect(result.inject).toContain("prompt submit timeout trace uses fast vector context");
+	});
+
+	it("bypasses prompt-submit embeddings when they exceed the hook budget", async () => {
+		const pending = makePendingEmbedding();
+		let signal: AbortSignal | undefined;
+		fetchEmbeddingMock.mockImplementationOnce(async (_text, _cfg, opts) => {
+			signal = opts?.signal;
+			return pending.promise;
+		});
+		hybridRecallMock.mockImplementationOnce(async (_params, _cfg, embed) => {
+			const vector = await embed("prompt submit timeout trace", {
+				provider: "ollama",
+				model: "nomic-embed-text",
+				dimensions: 768,
+				base_url: "http://localhost:11434",
+			});
+			return {
+				results: vector
+					? [
+							{
+								id: "mem-vector",
+								score: 0.95,
+								content: "prompt submit timeout trace should not wait forever",
+								created_at: "2026-03-26T20:10:00.000Z",
+							},
+						]
+					: [],
+			};
+		});
+
+		const start = Date.now();
+		const result = await handleUserPromptSubmit(
+			{
+				harness: "vscode-custom-agent",
+				userMessage: "prompt submit timeout trace",
+				sessionKey: "session-slow-embedding",
+			},
+			makeDeps(),
+		);
+
+		expect(Date.now() - start).toBeLessThan(1500);
+		expect(fetchEmbeddingMock).toHaveBeenCalledTimes(1);
+		expect(result.memoryCount).toBe(0);
+		expect(result.inject).toContain("No strong automatic memory match was injected");
+		expect(warnMock).toHaveBeenCalledWith(
+			"hooks",
+			"User prompt submit embedding timed out",
+			expect.objectContaining({ timeoutMs: 1000 }),
+		);
+		expect(signal?.aborted).toBe(true);
+		pending.resolve(null);
+		await Promise.resolve();
+	});
+
+	it("preserves non-vector prompt-submit recall when embeddings exceed the hook budget", async () => {
+		const pending = makePendingEmbedding();
+		fetchEmbeddingMock.mockImplementationOnce(async () => pending.promise);
+		hybridRecallMock.mockImplementationOnce(async (_params, _cfg, embed) => {
+			const vector = await embed("prompt submit timeout lexical fallback", {
+				provider: "ollama",
+				model: "nomic-embed-text",
+				dimensions: 768,
+				base_url: "http://localhost:11434",
+			});
+			return {
+				results: vector
+					? []
+					: [
+							{
+								id: "mem-keyword",
+								score: 0.91,
+								content: "prompt submit timeout lexical fallback still injects keyword recall",
+								created_at: "2026-03-26T20:10:00.000Z",
+							},
+						],
+			};
+		});
+
+		const result = await handleUserPromptSubmit(
+			{
+				harness: "vscode-custom-agent",
+				userMessage: "prompt submit timeout lexical fallback",
+				sessionKey: "session-slow-embedding-keyword-fallback",
+			},
+			makeDeps(),
+		);
+
+		expect(fetchEmbeddingMock).toHaveBeenCalledTimes(1);
+		expect(result.memoryCount).toBe(1);
+		expect(result.inject).toContain("prompt submit timeout lexical fallback still injects keyword recall");
+		pending.resolve(null);
+		await Promise.resolve();
+	});
+
+	it("aborts timed-out prompt-submit embeddings and recovers vector recall on the next request", async () => {
+		const pending = makePendingEmbedding();
+		let signal: AbortSignal | undefined;
+		fetchEmbeddingMock.mockImplementationOnce(async (_text, _cfg, opts) => {
+			signal = opts?.signal;
+			return pending.promise;
+		});
+		fetchEmbeddingMock.mockResolvedValueOnce([0.4, 0.5, 0.6]);
+		hybridRecallMock.mockImplementation(async (_params, _cfg, embed) => {
+			const vector = await embed("prompt submit timeout trace", {
+				provider: "ollama",
+				model: "nomic-embed-text",
+				dimensions: 768,
+				base_url: "http://localhost:11434",
+			});
+			return {
+				results: vector
+					? [
+							{
+								id: "mem-recovered-vector",
+								score: 0.95,
+								content: "prompt submit vector recall recovers after timed-out embedding abort",
+								created_at: "2026-03-26T20:10:00.000Z",
+							},
+						]
+					: [],
+			};
+		});
+
+		const first = await handleUserPromptSubmit(
+			{
+				harness: "vscode-custom-agent",
+				userMessage: "prompt submit timeout trace",
+				sessionKey: "session-first-slow-embedding",
+			},
+			makeDeps(),
+		);
+
+		const second = await handleUserPromptSubmit(
+			{
+				harness: "vscode-custom-agent",
+				userMessage: "prompt submit timeout trace",
+				sessionKey: "session-second-slow-embedding",
+			},
+			makeDeps(),
+		);
+
+		expect(signal?.aborted).toBe(true);
+		expect(fetchEmbeddingMock).toHaveBeenCalledTimes(2);
+		expect(first.memoryCount).toBe(0);
+		expect(second.memoryCount).toBe(1);
+		expect(second.inject).toContain("prompt submit vector recall recovers after timed-out embedding abort");
+		pending.resolve(null);
+		await Promise.resolve();
 	});
 
 	it("rescues a later relevant memory when earlier compact candidates are irrelevant", async () => {

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -2466,6 +2466,47 @@ type UserPromptSubmitDeps = {
 	readonly trackFtsHits: typeof trackFtsHits;
 };
 
+const PROMPT_SUBMIT_EMBEDDING_TIMEOUT_MS = 1000;
+let promptSubmitEmbeddingInFlight: Promise<number[] | null> | null = null;
+
+async function fetchPromptSubmitEmbedding(
+	deps: Pick<UserPromptSubmitDeps, "fetchEmbedding" | "logger">,
+	text: string,
+	cfg: Parameters<typeof fetchEmbedding>[1],
+): Promise<number[] | null> {
+	if (promptSubmitEmbeddingInFlight) {
+		deps.logger.warn("hooks", "User prompt submit embedding already in flight, skipping vector recall", {
+			timeoutMs: PROMPT_SUBMIT_EMBEDDING_TIMEOUT_MS,
+		});
+		return null;
+	}
+
+	const controller = new AbortController();
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	const request = deps.fetchEmbedding(text, cfg, { signal: controller.signal }).finally(() => {
+		if (promptSubmitEmbeddingInFlight === request) {
+			promptSubmitEmbeddingInFlight = null;
+		}
+	});
+	promptSubmitEmbeddingInFlight = request;
+	try {
+		return await Promise.race([
+			request,
+			new Promise<null>((resolve) => {
+				timer = setTimeout(() => {
+					controller.abort();
+					if (promptSubmitEmbeddingInFlight === request) {
+						promptSubmitEmbeddingInFlight = null;
+					}
+					resolve(null);
+				}, PROMPT_SUBMIT_EMBEDDING_TIMEOUT_MS);
+			}),
+		]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+}
+
 const DEFAULT_USER_PROMPT_SUBMIT_DEPS: UserPromptSubmitDeps = {
 	logger,
 	loadMemoryConfig,
@@ -2655,6 +2696,8 @@ export async function handleUserPromptSubmit(
 		const injectBudget = submitCfg.maxInjectChars ?? cfg.pipelineV2.guardrails.contextBudgetChars;
 		const minScore = resolveUserPromptMinScore(submitCfg.minScore);
 		const queryTerms = vectorQuery.slice(0, 80);
+		const recallStart = Date.now();
+		let embeddingTimedOut = false;
 		const recall = await deps.hybridRecall(
 			{
 				query: vectorQuery,
@@ -2667,8 +2710,34 @@ export async function handleUserPromptSubmit(
 				project: req.project,
 			},
 			cfg,
-			deps.fetchEmbedding,
+			async (text, embeddingCfg) => {
+				const startEmbedding = Date.now();
+				const embedding = await fetchPromptSubmitEmbedding(deps, text, embeddingCfg);
+				const embeddingDuration = Date.now() - startEmbedding;
+				if (!embedding && embeddingDuration >= PROMPT_SUBMIT_EMBEDDING_TIMEOUT_MS) {
+					embeddingTimedOut = true;
+					deps.logger.warn("hooks", "User prompt submit embedding timed out", {
+						harness: req.harness,
+						project: req.project,
+						sessionKey: req.sessionKey,
+						durationMs: embeddingDuration,
+						timeoutMs: PROMPT_SUBMIT_EMBEDDING_TIMEOUT_MS,
+					});
+				}
+				return embedding;
+			},
 		);
+		const recallDuration = Date.now() - recallStart;
+		if (recallDuration > 1000) {
+			deps.logger.warn("hooks", "User prompt submit recall was slow", {
+				harness: req.harness,
+				project: req.project,
+				sessionKey: req.sessionKey,
+				durationMs: recallDuration,
+				resultCount: recall.results.length,
+				embeddingTimedOut,
+			});
+		}
 
 		const topRaw = recall.results[0]?.score;
 		const topScore = typeof topRaw === "number" ? clampScore01(topRaw) : undefined;

--- a/packages/daemon/src/hooks.ts
+++ b/packages/daemon/src/hooks.ts
@@ -2467,37 +2467,21 @@ type UserPromptSubmitDeps = {
 };
 
 const PROMPT_SUBMIT_EMBEDDING_TIMEOUT_MS = 1000;
-let promptSubmitEmbeddingInFlight: Promise<number[] | null> | null = null;
 
 async function fetchPromptSubmitEmbedding(
 	deps: Pick<UserPromptSubmitDeps, "fetchEmbedding" | "logger">,
 	text: string,
 	cfg: Parameters<typeof fetchEmbedding>[1],
 ): Promise<number[] | null> {
-	if (promptSubmitEmbeddingInFlight) {
-		deps.logger.warn("hooks", "User prompt submit embedding already in flight, skipping vector recall", {
-			timeoutMs: PROMPT_SUBMIT_EMBEDDING_TIMEOUT_MS,
-		});
-		return null;
-	}
-
 	const controller = new AbortController();
 	let timer: ReturnType<typeof setTimeout> | null = null;
-	const request = deps.fetchEmbedding(text, cfg, { signal: controller.signal }).finally(() => {
-		if (promptSubmitEmbeddingInFlight === request) {
-			promptSubmitEmbeddingInFlight = null;
-		}
-	});
-	promptSubmitEmbeddingInFlight = request;
+	const request = deps.fetchEmbedding(text, cfg, { signal: controller.signal });
 	try {
 		return await Promise.race([
 			request,
 			new Promise<null>((resolve) => {
 				timer = setTimeout(() => {
 					controller.abort();
-					if (promptSubmitEmbeddingInFlight === request) {
-						promptSubmitEmbeddingInFlight = null;
-					}
 					resolve(null);
 				}, PROMPT_SUBMIT_EMBEDDING_TIMEOUT_MS);
 			}),


### PR DESCRIPTION
## Summary
- Bound UserPromptSubmit embedding lookup to 1000ms so the blocking hook can fail open before harness timeouts.
- Preserve vector-backed prompt recall when embeddings return quickly, while falling back to non-vector recall when they stall.
- Propagate abort signals into embedding provider fetches so timed-out prompt-submit HTTP embedding calls are cancelled instead of leaving the in-flight latch stuck.
- Add regression coverage for fast embedding injection, slow embedding bypass behavior, non-vector fallback injection, and vector recall recovery after a timed-out embedding abort.

## Validation
- [x] bun test packages/daemon/src/hooks.prompt-submit.test.ts packages/daemon/src/embedding-fetch.test.ts (24 pass)
- [x] bunx biome check packages/daemon/src/hooks.ts packages/daemon/src/hooks.prompt-submit.test.ts packages/daemon/src/embedding-fetch.ts packages/daemon/src/embedding-fetch.test.ts
- [x] git diff --check
- [ ] bun scripts/spec-deps-check.ts — blocked by existing spec dependency issue: `informed_by path does not exist for engram-informed-predictor-track: references/Engram`
- [ ] bun run --cwd packages/daemon build:types — blocked by existing package setup/type issues, including core migration rootDir errors, runtime provider name typing, GraphIQ MCP typing, and readonly test config errors.

## PR checklist
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Notes
- This is a narrow hook reliability bug fix. It does not change API, schema, admin/mutation endpoints, or spec-governed behavior, so docs/spec changes are not required.
- Full workspace typecheck/spec validation remain blocked by unrelated existing issues listed above; targeted tests and lint for the touched files pass.
