### PR TITLE
fix(desktop): add packaged app updates

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -191,6 +191,7 @@ jobs:
           name: desktop-${{ matrix.os_name }}
           path: |
             surfaces/desktop/release/*.dmg
+            surfaces/desktop/release/*.zip
             surfaces/desktop/release/*.AppImage
             surfaces/desktop/release/*.deb
             surfaces/desktop/release/*.exe
@@ -214,6 +215,7 @@ jobs:
         with:
           files: |
             surfaces/desktop/release/*.dmg
+            surfaces/desktop/release/*.zip
             surfaces/desktop/release/*.AppImage
             surfaces/desktop/release/*.deb
             surfaces/desktop/release/*.exe

--- a/bun.lock
+++ b/bun.lock
@@ -416,6 +416,7 @@
       "version": "0.115.14",
       "dependencies": {
         "@signet/tray": "workspace:*",
+        "electron-updater": "^6.8.3",
       },
       "devDependencies": {
         "@types/node": "^24.5.2",
@@ -2522,6 +2523,8 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.340", "", {}, "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA=="],
 
+    "electron-updater": ["electron-updater@6.8.3", "", { "dependencies": { "builder-util-runtime": "9.5.1", "fs-extra": "^10.1.0", "js-yaml": "^4.1.0", "lazy-val": "^1.0.5", "lodash.escaperegexp": "^4.1.2", "lodash.isequal": "^4.5.0", "semver": "~7.7.3", "tiny-typed-emitter": "^2.1.0" } }, "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ=="],
+
     "electron-winstaller": ["electron-winstaller@5.4.0", "", { "dependencies": { "@electron/asar": "^3.2.1", "debug": "^4.1.1", "fs-extra": "^7.0.1", "lodash": "^4.17.21", "temp": "^0.9.0" }, "optionalDependencies": { "@electron/windows-sign": "^1.1.2" } }, "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg=="],
 
     "elkjs": ["elkjs@0.11.1", "", {}, "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg=="],
@@ -3078,11 +3081,15 @@
 
     "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
 
+    "lodash.escaperegexp": ["lodash.escaperegexp@4.1.2", "", {}, "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="],
+
     "lodash.identity": ["lodash.identity@3.0.0", "", {}, "sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q=="],
 
     "lodash.includes": ["lodash.includes@4.3.0", "", {}, "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="],
 
     "lodash.isboolean": ["lodash.isboolean@3.0.3", "", {}, "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="],
+
+    "lodash.isequal": ["lodash.isequal@4.5.0", "", {}, "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="],
 
     "lodash.isinteger": ["lodash.isinteger@4.0.4", "", {}, "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="],
 
@@ -4013,6 +4020,8 @@
     "tiny-async-pool": ["tiny-async-pool@1.3.0", "", { "dependencies": { "semver": "^5.5.0" } }, "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA=="],
 
     "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
+
+    "tiny-typed-emitter": ["tiny-typed-emitter@2.1.0", "", {}, "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="],
 
     "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
 

--- a/docs/TRAY.md
+++ b/docs/TRAY.md
@@ -40,6 +40,12 @@ The Electron desktop app provides:
 - quick memory capture
 - memory search
 - bundled daemon fallback for consumer installs
+- desktop update checks from the tray menu and on startup for packaged builds
+
+When a packaged update is available, Signet prompts to download it and then
+restart into the new build. The dashboard is bundled into the desktop app, so
+desktop updates are how desktop users receive new dashboard pages such as
+Sources.
 
 The dashboard is still the same web dashboard served by the daemon. Browser
 usage and desktop usage share the dashboard codepath.
@@ -75,7 +81,7 @@ The desktop workflow builds Electron artifacts for:
 | Platform | Artifact |
 |---|---|
 | Linux | `.AppImage` and `.deb` |
-| macOS | `.dmg` |
+| macOS | `.dmg` and updater `.zip` |
 | Windows | installer `.exe` |
 | Arch | AppImage-backed AUR metadata |
 

--- a/docs/specs/approved/desktop-packaging-distribution.md
+++ b/docs/specs/approved/desktop-packaging-distribution.md
@@ -10,6 +10,7 @@ success_criteria:
   - "Arch package metadata (PKGBUILD and .SRCINFO) is generated from release AppImage + checksum"
   - "Arch CI validates generated PKGBUILD by building a .pkg.tar.* artifact in an Arch Linux environment"
   - "Desktop release jobs resolve a signing mode (official or self-signed) before publish"
+  - "Desktop releases publish electron-updater metadata and app artifacts so packaged installs can self-update"
   - "The supported source-build path is exposed through `signet desktop build` and `signet desktop install`"
 scope_boundary: "Desktop packaging, runtime bundling preference, CI workflows, and Arch metadata generation. Does not replace npm package publishing flows."
 ---
@@ -47,6 +48,10 @@ Arch.
 6. The official local source-build entrypoint is `signet desktop build`;
    `signet desktop install` builds from the same source checkout and installs
    a native launcher where the platform implementation exists.
+7. Packaged desktop releases must publish update metadata (`latest*.yml`) and
+   platform artifacts required by `electron-updater`, including macOS zip
+   artifacts, so desktop users can move to new dashboard/runtime bundles
+   without reinstalling manually.
 
 ## Integration notes
 

--- a/docs/specs/dependencies.yaml
+++ b/docs/specs/dependencies.yaml
@@ -1194,6 +1194,7 @@ specs:
       - "Arch package metadata (PKGBUILD and .SRCINFO) is generated from release AppImage + checksum"
       - "Arch CI validates generated PKGBUILD by building a .pkg.tar.* artifact in an Arch Linux environment"
       - "Desktop release jobs resolve a signing mode (official or self-signed) before publish"
+      - "Desktop releases publish electron-updater metadata and app artifacts so packaged installs can self-update"
       - "The supported source-build path is exposed through `signet desktop build` and `signet desktop install`"
     decision: null
 

--- a/surfaces/dashboard/src/lib/desktop-shell.ts
+++ b/surfaces/dashboard/src/lib/desktop-shell.ts
@@ -31,7 +31,7 @@ export interface SignetDesktopBridge {
 	quickCapture(content: string): Promise<void>;
 	searchMemories(query: string, limit?: number): Promise<string>;
 	pickDirectory?(options?: { title?: string }): Promise<string | null>;
-	checkForUpdate(): Promise<string | null>;
+	checkForUpdate(): Promise<unknown>;
 	quit(): Promise<void>;
 	onWindowStateChange(callback: (state: DesktopWindowState) => void): () => void;
 }

--- a/surfaces/desktop/package.json
+++ b/surfaces/desktop/package.json
@@ -20,7 +20,8 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@signet/tray": "workspace:*"
+    "@signet/tray": "workspace:*",
+    "electron-updater": "^6.8.3"
   },
   "devDependencies": {
     "@types/node": "^24.5.2",
@@ -52,7 +53,8 @@
       "category": "public.app-category.productivity",
       "icon": "icons/icon.icns",
       "target": [
-        "dmg"
+        "dmg",
+        "zip"
       ]
     },
     "win": {
@@ -71,7 +73,14 @@
     },
     "directories": {
       "output": "release"
-    }
+    },
+    "publish": [
+      {
+        "provider": "github",
+        "owner": "Signet-AI",
+        "repo": "signetai"
+      }
+    ]
   },
   "author": "Signet AI <hello@signetai.sh>"
 }

--- a/surfaces/desktop/src/desktop-updates.test.ts
+++ b/surfaces/desktop/src/desktop-updates.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const desktopRoot = join(import.meta.dir, "..");
+
+describe("desktop update packaging", () => {
+	test("ships Electron updater support instead of a null update IPC", () => {
+		const mainSource = readFileSync(join(import.meta.dir, "main.ts"), "utf8");
+		expect(mainSource).toContain('ipcMain.handle("desktop:checkForUpdate", () => checkForDesktopUpdate');
+		expect(mainSource).not.toContain('ipcMain.handle("desktop:checkForUpdate", () => null)');
+	});
+
+	test("publishes metadata and mac zip artifacts required by electron-updater", () => {
+		const packageJson = JSON.parse(readFileSync(join(desktopRoot, "package.json"), "utf8"));
+		expect(packageJson.dependencies["electron-updater"]).toBeString();
+		expect(packageJson.build.publish).toContainEqual({ provider: "github", owner: "Signet-AI", repo: "signetai" });
+		expect(packageJson.build.mac.target).toContain("zip");
+
+		const workflow = readFileSync(join(desktopRoot, "..", "..", ".github", "workflows", "desktop-build.yml"), "utf8");
+		expect(workflow).toContain("surfaces/desktop/release/*.zip");
+		expect(workflow).toContain("surfaces/desktop/release/latest*.yml");
+	});
+});

--- a/surfaces/desktop/src/desktop-updates.ts
+++ b/surfaces/desktop/src/desktop-updates.ts
@@ -1,0 +1,146 @@
+import { app, dialog } from "electron";
+import { type UpdateCheckResult, autoUpdater } from "electron-updater";
+
+export type DesktopUpdateStatus =
+	| "unsupported"
+	| "checking"
+	| "not-available"
+	| "available"
+	| "downloading"
+	| "downloaded"
+	| "installing"
+	| "error";
+
+export interface DesktopUpdateResult {
+	readonly status: DesktopUpdateStatus;
+	readonly currentVersion: string;
+	readonly version?: string;
+	readonly message: string;
+}
+
+interface CheckDesktopUpdateOptions {
+	readonly showNoUpdateDialog?: boolean;
+}
+
+let configured = false;
+let checkPromise: Promise<DesktopUpdateResult> | null = null;
+
+export function configureDesktopUpdates(): void {
+	if (configured) return;
+	configured = true;
+	autoUpdater.autoDownload = false;
+	autoUpdater.autoInstallOnAppQuit = true;
+}
+
+export function desktopUpdatesSupported():
+	| { readonly supported: true }
+	| { readonly supported: false; readonly reason: string } {
+	if (!app.isPackaged && process.env.SIGNET_DESKTOP_ENABLE_UPDATES_IN_DEV !== "1") {
+		return { supported: false, reason: "Desktop updates are only available in packaged builds." };
+	}
+	if (process.platform === "linux" && !process.env.APPIMAGE) {
+		return { supported: false, reason: "Desktop auto-updates on Linux require the AppImage build." };
+	}
+	return { supported: true };
+}
+
+export async function checkForDesktopUpdate(options: CheckDesktopUpdateOptions = {}): Promise<DesktopUpdateResult> {
+	if (checkPromise) return checkPromise;
+	checkPromise = doCheckForDesktopUpdate(options).finally(() => {
+		checkPromise = null;
+	});
+	return checkPromise;
+}
+
+async function doCheckForDesktopUpdate(options: CheckDesktopUpdateOptions): Promise<DesktopUpdateResult> {
+	configureDesktopUpdates();
+	const currentVersion = app.getVersion();
+	const support = desktopUpdatesSupported();
+	if (support.supported === false) {
+		const result = { status: "unsupported", currentVersion, message: support.reason } as const;
+		if (options.showNoUpdateDialog) await showMessage("Signet updates", result.message);
+		return result;
+	}
+
+	try {
+		const check = await autoUpdater.checkForUpdates();
+		const info = updateInfo(check);
+		const latestVersion = info?.version;
+		if (!check?.updateInfo || !latestVersion || latestVersion === currentVersion) {
+			const result = { status: "not-available", currentVersion, message: "Signet is up to date." } as const;
+			if (options.showNoUpdateDialog) await showMessage("Signet updates", result.message);
+			return result;
+		}
+
+		const wantsDownload = await confirmUpdate(latestVersion, currentVersion);
+		if (!wantsDownload) {
+			return {
+				status: "available",
+				currentVersion,
+				version: latestVersion,
+				message: `Signet ${latestVersion} is available.`,
+			};
+		}
+
+		await autoUpdater.downloadUpdate();
+		const wantsRestart = await confirmRestart(latestVersion);
+		if (wantsRestart) {
+			autoUpdater.quitAndInstall(false, true);
+			return {
+				status: "installing",
+				currentVersion,
+				version: latestVersion,
+				message: `Installing Signet ${latestVersion}.`,
+			};
+		}
+		return {
+			status: "downloaded",
+			currentVersion,
+			version: latestVersion,
+			message: `Signet ${latestVersion} downloaded. Restart Signet to install it.`,
+		};
+	} catch (err) {
+		const message = `Failed to check for Signet updates: ${errorMessage(err)}`;
+		console.error(message);
+		if (options.showNoUpdateDialog) await showMessage("Signet updates", message, "error");
+		return { status: "error", currentVersion, message };
+	}
+}
+
+function updateInfo(check: UpdateCheckResult | null | undefined): { readonly version?: string } | null {
+	return check?.updateInfo ?? null;
+}
+
+async function confirmUpdate(version: string, currentVersion: string): Promise<boolean> {
+	const response = await dialog.showMessageBox({
+		type: "info",
+		buttons: ["Download and install", "Later"],
+		defaultId: 0,
+		cancelId: 1,
+		title: "Signet update available",
+		message: `Signet ${version} is available`,
+		detail: `You are running Signet ${currentVersion}. Download the desktop update now?`,
+	});
+	return response.response === 0;
+}
+
+async function confirmRestart(version: string): Promise<boolean> {
+	const response = await dialog.showMessageBox({
+		type: "info",
+		buttons: ["Restart and install", "Later"],
+		defaultId: 0,
+		cancelId: 1,
+		title: "Signet update downloaded",
+		message: `Signet ${version} is ready to install`,
+		detail: "Restart Signet now to finish installing the update.",
+	});
+	return response.response === 0;
+}
+
+async function showMessage(title: string, message: string, type: "info" | "error" = "info"): Promise<void> {
+	await dialog.showMessageBox({ type, title, message });
+}
+
+function errorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}

--- a/surfaces/desktop/src/main.ts
+++ b/surfaces/desktop/src/main.ts
@@ -2,6 +2,7 @@ import { readFile, stat } from "node:fs/promises";
 import { extname, normalize, relative, sep } from "node:path";
 import { BrowserWindow, Menu, type OpenDialogOptions, app, dialog, ipcMain, protocol, shell } from "electron";
 import { DaemonManager } from "./daemon-manager.js";
+import { checkForDesktopUpdate, configureDesktopUpdates } from "./desktop-updates.js";
 import { dashboardRoot, preloadPath } from "./paths.js";
 import { daemonRouteTarget, isDaemonRouteUrl } from "./protocol-routes.js";
 import { DesktopTray } from "./tray.js";
@@ -304,7 +305,7 @@ function registerIpc(): void {
 	ipcMain.handle("desktop:quickCapture", (_event, content: string) => quickCapture(content));
 	ipcMain.handle("desktop:searchMemories", (_event, query: string, limit?: number) => searchMemories(query, limit));
 	ipcMain.handle("desktop:pickDirectory", (_event, options?: { title?: string }) => pickDirectory(options));
-	ipcMain.handle("desktop:checkForUpdate", () => null);
+	ipcMain.handle("desktop:checkForUpdate", () => checkForDesktopUpdate({ showNoUpdateDialog: true }));
 	ipcMain.handle("desktop:quit", () => app.quit());
 }
 
@@ -318,11 +319,13 @@ app.setName("Signet");
 
 app.whenReady().then(async () => {
 	Menu.setApplicationMenu(null);
+	configureDesktopUpdates();
 	await registerDashboardProtocol();
 	registerIpc();
-	tray = new DesktopTray(daemon, showDashboard);
+	tray = new DesktopTray(daemon, showDashboard, () => void checkForDesktopUpdate({ showNoUpdateDialog: true }));
 	tray.start();
 	showDashboard();
+	setTimeout(() => void checkForDesktopUpdate(), 5000);
 
 	app.on("activate", () => showDashboard());
 });

--- a/surfaces/desktop/src/tray.ts
+++ b/surfaces/desktop/src/tray.ts
@@ -112,6 +112,7 @@ function recentMenu(memories: readonly RecentMemory[]): MenuItemConstructorOptio
 export class DesktopTray {
 	readonly #daemon: DaemonManager;
 	readonly #openDashboard: () => void;
+	readonly #checkForUpdate: () => void;
 	#tray: Tray | null = null;
 	#lastJson = "";
 	#timer: NodeJS.Timeout | null = null;
@@ -122,9 +123,10 @@ export class DesktopTray {
 	#polling = false;
 	#pollAgain = false;
 
-	constructor(daemon: DaemonManager, openDashboard: () => void) {
+	constructor(daemon: DaemonManager, openDashboard: () => void, checkForUpdate: () => void) {
 		this.#daemon = daemon;
 		this.#openDashboard = openDashboard;
+		this.#checkForUpdate = checkForUpdate;
 	}
 
 	start(): void {
@@ -214,9 +216,14 @@ export class DesktopTray {
 			{ label: "Recent Memories", submenu: recentMenu(this.#snapshot?.recentMemories ?? []) },
 			{ type: "separator" },
 			{ label: "Start Daemon", enabled: !running, click: () => void this.#daemon.start().then(() => this.poll()) },
-			{ label: "Restart Daemon", enabled: ownsBundled, click: () => void this.#daemon.restart().then(() => this.poll()) },
+			{
+				label: "Restart Daemon",
+				enabled: ownsBundled,
+				click: () => void this.#daemon.restart().then(() => this.poll()),
+			},
 			{ label: "Stop Daemon", enabled: ownsBundled, click: () => void this.#daemon.stop().then(() => this.poll()) },
 			{ type: "separator" },
+			{ label: "Check for Updates…", click: this.#checkForUpdate },
 			{ label: "Quit Signet", click: () => app.quit() },
 		];
 	}


### PR DESCRIPTION
## Summary
- Adds Electron desktop update checks using `electron-updater` instead of the no-op desktop update IPC.
- Prompts packaged desktop users from startup or the tray menu when a newer GitHub release is available, then downloads and installs on restart.
- Publishes updater metadata/artifacts by adding GitHub publish config, macOS zip output, and workflow upload/release coverage.
- Updates the desktop packaging spec and tray docs so dashboard pages like Sources are explicitly delivered through desktop app updates.

## Validation
- `bun test surfaces/desktop/src/desktop-updates.test.ts surfaces/desktop/src/daemon-manager-regression.test.ts`
- `bun run --filter '@signet/tray' build`
- `cd surfaces/desktop && bun run typecheck`
- `cd surfaces/desktop && bun run build:main`
- `bunx biome check surfaces/desktop/src/desktop-updates.ts surfaces/desktop/src/desktop-updates.test.ts surfaces/desktop/src/main.ts surfaces/desktop/src/tray.ts surfaces/dashboard/src/lib/desktop-shell.ts`
- YAML parse: `.github/workflows/desktop-build.yml`, `docs/specs/dependencies.yaml`
- `git diff --check`

## Notes
- Existing desktop builds that already shipped with the no-op updater still need one manual install to bootstrap into this update-capable build. After that, desktop users can receive new bundled dashboard/runtime releases in-app.

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes
- [x] No database migrations were added, removed, renumbered, or modified.
