### PR TITLE
fix: restore desktop typecheck on fresh worktrees

### DIFF
--- a/surfaces/desktop/package.json
+++ b/surfaces/desktop/package.json
@@ -1,86 +1,75 @@
 {
-  "name": "@signet/desktop",
-  "version": "0.115.18",
-  "private": true,
-  "description": "Electron desktop distribution layer for Signet",
-  "homepage": "https://signetai.sh",
-  "type": "module",
-  "main": "dist/main.js",
-  "scripts": {
-    "build:core": "cd ../../platform/core && bun run build",
-    "build:tray": "cd ../tray && bun run build",
-    "build:dashboard": "cd ../../platform/daemon && bun run build:dashboard",
-    "build:daemon": "cd ../../platform/daemon && bun run build",
-    "build:main": "tsc -p tsconfig.json",
-    "stage:runtime": "node scripts/stage-runtime.mjs",
-    "build": "bun run build:main",
-    "build:desktop": "bun run build:core && bun run build:tray && bun run build:daemon && bun run stage:runtime && bun run build:main && electron-builder --publish never",
-    "dev": "bun run build:tray && bun run build:dashboard && bun run build:main && electron .",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "bun test"
-  },
-  "dependencies": {
-    "@signet/tray": "workspace:*",
-    "electron-updater": "^6.8.3"
-  },
-  "devDependencies": {
-    "@types/node": "^24.5.2",
-    "electron": "^41.2.1",
-    "electron-builder": "^26.8.1",
-    "typescript": "^5.7.0"
-  },
-  "build": {
-    "appId": "ai.signet.app",
-    "productName": "Signet",
-    "artifactName": "Signet-${version}-${os}-${arch}.${ext}",
-    "asar": true,
-    "npmRebuild": false,
-    "files": [
-      "dist/**/*",
-      "package.json"
-    ],
-    "extraResources": [
-      {
-        "from": "resources",
-        "to": "."
-      },
-      {
-        "from": "icons",
-        "to": "icons"
-      }
-    ],
-    "mac": {
-      "category": "public.app-category.productivity",
-      "icon": "icons/icon.icns",
-      "target": [
-        "dmg",
-        "zip"
-      ]
-    },
-    "win": {
-      "icon": "icons/icon.ico",
-      "target": [
-        "nsis"
-      ]
-    },
-    "linux": {
-      "category": "Utility",
-      "icon": "icons/icon.png",
-      "target": [
-        "AppImage",
-        "deb"
-      ]
-    },
-    "directories": {
-      "output": "release"
-    },
-    "publish": [
-      {
-        "provider": "github",
-        "owner": "Signet-AI",
-        "repo": "signetai"
-      }
-    ]
-  },
-  "author": "Signet AI <hello@signetai.sh>"
+	"name": "@signet/desktop",
+	"version": "0.115.18",
+	"private": true,
+	"description": "Electron desktop distribution layer for Signet",
+	"homepage": "https://signetai.sh",
+	"type": "module",
+	"main": "dist/main.js",
+	"scripts": {
+		"build:core": "cd ../../platform/core && bun run build",
+		"build:tray": "cd ../tray && bun run build",
+		"build:dashboard": "cd ../../platform/daemon && bun run build:dashboard",
+		"build:daemon": "cd ../../platform/daemon && bun run build",
+		"build:main": "tsc -p tsconfig.json",
+		"stage:runtime": "node scripts/stage-runtime.mjs",
+		"build": "bun run build:main",
+		"build:desktop": "bun run build:core && bun run build:tray && bun run build:daemon && bun run stage:runtime && bun run build:main && electron-builder --publish never",
+		"dev": "bun run build:tray && bun run build:dashboard && bun run build:main && electron .",
+		"typecheck": "bun run build:tray && tsc -p tsconfig.json --noEmit",
+		"test": "bun test"
+	},
+	"dependencies": {
+		"@signet/tray": "workspace:*",
+		"electron-updater": "^6.8.3"
+	},
+	"devDependencies": {
+		"@types/node": "^24.5.2",
+		"electron": "^41.2.1",
+		"electron-builder": "^26.8.1",
+		"typescript": "^5.7.0"
+	},
+	"build": {
+		"appId": "ai.signet.app",
+		"productName": "Signet",
+		"artifactName": "Signet-${version}-${os}-${arch}.${ext}",
+		"asar": true,
+		"npmRebuild": false,
+		"files": ["dist/**/*", "package.json"],
+		"extraResources": [
+			{
+				"from": "resources",
+				"to": "."
+			},
+			{
+				"from": "icons",
+				"to": "icons"
+			}
+		],
+		"mac": {
+			"category": "public.app-category.productivity",
+			"icon": "icons/icon.icns",
+			"target": ["dmg", "zip"]
+		},
+		"win": {
+			"icon": "icons/icon.ico",
+			"target": ["nsis"]
+		},
+		"linux": {
+			"category": "Utility",
+			"icon": "icons/icon.png",
+			"target": ["AppImage", "deb"]
+		},
+		"directories": {
+			"output": "release"
+		},
+		"publish": [
+			{
+				"provider": "github",
+				"owner": "Signet-AI",
+				"repo": "signetai"
+			}
+		]
+	},
+	"author": "Signet AI <hello@signetai.sh>"
 }

