### PR TITLE
fix(daemon): install ClawHub skills from dashboard

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -314,10 +314,12 @@
         "sharp": "^0.34.1",
         "umap-js": "^1.4.0",
         "yaml": "^2.8.2",
+        "yauzl": "2.10.0",
         "zod": "^4.3.6",
       },
       "devDependencies": {
         "@types/libsodium-wrappers": "^0.8.2",
+        "@types/yauzl": "^2.10.3",
       },
       "optionalDependencies": {
         "@signet/native": "workspace:*",

--- a/platform/daemon/package.json
+++ b/platform/daemon/package.json
@@ -52,12 +52,14 @@
     "sharp": "^0.34.1",
     "umap-js": "^1.4.0",
     "yaml": "^2.8.2",
+    "yauzl": "2.10.0",
     "zod": "^4.3.6"
   },
   "optionalDependencies": {
     "@signet/native": "workspace:*"
   },
   "devDependencies": {
-    "@types/libsodium-wrappers": "^0.8.2"
+    "@types/libsodium-wrappers": "^0.8.2",
+    "@types/yauzl": "^2.10.3"
   }
 }

--- a/platform/daemon/src/routes/skills.test.ts
+++ b/platform/daemon/src/routes/skills.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Hono } from "hono";
@@ -9,6 +9,7 @@ import {
 	listInstalledSkills,
 	mountSkillsRoutes,
 	parseSkillFrontmatter,
+	validateExtractedSkillTree,
 } from "./skills";
 
 // ---------------------------------------------------------------------------
