### PR TITLE
fix(acpx): use claude connector for Claude Code

### DIFF
--- a/docs/ACP-INTEGRATION.md
+++ b/docs/ACP-INTEGRATION.md
@@ -74,7 +74,7 @@ inference:
     background-acpx:
       executor: acpx
       acpx:
-        agent: codex          # codex, claude-code, opencode, or another ACPX agent
+        agent: codex          # codex, claude (Claude Code), opencode, or another ACPX agent
         version: "0.7.0"      # pinned by default
         mode: exec            # current default: one-shot exec
         permissions: deny-all
@@ -172,7 +172,7 @@ ACPX target config lives under `inference.targets.<name>.acpx`.
 
 | Field | Type | Description |
 |---|---|---|
-| `agent` | string | ACPX agent command, for example `codex`, `claude-code`, or `opencode`. |
+| `agent` | string | ACPX agent command, for example `codex`, `claude` for Claude Code, or `opencode`. Legacy `claude-code` values are normalized to `claude` before spawning ACPX. |
 | `version` / `acpxVersion` | string | ACPX npm package version. Defaults to Signet's pinned `0.7.0`. |
 | `bin` | string | Optional executable override. If omitted, Signet runs `npx -y acpx@<version>`. |
 | `cwd` | string | Working directory for ACPX and the harness. |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -401,7 +401,7 @@ subscription-backed CLI session, or gateway.
 | `account` | string | Account id from `inference.accounts` |
 | `endpoint` | string | Optional base URL override |
 | `command` | object | Command executor config with `bin`, optional `args`, `cwd`, and `env` |
-| `agent` | string | For `executor: acpx`, the harness adapter to run, for example `codex`, `claude-code`, or `opencode` |
+| `agent` | string | For `executor: acpx`, the ACPX adapter command to run, for example `codex`, `claude` for Claude Code, or `opencode`. Signet normalizes legacy `claude-code` values to ACPX's `claude` command. |
 | `acpxVersion` / `version` | string | Optional ACPX package version. Defaults to Signet's pinned ACPX version |
 | `mode` | string | Optional ACPX execution mode. Defaults to one-shot exec |
 | `cwd` | string | Optional working directory for harness execution |

--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -317,6 +317,31 @@ printf 'ok\n'
 		}
 	});
 
