### PR TITLE
[codex] fix Hermes default install discovery

### DIFF
--- a/packages/cli/src/features/setup-migrate.ts
+++ b/packages/cli/src/features/setup-migrate.ts
@@ -39,6 +39,22 @@ import {
 } from "./setup-shared.js";
 import type { SetupDeps } from "./setup-types.js";
 
+export function detectedHarnessesForExistingSetup(
+	detection: SetupDetection,
+	configuredHarnessList: readonly string[],
+): string[] {
+	const detected: string[] = [];
+	if (detection.harnesses.claudeCode) detected.push("claude-code");
+	if (detection.harnesses.openclaw) detected.push("openclaw");
+	if (detection.harnesses.opencode) detected.push("opencode");
+	if (detection.harnesses.codex) detected.push("codex");
+	if (detection.harnesses.hermesAgent) detected.push("hermes-agent");
+	if (detection.harnesses.gemini) detected.push("gemini");
+	if (detection.harnesses.ohMyPi || configuredHarnessList.includes("oh-my-pi")) detected.push("oh-my-pi");
+	if (detection.harnesses.pi || configuredHarnessList.includes("pi")) detected.push("pi");
+	return detected;
+}
+
 export async function runExistingSetupWizard(
 	basePath: string,
 	detection: SetupDetection,
@@ -121,16 +137,8 @@ export async function runExistingSetupWizard(
 			}
 		}
 
-		const detectedHarnesses: string[] = [];
-		if (detection.harnesses.claudeCode) detectedHarnesses.push("claude-code");
-		if (detection.harnesses.openclaw) detectedHarnesses.push("openclaw");
-		if (detection.harnesses.opencode) detectedHarnesses.push("opencode");
-		if (detection.harnesses.codex) detectedHarnesses.push("codex");
-		if (detection.harnesses.hermesAgent) detectedHarnesses.push("hermes-agent");
-		if (detection.harnesses.gemini) detectedHarnesses.push("gemini");
 		const configuredHarnessList = readHarnesses(existingConfig.harnesses);
