### PR TITLE
feat(hooks): surface active peer sessions

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -141,14 +141,17 @@ where recency is `1 / (1 + age_in_days)`.
 Called before each user turn is handed to the model. Returns lightweight
 context for the current prompt.
 
-The hook always includes current date/time metadata and per-turn Memory Check
-guidance unless the session is bypassed. When automatic recall finds useful
-context, the response also includes a `## Relevant Memory` block. When no
-strong automatic match is found, the response says so explicitly and reminds
-the agent to run targeted Signet recall before acting if the request depends
-on prior context, preferences, project history, or unresolved work. Both
-matched and no-strong-match paths also remind the agent to save durable facts
-with `/remember` or `memory_store`.
+The hook always includes current date/time metadata, active peer-session
+visibility, and per-turn Memory Check guidance unless the session is bypassed.
+Peer visibility is intentionally compact: it reports how many other Signet
+sessions are currently active, which apps they are in, and which are in the
+same project, with `agent_peers` available for the full live list. When
+automatic recall finds useful context, the response also includes a
+`## Relevant Memory` block. When no strong automatic match is found, the
+response says so explicitly and reminds the agent to run targeted Signet recall
+before acting if the request depends on prior context, preferences, project
+history, or unresolved work. Both matched and no-strong-match paths also remind
+the agent to save durable facts with `/remember` or `memory_store`.
 
 Recall order is:
 

--- a/docs/research/technical/RESEARCH-CROSS-SESSION-VISIBILITY.md
+++ b/docs/research/technical/RESEARCH-CROSS-SESSION-VISIBILITY.md
@@ -1,0 +1,50 @@
+---
+id: RESEARCH-CROSS-SESSION-VISIBILITY
+question: "How should Signet expose live and historical cross-session visibility without flooding prompt context or violating scope boundaries?"
+status: adopted
+updated: 2026-04-26
+---
+
+# Cross-Session Visibility Research
+
+## Question
+
+How should Signet expose live and historical cross-session visibility without
+flooding prompt context or violating scope boundaries?
+
+## Reference
+
+Hermes Agent provides a useful reference pattern. It separates cheap session
+awareness from deeper transcript search. The default path can list recent or
+active sessions with lightweight metadata, while deeper search is an explicit
+tool call that searches stored session transcripts, groups by session, excludes
+the current lineage, and summarizes only the matching sessions.
+
+The important design lesson is not the specific implementation language. It is
+the shape of the interface: agents should first know that other sessions exist,
+which app or surface they are in, and whether they are likely relevant. Only
+then should they spend context or model calls on transcript search.
+
+## Adopted Direction
+
+Signet should keep prompt-submit visibility compact and live. Prompt-submit may
+surface the number of active peer sessions, the apps those sessions are in, and
+which sessions share the current project. This should stay cheap, bounded, and
+safe by default.
+
+Deeper cross-session work should move into explicit tools and APIs. A future
+session browser/search surface should list recent and live sessions first, then
+allow scoped search over summaries and transcripts. Ongoing transcript search
+must respect agent scope, visibility, project boundaries, and session lineage.
+
+## Requirements Captured
+
+- Prompt-submit visibility is a hint, not the full browser.
+- Active peer visibility should include app identity, not only raw harness name.
+- Session search should support live sessions, recent sessions, summaries, and
+  transcript excerpts under policy.
+- Cross-session transcript search needs explicit RBAC and project/agent scope
+  controls before broad rollout.
+- Prompt budget and display limits must be configurable so many active agents do
+  not produce noisy context.
+

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -107,6 +107,9 @@ flowchart TD
   MP --> RDC
   DP --> DMS
   SSF --> DMS
+  MA --> CSV
+  SCP --> CSV
+  DMS -.-> CSV
   SR --> MCB
   PAF --> GMM
   PM --> ASL
@@ -153,6 +156,7 @@ and market subdirectories). Reference repos live in `references/`.
 | `dreaming-memory-consolidation` | LCM-PATTERNS, memory-pipeline-plan, knowledge-architecture-schema | How should Signet consolidate accumulated session knowledge into a cleaner entity graph during idle periods? |
 | `native-harness-memory-bridge` | RESEARCH-NATIVE-HARNESS-MEMORY-BRIDGE | How should Signet make harness-native memories portable without duplicating each harness's memory pipeline? |
 | `model-provider-router` | RESEARCH-INFERENCE-CONTROL-PLANE, RESEARCH-COMPETITIVE-SYSTEMS | How should Signet centralize inference across harnesses, daemon workloads, and heterogeneous provider backends under one policy surface? |
+| `cross-session-visibility-and-search` | RESEARCH-CROSS-SESSION-VISIBILITY | How should Signet expose live and historical cross-session visibility without flooding prompt context or violating scope boundaries? |
 
 ### Research Adoption Ledger (high-impact)
 
@@ -654,6 +658,9 @@ Phase ordering based on hard dependencies and integration contracts.
   - parity completion and primary-runtime switch strategy
 - **Deep Memory Search** (`deep-memory-search`)
   - optional multi-agent LLM memory search path (not primary retrieval)
+- **Cross-Session Visibility and Search** (`cross-session-visibility-and-search`)
+  - live peer-session visibility, recent-session browser, and scoped transcript or summary search
+  - reference inspiration: Hermes Agent session search and recent-session metadata flow
 - **MCP CLI Bridge and Usage Analytics** (`mcp-cli-bridge-and-usage-analytics`)
   - expose installed MCP servers as Signet CLI commands and track usage in dashboard
   - reference inspiration: MC Porter
@@ -764,6 +771,7 @@ Legend:
 | `remember-recall-skill-parity` | planning | `docs/specs/planning/remember-recall-skill-parity.md` | `procedural-memory-plan` | - | Stub: /remember and /recall architecture/schema parity |
 | `rust-daemon-parity-cutover` | planning | `docs/specs/planning/rust-daemon-parity-cutover.md` | `daemon-rust-rewrite`, `memory-pipeline-v2` | - | Stub: rust daemon parity and primary-runtime cutover |
 | `deep-memory-search` | planning | `docs/specs/planning/deep-memory-search.md` | `desire-paths-epic`, `ssm-foundation-evaluation` | - | Stub: optional supermemory-style deep memory escalation |
+| `cross-session-visibility-and-search` | planning | `docs/specs/planning/cross-session-visibility-and-search.md` | `multi-agent-support`, `session-continuity-protocol`, `jsonl-transcript-source-of-truth` | - | Durable session registry over live presence and canonical JSONL transcripts, with compact prompt-submit peer visibility plus explicit scoped summary/transcript search. |
 | `mcp-cli-bridge-and-usage-analytics` | approved | `docs/specs/approved/mcp-cli-bridge-and-usage-analytics.md` | `signet-runtime` | - | Phase 1: CLI bridge, invocation tracking, analytics API, dashboard panel |
 | `overview-usage-analytics` | approved | `docs/specs/approved/overview-usage-analytics.md` | `mcp-cli-bridge-and-usage-analytics`, `procedural-memory-plan` | - | Home overview card ranks most-used MCP servers and skills from real analytics instead of catalog popularity |
 | `git-marketplace-monorepo` | planning | `docs/specs/planning/git-marketplace-monorepo.md` | `predictor-agent-feedback` | - | Stub: GitHub-authenticated PR marketplace for skills and MCP servers |
@@ -841,6 +849,11 @@ independent of harness-specific connectors.
 
 **multi-agent-support**: Multiple agents share one SQLite database
 without data collision via agent_id scoping.
+
+**cross-session-visibility-and-search**: Agents can see compact live
+peer-session visibility during prompt-submit from a durable session registry,
+then explicitly list or search recent/live session summaries and canonical JSONL
+transcript excerpts under agent scope, visibility, project, and lineage policy.
 
 **sub-agent-context-continuity**: Parent session transcript is queryable during active sessions, and sub-agents inherit deterministic parent context with no LLM call.
 

--- a/docs/specs/dependencies.yaml
+++ b/docs/specs/dependencies.yaml
@@ -834,6 +834,28 @@ specs:
     decision: null
 
 
+  - id: cross-session-visibility-and-search
+    status: planning
+    path: docs/specs/planning/cross-session-visibility-and-search.md
+    hard_depends_on:
+      - multi-agent-support
+      - session-continuity-protocol
+      - jsonl-transcript-source-of-truth
+    soft_depends_on:
+      - deep-memory-search
+      - transcript-surface-separation
+    blocks: []
+    informed_by:
+      - docs/research/technical/RESEARCH-CROSS-SESSION-VISIBILITY.md
+    success_criteria:
+      - "Agents see compact live peer-session visibility during prompt-submit without materially increasing prompt noise"
+      - "Agents can explicitly list recent and active sessions with app, project, age, lifecycle status, end reason, and canonical transcript pointer"
+      - "Agents can search session summaries and transcript excerpts under the same agent scope and visibility rules as memory recall"
+      - "Ongoing transcript search reads from canonical JSONL or derived transcript indexes and cannot expose another agent's private session data across policy boundaries"
+      - "Operators can tune or disable prompt-submit peer visibility separately from explicit session search"
+    decision: null
+
+
   - id: mcp-cli-bridge-and-usage-analytics
     status: approved
     path: docs/specs/approved/mcp-cli-bridge-and-usage-analytics.md

