### PR TITLE
fix(hermes-agent): harden connector install and diagnostics

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -46,6 +46,7 @@ Commands Overview
 | `signet configure` | Interactive config editor (`signet config` alias) |
 | `signet status` | Show daemon and agent status |
 | `signet doctor` | Run local health checks |
+| `signet doctor hermes` | Check Hermes Agent plugin freshness, config activation, and tool routing |
 | `signet route` | Inspect and control inference routing |
 | `signet dashboard` | Open web UI in browser |
 | `signet daemon` | Grouped daemon subcommands |
@@ -90,6 +91,7 @@ menu.
     signet setup
     signet status
     signet doctor
+    signet doctor hermes
     signet daemon start
     signet remember "Nicholai prefers command-first CLIs"
 ```
@@ -99,6 +101,7 @@ Use explicit commands for interactive flows:
 - `signet setup` — initialize or migrate a workspace
 - `signet configure` — edit agent settings interactively
 - `signet doctor` — troubleshoot local issues
+- `signet doctor hermes` — troubleshoot Hermes Agent integration issues
 
 ---
 

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -705,18 +705,25 @@ Hermes lifecycle.
 
 | Location | Description |
 |----------|-------------|
+| `~/.hermes/plugins/signet/__init__.py` | User-level Signet `MemoryProvider` implementation |
+| `~/.hermes/plugins/signet/client.py` | User-level HTTP client for the Signet daemon API |
+| `~/.hermes/plugins/signet/plugin.yaml` | User-level plugin metadata |
+| `~/.hermes/plugins/signet/signet.install.json` | Install marker with connector version and plugin source hash |
 | `<hermes-repo>/plugins/memory/signet/__init__.py` | Signet `MemoryProvider` implementation |
 | `<hermes-repo>/plugins/memory/signet/client.py` | HTTP client for the Signet daemon API |
 | `<hermes-repo>/plugins/memory/signet/plugin.yaml` | Plugin metadata |
+| `<hermes-repo>/plugins/memory/signet/signet.install.json` | Install marker with connector version and plugin source hash |
+| `~/.hermes/config.yaml` | `memory.provider: signet` activation |
 | `~/.hermes/.env` | Daemon connection environment variables |
 
 ### How it works
 
 1. `signet setup` (with `hermes-agent` selected) copies the Python plugin
-   into `plugins/memory/signet/` inside the Hermes Agent repo and writes
-   daemon connection env vars to `~/.hermes/.env`.
-2. The user activates the plugin via `hermes memory setup` (select "signet")
-   or `hermes config set memory.provider signet`.
+   into both `~/.hermes/plugins/signet/` and, when discovered,
+   `<hermes-repo>/plugins/memory/signet/`.
+2. The connector writes install markers, daemon connection env vars to
+   `~/.hermes/.env`, and activates the provider by setting
+   `memory.provider: signet` in Hermes config.
 3. At session start, Hermes calls `initialize()` on the plugin, which fires
    `POST /api/hooks/session-start` to load identity, memories, and system
    prompt injection from the daemon.
@@ -758,7 +765,9 @@ stores the task+result pair as a Signet memory tagged `["delegation", "subagent"
 
 - Hermes Agent installed (repo with `plugins/memory/` directory)
 - Signet daemon running (`signet start`)
-- Plugin activated via `hermes memory setup` or `hermes config set memory.provider signet`
+- `signet setup --harness hermes-agent`
+- `signet doctor hermes` reports daemon health, plugin freshness, config
+  activation, and Hermes tool routing
 
 ---
 

--- a/integrations/hermes-agent/connector/hermes-plugin/__init__.py
+++ b/integrations/hermes-agent/connector/hermes-plugin/__init__.py
@@ -30,9 +30,12 @@ from typing import Any, Dict, List, Optional
 from agent.memory_provider import MemoryProvider
 
 try:
-    from plugins.memory.signet.client import SignetClient
+    from .client import SignetClient
 except ImportError:  # pragma: no cover — only missing during Hermes bootstrap
-    SignetClient = None  # type: ignore[assignment,misc]
+    try:
+        from plugins.memory.signet.client import SignetClient
+    except ImportError:
+        SignetClient = None  # type: ignore[assignment,misc]
 
 logger = logging.getLogger(__name__)
 
@@ -413,7 +416,8 @@ class SignetMemoryProvider(MemoryProvider):
             "Active. Memories are auto-recalled each turn via hybrid search. "
             "Use memory_search to query memory, memory_store to save facts, "
             "and memory_get/memory_list/memory_modify/memory_forget for direct "
-            "memory management."
+            "memory management. If Hermes reports Unknown tool for these names, "
+            "run `signet doctor hermes` and restart Hermes."
         )
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
@@ -714,9 +718,12 @@ class SignetMemoryProvider(MemoryProvider):
         t.start()
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
-        """Return Signet tool schemas."""
-        if not self._client:
-            return []
+        """Return Signet tool schemas.
+
+        Hermes indexes memory-provider tool dispatch before provider
+        initialization. Keep schemas stable even while the daemon is offline;
+        handle_tool_call() returns the runtime connectivity error.
+        """
         return list(ALL_TOOL_SCHEMAS)
 
     def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:

--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -503,6 +503,22 @@ describe("HermesAgentConnector.install()", () => {
 		expect(readFileSync(join(hermesHome, "config.yaml"), "utf-8")).toBe("memory: [\n");
 	});
 
+	it("warns instead of patching non-mapping memory blocks", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(hermesHome, { recursive: true });
+		writeFileSync(join(hermesHome, "config.yaml"), "model: test\nmemory:\n  - honcho\n  - archival\n");
+		process.env.HERMES_HOME = hermesHome;
+
+		const result = await new HermesAgentConnector().install(tmpRoot);
+
+		expect(result.success).toBe(true);
+		expect(result.warnings.some((w) => w.includes("Could not safely patch Hermes memory.provider"))).toBe(true);
+		expect(result.configsPatched ?? []).not.toContain(join(hermesHome, "config.yaml"));
+		expect(readFileSync(join(hermesHome, "config.yaml"), "utf-8")).toBe(
+			"model: test\nmemory:\n  - honcho\n  - archival\n",
+		);
+	});
+
 	it("writes daemon env vars into ~/.hermes/.env when SIGNET_DAEMON_URL is set", async () => {
 		const hermesRepo = join(tmpRoot, "hermes-agent");
 		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });

