### PR TITLE
fix(install): persist global bin paths

### DIFF
--- a/surfaces/cli/src/lib/runtime.test.ts
+++ b/surfaces/cli/src/lib/runtime.test.ts
@@ -5,10 +5,12 @@ import { join } from "node:path";
 import {
 	buildLaunchdDaemonPlist,
 	buildLaunchdDaemonStartArgs,
+	buildLaunchdDaemonStopArgs,
 	buildSystemdDaemonStartArgs,
 	didLaunchdDaemonStart,
 	didSystemdDaemonStart,
 	getDaemonStatus,
+	launchdDaemonPlistPath,
 	readManagedDaemonPid,
 } from "./runtime.js";
 
@@ -71,7 +73,7 @@ describe("buildLaunchdDaemonPlist", () => {
 		expect(plist).toContain("<key>RunAtLoad</key>");
 		expect(plist).toContain("<true/>");
 		expect(plist).toContain("<key>KeepAlive</key>");
-		expect(plist).toContain("<false/>");
+		expect(plist).toMatch(/<key>KeepAlive<\/key>\s*<true\/>/);
 		expect(plist).toContain("<key>StandardErrorPath</key>");
 		expect(plist).toContain("<string>/Users/user/.agents/.daemon/logs/startup.log</string>");
 	});
@@ -97,11 +99,24 @@ describe("buildLaunchdDaemonPlist", () => {
 		expect(strings[0]).toMatch(/^\//);
 	});
 
+	it("uses a persistent user LaunchAgent path", () => {
+		expect(launchdDaemonPlistPath("/Users/user/.agents", "/Users/user")).toBe(
+			"/Users/user/Library/LaunchAgents/ai.signet.daemon.plist",
+		);
+	});
+
 	it("uses launchctl bootstrap against the current user launchd domain", () => {
-		const args = buildLaunchdDaemonStartArgs("/Users/user/.agents/.daemon/ai.signet.daemon.plist");
+		const args = buildLaunchdDaemonStartArgs("/Users/user/Library/LaunchAgents/ai.signet.daemon.plist");
 		expect(args[0]).toBe("bootstrap");
 		expect(args[1]).toStartWith("gui/");
-		expect(args[2]).toBe("/Users/user/.agents/.daemon/ai.signet.daemon.plist");
+		expect(args[2]).toBe("/Users/user/Library/LaunchAgents/ai.signet.daemon.plist");
+	});
+
+	it("uses launchctl bootout against the current user launchd service", () => {
+		const args = buildLaunchdDaemonStopArgs();
+		expect(args[0]).toBe("bootout");
+		expect(args[1]).toStartWith("gui/");
+		expect(args[1]).toEndWith("/ai.signet.daemon");
 	});
 });
 

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -12,6 +12,7 @@ import {
 	unlinkSync,
 	writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
 import { basename, delimiter, dirname, join, normalize } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseSimpleYaml } from "@signet/core";
@@ -437,6 +438,15 @@ function xmlEscape(value: string): string {
 
 export const LAUNCHD_DAEMON_LABEL = "ai.signet.daemon";
 
+function currentLaunchdDomain(): string {
+	const uid = typeof process.getuid === "function" ? process.getuid() : null;
+	return uid === null ? "user" : `gui/${uid}`;
+}
+
+export function launchdDaemonPlistPath(_agentsDir: string, home: string = homedir()): string {
+	return join(home, "Library", "LaunchAgents", `${LAUNCHD_DAEMON_LABEL}.plist`);
+}
+
 export function buildLaunchdDaemonPlist(input: LaunchdDaemonPlistInput): string {
 	const label = input.label ?? LAUNCHD_DAEMON_LABEL;
 	const env = {
@@ -473,7 +483,7 @@ export function buildLaunchdDaemonPlist(input: LaunchdDaemonPlistInput): string 
 	<key>RunAtLoad</key>
 	<true/>
 	<key>KeepAlive</key>
-	<false/>
+	<true/>
 	<key>StandardOutPath</key>
 	<string>/dev/null</string>
 	<key>StandardErrorPath</key>
@@ -486,9 +496,11 @@ export function buildLaunchdDaemonPlist(input: LaunchdDaemonPlistInput): string 
 }
 
 export function buildLaunchdDaemonStartArgs(plistPath: string): string[] {
-	const uid = typeof process.getuid === "function" ? process.getuid() : null;
-	const domain = uid === null ? "user" : `gui/${uid}`;
-	return ["bootstrap", domain, plistPath];
+	return ["bootstrap", currentLaunchdDomain(), plistPath];
+}
+
+export function buildLaunchdDaemonStopArgs(label: string = LAUNCHD_DAEMON_LABEL): string[] {
+	return ["bootout", `${currentLaunchdDomain()}/${label}`];
 }
 
 export function didSystemdDaemonStart(result: Pick<SpawnSyncReturns<Buffer>, "status" | "signal" | "error">): boolean {
@@ -597,7 +609,8 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR): Promise<boole
 			}
 		}
 	} else if (process.platform === "darwin") {
-		const plistPath = join(daemonDir, `${LAUNCHD_DAEMON_LABEL}.plist`);
+		const plistPath = launchdDaemonPlistPath(agentsDir);
+		mkdirSync(dirname(plistPath), { recursive: true });
 		writeFileSync(
 			plistPath,
 			buildLaunchdDaemonPlist({
@@ -609,6 +622,12 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR): Promise<boole
 				startupLogPath,
 			}),
 		);
