### PR TITLE
fix(daemon): streaming rewrite for live-only transcript sessions during backfill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 .bun-tmp/
 .claude/
 .codex/
+.sisyphus/
 .cursorindexingignore
 .env
 .env.*.local
@@ -36,6 +37,7 @@
 .vscode/
 .worktrees/
 /marketing/
+/packages/
 /references/
 Thumbs.db
 coverage/

--- a/platform/daemon/src/bun-socket-polyfill.test.ts
+++ b/platform/daemon/src/bun-socket-polyfill.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Duplex } from "node:stream";
+import { applyPolyfill } from "./bun-socket-polyfill";
+
+describe("destroySoon polyfill", () => {
+	let originalDestroySoon: typeof Duplex.prototype.destroySoon | undefined;
+
+	beforeEach(() => {
+		originalDestroySoon = Duplex.prototype.destroySoon;
+		// biome-ignore lint/performance/noDelete: test requires undefined, not a value
+		delete (Duplex.prototype as Record<string, unknown>).destroySoon;
+	});
+
+	afterEach(() => {
+		if (originalDestroySoon) {
+			Duplex.prototype.destroySoon = originalDestroySoon;
+		}
+	});
+
+	test("Duplex lacks destroySoon before polyfill (simulates Bun HTTP socket)", () => {
+		const socket = new Duplex({ read() {}, write(_c, _e, cb) { cb(); } });
+		expect(typeof socket.destroySoon).toBe("undefined");
+	});
+
+	test("polyfill adds destroySoon to Duplex prototype", () => {
+		applyPolyfill();
+		const socket = new Duplex({ read() {}, write(_c, _e, cb) { cb(); } });
+		expect(typeof socket.destroySoon).toBe("function");
+	});
+
+	test("destroySoon calls end() on writable socket then destroys after finish", async () => {
+		applyPolyfill();
+		const socket = new Duplex({ read() {}, write(_c, _e, cb) { cb(); } });
+
+		let ended = false;
+		let destroyed = false;
+		socket.on("finish", () => { ended = true; });
+		socket.on("close", () => { destroyed = true; });
+
+		socket.destroySoon();
+
+		await new Promise((r) => setTimeout(r, 50));
+		expect(ended).toBe(true);
+		expect(destroyed).toBe(true);
+	});
+
+	test("destroySoon destroys immediately if already finished writing", async () => {
+		applyPolyfill();
+		const socket = new Duplex({ read() {}, write(_c, _e, cb) { cb(); } });
+
+		socket.end();
+		await new Promise((r) => socket.once("finish", r));
+
+		let destroyed = false;
+		socket.on("close", () => { destroyed = true; });
+
+		socket.destroySoon();
+		await new Promise((r) => setTimeout(r, 50));
+		expect(destroyed).toBe(true);
+	});
+
+	test("polyfill does not overwrite existing destroySoon", () => {
+		const sentinel = function sentinel() {};
+		Duplex.prototype.destroySoon = sentinel as unknown as typeof Duplex.prototype.destroySoon;
+
+		applyPolyfill();
+
+		expect(Duplex.prototype.destroySoon).toBe(sentinel);
+	});
+});

--- a/platform/daemon/src/bun-socket-polyfill.ts
+++ b/platform/daemon/src/bun-socket-polyfill.ts
@@ -1,0 +1,25 @@
+/**
+ * Polyfill for Bun's NodeHTTPServerSocket missing `destroySoon()`.
+ *
+ * Bun's HTTP server socket wrapper extends Duplex but omits destroySoon().
+ * @hono/node-server ≥1.19.13 calls it in its drain handler, crashing the
+ * daemon on any unconsumed POST body.
+ *
+ * Semantics match Node.js net.Socket.destroySoon() exactly:
+ * https://github.com/nodejs/node/blob/main/lib/net.js#L785
+ *
+ * Tracks: https://github.com/oven-sh/bun/issues/24127
+ * Remove when Bun ships PR #26264.
+ */
+import { Duplex } from "node:stream";
+
+export function applyPolyfill(): void {
+	if (typeof Duplex.prototype.destroySoon === "function") return;
+	Duplex.prototype.destroySoon = function destroySoon() {
+		if (this.writable) this.end();
+		if (this.writableFinished) this.destroy();
+		else this.once("finish", this.destroy);
+	};
+}
+
+applyPolyfill();

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -4,6 +4,7 @@
  * Background service for memory, API, and dashboard hosting
  */
 
+import "./bun-socket-polyfill";
 import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";

