### PR TITLE
refactor(identity): add configurable identity presets

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -145,6 +145,7 @@ signet setup --path /custom/path
 signet setup --non-interactive \
   --name "My Agent" \
   --harness claude-code \
+  --identity-preset minimal \
   --deployment-type vps \
   --embedding-provider native
 ```
@@ -159,6 +160,7 @@ Options:
 | `--description <description>` | Agent description in non-interactive mode |
 | `--deployment-type <type>` | Deployment context (`local`, `vps`, `server`) used for interactive guidance and non-interactive inferred defaults |
 | `--harness <harness>` | Repeatable/comma-separated harness list (`claude-code`, `opencode`, `openclaw`, `hermes-agent`, `oh-my-pi`, `pi`, `codex`, `forge`) |
+| `--identity-preset <preset>` | Identity/context preset (`minimal`, `hermes`, `openclaw`, `custom`); controls startup-loaded files and special prompt files like `DREAMING.md` |
 | `--embedding-provider <provider>` | Non-interactive embedding provider (`ollama`, `openai`, `native`, `none`) |
 | `--embedding-model <model>` | Non-interactive embedding model |
 | `--extraction-provider <provider>` | Non-interactive extraction provider (`claude-code`, `codex`, `ollama`, `opencode`, `openrouter`, `none`) |
@@ -178,7 +180,10 @@ Non-interactive behavior:
 
 - setup method: create new identity (no GitHub import)
 - provider flags are optional; setup infers defaults from `--deployment-type`
-  when omitted
+- `--identity-preset` defaults to `minimal` for new workspaces
+- the Minimal preset creates `AGENTS.md` for startup context and `DREAMING.md`
+  for dreaming sessions; `DREAMING.md` is not loaded into normal startup context
+- hooks/connectors are configured for requested harnesses
 - with `--deployment-type vps`, setup prefers non-local extraction defaults
   from selected harnesses when those tools are available locally, then other
   detected tooling (`claude-code`, `codex`, `opencode`), and falls back to

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -26,6 +26,8 @@ All files live in your active Signet workspace.
 | `agent.yaml` | Main configuration and manifest |
 | `AGENTS.md` | Agent-managed operating rules and instructions (synced to harnesses) |
 | `DREAMING.md` | Dreaming/reflection prompt used only for dreaming sessions; not loaded during normal startup |
+| `HEARTBEAT.md` | Heartbeat/background-check prompt used only for heartbeat sessions |
+| `BOOTSTRAP.md` | Bootstrap/setup prompt used only for first-run/bootstrap sessions |
 | `SOUL.md` | Agent-managed personality, tone, values, and temperament |
 | `MEMORY.md` | System-managed working memory summary (auto-generated, do not edit manually) |
 | `IDENTITY.md` | Agent-managed identity metadata |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -25,6 +25,7 @@ All files live in your active Signet workspace.
 |------|---------|
 | `agent.yaml` | Main configuration and manifest |
 | `AGENTS.md` | Agent-managed operating rules and instructions (synced to harnesses) |
+| `DREAMING.md` | Dreaming/reflection prompt used only for dreaming sessions; not loaded during normal startup |
 | `SOUL.md` | Agent-managed personality, tone, values, and temperament |
 | `MEMORY.md` | System-managed working memory summary (auto-generated, do not edit manually) |
 | `IDENTITY.md` | Agent-managed identity metadata |
@@ -121,6 +122,19 @@ memory:
     autonomous:
       enabled: true
       maintenanceMode: execute
+
+identity:
+  preset: minimal
+  startup:
+    load:
+      - path: AGENTS.md
+        role: operating_instructions
+        budget: 12000
+  special:
+    - path: DREAMING.md
+      kind: dreaming
+      role: dreaming_prompt
+      budget: 4000
 
 hooks:
   sessionStart:
@@ -252,6 +266,52 @@ importance(t) = base_importance × decay_rate^days_since_access
 ```
 
 Accessing a memory resets the decay timer.
+
+
+### identity
+
+Identity loading is configurable. Presets choose which Markdown files load
+into normal startup context and which files are reserved for special sessions.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `preset` | string | `minimal` | One of `minimal`, `hermes`, `openclaw`, or `custom` |
+| `startup.load` | array | preset-defined | Ordered files loaded into normal startup/static fallback context |
+| `special` | array | preset-defined | Prompt files used only for special sessions, such as dreaming |
+
+Built-in presets:
+
+- `minimal` — startup loads only `AGENTS.md`; `DREAMING.md` is still created
+  and available for dreaming sessions, but is not loaded every turn.
+- `hermes` — startup loads `SOUL.md` then `AGENTS.md`, matching Hermes'
+  current SOUL-primary identity plus project-context convention.
+- `openclaw` — rich startup stack: `AGENTS.md`, `SOUL.md`, `IDENTITY.md`,
+  `USER.md`, and `MEMORY.md`, with `HEARTBEAT.md`, `DREAMING.md`, and
+  `BOOTSTRAP.md` reserved as special-session prompts.
+- `custom` — explicit ordered startup list chosen by the user.
+
+Example custom order:
+
+```yaml
+identity:
+  preset: custom
+  startup:
+    load:
+      - path: USER.md
+        role: user_profile
+        budget: 6000
+      - path: AGENTS.md
+        role: operating_instructions
+        budget: 12000
+  special:
+    - path: DREAMING.md
+      kind: dreaming
+      role: dreaming_prompt
+      budget: 4000
+```
+
+Special session files are not startup context. `DREAMING.md` is the prompt for
+reflection/consolidation runs and costs zero tokens in ordinary sessions.
 
 
 ### memory.synthesis

--- a/docs/specs/approved/dreaming-memory-consolidation.md
+++ b/docs/specs/approved/dreaming-memory-consolidation.md
@@ -134,13 +134,15 @@ This means:
 ### Identity
 
 The dreaming agent is not an anonymous data processor. It is the same
-agent — with full identity context — taking time to reflect on its
-own experiences. It receives the complete identity stack:
+agent taking time to reflect on its own experiences. It receives the
+startup identity/context selected by the active identity preset, then
+receives `DREAMING.md` as the dreaming task prompt. For example:
 
-- `AGENTS.md` — operating instructions
-- `SOUL.md` — personality, values, temperament
-- `IDENTITY.md` — who the agent is
-- `USER.md` — who the user is and how to relate to them
+- Minimal startup: `AGENTS.md`
+- Hermes startup: `SOUL.md`, then `AGENTS.md` / Hermes project context
+- OpenClaw startup: `AGENTS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`,
+  and `MEMORY.md`
+- Special dreaming prompt: `DREAMING.md` appended only for dreaming sessions
 
 This matters because memory consolidation requires judgment about
 *what matters to this agent and this user*. An isolated worker can't
@@ -190,19 +192,20 @@ the rest.
 
 The dreaming agent receives (via normal session-start hook):
 
-1. **Full identity context** — AGENTS.md, SOUL.md, IDENTITY.md,
-   USER.md, MEMORY.md. The complete identity stack, same as any
-   session. The agent needs to know who it is, what it's been doing,
-   and what the current state of its memory looks like.
+1. **Active startup identity context** — the ordered files selected by
+   `identity.startup.load` in `agent.yaml`. Minimal agents may load only
+   `AGENTS.md`; richer presets can load `SOUL.md`, `IDENTITY.md`,
+   `USER.md`, and `MEMORY.md` according to their configured order.
 2. **Unprocessed session summaries** — all summaries written since the
    last dreaming pass, ordered chronologically. These are the session
    DAG nodes at depth 0 with `kind = "session"`.
 3. **Current entity graph snapshot** — all entities with their aspects
    and attributes, plus relationship edges. This is the agent's view
    of existing long-term memory.
-4. **A brief task prompt** — telling the agent to reflect on the
-   sessions and update the graph. No elaborate instructions — the
-   agent's own identity and judgment handles the rest.
+4. **`DREAMING.md` task prompt** — the special-session prompt telling
+   the agent to reflect on the sessions and update the graph. It is not
+   loaded in normal startup context; it is appended only for dreaming
+   sessions.
 
 ### Self-Improvement Loop
 

--- a/docs/specs/dependencies.yaml
+++ b/docs/specs/dependencies.yaml
@@ -1332,6 +1332,7 @@ specs:
       - "Stale or junk attributes are pruned without manual intervention"
       - "Users without large-model access fall back to the existing extraction pipeline with no degradation"
       - "Token spend per dreaming pass is bounded and configurable"
