### PR TITLE
fix(daemon): honor SIGNET_AGENT_ID in MCP daemonFetch

### DIFF
--- a/packages/daemon/src/mcp/tools.test.ts
+++ b/packages/daemon/src/mcp/tools.test.ts
@@ -641,6 +641,90 @@ describe("createMcpServer", () => {
 		});
 	});
 
+	describe("SIGNET_AGENT_ID propagation", () => {
+		const originalAgentId = process.env.SIGNET_AGENT_ID;
+
+		afterEach(() => {
+			if (originalAgentId === undefined) {
+				Reflect.deleteProperty(process.env, "SIGNET_AGENT_ID");
+			} else {
+				process.env.SIGNET_AGENT_ID = originalAgentId;
+			}
+		});
+
+		function captureFetch(): { headers?: Record<string, string>; body?: string } {
+			const cap: { headers?: Record<string, string>; body?: string } = {};
+			globalThis.fetch = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+				const headers: Record<string, string> = {};
+				const raw = init?.headers as Record<string, string> | Headers | undefined;
+				if (raw instanceof Headers) {
+					raw.forEach((value, key) => {
+						headers[key.toLowerCase()] = value;
+					});
+				} else if (raw && typeof raw === "object") {
+					for (const [key, value] of Object.entries(raw)) {
+						headers[key.toLowerCase()] = String(value);
+					}
+				}
+				cap.headers = headers;
+				cap.body = init?.body as string | undefined;
+				return new Response(
+					JSON.stringify({ method: "hybrid", results: [], meta: { totalReturned: 0, hasSupplementary: false, noHits: true } }),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}) as unknown as typeof fetch;
+			return cap;
+		}
+
+		it("injects SIGNET_AGENT_ID into POST body and request headers", async () => {
+			process.env.SIGNET_AGENT_ID = "telegram_main";
+			const cap = captureFetch();
+
+			await callTool(server, "memory_search", { query: "scoped query" });
+
+			const body = JSON.parse(cap.body ?? "{}");
+			expect(body.agentId).toBe("telegram_main");
+			expect(cap.headers?.["x-signet-agent-id"]).toBe("telegram_main");
+		});
+
+		it("does not override an explicit body.agentId", async () => {
+			process.env.SIGNET_AGENT_ID = "telegram_main";
+			const cap = captureFetch();
+
+			await callTool(server, "memory_feedback", {
+				session_key: "session-1",
+				agent_id: "explicit_agent",
+				ratings: { "mem-1": 1 },
+			});
+
+			const body = JSON.parse(cap.body ?? "{}");
+			expect(body.agentId).toBe("explicit_agent");
+			expect(cap.headers?.["x-signet-agent-id"]).toBe("telegram_main");
+		});
+
+		it("omits agent headers and body field when SIGNET_AGENT_ID is unset", async () => {
+			Reflect.deleteProperty(process.env, "SIGNET_AGENT_ID");
+			const cap = captureFetch();
+
+			await callTool(server, "memory_search", { query: "unscoped query" });
+
+			const body = JSON.parse(cap.body ?? "{}");
+			expect(body.agentId).toBeUndefined();
+			expect(cap.headers?.["x-signet-agent-id"]).toBeUndefined();
+		});
+
+		it("treats whitespace-only SIGNET_AGENT_ID as unset", async () => {
+			process.env.SIGNET_AGENT_ID = "   ";
+			const cap = captureFetch();
+
+			await callTool(server, "memory_search", { query: "blank agent id" });
+
+			const body = JSON.parse(cap.body ?? "{}");
+			expect(body.agentId).toBeUndefined();
+			expect(cap.headers?.["x-signet-agent-id"]).toBeUndefined();
+		});
+	});
+
 	describe("memory_store", () => {
 		it("calls remember endpoint", async () => {
 			const cap: { body?: string } = {};

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -219,6 +219,10 @@ const GRAPHIQ_COMPAT_ALIASES: ReadonlyMap<string, string> = new Map([
 // Internal HTTP helper
 // ---------------------------------------------------------------------------
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 async function daemonFetch<T>(
 	baseUrl: string,
 	path: string,
@@ -231,6 +235,9 @@ async function daemonFetch<T>(
 ): Promise<FetchResult<T>> {
 	const { method = "GET", body, timeout = 10_000, extraHeaders } = options;
 
+	const agentId = process.env.SIGNET_AGENT_ID?.trim();
+	const agentHeaders = agentId ? { "x-signet-agent-id": agentId } : {};
+
 	const init: RequestInit = {
 		method,
 		headers: {
@@ -238,13 +245,16 @@ async function daemonFetch<T>(
 			"x-signet-runtime-path": "plugin",
 			"x-signet-actor": "mcp-server",
 			"x-signet-actor-type": "harness",
+			...agentHeaders,
 			...extraHeaders,
 		},
 		signal: AbortSignal.timeout(timeout),
 	};
 
 	if (body !== undefined) {
-		init.body = JSON.stringify(body);
+		const finalBody =
+			agentId && isPlainObject(body) && body.agentId === undefined ? { ...body, agentId } : body;
+		init.body = JSON.stringify(finalBody);
 	}
 
 	try {


### PR DESCRIPTION
## Summary

The standalone MCP stdio server in `packages/daemon/src/mcp/tools.ts` ignores `SIGNET_AGENT_ID` and never sends `agentId` to the daemon. As a result, every `memory_search` / `memory_store` / `memory_recall` call from any harness that mounts the MCP server resolves server-side to `agentId=\"default\"` via `resolveAgentId`'s fallback — silently bypassing per-agent `read_policy: isolated` and pooling all memory traffic under the `default` bucket.

## Repro

Setup:
- Two agents in `agents` table: `default` (`read_policy: shared`) and `agent_b` (`read_policy: isolated`).
- Spawn the MCP server (`@signet/daemon` `mcp-stdio.ts`) under harness B with `SIGNET_AGENT_ID=agent_b`.
- Have agent B call `memory_store` with content X, then `memory_search` for X.

Observed: all writes from agent B land under `agent_id=default` in `memories`. Recalls return both default's and agent_b's bucket because the request is being treated as default. The `agents` row for `agent_b` exists (created by hooks/CLI which DO honor the env), but its `read_policy` is moot for any MCP-mediated traffic.

Expected: writes attributed to `agent_b`; recalls scoped to `agent_b`'s bucket per its `read_policy`.

## Root cause

`daemonFetch` in `packages/daemon/src/mcp/tools.ts` (the helper backing every MCP tool) sets only `Content-Type`, `x-signet-runtime-path`, `x-signet-actor`, `x-signet-actor-type` headers, and never enriches the body. The daemon's recall handler (`packages/daemon/src/routes/...` -> `resolveAgentId({ agentId: body.agentId, sessionKey: header })`) sees neither, falls back to `\"default\"`.

The CLI/hooks path (`packages/cli`) and the OpenClaw adapter (`packages/adapters/openclaw`) already honor `SIGNET_AGENT_ID`. The bug is scoped to this one helper.

This matches the \"Scoping leaks\" failure mode called out in `CLAUDE.md`:

> Thread `agent_id` through every read/write touching user data. Never hardcode `\"default\"` for scoped paths.

## Fix

In `daemonFetch`:

- Read `process.env.SIGNET_AGENT_ID` (trimmed; whitespace-only treated as unset).
- Add `x-signet-agent-id` header when the env is set (covers handlers that read it from headers).
- For request bodies that are plain objects without an existing `agentId`, spread in `agentId: <env value>` before serialization (covers handlers like `/api/memory/recall` that read `body.agentId`).
- Existing explicit args (e.g. `memory_feedback` taking `agent_id` from the LLM) are preserved — never overridden.

Minimal change, no new dependencies, fully backward compatible:
- When `SIGNET_AGENT_ID` is unset, behavior is identical to before.
- Non-object bodies (none today, but defensive) pass through untouched.

## Tests

Added a `SIGNET_AGENT_ID propagation` describe block in `packages/daemon/src/mcp/tools.test.ts` with 4 cases:

1. Injects `agentId` into POST body and `x-signet-agent-id` header when env is set.
2. Does not override an explicit `body.agentId` (uses `memory_feedback` to verify).
3. Omits header and body field when env is unset.
4. Treats whitespace-only env value as unset.

All 4 pass locally. The full `tools.test.ts` suite is `42 pass / 1 fail / 249 expect()` — the one failure (`falls back to graphiq state file when plugin registry has no graphiq entry`) reproduces on `origin/main` without my change and appears to be a Termux/Android-specific environment issue with the GraphIQ install path, unrelated to this PR.

## Test plan

- [ ] CI lint (Biome) — couldn't run locally, no Android binary. Code follows surrounding style.
- [ ] CI typecheck — local typecheck blocked by pre-existing workspace `rootDir` issues unrelated to this change.
- [ ] CI tests on the new `SIGNET_AGENT_ID propagation` describe block.
- [ ] Manual: harness with `SIGNET_AGENT_ID=foo` + isolated agent row writes/reads only its own bucket. Verified locally on `signetai 0.103.3` against patched `dist/mcp-stdio.js` — `memory_store` now lands rows with `agent_id=foo` in SQLite (was `default` before).

## Notes

- Considered also injecting via `x-signet-session-key` header in `agent:<id>` form, but body+header is more direct and matches the existing `body.agentId` priority in `resolveAgentId`.
- The bundled `signetai` package's `dist/mcp-stdio.js` will pick this up after the next `bun run build:signetai` + release.