### PR TITLE
docs: correct stale documentation claims

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -87,9 +87,20 @@ No authentication required. Lightweight liveness check.
   "status": "healthy",
   "uptime": 3600.5,
   "pid": 12345,
-  "version": "0.109.16",
+  "version": "0.109.x",
   "port": 3850,
-  "agentsDir": "/home/user/.agents"
+  "agentsDir": "/home/user/.agents",
+  "db": true,
+  "shuttingDown": false,
+  "updateAvailable": false,
+  "pendingRestart": false,
+  "pipeline": {
+    "extractionRunning": true,
+    "extractionStalled": false,
+    "extractionPending": 0,
+    "extractionBackoffMs": 0
+  },
+  "resources": { "...": "..." }
 }
 ```
 
@@ -105,7 +116,7 @@ silent fallback or hard-blocked extraction after boot.
 ```json
 {
   "status": "running",
-  "version": "0.109.16",
+  "version": "0.109.x",
   "pid": 12345,
   "uptime": 3600.5,
   "startedAt": "2026-02-21T10:00:00.000Z",
@@ -162,22 +173,25 @@ silent fallback or hard-blocked extraction after boot.
     "logFile": "/home/user/.agents/.daemon/logs/signet-2026-04-29.log"
   },
   "activeSessions": 1,
-  "inference": {
-    "enabled": true,
-    "source": "explicit",
-    "defaultPolicy": "auto",
-    "defaultAgentId": "default",
-    "targetCount": 4,
-    "policyCount": 2,
-    "explicit": true
-  },
+  "bypassedSessions": 1,
+  "agentCreatedAt": "2026-02-21T10:00:00.000Z",
   "health": { "score": 0.97, "status": "healthy" },
