### PR TITLE
feat(release): split stable and nightly channels

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -4,21 +4,28 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to promote to latest (e.g. 0.2.0)"
+        description: "Nightly version to promote to stable/latest (e.g. 0.113.1)"
         required: true
         type: string
 
 jobs:
   promote:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
-      - name: Promote to latest
+      - name: Promote to stable/latest
         run: |
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+          set -euo pipefail
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > "$NPM_CONFIG_USERCONFIG"
+          npm view "signetai@${VERSION}" version >/dev/null
           npm dist-tag add "signetai@${VERSION}" latest
           npm dist-tag add "@signetai/signet-memory-openclaw@${VERSION}" latest || true
-          echo "Promoted v${VERSION} to latest"
+          gh release edit "v${VERSION}" --repo "$GITHUB_REPOSITORY" --prerelease=false --latest
+          echo "Promoted v${VERSION} to stable/latest"
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/.npmrc
           VERSION: ${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Nightly Release
 
 on:
   push:
@@ -8,7 +8,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     concurrency:
-      group: release-pipeline
+      group: nightly-release-pipeline
       cancel-in-progress: true
     # Skip release commits (prevent loops) and non-code commits
     if: "!contains(github.event.head_commit.message, 'chore: release')"
@@ -132,7 +132,7 @@ jobs:
           git push origin HEAD:main
           git push origin "v$NEW_VERSION"
 
-      - name: Create GitHub Release (draft)
+      - name: Create GitHub Nightly Release (draft prerelease)
         id: create_release
         if: steps.changes.outputs.skip != 'true'
         run: |
@@ -144,10 +144,10 @@ jobs:
             echo "::error::Missing CHANGELOG.md section for v$NEW_VERSION"
             exit 1
           fi
-          # Create as draft — daemon assets are uploaded by build-daemon before
+          # Create as a draft prerelease — daemon assets are uploaded by build-daemon before
           # the publish job verifies asset completeness, undrafts the release,
-          # and publishes npm packages.
-          gh release create "v$NEW_VERSION" --draft --title "v$NEW_VERSION" --notes "$NOTES"
+          # and publishes npm packages to the nightly channel.
+          gh release create "v$NEW_VERSION" --draft --prerelease --title "v$NEW_VERSION" --notes "$NOTES"
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -291,26 +291,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish to npm
+      - name: Publish to npm nightly channel
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > "$NPM_CONFIG_USERCONFIG"
-          CURRENT=$(npm view signetai version 2>/dev/null || echo "0.0.0")
+          CURRENT=$(npm view "signetai@${NEW_VERSION}" version 2>/dev/null || echo "0.0.0")
           if [ "$CURRENT" = "$NEW_VERSION" ]; then
-            echo "signetai@$NEW_VERSION already published, skipping"
+            echo "signetai@$NEW_VERSION already published, refreshing next tag"
+            npm dist-tag add "signetai@${NEW_VERSION}" next
+            npm dist-tag add "@signetai/signet-memory-openclaw@${NEW_VERSION}" next || true
           else
             cd dist/signetai && npm publish --tag next --access public
             cd ../../integrations/openclaw/memory-adapter && npm publish --tag next --access public || true
           fi
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/.npmrc
-
-      - name: Promote to latest
-        if: needs.release.outputs.bump_level != 'major'
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > "$NPM_CONFIG_USERCONFIG"
-          npm dist-tag add "signetai@${NEW_VERSION}" latest
-          npm dist-tag add "@signetai/signet-memory-openclaw@${NEW_VERSION}" latest || true
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/.npmrc

--- a/docs/API.md
+++ b/docs/API.md
@@ -183,6 +183,7 @@ silent fallback or hard-blocked extraction after boot.
     "pendingRestart": null,
     "autoInstall": false,
     "checkInterval": 21600,
+    "channel": "stable",
     "lastCheckAt": null,
     "lastError": null,
     "timerActive": true

--- a/docs/RELEASE_CHANNELS.md
+++ b/docs/RELEASE_CHANNELS.md
@@ -1,0 +1,87 @@
+# Release channels
+
+Signet ships two user-facing release channels:
+
+| Channel | npm dist-tag | GitHub release state | Intended users |
+| --- | --- | --- | --- |
+| `stable` | `latest` | normal release | Default channel for normal users who want predictable behavior. |
+| `nightly` | `next` | prerelease | Opt-in channel for Signet development, dogfooding, and early validation. |
+
+There is no LTS channel yet. Stable/nightly gives Signet room to move quickly without promising long-term branch support before the project is ready for that maintenance burden.
+
+## Policy
+
+### Nightly
+
+- Built automatically from `main` by `.github/workflows/release.yml`.
+- Published to npm with the `next` dist-tag.
+- Created as a GitHub prerelease.
+- May include experimental defaults, unstable behavior, and day-to-day development churn.
+- Must remain opt-in; Signet should not silently move a stable user to nightly.
+
+Install explicitly:
+
+```bash
+npm install -g signetai@next
+```
+
+Or switch an existing install's update checks:
+
+```bash
+signet update channel nightly
+```
+
+### Stable
+
+- Published by manually running `.github/workflows/promote-release.yml` for a known-good nightly version.
+- Promoted to npm `latest`.
+- Marked as a normal GitHub release.
+- Default for install and update checks.
+
+Install:
+
+```bash
+npm install -g signetai
+```
+
+Or switch back from nightly:
+
+```bash
+signet update channel stable
+```
+
+## Update behavior
+
+The daemon stores the user-facing channel in `agent.yaml`:
+
+```yaml
+updates:
+  auto_install: false
+  check_interval: 21600
+  channel: stable
+```
+
+Compatibility aliases are accepted when reading config or CLI input:
+
+- `latest` -> `stable`
+- `next` -> `nightly`
+
+Channel lookup rules:
+
+- `stable` checks GitHub latest stable release first, then falls back to npm `latest`.
+- `nightly` skips GitHub latest and checks npm `next` directly, so it cannot be accidentally pinned back to stable by the GitHub latest endpoint.
+
+## Promotion checklist
+
+Before promoting a nightly to stable:
+
+1. Confirm CI for the nightly release workflow passed.
+2. Confirm daemon release assets exist for every supported platform.
+3. Confirm the npm package was published under `next`.
+4. Confirm the regression sentinel has not reported a blocker.
+5. Run the `Promote Release` workflow with the exact version.
+6. Verify npm `latest` points to the promoted version:
+
+```bash
+npm view signetai dist-tags --json
+```

--- a/platform/daemon/src/routes/misc-routes.ts
+++ b/platform/daemon/src/routes/misc-routes.ts
@@ -36,6 +36,7 @@ import {
 	checkForUpdates as checkForUpdatesImpl,
 	getUpdateState,
 	parseBooleanFlag,
+	parseUpdateChannel,
 	parseUpdateInterval,
 	runUpdate as runUpdateImpl,
 	setUpdateConfig,
@@ -460,14 +461,17 @@ export function registerMiscRoutes(app: Hono): void {
 			auto_install: boolean | string;
 			checkInterval: number | string;
 			check_interval: number | string;
+			channel: string;
 		}>;
 
 		const body = (await c.req.json()) as UpdateConfigBody;
 		const autoInstallRaw = body.autoInstall ?? body.auto_install;
 		const checkIntervalRaw = body.checkInterval ?? body.check_interval;
+		const channelRaw = body.channel;
 
 		let autoInstall: boolean | undefined;
 		let checkInterval: number | undefined;
+		let channel: ReturnType<typeof parseUpdateChannel> | undefined;
 
 		if (autoInstallRaw !== undefined) {
 			const parsed = parseBooleanFlag(autoInstallRaw);
@@ -491,11 +495,19 @@ export function registerMiscRoutes(app: Hono): void {
 			checkInterval = parsed;
 		}
 
-		const changed = autoInstall !== undefined || checkInterval !== undefined;
+		if (channelRaw !== undefined) {
+			const parsed = parseUpdateChannel(channelRaw);
+			if (parsed === null) {
+				return c.json({ success: false, error: "channel must be stable or nightly" }, 400);
+			}
+			channel = parsed;
+		}
+
+		const changed = autoInstall !== undefined || checkInterval !== undefined || channel !== undefined;
 		let persisted = true;
 
 		if (changed) {
-			const result = setUpdateConfig({ autoInstall, checkInterval });
+			const result = setUpdateConfig({ autoInstall, checkInterval, channel: channel ?? undefined });
 			persisted = result.persisted;
 		}
 

--- a/platform/daemon/src/update-route.test.ts
+++ b/platform/daemon/src/update-route.test.ts
@@ -43,6 +43,16 @@ describe("Bug 7: /api/update/run accepts targetVersion in body", () => {
 	});
 });
 
+describe("update channel config route", () => {
+	it("accepts and validates channel updates", () => {
+		const routeBody = mustMatch(DAEMON_SRC, /app\.post\("\/api\/update\/config"[\s\S]*?\}\);/);
+		expect(routeBody).toContain("channelRaw");
+		expect(routeBody).toContain("parseUpdateChannel(channelRaw)");
+		expect(routeBody).toContain("channel must be stable or nightly");
+		expect(routeBody).toContain("setUpdateConfig({ autoInstall, checkInterval, channel");
+	});
+});
+
 describe("Bug 1: CLI gives update/run enough time for desktop refresh", () => {
 	it("fetchFromDaemon for /api/update/run uses the shared install timeout", () => {
 		// Find the update install section — look for the POST to update/run
@@ -63,5 +73,11 @@ describe("Bug 1: CLI gives update/run enough time for desktop refresh", () => {
 	it("CLI reports skipped desktop refresh reasons", () => {
 		expect(CLI_SRC).toContain('data.desktopUpdate?.status === "skipped"');
 		expect(CLI_SRC).toContain("Desktop: ${data.desktopUpdate.message}");
+	});
+
+	it("CLI exposes stable/nightly update channel management", () => {
+		expect(CLI_SRC).toContain('.command("channel [channel]")');
+		expect(CLI_SRC).toContain("stable = default tested releases");
+		expect(CLI_SRC).toContain("Nightly tracks @next builds");
 	});
 });

--- a/platform/daemon/src/update-system.test.ts
+++ b/platform/daemon/src/update-system.test.ts
@@ -19,8 +19,10 @@ import {
 	getUpdateState,
 	initUpdateSystem,
 	normalizeTargetVersion,
+	npmTagForUpdateChannel,
 	parseBooleanFlag,
 	parseInstalledPackageVersion,
+	parseUpdateChannel,
 	parseUpdateInterval,
 	updateDesktopInstallAfterUpdate,
 	verifyInstalledVersion,
@@ -428,6 +430,26 @@ describe("config helpers", () => {
 		expect(parseUpdateInterval(100)).toBeNull(); // Below min
 		expect(parseUpdateInterval(999999999)).toBeNull(); // Above max
 		expect(parseUpdateInterval("not a number")).toBeNull();
+	});
+
+	it("parseUpdateChannel normalizes product channels and legacy npm aliases", () => {
+		expect(parseUpdateChannel("stable")).toBe("stable");
+		expect(parseUpdateChannel("latest")).toBe("stable");
+		expect(parseUpdateChannel("nightly")).toBe("nightly");
+		expect(parseUpdateChannel("next")).toBe("nightly");
+		expect(parseUpdateChannel("canary")).toBeNull();
+		expect(parseUpdateChannel(undefined)).toBeNull();
+	});
+
+	it("maps update channels to npm dist-tags", () => {
+		expect(npmTagForUpdateChannel("stable")).toBe("latest");
+		expect(npmTagForUpdateChannel("nightly")).toBe("next");
+	});
+
+	it("only queries GitHub latest for the stable channel", () => {
+		expect(UPDATE_SYSTEM_SRC).toContain('if (updateConfig.channel === "stable")');
+		expect(UPDATE_SYSTEM_SRC).toContain("fetchStableFromGitHub()");
+		expect(UPDATE_SYSTEM_SRC).toContain("fetchLatestFromNpm(updateConfig.channel)");
 	});
 
 	it("categorizeUpdateError classifies known patterns", () => {

--- a/platform/daemon/src/update-system.ts
+++ b/platform/daemon/src/update-system.ts
@@ -47,10 +47,12 @@ export interface UpdateRunResult {
 	desktopUpdate?: DesktopUpdateResult;
 }
 
+export type UpdateChannel = "stable" | "nightly";
+
 export interface UpdateConfig {
 	autoInstall: boolean;
 	checkInterval: number; // seconds
-	channel: "latest" | "next";
+	channel: UpdateChannel;
 }
 
 export interface UpdateState {
@@ -71,6 +73,8 @@ interface GitHubReleaseResponse {
 	html_url: string;
 	body?: string;
 	published_at?: string;
+	draft?: boolean;
+	prerelease?: boolean;
 }
 
 export type DesktopUpdateStatus = "updated" | "skipped" | "error";
@@ -95,6 +99,10 @@ export interface DesktopInstallDetection {
 
 const GITHUB_REPO = "Signet-AI/signetai";
 const NPM_PACKAGE = "signetai";
+const CHANNEL_TO_NPM_TAG: Record<UpdateChannel, "latest" | "next"> = {
+	stable: "latest",
+	nightly: "next",
+};
 const EXACT_SEMVER_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 const MANAGED_DESKTOP_LAUNCHER_MARKER = "# signet-desktop managed launcher";
 
@@ -122,7 +130,7 @@ let lastAutoUpdateError: string | null = null;
 let updateConfig: UpdateConfig = {
 	autoInstall: false,
 	checkInterval: DEFAULT_UPDATE_INTERVAL_SECONDS,
-	channel: "latest" as const,
+	channel: "stable" as const,
 };
 let restartCallback: (() => void) | null = null;
 
@@ -220,7 +228,11 @@ export function getUpdateSummary(): string | null {
 			agentsDir,
 			env: process.env,
 		});
-		const installCmd = getGlobalInstallCommand(packageManager.family, NPM_PACKAGE);
+		const installPackage =
+			updateConfig.channel === "nightly"
+				? `${NPM_PACKAGE}@${npmTagForUpdateChannel(updateConfig.channel)}`
+				: NPM_PACKAGE;
+		const installCmd = getGlobalInstallCommand(packageManager.family, installPackage);
 		const fullInstallCmd = `${installCmd.command} ${installCmd.args.join(" ")}`;
 
 		return `Signet v${latest} is available (current: v${currentVersion}).\n\nTo update Signet:\n  ${fullInstallCmd}\n  signet daemon restart\n  signet sync\n\nThese are the ONLY supported update commands. Do not use npx, bunx, or signet update install.${notes}`;
@@ -255,11 +267,23 @@ export function parseUpdateInterval(value: unknown): number | null {
 	return parsed;
 }
 
+export function parseUpdateChannel(value: unknown): UpdateChannel | null {
+	if (typeof value !== "string") return null;
+	const normalized = value.trim().toLowerCase();
+	if (normalized === "stable" || normalized === "latest") return "stable";
+	if (normalized === "nightly" || normalized === "next") return "nightly";
+	return null;
+}
+
+export function npmTagForUpdateChannel(channel: UpdateChannel): "latest" | "next" {
+	return CHANNEL_TO_NPM_TAG[channel];
+}
+
 function loadUpdateConfig(): UpdateConfig {
 	const defaults: UpdateConfig = {
 		autoInstall: false,
 		checkInterval: DEFAULT_UPDATE_INTERVAL_SECONDS,
-		channel: "latest" as const,
+		channel: "stable" as const,
 	};
 
 	const paths = [join(agentsDir, "agent.yaml"), join(agentsDir, "AGENT.yaml")];
@@ -288,9 +312,9 @@ function loadUpdateConfig(): UpdateConfig {
 					}
 				}
 
-				const channelRaw = updates.channel;
-				if (channelRaw === "next" || channelRaw === "latest") {
-					defaults.channel = channelRaw;
+				const channel = parseUpdateChannel(updates.channel);
+				if (channel !== null) {
+					defaults.channel = channel;
 				}
 			}
 
@@ -346,7 +370,7 @@ export function persistUpdateConfig(config: UpdateConfig): boolean {
 // Network
 // ---------------------------------------------------------------------------
 
-async function fetchLatestFromGitHub(): Promise<{
+async function fetchStableFromGitHub(): Promise<{
 	version: string;
 	releaseUrl?: string;
 	releaseNotes?: string;
@@ -365,6 +389,9 @@ async function fetchLatestFromGitHub(): Promise<{
 	}
 
 	const data = (await res.json()) as GitHubReleaseResponse;
+	if (data.draft || data.prerelease) {
+		throw new Error("GitHub latest release is not stable");
+	}
 	const version = data.tag_name.replace(/^v/, "");
 
 	return {
@@ -375,8 +402,9 @@ async function fetchLatestFromGitHub(): Promise<{
 	};
 }
 
-async function fetchLatestFromNpm(channel: "latest" | "next" = "latest"): Promise<string> {
-	const npmRes = await fetch(`https://registry.npmjs.org/${NPM_PACKAGE}/${channel}`, {
+async function fetchLatestFromNpm(channel: UpdateChannel = "stable"): Promise<string> {
+	const tag = npmTagForUpdateChannel(channel);
+	const npmRes = await fetch(`https://registry.npmjs.org/${NPM_PACKAGE}/${tag}`, {
 		signal: AbortSignal.timeout(10000),
 	});
 
@@ -407,14 +435,16 @@ export async function checkForUpdates(): Promise<UpdateInfo> {
 
 	const errors: string[] = [];
 
-	try {
-		const github = await fetchLatestFromGitHub();
-		result.latestVersion = github.version;
-		result.releaseUrl = github.releaseUrl;
-		result.releaseNotes = github.releaseNotes;
-		result.publishedAt = github.publishedAt;
-	} catch (e) {
-		errors.push((e as Error).message);
+	if (updateConfig.channel === "stable") {
+		try {
+			const github = await fetchStableFromGitHub();
+			result.latestVersion = github.version;
+			result.releaseUrl = github.releaseUrl;
+			result.releaseNotes = github.releaseNotes;
+			result.publishedAt = github.publishedAt;
+		} catch (e) {
+			errors.push((e as Error).message);
+		}
 	}
 
 	if (!result.latestVersion) {
@@ -1066,12 +1096,18 @@ export function stopUpdateTimer(): void {
 export function setUpdateConfig(patch: {
 	autoInstall?: boolean;
 	checkInterval?: number;
+	channel?: UpdateChannel;
 }): { config: UpdateConfig; persisted: boolean } {
 	if (patch.autoInstall !== undefined) {
 		updateConfig.autoInstall = patch.autoInstall;
 	}
 	if (patch.checkInterval !== undefined) {
 		updateConfig.checkInterval = patch.checkInterval;
+	}
+	if (patch.channel !== undefined) {
+		updateConfig.channel = patch.channel;
+		lastUpdateCheck = null;
+		lastUpdateCheckTime = null;
 	}
 
 	stopUpdateTimer();

--- a/surfaces/cli/src/commands/update.ts
+++ b/surfaces/cli/src/commands/update.ts
@@ -24,6 +24,21 @@ interface UpdateDeps {
 
 const UPDATE_INSTALL_TIMEOUT_MS = 15 * 60_000;
 
+type UpdateChannel = "stable" | "nightly";
+
+function parseUpdateChannel(value: unknown): UpdateChannel | null {
+	if (typeof value !== "string") return null;
+	const normalized = value.trim().toLowerCase();
+	if (normalized === "stable" || normalized === "latest") return "stable";
+	if (normalized === "nightly" || normalized === "next") return "nightly";
+	return null;
+}
+
+function formatUpdateChannel(channel: string | undefined): string {
+	if (channel === "nightly") return chalk.yellow("nightly");
+	return chalk.green("stable");
+}
+
 export function registerUpdateCommands(program: Command, deps: UpdateDeps): void {
 	const updateCmd = program.command("update").description("Check, install, and manage auto-updates");
 
@@ -185,6 +200,7 @@ export function registerUpdateCommands(program: Command, deps: UpdateDeps): void
 			const data = await deps.fetchFromDaemon<{
 				autoInstall?: boolean;
 				checkInterval?: number;
+				channel?: string;
 				pendingRestartVersion?: string;
 				lastAutoUpdateAt?: string;
 				lastAutoUpdateError?: string;
@@ -201,6 +217,7 @@ export function registerUpdateCommands(program: Command, deps: UpdateDeps): void
 				`  ${chalk.dim("Auto-install:")} ${data.autoInstall ? chalk.green("enabled") : chalk.dim("disabled")}`,
 			);
 			console.log(`  ${chalk.dim("Interval:")}     every ${data.checkInterval || "?"}s`);
+			console.log(`  ${chalk.dim("Channel:")}      ${formatUpdateChannel(data.channel)}`);
 			console.log(`  ${chalk.dim("In progress:")}  ${data.updateInProgress ? chalk.yellow("yes") : chalk.dim("no")}`);
 			if (data.pendingRestartVersion) {
 				console.log(`  ${chalk.dim("Pending:")}      v${data.pendingRestartVersion} (restart required)`);
@@ -210,6 +227,51 @@ export function registerUpdateCommands(program: Command, deps: UpdateDeps): void
 			}
 			if (data.lastAutoUpdateError) {
 				console.log(`  ${chalk.dim("Last error:")}   ${chalk.yellow(data.lastAutoUpdateError)}`);
+			}
+		});
+
+	updateCmd
+		.command("channel [channel]")
+		.description("Show or set the update channel (stable or nightly)")
+		.action(async (rawChannel?: string) => {
+			if (!rawChannel) {
+				const data = await deps.fetchFromDaemon<{ channel?: string }>("/api/update/config");
+				if (!data) {
+					console.error(chalk.red("Failed to get update channel"));
+					process.exit(1);
+				}
+				console.log(`Update channel: ${formatUpdateChannel(data.channel)}`);
+				console.log(chalk.dim("  stable = default tested releases; nightly = opt-in next builds"));
+				return;
+			}
+
+			const channel = parseUpdateChannel(rawChannel);
+			if (!channel) {
+				console.error(chalk.red("Channel must be stable or nightly"));
+				process.exit(1);
+			}
+
+			const data = await deps.fetchFromDaemon<{
+				success?: boolean;
+				persisted?: boolean;
+				config?: { channel?: string };
+			}>("/api/update/config", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ channel }),
+			});
+
+			if (!data?.success) {
+				console.error(chalk.red("Failed to set update channel"));
+				process.exit(1);
+			}
+
+			console.log(chalk.green(`✓ Update channel set to ${data.config?.channel ?? channel}`));
+			if (channel === "nightly") {
+				console.log(chalk.yellow("  Nightly tracks @next builds and may be unstable."));
+			}
+			if (data.persisted === false) {
+				console.log(chalk.yellow("  ⚠ Could not persist updates block to agent.yaml"));
 			}
 		});
 
@@ -238,6 +300,7 @@ export function registerUpdateCommands(program: Command, deps: UpdateDeps): void
 
 			const data = await deps.fetchFromDaemon<{ success?: boolean; persisted?: boolean }>("/api/update/config", {
 				method: "POST",
+				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ autoInstall: true, checkInterval: interval }),
 			});
 
@@ -260,6 +323,7 @@ export function registerUpdateCommands(program: Command, deps: UpdateDeps): void
 		.action(async () => {
 			const data = await deps.fetchFromDaemon<{ success?: boolean; persisted?: boolean }>("/api/update/config", {
 				method: "POST",
+				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ autoInstall: false }),
 			});
 


### PR DESCRIPTION
## Summary
- Converts the automatic `main` release workflow into a nightly channel that publishes npm `next` and marks GitHub releases as prereleases.
- Keeps stable releases manual via the promote workflow, which now promotes a known nightly to npm `latest` and marks the GitHub release latest/stable.
- Adds daemon/API/CLI support for user-facing `stable` and `nightly` update channels, while accepting legacy `latest`/`next` aliases.
- Documents the stable/nightly policy and promotion checklist.

## Test Plan
- [x] `python3` YAML parse for `.github/workflows/release.yml` and `.github/workflows/promote-release.yml`
- [x] `python3` spec dependency sanity check for `docs/specs/dependencies.yaml`
- [x] `bun test platform/daemon/src/update-system.test.ts platform/daemon/src/update-route.test.ts`
- [x] `bun run build`
- [x] `bunx biome check .github/workflows/promote-release.yml .github/workflows/release.yml docs/API.md docs/RELEASE_CHANNELS.md platform/daemon/src/routes/misc-routes.ts platform/daemon/src/update-route.test.ts platform/daemon/src/update-system.test.ts platform/daemon/src/update-system.ts surfaces/cli/src/commands/update.ts`
- [x] `git diff --check`

## Notes
- `bun run lint` still fails repo-wide on pre-existing formatting diagnostics across many package.json files; changed-file Biome check passes.
- No LTS channel is introduced in this PR.

## PR Readiness (MANDATORY)
- [x] Conventional commit message used.
- [x] Branch is based on `origin/main`.
- [x] Tests/builds relevant to this change were run locally.
- [x] Docs updated for changed release/update behavior.
- [x] No secrets or credentials are included.
- [x] Publish/install integrity considered for npm dist-tags and GitHub release state.

## Migration Notes
- Existing `updates.channel: latest` is read as `stable`.
- Existing `updates.channel: next` is read as `nightly`.
- Future persisted config writes use `stable` or `nightly`.
- Users can switch with `signet update channel stable` or `signet update channel nightly`.


## Required PR Readiness Checklist
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally
