### PR TITLE
fix(daemon): stop native memory fd leak

### DIFF
--- a/platform/daemon/src/native-memory-sources.test.ts
+++ b/platform/daemon/src/native-memory-sources.test.ts
@@ -255,6 +255,29 @@ describe("native memory sources", () => {
 		expect(count).toBe(1);
 	});
 
+	it("reindexes same-size native files when content changes", async () => {
+		const root = join(dir, ".codex");
+		mkdirSync(join(root, "memories"), { recursive: true });
+		const source = codexNativeMemorySource(root);
+		const file = join(root, "memories", "memory_summary.md");
+		const stamp = new Date("2026-04-22T12:00:00Z");
+		writeFileSync(file, "Codex remembered alpha state.\n");
+		utimesSync(file, stamp, stamp);
+
+		expect(await indexNativeMemoryFile(source, file, "agent-native")).toBe(true);
+		writeFileSync(file, "Codex remembered bravo state.\n");
+		utimesSync(file, stamp, stamp);
+
+		expect(await indexNativeMemoryFile(source, file, "agent-native")).toBe(true);
+		const row = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT content FROM memory_artifacts WHERE agent_id = ? AND source_path = ?")
+					.get("agent-native", file) as { content: string },
+		);
+		expect(row.content).toContain("bravo state");
+	});
+
 	it("indexes native memories when the source root is created after bridge startup", async () => {
 		const root = join(dir, ".codex");
 		const handle = startNativeMemoryBridge([codexNativeMemorySource(root)], {
@@ -278,6 +301,104 @@ describe("native memory sources", () => {
 				}
 			}
 			expect(indexed).toBe(true);
+		} finally {
+			await handle.close();
+		}
+	});
+
+	it("soft-deletes removed native memories during bridge sync", async () => {
+		const root = join(dir, ".codex");
+		const file = join(root, "memories", "memory_summary.md");
+		mkdirSync(join(root, "memories"), { recursive: true });
+		writeFileSync(file, "Codex remembered a native memory that will disappear.\n");
+
+		const handle = startNativeMemoryBridge([codexNativeMemorySource(root)], {
+			agentId: "agent-native",
+			pollIntervalMs: 0,
+		});
+		try {
+			expect(await handle.syncExisting()).toBe(1);
+			rmSync(file);
+			expect(await handle.syncExisting()).toBe(0);
+
+			const row = getDbAccessor().withReadDb(
+				(db) =>
+					db
+						.prepare("SELECT is_deleted, deleted_at FROM memory_artifacts WHERE agent_id = ? AND source_path = ?")
+						.get("agent-native", file) as {
+						is_deleted: number;
+						deleted_at: string | null;
+					},
+			);
+			expect(row.is_deleted).toBe(1);
+			expect(row.deleted_at).toBeTruthy();
+		} finally {
+			await handle.close();
+		}
+	});
+
+	it("soft-deletes known native memories when their source root is removed", async () => {
+		const root = join(dir, ".codex");
+		const file = join(root, "memories", "memory_summary.md");
+		mkdirSync(join(root, "memories"), { recursive: true });
+		writeFileSync(file, "Codex remembered a native root that will disappear.\n");
+
+		const handle = startNativeMemoryBridge([codexNativeMemorySource(root)], {
+			agentId: "agent-native",
+			pollIntervalMs: 0,
+		});
+		try {
+			expect(await handle.syncExisting()).toBe(1);
+			rmSync(root, { recursive: true, force: true });
+			expect(await handle.syncExisting()).toBe(0);
+
+			const row = getDbAccessor().withReadDb(
+				(db) =>
+					db
+						.prepare("SELECT is_deleted, deleted_at FROM memory_artifacts WHERE agent_id = ? AND source_path = ?")
+						.get("agent-native", file) as {
+						is_deleted: number;
+						deleted_at: string | null;
+					},
+			);
+			expect(row.is_deleted).toBe(1);
+			expect(row.deleted_at).toBeTruthy();
+		} finally {
+			await handle.close();
+		}
+	});
+
+	it("keeps known native memory state isolated by source root", async () => {
+		const rootA = join(dir, ".codex-a");
+		const rootB = join(dir, ".codex-b");
+		const fileA = join(rootA, "memories", "memory_summary.md");
+		const fileB = join(rootB, "memories", "memory_summary.md");
+		mkdirSync(join(rootA, "memories"), { recursive: true });
+		mkdirSync(join(rootB, "memories"), { recursive: true });
+		writeFileSync(fileA, "Codex remembered source A.\n");
+		writeFileSync(fileB, "Codex remembered source B.\n");
+
+		const handle = startNativeMemoryBridge([codexNativeMemorySource(rootA), codexNativeMemorySource(rootB)], {
+			agentId: "agent-native",
+			pollIntervalMs: 0,
+		});
+		try {
+			expect(await handle.syncExisting()).toBe(2);
+			expect(await handle.syncExisting()).toBe(0);
+
+			const rows = getDbAccessor().withReadDb(
+				(db) =>
+					db
+						.prepare("SELECT source_path, is_deleted FROM memory_artifacts WHERE agent_id = ? ORDER BY source_path")
+						.all("agent-native") as Array<{
+						source_path: string;
+						is_deleted: number;
+					}>,
+			);
+			expect(rows).toEqual([
+				{ source_path: fileA, is_deleted: 0 },
+				{ source_path: fileB, is_deleted: 0 },
+			]);
 		} finally {
 			await handle.close();
 		}

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -3,7 +3,6 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
-import { watch } from "chokidar";
 import { resolveDaemonAgentId } from "./agent-id";
 import { yieldEvery } from "./async-yield";
 import { getDbAccessor } from "./db-accessor";
@@ -33,7 +32,11 @@ export interface NativeMemoryBridgeOptions {
 	readonly pollIntervalMs?: number;
 }
 
-const indexed = new Map<string, string>();
+interface IndexedNativeMemory {
+	readonly contentHash: string;
+}
+
+const indexed = new Map<string, IndexedNativeMemory>();
 
 function codexRoot(): string {
 	return join(homedir(), ".codex");
@@ -132,6 +135,14 @@ function fingerprintKey(source: NativeMemorySource, filePath: string, agentId: s
 	return `${agentId}:${source.harness}:${filePath}`;
 }
 
+function sourceStateKey(source: NativeMemorySource, agentId: string): string {
+	return `${agentId}:${source.harness}:${source.root.replace(/\\/g, "/").replace(/\/$/, "")}`;
+}
+
+function contentFingerprint(content: string): string {
+	return createHash("sha256").update(content).digest("hex");
+}
+
 function nativeArtifactRowExists(filePath: string, agentId: string): boolean {
 	const sourcePath = filePath.replace(/\\/g, "/");
 	try {
@@ -174,8 +185,9 @@ export async function indexNativeMemoryFile(
 	if (!content.trim()) return false;
 
 	const key = fingerprintKey(source, filePath, agentId);
-	const fingerprint = `${mtimeMs}:${createHash("sha256").update(content).digest("hex")}`;
-	if (indexed.get(key) === fingerprint) {
+	const hash = contentFingerprint(content);
+	const cached = indexed.get(key);
+	if (cached?.contentHash === hash) {
 		if (nativeArtifactRowExists(filePath, agentId)) return false;
 		indexed.delete(key);
 	}
@@ -189,7 +201,7 @@ export async function indexNativeMemoryFile(
 			content,
 			sourceMtimeMs: mtimeMs,
 		});
-		indexed.set(key, fingerprint);
+		indexed.set(key, { contentHash: hash });
 		logger.info("watcher", "Indexed native memory artifact", {
 			harness: source.harness,
 			kind: pattern.kind,
@@ -220,37 +232,29 @@ export function startNativeMemoryBridge(
 	options: NativeMemoryBridgeOptions = {},
 ): NativeMemoryBridgeHandle {
 	const agentId = resolveBridgeAgentId(options.agentId);
-	const watchers = sources.map((source) => {
-		const patterns = source.files.map((file) => join(source.root, file.glob));
-		const watcher = watch(patterns, {
-			ignoreInitial: true,
-			persistent: true,
-		});
-		watcher.on("add", (path) => void indexNativeMemoryFile(source, path, agentId));
-		watcher.on("change", (path) => void indexNativeMemoryFile(source, path, agentId));
-		watcher.on("unlink", (path) => {
-			try {
-				removeNativeMemoryFile(source, path, agentId);
-			} catch (err) {
-				logger.warn("watcher", "Failed removing native memory artifact index row", {
-					harness: source.harness,
-					path,
-					error: err instanceof Error ? err.message : String(err),
-				});
-			}
-		});
-		return { source, watcher };
-	});
+	const known = new Map<string, Set<string>>();
 
 	const syncExisting = async (): Promise<number> => {
 		let count = 0;
 		const yielder = yieldEvery(20);
 		for (const source of sources) {
-			if (!existsSync(source.root)) continue;
-			for await (const file of walkMarkdownFiles(source.root)) {
-				if (await indexNativeMemoryFile(source, file, agentId)) count++;
-				await yielder();
+			const key = sourceStateKey(source, agentId);
+			const current = new Set<string>();
+			if (existsSync(source.root)) {
+				for await (const file of walkMarkdownFiles(source.root)) {
+					if (!matchesPattern(source, file)) continue;
+					current.add(file);
+					if (await indexNativeMemoryFile(source, file, agentId)) count++;
+					await yielder();
+				}
 			}
+			const previous = known.get(key);
+			if (previous) {
+				for (const file of previous) {
+					if (!current.has(file)) removeNativeMemoryFile(source, file, agentId);
+				}
+			}
+			known.set(key, current);
 		}
 		return count;
 	};
@@ -278,7 +282,6 @@ export function startNativeMemoryBridge(
 		syncExisting,
 		async close(): Promise<void> {
 			if (pollTimer) clearInterval(pollTimer);
-			await Promise.all(watchers.map(({ watcher }) => watcher.close()));
 		},
 	};
 }


### PR DESCRIPTION
## Summary

Fixes a daemon crash-loop/stability issue caused by the native memory bridge holding persistent chokidar watches over large Codex native-memory directories, especially `~/.codex/memories/rollout_summaries/*.md`. On the affected machine the old daemon process had roughly 3,750 file descriptors open, many pointing directly at rollout summary files.

## Changes

- Remove persistent chokidar watchers from the native memory bridge and rely on the existing bounded polling sync.
- Keep content-hash dedupe for matched native memory files so same-size or timestamp-preserving rewrites are detected immediately.
- Track known files per agent, harness, and normalized source root, then soft-delete artifact rows when native memory files or whole source roots disappear during sync.
- Add regression coverage for same-size rewrites, bridge-driven soft deletes, whole-root removal, and same-harness source isolation.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A — daemon-only change, no UI surface touched.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — N/A; narrow daemon bug fix, no spec-governed behavior or contract change.
- [x] Agent scoping verified on all new/changed data queries — native artifact reads and soft deletes continue to pass the resolved `agentId`.
- [x] Input/config validation and bounds checks added — N/A; no new external input or config surface.
- [x] Error handling and fallback paths tested (no silent swallow) — read/index failures still warn and return structured false results; removal behavior has regression coverage.
- [x] Security checks applied to admin/mutation endpoints — N/A; no endpoint or auth changes.
- [x] Docs updated for API/spec/status changes — N/A; no public API/spec/status change.
- [x] Regression tests added for each bug fix.
- [x] Lint/typecheck/tests pass locally.

## Migration Notes (if applicable)

N/A — no migrations touched.

- [ ] Migration is idempotent
- [ ] Daemon Rust parity reviewed or explicitly N/A
- [ ] Rollback / compatibility note included in PR description

## Testing

- [x] `bun test platform/daemon/src/native-memory-sources.test.ts platform/daemon/src/memory-ingest-filter.test.ts platform/daemon/src/async-yield.test.ts platform/daemon/src/event-loop-responsiveness.test.ts`
- [x] `bunx biome check platform/daemon/src/native-memory-sources.ts platform/daemon/src/native-memory-sources.test.ts`
- [x] `git diff --check`
- [x] `bun run build:core && cd dist/signetai && bun run build:daemon`
- [x] Tested against running daemon: patched local install stayed healthy on `v0.109.11`, FD count stayed near 200, and rollout summary FDs stayed at 0.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

This deliberately keeps native memory ingestion polling-based. These files are low urgency, and polling avoids the file descriptor pressure caused by persistent watchers over large native memory archives. A future cleanup could make discovery pattern-directed instead of walking broad roots and filtering.