### PR TITLE
fix(daemon): prune migration backups before copy

### DIFF
--- a/platform/daemon/src/db-accessor.test.ts
+++ b/platform/daemon/src/db-accessor.test.ts
@@ -2,17 +2,7 @@
  * Tests for the DB accessor (singleton read/write transaction wrapper).
  */
 import { afterEach, describe, expect, test } from "bun:test";
-import {
-	copyFileSync,
-	existsSync,
-	mkdirSync,
-	readFileSync,
-	readdirSync,
-	rmSync,
-	statSync,
-	unlinkSync,
-	writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {

--- a/platform/daemon/src/db-accessor.test.ts
+++ b/platform/daemon/src/db-accessor.test.ts
@@ -157,6 +157,40 @@ describe("DbAccessor", () => {
 		]);
 	});
 
+	test("ignores migration backups removed during metadata collection", () => {
+		const dbPath = tmpDbPath();
+		cleanupDirs.push(join(dbPath, ".."));
+		const dbDir = join(dbPath, "..");
+		writeFileSync(dbPath, "database");
+
+		const files = new Map<string, number>([
+			["test.db.bak-v60-3000", 3000],
+			["test.db.bak-v61-4000", 4000],
+			["test.db.bak-v62-5000", 5000],
+		]);
+		const missing = Object.assign(new Error("ENOENT: no such file or directory, stat"), { code: "ENOENT" });
+
+		backupBeforeMigration({ exec: () => {} }, dbPath, 63, {
+			copyFileSync: (_source, dest) => {
+				files.set(String(dest).slice(dbDir.length + 1), 6000);
+			},
+			readdirSync: () => ["test.db.bak-v59-2000", ...Array.from(files.keys())],
+			statSync: (path) => {
+				const name = String(path).slice(dbDir.length + 1);
+				const mtime = files.get(name);
+				if (mtime === undefined) throw missing;
+				return { mtimeMs: mtime };
+			},
+			unlinkSync: (path) => {
+				files.delete(String(path).slice(dbDir.length + 1));
+			},
+			now: () => 6000,
+			log: () => {},
+		});
+
+		expect(files.has("test.db.bak-v63-6000")).toBe(true);
+	});
+
 	test("cleans partial migration backup when copy fails", () => {
 		const dbPath = tmpDbPath();
 		cleanupDirs.push(join(dbPath, ".."));

--- a/platform/daemon/src/db-accessor.test.ts
+++ b/platform/daemon/src/db-accessor.test.ts
@@ -2,10 +2,21 @@
  * Tests for the DB accessor (singleton read/write transaction wrapper).
  */
 import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	readdirSync,
+	rmSync,
+	statSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+	backupBeforeMigration,
 	closeDbAccessor,
 	getDbAccessor,
 	initDbAccessor,
@@ -112,6 +123,78 @@ describe("DbAccessor", () => {
 
 		// Should not throw
 		closeDbAccessor();
+	});
+
+	test("prunes old migration backups before copying a new one", () => {
+		const dbPath = tmpDbPath();
+		cleanupDirs.push(join(dbPath, ".."));
+		const dbDir = join(dbPath, "..");
+		writeFileSync(dbPath, "database");
+
+		const files = new Map<string, number>([
+			["test.db.bak-v58-1000", 1000],
+			["test.db.bak-v59-2000", 2000],
+			["test.db.bak-v60-3000", 3000],
+			["test.db.bak-v61-4000", 4000],
+			["test.db.bak-v62-5000", 5000],
+		]);
+		const operations: string[] = [];
+
+		backupBeforeMigration({ exec: () => {} }, dbPath, 62, {
+			copyFileSync: (source, dest) => {
+				operations.push(`copy:${source}->${dest}`);
+				expect(operations).toContain("unlink:test.db.bak-v58-1000");
+				files.set(String(dest).slice(dbDir.length + 1), 6000);
+			},
+			readdirSync: () => Array.from(files.keys()),
+			statSync: (path) => ({ mtimeMs: files.get(String(path).slice(dbDir.length + 1)) ?? 0 }),
+			unlinkSync: (path) => {
+				const name = String(path).slice(dbDir.length + 1);
+				operations.push(`unlink:${name}`);
+				files.delete(name);
+			},
+			now: () => 6000,
+			log: () => {},
+		});
+
+		expect(operations[0]).toBe("unlink:test.db.bak-v58-1000");
+		expect(Array.from(files.keys()).sort()).toEqual([
+			"test.db.bak-v59-2000",
+			"test.db.bak-v60-3000",
+			"test.db.bak-v61-4000",
+			"test.db.bak-v62-5000",
+			"test.db.bak-v62-6000",
+		]);
+	});
+
+	test("cleans partial migration backup when copy fails", () => {
+		const dbPath = tmpDbPath();
+		cleanupDirs.push(join(dbPath, ".."));
+		const dbDir = join(dbPath, "..");
+		const files = new Map<string, number>();
+		const operations: string[] = [];
+
+		expect(() =>
+			backupBeforeMigration({ exec: () => {} }, dbPath, 65, {
+				copyFileSync: (_source, dest) => {
+					const name = String(dest).slice(dbDir.length + 1);
+					files.set(name, 1);
+					throw new Error("ENOSPC: no space left on device, copyfile");
+				},
+				readdirSync: () => Array.from(files.keys()),
+				statSync: (path) => ({ mtimeMs: files.get(String(path).slice(dbDir.length + 1)) ?? 0 }),
+				unlinkSync: (path) => {
+					const name = String(path).slice(dbDir.length + 1);
+					operations.push(`unlink:${name}`);
+					files.delete(name);
+				},
+				now: () => 7000,
+				log: () => {},
+			}),
+		).toThrow(/Free disk space and retry/);
+
+		expect(operations).toContain("unlink:test.db.bak-v65-7000");
+		expect(files.has("test.db.bak-v65-7000")).toBe(false);
 	});
 });
 

