### PR TITLE
fix(sources): index Obsidian sources asynchronously

### DIFF
--- a/platform/daemon/src/native-memory-sources.test.ts
+++ b/platform/daemon/src/native-memory-sources.test.ts
@@ -783,6 +783,45 @@ describe("native memory sources", () => {
 		}
 	});
 
+	it("reports per-source file progress when a bridge scans multiple sources", async () => {
+		const vaultA = join(dir, "vault-a");
+		const vaultB = join(dir, "vault-b");
+		mkdirSync(join(vaultA, "notes"), { recursive: true });
+		mkdirSync(join(vaultB, "notes"), { recursive: true });
+		writeFileSync(join(vaultA, "notes", "A1.md"), "# A1\n\nFirst vault note.");
+		writeFileSync(join(vaultA, "notes", "A2.md"), "# A2\n\nSecond vault note.");
+		writeFileSync(join(vaultB, "notes", "B1.md"), "# B1\n\nThird vault note.");
+		const events: Array<{ sourceId?: string; scanned: number; total: number; changed: number }> = [];
+		const handle = startNativeMemoryBridge(
+			[
+				obsidianNativeMemorySource(vaultA, "Vault A", "obsidian:vault-a"),
+				obsidianNativeMemorySource(vaultB, "Vault B", "obsidian:vault-b"),
+			],
+			{
+				agentId: "agent-native",
+				pollIntervalMs: 0,
+				onFileIndexed: (event) => {
+					events.push({
+						sourceId: event.source.sourceId,
+						scanned: event.scanned,
+						total: event.total,
+						changed: event.changed,
+					});
+				},
+			},
+		);
+		try {
+			expect(await handle.syncExisting()).toBe(3);
+			expect(events).toEqual([
+				{ sourceId: "obsidian:vault-a", scanned: 1, total: 2, changed: 1 },
+				{ sourceId: "obsidian:vault-a", scanned: 2, total: 2, changed: 2 },
+				{ sourceId: "obsidian:vault-b", scanned: 1, total: 1, changed: 1 },
+			]);
+		} finally {
+			await handle.close();
+		}
+	});
+
 	it("coalesces overlapping source sync requests and runs one trailing resync", async () => {
 		const root = join(dir, "vault");
 		const file = join(root, "permanent", "Burst.md");

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -49,6 +49,17 @@ export interface NativeMemoryBridgeOptions {
 	readonly fetchEmbedding?: SourceEmbeddingFetch;
 	readonly agentsDir?: string;
 	readonly includeConfiguredSources?: boolean;
+	readonly yieldEveryFiles?: number;
+	readonly onFileIndexed?: (event: NativeMemoryFileIndexEvent) => void;
+}
+
+export interface NativeMemoryFileIndexEvent {
+	readonly source: NativeMemorySource;
+	readonly filePath: string;
+	readonly indexed: boolean;
+	readonly scanned: number;
+	readonly total: number;
+	readonly changed: number;
 }
 
 interface IndexedNativeMemory {
@@ -440,16 +451,26 @@ export function startNativeMemoryBridge(
 
 	const runScan = async (): Promise<number> => {
 		let count = 0;
-		const yielder = yieldEvery(20);
+		let scanned = 0;
+		const yielder = yieldEvery(options.yieldEveryFiles ?? 20);
 		for (const source of activeBridgeSources(sources, options)) {
 			const key = sourceStateKey(source, agentId);
 			const current = new Set<string>();
 			const rootExists = existsSync(source.root);
 			if (rootExists) {
+				const files: string[] = [];
 				for await (const file of walkMarkdownFiles(source.root)) {
 					if (!matchesPattern(source, file)) continue;
+					files.push(file);
+					await yielder();
+				}
+				const total = files.length;
+				for (const file of files) {
+					scanned++;
+					const changed = await indexNativeMemoryFile(source, file, agentId, options);
+					if (changed) count++;
 					current.add(file);
-					if (await indexNativeMemoryFile(source, file, agentId, options)) count++;
+					options.onFileIndexed?.({ source, filePath: file, indexed: changed, scanned, total, changed: count });
 					await yielder();
 				}
 				const currentPaths = new Set([...current].map((file) => file.replace(/\\/g, "/")));

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -451,9 +451,10 @@ export function startNativeMemoryBridge(
 
 	const runScan = async (): Promise<number> => {
 		let count = 0;
-		let scanned = 0;
 		const yielder = yieldEvery(options.yieldEveryFiles ?? 20);
 		for (const source of activeBridgeSources(sources, options)) {
+			let changedCount = 0;
+			let scanned = 0;
 			const key = sourceStateKey(source, agentId);
 			const current = new Set<string>();
 			const rootExists = existsSync(source.root);
@@ -468,9 +469,12 @@ export function startNativeMemoryBridge(
 				for (const file of files) {
 					scanned++;
 					const changed = await indexNativeMemoryFile(source, file, agentId, options);
-					if (changed) count++;
+					if (changed) {
+						count++;
+						changedCount++;
+					}
 					current.add(file);
-					options.onFileIndexed?.({ source, filePath: file, indexed: changed, scanned, total, changed: count });
+					options.onFileIndexed?.({ source, filePath: file, indexed: changed, scanned, total, changed: changedCount });
 					await yielder();
 				}
 				const currentPaths = new Set([...current].map((file) => file.replace(/\\/g, "/")));

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -38,7 +38,13 @@ describe("Sources routes", () => {
 	});
 
 	function makeApp(
-		options: { indexed?: number; purged?: number; syncGate?: Promise<void>; onPurge?: () => void } = {},
+		options: {
+			indexed?: number;
+			purged?: number;
+			syncGate?: Promise<void>;
+			onPurge?: () => void;
+			onSyncStart?: () => void;
+		} = {},
 	): Hono {
 		const app = new Hono();
 		registerSourcesRoutes(app, {
@@ -50,6 +56,7 @@ describe("Sources routes", () => {
 				expect(bridgeOptions.yieldEveryFiles).toBe(1);
 				return {
 					syncExisting: async () => {
+						options.onSyncStart?.();
 						if (options.syncGate) await options.syncGate;
 						bridgeOptions.onFileIndexed?.({
 							source: sources[0] as NativeMemorySource,
@@ -132,10 +139,11 @@ describe("Sources routes", () => {
 	it("purges again when a disconnected source still has an in-flight index job", async () => {
 		let releaseScan = () => {};
 		let purges = 0;
+		let scanStarted = false;
 		const syncGate = new Promise<void>((resolve) => {
 			releaseScan = resolve;
 		});
-		const app = makeApp({ syncGate, onPurge: () => purges++ });
+		const app = makeApp({ syncGate, onPurge: () => purges++, onSyncStart: () => (scanStarted = true) });
 		const added = (await (
 			await app.request("/api/sources/obsidian", {
 				method: "POST",
@@ -143,6 +151,7 @@ describe("Sources routes", () => {
 				body: JSON.stringify({ path: vault, name: "Disconnecting Vault" }),
 			})
 		).json()) as { source: { id: string } };
+		await waitFor(() => scanStarted);
 
 		const res = await app.request(`/api/sources/${encodeURIComponent(added.source.id)}`, { method: "DELETE" });
 		expect(res.status).toBe(200);
@@ -151,6 +160,112 @@ describe("Sources routes", () => {
 		releaseScan();
 		await waitFor(() => purges === 2);
 		expect(loadSourcesConfig(dir).sources).toHaveLength(0);
+	});
+
+	it("runs a reconnect job after the disconnected source scan finishes", async () => {
+		let releaseFirstScan = () => {};
+		let syncCalls = 0;
+		let purges = 0;
+		const firstScanGate = new Promise<void>((resolve) => {
+			releaseFirstScan = resolve;
+		});
+		const app = new Hono();
+		registerSourcesRoutes(app, {
+			agentsDir: dir,
+			loadMemoryConfig,
+			startBridge: (sources: readonly NativeMemorySource[], bridgeOptions: NativeMemoryBridgeOptions) => {
+				syncCalls++;
+				const call = syncCalls;
+				return {
+					syncExisting: async () => {
+						if (call === 1) await firstScanGate;
+						bridgeOptions.onFileIndexed?.({
+							source: sources[0] as NativeMemorySource,
+							filePath: join(vault, "permanent", "Note.md"),
+							indexed: true,
+							scanned: 1,
+							total: 1,
+							changed: call,
+						});
+						return call;
+					},
+					close: async () => {},
+				} satisfies NativeMemoryBridgeHandle;
+			},
+			purgeNativeSource: () => {
+				purges++;
+				return 1;
+			},
+		});
+		const first = (await (
+			await app.request("/api/sources/obsidian", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ path: vault, name: "Reconnect Vault" }),
+			})
+		).json()) as { source: { id: string } };
+		await waitFor(() => syncCalls === 1);
+
+		expect(
+			(await app.request(`/api/sources/${encodeURIComponent(first.source.id)}`, { method: "DELETE" })).status,
+		).toBe(200);
+		expect(purges).toBe(1);
+		const reconnect = (await (
+			await app.request("/api/sources/obsidian", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ path: vault, name: "Reconnect Vault" }),
+			})
+		).json()) as { source: { id: string } };
+		expect(reconnect.source.id).toBe(first.source.id);
+
+		releaseFirstScan();
+		await waitFor(() => syncCalls === 2);
+		await waitFor(() => loadSourcesConfig(dir).sources[0]?.lastIndexedAt !== undefined);
+
+		const sources = (await (await app.request("/api/sources")).json()) as {
+			sources: Array<{ indexJob?: { indexed?: number; status?: string } }>;
+		};
+		expect(sources.sources[0]?.indexJob).toMatchObject({ indexed: 2, status: "complete" });
+		expect(purges).toBe(2);
+	});
+
+	it("purges tombstoned disconnected source artifacts when routes register after restart", async () => {
+		let releaseScan = () => {};
+		let scanStarted = false;
+		let runtimePurges = 0;
+		let startupPurges = 0;
+		const syncGate = new Promise<void>((resolve) => {
+			releaseScan = resolve;
+		});
+		const app = makeApp({ syncGate, onPurge: () => runtimePurges++, onSyncStart: () => (scanStarted = true) });
+		const added = (await (
+			await app.request("/api/sources/obsidian", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ path: vault, name: "Restart Cleanup Vault" }),
+			})
+		).json()) as { source: { id: string } };
+		await waitFor(() => scanStarted);
+
+		expect(
+			(await app.request(`/api/sources/${encodeURIComponent(added.source.id)}`, { method: "DELETE" })).status,
+		).toBe(200);
+		expect(runtimePurges).toBe(1);
+
+		const restarted = new Hono();
+		registerSourcesRoutes(restarted, {
+			agentsDir: dir,
+			loadMemoryConfig,
+			purgeNativeSource: () => {
+				startupPurges++;
+				return 1;
+			},
+		});
+		expect(startupPurges).toBe(1);
+
+		releaseScan();
+		await waitFor(() => runtimePurges === 2);
 	});
 
 	it("reports source chunk stats using source-owned chunk id prefixes", async () => {

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -6,7 +6,7 @@ import { addObsidianSource, loadSourcesConfig } from "@signet/core";
 import { Hono } from "hono";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
 import { loadMemoryConfig } from "../memory-config";
-import type { NativeMemoryBridgeHandle, NativeMemorySource } from "../native-memory-sources";
+import type { NativeMemoryBridgeHandle, NativeMemoryBridgeOptions, NativeMemorySource } from "../native-memory-sources";
 import { registerSourcesRoutes } from "./sources-routes";
 
 describe("Sources routes", () => {
@@ -37,26 +37,49 @@ describe("Sources routes", () => {
 		rmSync(dir, { recursive: true, force: true });
 	});
 
-	function makeApp(options: { indexed?: number; purged?: number } = {}): Hono {
+	function makeApp(
+		options: { indexed?: number; purged?: number; syncGate?: Promise<void>; onPurge?: () => void } = {},
+	): Hono {
 		const app = new Hono();
 		registerSourcesRoutes(app, {
 			agentsDir: dir,
 			loadMemoryConfig,
-			startBridge: (sources: readonly NativeMemorySource[]) => {
+			startBridge: (sources: readonly NativeMemorySource[], bridgeOptions: NativeMemoryBridgeOptions) => {
 				expect(sources).toHaveLength(1);
 				expect(sources[0]?.sourceId).toStartWith("obsidian:");
+				expect(bridgeOptions.yieldEveryFiles).toBe(1);
 				return {
-					syncExisting: async () => options.indexed ?? 1,
+					syncExisting: async () => {
+						if (options.syncGate) await options.syncGate;
+						bridgeOptions.onFileIndexed?.({
+							source: sources[0] as NativeMemorySource,
+							filePath: join(vault, "permanent", "Note.md"),
+							indexed: true,
+							scanned: 1,
+							total: 1,
+							changed: options.indexed ?? 1,
+						});
+						return options.indexed ?? 1;
+					},
 					close: async () => {},
 				} satisfies NativeMemoryBridgeHandle;
 			},
 			purgeNativeSource: (source, agentId) => {
 				expect(source.sourceId).toStartWith("obsidian:");
 				expect(agentId).toBe(process.env.SIGNET_AGENT_ID?.trim() || "default");
+				options.onPurge?.();
 				return options.purged ?? 7;
 			},
 		});
 		return app;
+	}
+
+	async function waitFor(predicate: () => boolean): Promise<void> {
+		for (let attempt = 0; attempt < 50; attempt++) {
+			if (predicate()) return;
+			await Bun.sleep(10);
+		}
+		throw new Error("Timed out waiting for condition");
 	}
 
 	it("lists no configured sources by default", async () => {
@@ -65,22 +88,69 @@ describe("Sources routes", () => {
 		expect(await res.json()).toEqual({ version: 1, sources: [] });
 	});
 
-	it("connects an Obsidian source, indexes it, and records lastIndexedAt", async () => {
+	it("connects an Obsidian source, queues indexing, and records lastIndexedAt after the job finishes", async () => {
 		const res = await makeApp({ indexed: 3 }).request("/api/sources/obsidian", {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ path: vault, name: "Route Vault" }),
 		});
 
-		expect(res.status).toBe(200);
-		const body = (await res.json()) as { created: boolean; indexed: number; source: { id: string; root: string } };
+		expect(res.status).toBe(202);
+		const body = (await res.json()) as {
+			created: boolean;
+			indexed: number;
+			queued: boolean;
+			source: { id: string; root: string };
+		};
 		expect(body.created).toBe(true);
-		expect(body.indexed).toBe(3);
+		expect(body.indexed).toBe(0);
+		expect(body.queued).toBe(true);
 		expect(body.source.root).toBe(vault);
 
-		const stored = loadSourcesConfig(dir).sources[0];
-		expect(stored?.id).toBe(body.source.id);
-		expect(stored?.lastIndexedAt).toBeTruthy();
+		await waitFor(() => !!loadSourcesConfig(dir).sources[0]?.lastIndexedAt);
+		expect(loadSourcesConfig(dir).sources[0]?.id).toBe(body.source.id);
+	});
+
+	it("does not block the connect response on a slow Obsidian source scan", async () => {
+		let releaseScan = () => {};
+		const syncGate = new Promise<void>((resolve) => {
+			releaseScan = resolve;
+		});
+		const res = await makeApp({ indexed: 3, syncGate }).request("/api/sources/obsidian", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ path: vault, name: "Slow Vault" }),
+		});
+
+		expect(res.status).toBe(202);
+		expect(loadSourcesConfig(dir).sources[0]?.lastIndexedAt).toBeUndefined();
+
+		releaseScan();
+		await waitFor(() => !!loadSourcesConfig(dir).sources[0]?.lastIndexedAt);
+	});
+
+	it("purges again when a disconnected source still has an in-flight index job", async () => {
+		let releaseScan = () => {};
+		let purges = 0;
+		const syncGate = new Promise<void>((resolve) => {
+			releaseScan = resolve;
+		});
+		const app = makeApp({ syncGate, onPurge: () => purges++ });
+		const added = (await (
+			await app.request("/api/sources/obsidian", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ path: vault, name: "Disconnecting Vault" }),
+			})
+		).json()) as { source: { id: string } };
+
+		const res = await app.request(`/api/sources/${encodeURIComponent(added.source.id)}`, { method: "DELETE" });
+		expect(res.status).toBe(200);
+		expect(purges).toBe(1);
+
+		releaseScan();
+		await waitFor(() => purges === 2);
+		expect(loadSourcesConfig(dir).sources).toHaveLength(0);
 	});
 
 	it("reports source chunk stats using source-owned chunk id prefixes", async () => {

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -14,11 +14,37 @@ import { getDbAccessor } from "../db-accessor";
 import { fetchEmbedding as defaultFetchEmbedding } from "../embedding-fetch";
 import { type ResolvedMemoryConfig, loadMemoryConfig as defaultLoadMemoryConfig } from "../memory-config";
 import {
+	type NativeMemoryBridgeHandle,
 	obsidianNativeMemorySource,
 	purgeNativeMemorySourceArtifacts,
 	startNativeMemoryBridge,
 } from "../native-memory-sources";
 import type { SourceEmbeddingFetch } from "../obsidian-source-embeddings";
+
+type SourceIndexJobStatus = "queued" | "running" | "complete" | "error";
+
+interface SourceIndexJob {
+	readonly id: string;
+	readonly sourceId: string;
+	readonly status: SourceIndexJobStatus;
+	readonly queuedAt: string;
+	readonly startedAt?: string;
+	readonly finishedAt?: string;
+	readonly scanned?: number;
+	readonly total?: number;
+	readonly indexed?: number;
+	readonly currentPath?: string;
+	readonly error?: string;
+}
+
+interface SourceIndexJobInput {
+	readonly source: SignetSourceEntry;
+	readonly agentsDir: string;
+	readonly loadMemoryConfig: (agentsDir: string) => ResolvedMemoryConfig;
+	readonly fetchEmbedding: SourceEmbeddingFetch;
+	readonly startBridge: typeof startNativeMemoryBridge;
+	readonly purgeNativeSource: typeof purgeNativeMemorySourceArtifacts;
+}
 
 const execFileAsync = promisify(execFile);
 
@@ -41,6 +67,10 @@ export interface RegisterSourcesRoutesDeps {
 	readonly purgeNativeSource?: typeof purgeNativeMemorySourceArtifacts;
 }
 
+const sourceIndexJobs = new Map<string, SourceIndexJob>();
+const sourceIndexInFlight = new Set<string>();
+const canceledSourceIndexJobs = new Set<string>();
+
 export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps = {}): void {
 	const agentsDir = deps.agentsDir ?? process.env.SIGNET_PATH ?? `${homedir()}/.agents`;
 	const loadMemoryConfig = deps.loadMemoryConfig ?? defaultLoadMemoryConfig;
@@ -52,7 +82,11 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 		const agentId = resolveDaemonAgentId();
 		return c.json({
 			version: config.version,
-			sources: config.sources.map((source) => ({ ...source, stats: sourceStats(source, agentId) })),
+			sources: config.sources.map((source) => ({
+				...source,
+				stats: sourceStats(source, agentId),
+				indexJob: sourceIndexJobs.get(source.id),
+			})),
 		});
 	});
 
@@ -84,38 +118,25 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 		const result = addObsidianSource({ root, name: body.name, excludeGlobs }, agentsDir);
 		if (result.ok === false) return c.json({ error: result.error }, 400);
 
-		const memoryConfig = loadMemoryConfig(agentsDir);
-		const bridge = startBridge(
-			[
-				obsidianNativeMemorySource(
-					result.source.root,
-					result.source.name,
-					result.source.id,
-					result.source.excludeGlobs,
-				),
-			],
-			{
-				pollIntervalMs: 0,
-				embeddingConfig: memoryConfig.embedding,
-				fetchEmbedding,
-				agentsDir,
-			},
-		);
-		let indexed = 0;
-		try {
-			indexed = await bridge.syncExisting();
-			markSourceIndexed(result.source.id, undefined, agentsDir);
-		} finally {
-			await bridge.close();
-		}
+		const job = enqueueSourceIndexJob({
+			source: result.source,
+			agentsDir,
+			loadMemoryConfig,
+			fetchEmbedding,
+			startBridge,
+			purgeNativeSource,
+		});
 
-		return c.json({ source: result.source, created: result.created, indexed });
+		return c.json({ source: result.source, created: result.created, indexed: 0, queued: true, job }, 202);
 	});
 
 	app.delete("/api/sources/:sourceId", (c) => {
 		const sourceId = c.req.param("sourceId");
 		const result = removeSource(sourceId, agentsDir);
 		if (result.ok === false) return c.json({ error: result.error }, 404);
+		const job = sourceIndexJobs.get(result.source.id);
+		if (job && (job.status === "queued" || job.status === "running")) canceledSourceIndexJobs.add(job.id);
+		sourceIndexJobs.delete(result.source.id);
 
 		const sourceAgentId = resolveDaemonAgentId();
 		const purged =
@@ -127,6 +148,86 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 				: 0;
 		return c.json({ source: result.source, purged });
 	});
+}
+
+function enqueueSourceIndexJob(input: SourceIndexJobInput): SourceIndexJob {
+	const existing = sourceIndexJobs.get(input.source.id);
+	if (existing && (existing.status === "queued" || existing.status === "running")) return existing;
+
+	const job: SourceIndexJob = {
+		id: `source-index:${input.source.id}:${Date.now()}`,
+		sourceId: input.source.id,
+		status: "queued",
+		queuedAt: new Date().toISOString(),
+	};
+	sourceIndexJobs.set(input.source.id, job);
+	setTimeout(() => {
+		void runSourceIndexJob(input, job);
+	}, 0).unref?.();
+	return job;
+}
+
+async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob): Promise<void> {
+	if (sourceIndexInFlight.has(input.source.id)) return;
+	sourceIndexInFlight.add(input.source.id);
+	const started: SourceIndexJob = {
+		...job,
+		status: "running",
+		startedAt: new Date().toISOString(),
+	};
+	sourceIndexJobs.set(input.source.id, started);
+
+	let bridge: NativeMemoryBridgeHandle | null = null;
+
+	try {
+		const memoryConfig = input.loadMemoryConfig(input.agentsDir);
+		bridge = input.startBridge(
+			[obsidianNativeMemorySource(input.source.root, input.source.name, input.source.id, input.source.excludeGlobs)],
+			{
+				pollIntervalMs: 0,
+				embeddingConfig: memoryConfig.embedding,
+				fetchEmbedding: input.fetchEmbedding,
+				agentsDir: input.agentsDir,
+				yieldEveryFiles: 1,
+				onFileIndexed: (event) => {
+					sourceIndexJobs.set(input.source.id, {
+						...started,
+						status: "running",
+						scanned: event.scanned,
+						total: event.total,
+						indexed: event.changed,
+						currentPath: event.filePath,
+					});
+				},
+			},
+		);
+		const indexed = await bridge.syncExisting();
+		markSourceIndexed(input.source.id, undefined, input.agentsDir);
+		const current = sourceIndexJobs.get(input.source.id) ?? started;
+		sourceIndexJobs.set(input.source.id, {
+			...current,
+			status: "complete",
+			finishedAt: new Date().toISOString(),
+			indexed,
+		});
+	} catch (err) {
+		const current = sourceIndexJobs.get(input.source.id) ?? started;
+		sourceIndexJobs.set(input.source.id, {
+			...current,
+			status: "error",
+			finishedAt: new Date().toISOString(),
+			error: err instanceof Error ? err.message : String(err),
+		});
+	} finally {
+		await bridge?.close().catch(() => undefined);
+		if (canceledSourceIndexJobs.delete(job.id)) {
+			input.purgeNativeSource(
+				obsidianNativeMemorySource(input.source.root, input.source.name, input.source.id, input.source.excludeGlobs),
+				resolveDaemonAgentId(),
+			);
+		}
+		sourceIndexInFlight.delete(input.source.id);
+	}
 }
 
 interface SourceStats {

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -1,5 +1,8 @@
 import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
+import { dirname } from "node:path";
 import { promisify } from "node:util";
 import {
 	type SignetSourceEntry,
@@ -46,6 +49,13 @@ interface SourceIndexJobInput {
 	readonly purgeNativeSource: typeof purgeNativeMemorySourceArtifacts;
 }
 
+interface SourceDeletionTombstone {
+	readonly id: string;
+	readonly source: SignetSourceEntry;
+	readonly agentId: string;
+	readonly deletedAt: string;
+}
+
 const execFileAsync = promisify(execFile);
 
 interface AddObsidianSourceBody {
@@ -77,6 +87,7 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 	const fetchEmbedding = deps.fetchEmbedding ?? defaultFetchEmbedding;
 	const startBridge = deps.startBridge ?? startNativeMemoryBridge;
 	const purgeNativeSource = deps.purgeNativeSource ?? purgeNativeMemorySourceArtifacts;
+	cleanupSourceDeletionTombstones(agentsDir, purgeNativeSource);
 	app.get("/api/sources", (c) => {
 		const config = loadSourcesConfig(agentsDir);
 		const agentId = resolveDaemonAgentId();
@@ -139,6 +150,7 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 		sourceIndexJobs.delete(result.source.id);
 
 		const sourceAgentId = resolveDaemonAgentId();
+		recordSourceDeletionTombstone(result.source, sourceAgentId, agentsDir);
 		const purged =
 			result.source.kind === "obsidian"
 				? purgeNativeSource(
@@ -146,6 +158,8 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 						sourceAgentId,
 					)
 				: 0;
+		if (!sourceIndexInFlight.has(result.source.id))
+			clearSourceDeletionTombstone(result.source.id, sourceAgentId, agentsDir);
 		return c.json({ source: result.source, purged });
 	});
 }
@@ -161,14 +175,15 @@ function enqueueSourceIndexJob(input: SourceIndexJobInput): SourceIndexJob {
 		queuedAt: new Date().toISOString(),
 	};
 	sourceIndexJobs.set(input.source.id, job);
-	setTimeout(() => {
-		void runSourceIndexJob(input, job);
-	}, 0).unref?.();
+	scheduleSourceIndexJob(input, job, 0);
 	return job;
 }
 
 async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob): Promise<void> {
-	if (sourceIndexInFlight.has(input.source.id)) return;
+	if (sourceIndexInFlight.has(input.source.id)) {
+		scheduleSourceIndexJob(input, job, 50);
+		return;
+	}
 	sourceIndexInFlight.add(input.source.id);
 	const started: SourceIndexJob = {
 		...job,
@@ -190,6 +205,7 @@ async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob
 				agentsDir: input.agentsDir,
 				yieldEveryFiles: 1,
 				onFileIndexed: (event) => {
+					if (!isCurrentSourceIndexJob(input.source.id, job.id)) return;
 					sourceIndexJobs.set(input.source.id, {
 						...started,
 						status: "running",
@@ -202,6 +218,7 @@ async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob
 			},
 		);
 		const indexed = await bridge.syncExisting();
+		if (!isCurrentSourceIndexJob(input.source.id, job.id)) return;
 		markSourceIndexed(input.source.id, undefined, input.agentsDir);
 		const current = sourceIndexJobs.get(input.source.id) ?? started;
 		sourceIndexJobs.set(input.source.id, {
@@ -211,6 +228,7 @@ async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob
 			indexed,
 		});
 	} catch (err) {
+		if (!isCurrentSourceIndexJob(input.source.id, job.id)) return;
 		const current = sourceIndexJobs.get(input.source.id) ?? started;
 		sourceIndexJobs.set(input.source.id, {
 			...current,
@@ -225,9 +243,107 @@ async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob
 				obsidianNativeMemorySource(input.source.root, input.source.name, input.source.id, input.source.excludeGlobs),
 				resolveDaemonAgentId(),
 			);
+			clearSourceDeletionTombstone(input.source.id, resolveDaemonAgentId(), input.agentsDir);
 		}
 		sourceIndexInFlight.delete(input.source.id);
 	}
+}
+
+function scheduleSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob, delayMs: number): void {
+	setTimeout(() => {
+		if (!isCurrentSourceIndexJob(input.source.id, job.id)) return;
+		void runSourceIndexJob(input, job);
+	}, delayMs).unref?.();
+}
+
+function isCurrentSourceIndexJob(sourceId: string, jobId: string): boolean {
+	return sourceIndexJobs.get(sourceId)?.id === jobId;
+}
+
+function cleanupSourceDeletionTombstones(
+	agentsDir: string,
+	purgeNativeSource: typeof purgeNativeMemorySourceArtifacts,
+): void {
+	const tombstones = loadSourceDeletionTombstones(agentsDir);
+	if (tombstones.length === 0) return;
+	const configuredIds = new Set(loadSourcesConfig(agentsDir).sources.map((source) => source.id));
+	const remaining: SourceDeletionTombstone[] = [];
+	for (const tombstone of tombstones) {
+		if (configuredIds.has(tombstone.source.id)) continue;
+		if (tombstone.source.kind === "obsidian") {
+			purgeNativeSource(
+				obsidianNativeMemorySource(
+					tombstone.source.root,
+					tombstone.source.name,
+					tombstone.source.id,
+					tombstone.source.excludeGlobs,
+				),
+				tombstone.agentId,
+			);
+		}
+	}
+	saveSourceDeletionTombstones(remaining, agentsDir);
+}
+
+function recordSourceDeletionTombstone(source: SignetSourceEntry, agentId: string, agentsDir: string): void {
+	const tombstones = loadSourceDeletionTombstones(agentsDir);
+	const next = tombstones.filter((entry) => entry.source.id !== source.id || entry.agentId !== agentId);
+	saveSourceDeletionTombstones(
+		[
+			...next,
+			{
+				id: randomUUID(),
+				source,
+				agentId,
+				deletedAt: new Date().toISOString(),
+			},
+		],
+		agentsDir,
+	);
+}
+
+function clearSourceDeletionTombstone(sourceId: string, agentId: string, agentsDir: string): void {
+	const tombstones = loadSourceDeletionTombstones(agentsDir);
+	const next = tombstones.filter((entry) => entry.source.id !== sourceId || entry.agentId !== agentId);
+	if (next.length !== tombstones.length) saveSourceDeletionTombstones(next, agentsDir);
+}
+
+function loadSourceDeletionTombstones(agentsDir: string): readonly SourceDeletionTombstone[] {
+	const path = sourceDeletionTombstonesPath(agentsDir);
+	if (!existsSync(path)) return [];
+	try {
+		const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+		if (!Array.isArray(parsed)) return [];
+		return parsed.filter(isSourceDeletionTombstone);
+	} catch {
+		return [];
+	}
+}
+
+function saveSourceDeletionTombstones(tombstones: readonly SourceDeletionTombstone[], agentsDir: string): void {
+	const path = sourceDeletionTombstonesPath(agentsDir);
+	mkdirSync(dirname(path), { recursive: true });
+	const tmp = `${path}.tmp-${process.pid}-${randomUUID()}`;
+	writeFileSync(tmp, `${JSON.stringify(tombstones, null, 2)}\n`, "utf8");
+	renameSync(tmp, path);
+}
+
+function sourceDeletionTombstonesPath(agentsDir: string): string {
+	return `${agentsDir.replace(/\/$/, "")}/.daemon/source-deletion-tombstones.json`;
+}
+
+function isSourceDeletionTombstone(value: unknown): value is SourceDeletionTombstone {
+	if (!value || typeof value !== "object") return false;
+	const candidate = value as Partial<SourceDeletionTombstone>;
+	return (
+		typeof candidate.id === "string" &&
+		typeof candidate.agentId === "string" &&
+		typeof candidate.deletedAt === "string" &&
+		!!candidate.source &&
+		typeof candidate.source === "object" &&
+		typeof candidate.source.id === "string" &&
+		candidate.source.kind === "obsidian"
+	);
 }
 
 interface SourceStats {

--- a/surfaces/dashboard/src/lib/api.ts
+++ b/surfaces/dashboard/src/lib/api.ts
@@ -97,6 +97,20 @@ export interface SignetSourceStats {
 	indexed: number;
 }
 
+export interface SignetSourceIndexJob {
+	id: string;
+	sourceId: string;
+	status: "queued" | "running" | "complete" | "error";
+	queuedAt: string;
+	startedAt?: string;
+	finishedAt?: string;
+	scanned?: number;
+	total?: number;
+	indexed?: number;
+	currentPath?: string;
+	error?: string;
+}
+
 export interface SignetSourceEntry {
 	id: string;
 	kind: "obsidian";
@@ -109,6 +123,7 @@ export interface SignetSourceEntry {
 	lastIndexedAt?: string;
 	excludeGlobs?: string[];
 	stats?: SignetSourceStats;
+	indexJob?: SignetSourceIndexJob;
 }
 
 export interface SourcesConfigResponse {
@@ -120,6 +135,8 @@ export interface AddSourceResponse {
 	source: SignetSourceEntry;
 	created: boolean;
 	indexed: number;
+	queued?: boolean;
+	job?: SignetSourceIndexJob;
 	error?: string;
 }
 

--- a/surfaces/dashboard/src/lib/components/tabs/SourcesTab.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/SourcesTab.svelte
@@ -13,7 +13,7 @@ import Plus from "@lucide/svelte/icons/plus";
 import RefreshCw from "@lucide/svelte/icons/refresh-cw";
 import Search from "@lucide/svelte/icons/search";
 import X from "@lucide/svelte/icons/x";
-import { onMount } from "svelte";
+import { onDestroy, onMount } from "svelte";
 
 type SourceKind =
 	| "obsidian"
@@ -105,6 +105,7 @@ let status = $state<string | null>(null);
 let error = $state<string | null>(null);
 let touchedPath = $state(false);
 let expandedKind = $state<SourceKind | null>(null);
+let sourceRefreshTimer: ReturnType<typeof setInterval> | null = null;
 
 const connectors: SourceConnector[] = [
 	{
@@ -440,6 +441,9 @@ const connectedCount = $derived(obsidianSources.length);
 const indexedCount = $derived(
 	obsidianSources.filter((source) => source.lastIndexedAt || (source.stats?.indexed ?? 0) > 0).length,
 );
+const hasActiveIndexJob = $derived(
+	obsidianSources.some((source) => source.indexJob?.status === "queued" || source.indexJob?.status === "running"),
+);
 const pathIsMissing = $derived(vaultPath.trim().length === 0);
 const canSubmit = $derived(!pathIsMissing && !adding && selectedKind === "obsidian");
 const filteredConnectors = $derived.by(() => {
@@ -457,15 +461,22 @@ const filteredConnectors = $derived.by(() => {
 
 onMount(() => {
 	void refreshSources();
+	sourceRefreshTimer = setInterval(() => {
+		if (hasActiveIndexJob) void refreshSources({ quiet: true });
+	}, 1000);
 });
 
-async function refreshSources(): Promise<void> {
-	loading = true;
+onDestroy(() => {
+	if (sourceRefreshTimer) clearInterval(sourceRefreshTimer);
+});
+
+async function refreshSources(options: { quiet?: boolean } = {}): Promise<void> {
+	if (!options.quiet) loading = true;
 	error = null;
 	try {
 		sources = await getSources();
 	} finally {
-		loading = false;
+		if (!options.quiet) loading = false;
 	}
 }
 
@@ -521,7 +532,9 @@ async function submitSource(): Promise<void> {
 			error = result.error;
 			return;
 		}
-		status = `${result.created ? "Connected" : "Updated"} ${result.source.name}. Indexed ${result.indexed} changed notes.`;
+		status = result.queued
+			? `${result.created ? "Connected" : "Updated"} ${result.source.name}. Indexing is running in the background.`
+			: `${result.created ? "Connected" : "Updated"} ${result.source.name}. Indexed ${result.indexed} changed notes.`;
 		vaultPath = "";
 		touchedPath = false;
 		connectMode = false;
@@ -571,10 +584,32 @@ function parseExcludeGlobs(value: string): string[] {
 }
 
 function sourceScanLabel(source: SignetSourceEntry): string {
+	if (source.indexJob?.status === "queued") return "Index queued";
+	if (source.indexJob?.status === "running") {
+		const scanned = source.indexJob.scanned ?? 0;
+		const indexed = source.indexJob.indexed ?? 0;
+		const total = source.indexJob.total ?? 0;
+		if (scanned > 0 && total > 0) return `Indexing · ${scanned}/${total} scanned · ${indexed} changed`;
+		return scanned > 0 ? `Indexing · ${scanned} scanned · ${indexed} changed` : "Indexing in background";
+	}
+	if (source.indexJob?.status === "error") return `Index failed: ${source.indexJob.error ?? "unknown error"}`;
 	const indexed = source.stats?.indexed ?? 0;
 	const chunks = source.stats?.chunks ?? 0;
 	if (indexed > 0) return `${indexed} notes · ${chunks} chunks${source.lastIndexedAt ? "" : " · syncing"}`;
 	return source.lastIndexedAt ? "Scan completed with no indexed notes" : "Connected; waiting for first indexed note";
+}
+
+function sourceIndexPercent(source: SignetSourceEntry): number {
+	const scanned = source.indexJob?.scanned ?? 0;
+	const total = source.indexJob?.total ?? 0;
+	if (total <= 0) return source.indexJob?.status === "complete" ? 100 : 0;
+	return Math.min(100, Math.max(0, Math.round((scanned / total) * 100)));
+}
+
+function sourceIndexCurrentPath(source: SignetSourceEntry): string {
+	const currentPath = source.indexJob?.currentPath;
+	if (!currentPath) return "";
+	return currentPath.startsWith(`${source.root}/`) ? currentPath.slice(source.root.length + 1) : currentPath;
 }
 </script>
 
@@ -861,13 +896,34 @@ function sourceScanLabel(source: SignetSourceEntry): string {
 													</div>
 													<code>{source.root}</code>
 												</div>
-												<ul>
-													<li><CheckCircle2 /> {source.enabled ? "Enabled" : "Disabled"}</li>
-													<li><Database /> {sourceScanLabel(source)}</li>
-													<li><Database /> Last complete scan: {formatDate(source.lastIndexedAt)}</li>
-												</ul>
-												{#if source.excludeGlobs?.length}
-													<div class="exclude-summary">
+													<ul>
+														<li><CheckCircle2 /> {source.enabled ? "Enabled" : "Disabled"}</li>
+														<li><Database /> {sourceScanLabel(source)}</li>
+														<li><Database /> Last complete scan: {formatDate(source.lastIndexedAt)}</li>
+													</ul>
+													{#if source.indexJob?.status === "queued" || source.indexJob?.status === "running"}
+														<div class="source-index-progress">
+															<div class="source-index-progress__head">
+																<span>{source.indexJob.status === "queued" ? "Queued" : "Indexing"}</span>
+																<strong>{sourceIndexPercent(source)}%</strong>
+															</div>
+															<div
+																class="source-index-progress__bar"
+																role="progressbar"
+																aria-valuemin="0"
+																aria-valuemax="100"
+																aria-valuenow={sourceIndexPercent(source)}
+																aria-label={`Indexing ${source.name}`}
+															>
+																<span style={`width: ${sourceIndexPercent(source)}%`}></span>
+															</div>
+															{#if sourceIndexCurrentPath(source)}
+																<code class="source-index-progress__path">{sourceIndexCurrentPath(source)}</code>
+															{/if}
+														</div>
+													{/if}
+													{#if source.excludeGlobs?.length}
+														<div class="exclude-summary">
 														<span>Ignoring</span>
 														<code>{source.excludeGlobs.join(", ")}</code>
 													</div>
@@ -1924,14 +1980,63 @@ function sourceScanLabel(source: SignetSourceEntry): string {
 		color: var(--sig-text-muted);
 	}
 
-	.connected-row li :global(svg) {
-		width: 13px;
-		height: 13px;
-	}
+		.connected-row li :global(svg) {
+			width: 13px;
+			height: 13px;
+		}
 
-	.exclude-summary {
-		display: grid;
-		gap: 4px;
+		.source-index-progress {
+			display: grid;
+			gap: 6px;
+			border: 1px solid var(--sig-border);
+			border-radius: 0;
+			padding: 8px;
+			background: var(--sig-surface);
+		}
+
+		.source-index-progress__head {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			gap: 10px;
+			font: 9px var(--font-mono);
+			letter-spacing: 0.08em;
+			text-transform: uppercase;
+			color: var(--sig-text-muted);
+		}
+
+		.source-index-progress__head strong {
+			margin: 0;
+			font: inherit;
+			color: var(--sig-text-bright);
+		}
+
+		.source-index-progress__bar {
+			position: relative;
+			width: 100%;
+			height: 7px;
+			border: 1px solid var(--sig-border-strong);
+			border-radius: 0;
+			overflow: hidden;
+			background: var(--sig-surface-raised);
+		}
+
+		.source-index-progress__bar span {
+			position: absolute;
+			inset: 0 auto 0 0;
+			min-width: 2px;
+			background: var(--sig-accent);
+			box-shadow: inset 0 1px 0 var(--sig-highlight-dim);
+			transition: width 0.2s var(--ease);
+		}
+
+		.source-index-progress__path {
+			color: var(--sig-text-muted);
+		}
+
+		.exclude-summary {
+			display: grid;
+			gap: 4px;
 		border: 1px dashed var(--sig-border);
 		padding: 8px;
 		background: rgba(255, 255, 255, 0.02);
@@ -2083,4 +2188,3 @@ function sourceScanLabel(source: SignetSourceEntry): string {
 		}
 	}
 </style>
-


### PR DESCRIPTION
## Summary

Async Obsidian source indexing so connecting a large vault no longer blocks the daemon request path. The dashboard now shows active source indexing progress while files are scanned one at a time.

## Changes

- Queue `POST /api/sources/obsidian` indexing work in a daemon-side background job and return `202` with job metadata.
- Track source indexing progress with queued/running/complete/error state, scanned/total/indexed counts, current file path, and cancellation cleanup on disconnect.
- Have the native source bridge discover and index markdown files sequentially with per-file progress callbacks.
- Add dashboard API types and a Sources tab progress bar that polls while a source job is active.
- Add regression coverage for non-blocking connect, in-flight disconnect cleanup, and progress callback behavior.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

Not captured yet. The changed UI is an in-flight source indexing progress state and requires a live queued source job to render meaningfully.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [ ] Daemon Rust parity reviewed or explicitly N/A
- [ ] Rollback / compatibility note included in PR description

No migrations touched.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Focused validation run locally:

- [x] `bun test platform/daemon/src/routes/sources-routes.test.ts`
- [x] `bun test platform/daemon/src/native-memory-sources.test.ts`
- [x] `cd surfaces/dashboard && bun run check` (passes with existing unrelated warnings)
- [x] `bunx biome check platform/daemon/src/native-memory-sources.ts platform/daemon/src/routes/sources-routes.ts platform/daemon/src/routes/sources-routes.test.ts surfaces/dashboard/src/lib/api.ts surfaces/dashboard/src/lib/components/tabs/SourcesTab.svelte`
- [x] `bun run --filter @signet/core build`
- [x] `bun run --filter @signet/daemon build` (passes with existing unrelated dashboard warnings)
- [x] `git diff --check`

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The first daemon build failed because local `@signet/core/dist` was stale after rebasing onto current `origin/main`; rebuilding `@signet/core` fixed the local export mismatch and the daemon build then passed.