+  "update": {
+    "currentVersion": "0.109.x",
+    "latestVersion": null,
+    "updateAvailable": false,
+    "pendingRestart": null,
+    "autoInstall": false,
+    "checkInterval": 21600,
+    "lastCheckAt": null,
+    "lastError": null,
+    "timerActive": true
+  },
   "embedding": {
     "provider": "ollama",
     "model": "nomic-embed-text",
     "available": true
-  },
-  "bypassedSessions": 1
+  }
 }
 ```
 
@@ -187,11 +201,7 @@ Monitor `providerResolution.extraction.status` for `degraded` or `blocked`
 states when the configured extraction provider is unavailable at startup.
 When `pipeline.extraction.overloaded` is `true`, the extraction worker is
 intentionally backing off for `overloadBackoffMs` between polls.
-The `inference` block summarizes the shared inference control plane status.
-`source` is `explicit` when a top-level `inference:` block is present in
-`agent.yaml`, `legacy-implicit` when extraction and synthesis providers are
-compiled into the router automatically, and `disabled` when no routeable
-targets exist.
+Use `GET /api/inference/status` for the shared inference control plane status.
 
 
 ### GET /api/features
@@ -2849,10 +2859,10 @@ is passed.
 
 ```json
 {
-  "currentVersion": "0.109.16",
-  "latestVersion": "0.109.17",
+  "currentVersion": "0.109.x",
+  "latestVersion": "0.110.0",
   "updateAvailable": true,
-  "releaseUrl": "https://github.com/Signet-AI/signetai/releases/tag/v0.109.17",
+  "releaseUrl": "https://github.com/Signet-AI/signetai/releases/tag/v0.110.0",
   "releaseNotes": "...",
   "publishedAt": "2026-02-20T12:00:00Z",
   "restartRequired": false,
@@ -2922,7 +2932,7 @@ update.
   "success": true,
   "message": "Update installed. Restart daemon to apply.",
   "output": "...",
-  "installedVersion": "0.109.17",
+  "installedVersion": "0.110.0",
   "restartRequired": true
 }
 ```
@@ -3686,7 +3696,7 @@ with version and timestamp metadata.
 ```json
 {
   "meta": {
-    "version": "0.109.16",
+    "version": "0.109.x",
     "exportedAt": "2026-02-21T10:00:00.000Z",
     "entityId": "uuid"
   },

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -110,8 +110,8 @@ memory:
     enabled: true
     shadowMode: false
     extraction:
-      provider: ollama
-      model: qwen3:4b
+      provider: llama-cpp
+      model: qwen3.5:4b
     synthesis:
       enabled: true
       provider: ollama
@@ -507,8 +507,8 @@ memory:
     enabled: true
     shadowMode: true        # extract without writing — safe first step
     extraction:
-      provider: ollama
-      model: qwen3:4b
+      provider: llama-cpp
+      model: qwen3.5:4b
 ```
 
 
@@ -521,7 +521,7 @@ These top-level boolean fields gate major pipeline behaviors.
 | `enabled` | `true` | Master switch. Pipeline does nothing when false. |
 | `shadowMode` | `false` | Extract facts but skip writes. Useful for evaluation. |
 | `mutationsFrozen` | `false` | Allow reads; block all writes. Overrides `shadowMode`. |
-| `semanticContradictionEnabled` | `false` | Enable LLM-based semantic contradiction detection for UPDATE/DELETE proposals. |
+| `semanticContradictionEnabled` | `true` | Enable LLM-based semantic contradiction detection for UPDATE/DELETE proposals. |
 | `telemetryEnabled` | `false` | Enable anonymous telemetry reporting. |
 
 The relationship between `shadowMode` and `mutationsFrozen` matters:
@@ -536,8 +536,8 @@ Controls the LLM-based extraction stage. Supports multiple providers.
 
 | Field | Default | Range | Description |
 |-------|---------|-------|-------------|
-| `provider` | `"ollama"` | — | `"none"`, `"ollama"`, `"claude-code"`, `"opencode"`, `"codex"`, `"anthropic"`, `"openrouter"`, or `"command"` |
-| `model` | `"qwen3:4b"` | — | Model name for the configured provider |
+| `provider` | `"llama-cpp"` | — | `"none"`, `"llama-cpp"`, `"ollama"`, `"claude-code"`, `"opencode"`, `"codex"`, `"anthropic"`, `"openrouter"`, or `"command"` |
+| `model` | `"qwen3.5:4b"` | — | Model name for the configured provider |
 | `timeout` | `90000` | 5000-300000 ms | Extraction call timeout |
 | `minConfidence` | `0.7` | 0.0-1.0 | Confidence threshold; facts below this are dropped |
 | `structuredOutput` | `true` | — | Send JSON schema in the `format` field of LLM requests. Set `false` when the provider rejects structured output (e.g. GitHub Copilot API). The daemon also auto-detects unsupported providers at runtime and disables this transparently. |
@@ -548,6 +548,7 @@ Controls the LLM-based extraction stage. Supports multiple providers.
 
 For safety, the intended extraction setups are:
 
+- local `llama-cpp` with `qwen3.5:4b` (default)
 - `claude-code` on a Haiku model
 - `codex` on a GPT Mini model
 - local `ollama` with `nemotron-3-nano:4b` (preferred) or `qwen3:4b` (deprecated — Nemotron's superior reasoning makes Qwen3 the weaker choice going forward; expect degraded extraction quality in future updates)
@@ -654,7 +655,7 @@ handles synthesis.
 | Field | Default | Range | Description |
 |-------|---------|-------|-------------|
 | `enabled` | `true` | — | Enable background session summary generation |
-| `provider` | inherited from extraction when omitted | — | `"none"`, `"ollama"`, `"claude-code"`, `"codex"`, `"opencode"`, `"anthropic"`, or `"openrouter"` |
+| `provider` | inherited from extraction when omitted | — | `"none"`, `"llama-cpp"`, `"ollama"`, `"claude-code"`, `"codex"`, `"opencode"`, `"anthropic"`, or `"openrouter"` |
 | `model` | inherited from extraction when omitted | — | Model name for the configured provider |
 | `endpoint` | inherited from extraction when omitted | — | Optional base URL override for Ollama, OpenCode, or OpenRouter |
 | `timeout` | inherited from extraction when omitted | 5000-300000 ms | Summary generation timeout |

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -66,9 +66,9 @@ Configuration
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `SIGNET_PORT` | `3850` | HTTP server port |
-| `SIGNET_HOST` | `127.0.0.1` | Daemon host for local calls and default bind address |
-| `SIGNET_BIND` | `SIGNET_HOST` | Explicit bind address override (for example `0.0.0.0`) |
-| `SIGNET_PATH` | `$SIGNET_WORKSPACE` | Base agents directory |
+| `SIGNET_HOST` | `127.0.0.1` | Daemon host used for local calls |
+| `SIGNET_BIND` | network mode bind | Explicit bind address override; defaults to `127.0.0.1` in localhost mode and `0.0.0.0` in tailscale mode |
+| `SIGNET_PATH` | `~/.agents` | Runtime override for the agents directory |
 | `SIGNET_LOG_FILE` | — | Optional explicit log file path |
 | `SIGNET_LOG_DIR` | `$SIGNET_WORKSPACE/.daemon/logs` | Optional log directory override |
 | `SIGNET_SQLITE_PATH` | — | macOS explicit SQLite dylib override used before Bun opens the database |
@@ -84,7 +84,7 @@ When log path overrides are set:
 |------|-------------|
 | `$SIGNET_WORKSPACE/.daemon/pid` | Process ID file |
 | `$SIGNET_WORKSPACE/.daemon/logs/` | Log directory |
-| `$SIGNET_WORKSPACE/.daemon/logs/daemon-YYYY-MM-DD.log` | Daily log file |
+| `$SIGNET_WORKSPACE/.daemon/logs/signet-YYYY-MM-DD.log` | Daily log file |
 | `$SIGNET_WORKSPACE/.daemon/logs/daemon.out.log` | stdout capture |
 | `$SIGNET_WORKSPACE/.daemon/logs/daemon.err.log` | stderr capture |
 
@@ -101,10 +101,11 @@ The pipeline lives at `platform/daemon/src/pipeline/` and is managed
 by `startPipeline()` / `stopPipeline()`. Four workers run in parallel:
 
 **Extraction worker** (`worker.ts`) polls the `memory_jobs` queue for
-pending extraction jobs. Each job runs the conversation through Ollama
-(default model: `qwen3:4b`), then passes the result to the decision
-stage which decides whether to write, update, or skip. The provider
-and decision stages run outside write locks to keep contention low.
+pending extraction jobs. Each job runs the conversation through the
+configured extraction provider (default `llama-cpp` with model
+`qwen3.5:4b`), then passes the result to the decision stage which
+decides whether to write, update, or skip. The provider and decision
+stages run outside write locks to keep contention low.
 
 **Document worker** (`document-worker.ts`) polls `memory_jobs` for
 `document_ingest` jobs. It fetches remote URLs if needed, chunks the
@@ -131,10 +132,10 @@ Pipeline config modes:
 |-----------|--------|
 | `shadowMode` | Extract memories but do not write them |
 | `mutationsFrozen` | Read-only; no writes at all |
-| `graphEnabled` | Enable knowledge graph traversal on recall |
-| `autonomousEnabled` | Allow the maintenance worker to run repairs |
-| `autonomousFrozen` | Pause autonomous repairs without disabling |
-| `maintenanceMode` | `"observe"` (log only) or `"execute"` (act) |
+| `graph.enabled` | Enable knowledge graph traversal on recall |
+| `autonomous.enabled` | Allow the maintenance worker to run repairs |
+| `autonomous.frozen` | Pause autonomous repairs without disabling |
+| `autonomous.maintenanceMode` | `"observe"` (log only) or `"execute"` (act) |
 
 ### Session Tracker
 
@@ -250,9 +251,20 @@ GET /health
   "status": "healthy",
   "uptime": 3600,
   "pid": 12345,
-  "version": "0.1.0",
+  "version": "0.109.x",
   "port": 3850,
-  "agentsDir": "/home/user/.agents"
+  "agentsDir": "/home/user/.agents",
+  "db": true,
+  "shuttingDown": false,
+  "updateAvailable": false,
+  "pendingRestart": false,
+  "pipeline": {
+    "extractionRunning": true,
+    "extractionStalled": false,
+    "extractionPending": 0,
+    "extractionBackoffMs": 0
+  },
+  "resources": { "...": "..." }
 }
 ```
 
@@ -265,14 +277,28 @@ GET /api/status
 ```json
 {
   "status": "running",
-  "version": "0.1.0",
+  "version": "0.109.x",
   "pid": 12345,
   "uptime": 3600,
   "startedAt": "2025-02-17T16:00:00.000Z",
   "port": 3850,
-  "host": "localhost",
+  "host": "127.0.0.1",
+  "bindHost": "127.0.0.1",
+  "networkMode": "localhost",
   "agentsDir": "/home/user/.agents",
-  "memoryDb": true
+  "memoryDb": true,
+  "pipelineV2": { "...": "..." },
+  "pipeline": { "extraction": { "...": "..." } },
+  "providerResolution": { "extraction": { "...": "..." } },
+  "logging": {
+    "logDir": "/home/user/.agents/.daemon/logs",
+    "logFile": "/home/user/.agents/.daemon/logs/signet-2026-04-29.log"
+  },
+  "activeSessions": 0,
+  "bypassedSessions": 0,
+  "agentCreatedAt": "2025-02-17T16:00:00.000Z",
+  "update": { "...": "..." },
+  "embedding": { "...": "..." }
 }
 ```
 
@@ -328,9 +354,9 @@ Security
 
 ### Network Binding
 
-The daemon binds to `localhost` by default and is not reachable from
-other machines. Set `SIGNET_HOST` to expose it on a broader interface,
-but pair that with auth mode `team` or `hybrid`.
+The daemon binds to loopback by default and is not reachable from
+other machines. Set `network.mode: tailscale` or `SIGNET_BIND` to expose it
+on a broader interface, but pair that with auth mode `team` or `hybrid`.
 
 ### Auth Modes
 
@@ -349,7 +375,7 @@ Logging
 -------
 
 Logs are written to the console and to a daily file at
-`$SIGNET_WORKSPACE/.daemon/logs/daemon-YYYY-MM-DD.log` by default. When
+`$SIGNET_WORKSPACE/.daemon/logs/signet-YYYY-MM-DD.log` by default. When
 `SIGNET_LOG_FILE` is set, logs are written to that exact file.
 When `SIGNET_LOG_DIR` is set (and `SIGNET_LOG_FILE` is unset), daily
 logs are written under `$SIGNET_LOG_DIR/`.

--- a/surfaces/dashboard/README.md
+++ b/surfaces/dashboard/README.md
@@ -1,42 +1,46 @@
-# sv
+# Signet Dashboard
 
-Everything you need to build a Svelte project, powered by [`sv`](https://github.com/sveltejs/cli).
+Svelte 5 + Vite dashboard bundled with the Signet daemon. The production build
+is static and served by `@signet/daemon` at `http://localhost:3850`.
 
-## Creating a project
+## Development
 
-If you're seeing this, you've probably already done this step. Congrats!
-
-```sh
-# create a new project
-npx sv create my-app
-```
-
-To recreate this project with the same configuration:
+Install dashboard dependencies from this package directory:
 
 ```sh
-# recreate this project
-npx sv create --template minimal --types ts --no-install .
+bun install
 ```
 
-## Developing
-
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+Run the Vite development server:
 
 ```sh
-npm run dev
-
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
+bun run dev
 ```
 
-## Building
-
-To create a production version of your app:
+The dev server proxies `/api`, `/health`, and `/memory` requests to the local
+daemon on port 3850, so start the daemon separately when testing live data:
 
 ```sh
-npm run build
+signet daemon start
 ```
 
-You can preview the production build with `npm run preview`.
+## Build
 
-> To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+```sh
+bun run build
+```
+
+The root workspace also builds the dashboard through:
+
+```sh
+bun run build:dashboard
+```
+
+## Check
+
+```sh
+bun run check
+```
+
+This runs `svelte-kit sync` and `svelte-check` with the local
+`tsconfig.json`.


### PR DESCRIPTION
Changed:

API.md: fixed /health, /api/status, update, and timeline examples.
CONFIGURATION.md: corrected pipeline defaults.
DAEMON.md: corrected bind/log/status/default provider claims.
README.md: replaced the stock Svelte README.