### PR TITLE
fix(publish): include Hermes plugin in signetai package

### DIFF
--- a/dist/signetai/package.json
+++ b/dist/signetai/package.json
@@ -11,6 +11,7 @@
     "bin",
     "dist",
     "dashboard",
+    "hermes-plugin",
     "scripts",
     "templates",
     "skills",
@@ -24,7 +25,8 @@
     "build:dashboard": "bun ../../scripts/prepare-dashboard-bundle.ts .",
     "copy:skills": "rm -rf skills && cp -r ../../skills skills",
     "copy:scripts": "mkdir -p scripts && cp ../../scripts/install-graphiq.sh scripts/install-graphiq.sh",
-    "prebuild": "bun run copy:skills && bun run copy:scripts",
+    "copy:hermes-plugin": "rm -rf hermes-plugin && cp -r ../../integrations/hermes-agent/connector/hermes-plugin hermes-plugin",
+    "prebuild": "bun run copy:skills && bun run copy:scripts && bun run copy:hermes-plugin",
     "prepublishOnly": "bun run build"
   },
   "keywords": [

--- a/scripts/check-publish-manifests.test.ts
+++ b/scripts/check-publish-manifests.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -15,6 +15,23 @@ function writeJson(file: string, value: unknown): void {
 }
 
 describe("check-publish-manifests", () => {
+	test("keeps Hermes plugin assets in the signetai publish package", () => {
+		const root = join(import.meta.dir, "..");
+		const manifest = JSON.parse(readFileSync(join(root, "dist", "signetai", "package.json"), "utf-8")) as {
+			files?: unknown;
+			scripts?: Record<string, string>;
+		};
+
+		expect(manifest.files).toContain("hermes-plugin");
+		expect(manifest.scripts?.["copy:hermes-plugin"]).toContain(
+			"../../integrations/hermes-agent/connector/hermes-plugin",
+		);
+		expect(manifest.scripts?.prebuild).toContain("copy:hermes-plugin");
+		expect(existsSync(join(root, "integrations", "hermes-agent", "connector", "hermes-plugin", "__init__.py"))).toBe(
+			true,
+		);
+	});
+
 	test("treats manifests with publishConfig.access public as publishable", () => {
 		expect(
 			isPublishableWorkspacePackage({


### PR DESCRIPTION
## Summary

- copies the Hermes connector plugin assets into the published `signetai` meta-package during prebuild
- includes `hermes-plugin` in the `signetai` npm `files` manifest so the bundled CLI can find it at runtime
- adds a publish-manifest regression so this asset drift is caught before the next publish

## Why

`signetai@0.109.17` bundles the Hermes connector into `dist/cli.js`, but the published package does not include the connector's `hermes-plugin/` directory. During `signet sync`, harness detection calls the Hermes connector and crashes with:

```text
Error: Cannot find hermes-plugin directory in connector package
```

The bundled connector already probes for `../hermes-plugin` relative to `dist/cli.js`, so the package just needs to ship the asset at `node_modules/signetai/hermes-plugin`.

## Validation

- `bun test scripts/check-publish-manifests.test.ts`
- `bunx biome check dist/signetai/package.json scripts/check-publish-manifests.test.ts`
- `git diff --check`
- `cd dist/signetai && bun run copy:hermes-plugin && test -f hermes-plugin/__init__.py && npm pack --dry-run --json`
  - confirmed the dry-run tarball includes `hermes-plugin/__init__.py`, `client.py`, `plugin.yaml`, and `README.md`
- patched the currently installed `signetai@0.109.17` package locally and confirmed `signet sync` completes, `signet doctor hermes --json` returns `ok: true`, and `signet status` shows daemon `v0.109.17` running

Note: I attempted `bun test integrations/hermes-agent/connector/index.test.ts` from this clean `main` worktree, but this worktree has no `node_modules`, so Bun could not resolve `@signet/connector-base`. The packaging regression and tarball dry-run cover this hotfix directly.

## Readiness checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

Notes: this PR changes publish packaging only. It does not add user-data queries, admin/mutation endpoints, API behavior, or spec-governed behavior; those checklist items were checked as not applicable for this patch.