### PR TITLE
fix(desktop): disable electron-builder auto publish

### DIFF
--- a/surfaces/desktop/package.json
+++ b/surfaces/desktop/package.json
@@ -14,7 +14,7 @@
     "build:main": "tsc -p tsconfig.json",
     "stage:runtime": "node scripts/stage-runtime.mjs",
     "build": "bun run build:main",
-    "build:desktop": "bun run build:core && bun run build:tray && bun run build:daemon && bun run stage:runtime && bun run build:main && electron-builder",
+    "build:desktop": "bun run build:core && bun run build:tray && bun run build:daemon && bun run stage:runtime && bun run build:main && electron-builder --publish never",
     "dev": "bun run build:tray && bun run build:dashboard && bun run build:main && electron .",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "bun test"

--- a/tests/integration/docker-build-regression.test.ts
+++ b/tests/integration/docker-build-regression.test.ts
@@ -96,6 +96,12 @@ describe("Docker build pipeline regression guard", () => {
 		expect(desktopBuild.indexOf("bun run build:core")).toBeLessThan(desktopBuild.indexOf("bun run build:daemon"));
 	});
 
+	it("keeps Electron Builder from auto-publishing during tag builds", () => {
+		expect(desktopBuild).toBeDefined();
+		if (!desktopBuild) return;
+		expect(desktopBuild).toContain("electron-builder --publish never");
+	});
+
 	it("uses a cross-platform skills copy script for daemon builds", () => {
 		expect(daemonCopySkills).toBe("bun ../../scripts/copy-skills.ts");
 		expect(daemonCopySkills).not.toContain("cp -r");


### PR DESCRIPTION
## Summary
- Prevent Electron Builder from auto-publishing during desktop package builds.
- Keep release asset publication in the existing GitHub Actions release step instead of Electron Builder's implicit GitHub publisher.
- Add a regression guard so the desktop build script keeps `--publish never`.

## Testing
- `bun test tests/integration/docker-build-regression.test.ts`
- `bunx --bun biome format --write surfaces/desktop/package.json tests/integration/docker-build-regression.test.ts`
- `bunx --bun biome check surfaces/desktop/package.json tests/integration/docker-build-regression.test.ts`
- `git diff --check`

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes
- [x] No database migrations were added, removed, renumbered, or modified.
