### PR TITLE
fix(memory): align exposed memory tools with harness guidance

### DIFF
--- a/integrations/codex/connector/src/config-toml.test.ts
+++ b/integrations/codex/connector/src/config-toml.test.ts
@@ -94,7 +94,7 @@ describe("CodexConnector.install — config.toml MCP registration", () => {
 		const content = readFileSync(configPath, "utf-8");
 		expect(content).toContain("[mcp_servers.signet]");
 		expect(content).toContain("command = 'signet-mcp'");
-		expect(content).toContain("disabled_tools = ['memory_search'");
+		expect(content).not.toContain("disabled_tools");
 		// Must not be an array — Codex's Rust parser expects Option<String>
 		expect(content).not.toContain("command = [");
 	});
@@ -126,6 +126,33 @@ describe("CodexConnector.install — config.toml MCP registration", () => {
 		expect(content).toContain("enabled = true");
 		expect(content).toContain("command = 'signet-mcp'");
 		expect(content).not.toContain("command = [");
+	});
+
+	test("removes stale disabled_tools from existing signet entry on re-install", async () => {
+		writeFileSync(
+			configPath,
+			[
+				"[model]",
+				'name = "gpt-4o"',
+				"",
+				"# Signet MCP server",
+				"[mcp_servers.signet]",
+				"command = 'signet-mcp'",
+				"disabled_tools = ['memory_search', 'memory_store']",
+				"",
+				"[history]",
+				"enabled = true",
+				"",
+			].join("\n"),
+		);
+
+		await connector().install(tempHome);
+
+		const content = readFileSync(configPath, "utf-8");
+		expect(content).toContain("[model]");
+		expect(content).toContain("[history]");
+		expect(content).toContain("command = 'signet-mcp'");
+		expect(content).not.toContain("disabled_tools");
 	});
 
 	test("appends section when config exists but has no signet entry", async () => {
@@ -168,7 +195,7 @@ describe("CodexConnector.install — config.toml MCP registration", () => {
 		expect(content).toContain("url = 'http://192.168.0.60:3850/mcp'");
 		expect(content).toContain("startup_timeout_sec = 10");
 		expect(content).toContain("tool_timeout_sec = 30");
-		expect(content).toContain("disabled_tools = ['memory_search'");
+		expect(content).not.toContain("disabled_tools");
 		expect(content).not.toContain("command = 'signet-mcp'");
 	});
 
@@ -267,11 +294,11 @@ describe("buildMcpBlock — TOML quoting", () => {
 	test("produces string command, not array", () => {
 		const block = buildMcpBlock({ command: "signet-mcp", args: [] });
 		expect(block).toContain("command = 'signet-mcp'");
-		expect(block).toContain("disabled_tools = ['memory_search'");
+		expect(block).not.toContain("disabled_tools");
 		expect(block).not.toContain("command = [");
 	});
 
-	test("preserves disabled tool parity for remote HTTP MCP", () => {
+	test("uses remote HTTP MCP without disabling memory tools", () => {
 		const block = buildMcpBlock({
 			url: "https://signet.example.com:3850/mcp",
 			startupTimeoutSec: 10,
@@ -279,7 +306,7 @@ describe("buildMcpBlock — TOML quoting", () => {
 		});
 
 		expect(block).toContain("url = 'https://signet.example.com:3850/mcp'");
-		expect(block).toContain("disabled_tools = ['memory_search'");
+		expect(block).not.toContain("disabled_tools");
 	});
 
 	test("Windows paths with backslashes are quoted correctly", () => {

--- a/integrations/codex/connector/src/index.ts
+++ b/integrations/codex/connector/src/index.ts
@@ -13,16 +13,6 @@ type SignetMcpConfig =
 	| { readonly command: string; readonly args: readonly string[] }
 	| { readonly url: string; readonly startupTimeoutSec: number; readonly toolTimeoutSec: number };
 
-const CODEX_DISABLED_MCP_TOOLS = [
-	"memory_search",
-	"memory_store",
-	"memory_get",
-	"memory_list",
-	"memory_modify",
-	"memory_forget",
-	"memory_feedback",
-] as const;
-
 // ---------------------------------------------------------------------------
 // Signet command resolution
 // ---------------------------------------------------------------------------
@@ -316,7 +306,6 @@ export function buildMcpBlock(mcp: SignetMcpConfig): string {
 			`url = ${tomlQuote(mcp.url)}`,
 			`startup_timeout_sec = ${mcp.startupTimeoutSec}`,
 			`tool_timeout_sec = ${mcp.toolTimeoutSec}`,
-			`disabled_tools = ${tomlInlineArray(CODEX_DISABLED_MCP_TOOLS)}`,
 			"",
 		].join("\n");
 	}
@@ -324,7 +313,6 @@ export function buildMcpBlock(mcp: SignetMcpConfig): string {
 	if (mcp.args.length > 0) {
 		block += `args = ${tomlInlineArray(mcp.args)}\n`;
 	}
-	block += `disabled_tools = ${tomlInlineArray(CODEX_DISABLED_MCP_TOOLS)}\n`;
 	return block;
 }
 

--- a/platform/daemon/src/hooks.prompt-submit.test.ts
+++ b/platform/daemon/src/hooks.prompt-submit.test.ts
@@ -60,7 +60,7 @@ function makePendingEmbedding(): {
 	return { promise, resolve: resolveEmbedding };
 }
 
-function makeDeps(): PromptDeps {
+function makeDeps(opts: { readonly agentFeedback?: boolean } = {}): PromptDeps {
 	return {
 		logger: {
 			debug() {},
@@ -76,7 +76,7 @@ function makeDeps(): PromptDeps {
 					...cfg.pipelineV2,
 					predictorPipeline: {
 						...cfg.pipelineV2.predictorPipeline,
-						agentFeedback: false,
+						agentFeedback: opts.agentFeedback ?? false,
 					},
 					continuity: {
 						...cfg.pipelineV2.continuity,
@@ -167,6 +167,22 @@ describe("handleUserPromptSubmit observability", () => {
 		const payload = submitCalls[0]?.[2];
 		expect(payload?.engine).toBe("no-query");
 		expect(payload?.memoryCount).toBe(0);
+	});
+
+	it("uses Pi-native memory tools in no-memory prompt guidance", async () => {
+		const result = await handleUserPromptSubmit(
+			{
+				harness: "pi",
+				userMessage: "   ",
+			},
+			makeDeps(),
+		);
+
+		expect(result.inject).toContain("No strong automatic memory match was injected");
+		expect(result.inject).toContain("run 1-3 targeted Signet recalls with signet_recall");
+		expect(result.inject).toContain("save it with /remember or signet_remember");
+		expect(result.inject).not.toContain("memory_search");
+		expect(result.inject).not.toContain("memory_store");
 	});
 
 	it("removes Secrets prompt contribution when signet.secrets is disabled", async () => {
@@ -296,6 +312,89 @@ describe("handleUserPromptSubmit observability", () => {
 		expect(result.inject).toContain("Avoid bag-of-keywords recall queries");
 		expect(result.inject).toContain("Treat graph expansion as supporting context, not proof");
 		expect(result.inject).not.toContain("[signet:recall");
+	});
+
+	it("uses Pi-native memory tools when injecting prompt-submit memories", async () => {
+		hybridRecallMock.mockResolvedValueOnce({
+			results: [
+				{
+					id: "mem-pi-guidance",
+					score: 0.95,
+					content: "Pi prompt guidance should use native Signet tool names",
+					created_at: "2026-03-26T20:10:00.000Z",
+				},
+			],
+		});
+
+		const result = await handleUserPromptSubmit(
+			{
+				harness: "pi",
+				userMessage: "show pi prompt guidance behavior",
+				sessionKey: "session-pi-guidance",
+			},
+			makeDeps(),
+		);
+
+		expect(result.engine).toBe("hybrid");
+		expect(result.inject).toContain("## Relevant Memory");
+		expect(result.inject).toContain("Pi prompt guidance should use native Signet tool names");
+		expect(result.inject).toContain("run 1-3 targeted recalls with signet_recall");
+		expect(result.inject).toContain("save it with /remember or signet_remember");
+		expect(result.inject).not.toContain("memory_search");
+		expect(result.inject).not.toContain("memory_store");
+	});
+
+	it("requests feedback with the namespaced MCP tool for non-Pi harnesses", async () => {
+		hybridRecallMock.mockResolvedValueOnce({
+			results: [
+				{
+					id: "mem-feedback-codex",
+					score: 0.95,
+					content: "feedback guidance should name the Codex MCP feedback tool",
+					created_at: "2026-03-26T20:10:00.000Z",
+				},
+			],
+		});
+
+		const result = await handleUserPromptSubmit(
+			{
+				harness: "codex",
+				userMessage: "show codex feedback guidance",
+				sessionKey: "session-codex-feedback",
+			},
+			makeDeps({ agentFeedback: true }),
+		);
+
+		expect(result.inject).toContain("mcp__signet__memory_feedback");
+		expect(result.inject).toContain('Pass session_key "session-codex-feedback"');
+		expect(result.inject).not.toContain("signet_memory_feedback tool");
+	});
+
+	it("requests feedback with the Pi-native feedback tool for Pi", async () => {
+		hybridRecallMock.mockResolvedValueOnce({
+			results: [
+				{
+					id: "mem-feedback-pi",
+					score: 0.95,
+					content: "feedback guidance should name the Pi feedback tool",
+					created_at: "2026-03-26T20:10:00.000Z",
+				},
+			],
+		});
+
+		const result = await handleUserPromptSubmit(
+			{
+				harness: "pi",
+				userMessage: "show pi feedback guidance",
+				sessionKey: "session-pi-feedback",
+			},
+			makeDeps({ agentFeedback: true }),
+		);
+
+		expect(result.inject).toContain("signet_memory_feedback");
+		expect(result.inject).not.toContain("mcp__signet__memory_feedback");
+		expect(result.inject).not.toContain('Pass session_key "session-pi-feedback"');
+		expect(result.inject).not.toContain("memory_store");
 	});
 
 	it("uses prompt-submit embeddings when they return within the hook budget", async () => {

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -277,6 +277,10 @@ function harnessSupportsNamedCrossAgentTools(harness: string): boolean {
 	return harness.trim().toLowerCase() === "codex";
 }
 
+function isPiHarness(harness: string): boolean {
+	return harness.trim().toLowerCase() === "pi";
+}
+
 function sanitizePeerPromptField(value: string | undefined): string {
 	if (!value) return "";
 	return value
@@ -553,6 +557,7 @@ export function appendSynthesisIndexBlock(content: string, indexBlock: string): 
 
 function buildTranscriptFallbackResponse(
 	metadataHeader: string,
+	harness: string,
 	queryTerms: string,
 	charBudget: number,
 	hits: ReadonlyArray<{
@@ -567,7 +572,7 @@ function buildTranscriptFallbackResponse(
 		content: `- [transcript ${formatTranscriptSessionLabel(hit.sessionKey)}] ${hit.excerpt} (${formatMemoryDate(hit.updatedAt)})`,
 	}));
 	const lines = selectWithBudget(rows, charBudget).map((row) => row.content);
-	const inject = buildPromptRecallInject(metadataHeader, lines, pluginContext);
+	const inject = buildPromptRecallInject(metadataHeader, lines, harness, pluginContext);
 	return {
 		inject,
 		memoryCount: lines.length,
@@ -579,6 +584,7 @@ function buildTranscriptFallbackResponse(
 
 function buildTemporalFallbackResponse(
 	metadataHeader: string,
+	harness: string,
 	queryTerms: string,
 	charBudget: number,
 	hits: ReadonlyArray<{
@@ -594,7 +600,7 @@ function buildTemporalFallbackResponse(
 		content: `- [thread ${hit.id}] ${hit.excerpt} (${formatMemoryDate(hit.latestAt)}, ${hit.threadLabel})`,
 	}));
 	const lines = selectWithBudget(rows, charBudget).map((row) => row.content);
-	const inject = buildPromptRecallInject(metadataHeader, lines, pluginContext);
+	const inject = buildPromptRecallInject(metadataHeader, lines, harness, pluginContext);
 	return {
 		inject,
 		memoryCount: lines.length,
@@ -683,17 +689,34 @@ function buildPluginPromptContributionSection(target: PluginPromptTargetV1, log:
 	}
 }
 
-function buildPromptRecallInject(metadataHeader: string, lines: ReadonlyArray<string>, pluginContext = ""): string {
+function buildPromptRecallGuidance(harness: string): string {
+	if (isPiHarness(harness)) {
+		return "Use the memories below as starting context before acting. If the task depends on prior context and anything is missing, run 1-3 targeted recalls with signet_recall. Ask natural questions with entity + event + timeframe when possible. Avoid bag-of-keywords recall queries. Treat graph expansion as supporting context, not proof.";
+	}
+	return "Use the memories below as starting context before acting. If the task depends on prior context and anything is missing, run 1-3 targeted recalls with /recall or memory_search. Ask natural questions with entity + event + timeframe when possible. Avoid bag-of-keywords recall queries. Expand with lcm_expand or knowledge_expand only when you need deeper lineage or graph context. Treat graph expansion as supporting context, not proof.";
+}
+
+function buildNoStrongMemoryMatchGuidance(harness: string): string {
+	if (isPiHarness(harness)) {
+		return "No strong automatic memory match was injected for this turn. If the request depends on prior context, preferences, project history, or unresolved work, run 1-3 targeted Signet recalls with signet_recall before executing commands, editing files, or making decisions. Ask natural questions with entity + event + timeframe when possible. Avoid bag-of-keywords recall queries. Treat graph expansion as supporting context, not proof.";
+	}
+	return "No strong automatic memory match was injected for this turn. If the request depends on prior context, preferences, project history, or unresolved work, run 1-3 targeted Signet recalls before executing commands, editing files, or making decisions. Ask natural questions with entity + event + timeframe when possible. Avoid bag-of-keywords recall queries. Treat graph expansion as supporting context, not proof.";
+}
+
+function buildDurableSaveGuidance(harness: string): string {
+	if (isPiHarness(harness)) return "If you learn something durable, save it with /remember or signet_remember.";
+	return "If you learn something durable, save it with /remember or memory_store.";
+}
+
+function buildPromptRecallInject(
+	metadataHeader: string,
+	lines: ReadonlyArray<string>,
+	harness: string,
+	pluginContext = "",
+): string {
 	// Keep formatting behavior aligned with daemon-rs
 	// `build_prompt_recall_inject()` in `platform/daemon-rs/.../routes/hooks.rs`.
-	const parts = [
-		metadataHeader.trimEnd(),
-		"",
-		"## Memory Check",
-		"",
-		"Use the memories below as starting context before acting. If the task depends on prior context and anything is missing, run 1-3 targeted recalls with /recall or memory_search. Ask natural questions with entity + event + timeframe when possible. Avoid bag-of-keywords recall queries. Expand with lcm_expand or knowledge_expand only when you need deeper lineage or graph context. Treat graph expansion as supporting context, not proof.",
-		"",
-	];
+	const parts = [metadataHeader.trimEnd(), "", "## Memory Check", "", buildPromptRecallGuidance(harness), ""];
 	if (pluginContext.trim().length > 0) {
 		parts.push(pluginContext.trimEnd());
 		parts.push("");
@@ -702,24 +725,17 @@ function buildPromptRecallInject(metadataHeader: string, lines: ReadonlyArray<st
 	parts.push("");
 	parts.push(...lines);
 	parts.push("");
-	parts.push("If you learn something durable, save it with /remember or memory_store.");
+	parts.push(buildDurableSaveGuidance(harness));
 	return `${parts.join("\n").trimEnd()}\n`;
 }
 
-function buildNoStrongMemoryMatchInject(metadataHeader: string, pluginContext = ""): string {
-	const parts = [
-		metadataHeader.trimEnd(),
-		"",
-		"## Memory Check",
-		"",
-		"No strong automatic memory match was injected for this turn. If the request depends on prior context, preferences, project history, or unresolved work, run 1-3 targeted Signet recalls before executing commands, editing files, or making decisions. Ask natural questions with entity + event + timeframe when possible. Avoid bag-of-keywords recall queries. Treat graph expansion as supporting context, not proof.",
-		"",
-	];
+function buildNoStrongMemoryMatchInject(metadataHeader: string, harness: string, pluginContext = ""): string {
+	const parts = [metadataHeader.trimEnd(), "", "## Memory Check", "", buildNoStrongMemoryMatchGuidance(harness), ""];
 	if (pluginContext.trim().length > 0) {
 		parts.push(pluginContext.trimEnd());
 		parts.push("");
 	}
-	parts.push("If you learn something durable, save it with /remember or memory_store.");
+	parts.push(buildDurableSaveGuidance(harness));
 	return `${parts.join("\n").trimEnd()}\n`;
 }
 
@@ -2731,7 +2747,7 @@ export async function handleUserPromptSubmit(
 			userMessage,
 			start,
 			{
-				inject: buildNoStrongMemoryMatchInject(metadataHeader, pluginContext),
+				inject: buildNoStrongMemoryMatchInject(metadataHeader, req.harness, pluginContext),
 				memoryCount: 0,
 				warnings,
 			},
@@ -2746,7 +2762,7 @@ export async function handleUserPromptSubmit(
 			userMessage,
 			start,
 			{
-				inject: buildNoStrongMemoryMatchInject(metadataHeader, pluginContext),
+				inject: buildNoStrongMemoryMatchInject(metadataHeader, req.harness, pluginContext),
 				memoryCount: 0,
 				warnings,
 			},
@@ -2784,7 +2800,7 @@ export async function handleUserPromptSubmit(
 				const startEmbedding = Date.now();
 				const embedding = await fetchPromptSubmitEmbedding(deps, text, embeddingCfg, embeddingTimeoutMs);
 				const embeddingDuration = Date.now() - startEmbedding;
-				if (!embedding && embeddingDuration >= embeddingTimeoutMs) {
+				if (!embedding && embeddingDuration >= embeddingTimeoutMs - 5) {
 					embeddingTimedOut = true;
 					deps.logger.warn("hooks", "User prompt submit embedding timed out", {
 						harness: req.harness,
@@ -2830,6 +2846,7 @@ export async function handleUserPromptSubmit(
 					start,
 					buildTemporalFallbackResponse(
 						metadataHeader,
+						req.harness,
 						queryTerms,
 						injectBudget,
 						temporalHits,
@@ -2854,6 +2871,7 @@ export async function handleUserPromptSubmit(
 					start,
 					buildTranscriptFallbackResponse(
 						metadataHeader,
+						req.harness,
 						queryTerms,
 						injectBudget,
 						transcriptHits,
@@ -2869,7 +2887,7 @@ export async function handleUserPromptSubmit(
 					userMessage,
 					start,
 					{
-						inject: buildNoStrongMemoryMatchInject(metadataHeader, pluginContext),
+						inject: buildNoStrongMemoryMatchInject(metadataHeader, req.harness, pluginContext),
 						memoryCount: 0,
 						warnings,
 					},
@@ -2884,7 +2902,7 @@ export async function handleUserPromptSubmit(
 				userMessage,
 				start,
 				{
-					inject: buildNoStrongMemoryMatchInject(metadataHeader, pluginContext),
+					inject: buildNoStrongMemoryMatchInject(metadataHeader, req.harness, pluginContext),
 					memoryCount: 0,
 					warnings,
 				},
@@ -2936,7 +2954,7 @@ export async function handleUserPromptSubmit(
 				userMessage,
 				start,
 				{
-					inject: buildNoStrongMemoryMatchInject(metadataHeader, pluginContext),
+					inject: buildNoStrongMemoryMatchInject(metadataHeader, req.harness, pluginContext),
 					memoryCount: 0,
 					warnings,
 				},
@@ -2951,14 +2969,14 @@ export async function handleUserPromptSubmit(
 				`[signet:note] ${omitted} additional ${omitted === 1 ? "match was" : "matches were"} omitted to keep this lightweight (raise memory.guardrails.contextBudgetChars to include more).`,
 			);
 		}
-		let inject = buildPromptRecallInject(metadataHeader, lines, pluginContext);
+		let inject = buildPromptRecallInject(metadataHeader, lines, req.harness, pluginContext);
 
 		// Append agent feedback request if enabled and there are injected memories
 		const selectedIds = selected.map((s) => s.id);
 		if (feedbackEnabled && selectedIds.length > 0) {
-			const isPiHarness = req.harness === "pi";
-			const toolName = isPiHarness ? "signet_memory_feedback" : "mcp__signet__memory_feedback";
-			const instruction = isPiHarness
+			const pi = isPiHarness(req.harness);
+			const toolName = pi ? "signet_memory_feedback" : "mcp__signet__memory_feedback";
+			const instruction = pi
 				? `Rate injected memories using the ${toolName} tool. Pass a ratings map of memory ID to score (-1 to 1). 0=unused, 1=directly helpful, -1=harmful.`
 				: `Rate injected memories using the ${toolName} tool. Pass session_key "${req.sessionKey}" and a ratings map of memory ID to score (-1 to 1). 0=unused, 1=directly helpful, -1=harmful.`;
 			inject += `\n<memory-feedback>\n${instruction}\nIDs: ${selectedIds.join(", ")}\n</memory-feedback>`;
@@ -2992,7 +3010,11 @@ export async function handleUserPromptSubmit(
 		);
 	} catch (e) {
 		deps.logger.error("hooks", "User prompt submit failed", e as Error);
-		return { inject: buildNoStrongMemoryMatchInject(metadataHeader, pluginContext), memoryCount: 0, warnings };
+		return {
+			inject: buildNoStrongMemoryMatchInject(metadataHeader, req.harness, pluginContext),
+			memoryCount: 0,
+			warnings,
+		};
 	}
 }
 


### PR DESCRIPTION
## Summary

- stop writing Codex `disabled_tools` for the Signet MCP server so canonical memory tools are available
- repair stale Codex Signet MCP blocks that disabled memory tools during reinstall/sync
- make prompt-submit memory guidance Pi-aware so it advertises `signet_recall`, `signet_remember`, and `signet_memory_feedback`

## Root Cause

Codex config generation disabled the canonical memory MCP tools while shared hook guidance still told Codex agents to use them. Pi had the inverse mismatch: it exposes native Signet tool names, but prompt-submit guidance still referenced generic `/recall`, `memory_search`, and `memory_store`.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`
- [x] `@signet/connector-*`

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [ ] Lint/typecheck/tests pass locally

Checklist exception applied because full workspace lint/typecheck are blocked by existing repo-wide issues unrelated to this PR. Scoped validation for the changed files passes.

## Validation

- `bun test integrations/codex/connector/src/config-toml.test.ts platform/daemon/src/hooks.prompt-submit.test.ts platform/daemon/src/hooks.test.ts`
- `bunx biome check integrations/codex/connector/src/index.ts integrations/codex/connector/src/config-toml.test.ts platform/daemon/src/hooks.ts platform/daemon/src/hooks.prompt-submit.test.ts`
- `git diff --check -- integrations/codex/connector/src/index.ts integrations/codex/connector/src/config-toml.test.ts platform/daemon/src/hooks.ts platform/daemon/src/hooks.prompt-submit.test.ts`

Full workspace `bun run typecheck` is currently blocked by the existing `@signet/desktop` import resolution for `@signet/tray`. Full `bun run lint` is currently blocked by pre-existing repository-wide `package.json` formatting diagnostics.

## Rollout Note

After this lands, affected Codex installs need to rerun `signet sync` or `signet connect codex`, then start a fresh Codex session so MCP tool availability is refreshed.