### PR TITLE
fix(daemon): bound ontology constellation graph reads

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -3474,6 +3474,17 @@ signet knowledge attributes Nicholai food restaurants favorite_restaurant --stat
 signet knowledge hygiene
 ```
 
+### GET /api/knowledge/constellation
+
+Return the bounded graph overlay used by the dashboard Ontology constellation.
+Query parameters: `agent_id`, `limit`, `max_aspects_per_entity`,
+`max_attributes_per_aspect`, and `dependency_limit`. The daemon clamps these
+limits so dashboard navigation cannot load the entire knowledge graph into one
+read response.
+
+Defaults: `limit=150`, `max_aspects_per_entity=6`,
+`max_attributes_per_aspect=4`, and `dependency_limit=500`.
+
 ### GET /api/knowledge/hygiene
 
 Return a report-only graph hygiene scan. Query parameters: `agent_id`, `limit`,

--- a/platform/daemon/src/knowledge-graph-list.test.ts
+++ b/platform/daemon/src/knowledge-graph-list.test.ts
@@ -259,9 +259,13 @@ describe("listKnowledgeEntities (issue #515)", () => {
 		seedEntity("e-hidden", "Hidden", { mentions: 0 });
 		seedAspect("asp-hub-a", "e-hub", "alpha");
 		seedAspect("asp-hub-b", "e-hub", "beta");
+		seedAspect("asp-hub-c", "e-hub", "gamma");
+		seedAspect("asp-hub-d", "e-hub", "delta");
 		seedAspect("asp-hidden", "e-hidden", "hidden");
 		seedAttribute("attr-hub-a-1", "asp-hub-a", { content: "important alpha", memoryId: "mem-a" });
 		seedAttribute("attr-hub-a-2", "asp-hub-a", { content: "less important alpha" });
+		seedAttribute("attr-hub-a-3", "asp-hub-a", { content: "third alpha" });
+		seedAttribute("attr-hub-a-4", "asp-hub-a", { content: "fourth alpha" });
 		seedAttribute("attr-hidden", "asp-hidden", { content: "hidden attr" });
 		seedDependency("dep-visible", "e-hub", "e-leaf", { strength: 0.9 });
 		seedDependency("dep-hidden", "e-hub", "e-hidden", { strength: 0.8 });

--- a/platform/daemon/src/knowledge-graph-list.test.ts
+++ b/platform/daemon/src/knowledge-graph-list.test.ts
@@ -13,7 +13,12 @@ import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
-import { getKnowledgeEntityDetail, getKnowledgeStats, listKnowledgeEntities } from "./knowledge-graph";
+import {
+	getKnowledgeEntityDetail,
+	getKnowledgeGraphForConstellation,
+	getKnowledgeStats,
+	listKnowledgeEntities,
+} from "./knowledge-graph";
 
 function makeDbPath(): string {
 	const dir = join(tmpdir(), `signet-kg-list-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -243,6 +248,36 @@ describe("listKnowledgeEntities (issue #515)", () => {
 
 		expect(mainScope.map((r) => r.entity.id)).toEqual(["e-main"]);
 		expect(defaultScope.map((r) => r.entity.id)).toEqual(["e-def"]);
+	});
+
+	test("builds a bounded constellation graph without loading every graph row", () => {
+		dbPath = makeDbPath();
+		initDbAccessor(dbPath);
+
+		seedEntity("e-hub", "Hub", { mentions: 10 });
+		seedEntity("e-leaf", "Leaf", { mentions: 9 });
+		seedEntity("e-hidden", "Hidden", { mentions: 0 });
+		seedAspect("asp-hub-a", "e-hub", "alpha");
+		seedAspect("asp-hub-b", "e-hub", "beta");
+		seedAspect("asp-hidden", "e-hidden", "hidden");
+		seedAttribute("attr-hub-a-1", "asp-hub-a", { content: "important alpha", memoryId: "mem-a" });
+		seedAttribute("attr-hub-a-2", "asp-hub-a", { content: "less important alpha" });
+		seedAttribute("attr-hidden", "asp-hidden", { content: "hidden attr" });
+		seedDependency("dep-visible", "e-hub", "e-leaf", { strength: 0.9 });
+		seedDependency("dep-hidden", "e-hub", "e-hidden", { strength: 0.8 });
+
+		const graph = getKnowledgeGraphForConstellation(getDbAccessor(), "default", {
+			limit: 2,
+			maxAspectsPerEntity: 1,
+			maxAttributesPerAspect: 1,
+			dependencyLimit: 10,
+		});
+
+		expect(graph.entities.map((entity) => entity.id)).toEqual(["e-hub", "e-leaf"]);
+		expect(graph.entities[0].aspects.map((aspect) => aspect.id)).toEqual(["asp-hub-a"]);
+		expect(graph.entities[0].aspects[0].attributes.map((attr) => attr.id)).toEqual(["attr-hub-a-1"]);
+		expect(graph.dependencies.map((dependency) => dependency.sourceEntityId)).toEqual(["e-hub"]);
+		expect(graph.dependencies.map((dependency) => dependency.targetEntityId)).toEqual(["e-leaf"]);
 	});
 });
 

