### PR TITLE
fix(graphiq): prevent false install failure from cleanup trap

### DIFF
--- a/scripts/install-graphiq.sh
+++ b/scripts/install-graphiq.sh
@@ -4,9 +4,18 @@ set -euo pipefail
 REPO="aaf2tbz/graphiq"
 INSTALL_DIR="${GRAPHIQ_INSTALL_DIR:-$HOME/.local/bin}"
 TIMEOUT="${GRAPHIQ_INSTALL_TIMEOUT:-120}"
+tmpdir=""
 
 log()  { printf "[graphiq] %s\n" "$*" >&2; }
 die()  { log "$@"; exit 1; }
+
+cleanup_tmpdir() {
+	if [ -n "${tmpdir:-}" ] && [ -d "${tmpdir:-}" ]; then
+		rm -rf "$tmpdir"
+	fi
+}
+
+trap cleanup_tmpdir EXIT
 
 need() { command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"; }
 
@@ -82,7 +91,7 @@ extract_asset_sha256() {
 
 cmd_install() {
 	need tar
-	local target tag tarball url tmpdir
+	local target tag tarball url
 	target="$(detect_target)"
 	tarball="graphiq-${target}.tar.gz"
 
@@ -115,7 +124,6 @@ cmd_install() {
 
 	mkdir -p "$INSTALL_DIR"
 	tmpdir="$(mktemp -d)"
-	trap 'rm -rf "$tmpdir"' EXIT
 
 	fetch "$url" "${tmpdir}/${tarball}"
 

--- a/surfaces/cli/src/features/graphiq.test.ts
+++ b/surfaces/cli/src/features/graphiq.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
 	SIGNET_GRAPHIQ_PLUGIN_ID,
 	getGraphiqProjectDbPath,
@@ -19,6 +22,18 @@ import {
 import { readSetupCorePluginEnabled } from "./setup-plugins.js";
 
 let tempRoot = "";
+
+function graphiqTarballForHost(): string {
+	const platform = process.platform;
+	const arch = process.arch;
+	if (platform === "darwin" && arch === "arm64") return "graphiq-aarch64-apple-darwin.tar.gz";
+	if (platform === "darwin" && arch === "x64") return "graphiq-x86_64-apple-darwin.tar.gz";
+	if (platform === "linux" && arch === "x64") return "graphiq-x86_64-unknown-linux-gnu.tar.gz";
+	if (platform === "linux" && (arch === "arm64" || arch === "arm")) {
+		return "graphiq-aarch64-unknown-linux-gnu.tar.gz";
+	}
+	throw new Error(`Unsupported host target in test: ${platform}/${arch}`);
+}
 
 function makeRoot(): string {
 	tempRoot = mkdtempSync(join(tmpdir(), "signet-graphiq-cli-"));
@@ -108,6 +123,68 @@ describe("GraphIQ plugin install", () => {
 
 		const args = readFileSync(capturePath, "utf-8");
 		expect(args).toContain("install");
+	});
+
+	test("install script exits successfully after a completed install", () => {
+		const basePath = makeRoot();
+		const fakeBin = join(basePath, "fake-bin");
+		const installDir = join(basePath, "install-bin");
+		const fixtureDir = join(basePath, "fixtures");
+		const tarballName = graphiqTarballForHost();
+		const tarballPath = join(fixtureDir, tarballName);
+		const curlPath = join(fakeBin, "curl");
+		const graphiqFixture = join(fixtureDir, "graphiq");
+		const scriptPath = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../scripts/install-graphiq.sh");
+		mkdirSync(fakeBin, { recursive: true });
+		mkdirSync(installDir, { recursive: true });
+		mkdirSync(fixtureDir, { recursive: true });
+		writeFileSync(graphiqFixture, "#!/bin/sh\necho graphiq fixture\n");
+		chmodSync(graphiqFixture, 0o755);
+		const tarResult = spawnSync("tar", ["-czf", tarballPath, "-C", fixtureDir, "graphiq"], { encoding: "utf-8" });
+		expect(tarResult.status).toBe(0);
+		const expectedSha = createHash("sha256").update(readFileSync(tarballPath)).digest("hex");
+		expect(expectedSha.length).toBe(64);
+		writeFileSync(
+			curlPath,
+			`#!/bin/sh
+set -eu
+url=""
+dest=""
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		-o)
+			dest="$2"
+			shift 2
+			;;
+		*)
+			url="$1"
+			shift
+			;;
+	esac
+done
+if [ -n "$dest" ]; then
+	cp ${JSON.stringify(tarballPath)} "$dest"
+	exit 0
+fi
+cat <<'JSON'
+{"tag_name":"v3.3.1","assets":[{"name":"${tarballName}","digest":"sha256:${expectedSha}"}]}
+JSON
+`,
+		);
+		chmodSync(curlPath, 0o755);
+
+		const result = spawnSync("bash", [scriptPath, "install"], {
+			env: {
+				...process.env,
+				PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+				GRAPHIQ_ALLOW_LATEST: "1",
+				GRAPHIQ_INSTALL_DIR: installDir,
+			},
+			encoding: "utf-8",
+		});
+
+		expect(result.status).toBe(0);
+		expect(existsSync(join(installDir, "graphiq"))).toBe(true);
 	});
 
 	test("does not run GraphIQ without --db when active project metadata is missing", async () => {


### PR DESCRIPTION
## Summary

Fixes the GraphIQ install script cleanup trap so successful installs exit with status 0. The original code declared a function-local `tmpdir` that shadowed the outer variable, causing the EXIT trap to reference an empty value. The fix hoists the trap to use the global `tmpdir` with a proper null/dir guard.

Replaces #599 (closed due to repeated false-positive scope-drift flags from the automated reviewer caused by the fork diff base shifting as main advanced).

Closes #586

## Changes

- `scripts/install-graphiq.sh` — moved `tmpdir` to script scope, added `cleanup_tmpdir()` with null/dir guard, installed single `trap cleanup_tmpdir EXIT` at script level, removed function-local `local tmpdir` and per-function trap.
- `surfaces/cli/src/features/graphiq.test.ts` — added end-to-end regression test with local fixture tarball and fake `curl`, asserting exit status 0 and installed binary presence.

## Type

- [x] `fix` — bug fix

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: `scripts/install-graphiq.sh`

## Screenshots

N/A

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A — no schema or migration changes.

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Credit: original fix by @LeuciRemi. This PR carries the same changes on a clean branch to resolve CI/reviewer issues.