### PR TITLE
fix(daemon): bundle install-graphiq.sh so graphiq install/update works

### DIFF
--- a/packages/daemon/src/routes/graphiq-install-path.ts
+++ b/packages/daemon/src/routes/graphiq-install-path.ts
@@ -1,0 +1,10 @@
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function getInstallScriptPath(): string {
+	const thisDir = dirname(fileURLToPath(import.meta.url));
+	const bundled = resolve(thisDir, "../scripts/install-graphiq.sh");
+	if (existsSync(bundled)) return bundled;
+	return resolve(thisDir, "../../../../scripts/install-graphiq.sh");
+}

--- a/packages/daemon/src/routes/graphiq-install-path.ts
+++ b/packages/daemon/src/routes/graphiq-install-path.ts
@@ -2,8 +2,8 @@ import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-export function getInstallScriptPath(): string {
-	const thisDir = dirname(fileURLToPath(import.meta.url));
+export function getInstallScriptPath(importMetaUrl: string = import.meta.url): string {
+	const thisDir = dirname(fileURLToPath(importMetaUrl));
 	const bundled = resolve(thisDir, "../scripts/install-graphiq.sh");
 	if (existsSync(bundled)) return bundled;
 	return resolve(thisDir, "../../../../scripts/install-graphiq.sh");

--- a/packages/daemon/src/routes/graphiq-routes.test.ts
+++ b/packages/daemon/src/routes/graphiq-routes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { getInstallScriptPath } from "./graphiq-install-path.js";
 
 const thisDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(thisDir, "../../../../");
@@ -9,7 +10,13 @@ const sourceScript = resolve(repoRoot, "scripts/install-graphiq.sh");
 const pkgScript = resolve(repoRoot, "packages/signetai/scripts/install-graphiq.sh");
 const pkgJsonPath = resolve(repoRoot, "packages/signetai/package.json");
 
-describe("graphiq install script bundling", () => {
+describe("getInstallScriptPath", () => {
+	test("returns a path that points to an existing install-graphiq.sh", () => {
+		const path = getInstallScriptPath();
+		expect(existsSync(path)).toBe(true);
+		expect(path).toMatch(/scripts\/install-graphiq\.sh$/);
+	});
+
 	test("install-graphiq.sh exists in repo root scripts directory", () => {
 		expect(existsSync(sourceScript)).toBe(true);
 	});
@@ -29,7 +36,7 @@ describe("graphiq install script bundling", () => {
 		expect(pkgJson.files).toContain("scripts");
 	});
 
-	test("copy:scripts build step copies install-graphiq.sh", () => {
+	test("copy:scripts build step exists in package.json", () => {
 		const pkgJson = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
 		expect(pkgJson.scripts["copy:scripts"]).toBeDefined();
 		expect(pkgJson.scripts.prebuild).toContain("copy:scripts");

--- a/packages/daemon/src/routes/graphiq-routes.test.ts
+++ b/packages/daemon/src/routes/graphiq-routes.test.ts
@@ -42,14 +42,15 @@ describe("getInstallScriptPath", () => {
 
 	test("production resolver finds script when placed in bundled dist layout", () => {
 		const fakePkg = join(thisDir, "__test_pkg_layout__");
-		const fakeDistRoutes = join(fakePkg, "dist", "routes");
+		const fakeDist = join(fakePkg, "dist");
 		const fakeScripts = join(fakePkg, "scripts");
-		mkdirSync(fakeDistRoutes, { recursive: true });
+		mkdirSync(fakeDist, { recursive: true });
 		mkdirSync(fakeScripts, { recursive: true });
+		writeFileSync(join(fakeDist, "daemon.js"), "// bundle\n");
 		const scriptContent = "#!/bin/sh\necho test\n";
 		writeFileSync(join(fakeScripts, "install-graphiq.sh"), scriptContent);
 		try {
-			const result = getInstallScriptPath(`file://${fakeDistRoutes}/`);
+			const result = getInstallScriptPath(`file://${join(fakeDist, "daemon.js")}`);
 			expect(existsSync(result)).toBe(true);
 			expect(readFileSync(result, "utf-8")).toBe(scriptContent);
 		} finally {

--- a/packages/daemon/src/routes/graphiq-routes.test.ts
+++ b/packages/daemon/src/routes/graphiq-routes.test.ts
@@ -1,53 +1,52 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const thisDir = dirname(fileURLToPath(import.meta.url));
-const repoScript = resolve(thisDir, "../../../../scripts/install-graphiq.sh");
+const repoRoot = resolve(thisDir, "../../../../");
+const sourceScript = resolve(repoRoot, "scripts/install-graphiq.sh");
+const pkgScript = resolve(repoRoot, "packages/signetai/scripts/install-graphiq.sh");
+const pkgJsonPath = resolve(repoRoot, "packages/signetai/package.json");
 
-describe("graphiq install script path resolution", () => {
-	test("install-graphiq.sh exists in repo scripts directory", () => {
-		expect(existsSync(repoScript)).toBe(true);
+describe("graphiq install script bundling", () => {
+	test("install-graphiq.sh exists in repo root scripts directory", () => {
+		expect(existsSync(sourceScript)).toBe(true);
 	});
 
-	test("source fallback path resolves to repo scripts directory", () => {
-		const sourcePath = resolve(thisDir, "../../../../scripts/install-graphiq.sh");
-		expect(sourcePath).toMatch(/scripts\/install-graphiq\.sh$/);
-		expect(existsSync(sourcePath)).toBe(true);
+	test("install-graphiq.sh exists in signetai package scripts directory", () => {
+		expect(existsSync(pkgScript)).toBe(true);
 	});
 
-	test("bundled path takes precedence when scripts directory exists alongside dist", () => {
-		const fakeDist = join(thisDir, "__test_dist__");
-		const fakeScripts = join(fakeDist, "scripts");
+	test("source and package scripts are identical", () => {
+		expect(readFileSync(sourceScript, "utf-8")).toBe(
+			readFileSync(pkgScript, "utf-8"),
+		);
+	});
+
+	test("signetai package.json includes scripts in files array", () => {
+		const pkgJson = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+		expect(pkgJson.files).toContain("scripts");
+	});
+
+	test("copy:scripts build step copies install-graphiq.sh", () => {
+		const pkgJson = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+		expect(pkgJson.scripts["copy:scripts"]).toBeDefined();
+		expect(pkgJson.scripts.prebuild).toContain("copy:scripts");
+	});
+
+	test("bundled path resolution: ../scripts from dist/daemon.js reaches scripts directory", () => {
+		const fakePkg = join(thisDir, "__test_pkg_layout__");
+		const fakeDist = join(fakePkg, "dist");
+		const fakeScripts = join(fakePkg, "scripts");
+		mkdirSync(fakeDist, { recursive: true });
 		mkdirSync(fakeScripts, { recursive: true });
 		writeFileSync(join(fakeScripts, "install-graphiq.sh"), "#!/bin/sh\n");
-
-		const bundled = resolve(fakeDist, "scripts/install-graphiq.sh");
 		try {
-			expect(existsSync(bundled)).toBe(true);
-			const result = resolveFakeScript(fakeDist);
-			expect(result).toBe(bundled);
+			const resolvedFromBundle = resolve(fakeDist, "../scripts/install-graphiq.sh");
+			expect(existsSync(resolvedFromBundle)).toBe(true);
 		} finally {
-			rmSync(fakeDist, { recursive: true, force: true });
-		}
-	});
-
-	test("falls back to source path when bundled script is absent", () => {
-		const fakeDist = join(thisDir, "__test_dist_noscript__");
-		mkdirSync(fakeDist, { recursive: true });
-		try {
-			const result = resolveFakeScript(fakeDist);
-			expect(result).toMatch(/scripts\/install-graphiq\.sh$/);
-			expect(existsSync(result)).toBe(true);
-		} finally {
-			rmSync(fakeDist, { recursive: true, force: true });
+			rmSync(fakePkg, { recursive: true, force: true });
 		}
 	});
 });
-
-function resolveFakeScript(fakeDistDir: string): string {
-	const bundled = resolve(fakeDistDir, "scripts/install-graphiq.sh");
-	if (existsSync(bundled)) return bundled;
-	return repoScript;
-}

--- a/packages/daemon/src/routes/graphiq-routes.test.ts
+++ b/packages/daemon/src/routes/graphiq-routes.test.ts
@@ -26,9 +26,7 @@ describe("getInstallScriptPath", () => {
 	});
 
 	test("source and package scripts are identical", () => {
-		expect(readFileSync(sourceScript, "utf-8")).toBe(
-			readFileSync(pkgScript, "utf-8"),
-		);
+		expect(readFileSync(sourceScript, "utf-8")).toBe(readFileSync(pkgScript, "utf-8"));
 	});
 
 	test("signetai package.json includes scripts in files array", () => {
@@ -42,16 +40,18 @@ describe("getInstallScriptPath", () => {
 		expect(pkgJson.scripts.prebuild).toContain("copy:scripts");
 	});
 
-	test("bundled path resolution: ../scripts from dist/daemon.js reaches scripts directory", () => {
+	test("production resolver finds script when placed in bundled dist layout", () => {
 		const fakePkg = join(thisDir, "__test_pkg_layout__");
-		const fakeDist = join(fakePkg, "dist");
+		const fakeDistRoutes = join(fakePkg, "dist", "routes");
 		const fakeScripts = join(fakePkg, "scripts");
-		mkdirSync(fakeDist, { recursive: true });
+		mkdirSync(fakeDistRoutes, { recursive: true });
 		mkdirSync(fakeScripts, { recursive: true });
-		writeFileSync(join(fakeScripts, "install-graphiq.sh"), "#!/bin/sh\n");
+		const scriptContent = "#!/bin/sh\necho test\n";
+		writeFileSync(join(fakeScripts, "install-graphiq.sh"), scriptContent);
 		try {
-			const resolvedFromBundle = resolve(fakeDist, "../scripts/install-graphiq.sh");
-			expect(existsSync(resolvedFromBundle)).toBe(true);
+			const result = getInstallScriptPath(`file://${fakeDistRoutes}/`);
+			expect(existsSync(result)).toBe(true);
+			expect(readFileSync(result, "utf-8")).toBe(scriptContent);
 		} finally {
 			rmSync(fakePkg, { recursive: true, force: true });
 		}

--- a/packages/daemon/src/routes/graphiq-routes.test.ts
+++ b/packages/daemon/src/routes/graphiq-routes.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const thisDir = dirname(fileURLToPath(import.meta.url));
+const repoScript = resolve(thisDir, "../../../../scripts/install-graphiq.sh");
+
+describe("graphiq install script path resolution", () => {
+	test("install-graphiq.sh exists in repo scripts directory", () => {
+		expect(existsSync(repoScript)).toBe(true);
+	});
+
+	test("source fallback path resolves to repo scripts directory", () => {
+		const sourcePath = resolve(thisDir, "../../../../scripts/install-graphiq.sh");
+		expect(sourcePath).toMatch(/scripts\/install-graphiq\.sh$/);
+		expect(existsSync(sourcePath)).toBe(true);
+	});
+
+	test("bundled path takes precedence when scripts directory exists alongside dist", () => {
+		const fakeDist = join(thisDir, "__test_dist__");
+		const fakeScripts = join(fakeDist, "scripts");
+		mkdirSync(fakeScripts, { recursive: true });
+		writeFileSync(join(fakeScripts, "install-graphiq.sh"), "#!/bin/sh\n");
+
+		const bundled = resolve(fakeDist, "scripts/install-graphiq.sh");
+		try {
+			expect(existsSync(bundled)).toBe(true);
+			const result = resolveFakeScript(fakeDist);
+			expect(result).toBe(bundled);
+		} finally {
+			rmSync(fakeDist, { recursive: true, force: true });
+		}
+	});
+
+	test("falls back to source path when bundled script is absent", () => {
+		const fakeDist = join(thisDir, "__test_dist_noscript__");
+		mkdirSync(fakeDist, { recursive: true });
+		try {
+			const result = resolveFakeScript(fakeDist);
+			expect(result).toMatch(/scripts\/install-graphiq\.sh$/);
+			expect(existsSync(result)).toBe(true);
+		} finally {
+			rmSync(fakeDist, { recursive: true, force: true });
+		}
+	});
+});
+
+function resolveFakeScript(fakeDistDir: string): string {
+	const bundled = resolve(fakeDistDir, "scripts/install-graphiq.sh");
+	if (existsSync(bundled)) return bundled;
+	return repoScript;
+}

--- a/packages/daemon/src/routes/graphiq-routes.ts
+++ b/packages/daemon/src/routes/graphiq-routes.ts
@@ -1,6 +1,5 @@
 import { constants, accessSync, existsSync, readFileSync, statSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join, resolve } from "node:path";
 import {
 	disableGraphiqState,
 	enableGraphiqState,
@@ -13,8 +12,8 @@ import { requirePermission } from "../auth";
 import { getActiveGraphiqDbPath, getAgentsDir, resolveGraphiqBinary, runCommand } from "../graphiq.js";
 import { SIGNET_GRAPHIQ_PLUGIN_ID } from "../plugins/bundled/graphiq.js";
 import { getDefaultPluginHost } from "../plugins/index.js";
-import { authConfig } from "./state.js";
 import { getInstallScriptPath } from "./graphiq-install-path.js";
+import { authConfig } from "./state.js";
 
 export function registerGraphiqRoutes(app: Hono): void {
 	const adminGuard = async (c: import("hono").Context, next: import("hono").Next) => {

--- a/packages/daemon/src/routes/graphiq-routes.ts
+++ b/packages/daemon/src/routes/graphiq-routes.ts
@@ -152,6 +152,8 @@ function isGraphiqInstalled(): boolean {
 
 function getInstallScriptPath(): string {
 	const thisDir = dirname(fileURLToPath(import.meta.url));
+	const bundled = resolve(thisDir, "../scripts/install-graphiq.sh");
+	if (existsSync(bundled)) return bundled;
 	return resolve(thisDir, "../../../../scripts/install-graphiq.sh");
 }
 

--- a/packages/daemon/src/routes/graphiq-routes.ts
+++ b/packages/daemon/src/routes/graphiq-routes.ts
@@ -14,6 +14,7 @@ import { getActiveGraphiqDbPath, getAgentsDir, resolveGraphiqBinary, runCommand 
 import { SIGNET_GRAPHIQ_PLUGIN_ID } from "../plugins/bundled/graphiq.js";
 import { getDefaultPluginHost } from "../plugins/index.js";
 import { authConfig } from "./state.js";
+import { getInstallScriptPath } from "./graphiq-install-path.js";
 
 export function registerGraphiqRoutes(app: Hono): void {
 	const adminGuard = async (c: import("hono").Context, next: import("hono").Next) => {
@@ -148,13 +149,6 @@ export function registerGraphiqRoutes(app: Hono): void {
 
 function isGraphiqInstalled(): boolean {
 	return resolveGraphiqBinary() !== null;
-}
-
-function getInstallScriptPath(): string {
-	const thisDir = dirname(fileURLToPath(import.meta.url));
-	const bundled = resolve(thisDir, "../scripts/install-graphiq.sh");
-	if (existsSync(bundled)) return bundled;
-	return resolve(thisDir, "../../../../scripts/install-graphiq.sh");
 }
 
 async function installGraphiq(): Promise<{ success: boolean; source?: string; error?: string }> {

--- a/packages/signetai/package.json
+++ b/packages/signetai/package.json
@@ -11,6 +11,7 @@
     "bin",
     "dist",
     "dashboard",
+    "scripts",
     "templates",
     "skills",
     "README.md",
@@ -22,7 +23,8 @@
     "build:daemon": "bun run build-daemon.ts",
     "build:dashboard": "bun ../../scripts/prepare-dashboard-bundle.ts .",
     "copy:skills": "rm -rf skills && cp -r ../../skills skills",
-    "prebuild": "bun run copy:skills",
+    "copy:scripts": "mkdir -p scripts && cp ../../scripts/install-graphiq.sh scripts/install-graphiq.sh",
+    "prebuild": "bun run copy:skills && bun run copy:scripts",
     "prepublishOnly": "bun run build"
   },
   "keywords": [

--- a/packages/signetai/scripts/install-graphiq.sh
+++ b/packages/signetai/scripts/install-graphiq.sh
@@ -18,7 +18,7 @@ detect_target() {
 		darwin-arm64)  echo "aarch64-apple-darwin"   ;;
 		darwin-x86_64) echo "x86_64-apple-darwin"    ;;
 		linux-x86_64)  echo "x86_64-unknown-linux-gnu" ;;
-		linux-aarch64) echo "aarch64-unknown-linux-gnu" ;;
+		linux-aarch64|linux-arm64|linux-armv8l) echo "aarch64-unknown-linux-gnu" ;;
 		*) die "Unsupported platform: $os-$arch"      ;;
 	esac
 }

--- a/packages/signetai/scripts/install-graphiq.sh
+++ b/packages/signetai/scripts/install-graphiq.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="aaf2tbz/graphiq"
+INSTALL_DIR="${GRAPHIQ_INSTALL_DIR:-$HOME/.local/bin}"
+TIMEOUT="${GRAPHIQ_INSTALL_TIMEOUT:-120}"
+
+log()  { printf "[graphiq] %s\n" "$*" >&2; }
+die()  { log "$@"; exit 1; }
+
+need() { command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"; }
+
+detect_target() {
+	local os arch
+	os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+	arch="$(uname -m)"
+	case "$os-$arch" in
+		darwin-arm64)  echo "aarch64-apple-darwin"   ;;
+		darwin-x86_64) echo "x86_64-apple-darwin"    ;;
+		linux-x86_64)  echo "x86_64-unknown-linux-gnu" ;;
+		linux-aarch64) echo "aarch64-unknown-linux-gnu" ;;
+		*) die "Unsupported platform: $os-$arch"      ;;
+	esac
+}
+
+fetch() {
+	local url="$1" dest="$2"
+	if command -v curl >/dev/null 2>&1; then
+		curl -fsSL --max-time "$TIMEOUT" -o "$dest" "$url"
+	elif command -v wget >/dev/null 2>&1; then
+		wget -q --timeout="$TIMEOUT" -O "$dest" "$url"
+	else
+		die "Neither curl nor wget found"
+	fi
+}
+
+sha256_file() {
+	if command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "$1" | cut -d' ' -f1
+	elif command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$1" | cut -d' ' -f1
+	else
+		die "Neither shasum nor sha256sum found (required for integrity check)"
+	fi
+}
+
+fetch_release_json() {
+	local url="$1"
+	if command -v curl >/dev/null 2>&1; then
+		curl -fsSL --max-time 15 "$url" 2>/dev/null
+	elif command -v wget >/dev/null 2>&1; then
+		wget -qO- --timeout=15 "$url" 2>/dev/null
+	fi
+}
+
+release_json_for_tag() {
+	local tag="$1"
+	if [ -z "$tag" ]; then
+		fetch_release_json "https://api.github.com/repos/${REPO}/releases/latest"
+		return
+	fi
+	fetch_release_json "https://api.github.com/repos/${REPO}/releases/tags/${tag}"
+}
+
+extract_asset_sha256() {
+	local json="$1" asset_name="$2"
+	if command -v jq >/dev/null 2>&1; then
+		echo "$json" | jq -r --arg name "$asset_name" \
+			'.assets[] | select(.name == $name) | .digest // ""' 2>/dev/null \
+			| sed -E 's/^sha256://'
+		return
+	fi
+	echo "$json" | awk -v name="$asset_name" '
+		BEGIN { RS = "{"; in_asset = 0; asset_name = "" }
+		/"name"\s*:\s*"/ { gsub(/.*"name"\s*:\s*"/, ""); gsub(/".*/, ""); asset_name = $0 }
+		/"digest"\s*:\s*"/ && asset_name == name {
+			gsub(/.*"digest"\s*:\s*"/, ""); gsub(/".*/, "");
+			gsub(/^sha256:/, ""); print; found = 1; exit
+		}
+	' 2>/dev/null
+}
+
+cmd_install() {
+	need tar
+	local target tag tarball url tmpdir
+	target="$(detect_target)"
+	tarball="graphiq-${target}.tar.gz"
+
+	if [ -n "${GRAPHIQ_VERSION:-}" ]; then
+		tag="$GRAPHIQ_VERSION"
+	else
+		[ "${GRAPHIQ_ALLOW_LATEST:-}" = "1" ] || die "Set GRAPHIQ_VERSION to pin a release tag, or GRAPHIQ_ALLOW_LATEST=1 to opt into latest"
+		tag=""
+	fi
+
+	local release_json
+	release_json="$(release_json_for_tag "$tag")"
+	[ -n "$release_json" ] || die "Could not fetch release metadata from GitHub"
+
+	if [ -z "$tag" ]; then
+		if command -v jq >/dev/null 2>&1; then
+			tag="$(echo "$release_json" | jq -r '.tag_name // empty' 2>/dev/null)"
+		else
+			tag="$(echo "$release_json" | grep '"tag_name"' | head -1 | sed -E 's/.*"([^"]+)".*/\1/')"
+		fi
+	fi
+	[ -n "$tag" ] || die "Could not determine release tag"
+
+	local expected_sha
+	expected_sha="$(extract_asset_sha256 "$release_json" "$tarball")"
+
+	url="https://github.com/${REPO}/releases/download/${tag}/${tarball}"
+
+	log "Installing graphiq ${tag} for ${target}..."
+
+	mkdir -p "$INSTALL_DIR"
+	tmpdir="$(mktemp -d)"
+	trap 'rm -rf "$tmpdir"' EXIT
+
+	fetch "$url" "${tmpdir}/${tarball}"
+
+	[ -n "$expected_sha" ] || die "No checksum found in release metadata for ${tarball} — refusing to install without integrity verification"
+	local actual_sha
+	actual_sha="$(sha256_file "${tmpdir}/${tarball}")"
+	if [ "$actual_sha" != "$expected_sha" ]; then
+		die "SHA256 mismatch for ${tarball}: expected ${expected_sha}, got ${actual_sha}"
+	fi
+	log "Integrity verified (sha256)"
+
+	tar -xzf "${tmpdir}/${tarball}" -C "$tmpdir"
+
+	local bin="${tmpdir}/graphiq"
+	[ -f "$bin" ] || bin="$(find "$tmpdir" -name graphiq -type f | head -1)"
+	[ -f "$bin" ] || die "graphiq binary not found in archive"
+
+	chmod +x "$bin"
+	mv "$bin" "${INSTALL_DIR}/graphiq"
+
+	log "Installed graphiq to ${INSTALL_DIR}/graphiq"
+
+	if ! echo ":${PATH}:" | grep -q ":${INSTALL_DIR}:"; then
+		log "WARNING: ${INSTALL_DIR} is not on PATH. Add it with:"
+		log "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+	fi
+}
+
+cmd_update() {
+	cmd_install
+	log "Update complete"
+}
+
+cmd_uninstall() {
+	local bin="${INSTALL_DIR}/graphiq"
+	if [ -f "$bin" ]; then
+		rm -f "$bin"
+		log "Removed ${bin}"
+	else
+		log "graphiq not found at ${bin}"
+	fi
+}
+
+cmd_version() {
+	local bin="${INSTALL_DIR}/graphiq"
+	if [ -f "$bin" ]; then
+		"$bin" --version 2>/dev/null || echo "unknown"
+	elif command -v graphiq >/dev/null 2>&1; then
+		graphiq --version 2>/dev/null || echo "unknown"
+	else
+		echo "not installed"
+	fi
+}
+
+usage() {
+	cat <<'EOF'
+Usage: install-graphiq.sh <command>
+
+Commands:
+  install    Download and install graphiq from GitHub releases
+  update     Re-download latest version (same as install)
+  uninstall  Remove the installed binary
+  version    Print installed version
+
+Environment:
+  GRAPHIQ_INSTALL_DIR    Installation directory (default: ~/.local/bin)
+  GRAPHIQ_VERSION        Pin to a specific release tag (required unless GRAPHIQ_ALLOW_LATEST=1)
+  GRAPHIQ_ALLOW_LATEST   Set to 1 to allow downloading the latest release tag
+  GRAPHIQ_INSTALL_TIMEOUT  Download timeout in seconds (default: 120)
+EOF
+}
+
+case "${1:-}" in
+	install)   cmd_install   ;;
+	update)    cmd_update     ;;
+	uninstall) cmd_uninstall  ;;
+	version)   cmd_version    ;;
+	*)         usage; exit 0  ;;
+esac

--- a/scripts/install-graphiq.sh
+++ b/scripts/install-graphiq.sh
@@ -18,7 +18,7 @@ detect_target() {
 		darwin-arm64)  echo "aarch64-apple-darwin"   ;;
 		darwin-x86_64) echo "x86_64-apple-darwin"    ;;
 		linux-x86_64)  echo "x86_64-unknown-linux-gnu" ;;
-		linux-aarch64) echo "aarch64-unknown-linux-gnu" ;;
+		linux-aarch64|linux-arm64|linux-armv8l) echo "aarch64-unknown-linux-gnu" ;;
 		*) die "Unsupported platform: $os-$arch"      ;;
 	esac
 }


### PR DESCRIPTION
## Summary

- Bundle `install-graphiq.sh` in the npm package so the daemon's graphiq install and update routes work correctly
- Fix `getInstallScriptPath()` to resolve correctly in both bundled (npm package: `dist/../scripts/`) and source (dev: `../../../../scripts/`) contexts
- Add `scripts` to package `files` array and `copy:scripts` build step

## Round 3: Address PR review — test production resolver directly

- Extracted `getInstallScriptPath()` into its own module (`graphiq-install-path.ts`) to avoid circular imports when importing in tests
- Regression tests now call the actual production `getInstallScriptPath()` and verify it returns a path to an existing script
- Tests validate: script exists at returned path, package.json bundling config, source/package parity, and bundled layout resolution

## Round 4: Address PR review — remove unused imports, test bundled layout via production resolver

- Removed unused imports (`dirname`, `fileURLToPath`) from `graphiq-routes.ts` left over from the extraction in Round 3
- Added `importMetaUrl` parameter to `getInstallScriptPath()` for testability under fake directory layouts
- Replaced test-only `resolve()` arithmetic with a test that calls the production resolver against a fake bundled layout
- Fixed import ordering and formatting per Biome

## Round 5: Address PR review — production-faithful bundled layout test

- Fixed test to pass a module file URL (`file://.../dist/daemon.js`) instead of a directory URL, matching real `import.meta.url` semantics in the bundled runtime
- The daemon bundles into a single `dist/daemon.js` via `build-daemon.ts`, so `../scripts/` from `dirname(import.meta.url)` correctly resolves to the package-root `scripts/` directory

## Round 6: Address PR review — add linux-arm64 alias to install script

- Added `linux-arm64` and `linux-armv8l` aliases to `detect_target()` in `install-graphiq.sh`
- Some ARM Linux environments report `arm64` via `uname -m` instead of `aarch64`, causing "Unsupported platform" errors
- All three variants (`aarch64`, `arm64`, `armv8l`) now map to `aarch64-unknown-linux-gnu`

## Changes

- `scripts/install-graphiq.sh` — added `linux-arm64`/`armv8l` aliases
- `packages/signetai/scripts/install-graphiq.sh` — same (build copy target)
- `packages/signetai/package.json` — added `scripts` to `files`, added `copy:scripts` build step
- `packages/daemon/src/routes/graphiq-install-path.ts` — extracted `getInstallScriptPath()` with optional `importMetaUrl` param for testability
- `packages/daemon/src/routes/graphiq-routes.ts` — imports `getInstallScriptPath` from extracted module; removed dead imports
- `packages/daemon/src/routes/graphiq-routes.test.ts` — regression tests calling production resolver, including production-faithful bundled layout

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/core`
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Regression tests now call the production `getInstallScriptPath()` directly (extracted to `graphiq-install-path.ts` to avoid circular import issues). Tests verify the resolver returns an existing script path in both source and production-faithful bundled layouts. The bundled layout test passes a file URL matching real `import.meta.url` in the `dist/daemon.js` bundle. Install script now handles `arm64`/`armv8l` as aliases for `aarch64` on Linux.