### PR TITLE
docs: correct stale documentation claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 <a href="https://github.com/openclaw/openclaw"><img src="https://img.shields.io/badge/OpenClaw-Compatible-orange?style=for-the-badge" alt="OpenClaw Compatible"></a>
 <a href="./docs/BENCHMARKING.md#current-longmemeval-score"><img src="https://img.shields.io/badge/LongMemEval-97.6%25-black?style=for-the-badge" alt="LongMemEval 97.6% answer accuracy"></a>
 
-**97.6% LongMemEval answer accuracy**<br />
+**97.6% average LongMemEval answer accuracy**<br />
 Readable record · inspectable recall · harnesses are replaceable
 
 [Website](https://signetai.sh) · [Docs](https://signetai.sh/docs) · [Benchmarks](./docs/BENCHMARKING.md) · [Vision](VISION.md) · [Discussions](https://github.com/Signet-AI/signetai/discussions) · [Discord](https://discord.gg/Psdeg7sQm7) · [Contributing](docs/CONTRIBUTING.md) · [AI Policy](AI_POLICY.md)
@@ -223,15 +223,15 @@ underneath it.
 
 [LongMemEval](https://arxiv.org/abs/2410.10813) measures whether a memory
 system can recover and use facts across long-running, multi-session
-assistant conversations. Signet's current published run scores **97.6% answer
-accuracy** under the MemoryBench `rules` profile.
+assistant conversations. Signet's latest tracked MemoryBench runs average
+**97.6% answer accuracy** under the `rules` profile.
 
 That profile keeps the benchmark contract strict: memories are ingested through
 `/api/memory/remember`, recalled through `/api/memory/recall`, and answered
 from bounded daemon recall results. Search does not call an LLM.
 
 See [Benchmarks](./docs/BENCHMARKING.md#current-longmemeval-score) for the
-methodology and run workflow.
+methodology, scoring note, and run workflow.
 
 ## Install (detailed)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -19,7 +19,8 @@ port are configurable via environment variables (see [[configuration]]).
 Base URL: http://localhost:3850
 SIGNET_PORT  — override port (default: 3850)
 SIGNET_HOST  — daemon host for local calls (default: 127.0.0.1)
-SIGNET_BIND  — bind host override (default: SIGNET_HOST)
+SIGNET_BIND  — bind host override (defaults to the configured network mode:
+               127.0.0.1 for localhost mode, 0.0.0.0 for tailscale mode)
 ```
 
 Authentication
@@ -86,7 +87,7 @@ No authentication required. Lightweight liveness check.
   "status": "healthy",
   "uptime": 3600.5,
   "pid": 12345,
-  "version": "0.1.69",
+  "version": "0.109.9",
   "port": 3850,
   "agentsDir": "/home/user/.agents"
 }
@@ -109,7 +110,9 @@ silent fallback or hard-blocked extraction after boot.
   "uptime": 3600.5,
   "startedAt": "2026-02-21T10:00:00.000Z",
   "port": 3850,
-  "host": "localhost",
+  "host": "127.0.0.1",
+  "bindHost": "127.0.0.1",
+  "networkMode": "localhost",
   "agentsDir": "/home/user/.agents",
   "memoryDb": true,
   "pipelineV2": {
@@ -117,9 +120,18 @@ silent fallback or hard-blocked extraction after boot.
     "paused": false,
     "shadowMode": false,
     "mutationsFrozen": false,
-    "graphEnabled": false,
-    "autonomousEnabled": false,
-    "extractionModel": "qwen3:4b"
+    "graph": {
+      "enabled": true,
+      "extractionWritesEnabled": false
+    },
+    "autonomous": {
+      "enabled": true,
+      "allowUpdateDelete": true
+    },
+    "extraction": {
+      "provider": "llama-cpp",
+      "model": "qwen3.5:4b"
+    }
   },
   "pipeline": {
     "extraction": {
@@ -134,17 +146,22 @@ silent fallback or hard-blocked extraction after boot.
   },
   "providerResolution": {
     "extraction": {
-      "configured": "claude-code",
-      "resolved": "claude-code",
-      "effective": "ollama",
-      "fallbackProvider": "ollama",
-      "status": "degraded",
-      "degraded": true,
-      "fallbackApplied": true,
-      "reason": "Claude Code CLI not found during extraction startup preflight",
-      "since": "2026-03-26T06:00:00.000Z"
+      "configured": "llama-cpp",
+      "resolved": "llama-cpp",
+      "effective": "llama-cpp",
+      "fallbackProvider": "llama-cpp",
+      "status": "active",
+      "degraded": false,
+      "fallbackApplied": false,
+      "reason": null,
+      "since": null
     }
   },
+  "logging": {
+    "logDir": "/home/user/.agents/.daemon/logs",
+    "logFile": "/home/user/.agents/.daemon/logs/signet-2026-04-29.log"
+  },
+  "activeSessions": 1,
   "inference": {
     "enabled": true,
     "source": "explicit",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -183,24 +183,22 @@ are called "shadow decisions" because they are always proposals first.
 controlled-write mode. For each `add` proposal, the worker checks
 confidence against `minFactConfidenceForWrite`, normalizes and hashes
 the content, checks for an existing memory with the same hash, and
-inserts via `txIngestEnvelope`. `update` and `delete` actions are
-blocked in the current implementation — they are recorded in history
-with a `blockedDestructive` reason. Contradiction detection (negation
-and antonym analysis) flags high-risk cases for review.
+inserts via `txIngestEnvelope`. `update` and `delete` proposals are
+blocked unless `autonomous.allowUpdateDelete` is true. When enabled,
+updates go through `txModifyMemory`, deletes go through `txForgetMemory`,
+and the previous target state is archived to the cold tier first. Pinned
+memories are not deleted without force. Contradiction detection can still
+block high-risk update proposals and record them for review.
 
 **Inline entity linking** (`inline-entity-linker.ts`): runs
 synchronously at write time inside `withWriteTx`, before any async
 pipeline work. It extracts candidate proper nouns from memory
-content, resolves or creates entities, infers aspects from verb
-patterns, and writes entity → aspect → attribute structures plus
-`memory_entity_mentions` rows. This makes entities immediately
-queryable via KA traversal without waiting for the async extraction
-worker. The linker also auto-detects decision language (14 regex
-patterns in `DECISION_PATTERNS`) and promotes matching attributes to
-`constraint` kind with elevated importance (0.85), ensuring decisions
-always surface in recall per invariant 5. The async pipeline still
-runs later for deeper analysis (supersession, dependency synthesis,
-confidence calibration).
+content and links the memory to entities that already exist for the same
+`agent_id` by writing `memory_entity_mentions` rows. It does not create
+entities, aspects, attributes, or dependency edges from raw text. Structured
+remember payloads, explicit user/agent actions, and reviewed repair passes
+own semantic graph authorship. The async pipeline still runs later for
+extraction, decisions, and optional graph persistence.
 
 **Hints worker** (`prospective-index.ts`): generates hypothetical
 future queries ("hints") for each memory at write time. For each new
@@ -235,11 +233,12 @@ would do before enabling writes.
 | `enabled` | Master pipeline switch |
 | `shadowMode` | Extract and propose, never write |
 | `mutationsFrozen` | Reads only; pipeline stays quiet |
-| `graphEnabled` | Run graph entity persistence |
-| `autonomousEnabled` | Allow agent-triggered repairs |
-| `autonomousFrozen` | Hard stop on all autonomous actions |
+| `graph.enabled` | Enable graph reads, traversal, and recall boosting |
+| `graph.extractionWritesEnabled` | Let background extraction persist graph entity triples |
+| `autonomous.enabled` | Allow scheduled maintenance and repair |
+| `autonomous.frozen` | Hard stop on autonomous maintenance actions |
 | `hints.enabled` | Run prospective hint generation at write time |
-| `maintenanceMode` | `observe` or `execute` for maintenance worker |
+| `autonomous.maintenanceMode` | `observe` or `execute` for maintenance worker |
 
 ---
 
@@ -545,8 +544,8 @@ scan.
   immediately outside the normal schedule.
 
 All repair actions pass through a policy gate (`checkRepairGate`). The
-gate checks `autonomousFrozen` first (hard stop), then
-`autonomousEnabled` for agent-role callers (operators and daemon bypass
+gate checks `autonomous.frozen` first (hard stop), then
+`autonomous.enabled` for agent-role callers (operators and daemon bypass
 this), then a rate limiter with per-action cooldown and hourly budget.
 Each successful repair writes an audit event to `memory_history` with
 `memory_id = 'system'`.
@@ -557,7 +556,7 @@ recommendations from the report, and either logs them (`observe` mode)
 or executes them (`execute` mode). A halt tracker prevents the same
 ineffective repair from running more than 3 consecutive cycles without
 improving the composite score. The worker only starts its interval
-timer when `autonomousEnabled && !autonomousFrozen`.
+timer when `autonomous.enabled && !autonomous.frozen`.
 
 ---
 
@@ -907,8 +906,9 @@ $SIGNET_WORKSPACE/
         └── daemon-YYYY-MM-DD.log
 ```
 
-The daemon binds to localhost only. All data stays local by design.
-The daemon collects local-only operational telemetry (latency
+By default the daemon binds to loopback. It can also bind for a configured
+network mode such as Tailscale, with auth and CORS controls governing remote
+access. All data stays local by design. The daemon collects local-only operational telemetry (latency
 histograms, usage counters, error ring buffer) accessible at
 `/api/telemetry/*`. No data is sent externally.
 

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -9,6 +9,17 @@ Signet runtime package. Runtime code still belongs under `platform/`, human
 surfaces under `surfaces/`, integrations under `integrations/`, and reusable
 libraries under `libs/`.
 
+## Current LongMemEval score
+
+Signet's latest tracked MemoryBench LongMemEval runs average **97.6% answer
+accuracy** under the `rules` profile. This is an average across the current
+tracked local and canary score set, not a claim that every individual run lands
+at exactly that value.
+
+For the underlying run ledger and per-run accuracy, Hit@K, F1, MRR, NDCG,
+latency, and context-size notes, see
+[`docs/BENCHMARKING-PROGRESS.md`](./BENCHMARKING-PROGRESS.md).
+
 ## Default developer run
 
 ```bash

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1105,8 +1105,8 @@ editing the config file is impractical.
 |----------|---------|-------------|
 | `SIGNET_PATH` | — | Runtime override for agents directory |
 | `SIGNET_PORT` | `3850` | Daemon HTTP port |
-| `SIGNET_HOST` | `127.0.0.1` | Daemon host for local calls and default bind address |
-| `SIGNET_BIND` | `SIGNET_HOST` | Explicit bind address override (`0.0.0.0`, etc.) |
+| `SIGNET_HOST` | `127.0.0.1` | Daemon host for local calls |
+| `SIGNET_BIND` | network mode bind | Explicit bind address override (`0.0.0.0`, etc.); defaults to `127.0.0.1` in localhost mode and `0.0.0.0` in tailscale mode |
 | `SIGNET_LOG_FILE` | — | Optional explicit daemon log file path |
 | `SIGNET_LOG_DIR` | `$SIGNET_WORKSPACE/.daemon/logs` | Optional daemon log directory override |
 | `SIGNET_SQLITE_PATH` | — | macOS explicit SQLite dylib override used before Bun opens the database |

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -37,60 +37,47 @@ is not already running, it starts it first.
 Layout
 ------
 
-The dashboard is a single-page app with three regions:
+The dashboard is a single-page app with a collapsible left navigation rail and
+a main workspace.
 
-- **Left sidebar** — agent identity summary, connector status, and a
-  file list for config editing.
-- **Center panel** — the main tabbed workspace.
-- **Right sidebar** — a compact memory panel with quick search. Hidden
-  when the Memory tab is active.
+- **Left navigation rail** — Overview, Ontology, Tasks, Audit, Secrets,
+  Skills, Settings, theme toggle, and project/release access.
+- **Main workspace** — lazy-loaded dashboard surfaces for the selected area.
 
-The header shows daemon version, total memory count, and connected
-harness count.
+The sidebar footer shows the daemon version and pending restart state when
+available.
 
 
 Left Sidebar
 ------------
 
-The left sidebar has three sections.
-
-**Identity** shows the agent name and creature type from `IDENTITY.md`,
-plus a quick count of total memories and active connectors.
-
-**Connectors** lists each configured harness (Claude Code, OpenCode,
-OpenClaw, etc.) and whether the harness config file exists on disk. A
-green indicator means the file is present and the harness is synced. If
-a connector shows `OFF`, run `signet sync` or save `AGENTS.md` to
-trigger a re-sync.
-
-**Config Files** lists all `.md` and `.yaml` files found in `$SIGNET_WORKSPACE/`.
-Clicking a file opens it in the Config editor.
+The sidebar is intentionally navigation-only. Identity, harness, config,
+pipeline, connector, and log details live inside Overview, Ontology, Settings,
+and Audit surfaces rather than as separate sidebar panels.
 
 
 Tabs
 ----
 
-**Config** — A CodeMirror 6 editor for your agent's identity files.
-Files are loaded from `$SIGNET_WORKSPACE/`. The editor provides syntax
-highlighting (markdown for `.md` files, YAML for `.yaml`), line
-numbers, bracket matching, fold gutters, search (`Ctrl+F`), and undo
-history. Use `Cmd+S` / `Ctrl+S` to save. Saving `AGENTS.md` triggers
-harness sync within 2 seconds. The editor uses a custom dark theme
-matching the dashboard design language, with a light theme variant
-activated by the `data-theme="light"` attribute.
+**Overview** — Home surface for daemon status, memory health, harness state,
+marketplace spotlights, pinned entity clusters, and upgrade/restart signals.
 
-**Settings** — A YAML editor (also CodeMirror 6) for `agent.yaml`.
-Modify embedding provider, pipeline V2 flags, search settings, memory
-retention windows, and auth configuration without leaving the browser.
-Changes are saved directly to `$SIGNET_WORKSPACE/agent.yaml`.
+**Ontology** — Unified memory workspace. It combines memory search, timeline,
+knowledge/entity inspection, and constellation/embedding exploration behind
+the `cortex-memory` route. Legacy hashes such as `#memory`, `#embeddings`,
+and `#knowledge` redirect here.
 
-**Memory** — Browse and search your memory database. Search runs hybrid
-(semantic + keyword) lookup. You can filter by type, tags, source
-harness, pinned status, importance score, and date. Each memory card has
-a "Find Similar" button that runs a vector similarity search. The count
-shown reflects your current filter state.
+**Settings** — Form-driven configuration editor for identity, embedding,
+memory, pipeline, connector, and review settings. Changes are saved to the
+resolved config files under `$SIGNET_WORKSPACE/`.
 
-**Embeddings** — A 3D force-directed graph of your memory space
+**Memory search** — Browse and search your memory database from the ontology
+workspace. Search runs hybrid (semantic + keyword) lookup. You can filter by
+type, tags, source harness, pinned status, importance score, and date. Each
+memory card has a "Find Similar" action that runs vector similarity search.
+The count shown reflects your current filter state.
+
+**Embeddings / Constellation** — A 3D force-directed graph of your memory space
 (powered by `3d-force-graph` / Three.js). Memories with vector
 embeddings appear as nodes; edges connect k-nearest neighbors.
 
@@ -138,7 +125,7 @@ Clicking an entity node opens an inspector panel showing the entity type,
 aspects list, dependency edges, and memory count. Clicking a memory node
 opens the existing memory detail panel.
 
-**Predictor Metrics Tab**
+**Predictor Metrics**
 
 When the predictive memory scorer is enabled, a Predictor tab surfaces
 scorer health metrics:
@@ -148,17 +135,16 @@ scorer health metrics:
 - Drift detection status (flags when model performance has degraded)
 - Training pair count (total comparison pairs accumulated)
 
-The predictor follows the current runtime config. If
-`predictor.enabled` is set to `false`, the tab shows a "not enabled"
-placeholder instead of live scorer metrics.
+The predictor follows the current runtime config. Current navigation routes
+predictor status through Settings and related ontology health panels; legacy
+`#predictor` hashes continue to resolve to Settings.
 
 
 **Pipeline — Active Sessions**
 
-The Pipeline tab includes a SessionList component that displays all
-active sessions with per-session bypass toggles. Each row shows the
-session key, harness name, runtime path, and a Switch control to
-enable or disable bypass. Toggling the switch calls
+The Settings pipeline section includes active-session controls with per-session
+bypass toggles. Each row shows the session key, harness name, runtime path, and
+a Switch control to enable or disable bypass. Toggling the switch calls
 `POST /api/sessions/:key/bypass` (see [[api#Sessions]]). When bypass
 is on, all hooks for that session return empty no-op responses — MCP
 tools still work normally.
@@ -166,7 +152,7 @@ tools still work normally.
 The session list auto-refreshes every 30 seconds and is only visible
 when at least one session is active.
 
-**Logs** — Real-time daemon log stream via Server-Sent Events
+**Audit** — Diagnostics and logs. The log view streams daemon events via Server-Sent Events
 (`/api/logs/stream`). A Live/Stop toggle controls the stream.
 Entries are color-coded by level (`debug`, `info`, `warn`, `error`)
 and labeled by category: `daemon`, `api`, `memory`, `sync`, `git`,
@@ -182,9 +168,9 @@ encrypted provider and 1Password compatibility flow. You can add new
 secrets (via a password input) or delete existing ones. For CLI use,
 prefer `signet secret put <NAME>`.
 
-**Skills** — Lists installed skills and lets you browse the skills.sh
-registry. Click a skill name to read its full `SKILL.md` before
-installing. Already-installed skills are marked.
+**Skills** — Lists installed skills and marketplace catalog entries from
+Signet, skills.sh, and ClawHub sources. Click a skill name to read details
+before installing. Already-installed skills are marked.
 
 The Skills tab also includes **Plugins**, a registry view for core and
 installed Signet extensions. It shows plugin state, health, capability

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -53,25 +53,25 @@ production data.
 **Controlled-write mode** is active when `enabled` is true, `shadowMode` is
 false, and `mutationsFrozen` is false. In this mode, ADD and NONE decisions
 are applied. ADD creates new memory rows and embeddings; NONE is recorded
-for audit only. Destructive decisions (UPDATE and DELETE) are blocked by
-default and require the separate `allowUpdateDelete` flag.
+for audit only. UPDATE and DELETE proposals are blocked unless
+`autonomous.allowUpdateDelete` is true.
 
-**Full mode** is the same as controlled-write mode with `allowUpdateDelete`
-set to true. In the current implementation, destructive mutations are
-recognized in the decision output but their application is reserved for a
-future phase — they are blocked with reason
-`destructive_mutations_not_implemented` and logged.
+**Full mode** is controlled-write mode with `allowUpdateDelete` set to true.
+In this mode UPDATE proposals modify the referenced memory through the mutation
+API path, and DELETE proposals soft-delete the referenced memory through the
+forget path. The previous target state is archived to the cold tier first, and
+pinned memories are skipped rather than deleted.
 
 The five config flags in detail:
 
 - `enabled` — Master switch. When false, no extraction jobs are processed.
 - `shadowMode` — Run extraction and decisions without writing any facts.
 - `allowUpdateDelete` — Permit UPDATE/DELETE decisions to mutate existing
-  memories. Currently infrastructure-only; mutations are not yet applied.
+  memories through guarded modify/forget paths.
 - `mutationsFrozen` — Emergency brake. Disables all writes even if
   `shadowMode` is false.
-- `autonomousFrozen` — Disables the maintenance worker's scheduled interval
-  even if `autonomousEnabled` is true.
+- `autonomous.frozen` — Disables the maintenance worker's scheduled interval
+  even if `autonomous.enabled` is true.
 
 
 Extraction Stage
@@ -342,7 +342,7 @@ and exposed on the pipeline status endpoint: `feedbackAspectsUpdated`,
 Graph-Augmented Search
 ---
 
-At query time, when `graphEnabled` is true and the caller requests a graph
+At query time, when `graph.enabled` is true and the caller requests a graph
 boost, `getGraphBoostIds` is called synchronously against the read database.
 The function returns a set of memory IDs that should receive a score boost
 in the final recall ranking.
@@ -494,8 +494,8 @@ Maintenance Worker
 ---
 
 The maintenance worker performs autonomous diagnostics and, optionally,
-self-repair. It is governed by `autonomousEnabled` and `autonomousFrozen`.
-If `autonomousEnabled` is false or `autonomousFrozen` is true, the interval
+self-repair. It is governed by `autonomous.enabled` and `autonomous.frozen`.
+If `autonomous.enabled` is false or `autonomous.frozen` is true, the interval
 never starts, though the worker's `tick()` method remains callable for
 on-demand inspection.
 
@@ -594,9 +594,10 @@ the baseline pipeline remains unchanged.
 Optional Reranking
 ---
 
-After baseline hybrid search returns a scored candidate list, an optional
-reranking pass can reorder the top-N entries using a cross-encoder or other
-scoring model. Reranking is disabled by default (`reranker.enabled: false`).
+After baseline hybrid search returns a scored candidate list, a reranking pass
+can reorder the top-N entries. Reranking is enabled by default, but the default
+provider is the pass-through `noopReranker` unless a concrete reranker path is
+selected.
 
 The `rerank` function accepts a query string, a mutable candidate list, a
 `RerankProvider` callback, and a `RerankConfig`. It slices the list at
@@ -653,9 +654,9 @@ prompted to return a JSON object with `contradicts` (boolean), `confidence`
 (0–1), and `reasoning` (string).
 
 Semantic contradiction detection is gated by `semanticContradictionEnabled`
-(default `false`). When enabled, the LLM call uses a configurable timeout
-controlled by `semanticContradictionTimeoutMs` (default 45 seconds, range
-5s–300s). On timeout or parse failure, the result defaults to "no
+(default `true`). When enabled, the LLM call uses a configurable timeout
+controlled by `semanticContradictionTimeoutMs` (default 120 seconds, range
+5s-300s). On timeout or parse failure, the result defaults to "no
 contradiction" — the check is advisory and never blocks a proposal.
 
 These same detection primitives are reused by the retroactive supersession
@@ -668,8 +669,8 @@ details.
 ```yaml
 memory:
   pipelineV2:
-    semanticContradictionEnabled: false
-    semanticContradictionTimeoutMs: 45000  # ms, range 5000–300000
+    semanticContradictionEnabled: true
+    semanticContradictionTimeoutMs: 120000  # ms, range 5000-300000
 ```
 
 
@@ -1039,8 +1040,8 @@ fields are only used to build an implicit compatibility profile when no explicit
 enabled                         true
 shadowMode                      false
 mutationsFrozen                 false
-semanticContradictionEnabled        false
-semanticContradictionTimeoutMs      45000   # ms, range 5000–300000
+semanticContradictionEnabled        true
+semanticContradictionTimeoutMs      120000  # ms, range 5000-300000
 telemetryEnabled                    false
 ```
 
@@ -1071,8 +1072,8 @@ extraction:
 
 synthesis:
   enabled: true
-  provider: llama-cpp            # "none" | "llama-cpp" | "ollama" | "claude-code" | "codex" | "opencode" | "anthropic" | "openrouter"
-  model: qwen3.5:4b
+  provider: ollama               # "none" | "llama-cpp" | "ollama" | "claude-code" | "codex" | "opencode" | "anthropic" | "openrouter"
+  model: qwen3:4b
   timeout: 120000                # ms, range 5000–300000
   # when omitted entirely, synthesis falls back to extraction provider/model
   # explicit top-level inference.workloads bindings override legacy provider selection
@@ -1091,15 +1092,19 @@ graph:
   boostTimeoutMs: 500            # ms, range 50–5000
 
 structural:
-  enabled: true
+  enabled: false
   classifyBatchSize: 8           # range 1–20
   dependencyBatchSize: 5         # range 1–10
   pollIntervalMs: 10000          # ms, range 2000–120000
-  synthesisEnabled: true
+  synthesisEnabled: false
   synthesisIntervalMs: 60000     # ms, range 10000–600000
   synthesisTopEntities: 20       # range 5–100
   synthesisMaxFacts: 10          # range 3–50
   synthesisMaxStallMs: 1800000   # 30 min, set 0 to disable
+  supersessionEnabled: true
+  supersessionSweepEnabled: true
+  supersessionSemanticFallback: false
+  supersessionMinConfidence: 0.7
 
 reranker:
   enabled: true
@@ -1132,9 +1137,10 @@ documents:
   maxContentBytes: 10485760      # 10 MB, range 1 KB–100 MB
 
 guardrails:
-  maxContentChars: 500           # range 50–100000
-  chunkTargetChars: 300          # range 50–50000
+  maxContentChars: 800           # range 50–100000
+  chunkTargetChars: 600          # range 50–50000
   recallTruncateChars: 500       # range 50–100000
+  contextBudgetChars: 4000
 
 continuity:
   enabled: true


### PR DESCRIPTION
## Summary

- Manually audited README, API, architecture, pipeline, dashboard, benchmarking, spec index, and configuration docs against current source on latest `origin/main`.
- Corrected stale API/status examples, pipeline defaults, destructive mutation behavior, dashboard navigation, network bind defaults, and benchmark-score framing.
- Restored the LongMemEval 97.6% claim as an averaged latest-score claim with an explicit scoring note in `docs/BENCHMARKING.md`.
- Kept changes documentation-only and did not use `scripts/doc-drift.ts` as source of truth.

## Drift found

- README linked to a missing `docs/BENCHMARKING.md#current-longmemeval-score` anchor; restored the anchor and clarified that 97.6% is the latest tracked MemoryBench average rather than a single exact run.
- `docs/API.md` still showed flat `pipelineV2` fields and an old daemon version/status sample instead of the current nested config shape and status fields.
- `docs/ARCHITECTURE.md` claimed the inline entity linker creates entities/aspects/attributes, but `platform/daemon/src/inline-entity-linker.ts` only links memories to existing same-agent entities.
- `docs/ARCHITECTURE.md` and `docs/PIPELINE.md` said UPDATE/DELETE pipeline decisions were not implemented, but `platform/daemon/src/pipeline/worker.ts` and worker tests now apply guarded update/delete paths when `autonomous.allowUpdateDelete` is true.
- `docs/PIPELINE.md` had stale defaults for semantic contradiction detection, synthesis provider/model, structural classification, guardrails, and reranking.
- `docs/DASHBOARD.md` described an older three-region dashboard with config files in the sidebar instead of the current navigation rail and unified ontology/settings/audit surfaces.
- `docs/API.md` and `docs/CONFIGURATION.md` described `SIGNET_BIND` as defaulting to `SIGNET_HOST`, but current network binding defaults are mode-specific.

## Evidence checked

- `platform/daemon/src/memory-config.ts`
- `platform/daemon/src/routes/pipeline-routes.ts`
- `platform/daemon/src/routes/state.ts`
- `platform/core/src/network.ts`
- `platform/daemon/src/inline-entity-linker.ts`
- `platform/daemon/src/pipeline/worker.ts`
- `platform/daemon/src/pipeline/worker.test.ts`
- `surfaces/dashboard/src/lib/components/app-sidebar.svelte`
- `surfaces/dashboard/src/lib/stores/navigation.svelte.ts`
- `surfaces/dashboard/src/lib/components/layout/TabContentLoader.svelte`
- `scripts/bench-memory.ts`
- `docs/BENCHMARKING-PROGRESS.md`
- `package.json`

## Checks run

- `bun scripts/spec-deps-check.ts`
- `bun scripts/sync-root-docs.ts --check`
- `bun scripts/bench-memory.ts --dry-run --port 3850 --limit 1`
- `git diff --check`
- targeted stale-pattern `rg` checks across touched docs

## Validation gaps

- Biome check did not validate these markdown docs: `@biomejs/biome@1.9.0 check README.md ...` completed dependency resolution but reported `Checked 0 files` / `No files were processed in the specified paths` under the repo config.
