### PR TITLE
fix(inference): repair Codex provider and test timeouts

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -406,7 +406,7 @@ signet route list
 signet route status
 signet route doctor
 signet route explain "fix this bun test" --agent rose --task-class hard_coding
-signet route test "summarize this transcript" --agent dot --task-class casual_chat
+signet route test "summarize this transcript" --agent dot --task-class casual_chat --timeout 60000
 signet route pin opus/opus46 --agent rose --task-class hard_coding
 signet route unpin --agent rose --task-class hard_coding
 ```
@@ -433,6 +433,7 @@ Common options:
 | `--privacy <privacy>` | Privacy tier override |
 | `--policy <policy>` | Explicit policy override |
 | `--target <targetRef>` | Explicit target pin for the current request |
+| `--timeout <ms>` | Request timeout for `route test`, up to 600000 ms |
 | `--refresh` | Re-check target health before routing |
 | `--debug` | Print the full routing decision trace |
 | `--json` | Emit raw JSON |

--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -367,17 +367,43 @@ describe("createCodexProvider", () => {
 		}) as unknown as typeof Bun.spawn;
 
 		const provider = createCodexProvider({ model: "gpt-5.3-codex" });
-		const result = await provider.generateWithUsage!("test");
+		if (!provider.generateWithUsage) {
+			throw new Error("expected generateWithUsage on Codex provider");
+		}
+		const result = await provider.generateWithUsage("test");
 		expect(result.text).toBe("done");
 		expect(result.usage?.inputTokens).toBe(12);
 		expect(result.usage?.cacheReadTokens).toBe(5);
 		expect(result.usage?.outputTokens).toBe(7);
 		expect(capturedArgs).not.toContain("-a");
 		expect(capturedArgs).toContain("--ephemeral");
-		expect(capturedArgs).toContain("mcp_servers.signet.enabled=false");
+		expect(capturedArgs).not.toContain("mcp_servers.signet.enabled=false");
 		expect(typeof capturedEnv?.HOME).toBe("string");
 		expect(capturedEnv?.HOME).not.toBe(process.env.HOME);
 		expect(typeof capturedEnv?.CODEX_HOME).toBe("string");
+	});
+
+	it("does not disable Signet MCP through an incomplete Codex config override", async () => {
+		let capturedArgs: string[] = [];
+		Bun.spawn = mock((args: string[]) => {
+			capturedArgs = args;
+			return {
+				stdout: streamFromString(
+					'{"type":"item.completed","item":{"type":"agent_message","text":"done"}}\n{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}\n',
+				),
+				stderr: streamFromString(""),
+				exited: Promise.resolve(0),
+				kill() {},
+			};
+		}) as unknown as typeof Bun.spawn;
+
+		const provider = createCodexProvider({ model: "gpt-5.3-codex" });
+		if (!provider.generateWithUsage) {
+			throw new Error("expected generateWithUsage on Codex provider");
+		}
+		await provider.generateWithUsage("test");
+
+		expect(capturedArgs).not.toContain("mcp_servers.signet.enabled=false");
 	});
 
 	it("spawns Codex with a sterile temp home and readonly copied auth", async () => {

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -2082,8 +2082,6 @@ export function createCodexProvider(config?: Partial<CodexProviderConfig>): LlmP
 					"--ephemeral",
 					"--sandbox",
 					"read-only",
-					"-c",
-					"mcp_servers.signet.enabled=false",
 					"-C",
 					cfg.workingDirectory,
 					"--model",

--- a/surfaces/cli/src/commands/route.test.ts
+++ b/surfaces/cli/src/commands/route.test.ts
@@ -87,6 +87,58 @@ describe("registerRouteCommands", () => {
 		expect(requestBody).toMatchObject({ maxTokens: 42 });
 	});
 
+	test("route test rejects invalid timeout values before daemon calls", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "signet-route-command-"));
+		tempDirs.push(dir);
+		const errors: string[] = [];
+		let called = false;
+		console.error = (line?: unknown) => {
+			errors.push(String(line ?? ""));
+		};
+		Object.defineProperty(process, "exit", {
+			configurable: true,
+			value(code?: string | number | null | undefined) {
+				throw new Error(`exit ${code ?? 0}`);
+			},
+		});
+		const program = new Command();
+		registerRouteCommands(program, {
+			AGENTS_DIR: dir,
+			fetchFromDaemon: async () => null,
+			secretApiCall: async () => {
+				called = true;
+				return { ok: true, data: null };
+			},
+		});
+
+		await expect(program.parseAsync(["node", "test", "route", "test", "hello", "--timeout", "0"])).rejects.toThrow(
+			"exit 1",
+		);
+
+		expect(called).toBe(false);
+		expect(errors.join("\n")).toContain("--timeout must be a positive integer");
+	});
+
+	test("route test forwards valid timeout values to the daemon request", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "signet-route-command-"));
+		tempDirs.push(dir);
+		let requestTimeout: number | undefined;
+		console.log = () => {};
+		const program = new Command();
+		registerRouteCommands(program, {
+			AGENTS_DIR: dir,
+			fetchFromDaemon: async () => null,
+			secretApiCall: async (_method, _path, _body, timeoutMs) => {
+				requestTimeout = timeoutMs;
+				return { ok: true, data: { text: "ok" } };
+			},
+		});
+
+		await program.parseAsync(["node", "test", "route", "test", "hello", "--timeout", "60000"]);
+
+		expect(requestTimeout).toBe(60000);
+	});
+
 	test("route pin refuses to rewrite an existing agent.yaml without explicit confirmation", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "signet-route-command-"));
 		tempDirs.push(dir);

--- a/surfaces/cli/src/commands/route.ts
+++ b/surfaces/cli/src/commands/route.ts
@@ -64,12 +64,22 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function parseMaxTokens(value: unknown): number | null | undefined {
+	return parsePositiveIntegerOption(value);
+}
+
+function parseTimeoutMs(value: unknown): number | null | undefined {
+	return parsePositiveIntegerOption(value, 600_000);
+}
+
+function parsePositiveIntegerOption(value: unknown, max?: number): number | null | undefined {
 	if (value === undefined) return undefined;
 	if (typeof value !== "string") return null;
 	const trimmed = value.trim();
 	if (!/^[1-9]\d*$/.test(trimmed)) return null;
 	const parsed = Number.parseInt(trimmed, 10);
-	return Number.isSafeInteger(parsed) ? parsed : null;
+	if (!Number.isSafeInteger(parsed)) return null;
+	if (max !== undefined && parsed > max) return null;
+	return parsed;
 }
 
 function parsePinnedTargetRef(
@@ -350,6 +360,7 @@ export function registerRouteCommands(program: Command, deps: RouteDeps): void {
 		.option("--policy <policy>", "Policy override")
 		.option("--target <targetRef>", "Pin to an explicit target ref")
 		.option("--max-tokens <maxTokens>", "Max output tokens")
+		.option("--timeout <ms>", "Request timeout in milliseconds, up to 600000")
 		.option("--refresh", "Refresh target health before inference")
 		.option("--debug", "Print the routed decision trace")
 		.option("--json", "Output as JSON")
@@ -360,17 +371,28 @@ export function registerRouteCommands(program: Command, deps: RouteDeps): void {
 				process.exit(1);
 				return;
 			}
-			const { ok, data } = await deps.secretApiCall("POST", "/api/inference/execute", {
-				prompt,
-				agentId: options.agent,
-				taskClass: options.taskClass,
-				operation: options.operation,
-				privacy: options.privacy,
-				explicitPolicy: options.policy,
-				explicitTargets: options.target ? [options.target] : undefined,
-				maxTokens,
-				refresh: options.refresh === true,
-			});
+			const timeoutMs = parseTimeoutMs(options.timeout);
+			if (timeoutMs === null) {
+				console.error(chalk.red("--timeout must be a positive integer no greater than 600000."));
+				process.exit(1);
+				return;
+			}
+			const { ok, data } = await deps.secretApiCall(
+				"POST",
+				"/api/inference/execute",
+				{
+					prompt,
+					agentId: options.agent,
+					taskClass: options.taskClass,
+					operation: options.operation,
+					privacy: options.privacy,
+					explicitPolicy: options.policy,
+					explicitTargets: options.target ? [options.target] : undefined,
+					maxTokens,
+					refresh: options.refresh === true,
+				},
+				timeoutMs,
+			);
 			if (!ok) {
 				console.error(chalk.red(`Routing test failed: ${JSON.stringify(data)}`));
 				process.exit(1);

--- a/surfaces/cli/src/lib/daemon.test.ts
+++ b/surfaces/cli/src/lib/daemon.test.ts
@@ -104,6 +104,20 @@ describe("createDaemonClient", () => {
 		expect(result.data).toEqual({ error: "Could not reach Signet daemon" });
 	});
 
+	test("secretApiCall reports timeout failures accurately", async () => {
+		globalThis.fetch = async () => {
+			const err = new Error("timed out");
+			Object.defineProperty(err, "name", { value: "TimeoutError" });
+			throw err;
+		};
+
+		const client = createDaemonClient(3850);
+		const result = await client.secretApiCall("POST", "/api/inference/execute", { prompt: "hi" }, 60000);
+
+		expect(result.ok).toBe(false);
+		expect(result.data).toEqual({ error: "Request timed out after 60000ms" });
+	});
+
 	test("secretApiCall falls back to text error payload when response is not json", async () => {
 		globalThis.fetch = async () =>
 			new Response("bad gateway", {

--- a/surfaces/cli/src/lib/daemon.ts
+++ b/surfaces/cli/src/lib/daemon.ts
@@ -101,7 +101,13 @@ export function createDaemonClient(port: number): {
 				data = { error: text || "Request failed" };
 			}
 			return { ok: res.ok, data };
-		} catch {
+		} catch (err) {
+			if (isTimeoutError(err)) {
+				return {
+					ok: false,
+					data: { error: `Request timed out after ${timeoutMs}ms` },
+				};
+			}
 			return {
 				ok: false,
 				data: { error: "Could not reach Signet daemon" },


### PR DESCRIPTION
## Summary

- Remove the Codex inference provider's `mcp_servers.signet.enabled=false` config override.
- Keep Codex inference isolated through the sterile temporary `HOME` and `CODEX_HOME` environment.
- Add a regression test that verifies the provider no longer passes the incomplete Signet MCP override.
- Add `signet route test --timeout <ms>` / `signet inference test --timeout <ms>` for longer real inference diagnostics.
- Report CLI daemon request timeouts as timeout failures instead of saying the daemon was unreachable.

## Changes

- `platform/daemon/src/pipeline/provider.ts` stops passing the incomplete Codex MCP disable override.
- `platform/daemon/src/pipeline/provider.test.ts` covers the Codex provider argument contract.
- `surfaces/cli/src/commands/route.ts` adds `--timeout <ms>` for routed inference tests.
- `surfaces/cli/src/lib/daemon.ts` reports client-side timeout failures accurately.
- CLI tests and `docs/CLI.md` document the timeout behavior.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A, no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Why

Closes #582.
Closes #584.

Codex inference was failing because Signet created a sterile Codex config home, then passed `-c mcp_servers.signet.enabled=false`. In that sterile config environment, the override creates an incomplete `mcp_servers.signet` table, and recent Codex versions reject it with `invalid transport in mcp_servers.signet`.

The sterile environment already prevents the real Signet MCP config from loading, so the override is unnecessary and unsafe.

The same diagnostic path also exposed that `signet inference test` had a hard 5s daemon request timeout and classified client-side request timeouts as daemon connectivity failures. The CLI now accepts an explicit timeout, validates it, forwards it to the daemon request, and reports timeout failures accurately.

## Migration Notes (if applicable)

N/A, no migrations touched.

## Testing

- [x] `bun test surfaces/cli/src/commands/route.test.ts surfaces/cli/src/lib/daemon.test.ts platform/daemon/src/pipeline/provider.test.ts`
- [x] `bun run --filter @signet/daemon build`
- [x] `bunx biome check surfaces/cli/src/commands/route.ts surfaces/cli/src/commands/route.test.ts surfaces/cli/src/lib/daemon.ts surfaces/cli/src/lib/daemon.test.ts docs/CLI.md platform/daemon/src/pipeline/provider.ts`
- [x] `bun run build:opencode-plugin && bun run build:oh-my-pi-extension && bun run build:pi-extension && bun run --filter '@signet/connector-opencode' --filter '@signet/connector-oh-my-pi' --filter '@signet/connector-pi' build && bun run --filter @signet/cli build`
- [ ] `bun run typecheck` passes
- [ ] Tested against running daemon

Note: `cd platform/daemon && bun run build:types` still fails on existing unrelated repo-wide TypeScript issues, including `rootDir` test imports from `platform/core/src`, existing `memory-search.test.ts` readonly config mutations, and existing GraphIQ route/tool typing issues. This PR does not add those failures.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The `checklist-exception` label is appropriate for the local typecheck item because the daemon declaration build is currently blocked by unrelated existing repo-wide TypeScript failures called out above.
