### PR TITLE
fix(daemon): apply is_deleted filter to BM25 FTS path

### DIFF
--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -156,6 +156,38 @@ describe("hybridRecall", () => {
 		expect(result.results.map((row) => row.id)).toContain("mem-keyword-sync-throw");
 	});
 
+	it("excludes soft-deleted memories from BM25/FTS keyword recall", async () => {
+		const now = new Date().toISOString();
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, type, agent_id, created_at, updated_at, updated_by, is_deleted
+				) VALUES (?, ?, 'fact', 'default', ?, ?, 'test', 1)`,
+			).run("mem-bm25-deleted", "bm25-deleted-marker should not surface", now, now);
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, type, agent_id, created_at, updated_at, updated_by
+				) VALUES (?, ?, 'fact', 'default', ?, ?, 'test')`,
+			).run("mem-bm25-live", "bm25-live-marker should surface", now, now);
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "bm25-deleted-marker",
+				keywordQuery: "bm25-deleted-marker",
+				limit: 5,
+				agentId: "default",
+				readPolicy: "isolated",
+			},
+			loadMemoryConfig(dir),
+			() => {
+				throw new Error("embedding unavailable");
+			},
+		);
+
+		expect(result.results.map((row) => row.id)).not.toContain("mem-bm25-deleted");
+	});
+
 	it("recalls indexed native harness memory artifacts without materializing memories", async () => {
 		const codexMemoryPath = join(dir, "codex", "memories", "MEMORY.md");
 		mkdirSync(join(dir, "codex", "memories"), { recursive: true });

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -905,7 +905,8 @@ export async function hybridRecall(
         SELECT m.id, bm25(memories_fts) AS raw_score
         FROM memories_fts
         JOIN memories m ON memories_fts.rowid = m.rowid
-        WHERE memories_fts MATCH ?${filter.sql}
+        WHERE memories_fts MATCH ?
+          AND m.is_deleted = 0${filter.sql}
         ORDER BY raw_score
         LIMIT ?
       `) as any


### PR DESCRIPTION
## Problem

BM25/FTS keyword path in `memory-search.ts:905` lacked an `is_deleted=0` predicate, so soft-deleted memories leaked into recall results. Sibling paths (lines 734, 791, 1275, 1887, 1959) already enforce the filter.

## Fix

Add `AND m.is_deleted = 0` before `${filter.sql}` so it composes cleanly with the existing scope/type/tag clauses built by `buildFilterClause()`.

```diff
        SELECT m.id, bm25(memories_fts) AS raw_score
        FROM memories_fts
        JOIN memories m ON memories_fts.rowid = m.rowid
-       WHERE memories_fts MATCH ?${filter.sql}
+       WHERE memories_fts MATCH ?
+         AND m.is_deleted = 0${filter.sql}
        ORDER BY raw_score
        LIMIT ?
```

<details>
<summary>Why soft-deletes leak (root cause)</summary>

`UPDATE memories SET is_deleted=1` does not fire the `memories_ad` FTS sync trigger (it only fires on `DELETE`, not on `UPDATE OF is_deleted`). The FTS5 row remains, so any path that joins `memories_fts → memories` without an `is_deleted` predicate returns the soft-deleted row.

Trigger redesign (e.g., `AFTER UPDATE OF is_deleted`) would cause re-index churn and is out of scope. Filter-side fix matches the existing convention in 5 other paths.

</details>

<details>
<summary>Repro before fix</summary>

\`\`\`bash
ID=\$(curl -s -X POST http://localhost:3850/api/memory \\
  -H 'Content-Type: application/json' \\
  -d '{\"content\":\"BM25-leak-test secret-string\"}' | jq -r .id)

curl -X POST \"http://localhost:3850/api/memory/\$ID/forget\"

# BM25 path returns it (BUG)
curl -s 'http://localhost:3850/api/memory/search?q=BM25-leak-test&mode=bm25' | jq '.results | length'
# → 1, expect 0
\`\`\`

</details>

## Tests

Added regression in `memory-search.test.ts`: inserts a soft-deleted row and a live row, asserts only the live row surfaces via keyword recall. Full file: 29 pass, 0 fail.