### PR TITLE
fix(ontology): enforce concrete semantic objects

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -4314,6 +4314,7 @@ silently disappear from the API reference.
 | POST | `/api/repair/reclassify-entities` | platform/daemon/src/routes/repair-routes.ts |
 | POST | `/api/repair/prune-chunk-groups` | platform/daemon/src/routes/repair-routes.ts |
 | POST | `/api/repair/prune-singleton-entities` | platform/daemon/src/routes/repair-routes.ts |
+| POST | `/api/repair/prune-generic-entities` | platform/daemon/src/routes/repair-routes.ts |
 | POST | `/api/repair/structural-backfill` | platform/daemon/src/routes/repair-routes.ts |
 | GET | `/api/repair/cold-stats` | platform/daemon/src/routes/repair-routes.ts |
 | POST | `/api/repair/cluster-entities` | platform/daemon/src/routes/repair-routes.ts |

--- a/docs/KNOWLEDGE-ARCHITECTURE.md
+++ b/docs/KNOWLEDGE-ARCHITECTURE.md
@@ -81,12 +81,23 @@ actually matter. The noise has been refined away. What remains is structure.
 Entities
 --------
 
-Everything in the database is either an entity, or it belongs to one.
+Everything in the database is either a semantic object, evidence for one,
+or derived structure that belongs to one.
 
-An entity is anything that can be identified — a person, a project, a
-system, a tool, a concept. Entities are persistent. They accumulate
-knowledge over time. They never expire. They are the organizing scope of
-the entire knowledge graph.
+An entity is an identity-bearing semantic object: a person, organization,
+project, product, system/tool, artifact/document/source, place, or event.
+Entities are concrete enough that an agent can point at them, revisit them,
+attach evidence to them, and ask follow-up questions about them later. Abstract
+descriptions belong in aspects, attributes, claims, or relations rather than
+being minted as entity rows.
+
+Events are first-class entities because time-aware recall depends on them.
+`Signet Daily Digest — 2026-05-10` is an event. It can have an `occurred_at`
+attribute, participants, related artifacts, source provenance, and relations to
+the projects/products it summarized. A question like "when was our last daily
+digest?" should sort daily-digest events by time and expand to source artifacts
+only when evidence is needed; it should not scrape transcript soup hoping a
+timestamp appears nearby.
 
 `nicholai` is an entity. `ooIDE` is an entity. `WorkOS` is an entity.
 Their relationships to each other — that nicholai works on ooIDE, that

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -222,26 +222,34 @@ The existing `importance` column on `memories` remains for backwards
 compatibility and cold-start scoring, but the structural computation
 is the source of truth once KA tables are populated.
 
-### 3. Entity type taxonomy is canonical
+### 3. Entity type taxonomy is concrete
 
-The knowledge architecture schema defines the canonical entity types:
-`person`, `project`, `system`, `tool`, `concept`, `skill`, `task`,
-`source`, `artifact`, `agent`, `policy`, `action`, `workflow`, `event`,
-`object_type`, `interface`, `observation`, `claim_slot`, `claim_value`,
-`unknown`.
+The knowledge architecture schema defines the canonical concrete entity types:
+`person`, `organization`, `project`, `product`, `system`, `tool`, `artifact`,
+`document`, `source`, `place`, and `event`.
 
-All specs that create entities MUST use this taxonomy. Procedural memory
-creates `entity_type = 'skill'`. Multi-agent creates agent-scoped
-entities. The ontology proposal loop extends KA's canonical taxonomy with
-source/proposal lifecycle labels so extraction can model artifacts,
-observations, claim slots, and claim values without minting ad-hoc string
-categories. The taxonomy is not extensible without updating KA and this
-invariant in the same change.
+Entities are identity-bearing semantic objects: things the agent can point at,
+revisit, update, and ask about later. Events are first-class because temporal
+questions such as "when was our last daily digest?" should resolve through
+provenance-backed happenings with time attributes, participants, event types,
+and related artifacts.
 
-**Planned extension:** DP-14 (Discovered Principles) in the desire
-paths epic will add `principle` as an entity type for emergent
-cross-entity patterns. This invariant must be updated when DP-14
-lands.
+Claims, aspects, and attributes describe entities. Relations carry predicates.
+Artifacts carry evidence. Extraction MUST NOT mint entities from pronouns,
+metadata roles (`Sender`, `Recipient`, `Author`), generic role words (`User`,
+`Assistant`, `System`), section headings (`Summary`, `Current Work`, `Primary
+Request`), discourse fragments, prompt scaffolding, claim slots, policies,
+actions, or workflows. Those belong in facts, aspects, attributes, relations,
+or operational/proposal layers.
+
+Legacy rows may still use older types while repair actions converge existing
+databases, but all new extraction and structured graph writes must pass the
+concrete taxonomy gate. The taxonomy is not extensible without updating KA and
+this invariant in the same change.
+
+Ontology-governance specs can still propose new semantic object classes, but
+new classes must explain why the object is identity-bearing and why aspects,
+attributes, relations, or proposal records cannot represent it cleanly.
 
 ### 4. Scorer consumes all available signals
 

--- a/docs/specs/complete/knowledge-architecture-schema.md
+++ b/docs/specs/complete/knowledge-architecture-schema.md
@@ -109,16 +109,25 @@ is the primary retrieval floor.
 
 ### 5.1 Entity type taxonomy
 
-Extend `entities.entity_type` usage to the canonical set:
+Extend `entities.entity_type` usage to the concrete, identity-bearing set:
 
 - `person`
+- `organization`
 - `project`
+- `product`
 - `system`
 - `tool`
-- `concept`
-- `skill`
-- `task`
-- `unknown` (fallback)
+- `artifact`
+- `document`
+- `source`
+- `place`
+- `event`
+
+Events are first-class entities when they represent real happenings with time,
+provenance, participants, a target object, or an event type. Abstract concepts,
+claim slots, policies, actions, workflows, tasks, and prompt roles are not
+entity types in the extraction path; they live as aspects, attributes, claims,
+relations, proposal records, or operational task metadata.
 
 ### 5.2 Backfill: `agent_id` on `entities`
 

--- a/docs/specs/dependencies.yaml
+++ b/docs/specs/dependencies.yaml
@@ -167,6 +167,8 @@ specs:
     success_criteria:
       - "Memory retrieval returns structurally related context, not just embedding-similar fragments"
       - "Entity graph traversal produces richer context than flat embedding search alone"
+      - "Extraction creates only concrete identity-bearing semantic objects as entities, with events first-class for time-aware recall"
+      - "Pronouns, metadata roles, headings, discourse fragments, prompt scaffolding, and abstract claim/policy/action slots are rejected or pruned instead of becoming entities"
     decision: null
 
   - id: knowledge-architecture-navigation

--- a/platform/daemon/src/entity-quality.test.ts
+++ b/platform/daemon/src/entity-quality.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import { classifyEntityQuality } from "./entity-quality";
+
+describe("entity-quality", () => {
+	it("allows short concrete tools and systems when the type is concrete", () => {
+		for (const [name, type] of [
+			["Bun", "tool"],
+			["npm", "tool"],
+			["Git", "tool"],
+			["AWS", "system"],
+			["Go", "tool"],
+			["CI", "system"],
+			["AI", "product"],
+		] as const) {
+			expect(classifyEntityQuality(name, type)).toEqual({ ok: true });
+		}
+	});
+
+	it("still rejects short untyped fragments and generic scaffolding", () => {
+		expect(classifyEntityQuality("50")).toEqual({ ok: false, reason: "numeric_only" });
+		expect(classifyEntityQuality("cli")).toEqual({ ok: false, reason: "too_short" });
+		expect(classifyEntityQuality("You", "person")).toEqual({
+			ok: false,
+			reason: "generic_or_scaffolding_name",
+		});
+		expect(classifyEntityQuality("Sender", "person")).toEqual({
+			ok: false,
+			reason: "generic_or_scaffolding_name",
+		});
+	});
+});

