### PR TITLE
fix(desktop): sync source before install

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -109,8 +109,11 @@ Use explicit commands for interactive flows:
 ---
 
 Builds the official Electron desktop app from an existing Signet source
-checkout. The command never clones over local work; run it from the repo root,
-set `SIGNET_SOURCE_DIR`, or pass `--repo <path>`.
+checkout. Without `--repo` or `SIGNET_SOURCE_DIR`, the command first syncs the
+managed workspace checkout at `<workspace>/signetai`, ignoring generated desktop
+build artifacts such as `surfaces/desktop/release/` so stale local artifacts do
+not block fast-forward pulls. Explicit source paths are left under user control;
+run it from the repo root, set `SIGNET_SOURCE_DIR`, or pass `--repo <path>`.
 
 ```bash
 signet desktop build

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -112,12 +112,14 @@ Builds the official Electron desktop app from an existing Signet source
 checkout. Without `--repo` or `SIGNET_SOURCE_DIR`, the command first syncs the
 managed workspace checkout at `<workspace>/signetai`, ignoring generated desktop
 build artifacts such as `surfaces/desktop/release/` so stale local artifacts do
-not block fast-forward pulls. Explicit source paths are left under user control;
-run it from the repo root, set `SIGNET_SOURCE_DIR`, or pass `--repo <path>`.
+not block fast-forward pulls. Explicit source paths are left under user
+control; set `SIGNET_SOURCE_DIR` or pass `--repo <path>`. To build the checkout
+you are currently in, run `signet desktop install --repo .`.
 
 ```bash
 signet desktop build
 signet desktop install