-		if (detection.harnesses.ohMyPi || configuredHarnessList.includes("oh-my-pi")) detectedHarnesses.push("oh-my-pi");
-		if (detection.harnesses.pi || configuredHarnessList.includes("pi")) detectedHarnesses.push("pi");
+		const detectedHarnesses = detectedHarnessesForExistingSetup(detection, configuredHarnessList);
 		const wantsForge = detection.harnesses.forge || configuredHarnessList.includes("forge");
 		const installedForgePath = findSignetForgeBinary(basePath);
 		if (wantsForge && installedForgePath) {

--- a/packages/cli/src/features/setup.test.ts
+++ b/packages/cli/src/features/setup.test.ts
@@ -5,10 +5,11 @@ import { join } from "node:path";
 import {
 	SIGNET_SECRETS_PLUGIN_ID,
 	type SetupDetection,
+	detectExistingSetup,
 	readGraphiqState,
 	updateGraphiqActiveProject,
 } from "@signet/core";
-import { runExistingSetupWizard } from "./setup-migrate.js";
+import { detectedHarnessesForExistingSetup, runExistingSetupWizard } from "./setup-migrate.js";
 import type { SetupDeps } from "./setup-types.js";
 import { setupWizard } from "./setup.js";
 
@@ -22,6 +23,10 @@ const NO_HARNESSES = {
 	forge: false,
 	hermesAgent: false,
 };
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_HERMES_REPO = process.env.HERMES_REPO;
+const ORIGINAL_HERMES_HOME = process.env.HERMES_HOME;
 
 function fakeDetection(basePath = "/tmp/agents"): SetupDetection {
 	return {
@@ -82,6 +87,24 @@ describe("setupWizard non-interactive harness hooks", () => {
 	let root: string;
 
 	afterEach(() => {
+		if (ORIGINAL_HOME === undefined) {
+			// biome-ignore lint/performance/noDelete: assigning undefined stores the string "undefined"
+			delete process.env.HOME;
+		} else {
+			process.env.HOME = ORIGINAL_HOME;
+		}
+		if (ORIGINAL_HERMES_REPO === undefined) {
+			// biome-ignore lint/performance/noDelete: assigning undefined stores the string "undefined"
+			delete process.env.HERMES_REPO;
+		} else {
+			process.env.HERMES_REPO = ORIGINAL_HERMES_REPO;
+		}
+		if (ORIGINAL_HERMES_HOME === undefined) {
+			// biome-ignore lint/performance/noDelete: assigning undefined stores the string "undefined"
+			delete process.env.HERMES_HOME;
+		} else {
+			process.env.HERMES_HOME = ORIGINAL_HERMES_HOME;
+		}
 		if (root) {
 			rmSync(root, { recursive: true, force: true });
 		}
@@ -265,6 +288,22 @@ describe("setupWizard non-interactive harness hooks", () => {
 		const state = readGraphiqState(basePath);
 		expect(state.enabled).toBe(false);
 		expect(state.activeProject).toBe(projectPath);
+	});
+
+	it("includes Hermes in migration harnesses when detected in ~/.hermes", () => {
+		root = mkdtempSync(join(tmpdir(), "setup-migrate-hermes-default-"));
+		const basePath = join(root, "agents");
+		mkdirSync(basePath, { recursive: true });
+		mkdirSync(join(root, ".hermes", "plugins", "memory"), { recursive: true });
+		process.env.HOME = root;
+		// biome-ignore lint/performance/noDelete: default ~/.hermes must be enough
+		delete process.env.HERMES_REPO;
+		// biome-ignore lint/performance/noDelete: default ~/.hermes must be enough
+		delete process.env.HERMES_HOME;
+
+		const detection = detectExistingSetup(basePath);
+		expect(detection.harnesses.hermesAgent).toBe(true);
+		expect(detectedHarnessesForExistingSetup(detection, [])).toContain("hermes-agent");
 	});
 
 	it("fails fast on unknown non-interactive harness values in the existing-install path", async () => {

--- a/packages/connector-hermes-agent/index.test.ts
+++ b/packages/connector-hermes-agent/index.test.ts
@@ -113,13 +113,43 @@ describe("HermesAgentConnector.install()", () => {
 		expect(connector.isInstalled()).toBe(true);
 	});
 
+	it("copies plugin files into ~/.hermes when HERMES_REPO is unset", async () => {
+		const hermesRepo = join(tmpRoot, ".hermes");
+		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
+
+		const connector = new HermesAgentConnector();
+		const result = await connector.install(tmpRoot);
+
+		const pluginDir = join(hermesRepo, "plugins", "memory", "signet");
+		expect(result.success).toBe(true);
+		expect(result.warnings.some((w) => w.includes("Hermes Agent install not found"))).toBe(false);
+		expect(existsSync(join(pluginDir, "__init__.py"))).toBe(true);
+		expect(existsSync(join(pluginDir, "client.py"))).toBe(true);
+		expect(connector.isInstalled()).toBe(true);
+	});
+
+	it("copies plugin files into HERMES_HOME when HERMES_REPO is unset", async () => {
+		const hermesHome = join(tmpRoot, "custom-hermes-home");
+		mkdirSync(join(hermesHome, "plugins", "memory"), { recursive: true });
+		process.env.HERMES_HOME = hermesHome;
+
+		const connector = new HermesAgentConnector();
+		const result = await connector.install(tmpRoot);
+
+		const pluginDir = join(hermesHome, "plugins", "memory", "signet");
+		expect(result.success).toBe(true);
+		expect(result.warnings.some((w) => w.includes("Hermes Agent install not found"))).toBe(false);
+		expect(existsSync(join(pluginDir, "__init__.py"))).toBe(true);
+		expect(connector.isInstalled()).toBe(true);
+	});
+
 	it("warns (does not throw) when HERMES_REPO is unset", async () => {
 		process.env.HERMES_HOME = join(tmpRoot, ".hermes");
 
 		const result = await new HermesAgentConnector().install(tmpRoot);
 
 		expect(result.success).toBe(true);
-		expect(result.warnings.some((w) => w.includes("HERMES_REPO"))).toBe(true);
+		expect(result.warnings.some((w) => w.includes("Hermes Agent install not found"))).toBe(true);
 	});
 
 	it("writes daemon env vars into ~/.hermes/.env when SIGNET_DAEMON_URL is set", async () => {

--- a/packages/connector-hermes-agent/src/index.ts
+++ b/packages/connector-hermes-agent/src/index.ts
@@ -1,57 +1,11 @@
-import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { BaseConnector, type InstallResult, type UninstallResult } from "@signet/connector-base";
-import { expandHome, hermesAgentCandidateDirs, resolveHermesRepoPluginPath } from "@signet/core";
+import { expandHome, resolveHermesHomePath, resolveHermesRepoPath, resolveHermesRepoPluginPath } from "@signet/core";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-
-// ---------------------------------------------------------------------------
-// Hermes home discovery
-// ---------------------------------------------------------------------------
-
-/** Resolve the Hermes Agent home directory.
- *  Order: HERMES_HOME env -> ~/.hermes (default) */
-function resolveHermesHome(): string {
-	const explicit = process.env.HERMES_HOME?.trim();
-	if (explicit) return explicit;
-	return join(homedir(), ".hermes");
-}
-
-/**
- * Resolve the Hermes Agent repo directory by checking for a `plugins/memory` tree.
- * Checks HERMES_REPO env, common paths, and falls back to which(1).
- *
- * Note: this checks for Hermes presence, not Signet plugin installation.
- * Use resolveHermesRepoPluginPath() (from @signet/core) for the latter.
- */
-function resolveHermesRepo(): string | null {
-	const explicit = process.env.HERMES_REPO?.trim();
-	if (explicit && existsSync(join(explicit, "plugins", "memory"))) return explicit;
-
-	for (const candidate of hermesAgentCandidateDirs()) {
-		if (existsSync(join(candidate, "plugins", "memory"))) return candidate;
-	}
-
-	// Fallback: resolve via `hermes` CLI in PATH
-	try {
-		const hermesPath = execFileSync("which", ["hermes"], {
-			encoding: "utf-8",
-			stdio: ["ignore", "pipe", "ignore"],
-			timeout: 3000,
-		}).trim();
-		if (hermesPath) {
-			const repoDir = dirname(realpathSync(hermesPath));
-			if (existsSync(join(repoDir, "plugins", "memory"))) return repoDir;
-		}
-	} catch {
-		// Not in PATH
-	}
-
-	return null;
-}
 
 // ---------------------------------------------------------------------------
 // Plugin file management
@@ -221,11 +175,11 @@ export class HermesAgentConnector extends BaseConnector {
 	readonly harnessId = "hermes-agent";
 
 	private getHermesHome(): string {
-		return resolveHermesHome();
+		return resolveHermesHomePath();
 	}
 
 	private getHermesRepo(): string | null {
-		return resolveHermesRepo();
+		return resolveHermesRepoPath();
 	}
 
 	getConfigPath(): string {
@@ -256,7 +210,7 @@ export class HermesAgentConnector extends BaseConnector {
 			}
 		} else {
 			warnings.push(
-				"Hermes Agent repo not found. Set HERMES_REPO env var to the hermes-agent directory, " +
+				"Hermes Agent install not found. Install Hermes in ~/.hermes or set HERMES_REPO to the hermes-agent directory, " +
 					"then re-run setup. Alternatively, copy the plugin manually:\n" +
 					"  cp -r <signet>/packages/connector-hermes-agent/hermes-plugin/ " +
 					"<hermes-agent>/plugins/memory/signet/",

--- a/packages/core/src/__tests__/identity.test.ts
+++ b/packages/core/src/__tests__/identity.test.ts
@@ -13,15 +13,29 @@ import {
 import { parseSimpleYaml } from "../yaml";
 
 const TMP = join(tmpdir(), `signet-identity-test-${Date.now()}`);
+const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_HERMES_REPO = process.env.HERMES_REPO;
+const ORIGINAL_HERMES_HOME = process.env.HERMES_HOME;
 
 beforeEach(() => mkdirSync(TMP, { recursive: true }));
 afterEach(() => {
+	if (ORIGINAL_HOME === undefined) {
+		// biome-ignore lint/performance/noDelete: assigning undefined stores the string "undefined"
+		delete process.env.HOME;
+	} else {
+		process.env.HOME = ORIGINAL_HOME;
+	}
 	if (ORIGINAL_HERMES_REPO === undefined) {
 		// biome-ignore lint/performance/noDelete: assigning undefined stores the string "undefined"
 		delete process.env.HERMES_REPO;
 	} else {
 		process.env.HERMES_REPO = ORIGINAL_HERMES_REPO;
+	}
+	if (ORIGINAL_HERMES_HOME === undefined) {
+		// biome-ignore lint/performance/noDelete: assigning undefined stores the string "undefined"
+		delete process.env.HERMES_HOME;
+	} else {
+		process.env.HERMES_HOME = ORIGINAL_HERMES_HOME;
 	}
 	rmSync(TMP, { recursive: true, force: true });
 });
@@ -115,6 +129,25 @@ describe("parseSimpleYaml", () => {
 });
 
 describe("detectExistingSetup", () => {
+	test("detects Hermes Agent in the default ~/.hermes install path", () => {
+		process.env.HOME = TMP;
+		mkdirSync(join(TMP, ".hermes", "plugins", "memory"), { recursive: true });
+
+		const detection = detectExistingSetup(TMP);
+
+		expect(detection.harnesses.hermesAgent).toBe(true);
+	});
+
+	test("detects Hermes Agent from HERMES_HOME without HERMES_REPO", () => {
+		const hermesHome = join(TMP, "custom-hermes-home");
+		process.env.HERMES_HOME = hermesHome;
+		mkdirSync(join(hermesHome, "plugins", "memory"), { recursive: true });
+
+		const detection = detectExistingSetup(TMP);
+
+		expect(detection.harnesses.hermesAgent).toBe(true);
+	});
+
 	test("detects Hermes Agent before the Signet memory plugin is installed", () => {
 		const hermesRepo = join(TMP, "hermes-agent");
 		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });

--- a/packages/core/src/identity.ts
+++ b/packages/core/src/identity.ts
@@ -355,6 +355,15 @@ function isForgeInstalled(agentsDir: string, home: string): boolean {
 	return findSignetForgeBinary(agentsDir, home) !== null;
 }
 
+function userHome(): string {
+	return process.env.HOME?.trim() || homedir();
+}
+
+export function resolveHermesHomePath(): string {
+	const hermesHome = process.env.HERMES_HOME?.trim();
+	return hermesHome || join(userHome(), ".hermes");
+}
+
 /**
  * Canonical list of common Hermes Agent repo install paths.
  *
@@ -362,8 +371,10 @@ function isForgeInstalled(agentsDir: string, home: string): boolean {
  * the list, eliminating parity drift between install and detection logic.
  */
 export function hermesAgentCandidateDirs(): readonly string[] {
-	const home = homedir();
+	const home = userHome();
+	const hermesHome = resolveHermesHomePath();
 	return [
+		hermesHome,
 		join(home, "hermes-agent"),
 		join(home, ".local", "share", "hermes-agent"),
 		join(home, "src", "hermes-agent"),
@@ -377,6 +388,8 @@ export function hermesAgentCandidateDirs(): readonly string[] {
  * This detects a Hermes install before the Signet plugin has been copied in.
  * It checks for the repo's `plugins/memory` tree rather than the Signet plugin
  * file, so setup can offer and install the Hermes connector on first run.
+ * Resolution order: HERMES_REPO, HERMES_HOME, ~/.hermes, legacy/common paths,
+ * then the hermes executable location.
  */
 export function resolveHermesRepoPath(): string | null {
 	const hermesRepo = process.env.HERMES_REPO?.trim();
@@ -408,7 +421,7 @@ export function resolveHermesRepoPath(): string | null {
 /**
  * Resolve the path to the Signet plugin file inside the Hermes Agent repo.
  *
- * Checks (in order): `HERMES_REPO` env var, four common install paths, then
+ * Checks (in order): `HERMES_REPO` env var, common install paths, then
  * falls back to resolving the `hermes` CLI via `which(1)` + `realpathSync`.
  *
  * Returns the full path to `plugins/memory/signet/__init__.py` when found,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -241,6 +241,7 @@ export {
 	STATIC_IDENTITY_SESSION_START_TIMEOUT_STATUS,
 	resolveSignetForgeManagedPath,
 	resolveAgentBasePath,
+	resolveHermesHomePath,
 	resolveHermesRepoPath,
 	resolveHermesRepoPluginPath,
 	hermesAgentCandidateDirs,


### PR DESCRIPTION
## Summary

This fixes Hermes Agent setup detection so Signet can find default and custom Hermes installs before the Signet plugin has already been copied in.

## Root cause

Hermes discovery logic was split between the connector and core setup detection. The connector could install into some locations, but existing setup detection and migration did not consistently recognize a standard `~/.hermes` install or `HERMES_HOME` unless `HERMES_REPO` was set.

## Changes

- Add shared Hermes home/repo resolution in `@signet/core`.
- Include `HERMES_HOME` and the default `~/.hermes` path in Hermes candidate detection.
- Make `connector-hermes-agent` use the shared resolver instead of carrying duplicate discovery logic.
- Include detected Hermes installs in existing setup migration harness selection.
- Add regression tests for `~/.hermes`, `HERMES_HOME`, and migration detection.

## Validation

- `bun test packages/core/src/__tests__/identity.test.ts packages/connector-hermes-agent/index.test.ts packages/cli/src/features/setup.test.ts`
- `bun run --filter @signet/core typecheck`
- `bun run --filter @signet/connector-hermes-agent typecheck`
- `bunx biome check packages/core/src/identity.ts packages/core/src/index.ts packages/core/src/__tests__/identity.test.ts packages/connector-hermes-agent/src/index.ts packages/connector-hermes-agent/index.test.ts packages/cli/src/features/setup-migrate.ts packages/cli/src/features/setup.test.ts`
- `git diff --check -- packages/core/src/identity.ts packages/core/src/index.ts packages/core/src/__tests__/identity.test.ts packages/connector-hermes-agent/src/index.ts packages/connector-hermes-agent/index.test.ts packages/cli/src/features/setup-migrate.ts packages/cli/src/features/setup.test.ts`
- `bun run --filter @signet/core build`
- `bun run --filter @signet/connector-hermes-agent build`
- `bun build ./packages/cli/src/cli.ts --outfile /tmp/signet-cli-hermes-check.js --target node --external better-sqlite3`
