### PR TITLE
fix(daemon): stabilize Obsidian source sync

### DIFF
--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -92,9 +92,8 @@ import { createSingleFlightRunner } from "./single-flight-runner";
 import {
 	beginSourceIndexJob,
 	clearSourceIndexInFlight,
-	completeSourceIndexJob,
+	completeSourceIndexJobFromProgress,
 	failSourceIndexJob,
-	getSourceIndexJob,
 	markSourceIndexInFlight,
 	markSourceIndexJobRunning,
 	updateSourceIndexJobProgress,
@@ -1613,9 +1612,9 @@ async function main() {
 			});
 			nativeMemoryBridge
 				.syncExisting()
-				.then((indexed) => {
+				.then(() => {
 					for (const [sourceId, jobId] of startupSourceJobs) {
-						completeSourceIndexJob(sourceId, jobId, getSourceIndexJob(sourceId)?.indexed ?? indexed);
+						completeSourceIndexJobFromProgress(sourceId, jobId);
 					}
 				})
 				.catch((e) => {

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -18,6 +18,7 @@ import {
 	type PipelineSynthesisConfig,
 	buildArchitectureDoc,
 	loadConfiguredHarnesses,
+	loadSourcesConfig,
 	normalizeAgentRosterEntry,
 	parseSimpleYaml,
 	stripSignetBlock,
@@ -43,12 +44,7 @@ import { closeInferenceProviderResolver, getInferenceProvider, initInferenceProv
 import { logger } from "./logger";
 import { type ResolvedMemoryConfig, loadMemoryConfig } from "./memory-config";
 import { registerGlobalMiddleware } from "./middleware";
-import {
-	type NativeMemoryBridgeHandle,
-	claudeCodeNativeMemorySource,
-	codexNativeMemorySource,
-	startNativeMemoryBridge,
-} from "./native-memory-sources";
+import { type NativeMemoryBridgeHandle, startNativeMemoryBridge } from "./native-memory-sources";
 import { DEFAULT_RETENTION, ensureRetentionWorker, setDreamingWorker, startPipeline, stopPipeline } from "./pipeline";
 import { type DreamingWorkerHandle, startDreamingWorker } from "./pipeline/dreaming-worker";
 import type { WorkerInit } from "./pipeline/extraction-thread-protocol";
@@ -93,6 +89,16 @@ import { getSecret } from "./secrets.js";
 import { flushPendingCheckpoints, initCheckpointFlush, pruneCheckpoints } from "./session-checkpoints";
 import { releaseAllSessions, startSessionCleanup, stopSessionCleanup } from "./session-tracker";
 import { createSingleFlightRunner } from "./single-flight-runner";
+import {
+	beginSourceIndexJob,
+	clearSourceIndexInFlight,
+	completeSourceIndexJob,
+	failSourceIndexJob,
+	getSourceIndexJob,
+	markSourceIndexInFlight,
+	markSourceIndexJobRunning,
+	updateSourceIndexJobProgress,
+} from "./source-index-progress";
 import { type TelemetryCollector, createTelemetryCollector } from "./telemetry";
 
 import {
@@ -240,6 +246,7 @@ let nativeMemoryBridge: NativeMemoryBridgeHandle | null = null;
 // Track ingested files to avoid re-processing (path -> content hash)
 const ingestedMemoryFiles = new Map<string, string>();
 const MEMORY_IMPORT_POLL_MS = 30_000;
+const MEMORY_IMPORT_FILE_DELAY_MS = 50;
 let memoryImportTimer: ReturnType<typeof setInterval> | null = null;
 let memoryImportInFlight = false;
 
@@ -537,6 +544,7 @@ async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 
 	const chunks = chunkMarkdownHierarchically(content, 512);
 	let inserted = 0;
+	const yielder = yieldEvery(1);
 
 	for (let i = 0; i < chunks.length; i++) {
 		const chunk = chunks[i];
@@ -545,7 +553,10 @@ async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 			chunk.header && chunk.text.startsWith(chunk.header)
 				? chunk.text.slice(chunk.header.length).trim()
 				: chunk.text.trim();
-		if (body.length < 80) continue;
+		if (body.length < 80) {
+			await yielder();
+			continue;
+		}
 
 		const chunkKey = `openclaw:${filename}:${createHash("sha256").update(chunk.text).digest("hex").slice(0, 16)}`;
 		try {
@@ -558,6 +569,7 @@ async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 					importance: chunk.level === "section" ? 0.65 : 0.55,
 					sourceType: "openclaw-memory-log",
 					sourceId: chunkKey,
+					idempotencyKey: chunkKey,
 					tags: [
 						"openclaw",
 						"memory-log",
@@ -587,6 +599,7 @@ async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 				...errDetails,
 			});
 		}
+		await yielder();
 	}
 
 	if (inserted > 0) {
@@ -629,6 +642,7 @@ async function importExistingMemoryFiles(): Promise<number> {
 		const count = await ingestMemoryMarkdown(join(memoryDir, file));
 		totalChunks += count;
 		await yielder();
+		await sleep(MEMORY_IMPORT_FILE_DELAY_MS);
 	}
 
 	if (totalChunks > 0) {
@@ -638,6 +652,10 @@ async function importExistingMemoryFiles(): Promise<number> {
 		});
 	}
 	return totalChunks;
+}
+
+function sleep(ms: number): Promise<void> {
+	return ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve();
 }
 
 function startMemoryImportPoller(): void {
@@ -1566,17 +1584,49 @@ async function main() {
 		startMemoryImportPoller();
 
 		if (!nativeMemoryBridge) {
-			nativeMemoryBridge = startNativeMemoryBridge([codexNativeMemorySource(), claudeCodeNativeMemorySource()], {
+			const startupSourceJobs = new Map<string, string>();
+			for (const source of loadSourcesConfig(AGENTS_DIR).sources) {
+				if (!source.enabled || source.kind !== "obsidian") continue;
+				const job = beginSourceIndexJob(source.id, "source-startup");
+				startupSourceJobs.set(source.id, job.id);
+				markSourceIndexInFlight(source.id);
+				markSourceIndexJobRunning(source.id, job.id);
+			}
+			nativeMemoryBridge = startNativeMemoryBridge([], {
 				agentsDir: AGENTS_DIR,
 				includeConfiguredSources: true,
-				embeddingConfig: memoryCfg.embedding,
-				fetchEmbedding,
+				pollIntervalMs: 0,
+				sourceCleanupEnabled: false,
+				sourceGraphEnabled: false,
+				onFileIndexed: (event) => {
+					const sourceId = event.source.sourceId;
+					if (!sourceId) return;
+					const jobId = startupSourceJobs.get(sourceId);
+					if (!jobId) return;
+					updateSourceIndexJobProgress(sourceId, jobId, {
+						scanned: event.scanned,
+						total: event.total,
+						indexed: event.changed,
+						currentPath: event.filePath,
+					});
+				},
 			});
+			nativeMemoryBridge
+				.syncExisting()
+				.then((indexed) => {
+					for (const [sourceId, jobId] of startupSourceJobs) {
+						completeSourceIndexJob(sourceId, jobId, getSourceIndexJob(sourceId)?.indexed ?? indexed);
+					}
+				})
+				.catch((e) => {
+					for (const [sourceId, jobId] of startupSourceJobs) failSourceIndexJob(sourceId, jobId, e);
+					const errDetails = e instanceof Error ? { message: e.message, stack: e.stack } : { error: String(e) };
+					logger.error("daemon", "Failed to sync native memory sources", undefined, errDetails);
+				})
+				.finally(() => {
+					for (const sourceId of startupSourceJobs.keys()) clearSourceIndexInFlight(sourceId);
+				});
 		}
-		nativeMemoryBridge.syncExisting().catch((e) => {
-			const errDetails = e instanceof Error ? { message: e.message, stack: e.stack } : { error: String(e) };
-			logger.error("daemon", "Failed to sync native memory sources", undefined, errDetails);
-		});
 
 		const startupCfg = loadMemoryConfig(AGENTS_DIR);
 		if (startupCfg.embedding.provider !== "none") {

--- a/platform/daemon/src/native-memory-sources.test.ts
+++ b/platform/daemon/src/native-memory-sources.test.ts
@@ -530,6 +530,44 @@ describe("native memory sources", () => {
 		expect(rows).toEqual({ artifacts: 1, entities: 0 });
 	});
 
+	it("can expand unchanged Obsidian artifacts after a lightweight source scan", async () => {
+		const root = join(dir, "vault");
+		const source = obsidianNativeMemorySource(root, "Vault", "obsidian:vault");
+		const file = join(root, "permanent", "Signet.md");
+		mkdirSync(join(root, "permanent"), { recursive: true });
+		writeFileSync(
+			file,
+			"# Signet Sources\n\nSource-backed memory can first index the file artifact, then later add graph rows and embeddings without changing the note.\n",
+		);
+
+		expect(
+			await indexNativeMemoryFile(source, file, "agent-native", {
+				sourceGraphEnabled: false,
+			}),
+		).toBe(true);
+		expect(
+			await indexNativeMemoryFile(source, file, "agent-native", {
+				embeddingConfig: { provider: "native", model: "test", dimensions: 3, base_url: "" },
+				fetchEmbedding: async () => [1, 2, 3],
+			}),
+		).toBe(true);
+
+		const rows = getDbAccessor().withReadDb((db) => ({
+			entities: (
+				db
+					.prepare("SELECT COUNT(*) AS count FROM entities WHERE agent_id = ? AND source_id = ?")
+					.get("agent-native", "obsidian:vault") as { count: number }
+			).count,
+			embeddings: (
+				db
+					.prepare("SELECT COUNT(*) AS count FROM embeddings WHERE agent_id = ? AND source_type = ?")
+					.get("agent-native", "source_obsidian_chunk") as { count: number }
+			).count,
+		}));
+		expect(rows.entities).toBeGreaterThan(0);
+		expect(rows.embeddings).toBeGreaterThan(0);
+	});
+
 	it("skips hidden Obsidian vault directories by default", async () => {
 		const root = join(dir, "vault");
 		mkdirSync(join(root, ".claude"), { recursive: true });

--- a/platform/daemon/src/native-memory-sources.test.ts
+++ b/platform/daemon/src/native-memory-sources.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { addObsidianSource, loadSourcesConfig } from "@signet/core";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { indexExternalMemoryArtifact } from "./memory-lineage";
 import {
 	claudeCodeNativeMemorySource,
 	codexNativeMemorySource,
@@ -259,6 +260,28 @@ describe("native memory sources", () => {
 		expect(count).toBe(1);
 	});
 
+	it("skips unchanged native files when the artifact row already exists after a cold cache start", async () => {
+		const root = join(dir, ".codex");
+		mkdirSync(join(root, "memories"), { recursive: true });
+		const file = join(root, "memories", "memory_summary.md");
+		const content = "Codex remembered a persisted artifact row.\n";
+		writeFileSync(file, content);
+		indexExternalMemoryArtifact({
+			agentId: "agent-native",
+			sourcePath: file,
+			sourceKind: "native_memory_summary",
+			harness: "codex",
+			content,
+			sourceMtimeMs: Date.now(),
+		});
+
+		expect(await indexNativeMemoryFile(codexNativeMemorySource(root), file, "agent-native")).toBe(false);
+		const count = getDbAccessor().withReadDb(
+			(db) => db.prepare("SELECT COUNT(*) AS count FROM memory_artifacts").get() as { count: number },
+		).count;
+		expect(count).toBe(1);
+	});
+
 	it("reindexes same-size native files when content changes", async () => {
 		const root = join(dir, ".codex");
 		mkdirSync(join(root, "memories"), { recursive: true });
@@ -336,6 +359,37 @@ describe("native memory sources", () => {
 			);
 			expect(row.is_deleted).toBe(1);
 			expect(row.deleted_at).toBeTruthy();
+		} finally {
+			await handle.close();
+		}
+	});
+
+	it("can defer stale source cleanup during bridge sync", async () => {
+		const root = join(dir, "vault");
+		const file = join(root, "permanent", "Old.md");
+		mkdirSync(join(root, "permanent"), { recursive: true });
+		writeFileSync(file, "# Old\n\nThis source file will be removed after initial indexing.\n");
+		const source = obsidianNativeMemorySource(root, "Cleanup Vault", "obsidian:cleanup-test");
+
+		const handle = startNativeMemoryBridge([source], {
+			agentId: "agent-native",
+			pollIntervalMs: 0,
+			sourceCleanupEnabled: false,
+		});
+		try {
+			expect(await handle.syncExisting()).toBe(1);
+			rmSync(file);
+			expect(await handle.syncExisting()).toBe(0);
+
+			const row = getDbAccessor().withReadDb(
+				(db) =>
+					db
+						.prepare(
+							"SELECT is_deleted FROM memory_artifacts WHERE agent_id = ? AND source_path = ? AND harness = 'obsidian'",
+						)
+						.get("agent-native", file) as { is_deleted: number | null },
+			);
+			expect(row.is_deleted ?? 0).toBe(0);
 		} finally {
 			await handle.close();
 		}
@@ -447,6 +501,33 @@ describe("native memory sources", () => {
 		expect(row.source_kind).toBe("source_obsidian_markdown");
 		expect(row.harness).toBe("obsidian");
 		expect(row.content).toContain("Obsidian source knowledge base note");
+	});
+
+	it("can defer Obsidian graph projection while still indexing source artifacts", async () => {
+		const root = join(dir, "vault");
+		const file = join(root, "permanent", "Signet.md");
+		mkdirSync(join(root, "permanent"), { recursive: true });
+		writeFileSync(file, "# Signet\n\nSource-backed memory can defer graph expansion out of the daemon sync path.\n");
+
+		expect(
+			await indexNativeMemoryFile(obsidianNativeMemorySource(root, "Vault", "obsidian:vault"), file, "agent-native", {
+				sourceGraphEnabled: false,
+			}),
+		).toBe(true);
+
+		const rows = getDbAccessor().withReadDb((db) => ({
+			artifacts: (
+				db.prepare("SELECT COUNT(*) AS count FROM memory_artifacts WHERE source_path = ?").get(file) as {
+					count: number;
+				}
+			).count,
+			entities: (
+				db
+					.prepare("SELECT COUNT(*) AS count FROM entities WHERE agent_id = ? AND source_id = ?")
+					.get("agent-native", "obsidian:vault") as { count: number }
+			).count,
+		}));
+		expect(rows).toEqual({ artifacts: 1, entities: 0 });
 	});
 
 	it("skips hidden Obsidian vault directories by default", async () => {
@@ -783,6 +864,39 @@ describe("native memory sources", () => {
 		}
 	});
 
+	it("can sync configured Obsidian sources without scanning harness memory roots", async () => {
+		const codexRoot = join(dir, ".codex");
+		const codexFile = join(codexRoot, "memories", "memory_summary.md");
+		mkdirSync(join(codexRoot, "memories"), { recursive: true });
+		writeFileSync(codexFile, "Codex memory should not be pulled into source-only startup scans.\n");
+		const vault = join(dir, "vault");
+		const vaultFile = join(vault, "literature", "Source Note.md");
+		mkdirSync(join(vault, "literature"), { recursive: true });
+		writeFileSync(vaultFile, "# Source Note\n\nSource-only bridge scans should still index configured vault files.\n");
+		const added = addObsidianSource({ root: vault, name: "Source Vault" }, dir);
+		expect(added.ok).toBe(true);
+
+		const handle = startNativeMemoryBridge([], {
+			agentId: "agent-native",
+			agentsDir: dir,
+			includeConfiguredSources: true,
+			pollIntervalMs: 0,
+		});
+		try {
+			expect(await handle.syncExisting()).toBe(1);
+			const rows = getDbAccessor().withReadDb(
+				(db) =>
+					db.prepare("SELECT harness, source_path FROM memory_artifacts ORDER BY source_path").all() as Array<{
+						harness: string;
+						source_path: string;
+					}>,
+			);
+			expect(rows).toEqual([{ harness: "obsidian", source_path: vaultFile }]);
+		} finally {
+			await handle.close();
+		}
+	});
+
 	it("reports per-source file progress when a bridge scans multiple sources", async () => {
 		const vaultA = join(dir, "vault-a");
 		const vaultB = join(dir, "vault-b");
@@ -856,6 +970,35 @@ describe("native memory sources", () => {
 						.get("agent-native", file) as { content: string },
 			);
 			expect(row.content).toContain("Second version after overlapping change");
+		} finally {
+			await handle.close();
+		}
+	});
+
+	it("does not let polling ticks queue trailing full rescans while a source sync is already running", async () => {
+		const root = join(dir, "vault");
+		const file = join(root, "permanent", "Slow.md");
+		mkdirSync(join(root, "permanent"), { recursive: true });
+		writeFileSync(
+			file,
+			"# Slow\n\nA slow source embedding request gives the polling timer enough time to fire while the first scan is still in flight.\n",
+		);
+		const events: Array<{ scanned: number; total: number }> = [];
+		const handle = startNativeMemoryBridge([obsidianNativeMemorySource(root, "Slow Vault", "obsidian:slow-vault")], {
+			agentId: "agent-native",
+			pollIntervalMs: 1,
+			embeddingConfig: { provider: "native", model: "test", dimensions: 3, base_url: "" },
+			fetchEmbedding: async () => {
+				await Bun.sleep(20);
+				return [1, 2, 3];
+			},
+			onFileIndexed: (event) => {
+				events.push({ scanned: event.scanned, total: event.total });
+			},
+		});
+		try {
+			expect(await handle.syncExisting()).toBe(1);
+			expect(events).toEqual([{ scanned: 1, total: 1 }]);
 		} finally {
 			await handle.close();
 		}

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { homedir } from "node:os";
@@ -9,7 +8,7 @@ import { yieldEvery } from "./async-yield";
 import { getDbAccessor } from "./db-accessor";
 import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
-import { indexExternalMemoryArtifact, softDeleteArtifactRowsForPath } from "./memory-lineage";
+import { hashNormalizedBody, indexExternalMemoryArtifact, softDeleteArtifactRowsForPath } from "./memory-lineage";
 import {
 	type SourceEmbeddingFetch,
 	indexObsidianSourceEmbeddings,
@@ -38,8 +37,12 @@ export interface NativeMemoryFilePattern {
 }
 
 export interface NativeMemoryBridgeHandle {
-	readonly syncExisting: () => Promise<number>;
+	readonly syncExisting: (options?: NativeMemoryBridgeSyncOptions) => Promise<number>;
 	readonly close: () => Promise<void>;
+}
+
+export interface NativeMemoryBridgeSyncOptions {
+	readonly requestResyncIfBusy?: boolean;
 }
 
 export interface NativeMemoryBridgeOptions {
@@ -50,6 +53,9 @@ export interface NativeMemoryBridgeOptions {
 	readonly agentsDir?: string;
 	readonly includeConfiguredSources?: boolean;
 	readonly yieldEveryFiles?: number;
+	readonly sourceFileDelayMs?: number;
+	readonly sourceCleanupEnabled?: boolean;
+	readonly sourceGraphEnabled?: boolean;
 	readonly onFileIndexed?: (event: NativeMemoryFileIndexEvent) => void;
 }
 
@@ -67,6 +73,7 @@ interface IndexedNativeMemory {
 }
 
 const indexed = new Map<string, IndexedNativeMemory>();
+const DEFAULT_OBSIDIAN_SOURCE_FILE_DELAY_MS = 250;
 
 function codexRoot(): string {
 	return join(homedir(), ".codex");
@@ -222,22 +229,33 @@ function sourceStateKey(source: NativeMemorySource, agentId: string): string {
 }
 
 function contentFingerprint(content: string): string {
-	return createHash("sha256").update(content).digest("hex");
+	return hashNormalizedBody(content);
 }
 
-function nativeArtifactRowExists(filePath: string, agentId: string): boolean {
+function sourceFileDelayMs(source: NativeMemorySource, options: NativeMemoryBridgeOptions): number {
+	if (options.sourceFileDelayMs !== undefined) {
+		return Math.max(0, Math.floor(options.sourceFileDelayMs));
+	}
+	return source.harness === "obsidian" ? DEFAULT_OBSIDIAN_SOURCE_FILE_DELAY_MS : 0;
+}
+
+function sleep(ms: number): Promise<void> {
+	return ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve();
+}
+
+function nativeArtifactContentHash(filePath: string, agentId: string): string | null {
 	const sourcePath = filePath.replace(/\\/g, "/");
 	try {
 		return getDbAccessor().withReadDb((db) => {
 			const row = db
 				.prepare(
-					"SELECT 1 FROM memory_artifacts WHERE agent_id = ? AND source_path = ? AND COALESCE(is_deleted, 0) = 0 LIMIT 1",
+					"SELECT source_sha256 FROM memory_artifacts WHERE agent_id = ? AND source_path = ? AND COALESCE(is_deleted, 0) = 0 LIMIT 1",
 				)
-				.get(agentId, sourcePath);
-			return !!row;
+				.get(agentId, sourcePath) as { source_sha256: string } | undefined;
+			return row?.source_sha256 ?? null;
 		});
 	} catch {
-		return false;
+		return null;
 	}
 }
 
@@ -281,7 +299,7 @@ export async function indexNativeMemoryFile(
 	source: NativeMemorySource,
 	filePath: string,
 	agentId = resolveDaemonAgentId(),
-	options: Pick<NativeMemoryBridgeOptions, "embeddingConfig" | "fetchEmbedding"> = {},
+	options: Pick<NativeMemoryBridgeOptions, "embeddingConfig" | "fetchEmbedding" | "sourceGraphEnabled"> = {},
 ): Promise<boolean> {
 	const pattern = matchesPattern(source, filePath);
 	if (!pattern) return false;
@@ -305,10 +323,15 @@ export async function indexNativeMemoryFile(
 
 	const key = fingerprintKey(source, filePath, agentId);
 	const hash = contentFingerprint(content);
+	const persistedHash = nativeArtifactContentHash(filePath, agentId);
 	const cached = indexed.get(key);
 	if (cached?.contentHash === hash) {
-		if (nativeArtifactRowExists(filePath, agentId)) return false;
+		if (persistedHash === hash) return false;
 		indexed.delete(key);
+	}
+	if (persistedHash === hash) {
+		indexed.set(key, { contentHash: hash });
+		return false;
 	}
 
 	try {
@@ -322,14 +345,16 @@ export async function indexNativeMemoryFile(
 		});
 		if (source.harness === "obsidian" && pattern.kind === "source_obsidian_markdown") {
 			const sourceId = source.sourceId ?? sourceIdForObsidianRoot(source.root);
-			indexObsidianSourceStructure({
-				agentId,
-				sourceId,
-				sourceName: source.displayName,
-				root: source.root,
-				filePath,
-				content,
-			});
+			if (options.sourceGraphEnabled ?? true) {
+				indexObsidianSourceStructure({
+					agentId,
+					sourceId,
+					sourceName: source.displayName,
+					root: source.root,
+					filePath,
+					content,
+				});
+			}
 			if (options.embeddingConfig && options.fetchEmbedding) {
 				const embeddingResult = await indexObsidianSourceEmbeddings({
 					agentId,
@@ -466,6 +491,7 @@ export function startNativeMemoryBridge(
 					await yielder();
 				}
 				const total = files.length;
+				const fileDelayMs = sourceFileDelayMs(source, options);
 				for (const file of files) {
 					scanned++;
 					const changed = await indexNativeMemoryFile(source, file, agentId, options);
@@ -476,14 +502,17 @@ export function startNativeMemoryBridge(
 					current.add(file);
 					options.onFileIndexed?.({ source, filePath: file, indexed: changed, scanned, total, changed: changedCount });
 					await yielder();
+					await sleep(fileDelayMs);
 				}
-				const currentPaths = new Set([...current].map((file) => file.replace(/\\/g, "/")));
-				for (const file of activeNativeArtifactPaths(source, agentId)) {
-					if (!currentPaths.has(file.replace(/\\/g, "/"))) removeNativeMemoryFile(source, file, agentId);
+				if (options.sourceCleanupEnabled ?? true) {
+					const currentPaths = new Set([...current].map((file) => file.replace(/\\/g, "/")));
+					for (const file of activeNativeArtifactPaths(source, agentId)) {
+						if (!currentPaths.has(file.replace(/\\/g, "/"))) removeNativeMemoryFile(source, file, agentId);
+					}
 				}
 			}
 			const previous = known.get(key);
-			if (previous) {
+			if (previous && (options.sourceCleanupEnabled ?? true)) {
 				for (const file of previous) {
 					if (!current.has(file)) removeNativeMemoryFile(source, file, agentId);
 				}
@@ -496,9 +525,9 @@ export function startNativeMemoryBridge(
 
 	let syncInFlight: Promise<number> | null = null;
 	let resyncRequested = false;
-	const syncExisting = async (): Promise<number> => {
+	const syncExisting = async (syncOptions: NativeMemoryBridgeSyncOptions = {}): Promise<number> => {
 		if (syncInFlight) {
-			resyncRequested = true;
+			if (syncOptions.requestResyncIfBusy ?? true) resyncRequested = true;
 			return syncInFlight;
 		}
 		syncInFlight = Promise.resolve()
@@ -519,7 +548,7 @@ export function startNativeMemoryBridge(
 	const pollTimer =
 		pollIntervalMs > 0
 			? setInterval(() => {
-					syncExisting().catch((err) => {
+					syncExisting({ requestResyncIfBusy: false }).catch((err) => {
 						logger.warn("watcher", "Failed polling native memory sources", {
 							error: err instanceof Error ? err.message : String(err),
 						});

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -10,7 +10,9 @@ import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
 import { hashNormalizedBody, indexExternalMemoryArtifact, softDeleteArtifactRowsForPath } from "./memory-lineage";
 import {
+	OBSIDIAN_CHUNK_SOURCE_TYPE,
 	type SourceEmbeddingFetch,
+	buildObsidianSourceChunks,
 	indexObsidianSourceEmbeddings,
 	purgeObsidianSourceEmbeddings,
 	purgeObsidianSourceFileEmbeddings,
@@ -261,6 +263,54 @@ function nativeArtifactContentHash(filePath: string, agentId: string): string | 
 	}
 }
 
+function obsidianGraphExists(agentId: string, sourceId: string, filePath: string): boolean {
+	try {
+		return getDbAccessor().withReadDb((db) => {
+			const row = db
+				.prepare(
+					`SELECT 1 FROM entities
+					 WHERE agent_id = ?
+					   AND source_id = ?
+					   AND source_path = ?
+					   AND entity_type = 'source_document'
+					 LIMIT 1`,
+				)
+				.get(agentId, sourceId, filePath.replace(/\\/g, "/")) as { "1": number } | undefined;
+			return row !== undefined;
+		});
+	} catch {
+		return false;
+	}
+}
+
+function obsidianEmbeddingsExist(input: {
+	readonly agentId: string;
+	readonly sourceId: string;
+	readonly root: string;
+	readonly filePath: string;
+	readonly content: string;
+}): boolean {
+	const chunks = buildObsidianSourceChunks(input);
+	if (chunks.length === 0) return true;
+	try {
+		return getDbAccessor().withReadDb((db) => {
+			const rows = db
+				.prepare(
+					`SELECT source_id FROM embeddings
+					 WHERE agent_id = ?
+					   AND source_type = ?
+					   AND source_id IN (${chunks.map(() => "?").join(", ")})`,
+				)
+				.all(input.agentId, OBSIDIAN_CHUNK_SOURCE_TYPE, ...chunks.map((chunk) => chunk.id)) as Array<{
+				source_id: string;
+			}>;
+			return new Set(rows.map((row) => row.source_id)).size === chunks.length;
+		});
+	} catch {
+		return false;
+	}
+}
+
 function activeNativeArtifactPaths(source: NativeMemorySource, agentId: string): string[] {
 	const normalizedRoot = resolve(source.root).replace(/\\/g, "/").replace(/\/$/, "");
 	const rootPrefix = `${normalizedRoot}/`;
@@ -328,27 +378,49 @@ export async function indexNativeMemoryFile(
 	const key = fingerprintKey(source, filePath, agentId);
 	const hash = contentFingerprint(content);
 	const persistedHash = nativeArtifactContentHash(filePath, agentId);
+	const obsidian = source.harness === "obsidian" && pattern.kind === "source_obsidian_markdown";
+	const sourceId = obsidian ? (source.sourceId ?? sourceIdForObsidianRoot(source.root)) : null;
+	const graphRequested = obsidian && (options.sourceGraphEnabled ?? true);
+	const embeddingRequested =
+		obsidian &&
+		options.embeddingConfig?.provider !== "none" &&
+		options.embeddingConfig !== undefined &&
+		options.fetchEmbedding !== undefined;
+	const semanticComplete =
+		!obsidian ||
+		((!graphRequested || obsidianGraphExists(agentId, sourceId ?? "", filePath)) &&
+			(!embeddingRequested ||
+				obsidianEmbeddingsExist({
+					agentId,
+					sourceId: sourceId ?? "",
+					root: source.root,
+					filePath,
+					content,
+				})));
 	const cached = indexed.get(key);
 	if (cached?.contentHash === hash) {
-		if (persistedHash === hash) return false;
+		if (persistedHash === hash && semanticComplete) return false;
 		indexed.delete(key);
 	}
-	if (persistedHash === hash) {
+	if (persistedHash === hash && semanticComplete) {
 		indexed.set(key, { contentHash: hash });
 		return false;
 	}
 
 	try {
-		indexExternalMemoryArtifact({
-			agentId,
-			sourcePath: filePath,
-			sourceKind: pattern.kind,
-			harness: source.harness,
-			content,
-			sourceMtimeMs: mtimeMs,
-		});
-		if (source.harness === "obsidian" && pattern.kind === "source_obsidian_markdown") {
-			const sourceId = source.sourceId ?? sourceIdForObsidianRoot(source.root);
+		const artifactChanged = persistedHash !== hash;
+		if (artifactChanged) {
+			indexExternalMemoryArtifact({
+				agentId,
+				sourcePath: filePath,
+				sourceKind: pattern.kind,
+				harness: source.harness,
+				content,
+				sourceMtimeMs: mtimeMs,
+			});
+		}
+		let semanticIndexed = false;
+		if (obsidian && sourceId) {
 			if (options.sourceGraphEnabled ?? true) {
 				indexObsidianSourceStructure({
 					agentId,
@@ -359,6 +431,7 @@ export async function indexNativeMemoryFile(
 					content,
 					markdownPathIndex: options.markdownPathIndex,
 				});
+				semanticIndexed = true;
 			}
 			if (options.embeddingConfig && options.fetchEmbedding) {
 				const embeddingResult = await indexObsidianSourceEmbeddings({
@@ -378,15 +451,18 @@ export async function indexNativeMemoryFile(
 						skipped: embeddingResult.skipped,
 					});
 				}
+				semanticIndexed = true;
 			}
 		}
 		indexed.set(key, { contentHash: hash });
-		logger.info("watcher", "Indexed native memory artifact", {
-			harness: source.harness,
-			kind: pattern.kind,
-			path: filePath,
-		});
-		return true;
+		if (artifactChanged) {
+			logger.info("watcher", "Indexed native memory artifact", {
+				harness: source.harness,
+				kind: pattern.kind,
+				path: filePath,
+			});
+		}
+		return artifactChanged || semanticIndexed;
 	} catch (err) {
 		logger.warn("watcher", "Failed indexing native memory artifact", {
 			harness: source.harness,

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -16,6 +16,8 @@ import {
 	purgeObsidianSourceFileEmbeddings,
 } from "./obsidian-source-embeddings";
 import {
+	type ObsidianMarkdownPathIndex,
+	buildObsidianMarkdownPathIndex,
 	indexObsidianSourceStructure,
 	purgeObsidianSourceFileStructure,
 	purgeObsidianSourceStructure,
@@ -299,7 +301,9 @@ export async function indexNativeMemoryFile(
 	source: NativeMemorySource,
 	filePath: string,
 	agentId = resolveDaemonAgentId(),
-	options: Pick<NativeMemoryBridgeOptions, "embeddingConfig" | "fetchEmbedding" | "sourceGraphEnabled"> = {},
+	options: Pick<NativeMemoryBridgeOptions, "embeddingConfig" | "fetchEmbedding" | "sourceGraphEnabled"> & {
+		readonly markdownPathIndex?: ObsidianMarkdownPathIndex;
+	} = {},
 ): Promise<boolean> {
 	const pattern = matchesPattern(source, filePath);
 	if (!pattern) return false;
@@ -353,6 +357,7 @@ export async function indexNativeMemoryFile(
 					root: source.root,
 					filePath,
 					content,
+					markdownPathIndex: options.markdownPathIndex,
 				});
 			}
 			if (options.embeddingConfig && options.fetchEmbedding) {
@@ -492,9 +497,16 @@ export function startNativeMemoryBridge(
 				}
 				const total = files.length;
 				const fileDelayMs = sourceFileDelayMs(source, options);
+				const markdownPathIndex =
+					source.harness === "obsidian" && (options.sourceGraphEnabled ?? true)
+						? buildObsidianMarkdownPathIndex(source.root, files)
+						: undefined;
 				for (const file of files) {
 					scanned++;
-					const changed = await indexNativeMemoryFile(source, file, agentId, options);
+					const changed = await indexNativeMemoryFile(source, file, agentId, {
+						...options,
+						markdownPathIndex,
+					});
 					if (changed) {
 						count++;
 						changedCount++;

--- a/platform/daemon/src/obsidian-source-embeddings.test.ts
+++ b/platform/daemon/src/obsidian-source-embeddings.test.ts
@@ -104,6 +104,46 @@ describe("Obsidian source embeddings", () => {
 		expect(rows.every((row) => /lines: \d+-\d+/.test(row.chunk_text))).toBe(true);
 	});
 
+	it("does not re-embed unchanged source chunks after the in-memory cache is cold", async () => {
+		const filePath = join(vault, "literature", "source-memory.md");
+		const content =
+			"# Source Memory\n\nThis section explains that Obsidian vault files remain canonical source truth while Signet indexes addressable chunks for retrieval.\n\n## Chunk Strategy\n\nHeading aware chunks should preserve source_path, vault relative path, heading, and line range so an agent can read back through the canonical note.\n";
+		let fetches = 0;
+
+		const first = await indexObsidianSourceEmbeddings({
+			agentId: "obsidian-embedding-agent",
+			sourceId: "obsidian:test-vault",
+			root: vault,
+			filePath,
+			content,
+			embeddingConfig,
+			fetchEmbedding: async () => {
+				fetches++;
+				return testVector(fetches);
+			},
+		});
+		expect(first.embedded).toBe(first.chunks);
+		expect(fetches).toBe(first.chunks);
+
+		const second = await indexObsidianSourceEmbeddings({
+			agentId: "obsidian-embedding-agent",
+			sourceId: "obsidian:test-vault",
+			root: vault,
+			filePath,
+			content,
+			embeddingConfig,
+			fetchEmbedding: async () => {
+				fetches++;
+				return testVector(fetches);
+			},
+		});
+
+		expect(second.chunks).toBe(first.chunks);
+		expect(second.embedded).toBe(0);
+		expect(second.skipped).toBe(first.chunks);
+		expect(fetches).toBe(first.chunks);
+	});
+
 	it("keeps chunk IDs distinct for repeated heading paths", () => {
 		const filePath = join(vault, "literature", "repeated-headings.md");
 		const chunks = buildObsidianSourceChunks({

--- a/platform/daemon/src/obsidian-source-embeddings.ts
+++ b/platform/daemon/src/obsidian-source-embeddings.ts
@@ -1,10 +1,12 @@
 import { createHash } from "node:crypto";
 import { relative } from "node:path";
+import { yieldEvery } from "./async-yield";
 import { getDbAccessor } from "./db-accessor";
 import { syncVecDeleteByEmbeddingIds, syncVecInsert, vectorToBlob } from "./db-helpers";
 import type { EmbeddingConfig } from "./memory-config";
 
 export const OBSIDIAN_CHUNK_SOURCE_TYPE = "source_obsidian_chunk";
+const OBSIDIAN_SOURCE_CHUNK_DELAY_MS = 100;
 
 export type SourceEmbeddingFetch = (text: string, cfg: EmbeddingConfig) => Promise<number[] | null>;
 
@@ -224,6 +226,7 @@ export async function indexObsidianSourceEmbeddings(
 	if (input.embeddingConfig.provider === "none") return { chunks: 0, embedded: 0, skipped: 0 };
 	const chunks = buildObsidianSourceChunks(input);
 	const currentHashes = new Set<string>();
+	const yielder = yieldEvery(1);
 	let embedded = 0;
 	let skipped = 0;
 	const now = new Date().toISOString();
@@ -231,9 +234,17 @@ export async function indexObsidianSourceEmbeddings(
 	for (const chunk of chunks) {
 		const contentHash = hash(`${input.agentId}\n${chunk.id}\n${chunk.chunkText}`);
 		currentHashes.add(contentHash);
+		if (existingChunkEmbeddingContentHash(input.agentId, chunk.id) === contentHash) {
+			skipped++;
+			await yielder();
+			await sleep(OBSIDIAN_SOURCE_CHUNK_DELAY_MS);
+			continue;
+		}
 		const vector = await input.fetchEmbedding(chunk.chunkText, input.embeddingConfig);
 		if (!vector || vector.length === 0) {
 			skipped++;
+			await yielder();
+			await sleep(OBSIDIAN_SOURCE_CHUNK_DELAY_MS);
 			continue;
 		}
 		getDbAccessor().withWriteTx((db) => {
@@ -274,6 +285,8 @@ export async function indexObsidianSourceEmbeddings(
 			syncVecInsert(db, stored?.id ?? embId, vector);
 		});
 		embedded++;
+		await yielder();
+		await sleep(OBSIDIAN_SOURCE_CHUNK_DELAY_MS);
 	}
 
 	getDbAccessor().withWriteTx((db) => {
@@ -295,6 +308,19 @@ export async function indexObsidianSourceEmbeddings(
 	});
 
 	return { chunks: chunks.length, embedded, skipped };
+}
+
+function sleep(ms: number): Promise<void> {
+	return ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve();
+}
+
+function existingChunkEmbeddingContentHash(agentId: string, chunkId: string): string | null {
+	const row = getDbAccessor().withReadDb((db) =>
+		db
+			.prepare("SELECT content_hash FROM embeddings WHERE source_type = ? AND source_id = ? AND agent_id = ? LIMIT 1")
+			.get(OBSIDIAN_CHUNK_SOURCE_TYPE, chunkId, agentId),
+	) as { content_hash: string } | undefined;
+	return row?.content_hash ?? null;
 }
 
 export function purgeObsidianSourceFileEmbeddings(input: PurgeObsidianSourceFileEmbeddingsInput): number {

--- a/platform/daemon/src/obsidian-source-graph.test.ts
+++ b/platform/daemon/src/obsidian-source-graph.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import {
+	buildObsidianMarkdownPathIndex,
 	indexObsidianSourceStructure,
 	purgeObsidianSourceFileStructure,
 	purgeObsidianSourceStructure,
@@ -167,12 +168,13 @@ describe("Obsidian source graph structure", () => {
 		expect(remaining).toEqual({ entities: 0, attrs: 0, deps: 0, communities: 0 });
 	});
 
-	it("does not walk the full vault to resolve every wikilink while indexing one note", () => {
+	it("resolves cross-folder wikilinks from a per-scan markdown path index", () => {
 		const doc = join(vault, "literature", "Arch-Linux", "hyprland.md");
 		const nestedTarget = join(vault, "literature", "Other", "Deep Target.md");
 		mkdirSync(join(vault, "literature", "Other"), { recursive: true });
 		writeFileSync(doc, "# Hyprland\n\nLinks to [[Deep Target]].\n");
 		writeFileSync(nestedTarget, "# Deep Target\n\nThis file exists elsewhere in the vault.\n");
+		const markdownPathIndex = buildObsidianMarkdownPathIndex(vault, [doc, nestedTarget]);
 
 		indexObsidianSourceStructure({
 			agentId: "obsidian-graph-agent",
@@ -181,6 +183,7 @@ describe("Obsidian source graph structure", () => {
 			root: vault,
 			filePath: doc,
 			content: readFileSync(doc, "utf-8"),
+			markdownPathIndex,
 		});
 
 		const row = getDbAccessor().withReadDb(
@@ -192,13 +195,13 @@ describe("Obsidian source graph structure", () => {
 						 WHERE agent_id = ?
 						   AND canonical_name = ?`,
 					)
-					.get("obsidian-graph-agent", "obsidian:obsidian:test-vault:document:Deep Target.md") as
+					.get("obsidian-graph-agent", "obsidian:obsidian:test-vault:document:literature/Other/Deep Target.md") as
 					| { entity_type: string; source_path: string }
 					| undefined,
 		);
 		expect(row).toEqual({
-			entity_type: "source_document_reference",
-			source_path: join(vault, "Deep Target.md"),
+			entity_type: "source_document",
+			source_path: nestedTarget,
 		});
 	});
 

--- a/platform/daemon/src/obsidian-source-graph.test.ts
+++ b/platform/daemon/src/obsidian-source-graph.test.ts
@@ -172,7 +172,7 @@ describe("Obsidian source graph structure", () => {
 		const doc = join(vault, "literature", "Arch-Linux", "hyprland.md");
 		const nestedTarget = join(vault, "literature", "Other", "Deep Target.md");
 		mkdirSync(join(vault, "literature", "Other"), { recursive: true });
-		writeFileSync(doc, "# Hyprland\n\nLinks to [[Deep Target]].\n");
+		writeFileSync(doc, "# Hyprland\n\nLinks to [[deep-target]].\n");
 		writeFileSync(nestedTarget, "# Deep Target\n\nThis file exists elsewhere in the vault.\n");
 		const markdownPathIndex = buildObsidianMarkdownPathIndex(vault, [doc, nestedTarget]);
 

--- a/platform/daemon/src/obsidian-source-graph.test.ts
+++ b/platform/daemon/src/obsidian-source-graph.test.ts
@@ -167,6 +167,41 @@ describe("Obsidian source graph structure", () => {
 		expect(remaining).toEqual({ entities: 0, attrs: 0, deps: 0, communities: 0 });
 	});
 
+	it("does not walk the full vault to resolve every wikilink while indexing one note", () => {
+		const doc = join(vault, "literature", "Arch-Linux", "hyprland.md");
+		const nestedTarget = join(vault, "literature", "Other", "Deep Target.md");
+		mkdirSync(join(vault, "literature", "Other"), { recursive: true });
+		writeFileSync(doc, "# Hyprland\n\nLinks to [[Deep Target]].\n");
+		writeFileSync(nestedTarget, "# Deep Target\n\nThis file exists elsewhere in the vault.\n");
+
+		indexObsidianSourceStructure({
+			agentId: "obsidian-graph-agent",
+			sourceId: "obsidian:test-vault",
+			sourceName: "Test Vault",
+			root: vault,
+			filePath: doc,
+			content: readFileSync(doc, "utf-8"),
+		});
+
+		const row = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare(
+						`SELECT entity_type, source_path
+						 FROM entities
+						 WHERE agent_id = ?
+						   AND canonical_name = ?`,
+					)
+					.get("obsidian-graph-agent", "obsidian:obsidian:test-vault:document:Deep Target.md") as
+					| { entity_type: string; source_path: string }
+					| undefined,
+		);
+		expect(row).toEqual({
+			entity_type: "source_document_reference",
+			source_path: join(vault, "Deep Target.md"),
+		});
+	});
+
 	it("refreshes a changed note by removing stale headings, claims, and wiki-link dependencies", () => {
 		const doc = join(vault, "literature", "Arch-Linux", "mutable.md");
 		writeFileSync(

--- a/platform/daemon/src/obsidian-source-graph.ts
+++ b/platform/daemon/src/obsidian-source-graph.ts
@@ -55,6 +55,7 @@ interface HeadingSection {
 
 export interface ObsidianMarkdownPathIndex {
 	readonly byStem: ReadonlyMap<string, string>;
+	readonly byNormalizedStem: ReadonlyMap<string, string>;
 	readonly byRel: ReadonlyMap<string, string>;
 }
 
@@ -326,15 +327,19 @@ function markdownTarget(target: string): string {
 export function buildObsidianMarkdownPathIndex(root: string, files: readonly string[]): ObsidianMarkdownPathIndex {
 	const normalized = normalizedRoot(root);
 	const byStem = new Map<string, string>();
+	const byNormalizedStem = new Map<string, string>();
 	const byRel = new Map<string, string>();
 	for (const file of files) {
 		const path = normalizedPath(file);
 		const rel = relPath(normalized, path);
 		if (!rel.endsWith(".md")) continue;
 		byRel.set(rel, path);
-		if (!byStem.has(displayNameForFile(path))) byStem.set(displayNameForFile(path), path);
+		const stem = displayNameForFile(path);
+		if (!byStem.has(stem)) byStem.set(stem, path);
+		const normalizedStem = slug(stem);
+		if (!byNormalizedStem.has(normalizedStem)) byNormalizedStem.set(normalizedStem, path);
 	}
-	return { byStem, byRel };
+	return { byStem, byNormalizedStem, byRel };
 }
 
 function resolveWikiLinkPath(
@@ -349,7 +354,9 @@ function resolveWikiLinkPath(
 		const found = existingMarkdownPath(candidate);
 		if (found) return { path: found, rel: relPath(root, found), found: true };
 	}
-	const indexed = index?.byRel.get(targetPath) ?? (target.includes("/") ? undefined : index?.byStem.get(target));
+	const indexed =
+		index?.byRel.get(targetPath) ??
+		(target.includes("/") ? undefined : (index?.byStem.get(target) ?? index?.byNormalizedStem.get(slug(target))));
 	if (indexed) return { path: indexed, rel: relPath(root, indexed), found: true };
 	const rel = targetPath;
 	return { path: normalizedPath(join(root, rel)), rel, found: false };

--- a/platform/daemon/src/obsidian-source-graph.ts
+++ b/platform/daemon/src/obsidian-source-graph.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { readdirSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { basename, dirname, extname, join, relative, resolve } from "node:path";
 import type { WriteDb } from "./db-accessor";
 import { getDbAccessor } from "./db-accessor";
@@ -305,23 +305,26 @@ function wikiLinks(content: string): string[] {
 	return [...links];
 }
 
-function findMarkdownByStem(root: string, target: string): string | null {
-	const wanted = slug(target).replace(/_/g, "-");
-	const stack = [root];
-	while (stack.length > 0) {
-		const dir = stack.pop();
-		if (!dir) continue;
-		for (const entry of readdirSync(dir, { withFileTypes: true })) {
-			const path = join(dir, entry.name);
-			if (entry.isDirectory()) {
-				if ([".obsidian", ".trash", ".hermes"].includes(entry.name)) continue;
-				stack.push(path);
-			} else if (entry.isFile() && entry.name.endsWith(".md")) {
-				if (slug(basename(entry.name, ".md")).replace(/_/g, "-") === wanted) return path;
-			}
-		}
+function existingMarkdownPath(path: string): string | null {
+	try {
+		return existsSync(path) && statSync(path).isFile() ? normalizedPath(path) : null;
+	} catch {
+		return null;
 	}
-	return null;
+}
+
+function resolveWikiLinkPath(
+	root: string,
+	filePath: string,
+	target: string,
+): { path: string; rel: string; found: boolean } {
+	const candidates = [join(dirname(filePath), `${target}.md`), join(root, `${target}.md`)];
+	for (const candidate of candidates) {
+		const found = existingMarkdownPath(candidate);
+		if (found) return { path: found, rel: relPath(root, found), found: true };
+	}
+	const rel = `${target}.md`;
+	return { path: normalizedPath(join(root, rel)), rel, found: false };
 }
 
 function folderRelatives(root: string, filePath: string): string[] {
@@ -509,18 +512,16 @@ export function indexObsidianSourceStructure(
 			dependenciesTouched++;
 
 		for (const link of wikiLinks(content)) {
-			const found = findMarkdownByStem(root, link);
-			const targetRel = found ? relPath(root, normalizedPath(found)) : `${link}.md`;
-			const targetPath = found ? normalizedPath(found) : join(root, targetRel);
+			const targetPath = resolveWikiLinkPath(root, filePath, link);
 			const target = upsertSourceEntity(db, {
-				id: idFor(input.agentId, input.sourceId, "document", targetRel),
-				name: displayNameForFile(targetPath),
-				canonicalName: sourceCanonical(input.sourceId, "document", targetRel),
-				entityType: found ? "source_document" : "source_document_reference",
+				id: idFor(input.agentId, input.sourceId, "document", targetPath.rel),
+				name: displayNameForFile(targetPath.path),
+				canonicalName: sourceCanonical(input.sourceId, "document", targetPath.rel),
+				entityType: targetPath.found ? "source_document" : "source_document_reference",
 				agentId: input.agentId,
 				sourceId: input.sourceId,
 				sourceRoot: root,
-				sourcePath: normalizedPath(targetPath),
+				sourcePath: targetPath.path,
 				now,
 			});
 			documentEntitiesTouched++;
@@ -531,7 +532,7 @@ export function indexObsidianSourceStructure(
 					agentId: input.agentId,
 					type: "wiki_link",
 					strength: 0.9,
-					confidence: found ? 1 : 0.7,
+					confidence: targetPath.found ? 1 : 0.7,
 					reason: requireDependencyReason("related_to", `Obsidian wiki link [[${link}]] in ${fileRel}`),
 					sourceId: input.sourceId,
 					sourceRoot: root,

--- a/platform/daemon/src/obsidian-source-graph.ts
+++ b/platform/daemon/src/obsidian-source-graph.ts
@@ -14,6 +14,7 @@ export interface IndexObsidianSourceStructureInput {
 	readonly root: string;
 	readonly filePath: string;
 	readonly content: string;
+	readonly markdownPathIndex?: ObsidianMarkdownPathIndex;
 }
 
 export interface IndexObsidianSourceStructureResult {
@@ -50,6 +51,11 @@ interface HeadingSection {
 	readonly heading: string;
 	readonly level: number;
 	readonly body: string;
+}
+
+export interface ObsidianMarkdownPathIndex {
+	readonly byStem: ReadonlyMap<string, string>;
+	readonly byRel: ReadonlyMap<string, string>;
 }
 
 function normalizedRoot(root: string): string {
@@ -313,17 +319,39 @@ function existingMarkdownPath(path: string): string | null {
 	}
 }
 
+function markdownTarget(target: string): string {
+	return target.endsWith(".md") ? target : `${target}.md`;
+}
+
+export function buildObsidianMarkdownPathIndex(root: string, files: readonly string[]): ObsidianMarkdownPathIndex {
+	const normalized = normalizedRoot(root);
+	const byStem = new Map<string, string>();
+	const byRel = new Map<string, string>();
+	for (const file of files) {
+		const path = normalizedPath(file);
+		const rel = relPath(normalized, path);
+		if (!rel.endsWith(".md")) continue;
+		byRel.set(rel, path);
+		if (!byStem.has(displayNameForFile(path))) byStem.set(displayNameForFile(path), path);
+	}
+	return { byStem, byRel };
+}
+
 function resolveWikiLinkPath(
 	root: string,
 	filePath: string,
 	target: string,
+	index?: ObsidianMarkdownPathIndex,
 ): { path: string; rel: string; found: boolean } {
-	const candidates = [join(dirname(filePath), `${target}.md`), join(root, `${target}.md`)];
+	const targetPath = markdownTarget(target);
+	const candidates = [join(dirname(filePath), targetPath), join(root, targetPath)];
 	for (const candidate of candidates) {
 		const found = existingMarkdownPath(candidate);
 		if (found) return { path: found, rel: relPath(root, found), found: true };
 	}
-	const rel = `${target}.md`;
+	const indexed = index?.byRel.get(targetPath) ?? (target.includes("/") ? undefined : index?.byStem.get(target));
+	if (indexed) return { path: indexed, rel: relPath(root, indexed), found: true };
+	const rel = targetPath;
 	return { path: normalizedPath(join(root, rel)), rel, found: false };
 }
 
@@ -512,7 +540,7 @@ export function indexObsidianSourceStructure(
 			dependenciesTouched++;
 
 		for (const link of wikiLinks(content)) {
-			const targetPath = resolveWikiLinkPath(root, filePath, link);
+			const targetPath = resolveWikiLinkPath(root, filePath, link, input.markdownPathIndex);
 			const target = upsertSourceEntity(db, {
 				id: idFor(input.agentId, input.sourceId, "document", targetPath.rel),
 				name: displayNameForFile(targetPath.path),

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -5,8 +5,14 @@ import { join } from "node:path";
 import { addObsidianSource, loadSourcesConfig } from "@signet/core";
 import { Hono } from "hono";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
-import { loadMemoryConfig } from "../memory-config";
 import type { NativeMemoryBridgeHandle, NativeMemoryBridgeOptions, NativeMemorySource } from "../native-memory-sources";
+import {
+	beginSourceIndexJob,
+	clearSourceIndexProgressForTests,
+	completeSourceIndexJob,
+	markSourceIndexJobRunning,
+	updateSourceIndexJobProgress,
+} from "../source-index-progress";
 import { registerSourcesRoutes } from "./sources-routes";
 
 describe("Sources routes", () => {
@@ -16,6 +22,7 @@ describe("Sources routes", () => {
 	let previousSignetAgentId: string | undefined;
 
 	beforeEach(() => {
+		clearSourceIndexProgressForTests();
 		dir = mkdtempSync(join(tmpdir(), "signet-sources-routes-"));
 		vault = join(dir, "vault");
 		mkdirSync(join(vault, "permanent"), { recursive: true });
@@ -29,6 +36,7 @@ describe("Sources routes", () => {
 	});
 
 	afterEach(() => {
+		clearSourceIndexProgressForTests();
 		closeDbAccessor();
 		if (previousSignetPath === undefined) Reflect.deleteProperty(process.env, "SIGNET_PATH");
 		else process.env.SIGNET_PATH = previousSignetPath;
@@ -49,11 +57,14 @@ describe("Sources routes", () => {
 		const app = new Hono();
 		registerSourcesRoutes(app, {
 			agentsDir: dir,
-			loadMemoryConfig,
 			startBridge: (sources: readonly NativeMemorySource[], bridgeOptions: NativeMemoryBridgeOptions) => {
 				expect(sources).toHaveLength(1);
 				expect(sources[0]?.sourceId).toStartWith("obsidian:");
 				expect(bridgeOptions.yieldEveryFiles).toBe(1);
+				expect(bridgeOptions.embeddingConfig).toBeUndefined();
+				expect(bridgeOptions.fetchEmbedding).toBeUndefined();
+				expect(bridgeOptions.sourceCleanupEnabled).toBe(false);
+				expect(bridgeOptions.sourceGraphEnabled).toBe(false);
 				return {
 					syncExisting: async () => {
 						options.onSyncStart?.();
@@ -172,7 +183,6 @@ describe("Sources routes", () => {
 		const app = new Hono();
 		registerSourcesRoutes(app, {
 			agentsDir: dir,
-			loadMemoryConfig,
 			startBridge: (sources: readonly NativeMemorySource[], bridgeOptions: NativeMemoryBridgeOptions) => {
 				syncCalls++;
 				const call = syncCalls;
@@ -256,7 +266,6 @@ describe("Sources routes", () => {
 		const restarted = new Hono();
 		registerSourcesRoutes(restarted, {
 			agentsDir: dir,
-			loadMemoryConfig,
 			purgeNativeSource: () => {
 				startupPurges++;
 				return 1;
@@ -313,6 +322,40 @@ describe("Sources routes", () => {
 			sources: Array<{ stats?: { artifacts: number; chunks: number; indexed: number } }>;
 		};
 		expect(body.sources[0]?.stats).toEqual({ artifacts: 1, chunks: 1, indexed: 1 });
+	});
+
+	it("surfaces background source sync progress in the sources response", async () => {
+		const added = addObsidianSource({ root: vault, name: "Background Vault" }, dir);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+
+		const job = beginSourceIndexJob(added.source.id, "source-startup");
+		markSourceIndexJobRunning(added.source.id, job.id);
+		updateSourceIndexJobProgress(added.source.id, job.id, {
+			scanned: 3,
+			total: 10,
+			indexed: 2,
+			currentPath: join(vault, "permanent", "Note.md"),
+		});
+
+		const res = await makeApp().request("/api/sources");
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			sources: Array<{ indexJob?: { status?: string; scanned?: number; total?: number; indexed?: number } }>;
+		};
+		expect(body.sources[0]?.indexJob).toMatchObject({ status: "running", scanned: 3, total: 10, indexed: 2 });
+
+		completeSourceIndexJob(added.source.id, job.id, 2);
+		updateSourceIndexJobProgress(added.source.id, job.id, {
+			scanned: 4,
+			total: 10,
+			indexed: 3,
+			currentPath: join(vault, "permanent", "Note.md"),
+		});
+		const completed = (await (await makeApp().request("/api/sources")).json()) as {
+			sources: Array<{ indexJob?: { status?: string; scanned?: number; indexed?: number } }>;
+		};
+		expect(completed.sources[0]?.indexJob).toMatchObject({ status: "complete", scanned: 3, indexed: 2 });
 	});
 
 	it("disconnects a source, removes config, and returns purge count", async () => {

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -10,6 +10,8 @@ import {
 	beginSourceIndexJob,
 	clearSourceIndexProgressForTests,
 	completeSourceIndexJob,
+	completeSourceIndexJobFromProgress,
+	getSourceIndexJob,
 	markSourceIndexJobRunning,
 	updateSourceIndexJobProgress,
 } from "../source-index-progress";
@@ -356,6 +358,25 @@ describe("Sources routes", () => {
 			sources: Array<{ indexJob?: { status?: string; scanned?: number; indexed?: number } }>;
 		};
 		expect(completed.sources[0]?.indexJob).toMatchObject({ status: "complete", scanned: 3, indexed: 2 });
+	});
+
+	it("completes startup source jobs from their own progress, not aggregate bridge counts", () => {
+		const active = beginSourceIndexJob("obsidian:active", "source-startup");
+		const empty = beginSourceIndexJob("obsidian:empty", "source-startup");
+		markSourceIndexJobRunning("obsidian:active", active.id);
+		markSourceIndexJobRunning("obsidian:empty", empty.id);
+		updateSourceIndexJobProgress("obsidian:active", active.id, {
+			scanned: 2,
+			total: 2,
+			indexed: 2,
+			currentPath: join(vault, "permanent", "Note.md"),
+		});
+
+		completeSourceIndexJobFromProgress("obsidian:active", active.id);
+		completeSourceIndexJobFromProgress("obsidian:empty", empty.id);
+
+		expect(getSourceIndexJob("obsidian:active")?.indexed).toBe(2);
+		expect(getSourceIndexJob("obsidian:empty")?.indexed).toBe(0);
 	});
 
 	it("disconnects a source, removes config, and returns purge count", async () => {

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -14,37 +14,31 @@ import {
 import type { Hono } from "hono";
 import { resolveDaemonAgentId } from "../agent-id";
 import { getDbAccessor } from "../db-accessor";
-import { fetchEmbedding as defaultFetchEmbedding } from "../embedding-fetch";
-import { type ResolvedMemoryConfig, loadMemoryConfig as defaultLoadMemoryConfig } from "../memory-config";
 import {
 	type NativeMemoryBridgeHandle,
 	obsidianNativeMemorySource,
 	purgeNativeMemorySourceArtifacts,
 	startNativeMemoryBridge,
 } from "../native-memory-sources";
-import type { SourceEmbeddingFetch } from "../obsidian-source-embeddings";
-
-type SourceIndexJobStatus = "queued" | "running" | "complete" | "error";
-
-interface SourceIndexJob {
-	readonly id: string;
-	readonly sourceId: string;
-	readonly status: SourceIndexJobStatus;
-	readonly queuedAt: string;
-	readonly startedAt?: string;
-	readonly finishedAt?: string;
-	readonly scanned?: number;
-	readonly total?: number;
-	readonly indexed?: number;
-	readonly currentPath?: string;
-	readonly error?: string;
-}
+import {
+	type SourceIndexJob,
+	beginSourceIndexJob,
+	cancelSourceIndexJob,
+	clearSourceIndexInFlight,
+	completeSourceIndexJob,
+	consumeCanceledSourceIndexJob,
+	failSourceIndexJob,
+	getSourceIndexJob,
+	isCurrentSourceIndexJob,
+	isSourceIndexInFlight,
+	markSourceIndexInFlight,
+	markSourceIndexJobRunning,
+	updateSourceIndexJobProgress,
+} from "../source-index-progress";
 
 interface SourceIndexJobInput {
 	readonly source: SignetSourceEntry;
 	readonly agentsDir: string;
-	readonly loadMemoryConfig: (agentsDir: string) => ResolvedMemoryConfig;
-	readonly fetchEmbedding: SourceEmbeddingFetch;
 	readonly startBridge: typeof startNativeMemoryBridge;
 	readonly purgeNativeSource: typeof purgeNativeMemorySourceArtifacts;
 }
@@ -71,20 +65,12 @@ interface PickDirectoryBody {
 
 export interface RegisterSourcesRoutesDeps {
 	readonly agentsDir?: string;
-	readonly loadMemoryConfig?: (agentsDir: string) => ResolvedMemoryConfig;
-	readonly fetchEmbedding?: SourceEmbeddingFetch;
 	readonly startBridge?: typeof startNativeMemoryBridge;
 	readonly purgeNativeSource?: typeof purgeNativeMemorySourceArtifacts;
 }
 
-const sourceIndexJobs = new Map<string, SourceIndexJob>();
-const sourceIndexInFlight = new Set<string>();
-const canceledSourceIndexJobs = new Set<string>();
-
 export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps = {}): void {
 	const agentsDir = deps.agentsDir ?? process.env.SIGNET_PATH ?? `${homedir()}/.agents`;
-	const loadMemoryConfig = deps.loadMemoryConfig ?? defaultLoadMemoryConfig;
-	const fetchEmbedding = deps.fetchEmbedding ?? defaultFetchEmbedding;
 	const startBridge = deps.startBridge ?? startNativeMemoryBridge;
 	const purgeNativeSource = deps.purgeNativeSource ?? purgeNativeMemorySourceArtifacts;
 	cleanupSourceDeletionTombstones(agentsDir, purgeNativeSource);
@@ -96,7 +82,7 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 			sources: config.sources.map((source) => ({
 				...source,
 				stats: sourceStats(source, agentId),
-				indexJob: sourceIndexJobs.get(source.id),
+				indexJob: getSourceIndexJob(source.id),
 			})),
 		});
 	});
@@ -132,8 +118,6 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 		const job = enqueueSourceIndexJob({
 			source: result.source,
 			agentsDir,
-			loadMemoryConfig,
-			fetchEmbedding,
 			startBridge,
 			purgeNativeSource,
 		});
@@ -145,9 +129,7 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 		const sourceId = c.req.param("sourceId");
 		const result = removeSource(sourceId, agentsDir);
 		if (result.ok === false) return c.json({ error: result.error }, 404);
-		const job = sourceIndexJobs.get(result.source.id);
-		if (job && (job.status === "queued" || job.status === "running")) canceledSourceIndexJobs.add(job.id);
-		sourceIndexJobs.delete(result.source.id);
+		cancelSourceIndexJob(result.source.id);
 
 		const sourceAgentId = resolveDaemonAgentId();
 		recordSourceDeletionTombstone(result.source, sourceAgentId, agentsDir);
@@ -158,57 +140,40 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 						sourceAgentId,
 					)
 				: 0;
-		if (!sourceIndexInFlight.has(result.source.id))
+		if (!isSourceIndexInFlight(result.source.id))
 			clearSourceDeletionTombstone(result.source.id, sourceAgentId, agentsDir);
 		return c.json({ source: result.source, purged });
 	});
 }
 
 function enqueueSourceIndexJob(input: SourceIndexJobInput): SourceIndexJob {
-	const existing = sourceIndexJobs.get(input.source.id);
-	if (existing && (existing.status === "queued" || existing.status === "running")) return existing;
-
-	const job: SourceIndexJob = {
-		id: `source-index:${input.source.id}:${Date.now()}`,
-		sourceId: input.source.id,
-		status: "queued",
-		queuedAt: new Date().toISOString(),
-	};
-	sourceIndexJobs.set(input.source.id, job);
+	const job = beginSourceIndexJob(input.source.id);
 	scheduleSourceIndexJob(input, job, 0);
 	return job;
 }
 
 async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob): Promise<void> {
-	if (sourceIndexInFlight.has(input.source.id)) {
+	if (isSourceIndexInFlight(input.source.id)) {
 		scheduleSourceIndexJob(input, job, 50);
 		return;
 	}
-	sourceIndexInFlight.add(input.source.id);
-	const started: SourceIndexJob = {
-		...job,
-		status: "running",
-		startedAt: new Date().toISOString(),
-	};
-	sourceIndexJobs.set(input.source.id, started);
+	markSourceIndexInFlight(input.source.id);
+	markSourceIndexJobRunning(input.source.id, job.id);
 
 	let bridge: NativeMemoryBridgeHandle | null = null;
 
 	try {
-		const memoryConfig = input.loadMemoryConfig(input.agentsDir);
 		bridge = input.startBridge(
 			[obsidianNativeMemorySource(input.source.root, input.source.name, input.source.id, input.source.excludeGlobs)],
 			{
 				pollIntervalMs: 0,
-				embeddingConfig: memoryConfig.embedding,
-				fetchEmbedding: input.fetchEmbedding,
 				agentsDir: input.agentsDir,
 				yieldEveryFiles: 1,
+				sourceCleanupEnabled: false,
+				sourceGraphEnabled: false,
 				onFileIndexed: (event) => {
 					if (!isCurrentSourceIndexJob(input.source.id, job.id)) return;
-					sourceIndexJobs.set(input.source.id, {
-						...started,
-						status: "running",
+					updateSourceIndexJobProgress(input.source.id, job.id, {
 						scanned: event.scanned,
 						total: event.total,
 						indexed: event.changed,
@@ -220,32 +185,20 @@ async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob
 		const indexed = await bridge.syncExisting();
 		if (!isCurrentSourceIndexJob(input.source.id, job.id)) return;
 		markSourceIndexed(input.source.id, undefined, input.agentsDir);
-		const current = sourceIndexJobs.get(input.source.id) ?? started;
-		sourceIndexJobs.set(input.source.id, {
-			...current,
-			status: "complete",
-			finishedAt: new Date().toISOString(),
-			indexed,
-		});
+		completeSourceIndexJob(input.source.id, job.id, indexed);
 	} catch (err) {
 		if (!isCurrentSourceIndexJob(input.source.id, job.id)) return;
-		const current = sourceIndexJobs.get(input.source.id) ?? started;
-		sourceIndexJobs.set(input.source.id, {
-			...current,
-			status: "error",
-			finishedAt: new Date().toISOString(),
-			error: err instanceof Error ? err.message : String(err),
-		});
+		failSourceIndexJob(input.source.id, job.id, err);
 	} finally {
 		await bridge?.close().catch(() => undefined);
-		if (canceledSourceIndexJobs.delete(job.id)) {
+		if (consumeCanceledSourceIndexJob(job.id)) {
 			input.purgeNativeSource(
 				obsidianNativeMemorySource(input.source.root, input.source.name, input.source.id, input.source.excludeGlobs),
 				resolveDaemonAgentId(),
 			);
 			clearSourceDeletionTombstone(input.source.id, resolveDaemonAgentId(), input.agentsDir);
 		}
-		sourceIndexInFlight.delete(input.source.id);
+		clearSourceIndexInFlight(input.source.id);
 	}
 }
 
@@ -254,10 +207,6 @@ function scheduleSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob,
 		if (!isCurrentSourceIndexJob(input.source.id, job.id)) return;
 		void runSourceIndexJob(input, job);
 	}, delayMs).unref?.();
-}
-
-function isCurrentSourceIndexJob(sourceId: string, jobId: string): boolean {
-	return sourceIndexJobs.get(sourceId)?.id === jobId;
 }
 
 function cleanupSourceDeletionTombstones(

--- a/platform/daemon/src/source-index-progress.ts
+++ b/platform/daemon/src/source-index-progress.ts
@@ -1,0 +1,128 @@
+export type SourceIndexJobStatus = "queued" | "running" | "complete" | "error";
+
+export interface SourceIndexJob {
+	readonly id: string;
+	readonly sourceId: string;
+	readonly status: SourceIndexJobStatus;
+	readonly queuedAt: string;
+	readonly startedAt?: string;
+	readonly finishedAt?: string;
+	readonly scanned?: number;
+	readonly total?: number;
+	readonly indexed?: number;
+	readonly currentPath?: string;
+	readonly error?: string;
+}
+
+export interface SourceIndexProgressEvent {
+	readonly scanned: number;
+	readonly total: number;
+	readonly indexed: number;
+	readonly currentPath: string;
+}
+
+const sourceIndexJobs = new Map<string, SourceIndexJob>();
+const sourceIndexInFlight = new Set<string>();
+const canceledSourceIndexJobs = new Set<string>();
+
+export function getSourceIndexJob(sourceId: string): SourceIndexJob | undefined {
+	return sourceIndexJobs.get(sourceId);
+}
+
+export function beginSourceIndexJob(sourceId: string, prefix = "source-index"): SourceIndexJob {
+	const existing = sourceIndexJobs.get(sourceId);
+	if (existing && (existing.status === "queued" || existing.status === "running")) return existing;
+	const job: SourceIndexJob = {
+		id: `${prefix}:${sourceId}:${Date.now()}`,
+		sourceId,
+		status: "queued",
+		queuedAt: new Date().toISOString(),
+	};
+	sourceIndexJobs.set(sourceId, job);
+	return job;
+}
+
+export function markSourceIndexJobRunning(sourceId: string, jobId: string): SourceIndexJob | undefined {
+	if (!isCurrentSourceIndexJob(sourceId, jobId)) return undefined;
+	const current = sourceIndexJobs.get(sourceId);
+	if (!current) return undefined;
+	const running: SourceIndexJob = {
+		...current,
+		status: "running",
+		startedAt: current.startedAt ?? new Date().toISOString(),
+	};
+	sourceIndexJobs.set(sourceId, running);
+	return running;
+}
+
+export function updateSourceIndexJobProgress(sourceId: string, jobId: string, event: SourceIndexProgressEvent): void {
+	if (!isCurrentSourceIndexJob(sourceId, jobId)) return;
+	const current = sourceIndexJobs.get(sourceId);
+	if (!current) return;
+	if (current.status === "complete" || current.status === "error") return;
+	sourceIndexJobs.set(sourceId, {
+		...current,
+		status: "running",
+		startedAt: current.startedAt ?? new Date().toISOString(),
+		scanned: event.scanned,
+		total: event.total,
+		indexed: event.indexed,
+		currentPath: event.currentPath,
+	});
+}
+
+export function completeSourceIndexJob(sourceId: string, jobId: string, indexed: number): void {
+	if (!isCurrentSourceIndexJob(sourceId, jobId)) return;
+	const current = sourceIndexJobs.get(sourceId);
+	if (!current) return;
+	sourceIndexJobs.set(sourceId, {
+		...current,
+		status: "complete",
+		finishedAt: new Date().toISOString(),
+		indexed,
+	});
+}
+
+export function failSourceIndexJob(sourceId: string, jobId: string, error: unknown): void {
+	if (!isCurrentSourceIndexJob(sourceId, jobId)) return;
+	const current = sourceIndexJobs.get(sourceId);
+	if (!current) return;
+	sourceIndexJobs.set(sourceId, {
+		...current,
+		status: "error",
+		finishedAt: new Date().toISOString(),
+		error: error instanceof Error ? error.message : String(error),
+	});
+}
+
+export function isCurrentSourceIndexJob(sourceId: string, jobId: string): boolean {
+	return sourceIndexJobs.get(sourceId)?.id === jobId;
+}
+
+export function isSourceIndexInFlight(sourceId: string): boolean {
+	return sourceIndexInFlight.has(sourceId);
+}
+
+export function markSourceIndexInFlight(sourceId: string): void {
+	sourceIndexInFlight.add(sourceId);
+}
+
+export function clearSourceIndexInFlight(sourceId: string): void {
+	sourceIndexInFlight.delete(sourceId);
+}
+
+export function cancelSourceIndexJob(sourceId: string): void {
+	const job = sourceIndexJobs.get(sourceId);
+	if (job && (job.status === "queued" || job.status === "running")) canceledSourceIndexJobs.add(job.id);
+	sourceIndexJobs.delete(sourceId);
+}
+
+export function consumeCanceledSourceIndexJob(jobId: string): boolean {
+	return canceledSourceIndexJobs.delete(jobId);
+}
+
+export function clearSourceIndexProgressForTests(): void {
+	sourceIndexJobs.clear();
+	sourceIndexInFlight.clear();
+	canceledSourceIndexJobs.clear();
+}

--- a/platform/daemon/src/source-index-progress.ts
+++ b/platform/daemon/src/source-index-progress.ts
@@ -83,6 +83,10 @@ export function completeSourceIndexJob(sourceId: string, jobId: string, indexed:
 	});
 }
 
+export function completeSourceIndexJobFromProgress(sourceId: string, jobId: string): void {
+	completeSourceIndexJob(sourceId, jobId, sourceIndexJobs.get(sourceId)?.indexed ?? 0);
+}
+
 export function failSourceIndexJob(sourceId: string, jobId: string, error: unknown): void {
 	if (!isCurrentSourceIndexJob(sourceId, jobId)) return;
 	const current = sourceIndexJobs.get(sourceId);


### PR DESCRIPTION
## Summary

This follow-up fixes the Obsidian source sync path that still saturated the daemon after #634 merged.

The remaining problems were:

- daemon startup still did heavy configured-source work inline with embeddings/graph projection available on the hot path
- configured source sync defaulted to periodic polling, so a large vault could immediately start another full scan after completing
- unchanged artifacts/chunks were only cached in memory, so a cold daemon restart still repeated expensive work
- Obsidian wiki-link graph projection could walk the vault per link
- dashboard progress existed for explicit source jobs, but not automatic startup source sync

## What changed

- Startup source sync now scans only configured sources, not Codex/Claude harness memory roots.
- Startup and dashboard source sync disable inline embeddings, graph projection, and stale cleanup so the daemon indexes source artifacts without blocking on semantic expansion/cleanup work.
- Startup source sync uses `pollIntervalMs: 0`, so it does one paced scan instead of polling the vault forever.
- Source sync progress is shared through `/api/sources`, so dashboard source cards can show automatic startup progress too.
- Obsidian artifact/chunk indexing skips unchanged persisted rows after cold restart.
- Obsidian graph wikilink resolution no longer walks the whole vault per link.
- Poll ticks no longer queue trailing full rescans while a long sync is already running.

## Live validation

Hotpatched the installed daemon at `/home/nicholai/node_modules/signetai/dist/daemon.js` and restarted it with the Obsidian source enabled.

Observed after restart:

- `/api/status` returned immediately while source sync was running
- `/api/sources` reported a running startup job with scanned/total/currentPath progress
- source scan completed once, updated `lastIndexedAt`, and no longer used periodic polling
- no new live event-loop warnings appeared in the sampled log window after the final restart

## Validation

```bash
bunx biome check platform/daemon/src/daemon.ts platform/daemon/src/native-memory-sources.ts platform/daemon/src/native-memory-sources.test.ts platform/daemon/src/obsidian-source-embeddings.ts platform/daemon/src/obsidian-source-embeddings.test.ts platform/daemon/src/obsidian-source-graph.ts platform/daemon/src/obsidian-source-graph.test.ts platform/daemon/src/routes/sources-routes.ts platform/daemon/src/routes/sources-routes.test.ts platform/daemon/src/source-index-progress.ts
bun test platform/daemon/src/routes/sources-routes.test.ts platform/daemon/src/native-memory-sources.test.ts platform/daemon/src/obsidian-source-graph.test.ts platform/daemon/src/obsidian-source-embeddings.test.ts
bun run --filter @signet/daemon build
```

Notes: daemon build still emits pre-existing Svelte a11y/deprecation warnings from dashboard components unrelated to this patch.


## Readiness checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

Notes:
- Spec dependency check passed with `bun scripts/spec-deps-check.ts`; no spec/API/status docs changed because this is a daemon reliability bug fix within the existing Sources contract.
- No new admin endpoints were added. Existing source connect/disconnect routes keep their current route shape; this PR narrows background work and progress reporting.
