### PR TITLE
fix(memory): harden recall authorization

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1196,10 +1196,11 @@ with an `error` field. The batch continues — partial success is possible.
 
 ### POST /api/memory/recall
 
-Hybrid search combining BM25 keyword (FTS5) and vector similarity. Results
-are fused using a configurable alpha weight (`cfg.search.alpha`). Optional
-graph boost and reranker pass are applied if enabled in pipeline config.
-Requires `recall` permission.
+Hybrid recall combining FTS5, prospective hints, vector similarity,
+structured path evidence, graph traversal, and optional reranking. The daemon
+authorizes candidate IDs before any content-bearing rerank, summary,
+dampening, expansion, or access-tracking stage runs. Requires `recall`
+permission. For the full execution model, see [Hybrid Recall](./MEMORY.md#hybrid-recall).
 
 **Request body**
 
@@ -1249,7 +1250,9 @@ Only `query` is required.
 }
 ```
 
-`source` per result is one of `hybrid`, `vector`, `keyword`, or `llm_summary`.
+Common `source` values include `hybrid`, `vector`, `keyword`, `hint`, `sec`,
+`structured`, `traversal`, `ka_traversal`, `source_obsidian`,
+`native_memory`, `transcript`, `constructed`, `graph`, and `llm_summary`.
 `method` on the response reflects whether vector search was available for
 this call.
 

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -123,89 +123,170 @@ with a relationship label. Memory-entity associations are tracked in
 `memory_entity_mentions`.
 
 
-Hybrid Search
+Hybrid Recall
 -------------
 
-Search (`platform/core/src/search.ts`) blends two independent signals:
-BM25 keyword relevance and cosine vector similarity. These signals are
-useful because they help build a bounded candidate pool for later
-ranking and context selection.
+Recall is implemented in `platform/daemon/src/memory-search.ts` by
+`hybridRecall`. Its job is not to find one perfect row. Its job is to
+collect a broad candidate set, filter it to the caller's allowed view,
+shape the evidence, and return a bounded list of useful context.
 
-### BM25 Keyword Search
+The route layer checks the caller has `recall` permission. The search
+layer then enforces the data boundary again with one shared filter:
 
-FTS5 BM25 scores are negative (lower = better match). The
-implementation normalizes them to [0, 1] using `1 / (1 + |score|)`.
-This makes them comparable with cosine similarity scores.
+- `agentId` and `readPolicy` control agent visibility. If `agentId` is
+  present and `readPolicy` is omitted, recall defaults to isolated access.
+- `project` restricts results to that project.
+- `scope` restricts results to that explicit scope. When `scope` is
+  omitted, normal recall excludes scoped memories.
+- `type`, `tags`, `who`, `pinned`, `importance_min`, `since`, and `until`
+  narrow the memory rows inside that visibility boundary.
 
-```sql
-SELECT m.id, bm25(memories_fts) AS raw_score
-FROM memories_fts
-JOIN memories m ON memories_fts.rowid = m.rowid
-WHERE memories_fts MATCH ?
-ORDER BY raw_score
-LIMIT ?
-```
+The important safety rule is:
 
-### Vector Search
+> Candidate IDs may be broad, but memory content is not loaded, reranked,
+> summarized, dampened, expanded, or access-tracked until the shared filter
+> has authorized those IDs.
 
-Vector search uses `sqlite-vec` with a `vec_embeddings` virtual table.
-Queries use the KNN MATCH syntax. The distance metric is cosine, which
-`sqlite-vec` returns as `(1 - similarity)`, so the implementation
-converts: `similarity = 1 - distance`.
+That rule matters because vector search and graph traversal are intentionally
+high-recall channels. They can produce IDs that did not pass through the FTS
+SQL filter. `hybridRecall` therefore runs an explicit `authorize_candidates`
+stage before any content-bearing stage.
 
-```sql
-SELECT e.source_id, v.distance
-FROM vec_embeddings v
-JOIN embeddings e ON v.id = e.id
-JOIN memories m ON e.source_id = m.id
-WHERE v.embedding MATCH ? AND k = ?
-ORDER BY v.distance
-```
+### Phase 1: Prepare the Query
 
-### Alpha Blending
+Recall starts with the original `query`, an optional `keywordQuery`, and a
+normalized `limit`. `limit` is clamped to a bounded range so callers cannot
+force unbounded recall work.
 
-Scores from both sources are merged using a configurable alpha weight:
+The keyword side uses `sanitizeFtsQuery` to produce a safe FTS5 `MATCH`
+expression. If sanitization leaves no searchable tokens, the FTS and hint
+paths are skipped instead of issuing an empty `MATCH`.
 
-```
-score = alpha × vector_score + (1 - alpha) × bm25_score
-```
+`expandRecallKeywordQuery` adds a small mechanical expansion set for known
+class-to-instance gaps. The expansion affects keyword and hint search only.
+Vector search and model summaries still use the user's original query.
 
-If only one source returns a result for a given memory ID, its score
-is used directly without blending. Results below `min_score` are
-dropped. The default alpha is 0.7 (70% semantic, 30% keyword).
+### Phase 2: Collect Candidate IDs
 
-Configure in `agent.yaml`:
+Candidate collection uses several independent channels:
 
-```yaml
-search:
-  alpha: 0.7       # vector weight; 1 - alpha goes to BM25
-  min_score: 0.1   # drop results below this threshold
-```
+- **Memory FTS** queries `memories_fts`, joins to `memories`, applies the
+  shared filter, and normalizes BM25 scores within the batch.
+- **Prospective hints** query `memory_hints_fts`. Hints are write-time
+  alternate phrasings. They can rescue a memory whose content does not use
+  the same words as the current query.
+- **Vector search** embeds the original query and searches `vec_embeddings`
+  through `sqlite-vec`. Vector search cannot pre-filter every recall scope,
+  so constrained searches over-fetch and rely on authorization after merge.
+- **Structured path candidates** search entity/aspect/group/claim paths so
+  structured knowledge can surface even when its prose is sparse.
+- **Graph traversal** resolves focal entities and walks the knowledge graph.
+  In traversal-primary mode, graph results are treated as a first-class
+  retrieval channel rather than a small boost.
 
-### Graph-Augmented Search
+Flat lexical, hint, vector, and structured scores are merged by memory ID.
+When a memory appears in multiple channels, the strongest calibrated evidence
+wins unless there is an explicit blend. Pure hint-only hits are capped so
+generated hints can rescue recall but do not outrank directly grounded
+keyword, vector, or structured evidence.
 
-When `graphEnabled = true`, the recall endpoint runs an additional
-graph lookup before returning results
-(`platform/daemon/src/pipeline/graph-search.ts`).
+Traversal-primary mode sorts traversal candidates before selection and
+max-merges traversal overlap with flat candidates. This prevents a weak graph
+score from discarding stronger direct evidence for the same memory.
 
-The query is tokenized and matched against entity `canonical_name`
-values (top 20 by `mentions` count). From those seed entities, the
-graph expands one hop in both directions through the `relations` table
-(up to 50 neighbors). The resulting expanded entity set is joined to
-`memory_entity_mentions` to produce a set of linked memory IDs.
+### Phase 3: Authorize Candidates
 
-Memories in this set receive a configurable boost to their combined
-score. The graph lookup runs synchronously with a deadline to prevent
-slow queries from blocking recall. On timeout or error, the boost
-set is empty and search degrades gracefully. In other words, graph
-structure improves candidate quality when available but does not become
-a hard dependency for recall.
+After candidate collection and coarse score fusion, `authorize_candidates`
+requeries `memories` with the shared filter and removes anything outside the
+caller's allowed view. This is the boundary between "IDs only" and "content
+can now be read."
 
-### Optional Reranking
+New recall stages should follow this rule:
 
-If `search.reranking = true` is set, results above the minimum score
-threshold can be passed to a reranker model before final ordering.
-This is optional and provider-dependent.
+- Stages that only produce IDs and scores may run before authorization.
+- Stages that read memory content, send text to a model, build summaries,
+  inspect entity coverage, expand transcripts, or update metadata must run
+  after authorization.
+
+### Phase 4: Shape Authorized Evidence
+
+Once candidates are authorized, recall can safely use content-bearing
+post-processing:
+
+- **Structured Evidence Convolution (SEC-lite)** compares lexical, semantic,
+  hint, traversal, and structured signals so graph-only results do not blindly
+  dominate direct evidence.
+- **Facet coverage** can read candidate content and prefer rows that cover
+  more of the query's facets.
+- **Rehearsal boost** applies a small access-frequency and recency signal
+  when enabled.
+- **Reranking** can use an embedding reranker or an LLM reranker on the
+  authorized top-N candidates. If the reranker fails or times out, recall
+  keeps the existing ordering.
+- **Dampening** penalizes low-overlap semantic hits, hub-like entity
+  dominance, and other noisy retrieval shapes.
+- **Currentness** annotates superseded memories and boosts current
+  replacements.
+
+All of these stages are non-fatal. Recall should degrade toward simpler
+keyword/vector results rather than fail the whole response.
+
+### Phase 5: Hydrate and Assemble Results
+
+Hydration fetches full memory rows with the same shared filter used by
+authorization. Constrained searches use a larger pre-hydration window so
+valid later candidates can still return after broad vector or traversal IDs
+are removed.
+
+Assembly walks the pre-hydrated scored list, keeps only hydrated rows, and
+then applies the caller's `limit`. Access tracking updates only the memory
+IDs that actually appear in the returned primary result set. Synthetic cards
+and unauthorized candidates never update `access_count`.
+
+Supplementary results may include:
+
+- source-backed Obsidian chunks,
+- native memory artifacts,
+- transcript fallback cards when `expand` is enabled,
+- an LLM summary card when the LLM reranker path has remaining timeout
+  budget,
+- linked rationale memories for decision results,
+- constructed graph context cards.
+
+The final response is capped to `limit`. Supplementary rows are marked with
+`supplementary: true` so callers can distinguish them from ordinary memory
+rows.
+
+### Source and Transcript Rescue Paths
+
+If normal memory candidates produce no hits, recall can fall back to source
+chunks, native memory artifacts, and transcript FTS. These paths return
+synthetic recall rows rather than materializing new `memories` records, but
+each fallback is only enabled when its backing rows can satisfy the caller's
+scope boundary.
+
+Source chunk vector fallback is disabled for project-scoped recall until chunk
+embeddings carry a strong source root/project binding. Project-scoped searches
+still use authorized memory rows, native source artifacts, and transcript
+fallbacks; they do not guess source ownership from chunk text metadata.
+
+When `expand` is enabled and ordinary memory rows reference session source
+IDs, recall may fetch raw transcript excerpts and same-session structured
+summaries. This is a lossless backing-source path: extracted memories remain
+the primary row, but the transcript can restore details that extraction
+compressed away.
+
+### Timing and Failure Behavior
+
+Every major stage records timing data in `meta.timings`. Slow recalls log a
+stage breakdown so latency regressions can be localized without guessing.
+
+Secondary channels are deliberately best-effort. Embedding, vector search,
+graph traversal, structured evidence, reranking, dampening, currentness,
+source fallback, transcript expansion, and LLM summary failures are logged
+and skipped. The caller should receive the best safe recall response the
+daemon can produce from the remaining channels.
 
 ### Recall API
 
@@ -221,7 +302,8 @@ curl -X POST http://localhost:3850/api/memory/recall \
 ```
 
 Optional filters: `type`, `tags`, `who`, `pinned`, `importance_min`,