--- a/docs/specs/planning/cross-session-visibility-and-search.md
+++ b/docs/specs/planning/cross-session-visibility-and-search.md
@@ -1,0 +1,66 @@
+---
+id: cross-session-visibility-and-search
+status: planning
+title: Cross-Session Visibility and Search
+informed_by:
+  - docs/research/technical/RESEARCH-CROSS-SESSION-VISIBILITY.md
+---
+
+# Cross-Session Visibility and Search
+
+## Problem
+
+Signet now has canonical JSONL transcripts and live cross-agent presence, but
+the agent experience is still too thin. Agents can miss that related work is
+happening in another active session, and there is no first-class equivalent of
+a session browser that starts with cheap metadata and escalates to scoped
+transcript or summary search only when needed.
+
+## Direction
+
+The prompt-submit hook should remain lightweight. It can show bounded peer
+session visibility from a durable session registry: how many peer sessions are
+active, which app or harness they are in, whether any share the current project,
+and which MCP tools can inspect or coordinate with them. Live presence is only
+a cache over the registry, not the source of truth.
+
+Canonical JSONL transcripts are the transcript substrate. Prompt-submit appends
+live turns, session-end replaces the final session slice, and the registry keeps
+the session lifecycle pointer: app identity, project, started/last-seen/ended
+times, status, end reason, and transcript location. A session without a stable
+session key or session id can be shown as ephemeral live presence, but should
+not become durable history until the harness provides a stable identifier.
+
+The deeper surface should be explicit. A future MCP/API layer should support a
+session browser and session search flow that can list live sessions, list recent
+sessions, search summaries, and search transcript excerpts. Search must exclude
+or de-emphasize the current lineage unless explicitly requested.
+
+## Open Requirements
+
+1. Add a configurable prompt budget and display limit for live peer visibility.
+2. Keep explicit app identity metadata in the durable session registry, with
+   live presence as a short-lived cache for coordination.
+3. Use canonical JSONL transcript paths as the transcript pointer for active and
+   ended sessions.
+4. Add a scoped session browser/search MCP tool for live and historical sessions.
+5. Support ongoing transcript search for active sessions where canonical JSONL
+   has live prompt-submit turns before session-end.
+6. Enforce agent scope, memory visibility, project boundaries, and lineage rules
+   before exposing transcript search broadly.
+7. Document the fallback hierarchy: live peer metadata first, recent session
+   metadata second, summary search third, transcript search last.
+
+## Success Criteria
+
+- Agents see compact live peer-session visibility during prompt-submit without
+  materially increasing prompt noise.
+- Agents can explicitly list recent and active sessions with app, project, age,
+  lifecycle status, end reason, and canonical transcript pointer.
+- Agents can search session summaries and transcript excerpts under the same
+  agent scope and visibility rules as memory recall.
+- Ongoing transcript search reads from canonical JSONL or derived transcript
+  indexes and cannot expose another agent's private session data across policy
+  boundaries.
+- Operators can tune or disable prompt-submit peer visibility separately from
+  explicit session search.

--- a/platform/core/src/migrations/064-session-registry.ts
+++ b/platform/core/src/migrations/064-session-registry.ts
@@ -1,0 +1,47 @@
+/**
+ * Migration 064: durable session registry.
+ *
+ * Cross-agent presence is intentionally live and in-memory. This registry gives
+ * sessions a durable lifecycle row that can point at the canonical JSONL
+ * transcript substrate and survive daemon restarts.
+ */
+export function up(db: { exec(sql: string): void }): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS session_registry (
+			id TEXT PRIMARY KEY,
+			agent_id TEXT NOT NULL DEFAULT 'default',
+			session_key TEXT,
+			session_id TEXT,
+			harness TEXT NOT NULL,
+			app_id TEXT NOT NULL,
+			app_label TEXT NOT NULL,
+			project TEXT,
+			cwd TEXT,
+			runtime_path TEXT,
+			provider TEXT,
+			status TEXT NOT NULL DEFAULT 'active',
+			started_at TEXT NOT NULL,
+			last_seen_at TEXT NOT NULL,
+			ended_at TEXT,
+			end_reason TEXT,
+			transcript_path TEXT,
+			updated_at TEXT NOT NULL,
+			CHECK (status IN ('active', 'ended', 'stale')),
+			CHECK (runtime_path IS NULL OR runtime_path IN ('plugin', 'legacy'))
+		);
+
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_session_registry_agent_harness_session_key
+			ON session_registry(agent_id, harness, session_key)
+			WHERE session_key IS NOT NULL;
+
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_session_registry_agent_harness_session_id
+			ON session_registry(agent_id, harness, session_id)
+			WHERE session_id IS NOT NULL;
+
+		CREATE INDEX IF NOT EXISTS idx_session_registry_active
+			ON session_registry(agent_id, status, last_seen_at DESC);
+
+		CREATE INDEX IF NOT EXISTS idx_session_registry_project
+			ON session_registry(agent_id, project, status, last_seen_at DESC);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -69,6 +69,7 @@ import { up as entityAttributeGroupKey } from "./060-entity-attribute-group-key"
 import { up as memoryArtifactSourceMtime } from "./061-memory-artifact-source-mtime";
 import { up as memoryArtifactSoftDelete } from "./062-memory-artifact-soft-delete";
 import { up as contentOnlyMemoriesFtsUpdate } from "./063-content-only-memories-fts-update";
+import { up as sessionRegistry } from "./064-session-registry";
 
 // -- Public interface consumed by Database.init() --
 
@@ -596,6 +597,14 @@ export const MIGRATIONS: readonly Migration[] = [
 		version: 63,
 		name: "content-only-memories-fts-update",
 		up: contentOnlyMemoriesFtsUpdate,
+	},
+	{
+		version: 64,
+		name: "session-registry",
+		up: sessionRegistry,
+		artifacts: {
+			tables: ["session_registry"],
+		},
 	},
 ];
 

--- a/platform/daemon/src/hooks.prompt-submit.test.ts
+++ b/platform/daemon/src/hooks.prompt-submit.test.ts
@@ -2,10 +2,7 @@ import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { handleUserPromptSubmit } from "./hooks";
-import { SIGNET_SECRETS_PLUGIN_ID, getDefaultPluginHost, resetDefaultPluginHostForTests } from "./plugins/index";
-
-type PromptDeps = Required<NonNullable<Parameters<typeof handleUserPromptSubmit>[1]>>;
+import { resetCrossAgentStateForTest, upsertAgentPresence } from "./cross-agent";
 
 const originalSignetPath = process.env.SIGNET_PATH;
 const agentsDir = mkdtempSync(join(tmpdir(), "signet-hooks-prompt-submit-"));
@@ -15,6 +12,15 @@ const memoryDbPath = join(memoryDir, "memories.db");
 mkdirSync(memoryDir, { recursive: true });
 writeFileSync(memoryDbPath, "");
 process.env.SIGNET_PATH = agentsDir;
+
+const { handleUserPromptSubmit } = await import("./hooks");
+const { closeDbAccessor, initDbAccessor } = await import("./db-accessor");
+const { upsertSessionRegistry } = await import("./session-registry");
+const { SIGNET_SECRETS_PLUGIN_ID, getDefaultPluginHost, resetDefaultPluginHostForTests } = await import(
+	"./plugins/index"
+);
+
+type PromptDeps = Required<NonNullable<Parameters<typeof handleUserPromptSubmit>[1]>>;
 
 const infoMock = mock((_cat: string, _msg: string, _data?: Record<string, unknown>) => {});
 const warnMock = mock((..._args: unknown[]) => {});