--- a/tests/integration/docker-build-regression.test.ts
+++ b/tests/integration/docker-build-regression.test.ts
@@ -6,7 +6,9 @@ import { fileURLToPath } from "node:url";
 const rootDir = fileURLToPath(new URL("../../", import.meta.url));
 const dockerfile = readFileSync(join(rootDir, "deploy/docker/Dockerfile"), "utf8");
 const dockerignore = readFileSync(join(rootDir, ".dockerignore"), "utf8");
-const openclawPackageJson = JSON.parse(readFileSync(join(rootDir, "integrations/openclaw/memory-adapter/package.json"), "utf8"));
+const openclawPackageJson = JSON.parse(
+	readFileSync(join(rootDir, "integrations/openclaw/memory-adapter/package.json"), "utf8"),
+);
 const daemonPackageJson = JSON.parse(readFileSync(join(rootDir, "platform/daemon/package.json"), "utf8"));
 const desktopPackageJson = JSON.parse(readFileSync(join(rootDir, "surfaces/desktop/package.json"), "utf8"));
 const openclawBuild =
@@ -38,6 +40,16 @@ const desktopBuild =
 	"build:desktop" in desktopPackageJson.scripts &&
 	typeof desktopPackageJson.scripts["build:desktop"] === "string"
 		? desktopPackageJson.scripts["build:desktop"]
+		: undefined;
+const desktopTypecheck =
+	typeof desktopPackageJson === "object" &&
+	desktopPackageJson !== null &&
+	"scripts" in desktopPackageJson &&
+	typeof desktopPackageJson.scripts === "object" &&
+	desktopPackageJson.scripts !== null &&
+	"typecheck" in desktopPackageJson.scripts &&
+	typeof desktopPackageJson.scripts.typecheck === "string"
+		? desktopPackageJson.scripts.typecheck
 		: undefined;
 const desktopHomepage =
 	typeof desktopPackageJson === "object" &&
@@ -94,6 +106,13 @@ describe("Docker build pipeline regression guard", () => {
 		expect(desktopBuild).toStartWith("bun run build:core");
 		expect(desktopBuild).toContain("bun run build:daemon");
 		expect(desktopBuild.indexOf("bun run build:core")).toBeLessThan(desktopBuild.indexOf("bun run build:daemon"));
+	});
+
+	it("keeps desktop typecheck aligned with workspace dependency order", () => {
+		expect(desktopTypecheck).toBeDefined();
+		if (!desktopTypecheck) return;
+		expect(desktopTypecheck).toStartWith("bun run build:tray");
+		expect(desktopTypecheck).toContain("tsc -p tsconfig.json --noEmit");
 	});
 
 	it("keeps Electron Builder from auto-publishing during tag builds", () => {


### PR DESCRIPTION
## Summary
- Daily main regression sentinel found `bun run typecheck` failing on `origin/main` after the desktop tray package dependency was introduced.
- Root cause: `@signet/desktop` imports `@signet/tray`, whose package `types` point at `dist/index.d.ts`; the root typecheck runs workspace package typechecks in parallel and did not build tray before desktop resolved those types.
- Fix: prebuild tray in the desktop typecheck script and add a regression guard so desktop typecheck remains dependency-order aware.

## Regression detected
`bun run typecheck` on a clean sentinel worktree failed with:

```text
@signet/desktop typecheck: src/tray.ts(1,87): error TS2307: Cannot find module '@signet/tray' or its corresponding type declarations.
```

## Root cause
PR #673 added the packaged desktop update path while desktop already depends on shared tray utilities. The desktop build path builds tray first, but the typecheck path only ran `tsc -p tsconfig.json --noEmit`. Because `@signet/tray` exposes generated declarations from `dist/`, a fresh worktree with no prior tray build cannot typecheck desktop.

## Fix summary
- Change `surfaces/desktop` `typecheck` to run `bun run build:tray` before `tsc --noEmit`.
- Add an integration regression guard covering desktop typecheck dependency order.

## Tests / checks run
- `bun install` — passed
- `bun test tests/integration/docker-build-regression.test.ts` — initially failed before fix, passes after fix
- `bun run typecheck` — initially failed before fix, passes after fix
- `bun test surfaces/desktop/src/desktop-updates.test.ts surfaces/cli/src/features/desktop.test.ts platform/core/src/workspace-source-repo.test.ts tests/integration/docker-build-regression.test.ts` — passed, 33 tests
- `bun scripts/version-sync.ts --check` — passed
- `bun scripts/check-publish-manifests.ts` — passed
- `cargo check -p signet-daemon -p signet-mcp-stdio` from `platform/daemon-rs` — passed
- `cargo test -p signet-daemon` from `platform/daemon-rs` — passed, 133 unit tests; contract replay tests ignored as expected
- `bunx --bun biome check surfaces/desktop/package.json tests/integration/docker-build-regression.test.ts` — passed
- `git diff --check` — passed

## Remaining risk / follow-up
- This keeps the fix intentionally narrow. It does not change desktop runtime behavior or release packaging.

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes
- [x] No database migrations were added, removed, renumbered, or modified.