--- a/platform/daemon/src/knowledge-graph.ts
+++ b/platform/daemon/src/knowledge-graph.ts
@@ -1860,11 +1860,16 @@ export function getKnowledgeGraphForConstellation(
 		const aspectRows = db
 			.prepare(
 				`SELECT id, entity_id, name, weight
-				 FROM entity_aspects
-				 WHERE agent_id = ? AND entity_id IN (${entityIdPlaceholders})
+				 FROM (
+				   SELECT id, entity_id, name, weight,
+				          ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY weight DESC, name ASC) AS rn
+				   FROM entity_aspects
+				   WHERE agent_id = ? AND entity_id IN (${entityIdPlaceholders})
+				 ) ranked_aspects
+				 WHERE rn <= ?
 				 ORDER BY entity_id ASC, weight DESC, name ASC`,
 			)
-			.all(agentId, ...entityIds) as Array<Record<string, unknown>>;
+			.all(agentId, ...entityIds, maxAspectsPerEntity) as Array<Record<string, unknown>>;
 
 		const aspectsByEntity = new Map<
 			string,
@@ -1898,11 +1903,16 @@ export function getKnowledgeGraphForConstellation(
 			const attrRows = db
 				.prepare(
 					`SELECT id, aspect_id, content, kind, importance, memory_id
-					 FROM entity_attributes
-					 WHERE agent_id = ? AND status = 'active' AND aspect_id IN (${aspectIdPlaceholders})
+					 FROM (
+					   SELECT id, aspect_id, content, kind, importance, memory_id,
+					          ROW_NUMBER() OVER (PARTITION BY aspect_id ORDER BY importance DESC, id ASC) AS rn
+					   FROM entity_attributes
+					   WHERE agent_id = ? AND status = 'active' AND aspect_id IN (${aspectIdPlaceholders})
+					 ) ranked_attributes
+					 WHERE rn <= ?
 					 ORDER BY aspect_id ASC, importance DESC`,
 				)
-				.all(agentId, ...aspectIds) as Array<Record<string, unknown>>;
+				.all(agentId, ...aspectIds, maxAttributesPerAspect) as Array<Record<string, unknown>>;
 
 			for (const row of attrRows) {
 				const aspectId = row.aspect_id as string;

--- a/platform/daemon/src/knowledge-graph.ts
+++ b/platform/daemon/src/knowledge-graph.ts
@@ -1808,26 +1808,46 @@ export interface ConstellationGraph {
 	readonly dependencies: readonly ConstellationDependency[];
 }
 
-export function getKnowledgeGraphForConstellation(accessor: DbAccessor, agentId: string): ConstellationGraph {
+export interface ConstellationGraphOptions {
+	readonly limit?: number;
+	readonly maxAspectsPerEntity?: number;
+	readonly maxAttributesPerAspect?: number;
+	readonly dependencyLimit?: number;
+}
+
+function boundedInteger(value: number | undefined, fallback: number, min: number, max: number): number {
+	return Number.isFinite(value) ? Math.min(Math.max(Math.trunc(value as number), min), max) : fallback;
+}
+
+function placeholders(count: number): string {
+	return Array.from({ length: count }, () => "?").join(", ");
+}
+
+export function getKnowledgeGraphForConstellation(
+	accessor: DbAccessor,
+	agentId: string,
+	options: ConstellationGraphOptions = {},
+): ConstellationGraph {
+	const limit = boundedInteger(options.limit, 150, 1, 300);
+	const maxAspectsPerEntity = boundedInteger(options.maxAspectsPerEntity, 6, 1, 25);
+	const maxAttributesPerAspect = boundedInteger(options.maxAttributesPerAspect, 4, 1, 20);
+	const dependencyLimit = boundedInteger(options.dependencyLimit, 500, 1, 2000);
+
 	return accessor.withReadDb((db) => {
-		// 1. Fetch filtered entities: mentions > 0 OR pinned OR has aspects, LIMIT 500
+		// Keep the dashboard read path bounded. The previous implementation loaded
+		// every aspect, active attribute, and dependency for the agent, then filtered
+		// in JS. Large real workspaces can turn a simple Ontology tab visit into an
+		// event-loop/RSS spike big enough for systemd to SIGKILL the daemon.
 		const entityRows = db
 			.prepare(
 				`SELECT e.id, e.name, e.entity_type, e.mentions, e.pinned
 				 FROM entities e
 				 WHERE e.agent_id = ?
-				   AND (
-				     e.mentions > 0
-				     OR e.pinned = 1
-				     OR EXISTS (
-				       SELECT 1 FROM entity_aspects asp
-				       WHERE asp.entity_id = e.id AND asp.agent_id = e.agent_id
-				     )
-				   )
+				   AND (e.mentions > 0 OR e.pinned = 1)
 				 ORDER BY e.pinned DESC, e.mentions DESC, e.name ASC
-				 LIMIT 500`,
+				 LIMIT ?`,
 			)
-			.all(agentId) as Array<Record<string, unknown>>;
+			.all(agentId, limit) as Array<Record<string, unknown>>;
 
 		const entityIds = entityRows.map((r) => r.id as string).filter((id) => typeof id === "string");
 
@@ -1835,16 +1855,16 @@ export function getKnowledgeGraphForConstellation(accessor: DbAccessor, agentId:
 			return { entities: [], dependencies: [] };
 		}
 
-		// 2. Batch-fetch aspects for those entity IDs
 		const entityIdSet = new Set(entityIds);
+		const entityIdPlaceholders = placeholders(entityIds.length);
 		const aspectRows = db
 			.prepare(
 				`SELECT id, entity_id, name, weight
 				 FROM entity_aspects
-				 WHERE agent_id = ?
-				 ORDER BY weight DESC, name ASC`,
+				 WHERE agent_id = ? AND entity_id IN (${entityIdPlaceholders})
+				 ORDER BY entity_id ASC, weight DESC, name ASC`,
 			)
-			.all(agentId) as Array<Record<string, unknown>>;
+			.all(agentId, ...entityIds) as Array<Record<string, unknown>>;
 
 		const aspectsByEntity = new Map<
 			string,
@@ -1854,14 +1874,15 @@ export function getKnowledgeGraphForConstellation(accessor: DbAccessor, agentId:
 				weight: number;
 			}>
 		>();
-		const aspectIdSet = new Set<string>();
+		const aspectIds: string[] = [];
 
 		for (const row of aspectRows) {
 			const entityId = row.entity_id as string;
 			if (!entityIdSet.has(entityId)) continue;
-			const aspectId = row.id as string;
-			aspectIdSet.add(aspectId);
 			const bucket = aspectsByEntity.get(entityId) ?? [];
+			if (bucket.length >= maxAspectsPerEntity) continue;
+			const aspectId = row.id as string;
+			aspectIds.push(aspectId);
 			bucket.push({
 				id: aspectId,
 				name: row.name as string,
@@ -1870,32 +1891,35 @@ export function getKnowledgeGraphForConstellation(accessor: DbAccessor, agentId:
 			aspectsByEntity.set(entityId, bucket);
 		}
 
-		// 3. Batch-fetch active attributes for those aspect IDs
-		const attrRows = db
-			.prepare(
-				`SELECT id, aspect_id, content, kind, importance, memory_id
-				 FROM entity_attributes
-				 WHERE agent_id = ? AND status = 'active'
-				 ORDER BY importance DESC`,
-			)
-			.all(agentId) as Array<Record<string, unknown>>;
-
 		const attrsByAspect = new Map<string, ConstellationAttribute[]>();
-		for (const row of attrRows) {
-			const aspectId = row.aspect_id as string;
-			if (!aspectIdSet.has(aspectId)) continue;
-			const bucket = attrsByAspect.get(aspectId) ?? [];
-			bucket.push({
-				id: row.id as string,
-				content: row.content as string,
-				kind: row.kind as "attribute" | "constraint",
-				importance: Number(row.importance ?? 0.5),
-				memoryId: typeof row.memory_id === "string" ? row.memory_id : null,
-			});
-			attrsByAspect.set(aspectId, bucket);
+		if (aspectIds.length > 0) {
+			const aspectIdSet = new Set(aspectIds);
+			const aspectIdPlaceholders = placeholders(aspectIds.length);
+			const attrRows = db
+				.prepare(
+					`SELECT id, aspect_id, content, kind, importance, memory_id
+					 FROM entity_attributes
+					 WHERE agent_id = ? AND status = 'active' AND aspect_id IN (${aspectIdPlaceholders})
+					 ORDER BY aspect_id ASC, importance DESC`,
+				)
+				.all(agentId, ...aspectIds) as Array<Record<string, unknown>>;
+
+			for (const row of attrRows) {
+				const aspectId = row.aspect_id as string;
+				if (!aspectIdSet.has(aspectId)) continue;
+				const bucket = attrsByAspect.get(aspectId) ?? [];
+				if (bucket.length >= maxAttributesPerAspect) continue;
+				bucket.push({
+					id: row.id as string,
+					content: row.content as string,
+					kind: row.kind as "attribute" | "constraint",
+					importance: Number(row.importance ?? 0.5),
+					memoryId: typeof row.memory_id === "string" ? row.memory_id : null,
+				});
+				attrsByAspect.set(aspectId, bucket);
+			}
 		}
 
-		// Assemble entities with nested aspects and attributes
 		const entities: ConstellationEntity[] = entityRows.map((row) => {
 			const eid = row.id as string;
 			const aspects: ConstellationAspect[] = (aspectsByEntity.get(eid) ?? []).map((asp) => ({
@@ -1914,25 +1938,24 @@ export function getKnowledgeGraphForConstellation(accessor: DbAccessor, agentId:
 			};
 		});
 
-		// 4. Fetch dependencies where both source and target are in the entity set
 		const depRows = db
 			.prepare(
 				`SELECT source_entity_id, target_entity_id, dependency_type, strength
 				 FROM entity_dependencies
-				 WHERE agent_id = ?`,
+				 WHERE agent_id = ?
+				   AND source_entity_id IN (${entityIdPlaceholders})
+				   AND target_entity_id IN (${entityIdPlaceholders})
+				 ORDER BY strength DESC
+				 LIMIT ?`,
 			)
-			.all(agentId) as Array<Record<string, unknown>>;
+			.all(agentId, ...entityIds, ...entityIds, dependencyLimit) as Array<Record<string, unknown>>;
 
-		const dependencies: ConstellationDependency[] = depRows
-			.filter(
-				(row) => entityIdSet.has(row.source_entity_id as string) && entityIdSet.has(row.target_entity_id as string),
-			)
-			.map((row) => ({
-				sourceEntityId: row.source_entity_id as string,
-				targetEntityId: row.target_entity_id as string,
-				dependencyType: row.dependency_type as string,
-				strength: Number(row.strength ?? 0.5),
-			}));
+		const dependencies: ConstellationDependency[] = depRows.map((row) => ({
+			sourceEntityId: row.source_entity_id as string,
+			targetEntityId: row.target_entity_id as string,
+			dependencyType: row.dependency_type as string,
+			strength: Number(row.strength ?? 0.5),
+		}));
 
 		return { entities, dependencies };
 	});

--- a/platform/daemon/src/routes/knowledge-routes.ts
+++ b/platform/daemon/src/routes/knowledge-routes.ts
@@ -312,7 +312,14 @@ export function registerKnowledgeRoutes(app: Hono): void {
 
 	app.get("/api/knowledge/constellation", (c) => {
 		const agentId = c.req.query("agent_id") ?? "default";
-		return c.json(getKnowledgeGraphForConstellation(getDbAccessor(), agentId));
+		return c.json(
+			getKnowledgeGraphForConstellation(getDbAccessor(), agentId, {
+				limit: parseNavigationLimit(c.req.query("limit"), 150, 300),
+				maxAspectsPerEntity: parseNavigationLimit(c.req.query("max_aspects_per_entity"), 6, 25),
+				maxAttributesPerAspect: parseNavigationLimit(c.req.query("max_attributes_per_aspect"), 4, 20),
+				dependencyLimit: parseNavigationLimit(c.req.query("dependency_limit"), 500, 2000),
+			}),
+		);
 	});
 
 	app.post("/api/knowledge/expand", async (c) => {

--- a/surfaces/dashboard/src/lib/api.ts
+++ b/surfaces/dashboard/src/lib/api.ts
@@ -2767,7 +2767,7 @@ export interface ConstellationGraph {
 
 export async function getConstellationOverlay(agentId: string): Promise<ConstellationGraph | null> {
 	try {
-		const path = `${API_BASE}/api/knowledge/constellation?agent_id=${encodeURIComponent(agentId)}`;
+		const path = `${API_BASE}/api/knowledge/constellation?agent_id=${encodeURIComponent(agentId)}&limit=150&max_aspects_per_entity=6&max_attributes_per_aspect=4&dependency_limit=500`;
 		const res = await fetch(path);
 		if (!res.ok) return null;
 		return (await res.json()) as ConstellationGraph;


### PR DESCRIPTION
## Summary

- Bounds `/api/knowledge/constellation` so Ontology dashboard navigation cannot load the full knowledge graph into one response.
- Changes constellation assembly to query only the selected entity and aspect IDs, with clamps for entity count, aspects per entity, attributes per aspect, and dependencies.
- Updates the dashboard client to request the bounded overlay defaults and documents the new query parameters.
- Adds a regression test proving the constellation graph respects these caps and does not include rows outside the bounded entity set.

## Context

On a real workspace, opening the dashboard Ontology tab made `/api/knowledge/constellation` load all aspects, active attributes, and dependencies for the agent before filtering in JS. That read path timed out, stalled `/api/status`, and could push the daemon into a systemd `SIGKILL` with high peak RSS. This keeps the visual overview useful while making the read path predictable under large graphs.

## Validation

- [x] `bun run build:core`
- [x] `bun test platform/daemon/src/knowledge-graph-list.test.ts platform/daemon/src/knowledge-navigation.test.ts`
- [x] `bunx biome check platform/daemon/src/knowledge-graph.ts platform/daemon/src/routes/knowledge-routes.ts platform/daemon/src/knowledge-graph-list.test.ts surfaces/dashboard/src/lib/api.ts docs/API.md`
- [x] `git diff --check`
- [x] Live smoke on Nicholai's workspace after hotpatch: `/api/knowledge/constellation` returned 150 entities and 500 dependencies in about 65ms, and `/api/status` stayed responsive.

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes
- [x] No database migrations were added, removed, renumbered, or modified.