--- a/platform/daemon/src/session-transcripts.ts
+++ b/platform/daemon/src/session-transcripts.ts
@@ -46,7 +46,6 @@ export interface TranscriptHit {
 
 interface BackfillSeen {
 	readonly classification: TranscriptSessionKeyClassification;
-	readonly allKeys: Set<string>;
 }
 
 function createBackfillSeenReader(basePath: string, agentId?: string): (harness: string) => Promise<BackfillSeen> {
@@ -57,11 +56,19 @@ function createBackfillSeenReader(basePath: string, agentId?: string): (harness:
 		if (existing) return existing;
 		const loaded = readCanonicalTranscriptSessionKeys({ basePath, harness, agentId }).then((classification) => ({
 			classification,
-			allKeys: new Set([...classification.canonicalKeys, ...classification.liveOnlyKeys]),
 		}));
 		seen.set(key, loaded);
 		return loaded;
 	};
+}
+
+function knownBackfillKeys(classification: TranscriptSessionKeyClassification): Set<string> {
+	return new Set([...classification.canonicalKeys, ...classification.liveOnlyKeys]);
+}
+
+function markBackfillCanonical(classification: TranscriptSessionKeyClassification, key: string): void {
+	classification.liveOnlyKeys.delete(key);
+	classification.canonicalKeys.add(key);
 }
 
 function tableExists(name: string): boolean {
@@ -135,7 +142,7 @@ async function backfillMarkdownTranscriptArtifacts(
 				sourcePath: `memory/${name}`,
 				transcript: parsed.body,
 			};
-			const { classification, allKeys } = await getSeen(harness);
+			const { classification } = await getSeen(harness);
 			const key = sessionSeqCacheKey(input);
 			if (classification.liveOnlyKeys.has(key)) {
 				const replacements =
@@ -154,7 +161,9 @@ async function backfillMarkdownTranscriptArtifacts(
 				liveOnlyReplacements.set(harness, replacements);
 				continue;
 			}
-			await appendCanonicalTranscriptSnapshotIfMissing(input, allKeys);
+			if (await appendCanonicalTranscriptSnapshotIfMissing(input, knownBackfillKeys(classification))) {
+				markBackfillCanonical(classification, key);
+			}
 		} catch (error) {
 			failures++;
 			logger.warn("transcripts", "Markdown transcript backfill failed", {
@@ -171,8 +180,7 @@ async function backfillMarkdownTranscriptArtifacts(
 			await rewriteReplacingLiveOnlySessions(jsonlPath, replacements);
 			const { classification } = await getSeen(harness);
 			for (const key of replacements.keys()) {
-				classification.liveOnlyKeys.delete(key);
-				classification.canonicalKeys.add(key);
+				markBackfillCanonical(classification, key);
 			}
 		} catch (error) {
 			failures++;
@@ -231,7 +239,7 @@ async function backfillDatabaseTranscripts(
 					sourceFormat: "db" as const,
 					transcript: row.content,
 				};
-				const { classification, allKeys } = await getSeen(harness);
+				const { classification } = await getSeen(harness);
 				const key = sessionSeqCacheKey(input);
 				if (classification.liveOnlyKeys.has(key)) {
 					const replacements =
@@ -249,7 +257,9 @@ async function backfillDatabaseTranscripts(
 					liveOnlyReplacements.set(harness, replacements);
 					continue;
 				}
-				await appendCanonicalTranscriptSnapshotIfMissing(input, allKeys);
+				if (await appendCanonicalTranscriptSnapshotIfMissing(input, knownBackfillKeys(classification))) {
+					markBackfillCanonical(classification, key);
+				}
 			}
 			offset += PAGE_SIZE;
 			await new Promise((resolve) => setTimeout(resolve, 0));
@@ -260,8 +270,7 @@ async function backfillDatabaseTranscripts(
 			await rewriteReplacingLiveOnlySessions(jsonlPath, replacements);
 			const { classification } = await getSeen(harness);
 			for (const key of replacements.keys()) {
-				classification.liveOnlyKeys.delete(key);
-				classification.canonicalKeys.add(key);
+				markBackfillCanonical(classification, key);
 			}
 		}
 	} catch (error) {

--- a/platform/daemon/src/session-transcripts.ts
+++ b/platform/daemon/src/session-transcripts.ts
@@ -5,9 +5,14 @@ import { getDbAccessor } from "./db-accessor";
 import { logger } from "./logger";
 import { sanitizeFtsQuery } from "./memory-search";
 import {
+	type TranscriptIdentity,
+	type TranscriptSessionKeyClassification,
 	appendCanonicalTranscriptSnapshotIfMissing,
+	canonicalTranscriptPath,
 	readCanonicalTranscriptSessionKeys,
+	rewriteReplacingLiveOnlySessions,
 	sanitizeHarnessPath,
+	sessionSeqCacheKey,
 } from "./transcript-jsonl";
 
 interface TranscriptRow {
@@ -39,13 +44,21 @@ export interface TranscriptHit {
 	readonly rank: number;
 }
 
-function createBackfillSeenReader(basePath: string, agentId?: string): (harness: string) => Promise<Set<string>> {
-	const seen = new Map<string, Promise<Set<string>>>();
+interface BackfillSeen {
+	readonly classification: TranscriptSessionKeyClassification;
+	readonly allKeys: Set<string>;
+}
+
+function createBackfillSeenReader(basePath: string, agentId?: string): (harness: string) => Promise<BackfillSeen> {
+	const seen = new Map<string, Promise<BackfillSeen>>();
 	return (harness: string) => {
 		const key = sanitizeHarnessPath(harness);
 		const existing = seen.get(key);
 		if (existing) return existing;
-		const loaded = readCanonicalTranscriptSessionKeys({ basePath, harness, agentId });
+		const loaded = readCanonicalTranscriptSessionKeys({ basePath, harness, agentId }).then((classification) => ({
+			classification,
+			allKeys: new Set([...classification.canonicalKeys, ...classification.liveOnlyKeys]),
+		}));
 		seen.set(key, loaded);
 		return loaded;
 	};
@@ -92,11 +105,15 @@ function parseArtifactFrontmatter(content: string): { frontmatter: Record<string
 async function backfillMarkdownTranscriptArtifacts(
 	basePath: string,
 	agentId: string | undefined,
-	getSeen: (harness: string) => Promise<Set<string>>,
+	getSeen: (harness: string) => Promise<BackfillSeen>,
 ): Promise<number> {
 	const memoryDir = join(basePath, "memory");
 	if (!existsSync(memoryDir)) return 0;
 	let failures = 0;
+	const liveOnlyReplacements = new Map<
+		string,
+		Map<string, { readonly identity: TranscriptIdentity; readonly transcript: string }>
+	>();
 	const files = readdirSync(memoryDir).filter((name) => name.endsWith("--transcript.md"));
 	for (const [i, name] of files.entries()) {
 		const path = join(memoryDir, name);
@@ -106,21 +123,38 @@ async function backfillMarkdownTranscriptArtifacts(
 			const rowAgentId = parsed.frontmatter.agent_id || "default";
 			if (agentId && rowAgentId !== agentId) continue;
 			const harness = parsed.frontmatter.harness || "unknown";
-			await appendCanonicalTranscriptSnapshotIfMissing(
-				{
-					basePath,
-					agentId: rowAgentId,
-					harness,
-					sessionKey: parsed.frontmatter.session_key || null,
-					sessionId: parsed.frontmatter.session_id || null,
-					project: parsed.frontmatter.project || null,
-					capturedAt: parsed.frontmatter.captured_at || new Date().toISOString(),
-					sourceFormat: "markdown",
-					sourcePath: `memory/${name}`,
-					transcript: parsed.body,
-				},
-				await getSeen(harness),
-			);
+			const input = {
+				basePath,
+				agentId: rowAgentId,
+				harness,
+				sessionKey: parsed.frontmatter.session_key || null,
+				sessionId: parsed.frontmatter.session_id || null,
+				project: parsed.frontmatter.project || null,
+				capturedAt: parsed.frontmatter.captured_at || new Date().toISOString(),
+				sourceFormat: "markdown" as const,
+				sourcePath: `memory/${name}`,
+				transcript: parsed.body,
+			};
+			const { classification, allKeys } = await getSeen(harness);
+			const key = sessionSeqCacheKey(input);
+			if (classification.liveOnlyKeys.has(key)) {
+				const replacements =
+					liveOnlyReplacements.get(harness) ||
+					new Map<string, { readonly identity: TranscriptIdentity; readonly transcript: string }>();
+				replacements.set(key, {
+					identity: {
+						agentId: input.agentId,
+						harness: input.harness,
+						sessionKey: input.sessionKey,
+						sessionId: input.sessionId,
+						sourceFormat: "markdown",
+					},
+					transcript: input.transcript,
+				});
+				liveOnlyReplacements.set(harness, replacements);
+				continue;
+			}
+			await appendCanonicalTranscriptSnapshotIfMissing(input, allKeys);
 		} catch (error) {
 			failures++;
 			logger.warn("transcripts", "Markdown transcript backfill failed", {
@@ -130,16 +164,39 @@ async function backfillMarkdownTranscriptArtifacts(
 		}
 		if (i > 0 && i % 100 === 0) await new Promise((resolve) => setTimeout(resolve, 0));
 	}
+	for (const [harness, replacements] of liveOnlyReplacements.entries()) {
+		if (replacements.size === 0) continue;
+		const jsonlPath = canonicalTranscriptPath(basePath, harness);
+		try {
+			await rewriteReplacingLiveOnlySessions(jsonlPath, replacements);
+			const { classification } = await getSeen(harness);
+			for (const key of replacements.keys()) {
+				classification.liveOnlyKeys.delete(key);
+				classification.canonicalKeys.add(key);
+			}
+		} catch (error) {
+			failures++;
+			logger.warn("transcripts", "Markdown transcript backfill rewrite failed", {
+				error: error instanceof Error ? error.message : String(error),
+				harness,
+				path: jsonlPath,
+			});
+		}
+	}
 	return failures;
 }
 
 async function backfillDatabaseTranscripts(
 	basePath: string,
 	agentId: string | undefined,
-	getSeen: (harness: string) => Promise<Set<string>>,
+	getSeen: (harness: string) => Promise<BackfillSeen>,
 ): Promise<boolean> {
 	if (!tableExists("session_transcripts")) return true;
 	const PAGE_SIZE = 100;
+	const liveOnlyReplacements = new Map<
+		string,
+		Map<string, { readonly identity: TranscriptIdentity; readonly transcript: string }>
+	>();
 	try {
 		let offset = 0;
 		while (true) {
@@ -164,22 +221,48 @@ async function backfillDatabaseTranscripts(
 				const rowAgentId = row.agent_id?.trim() || "default";
 				if (agentId && rowAgentId !== agentId) continue;
 				const harness = row.harness?.trim() || "unknown";
-				await appendCanonicalTranscriptSnapshotIfMissing(
-					{
-						basePath,
-						agentId: rowAgentId,
-						harness,
-						sessionKey: row.session_key,
-						project: row.project,
-						capturedAt: row.updated_at || row.created_at || new Date().toISOString(),
-						sourceFormat: "db",
-						transcript: row.content,
-					},
-					await getSeen(harness),
-				);
+				const input = {
+					basePath,
+					agentId: rowAgentId,
+					harness,
+					sessionKey: row.session_key,
+					project: row.project,
+					capturedAt: row.updated_at || row.created_at || new Date().toISOString(),
+					sourceFormat: "db" as const,
+					transcript: row.content,
+				};
+				const { classification, allKeys } = await getSeen(harness);
+				const key = sessionSeqCacheKey(input);
+				if (classification.liveOnlyKeys.has(key)) {
+					const replacements =
+						liveOnlyReplacements.get(harness) ||
+						new Map<string, { readonly identity: TranscriptIdentity; readonly transcript: string }>();
+					replacements.set(key, {
+						identity: {
+							agentId: input.agentId,
+							harness: input.harness,
+							sessionKey: input.sessionKey,
+							sourceFormat: "db",
+						},
+						transcript: input.transcript,
+					});
+					liveOnlyReplacements.set(harness, replacements);
+					continue;
+				}
+				await appendCanonicalTranscriptSnapshotIfMissing(input, allKeys);
 			}
 			offset += PAGE_SIZE;
 			await new Promise((resolve) => setTimeout(resolve, 0));
+		}
+		for (const [harness, replacements] of liveOnlyReplacements.entries()) {
+			if (replacements.size === 0) continue;
+			const jsonlPath = canonicalTranscriptPath(basePath, harness);
+			await rewriteReplacingLiveOnlySessions(jsonlPath, replacements);
+			const { classification } = await getSeen(harness);
+			for (const key of replacements.keys()) {
+				classification.liveOnlyKeys.delete(key);
+				classification.canonicalKeys.add(key);
+			}
 		}
 	} catch (error) {
 		logger.warn("transcripts", "Database transcript backfill failed", {

--- a/platform/daemon/src/transcript-jsonl.test.ts
+++ b/platform/daemon/src/transcript-jsonl.test.ts
@@ -8,6 +8,7 @@ import {
 	appendCanonicalTranscriptSnapshotIfMissing,
 	appendCanonicalTranscriptTurns,
 	canonicalTranscriptPath,
+	readCanonicalTranscriptSessionKeys,
 	writeCanonicalTranscriptSnapshot,
 } from "./transcript-jsonl";
 
@@ -319,5 +320,84 @@ describe("backfill OOM regression (#587)", () => {
 		expect(content).toContain("final prompt");
 		expect(content).toContain("final reply");
 		expect(content).toContain("second session");
+	});
+});
+
+describe("readCanonicalTranscriptSessionKeys classification", () => {
+	test("classifies canonical and live-only sessions separately", async () => {
+		const root = makeRoot("classify-separate");
+
+		await appendCanonicalTranscriptTurns({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-1",
+			sourceFormat: "live",
+			turns: [{ role: "user", content: "partial live turn" }],
+		});
+
+		await writeCanonicalTranscriptSnapshot({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-2",
+			sourceFormat: "db",
+			transcript: "User: canonical prompt\nAssistant: canonical reply",
+		});
+
+		const { canonicalKeys, liveOnlyKeys } = await readCanonicalTranscriptSessionKeys({
+			basePath: root,
+			harness: "codex",
+			agentId: "default",
+		});
+
+		expect(canonicalKeys.size).toBe(1);
+		expect(liveOnlyKeys.size).toBe(1);
+		for (const key of canonicalKeys) {
+			expect(liveOnlyKeys.has(key)).toBe(false);
+		}
+	});
+
+	test("promotes session to canonical when it has both live and non-live records", async () => {
+		const root = makeRoot("classify-promote");
+
+		await appendCanonicalTranscriptTurns({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-1",
+			sourceFormat: "live",
+			turns: [{ role: "user", content: "live partial" }],
+		});
+
+		await writeCanonicalTranscriptSnapshot({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-1",
+			sourceFormat: "normalized",
+			transcript: "User: canonical final\nAssistant: canonical reply",
+		});
+
+		const { canonicalKeys, liveOnlyKeys } = await readCanonicalTranscriptSessionKeys({
+			basePath: root,
+			harness: "codex",
+			agentId: "default",
+		});
+
+		expect(canonicalKeys.size).toBe(1);
+		expect(liveOnlyKeys.size).toBe(0);
+	});
+
+	test("returns empty sets for nonexistent file", async () => {
+		const root = makeRoot("classify-empty");
+		const { canonicalKeys, liveOnlyKeys } = await readCanonicalTranscriptSessionKeys({
+			basePath: root,
+			harness: "codex",
+			agentId: "default",
+		});
+
+		expect(canonicalKeys.size).toBe(0);
+		expect(liveOnlyKeys.size).toBe(0);
 	});
 });

--- a/platform/daemon/src/transcript-jsonl.test.ts
+++ b/platform/daemon/src/transcript-jsonl.test.ts
@@ -323,6 +323,114 @@ describe("backfill OOM regression (#587)", () => {
 		expect(content).toContain("final reply");
 		expect(content).toContain("second session");
 	});
+
+	test("writeCanonicalTranscriptSnapshot handles large files without excessive memory (OOM guard)", async () => {
+		const root = makeRoot("snapshot-oom-guard");
+		const jsonlPath = canonicalTranscriptPath(root, "opencode");
+
+		// Pre-populate with 200 sessions × 10 turns each = 2000 JSONL records (~3–5 MB)
+		mkdirSync(dirname(jsonlPath), { recursive: true });
+		const lines: string[] = [];
+		for (let s = 0; s < 200; s++) {
+			for (let t = 0; t < 10; t++) {
+				lines.push(
+					JSON.stringify({
+						schema: "signet.transcript.v1",
+						id: `pre-${s}-${t}`,
+						captured_at: "2026-04-01T00:00:00.000Z",
+						agent_id: "default",
+						harness: "opencode",
+						session_key: `session-${s}`,
+						session_id: `session-${s}`,
+						project: null,
+						seq: t + 1,
+						role: t % 2 === 0 ? "user" : "assistant",
+						content: `Turn ${t} of session ${s} with padding ${"x".repeat(500)}`,
+						source_format: "normalized",
+						source_sha256: `sha-${s}-${t}`,
+					}),
+				);
+			}
+		}
+		writeFileSync(jsonlPath, `${lines.join("\n")}\n`, "utf8");
+
+		const sizeBefore = statSync(jsonlPath).size;
+		expect(sizeBefore).toBeGreaterThan(1_000_000); // At least 1 MB
+
+		// Replace one session (session-50)
+		await writeCanonicalTranscriptSnapshot({
+			basePath: root,
+			agentId: "default",
+			harness: "opencode",
+			sessionKey: "session-50",
+			sourceFormat: "normalized",
+			transcript: "User: replaced prompt\nAssistant: replaced reply",
+		});
+
+		const content = readFileSync(jsonlPath, "utf8");
+		const records = content
+			.split("\n")
+			.filter((l) => l.trim().length > 0)
+			.map((l) => JSON.parse(l) as { session_key: string; content: string });
+
+		// session-50 records replaced
+		const session50 = records.filter((r) => r.session_key === "session-50");
+		expect(session50.length).toBe(2);
+		expect(session50[0]?.content).toBe("replaced prompt");
+		expect(session50[1]?.content).toBe("replaced reply");
+
+		// Other sessions preserved
+		const session0 = records.filter((r) => r.session_key === "session-0");
+		expect(session0.length).toBe(10);
+
+		const session199 = records.filter((r) => r.session_key === "session-199");
+		expect(session199.length).toBe(10);
+
+		// Total records: (200 - 1) * 10 + 2 = 1992
+		expect(records.length).toBe(1992);
+	});
+
+	test("writeCanonicalTranscriptSnapshot overwrites stale temp file from prior crash", async () => {
+		const root = makeRoot("snapshot-stale-tmp");
+		const jsonlPath = canonicalTranscriptPath(root, "opencode");
+
+		// Create initial JSONL with one session
+		await appendCanonicalTranscriptTurns({
+			basePath: root,
+			agentId: "default",
+			harness: "opencode",
+			sessionKey: "existing-session",
+			sourceFormat: "live",
+			turns: [
+				{ role: "user", content: "existing prompt" },
+				{ role: "assistant", content: "existing reply" },
+			],
+		});
+
+		// Simulate a crash leaving a stale .snapshot-tmp
+		const staleTmp = `${jsonlPath}.snapshot-tmp`;
+		writeFileSync(staleTmp, "corrupted partial write\n", "utf8");
+		expect(existsSync(staleTmp)).toBe(true);
+
+		// Write a new snapshot — should overwrite the stale tmp and succeed
+		await writeCanonicalTranscriptSnapshot({
+			basePath: root,
+			agentId: "default",
+			harness: "opencode",
+			sessionKey: "new-session",
+			sourceFormat: "normalized",
+			transcript: "User: new prompt\nAssistant: new reply",
+		});
+
+		// Stale tmp cleaned up (renamed over)
+		expect(existsSync(staleTmp)).toBe(false);
+
+		// Both sessions present in final JSONL
+		const content = readFileSync(jsonlPath, "utf8");
+		expect(content).toContain("existing prompt");
+		expect(content).toContain("new prompt");
+		expect(content).toContain("new reply");
+	});
 });
 
 describe("backfill replaces live-only sessions", () => {

--- a/platform/daemon/src/transcript-jsonl.test.ts
+++ b/platform/daemon/src/transcript-jsonl.test.ts
@@ -9,6 +9,8 @@ import {
 	appendCanonicalTranscriptTurns,
 	canonicalTranscriptPath,
 	readCanonicalTranscriptSessionKeys,
+	rewriteReplacingLiveOnlySessions,
+	sessionSeqCacheKey,
 	writeCanonicalTranscriptSnapshot,
 } from "./transcript-jsonl";
 
@@ -399,5 +401,182 @@ describe("readCanonicalTranscriptSessionKeys classification", () => {
 
 		expect(canonicalKeys.size).toBe(0);
 		expect(liveOnlyKeys.size).toBe(0);
+	});
+});
+
+describe("rewriteReplacingLiveOnlySessions", () => {
+	test("replaces live-only session with fuller data and preserves canonical sessions", async () => {
+		const root = makeRoot("rewrite-replace");
+		const jsonlPath = canonicalTranscriptPath(root, "codex");
+
+		await writeCanonicalTranscriptSnapshot({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-a",
+			sourceFormat: "db",
+			transcript: "User: A prompt\nAssistant: A reply",
+		});
+		await appendCanonicalTranscriptTurns({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-b",
+			sourceFormat: "live",
+			turns: [{ role: "user", content: "B partial" }],
+		});
+		await writeCanonicalTranscriptSnapshot({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-c",
+			sourceFormat: "db",
+			transcript: "User: C prompt\nAssistant: C reply",
+		});
+
+		const sessionBIdentity = {
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-b",
+			sourceFormat: "db" as const,
+		};
+		const replaced = await rewriteReplacingLiveOnlySessions(
+			jsonlPath,
+			new Map([
+				[
+					sessionSeqCacheKey(sessionBIdentity),
+					{ identity: sessionBIdentity, transcript: "User: B canonical\nAssistant: B reply" },
+				],
+			]),
+		);
+
+		expect(replaced).toBe(1);
+		const lines = readFileSync(jsonlPath, "utf8")
+			.split(/\r?\n/)
+			.filter((line) => line.trim().length > 0)
+			.map((line) => JSON.parse(line) as { readonly session_key: string | null; readonly source_format: string; readonly content: string });
+
+		expect(lines.some((line) => line.session_key === "session-a" && line.content.includes("A prompt"))).toBe(true);
+		expect(lines.some((line) => line.session_key === "session-c" && line.content.includes("C prompt"))).toBe(true);
+		expect(lines.some((line) => line.session_key === "session-b" && line.source_format === "live")).toBe(false);
+		expect(lines.some((line) => line.session_key === "session-b" && line.content.includes("B canonical"))).toBe(true);
+		expect(lines.filter((line) => line.session_key === "session-b").every((line) => line.source_format === "db")).toBe(true);
+	});
+
+	test("preserves chronological file order after replacement", async () => {
+		const root = makeRoot("rewrite-order");
+		const jsonlPath = canonicalTranscriptPath(root, "codex");
+
+		await writeCanonicalTranscriptSnapshot({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-a",
+			sourceFormat: "db",
+			transcript: "User: A one",
+		});
+		await appendCanonicalTranscriptTurns({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-b",
+			sourceFormat: "live",
+			turns: [{ role: "user", content: "B only" }],
+		});
+		await writeCanonicalTranscriptSnapshot({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-c",
+			sourceFormat: "db",
+			transcript: "User: C one",
+		});
+
+		const sessionBIdentity = {
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-b",
+			sourceFormat: "db" as const,
+		};
+		await rewriteReplacingLiveOnlySessions(
+			jsonlPath,
+			new Map([
+				[
+					sessionSeqCacheKey(sessionBIdentity),
+					{ identity: sessionBIdentity, transcript: "User: B canonical\nAssistant: B two" },
+				],
+			]),
+		);
+
+		const lines = readFileSync(jsonlPath, "utf8")
+			.split(/\r?\n/)
+			.filter((line) => line.trim().length > 0)
+			.map((line) => JSON.parse(line) as { readonly session_key: string | null; readonly source_format: string });
+
+		const firstA = lines.findIndex((line) => line.session_key === "session-a");
+		const firstB = lines.findIndex((line) => line.session_key === "session-b");
+		const firstC = lines.findIndex((line) => line.session_key === "session-c");
+		expect(firstA).toBeGreaterThanOrEqual(0);
+		expect(firstB).toBeGreaterThanOrEqual(0);
+		expect(firstC).toBeGreaterThanOrEqual(0);
+		expect(firstA).toBeLessThan(firstB);
+		expect(firstB).toBeLessThan(firstC);
+		expect(lines.filter((line) => line.session_key === "session-b").every((line) => line.source_format === "db")).toBe(true);
+	});
+
+	test("overwrites stale rewrite-tmp file from interrupted previous rewrite", async () => {
+		const root = makeRoot("rewrite-stale-tmp");
+		const jsonlPath = canonicalTranscriptPath(root, "codex");
+		await appendCanonicalTranscriptTurns({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-1",
+			sourceFormat: "live",
+			turns: [{ role: "user", content: "partial stale" }],
+		});
+
+		const tmpPath = `${jsonlPath}.rewrite-tmp`;
+		writeFileSync(tmpPath, "stale interrupted rewrite", "utf8");
+
+		const identity = {
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-1",
+			sourceFormat: "db" as const,
+		};
+		const replaced = await rewriteReplacingLiveOnlySessions(
+			jsonlPath,
+			new Map([[sessionSeqCacheKey(identity), { identity, transcript: "User: complete one\nAssistant: complete two" }]]),
+		);
+
+		expect(replaced).toBe(1);
+		const content = readFileSync(jsonlPath, "utf8");
+		expect(content).not.toContain("stale interrupted rewrite");
+		expect(content).toContain("complete one");
+		expect(existsSync(tmpPath)).toBe(false);
+	});
+
+	test("returns 0 for empty replacements map", async () => {
+		const root = makeRoot("rewrite-empty-map");
+		const jsonlPath = canonicalTranscriptPath(root, "codex");
+		await appendCanonicalTranscriptTurns({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-empty",
+			sourceFormat: "live",
+			turns: [{ role: "user", content: "keep me" }],
+		});
+
+		const before = readFileSync(jsonlPath, "utf8");
+		const replaced = await rewriteReplacingLiveOnlySessions(jsonlPath, new Map());
+		const after = readFileSync(jsonlPath, "utf8");
+
+		expect(replaced).toBe(0);
+		expect(after).toBe(before);
 	});
 });

--- a/platform/daemon/src/transcript-jsonl.test.ts
+++ b/platform/daemon/src/transcript-jsonl.test.ts
@@ -807,4 +807,79 @@ describe("rewriteReplacingLiveOnlySessions", () => {
 		expect(replaced).toBe(0);
 		expect(after).toBe(before);
 	});
+
+	test("preserves non-live records for a replaced session key", async () => {
+		const root = makeRoot("rewrite-preserve-nonlive");
+
+		await appendCanonicalTranscriptTurns({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-1",
+			sourceFormat: "live",
+			turns: [{ role: "user", content: "live turn one" }],
+		});
+
+		await writeCanonicalTranscriptSnapshot({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-1",
+			sourceFormat: "normalized",
+			transcript: "User: canonical turn\nAssistant: canonical reply",
+		});
+
+		const jsonlPath = canonicalTranscriptPath(root, "codex");
+		const identity = {
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-1",
+			sourceFormat: "db" as const,
+		};
+		const key = sessionSeqCacheKey(identity);
+		const replacements = new Map([
+			[key, { identity, transcript: "User: db replacement\nAssistant: db reply" }],
+		]);
+
+		await rewriteReplacingLiveOnlySessions(jsonlPath, replacements);
+
+		const content = readFileSync(jsonlPath, "utf8");
+		// Session was already healed (non-live records) — replacement skipped
+		expect(content).toContain("canonical turn");
+		expect(content).toContain("canonical reply");
+		expect(content).not.toContain("db replacement");
+	});
+
+	test("preserves original lines when replacement transcript is empty", async () => {
+		const root = makeRoot("rewrite-empty-transcript");
+
+		await appendCanonicalTranscriptTurns({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-1",
+			sourceFormat: "live",
+			turns: [{ role: "user", content: "preserve me" }],
+		});
+
+		const jsonlPath = canonicalTranscriptPath(root, "codex");
+		const identity = {
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-1",
+			sourceFormat: "db" as const,
+		};
+		const key = sessionSeqCacheKey(identity);
+		const replacements = new Map([
+			[key, { identity, transcript: "" }],
+		]);
+
+		const count = await rewriteReplacingLiveOnlySessions(jsonlPath, replacements);
+
+		const content = readFileSync(jsonlPath, "utf8");
+		expect(content).toContain("preserve me");
+		expect(count).toBe(0);
+	});
 });

--- a/platform/daemon/src/transcript-jsonl.test.ts
+++ b/platform/daemon/src/transcript-jsonl.test.ts
@@ -3,6 +3,7 @@ import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, write
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import { ensureCanonicalTranscriptHistory } from "./session-transcripts";
 import {
 	appendCanonicalTranscriptSnapshotIfMissing,
@@ -23,6 +24,7 @@ function makeRoot(name: string): string {
 }
 
 afterEach(() => {
+	closeDbAccessor();
 	for (const root of roots.splice(0)) {
 		rmSync(root, { recursive: true, force: true });
 	}
@@ -483,6 +485,23 @@ describe("backfill replaces live-only sessions", () => {
 			);
 	}
 
+	function initTranscriptDb(root: string): void {
+		initDbAccessor(join(root, "memory", "memories.db"), { agentsDir: root });
+		getDbAccessor().withWriteTx((db) => {
+			db.exec(
+				`CREATE TABLE IF NOT EXISTS session_transcripts (
+					session_key TEXT NOT NULL,
+					content TEXT NOT NULL,
+					harness TEXT,
+					project TEXT,
+					agent_id TEXT,
+					created_at TEXT,
+					updated_at TEXT
+				)`,
+			);
+		});
+	}
+
 	test("markdown backfill replaces live-only session with fuller artifact data", async () => {
 		const root = makeRoot("backfill-live-replace");
 
@@ -509,6 +528,55 @@ describe("backfill replaces live-only sessions", () => {
 		expect(lines.some((line) => line.session_key === "live-session" && line.source_format === "markdown")).toBe(true);
 		expect(lines.some((line) => line.session_key === "live-session" && line.content.includes("fuller migrated reply"))).toBe(true);
 		expect(lines.some((line) => line.session_key === "live-session" && line.content.includes("partial live prompt"))).toBe(false);
+	});
+
+	test("does not duplicate a session when DB backfill follows markdown live-only promotion", async () => {
+		const root = makeRoot("backfill-markdown-db-same-session");
+		initTranscriptDb(root);
+
+		await appendCanonicalTranscriptTurns({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "shared-session",
+			sourceFormat: "live",
+			turns: [{ role: "user", content: "partial live prompt" }],
+		});
+
+		writeTranscriptArtifact({
+			root,
+			fileName: "2026-04-29T00-00-00Z--sharedsession000--transcript.md",
+			sessionKey: "shared-session",
+			transcript: "User: markdown prompt\nAssistant: markdown reply",
+		});
+
+		getDbAccessor()
+			.withWriteTx((db) =>
+				db
+					.prepare(
+						`INSERT INTO session_transcripts (
+							session_key, content, harness, project, agent_id, created_at, updated_at
+						) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+					)
+					.run(
+						"shared-session",
+						"User: db prompt\nAssistant: db reply",
+						"codex",
+						null,
+						"default",
+						"2026-04-29T00:01:00.000Z",
+						"2026-04-29T00:01:00.000Z",
+					),
+			);
+
+		await ensureCanonicalTranscriptHistory(root, "default");
+
+		const lines = readJsonlLines(root).filter((line) => line.session_key === "shared-session");
+		expect(lines).toHaveLength(2);
+		expect(lines.every((line) => line.source_format === "markdown")).toBe(true);
+		expect(lines.some((line) => line.content.includes("markdown reply"))).toBe(true);
+		expect(lines.some((line) => line.content.includes("db reply"))).toBe(false);
+		expect(lines.some((line) => line.source_format === "live")).toBe(false);
 	});
 
 	test("canonical sessions are not replaced during backfill", async () => {

--- a/platform/daemon/src/transcript-jsonl.test.ts
+++ b/platform/daemon/src/transcript-jsonl.test.ts
@@ -1014,6 +1014,49 @@ describe("rewriteReplacingLiveOnlySessions", () => {
 		expect(liveTurn.seq).toBe(6);
 	});
 
+	test("skips replacement when session has both live and non-live records (race guard)", async () => {
+		const root = makeRoot("rewrite-race-guard");
+
+		await appendCanonicalTranscriptTurns({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-1",
+			sourceFormat: "live",
+			turns: [{ role: "user", content: "live partial" }],
+		});
+
+		await appendCanonicalTranscriptTurns({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-1",
+			sourceFormat: "normalized",
+			turns: [{ role: "user", content: "canonical full" }, { role: "assistant", content: "canonical reply" }],
+		});
+
+		const jsonlPath = canonicalTranscriptPath(root, "codex");
+		const identity = {
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-1",
+			sourceFormat: "db" as const,
+		};
+		const key = sessionSeqCacheKey(identity);
+		const replacements = new Map([
+			[key, { identity, transcript: "User: db version\nAssistant: db reply" }],
+		]);
+
+		const count = await rewriteReplacingLiveOnlySessions(jsonlPath, replacements);
+
+		const content = readFileSync(jsonlPath, "utf8");
+		expect(content).toContain("live partial");
+		expect(content).toContain("canonical full");
+		expect(content).not.toContain("db version");
+		expect(count).toBe(1);
+	});
+
 	test("preserves original lines when replacement transcript is empty", async () => {
 		const root = makeRoot("rewrite-empty-transcript");
 

--- a/platform/daemon/src/transcript-jsonl.test.ts
+++ b/platform/daemon/src/transcript-jsonl.test.ts
@@ -474,6 +474,83 @@ describe("backfill replaces live-only sessions", () => {
 		expect(lines.some((line) => line.session_key === "existing-session" && line.content.includes("existing reply"))).toBe(true);
 		expect(lines.some((line) => line.session_key === "new-session" && line.content.includes("new markdown reply"))).toBe(true);
 	});
+
+	test("handles many live-only sessions without full-file parse (OOM guard)", async () => {
+		const root = makeRoot("backfill-oom-guard");
+		const memDir = join(root, "memory");
+
+		// Pre-populate with canonical data (creates a non-trivial file)
+		for (let i = 0; i < 50; i++) {
+			await writeCanonicalTranscriptSnapshot({
+				basePath: root,
+				agentId: "default",
+				harness: "codex",
+				sessionKey: `canonical-${i}`,
+				sourceFormat: "normalized",
+				transcript: `User: canonical prompt ${i} ${"x".repeat(200)}\nAssistant: canonical reply ${i} ${"y".repeat(200)}`,
+			});
+		}
+
+		// Add 20 live-only sessions
+		for (let i = 0; i < 20; i++) {
+			await appendCanonicalTranscriptTurns({
+				basePath: root,
+				agentId: "default",
+				harness: "codex",
+				sessionKey: `live-${i}`,
+				sessionId: `live-${i}`,
+				sourceFormat: "live",
+				turns: [
+					{ role: "user", content: `live prompt ${i}` },
+					{ role: "assistant", content: `live reply ${i}` },
+				],
+			});
+		}
+
+		// Create markdown artifacts with fuller data for all 20 live-only sessions
+		mkdirSync(memDir, { recursive: true });
+		for (let i = 0; i < 20; i++) {
+			writeFileSync(
+				join(memDir, `2026-04-29T00-00-00Z--oomguard${String(i).padStart(6, "0")}--transcript.md`),
+				[
+					"---",
+					'kind: "transcript"',
+					'agent_id: "default"',
+					'harness: "codex"',
+					`session_key: "live-${i}"`,
+					`session_id: "live-${i}"`,
+					`captured_at: "2026-04-29T00:00:${String(i).padStart(2, "0")}.000Z"`,
+					"---",
+					`User: full prompt ${i}`,
+					`Assistant: full reply ${i}`,
+					`User: follow-up ${i}`,
+					`Assistant: follow-up reply ${i}`,
+					"",
+				].join("\n"),
+				"utf8",
+			);
+		}
+
+		await ensureCanonicalTranscriptHistory(root, "default");
+
+		const jsonlPath = join(memDir, "codex", "transcripts", "transcript.jsonl");
+		const content = readFileSync(jsonlPath, "utf8");
+
+		// All 20 live-only sessions replaced
+		for (let i = 0; i < 20; i++) {
+			expect(content).not.toContain(`live prompt ${i}`);
+			expect(content).toContain(`full prompt ${i}`);
+			expect(content).toContain(`follow-up ${i}`);
+		}
+
+		// All 50 canonical sessions untouched
+		for (let i = 0; i < 50; i++) {
+			expect(content).toContain(`canonical prompt ${i}`);
+		}
+
+		// Marker written
+		expect(existsSync(join(memDir, ".canonical-transcript-backfill-v1.default"))).toBe(true);
+	});
 });
 
 describe("readCanonicalTranscriptSessionKeys classification", () => {

--- a/platform/daemon/src/transcript-jsonl.test.ts
+++ b/platform/daemon/src/transcript-jsonl.test.ts
@@ -325,6 +325,157 @@ describe("backfill OOM regression (#587)", () => {
 	});
 });
 
+describe("backfill replaces live-only sessions", () => {
+	function writeTranscriptArtifact(params: {
+		readonly root: string;
+		readonly fileName: string;
+		readonly agentId?: string;
+		readonly harness?: string;
+		readonly sessionKey: string;
+		readonly sessionId?: string;
+		readonly capturedAt?: string;
+		readonly transcript: string;
+	}): void {
+		const artifact = join(params.root, "memory", params.fileName);
+		mkdirSync(dirname(artifact), { recursive: true });
+		writeFileSync(
+			artifact,
+			[
+				"---",
+				'kind: "transcript"',
+				`agent_id: ${JSON.stringify(params.agentId || "default")}`,
+				`harness: ${JSON.stringify(params.harness || "codex")}`,
+				`session_key: ${JSON.stringify(params.sessionKey)}`,
+				`session_id: ${JSON.stringify(params.sessionId || params.sessionKey)}`,
+				`captured_at: ${JSON.stringify(params.capturedAt || "2026-04-28T00:00:00.000Z")}`,
+				"---",
+				params.transcript,
+				"",
+			].join("\n"),
+			"utf8",
+		);
+	}
+
+	function readJsonlLines(root: string): Array<{
+		readonly session_key: string | null;
+		readonly source_format: string;
+		readonly content: string;
+	}> {
+		const jsonlPath = canonicalTranscriptPath(root, "codex");
+		return readFileSync(jsonlPath, "utf8")
+			.split(/\r?\n/)
+			.filter((line) => line.trim().length > 0)
+			.map(
+				(line) =>
+					JSON.parse(line) as {
+						readonly session_key: string | null;
+						readonly source_format: string;
+						readonly content: string;
+					},
+			);
+	}
+
+	test("markdown backfill replaces live-only session with fuller artifact data", async () => {
+		const root = makeRoot("backfill-live-replace");
+
+		await appendCanonicalTranscriptTurns({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "live-session",
+			sourceFormat: "live",
+			turns: [{ role: "user", content: "partial live prompt" }],
+		});
+
+		writeTranscriptArtifact({
+			root,
+			fileName: "2026-04-29T00-00-00Z--livesession000000--transcript.md",
+			sessionKey: "live-session",
+			transcript: "User: fuller migrated prompt\nAssistant: fuller migrated reply",
+		});
+
+		await ensureCanonicalTranscriptHistory(root, "default");
+
+		const lines = readJsonlLines(root);
+		expect(lines.some((line) => line.session_key === "live-session" && line.source_format === "live")).toBe(false);
+		expect(lines.some((line) => line.session_key === "live-session" && line.source_format === "markdown")).toBe(true);
+		expect(lines.some((line) => line.session_key === "live-session" && line.content.includes("fuller migrated reply"))).toBe(true);
+		expect(lines.some((line) => line.session_key === "live-session" && line.content.includes("partial live prompt"))).toBe(false);
+	});
+
+	test("canonical sessions are not replaced during backfill", async () => {
+		const root = makeRoot("backfill-canonical-untouched");
+
+		await writeCanonicalTranscriptSnapshot({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "canonical-session",
+			sourceFormat: "db",
+			transcript: "User: canonical source\nAssistant: canonical source reply",
+		});
+		await appendCanonicalTranscriptTurns({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "live-session",
+			sourceFormat: "live",
+			turns: [{ role: "user", content: "live only content" }],
+		});
+
+		writeTranscriptArtifact({
+			root,
+			fileName: "2026-04-29T00-00-00Z--canon-session0000--transcript.md",
+			sessionKey: "canonical-session",
+			transcript: "User: markdown should not replace canonical\nAssistant: markdown should not replace canonical",
+		});
+		writeTranscriptArtifact({
+			root,
+			fileName: "2026-04-29T00-00-00Z--live-session00000--transcript.md",
+			sessionKey: "live-session",
+			transcript: "User: markdown replacement for live\nAssistant: markdown replacement reply",
+		});
+
+		await ensureCanonicalTranscriptHistory(root, "default");
+
+		const lines = readJsonlLines(root);
+		expect(lines.some((line) => line.session_key === "canonical-session" && line.content.includes("canonical source reply"))).toBe(
+			true,
+		);
+		expect(lines.some((line) => line.session_key === "canonical-session" && line.content.includes("markdown should not replace canonical"))).toBe(
+			false,
+		);
+		expect(lines.some((line) => line.session_key === "live-session" && line.source_format === "live")).toBe(false);
+		expect(lines.some((line) => line.session_key === "live-session" && line.content.includes("markdown replacement reply"))).toBe(true);
+	});
+
+	test("new sessions still appended normally", async () => {
+		const root = makeRoot("backfill-new-append");
+
+		await writeCanonicalTranscriptSnapshot({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "existing-session",
+			sourceFormat: "db",
+			transcript: "User: existing canonical\nAssistant: existing reply",
+		});
+
+		writeTranscriptArtifact({
+			root,
+			fileName: "2026-04-29T00-00-00Z--new-session0000000--transcript.md",
+			sessionKey: "new-session",
+			transcript: "User: new markdown prompt\nAssistant: new markdown reply",
+		});
+
+		await ensureCanonicalTranscriptHistory(root, "default");
+
+		const lines = readJsonlLines(root);
+		expect(lines.some((line) => line.session_key === "existing-session" && line.content.includes("existing reply"))).toBe(true);
+		expect(lines.some((line) => line.session_key === "new-session" && line.content.includes("new markdown reply"))).toBe(true);
+	});
+});
+
 describe("readCanonicalTranscriptSessionKeys classification", () => {
 	test("classifies canonical and live-only sessions separately", async () => {
 		const root = makeRoot("classify-separate");

--- a/platform/daemon/src/transcript-jsonl.test.ts
+++ b/platform/daemon/src/transcript-jsonl.test.ts
@@ -959,6 +959,61 @@ describe("rewriteReplacingLiveOnlySessions", () => {
 		expect(content).not.toContain("db replacement");
 	});
 
+	test("healed session does not clobber seq cache with replacement turn count", async () => {
+		const root = makeRoot("rewrite-healed-seq");
+
+		// Write 5 canonical turns (seq 1-5) via snapshot.
+		await writeCanonicalTranscriptSnapshot({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-1",
+			sourceFormat: "normalized",
+			transcript: [
+				"User: turn one",
+				"Assistant: reply one",
+				"User: turn two",
+				"Assistant: reply two",
+				"User: turn three",
+			].join("\n"),
+		});
+
+		const jsonlPath = canonicalTranscriptPath(root, "codex");
+		const identity = {
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-1",
+			sourceFormat: "db" as const,
+		};
+		const key = sessionSeqCacheKey(identity);
+
+		// Replacement has only 2 turns — would clobber seq to 2 if cache is updated.
+		const replacements = new Map([
+			[key, { identity, transcript: "User: short\nAssistant: short reply" }],
+		]);
+
+		const count = await rewriteReplacingLiveOnlySessions(jsonlPath, replacements);
+		// Session was already healed (non-live), replacement skipped.
+		expect(count).toBe(1);
+
+		// Append a live turn — should get seq 6, not seq 3.
+		await appendCanonicalTranscriptTurns({
+			basePath: root,
+			agentId: "default",
+			harness: "codex",
+			sessionKey: "session-1",
+			sourceFormat: "live",
+			turns: [{ role: "user", content: "live turn six" }],
+		});
+
+		const content = readFileSync(jsonlPath, "utf8");
+		const records = content.trim().split("\n").map((l) => JSON.parse(l));
+		const liveTurn = records.find((r: Record<string, unknown>) => r.content === "live turn six");
+		expect(liveTurn).toBeTruthy();
+		expect(liveTurn.seq).toBe(6);
+	});
+
 	test("preserves original lines when replacement transcript is empty", async () => {
 		const root = makeRoot("rewrite-empty-transcript");
 

--- a/platform/daemon/src/transcript-jsonl.ts
+++ b/platform/daemon/src/transcript-jsonl.ts
@@ -553,9 +553,38 @@ export function rewriteReplacingLiveOnlySessions(
 ): Promise<number> {
 	if (replacements.size === 0 || !existsSync(jsonlPath)) return Promise.resolve(0);
 	return withTranscriptFileLock(jsonlPath, async () => {
+		// Re-classify inside the lock: between external classification and lock
+		// acquisition, session-end hooks may have written non-live records. Only
+		// replace sessions that are STILL live-only at the moment we hold the lock.
+		const healedKeys = new Set<string>();
+		const prescan = createInterface({
+			input: createReadStream(jsonlPath, { encoding: "utf8" }),
+			crlfDelay: Number.POSITIVE_INFINITY,
+		});
+		try {
+			for await (const line of prescan) {
+				const trimmed = line.trim();
+				if (trimmed.length === 0) continue;
+				try {
+					const parsed = JSON.parse(trimmed) as Partial<CanonicalTranscriptRecord>;
+					if (parsed.schema !== "signet.transcript.v1" || typeof parsed.content !== "string") continue;
+					const record = parsed as CanonicalTranscriptRecord;
+					const key = recordSeqCacheKey(record);
+					if (replacements.has(key) && record.source_format !== "live") {
+						healedKeys.add(key);
+					}
+				} catch {}
+			}
+		} finally {
+			prescan.close();
+		}
+		const effectiveReplacements = healedKeys.size > 0
+			? new Map([...replacements].filter(([k]) => !healedKeys.has(k)))
+			: replacements;
+		if (effectiveReplacements.size === 0) return healedKeys.size;
+
 		const tmpPath = `${jsonlPath}.rewrite-tmp`;
 		const rewritten = new Set<string>();
-		const healed = new Set<string>();
 		let fd: number | null = null;
 		try {
 			fd = openSync(tmpPath, "w");
@@ -575,23 +604,16 @@ export function rewriteReplacingLiveOnlySessions(
 						}
 					const record = parsed as CanonicalTranscriptRecord;
 					const key = recordSeqCacheKey(record);
-					if (!replacements.has(key)) {
+					if (!effectiveReplacements.has(key)) {
 						writeSync(fd, `${line}\n`);
 						continue;
 					}
-					if (rewritten.has(key) || healed.has(key)) {
-						// Only skip live-format lines; preserve any non-live records.
+					if (rewritten.has(key)) {
 						if (record.source_format === "live") continue;
 						writeSync(fd, `${line}\n`);
 						continue;
 					}
-					if (record.source_format !== "live") {
-						// Session was healed between classification and rewrite — skip replacement.
-						writeSync(fd, `${line}\n`);
-						healed.add(key);
-						continue;
-					}
-					const entry = replacements.get(key);
+					const entry = effectiveReplacements.get(key);
 					if (!entry) {
 						writeSync(fd, `${line}\n`);
 						continue;
@@ -600,7 +622,6 @@ export function rewriteReplacingLiveOnlySessions(
 						.map((turn, index) => makeRecord(entry.identity, turn, index + 1))
 						.filter((r): r is CanonicalTranscriptRecord => r !== null);
 					if (next.length === 0) {
-						// Replacement payload is empty — preserve original line (fail-closed).
 						writeSync(fd, `${line}\n`);
 						continue;
 					}
@@ -619,11 +640,8 @@ export function rewriteReplacingLiveOnlySessions(
 			closeSync(fd);
 			fd = null;
 			renameSync(tmpPath, jsonlPath);
-			// Only update seq cache for sessions that were actually rewritten.
-			// Healed sessions already have a correct (or higher) seq from the
-			// session-end hook — overwriting from the replacement would lower it.
 			for (const key of rewritten) {
-				const entry = replacements.get(key);
+				const entry = effectiveReplacements.get(key);
 				if (!entry) continue;
 				const seq = transcriptTextToTurns(entry.transcript).reduce((count, turn) => {
 					if (makeRecord(entry.identity, turn, count + 1) === null) return count;
@@ -631,7 +649,7 @@ export function rewriteReplacingLiveOnlySessions(
 				}, 0);
 				sessionSeqCache.set(sessionSeqCacheKey(entry.identity), seq);
 			}
-			return rewritten.size + healed.size;
+			return rewritten.size + healedKeys.size;
 		} catch (error) {
 			if (fd !== null) closeSync(fd);
 			rmSync(tmpPath, { force: true });

--- a/platform/daemon/src/transcript-jsonl.ts
+++ b/platform/daemon/src/transcript-jsonl.ts
@@ -37,12 +37,17 @@ export interface CanonicalTranscriptRecord {
 	readonly source_sha256: string;
 }
 
+export interface TranscriptSessionKeyClassification {
+	readonly canonicalKeys: Set<string>;
+	readonly liveOnlyKeys: Set<string>;
+}
+
 export interface TranscriptTurn {
 	readonly role: TranscriptRole;
 	readonly content: string;
 }
 
-interface TranscriptIdentity {
+export interface TranscriptIdentity {
 	readonly basePath?: string;
 	readonly agentId: string;
 	readonly harness: string;
@@ -313,7 +318,7 @@ function sameSession(record: CanonicalTranscriptRecord, input: TranscriptIdentit
 	);
 }
 
-function sessionSeqCacheKey(input: TranscriptIdentity): string {
+export function sessionSeqCacheKey(input: TranscriptIdentity): string {
 	return [
 		input.agentId.trim() || "default",
 		sanitizeHarnessPath(input.harness),
@@ -348,10 +353,11 @@ export async function readCanonicalTranscriptSessionKeys(input: {
 	readonly basePath?: string;
 	readonly harness: string;
 	readonly agentId?: string;
-}): Promise<Set<string>> {
+}): Promise<TranscriptSessionKeyClassification> {
 	const path = canonicalTranscriptPath(input.basePath, input.harness);
-	const keys = new Set<string>();
-	if (!existsSync(path)) return keys;
+	const canonicalKeys = new Set<string>();
+	const liveOnlyKeys = new Set<string>();
+	if (!existsSync(path)) return { canonicalKeys, liveOnlyKeys };
 	const agentId = input.agentId?.trim() || null;
 	const lines = createInterface({
 		input: createReadStream(path, { encoding: "utf8" }),
@@ -366,7 +372,13 @@ export async function readCanonicalTranscriptSessionKeys(input: {
 				if (parsed.schema !== "signet.transcript.v1" || typeof parsed.content !== "string") continue;
 				const record = parsed as CanonicalTranscriptRecord;
 				if (agentId !== null && record.agent_id !== agentId) continue;
-				keys.add(recordSeqCacheKey(record));
+				const key = recordSeqCacheKey(record);
+				if (record.source_format !== "live") {
+					canonicalKeys.add(key);
+					liveOnlyKeys.delete(key);
+					continue;
+				}
+				if (!canonicalKeys.has(key)) liveOnlyKeys.add(key);
 			} catch {
 				// Ignore malformed historical lines rather than blocking capture.
 			}
@@ -374,7 +386,7 @@ export async function readCanonicalTranscriptSessionKeys(input: {
 	} finally {
 		lines.close();
 	}
-	return keys;
+	return { canonicalKeys, liveOnlyKeys };
 }
 
 async function hasSessionRecord(path: string, input: TranscriptIdentity): Promise<boolean> {

--- a/platform/daemon/src/transcript-jsonl.ts
+++ b/platform/daemon/src/transcript-jsonl.ts
@@ -4,6 +4,7 @@ import {
 	closeSync,
 	createReadStream,
 	existsSync,
+	fsyncSync,
 	mkdirSync,
 	openSync,
 	readFileSync,
@@ -11,6 +12,7 @@ import {
 	renameSync,
 	rmSync,
 	statSync,
+	writeSync,
 	writeFileSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
@@ -486,6 +488,75 @@ export function appendCanonicalTranscriptSnapshotIfMissing(
 		);
 		knownSessionKeys?.add(key);
 		return path;
+	});
+}
+
+export function rewriteReplacingLiveOnlySessions(
+	jsonlPath: string,
+	replacements: ReadonlyMap<string, { readonly identity: TranscriptIdentity; readonly transcript: string }>,
+): Promise<number> {
+	if (replacements.size === 0 || !existsSync(jsonlPath)) return Promise.resolve(0);
+	return withTranscriptFileLock(jsonlPath, async () => {
+		const tmpPath = `${jsonlPath}.rewrite-tmp`;
+		const replaced = new Set<string>();
+		let fd: number | null = null;
+		try {
+			fd = openSync(tmpPath, "w");
+			const lines = createInterface({
+				input: createReadStream(jsonlPath, { encoding: "utf8" }),
+				crlfDelay: Number.POSITIVE_INFINITY,
+			});
+			try {
+				for await (const line of lines) {
+					const trimmedLine = line.trim();
+					if (trimmedLine.length === 0) continue;
+					try {
+						const parsed = JSON.parse(trimmedLine) as Partial<CanonicalTranscriptRecord>;
+						if (parsed.schema !== "signet.transcript.v1" || typeof parsed.content !== "string") {
+							writeSync(fd, `${line}\n`);
+							continue;
+						}
+						const key = recordSeqCacheKey(parsed as CanonicalTranscriptRecord);
+						if (!replacements.has(key)) {
+							writeSync(fd, `${line}\n`);
+							continue;
+						}
+						if (replaced.has(key)) continue;
+						const entry = replacements.get(key);
+						if (!entry) continue;
+						const next = transcriptTextToTurns(entry.transcript)
+							.map((turn, index) => makeRecord(entry.identity, turn, index + 1))
+							.filter((record): record is CanonicalTranscriptRecord => record !== null);
+						for (const record of next) {
+							writeSync(fd, `${JSON.stringify(record)}\n`);
+						}
+						replaced.add(key);
+					} catch {
+						writeSync(fd, `${line}\n`);
+					}
+				}
+			} finally {
+				lines.close();
+			}
+			fsyncSync(fd);
+			closeSync(fd);
+			fd = null;
+			renameSync(tmpPath, jsonlPath);
+			for (const key of replaced) {
+				const entry = replacements.get(key);
+				if (!entry) continue;
+				const seq = transcriptTextToTurns(entry.transcript).reduce((count, turn) => {
+					if (makeRecord(entry.identity, turn, count + 1) === null) return count;
+					return count + 1;
+				}, 0);
+				sessionSeqCache.set(sessionSeqCacheKey(entry.identity), seq);
+			}
+			return replaced.size;
+		} catch (error) {
+			if (fd !== null) closeSync(fd);
+			rmSync(tmpPath, { force: true });
+			throw error;
+		}
 	});
 }
 

--- a/platform/daemon/src/transcript-jsonl.ts
+++ b/platform/daemon/src/transcript-jsonl.ts
@@ -516,21 +516,41 @@ export function rewriteReplacingLiveOnlySessions(
 							writeSync(fd, `${line}\n`);
 							continue;
 						}
-						const key = recordSeqCacheKey(parsed as CanonicalTranscriptRecord);
-						if (!replacements.has(key)) {
-							writeSync(fd, `${line}\n`);
-							continue;
-						}
-						if (replaced.has(key)) continue;
-						const entry = replacements.get(key);
-						if (!entry) continue;
-						const next = transcriptTextToTurns(entry.transcript)
-							.map((turn, index) => makeRecord(entry.identity, turn, index + 1))
-							.filter((record): record is CanonicalTranscriptRecord => record !== null);
-						for (const record of next) {
-							writeSync(fd, `${JSON.stringify(record)}\n`);
-						}
+					const record = parsed as CanonicalTranscriptRecord;
+					const key = recordSeqCacheKey(record);
+					if (!replacements.has(key)) {
+						writeSync(fd, `${line}\n`);
+						continue;
+					}
+					if (replaced.has(key)) {
+						// Only skip live-format lines; preserve any non-live records.
+						if (record.source_format === "live") continue;
+						writeSync(fd, `${line}\n`);
+						continue;
+					}
+					if (record.source_format !== "live") {
+						// Session was healed between classification and rewrite — skip replacement.
+						writeSync(fd, `${line}\n`);
 						replaced.add(key);
+						continue;
+					}
+					const entry = replacements.get(key);
+					if (!entry) {
+						writeSync(fd, `${line}\n`);
+						continue;
+					}
+					const next = transcriptTextToTurns(entry.transcript)
+						.map((turn, index) => makeRecord(entry.identity, turn, index + 1))
+						.filter((r): r is CanonicalTranscriptRecord => r !== null);
+					if (next.length === 0) {
+						// Replacement payload is empty — preserve original line (fail-closed).
+						writeSync(fd, `${line}\n`);
+						continue;
+					}
+					for (const r of next) {
+						writeSync(fd, `${JSON.stringify(r)}\n`);
+					}
+					replaced.add(key);
 					} catch {
 						writeSync(fd, `${line}\n`);
 					}

--- a/platform/daemon/src/transcript-jsonl.ts
+++ b/platform/daemon/src/transcript-jsonl.ts
@@ -554,7 +554,8 @@ export function rewriteReplacingLiveOnlySessions(
 	if (replacements.size === 0 || !existsSync(jsonlPath)) return Promise.resolve(0);
 	return withTranscriptFileLock(jsonlPath, async () => {
 		const tmpPath = `${jsonlPath}.rewrite-tmp`;
-		const replaced = new Set<string>();
+		const rewritten = new Set<string>();
+		const healed = new Set<string>();
 		let fd: number | null = null;
 		try {
 			fd = openSync(tmpPath, "w");
@@ -578,7 +579,7 @@ export function rewriteReplacingLiveOnlySessions(
 						writeSync(fd, `${line}\n`);
 						continue;
 					}
-					if (replaced.has(key)) {
+					if (rewritten.has(key) || healed.has(key)) {
 						// Only skip live-format lines; preserve any non-live records.
 						if (record.source_format === "live") continue;
 						writeSync(fd, `${line}\n`);
@@ -587,7 +588,7 @@ export function rewriteReplacingLiveOnlySessions(
 					if (record.source_format !== "live") {
 						// Session was healed between classification and rewrite — skip replacement.
 						writeSync(fd, `${line}\n`);
-						replaced.add(key);
+						healed.add(key);
 						continue;
 					}
 					const entry = replacements.get(key);
@@ -606,7 +607,7 @@ export function rewriteReplacingLiveOnlySessions(
 					for (const r of next) {
 						writeSync(fd, `${JSON.stringify(r)}\n`);
 					}
-					replaced.add(key);
+					rewritten.add(key);
 					} catch {
 						writeSync(fd, `${line}\n`);
 					}
@@ -618,7 +619,10 @@ export function rewriteReplacingLiveOnlySessions(
 			closeSync(fd);
 			fd = null;
 			renameSync(tmpPath, jsonlPath);
-			for (const key of replaced) {
+			// Only update seq cache for sessions that were actually rewritten.
+			// Healed sessions already have a correct (or higher) seq from the
+			// session-end hook — overwriting from the replacement would lower it.
+			for (const key of rewritten) {
 				const entry = replacements.get(key);
 				if (!entry) continue;
 				const seq = transcriptTextToTurns(entry.transcript).reduce((count, turn) => {
@@ -627,7 +631,7 @@ export function rewriteReplacingLiveOnlySessions(
 				}, 0);
 				sessionSeqCache.set(sessionSeqCacheKey(entry.identity), seq);
 			}
-			return replaced.size;
+			return rewritten.size + healed.size;
 		} catch (error) {
 			if (fd !== null) closeSync(fd);
 			rmSync(tmpPath, { force: true });

--- a/platform/daemon/src/transcript-jsonl.ts
+++ b/platform/daemon/src/transcript-jsonl.ts
@@ -426,18 +426,74 @@ export function writeCanonicalTranscriptSnapshot(
 	const turns = transcriptTextToTurns(input.transcript);
 	if (turns.length === 0) return Promise.resolve(null);
 	const path = canonicalTranscriptPath(input.basePath, input.harness);
-	return withTranscriptFileLock(path, () => {
-		const existing = readRecords(path).filter((record) => !sameSession(record, input));
+	return withTranscriptFileLock(path, async () => {
 		const next = turns
 			.map((turn, index) => makeRecord(input, turn, index + 1))
 			.filter((record): record is CanonicalTranscriptRecord => record !== null);
 		if (next.length === 0) return null;
-		writeRecords(path, [...existing, ...next]);
-		sessionSeqCache.set(
-			sessionSeqCacheKey(input),
-			next.reduce((max, record) => Math.max(max, record.seq), 0),
-		);
-		return path;
+
+		if (!existsSync(path)) {
+			mkdirSync(dirname(path), { recursive: true });
+			const body = next.map((r) => JSON.stringify(r)).join("\n");
+			writeFileSync(path, `${body}\n`, "utf8");
+			sessionSeqCache.set(
+				sessionSeqCacheKey(input),
+				next.reduce((max, record) => Math.max(max, record.seq), 0),
+			);
+			return path;
+		}
+
+		const tmpPath = `${path}.snapshot-tmp`;
+		let fd: number | null = null;
+		try {
+			fd = openSync(tmpPath, "w");
+			const lines = createInterface({
+				input: createReadStream(path, { encoding: "utf8" }),
+				crlfDelay: Number.POSITIVE_INFINITY,
+			});
+			try {
+				for await (const line of lines) {
+					const trimmedLine = line.trim();
+					if (trimmedLine.length === 0) continue;
+					try {
+						const parsed = JSON.parse(trimmedLine) as Partial<CanonicalTranscriptRecord>;
+						if (
+							parsed.schema !== "signet.transcript.v1" ||
+							typeof parsed.content !== "string"
+						) {
+							writeSync(fd, `${line}\n`);
+							continue;
+						}
+						if (sameSession(parsed as CanonicalTranscriptRecord, input)) {
+							continue; // Skip — will be replaced by `next` records at end
+						}
+						writeSync(fd, `${line}\n`);
+					} catch {
+						// Malformed line — preserve verbatim
+						writeSync(fd, `${line}\n`);
+					}
+				}
+			} finally {
+				lines.close();
+			}
+			// Append new canonical records for this session
+			for (const r of next) {
+				writeSync(fd, `${JSON.stringify(r)}\n`);
+			}
+			fsyncSync(fd);
+			closeSync(fd);
+			fd = null;
+			renameSync(tmpPath, path);
+			sessionSeqCache.set(
+				sessionSeqCacheKey(input),
+				next.reduce((max, record) => Math.max(max, record.seq), 0),
+			);
+			return path;
+		} catch (error) {
+			if (fd !== null) closeSync(fd);
+			rmSync(tmpPath, { force: true });
+			throw error;
+		}
 	});
 }
 


### PR DESCRIPTION
## Summary

- Streaming rewrite for live-only transcript sessions during backfill (fixes partial live turns persisting when full transcripts exist as artifacts)
- **Streaming `writeCanonicalTranscriptSnapshot` to prevent OOM on large JSONL files** (fixes daemon OOM kill on 924 MB opencode JSONL during session-end)
- **Fix seq cache clobber on healed sessions** — separate `rewritten`/`healed` sets so only actually-rewritten sessions update sessionSeqCache
- **Polyfill `destroySoon` for Bun HTTP socket compatibility** — prevents daemon crash when @hono/node-server drain handler fires on unconsumed POST bodies (fixes #595)
- **Race guard** — re-classify inside file lock to prevent rewriting sessions that were healed between classification and lock acquisition

## Changes

| File | Change |
|---|---|
| `platform/daemon/src/transcript-jsonl.ts` | Streaming `writeCanonicalTranscriptSnapshot`, streaming `rewriteReplacingLiveOnlySessions` with pre-scan race guard, fail-closed on empty replacement |
| `platform/daemon/src/transcript-jsonl.test.ts` | 26 tests: classification, rewrite, OOM guard, crash-safety, seq-cache regression, race guard |
| `platform/daemon/src/session-transcripts.ts` | Backfill orchestration: classify → rewrite → append, `createBackfillSeenReader()` |
| `platform/daemon/src/bun-socket-polyfill.ts` | `Duplex.prototype.destroySoon` polyfill (Node.js-exact semantics, remove when Bun ships PR #26264) |
| `platform/daemon/src/bun-socket-polyfill.test.ts` | 5 tests: baseline, apply, writable→end→destroy, finished→destroy, no-overwrite |
| `platform/daemon/src/daemon.ts` | Import polyfill as first module |

## OOM Fix Performance

| Metric | Before | After |
|---|---|---|
| Peak RSS | 7.2 GB (OOM killed) | 152 MB |
| File size | 924 MB | 924 MB (preserved) |
| Elapsed | N/A (killed) | 5 seconds |
| Memory complexity | O(file_size) | O(line_size) |

## destroySoon Fix

Root cause: `@hono/node-server` v1.19.13 calls `socket.destroySoon()` in its drain handler. Bun's HTTP server socket wrapper (`NodeHTTPServerSocket`) extends `Duplex` but lacks this method. Any unconsumed POST body (MCP reconnection, client disconnect) crashes the daemon.

Upstream: https://github.com/oven-sh/bun/issues/24127 (open), PR https://github.com/oven-sh/bun/pull/26264 (not merged).

Polyfill uses Node.js-exact semantics. Verified locally: daemon survives POST with unconsumed body that previously crashed it.

## Readiness Checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally