### PR TITLE
fix(cli): wrap launchd plist runtime in /bin/bash to avoid macOS AMFI exec failure

### DIFF
--- a/platform/daemon/src/service.ts
+++ b/platform/daemon/src/service.ts
@@ -82,8 +82,9 @@ function generateLaunchdPlist(port: number = 3850): string {
     
     <key>ProgramArguments</key>
     <array>
-        <string>${resolveRuntimePath()}</string>
-        <string>${daemonPath}</string>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>exec ${resolveRuntimePath()} ${daemonPath}</string>
     </array>
     
     <key>EnvironmentVariables</key>

--- a/platform/daemon/src/service.ts
+++ b/platform/daemon/src/service.ts
@@ -84,7 +84,9 @@ function generateLaunchdPlist(port: number = 3850): string {
     <array>
         <string>/bin/bash</string>
         <string>-c</string>
-        <string>exec ${resolveRuntimePath()} ${daemonPath}</string>
+        <string>exec &quot;$0&quot; &quot;$1&quot;</string>
+        <string>${resolveRuntimePath()}</string>
+        <string>${daemonPath}</string>
     </array>
     
     <key>EnvironmentVariables</key>

--- a/surfaces/cli/src/lib/runtime.test.ts
+++ b/surfaces/cli/src/lib/runtime.test.ts
@@ -56,7 +56,9 @@ describe("buildLaunchdDaemonPlist", () => {
 		expect(plist).toContain("<key>Label</key>");
 		expect(plist).toContain("<string>ai.signet.daemon.test</string>");
 		expect(plist).toContain("<key>ProgramArguments</key>");
-		expect(plist).toContain("<string>/opt/signet/dist/daemon.js</string>");
+		expect(plist).toContain("<string>/bin/bash</string>");
+		expect(plist).toContain("<string>-c</string>");
+		expect(plist).toContain(`exec ${process.execPath} /opt/signet/dist/daemon.js`);
 		expect(plist).toContain("<key>SIGNET_PORT</key>");
 		expect(plist).toContain("<string>3850</string>");
 		expect(plist).toContain("<key>SIGNET_HOST</key>");
@@ -71,6 +73,27 @@ describe("buildLaunchdDaemonPlist", () => {
 		expect(plist).toContain("<false/>");
 		expect(plist).toContain("<key>StandardErrorPath</key>");
 		expect(plist).toContain("<string>/Users/user/.agents/.daemon/logs/startup.log</string>");
+	});
+
+	it("wraps runtime in /bin/bash -c to avoid macOS AMFI launchd exec failure", () => {
+		const plist = buildLaunchdDaemonPlist({
+			daemonPath: "/opt/signet/dist/daemon.js",
+			agentsDir: "/Users/user/.agents",
+			port: 3850,
+			host: "127.0.0.1",
+			bind: "0.0.0.0",
+			startupLogPath: "/Users/user/.agents/.daemon/logs/startup.log",
+		});
+
+		const programArgsMatch = plist.match(/<key>ProgramArguments<\/key>\s*<array>([\s\S]*?)<\/array>/);
+		expect(programArgsMatch).not.toBeNull();
+
+		const inner = programArgsMatch?.[1] ?? "";
+		const strings = [...inner.matchAll(/<string>(.*?)<\/string>/g)].map((m) => m[1]);
+		expect(strings[0]).toBe("/bin/bash");
+		expect(strings[1]).toBe("-c");
+		expect(strings[2]).toContain("exec ");
+		expect(strings[2]).toContain("/opt/signet/dist/daemon.js");
 	});
 
 	it("uses launchctl bootstrap against the current user launchd domain", () => {

--- a/surfaces/cli/src/lib/runtime.test.ts
+++ b/surfaces/cli/src/lib/runtime.test.ts
@@ -58,7 +58,9 @@ describe("buildLaunchdDaemonPlist", () => {
 		expect(plist).toContain("<key>ProgramArguments</key>");
 		expect(plist).toContain("<string>/bin/bash</string>");
 		expect(plist).toContain("<string>-c</string>");
-		expect(plist).toContain(`exec ${process.execPath} /opt/signet/dist/daemon.js`);
+		expect(plist).toContain('<string>exec &quot;$0&quot; &quot;$1&quot;</string>');
+		expect(plist).toContain(`<string>${process.execPath}</string>`);
+		expect(plist).toContain("<string>/opt/signet/dist/daemon.js</string>");
 		expect(plist).toContain("<key>SIGNET_PORT</key>");
 		expect(plist).toContain("<string>3850</string>");
 		expect(plist).toContain("<key>SIGNET_HOST</key>");
@@ -92,8 +94,9 @@ describe("buildLaunchdDaemonPlist", () => {
 		const strings = [...inner.matchAll(/<string>(.*?)<\/string>/g)].map((m) => m[1]);
 		expect(strings[0]).toBe("/bin/bash");
 		expect(strings[1]).toBe("-c");
-		expect(strings[2]).toContain("exec ");
-		expect(strings[2]).toContain("/opt/signet/dist/daemon.js");
+		expect(strings[2]).toBe('exec &quot;$0&quot; &quot;$1&quot;');
+		expect(strings[3]).toBe(process.execPath);
+		expect(strings[4]).toBe("/opt/signet/dist/daemon.js");
 	});
 
 	it("uses launchctl bootstrap against the current user launchd domain", () => {

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -462,7 +462,9 @@ export function buildLaunchdDaemonPlist(input: LaunchdDaemonPlistInput): string 
 	<array>
 		<string>/bin/bash</string>
 		<string>-c</string>
-		<string>exec ${xmlEscape(processRuntimeCommand())} ${xmlEscape(input.daemonPath)}</string>
+		<string>exec &quot;$0&quot; &quot;$1&quot;</string>
+		<string>${xmlEscape(processRuntimeCommand())}</string>
+		<string>${xmlEscape(input.daemonPath)}</string>
 	</array>
 	<key>EnvironmentVariables</key>
 	<dict>${envEntries}

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -460,8 +460,9 @@ export function buildLaunchdDaemonPlist(input: LaunchdDaemonPlistInput): string 
 	<string>${xmlEscape(label)}</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>${xmlEscape(processRuntimeCommand())}</string>
-		<string>${xmlEscape(input.daemonPath)}</string>
+		<string>/bin/bash</string>
+		<string>-c</string>
+		<string>exec ${xmlEscape(processRuntimeCommand())} ${xmlEscape(input.daemonPath)}</string>
 	</array>
 	<key>EnvironmentVariables</key>
 	<dict>${envEntries}


### PR DESCRIPTION
## Summary

macOS launchd cannot directly exec homebrew-installed bun binaries due to Apple Mobile File Integrity (AMFI) restrictions. The daemon starts fine when spawned from a shell but `launchctl bootstrap` fails with `"Bootstrap failed: 5: Input/output error"` (EIO, exit code 78 `EX_CONFIG`).

Wrapping the invocation in `/bin/bash -c "exec <bun> <daemon>"` sidesteps the restriction because `/bin/bash` is a system binary that launchd trusts.

## Changes

| File | Change |
|---|---|
| `surfaces/cli/src/lib/runtime.ts` | `buildLaunchdDaemonPlist()` now emits `/bin/bash -c exec` instead of raw bun path |
| `platform/daemon/src/service.ts` | Parity fix in `generateLaunchdPlist()` for the service installation layer |
| `surfaces/cli/src/lib/runtime.test.ts` | Updated existing plist assertions + new regression test verifying bash wrapping |

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: `platform/daemon` (service.ts)

## Screenshots

N/A, no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no spec-governed behavior touched
- [x] Agent scoping verified on all new/changed data queries — N/A, no data queries changed
- [x] Input/config validation and bounds checks added — N/A, no new inputs
- [x] Error handling and fallback paths tested (no silent swallow) — N/A, fix is in plist generation
- [x] Security checks applied to admin/mutation endpoints — N/A
- [x] Docs updated for API/spec/status changes — N/A, no API changes
- [x] Regression tests added for each bug fix — 1 new test verifying bash wrapping
- [x] Lint/typecheck/tests pass locally — 11 tests pass, typecheck clean

## Migration Notes (if applicable)

N/A. The plist is regenerated on every `signet daemon start`, so the fix takes effect immediately without user action.

## Testing

- [x] `bun test surfaces/cli/src/lib/runtime.test.ts` (11 tests, 0 failures)
- [x] `bun run build` passes
- [x] `bun run typecheck` passes
- [x] Manually verified: daemon starts successfully via launchd with the wrapped plist on macOS (arm64, Sequoia)

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Root cause

`processRuntimeCommand()` in `runtime.ts` resolves to the absolute bun binary path (e.g. `/opt/homebrew/Cellar/bun/1.3.11/bin/bun`) which gets written directly into the launchd plist's `<ProgramArguments>`. macOS AMFI blocks execution of this binary when launched by launchd because it lacks the necessary exception that shell-spawned processes inherit. The fix wraps the invocation in `/bin/bash -c` which is a signed system binary, allowing the bun binary to execute within the bash subprocess.