### PR TITLE
feat(blog): three new essays on memory architecture and sovereignty

### DIFF
--- a/web/marketing/src/content/blog/bring-both-kinds-of-memory.mdx
+++ b/web/marketing/src/content/blog/bring-both-kinds-of-memory.mdx
@@ -1,0 +1,108 @@
+---
+title: "Bring Both Kinds of Memory"
+description: "Signet should let you bring both curated knowledge and structured data into one place, then let your agents use whichever form the work requires. The answer is not wiki or database. It is both."
+date: 2026-05-11
+author: "Nicholai"
+tags: ["architecture", "memory", "knowledge"]
+image: /blog/bring-both-kinds-of-memory.png
+draft: false
+---
+
+Signet should let you bring both curated knowledge and structured data into one place, then let your agents use whichever form the work requires.
+
+That sounds simple, but it cuts through one of the more confused arguments in agent memory right now. People keep asking whether the future is markdown wikis or structured databases, whether agents should maintain human-readable notes or query precise tables, whether memory should be a living notebook or a knowledge graph. The answer is yes. Not because tradeoffs are fake, but because different kinds of knowledge deserve different shapes.
+
+A research note is not a customer record. A codebase is not a journal entry. A meeting transcript is not the same thing as the decision that came out of it. Trying to force all of those into one memory model is how you get systems that look elegant in demos and fall apart the moment real work touches them.
+
+The useful question is not, "Should memory be a wiki or a database?" The useful question is, "When should the system do the hard thinking?"
+
+
+## When thinking happens at write time
+
+A wiki is a write-time intelligence system.
+
+When you drop in a source, the agent does not just store it. It reads the source, decides what matters, updates existing pages, adds links, names contradictions, and turns raw material into something you can browse later. The value is not the folder of markdown files by itself. The value is that the system compiled understanding once instead of forcing every future question to rediscover it.
+
+This is why Karpathy's LLM wiki landed so hard. Most people have spent the last few years uploading files into chat windows and asking the model to reason across them. The model does real cognitive work, gives a decent answer, and then throws the work away. Ask a similar question next week and the same thing happens again. It searches, rereads, reconnects, summarizes, forgets.
+
+A maintained wiki changes that loop. The agent becomes a keeper of the thinking system, not just an answer machine. It writes down the synthesis. It keeps the links alive. It notices that this week's paper changes the meaning of last week's note. It gives you a place to wander through your own understanding.
+
+That matters for the kind of work where meaning lives between sources. If you are reading ten papers on agent memory, the value is not just in paper one or paper six. It is in the way paper six changes your reading of paper one. It is in the contradiction between two claims that both seemed true until they sat next to each other. It is in the slow formation of taste.
+
+Obsidian is good at this because it respects the shape of thought. A note can be a source, a summary, a concept, a contradiction, a project hub, or a half-formed question. Wikilinks let ideas touch without needing a rigid schema first. The file stays readable. The graph stays inspectable. Git can show what changed.
+
+That is curated knowledge. It carries judgment. It is not just data about the world. It is a record of how someone is coming to understand the world.
+
+
+## When thinking happens at read time
+
+A structured memory system is different. It does less interpretation when the source arrives and more interpretation when a question is asked.
+
+That is not a weakness. It is the whole point.
+
+If you store a meeting as structured data, you can keep the speaker, timestamp, client, project, decision, action items, confidence, and source link separate. If you store a codebase as a structured graph, an agent can ask which module calls which function, which files changed recently, which symbols connect two features, and which claim came from which source. If you store personal memory as entities, aspects, and attributes, the agent can retrieve a preference without pretending a paragraph summary is the canonical truth.
+
+This kind of memory wins when precision matters. You can filter it, sort it, join it, query it, audit it, and expose it safely to multiple agents at once.
+
+A folder of markdown files can approximate some of that, bless its heart, but there is a point where approximation becomes fiction. "Find every pricing conversation from Q1 involving this client" is not a literary question. "Show which code paths touch this API" is not a vibes question. "Which facts about this person are current, and which were superseded?" is not something you want buried in prose that sounds confident because the sentence is well written.
+
+Structured memory also preserves tension. A wiki can accidentally smooth over a contradiction because prose wants to resolve things. If engineering says a build will take twelve weeks and sales promised eight, the system should not elegantly average that into ten. The gap is the point. A structured store can keep both claims, both sources, both timestamps, and the fact that they conflict.
+
+That is read-time intelligence. The system keeps the substrate faithful, then lets the agent reason from it when the actual question appears.
+
+
+## Why one layer is not enough
+
+The temptation is to pick a side.
+
+Wiki people are right that raw storage is not understanding. If all you have is a pile of transcripts, PDFs, source files, and chat logs, your agent has to rebuild meaning from scratch every time. It burns tokens, misses connections, and repeats work it already did yesterday.
+
+Database people are right that clean summaries are not ground truth. A wiki page can hide what it left out. It can make old understanding look current. It can turn uncertainty into confident prose. It can become a beautiful dashboard that hides the one row you needed to see.
+
+Both failures matter because agents do not only answer questions anymore. They act. They write code, make plans, draft emails, prepare reports, inspect systems, route work, and carry decisions from one environment into another. If the memory layer is too raw, the agent wastes effort. If it is too distilled, the agent inherits yesterday's editorial mistake and builds on it.
+
+This is the reason the no-escape theorem matters beyond the math. Meaning-based retrieval is useful, but it degrades as the corpus grows. Exact records are stable, but inert. The sane architecture keeps an exact substrate and builds semantic or narrative layers over it. One layer preserves what happened. The other helps the agent understand why it matters.
+
+Separately, neither is enough. Together, they stop pretending there is only one shape for knowledge.
+
+
+## What Signet should do
+
+Signet's job is to be the place where these forms meet.
+
+A user should be able to connect an Obsidian vault and have agents treat it as a curated knowledge base, not as a dumb folder of text. The backlinks, project hubs, daily notes, literature notes, people notes, and permanent notes are part of the meaning. They should be indexed, searchable, linkable, and available to agents without stripping away the narrative shape that made the vault useful in the first place.
+
+The same user should be able to connect a codebase and have agents reason over its structure. Not just grep strings. Not just dump files into context. The agent should be able to ask about modules, symbols, call paths, ownership, tests, recent changes, and architectural constraints.
+
+The same user should be able to connect structured databases. Customers, tasks, calendar events, memories, research claims, audit logs, whatever the work requires. Those stores should remain queryable as structured stores. They should not have to be flattened into prose before an agent can use them.
+
+That is the product thesis: Signet lets you bring curated data and structured data to one place, then lets your agents use both.
+
+Not one memory system for every kind of knowledge. One context layer that can hold multiple kinds of knowledge without confusing them.
+
+The important part is provenance. Signet should know the difference between a source and a synthesis, between a claim and a summary, between a code symbol and a note about that symbol, between a human-written project hub and an agent-generated brief. The compiled layer can be useful without becoming the source of truth.
+
+That gives users a better deal than the current split. Today, your curated thinking lives in Obsidian. Your code lives in repositories. Your structured data lives in databases. Your agent memory lives wherever the harness decided to hide it. Every tool gets a partial view, so every agent behaves like a smart stranger standing in the wrong room.
+
+Signet should make the room portable.
+
+The agent should be able to walk into your work with the vault, the database, the codebase, and the memory layer available as different surfaces of the same owned context. It should know when to read the wiki, when to query the database, when to inspect the file, and when to ask for the raw source because the summary is not enough.
+
+That is not a small distinction. It is the difference between memory as a feature and context as infrastructure.
+
+
+## The human still owns the shape
+
+There is one more piece that matters. A system like this should not erase human curation.
+
+The appeal of an Obsidian vault is not that markdown is magical. It is that the human can shape the knowledge. A project hub carries emphasis. A people note carries relational judgment. A permanent note carries a claim someone was willing to stand behind. A daily note carries the mess of what actually happened before it became a clean story.
+
+Agents can help maintain that. They can transcribe, link, index, extract, summarize, and flag contradictions. They can do the bookkeeping humans are bad at maintaining. But they should not quietly replace the user's judgment with a shiny summary and call it memory.
+
+The same is true on the structured side. A database schema is a theory about what matters. If you track source, timestamp, confidence, and supersession, you are saying provenance matters. If you track entities and aspects, you are saying identity and context change over time. If you track code symbols and call edges, you are saying structure matters as much as text.
+
+Signet should respect those theories instead of flattening them.
+
+The goal is not to build one perfect brain in the cloud. The goal is to give agents durable access to the context users already own, in the forms where that context makes sense. Sometimes that form is a note. Sometimes it is a table. Sometimes it is a graph. Sometimes it is a raw file you should not summarize until the question demands it.
+
+The future of agent memory is not choosing between the study guide and the filing cabinet. It is giving the agent both, teaching it which one it is holding, and making sure the user owns the room they live in.