--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { HermesAgentConnector } from "./src/index.js";
+import { HermesAgentConnector, diagnoseHermesIntegration } from "./src/index.js";
 
 const originalEnv = {
 	HOME: process.env.HOME,
@@ -75,28 +76,99 @@ describe("HermesAgentConnector.isInstalled()", () => {
 		const hermesRepo = join(tmpRoot, "hermes-agent");
 		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
 		process.env.HERMES_REPO = hermesRepo;
+		process.env.HERMES_HOME = join(tmpRoot, ".hermes");
 
 		expect(new HermesAgentConnector().isInstalled()).toBe(false);
 	});
 
-	it("returns true only when signet/__init__.py is present in plugins/memory", () => {
+	it("returns false when the plugin exists but Hermes is not configured to use signet", async () => {
 		const hermesRepo = join(tmpRoot, "hermes-agent");
-		const pluginDir = join(hermesRepo, "plugins", "memory", "signet");
-		mkdirSync(pluginDir, { recursive: true });
-		writeFileSync(join(pluginDir, "__init__.py"), "# signet plugin\n");
+		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
+		process.env.HERMES_HOME = join(tmpRoot, ".hermes");
 		process.env.HERMES_REPO = hermesRepo;
+		await new HermesAgentConnector().install(tmpRoot);
+		writeFileSync(join(process.env.HERMES_HOME, "config.yaml"), "memory:\n  provider: honcho\n");
+
+		expect(new HermesAgentConnector().isInstalled()).toBe(false);
+	});
+
+	it("returns true when a fixed Signet provider is installed and activated", async () => {
+		const hermesRepo = join(tmpRoot, "hermes-agent");
+		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
+		process.env.HERMES_HOME = join(tmpRoot, ".hermes");
+		process.env.HERMES_REPO = hermesRepo;
+
+		await new HermesAgentConnector().install(tmpRoot);
 
 		expect(new HermesAgentConnector().isInstalled()).toBe(true);
 	});
 
-	it("returns false when HERMES_REPO is not set and no known install paths exist", () => {
-		// HOME is a fresh tmp dir with no hermes paths
+	it("returns true when Hermes uses dotted memory.provider config", async () => {
+		const hermesRepo = join(tmpRoot, "hermes-agent");
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
+		mkdirSync(hermesHome, { recursive: true });
+		writeFileSync(join(hermesHome, "config.yaml"), "memory.provider: signet\n");
+		process.env.HERMES_HOME = hermesHome;
+		process.env.HERMES_REPO = hermesRepo;
+
+		await new HermesAgentConnector().install(tmpRoot);
+
+		expect(new HermesAgentConnector().isInstalled()).toBe(true);
+	});
+
+	it("returns false when dotted memory.provider conflicts with nested Signet provider", async () => {
+		const hermesRepo = join(tmpRoot, "hermes-agent");
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
+		process.env.HERMES_HOME = hermesHome;
+		process.env.HERMES_REPO = hermesRepo;
+
+		await new HermesAgentConnector().install(tmpRoot);
+		writeFileSync(join(hermesHome, "config.yaml"), "memory:\n  provider: signet\nmemory.provider: honcho\n");
+
+		expect(new HermesAgentConnector().isInstalled()).toBe(false);
+	});
+
+	it("ignores nested provider keys when checking Hermes memory provider config", async () => {
+		const hermesRepo = join(tmpRoot, "hermes-agent");
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
+		process.env.HERMES_HOME = hermesHome;
+		process.env.HERMES_REPO = hermesRepo;
+
+		await new HermesAgentConnector().install(tmpRoot);
+		writeFileSync(join(hermesHome, "config.yaml"), "memory:\n  some_feature:\n    provider: signet\n");
+
+		expect(new HermesAgentConnector().isInstalled()).toBe(false);
+	});
+
+	it("returns false when repo plugin is stale even if the user plugin is fresh", async () => {
+		const hermesRepo = join(tmpRoot, "hermes-agent");
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
+		process.env.HERMES_HOME = hermesHome;
+		process.env.HERMES_REPO = hermesRepo;
+
+		await new HermesAgentConnector().install(tmpRoot);
+		writeFileSync(
+			join(hermesRepo, "plugins", "memory", "signet", "signet.install.json"),
+			JSON.stringify({
+				connector: "@signet/connector-hermes-agent",
+				schemaVersion: 1,
+				connectorVersion: "0.0.0",
+				sourceHash: "stale",
+				targetKind: "repo",
+				installedAt: "2026-01-01T00:00:00.000Z",
+			}),
+		);
+
 		expect(new HermesAgentConnector().isInstalled()).toBe(false);
 	});
 });
 
 describe("HermesAgentConnector.install()", () => {
-	it("copies plugin files into plugins/memory/signet/ when HERMES_REPO is set", async () => {
+	it("copies plugin files into both user and repo plugin locations when HERMES_REPO is set", async () => {
 		const hermesRepo = join(tmpRoot, "hermes-agent");
 		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
 		process.env.HERMES_REPO = hermesRepo;
@@ -105,51 +177,222 @@ describe("HermesAgentConnector.install()", () => {
 		const connector = new HermesAgentConnector();
 		const result = await connector.install(tmpRoot);
 
-		const pluginDir = join(hermesRepo, "plugins", "memory", "signet");
+		const repoPluginDir = join(hermesRepo, "plugins", "memory", "signet");
+		const userPluginDir = join(process.env.HERMES_HOME, "plugins", "signet");
 		expect(result.success).toBe(true);
-		expect(existsSync(join(pluginDir, "__init__.py"))).toBe(true);
-		expect(existsSync(join(pluginDir, "client.py"))).toBe(true);
-		expect(existsSync(join(pluginDir, "plugin.yaml"))).toBe(true);
+		expect(existsSync(join(repoPluginDir, "__init__.py"))).toBe(true);
+		expect(existsSync(join(repoPluginDir, "client.py"))).toBe(true);
+		expect(existsSync(join(repoPluginDir, "plugin.yaml"))).toBe(true);
+		expect(existsSync(join(repoPluginDir, "signet.install.json"))).toBe(true);
+		expect(existsSync(join(userPluginDir, "__init__.py"))).toBe(true);
+		expect(existsSync(join(userPluginDir, "client.py"))).toBe(true);
+		expect(existsSync(join(userPluginDir, "plugin.yaml"))).toBe(true);
+		expect(existsSync(join(userPluginDir, "signet.install.json"))).toBe(true);
 		expect(connector.isInstalled()).toBe(true);
 	});
 
-	it("copies plugin files into ~/.hermes when HERMES_REPO is unset", async () => {
-		const hermesRepo = join(tmpRoot, ".hermes");
-		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
-
-		const connector = new HermesAgentConnector();
-		const result = await connector.install(tmpRoot);
-
-		const pluginDir = join(hermesRepo, "plugins", "memory", "signet");
-		expect(result.success).toBe(true);
-		expect(result.warnings.some((w) => w.includes("Hermes Agent install not found"))).toBe(false);
-		expect(existsSync(join(pluginDir, "__init__.py"))).toBe(true);
-		expect(existsSync(join(pluginDir, "client.py"))).toBe(true);
-		expect(connector.isInstalled()).toBe(true);
-	});
-
-	it("copies plugin files into HERMES_HOME when HERMES_REPO is unset", async () => {
-		const hermesHome = join(tmpRoot, "custom-hermes-home");
-		mkdirSync(join(hermesHome, "plugins", "memory"), { recursive: true });
+	it("copies plugin files into $HERMES_HOME/plugins/signet when HERMES_REPO is unset", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
 		process.env.HERMES_HOME = hermesHome;
 
 		const connector = new HermesAgentConnector();
 		const result = await connector.install(tmpRoot);
 
-		const pluginDir = join(hermesHome, "plugins", "memory", "signet");
+		const pluginDir = join(hermesHome, "plugins", "signet");
 		expect(result.success).toBe(true);
 		expect(result.warnings.some((w) => w.includes("Hermes Agent install not found"))).toBe(false);
 		expect(existsSync(join(pluginDir, "__init__.py"))).toBe(true);
+		expect(existsSync(join(pluginDir, "client.py"))).toBe(true);
+		expect(existsSync(join(pluginDir, "signet.install.json"))).toBe(true);
 		expect(connector.isInstalled()).toBe(true);
 	});
 
-	it("warns (does not throw) when HERMES_REPO is unset", async () => {
+	it("copies plugin files into HERMES_HOME when HERMES_REPO is unset", async () => {
+		const hermesHome = join(tmpRoot, "custom-hermes-home");
+		process.env.HERMES_HOME = hermesHome;
+
+		const connector = new HermesAgentConnector();
+		const result = await connector.install(tmpRoot);
+
+		const pluginDir = join(hermesHome, "plugins", "signet");
+		expect(result.success).toBe(true);
+		expect(result.warnings.some((w) => w.includes("Hermes Agent install not found"))).toBe(false);
+		expect(existsSync(join(pluginDir, "__init__.py"))).toBe(true);
+		expect(existsSync(join(pluginDir, "signet.install.json"))).toBe(true);
+		expect(connector.isInstalled()).toBe(true);
+	});
+
+	it("treats stale marker hashes as not installed", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		process.env.HERMES_HOME = hermesHome;
+
+		await new HermesAgentConnector().install(tmpRoot);
+		writeFileSync(
+			join(hermesHome, "plugins", "signet", "signet.install.json"),
+			JSON.stringify({
+				connector: "@signet/connector-hermes-agent",
+				schemaVersion: 1,
+				connectorVersion: "0.0.0",
+				sourceHash: "stale",
+				targetKind: "user",
+				installedAt: "2026-01-01T00:00:00.000Z",
+			}),
+		);
+
+		expect(new HermesAgentConnector().isInstalled()).toBe(false);
+	});
+
+	it("reports Hermes diagnostic failures with repair hints", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		process.env.HERMES_HOME = hermesHome;
+
+		const report = await diagnoseHermesIntegration({
+			hermesHome,
+			hermesRepo: null,
+			daemonUrl: "http://127.0.0.1:1",
+		});
+
+		expect(report.ok).toBe(false);
+		expect(report.checks.map((check) => check.id)).toContain("tool-routing");
+		expect(report.checks.every((check) => typeof check.detail === "string" && check.detail.length > 0)).toBe(true);
+		expect(report.warnings.some((warning) => warning.includes("Hermes checkout was not found"))).toBe(true);
+	});
+
+	it("activates signet as Hermes memory provider in config.yaml", async () => {
 		process.env.HERMES_HOME = join(tmpRoot, ".hermes");
 
 		const result = await new HermesAgentConnector().install(tmpRoot);
 
 		expect(result.success).toBe(true);
-		expect(result.warnings.some((w) => w.includes("Hermes Agent install not found"))).toBe(true);
+		expect(result.configsPatched).toContain(join(process.env.HERMES_HOME, "config.yaml"));
+		expect(readFileSync(join(process.env.HERMES_HOME, "config.yaml"), "utf-8")).toContain(
+			"memory:\n  provider: signet\n",
+		);
+	});
+
+	it("preserves existing Hermes config when activating signet", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(hermesHome, { recursive: true });
+		writeFileSync(join(hermesHome, "config.yaml"), "model: test\nmemory:\n  nudge_interval: 10\n");
+		process.env.HERMES_HOME = hermesHome;
+
+		const result = await new HermesAgentConnector().install(tmpRoot);
+		const config = readFileSync(join(hermesHome, "config.yaml"), "utf-8");
+
+		expect(result.success).toBe(true);
+		expect(config).toContain("model: test\n");
+		expect(config).toContain("memory:\n  provider: signet\n  nudge_interval: 10\n");
+	});
+
+	it("preserves dotted memory.provider config when it is already signet", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(hermesHome, { recursive: true });
+		writeFileSync(join(hermesHome, "config.yaml"), "model: test\nmemory.provider: signet\n");
+		process.env.HERMES_HOME = hermesHome;
+
+		const result = await new HermesAgentConnector().install(tmpRoot);
+		const config = readFileSync(join(hermesHome, "config.yaml"), "utf-8");
+
+		expect(result.success).toBe(true);
+		expect(result.configsPatched ?? []).not.toContain(join(hermesHome, "config.yaml"));
+		expect(config).toBe("model: test\nmemory.provider: signet\n");
+	});
+
+	it("updates dotted memory.provider config without appending a nested memory block", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(hermesHome, { recursive: true });
+		writeFileSync(join(hermesHome, "config.yaml"), "model: test\nmemory.provider: honcho\n");
+		process.env.HERMES_HOME = hermesHome;
+
+		const result = await new HermesAgentConnector().install(tmpRoot);
+		const config = readFileSync(join(hermesHome, "config.yaml"), "utf-8");
+
+		expect(result.success).toBe(true);
+		expect(result.configsPatched).toContain(join(hermesHome, "config.yaml"));
+		expect(config).toContain("model: test\n");
+		expect(config).toContain("memory.provider: signet\n");
+		expect(config).not.toContain("memory:\n  provider: signet\n");
+	});
+
+	it("uses dotted memory.provider as the only active provider in mixed-form config", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(hermesHome, { recursive: true });
+		writeFileSync(
+			join(hermesHome, "config.yaml"),
+			"model: test\nmemory:\n  nudge_interval: 10\nmemory.provider: honcho\n",
+		);
+		process.env.HERMES_HOME = hermesHome;
+
+		const result = await new HermesAgentConnector().install(tmpRoot);
+		const config = readFileSync(join(hermesHome, "config.yaml"), "utf-8");
+
+		expect(result.success).toBe(true);
+		expect(result.configsPatched).toContain(join(hermesHome, "config.yaml"));
+		expect(config).toBe("model: test\nmemory:\n  nudge_interval: 10\nmemory.provider: signet\n");
+		expect(config).not.toContain("provider: signet\n  nudge_interval");
+	});
+
+	it("removes nested provider when dotted memory.provider is active", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(hermesHome, { recursive: true });
+		writeFileSync(
+			join(hermesHome, "config.yaml"),
+			"model: test\nmemory:\n  provider: honcho\n  nudge_interval: 10\nmemory.provider: signet\n",
+		);
+		process.env.HERMES_HOME = hermesHome;
+
+		const result = await new HermesAgentConnector().install(tmpRoot);
+		const config = readFileSync(join(hermesHome, "config.yaml"), "utf-8");
+
+		expect(result.success).toBe(true);
+		expect(result.configsPatched).toContain(join(hermesHome, "config.yaml"));
+		expect(config).toBe("model: test\nmemory:\n  nudge_interval: 10\nmemory.provider: signet\n");
+	});
+
+	it("adds direct memory provider without rewriting nested provider keys", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(hermesHome, { recursive: true });
+		writeFileSync(join(hermesHome, "config.yaml"), "model: test\nmemory:\n  some_feature:\n    provider: honcho\n");
+		process.env.HERMES_HOME = hermesHome;
+
+		const result = await new HermesAgentConnector().install(tmpRoot);
+		const config = readFileSync(join(hermesHome, "config.yaml"), "utf-8");
+
+		expect(result.success).toBe(true);
+		expect(result.configsPatched).toContain(join(hermesHome, "config.yaml"));
+		expect(config).toBe("model: test\nmemory:\n  provider: signet\n  some_feature:\n    provider: honcho\n");
+	});
+
+	it("records the previous nested memory provider before replacing it", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(hermesHome, { recursive: true });
+		writeFileSync(join(hermesHome, "config.yaml"), "memory:\n  provider: honcho\n");
+		process.env.HERMES_HOME = hermesHome;
+
+		const result = await new HermesAgentConnector().install(tmpRoot);
+		const backupPath = join(hermesHome, "signet.provider.backup.json");
+		const backup = JSON.parse(readFileSync(backupPath, "utf-8"));
+
+		expect(result.filesWritten).toContain(backupPath);
+		expect(backup).toMatchObject({
+			schemaVersion: 1,
+			configPath: join(hermesHome, "config.yaml"),
+			providerKind: "nested",
+			previousProvider: "honcho",
+		});
+	});
+
+	it("warns instead of patching unsafe memory config YAML", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(hermesHome, { recursive: true });
+		writeFileSync(join(hermesHome, "config.yaml"), "memory: [\n");
+		process.env.HERMES_HOME = hermesHome;
+
+		const result = await new HermesAgentConnector().install(tmpRoot);
+
+		expect(result.success).toBe(true);
+		expect(result.warnings.some((w) => w.includes("Could not safely patch Hermes memory.provider"))).toBe(true);
+		expect(readFileSync(join(hermesHome, "config.yaml"), "utf-8")).toBe("memory: [\n");
 	});
 
 	it("writes daemon env vars into ~/.hermes/.env when SIGNET_DAEMON_URL is set", async () => {
@@ -268,6 +511,107 @@ describe("Hermes Agent bundled plugin", () => {
 		expect(plugin).toContain('if tool_name in ("memory_search", "recall", "signet_search")');
 	});
 
+	it("returns Signet tool schemas before daemon initialization", () => {
+		const plugin = readFileSync(join(import.meta.dir, "hermes-plugin", "__init__.py"), "utf-8");
+		const schemasFn = plugin.slice(plugin.indexOf("def get_tool_schemas"), plugin.indexOf("def handle_tool_call"));
+
+		expect(schemasFn).toContain("return list(ALL_TOOL_SCHEMAS)");
+		expect(schemasFn).not.toContain("if not self._client");
+		expect(plugin).toContain('return json.dumps({"error": "Signet daemon is not connected."})');
+	});
+
+	it("registers Signet tools with a Hermes-style memory manager before daemon initialization", () => {
+		const fixture = join(tmpRoot, "python-fixture");
+		cpSync(join(import.meta.dir, "hermes-plugin"), join(fixture, "plugins", "memory", "signet"), { recursive: true });
+		mkdirSync(join(fixture, "agent"), { recursive: true });
+		writeFileSync(join(fixture, "agent", "__init__.py"), "");
+		writeFileSync(join(fixture, "plugins", "__init__.py"), "");
+		writeFileSync(join(fixture, "plugins", "memory", "__init__.py"), "");
+		writeFileSync(join(fixture, "agent", "memory_provider.py"), "class MemoryProvider:\n    pass\n");
+		writeFileSync(
+			join(fixture, "agent", "memory_manager.py"),
+			[
+				"class MemoryManager:",
+				"    def __init__(self):",
+				"        self._tool_to_provider = {}",
+				"    def add_provider(self, provider):",
+				"        for schema in provider.get_tool_schemas():",
+				"            self._tool_to_provider[schema['name']] = provider",
+				"    def get_all_tool_names(self):",
+				"        return set(self._tool_to_provider.keys())",
+				"    def has_tool(self, name):",
+				"        return name in self._tool_to_provider",
+				"",
+			].join("\n"),
+		);
+
+		const result = spawnSync(
+			"python",
+			[
+				"-c",
+				[
+					"from plugins.memory.signet import SignetMemoryProvider",
+					"from agent.memory_manager import MemoryManager",
+					"provider = SignetMemoryProvider()",
+					"manager = MemoryManager()",
+					"manager.add_provider(provider)",
+					"names = manager.get_all_tool_names()",
+					"assert 'memory_search' in names",
+					"assert 'recall' in names",
+					"assert manager.has_tool('memory_store')",
+					"print(','.join(sorted(names)))",
+				].join("\n"),
+			],
+			{ env: { ...process.env, PYTHONPATH: fixture }, encoding: "utf-8" },
+		);
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("memory_search");
+		expect(result.stdout).toContain("remember");
+	});
+
+	it("imports the client from a Hermes user-installed provider namespace", () => {
+		const fixture = join(tmpRoot, "python-user-fixture");
+		const pluginDir = join(fixture, "plugins", "signet");
+		cpSync(join(import.meta.dir, "hermes-plugin"), pluginDir, { recursive: true });
+		mkdirSync(join(fixture, "agent"), { recursive: true });
+		writeFileSync(join(fixture, "agent", "__init__.py"), "");
+		writeFileSync(join(fixture, "agent", "memory_provider.py"), "class MemoryProvider:\n    pass\n");
+
+		const result = spawnSync(
+			"python",
+			[
+				"-c",
+				[
+					"import importlib.util, sys, types",
+					"from pathlib import Path",
+					`root = Path(${JSON.stringify(fixture)})`,
+					"provider_dir = root / 'plugins' / 'signet'",
+					"sys.path.insert(0, str(root))",
+					"parent = types.ModuleType('_hermes_user_memory')",
+					"parent.__path__ = [str(root / 'plugins')]",
+					"sys.modules['_hermes_user_memory'] = parent",
+					"client_spec = importlib.util.spec_from_file_location('_hermes_user_memory.signet.client', provider_dir / 'client.py')",
+					"client_mod = importlib.util.module_from_spec(client_spec)",
+					"sys.modules['_hermes_user_memory.signet.client'] = client_mod",
+					"client_spec.loader.exec_module(client_mod)",
+					"spec = importlib.util.spec_from_file_location('_hermes_user_memory.signet', provider_dir / '__init__.py', submodule_search_locations=[str(provider_dir)])",
+					"mod = importlib.util.module_from_spec(spec)",
+					"sys.modules['_hermes_user_memory.signet'] = mod",
+					"spec.loader.exec_module(mod)",
+					"assert mod.SignetClient is not None",
+					"provider = mod.SignetMemoryProvider()",
+					"assert any(schema['name'] == 'memory_search' for schema in provider.get_tool_schemas())",
+					"print(mod.SignetClient.__name__)",
+				].join("\n"),
+			],
+			{ env: { ...process.env, PYTHONPATH: fixture }, encoding: "utf-8" },
+		);
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("SignetClient");
+	});
+
 	it("does not force agentId into explicit recall requests", () => {
 		const client = readFileSync(join(import.meta.dir, "hermes-plugin", "client.py"), "utf-8");
 
@@ -351,9 +695,93 @@ describe("HermesAgentConnector.uninstall()", () => {
 		expect(connector.isInstalled()).toBe(true);
 
 		const result = await connector.uninstall();
-		const pluginDir = join(hermesRepo, "plugins", "memory", "signet");
-		expect(result.filesRemoved).toContain(pluginDir);
+		const repoPluginDir = join(hermesRepo, "plugins", "memory", "signet");
+		const userPluginDir = join(process.env.HERMES_HOME, "plugins", "signet");
+		expect(result.filesRemoved).toContain(repoPluginDir);
+		expect(result.filesRemoved).toContain(userPluginDir);
 		expect(connector.isInstalled()).toBe(false);
+	});
+
+	it("clears memory.provider only when it is signet", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(hermesHome, { recursive: true });
+		writeFileSync(join(hermesHome, "config.yaml"), "memory:\n  provider: signet\n  nudge_interval: 10\n");
+		process.env.HERMES_HOME = hermesHome;
+
+		const result = await new HermesAgentConnector().uninstall();
+
+		expect(result.configsPatched).toContain(join(hermesHome, "config.yaml"));
+		expect(readFileSync(join(hermesHome, "config.yaml"), "utf-8")).toContain("memory:\n  provider: ''\n");
+	});
+
+	it("clears dotted memory.provider only when it is signet", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(hermesHome, { recursive: true });
+		writeFileSync(join(hermesHome, "config.yaml"), "memory.provider: signet\n");
+		process.env.HERMES_HOME = hermesHome;
+
+		const result = await new HermesAgentConnector().uninstall();
+
+		expect(result.configsPatched).toContain(join(hermesHome, "config.yaml"));
+		expect(readFileSync(join(hermesHome, "config.yaml"), "utf-8")).toBe("memory.provider: ''\n");
+	});
+
+	it("restores a previous nested memory provider on uninstall", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(hermesHome, { recursive: true });
+		writeFileSync(join(hermesHome, "config.yaml"), "memory:\n  provider: honcho\n  nudge_interval: 10\n");
+		process.env.HERMES_HOME = hermesHome;
+
+		const connector = new HermesAgentConnector();
+		await connector.install(tmpRoot);
+		const result = await connector.uninstall();
+
+		expect(result.configsPatched).toContain(join(hermesHome, "config.yaml"));
+		expect(result.filesRemoved).toContain(join(hermesHome, "signet.provider.backup.json"));
+		expect(readFileSync(join(hermesHome, "config.yaml"), "utf-8")).toContain(
+			"memory:\n  provider: honcho\n  nudge_interval: 10\n",
+		);
+	});
+
+	it("restores a previous dotted memory provider on uninstall", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(hermesHome, { recursive: true });
+		writeFileSync(join(hermesHome, "config.yaml"), "model: test\nmemory.provider: honcho\n");
+		process.env.HERMES_HOME = hermesHome;
+
+		const connector = new HermesAgentConnector();
+		await connector.install(tmpRoot);
+		const result = await connector.uninstall();
+
+		expect(result.configsPatched).toContain(join(hermesHome, "config.yaml"));
+		expect(result.filesRemoved).toContain(join(hermesHome, "signet.provider.backup.json"));
+		expect(readFileSync(join(hermesHome, "config.yaml"), "utf-8")).toBe("model: test\nmemory.provider: honcho\n");
+	});
+
+	it("does not clear another active memory provider", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(hermesHome, { recursive: true });
+		writeFileSync(join(hermesHome, "config.yaml"), "memory:\n  provider: honcho\n");
+		process.env.HERMES_HOME = hermesHome;
+
+		const result = await new HermesAgentConnector().uninstall();
+
+		expect(result.configsPatched ?? []).not.toContain(join(hermesHome, "config.yaml"));
+		expect(readFileSync(join(hermesHome, "config.yaml"), "utf-8")).toContain("provider: honcho");
+	});
+
+	it("does not clear nested provider keys during uninstall", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(hermesHome, { recursive: true });
+		writeFileSync(join(hermesHome, "config.yaml"), "memory:\n  some_feature:\n    provider: signet\n");
+		process.env.HERMES_HOME = hermesHome;
+
+		const result = await new HermesAgentConnector().uninstall();
+
+		expect(result.configsPatched ?? []).not.toContain(join(hermesHome, "config.yaml"));
+		expect(readFileSync(join(hermesHome, "config.yaml"), "utf-8")).toBe(
+			"memory:\n  some_feature:\n    provider: signet\n",
+		);
 	});
 
 	it("removes persisted Signet env vars including SIGNET_TOKEN", async () => {

--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -222,6 +222,57 @@ describe("HermesAgentConnector.install()", () => {
 		expect(connector.isInstalled()).toBe(true);
 	});
 
+	it("fails when the user plugin is the only usable target and cannot be written", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(hermesHome, { recursive: true });
+		writeFileSync(join(hermesHome, "plugins"), "not a directory");
+		process.env.HERMES_HOME = hermesHome;
+
+		const result = await new HermesAgentConnector().install(tmpRoot);
+
+		expect(result.success).toBe(false);
+		expect(result.message).toContain("could not install the Hermes user Signet provider");
+		expect(result.warnings.some((w) => w.includes("Failed to install Hermes user plugin files"))).toBe(true);
+		expect(result.configsPatched ?? []).not.toContain(join(hermesHome, "config.yaml"));
+		expect(readFileSync(join(hermesHome, "plugins"), "utf-8")).toBe("not a directory");
+	});
+
+	it("succeeds when the user plugin copy fails but the repo plugin copy is refreshed", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		const hermesRepo = join(tmpRoot, "hermes-agent");
+		mkdirSync(hermesHome, { recursive: true });
+		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });
+		writeFileSync(join(hermesHome, "plugins"), "not a directory");
+		process.env.HERMES_HOME = hermesHome;
+		process.env.HERMES_REPO = hermesRepo;
+
+		const result = await new HermesAgentConnector().install(tmpRoot);
+
+		expect(result.success).toBe(true);
+		expect(result.warnings.some((w) => w.includes("Failed to install Hermes user plugin files"))).toBe(true);
+		expect(existsSync(join(hermesRepo, "plugins", "memory", "signet", "signet.install.json"))).toBe(true);
+		expect(new HermesAgentConnector().isInstalled()).toBe(true);
+	});
+
+	it("fails when a discoverable repo plugin copy cannot be refreshed", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		const hermesRepo = join(tmpRoot, "hermes-agent");
+		mkdirSync(hermesHome, { recursive: true });
+		mkdirSync(join(hermesRepo, "plugins"), { recursive: true });
+		writeFileSync(join(hermesRepo, "plugins", "memory"), "not a directory");
+		process.env.HERMES_HOME = hermesHome;
+		process.env.HERMES_REPO = hermesRepo;
+
+		const result = await new HermesAgentConnector().install(tmpRoot);
+
+		expect(result.success).toBe(false);
+		expect(result.message).toContain("could not refresh the Hermes repo Signet provider");
+		expect(result.warnings.some((w) => w.includes("Failed to refresh Hermes repo plugin files"))).toBe(true);
+		expect(existsSync(join(hermesHome, "plugins", "signet", "signet.install.json"))).toBe(true);
+		expect(result.configsPatched ?? []).not.toContain(join(hermesHome, "config.yaml"));
+		expect(new HermesAgentConnector().isInstalled()).toBe(false);
+	});
+
 	it("treats stale marker hashes as not installed", async () => {
 		const hermesHome = join(tmpRoot, ".hermes");
 		process.env.HERMES_HOME = hermesHome;

--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -498,22 +498,31 @@ describe("HermesAgentConnector.install()", () => {
 
 		const result = await new HermesAgentConnector().install(tmpRoot);
 
-		expect(result.success).toBe(true);
+		expect(result.success).toBe(false);
+		expect(result.message).toContain("not activated");
+		expect(result.message).not.toContain("deployed and activated");
 		expect(result.warnings.some((w) => w.includes("Could not safely patch Hermes memory.provider"))).toBe(true);
+		expect(new HermesAgentConnector().isInstalled()).toBe(false);
 		expect(readFileSync(join(hermesHome, "config.yaml"), "utf-8")).toBe("memory: [\n");
 	});
 
-	it("warns instead of patching non-mapping memory blocks", async () => {
+	it("fails safely instead of patching non-mapping memory blocks", async () => {
 		const hermesHome = join(tmpRoot, ".hermes");
 		mkdirSync(hermesHome, { recursive: true });
 		writeFileSync(join(hermesHome, "config.yaml"), "model: test\nmemory:\n  - honcho\n  - archival\n");
 		process.env.HERMES_HOME = hermesHome;
 
 		const result = await new HermesAgentConnector().install(tmpRoot);
+		const report = await diagnoseHermesIntegration({ hermesHome, hermesRepo: null });
+		const providerCheck = report.checks.find((check) => check.id === "provider-config");
 
-		expect(result.success).toBe(true);
+		expect(result.success).toBe(false);
+		expect(result.message).toContain("not activated");
+		expect(result.message).not.toContain("deployed and activated");
 		expect(result.warnings.some((w) => w.includes("Could not safely patch Hermes memory.provider"))).toBe(true);
 		expect(result.configsPatched ?? []).not.toContain(join(hermesHome, "config.yaml"));
+		expect(new HermesAgentConnector().isInstalled()).toBe(false);
+		expect(providerCheck?.ok).toBe(false);
 		expect(readFileSync(join(hermesHome, "config.yaml"), "utf-8")).toBe(
 			"model: test\nmemory:\n  - honcho\n  - archival\n",
 		);

--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -258,6 +258,34 @@ describe("HermesAgentConnector.install()", () => {
 		expect(report.warnings.some((warning) => warning.includes("Hermes checkout was not found"))).toBe(true);
 	});
 
+	it("accepts a current user-plugin-only install in Hermes diagnostics", async () => {
+		const originalFetch = globalThis.fetch;
+		const hermesHome = join(tmpRoot, ".hermes");
+		process.env.HERMES_HOME = hermesHome;
+
+		globalThis.fetch = (async () => new Response("ok", { status: 200 })) as typeof fetch;
+
+		try {
+			await new HermesAgentConnector().install(tmpRoot);
+
+			const report = await diagnoseHermesIntegration({
+				hermesHome,
+				hermesRepo: null,
+				daemonUrl: "http://127.0.0.1:3850",
+			});
+			const checks = Object.fromEntries(report.checks.map((check) => [check.id, check]));
+
+			expect(report.ok).toBe(true);
+			expect(checks["user-plugin"]?.ok).toBe(true);
+			expect(checks["repo-plugin"]?.ok).toBe(true);
+			expect(checks["tool-routing"]?.ok).toBe(true);
+			expect(checks["repo-plugin"]?.detail).toContain("using user plugin copy only");
+			expect(checks["tool-routing"]?.detail).toContain("runtime probe skipped without Hermes checkout");
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
 	it("activates signet as Hermes memory provider in config.yaml", async () => {
 		process.env.HERMES_HOME = join(tmpRoot, ".hermes");
 
@@ -332,6 +360,29 @@ describe("HermesAgentConnector.install()", () => {
 		expect(config).not.toContain("provider: signet\n  nudge_interval");
 	});
 
+	it("backs up the dotted provider when both provider forms need cleanup", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(hermesHome, { recursive: true });
+		writeFileSync(
+			join(hermesHome, "config.yaml"),
+			"model: test\nmemory:\n  provider: stale\n  nudge_interval: 10\nmemory.provider: honcho\n",
+		);
+		process.env.HERMES_HOME = hermesHome;
+
+		const result = await new HermesAgentConnector().install(tmpRoot);
+		const backup = JSON.parse(readFileSync(join(hermesHome, "signet.provider.backup.json"), "utf-8"));
+
+		expect(result.success).toBe(true);
+		expect(result.filesWritten).toContain(join(hermesHome, "signet.provider.backup.json"));
+		expect(backup).toMatchObject({
+			providerKind: "dotted",
+			previousProvider: "honcho",
+		});
+		expect(readFileSync(join(hermesHome, "config.yaml"), "utf-8")).toBe(
+			"model: test\nmemory:\n  nudge_interval: 10\nmemory.provider: signet\n",
+		);
+	});
+
 	it("removes nested provider when dotted memory.provider is active", async () => {
 		const hermesHome = join(tmpRoot, ".hermes");
 		mkdirSync(hermesHome, { recursive: true });
@@ -343,9 +394,15 @@ describe("HermesAgentConnector.install()", () => {
 
 		const result = await new HermesAgentConnector().install(tmpRoot);
 		const config = readFileSync(join(hermesHome, "config.yaml"), "utf-8");
+		const backup = JSON.parse(readFileSync(join(hermesHome, "signet.provider.backup.json"), "utf-8"));
 
 		expect(result.success).toBe(true);
 		expect(result.configsPatched).toContain(join(hermesHome, "config.yaml"));
+		expect(result.filesWritten).toContain(join(hermesHome, "signet.provider.backup.json"));
+		expect(backup).toMatchObject({
+			providerKind: "nested",
+			previousProvider: "honcho",
+		});
 		expect(config).toBe("model: test\nmemory:\n  nudge_interval: 10\nmemory.provider: signet\n");
 	});
 
@@ -756,6 +813,26 @@ describe("HermesAgentConnector.uninstall()", () => {
 		expect(result.configsPatched).toContain(join(hermesHome, "config.yaml"));
 		expect(result.filesRemoved).toContain(join(hermesHome, "signet.provider.backup.json"));
 		expect(readFileSync(join(hermesHome, "config.yaml"), "utf-8")).toBe("model: test\nmemory.provider: honcho\n");
+	});
+
+	it("restores a removed nested provider when dotted signet is uninstalled", async () => {
+		const hermesHome = join(tmpRoot, ".hermes");
+		mkdirSync(hermesHome, { recursive: true });
+		writeFileSync(
+			join(hermesHome, "config.yaml"),
+			"model: test\nmemory:\n  provider: honcho\n  nudge_interval: 10\nmemory.provider: signet\n",
+		);
+		process.env.HERMES_HOME = hermesHome;
+
+		const connector = new HermesAgentConnector();
+		await connector.install(tmpRoot);
+		const result = await connector.uninstall();
+
+		expect(result.configsPatched).toContain(join(hermesHome, "config.yaml"));
+		expect(result.filesRemoved).toContain(join(hermesHome, "signet.provider.backup.json"));
+		expect(readFileSync(join(hermesHome, "config.yaml"), "utf-8")).toBe(
+			"model: test\nmemory:\n  provider: honcho\n  nudge_interval: 10\nmemory.provider: ''\n",
+		);
 	});
 
 	it("does not clear another active memory provider", async () => {

--- a/integrations/hermes-agent/connector/src/index.ts
+++ b/integrations/hermes-agent/connector/src/index.ts
@@ -702,11 +702,14 @@ export class HermesAgentConnector extends BaseConnector {
 
 		const hermesHome = this.getHermesHome();
 		const hermesRepo = this.getHermesRepo();
+		let userPluginInstalled = false;
+		let repoPluginInstalled = false;
 
 		// 1. Install the Python plugin into the current user-plugin location.
 		try {
 			const pluginFiles = installPlugin(getUserPluginTargetDir(hermesHome), "user");
 			filesWritten.push(...pluginFiles);
+			userPluginInstalled = true;
 		} catch (e) {
 			const msg = e instanceof Error ? e.message : String(e);
 			warnings.push(`Failed to install Hermes user plugin files: ${msg}`);
@@ -719,10 +722,23 @@ export class HermesAgentConnector extends BaseConnector {
 			try {
 				const pluginFiles = installPlugin(getRepoPluginTargetDir(hermesRepo), "repo");
 				filesWritten.push(...pluginFiles);
+				repoPluginInstalled = true;
 			} catch (e) {
 				const msg = e instanceof Error ? e.message : String(e);
 				warnings.push(`Failed to refresh Hermes repo plugin files: ${msg}`);
 			}
+		}
+		const usablePluginTargetInstalled = hermesRepo ? repoPluginInstalled : userPluginInstalled;
+		if (!usablePluginTargetInstalled) {
+			return {
+				success: false,
+				message: hermesRepo
+					? "Hermes Agent integration failed — could not refresh the Hermes repo Signet provider"
+					: "Hermes Agent integration failed — could not install the Hermes user Signet provider",
+				filesWritten,
+				configsPatched,
+				warnings,
+			};
 		}
 
 		// 2. Write env config for the Signet daemon connection

--- a/integrations/hermes-agent/connector/src/index.ts
+++ b/integrations/hermes-agent/connector/src/index.ts
@@ -341,7 +341,8 @@ function configureProvider(
 	let backupPath: string | null = null;
 	if (dottedProvider !== null) {
 		let changed = false;
-		if (!dottedProviderLineIsSignet(lines[dottedProvider] ?? "")) {
+		const dottedWasSignet = dottedProviderLineIsSignet(lines[dottedProvider] ?? "");
+		if (!dottedWasSignet) {
 			backupPath = writeProviderBackup(
 				hermesHome,
 				configPath,
@@ -352,6 +353,15 @@ function configureProvider(
 			changed = true;
 		}
 		if (block !== null && typeof block === "object" && block.provider !== null && block.provider !== undefined) {
+			if (dottedWasSignet) {
+				const nestedBackupPath = writeProviderBackup(
+					hermesHome,
+					configPath,
+					"nested",
+					parseProviderLine(lines[block.provider] ?? "") ?? "",
+				);
+				backupPath = nestedBackupPath ?? backupPath;
+			}
 			lines.splice(block.provider, 1);
 			changed = true;
 		}
@@ -398,6 +408,14 @@ function restoreOrClearProvider(hermesHome: string): { configPath: string | null
 	let configChanged = false;
 	if (dottedProvider !== null && dottedProviderLineIsSignet(lines[dottedProvider] ?? "")) {
 		setDottedProviderLine(lines, dottedProvider, backup?.providerKind === "dotted" ? backup.previousProvider : "''");
+		if (backup?.providerKind === "nested") {
+			if (block !== null && typeof block === "object") {
+				lines.splice(block.start + 1, 0, `${" ".repeat(block.indent)}provider: ${backup.previousProvider}`);
+			} else {
+				if (lines.length > 0 && lines[lines.length - 1] !== "") lines.push("");
+				lines.push("memory:", `  provider: ${backup.previousProvider}`);
+			}
+		}
 		configChanged = true;
 	} else if (
 		block !== null &&
@@ -884,7 +902,7 @@ export async function diagnoseHermesIntegration(opts?: {
 	readonly daemonUrl?: string;
 }): Promise<HermesDoctorReport> {
 	const hermesHome = opts?.hermesHome ?? resolveHermesHomePath();
-	const hermesRepo = opts?.hermesRepo ?? resolveHermesRepoPath();
+	const hermesRepo = opts && "hermesRepo" in opts ? (opts.hermesRepo ?? null) : resolveHermesRepoPath();
 	const daemonUrl = opts?.daemonUrl ?? (process.env.SIGNET_DAEMON_URL?.trim() || "http://localhost:3850");
 	const configPath = resolveConfigPath(hermesHome);
 	const userPluginDir = getUserPluginTargetDir(hermesHome);
@@ -895,7 +913,9 @@ export async function diagnoseHermesIntegration(opts?: {
 	const repoPluginCurrent = repoPluginDir ? pluginLooksCurrent(repoPluginDir) : false;
 	const probe = hermesRepo
 		? probeHermesProvider(hermesRepo)
-		: { ok: false, toolNames: [], error: "Hermes repo not found" };
+		: userPluginCurrent
+			? { ok: true, toolNames: REQUIRED_TOOL_NAMES, error: null }
+			: { ok: false, toolNames: [], error: "Hermes repo not found and user plugin is missing or stale" };
 	const daemon = await checkDaemon(daemonUrl);
 
 	checks.push({
@@ -926,15 +946,15 @@ export async function diagnoseHermesIntegration(opts?: {
 	checks.push({
 		id: "repo-plugin",
 		label: "Hermes repo plugin copy",
-		ok: repoPluginDir !== null && repoPluginCurrent,
+		ok: repoPluginDir === null || repoPluginCurrent,
 		detail:
 			repoPluginDir === null
-				? "Hermes checkout not found"
+				? "Hermes checkout not found; using user plugin copy only"
 				: repoPluginCurrent
 					? `${repoPluginDir} matches bundled Signet plugin`
 					: `${repoPluginDir} is missing or stale`,
 		fix:
-			repoPluginDir !== null && repoPluginCurrent
+			repoPluginDir === null || repoPluginCurrent
 				? undefined
 				: "Set HERMES_REPO to the Hermes Agent checkout, then run `signet setup --harness hermes-agent`.",
 	});
@@ -943,7 +963,9 @@ export async function diagnoseHermesIntegration(opts?: {
 		label: "Hermes tool routing",
 		ok: probe.ok,
 		detail: probe.ok
-			? `Hermes exposes ${REQUIRED_TOOL_NAMES.join(", ")}`
+			? hermesRepo
+				? `Hermes exposes ${REQUIRED_TOOL_NAMES.join(", ")}`
+				: `User plugin advertises ${REQUIRED_TOOL_NAMES.join(", ")}; runtime probe skipped without Hermes checkout`
 			: `Hermes provider probe failed: ${probe.error ?? "unknown error"}`,
 		fix: probe.ok
 			? undefined
@@ -952,7 +974,7 @@ export async function diagnoseHermesIntegration(opts?: {
 
 	if (!hermesRepo) {
 		warnings.push(
-			"Hermes checkout was not found; repo-plugin and tool-routing checks need HERMES_REPO or ~/.hermes/hermes-agent.",
+			"Hermes checkout was not found; repo-plugin install is optional, and runtime tool-routing probes need HERMES_REPO or ~/.hermes/hermes-agent.",
 		);
 	}
 

--- a/integrations/hermes-agent/connector/src/index.ts
+++ b/integrations/hermes-agent/connector/src/index.ts
@@ -831,6 +831,16 @@ export class HermesAgentConnector extends BaseConnector {
 		if (providerConfig.backupPath) {
 			filesWritten.push(providerConfig.backupPath);
 		}
+		if (!isProviderConfigured(hermesHome)) {
+			return {
+				success: false,
+				message:
+					"Hermes Agent integration incomplete — Signet provider was deployed but not activated in Hermes config",
+				filesWritten,
+				configsPatched,
+				warnings,
+			};
+		}
 
 		if (hermesRepo) {
 			const probe = probeHermesProvider(hermesRepo);

--- a/integrations/hermes-agent/connector/src/index.ts
+++ b/integrations/hermes-agent/connector/src/index.ts
@@ -176,6 +176,14 @@ function leadingWhitespaceLength(line: string): number | null {
 	return match ? (match[1]?.length ?? null) : null;
 }
 
+function isYamlMappingEntry(value: string): boolean {
+	const trimmed = value.trimStart();
+	if (trimmed.startsWith("-")) return false;
+	const colon = trimmed.indexOf(":");
+	if (colon <= 0) return false;
+	return trimmed.slice(0, colon).trim().length > 0;
+}
+
 function findMemoryBlock(lines: string[]): MemoryBlock | "missing" | null {
 	const starts: number[] = [];
 	for (let i = 0; i < lines.length; i++) {
@@ -205,7 +213,10 @@ function findMemoryBlock(lines: string[]): MemoryBlock | "missing" | null {
 	const childIndent = indent ?? 2;
 	for (let i = start + 1; i < end; i++) {
 		const line = lines[i] ?? "";
-		if (leadingWhitespaceLength(line) === childIndent && /^provider:\s*/.test(line.slice(childIndent))) {
+		if (leadingWhitespaceLength(line) !== childIndent) continue;
+		const child = line.slice(childIndent);
+		if (!isYamlMappingEntry(child)) return null;
+		if (/^provider:\s*/.test(child)) {
 			provider = i;
 			break;
 		}

--- a/integrations/hermes-agent/connector/src/index.ts
+++ b/integrations/hermes-agent/connector/src/index.ts
@@ -1,9 +1,11 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { BaseConnector, type InstallResult, type UninstallResult } from "@signet/connector-base";
-import { expandHome, resolveHermesHomePath, resolveHermesRepoPath, resolveHermesRepoPluginPath } from "@signet/core";
+import { expandHome, resolveHermesHomePath, resolveHermesRepoPath } from "@signet/core";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -22,21 +24,84 @@ function getPluginSourceDir(): string {
 	throw new Error("Cannot find hermes-plugin directory in connector package");
 }
 
-function getPluginTargetDir(hermesRepo: string): string {
+const PLUGIN_FILES = ["__init__.py", "client.py", "plugin.yaml", "README.md"] as const;
+const INSTALL_MARKER_FILE = "signet.install.json";
+const PROVIDER_BACKUP_FILE = "signet.provider.backup.json";
+const REQUIRED_TOOL_NAMES = [
+	"memory_search",
+	"memory_store",
+	"memory_get",
+	"memory_list",
+	"memory_modify",
+	"memory_forget",
+	"recall",
+	"remember",
+] as const;
+
+export interface HermesDiagnosticCheck {
+	readonly id: string;
+	readonly label: string;
+	readonly ok: boolean;
+	readonly detail: string;
+	readonly fix?: string;
+}
+
+export interface HermesDoctorReport {
+	readonly ok: boolean;
+	readonly hermesHome: string;
+	readonly hermesRepo: string | null;
+	readonly configPath: string;
+	readonly userPluginDir: string;
+	readonly repoPluginDir: string | null;
+	readonly toolNames: readonly string[];
+	readonly checks: readonly HermesDiagnosticCheck[];
+	readonly warnings: readonly string[];
+}
+
+interface InstallMarker {
+	readonly connector: "@signet/connector-hermes-agent";
+	readonly schemaVersion: 1;
+	readonly connectorVersion: string;
+	readonly sourceHash: string;
+	readonly targetKind: "user" | "repo";
+	readonly installedAt: string;
+}
+
+interface ProviderBackup {
+	readonly schemaVersion: 1;
+	readonly configPath: string;
+	readonly providerKind: "nested" | "dotted";
+	readonly previousProvider: string;
+	readonly createdAt: string;
+}
+
+interface HermesProbeResult {
+	readonly ok: boolean;
+	readonly toolNames: readonly string[];
+	readonly error: string | null;
+}
+
+function getRepoPluginTargetDir(hermesRepo: string): string {
 	return join(hermesRepo, "plugins", "memory", "signet");
 }
 
-/** Copy the Signet memory plugin into the Hermes plugins directory. */
-function installPlugin(hermesRepo: string): string[] {
+function getUserPluginTargetDir(hermesHome: string): string {
+	return join(hermesHome, "plugins", "signet");
+}
+
+function getProviderBackupPath(hermesHome: string): string {
+	return join(hermesHome, PROVIDER_BACKUP_FILE);
+}
+
+/** Copy the Signet memory plugin into a Hermes plugin directory. */
+function installPlugin(targetDir: string, targetKind: InstallMarker["targetKind"]): string[] {
 	const sourceDir = getPluginSourceDir();
-	const targetDir = getPluginTargetDir(hermesRepo);
 
 	mkdirSync(targetDir, { recursive: true });
 
-	const files = ["__init__.py", "client.py", "plugin.yaml", "README.md"];
 	const written: string[] = [];
 
-	for (const file of files) {
+	for (const file of PLUGIN_FILES) {
 		const src = join(sourceDir, file);
 		const dst = join(targetDir, file);
 		if (existsSync(src)) {
@@ -44,13 +109,13 @@ function installPlugin(hermesRepo: string): string[] {
 			written.push(dst);
 		}
 	}
+	written.push(writeInstallMarker(targetDir, targetKind));
 
 	return written;
 }
 
 /** Remove the Signet memory plugin from the Hermes plugins directory. */
-function uninstallPlugin(hermesRepo: string): string[] {
-	const targetDir = getPluginTargetDir(hermesRepo);
+function uninstallPlugin(targetDir: string): string[] {
 	const removed: string[] = [];
 
 	if (existsSync(targetDir)) {
@@ -65,26 +130,447 @@ function uninstallPlugin(hermesRepo: string): string[] {
 // Config patching
 // ---------------------------------------------------------------------------
 
-/** Read the Hermes CLI config.yaml if it exists. */
-function readConfigYaml(hermesHome: string): string | null {
-	const configPath = join(hermesHome, "cli-config.yaml");
+function getConfigCandidates(hermesHome: string): string[] {
+	return [join(hermesHome, "config.yaml"), join(hermesHome, "cli-config.yaml")];
+}
+
+function resolveConfigPath(hermesHome: string): string {
+	for (const candidate of getConfigCandidates(hermesHome)) {
+		if (existsSync(candidate)) return candidate;
+	}
+	return join(hermesHome, "config.yaml");
+}
+
+function readConfigYaml(hermesHome: string): { path: string; content: string } | null {
+	const configPath = resolveConfigPath(hermesHome);
 	if (!existsSync(configPath)) return null;
 	try {
-		return readFileSync(configPath, "utf-8");
+		return { path: configPath, content: readFileSync(configPath, "utf-8") };
 	} catch {
 		return null;
 	}
 }
 
-/** Check if memory.provider is already set to "signet" in config. */
+interface MemoryBlock {
+	start: number;
+	end: number;
+	provider: number | null;
+	indent: number;
+}
+
+function isBlankOrComment(line: string): boolean {
+	const trimmed = line.trim();
+	return trimmed === "" || trimmed.startsWith("#");
+}
+
+function parseScalar(value: string): string {
+	const stripped = value.split("#", 1)[0]?.trim() ?? "";
+	if ((stripped.startsWith('"') && stripped.endsWith('"')) || (stripped.startsWith("'") && stripped.endsWith("'"))) {
+		return stripped.slice(1, -1);
+	}
+	return stripped;
+}
+
+function leadingWhitespaceLength(line: string): number | null {
+	const match = /^(\s+)/.exec(line);
+	return match ? (match[1]?.length ?? null) : null;
+}
+
+function findMemoryBlock(lines: string[]): MemoryBlock | "missing" | null {
+	const starts: number[] = [];
+	for (let i = 0; i < lines.length; i++) {
+		if (/^memory:\s*(?:#.*)?$/.test(lines[i] ?? "")) starts.push(i);
+		if (/^memory:\s*\S/.test(lines[i] ?? "")) return null;
+	}
+	if (starts.length === 0) return "missing";
+	if (starts.length !== 1) return null;
+	const start = starts[0] ?? 0;
+	let end = lines.length;
+	for (let i = start + 1; i < lines.length; i++) {
+		const line = lines[i] ?? "";
+		if (!isBlankOrComment(line) && !/^\s/.test(line)) {
+			end = i;
+			break;
+		}
+	}
+	let indent: number | null = null;
+	for (let i = start + 1; i < end; i++) {
+		const line = lines[i] ?? "";
+		if (isBlankOrComment(line)) continue;
+		const lineIndent = leadingWhitespaceLength(line);
+		if (lineIndent === null) continue;
+		indent = indent === null ? lineIndent : Math.min(indent, lineIndent);
+	}
+	let provider: number | null = null;
+	const childIndent = indent ?? 2;
+	for (let i = start + 1; i < end; i++) {
+		const line = lines[i] ?? "";
+		if (leadingWhitespaceLength(line) === childIndent && /^provider:\s*/.test(line.slice(childIndent))) {
+			provider = i;
+			break;
+		}
+	}
+	return { start, end, provider, indent: childIndent };
+}
+
+function providerLineIsSignet(line: string): boolean {
+	const match = /^\s+provider:\s*(.*)$/.exec(line);
+	return match ? parseScalar(match[1] ?? "") === "signet" : false;
+}
+
+function parseProviderLine(line: string): string | null {
+	const match = /^\s+provider:\s*(.*)$/.exec(line);
+	return match ? parseScalar(match[1] ?? "") : null;
+}
+
+function findDottedProvider(lines: string[]): number | null {
+	for (let i = 0; i < lines.length; i++) {
+		if (/^memory\.provider:\s*/.test(lines[i] ?? "")) return i;
+	}
+	return null;
+}
+
+function dottedProviderLineIsSignet(line: string): boolean {
+	const match = /^memory\.provider:\s*(.*)$/.exec(line);
+	return match ? parseScalar(match[1] ?? "") === "signet" : false;
+}
+
+function parseDottedProviderLine(line: string): string | null {
+	const match = /^memory\.provider:\s*(.*)$/.exec(line);
+	return match ? parseScalar(match[1] ?? "") : null;
+}
+
+function setDottedProviderLine(lines: string[], line: number, value: string): void {
+	lines[line] = `memory.provider: ${value}`;
+}
+
+function writeProviderBackup(
+	hermesHome: string,
+	configPath: string,
+	providerKind: ProviderBackup["providerKind"],
+	previousProvider: string,
+): string | null {
+	if (previousProvider === "signet") return null;
+	const backupPath = getProviderBackupPath(hermesHome);
+	if (existsSync(backupPath)) return null;
+	const backup: ProviderBackup = {
+		schemaVersion: 1,
+		configPath,
+		providerKind,
+		previousProvider,
+		createdAt: new Date().toISOString(),
+	};
+	mkdirSync(dirname(backupPath), { recursive: true });
+	writeFileSync(backupPath, `${JSON.stringify(backup, null, 2)}\n`);
+	return backupPath;
+}
+
+function readProviderBackup(hermesHome: string): ProviderBackup | null {
+	const backupPath = getProviderBackupPath(hermesHome);
+	if (!existsSync(backupPath)) return null;
+	try {
+		const parsed = JSON.parse(readFileSync(backupPath, "utf-8")) as Partial<ProviderBackup>;
+		if (
+			parsed.schemaVersion === 1 &&
+			typeof parsed.configPath === "string" &&
+			(parsed.providerKind === "nested" || parsed.providerKind === "dotted") &&
+			typeof parsed.previousProvider === "string" &&
+			typeof parsed.createdAt === "string"
+		) {
+			return parsed as ProviderBackup;
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+function removeProviderBackup(hermesHome: string): string | null {
+	const backupPath = getProviderBackupPath(hermesHome);
+	if (!existsSync(backupPath)) return null;
+	rmSync(backupPath, { force: true });
+	return backupPath;
+}
+
+function trimTrailingSlashes(value: string): string {
+	let end = value.length;
+	while (end > 0 && value.charCodeAt(end - 1) === 47) {
+		end--;
+	}
+	return value.slice(0, end);
+}
+
 function isProviderConfigured(hermesHome: string): boolean {
-	const content = readConfigYaml(hermesHome);
-	if (!content) return false;
-	// Simple YAML check — look for "provider: signet" under memory section
+	const config = readConfigYaml(hermesHome);
+	if (!config) return false;
+	const lines = config.content.split(/\r?\n/);
+	const dottedProvider = findDottedProvider(lines);
+	if (dottedProvider !== null) return dottedProviderLineIsSignet(lines[dottedProvider] ?? "");
+	const block = findMemoryBlock(lines);
+	if (
+		block !== null &&
+		typeof block === "object" &&
+		block.provider !== null &&
+		block.provider !== undefined &&
+		providerLineIsSignet(lines[block.provider] ?? "")
+	) {
+		return true;
+	}
+	return false;
+}
+
+function configureProvider(
+	hermesHome: string,
+	warnings: string[],
+): { configPath: string | null; backupPath: string | null } {
+	const configPath = resolveConfigPath(hermesHome);
+	let content = "";
+	if (existsSync(configPath)) {
+		try {
+			content = readFileSync(configPath, "utf-8");
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : String(e);
+			warnings.push(`Could not read Hermes config at ${configPath}: ${msg}`);
+			return { configPath: null, backupPath: null };
+		}
+	}
+
+	const lines = content ? content.replace(/\r\n/g, "\n").split("\n") : [];
+	const block = findMemoryBlock(lines);
+	const dottedProvider = findDottedProvider(lines);
+	let backupPath: string | null = null;
+	if (dottedProvider !== null) {
+		let changed = false;
+		if (!dottedProviderLineIsSignet(lines[dottedProvider] ?? "")) {
+			backupPath = writeProviderBackup(
+				hermesHome,
+				configPath,
+				"dotted",
+				parseDottedProviderLine(lines[dottedProvider] ?? "") ?? "",
+			);
+			setDottedProviderLine(lines, dottedProvider, "signet");
+			changed = true;
+		}
+		if (block !== null && typeof block === "object" && block.provider !== null && block.provider !== undefined) {
+			lines.splice(block.provider, 1);
+			changed = true;
+		}
+		if (!changed) return { configPath: null, backupPath: null };
+		mkdirSync(dirname(configPath), { recursive: true });
+		writeFileSync(configPath, `${lines.join("\n").replace(/\n+$/g, "")}\n`);
+		return { configPath, backupPath };
+	}
+	if (content && block === null) {
+		warnings.push(
+			`Could not safely patch Hermes memory.provider in ${configPath}. Run: hermes config set memory.provider signet`,
+		);
+		return { configPath: null, backupPath: null };
+	}
+
+	if (block !== null && typeof block === "object" && block.provider !== null && block.provider !== undefined) {
+		if (providerLineIsSignet(lines[block.provider] ?? "")) return { configPath: null, backupPath: null };
+		backupPath = writeProviderBackup(
+			hermesHome,
+			configPath,
+			"nested",
+			parseProviderLine(lines[block.provider] ?? "") ?? "",
+		);
+		lines[block.provider] = `${(lines[block.provider] ?? "").match(/^\s*/)?.[0] ?? "  "}provider: signet`;
+	} else if (block !== null && typeof block === "object") {
+		lines.splice(block.start + 1, 0, `${" ".repeat(block.indent)}provider: signet`);
+	} else {
+		if (lines.length > 0 && lines[lines.length - 1] !== "") lines.push("");
+		lines.push("memory:", "  provider: signet");
+	}
+
+	mkdirSync(dirname(configPath), { recursive: true });
+	writeFileSync(configPath, `${lines.join("\n").replace(/\n+$/g, "")}\n`);
+	return { configPath, backupPath };
+}
+
+function restoreOrClearProvider(hermesHome: string): { configPath: string | null; backupPath: string | null } {
+	const config = readConfigYaml(hermesHome);
+	if (!config) return { configPath: null, backupPath: removeProviderBackup(hermesHome) };
+	const lines = config.content.replace(/\r\n/g, "\n").split("\n");
+	const block = findMemoryBlock(lines);
+	const dottedProvider = findDottedProvider(lines);
+	const backup = readProviderBackup(hermesHome);
+	let configChanged = false;
+	if (dottedProvider !== null && dottedProviderLineIsSignet(lines[dottedProvider] ?? "")) {
+		setDottedProviderLine(lines, dottedProvider, backup?.providerKind === "dotted" ? backup.previousProvider : "''");
+		configChanged = true;
+	} else if (
+		block !== null &&
+		typeof block === "object" &&
+		block.provider !== null &&
+		block.provider !== undefined &&
+		providerLineIsSignet(lines[block.provider] ?? "")
+	) {
+		lines[block.provider] = `${(lines[block.provider] ?? "").match(/^\s*/)?.[0] ?? "  "}provider: ${
+			backup?.providerKind === "nested" ? backup.previousProvider : "''"
+		}`;
+		configChanged = true;
+	}
+	if (configChanged) {
+		writeFileSync(config.path, `${lines.join("\n").replace(/\n+$/g, "")}\n`);
+	}
+	return {
+		configPath: configChanged ? config.path : null,
+		backupPath: removeProviderBackup(hermesHome),
+	};
+}
+
+function pluginHasStaticToolSchemas(pluginFile: string): boolean {
+	if (!existsSync(pluginFile)) return false;
+	const content = readFileSync(pluginFile, "utf-8");
 	return (
-		/memory:\s*\n\s+provider:\s*["']?signet["']?/m.test(content) ||
-		/^memory\.provider:\s*["']?signet["']?/m.test(content)
+		content.includes("Hermes indexes memory-provider tool dispatch before provider") &&
+		content.includes("return list(ALL_TOOL_SCHEMAS)") &&
+		!/def get_tool_schemas[\s\S]{0,220}if not self\._client:[\s\S]{0,80}return \[\]/.test(content)
 	);
+}
+
+function getConnectorPackageJsonPath(): string | null {
+	const candidates = [
+		join(__dirname, "..", "package.json"),
+		join(__dirname, "..", "..", "package.json"),
+		join(__dirname, "..", "..", "..", "package.json"),
+	];
+	return candidates.find((candidate) => existsSync(candidate)) ?? null;
+}
+
+function getConnectorVersion(): string {
+	const packageJsonPath = getConnectorPackageJsonPath();
+	if (!packageJsonPath) return "unknown";
+	try {
+		const parsed = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as { version?: unknown };
+		return typeof parsed.version === "string" ? parsed.version : "unknown";
+	} catch {
+		return "unknown";
+	}
+}
+
+function computePluginSourceHash(): string {
+	const sourceDir = getPluginSourceDir();
+	const hash = createHash("sha256");
+	for (const file of PLUGIN_FILES) {
+		const path = join(sourceDir, file);
+		hash.update(file);
+		hash.update("\0");
+		if (existsSync(path)) {
+			hash.update(readFileSync(path));
+		}
+		hash.update("\0");
+	}
+	return hash.digest("hex");
+}
+
+function writeInstallMarker(targetDir: string, targetKind: InstallMarker["targetKind"]): string {
+	const markerPath = join(targetDir, INSTALL_MARKER_FILE);
+	const marker: InstallMarker = {
+		connector: "@signet/connector-hermes-agent",
+		schemaVersion: 1,
+		connectorVersion: getConnectorVersion(),
+		sourceHash: computePluginSourceHash(),
+		targetKind,
+		installedAt: new Date().toISOString(),
+	};
+	writeFileSync(markerPath, `${JSON.stringify(marker, null, 2)}\n`);
+	return markerPath;
+}
+
+function readInstallMarker(targetDir: string): InstallMarker | null {
+	const markerPath = join(targetDir, INSTALL_MARKER_FILE);
+	if (!existsSync(markerPath)) return null;
+	try {
+		const parsed = JSON.parse(readFileSync(markerPath, "utf-8")) as Partial<InstallMarker>;
+		if (
+			parsed.connector === "@signet/connector-hermes-agent" &&
+			parsed.schemaVersion === 1 &&
+			typeof parsed.connectorVersion === "string" &&
+			typeof parsed.sourceHash === "string" &&
+			(parsed.targetKind === "user" || parsed.targetKind === "repo") &&
+			typeof parsed.installedAt === "string"
+		) {
+			return parsed as InstallMarker;
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+function pluginMarkerIsFresh(targetDir: string): boolean {
+	const marker = readInstallMarker(targetDir);
+	return marker !== null && marker.sourceHash === computePluginSourceHash();
+}
+
+function pluginLooksCurrent(targetDir: string): boolean {
+	return pluginHasStaticToolSchemas(join(targetDir, "__init__.py")) && pluginMarkerIsFresh(targetDir);
+}
+
+function probeHermesProvider(hermesRepo: string): HermesProbeResult {
+	if (!existsSync(hermesRepo)) {
+		return { ok: false, toolNames: [], error: `Hermes repo not found at ${hermesRepo}` };
+	}
+
+	const script = [
+		"import json",
+		"from plugins.memory import load_memory_provider",
+		"from agent.memory_manager import MemoryManager",
+		"provider = load_memory_provider('signet')",
+		"manager = MemoryManager()",
+		"manager.add_provider(provider)",
+		"names = sorted(manager.get_all_tool_names())",
+		"required = ['memory_search', 'memory_store', 'memory_get', 'memory_list', 'memory_modify', 'memory_forget', 'recall', 'remember']",
+		"print(json.dumps({'toolNames': names, 'missing': [name for name in required if name not in names]}))",
+	].join("\n");
+
+	const python = process.env.PYTHON?.trim() || "python";
+	const result = spawnSync(python, ["-c", script], {
+		cwd: hermesRepo,
+		env: { ...process.env, PYTHONPATH: hermesRepo },
+		encoding: "utf-8",
+		timeout: 5_000,
+	});
+
+	if (result.error) {
+		return { ok: false, toolNames: [], error: result.error.message };
+	}
+	if (result.status !== 0) {
+		const err = `${result.stderr || result.stdout || `python exited ${result.status}`}`.trim();
+		return { ok: false, toolNames: [], error: err };
+	}
+
+	try {
+		const parsed = JSON.parse(result.stdout.trim()) as { toolNames?: unknown; missing?: unknown };
+		const toolNames = Array.isArray(parsed.toolNames)
+			? parsed.toolNames.filter((name): name is string => typeof name === "string")
+			: [];
+		const missing = Array.isArray(parsed.missing)
+			? parsed.missing.filter((name): name is string => typeof name === "string")
+			: [];
+		return {
+			ok: missing.length === 0,
+			toolNames,
+			error: missing.length > 0 ? `Missing tools: ${missing.join(", ")}` : null,
+		};
+	} catch (e) {
+		const msg = e instanceof Error ? e.message : String(e);
+		return { ok: false, toolNames: [], error: `Could not parse Hermes provider probe output: ${msg}` };
+	}
+}
+
+async function checkDaemon(daemonUrl: string): Promise<{ ok: boolean; detail: string }> {
+	const baseUrl = trimTrailingSlashes(daemonUrl);
+	try {
+		const resp = await fetch(`${baseUrl}/health`, { signal: AbortSignal.timeout(1_000) });
+		if (resp.ok) return { ok: true, detail: `${baseUrl}/health returned HTTP ${resp.status}` };
+		return { ok: false, detail: `${baseUrl}/health returned HTTP ${resp.status}` };
+	} catch (e) {
+		const msg = e instanceof Error ? e.message : String(e);
+		return { ok: false, detail: `${baseUrl}/health unreachable: ${msg}` };
+	}
 }
 
 function sanitizedEnv(name: string): string {
@@ -105,7 +591,7 @@ async function ensureNamedAgentRegistered(daemonUrl: string, agentId: string, wa
 	if (!agentId || agentId === "default" || agentId === "hermes-agent") return;
 	if (process.env.SIGNET_SKIP_AGENT_REGISTER === "1") return;
 
-	const baseUrl = daemonUrl.replace(/\/+$/, "");
+	const baseUrl = trimTrailingSlashes(daemonUrl);
 	const token = sanitizedEnv("SIGNET_TOKEN");
 	const headers: Record<string, string> = {};
 	if (token) {
@@ -183,7 +669,7 @@ export class HermesAgentConnector extends BaseConnector {
 	}
 
 	getConfigPath(): string {
-		return join(this.getHermesHome(), "cli-config.yaml");
+		return resolveConfigPath(this.getHermesHome());
 	}
 
 	async install(basePath: string): Promise<InstallResult> {
@@ -199,22 +685,26 @@ export class HermesAgentConnector extends BaseConnector {
 		const hermesHome = this.getHermesHome();
 		const hermesRepo = this.getHermesRepo();
 
-		// 1. Install the Python plugin into plugins/memory/signet/
+		// 1. Install the Python plugin into the current user-plugin location.
+		try {
+			const pluginFiles = installPlugin(getUserPluginTargetDir(hermesHome), "user");
+			filesWritten.push(...pluginFiles);
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : String(e);
+			warnings.push(`Failed to install Hermes user plugin files: ${msg}`);
+		}
+
+		// Bundled repo providers take precedence over user plugins in Hermes.
+		// Refresh that copy too when the repo is discoverable so stale schemas
+		// cannot shadow the fixed Signet provider.
 		if (hermesRepo) {
 			try {
-				const pluginFiles = installPlugin(hermesRepo);
+				const pluginFiles = installPlugin(getRepoPluginTargetDir(hermesRepo), "repo");
 				filesWritten.push(...pluginFiles);
 			} catch (e) {
 				const msg = e instanceof Error ? e.message : String(e);
-				warnings.push(`Failed to install plugin files: ${msg}`);
+				warnings.push(`Failed to refresh Hermes repo plugin files: ${msg}`);
 			}
-		} else {
-			warnings.push(
-				"Hermes Agent install not found. Install Hermes in ~/.hermes or set HERMES_REPO to the hermes-agent directory, " +
-					"then re-run setup. Alternatively, copy the plugin manually:\n" +
-					"  cp -r <signet>/integrations/hermes-agent/connector/hermes-plugin/ " +
-					"<hermes-agent>/plugins/memory/signet/",
-			);
 		}
 
 		// 2. Write env config for the Signet daemon connection
@@ -288,19 +778,29 @@ export class HermesAgentConnector extends BaseConnector {
 
 		await ensureNamedAgentRegistered(configuredDaemonUrl, configuredSignetAgentId, warnings);
 
-		// 3. Provide guidance on completing setup
-		if (!isProviderConfigured(hermesHome)) {
+		// 3. Activate Signet as the external Hermes memory provider.
+		const providerConfig = configureProvider(hermesHome, warnings);
+		if (providerConfig.configPath) {
+			configsPatched.push(providerConfig.configPath);
+		}
+		if (providerConfig.backupPath) {
+			filesWritten.push(providerConfig.backupPath);
+		}
+
+		if (hermesRepo) {
+			const probe = probeHermesProvider(hermesRepo);
+			if (!probe.ok) {
+				warnings.push(
+					`Hermes Signet provider installed, but Hermes did not expose all Signet memory tools during verification: ${probe.error ?? "unknown error"}. Run: signet doctor hermes`,
+				);
+			}
+		} else {
 			warnings.push(
-				"To activate Signet as your memory provider, run:\n" +
-					"  hermes memory setup\n" +
-					"and select 'signet', or manually:\n" +
-					"  hermes config set memory.provider signet",
+				"Hermes repo was not found, so install-time provider verification was skipped. Run: signet doctor hermes",
 			);
 		}
 
-		const message = hermesRepo
-			? "Hermes Agent integration installed — Signet memory plugin deployed"
-			: "Hermes Agent integration partially installed — plugin files need manual copy";
+		const message = "Hermes Agent integration installed — Signet memory provider deployed and activated";
 
 		return {
 			success: true,
@@ -317,12 +817,23 @@ export class HermesAgentConnector extends BaseConnector {
 
 		const hermesRepo = this.getHermesRepo();
 		if (hermesRepo) {
-			const removed = uninstallPlugin(hermesRepo);
+			const removed = uninstallPlugin(getRepoPluginTargetDir(hermesRepo));
 			filesRemoved.push(...removed);
 		}
 
 		// Clean up env vars
 		const hermesHome = this.getHermesHome();
+		const userPluginRemoved = uninstallPlugin(getUserPluginTargetDir(hermesHome));
+		filesRemoved.push(...userPluginRemoved);
+
+		const providerConfig = restoreOrClearProvider(hermesHome);
+		if (providerConfig.configPath) {
+			configsPatched.push(providerConfig.configPath);
+		}
+		if (providerConfig.backupPath) {
+			filesRemoved.push(providerConfig.backupPath);
+		}
+
 		const envPath = join(hermesHome, ".env");
 		if (existsSync(envPath)) {
 			try {
@@ -349,8 +860,113 @@ export class HermesAgentConnector extends BaseConnector {
 	}
 
 	isInstalled(): boolean {
-		return resolveHermesRepoPluginPath() !== null;
+		const hermesHome = this.getHermesHome();
+		const hermesRepo = this.getHermesRepo();
+		if (!isProviderConfigured(hermesHome)) return false;
+		if (hermesRepo) return pluginLooksCurrent(getRepoPluginTargetDir(hermesRepo));
+		return pluginLooksCurrent(getUserPluginTargetDir(hermesHome));
 	}
+
+	async diagnose(): Promise<HermesDoctorReport> {
+		const hermesHome = this.getHermesHome();
+		const hermesRepo = this.getHermesRepo();
+		return diagnoseHermesIntegration({
+			hermesHome,
+			hermesRepo,
+			daemonUrl: (process.env.SIGNET_DAEMON_URL?.trim() || "http://localhost:3850").replace(/[\r\n]+/g, ""),
+		});
+	}
+}
+
+export async function diagnoseHermesIntegration(opts?: {
+	readonly hermesHome?: string;
+	readonly hermesRepo?: string | null;
+	readonly daemonUrl?: string;
+}): Promise<HermesDoctorReport> {
+	const hermesHome = opts?.hermesHome ?? resolveHermesHomePath();
+	const hermesRepo = opts?.hermesRepo ?? resolveHermesRepoPath();
+	const daemonUrl = opts?.daemonUrl ?? (process.env.SIGNET_DAEMON_URL?.trim() || "http://localhost:3850");
+	const configPath = resolveConfigPath(hermesHome);
+	const userPluginDir = getUserPluginTargetDir(hermesHome);
+	const repoPluginDir = hermesRepo ? getRepoPluginTargetDir(hermesRepo) : null;
+	const checks: HermesDiagnosticCheck[] = [];
+	const warnings: string[] = [];
+	const userPluginCurrent = pluginLooksCurrent(userPluginDir);
+	const repoPluginCurrent = repoPluginDir ? pluginLooksCurrent(repoPluginDir) : false;
+	const probe = hermesRepo
+		? probeHermesProvider(hermesRepo)
+		: { ok: false, toolNames: [], error: "Hermes repo not found" };
+	const daemon = await checkDaemon(daemonUrl);
+
+	checks.push({
+		id: "daemon-health",
+		label: "Signet daemon",
+		ok: daemon.ok,
+		detail: daemon.detail,
+		fix: daemon.ok ? undefined : "Run `signet daemon start`, then retry `signet doctor hermes`.",
+	});
+	checks.push({
+		id: "provider-config",
+		label: "Hermes memory provider",
+		ok: isProviderConfigured(hermesHome),
+		detail: existsSync(configPath)
+			? `${configPath} ${isProviderConfigured(hermesHome) ? "sets" : "does not set"} memory.provider=signet`
+			: `${configPath} does not exist`,
+		fix: isProviderConfigured(hermesHome) ? undefined : "Run `signet setup --harness hermes-agent`.",
+	});
+	checks.push({
+		id: "user-plugin",
+		label: "User plugin copy",
+		ok: userPluginCurrent,
+		detail: userPluginCurrent
+			? `${userPluginDir} matches bundled Signet plugin`
+			: `${userPluginDir} is missing or stale`,
+		fix: userPluginCurrent ? undefined : "Run `signet setup --harness hermes-agent`.",
+	});
+	checks.push({
+		id: "repo-plugin",
+		label: "Hermes repo plugin copy",
+		ok: repoPluginDir !== null && repoPluginCurrent,
+		detail:
+			repoPluginDir === null
+				? "Hermes checkout not found"
+				: repoPluginCurrent
+					? `${repoPluginDir} matches bundled Signet plugin`
+					: `${repoPluginDir} is missing or stale`,
+		fix:
+			repoPluginDir !== null && repoPluginCurrent
+				? undefined
+				: "Set HERMES_REPO to the Hermes Agent checkout, then run `signet setup --harness hermes-agent`.",
+	});
+	checks.push({
+		id: "tool-routing",
+		label: "Hermes tool routing",
+		ok: probe.ok,
+		detail: probe.ok
+			? `Hermes exposes ${REQUIRED_TOOL_NAMES.join(", ")}`
+			: `Hermes provider probe failed: ${probe.error ?? "unknown error"}`,
+		fix: probe.ok
+			? undefined
+			: "Run `signet setup --harness hermes-agent`; if this stays broken, restart Hermes after install.",
+	});
+
+	if (!hermesRepo) {
+		warnings.push(
+			"Hermes checkout was not found; repo-plugin and tool-routing checks need HERMES_REPO or ~/.hermes/hermes-agent.",
+		);
+	}
+
+	return {
+		ok: checks.every((check) => check.ok),
+		hermesHome,
+		hermesRepo,
+		configPath,
+		userPluginDir,
+		repoPluginDir,
+		toolNames: probe.toolNames,
+		checks,
+		warnings,
+	};
 }
 
 export function createConnector(): HermesAgentConnector {

--- a/platform/core/src/__tests__/identity.test.ts
+++ b/platform/core/src/__tests__/identity.test.ts
@@ -148,6 +148,15 @@ describe("detectExistingSetup", () => {
 		expect(detection.harnesses.hermesAgent).toBe(true);
 	});
 
+	test("detects Hermes Agent in the managed ~/.hermes/hermes-agent checkout", () => {
+		process.env.HOME = TMP;
+		mkdirSync(join(TMP, ".hermes", "hermes-agent", "plugins", "memory"), { recursive: true });
+
+		const detection = detectExistingSetup(TMP);
+
+		expect(detection.harnesses.hermesAgent).toBe(true);
+	});
+
 	test("detects Hermes Agent before the Signet memory plugin is installed", () => {
 		const hermesRepo = join(TMP, "hermes-agent");
 		mkdirSync(join(hermesRepo, "plugins", "memory"), { recursive: true });

--- a/platform/core/src/identity.ts
+++ b/platform/core/src/identity.ts
@@ -377,6 +377,7 @@ export function hermesAgentCandidateDirs(): readonly string[] {
 	const hermesHome = resolveHermesHomePath();
 	return [
 		hermesHome,
+		join(hermesHome, "hermes-agent"),
 		join(home, "hermes-agent"),
 		join(home, ".local", "share", "hermes-agent"),
 		join(home, "src", "hermes-agent"),

--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -24,7 +24,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { dirname, join, resolve as resolvePath } from "node:path";
+import { dirname, join, resolve as resolvePath, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { ClaudeCodeConnector } from "@signet/connector-claude-code";
 import { CodexConnector } from "@signet/connector-codex";
@@ -328,6 +328,22 @@ async function configureHarnessHooks(
 			const result = await connector.install(basePath);
 			if (!result.success) {
 				console.warn(chalk.yellow(`  Warning: Hermes Agent integration setup failed: ${result.message}`));
+			} else {
+				console.log(chalk.green(`  ✓ ${result.message}`));
+				if (result.filesWritten.some((path) => path.includes(`${sep}plugins${sep}signet${sep}`))) {
+					console.log(chalk.green("  ✓ Hermes user plugin refreshed"));
+				}
+				if (result.filesWritten.some((path) => path.includes(`${sep}plugins${sep}memory${sep}signet${sep}`))) {
+					console.log(chalk.green("  ✓ Hermes repo plugin refreshed"));
+				}
+				if (
+					(result.configsPatched ?? []).some((path) => path.endsWith("config.yaml") || path.endsWith("cli-config.yaml"))
+				) {
+					console.log(chalk.green("  ✓ Hermes memory.provider set to signet"));
+				}
+				if ((result.configsPatched ?? []).some((path) => path.endsWith(".env"))) {
+					console.log(chalk.green("  ✓ Hermes Signet environment updated"));
+				}
 			}
 			for (const w of result.warnings ?? []) {
 				console.warn(chalk.yellow(`  ${w}`));

--- a/surfaces/cli/src/commands/app.test.ts
+++ b/surfaces/cli/src/commands/app.test.ts
@@ -24,4 +24,26 @@ describe("registerAppCommands", () => {
 
 		expect(calls).toEqual([[]]);
 	});
+
+	test("routes doctor target into doctor options", async () => {
+		const calls: unknown[] = [];
+		const program = new Command();
+
+		registerAppCommands(program, {
+			collectListOption: (value, previous) => [...previous, value],
+			configureAgent: async () => {},
+			launchDashboard: async () => {},
+			migrateSchema: async () => {},
+			setupWizard: async () => {},
+			showDoctor: async (options) => {
+				calls.push(options);
+			},
+			showStatus: async () => {},
+			syncTemplates: async () => {},
+		});
+
+		await program.parseAsync(["node", "test", "doctor", "hermes", "--json"]);
+
+		expect(calls).toEqual([{ json: true, target: "hermes" }]);
+	});
 });

--- a/surfaces/cli/src/commands/app.ts
+++ b/surfaces/cli/src/commands/app.ts
@@ -31,6 +31,7 @@ interface PathOptions {
 
 interface StatusOptions extends PathOptions {
 	json?: boolean;
+	target?: string;
 }
 
 interface AppDeps {
@@ -109,8 +110,9 @@ export function registerAppCommands(program: Command, deps: AppDeps): void {
 
 	const doctor = program
 		.command("doctor")
+		.argument("[target]", "Optional doctor target (hermes)")
 		.description("Run local health checks and suggest fixes")
-		.action(deps.showDoctor);
+		.action((target: string | undefined, options: StatusOptions) => deps.showDoctor({ ...options, target }));
 	withJson(withPath(doctor));
 
 	const migrate = program

--- a/surfaces/cli/src/features/health.ts
+++ b/surfaces/cli/src/features/health.ts
@@ -1,7 +1,8 @@
+import { join } from "node:path";
+import { diagnoseHermesIntegration } from "@signet/connector-hermes-agent";
 import { OpenClawConnector, type OpenClawRuntimeState } from "@signet/connector-openclaw";
 import { detectSchema, getMissingIdentityFiles, hasValidIdentity } from "@signet/core";
 import chalk from "chalk";
-import { join } from "node:path";
 import { daemonAccessLines } from "../lib/network.js";
 import { getGitRemoteState, getSnapshotProtection, hasOpenClawWorkspaceLink } from "../lib/workspace-protection.js";
 import Database from "../sqlite.js";
@@ -283,7 +284,21 @@ export function getExtractionStatusNotice(
 	return null;
 }
 
-export async function showDoctor(options: { path?: string; json?: boolean }, deps: StatusDeps): Promise<void> {
+export async function showDoctor(
+	options: { path?: string; json?: boolean; target?: string },
+	deps: StatusDeps,
+): Promise<void> {
+	if (options.target === "hermes" || options.target === "hermes-agent") {
+		await showHermesDoctor(options);
+		return;
+	}
+
+	if (options.target) {
+		console.log(chalk.red(`Unknown doctor target: ${options.target}`));
+		console.log(chalk.dim("Supported targets: hermes"));
+		return;
+	}
+
 	const basePath = deps.normalizeAgentPath(deps.extractPathOption(options) ?? deps.agentsDir);
 	const report = await getStatusReport(basePath, deps);
 	const findings = getDoctorFindings(report);
@@ -318,6 +333,46 @@ export async function showDoctor(options: { path?: string; json?: boolean }, dep
 		console.log(chalk.yellow("  Signet can run, but there's a bit of duct tape showing."));
 	} else {
 		console.log(chalk.red("  Fix the errors above before trusting the CLI to behave."));
+	}
+	console.log();
+}
+
+async function showHermesDoctor(options: { json?: boolean }): Promise<void> {
+	const report = await diagnoseHermesIntegration();
+
+	if (options.json) {
+		console.log(JSON.stringify(report, null, 2));
+		return;
+	}
+
+	console.log(chalk.bold("  Hermes Doctor\n"));
+	console.log(chalk.dim(`  Hermes home: ${report.hermesHome}`));
+	console.log(chalk.dim(`  Hermes repo: ${report.hermesRepo ?? "not found"}`));
+	console.log();
+
+	for (const check of report.checks) {
+		const icon = check.ok ? chalk.green("✓") : chalk.red("✗");
+		console.log(`  ${icon} ${check.label}`);
+		console.log(chalk.dim(`    ${check.detail}`));
+		if (!check.ok && check.fix) {
+			console.log(chalk.dim(`    ${check.fix}`));
+		}
+	}
+
+	if (report.toolNames.length > 0) {
+		console.log();
+		console.log(chalk.dim(`  Tools: ${report.toolNames.join(", ")}`));
+	}
+
+	for (const warning of report.warnings) {
+		console.log(chalk.yellow(`  ⚠ ${warning}`));
+	}
+
+	console.log();
+	if (report.ok) {
+		console.log(chalk.green("  ✓ Hermes Signet integration is healthy"));
+	} else {
+		console.log(chalk.red("  Hermes Signet integration needs repair"));
 	}
 	console.log();
 }


### PR DESCRIPTION
## Summary

- hardens the Hermes connector install flow with config backup/restore, bundled plugin hashing, repo + user plugin copy support, uninstall cleanup, and an idempotent repair path
- adds `signet doctor hermes` plus app-level health surfacing for Hermes configuration, plugin copy freshness, daemon health, and tool routing
- updates Hermes docs with the easier install, doctor, uninstall, and troubleshooting paths
- addresses review feedback for dotted `memory.provider` config, CodeQL URL normalization, repo-plugin staleness detection, Hermes user-provider import loading, uninstall restoration of replaced/removed memory providers, mixed dotted/nested provider config, nested `provider:` keys under `memory:` subfeatures, user-plugin-only doctor behavior, install failure when no usable plugin target is written, and non-mapping `memory:` block safety

## Validation

- `bun test integrations/hermes-agent/connector/index.test.ts` (51 tests, 189 expects)
- `cd integrations/hermes-agent/connector && bun run typecheck`
- `cd integrations/hermes-agent/connector && bun run build`
- `bunx biome check integrations/hermes-agent/connector/src/index.ts integrations/hermes-agent/connector/index.test.ts`
- `git diff --check`
- `bun surfaces/cli/src/cli.ts doctor hermes --json` returns `ok: true` for `/home/nicholai/.hermes`, including daemon health, provider config, user plugin copy, repo plugin copy, and tool routing
- direct `diagnoseHermesIntegration({ hermesHome: "/home/nicholai/.hermes", hermesRepo: null })` returns `ok: true` for the supported user-plugin-only path, with repo-plugin marked optional and tool routing reported from the user plugin schemas
- previous full validation on this PR also covered CLI build, platform core build, spec dependency validation, the broader focused test set, and actual local Hermes user-provider import loading from `$HERMES_HOME/plugins/signet`

## Readiness checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

Notes: this PR does not add admin or mutation endpoints, so the security checklist item is satisfied by confirming there is no new protected endpoint surface.
