### PR TITLE
fix(stability): harden recent regression surfaces

### DIFF
--- a/integrations/codex/connector/src/config-toml.test.ts
+++ b/integrations/codex/connector/src/config-toml.test.ts
@@ -221,6 +221,18 @@ describe("CodexConnector.install — config.toml MCP registration", () => {
 		expect(stopHandler.command).toBe("SIGNET_DAEMON_URL='http://192.168.0.60:3850' signet hook session-end -H codex");
 	});
 
+	test("remote lifecycle hooks remain idempotent across repeated installs", async () => {
+		process.env.SIGNET_DAEMON_URL = "http://192.168.0.60:3850/";
+
+		await connector().install(tempHome);
+		await connector().install(tempHome);
+
+		const hooks = readHooksJson().hooks as Record<string, Record<string, unknown>[]>;
+		expect(hooks.SessionStart).toHaveLength(1);
+		expect(hooks.UserPromptSubmit).toHaveLength(1);
+		expect(hooks.Stop).toHaveLength(1);
+	});
+
 	test("rejects unsafe remote daemon URLs before writing Codex config", async () => {
 		process.env.SIGNET_DAEMON_URL = 'http://192.168.0.60:3850/" && calc';
 

--- a/integrations/codex/connector/src/index.ts
+++ b/integrations/codex/connector/src/index.ts
@@ -184,7 +184,9 @@ function escapeRegExp(value: string): string {
 }
 
 function isSignetHookCommand(cmd: string): boolean {
-	const normalized = cmd.trim().replace(/\s+/g, " ");
+	let normalized = cmd.trim().replace(/\s+/g, " ");
+	normalized = normalized.replace(/^SIGNET_DAEMON_URL=(?:'[^']*'|"[^"]*"|\S+)\s+/i, "");
+	normalized = normalized.replace(/^set "SIGNET_DAEMON_URL=[^"]*" && /i, "");
 	return SIGNET_HOOK_SUBCOMMANDS.some((subcommand) => {
 		const hook = `hook\\s+${escapeRegExp(subcommand)}\\b`;
 		const bare = new RegExp(`^(?:signet|signet\\.(?:cmd|ps1|bat|exe))\\s+${hook}`, "i");

--- a/platform/daemon/src/hooks.test.ts
+++ b/platform/daemon/src/hooks.test.ts
@@ -718,6 +718,23 @@ describe("handleSessionStart", () => {
 		expect(restarted.inject).toContain("Fresh startup memory");
 	});
 
+	test.serial("deduplicates session-start by agent and harness scope", async () => {
+		createMemoryDb([{ content: "Scoped startup memory", importance: 0.9 }]);
+		const sessionKey = "shared-session-key";
+
+		await handleSessionStart({ harness: "codex", sessionKey });
+
+		const otherHarness = await handleSessionStart({ harness: "claude-code", sessionKey });
+		expect(otherHarness.memories.length).toBe(1);
+		expect(otherHarness.inject).toContain("Scoped startup memory");
+
+		const otherAgent = await handleSessionStart({ harness: "codex", sessionKey, agentId: "agent-b" });
+		expect(otherAgent.inject).toContain("Signet Status");
+
+		const duplicate = await handleSessionStart({ harness: "codex", sessionKey });
+		expect(duplicate.memories).toEqual([]);
+	});
+
 	test.serial("loads identity from agent.yaml", async () => {
 		writeAgentYaml(`
 agent:

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -187,6 +187,24 @@ async function appendCanonicalLiveTranscriptTurns(params: {
 const sessionStartSeen = new Map<string, number>();
 const SESSION_START_SEEN_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
+function sessionStartDedupeKey(req: {
+	readonly harness?: string;
+	readonly agentId?: string;
+	readonly project?: string;
+	readonly cwd?: string;
+	readonly sessionKey?: string;
+	readonly sessionId?: string;
+}): string | null {
+	const sessionKey = req.sessionKey || req.sessionId;
+	if (!sessionKey) return null;
+	return [
+		resolveAgentId({ agentId: req.agentId, sessionKey }),
+		req.harness ?? "",
+		req.project ?? req.cwd ?? "",
+		sessionKey,
+	].join("\0");
+}
+
 function pruneSessionStartSeen(now = Date.now()): void {
 	for (const [sessionKey, seenAt] of sessionStartSeen.entries()) {
 		if (now - seenAt > SESSION_START_SEEN_TTL_MS) sessionStartSeen.delete(sessionKey);
@@ -1443,7 +1461,8 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	// a minimal stub. Identity files / MEMORY.md are already in the context.
 	// Must fire BEFORE initContinuity to avoid resetting accumulated state.
 	pruneSessionStartSeen();
-	if (req.sessionKey && sessionStartSeen.has(req.sessionKey)) {
+	const dedupeKey = sessionStartDedupeKey(req);
+	if (dedupeKey && sessionStartSeen.has(dedupeKey)) {
 		logger.info("hooks", "Session start dedup — returning minimal stub", {
 			harness: req.harness,
 			sessionKey: req.sessionKey,
@@ -1947,8 +1966,8 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	});
 
 	// Mark this session as having received the full inject
-	if (req.sessionKey) {
-		sessionStartSeen.set(req.sessionKey, Date.now());
+	if (dedupeKey) {
+		sessionStartSeen.set(dedupeKey, Date.now());
 	}
 
 	return {
@@ -2986,6 +3005,8 @@ export async function handleSessionEnd(req: SessionEndRequest): Promise<SessionE
 
 	if (req.reason === "clear") {
 		// Caller intends to discard session context — skip checkpoint, just clean up
+		const dedupeKey = sessionStartDedupeKey(req);
+		if (dedupeKey) sessionStartSeen.delete(dedupeKey);
 		if (sessionKey) sessionStartSeen.delete(sessionKey);
 		clearContinuity(sessionKey);
 		return { memoriesSaved: 0 };

--- a/platform/daemon/src/knowledge-feedback.test.ts
+++ b/platform/daemon/src/knowledge-feedback.test.ts
@@ -109,6 +109,17 @@ describe("knowledge feedback", () => {
 		expect(resolved.entityIds).toEqual(["entity-pinned"]);
 	});
 
+	test("entity health is empty after predictor comparison table retirement", () => {
+		dbPath = makeDbPath();
+		initDbAccessor(dbPath);
+
+		getDbAccessor().withWriteTx((db) => {
+			db.exec("DROP TABLE IF EXISTS predictor_comparisons");
+		});
+
+		expect(getEntityHealth(getDbAccessor(), "default")).toEqual([]);
+	});
+
 	test("fts overlap feedback raises aspect weights and decay respects the floor", () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
@@ -174,5 +185,4 @@ describe("knowledge feedback", () => {
 		);
 		expect(afterDecay?.weight).toBe(0.1);
 	});
-
 });

--- a/platform/daemon/src/knowledge-graph.ts
+++ b/platform/daemon/src/knowledge-graph.ts
@@ -1662,6 +1662,11 @@ export function getEntityHealth(
 			args.push(since);
 		}
 
+		const predictorComparisonsExists = db
+			.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'predictor_comparisons'")
+			.get();
+		if (!predictorComparisonsExists) return [];
+
 		const rows = db
 			.prepare(
 				`SELECT

--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -211,6 +211,36 @@ printf '%s\n' '{"type":"result","text":"final answer"}'
 		}
 	});
 
+	it("uses ACP JSON-RPC message chunks as final text when completion carries only stop metadata", async () => {
+		const root = join(tmpdir(), `signet-acpx-jsonrpc-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(root, { recursive: true });
+		const bin = join(root, "fake-acpx-jsonrpc.sh");
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hello "}}}}'
+printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"world"}}}}'
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"stopReason":"end_turn"}}'
+`,
+		);
+		chmodSync(bin, 0o755);
+		try {
+			const events: unknown[] = [];
+			const provider = createAcpxProvider({
+				agent: "codex",
+				bin,
+				format: "json",
+				captureEvents: true,
+				onEvent: (event) => events.push(event),
+			});
+
+			await expect(provider.generate("hello json", { timeoutMs: 1000 })).resolves.toBe("hello world");
+			expect(events).toHaveLength(3);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("does not deliver ACPX JSON events when captureEvents is disabled", async () => {
 		const root = join(tmpdir(), `signet-acpx-events-disabled-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		mkdirSync(root, { recursive: true });
@@ -317,7 +347,6 @@ printf 'ok\n'
 			rmSync(root, { recursive: true, force: true });
 		}
 	});
-
 });
 
 describe("createOllamaProvider", () => {

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -1069,7 +1069,27 @@ function extractAcpxTextCandidate(event: AcpxJsonEvent): string | undefined {
 
 function isAcpxFinalEvent(event: AcpxJsonEvent): boolean {
 	const type = acpxStringField(event, "type")?.toLowerCase();
-	return type !== undefined && ["result", "final", "complete", "completed", "done", "response"].includes(type);
+	if (type !== undefined && ["result", "final", "complete", "completed", "done", "response"].includes(type))
+		return true;
+	const result = event.result;
+	return isJsonRecord(result) && typeof result.stopReason === "string";
+}
+
+function extractAcpxMessageChunk(event: AcpxJsonEvent): string | undefined {
+	if (acpxStringField(event, "method") !== "session/update") return undefined;
+	const params = event.params;
+	if (!isJsonRecord(params)) return undefined;
+	const update = params.update;
+	if (!isJsonRecord(update)) return undefined;
+	const sessionUpdate = acpxStringField(update, "sessionUpdate")?.toLowerCase();
+	if (sessionUpdate !== undefined && !sessionUpdate.includes("message")) return undefined;
+	const content = update.content;
+	if (typeof content === "string" && content.length > 0) return content;
+	if (isJsonRecord(content)) {
+		const text = acpxStringField(content, "text");
+		if (text !== undefined) return text;
+	}
+	return undefined;
 }
 
 function parseAcpxJsonOutput(
@@ -1079,6 +1099,7 @@ function parseAcpxJsonOutput(
 	const maxCapturedEvents = Math.max(0, config.maxCapturedEvents ?? 200);
 	let emittedEvents = 0;
 	let finalText: string | undefined;
+	let streamedText = "";
 	const lines = stdout
 		.split(/\r?\n/)
 		.map((line) => line.trim())
@@ -1097,9 +1118,15 @@ function parseAcpxJsonOutput(
 		if (!isJsonRecord(parsed)) {
 			throw new Error(`${config.agent} via ACPX emitted non-object JSON event on line ${index + 1}`);
 		}
+		const chunk = extractAcpxMessageChunk(parsed);
+		if (chunk !== undefined) streamedText += chunk;
 		if (isAcpxFinalEvent(parsed)) {
 			const candidate = extractAcpxTextCandidate(parsed);
-			if (candidate?.trim()) finalText = candidate;
+			if (candidate?.trim()) {
+				finalText = candidate;
+			} else if (streamedText.trim()) {
+				finalText = streamedText;
+			}
 		}
 		if (config.captureEvents === true && emittedEvents < maxCapturedEvents) {
 			emittedEvents += 1;

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -158,7 +158,10 @@ async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob
 		return;
 	}
 	markSourceIndexInFlight(input.source.id);
-	markSourceIndexJobRunning(input.source.id, job.id);
+	if (!markSourceIndexJobRunning(input.source.id, job.id)) {
+		clearSourceIndexInFlight(input.source.id);
+		return;
+	}
 
 	let bridge: NativeMemoryBridgeHandle | null = null;
 

--- a/platform/daemon/src/source-index-progress.test.ts
+++ b/platform/daemon/src/source-index-progress.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import {
+	beginSourceIndexJob,
+	clearSourceIndexProgressForTests,
+	completeSourceIndexJob,
+	getSourceIndexJob,
+	markSourceIndexJobRunning,
+} from "./source-index-progress";
+
+describe("source index progress", () => {
+	test("does not reopen completed jobs when a duplicate delayed runner fires", () => {
+		clearSourceIndexProgressForTests();
+		const job = beginSourceIndexJob("source-1");
+		expect(markSourceIndexJobRunning("source-1", job.id)?.status).toBe("running");
+		completeSourceIndexJob("source-1", job.id, 3);
+
+		expect(markSourceIndexJobRunning("source-1", job.id)).toBeUndefined();
+		expect(getSourceIndexJob("source-1")?.status).toBe("complete");
+	});
+});

--- a/platform/daemon/src/source-index-progress.ts
+++ b/platform/daemon/src/source-index-progress.ts
@@ -45,7 +45,7 @@ export function beginSourceIndexJob(sourceId: string, prefix = "source-index"): 
 export function markSourceIndexJobRunning(sourceId: string, jobId: string): SourceIndexJob | undefined {
 	if (!isCurrentSourceIndexJob(sourceId, jobId)) return undefined;
 	const current = sourceIndexJobs.get(sourceId);
-	if (!current) return undefined;
+	if (!current || (current.status !== "queued" && current.status !== "running")) return undefined;
 	const running: SourceIndexJob = {
 		...current,
 		status: "running",

--- a/surfaces/cli/src/commands/hook.test.ts
+++ b/surfaces/cli/src/commands/hook.test.ts
@@ -301,6 +301,28 @@ describe("buildSessionStartBody", () => {
 			runtimePath: "legacy",
 		});
 	});
+
+	test("forwards parent_key aliases for explicit parent context", () => {
+		expect(
+			buildSessionStartBody(
+				{ parent_key: "parent-from-snake", sessionKey: "child-session", cwd: "/tmp/project" },
+				{ harness: "custom-harness" },
+			),
+		).toMatchObject({
+			parentSessionKey: "parent-from-snake",
+			sessionKey: "child-session",
+		});
+
+		expect(
+			buildSessionStartBody(
+				{ parentKey: "parent-from-camel", sessionKey: "child-session", cwd: "/tmp/project" },
+				{ harness: "custom-harness" },
+			),
+		).toMatchObject({
+			parentSessionKey: "parent-from-camel",
+			sessionKey: "child-session",
+		});
+	});
 });
 
 describe("buildUserPromptSubmitBody", () => {

--- a/surfaces/cli/src/commands/hook.ts
+++ b/surfaces/cli/src/commands/hook.ts
@@ -466,7 +466,14 @@ export function buildSessionStartBody(
 		nativeAgentId ? "" : body?.agent_id,
 	);
 	const harnessAgentId = pickString(body?.harness_agent_id, body?.harnessAgentId, nativeAgentId);
-	const parentSessionKey = pickString(body?.parent_session_key, body?.parentSessionKey, body?.parentID, body?.parentId);
+	const parentSessionKey = pickString(
+		body?.parent_session_key,
+		body?.parentSessionKey,
+		body?.parent_key,
+		body?.parentKey,
+		body?.parentID,
+		body?.parentId,
+	);
 	return {
 		harness: options.harness,
 		project: pickString(options.project, body?.cwd),


### PR DESCRIPTION
## Summary
- Hardens ACPX JSON parsing so real ACP JSON-RPC `session/update` chunks produce final provider text instead of failing when completion only carries stop metadata.
- Keeps retired predictor comparison data from breaking entity-health endpoints on fresh/current schemas.
- Prevents duplicate/delayed Obsidian source-index runners from reopening already-completed jobs.
- Fixes hook/context regressions from the recent session work: scoped session-start dedupe, `parent_key`/`parentKey` forwarding, and remote Codex hook reinstall idempotency.

## Regression coverage
- ACPX JSON-RPC chunk stream final-text contract.
- Predictor-comparison table retirement on entity health.
- Completed source index job cannot transition back to running.
- Session-start dedupe is scoped by agent/harness/project/session.
- CLI forwards `parent_key` aliases into session-start body.
- Codex remote hooks remain idempotent across repeated installs.

## Test Plan
- [x] `bun install`
- [x] `bun run build:core`
- [x] `bun run build:connector-base`
- [x] `bun test surfaces/cli/src/commands/hook.test.ts platform/daemon/src/knowledge-feedback.test.ts platform/daemon/src/source-index-progress.test.ts integrations/codex/connector/src/config-toml.test.ts platform/daemon/src/pipeline/provider.test.ts platform/daemon/src/hooks.test.ts`
- [x] `bun run build`
- [x] `git diff --check`
- [x] spec dependency sanity check for `docs/specs/dependencies.yaml`
- [x] focused Biome check on changed files except `platform/daemon/src/pipeline/provider.test.ts`

Note: `platform/daemon/src/pipeline/provider.test.ts` has pre-existing Biome diagnostics unrelated to this patch (`delete process.env`, non-null assertions, and wider formatting churn). I left those alone to keep this PR focused.

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes
- [x] No schema migration required.
- [x] Backward compatibility preserved for existing hook/update/source configurations.
