### PR TITLE
perf(memory): reduce recall hot path latency

### DIFF
--- a/platform/core/src/fts-schema.ts
+++ b/platform/core/src/fts-schema.ts
@@ -35,7 +35,7 @@ export function createMemoriesFts(db: FtsSchemaExecDb): void {
 		END;
 	`);
 	db.exec(`
-		CREATE TRIGGER IF NOT EXISTS memories_au AFTER UPDATE ON memories BEGIN
+		CREATE TRIGGER IF NOT EXISTS memories_au AFTER UPDATE OF content ON memories BEGIN
 			INSERT INTO memories_fts(memories_fts, rowid, content) VALUES('delete', old.rowid, old.content);
 			INSERT INTO memories_fts(rowid, content) VALUES (new.rowid, new.content);
 		END;

--- a/platform/core/src/migrations/063-content-only-memories-fts-update.ts
+++ b/platform/core/src/migrations/063-content-only-memories-fts-update.ts
@@ -1,0 +1,18 @@
+/**
+ * Migration 063: avoid FTS churn on metadata-only memory updates.
+ *
+ * Recall updates access_count and last_accessed for returned memories. The
+ * legacy AFTER UPDATE trigger rebuilt the FTS row for every one of those
+ * metadata writes, adding avoidable latency to recall and prompt-submit. FTS
+ * content only depends on memories.content, so restrict the update trigger to
+ * content changes.
+ */
+export function up(db: { exec(sql: string): void }): void {
+	db.exec("DROP TRIGGER IF EXISTS memories_au");
+	db.exec(`
+		CREATE TRIGGER IF NOT EXISTS memories_au AFTER UPDATE OF content ON memories BEGIN
+			INSERT INTO memories_fts(memories_fts, rowid, content) VALUES('delete', old.rowid, old.content);
+			INSERT INTO memories_fts(rowid, content) VALUES (new.rowid, new.content);
+		END;
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -68,6 +68,7 @@ import { up as entityAttributeClaimKey } from "./059-entity-attribute-claim-key"
 import { up as entityAttributeGroupKey } from "./060-entity-attribute-group-key";
 import { up as memoryArtifactSourceMtime } from "./061-memory-artifact-source-mtime";
 import { up as memoryArtifactSoftDelete } from "./062-memory-artifact-soft-delete";
+import { up as contentOnlyMemoriesFtsUpdate } from "./063-content-only-memories-fts-update";
 
 // -- Public interface consumed by Database.init() --
 
@@ -590,6 +591,11 @@ export const MIGRATIONS: readonly Migration[] = [
 				{ table: "memory_artifacts", column: "deleted_at" },
 			],
 		},
+	},
+	{
+		version: 63,
+		name: "content-only-memories-fts-update",
+		up: contentOnlyMemoriesFtsUpdate,
 	},
 ];
 

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -1055,4 +1055,48 @@ describe("migration framework", () => {
 		expect(after).toContain("We celebrate wins together");
 		expect(after).not.toContain("Celebrity filter blocks face likenesses");
 	});
+
+	test("migration 063 limits memories_fts updates to content changes", () => {
+		db = createFreshDb();
+		runMigrations(db);
+
+		const trigger = db
+			.query<{ sql: string }, []>("SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = 'memories_au'")
+			.get();
+		expect(trigger?.sql).toContain("AFTER UPDATE OF content ON memories");
+
+		db.exec(`
+			INSERT INTO memories (id, content, type, confidence, access_count, created_at, updated_at, updated_by)
+			VALUES ('mem-fts-access', 'recall access tracking should stay searchable', 'fact', 0.9, 0, datetime('now'), datetime('now'), 'test')
+		`);
+
+		db.prepare("UPDATE memories SET access_count = access_count + 1 WHERE id = ?").run("mem-fts-access");
+		expect(
+			db
+				.query<{ id: string }, [string]>(
+					`SELECT m.id
+					 FROM memories_fts
+					 JOIN memories m ON memories_fts.rowid = m.rowid
+					 WHERE memories_fts MATCH ?`,
+				)
+				.all("searchable")
+				.map((row) => row.id),
+		).toContain("mem-fts-access");
+
+		db.prepare("UPDATE memories SET content = ? WHERE id = ?").run(
+			"content updates still refresh searchable text",
+			"mem-fts-access",
+		);
+		expect(
+			db
+				.query<{ id: string }, [string]>(
+					`SELECT m.id
+					 FROM memories_fts
+					 JOIN memories m ON memories_fts.rowid = m.rowid
+					 WHERE memories_fts MATCH ?`,
+				)
+				.all("refresh")
+				.map((row) => row.id),
+		).toContain("mem-fts-access");
+	});
 });

--- a/platform/daemon/src/memory-search.bench.ts
+++ b/platform/daemon/src/memory-search.bench.ts
@@ -1,0 +1,182 @@
+/**
+ * Benchmark: hybrid recall search latency.
+ *
+ * Measures the shared hot path used by explicit recall and
+ * user-prompt-submit. The benchmark uses a synthetic local workspace so it can
+ * be run before and after search changes without touching real memory data.
+ *
+ * Run:
+ *   bun run build:core
+ *   bun run platform/daemon/src/memory-search.bench.ts
+ *
+ * Knobs:
+ *   SIGNET_RECALL_BENCH_MEMORIES=2000
+ *   SIGNET_RECALL_BENCH_ITERS=60
+ *   SIGNET_RECALL_BENCH_EMBED_MS=40
+ */
+
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { loadMemoryConfig } from "./memory-config";
+import { hybridRecall } from "./memory-search";
+
+const TEST_DIR = join(tmpdir(), `signet-recall-bench-${Date.now()}`);
+const MEMORY_COUNT = parseEnvInt("SIGNET_RECALL_BENCH_MEMORIES", 2000);
+const ITERS = parseEnvInt("SIGNET_RECALL_BENCH_ITERS", 60);
+const EMBED_MS = parseEnvInt("SIGNET_RECALL_BENCH_EMBED_MS", 40);
+const QUERY = "signet memory search performance prompt submit recall";
+
+process.env.SIGNET_PATH = TEST_DIR;
+
+function parseEnvInt(name: string, fallback: number): number {
+	const raw = process.env[name];
+	if (!raw) return fallback;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function setupWorkspace(): void {
+	mkdirSync(join(TEST_DIR, "memory"), { recursive: true });
+	writeFileSync(
+		join(TEST_DIR, "agent.yaml"),
+		[
+			"name: RecallBench",
+			"search:",
+			"  top_k: 20",
+			"  min_score: 0.1",
+			"embedding:",
+			"  provider: none",
+			"  model: bench",
+			"  dimensions: 768",
+			"memory:",
+			"  pipelineV2:",
+			"    graph:",
+			"      enabled: true",
+			"    traversal:",
+			"      enabled: true",
+			"      primary: true",
+			"    hints:",
+			"      enabled: true",
+			"    reranker:",
+			"      enabled: true",
+			"",
+		].join("\n"),
+	);
+
+	const dbPath = join(TEST_DIR, "memory", "memories.db");
+	if (existsSync(dbPath)) rmSync(dbPath);
+	initDbAccessor(dbPath);
+
+	const now = new Date().toISOString();
+	getDbAccessor().withWriteTx((db) => {
+		const memoryStmt = db.prepare(
+			`INSERT INTO memories (
+				id, content, type, agent_id, importance, created_at, updated_at, updated_by
+			) VALUES (?, ?, 'fact', 'default', ?, ?, ?, 'bench')`,
+		);
+		const hintStmt = db.prepare(
+			`INSERT INTO memory_hints (id, memory_id, agent_id, hint, created_at)
+			 VALUES (?, ?, 'default', ?, ?)`,
+		);
+		const mentionStmt = db.prepare("INSERT INTO memory_entity_mentions (memory_id, entity_id) VALUES (?, ?)");
+
+		db.prepare(
+			`INSERT INTO entities (
+				id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at
+			) VALUES (?, ?, ?, 'project', 'default', ?, ?, ?)`,
+		).run("ent-signet", "Signet", "signet", MEMORY_COUNT, now, now);
+
+		for (let i = 0; i < MEMORY_COUNT; i++) {
+			const id = `bench-mem-${String(i).padStart(5, "0")}`;
+			const topic =
+				i % 3 === 0
+					? "prompt submit recall latency"
+					: i % 3 === 1
+						? "memory search performance"
+						: "agent context retrieval";
+			memoryStmt.run(
+				id,
+				`Signet ${topic} benchmark memory ${i}. This record keeps recall behavior measurable under lexical, hint, and traversal search.`,
+				0.3 + (i % 7) * 0.08,
+				now,
+				now,
+			);
+			if (i < 200) {
+				hintStmt.run(`hint-${id}`, id, `How fast is Signet ${topic}?`, now);
+				mentionStmt.run(id, "ent-signet");
+			}
+		}
+	});
+}
+
+async function fakeEmbedding(): Promise<number[]> {
+	await Bun.sleep(EMBED_MS);
+	return Array.from({ length: 768 }, (_, index) => (index % 17) / 17);
+}
+
+interface Stats {
+	readonly avg: number;
+	readonly p50: number;
+	readonly p95: number;
+	readonly min: number;
+	readonly max: number;
+}
+
+function stats(times: readonly number[]): Stats {
+	const sorted = [...times].sort((a, b) => a - b);
+	const sum = sorted.reduce((acc, value) => acc + value, 0);
+	return {
+		avg: sum / sorted.length,
+		p50: sorted[Math.floor(sorted.length * 0.5)] ?? 0,
+		p95: sorted[Math.floor(sorted.length * 0.95)] ?? 0,
+		min: sorted[0] ?? 0,
+		max: sorted[sorted.length - 1] ?? 0,
+	};
+}
+
+function printStats(label: string, result: Stats): void {
+	console.log(`\n${label}`);
+	console.log("=".repeat(64));
+	console.log(
+		`avg ${result.avg.toFixed(2)}ms | p50 ${result.p50.toFixed(2)}ms | p95 ${result.p95.toFixed(2)}ms | min ${result.min.toFixed(2)}ms | max ${result.max.toFixed(2)}ms`,
+	);
+}
+
+setupWorkspace();
+const cfg = loadMemoryConfig(TEST_DIR);
+const params = {
+	query: QUERY,
+	keywordQuery: QUERY,
+	limit: 10,
+	agentId: "default",
+	readPolicy: "isolated",
+} as const;
+
+console.log("\nHybrid recall latency benchmark");
+console.log("=".repeat(64));
+console.log(`workspace: ${TEST_DIR}`);
+console.log(`memories: ${MEMORY_COUNT}`);
+console.log(`iterations: ${ITERS}`);
+console.log(`synthetic embedding delay: ${EMBED_MS}ms`);
+
+for (let i = 0; i < 5; i++) {
+	await hybridRecall(params, cfg, fakeEmbedding);
+}
+
+const times: number[] = [];
+let ids = "";
+for (let i = 0; i < ITERS; i++) {
+	const start = performance.now();
+	const result = await hybridRecall(params, cfg, fakeEmbedding);
+	times.push(performance.now() - start);
+	if (i === 0) ids = result.results.map((row) => row.id).join(", ");
+}
+
+printStats("hybridRecall", stats(times));
+console.log(`first result ids: ${ids}`);
+
+closeDbAccessor();
+if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true, force: true });
+process.exit(0);

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -129,6 +129,33 @@ describe("hybridRecall", () => {
 		});
 	});
 
+	it("falls back to keyword recall when embedding throws synchronously", async () => {
+		const now = new Date().toISOString();
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, type, agent_id, created_at, updated_at, updated_by
+				) VALUES (?, ?, 'fact', 'default', ?, ?, 'test')`,
+			).run("mem-keyword-sync-throw", "keyword-only recall survives embedding failure", now, now);
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "keyword-only recall",
+				keywordQuery: "keyword-only recall",
+				limit: 5,
+				agentId: "default",
+				readPolicy: "isolated",
+			},
+			loadMemoryConfig(dir),
+			() => {
+				throw new Error("embedding unavailable");
+			},
+		);
+
+		expect(result.results.map((row) => row.id)).toContain("mem-keyword-sync-throw");
+	});
+
 	it("recalls indexed native harness memory artifacts without materializing memories", async () => {
 		const codexMemoryPath = join(dir, "codex", "memories", "MEMORY.md");
 		mkdirSync(join(dir, "codex", "memories"), { recursive: true });

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -869,6 +869,30 @@ export async function hybridRecall(
 
 	const filter = buildFilterClause(params);
 	const scoped = params.scope !== undefined;
+	const queryVecPromise = (() => {
+		try {
+			return Promise.resolve(embedFn(query, cfg.embedding));
+		} catch (e) {
+			return Promise.reject(e);
+		}
+	})();
+	let graphQueryTokens: string[] | undefined;
+	let focalCache: { agentId: string; value: ReturnType<typeof resolveFocalEntities> } | null = null;
+	const getGraphQueryTokens = (): string[] => {
+		graphQueryTokens ??= tokenizeGraphQuery(query);
+		return graphQueryTokens;
+	};
+	const getFocalEntities = (agentId: string): ReturnType<typeof resolveFocalEntities> => {
+		if (focalCache?.agentId === agentId) return focalCache.value;
+		const value = getDbAccessor().withReadDb((db) =>
+			resolveFocalEntities(db, agentId, {
+				queryTokens: getGraphQueryTokens(),
+				includePinned: false,
+			}),
+		);
+		focalCache = { agentId, value };
+		return value;
+	};
 
 	// --- BM25 keyword search via FTS5 ---
 	const bm25Map = new Map<string, number>();
@@ -952,9 +976,13 @@ export async function hybridRecall(
 	}
 
 	// --- Query embedding (used by reranker even when vector search is skipped) ---
+	// Start embedding before the synchronous lexical/structured DB work above.
+	// Local embedding providers are often the slowest prompt-submit step, so
+	// overlapping that I/O with candidate lookup reduces wall-clock latency
+	// without changing the recall channels or final ranking math.
 	let queryVecF32: Float32Array | null = null;
 	try {
-		const queryVec = await embedFn(query, cfg.embedding);
+		const queryVec = await queryVecPromise;
 		if (queryVec) queryVecF32 = new Float32Array(queryVec);
 	} catch (e) {
 		logger.warn("memory", "Embedding failed", { error: String(e) });
@@ -1063,15 +1091,10 @@ export async function hybridRecall(
 		if (cfg.pipelineV2.traversal) {
 			try {
 				const traversalCfg = cfg.pipelineV2.traversal;
-				const queryTokens = tokenizeGraphQuery(query);
+				const queryTokens = getGraphQueryTokens();
 				if (queryTokens.length > 0) {
 					const agentId = params.agentId ?? "default";
-					const focal = getDbAccessor().withReadDb((db) =>
-						resolveFocalEntities(db, agentId, {
-							queryTokens,
-							includePinned: false,
-						}),
-					);
+					const focal = getFocalEntities(agentId);
 
 					if (focal.entityIds.length > 0) {
 						const traversal = getDbAccessor().withReadDb((db) =>
@@ -1201,15 +1224,10 @@ export async function hybridRecall(
 		if (cfg.pipelineV2.graph.enabled && cfg.pipelineV2.traversal?.enabled) {
 			try {
 				const traversalCfg = cfg.pipelineV2.traversal;
-				const queryTokens = tokenizeGraphQuery(query);
+				const queryTokens = getGraphQueryTokens();
 				if (queryTokens.length > 0) {
 					const agentId = params.agentId ?? "default";
-					const focal = getDbAccessor().withReadDb((db) =>
-						resolveFocalEntities(db, agentId, {
-							queryTokens,
-							includePinned: false,
-						}),
-					);
+					const focal = getFocalEntities(agentId);
 
 					if (focal.entityIds.length > 0) {
 						const traversal = getDbAccessor().withReadDb((db) =>
@@ -1917,14 +1935,11 @@ export async function hybridRecall(
 
 	if (cfg.pipelineV2.graph.enabled && cfg.pipelineV2.traversal?.enabled) {
 		try {
-			const queryTokens = tokenizeGraphQuery(query);
+			const queryTokens = getGraphQueryTokens();
 			if (queryTokens.length > 0) {
 				const agentId = params.agentId ?? "default";
+				const focal = getFocalEntities(agentId);
 				const ctx = getDbAccessor().withReadDb((db) => {
-					const focal = resolveFocalEntities(db, agentId, {
-						queryTokens,
-						includePinned: false,
-					});
 					if (focal.entityIds.length === 0) return null;
 
 					// Scope-filter: only include entities mentioned in


### PR DESCRIPTION
## Summary

Start recall embeddings eagerly before synchronous lexical and structured DB candidate lookup, so prompt-submit and recall can overlap provider latency with local search work. This also caches graph query tokenization and focal entity resolution inside a single hybrid recall call, and avoids unnecessary memories FTS rebuilds when recall only updates metadata like `access_count` and `last_accessed`.

## Changes

- `platform/daemon/src/memory-search.ts`: start query embedding immediately, preserve keyword fallback when embedding fails, and cache per-call graph helpers.
- `platform/core/src/fts-schema.ts`: make the memories FTS update trigger content-only for new databases.
- `platform/core/src/migrations/063-content-only-memories-fts-update.ts`: migrate existing databases to the content-only trigger.
- `platform/daemon/src/memory-search.bench.ts`: add a repeatable before/after benchmark for recall latency.
- `platform/daemon/src/memory-search.test.ts` and `platform/core/src/migrations/migrations.test.ts`: add regression coverage for embedding fallback and metadata-only FTS updates.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [x] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

N/A, no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Migration 063 only replaces the `memories_au` trigger with the same content-only definition used for new databases. It is idempotent because it drops and recreates the trigger. Rollback is compatible with older daemon behavior by restoring the broader `AFTER UPDATE ON memories` trigger, though that reintroduces metadata-only FTS churn. Daemon Rust parity is N/A because this changes SQLite migration/schema behavior shared by the database, not a separate Rust runtime implementation path.

## Measurement

Synthetic benchmark, 2,000 memories, 40 ms embedding delay:

- Before: avg 746.18 ms, p50 742.65 ms, p95 842.41 ms.
- After: avg 622.66 ms, p50 618.25 ms, p95 653.39 ms.

The benchmark preserved the same first result IDs across before and after runs.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Validated locally with:

- `bun run build:core`
- `bun scripts/spec-deps-check.ts`
- `bunx biome check platform/daemon/src/memory-search.ts platform/daemon/src/memory-search.test.ts platform/daemon/src/memory-search.bench.ts platform/core/src/fts-schema.ts platform/core/src/migrations/063-content-only-memories-fts-update.ts platform/core/src/migrations/index.ts platform/core/src/migrations/migrations.test.ts`
- `timeout 120s bun test platform/core/src/migrations/migrations.test.ts platform/daemon/src/memory-search.test.ts`
- `git diff --check`

Note: `platform/daemon` `build:types` still fails from existing rootDir/test inclusion and unrelated daemon type errors, not from this patch. `bun run build:core` includes the affected core declaration build.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

PR feedback addressed in the latest push: query embedding is now invoked eagerly with sync throw conversion, and the migration header now matches migration 063.