+	it("maps the legacy claude-code agent alias to ACPX's claude command", async () => {
+		const root = join(tmpdir(), `signet-acpx-claude-alias-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(root, { recursive: true });
+		const bin = join(root, "fake-bunx.sh");
+		const argsPath = join(root, "args.json");
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+printf '%s\n' "$@" > ${JSON.stringify(argsPath)}
+printf 'ok\n'
+`,
+		);
+		chmodSync(bin, 0o755);
+		try {
+			const provider = createAcpxProvider({ agent: "claude-code", bin, package: "acpx@0.7.0", hooks: "disabled" });
+			await expect(provider.generate("hello", { timeoutMs: 1000 })).resolves.toBe("ok");
+			const args = readFileSync(argsPath, "utf-8").trim().split("\n");
+			expect(args).toContain("claude");
+			expect(args).not.toContain("claude-code");
+			expect(args.slice(args.indexOf("claude"))).toEqual(["claude", "exec", "--file", "-"]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("normalizes relative ACPX cwd before spawning and forwarding --cwd", async () => {
 		const root = join(tmpdir(), `signet-acpx-cwd-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		mkdirSync(join(root, "workspace"), { recursive: true });

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -982,6 +982,10 @@ export interface AcpxProviderConfig {
 
 const DEFAULT_ACPX_VERSION = "0.7.0";
 
+function normalizeAcpxAgent(agent: string): string {
+	return agent === "claude-code" ? "claude" : agent;
+}
+
 function acpxPermissionArgs(mode: AcpxPermissionMode | undefined): string[] {
 	switch (mode) {
 		case "deny-all":
@@ -1034,7 +1038,7 @@ function buildAcpxCommand(
 	if (config.terminal === "disabled") args.push("--no-terminal");
 	if (config.allowedTools) args.push("--allowed-tools", config.allowedTools.join(","));
 	args.push(...(config.extraArgs ?? []));
-	args.push(config.agent);
+	args.push(normalizeAcpxAgent(config.agent));
 	if ((config.mode ?? "exec") === "session" && config.session) {
 		args.push("-s", config.session);
 	}

--- a/surfaces/cli/src/features/setup-pipeline.test.ts
+++ b/surfaces/cli/src/features/setup-pipeline.test.ts
@@ -87,11 +87,23 @@ describe("buildSetupInference", () => {
 		});
 	});
 
-	it("selects ACPX agent from detected providers when no harness was selected", () => {
-		const inference = buildSetupInference("acpx", "haiku", [], ["acpx", "claude-code"], "/usr/local/bin/bunx");
-		expect(inference?.targets["background-acpx"]).toMatchObject({
+	it("maps Claude Code harness/provider selection to ACPX's claude connector", () => {
+		const fromHarness = buildSetupInference("acpx", "haiku", ["claude-code"], ["acpx"], "/usr/local/bin/bunx");
+		expect(fromHarness?.targets["background-acpx"]).toMatchObject({
 			executor: "acpx",
-			acpx: { agent: "claude-code" },
+			acpx: { agent: "claude" },
+		});
+
+		const fromDetectedProvider = buildSetupInference(
+			"acpx",
+			"haiku",
+			[],
+			["acpx", "claude-code"],
+			"/usr/local/bin/bunx",
+		);
+		expect(fromDetectedProvider?.targets["background-acpx"]).toMatchObject({
+			executor: "acpx",
+			acpx: { agent: "claude" },
 		});
 	});
 	it("does not emit ACPX routing without a resolved launcher", () => {

--- a/surfaces/cli/src/features/setup-pipeline.ts
+++ b/surfaces/cli/src/features/setup-pipeline.ts
@@ -83,15 +83,21 @@ export interface SetupInferenceConfig {
 	readonly workloads: Record<string, unknown>;
 }
 
+type SetupAcpxAgent = "codex" | "claude" | "opencode";
+
+function toAcpxAgent(provider: Extract<HarnessChoice, "codex" | "claude-code" | "opencode">): SetupAcpxAgent {
+	return provider === "claude-code" ? "claude" : provider;
+}
+
 function selectAcpxAgent(
 	harnesses: readonly string[],
 	availableProviders: readonly ExtractionProviderChoice[] = [],
-): Extract<HarnessChoice, "codex" | "claude-code" | "opencode"> {
+): SetupAcpxAgent {
 	for (const harness of harnesses) {
-		if (harness === "codex" || harness === "claude-code" || harness === "opencode") return harness;
+		if (harness === "codex" || harness === "claude-code" || harness === "opencode") return toAcpxAgent(harness);
 	}
 	for (const provider of availableProviders) {
-		if (provider === "codex" || provider === "claude-code" || provider === "opencode") return provider;
+		if (provider === "codex" || provider === "claude-code" || provider === "opencode") return toAcpxAgent(provider);
 	}
 	return "codex";
 }


### PR DESCRIPTION
## Summary
- Fixes setup-generated ACPX routing for Claude Code by writing ACPX's `claude` connector command instead of the harness name `claude-code`.
- Normalizes existing `claude-code` ACPX config at spawn time so already-generated configs do not keep failing with `Failed to spawn agent command: claude-code`.
- Updates ACPX configuration docs to distinguish Signet's Claude Code harness name from ACPX's `claude` adapter command.

Fixes #664

## Test Plan
- [x] `npm view acpx@0.7.0 version bin --json`
- [x] `npx -y acpx@0.7.0 --help` confirms the `claude` command is available and `claude-code` is not listed
- [x] `./node_modules/.bin/biome check surfaces/cli/src/features/setup-pipeline.ts surfaces/cli/src/features/setup-pipeline.test.ts platform/daemon/src/pipeline/provider.ts`
- [x] `bun test surfaces/cli/src/features/setup-pipeline.test.ts platform/daemon/src/pipeline/provider.test.ts --test-name-pattern 'ACPX|acpx|Claude Code|claude-code|claude connector|legacy claude-code'`
- [x] `bun test surfaces/cli/src/features/setup-pipeline.test.ts platform/daemon/src/pipeline/provider.test.ts`
- [x] `bun run build:core`
- [x] `bun scripts/spec-deps-check.ts`
- [x] `git diff --check`

Note: broad Biome on `platform/daemon/src/pipeline/provider.test.ts` still reports pre-existing formatting/lint findings outside this patch; targeted tests for that file pass.

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes
- [x] No database migrations were added, removed, renumbered, or modified.
