### PR TITLE
fix(hooks): avoid resumed summary artifact collisions

### DIFF
--- a/platform/daemon/src/hooks.test.ts
+++ b/platform/daemon/src/hooks.test.ts
@@ -1939,6 +1939,113 @@ describe("handleSessionEnd", () => {
 		expect(manifest).toContain('transcript_path: "memory/test/transcripts/transcript.jsonl"');
 	});
 
+	test.serial("resumed session-end with same harness session id gets distinct immutable artifact ids", async () => {
+		createMemoryDb([]);
+		const transcriptPath = join(TEST_DIR, "resumed-claude-transcript.txt");
+		const sessionKey = "claude-resumed-session";
+		const harnessSessionId = "reused-claude-uuid";
+		const project = "/home/user/signetai";
+
+		writeFileSync(
+			transcriptPath,
+			"User: first part asked about release channels.\nAssistant: first close summarized release-channel work.\n".repeat(
+				8,
+			),
+		);
+		expect(
+			(
+				await handleSessionEnd({
+					harness: "claude-code",
+					transcriptPath,
+					sessionKey,
+					sessionId: harnessSessionId,
+					cwd: project,
+				})
+			).queued,
+		).toBe(true);
+
+		writeFileSync(
+			transcriptPath,
+			"User: resumed part investigated daemon startup failures and backup pruning.\nAssistant: resumed close summarized daemon migration backup fixes.\n".repeat(
+				8,
+			),
+		);
+		expect(
+			(
+				await handleSessionEnd({
+					harness: "claude-code",
+					transcriptPath,
+					sessionKey,
+					sessionId: harnessSessionId,
+					cwd: project,
+				})
+			).queued,
+		).toBe(true);
+
+		const db = openTestDb();
+		try {
+			const jobs = db
+				.prepare(
+					`SELECT id, session_id, session_key, captured_at, transcript
+					 FROM summary_jobs
+					 WHERE session_key = ?
+					 ORDER BY rowid ASC`,
+				)
+				.all(sessionKey) as Array<{
+				id: string;
+				session_id: string;
+				session_key: string;
+				captured_at: string;
+				transcript: string;
+			}>;
+
+			expect(jobs).toHaveLength(2);
+			expect(jobs[0].session_key).toBe(sessionKey);
+			expect(jobs[1].session_key).toBe(sessionKey);
+			expect(jobs[0].session_id).not.toBe(harnessSessionId);
+			expect(jobs[1].session_id).not.toBe(harnessSessionId);
+			expect(jobs[0].session_id).not.toBe(jobs[1].session_id);
+			expect(jobs[0].session_id).toStartWith(`session-end:path:${transcriptPath}:`);
+			expect(jobs[1].session_id).toStartWith(`session-end:path:${transcriptPath}:`);
+
+			await writeSummaryArtifact({
+				agentId: "default",
+				sessionId: jobs[0].session_id,
+				sessionKey,
+				project,
+				harness: "claude-code",
+				capturedAt: jobs[0].captured_at,
+				startedAt: null,
+				endedAt: jobs[0].captured_at,
+				summary: "# First resumed session notes\n\nFirst close content.",
+				provider: null,
+			});
+			await writeSummaryArtifact({
+				agentId: "default",
+				sessionId: jobs[1].session_id,
+				sessionKey,
+				project,
+				harness: "claude-code",
+				capturedAt: jobs[1].captured_at,
+				startedAt: null,
+				endedAt: jobs[1].captured_at,
+				summary: "# Second resumed session notes\n\nDifferent close content.",
+				provider: null,
+			});
+
+			const summaries = db
+				.prepare(
+					`SELECT COUNT(*) AS count
+					 FROM memory_artifacts
+					 WHERE session_key = ? AND source_kind = 'summary'`,
+				)
+				.get(sessionKey) as { count: number };
+			expect(summaries.count).toBe(2);
+		} finally {
+			db.close();
+		}
+	});
+
 	test.serial("defers canonical JSONL rewrite until after session-end response", async () => {
 		createMemoryDb([]);
 		const transcriptPath = join(TEST_DIR, "deferred-canonical-transcript.txt");

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -3091,17 +3091,21 @@ export async function handleSessionEnd(req: SessionEndRequest): Promise<SessionE
 	// storage must preserve the full canonical transcript.
 	const retainedTranscript = transcript;
 
-	// Derive a stable session identity for artifact paths.  When the
-	// transcript is empty and no explicit sessionId was provided,
-	// deriveSessionEndFallbackId returns a random UUID — making this call
-	// non-idempotent.  This is acceptable because: (a) empty-transcript
-	// sessions skip the transcript artifact write (guard below) and the
-	// summary job (< 500 char guard), so no ghost artifacts accumulate;
-	// (b) very short (1–499 char) transcripts do write a transcript
-	// artifact with a non-deterministic path, but the summary job is
-	// still skipped, limiting blast radius.
-	const sessionId =
-		req.sessionId?.trim() || deriveSessionEndFallbackId(sessionKey, req.transcriptPath, retainedTranscript);
+	// Derive a session-end artifact identity from the stable harness identity
+	// plus transcript path/content. Some harnesses reuse the same sessionId
+	// when a conversation is resumed; raw reuse would make immutable summary
+	// artifacts collide with an earlier close of the same conversation.
+	// `sessionKey` remains the continuity/grouping key, while this sessionId is
+	// the immutable artifact identity for this particular session-end snapshot.
+	// When the transcript is empty, deriveSessionEndFallbackId returns a random
+	// UUID; empty sessions skip summaries and transcript artifacts below, and
+	// very short transcript artifacts intentionally prefer uniqueness over
+	// mutating a prior immutable artifact.
+	const sessionId = deriveSessionEndFallbackId(
+		req.sessionId?.trim() || sessionKey,
+		req.transcriptPath,
+		retainedTranscript,
+	);
 
 	// Lossless retention: keep the live transcript snapshot available to
 	// subsequent hook calls before returning. The heavier canonical JSONL


### PR DESCRIPTION
## Summary
- Fix session-end artifact identity for resumed harness sessions that reuse the same `sessionId`.
- Preserve the raw harness/session continuity in `sessionKey`, but derive immutable summary/transcript artifact identity from harness session id + transcript path/content.
- Add a regression test that simulates Claude Code resume reusing the same session id and verifies distinct immutable summary artifacts are written.

Fixes #658.

## Testing
- `bun run build:core`
- `bun test platform/daemon/src/hooks.test.ts --filter 'resumed session-end with same harness session id gets distinct immutable artifact ids'`
  - Note: Bun ran the full `hooks.test.ts` file despite the filter: 170 pass / 0 fail.
- `bunx --bun biome check platform/daemon/src/hooks.ts platform/daemon/src/hooks.test.ts`
- `git diff --check`
- `bun run build:connector-base`
- `bun run build:opencode-plugin`
- `bun run build:deps`
- `bun run build:oh-my-pi-extension`
- `bun run build:connector-oh-my-pi`
- `bun run build:pi-extension`
- `bun run build:connector-pi`
- `bun run build:signetai`
- YAML parse of `docs/specs/dependencies.yaml`

## Readiness Checklist
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally
