### PR TITLE
fix(update): refresh desktop app after Signet update

### DIFF
--- a/docs/TRAY.md
+++ b/docs/TRAY.md
@@ -22,6 +22,13 @@ resources and marks that daemon as desktop-owned.
 The daemon remains a separate local process. The desktop app is a
 distribution and control layer, not a replacement for the daemon.
 
+When `signet update install` or daemon auto-update installs a new Signet
+version, the update system checks for a managed Linux desktop install at
+`~/.local/bin/signet-desktop` / `~/.local/share/signet/desktop/Signet.AppImage`.
+If present, it refreshes the Electron AppImage from the synced Signet source
+checkout as part of the same update. Unmanaged desktop launchers are left
+untouched and reported as skipped.
+
 ## User-facing behavior
 
 The Electron desktop app provides:

--- a/platform/daemon/src/update-route.test.ts
+++ b/platform/daemon/src/update-route.test.ts
@@ -59,4 +59,9 @@ describe("Bug 1: CLI gives update/run enough time for desktop refresh", () => {
 		expect(callSite).toContain("JSON.stringify");
 		expect(callSite).toContain("Content-Type");
 	});
+
+	it("CLI reports skipped desktop refresh reasons", () => {
+		expect(CLI_SRC).toContain('data.desktopUpdate?.status === "skipped"');
+		expect(CLI_SRC).toContain("Desktop: ${data.desktopUpdate.message}");
+	});
 });

--- a/platform/daemon/src/update-route.test.ts
+++ b/platform/daemon/src/update-route.test.ts
@@ -43,11 +43,12 @@ describe("Bug 7: /api/update/run accepts targetVersion in body", () => {
 	});
 });
 