--- a/web/marketing/src/content/blog/the-obsidian-of-ai-memory-systems.mdx
+++ b/web/marketing/src/content/blog/the-obsidian-of-ai-memory-systems.mdx
@@ -1,0 +1,87 @@
+---
+title: "The Obsidian of AI Memory Systems"
+description: "The lesson from Obsidian is not markdown. It is that people should own the shape of their thinking. That is the posture AI memory systems need."
+date: 2026-05-11
+author: "Nicholai"
+tags: ["sovereignty", "obsidian", "knowledge", "positioning"]
+image: /blog/the-obsidian-of-ai-memory-systems.png
+draft: false
+---
+
+The lesson from Obsidian is not markdown. It is that people should own the shape of their thinking.
+
+That is easy to miss because the surface details are so visible. Local files. Wikilinks. Graph view. Backlinks. Plugins. Themes. A folder you can sync with git. Those details matter, but they are not the deepest reason Obsidian works. Obsidian works because it does not force every thought into the same box.
+
+A daily note can stay messy. A permanent note can sharpen into an argument. A project hub can collect the current state. A people note can carry relational context. A literature note can preserve someone else's idea while linking into your own. The system gives enough structure for connections to compound, but not so much structure that the tool starts thinking it is smarter than the user.
+
+That is the posture AI memory systems need.
+
+
+## The wrong lesson
+
+A shallow version of this argument says, "Use markdown for AI memory."
+
+Markdown is good. Plain text is inspectable, portable, diffable, and boring in the best possible way. A memory you can read with `cat` has a different moral character than a memory trapped behind a product API. But markdown by itself is not the point. A folder full of random markdown files can still be a junk drawer.
+
+The better lesson is that Obsidian makes knowledge navigable without making it rigid.
+
+That matters because human knowledge is uneven. Some ideas are polished. Some are fragments. Some are questions. Some are records. Some are private context that should inform action without being sprayed into every answer. Some are project-specific. Some belong to a person. Some belong to a moment and should not pretend to be timeless.
+
+A good memory system needs to hold all of that without demanding that every piece become the same kind of object.
+
+The danger with AI systems is that they love neatness. Give an agent a messy folder and it will want to summarize, categorize, compress, rename, and sand down all the splinters. Sometimes that is helpful. Sometimes that destroys the reason the note mattered.
+
+A vault is not a filing cabinet. It is a thinking environment.
+
+
+## Curated knowledge carries judgment
+
+A curated note is not just data. It is a choice.
+
+When a human links two ideas, that link carries judgment. When a project hub says "current state," it tells the agent what the human believes is live. When a people note tracks communication style, it is not merely storing facts about a person. It is preserving relational context so the agent does not behave like a forklift in a flower shop.
+
+This is the difference between indexing an Obsidian vault as raw text and understanding it as a curated knowledge base. The links matter. The folders matter lightly. The note types matter. The absence of a link can matter. The fact that something lives in a daily note instead of a permanent note can matter.
+
+Agents need access to that shape.
+
+If Signet connects to an Obsidian vault, it should not treat the vault like a bag of chunks. It should understand backlinks, project hubs, daily notes, literature notes, people notes, and permanent notes as different surfaces. It should know that some notes are sources and some notes are synthesis. It should preserve the human's structure instead of replacing it with whatever taxonomy the model invented during ingest.
+
+That does not mean the agent never writes. The agent can transcribe, link, index, summarize, and maintain. It can do the bookkeeping. It can notice missing connections. It can update a project hub after a daily note changes the state of the work. That is exactly the kind of labor agents are good at.
+
+But the agent should be maintaining the user's thinking system, not colonizing it.
+
+
+## Obsidian alone is not enough
+
+The other mistake is pretending a vault can do every job.
+
+A vault is wonderful for narrative knowledge, but agents also need structured operations. They need to query code symbols, filter tasks, inspect source provenance, sort events by time, compare current and superseded facts, and let multiple tools read the same context without stepping on one another.
+
+This is where wiki and structured memory need each other. Obsidian gives the human-shaped layer. Structured stores give the machine-shaped layer. Neither should dominate the other.
+
+A codebase should not have to become a prose essay before an agent can reason about it. A database should not have to become a wiki page before an agent can filter it. A personal vault should not have to become a rigid schema before its links and notes become useful.
+
+This is the real opportunity for Signet. It can let an Obsidian vault remain a vault while still connecting it to structured memory, code graphs, explicit agent memories, and generated views.
+
+The vault becomes one surface of owned context. Not the only surface. Not a toy interface over a hidden database. One honest surface among several.
+
+
+## What Signet should borrow
+
+Signet should borrow Obsidian's restraint.
+
+Do not make the context layer the whole application. Do not force every user into the same workflow. Do not make the agent's summary more authoritative than the user's file. Do not hide the memory somewhere only the product can inspect. Do not over-solve the user's thinking until there is nothing human left in it.
+
+Borrow the local-first instinct. Borrow the graph of associations. Borrow the idea that links are first-class. Borrow the acceptance that some notes are messy because life is messy. Borrow the plugin-shaped openness, where people can extend the system without waiting for the vendor to bless every use case.
+
+Then add what agents need.
+
+Add structured recall. Add provenance. Add currentness. Add scoped access. Add query APIs. Add codebase indexing. Add secrets. Add cross-harness portability. Add the ability for Claude Code, OpenCode, Codex, OpenClaw, and the next harness to stand on the same owned context without trapping that context inside any one of them.
+
+That is how Signet becomes the Obsidian of AI memory systems without becoming an Obsidian clone.
+
+The goal is not a prettier notebook. The goal is a context layer that respects human-shaped knowledge and gives agents the structure they need to act on it.
+
+Let people keep the shape of their thinking. Let agents help maintain it. Let structured systems make it queryable. Let the user own the whole thing.
+
+That is the part worth building.