@@ -546,6 +547,35 @@ describe("install command args", () => {
 			kind: "skills-cli",
 			pkg: "inference-skills/skills@web-search",
 			args: ["add", "inference-skills/skills@web-search", "--global", "--yes"],
+		});
+	});
+});
+
+describe("ClawHub skill archive validation", () => {
+	const tmpRoot = join(tmpdir(), `signet-clawhub-validate-${process.pid}`);
+
+	afterEach(() => {
+		rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	it("accepts regular files and directories", () => {
+		const root = join(tmpRoot, "valid");
+		mkdirSync(join(root, "references"), { recursive: true });
+		writeFileSync(join(root, "SKILL.md"), "# Valid\n");
+		writeFileSync(join(root, "references", "README.md"), "# Reference\n");
+
+		expect(validateExtractedSkillTree(root)).toEqual({ ok: true });
+	});
+
+	it("rejects symbolic links before copying into the skills directory", () => {
+		const root = join(tmpRoot, "symlink");
+		mkdirSync(root, { recursive: true });
+		writeFileSync(join(root, "target.md"), "# Target\n");
+		symlinkSync("target.md", join(root, "SKILL.md"));
+
+		expect(validateExtractedSkillTree(root)).toEqual({
+			ok: false,
+			error: "ClawHub package root SKILL.md must be a regular file",
 		});
 	});
 });

--- a/platform/daemon/src/routes/skills.test.ts
+++ b/platform/daemon/src/routes/skills.test.ts
@@ -610,6 +610,17 @@ describe("ClawHub skill archive validation", () => {
 		).toEqual({ ok: false, error: "ClawHub zip contains unsafe paths" });
 	});
 
+	it("rejects oversized entries before extraction", () => {
+		expect(
+			validateClawhubZipEntryMetadata({
+				fileName: "large.bin",
+				externalFileAttributes: 0o100644 << 16,
+				uncompressedSize: 26 * 1024 * 1024,
+				versionMadeBy: 3 << 8,
+			}),
+		).toEqual({ ok: false, error: "ClawHub zip entry is too large" });
+	});
+
 	it("rejects symbolic links before copying into the skills directory", () => {
 		const root = join(tmpRoot, "symlink");
 		mkdirSync(root, { recursive: true });

--- a/platform/daemon/src/routes/skills.test.ts
+++ b/platform/daemon/src/routes/skills.test.ts
@@ -9,6 +9,7 @@ import {
 	listInstalledSkills,
 	mountSkillsRoutes,
 	parseSkillFrontmatter,
+	validateClawhubZipEntryMetadata,
 	validateExtractedSkillTree,
 } from "./skills";
 
@@ -565,6 +566,46 @@ describe("ClawHub skill archive validation", () => {
 		writeFileSync(join(root, "references", "README.md"), "# Reference\n");
 
 		expect(validateExtractedSkillTree(root)).toEqual({ ok: true });
+	});
+
+	it("accepts regular file metadata before extraction", () => {
+		expect(
+			validateClawhubZipEntryMetadata({
+				fileName: "references/README.md",
+				externalFileAttributes: 0o100644 << 16,
+				versionMadeBy: 3 << 8,
+			}),
+		).toEqual({ ok: true, path: "references/README.md", kind: "file" });
+	});
+
+	it("accepts directory metadata before extraction", () => {
+		expect(
+			validateClawhubZipEntryMetadata({
+				fileName: "references/",
+				externalFileAttributes: 0o40755 << 16,
+				versionMadeBy: 3 << 8,
+			}),
+		).toEqual({ ok: true, path: "references", kind: "directory" });
+	});
+
+	it("rejects symlink metadata before extraction", () => {
+		expect(
+			validateClawhubZipEntryMetadata({
+				fileName: "SKILL.md",
+				externalFileAttributes: 0o120777 << 16,
+				versionMadeBy: 3 << 8,
+			}),
+		).toEqual({ ok: false, error: "ClawHub zip contains unsupported entry types" });
+	});
+
+	it("rejects traversal paths before extraction", () => {
+		expect(
+			validateClawhubZipEntryMetadata({
+				fileName: "refs/../../SKILL.md",
+				externalFileAttributes: 0o100644 << 16,
+				versionMadeBy: 3 << 8,
+			}),
+		).toEqual({ ok: false, error: "ClawHub zip contains unsafe paths" });
 	});
 
 	it("rejects symbolic links before copying into the skills directory", () => {

--- a/platform/daemon/src/routes/skills.test.ts
+++ b/platform/daemon/src/routes/skills.test.ts
@@ -9,8 +9,10 @@ import {
 	listInstalledSkills,
 	mountSkillsRoutes,
 	parseSkillFrontmatter,
+	replaceSkillDirectoryAtomically,
 	validateClawhubZipEntryMetadata,
 	validateExtractedSkillTree,
+	withClawhubInstallLock,
 } from "./skills";
 
 // ---------------------------------------------------------------------------
@@ -618,5 +620,48 @@ describe("ClawHub skill archive validation", () => {
 			ok: false,
 			error: "ClawHub package root SKILL.md must be a regular file",
 		});
+	});
+
+	it("replaces target skill directories through a staging directory", () => {
+		const source = join(tmpRoot, "source");
+		const target = join(tmpRoot, "skills", "demo");
+		mkdirSync(source, { recursive: true });
+		mkdirSync(target, { recursive: true });
+		writeFileSync(join(source, "SKILL.md"), "# New\n");
+		writeFileSync(join(target, "SKILL.md"), "# Old\n");
+
+		replaceSkillDirectoryAtomically(source, target);
+
+		expect(readFileSync(join(target, "SKILL.md"), "utf-8")).toBe("# New\n");
+		expect(readdirSync(join(tmpRoot, "skills")).filter((name) => name.includes(".demo."))).toEqual([]);
+	});
+
+	it("serializes concurrent installs for the same ClawHub slug", async () => {
+		const order: string[] = [];
+		let releaseFirst: (() => void) | undefined;
+		let markFirstStarted: (() => void) | undefined;
+		const firstStarted = new Promise<void>((resolve) => {
+			markFirstStarted = resolve;
+		});
+		const firstCanFinish = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+
+		const first = withClawhubInstallLock("demo", async () => {
+			order.push("first:start");
+			markFirstStarted?.();
+			await firstCanFinish;
+			order.push("first:end");
+		});
+		const second = withClawhubInstallLock("demo", async () => {
+			order.push("second:start");
+			order.push("second:end");
+		});
+
+		await firstStarted;
+		expect(order).toEqual(["first:start"]);
+		releaseFirst?.();
+		await Promise.all([first, second]);
+		expect(order).toEqual(["first:start", "first:end", "second:start", "second:end"]);
 	});
 });

--- a/platform/daemon/src/routes/skills.test.ts
+++ b/platform/daemon/src/routes/skills.test.ts
@@ -3,7 +3,13 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Hono } from "hono";
-import { formatInstalls, listInstalledSkills, mountSkillsRoutes, parseSkillFrontmatter } from "./skills";
+import {
+	buildSkillInstallPlan,
+	formatInstalls,
+	listInstalledSkills,
+	mountSkillsRoutes,
+	parseSkillFrontmatter,
+} from "./skills";
 
 // ---------------------------------------------------------------------------
 // Repo skills frontmatter validation (regression guard)
