### PR TITLE
fix(sources): surface Obsidian indexing status

### DIFF
--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -35,9 +35,12 @@ Obsidian Sources v1 indexes Markdown files below a vault root:
 
 ```bash
 signet sources add obsidian /path/to/ObsidianVault --name "Research Vault"
+signet sources add obsidian /path/to/ObsidianVault --exclude "private/**" --exclude "*.tmp"
 signet sources list
 signet sources remove obsidian:...
 ```
+
+By default, Obsidian sources ignore Obsidian internals, trash, Hermes metadata, hidden dot-folders, and hidden files. Add more ignore globs from the dashboard connect form or repeat `--exclude` in the CLI when a vault contains tool folders or file types that should stay outside source recall.
 
 The dashboard also includes a Sources browser for connecting and removing knowledge bases. In the desktop app, **Browse** opens the native folder picker. In browser/dev mode, Signet tries a daemon-backed OS picker and falls back to asking you to paste the path if no picker is available.
 

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -203,6 +203,7 @@ export type {
 } from "./workspace-source-repo";
 export {
 	addObsidianSource,
+	DEFAULT_OBSIDIAN_EXCLUDE_GLOBS,
 	getAgentsDir,
 	getSourcesConfigPath,
 	loadSourcesConfig,

--- a/platform/core/src/sources-config.test.ts
+++ b/platform/core/src/sources-config.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+	DEFAULT_OBSIDIAN_EXCLUDE_GLOBS,
 	addObsidianSource,
 	getSourcesConfigPath,
 	loadSourcesConfig,
@@ -44,6 +45,18 @@ describe("sources-config", () => {
 		expect(config.sources).toHaveLength(1);
 		expect(config.sources[0]?.root).toBe(vault);
 		expect(JSON.parse(readFileSync(getSourcesConfigPath(agentsDir), "utf8")).sources[0].mode).toBe("read-only");
+	});
+
+	it("merges custom Obsidian excludes with default privacy excludes", () => {
+		const agentsDir = tmp();
+		const vault = join(agentsDir, "vault");
+		mkdirSync(vault, { recursive: true });
+
+		const result = addObsidianSource({ root: vault, excludeGlobs: ["private/**", "**/.obsidian/**"] }, agentsDir);
+
+		expect(result.ok).toBe(true);
+		if (result.ok === false) throw new Error(result.error);
+		expect(result.source.excludeGlobs).toEqual([...DEFAULT_OBSIDIAN_EXCLUDE_GLOBS, "private/**"]);
 	});
 
 	it("updates an existing Obsidian source instead of duplicating it", () => {

--- a/platform/core/src/sources-config.ts
+++ b/platform/core/src/sources-config.ts
@@ -16,7 +16,16 @@ export interface SignetSourceEntry {
 	readonly createdAt: string;
 	readonly updatedAt: string;
 	readonly lastIndexedAt?: string;
+	readonly excludeGlobs?: readonly string[];
 }
+
+export const DEFAULT_OBSIDIAN_EXCLUDE_GLOBS = [
+	"**/.obsidian/**",
+	"**/.trash/**",
+	"**/.hermes/**",
+	"**/.*/**",
+	"**/.*",
+] as const;
 
 export interface SignetSourcesConfig {
 	readonly version: 1;
@@ -26,6 +35,7 @@ export interface SignetSourcesConfig {
 export interface AddObsidianSourceInput {
 	readonly root: string;
 	readonly name?: string;
+	readonly excludeGlobs?: readonly string[];
 	readonly now?: string;
 }
 
@@ -119,7 +129,14 @@ function addObsidianSourceChecked(input: AddObsidianSourceInput, agentsDir = get
 	const cfg = loadSourcesConfigForWrite(agentsDir);
 	const existing = cfg.sources.find((source) => source.kind === "obsidian" && source.root === root);
 	if (existing) {
-		const updated = { ...existing, name: cleanName(input.name) ?? existing.name, enabled: true, updatedAt: now };
+		const updated = {
+			...existing,
+			name: cleanName(input.name) ?? existing.name,
+			excludeGlobs: cleanExcludeGlobs(input.excludeGlobs) ??
+				existing.excludeGlobs ?? [...DEFAULT_OBSIDIAN_EXCLUDE_GLOBS],
+			enabled: true,
+			updatedAt: now,
+		};
 		saveSourcesConfig(
 			{
 				version: SOURCES_CONFIG_VERSION,
@@ -139,6 +156,7 @@ function addObsidianSourceChecked(input: AddObsidianSourceInput, agentsDir = get
 		mode: "read-only",
 		createdAt: now,
 		updatedAt: now,
+		excludeGlobs: cleanExcludeGlobs(input.excludeGlobs) ?? [...DEFAULT_OBSIDIAN_EXCLUDE_GLOBS],
 	};
 	saveSourcesConfig({ version: SOURCES_CONFIG_VERSION, sources: [...cfg.sources, source] }, agentsDir);
 	return { ok: true, source, created: true };
@@ -234,6 +252,12 @@ function cleanName(value: string | undefined): string | null {
 	return trimmed && trimmed.length > 0 ? trimmed : null;
 }
 
+function cleanExcludeGlobs(values: readonly string[] | undefined): readonly string[] | null {
+	if (!values) return null;
+	const cleaned = Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
+	return cleaned.length > 0 ? cleaned : [];
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -249,6 +273,8 @@ function isSourceEntry(value: unknown): value is SignetSourceEntry {
 		value.mode === "read-only" &&
 		typeof value.createdAt === "string" &&
 		typeof value.updatedAt === "string" &&
-		(value.lastIndexedAt === undefined || typeof value.lastIndexedAt === "string")
+		(value.lastIndexedAt === undefined || typeof value.lastIndexedAt === "string") &&
+		(value.excludeGlobs === undefined ||
+			(Array.isArray(value.excludeGlobs) && value.excludeGlobs.every((entry) => typeof entry === "string")))
 	);
 }

--- a/platform/core/src/sources-config.ts
+++ b/platform/core/src/sources-config.ts
@@ -132,8 +132,9 @@ function addObsidianSourceChecked(input: AddObsidianSourceInput, agentsDir = get
 		const updated = {
 			...existing,
 			name: cleanName(input.name) ?? existing.name,
-			excludeGlobs: cleanExcludeGlobs(input.excludeGlobs) ??
-				existing.excludeGlobs ?? [...DEFAULT_OBSIDIAN_EXCLUDE_GLOBS],
+			excludeGlobs: input.excludeGlobs
+				? mergeDefaultObsidianExcludeGlobs(input.excludeGlobs)
+				: (existing.excludeGlobs ?? [...DEFAULT_OBSIDIAN_EXCLUDE_GLOBS]),
 			enabled: true,
 			updatedAt: now,
 		};
@@ -156,7 +157,7 @@ function addObsidianSourceChecked(input: AddObsidianSourceInput, agentsDir = get
 		mode: "read-only",
 		createdAt: now,
 		updatedAt: now,
-		excludeGlobs: cleanExcludeGlobs(input.excludeGlobs) ?? [...DEFAULT_OBSIDIAN_EXCLUDE_GLOBS],
+		excludeGlobs: mergeDefaultObsidianExcludeGlobs(input.excludeGlobs),
 	};
 	saveSourcesConfig({ version: SOURCES_CONFIG_VERSION, sources: [...cfg.sources, source] }, agentsDir);
 	return { ok: true, source, created: true };
@@ -256,6 +257,12 @@ function cleanExcludeGlobs(values: readonly string[] | undefined): readonly stri
 	if (!values) return null;
 	const cleaned = Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
 	return cleaned.length > 0 ? cleaned : [];
+}
+
+function mergeDefaultObsidianExcludeGlobs(values: readonly string[] | undefined): readonly string[] {
+	return [...DEFAULT_OBSIDIAN_EXCLUDE_GLOBS, ...(cleanExcludeGlobs(values) ?? [])].filter(
+		(value, index, all) => all.indexOf(value) === index,
+	);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/platform/daemon/src/native-memory-sources.test.ts
+++ b/platform/daemon/src/native-memory-sources.test.ts
@@ -428,11 +428,11 @@ describe("native memory sources", () => {
 
 	it("indexes Obsidian markdown as read-only source artifacts", async () => {
 		const root = join(dir, "vault");
-		const file = join(root, "permanent", "Signet.md");
 		mkdirSync(join(root, "permanent"), { recursive: true });
-		writeFileSync(file, "# Signet\n\nSignet Sources preserves native Obsidian graph context.\n");
+		const file = join(root, "permanent", "Signet.md");
+		writeFileSync(file, "# Signet\n\nObsidian source knowledge base note.\n");
 
-		expect(await indexNativeMemoryFile(obsidianNativeMemorySource(root, "Research Vault"), file)).toBe(true);
+		expect(await indexNativeMemoryFile(obsidianNativeMemorySource(root), file, "agent-obsidian")).toBe(true);
 
 		const row = getDbAccessor().withReadDb(
 			(db) =>
@@ -446,7 +446,26 @@ describe("native memory sources", () => {
 		expect(row.source_path).toBe(file);
 		expect(row.source_kind).toBe("source_obsidian_markdown");
 		expect(row.harness).toBe("obsidian");
-		expect(row.content).toContain("native Obsidian graph context");
+		expect(row.content).toContain("Obsidian source knowledge base note");
+	});
+
+	it("skips hidden Obsidian vault directories by default", async () => {
+		const root = join(dir, "vault");
+		mkdirSync(join(root, ".claude"), { recursive: true });
+		const file = join(root, ".claude", "CLAUDE.md");
+		writeFileSync(file, "# Hidden agent prompt\n\nThis should stay out of source recall by default.\n");
+
+		expect(await indexNativeMemoryFile(obsidianNativeMemorySource(root), file, "agent-obsidian")).toBe(false);
+	});
+
+	it("honors custom Obsidian exclude globs", async () => {
+		const root = join(dir, "vault");
+		mkdirSync(join(root, "private"), { recursive: true });
+		const file = join(root, "private", "Secret.md");
+		writeFileSync(file, "# Private\n\nThis folder is excluded by user glob.\n");
+
+		const source = obsidianNativeMemorySource(root, "Vault", "obsidian:test", ["private/**"]);
+		expect(await indexNativeMemoryFile(source, file, "agent-obsidian")).toBe(false);
 	});
 
 	it("removes Obsidian graph rows when a source markdown file disappears", async () => {

--- a/platform/daemon/src/native-memory-sources.test.ts
+++ b/platform/daemon/src/native-memory-sources.test.ts
@@ -635,6 +635,92 @@ describe("native memory sources", () => {
 		expect(remaining.count).toBe(0);
 	});
 
+	it("purges previously indexed Obsidian files that become excluded after restart", async () => {
+		const root = join(dir, "vault");
+		const privateFile = join(root, "private", "Secret.md");
+		mkdirSync(join(root, "private"), { recursive: true });
+		writeFileSync(
+			privateFile,
+			"# Secret\n\nPreviously indexed private source content with enough text for source chunk embeddings.\n",
+		);
+		const addedInitial = addObsidianSource({ root, name: "Exclude Vault", excludeGlobs: [] }, dir);
+		expect(addedInitial.ok).toBe(true);
+		if (addedInitial.ok === false) throw new Error(addedInitial.error);
+		const sourceId = addedInitial.source.id;
+		const initialSource = obsidianNativeMemorySource(root, "Exclude Vault", sourceId, []);
+
+		expect(
+			await indexNativeMemoryFile(initialSource, privateFile, "agent-native", {
+				embeddingConfig: { provider: "native", model: "test", dimensions: 3, base_url: "" },
+				fetchEmbedding: async () => [1, 2, 3],
+			}),
+		).toBe(true);
+
+		const before = getDbAccessor().withReadDb((db) => ({
+			artifacts: (
+				db
+					.prepare(
+						"SELECT COUNT(*) AS count FROM memory_artifacts WHERE agent_id = ? AND source_path = ? AND COALESCE(is_deleted, 0) = 0",
+					)
+					.get("agent-native", privateFile) as { count: number }
+			).count,
+			chunks: (
+				db
+					.prepare(
+						"SELECT COUNT(*) AS count FROM embeddings WHERE agent_id = ? AND source_type = 'source_obsidian_chunk' AND source_id >= ? AND source_id < ?",
+					)
+					.get("agent-native", `${sourceId}:`, `${sourceId}:\uffff`) as { count: number }
+			).count,
+			entities: (
+				db
+					.prepare("SELECT COUNT(*) AS count FROM entities WHERE agent_id = ? AND source_path = ?")
+					.get("agent-native", privateFile) as { count: number }
+			).count,
+		}));
+		expect(before.artifacts).toBe(1);
+		expect(before.chunks).toBeGreaterThan(0);
+		expect(before.entities).toBeGreaterThan(0);
+
+		const added = addObsidianSource({ root, name: "Exclude Vault", excludeGlobs: ["private/**"] }, dir);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+
+		const handle = startNativeMemoryBridge([codexNativeMemorySource(join(dir, ".codex"))], {
+			agentId: "agent-native",
+			agentsDir: dir,
+			includeConfiguredSources: true,
+			pollIntervalMs: 0,
+		});
+		try {
+			expect(await handle.syncExisting()).toBe(0);
+		} finally {
+			await handle.close();
+		}
+
+		const after = getDbAccessor().withReadDb((db) => ({
+			artifacts: (
+				db
+					.prepare(
+						"SELECT COUNT(*) AS count FROM memory_artifacts WHERE agent_id = ? AND source_path = ? AND COALESCE(is_deleted, 0) = 0",
+					)
+					.get("agent-native", privateFile) as { count: number }
+			).count,
+			chunks: (
+				db
+					.prepare(
+						"SELECT COUNT(*) AS count FROM embeddings WHERE agent_id = ? AND source_type = 'source_obsidian_chunk' AND source_id >= ? AND source_id < ?",
+					)
+					.get("agent-native", `${sourceId}:`, `${sourceId}:\uffff`) as { count: number }
+			).count,
+			entities: (
+				db
+					.prepare("SELECT COUNT(*) AS count FROM entities WHERE agent_id = ? AND source_path = ?")
+					.get("agent-native", privateFile) as { count: number }
+			).count,
+		}));
+		expect(after).toEqual({ artifacts: 0, chunks: 0, entities: 0 });
+	});
+
 	it("does not mark a configured Obsidian source indexed when the root is missing", async () => {
 		const root = join(dir, "missing-vault");
 		mkdirSync(root, { recursive: true });

--- a/platform/daemon/src/native-memory-sources.test.ts
+++ b/platform/daemon/src/native-memory-sources.test.ts
@@ -468,6 +468,16 @@ describe("native memory sources", () => {
 		expect(await indexNativeMemoryFile(source, file, "agent-obsidian")).toBe(false);
 	});
 
+	it("treats bare Obsidian exclude globs as vault-wide filename patterns", async () => {
+		const root = join(dir, "vault");
+		mkdirSync(join(root, "nested"), { recursive: true });
+		const nestedFile = join(root, "nested", "Draft.tmp.md");
+		writeFileSync(nestedFile, "# Draft\n\nThis nested file should be excluded by a bare filename glob.\n");
+
+		const source = obsidianNativeMemorySource(root, "Vault", "obsidian:test", ["*.tmp.md"]);
+		expect(await indexNativeMemoryFile(source, nestedFile, "agent-obsidian")).toBe(false);
+	});
+
 	it("removes Obsidian graph rows when a source markdown file disappears", async () => {
 		const root = join(dir, "vault");
 		const source = obsidianNativeMemorySource(root, "Research Vault", "obsidian:remove-file-vault");

--- a/platform/daemon/src/native-memory-sources.test.ts
+++ b/platform/daemon/src/native-memory-sources.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { addObsidianSource } from "@signet/core";
+import { addObsidianSource, loadSourcesConfig } from "@signet/core";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import {
 	claudeCodeNativeMemorySource,
@@ -633,6 +633,28 @@ describe("native memory sources", () => {
 					.get(`${root.replace(/\\/g, "/")}/%`) as { count: number },
 		);
 		expect(remaining.count).toBe(0);
+	});
+
+	it("does not mark a configured Obsidian source indexed when the root is missing", async () => {
+		const root = join(dir, "missing-vault");
+		mkdirSync(root, { recursive: true });
+		const added = addObsidianSource({ root, name: "Missing Vault" }, dir);
+		expect(added.ok).toBe(true);
+		rmSync(root, { recursive: true, force: true });
+
+		const handle = startNativeMemoryBridge([codexNativeMemorySource(join(dir, ".codex"))], {
+			agentId: "agent-native",
+			agentsDir: dir,
+			includeConfiguredSources: true,
+			pollIntervalMs: 0,
+		});
+		try {
+			expect(await handle.syncExisting()).toBe(0);
+			const stored = loadSourcesConfig(dir).sources.find((source) => source.root === root);
+			expect(stored?.lastIndexedAt).toBeUndefined();
+		} finally {
+			await handle.close();
+		}
 	});
 
 	it("reloads configured Obsidian sources on each sync and updates them in place", async () => {

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -404,7 +404,8 @@ export function startNativeMemoryBridge(
 		for (const source of activeBridgeSources(sources, options)) {
 			const key = sourceStateKey(source, agentId);
 			const current = new Set<string>();
-			if (existsSync(source.root)) {
+			const rootExists = existsSync(source.root);
+			if (rootExists) {
 				for await (const file of walkMarkdownFiles(source.root)) {
 					if (!matchesPattern(source, file)) continue;
 					current.add(file);
@@ -419,7 +420,7 @@ export function startNativeMemoryBridge(
 				}
 			}
 			known.set(key, current);
-			if (source.sourceId) markSourceIndexed(source.sourceId, undefined, options.agentsDir);
+			if (rootExists && source.sourceId) markSourceIndexed(source.sourceId, undefined, options.agentsDir);
 		}
 		return count;
 	};

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -226,6 +226,42 @@ function nativeArtifactRowExists(filePath: string, agentId: string): boolean {
 	}
 }
 
+function activeNativeArtifactPaths(source: NativeMemorySource, agentId: string): string[] {
+	const normalizedRoot = resolve(source.root).replace(/\\/g, "/").replace(/\/$/, "");
+	const rootPrefix = `${normalizedRoot}/`;
+	try {
+		return getDbAccessor().withReadDb((db) => {
+			const rows = db
+				.prepare(
+					`SELECT source_path FROM memory_artifacts
+					 WHERE agent_id = ?
+					   AND harness = ?
+					   AND source_path >= ?
+					   AND source_path < ?
+					   AND source_kind IN (${source.files.map(() => "?").join(", ")})
+					   AND COALESCE(is_deleted, 0) = 0`,
+				)
+				.all(
+					agentId,
+					source.harness,
+					rootPrefix,
+					prefixUpperBound(rootPrefix),
+					...source.files.map((file) => file.kind),
+				) as Array<{
+				source_path: string;
+			}>;
+			return rows.map((row) => row.source_path);
+		});
+	} catch (err) {
+		logger.warn("watcher", "Failed listing active native memory artifacts", {
+			harness: source.harness,
+			root: source.root,
+			error: err instanceof Error ? err.message : String(err),
+		});
+		return [];
+	}
+}
+
 export async function indexNativeMemoryFile(
 	source: NativeMemorySource,
 	filePath: string,
@@ -411,6 +447,10 @@ export function startNativeMemoryBridge(
 					current.add(file);
 					if (await indexNativeMemoryFile(source, file, agentId, options)) count++;
 					await yielder();
+				}
+				const currentPaths = new Set([...current].map((file) => file.replace(/\\/g, "/")));
+				for (const file of activeNativeArtifactPaths(source, agentId)) {
+					if (!currentPaths.has(file.replace(/\\/g, "/"))) removeNativeMemoryFile(source, file, agentId);
 				}
 			}
 			const previous = known.get(key);

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, join, resolve } from "node:path";
-import { loadSourcesConfig } from "@signet/core";
+import { DEFAULT_OBSIDIAN_EXCLUDE_GLOBS, loadSourcesConfig, markSourceIndexed } from "@signet/core";
 import { resolveDaemonAgentId } from "./agent-id";
 import { yieldEvery } from "./async-yield";
 import { getDbAccessor } from "./db-accessor";
@@ -103,6 +103,7 @@ export function obsidianNativeMemorySource(
 	root: string,
 	displayName = "Obsidian",
 	sourceId = sourceIdForObsidianRoot(root),
+	excludeGlobs: readonly string[] = DEFAULT_OBSIDIAN_EXCLUDE_GLOBS,
 ): NativeMemorySource {
 	return {
 		harness: "obsidian",
@@ -113,8 +114,7 @@ export function obsidianNativeMemorySource(
 			{
 				glob: "**/*.md",
 				kind: "source_obsidian_markdown",
-				include: (_path, rel) =>
-					!rel.split("/").some((part) => part === ".obsidian" || part === ".trash" || part === ".hermes"),
+				include: (_path, rel) => !isExcludedByGlobs(rel, excludeGlobs),
 			},
 		],
 	};
@@ -123,7 +123,7 @@ export function obsidianNativeMemorySource(
 export function configuredNativeMemorySources(agentsDir?: string): NativeMemorySource[] {
 	const configured = loadSourcesConfig(agentsDir)
 		.sources.filter((source) => source.enabled && source.kind === "obsidian")
-		.map((source) => obsidianNativeMemorySource(source.root, source.name, source.id));
+		.map((source) => obsidianNativeMemorySource(source.root, source.name, source.id, source.excludeGlobs));
 	return [codexNativeMemorySource(), claudeCodeNativeMemorySource(), ...configured];
 }
 
@@ -153,6 +153,11 @@ function matchesPattern(source: NativeMemorySource, filePath: string): NativeMem
 
 function matchesGlob(glob: string, rel: string): boolean {
 	return matchGlobParts(glob.split("/"), rel.split("/"));
+}
+
+function isExcludedByGlobs(rel: string, excludeGlobs: readonly string[]): boolean {
+	const normalized = rel.replace(/\\/g, "/").replace(/^\.\//, "");
+	return excludeGlobs.some((glob) => matchesGlob(glob.replace(/\\/g, "/"), normalized));
 }
 
 function matchGlobParts(globParts: readonly string[], relParts: readonly string[]): boolean {
@@ -185,7 +190,7 @@ function activeBridgeSources(
 	if (!options.includeConfiguredSources) return [...baseSources];
 	const configured = loadSourcesConfig(options.agentsDir)
 		.sources.filter((source) => source.enabled && source.kind === "obsidian")
-		.map((source) => obsidianNativeMemorySource(source.root, source.name, source.id));
+		.map((source) => obsidianNativeMemorySource(source.root, source.name, source.id, source.excludeGlobs));
 	const byKey = new Map<string, NativeMemorySource>();
 	for (const source of [...baseSources, ...configured]) {
 		byKey.set(source.sourceId ?? `${source.harness}:${source.root}`, source);
@@ -414,6 +419,7 @@ export function startNativeMemoryBridge(
 				}
 			}
 			known.set(key, current);
+			if (source.sourceId) markSourceIndexed(source.sourceId, undefined, options.agentsDir);
 		}
 		return count;
 	};

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -157,7 +157,11 @@ function matchesGlob(glob: string, rel: string): boolean {
 
 function isExcludedByGlobs(rel: string, excludeGlobs: readonly string[]): boolean {
 	const normalized = rel.replace(/\\/g, "/").replace(/^\.\//, "");
-	return excludeGlobs.some((glob) => matchesGlob(glob.replace(/\\/g, "/"), normalized));
+	return excludeGlobs.some((glob) => {
+		const normalizedGlob = glob.replace(/\\/g, "/").replace(/^\.\//, "");
+		const vaultWideGlob = normalizedGlob.includes("/") ? normalizedGlob : `**/${normalizedGlob}`;
+		return matchesGlob(vaultWideGlob, normalized);
+	});
 }
 
 function matchGlobParts(globParts: readonly string[], relParts: readonly string[]): boolean {

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -2,8 +2,9 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadSourcesConfig } from "@signet/core";
+import { addObsidianSource, loadSourcesConfig } from "@signet/core";
 import { Hono } from "hono";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
 import { loadMemoryConfig } from "../memory-config";
 import type { NativeMemoryBridgeHandle, NativeMemorySource } from "../native-memory-sources";
 import { registerSourcesRoutes } from "./sources-routes";
@@ -12,6 +13,7 @@ describe("Sources routes", () => {
 	let dir = "";
 	let vault = "";
 	let previousSignetPath: string | undefined;
+	let previousSignetAgentId: string | undefined;
 
 	beforeEach(() => {
 		dir = mkdtempSync(join(tmpdir(), "signet-sources-routes-"));
@@ -19,12 +21,19 @@ describe("Sources routes", () => {
 		mkdirSync(join(vault, "permanent"), { recursive: true });
 		writeFileSync(join(vault, "permanent", "Note.md"), "# Note\n\nRoute test source note.");
 		previousSignetPath = process.env.SIGNET_PATH;
+		previousSignetAgentId = process.env.SIGNET_AGENT_ID;
 		process.env.SIGNET_PATH = dir;
+		Reflect.deleteProperty(process.env, "SIGNET_AGENT_ID");
+		mkdirSync(join(dir, "memory"), { recursive: true });
+		initDbAccessor(join(dir, "memory", "memories.db"));
 	});
 
 	afterEach(() => {
+		closeDbAccessor();
 		if (previousSignetPath === undefined) Reflect.deleteProperty(process.env, "SIGNET_PATH");
 		else process.env.SIGNET_PATH = previousSignetPath;
+		if (previousSignetAgentId === undefined) Reflect.deleteProperty(process.env, "SIGNET_AGENT_ID");
+		else process.env.SIGNET_AGENT_ID = previousSignetAgentId;
 		rmSync(dir, { recursive: true, force: true });
 	});
 
@@ -72,6 +81,53 @@ describe("Sources routes", () => {
 		const stored = loadSourcesConfig(dir).sources[0];
 		expect(stored?.id).toBe(body.source.id);
 		expect(stored?.lastIndexedAt).toBeTruthy();
+	});
+
+	it("reports source chunk stats using source-owned chunk id prefixes", async () => {
+		const added = addObsidianSource({ root: vault, name: "Stats Vault" }, dir);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memory_artifacts
+				 (agent_id, source_path, source_sha256, source_kind, session_id, session_token, harness, captured_at, content, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			).run(
+				"default",
+				join(vault, "permanent", "Note.md"),
+				"sha",
+				"source_obsidian_markdown",
+				"session",
+				"token",
+				"obsidian",
+				"2026-01-01T00:00:00.000Z",
+				"# Note",
+				"2026-01-01T00:00:00.000Z",
+			);
+			db.prepare(
+				`INSERT INTO embeddings
+				 (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			).run(
+				"chunk-1",
+				"chunk-hash-1",
+				new Uint8Array([0]),
+				1,
+				"source_obsidian_chunk",
+				`${added.source.id}:permanent/Note.md#overview:1-3:0`,
+				"source chunk",
+				"2026-01-01T00:00:00.000Z",
+				"default",
+			);
+		});
+
+		const res = await makeApp().request("/api/sources");
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			sources: Array<{ stats?: { artifacts: number; chunks: number; indexed: number } }>;
+		};
+		expect(body.sources[0]?.stats).toEqual({ artifacts: 1, chunks: 1, indexed: 1 });
 	});
 
 	it("disconnects a source, removes config, and returns purge count", async () => {

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -138,6 +138,7 @@ interface SourceStats {
 function sourceStats(source: SignetSourceEntry, agentId: string): SourceStats {
 	if (source.kind !== "obsidian") return { artifacts: 0, chunks: 0, indexed: 0 };
 	const rootPrefix = `${source.root.replace(/\\/g, "/").replace(/\/$/, "")}/`;
+	const chunkPrefix = `${source.id}:`;
 	try {
 		return getDbAccessor().withReadDb((db) => {
 			const artifacts = countRow(
@@ -150,9 +151,9 @@ function sourceStats(source: SignetSourceEntry, agentId: string): SourceStats {
 			const chunks = countRow(
 				db
 					.prepare(
-						"SELECT COUNT(*) AS n FROM embeddings WHERE agent_id = ? AND source_type = 'source_obsidian_chunk' AND source_id = ?",
+						"SELECT COUNT(*) AS n FROM embeddings WHERE agent_id = ? AND source_type = 'source_obsidian_chunk' AND source_id >= ? AND source_id < ?",
 					)
-					.get(agentId, source.id),
+					.get(agentId, chunkPrefix, `${chunkPrefix}\uffff`),
 			);
 			return { artifacts, chunks, indexed: artifacts };
 		});

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -1,9 +1,16 @@
 import { execFile } from "node:child_process";
 import { homedir } from "node:os";
 import { promisify } from "node:util";
-import { addObsidianSource, loadSourcesConfig, markSourceIndexed, removeSource } from "@signet/core";
+import {
+	type SignetSourceEntry,
+	addObsidianSource,
+	loadSourcesConfig,
+	markSourceIndexed,
+	removeSource,
+} from "@signet/core";
 import type { Hono } from "hono";
 import { resolveDaemonAgentId } from "../agent-id";
+import { getDbAccessor } from "../db-accessor";
 import { fetchEmbedding as defaultFetchEmbedding } from "../embedding-fetch";
 import { type ResolvedMemoryConfig, loadMemoryConfig as defaultLoadMemoryConfig } from "../memory-config";
 import {
@@ -19,6 +26,7 @@ interface AddObsidianSourceBody {
 	readonly path?: string;
 	readonly root?: string;
 	readonly name?: string;
+	readonly excludeGlobs?: readonly string[];
 }
 
 interface PickDirectoryBody {
@@ -40,7 +48,12 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 	const startBridge = deps.startBridge ?? startNativeMemoryBridge;
 	const purgeNativeSource = deps.purgeNativeSource ?? purgeNativeMemorySourceArtifacts;
 	app.get("/api/sources", (c) => {
-		return c.json(loadSourcesConfig(agentsDir));
+		const config = loadSourcesConfig(agentsDir);
+		const agentId = resolveDaemonAgentId();
+		return c.json({
+			version: config.version,
+			sources: config.sources.map((source) => ({ ...source, stats: sourceStats(source, agentId) })),
+		});
 	});
 
 	app.post("/api/sources/pick-directory", async (c) => {
@@ -65,15 +78,29 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 		}
 
 		const root = body.root ?? body.path ?? "";
-		const result = addObsidianSource({ root, name: body.name }, agentsDir);
+		const excludeGlobs = Array.isArray(body.excludeGlobs)
+			? body.excludeGlobs.filter((entry) => typeof entry === "string")
+			: undefined;
+		const result = addObsidianSource({ root, name: body.name, excludeGlobs }, agentsDir);
 		if (result.ok === false) return c.json({ error: result.error }, 400);
 
 		const memoryConfig = loadMemoryConfig(agentsDir);
-		const bridge = startBridge([obsidianNativeMemorySource(result.source.root, result.source.name, result.source.id)], {
-			pollIntervalMs: 0,
-			embeddingConfig: memoryConfig.embedding,
-			fetchEmbedding,
-		});
+		const bridge = startBridge(
+			[
+				obsidianNativeMemorySource(
+					result.source.root,
+					result.source.name,
+					result.source.id,
+					result.source.excludeGlobs,
+				),
+			],
+			{
+				pollIntervalMs: 0,
+				embeddingConfig: memoryConfig.embedding,
+				fetchEmbedding,
+				agentsDir,
+			},
+		);
 		let indexed = 0;
 		try {
 			indexed = await bridge.syncExisting();
@@ -100,6 +127,44 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 				: 0;
 		return c.json({ source: result.source, purged });
 	});
+}
+
+interface SourceStats {
+	readonly artifacts: number;
+	readonly chunks: number;
+	readonly indexed: number;
+}
+
+function sourceStats(source: SignetSourceEntry, agentId: string): SourceStats {
+	if (source.kind !== "obsidian") return { artifacts: 0, chunks: 0, indexed: 0 };
+	const rootPrefix = `${source.root.replace(/\\/g, "/").replace(/\/$/, "")}/`;
+	try {
+		return getDbAccessor().withReadDb((db) => {
+			const artifacts = countRow(
+				db
+					.prepare(
+						"SELECT COUNT(*) AS n FROM memory_artifacts WHERE agent_id = ? AND harness = 'obsidian' AND source_path >= ? AND source_path < ? AND COALESCE(is_deleted, 0) = 0",
+					)
+					.get(agentId, rootPrefix, `${rootPrefix}\uffff`),
+			);
+			const chunks = countRow(
+				db
+					.prepare(
+						"SELECT COUNT(*) AS n FROM embeddings WHERE agent_id = ? AND source_type = 'source_obsidian_chunk' AND source_id = ?",
+					)
+					.get(agentId, source.id),
+			);
+			return { artifacts, chunks, indexed: artifacts };
+		});
+	} catch {
+		return { artifacts: 0, chunks: 0, indexed: 0 };
+	}
+}
+
+function countRow(row: unknown): number {
+	return typeof row === "object" && row !== null && "n" in row && typeof (row as { n?: unknown }).n === "number"
+		? (row as { n: number }).n
+		: 0;
 }
 
 async function pickDirectory(title: string): Promise<{ ok: true; path: string } | { ok: false; error: string }> {

--- a/surfaces/cli/src/commands/sources.ts
+++ b/surfaces/cli/src/commands/sources.ts
@@ -6,6 +6,10 @@ export interface RegisterSourcesCommandsDeps extends SourcesDeps {
 	readonly secretApiCall?: DaemonApiCall;
 }
 
+function collect(value: string, previous: string[]): string[] {
+	return [...previous, value];
+}
+
 export function registerSourcesCommands(program: Command, deps: RegisterSourcesCommandsDeps): void {
 	const sources = program.command("sources").description("Manage external read-only knowledge sources");
 
@@ -49,5 +53,13 @@ export function registerSourcesCommands(program: Command, deps: RegisterSourcesC
 		.command("obsidian <path>")
 		.description("Index an Obsidian vault as a read-only recall source")
 		.option("--name <name>", "Display name for the vault")
-		.action((path: string, options: { name?: string }) => addObsidianVaultSource(path, options, deps));
+		.option(
+			"--exclude <glob>",
+			"Exclude glob (repeatable). Defaults already ignore dot-folders and Obsidian internals.",
+			collect,
+			[],
+		)
+		.action((path: string, options: { name?: string; exclude?: string[] }) =>
+			addObsidianVaultSource(path, options, deps),
+		);
 }

--- a/surfaces/cli/src/features/sources.test.ts
+++ b/surfaces/cli/src/features/sources.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { addObsidianSource, loadSourcesConfig } from "@signet/core";
-import { removeConfiguredSource } from "./sources";
+import { addObsidianVaultSource, removeConfiguredSource } from "./sources";
 
 describe("sources CLI features", () => {
 	let dir = "";
@@ -79,6 +79,20 @@ describe("sources CLI features", () => {
 		expect(logs.join("\n")).toContain("Purged 12 Signet-owned source rows");
 		expect(logs.join("\n")).toContain("Source files were not modified");
 		expect(warnings).toHaveLength(0);
+		expect(process.exitCode).not.toBe(1);
+	});
+
+	it("preserves existing custom excludes when re-adding an Obsidian source without --exclude", async () => {
+		const added = addObsidianSource({ root: vault, name: "CLI Vault", excludeGlobs: ["private/**"] }, dir);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+
+		await addObsidianVaultSource(vault, { name: "Renamed CLI Vault", exclude: [] }, { agentsDir: dir });
+
+		const [source] = loadSourcesConfig(dir).sources;
+		expect(source?.name).toBe("Renamed CLI Vault");
+		expect(source?.excludeGlobs).toContain("private/**");
+		expect(logs.join("\n")).toContain("Updated Obsidian source: Renamed CLI Vault");
 		expect(process.exitCode).not.toBe(1);
 	});
 

--- a/surfaces/cli/src/features/sources.ts
+++ b/surfaces/cli/src/features/sources.ts
@@ -24,7 +24,7 @@ export async function addObsidianVaultSource(
 	options: AddObsidianSourceOptions,
 	deps: SourcesDeps,
 ): Promise<void> {
-	const excludeGlobs = Array.isArray(options.exclude) ? options.exclude : undefined;
+	const excludeGlobs = options.exclude && options.exclude.length > 0 ? options.exclude : undefined;
 	const result = addObsidianSource({ root: path, name: options.name, excludeGlobs }, deps.agentsDir);
 	if (result.ok === false) {
 		console.error(chalk.red(`✗ ${result.error}`));

--- a/surfaces/cli/src/features/sources.ts
+++ b/surfaces/cli/src/features/sources.ts
@@ -16,6 +16,7 @@ export type DaemonRemoveSourceResult =
 
 export interface AddObsidianSourceOptions {
 	readonly name?: string;
+	readonly exclude?: readonly string[];
 }
 
 export async function addObsidianVaultSource(
@@ -23,7 +24,8 @@ export async function addObsidianVaultSource(
 	options: AddObsidianSourceOptions,
 	deps: SourcesDeps,
 ): Promise<void> {
-	const result = addObsidianSource({ root: path, name: options.name }, deps.agentsDir);
+	const excludeGlobs = Array.isArray(options.exclude) ? options.exclude : undefined;
+	const result = addObsidianSource({ root: path, name: options.name, excludeGlobs }, deps.agentsDir);
 	if (result.ok === false) {
 		console.error(chalk.red(`✗ ${result.error}`));
 		process.exitCode = 1;
@@ -51,6 +53,7 @@ export async function listSources(deps: SourcesDeps): Promise<void> {
 		console.log(`${source.name} ${chalk.dim(`(${source.kind}, ${source.mode}, ${status})`)}`);
 		console.log(chalk.dim(`  id: ${source.id}`));
 		console.log(chalk.dim(`  root: ${source.root}`));
+		if (source.excludeGlobs?.length) console.log(chalk.dim(`  excludes: ${source.excludeGlobs.join(", ")}`));
 		if (source.lastIndexedAt) console.log(chalk.dim(`  last indexed: ${source.lastIndexedAt}`));
 	}
 }

--- a/surfaces/dashboard/src/lib/api.ts
+++ b/surfaces/dashboard/src/lib/api.ts
@@ -91,6 +91,12 @@ export interface DocumentConnector {
 	updated_at: string;
 }
 
+export interface SignetSourceStats {
+	artifacts: number;
+	chunks: number;
+	indexed: number;
+}
+
 export interface SignetSourceEntry {
 	id: string;
 	kind: "obsidian";
@@ -101,6 +107,8 @@ export interface SignetSourceEntry {
 	createdAt: string;
 	updatedAt: string;
 	lastIndexedAt?: string;
+	excludeGlobs?: string[];
+	stats?: SignetSourceStats;
 }
 
 export interface SourcesConfigResponse {
@@ -992,11 +1000,15 @@ export async function pickSourceDirectory(title = "Choose folder"): Promise<Pick
 	}
 }
 
-export async function addObsidianSource(path: string, name?: string): Promise<AddSourceResponse> {
+export async function addObsidianSource(
+	path: string,
+	name?: string,
+	excludeGlobs?: string[],
+): Promise<AddSourceResponse> {
 	const response = await fetch(`${API_BASE}/api/sources/obsidian`, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ path, name }),
+		body: JSON.stringify({ path, name, excludeGlobs }),
 	});
 	const body = (await response.json().catch(() => null)) as Partial<AddSourceResponse> | null;
 	if (!response.ok) {

--- a/surfaces/dashboard/src/lib/components/home/KnowledgeBaseMap.svelte
+++ b/surfaces/dashboard/src/lib/components/home/KnowledgeBaseMap.svelte
@@ -33,11 +33,11 @@ const SIGNET_MEMORY_BASE: KnowledgeBase = {
 };
 
 const NODE_SLOTS = [
-	{ x: 33, y: 68 },
-	{ x: 54, y: 24 },
-	{ x: 74, y: 62 },
-	{ x: 86, y: 32 },
-	{ x: 18, y: 76 },
+	{ x: 18, y: 72 },
+	{ x: 73, y: 24 },
+	{ x: 80, y: 72 },
+	{ x: 22, y: 24 },
+	{ x: 88, y: 48 },
 ] as const;
 
 let loaded = $state(false);
@@ -52,27 +52,35 @@ onMount(async () => {
 });
 
 const externalKnowledgeBases = $derived.by((): KnowledgeBase[] => {
-	const sourceBases = sources.map((source, index): KnowledgeBase => ({
-		id: `source:${source.id}`,
-		name: source.name || basename(source.root),
-		kind: "source",
-		provider: source.kind,
-		detail: source.root,
-		status: source.enabled ? (source.lastIndexedAt ? "online" : "syncing") : "offline",
-		updatedAt: source.lastIndexedAt ?? source.updatedAt ?? null,
-		...NODE_SLOTS[index % NODE_SLOTS.length],
-	}));
+	const sourceBases = sources.map(
+		(source, index): KnowledgeBase => ({
+			id: `source:${source.id}`,
+			name: source.name || basename(source.root),
+			kind: "source",
+			provider: source.kind,
+			detail: source.root,
+			status: source.enabled
+				? source.lastIndexedAt || (source.stats?.indexed ?? 0) > 0
+					? "online"
+					: "syncing"
+				: "offline",
+			updatedAt: source.lastIndexedAt ?? source.updatedAt ?? null,
+			...NODE_SLOTS[index % NODE_SLOTS.length],
+		}),
+	);
 
-	const connectorBases = connectors.map((connector, index): KnowledgeBase => ({
-		id: `connector:${connector.id}`,
-		name: connector.display_name || connector.provider,
-		kind: "connector",
-		provider: connector.provider,
-		detail: connector.last_error ?? `${connector.provider} document connector`,
-		status: connectorStatus(connector),
-		updatedAt: connector.last_sync_at ?? connector.updated_at ?? null,
-		...NODE_SLOTS[(sourceBases.length + index) % NODE_SLOTS.length],
-	}));
+	const connectorBases = connectors.map(
+		(connector, index): KnowledgeBase => ({
+			id: `connector:${connector.id}`,
+			name: connector.display_name || connector.provider,
+			kind: "connector",
+			provider: connector.provider,
+			detail: connector.last_error ?? `${connector.provider} document connector`,
+			status: connectorStatus(connector),
+			updatedAt: connector.last_sync_at ?? connector.updated_at ?? null,
+			...NODE_SLOTS[(sourceBases.length + index) % NODE_SLOTS.length],
+		}),
+	);
 
 	return [...sourceBases, ...connectorBases].slice(0, NODE_SLOTS.length);
 });

--- a/surfaces/dashboard/src/lib/components/tabs/SourcesTab.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/SourcesTab.svelte
@@ -99,6 +99,8 @@ let connectMode = $state(false);
 let vaultPath = $state("");
 // biome-ignore lint/style/useConst: Svelte bind:value mutates this rune from markup.
 let vaultName = $state("Obsidian Vault");
+// biome-ignore lint/style/useConst: Svelte bind:value mutates this rune from markup.
+let excludeGlobsText = $state("**/.obsidian/**\n**/.trash/**\n**/.hermes/**\n**/.*/**\n**/.*");
 let status = $state<string | null>(null);
 let error = $state<string | null>(null);
 let touchedPath = $state(false);
@@ -435,7 +437,9 @@ const filters: Array<{ id: ActiveFilter; label: string }> = [
 const selectedConnector = $derived(connectors.find((connector) => connector.kind === selectedKind) ?? connectors[0]);
 const obsidianSources = $derived(sources.filter((source) => source.kind === "obsidian"));
 const connectedCount = $derived(obsidianSources.length);
-const indexedCount = $derived(obsidianSources.filter((source) => source.lastIndexedAt).length);
+const indexedCount = $derived(
+	obsidianSources.filter((source) => source.lastIndexedAt || (source.stats?.indexed ?? 0) > 0).length,
+);
 const pathIsMissing = $derived(vaultPath.trim().length === 0);
 const canSubmit = $derived(!pathIsMissing && !adding && selectedKind === "obsidian");
 const filteredConnectors = $derived.by(() => {
@@ -511,7 +515,8 @@ async function submitSource(): Promise<void> {
 	status = null;
 	error = null;
 	try {
-		const result = await addObsidianSource(vaultPath.trim(), vaultName.trim() || undefined);
+		const excludeGlobs = parseExcludeGlobs(excludeGlobsText);
+		const result = await addObsidianSource(vaultPath.trim(), vaultName.trim() || undefined, excludeGlobs);
 		if (result.error) {
 			error = result.error;
 			return;
@@ -548,10 +553,28 @@ async function disconnectSource(source: SignetSourceEntry): Promise<void> {
 }
 
 function formatDate(value: string | undefined): string {
-	if (!value) return "Not scanned yet";
+	if (!value) return "Not completed yet";
 	const date = new Date(value);
 	if (Number.isNaN(date.getTime())) return value;
 	return date.toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+
+function parseExcludeGlobs(value: string): string[] {
+	return Array.from(
+		new Set(
+			value
+				.split(/[\n,]/)
+				.map((entry) => entry.trim())
+				.filter(Boolean),
+		),
+	);
+}
+
+function sourceScanLabel(source: SignetSourceEntry): string {
+	const indexed = source.stats?.indexed ?? 0;
+	const chunks = source.stats?.chunks ?? 0;
+	if (indexed > 0) return `${indexed} notes · ${chunks} chunks${source.lastIndexedAt ? "" : " · syncing"}`;
+	return source.lastIndexedAt ? "Scan completed with no indexed notes" : "Connected; waiting for first indexed note";
 }
 </script>
 
@@ -790,7 +813,9 @@ function formatDate(value: string | undefined): string {
 				<div class="connector-grid" class:has-expanded={expandedKind !== null}>
 					{#each filteredConnectors as connector (connector.kind)}
 						{@const expanded = expandedKind === connector.kind}
-						<article class="connector-card" class:expanded class:compressed={expandedKind !== null && !expanded}>
+						{@const connectedSources = connector.kind === "obsidian" ? obsidianSources : []}
+						{@const isConnected = connectedSources.length > 0}
+						<article class="connector-card" class:expanded class:connected={isConnected} class:compressed={expandedKind !== null && !expanded}>
 							<button
 								class="connector-row"
 								class:selected={expanded}
@@ -802,11 +827,13 @@ function formatDate(value: string | undefined): string {
 									{@render sourceLogo(connector.icon)}
 								</span>
 								<span class="connector-copy">
-									<strong>{connector.name}</strong>
-									<small>{connector.detail}</small>
+									<strong>{isConnected && connectedSources[0] ? connectedSources[0].name : connector.name}</strong>
+									<small>{isConnected && connectedSources[0] ? sourceScanLabel(connectedSources[0]) : connector.detail}</small>
 								</span>
-								<span class="connector-action" class:available={connector.status === "available"}>
-									{#if expanded}
+								<span class="connector-action" class:available={connector.status === "available"} class:connected={isConnected}>
+									{#if isConnected}
+										<CheckCircle2 />
+									{:else if expanded}
 										<X />
 									{:else if connector.status === "available"}
 										<Check />
@@ -820,38 +847,79 @@ function formatDate(value: string | undefined): string {
 
 							<div class="connector-expand" class:open={expanded} aria-hidden={!expanded}>
 								<p class="connector-description">{connector.description}</p>
-								{#if !connectMode || !expanded}
-									<button
-										class="connect-button"
-										type="button"
-										disabled={connector.status !== "available" || !expanded}
-										onclick={() => (connectMode = true)}
-									>
-										<Link2 /> {connector.status === "available" ? "Connect" : "Planned source"}
-									</button>
-								{/if}
 
-								{#if connectMode && expanded && connector.kind === "obsidian"}
-									<form class="connect-form" onsubmit={(event) => { event.preventDefault(); void submitSource(); }}>
-										<label>
-											<span>Display name</span>
-											<input bind:value={vaultName} placeholder="Obsidian Vault" />
-										</label>
-										<label>
-											<span>Vault folder</span>
-											<div class="path-row">
-												<input bind:value={vaultPath} placeholder="Choose your vault folder..." onblur={() => (touchedPath = true)} />
-												<button type="button" onclick={() => void chooseFolder()} disabled={pickingFolder}>
-													<FolderOpen /> {pickingFolder ? "Opening" : "Browse"}
+								{#if loading && connector.kind === "obsidian"}
+									<p class="connected-loading">Checking source registry...</p>
+								{:else if isConnected}
+									<div class="connected-list connected-list--inline">
+										{#each connectedSources as source (source.id)}
+											<article class="connected-row connected-row--inline">
+												<div class="connected-main">
+													<div class="connected-title-row">
+														<strong>{source.name}</strong>
+														<span class="status-badge status-badge--connected">Connected</span>
+													</div>
+													<code>{source.root}</code>
+												</div>
+												<ul>
+													<li><CheckCircle2 /> {source.enabled ? "Enabled" : "Disabled"}</li>
+													<li><Database /> {sourceScanLabel(source)}</li>
+													<li><Database /> Last complete scan: {formatDate(source.lastIndexedAt)}</li>
+												</ul>
+												{#if source.excludeGlobs?.length}
+													<div class="exclude-summary">
+														<span>Ignoring</span>
+														<code>{source.excludeGlobs.join(", ")}</code>
+													</div>
+												{/if}
+												<button
+													class="disconnect-button"
+													type="button"
+													disabled={removingSourceId === source.id}
+													onclick={() => void disconnectSource(source)}
+												>
+													{#if removingSourceId === source.id}<span class="spin"><RefreshCw /></span>{:else}<X />{/if}
+													{removingSourceId === source.id ? "Removing" : "Disconnect vault"}
 												</button>
-											</div>
-										</label>
-										{#if touchedPath && pathIsMissing}<p class="field-error">Vault folder is required.</p>{/if}
-										<button class="connect-button" type="submit" disabled={!canSubmit}>
-											{#if adding}<span class="spin"><RefreshCw /></span>{:else}<CirclePlus />{/if}
-											{adding ? "Indexing" : "Add source"}
+											</article>
+										{/each}
+									</div>
+								{:else if connector.status === "available"}
+									{#if !connectMode || !expanded}
+										<button class="connect-button" type="button" disabled={!expanded} onclick={() => (connectMode = true)}>
+											<Link2 /> Connect
 										</button>
-									</form>
+									{/if}
+
+									{#if connectMode && expanded && connector.kind === "obsidian"}
+										<form class="connect-form" onsubmit={(event) => { event.preventDefault(); void submitSource(); }}>
+											<label>
+												<span>Display name</span>
+												<input bind:value={vaultName} placeholder="Obsidian Vault" />
+											</label>
+											<label>
+												<span>Vault folder</span>
+												<div class="path-row">
+													<input bind:value={vaultPath} placeholder="Choose your vault folder..." onblur={() => (touchedPath = true)} />
+													<button type="button" onclick={() => void chooseFolder()} disabled={pickingFolder}>
+														<FolderOpen /> {pickingFolder ? "Opening" : "Browse"}
+													</button>
+												</div>
+											</label>
+											{#if touchedPath && pathIsMissing}<p class="field-error">Vault folder is required.</p>{/if}
+											<label>
+												<span>Ignore globs</span>
+												<textarea bind:value={excludeGlobsText} rows="5" placeholder="**/.*/**&#10;**/node_modules/**"></textarea>
+												<small class="field-hint">One glob per line or comma. Default ignores Obsidian internals, trash, Hermes metadata, hidden dot-folders, and hidden files.</small>
+											</label>
+											<button class="connect-button" type="submit" disabled={!canSubmit}>
+												{#if adding}<span class="spin"><RefreshCw /></span>{:else}<CirclePlus />{/if}
+												{adding ? "Indexing" : "Add source"}
+											</button>
+										</form>
+									{/if}
+								{:else}
+									<p class="form-status form-status--info">Planned source. Not connectable yet.</p>
 								{/if}
 
 								{#if selectedKind === connector.kind && status}<p class="form-status form-status--info">{status}</p>{/if}
@@ -863,39 +931,6 @@ function formatDate(value: string | undefined): string {
 				<footer>{connectors.filter((connector) => connector.status === "available").length} live / {connectors.filter((connector) => connector.status === "planned").length} planned sources</footer>
 			</section>
 
-			{#if loading || obsidianSources.length > 0}
-				<section class="connected-panel sig-panel">
-					<header class="section-label">Connected locally</header>
-					{#if loading}
-						<p class="connected-loading">Checking source registry...</p>
-					{:else}
-						<div class="connected-list">
-							<p class="removal-note">Remove any knowledge base here. Signet purges its indexed artifacts, graph rows, and source chunks; the original files stay untouched.</p>
-							{#each obsidianSources as source (source.id)}
-								<article class="connected-row">
-									<div>
-										<strong>{source.name}</strong>
-										<code>{source.root}</code>
-									</div>
-									<ul>
-										<li><CheckCircle2 /> {source.enabled ? "Enabled" : "Disabled"}</li>
-										<li><Database /> {formatDate(source.lastIndexedAt)}</li>
-									</ul>
-									<button
-										class="disconnect-button"
-										type="button"
-										disabled={removingSourceId === source.id}
-										onclick={() => void disconnectSource(source)}
-									>
-										{#if removingSourceId === source.id}<span class="spin"><RefreshCw /></span>{:else}<X />{/if}
-										{removingSourceId === source.id ? "Removing" : "Remove knowledge base"}
-									</button>
-								</article>
-							{/each}
-						</div>
-					{/if}
-				</section>
-			{/if}
 		</main>
 
 	</div>
@@ -1417,8 +1452,7 @@ function formatDate(value: string | undefined): string {
 		color: var(--sig-text-muted);
 	}
 
-	.featured-panel .section-label,
-	.connected-panel .section-label {
+	.featured-panel .section-label {
 		padding-left: 2px;
 	}
 
@@ -1455,9 +1489,12 @@ function formatDate(value: string | undefined): string {
 		z-index: 20;
 		background: var(--sig-surface-raised);
 		box-shadow:
-			inset 2px 0 0 var(--sig-accent),
-			0 14px 30px rgba(0, 0, 0, 0.4),
-			0 0 0 1px var(--sig-border-strong);
+			0 0 0 1px rgba(245, 158, 11, 0.26),
+			0 18px 42px rgba(0, 0, 0, 0.35);
+	}
+
+	.connector-card.connected {
+		border-color: rgba(34, 197, 94, 0.36);
 	}
 
 	.connector-row {
@@ -1582,6 +1619,12 @@ function formatDate(value: string | undefined): string {
 		color: var(--sig-success);
 	}
 
+	.connector-action.connected {
+		border-color: rgba(34, 197, 94, 0.62);
+		background: rgba(34, 197, 94, 0.1);
+		color: var(--sig-success);
+	}
+
 	.connector-action :global(svg) {
 		width: 14px;
 		height: 14px;
@@ -1656,9 +1699,9 @@ function formatDate(value: string | undefined): string {
 		color: var(--sig-text-muted);
 	}
 
-	.connect-form input {
+	.connect-form input,
+	.connect-form textarea {
 		width: 100%;
-		height: 32px;
 		border: 1px solid var(--sig-border-strong);
 		border-radius: 0;
 		background: var(--sig-surface-raised);
@@ -1666,6 +1709,21 @@ function formatDate(value: string | undefined): string {
 		font: 11px var(--font-mono);
 		color: var(--sig-text-bright);
 		outline: none;
+	}
+
+	.connect-form input {
+		height: 32px;
+	}
+
+	.connect-form textarea {
+		min-height: 86px;
+		padding: 9px 10px;
+		resize: vertical;
+	}
+
+	.field-hint {
+		font: 10px/1.4 var(--font-body);
+		color: var(--sig-text-muted);
 	}
 
 	.path-row {
@@ -1769,6 +1827,11 @@ function formatDate(value: string | undefined): string {
 		background: var(--sig-surface);
 	}
 
+	.connected-list--inline {
+		border-color: var(--sig-border-strong);
+		background: rgba(0, 0, 0, 0.12);
+	}
+
 	.connected-loading {
 		border: 1px solid var(--sig-border);
 		border-radius: 0;
@@ -1798,6 +1861,36 @@ function formatDate(value: string | undefined): string {
 		background: var(--sig-surface-raised);
 	}
 
+	.connected-row--inline {
+		grid-template-columns: minmax(0, 1fr);
+		gap: 10px;
+	}
+
+	.connected-main {
+		min-width: 0;
+	}
+
+	.connected-title-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 10px;
+	}
+
+	.status-badge {
+		border: 1px solid var(--sig-border);
+		padding: 2px 6px;
+		font: 9px var(--font-mono);
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	.status-badge--connected {
+		border-color: rgba(34, 197, 94, 0.45);
+		color: var(--sig-success);
+		background: rgba(34, 197, 94, 0.08);
+	}
+
 	.connected-row strong {
 		display: block;
 		margin-bottom: 4px;
@@ -1825,7 +1918,7 @@ function formatDate(value: string | undefined): string {
 	.connected-row li {
 		display: flex;
 		align-items: center;
-		justify-content: flex-end;
+		justify-content: flex-start;
 		gap: 6px;
 		font-size: 10px;
 		color: var(--sig-text-muted);
@@ -1834,6 +1927,26 @@ function formatDate(value: string | undefined): string {
 	.connected-row li :global(svg) {
 		width: 13px;
 		height: 13px;
+	}
+
+	.exclude-summary {
+		display: grid;
+		gap: 4px;
+		border: 1px dashed var(--sig-border);
+		padding: 8px;
+		background: rgba(255, 255, 255, 0.02);
+	}
+
+	.exclude-summary span {
+		font: 9px var(--font-mono);
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--sig-text-muted);
+	}
+
+	.exclude-summary code {
+		white-space: normal;
+		word-break: break-word;
 	}
 
 	.disconnect-button {


### PR DESCRIPTION
## Summary

Follow-up to the Obsidian Sources merge that makes connected vault state visible and trustworthy in the daemon API, CLI, docs, and dashboard.

The main fix is that Sources no longer treats `lastIndexedAt` as the only evidence that an Obsidian vault has indexed content. The daemon now reports DB-backed source stats, configured source scans mark completion when background polling finishes a pass, and the dashboard renders the connected Obsidian card as the management surface instead of hiding status/removal in a separate lower panel.

## Changes

- Add durable `excludeGlobs` support for Obsidian sources, including default hidden/tool-directory excludes.
- Add repeatable CLI `--exclude <glob>` support and show configured excludes in `signet sources list`.
- Return agent-scoped `stats` from `GET /api/sources` for Obsidian artifacts/chunks/indexed counts.
- Mark configured background source scans complete after a successful bridge scan.
- Pass configured excludes and `agentsDir` through the one-shot dashboard/daemon connect path.
- Update dashboard source types and card copy to use DB-backed stats when available.
- Refactor the featured Obsidian card so connected status, path, counts, scan time, excludes, and disconnect live inline in the card.
- Adjust the Overview knowledge-base node layout and status logic to reduce overlap and use indexed rows as a status signal.
- Document default ignore behavior and CLI exclude examples in `docs/SOURCES.md`.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [x] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

Validated locally in the dashboard dev server against the live daemon. The Obsidian featured card renders as connected inline and expands into its management panel. The live daemon is still v0.110.0, so the screenshot shows the old-daemon `0 indexed`/waiting text until this branch's daemon API is installed.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [ ] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

No database migrations. Existing source configs remain compatible. New/updated Obsidian configs can include `excludeGlobs`; older configs simply use the default exclude set at runtime.

## Testing

- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Tested against running daemon
- [ ] N/A

Validation run locally:

```bash
bun run --filter @signet/core build
bun test platform/core/src/sources-config.test.ts \
  platform/daemon/src/native-memory-sources.test.ts \
  platform/daemon/src/routes/sources-routes.test.ts \
  surfaces/cli/src/features/sources.test.ts
bun run --filter @signet/daemon build
bun run --filter @signet/cli build
cd surfaces/dashboard && bun run check && bun run build
bunx biome check docs/SOURCES.md \
  platform/core/src/index.ts \
  platform/core/src/sources-config.ts \
  platform/daemon/src/native-memory-sources.test.ts \
  platform/daemon/src/native-memory-sources.ts \
  platform/daemon/src/routes/sources-routes.ts \
  surfaces/cli/src/commands/sources.ts \
  surfaces/cli/src/features/sources.ts \
  surfaces/dashboard/src/lib/api.ts \
  surfaces/dashboard/src/lib/components/home/KnowledgeBaseMap.svelte \
  surfaces/dashboard/src/lib/components/tabs/SourcesTab.svelte
git diff --check
```

Results:

- Focused tests: 41 pass, 0 fail.
- Core build passed.
- Daemon build passed.
- CLI build passed.
- Dashboard `svelte-check` passed with 0 errors and existing unrelated warnings.
- Dashboard production build passed.
- Biome check passed on touched files.
- `git diff --check` passed.
- Live source recall smoke on the installed daemon returned `source_obsidian_chunk` hits with `source_path` provenance for `hyprland quickshell`; live DB had Obsidian artifacts/chunks/graph rows present.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

This branch intentionally does not restart or replace the user's live installed daemon. The live daemon on v0.110.0 can already recall Obsidian chunks, but the new dashboard stats/completed-scan behavior requires this branch's daemon API to be installed and restarted.
