### PR TITLE
fix(cli): resolve bundled GraphIQ install script

### DIFF
--- a/surfaces/cli/src/features/graphiq.test.ts
+++ b/surfaces/cli/src/features/graphiq.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import {
 	SIGNET_GRAPHIQ_PLUGIN_ID,
 	getGraphiqProjectDbPath,
@@ -9,7 +9,13 @@ import {
 	updateGraphiqActiveProject,
 	writeGraphiqState,
 } from "@signet/core";
-import { ensureGraphiqInstalled, installGraphiqPlugin, runGraphiqDoctor, uninstallGraphiqPlugin } from "./graphiq.js";
+import {
+	ensureGraphiqInstalled,
+	installGraphiqPlugin,
+	resolveInstallScriptPath,
+	runGraphiqDoctor,
+	uninstallGraphiqPlugin,
+} from "./graphiq.js";
 import { readSetupCorePluginEnabled } from "./setup-plugins.js";
 
 let tempRoot = "";
@@ -25,6 +31,30 @@ afterEach(() => {
 });
 
 describe("GraphIQ plugin install", () => {
+	test("resolves bundled install script beside packaged CLI dist", () => {
+		const basePath = makeRoot();
+		const distDir = join(basePath, "node_modules", "signetai", "dist");
+		const scriptsDir = join(basePath, "node_modules", "signetai", "scripts");
+		const scriptPath = join(scriptsDir, "install-graphiq.sh");
+		mkdirSync(scriptsDir, { recursive: true });
+		mkdirSync(distDir, { recursive: true });
+		writeFileSync(scriptPath, "#!/bin/sh\n");
+
+		expect(resolveInstallScriptPath(distDir)).toBe(resolve(scriptPath));
+	});
+
+	test("falls back to source-tree install script during local development", () => {
+		const basePath = makeRoot();
+		const featureDir = join(basePath, "surfaces", "cli", "src", "features");
+		const scriptsDir = join(basePath, "scripts");
+		const scriptPath = join(scriptsDir, "install-graphiq.sh");
+		mkdirSync(featureDir, { recursive: true });
+		mkdirSync(scriptsDir, { recursive: true });
+		writeFileSync(scriptPath, "#!/bin/sh\n");
+
+		expect(resolveInstallScriptPath(featureDir)).toBe(resolve(scriptPath));
+	});
+
 	test("disables persisted GraphIQ runtime state when install fails", async () => {
 		const basePath = makeRoot();
 		const projectPath = join(basePath, "project");

--- a/surfaces/cli/src/features/graphiq.ts
+++ b/surfaces/cli/src/features/graphiq.ts
@@ -37,9 +37,12 @@ type GraphiqInstallSource = "script" | "homebrew" | "source" | "existing";
 
 const DEFAULT_INSTALL_DIR = join(homedir(), ".local", "bin");
 
-function getInstallScriptPath(): string {
-	const thisDir = dirname(fileURLToPath(import.meta.url));
-	return resolve(thisDir, "../../../../scripts/install-graphiq.sh");
+export function resolveInstallScriptPath(thisDir = dirname(fileURLToPath(import.meta.url))): string | null {
+	const candidates = [
+		resolve(thisDir, "../scripts/install-graphiq.sh"),
+		resolve(thisDir, "../../../../scripts/install-graphiq.sh"),
+	];
+	return candidates.find((candidate) => existsSync(candidate)) ?? null;
 }
 
 function resolveGraphiqBinary(): string | null {
@@ -87,8 +90,8 @@ export async function ensureGraphiqInstalled(options: {
 	if (hasGraphiqBinary()) return "existing";
 	if (!options.installIfMissing) return null;
 
-	const script = getInstallScriptPath();
-	if (!existsSync(script)) {
+	const script = resolveInstallScriptPath();
+	if (!script) {
 		console.log(chalk.red("  GraphIQ install script not found."));
 		return null;
 	}


### PR DESCRIPTION
## Summary

Fixes `signet graphiq install` from the packaged `signetai` CLI by resolving the bundled GraphIQ install script before falling back to the source-tree path used during local development.

## Root cause

The CLI bundle runs from `dist/cli.js` inside the published `signetai` package. The previous source-tree-relative lookup walked outside the installed package, so `scripts/install-graphiq.sh` could not be found even though it was included in the package.

## Changes

- Add a shared `resolveInstallScriptPath()` helper that checks `../scripts/install-graphiq.sh` first for packaged installs.
- Preserve the existing `../../../../scripts/install-graphiq.sh` fallback for local source-tree execution.
- Add regression coverage for both packaged and source-tree layouts.

## Validation

- `bun run --filter '@signet/cli' test src/features/graphiq.test.ts`
- `bunx biome check surfaces/cli/src/features/graphiq.ts surfaces/cli/src/features/graphiq.test.ts`
- `git diff --check -- surfaces/cli/src/features/graphiq.ts surfaces/cli/src/features/graphiq.test.ts`
- `cd dist/signetai && bun run copy:scripts && bun run build:cli`
- Smoke-tested the built packaged CLI with a fake `bash`; it invoked `dist/signetai/scripts/install-graphiq.sh install` instead of reporting the script missing.

Closes #578.
