### PR TITLE
feat(dashboard): add ACPX quick setup

### DIFF
--- a/surfaces/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
@@ -18,6 +18,11 @@ import {
 } from "$lib/stores/settings.svelte";
 import { defaultPipelineModel } from "@signet/core/pipeline-providers";
 import {
+	ACPX_DASHBOARD_AGENT_OPTIONS,
+	type AcpxDashboardAgent,
+	applyAcpxDashboardSetup,
+	defaultAcpxDashboardAgent,
+	defaultAcpxDashboardModel,
 	hasExplicitSynthesisConfig,
 	hasExplicitSynthesisProvider,
 	resolveSynthesisEnabled,
@@ -38,6 +43,7 @@ const EXTRACTION_SAFETY_TEXT =
 
 const EXTRACTION_PROVIDER_OPTIONS = [
 	{ value: "none", label: "none (disable extraction)" },
+	{ value: "acpx", label: "acpx (recommended dashboard setup)" },
 	{ value: "llama-cpp", label: "llama-cpp" },
 	{ value: "ollama", label: "ollama" },
 	{ value: "claude-code", label: "claude-code" },
@@ -49,6 +55,7 @@ const EXTRACTION_PROVIDER_OPTIONS = [
 
 // Hardcoded fallback presets — used when the registry API is unavailable
 const FALLBACK_MODEL_PRESETS: Record<string, Array<{ value: string; label: string }>> = {
+	acpx: ACPX_DASHBOARD_AGENT_OPTIONS.map((option) => ({ value: option.model, label: `${option.label} safe default` })),
 	"llama-cpp": [
 		{ value: "qwen3.5:4b", label: "qwen3.5:4b" },
 		{ value: "qwen3:8b", label: "qwen3:8b" },
@@ -130,6 +137,9 @@ function getModelPresets(provider: string): Array<{ value: string; label: string
 
 function pickPreferredModel(provider: string, presets: Array<{ value: string; label: string }>): string {
 	const vals = presets.map((preset) => preset.value);
+	if (provider === "acpx") {
+		return vals.find((v) => v.toLowerCase().includes("mini")) ?? vals[0] ?? "";
+	}
 	if (provider === "claude-code" || provider === "anthropic") {
 		return vals.find((v) => v.toLowerCase().includes("haiku")) ?? vals[0] ?? "";
 	}
@@ -209,7 +219,7 @@ function extractionDisabled(): boolean {
 }
 
 function providerRisky(provider: string): boolean {
-	return provider === "anthropic" || provider === "openrouter" || provider === "opencode";
+	return provider === "acpx" || provider === "anthropic" || provider === "openrouter" || provider === "opencode";
 }
 
 function extractionProviderRisky(): boolean {
@@ -372,6 +382,38 @@ function extractionModelLabel(): string {
 	return preset ? preset.label : model;
 }
 
+let acpxAgent = $state<AcpxDashboardAgent>("codex");
+let acpxModel = $state(defaultAcpxDashboardModel("codex"));
+
+$effect(() => {
+	const nextAgent = defaultAcpxDashboardAgent(st.agent);
+	acpxAgent = nextAgent;
+	const current =
+		st.aStr(["memory", "pipelineV2", "extractionProvider"]) === "acpx"
+			? st.aStr(["memory", "pipelineV2", "extractionModel"])
+			: "";
+	acpxModel = current || defaultAcpxDashboardModel(nextAgent);
+});
+
+function acpxAgentLabel(): string {
+	return ACPX_DASHBOARD_AGENT_OPTIONS.find((option) => option.value === acpxAgent)?.label ?? acpxAgent;
+}
+
+function setAcpxAgent(value: string | undefined): void {
+	if (value !== "codex" && value !== "claude-code" && value !== "opencode") return;
+	acpxAgent = value;
+	acpxModel = defaultAcpxDashboardModel(value);
+}
+
+function setAcpxModel(e: Event): void {
+	acpxModel = (e.currentTarget as HTMLInputElement).value;
+}
+
+function applyAcpxQuickSetup(): void {
+	applyAcpxDashboardSetup(st.agent, { agent: acpxAgent, model: acpxModel });
+	st.agent = { ...st.agent };
+}
+
 const STRENGTH_MAX_TOKENS: Record<string, number> = { low: 1024, medium: 2048, high: 4096 };
 
 function strengthMaxTokensLabel(): number {
@@ -390,6 +432,49 @@ const ADVANCED_FEATURE_KEYS = ["autonomousFrozen"] as const;
 
 {#if st.agentFile}
 	<FormSection description="V2 memory pipeline. Runs LLM-based fact extraction on incoming memories, then decides whether to write, update, or skip. Lives under memory.pipelineV2 in agent.yaml.">
+		<div class="rounded-lg border border-[var(--sig-border-strong)] bg-[color-mix(in_srgb,var(--sig-bg),var(--sig-highlight)_4%)] p-3">
+			<div class="flex flex-col gap-3">
+				<div class="flex items-start justify-between gap-3">
+					<div class="flex flex-col gap-1">
+						<span class="font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--sig-highlight)]">ACPX quick setup</span>
+						<span class="text-[12px] leading-snug text-[var(--sig-text)]">Configure background extraction and session synthesis through ACPX with the guarded defaults Signet expects.</span>
+					</div>
+					<button
+						type="button"
+						class="shrink-0 rounded-md border border-[var(--sig-highlight)] bg-[color-mix(in_srgb,var(--sig-highlight),transparent_88%)] px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.08em] text-[var(--sig-highlight)] transition-colors hover:bg-[color-mix(in_srgb,var(--sig-highlight),transparent_80%)]"
+						onclick={applyAcpxQuickSetup}
+					>
+						Use ACPX defaults
+					</button>
+				</div>
+
+				<div class="grid gap-2 md:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]">
+					<div class="flex flex-col gap-1.5">
+						<span class="font-mono text-[9px] uppercase tracking-[0.1em] text-[var(--sig-text-muted)]">Agent adapter</span>
+						<Select.Root type="single" value={acpxAgent} onValueChange={setAcpxAgent}>
+							<Select.Trigger class={selectTriggerClass}>{acpxAgentLabel()}</Select.Trigger>
+							<Select.Content class={selectContentClass}>
+								{#each ACPX_DASHBOARD_AGENT_OPTIONS as option (option.value)}
+									<Select.Item class={selectItemClass} value={option.value} label={option.label} />
+								{/each}
+							</Select.Content>
+						</Select.Root>
+					</div>
+					<div class="flex flex-col gap-1.5">
+						<span class="font-mono text-[9px] uppercase tracking-[0.1em] text-[var(--sig-text-muted)]">Model</span>
+						<Input value={acpxModel} oninput={setAcpxModel} placeholder="model passed through ACPX" />
+					</div>
+				</div>
+
+				<div class="grid gap-2 text-[9px] uppercase tracking-[0.08em] text-[var(--sig-text-muted)] md:grid-cols-3">
+					<span>npx acpx@0.7.0</span>
+					<span>permissions: deny-all</span>
+					<span>hooks: disabled</span>
+				</div>
+				<span class="text-[9px] uppercase tracking-wider text-[var(--sig-warning)]">Writes memory.pipelineV2 plus a background-acpx inference route for memory extraction and session synthesis. Save settings after applying.</span>
+			</div>
+		</div>
+
 		<FormField label={PIPELINE_CORE_BOOLS[0].key} description={PIPELINE_CORE_BOOLS[0].desc}>
 			<Switch checked={st.aBool(["memory", "pipelineV2", PIPELINE_CORE_BOOLS[0].key])} onCheckedChange={setBool(["memory", "pipelineV2", PIPELINE_CORE_BOOLS[0].key])} />
 		</FormField>

--- a/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts
@@ -144,6 +144,7 @@ describe("pipeline-settings ACPX dashboard setup", () => {
 		const agent: Record<string, unknown> = {
 			harnesses: ["claude-code"],
 			inference: {
+				defaultPolicy: "custom-local",
 				targets: {
 					"custom-local": { executor: "ollama" },
 				},
@@ -165,8 +166,15 @@ describe("pipeline-settings ACPX dashboard setup", () => {
 				},
 			},
 		});
+		expect((agent.memory as { pipelineV2: Record<string, unknown> }).pipelineV2).not.toHaveProperty(
+			"autonomousEnabled",
+		);
+		expect((agent.memory as { pipelineV2: Record<string, unknown> }).pipelineV2).not.toHaveProperty(
+			"allowUpdateDelete",
+		);
+		expect((agent.memory as { pipelineV2: Record<string, unknown> }).pipelineV2).not.toHaveProperty("maintenanceMode");
 		expect(agent.inference).toMatchObject({
-			defaultPolicy: "background-acpx",
+			defaultPolicy: "custom-local",
 			targets: {
 				"custom-local": { executor: "ollama" },
 				"background-acpx": {

--- a/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts
@@ -2,6 +2,8 @@
 import { describe, expect, it } from "bun:test";
 import { DEFAULT_PIPELINE_TIMEOUT_MS } from "@signet/core/pipeline-providers";
 import {
+	applyAcpxDashboardSetup,
+	defaultAcpxDashboardAgent,
 	hasExplicitSynthesisConfig,
 	hasExplicitSynthesisProvider,
 	resolveSynthesisEnabled,
@@ -119,5 +121,79 @@ describe("pipeline-settings synthesis resolution", () => {
 
 		expect(resolveSynthesisProvider(agent)).toBe("none");
 		expect(resolveSynthesisEnabled(agent)).toBe(false);
+	});
+});
+
+describe("pipeline-settings ACPX dashboard setup", () => {
+	it("detects the preferred ACPX agent from generated inference config before harnesses", () => {
+		const agent = {
+			harnesses: ["claude-code"],
+			inference: {
+				targets: {
+					"background-acpx": {
+						acpx: { agent: "opencode" },
+					},
+				},
+			},
+		};
+
+		expect(defaultAcpxDashboardAgent(agent)).toBe("opencode");
+	});
+
+	it("applies a one-click ACPX background setup for extraction, synthesis, and routing", () => {
+		const agent: Record<string, unknown> = {
+			harnesses: ["claude-code"],
+			inference: {
+				targets: {
+					"custom-local": { executor: "ollama" },
+				},
+			},
+		};
+
+		applyAcpxDashboardSetup(agent, { agent: "claude-code" });
+
+		expect(agent.memory).toMatchObject({
+			pipelineV2: {
+				enabled: true,
+				extractionProvider: "acpx",
+				extractionModel: "claude-haiku-4-5",
+				synthesis: {
+					enabled: true,
+					provider: "acpx",
+					model: "claude-haiku-4-5",
+					timeout: 120000,
+				},
+			},
+		});
+		expect(agent.inference).toMatchObject({
+			defaultPolicy: "background-acpx",
+			targets: {
+				"custom-local": { executor: "ollama" },
+				"background-acpx": {
+					executor: "acpx",
+					acpx: {
+						agent: "claude-code",
+						package: "acpx@0.7.0",
+						permissions: "deny-all",
+						hooks: "disabled",
+					},
+					models: {
+						default: {
+							model: "claude-haiku-4-5",
+						},
+					},
+				},
+			},
+			policies: {
+				"background-acpx": {
+					mode: "automatic",
+					defaultTargets: ["background-acpx/default"],
+				},
+			},
+			workloads: {
+				memoryExtraction: { target: "background-acpx/default", taskClass: "memory_extraction" },
+				sessionSynthesis: { target: "background-acpx/default", taskClass: "session_synthesis" },
+			},
+		});
 	});
 });

--- a/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.ts
@@ -11,6 +11,20 @@ function toRecord(value: unknown): Record<string, unknown> | null {
 		: null;
 }
 
+function mutableRecord(value: unknown): Record<string, unknown> | null {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null;
+}
+
+function ensureRecord(root: Record<string, unknown>, key: string): Record<string, unknown> {
+	const existing = mutableRecord(root[key]);
+	if (existing) return existing;
+	const next: Record<string, unknown> = {};
+	root[key] = next;
+	return next;
+}
+
 function readPipeline(agent: unknown): Record<string, unknown> | null {
 	const root = toRecord(agent);
 	const mem = toRecord(root?.memory);
@@ -110,4 +124,94 @@ export function resolveSynthesisEnabled(agent: unknown): boolean {
 	const pipeline = readPipeline(agent);
 	if (resolveSynthesisProvider(agent) === "none") return false;
 	return readBoolean(pipeline, "synthesis", "enabled") ?? true;
+}
+export type AcpxDashboardAgent = "codex" | "claude-code" | "opencode";
+
+export const ACPX_DASHBOARD_AGENT_OPTIONS: Array<{
+	readonly value: AcpxDashboardAgent;
+	readonly label: string;
+	readonly model: string;
+}> = [
+	{ value: "codex", label: "Codex CLI", model: "gpt-5-codex-mini" },
+	{ value: "claude-code", label: "Claude Code", model: "claude-haiku-4-5" },
+	{ value: "opencode", label: "OpenCode", model: "anthropic/claude-haiku-4-5-20251001" },
+];
+
+export function defaultAcpxDashboardAgent(agentConfig: unknown): AcpxDashboardAgent {
+	const inference = toRecord(toRecord(agentConfig)?.inference);
+	const target = toRecord(toRecord(inference?.targets)?.["background-acpx"]);
+	const acpx = toRecord(target?.acpx);
+	const configured = acpx?.agent;
+	if (configured === "claude-code" || configured === "opencode" || configured === "codex") return configured;
+	const harnesses = toRecord(agentConfig)?.harnesses;
+	if (Array.isArray(harnesses)) {
+		for (const harness of harnesses) {
+			if (harness === "codex" || harness === "claude-code" || harness === "opencode") return harness;
+		}
+	}
+	return "codex";
+}
+
+export function defaultAcpxDashboardModel(agent: AcpxDashboardAgent): string {
+	return ACPX_DASHBOARD_AGENT_OPTIONS.find((option) => option.value === agent)?.model ?? "gpt-5-codex-mini";
+}
+
+export function applyAcpxDashboardSetup(
+	agentConfig: Record<string, unknown>,
+	options: { readonly agent: AcpxDashboardAgent; readonly model?: string },
+): void {
+	const model = options.model?.trim() || defaultAcpxDashboardModel(options.agent);
+	const memory = ensureRecord(agentConfig, "memory");
+	const pipeline = ensureRecord(memory, "pipelineV2");
+	pipeline.enabled = true;
+	pipeline.extractionProvider = "acpx";
+	pipeline.extractionModel = model;
+	pipeline.semanticContradictionEnabled = true;
+	pipeline.graphEnabled = true;
+	pipeline.rerankerEnabled = true;
+	pipeline.autonomousEnabled = true;
+	pipeline.allowUpdateDelete = true;
+	pipeline.maintenanceMode = "execute";
+	pipeline.synthesis = {
+		enabled: true,
+		provider: "acpx",
+		model,
+		timeout: 120000,
+	};
+
+	const inference = ensureRecord(agentConfig, "inference");
+	inference.defaultPolicy = "background-acpx";
+	const targets = ensureRecord(inference, "targets");
+	targets["background-acpx"] = {
+		executor: "acpx",
+		acpx: {
+			agent: options.agent,
+			package: "acpx@0.7.0",
+			version: "0.7.0",
+			mode: "exec",
+			permissions: "deny-all",
+			hooks: "disabled",
+			terminal: "inherit",
+		},
+		models: {
+			default: {
+				model,
+				reasoning: "medium",
+				toolUse: true,
+				costTier: "medium",
+			},
+		},
+	};
+	const policies = ensureRecord(inference, "policies");
+	policies["background-acpx"] = {
+		mode: "automatic",
+		defaultTargets: ["background-acpx/default"],
+		fallbackTargets: ["background-acpx/default"],
+	};
+	const taskClasses = ensureRecord(inference, "taskClasses");
+	taskClasses.memory_extraction = { reasoning: "medium", toolsRequired: true, privacy: "restricted_remote" };
+	taskClasses.session_synthesis = { reasoning: "medium", toolsRequired: true, privacy: "restricted_remote" };
+	const workloads = ensureRecord(inference, "workloads");
+	workloads.memoryExtraction = { target: "background-acpx/default", taskClass: "memory_extraction" };
+	workloads.sessionSynthesis = { target: "background-acpx/default", taskClass: "session_synthesis" };
 }

--- a/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.ts
@@ -169,9 +169,6 @@ export function applyAcpxDashboardSetup(
 	pipeline.semanticContradictionEnabled = true;
 	pipeline.graphEnabled = true;
 	pipeline.rerankerEnabled = true;
-	pipeline.autonomousEnabled = true;
-	pipeline.allowUpdateDelete = true;
-	pipeline.maintenanceMode = "execute";
 	pipeline.synthesis = {
 		enabled: true,
 		provider: "acpx",
@@ -180,7 +177,6 @@ export function applyAcpxDashboardSetup(
 	};
 
 	const inference = ensureRecord(agentConfig, "inference");
-	inference.defaultPolicy = "background-acpx";
 	const targets = ensureRecord(inference, "targets");
 	targets["background-acpx"] = {
 		executor: "acpx",


### PR DESCRIPTION
## Summary
- Add an ACPX quick setup panel to Dashboard → Settings → Pipeline.
- Make `acpx` selectable as a pipeline provider and provide safe ACPX model presets.
- One click now writes both `memory.pipelineV2` and the `background-acpx` inference route with guarded defaults: `acpx@0.7.0`, `permissions: deny-all`, `hooks: disabled`, memory extraction workload, and session synthesis workload.
- Add regression coverage for ACPX agent detection and generated dashboard setup config.

## Testing
- `bun run build:core`
- `bun test surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts`
- `bunx --bun biome check surfaces/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.ts surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts`
- `git diff --check`
- `cd surfaces/dashboard && bun run check` (0 errors; existing warnings only)
- `cd surfaces/dashboard && bun run build` (existing warnings only)
- `python3 - <<'PY' ... yaml.safe_load('docs/specs/dependencies.yaml') ... PY`

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes
- [x] No database migrations were added, removed, renumbered, or modified.