--- a/platform/daemon/src/entity-quality.ts
+++ b/platform/daemon/src/entity-quality.ts
@@ -1,0 +1,193 @@
+const CONCRETE_ENTITY_TYPES = [
+	"person",
+	"organization",
+	"project",
+	"product",
+	"system",
+	"tool",
+	"artifact",
+	"document",
+	"source",
+	"place",
+	"event",
+] as const;
+
+export type ConcreteEntityType = (typeof CONCRETE_ENTITY_TYPES)[number];
+
+export const CONCRETE_ENTITY_TYPE_SET = new Set<string>(CONCRETE_ENTITY_TYPES);
+
+const ABSTRACT_OR_OPERATIONAL_TYPES = new Set([
+	"concept",
+	"task",
+	"skill",
+	"agent",
+	"policy",
+	"action",
+	"workflow",
+	"object_type",
+	"interface",
+	"observation",
+	"claim_slot",
+	"claim_value",
+	"chunk_group",
+]);
+
+const GENERIC_CANONICAL_NAMES = new Set([
+	"a",
+	"an",
+	"and",
+	"are",
+	"author",
+	"because",
+	"being",
+	"but",
+	"can",
+	"current work",
+	"did",
+	"do",
+	"does",
+	"for",
+	"from",
+	"had",
+	"has",
+	"have",
+	"he",
+	"her",
+	"him",
+	"his",
+	"i",
+	"in",
+	"intent",
+	"is",
+	"it",
+	"its",
+	"let",
+	"of",
+	"on",
+	"or",
+	"pending tasks",
+	"primary request",
+	"read",
+	"recipient",
+	"sender",
+	"she",
+	"someone",
+	"summary",
+	"that",
+	"the",
+	"their",
+	"them",
+	"they",
+	"this",
+	"to",
+	"understand",
+	"want",
+	"was",
+	"we",
+	"we're",
+	"were",
+	"with",
+	"write",
+	"you",
+	"your",
+]);
+
+const METADATA_LABELS = new Set([
+	"assistant",
+	"author",
+	"current work",
+	"intent",
+	"pending tasks",
+	"primary request",
+	"recipient",
+	"sender",
+	"system",
+	"user",
+]);
+
+const DISCOURSE_WORDS = new Set([
+	"because",
+	"despite",
+	"however",
+	"let",
+	"once",
+	"read",
+	"summary",
+	"understand",
+	"want",
+	"write",
+]);
+
+const EVENT_WORDS =
+	/\b(announce(?:d|ment)?|created|decided|deployed|digest|installed|launched|meeting|merged|published|released|started|stopped|updated)\b/i;
+const DATE_OR_TIME =
+	/\b(\d{4}-\d{2}-\d{2}|\d{1,2}:\d{2}|jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?|today|yesterday|last\s+(?:night|week|month|year|daily))\b/i;
+
+export interface EntityQualityResult {
+	readonly ok: boolean;
+	readonly reason?: string;
+}
+
+export function normalizeEntityName(value: string): string {
+	return value
+		.trim()
+		.replace(/[“”]/g, '"')
+		.replace(/[‘’]/g, "'")
+		.replace(/^['"`]+|['"`]+$/g, "")
+		.toLowerCase()
+		.replace(/\s+/g, " ");
+}
+
+export function normalizeEntityType(value: string | undefined): string | undefined {
+	const normalized = value
+		?.trim()
+		.toLowerCase()
+		.replace(/[\s-]+/g, "_");
+	return normalized || undefined;
+}
+
+export function isConcreteEntityType(type: string | undefined): type is ConcreteEntityType {
+	return typeof type === "string" && CONCRETE_ENTITY_TYPE_SET.has(type);
+}
+
+export function isKnownAbstractEntityType(type: string | undefined): boolean {
+	return typeof type === "string" && ABSTRACT_OR_OPERATIONAL_TYPES.has(type);
+}
+
+export function classifyEntityQuality(name: string, type?: string): EntityQualityResult {
+	const canonical = normalizeEntityName(name);
+	if (canonical.length < 4) return { ok: false, reason: "too_short" };
+	if (/^\d+$/.test(canonical)) return { ok: false, reason: "numeric_only" };
+	if (GENERIC_CANONICAL_NAMES.has(canonical)) return { ok: false, reason: "generic_or_scaffolding_name" };
+	if (METADATA_LABELS.has(canonical)) return { ok: false, reason: "metadata_role" };
+	if (DISCOURSE_WORDS.has(canonical)) return { ok: false, reason: "discourse_fragment" };
+	if (/^(user|assistant|system|sender|recipient|author)\b[:\s-]+/i.test(name.trim())) {
+		return { ok: false, reason: "role_prefixed_scaffolding" };
+	}
+	if (/^(current|pending|primary)\s+/i.test(canonical)) {
+		return { ok: false, reason: "section_heading" };
+	}
+
+	const normalizedType = normalizeEntityType(type);
+	if (normalizedType && normalizedType !== "extracted" && normalizedType !== "unknown") {
+		if (!isConcreteEntityType(normalizedType)) {
+			return {
+				ok: false,
+				reason: isKnownAbstractEntityType(normalizedType) ? "non_concrete_entity_type" : "unknown_entity_type",
+			};
+		}
+		if (normalizedType === "event" && !DATE_OR_TIME.test(name) && !EVENT_WORDS.test(name)) {
+			return { ok: false, reason: "event_without_time_or_event_signal" };
+		}
+	}
+
+	return { ok: true };
+}
+
+export function shouldPersistEntity(name: string, type?: string): boolean {
+	return classifyEntityQuality(name, type).ok;
+}
+
+export function concreteEntityTypesForPrompt(): string {
+	return CONCRETE_ENTITY_TYPES.join("|");
+}

--- a/platform/daemon/src/entity-quality.ts
+++ b/platform/daemon/src/entity-quality.ts
@@ -156,7 +156,9 @@ export function isKnownAbstractEntityType(type: string | undefined): boolean {
 
 export function classifyEntityQuality(name: string, type?: string): EntityQualityResult {
 	const canonical = normalizeEntityName(name);
-	if (canonical.length < 4) return { ok: false, reason: "too_short" };
+	const normalizedType = normalizeEntityType(type);
+	const hasConcreteType = isConcreteEntityType(normalizedType);
+
 	if (/^\d+$/.test(canonical)) return { ok: false, reason: "numeric_only" };
 	if (GENERIC_CANONICAL_NAMES.has(canonical)) return { ok: false, reason: "generic_or_scaffolding_name" };
 	if (METADATA_LABELS.has(canonical)) return { ok: false, reason: "metadata_role" };
@@ -167,8 +169,8 @@ export function classifyEntityQuality(name: string, type?: string): EntityQualit
 	if (/^(current|pending|primary)\s+/i.test(canonical)) {
 		return { ok: false, reason: "section_heading" };
 	}
+	if (canonical.length < 4 && !hasConcreteType) return { ok: false, reason: "too_short" };
 
-	const normalizedType = normalizeEntityType(type);
 	if (normalizedType && normalizedType !== "extracted" && normalizedType !== "unknown") {
 		if (!isConcreteEntityType(normalizedType)) {
 			return {

--- a/platform/daemon/src/knowledge-graph-hygiene.test.ts
+++ b/platform/daemon/src/knowledge-graph-hygiene.test.ts
@@ -11,14 +11,14 @@ function makeDbPath(): string {
 	return join(dir, "memories.db");
 }
 
-function seedEntity(id: string, name: string, mentions = 1): void {
+function seedEntity(id: string, name: string, mentions = 1, entityType = "project"): void {
 	const now = "2026-04-19T00:00:00.000Z";
 	getDbAccessor().withWriteTx((db) => {
 		db.prepare(
 			`INSERT INTO entities
 			 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
-			 VALUES (?, ?, ?, 'concept', 'default', ?, ?, ?)`,
-		).run(id, name, name.toLowerCase(), mentions, now, now);
+			 VALUES (?, ?, ?, ?, 'default', ?, ?, ?)`,
+		).run(id, name, name.toLowerCase(), entityType, mentions, now, now);
 	});
 }
 

--- a/platform/daemon/src/knowledge-graph-hygiene.ts
+++ b/platform/daemon/src/knowledge-graph-hygiene.ts
@@ -1,4 +1,5 @@
 import type { DbAccessor } from "./db-accessor";
+import { classifyEntityQuality, normalizeEntityName } from "./entity-quality";
 
 const GENERIC_ENTITY_NAMES = new Set([
 	"a",
@@ -84,14 +85,14 @@ export interface KnowledgeHygieneReport {
 }
 
 function normalize(value: string): string {
-	return value.trim().toLowerCase().replace(/\s+/g, " ");
+	return normalizeEntityName(value);
 }
 
-function reasonForEntity(name: string, canonicalName: string, mentions: number): string | null {
+function reasonForEntity(name: string, canonicalName: string, mentions: number, entityType?: string): string | null {
+	const quality = classifyEntityQuality(name || canonicalName, entityType);
+	if (!quality.ok) return quality.reason ?? "invalid_entity";
 	const canonical = normalize(canonicalName || name);
-	if (canonical.length < 2) return "too_short";
 	if (GENERIC_ENTITY_NAMES.has(canonical)) return "generic_word";
-	if (/^\d+$/.test(canonical)) return "numeric_only";
 	if (mentions === 0) return "zero_mentions";
 	return null;
 }
@@ -137,7 +138,12 @@ export function getKnowledgeHygieneReport(
 
 		const suspiciousEntities = entities
 			.flatMap((entity): SuspiciousEntity[] => {
-				const reason = reasonForEntity(entity.name, entity.canonical_name ?? entity.name, entity.mentions ?? 0);
+				const reason = reasonForEntity(
+					entity.name,
+					entity.canonical_name ?? entity.name,
+					entity.mentions ?? 0,
+					entity.entity_type,
+				);
 				return reason
 					? [
 							{
@@ -212,7 +218,7 @@ export function getKnowledgeHygieneReport(
 
 		const safeMentionCandidates: SafeMentionCandidate[] = [];
 		const knownEntities = entities.filter(
-			(entity) => !reasonForEntity(entity.name, entity.canonical_name ?? entity.name, 1),
+			(entity) => !reasonForEntity(entity.name, entity.canonical_name ?? entity.name, 1, entity.entity_type),
 		);
 		for (const memory of memories) {
 			if (safeMentionCandidates.length >= limit) break;

--- a/platform/daemon/src/pipeline/extraction.test.ts
+++ b/platform/daemon/src/pipeline/extraction.test.ts
@@ -24,7 +24,7 @@ function mockProvider(responses: string[]): LlmProvider {
 }
 
 // Inputs must be >= MIN_FACT_LENGTH (80) chars to pass the early-return guard.
-const INPUT = "User prefers dark mode and uses vim keybindings in their VS Code development environment";
+const INPUT = "Nicholai prefers dark mode and uses vim keybindings in their VS Code development environment";
 const INPUT_GENERIC = "Some content that is long enough to pass the extraction input gate and be processed fully";
 
 const VALID_RESPONSE = JSON.stringify({
@@ -35,16 +35,18 @@ const VALID_RESPONSE = JSON.stringify({
 			confidence: 0.9,
 		},
 		{
-			content: "User uses vim keybindings in VS Code and has customized their keybinding configuration extensively",
+			content: "Nicholai uses vim keybindings in VS Code and has customized their keybinding configuration extensively",
 			type: "preference",
 			confidence: 0.85,
 		},
 	],
 	entities: [
 		{
-			source: "User",
-			relationship: "prefers",
-			target: "dark mode",
+			source: "Nicholai",
+			source_type: "person",
+			relationship: "uses",
+			target: "VS Code",
+			target_type: "tool",
 			confidence: 0.9,
 		},
 	],
@@ -84,9 +86,9 @@ describe("extractFactsAndEntities", () => {
 		expect(result.facts[0].type).toBe("preference");
 		expect(result.facts[0].confidence).toBe(0.9);
 		expect(result.entities).toHaveLength(1);
-		expect(result.entities[0].source).toBe("User");
-		expect(result.entities[0].relationship).toBe("prefers");
-		expect(result.entities[0].target).toBe("dark mode");
+		expect(result.entities[0].source).toBe("Nicholai");
+		expect(result.entities[0].relationship).toBe("uses");
+		expect(result.entities[0].target).toBe("VS Code");
 		expect(result.warnings).toHaveLength(0);
 	});
 
@@ -125,10 +127,10 @@ ${VALID_RESPONSE}
 	it("parses JSON with trailing commas from fallback model", async () => {
 		const trailingCommaResponse = `{
 		  "facts": [
-		    {"content": "User prefers dark mode for their terminal, editor, and all development tool interfaces in daily work", "type": "preference", "confidence": 0.9,},
+		    {"content": "Nicholai prefers dark mode for their terminal, editor, and all development tool interfaces in daily work", "type": "preference", "confidence": 0.9,},
 		  ],
 		  "entities": [
-		    {"source": "User", "relationship": "prefers", "target": "dark mode", "confidence": 0.9,},
+		    {"source": "Nicholai", "source_type": "person", "relationship": "uses", "target": "VS Code", "target_type": "tool", "confidence": 0.9,},
 		  ],
 		}`;
 		const provider = mockProvider([trailingCommaResponse]);
@@ -225,9 +227,11 @@ ${VALID_RESPONSE}
 			],
 			entities: [
 				{
-					source: "User",
+					source: "Nicholai",
+					source_type: "person",
 					relationship: "uses",
-					target: "vim",
+					target: "VS Code",
+					target_type: "tool",
 					confidence: 2.0,
 				},
 			],
@@ -282,6 +286,51 @@ ${VALID_RESPONSE}
 		expect(result.warnings.some((w) => w.includes("too short"))).toBe(true);
 	});
 
+	it("keeps timestamped events but rejects prompt scaffolding as entities", async () => {
+		const response = JSON.stringify({
+			facts: [
+				{
+					content:
+						"The Signet Daily Digest published on 2026-05-10 summarized the desktop updater work and sources page delivery",
+					type: "fact",
+					confidence: 0.88,
+				},
+			],
+			entities: [
+				{
+					source: "Signet Daily Digest — 2026-05-10",
+					source_type: "event",
+					relationship: "summarized",
+					target: "Signet Desktop",
+					target_type: "product",
+					confidence: 0.85,
+				},
+				{
+					source: "Sender",
+					source_type: "person",
+					relationship: "said",
+					target: "Summary",
+					target_type: "document",
+					confidence: 0.8,
+				},
+				{
+					source: "We're",
+					relationship: "working_on",
+					target: "Current Work",
+					confidence: 0.8,
+				},
+			],
+		});
+		const provider = mockProvider([response]);
+		const result = await extractFactsAndEntities(INPUT_GENERIC, provider);
+
+		expect(result.entities).toHaveLength(1);
+		expect(result.entities[0].source).toBe("Signet Daily Digest — 2026-05-10");
+		expect(result.entities[0].sourceType).toBe("event");
+		expect(result.warnings.some((warning) => warning.includes("Sender"))).toBe(true);
+		expect(result.warnings.some((warning) => warning.includes("We're"))).toBe(true);
+	});
+
 	it("rejects entities with missing source or target", async () => {
 		const response = JSON.stringify({
 			facts: [],
@@ -295,14 +344,14 @@ ${VALID_RESPONSE}
 				},
 				// missing target
 				{
-					source: "User",
+					source: "Nicholai",
 					relationship: "prefers",
 					target: "",
 					confidence: 0.8,
 				},
 				// valid entity
 				{
-					source: "User",
+					source: "Nicholai",
 					relationship: "likes",
 					target: "coffee",
 					confidence: 0.9,

--- a/platform/daemon/src/pipeline/extraction.ts
+++ b/platform/daemon/src/pipeline/extraction.ts
@@ -12,6 +12,7 @@ import {
 	MEMORY_TYPES,
 	type MemoryType,
 } from "@signet/core";
+import { classifyEntityQuality, concreteEntityTypesForPrompt, normalizeEntityType } from "../entity-quality";
 import { logger } from "../logger";
 import { type LlmProvider, RateLimitExceededError } from "./provider";
 
@@ -32,12 +33,13 @@ const VALID_TYPES = new Set<string>(MEMORY_TYPES);
 // ---------------------------------------------------------------------------
 
 function buildExtractionPrompt(content: string): string {
-	return `Extract key facts and entity relationships from this text.
+	const entityTypes = concreteEntityTypesForPrompt();
+	return `Extract key facts and concrete semantic-object relationships from this text.
 
 Return JSON with two arrays: "facts" and "entities".
 
 Each fact: {"content": "...", "type": "fact|preference|decision|rationale|procedural|semantic", "confidence": 0.0-1.0}
-Each entity: {"source": "...", "source_type": "person|project|system|tool|concept|skill|task|unknown", "relationship": "...", "target": "...", "target_type": "person|project|system|tool|concept|skill|task|unknown", "confidence": 0.0-1.0}
+Each entity: {"source": "...", "source_type": "${entityTypes}", "relationship": "...", "target": "...", "target_type": "${entityTypes}", "confidence": 0.0-1.0}
 
 IMPORTANT — Atomic facts:
 Each fact must be fully understandable WITHOUT the original conversation. Include the specific subject (package name, file path, component, tool) and enough context that a reader seeing only this fact knows exactly what it refers to.
@@ -48,6 +50,11 @@ GOOD: "The @signet/connector-opencode install() function writes pre-bundled sign
 BAD: "Uses PostgreSQL instead of MongoDB"
 GOOD: "The auth service uses PostgreSQL instead of MongoDB for better relational query support"
 
+Entity discipline:
+Entities are identity-bearing semantic objects only: people, organizations, projects, products, systems/tools, artifacts/documents/sources, places, and events.
+Events are first-class only for real happenings with a date/time, provenance, participants, a target object, or an event type (for example: "Daily Digest — 2026-05-10" or "PR #675 merged on 2026-05-11").
+Do NOT create entities for pronouns, metadata roles, headings, discourse fragments, generic role words, prompt scaffolding, claim slots, policies, actions, workflows, or abstract concepts. Put descriptions in facts/aspects/attributes; put predicates in relationships.
+
 Types: fact (objective info), preference (user likes/dislikes), decision (choices made), rationale (WHY a decision was made — reasoning, alternatives considered, tradeoffs), procedural (how-to knowledge), semantic (concepts/definitions).
 
 When you see a decision with reasoning, extract BOTH a decision fact AND a rationale fact. The rationale should capture the WHY, including alternatives considered and tradeoffs.
@@ -57,11 +64,18 @@ Examples:
 Input: "User prefers dark mode and uses vim keybindings in VS Code"
 Output:
 {"facts": [
-  {"content": "User prefers dark mode for all editor and terminal interfaces", "type": "preference", "confidence": 0.9},
-  {"content": "User uses vim keybindings in VS Code as their primary editing mode", "type": "preference", "confidence": 0.9}
+  {"content": "Nicholai prefers dark mode for all editor and terminal interfaces", "type": "preference", "confidence": 0.9},
+  {"content": "Nicholai uses vim keybindings in VS Code as their primary editing mode", "type": "preference", "confidence": 0.9}
 ], "entities": [
-  {"source": "User", "source_type": "person", "relationship": "prefers", "target": "dark mode", "target_type": "concept", "confidence": 0.9},
-  {"source": "User", "source_type": "person", "relationship": "uses", "target": "vim keybindings", "target_type": "tool", "confidence": 0.9}
+  {"source": "Nicholai", "source_type": "person", "relationship": "uses", "target": "VS Code", "target_type": "tool", "confidence": 0.9}
+]}
+
+Input: "The Signet Daily Digest was published on 2026-05-10 and summarized the desktop updater work."
+Output:
+{"facts": [
+  {"content": "The Signet Daily Digest published on 2026-05-10 summarized the desktop updater work", "type": "fact", "confidence": 0.85}
+], "entities": [
+  {"source": "Signet Daily Digest — 2026-05-10", "source_type": "event", "relationship": "summarized", "target": "Signet Desktop", "target_type": "product", "confidence": 0.85}
 ]}
 
 Input: "Decided to use PostgreSQL instead of MongoDB for the auth service because relational queries suit the access-control schema better and we need ACID transactions"
@@ -361,15 +375,26 @@ function validateEntity(raw: unknown, warnings: string[]): ExtractedEntity | nul
 	const rawConf = typeof obj.confidence === "number" ? obj.confidence : 0.5;
 	const confidence = Math.max(0, Math.min(1, rawConf));
 
-	const sourceType = typeof obj.source_type === "string" ? obj.source_type.trim() : undefined;
-	const targetType = typeof obj.target_type === "string" ? obj.target_type.trim() : undefined;
+	const sourceType = normalizeEntityType(typeof obj.source_type === "string" ? obj.source_type : undefined);
+	const targetType = normalizeEntityType(typeof obj.target_type === "string" ? obj.target_type : undefined);
+
+	const sourceQuality = classifyEntityQuality(source, sourceType);
+	if (!sourceQuality.ok) {
+		warnings.push(`Rejected source entity "${source}" (${sourceQuality.reason})`);
+		return null;
+	}
+	const targetQuality = classifyEntityQuality(target, targetType);
+	if (!targetQuality.ok) {
+		warnings.push(`Rejected target entity "${target}" (${targetQuality.reason})`);
+		return null;
+	}
 
 	return {
 		source,
-		sourceType: sourceType || undefined,
+		sourceType,
 		relationship,
 		target,
-		targetType: targetType || undefined,
+		targetType,
 		confidence,
 	};
 }

--- a/platform/daemon/src/pipeline/graph-transactions.test.ts
+++ b/platform/daemon/src/pipeline/graph-transactions.test.ts
@@ -157,6 +157,30 @@ describe("graph-transactions", () => {
 			expect(mentions).toHaveLength(2);
 		});
 
+		it("persists typed short concrete entities through the shared quality gate", () => {
+			const now = new Date().toISOString();
+			const result = txPersistEntities(asWriteDb(db), {
+				entities: [
+					{
+						source: "AI",
+						sourceType: "product",
+						relationship: "uses",
+						target: "Go",
+						targetType: "tool",
+						confidence: 0.8,
+					},
+				],
+				sourceMemoryId: "mem-1",
+				agentId: "agent-1",
+				extractedAt: now,
+			});
+
+			expect(result.entitiesInserted).toBe(2);
+			expect(result.relationsInserted).toBe(1);
+			const names = db.prepare("SELECT name FROM entities ORDER BY name").all() as Array<{ name: string }>;
+			expect(names.map((row) => row.name)).toEqual(["AI", "Go"]);
+		});
+
 		it("rejects generic scaffolding triples without partial source writes", () => {
 			const now = new Date().toISOString();
 			const result = txPersistEntities(asWriteDb(db), {

--- a/platform/daemon/src/pipeline/graph-transactions.test.ts
+++ b/platform/daemon/src/pipeline/graph-transactions.test.ts
@@ -75,7 +75,7 @@ describe("graph-transactions", () => {
 			const now = new Date().toISOString();
 
 			const first = txPersistEntities(asWriteDb(db), {
-				entities: [{ source: "User", relationship: "likes", target: "Cats", confidence: 0.8 }],
+				entities: [{ source: "Nicholai", relationship: "likes", target: "Cats", confidence: 0.8 }],
 				sourceMemoryId: "mem-1",
 				extractedAt: now,
 				agentId: "default",
@@ -84,7 +84,7 @@ describe("graph-transactions", () => {
 			expect(first.entitiesUpdated).toBe(0);
 
 			const second = txPersistEntities(asWriteDb(db), {
-				entities: [{ source: "user", relationship: "likes", target: "cats", confidence: 0.7 }],
+				entities: [{ source: "nicholai", relationship: "likes", target: "cats", confidence: 0.7 }],
 				sourceMemoryId: "mem-2",
 				extractedAt: now,
 				agentId: "default",
@@ -101,7 +101,7 @@ describe("graph-transactions", () => {
 			expect(entities).toHaveLength(2);
 			expect(entities[0].canonical_name).toBe("cats");
 			expect(entities[0].mentions).toBe(2);
-			expect(entities[1].canonical_name).toBe("user");
+			expect(entities[1].canonical_name).toBe("nicholai");
 			expect(entities[1].mentions).toBe(2);
 		});
 
@@ -155,6 +155,39 @@ describe("graph-transactions", () => {
 
 			const mentions = db.query("SELECT * FROM memory_entity_mentions").all();
 			expect(mentions).toHaveLength(2);
+		});
+
+		it("rejects generic scaffolding triples without partial source writes", () => {
+			const now = new Date().toISOString();
+			const result = txPersistEntities(asWriteDb(db), {
+				entities: [
+					{
+						source: "Sender",
+						sourceType: "person",
+						relationship: "said",
+						target: "Signet",
+						targetType: "project",
+						confidence: 0.9,
+					},
+					{
+						source: "Signet Daily Digest — 2026-05-10",
+						sourceType: "event",
+						relationship: "summarized",
+						target: "Signet Desktop",
+						targetType: "product",
+						confidence: 0.9,
+					},
+				],
+				sourceMemoryId: "mem-events",
+				extractedAt: now,
+				agentId: "default",
+			});
+
+			expect(result.entitiesInserted).toBe(2);
+			expect(result.relationsInserted).toBe(1);
+			expect(result.mentionsLinked).toBe(2);
+			const names = db.query("SELECT name FROM entities ORDER BY name").all() as Array<{ name: string }>;
+			expect(names.map((row) => row.name)).toEqual(["Signet Daily Digest — 2026-05-10", "Signet Desktop"]);
 		});
 
 		it("records reasoned related_to audit history for structured co-occurrences", () => {

--- a/platform/daemon/src/pipeline/graph-transactions.ts
+++ b/platform/daemon/src/pipeline/graph-transactions.ts
@@ -11,6 +11,7 @@ import type { ExtractedEntity } from "@signet/core";
 import type { WriteDb } from "../db-accessor";
 import { countChanges } from "../db-helpers";
 import { requireDependencyReason } from "../dependency-history";
+import { normalizeEntityType, shouldPersistEntity } from "../entity-quality";
 import { isDecisionContent } from "../inline-entity-linker";
 
 // ---------------------------------------------------------------------------
@@ -224,14 +225,16 @@ function markSupersededSiblings(
 function upsertEntity(
 	db: WriteDb,
 	rawName: string,
-	entityType: string,
+	entityType: string | undefined,
 	agentId: string,
 	now: string,
 ): UpsertEntityResult | null {
 	const canonical = toCanonicalName(rawName);
+	const normalizedType = normalizeEntityType(entityType) ?? "extracted";
 
-	// Skip trivially short names like "50", "0", "cli", "npm"
-	if (canonical.length < 4) return null;
+	// Skip trivially short names like "50", "0", "cli", "npm" and
+	// non-concrete scaffolding such as "Sender", "We're", or "Summary".
+	if (!shouldPersistEntity(rawName, normalizedType === "extracted" ? undefined : normalizedType)) return null;
 
 	// Look up by canonical_name first, then fall back to name (handles
 	// rows where canonical_name was never backfilled and is still NULL).
@@ -249,10 +252,10 @@ function upsertEntity(
 			 SET mentions = mentions + 1, updated_at = ?
 			 WHERE id = ?`,
 		).run(now, existing.id);
-		// Upgrade entity_type if currently "extracted" and we have a real type
-		if (entityType !== "extracted" && existing.entity_type === "extracted") {
+		// Upgrade entity_type if currently "extracted" and we have a concrete type
+		if (normalizedType !== "extracted" && existing.entity_type === "extracted") {
 			db.prepare(`UPDATE entities SET entity_type = ? WHERE id = ? AND entity_type = 'extracted'`).run(
-				entityType,
+				normalizedType,
 				existing.id,
 			);
 		}
@@ -265,7 +268,7 @@ function upsertEntity(
 			`INSERT INTO entities
 			 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
 			 VALUES (?, ?, ?, ?, ?, 1, ?, ?)`,
-		).run(id, rawName, canonical, entityType, agentId, now, now);
+		).run(id, rawName, canonical, normalizedType, agentId, now, now);
 		return { id, inserted: true };
 	} catch (e) {
 		// name UNIQUE constraint collision — fall back to existing row.
@@ -366,13 +369,17 @@ export function txPersistEntities(db: WriteDb, input: PersistEntitiesInput): Per
 		const tgtCanon = triple.target.trim().toLowerCase().replace(/\s+/g, " ");
 		if (srcCanon.length < 4 || tgtCanon.length < 4) continue;
 
-		const source = upsertEntity(db, triple.source, triple.sourceType ?? "extracted", input.agentId, now);
+		const sourceType = normalizeEntityType(triple.sourceType);
+		const targetType = normalizeEntityType(triple.targetType);
+		if (!shouldPersistEntity(triple.source, sourceType) || !shouldPersistEntity(triple.target, targetType)) continue;
+
+		const source = upsertEntity(db, triple.source, sourceType, input.agentId, now);
 		// Defensive — pre-check above should prevent null, but guard anyway
 		if (source === null) continue;
 		if (source.inserted) entitiesInserted++;
 		else entitiesUpdated++;
 
-		const target = upsertEntity(db, triple.target, triple.targetType ?? "extracted", input.agentId, now);
+		const target = upsertEntity(db, triple.target, targetType, input.agentId, now);
 		if (target === null) continue;
 		if (target.inserted) entitiesInserted++;
 		else entitiesUpdated++;
@@ -482,7 +489,7 @@ export function txPersistStructured(db: WriteDb, input: PersistStructuredInput):
 			.get(canonical, input.agentId) as { id: string } | undefined;
 
 		if (!row) {
-			const inserted = upsertEntity(db, sa.entityName, sa.entityType ?? "unknown", input.agentId, input.now);
+			const inserted = upsertEntity(db, sa.entityName, sa.entityType, input.agentId, input.now);
 			if (!inserted) continue;
 			if (inserted.inserted) entitiesInserted++;
 			else entitiesUpdated++;

--- a/platform/daemon/src/pipeline/graph-transactions.ts
+++ b/platform/daemon/src/pipeline/graph-transactions.ts
@@ -365,10 +365,6 @@ export function txPersistEntities(db: WriteDb, input: PersistEntitiesInput): Per
 	for (const triple of input.entities) {
 		// Pre-validate both names before any DB writes — prevents phantom mention
 		// increments on the source when the target would be filtered by upsertEntity.
-		const srcCanon = triple.source.trim().toLowerCase().replace(/\s+/g, " ");
-		const tgtCanon = triple.target.trim().toLowerCase().replace(/\s+/g, " ");
-		if (srcCanon.length < 4 || tgtCanon.length < 4) continue;
-
 		const sourceType = normalizeEntityType(triple.sourceType);
 		const targetType = normalizeEntityType(triple.targetType);
 		if (!shouldPersistEntity(triple.source, sourceType) || !shouldPersistEntity(triple.target, targetType)) continue;

--- a/platform/daemon/src/repair-actions.test.ts
+++ b/platform/daemon/src/repair-actions.test.ts
@@ -19,6 +19,7 @@ import {
 	deduplicateMemories,
 	getDedupStats,
 	getEmbeddingGapStats,
+	pruneGenericEntities,
 	reembedMissingMemories,
 	releaseStaleLeases,
 	requeueDeadJobs,
@@ -299,6 +300,41 @@ describe("checkRepairGate", () => {
 		const cfg = { ...TEST_CFG, autonomous: { ...TEST_CFG.autonomous, enabled: false } };
 		const result = checkRepairGate(cfg, CTX_OPERATOR, limiter, "a", 0, 100);
 		expect(result.allowed).toBe(true);
+	});
+});
+
+describe("pruneGenericEntities", () => {
+	it("dry-runs and deletes generic entities without touching pinned or concrete entities", () => {
+		const db = new Database(":memory:");
+		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+		const accessor = asAccessor(db);
+		const limiter = createRateLimiter();
+		const now = new Date().toISOString();
+
+		try {
+			const insert = db.prepare(
+				`INSERT INTO entities
+				 (id, name, canonical_name, entity_type, agent_id, mentions, pinned, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, 'default', ?, ?, ?, ?)`,
+			);
+			insert.run("ent-sender", "Sender", "sender", "person", 174, 0, now, now);
+			insert.run("ent-signet", "Signet", "signet", "project", 5, 0, now, now);
+			insert.run("ent-pinned", "Summary", "summary", "document", 3, 1, now, now);
+
+			const dryRun = pruneGenericEntities(accessor, TEST_CFG, CTX_OPERATOR, limiter, { dryRun: true });
+			expect(dryRun.success).toBe(true);
+			expect(dryRun.affected).toBe(1);
+			expect(dryRun.message).toContain("Sender");
+
+			const result = pruneGenericEntities(accessor, TEST_CFG, CTX_OPERATOR, limiter, { dryRun: false });
+			expect(result.success).toBe(true);
+			expect(result.affected).toBe(1);
+
+			const remaining = db.prepare("SELECT name FROM entities ORDER BY name").all() as Array<{ name: string }>;
+			expect(remaining.map((row) => row.name)).toEqual(["Signet", "Summary"]);
+		} finally {
+			db.close();
+		}
 	});
 });
 

--- a/platform/daemon/src/repair-actions.test.ts
+++ b/platform/daemon/src/repair-actions.test.ts
@@ -342,6 +342,37 @@ describe("pruneGenericEntities", () => {
 			db.close();
 		}
 	});
+
+	it("continues scanning past recent valid entities to find older generic rows", () => {
+		const db = new Database(":memory:");
+		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+		const accessor = asAccessor(db);
+		const limiter = createRateLimiter();
+		const recent = "2026-05-11T18:00:00.000Z";
+		const old = "2026-05-01T18:00:00.000Z";
+
+		try {
+			const insert = db.prepare(
+				`INSERT INTO entities
+				 (id, name, canonical_name, entity_type, agent_id, mentions, pinned, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, 'default', ?, 0, ?, ?)`,
+			);
+			for (let i = 0; i < 510; i += 1) {
+				insert.run(`ent-project-${i}`, `Project ${i}`, `project ${i}`, "project", 1, recent, recent);
+			}
+			insert.run("ent-sender-old", "Sender", "sender", "person", 12, old, old);
+
+			const dryRun = pruneGenericEntities(accessor, TEST_CFG, CTX_OPERATOR, limiter, {
+				dryRun: true,
+				batchSize: 1,
+			});
+			expect(dryRun.success).toBe(true);
+			expect(dryRun.affected).toBe(1);
+			expect(dryRun.message).toContain("Sender");
+		} finally {
+			db.close();
+		}
+	});
 });
 
 describe("structuralBackfill", () => {

--- a/platform/daemon/src/repair-actions.test.ts
+++ b/platform/daemon/src/repair-actions.test.ts
@@ -320,6 +320,12 @@ describe("pruneGenericEntities", () => {
 			insert.run("ent-sender", "Sender", "sender", "person", 174, 0, now, now);
 			insert.run("ent-signet", "Signet", "signet", "project", 5, 0, now, now);
 			insert.run("ent-pinned", "Summary", "summary", "document", 3, 1, now, now);
+			insert.run("ent-skill", "Skill Creator", "skill creator", "skill", 1, 0, now, now);
+			db.prepare(
+				`INSERT INTO skill_meta
+				 (entity_id, agent_id, source, installed_at, fs_path)
+				 VALUES (?, 'default', 'signet', ?, ?)`,
+			).run("ent-skill", now, "/skills/skill-creator/SKILL.md");
 
 			const dryRun = pruneGenericEntities(accessor, TEST_CFG, CTX_OPERATOR, limiter, { dryRun: true });
 			expect(dryRun.success).toBe(true);
@@ -331,7 +337,7 @@ describe("pruneGenericEntities", () => {
 			expect(result.affected).toBe(1);
 
 			const remaining = db.prepare("SELECT name FROM entities ORDER BY name").all() as Array<{ name: string }>;
-			expect(remaining.map((row) => row.name)).toEqual(["Signet", "Summary"]);
+			expect(remaining.map((row) => row.name)).toEqual(["Signet", "Skill Creator", "Summary"]);
 		} finally {
 			db.close();
 		}

--- a/platform/daemon/src/repair-actions.ts
+++ b/platform/daemon/src/repair-actions.ts
@@ -1818,24 +1818,33 @@ export function pruneGenericEntities(
 	const batchSize = Math.max(1, Math.min(Math.floor(options?.batchSize ?? 100), 500));
 	const agentId = options?.agentId ?? "default";
 	const candidates = accessor.withReadDb((db) => {
-		const rows = db
-			.prepare(
-				`SELECT e.id, e.name, e.entity_type
-				 FROM entities e
-				 WHERE e.agent_id = ?
-				   AND COALESCE(e.pinned, 0) = 0
-				   AND e.entity_type NOT IN ('skill')
-				   AND NOT EXISTS (SELECT 1 FROM skill_meta sm WHERE sm.entity_id = e.id)
-				 ORDER BY e.updated_at DESC
-				 LIMIT ?`,
-			)
-			.all(agentId, Math.max(batchSize * 10, 200)) as GenericEntityCandidate[];
-		return rows
-			.flatMap((row): GenericEntityCandidate[] => {
+		const candidates: GenericEntityCandidate[] = [];
+		const pageSize = Math.max(batchSize * 10, 500);
+		let offset = 0;
+		const selectPage = db.prepare(
+			`SELECT e.id, e.name, e.entity_type
+			 FROM entities e
+			 WHERE e.agent_id = ?
+			   AND COALESCE(e.pinned, 0) = 0
+			   AND e.entity_type NOT IN ('skill')
+			   AND NOT EXISTS (SELECT 1 FROM skill_meta sm WHERE sm.entity_id = e.id)
+			 ORDER BY e.updated_at DESC
+			 LIMIT ? OFFSET ?`,
+		);
+
+		for (;;) {
+			const rows = selectPage.all(agentId, pageSize, offset) as GenericEntityCandidate[];
+			if (rows.length === 0) break;
+			for (const row of rows) {
 				const quality = classifyEntityQuality(row.name, row.entity_type);
-				return quality.ok ? [] : [{ ...row, reason: quality.reason }];
-			})
-			.slice(0, batchSize);
+				if (!quality.ok) {
+					candidates.push({ ...row, reason: quality.reason });
+					if (candidates.length >= batchSize) return candidates;
+				}
+			}
+			offset += rows.length;
+		}
+		return candidates;
 	});
 
 	if (options?.dryRun ?? true) {

--- a/platform/daemon/src/repair-actions.ts
+++ b/platform/daemon/src/repair-actions.ts
@@ -23,6 +23,7 @@ import {
 	vectorToBlob,
 } from "./db-helpers";
 import { type UnembeddedRow, countUnembeddedMemories, listUnembeddedMemories } from "./embedding-coverage";
+import { classifyEntityQuality } from "./entity-quality";
 import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
 import type { PipelineV2Config } from "./memory-config";
@@ -1400,7 +1401,19 @@ async function findSemanticDuplicates(
 // Reclassify extracted entities via LLM
 // ---------------------------------------------------------------------------
 
-const VALID_ENTITY_TYPES = new Set(["person", "project", "system", "tool", "concept", "skill", "task"]);
+const VALID_ENTITY_TYPES = new Set([
+	"person",
+	"organization",
+	"project",
+	"product",
+	"system",
+	"tool",
+	"artifact",
+	"document",
+	"source",
+	"place",
+	"event",
+]);
 
 const DEFAULT_RECLASSIFY_BATCH = 20;
 const MIN_RECLASSIFY_BATCH = 5;
@@ -1493,7 +1506,7 @@ export async function reclassifyEntities(
 
 	const entityList = entities.map((e, idx) => `${idx + 1}. ${e.canonical_name ?? e.name}`).join("\n");
 
-	const prompt = `Classify each entity into one of these types: person, project, system, tool, concept, skill, task
+	const prompt = `Classify each entity into one of these concrete identity-bearing types: person, organization, project, product, system, tool, artifact, document, source, place, event
 
 Entities:
 ${entityList}
@@ -1748,6 +1761,118 @@ export function pruneSingletonExtractedEntities(
 		affected,
 		message: `deleted ${affected} singleton extracted entities`,
 	};
+}
+
+// ---------------------------------------------------------------------------
+// pruneGenericEntities
+// ---------------------------------------------------------------------------
+
+interface GenericEntityCandidate {
+	readonly id: string;
+	readonly name: string;
+	readonly entity_type: string;
+	reason?: string;
+}
+
+function deleteEntityGraphRows(db: WriteDb, ids: readonly string[]): void {
+	if (ids.length === 0) return;
+	const placeholders = ids.map(() => "?").join(",");
+	const aspectIds = db
+		.prepare(`SELECT id FROM entity_aspects WHERE entity_id IN (${placeholders})`)
+		.all(...ids) as Array<{ id: string }>;
+	if (aspectIds.length > 0) {
+		const aspectPlaceholders = aspectIds.map(() => "?").join(",");
+		db.prepare(`DELETE FROM entity_attributes WHERE aspect_id IN (${aspectPlaceholders})`).run(
+			...aspectIds.map((row) => row.id),
+		);
+	}
+	db.prepare(`DELETE FROM memory_entity_mentions WHERE entity_id IN (${placeholders})`).run(...ids);
+	db.prepare(
+		`DELETE FROM relations WHERE source_entity_id IN (${placeholders}) OR target_entity_id IN (${placeholders})`,
+	).run(...ids, ...ids);
+	db.prepare(
+		`DELETE FROM entity_dependencies WHERE source_entity_id IN (${placeholders}) OR target_entity_id IN (${placeholders})`,
+	).run(...ids, ...ids);
+	db.prepare(`DELETE FROM entity_aspects WHERE entity_id IN (${placeholders})`).run(...ids);
+	db.prepare(`DELETE FROM entities WHERE id IN (${placeholders})`).run(...ids);
+}
+
+/**
+ * Delete concrete-ontology violations such as pronouns, metadata labels,
+ * headings, discourse fragments, and non-concrete extraction types. Defaults
+ * to dry-run at the route layer so operators can inspect candidates first.
+ */
+export function pruneGenericEntities(
+	accessor: DbAccessor,
+	cfg: PipelineV2Config,
+	ctx: RepairContext,
+	limiter: RateLimiter,
+	options?: { batchSize?: number; dryRun?: boolean; agentId?: string },
+): RepairResult {
+	const action = "pruneGenericEntities";
+	const gate = checkRepairGate(cfg, ctx, limiter, action, 60_000, 10);
+	if (!gate.allowed) {
+		return { action, success: false, affected: 0, message: gate.reason ?? "denied" };
+	}
+
+	const batchSize = Math.max(1, Math.min(Math.floor(options?.batchSize ?? 100), 500));
+	const agentId = options?.agentId ?? "default";
+	const candidates = accessor.withReadDb((db) => {
+		const rows = db
+			.prepare(
+				`SELECT id, name, entity_type
+				 FROM entities
+				 WHERE agent_id = ?
+				   AND COALESCE(pinned, 0) = 0
+				 ORDER BY updated_at DESC
+				 LIMIT ?`,
+			)
+			.all(agentId, Math.max(batchSize * 10, 200)) as GenericEntityCandidate[];
+		return rows
+			.flatMap((row): GenericEntityCandidate[] => {
+				const quality = classifyEntityQuality(row.name, row.entity_type);
+				return quality.ok ? [] : [{ ...row, reason: quality.reason }];
+			})
+			.slice(0, batchSize);
+	});
+
+	if (options?.dryRun ?? true) {
+		const preview = candidates
+			.slice(0, 10)
+			.map((row) => `${row.name} (${row.reason ?? "invalid"})`)
+			.join(", ");
+		return {
+			action,
+			success: true,
+			affected: candidates.length,
+			message: `dry-run: would delete ${candidates.length} generic/non-concrete entities${preview ? `: ${preview}` : ""}`,
+		};
+	}
+
+	if (candidates.length === 0) {
+		return { action, success: true, affected: 0, message: "no generic/non-concrete entities found" };
+	}
+
+	const affected = accessor.withWriteTx((db) => {
+		const ids = candidates.map((row) => row.id);
+		deleteEntityGraphRows(db, ids);
+		writeRepairAudit(
+			db,
+			action,
+			ctx,
+			ids.length,
+			`deleted ${ids.length} generic/non-concrete entities for agent ${agentId}`,
+		);
+		return ids.length;
+	});
+
+	limiter.record(action);
+	logger.info("pipeline", "repair: pruned generic/non-concrete entities", {
+		affected,
+		agentId,
+		actor: ctx.actor,
+	});
+	return { action, success: true, affected, message: `deleted ${affected} generic/non-concrete entities` };
 }
 
 // ---------------------------------------------------------------------------

--- a/platform/daemon/src/repair-actions.ts
+++ b/platform/daemon/src/repair-actions.ts
@@ -1820,11 +1820,13 @@ export function pruneGenericEntities(
 	const candidates = accessor.withReadDb((db) => {
 		const rows = db
 			.prepare(
-				`SELECT id, name, entity_type
-				 FROM entities
-				 WHERE agent_id = ?
-				   AND COALESCE(pinned, 0) = 0
-				 ORDER BY updated_at DESC
+				`SELECT e.id, e.name, e.entity_type
+				 FROM entities e
+				 WHERE e.agent_id = ?
+				   AND COALESCE(e.pinned, 0) = 0
+				   AND e.entity_type NOT IN ('skill')
+				   AND NOT EXISTS (SELECT 1 FROM skill_meta sm WHERE sm.entity_id = e.id)
+				 ORDER BY e.updated_at DESC
 				 LIMIT ?`,
 			)
 			.all(agentId, Math.max(batchSize * 10, 200)) as GenericEntityCandidate[];

--- a/platform/daemon/src/routes/repair-routes.ts
+++ b/platform/daemon/src/routes/repair-routes.ts
@@ -18,6 +18,7 @@ import {
 	getDedupStats,
 	getEmbeddingGapStats,
 	pruneChunkGroupEntities,
+	pruneGenericEntities,
 	pruneSingletonExtractedEntities,
 	reclassifyEntities,
 	reembedMissingMemories,
@@ -258,6 +259,28 @@ export function registerRepairRoutes(app: Hono): void {
 			batchSize,
 			dryRun,
 			maxMentions,
+		});
+		return c.json(result, repairHttpStatus(result));
+	});
+
+	app.post("/api/repair/prune-generic-entities", async (c) => {
+		const cfg = loadMemoryConfig(AGENTS_DIR);
+		const ctx = resolveRepairContext(c);
+		let batchSize = 100;
+		let dryRun = true;
+		let agentId = c.req.query("agent_id") ?? "default";
+		try {
+			const body = await c.req.json();
+			if (typeof body?.batchSize === "number") batchSize = body.batchSize;
+			if (typeof body?.dryRun === "boolean") dryRun = body.dryRun;
+			if (typeof body?.agentId === "string" && body.agentId.trim()) agentId = body.agentId.trim();
+		} catch {
+			// no body or invalid JSON — use defaults
+		}
+		const result = pruneGenericEntities(getDbAccessor(), cfg.pipelineV2, ctx, repairLimiter, {
+			batchSize,
+			dryRun,
+			agentId,
 		});
 		return c.json(result, repairHttpStatus(result));
 	});


### PR DESCRIPTION
## Summary
- Adds a shared concrete entity-quality gate for extraction and graph writes, so pronouns, metadata scaffolding, headings, discourse fragments, and abstract claim slots do not become ontology entities.
- Narrows the canonical entity taxonomy to concrete semantic objects: people, organizations, projects, products, systems/tools, artifacts/documents/sources, places, and first-class events.
- Keeps timestamped/provenance-backed events as valid semantic objects and adds a repair endpoint to dry-run or prune existing generic/non-concrete entity pollution.
- Updates ontology docs/spec invariants from the Obsidian-backed model: artifacts carry evidence, entities/events are semantic objects, aspects/attributes/claims describe them, and relations carry predicates.

## Validation
- `bun install`
- `bun run build:core`
- `bun test platform/daemon/src/entity-quality.test.ts platform/daemon/src/pipeline/extraction.test.ts platform/daemon/src/pipeline/graph-transactions.test.ts platform/daemon/src/knowledge-graph-hygiene.test.ts platform/daemon/src/repair-actions.test.ts` (`82 pass, 0 fail`)
- `bunx biome check platform/daemon/src/entity-quality.ts platform/daemon/src/entity-quality.test.ts platform/daemon/src/pipeline/extraction.ts platform/daemon/src/pipeline/extraction.test.ts platform/daemon/src/pipeline/graph-transactions.ts platform/daemon/src/pipeline/graph-transactions.test.ts platform/daemon/src/knowledge-graph-hygiene.ts platform/daemon/src/knowledge-graph-hygiene.test.ts platform/daemon/src/repair-actions.ts platform/daemon/src/repair-actions.test.ts platform/daemon/src/routes/repair-routes.ts docs/KNOWLEDGE-ARCHITECTURE.md docs/specs/INDEX.md docs/specs/dependencies.yaml docs/specs/complete/knowledge-architecture-schema.md docs/API.md`
- `bun run --filter '@signet/daemon' build` *(filter lookup fell back to the daemon build script; build passed with existing dashboard Svelte warnings)*
- `git diff --check`

## Notes
- No destructive cleanup runs automatically. The new `/api/repair/prune-generic-entities` path supports `dryRun` first and only targets entities rejected by the concrete quality gate while skipping pinned rows and lifecycle-owned skill rows; it pages through valid rows so older junk cannot hide behind a recency-limited window.
- Short names are allowed when typed as concrete objects (`Bun`, `npm`, `Git`, `AWS`, `Go`, `CI`, `AI`), while numeric-only, untyped short fragments, and generic scaffolding remain rejected.
- `extracted` / `unknown` legacy types are tolerated at write-time only when the entity name itself looks concrete, so old rows and extraction gaps do not break legitimate objects while junk still gets blocked.

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes
- [x] No database migrations were added, removed, renumbered, or modified.