--- a/platform/daemon/src/db-accessor.ts
+++ b/platform/daemon/src/db-accessor.ts
@@ -401,6 +401,10 @@ function readErrorMessage(err: unknown): string {
 	return err instanceof Error ? err.message : String(err);
 }
 
+function isMissingPathError(err: unknown): boolean {
+	return err instanceof Error && "code" in err && (err.code === "ENOENT" || err.code === "ENOTDIR");
+}
+
 function migrationBackups(
 	dbPath: string,
 	deps: MigrationBackupDeps,
@@ -410,7 +414,14 @@ function migrationBackups(
 	return deps
 		.readdirSync(dir)
 		.filter((f) => f.startsWith(`${base}.bak-v`))
-		.map((f) => ({ name: f, mtime: deps.statSync(join(dir, f)).mtimeMs }))
+		.flatMap((f) => {
+			try {
+				return [{ name: f, mtime: deps.statSync(join(dir, f)).mtimeMs }];
+			} catch (err) {
+				if (isMissingPathError(err)) return [];
+				throw err;
+			}
+		})
 		.sort((a, b) => b.mtime - a.mtime);
 }
 

--- a/platform/daemon/src/db-accessor.ts
+++ b/platform/daemon/src/db-accessor.ts
@@ -379,40 +379,96 @@ export function isVectorRuntimeUsable(): boolean {
 
 const MAX_MIGRATION_BACKUPS = 5;
 
+interface MigrationBackupDeps {
+	readonly copyFileSync: (source: string, destination: string) => void;
+	readonly readdirSync: (path: string) => string[];
+	readonly statSync: (path: string) => { readonly mtimeMs: number };
+	readonly unlinkSync: (path: string) => void;
+	readonly now: () => number;
+	readonly log: (message: string) => void;
+}
+
+const migrationBackupDeps: MigrationBackupDeps = {
+	copyFileSync,
+	readdirSync,
+	statSync,
+	unlinkSync,
+	now: Date.now,
+	log: console.log,
+};
+
+function readErrorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
+function migrationBackups(
+	dbPath: string,
+	deps: MigrationBackupDeps,
+): Array<{ readonly name: string; readonly mtime: number }> {
+	const dir = dirname(dbPath);
+	const base = basename(dbPath);
+	return deps
+		.readdirSync(dir)
+		.filter((f) => f.startsWith(`${base}.bak-v`))
+		.map((f) => ({ name: f, mtime: deps.statSync(join(dir, f)).mtimeMs }))
+		.sort((a, b) => b.mtime - a.mtime);
+}
+
+function pruneMigrationBackups(dbPath: string, keep: number, deps: MigrationBackupDeps): void {
+	const dir = dirname(dbPath);
+	for (const old of migrationBackups(dbPath, deps).slice(Math.max(0, keep))) {
+		try {
+			deps.unlinkSync(join(dir, old.name));
+			deps.log(`[db-accessor] Pruned old backup: ${old.name}`);
+		} catch {
+			// Best effort.
+		}
+	}
+}
+
 /**
  * Back up the database file before running migrations.
  * Flushes WAL first, then copies the main file. Prunes old
- * backups beyond MAX_MIGRATION_BACKUPS (oldest by mtime).
+ * backups before copying so a full backup set does not require
+ * temporary disk headroom for one extra database-sized file.
  */
-function backupBeforeMigration(db: Database, dbPath: string, schemaVersion: number): void {
-	// Flush WAL so the .db file is self-contained
+export function backupBeforeMigration(
+	db: { exec(sql: string): unknown },
+	dbPath: string,
+	schemaVersion: number,
+	deps: MigrationBackupDeps = migrationBackupDeps,
+): void {
+	// Flush WAL so the .db file is self-contained.
 	try {
 		db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
 	} catch {
-		// Non-fatal — backup still useful even with WAL
+		// Non-fatal — backup still useful even with WAL.
 	}
 
-	const timestamp = Date.now();
+	// Make room for the incoming backup first. Otherwise a user with exactly
+	// MAX_MIGRATION_BACKUPS retained backups needs space for an extra full DB
+	// copy before retention can help, which can brick daemon startup on ENOSPC.
+	pruneMigrationBackups(dbPath, MAX_MIGRATION_BACKUPS - 1, deps);
+
+	const timestamp = deps.now();
 	const backupDest = `${dbPath}.bak-v${schemaVersion}-${timestamp}`;
-	copyFileSync(dbPath, backupDest);
-	console.log(`[db-accessor] Pre-migration backup: ${backupDest}`);
-
-	// Prune old backups
-	const dir = dirname(dbPath);
-	const base = basename(dbPath);
-	const backups = readdirSync(dir)
-		.filter((f) => f.startsWith(`${base}.bak-v`))
-		.map((f) => ({ name: f, mtime: statSync(join(dir, f)).mtimeMs }))
-		.sort((a, b) => b.mtime - a.mtime);
-
-	for (const old of backups.slice(MAX_MIGRATION_BACKUPS)) {
+	try {
+		deps.copyFileSync(dbPath, backupDest);
+	} catch (err) {
 		try {
-			unlinkSync(join(dir, old.name));
-			console.log(`[db-accessor] Pruned old backup: ${old.name}`);
+			deps.unlinkSync(backupDest);
 		} catch {
-			// Best effort
+			// Best effort cleanup for partial copy files.
 		}
+		throw new Error(
+			`Failed to create pre-migration backup at ${backupDest}. ` +
+				`Free disk space and retry; the database was not migrated. Cause: ${readErrorMessage(err)}`,
+		);
 	}
+	deps.log(`[db-accessor] Pre-migration backup: ${backupDest}`);
+
+	// Final retention pass in case another process wrote backups concurrently.
+	pruneMigrationBackups(dbPath, MAX_MIGRATION_BACKUPS, deps);
 }
 
 /**


### PR DESCRIPTION
## Summary
- fixes daemon startup migration backups so retention pruning happens before copying the next full DB backup
- cleans up partial backup files if copy fails, and surfaces an actionable free-disk-space error instead of leaving corrupted backup artifacts
- adds regression coverage for pre-copy pruning and partial-copy cleanup

## Root cause
`signetai@0.113.1` was not failing because the daemon binary was missing or the port was blocked. Startup migration v65 needed to create a full `memories.db` backup (~1.3GB on the reported machine), but `/` had 0 bytes available. The backup retention logic pruned old backups only after successfully copying the new backup, so a workspace already at the retention limit still needed temporary headroom for one extra full DB-sized file. On `ENOSPC`, startup aborted and left partial `.bak-v65-*` files behind.

## Fix
- prune old migration backups down to `MAX_MIGRATION_BACKUPS - 1` before copying the new backup
- retain the final post-copy prune as a concurrency/race cleanup pass
- delete partial destination files when the copy fails
- wrap backup copy failures with an explicit “free disk space and retry; database was not migrated” message

## Test Plan
- [x] `bun run build:core`
- [x] `bun test platform/daemon/src/db-accessor.test.ts`
- [x] `git diff --check`
- [x] `bunx --bun biome check platform/daemon/src/db-accessor.ts platform/daemon/src/db-accessor.test.ts`
- [x] `bun run build:signetai`
- [x] Manual verification: local installed `signetai@0.113.1` daemon is running again after clearing disposable cache space and successful v65 backup

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes
- [x] No database migrations were added, removed, renumbered, or modified.
