### PR TITLE
fix(openclaw): keep bundled sdk out of publish deps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "signet",
       "devDependencies": {
         "@biomejs/biome": "^1.9.0",
+        "@signet/sdk": "workspace:*",
         "@types/node": "^24.5.2",
         "bun-types": "^1.3.9",
         "turbo": "^2.9.6",
@@ -146,11 +147,11 @@
       "name": "@signetai/signet-memory-openclaw",
       "version": "0.110.3",
       "dependencies": {
-        "@signet/sdk": "workspace:*",
         "@sinclair/typebox": "0.34.47",
       },
       "devDependencies": {
         "@signet/core": "workspace:*",
+        "@signet/sdk": "workspace:*",
         "@types/node": "^22.0.0",
       },
       "peerDependencies": {

--- a/integrations/openclaw/memory-adapter/package.json
+++ b/integrations/openclaw/memory-adapter/package.json
@@ -33,11 +33,11 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@signet/sdk": "workspace:*",
     "@sinclair/typebox": "0.34.47"
   },
   "devDependencies": {
     "@signet/core": "workspace:*",
+    "@signet/sdk": "workspace:*",
     "@types/node": "^22.0.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build:oh-my-pi-extension": "cd integrations/oh-my-pi/extension && bun run build",
     "build:pi-extension": "cd integrations/pi/extension && bun run build",
     "build:connector-pi": "cd integrations/pi/connector && bun run build",
-    "build:deps": "bun run --filter '@signet/connector-claude-code' --filter '@signet/connector-codex' --filter '@signet/connector-forge' --filter '@signet/connector-gemini' --filter '@signet/connector-hermes-agent' --filter '@signet/connector-opencode' --filter '@signet/connector-openclaw' --filter '@signetai/*' --filter '@signet/daemon' --filter '@signet/sdk' build",
+    "build:deps": "bun run --filter '@signet/sdk' build && bun run --filter '@signet/connector-claude-code' --filter '@signet/connector-codex' --filter '@signet/connector-forge' --filter '@signet/connector-gemini' --filter '@signet/connector-hermes-agent' --filter '@signet/connector-opencode' --filter '@signet/connector-openclaw' --filter '@signetai/*' --filter '@signet/daemon' build",
     "build:signetai": "cd dist/signetai && bun run build",
     "build:publish": "bun run build:dashboard && bun run build:signetai",
     "build:dashboard": "cd surfaces/dashboard && bun install && bun run build",
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",
+    "@signet/sdk": "workspace:*",
     "@types/node": "^24.5.2",
     "bun-types": "^1.3.9",
     "turbo": "^2.9.6",

--- a/scripts/check-publish-manifests.test.ts
+++ b/scripts/check-publish-manifests.test.ts
@@ -147,6 +147,50 @@ describe("check-publish-manifests", () => {
 		}
 	});
 
+	test("keeps bundled Signet internals out of the OpenClaw adapter runtime manifest", () => {
+		const root = join(import.meta.dir, "..");
+		const rootPackageFile = join(root, "package.json");
+		const adapterFile = join(root, "integrations", "openclaw", "memory-adapter", "package.json");
+		const sdkFile = join(root, "libs", "sdk", "package.json");
+		const coreFile = join(root, "platform", "core", "package.json");
+
+		const rootPackage = JSON.parse(readFileSync(rootPackageFile, "utf-8")) as {
+			devDependencies?: Record<string, string>;
+			scripts?: Record<string, string>;
+		};
+		const adapter = JSON.parse(readFileSync(adapterFile, "utf-8")) as {
+			dependencies?: Record<string, string>;
+			devDependencies?: Record<string, string>;
+		};
+
+		expect(rootPackage.devDependencies?.["@signet/sdk"]).toBe("workspace:*");
+		expect(rootPackage.scripts?.["build:deps"]).toStartWith("bun run --filter '@signet/sdk' build && ");
+		expect(adapter.dependencies?.["@signet/sdk"]).toBeUndefined();
+		expect(adapter.devDependencies?.["@signet/sdk"]).toBeDefined();
+
+		const workspacePackages = collectWorkspacePackages([adapterFile, sdkFile, coreFile]);
+
+		expect(collectManifestIssues([adapterFile], workspacePackages)).toHaveLength(0);
+
+		const releaseRewrittenAdapterDir = mkdtempSync(join(tmpdir(), "signet-openclaw-release-manifest-"));
+		try {
+			const releaseRewrittenAdapterFile = join(releaseRewrittenAdapterDir, "package.json");
+			writeJson(releaseRewrittenAdapterFile, {
+				...JSON.parse(readFileSync(adapterFile, "utf-8")),
+				version: "1.2.3",
+				devDependencies: {
+					...adapter.devDependencies,
+					"@signet/core": "1.2.3",
+					"@signet/sdk": "1.2.3",
+				},
+			});
+
+			expect(collectManifestIssues([releaseRewrittenAdapterFile], workspacePackages)).toHaveLength(0);
+		} finally {
+			rmSync(releaseRewrittenAdapterDir, { recursive: true, force: true });
+		}
+	});
+
 	test("allows runtime dependencies on publishable workspace packages", () => {
 		const root = mkdtempSync(join(tmpdir(), "signet-publish-manifests-"));
 		try {


### PR DESCRIPTION
## Summary

Fixes the main release failure by keeping the bundled Signet SDK out of the OpenClaw adapter's published runtime dependency manifest, while preserving deterministic build order for Docker/CI.

The release publish guard failed because `@signetai/signet-memory-openclaw` declared `@signet/sdk` in `dependencies`. During publish, `version-sync` rewrote that workspace dependency to the release version, then `check-publish-manifests` rejected it because `@signet/sdk` is an internal workspace package and is not published to npm.

The adapter build bundles Signet internals, matching the existing `@signet/core` treatment, so `@signet/sdk` belongs in `devDependencies`. Docker smoke also exposed a race: `build:deps` previously built `@signet/sdk` and `@signetai/signet-memory-openclaw` concurrently, so the adapter could resolve the SDK before `libs/sdk/dist` existed. `build:deps` now builds the SDK first, then runs the parallel dependent package build.

## Changes

- Move `@signet/sdk` from runtime `dependencies` to `devDependencies` in `integrations/openclaw/memory-adapter/package.json`.
- Keep `bun.lock` aligned with that package manifest change.
- Add `@signet/sdk` as a root private workspace dev dependency so workspace installs can resolve the SDK for builds.
- Split `build:deps` so `@signet/sdk` builds before adapter/daemon dependent packages run in parallel.
- Add a regression test that locks the OpenClaw adapter manifest shape, root SDK build dependency, and build-order guard.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: `@signetai/signet-memory-openclaw`, root build script, publish manifest guard

## Screenshots

N/A, no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — N/A, release/build manifest classification only
- [x] Agent scoping verified on all new/changed data queries — N/A, no data queries changed
- [x] Input/config validation and bounds checks added — N/A, no runtime input changed
- [x] Error handling and fallback paths tested (no silent swallow) — N/A, no runtime error path changed
- [x] Security checks applied to admin/mutation endpoints — N/A, no endpoints changed
- [x] Docs updated for API/spec/status changes — N/A, no API/spec/status change
- [x] Regression tests added for each bug fix — `scripts/check-publish-manifests.test.ts` now catches SDK runtime drift and the build-order race
- [x] Lint/typecheck/tests pass locally — targeted checks below

## Migration Notes (if applicable)

N/A.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Targeted validation run locally:

```bash
# RED checks were verified by temporarily reintroducing the broken states:
# - @signet/sdk in adapter dependencies failed the manifest regression
# - build:deps with SDK running concurrently failed the build-order assertion

bun test scripts/check-publish-manifests.test.ts -t "keeps bundled Signet internals out of the OpenClaw adapter runtime manifest"
bun test scripts/check-publish-manifests.test.ts
bun scripts/check-publish-manifests.ts
bun run build:core
bun run build:deps
SIGNET_HTTP_PORT=8080 SIGNET_HTTPS_PORT=8443 docker compose -f deploy/docker/compose.yml build signet
git diff --check
```

Notes: `version-sync` was used earlier only to simulate the release publish guard. Unrelated local Rust version churn from that command was reverted before commit.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

This should unblock the release publish guard without requiring `@signet/sdk` to be published as a separate npm package, and without a CI race between SDK and adapter builds.
