### PR TITLE
Fix predictor deprecation and ACPX setup regressions

### DIFF
--- a/dist/signetai/templates/agent.yaml.template
+++ b/dist/signetai/templates/agent.yaml.template
@@ -147,15 +147,6 @@ memory:
     # Semantic contradiction detection — flags conflicting memory updates
     semanticContradictionEnabled: true
 
-    # Predictor — ML-based memory relevance scoring
-    predictor:
-      enabled: true
-
-    # Agent feedback loop for memory relevance
-    predictorPipeline:
-      agentFeedback: true
-      # Opt-in: contribute anonymized training data
-      trainingTelemetry: false
 
 # ============================================================================
 # Hooks Configuration

--- a/libs/sdk/src/__tests__/client.test.ts
+++ b/libs/sdk/src/__tests__/client.test.ts
@@ -250,6 +250,14 @@ describe("SignetClient", () => {
 		expect(result.results[0]?.project).toBe("proj-a");
 	});
 
+	test("retired predictor SDK methods fail locally with a clear deprecation error", async () => {
+		const { client } = mockDaemon();
+
+		expect(typeof client.getPredictorStatus).toBe("function");
+		await expect(client.getPredictorStatus()).rejects.toThrow("Signet predictor APIs were removed in v0.112");
+		expect(recorded).toHaveLength(0);
+	});
+
 	test("deprecated rememberHook()/recallHook() aliases still work", async () => {
 		const { client } = mockDaemon((req) => {
 			if (req.path === "/api/hooks/remember") {

--- a/libs/sdk/src/client-p2.ts
+++ b/libs/sdk/src/client-p2.ts
@@ -744,72 +744,51 @@ export class SignetClientP2 {
 		return this.transport.post<AgentMessageSendResponse>("/api/cross-agent/messages", opts);
 	}
 
-	// --- Predictor ---
+	// --- Predictor (retired) ---
 
 	/**
-	 * @example
-	 * const status = await client.getPredictorStatus();
+	 * @deprecated Signet predictor APIs were removed in 0.112. Use memory search telemetry and pipeline diagnostics instead.
 	 */
 	async getPredictorStatus(): Promise<PredictorStatusResponse> {
-		return this.transport.get<PredictorStatusResponse>("/api/predictor/status");
+		predictorDeprecated();
 	}
 
-	/**
-	 * @example
-	 * const { comparisons, count } = await client.getComparisonsByProject('my-project');
-	 */
-	async getComparisonsByProject(project: string): Promise<ComparisonsByProjectResponse> {
-		return this.transport.get<ComparisonsByProjectResponse>("/api/predictor/comparisons/by-project", { project });
+	/** @deprecated Signet predictor APIs were removed in 0.112. */
+	async getComparisonsByProject(_project: string): Promise<ComparisonsByProjectResponse> {
+		predictorDeprecated();
 	}
 
-	/**
-	 * @example
-	 * const { comparisons, count } = await client.getComparisonsByEntity('entity-123');
-	 */
-	async getComparisonsByEntity(entityId: string): Promise<ComparisonsByEntityResponse> {
-		return this.transport.get<ComparisonsByEntityResponse>("/api/predictor/comparisons/by-entity", {
-			entity_id: entityId,
-		});
+	/** @deprecated Signet predictor APIs were removed in 0.112. */
+	async getComparisonsByEntity(_entityId: string): Promise<ComparisonsByEntityResponse> {
+		predictorDeprecated();
 	}
 
-	/**
-	 * @example
-	 * const { comparisons, total } = await client.listComparisons({ limit: 50, offset: 0 });
-	 */
-	async listComparisons(opts?: {
+	/** @deprecated Signet predictor APIs were removed in 0.112. */
+	async listComparisons(_opts?: {
 		readonly limit?: number;
 		readonly offset?: number;
 		readonly agentId?: string;
 	}): Promise<ComparisonsListResponse> {
-		return this.transport.get<ComparisonsListResponse>("/api/predictor/comparisons", opts);
+		predictorDeprecated();
 	}
 
-	/**
-	 * @example
-	 * const { runs, count } = await client.listTrainingRuns();
-	 */
-	async listTrainingRuns(opts?: {
+	/** @deprecated Signet predictor APIs were removed in 0.112. */
+	async listTrainingRuns(_opts?: {
 		readonly agentId?: string;
 		readonly limit?: number;
 	}): Promise<TrainingRunsResponse> {
-		return this.transport.get<TrainingRunsResponse>("/api/predictor/training", opts);
+		predictorDeprecated();
 	}
 
-	/**
-	 * @example
-	 * const { count } = await client.getTrainingPairsCount();
-	 */
+	/** @deprecated Signet predictor APIs were removed in 0.112. */
 	async getTrainingPairsCount(): Promise<TrainingPairsCountResponse> {
-		return this.transport.get<TrainingPairsCountResponse>("/api/predictor/training-pairs-count");
+		predictorDeprecated();
 	}
 
-	/**
-	 * @example
-	 * const result = await client.trainPredictor({ force: false });
-	 */
-	async trainPredictor(opts?: {
+	/** @deprecated Signet predictor APIs were removed in 0.112. */
+	async trainPredictor(_opts?: {
 		readonly force?: boolean;
 	}): Promise<TrainPredictorResponse> {
-		return this.transport.post<TrainPredictorResponse>("/api/predictor/train", opts ?? {});
+		predictorDeprecated();
 	}
 }

--- a/libs/sdk/src/client-p2.ts
+++ b/libs/sdk/src/client-p2.ts
@@ -745,11 +745,16 @@ export class SignetClientP2 {
 	}
 
 	// --- Predictor (retired) ---
-	
+
 	private predictorDeprecated(): never {
 		throw new Error(
 			"Signet predictor APIs were removed in v0.112. Use memory search telemetry and pipeline diagnostics instead.",
 		);
+	}
+
+	/** @deprecated Signet predictor APIs were removed in 0.112. */
+	async getPredictorStatus(): Promise<never> {
+		this.predictorDeprecated();
 	}
 
 	/** @deprecated Signet predictor APIs were removed in 0.112. */

--- a/libs/sdk/src/client-p2.ts
+++ b/libs/sdk/src/client-p2.ts
@@ -745,22 +745,21 @@ export class SignetClientP2 {
 	}
 
 	// --- Predictor (retired) ---
-
-	/**
-	 * @deprecated Signet predictor APIs were removed in 0.112. Use memory search telemetry and pipeline diagnostics instead.
-	 */
-	async getPredictorStatus(): Promise<PredictorStatusResponse> {
-		predictorDeprecated();
+	
+	private predictorDeprecated(): never {
+		throw new Error(
+			"Signet predictor APIs were removed in v0.112. Use memory search telemetry and pipeline diagnostics instead.",
+		);
 	}
 
 	/** @deprecated Signet predictor APIs were removed in 0.112. */
 	async getComparisonsByProject(_project: string): Promise<ComparisonsByProjectResponse> {
-		predictorDeprecated();
+		this.predictorDeprecated();
 	}
 
 	/** @deprecated Signet predictor APIs were removed in 0.112. */
 	async getComparisonsByEntity(_entityId: string): Promise<ComparisonsByEntityResponse> {
-		predictorDeprecated();
+		this.predictorDeprecated();
 	}
 
 	/** @deprecated Signet predictor APIs were removed in 0.112. */
@@ -769,7 +768,7 @@ export class SignetClientP2 {
 		readonly offset?: number;
 		readonly agentId?: string;
 	}): Promise<ComparisonsListResponse> {
-		predictorDeprecated();
+		this.predictorDeprecated();
 	}
 
 	/** @deprecated Signet predictor APIs were removed in 0.112. */
@@ -777,18 +776,18 @@ export class SignetClientP2 {
 		readonly agentId?: string;
 		readonly limit?: number;
 	}): Promise<TrainingRunsResponse> {
-		predictorDeprecated();
+		this.predictorDeprecated();
 	}
 
 	/** @deprecated Signet predictor APIs were removed in 0.112. */
 	async getTrainingPairsCount(): Promise<TrainingPairsCountResponse> {
-		predictorDeprecated();
+		this.predictorDeprecated();
 	}
 
 	/** @deprecated Signet predictor APIs were removed in 0.112. */
 	async trainPredictor(_opts?: {
 		readonly force?: boolean;
 	}): Promise<TrainPredictorResponse> {
-		predictorDeprecated();
+		this.predictorDeprecated();
 	}
 }

--- a/platform/core/src/routing.test.ts
+++ b/platform/core/src/routing.test.ts
@@ -225,6 +225,55 @@ describe("inference config + decision engine", () => {
 		expect(parsed.value.workloads?.memoryExtraction?.target).toBe(makeRoutingTargetRef("background", "default"));
 	});
 
+	it("preserves generated ACPX launcher package metadata when parsing setup routing", () => {
+		const parsed = parseRoutingConfig({
+			inference: {
+				defaultPolicy: "background-acpx",
+				targets: {
+					"background-acpx": {
+						executor: "acpx",
+						acpx: {
+							agent: "codex",
+							bin: "/usr/local/bin/bunx",
+							package: "acpx@0.7.0",
+						},
+						models: {
+							default: {
+								model: "gpt-5-codex-mini",
+								toolUse: true,
+							},
+						},
+					},
+				},
+				policies: {
+					"background-acpx": {
+						mode: "automatic",
+						defaultTargets: [makeRoutingTargetRef("background-acpx", "default")],
+					},
+				},
+				taskClasses: {
+					memory_extraction: {
+						preferredTargets: [makeRoutingTargetRef("background-acpx", "default")],
+					},
+				},
+				workloads: {
+					memoryExtraction: { target: makeRoutingTargetRef("background-acpx", "default") },
+				},
+			},
+		});
+
+		expect(parsed.ok).toBe(true);
+		if (!parsed.ok) return;
+		expect(parsed.value.targets["background-acpx"]?.acpx).toMatchObject({
+			agent: "codex",
+			bin: "/usr/local/bin/bunx",
+			package: "acpx@0.7.0",
+		});
+		expect(parsed.value.taskClasses.memory_extraction?.preferredTargets).toEqual([
+			makeRoutingTargetRef("background-acpx", "default"),
+		]);
+	});
+
 	it("parses documented ACPX terminal booleans into terminal modes", () => {
 		const parsed = parseRoutingConfig({
 			inference: {

--- a/platform/core/src/routing.ts
+++ b/platform/core/src/routing.ts
@@ -89,6 +89,7 @@ export interface RoutingAcpxConfig {
 	readonly agent: string;
 	readonly version?: string;
 	readonly bin?: string;
+	readonly package?: string;
 	readonly cwd?: string;
 	readonly session?: string;
 	readonly mode?: RoutingAcpxSessionMode;

--- a/platform/core/src/routing.ts
+++ b/platform/core/src/routing.ts
@@ -507,6 +507,7 @@ function parseAcpxConfig(raw: unknown): RoutingAcpxConfig | undefined {
 		agent,
 		version: asString(nested.version ?? nested.acpxVersion ?? nested.acpx_version),
 		bin: asString(nested.bin ?? nested.command),
+		package: asString(nested.package ?? nested.packageRef ?? nested.package_ref),
 		cwd: asString(nested.cwd ?? nested.workspace),
 		session: asString(nested.session ?? nested.sessionName ?? nested.session_name),
 		mode: asAcpxSessionMode(nested.mode),

--- a/platform/daemon-rs/contracts/parity-rules.json
+++ b/platform/daemon-rs/contracts/parity-rules.json
@@ -189,10 +189,6 @@
 				"deterministic": ["models"],
 				"ignoreFields": []
 			},
-			"GET /api/predictor/status": {
-				"deterministic": ["enabled", "modelLoaded"],
-				"ignoreFields": ["lastTrainedAt"]
-			},
 			"GET /api/memory/timeline": {
 				"deterministic": ["events.*.id", "events.*.type"],
 				"ignoreFields": ["events.*.timestamp"],

--- a/platform/daemon-rs/crates/signet-core/src/config.rs
+++ b/platform/daemon-rs/crates/signet-core/src/config.rs
@@ -1344,8 +1344,11 @@ impl Default for PipelineV2Config {
             structural: StructuralConfig::default(),
             feedback: FeedbackConfig::default(),
             significance: Some(SignificanceConfig::default()),
-            predictor: Some(PredictorConfig::default()),
-            predictor_pipeline: PredictorPipelineConfig::default(),
+            predictor: None,
+            predictor_pipeline: PredictorPipelineConfig {
+                agent_feedback: false,
+                training_telemetry: false,
+            },
             model_registry: ModelRegistryConfig::default(),
         }
     }

--- a/platform/daemon-rs/crates/signet-daemon/tests/contract_replay.rs
+++ b/platform/daemon-rs/crates/signet-daemon/tests/contract_replay.rs
@@ -322,14 +322,6 @@ async fn pipeline_endpoints() {
     assert_eq!(body["paused"], false);
 }
 
-#[tokio::test]
-#[ignore = "requires built daemon binary"]
-async fn predictor_endpoints() {
-    let server = TestServer::start().await;
-
-    let resp = server.get("/api/predictor/status").await;
-    assert_eq!(resp.status(), 200);
-}
 
 #[tokio::test]
 #[ignore = "requires built daemon binary"]

--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -174,6 +174,31 @@ printf '  acpx answer  \\n'
 		}
 	});
 
+
+	it("passes configured ACPX package to an absolute launcher", async () => {
+		const root = join(tmpdir(), `signet-acpx-package-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(root, { recursive: true });
+		const bin = join(root, "fake-bunx.sh");
+		const argsPath = join(root, "args.json");
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+printf '%s\n' "$@" > ${JSON.stringify(argsPath)}
+printf 'ok\n'
+`,
+		);
+		chmodSync(bin, 0o755);
+		try {
+			const provider = createAcpxProvider({ agent: "codex", bin, package: "acpx@0.7.0", hooks: "disabled" });
+			await expect(provider.generate("hello", { timeoutMs: 1000 })).resolves.toBe("ok");
+			const args = readFileSync(argsPath, "utf-8").trim().split("\n");
+			expect(args.slice(0, 3)).toEqual(["acpx@0.7.0", "--format", "quiet"]);
+			expect(args).toContain("codex");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("normalizes relative ACPX cwd before spawning and forwarding --cwd", async () => {
 		const root = join(tmpdir(), `signet-acpx-cwd-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		mkdirSync(join(root, "workspace"), { recursive: true });

--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -173,6 +173,38 @@ printf '  acpx answer  \\n'
 			rmSync(root, { recursive: true, force: true });
 		}
 	});
+
+	it("normalizes relative ACPX cwd before spawning and forwarding --cwd", async () => {
+		const root = join(tmpdir(), `signet-acpx-cwd-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(join(root, "workspace"), { recursive: true });
+		const bin = join(root, "fake-acpx.sh");
+		const argsPath = join(root, "args.json");
+		const pwdPath = join(root, "pwd.txt");
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+printf '%s\n' "$@" > ${JSON.stringify(argsPath)}
+pwd > ${JSON.stringify(pwdPath)}
+printf 'ok\n'
+`,
+		);
+		chmodSync(bin, 0o755);
+		const previousCwd = process.cwd();
+		try {
+			process.chdir(root);
+			const provider = createAcpxProvider({ agent: "codex", bin, cwd: "workspace", hooks: "disabled" });
+			await expect(provider.generate("hello", { timeoutMs: 1000 })).resolves.toBe("ok");
+			const args = readFileSync(argsPath, "utf-8").trim().split("\n");
+			const cwdIndex = args.indexOf("--cwd");
+			expect(cwdIndex).toBeGreaterThanOrEqual(0);
+			expect(args[cwdIndex + 1]).toBe(join(root, "workspace"));
+			expect(readFileSync(pwdPath, "utf-8").trim()).toBe(join(root, "workspace"));
+		} finally {
+			process.chdir(previousCwd);
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 });
 
 describe("createOllamaProvider", () => {

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -10,7 +10,7 @@
 import { spawn as nodeSpawn } from "node:child_process";
 import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join, resolve as resolvePath } from "node:path";
 import { Readable } from "node:stream";
 import {
 	DEFAULT_PROVIDER_RATE_LIMIT,
@@ -951,7 +951,6 @@ function replacePromptTokens(value: string, prompt: string): string {
 	return value.split("$PROMPT").join(prompt).split("{{prompt}}").join(prompt);
 }
 
-
 export type AcpxPermissionMode = "inherit" | "deny-all" | "approve-reads" | "approve-all";
 export type AcpxHooksMode = "inherit" | "disabled" | "enabled";
 export type AcpxTerminalMode = "inherit" | "disabled" | "enabled";
@@ -993,20 +992,29 @@ function acpxEnv(hooks: AcpxHooksMode | undefined): NodeJS.ProcessEnv {
 	if (hooks === "disabled") {
 		env.SIGNET_NO_HOOKS = "1";
 	} else if (hooks === "enabled") {
-		delete env.SIGNET_NO_HOOKS;
+		env.SIGNET_NO_HOOKS = undefined;
 	}
 	return env;
 }
 
-function buildAcpxCommand(config: AcpxProviderConfig, timeoutMs: number): { bin: string; args: string[] } {
+function resolveAcpxCwd(cwd: string | undefined): string | undefined {
+	if (!cwd) return undefined;
+	return isAbsolute(cwd) ? cwd : resolvePath(cwd);
+}
+
+function buildAcpxCommand(
+	config: AcpxProviderConfig,
+	timeoutMs: number,
+): { bin: string; args: string[]; cwd?: string } {
 	const bin = config.bin ?? "npx";
+	const cwd = resolveAcpxCwd(config.cwd);
 	const args: string[] = [];
 	if (!config.bin) {
 		args.push("-y", `acpx@${config.version ?? DEFAULT_ACPX_VERSION}`);
 	}
 	args.push("--format", "quiet");
 	args.push("--timeout", String(Math.max(1, Math.ceil(timeoutMs / 1000))));
-	if (config.cwd) args.push("--cwd", config.cwd);
+	if (cwd) args.push("--cwd", cwd);
 	if (config.model) args.push("--model", config.model);
 	args.push(...acpxPermissionArgs(config.permissions));
 	if (config.terminal === "disabled") args.push("--no-terminal");
@@ -1017,7 +1025,7 @@ function buildAcpxCommand(config: AcpxProviderConfig, timeoutMs: number): { bin:
 		args.push("-s", config.session);
 	}
 	args.push("exec", "--file", "-");
-	return { bin, args };
+	return { bin, args, cwd };
 }
 
 export function createAcpxProvider(config: AcpxProviderConfig): LlmProvider {
@@ -1025,13 +1033,13 @@ export function createAcpxProvider(config: AcpxProviderConfig): LlmProvider {
 		name: `acpx:${config.agent}${config.model ? `:${config.model}` : ""}`,
 		async generate(prompt, opts): Promise<string> {
 			const timeoutMs = opts?.timeoutMs ?? config.timeoutMs ?? 60_000;
-			const { bin, args } = buildAcpxCommand(config, timeoutMs);
+			const { bin, args, cwd } = buildAcpxCommand(config, timeoutMs);
 			return new Promise<string>((resolve, reject) => {
 				let stdout = "";
 				let stderr = "";
 				let settled = false;
 				const child = nodeSpawn(bin, args, {
-					cwd: config.cwd,
+					cwd,
 					env: acpxEnv(config.hooks),
 					stdio: ["pipe", "pipe", "pipe"],
 					windowsHide: true,

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -961,6 +961,7 @@ export interface AcpxProviderConfig {
 	readonly model?: string;
 	readonly version?: string;
 	readonly bin?: string;
+	readonly package?: string;
 	readonly cwd?: string;
 	readonly session?: string;
 	readonly mode?: AcpxSessionMode;
@@ -1008,9 +1009,11 @@ function buildAcpxCommand(
 ): { bin: string; args: string[]; cwd?: string } {
 	const bin = config.bin ?? "npx";
 	const cwd = resolveAcpxCwd(config.cwd);
+	const packageRef = config.package ?? (!config.bin ? `acpx@${config.version ?? DEFAULT_ACPX_VERSION}` : undefined);
 	const args: string[] = [];
-	if (!config.bin) {
-		args.push("-y", `acpx@${config.version ?? DEFAULT_ACPX_VERSION}`);
+	if (packageRef) {
+		if (bin.endsWith("npx") || bin.endsWith("npx.cmd")) args.push("-y");
+		args.push(packageRef);
 	}
 	args.push("--format", "quiet");
 	args.push("--timeout", String(Math.max(1, Math.ceil(timeoutMs / 1000))));

--- a/platform/daemon/src/pipeline/supersession.test.ts
+++ b/platform/daemon/src/pipeline/supersession.test.ts
@@ -163,7 +163,6 @@ function testConfig(overrides?: Partial<PipelineV2Config>): PipelineV2Config {
 			staleDays: 14,
 			decayIntervalSessions: 10,
 		},
-		predictorPipeline: { enabled: false, sidecarUrl: "", trainIntervalMs: 300000, trainingMinSessions: 20 },
 		modelRegistry: { models: {} },
 		...overrides,
 	} as PipelineV2Config;

--- a/platform/daemon/src/pipeline/worker.integration.test.ts
+++ b/platform/daemon/src/pipeline/worker.integration.test.ts
@@ -281,7 +281,6 @@ function testPipelineCfg(): PipelineV2Config {
 			minEntityOverlap: 1,
 			noveltyThreshold: 0.15,
 		},
-		predictorPipeline: { agentFeedback: false, trainingTelemetry: false },
 		modelRegistry: { enabled: false, refreshIntervalMs: 3600_000 },
 		hints: {
 			enabled: true,

--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -374,7 +374,6 @@ const OPENCLAW_PLUGIN_PACKAGE = "@signetai/signet-memory-openclaw";
 const OPENCLAW_PLUGIN_SYNC_FILENAME = "openclaw-plugin-version";
 const OPENCLAW_PLUGIN_RETRY_FILENAME = "openclaw-plugin-retry-at";
 const OPENCLAW_PLUGIN_RETRY_DELAY_MS = 10 * 60_000;
-const PREDICTOR_DOWNLOAD_TIMEOUT_MS = 60_000;
 
 function getVersionFromPackageJson(packageJsonPath: string): string | null {
 	if (!existsSync(packageJsonPath)) {

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -15,7 +15,7 @@ import { daemonAccessLines } from "../lib/network.js";
 import Database from "../sqlite.js";
 import { installForge, managedForgeInstallSupportedOnCurrentPlatform } from "./forge.js";
 import { installGraphiqPlugin } from "./graphiq.js";
-import { buildSetupInference, buildSetupPipeline } from "./setup-pipeline.js";
+import { applySetupInferenceRoute, buildSetupInference, buildSetupPipeline } from "./setup-pipeline.js";
 import { writeSetupCorePluginRegistry } from "./setup-plugins.js";
 import { enforceSetupProtection, printSetupProtectionSummary, refreshSnapshotProtection } from "./setup-protection.js";
 import { formatWorkspaceSourceRepoSync, readErr, readRecord } from "./setup-shared.js";
@@ -139,8 +139,9 @@ export async function runFreshSetup(cfg: FreshSetupConfig, deps: SetupDeps): Pro
 			cfg.extractionModel,
 			cfg.harnesses,
 			cfg.availableExtractionProviders,
+			cfg.acpxBin,
 		);
-		if (inference) config.inference = inference;
+		applySetupInferenceRoute(config, inference);
 
 		writeFileSync(join(cfg.basePath, "agent.yaml"), formatYaml(config));
 

--- a/surfaces/cli/src/features/setup-migrate.ts
+++ b/surfaces/cli/src/features/setup-migrate.ts
@@ -24,7 +24,12 @@ import { daemonAccessLines } from "../lib/network.js";
 import Database from "../sqlite.js";
 import { installForge, managedForgeInstallSupportedOnCurrentPlatform } from "./forge.js";
 import { installGraphiqPlugin } from "./graphiq.js";
-import { buildSetupInference, buildSetupPipeline, defaultExtractionModel } from "./setup-pipeline.js";
+import {
+	applySetupInferenceRoute,
+	buildSetupInference,
+	buildSetupPipeline,
+	defaultExtractionModel,
+} from "./setup-pipeline.js";
 import { writeSetupCorePluginRegistry } from "./setup-plugins.js";
 import { enforceSetupProtection, printSetupProtectionSummary, refreshSnapshotProtection } from "./setup-protection.js";
 import {
@@ -71,6 +76,7 @@ export async function runExistingSetupWizard(
 		extractionProvider?: ExtractionProviderChoice;
 		extractionModel?: string;
 		availableExtractionProviders?: readonly ExtractionProviderChoice[];
+		acpxBin?: string;
 		signetSecretsEnabled?: boolean;
 		graphiqEnabled?: boolean;
 	},
@@ -227,8 +233,9 @@ export async function runExistingSetupWizard(
 				options.extractionModel || defaultExtractionModel(options.extractionProvider),
 				detectedHarnesses,
 				options.availableExtractionProviders,
+				options.acpxBin,
 			);
-			if (inference) config.inference = inference;
+			applySetupInferenceRoute(config, inference);
 		}
 
 		if (!existsSync(join(basePath, "agent.yaml"))) {

--- a/surfaces/cli/src/features/setup-pipeline.test.ts
+++ b/surfaces/cli/src/features/setup-pipeline.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { buildSetupInference, buildSetupPipeline, defaultExtractionModel } from "./setup-pipeline";
+import {
+	applySetupInferenceRoute,
+	buildSetupInference,
+	buildSetupPipeline,
+	defaultExtractionModel,
+} from "./setup-pipeline";
 
 describe("defaultExtractionModel", () => {
 	it("prefers the cheap codex mini model", () => {
@@ -64,7 +69,7 @@ describe("buildSetupPipeline", () => {
 
 describe("buildSetupInference", () => {
 	it("writes ACPX as explicit inference routing with the selected harness agent", () => {
-		const inference = buildSetupInference("acpx", "gpt-5-codex-mini", ["opencode", "codex"]);
+		const inference = buildSetupInference("acpx", "gpt-5-codex-mini", ["opencode", "codex"], [], "/usr/local/bin/bunx");
 		expect(inference?.targets["background-acpx"]).toMatchObject({
 			executor: "acpx",
 			acpx: {
@@ -82,10 +87,39 @@ describe("buildSetupInference", () => {
 	});
 
 	it("selects ACPX agent from detected providers when no harness was selected", () => {
-		const inference = buildSetupInference("acpx", "haiku", [], ["acpx", "claude-code"]);
+		const inference = buildSetupInference("acpx", "haiku", [], ["acpx", "claude-code"], "/usr/local/bin/bunx");
 		expect(inference?.targets["background-acpx"]).toMatchObject({
 			executor: "acpx",
 			acpx: { agent: "claude-code" },
+		});
+	});
+	it("does not emit ACPX routing without a resolved launcher", () => {
+		expect(buildSetupInference("acpx", "haiku", ["codex"], ["acpx"])).toBeUndefined();
+	});
+
+	it("removes generated ACPX routing when setup switches to another provider", () => {
+		const config: Record<string, unknown> = {
+			inference: buildSetupInference("acpx", "haiku", ["codex"], ["acpx"], "/usr/local/bin/bunx"),
+		};
+
+		applySetupInferenceRoute(config, undefined);
+
+		expect(config).not.toHaveProperty("inference");
+	});
+
+	it("preserves custom inference routing when removing generated ACPX setup routing", () => {
+		const config: Record<string, unknown> = {
+			inference: {
+				defaultPolicy: "custom",
+				targets: { custom: { executor: "local" } },
+			},
+		};
+
+		applySetupInferenceRoute(config, undefined);
+
+		expect(config.inference).toEqual({
+			defaultPolicy: "custom",
+			targets: { custom: { executor: "local" } },
 		});
 	});
 });

--- a/surfaces/cli/src/features/setup-pipeline.test.ts
+++ b/surfaces/cli/src/features/setup-pipeline.test.ts
@@ -74,6 +74,7 @@ describe("buildSetupInference", () => {
 			executor: "acpx",
 			acpx: {
 				agent: "opencode",
+				package: "acpx@0.7.0",
 				version: "0.7.0",
 				hooks: "disabled",
 				permissions: "deny-all",
@@ -120,6 +121,27 @@ describe("buildSetupInference", () => {
 		expect(config.inference).toEqual({
 			defaultPolicy: "custom",
 			targets: { custom: { executor: "local" } },
+		});
+	});
+
+	it("preserves custom inference task classes when removing generated ACPX setup routing", () => {
+		const config: Record<string, unknown> = {
+			inference: {
+				...buildSetupInference("acpx", "haiku", ["codex"], ["acpx"], "/usr/local/bin/bunx"),
+				taskClasses: {
+					memory_extraction: { reasoning: "medium", toolsRequired: true, privacy: "restricted_remote" },
+					session_synthesis: { reasoning: "medium", toolsRequired: true, privacy: "restricted_remote" },
+					custom_review: { reasoning: "high", toolsRequired: true, privacy: "local" },
+				},
+			},
+		};
+
+		applySetupInferenceRoute(config, undefined);
+
+		expect(config.inference).toEqual({
+			taskClasses: {
+				custom_review: { reasoning: "high", toolsRequired: true, privacy: "local" },
+			},
 		});
 	});
 });

--- a/surfaces/cli/src/features/setup-pipeline.test.ts
+++ b/surfaces/cli/src/features/setup-pipeline.test.ts
@@ -144,4 +144,29 @@ describe("buildSetupInference", () => {
 			},
 		});
 	});
+
+	it("removes generated ACPX task classes from legacy target-only workloads", () => {
+		const config: Record<string, unknown> = {
+			inference: {
+				...buildSetupInference("acpx", "haiku", ["codex"], ["acpx"], "/usr/local/bin/bunx"),
+				workloads: {
+					memoryExtraction: { target: "background-acpx/default" },
+					sessionSynthesis: { target: "background-acpx/default" },
+				},
+				taskClasses: {
+					memory_extraction: { reasoning: "medium", toolsRequired: true, privacy: "restricted_remote" },
+					session_synthesis: { reasoning: "medium", toolsRequired: true, privacy: "restricted_remote" },
+					custom_review: { reasoning: "high", toolsRequired: true, privacy: "local" },
+				},
+			},
+		};
+
+		applySetupInferenceRoute(config, undefined);
+
+		expect(config.inference).toEqual({
+			taskClasses: {
+				custom_review: { reasoning: "high", toolsRequired: true, privacy: "local" },
+			},
+		});
+	});
 });

--- a/surfaces/cli/src/features/setup-pipeline.ts
+++ b/surfaces/cli/src/features/setup-pipeline.ts
@@ -172,11 +172,11 @@ export function applySetupInferenceRoute(
 	if (route.targets) Reflect.deleteProperty(route.targets, "background-acpx");
 	if (route.policies) Reflect.deleteProperty(route.policies, "background-acpx");
 	if (route.workloads?.memoryExtraction && isGeneratedAcpxWorkload(route.workloads.memoryExtraction)) {
-		generatedTaskClasses.add(getAcpxWorkloadTaskClass(route.workloads.memoryExtraction));
+		generatedTaskClasses.add(getAcpxWorkloadTaskClass(route.workloads.memoryExtraction, "memory_extraction"));
 		Reflect.deleteProperty(route.workloads, "memoryExtraction");
 	}
 	if (route.workloads?.sessionSynthesis && isGeneratedAcpxWorkload(route.workloads.sessionSynthesis)) {
-		generatedTaskClasses.add(getAcpxWorkloadTaskClass(route.workloads.sessionSynthesis));
+		generatedTaskClasses.add(getAcpxWorkloadTaskClass(route.workloads.sessionSynthesis, "session_synthesis"));
 		Reflect.deleteProperty(route.workloads, "sessionSynthesis");
 	}
 	for (const taskClass of generatedTaskClasses) {
@@ -192,9 +192,10 @@ export function applySetupInferenceRoute(
 	if (Object.keys(route).length === 0) Reflect.deleteProperty(config, "inference");
 }
 
-function getAcpxWorkloadTaskClass(value: unknown): string {
-	if (typeof value !== "object" || value === null || Array.isArray(value)) return "";
-	return String((value as { taskClass?: unknown }).taskClass ?? "");
+function getAcpxWorkloadTaskClass(value: unknown, fallback: string): string {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return fallback;
+	const taskClass = (value as { taskClass?: unknown }).taskClass;
+	return typeof taskClass === "string" && taskClass.length > 0 ? taskClass : fallback;
 }
 
 function isGeneratedAcpxTaskClass(taskClass: string, value: unknown): boolean {

--- a/surfaces/cli/src/features/setup-pipeline.ts
+++ b/surfaces/cli/src/features/setup-pipeline.ts
@@ -101,8 +101,9 @@ export function buildSetupInference(
 	model?: string,
 	harnesses: readonly string[] = [],
 	availableProviders: readonly ExtractionProviderChoice[] = [],
+	acpxBin?: string,
 ): SetupInferenceConfig | undefined {
-	if (provider !== "acpx") return undefined;
+	if (provider !== "acpx" || !acpxBin) return undefined;
 	const resolved = model?.trim() || defaultExtractionModel(provider);
 	const targetRef = "background-acpx/default";
 	return {
@@ -112,6 +113,7 @@ export function buildSetupInference(
 				executor: "acpx",
 				acpx: {
 					agent: selectAcpxAgent(harnesses, availableProviders),
+					bin: acpxBin,
 					version: "0.7.0",
 					mode: "exec",
 					permissions: "deny-all",
@@ -144,4 +146,48 @@ export function buildSetupInference(
 			sessionSynthesis: { target: targetRef, taskClass: "session_synthesis" },
 		},
 	};
+}
+
+export function applySetupInferenceRoute(
+	config: Record<string, unknown>,
+	inference: SetupInferenceConfig | undefined,
+): void {
+	if (inference) {
+		config.inference = inference;
+		return;
+	}
+
+	const existing = config.inference;
+	if (typeof existing !== "object" || existing === null || Array.isArray(existing)) return;
+	const route = existing as {
+		defaultPolicy?: unknown;
+		targets?: Record<string, unknown>;
+		policies?: Record<string, unknown>;
+		workloads?: Record<string, unknown>;
+		taskClasses?: Record<string, unknown>;
+	};
+	if (route.defaultPolicy !== "background-acpx") return;
+	if (route.targets) Reflect.deleteProperty(route.targets, "background-acpx");
+	if (route.policies) Reflect.deleteProperty(route.policies, "background-acpx");
+	if (route.workloads?.memoryExtraction && isGeneratedAcpxWorkload(route.workloads.memoryExtraction)) {
+		Reflect.deleteProperty(route.workloads, "memoryExtraction");
+	}
+	if (route.workloads?.sessionSynthesis && isGeneratedAcpxWorkload(route.workloads.sessionSynthesis)) {
+		Reflect.deleteProperty(route.workloads, "sessionSynthesis");
+	}
+	Reflect.deleteProperty(route, "taskClasses");
+	if (route.targets && Object.keys(route.targets).length === 0) Reflect.deleteProperty(route, "targets");
+	if (route.policies && Object.keys(route.policies).length === 0) Reflect.deleteProperty(route, "policies");
+	if (route.workloads && Object.keys(route.workloads).length === 0) Reflect.deleteProperty(route, "workloads");
+	Reflect.deleteProperty(route, "defaultPolicy");
+	if (Object.keys(route).length === 0) Reflect.deleteProperty(config, "inference");
+}
+
+function isGeneratedAcpxWorkload(value: unknown): boolean {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		!Array.isArray(value) &&
+		(value as { target?: unknown }).target === "background-acpx/default"
+	);
 }

--- a/surfaces/cli/src/features/setup-pipeline.ts
+++ b/surfaces/cli/src/features/setup-pipeline.ts
@@ -114,6 +114,7 @@ export function buildSetupInference(
 				acpx: {
 					agent: selectAcpxAgent(harnesses, availableProviders),
 					bin: acpxBin,
+					package: "acpx@0.7.0",
 					version: "0.7.0",
 					mode: "exec",
 					permissions: "deny-all",
@@ -167,20 +168,40 @@ export function applySetupInferenceRoute(
 		taskClasses?: Record<string, unknown>;
 	};
 	if (route.defaultPolicy !== "background-acpx") return;
+	const generatedTaskClasses = new Set<string>();
 	if (route.targets) Reflect.deleteProperty(route.targets, "background-acpx");
 	if (route.policies) Reflect.deleteProperty(route.policies, "background-acpx");
 	if (route.workloads?.memoryExtraction && isGeneratedAcpxWorkload(route.workloads.memoryExtraction)) {
+		generatedTaskClasses.add(getAcpxWorkloadTaskClass(route.workloads.memoryExtraction));
 		Reflect.deleteProperty(route.workloads, "memoryExtraction");
 	}
 	if (route.workloads?.sessionSynthesis && isGeneratedAcpxWorkload(route.workloads.sessionSynthesis)) {
+		generatedTaskClasses.add(getAcpxWorkloadTaskClass(route.workloads.sessionSynthesis));
 		Reflect.deleteProperty(route.workloads, "sessionSynthesis");
 	}
-	Reflect.deleteProperty(route, "taskClasses");
+	for (const taskClass of generatedTaskClasses) {
+		if (isGeneratedAcpxTaskClass(taskClass, route.taskClasses?.[taskClass])) {
+			Reflect.deleteProperty(route.taskClasses, taskClass);
+		}
+	}
 	if (route.targets && Object.keys(route.targets).length === 0) Reflect.deleteProperty(route, "targets");
 	if (route.policies && Object.keys(route.policies).length === 0) Reflect.deleteProperty(route, "policies");
+	if (route.taskClasses && Object.keys(route.taskClasses).length === 0) Reflect.deleteProperty(route, "taskClasses");
 	if (route.workloads && Object.keys(route.workloads).length === 0) Reflect.deleteProperty(route, "workloads");
 	Reflect.deleteProperty(route, "defaultPolicy");
 	if (Object.keys(route).length === 0) Reflect.deleteProperty(config, "inference");
+}
+
+function getAcpxWorkloadTaskClass(value: unknown): string {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return "";
+	return String((value as { taskClass?: unknown }).taskClass ?? "");
+}
+
+function isGeneratedAcpxTaskClass(taskClass: string, value: unknown): boolean {
+	if (taskClass !== "memory_extraction" && taskClass !== "session_synthesis") return false;
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+	const record = value as { reasoning?: unknown; toolsRequired?: unknown; privacy?: unknown };
+	return record.reasoning === "medium" && record.toolsRequired === true && record.privacy === "restricted_remote";
 }
 
 function isGeneratedAcpxWorkload(value: unknown): boolean {

--- a/surfaces/cli/src/features/setup-providers.ts
+++ b/surfaces/cli/src/features/setup-providers.ts
@@ -130,6 +130,24 @@ export async function preflightOllamaEmbedding(model: string): Promise<{
 	}
 }
 
+export function resolveCommandPath(command: string): string | undefined {
+	try {
+		const result = spawnSync(process.platform === "win32" ? "where" : "which", [command], {
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
+			timeout: COMMAND_DETECTION_TIMEOUT_MS,
+			windowsHide: true,
+		});
+		if (result.status !== 0) return undefined;
+		return result.stdout
+			.split(/\r?\n/)
+			.map((line) => line.trim())
+			.find(Boolean);
+	} catch {
+		return undefined;
+	}
+}
+
 export function hasCommand(command: string): boolean {
 	try {
 		const result = spawnSync(command, ["--version"], {

--- a/surfaces/cli/src/features/setup-types.ts
+++ b/surfaces/cli/src/features/setup-types.ts
@@ -79,6 +79,7 @@ export interface FreshSetupConfig {
 	readonly extractionProvider: ExtractionProviderChoice;
 	readonly extractionModel: string;
 	readonly availableExtractionProviders: readonly ExtractionProviderChoice[];
+	readonly acpxBin?: string;
 	readonly searchBalance: number;
 	readonly searchTopK: number;
 	readonly searchMinScore: number;

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -18,6 +18,7 @@ import {
 	hasLlamaCppServer,
 	preflightOllamaEmbedding,
 	promptOpenAIEmbeddingModel,
+	resolveCommandPath,
 	validateOllamaModelNonInteractive,
 } from "./setup-providers.js";
 import {
@@ -123,9 +124,11 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 	const hasCodexCommand = hasCommand("codex");
 	const hasOllamaCommand = hasCommand("ollama");
 	const hasOpenCodeCommand = hasCommand("opencode");
+	const acpxBin = resolveCommandPath("bunx") ?? resolveCommandPath("npx");
 	const llamaCppServerAvailable = await hasLlamaCppServer();
 	const availableToolExtractionProviders: ExtractionProviderChoice[] = [];
-	if (hasClaudeCommand || hasCodexCommand || hasOpenCodeCommand) availableToolExtractionProviders.push("acpx");
+	if (acpxBin && (hasClaudeCommand || hasCodexCommand || hasOpenCodeCommand))
+		availableToolExtractionProviders.push("acpx");
 	if (llamaCppServerAvailable) availableToolExtractionProviders.push("llama-cpp");
 	if (hasClaudeCommand) availableToolExtractionProviders.push("claude-code");
 	if (hasCodexCommand) availableToolExtractionProviders.push("codex");
@@ -305,6 +308,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 				extractionProvider: migrationExtractionProvider,
 				extractionModel: deps.normalizeStringValue(options.extractionModel) || undefined,
 				availableExtractionProviders: availableToolExtractionProviders,
+				acpxBin,
 				signetSecretsEnabled,
 				graphiqEnabled,
 			});
@@ -391,6 +395,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 					deps.normalizeStringValue(existingExtraction.model) ||
 					undefined,
 				availableExtractionProviders: availableToolExtractionProviders,
+				acpxBin,
 				signetSecretsEnabled,
 				graphiqEnabled,
 			});
@@ -938,6 +943,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		extractionProvider,
 		extractionModel,
 		availableExtractionProviders: availableToolExtractionProviders,
+		acpxBin,
 		searchBalance,
 		searchTopK,
 		searchMinScore,

--- a/surfaces/cli/templates/agent.yaml.template
+++ b/surfaces/cli/templates/agent.yaml.template
@@ -151,15 +151,6 @@ memory:
     # Semantic contradiction detection — flags conflicting memory updates
     semanticContradictionEnabled: true
 
-    # Predictor — ML-based memory relevance scoring
-    predictor:
-      enabled: true
-
-    # Agent feedback loop for memory relevance
-    predictorPipeline:
-      agentFeedback: true
-      # Opt-in: contribute anonymized training data
-      trainingTelemetry: false
 
 # ============================================================================
 # Hooks Configuration

--- a/surfaces/dashboard/src/lib/api.ts
+++ b/surfaces/dashboard/src/lib/api.ts
@@ -2713,41 +2713,16 @@ export async function getKnowledgeEntityHealth(
 	}
 }
 
-export async function getPredictorEntitySlices(since?: string): Promise<PredictorEntitySlice[]> {
-	try {
-		const params = new URLSearchParams();
-		if (since) params.set("since", since);
-		const res = await fetch(`${API_BASE}/api/predictor/comparisons/by-entity?${params.toString()}`);
-		if (!res.ok) throw new Error("Failed to fetch predictor entity slices");
-		const data = (await res.json()) as { items?: PredictorEntitySlice[] };
-		return data.items ?? [];
-	} catch {
-		return [];
-	}
+export async function getPredictorEntitySlices(_since?: string): Promise<PredictorEntitySlice[]> {
+	return [];
 }
 
-export async function getPredictorProjectSlices(since?: string): Promise<PredictorProjectSlice[]> {
-	try {
-		const params = new URLSearchParams();
-		if (since) params.set("since", since);
-		const res = await fetch(`${API_BASE}/api/predictor/comparisons/by-project?${params.toString()}`);
-		if (!res.ok) throw new Error("Failed to fetch predictor project slices");
-		const data = (await res.json()) as { items?: PredictorProjectSlice[] };
-		return data.items ?? [];
-	} catch {
-		return [];
-	}
+export async function getPredictorProjectSlices(_since?: string): Promise<PredictorProjectSlice[]> {
+	return [];
 }
 
-export async function getPredictorTrainingRuns(limit = 20): Promise<PredictorTrainingRun[]> {
-	try {
-		const res = await fetch(`${API_BASE}/api/predictor/training?limit=${limit}`);
-		if (!res.ok) throw new Error("Failed to fetch predictor training runs");
-		const data = (await res.json()) as { items?: PredictorTrainingRun[] };
-		return data.items ?? [];
-	} catch {
-		return [];
-	}
+export async function getPredictorTrainingRuns(_limit = 20): Promise<PredictorTrainingRun[]> {
+	return [];
 }
 
 // ---------------------------------------------------------------------------

--- a/surfaces/dashboard/src/lib/components/cortex/CortexTasksPanel.svelte
+++ b/surfaces/dashboard/src/lib/components/cortex/CortexTasksPanel.svelte
@@ -15,35 +15,20 @@ import {
 	ts,
 } from "$lib/stores/tasks.svelte";
 import Plus from "@lucide/svelte/icons/plus";
-import Zap from "@lucide/svelte/icons/zap";
 import { onMount } from "svelte";
 
 // biome-ignore lint/style/useConst: Mutated from template callback.
 let selectedColumn = $state(0);
 // biome-ignore lint/style/useConst: Mutated from template callback.
 let selectedTask = $state(0);
-let predictorActive = $state(false);
 
 const taskCount = $derived(ts.tasks.length);
 
 onMount(() => {
 	fetchTasks();
-	checkPredictor();
 	const interval = setInterval(fetchTasks, 15_000);
 	return () => clearInterval(interval);
 });
-
-async function checkPredictor(): Promise<void> {
-	try {
-		const res = await fetch(`${API_BASE}/api/predictor/status`);
-		if (res.ok) {
-			const data = await res.json();
-			predictorActive = data.enabled === true;
-		}
-	} catch {
-		predictorActive = false;
-	}
-}
 </script>
 
 <div class="tasks-panel">
@@ -51,12 +36,6 @@ async function checkPredictor(): Promise<void> {
 		<div class="tasks-header-left">
 			<span class="tasks-title">SCHEDULER</span>
 			<span class="tasks-count">{taskCount} TASKS</span>
-			{#if predictorActive}
-				<span class="predictor-badge">
-					<Zap class="size-2.5" />
-					PREDICTOR
-				</span>
-			{/if}
 		</div>
 		<button class="new-task-btn" onclick={() => openForm()}>
 			<Plus class="size-3" />
@@ -155,22 +134,6 @@ async function checkPredictor(): Promise<void> {
 		font-size: 8px;
 		letter-spacing: 0.1em;
 		color: var(--sig-text-muted);
-	}
-
-	.predictor-badge {
-		display: flex;
-		align-items: center;
-		gap: 3px;
-		font-family: var(--font-mono);
-		font-size: 8px;
-		text-transform: uppercase;
-		letter-spacing: 0.06em;
-		color: var(--sig-highlight-text);
-		background: var(--sig-highlight-muted);
-		border: 1px solid var(--sig-highlight-dim);
-		padding: 1px 6px;
-		border-radius: 4px;
-		line-height: 1.4;
 	}
 
 	.new-task-btn {

--- a/surfaces/dashboard/src/lib/components/cortex/TroubleshooterPanel.svelte
+++ b/surfaces/dashboard/src/lib/components/cortex/TroubleshooterPanel.svelte
@@ -55,7 +55,6 @@ const groupDefs: readonly GroupDef[] = [
 			{ label: "Health", kind: "api", method: "GET", path: "/health" },
 			{ label: "Diagnostics", kind: "api", method: "GET", path: "/api/diagnostics" },
 			{ label: "Pipeline", kind: "api", method: "GET", path: "/api/pipeline/status" },
-			{ label: "Predictor", kind: "api", method: "GET", path: "/api/predictor/status" },
 			{ label: "Git", kind: "api", method: "GET", path: "/api/git/status" },
 			{ label: "Embeddings", kind: "api", method: "GET", path: "/api/embeddings/health" },
 		],

--- a/surfaces/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
@@ -565,18 +565,6 @@ const ADVANCED_FEATURE_KEYS = ["autonomousFrozen"] as const;
 			<Switch checked={st.aBool(["memory", "pipelineV2", "modelRegistry", "enabled"])} onCheckedChange={setBool(["memory", "pipelineV2", "modelRegistry", "enabled"])} />
 		</FormField>
 
-		<div class="font-mono text-[9px] tracking-[0.08em] uppercase text-[var(--sig-text-muted)] pt-3 pb-1 border-b border-[var(--sig-border)] mb-1">
-			Predictor
-		</div>
-		<FormField label="enabled" description="Enable the predictive memory scorer. Learns which memories are most useful based on agent feedback.">
-			<Switch checked={st.aBool(["memory", "pipelineV2", "predictor", "enabled"])} onCheckedChange={setBool(["memory", "pipelineV2", "predictor", "enabled"])} />
-		</FormField>
-		<FormField label="agentFeedback" description="Allow the agent to provide relevance feedback on recalled memories.">
-			<Switch checked={st.aBool(["memory", "pipelineV2", "predictorPipeline", "agentFeedback"])} onCheckedChange={setBool(["memory", "pipelineV2", "predictorPipeline", "agentFeedback"])} />
-		</FormField>
-		<FormField label="trainingTelemetry" description="Contribute anonymized training signals to improve the shared base model.">
-			<Switch checked={st.aBool(["memory", "pipelineV2", "predictorPipeline", "trainingTelemetry"])} onCheckedChange={setBool(["memory", "pipelineV2", "predictorPipeline", "trainingTelemetry"])} />
-		</FormField>
 
 		<AdvancedSection>
 			<FormField label={PIPELINE_CORE_BOOLS[1].key} description={PIPELINE_CORE_BOOLS[1].desc}>

--- a/surfaces/dashboard/src/lib/stores/settings.svelte.ts
+++ b/surfaces/dashboard/src/lib/stores/settings.svelte.ts
@@ -251,25 +251,12 @@ class SettingsStore {
 			semanticContradictionEnabled: true,
 			rerankerEnabled: true,
 		};
-		const PREDICTOR: Record<string, boolean> = { enabled: true };
-		const PREDICTOR_PIPELINE: Record<string, boolean> = {
-			agentFeedback: true,
-			trainingTelemetry: false,
-		};
 		const SEARCH: Record<string, boolean> = { rehearsal_enabled: true };
 
 		if (path[0] === "memory" && path[1] === "pipelineV2") {
 			if (path.length === 3) {
 				const key = path[2];
 				if (key in PIPELINE) return PIPELINE[key];
-			}
-			if (path.length === 4 && path[2] === "predictor") {
-				const key = path[3];
-				if (key in PREDICTOR) return PREDICTOR[key];
-			}
-			if (path.length === 4 && path[2] === "predictorPipeline") {
-				const key = path[3];
-				if (key in PREDICTOR_PIPELINE) return PREDICTOR_PIPELINE[key];
 			}
 		}
 		if (path[0] === "search") {
@@ -329,10 +316,10 @@ class SettingsStore {
 	}
 
 	addCustomHarness(name: string): void {
-		name = name.trim();
-		if (!name) return;
+		const trimmedName = name.trim();
+		if (!trimmedName) return;
 		const arr = this.harnessArray();
-		if (!arr.includes(name)) this.set(this.agent, ["harnesses"], [...arr, name]);
+		if (!arr.includes(trimmedName)) this.set(this.agent, ["harnesses"], [...arr, trimmedName]);
 	}
 
 	removeCustomHarness(name: string): void {


### PR DESCRIPTION
## Summary
- remove active predictor endpoint/config/UI/template leftovers after the 0.112 predictor deprecation
- make retired SDK predictor methods fail locally instead of calling removed `/api/predictor/*` routes
- stop setup from emitting fragile bare-`npx` ACPX routing; persist a resolved ACPX launcher path and clear generated ACPX routing when switching providers
- normalize ACPX cwd before passing it to both spawn and `--cwd` so relative paths do not resolve twice

## Changes
- Updated setup-pipeline, daemon pipeline, provider and worker integration
- Removed predictor leftovers
- Fixed ACPX routing configuration

## Type
- [x] `fix` — bug fix

## Packages affected
- [x] `@signet/daemon`
- [x] `@signet/cli`
- [x] `@signet/sdk`

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Testing
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Tested against running daemon

## AI disclosure
- [x] AI tools were used (see `Assisted-by` tags in commits)
