### PR TITLE
perf(daemon): speed up memory recall

### DIFF
--- a/platform/daemon/src/memory-search.bench.ts
+++ b/platform/daemon/src/memory-search.bench.ts
@@ -2,31 +2,49 @@
  * Benchmark: hybrid recall search latency.
  *
  * Measures the shared hot path used by explicit recall and
- * user-prompt-submit. The benchmark uses a synthetic local workspace so it can
- * be run before and after search changes without touching real memory data.
+ * user-prompt-submit. By default the benchmark uses a synthetic local
+ * workspace so it can be run before and after search changes without touching
+ * real memory data.
  *
  * Run:
  *   bun run build:core
  *   bun run platform/daemon/src/memory-search.bench.ts
  *
- * Knobs:
+ * Synthetic knobs:
  *   SIGNET_RECALL_BENCH_MEMORIES=2000
  *   SIGNET_RECALL_BENCH_ITERS=60
  *   SIGNET_RECALL_BENCH_EMBED_MS=40
+ *
+ * Copied real-workspace mode:
+ *   SIGNET_RECALL_BENCH_SOURCE_PATH=~/.agents
+ *   SIGNET_RECALL_BENCH_QUERY="what do you remember about Signet recall slowness"
+ *   SIGNET_RECALL_BENCH_EMBED=real
+ *   bun run platform/daemon/src/memory-search.bench.ts
+ *
+ * The source workspace is copied into /tmp first. The benchmark never opens
+ * the live memory database directly.
  */
 
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { copyFileSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { fetchEmbedding } from "./embedding-fetch";
 import { loadMemoryConfig } from "./memory-config";
-import { hybridRecall } from "./memory-search";
+import { type RecallStageTiming, hybridRecall } from "./memory-search";
 
 const TEST_DIR = join(tmpdir(), `signet-recall-bench-${Date.now()}`);
 const MEMORY_COUNT = parseEnvInt("SIGNET_RECALL_BENCH_MEMORIES", 2000);
 const ITERS = parseEnvInt("SIGNET_RECALL_BENCH_ITERS", 60);
 const EMBED_MS = parseEnvInt("SIGNET_RECALL_BENCH_EMBED_MS", 40);
-const QUERY = "signet memory search performance prompt submit recall";
+const SOURCE_PATH = parsePath(process.env.SIGNET_RECALL_BENCH_SOURCE_PATH);
+const QUERY =
+	process.env.SIGNET_RECALL_BENCH_QUERY?.trim() ||
+	(SOURCE_PATH
+		? "what do you remember about Signet memory search performance and recall slowness"
+		: "signet memory search performance prompt submit recall");
+const EMBED_MODE = process.env.SIGNET_RECALL_BENCH_EMBED === "real" ? "real" : "fake";
+let fakeEmbeddingDimensions = 768;
 
 process.env.SIGNET_PATH = TEST_DIR;
 
@@ -37,8 +55,31 @@ function parseEnvInt(name: string, fallback: number): number {
 	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+function parsePath(raw: string | undefined): string | null {
+	const path = raw?.trim();
+	if (!path) return null;
+	return resolve(path.startsWith("~") ? join(homedir(), path.slice(1)) : path);
+}
+
+function copyIfExists(from: string, to: string): void {
+	if (existsSync(from)) copyFileSync(from, to);
+}
+
 function setupWorkspace(): void {
 	mkdirSync(join(TEST_DIR, "memory"), { recursive: true });
+	if (SOURCE_PATH) {
+		const dbPath = join(SOURCE_PATH, "memory", "memories.db");
+		const cfgPath = join(SOURCE_PATH, "agent.yaml");
+		if (!existsSync(dbPath)) throw new Error(`Source memory DB not found: ${dbPath}`);
+		if (!existsSync(cfgPath)) throw new Error(`Source agent.yaml not found: ${cfgPath}`);
+		copyFileSync(cfgPath, join(TEST_DIR, "agent.yaml"));
+		copyFileSync(dbPath, join(TEST_DIR, "memory", "memories.db"));
+		copyIfExists(`${dbPath}-wal`, join(TEST_DIR, "memory", "memories.db-wal"));
+		copyIfExists(`${dbPath}-shm`, join(TEST_DIR, "memory", "memories.db-shm"));
+		initDbAccessor(join(TEST_DIR, "memory", "memories.db"));
+		return;
+	}
+
 	writeFileSync(
 		join(TEST_DIR, "agent.yaml"),
 		[
@@ -113,7 +154,7 @@ function setupWorkspace(): void {
 
 async function fakeEmbedding(): Promise<number[]> {
 	await Bun.sleep(EMBED_MS);
-	return Array.from({ length: 768 }, (_, index) => (index % 17) / 17);
+	return Array.from({ length: fakeEmbeddingDimensions }, (_, index) => (index % 17) / 17);
 }
 
 interface Stats {
@@ -144,8 +185,24 @@ function printStats(label: string, result: Stats): void {
 	);
 }
 
+function summarizeStages(samples: readonly (readonly RecallStageTiming[])[]): RecallStageTiming[] {
+	const totals = new Map<string, { total: number; count: number }>();
+	for (const sample of samples) {
+		for (const stage of sample) {
+			const prev = totals.get(stage.name) ?? { total: 0, count: 0 };
+			prev.total += stage.durationMs;
+			prev.count += 1;
+			totals.set(stage.name, prev);
+		}
+	}
+	return [...totals.entries()]
+		.map(([name, value]) => ({ name, durationMs: Math.round((value.total / value.count) * 100) / 100 }))
+		.sort((a, b) => b.durationMs - a.durationMs);
+}
+
 setupWorkspace();
 const cfg = loadMemoryConfig(TEST_DIR);
+fakeEmbeddingDimensions = cfg.embedding.dimensions;
 const params = {
 	query: QUERY,
 	keywordQuery: QUERY,
@@ -153,29 +210,39 @@ const params = {
 	agentId: "default",
 	readPolicy: "isolated",
 } as const;
+const embed = EMBED_MODE === "real" ? fetchEmbedding : fakeEmbedding;
 
 console.log("\nHybrid recall latency benchmark");
 console.log("=".repeat(64));
 console.log(`workspace: ${TEST_DIR}`);
-console.log(`memories: ${MEMORY_COUNT}`);
+if (SOURCE_PATH) console.log(`source workspace: ${SOURCE_PATH}`);
+else console.log(`memories: ${MEMORY_COUNT}`);
+console.log(`query: ${QUERY}`);
 console.log(`iterations: ${ITERS}`);
-console.log(`synthetic embedding delay: ${EMBED_MS}ms`);
+console.log(`embedding: ${EMBED_MODE}${EMBED_MODE === "fake" ? ` (${EMBED_MS}ms synthetic delay)` : ""}`);
 
 for (let i = 0; i < 5; i++) {
-	await hybridRecall(params, cfg, fakeEmbedding);
+	await hybridRecall(params, cfg, embed);
 }
 
 const times: number[] = [];
+const stageSamples: RecallStageTiming[][] = [];
 let ids = "";
 for (let i = 0; i < ITERS; i++) {
 	const start = performance.now();
-	const result = await hybridRecall(params, cfg, fakeEmbedding);
+	const result = await hybridRecall(params, cfg, embed);
 	times.push(performance.now() - start);
+	stageSamples.push(result.meta.timings.stages);
 	if (i === 0) ids = result.results.map((row) => row.id).join(", ");
 }
 
 printStats("hybridRecall", stats(times));
 console.log(`first result ids: ${ids}`);
+console.log("\nSlowest recall stages (avg)");
+console.log("=".repeat(64));
+for (const stage of summarizeStages(stageSamples).slice(0, 12)) {
+	console.log(`${stage.name.padEnd(32)} ${stage.durationMs.toFixed(2)}ms`);
+}
 
 closeDbAccessor();
 if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true, force: true });

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -122,11 +122,27 @@ describe("hybridRecall", () => {
 		);
 
 		expect(result.results).toEqual([]);
-		expect(result.meta).toEqual({
+		expect(result.meta).toMatchObject({
 			totalReturned: 0,
 			hasSupplementary: false,
 			noHits: true,
 		});
+		expect(result.meta.timings.totalMs).toBeGreaterThanOrEqual(0);
+		expect(result.meta.timings.stages.map((stage) => stage.name)).toEqual(
+			expect.arrayContaining([
+				"memory_fts",
+				"hints_fts",
+				"query_embedding_wait",
+				"flat_score_merge",
+				"final_rank",
+				"source_chunk_vector_fallback",
+				"native_artifact_fallback",
+				"transcript_fallback",
+			]),
+		);
+		for (const stage of result.meta.timings.stages) {
+			expect(stage.durationMs).toBeGreaterThanOrEqual(0);
+		}
 	});
 
 	it("falls back to keyword recall when embedding throws synchronously", async () => {
@@ -154,6 +170,42 @@ describe("hybridRecall", () => {
 		);
 
 		expect(result.results.map((row) => row.id)).toContain("mem-keyword-sync-throw");
+	});
+
+	it("falls back to keyword recall when embedding rejects before the delayed wait", async () => {
+		const unhandled: unknown[] = [];
+		const onUnhandled = (reason: unknown): void => {
+			unhandled.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandled);
+		try {
+			const now = new Date().toISOString();
+			getDbAccessor().withWriteTx((db) => {
+				db.prepare(
+					`INSERT INTO memories (
+						id, content, type, agent_id, created_at, updated_at, updated_by
+					) VALUES (?, ?, 'fact', 'default', ?, ?, 'test')`,
+				).run("mem-keyword-async-reject", "keyword recall survives fast async embedding rejection", now, now);
+			});
+
+			const result = await hybridRecall(
+				{
+					query: "keyword recall fast async rejection",
+					keywordQuery: "keyword recall fast async rejection",
+					limit: 5,
+					agentId: "default",
+					readPolicy: "isolated",
+				},
+				loadMemoryConfig(dir),
+				() => Promise.reject(new Error("embedding unavailable")),
+			);
+			await Bun.sleep(0);
+
+			expect(result.results.map((row) => row.id)).toContain("mem-keyword-async-reject");
+			expect(unhandled).toEqual([]);
+		} finally {
+			process.off("unhandledRejection", onUnhandled);
+		}
 	});
 
 	it("excludes soft-deleted memories from BM25/FTS keyword recall", async () => {
@@ -186,6 +238,48 @@ describe("hybridRecall", () => {
 		);
 
 		expect(result.results.map((row) => row.id)).not.toContain("mem-bm25-deleted");
+	});
+
+	it("keeps hint recall scoped to live memories for the requesting agent", async () => {
+		const now = new Date().toISOString();
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, type, agent_id, created_at, updated_at, updated_by, is_deleted
+				) VALUES (?, ?, 'fact', 'default', ?, ?, 'test', 1)`,
+			).run("mem-hint-deleted", "deleted hint target has unrelated body", now, now);
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, type, agent_id, created_at, updated_at, updated_by
+				) VALUES (?, ?, 'fact', 'agent-b', ?, ?, 'test')`,
+			).run("mem-hint-other-agent", "other agent hint target has unrelated body", now, now);
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, type, agent_id, created_at, updated_at, updated_by
+				) VALUES (?, ?, 'fact', 'default', ?, ?, 'test')`,
+			).run("mem-hint-live", "live hint target has unrelated body", now, now);
+			const stmt = db.prepare(
+				`INSERT INTO memory_hints (id, memory_id, agent_id, hint, created_at)
+				 VALUES (?, ?, ?, ?, ?)`,
+			);
+			stmt.run("hint-deleted", "mem-hint-deleted", "default", "hint-scope-marker", now);
+			stmt.run("hint-other-agent", "mem-hint-other-agent", "agent-b", "hint-scope-marker", now);
+			stmt.run("hint-live", "mem-hint-live", "default", "hint-scope-marker", now);
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "hint-scope-marker",
+				keywordQuery: "hint-scope-marker",
+				limit: 5,
+				agentId: "default",
+				readPolicy: "isolated",
+			},
+			loadMemoryConfig(dir),
+			async () => null,
+		);
+
+		expect(result.results.map((row) => row.id)).toEqual(["mem-hint-live"]);
 	});
 
 	it("recalls indexed native harness memory artifacts without materializing memories", async () => {
@@ -695,7 +789,12 @@ describe("hybridRecall", () => {
 			db.prepare(
 				`INSERT INTO memory_hints (id, memory_id, agent_id, hint, created_at)
 				 VALUES (?, ?, 'default', ?, ?)`,
-			).run("hint-spotify-structured", "mem-spotify-structured", "What music streaming service has the user been using lately?", now);
+			).run(
+				"hint-spotify-structured",
+				"mem-spotify-structured",
+				"What music streaming service has the user been using lately?",
+				now,
+			);
 		});
 
 		const cfg = loadMemoryConfig(dir);

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -83,6 +83,7 @@ export interface RecallResponse {
 		totalReturned: number;
 		hasSupplementary: boolean;
 		noHits: boolean;
+		timings: RecallTimings;
 	};
 	entities?: Array<{
 		name: string;
@@ -96,6 +97,64 @@ export interface RecallResponse {
 }
 
 export type EmbedFn = (text: string, cfg: EmbeddingConfig) => Promise<number[] | null>;
+
+export interface RecallStageTiming {
+	name: string;
+	durationMs: number;
+}
+
+export interface RecallTimings {
+	totalMs: number;
+	stages: RecallStageTiming[];
+}
+
+type UntimedRecallResponse = Omit<RecallResponse, "meta"> & {
+	meta: Omit<RecallResponse["meta"], "timings">;
+};
+
+const RECALL_TIMING_LOG_THRESHOLD_MS = 1000;
+
+function roundDuration(ms: number): number {
+	return Math.round(ms * 100) / 100;
+}
+
+function createRecallTimingCollector(): {
+	readonly record: (name: string, start: number) => void;
+	readonly time: <T>(name: string, fn: () => T) => T;
+	readonly timeAsync: <T>(name: string, fn: () => Promise<T>) => Promise<T>;
+	readonly finish: () => RecallTimings;
+} {
+	const start = performance.now();
+	const stages: RecallStageTiming[] = [];
+	const record = (name: string, stageStart: number): void => {
+		stages.push({ name, durationMs: roundDuration(performance.now() - stageStart) });
+	};
+	return {
+		record,
+		time<T>(name: string, fn: () => T): T {
+			const stageStart = performance.now();
+			try {
+				return fn();
+			} finally {
+				record(name, stageStart);
+			}
+		},
+		async timeAsync<T>(name: string, fn: () => Promise<T>): Promise<T> {
+			const stageStart = performance.now();
+			try {
+				return await fn();
+			} finally {
+				record(name, stageStart);
+			}
+		},
+		finish(): RecallTimings {
+			return {
+				totalMs: roundDuration(performance.now() - start),
+				stages: [...stages],
+			};
+		},
+	};
+}
 
 // ---------------------------------------------------------------------------
 // Agent scope clause (exported for testing)
@@ -950,15 +1009,44 @@ export async function hybridRecall(
 	const limit = params.limit ?? 10;
 	const alpha = cfg.search.alpha;
 	const minScore = cfg.search.min_score;
+	const timings = createRecallTimingCollector();
+	const finish = (response: UntimedRecallResponse): RecallResponse => {
+		const recallTimings = timings.finish();
+		if (recallTimings.totalMs >= RECALL_TIMING_LOG_THRESHOLD_MS) {
+			logger.warn("memory", "Recall stage timings", {
+				agentId: params.agentId ?? "default",
+				limit,
+				resultCount: response.meta.totalReturned,
+				totalMs: recallTimings.totalMs,
+				stages: recallTimings.stages,
+			});
+		}
+		return {
+			...response,
+			meta: {
+				...response.meta,
+				timings: recallTimings,
+			},
+		};
+	};
 
 	const filter = buildFilterClause(params);
 	const scoped = params.scope !== undefined;
 	const queryVecPromise = (() => {
+		const embeddingStart = performance.now();
+		let promise: Promise<number[] | null>;
 		try {
-			return Promise.resolve(embedFn(query, cfg.embedding));
+			promise = Promise.resolve(embedFn(query, cfg.embedding));
 		} catch (e) {
-			return Promise.reject(e);
+			promise = Promise.reject(e);
 		}
+		const timed = promise.finally(() => {
+			timings.record("query_embedding_total", embeddingStart);
+		});
+		// The actual error path is handled later at query_embedding_wait, but
+		// Bun can report a fast rejection before synchronous DB work reaches it.
+		timed.catch(() => undefined);
+		return timed;
 	})();
 	let graphQueryTokens: string[] | undefined;
 	let focalCache: { agentId: string; value: ReturnType<typeof resolveFocalEntities> } | null = null;
@@ -983,30 +1071,34 @@ export async function hybridRecall(
 	const hintMap = new Map<string, number>();
 	const traversalEvidenceMap = new Map<string, number>();
 	try {
-		getDbAccessor().withReadDb((db) => {
-			const ftsRows = (
-				db.prepare(`
+		timings.time("memory_fts", () => {
+			getDbAccessor().withReadDb((db) => {
+				// CROSS JOIN keeps SQLite from scanning memories first via
+				// low-selectivity filters before applying the FTS rowid match.
+				const ftsRows = (
+					db.prepare(`
         SELECT m.id, bm25(memories_fts) AS raw_score
         FROM memories_fts
-        JOIN memories m ON memories_fts.rowid = m.rowid
+        CROSS JOIN memories m ON memories_fts.rowid = m.rowid
         WHERE memories_fts MATCH ?
           AND m.is_deleted = 0${filter.sql}
         ORDER BY raw_score
         LIMIT ?
       `) as any
-			).all(keywordQuery, ...filter.args, cfg.search.top_k) as Array<{
-				id: string;
-				raw_score: number;
-			}>;
+				).all(keywordQuery, ...filter.args, cfg.search.top_k) as Array<{
+					id: string;
+					raw_score: number;
+				}>;
 
-			// Min-max normalize BM25 scores to [0,1] within the batch
-			const rawScores = ftsRows.map((r) => Math.abs(r.raw_score));
-			const maxRaw = rawScores.length > 0 ? Math.max(...rawScores) : 1;
-			const normalizer = maxRaw > 0 ? maxRaw : 1;
-			for (const row of ftsRows) {
-				const normalised = Math.abs(row.raw_score) / normalizer;
-				bm25Map.set(row.id, normalised);
-			}
+				// Min-max normalize BM25 scores to [0,1] within the batch
+				const rawScores = ftsRows.map((r) => Math.abs(r.raw_score));
+				const maxRaw = rawScores.length > 0 ? Math.max(...rawScores) : 1;
+				const normalizer = maxRaw > 0 ? maxRaw : 1;
+				for (const row of ftsRows) {
+					const normalised = Math.abs(row.raw_score) / normalizer;
+					bm25Map.set(row.id, normalised);
+				}
+			});
 		});
 	} catch (e) {
 		logger.warn("memory", "FTS search failed, continuing with vector only", {
@@ -1019,38 +1111,36 @@ export async function hybridRecall(
 	// elevates its parent memory via Math.max (not additive stacking).
 	if (cfg.pipelineV2.hints?.enabled) {
 		try {
-			getDbAccessor().withReadDb((db) => {
-				const sql = scoped
-					? `SELECT h.memory_id AS id, bm25(memory_hints_fts) AS raw_score
+			timings.time("hints_fts", () => {
+				getDbAccessor().withReadDb((db) => {
+					// Keep memory_hints_fts first; the agent/scope indexes are much
+					// less selective than the FTS match on large workspaces.
+					const sql = `SELECT h.memory_id AS id, bm25(memory_hints_fts) AS raw_score
 					   FROM memory_hints_fts
-					   JOIN memory_hints h ON memory_hints_fts.rowid = h.rowid
-					   JOIN memories m ON m.id = h.memory_id
-					   WHERE memory_hints_fts MATCH ? AND h.agent_id = ? AND m.scope = ?
-					   ORDER BY raw_score LIMIT ?`
-					: `SELECT h.memory_id AS id, bm25(memory_hints_fts) AS raw_score
-					   FROM memory_hints_fts
-					   JOIN memory_hints h ON memory_hints_fts.rowid = h.rowid
-					   WHERE memory_hints_fts MATCH ? AND h.agent_id = ?
+					   CROSS JOIN memory_hints h ON memory_hints_fts.rowid = h.rowid
+					   CROSS JOIN memories m ON m.id = h.memory_id
+					   WHERE memory_hints_fts MATCH ?
+					     AND h.agent_id = ?
+					     AND m.is_deleted = 0${filter.sql}
 					   ORDER BY raw_score LIMIT ?`;
 
-				const agentId = params.agentId ?? "default";
-				const args = scoped
-					? [keywordQuery, agentId, params.scope, cfg.search.top_k]
-					: [keywordQuery, agentId, cfg.search.top_k];
+					const agentId = params.agentId ?? "default";
+					const args = [keywordQuery, agentId, ...filter.args, cfg.search.top_k];
 
-				const rows = (db.prepare(sql) as any).all(...args) as Array<{
-					id: string;
-					raw_score: number;
-				}>;
+					const rows = (db.prepare(sql) as any).all(...args) as Array<{
+						id: string;
+						raw_score: number;
+					}>;
 
-				// Normalize hint scores the same way as memory FTS
-				const rawScores = rows.map((r) => Math.abs(r.raw_score));
-				const maxRaw = rawScores.length > 0 ? Math.max(...rawScores) : 1;
-				const normalizer = maxRaw > 0 ? maxRaw : 1;
-				for (const row of rows) {
-					const hint = Math.abs(row.raw_score) / normalizer;
-					hintMap.set(row.id, Math.max(hintMap.get(row.id) ?? 0, hint));
-				}
+					// Normalize hint scores the same way as memory FTS
+					const rawScores = rows.map((r) => Math.abs(r.raw_score));
+					const maxRaw = rawScores.length > 0 ? Math.max(...rawScores) : 1;
+					const normalizer = maxRaw > 0 ? maxRaw : 1;
+					for (const row of rows) {
+						const hint = Math.abs(row.raw_score) / normalizer;
+						hintMap.set(row.id, Math.max(hintMap.get(row.id) ?? 0, hint));
+					}
+				});
 			});
 		} catch (e) {
 			// memory_hints_fts may not exist on pre-038 databases — silent fallback
@@ -1067,7 +1157,7 @@ export async function hybridRecall(
 	// without changing the recall channels or final ranking math.
 	let queryVecF32: Float32Array | null = null;
 	try {
-		const queryVec = await queryVecPromise;
+		const queryVec = await timings.timeAsync("query_embedding_wait", () => queryVecPromise);
 		if (queryVec) queryVecF32 = new Float32Array(queryVec);
 	} catch (e) {
 		logger.warn("memory", "Embedding failed", { error: String(e) });
@@ -1082,14 +1172,16 @@ export async function hybridRecall(
 	if (queryVecF32) {
 		const vecLimit = scoped ? cfg.search.top_k * 2 : cfg.search.top_k;
 		try {
-			getDbAccessor().withReadDb((db) => {
-				const vecResults = vectorSearch(db as any, queryVecF32!, {
-					limit: vecLimit,
-					type: params.type as "fact" | "preference" | "decision" | undefined,
+			timings.time("vector_search", () => {
+				getDbAccessor().withReadDb((db) => {
+					const vecResults = vectorSearch(db as any, queryVecF32!, {
+						limit: vecLimit,
+						type: params.type as "fact" | "preference" | "decision" | undefined,
+					});
+					for (const r of vecResults) {
+						vectorMap.set(r.id, r.score);
+					}
 				});
-				for (const r of vecResults) {
-					vectorMap.set(r.id, r.score);
-				}
 			});
 		} catch (e) {
 			logger.warn("memory", "Vector search failed, using keyword only", {
@@ -1108,13 +1200,15 @@ export async function hybridRecall(
 	if (cfg.pipelineV2.graph.enabled) {
 		try {
 			const agentId = params.agentId ?? "default";
-			const candidates = getDbAccessor().withReadDb((db) =>
-				findStructuredPathCandidates(db, query, agentId, {
-					limit: cfg.search.top_k,
-					minScore,
-					filterSql: filter.sql,
-					filterArgs: filter.args,
-				}),
+			const candidates = timings.time("structured_path_candidates", () =>
+				getDbAccessor().withReadDb((db) =>
+					findStructuredPathCandidates(db, query, agentId, {
+						limit: cfg.search.top_k,
+						minScore,
+						filterSql: filter.sql,
+						filterArgs: filter.args,
+					}),
+				),
 			);
 			for (const [id, score] of candidates) structuredCandidateMap.set(id, score);
 		} catch (e) {
@@ -1128,166 +1222,171 @@ export async function hybridRecall(
 	const allIds = new Set([...bm25Map.keys(), ...hintMap.keys(), ...vectorMap.keys(), ...structuredCandidateMap.keys()]);
 	const flatScored: Array<{ id: string; score: number; source: string }> = [];
 
-	for (const id of allIds) {
-		const bm25 = bm25Map.get(id) ?? 0;
-		const hint = hintMap.get(id) ?? 0;
-		const vec = vectorMap.get(id) ?? 0;
-		const structured = structuredCandidateMap.get(id) ?? 0;
-		let score: number;
-		let source: string;
+	timings.time("flat_score_merge", () => {
+		for (const id of allIds) {
+			const bm25 = bm25Map.get(id) ?? 0;
+			const hint = hintMap.get(id) ?? 0;
+			const vec = vectorMap.get(id) ?? 0;
+			const structured = structuredCandidateMap.get(id) ?? 0;
+			let score: number;
+			let source: string;
 
-		if (bm25 > 0 && vec > 0) {
-			score = alpha * vec + (1 - alpha) * bm25;
-			source = "hybrid";
-		} else if (vec > 0) {
-			score = vec;
-			source = "vector";
-		} else if (bm25 > 0) {
-			score = bm25;
-			source = "keyword";
-		} else {
-			score = structured;
-			source = "structured";
-		}
-		if (hint > 0 && hint >= score) {
-			const hasDirectEvidence = bm25 > 0 || vec > 0 || structured > 0;
-			score = hasDirectEvidence ? hint : Math.min(hint, HINT_ONLY_SCORE_CAP);
-			source = bm25 > 0 || vec > 0 ? "hybrid" : structured > 0 ? "sec" : "hint";
-		}
-		if (structured > 0 && structured >= score) {
-			score = structured;
-			source = bm25 > 0 || vec > 0 || hint > 0 ? "sec" : "structured";
+			if (bm25 > 0 && vec > 0) {
+				score = alpha * vec + (1 - alpha) * bm25;
+				source = "hybrid";
+			} else if (vec > 0) {
+				score = vec;
+				source = "vector";
+			} else if (bm25 > 0) {
+				score = bm25;
+				source = "keyword";
+			} else {
+				score = structured;
+				source = "structured";
+			}
+			if (hint > 0 && hint >= score) {
+				const hasDirectEvidence = bm25 > 0 || vec > 0 || structured > 0;
+				score = hasDirectEvidence ? hint : Math.min(hint, HINT_ONLY_SCORE_CAP);
+				source = bm25 > 0 || vec > 0 ? "hybrid" : structured > 0 ? "sec" : "hint";
+			}
+			if (structured > 0 && structured >= score) {
+				score = structured;
+				source = bm25 > 0 || vec > 0 || hint > 0 ? "sec" : "structured";
+			}
+
+			if (score >= minScore) flatScored.push({ id, score, source });
 		}
 
-		if (score >= minScore) flatScored.push({ id, score, source });
-	}
-
-	flatScored.sort((a, b) => b.score - a.score);
+		flatScored.sort((a, b) => b.score - a.score);
+	});
 
 	// --- Score pipeline: traversal-primary vs legacy boost ---
 	const traversalPrimary =
 		cfg.pipelineV2.graph.enabled && cfg.pipelineV2.traversal?.enabled && cfg.pipelineV2.traversal?.primary !== false;
 
-	let scored: Array<{ id: string; score: number; source: string }>;
+	let scored: Array<{ id: string; score: number; source: string }> = [];
 
 	if (traversalPrimary) {
-		// Channel A: graph traversal (primary retrieval path per DP-6)
-		const traversalScored: Array<{ id: string; score: number; source: string }> = [];
+		timings.time("traversal_primary", () => {
+			// Channel A: graph traversal (primary retrieval path per DP-6)
+			const traversalScored: Array<{ id: string; score: number; source: string }> = [];
 
-		if (cfg.pipelineV2.traversal) {
-			try {
-				const traversalCfg = cfg.pipelineV2.traversal;
-				const queryTokens = getGraphQueryTokens();
-				if (queryTokens.length > 0) {
-					const agentId = params.agentId ?? "default";
-					const focal = getFocalEntities(agentId);
+			if (cfg.pipelineV2.traversal) {
+				try {
+					const traversalCfg = cfg.pipelineV2.traversal;
+					const queryTokens = getGraphQueryTokens();
+					if (queryTokens.length > 0) {
+						const agentId = params.agentId ?? "default";
+						const focal = getFocalEntities(agentId);
 
-					if (focal.entityIds.length > 0) {
-						const traversal = getDbAccessor().withReadDb((db) =>
-							traverseKnowledgeGraph(focal.entityIds, db, agentId, {
-								maxAspectsPerEntity: traversalCfg.maxAspectsPerEntity,
-								maxAttributesPerAspect: traversalCfg.maxAttributesPerAspect,
-								maxDependencyHops: traversalCfg.maxDependencyHops,
-								minDependencyStrength: traversalCfg.minDependencyStrength,
-								maxBranching: traversalCfg.maxBranching,
-								maxTraversalPaths: traversalCfg.maxTraversalPaths,
-								minConfidence: traversalCfg.minConfidence,
-								timeoutMs: traversalCfg.timeoutMs,
-								scope: params.scope,
-							}),
-						);
-
-						// Cosine re-scoring: when query embedding is available,
-						// blend structural importance with semantic similarity so
-						// traversal results rank by relevance, not just graph
-						// proximity.  Without this, uniform importance (0.5/0.8)
-						// makes traversal ordering effectively random.
-						const cosineMap = new Map<string, number>();
-						if (queryVecF32 && traversal.memoryScores.size > 0) {
-							const ids = [...traversal.memoryScores.keys()];
-							const ph = ids.map(() => "?").join(", ");
-							const embRows = getDbAccessor().withReadDb(
-								(db) =>
-									db
-										.prepare(
-											`SELECT source_id, vector FROM embeddings
-										 WHERE source_id IN (${ph}) AND vector IS NOT NULL`,
-										)
-										.all(...ids) as Array<{
-										source_id: string;
-										vector: Buffer | null;
-									}>,
+						if (focal.entityIds.length > 0) {
+							const traversal = getDbAccessor().withReadDb((db) =>
+								traverseKnowledgeGraph(focal.entityIds, db, agentId, {
+									maxAspectsPerEntity: traversalCfg.maxAspectsPerEntity,
+									maxAttributesPerAspect: traversalCfg.maxAttributesPerAspect,
+									maxDependencyHops: traversalCfg.maxDependencyHops,
+									minDependencyStrength: traversalCfg.minDependencyStrength,
+									maxBranching: traversalCfg.maxBranching,
+									maxTraversalPaths: traversalCfg.maxTraversalPaths,
+									minConfidence: traversalCfg.minConfidence,
+									timeoutMs: traversalCfg.timeoutMs,
+									scope: params.scope,
+								}),
 							);
-							const qv = queryVecF32;
-							for (const row of embRows) {
-								if (!row.vector) continue;
-								const mv = new Float32Array(row.vector.buffer, row.vector.byteOffset, row.vector.byteLength / 4);
-								const cosine = cosineSimilarity(qv, mv);
-								cosineMap.set(row.source_id, cosine);
-								semanticEvidenceMap.set(row.source_id, Math.max(semanticEvidenceMap.get(row.source_id) ?? 0, cosine));
-							}
-						}
 
-						const cosineWeight = 0.7;
-						for (const [memoryId, importance] of traversal.memoryScores) {
-							const cosine = cosineMap.get(memoryId) ?? 0;
-							const imp = Math.max(minScore, Math.min(1, importance));
-							traversalEvidenceMap.set(memoryId, Math.max(traversalEvidenceMap.get(memoryId) ?? 0, imp));
-							const score = cosine > 0 ? cosineWeight * cosine + (1 - cosineWeight) * imp : imp;
-							traversalScored.push({
-								id: memoryId,
-								score,
-								source: "traversal",
+							// Cosine re-scoring: when query embedding is available,
+							// blend structural importance with semantic similarity so
+							// traversal results rank by relevance, not just graph
+							// proximity. Without this, uniform importance (0.5/0.8)
+							// makes traversal ordering effectively random.
+							const cosineMap = new Map<string, number>();
+							if (queryVecF32 && traversal.memoryScores.size > 0) {
+								const ids = [...traversal.memoryScores.keys()];
+								const ph = ids.map(() => "?").join(", ");
+								const embRows = getDbAccessor().withReadDb(
+									(db) =>
+										db
+											.prepare(
+												`SELECT source_id, vector FROM embeddings
+											 WHERE source_id IN (${ph}) AND vector IS NOT NULL`,
+											)
+											.all(...ids) as Array<{
+											source_id: string;
+											vector: Buffer | null;
+										}>,
+								);
+								const qv = queryVecF32;
+								for (const row of embRows) {
+									if (!row.vector) continue;
+									const mv = new Float32Array(row.vector.buffer, row.vector.byteOffset, row.vector.byteLength / 4);
+									const cosine = cosineSimilarity(qv, mv);
+									cosineMap.set(row.source_id, cosine);
+									semanticEvidenceMap.set(row.source_id, Math.max(semanticEvidenceMap.get(row.source_id) ?? 0, cosine));
+								}
+							}
+
+							const cosineWeight = 0.7;
+							for (const [memoryId, importance] of traversal.memoryScores) {
+								const cosine = cosineMap.get(memoryId) ?? 0;
+								const imp = Math.max(minScore, Math.min(1, importance));
+								traversalEvidenceMap.set(memoryId, Math.max(traversalEvidenceMap.get(memoryId) ?? 0, imp));
+								const score = cosine > 0 ? cosineWeight * cosine + (1 - cosineWeight) * imp : imp;
+								traversalScored.push({
+									id: memoryId,
+									score,
+									source: "traversal",
+								});
+							}
+
+							setTraversalStatus({
+								phase: "recall",
+								at: new Date().toISOString(),
+								source: focal.source,
+								focalEntityNames: focal.entityNames,
+								focalEntities: focal.entityIds.length,
+								traversedEntities: traversal.entityCount,
+								memoryCount: traversal.memoryIds.size,
+								constraintCount: traversal.constraints.length,
+								timedOut: traversal.timedOut,
 							});
 						}
-
-						setTraversalStatus({
-							phase: "recall",
-							at: new Date().toISOString(),
-							source: focal.source,
-							focalEntityNames: focal.entityNames,
-							focalEntities: focal.entityIds.length,
-							traversedEntities: traversal.entityCount,
-							memoryCount: traversal.memoryIds.size,
-							constraintCount: traversal.constraints.length,
-							timedOut: traversal.timedOut,
-						});
 					}
+				} catch (e) {
+					logger.warn("memory", "Traversal channel failed (non-fatal)", {
+						error: e instanceof Error ? e.message : String(e),
+					});
 				}
-			} catch (e) {
-				logger.warn("memory", "Traversal channel failed (non-fatal)", {
-					error: e instanceof Error ? e.message : String(e),
-				});
 			}
-		}
 
-		// Channel merge: ensure flat candidates are eligible to compete in the
-		// final sorted pool. Flat gets at least 40% of pre-sort slots so hub
-		// entities (high-mention traversal walks) can't exclude keyword/vector
-		// matches entirely. After the sort, final top-N is score-ordered —
-		// the guarantee is eligibility, not placement.
-		const traversalIds = new Set(traversalScored.map((s) => s.id));
-		const flatOnly = flatScored.filter((s) => !traversalIds.has(s.id));
-		const candidateBudget = Math.max(limit, Math.min(cfg.search.top_k, limit * 4));
-		const minFlat = Math.ceil(candidateBudget * 0.4);
-		const maxTraversal = candidateBudget - Math.min(minFlat, flatOnly.length);
-		scored = [
-			...traversalScored.slice(0, maxTraversal),
-			// When traversal underperforms its cap, flat absorbs the surplus
-			// slots — this is intentional, not a bug. Keep the pre-SEC pool
-			// wider than the final limit so structured evidence can rescue
-			// lower raw-rank but better path-matched candidates.
-			...flatOnly.slice(0, candidateBudget - Math.min(maxTraversal, traversalScored.length)),
-		];
-		scored.sort((a, b) => b.score - a.score);
+			// Channel merge: ensure flat candidates are eligible to compete in the
+			// final sorted pool. Flat gets at least 40% of pre-sort slots so hub
+			// entities (high-mention traversal walks) can't exclude keyword/vector
+			// matches entirely. After the sort, final top-N is score-ordered.
+			const traversalIds = new Set(traversalScored.map((s) => s.id));
+			const flatOnly = flatScored.filter((s) => !traversalIds.has(s.id));
+			const candidateBudget = Math.max(limit, Math.min(cfg.search.top_k, limit * 4));
+			const minFlat = Math.ceil(candidateBudget * 0.4);
+			const maxTraversal = candidateBudget - Math.min(minFlat, flatOnly.length);
+			scored = [
+				...traversalScored.slice(0, maxTraversal),
+				// When traversal underperforms its cap, flat absorbs the surplus
+				// slots — this is intentional, not a bug. Keep the pre-SEC pool
+				// wider than the final limit so structured evidence can rescue
+				// lower raw-rank but better path-matched candidates.
+				...flatOnly.slice(0, candidateBudget - Math.min(maxTraversal, traversalScored.length)),
+			];
+			scored.sort((a, b) => b.score - a.score);
+		});
 	} else {
 		scored = flatScored;
 
 		// --- Graph boost: pull up memories linked via knowledge graph ---
 		if (cfg.pipelineV2.graph.enabled && cfg.pipelineV2.graph.boostWeight > 0) {
 			try {
-				const graphResult = getDbAccessor().withReadDb((db) =>
-					getGraphBoostIds(query, db, cfg.pipelineV2.graph.boostTimeoutMs, params.agentId),
+				const graphResult = timings.time("graph_boost", () =>
+					getDbAccessor().withReadDb((db) =>
+						getGraphBoostIds(query, db, cfg.pipelineV2.graph.boostTimeoutMs, params.agentId),
+					),
 				);
 				if (graphResult.graphLinkedIds.size > 0) {
 					const gw = cfg.pipelineV2.graph.boostWeight;
@@ -1309,47 +1408,48 @@ export async function hybridRecall(
 		// --- KA traversal boost: structural one-hop retrieval via KA tables ---
 		if (cfg.pipelineV2.graph.enabled && cfg.pipelineV2.traversal?.enabled) {
 			try {
-				const traversalCfg = cfg.pipelineV2.traversal;
-				const queryTokens = getGraphQueryTokens();
-				if (queryTokens.length > 0) {
-					const agentId = params.agentId ?? "default";
-					const focal = getFocalEntities(agentId);
+				timings.time("traversal_boost", () => {
+					const traversalCfg = cfg.pipelineV2.traversal;
+					const queryTokens = getGraphQueryTokens();
+					if (traversalCfg && queryTokens.length > 0) {
+						const agentId = params.agentId ?? "default";
+						const focal = getFocalEntities(agentId);
 
-					if (focal.entityIds.length > 0) {
-						const traversal = getDbAccessor().withReadDb((db) =>
-							traverseKnowledgeGraph(focal.entityIds, db, agentId, {
-								maxAspectsPerEntity: traversalCfg.maxAspectsPerEntity,
-								maxAttributesPerAspect: traversalCfg.maxAttributesPerAspect,
-								maxDependencyHops: traversalCfg.maxDependencyHops,
-								minDependencyStrength: traversalCfg.minDependencyStrength,
-								maxBranching: traversalCfg.maxBranching,
-								maxTraversalPaths: traversalCfg.maxTraversalPaths,
-								minConfidence: traversalCfg.minConfidence,
-								timeoutMs: traversalCfg.timeoutMs,
-							}),
-						);
+						if (focal.entityIds.length > 0) {
+							const traversal = getDbAccessor().withReadDb((db) =>
+								traverseKnowledgeGraph(focal.entityIds, db, agentId, {
+									maxAspectsPerEntity: traversalCfg.maxAspectsPerEntity,
+									maxAttributesPerAspect: traversalCfg.maxAttributesPerAspect,
+									maxDependencyHops: traversalCfg.maxDependencyHops,
+									minDependencyStrength: traversalCfg.minDependencyStrength,
+									maxBranching: traversalCfg.maxBranching,
+									maxTraversalPaths: traversalCfg.maxTraversalPaths,
+									minConfidence: traversalCfg.minConfidence,
+									timeoutMs: traversalCfg.timeoutMs,
+								}),
+							);
 
-						const tw = traversalCfg.boostWeight;
-						const scoredById = new Map(scored.map((row) => [row.id, row]));
-						const missingIds: string[] = [];
+							const tw = traversalCfg.boostWeight;
+							const scoredById = new Map(scored.map((row) => [row.id, row]));
+							const missingIds: string[] = [];
 
-						for (const memoryId of traversal.memoryIds) {
-							const existing = scoredById.get(memoryId);
-							if (existing) {
-								existing.score = (1 - tw) * existing.score + tw;
-								traversalEvidenceMap.set(memoryId, Math.max(traversalEvidenceMap.get(memoryId) ?? 0, tw));
-							} else {
-								missingIds.push(memoryId);
+							for (const memoryId of traversal.memoryIds) {
+								const existing = scoredById.get(memoryId);
+								if (existing) {
+									existing.score = (1 - tw) * existing.score + tw;
+									traversalEvidenceMap.set(memoryId, Math.max(traversalEvidenceMap.get(memoryId) ?? 0, tw));
+								} else {
+									missingIds.push(memoryId);
+								}
 							}
-						}
 
-						if (missingIds.length > 0) {
-							const placeholders = missingIds.map(() => "?").join(", ");
-							const baseRows = getDbAccessor().withReadDb(
-								(db) =>
-									db
-										.prepare(
-											`SELECT
+							if (missingIds.length > 0) {
+								const placeholders = missingIds.map(() => "?").join(", ");
+								const baseRows = getDbAccessor().withReadDb(
+									(db) =>
+										db
+											.prepare(
+												`SELECT
 												 m.id,
 												 COALESCE(MAX(ea.importance), m.importance, 0.5) AS traversal_score
 											 FROM memories m
@@ -1361,39 +1461,40 @@ export async function hybridRecall(
 											   AND m.is_deleted = 0
 											 ${filter.sql}
 											 GROUP BY m.id, m.importance`,
-										)
-										.all(agentId, ...missingIds, ...filter.args) as Array<{
-										id: string;
-										traversal_score: number;
-									}>,
-							);
+											)
+											.all(agentId, ...missingIds, ...filter.args) as Array<{
+											id: string;
+											traversal_score: number;
+										}>,
+								);
 
-							for (const row of baseRows) {
-								const traversalScore = Math.max(minScore, Math.min(1, row.traversal_score));
-								traversalEvidenceMap.set(row.id, Math.max(traversalEvidenceMap.get(row.id) ?? 0, traversalScore));
-								scored.push({
-									id: row.id,
-									score: traversalScore,
-									source: "ka_traversal",
-								});
+								for (const row of baseRows) {
+									const traversalScore = Math.max(minScore, Math.min(1, row.traversal_score));
+									traversalEvidenceMap.set(row.id, Math.max(traversalEvidenceMap.get(row.id) ?? 0, traversalScore));
+									scored.push({
+										id: row.id,
+										score: traversalScore,
+										source: "ka_traversal",
+									});
+								}
 							}
+
+							scored.sort((a, b) => b.score - a.score);
+
+							setTraversalStatus({
+								phase: "recall",
+								at: new Date().toISOString(),
+								source: focal.source,
+								focalEntityNames: focal.entityNames,
+								focalEntities: focal.entityIds.length,
+								traversedEntities: traversal.entityCount,
+								memoryCount: traversal.memoryIds.size,
+								constraintCount: traversal.constraints.length,
+								timedOut: traversal.timedOut,
+							});
 						}
-
-						scored.sort((a, b) => b.score - a.score);
-
-						setTraversalStatus({
-							phase: "recall",
-							at: new Date().toISOString(),
-							source: focal.source,
-							focalEntityNames: focal.entityNames,
-							focalEntities: focal.entityIds.length,
-							traversedEntities: traversal.entityCount,
-							memoryCount: traversal.memoryIds.size,
-							constraintCount: traversal.constraints.length,
-							timedOut: traversal.timedOut,
-						});
 					}
-				}
+				});
 			} catch (e) {
 				logger.warn("memory", "KA traversal boost failed (non-fatal)", {
 					error: e instanceof Error ? e.message : String(e),
@@ -1418,6 +1519,7 @@ export async function hybridRecall(
 	// prevents graph-only memories from outranking directly anchored evidence,
 	// while still letting prospective hints rescue class-to-instance matches.
 	if (scored.length > 0) {
+		const structuredEvidenceStart = performance.now();
 		try {
 			const byId = new Map<string, { id: string; score: number; source: string }>();
 			for (const row of scored) mergeCandidate(byId, row);
@@ -1482,10 +1584,14 @@ export async function hybridRecall(
 			logger.warn("memory", "Structured evidence shaping failed (non-fatal)", {
 				error: e instanceof Error ? e.message : String(e),
 			});
+		} finally {
+			timings.record("structured_evidence", structuredEvidenceStart);
 		}
 	}
 
-	applyRehearsalBoost(scored, cfg.search);
+	timings.time("rehearsal_boost", () => {
+		applyRehearsalBoost(scored, cfg.search);
+	});
 
 	// --- Optional reranker hook ---
 	let recallSummary: string | undefined;
@@ -1493,6 +1599,7 @@ export async function hybridRecall(
 	// Set inside the reranker block; consumed after final results are assembled.
 	let summarizeLeft = 0;
 	if (cfg.pipelineV2.reranker.enabled) {
+		const rerankerStageStart = performance.now();
 		try {
 			const rerankStart = Date.now();
 			const topForRerank = scored.slice(0, cfg.pipelineV2.reranker.topN);
@@ -1557,6 +1664,8 @@ export async function hybridRecall(
 			logger.warn("memory", "Reranker failed (non-fatal)", {
 				error: e instanceof Error ? e.message : String(e),
 			});
+		} finally {
+			timings.record("reranker", rerankerStageStart);
 		}
 	}
 
@@ -1565,6 +1674,7 @@ export async function hybridRecall(
 	// gravity (penalize zero-term-overlap semantic hits), hub (penalize
 	// high-degree entity dominance), resolution (boost actionable types).
 	if (scored.length > 0) {
+		const dampeningStart = performance.now();
 		try {
 			const dampenIds = scored.map((s) => s.id);
 			const dampenPh = dampenIds.map(() => "?").join(", ");
@@ -1670,11 +1780,14 @@ export async function hybridRecall(
 			logger.warn("memory", "Dampening failed (non-fatal)", {
 				error: e instanceof Error ? e.message : String(e),
 			});
+		} finally {
+			timings.record("dampening", dampeningStart);
 		}
 	}
 
 	let currentness = new Map<string, CurrentnessInfo>();
 	if (scored.length > 0) {
+		const currentnessStart = performance.now();
 		try {
 			currentness = loadCurrentnessInfo(
 				scored.map((row) => row.id),
@@ -1685,17 +1798,21 @@ export async function hybridRecall(
 			logger.warn("memory", "Currentness shaping failed (non-fatal)", {
 				error: e instanceof Error ? e.message : String(e),
 			});
+		} finally {
+			timings.record("currentness", currentnessStart);
 		}
 	}
 
-	for (const row of scored) {
-		const hasDirectEvidence =
-			(bm25Map.get(row.id) ?? 0) > 0 ||
-			(vectorMap.get(row.id) ?? 0) > 0 ||
-			(structuredEvidenceMap.get(row.id) ?? 0) > 0;
-		if (row.source === "hint" && !hasDirectEvidence) row.score = Math.min(row.score, HINT_ONLY_SCORE_CAP);
-	}
-	scored.sort((a, b) => b.score - a.score);
+	timings.time("final_rank", () => {
+		for (const row of scored) {
+			const hasDirectEvidence =
+				(bm25Map.get(row.id) ?? 0) > 0 ||
+				(vectorMap.get(row.id) ?? 0) > 0 ||
+				(structuredEvidenceMap.get(row.id) ?? 0) > 0;
+			if (row.source === "hint" && !hasDirectEvidence) row.score = Math.min(row.score, HINT_ONLY_SCORE_CAP);
+		}
+		scored.sort((a, b) => b.score - a.score);
+	});
 
 	// Over-fetch before hydration when scoped. Vector search can't
 	// pre-filter by scope, so out-of-scope IDs get dropped at
@@ -1705,7 +1822,9 @@ export async function hybridRecall(
 	const recallTruncate = cfg.pipelineV2.guardrails.recallTruncateChars;
 
 	if (topIds.length === 0) {
-		const sourceChunkHits = buildSourceChunkVectorHits(queryVecF32, new Set(), limit, params.agentId);
+		const sourceChunkHits = timings.time("source_chunk_vector_fallback", () =>
+			buildSourceChunkVectorHits(queryVecF32, new Set(), limit, params.agentId),
+		);
 		if (sourceChunkHits.length > 0) {
 			const results = sourceChunkHits.slice(0, limit).map((hit): RecallResult => {
 				const content = `[Obsidian vault chunk: ${hit.sourcePath}]\n${hit.chunkText}`;
@@ -1730,7 +1849,7 @@ export async function hybridRecall(
 					supplementary: true,
 				};
 			});
-			return {
+			return finish({
 				results,
 				query,
 				method: "hybrid",
@@ -1739,9 +1858,11 @@ export async function hybridRecall(
 					hasSupplementary: true,
 					noHits: false,
 				},
-			};
+			});
 		}
-		const nativeHits = buildNativeArtifactRecallHits(params, expandedQuery, new Set());
+		const nativeHits = timings.time("native_artifact_fallback", () =>
+			buildNativeArtifactRecallHits(params, expandedQuery, new Set()),
+		);
 		if (nativeHits.length > 0) {
 			const results = nativeHits.slice(0, limit).map((hit): RecallResult => {
 				const content = nativeArtifactRecallContent(hit);
@@ -1767,7 +1888,7 @@ export async function hybridRecall(
 					supplementary: true,
 				};
 			});
-			return {
+			return finish({
 				results,
 				query,
 				method: "keyword",
@@ -1776,9 +1897,11 @@ export async function hybridRecall(
 					hasSupplementary: true,
 					noHits: false,
 				},
-			};
+			});
 		}
-		const transcriptHits = buildTranscriptRecallHits(params, expandedQuery, new Set());
+		const transcriptHits = timings.time("transcript_fallback", () =>
+			buildTranscriptRecallHits(params, expandedQuery, new Set()),
+		);
 		if (transcriptHits.length > 0) {
 			const transcriptSummaries = loadStructuredSummariesBySourceId(
 				params,
@@ -1810,7 +1933,7 @@ export async function hybridRecall(
 					supplementary: true,
 				};
 			});
-			return {
+			return finish({
 				results,
 				query,
 				method: "keyword",
@@ -1819,9 +1942,9 @@ export async function hybridRecall(
 					hasSupplementary: true,
 					noHits: false,
 				},
-			};
+			});
 		}
-		return {
+		return finish({
 			results: [],
 			query,
 			method: "hybrid",
@@ -1830,7 +1953,7 @@ export async function hybridRecall(
 				hasSupplementary: false,
 				noHits: true,
 			},
-		};
+		});
 	}
 
 	// --- Fetch full memory rows ---
@@ -1853,26 +1976,28 @@ export async function hybridRecall(
 			: { sql: "", args: [] };
 	const placeholders = topIds.map(() => "?").join(", ");
 
-	const rows = getDbAccessor().withReadDb(
-		(db) =>
-			db
-				.prepare(
-					`SELECT m.id, m.content, m.source_id, m.type, m.tags, m.pinned, m.importance, m.who, m.project, m.created_at
+	const rows = timings.time("hydrate_memory_rows", () =>
+		getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare(
+						`SELECT m.id, m.content, m.source_id, m.type, m.tags, m.pinned, m.importance, m.who, m.project, m.created_at
         FROM memories m
-        WHERE m.id IN (${placeholders})${scopeClause}${projectClause}${agentScope.sql}`,
-				)
-				.all(...topIds, ...scopeArgs, ...projectArgs, ...agentScope.args) as Array<{
-				id: string;
-				content: string;
-				source_id: string | null;
-				type: string;
-				tags: string | null;
-				pinned: number;
-				importance: number;
-				who: string;
-				project: string | null;
-				created_at: string;
-			}>,
+        WHERE m.id IN (${placeholders}) AND m.is_deleted = 0${scopeClause}${projectClause}${agentScope.sql}`,
+					)
+					.all(...topIds, ...scopeArgs, ...projectArgs, ...agentScope.args) as Array<{
+					id: string;
+					content: string;
+					source_id: string | null;
+					type: string;
+					tags: string | null;
+					pinned: number;
+					importance: number;
+					who: string;
+					project: string | null;
+					created_at: string;
+				}>,
+		),
 	);
 
 	// Update access tracking (don't fail if this fails).
@@ -1880,12 +2005,14 @@ export async function hybridRecall(
 	// array — so the synthetic llm_summary card injected later is never
 	// included here and never touches the memories table.
 	try {
-		getDbAccessor().withWriteTx((db) => {
-			db.prepare(
-				`UPDATE memories
+		timings.time("access_tracking_update", () => {
+			getDbAccessor().withWriteTx((db) => {
+				db.prepare(
+					`UPDATE memories
           SET last_accessed = datetime('now'), access_count = access_count + 1
-          WHERE id IN (${placeholders})`,
-			).run(...topIds);
+          WHERE id IN (${placeholders}) AND is_deleted = 0`,
+				).run(...topIds);
+			});
 		});
 	} catch (e) {
 		logger.warn("memory", "Failed to update access tracking", e as Error);
@@ -1894,38 +2021,37 @@ export async function hybridRecall(
 	const rowMap = new Map(rows.map((r) => [r.id, r]));
 	// No pre-decrement: always fetch `limit` memories. The summary card is
 	// injected after assembly and the array is capped to `limit` at that point.
-	const results: RecallResult[] = scored
-		.slice(0, limit)
-		.filter((s) => rowMap.has(s.id))
-		.map((s) => {
-			const r = rowMap.get(s.id)!;
-			const content = annotateCurrentness(r.content, currentness.get(r.id));
-			const isTruncated = content.length > recallTruncate;
-			return {
-				id: r.id,
-				content: isTruncated ? `${content.slice(0, recallTruncate)} [truncated]` : content,
-				content_length: content.length,
-				truncated: isTruncated,
-				score: Math.round(s.score * 100) / 100,
-				source: s.source,
-				...(r.source_id ? { source_id: r.source_id, session_id: sessionIdFromSourceId(r.source_id) } : {}),
-				type: r.type,
-				tags: r.tags,
-				pinned: !!r.pinned,
-				importance: r.importance,
-				who: r.who,
-				project: r.project,
-				created_at: r.created_at,
-			};
-		});
+	const results: RecallResult[] = timings.time("assemble_results", () =>
+		scored
+			.slice(0, limit)
+			.filter((s) => rowMap.has(s.id))
+			.map((s) => {
+				const r = rowMap.get(s.id)!;
+				const content = annotateCurrentness(r.content, currentness.get(r.id));
+				const isTruncated = content.length > recallTruncate;
+				return {
+					id: r.id,
+					content: isTruncated ? `${content.slice(0, recallTruncate)} [truncated]` : content,
+					content_length: content.length,
+					truncated: isTruncated,
+					score: Math.round(s.score * 100) / 100,
+					source: s.source,
+					...(r.source_id ? { source_id: r.source_id, session_id: sessionIdFromSourceId(r.source_id) } : {}),
+					type: r.type,
+					tags: r.tags,
+					pinned: !!r.pinned,
+					importance: r.importance,
+					who: r.who,
+					project: r.project,
+					created_at: r.created_at,
+				};
+			}),
+	);
 
 	if (results.length < limit) {
 		const existingSourceIds = new Set(results.map((row) => row.source_id).filter((id): id is string => !!id));
-		const sourceChunkHits = buildSourceChunkVectorHits(
-			queryVecF32,
-			existingSourceIds,
-			limit - results.length,
-			params.agentId,
+		const sourceChunkHits = timings.time("source_chunk_vector_supplement", () =>
+			buildSourceChunkVectorHits(queryVecF32, existingSourceIds, limit - results.length, params.agentId),
 		);
 		for (const hit of sourceChunkHits) {
 			if (results.length >= limit) break;
@@ -1956,7 +2082,9 @@ export async function hybridRecall(
 
 	if (results.length < limit) {
 		const existingSourceIds = new Set(results.map((row) => row.source_id).filter((id): id is string => !!id));
-		const nativeHits = buildNativeArtifactRecallHits(params, expandedQuery, existingSourceIds);
+		const nativeHits = timings.time("native_artifact_supplement", () =>
+			buildNativeArtifactRecallHits(params, expandedQuery, existingSourceIds),
+		);
 		for (const hit of nativeHits) {
 			if (results.length >= limit) break;
 			const content = nativeArtifactRecallContent(hit);
@@ -1988,6 +2116,7 @@ export async function hybridRecall(
 	// Skip when limit < 2: can't fit a summary card without evicting the only
 	// real memory, which would leave the caller with nothing to verify against.
 	if (summarizeLeft > 0 && results.length > 0 && limit >= 2) {
+		const llmSummaryStart = performance.now();
 		try {
 			const summCandidates = results.slice(0, 12).map((r) => ({ id: r.id, content: r.content, score: r.score }));
 			const s = await summarizeRecallWithLlm(getLlmProvider(), query, summCandidates, summarizeLeft);
@@ -1996,6 +2125,8 @@ export async function hybridRecall(
 			logger.warn("memory", "LLM summary failed (non-fatal)", {
 				error: e instanceof Error ? e.message : String(e),
 			});
+		} finally {
+			timings.record("llm_summary", llmSummaryStart);
 		}
 	}
 
@@ -2027,6 +2158,7 @@ export async function hybridRecall(
 	const existingIds = new Set(results.map((r) => r.id));
 
 	if (decisionIds.length > 0 && cfg.pipelineV2.graph.enabled) {
+		const rationaleStart = performance.now();
 		try {
 			const supplementary = getDbAccessor().withReadDb((db) => {
 				// Find entities linked to decision memories
@@ -2094,6 +2226,8 @@ export async function hybridRecall(
 			logger.warn("memory", "Rationale linking failed (non-fatal)", {
 				error: e instanceof Error ? e.message : String(e),
 			});
+		} finally {
+			timings.record("rationale_linking", rationaleStart);
 		}
 	}
 
@@ -2102,6 +2236,7 @@ export async function hybridRecall(
 	let focalEids: string[] = [];
 
 	if (cfg.pipelineV2.graph.enabled && cfg.pipelineV2.traversal?.enabled) {
+		const entityContextStart = performance.now();
 		try {
 			const queryTokens = getGraphQueryTokens();
 			if (queryTokens.length > 0) {
@@ -2147,7 +2282,7 @@ export async function hybridRecall(
 						.map((ent) => {
 							const aspects = db
 								.prepare(
-									`SELECT id, name FROM entity_aspects
+									`SELECT id, name FROM entity_aspects INDEXED BY idx_entity_aspects_entity
 								 WHERE entity_id = ? AND agent_id = ?
 								 ORDER BY weight DESC LIMIT 10`,
 								)
@@ -2160,7 +2295,7 @@ export async function hybridRecall(
 									.map((asp) => {
 										const attrs = db
 											.prepare(
-												`SELECT content, status, importance FROM entity_attributes
+												`SELECT content, status, importance FROM entity_attributes INDEXED BY idx_entity_attributes_aspect
 										 WHERE aspect_id = ? AND agent_id = ? AND status = 'active'
 										 ORDER BY importance DESC LIMIT 5`,
 											)
@@ -2188,6 +2323,8 @@ export async function hybridRecall(
 			logger.warn("memory", "Entity context fetch failed (non-fatal)", {
 				error: e instanceof Error ? e.message : String(e),
 			});
+		} finally {
+			timings.record("entity_context", entityContextStart);
 		}
 	}
 
@@ -2197,6 +2334,7 @@ export async function hybridRecall(
 	// actual memories that answer the query, cap their scores below the
 	// lowest real result score.
 	if (focalEids.length > 0) {
+		const constructedStart = performance.now();
 		try {
 			const agentId = params.agentId ?? "default";
 			const cap = Math.max(3, Math.ceil(limit * 0.3));
@@ -2233,6 +2371,8 @@ export async function hybridRecall(
 			logger.warn("memory", "Constructed context failed (non-fatal)", {
 				error: e instanceof Error ? e.message : String(e),
 			});
+		} finally {
+			timings.record("constructed_context", constructedStart);
 		}
 	}
 
@@ -2241,6 +2381,7 @@ export async function hybridRecall(
 	// lossless backing source. Use them as a mechanical rescue channel for
 	// cases where the extracted memory compressed away the exact detail.
 	if (params.expand) {
+		const transcriptExpansionStart = performance.now();
 		const sourceIds = new Set(
 			results
 				.map((result) => rowMap.get(result.id)?.source_id ?? result.source_id)
@@ -2286,11 +2427,13 @@ export async function hybridRecall(
 			results.sort((a, b) => b.score - a.score);
 			if (results.length > limit) results.length = limit;
 		}
+		timings.record("transcript_expansion", transcriptExpansionStart);
 	}
 
 	// --- Lossless expansion: fetch raw session transcripts ---
 	let sources: Record<string, string> | undefined;
 	if (params.expand) {
+		const sourceExpansionStart = performance.now();
 		try {
 			const keys = [
 				...new Set([...rowMap.values()].map((r) => r.source_id).filter((s): s is string => s !== null && s !== "")),
@@ -2314,10 +2457,13 @@ export async function hybridRecall(
 			}
 		} catch {
 			// Non-fatal — table may not exist pre-migration
+		} finally {
+			timings.record("source_expansion_fetch", sourceExpansionStart);
 		}
 	}
 
 	if (params.expand && sources) {
+		const sourceExcerptStart = performance.now();
 		for (const result of results.filter((row) => row.source !== "transcript").slice(0, Math.min(5, limit))) {
 			const sourceId = rowMap.get(result.id)?.source_id ?? result.source_id;
 			if (!sourceId) continue;
@@ -2330,9 +2476,10 @@ export async function hybridRecall(
 			result.content_length = content.length;
 			result.truncated = content.length > recallTruncate;
 		}
+		timings.record("source_excerpt_merge", sourceExcerptStart);
 	}
 
-	return {
+	return finish({
 		results,
 		query,
 		method: vectorMap.size > 0 ? "hybrid" : "keyword",
@@ -2343,5 +2490,5 @@ export async function hybridRecall(
 		},
 		entities: entityContext && entityContext.length > 0 ? entityContext : undefined,
 		sources,
-	};
+	});
 }

--- a/platform/daemon/src/pipeline/context-construction.ts
+++ b/platform/daemon/src/pipeline/context-construction.ts
@@ -132,7 +132,7 @@ export function constructContextBlocks(
 	for (const ent of entities) {
 		const aspects = db
 			.prepare(
-				`SELECT id, name FROM entity_aspects
+				`SELECT id, name FROM entity_aspects INDEXED BY idx_entity_aspects_entity
 				 WHERE entity_id = ? AND agent_id = ?
 				 ORDER BY weight DESC LIMIT 10`,
 			)
@@ -146,7 +146,7 @@ export function constructContextBlocks(
 		for (const asp of aspects) {
 			const attrs = db
 				.prepare(
-					`SELECT content, importance FROM entity_attributes
+					`SELECT content, importance FROM entity_attributes INDEXED BY idx_entity_attributes_aspect
 					 WHERE aspect_id = ? AND agent_id = ?
 					   AND status = 'active' AND kind != 'constraint'
 					 ORDER BY importance DESC LIMIT 5`,
@@ -168,8 +168,9 @@ export function constructContextBlocks(
 		const constraints = db
 			.prepare(
 				`SELECT DISTINCT ea.content, ea.importance
-				 FROM entity_attributes ea
-				 JOIN entity_aspects asp ON asp.id = ea.aspect_id
+				 FROM entity_aspects asp INDEXED BY idx_entity_aspects_entity
+				 CROSS JOIN entity_attributes ea INDEXED BY idx_entity_attributes_aspect
+				   ON ea.aspect_id = asp.id
 				 WHERE asp.entity_id = ? AND ea.agent_id = ?
 				   AND ea.kind = 'constraint' AND ea.status = 'active'
 				 ORDER BY ea.importance DESC LIMIT 10`,
@@ -186,7 +187,7 @@ export function constructContextBlocks(
 		const deps = db
 			.prepare(
 				`SELECT ed.target_entity_id, e.name
-				 FROM entity_dependencies ed
+				 FROM entity_dependencies ed INDEXED BY idx_entity_dependencies_source
 				 JOIN entities e ON e.id = ed.target_entity_id
 				 WHERE ed.source_entity_id = ? AND ed.agent_id = ?
 				   AND ed.strength >= 0.3

--- a/platform/daemon/src/pipeline/graph-traversal.ts
+++ b/platform/daemon/src/pipeline/graph-traversal.ts
@@ -111,6 +111,8 @@ function getEntityNames(db: ReadDb, ids: ReadonlyArray<string>): string[] {
 	const entityIds = sanitizeEntityIds(ids);
 	if (entityIds.length === 0) return [];
 	const placeholders = entityIds.map(() => "?").join(", ");
+	// Keep entities_fts first; broad query tokens can otherwise make
+	// SQLite scan all agent entities before applying the FTS rowid match.
 	const rows = db
 		.prepare(
 			`SELECT id, name
@@ -209,7 +211,7 @@ function resolveByQueryTokens(db: ReadDb, agentId: string, queryTokens: Readonly
 		const rows = db
 			.prepare(
 				`SELECT e.id FROM entities_fts
-				 JOIN entities e ON e.rowid = entities_fts.rowid
+					 CROSS JOIN entities e ON e.rowid = entities_fts.rowid
 				 WHERE entities_fts MATCH ?
 				   AND e.agent_id = ?
 				 ORDER BY rank
@@ -395,11 +397,12 @@ export function traverseKnowledgeGraph(
 			const constraintRows = db
 				.prepare(
 					`SELECT e.name as entity_name, ea.content, ea.importance
-					 FROM entity_attributes ea
-					 JOIN entity_aspects asp ON asp.id = ea.aspect_id
-					 JOIN entities e ON e.id = asp.entity_id
-					 WHERE asp.entity_id = ?
-					   AND asp.agent_id = ?
+						 FROM entity_aspects asp INDEXED BY idx_entity_aspects_entity
+						 CROSS JOIN entity_attributes ea INDEXED BY idx_entity_attributes_aspect
+						   ON ea.aspect_id = asp.id
+						 JOIN entities e ON e.id = asp.entity_id
+						 WHERE asp.entity_id = ?
+						   AND asp.agent_id = ?
 					   AND ea.agent_id = ?
 					   AND ea.kind = 'constraint'
 					   AND ea.status = 'active'
@@ -426,15 +429,15 @@ export function traverseKnowledgeGraph(
 
 			// Apply optional aspect name filter for on-demand expansion
 			const aspectQuery = config.aspectFilter
-				? `SELECT id FROM entity_aspects
-					 WHERE entity_id = ? AND agent_id = ?
-					   AND canonical_name LIKE ?
-					 ORDER BY weight DESC
-					 LIMIT ?`
-				: `SELECT id FROM entity_aspects
-					 WHERE entity_id = ? AND agent_id = ?
-					 ORDER BY weight DESC
-					 LIMIT ?`;
+				? `SELECT id FROM entity_aspects INDEXED BY idx_entity_aspects_entity
+						 WHERE entity_id = ? AND agent_id = ?
+						   AND canonical_name LIKE ?
+						 ORDER BY weight DESC
+						 LIMIT ?`
+				: `SELECT id FROM entity_aspects INDEXED BY idx_entity_aspects_entity
+						 WHERE entity_id = ? AND agent_id = ?
+						 ORDER BY weight DESC
+						 LIMIT ?`;
 
 			const aspectArgs = config.aspectFilter
 				? [entityId, agentId, `%${config.aspectFilter}%`, config.maxAspectsPerEntity]
@@ -452,10 +455,10 @@ export function traverseKnowledgeGraph(
 					const scopeArgs: unknown[] = config.scope === null ? [] : [config.scope];
 					attributeRows = db
 						.prepare(
-							`SELECT ea.memory_id, ea.importance FROM entity_attributes ea
-							 JOIN memories m ON m.id = ea.memory_id
-							 WHERE ea.aspect_id = ?
-							   AND ea.agent_id = ?
+							`SELECT ea.memory_id, ea.importance FROM entity_attributes ea INDEXED BY idx_entity_attributes_aspect
+								 JOIN memories m ON m.id = ea.memory_id
+								 WHERE ea.aspect_id = ?
+								   AND ea.agent_id = ?
 							   AND ea.status = 'active'
 							   AND m.is_deleted = 0 ${scopeClause}
 							 ORDER BY ea.importance DESC
@@ -468,10 +471,10 @@ export function traverseKnowledgeGraph(
 				} else {
 					attributeRows = db
 						.prepare(
-							`SELECT memory_id, importance FROM entity_attributes
-							 WHERE aspect_id = ?
-							   AND agent_id = ?
-							   AND status = 'active'
+							`SELECT memory_id, importance FROM entity_attributes INDEXED BY idx_entity_attributes_aspect
+								 WHERE aspect_id = ?
+								   AND agent_id = ?
+								   AND status = 'active'
 							 ORDER BY importance DESC
 							 LIMIT ?`,
 						)
@@ -548,8 +551,9 @@ export function traverseKnowledgeGraph(
 			const dependencyRows = db
 				.prepare(
 					`SELECT id, source_entity_id, target_entity_id FROM entity_dependencies
-					 WHERE agent_id = ?
-					   AND source_entity_id IN (${dependencyPlaceholders})
+						 INDEXED BY idx_entity_dependencies_source
+						 WHERE agent_id = ?
+						   AND source_entity_id IN (${dependencyPlaceholders})
 					   AND (COALESCE(confidence, 0.7) * strength) >= ?
 					   AND COALESCE(confidence, 0.7) >= ?
 					 ORDER BY (COALESCE(confidence, 0.7) * strength) DESC


### PR DESCRIPTION
## Summary

- add per-stage timing metadata to every memory recall response and log structured timings for slow recalls
- force FTS-backed recall joins to start from the virtual table instead of low-selectivity memory/entity indexes
- force graph/context queries to use existing selective indexes for entity/aspect/attribute/dependency lookup
- keep hint recall scoped to live memories by joining hints back to `memories` and applying `is_deleted`, scope, agent, and visibility filters
- attach an immediate rejection observer to the overlapped embedding promise so fast provider failures cannot surface as unhandled rejections before the later wait stage handles them
- extend `memory-search.bench.ts` with a copied real-workspace mode that prints averaged per-stage timings without opening the live DB directly

## Changes

- `platform/daemon/src/memory-search.ts`
- `platform/daemon/src/memory-search.test.ts`
- `platform/daemon/src/memory-search.bench.ts`
- `platform/daemon/src/pipeline/context-construction.ts`
- `platform/daemon/src/pipeline/graph-traversal.ts`

## Type

- [x] `perf` — performance improvement

## Packages affected

- [x] `@signet/daemon`

## Root Cause

Large workspaces could make SQLite choose broad `agent_id`, `status`, or `is_deleted` indexes before applying FTS rowid matches or entity/aspect filters. On a copied 1.2 GB local memory DB, this made a single recall spend tens of seconds in synchronous SQLite work.

While reviewing the optimized hint query, we also tightened the hint path so hint-only candidates must resolve through a live, in-scope memory before they can enter scoring. Review feedback also caught that the overlapped embedding request needed an immediate rejection observer while preserving the later `query_embedding_wait` error handling.

## Benchmark Workflow

Synthetic benchmark:

```bash
SIGNET_RECALL_BENCH_ITERS=5 \
SIGNET_RECALL_BENCH_MEMORIES=1000 \
SIGNET_RECALL_BENCH_EMBED_MS=10 \
bun run platform/daemon/src/memory-search.bench.ts
```

Copied real-workspace benchmark:

```bash
SIGNET_RECALL_BENCH_SOURCE_PATH=~/.agents \
SIGNET_RECALL_BENCH_ITERS=3 \
SIGNET_RECALL_BENCH_EMBED=real \
bun run platform/daemon/src/memory-search.bench.ts
```

The real-workspace mode copies `agent.yaml`, `memories.db`, and WAL/SHM files into `/tmp` first. It does not open the live DB directly.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

Readiness notes:

- Spec alignment: read `docs/specs/INDEX.md`; `bun scripts/spec-deps-check.ts` passes. This is a daemon recall performance hot-path change, not new spec/API/schema behavior.
- Agent scoping: changed data queries preserve `agent_id`, `scope`, `visibility`, and `is_deleted` filters. Hint recall now re-joins `memory_hints` through `memories` before scoring.
- Input/security/docs: no new external inputs, admin/mutation endpoints, migrations, API contract, or status docs were introduced.
- Typecheck caveat: targeted tests, benchmark, Biome check, and Bun bundle check pass locally. Broad daemon `tsc --noEmit` is still blocked by existing repo-wide type errors unrelated to this PR.

## Migration Notes (if applicable)

- No migrations touched.
- Daemon Rust parity: N/A; JS daemon recall/query-path optimization only.

## Validation

- [x] `bun test platform/daemon/src/memory-search.test.ts platform/daemon/src/knowledge-feedback.test.ts`
- [x] `SIGNET_RECALL_BENCH_ITERS=5 SIGNET_RECALL_BENCH_MEMORIES=1000 SIGNET_RECALL_BENCH_EMBED_MS=10 bun run platform/daemon/src/memory-search.bench.ts`
- [x] `SIGNET_RECALL_BENCH_SOURCE_PATH=~/.agents SIGNET_RECALL_BENCH_ITERS=3 SIGNET_RECALL_BENCH_EMBED=real bun run platform/daemon/src/memory-search.bench.ts`
- [x] `bunx biome check platform/daemon/src/memory-search.ts platform/daemon/src/memory-search.test.ts platform/daemon/src/memory-search.bench.ts platform/daemon/src/pipeline/graph-traversal.ts platform/daemon/src/pipeline/context-construction.ts`
- [x] `bun build platform/daemon/src/memory-search.ts --outfile /tmp/signet-memory-search-check.js --target bun`

Copied real-DB timing evidence:

- before SQL fixes: about 30.2s
- after FTS join-order fixes: about 1.23s
- after graph/context index forcing: about 188-212ms over 3 runs with real Ollama embeddings
- latest committed benchmark run: avg 218.09ms over 3 runs with real Ollama embeddings

## AI disclosure

- [x] AI tools were used