### PR TITLE
fix(docker): verify public ghcr pulls after publish

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -55,17 +55,16 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Verify public GHCR pull
+      - name: Verify public GHCR latest pull
+        if: ${{ !contains(github.ref_name, '-') }}
         run: |
           set -euo pipefail
           tmp_config="$(mktemp -d)"
           trap 'rm -rf "${tmp_config}"' EXIT
           if ! DOCKER_CONFIG="${tmp_config}" docker manifest inspect ghcr.io/signet-ai/signet:latest >/tmp/signet-public-manifest.json; then
-            cat <<'EOF' >&2
-::error::Published ghcr.io/signet-ai/signet:latest is not publicly pullable.
-The Docker image was pushed, but anonymous GHCR pulls cannot retrieve it.
-Set the GHCR package visibility to public and keep repository inheritance linked:
-https://github.com/orgs/Signet-AI/packages/container/package/signet/settings
-EOF
+            echo "::error::Published ghcr.io/signet-ai/signet:latest is not publicly pullable." >&2
+            echo "The stable Docker image was pushed, but anonymous GHCR pulls cannot retrieve it." >&2
+            echo "Set the GHCR package visibility to public and keep repository inheritance linked:" >&2
+            echo "https://github.com/orgs/Signet-AI/packages/container/package/signet/settings" >&2
             exit 1
           fi

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -54,3 +54,18 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Verify public GHCR pull
+        run: |
+          set -euo pipefail
+          tmp_config="$(mktemp -d)"
+          trap 'rm -rf "${tmp_config}"' EXIT
+          if ! DOCKER_CONFIG="${tmp_config}" docker manifest inspect ghcr.io/signet-ai/signet:latest >/tmp/signet-public-manifest.json; then
+            cat <<'EOF' >&2
+::error::Published ghcr.io/signet-ai/signet:latest is not publicly pullable.
+The Docker image was pushed, but anonymous GHCR pulls cannot retrieve it.
+Set the GHCR package visibility to public and keep repository inheritance linked:
+https://github.com/orgs/Signet-AI/packages/container/package/signet/settings
+EOF
+            exit 1
+          fi

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -34,6 +34,18 @@ container:
 - `memory/memories.db`
 - `.daemon/auth-secret`
 
+## Published image
+
+Release tags publish the multi-arch image to GHCR:
+
+```bash
+docker pull ghcr.io/signet-ai/signet:latest
+```
+
+The package must remain public. Release CI verifies anonymous pulls after
+pushing so package visibility regressions do not look green while users see
+`unauthorized`.
+
 ## Upgrade flow
 
 ```bash

--- a/tests/integration/docker-build-regression.test.ts
+++ b/tests/integration/docker-build-regression.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 
 const rootDir = fileURLToPath(new URL("../../", import.meta.url));
 const dockerfile = readFileSync(join(rootDir, "deploy/docker/Dockerfile"), "utf8");
+const dockerImageWorkflow = readFileSync(join(rootDir, ".github/workflows/docker-image.yml"), "utf8");
 const dockerignore = readFileSync(join(rootDir, ".dockerignore"), "utf8");
 const openclawPackageJson = JSON.parse(
 	readFileSync(join(rootDir, "integrations/openclaw/memory-adapter/package.json"), "utf8"),
@@ -128,5 +129,11 @@ describe("Docker build pipeline regression guard", () => {
 
 	it("keeps desktop Linux package metadata complete for deb generation", () => {
 		expect(desktopHomepage).toBe("https://signetai.sh");
+	});
+
+	it("fails Docker release CI when GHCR latest is not publicly pullable", () => {
+		expect(dockerImageWorkflow).toContain("Verify public GHCR pull");
+		expect(dockerImageWorkflow).toContain("DOCKER_CONFIG=\"${tmp_config}\" docker manifest inspect ghcr.io/signet-ai/signet:latest");
+		expect(dockerImageWorkflow).toContain("is not publicly pullable");
 	});
 });

--- a/tests/integration/docker-build-regression.test.ts
+++ b/tests/integration/docker-build-regression.test.ts
@@ -131,8 +131,9 @@ describe("Docker build pipeline regression guard", () => {
 		expect(desktopHomepage).toBe("https://signetai.sh");
 	});
 
-	it("fails Docker release CI when GHCR latest is not publicly pullable", () => {
-		expect(dockerImageWorkflow).toContain("Verify public GHCR pull");
+	it("fails stable Docker release CI when GHCR latest is not publicly pullable", () => {
+		expect(dockerImageWorkflow).toContain("Verify public GHCR latest pull");
+		expect(dockerImageWorkflow).toContain('if: ${{ !contains(github.ref_name, \'-\') }}');
 		expect(dockerImageWorkflow).toContain("DOCKER_CONFIG=\"${tmp_config}\" docker manifest inspect ghcr.io/signet-ai/signet:latest");
 		expect(dockerImageWorkflow).toContain("is not publicly pullable");
 	});


### PR DESCRIPTION
## Summary
- Add a post-publish Docker release guard that verifies `ghcr.io/signet-ai/signet:latest` is anonymously pullable.
- Document the public GHCR image and the requirement that the package remain public.
- Add regression coverage so the Docker release workflow keeps the public-pull check.

## Root cause
Docker images are being pushed successfully, but anonymous GHCR pulls currently return `unauthorized`. That points to GHCR package visibility/access drift, not a build/push failure. The current GitHub token available here does not include package admin scopes, so the package visibility still needs to be flipped in GHCR settings.

## Testing
- `bun test tests/integration/docker-build-regression.test.ts`
- `bunx --bun biome format --write .github/workflows/docker-image.yml tests/integration/docker-build-regression.test.ts deploy/docker/README.md`
- `bunx --bun biome check .github/workflows/docker-image.yml tests/integration/docker-build-regression.test.ts deploy/docker/README.md`
- `git diff --check`

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes
- [x] No database migrations were added, removed, renumbered, or modified.
