### PR TITLE
fix(memory): sanitize generated hints

### DIFF
--- a/integrations/hermes-agent/connector/hermes-plugin/__init__.py
+++ b/integrations/hermes-agent/connector/hermes-plugin/__init__.py
@@ -138,7 +138,8 @@ MEMORY_STORE_SCHEMA = {
             "hints": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "Prospective recall hints and alternate phrasings for retrieving this memory later.",
+                "minItems": 1,
+                "description": "Required agent-provided prospective recall hints and alternate phrasings for retrieving this memory later.",
             },
             "transcript": {
                 "type": "string",
@@ -166,7 +167,7 @@ MEMORY_STORE_SCHEMA = {
                 },
             },
         },
-        "required": ["content"],
+        "required": ["content", "hints"],
     },
 }
 
@@ -816,6 +817,9 @@ class SignetMemoryProvider(MemoryProvider):
             structured = store_args.get("structured")
             if not isinstance(structured, dict):
                 structured = None
+            hints = _string_list(store_args.get("hints"))
+            if not hints:
+                return json.dumps({"error": "Missing required parameter: hints"})
             result = self._client.remember(
                 content,
                 importance=importance,
@@ -823,7 +827,7 @@ class SignetMemoryProvider(MemoryProvider):
                 memory_type=str(store_args.get("type", "") or ""),
                 pinned=store_args.get("pinned") if isinstance(store_args.get("pinned"), bool) else None,
                 project=str(store_args.get("project", "") or self._project),
-                hints=_string_list(store_args.get("hints")),
+                hints=hints,
                 transcript=str(store_args.get("transcript", "") or ""),
                 structured=structured,
                 who="hermes-agent",

--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -799,12 +799,15 @@ describe("Hermes Agent bundled plugin", () => {
 		const client = readFileSync(join(import.meta.dir, "hermes-plugin", "client.py"), "utf-8");
 
 		expect(plugin).toContain('"hints"');
+		expect(plugin).toContain('"required": ["content", "hints"]');
+		expect(plugin).toContain('"minItems": 1');
 		expect(plugin).toContain('"transcript"');
 		expect(plugin).toContain('"structured"');
 		expect(plugin).toContain('"entityName"');
 		expect(plugin).toContain('"attributes"');
 		expect(plugin).toContain("Prospective recall hints");
-		expect(plugin).toContain('hints=_string_list(store_args.get("hints"))');
+		expect(plugin).toContain('hints = _string_list(store_args.get("hints"))');
+		expect(plugin).toContain('Missing required parameter: hints');
 		expect(plugin).toContain('transcript=str(store_args.get("transcript", "") or "")');
 		expect(plugin).toContain("structured=structured");
 		expect(client).toContain("hints: Optional[List[str]] = None");

--- a/platform/daemon/src/mcp/tools.test.ts
+++ b/platform/daemon/src/mcp/tools.test.ts
@@ -642,6 +642,18 @@ describe("createMcpServer", () => {
 	});
 
 	describe("memory_store", () => {
+		it("requires agent-provided prospective hints", () => {
+			const schema = getRegisteredTools(server).memory_store.inputSchema as unknown as {
+				safeParse: (value: unknown) => { success: boolean };
+			};
+
+			expect(schema.safeParse({ content: "Remember this fact" }).success).toBe(false);
+			expect(schema.safeParse({ content: "Remember this fact", hints: [] }).success).toBe(false);
+			expect(schema.safeParse({ content: "Remember this fact", hints: ["What fact should be remembered?"] }).success).toBe(
+				true,
+			);
+		});
+
 		it("calls remember endpoint", async () => {
 			const cap: { body?: string } = {};
 			mockFetch(200, { id: "abc-123", deduped: false }, cap);
@@ -649,6 +661,7 @@ describe("createMcpServer", () => {
 			const result = await callTool(server, "memory_store", {
 				content: "Remember this fact",
 				importance: 0.8,
+				hints: ["What fact should be remembered?"],
 			});
 
 			const body = JSON.parse(cap.body ?? "{}");
@@ -664,6 +677,7 @@ describe("createMcpServer", () => {
 			await callTool(server, "memory_store", {
 				content: "tagged memory",
 				tags: "foo,bar",
+				hints: ["How should tagged memory be found?"],
 			});
 
 			const body = JSON.parse(cap.body ?? "{}");
@@ -678,6 +692,7 @@ describe("createMcpServer", () => {
 			await callTool(server, "memory_store", {
 				content: "critical constraint",
 				pinned: true,
+				hints: ["What critical constraint was pinned?"],
 			});
 
 			const body = JSON.parse(cap.body ?? "{}");
@@ -726,6 +741,7 @@ describe("createMcpServer", () => {
 
 			await callTool(server, "memory_store", {
 				content: "Legacy structured tuple.",
+				hints: ["What legacy structured tuple was stored?"],
 				structured: {
 					aspects: [
 						{

--- a/platform/daemon/src/mcp/tools.ts
+++ b/platform/daemon/src/mcp/tools.ts
@@ -860,9 +860,9 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 				tags: z.string().optional().describe("Comma-separated tags for categorization"),
 				pinned: z.boolean().optional().describe("Pin this memory — prevents decay, bypasses 0.95^days aging"),
 				hints: z
-					.array(z.string())
-					.optional()
-					.describe("Prospective recall hints and alternate phrasings for retrieving this memory later"),
+					.array(z.string().trim().min(1))
+					.min(1)
+					.describe("Required agent-provided prospective recall hints and alternate phrasings for retrieving this memory later"),
 				createdAt: z
 					.string()
 					.optional()

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -640,6 +640,7 @@ describe("hybridRecall", () => {
 
 		expect(result.results[0]?.id).toBe("mem-spotify");
 		expect(result.results[0]?.source).toBe("hint");
+		expect(result.results[0]?.score).toBeLessThan(0.8);
 	});
 
 	it("uses structured path candidates when lexical recall misses a music platform", async () => {
@@ -690,6 +691,11 @@ describe("hybridRecall", () => {
 				now,
 				now,
 			);
+
+			db.prepare(
+				`INSERT INTO memory_hints (id, memory_id, agent_id, hint, created_at)
+				 VALUES (?, ?, 'default', ?, ?)`,
+			).run("hint-spotify-structured", "mem-spotify-structured", "What music streaming service has the user been using lately?", now);
 		});
 
 		const cfg = loadMemoryConfig(dir);
@@ -714,6 +720,7 @@ describe("hybridRecall", () => {
 		const hit = result.results.find((row) => row.id === "mem-spotify-structured");
 		expect(hit).toBeDefined();
 		expect(["structured", "sec"]).toContain(hit?.source);
+		expect(hit?.score).toBeGreaterThan(0.75);
 	});
 
 	it("uses structured path candidates when lexical recall misses a shampoo brand", async () => {

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -855,6 +855,11 @@ function cosineSimilarity(query: Float32Array, memory: Float32Array): number {
 // Main search orchestration
 // ---------------------------------------------------------------------------
 
+// Hints are synthetic retrieval scouts. Pure hint matches should rescue recall,
+// not outrank directly grounded lexical/vector/structured evidence. A hint
+// supported by direct evidence can keep its score; only hint-only rows are capped.
+const HINT_ONLY_SCORE_CAP = 0.75;
+
 export async function hybridRecall(
 	params: RecallParams,
 	cfg: ResolvedMemoryConfig,
@@ -1066,8 +1071,9 @@ export async function hybridRecall(
 			source = "structured";
 		}
 		if (hint > 0 && hint >= score) {
-			score = hint;
-			source = bm25 > 0 || vec > 0 ? "hybrid" : "hint";
+			const hasDirectEvidence = bm25 > 0 || vec > 0 || structured > 0;
+			score = hasDirectEvidence ? hint : Math.min(hint, HINT_ONLY_SCORE_CAP);
+			source = bm25 > 0 || vec > 0 ? "hybrid" : structured > 0 ? "sec" : "hint";
 		}
 		if (structured > 0 && structured >= score) {
 			score = structured;
@@ -1602,6 +1608,15 @@ export async function hybridRecall(
 			});
 		}
 	}
+
+	for (const row of scored) {
+		const hasDirectEvidence =
+			(bm25Map.get(row.id) ?? 0) > 0 ||
+			(vectorMap.get(row.id) ?? 0) > 0 ||
+			(structuredEvidenceMap.get(row.id) ?? 0) > 0;
+		if (row.source === "hint" && !hasDirectEvidence) row.score = Math.min(row.score, HINT_ONLY_SCORE_CAP);
+	}
+	scored.sort((a, b) => b.score - a.score);
 
 	// Over-fetch before hydration when scoped. Vector search can't
 	// pre-filter by scope, so out-of-scope IDs get dropped at

--- a/platform/daemon/src/pipeline/prospective-index.test.ts
+++ b/platform/daemon/src/pipeline/prospective-index.test.ts
@@ -198,6 +198,28 @@ function cotNoiseProvider(): LlmProvider {
 	};
 }
 
+/** Response containing prompt scaffolding that can look query-shaped. */
+function promptResidueProvider(): LlmProvider {
+	return {
+		name: "mock-prompt-residue",
+		async generate() {
+			return [
+				"Who requested: Jake",
+				"When: Apr 27",
+				"However, the problem says: 5 diverse questions or cues",
+				"But note: the fact says Jake requested this on Apr 27",
+				"Alternatively, ask about the connection",
+				"We need to be diverse and avoid repeating the same type.",
+				"When did Jake switch the iMessage agent model from GLM 5.1 to gpt-5.5?",
+				"What model did Jake request for the iMessage agent on Apr 27?",
+			].join("\n");
+		},
+		async available() {
+			return true;
+		},
+	};
+}
+
 /** Numbered list output (common LLM format). */
 function numberedProvider(): LlmProvider {
 	return {
@@ -299,6 +321,19 @@ describe("prospective-index", () => {
 				expect(h).not.toContain("Make sure");
 				expect(h).not.toContain("Now for");
 			}
+		});
+
+		it("rejects prompt residue and generic label cues", async () => {
+			const hints = await generateHints(
+				promptResidueProvider(),
+				"Jake switched the iMessage agent model from GLM 5.1 to gpt-5.5 on Apr 27.",
+				HINTS_CFG,
+			);
+
+			expect(hints).toEqual([
+				"When did Jake switch the iMessage agent model from GLM 5.1 to gpt-5.5?",
+				"What model did Jake request for the iMessage agent on Apr 27?",
+			]);
 		});
 
 		it("strips numbering and bullet prefixes", async () => {

--- a/platform/daemon/src/pipeline/prospective-index.ts
+++ b/platform/daemon/src/pipeline/prospective-index.ts
@@ -57,8 +57,28 @@ function buildPrompt(content: string, max: number): string {
 // Hint generation
 // ---------------------------------------------------------------------------
 
-/** Check if a line looks like a question or conversational cue (not CoT noise). */
+const PROMPT_RESIDUE_PATTERNS = [
+	/\bhowever\b/i,
+	/\bbut note\b/i,
+	/\balternatively\b/i,
+	/\bthe problem says\b/i,
+	/\bthe fact says\b/i,
+	/\bdiverse questions?\b/i,
+	/\bdiverse cues?\b/i,
+	/\bwe need to\b/i,
+	/\blet'?s\b/i,
+	/\bmake sure\b/i,
+];
+
+const GENERIC_LABEL_CUE_PATTERNS = [
+	/^(who requested|when|current status|what is the current status)\s*:/i,
+	/^(direct|temporal|relational|indirect|conversational)\s*:/i,
+];
+
+/** Check if a line looks like a useful question or conversational cue (not prompt residue). */
 function isHintLine(line: string): boolean {
+	if (PROMPT_RESIDUE_PATTERNS.some((pattern) => pattern.test(line))) return false;
+	if (GENERIC_LABEL_CUE_PATTERNS.some((pattern) => pattern.test(line))) return false;
 	if (line.endsWith("?")) return true;
 	// Conversational cues: "Tell me about...", "Describe...", etc.
 	if (


### PR DESCRIPTION
## Summary

Fixes a recall relevance failure where generated prospective hints could store prompt residue or overly generic cue labels, then rank as stronger evidence than direct memory matches. Also requires agent-facing memory-store tools to provide at least one prospective recall hint.

## Changes

- Filter generated prospective hints that contain prompt-scaffolding / CoT-like residue such as `However`, `But note`, `the problem says`, `the fact says`, `we need to`, and related generation-task language.
- Reject generic label cues like `Who requested: Jake` and `When: Apr 27` that act as broad search magnets instead of useful future recall questions.
- Cap pure hint-only recall scores at `0.75` so hints can rescue relevant memories, but cannot dominate direct lexical/vector/structured evidence on their own.
- Preserve structured+hint evidence as directly grounded evidence instead of treating it as pure hint-only during the cap pass.
- Require agent-provided `hints` on MCP/Hermes `memory_store`/`remember` schemas (`minItems: 1`) while leaving daemon/API and human CLI compatibility intact.
- Add regression coverage for contaminated hint generation, hint-only score capping, structured+hint cap behavior, and agent-store hint requirements.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [x] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A — daemon/connector recall + memory tool schema change.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — narrow bug fix/tool schema guardrail, no daemon persistence schema changes
- [x] Agent scoping verified on all new/changed data queries — no new data queries/scoping paths added
- [x] Input/config validation and bounds checks added — generated hints now have stricter validation; hint-only scores are bounded; agent store hints require non-empty arrays
- [x] Error handling and fallback paths tested (no silent swallow) — existing worker error tests remain covered
- [x] Security checks applied to admin/mutation endpoints — N/A, no endpoint/auth changes
- [x] Docs updated for API/spec/status changes — backlog items recorded in Obsidian; no public docs change for internal PR
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally — targeted tests, broader affected tests, diff check, and build:core passed locally

## Migration Notes (if applicable)

N/A — no database migrations touched. Existing polluted hint rows will need a separate repair/backfill cleanup if desired.

- [ ] Migration is idempotent
- [ ] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Targeted local validation:

```bash
bun test platform/daemon/src/pipeline/prospective-index.test.ts --test-name-pattern 'rejects prompt residue'
bun test platform/daemon/src/memory-search.test.ts --test-name-pattern 'uses prospective hints as their own evidence channel'
bun test platform/daemon/src/memory-search.test.ts --test-name-pattern 'uses structured path candidates when lexical recall misses a music platform'
bun test platform/daemon/src/mcp/tools.test.ts --test-name-pattern 'memory_store'
bun test integrations/hermes-agent/connector/index.test.ts --test-name-pattern 'complete Signet memory_store schema'
bun test platform/daemon/src/pipeline/prospective-index.test.ts platform/daemon/src/memory-search.test.ts platform/daemon/src/mcp/tools.test.ts integrations/hermes-agent/connector/index.test.ts
git diff --check
bun run build:core
```

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

This PR prevents new generated hint pollution, reduces hint-only over-ranking, and makes agent-written memories more retrievable by requiring explicit future-recall hints. It does not delete/regenerate existing bad hints; that should be a follow-up repair job so we can inspect/measure before destructive cleanup.