@@ -512,59 +518,34 @@ This is a test skill.`,
 // ---------------------------------------------------------------------------
 
 describe("install command args", () => {
-	// Test the regex pattern used to detect multi-skill repo sources
-	const repoPattern = /^[\w-]+\/[\w.-]+$/;
-
-	it("matches owner/repo format", () => {
-		expect(repoPattern.test("Signet-AI/signetai")).toBe(true);
-		expect(repoPattern.test("vercel-labs/agent-skills")).toBe(true);
-		expect(repoPattern.test("anthropic-ai/browser-use")).toBe(true);
-	});
-
-	it("does not match clawhub@ prefixed sources", () => {
-		expect(repoPattern.test("clawhub@some-skill")).toBe(false);
-	});
-
-	it("does not match bare skill names", () => {
-		// bare names don't contain a slash
-		expect(repoPattern.test("browser-use")).toBe(false);
-		expect(repoPattern.test("web-search")).toBe(false);
-	});
-
-	it("does not match owner/repo@ref format", () => {
-		// The @ makes it fail the pattern — these are handled by skills CLI directly
-		expect(repoPattern.test("vercel-labs/skills@browser-use")).toBe(false);
-	});
-
 	it("constructs --skill flag for repo sources", () => {
-		const source = "Signet-AI/signetai";
-		const name = "web-search";
-		const args = ["add", source, "--global", "--yes"];
-		// @ts-ignore
-		if (source && source !== name && repoPattern.test(source)) {
-			args.push("--skill", name);
-		}
-		expect(args).toEqual(["add", "Signet-AI/signetai", "--global", "--yes", "--skill", "web-search"]);
+		expect(buildSkillInstallPlan("web-search", "Signet-AI/signetai")).toEqual({
+			kind: "skills-cli",
+			pkg: "Signet-AI/signetai",
+			args: ["add", "Signet-AI/signetai", "--global", "--yes", "--skill", "web-search"],
+		});
 	});
 
 	it("does not add --skill when source equals name", () => {
-		const source = "browser-use";
-		const name = "browser-use";
-		const args = ["add", source, "--global", "--yes"];
-		if (source && source !== name && repoPattern.test(source)) {
-			args.push("--skill", name);
-		}
-		expect(args).toEqual(["add", "browser-use", "--global", "--yes"]);
+		expect(buildSkillInstallPlan("browser-use", "browser-use")).toEqual({
+			kind: "skills-cli",
+			pkg: "browser-use",
+			args: ["add", "browser-use", "--global", "--yes"],
+		});
 	});
 
-	it("does not add --skill for clawhub sources", () => {
-		const source = "clawhub@some-skill";
-		const name = "some-skill";
-		const args = ["add", source, "--global", "--yes"];
-		// @ts-ignore
-		if (source && source !== name && repoPattern.test(source)) {
-			args.push("--skill", name);
-		}
-		expect(args).toEqual(["add", "clawhub@some-skill", "--global", "--yes"]);
+	it("routes ClawHub sources through the ClawHub installer", () => {
+		expect(buildSkillInstallPlan("some-skill", "clawhub@some-skill")).toEqual({
+			kind: "clawhub",
+			slug: "some-skill",
+		});
+	});
+
+	it("keeps skills.sh owner/repo@skill sources on the skills CLI path", () => {
+		expect(buildSkillInstallPlan("web-search", "inference-skills/skills@web-search")).toEqual({
+			kind: "skills-cli",
+			pkg: "inference-skills/skills@web-search",
+			args: ["add", "inference-skills/skills@web-search", "--global", "--yes"],
+		});
 	});
 });

--- a/platform/daemon/src/routes/skills.ts
+++ b/platform/daemon/src/routes/skills.ts
@@ -6,19 +6,19 @@
  */
 
 import { spawn } from "node:child_process";
-import { existsSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import { getSkillsRunnerCommand, resolvePrimaryPackageManager } from "@signet/core";
 import type { Hono } from "hono";
+import type { AuthMode } from "../auth/index.js";
+import { type DbAccessor, getDbAccessor } from "../db-accessor.js";
+import { getLlmProvider } from "../llm.js";
 import { logger } from "../logger.js";
+import { type EmbeddingConfig, type PipelineV2Config, loadMemoryConfig } from "../memory-config.js";
+import type { LlmProvider } from "../pipeline/provider.js";
 import { parseSkillFile, patchSkillFrontmatter } from "../pipeline/skill-frontmatter.js";
 import { installSkillNode, uninstallSkillNode } from "../pipeline/skill-graph.js";
-import { getDbAccessor, type DbAccessor } from "../db-accessor.js";
-import type { AuthMode } from "../auth/index.js";
-import { loadMemoryConfig, type EmbeddingConfig, type PipelineV2Config } from "../memory-config.js";
-import { getLlmProvider } from "../llm.js";
-import type { LlmProvider } from "../pipeline/provider.js";
 
 function getAgentsDir(): string {
 	return process.env.SIGNET_PATH || join(homedir(), ".agents");
@@ -103,6 +103,7 @@ let catalogFetchedAt = 0;
 let clawhubCache: ClawhubItem[] = [];
 let clawhubFetchedAt = 0;
 const CATALOG_TTL = 10 * 60 * 1000;
+const CLAWHUB_DOWNLOAD_BASE = process.env.CLAWHUB_DOWNLOAD_BASE ?? "https://clawhub.ai/api/v1/download";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -361,6 +362,120 @@ function getProviderSafe(): LlmProvider | null {
 		return getLlmProvider();
 	} catch {
 		return null;
+	}
+}
+
+type SkillInstallPlan =
+	| {
+			kind: "skills-cli";
+			pkg: string;
+			args: string[];
+	  }
+	| {
+			kind: "clawhub";
+			slug: string;
+	  };
+
+export function buildSkillInstallPlan(name: string, source?: string): SkillInstallPlan {
+	if (source?.startsWith("clawhub@")) {
+		const slug = source.slice("clawhub@".length);
+		return { kind: "clawhub", slug: slug || name };
+	}
+
+	const pkg = source || name;
+	const args = ["add", pkg, "--global", "--yes"];
+	if (source && source !== name && /^[\w-]+\/[\w.-]+$/.test(source)) {
+		args.push("--skill", name);
+	}
+	return { kind: "skills-cli", pkg, args };
+}
+
+function isSafeZipEntry(entry: string): boolean {
+	const normalized = entry.replaceAll("\\", "/");
+	if (!normalized || normalized.includes("\0") || normalized.startsWith("/") || /^[A-Za-z]:\//.test(normalized)) {
+		return false;
+	}
+	return normalized.split("/").every((part) => part && part !== "." && part !== "..");
+}
+
+function runProcess(command: string, args: string[]): Promise<{ code: number | null; stdout: string; stderr: string }> {
+	return new Promise((resolveProcess, reject) => {
+		const proc = spawn(command, args, {
+			env: { ...process.env },
+			timeout: 60000,
+			windowsHide: true,
+		});
+
+		let stdout = "";
+		let stderr = "";
+		proc.stdout.on("data", (d: Buffer) => {
+			stdout += d.toString();
+		});
+		proc.stderr.on("data", (d: Buffer) => {
+			stderr += d.toString();
+		});
+		proc.on("close", (code) => resolveProcess({ code, stdout, stderr }));
+		proc.on("error", reject);
+	});
+}
+
+async function installClawhubSkill(
+	slug: string,
+): Promise<{ success: true; output: string } | { success: false; error: string }> {
+	if (!/^[\w.-]+$/.test(slug)) {
+		return { success: false, error: "Invalid ClawHub skill slug" };
+	}
+
+	const tempRoot = mkdtempSync(join(tmpdir(), "signet-clawhub-skill-"));
+	const zipPath = join(tempRoot, `${slug}.zip`);
+	const extractDir = join(tempRoot, "extract");
+	const targetDir = join(getSkillsDir(), slug);
+
+	try {
+		const url = new URL(CLAWHUB_DOWNLOAD_BASE);
+		url.searchParams.set("slug", slug);
+		const res = await fetch(url, { headers: { "User-Agent": "signet-daemon" } });
+		if (!res.ok) {
+			return { success: false, error: `ClawHub download failed with HTTP ${res.status}` };
+		}
+
+		writeFileSync(zipPath, Buffer.from(await res.arrayBuffer()));
+
+		const listing = await runProcess("unzip", ["-Z1", zipPath]);
+		if (listing.code !== 0) {
+			return { success: false, error: listing.stderr || listing.stdout || "Unable to inspect ClawHub zip" };
+		}
+
+		const entries = listing.stdout.split(/\r?\n/).filter(Boolean);
+		if (entries.length === 0 || !entries.every(isSafeZipEntry)) {
+			return { success: false, error: "ClawHub zip contains unsafe paths" };
+		}
+
+		mkdirSync(extractDir, { recursive: true });
+		const extracted = await runProcess("unzip", ["-q", zipPath, "-d", extractDir]);
+		if (extracted.code !== 0) {
+			return { success: false, error: extracted.stderr || extracted.stdout || "Unable to extract ClawHub zip" };
+		}
+
+		if (!existsSync(join(extractDir, "SKILL.md"))) {
+			return { success: false, error: "ClawHub package did not contain a root SKILL.md" };
+		}
+
+		mkdirSync(getSkillsDir(), { recursive: true });
+		const resolvedTarget = resolve(targetDir);
+		const resolvedSkillsDir = resolve(getSkillsDir());
+		const targetRelative = relative(resolvedSkillsDir, resolvedTarget);
+		if (!targetRelative || targetRelative.startsWith("..") || isAbsolute(targetRelative)) {
+			return { success: false, error: "Invalid ClawHub install target" };
+		}
+
+		rmSync(targetDir, { recursive: true, force: true });
+		cpSync(extractDir, targetDir, { recursive: true });
+		return { success: true, output: `Installed ClawHub skill ${slug}` };
+	} catch (err) {
+		return { success: false, error: err instanceof Error ? err.message : String(err) };
+	} finally {
+		rmSync(tempRoot, { recursive: true, force: true });
 	}
 }
 
@@ -764,20 +879,31 @@ export function mountSkillsRoutes(app: Hono, _authMode: AuthMode = "local"): voi
 			return c.json({ error: "Invalid skill name" }, 400);
 		}
 
-		const pkg = source || name;
-		logger.info("skills", "Installing skill", { name, pkg });
+		const plan = buildSkillInstallPlan(name, source);
+		logger.info("skills", "Installing skill", { name, source, plan });
+
+		if (plan.kind === "clawhub") {
+			const result = await installClawhubSkill(plan.slug);
+			if (!result.success) {
+				logger.error("skills", "ClawHub skill install failed", undefined, {
+					slug: plan.slug,
+					error: result.error,
+				});
+				return c.json({ success: false, error: result.error }, 500);
+			}
+
+			logger.info("skills", "ClawHub skill installed", { name, slug: plan.slug });
+			onSkillInstalled(plan.slug).catch((e) => {
+				logger.error("skills", "Post-install graph hook failed", e as Error);
+			});
+			return c.json({ success: true, name: plan.slug, output: result.output });
+		}
+
 		const packageManager = resolvePrimaryPackageManager({
 			agentsDir: getAgentsDir(),
 			env: process.env,
 		});
-		// For multi-skill repo sources (owner/repo format), pass --skill to
-		// target a specific skill. This handles Signet-AI/signetai and any
-		// other GitHub repo that bundles multiple skills.
-		const args = ["add", pkg, "--global", "--yes"];
-		if (source && source !== name && /^[\w-]+\/[\w.-]+$/.test(source)) {
-			args.push("--skill", name);
-		}
-		const skillsCommand = getSkillsRunnerCommand(packageManager.family, args);
+		const skillsCommand = getSkillsRunnerCommand(packageManager.family, plan.args);
 
 		logger.info("skills", "Using package manager", {
 			command: `${skillsCommand.command} ${skillsCommand.args.join(" ")}`,

--- a/platform/daemon/src/routes/skills.ts
+++ b/platform/daemon/src/routes/skills.ts
@@ -8,6 +8,7 @@
 import { spawn } from "node:child_process";
 import {
 	cpSync,
+	createWriteStream,
 	existsSync,
 	lstatSync,
 	mkdirSync,
@@ -18,9 +19,12 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { pipeline } from "node:stream/promises";
 import { getSkillsRunnerCommand, resolvePrimaryPackageManager } from "@signet/core";
 import type { Hono } from "hono";
+import type { Entry, ZipFile } from "yauzl";
+import * as yauzl from "yauzl";
 import type { AuthMode } from "../auth/index.js";
 import { type DbAccessor, getDbAccessor } from "../db-accessor.js";
 import { getLlmProvider } from "../llm.js";
@@ -400,12 +404,45 @@ export function buildSkillInstallPlan(name: string, source?: string): SkillInsta
 	return { kind: "skills-cli", pkg, args };
 }
 
-function isSafeZipEntry(entry: string): boolean {
+type ClawhubZipEntryKind = "file" | "directory";
+
+type ClawhubZipEntryMetadata = {
+	fileName: string;
+	externalFileAttributes: number;
+	versionMadeBy: number;
+	encrypted?: boolean;
+};
+
+const ZIP_UNIX_HOST = 3;
+const ZIP_MODE_TYPE_MASK = 0o170000;
+const ZIP_MODE_DIRECTORY = 0o040000;
+const ZIP_MODE_REGULAR_FILE = 0o100000;
+
+function normalizeZipEntryPath(entry: string): string | null {
 	const normalized = entry.replaceAll("\\", "/");
 	if (!normalized || normalized.includes("\0") || normalized.startsWith("/") || /^[A-Za-z]:\//.test(normalized)) {
-		return false;
+		return null;
 	}
-	return normalized.split("/").every((part) => part && part !== "." && part !== "..");
+	const path = normalized.endsWith("/") ? normalized.slice(0, -1) : normalized;
+	if (!path) return null;
+	return path.split("/").every((part) => part && part !== "." && part !== "..") ? path : null;
+}
+
+export function validateClawhubZipEntryMetadata(
+	entry: ClawhubZipEntryMetadata,
+): { ok: true; path: string; kind: ClawhubZipEntryKind } | { ok: false; error: string } {
+	const path = normalizeZipEntryPath(entry.fileName);
+	if (!path) return { ok: false, error: "ClawHub zip contains unsafe paths" };
+	if (entry.encrypted) return { ok: false, error: "ClawHub zip contains encrypted entries" };
+
+	const unixMode = entry.versionMadeBy >> 8 === ZIP_UNIX_HOST ? entry.externalFileAttributes >>> 16 : 0;
+	const impliedDirectory = entry.fileName.replaceAll("\\", "/").endsWith("/");
+	if (unixMode === 0) return { ok: true, path, kind: impliedDirectory ? "directory" : "file" };
+
+	const kind = unixMode & ZIP_MODE_TYPE_MASK;
+	if (kind === ZIP_MODE_DIRECTORY) return { ok: true, path, kind: "directory" };
+	if (kind === ZIP_MODE_REGULAR_FILE && !impliedDirectory) return { ok: true, path, kind: "file" };
+	return { ok: false, error: "ClawHub zip contains unsupported entry types" };
 }
 
 export function validateExtractedSkillTree(root: string): { ok: true } | { ok: false; error: string } {
@@ -439,24 +476,101 @@ export function validateExtractedSkillTree(root: string): { ok: true } | { ok: f
 	return { ok: true };
 }
 
-function runProcess(command: string, args: string[]): Promise<{ code: number | null; stdout: string; stderr: string }> {
-	return new Promise((resolveProcess, reject) => {
-		const proc = spawn(command, args, {
-			env: { ...process.env },
-			timeout: 60000,
-			windowsHide: true,
-		});
+function openZip(path: string): Promise<ZipFile> {
+	return new Promise((resolveZip, reject) => {
+		yauzl.open(
+			path,
+			{
+				autoClose: true,
+				lazyEntries: true,
+				strictFileNames: true,
+				validateEntrySizes: true,
+			},
+			(err, zip) => {
+				if (err) {
+					reject(err);
+					return;
+				}
+				if (!zip) {
+					reject(new Error("Unable to open ClawHub zip"));
+					return;
+				}
+				resolveZip(zip);
+			},
+		);
+	});
+}
 
-		let stdout = "";
-		let stderr = "";
-		proc.stdout.on("data", (d: Buffer) => {
-			stdout += d.toString();
+function openZipEntryStream(zip: ZipFile, entry: Entry): Promise<NodeJS.ReadableStream> {
+	return new Promise((resolveStream, reject) => {
+		zip.openReadStream(entry, (err, stream) => {
+			if (err) {
+				reject(err);
+				return;
+			}
+			resolveStream(stream);
 		});
-		proc.stderr.on("data", (d: Buffer) => {
-			stderr += d.toString();
+	});
+}
+
+function resolveExtractPath(root: string, entryPath: string): string | null {
+	const target = resolve(root, entryPath);
+	const rel = relative(resolve(root), target);
+	return !rel || rel.startsWith("..") || isAbsolute(rel) ? null : target;
+}
+
+async function extractClawhubZip(
+	zipPath: string,
+	extractDir: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+	const zip = await openZip(zipPath);
+	return new Promise((resolveExtract) => {
+		let done = false;
+		const fail = (error: string): void => {
+			if (done) return;
+			done = true;
+			zip.close();
+			resolveExtract({ ok: false, error });
+		};
+		const pass = (): void => {
+			if (done) return;
+			done = true;
+			resolveExtract({ ok: true });
+		};
+
+		zip.on("error", (err) => fail(err.message));
+		zip.on("end", pass);
+		zip.on("entry", (entry: Entry) => {
+			const validation = validateClawhubZipEntryMetadata({
+				fileName: entry.fileName,
+				externalFileAttributes: entry.externalFileAttributes,
+				versionMadeBy: entry.versionMadeBy,
+				encrypted: entry.isEncrypted(),
+			});
+			if (!validation.ok) {
+				fail(validation.error);
+				return;
+			}
+
+			const target = resolveExtractPath(extractDir, validation.path);
+			if (!target) {
+				fail("ClawHub zip contains unsafe paths");
+				return;
+			}
+
+			if (validation.kind === "directory") {
+				mkdirSync(target, { recursive: true });
+				zip.readEntry();
+				return;
+			}
+
+			mkdirSync(dirname(target), { recursive: true });
+			openZipEntryStream(zip, entry)
+				.then((stream) => pipeline(stream, createWriteStream(target)))
+				.then(() => zip.readEntry())
+				.catch((err: unknown) => fail(err instanceof Error ? err.message : String(err)));
 		});
-		proc.on("close", (code) => resolveProcess({ code, stdout, stderr }));
-		proc.on("error", reject);
+		zip.readEntry();
 	});
 }
 
@@ -482,20 +596,10 @@ async function installClawhubSkill(
 
 		writeFileSync(zipPath, Buffer.from(await res.arrayBuffer()));
 
-		const listing = await runProcess("unzip", ["-Z1", zipPath]);
-		if (listing.code !== 0) {
-			return { success: false, error: listing.stderr || listing.stdout || "Unable to inspect ClawHub zip" };
-		}
-
-		const entries = listing.stdout.split(/\r?\n/).filter(Boolean);
-		if (entries.length === 0 || !entries.every(isSafeZipEntry)) {
-			return { success: false, error: "ClawHub zip contains unsafe paths" };
-		}
-
 		mkdirSync(extractDir, { recursive: true });
-		const extracted = await runProcess("unzip", ["-q", zipPath, "-d", extractDir]);
-		if (extracted.code !== 0) {
-			return { success: false, error: extracted.stderr || extracted.stdout || "Unable to extract ClawHub zip" };
+		const extracted = await extractClawhubZip(zipPath, extractDir);
+		if (!extracted.ok) {
+			return { success: false, error: extracted.error };
 		}
 
 		const validation = validateExtractedSkillTree(extractDir);

--- a/platform/daemon/src/routes/skills.ts
+++ b/platform/daemon/src/routes/skills.ts
@@ -6,7 +6,17 @@
  */
 
 import { spawn } from "node:child_process";
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+	cpSync,
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	readdirSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import { getSkillsRunnerCommand, resolvePrimaryPackageManager } from "@signet/core";
@@ -398,6 +408,37 @@ function isSafeZipEntry(entry: string): boolean {
 	return normalized.split("/").every((part) => part && part !== "." && part !== "..");
 }
 
+export function validateExtractedSkillTree(root: string): { ok: true } | { ok: false; error: string } {
+	const skillMd = join(root, "SKILL.md");
+	if (!existsSync(skillMd)) {
+		return { ok: false, error: "ClawHub package did not contain a root SKILL.md" };
+	}
+	if (!lstatSync(skillMd).isFile()) {
+		return { ok: false, error: "ClawHub package root SKILL.md must be a regular file" };
+	}
+
+	const stack = [root];
+	while (stack.length > 0) {
+		const dir = stack.pop();
+		if (!dir) continue;
+		for (const entry of readdirSync(dir, { withFileTypes: true })) {
+			const path = join(dir, entry.name);
+			if (entry.isSymbolicLink()) {
+				return { ok: false, error: "ClawHub package contains symbolic links" };
+			}
+			if (entry.isDirectory()) {
+				stack.push(path);
+				continue;
+			}
+			if (!entry.isFile()) {
+				return { ok: false, error: "ClawHub package contains non-regular files" };
+			}
+		}
+	}
+
+	return { ok: true };
+}
+
 function runProcess(command: string, args: string[]): Promise<{ code: number | null; stdout: string; stderr: string }> {
 	return new Promise((resolveProcess, reject) => {
 		const proc = spawn(command, args, {
@@ -457,8 +498,9 @@ async function installClawhubSkill(
 			return { success: false, error: extracted.stderr || extracted.stdout || "Unable to extract ClawHub zip" };
 		}
 
-		if (!existsSync(join(extractDir, "SKILL.md"))) {
-			return { success: false, error: "ClawHub package did not contain a root SKILL.md" };
+		const validation = validateExtractedSkillTree(extractDir);
+		if (!validation.ok) {
+			return { success: false, error: validation.error };
 		}
 
 		mkdirSync(getSkillsDir(), { recursive: true });

--- a/platform/daemon/src/routes/skills.ts
+++ b/platform/daemon/src/routes/skills.ts
@@ -15,6 +15,7 @@ import {
 	mkdtempSync,
 	readFileSync,
 	readdirSync,
+	renameSync,
 	rmSync,
 	writeFileSync,
 } from "node:fs";
@@ -574,6 +575,49 @@ async function extractClawhubZip(
 	});
 }
 
+const clawhubInstallLocks = new Map<string, Promise<unknown>>();
+
+export async function withClawhubInstallLock<T>(slug: string, fn: () => Promise<T>): Promise<T> {
+	const prev = clawhubInstallLocks.get(slug) ?? Promise.resolve();
+	const next = prev.catch(() => undefined).then(fn);
+	clawhubInstallLocks.set(slug, next);
+	try {
+		return await next;
+	} finally {
+		if (clawhubInstallLocks.get(slug) === next) {
+			clawhubInstallLocks.delete(slug);
+		}
+	}
+}
+
+export function replaceSkillDirectoryAtomically(sourceDir: string, targetDir: string): void {
+	const skillsDir = dirname(targetDir);
+	const targetName = targetDir.split(/[\\/]/).pop() ?? "skill";
+	const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+	const stagingDir = join(skillsDir, `.${targetName}.${suffix}.tmp`);
+	const backupDir = join(skillsDir, `.${targetName}.${suffix}.bak`);
+	let movedTarget = false;
+
+	try {
+		rmSync(stagingDir, { recursive: true, force: true });
+		rmSync(backupDir, { recursive: true, force: true });
+		cpSync(sourceDir, stagingDir, { recursive: true });
+		if (existsSync(targetDir)) {
+			renameSync(targetDir, backupDir);
+			movedTarget = true;
+		}
+		renameSync(stagingDir, targetDir);
+		rmSync(backupDir, { recursive: true, force: true });
+	} catch (err) {
+		rmSync(stagingDir, { recursive: true, force: true });
+		if (movedTarget && existsSync(backupDir) && !existsSync(targetDir)) {
+			renameSync(backupDir, targetDir);
+		}
+		rmSync(backupDir, { recursive: true, force: true });
+		throw err;
+	}
+}
+
 async function installClawhubSkill(
 	slug: string,
 ): Promise<{ success: true; output: string } | { success: false; error: string }> {
@@ -615,8 +659,7 @@ async function installClawhubSkill(
 			return { success: false, error: "Invalid ClawHub install target" };
 		}
 
-		rmSync(targetDir, { recursive: true, force: true });
-		cpSync(extractDir, targetDir, { recursive: true });
+		await withClawhubInstallLock(slug, async () => replaceSkillDirectoryAtomically(extractDir, targetDir));
 		return { success: true, output: `Installed ClawHub skill ${slug}` };
 	} catch (err) {
 		return { success: false, error: err instanceof Error ? err.message : String(err) };

--- a/platform/daemon/src/routes/skills.ts
+++ b/platform/daemon/src/routes/skills.ts
@@ -119,6 +119,10 @@ let clawhubCache: ClawhubItem[] = [];
 let clawhubFetchedAt = 0;
 const CATALOG_TTL = 10 * 60 * 1000;
 const CLAWHUB_DOWNLOAD_BASE = process.env.CLAWHUB_DOWNLOAD_BASE ?? "https://clawhub.ai/api/v1/download";
+const MAX_CLAWHUB_ZIP_BYTES = 50 * 1024 * 1024;
+const MAX_CLAWHUB_ZIP_ENTRIES = 500;
+const MAX_CLAWHUB_ENTRY_BYTES = 25 * 1024 * 1024;
+const MAX_CLAWHUB_UNCOMPRESSED_BYTES = 100 * 1024 * 1024;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -410,6 +414,7 @@ type ClawhubZipEntryKind = "file" | "directory";
 type ClawhubZipEntryMetadata = {
 	fileName: string;
 	externalFileAttributes: number;
+	uncompressedSize?: number;
 	versionMadeBy: number;
 	encrypted?: boolean;
 };
@@ -435,6 +440,9 @@ export function validateClawhubZipEntryMetadata(
 	const path = normalizeZipEntryPath(entry.fileName);
 	if (!path) return { ok: false, error: "ClawHub zip contains unsafe paths" };
 	if (entry.encrypted) return { ok: false, error: "ClawHub zip contains encrypted entries" };
+	if (entry.uncompressedSize !== undefined && entry.uncompressedSize > MAX_CLAWHUB_ENTRY_BYTES) {
+		return { ok: false, error: "ClawHub zip entry is too large" };
+	}
 
 	const unixMode = entry.versionMadeBy >> 8 === ZIP_UNIX_HOST ? entry.externalFileAttributes >>> 16 : 0;
 	const impliedDirectory = entry.fileName.replaceAll("\\", "/").endsWith("/");
@@ -527,6 +535,8 @@ async function extractClawhubZip(
 	const zip = await openZip(zipPath);
 	return new Promise((resolveExtract) => {
 		let done = false;
+		let entries = 0;
+		let totalUncompressedBytes = 0;
 		const fail = (error: string): void => {
 			if (done) return;
 			done = true;
@@ -542,9 +552,21 @@ async function extractClawhubZip(
 		zip.on("error", (err) => fail(err.message));
 		zip.on("end", pass);
 		zip.on("entry", (entry: Entry) => {
+			entries += 1;
+			totalUncompressedBytes += entry.uncompressedSize;
+			if (entries > MAX_CLAWHUB_ZIP_ENTRIES) {
+				fail("ClawHub zip contains too many entries");
+				return;
+			}
+			if (totalUncompressedBytes > MAX_CLAWHUB_UNCOMPRESSED_BYTES) {
+				fail("ClawHub zip uncompressed content is too large");
+				return;
+			}
+
 			const validation = validateClawhubZipEntryMetadata({
 				fileName: entry.fileName,
 				externalFileAttributes: entry.externalFileAttributes,
+				uncompressedSize: entry.uncompressedSize,
 				versionMadeBy: entry.versionMadeBy,
 				encrypted: entry.isEncrypted(),
 			});
@@ -573,6 +595,46 @@ async function extractClawhubZip(
 		});
 		zip.readEntry();
 	});
+}
+
+async function writeResponseBodyToFileWithLimit(
+	res: Response,
+	path: string,
+	limit: number,
+): Promise<{ ok: true; bytes: number } | { ok: false; error: string }> {
+	const header = res.headers.get("content-length");
+	if (header) {
+		const bytes = Number(header);
+		if (Number.isFinite(bytes) && bytes > limit) {
+			return { ok: false, error: "ClawHub download is too large" };
+		}
+	}
+	if (!res.body) return { ok: false, error: "ClawHub download did not include a response body" };
+
+	const reader = res.body.getReader();
+	const output = createWriteStream(path);
+	let bytes = 0;
+	try {
+		while (true) {
+			const chunk = await reader.read();
+			if (chunk.done) break;
+			bytes += chunk.value.byteLength;
+			if (bytes > limit) {
+				output.destroy();
+				return { ok: false, error: "ClawHub download is too large" };
+			}
+			await new Promise<void>((resolveWrite, rejectWrite) => {
+				output.write(chunk.value, (err) => {
+					if (err) rejectWrite(err);
+					else resolveWrite();
+				});
+			});
+		}
+		await new Promise<void>((resolveEnd) => output.end(resolveEnd));
+		return { ok: true, bytes };
+	} finally {
+		reader.releaseLock();
+	}
 }
 
 const clawhubInstallLocks = new Map<string, Promise<unknown>>();
@@ -638,7 +700,10 @@ async function installClawhubSkill(
 			return { success: false, error: `ClawHub download failed with HTTP ${res.status}` };
 		}
 
-		writeFileSync(zipPath, Buffer.from(await res.arrayBuffer()));
+		const download = await writeResponseBodyToFileWithLimit(res, zipPath, MAX_CLAWHUB_ZIP_BYTES);
+		if (!download.ok) {
+			return { success: false, error: download.error };
+		}
 
 		mkdirSync(extractDir, { recursive: true });
 		const extracted = await extractClawhubZip(zipPath, extractDir);


### PR DESCRIPTION
## Summary

Fix dashboard skill installs for ClawHub-backed marketplace entries.

The dashboard already sends `name` and `source` to `POST /api/skills/install`, but the daemon treated every source as a package for the `skills` CLI. That works for Signet official skills and Skills.sh entries, but ClawHub entries use `clawhub@<slug>`, which the CLI tried to clone as a git repository.

This PR adds a small install planner in the daemon route:

- `Signet-AI/signetai` and other multi-skill GitHub repos still use `skills add ... --skill <name>`.
- Skills.sh `owner/repo@skill` sources still use the existing `skills` CLI path.
- ClawHub sources now download the ClawHub zip, validate archive paths and entry metadata before extraction, reject symlinks/special files, require a root `SKILL.md`, and install into the Signet skills directory.

## Readiness Checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Validation

- `bunx biome check platform/daemon/src/routes/skills.ts platform/daemon/src/routes/skills.test.ts`
- `bun test --timeout 15000 src/routes/skills.test.ts --test-name-pattern "install command args|POST /api/skills/install|ClawHub skill archive validation"`
- `bun test --timeout 15000 src/routes/skills.test.ts`
- `bun run build` in `platform/core`
- `bun run build` in `platform/daemon`

The daemon build still emits existing unrelated Svelte a11y/deprecation warnings in dashboard components.

I also tried `bun run build:types` in `platform/daemon`; it currently fails on existing repo-wide rootDir/test typing issues outside this PR, so I did not treat that as branch-specific signal.