+      - "Dreaming uses DREAMING.md as its special-session prompt file instead of loading that prompt during ordinary startup context"
       - "Dreaming passes run as full sessions with transcript capture and self-improvement loop (Phase 2)"
       - "Pipeline V2 extraction is gated off when dreaming is enabled (Phase 2)"
     decision: null

--- a/platform/core/src/__tests__/identity.test.ts
+++ b/platform/core/src/__tests__/identity.test.ts
@@ -9,6 +9,7 @@ import {
 	readStaticIdentity,
 	resolvePromptSubmitTimeoutMs,
 	resolveSessionStartTimeoutMs,
+	resolveStartupIdentityFiles,
 } from "../identity";
 import { parseSimpleYaml } from "../yaml";
 
@@ -105,7 +106,7 @@ describe("readStaticIdentity", () => {
 		expect(result).not.toContain("## Soul");
 	});
 
-	test("reads all five identity files", () => {
+	test("reads all five legacy identity files", () => {
 		writeFileSync(join(TMP, "AGENTS.md"), "agents");
 		writeFileSync(join(TMP, "SOUL.md"), "soul");
 		writeFileSync(join(TMP, "IDENTITY.md"), "identity");
@@ -119,6 +120,34 @@ describe("readStaticIdentity", () => {
 		expect(result).toContain("## Identity");
 		expect(result).toContain("## About Your User");
 		expect(result).toContain("## Working Memory");
+	});
+
+	test("minimal preset loads only AGENTS.md during startup and leaves DREAMING.md special-session only", () => {
+		writeFileSync(
+			join(TMP, "agent.yaml"),
+			"identity:\n  preset: minimal\n  startup:\n    load:\n      - path: AGENTS.md\n        role: operating_instructions\n        budget: 12000\n  special:\n    - path: DREAMING.md\n      kind: dreaming\n      role: dreaming_prompt\n      budget: 4000\n",
+		);
+		writeFileSync(join(TMP, "AGENTS.md"), "agents");
+		writeFileSync(join(TMP, "DREAMING.md"), "dreaming");
+		writeFileSync(join(TMP, "SOUL.md"), "soul");
+
+		expect(resolveStartupIdentityFiles(TMP).map((entry) => entry.path)).toEqual(["AGENTS.md"]);
+		const result = readStaticIdentity(TMP);
+		expect(result).toContain("agents");
+		expect(result).not.toContain("dreaming");
+		expect(result).not.toContain("soul");
+	});
+
+	test("respects configured startup identity file order", () => {
+		writeFileSync(
+			join(TMP, "agent.yaml"),
+			"identity:\n  preset: custom\n  startup:\n    load:\n      - path: USER.md\n        role: user_profile\n        budget: 6000\n      - path: AGENTS.md\n        role: operating_instructions\n        budget: 12000\n",
+		);
+		writeFileSync(join(TMP, "AGENTS.md"), "agents");
+		writeFileSync(join(TMP, "USER.md"), "user");
+
+		const result = readStaticIdentity(TMP) ?? "";
+		expect(result.indexOf("## About Your User")).toBeLessThan(result.indexOf("## Agent Instructions"));
 	});
 });
 

--- a/platform/core/src/identity.ts
+++ b/platform/core/src/identity.ts
@@ -727,6 +727,20 @@ function readIdentityEntryList(value: unknown): IdentityContextFileEntry[] {
 	return value.map(readIdentityEntry).filter((entry): entry is IdentityContextFileEntry => entry !== null);
 }
 
+function readSpecialIdentityEntry(value: unknown): IdentitySpecialFileEntry | null {
+	const record = readRecord(value);
+	const kind = typeof record.kind === "string" ? record.kind : "";
+	if (kind !== "dreaming" && kind !== "heartbeat" && kind !== "bootstrap") return null;
+	const entry = readIdentityEntry(value);
+	if (!entry) return null;
+	return { ...entry, kind };
+}
+
+function readSpecialIdentityEntryList(value: unknown): IdentitySpecialFileEntry[] {
+	if (!Array.isArray(value)) return [];
+	return value.map(readSpecialIdentityEntry).filter((entry): entry is IdentitySpecialFileEntry => entry !== null);
+}
+
 function identityHeaderFor(path: string, role?: string): string {
 	const filename = path.split(/[\\/]/).pop() ?? path;
 	return STATIC_HEADER_BY_FILE[filename] ?? role ?? filename.replace(/\.md$/i, "");
@@ -748,6 +762,25 @@ export function resolveStartupIdentityFiles(agentsDir: string): IdentityContextF
 		// Fall back to legacy static identity order.
 	}
 	return STATIC_BUDGETS.map(({ file, budget }) => ({ path: file, budget }));
+}
+
+export function resolveSpecialIdentityFiles(agentsDir: string, kind: IdentitySessionKind): IdentitySpecialFileEntry[] {
+	const agentYaml = join(agentsDir, "agent.yaml");
+	if (!existsSync(agentYaml)) {
+		return IDENTITY_PRESETS.minimal.special.filter((entry) => entry.kind === kind);
+	}
+	try {
+		const config = parseSimpleYaml(readFileSync(agentYaml, "utf-8"));
+		const identity = readRecord(config.identity);
+		const configured = readSpecialIdentityEntryList(identity.special).filter((entry) => entry.kind === kind);
+		if (configured.length > 0) return configured;
+		const presetName = typeof identity.preset === "string" ? identity.preset : "";
+		const preset = IDENTITY_PRESETS[presetName as IdentityPresetName];
+		if (preset) return preset.special.filter((entry) => entry.kind === kind);
+	} catch {
+		// Fall back to the minimal special-session prompt set.
+	}
+	return IDENTITY_PRESETS.minimal.special.filter((entry) => entry.kind === kind);
 }
 
 export const STATIC_IDENTITY_OFFLINE_STATUS = "[signet: daemon offline — running with static identity]";

--- a/platform/core/src/identity.ts
+++ b/platform/core/src/identity.ts
@@ -12,6 +12,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { listOhMyPiAgentDirCandidates, resolveOhMyPiAgentDir } from "./oh-my-pi";
 import { listPiAgentDirCandidates, resolvePiAgentDir } from "./pi";
+import { parseSimpleYaml } from "./yaml";
 
 const FORGE_BINARY_NAME = "forge";
 const SIGNET_FORGE_PRIMARY_MARKER = "Signet's native AI terminal";
@@ -60,6 +61,12 @@ export function resolveAgentBasePath(agentName: string, workspaceDir: string): s
 /**
  * Specification for an identity file
  */
+export type IdentityPresetName = "minimal" | "hermes" | "openclaw" | "custom";
+
+export type IdentityFileContext = "startup" | "session";
+
+export type IdentitySessionKind = "dreaming" | "heartbeat" | "bootstrap";
+
 export interface IdentityFileSpec {
 	/** Relative path from the base directory */
 	path: string;
@@ -67,6 +74,28 @@ export interface IdentityFileSpec {
 	description: string;
 	/** Whether this file is optional */
 	optional?: boolean;
+	/** Whether this file is loaded during normal startup or only in a special session */
+	context?: IdentityFileContext;
+	/** Special session kind when context is "session" */
+	session?: IdentitySessionKind;
+}
+
+export interface IdentityContextFileEntry {
+	path: string;
+	role?: string;
+	budget?: number;
+	enabled?: boolean;
+}
+
+export interface IdentitySpecialFileEntry extends IdentityContextFileEntry {
+	kind: IdentitySessionKind;
+}
+
+export interface IdentityPresetSpec {
+	name: IdentityPresetName;
+	description: string;
+	startup: IdentityContextFileEntry[];
+	special: IdentitySpecialFileEntry[];
 }
 
 /**
@@ -124,8 +153,10 @@ export const IDENTITY_FILES: Record<string, IdentityFileSpec> = {
 	},
 	heartbeat: {
 		path: "HEARTBEAT.md",
-		description: "Current working state, focus, and blockers",
+		description: "Heartbeat prompt used only for heartbeat/background check sessions",
 		optional: true,
+		context: "session",
+		session: "heartbeat",
 	},
 	memory: {
 		path: "MEMORY.md",
@@ -141,6 +172,55 @@ export const IDENTITY_FILES: Record<string, IdentityFileSpec> = {
 		path: "BOOTSTRAP.md",
 		description: "Setup ritual (typically deleted after first run)",
 		optional: true,
+		context: "session",
+		session: "bootstrap",
+	},
+	dreaming: {
+		path: "DREAMING.md",
+		description: "Dreaming/reflection prompt used only for dreaming sessions",
+		optional: true,
+		context: "session",
+		session: "dreaming",
+	},
+};
+
+export const IDENTITY_PRESETS: Record<IdentityPresetName, IdentityPresetSpec> = {
+	minimal: {
+		name: "minimal",
+		description: "AGENTS.md only for normal startup, plus DREAMING.md for dreaming sessions.",
+		startup: [{ path: "AGENTS.md", role: "operating_instructions", budget: 12_000 }],
+		special: [{ path: "DREAMING.md", kind: "dreaming", role: "dreaming_prompt", budget: 4_000 }],
+	},
+	hermes: {
+		name: "hermes",
+		description: "Hermes-style SOUL.md primary identity with project-context discovery handled by Hermes.",
+		startup: [
+			{ path: "SOUL.md", role: "primary_identity", budget: 4_000 },
+			{ path: "AGENTS.md", role: "project_context", budget: 12_000 },
+		],
+		special: [{ path: "DREAMING.md", kind: "dreaming", role: "dreaming_prompt", budget: 4_000 }],
+	},
+	openclaw: {
+		name: "openclaw",
+		description: "OpenClaw-style rich identity stack for character-forward agents.",
+		startup: [
+			{ path: "AGENTS.md", role: "operating_instructions", budget: 12_000 },
+			{ path: "SOUL.md", role: "persona", budget: 4_000 },
+			{ path: "IDENTITY.md", role: "agent_identity", budget: 2_000 },
+			{ path: "USER.md", role: "user_profile", budget: 6_000 },
+			{ path: "MEMORY.md", role: "working_memory", budget: 10_000 },
+		],
+		special: [
+			{ path: "HEARTBEAT.md", kind: "heartbeat", role: "heartbeat_prompt", budget: 4_000 },
+			{ path: "DREAMING.md", kind: "dreaming", role: "dreaming_prompt", budget: 4_000 },
+			{ path: "BOOTSTRAP.md", kind: "bootstrap", role: "bootstrap_prompt", budget: 4_000 },
+		],
+	},
+	custom: {
+		name: "custom",
+		description: "User-selected startup files and explicit order.",
+		startup: [{ path: "AGENTS.md", role: "operating_instructions", budget: 12_000 }],
+		special: [{ path: "DREAMING.md", kind: "dreaming", role: "dreaming_prompt", budget: 4_000 }],
 	},
 };
 
@@ -608,6 +688,68 @@ const STATIC_BUDGETS: ReadonlyArray<{ file: string; header: string; budget: numb
 	{ file: "MEMORY.md", header: "Working Memory", budget: 10_000 },
 ];
 
+const STATIC_HEADER_BY_FILE: Record<string, string> = {
+	"AGENTS.md": "Agent Instructions",
+	"SOUL.md": "Soul",
+	"IDENTITY.md": "Identity",
+	"USER.md": "About Your User",
+	"MEMORY.md": "Working Memory",
+};
+
+function isSafeRelativeIdentityPath(path: string): boolean {
+	const trimmed = path.trim();
+	if (!trimmed) return false;
+	if (trimmed.startsWith("/") || trimmed.startsWith("~")) return false;
+	return !trimmed.split(/[\\/]/).includes("..");
+}
+
+function readRecord(value: unknown): Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function readIdentityEntry(value: unknown): IdentityContextFileEntry | null {
+	if (typeof value === "string") {
+		return isSafeRelativeIdentityPath(value) ? { path: value } : null;
+	}
+	const record = readRecord(value);
+	const path = typeof record.path === "string" ? record.path.trim() : "";
+	if (!isSafeRelativeIdentityPath(path)) return null;
+	if (record.enabled === false) return null;
+	const role = typeof record.role === "string" ? record.role : undefined;
+	const rawBudget =
+		typeof record.budget === "number" ? record.budget : Number.parseInt(String(record.budget ?? ""), 10);
+	const budget = Number.isFinite(rawBudget) && rawBudget > 0 ? Math.floor(rawBudget) : undefined;
+	return { path, role, budget };
+}
+
+function readIdentityEntryList(value: unknown): IdentityContextFileEntry[] {
+	if (!Array.isArray(value)) return [];
+	return value.map(readIdentityEntry).filter((entry): entry is IdentityContextFileEntry => entry !== null);
+}
+
+function identityHeaderFor(path: string, role?: string): string {
+	const filename = path.split(/[\\/]/).pop() ?? path;
+	return STATIC_HEADER_BY_FILE[filename] ?? role ?? filename.replace(/\.md$/i, "");
+}
+
+export function resolveStartupIdentityFiles(agentsDir: string): IdentityContextFileEntry[] {
+	const agentYaml = join(agentsDir, "agent.yaml");
+	if (!existsSync(agentYaml)) return STATIC_BUDGETS.map(({ file, budget }) => ({ path: file, budget }));
+	try {
+		const config = parseSimpleYaml(readFileSync(agentYaml, "utf-8"));
+		const identity = readRecord(config.identity);
+		const startup = readRecord(identity.startup);
+		const configured = readIdentityEntryList(startup.load);
+		if (configured.length > 0) return configured;
+		const presetName = typeof identity.preset === "string" ? identity.preset : "";
+		const preset = IDENTITY_PRESETS[presetName as IdentityPresetName];
+		if (preset) return preset.startup;
+	} catch {
+		// Fall back to legacy static identity order.
+	}
+	return STATIC_BUDGETS.map(({ file, budget }) => ({ path: file, budget }));
+}
+
 export const STATIC_IDENTITY_OFFLINE_STATUS = "[signet: daemon offline — running with static identity]";
 export const STATIC_IDENTITY_SESSION_START_TIMEOUT_STATUS =
 	"[signet: daemon session-start timed out — running with static identity]";
@@ -639,14 +781,15 @@ export function readStaticIdentity(agentsDir: string, status = STATIC_IDENTITY_O
 
 	const parts: string[] = [];
 
-	for (const { file, header, budget } of STATIC_BUDGETS) {
-		const path = join(agentsDir, file);
+	for (const entry of resolveStartupIdentityFiles(agentsDir)) {
+		const path = join(agentsDir, entry.path);
 		if (!existsSync(path)) continue;
 		try {
 			const raw = readFileSync(path, "utf-8").trim();
 			if (!raw) continue;
+			const budget = entry.budget ?? STATIC_BUDGETS.find((candidate) => candidate.file === entry.path)?.budget ?? 4_000;
 			const content = raw.length <= budget ? raw : `${raw.slice(0, budget)}\n[truncated]`;
-			parts.push(`## ${header}\n\n${content}`);
+			parts.push(`## ${identityHeaderFor(entry.path, entry.role)}\n\n${content}`);
 		} catch {
 			// skip unreadable files
 		}

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -250,6 +250,7 @@ export type { MigrationDb, Migration } from "./migrations/index";
 // Identity file management
 export {
 	IDENTITY_FILES,
+	IDENTITY_PRESETS,
 	REQUIRED_IDENTITY_KEYS,
 	OPTIONAL_IDENTITY_KEYS,
 	detectExistingSetup,
@@ -262,6 +263,7 @@ export {
 	getMissingIdentityFiles,
 	summarizeIdentity,
 	readStaticIdentity,
+	resolveStartupIdentityFiles,
 	resolveSessionStartTimeoutMs,
 	resolvePromptSubmitTimeoutMs,
 	STATIC_IDENTITY_OFFLINE_STATUS,
@@ -275,6 +277,12 @@ export {
 } from "./identity";
 export type {
 	IdentityFileSpec,
+	IdentityPresetName,
+	IdentityFileContext,
+	IdentitySessionKind,
+	IdentityContextFileEntry,
+	IdentitySpecialFileEntry,
+	IdentityPresetSpec,
 	IdentityFile,
 	IdentityMap,
 	SetupDetection,

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -263,6 +263,7 @@ export {
 	getMissingIdentityFiles,
 	summarizeIdentity,
 	readStaticIdentity,
+	resolveSpecialIdentityFiles,
 	resolveStartupIdentityFiles,
 	resolveSessionStartTimeoutMs,
 	resolvePromptSubmitTimeoutMs,

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -7,6 +7,9 @@
 
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { DreamingConfig } from "@signet/core";
 import { runMigrations } from "../../../core/src/migrations";
 import type { DbAccessor } from "../db-accessor";
@@ -106,6 +109,14 @@ describe("dreaming", () => {
 		db.close();
 	});
 
+	function withTempIdentity(files: Record<string, string>): string {
+		const dir = mkdtempSync(join(tmpdir(), "dreaming-identity-"));
+		for (const [name, content] of Object.entries(files)) {
+			writeFileSync(join(dir, name), content);
+		}
+		return dir;
+	}
+
 	describe("state management", () => {
 		it("returns zero state for new agent", () => {
 			const state = getDreamingState(accessor, AGENT);
@@ -204,6 +215,30 @@ describe("dreaming", () => {
 			expect(passes.length).toBe(1);
 			expect(passes[0]?.mode).toBe("compact");
 			expect(passes[0]?.status).toBe("completed");
+		});
+
+		it("loads configured startup identity and DREAMING.md special prompt", async () => {
+			seedEntity(db, "ent-1", "Signet", "project");
+			const dir = withTempIdentity({
+				"agent.yaml":
+					"identity:\n  preset: minimal\n  startup:\n    load:\n      - path: AGENTS.md\n        role: startup_rules\n        budget: 12000\n  special:\n    - path: DREAMING.md\n      kind: dreaming\n      role: dreaming_prompt\n      budget: 4000\n",
+				"AGENTS.md": "Startup rules are loaded normally.",
+				"SOUL.md": "Soul should not be loaded by the minimal startup preset.",
+				"DREAMING.md": "Dreaming-specific reflection instructions.",
+			});
+			try {
+				const generate = async (prompt: string) => {
+					expect(prompt).toContain("Startup rules are loaded normally.");
+					expect(prompt).toContain("Dreaming-specific reflection instructions.");
+					expect(prompt).toContain("<dreaming_prompt>");
+					expect(prompt).not.toContain("Soul should not be loaded");
+					return JSON.stringify({ mutations: [], summary: "Prompt inspected" });
+				};
+
+				await runDreamingPass(accessor, generate, defaultCfg(), dir, AGENT, "compact");
+			} finally {
+				rmSync(dir, { recursive: true, force: true });
+			}
 		});
 
 		it("applies create_entity mutations", async () => {

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -241,6 +241,28 @@ describe("dreaming", () => {
 			}
 		});
 
+		it("keeps startup MEMORY.md in the working_memory block without duplicating identity", async () => {
+			seedEntity(db, "ent-1", "Signet", "project");
+			const dir = withTempIdentity({
+				"agent.yaml":
+					"identity:\n  preset: openclaw\n  startup:\n    load:\n      - path: AGENTS.md\n        role: startup_rules\n      - path: MEMORY.md\n        role: working_memory\n  special:\n    - path: DREAMING.md\n      kind: dreaming\n      role: dreaming_prompt\n",
+				"AGENTS.md": "Startup rules are loaded normally.",
+				"MEMORY.md": "Memory appears exactly once.",
+				"DREAMING.md": "Dreaming-specific reflection instructions.",
+			});
+			try {
+				const generate = async (prompt: string) => {
+					expect(prompt.match(/Memory appears exactly once\./g)?.length).toBe(1);
+					expect(prompt).toContain("<working_memory>\nMemory appears exactly once.\n</working_memory>");
+					return JSON.stringify({ mutations: [], summary: "Prompt inspected" });
+				};
+
+				await runDreamingPass(accessor, generate, defaultCfg(), dir, AGENT, "compact");
+			} finally {
+				rmSync(dir, { recursive: true, force: true });
+			}
+		});
+
 		it("applies create_entity mutations", async () => {
 			seedSummary(db, "s-1", "User started working on a Rust project called Nexus", 500);
 

--- a/platform/daemon/src/pipeline/dreaming.test.ts
+++ b/platform/daemon/src/pipeline/dreaming.test.ts
@@ -223,6 +223,7 @@ describe("dreaming", () => {
 				"agent.yaml":
 					"identity:\n  preset: minimal\n  startup:\n    load:\n      - path: AGENTS.md\n        role: startup_rules\n        budget: 12000\n  special:\n    - path: DREAMING.md\n      kind: dreaming\n      role: dreaming_prompt\n      budget: 4000\n",
 				"AGENTS.md": "Startup rules are loaded normally.",
+				"MEMORY.md": "Minimal preset memory should not be injected implicitly.",
 				"SOUL.md": "Soul should not be loaded by the minimal startup preset.",
 				"DREAMING.md": "Dreaming-specific reflection instructions.",
 			});
@@ -232,6 +233,7 @@ describe("dreaming", () => {
 					expect(prompt).toContain("Dreaming-specific reflection instructions.");
 					expect(prompt).toContain("<dreaming_prompt>");
 					expect(prompt).not.toContain("Soul should not be loaded");
+					expect(prompt).not.toContain("Minimal preset memory should not be injected implicitly.");
 					return JSON.stringify({ mutations: [], summary: "Prompt inspected" });
 				};
 

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -11,7 +11,12 @@
 import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import type { DreamingConfig } from "@signet/core";
+import {
+	type DreamingConfig,
+	type IdentityContextFileEntry,
+	resolveSpecialIdentityFiles,
+	resolveStartupIdentityFiles,
+} from "@signet/core";
 import type { DbAccessor, ReadDb, WriteDb } from "../db-accessor";
 import { logger } from "../logger";
 import { countTokens } from "./tokenizer";
@@ -404,13 +409,26 @@ function warnIfTruncated(
 // Prompt construction
 // ---------------------------------------------------------------------------
 
-function readIdentityFile(dir: string, name: string): string {
+function readIdentityFile(dir: string, entry: IdentityContextFileEntry): string {
 	try {
-		return readFileSync(join(dir, name), "utf-8").trim();
+		const raw = readFileSync(join(dir, entry.path), "utf-8").trim();
+		if (!raw) return "";
+		const budget = entry.budget ?? 4_000;
+		return raw.length <= budget ? raw : `${raw.slice(0, budget)}\n[truncated]`;
 	} catch (err) {
-		logger.warn("dreaming", "Could not read identity file", { name, error: String(err) });
+		logger.warn("dreaming", "Could not read identity file", { name: entry.path, error: String(err) });
 		return "";
 	}
+}
+
+function renderIdentityBlock(dir: string, entries: readonly IdentityContextFileEntry[]): string {
+	return entries
+		.map((entry) => {
+			const content = readIdentityFile(dir, entry);
+			return content ? `## ${entry.role ?? entry.path}\n\n${content}` : "";
+		})
+		.filter((s) => s.length > 0)
+		.join("\n\n---\n\n");
 }
 
 function buildDreamingPrompt(
@@ -420,16 +438,9 @@ function buildDreamingPrompt(
 	agentsDir: string,
 	maxTokens: number,
 ): string {
-	const identity = [
-		readIdentityFile(agentsDir, "AGENTS.md"),
-		readIdentityFile(agentsDir, "SOUL.md"),
-		readIdentityFile(agentsDir, "IDENTITY.md"),
-		readIdentityFile(agentsDir, "USER.md"),
-	]
-		.filter((s) => s.length > 0)
-		.join("\n\n---\n\n");
-
-	const memoryMd = readIdentityFile(agentsDir, "MEMORY.md");
+	const identity = renderIdentityBlock(agentsDir, resolveStartupIdentityFiles(agentsDir));
+	const dreamingPrompt = renderIdentityBlock(agentsDir, resolveSpecialIdentityFiles(agentsDir, "dreaming"));
+	const memoryMd = readIdentityFile(agentsDir, { path: "MEMORY.md", role: "working_memory", budget: 10_000 });
 
 	// Build graph snapshot
 	const entityMap = new Map(graph.entities.map((e) => [e.id, e]));
@@ -513,7 +524,7 @@ ${identity}
 ${memoryMd}
 </working_memory>
 
-<task>
+${dreamingPrompt ? `<dreaming_prompt>\n${dreamingPrompt}\n</dreaming_prompt>\n\n` : ""}<task>
 You are taking time to reflect on ${mode === "compact" ? "your knowledge graph" : "your recent sessions"} and consolidate your memory.
 
 ${modeInstructions}

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -445,10 +445,7 @@ function buildDreamingPrompt(
 		startupEntries.filter((entry) => entry !== startupMemoryEntry),
 	);
 	const dreamingPrompt = renderIdentityBlock(agentsDir, resolveSpecialIdentityFiles(agentsDir, "dreaming"));
-	const memoryMd = readIdentityFile(
-		agentsDir,
-		startupMemoryEntry ?? { path: "MEMORY.md", role: "working_memory", budget: 10_000 },
-	);
+	const memoryMd = startupMemoryEntry ? readIdentityFile(agentsDir, startupMemoryEntry) : "";
 
 	// Build graph snapshot
 	const entityMap = new Map(graph.entities.map((e) => [e.id, e]));

--- a/platform/daemon/src/pipeline/dreaming.ts
+++ b/platform/daemon/src/pipeline/dreaming.ts
@@ -438,9 +438,17 @@ function buildDreamingPrompt(
 	agentsDir: string,
 	maxTokens: number,
 ): string {
-	const identity = renderIdentityBlock(agentsDir, resolveStartupIdentityFiles(agentsDir));
+	const startupEntries = resolveStartupIdentityFiles(agentsDir);
+	const startupMemoryEntry = startupEntries.find((entry) => entry.path.split(/[\\/]/).pop() === "MEMORY.md");
+	const identity = renderIdentityBlock(
+		agentsDir,
+		startupEntries.filter((entry) => entry !== startupMemoryEntry),
+	);
 	const dreamingPrompt = renderIdentityBlock(agentsDir, resolveSpecialIdentityFiles(agentsDir, "dreaming"));
-	const memoryMd = readIdentityFile(agentsDir, { path: "MEMORY.md", role: "working_memory", budget: 10_000 });
+	const memoryMd = readIdentityFile(
+		agentsDir,
+		startupMemoryEntry ?? { path: "MEMORY.md", role: "working_memory", budget: 10_000 },
+	);
 
 	// Build graph snapshot
 	const entityMap = new Map(graph.entities.map((e) => [e.id, e]));

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -9,15 +9,20 @@ builtin: true
 # /onboarding
 
 Walk the user through an interactive interview to personalize their
-Signet workspace. This populates the identity files (AGENTS.md,
-SOUL.md, IDENTITY.md, USER.md) with their preferences, personality
-settings, and profile information.
+Signet workspace. Start by choosing the identity/context preset
+(OpenClaw, Hermes, Minimal, or Custom) so onboarding matches the user's
+token budget and identity-file conventions instead of assuming one fixed
+stack. Minimal loads only AGENTS.md during startup and still creates
+DREAMING.md as a special dreaming-session prompt file.
 
 ## What This Skill Does
 
 This skill writes configuration files to `~/.agents/`. Specifically:
 
-- Reads and writes: IDENTITY.md, SOUL.md, USER.md, AGENTS.md
+- Reads and writes whichever startup identity files the selected preset uses
+  (for example AGENTS.md only in Minimal, or the richer OpenClaw stack)
+- Writes special session prompt files such as DREAMING.md without loading
+  them into ordinary startup context
 - Runs `signet setup` if Signet isn't initialized yet
 - Does NOT access external APIs or services
 - Does NOT send data anywhere outside the local machine
@@ -43,7 +48,8 @@ signet setup --non-interactive \
   --name "My Agent" \
   --description "Personal AI assistant" \
   --harness claude-code \
-  --embedding-provider <ollama|openai|none> \
+  --identity-preset minimal \
+  --embedding-provider <ollama|openai|native|none> \
   --extraction-provider <claude-code|codex|opencode|ollama|none>
 ```
 
@@ -72,24 +78,41 @@ This is getting to know someone, not filling out a form.
 
 ## Starting the Interview
 
-Before asking any questions, present the full outline so the user
-knows what to expect:
+Before asking detailed identity questions, present the full outline and
+start with the identity preset/context-budget choice:
 
 ```
 here's what we'll walk through together:
 
-1. agent identity — who am i? (name, creature type, vibe)
-2. personality & tone — how should i communicate?
-3. your profile — who are you?
-4. behavior settings — how should i operate?
-5. review — make sure everything looks right
-6. workspace audit — health check on the setup
+1. identity preset — OpenClaw, Hermes, Minimal, or Custom
+2. identity files — choose startup-loaded files and order, if using Custom
+3. special session files — DREAMING.md for dreaming sessions, HEARTBEAT.md for heartbeat sessions, etc.
+4. agent identity — who am i? (name, creature type, vibe), if the preset uses that layer
+5. personality & tone — how should i communicate?, if the preset uses that layer
+6. your profile — who are you?, if the preset uses that layer
+7. behavior settings — how should i operate?
+8. review — make sure everything looks right
+9. workspace audit — health check on the setup
 
 this takes about 5-10 minutes. nothing is permanent — you can change
 any of this later by running /onboarding again or editing the files
 directly in ~/.agents/.
 
-ready? let's start with who i am.
+first, pick your identity/context preset:
+
+- OpenClaw — rich workspace identity using OpenClaw-style templates such as
+  AGENTS.md, SOUL.md, IDENTITY.md, USER.md, MEMORY.md, HEARTBEAT.md,
+  BOOT/BOOTSTRAP.md, and DREAMING.md.
+- Hermes — Hermes-style primary identity centered on SOUL.md plus Hermes'
+  project-context discovery behavior (.hermes.md/HERMES.md, AGENTS.md,
+  CLAUDE.md, .cursorrules). Do not invent OpenClaw's SOUL/IDENTITY/USER
+  stack semantics for Hermes.
+- Minimal — AGENTS.md only for startup context, lowest token use. Still
+  include DREAMING.md as a special dreaming-session prompt file; it is not
+  loaded into normal startup context.
+- Custom — choose any startup files and explicit load order.
+
+ready? let's choose the preset first.
 ```
 
 ---

--- a/surfaces/cli/src/commands/app.ts
+++ b/surfaces/cli/src/commands/app.ts
@@ -96,6 +96,10 @@ export function registerAppCommands(program: Command, deps: AppDeps): void {
 		)
 		.option("--with-graphiq", "Install and enable the optional GraphIQ code retrieval plugin")
 		.option("--disable-graphiq", "Leave the optional GraphIQ plugin disabled during setup")
+		.option(
+			"--identity-preset <preset>",
+			"Identity preset for startup/special prompt files (minimal, hermes, openclaw, custom)",
+		)
 		.action(deps.setupWizard);
 
 	const dashboard = program

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -121,6 +121,13 @@ export async function runFreshSetup(cfg: FreshSetupConfig, deps: SetupDeps): Pro
 				top_k: cfg.searchTopK,
 				min_score: cfg.searchMinScore,
 			},
+			identity: {
+				preset: cfg.identityPreset,
+				startup: {
+					load: cfg.startupIdentityFiles,
+				},
+				special: cfg.specialIdentityFiles,
+			},
 		};
 
 		if (cfg.embeddingProvider !== "none") {
@@ -157,12 +164,12 @@ export async function runFreshSetup(cfg: FreshSetupConfig, deps: SetupDeps): Pro
 			disableGraphiqState(cfg.basePath);
 		}
 
-		const docFiles = [
-			{ name: "MEMORY.md", template: "MEMORY.md.template" },
-			{ name: "SOUL.md", template: "SOUL.md.template" },
-			{ name: "IDENTITY.md", template: "IDENTITY.md.template" },
-			{ name: "USER.md", template: "USER.md.template" },
-		];
+		const docFiles = Array.from(
+			new Set([
+				...cfg.startupIdentityFiles.map((entry) => entry.path),
+				...cfg.specialIdentityFiles.map((entry) => entry.path),
+			]),
+		).map((name) => ({ name, template: `${name}.template` }));
 
 		for (const doc of docFiles) {
 			const templatePath = join(templatesDir, doc.template);
@@ -266,11 +273,17 @@ export async function runFreshSetup(cfg: FreshSetupConfig, deps: SetupDeps): Pro
 		console.log(chalk.dim("  Files created:"));
 		console.log(chalk.dim(`    ${cfg.basePath}/`));
 		console.log(chalk.dim("    ├── agent.yaml    manifest & config"));
-		console.log(chalk.dim("    ├── AGENTS.md     agent instructions"));
-		console.log(chalk.dim("    ├── SOUL.md       personality & tone"));
-		console.log(chalk.dim("    ├── IDENTITY.md   agent identity"));
-		console.log(chalk.dim("    ├── USER.md       your profile"));
-		console.log(chalk.dim("    ├── MEMORY.md     working memory"));
+		const reportedDocs = Array.from(
+			new Set([
+				"AGENTS.md",
+				...cfg.startupIdentityFiles.map((entry) => entry.path),
+				...cfg.specialIdentityFiles.map((entry) => entry.path),
+			]),
+		).filter((name) => existsSync(join(cfg.basePath, name)));
+		for (const name of reportedDocs) {
+			const special = cfg.specialIdentityFiles.some((entry) => entry.path === name) ? " (special session)" : "";
+			console.log(chalk.dim(`    ├── ${name.padEnd(12)}${special}`));
+		}
 		console.log(chalk.dim("    ├── signetai/     Signet source checkout"));
 		console.log(chalk.dim("    └── memory/       database & vectors"));
 

--- a/surfaces/cli/src/features/setup-migrate.ts
+++ b/surfaces/cli/src/features/setup-migrate.ts
@@ -278,7 +278,9 @@ export async function runExistingSetupWizard(
 			{ name: "SOUL.md", template: "SOUL.md.template" },
 			{ name: "IDENTITY.md", template: "IDENTITY.md.template" },
 			{ name: "USER.md", template: "USER.md.template" },
+			{ name: "HEARTBEAT.md", template: "HEARTBEAT.md.template" },
 			{ name: "DREAMING.md", template: "DREAMING.md.template" },
+			{ name: "BOOTSTRAP.md", template: "BOOTSTRAP.md.template" },
 		];
 
 		for (const doc of docs) {

--- a/surfaces/cli/src/features/setup-migrate.ts
+++ b/surfaces/cli/src/features/setup-migrate.ts
@@ -200,13 +200,21 @@ export async function runExistingSetupWizard(
 				min_score: 0.3,
 			},
 			identity: {
-				agents: "AGENTS.md",
-				soul: "SOUL.md",
-				identity: "IDENTITY.md",
-				user: "USER.md",
-				heartbeat: "HEARTBEAT.md",
-				memory: "MEMORY.md",
-				tools: "TOOLS.md",
+				preset: "openclaw",
+				startup: {
+					load: [
+						{ path: "AGENTS.md", role: "operating_instructions", budget: 12000 },
+						{ path: "SOUL.md", role: "persona", budget: 4000 },
+						{ path: "IDENTITY.md", role: "agent_identity", budget: 2000 },
+						{ path: "USER.md", role: "user_profile", budget: 6000 },
+						{ path: "MEMORY.md", role: "working_memory", budget: 10000 },
+					],
+				},
+				special: [
+					{ path: "HEARTBEAT.md", kind: "heartbeat", role: "heartbeat_prompt", budget: 4000 },
+					{ path: "DREAMING.md", kind: "dreaming", role: "dreaming_prompt", budget: 4000 },
+					{ path: "BOOTSTRAP.md", kind: "bootstrap", role: "bootstrap_prompt", budget: 4000 },
+				],
 			},
 		};
 
@@ -270,6 +278,7 @@ export async function runExistingSetupWizard(
 			{ name: "SOUL.md", template: "SOUL.md.template" },
 			{ name: "IDENTITY.md", template: "IDENTITY.md.template" },
 			{ name: "USER.md", template: "USER.md.template" },
+			{ name: "DREAMING.md", template: "DREAMING.md.template" },
 		];
 
 		for (const doc of docs) {

--- a/surfaces/cli/src/features/setup-types.ts
+++ b/surfaces/cli/src/features/setup-types.ts
@@ -1,4 +1,10 @@
-import type { SetupDetection, WorkspaceSourceRepoSyncResult } from "@signet/core";
+import type {
+	IdentityContextFileEntry,
+	IdentityPresetName,
+	IdentitySpecialFileEntry,
+	SetupDetection,
+	WorkspaceSourceRepoSyncResult,
+} from "@signet/core";
 import type { EmbeddingProviderChoice, ExtractionProviderChoice, OpenClawRuntimeChoice } from "./setup-shared.js";
 
 export interface SetupWizardOptions {
@@ -23,6 +29,7 @@ export interface SetupWizardOptions {
 	disableSignetSecrets?: boolean;
 	withGraphiq?: boolean;
 	disableGraphiq?: boolean;
+	identityPreset?: string;
 }
 
 export interface SetupDeps {
@@ -93,4 +100,7 @@ export interface FreshSetupConfig {
 	readonly createLocalBackup: boolean;
 	readonly signetSecretsEnabled: boolean;
 	readonly graphiqEnabled: boolean;
+	readonly identityPreset: IdentityPresetName;
+	readonly startupIdentityFiles: readonly IdentityContextFileEntry[];
+	readonly specialIdentityFiles: readonly IdentitySpecialFileEntry[];
 }

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -86,7 +86,16 @@ function stubDeps(overrides: Partial<SetupDeps> = {}): SetupDeps {
 
 function writeIdentityTemplates(dir: string): void {
 	mkdirSync(dir, { recursive: true });
-	for (const name of ["AGENTS.md", "SOUL.md", "IDENTITY.md", "USER.md", "MEMORY.md", "DREAMING.md"]) {
+	for (const name of [
+		"AGENTS.md",
+		"SOUL.md",
+		"IDENTITY.md",
+		"USER.md",
+		"MEMORY.md",
+		"DREAMING.md",
+		"HEARTBEAT.md",
+		"BOOTSTRAP.md",
+	]) {
 		writeFileSync(join(dir, `${name}.template`), `${name} for {{AGENT_NAME}}`);
 	}
 }
@@ -342,6 +351,42 @@ describe("setupWizard non-interactive harness hooks", () => {
 		expect(existsSync(join(basePath, "AGENTS.md"))).toBe(true);
 		expect(existsSync(join(basePath, "DREAMING.md"))).toBe(true);
 		expect(existsSync(join(basePath, "SOUL.md"))).toBe(false);
+	});
+
+	it("writes every openclaw special-session file referenced by the identity preset", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-ni-openclaw-identity-"));
+		const basePath = join(root, "agents");
+		const templatesPath = join(root, "templates");
+		writeIdentityTemplates(templatesPath);
+
+		const freshDetection: SetupDetection = {
+			...fakeDetection(basePath),
+			agentsDir: false,
+			memoryDb: false,
+		};
+		const deps = stubDeps({
+			AGENTS_DIR: basePath,
+			getTemplatesDir: mock(() => templatesPath),
+			normalizeAgentPath: mock((p: string) => p),
+			detectExistingSetup: mock(() => freshDetection),
+		});
+
+		await setupWizard({ nonInteractive: true, identityPreset: "openclaw", skipGit: true }, deps);
+
+		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
+		for (const name of [
+			"AGENTS.md",
+			"SOUL.md",
+			"IDENTITY.md",
+			"USER.md",
+			"MEMORY.md",
+			"HEARTBEAT.md",
+			"DREAMING.md",
+			"BOOTSTRAP.md",
+		]) {
+			expect(agentYaml).toContain(`path: ${name}`);
+			expect(existsSync(join(basePath, name))).toBe(true);
+		}
 	});
 
 	it("fails fast on unknown non-interactive identity presets", async () => {

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -82,6 +82,13 @@ function stubDeps(overrides: Partial<SetupDeps> = {}): SetupDeps {
 		})),
 		...overrides,
 	};
+}
+
+function writeIdentityTemplates(dir: string): void {
+	mkdirSync(dir, { recursive: true });
+	for (const name of ["AGENTS.md", "SOUL.md", "IDENTITY.md", "USER.md", "MEMORY.md", "DREAMING.md"]) {
+		writeFileSync(join(dir, `${name}.template`), `${name} for {{AGENT_NAME}}`);
+	}
 }
 
 describe("setupWizard non-interactive harness hooks", () => {
@@ -307,7 +314,37 @@ describe("setupWizard non-interactive harness hooks", () => {
 		expect(detectedHarnessesForExistingSetup(detection, [])).toContain("hermes-agent");
 	});
 
-	it("fails fast on unknown non-interactive harness values in the existing-install path", async () => {
+	it("writes minimal identity preset with DREAMING.md as special-session file", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-ni-minimal-identity-"));
+		const basePath = join(root, "agents");
+		const templatesPath = join(root, "templates");
+		writeIdentityTemplates(templatesPath);
+
+		const freshDetection: SetupDetection = {
+			...fakeDetection(basePath),
+			agentsDir: false,
+			memoryDb: false,
+		};
+		const deps = stubDeps({
+			AGENTS_DIR: basePath,
+			getTemplatesDir: mock(() => templatesPath),
+			normalizeAgentPath: mock((p: string) => p),
+			detectExistingSetup: mock(() => freshDetection),
+		});
+
+		await setupWizard({ nonInteractive: true, identityPreset: "minimal", skipGit: true }, deps);
+
+		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
+		expect(agentYaml).toContain("preset: minimal");
+		expect(agentYaml).toContain("path: AGENTS.md");
+		expect(agentYaml).toContain("path: DREAMING.md");
+		expect(agentYaml).toContain("kind: dreaming");
+		expect(existsSync(join(basePath, "AGENTS.md"))).toBe(true);
+		expect(existsSync(join(basePath, "DREAMING.md"))).toBe(true);
+		expect(existsSync(join(basePath, "SOUL.md"))).toBe(false);
+	});
+
+	it("fails fast on unknown non-interactive identity presets", async () => {
 		root = mkdtempSync(join(tmpdir(), "setup-ni-invalid-harness-"));
 		const basePath = join(root, "agents");
 		mkdirSync(basePath, { recursive: true });
@@ -324,9 +361,11 @@ describe("setupWizard non-interactive harness hooks", () => {
 				detectExistingSetup: mock(() => fakeDetection(basePath)),
 			});
 
-			await expect(setupWizard({ nonInteractive: true, harness: ["pi,nope"] }, deps)).rejects.toThrow("process.exit:1");
+			await expect(setupWizard({ nonInteractive: true, identityPreset: "maximalist" }, deps)).rejects.toThrow(
+				"process.exit:1",
+			);
 			expect(errorSpy).toHaveBeenCalled();
-			expect(String(errorSpy.mock.calls[0]?.[0] ?? "")).toContain("Unknown --harness value(s): nope");
+			expect(String(errorSpy.mock.calls[0]?.[0] ?? "")).toContain("Unknown --identity-preset value: maximalist");
 		} finally {
 			exitSpy.mockRestore();
 			errorSpy.mockRestore();

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -353,6 +353,35 @@ describe("setupWizard non-interactive harness hooks", () => {
 		expect(existsSync(join(basePath, "SOUL.md"))).toBe(false);
 	});
 
+	it("writes custom identity preset with concrete files for every referenced path", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-ni-custom-identity-"));
+		const basePath = join(root, "agents");
+		const templatesPath = join(root, "templates");
+		writeIdentityTemplates(templatesPath);
+
+		const freshDetection: SetupDetection = {
+			...fakeDetection(basePath),
+			agentsDir: false,
+			memoryDb: false,
+		};
+		const deps = stubDeps({
+			AGENTS_DIR: basePath,
+			getTemplatesDir: mock(() => templatesPath),
+			normalizeAgentPath: mock((p: string) => p),
+			detectExistingSetup: mock(() => freshDetection),
+		});
+
+		await setupWizard({ nonInteractive: true, identityPreset: "custom", skipGit: true }, deps);
+
+		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
+		expect(agentYaml).toContain("preset: custom");
+		for (const name of ["AGENTS.md", "DREAMING.md"]) {
+			expect(agentYaml).toContain(`path: ${name}`);
+			expect(existsSync(join(basePath, name))).toBe(true);
+		}
+		expect(existsSync(join(basePath, "SOUL.md"))).toBe(false);
+	});
+
 	it("writes every openclaw special-session file referenced by the identity preset", async () => {
 		root = mkdtempSync(join(tmpdir(), "setup-ni-openclaw-identity-"));
 		const basePath = join(root, "agents");

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -2,7 +2,17 @@ import { copyFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { checkbox, confirm, input, select } from "@inquirer/prompts";
 import { OpenClawConnector } from "@signet/connector-openclaw";
-import { NETWORK_MODES, type NetworkMode, disableGraphiqState, parseSimpleYaml, readNetworkMode } from "@signet/core";
+import {
+	IDENTITY_PRESETS,
+	type IdentityContextFileEntry,
+	type IdentityPresetName,
+	type IdentitySpecialFileEntry,
+	NETWORK_MODES,
+	type NetworkMode,
+	disableGraphiqState,
+	parseSimpleYaml,
+	readNetworkMode,
+} from "@signet/core";
 import chalk from "chalk";
 import open from "open";
 import ora from "ora";
@@ -51,6 +61,24 @@ import {
 	resolveSetupExtractionProvider,
 } from "./setup-shared.js";
 import type { FreshSetupConfig, SetupDeps, SetupWizardOptions } from "./setup-types.js";
+
+const IDENTITY_PRESET_CHOICES = ["minimal", "hermes", "openclaw", "custom"] as const;
+
+function cloneStartupFiles(preset: IdentityPresetName): IdentityContextFileEntry[] {
+	return IDENTITY_PRESETS[preset].startup.map((entry) => ({ ...entry }));
+}
+
+function cloneSpecialFiles(preset: IdentityPresetName): IdentitySpecialFileEntry[] {
+	return IDENTITY_PRESETS[preset].special.map((entry) => ({ ...entry }));
+}
+
+function toStartupChoice(entry: IdentityContextFileEntry, checked: boolean) {
+	return {
+		value: entry.path,
+		name: `${entry.path}${entry.role ? ` — ${entry.role.replace(/_/g, " ")}` : ""}`,
+		checked,
+	};
+}
 
 export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps): Promise<void> {
 	console.log(deps.signetLogo());
@@ -120,6 +148,14 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 	const existingHarnesses = readHarnesses(existingConfig.harnesses);
 	const normalizedExistingHarnesses = normalizeHarnessList(existingHarnesses, deps);
 	const existingNetworkMode = readNetworkMode(existingConfig);
+	const existingIdentity = readRecord(existingConfig.identity);
+	const configuredIdentityPreset = deps.normalizeChoice(options.identityPreset, IDENTITY_PRESET_CHOICES);
+	const existingIdentityPreset = deps.normalizeChoice(existingIdentity.preset, IDENTITY_PRESET_CHOICES);
+	if (options.identityPreset && !configuredIdentityPreset) {
+		failSetupValidation(
+			`Unknown --identity-preset value: ${options.identityPreset}. Valid choices: ${IDENTITY_PRESET_CHOICES.join(", ")}.`,
+		);
+	}
 	const hasClaudeCommand = hasCommand("claude");
 	const hasCodexCommand = hasCommand("codex");
 	const hasOllamaCommand = hasCommand("ollama");
@@ -421,6 +457,51 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 			return;
 		}
 		console.log();
+	}
+
+	const defaultIdentityPreset: IdentityPresetName = configuredIdentityPreset ?? existingIdentityPreset ?? "minimal";
+	const identityPreset: IdentityPresetName = nonInteractive
+		? defaultIdentityPreset
+		: await select({
+				message: "Identity/context preset:",
+				choices: [
+					{
+						value: "minimal",
+						name: "Minimal — AGENTS.md startup context + DREAMING.md for dreaming sessions",
+						description: "Lowest token use; DREAMING.md is special-session only.",
+					},
+					{
+						value: "hermes",
+						name: "Hermes — SOUL.md primary identity + AGENTS.md/project context",
+						description: "Grounded in Hermes' current SOUL.md and project-context discovery model.",
+					},
+					{
+						value: "openclaw",
+						name: "OpenClaw — rich character-forward identity stack",
+						description: "AGENTS, SOUL, IDENTITY, USER, MEMORY plus special HEARTBEAT/DREAMING/BOOTSTRAP prompts.",
+					},
+					{
+						value: "custom",
+						name: "Custom — choose startup files explicitly",
+						description: "Start from Minimal, then select files and order for token efficiency.",
+					},
+				],
+				default: defaultIdentityPreset,
+			});
+
+	let startupIdentityFiles = cloneStartupFiles(identityPreset);
+	let specialIdentityFiles = cloneSpecialFiles(identityPreset);
+	if (!nonInteractive && identityPreset === "custom") {
+		const availableStartupFiles = [...IDENTITY_PRESETS.openclaw.startup, ...IDENTITY_PRESETS.hermes.startup].filter(
+			(entry, index, entries) => entries.findIndex((candidate) => candidate.path === entry.path) === index,
+		);
+		const selected = await checkbox({
+			message: "Which files should load during normal startup?",
+			choices: availableStartupFiles.map((entry) => toStartupChoice(entry, entry.path === "AGENTS.md")),
+		});
+		startupIdentityFiles = availableStartupFiles.filter((entry) => selected.includes(entry.path));
+		if (startupIdentityFiles.length === 0) startupIdentityFiles = cloneStartupFiles("minimal");
+		specialIdentityFiles = cloneSpecialFiles("custom");
 	}
 
 	const configuredName = deps.normalizeStringValue(options.name);
@@ -957,6 +1038,9 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		createLocalBackup: options.createLocalBackup === true,
 		signetSecretsEnabled,
 		graphiqEnabled,
+		identityPreset,
+		startupIdentityFiles,
+		specialIdentityFiles,
 	};
 
 	await runFreshSetup(cfg, deps);

--- a/surfaces/cli/templates/BOOTSTRAP.md.template
+++ b/surfaces/cli/templates/BOOTSTRAP.md.template
@@ -1,0 +1,11 @@
+# BOOTSTRAP.md
+
+You are {{AGENT_NAME}} during a bootstrap/setup session.
+
+Use this file only for initial workspace orientation and first-run setup. Do not treat it as ordinary startup identity context.
+
+## Bootstrap Instructions
+
+- Establish the workspace structure and essential configuration.
+- Prefer durable, explicit setup steps over implicit assumptions.
+- Once setup is complete, do not keep repeating bootstrap guidance in normal sessions.

--- a/surfaces/cli/templates/DREAMING.md.template
+++ b/surfaces/cli/templates/DREAMING.md.template
@@ -1,0 +1,39 @@
+dreaming - reflection & consolidation prompt
+===
+
+This file is used only for {{AGENT_NAME}}'s dreaming sessions. It is not
+loaded into normal startup context.
+
+purpose
+---
+
+Use dreaming to reflect on recent experience, consolidate useful patterns,
+clean up stale working context, and surface durable memories or next actions.
+Dreaming should produce grounded updates, not fictional lore or hallucinated
+progress.
+
+guidance
+---
+
+- Review recent transcripts, memories, tasks, and artifacts with provenance.
+- Prefer concrete, time-aware semantic objects: people, organizations,
+  projects, products, systems/tools, artifacts/documents/sources, places,
+  and events.
+- Treat events as first-class when something happened at a time.
+- Keep claims, aspects, and attributes as descriptions of entities/events.
+- Preserve evidence links back to source artifacts when possible.
+- Reject prompt scaffolding, metadata roles, pronouns, headings, and discourse
+  fragments as entities.
+- Save only durable facts, preferences, decisions, and reusable workflows.
+- Do not rewrite identity files unless the dreaming task explicitly asks for
+  identity maintenance.
+
+output
+---
+
+End each dreaming session with:
+
+1. durable memories or ontology updates made
+2. stale/noisy context pruned or recommended for pruning
+3. unresolved questions or follow-up tasks
+4. evidence/provenance used

--- a/surfaces/cli/templates/HEARTBEAT.md.template
+++ b/surfaces/cli/templates/HEARTBEAT.md.template
@@ -1,0 +1,11 @@
+# HEARTBEAT.md
+
+You are {{AGENT_NAME}} during a heartbeat/background check session.
+
+Use this file only for lightweight liveness, status, and operational reflection. Do not treat it as ordinary startup identity context.
+
+## Heartbeat Instructions
+
+- Check current focus, blockers, and health signals.
+- Report only material changes or actionable problems.
+- Stay concise and avoid re-summarizing unchanged context.

--- a/surfaces/dashboard/src/lib/components/config/IdentityPanel.svelte
+++ b/surfaces/dashboard/src/lib/components/config/IdentityPanel.svelte
@@ -12,7 +12,7 @@ interface Props {
 	onDirtyChange?: (dirty: boolean) => void;
 }
 
-let { configFiles, onDirtyChange }: Props = $props();
+const { configFiles, onDirtyChange }: Props = $props();
 
 const CHAR_BUDGETS: Record<string, number> = {
 	"AGENTS.md": 12000,
@@ -20,6 +20,7 @@ const CHAR_BUDGETS: Record<string, number> = {
 	"USER.md": 6000,
 	"SOUL.md": 4000,
 	"IDENTITY.md": 2000,
+	"DREAMING.md": 4000,
 };
 
 const mdFiles = $derived(configFiles?.filter((f) => f.name.endsWith(".md")) ?? []);
@@ -29,10 +30,10 @@ let prevSelectedFile = $state("");
 let editorContent = $state("");
 let saving = $state(false);
 let savedByFile = $state<Record<string, string>>({});
-let collapsed = $state(false);
+const collapsed = $state(false);
 let jumpMenuOpen = $state(false);
 let jumpFilter = $state("");
-let jumpInputRef = $state<HTMLInputElement | null>(null);
+const jumpInputRef = $state<HTMLInputElement | null>(null);
 
 const activeFile = $derived(mdFiles.find((f) => f.name === selectedFile));
 

--- a/surfaces/dashboard/src/lib/components/config/IdentityPanel.svelte
+++ b/surfaces/dashboard/src/lib/components/config/IdentityPanel.svelte
@@ -30,10 +30,11 @@ let prevSelectedFile = $state("");
 let editorContent = $state("");
 let saving = $state(false);
 let savedByFile = $state<Record<string, string>>({});
-const collapsed = $state(false);
+let collapsed = $state(false);
 let jumpMenuOpen = $state(false);
 let jumpFilter = $state("");
-const jumpInputRef = $state<HTMLInputElement | null>(null);
+// biome-ignore lint/style/useConst: Svelte bind:this writes the DOM node into this reference at runtime.
+let jumpInputRef = $state<HTMLInputElement | null>(null);
 
 const activeFile = $derived(mdFiles.find((f) => f.name === selectedFile));
 
@@ -96,6 +97,14 @@ function handlePanelKey(e: KeyboardEvent): void {
 		jumpMenuOpen = false;
 		jumpFilter = "";
 	}
+}
+
+function expandPanel(): void {
+	collapsed = false;
+}
+
+function collapsePanel(): void {
+	collapsed = true;
 }
 
 function selectFileWithGuard(name: string): void {
@@ -163,7 +172,7 @@ export function discard(): void {
 		<button
 			type="button"
 			class="collapse-toggle"
-			onclick={() => (collapsed = false)}
+			onclick={expandPanel}
 			title="Open identity panel"
 		>
 			<PanelLeft size={14} />
@@ -219,7 +228,7 @@ export function discard(): void {
 			<button
 				type="button"
 				class="collapse-toggle"
-				onclick={() => (collapsed = true)}
+				onclick={collapsePanel}
 				title="Collapse panel"
 			>
 				<PanelLeftClose size={14} />

--- a/surfaces/dashboard/src/lib/components/config/IdentityPanel.svelte
+++ b/surfaces/dashboard/src/lib/components/config/IdentityPanel.svelte
@@ -21,6 +21,8 @@ const CHAR_BUDGETS: Record<string, number> = {
 	"SOUL.md": 4000,
 	"IDENTITY.md": 2000,
 	"DREAMING.md": 4000,
+	"HEARTBEAT.md": 4000,
+	"BOOTSTRAP.md": 4000,
 };
 
 const mdFiles = $derived(configFiles?.filter((f) => f.name.endsWith(".md")) ?? []);


### PR DESCRIPTION
## Summary
- Add configurable identity presets for setup/onboarding: Minimal, Hermes, OpenClaw, and Custom.
- Add `DREAMING.md` as a special-session prompt template that is created even by the Minimal preset but not loaded during ordinary startup/static identity context.
- Persist ordered `identity.startup.load` and `identity.special` entries in `agent.yaml`, and make static identity fallback honor the configured startup order.
- Update onboarding guidance, CLI/config docs, and the dreaming consolidation spec to distinguish startup context from special session prompts.

## Validation
- `bun install`
- `bun run build:core`
- `bun test platform/core/src/__tests__/identity.test.ts surfaces/cli/src/features/setup.test.ts`
- `cd surfaces/cli && bun run build:cli`
- `bunx biome check platform/core/src/identity.ts platform/core/src/index.ts platform/core/src/__tests__/identity.test.ts surfaces/cli/src/features/setup.ts surfaces/cli/src/features/setup-types.ts surfaces/cli/src/features/setup-fresh.ts surfaces/cli/src/features/setup-migrate.ts surfaces/cli/src/features/setup.test.ts surfaces/cli/src/commands/app.ts surfaces/dashboard/src/lib/components/config/IdentityPanel.svelte docs/CONFIGURATION.md docs/CLI.md docs/specs/dependencies.yaml docs/specs/approved/dreaming-memory-consolidation.md surfaces/cli/templates/DREAMING.md.template skills/onboarding/SKILL.md`
- `git diff --check`

## Notes
- Minimal means `AGENTS.md` only for normal startup context, not "only one file exists"; it still creates `DREAMING.md` because dreaming sessions need their own prompt.
- Hermes preset is grounded in Hermes' current SOUL-primary identity shape plus project context conventions, not the OpenClaw/Signet SOUL+IDENTITY+USER stack.
- `DREAMING.md` is deliberately special-session only and is not included in `readStaticIdentity()` startup fallback.

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes
- [x] No database migrations were added, removed, renumbered, or modified.
