### PR TITLE
fix(memory): guide recall query shape

### DIFF
--- a/integrations/hermes-agent/connector/hermes-plugin/__init__.py
+++ b/integrations/hermes-agent/connector/hermes-plugin/__init__.py
@@ -46,11 +46,21 @@ logger = logging.getLogger(__name__)
 
 MEMORY_SEARCH_SCHEMA = {
     "name": "memory_search",
-    "description": "Search Signet memories using hybrid vector + keyword search.",
+    "description": (
+        "Search Signet memories using hybrid vector + keyword search. "
+        "Ask a natural-language question with entity, event, and timeframe when possible. "
+        "Avoid bag-of-keywords queries; use keyword_query only when you intentionally need exact lexical matching."
+    ),
     "parameters": {
         "type": "object",
         "properties": {
-            "query": {"type": "string", "description": "Search query text."},
+            "query": {
+                "type": "string",
+                "description": (
+                    "Natural-language recall question. Include the relevant entity/person/project, event or decision, "
+                    "and timeframe when known; avoid diagnostic keyword soup."
+                ),
+            },
             "limit": {"type": "integer", "description": "Max results to return (default 10, max 50)."},
             "project": {"type": "string", "description": "Optional project path filter."},
             "expand": {"type": "boolean", "description": "Include lossless session transcripts as sources."},
@@ -217,7 +227,7 @@ MEMORY_FORGET_SCHEMA = {
 
 RECALL_ALIAS_SCHEMA = {
     "name": "recall",
-    "description": "Alias for memory_search.",
+    "description": "Alias for memory_search. Use the same natural-language query discipline; avoid bag-of-keywords queries.",
     "parameters": MEMORY_SEARCH_SCHEMA["parameters"],
 }
 

--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -184,6 +184,10 @@ describe("HermesAgentConnector.install()", () => {
 		expect(existsSync(join(repoPluginDir, "client.py"))).toBe(true);
 		expect(existsSync(join(repoPluginDir, "plugin.yaml"))).toBe(true);
 		expect(existsSync(join(repoPluginDir, "signet.install.json"))).toBe(true);
+		expect(readFileSync(join(repoPluginDir, "__init__.py"), "utf-8")).toContain(
+			"Ask a natural-language question with entity, event, and timeframe when possible",
+		);
+		expect(readFileSync(join(repoPluginDir, "__init__.py"), "utf-8")).toContain("Avoid bag-of-keywords queries");
 		expect(existsSync(join(userPluginDir, "__init__.py"))).toBe(true);
 		expect(existsSync(join(userPluginDir, "client.py"))).toBe(true);
 		expect(existsSync(join(userPluginDir, "plugin.yaml"))).toBe(true);

--- a/platform/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/platform/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -113,8 +113,8 @@ You have persistent memory managed by Signet.\n\
 \n\
 Memory Check Loop:\n\
 - when to use: before commands, file edits, architectural choices, bug fixes, continuation work, user-preference-sensitive answers, or anything that may depend on prior decisions\n\
-- procedure: check injected context first, then run 1-3 targeted recalls with mcp__signet__memory_search; expand session lineage with mcp__signet__lcm_expand or known entities with mcp__signet__knowledge_expand and mcp__signet__knowledge_expand_session when needed\n\
-- pitfalls: do not treat a missing automatic memory match as proof no prior context exists; do not trust memory blindly when repo, files, or live system state can verify it; do not spam broad recalls for trivial self-contained prompts\n\
+- procedure: check injected context first, then run 1-3 targeted recalls with mcp__signet__memory_search; shape recall queries as natural questions with an entity, event, and timeframe when possible; expand session lineage with mcp__signet__lcm_expand or known entities with mcp__signet__knowledge_expand and mcp__signet__knowledge_expand_session when needed\n\
+- pitfalls: avoid bag-of-keywords queries; do not treat a missing automatic memory match as proof no prior context exists; do not trust memory blindly when repo, files, or live system state can verify it; do not spam broad recalls for trivial self-contained prompts; treat graph expansion as supporting context, not proof\n\
 - verification: before acting, know what context you found, what remains unknown, and whether it is safe to proceed\n\
 \n\
 Memory tools:\n\
@@ -815,7 +815,7 @@ fn build_prompt_recall_inject(metadata_header: &str, sources: &[String]) -> Stri
         String::new(),
         "## Memory Check".to_string(),
         String::new(),
-        "Use the memories below as starting context before acting. If the task depends on prior context and anything is missing, run 1-3 targeted recalls with /recall or memory_search, then expand with lcm_expand or knowledge_expand when needed."
+        "Use the memories below as starting context before acting. If the task depends on prior context and anything is missing, run 1-3 targeted recalls with /recall or memory_search. Ask natural questions with entity + event + timeframe when possible. Avoid bag-of-keywords recall queries. Expand with lcm_expand or knowledge_expand only when you need deeper lineage or graph context. Treat graph expansion as supporting context, not proof."
             .to_string(),
         String::new(),
         "## Relevant Memory".to_string(),
@@ -834,7 +834,7 @@ fn build_prompt_recall_inject(metadata_header: &str, sources: &[String]) -> Stri
 
 fn build_no_strong_memory_match_inject(metadata_header: &str) -> String {
     format!(
-        "{}\n\n## Memory Check\n\nNo strong automatic memory match was injected for this turn. If the request depends on prior context, preferences, project history, or unresolved work, run 1-3 targeted Signet recalls before executing commands, editing files, or making decisions.\n\nIf you learn something durable, save it with /remember or memory_store.\n",
+        "{}\n\n## Memory Check\n\nNo strong automatic memory match was injected for this turn. If the request depends on prior context, preferences, project history, or unresolved work, run 1-3 targeted Signet recalls before executing commands, editing files, or making decisions. Ask natural questions with entity + event + timeframe when possible. Avoid bag-of-keywords recall queries. Treat graph expansion as supporting context, not proof.\n\nIf you learn something durable, save it with /remember or memory_store.\n",
         metadata_header.trim_end()
     )
 }

--- a/platform/daemon/src/hooks.prompt-submit.test.ts
+++ b/platform/daemon/src/hooks.prompt-submit.test.ts
@@ -292,6 +292,9 @@ describe("handleUserPromptSubmit observability", () => {
 		expect(result.inject).toContain("[memory] prompt submit observability now logs fallback engine transitions");
 		expect(result.inject).toContain("Use the memories below as starting context before acting");
 		expect(result.inject).toContain("run 1-3 targeted recalls with /recall or memory_search");
+		expect(result.inject).toContain("Ask natural questions with entity + event + timeframe when possible");
+		expect(result.inject).toContain("Avoid bag-of-keywords recall queries");
+		expect(result.inject).toContain("Treat graph expansion as supporting context, not proof");
 		expect(result.inject).not.toContain("[signet:recall");
 	});
 

--- a/platform/daemon/src/hooks.test.ts
+++ b/platform/daemon/src/hooks.test.ts
@@ -3248,6 +3248,9 @@ describe("buildSignetSystemPrompt", () => {
 		expect(prompt).toContain("Memory Check Loop");
 		expect(prompt).toContain("before commands, file edits, architectural choices");
 		expect(prompt).toContain("run 1-3 targeted recalls with mcp__signet__memory_search");
+		expect(prompt).toContain("shape recall queries as natural questions with an entity, event, and timeframe");
+		expect(prompt).toContain("avoid bag-of-keywords queries");
+		expect(prompt).toContain("treat graph expansion as supporting context, not proof");
 		expect(prompt).toContain("do not treat a missing automatic memory match as proof no prior context exists");
 		expect(prompt).toContain("before acting, know what context you found");
 	});

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -291,8 +291,8 @@ You have persistent memory managed by Signet.
 
 Memory Check Loop:
 - when to use: before commands, file edits, architectural choices, bug fixes, continuation work, user-preference-sensitive answers, or anything that may depend on prior decisions
-- procedure: check injected context first, then run 1-3 targeted recalls with mcp__signet__memory_search; expand session lineage with mcp__signet__lcm_expand or known entities with mcp__signet__knowledge_expand and mcp__signet__knowledge_expand_session when needed
-- pitfalls: do not treat a missing automatic memory match as proof no prior context exists; do not trust memory blindly when repo, files, or live system state can verify it; do not spam broad recalls for trivial self-contained prompts
+- procedure: check injected context first, then run 1-3 targeted recalls with mcp__signet__memory_search; shape recall queries as natural questions with an entity, event, and timeframe when possible; expand session lineage with mcp__signet__lcm_expand or known entities with mcp__signet__knowledge_expand and mcp__signet__knowledge_expand_session when needed
+- pitfalls: avoid bag-of-keywords queries; do not treat a missing automatic memory match as proof no prior context exists; do not trust memory blindly when repo, files, or live system state can verify it; do not spam broad recalls for trivial self-contained prompts; treat graph expansion as supporting context, not proof
 - verification: before acting, know what context you found, what remains unknown, and whether it is safe to proceed
 
 Memory tools:
@@ -691,7 +691,7 @@ function buildPromptRecallInject(metadataHeader: string, lines: ReadonlyArray<st
 		"",
 		"## Memory Check",
 		"",
-		"Use the memories below as starting context before acting. If the task depends on prior context and anything is missing, run 1-3 targeted recalls with /recall or memory_search, then expand with lcm_expand or knowledge_expand when needed.",
+		"Use the memories below as starting context before acting. If the task depends on prior context and anything is missing, run 1-3 targeted recalls with /recall or memory_search. Ask natural questions with entity + event + timeframe when possible. Avoid bag-of-keywords recall queries. Expand with lcm_expand or knowledge_expand only when you need deeper lineage or graph context. Treat graph expansion as supporting context, not proof.",
 		"",
 	];
 	if (pluginContext.trim().length > 0) {
@@ -712,7 +712,7 @@ function buildNoStrongMemoryMatchInject(metadataHeader: string, pluginContext = 
 		"",
 		"## Memory Check",
 		"",
-		"No strong automatic memory match was injected for this turn. If the request depends on prior context, preferences, project history, or unresolved work, run 1-3 targeted Signet recalls before executing commands, editing files, or making decisions.",
+		"No strong automatic memory match was injected for this turn. If the request depends on prior context, preferences, project history, or unresolved work, run 1-3 targeted Signet recalls before executing commands, editing files, or making decisions. Ask natural questions with entity + event + timeframe when possible. Avoid bag-of-keywords recall queries. Treat graph expansion as supporting context, not proof.",
 		"",
 	];
 	if (pluginContext.trim().length > 0) {


### PR DESCRIPTION
## Summary
- Add natural-language recall query guidance to Signet prompt injection for TypeScript and Rust daemons
- Warn agents away from bag-of-keywords recall queries and frame graph expansion as supporting context, not proof
- Update Hermes memory tool schemas/tests so memory_search/recall descriptions nudge entity + event + timeframe queries

## Readiness checklist
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
  - Prompt/schema copy only; no spec dependency changes required.
- [x] Agent scoping verified on all new/changed data queries
  - No new/changed data queries; guidance only.
- [x] Input/config validation and bounds checks added
  - No new inputs/config/bounds; existing hook formatting only.
- [x] Error handling and fallback paths tested (no silent swallow)
  - Existing fallback-path tests updated for new guidance text.
- [x] Security checks applied to admin/mutation endpoints
  - No admin/mutation endpoint changes.
- [x] Docs updated for API/spec/status changes
  - No public API/spec/status changes; Hermes tool schema descriptions updated.
- [x] Regression tests added for each bug fix
  - Added/updated assertions for TypeScript prompt injects and Hermes bundled plugin schema copy.
- [x] Lint/typecheck/tests pass locally
  - See Test Plan below.

## Test Plan
- `bun test platform/daemon/src/hooks.test.ts platform/daemon/src/hooks.prompt-submit.test.ts integrations/hermes-agent/connector/index.test.ts`
- `bun test platform/daemon/src/hooks.prompt-submit.test.ts --test-name-pattern 'uses configured prompt-submit embedding timeout'`
- `cargo test -p signet-daemon hooks`