+signet desktop install --repo .
 signet desktop install --repo ~/signet/signetai
 signet desktop install --skip-build
 ```

--- a/platform/core/src/workspace-source-repo.test.ts
+++ b/platform/core/src/workspace-source-repo.test.ts
@@ -115,6 +115,29 @@ describe("syncWorkspaceSourceRepo", () => {
 		expect(result.message).toContain("already current");
 	});
 
+	it("pulls through generated desktop build artifacts", () => {
+		const { remoteUrl, workDir } = seedRemote();
+		const workspaceDir = makeTempDir("signet-source-workspace-");
+
+		expect(syncWorkspace(workspaceDir, remoteUrl).status).toBe("cloned");
+		const repoPath = resolveWorkspaceSourceRepoPath(workspaceDir);
+		mkdirSync(join(repoPath, "surfaces", "desktop", "release"), { recursive: true });
+		mkdirSync(join(repoPath, "surfaces", "desktop", "resources", "daemon"), { recursive: true });
+		mkdirSync(join(repoPath, "dist", "signetai", "hermes-plugin"), { recursive: true });
+		writeFileSync(join(repoPath, "surfaces", "desktop", "release", "Signet-0.1.0-linux-x64.AppImage"), "app");
+		writeFileSync(join(repoPath, "surfaces", "desktop", "resources", "daemon", "daemon.js"), "daemon");
+		writeFileSync(join(repoPath, "dist", "signetai", "hermes-plugin", "plugin.py"), "plugin");
+		pushRemoteChange(workDir, "# signet\n\nremote build fix\n", "remote build fix");
+
+		const result = syncWorkspace(workspaceDir, remoteUrl);
+
+		expect(result.status).toBe("pulled");
+		expect(readFileSync(join(repoPath, "README.md"), "utf-8")).toContain("remote build fix");
+		expect(
+			readFileSync(join(repoPath, "surfaces", "desktop", "release", "Signet-0.1.0-linux-x64.AppImage"), "utf-8"),
+		).toBe("app");
+	});
+
 	it("fetches but does not pull over local workspace changes", () => {
 		const { remoteUrl, workDir } = seedRemote();
 		const workspaceDir = makeTempDir("signet-source-workspace-");

--- a/platform/core/src/workspace-source-repo.ts
+++ b/platform/core/src/workspace-source-repo.ts
@@ -769,13 +769,47 @@ function isWorkingTreeDirtyWith(run: typeof runGit, repoPath: string, timeoutMs:
 function isWorkingTreeDirtyWith(run: typeof runGitAsync, repoPath: string, timeoutMs: number): Promise<boolean>;
 function isWorkingTreeDirtyWith(run: GitRunner, repoPath: string, timeoutMs: number): MaybePromise<boolean>;
 function isWorkingTreeDirtyWith(run: GitRunner, repoPath: string, timeoutMs: number): MaybePromise<boolean> {
-	return mapMaybePromise(run(["status", "--porcelain", "--ignore-submodules=all"], repoPath, timeoutMs), (result) => {
-		if (!result.ok) {
-			return true;
-		}
+	return mapMaybePromise(
+		run(["status", "--porcelain", "--untracked-files=all", "--ignore-submodules=all"], repoPath, timeoutMs),
+		(result) => {
+			if (!result.ok) {
+				return true;
+			}
 
-		return result.stdout.trim().length > 0;
-	});
+			return result.stdout
+				.split("\n")
+				.map((line) => line.trimEnd())
+				.filter((line) => line.length > 0)
+				.some((line) => !isGeneratedSourceRepoStatusLine(line));
+		},
+	);
+}
+
+const GENERATED_SOURCE_REPO_PATH_PREFIXES = [
+	"dist/signetai/dashboard/",
+	"dist/signetai/dist/",
+	"dist/signetai/hermes-plugin/",
+	"dist/signetai/node_modules/",
+	"dist/signetai/skills/",
+	"surfaces/desktop/dist/",
+	"surfaces/desktop/release/",
+	"surfaces/desktop/resources/",
+];
+
+function isGeneratedSourceRepoStatusLine(line: string): boolean {
+	const path = parsePorcelainStatusPath(line);
+	if (!path) return false;
+	return GENERATED_SOURCE_REPO_PATH_PREFIXES.some((prefix) => path === prefix.slice(0, -1) || path.startsWith(prefix));
+}
+
+function parsePorcelainStatusPath(line: string): string | null {
+	if (line.length < 4) return null;
+	const rawPath = line.slice(3);
+	const renameSeparator = " -> ";
+	const path = rawPath.includes(renameSeparator)
+		? rawPath.slice(rawPath.lastIndexOf(renameSeparator) + renameSeparator.length)
+		: rawPath;
+	return path.replace(/^\"|\"$/g, "");
 }
 
 function readUpstreamBranchWith(run: typeof runGit, repoPath: string, timeoutMs: number): string | null;

--- a/surfaces/cli/src/features/desktop.test.ts
+++ b/surfaces/cli/src/features/desktop.test.ts
@@ -151,6 +151,43 @@ describe("desktop source checkout resolution", () => {
 });
 
 describe("desktop source build", () => {
+	test("syncs the managed workspace checkout before building by default", () => {
+		const root = makeCheckout();
+		const home = mkdtempSync(join(tmpdir(), "signet-desktop-home-"));
+		const workspace = join(home, "workspace");
+		const calls: string[] = [];
+		try {
+			mkdirSync(workspace, { recursive: true });
+			const result = buildDesktopFromSource(
+				{},
+				{
+					cwd: home,
+					env: { SIGNET_PATH: workspace },
+					syncWorkspaceSourceRepo: (workspaceDir) => {
+						calls.push(`sync ${workspaceDir}`);
+						return {
+							status: "pulled",
+							path: root,
+							message: "pulled latest Signet source checkout",
+							branch: "main",
+							defaultBranch: "main",
+						};
+					},
+					runner: (cmd, args, opts) => {
+						calls.push(`${cmd} ${args.join(" ")} @ ${opts.cwd}`);
+						return { status: 0 };
+					},
+				},
+			);
+
+			expect(result.repo).toBe(root);
+			expect(calls).toEqual([`sync ${workspace}`, `bun install @ ${root}`, `bun run build:desktop @ ${root}`]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
 	test("runs dependency install before desktop build", () => {
 		const root = makeCheckout();
 		const calls: string[] = [];
@@ -278,6 +315,48 @@ describe("linux desktop install", () => {
 
 			expect(lstatSync(result.binary).isSymbolicLink()).toBe(false);
 			expect(readFileSync(result.binary, "utf8")).toContain(`exec '${result.appImage}' "$@"`);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
+	test("syncs managed checkout before default install builds", () => {
+		const root = makeCheckout();
+		const home = mkdtempSync(join(tmpdir(), "signet-desktop-home-"));
+		const workspace = join(home, "workspace");
+		const calls: string[] = [];
+		try {
+			mkdirSync(workspace, { recursive: true });
+			const release = join(root, "surfaces", "desktop", "release");
+			mkdirSync(release, { recursive: true });
+			writeFileSync(join(release, "Signet-0.1.0-linux-x86_64.AppImage"), "app");
+
+			const result = installDesktopFromSource(
+				{},
+				{
+					home,
+					env: { SIGNET_PATH: workspace },
+					platform: "linux",
+					syncWorkspaceSourceRepo: (workspaceDir) => {
+						calls.push(`sync ${workspaceDir}`);
+						return {
+							status: "pulled",
+							path: root,
+							message: "pulled latest Signet source checkout",
+							branch: "main",
+							defaultBranch: "main",
+						};
+					},
+					runner: (cmd, args, opts) => {
+						calls.push(`${cmd} ${args.join(" ")} @ ${opts.cwd}`);
+						return { status: 0 };
+					},
+				},
+			);
+
+			expect(existsSync(result.appImage)).toBe(true);
+			expect(calls).toEqual([`sync ${workspace}`, `bun install @ ${root}`, `bun run build:desktop @ ${root}`]);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 			rmSync(home, { recursive: true, force: true });

--- a/surfaces/cli/src/features/desktop.ts
+++ b/surfaces/cli/src/features/desktop.ts
@@ -16,11 +16,12 @@ import {
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { resolveWorkspaceSourceRepoPath } from "@signet/core";
+import { resolveWorkspaceSourceRepoPath, syncWorkspaceSourceRepo } from "@signet/core";
 import { resolveAgentsDir } from "../lib/workspace.js";
 
 export interface DesktopCommandOptions {
 	readonly repo?: string;
+	readonly skipSourceSync?: boolean;
 }
 
 export interface DesktopInstallOptions extends DesktopCommandOptions {
@@ -46,6 +47,7 @@ interface DesktopCommandContext {
 	readonly home?: string;
 	readonly platform?: NodeJS.Platform;
 	readonly runner?: CommandRunner;
+	readonly syncWorkspaceSourceRepo?: typeof syncWorkspaceSourceRepo;
 }
 
 interface CommandResult {
@@ -103,11 +105,24 @@ function desktopSourceCheckoutCandidates(ctx: Pick<DesktopCommandContext, "cwd" 
 	});
 }
 
+function prepareDesktopSourceCheckout(options: DesktopCommandOptions, ctx: DesktopCommandContext): string {
+	const env = ctx.env ?? process.env;
+	const explicit = options.repo?.trim() || env.SIGNET_SOURCE_DIR?.trim();
+	if (explicit || options.skipSourceSync) return resolveDesktopSourceCheckout(options.repo, ctx);
+
+	const workspace = resolveAgentsDir(env).path;
+	const sync = (ctx.syncWorkspaceSourceRepo ?? syncWorkspaceSourceRepo)(workspace);
+	if (!["cloned", "pulled", "current"].includes(sync.status)) {
+		throw new Error(`Could not update Signet source checkout before desktop build: ${sync.message}`);
+	}
+	return sync.path;
+}
+
 export function buildDesktopFromSource(
 	options: DesktopCommandOptions = {},
 	ctx: DesktopCommandContext = {},
 ): DesktopBuildResult {
-	const repo = resolveDesktopSourceCheckout(options.repo, ctx);
+	const repo = prepareDesktopSourceCheckout(options, ctx);
 	const runner = ctx.runner ?? defaultRunner;
 	const env = ctx.env ?? process.env;
 
@@ -121,10 +136,12 @@ export function installDesktopFromSource(
 	options: DesktopInstallOptions = {},
 	ctx: DesktopCommandContext = {},
 ): DesktopLinuxInstallResult {
-	const repo = resolveDesktopSourceCheckout(options.repo, ctx);
+	const repo = options.skipBuild
+		? resolveDesktopSourceCheckout(options.repo, ctx)
+		: prepareDesktopSourceCheckout(options, ctx);
 	const workspace = resolveAgentsDir(ctx.env ?? process.env).path;
 	if (!options.skipBuild) {
-		buildDesktopFromSource({ repo }, ctx);
+		buildDesktopFromSource({ repo, skipSourceSync: true }, ctx);
 	}
 
 	const platform = ctx.platform ?? process.platform;


### PR DESCRIPTION
## Summary
- Syncs the managed `<workspace>/signetai` checkout before default `signet desktop build` / `signet desktop install` runs so manual installs build the latest source instead of stale local code.
- Keeps explicit `--repo` / `SIGNET_SOURCE_DIR` behavior under user control.
- Ignores generated desktop/build output paths during managed source checkout dirty checks so AppImage/resources/dist artifacts do not block a safe fast-forward pull.
- Documents the managed checkout sync behavior.

## Validation
- `bun install`
- `bun run build:core`
- `bun test platform/core/src/workspace-source-repo.test.ts surfaces/cli/src/features/desktop.test.ts`
- `bunx biome check platform/core/src/workspace-source-repo.ts platform/core/src/workspace-source-repo.test.ts surfaces/cli/src/features/desktop.ts surfaces/cli/src/features/desktop.test.ts docs/CLI.md`
- `git diff --check`
- `bun run --filter '@signet/cli' build`

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes
- [x] No database migrations were added, removed, renumbered, or modified.