@@ -131,18 +137,206 @@ describe("handleUserPromptSubmit observability", () => {
 		searchTemporalFallbackMock.mockImplementation(() => emptyTemporalHits);
 		searchTranscriptFallbackMock.mockClear();
 		searchTranscriptFallbackMock.mockImplementation(() => emptyTranscriptHits);
+		closeDbAccessor();
+		rmSync(memoryDbPath, { force: true });
 		ensureMemoryDbExists();
+		initDbAccessor(memoryDbPath, { agentsDir });
+		resetCrossAgentStateForTest();
 		resetDefaultPluginHostForTests();
 		getDefaultPluginHost().setEnabled(SIGNET_SECRETS_PLUGIN_ID, true);
 	});
 
 	afterAll(() => {
+		closeDbAccessor();
 		rmSync(agentsDir, { recursive: true, force: true });
+		resetCrossAgentStateForTest();
 		if (originalSignetPath === undefined) {
 			Reflect.deleteProperty(process.env, "SIGNET_PATH");
 		} else {
 			process.env.SIGNET_PATH = originalSignetPath;
 		}
+	});
+
+	it("includes active peer session visibility on prompt submit", async () => {
+		upsertAgentPresence({
+			sessionKey: "current-session",
+			agentId: "default",
+			harness: "codex",
+			project: "/repo",
+		});
+		upsertAgentPresence({
+			sessionKey: "peer-hermes",
+			agentId: "default",
+			harness: "hermes-agent",
+			project: "/repo",
+		});
+		upsertAgentPresence({
+			sessionKey: "peer-claude",
+			agentId: "default",
+			harness: "claude-code",
+			project: "/other",
+		});
+
+		const result = await handleUserPromptSubmit(
+			{
+				harness: "codex",
+				userMessage: "   ",
+				sessionKey: "current-session",
+				project: "/repo",
+			},
+			makeDeps(),
+		);
+
+		expect(result.inject).toContain("## Active Peer Sessions");
+		expect(result.inject).toContain("Showing 2 active peer sessions");
+		expect(result.inject).toContain("Hermes Agent 1");
+		expect(result.inject).toContain("Claude Code 1");
+		expect(result.inject).toContain("1 in this project");
+		expect(result.inject).toContain("Hermes Agent: default session=peer-hermes, this project");
+		expect(result.inject).not.toContain("session=current-session");
+		expect(result.inject).not.toContain("project=/other");
+		expect(result.inject).toContain("use `agent_peers` for the full live list");
+	});
+
+	it("deduplicates the same peer reported by durable registry and live presence", async () => {
+		upsertSessionRegistry({
+			sessionKey: "peer-hermes",
+			agentId: "default",
+			harness: "hermes-agent",
+			project: "/repo",
+		});
+		upsertAgentPresence({
+			sessionKey: "peer-hermes",
+			agentId: "default",
+			harness: "hermes-agent",
+			project: "/repo",
+		});
+
+		const result = await handleUserPromptSubmit(
+			{
+				harness: "codex",
+				userMessage: "   ",
+				sessionKey: "current-session",
+				project: "/repo",
+			},
+			makeDeps(),
+		);
+
+		expect(result.inject).toContain("Showing 1 active peer session");
+		expect(result.inject).toContain("Hermes Agent 1");
+		expect(result.inject.match(/session=peer-hermes/g) ?? []).toHaveLength(1);
+	});
+
+	it("deduplicates session-id-only peers reported by durable registry and live presence", async () => {
+		upsertSessionRegistry({
+			sessionId: "legacy-session-id",
+			agentId: "default",
+			harness: "hermes-agent",
+			project: "/repo",
+		});
+		upsertAgentPresence({
+			sessionKey: "legacy-session-id",
+			agentId: "default",
+			harness: "hermes-agent",
+			project: "/repo",
+		});
+
+		const result = await handleUserPromptSubmit(
+			{
+				harness: "codex",
+				userMessage: "   ",
+				sessionKey: "current-session",
+				project: "/repo",
+			},
+			makeDeps(),
+		);
+
+		expect(result.inject).toContain("Showing 1 active peer session");
+		expect(result.inject).toContain("Hermes Agent 1");
+		expect(result.inject.match(/session=legacy-session-id/g) ?? []).toHaveLength(1);
+	});
+
+	it("sanitizes untrusted harness labels before injecting peer visibility", async () => {
+		upsertAgentPresence({
+			sessionKey: "current-session",
+			agentId: "default",
+			harness: "codex",
+		});
+		upsertAgentPresence({
+			sessionKey: "peer-injection",
+			agentId: "default",
+			harness: "evil\n## Inject `<tag>` *bold*",
+		});
+
+		const result = await handleUserPromptSubmit(
+			{
+				harness: "codex",
+				userMessage: "   ",
+				sessionKey: "current-session",
+			},
+			makeDeps(),
+		);
+
+		expect(result.inject).toContain("evil Inject tag bold");
+		expect(result.inject).not.toContain("## Inject");
+		expect(result.inject).not.toContain("`<tag>`");
+		expect(result.inject).not.toContain("*bold*");
+	});
+
+	it("does not emit raw peer project paths when requester has no project", async () => {
+		upsertAgentPresence({
+			sessionKey: "current-session",
+			agentId: "default",
+			harness: "codex",
+		});
+		upsertAgentPresence({
+			sessionKey: "peer-secret-project",
+			agentId: "default",
+			harness: "hermes-agent",
+			project: "/home/nicholai/private/worktree",
+		});
+
+		const result = await handleUserPromptSubmit(
+			{
+				harness: "codex",
+				userMessage: "   ",
+				sessionKey: "current-session",
+			},
+			makeDeps(),
+		);
+
+		expect(result.inject).toContain("## Active Peer Sessions");
+		expect(result.inject).toContain("Hermes Agent: default session=peer-secret-project");
+		expect(result.inject).not.toContain("project=");
+		expect(result.inject).not.toContain("/home/nicholai/private/worktree");
+	});
+
+	it("labels peer visibility as a capped display when many peers are active", async () => {
+		upsertAgentPresence({
+			sessionKey: "current-session",
+			agentId: "default",
+			harness: "codex",
+		});
+		for (let index = 0; index < 10; index++) {
+			upsertAgentPresence({
+				sessionKey: `peer-${index}`,
+				agentId: "default",
+				harness: "claude-code",
+			});
+		}
+
+		const result = await handleUserPromptSubmit(
+			{
+				harness: "codex",
+				userMessage: "   ",
+				sessionKey: "current-session",
+			},
+			makeDeps(),
+		);
+
+		expect(result.inject).toContain("Showing 8 of 10 active peer sessions");
+		expect(result.inject).toContain("2 more active sessions omitted");
+		expect(result.inject).not.toContain("10 peer sessions active right now");
 	});
 
 	it("logs successful no-query outcomes", async () => {

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -75,6 +75,7 @@ import {
 } from "./predictor-scoring";
 import { getPredictorState, updatePredictorState } from "./predictor-state";
 import { listSecrets } from "./secrets";
+import { formatSessionAppLabel } from "./session-apps";
 import {
 	flushPendingCheckpoints,
 	formatPeriodicDigest,
@@ -88,6 +89,7 @@ import {
 } from "./session-checkpoints";
 import { parseFeedback, recordAgentFeedback, recordSessionCandidates, trackFtsHits } from "./session-memories";
 import { isNoiseSession } from "./session-noise";
+import { type SessionRegistryRecord, listActiveSessionRegistry } from "./session-registry";
 import { getExpiryWarning } from "./session-tracker";
 import {
 	ensureCanonicalTranscriptHistory,
@@ -273,16 +275,161 @@ function formatTranscriptSessionLabel(sessionKey: string): string {
 	return `${sessionKey.slice(0, 8)}…${sessionKey.slice(-6)}`;
 }
 
-function harnessSupportsNamedCrossAgentTools(harness: string): boolean {
-	return harness.trim().toLowerCase() === "codex";
-}
-
 function sanitizePeerPromptField(value: string | undefined): string {
 	if (!value) return "";
 	return value
 		.replace(/[\r\n`*#[\]<>]/g, " ")
 		.replace(/\s+/g, " ")
 		.trim();
+}
+
+function sanitizePeerPromptLabel(value: string | undefined): string {
+	return sanitizePeerPromptField(value) || "Unknown app";
+}
+
+function pluralizeSession(count: number): string {
+	return count === 1 ? "session" : "sessions";
+}
+
+const PEER_VISIBILITY_FETCH_LIMIT = 50;
+const PEER_VISIBILITY_DISPLAY_LIMIT = 8;
+const PEER_VISIBILITY_LIST_LIMIT = PEER_VISIBILITY_DISPLAY_LIMIT;
+
+interface PromptPeerSession {
+	readonly agentId: string;
+	readonly sessionKey?: string;
+	readonly harness: string;
+	readonly appLabel: string;
+	readonly project?: string;
+	readonly startedAt: string;
+	readonly lastSeenAt: string;
+}
+
+function promptPeerAppId(harness: string): string {
+	return (
+		harness
+			.trim()
+			.toLowerCase()
+			.replace(/[_\s]+/g, "-") || "unknown"
+	);
+}
+
+function registryPeerKey(peer: SessionRegistryRecord): string {
+	const token = peer.sessionKey ?? peer.sessionId;
+	return `${peer.appId}:${token ? `session:${token}` : `row:${peer.id}`}`;
+}
+
+function presencePeerKey(peer: {
+	readonly harness: string;
+	readonly sessionKey?: string;
+	readonly key: string;
+}): string {
+	const token = peer.sessionKey ? `session:${peer.sessionKey}` : `row:${peer.key}`;
+	const appId = promptPeerAppId(peer.harness);
+	return `${appId}:${token}`;
+}
+
+function collectPromptPeerSessions(
+	req: Pick<
+		UserPromptSubmitRequest | SessionStartRequest,
+		"agentId" | "harness" | "project" | "sessionKey" | "sessionId"
+	>,
+	agentId: string,
+	listPresence: typeof listAgentPresence,
+	listRegistry: typeof listActiveSessionRegistry,
+): PromptPeerSession[] {
+	const byKey = new Map<string, PromptPeerSession>();
+	const currentSession = req.sessionKey ?? req.sessionId;
+	for (const peer of listRegistry({
+		agentId,
+		sessionKey: req.sessionKey,
+		sessionId: req.sessionId,
+		harness: req.harness,
+		includeSelf: false,
+		limit: PEER_VISIBILITY_FETCH_LIMIT,
+	})) {
+		byKey.set(registryPeerKey(peer), {
+			agentId: peer.agentId,
+			sessionKey: peer.sessionKey ?? peer.sessionId ?? undefined,
+			harness: peer.harness,
+			appLabel: peer.appLabel,
+			project: peer.project ?? undefined,
+			startedAt: peer.startedAt,
+			lastSeenAt: peer.lastSeenAt,
+		});
+	}
+
+	for (const peer of listPresence({
+		agentId,
+		sessionKey: currentSession,
+		includeSelf: false,
+		limit: PEER_VISIBILITY_FETCH_LIMIT,
+	})) {
+		const key = presencePeerKey(peer);
+		byKey.set(key, {
+			agentId: peer.agentId,
+			sessionKey: peer.sessionKey,
+			harness: peer.harness,
+			appLabel: formatSessionAppLabel(peer.harness),
+			project: peer.project,
+			startedAt: peer.startedAt,
+			lastSeenAt: peer.lastSeenAt,
+		});
+	}
+
+	return [...byKey.values()].sort((a, b) => b.lastSeenAt.localeCompare(a.lastSeenAt));
+}
+
+function buildPeerSessionVisibilitySection(
+	req: Pick<
+		UserPromptSubmitRequest | SessionStartRequest,
+		"agentId" | "harness" | "project" | "sessionKey" | "sessionId"
+	>,
+	agentId: string,
+	listPresence: typeof listAgentPresence = listAgentPresence,
+	listRegistry: typeof listActiveSessionRegistry = listActiveSessionRegistry,
+): string {
+	const peers = collectPromptPeerSessions(req, agentId, listPresence, listRegistry);
+	if (peers.length === 0) return "";
+	const visiblePeers = peers.slice(0, PEER_VISIBILITY_DISPLAY_LIMIT);
+
+	const counts = new Map<string, number>();
+	for (const peer of visiblePeers) {
+		const label = sanitizePeerPromptLabel(peer.appLabel);
+		counts.set(label, (counts.get(label) ?? 0) + 1);
+	}
+	const appSummary = [...counts.entries()]
+		.sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+		.map(([label, count]) => `${label} ${count}`)
+		.join(", ");
+	const sameProject = req.project ? peers.filter((peer) => peer.project === req.project).length : 0;
+	const projectSummary =
+		req.project && sameProject > 0 ? `; ${sameProject} in this project` : req.project ? "; none in this project" : "";
+	const countLabel =
+		peers.length > visiblePeers.length
+			? `Showing ${visiblePeers.length} of ${peers.length} active peer ${pluralizeSession(peers.length)}`
+			: `Showing ${visiblePeers.length} active peer ${pluralizeSession(visiblePeers.length)}`;
+	const lines = ["## Active Peer Sessions", "", `${countLabel} (${appSummary}${projectSummary}).`];
+
+	for (const peer of visiblePeers.slice(0, PEER_VISIBILITY_LIST_LIMIT)) {
+		const app = sanitizePeerPromptLabel(peer.appLabel);
+		const safeAgentId = sanitizePeerPromptField(peer.agentId) || "unknown-agent";
+		const safeSessionKey = sanitizePeerPromptField(peer.sessionKey);
+		const sameProjectLabel = req.project && peer.project === req.project ? ", this project" : "";
+		const projectLabel = sameProjectLabel;
+		const sessionLabel = safeSessionKey ? ` session=${safeSessionKey}` : "";
+		lines.push(`- ${app}: ${safeAgentId}${sessionLabel}${projectLabel}, seen ${formatLastSeenShort(peer.lastSeenAt)}.`);
+	}
+	if (peers.length > PEER_VISIBILITY_LIST_LIMIT) {
+		lines.push(
+			`- ${peers.length - PEER_VISIBILITY_LIST_LIMIT} more active ${pluralizeSession(peers.length - PEER_VISIBILITY_LIST_LIMIT)} omitted.`,
+		);
+	}
+
+	lines.push(
+		"When Signet cross-agent MCP tools are available, use `agent_peers` for the full live list and `agent_message_send` or `agent_message_inbox` when coordination would help. Use memory or transcript recall for older sessions.",
+	);
+	return `${lines.join("\n")}\n`;
 }
 
 export function buildSignetSystemPrompt(): string {
@@ -388,6 +535,7 @@ export interface SessionStartRequest {
 	agentId?: string;
 	context?: string;
 	sessionKey?: string;
+	sessionId?: string;
 	runtimePath?: "plugin" | "legacy";
 }
 
@@ -431,6 +579,7 @@ export interface UserPromptSubmitRequest {
 	userPrompt?: string;
 	lastAssistantMessage?: string;
 	sessionKey?: string;
+	sessionId?: string;
 	transcriptPath?: string;
 	transcript?: string;
 	runtimePath?: "plugin" | "legacy";
@@ -1858,31 +2007,11 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	});
 	injectParts.push(`\n# Current Date & Time\n${now} (${tz})\n`);
 
-	if (req.project) {
-		const peerSessions = listAgentPresence({
-			agentId: resolveAgentId(req),
-			sessionKey: req.sessionKey,
-			project: req.project,
-			includeSelf: false,
-			limit: 6,
-		});
-		if (peerSessions.length > 0) {
-			injectParts.push("\n## Active Peer Sessions\n");
-			injectParts.push("Other Signet agent sessions are active right now:");
-			for (const peer of peerSessions) {
-				const safeAgentId = sanitizePeerPromptField(peer.agentId) || "unknown-agent";
-				const safeHarness = sanitizePeerPromptField(peer.harness) || "unknown-harness";
-				const safeSessionKey = sanitizePeerPromptField(peer.sessionKey);
-				const safeProject = sanitizePeerPromptField(peer.project);
-				const sessionLabel = safeSessionKey ? ` session=${safeSessionKey}` : "";
-				const projectLabel = safeProject ? ` project=${safeProject}` : "";
-				injectParts.push(
-					`- ${safeAgentId} (${safeHarness})${projectLabel}${sessionLabel} [seen ${formatLastSeenShort(peer.lastSeenAt)}]`,
-				);
-			}
-			if (harnessSupportsNamedCrossAgentTools(req.harness)) {
-				injectParts.push("Use `agent_message_send` to ask for help and `agent_message_inbox` to read replies.");
-			}
+	{
+		const peerSection = buildPeerSessionVisibilitySection(req, resolveAgentId(req));
+		if (peerSection) {
+			injectParts.push("");
+			injectParts.push(peerSection.trimEnd());
 		}
 	}
 
@@ -2525,6 +2654,7 @@ type UserPromptSubmitDeps = {
 	readonly searchTemporalFallback: typeof searchTemporalFallback;
 	readonly searchTranscriptFallback: typeof searchTranscriptFallback;
 	readonly trackFtsHits: typeof trackFtsHits;
+	readonly listAgentPresence: typeof listAgentPresence;
 };
 
 const PROMPT_SUBMIT_EMBEDDING_TIMEOUT_MS = 1000;
@@ -2571,6 +2701,7 @@ const DEFAULT_USER_PROMPT_SUBMIT_DEPS: UserPromptSubmitDeps = {
 	searchTemporalFallback,
 	searchTranscriptFallback,
 	trackFtsHits,
+	listAgentPresence,
 };
 
 export async function handleUserPromptSubmit(
@@ -2721,7 +2852,8 @@ export async function handleUserPromptSubmit(
 		dateStyle: "full",
 		timeStyle: "short",
 	});
-	const metadataHeader = `# Current Date & Time\n${now} (${tz})\n`;
+	const peerSection = buildPeerSessionVisibilitySection(req, agentId, deps.listAgentPresence);
+	const metadataHeader = `# Current Date & Time\n${now} (${tz})\n${peerSection ? `\n${peerSection}` : ""}`;
 	const expiryWarning = req.sessionKey ? deps.getExpiryWarning(req.sessionKey) : null;
 	const warnings = expiryWarning ? [expiryWarning] : undefined;
 	const pluginContext = buildPluginPromptContributionSection("user-prompt-submit", deps.logger);

--- a/platform/daemon/src/routes/hooks-routes.ts
+++ b/platform/daemon/src/routes/hooks-routes.ts
@@ -44,6 +44,7 @@ import { writeCompactionArtifact } from "../memory-lineage.js";
 import { hybridRecall } from "../memory-search";
 import { getSynthesisWorker, readLastSynthesisTime } from "../pipeline";
 import { isNoiseSession } from "../session-noise";
+import { listActiveSessionRegistry, markSessionRegistryEnded, upsertSessionRegistry } from "../session-registry";
 import {
 	type RuntimePath,
 	claimSession,
@@ -214,6 +215,17 @@ export function listLiveSessions(agentId: string): Array<{
 			bypassed: isSessionBypassed(key),
 		});
 	}
+	for (const session of listActiveSessionRegistry({ agentId, includeSelf: true, limit: Number.MAX_SAFE_INTEGER })) {
+		const key = normalizeSessionKey(session.sessionKey ?? session.sessionId ?? session.id);
+		if (byKey.has(key)) continue;
+		byKey.set(key, {
+			key,
+			runtimePath: session.runtimePath ?? "unknown",
+			claimedAt: session.startedAt,
+			expiresAt: null,
+			bypassed: isSessionBypassed(key),
+		});
+	}
 	return [...byKey.values()].sort((a, b) => b.claimedAt.localeCompare(a.claimedAt));
 }
 
@@ -237,11 +249,15 @@ function registerSessionStart(app: Hono): void {
 			const runtimePath = resolveRuntimePath(c, body);
 			if (runtimePath) body.runtimePath = runtimePath;
 
-			if (body.sessionKey && runtimePath) {
+			const sessionKey = parseOptionalString(body.sessionKey);
+			const sessionId = parseOptionalString(body.sessionId);
+			const sessionIdentity = sessionKey ?? sessionId;
+
+			if (sessionIdentity && runtimePath) {
 				const claim = claimSession(
-					body.sessionKey,
+					sessionIdentity,
 					runtimePath,
-					resolveAgentId({ agentId: body.agentId, sessionKey: body.sessionKey }),
+					resolveAgentId({ agentId: body.agentId, sessionKey: sessionIdentity }),
 				);
 				if (!claim.ok) {
 					return c.json(
@@ -253,9 +269,22 @@ function registerSessionStart(app: Hono): void {
 				}
 			}
 
+			const agentId = resolveAgentId({
+				agentId: parseOptionalString(body.agentId),
+				sessionKey: sessionIdentity,
+			});
 			upsertAgentPresence({
-				sessionKey: parseOptionalString(body.sessionKey),
-				agentId: parseOptionalString(body.agentId) ?? "default",
+				sessionKey: sessionIdentity,
+				agentId,
+				harness: body.harness,
+				project: parseOptionalString(body.project),
+				runtimePath,
+				provider: body.harness,
+			});
+			upsertSessionRegistry({
+				sessionKey,
+				sessionId,
+				agentId,
 				harness: body.harness,
 				project: parseOptionalString(body.project),
 				runtimePath,
@@ -303,10 +332,12 @@ function registerUserPromptSubmit(app: Hono): void {
 			if (runtimePath) body.runtimePath = runtimePath;
 
 			const sessionKey = parseOptionalString(body.sessionKey);
-			const known = sessionKey ? hasSession(sessionKey) : false;
+			const sessionId = parseOptionalString(body.sessionId);
+			const sessionIdentity = sessionKey ?? sessionId;
+			const known = sessionIdentity ? hasSession(sessionIdentity) : false;
 
-			const agentId = parseOptionalString(body.agentId) ?? "default";
-			const duplicate = claimAutomaticSessionOrSkip(sessionKey, runtimePath, agentId, "user-prompt-submit", {
+			const agentId = resolveAgentId({ agentId: parseOptionalString(body.agentId), sessionKey: sessionIdentity });
+			const duplicate = claimAutomaticSessionOrSkip(sessionIdentity, runtimePath, agentId, "user-prompt-submit", {
 				inject: "",
 				memoryCount: 0,
 				sessionKnown: known,
@@ -314,11 +345,11 @@ function registerUserPromptSubmit(app: Hono): void {
 			if (duplicate) {
 				return c.json(duplicate);
 			}
-			if (sessionKey) {
-				const touched = touchAgentPresence(sessionKey);
+			if (sessionIdentity) {
+				const touched = touchAgentPresence(sessionIdentity);
 				if (!touched) {
 					upsertAgentPresence({
-						sessionKey,
+						sessionKey: sessionIdentity,
 						agentId,
 						harness: body.harness,
 						project: parseOptionalString(body.project),
@@ -326,6 +357,15 @@ function registerUserPromptSubmit(app: Hono): void {
 						provider: body.harness,
 					});
 				}
+				upsertSessionRegistry({
+					sessionKey,
+					sessionId,
+					agentId,
+					harness: body.harness,
+					project: parseOptionalString(body.project),
+					runtimePath,
+					provider: body.harness,
+				});
 			} else {
 				upsertAgentPresence({
 					agentId,
@@ -369,13 +409,15 @@ function registerSessionEnd(app: Hono): void {
 
 			stampHarness(body.harness);
 
-			const sessionKey = body.sessionKey || body.sessionId;
+			const rawSessionKey = parseOptionalString(body.sessionKey);
+			const sessionId = parseOptionalString(body.sessionId);
+			const sessionKey = rawSessionKey ?? sessionId;
 			const conflict = skipConflictingSessionEnd(sessionKey, runtimePath);
 			if (conflict) return c.json(conflict);
 			const duplicate = claimAutomaticSessionOrSkip(
 				sessionKey,
 				runtimePath,
-				parseOptionalString(body.agentId) ?? "default",
+				resolveAgentId({ agentId: parseOptionalString(body.agentId), sessionKey }),
 				"session-end",
 				{
 					memoriesSaved: 0,
@@ -385,6 +427,16 @@ function registerSessionEnd(app: Hono): void {
 
 			if (sessionKey && isSessionBypassed(sessionKey)) {
 				markSessionEnded(sessionKey, runtimePath);
+				markSessionRegistryEnded({
+					sessionKey: rawSessionKey,
+					sessionId,
+					agentId: resolveAgentId({ agentId: parseOptionalString(body.agentId), sessionKey }),
+					harness: body.harness,
+					cwd: parseOptionalString(body.cwd),
+					runtimePath,
+					provider: body.harness,
+					reason: "bypassed",
+				});
 				removeAgentPresence(sessionKey);
 				return c.json({ memoriesSaved: 0, bypassed: true });
 			}
@@ -393,12 +445,32 @@ function registerSessionEnd(app: Hono): void {
 				const result = await handleSessionEnd(body);
 				if (sessionKey) {
 					markSessionEnded(sessionKey, runtimePath);
+					markSessionRegistryEnded({
+						sessionKey: rawSessionKey,
+						sessionId,
+						agentId: resolveAgentId({ agentId: parseOptionalString(body.agentId), sessionKey }),
+						harness: body.harness,
+						cwd: parseOptionalString(body.cwd),
+						runtimePath,
+						provider: body.harness,
+						reason: parseOptionalString(body.reason) ?? "session-end",
+					});
 					removeAgentPresence(sessionKey);
 				}
 				return c.json(result);
 			} catch (e) {
 				if (sessionKey) {
 					releaseSession(sessionKey);
+					markSessionRegistryEnded({
+						sessionKey: rawSessionKey,
+						sessionId,
+						agentId: resolveAgentId({ agentId: parseOptionalString(body.agentId), sessionKey }),
+						harness: body.harness,
+						cwd: parseOptionalString(body.cwd),
+						runtimePath,
+						provider: body.harness,
+						reason: "error",
+					});
 					removeAgentPresence(sessionKey);
 				}
 				throw e;

--- a/platform/daemon/src/routes/session-routes.ts
+++ b/platform/daemon/src/routes/session-routes.ts
@@ -4,6 +4,7 @@ import { requirePermission } from "../auth";
 import { listAgentPresence, touchAgentPresence } from "../cross-agent.js";
 import { getDbAccessor } from "../db-accessor.js";
 import { logger } from "../logger.js";
+import { listActiveSessionRegistry } from "../session-registry.js";
 import {
 	type RuntimePath,
 	bypassSession,
@@ -24,7 +25,10 @@ function listLiveSessions(agentId: string): Array<{
 	expiresAt: string | null;
 	bypassed: boolean;
 }> {
-	const byKey = new Map<string, { key: string; runtimePath: string; claimedAt: string; expiresAt: string | null; bypassed: boolean }>(
+	const byKey = new Map<
+		string,
+		{ key: string; runtimePath: string; claimedAt: string; expiresAt: string | null; bypassed: boolean }
+	>(
 		getActiveSessions()
 			.filter((s) => s.agentId === agentId)
 			.map((session) => [session.key, session] as const),
@@ -39,6 +43,17 @@ function listLiveSessions(agentId: string): Array<{
 			key,
 			runtimePath: presence.runtimePath ?? "unknown",
 			claimedAt: presence.startedAt,
+			expiresAt: null,
+			bypassed: isSessionBypassed(key),
+		});
+	}
+	for (const session of listActiveSessionRegistry({ agentId, includeSelf: true, limit: Number.MAX_SAFE_INTEGER })) {
+		const key = normalizeSessionKey(session.sessionKey ?? session.sessionId ?? session.id);
+		if (byKey.has(key)) continue;
+		byKey.set(key, {
+			key,
+			runtimePath: session.runtimePath ?? "unknown",
+			claimedAt: session.startedAt,
 			expiresAt: null,
 			bypassed: isSessionBypassed(key),
 		});

--- a/platform/daemon/src/session-apps.ts
+++ b/platform/daemon/src/session-apps.ts
@@ -1,0 +1,24 @@
+export function formatSessionAppLabel(harness: string): string {
+	const normalized = harness
+		.trim()
+		.toLowerCase()
+		.replace(/[_\s]+/g, "-");
+	const labels: Record<string, string> = {
+		"claude-code": "Claude Code",
+		claude: "Claude Code",
+		codex: "Codex",
+		gemini: "Gemini",
+		hermes: "Hermes Agent",
+		"hermes-agent": "Hermes Agent",
+		openclaw: "OpenClaw",
+		opencode: "OpenCode",
+		pi: "Pi",
+	};
+	if (labels[normalized]) return labels[normalized];
+	return (
+		harness
+			.replace(/[\r\n`*#[\]<>]/g, " ")
+			.replace(/\s+/g, " ")
+			.trim() || "Unknown app"
+	);
+}

--- a/platform/daemon/src/session-registry.test.ts
+++ b/platform/daemon/src/session-registry.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDbAccessor, initDbAccessor } from "./db-accessor";
+import { listActiveSessionRegistry, markSessionRegistryEnded, upsertSessionRegistry } from "./session-registry";
+
+let root = "";
+const originalSignetPath = process.env.SIGNET_PATH;
+
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), "signet-session-registry-"));
+	mkdirSync(join(root, "memory"), { recursive: true });
+	process.env.SIGNET_PATH = root;
+	initDbAccessor(join(root, "memory", "memories.db"), { agentsDir: root });
+});
+
+afterEach(() => {
+	closeDbAccessor();
+	rmSync(root, { recursive: true, force: true });
+	if (originalSignetPath === undefined) {
+		Reflect.deleteProperty(process.env, "SIGNET_PATH");
+	} else {
+		process.env.SIGNET_PATH = originalSignetPath;
+	}
+});
+
+describe("session registry", () => {
+	test("keeps active sessions durable and removes ended sessions from live listings", () => {
+		const active = upsertSessionRegistry({
+			agentId: "default",
+			sessionKey: "sess-live",
+			harness: "hermes-agent",
+			project: "/repo",
+			runtimePath: "plugin",
+		});
+
+		expect(active?.appLabel).toBe("Hermes Agent");
+		expect(active?.transcriptPath).toBe("memory/hermes-agent/transcripts/transcript.jsonl");
+		expect(listActiveSessionRegistry({ agentId: "default", includeSelf: true })).toHaveLength(1);
+
+		const ended = markSessionRegistryEnded({
+			agentId: "default",
+			sessionKey: "sess-live",
+			harness: "hermes-agent",
+			project: "/repo",
+			runtimePath: "plugin",
+			reason: "session-end",
+		});
+
+		expect(ended?.status).toBe("ended");
+		expect(ended?.endReason).toBe("session-end");
+		expect(listActiveSessionRegistry({ agentId: "default", includeSelf: true })).toHaveLength(0);
+	});
+
+	test("lists same-agent peer sessions while excluding the current session", () => {
+		upsertSessionRegistry({
+			agentId: "default",
+			sessionKey: "current",
+			harness: "codex",
+			project: "/repo",
+		});
+		upsertSessionRegistry({
+			agentId: "default",
+			sessionKey: "other",
+			harness: "claude-code",
+			project: "/repo",
+		});
+		upsertSessionRegistry({
+			agentId: "other-agent",
+			sessionKey: "other-agent-session",
+			harness: "opencode",
+			project: "/repo",
+		});
+
+		const peers = listActiveSessionRegistry({
+			agentId: "default",
+			sessionKey: "current",
+			harness: "codex",
+			includeSelf: false,
+		});
+
+		expect(peers.map((peer) => peer.sessionKey)).toEqual(["other"]);
+	});
+
+	test("tracks and ends sessions that only provide sessionId", () => {
+		const active = upsertSessionRegistry({
+			agentId: "default",
+			sessionId: "stable-session-id",
+			harness: "codex",
+		});
+
+		expect(active?.sessionKey).toBeNull();
+		expect(active?.sessionId).toBe("stable-session-id");
+		expect(listActiveSessionRegistry({ agentId: "default", includeSelf: true })).toHaveLength(1);
+
+		const ended = markSessionRegistryEnded({
+			agentId: "default",
+			sessionId: "stable-session-id",
+			harness: "codex",
+		});
+
+		expect(ended?.status).toBe("ended");
+		expect(ended?.sessionKey).toBeNull();
+		expect(ended?.sessionId).toBe("stable-session-id");
+		expect(listActiveSessionRegistry({ agentId: "default", includeSelf: true })).toHaveLength(0);
+	});
+
+	test("keeps sessionKey-only and sessionId-only identities distinct", () => {
+		const byKey = upsertSessionRegistry({
+			agentId: "default",
+			sessionKey: "same-token",
+			harness: "codex",
+		});
+		const byId = upsertSessionRegistry({
+			agentId: "default",
+			sessionId: "same-token",
+			harness: "codex",
+		});
+
+		expect(byKey?.id).not.toBe(byId?.id);
+		expect(listActiveSessionRegistry({ agentId: "default", includeSelf: true })).toHaveLength(2);
+
+		markSessionRegistryEnded({
+			agentId: "default",
+			sessionKey: "same-token",
+			harness: "codex",
+		});
+
+		const remaining = listActiveSessionRegistry({ agentId: "default", includeSelf: true });
+		expect(remaining).toHaveLength(1);
+		expect(remaining[0]?.sessionKey).toBeNull();
+		expect(remaining[0]?.sessionId).toBe("same-token");
+	});
+
+	test("does not truncate explicit large live-session listings", () => {
+		for (let index = 0; index < 205; index++) {
+			upsertSessionRegistry({
+				agentId: "default",
+				sessionKey: `session-${index}`,
+				harness: "codex",
+			});
+		}
+
+		expect(
+			listActiveSessionRegistry({ agentId: "default", includeSelf: true, limit: Number.MAX_SAFE_INTEGER }),
+		).toHaveLength(205);
+	});
+
+	test("backfills a later sessionId without losing the canonical sessionKey", () => {
+		upsertSessionRegistry({
+			agentId: "default",
+			sessionKey: "stable-key",
+			harness: "claude-code",
+		});
+
+		const ended = markSessionRegistryEnded({
+			agentId: "default",
+			sessionKey: "stable-key",
+			sessionId: "stable-id",
+			harness: "claude-code",
+		});
+
+		expect(ended?.sessionKey).toBe("stable-key");
+		expect(ended?.sessionId).toBe("stable-id");
+		expect(ended?.status).toBe("ended");
+	});
+
+	test("merges a sessionId-only row when the canonical sessionKey arrives later", () => {
+		const byId = upsertSessionRegistry({
+			agentId: "default",
+			sessionId: "stable-id",
+			harness: "claude-code",
+		});
+
+		const byKeyAndId = upsertSessionRegistry({
+			agentId: "default",
+			sessionKey: "stable-key",
+			sessionId: "stable-id",
+			harness: "claude-code",
+		});
+
+		expect(byKeyAndId?.id).toBe(byId?.id);
+		expect(byKeyAndId?.sessionKey).toBe("stable-key");
+		expect(byKeyAndId?.sessionId).toBe("stable-id");
+		expect(listActiveSessionRegistry({ agentId: "default", includeSelf: true })).toHaveLength(1);
+	});
+
+	test("merges split key and id rows when a later hook reports both identities", () => {
+		upsertSessionRegistry({
+			agentId: "default",
+			sessionKey: "stable-key",
+			harness: "claude-code",
+		});
+		upsertSessionRegistry({
+			agentId: "default",
+			sessionId: "stable-id",
+			harness: "claude-code",
+		});
+
+		const ended = markSessionRegistryEnded({
+			agentId: "default",
+			sessionKey: "stable-key",
+			sessionId: "stable-id",
+			harness: "claude-code",
+		});
+
+		expect(ended?.sessionKey).toBe("stable-key");
+		expect(ended?.sessionId).toBe("stable-id");
+		expect(ended?.status).toBe("ended");
+		expect(listActiveSessionRegistry({ agentId: "default", includeSelf: true })).toHaveLength(0);
+	});
+
+	test("does not exclude same-token peers from other harnesses", () => {
+		upsertSessionRegistry({
+			agentId: "default",
+			sessionKey: "same-token",
+			harness: "codex",
+		});
+		upsertSessionRegistry({
+			agentId: "default",
+			sessionKey: "same-token",
+			harness: "claude-code",
+		});
+
+		const peers = listActiveSessionRegistry({
+			agentId: "default",
+			sessionKey: "same-token",
+			harness: "codex",
+			includeSelf: false,
+		});
+
+		expect(peers).toHaveLength(1);
+		expect(peers[0]?.harness).toBe("claude-code");
+	});
+
+	test("does not globally exclude same-token peers when caller omits harness", () => {
+		upsertSessionRegistry({
+			agentId: "default",
+			sessionKey: "same-token",
+			harness: "codex",
+		});
+		upsertSessionRegistry({
+			agentId: "default",
+			sessionKey: "same-token",
+			harness: "claude-code",
+		});
+
+		const peers = listActiveSessionRegistry({
+			agentId: "default",
+			sessionKey: "same-token",
+			includeSelf: false,
+		});
+
+		expect(peers.map((peer) => peer.harness).sort()).toEqual(["claude-code", "codex"]);
+	});
+});

--- a/platform/daemon/src/session-registry.ts
+++ b/platform/daemon/src/session-registry.ts
@@ -1,0 +1,387 @@
+import { createHash } from "node:crypto";
+import { type WriteDb, getDbAccessor, hasDbAccessor } from "./db-accessor";
+import { logger } from "./logger";
+import { formatSessionAppLabel } from "./session-apps";
+import { canonicalTranscriptRelativePath, sanitizeHarnessPath } from "./transcript-jsonl";
+
+export type SessionRegistryStatus = "active" | "ended" | "stale";
+
+export interface SessionRegistryRecord {
+	readonly id: string;
+	readonly agentId: string;
+	readonly sessionKey: string | null;
+	readonly sessionId: string | null;
+	readonly harness: string;
+	readonly appId: string;
+	readonly appLabel: string;
+	readonly project: string | null;
+	readonly cwd: string | null;
+	readonly runtimePath: "plugin" | "legacy" | null;
+	readonly provider: string | null;
+	readonly status: SessionRegistryStatus;
+	readonly startedAt: string;
+	readonly lastSeenAt: string;
+	readonly endedAt: string | null;
+	readonly endReason: string | null;
+	readonly transcriptPath: string | null;
+}
+
+export interface SessionRegistryInput {
+	readonly agentId?: string | null;
+	readonly sessionKey?: string | null;
+	readonly sessionId?: string | null;
+	readonly harness: string;
+	readonly project?: string | null;
+	readonly cwd?: string | null;
+	readonly runtimePath?: "plugin" | "legacy" | null;
+	readonly provider?: string | null;
+	readonly transcriptPath?: string | null;
+}
+
+export interface ListSessionRegistryOptions {
+	readonly agentId?: string;
+	readonly sessionKey?: string;
+	readonly sessionId?: string;
+	readonly harness?: string;
+	readonly includeSelf?: boolean;
+	readonly project?: string;
+	readonly limit?: number;
+}
+
+const STALE_AFTER_MS = 4 * 60 * 60 * 1000;
+
+function clean(value: string | null | undefined): string | null {
+	const trimmed = value?.trim();
+	return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+function stableId(agentId: string, harness: string, sessionKey: string | null, sessionId: string | null): string {
+	const identityKind = sessionKey !== null ? "session_key" : "session_id";
+	const identityValue = sessionKey ?? sessionId ?? "";
+	return createHash("sha256")
+		.update([agentId, sanitizeHarnessPath(harness), identityKind, identityValue].join("\0"), "utf8")
+		.digest("hex")
+		.slice(0, 32);
+}
+
+function identity(input: SessionRegistryInput): {
+	readonly id: string;
+	readonly agentId: string;
+	readonly sessionKey: string | null;
+	readonly sessionId: string | null;
+	readonly harness: string;
+	readonly appId: string;
+	readonly appLabel: string;
+} | null {
+	const sessionKey = clean(input.sessionKey);
+	const sessionId = clean(input.sessionId);
+	if (!sessionKey && !sessionId) return null;
+	const agentId = clean(input.agentId) ?? "default";
+	const harness = clean(input.harness) ?? "unknown";
+	return {
+		id: stableId(agentId, harness, sessionKey, sessionId),
+		agentId,
+		sessionKey,
+		sessionId,
+		harness,
+		appId: sanitizeHarnessPath(harness),
+		appLabel: formatSessionAppLabel(harness),
+	};
+}
+
+type SessionRegistryIdentity = NonNullable<ReturnType<typeof identity>>;
+
+function findMatchingRegistryRows(db: WriteDb, info: SessionRegistryIdentity): Record<string, unknown>[] {
+	const matches: string[] = [];
+	const args: unknown[] = [info.agentId, info.harness];
+	if (info.sessionKey) {
+		matches.push("session_key = ?");
+		args.push(info.sessionKey);
+	}
+	if (info.sessionId) {
+		matches.push("session_id = ?");
+		args.push(info.sessionId);
+	}
+	if (matches.length === 0) return [];
+	args.push(info.id, info.sessionKey ?? "", info.sessionId ?? "");
+	return db
+		.prepare(
+			`SELECT *
+			 FROM session_registry
+			 WHERE agent_id = ?
+			   AND harness = ?
+			   AND (${matches.join(" OR ")})
+			 ORDER BY CASE
+			   WHEN id = ? THEN 0
+			   WHEN session_key = ? THEN 1
+			   WHEN session_id = ? THEN 2
+			   ELSE 3
+			 END,
+			 last_seen_at DESC`,
+		)
+		.all(...args)
+		.map((row) => row as Record<string, unknown>);
+}
+
+function resolveWriteIdentity(db: WriteDb, info: SessionRegistryIdentity): SessionRegistryIdentity {
+	const rows = findMatchingRegistryRows(db, info);
+	if (rows.length === 0) return info;
+	const id = String(rows[0]?.id ?? info.id);
+	for (const row of rows.slice(1)) {
+		const duplicateId = String(row.id);
+		if (duplicateId !== id) {
+			db.prepare("DELETE FROM session_registry WHERE id = ?").run(duplicateId);
+		}
+	}
+	return { ...info, id };
+}
+
+function registryTableExists(): boolean {
+	if (!hasDbAccessor()) return false;
+	try {
+		return getDbAccessor().withReadDb((db) => {
+			const row = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'session_registry'").get();
+			return row !== undefined;
+		});
+	} catch {
+		return false;
+	}
+}
+
+function toStatus(value: unknown): SessionRegistryStatus {
+	return value === "ended" || value === "stale" ? value : "active";
+}
+
+function toRuntimePath(value: unknown): "plugin" | "legacy" | null {
+	return value === "plugin" || value === "legacy" ? value : null;
+}
+
+function stringOrNull(value: unknown): string | null {
+	return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function rowToRecord(row: Record<string, unknown>): SessionRegistryRecord {
+	return {
+		id: String(row.id),
+		agentId: String(row.agent_id),
+		sessionKey: stringOrNull(row.session_key),
+		sessionId: stringOrNull(row.session_id),
+		harness: String(row.harness),
+		appId: String(row.app_id),
+		appLabel: String(row.app_label),
+		project: stringOrNull(row.project),
+		cwd: stringOrNull(row.cwd),
+		runtimePath: toRuntimePath(row.runtime_path),
+		provider: stringOrNull(row.provider),
+		status: toStatus(row.status),
+		startedAt: String(row.started_at),
+		lastSeenAt: String(row.last_seen_at),
+		endedAt: stringOrNull(row.ended_at),
+		endReason: stringOrNull(row.end_reason),
+		transcriptPath: stringOrNull(row.transcript_path),
+	};
+}
+
+function expireStaleSessions(nowMs = Date.now()): void {
+	if (!registryTableExists()) return;
+	const threshold = new Date(nowMs - STALE_AFTER_MS).toISOString();
+	const now = new Date(nowMs).toISOString();
+	try {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`UPDATE session_registry
+				 SET status = 'stale',
+				     ended_at = COALESCE(ended_at, ?),
+				     end_reason = COALESCE(end_reason, 'stale'),
+				     updated_at = ?
+				 WHERE status = 'active'
+				   AND last_seen_at < ?`,
+			).run(now, now, threshold);
+		});
+	} catch (error) {
+		logger.warn("session-tracker", "Session registry stale sweep failed", {
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+}
+
+export function upsertSessionRegistry(input: SessionRegistryInput): SessionRegistryRecord | null {
+	const info = identity(input);
+	if (!info || !registryTableExists()) return null;
+	const now = new Date().toISOString();
+	const transcriptPath = clean(input.transcriptPath) ?? canonicalTranscriptRelativePath(info.harness);
+
+	try {
+		return getDbAccessor().withWriteTx((db) => {
+			const resolved = resolveWriteIdentity(db, info);
+			db.prepare(
+				`INSERT INTO session_registry (
+					id, agent_id, session_key, session_id, harness, app_id, app_label,
+					project, cwd, runtime_path, provider, status, started_at, last_seen_at,
+					ended_at, end_reason, transcript_path, updated_at
+				)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, NULL, NULL, ?, ?)
+				ON CONFLICT(id) DO UPDATE SET
+					session_key = COALESCE(session_registry.session_key, excluded.session_key),
+					session_id = COALESCE(session_registry.session_id, excluded.session_id),
+					harness = excluded.harness,
+					app_id = excluded.app_id,
+					app_label = excluded.app_label,
+					project = COALESCE(excluded.project, session_registry.project),
+					cwd = COALESCE(excluded.cwd, session_registry.cwd),
+					runtime_path = COALESCE(excluded.runtime_path, session_registry.runtime_path),
+					provider = COALESCE(excluded.provider, session_registry.provider),
+					status = 'active',
+					last_seen_at = excluded.last_seen_at,
+					ended_at = NULL,
+					end_reason = NULL,
+					transcript_path = COALESCE(excluded.transcript_path, session_registry.transcript_path),
+					updated_at = excluded.updated_at`,
+			).run(
+				resolved.id,
+				resolved.agentId,
+				resolved.sessionKey,
+				resolved.sessionId,
+				resolved.harness,
+				resolved.appId,
+				resolved.appLabel,
+				clean(input.project),
+				clean(input.cwd),
+				input.runtimePath ?? null,
+				clean(input.provider),
+				now,
+				now,
+				transcriptPath,
+				now,
+			);
+			const row = db.prepare("SELECT * FROM session_registry WHERE id = ?").get(resolved.id);
+			return row && typeof row === "object" ? rowToRecord(row as Record<string, unknown>) : null;
+		});
+	} catch (error) {
+		logger.warn("session-tracker", "Session registry upsert failed", {
+			error: error instanceof Error ? error.message : String(error),
+			sessionKey: info.sessionKey,
+			sessionId: info.sessionId,
+		});
+		return null;
+	}
+}
+
+export function markSessionRegistryEnded(
+	input: SessionRegistryInput & { readonly endedAt?: string; readonly reason?: string | null },
+): SessionRegistryRecord | null {
+	const info = identity(input);
+	if (!info || !registryTableExists()) return null;
+	const endedAt = clean(input.endedAt) ?? new Date().toISOString();
+	const reason = clean(input.reason) ?? "session-end";
+	const transcriptPath = clean(input.transcriptPath) ?? canonicalTranscriptRelativePath(info.harness);
+
+	try {
+		return getDbAccessor().withWriteTx((db) => {
+			const resolved = resolveWriteIdentity(db, info);
+			db.prepare(
+				`INSERT INTO session_registry (
+					id, agent_id, session_key, session_id, harness, app_id, app_label,
+					project, cwd, runtime_path, provider, status, started_at, last_seen_at,
+					ended_at, end_reason, transcript_path, updated_at
+				)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'ended', ?, ?, ?, ?, ?, ?)
+				ON CONFLICT(id) DO UPDATE SET
+					session_key = COALESCE(session_registry.session_key, excluded.session_key),
+					session_id = COALESCE(session_registry.session_id, excluded.session_id),
+					harness = excluded.harness,
+					app_id = excluded.app_id,
+					app_label = excluded.app_label,
+					project = COALESCE(excluded.project, session_registry.project),
+					cwd = COALESCE(excluded.cwd, session_registry.cwd),
+					runtime_path = COALESCE(excluded.runtime_path, session_registry.runtime_path),
+					provider = COALESCE(excluded.provider, session_registry.provider),
+					status = 'ended',
+					last_seen_at = MAX(session_registry.last_seen_at, excluded.last_seen_at),
+					ended_at = excluded.ended_at,
+					end_reason = excluded.end_reason,
+					transcript_path = COALESCE(excluded.transcript_path, session_registry.transcript_path),
+					updated_at = excluded.updated_at`,
+			).run(
+				resolved.id,
+				resolved.agentId,
+				resolved.sessionKey,
+				resolved.sessionId,
+				resolved.harness,
+				resolved.appId,
+				resolved.appLabel,
+				clean(input.project),
+				clean(input.cwd),
+				input.runtimePath ?? null,
+				clean(input.provider),
+				endedAt,
+				endedAt,
+				endedAt,
+				reason,
+				transcriptPath,
+				endedAt,
+			);
+			const row = db.prepare("SELECT * FROM session_registry WHERE id = ?").get(resolved.id);
+			return row && typeof row === "object" ? rowToRecord(row as Record<string, unknown>) : null;
+		});
+	} catch (error) {
+		logger.warn("session-tracker", "Session registry end failed", {
+			error: error instanceof Error ? error.message : String(error),
+			sessionKey: info.sessionKey,
+			sessionId: info.sessionId,
+		});
+		return null;
+	}
+}
+
+export function listActiveSessionRegistry(options: ListSessionRegistryOptions = {}): SessionRegistryRecord[] {
+	if (!registryTableExists()) return [];
+	expireStaleSessions();
+	const agentId = clean(options.agentId);
+	const sessionKey = clean(options.sessionKey);
+	const sessionId = clean(options.sessionId);
+	const harness = clean(options.harness);
+	const project = clean(options.project);
+	const includeSelf = options.includeSelf !== false;
+	const limit = options.limit && Number.isFinite(options.limit) && options.limit > 0 ? Math.trunc(options.limit) : 50;
+
+	try {
+		return getDbAccessor().withReadDb((db) => {
+			const parts = ["SELECT * FROM session_registry WHERE status = 'active'"];
+			const args: unknown[] = [];
+			if (project) {
+				parts.push("AND project = ?");
+				args.push(project);
+			}
+			if (agentId) {
+				parts.push("AND agent_id = ?");
+				args.push(agentId);
+			}
+			const selfMatches: string[] = [];
+			const selfArgs: unknown[] = [];
+			if (sessionKey) {
+				selfMatches.push("session_key = ?");
+				selfArgs.push(sessionKey);
+			}
+			if (sessionId) {
+				selfMatches.push("session_id = ?");
+				selfArgs.push(sessionId);
+			}
+			if (agentId && !includeSelf && harness && selfMatches.length > 0) {
+				parts.push(`AND NOT (harness = ? AND (${selfMatches.join(" OR ")}))`);
+				args.push(harness, ...selfArgs);
+			}
+			parts.push("ORDER BY last_seen_at DESC LIMIT ?");
+			args.push(limit);
+			return db
+				.prepare(parts.join("\n"))
+				.all(...args)
+				.map((row) => rowToRecord(row as Record<string, unknown>));
+		});
+	} catch (error) {
+		logger.warn("session-tracker", "Session registry list failed", {
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return [];
+	}
+}

--- a/surfaces/cli/src/commands/hook.test.ts
+++ b/surfaces/cli/src/commands/hook.test.ts
@@ -6,6 +6,7 @@ import {
 	buildSessionEndBody,
 	buildSessionStartFallback,
 	buildUserPromptSubmitBody,
+	pickSessionId,
 	pickSessionKey,
 	registerHookCommands,
 	resolvePromptSubmitTimeout,
@@ -37,6 +38,18 @@ describe("pickSessionKey", () => {
 				sessionId: "sess-camel-id",
 			}),
 		).toBe("sess-camel-id");
+	});
+});
+
+describe("pickSessionId", () => {
+	test("preserves legacy session ids without treating canonical keys as ids", () => {
+		expect(
+			pickSessionId({
+				sessionKey: "sess-canonical-key",
+				sessionId: "sess-legacy-id",
+			}),
+		).toBe("sess-legacy-id");
+		expect(pickSessionId({ sessionKey: "sess-canonical-key" })).toBe("");
 	});
 });
 
@@ -141,7 +154,7 @@ describe("buildSessionEndBody", () => {
 			harness: "claude-code",
 			transcriptPath: "/tmp/session.txt",
 			transcript: "user: hi\nassistant: hello",
-			sessionId: "sess-1",
+			sessionId: "",
 			sessionKey: "sess-1",
 			cwd: "/tmp/project",
 			reason: "shutdown",
@@ -192,10 +205,27 @@ describe("buildUserPromptSubmitBody", () => {
 			userMessage: "clean prompt",
 			userPrompt: "raw prompt",
 			sessionKey: "sess-2",
+			sessionId: "",
 			transcriptPath: "",
 			transcript: "user: hi",
 			runtimePath: "legacy",
 			lastAssistantMessage: "prior answer",
+		});
+	});
+
+	test("preserves distinct legacy session ids without collapsing them into sessionKey", () => {
+		expect(
+			buildUserPromptSubmitBody(
+				{
+					prompt: "raw prompt",
+					sessionId: "sess-legacy-id",
+				},
+				"claude-code",
+				"/tmp/project",
+			),
+		).toMatchObject({
+			sessionKey: "",
+			sessionId: "sess-legacy-id",
 		});
 	});
 

--- a/surfaces/cli/src/commands/hook.ts
+++ b/surfaces/cli/src/commands/hook.ts
@@ -135,7 +135,8 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 		.option("--codex-json", "Output Codex hook JSON")
 		.action(async (options) => {
 			const input = await readJson();
-			const sessionKey = pickSessionKey(input);
+			const sessionKey = pickCanonicalSessionKey(input);
+			const sessionId = pickSessionId(input);
 			const stdinProject = pickString(input?.cwd);
 			const res = await deps.fetchDaemonResult<{
 				identity?: { name: string; description?: string };
@@ -151,6 +152,7 @@ export function registerHookCommands(program: Command, deps: HookDeps): void {
 					agentId: options.agentId,
 					context: options.context,
 					sessionKey,
+					sessionId,
 					runtimePath: LEGACY_RUNTIME_PATH,
 				}),
 				timeout: SESSION_START_TIMEOUT_MS,
@@ -429,7 +431,17 @@ function pickString(...values: unknown[]): string {
 
 export function pickSessionKey(input: Record<string, unknown> | null): string {
 	if (!input) return "";
-	return pickString(input.session_key, input.sessionKey, input.session_id, input.sessionId);
+	return pickString(pickCanonicalSessionKey(input), pickSessionId(input));
+}
+
+function pickCanonicalSessionKey(input: Record<string, unknown> | null): string {
+	if (!input) return "";
+	return pickString(input.session_key, input.sessionKey);
+}
+
+export function pickSessionId(input: Record<string, unknown> | null): string {
+	if (!input) return "";
+	return pickString(input.session_id, input.sessionId);
 }
 
 export function buildUserPromptSubmitBody(
@@ -442,6 +454,7 @@ export function buildUserPromptSubmitBody(
 	userMessage: string;
 	userPrompt: string;
 	sessionKey: string;
+	sessionId: string;
 	transcriptPath: string;
 	transcript: string;
 	lastAssistantMessage?: string;
@@ -456,7 +469,8 @@ export function buildUserPromptSubmitBody(
 		project,
 		userMessage,
 		userPrompt,
-		sessionKey: pickSessionKey(body),
+		sessionKey: pickCanonicalSessionKey(body),
+		sessionId: pickSessionId(body),
 		transcriptPath: pickString(body?.transcript_path, body?.transcriptPath),
 		transcript: pickString(body?.transcript),
 		runtimePath: LEGACY_RUNTIME_PATH,
@@ -509,8 +523,8 @@ export function buildSessionEndBody(
 	runtimePath: typeof LEGACY_RUNTIME_PATH;
 } {
 	const body = input ?? {};
-	const sessionKey = pickSessionKey(body);
-	const sessionId = pickString(body.session_id, body.sessionId, sessionKey);
+	const sessionKey = pickCanonicalSessionKey(body);
+	const sessionId = pickSessionId(body);
 	return {
 		harness,
 		transcriptPath: pickString(body.transcript_path, body.transcriptPath),


### PR DESCRIPTION
## Summary

- Add compact active peer-session visibility to session-start and user-prompt-submit context.
- Add a durable `session_registry` table so session identity, app metadata, status, end reason, and canonical transcript pointers survive beyond the in-memory presence map.
- Build prompt peer visibility from the registry plus live presence, with common app labels for Hermes Agent, Claude Code, Codex, OpenClaw, OpenCode, and friends.
- Update the cross-session visibility spec to depend on canonical JSONL transcripts and record the remaining session browser/search work.

## Why

Hermes Agent has a cleaner model: cheap live/recent session awareness first, deeper transcript search only when explicitly needed. The first draft only leaned on volatile presence, which was useful but too hacky. This revision treats presence as a live cache and gives Signet a durable lifecycle row that can point at `memory/{harness}/transcripts/transcript.jsonl`.

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Migration 064 creates `session_registry` with `IF NOT EXISTS` table/index DDL only. Existing memory/session data is not rewritten. JS daemon owns this registry today; Rust parity is N/A until daemon-rs implements this hook/session surface. Rollback compatibility is safe because older daemons ignore the extra table, and the feature degrades back to live in-memory presence when the registry is unavailable.

## PR Readiness

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Validation

- `bun run build:core`
- `bun scripts/spec-deps-check.ts`
- `bunx biome check platform/daemon/src/session-registry.ts platform/daemon/src/session-registry.test.ts platform/daemon/src/hooks.ts platform/daemon/src/routes/hooks-routes.ts surfaces/cli/src/commands/hook.ts surfaces/cli/src/commands/hook.test.ts`
- `bun test platform/daemon/src/session-registry.test.ts platform/daemon/src/hooks.prompt-submit.test.ts surfaces/cli/src/commands/hook.test.ts`
- `bun test platform/daemon/src/hooks.prompt-submit.test.ts platform/daemon/src/cross-agent.test.ts platform/daemon/src/transcript-jsonl.test.ts platform/core/src/migrations/migrations.test.ts platform/daemon/src/session-registry.test.ts surfaces/cli/src/commands/hook.test.ts`

Typecheck note: `cd platform/daemon && bun run build:types` was attempted. It still fails on existing daemon project-wide rootDir/test/config errors outside this PR surface; no new `session-registry.ts` type errors remain after changing its logger category to `session-tracker`.

## Notes

The follow-up spec still tracks the larger surface: configurable prompt budget, explicit session browser/search MCP tools, scoped summary/transcript search, ongoing transcript search over canonical JSONL, and RBAC/project/lineage enforcement.