--- a/web/marketing/src/content/blog/the-source-and-the-synthesis.mdx
+++ b/web/marketing/src/content/blog/the-source-and-the-synthesis.mdx
@@ -1,0 +1,98 @@
+---
+title: "The Source and the Synthesis"
+description: "A good memory system keeps the source and the synthesis separate. Raw memory without synthesis is a warehouse with no lights. Synthesis without source is a confident story you cannot audit."
+date: 2026-05-11
+author: "Nicholai"
+tags: ["architecture", "memory", "positioning"]
+image: /blog/the-source-and-the-synthesis.png
+draft: false
+---
+
+A good memory system keeps the source and the synthesis separate.
+
+The source is what happened. The synthesis is what the system currently thinks it means. Both are useful. They are not the same thing.
+
+This sounds obvious until an agent starts working across months of chat logs, meeting notes, code changes, research papers, project docs, and personal preferences. At that point, the distinction gets expensive fast. If the agent only has raw source, it has to reconstruct meaning every time it acts. If it only has synthesis, it can act quickly from a polished misunderstanding.
+
+That is the trap. Raw memory without synthesis is a warehouse with no lights. Synthesis without source is a confident story you cannot audit.
+
+Signet should preserve the substrate, generate the understanding, and query on top of both.
+
+
+## The source is the ground
+
+A source is the thing you can point to when somebody asks, "How do we know?"
+
+It might be a transcript, a daily note, a commit, a code file, a database row, a calendar event, a clipped article, or a screenshot. It does not need to be pretty. It needs to be durable. It needs provenance. It needs timestamps. It needs to survive the model, the harness, the current summary, and the mood of whoever was asking questions that day.
+
+This is where a lot of AI memory systems get too clever too early. They ingest a conversation and immediately turn it into a tidy statement. They compress a messy thread into three bullets. They rewrite a project history into a clean narrative. That can be useful, but it is not harmless. Every compression is an editorial act. Every summary decides what mattered. Every clean sentence leaves something out.
+
+Sometimes the omitted thing is trivia. Sometimes it is the entire point.
+
+A customer saying, "This is fine for now," and a customer saying, "This is fine," can lead to very different decisions three months later. A project note that says "blocked on auth" is not the same as the three-message exchange where the team realized the auth problem was really a permissions boundary problem. A code comment can tell you what the function does. The commit history can tell you why it got weird.
+
+If the source is gone, the agent cannot recover that texture. It can only reason from the version someone, or something, decided to keep.
+
+
+## The synthesis is the map
+
+But source alone is not enough.
+
+If an agent has to reread every raw artifact before doing anything useful, the system has not built memory. It has built storage. That is better than nothing, but not by much. Storage remembers that something exists. Memory helps the agent use it.
+
+Synthesis is what turns accumulated source into working context. It notices that three meetings were really about the same unresolved decision. It turns a pile of research clips into a concept note. It tracks that a preference changed. It names that two people are using the same word differently. It compiles what would otherwise be scattered across files, chats, and commits.
+
+This is why LLM-maintained wikis are compelling. They stop making the model rediscover the same shape over and over. The system writes down what it has learned. It updates links. It makes a topic browsable. It gives the human and the agent a shared artifact to return to.
+
+That is real value. Pretending otherwise is just database chauvinism with a nice hat.
+
+A synthesis is not lesser because it is derived. It is lesser only when it pretends not to be derived. A good synthesis should know what sources support it, what assumptions shaped it, when it was last refreshed, and where it might be wrong. It should be easy to challenge. It should invite the agent back to the raw material when the question demands precision.
+
+The map is allowed to be useful. It is not allowed to become the territory.
+
+
+## Where systems go wrong
+
+Most bad memory systems fail by collapsing layers.
+
+One version collapses everything into raw logs. The product says, "We remember everything," but what it really means is, "We can search old text." The agent then has to decide what to pull, what to trust, what changed, what contradicted what, and whether the current question needs an exact fact or a conceptual summary. It pays that reasoning tax again and again.
+
+The other version collapses everything into summaries. The product says, "We understand you," but what it really means is, "We wrote down a lossy interpretation and hope it stays true." This feels better at first because the output is clean. It feels like memory. It reads like understanding. Then one day the agent acts on a stale summary, or misses the source that would have changed the answer, and nobody knows where the mistake entered the system.
+
+That is the dangerous part. A pile of raw source looks incomplete when it is incomplete. A clean synthesis can look complete while being wrong. It can launder uncertainty through prose.
+
+The solution is not to hate summaries. The solution is to keep them in their place.
+
+
+## Preserve, generate, query
+
+The architecture Signet should aim for is simple enough to say plainly.
+
+Preserve the substrate. Generate understanding from it. Query on top of both.
+
+Preserving the substrate means source material remains available in its own shape. Markdown notes stay notes. Code stays code. Databases stay databases. Transcripts stay transcripts. Structured memories keep their entity, aspect, claim, timestamp, and provenance. A later agent can inspect the ground truth instead of trusting a story about it.
+
+Generating understanding means agents can still compile, summarize, connect, and maintain narrative artifacts. Project hubs, topic briefs, contradiction maps, research summaries, people notes, daily digests, and wiki pages are all useful. They are the working layer. They help humans and agents move quickly without starting from zero.
+
+Querying on top of both means the agent can choose the right layer for the job. If the question is conceptual, read the synthesis first. If the question is precise, query the structured store. If the answer carries risk, inspect the source. If the synthesis and source disagree, trust the source and update the synthesis.
+
+That last part matters. The system should not make the user remember which layer is safe. The agent should know.
+
+
+## What this unlocks
+
+Once source and synthesis are separated, the product gets calmer.
+
+An Obsidian vault can be imported as curated knowledge without being flattened into a database-shaped smear. The links, hubs, and narrative notes still matter. They carry human judgment. They tell the agent what the user has already chosen to connect.
+
+A codebase can be indexed structurally without being treated like an essay. The agent can query symbols, call paths, modules, and tests, then open source files when the exact implementation matters.
+
+A structured memory graph can hold facts without pretending every fact belongs in prose. It can preserve currentness, supersession, confidence, and provenance. It can keep two conflicting claims visible instead of smoothing them into a sentence that feels reasonable and is strategically useless.
+
+A generated wiki can sit on top of all of that. It can be beautiful. It can be readable. It can help the user think. But it does not have to carry the impossible burden of being both interface and truth.
+
+That is the shape I want from Signet. Not a magic brain. Not a pile of files. Not a database with branding. A context layer that knows what kind of knowledge it is holding.
+
+The source lets the agent stay honest. The synthesis lets the agent move.
+
+You need both.


