### PR TITLE
fix(release): keep dev workspace links local

### DIFF
--- a/integrations/openclaw/memory-adapter/package.json
+++ b/integrations/openclaw/memory-adapter/package.json
@@ -36,8 +36,8 @@
     "@sinclair/typebox": "0.34.47"
   },
   "devDependencies": {
-    "@signet/core": "0.115.1",
-    "@signet/sdk": "0.115.1",
+    "@signet/core": "workspace:*",
+    "@signet/sdk": "workspace:*",
     "@types/node": "^22.0.0"
   },
   "peerDependencies": {

--- a/scripts/version-sync.test.ts
+++ b/scripts/version-sync.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { VERSION_SYNC_PACKAGE_GLOBS, collectCargoLockMismatches, findCargoLockPackageVersion } from "./version-sync";
+import {
+	VERSION_SYNC_PACKAGE_GLOBS,
+	collectCargoLockMismatches,
+	findCargoLockPackageVersion,
+	resolveWorkspaceProtocols,
+} from "./version-sync";
 
 describe("version-sync", () => {
 	test("keeps web workspace manifests out of Signet release version sync", () => {
@@ -29,6 +34,44 @@ dependencies = [
 
 		expect(findCargoLockPackageVersion(lock, "signet-daemon")).toBe("0.82.5");
 		expect(findCargoLockPackageVersion(lock, "signet-native")).toBeNull();
+	});
+
+	test("resolves publishable runtime workspace protocols without rewriting dev-only workspace links", () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-version-sync-publish-"));
+		try {
+			const manifest = join(root, "package.json");
+			writeFileSync(
+				manifest,
+				JSON.stringify(
+					{
+						name: "@signetai/test-publishable",
+						version: "0.1.0",
+						dependencies: { "@signet/runtime": "workspace:*" },
+						optionalDependencies: { "@signet/optional": "workspace:^" },
+						peerDependencies: { "@signet/peer": "workspace:~" },
+						devDependencies: { "@signet/core": "workspace:*", "@signet/sdk": "workspace:*" },
+						publishConfig: { access: "public" },
+					},
+					null,
+					2,
+				),
+			);
+
+			expect(resolveWorkspaceProtocols([manifest], "0.115.2", false)).toEqual([manifest]);
+			const updated = JSON.parse(readFileSync(manifest, "utf8")) as {
+				dependencies: Record<string, string>;
+				optionalDependencies: Record<string, string>;
+				peerDependencies: Record<string, string>;
+				devDependencies: Record<string, string>;
+			};
+			expect(updated.dependencies["@signet/runtime"]).toBe("0.115.2");
+			expect(updated.optionalDependencies["@signet/optional"]).toBe("^0.115.2");
+			expect(updated.peerDependencies["@signet/peer"]).toBe("~0.115.2");
+			expect(updated.devDependencies["@signet/core"]).toBe("workspace:*");
+			expect(updated.devDependencies["@signet/sdk"]).toBe("workspace:*");
+		} finally {
+			rmSync(root, { force: true, recursive: true });
+		}
 	});
 
 	test("flags stale Cargo.lock versions for workspace packages", () => {

--- a/scripts/version-sync.ts
+++ b/scripts/version-sync.ts
@@ -20,6 +20,7 @@ const FORGE_MANIFEST_FILES = [
 	"surfaces/cli/templates/forge/manifest.json",
 	"dist/signetai/templates/forge/manifest.json",
 ];
+const PUBLISH_RUNTIME_DEPENDENCY_FIELDS = ["dependencies", "optionalDependencies", "peerDependencies"] as const;
 
 function parseSemver(version: string): [number, number, number] {
 	const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
@@ -217,7 +218,20 @@ function regenerateCargoLock(cargoFile: string): void {
 	}
 }
 
-function resolveWorkspaceProtocols(files: readonly string[], version: string, checkOnly: boolean): string[] {
+function resolveWorkspaceSpec(spec: string, version: string): string {
+	switch (spec) {
+		case "workspace:*":
+			return version;
+		case "workspace:^":
+			return `^${version}`;
+		case "workspace:~":
+			return `~${version}`;
+		default:
+			return spec;
+	}
+}
+
+export function resolveWorkspaceProtocols(files: readonly string[], version: string, checkOnly: boolean): string[] {
 	const patched: string[] = [];
 	for (const file of files) {
 		const raw = readFileSync(file, "utf8");
@@ -225,14 +239,25 @@ function resolveWorkspaceProtocols(files: readonly string[], version: string, ch
 		// Only resolve for packages that will be published
 		if (!pkg.publishConfig || pkg.private) continue;
 
-		let changed = raw;
-		// Replace workspace: protocols with resolved versions
-		changed = changed.replace(/"workspace:\*"/g, `"${version}"`);
-		changed = changed.replace(/"workspace:\^"/g, `"^${version}"`);
-		changed = changed.replace(/"workspace:~"/g, `"~${version}"`);
-		if (changed !== raw) {
+		let changed = false;
+		// Replace workspace: protocols only in runtime dependency fields. Dev-only
+		// workspace links must stay local so the nightly release can run bun install
+		// before the newly bumped internal packages have been published.
+		for (const field of PUBLISH_RUNTIME_DEPENDENCY_FIELDS) {
+			const deps = pkg[field];
+			if (!deps || typeof deps !== "object" || Array.isArray(deps)) continue;
+			for (const [name, spec] of Object.entries(deps as Record<string, unknown>)) {
+				if (typeof spec !== "string") continue;
+				const resolved = resolveWorkspaceSpec(spec, version);
+				if (resolved !== spec) {
+					(deps as Record<string, unknown>)[name] = resolved;
+					changed = true;
+				}
+			}
+		}
+		if (changed) {
 			if (!checkOnly) {
-				writeFileSync(file, changed);
+				writeFileSync(file, `${JSON.stringify(pkg, null, 2)}\n`);
 			}
 			patched.push(file);
 		}


### PR DESCRIPTION
## Summary

Fixes the current `main` Nightly Release failure. The release job was bumping workspace package versions before publish, then running `bun install`. The OpenClaw memory adapter had dev-only `@signet/core` / `@signet/sdk` dependencies pinned to the just-current release version, so after the next bump Bun stopped treating them as local workspaces and tried to fetch unpublished `@signet/*` packages from npm.

## Changes

- Restores the OpenClaw memory adapter's Signet dev dependencies to `workspace:*` so release-time installs stay local before publish.
- Narrows `version-sync` workspace protocol resolution to publish runtime dependency fields only: `dependencies`, `optionalDependencies`, and `peerDependencies`.
- Adds a regression test proving publish runtime deps are resolved while dev-only workspace links remain local.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: release/version sync, OpenClaw memory adapter dev manifest

## Screenshots

N/A — release tooling only.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes

- [x] No database migrations were added, removed, renumbered, or modified.

## Testing

- [x] `bun install`
- [x] `bun test scripts/version-sync.test.ts tests/integration/version-consistency-workflow.test.ts scripts/check-publish-manifests.test.ts` — 14 pass / 0 fail
- [x] `bun scripts/version-sync.ts --check`
- [x] `bun scripts/check-publish-manifests.ts`
- [x] Simulated next release sync in a scratch worktree: `bun scripts/version-sync.ts --to 0.115.2 && bun install --frozen-lockfile`

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

This is a direct follow-up to the failed `Nightly Release` run on `main` at `2d8e4d581ff067df69aac0973589077594e297a6`, where `bun install` attempted to resolve unpublished `@signet/core@0.115.1` and `@signet/sdk@0.115.1` from npm during the version bump step.