-describe("Bug 1: CLI passes 120s timeout to update/run", () => {
-	it("fetchFromDaemon for /api/update/run has 120s timeout", () => {
+describe("Bug 1: CLI gives update/run enough time for desktop refresh", () => {
+	it("fetchFromDaemon for /api/update/run uses the shared install timeout", () => {
 		// Find the update install section — look for the POST to update/run
 		const callSite = mustMatch(CLI_SRC, /fetchFromDaemon[\s\S]*?\/api\/update\/run[\s\S]*?\);/);
-		expect(callSite).toContain("120_000");
+		expect(CLI_SRC).toContain("const UPDATE_INSTALL_TIMEOUT_MS = 15 * 60_000");
+		expect(callSite).toContain("UPDATE_INSTALL_TIMEOUT_MS");
 		expect(callSite).toContain('method: "POST"');
 	});
 

--- a/platform/daemon/src/update-system.test.ts
+++ b/platform/daemon/src/update-system.test.ts
@@ -12,7 +12,9 @@ import { join } from "node:path";
 import {
 	MAX_UPDATE_INTERVAL_SECONDS,
 	MIN_UPDATE_INTERVAL_SECONDS,
+	canUpdateDesktopFromSourceSync,
 	categorizeUpdateError,
+	detectDesktopInstall,
 	finalizeSuccessfulUpdateInstall,
 	getUpdateState,
 	initUpdateSystem,
@@ -20,6 +22,7 @@ import {
 	parseBooleanFlag,
 	parseInstalledPackageVersion,
 	parseUpdateInterval,
+	updateDesktopInstallAfterUpdate,
 	verifyInstalledVersion,
 } from "./update-system";
 
@@ -74,6 +77,10 @@ describe("Issue 322: verify installed version after update install", () => {
 					defaultBranch: "main",
 				};
 			},
+			updateDesktopInstallAfterUpdate: async () => ({
+				status: "skipped",
+				message: "Signet desktop app is not installed",
+			}),
 		});
 
 		expect(calls).toEqual([workspaceDir]);
@@ -83,8 +90,150 @@ describe("Issue 322: verify installed version after update install", () => {
 			output: "installed ok",
 			installedVersion: "0.78.1",
 			restartRequired: true,
+			desktopUpdate: {
+				status: "skipped",
+				message: "Signet desktop app is not installed",
+			},
 		});
 		expect(getUpdateState().pendingRestartVersion).toBe("0.78.1");
+	});
+
+	it("attempts managed desktop update after source checkout sync", async () => {
+		const workspaceDir = join(tmpdir(), `signet-update-desktop-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		const calls: string[] = [];
+		initUpdateSystem("0.78.0", workspaceDir);
+
+		const result = await finalizeSuccessfulUpdateInstall("0.78.1", "installed ok", {
+			syncWorkspaceSourceRepoAsync: async (dir) => ({
+				status: "pulled",
+				path: join(dir, "signetai"),
+				message: "fast-forwarded Signet source checkout",
+				branch: "main",
+				defaultBranch: "main",
+			}),
+			updateDesktopInstallAfterUpdate: async (repoSync, version) => {
+				calls.push(`${version}@${repoSync.path}`);
+				return {
+					status: "updated",
+					message: `Signet desktop app updated to v${version}.`,
+				};
+			},
+		});
+
+		expect(calls).toEqual([`0.78.1@${join(workspaceDir, "signetai")}`]);
+		expect(result.desktopUpdate).toEqual({
+			status: "updated",
+			message: "Signet desktop app updated to v0.78.1.",
+		});
+	});
+});
+
+describe("desktop update integration", () => {
+	it("detects absent, managed, and unmanaged Linux desktop installs", () => {
+		const home = "/home/tester";
+		const launcher = join(home, ".local", "bin", "signet-desktop");
+
+		expect(
+			detectDesktopInstall(home, {
+				existsSync: () => false,
+				readFileSync: () => "",
+			}),
+		).toMatchObject({ installed: false, managed: false });
+
+		expect(
+			detectDesktopInstall(home, {
+				existsSync: (path) => path === launcher,
+				readFileSync: () => "# signet-desktop managed launcher\n",
+			}),
+		).toMatchObject({ installed: true, managed: true });
+
+		expect(
+			detectDesktopInstall(home, {
+				existsSync: (path) => path === launcher,
+				readFileSync: () => "#!/usr/bin/env sh\nexec /custom/Signet.AppImage\n",
+			}),
+		).toMatchObject({ installed: true, managed: false });
+	});
+
+	it("only updates desktop from a current or fast-forwarded source checkout", () => {
+		expect(canUpdateDesktopFromSourceSync("cloned")).toBe(true);
+		expect(canUpdateDesktopFromSourceSync("pulled")).toBe(true);
+		expect(canUpdateDesktopFromSourceSync("current")).toBe(true);
+		expect(canUpdateDesktopFromSourceSync("fetched")).toBe(false);
+		expect(canUpdateDesktopFromSourceSync("skipped")).toBe(false);
+		expect(canUpdateDesktopFromSourceSync("error")).toBe(false);
+	});
+
+	it("runs the installed Signet CLI desktop installer for managed installs", async () => {
+		const home = "/home/tester";
+		const repo = "/workspace/signetai";
+		const launcher = join(home, ".local", "bin", "signet-desktop");
+		const signetBin = "/pkg/bin/signet.js";
+		const calls: string[] = [];
+		initUpdateSystem("0.78.0", "/workspace");
+
+		const result = await updateDesktopInstallAfterUpdate(
+			{
+				status: "pulled",
+				path: repo,
+				message: "fast-forwarded Signet source checkout",
+				branch: "main",
+				defaultBranch: "main",
+			},
+			"0.78.1",
+			{
+				home,
+				env: {},
+				execPath: "/usr/bin/node",
+				existsSync: (path) => path === launcher || path === signetBin,
+				readFileSync: () => "# signet-desktop managed launcher\n",
+				resolvePrimaryPackageManager: () => ({
+					family: "bun",
+					source: "fallback",
+					reason: "test",
+					available: { bun: true, npm: false, pnpm: false, yarn: false },
+				}),
+				resolveGlobalPackagePath: () => "/pkg",
+				runCommand: async (command, args, options) => {
+					calls.push(`${command} ${args.join(" ")} @ ${options.cwd}`);
+					return { exitCode: 0, stdout: "desktop installed", stderr: "", timedOut: false };
+				},
+			},
+		);
+
+		expect(result).toEqual({
+			status: "updated",
+			message: "Signet desktop app updated to v0.78.1.",
+			output: "desktop installed",
+		});
+		expect(calls).toEqual([`/usr/bin/node ${signetBin} desktop install --repo ${repo} @ ${repo}`]);
+	});
+
+	it("skips desktop update when the source checkout was not fast-forwarded", async () => {
+		const calls: string[] = [];
+		const result = await updateDesktopInstallAfterUpdate(
+			{
+				status: "fetched",
+				path: "/workspace/signetai",
+				message: "skipped pull because the working tree has local changes",
+				branch: "main",
+				defaultBranch: "main",
+			},
+			"0.78.1",
+			{
+				home: "/home/tester",
+				existsSync: () => true,
+				readFileSync: () => "# signet-desktop managed launcher\n",
+				runCommand: async () => {
+					calls.push("ran");
+					return { exitCode: 0, stdout: "", stderr: "", timedOut: false };
+				},
+			},
+		);
+
+		expect(result.status).toBe("skipped");
+		expect(result.message).toContain("source checkout sync status was 'fetched'");
+		expect(calls).toEqual([]);
 	});
 });
 

--- a/platform/daemon/src/update-system.test.ts
+++ b/platform/daemon/src/update-system.test.ts
@@ -132,6 +132,7 @@ describe("desktop update integration", () => {
 	it("detects absent, managed, and unmanaged Linux desktop installs", () => {
 		const home = "/home/tester";
 		const launcher = join(home, ".local", "bin", "signet-desktop");
+		const appImage = join(home, ".local", "share", "signet", "desktop", "Signet.AppImage");
 
 		expect(
 			detectDesktopInstall(home, {
@@ -146,6 +147,17 @@ describe("desktop update integration", () => {
 				readFileSync: () => "# signet-desktop managed launcher\n",
 			}),
 		).toMatchObject({ installed: true, managed: true });
+
+		expect(
+			detectDesktopInstall(home, {
+				existsSync: (path) => path === appImage,
+				readFileSync: () => "",
+			}),
+		).toMatchObject({
+			installed: true,
+			managed: false,
+			reason: "Signet desktop AppImage exists without a managed launcher",
+		});
 
 		expect(
 			detectDesktopInstall(home, {

--- a/platform/daemon/src/update-system.ts
+++ b/platform/daemon/src/update-system.ts
@@ -7,6 +7,7 @@
 
 import { spawn } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import {
 	type PackageManagerFamily,
@@ -43,6 +44,7 @@ export interface UpdateRunResult {
 	output?: string;
 	installedVersion?: string;
 	restartRequired?: boolean;
+	desktopUpdate?: DesktopUpdateResult;
 }
 
 export interface UpdateConfig {
@@ -71,6 +73,22 @@ interface GitHubReleaseResponse {
 	published_at?: string;
 }
 
+export type DesktopUpdateStatus = "updated" | "skipped" | "error";
+
+export interface DesktopUpdateResult {
+	readonly status: DesktopUpdateStatus;
+	readonly message: string;
+	readonly output?: string;
+}
+
+export interface DesktopInstallDetection {
+	readonly installed: boolean;
+	readonly managed: boolean;
+	readonly launcherPath: string;
+	readonly appImagePath: string;
+	readonly reason?: string;
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -78,9 +96,11 @@ interface GitHubReleaseResponse {
 const GITHUB_REPO = "Signet-AI/signetai";
 const NPM_PACKAGE = "signetai";
 const EXACT_SEMVER_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+const MANAGED_DESKTOP_LAUNCHER_MARKER = "# signet-desktop managed launcher";
 
 export const MIN_UPDATE_INTERVAL_SECONDS = 300;
 export const MAX_UPDATE_INTERVAL_SECONDS = 604800;
+export const DESKTOP_UPDATE_TIMEOUT_MS = 15 * 60_000;
 const DEFAULT_UPDATE_INTERVAL_SECONDS = 21600;
 
 // ---------------------------------------------------------------------------
@@ -179,18 +199,12 @@ export function getUpdateSummary(): string | null {
 	}
 
 	if (pendingRestartVersion) {
-		return (
-			`Signet v${pendingRestartVersion} is installed but needs ` +
-			"a daemon restart. Run:\n" +
-			"  signet daemon restart\n" +
-			"  signet sync\n\n" +
-			"These are the ONLY supported post-update commands."
-		);
+		return `Signet v${pendingRestartVersion} is installed but needs a daemon restart. Run:\n  signet daemon restart\n  signet sync\n\nThese are the ONLY supported post-update commands.`;
 	}
 
 	if (lastAutoUpdateError && updateConfig.autoInstall) {
 		const categorized = categorizeUpdateError(lastAutoUpdateError);
-		return `Auto-updates are enabled but failing: ${categorized} ` + "Run `signet update status` for details.";
+		return `Auto-updates are enabled but failing: ${categorized} Run \`signet update status\` for details.`;
 	}
 
 	const latest = lastUpdateCheck?.latestVersion;
@@ -199,12 +213,7 @@ export function getUpdateSummary(): string | null {
 
 		if (updateConfig.autoInstall) {
 			const autoInfo = lastAutoUpdateAt ? ` Last auto-update: ${lastAutoUpdateAt.toISOString()}.` : "";
-			return (
-				`Signet v${latest} is available (current: v${currentVersion}). ` +
-				"Auto-update will install it on the next check cycle." +
-				autoInfo +
-				notes
-			);
+			return `Signet v${latest} is available (current: v${currentVersion}). Auto-update will install it on the next check cycle.${autoInfo}${notes}`;
 		}
 
 		const packageManager = resolvePrimaryPackageManager({
@@ -214,16 +223,7 @@ export function getUpdateSummary(): string | null {
 		const installCmd = getGlobalInstallCommand(packageManager.family, NPM_PACKAGE);
 		const fullInstallCmd = `${installCmd.command} ${installCmd.args.join(" ")}`;
 
-		return (
-			`Signet v${latest} is available (current: v${currentVersion}).\n\n` +
-			"To update Signet:\n" +
-			`  ${fullInstallCmd}\n` +
-			"  signet daemon restart\n" +
-			"  signet sync\n\n" +
-			"These are the ONLY supported update commands. " +
-			"Do not use npx, bunx, or signet update install." +
-			notes
-		);
+		return `Signet v${latest} is available (current: v${currentVersion}).\n\nTo update Signet:\n  ${fullInstallCmd}\n  signet daemon restart\n  signet sync\n\nThese are the ONLY supported update commands. Do not use npx, bunx, or signet update install.${notes}`;
 	}
 
 	if (lastAutoUpdateAt && updateConfig.autoInstall) {
@@ -304,12 +304,7 @@ function loadUpdateConfig(): UpdateConfig {
 }
 
 function formatUpdatesSection(config: UpdateConfig): string {
-	return (
-		`updates:\n` +
-		`  auto_install: ${config.autoInstall}\n` +
-		`  check_interval: ${config.checkInterval}\n` +
-		`  channel: ${config.channel}\n`
-	);
+	return `updates:\n  auto_install: ${config.autoInstall}\n  check_interval: ${config.checkInterval}\n  channel: ${config.channel}\n`;
 }
 
 export function persistUpdateConfig(config: UpdateConfig): boolean {
@@ -492,6 +487,10 @@ interface UpdateVerificationDeps {
 
 interface FinalizeSuccessfulUpdateDeps {
 	syncWorkspaceSourceRepoAsync: (workspaceDir: string) => Promise<WorkspaceSourceRepoSyncResult>;
+	updateDesktopInstallAfterUpdate?: (
+		repoSync: WorkspaceSourceRepoSyncResult,
+		installedVersion: string,
+	) => Promise<DesktopUpdateResult>;
 }
 
 export function verifyInstalledVersion(
@@ -550,11 +549,249 @@ export function verifyInstalledVersion(
 	}
 }
 
+interface DesktopInstallDetectionDeps {
+	readonly existsSync: (path: string) => boolean;
+	readonly readFileSync: (path: string, encoding: BufferEncoding) => string;
+}
+
+interface DesktopCommandResult {
+	readonly exitCode: number | null;
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly errorMessage?: string;
+	readonly timedOut: boolean;
+}
+
+interface DesktopCommandOptions {
+	readonly cwd: string;
+	readonly env: NodeJS.ProcessEnv;
+	readonly timeoutMs: number;
+}
+
+interface DesktopUpdateDeps {
+	readonly home?: string;
+	readonly env?: NodeJS.ProcessEnv;
+	readonly execPath?: string;
+	readonly timeoutMs?: number;
+	readonly existsSync?: (path: string) => boolean;
+	readonly readFileSync?: (path: string, encoding: BufferEncoding) => string;
+	readonly resolveGlobalPackagePath?: (family: PackageManagerFamily, packageName: string) => string | undefined;
+	readonly resolvePrimaryPackageManager?: typeof resolvePrimaryPackageManager;
+	readonly runCommand?: (
+		command: string,
+		args: readonly string[],
+		options: DesktopCommandOptions,
+	) => Promise<DesktopCommandResult>;
+}
+
+export function detectDesktopInstall(
+	home = homedir(),
+	deps: DesktopInstallDetectionDeps = {
+		existsSync: (path) => existsSync(path),
+		readFileSync: (path, encoding) => readFileSync(path, { encoding }),
+	},
+): DesktopInstallDetection {
+	const launcherPath = join(home, ".local", "bin", "signet-desktop");
+	const appImagePath = join(home, ".local", "share", "signet", "desktop", "Signet.AppImage");
+	const launcherExists = deps.existsSync(launcherPath);
+	const appImageExists = deps.existsSync(appImagePath);
+
+	if (!launcherExists && !appImageExists) {
+		return {
+			installed: false,
+			managed: false,
+			launcherPath,
+			appImagePath,
+			reason: "Signet desktop app is not installed",
+		};
+	}
+
+	if (!launcherExists) {
+		return {
+			installed: true,
+			managed: true,
+			launcherPath,
+			appImagePath,
+			reason: "managed Signet desktop AppImage exists without a launcher",
+		};
+	}
+
+	try {
+		const launcher = deps.readFileSync(launcherPath, "utf-8");
+		return {
+			installed: true,
+			managed: launcher.includes(MANAGED_DESKTOP_LAUNCHER_MARKER),
+			launcherPath,
+			appImagePath,
+			reason: launcher.includes(MANAGED_DESKTOP_LAUNCHER_MARKER)
+				? "managed Signet desktop launcher found"
+				: "existing signet-desktop launcher is not managed by Signet",
+		};
+	} catch (error) {
+		return {
+			installed: true,
+			managed: false,
+			launcherPath,
+			appImagePath,
+			reason: `could not read Signet desktop launcher: ${error instanceof Error ? error.message : String(error)}`,
+		};
+	}
+}
+
+export function canUpdateDesktopFromSourceSync(status: WorkspaceSourceRepoSyncResult["status"]): boolean {
+	return status === "cloned" || status === "pulled" || status === "current";
+}
+
+function clipUpdateOutput(output: string): string | undefined {
+	const trimmed = output.trim();
+	if (!trimmed) return undefined;
+	return trimmed.length <= 6000 ? trimmed : trimmed.slice(-6000);
+}
+
+async function runDesktopCommand(
+	command: string,
+	args: readonly string[],
+	options: DesktopCommandOptions,
+): Promise<DesktopCommandResult> {
+	return await new Promise((resolve) => {
+		const proc = spawn(command, [...args], {
+			cwd: options.cwd,
+			env: options.env,
+			stdio: ["ignore", "pipe", "pipe"],
+			windowsHide: true,
+		});
+		let stdout = "";
+		let stderr = "";
+		let settled = false;
+		let timer: ReturnType<typeof setTimeout> | null = null;
+
+		const settle = (result: DesktopCommandResult): void => {
+			if (settled) return;
+			settled = true;
+			if (timer) clearTimeout(timer);
+			resolve(result);
+		};
+
+		timer = setTimeout(() => {
+			proc.kill("SIGKILL");
+			settle({
+				exitCode: null,
+				stdout,
+				stderr,
+				errorMessage: `desktop update exceeded ${options.timeoutMs}ms`,
+				timedOut: true,
+			});
+		}, options.timeoutMs);
+
+		proc.stdout?.on("data", (chunk: Buffer | string) => {
+			stdout += chunk.toString();
+		});
+		proc.stderr?.on("data", (chunk: Buffer | string) => {
+			stderr += chunk.toString();
+		});
+		proc.on("error", (error) => {
+			settle({
+				exitCode: null,
+				stdout,
+				stderr,
+				errorMessage: error.message,
+				timedOut: false,
+			});
+		});
+		proc.on("close", (code) => {
+			settle({
+				exitCode: code,
+				stdout,
+				stderr,
+				timedOut: false,
+			});
+		});
+	});
+}
+
+export async function updateDesktopInstallAfterUpdate(
+	repoSync: WorkspaceSourceRepoSyncResult,
+	installedVersion: string,
+	deps: DesktopUpdateDeps = {},
+): Promise<DesktopUpdateResult> {
+	const fsDeps = {
+		existsSync: deps.existsSync ?? ((path: string) => existsSync(path)),
+		readFileSync: deps.readFileSync ?? ((path: string, encoding: BufferEncoding) => readFileSync(path, { encoding })),
+	};
+	const desktop = detectDesktopInstall(deps.home ?? homedir(), fsDeps);
+	if (!desktop.installed) {
+		return { status: "skipped", message: desktop.reason ?? "Signet desktop app is not installed" };
+	}
+	if (!desktop.managed) {
+		return {
+			status: "skipped",
+			message: `${desktop.reason ?? "Signet desktop install is not managed"}. Skipping automatic desktop update.`,
+		};
+	}
+	if (!canUpdateDesktopFromSourceSync(repoSync.status)) {
+		return {
+			status: "skipped",
+			message: `Signet desktop update skipped because source checkout sync status was '${repoSync.status}': ${repoSync.message}`,
+		};
+	}
+
+	const env = deps.env ?? process.env;
+	const packageManager = (deps.resolvePrimaryPackageManager ?? resolvePrimaryPackageManager)({
+		agentsDir,
+		env,
+	});
+	const packagePath = (deps.resolveGlobalPackagePath ?? resolveGlobalPackagePath)(packageManager.family, NPM_PACKAGE);
+	if (!packagePath) {
+		return {
+			status: "error",
+			message: "Could not locate the installed signetai package to run desktop update",
+		};
+	}
+
+	const signetBin = join(packagePath, "bin", "signet.js");
+	if (!fsDeps.existsSync(signetBin)) {
+		return {
+			status: "error",
+			message: `Installed signetai package is missing CLI entrypoint at ${signetBin}`,
+		};
+	}
+
+	const command = deps.execPath ?? process.execPath;
+	const args = [signetBin, "desktop", "install", "--repo", repoSync.path];
+	const result = await (deps.runCommand ?? runDesktopCommand)(command, args, {
+		cwd: repoSync.path,
+		env: {
+			...env,
+			SIGNET_SOURCE_DIR: repoSync.path,
+		},
+		timeoutMs: deps.timeoutMs ?? DESKTOP_UPDATE_TIMEOUT_MS,
+	});
+	const output = clipUpdateOutput(`${result.stdout}\n${result.stderr}`);
+
+	if (result.exitCode !== 0) {
+		const cause = result.timedOut
+			? result.errorMessage
+			: (result.errorMessage ?? `exit ${result.exitCode ?? "unknown"}`);
+		return {
+			status: "error",
+			message: `Signet desktop update failed after installing v${installedVersion}: ${cause}`,
+			output,
+		};
+	}
+
+	return {
+		status: "updated",
+		message: `Signet desktop app updated to v${installedVersion}.`,
+		output,
+	};
+}
+
 export async function finalizeSuccessfulUpdateInstall(
 	installedVersion: string,
 	stdout: string,
 	deps: FinalizeSuccessfulUpdateDeps = {
 		syncWorkspaceSourceRepoAsync: (workspaceDir) => syncWorkspaceSourceRepoAsync(workspaceDir),
+		updateDesktopInstallAfterUpdate: (repoSync, version) => updateDesktopInstallAfterUpdate(repoSync, version),
 	},
 ): Promise<UpdateRunResult> {
 	pendingRestartVersion = installedVersion;
@@ -575,6 +812,18 @@ export async function finalizeSuccessfulUpdateInstall(
 		});
 	}
 
+	const desktopUpdate = await (deps.updateDesktopInstallAfterUpdate ?? updateDesktopInstallAfterUpdate)(
+		repoSync,
+		installedVersion,
+	);
+	if (desktopUpdate.status === "updated") {
+		logger.info("update", desktopUpdate.message);
+	} else if (desktopUpdate.status === "error") {
+		logger.warn("update", desktopUpdate.message);
+	} else {
+		logger.info("update", desktopUpdate.message);
+	}
+
 	logger.info("system", "Update installed successfully");
 	return {
 		success: true,
@@ -582,6 +831,7 @@ export async function finalizeSuccessfulUpdateInstall(
 		output: stdout,
 		installedVersion,
 		restartRequired: true,
+		desktopUpdate,
 	};
 }
 

--- a/platform/daemon/src/update-system.ts
+++ b/platform/daemon/src/update-system.ts
@@ -609,10 +609,10 @@ export function detectDesktopInstall(
 	if (!launcherExists) {
 		return {
 			installed: true,
-			managed: true,
+			managed: false,
 			launcherPath,
 			appImagePath,
-			reason: "managed Signet desktop AppImage exists without a launcher",
+			reason: "Signet desktop AppImage exists without a managed launcher",
 		};
 	}
 

--- a/surfaces/cli/src/commands/update.ts
+++ b/surfaces/cli/src/commands/update.ts
@@ -22,6 +22,8 @@ interface UpdateDeps {
 	) => { installed: string[]; updated: string[]; skipped: string[] };
 }
 
+const UPDATE_INSTALL_TIMEOUT_MS = 15 * 60_000;
+
 export function registerUpdateCommands(program: Command, deps: UpdateDeps): void {
 	const updateCmd = program.command("update").description("Check, install, and manage auto-updates");
 
@@ -115,9 +117,10 @@ export function registerUpdateCommands(program: Command, deps: UpdateDeps): void
 				message?: string;
 				output?: string;
 				restartRequired?: boolean;
+				desktopUpdate?: { status?: string; message?: string };
 			}>("/api/update/run", {
 				method: "POST",
-				timeout: 120_000,
+				timeout: UPDATE_INSTALL_TIMEOUT_MS,
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ targetVersion: check.latestVersion }),
 			});
@@ -131,6 +134,11 @@ export function registerUpdateCommands(program: Command, deps: UpdateDeps): void
 			}
 
 			spinner.succeed(data.message || "Update installed");
+			if (data.desktopUpdate?.status === "updated") {
+				console.log(chalk.green(`  ✓ ${data.desktopUpdate.message}`));
+			} else if (data.desktopUpdate?.status === "error") {
+				console.log(chalk.yellow(`  ⚠ ${data.desktopUpdate.message}`));
+			}
 			try {
 				const skillResult = deps.syncBuiltinSkills(deps.getSkillsSourceDir(), deps.AGENTS_DIR);
 				const totalSynced = skillResult.installed.length + skillResult.updated.length;

--- a/surfaces/cli/src/commands/update.ts
+++ b/surfaces/cli/src/commands/update.ts
@@ -138,6 +138,8 @@ export function registerUpdateCommands(program: Command, deps: UpdateDeps): void
 				console.log(chalk.green(`  ✓ ${data.desktopUpdate.message}`));
 			} else if (data.desktopUpdate?.status === "error") {
 				console.log(chalk.yellow(`  ⚠ ${data.desktopUpdate.message}`));
+			} else if (data.desktopUpdate?.status === "skipped") {
+				console.log(chalk.dim(`  Desktop: ${data.desktopUpdate.message}`));
 			}
 			try {
 				const skillResult = deps.syncBuiltinSkills(deps.getSkillsSourceDir(), deps.AGENTS_DIR);


### PR DESCRIPTION
## Summary

This updates Signet's update flow so users with the managed Electron desktop app installed get their desktop AppImage refreshed when Signet itself updates.

The daemon now detects a managed Linux desktop install by checking for Signet's managed `signet-desktop` launcher marker under `~/.local/bin/signet-desktop`. If the managed launcher is present, the update flow refreshes the synced Signet source checkout and runs the installed Signet CLI desktop installer against that checkout. If only an AppImage exists, or if the launcher is not Signet-managed, the desktop update is skipped instead of overwriting an unmanaged install.

The CLI update command now gives `/api/update/run` a 15 minute timeout so the desktop build/install step has enough time to complete, and it reports desktop update success or failure when the daemon returns that status.

## Why

Before this change, updating the global `signetai` package could leave the Electron desktop app on an older bundled daemon/dashboard until the user manually rebuilt and reinstalled it. Desktop users should get the matching desktop app as part of the same Signet update path.

The safety constraint is that automatic updates must only touch installs Signet owns. A manually placed AppImage or custom launcher should not be overwritten just because it lives in the same default path.

## Behavior

Managed desktop install present:

```text
signet update install
-> install updated signetai package
-> sync the workspace Signet source checkout
-> run signet desktop install --repo <synced checkout>
-> restart still required for daemon changes
```

Unmanaged or AppImage-only desktop install present:

```text
signet update install
-> install updated signetai package
-> skip desktop refresh and report why
```

## Validation

- `bun test platform/daemon/src/update-system.test.ts platform/daemon/src/update-route.test.ts surfaces/cli/src/features/desktop.test.ts`
- `bunx biome check platform/daemon/src/update-system.ts platform/daemon/src/update-system.test.ts platform/daemon/src/update-route.test.ts surfaces/cli/src/commands/update.ts docs/TRAY.md`
- `bun build platform/daemon/src/update-system.ts --outfile /tmp/signet-update-system.js --target node --external better-sqlite3`
- `bun build surfaces/cli/src/commands/update.ts --outfile /tmp/signet-update-command.js --target node`
- `git diff --check`
