### PR TITLE
fix(pipeline): isolate background acpx summaries

### DIFF
--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -83,15 +83,8 @@ function withParentSession(
 			return new Response(null, { status: 200 });
 		}
 		// Route parent session creation to a fixed response
-		if (
-			init?.method === "POST" &&
-			url.includes("/session") &&
-			!url.includes("/message")
-		) {
-			const body =
-				typeof init.body === "string"
-					? (JSON.parse(init.body) as Record<string, unknown>)
-					: {};
+		if (init?.method === "POST" && url.includes("/session") && !url.includes("/message")) {
+			const body = typeof init.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : {};
 			if (body.title === "signet-system") {
 				return Response.json({
 					id: "ses_parent",
@@ -129,16 +122,20 @@ describe("createAcpxProvider", () => {
 		const argsPath = join(root, "args.json");
 		const promptPath = join(root, "prompt.txt");
 		const hooksPath = join(root, "hooks.txt");
+		const cwdPath = join(root, "cwd.txt");
 		writeFileSync(
 			bin,
 			`#!/usr/bin/env bash
 printf '%s\n' "$@" > ${JSON.stringify(argsPath)}
+printf '%s' "$PWD" > ${JSON.stringify(cwdPath)}
 cat > ${JSON.stringify(promptPath)}
 printf '%s' "\${SIGNET_NO_HOOKS:-}" > ${JSON.stringify(hooksPath)}
 printf '  acpx answer  \\n'
 `,
 		);
 		chmodSync(bin, 0o755);
+		const previousSignetPath = process.env.SIGNET_PATH;
+		process.env.SIGNET_PATH = root;
 		try {
 			const provider = createAcpxProvider({
 				agent: "codex",
@@ -157,19 +154,55 @@ printf '  acpx answer  \\n'
 			expect(args).toContain("quiet");
 			expect(args).toContain("--deny-all");
 			expect(args).toContain("--no-terminal");
+			expect(args).toContain("--allowed-tools");
+			expect(args[args.indexOf("--allowed-tools") + 1]).toBe("read_file");
 			expect(args).toContain("codex");
 			const agentIndex = args.indexOf("codex");
-			expect(args.slice(agentIndex)).toEqual([
-				"codex",
-				"-s",
-				"background",
-				"exec",
-				"--file",
-				"-",
-			]);
+			expect(args.slice(agentIndex)).toEqual(["codex", "-s", "background", "exec", "--file", "-"]);
 			expect(readFileSync(promptPath, "utf-8")).toBe("hello acpx");
 			expect(readFileSync(hooksPath, "utf-8")).toBe("1");
+			expect(readFileSync(cwdPath, "utf-8")).toBe(join(root, ".daemon", "acpx-background"));
 		} finally {
+			if (previousSignetPath === undefined) Reflect.deleteProperty(process.env, "SIGNET_PATH");
+			else process.env.SIGNET_PATH = previousSignetPath;
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("defaults hook-disabled ACPX background runs to a sterile cwd and empty tool catalog", async () => {
+		const root = join(tmpdir(), `signet-acpx-isolated-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(root, { recursive: true });
+		const bin = join(root, "fake-acpx-isolated.sh");
+		const argsPath = join(root, "args.json");
+		const cwdPath = join(root, "cwd.txt");
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+printf '%s\n' "$@" > ${JSON.stringify(argsPath)}
+printf '%s' "$PWD" > ${JSON.stringify(cwdPath)}
+printf 'ok\\n'
+`,
+		);
+		chmodSync(bin, 0o755);
+		const previousSignetPath = process.env.SIGNET_PATH;
+		process.env.SIGNET_PATH = root;
+		try {
+			const provider = createAcpxProvider({
+				agent: "claude",
+				bin,
+				permissions: "deny-all",
+				hooks: "disabled",
+			});
+			await expect(provider.generate("summarize", { timeoutMs: 1000 })).resolves.toBe("ok");
+			const args = readFileSync(argsPath, "utf-8").trim().split("\n");
+			expect(args).toContain("--deny-all");
+			expect(args).toContain("--allowed-tools");
+			expect(args[args.indexOf("--allowed-tools") + 1]).toBe("");
+			expect(args.slice(args.indexOf("claude"))).toEqual(["claude", "exec", "--file", "-"]);
+			expect(readFileSync(cwdPath, "utf-8")).toBe(join(root, ".daemon", "acpx-background"));
+		} finally {
+			if (previousSignetPath === undefined) Reflect.deleteProperty(process.env, "SIGNET_PATH");
+			else process.env.SIGNET_PATH = previousSignetPath;
 			rmSync(root, { recursive: true, force: true });
 		}
 	});
@@ -687,12 +720,12 @@ describe("createCodexProvider", () => {
 			expect(capturedEnv?.XDG_CONFIG_HOME).toBe(join(capturedEnv?.HOME ?? "", ".config"));
 		} finally {
 			if (prevHome === undefined) {
-				delete process.env.HOME;
+				Reflect.deleteProperty(process.env, "HOME");
 			} else {
 				process.env.HOME = prevHome;
 			}
 			if (prevCodexHome === undefined) {
-				delete process.env.CODEX_HOME;
+				Reflect.deleteProperty(process.env, "CODEX_HOME");
 			} else {
 				process.env.CODEX_HOME = prevCodexHome;
 			}
@@ -818,22 +851,24 @@ describe("createOpenCodeProvider", () => {
 
 	it("generate() extracts text from parts array", async () => {
 		let callCount = 0;
-		mockFetch(withParentSession(async (url) => {
-			callCount++;
-			if (url.includes("/session") && !url.includes("/message")) {
-				// Session creation
-				return Response.json({
-					id: "ses_test",
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			// Message
-			return Response.json(openCodeResponse("  extracted fact  "));
-		}));
+		mockFetch(
+			withParentSession(async (url) => {
+				callCount++;
+				if (url.includes("/session") && !url.includes("/message")) {
+					// Session creation
+					return Response.json({
+						id: "ses_test",
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
+				// Message
+				return Response.json(openCodeResponse("  extracted fact  "));
+			}),
+		);
 
 		const provider = createOpenCodeProvider({ baseUrl: "http://localhost:9999" });
 		const result = await provider.generate("test prompt");
@@ -843,20 +878,22 @@ describe("createOpenCodeProvider", () => {
 
 	it("generate() creates a new child session per call after cleanup", async () => {
 		let sessionCreations = 0;
-		mockFetch(withParentSession(async (url) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				sessionCreations++;
-				return Response.json({
-					id: "ses_reuse",
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			return Response.json(openCodeResponse("ok"));
-		}));
+		mockFetch(
+			withParentSession(async (url) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					sessionCreations++;
+					return Response.json({
+						id: "ses_reuse",
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
+				return Response.json(openCodeResponse("ok"));
+			}),
+		);
 
 		const provider = createOpenCodeProvider({ baseUrl: "http://localhost:9999" });
 		await provider.generate("prompt 1");
@@ -910,16 +947,12 @@ describe("createOpenCodeProvider", () => {
 		await new Promise((r) => setTimeout(r, 100));
 
 		// Parent session created once, without parentID
-		const parentBody = sessionBodies.find(
-			(b) => b.title === "signet-system",
-		);
+		const parentBody = sessionBodies.find((b) => b.title === "signet-system");
 		expect(parentBody).toBeDefined();
 		expect(parentBody?.parentID).toBeUndefined();
 
 		// Child sessions include parentID pointing to parent
-		const childBodies = sessionBodies.filter(
-			(b) => b.title === "signet-extraction",
-		);
+		const childBodies = sessionBodies.filter((b) => b.title === "signet-extraction");
 		expect(childBodies).toHaveLength(2);
 		for (const b of childBodies) {
 			expect(b.parentID).toBe("ses_parent_qa");
@@ -941,11 +974,7 @@ describe("createOpenCodeProvider", () => {
 			if (init?.method === "DELETE" && url.includes("/session/")) {
 				return new Response(null, { status: 200 });
 			}
-			if (
-				init?.method === "POST" &&
-				url.includes("/session") &&
-				!url.includes("/message")
-			) {
+			if (init?.method === "POST" && url.includes("/session") && !url.includes("/message")) {
 				const body = parseJsonObjectBody(init?.body);
 				sessionBodies.push(body);
 
@@ -991,9 +1020,7 @@ describe("createOpenCodeProvider", () => {
 		expect(result).toBe("ok");
 
 		// The retry attempt must NOT carry parentID
-		const childBodies = sessionBodies.filter(
-			(b) => b.title === "signet-extraction",
-		);
+		const childBodies = sessionBodies.filter((b) => b.title === "signet-extraction");
 		expect(childBodies.length).toBeGreaterThanOrEqual(2);
 		// First attempt had parentID
 		expect(childBodies[0].parentID).toBeDefined();
@@ -1008,11 +1035,7 @@ describe("createOpenCodeProvider", () => {
 			if (init?.method === "DELETE" && url.includes("/session/")) {
 				return new Response(null, { status: 200 });
 			}
-			if (
-				init?.method === "POST" &&
-				url.includes("/session") &&
-				!url.includes("/message")
-			) {
+			if (init?.method === "POST" && url.includes("/session") && !url.includes("/message")) {
 				const body = parseJsonObjectBody(init?.body);
 				if (body.title === "signet-system") {
 					return Response.json({
@@ -1065,24 +1088,26 @@ describe("createOpenCodeProvider", () => {
 	it("generate() retries on 404 (expired session)", async () => {
 		let messageAttempts = 0;
 		let sessionCreations = 0;
-		mockFetch(withParentSession(async (url) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				sessionCreations++;
-				return Response.json({
-					id: `ses_${sessionCreations}`,
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			messageAttempts++;
-			if (messageAttempts === 1) {
-				return new Response("session not found", { status: 404 });
-			}
-			return Response.json(openCodeResponse("recovered"));
-		}));
+		mockFetch(
+			withParentSession(async (url) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					sessionCreations++;
+					return Response.json({
+						id: `ses_${sessionCreations}`,
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
+				messageAttempts++;
+				if (messageAttempts === 1) {
+					return new Response("session not found", { status: 404 });
+				}
+				return Response.json(openCodeResponse("recovered"));
+			}),
+		);
 
 		const provider = createOpenCodeProvider({ baseUrl: "http://localhost:9999" });
 		const result = await provider.generate("test");
@@ -1091,19 +1116,21 @@ describe("createOpenCodeProvider", () => {
 	});
 
 	it("generateWithUsage() maps tokens and cost from response", async () => {
-		mockFetch(withParentSession(async (url) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				return Response.json({
-					id: "ses_usage",
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			return Response.json(openCodeResponse("result", { input: 100, output: 25 }, 0.0042));
-		}));
+		mockFetch(
+			withParentSession(async (url) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: "ses_usage",
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
+				return Response.json(openCodeResponse("result", { input: 100, output: 25 }, 0.0042));
+			}),
+		);
 
 		const provider = createOpenCodeProvider({ baseUrl: "http://localhost:9999" });
 		const result = await provider.generateWithUsage!("test");
@@ -1115,43 +1142,47 @@ describe("createOpenCodeProvider", () => {
 	});
 
 	it("generate() throws on non-200 non-retryable status", async () => {
-		mockFetch(withParentSession(async (url) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				return Response.json({
-					id: "ses_err",
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			return new Response("internal server error", { status: 500 });
-		}));
+		mockFetch(
+			withParentSession(async (url) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: "ses_err",
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
+				return new Response("internal server error", { status: 500 });
+			}),
+		);
 
 		const provider = createOpenCodeProvider({ baseUrl: "http://localhost:9999" });
 		await expect(provider.generate("test")).rejects.toThrow(/OpenCode HTTP 500/);
 	});
 
 	it("generate() throws a timeout error on slow responses", async () => {
-		mockFetch(withParentSession(async (url, init) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				return Response.json({
-					id: "ses_slow",
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			return new Promise((_resolve, reject) => {
-				const signal = init?.signal;
-				if (signal) {
-					signal.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
+		mockFetch(
+			withParentSession(async (url, init) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: "ses_slow",
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
 				}
-			});
-		}));
+				return new Promise((_resolve, reject) => {
+					const signal = init?.signal;
+					if (signal) {
+						signal.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
+					}
+				});
+			}),
+		);
 
 		const provider = createOpenCodeProvider({
 			baseUrl: "http://localhost:9999",
@@ -1169,9 +1200,11 @@ describe("createOpenCodeProvider", () => {
 	});
 
 	it("available() returns false when server is unreachable", async () => {
-		mockFetch(withParentSession(() => {
-			throw new Error("connection refused");
-		}));
+		mockFetch(
+			withParentSession(() => {
+				throw new Error("connection refused");
+			}),
+		);
 
 		const provider = createOpenCodeProvider({ baseUrl: "http://localhost:9999" });
 		const result = await provider.available();
@@ -1180,20 +1213,22 @@ describe("createOpenCodeProvider", () => {
 
 	it("generate() sends correct request body with parts format", async () => {
 		let capturedBody: Record<string, unknown> = {};
-		mockFetch(withParentSession(async (url, init) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				return Response.json({
-					id: "ses_body",
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			capturedBody = JSON.parse(init?.body as string);
-			return Response.json(openCodeResponse("ok"));
-		}));
+		mockFetch(
+			withParentSession(async (url, init) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: "ses_body",
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
+				capturedBody = JSON.parse(init?.body as string);
+				return Response.json(openCodeResponse("ok"));
+			}),
+		);
 
 		const provider = createOpenCodeProvider({
 			baseUrl: "http://localhost:9999",
@@ -1214,20 +1249,22 @@ describe("createOpenCodeProvider", () => {
 
 	it("generate() sends signet-pipeline agent in request body", async () => {
 		let capturedBody: Record<string, unknown> = {};
-		mockFetch(withParentSession(async (url, init) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				return Response.json({
-					id: "ses_agent",
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			capturedBody = JSON.parse(init?.body as string);
-			return Response.json(openCodeResponse("ok"));
-		}));
+		mockFetch(
+			withParentSession(async (url, init) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: "ses_agent",
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
+				capturedBody = JSON.parse(init?.body as string);
+				return Response.json(openCodeResponse("ok"));
+			}),
+		);
 
 		const provider = createOpenCodeProvider({
 			baseUrl: "http://localhost:9999",
@@ -1240,20 +1277,22 @@ describe("createOpenCodeProvider", () => {
 
 	it("generate() omits agent when config.agent is empty", async () => {
 		let capturedBody: Record<string, unknown> = {};
-		mockFetch(withParentSession(async (url, init) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				return Response.json({
-					id: "ses_no_agent",
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			capturedBody = JSON.parse(init?.body as string);
-			return Response.json(openCodeResponse("ok"));
-		}));
+		mockFetch(
+			withParentSession(async (url, init) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: "ses_no_agent",
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
+				capturedBody = JSON.parse(init?.body as string);
+				return Response.json(openCodeResponse("ok"));
+			}),
+		);
 
 		const provider = createOpenCodeProvider({
 			baseUrl: "http://localhost:9999",
@@ -1268,25 +1307,27 @@ describe("createOpenCodeProvider", () => {
 	it("generate() retries without agent on agent-not-found 4xx and stays disabled", async () => {
 		let sessionCount = 0;
 		let lastBody: Record<string, unknown> = {};
-		mockFetch(withParentSession(async (url, init) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				sessionCount++;
-				return Response.json({
-					id: `ses_agent_fallback_${sessionCount}`,
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			const parsed = JSON.parse(init?.body as string);
-			if (parsed.agent) {
-				return new Response(`unknown agent "signet-pipeline"`, { status: 400 });
-			}
-			lastBody = parsed;
-			return Response.json(openCodeResponse("recovered"));
-		}));
+		mockFetch(
+			withParentSession(async (url, init) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					sessionCount++;
+					return Response.json({
+						id: `ses_agent_fallback_${sessionCount}`,
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
+				const parsed = JSON.parse(init?.body as string);
+				if (parsed.agent) {
+					return new Response(`unknown agent "signet-pipeline"`, { status: 400 });
+				}
+				lastBody = parsed;
+				return Response.json(openCodeResponse("recovered"));
+			}),
+		);
 
 		const provider = createOpenCodeProvider({
 			baseUrl: "http://localhost:9999",
@@ -1304,28 +1345,30 @@ describe("createOpenCodeProvider", () => {
 	it("generate() falls back when agent-rejection 400 arrives after agent already disabled", async () => {
 		let sessionCount = 0;
 		let agentSeen = false;
-		mockFetch(withParentSession(async (url, init) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				sessionCount++;
-				return Response.json({
-					id: `ses_concurrent_${sessionCount}`,
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			const parsed = JSON.parse(init?.body as string);
-			if (parsed.agent) {
-				agentSeen = true;
-				return new Response(`unknown agent "signet-pipeline"`, { status: 400 });
-			}
-			if (!agentSeen) {
-				return new Response(`unknown agent "signet-pipeline"`, { status: 400 });
-			}
-			return Response.json(openCodeResponse("ok"));
-		}));
+		mockFetch(
+			withParentSession(async (url, init) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					sessionCount++;
+					return Response.json({
+						id: `ses_concurrent_${sessionCount}`,
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
+				const parsed = JSON.parse(init?.body as string);
+				if (parsed.agent) {
+					agentSeen = true;
+					return new Response(`unknown agent "signet-pipeline"`, { status: 400 });
+				}
+				if (!agentSeen) {
+					return new Response(`unknown agent "signet-pipeline"`, { status: 400 });
+				}
+				return Response.json(openCodeResponse("ok"));
+			}),
+		);
 
 		const provider = createOpenCodeProvider({
 			baseUrl: "http://localhost:9999",
@@ -1340,19 +1383,21 @@ describe("createOpenCodeProvider", () => {
 		sessionCount = 0;
 		agentSeen = false;
 		let threw = false;
-		mockFetch(withParentSession(async (url) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				return Response.json({
-					id: "ses_sibling",
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			return new Response(`unknown agent "signet-pipeline"`, { status: 400 });
-		}));
+		mockFetch(
+			withParentSession(async (url) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: "ses_sibling",
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
+				return new Response(`unknown agent "signet-pipeline"`, { status: 400 });
+			}),
+		);
 		try {
 			await provider.generate("extract sibling");
 		} catch {
@@ -1363,20 +1408,22 @@ describe("createOpenCodeProvider", () => {
 
 	it("generate() omits format field when enableStructuredOutput is false", async () => {
 		let capturedBody: Record<string, unknown> = {};
-		mockFetch(withParentSession(async (url, init) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				return Response.json({
-					id: "ses_no_so",
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			capturedBody = JSON.parse(init?.body as string);
-			return Response.json(openCodeResponse("ok"));
-		}));
+		mockFetch(
+			withParentSession(async (url, init) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: "ses_no_so",
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
+				capturedBody = JSON.parse(init?.body as string);
+				return Response.json(openCodeResponse("ok"));
+			}),
+		);
 
 		const provider = createOpenCodeProvider({
 			baseUrl: "http://localhost:9999",
@@ -1390,26 +1437,28 @@ describe("createOpenCodeProvider", () => {
 	});
 
 	it("generate() joins multiple text parts", async () => {
-		mockFetch(withParentSession(async (url) => {
-			if (url.includes("/session") && !url.includes("/message")) {
+		mockFetch(
+			withParentSession(async (url) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: "ses_multi",
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
 				return Response.json({
-					id: "ses_multi",
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
+					info: { role: "assistant", id: "msg_test", sessionID: "ses_multi", cost: 0, tokens: { input: 0, output: 0 } },
+					parts: [
+						{ type: "text", text: "first part", id: "p1", sessionID: "ses_multi", messageID: "msg_test" },
+						{ type: "tool", id: "p2", sessionID: "ses_multi", messageID: "msg_test" },
+						{ type: "text", text: "second part", id: "p3", sessionID: "ses_multi", messageID: "msg_test" },
+					],
 				});
-			}
-			return Response.json({
-				info: { role: "assistant", id: "msg_test", sessionID: "ses_multi", cost: 0, tokens: { input: 0, output: 0 } },
-				parts: [
-					{ type: "text", text: "first part", id: "p1", sessionID: "ses_multi", messageID: "msg_test" },
-					{ type: "tool", id: "p2", sessionID: "ses_multi", messageID: "msg_test" },
-					{ type: "text", text: "second part", id: "p3", sessionID: "ses_multi", messageID: "msg_test" },
-				],
-			});
-		}));
+			}),
+		);
 
 		const provider = createOpenCodeProvider({ baseUrl: "http://localhost:9999" });
 		const result = await provider.generate("test");
@@ -1419,40 +1468,42 @@ describe("createOpenCodeProvider", () => {
 	it("generate() polls session messages when post response is empty", async () => {
 		let postCalls = 0;
 		let getCalls = 0;
-		mockFetch(withParentSession(async (url, init) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				return Response.json({
-					id: "ses_poll",
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			if (init?.method === "POST") {
-				postCalls++;
-				return new Response("", {
-					status: 200,
-					headers: { "Content-Type": "application/json" },
-				});
-			}
-			getCalls++;
-			if (getCalls === 1) {
+		mockFetch(
+			withParentSession(async (url, init) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: "ses_poll",
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
+				if (init?.method === "POST") {
+					postCalls++;
+					return new Response("", {
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					});
+				}
+				getCalls++;
+				if (getCalls === 1) {
+					return Response.json([
+						{
+							info: { role: "user" },
+							parts: [{ type: "text", text: "pending" }],
+						},
+					]);
+				}
 				return Response.json([
 					{
-						info: { role: "user" },
-						parts: [{ type: "text", text: "pending" }],
+						info: { role: "assistant", tokens: { input: 1, output: 1 } },
+						parts: [{ type: "text", text: "recovered" }],
 					},
 				]);
-			}
-			return Response.json([
-				{
-					info: { role: "assistant", tokens: { input: 1, output: 1 } },
-					parts: [{ type: "text", text: "recovered" }],
-				},
-			]);
-		}));
+			}),
+		);
 
 		const provider = createOpenCodeProvider({ baseUrl: "http://localhost:9999" });
 		const result = await provider.generate("test");
@@ -1463,31 +1514,33 @@ describe("createOpenCodeProvider", () => {
 
 	it("generate() returns fallback JSON when no assistant text appears", async () => {
 		let getCalls = 0;
-		mockFetch(withParentSession(async (url, init) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				return Response.json({
-					id: "ses_bad",
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			if (init?.method === "POST") {
-				return new Response("", {
-					status: 200,
-					headers: { "Content-Type": "application/json" },
-				});
-			}
-			getCalls++;
-			return Response.json([
-				{
-					info: { role: "user" },
-					parts: [{ type: "text", text: "still pending" }],
-				},
-			]);
-		}));
+		mockFetch(
+			withParentSession(async (url, init) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: "ses_bad",
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
+				if (init?.method === "POST") {
+					return new Response("", {
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					});
+				}
+				getCalls++;
+				return Response.json([
+					{
+						info: { role: "user" },
+						parts: [{ type: "text", text: "still pending" }],
+					},
+				]);
+			}),
+		);
 
 		const provider = createOpenCodeProvider({ baseUrl: "http://localhost:9999" });
 		const result = await provider.generate("test", { timeoutMs: 200 });
@@ -1499,46 +1552,48 @@ describe("createOpenCodeProvider", () => {
 		const seenUrls: string[] = [];
 		let fallbackBody: Record<string, unknown> | null = null;
 		let postCount = 0;
-		mockFetch(withParentSession(async (url, init) => {
-			seenUrls.push(url);
-			if (url.includes("/session") && !url.includes("/message")) {
-				return Response.json({
-					id: "ses_fallback",
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			if (url.includes("/session/ses_fallback/message")) {
-				if (init?.method === "POST") {
-					postCount++;
-					// First POST returns 404 (session gone) to take the short
-					// retry path (line 2370-2385) that reaches tryOllamaFallback
-					// after only one poll cycle instead of three.
-					if (postCount === 1) {
-						return new Response("Not Found", { status: 404 });
-					}
-					// Retry POST returns empty 200 (malformed) so
-					// parsePostResponse → pollForAssistantMessage → null,
-					// which triggers the Ollama fallback.
-					return new Response("", {
-						status: 200,
-						headers: { "Content-Type": "application/json" },
+		mockFetch(
+			withParentSession(async (url, init) => {
+				seenUrls.push(url);
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: "ses_fallback",
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
 					});
 				}
-				return Response.json([]);
-			}
-			if (url === "http://172.17.0.1:11434/api/tags") {
-				return Response.json({ models: [] });
-			}
-			if (url === "http://172.17.0.1:11434/api/generate") {
-				fallbackBody = parseJsonObjectBody(init?.body);
-				return Response.json({ response: '{"facts":[],"entities":[]}' });
-			}
-			return new Response("unexpected url", { status: 500 });
-		}));
+				if (url.includes("/session/ses_fallback/message")) {
+					if (init?.method === "POST") {
+						postCount++;
+						// First POST returns 404 (session gone) to take the short
+						// retry path (line 2370-2385) that reaches tryOllamaFallback
+						// after only one poll cycle instead of three.
+						if (postCount === 1) {
+							return new Response("Not Found", { status: 404 });
+						}
+						// Retry POST returns empty 200 (malformed) so
+						// parsePostResponse → pollForAssistantMessage → null,
+						// which triggers the Ollama fallback.
+						return new Response("", {
+							status: 200,
+							headers: { "Content-Type": "application/json" },
+						});
+					}
+					return Response.json([]);
+				}
+				if (url === "http://172.17.0.1:11434/api/tags") {
+					return Response.json({ models: [] });
+				}
+				if (url === "http://172.17.0.1:11434/api/generate") {
+					fallbackBody = parseJsonObjectBody(init?.body);
+					return Response.json({ response: '{"facts":[],"entities":[]}' });
+				}
+				return new Response("unexpected url", { status: 500 });
+			}),
+		);
 
 		const provider = createOpenCodeProvider({
 			baseUrl: "http://localhost:9999",
@@ -1559,36 +1614,38 @@ describe("createOpenCodeProvider", () => {
 	it("generate() does NOT attempt Ollama fallback when enableOllamaFallback is omitted (safe default)", async () => {
 		const seenUrls: string[] = [];
 		let postCount = 0;
-		mockFetch(withParentSession(async (url, init) => {
-			seenUrls.push(url);
-			if (url.includes("/session") && !url.includes("/message")) {
-				return Response.json({
-					id: "ses_no_fallback",
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			if (url.includes("/session/ses_no_fallback/message")) {
-				if (init?.method === "POST") {
-					postCount++;
-					if (postCount === 1) {
-						return new Response("Not Found", { status: 404 });
-					}
-					return new Response("", {
-						status: 200,
-						headers: { "Content-Type": "application/json" },
+		mockFetch(
+			withParentSession(async (url, init) => {
+				seenUrls.push(url);
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: "ses_no_fallback",
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
 					});
 				}
-				return Response.json([]);
-			}
-			if (url.includes("11434")) {
-				return Response.json({ models: [] });
-			}
-			return new Response("unexpected url", { status: 500 });
-		}));
+				if (url.includes("/session/ses_no_fallback/message")) {
+					if (init?.method === "POST") {
+						postCount++;
+						if (postCount === 1) {
+							return new Response("Not Found", { status: 404 });
+						}
+						return new Response("", {
+							status: 200,
+							headers: { "Content-Type": "application/json" },
+						});
+					}
+					return Response.json([]);
+				}
+				if (url.includes("11434")) {
+					return Response.json({ models: [] });
+				}
+				return new Response("unexpected url", { status: 500 });
+			}),
+		);
 
 		const provider = createOpenCodeProvider({
 			baseUrl: "http://localhost:9999",
@@ -1603,29 +1660,33 @@ describe("createOpenCodeProvider", () => {
 	}, 35000);
 
 	it("generate() prefers info.structured over text parts", async () => {
-		mockFetch(withParentSession(async (url) => {
-			if (url.includes("/session") && !url.includes("/message")) {
+		mockFetch(
+			withParentSession(async (url) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: "ses_structured",
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
 				return Response.json({
-					id: "ses_structured",
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
+					info: {
+						role: "assistant",
+						id: "msg_s",
+						sessionID: "ses_structured",
+						cost: 0,
+						tokens: { input: 10, output: 5 },
+						structured: { facts: [{ content: "from structured", type: "fact", confidence: 0.9 }], entities: [] },
+					},
+					parts: [
+						{ type: "text", text: "ignore this text", id: "p1", sessionID: "ses_structured", messageID: "msg_s" },
+					],
 				});
-			}
-			return Response.json({
-				info: {
-					role: "assistant",
-					id: "msg_s",
-					sessionID: "ses_structured",
-					cost: 0,
-					tokens: { input: 10, output: 5 },
-					structured: { facts: [{ content: "from structured", type: "fact", confidence: 0.9 }], entities: [] },
-				},
-				parts: [{ type: "text", text: "ignore this text", id: "p1", sessionID: "ses_structured", messageID: "msg_s" }],
-			});
-		}));
+			}),
+		);
 
 		const provider = createOpenCodeProvider({ baseUrl: "http://localhost:9999" });
 		const result = await provider.generate("test");
@@ -1634,29 +1695,31 @@ describe("createOpenCodeProvider", () => {
 	});
 
 	it("generate() returns info.structured as string when it is a string", async () => {
-		mockFetch(withParentSession(async (url) => {
-			if (url.includes("/session") && !url.includes("/message")) {
+		mockFetch(
+			withParentSession(async (url) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: "ses_str",
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
 				return Response.json({
-					id: "ses_str",
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
+					info: {
+						role: "assistant",
+						id: "msg_str",
+						sessionID: "ses_str",
+						cost: 0,
+						tokens: { input: 0, output: 0 },
+						structured: '{"description":"test skill","triggers":["run tests"],"tags":["testing"]}',
+					},
+					parts: [],
 				});
-			}
-			return Response.json({
-				info: {
-					role: "assistant",
-					id: "msg_str",
-					sessionID: "ses_str",
-					cost: 0,
-					tokens: { input: 0, output: 0 },
-					structured: '{"description":"test skill","triggers":["run tests"],"tags":["testing"]}',
-				},
-				parts: [],
-			});
-		}));
+			}),
+		);
 
 		const provider = createOpenCodeProvider({ baseUrl: "http://localhost:9999" });
 		const result = await provider.generate("test");
@@ -1666,25 +1729,27 @@ describe("createOpenCodeProvider", () => {
 	it("generate() disables structured output on 422 and retries without format", async () => {
 		let attempts = 0;
 		const bodies: Record<string, unknown>[] = [];
-		mockFetch(withParentSession(async (url, init) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				return Response.json({
-					id: `ses_compat_${attempts}`,
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			attempts++;
-			bodies.push(JSON.parse(init?.body as string));
-			if (attempts === 1) {
-				// 422 with "format" JSON key — signals structured output unsupported
-				return new Response('{"issues":[{"path":["format"],"message":"Unrecognized key"}]}', { status: 422 });
-			}
-			return Response.json(openCodeResponse("fallback works"));
-		}));
+		mockFetch(
+			withParentSession(async (url, init) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: `ses_compat_${attempts}`,
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
+				attempts++;
+				bodies.push(JSON.parse(init?.body as string));
+				if (attempts === 1) {
+					// 422 with "format" JSON key — signals structured output unsupported
+					return new Response('{"issues":[{"path":["format"],"message":"Unrecognized key"}]}', { status: 422 });
+				}
+				return Response.json(openCodeResponse("fallback works"));
+			}),
+		);
 
 		const provider = createOpenCodeProvider({ baseUrl: "http://localhost:9999" });
 		const first = await provider.generate("test");
@@ -1700,33 +1765,35 @@ describe("createOpenCodeProvider", () => {
 	it("generate() disables structured output after consecutive malformed 200 responses", async () => {
 		let postCount = 0;
 		const postBodies: Record<string, unknown>[] = [];
-		mockFetch(withParentSession(async (url, init) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				return Response.json({
-					id: `ses_200err_${postCount}`,
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			if (init?.method === "POST") {
-				postCount++;
-				postBodies.push(JSON.parse(init?.body as string));
-				if (postCount <= 2) {
-					// First two POSTs: 200 with empty body (GitHub Copilot schema rejection pattern)
-					return new Response("", {
-						status: 200,
-						headers: { "Content-Type": "application/json" },
+		mockFetch(
+			withParentSession(async (url, init) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: `ses_200err_${postCount}`,
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
 					});
 				}
-				// Third POST (after structured output disabled): succeed
-				return Response.json(openCodeResponse("recovered without format"));
-			}
-			// GET polls: return empty array so poll times out quickly
-			return Response.json([]);
-		}));
+				if (init?.method === "POST") {
+					postCount++;
+					postBodies.push(JSON.parse(init?.body as string));
+					if (postCount <= 2) {
+						// First two POSTs: 200 with empty body (GitHub Copilot schema rejection pattern)
+						return new Response("", {
+							status: 200,
+							headers: { "Content-Type": "application/json" },
+						});
+					}
+					// Third POST (after structured output disabled): succeed
+					return Response.json(openCodeResponse("recovered without format"));
+				}
+				// GET polls: return empty array so poll times out quickly
+				return Response.json([]);
+			}),
+		);
 
 		const provider = createOpenCodeProvider({
 			baseUrl: "http://localhost:9999",
@@ -1745,24 +1812,26 @@ describe("createOpenCodeProvider", () => {
 
 	it("generate() does not disable structured output on an unrelated 400", async () => {
 		let attempts = 0;
-		mockFetch(withParentSession(async (url, init) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				return Response.json({
-					id: `ses_unrelated_${attempts}`,
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			attempts++;
-			if (attempts === 1) {
-				// 400 with "format" word but not a structured-output rejection
-				return new Response('{"error":"Invalid request format: parts array is missing"}', { status: 400 });
-			}
-			return Response.json(openCodeResponse("ok"));
-		}));
+		mockFetch(
+			withParentSession(async (url, init) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: `ses_unrelated_${attempts}`,
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
+				attempts++;
+				if (attempts === 1) {
+					// 400 with "format" word but not a structured-output rejection
+					return new Response('{"error":"Invalid request format: parts array is missing"}', { status: 400 });
+				}
+				return Response.json(openCodeResponse("ok"));
+			}),
+		);
 
 		const provider = createOpenCodeProvider({ baseUrl: "http://localhost:9999" });
 		// Should throw, not silently disable structured output and retry
@@ -1771,19 +1840,21 @@ describe("createOpenCodeProvider", () => {
 	});
 
 	it("generate() preserves error body on non-format 400", async () => {
-		mockFetch(withParentSession(async (url) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				return Response.json({
-					id: "ses_400",
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			return new Response("bad request: missing required field", { status: 400 });
-		}));
+		mockFetch(
+			withParentSession(async (url) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: "ses_400",
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
+				return new Response("bad request: missing required field", { status: 400 });
+			}),
+		);
 
 		const provider = createOpenCodeProvider({ baseUrl: "http://localhost:9999" });
 		await expect(provider.generate("test")).rejects.toThrow(/bad request: missing required field/);
@@ -1794,19 +1865,21 @@ describe("createOpenCodeProvider", () => {
 		expect(provider.name).toBe("opencode:github-copilot/gpt-4o");
 	});
 	it("generate() refreshes bypass TTL on reused session", async () => {
-		mockFetch(withParentSession(async (url) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				return Response.json({
-					id: "ses_bypass_refresh",
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			return Response.json(openCodeResponse("ok"));
-		}));
+		mockFetch(
+			withParentSession(async (url) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: "ses_bypass_refresh",
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
+				return Response.json(openCodeResponse("ok"));
+			}),
+		);
 
 		const provider = createOpenCodeProvider({ baseUrl: "http://localhost:9999" });
 		await provider.generate("prompt 1");
@@ -1830,24 +1903,26 @@ describe("createOpenCodeProvider", () => {
 		let peak = 0;
 		let inflight = 0;
 
-		mockFetch(withParentSession(async (url) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				return Response.json({
-					id: `ses_conc_${Date.now()}`,
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			inflight++;
-			if (inflight > peak) peak = inflight;
-			// Brief delay to allow other semaphore-gated requests to overlap
-			await new Promise((resolve) => setTimeout(resolve, 50));
-			inflight--;
-			return Response.json(openCodeResponse("ok"));
-		}));
+		mockFetch(
+			withParentSession(async (url) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: `ses_conc_${Date.now()}`,
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
+				inflight++;
+				if (inflight > peak) peak = inflight;
+				// Brief delay to allow other semaphore-gated requests to overlap
+				await new Promise((resolve) => setTimeout(resolve, 50));
+				inflight--;
+				return Response.json(openCodeResponse("ok"));
+			}),
+		);
 
 		const N = 8;
 		const providers = Array.from({ length: N }, (_, i) =>
@@ -1864,20 +1939,22 @@ describe("createOpenCodeProvider", () => {
 	it("generate() throws deadline error when semaphore wait exceeds timeout", async () => {
 		const blockers: Array<() => void> = [];
 
-		mockFetch(withParentSession(async (url) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				return Response.json({
-					id: `ses_deadline_${Date.now()}`,
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			await new Promise<void>((resolve) => blockers.push(resolve));
-			return Response.json(openCodeResponse("ok"));
-		}));
+		mockFetch(
+			withParentSession(async (url) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: `ses_deadline_${Date.now()}`,
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
+				await new Promise<void>((resolve) => blockers.push(resolve));
+				return Response.json(openCodeResponse("ok"));
+			}),
+		);
 
 		// Fill all 4 semaphore slots with blocked requests
 		const fillers = Array.from({ length: 4 }, (_, i) =>
@@ -1903,27 +1980,25 @@ describe("createOpenCodeProvider", () => {
 		const sessionIds: string[] = [];
 		let sessionCounter = 0;
 
-		mockFetch(withParentSession(async (url, init) => {
-			if (
-				init?.method === "POST" &&
-				url.includes("/session") &&
-				!url.includes("/message")
-			) {
-				const id = `ses_race_${++sessionCounter}`;
-				return Response.json({
-					id,
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			const match = url.match(/\/session\/([^/]+)\/message/);
-			if (match) sessionIds.push(match[1]);
-			await new Promise((resolve) => setTimeout(resolve, 50));
-			return Response.json(openCodeResponse("ok"));
-		}));
+		mockFetch(
+			withParentSession(async (url, init) => {
+				if (init?.method === "POST" && url.includes("/session") && !url.includes("/message")) {
+					const id = `ses_race_${++sessionCounter}`;
+					return Response.json({
+						id,
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
+				const match = url.match(/\/session\/([^/]+)\/message/);
+				if (match) sessionIds.push(match[1]);
+				await new Promise((resolve) => setTimeout(resolve, 50));
+				return Response.json(openCodeResponse("ok"));
+			}),
+		);
 
 		const provider = createOpenCodeProvider({
 			baseUrl: "http://localhost:9999",
@@ -1931,13 +2006,8 @@ describe("createOpenCodeProvider", () => {
 		});
 
 		const callA = provider.generate("prompt-a");
-		const callBC = new Promise<void>((resolve) =>
-			setTimeout(resolve, 10),
-		).then(() =>
-			Promise.all([
-				provider.generate("prompt-b"),
-				provider.generate("prompt-c"),
-			]),
+		const callBC = new Promise<void>((resolve) => setTimeout(resolve, 10)).then(() =>
+			Promise.all([provider.generate("prompt-b"), provider.generate("prompt-c")]),
 		);
 
 		const [resultA, resultsBC] = await Promise.all([callA, callBC]);
@@ -1960,58 +2030,53 @@ describe("createOpenCodeProvider", () => {
 		const sessionIds: string[] = [];
 		const pollTargets: string[] = [];
 
-		mockFetch(withParentSession(async (url, init) => {
-			// Child session creation — track IDs
-			if (
-				init?.method === "POST" &&
-				url.includes("/session") &&
-				!url.includes("/message")
-			) {
-				const id = `ses_fmt_${++sessionCounter}`;
-				sessionIds.push(id);
-				return Response.json({
-					id,
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-
-			// POST message
-			if (init?.method === "POST" && url.includes("/message")) {
-				const match = url.match(/\/session\/([^/]+)\/message/);
-				const sid = match?.[1] ?? "";
-				if (sid === "ses_fmt_1") {
-					// First session → 422 format rejection
-					return new Response(
-						'{"issues":[{"path":["format"],"message":"Unrecognized key"}]}',
-						{ status: 422 },
-					);
+		mockFetch(
+			withParentSession(async (url, init) => {
+				// Child session creation — track IDs
+				if (init?.method === "POST" && url.includes("/session") && !url.includes("/message")) {
+					const id = `ses_fmt_${++sessionCounter}`;
+					sessionIds.push(id);
+					return Response.json({
+						id,
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
 				}
-				// Retry session → empty body (forces poll fallback)
-				return new Response("", {
-					status: 200,
-					headers: { "Content-Type": "application/json" },
-				});
-			}
 
-			// GET poll — record which session is being polled
-			if (init?.method === "GET" || (!init?.method && url.includes("/message"))) {
-				const match = url.match(/\/session\/([^/]+)\/message/);
-				if (match) pollTargets.push(match[1]);
-
-				// Only the retry session has the assistant message
-				if (match?.[1] === "ses_fmt_2") {
-					return Response.json([openCodeResponse("polled-from-retry")]);
+				// POST message
+				if (init?.method === "POST" && url.includes("/message")) {
+					const match = url.match(/\/session\/([^/]+)\/message/);
+					const sid = match?.[1] ?? "";
+					if (sid === "ses_fmt_1") {
+						// First session → 422 format rejection
+						return new Response('{"issues":[{"path":["format"],"message":"Unrecognized key"}]}', { status: 422 });
+					}
+					// Retry session → empty body (forces poll fallback)
+					return new Response("", {
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					});
 				}
-				// Original session returns empty — no message here
-				return Response.json([]);
-			}
 
-			return new Response(null, { status: 404 });
-		}));
+				// GET poll — record which session is being polled
+				if (init?.method === "GET" || (!init?.method && url.includes("/message"))) {
+					const match = url.match(/\/session\/([^/]+)\/message/);
+					if (match) pollTargets.push(match[1]);
+
+					// Only the retry session has the assistant message
+					if (match?.[1] === "ses_fmt_2") {
+						return Response.json([openCodeResponse("polled-from-retry")]);
+					}
+					// Original session returns empty — no message here
+					return Response.json([]);
+				}
+
+				return new Response(null, { status: 404 });
+			}),
+		);
 
 		const provider = createOpenCodeProvider({
 			baseUrl: "http://localhost:9999",
@@ -2039,15 +2104,8 @@ describe("createOpenCodeProvider", () => {
 
 		mockFetch(async (url, init) => {
 			// Parent session
-			if (
-				init?.method === "POST" &&
-				url.includes("/session") &&
-				!url.includes("/message")
-			) {
-				const body =
-					typeof init.body === "string"
-						? (JSON.parse(init.body) as Record<string, unknown>)
-						: {};
+			if (init?.method === "POST" && url.includes("/session") && !url.includes("/message")) {
+				const body = typeof init.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : {};
 				if (body.title === "signet-system") {
 					return Response.json({
 						id: "ses_parent",
@@ -2396,9 +2454,9 @@ describe("awaitSubprocessWithDeadline — success-after-timeout race", () => {
 			return "success-value";
 		};
 
-		await expect(
-			awaitSubprocessWithDeadline(fakeProc, 30, "test", 30, resultFn),
-		).rejects.toBeInstanceOf(SemaphoreTimeoutError);
+		await expect(awaitSubprocessWithDeadline(fakeProc, 30, "test", 30, resultFn)).rejects.toBeInstanceOf(
+			SemaphoreTimeoutError,
+		);
 
 		expect(killed).toBe(true);
 	});
@@ -2414,33 +2472,32 @@ describe("createOpenCodeProvider — session creation vs semaphore ordering", ()
 		const sessionDelayMs = 300;
 		const messageDelayMs = 200;
 
-		mockFetch(withParentSession(async (url, init) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				await new Promise((r) => setTimeout(r, sessionDelayMs));
-				return Response.json({
-					id: "ses_deadline_test",
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			// LLM call takes 200ms — should hit AbortError if only 100ms remains
-			return new Promise((_resolve, reject) => {
-				const signal = init?.signal;
-				const timer = setTimeout(
-					() => _resolve(Response.json(openCodeResponse("ok"))),
-					messageDelayMs,
-				);
-				if (signal) {
-					signal.addEventListener("abort", () => {
-						clearTimeout(timer);
-						reject(new DOMException("aborted", "AbortError"));
+		mockFetch(
+			withParentSession(async (url, init) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					await new Promise((r) => setTimeout(r, sessionDelayMs));
+					return Response.json({
+						id: "ses_deadline_test",
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
 					});
 				}
-			});
-		}));
+				// LLM call takes 200ms — should hit AbortError if only 100ms remains
+				return new Promise((_resolve, reject) => {
+					const signal = init?.signal;
+					const timer = setTimeout(() => _resolve(Response.json(openCodeResponse("ok"))), messageDelayMs);
+					if (signal) {
+						signal.addEventListener("abort", () => {
+							clearTimeout(timer);
+							reject(new DOMException("aborted", "AbortError"));
+						});
+					}
+				});
+			}),
+		);
 
 		const provider = createOpenCodeProvider({
 			baseUrl: "http://localhost:9999",
@@ -2466,41 +2523,42 @@ describe("createOpenCodeProvider — retry session creation respects deadline", 
 		// only ~200ms of the 600ms budget remains after the first round-trip.
 		let sessionCount = 0;
 
-		mockFetch(withParentSession(async (url, init) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				sessionCount++;
-				if (sessionCount > 1) {
-					// Second session creation is slow
-					await new Promise<void>((resolve, reject) => {
-						const timer = setTimeout(() => resolve(), 500);
-						const signal = init?.signal;
-						if (signal) {
-							signal.addEventListener("abort", () => {
-								clearTimeout(timer);
-								reject(new DOMException("aborted", "AbortError"));
-							});
-						}
+		mockFetch(
+			withParentSession(async (url, init) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					sessionCount++;
+					if (sessionCount > 1) {
+						// Second session creation is slow
+						await new Promise<void>((resolve, reject) => {
+							const timer = setTimeout(() => resolve(), 500);
+							const signal = init?.signal;
+							if (signal) {
+								signal.addEventListener("abort", () => {
+									clearTimeout(timer);
+									reject(new DOMException("aborted", "AbortError"));
+								});
+							}
+						});
+					}
+					return Response.json({
+						id: `ses_retry_${sessionCount}`,
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
 					});
 				}
-				return Response.json({
-					id: `ses_retry_${sessionCount}`,
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			if (url.includes("/message")) {
-				// First message: 422 with format rejection (takes ~300ms)
-				await new Promise((r) => setTimeout(r, 300));
-				return new Response(
-					JSON.stringify({ issues: [{ path: ["format"], message: "unsupported" }] }),
-					{ status: 422 },
-				);
-			}
-			return new Response("not found", { status: 404 });
-		}));
+				if (url.includes("/message")) {
+					// First message: 422 with format rejection (takes ~300ms)
+					await new Promise((r) => setTimeout(r, 300));
+					return new Response(JSON.stringify({ issues: [{ path: ["format"], message: "unsupported" }] }), {
+						status: 422,
+					});
+				}
+				return new Response("not found", { status: 404 });
+			}),
+		);
 
 		const provider = createOpenCodeProvider({
 			baseUrl: "http://localhost:9999",
@@ -2595,42 +2653,44 @@ describe("createOpenCodeProvider — nested semaphore deadlock in fallback", () 
 		const N = 4; // matches DEFAULT_MAX_LLM_CONCURRENCY
 		let postCount = 0;
 
-		mockFetch(withParentSession(async (url, init) => {
-			// Session creation
-			if (url.includes("/session") && !url.includes("/message")) {
-				return Response.json({
-					id: `ses_deadlock_${postCount}`,
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			// Ollama availability check
-			if (url.includes("/api/tags")) {
-				return Response.json({ models: [{ name: "qwen3.5:4b" }] });
-			}
-			// Ollama fallback generate
-			if (url.includes("/api/generate")) {
-				await new Promise((r) => setTimeout(r, 20));
-				return Response.json({
-					response: JSON.stringify({ result: "fallback-ok" }),
-					prompt_eval_count: 10,
-					eval_count: 5,
-				});
-			}
-			// OpenCode message POST — always return malformed (empty body)
-			if (init?.method === "POST" && url.includes("/message")) {
-				postCount++;
-				return new Response("", {
-					status: 200,
-					headers: { "Content-Type": "application/json" },
-				});
-			}
-			// GET polls — empty array to trigger malformed path
-			return Response.json([]);
-		}));
+		mockFetch(
+			withParentSession(async (url, init) => {
+				// Session creation
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: `ses_deadlock_${postCount}`,
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
+					});
+				}
+				// Ollama availability check
+				if (url.includes("/api/tags")) {
+					return Response.json({ models: [{ name: "qwen3.5:4b" }] });
+				}
+				// Ollama fallback generate
+				if (url.includes("/api/generate")) {
+					await new Promise((r) => setTimeout(r, 20));
+					return Response.json({
+						response: JSON.stringify({ result: "fallback-ok" }),
+						prompt_eval_count: 10,
+						eval_count: 5,
+					});
+				}
+				// OpenCode message POST — always return malformed (empty body)
+				if (init?.method === "POST" && url.includes("/message")) {
+					postCount++;
+					return new Response("", {
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					});
+				}
+				// GET polls — empty array to trigger malformed path
+				return Response.json([]);
+			}),
+		);
 
 		const providers = Array.from({ length: N }, () =>
 			createOpenCodeProvider({
@@ -2666,52 +2726,54 @@ describe("createOpenCodeProvider — fallback respects remaining deadline", () =
 		let ollamaFetchAbortedAt = 0;
 		let postCount = 0;
 
-		mockFetch(withParentSession(async (url, init) => {
-			if (url.includes("/session") && !url.includes("/message")) {
-				return Response.json({
-					id: `ses_deadline_${postCount}`,
-					slug: "test",
-					projectID: "p",
-					directory: "/tmp",
-					title: "test",
-					version: "1",
-				});
-			}
-			if (url.includes("/api/tags")) {
-				return Response.json({ models: [{ name: "qwen3.5:4b" }] });
-			}
-			if (url.includes("/api/generate")) {
-				ollamaFetchStartedAt = performance.now();
-				try {
-					await new Promise((resolve, reject) => {
-						const t = setTimeout(resolve, 10_000);
-						if (init?.signal) {
-							init.signal.addEventListener("abort", () => {
-								clearTimeout(t);
-								reject(new DOMException("Aborted", "AbortError"));
-							});
-						}
+		mockFetch(
+			withParentSession(async (url, init) => {
+				if (url.includes("/session") && !url.includes("/message")) {
+					return Response.json({
+						id: `ses_deadline_${postCount}`,
+						slug: "test",
+						projectID: "p",
+						directory: "/tmp",
+						title: "test",
+						version: "1",
 					});
-				} catch {
-					ollamaFetchAbortedAt = performance.now();
-					throw new DOMException("Aborted", "AbortError");
 				}
-				return Response.json({
-					response: "should not reach this",
-					prompt_eval_count: 10,
-					eval_count: 5,
-				});
-			}
-			if (init?.method === "POST" && url.includes("/message")) {
-				postCount++;
-				await new Promise((r) => setTimeout(r, 300));
-				return new Response("", {
-					status: 200,
-					headers: { "Content-Type": "application/json" },
-				});
-			}
-			return Response.json([]);
-		}));
+				if (url.includes("/api/tags")) {
+					return Response.json({ models: [{ name: "qwen3.5:4b" }] });
+				}
+				if (url.includes("/api/generate")) {
+					ollamaFetchStartedAt = performance.now();
+					try {
+						await new Promise((resolve, reject) => {
+							const t = setTimeout(resolve, 10_000);
+							if (init?.signal) {
+								init.signal.addEventListener("abort", () => {
+									clearTimeout(t);
+									reject(new DOMException("Aborted", "AbortError"));
+								});
+							}
+						});
+					} catch {
+						ollamaFetchAbortedAt = performance.now();
+						throw new DOMException("Aborted", "AbortError");
+					}
+					return Response.json({
+						response: "should not reach this",
+						prompt_eval_count: 10,
+						eval_count: 5,
+					});
+				}
+				if (init?.method === "POST" && url.includes("/message")) {
+					postCount++;
+					await new Promise((r) => setTimeout(r, 300));
+					return new Response("", {
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					});
+				}
+				return Response.json([]);
+			}),
+		);
 
 		const provider = createOpenCodeProvider({
 			baseUrl: "http://localhost:9999",

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -1005,9 +1005,23 @@ function acpxEnv(hooks: AcpxHooksMode | undefined): NodeJS.ProcessEnv {
 	return env;
 }
 
-function resolveAcpxCwd(cwd: string | undefined): string | undefined {
-	if (!cwd) return undefined;
-	return isAbsolute(cwd) ? cwd : resolvePath(cwd);
+function getAgentsDir(): string {
+	return process.env.SIGNET_PATH || join(homedir(), ".agents");
+}
+
+function resolveAcpxCwd(cwd: string | undefined, hooks: AcpxHooksMode | undefined): string | undefined {
+	if (cwd) return isAbsolute(cwd) ? cwd : resolvePath(cwd);
+	if (hooks !== "disabled") return undefined;
+	const isolatedCwd = join(getAgentsDir(), ".daemon", "acpx-background");
+	mkdirSync(isolatedCwd, { recursive: true });
+	return isolatedCwd;
+}
+
+function resolveAcpxAllowedTools(
+	config: Pick<AcpxProviderConfig, "allowedTools" | "hooks">,
+): readonly string[] | undefined {
+	if (config.allowedTools !== undefined) return config.allowedTools;
+	return config.hooks === "disabled" ? [] : undefined;
 }
 
 function resolveAcpxFormat(config: Pick<AcpxProviderConfig, "format" | "captureEvents">): AcpxOutputFormat {
@@ -1019,8 +1033,9 @@ function buildAcpxCommand(
 	timeoutMs: number,
 ): { bin: string; args: string[]; cwd?: string } {
 	const bin = config.bin ?? "npx";
-	const cwd = resolveAcpxCwd(config.cwd);
+	const cwd = resolveAcpxCwd(config.cwd, config.hooks);
 	const packageRef = config.package ?? (!config.bin ? `acpx@${config.version ?? DEFAULT_ACPX_VERSION}` : undefined);
+	const allowedTools = resolveAcpxAllowedTools(config);
 	const args: string[] = [];
 	if (packageRef) {
 		if (bin.endsWith("npx") || bin.endsWith("npx.cmd")) args.push("-y");
@@ -1032,7 +1047,7 @@ function buildAcpxCommand(
 	if (config.model) args.push("--model", config.model);
 	args.push(...acpxPermissionArgs(config.permissions));
 	if (config.terminal === "disabled") args.push("--no-terminal");
-	if (config.allowedTools) args.push("--allowed-tools", config.allowedTools.join(","));
+	if (allowedTools) args.push("--allowed-tools", allowedTools.join(","));
 	args.push(...(config.extraArgs ?? []));
 	args.push(config.agent);
 	if ((config.mode ?? "exec") === "session" && config.session) {


### PR DESCRIPTION
## Summary
- Isolate hook-disabled ACPX pipeline runs in a Signet-owned `.daemon/acpx-background` cwd instead of inheriting the daemon or project cwd.
- Default hook-disabled ACPX runs to `--allowed-tools ""` unless the user explicitly configures an allowed tool list.
- Add regression coverage for the summary/background ACPX boundary so project `.claude/settings.json` and MCP/tool stacks do not get pulled into summarization by cwd inheritance.

Fixes #665

## Test Plan
- [x] `bun run build:core`
- [x] `bun test platform/daemon/src/pipeline/provider.test.ts --filter 'ACPX'`
- [x] `bunx --bun biome check platform/daemon/src/pipeline/provider.ts platform/daemon/src/pipeline/provider.test.ts`
- [x] `git diff --check`
- [x] `bun run build:connector-base`
- [x] `bun run build:opencode-plugin`
- [x] `bun run build:deps`
- [x] `bun run build:oh-my-pi-extension`
- [x] `bun run build:connector-oh-my-pi`
- [x] `bun run build:pi-extension`
- [x] `bun run build:connector-pi`
- [x] `bun run build:signetai`

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes
- [x] No database migrations were added, removed, renumbered, or modified.