+		const bootout = spawnSync("launchctl", buildLaunchdDaemonStopArgs(), {
+			stdio: ["ignore", "ignore", stderrTarget],
+			windowsHide: true,
+			env: daemonEnv,
+			timeout: 5000,
+		});
 		const bootstrap = spawnSync("launchctl", buildLaunchdDaemonStartArgs(plistPath), {
 			stdio: ["ignore", "ignore", stderrTarget],
 			windowsHide: true,
@@ -617,8 +636,7 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR): Promise<boole
 		});
 		startedByServiceManager = didLaunchdDaemonStart(bootstrap);
 		if (!startedByServiceManager) {
-			const uid = typeof process.getuid === "function" ? process.getuid() : null;
-			const target = `${uid === null ? "user" : `gui/${uid}`}/${LAUNCHD_DAEMON_LABEL}`;
+			const target = buildLaunchdDaemonStopArgs()[1];
 			const kickstart = spawnSync("launchctl", ["kickstart", "-k", target], {
 				stdio: ["ignore", "ignore", stderrTarget],
 				windowsHide: true,
@@ -630,7 +648,7 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR): Promise<boole
 				try {
 					appendFileSync(
 						startupLogPath,
-						`[launchd fallback] bootstrapStatus=${bootstrap.status ?? "null"} kickstartStatus=${kickstart.status ?? "null"} bootstrapError=${bootstrap.error?.message ?? ""} kickstartError=${kickstart.error?.message ?? ""}
+						`[launchd fallback] bootoutStatus=${bootout.status ?? "null"} bootstrapStatus=${bootstrap.status ?? "null"} kickstartStatus=${kickstart.status ?? "null"} bootoutError=${bootout.error?.message ?? ""} bootstrapError=${bootstrap.error?.message ?? ""} kickstartError=${kickstart.error?.message ?? ""}
 `,
 					);
 				} catch {
@@ -700,6 +718,14 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR): Promise<boole
 }
 
 export async function stopDaemon(agentsDir: string = AGENTS_DIR): Promise<boolean> {
+	if (process.platform === "darwin") {
+		spawnSync("launchctl", buildLaunchdDaemonStopArgs(), {
+			stdio: "ignore",
+			windowsHide: true,
+			timeout: 5000,
+		});
+	}
+
 	const pids = new Set<number>();
 	const managed = readManagedDaemonPid(agentsDir);
 	if (managed !== null) {

--- a/tests/integration/installer-path-regression.test.ts
+++ b/tests/integration/installer-path-regression.test.ts
@@ -14,8 +14,10 @@ describe("installer PATH persistence regression guard", () => {
 		expect(unixInstaller).toContain('persist_path_dir "$BUN_INSTALL/bin"');
 		expect(unixInstaller).toContain("npm_global_bin");
 		expect(unixInstaller).toContain('persist_path_dir "$NPM_GLOBAL_BIN"');
-		expect(unixInstaller).toContain("fish_add_path");
-		expect(unixInstaller).toContain('export PATH="%s:$PATH"');
+		expect(unixInstaller).toContain("string escape -- $argv[1]");
+		expect(unixInstaller).toContain("fish_add_path -- %s");
+		expect(unixInstaller).toContain("printf -v escaped '%q'");
+		expect(unixInstaller).toContain('export PATH=%s:"$PATH"');
 	});
 
 	it("persists Bun and npm global bins to the Windows user PATH", () => {

--- a/tests/integration/installer-path-regression.test.ts
+++ b/tests/integration/installer-path-regression.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = fileURLToPath(new URL("../../", import.meta.url));
+const unixInstaller = readFileSync(join(rootDir, "web/marketing/public/install.sh"), "utf8");
+const windowsInstaller = readFileSync(join(rootDir, "web/marketing/public/install.ps1"), "utf8");
+
+describe("installer PATH persistence regression guard", () => {
+	it("persists Bun and npm global bins for future Unix shells", () => {
+		expect(unixInstaller).toContain("persist_path_dir");
+		expect(unixInstaller).toContain('persist_path_dir "$BUN_BIN"');
+		expect(unixInstaller).toContain('persist_path_dir "$BUN_INSTALL/bin"');
+		expect(unixInstaller).toContain("npm_global_bin");
+		expect(unixInstaller).toContain('persist_path_dir "$NPM_GLOBAL_BIN"');
+		expect(unixInstaller).toContain("fish_add_path");
+		expect(unixInstaller).toContain('export PATH="%s:$PATH"');
+	});
+
+	it("persists Bun and npm global bins to the Windows user PATH", () => {
+		expect(windowsInstaller).toContain("function Add-UserPathEntry");
+		expect(windowsInstaller).toContain('[Environment]::SetEnvironmentVariable("Path", $newPath, "User")');
+		expect(windowsInstaller).not.toContain("if (-not (Test-Path $dir)) { return }");
+		expect(windowsInstaller).toContain("Get-Command bun");
+		expect(windowsInstaller).toContain("Split-Path -Parent $bunCommand.Source");
+		expect(windowsInstaller).toContain("Add-UserPathEntry $bunBin");
+		expect(windowsInstaller).toContain('Add-UserPathEntry (Join-Path $env:APPDATA "npm")');
+	});
+});

--- a/web/marketing/public/install.ps1
+++ b/web/marketing/public/install.ps1
@@ -8,6 +8,31 @@ function Write-Ok($msg)    { Write-Host "  [OK] $msg" -ForegroundColor Green }
 function Write-Warn($msg)  { Write-Host "  [!] $msg" -ForegroundColor Yellow }
 function Write-Err($msg)   { Write-Host "  [X] $msg" -ForegroundColor Red }
 
+function Add-UserPathEntry($dir) {
+    if (-not $dir) { return }
+
+    $parts = @($env:PATH -split ';' | Where-Object { $_ })
+    if ($parts -notcontains $dir) {
+        $env:PATH = "$dir;$env:PATH"
+    }
+
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $userParts = @($userPath -split ';' | Where-Object { $_ })
+    $alreadyPersisted = $false
+    foreach ($entry in $userParts) {
+        if ([string]::Equals($entry.TrimEnd('\'), $dir.TrimEnd('\'), [StringComparison]::OrdinalIgnoreCase)) {
+            $alreadyPersisted = $true
+            break
+        }
+    }
+
+    if (-not $alreadyPersisted) {
+        $newPath = if ([string]::IsNullOrWhiteSpace($userPath)) { $dir } else { "$userPath;$dir" }
+        [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+        Write-Info "Added $dir to the user PATH for future terminals"
+    }
+}
+
 # --- Banner ---
 Write-Host ""
 Write-Host ([char]0x2501 * 50)
@@ -26,6 +51,10 @@ try {
     $bunVersion = & bun --version 2>$null
     if ($LASTEXITCODE -eq 0) {
         Write-Ok "Bun: v$bunVersion"
+        $bunCommand = Get-Command bun -ErrorAction SilentlyContinue
+        if ($bunCommand -and $bunCommand.Source) {
+            Add-UserPathEntry (Split-Path -Parent $bunCommand.Source)
+        }
         $HasBun = $true
     }
 } catch {}
@@ -100,7 +129,7 @@ if (-not $HasBun) {
     $bunInstall = if ($env:BUN_INSTALL) { $env:BUN_INSTALL } else { Join-Path $HOME ".bun" }
     $bunBin = Join-Path $bunInstall "bin"
     if (Test-Path (Join-Path $bunBin "bun.exe")) {
-        $env:PATH = "$bunBin;$env:PATH"
+        Add-UserPathEntry $bunBin
     }
 
     try {
@@ -130,6 +159,7 @@ if ($HasBun) {
         Write-Err "bun install failed"
         if ($HasNode) {
             Write-Info "Falling back to npm..."
+            Add-UserPathEntry (Join-Path $env:APPDATA "npm")
             & npm install -g signetai
             if ($LASTEXITCODE -ne 0) {
                 Write-Err "npm install also failed"
@@ -140,6 +170,7 @@ if ($HasBun) {
         }
     }
 } elseif ($HasNode) {
+    Add-UserPathEntry (Join-Path $env:APPDATA "npm")
     & npm install -g signetai
     if ($LASTEXITCODE -ne 0) {
         Write-Err "npm install failed"

--- a/web/marketing/public/install.sh
+++ b/web/marketing/public/install.sh
@@ -17,6 +17,47 @@ warn()  { printf "  ${YELLOW}⚠ %b${RESET}\n" "$1"; }
 error() { printf "  ${RED}✗ %b${RESET}\n" "$1"; }
 ok()    { printf "  ${GREEN}✓ %b${RESET}\n" "$1"; }
 
+# Persist a bin directory for future shells when an installer places tools there.
+persist_path_dir() {
+  local bin_dir="$1"
+  [ -n "$bin_dir" ] || return 0
+  case ":$PATH:" in
+    *":$bin_dir:"*) ;;
+    *) export PATH="$bin_dir:$PATH" ;;
+  esac
+
+  local shell_rc=""
+  case "$(basename "${SHELL:-bash}")" in
+    zsh)  shell_rc="$HOME/.zshrc" ;;
+    fish) shell_rc="$HOME/.config/fish/config.fish" ;;
+    *)    shell_rc="$HOME/.bashrc" ;;
+  esac
+
+  if [ -z "$shell_rc" ]; then
+    return 0
+  fi
+
+  mkdir -p "$(dirname "$shell_rc")"
+  if ! grep -Fq "$bin_dir" "$shell_rc" 2>/dev/null; then
+    if [ "$(basename "$shell_rc")" = "config.fish" ]; then
+      printf '\nfish_add_path %s\n' "$bin_dir" >> "$shell_rc"
+    else
+      printf '\nexport PATH="%s:$PATH"\n' "$bin_dir" >> "$shell_rc"
+    fi
+    info "${DIM}Added $bin_dir to $shell_rc${RESET}"
+  fi
+}
+
+npm_global_bin() {
+  local prefix
+  prefix="$(npm config get prefix 2>/dev/null || echo "")"
+  [ -n "$prefix" ] || return 0
+  case "$prefix" in
+    */bin) printf '%s\n' "$prefix" ;;
+    *)     printf '%s/bin\n' "$prefix" ;;
+  esac
+}
+
 # --- Banner ---
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -57,6 +98,8 @@ if command -v bun >/dev/null 2>&1; then
   BUN_VERSION="$(bun --version 2>/dev/null || echo "unknown")"
   ok "Bun: v$BUN_VERSION"
   HAS_BUN=true
+  BUN_BIN="$(dirname "$(command -v bun)")"
+  persist_path_dir "$BUN_BIN"
 fi
 
 # --- Check for node 18+ ---
@@ -95,7 +138,7 @@ if [ "$HAS_BUN" = false ]; then
   # Source bun env so it's available in this session
   BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
   if [ -f "$BUN_INSTALL/bin/bun" ]; then
-    export PATH="$BUN_INSTALL/bin:$PATH"
+    persist_path_dir "$BUN_INSTALL/bin"
   fi
 
   if command -v bun >/dev/null 2>&1; then
@@ -127,9 +170,10 @@ if [ "$HAS_BUN" = true ]; then
           info "Fixing to ~/.npm-global to avoid permission issues..."
           mkdir -p "$HOME/.npm-global"
           npm config set prefix "$HOME/.npm-global"
-          export PATH="$HOME/.npm-global/bin:$PATH"
           ;;
       esac
+      NPM_GLOBAL_BIN="$(npm_global_bin)"
+      persist_path_dir "$NPM_GLOBAL_BIN"
       if ! npm install -g signetai; then
         error "npm install also failed"
         exit 1
@@ -146,19 +190,10 @@ elif [ "$HAS_NODE" = true ]; then
       info "Fixing to ~/.npm-global to avoid permission issues..."
       mkdir -p "$HOME/.npm-global"
       npm config set prefix "$HOME/.npm-global"
-      export PATH="$HOME/.npm-global/bin:$PATH"
-      # Persist PATH fix
-      SHELL_RC=""
-      case "$(basename "${SHELL:-bash}")" in
-        zsh)  SHELL_RC="$HOME/.zshrc" ;;
-        *)    SHELL_RC="$HOME/.bashrc" ;;
-      esac
-      if [ -n "$SHELL_RC" ] && ! grep -q '.npm-global' "$SHELL_RC" 2>/dev/null; then
-        printf '\nexport PATH="$HOME/.npm-global/bin:$PATH"\n' >> "$SHELL_RC"
-        info "${DIM}Added PATH to $SHELL_RC${RESET}"
-      fi
       ;;
   esac
+  NPM_GLOBAL_BIN="$(npm_global_bin)"
+  persist_path_dir "$NPM_GLOBAL_BIN"
   if ! npm install -g signetai; then
     error "npm install failed"
     exit 1

--- a/web/marketing/public/install.sh
+++ b/web/marketing/public/install.sh
@@ -40,9 +40,19 @@ persist_path_dir() {
   mkdir -p "$(dirname "$shell_rc")"
   if ! grep -Fq "$bin_dir" "$shell_rc" 2>/dev/null; then
     if [ "$(basename "$shell_rc")" = "config.fish" ]; then
-      printf '\nfish_add_path %s\n' "$bin_dir" >> "$shell_rc"
+      # string escape returns fish-safe source text, not raw data.
+      local escaped
+      if command -v fish >/dev/null 2>&1; then
+        escaped="$(fish -c 'string escape -- $argv[1]' "$bin_dir")"
+        printf '\nfish_add_path -- %s\n' "$escaped" >> "$shell_rc"
+      else
+        warn "fish shell detected but fish is not executable; add $bin_dir to PATH manually"
+        return 0
+      fi
     else
-      printf '\nexport PATH="%s:$PATH"\n' "$bin_dir" >> "$shell_rc"
+      # Bash's %q emits shell-safe source text; zsh accepts the same quoting forms.
+      printf -v escaped '%q' "$bin_dir"
+      printf '\nexport PATH=%s:"$PATH"\n' "$escaped" >> "$shell_rc"
     fi
     info "${DIM}Added $bin_dir to $shell_rc${RESET}"
   fi


### PR DESCRIPTION
## Summary
- Persist Bun/npm global bin directories during the Unix curl installer instead of only exporting PATH for the current installer process.
- Persist Bun/npm global bin directories to the Windows user PATH during install so new terminals keep finding `signet`.
- Add an installer regression guard covering both install scripts.

## Context
Discord feedback reported repeated Signet reinstalls because `signet` keeps disappearing from PATH/alignment on user machines. The installer could detect Signet in common bin dirs and tell the user to repair PATH, but Windows did not persist PATH at all and the Unix Bun path / fallback-npm paths were only partially persistent.

## Testing
- `bun test tests/integration/installer-path-regression.test.ts`
- `bash -n web/marketing/public/install.sh`
- `git diff --check`
- `bunx --bun biome check tests/integration/installer-path-regression.test.ts`

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes
- [x] No database migrations were added, removed, renumbered, or modified.

## Follow-up
- Escaped Unix shell PATH persistence to avoid persisting npm-controlled shell syntax into startup files.
- Fixed the macOS daemon lifecycle path: Signet now writes the launchd plist to `~/Library/LaunchAgents/ai.signet.daemon.plist`, uses `KeepAlive=true`, bootouts stale launchd state before bootstrap, and bootouts the service before `signet daemon stop` so KeepAlive does not resurrect intentional stops.

Fixes #686
