### PR TITLE
fix(openclaw): preserve prompt content in provider requests

### DIFF
--- a/integrations/openclaw/memory-adapter/src/index.test.ts
+++ b/integrations/openclaw/memory-adapter/src/index.test.ts
@@ -258,7 +258,7 @@ afterEach(async () => {
 	globalThis.setInterval = originalSetInterval;
 	globalThis.clearInterval = originalClearInterval;
 	if (originalSignetPath === undefined) {
-		delete process.env.SIGNET_PATH;
+		Reflect.deleteProperty(process.env, "SIGNET_PATH");
 	} else {
 		process.env.SIGNET_PATH = originalSignetPath;
 	}
@@ -1797,7 +1797,7 @@ describe("registration guard (#422)", () => {
 });
 
 // ===========================================================================
-// Request normalization (routing metadata + content normalization)
+// Request normalization (routing metadata only)
 // ===========================================================================
 
 describe("injectBillingBlock", () => {
@@ -1864,56 +1864,6 @@ describe("injectBillingBlock", () => {
 	});
 });
 
-describe("replaceTriggers", () => {
-	const { replaceTriggers } = _sanitization;
-
-	it("replaces OpenClaw platform name", () => {
-		const [result, changed] = replaceTriggers("Welcome to OpenClaw");
-		expect(changed).toBeTrue();
-		expect(result).not.toContain("OpenClaw");
-		expect(result).toContain("assistant platform");
-	});
-
-	it("replaces lowercase openclaw", () => {
-		const [result, changed] = replaceTriggers("path: /usr/lib/node_modules/openclaw/docs");
-		expect(changed).toBeTrue();
-		expect(result).not.toContain("openclaw");
-	});
-
-	it("replaces session management tool names", () => {
-		const input = JSON.stringify({
-			tools: [
-				{ name: "sessions_spawn" },
-				{ name: "sessions_list" },
-				{ name: "sessions_history" },
-				{ name: "sessions_send" },
-			],
-		});
-		const [result, changed] = replaceTriggers(input);
-		expect(changed).toBeTrue();
-		expect(result).not.toContain("sessions_spawn");
-		expect(result).not.toContain("sessions_list");
-		expect(result).not.toContain("sessions_history");
-		expect(result).not.toContain("sessions_send");
-		expect(result).toContain("create_task");
-		expect(result).toContain("list_tasks");
-		expect(result).toContain("get_history");
-		expect(result).toContain("send_to_task");
-	});
-
-	it("replaces 'running inside' self-declaration", () => {
-		const [result, changed] = replaceTriggers("You are running inside a harness.");
-		expect(changed).toBeTrue();
-		expect(result).toBe("You are running on a harness.");
-	});
-
-	it("returns unchanged for clean input", () => {
-		const [result, changed] = replaceTriggers("You are a helpful assistant.");
-		expect(changed).toBeFalse();
-		expect(result).toBe("You are a helpful assistant.");
-	});
-});
-
 describe("mergeBetaHeaders", () => {
 	const { mergeBetaHeaders, REQUIRED_BETAS } = _sanitization;
 
@@ -1948,7 +1898,7 @@ describe("mergeBetaHeaders", () => {
 describe("sanitizeRequest", () => {
 	const { sanitizeRequest, BILLING_BLOCK } = _sanitization;
 
-	it("injects billing block and replaces triggers", () => {
+	it("injects billing block and preserves request content", () => {
 		const request = {
 			body: JSON.stringify({
 				model: "claude-sonnet-4-20250514",
@@ -1961,9 +1911,9 @@ describe("sanitizeRequest", () => {
 		const blocks = parsed.system as Array<{ type: string; text: string }>;
 		// Billing block injected as first element
 		expect(blocks[0].text).toContain("x-anthropic-billing-header");
-		// Trigger phrases replaced
-		expect(request.body).not.toContain("OpenClaw");
-		expect(request.body).not.toContain("running inside");
+		// Product and prompt text are not rewritten.
+		expect(request.body).toContain("OpenClaw");
+		expect(request.body).toContain("running inside");
 	});
 
 	it("injects billing block even when no triggers present", () => {
@@ -1979,7 +1929,7 @@ describe("sanitizeRequest", () => {
 		expect(blocks[0].text).toContain("x-anthropic-billing-header");
 	});
 
-	it("replaces session tool names in tool definitions", () => {
+	it("preserves session tool names in tool definitions", () => {
 		const request = {
 			body: JSON.stringify({
 				system: [{ type: "text", text: "You are a helpful assistant." }],
@@ -1987,8 +1937,8 @@ describe("sanitizeRequest", () => {
 			}),
 		};
 		expect(sanitizeRequest(request)).toBeTrue();
-		expect(request.body).not.toContain("sessions_spawn");
-		expect(request.body).toContain("create_task");
+		expect(request.body).toContain("sessions_spawn");
+		expect(request.body).not.toContain("create_task");
 	});
 
 	it("does not double-inject billing block", () => {
@@ -2011,10 +1961,10 @@ describe("sanitizeRequest", () => {
 		expect(sanitizeRequest({ body: 42 })).toBeFalse();
 	});
 
-	it("handles non-JSON body with triggers", () => {
+	it("leaves non-JSON body untouched", () => {
 		const request = { body: "some text OpenClaw more text" };
-		expect(sanitizeRequest(request)).toBeTrue();
-		expect(request.body).not.toContain("OpenClaw");
+		expect(sanitizeRequest(request)).toBeFalse();
+		expect(request.body).toBe("some text OpenClaw more text");
 	});
 
 	it("returns false for non-JSON body without triggers", () => {
@@ -2069,7 +2019,7 @@ describe("installFetchSanitizer", () => {
 		globalThis.fetch = savedFetch;
 	});
 
-	it("injects billing block, replaces triggers, and merges betas", async () => {
+	it("injects billing block, preserves prompt text, and merges betas", async () => {
 		const remove = installFetchSanitizer();
 		try {
 			await globalThis.fetch("https://api.anthropic.com/v1/messages", {
@@ -2086,8 +2036,9 @@ describe("installFetchSanitizer", () => {
 			const blocks = sent.system as Array<{ type: string; text: string }>;
 			// Billing block injected
 			expect(blocks[0].text).toContain("x-anthropic-billing-header");
-			// Triggers replaced
-			expect(capturedBodies[0]).not.toContain("OpenClaw");
+			// Product and prompt text are not rewritten.
+			expect(capturedBodies[0]).toContain("OpenClaw");
+			expect(capturedBodies[0]).toContain("running inside");
 			// Beta headers merged
 			expect(capturedHeaders[0]["anthropic-beta"]).toContain("oauth-2025-04-20");
 		} finally {
@@ -2170,7 +2121,7 @@ describe("installSdkSanitizer", () => {
 			const parsed = JSON.parse(request.body as string) as Record<string, unknown>;
 			const blocks = parsed.system as Array<{ type: string; text: string }>;
 			expect(blocks[0].text).toContain("x-anthropic-billing-header");
-			expect(JSON.stringify(parsed)).not.toContain("OpenClaw");
+			expect(JSON.stringify(parsed)).toContain("OpenClaw");
 		} finally {
 			FakeAnthropic.prototype.prepareRequest = original;
 		}

--- a/integrations/openclaw/memory-adapter/src/index.ts
+++ b/integrations/openclaw/memory-adapter/src/index.ts
@@ -887,9 +887,9 @@ export function cleanupTimedMap(map: Map<string, number>, now: number, ttlMs = S
 
 // ---------------------------------------------------------------------------
 // Request normalization layer — ensures outgoing provider requests carry the
-// correct routing metadata and content normalization for subscription-tier
-// OAuth token flows. Without this, OAuth-authenticated requests may be
-// misrouted or rejected by the upstream gateway.
+// correct routing metadata for subscription-tier OAuth token flows. Without
+// this, OAuth-authenticated requests may be misrouted or rejected by the
+// upstream gateway.
 //
 // The plugin hook API does not expose the assembled request body, so we
 // intercept at two layers:
@@ -918,20 +918,6 @@ const REQUIRED_BETAS = [
 	"effort-2025-11-24",
 ] as const;
 
-// Content normalization rules — these specific strings in the request body
-// cause upstream rejection when present. Other tool names, prompt structure,
-// workspace files, and config paths are unaffected.
-const TRIGGER_REPLACEMENTS: ReadonlyArray<readonly [string, string]> = [
-	["OpenClaw", "assistant platform"],
-	["openclaw", "assistant platform"],
-	["sessions_spawn", "create_task"],
-	["sessions_list", "list_tasks"],
-	["sessions_history", "get_history"],
-	["sessions_send", "send_to_task"],
-	["sessions_yield", "yield_turn"],
-	["running inside", "running on"],
-] as const;
-
 /**
  * Inject the routing metadata block as system[0] if not already present.
  * Handles both string and array system prompt formats.
@@ -958,43 +944,20 @@ function injectBillingBlock(body: Record<string, unknown>): boolean {
 }
 
 /**
- * Replace verified trigger phrases in a string.
- * Returns the cleaned string and whether any replacement occurred.
- */
-function replaceTriggers(input: string): [string, boolean] {
-	let result = input;
-	let changed = false;
-	for (const [find, replace] of TRIGGER_REPLACEMENTS) {
-		if (result.includes(find)) {
-			result = result.split(find).join(replace);
-			changed = true;
-		}
-	}
-	return [result, changed];
-}
-
-/**
- * Normalize a serialized JSON request body: inject routing block and
- * apply content replacements. Modifies the carrier object in-place.
+ * Normalize a serialized JSON request body by injecting the routing block.
+ * Modifies the carrier object in-place.
  */
 function sanitizeRequest(request: { body?: unknown }): boolean {
 	if (!request.body || typeof request.body !== "string") return false;
 	try {
 		const body = JSON.parse(request.body) as Record<string, unknown>;
 		const injected = injectBillingBlock(body);
-		const serialized = JSON.stringify(body);
-		const [cleaned, replaced] = replaceTriggers(serialized);
-		if (injected || replaced) {
-			request.body = cleaned;
+		if (injected) {
+			request.body = JSON.stringify(body);
 			return true;
 		}
 	} catch {
-		// Not valid JSON — try raw string sweep for trigger phrases only
-		const [cleaned, replaced] = replaceTriggers(request.body as string);
-		if (replaced) {
-			request.body = cleaned;
-			return true;
-		}
+		// Not valid JSON — leave opaque request bodies untouched.
 	}
 	return false;
 }
@@ -2431,11 +2394,10 @@ export function _resetRegistration(): void {
 	}
 }
 
-/** @internal Test-only exports for system prompt sanitization. */
+/** @internal Test-only exports for provider request normalization. */
 export const _sanitization = {
 	isAnthropicApiUrl,
 	injectBillingBlock,
-	replaceTriggers,
 	sanitizeRequest,
 	mergeBetaHeaders,
 	readClaudeCodeOAuthToken,
@@ -2445,7 +2407,6 @@ export const _sanitization = {
 	installSdkSanitizer,
 	BILLING_BLOCK,
 	REQUIRED_BETAS,
-	TRIGGER_REPLACEMENTS,
 } as const;
 
 export default signetPlugin;


### PR DESCRIPTION
## Summary

Stops the OpenClaw memory adapter from rewriting provider request content. The Anthropic request normalization layer still injects routing metadata and beta headers for OAuth subscription routing, but it no longer changes `OpenClaw`, `openclaw`, `sessions_*`, or `running inside` text to other strings.

## Changes

- Remove the prompt/content trigger replacement table from `@signetai/signet-memory-openclaw`.
- Keep billing block injection, beta header merging, and OAuth auth swapping intact.
- Update regressions to assert OpenClaw/product text and session tool names are preserved through request normalization.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: `@signetai/signet-memory-openclaw`

## Screenshots

N/A, no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) - N/A, routine bug fix within existing adapter behavior
- [x] Agent scoping verified on all new/changed data queries - N/A, no data queries changed
- [x] Input/config validation and bounds checks added - N/A, no new external inputs or config bounds
- [x] Error handling and fallback paths tested (no silent swallow) - existing fallback behavior preserved; request normalization tests updated
- [x] Security checks applied to admin/mutation endpoints - N/A, no endpoints changed
- [x] Docs updated for API/spec/status changes - N/A, no API/spec/status behavior changed
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A, no migrations.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Targeted validation run:

```bash
cd platform/core && bun run build
cd integrations/openclaw/memory-adapter && bun test src/index.test.ts
cd integrations/openclaw/memory-adapter && bun run build
bunx biome check integrations/openclaw/memory-adapter/src/index.ts integrations/openclaw/memory-adapter/src/index.test.ts
```

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The initial direct package test failed until `@signet/core` was built, because this worktree had no built `platform/core/dist` export target yet. After building core, the focused adapter tests and package build passed.