-`since` (ISO timestamp).
+`since`, `until`, `agentId`, `readPolicy`, `policyGroup`, `project`,
+`scope`, and `expand`.
 
 
 Content Normalization

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -64,6 +64,14 @@ describe("hybridRecall", () => {
 		};
 	}
 
+	function vectorBlob(values: readonly number[]): Buffer {
+		return Buffer.from(new Float32Array(values).buffer);
+	}
+
+	function unitVector(): number[] {
+		return Array.from({ length: 768 }, (_, index) => (index === 0 ? 1 : 0));
+	}
+
 	it("keeps expanded transcript sources scoped to the requesting agent", async () => {
 		const now = new Date().toISOString();
 		getDbAccessor().withWriteTx((db) => {
@@ -143,6 +151,145 @@ describe("hybridRecall", () => {
 		for (const stage of result.meta.timings.stages) {
 			expect(stage.durationMs).toBeGreaterThanOrEqual(0);
 		}
+	});
+
+	it("skips source chunk vector fallback for project-scoped recall", async () => {
+		const now = new Date().toISOString();
+		const vec = unitVector();
+		getDbAccessor().withWriteTx((db) => {
+			const artifact = db.prepare(
+				`INSERT INTO memory_artifacts (
+					agent_id, source_path, source_sha256, source_kind, session_id,
+					session_token, project, harness, captured_at, content, updated_at
+				) VALUES (
+					'default', ?, ?, 'source_obsidian_markdown', ?, ?, ?, 'obsidian', ?, ?, ?
+				)`,
+			);
+			artifact.run(
+				"/workspace/project-a/source-a.md",
+				createHash("sha256").update("project-a").digest("hex"),
+				"source-a",
+				"token-a",
+				"/workspace/project-a",
+				now,
+				"project-a source artifact",
+				now,
+			);
+			artifact.run(
+				"/workspace/project-b/source-b.md",
+				createHash("sha256").update("project-b").digest("hex"),
+				"source-b",
+				"token-b",
+				"/workspace/project-b",
+				now,
+				"project-b source artifact",
+				now,
+			);
+
+			const embedding = db.prepare(
+				`INSERT INTO embeddings (
+					id, content_hash, vector, dimensions, source_type, source_id,
+					chunk_text, created_at, agent_id
+				) VALUES (?, ?, ?, 768, 'source_obsidian_chunk', ?, ?, ?, 'default')`,
+			);
+			embedding.run(
+				"emb-source-a",
+				"hash-source-a",
+				vectorBlob(vec),
+				"obsidian:vault-a:source-a.md#overview:1-1:0",
+				"source_path: /workspace/project-a/source-a.md\nproject-a private source chunk",
+				now,
+			);
+			embedding.run(
+				"emb-source-b",
+				"hash-source-b",
+				vectorBlob(vec),
+				"obsidian:vault-b:source-b.md#overview:1-1:0",
+				"source_path: /workspace/project-a/source-a.md\nproject-b spoofed source chunk",
+				now,
+			);
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "private source chunk",
+				keywordQuery: "private source chunk",
+				limit: 5,
+				agentId: "default",
+				readPolicy: "isolated",
+				project: "/workspace/project-a",
+			},
+			testCfg(),
+			async () => vec,
+		);
+
+		expect(result.results).toEqual([]);
+		expect(result.meta.noHits).toBe(true);
+	});
+
+	it("drops ambiguous source chunk vector matches for project-scoped recall", async () => {
+		const now = new Date().toISOString();
+		const vec = unitVector();
+		getDbAccessor().withWriteTx((db) => {
+			const artifact = db.prepare(
+				`INSERT INTO memory_artifacts (
+					agent_id, source_path, source_sha256, source_kind, session_id,
+					session_token, project, harness, captured_at, content, updated_at
+				) VALUES (
+					'default', ?, ?, 'source_obsidian_markdown', ?, ?, ?, 'obsidian', ?, ?, ?
+				)`,
+			);
+			artifact.run(
+				"/workspace/project-a/shared.md",
+				createHash("sha256").update("shared-a").digest("hex"),
+				"shared-a",
+				"shared-token-a",
+				"/workspace/project-a",
+				now,
+				"project-a shared artifact",
+				now,
+			);
+			artifact.run(
+				"/workspace/project-b/shared.md",
+				createHash("sha256").update("shared-b").digest("hex"),
+				"shared-b",
+				"shared-token-b",
+				"/workspace/project-b",
+				now,
+				"project-b shared artifact",
+				now,
+			);
+
+			db.prepare(
+				`INSERT INTO embeddings (
+					id, content_hash, vector, dimensions, source_type, source_id,
+					chunk_text, created_at, agent_id
+				) VALUES (?, ?, ?, 768, 'source_obsidian_chunk', ?, ?, ?, 'default')`,
+			).run(
+				"emb-shared-b",
+				"hash-shared-b",
+				vectorBlob(vec),
+				"obsidian:vault-b:shared.md#overview:1-1:0",
+				"source_path: /workspace/project-a/shared.md\nambiguous project-b spoofed chunk marker",
+				now,
+			);
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "ambiguous project-b spoofed chunk marker",
+				keywordQuery: "ambiguous project-b spoofed chunk marker",
+				limit: 5,
+				agentId: "default",
+				readPolicy: "isolated",
+				project: "/workspace/project-a",
+			},
+			testCfg(),
+			async () => vec,
+		);
+
+		expect(result.results).toEqual([]);
+		expect(result.meta.noHits).toBe(true);
 	});
 
 	it("falls back to keyword recall when embedding throws synchronously", async () => {
@@ -280,6 +427,45 @@ describe("hybridRecall", () => {
 		);
 
 		expect(result.results.map((row) => row.id)).toEqual(["mem-hint-live"]);
+	});
+
+	it("defaults agent searches without readPolicy to isolated access", async () => {
+		const now = new Date().toISOString();
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, type, agent_id, created_at, updated_at, updated_by
+				) VALUES (?, ?, 'fact', ?, ?, ?, 'test')`,
+			).run("mem-agent-a", "agent-isolation-marker recall content", "agent-a", now, now);
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, type, agent_id, created_at, updated_at, updated_by
+				) VALUES (?, ?, 'fact', ?, ?, ?, 'test')`,
+			).run("mem-agent-b", "agent-isolation-marker recall content", "agent-b", now, now);
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "agent-isolation-marker",
+				keywordQuery: "agent-isolation-marker",
+				limit: 5,
+				agentId: "agent-a",
+			},
+			loadMemoryConfig(dir),
+			async () => null,
+		);
+
+		expect(result.results.map((row) => row.id)).toEqual(["mem-agent-a"]);
+		const counts = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT id, access_count FROM memories WHERE id IN ('mem-agent-a', 'mem-agent-b') ORDER BY id")
+					.all() as Array<{ id: string; access_count: number }>,
+		);
+		expect(counts).toEqual([
+			{ id: "mem-agent-a", access_count: 1 },
+			{ id: "mem-agent-b", access_count: 0 },
+		]);
 	});
 
 	it("recalls indexed native harness memory artifacts without materializing memories", async () => {
@@ -1079,6 +1265,54 @@ assistant: Considering your weightlifting background, power yoga might be useful
 		expect(hit?.content).toContain("exercise classes and calendar planning");
 	});
 