### PR DESCRIPTION
## New Blog Posts

Three essays adapted from the Obsidian vault for publication on signetai.sh.

### 1. The Source and the Synthesis
A good memory system keeps source and synthesis separate. Raw memory without synthesis is a warehouse with no lights. Synthesis without source is a confident story you cannot audit. The architecture: preserve the substrate, generate understanding, query on top of both.

### 2. Bring Both Kinds of Memory
Wiki vs database is a false choice. Write-time intelligence (curated knowledge, human judgment) meets read-time intelligence (structured query, filtering, precision). Signet is where both forms meet, with provenance.

### 3. The Obsidian of AI Memory Systems
The lesson from Obsidian is not markdown. It is that people should own the shape of their thinking. Signet borrows that restraint and adds what agents need: structured recall, scoped access, cross-harness portability.

## Details
- Converted from Obsidian vault essays (permanent/blogs/)
- Removed wikilinks, image embeds, adapted to MDX format
- Existing blog posts had similar architecture themes (retrieval-is-not-memory, knowledge-architecture) — these complement rather than duplicate
- When merged to main, deploy-web.yml will auto-deploy to Cloudflare

## Verification
- `bun run build` passes cleanly with all three new posts
- Frontmatter follows existing convention (title, description, date, author, tags, image, draft)