+	it("defaults transcript summary hydration to the default agent when agentId is omitted", async () => {
+		const now = new Date().toISOString();
+		getDbAccessor().withWriteTx((db) => {
+			const memory = db.prepare(
+				`INSERT INTO memories (
+					id, content, type, source_id, agent_id, project, created_at, updated_at, updated_by
+				) VALUES (?, ?, 'fact', ?, ?, NULL, ?, ?, 'test')`,
+			);
+			memory.run(
+				"mem-default-summary",
+				"Default agent summary says the user maintains a fermented dough culture in the fridge.",
+				"shared-session-42",
+				"default",
+				now,
+				now,
+			);
+			memory.run(
+				"mem-other-agent-summary",
+				"Other agent summary says the user keeps backup API keys in a notebook.",
+				"shared-session-42",
+				"agent-b",
+				now,
+				now,
+			);
+
+			db.prepare(
+				`INSERT INTO session_transcripts (
+					session_key, content, harness, project, agent_id, created_at, updated_at
+				) VALUES (?, ?, 'codex', NULL, 'default', ?, ?)`,
+			).run("shared-session-42", "user: We discussed sourdough starter storage and feeding cadence.", now, now);
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "sourdough starter feeding cadence",
+				limit: 5,
+				expand: true,
+			},
+			testCfg({ reranker: false }),
+			async () => null,
+		);
+
+		const hit = result.results.find((row) => row.id === "transcript:shared-session-42");
+		expect(hit?.content).toContain("Default agent summary");
+		expect(hit?.content).not.toContain("Other agent summary");
+		expect(hit?.content).not.toContain("backup API keys");
+	});
+
 	it("dampens stale structured memories and annotates current replacements", async () => {
 		const oldDate = "2023-05-01T12:00:00.000Z";
 		const newDate = "2023-06-01T12:00:00.000Z";
@@ -1233,6 +1467,76 @@ assistant: Considering your weightlifting background, power yoga might be useful
 
 		expect(result.results.map((row) => row.id)).toContain("mem-project");
 		expect(result.results.map((row) => row.id)).not.toContain("mem-null-project");
+	});
+
+	it("assembles scoped over-fetch results after unauthorized candidates are removed", async () => {
+		const now = new Date().toISOString();
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, type, agent_id, project, created_at, updated_at, updated_by
+				) VALUES (?, ?, 'fact', 'default', ?, ?, ?, 'test')`,
+			).run("mem-authorized-project", "Signet authorized project recall marker", "/home/nicholai", now, now);
+
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, type, agent_id, project, created_at, updated_at, updated_by
+				) VALUES (?, ?, 'fact', 'default', NULL, ?, ?, 'test')`,
+			).run("mem-unauthorized-project", "Signet unauthorized traversal recall marker", now, now);
+
+			db.prepare(
+				`INSERT INTO entities (
+					id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at
+				) VALUES (?, ?, ?, 'project', 'default', 5, ?, ?)`,
+			).run("ent-overfetch", "Signet", "signet", now, now);
+
+			db.prepare(
+				`INSERT INTO entity_aspects (
+					id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at
+				) VALUES (?, ?, 'default', 'context', 'context', 0.9, ?, ?)`,
+			).run("asp-overfetch", "ent-overfetch", now, now);
+
+			const attr = db.prepare(
+				`INSERT INTO entity_attributes (
+					id, aspect_id, agent_id, memory_id, kind, content, normalized_content, confidence, importance, status, created_at, updated_at
+				) VALUES (?, 'asp-overfetch', 'default', ?, 'attribute', ?, ?, 1, ?, 'active', ?, ?)`,
+			);
+			attr.run(
+				"attr-unauthorized-overfetch",
+				"mem-unauthorized-project",
+				"Signet unauthorized traversal recall marker",
+				"signet unauthorized traversal recall marker",
+				1,
+				now,
+				now,
+			);
+			attr.run(
+				"attr-authorized-overfetch",
+				"mem-authorized-project",
+				"Signet authorized project recall marker",
+				"signet authorized project recall marker",
+				0.5,
+				now,
+				now,
+			);
+		});
+
+		const cfg = testCfg({ graph: true, traversal: true, traversalPrimary: true });
+
+		const result = await hybridRecall(
+			{
+				query: "Signet",
+				keywordQuery: "Signet",
+				limit: 1,
+				agentId: "default",
+				readPolicy: "isolated",
+				project: "/home/nicholai",
+			},
+			cfg,
+			async () => null,
+		);
+
+		expect(result.results.map((row) => row.id)).toEqual(["mem-authorized-project"]);
 	});
 
 	it("does not use pinned entities as implicit traversal ballast for recall queries", async () => {

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -1,9 +1,15 @@
 /**
  * Hybrid recall search orchestration.
  *
- * Extracted from daemon.ts — this module contains the pure search logic
- * between "parse request" and "format response". The route handler in
- * daemon.ts is now a thin HTTP wrapper that delegates here.
+ * This module turns a user query into a bounded, authorized recall response.
+ * The route handler in daemon.ts owns HTTP parsing and permissions; this file
+ * owns retrieval mechanics, score shaping, fallback sources, and response
+ * assembly.
+ *
+ * The critical invariant is ordering: broad candidate IDs may come from vector
+ * search, graph traversal, or source rescue paths, but memory content must not
+ * be loaded for reranking, dampening, summaries, expansion, or access tracking
+ * until the shared scope/project/agent filter has authorized those IDs.
  */
 
 import { createHash } from "node:crypto";
@@ -253,13 +259,18 @@ function buildFilterClause(params: RecallParams): FilterClause {
 		args,
 	};
 
-	// Agent visibility filtering — only applied when both agentId and readPolicy are provided.
-	if (params.agentId && params.readPolicy) {
-		const scope = buildAgentScopeClause(params.agentId, params.readPolicy, params.policyGroup ?? null);
+	// Agent visibility filtering defaults to isolated when an agent is known.
+	if (params.agentId) {
+		const scope = buildAgentScopeClause(params.agentId, params.readPolicy ?? "isolated", params.policyGroup ?? null);
 		return { sql: base.sql + scope.sql, args: [...base.args, ...scope.args] };
 	}
 
 	return base;
+}
+
+function normalizeRecallLimit(raw: number | undefined): number {
+	if (typeof raw !== "number" || !Number.isFinite(raw)) return 10;
+	return Math.max(1, Math.min(50, Math.floor(raw)));
 }
 
 // ---------------------------------------------------------------------------
@@ -461,6 +472,30 @@ function mergeCandidate(
 	}
 }
 
+function authorizeScoredCandidates(
+	scored: ReadonlyArray<{ id: string; score: number; source: string }>,
+	filter: FilterClause,
+): Array<{ id: string; score: number; source: string }> {
+	// Candidate collectors intentionally cast a wide net. This is the single
+	// pre-content gate for database-backed memories: after this point the IDs
+	// are safe to use in stages that read content or mutate access metadata.
+	const ids = [...new Set(scored.map((row) => row.id))];
+	if (ids.length === 0) return [];
+	const placeholders = ids.map(() => "?").join(", ");
+	const allowed = getDbAccessor().withReadDb((db) => {
+		const rows = db
+			.prepare(
+				`SELECT m.id
+				 FROM memories m
+				 WHERE m.id IN (${placeholders})
+				   AND m.is_deleted = 0${filter.sql}`,
+			)
+			.all(...ids, ...filter.args) as Array<{ id: string }>;
+		return new Set(rows.map((row) => row.id));
+	});
+	return scored.filter((row) => allowed.has(row.id));
+}
+
 interface CurrentnessInfo {
 	readonly active: readonly string[];
 	readonly superseded: ReadonlyArray<{
@@ -588,6 +623,7 @@ interface SourceChunkVectorHit {
 	readonly chunkText: string;
 	readonly score: number;
 	readonly createdAt: string;
+	readonly project: string | null;
 }
 
 function nativeIdSegment(value: string | null | undefined): string {
@@ -631,19 +667,26 @@ function buildSourceChunkVectorHits(
 	queryVec: Float32Array | null,
 	existingSourceIds: ReadonlySet<string>,
 	limit: number,
-	agentId?: string,
+	agentId: string,
+	project?: string,
 ): SourceChunkVectorHit[] {
-	if (!queryVec || limit <= 0 || !agentId) return [];
+	if (!queryVec || limit <= 0) return [];
+	// Source chunk embeddings only carry agent_id plus an embedding source_id.
+	// The live artifact table carries project, but not the source root/id needed
+	// to bind an embedding to that project without filename spoofing. Skip this
+	// rescue path for project-scoped recall until the index has that strong key.
+	if (project) return [];
 	try {
 		return getDbAccessor().withReadDb((db) => {
-			const agentWhere = agentId ? " AND agent_id = ?" : "";
 			const rows = db
 				.prepare(
 					`SELECT id, source_id, vector, chunk_text, created_at
 					 FROM embeddings
-					 WHERE source_type = 'source_obsidian_chunk' AND vector IS NOT NULL${agentWhere}`,
+					 WHERE source_type = 'source_obsidian_chunk'
+					   AND vector IS NOT NULL
+					   AND agent_id = ?`,
 				)
-				.all(...(agentId ? [agentId] : [])) as Array<{
+				.all(agentId) as Array<{
 				id: string;
 				source_id: string;
 				vector: Buffer;
@@ -651,17 +694,23 @@ function buildSourceChunkVectorHits(
 				created_at: string;
 			}>;
 			return rows
-				.map((row) => ({
-					embeddingId: row.id,
-					sourceId: row.source_id,
-					sourcePath: sourcePathFromChunkText(row.chunk_text),
-					chunkText: row.chunk_text,
-					score: cosineSimilarity(
-						queryVec,
-						new Float32Array(row.vector.buffer, row.vector.byteOffset, row.vector.byteLength / 4),
-					),
-					createdAt: row.created_at,
-				}))
+				.flatMap((row) => {
+					const sourcePath = sourcePathFromChunkText(row.chunk_text);
+					return [
+						{
+							embeddingId: row.id,
+							sourceId: row.source_id,
+							sourcePath,
+							chunkText: row.chunk_text,
+							score: cosineSimilarity(
+								queryVec,
+								new Float32Array(row.vector.buffer, row.vector.byteOffset, row.vector.byteLength / 4),
+							),
+							createdAt: row.created_at,
+							project: null,
+						},
+					];
+				})
 				.filter((row) => row.score > 0 && !existingSourceIds.has(row.sourceId))
 				.sort((a, b) => b.score - a.score)
 				.slice(0, limit);
@@ -921,20 +970,24 @@ function loadStructuredSummariesBySourceId(params: RecallParams, sourceIds: read
 	try {
 		return getDbAccessor().withReadDb((db) => {
 			const placeholders = unique.map(() => "?").join(", ");
+			const scope = buildAgentScopeClause(
+				params.agentId ?? "default",
+				params.readPolicy ?? "isolated",
+				params.policyGroup ?? null,
+			);
+			const projectSql = params.project ? "AND m.project = ?" : "";
+			const projectArgs: unknown[] = params.project ? [params.project] : [];
 			const parts = [
-				"SELECT source_id, content",
-				"FROM memories",
-				`WHERE source_id IN (${placeholders})`,
-				"AND agent_id = ?",
-				"AND COALESCE(is_deleted, 0) = 0",
-				"AND TRIM(content) != ''",
+				"SELECT m.source_id, m.content",
+				"FROM memories m",
+				`WHERE m.source_id IN (${placeholders})`,
+				"AND COALESCE(m.is_deleted, 0) = 0",
+				"AND TRIM(m.content) != ''",
+				projectSql,
+				scope.sql,
 			];
-			const args: unknown[] = [...unique, params.agentId ?? "default"];
-			if (params.project) {
-				parts.push("AND project = ?");
-				args.push(params.project);
-			}
-			parts.push("ORDER BY importance DESC, updated_at DESC, created_at DESC");
+			const args: unknown[] = [...unique, ...projectArgs, ...scope.args];
+			parts.push("ORDER BY m.importance DESC, m.updated_at DESC, m.created_at DESC");
 
 			const rows = db.prepare(parts.join("\n")).all(...args) as Array<{
 				source_id: string | null;
@@ -998,6 +1051,21 @@ function cosineSimilarity(query: Float32Array, memory: Float32Array): number {
 // supported by direct evidence can keep its score; only hint-only rows are capped.
 const HINT_ONLY_SCORE_CAP = 0.75;
 
+/**
+ * Run the recall pipeline.
+ *
+ * The stages are deliberately split into two halves:
+ *
+ * 1. Candidate collection: FTS, hints, vector, structured path search, and
+ *    graph traversal collect IDs and scores. These stages may over-fetch.
+ * 2. Authorized content handling: after `authorize_candidates`, later stages
+ *    may read content, call rerankers, apply dampening/currentness, hydrate
+ *    results, expand transcripts, and update access counts.
+ *
+ * Keep that boundary intact. It is what prevents high-recall channels such as
+ * vector search and traversal from leaking out-of-scope content into model or
+ * summary paths.
+ */
 export async function hybridRecall(
 	params: RecallParams,
 	cfg: ResolvedMemoryConfig,
@@ -1006,7 +1074,7 @@ export async function hybridRecall(
 	const query = params.query;
 	const expandedQuery = expandRecallKeywordQuery(params.query);
 	const keywordQuery = sanitizeFtsQuery((params.keywordQuery ?? expandedQuery).trim());
-	const limit = params.limit ?? 10;
+	const limit = normalizeRecallLimit(params.limit);
 	const alpha = cfg.search.alpha;
 	const minScore = cfg.search.min_score;
 	const timings = createRecallTimingCollector();
@@ -1031,7 +1099,7 @@ export async function hybridRecall(
 	};
 
 	const filter = buildFilterClause(params);
-	const scoped = params.scope !== undefined;
+	const needsPostFilter = params.scope !== undefined || !!params.project || !!params.agentId;
 	const queryVecPromise = (() => {
 		const embeddingStart = performance.now();
 		let promise: Promise<number[] | null>;
@@ -1072,6 +1140,7 @@ export async function hybridRecall(
 	const traversalEvidenceMap = new Map<string, number>();
 	try {
 		timings.time("memory_fts", () => {
+			if (keywordQuery.length === 0) return;
 			getDbAccessor().withReadDb((db) => {
 				// CROSS JOIN keeps SQLite from scanning memories first via
 				// low-selectivity filters before applying the FTS rowid match.
@@ -1112,6 +1181,7 @@ export async function hybridRecall(
 	if (cfg.pipelineV2.hints?.enabled) {
 		try {
 			timings.time("hints_fts", () => {
+				if (keywordQuery.length === 0) return;
 				getDbAccessor().withReadDb((db) => {
 					// Keep memory_hints_fts first; the agent/scope indexes are much
 					// less selective than the FTS match on large workspaces.
@@ -1164,17 +1234,18 @@ export async function hybridRecall(
 	}
 
 	// --- Vector search via sqlite-vec ---
-	// sqlite-vec cannot pre-filter by scope, so scoped queries over-fetch
-	// (2x top_k) and rely on hydration-time scope filtering (line ~685).
-	// This ensures scoped queries still benefit from vector similarity
-	// when graph traversal yields no focal entities.
+	// sqlite-vec cannot pre-filter by recall scope/project/agent policy, so
+	// constrained queries over-fetch and rely on candidate authorization.
+	// This keeps constrained queries eligible for vector similarity when graph
+	// traversal yields no focal entities.
 	const vectorMap = new Map<string, number>();
 	if (queryVecF32) {
-		const vecLimit = scoped ? cfg.search.top_k * 2 : cfg.search.top_k;
+		const queryVector = queryVecF32;
+		const vecLimit = needsPostFilter ? cfg.search.top_k * 2 : cfg.search.top_k;
 		try {
 			timings.time("vector_search", () => {
 				getDbAccessor().withReadDb((db) => {
-					const vecResults = vectorSearch(db as any, queryVecF32!, {
+					const vecResults = vectorSearch(db as any, queryVector, {
 						limit: vecLimit,
 						type: params.type as "fact" | "preference" | "decision" | undefined,
 					});
@@ -1358,24 +1429,28 @@ export async function hybridRecall(
 				}
 			}
 
-			// Channel merge: ensure flat candidates are eligible to compete in the
-			// final sorted pool. Flat gets at least 40% of pre-sort slots so hub
-			// entities (high-mention traversal walks) can't exclude keyword/vector
-			// matches entirely. After the sort, final top-N is score-ordered.
-			const traversalIds = new Set(traversalScored.map((s) => s.id));
-			const flatOnly = flatScored.filter((s) => !traversalIds.has(s.id));
+			// Channel merge: max-fuse overlapping flat/traversal candidates so a
+			// weak graph score never discards stronger lexical/vector evidence.
+			traversalScored.sort((a, b) => b.score - a.score);
 			const candidateBudget = Math.max(limit, Math.min(cfg.search.top_k, limit * 4));
+			const flatIds = new Set(flatScored.map((row) => row.id));
 			const minFlat = Math.ceil(candidateBudget * 0.4);
-			const maxTraversal = candidateBudget - Math.min(minFlat, flatOnly.length);
-			scored = [
-				...traversalScored.slice(0, maxTraversal),
-				// When traversal underperforms its cap, flat absorbs the surplus
-				// slots — this is intentional, not a bug. Keep the pre-SEC pool
-				// wider than the final limit so structured evidence can rescue
-				// lower raw-rank but better path-matched candidates.
-				...flatOnly.slice(0, candidateBudget - Math.min(maxTraversal, traversalScored.length)),
-			];
-			scored.sort((a, b) => b.score - a.score);
+			const byId = new Map<string, { id: string; score: number; source: string }>();
+			for (const row of flatScored) mergeCandidate(byId, row);
+			for (const row of traversalScored) mergeCandidate(byId, row);
+			const fused = [...byId.values()].sort((a, b) => b.score - a.score);
+			const selected: Array<{ id: string; score: number; source: string }> = [];
+			let flatCount = 0;
+			for (const row of fused) {
+				if (selected.length >= candidateBudget) break;
+				const isFlat = flatIds.has(row.id);
+				const remaining = candidateBudget - selected.length;
+				const neededFlat = Math.max(0, Math.min(minFlat, flatScored.length) - flatCount);
+				if (!isFlat && neededFlat >= remaining) continue;
+				selected.push(row);
+				if (isFlat) flatCount++;
+			}
+			scored = selected;
 		});
 	} else {
 		scored = flatScored;
@@ -1512,6 +1587,12 @@ export async function hybridRecall(
 		scored = [...byId.values()].sort((a, b) => b.score - a.score);
 	}
 
+	if (scored.length > 0) {
+		scored = timings.time("authorize_candidates", () => authorizeScoredCandidates(scored, filter));
+	}
+
+	// Everything below this point may assume `scored` only contains memory IDs
+	// visible to the caller. Keep new content-bearing stages below this line.
 	const structuredEvidenceMap = new Map(structuredCandidateMap);
 
 	// --- Structured Evidence Convolution (SEC-lite) ---
@@ -1598,7 +1679,7 @@ export async function hybridRecall(
 	// Remaining timeout budget to use for LLM summary after reranking.
 	// Set inside the reranker block; consumed after final results are assembled.
 	let summarizeLeft = 0;
-	if (cfg.pipelineV2.reranker.enabled) {
+	if (cfg.pipelineV2.reranker.enabled && scored.length > 0) {
 		const rerankerStageStart = performance.now();
 		try {
 			const rerankStart = Date.now();
@@ -1814,16 +1895,16 @@ export async function hybridRecall(
 		scored.sort((a, b) => b.score - a.score);
 	});
 
-	// Over-fetch before hydration when scoped. Vector search can't
-	// pre-filter by scope, so out-of-scope IDs get dropped at
-	// hydration. 3x compensates for the expected discard rate.
-	const preHydrate = scoped ? limit * 3 : limit;
+	// Over-fetch before hydration for constrained searches. Broad candidate
+	// channels can include IDs that candidate authorization or hydration drops.
+	// 3x compensates for the expected discard rate.
+	const preHydrate = needsPostFilter ? limit * 3 : limit;
 	const topIds = scored.slice(0, preHydrate).map((s) => s.id);
 	const recallTruncate = cfg.pipelineV2.guardrails.recallTruncateChars;
 
 	if (topIds.length === 0) {
 		const sourceChunkHits = timings.time("source_chunk_vector_fallback", () =>
-			buildSourceChunkVectorHits(queryVecF32, new Set(), limit, params.agentId),
+			buildSourceChunkVectorHits(queryVecF32, new Set(), limit, params.agentId ?? "default", params.project),
 		);
 		if (sourceChunkHits.length > 0) {
 			const results = sourceChunkHits.slice(0, limit).map((hit): RecallResult => {
@@ -1843,7 +1924,7 @@ export async function hybridRecall(
 					pinned: false,
 					importance: 0.6,
 					who: "obsidian",
-					project: null,
+					project: hit.project,
 					created_at: hit.createdAt,
 					source_path: hit.sourcePath,
 					supplementary: true,
@@ -1957,23 +2038,8 @@ export async function hybridRecall(
 	}
 
 	// --- Fetch full memory rows ---
-	// Scope filter on hydration catches any results that bypassed
-	// the FTS filter clause (e.g. unscoped graph boost results).
-	// Agent scope filter also applied here to catch vector/traversal
-	// results that bypass FTS-level agent filtering.
-	const scopeClause =
-		params.scope !== undefined
-			? params.scope === null
-				? " AND m.scope IS NULL"
-				: " AND m.scope = ?"
-			: " AND m.scope IS NULL";
-	const scopeArgs: unknown[] = params.scope !== undefined && params.scope !== null ? [params.scope] : [];
-	const projectClause = params.project ? " AND m.project = ?" : "";
-	const projectArgs: unknown[] = params.project ? [params.project] : [];
-	const agentScope =
-		params.agentId && params.readPolicy
-			? buildAgentScopeClause(params.agentId, params.readPolicy, params.policyGroup ?? null)
-			: { sql: "", args: [] };
+	// Hydration uses the same auth/scope/project filter as candidate
+	// authorization so no alternate path can widen access.
 	const placeholders = topIds.map(() => "?").join(", ");
 
 	const rows = timings.time("hydrate_memory_rows", () =>
@@ -1983,9 +2049,9 @@ export async function hybridRecall(
 					.prepare(
 						`SELECT m.id, m.content, m.source_id, m.type, m.tags, m.pinned, m.importance, m.who, m.project, m.created_at
         FROM memories m
-        WHERE m.id IN (${placeholders}) AND m.is_deleted = 0${scopeClause}${projectClause}${agentScope.sql}`,
+        WHERE m.id IN (${placeholders}) AND m.is_deleted = 0${filter.sql}`,
 					)
-					.all(...topIds, ...scopeArgs, ...projectArgs, ...agentScope.args) as Array<{
+					.all(...topIds, ...filter.args) as Array<{
 					id: string;
 					content: string;
 					source_id: string | null;
@@ -2000,58 +2066,74 @@ export async function hybridRecall(
 		),
 	);
 
-	// Update access tracking (don't fail if this fails).
-	// Uses topIds (real DB memory IDs from scored), not the final results
-	// array — so the synthetic llm_summary card injected later is never
-	// included here and never touches the memories table.
-	try {
-		timings.time("access_tracking_update", () => {
-			getDbAccessor().withWriteTx((db) => {
-				db.prepare(
-					`UPDATE memories
-          SET last_accessed = datetime('now'), access_count = access_count + 1
-          WHERE id IN (${placeholders}) AND is_deleted = 0`,
-				).run(...topIds);
-			});
-		});
-	} catch (e) {
-		logger.warn("memory", "Failed to update access tracking", e as Error);
-	}
-
 	const rowMap = new Map(rows.map((r) => [r.id, r]));
 	// No pre-decrement: always fetch `limit` memories. The summary card is
 	// injected after assembly and the array is capped to `limit` at that point.
 	const results: RecallResult[] = timings.time("assemble_results", () =>
 		scored
-			.slice(0, limit)
+			.slice(0, preHydrate)
 			.filter((s) => rowMap.has(s.id))
-			.map((s) => {
-				const r = rowMap.get(s.id)!;
+			.slice(0, limit)
+			.flatMap((s) => {
+				const r = rowMap.get(s.id);
+				if (!r) return [];
 				const content = annotateCurrentness(r.content, currentness.get(r.id));
 				const isTruncated = content.length > recallTruncate;
-				return {
-					id: r.id,
-					content: isTruncated ? `${content.slice(0, recallTruncate)} [truncated]` : content,
-					content_length: content.length,
-					truncated: isTruncated,
-					score: Math.round(s.score * 100) / 100,
-					source: s.source,
-					...(r.source_id ? { source_id: r.source_id, session_id: sessionIdFromSourceId(r.source_id) } : {}),
-					type: r.type,
-					tags: r.tags,
-					pinned: !!r.pinned,
-					importance: r.importance,
-					who: r.who,
-					project: r.project,
-					created_at: r.created_at,
-				};
+				return [
+					{
+						id: r.id,
+						content: isTruncated ? `${content.slice(0, recallTruncate)} [truncated]` : content,
+						content_length: content.length,
+						truncated: isTruncated,
+						score: Math.round(s.score * 100) / 100,
+						source: s.source,
+						...(r.source_id ? { source_id: r.source_id, session_id: sessionIdFromSourceId(r.source_id) } : {}),
+						type: r.type,
+						tags: r.tags,
+						pinned: !!r.pinned,
+						importance: r.importance,
+						who: r.who,
+						project: r.project,
+						created_at: r.created_at,
+					},
+				];
 			}),
 	);
+
+	// Update access tracking only for authorized memories actually returned.
+	try {
+		const trackedIds = results.map((row) => row.id).filter((id) => rowMap.has(id));
+		if (trackedIds.length > 0) {
+			timings.time("access_tracking_update", () => {
+				const trackedPlaceholders = trackedIds.map(() => "?").join(", ");
+				getDbAccessor().withWriteTx((db) => {
+					db.prepare(
+						`UPDATE memories
+						 SET last_accessed = datetime('now'), access_count = access_count + 1
+						 WHERE id IN (
+						   SELECT m.id
+						   FROM memories m
+						   WHERE m.id IN (${trackedPlaceholders})
+						     AND m.is_deleted = 0${filter.sql}
+						 )`,
+					).run(...trackedIds, ...filter.args);
+				});
+			});
+		}
+	} catch (e) {
+		logger.warn("memory", "Failed to update access tracking", e as Error);
+	}
 
 	if (results.length < limit) {
 		const existingSourceIds = new Set(results.map((row) => row.source_id).filter((id): id is string => !!id));
 		const sourceChunkHits = timings.time("source_chunk_vector_supplement", () =>
-			buildSourceChunkVectorHits(queryVecF32, existingSourceIds, limit - results.length, params.agentId),
+			buildSourceChunkVectorHits(
+				queryVecF32,
+				existingSourceIds,
+				limit - results.length,
+				params.agentId ?? "default",
+				params.project,
+			),
 		);
 		for (const hit of sourceChunkHits) {
 			if (results.length >= limit) break;
@@ -2071,7 +2153,7 @@ export async function hybridRecall(
 				pinned: false,
 				importance: 0.6,
 				who: "obsidian",
-				project: null,
+				project: hit.project,
 				created_at: hit.createdAt,
 				source_path: hit.sourcePath,
 				supplementary: true,
@@ -2185,10 +2267,10 @@ export async function hybridRecall(
 							 WHERE mem.entity_id IN (${ePlaceholders})
 							   AND m.type = 'rationale'
 							   AND m.is_deleted = 0
-							   ${scopeClause}${agentScope.sql}
+							   ${filter.sql}
 							 LIMIT 10`,
 					)
-					.all(...eIds, ...scopeArgs, ...agentScope.args) as Array<{
+					.all(...eIds, ...filter.args) as Array<{
 					id: string;
 					content: string;
 					type: string;
@@ -2202,6 +2284,7 @@ export async function hybridRecall(
 			});
 
 			for (const r of supplementary) {
+				if (results.length >= limit) break;
 				if (existingIds.has(r.id)) continue;
 				existingIds.add(r.id);
 				const isTrunc = r.content.length > recallTruncate;
@@ -2245,23 +2328,20 @@ export async function hybridRecall(
 				const ctx = getDbAccessor().withReadDb((db) => {
 					if (focal.entityIds.length === 0) return null;
 
-					// Scope-filter: only include entities mentioned in
-					// in-scope memories so unscoped entities (codebase
-					// concepts etc.) don't pollute scoped searches.
+					// Project/scope-constrained recall should not let broad focal
+					// entities pull in structural context from outside that slice.
 					let eids = focal.entityIds;
-					if (params.scope !== undefined) {
+					if (params.scope !== undefined || params.project) {
 						const ph = eids.map(() => "?").join(", ");
-						const sc = params.scope === null ? "m.scope IS NULL" : "m.scope = ?";
-						const sa: unknown[] = params.scope === null ? [] : [params.scope];
 						const sr = db
 							.prepare(
 								`SELECT DISTINCT mem.entity_id
 								 FROM memory_entity_mentions mem
 								 JOIN memories m ON m.id = mem.memory_id
 								 WHERE mem.entity_id IN (${ph})
-								   AND ${sc} AND m.is_deleted = 0`,
+								   AND m.is_deleted = 0${filter.sql}`,
 							)
-							.all(...eids, ...sa) as Array<{ entity_id: string }>;
+							.all(...eids, ...filter.args) as Array<{ entity_id: string }>;
 						eids = sr.map((r) => r.entity_id);
 						if (eids.length === 0) return null;
 					}
@@ -2344,7 +2424,7 @@ export async function hybridRecall(
 			const maxConstructed = Math.max(0.01, minReal - 0.01);
 			let added = 0;
 			for (const block of blocks) {
-				if (added >= cap) break;
+				if (added >= cap || results.length >= limit) break;
 				const syntheticId = `constructed:${block.provenance.entityName}`;
 				if (existingIds.has(syntheticId)) continue;
 				existingIds.add(syntheticId);
@@ -2441,14 +2521,16 @@ export async function hybridRecall(
 			if (keys.length > 0) {
 				const ph = keys.map(() => "?").join(", ");
 				const agentId = params.agentId ?? "default";
+				const projectSql = params.project ? " AND project = ?" : "";
+				const projectArgs: unknown[] = params.project ? [params.project] : [];
 				const transcripts = getDbAccessor().withReadDb(
 					(db) =>
 						db
 							.prepare(
 								`SELECT session_key, content FROM session_transcripts
-								 WHERE agent_id = ? AND session_key IN (${ph})`,
+								 WHERE agent_id = ? AND session_key IN (${ph})${projectSql}`,
 							)
-							.all(agentId, ...keys) as Array<{ session_key: string; content: string }>,
+							.all(agentId, ...keys, ...projectArgs) as Array<{ session_key: string; content: string }>,
 				);
 				if (transcripts.length > 0) {
 					sources = {};
@@ -2478,6 +2560,8 @@ export async function hybridRecall(
 		}
 		timings.record("source_excerpt_merge", sourceExcerptStart);
 	}
+
+	if (results.length > limit) results.length = limit;
 
 	return finish({
 		results,


### PR DESCRIPTION
## Summary

- Default agent-scoped recall to isolated access when `readPolicy` is omitted.
- Add an explicit authorization gate before content-bearing recall stages such as SEC coverage, reranking, dampening, currentness, hydration, transcript expansion, and access tracking.
- Fix scoped over-fetch assembly and access tracking so only authorized returned memory IDs are counted.
- Sort and max-merge traversal-primary candidates so weaker graph evidence does not discard stronger direct evidence.
- Disable source-backed vector chunk rescue for project-scoped recall until chunk embeddings carry a strong project/source-root binding; project-scoped recall still uses authorized memory rows, native artifacts, and transcript fallbacks.
- Expand the memory-search docs and inline comments to document the recall phases and safety boundary.

## Why

Memory search collects candidates from broad channels: FTS, hints, vector search, graph traversal, structured path search, source chunks, native artifacts, and transcripts. Some of those channels can produce IDs before normal hydration filters run. The previous ordering let several post-processing stages fetch or act on candidate content before final filtered hydration. This patch makes the authorization boundary explicit and shared.

## Review Follow-Up

- Fixed transcript summary hydration so omitted `agentId` still defaults to the `default` agent boundary instead of widening to all agents.
- Added a regression test covering same-source transcript summary hydration across default and non-default agents.
- Closed the source-backed vector chunk project leak by skipping that rescue path for project-scoped recall until the source index has a strong source-root/project key.
- Added regressions for project-scoped source chunk spoofing and ambiguous same-basename source artifacts.
- Updated `docs/MEMORY.md` to document that fallback paths are enabled only when their backing rows can satisfy the caller's scope boundary.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Validation

- `bun test platform/daemon/src/memory-search.test.ts` — 36 pass.
- `bunx biome check platform/daemon/src/memory-search.ts platform/daemon/src/memory-search.test.ts docs/MEMORY.md docs/API.md` — exits 0 with existing `any` warnings in `memory-search.ts`.
- `git diff --check` — clean.

## Notes

The broader daemon type declaration build is still blocked by unrelated existing rootDir/test typing issues and an existing `provider-safety.ts` union narrowing error, so this PR uses the focused recall test plus targeted lint/format checks.
