### PR TITLE
feat(setup): add dashboard setup entry

### DIFF
--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -15,6 +15,10 @@
 			"import": "./dist/pipeline-providers.js",
 			"types": "./dist/pipeline-providers.d.ts"
 		},
+		"./identity-presets": {
+			"import": "./dist/identity-presets.js",
+			"types": "./dist/identity-presets.d.ts"
+		},
 		"./llm-model-catalog": {
 			"import": "./dist/llm-model-catalog.js",
 			"types": "./dist/llm-model-catalog.d.ts"
@@ -22,7 +26,7 @@
 	},
 	"files": ["dist", "!dist/**/*.test.*", "!dist/**/__tests__/**"],
 	"scripts": {
-		"build": "bun build ./src/index.ts ./src/pipeline-providers.ts ./src/llm-model-catalog.ts --outdir ./dist --target node --external better-sqlite3 && bun run build:types",
+		"build": "bun build ./src/index.ts ./src/pipeline-providers.ts ./src/identity-presets.ts ./src/llm-model-catalog.ts --outdir ./dist --target node --external better-sqlite3 && bun run build:types",
 		"build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
 		"dev": "bun --watch src/index.ts",
 		"test": "bun test",

--- a/platform/core/src/identity-presets.ts
+++ b/platform/core/src/identity-presets.ts
@@ -1,0 +1,148 @@
+export type IdentityPresetName = "minimal" | "hermes" | "openclaw" | "custom";
+
+export type IdentityFileContext = "startup" | "session";
+
+export type IdentitySessionKind = "dreaming" | "heartbeat" | "bootstrap";
+
+export interface IdentityFileSpec {
+	/** Relative path from the base directory */
+	path: string;
+	/** Human-readable description */
+	description: string;
+	/** Whether this file is optional */
+	optional?: boolean;
+	/** Whether this file is loaded during normal startup or only in a special session */
+	context?: IdentityFileContext;
+	/** Special session kind when context is "session" */
+	session?: IdentitySessionKind;
+}
+
+export interface IdentityContextFileEntry {
+	path: string;
+	role?: string;
+	budget?: number;
+	enabled?: boolean;
+}
+
+export interface IdentitySpecialFileEntry extends IdentityContextFileEntry {
+	kind: IdentitySessionKind;
+}
+
+export interface IdentityPresetSpec {
+	name: IdentityPresetName;
+	description: string;
+	startup: IdentityContextFileEntry[];
+	special: IdentitySpecialFileEntry[];
+}
+
+/**
+ * Standard identity files that form the cross-harness identity standard.
+ * These are recognized by Signet and multiple harnesses.
+ */
+export const IDENTITY_FILES: Record<string, IdentityFileSpec> = {
+	agents: {
+		path: "AGENTS.md",
+		description: "Operational rules and behavioral settings",
+		optional: false,
+	},
+	soul: {
+		path: "SOUL.md",
+		description: "Persona, character, and security settings",
+		optional: false,
+	},
+	identity: {
+		path: "IDENTITY.md",
+		description: "Agent name, creature type, and vibe",
+		optional: false,
+	},
+	user: {
+		path: "USER.md",
+		description: "User profile and preferences",
+		optional: false,
+	},
+	heartbeat: {
+		path: "HEARTBEAT.md",
+		description: "Heartbeat prompt used only for heartbeat/background check sessions",
+		optional: true,
+		context: "session",
+		session: "heartbeat",
+	},
+	memory: {
+		path: "MEMORY.md",
+		description: "Memory index and summary",
+		optional: true,
+	},
+	tools: {
+		path: "TOOLS.md",
+		description: "Tool preferences and notes",
+		optional: true,
+	},
+	bootstrap: {
+		path: "BOOTSTRAP.md",
+		description: "Setup ritual (typically deleted after first run)",
+		optional: true,
+		context: "session",
+		session: "bootstrap",
+	},
+	dreaming: {
+		path: "DREAMING.md",
+		description: "Dreaming/reflection prompt used only for dreaming sessions",
+		optional: true,
+		context: "session",
+		session: "dreaming",
+	},
+};
+
+export const IDENTITY_PRESETS: Record<IdentityPresetName, IdentityPresetSpec> = {
+	minimal: {
+		name: "minimal",
+		description: "AGENTS.md only for normal startup, plus DREAMING.md for dreaming sessions.",
+		startup: [{ path: "AGENTS.md", role: "operating_instructions", budget: 12_000 }],
+		special: [{ path: "DREAMING.md", kind: "dreaming", role: "dreaming_prompt", budget: 4_000 }],
+	},
+	hermes: {
+		name: "hermes",
+		description: "Hermes-style SOUL.md primary identity with project-context discovery handled by Hermes.",
+		startup: [
+			{ path: "SOUL.md", role: "primary_identity", budget: 4_000 },
+			{ path: "AGENTS.md", role: "project_context", budget: 12_000 },
+		],
+		special: [{ path: "DREAMING.md", kind: "dreaming", role: "dreaming_prompt", budget: 4_000 }],
+	},
+	openclaw: {
+		name: "openclaw",
+		description: "OpenClaw-style rich identity stack for character-forward agents.",
+		startup: [
+			{ path: "AGENTS.md", role: "operating_instructions", budget: 12_000 },
+			{ path: "SOUL.md", role: "persona", budget: 4_000 },
+			{ path: "IDENTITY.md", role: "agent_identity", budget: 2_000 },
+			{ path: "USER.md", role: "user_profile", budget: 6_000 },
+			{ path: "MEMORY.md", role: "working_memory", budget: 10_000 },
+		],
+		special: [
+			{ path: "HEARTBEAT.md", kind: "heartbeat", role: "heartbeat_prompt", budget: 4_000 },
+			{ path: "DREAMING.md", kind: "dreaming", role: "dreaming_prompt", budget: 4_000 },
+			{ path: "BOOTSTRAP.md", kind: "bootstrap", role: "bootstrap_prompt", budget: 4_000 },
+		],
+	},
+	custom: {
+		name: "custom",
+		description: "User-selected startup files and explicit order.",
+		startup: [{ path: "AGENTS.md", role: "operating_instructions", budget: 12_000 }],
+		special: [{ path: "DREAMING.md", kind: "dreaming", role: "dreaming_prompt", budget: 4_000 }],
+	},
+};
+
+/**
+ * Required identity files (non-optional)
+ */
+export const REQUIRED_IDENTITY_KEYS = Object.entries(IDENTITY_FILES)
+	.filter(([, spec]) => !spec.optional)
+	.map(([key]) => key);
+
+/**
+ * Optional identity files
+ */
+export const OPTIONAL_IDENTITY_KEYS = Object.entries(IDENTITY_FILES)
+	.filter(([, spec]) => spec.optional)
+	.map(([key]) => key);

--- a/platform/core/src/identity.ts
+++ b/platform/core/src/identity.ts
@@ -10,9 +10,35 @@ import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import {
+	IDENTITY_FILES,
+	IDENTITY_PRESETS,
+	type IdentityContextFileEntry,
+	type IdentityFileContext,
+	type IdentityFileSpec,
+	type IdentityPresetName,
+	type IdentityPresetSpec,
+	type IdentitySessionKind,
+	type IdentitySpecialFileEntry,
+	OPTIONAL_IDENTITY_KEYS,
+	REQUIRED_IDENTITY_KEYS,
+} from "./identity-presets";
 import { listOhMyPiAgentDirCandidates, resolveOhMyPiAgentDir } from "./oh-my-pi";
 import { listPiAgentDirCandidates, resolvePiAgentDir } from "./pi";
 import { parseSimpleYaml } from "./yaml";
+export {
+	IDENTITY_FILES,
+	IDENTITY_PRESETS,
+	OPTIONAL_IDENTITY_KEYS,
+	REQUIRED_IDENTITY_KEYS,
+	type IdentityContextFileEntry,
+	type IdentityFileContext,
+	type IdentityFileSpec,
+	type IdentityPresetName,
+	type IdentityPresetSpec,
+	type IdentitySessionKind,
+	type IdentitySpecialFileEntry,
+} from "./identity-presets";
 
 const OH_MY_PI_MANAGED_EXTENSION_FILENAME = "signet-oh-my-pi.js";
 const OH_MY_PI_LEGACY_MANAGED_EXTENSION_FILENAME = "signet-oh-my-pi.mjs";
@@ -29,46 +55,6 @@ const PI_MANAGED_MARKER = "SIGNET_MANAGED_PI_EXTENSION";
 export function resolveAgentBasePath(agentName: string, workspaceDir: string): string {
 	if (agentName === "default") return workspaceDir;
 	return join(workspaceDir, "agents", agentName);
-}
-
-/**
- * Specification for an identity file
- */
-export type IdentityPresetName = "minimal" | "hermes" | "openclaw" | "custom";
-
-export type IdentityFileContext = "startup" | "session";
-
-export type IdentitySessionKind = "dreaming" | "heartbeat" | "bootstrap";
-
-export interface IdentityFileSpec {
-	/** Relative path from the base directory */
-	path: string;
-	/** Human-readable description */
-	description: string;
-	/** Whether this file is optional */
-	optional?: boolean;
-	/** Whether this file is loaded during normal startup or only in a special session */
-	context?: IdentityFileContext;
-	/** Special session kind when context is "session" */
-	session?: IdentitySessionKind;
-}
-
-export interface IdentityContextFileEntry {
-	path: string;
-	role?: string;
-	budget?: number;
-	enabled?: boolean;
-}
-
-export interface IdentitySpecialFileEntry extends IdentityContextFileEntry {
-	kind: IdentitySessionKind;
-}
-
-export interface IdentityPresetSpec {
-	name: IdentityPresetName;
-	description: string;
-	startup: IdentityContextFileEntry[];
-	special: IdentitySpecialFileEntry[];
 }
 
 /**
@@ -98,118 +84,6 @@ export interface IdentityMap {
 	tools?: IdentityFile;
 	bootstrap?: IdentityFile;
 }
-
-/**
- * Standard identity files that form the cross-harness identity standard.
- * These are recognized by Signet and multiple harnesses.
- */
-export const IDENTITY_FILES: Record<string, IdentityFileSpec> = {
-	agents: {
-		path: "AGENTS.md",
-		description: "Operational rules and behavioral settings",
-		optional: false,
-	},
-	soul: {
-		path: "SOUL.md",
-		description: "Persona, character, and security settings",
-		optional: false,
-	},
-	identity: {
-		path: "IDENTITY.md",
-		description: "Agent name, creature type, and vibe",
-		optional: false,
-	},
-	user: {
-		path: "USER.md",
-		description: "User profile and preferences",
-		optional: false,
-	},
-	heartbeat: {
-		path: "HEARTBEAT.md",
-		description: "Heartbeat prompt used only for heartbeat/background check sessions",
-		optional: true,
-		context: "session",
-		session: "heartbeat",
-	},
-	memory: {
-		path: "MEMORY.md",
-		description: "Memory index and summary",
-		optional: true,
-	},
-	tools: {
-		path: "TOOLS.md",
-		description: "Tool preferences and notes",
-		optional: true,
-	},
-	bootstrap: {
-		path: "BOOTSTRAP.md",
-		description: "Setup ritual (typically deleted after first run)",
-		optional: true,
-		context: "session",
-		session: "bootstrap",
-	},
-	dreaming: {
-		path: "DREAMING.md",
-		description: "Dreaming/reflection prompt used only for dreaming sessions",
-		optional: true,
-		context: "session",
-		session: "dreaming",
-	},
-};
-
-export const IDENTITY_PRESETS: Record<IdentityPresetName, IdentityPresetSpec> = {
-	minimal: {
-		name: "minimal",
-		description: "AGENTS.md only for normal startup, plus DREAMING.md for dreaming sessions.",
-		startup: [{ path: "AGENTS.md", role: "operating_instructions", budget: 12_000 }],
-		special: [{ path: "DREAMING.md", kind: "dreaming", role: "dreaming_prompt", budget: 4_000 }],
-	},
-	hermes: {
-		name: "hermes",
-		description: "Hermes-style SOUL.md primary identity with project-context discovery handled by Hermes.",
-		startup: [
-			{ path: "SOUL.md", role: "primary_identity", budget: 4_000 },
-			{ path: "AGENTS.md", role: "project_context", budget: 12_000 },
-		],
-		special: [{ path: "DREAMING.md", kind: "dreaming", role: "dreaming_prompt", budget: 4_000 }],
-	},
-	openclaw: {
-		name: "openclaw",
-		description: "OpenClaw-style rich identity stack for character-forward agents.",
-		startup: [
-			{ path: "AGENTS.md", role: "operating_instructions", budget: 12_000 },
-			{ path: "SOUL.md", role: "persona", budget: 4_000 },
-			{ path: "IDENTITY.md", role: "agent_identity", budget: 2_000 },
-			{ path: "USER.md", role: "user_profile", budget: 6_000 },
-			{ path: "MEMORY.md", role: "working_memory", budget: 10_000 },
-		],
-		special: [
-			{ path: "HEARTBEAT.md", kind: "heartbeat", role: "heartbeat_prompt", budget: 4_000 },
-			{ path: "DREAMING.md", kind: "dreaming", role: "dreaming_prompt", budget: 4_000 },
-			{ path: "BOOTSTRAP.md", kind: "bootstrap", role: "bootstrap_prompt", budget: 4_000 },
-		],
-	},
-	custom: {
-		name: "custom",
-		description: "User-selected startup files and explicit order.",
-		startup: [{ path: "AGENTS.md", role: "operating_instructions", budget: 12_000 }],
-		special: [{ path: "DREAMING.md", kind: "dreaming", role: "dreaming_prompt", budget: 4_000 }],
-	},
-};
-
-/**
- * Required identity files (non-optional)
- */
-export const REQUIRED_IDENTITY_KEYS = Object.entries(IDENTITY_FILES)
-	.filter(([, spec]) => !spec.optional)
-	.map(([key]) => key);
-
-/**
- * Optional identity files
- */
-export const OPTIONAL_IDENTITY_KEYS = Object.entries(IDENTITY_FILES)
-	.filter(([, spec]) => spec.optional)
-	.map(([key]) => key);
 
 /**
  * Detection result for existing setup

--- a/surfaces/cli/src/commands/app.test.ts
+++ b/surfaces/cli/src/commands/app.test.ts
@@ -25,6 +25,50 @@ describe("registerAppCommands", () => {
 		expect(calls).toEqual([[]]);
 	});
 
+	test("passes setup mode to the setup wizard", async () => {
+		const calls: unknown[] = [];
+		const program = new Command();
+
+		registerAppCommands(program, {
+			collectListOption: (value, previous) => [...previous, value],
+			configureAgent: async () => {},
+			launchDashboard: async () => {},
+			migrateSchema: async () => {},
+			setupWizard: async (options) => {
+				calls.push(options);
+			},
+			showDoctor: async () => {},
+			showStatus: async () => {},
+			syncTemplates: async () => {},
+		});
+
+		await program.parseAsync(["node", "test", "setup", "--setup-mode", "dashboard"]);
+
+		expect(calls).toEqual([expect.objectContaining({ setupMode: "dashboard" })]);
+	});
+
+	test("rejects malformed setup option tokens as excess arguments", async () => {
+		const calls: unknown[] = [];
+		const program = new Command();
+		program.exitOverride();
+
+		registerAppCommands(program, {
+			collectListOption: (value, previous) => [...previous, value],
+			configureAgent: async () => {},
+			launchDashboard: async () => {},
+			migrateSchema: async () => {},
+			setupWizard: async (options) => {
+				calls.push(options);
+			},
+			showDoctor: async () => {},
+			showStatus: async () => {},
+			syncTemplates: async () => {},
+		});
+
+		await expect(program.parseAsync(["node", "test", "setup", " --setup-mode", "dashboard"])).rejects.toThrow();
+		expect(calls).toEqual([]);
+	});
+
 	test("routes doctor target into doctor options", async () => {
 		const calls: unknown[] = [];
 		const program = new Command();

--- a/surfaces/cli/src/commands/app.ts
+++ b/surfaces/cli/src/commands/app.ts
@@ -24,6 +24,7 @@ interface SetupOptions {
 	disableSignetSecrets?: boolean;
 	withGraphiq?: boolean;
 	disableGraphiq?: boolean;
+	setupMode?: string;
 }
 
 interface PathOptions {
@@ -69,9 +70,11 @@ export function registerAppCommands(program: Command, deps: AppDeps): void {
 
 	program
 		.command("setup")
+		.allowExcessArguments(false)
 		.description("Setup wizard (interactive by default)")
 		.option("-p, --path <path>", "Base path for agent files")
 		.option("--non-interactive", "Run setup without prompts")
+		.option("--setup-mode <mode>", "Interactive setup surface (terminal, dashboard)")
 		.option("--name <name>", "Agent name (non-interactive mode)")
 		.option("--description <description>", "Agent description (non-interactive mode)")
 		.option(
@@ -92,7 +95,7 @@ export function registerAppCommands(program: Command, deps: AppDeps): void {
 		.option("--embedding-model <model>", "Embedding model in non-interactive mode")
 		.option(
 			"--extraction-provider <provider>",
-			"Extraction provider in non-interactive mode (claude-code, codex, llama-cpp, ollama, opencode, openrouter, openai-compatible, none)",
+			"Extraction provider in non-interactive mode (acpx, claude-code, codex, llama-cpp, ollama, opencode, openrouter, openai-compatible, none)",
 		)
 		.option("--extraction-model <model>", "Extraction model in non-interactive mode")
 		.option("--extraction-endpoint <url>", "OpenAI-compatible extraction endpoint in non-interactive mode")

--- a/surfaces/cli/src/features/setup-types.ts
+++ b/surfaces/cli/src/features/setup-types.ts
@@ -30,7 +30,8 @@ export interface SetupWizardOptions {
 	disableSignetSecrets?: boolean;
 	withGraphiq?: boolean;
 	disableGraphiq?: boolean;
-	identityPreset?: string;
+		identityPreset?: string;
+		setupMode?: string;
 }
 
 export interface SetupDeps {

--- a/surfaces/cli/src/features/setup-types.ts
+++ b/surfaces/cli/src/features/setup-types.ts
@@ -30,8 +30,8 @@ export interface SetupWizardOptions {
 	disableSignetSecrets?: boolean;
 	withGraphiq?: boolean;
 	disableGraphiq?: boolean;
-		identityPreset?: string;
-		setupMode?: string;
+	identityPreset?: string;
+	setupMode?: string;
 }
 
 export interface SetupDeps {

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -357,6 +357,50 @@ describe("setupWizard non-interactive harness hooks", () => {
 		expect(detectedHarnessesForExistingSetup(detection, [])).toContain("hermes-agent");
 	});
 
+	it("writes complete identity config from the dashboard setup branch", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-dashboard-identity-"));
+		const basePath = join(root, "agents");
+		const templatesPath = join(root, "templates");
+		writeIdentityTemplates(templatesPath);
+
+		const freshDetection: SetupDetection = {
+			...fakeDetection(basePath),
+			agentsDir: false,
+			memoryDb: false,
+		};
+		const deps = stubDeps({
+			AGENTS_DIR: basePath,
+			getTemplatesDir: mock(() => templatesPath),
+			normalizeAgentPath: mock((p: string) => p),
+			detectExistingSetup: mock(() => freshDetection),
+		});
+
+		await setupWizard(
+			{
+				setupMode: "dashboard",
+				identityPreset: "hermes",
+				extractionProvider: "openai-compatible",
+				extractionModel: "openai/gpt-oss-20b",
+				extractionEndpoint: "https://gateway.example.test/v1",
+				skipGit: true,
+				openDashboard: false,
+			},
+			deps,
+		);
+
+		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
+		expect(agentYaml).toContain("preset: hermes");
+		expect(agentYaml).toContain("path: SOUL.md");
+		expect(agentYaml).toContain("path: AGENTS.md");
+		expect(agentYaml).toContain("path: DREAMING.md");
+		expect(agentYaml).toContain("provider: openai-compatible");
+		expect(agentYaml).toContain("model: openai/gpt-oss-20b");
+		expect(agentYaml).toContain("endpoint: https://gateway.example.test/v1");
+		expect(existsSync(join(basePath, "SOUL.md"))).toBe(true);
+		expect(existsSync(join(basePath, "AGENTS.md"))).toBe(true);
+		expect(existsSync(join(basePath, "DREAMING.md"))).toBe(true);
+	});
+
 	it("writes minimal identity preset with DREAMING.md as special-session file", async () => {
 		root = mkdtempSync(join(tmpdir(), "setup-ni-minimal-identity-"));
 		const basePath = join(root, "agents");

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -190,6 +190,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 	const existingIdentity = readRecord(existingConfig.identity);
 	const configuredIdentityPreset = deps.normalizeChoice(options.identityPreset, IDENTITY_PRESET_CHOICES);
 	const existingIdentityPreset = deps.normalizeChoice(existingIdentity.preset, IDENTITY_PRESET_CHOICES);
+	const defaultIdentityPreset: IdentityPresetName = configuredIdentityPreset ?? existingIdentityPreset ?? "minimal";
 	if (options.identityPreset && !configuredIdentityPreset) {
 		failSetupValidation(
 			`Unknown --identity-preset value: ${options.identityPreset}. Valid choices: ${IDENTITY_PRESET_CHOICES.join(", ")}.`,
@@ -519,6 +520,9 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 			return;
 		}
 		if (setupMethod === "dashboard") {
+			const identityPreset = defaultIdentityPreset;
+			const startupIdentityFiles = cloneStartupFiles(identityPreset);
+			const specialIdentityFiles = cloneSpecialFiles(identityPreset);
 			const deploymentType = requestedDeploymentType ?? "local";
 			const embeddingProvider = requestedEmbeddingProvider ?? defaultEmbeddingProviderForDeployment(deploymentType);
 			let embeddingModel = deps.normalizeStringValue(options.embeddingModel) || "nomic-embed-text-v1.5";
@@ -538,6 +542,12 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 			});
 			const extractionModel =
 				deps.normalizeStringValue(options.extractionModel) || defaultExtractionModel(extractionProvider);
+			const extractionEndpoint = resolveSetupExtractionEndpoint({
+				provider: extractionProvider,
+				requestedEndpoint: requestedExtractionEndpoint,
+				existingProvider: detectedProvider,
+				existingEndpoint: existingExtractionEndpoint,
+			});
 			await runFreshSetup(
 				{
 					basePath,
@@ -553,6 +563,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 					embeddingDimensions,
 					extractionProvider,
 					extractionModel,
+					extractionEndpoint,
 					availableExtractionProviders: availableToolExtractionProviders,
 					acpxBin,
 					searchBalance: deps.parseSearchBalanceValue(options.searchBalance) ?? 0.7,
@@ -563,11 +574,14 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 					gitEnabled: options.skipGit !== true,
 					existingAgentsDir: existing.agentsDir,
 					nonInteractive: true,
-					openDashboard: true,
+					openDashboard: options.openDashboard !== false,
 					allowUnprotectedWorkspace: options.allowUnprotectedWorkspace === true,
 					createLocalBackup: options.createLocalBackup === true,
 					signetSecretsEnabled: await resolveSignetSecretsCorePluginSelection(basePath, true, options),
 					graphiqEnabled: await resolveGraphiqPluginSelection(basePath, true, options),
+					identityPreset,
+					startupIdentityFiles,
+					specialIdentityFiles,
 				},
 				deps,
 			);
@@ -576,7 +590,6 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		console.log();
 	}
 
-	const defaultIdentityPreset: IdentityPresetName = configuredIdentityPreset ?? existingIdentityPreset ?? "minimal";
 	const identityPreset: IdentityPresetName = nonInteractive
 		? defaultIdentityPreset
 		: await select({

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -179,6 +179,8 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 	const requestedExtractionProvider = deps.normalizeChoice(rawExtractionProvider, EXTRACTION_PROVIDER_CHOICES);
 	const rawExtractionEndpoint = deps.normalizeStringValue(options.extractionEndpoint);
 	const requestedExtractionEndpoint = normalizeHttpEndpoint(rawExtractionEndpoint);
+	const rawSetupMode = deps.normalizeStringValue(options.setupMode);
+	const requestedSetupMode = deps.normalizeChoice(rawSetupMode, ["terminal", "dashboard"] as const);
 	const existingName = readString(existingConfig.name) ?? readString(existingAgent.name) ?? "My Agent";
 	const existingDesc =
 		readString(existingConfig.description) ?? readString(existingAgent.description) ?? "Personal AI assistant";
@@ -226,6 +228,9 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 	}
 	if (rawExtractionEndpoint && !requestedExtractionEndpoint) {
 		failSetupValidation("--extraction-endpoint must be an http:// or https:// URL.");
+	}
+	if (rawSetupMode && !requestedSetupMode) {
+		failSetupValidation(`Unknown --setup-mode value: ${rawSetupMode}. Valid choices: terminal, dashboard.`);
 	}
 	const unknownHarnessValues = findUnknownHarnessValues(options.harness, deps);
 	if (nonInteractive && unknownHarnessValues.length > 0) {
@@ -496,18 +501,76 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 
 		const setupMethod = nonInteractive
 			? "new"
-			: await select({
-					message: "How would you like to set up?",
-					choices: [
-						{ value: "new", name: "Create new agent identity" },
-						{ value: "github", name: "Import from GitHub repository" },
-					],
-				});
+			: requestedSetupMode === "dashboard"
+				? "dashboard"
+				: await select({
+						message: "How would you like to set up?",
+						choices: [
+							{ value: "new", name: "Create new agent identity in terminal" },
+							{ value: "dashboard", name: "Create defaults and finish in dashboard" },
+							{ value: "github", name: "Import from GitHub repository" },
+						],
+					});
 
 		if (setupMethod === "github") {
 			mkdirSync(basePath, { recursive: true });
 			mkdirSync(join(basePath, "memory"), { recursive: true });
 			await deps.importFromGitHub(basePath);
+			return;
+		}
+		if (setupMethod === "dashboard") {
+			const deploymentType = requestedDeploymentType ?? "local";
+			const embeddingProvider = requestedEmbeddingProvider ?? defaultEmbeddingProviderForDeployment(deploymentType);
+			let embeddingModel = deps.normalizeStringValue(options.embeddingModel) || "nomic-embed-text-v1.5";
+			let embeddingDimensions = getEmbeddingDimensions(embeddingModel);
+			if (embeddingProvider === "native") {
+				embeddingModel = "nomic-embed-text-v1.5";
+				embeddingDimensions = 768;
+			}
+			const harnesses = normalizeHarnessList(options.harness, deps);
+			const extractionProvider = resolveSetupExtractionProvider({
+				deploymentType,
+				requestedProvider: requestedExtractionProvider,
+				preserveExisting: false,
+				detectedProvider,
+				availableProviders: availableToolExtractionProviders,
+				preferredHarnesses: harnesses,
+			});
+			const extractionModel =
+				deps.normalizeStringValue(options.extractionModel) || defaultExtractionModel(extractionProvider);
+			await runFreshSetup(
+				{
+					basePath,
+					agentName: deps.normalizeStringValue(options.name) || existingName,
+					agentDescription: deps.normalizeStringValue(options.description) || existingDesc,
+					networkMode: deps.normalizeChoice(options.networkMode, NETWORK_MODES) ?? "localhost",
+					harnesses,
+					openclawRuntimePath: deps.normalizeChoice(options.openclawRuntimePath, OPENCLAW_RUNTIME_CHOICES) ?? "plugin",
+					configureOpenClawWs: options.configureOpenclawWorkspace === true,
+					openclawConfigCount: new OpenClawConnector().getDiscoveredConfigPaths().length,
+					embeddingProvider,
+					embeddingModel,
+					embeddingDimensions,
+					extractionProvider,
+					extractionModel,
+					availableExtractionProviders: availableToolExtractionProviders,
+					acpxBin,
+					searchBalance: deps.parseSearchBalanceValue(options.searchBalance) ?? 0.7,
+					searchTopK: 20,
+					searchMinScore: 0.3,
+					memorySessionBudget: 2000,
+					memoryDecayRate: 0.95,
+					gitEnabled: options.skipGit !== true,
+					existingAgentsDir: existing.agentsDir,
+					nonInteractive: true,
+					openDashboard: true,
+					allowUnprotectedWorkspace: options.allowUnprotectedWorkspace === true,
+					createLocalBackup: options.createLocalBackup === true,
+					signetSecretsEnabled: await resolveSignetSecretsCorePluginSelection(basePath, true, options),
+					graphiqEnabled: await resolveGraphiqPluginSelection(basePath, true, options),
+				},
+				deps,
+			);
 			return;
 		}
 		console.log();

--- a/surfaces/dashboard/src/lib/components/onboarding/OnboardingModal.svelte
+++ b/surfaces/dashboard/src/lib/components/onboarding/OnboardingModal.svelte
@@ -1,57 +1,113 @@
 <script lang="ts">
 import { invalidateAll } from "$app/navigation";
-import type { ConfigFile, DaemonStatus, MemoryStats } from "$lib/api";
+import { type ConfigFile, type DaemonStatus, type Harness, type MemoryStats, saveConfigFileResult } from "$lib/api";
 import { applyRecommendedPipelineSetup } from "$lib/components/tabs/settings/pipeline-settings";
 import { Button } from "$lib/components/ui/button/index.js";
+import { Checkbox } from "$lib/components/ui/checkbox/index.js";
 import { Input } from "$lib/components/ui/input/index.js";
-import * as Select from "$lib/components/ui/select/index.js";
+import { Textarea } from "$lib/components/ui/textarea/index.js";
 import type { TabId } from "$lib/stores/navigation.svelte";
-import { st } from "$lib/stores/settings.svelte";
+import { KNOWN_HARNESSES, st } from "$lib/stores/settings.svelte";
 import { toast } from "$lib/stores/toast.svelte";
-import type { PipelineProviderChoice } from "@signet/core/pipeline-providers";
+import { type PipelineProviderChoice, defaultPipelineModel } from "@signet/core/pipeline-providers";
 import { onMount, untrack } from "svelte";
+import { stringify } from "yaml";
 
 interface Props {
 	configFiles: ConfigFile[];
 	memoryStats: MemoryStats;
 	daemonStatus: DaemonStatus | null;
+	harnesses?: Harness[];
 	onnavigate?: (tab: TabId) => void;
 }
 
-const { configFiles, memoryStats, daemonStatus, onnavigate }: Props = $props();
+type ProviderOption = {
+	value: PipelineProviderChoice;
+	label: string;
+	detail: string;
+	mode: "agent" | "local" | "api" | "off" | "custom";
+	endpointPlaceholder?: string;
+};
 
-const selectTriggerClass =
-	"font-mono text-[11px] text-[var(--sig-text)] bg-[var(--sig-bg)] border-[var(--sig-border-strong)] rounded-md w-full h-9 px-2 box-border focus-visible:border-[var(--sig-accent)]";
-const selectContentClass =
-	"font-mono text-[11px] bg-[var(--sig-bg)] text-[var(--sig-text)] border-[var(--sig-border-strong)] rounded-md";
-const selectItemClass = "font-mono text-[11px] rounded-md";
+const { configFiles, memoryStats, daemonStatus, harnesses = [], onnavigate }: Props = $props();
 
-const PROVIDERS: Array<{ value: PipelineProviderChoice; label: string; model: string; note: string }> = [
+const PROVIDERS: ProviderOption[] = [
 	{
 		value: "acpx",
-		label: "ACPX — use existing agent CLI",
-		model: "gpt-5-codex-mini",
-		note: "Best default if Codex/Claude/OpenCode is already configured.",
+		label: "ACPX",
+		detail: "Route extraction through a selected installed agent harness.",
+		mode: "agent",
 	},
 	{
 		value: "llama-cpp",
-		label: "llama.cpp — local",
-		model: "qwen3.5:4b",
-		note: "Local extraction; needs a llama.cpp server.",
+		label: "llama.cpp",
+		detail: "Use a local llama.cpp OpenAI-compatible server.",
+		mode: "local",
+		endpointPlaceholder: "http://127.0.0.1:8080/v1",
 	},
 	{
 		value: "ollama",
-		label: "Ollama — local",
-		model: "qwen3:4b",
-		note: "Local extraction; needs Ollama and the model installed.",
+		label: "Ollama",
+		detail: "Use an Ollama daemon running on this machine or LAN.",
+		mode: "local",
+		endpointPlaceholder: "http://127.0.0.1:11434",
+	},
+	{
+		value: "claude-code",
+		label: "Claude Code",
+		detail: "Call the local Claude Code CLI directly for extraction.",
+		mode: "agent",
+	},
+	{
+		value: "codex",
+		label: "Codex",
+		detail: "Call the local Codex CLI directly for extraction.",
+		mode: "agent",
+	},
+	{
+		value: "opencode",
+		label: "OpenCode",
+		detail: "Use OpenCode as the extraction backend.",
+		mode: "agent",
+	},
+	{
+		value: "anthropic",
+		label: "Anthropic API",
+		detail: "Use Anthropic directly with configured secrets.",
+		mode: "api",
+		endpointPlaceholder: "https://api.anthropic.com",
+	},
+	{
+		value: "openrouter",
+		label: "OpenRouter",
+		detail: "Use OpenRouter with configured secrets.",
+		mode: "api",
+		endpointPlaceholder: "https://openrouter.ai/api/v1",
+	},
+	{
+		value: "command",
+		label: "Command",
+		detail: "Use a custom command provider configured in advanced settings.",
+		mode: "custom",
 	},
 	{
 		value: "none",
-		label: "Disable background extraction",
-		model: "",
-		note: "Safe choice for VPS/shared installs or testing the shell only.",
+		label: "Off",
+		detail: "Leave extraction disabled for now; configure it later.",
+		mode: "off",
 	},
 ];
+
+const MODEL_PRESETS: Partial<Record<PipelineProviderChoice, string[]>> = {
+	acpx: ["gpt-5-codex-mini", "gpt-5-codex", "claude-haiku-4-5"],
+	"llama-cpp": ["qwen3.5:4b", "qwen3:8b", "llama-3.1-8b"],
+	ollama: ["qwen3:4b", "qwen3:8b", "glm-4.7-flash"],
+	"claude-code": ["haiku", "sonnet", "opus"],
+	codex: ["gpt-5-codex-mini", "gpt-5-codex", "gpt-5.4"],
+	opencode: ["anthropic/claude-haiku-4-5-20251001", "google/gemini-2.5-flash"],
+	anthropic: ["haiku", "sonnet", "opus"],
+	openrouter: ["openai/gpt-4o-mini", "anthropic/claude-haiku-4-5-20251001"],
+};
 
 let open = $state(false);
 let initialized = $state(false);
@@ -60,13 +116,33 @@ let agentName = $state("My Agent");
 let agentDescription = $state("Personal AI assistant");
 let provider = $state<PipelineProviderChoice>("acpx");
 let model = $state("gpt-5-codex-mini");
+let endpoint = $state("");
+let selectedHarness = $state("");
+let selectedHarnesses = $state<string[]>([]);
+let synthesisEnabled = $state(true);
+// biome-ignore lint/style/useConst: Svelte state is mutated by onboarding buttons.
+let afterSaveTab = $state<TabId | "stay" | "sources">("sources");
 let forceOpen = false;
 
 const storageKey = $derived(`signet:onboarding:dismissed:${daemonStatus?.agentsDir ?? "unknown"}`);
-const providerNote = $derived(PROVIDERS.find((option) => option.value === provider)?.note ?? "");
+const providerOption = $derived(PROVIDERS.find((option) => option.value === provider) ?? PROVIDERS[0]);
+const harnessOptions = $derived.by(() => {
+	const fromApi = harnesses.map((h) => h.id || h.name).filter(Boolean);
+	const combined = [...new Set([...fromApi, ...KNOWN_HARNESSES])];
+	return combined.map((id) => ({
+		id,
+		meta: harnesses.find((h) => h.id === id || h.name === id),
+	}));
+});
+const selectedProviderModels = $derived(MODEL_PRESETS[provider] ?? []);
+const needsEndpoint = $derived(providerOption.mode === "local" || providerOption.mode === "api");
+
+function readPipelineString(...path: string[]): string {
+	return st.aStr(["memory", "pipelineV2", ...path]);
+}
 
 function currentProvider(): PipelineProviderChoice {
-	const raw = st.aStr(["memory", "pipelineV2", "extractionProvider"]);
+	const raw = readPipelineString("extractionProvider") || readPipelineString("extraction", "provider");
 	return PROVIDERS.some((option) => option.value === raw) ? (raw as PipelineProviderChoice) : "acpx";
 }
 
@@ -76,9 +152,19 @@ function hydrateFromSettings(): void {
 	agentDescription = st.aStr(["agent", "description"]) || st.aStr(["description"]) || "Personal AI assistant";
 	provider = currentProvider();
 	model =
-		st.aStr(["memory", "pipelineV2", "extractionModel"]) ||
-		PROVIDERS.find((option) => option.value === provider)?.model ||
+		readPipelineString("extractionModel") ||
+		readPipelineString("extraction", "model") ||
+		defaultPipelineModel(provider);
+	endpoint =
+		readPipelineString("extraction", "endpoint") ||
+		readPipelineString("extractionEndpoint") ||
+		readPipelineString("extractionBaseUrl") ||
 		"";
+	selectedHarness = readPipelineString("extraction", "harness") || "";
+	selectedHarnesses = st.harnessArray();
+	if (selectedHarnesses.length === 0 && harnessOptions.length > 0) selectedHarnesses = [harnessOptions[0].id];
+	if (!selectedHarness && selectedHarnesses.length > 0) selectedHarness = selectedHarnesses[0];
+	synthesisEnabled = provider !== "none";
 	initialized = true;
 }
 
@@ -106,6 +192,9 @@ onMount(() => {
 
 $effect(() => {
 	const _configFiles = configFiles;
+	const _harnesses = harnesses;
+	void _configFiles;
+	void _harnesses;
 	untrack(hydrateFromSettings);
 });
 
@@ -117,14 +206,25 @@ $effect(() => {
 	maybeOpen();
 });
 
-function setProvider(value: string | undefined): void {
-	const next = PROVIDERS.find((option) => option.value === value);
-	if (!next) return;
-	provider = next.value;
-	model = next.model;
+function chooseProvider(next: PipelineProviderChoice): void {
+	provider = next;
+	model = MODEL_PRESETS[next]?.[0] ?? defaultPipelineModel(next);
+	endpoint = PROVIDERS.find((option) => option.value === next)?.endpointPlaceholder ?? "";
+	if (next === "none") endpoint = "";
+}
+
+function toggleHarness(id: string, checked: boolean | string): void {
+	if (checked) {
+		selectedHarnesses = [...new Set([...selectedHarnesses, id])];
+		if (!selectedHarness) selectedHarness = id;
+		return;
+	}
+	selectedHarnesses = selectedHarnesses.filter((h) => h !== id);
+	if (selectedHarness === id) selectedHarness = selectedHarnesses[0] ?? "";
 }
 
 function dismiss(): void {
+	forceOpen = false;
 	localStorage.setItem(storageKey, "true");
 	open = false;
 }
@@ -134,19 +234,39 @@ function openSettings(): void {
 	onnavigate?.("settings");
 }
 
+async function persistOnboardingConfig(): Promise<void> {
+	if (st.agentFile) {
+		await st.save();
+		return;
+	}
+	const result = await saveConfigFileResult("agent.yaml", stringify(st.agent));
+	if (!result.ok) throw new Error(result.error ?? `Failed to create agent.yaml (${result.status})`);
+	st.agentSnapshot = JSON.stringify(st.agent);
+}
+
 async function finish(): Promise<void> {
 	if (saving) return;
 	saving = true;
 	try {
 		st.aSetStr(["agent", "name"], agentName.trim() || "My Agent");
 		st.aSetStr(["agent", "description"], agentDescription.trim() || "Personal AI assistant");
-		applyRecommendedPipelineSetup(st.agent, { provider, model });
+		st.set(st.agent, ["harnesses"], selectedHarnesses);
+		applyRecommendedPipelineSetup(st.agent, {
+			provider,
+			model,
+			endpoint: needsEndpoint ? endpoint : "",
+			acpxHarness: provider === "acpx" ? selectedHarness : "",
+			synthesisEnabled,
+		});
 		st.agent = { ...st.agent };
-		await st.save();
+		await persistOnboardingConfig();
+		forceOpen = false;
 		localStorage.setItem(storageKey, "true");
 		open = false;
 		await invalidateAll();
-		toast("Onboarding settings saved", "success");
+		toast("Onboarding saved", "success");
+		if (afterSaveTab === "sources") onnavigate?.("sources");
+		else if (afterSaveTab !== "stay") onnavigate?.(afterSaveTab);
 	} finally {
 		saving = false;
 	}
@@ -156,56 +276,144 @@ async function finish(): Promise<void> {
 {#if open}
 	<div class="onboarding-backdrop" role="presentation">
 		<div class="onboarding-modal" role="dialog" aria-modal="true" aria-labelledby="onboarding-title" tabindex="-1">
-			<div class="onboarding-rail" aria-hidden="true"></div>
 			<header class="onboarding-header">
 				<div>
-					<p class="onboarding-kicker">First run</p>
-					<h2 id="onboarding-title">Set up your Signet workspace</h2>
+					<p class="eyebrow">Dashboard onboarding</p>
+					<h2 id="onboarding-title">Bring this agent online</h2>
+					<p class="lede">Name the agent, choose the harnesses it should sync into, and wire the memory pipeline to something real.</p>
 				</div>
 				<button class="icon-button" type="button" aria-label="Dismiss onboarding" onclick={dismiss}>×</button>
 			</header>
 
-			<div class="onboarding-grid">
-				<label class="field">
-					<span>Agent name</span>
-					<Input bind:value={agentName} placeholder="My Agent" />
-				</label>
+			<div class="onboarding-body">
+				<section class="setup-panel identity-panel">
+					<div class="section-head">
+						<span class="step">01</span>
+						<div>
+							<h3>Identity</h3>
+							<p>What should harnesses call this agent?</p>
+						</div>
+					</div>
+					<div class="field-grid">
+						<label class="field">
+							<span>Name</span>
+							<Input bind:value={agentName} placeholder="Dot" />
+						</label>
+						<label class="field field-wide">
+							<span>Description</span>
+							<Textarea rows={3} bind:value={agentDescription} placeholder="A portable memory agent for..." />
+						</label>
+					</div>
+				</section>
 
-				<label class="field">
-					<span>Agent description</span>
-					<Input bind:value={agentDescription} placeholder="Personal AI assistant" />
-				</label>
+				<section class="setup-panel">
+					<div class="section-head">
+						<span class="step">02</span>
+						<div>
+							<h3>Harnesses</h3>
+							<p>Loaded from the daemon. Pick every surface Signet should keep configured.</p>
+						</div>
+					</div>
+					<div class="harness-list">
+						{#each harnessOptions as h (h.id)}
+							<label class="harness-row" class:harness-row-active={selectedHarnesses.includes(h.id)}>
+								<Checkbox checked={selectedHarnesses.includes(h.id)} onCheckedChange={(checked) => toggleHarness(h.id, checked)} />
+								<span class="status-dot" class:status-dot-installed={h.meta?.exists}></span>
+								<span class="harness-main">
+									<strong>{h.id}</strong>
+									<small>{h.meta?.path ?? "known harness"}</small>
+								</span>
+								<span class="harness-state">{h.meta?.exists ? "installed" : "not found"}</span>
+							</label>
+						{/each}
+					</div>
+				</section>
 
-				<div class="field field-wide">
-					<span>Memory extraction provider</span>
-					<Select.Root type="single" value={provider} onValueChange={setProvider}>
-						<Select.Trigger class={selectTriggerClass}>
-							{PROVIDERS.find((option) => option.value === provider)?.label ?? provider}
-						</Select.Trigger>
-						<Select.Content class={selectContentClass}>
-							{#each PROVIDERS as option (option.value)}
-								<Select.Item class={selectItemClass} value={option.value} label={option.label} />
-							{/each}
-						</Select.Content>
-					</Select.Root>
-					<small>{providerNote}</small>
-				</div>
+				<section class="setup-panel setup-panel-wide">
+					<div class="section-head">
+						<span class="step">03</span>
+						<div>
+							<h3>Memory engine</h3>
+							<p>Choose the extraction provider. Provider-specific fields appear below.</p>
+						</div>
+					</div>
 
-				<label class="field field-wide">
-					<span>Model</span>
-					<Input bind:value={model} placeholder={provider === "none" ? "disabled" : "model id"} disabled={provider === "none"} />
-				</label>
-			</div>
+					<div class="provider-grid">
+						{#each PROVIDERS as option (option.value)}
+							<button type="button" class="provider-card" class:provider-card-active={provider === option.value} onclick={() => chooseProvider(option.value)}>
+								<span>{option.label}</span>
+								<small>{option.detail}</small>
+							</button>
+						{/each}
+					</div>
 
-			<div class="onboarding-copy">
-				<p>These choices write the existing <code>agent.yaml</code> identity and <code>memory.pipelineV2</code> provider settings. No separate dashboard-only ACPX routing gets created.</p>
+					<div class="provider-detail">
+						<div class="detail-banner">
+							<span>{providerOption.mode}</span>
+							<p>{providerOption.detail}</p>
+						</div>
+
+						{#if provider === "acpx"}
+							<div class="field field-wide">
+								<span>ACPX harness</span>
+								<div class="choice-row">
+									{#each selectedHarnesses as h (h)}
+										<button type="button" class="choice-pill" class:choice-pill-active={selectedHarness === h} onclick={() => { selectedHarness = h; }}>{h}</button>
+									{/each}
+									{#if selectedHarnesses.length === 0}<small>Select at least one harness above.</small>{/if}
+								</div>
+							</div>
+						{/if}
+
+						<div class="field-grid">
+							<label class="field">
+								<span>Model</span>
+								<Input bind:value={model} placeholder="model id" disabled={provider === "none"} />
+							</label>
+							{#if needsEndpoint}
+								<label class="field">
+									<span>Endpoint URL</span>
+									<Input bind:value={endpoint} placeholder={providerOption.endpointPlaceholder ?? "https://..."} />
+								</label>
+							{/if}
+						</div>
+
+						{#if selectedProviderModels.length > 0 && provider !== "none"}
+							<div class="choice-row">
+								{#each selectedProviderModels as preset (preset)}
+									<button type="button" class="choice-pill" class:choice-pill-active={model === preset} onclick={() => { model = preset; }}>{preset}</button>
+								{/each}
+							</div>
+						{/if}
+
+						<label class="inline-toggle">
+							<Checkbox checked={synthesisEnabled} onCheckedChange={(checked) => { synthesisEnabled = !!checked; }} />
+							<span>Use the same provider for session synthesis</span>
+						</label>
+					</div>
+				</section>
+
+				<section class="setup-panel setup-panel-wide next-panel">
+					<div class="section-head">
+						<span class="step">04</span>
+						<div>
+							<h3>Next step</h3>
+							<p>After saving, continue to the surface that actually brings context in.</p>
+						</div>
+					</div>
+					<div class="choice-row">
+						<button type="button" class="choice-pill" class:choice-pill-active={afterSaveTab === "sources"} onclick={() => { afterSaveTab = "sources"; }}>Connect sources</button>
+						<button type="button" class="choice-pill" class:choice-pill-active={afterSaveTab === "settings"} onclick={() => { afterSaveTab = "settings"; }}>Review settings</button>
+						<button type="button" class="choice-pill" class:choice-pill-active={afterSaveTab === "stay"} onclick={() => { afterSaveTab = "stay"; }}>Stay here</button>
+					</div>
+				</section>
 			</div>
 
 			<footer class="onboarding-actions">
 				<Button variant="ghost" type="button" onclick={openSettings}>Open full settings</Button>
 				<div class="action-cluster">
-					<Button variant="outline" type="button" onclick={dismiss}>Skip for now</Button>
-					<Button type="button" onclick={finish} disabled={saving}>{saving ? "Saving…" : "Save and start"}</Button>
+					<Button variant="outline" type="button" onclick={dismiss}>Skip</Button>
+					<Button type="button" onclick={finish} disabled={saving}>{saving ? "Saving…" : "Save onboarding"}</Button>
 				</div>
 			</footer>
 		</div>
@@ -219,82 +427,143 @@ async function finish(): Promise<void> {
 		z-index: 90;
 		display: grid;
 		place-items: center;
-		padding: 24px;
-		background:
-			linear-gradient(135deg, color-mix(in srgb, var(--sig-bg), transparent 8%), color-mix(in srgb, var(--sig-bg), transparent 24%)),
-			rgba(0, 0, 0, 0.55);
-		backdrop-filter: blur(8px);
+		padding: 22px;
+		background: color-mix(in srgb, var(--sig-bg), transparent 18%);
+		backdrop-filter: blur(2px);
 	}
 
 	.onboarding-modal {
-		position: relative;
-		width: min(720px, 100%);
+		width: min(1040px, 100%);
+		max-height: min(880px, calc(100vh - 44px));
+		display: flex;
+		flex-direction: column;
 		border: 1px solid var(--sig-border-strong);
-		border-radius: 0;
-		background: color-mix(in srgb, var(--sig-surface), var(--sig-bg) 18%);
-		box-shadow: 0 24px 80px rgba(0, 0, 0, 0.5);
+		background: var(--sig-bg);
+		box-shadow: 0 0 0 1px var(--sig-bg), 0 20px 70px rgba(0, 0, 0, 0.55);
 		overflow: hidden;
-	}
-
-	.onboarding-rail {
-		position: absolute;
-		inset: 0 auto 0 0;
-		width: 4px;
-		background: var(--sig-highlight);
-		box-shadow: 0 0 24px color-mix(in srgb, var(--sig-highlight), transparent 40%);
 	}
 
 	.onboarding-header {
 		display: flex;
 		align-items: flex-start;
 		justify-content: space-between;
-		gap: 16px;
-		padding: 22px 24px 16px 28px;
-		border-bottom: 1px solid var(--sig-border);
+		gap: 18px;
+		padding: 20px 22px 18px;
+		border-bottom: 1px solid var(--sig-border-strong);
+		background: linear-gradient(90deg, color-mix(in srgb, var(--sig-surface-raised), var(--sig-highlight) 4%), var(--sig-bg));
 	}
 
-	.onboarding-kicker,
-	.field > span {
-		margin: 0 0 6px;
+	.eyebrow,
+	.field > span,
+	.step,
+	.harness-state {
 		font-family: var(--font-mono, monospace);
 		font-size: 10px;
-		letter-spacing: 0.14em;
+		letter-spacing: 0.13em;
 		text-transform: uppercase;
 		color: var(--sig-highlight);
 	}
 
-	h2 {
+	.eyebrow,
+	h2,
+	.lede,
+	h3,
+	.section-head p {
 		margin: 0;
-		font-family: var(--font-heading, inherit);
-		font-size: 24px;
-		letter-spacing: -0.02em;
+	}
+
+	h2 {
+		margin-top: 4px;
+		font-family: var(--font-display, var(--font-heading, inherit));
+		font-size: clamp(28px, 4vw, 44px);
+		line-height: 0.95;
+		letter-spacing: -0.04em;
 		color: var(--sig-text-bright);
+		text-transform: uppercase;
+	}
+
+	.lede {
+		max-width: 680px;
+		margin-top: 10px;
+		font-size: 14px;
+		line-height: 1.5;
+		color: var(--sig-text);
 	}
 
 	.icon-button {
+		width: 38px;
+		height: 38px;
 		border: 1px solid var(--sig-border-strong);
-		background: transparent;
-		color: var(--sig-text-muted);
-		font-size: 20px;
-		line-height: 1;
-		width: 32px;
-		height: 32px;
+		background: var(--sig-surface-raised);
+		color: var(--sig-text);
+		font-size: 22px;
 		cursor: pointer;
 	}
 
-	.icon-button:hover {
-		color: var(--sig-text-bright);
-		border-color: var(--sig-highlight);
+	.onboarding-body {
+		display: grid;
+		grid-template-columns: minmax(260px, 0.9fr) minmax(380px, 1.4fr);
+		gap: 12px;
+		padding: 14px;
+		overflow: auto;
 	}
 
-	.onboarding-grid {
+	.setup-panel {
+		border: 1px solid var(--sig-border);
+		background: var(--sig-surface);
+		padding: 14px;
+	}
+
+	.setup-panel-wide {
+		grid-column: 2;
+	}
+
+	.identity-panel {
+		grid-row: span 1;
+	}
+
+	.section-head {
+		display: flex;
+		gap: 11px;
+		align-items: flex-start;
+		margin-bottom: 12px;
+	}
+
+	.step {
+		display: inline-grid;
+		place-items: center;
+		width: 30px;
+		height: 30px;
+		border: 1px solid var(--sig-border-strong);
+		background: var(--sig-bg);
+		color: var(--sig-text-bright);
+	}
+
+	h3 {
+		font-family: var(--font-display, inherit);
+		font-size: 18px;
+		letter-spacing: 0.02em;
+		color: var(--sig-text-bright);
+		text-transform: uppercase;
+	}
+
+	.section-head p,
+	.provider-card small,
+	.harness-main small,
+	.detail-banner p {
+		font-size: 12px;
+		line-height: 1.4;
+		color: var(--sig-text-muted);
+	}
+
+	.field-grid {
 		display: grid;
 		grid-template-columns: repeat(2, minmax(0, 1fr));
-		gap: 14px;
-		padding: 20px 24px 10px 28px;
+		gap: 12px;
 	}
 
-	.field {
+	.field,
+	.harness-main {
 		display: flex;
 		flex-direction: column;
 		gap: 6px;
@@ -304,23 +573,136 @@ async function finish(): Promise<void> {
 		grid-column: 1 / -1;
 	}
 
-	small {
-		font-size: 11px;
-		line-height: 1.4;
-		color: var(--sig-text-muted);
+	.harness-list,
+	.provider-detail {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
 	}
 
-	.onboarding-copy {
-		padding: 4px 24px 0 28px;
-		font-size: 12px;
-		line-height: 1.55;
-		color: var(--sig-text-muted);
+	.harness-row {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 10px;
+		border: 1px solid var(--sig-border);
+		background: var(--sig-bg);
+		cursor: pointer;
 	}
 
-	code {
+	.harness-row-active {
+		border-color: var(--sig-border-strong);
+		background: color-mix(in srgb, var(--sig-surface-raised), var(--sig-highlight) 5%);
+	}
+
+	.status-dot {
+		width: 8px;
+		height: 8px;
+		border: 1px solid var(--sig-text-muted);
+		background: transparent;
+	}
+
+	.status-dot-installed {
+		border-color: var(--sig-success);
+		background: var(--sig-success);
+	}
+
+	.harness-main {
+		min-width: 0;
+		flex: 1;
+	}
+
+	.harness-main strong {
+		font-size: 13px;
+		color: var(--sig-text-bright);
+	}
+
+	.harness-main small {
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+	}
+
+	.provider-grid {
+		display: grid;
+		grid-template-columns: repeat(5, minmax(0, 1fr));
+		gap: 8px;
+		margin-bottom: 12px;
+	}
+
+	.provider-card {
+		min-height: 92px;
+		padding: 10px;
+		text-align: left;
+		border: 1px solid var(--sig-border);
+		background: var(--sig-bg);
+		color: var(--sig-text);
+		cursor: pointer;
+	}
+
+	.provider-card span {
+		display: block;
+		margin-bottom: 7px;
+		font-family: var(--font-display, inherit);
+		font-size: 13px;
+		text-transform: uppercase;
+		color: var(--sig-text-bright);
+	}
+
+	.provider-card-active {
+		border-color: var(--sig-highlight);
+		background: color-mix(in srgb, var(--sig-bg), var(--sig-highlight) 9%);
+		box-shadow: inset 3px 0 0 var(--sig-highlight);
+	}
+
+	.detail-banner {
+		display: flex;
+		gap: 12px;
+		align-items: center;
+		padding: 10px 12px;
+		border: 1px solid var(--sig-border-strong);
+		background: var(--sig-surface-raised);
+	}
+
+	.detail-banner span {
+		font-family: var(--font-mono, monospace);
+		font-size: 10px;
+		text-transform: uppercase;
+		color: var(--sig-highlight);
+	}
+
+	.choice-row {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+	}
+
+	.choice-pill {
+		border: 1px solid var(--sig-border);
+		background: var(--sig-bg);
+		color: var(--sig-text);
+		padding: 7px 10px;
 		font-family: var(--font-mono, monospace);
 		font-size: 11px;
-		color: var(--sig-highlight);
+		cursor: pointer;
+	}
+
+	.choice-pill-active {
+		border-color: var(--sig-highlight);
+		color: var(--sig-text-bright);
+		background: color-mix(in srgb, var(--sig-bg), var(--sig-highlight) 8%);
+	}
+
+	.inline-toggle {
+		display: flex;
+		align-items: center;
+		gap: 9px;
+		font-size: 12px;
+		color: var(--sig-text);
+	}
+
+	.next-panel {
+		background: color-mix(in srgb, var(--sig-surface), var(--sig-highlight) 3%);
 	}
 
 	.onboarding-actions {
@@ -328,7 +710,9 @@ async function finish(): Promise<void> {
 		align-items: center;
 		justify-content: space-between;
 		gap: 12px;
-		padding: 18px 24px 22px 28px;
+		padding: 14px;
+		border-top: 1px solid var(--sig-border-strong);
+		background: var(--sig-surface);
 	}
 
 	.action-cluster {
@@ -336,18 +720,15 @@ async function finish(): Promise<void> {
 		gap: 10px;
 	}
 
-	@media (max-width: 640px) {
-		.onboarding-grid {
+	@media (max-width: 900px) {
+		.onboarding-body,
+		.field-grid,
+		.provider-grid {
 			grid-template-columns: 1fr;
 		}
 
-		.onboarding-actions {
-			align-items: stretch;
-			flex-direction: column-reverse;
-		}
-
-		.action-cluster {
-			flex-direction: column;
+		.setup-panel-wide {
+			grid-column: auto;
 		}
 	}
 </style>

--- a/surfaces/dashboard/src/lib/components/onboarding/OnboardingModal.svelte
+++ b/surfaces/dashboard/src/lib/components/onboarding/OnboardingModal.svelte
@@ -1,227 +1,213 @@
 <script lang="ts">
-	import { invalidateAll } from "$app/navigation";
-	import { type ConfigFile, type DaemonStatus, type Harness, type MemoryStats, saveConfigFileResult } from "$lib/api";
-	import { Button } from "$lib/components/ui/button/index.js";
-	import { applyRecommendedPipelineSetup, resolveSynthesisEnabled } from "$lib/components/tabs/settings/pipeline-settings";
-	import { KNOWN_HARNESSES, st } from "$lib/stores/settings.svelte";
-	import { toast } from "$lib/stores/toast.svelte";
-	import type { TabId } from "$lib/stores/navigation.svelte";
-	import { defaultPipelineModel, type PipelineProviderChoice } from "@signet/core/pipeline-providers";
-	import { onMount, untrack } from "svelte";
-	import { fly } from "svelte/transition";
-	import { stringify } from "yaml";
-	import {
-		type OnboardingState,
-		type EmbeddingProvider,
-		type IdentityPresetName,
-		EMBEDDING_PROVIDER_OPTIONS,
-		EXTRACTION_PROVIDER_OPTIONS,
-		EXTRACTION_MODEL_PRESETS,
-		createDefaultState,
-	} from "./onboarding-state.svelte";
-	import WelcomeStep from "./steps/WelcomeStep.svelte";
-	import IdentityStep from "./steps/IdentityStep.svelte";
-	import EmbeddingStep from "./steps/EmbeddingStep.svelte";
-	import ExtractionStep from "./steps/ExtractionStep.svelte";
-	import ReviewStep from "./steps/ReviewStep.svelte";
+import { invalidateAll } from "$app/navigation";
+import { type ConfigFile, type DaemonStatus, type Harness, type MemoryStats, saveConfigFileResult } from "$lib/api";
+import { resolveSynthesisEnabled } from "$lib/components/tabs/settings/pipeline-settings";
+import { Button } from "$lib/components/ui/button/index.js";
+import type { TabId } from "$lib/stores/navigation.svelte";
+import { KNOWN_HARNESSES, st } from "$lib/stores/settings.svelte";
+import { toast } from "$lib/stores/toast.svelte";
+import { type PipelineProviderChoice, defaultPipelineModel } from "@signet/core/pipeline-providers";
+import { onMount, untrack } from "svelte";
+import { fly } from "svelte/transition";
+import { stringify } from "yaml";
+import {
+	applyOnboardingConfig,
+	defaultIdentityFileContent,
+	missingIdentityFiles,
+	validateOnboardingState,
+	validateOnboardingStep,
+} from "./onboarding-config";
+import {
+	EMBEDDING_PROVIDER_OPTIONS,
+	EXTRACTION_PROVIDER_OPTIONS,
+	type EmbeddingProvider,
+	type IdentityPresetName,
+	type OnboardingState,
+	createDefaultState,
+} from "./onboarding-state.svelte";
+import EmbeddingStep from "./steps/EmbeddingStep.svelte";
+import ExtractionStep from "./steps/ExtractionStep.svelte";
+import IdentityStep from "./steps/IdentityStep.svelte";
+import ReviewStep from "./steps/ReviewStep.svelte";
+import WelcomeStep from "./steps/WelcomeStep.svelte";
 
-	interface Props {
-		configFiles: ConfigFile[];
-		memoryStats: MemoryStats;
-		daemonStatus: DaemonStatus | null;
-		harnesses?: Harness[];
-		onnavigate?: (tab: TabId) => void;
+interface Props {
+	configFiles: ConfigFile[];
+	memoryStats: MemoryStats;
+	daemonStatus: DaemonStatus | null;
+	harnesses?: Harness[];
+	onnavigate?: (tab: TabId) => void;
+}
+
+const { configFiles, memoryStats, daemonStatus, harnesses = [], onnavigate }: Props = $props();
+
+const STEPS = [
+	{ number: "01", title: "Welcome", subtitle: "Choose an identity preset for your agent." },
+	{ number: "02", title: "Identity", subtitle: "Name your agent and select harnesses." },
+	{ number: "03", title: "Embeddings", subtitle: "Configure vector search for semantic recall." },
+	{ number: "04", title: "Extraction", subtitle: "Pick an extraction route for the memory pipeline." },
+	{ number: "05", title: "Review", subtitle: "Confirm your choices before saving." },
+];
+
+let open = $state(false);
+let initialized = $state(false);
+let forceOpen = false;
+let direction = $state<1 | -1>(1);
+const obState = $state<OnboardingState>(createDefaultState());
+
+const storageKey = $derived(`signet:onboarding:dismissed:${daemonStatus?.agentsDir ?? "unknown"}`);
+
+function readPipelineString(...path: string[]): string {
+	return st.aStr(["memory", "pipelineV2", ...path]);
+}
+
+function hydrateFromSettings(): void {
+	st.init(configFiles);
+	obState.agentName = st.aStr(["agent", "name"]) || st.aStr(["name"]) || "My Agent";
+	obState.agentDescription = st.aStr(["agent", "description"]) || st.aStr(["description"]) || "Personal AI assistant";
+	obState.identityPreset = (st.aStr(["identity", "preset"]) || "minimal") as IdentityPresetName;
+
+	const harnessFromApi = harnesses.map((h) => h.id || h.name).filter(Boolean);
+	const combined = [...new Set([...harnessFromApi, ...KNOWN_HARNESSES])];
+	obState.selectedHarnesses = st.harnessArray();
+	if (obState.selectedHarnesses.length === 0 && combined.length > 0) {
+		obState.selectedHarnesses = [combined[0]];
 	}
+	obState.selectedHarness = obState.selectedHarnesses[0] ?? "";
 
-	const { configFiles, memoryStats, daemonStatus, harnesses = [], onnavigate }: Props = $props();
+	const embProvider = st.sStr([...st.embPath(), "provider"]) || "native";
+	obState.embeddingProvider = EMBEDDING_PROVIDER_OPTIONS.some((o) => o.value === embProvider)
+		? (embProvider as EmbeddingProvider)
+		: "native";
+	obState.embeddingModel =
+		st.sStr([...st.embPath(), "model"]) ||
+		(EMBEDDING_PROVIDER_OPTIONS.find((o) => o.value === obState.embeddingProvider)?.defaultModel ?? "");
+	obState.embeddingEndpoint = st.sStr([...st.embPath(), "base_url"]) || st.sStr([...st.embPath(), "baseurl"]) || "";
 
-	const STEPS = [
-		{ number: "01", title: "Welcome", subtitle: "Choose an identity preset for your agent." },
-		{ number: "02", title: "Identity", subtitle: "Name your agent and select harnesses." },
-		{ number: "03", title: "Embeddings", subtitle: "Configure vector search for semantic recall." },
-		{ number: "04", title: "Extraction", subtitle: "Pick an extraction route for the memory pipeline." },
-		{ number: "05", title: "Review", subtitle: "Confirm your choices before saving." },
-	];
+	const rawProvider = readPipelineString("extractionProvider") || readPipelineString("extraction", "provider");
+	obState.extractionProvider = EXTRACTION_PROVIDER_OPTIONS.some((o) => o.value === rawProvider)
+		? (rawProvider as PipelineProviderChoice)
+		: "acpx";
+	obState.extractionModel =
+		readPipelineString("extractionModel") ||
+		readPipelineString("extraction", "model") ||
+		defaultPipelineModel(obState.extractionProvider);
+	obState.extractionEndpoint =
+		readPipelineString("extraction", "endpoint") ||
+		readPipelineString("extractionEndpoint") ||
+		readPipelineString("extractionBaseUrl") ||
+		"";
+	obState.synthesisEnabled = resolveSynthesisEnabled(st.agent);
+	initialized = true;
+}
 
-	let open = $state(false);
-	let initialized = $state(false);
-	let forceOpen = false;
-	let direction = $state<1 | -1>(1);
-	let obState = $state<OnboardingState>(createDefaultState());
+function isDefaultishWorkspace(): boolean {
+	const name = obState.agentName.trim().toLowerCase();
+	return memoryStats.total === 0 && (name === "my agent" || name.length === 0);
+}
 
-	const storageKey = $derived(`signet:onboarding:dismissed:${daemonStatus?.agentsDir ?? "unknown"}`);
-
-	function readPipelineString(...path: string[]): string {
-		return st.aStr(["memory", "pipelineV2", ...path]);
+function maybeOpen(): void {
+	if (typeof window === "undefined") return;
+	if (!initialized || !daemonStatus) return;
+	if (forceOpen) {
+		open = true;
+		return;
 	}
+	if (localStorage.getItem(storageKey) === "true") return;
+	if (isDefaultishWorkspace()) open = true;
+}
 
-	function hydrateFromSettings(): void {
-		st.init(configFiles);
-		obState.agentName = st.aStr(["agent", "name"]) || st.aStr(["name"]) || "My Agent";
-		obState.agentDescription = st.aStr(["agent", "description"]) || st.aStr(["description"]) || "Personal AI assistant";
-		obState.identityPreset = (st.aStr(["identity", "preset"]) || "minimal") as IdentityPresetName;
+onMount(() => {
+	forceOpen = new URLSearchParams(window.location.search).get("onboarding") === "1";
+	untrack(hydrateFromSettings);
+	maybeOpen();
+});
 
-		const harnessFromApi = harnesses.map((h) => h.id || h.name).filter(Boolean);
-		const combined = [...new Set([...harnessFromApi, ...KNOWN_HARNESSES])];
-		obState.selectedHarnesses = st.harnessArray();
-		if (obState.selectedHarnesses.length === 0 && combined.length > 0) {
-			obState.selectedHarnesses = [combined[0]];
-		}
-		obState.selectedHarness = obState.selectedHarnesses[0] ?? "";
+$effect(() => {
+	const _configFiles = configFiles;
+	const _harnesses = harnesses;
+	void _configFiles;
+	void _harnesses;
+	untrack(hydrateFromSettings);
+});
 
-		const embProvider = st.sStr([...st.embPath(), "provider"]) || "native";
-		obState.embeddingProvider = EMBEDDING_PROVIDER_OPTIONS.some((o) => o.value === embProvider) ? embProvider as EmbeddingProvider : "native";
-		obState.embeddingModel =
-			st.sStr([...st.embPath(), "model"]) ||
-			(EMBEDDING_PROVIDER_OPTIONS.find((o) => o.value === obState.embeddingProvider)?.defaultModel ?? "");
-		obState.embeddingEndpoint = st.sStr([...st.embPath(), "base_url"]) || st.sStr([...st.embPath(), "baseurl"]) || "";
+$effect(() => {
+	const _daemonStatus = daemonStatus;
+	const _memoryTotal = memoryStats.total;
+	void _daemonStatus;
+	void _memoryTotal;
+	maybeOpen();
+});
 
-		const rawProvider =
-			readPipelineString("extractionProvider") || readPipelineString("extraction", "provider");
-		obState.extractionProvider = EXTRACTION_PROVIDER_OPTIONS.some((o) => o.value === rawProvider)
-			? (rawProvider as PipelineProviderChoice)
-			: "acpx";
-		obState.extractionModel =
-			readPipelineString("extractionModel") ||
-			readPipelineString("extraction", "model") ||
-			defaultPipelineModel(obState.extractionProvider);
-		obState.extractionEndpoint =
-			readPipelineString("extraction", "endpoint") ||
-			readPipelineString("extractionEndpoint") ||
-			readPipelineString("extractionBaseUrl") ||
-			"";
-		obState.synthesisEnabled = resolveSynthesisEnabled(st.agent);
-		initialized = true;
+function dismiss(): void {
+	forceOpen = false;
+	localStorage.setItem(storageKey, "true");
+	open = false;
+}
+
+function openSettings(): void {
+	dismiss();
+	onnavigate?.("settings");
+}
+
+function nextStep(): void {
+	const errors = validateOnboardingStep(obState, obState.currentStep);
+	if (errors.length > 0) {
+		toast(errors[0], "error");
+		return;
 	}
+	direction = 1;
+	obState.currentStep = Math.min(obState.currentStep + 1, STEPS.length - 1);
+}
 
-	function isDefaultishWorkspace(): boolean {
-		const name = obState.agentName.trim().toLowerCase();
-		return memoryStats.total === 0 && (name === "my agent" || name.length === 0);
+function prevStep(): void {
+	direction = -1;
+	obState.currentStep = Math.max(obState.currentStep - 1, 0);
+}
+
+async function ensureIdentityFiles(): Promise<void> {
+	for (const file of missingIdentityFiles(configFiles, obState.identityPreset)) {
+		const result = await saveConfigFileResult(
+			file,
+			defaultIdentityFileContent(file, obState.agentName.trim() || "My Agent"),
+		);
+		if (!result.ok) throw new Error(result.error ?? `Failed to create ${file} (${result.status})`);
 	}
+}
 
-	function maybeOpen(): void {
-		if (typeof window === "undefined") return;
-		if (!initialized || !daemonStatus) return;
-		if (forceOpen) {
-			open = true;
-			return;
-		}
-		if (localStorage.getItem(storageKey) === "true") return;
-		if (isDefaultishWorkspace()) open = true;
+async function persistOnboardingConfig(): Promise<void> {
+	if (st.agentFile) {
+		await st.save();
+		return;
 	}
+	const result = await saveConfigFileResult("agent.yaml", stringify(st.agent));
+	if (!result.ok) throw new Error(result.error ?? `Failed to create agent.yaml (${result.status})`);
+	st.agentSnapshot = JSON.stringify(st.agent);
+}
 
-	onMount(() => {
-		forceOpen = new URLSearchParams(window.location.search).get("onboarding") === "1";
-		untrack(hydrateFromSettings);
-		maybeOpen();
-	});
-
-	$effect(() => {
-		const _configFiles = configFiles;
-		const _harnesses = harnesses;
-		void _configFiles;
-		void _harnesses;
-		untrack(hydrateFromSettings);
-	});
-
-	$effect(() => {
-		const _daemonStatus = daemonStatus;
-		const _memoryTotal = memoryStats.total;
-		void _daemonStatus;
-		void _memoryTotal;
-		maybeOpen();
-	});
-
-	function dismiss(): void {
-		forceOpen = false;
-		localStorage.setItem(storageKey, "true");
-		open = false;
-	}
-
-	function openSettings(): void {
-		dismiss();
-		onnavigate?.("settings");
-	}
-
-	function validateStep(step: number): string[] {
-		if (step === 1) {
-			const errors: string[] = [];
-			if (!obState.agentName.trim()) errors.push("Agent name is required.");
-			if (obState.selectedHarnesses.length === 0) errors.push("Select at least one harness.");
-			return errors;
-		}
-		if (step === 2) {
-			if (obState.embeddingProvider === "none") return [];
-			if (!obState.embeddingModel.trim()) return ["Embedding model is required."];
-			return [];
-		}
-		if (step === 3) {
-			if (obState.extractionProvider === "none") return [];
-			if (!obState.extractionModel.trim()) return ["Extraction model is required."];
-			return [];
-		}
-		return [];
-	}
-
-	function nextStep(): void {
-		const errors = validateStep(obState.currentStep);
+async function finish(): Promise<void> {
+	if (obState.saving) return;
+	obState.saving = true;
+	try {
+		const errors = validateOnboardingState(obState);
 		if (errors.length > 0) {
 			toast(errors[0], "error");
 			return;
 		}
-		direction = 1;
-		obState.currentStep = Math.min(obState.currentStep + 1, STEPS.length - 1);
+		applyOnboardingConfig(st.agent, obState);
+		st.agent = { ...st.agent };
+		await ensureIdentityFiles();
+		await persistOnboardingConfig();
+		forceOpen = false;
+		localStorage.setItem(storageKey, "true");
+		open = false;
+		await invalidateAll();
+		toast("Setup complete", "success");
+		onnavigate?.("sources");
+	} finally {
+		obState.saving = false;
 	}
-
-	function prevStep(): void {
-		direction = -1;
-		obState.currentStep = Math.max(obState.currentStep - 1, 0);
-	}
-
-	async function persistOnboardingConfig(): Promise<void> {
-		if (st.agentFile) {
-			await st.save();
-			return;
-		}
-		const result = await saveConfigFileResult("agent.yaml", stringify(st.agent));
-		if (!result.ok) throw new Error(result.error ?? `Failed to create agent.yaml (${result.status})`);
-		st.agentSnapshot = JSON.stringify(st.agent);
-	}
-
-	async function finish(): Promise<void> {
-		if (obState.saving) return;
-		obState.saving = true;
-		try {
-			st.aSetStr(["agent", "name"], obState.agentName.trim() || "My Agent");
-			st.aSetStr(["agent", "description"], obState.agentDescription.trim() || "Personal AI assistant");
-			st.aSetStr(["identity", "preset"], obState.identityPreset);
-			st.set(st.agent, ["harnesses"], obState.selectedHarnesses);
-
-			const needsEndpoint = (() => {
-				const mode = EXTRACTION_PROVIDER_OPTIONS.find((o) => o.value === obState.extractionProvider)?.mode;
-				return mode === "local" || mode === "api";
-			})();
-
-			applyRecommendedPipelineSetup(st.agent, {
-				provider: obState.extractionProvider,
-				model: obState.extractionModel,
-				endpoint: needsEndpoint ? obState.extractionEndpoint : "",
-				acpxHarness: obState.extractionProvider === "acpx" ? obState.selectedHarness : "",
-				synthesisEnabled: obState.synthesisEnabled,
-			});
-
-			st.agent = { ...st.agent };
-			await persistOnboardingConfig();
-			forceOpen = false;
-			localStorage.setItem(storageKey, "true");
-			open = false;
-			await invalidateAll();
-			toast("Setup complete", "success");
-			onnavigate?.("sources");
-		} finally {
-			obState.saving = false;
-		}
-	}
+}
 </script>
 
 {#if open}

--- a/surfaces/dashboard/src/lib/components/onboarding/OnboardingModal.svelte
+++ b/surfaces/dashboard/src/lib/components/onboarding/OnboardingModal.svelte
@@ -1,277 +1,227 @@
 <script lang="ts">
-import { invalidateAll } from "$app/navigation";
-import { type ConfigFile, type DaemonStatus, type Harness, type MemoryStats, saveConfigFileResult } from "$lib/api";
-import { applyRecommendedPipelineSetup, resolveSynthesisEnabled } from "$lib/components/tabs/settings/pipeline-settings";
-import { Button } from "$lib/components/ui/button/index.js";
-import { Checkbox } from "$lib/components/ui/checkbox/index.js";
-import { Input } from "$lib/components/ui/input/index.js";
-import { Textarea } from "$lib/components/ui/textarea/index.js";
-import type { TabId } from "$lib/stores/navigation.svelte";
-import { KNOWN_HARNESSES, st } from "$lib/stores/settings.svelte";
-import { toast } from "$lib/stores/toast.svelte";
-import { type PipelineProviderChoice, defaultPipelineModel } from "@signet/core/pipeline-providers";
-import { onMount, untrack } from "svelte";
-import { stringify } from "yaml";
+	import { invalidateAll } from "$app/navigation";
+	import { type ConfigFile, type DaemonStatus, type Harness, type MemoryStats, saveConfigFileResult } from "$lib/api";
+	import { Button } from "$lib/components/ui/button/index.js";
+	import { applyRecommendedPipelineSetup, resolveSynthesisEnabled } from "$lib/components/tabs/settings/pipeline-settings";
+	import { KNOWN_HARNESSES, st } from "$lib/stores/settings.svelte";
+	import { toast } from "$lib/stores/toast.svelte";
+	import type { TabId } from "$lib/stores/navigation.svelte";
+	import { defaultPipelineModel, type PipelineProviderChoice } from "@signet/core/pipeline-providers";
+	import { onMount, untrack } from "svelte";
+	import { fly } from "svelte/transition";
+	import { stringify } from "yaml";
+	import {
+		type OnboardingState,
+		type EmbeddingProvider,
+		type IdentityPresetName,
+		EMBEDDING_PROVIDER_OPTIONS,
+		EXTRACTION_PROVIDER_OPTIONS,
+		EXTRACTION_MODEL_PRESETS,
+		createDefaultState,
+	} from "./onboarding-state.svelte";
+	import WelcomeStep from "./steps/WelcomeStep.svelte";
+	import IdentityStep from "./steps/IdentityStep.svelte";
+	import EmbeddingStep from "./steps/EmbeddingStep.svelte";
+	import ExtractionStep from "./steps/ExtractionStep.svelte";
+	import ReviewStep from "./steps/ReviewStep.svelte";
 
-interface Props {
-	configFiles: ConfigFile[];
-	memoryStats: MemoryStats;
-	daemonStatus: DaemonStatus | null;
-	harnesses?: Harness[];
-	onnavigate?: (tab: TabId) => void;
-}
-
-type ProviderOption = {
-	value: PipelineProviderChoice;
-	label: string;
-	detail: string;
-	mode: "agent" | "local" | "api" | "off" | "custom";
-	endpointPlaceholder?: string;
-};
-
-const { configFiles, memoryStats, daemonStatus, harnesses = [], onnavigate }: Props = $props();
-
-const PROVIDERS: ProviderOption[] = [
-	{
-		value: "acpx",
-		label: "ACPX",
-		detail: "Route extraction through a selected installed agent harness.",
-		mode: "agent",
-	},
-	{
-		value: "llama-cpp",
-		label: "llama.cpp",
-		detail: "Use a local llama.cpp OpenAI-compatible server.",
-		mode: "local",
-		endpointPlaceholder: "http://127.0.0.1:8080/v1",
-	},
-	{
-		value: "ollama",
-		label: "Ollama",
-		detail: "Use an Ollama daemon running on this machine or LAN.",
-		mode: "local",
-		endpointPlaceholder: "http://127.0.0.1:11434",
-	},
-	{
-		value: "claude-code",
-		label: "Claude Code",
-		detail: "Call the local Claude Code CLI directly for extraction.",
-		mode: "agent",
-	},
-	{
-		value: "codex",
-		label: "Codex",
-		detail: "Call the local Codex CLI directly for extraction.",
-		mode: "agent",
-	},
-	{
-		value: "opencode",
-		label: "OpenCode",
-		detail: "Use OpenCode as the extraction backend.",
-		mode: "agent",
-	},
-	{
-		value: "anthropic",
-		label: "Anthropic API",
-		detail: "Use Anthropic directly with configured secrets.",
-		mode: "api",
-		endpointPlaceholder: "https://api.anthropic.com",
-	},
-	{
-		value: "openrouter",
-		label: "OpenRouter",
-		detail: "Use OpenRouter with configured secrets.",
-		mode: "api",
-		endpointPlaceholder: "https://openrouter.ai/api/v1",
-	},
-	{
-		value: "command",
-		label: "Command",
-		detail: "Use a custom command provider configured in advanced settings.",
-		mode: "custom",
-	},
-	{
-		value: "none",
-		label: "Off",
-		detail: "Leave extraction disabled for now; configure it later.",
-		mode: "off",
-	},
-];
-
-const MODEL_PRESETS: Partial<Record<PipelineProviderChoice, string[]>> = {
-	acpx: ["gpt-5-codex-mini", "gpt-5-codex", "claude-haiku-4-5"],
-	"llama-cpp": ["qwen3.5:4b", "qwen3:8b", "llama-3.1-8b"],
-	ollama: ["qwen3:4b", "qwen3:8b", "glm-4.7-flash"],
-	"claude-code": ["haiku", "sonnet", "opus"],
-	codex: ["gpt-5-codex-mini", "gpt-5-codex", "gpt-5.4"],
-	opencode: ["anthropic/claude-haiku-4-5-20251001", "google/gemini-2.5-flash"],
-	anthropic: ["haiku", "sonnet", "opus"],
-	openrouter: ["openai/gpt-4o-mini", "anthropic/claude-haiku-4-5-20251001"],
-};
-
-let open = $state(false);
-let initialized = $state(false);
-let saving = $state(false);
-let agentName = $state("My Agent");
-let agentDescription = $state("Personal AI assistant");
-let provider = $state<PipelineProviderChoice>("acpx");
-let model = $state("gpt-5-codex-mini");
-let endpoint = $state("");
-let selectedHarness = $state("");
-let selectedHarnesses = $state<string[]>([]);
-let synthesisEnabled = $state(true);
-let showAdvancedProviders = $state(false);
-// biome-ignore lint/style/useConst: Svelte state is mutated by onboarding buttons.
-let afterSaveTab = $state<TabId | "stay" | "sources">("sources");
-let forceOpen = false;
-
-const storageKey = $derived(`signet:onboarding:dismissed:${daemonStatus?.agentsDir ?? "unknown"}`);
-const providerOption = $derived(PROVIDERS.find((option) => option.value === provider) ?? PROVIDERS[0]);
-const harnessOptions = $derived.by(() => {
-	const fromApi = harnesses.map((h) => h.id || h.name).filter(Boolean);
-	const combined = [...new Set([...fromApi, ...KNOWN_HARNESSES])];
-	return combined.map((id) => ({
-		id,
-		meta: harnesses.find((h) => h.id === id || h.name === id),
-	}));
-});
-const selectedProviderModels = $derived(MODEL_PRESETS[provider] ?? []);
-const needsEndpoint = $derived(providerOption.mode === "local" || providerOption.mode === "api");
-
-function readPipelineString(...path: string[]): string {
-	return st.aStr(["memory", "pipelineV2", ...path]);
-}
-
-function currentProvider(): PipelineProviderChoice {
-	const raw = readPipelineString("extractionProvider") || readPipelineString("extraction", "provider");
-	return PROVIDERS.some((option) => option.value === raw) ? (raw as PipelineProviderChoice) : "acpx";
-}
-
-function hydrateFromSettings(): void {
-	st.init(configFiles);
-	agentName = st.aStr(["agent", "name"]) || st.aStr(["name"]) || "My Agent";
-	agentDescription = st.aStr(["agent", "description"]) || st.aStr(["description"]) || "Personal AI assistant";
-	provider = currentProvider();
-	model =
-		readPipelineString("extractionModel") ||
-		readPipelineString("extraction", "model") ||
-		defaultPipelineModel(provider);
-	endpoint =
-		readPipelineString("extraction", "endpoint") ||
-		readPipelineString("extractionEndpoint") ||
-		readPipelineString("extractionBaseUrl") ||
-		"";
-	selectedHarness = readPipelineString("extraction", "harness") || "";
-	selectedHarnesses = st.harnessArray();
-	if (selectedHarnesses.length === 0 && harnessOptions.length > 0) selectedHarnesses = [harnessOptions[0].id];
-	if (!selectedHarness && selectedHarnesses.length > 0) selectedHarness = selectedHarnesses[0];
-	synthesisEnabled = resolveSynthesisEnabled(st.agent);
-	initialized = true;
-}
-
-function isDefaultishWorkspace(): boolean {
-	const name = agentName.trim().toLowerCase();
-	return memoryStats.total === 0 && (name === "my agent" || name.length === 0);
-}
-
-function maybeOpen(): void {
-	if (typeof window === "undefined") return;
-	if (!initialized || !daemonStatus) return;
-	if (forceOpen) {
-		open = true;
-		return;
+	interface Props {
+		configFiles: ConfigFile[];
+		memoryStats: MemoryStats;
+		daemonStatus: DaemonStatus | null;
+		harnesses?: Harness[];
+		onnavigate?: (tab: TabId) => void;
 	}
-	if (localStorage.getItem(storageKey) === "true") return;
-	if (isDefaultishWorkspace()) open = true;
-}
 
-onMount(() => {
-	forceOpen = new URLSearchParams(window.location.search).get("onboarding") === "1";
-	untrack(hydrateFromSettings);
-	maybeOpen();
-});
+	const { configFiles, memoryStats, daemonStatus, harnesses = [], onnavigate }: Props = $props();
 
-$effect(() => {
-	const _configFiles = configFiles;
-	const _harnesses = harnesses;
-	void _configFiles;
-	void _harnesses;
-	untrack(hydrateFromSettings);
-});
+	const STEPS = [
+		{ number: "01", title: "Welcome", subtitle: "Choose an identity preset for your agent." },
+		{ number: "02", title: "Identity", subtitle: "Name your agent and select harnesses." },
+		{ number: "03", title: "Embeddings", subtitle: "Configure vector search for semantic recall." },
+		{ number: "04", title: "Extraction", subtitle: "Pick an extraction route for the memory pipeline." },
+		{ number: "05", title: "Review", subtitle: "Confirm your choices before saving." },
+	];
 
-$effect(() => {
-	const _daemonStatus = daemonStatus;
-	const _memoryTotal = memoryStats.total;
-	void _daemonStatus;
-	void _memoryTotal;
-	maybeOpen();
-});
+	let open = $state(false);
+	let initialized = $state(false);
+	let forceOpen = false;
+	let direction = $state<1 | -1>(1);
+	let obState = $state<OnboardingState>(createDefaultState());
 
-function chooseProvider(next: PipelineProviderChoice): void {
-	provider = next;
-	model = MODEL_PRESETS[next]?.[0] ?? defaultPipelineModel(next);
-	endpoint = PROVIDERS.find((option) => option.value === next)?.endpointPlaceholder ?? "";
-	if (next === "none") endpoint = "";
-}
+	const storageKey = $derived(`signet:onboarding:dismissed:${daemonStatus?.agentsDir ?? "unknown"}`);
 
-function toggleHarness(id: string, checked: boolean | string): void {
-	if (checked) {
-		selectedHarnesses = [...new Set([...selectedHarnesses, id])];
-		if (!selectedHarness) selectedHarness = id;
-		return;
+	function readPipelineString(...path: string[]): string {
+		return st.aStr(["memory", "pipelineV2", ...path]);
 	}
-	selectedHarnesses = selectedHarnesses.filter((h) => h !== id);
-	if (selectedHarness === id) selectedHarness = selectedHarnesses[0] ?? "";
-}
 
-function dismiss(): void {
-	forceOpen = false;
-	localStorage.setItem(storageKey, "true");
-	open = false;
-}
+	function hydrateFromSettings(): void {
+		st.init(configFiles);
+		obState.agentName = st.aStr(["agent", "name"]) || st.aStr(["name"]) || "My Agent";
+		obState.agentDescription = st.aStr(["agent", "description"]) || st.aStr(["description"]) || "Personal AI assistant";
+		obState.identityPreset = (st.aStr(["identity", "preset"]) || "minimal") as IdentityPresetName;
 
-function openSettings(): void {
-	dismiss();
-	onnavigate?.("settings");
-}
+		const harnessFromApi = harnesses.map((h) => h.id || h.name).filter(Boolean);
+		const combined = [...new Set([...harnessFromApi, ...KNOWN_HARNESSES])];
+		obState.selectedHarnesses = st.harnessArray();
+		if (obState.selectedHarnesses.length === 0 && combined.length > 0) {
+			obState.selectedHarnesses = [combined[0]];
+		}
+		obState.selectedHarness = obState.selectedHarnesses[0] ?? "";
 
-async function persistOnboardingConfig(): Promise<void> {
-	if (st.agentFile) {
-		await st.save();
-		return;
+		const embProvider = st.sStr([...st.embPath(), "provider"]) || "native";
+		obState.embeddingProvider = EMBEDDING_PROVIDER_OPTIONS.some((o) => o.value === embProvider) ? embProvider as EmbeddingProvider : "native";
+		obState.embeddingModel =
+			st.sStr([...st.embPath(), "model"]) ||
+			(EMBEDDING_PROVIDER_OPTIONS.find((o) => o.value === obState.embeddingProvider)?.defaultModel ?? "");
+		obState.embeddingEndpoint = st.sStr([...st.embPath(), "base_url"]) || st.sStr([...st.embPath(), "baseurl"]) || "";
+
+		const rawProvider =
+			readPipelineString("extractionProvider") || readPipelineString("extraction", "provider");
+		obState.extractionProvider = EXTRACTION_PROVIDER_OPTIONS.some((o) => o.value === rawProvider)
+			? (rawProvider as PipelineProviderChoice)
+			: "acpx";
+		obState.extractionModel =
+			readPipelineString("extractionModel") ||
+			readPipelineString("extraction", "model") ||
+			defaultPipelineModel(obState.extractionProvider);
+		obState.extractionEndpoint =
+			readPipelineString("extraction", "endpoint") ||
+			readPipelineString("extractionEndpoint") ||
+			readPipelineString("extractionBaseUrl") ||
+			"";
+		obState.synthesisEnabled = resolveSynthesisEnabled(st.agent);
+		initialized = true;
 	}
-	const result = await saveConfigFileResult("agent.yaml", stringify(st.agent));
-	if (!result.ok) throw new Error(result.error ?? `Failed to create agent.yaml (${result.status})`);
-	st.agentSnapshot = JSON.stringify(st.agent);
-}
 
-async function finish(): Promise<void> {
-	if (saving) return;
-	saving = true;
-	try {
-		st.aSetStr(["agent", "name"], agentName.trim() || "My Agent");
-		st.aSetStr(["agent", "description"], agentDescription.trim() || "Personal AI assistant");
-		st.set(st.agent, ["harnesses"], selectedHarnesses);
-		applyRecommendedPipelineSetup(st.agent, {
-			provider,
-			model,
-			endpoint: needsEndpoint ? endpoint : "",
-			acpxHarness: provider === "acpx" ? selectedHarness : "",
-			synthesisEnabled,
-		});
-		st.agent = { ...st.agent };
-		await persistOnboardingConfig();
+	function isDefaultishWorkspace(): boolean {
+		const name = obState.agentName.trim().toLowerCase();
+		return memoryStats.total === 0 && (name === "my agent" || name.length === 0);
+	}
+
+	function maybeOpen(): void {
+		if (typeof window === "undefined") return;
+		if (!initialized || !daemonStatus) return;
+		if (forceOpen) {
+			open = true;
+			return;
+		}
+		if (localStorage.getItem(storageKey) === "true") return;
+		if (isDefaultishWorkspace()) open = true;
+	}
+
+	onMount(() => {
+		forceOpen = new URLSearchParams(window.location.search).get("onboarding") === "1";
+		untrack(hydrateFromSettings);
+		maybeOpen();
+	});
+
+	$effect(() => {
+		const _configFiles = configFiles;
+		const _harnesses = harnesses;
+		void _configFiles;
+		void _harnesses;
+		untrack(hydrateFromSettings);
+	});
+
+	$effect(() => {
+		const _daemonStatus = daemonStatus;
+		const _memoryTotal = memoryStats.total;
+		void _daemonStatus;
+		void _memoryTotal;
+		maybeOpen();
+	});
+
+	function dismiss(): void {
 		forceOpen = false;
 		localStorage.setItem(storageKey, "true");
 		open = false;
-		await invalidateAll();
-		toast("Onboarding saved", "success");
-		if (afterSaveTab === "sources") onnavigate?.("sources");
-		else if (afterSaveTab !== "stay") onnavigate?.(afterSaveTab);
-	} finally {
-		saving = false;
 	}
-}
+
+	function openSettings(): void {
+		dismiss();
+		onnavigate?.("settings");
+	}
+
+	function validateStep(step: number): string[] {
+		if (step === 1) {
+			const errors: string[] = [];
+			if (!obState.agentName.trim()) errors.push("Agent name is required.");
+			if (obState.selectedHarnesses.length === 0) errors.push("Select at least one harness.");
+			return errors;
+		}
+		if (step === 2) {
+			if (obState.embeddingProvider === "none") return [];
+			if (!obState.embeddingModel.trim()) return ["Embedding model is required."];
+			return [];
+		}
+		if (step === 3) {
+			if (obState.extractionProvider === "none") return [];
+			if (!obState.extractionModel.trim()) return ["Extraction model is required."];
+			return [];
+		}
+		return [];
+	}
+
+	function nextStep(): void {
+		const errors = validateStep(obState.currentStep);
+		if (errors.length > 0) {
+			toast(errors[0], "error");
+			return;
+		}
+		direction = 1;
+		obState.currentStep = Math.min(obState.currentStep + 1, STEPS.length - 1);
+	}
+
+	function prevStep(): void {
+		direction = -1;
+		obState.currentStep = Math.max(obState.currentStep - 1, 0);
+	}
+
+	async function persistOnboardingConfig(): Promise<void> {
+		if (st.agentFile) {
+			await st.save();
+			return;
+		}
+		const result = await saveConfigFileResult("agent.yaml", stringify(st.agent));
+		if (!result.ok) throw new Error(result.error ?? `Failed to create agent.yaml (${result.status})`);
+		st.agentSnapshot = JSON.stringify(st.agent);
+	}
+
+	async function finish(): Promise<void> {
+		if (obState.saving) return;
+		obState.saving = true;
+		try {
+			st.aSetStr(["agent", "name"], obState.agentName.trim() || "My Agent");
+			st.aSetStr(["agent", "description"], obState.agentDescription.trim() || "Personal AI assistant");
+			st.aSetStr(["identity", "preset"], obState.identityPreset);
+			st.set(st.agent, ["harnesses"], obState.selectedHarnesses);
+
+			const needsEndpoint = (() => {
+				const mode = EXTRACTION_PROVIDER_OPTIONS.find((o) => o.value === obState.extractionProvider)?.mode;
+				return mode === "local" || mode === "api";
+			})();
+
+			applyRecommendedPipelineSetup(st.agent, {
+				provider: obState.extractionProvider,
+				model: obState.extractionModel,
+				endpoint: needsEndpoint ? obState.extractionEndpoint : "",
+				acpxHarness: obState.extractionProvider === "acpx" ? obState.selectedHarness : "",
+				synthesisEnabled: obState.synthesisEnabled,
+			});
+
+			st.agent = { ...st.agent };
+			await persistOnboardingConfig();
+			forceOpen = false;
+			localStorage.setItem(storageKey, "true");
+			open = false;
+			await invalidateAll();
+			toast("Setup complete", "success");
+			onnavigate?.("sources");
+		} finally {
+			obState.saving = false;
+		}
+	}
 </script>
 
 {#if open}
@@ -281,190 +231,73 @@ async function finish(): Promise<void> {
 				<div class="header-copy">
 					<div class="header-kicker">
 						<span class="signal-dot"></span>
-						<span>FIRST_RUN_SEQUENCE</span>
-						<span class="header-coordinate">AGENT_BOOTSTRAP / 04</span>
+						<span>SETUP_SEQUENCE</span>
+						<span class="header-step">{STEPS[obState.currentStep].number} / {String(STEPS.length).padStart(2, "0")}</span>
 					</div>
 					<h2 id="onboarding-title">Initialize Signet</h2>
-					<p class="lede">Set identity, harness sync, and memory extraction. Everything can change later.</p>
+					<p class="lede">{STEPS[obState.currentStep].subtitle}</p>
 				</div>
-				<button class="icon-button sig-switch" type="button" aria-label="Dismiss onboarding" onclick={dismiss}>×</button>
+
+				<div class="progress-track">
+					{#each STEPS as step, i (i)}
+						<button
+							type="button"
+							class="progress-dot"
+							class:progress-dot-active={i === obState.currentStep}
+							class:progress-dot-done={i < obState.currentStep}
+							disabled={i > obState.currentStep}
+							onclick={() => { if (i < obState.currentStep) { direction = -1; obState.currentStep = i; } }}
+							aria-label="Go to step {i + 1}: {step.title}"
+						>
+							{i + 1}
+						</button>
+						{#if i < STEPS.length - 1}
+							<span class="progress-line" class:progress-line-done={i < obState.currentStep}></span>
+						{/if}
+					{/each}
+				</div>
+
+				<button class="icon-button sig-switch" type="button" aria-label="Dismiss onboarding" onclick={dismiss}>
+					&times;
+				</button>
 			</header>
 
 			<div class="onboarding-body">
-				<aside class="step-nav" aria-label="Onboarding steps">
-					<div class="step-nav-item step-nav-item-active">
-						<span class="step-nav-index">01</span>
-						<div>
-							<strong>Identity</strong>
-							<small>Name and describe your agent</small>
-						</div>
+				{#key obState.currentStep}
+					<div class="step-panel" in:fly={{ x: direction * 60, duration: 180 }}>
+						{#if obState.currentStep === 0}
+							<WelcomeStep state={obState} />
+						{:else if obState.currentStep === 1}
+							<IdentityStep state={obState} {harnesses} />
+						{:else if obState.currentStep === 2}
+							<EmbeddingStep state={obState} />
+						{:else if obState.currentStep === 3}
+							<ExtractionStep state={obState} />
+						{:else}
+							<ReviewStep state={obState} />
+						{/if}
 					</div>
-					<div class="step-nav-item">
-						<span class="step-nav-index">02</span>
-						<div>
-							<strong>Harness sync</strong>
-							<small>Select harnesses to sync with</small>
-						</div>
-					</div>
-					<div class="step-nav-item">
-						<span class="step-nav-index">03</span>
-						<div>
-							<strong>Memory engine</strong>
-							<small>Choose memory extraction routes</small>
-						</div>
-					</div>
-					<div class="step-nav-item">
-						<span class="step-nav-index">04</span>
-						<div>
-							<strong>Sources</strong>
-							<small>Review and continue</small>
-						</div>
-					</div>
-				</aside>
-
-				<main class="setup-main">
-					<section class="setup-panel identity-panel">
-						<div class="section-head">
-							<span class="step">01</span>
-							<div>
-								<h3>Identity</h3>
-								<p>Give the agent a recognizable name before syncing it into tools.</p>
-							</div>
-						</div>
-						<div class="field-grid">
-							<label class="field">
-								<span>Name</span>
-								<Input class="onboarding-input" bind:value={agentName} placeholder="Dot" />
-							</label>
-							<label class="field field-wide">
-								<span>Description</span>
-								<Textarea class="onboarding-input onboarding-textarea" rows={2} bind:value={agentDescription} placeholder="A portable memory agent for..." />
-							</label>
-						</div>
-					</section>
-
-					<section class="setup-panel">
-						<div class="section-head">
-							<span class="step">02</span>
-							<div>
-								<h3>Harness sync</h3>
-								<p>Choose where Signet maintains this identity.</p>
-							</div>
-						</div>
-						<div class="harness-list">
-							{#each harnessOptions as h (h.id)}
-								<label class="harness-row sig-switch" class:harness-row-active={selectedHarnesses.includes(h.id)}>
-									<Checkbox checked={selectedHarnesses.includes(h.id)} onCheckedChange={(checked) => toggleHarness(h.id, checked)} />
-									<span class="status-dot" class:status-dot-installed={h.meta?.exists}></span>
-									<span class="harness-main">
-										<strong>{h.id}</strong>
-										<small>{h.meta?.path ?? "known harness"}</small>
-									</span>
-									<span class="harness-state">{h.meta?.exists ? "installed" : "not found"}</span>
-								</label>
-							{/each}
-						</div>
-					</section>
-
-					<section class="setup-panel memory-panel">
-						<div class="section-head">
-							<span class="step">03</span>
-							<div>
-								<h3>Memory engine</h3>
-								<p>Pick an extraction route. Advanced routes stay available without dominating the flow.</p>
-							</div>
-						</div>
-
-						<div class="provider-grid">
-							<p class="provider-group-title">Recommended routes</p>
-							{#each PROVIDERS as option (option.value)}
-								{#if option.value === "acpx" || option.value === "ollama" || option.value === "codex" || option.value === "claude-code"}
-									<button type="button" class="provider-card sig-switch" class:provider-card-active={provider === option.value} onclick={() => chooseProvider(option.value)} aria-pressed={provider === option.value}>
-										<span class="provider-radio" aria-hidden="true"></span>
-										<span class="provider-mode">{option.mode}</span>
-										{#if provider === option.value}<span class="selected-badge">selected</span>{/if}
-										<strong>{option.label}</strong>
-										<small>{option.detail}</small>
-									</button>
-								{/if}
-							{/each}
-
-							<button type="button" class="advanced-toggle sig-switch" onclick={() => { showAdvancedProviders = !showAdvancedProviders; }} aria-expanded={showAdvancedProviders}>
-								<span>{showAdvancedProviders ? "Hide advanced routes" : "Show advanced routes"}</span>
-							</button>
-
-							{#if showAdvancedProviders}
-								<p class="provider-group-title provider-group-title-secondary">Advanced routes</p>
-								{#each PROVIDERS as option (option.value)}
-									{#if option.value !== "acpx" && option.value !== "ollama" && option.value !== "codex" && option.value !== "claude-code"}
-										<button type="button" class="provider-card provider-card-compact sig-switch" class:provider-card-active={provider === option.value} onclick={() => chooseProvider(option.value)} aria-pressed={provider === option.value}>
-											<span class="provider-radio" aria-hidden="true"></span>
-											<span class="provider-mode">{option.mode}</span>
-											{#if provider === option.value}<span class="selected-badge">selected</span>{/if}
-											<strong>{option.label}</strong>
-											<small>{option.detail}</small>
-										</button>
-									{/if}
-								{/each}
-							{/if}
-						</div>
-
-						<div class="provider-detail">
-							<div class="detail-banner">
-								<span>{providerOption.mode}</span>
-								<p>{providerOption.detail}</p>
-							</div>
-
-							{#if provider === "acpx"}
-								<div class="field field-wide">
-									<span>ACPX harness</span>
-									<div class="choice-row">
-										{#each selectedHarnesses as h (h)}
-											<button type="button" class="choice-pill sig-switch" class:choice-pill-active={selectedHarness === h} onclick={() => { selectedHarness = h; }}>{h}</button>
-										{/each}
-										{#if selectedHarnesses.length === 0}<small class="empty-hint">Select at least one harness above.</small>{/if}
-									</div>
-								</div>
-							{/if}
-
-							<div class="field-grid">
-								<label class="field">
-									<span>Model</span>
-									<Input class="onboarding-input" bind:value={model} placeholder="model id" disabled={provider === "none"} />
-								</label>
-								{#if needsEndpoint}
-									<label class="field">
-										<span>Endpoint URL</span>
-										<Input class="onboarding-input" bind:value={endpoint} placeholder={providerOption.endpointPlaceholder ?? "https://..."} />
-									</label>
-								{/if}
-							</div>
-
-							{#if selectedProviderModels.length > 0 && provider !== "none"}
-								<div class="choice-row preset-row" aria-label="Model presets">
-									{#each selectedProviderModels as preset (preset)}
-										<button type="button" class="choice-pill sig-switch" class:choice-pill-active={model === preset} onclick={() => { model = preset; }}>{preset}</button>
-									{/each}
-								</div>
-							{/if}
-
-							<label class="inline-toggle sig-switch">
-								<Checkbox checked={synthesisEnabled} onCheckedChange={(checked) => { synthesisEnabled = !!checked; }} />
-								<span>Use the same provider for session synthesis</span>
-							</label>
-						</div>
-					</section>
-
-				</main>
+				{/key}
 			</div>
 
 			<footer class="onboarding-actions sig-panel-footer">
 				<div class="secondary-actions">
-					<Button variant="ghost" type="button" onclick={openSettings}>Open full settings</Button>
+					<Button variant="ghost" type="button" onclick={openSettings}>Settings</Button>
 					<Button variant="ghost" type="button" onclick={dismiss}>Skip for now</Button>
 				</div>
 				<div class="action-cluster">
-					<Button type="button" onclick={finish} disabled={saving}>{saving ? "Saving…" : afterSaveTab === "sources" ? "Continue to sources →" : "Save setup"}</Button>
+					{#if obState.currentStep > 0}
+						<Button variant="ghost" type="button" onclick={prevStep}>Back</Button>
+					{/if}
+					{#if obState.currentStep < STEPS.length - 1}
+						<Button type="button" onclick={nextStep}>
+							{obState.currentStep === 0 ? "Get started" : "Continue"}
+						</Button>
+					{:else}
+						<Button type="button" onclick={finish} disabled={obState.saving}>
+							{obState.saving ? "Saving..." : "Save and continue to sources"}
+						</Button>
+					{/if}
 				</div>
 			</footer>
 		</div>
@@ -481,14 +314,15 @@ async function finish(): Promise<void> {
 		padding: 24px;
 		background:
 			radial-gradient(circle at 52% 16%, color-mix(in srgb, var(--sig-highlight), transparent 84%), transparent 32%),
+			radial-gradient(ellipse at 80% 85%, color-mix(in srgb, var(--sig-surface-raised), transparent 60%), transparent 50%),
 			color-mix(in srgb, var(--sig-bg), transparent 10%);
-		backdrop-filter: blur(5px) saturate(0.95);
+		backdrop-filter: blur(8px) saturate(0.9);
 	}
 
 	.onboarding-modal {
 		position: relative;
-		width: min(1180px, 100%);
-		max-height: min(900px, calc(100vh - 32px));
+		width: min(960px, 100%);
+		height: min(720px, calc(100vh - 48px));
 		display: flex;
 		flex-direction: column;
 		background: var(--sig-bg);
@@ -553,19 +387,7 @@ async function finish(): Promise<void> {
 	.header-copy {
 		position: relative;
 		z-index: 1;
-		max-width: 760px;
-	}
-
-	.header-kicker,
-	.field > span,
-	.step,
-	.harness-state,
-	.provider-mode {
-		font-family: var(--font-mono, monospace);
-		font-size: 10px;
-		letter-spacing: 0.1em;
-		text-transform: uppercase;
-		color: var(--sig-text-muted);
+		max-width: 480px;
 	}
 
 	.header-kicker {
@@ -573,6 +395,10 @@ async function finish(): Promise<void> {
 		align-items: center;
 		gap: 10px;
 		margin-bottom: 10px;
+		font-family: var(--font-mono, monospace);
+		font-size: 10px;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
 		color: var(--sig-highlight-text);
 	}
 
@@ -584,33 +410,81 @@ async function finish(): Promise<void> {
 		box-shadow: 0 0 10px color-mix(in srgb, var(--sig-success), transparent 28%);
 	}
 
-	.header-coordinate {
+	.header-step {
 		color: var(--sig-text-muted);
 	}
 
-	h2,
-	.lede,
-	h3,
-	.section-head p {
-		margin: 0;
-	}
-
 	h2 {
+		margin: 0;
 		font-family: var(--font-display, monospace);
 		font-size: clamp(24px, 3.4vw, 38px);
 		line-height: 0.94;
 		letter-spacing: 0.06em;
 		color: var(--sig-text-bright);
 		text-transform: uppercase;
-		text-wrap: balance;
 	}
 
 	.lede {
-		max-width: 650px;
-		margin-top: 7px;
+		margin: 7px 0 0;
 		font-size: 13px;
 		line-height: 1.35;
 		color: var(--sig-text);
+	}
+
+	.progress-track {
+		position: relative;
+		z-index: 1;
+		display: flex;
+		align-items: center;
+		gap: 0;
+		margin-top: 12px;
+	}
+
+	.progress-dot {
+		width: 28px;
+		height: 28px;
+		display: inline-grid;
+		place-items: center;
+		font-family: var(--font-mono, monospace);
+		font-size: 10px;
+		letter-spacing: 0.05em;
+		color: var(--sig-text-muted);
+		background: var(--sig-bg);
+		border: 1px solid var(--sig-border-strong);
+		cursor: pointer;
+		transition: border-color var(--dur) var(--ease), color var(--dur) var(--ease),
+			background var(--dur) var(--ease), box-shadow var(--dur) var(--ease);
+	}
+
+	.progress-dot:hover:not(:disabled) {
+		border-color: var(--sig-highlight);
+		color: var(--sig-text-bright);
+	}
+
+	.progress-dot:disabled {
+		cursor: default;
+	}
+
+	.progress-dot-active {
+		border-color: var(--sig-highlight);
+		background: var(--sig-highlight);
+		color: var(--sig-bg);
+		box-shadow: 0 0 12px color-mix(in srgb, var(--sig-highlight), transparent 32%);
+	}
+
+	.progress-dot-done {
+		border-color: var(--sig-highlight);
+		color: var(--sig-highlight-text);
+	}
+
+	.progress-line {
+		width: 28px;
+		height: 2px;
+		background: var(--sig-border-strong);
+	}
+
+	.progress-line-done {
+		background: var(--sig-highlight);
 	}
 
 	.icon-button {
@@ -625,383 +499,17 @@ async function finish(): Promise<void> {
 	}
 
 	.onboarding-body {
-		display: grid;
-		grid-template-columns: 196px minmax(0, 1fr);
-		gap: 0;
-		padding: 0;
-		overflow: auto;
+		flex: 1;
+		overflow-y: auto;
+		overflow-x: hidden;
+		padding: 24px 30px;
 		background:
-			radial-gradient(circle at 22% 18%, var(--sig-highlight-dim), transparent 28%),
+			radial-gradient(ellipse at 25% 10%, color-mix(in srgb, var(--sig-highlight), transparent 92%), transparent 40%),
 			var(--sig-bg);
 	}
 
-	.step-nav {
-		display: flex;
-		flex-direction: column;
-		gap: 2px;
-		padding: 18px 16px;
-		border-right: 1px solid var(--sig-border-strong);
-		background: color-mix(in srgb, var(--sig-surface), transparent 18%);
-	}
-
-	.step-nav-item {
+	.step-panel {
 		position: relative;
-		display: grid;
-		grid-template-columns: 28px minmax(0, 1fr);
-		gap: 10px;
-		padding: 11px 0 11px 12px;
-		border-left: 2px solid transparent;
-		color: var(--sig-text-muted);
-	}
-
-	.step-nav-item-active {
-		border-left-color: var(--sig-highlight);
-		color: var(--sig-highlight-text);
-		background: linear-gradient(90deg, var(--sig-highlight-muted), transparent 88%);
-	}
-
-	.step-nav-index,
-	.step-nav-item strong,
-	.step-nav-item small {
-		font-family: var(--font-mono, monospace);
-		text-transform: uppercase;
-	}
-
-	.step-nav-index {
-		font-size: 11px;
-		letter-spacing: 0.1em;
-		color: currentColor;
-	}
-
-	.step-nav-item strong {
-		display: block;
-		font-size: 11px;
-		letter-spacing: 0.11em;
-		color: currentColor;
-	}
-
-	.step-nav-item small {
-		display: block;
-		margin-top: 5px;
-		font-size: 11px;
-		line-height: 1.35;
-		letter-spacing: 0.01em;
-		text-transform: none;
-		color: var(--sig-text-muted);
-	}
-
-	.setup-main {
-		display: grid;
-		grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
-		gap: 14px;
-		align-items: start;
-		padding: 8px 16px 8px;
-	}
-
-	.setup-panel {
-		position: relative;
-		border: 1px solid var(--sig-border-strong);
-		border-radius: var(--sig-radius);
-		background: color-mix(in srgb, var(--sig-surface), transparent 5%);
-		padding: 10px;
-		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 1px 3px rgba(0, 0, 0, 0.28);
-		overflow: hidden;
-	}
-
-	.setup-panel::before {
-		content: "";
-		position: absolute;
-		inset: 0;
-		pointer-events: none;
-		background: linear-gradient(135deg, rgba(255, 255, 255, 0.035), transparent 42%);
-	}
-
-	.identity-panel {
-		grid-column: 1;
-	}
-
-	.memory-panel {
-		grid-column: 2;
-		grid-row: 1 / span 3;
-	}
-
-	.section-head {
-		position: relative;
-		display: flex;
-		gap: 12px;
-		align-items: flex-start;
-		margin-bottom: 8px;
-	}
-
-	.step {
-		display: inline-grid;
-		place-items: center;
-		width: 32px;
-		height: 32px;
-		border: 1px solid var(--sig-border-strong);
-		background: var(--sig-bg);
-		color: var(--sig-text-bright);
-		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
-	}
-
-	h3 {
-		font-family: var(--font-display, monospace);
-		font-size: 14px;
-		letter-spacing: 0.09em;
-		color: var(--sig-text-bright);
-		text-transform: uppercase;
-	}
-
-	.section-head p,
-	.provider-card small,
-	.harness-main small,
-	.detail-banner p,
-	.empty-hint {
-		font-size: 12px;
-		line-height: 1.35;
-		color: var(--sig-text-muted);
-	}
-
-	.field-grid {
-		display: grid;
-		grid-template-columns: repeat(2, minmax(0, 1fr));
-		gap: 10px;
-	}
-
-	.field,
-	.harness-main {
-		display: flex;
-		flex-direction: column;
-		gap: 7px;
-	}
-
-	.field-wide {
-		grid-column: 1 / -1;
-	}
-
-	:global(.onboarding-input) {
-		border-radius: var(--sig-radius) !important;
-		border-color: var(--sig-border-strong) !important;
-		background: color-mix(in srgb, var(--sig-bg), transparent 6%) !important;
-		color: var(--sig-text-bright) !important;
-		font-family: var(--font-mono, monospace) !important;
-		box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.28) !important;
-	}
-
-	:global(.onboarding-textarea) {
-		min-height: 48px !important;
-		resize: vertical;
-	}
-
-	.harness-list,
-	.provider-detail {
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
-	}
-
-	.harness-list {
-		max-height: 198px;
-		overflow: auto;
-		padding-right: 2px;
-	}
-
-	.harness-row {
-		display: flex;
-		align-items: center;
-		gap: 10px;
-		padding: 10px;
-		cursor: pointer;
-	}
-
-	.harness-row-active {
-		border-color: var(--sig-highlight-dim);
-		background: var(--sig-highlight-muted);
-		box-shadow: inset 3px 0 0 var(--sig-highlight), inset 0 1px 0 rgba(255, 255, 255, 0.05);
-	}
-
-	.status-dot {
-		width: 8px;
-		height: 8px;
-		border: 1px solid var(--sig-text-muted);
-		background: transparent;
-		flex: 0 0 auto;
-	}
-
-	.status-dot-installed {
-		border-color: var(--sig-success);
-		background: var(--sig-success);
-		box-shadow: 0 0 8px color-mix(in srgb, var(--sig-success), transparent 40%);
-	}
-
-	.harness-main {
-		min-width: 0;
-		flex: 1;
-	}
-
-	.harness-main strong {
-		font-size: 13px;
-		color: var(--sig-text-bright);
-	}
-
-	.harness-main small {
-		overflow: hidden;
-		white-space: nowrap;
-		text-overflow: ellipsis;
-	}
-
-	.provider-grid {
-		display: grid;
-		grid-template-columns: repeat(2, minmax(0, 1fr));
-		gap: 8px;
-		margin-bottom: 10px;
-	}
-
-	.provider-group-title {
-		grid-column: 1 / -1;
-		margin: 2px 0 -2px;
-		font-family: var(--font-mono, monospace);
-		font-size: 10px;
-		letter-spacing: 0.11em;
-		text-transform: uppercase;
-		color: var(--sig-highlight-text);
-	}
-
-	.provider-group-title-secondary {
-		margin-top: 8px;
-		color: var(--sig-text-muted);
-	}
-
-	.provider-card-compact {
-		min-height: 72px;
-	}
-
-	.provider-card-compact small {
-		display: none;
-	}
-
-	.provider-card {
-		position: relative;
-		min-height: 40px;
-		padding: 8px 10px 8px 30px;
-		text-align: left;
-		color: var(--sig-text);
-		cursor: pointer;
-	}
-
-	.provider-radio {
-		position: absolute;
-		top: 13px;
-		left: 12px;
-		width: 12px;
-		height: 12px;
-		border: 1px solid var(--sig-border-strong);
-		background: var(--sig-bg);
-	}
-
-	.provider-card-active .provider-radio {
-		border-color: var(--sig-highlight);
-		background: var(--sig-highlight);
-		box-shadow: inset 0 0 0 3px var(--sig-bg), 0 0 9px color-mix(in srgb, var(--sig-highlight), transparent 36%);
-	}
-
-	.provider-card small {
-		display: none;
-	}
-
-	.provider-card strong {
-		display: block;
-		margin: 4px 0 0;
-		font-family: var(--font-display, monospace);
-		font-size: 13px;
-		letter-spacing: 0.08em;
-		text-transform: uppercase;
-		color: var(--sig-text-bright);
-	}
-
-	.provider-card-active {
-		border-color: var(--sig-highlight);
-		background: color-mix(in srgb, var(--sig-surface-raised), var(--sig-highlight) 10%);
-		box-shadow: var(--sig-glow-highlight), inset 3px 0 0 var(--sig-highlight), inset 0 1px 0 rgba(255, 255, 255, 0.08);
-	}
-
-	.provider-mode {
-		color: var(--sig-highlight-text);
-	}
-
-	.selected-badge {
-		position: absolute;
-		top: 9px;
-		right: 10px;
-		font-family: var(--font-mono, monospace);
-		font-size: 9px;
-		letter-spacing: 0.1em;
-		text-transform: uppercase;
-		color: var(--sig-highlight-text);
-	}
-
-	.advanced-toggle {
-		grid-column: 1 / -1;
-		justify-content: center;
-		min-height: 28px;
-		padding: 6px 10px;
-		font-family: var(--font-mono, monospace);
-		font-size: 11px;
-		letter-spacing: 0.08em;
-		text-transform: uppercase;
-		color: var(--sig-text);
-		cursor: pointer;
-	}
-
-	.detail-banner {
-		display: flex;
-		gap: 12px;
-		align-items: center;
-		padding: 8px 10px;
-		border: 1px solid var(--sig-border-strong);
-		border-radius: var(--sig-radius);
-		background: var(--sig-bg);
-	}
-
-	.detail-banner span {
-		font-family: var(--font-mono, monospace);
-		font-size: 10px;
-		text-transform: uppercase;
-		color: var(--sig-highlight-text);
-	}
-
-	.choice-row {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 8px;
-	}
-
-	.preset-row {
-		padding-top: 2px;
-	}
-
-	.choice-pill {
-		padding: 7px 10px;
-		font-family: var(--font-mono, monospace);
-		font-size: 12px;
-		color: var(--sig-text);
-		cursor: pointer;
-	}
-
-	.choice-pill-active {
-		border-color: var(--sig-highlight);
-		color: var(--sig-text-bright);
-		background: var(--sig-highlight-muted);
-	}
-
-	.inline-toggle {
-		display: flex;
-		align-items: center;
-		gap: 9px;
-		padding: 10px;
-		font-size: 12px;
-		color: var(--sig-text);
-		cursor: pointer;
 	}
 
 	.onboarding-actions {
@@ -1009,8 +517,7 @@ async function finish(): Promise<void> {
 		align-items: center;
 		justify-content: space-between;
 		gap: 12px;
-		padding: 10px 18px;
-		background: var(--sig-surface);
+		padding: 12px 24px;
 	}
 
 	.action-cluster,
@@ -1021,21 +528,8 @@ async function finish(): Promise<void> {
 	}
 
 	@media (max-width: 980px) {
-		.onboarding-body,
-		.setup-main,
-		.field-grid,
-		.provider-grid {
-			grid-template-columns: 1fr;
-		}
-
-		.step-nav {
+		.progress-track {
 			display: none;
-		}
-
-		.identity-panel,
-		.memory-panel {
-			grid-column: auto;
-			grid-row: auto;
 		}
 	}
 
@@ -1045,7 +539,7 @@ async function finish(): Promise<void> {
 		}
 
 		.onboarding-modal {
-			max-height: calc(100dvh - 16px);
+			height: calc(100dvh - 16px);
 		}
 
 		.onboarding-header {
@@ -1065,7 +559,6 @@ async function finish(): Promise<void> {
 
 		.lede {
 			font-size: 13px;
-			line-height: 1.35;
 		}
 
 		.icon-button {
@@ -1074,33 +567,13 @@ async function finish(): Promise<void> {
 			flex: 0 0 auto;
 		}
 
-		.header-coordinate,
-		.step-nav {
+		.header-step,
+		.progress-track {
 			display: none;
 		}
 
 		.onboarding-body {
-			padding: 12px 12px 18px;
-		}
-
-		.setup-panel {
-			padding: 14px;
-		}
-
-		.harness-list {
-			max-height: 242px;
-		}
-
-		.provider-card {
-			min-height: 72px;
-		}
-
-		.provider-card small,
-		.harness-main small,
-		.section-head p,
-		.detail-banner p {
-			font-size: 12px;
-			line-height: 1.35;
+			padding: 16px;
 		}
 
 		.onboarding-actions {

--- a/surfaces/dashboard/src/lib/components/onboarding/OnboardingModal.svelte
+++ b/surfaces/dashboard/src/lib/components/onboarding/OnboardingModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { invalidateAll } from "$app/navigation";
 import { type ConfigFile, type DaemonStatus, type Harness, type MemoryStats, saveConfigFileResult } from "$lib/api";
-import { applyRecommendedPipelineSetup } from "$lib/components/tabs/settings/pipeline-settings";
+import { applyRecommendedPipelineSetup, resolveSynthesisEnabled } from "$lib/components/tabs/settings/pipeline-settings";
 import { Button } from "$lib/components/ui/button/index.js";
 import { Checkbox } from "$lib/components/ui/checkbox/index.js";
 import { Input } from "$lib/components/ui/input/index.js";
@@ -165,7 +165,7 @@ function hydrateFromSettings(): void {
 	selectedHarnesses = st.harnessArray();
 	if (selectedHarnesses.length === 0 && harnessOptions.length > 0) selectedHarnesses = [harnessOptions[0].id];
 	if (!selectedHarness && selectedHarnesses.length > 0) selectedHarness = selectedHarnesses[0];
-	synthesisEnabled = provider !== "none";
+	synthesisEnabled = resolveSynthesisEnabled(st.agent);
 	initialized = true;
 }
 

--- a/surfaces/dashboard/src/lib/components/onboarding/OnboardingModal.svelte
+++ b/surfaces/dashboard/src/lib/components/onboarding/OnboardingModal.svelte
@@ -275,145 +275,203 @@ async function finish(): Promise<void> {
 
 {#if open}
 	<div class="onboarding-backdrop" role="presentation">
-		<div class="onboarding-modal" role="dialog" aria-modal="true" aria-labelledby="onboarding-title" tabindex="-1">
-			<header class="onboarding-header">
-				<div>
-					<p class="eyebrow">Dashboard onboarding</p>
+		<div class="onboarding-modal sig-panel" role="dialog" aria-modal="true" aria-labelledby="onboarding-title" tabindex="-1">
+			<header class="onboarding-header sig-panel-header">
+				<div class="header-copy">
+					<div class="header-kicker">
+						<span class="signal-dot"></span>
+						<span>FIRST_RUN_SEQUENCE</span>
+						<span class="header-coordinate">AGENT_BOOTSTRAP / 04</span>
+					</div>
 					<h2 id="onboarding-title">Bring this agent online</h2>
-					<p class="lede">Name the agent, choose the harnesses it should sync into, and wire the memory pipeline to something real.</p>
+					<p class="lede">Set identity, harness sync, and memory extraction. Everything can change later.</p>
 				</div>
-				<button class="icon-button" type="button" aria-label="Dismiss onboarding" onclick={dismiss}>×</button>
+				<button class="icon-button sig-switch" type="button" aria-label="Dismiss onboarding" onclick={dismiss}>×</button>
 			</header>
 
-			<div class="onboarding-body">
-				<section class="setup-panel identity-panel">
-					<div class="section-head">
-						<span class="step">01</span>
-						<div>
-							<h3>Identity</h3>
-							<p>What should harnesses call this agent?</p>
-						</div>
-					</div>
-					<div class="field-grid">
-						<label class="field">
-							<span>Name</span>
-							<Input bind:value={agentName} placeholder="Dot" />
-						</label>
-						<label class="field field-wide">
-							<span>Description</span>
-							<Textarea rows={3} bind:value={agentDescription} placeholder="A portable memory agent for..." />
-						</label>
-					</div>
-				</section>
-
-				<section class="setup-panel">
-					<div class="section-head">
-						<span class="step">02</span>
-						<div>
-							<h3>Harnesses</h3>
-							<p>Loaded from the daemon. Pick every surface Signet should keep configured.</p>
-						</div>
-					</div>
-					<div class="harness-list">
-						{#each harnessOptions as h (h.id)}
-							<label class="harness-row" class:harness-row-active={selectedHarnesses.includes(h.id)}>
-								<Checkbox checked={selectedHarnesses.includes(h.id)} onCheckedChange={(checked) => toggleHarness(h.id, checked)} />
-								<span class="status-dot" class:status-dot-installed={h.meta?.exists}></span>
-								<span class="harness-main">
-									<strong>{h.id}</strong>
-									<small>{h.meta?.path ?? "known harness"}</small>
-								</span>
-								<span class="harness-state">{h.meta?.exists ? "installed" : "not found"}</span>
-							</label>
-						{/each}
-					</div>
-				</section>
-
-				<section class="setup-panel setup-panel-wide">
-					<div class="section-head">
-						<span class="step">03</span>
-						<div>
-							<h3>Memory engine</h3>
-							<p>Choose the extraction provider. Provider-specific fields appear below.</p>
-						</div>
-					</div>
-
-					<div class="provider-grid">
-						{#each PROVIDERS as option (option.value)}
-							<button type="button" class="provider-card" class:provider-card-active={provider === option.value} onclick={() => chooseProvider(option.value)}>
-								<span>{option.label}</span>
-								<small>{option.detail}</small>
-							</button>
-						{/each}
-					</div>
-
-					<div class="provider-detail">
-						<div class="detail-banner">
-							<span>{providerOption.mode}</span>
-							<p>{providerOption.detail}</p>
-						</div>
-
-						{#if provider === "acpx"}
-							<div class="field field-wide">
-								<span>ACPX harness</span>
-								<div class="choice-row">
-									{#each selectedHarnesses as h (h)}
-										<button type="button" class="choice-pill" class:choice-pill-active={selectedHarness === h} onclick={() => { selectedHarness = h; }}>{h}</button>
-									{/each}
-									{#if selectedHarnesses.length === 0}<small>Select at least one harness above.</small>{/if}
-								</div>
-							</div>
-						{/if}
-
-						<div class="field-grid">
-							<label class="field">
-								<span>Model</span>
-								<Input bind:value={model} placeholder="model id" disabled={provider === "none"} />
-							</label>
-							{#if needsEndpoint}
-								<label class="field">
-									<span>Endpoint URL</span>
-									<Input bind:value={endpoint} placeholder={providerOption.endpointPlaceholder ?? "https://..."} />
-								</label>
-							{/if}
-						</div>
-
-						{#if selectedProviderModels.length > 0 && provider !== "none"}
-							<div class="choice-row">
-								{#each selectedProviderModels as preset (preset)}
-									<button type="button" class="choice-pill" class:choice-pill-active={model === preset} onclick={() => { model = preset; }}>{preset}</button>
-								{/each}
-							</div>
-						{/if}
-
-						<label class="inline-toggle">
-							<Checkbox checked={synthesisEnabled} onCheckedChange={(checked) => { synthesisEnabled = !!checked; }} />
-							<span>Use the same provider for session synthesis</span>
-						</label>
-					</div>
-				</section>
-
-				<section class="setup-panel setup-panel-wide next-panel">
-					<div class="section-head">
-						<span class="step">04</span>
-						<div>
-							<h3>Next step</h3>
-							<p>After saving, continue to the surface that actually brings context in.</p>
-						</div>
-					</div>
-					<div class="choice-row">
-						<button type="button" class="choice-pill" class:choice-pill-active={afterSaveTab === "sources"} onclick={() => { afterSaveTab = "sources"; }}>Connect sources</button>
-						<button type="button" class="choice-pill" class:choice-pill-active={afterSaveTab === "settings"} onclick={() => { afterSaveTab = "settings"; }}>Review settings</button>
-						<button type="button" class="choice-pill" class:choice-pill-active={afterSaveTab === "stay"} onclick={() => { afterSaveTab = "stay"; }}>Stay here</button>
-					</div>
-				</section>
+			<div class="progress-rail" aria-hidden="true">
+				<span class="progress-node progress-node-active">01 Identity</span>
+				<span class="progress-line"></span>
+				<span class="progress-node progress-node-active">02 Harness</span>
+				<span class="progress-line"></span>
+				<span class="progress-node progress-node-active">03 Memory</span>
+				<span class="progress-line progress-line-muted"></span>
+				<span class="progress-node">04 Sources</span>
 			</div>
 
-			<footer class="onboarding-actions">
+			<div class="onboarding-body">
+				<aside class="setup-summary setup-panel" aria-hidden="true">
+					<div class="summary-readout">
+						<span class="summary-label">ACTIVE PROFILE</span>
+						<strong>{agentName.trim() || "My Agent"}</strong>
+						<p>{agentDescription.trim() || "Personal AI assistant"}</p>
+					</div>
+					<div class="summary-grid">
+						<div>
+							<span>provider</span>
+							<strong>{providerOption.label}</strong>
+						</div>
+						<div>
+							<span>model</span>
+							<strong>{provider === "none" ? "disabled" : model}</strong>
+						</div>
+						<div>
+							<span>harnesses</span>
+							<strong>{selectedHarnesses.length || 0} selected</strong>
+						</div>
+						<div>
+							<span>next</span>
+							<strong>{afterSaveTab === "sources" ? "sources" : afterSaveTab === "settings" ? "settings" : "dashboard"}</strong>
+						</div>
+					</div>
+					<p class="summary-note">Recommended: keep the default harness, choose the extraction backend you already trust, then connect sources.</p>
+				</aside>
+
+				<main class="setup-main">
+					<section class="setup-panel identity-panel">
+						<div class="section-head">
+							<span class="step">01</span>
+							<div>
+								<h3>Identity</h3>
+								<p>Give the agent a recognizable name before syncing it into tools.</p>
+							</div>
+						</div>
+						<div class="field-grid">
+							<label class="field">
+								<span>Name</span>
+								<Input class="onboarding-input" bind:value={agentName} placeholder="Dot" />
+							</label>
+							<label class="field field-wide">
+								<span>Description</span>
+								<Textarea class="onboarding-input onboarding-textarea" rows={2} bind:value={agentDescription} placeholder="A portable memory agent for..." />
+							</label>
+						</div>
+					</section>
+
+					<section class="setup-panel">
+						<div class="section-head">
+							<span class="step">02</span>
+							<div>
+								<h3>Harness sync</h3>
+								<p>Choose where Signet should maintain this identity. Installed harnesses are ready now.</p>
+							</div>
+						</div>
+						<div class="harness-list">
+							{#each harnessOptions as h (h.id)}
+								<label class="harness-row sig-switch" class:harness-row-active={selectedHarnesses.includes(h.id)}>
+									<Checkbox checked={selectedHarnesses.includes(h.id)} onCheckedChange={(checked) => toggleHarness(h.id, checked)} />
+									<span class="status-dot" class:status-dot-installed={h.meta?.exists}></span>
+									<span class="harness-main">
+										<strong>{h.id}</strong>
+										<small>{h.meta?.path ?? "known harness"}</small>
+									</span>
+									<span class="harness-state">{h.meta?.exists ? "installed" : "not found"}</span>
+								</label>
+							{/each}
+						</div>
+					</section>
+
+					<section class="setup-panel memory-panel">
+						<div class="section-head">
+							<span class="step">03</span>
+							<div>
+								<h3>Memory engine</h3>
+								<p>Pick the extraction path. The common choices are first; advanced routes stay available without dominating the flow.</p>
+							</div>
+						</div>
+
+						<div class="provider-grid">
+							<p class="provider-group-title">Recommended routes</p>
+							{#each PROVIDERS as option (option.value)}
+								{#if option.value === "acpx" || option.value === "ollama" || option.value === "codex" || option.value === "claude-code"}
+									<button type="button" class="provider-card sig-switch" class:provider-card-active={provider === option.value} onclick={() => chooseProvider(option.value)}>
+										<span class="provider-mode">{option.mode}</span>
+										<strong>{option.label}</strong>
+										<small>{option.detail}</small>
+									</button>
+								{/if}
+							{/each}
+
+							<p class="provider-group-title provider-group-title-secondary">Other routes</p>
+							{#each PROVIDERS as option (option.value)}
+								{#if option.value !== "acpx" && option.value !== "ollama" && option.value !== "codex" && option.value !== "claude-code"}
+									<button type="button" class="provider-card provider-card-compact sig-switch" class:provider-card-active={provider === option.value} onclick={() => chooseProvider(option.value)}>
+										<span class="provider-mode">{option.mode}</span>
+										<strong>{option.label}</strong>
+										<small>{option.detail}</small>
+									</button>
+								{/if}
+							{/each}
+						</div>
+
+						<div class="provider-detail">
+							<div class="detail-banner">
+								<span>{providerOption.mode}</span>
+								<p>{providerOption.detail}</p>
+							</div>
+
+							{#if provider === "acpx"}
+								<div class="field field-wide">
+									<span>ACPX harness</span>
+									<div class="choice-row">
+										{#each selectedHarnesses as h (h)}
+											<button type="button" class="choice-pill sig-switch" class:choice-pill-active={selectedHarness === h} onclick={() => { selectedHarness = h; }}>{h}</button>
+										{/each}
+										{#if selectedHarnesses.length === 0}<small class="empty-hint">Select at least one harness above.</small>{/if}
+									</div>
+								</div>
+							{/if}
+
+							<div class="field-grid">
+								<label class="field">
+									<span>Model</span>
+									<Input class="onboarding-input" bind:value={model} placeholder="model id" disabled={provider === "none"} />
+								</label>
+								{#if needsEndpoint}
+									<label class="field">
+										<span>Endpoint URL</span>
+										<Input class="onboarding-input" bind:value={endpoint} placeholder={providerOption.endpointPlaceholder ?? "https://..."} />
+									</label>
+								{/if}
+							</div>
+
+							{#if selectedProviderModels.length > 0 && provider !== "none"}
+								<div class="choice-row preset-row" aria-label="Model presets">
+									{#each selectedProviderModels as preset (preset)}
+										<button type="button" class="choice-pill sig-switch" class:choice-pill-active={model === preset} onclick={() => { model = preset; }}>{preset}</button>
+									{/each}
+								</div>
+							{/if}
+
+							<label class="inline-toggle sig-switch">
+								<Checkbox checked={synthesisEnabled} onCheckedChange={(checked) => { synthesisEnabled = !!checked; }} />
+								<span>Use the same provider for session synthesis</span>
+							</label>
+						</div>
+					</section>
+
+					<section class="setup-panel next-panel">
+						<div class="section-head">
+							<span class="step">04</span>
+							<div>
+								<h3>Continue</h3>
+								<p>Save the basics, then move into the thing that makes memory useful: source connection.</p>
+							</div>
+						</div>
+						<div class="choice-row next-row">
+							<button type="button" class="choice-pill sig-switch" class:choice-pill-active={afterSaveTab === "sources"} onclick={() => { afterSaveTab = "sources"; }}>Connect sources</button>
+							<button type="button" class="choice-pill sig-switch" class:choice-pill-active={afterSaveTab === "settings"} onclick={() => { afterSaveTab = "settings"; }}>Review settings</button>
+							<button type="button" class="choice-pill sig-switch" class:choice-pill-active={afterSaveTab === "stay"} onclick={() => { afterSaveTab = "stay"; }}>Stay here</button>
+						</div>
+					</section>
+				</main>
+			</div>
+
+			<footer class="onboarding-actions sig-panel-footer">
 				<Button variant="ghost" type="button" onclick={openSettings}>Open full settings</Button>
 				<div class="action-cluster">
 					<Button variant="outline" type="button" onclick={dismiss}>Skip</Button>
-					<Button type="button" onclick={finish} disabled={saving}>{saving ? "Saving…" : "Save onboarding"}</Button>
+					<Button type="button" onclick={finish} disabled={saving}>{saving ? "Saving…" : "Save and continue"}</Button>
 				</div>
 			</footer>
 		</div>
@@ -427,122 +485,318 @@ async function finish(): Promise<void> {
 		z-index: 90;
 		display: grid;
 		place-items: center;
-		padding: 22px;
-		background: color-mix(in srgb, var(--sig-bg), transparent 18%);
-		backdrop-filter: blur(2px);
+		padding: 24px;
+		background:
+			radial-gradient(circle at 52% 16%, color-mix(in srgb, var(--sig-highlight), transparent 84%), transparent 32%),
+			color-mix(in srgb, var(--sig-bg), transparent 10%);
+		backdrop-filter: blur(5px) saturate(0.95);
 	}
 
 	.onboarding-modal {
-		width: min(1040px, 100%);
-		max-height: min(880px, calc(100vh - 44px));
+		position: relative;
+		width: min(1060px, 100%);
+		max-height: min(900px, calc(100vh - 48px));
 		display: flex;
 		flex-direction: column;
-		border: 1px solid var(--sig-border-strong);
 		background: var(--sig-bg);
-		box-shadow: 0 0 0 1px var(--sig-bg), 0 20px 70px rgba(0, 0, 0, 0.55);
 		overflow: hidden;
 	}
 
+	.onboarding-modal::before,
+	.onboarding-modal::after {
+		content: "";
+		position: absolute;
+		z-index: 2;
+		pointer-events: none;
+		width: 24px;
+		height: 24px;
+		border-color: var(--sig-border-strong);
+		border-style: solid;
+		opacity: 0.45;
+	}
+
+	.onboarding-modal::before {
+		top: 10px;
+		left: 10px;
+		border-width: 1px 0 0 1px;
+	}
+
+	.onboarding-modal::after {
+		right: 10px;
+		bottom: 10px;
+		border-width: 0 1px 1px 0;
+	}
+
 	.onboarding-header {
+		position: relative;
 		display: flex;
 		align-items: flex-start;
 		justify-content: space-between;
-		gap: 18px;
-		padding: 20px 22px 18px;
-		border-bottom: 1px solid var(--sig-border-strong);
-		background: linear-gradient(90deg, color-mix(in srgb, var(--sig-surface-raised), var(--sig-highlight) 4%), var(--sig-bg));
+		gap: 24px;
+		padding: 20px 30px 18px;
+		background:
+			linear-gradient(var(--sig-grid-line) 1px, transparent 1px),
+			linear-gradient(90deg, var(--sig-grid-line) 1px, transparent 1px),
+			linear-gradient(135deg, color-mix(in srgb, var(--sig-surface-raised), var(--sig-highlight) 8%), var(--sig-bg) 64%);
+		background-size: 28px 28px, 28px 28px, auto;
+		overflow: hidden;
 	}
 
-	.eyebrow,
+	.onboarding-header::after {
+		content: "SIGNET / MEMORY / IDENTITY";
+		position: absolute;
+		right: 72px;
+		bottom: -15px;
+		font-family: var(--font-display, monospace);
+		font-size: clamp(24px, 5vw, 58px);
+		letter-spacing: 0.1em;
+		color: var(--sig-text-bright);
+		opacity: 0.022;
+		white-space: nowrap;
+		pointer-events: none;
+	}
+
+	.header-copy {
+		position: relative;
+		z-index: 1;
+		max-width: 760px;
+	}
+
+	.header-kicker,
 	.field > span,
 	.step,
-	.harness-state {
+	.harness-state,
+	.provider-mode,
+	.summary-label,
+	.summary-grid span {
 		font-family: var(--font-mono, monospace);
 		font-size: 10px;
-		letter-spacing: 0.13em;
+		letter-spacing: 0.1em;
 		text-transform: uppercase;
-		color: var(--sig-highlight);
+		color: var(--sig-text-muted);
 	}
 
-	.eyebrow,
+	.header-kicker {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		margin-bottom: 10px;
+		color: var(--sig-highlight-text);
+	}
+
+	.signal-dot {
+		width: 7px;
+		height: 7px;
+		border: 1px solid var(--sig-success);
+		background: var(--sig-success);
+		box-shadow: 0 0 10px color-mix(in srgb, var(--sig-success), transparent 28%);
+	}
+
+	.header-coordinate {
+		color: var(--sig-text-muted);
+	}
+
 	h2,
 	.lede,
 	h3,
-	.section-head p {
+	.section-head p,
+	.summary-readout p {
 		margin: 0;
 	}
 
 	h2 {
-		margin-top: 4px;
-		font-family: var(--font-display, var(--font-heading, inherit));
-		font-size: clamp(28px, 4vw, 44px);
-		line-height: 0.95;
-		letter-spacing: -0.04em;
+		font-family: var(--font-display, monospace);
+		font-size: clamp(24px, 3.4vw, 38px);
+		line-height: 0.94;
+		letter-spacing: 0.06em;
 		color: var(--sig-text-bright);
 		text-transform: uppercase;
+		text-wrap: balance;
 	}
 
 	.lede {
-		max-width: 680px;
+		max-width: 650px;
 		margin-top: 10px;
 		font-size: 14px;
-		line-height: 1.5;
+		line-height: 1.45;
 		color: var(--sig-text);
 	}
 
 	.icon-button {
-		width: 38px;
-		height: 38px;
-		border: 1px solid var(--sig-border-strong);
-		background: var(--sig-surface-raised);
+		position: relative;
+		z-index: 3;
+		width: 40px;
+		height: 40px;
 		color: var(--sig-text);
-		font-size: 22px;
+		font-size: 24px;
+		line-height: 1;
 		cursor: pointer;
+	}
+
+	.progress-rail {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 12px 34px;
+		border-right: 1px solid var(--sig-border);
+		background: var(--sig-surface);
+	}
+
+	.progress-node {
+		display: grid;
+		place-items: center;
+		width: auto;
+		min-width: 82px;
+		height: 22px;
+		padding: 0 8px;
+		border: 1px solid var(--sig-border);
+		font-family: var(--font-mono, monospace);
+		font-size: 10px;
+		color: var(--sig-text-muted);
+		background: var(--sig-bg);
+	}
+
+	.progress-node-active {
+		border-color: var(--sig-highlight-dim);
+		color: var(--sig-highlight-text);
+		background: var(--sig-highlight-muted);
+	}
+
+	.progress-line {
+		flex: 1;
+		height: 1px;
+		background: linear-gradient(90deg, var(--sig-highlight), var(--sig-border-strong));
+		opacity: 0.55;
+	}
+
+	.progress-line-muted {
+		background: var(--sig-border);
 	}
 
 	.onboarding-body {
 		display: grid;
-		grid-template-columns: minmax(260px, 0.9fr) minmax(380px, 1.4fr);
-		gap: 12px;
-		padding: 14px;
+		grid-template-columns: 1fr;
+		gap: 18px;
+		padding: 18px 18px 28px;
 		overflow: auto;
+		background:
+			radial-gradient(circle at 22% 18%, var(--sig-highlight-dim), transparent 28%),
+			var(--sig-bg);
+	}
+
+	.setup-main {
+		display: grid;
+		grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
+		gap: 18px;
+		align-items: start;
 	}
 
 	.setup-panel {
+		position: relative;
+		border: 1px solid var(--sig-border-strong);
+		border-radius: var(--sig-radius);
+		background: color-mix(in srgb, var(--sig-surface), transparent 5%);
+		padding: 16px;
+		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 1px 3px rgba(0, 0, 0, 0.28);
+		overflow: hidden;
+	}
+
+	.setup-panel::before {
+		content: "";
+		position: absolute;
+		inset: 0;
+		pointer-events: none;
+		background: linear-gradient(135deg, rgba(255, 255, 255, 0.035), transparent 42%);
+	}
+
+	.setup-summary {
+		display: none;
+	}
+
+	.summary-readout {
+		position: relative;
+		padding-right: 16px;
+		border-right: 1px solid var(--sig-border);
+	}
+
+	.summary-readout strong {
+		display: block;
+		margin-top: 8px;
+		font-family: var(--font-display, monospace);
+		font-size: 26px;
+		line-height: 1;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--sig-text-bright);
+	}
+
+	.summary-readout p,
+	.summary-note {
+		margin-top: 10px;
+		font-size: 13px;
+		line-height: 1.45;
+		color: var(--sig-text-muted);
+	}
+
+	.summary-grid {
+		display: grid;
+		grid-template-columns: repeat(4, minmax(0, 1fr));
 		border: 1px solid var(--sig-border);
-		background: var(--sig-surface);
-		padding: 14px;
+		background: var(--sig-bg);
 	}
 
-	.setup-panel-wide {
+	.summary-grid div {
+		padding: 10px 11px;
+		border-right: 1px solid var(--sig-border);
+	}
+
+	.summary-grid div:last-child {
+		border-right: 0;
+	}
+
+	.summary-grid strong {
+		display: block;
+		margin-top: 4px;
+		font-family: var(--font-mono, monospace);
+		font-size: 15px;
+		line-height: 1.1;
+		color: var(--sig-text-bright);
+		word-break: break-word;
+	}
+
+	.identity-panel,
+	.next-panel {
+		grid-column: 1;
+	}
+
+	.memory-panel {
 		grid-column: 2;
-	}
-
-	.identity-panel {
-		grid-row: span 1;
+		grid-row: 1 / span 3;
 	}
 
 	.section-head {
+		position: relative;
 		display: flex;
-		gap: 11px;
+		gap: 12px;
 		align-items: flex-start;
-		margin-bottom: 12px;
+		margin-bottom: 14px;
 	}
 
 	.step {
 		display: inline-grid;
 		place-items: center;
-		width: 30px;
-		height: 30px;
+		width: 32px;
+		height: 32px;
 		border: 1px solid var(--sig-border-strong);
 		background: var(--sig-bg);
 		color: var(--sig-text-bright);
+		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 	}
 
 	h3 {
-		font-family: var(--font-display, inherit);
-		font-size: 18px;
-		letter-spacing: 0.02em;
+		font-family: var(--font-display, monospace);
+		font-size: 14px;
+		letter-spacing: 0.09em;
 		color: var(--sig-text-bright);
 		text-transform: uppercase;
 	}
@@ -550,9 +804,10 @@ async function finish(): Promise<void> {
 	.section-head p,
 	.provider-card small,
 	.harness-main small,
-	.detail-banner p {
+	.detail-banner p,
+	.empty-hint {
 		font-size: 12px;
-		line-height: 1.4;
+		line-height: 1.35;
 		color: var(--sig-text-muted);
 	}
 
@@ -566,18 +821,38 @@ async function finish(): Promise<void> {
 	.harness-main {
 		display: flex;
 		flex-direction: column;
-		gap: 6px;
+		gap: 7px;
 	}
 
 	.field-wide {
 		grid-column: 1 / -1;
 	}
 
+	:global(.onboarding-input) {
+		border-radius: var(--sig-radius) !important;
+		border-color: var(--sig-border-strong) !important;
+		background: color-mix(in srgb, var(--sig-bg), transparent 6%) !important;
+		color: var(--sig-text-bright) !important;
+		font-family: var(--font-mono, monospace) !important;
+		box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.28) !important;
+	}
+
+	:global(.onboarding-textarea) {
+		min-height: 74px !important;
+		resize: vertical;
+	}
+
 	.harness-list,
 	.provider-detail {
 		display: flex;
 		flex-direction: column;
-		gap: 8px;
+		gap: 9px;
+	}
+
+	.harness-list {
+		max-height: 268px;
+		overflow: auto;
+		padding-right: 2px;
 	}
 
 	.harness-row {
@@ -585,14 +860,13 @@ async function finish(): Promise<void> {
 		align-items: center;
 		gap: 10px;
 		padding: 10px;
-		border: 1px solid var(--sig-border);
-		background: var(--sig-bg);
 		cursor: pointer;
 	}
 
 	.harness-row-active {
-		border-color: var(--sig-border-strong);
-		background: color-mix(in srgb, var(--sig-surface-raised), var(--sig-highlight) 5%);
+		border-color: var(--sig-highlight-dim);
+		background: var(--sig-highlight-muted);
+		box-shadow: inset 3px 0 0 var(--sig-highlight), inset 0 1px 0 rgba(255, 255, 255, 0.05);
 	}
 
 	.status-dot {
@@ -600,11 +874,13 @@ async function finish(): Promise<void> {
 		height: 8px;
 		border: 1px solid var(--sig-text-muted);
 		background: transparent;
+		flex: 0 0 auto;
 	}
 
 	.status-dot-installed {
 		border-color: var(--sig-success);
 		background: var(--sig-success);
+		box-shadow: 0 0 8px color-mix(in srgb, var(--sig-success), transparent 40%);
 	}
 
 	.harness-main {
@@ -625,34 +901,60 @@ async function finish(): Promise<void> {
 
 	.provider-grid {
 		display: grid;
-		grid-template-columns: repeat(5, minmax(0, 1fr));
-		gap: 8px;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 9px;
 		margin-bottom: 12px;
 	}
 
+	.provider-group-title {
+		grid-column: 1 / -1;
+		margin: 2px 0 -2px;
+		font-family: var(--font-mono, monospace);
+		font-size: 10px;
+		letter-spacing: 0.11em;
+		text-transform: uppercase;
+		color: var(--sig-highlight-text);
+	}
+
+	.provider-group-title-secondary {
+		margin-top: 8px;
+		color: var(--sig-text-muted);
+	}
+
+	.provider-card-compact {
+		min-height: 72px;
+	}
+
+	.provider-card-compact small {
+		display: none;
+	}
+
 	.provider-card {
-		min-height: 92px;
-		padding: 10px;
+		min-height: 78px;
+		padding: 12px;
 		text-align: left;
-		border: 1px solid var(--sig-border);
-		background: var(--sig-bg);
 		color: var(--sig-text);
 		cursor: pointer;
 	}
 
-	.provider-card span {
+	.provider-card strong {
 		display: block;
-		margin-bottom: 7px;
-		font-family: var(--font-display, inherit);
+		margin: 7px 0 6px;
+		font-family: var(--font-display, monospace);
 		font-size: 13px;
+		letter-spacing: 0.08em;
 		text-transform: uppercase;
 		color: var(--sig-text-bright);
 	}
 
 	.provider-card-active {
 		border-color: var(--sig-highlight);
-		background: color-mix(in srgb, var(--sig-bg), var(--sig-highlight) 9%);
-		box-shadow: inset 3px 0 0 var(--sig-highlight);
+		background: color-mix(in srgb, var(--sig-surface-raised), var(--sig-highlight) 10%);
+		box-shadow: var(--sig-glow-highlight), inset 3px 0 0 var(--sig-highlight), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+	}
+
+	.provider-mode {
+		color: var(--sig-highlight-text);
 	}
 
 	.detail-banner {
@@ -661,14 +963,15 @@ async function finish(): Promise<void> {
 		align-items: center;
 		padding: 10px 12px;
 		border: 1px solid var(--sig-border-strong);
-		background: var(--sig-surface-raised);
+		border-radius: var(--sig-radius);
+		background: var(--sig-bg);
 	}
 
 	.detail-banner span {
 		font-family: var(--font-mono, monospace);
 		font-size: 10px;
 		text-transform: uppercase;
-		color: var(--sig-highlight);
+		color: var(--sig-highlight-text);
 	}
 
 	.choice-row {
@@ -677,32 +980,40 @@ async function finish(): Promise<void> {
 		gap: 8px;
 	}
 
+	.preset-row {
+		padding-top: 2px;
+	}
+
 	.choice-pill {
-		border: 1px solid var(--sig-border);
-		background: var(--sig-bg);
-		color: var(--sig-text);
 		padding: 7px 10px;
 		font-family: var(--font-mono, monospace);
-		font-size: 11px;
+		font-size: 12px;
+		color: var(--sig-text);
 		cursor: pointer;
 	}
 
 	.choice-pill-active {
 		border-color: var(--sig-highlight);
 		color: var(--sig-text-bright);
-		background: color-mix(in srgb, var(--sig-bg), var(--sig-highlight) 8%);
+		background: var(--sig-highlight-muted);
 	}
 
 	.inline-toggle {
 		display: flex;
 		align-items: center;
 		gap: 9px;
+		padding: 10px;
 		font-size: 12px;
 		color: var(--sig-text);
+		cursor: pointer;
 	}
 
 	.next-panel {
-		background: color-mix(in srgb, var(--sig-surface), var(--sig-highlight) 3%);
+		background: color-mix(in srgb, var(--sig-surface), var(--sig-success) 4%);
+	}
+
+	.next-row .choice-pill:first-child {
+		border-color: color-mix(in srgb, var(--sig-success), var(--sig-border-strong) 35%);
 	}
 
 	.onboarding-actions {
@@ -710,8 +1021,7 @@ async function finish(): Promise<void> {
 		align-items: center;
 		justify-content: space-between;
 		gap: 12px;
-		padding: 14px;
-		border-top: 1px solid var(--sig-border-strong);
+		padding: 16px 22px;
 		background: var(--sig-surface);
 	}
 
@@ -720,15 +1030,53 @@ async function finish(): Promise<void> {
 		gap: 10px;
 	}
 
-	@media (max-width: 900px) {
+	@media (max-width: 980px) {
 		.onboarding-body,
+		.setup-main,
 		.field-grid,
 		.provider-grid {
 			grid-template-columns: 1fr;
 		}
 
-		.setup-panel-wide {
+		.setup-summary {
+			position: relative;
+			min-height: auto;
+		}
+
+		.identity-panel,
+		.memory-panel,
+		.next-panel {
 			grid-column: auto;
+			grid-row: auto;
+		}
+	}
+
+	@media (max-width: 620px) {
+		.onboarding-backdrop {
+			padding: 8px;
+		}
+
+		.onboarding-header {
+			padding: 22px 18px 18px;
+		}
+
+		.header-coordinate,
+		.progress-rail,
+		.setup-summary {
+			display: none;
+		}
+
+		.onboarding-body {
+			padding: 10px;
+		}
+
+		.onboarding-actions {
+			align-items: stretch;
+			flex-direction: column;
+		}
+
+		.action-cluster {
+			justify-content: flex-end;
 		}
 	}
 </style>

--- a/surfaces/dashboard/src/lib/components/onboarding/OnboardingModal.svelte
+++ b/surfaces/dashboard/src/lib/components/onboarding/OnboardingModal.svelte
@@ -1,0 +1,353 @@
+<script lang="ts">
+import { invalidateAll } from "$app/navigation";
+import type { ConfigFile, DaemonStatus, MemoryStats } from "$lib/api";
+import { applyRecommendedPipelineSetup } from "$lib/components/tabs/settings/pipeline-settings";
+import { Button } from "$lib/components/ui/button/index.js";
+import { Input } from "$lib/components/ui/input/index.js";
+import * as Select from "$lib/components/ui/select/index.js";
+import type { TabId } from "$lib/stores/navigation.svelte";
+import { st } from "$lib/stores/settings.svelte";
+import { toast } from "$lib/stores/toast.svelte";
+import type { PipelineProviderChoice } from "@signet/core/pipeline-providers";
+import { onMount, untrack } from "svelte";
+
+interface Props {
+	configFiles: ConfigFile[];
+	memoryStats: MemoryStats;
+	daemonStatus: DaemonStatus | null;
+	onnavigate?: (tab: TabId) => void;
+}
+
+const { configFiles, memoryStats, daemonStatus, onnavigate }: Props = $props();
+
+const selectTriggerClass =
+	"font-mono text-[11px] text-[var(--sig-text)] bg-[var(--sig-bg)] border-[var(--sig-border-strong)] rounded-md w-full h-9 px-2 box-border focus-visible:border-[var(--sig-accent)]";
+const selectContentClass =
+	"font-mono text-[11px] bg-[var(--sig-bg)] text-[var(--sig-text)] border-[var(--sig-border-strong)] rounded-md";
+const selectItemClass = "font-mono text-[11px] rounded-md";
+
+const PROVIDERS: Array<{ value: PipelineProviderChoice; label: string; model: string; note: string }> = [
+	{
+		value: "acpx",
+		label: "ACPX — use existing agent CLI",
+		model: "gpt-5-codex-mini",
+		note: "Best default if Codex/Claude/OpenCode is already configured.",
+	},
+	{
+		value: "llama-cpp",
+		label: "llama.cpp — local",
+		model: "qwen3.5:4b",
+		note: "Local extraction; needs a llama.cpp server.",
+	},
+	{
+		value: "ollama",
+		label: "Ollama — local",
+		model: "qwen3:4b",
+		note: "Local extraction; needs Ollama and the model installed.",
+	},
+	{
+		value: "none",
+		label: "Disable background extraction",
+		model: "",
+		note: "Safe choice for VPS/shared installs or testing the shell only.",
+	},
+];
+
+let open = $state(false);
+let initialized = $state(false);
+let saving = $state(false);
+let agentName = $state("My Agent");
+let agentDescription = $state("Personal AI assistant");
+let provider = $state<PipelineProviderChoice>("acpx");
+let model = $state("gpt-5-codex-mini");
+let forceOpen = false;
+
+const storageKey = $derived(`signet:onboarding:dismissed:${daemonStatus?.agentsDir ?? "unknown"}`);
+const providerNote = $derived(PROVIDERS.find((option) => option.value === provider)?.note ?? "");
+
+function currentProvider(): PipelineProviderChoice {
+	const raw = st.aStr(["memory", "pipelineV2", "extractionProvider"]);
+	return PROVIDERS.some((option) => option.value === raw) ? (raw as PipelineProviderChoice) : "acpx";
+}
+
+function hydrateFromSettings(): void {
+	st.init(configFiles);
+	agentName = st.aStr(["agent", "name"]) || st.aStr(["name"]) || "My Agent";
+	agentDescription = st.aStr(["agent", "description"]) || st.aStr(["description"]) || "Personal AI assistant";
+	provider = currentProvider();
+	model =
+		st.aStr(["memory", "pipelineV2", "extractionModel"]) ||
+		PROVIDERS.find((option) => option.value === provider)?.model ||
+		"";
+	initialized = true;
+}
+
+function isDefaultishWorkspace(): boolean {
+	const name = agentName.trim().toLowerCase();
+	return memoryStats.total === 0 && (name === "my agent" || name.length === 0);
+}
+
+function maybeOpen(): void {
+	if (typeof window === "undefined") return;
+	if (!initialized || !daemonStatus) return;
+	if (forceOpen) {
+		open = true;
+		return;
+	}
+	if (localStorage.getItem(storageKey) === "true") return;
+	if (isDefaultishWorkspace()) open = true;
+}
+
+onMount(() => {
+	forceOpen = new URLSearchParams(window.location.search).get("onboarding") === "1";
+	untrack(hydrateFromSettings);
+	maybeOpen();
+});
+
+$effect(() => {
+	const _configFiles = configFiles;
+	untrack(hydrateFromSettings);
+});
+
+$effect(() => {
+	const _daemonStatus = daemonStatus;
+	const _memoryTotal = memoryStats.total;
+	void _daemonStatus;
+	void _memoryTotal;
+	maybeOpen();
+});
+
+function setProvider(value: string | undefined): void {
+	const next = PROVIDERS.find((option) => option.value === value);
+	if (!next) return;
+	provider = next.value;
+	model = next.model;
+}
+
+function dismiss(): void {
+	localStorage.setItem(storageKey, "true");
+	open = false;
+}
+
+function openSettings(): void {
+	dismiss();
+	onnavigate?.("settings");
+}
+
+async function finish(): Promise<void> {
+	if (saving) return;
+	saving = true;
+	try {
+		st.aSetStr(["agent", "name"], agentName.trim() || "My Agent");
+		st.aSetStr(["agent", "description"], agentDescription.trim() || "Personal AI assistant");
+		applyRecommendedPipelineSetup(st.agent, { provider, model });
+		st.agent = { ...st.agent };
+		await st.save();
+		localStorage.setItem(storageKey, "true");
+		open = false;
+		await invalidateAll();
+		toast("Onboarding settings saved", "success");
+	} finally {
+		saving = false;
+	}
+}
+</script>
+
+{#if open}
+	<div class="onboarding-backdrop" role="presentation">
+		<div class="onboarding-modal" role="dialog" aria-modal="true" aria-labelledby="onboarding-title" tabindex="-1">
+			<div class="onboarding-rail" aria-hidden="true"></div>
+			<header class="onboarding-header">
+				<div>
+					<p class="onboarding-kicker">First run</p>
+					<h2 id="onboarding-title">Set up your Signet workspace</h2>
+				</div>
+				<button class="icon-button" type="button" aria-label="Dismiss onboarding" onclick={dismiss}>×</button>
+			</header>
+
+			<div class="onboarding-grid">
+				<label class="field">
+					<span>Agent name</span>
+					<Input bind:value={agentName} placeholder="My Agent" />
+				</label>
+
+				<label class="field">
+					<span>Agent description</span>
+					<Input bind:value={agentDescription} placeholder="Personal AI assistant" />
+				</label>
+
+				<div class="field field-wide">
+					<span>Memory extraction provider</span>
+					<Select.Root type="single" value={provider} onValueChange={setProvider}>
+						<Select.Trigger class={selectTriggerClass}>
+							{PROVIDERS.find((option) => option.value === provider)?.label ?? provider}
+						</Select.Trigger>
+						<Select.Content class={selectContentClass}>
+							{#each PROVIDERS as option (option.value)}
+								<Select.Item class={selectItemClass} value={option.value} label={option.label} />
+							{/each}
+						</Select.Content>
+					</Select.Root>
+					<small>{providerNote}</small>
+				</div>
+
+				<label class="field field-wide">
+					<span>Model</span>
+					<Input bind:value={model} placeholder={provider === "none" ? "disabled" : "model id"} disabled={provider === "none"} />
+				</label>
+			</div>
+
+			<div class="onboarding-copy">
+				<p>These choices write the existing <code>agent.yaml</code> identity and <code>memory.pipelineV2</code> provider settings. No separate dashboard-only ACPX routing gets created.</p>
+			</div>
+
+			<footer class="onboarding-actions">
+				<Button variant="ghost" type="button" onclick={openSettings}>Open full settings</Button>
+				<div class="action-cluster">
+					<Button variant="outline" type="button" onclick={dismiss}>Skip for now</Button>
+					<Button type="button" onclick={finish} disabled={saving}>{saving ? "Saving…" : "Save and start"}</Button>
+				</div>
+			</footer>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.onboarding-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: 90;
+		display: grid;
+		place-items: center;
+		padding: 24px;
+		background:
+			linear-gradient(135deg, color-mix(in srgb, var(--sig-bg), transparent 8%), color-mix(in srgb, var(--sig-bg), transparent 24%)),
+			rgba(0, 0, 0, 0.55);
+		backdrop-filter: blur(8px);
+	}
+
+	.onboarding-modal {
+		position: relative;
+		width: min(720px, 100%);
+		border: 1px solid var(--sig-border-strong);
+		border-radius: 0;
+		background: color-mix(in srgb, var(--sig-surface), var(--sig-bg) 18%);
+		box-shadow: 0 24px 80px rgba(0, 0, 0, 0.5);
+		overflow: hidden;
+	}
+
+	.onboarding-rail {
+		position: absolute;
+		inset: 0 auto 0 0;
+		width: 4px;
+		background: var(--sig-highlight);
+		box-shadow: 0 0 24px color-mix(in srgb, var(--sig-highlight), transparent 40%);
+	}
+
+	.onboarding-header {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 16px;
+		padding: 22px 24px 16px 28px;
+		border-bottom: 1px solid var(--sig-border);
+	}
+
+	.onboarding-kicker,
+	.field > span {
+		margin: 0 0 6px;
+		font-family: var(--font-mono, monospace);
+		font-size: 10px;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--sig-highlight);
+	}
+
+	h2 {
+		margin: 0;
+		font-family: var(--font-heading, inherit);
+		font-size: 24px;
+		letter-spacing: -0.02em;
+		color: var(--sig-text-bright);
+	}
+
+	.icon-button {
+		border: 1px solid var(--sig-border-strong);
+		background: transparent;
+		color: var(--sig-text-muted);
+		font-size: 20px;
+		line-height: 1;
+		width: 32px;
+		height: 32px;
+		cursor: pointer;
+	}
+
+	.icon-button:hover {
+		color: var(--sig-text-bright);
+		border-color: var(--sig-highlight);
+	}
+
+	.onboarding-grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 14px;
+		padding: 20px 24px 10px 28px;
+	}
+
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+
+	.field-wide {
+		grid-column: 1 / -1;
+	}
+
+	small {
+		font-size: 11px;
+		line-height: 1.4;
+		color: var(--sig-text-muted);
+	}
+
+	.onboarding-copy {
+		padding: 4px 24px 0 28px;
+		font-size: 12px;
+		line-height: 1.55;
+		color: var(--sig-text-muted);
+	}
+
+	code {
+		font-family: var(--font-mono, monospace);
+		font-size: 11px;
+		color: var(--sig-highlight);
+	}
+
+	.onboarding-actions {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+		padding: 18px 24px 22px 28px;
+	}
+
+	.action-cluster {
+		display: flex;
+		gap: 10px;
+	}
+
+	@media (max-width: 640px) {
+		.onboarding-grid {
+			grid-template-columns: 1fr;
+		}
+
+		.onboarding-actions {
+			align-items: stretch;
+			flex-direction: column-reverse;
+		}
+
+		.action-cluster {
+			flex-direction: column;
+		}
+	}
+</style>

--- a/surfaces/dashboard/src/lib/components/onboarding/OnboardingModal.svelte
+++ b/surfaces/dashboard/src/lib/components/onboarding/OnboardingModal.svelte
@@ -120,6 +120,7 @@ let endpoint = $state("");
 let selectedHarness = $state("");
 let selectedHarnesses = $state<string[]>([]);
 let synthesisEnabled = $state(true);
+let showAdvancedProviders = $state(false);
 // biome-ignore lint/style/useConst: Svelte state is mutated by onboarding buttons.
 let afterSaveTab = $state<TabId | "stay" | "sources">("sources");
 let forceOpen = false;
@@ -384,24 +385,32 @@ async function finish(): Promise<void> {
 							<p class="provider-group-title">Recommended routes</p>
 							{#each PROVIDERS as option (option.value)}
 								{#if option.value === "acpx" || option.value === "ollama" || option.value === "codex" || option.value === "claude-code"}
-									<button type="button" class="provider-card sig-switch" class:provider-card-active={provider === option.value} onclick={() => chooseProvider(option.value)}>
+									<button type="button" class="provider-card sig-switch" class:provider-card-active={provider === option.value} onclick={() => chooseProvider(option.value)} aria-pressed={provider === option.value}>
 										<span class="provider-mode">{option.mode}</span>
+										{#if provider === option.value}<span class="selected-badge">selected</span>{/if}
 										<strong>{option.label}</strong>
 										<small>{option.detail}</small>
 									</button>
 								{/if}
 							{/each}
 
-							<p class="provider-group-title provider-group-title-secondary">Other routes</p>
-							{#each PROVIDERS as option (option.value)}
-								{#if option.value !== "acpx" && option.value !== "ollama" && option.value !== "codex" && option.value !== "claude-code"}
-									<button type="button" class="provider-card provider-card-compact sig-switch" class:provider-card-active={provider === option.value} onclick={() => chooseProvider(option.value)}>
-										<span class="provider-mode">{option.mode}</span>
-										<strong>{option.label}</strong>
-										<small>{option.detail}</small>
-									</button>
-								{/if}
-							{/each}
+							<button type="button" class="advanced-toggle sig-switch" onclick={() => { showAdvancedProviders = !showAdvancedProviders; }} aria-expanded={showAdvancedProviders}>
+								<span>{showAdvancedProviders ? "Hide advanced routes" : "Show advanced routes"}</span>
+							</button>
+
+							{#if showAdvancedProviders}
+								<p class="provider-group-title provider-group-title-secondary">Advanced routes</p>
+								{#each PROVIDERS as option (option.value)}
+									{#if option.value !== "acpx" && option.value !== "ollama" && option.value !== "codex" && option.value !== "claude-code"}
+										<button type="button" class="provider-card provider-card-compact sig-switch" class:provider-card-active={provider === option.value} onclick={() => chooseProvider(option.value)} aria-pressed={provider === option.value}>
+											<span class="provider-mode">{option.mode}</span>
+											{#if provider === option.value}<span class="selected-badge">selected</span>{/if}
+											<strong>{option.label}</strong>
+											<small>{option.detail}</small>
+										</button>
+									{/if}
+								{/each}
+							{/if}
 						</div>
 
 						<div class="provider-detail">
@@ -468,10 +477,12 @@ async function finish(): Promise<void> {
 			</div>
 
 			<footer class="onboarding-actions sig-panel-footer">
-				<Button variant="ghost" type="button" onclick={openSettings}>Open full settings</Button>
+				<div class="secondary-actions">
+					<Button variant="ghost" type="button" onclick={openSettings}>Open full settings</Button>
+					<Button variant="ghost" type="button" onclick={dismiss}>Skip for now</Button>
+				</div>
 				<div class="action-cluster">
-					<Button variant="outline" type="button" onclick={dismiss}>Skip</Button>
-					<Button type="button" onclick={finish} disabled={saving}>{saving ? "Saving…" : "Save and continue"}</Button>
+					<Button type="button" onclick={finish} disabled={saving}>{saving ? "Saving…" : afterSaveTab === "sources" ? "Continue to sources" : "Save setup"}</Button>
 				</div>
 			</footer>
 		</div>
@@ -930,6 +941,7 @@ async function finish(): Promise<void> {
 	}
 
 	.provider-card {
+		position: relative;
 		min-height: 78px;
 		padding: 12px;
 		text-align: left;
@@ -955,6 +967,30 @@ async function finish(): Promise<void> {
 
 	.provider-mode {
 		color: var(--sig-highlight-text);
+	}
+
+	.selected-badge {
+		position: absolute;
+		top: 9px;
+		right: 10px;
+		font-family: var(--font-mono, monospace);
+		font-size: 9px;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--sig-highlight-text);
+	}
+
+	.advanced-toggle {
+		grid-column: 1 / -1;
+		justify-content: center;
+		min-height: 36px;
+		padding: 8px 12px;
+		font-family: var(--font-mono, monospace);
+		font-size: 11px;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--sig-text);
+		cursor: pointer;
 	}
 
 	.detail-banner {
@@ -1025,9 +1061,11 @@ async function finish(): Promise<void> {
 		background: var(--sig-surface);
 	}
 
-	.action-cluster {
+	.action-cluster,
+	.secondary-actions {
 		display: flex;
 		gap: 10px;
+		align-items: center;
 	}
 
 	@media (max-width: 980px) {
@@ -1056,8 +1094,34 @@ async function finish(): Promise<void> {
 			padding: 8px;
 		}
 
+		.onboarding-modal {
+			max-height: calc(100dvh - 16px);
+		}
+
 		.onboarding-header {
-			padding: 22px 18px 18px;
+			padding: 18px 16px 16px;
+			gap: 12px;
+		}
+
+		.onboarding-header::after {
+			display: none;
+		}
+
+		h2 {
+			font-size: 24px;
+			line-height: 1;
+			letter-spacing: 0.04em;
+		}
+
+		.lede {
+			font-size: 13px;
+			line-height: 1.35;
+		}
+
+		.icon-button {
+			width: 42px;
+			height: 42px;
+			flex: 0 0 auto;
 		}
 
 		.header-coordinate,
@@ -1067,16 +1131,38 @@ async function finish(): Promise<void> {
 		}
 
 		.onboarding-body {
-			padding: 10px;
+			padding: 12px 12px 18px;
+		}
+
+		.setup-panel {
+			padding: 14px;
+		}
+
+		.harness-list {
+			max-height: 242px;
+		}
+
+		.provider-card {
+			min-height: 72px;
+		}
+
+		.provider-card small,
+		.harness-main small,
+		.section-head p,
+		.detail-banner p {
+			font-size: 12px;
+			line-height: 1.35;
 		}
 
 		.onboarding-actions {
 			align-items: stretch;
 			flex-direction: column;
+			padding: 12px;
 		}
 
-		.action-cluster {
-			justify-content: flex-end;
+		.action-cluster,
+		.secondary-actions {
+			justify-content: space-between;
 		}
 	}
 </style>

--- a/surfaces/dashboard/src/lib/components/onboarding/OnboardingModal.svelte
+++ b/surfaces/dashboard/src/lib/components/onboarding/OnboardingModal.svelte
@@ -284,7 +284,7 @@ async function finish(): Promise<void> {
 						<span>FIRST_RUN_SEQUENCE</span>
 						<span class="header-coordinate">AGENT_BOOTSTRAP / 04</span>
 					</div>
-					<h2 id="onboarding-title">Bring this agent online</h2>
+					<h2 id="onboarding-title">Initialize Signet</h2>
 					<p class="lede">Set identity, harness sync, and memory extraction. Everything can change later.</p>
 				</div>
 				<button class="icon-button sig-switch" type="button" aria-label="Dismiss onboarding" onclick={dismiss}>×</button>
@@ -459,20 +459,6 @@ async function finish(): Promise<void> {
 						</div>
 					</section>
 
-					<section class="setup-panel next-panel">
-						<div class="section-head">
-							<span class="step">04</span>
-							<div>
-								<h3>Continue</h3>
-								<p>Save the basics, then move into the thing that makes memory useful: source connection.</p>
-							</div>
-						</div>
-						<div class="choice-row next-row">
-							<button type="button" class="choice-pill sig-switch" class:choice-pill-active={afterSaveTab === "sources"} onclick={() => { afterSaveTab = "sources"; }}>Connect sources</button>
-							<button type="button" class="choice-pill sig-switch" class:choice-pill-active={afterSaveTab === "settings"} onclick={() => { afterSaveTab = "settings"; }}>Review settings</button>
-							<button type="button" class="choice-pill sig-switch" class:choice-pill-active={afterSaveTab === "stay"} onclick={() => { afterSaveTab = "stay"; }}>Stay here</button>
-						</div>
-					</section>
 				</main>
 			</div>
 
@@ -648,7 +634,7 @@ async function finish(): Promise<void> {
 		display: flex;
 		align-items: center;
 		gap: 8px;
-		padding: 12px 34px;
+		padding: 9px 30px;
 		border-right: 1px solid var(--sig-border);
 		background: var(--sig-surface);
 	}
@@ -658,7 +644,7 @@ async function finish(): Promise<void> {
 		place-items: center;
 		width: auto;
 		min-width: 82px;
-		height: 22px;
+		height: 20px;
 		padding: 0 8px;
 		border: 1px solid var(--sig-border);
 		font-family: var(--font-mono, monospace);
@@ -687,8 +673,8 @@ async function finish(): Promise<void> {
 	.onboarding-body {
 		display: grid;
 		grid-template-columns: 1fr;
-		gap: 18px;
-		padding: 18px 18px 28px;
+		gap: 14px;
+		padding: 14px 16px 16px;
 		overflow: auto;
 		background:
 			radial-gradient(circle at 22% 18%, var(--sig-highlight-dim), transparent 28%),
@@ -698,7 +684,7 @@ async function finish(): Promise<void> {
 	.setup-main {
 		display: grid;
 		grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
-		gap: 18px;
+		gap: 14px;
 		align-items: start;
 	}
 
@@ -707,7 +693,7 @@ async function finish(): Promise<void> {
 		border: 1px solid var(--sig-border-strong);
 		border-radius: var(--sig-radius);
 		background: color-mix(in srgb, var(--sig-surface), transparent 5%);
-		padding: 16px;
+		padding: 14px;
 		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 1px 3px rgba(0, 0, 0, 0.28);
 		overflow: hidden;
 	}
@@ -775,8 +761,7 @@ async function finish(): Promise<void> {
 		word-break: break-word;
 	}
 
-	.identity-panel,
-	.next-panel {
+	.identity-panel {
 		grid-column: 1;
 	}
 
@@ -790,7 +775,7 @@ async function finish(): Promise<void> {
 		display: flex;
 		gap: 12px;
 		align-items: flex-start;
-		margin-bottom: 14px;
+		margin-bottom: 11px;
 	}
 
 	.step {
@@ -849,7 +834,7 @@ async function finish(): Promise<void> {
 	}
 
 	:global(.onboarding-textarea) {
-		min-height: 74px !important;
+		min-height: 56px !important;
 		resize: vertical;
 	}
 
@@ -861,7 +846,7 @@ async function finish(): Promise<void> {
 	}
 
 	.harness-list {
-		max-height: 268px;
+		max-height: 198px;
 		overflow: auto;
 		padding-right: 2px;
 	}
@@ -942,16 +927,20 @@ async function finish(): Promise<void> {
 
 	.provider-card {
 		position: relative;
-		min-height: 78px;
-		padding: 12px;
+		min-height: 64px;
+		padding: 10px 12px;
 		text-align: left;
 		color: var(--sig-text);
 		cursor: pointer;
 	}
 
+	.provider-card small {
+		display: none;
+	}
+
 	.provider-card strong {
 		display: block;
-		margin: 7px 0 6px;
+		margin: 6px 0 0;
 		font-family: var(--font-display, monospace);
 		font-size: 13px;
 		letter-spacing: 0.08em;
@@ -1044,20 +1033,12 @@ async function finish(): Promise<void> {
 		cursor: pointer;
 	}
 
-	.next-panel {
-		background: color-mix(in srgb, var(--sig-surface), var(--sig-success) 4%);
-	}
-
-	.next-row .choice-pill:first-child {
-		border-color: color-mix(in srgb, var(--sig-success), var(--sig-border-strong) 35%);
-	}
-
 	.onboarding-actions {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
 		gap: 12px;
-		padding: 16px 22px;
+		padding: 12px 18px;
 		background: var(--sig-surface);
 	}
 
@@ -1082,8 +1063,7 @@ async function finish(): Promise<void> {
 		}
 
 		.identity-panel,
-		.memory-panel,
-		.next-panel {
+		.memory-panel {
 			grid-column: auto;
 			grid-row: auto;
 		}

--- a/surfaces/dashboard/src/lib/components/onboarding/OnboardingModal.svelte
+++ b/surfaces/dashboard/src/lib/components/onboarding/OnboardingModal.svelte
@@ -290,42 +290,36 @@ async function finish(): Promise<void> {
 				<button class="icon-button sig-switch" type="button" aria-label="Dismiss onboarding" onclick={dismiss}>×</button>
 			</header>
 
-			<div class="progress-rail" aria-hidden="true">
-				<span class="progress-node progress-node-active">01 Identity</span>
-				<span class="progress-line"></span>
-				<span class="progress-node progress-node-active">02 Harness</span>
-				<span class="progress-line"></span>
-				<span class="progress-node progress-node-active">03 Memory</span>
-				<span class="progress-line progress-line-muted"></span>
-				<span class="progress-node">04 Sources</span>
-			</div>
-
 			<div class="onboarding-body">
-				<aside class="setup-summary setup-panel" aria-hidden="true">
-					<div class="summary-readout">
-						<span class="summary-label">ACTIVE PROFILE</span>
-						<strong>{agentName.trim() || "My Agent"}</strong>
-						<p>{agentDescription.trim() || "Personal AI assistant"}</p>
-					</div>
-					<div class="summary-grid">
+				<aside class="step-nav" aria-label="Onboarding steps">
+					<div class="step-nav-item step-nav-item-active">
+						<span class="step-nav-index">01</span>
 						<div>
-							<span>provider</span>
-							<strong>{providerOption.label}</strong>
-						</div>
-						<div>
-							<span>model</span>
-							<strong>{provider === "none" ? "disabled" : model}</strong>
-						</div>
-						<div>
-							<span>harnesses</span>
-							<strong>{selectedHarnesses.length || 0} selected</strong>
-						</div>
-						<div>
-							<span>next</span>
-							<strong>{afterSaveTab === "sources" ? "sources" : afterSaveTab === "settings" ? "settings" : "dashboard"}</strong>
+							<strong>Identity</strong>
+							<small>Name and describe your agent</small>
 						</div>
 					</div>
-					<p class="summary-note">Recommended: keep the default harness, choose the extraction backend you already trust, then connect sources.</p>
+					<div class="step-nav-item">
+						<span class="step-nav-index">02</span>
+						<div>
+							<strong>Harness sync</strong>
+							<small>Select harnesses to sync with</small>
+						</div>
+					</div>
+					<div class="step-nav-item">
+						<span class="step-nav-index">03</span>
+						<div>
+							<strong>Memory engine</strong>
+							<small>Choose memory extraction routes</small>
+						</div>
+					</div>
+					<div class="step-nav-item">
+						<span class="step-nav-index">04</span>
+						<div>
+							<strong>Sources</strong>
+							<small>Review and continue</small>
+						</div>
+					</div>
 				</aside>
 
 				<main class="setup-main">
@@ -354,7 +348,7 @@ async function finish(): Promise<void> {
 							<span class="step">02</span>
 							<div>
 								<h3>Harness sync</h3>
-								<p>Choose where Signet should maintain this identity. Installed harnesses are ready now.</p>
+								<p>Choose where Signet maintains this identity.</p>
 							</div>
 						</div>
 						<div class="harness-list">
@@ -377,7 +371,7 @@ async function finish(): Promise<void> {
 							<span class="step">03</span>
 							<div>
 								<h3>Memory engine</h3>
-								<p>Pick the extraction path. The common choices are first; advanced routes stay available without dominating the flow.</p>
+								<p>Pick an extraction route. Advanced routes stay available without dominating the flow.</p>
 							</div>
 						</div>
 
@@ -386,6 +380,7 @@ async function finish(): Promise<void> {
 							{#each PROVIDERS as option (option.value)}
 								{#if option.value === "acpx" || option.value === "ollama" || option.value === "codex" || option.value === "claude-code"}
 									<button type="button" class="provider-card sig-switch" class:provider-card-active={provider === option.value} onclick={() => chooseProvider(option.value)} aria-pressed={provider === option.value}>
+										<span class="provider-radio" aria-hidden="true"></span>
 										<span class="provider-mode">{option.mode}</span>
 										{#if provider === option.value}<span class="selected-badge">selected</span>{/if}
 										<strong>{option.label}</strong>
@@ -403,6 +398,7 @@ async function finish(): Promise<void> {
 								{#each PROVIDERS as option (option.value)}
 									{#if option.value !== "acpx" && option.value !== "ollama" && option.value !== "codex" && option.value !== "claude-code"}
 										<button type="button" class="provider-card provider-card-compact sig-switch" class:provider-card-active={provider === option.value} onclick={() => chooseProvider(option.value)} aria-pressed={provider === option.value}>
+											<span class="provider-radio" aria-hidden="true"></span>
 											<span class="provider-mode">{option.mode}</span>
 											{#if provider === option.value}<span class="selected-badge">selected</span>{/if}
 											<strong>{option.label}</strong>
@@ -468,7 +464,7 @@ async function finish(): Promise<void> {
 					<Button variant="ghost" type="button" onclick={dismiss}>Skip for now</Button>
 				</div>
 				<div class="action-cluster">
-					<Button type="button" onclick={finish} disabled={saving}>{saving ? "Saving…" : afterSaveTab === "sources" ? "Continue to sources" : "Save setup"}</Button>
+					<Button type="button" onclick={finish} disabled={saving}>{saving ? "Saving…" : afterSaveTab === "sources" ? "Continue to sources →" : "Save setup"}</Button>
 				</div>
 			</footer>
 		</div>
@@ -491,8 +487,8 @@ async function finish(): Promise<void> {
 
 	.onboarding-modal {
 		position: relative;
-		width: min(1060px, 100%);
-		max-height: min(900px, calc(100vh - 48px));
+		width: min(1180px, 100%);
+		max-height: min(900px, calc(100vh - 32px));
 		display: flex;
 		flex-direction: column;
 		background: var(--sig-bg);
@@ -530,11 +526,12 @@ async function finish(): Promise<void> {
 		align-items: flex-start;
 		justify-content: space-between;
 		gap: 24px;
-		padding: 20px 30px 18px;
+		padding: 18px 30px 15px;
+		border-bottom: 1px solid var(--sig-border-strong);
 		background:
 			linear-gradient(var(--sig-grid-line) 1px, transparent 1px),
 			linear-gradient(90deg, var(--sig-grid-line) 1px, transparent 1px),
-			linear-gradient(135deg, color-mix(in srgb, var(--sig-surface-raised), var(--sig-highlight) 8%), var(--sig-bg) 64%);
+			linear-gradient(135deg, color-mix(in srgb, var(--sig-surface-raised), var(--sig-highlight) 5%), var(--sig-bg) 68%);
 		background-size: 28px 28px, 28px 28px, auto;
 		overflow: hidden;
 	}
@@ -563,9 +560,7 @@ async function finish(): Promise<void> {
 	.field > span,
 	.step,
 	.harness-state,
-	.provider-mode,
-	.summary-label,
-	.summary-grid span {
+	.provider-mode {
 		font-family: var(--font-mono, monospace);
 		font-size: 10px;
 		letter-spacing: 0.1em;
@@ -596,8 +591,7 @@ async function finish(): Promise<void> {
 	h2,
 	.lede,
 	h3,
-	.section-head p,
-	.summary-readout p {
+	.section-head p {
 		margin: 0;
 	}
 
@@ -613,9 +607,9 @@ async function finish(): Promise<void> {
 
 	.lede {
 		max-width: 650px;
-		margin-top: 10px;
-		font-size: 14px;
-		line-height: 1.45;
+		margin-top: 7px;
+		font-size: 13px;
+		line-height: 1.35;
 		color: var(--sig-text);
 	}
 
@@ -630,62 +624,78 @@ async function finish(): Promise<void> {
 		cursor: pointer;
 	}
 
-	.progress-rail {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-		padding: 9px 30px;
-		border-right: 1px solid var(--sig-border);
-		background: var(--sig-surface);
-	}
-
-	.progress-node {
-		display: grid;
-		place-items: center;
-		width: auto;
-		min-width: 82px;
-		height: 20px;
-		padding: 0 8px;
-		border: 1px solid var(--sig-border);
-		font-family: var(--font-mono, monospace);
-		font-size: 10px;
-		color: var(--sig-text-muted);
-		background: var(--sig-bg);
-	}
-
-	.progress-node-active {
-		border-color: var(--sig-highlight-dim);
-		color: var(--sig-highlight-text);
-		background: var(--sig-highlight-muted);
-	}
-
-	.progress-line {
-		flex: 1;
-		height: 1px;
-		background: linear-gradient(90deg, var(--sig-highlight), var(--sig-border-strong));
-		opacity: 0.55;
-	}
-
-	.progress-line-muted {
-		background: var(--sig-border);
-	}
-
 	.onboarding-body {
 		display: grid;
-		grid-template-columns: 1fr;
-		gap: 14px;
-		padding: 14px 16px 16px;
+		grid-template-columns: 196px minmax(0, 1fr);
+		gap: 0;
+		padding: 0;
 		overflow: auto;
 		background:
 			radial-gradient(circle at 22% 18%, var(--sig-highlight-dim), transparent 28%),
 			var(--sig-bg);
 	}
 
+	.step-nav {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		padding: 18px 16px;
+		border-right: 1px solid var(--sig-border-strong);
+		background: color-mix(in srgb, var(--sig-surface), transparent 18%);
+	}
+
+	.step-nav-item {
+		position: relative;
+		display: grid;
+		grid-template-columns: 28px minmax(0, 1fr);
+		gap: 10px;
+		padding: 11px 0 11px 12px;
+		border-left: 2px solid transparent;
+		color: var(--sig-text-muted);
+	}
+
+	.step-nav-item-active {
+		border-left-color: var(--sig-highlight);
+		color: var(--sig-highlight-text);
+		background: linear-gradient(90deg, var(--sig-highlight-muted), transparent 88%);
+	}
+
+	.step-nav-index,
+	.step-nav-item strong,
+	.step-nav-item small {
+		font-family: var(--font-mono, monospace);
+		text-transform: uppercase;
+	}
+
+	.step-nav-index {
+		font-size: 11px;
+		letter-spacing: 0.1em;
+		color: currentColor;
+	}
+
+	.step-nav-item strong {
+		display: block;
+		font-size: 11px;
+		letter-spacing: 0.11em;
+		color: currentColor;
+	}
+
+	.step-nav-item small {
+		display: block;
+		margin-top: 5px;
+		font-size: 11px;
+		line-height: 1.35;
+		letter-spacing: 0.01em;
+		text-transform: none;
+		color: var(--sig-text-muted);
+	}
+
 	.setup-main {
 		display: grid;
-		grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
+		grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
 		gap: 14px;
 		align-items: start;
+		padding: 8px 16px 8px;
 	}
 
 	.setup-panel {
@@ -693,7 +703,7 @@ async function finish(): Promise<void> {
 		border: 1px solid var(--sig-border-strong);
 		border-radius: var(--sig-radius);
 		background: color-mix(in srgb, var(--sig-surface), transparent 5%);
-		padding: 14px;
+		padding: 10px;
 		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 1px 3px rgba(0, 0, 0, 0.28);
 		overflow: hidden;
 	}
@@ -704,61 +714,6 @@ async function finish(): Promise<void> {
 		inset: 0;
 		pointer-events: none;
 		background: linear-gradient(135deg, rgba(255, 255, 255, 0.035), transparent 42%);
-	}
-
-	.setup-summary {
-		display: none;
-	}
-
-	.summary-readout {
-		position: relative;
-		padding-right: 16px;
-		border-right: 1px solid var(--sig-border);
-	}
-
-	.summary-readout strong {
-		display: block;
-		margin-top: 8px;
-		font-family: var(--font-display, monospace);
-		font-size: 26px;
-		line-height: 1;
-		letter-spacing: 0.08em;
-		text-transform: uppercase;
-		color: var(--sig-text-bright);
-	}
-
-	.summary-readout p,
-	.summary-note {
-		margin-top: 10px;
-		font-size: 13px;
-		line-height: 1.45;
-		color: var(--sig-text-muted);
-	}
-
-	.summary-grid {
-		display: grid;
-		grid-template-columns: repeat(4, minmax(0, 1fr));
-		border: 1px solid var(--sig-border);
-		background: var(--sig-bg);
-	}
-
-	.summary-grid div {
-		padding: 10px 11px;
-		border-right: 1px solid var(--sig-border);
-	}
-
-	.summary-grid div:last-child {
-		border-right: 0;
-	}
-
-	.summary-grid strong {
-		display: block;
-		margin-top: 4px;
-		font-family: var(--font-mono, monospace);
-		font-size: 15px;
-		line-height: 1.1;
-		color: var(--sig-text-bright);
-		word-break: break-word;
 	}
 
 	.identity-panel {
@@ -775,7 +730,7 @@ async function finish(): Promise<void> {
 		display: flex;
 		gap: 12px;
 		align-items: flex-start;
-		margin-bottom: 11px;
+		margin-bottom: 8px;
 	}
 
 	.step {
@@ -810,7 +765,7 @@ async function finish(): Promise<void> {
 	.field-grid {
 		display: grid;
 		grid-template-columns: repeat(2, minmax(0, 1fr));
-		gap: 12px;
+		gap: 10px;
 	}
 
 	.field,
@@ -834,7 +789,7 @@ async function finish(): Promise<void> {
 	}
 
 	:global(.onboarding-textarea) {
-		min-height: 56px !important;
+		min-height: 48px !important;
 		resize: vertical;
 	}
 
@@ -842,7 +797,7 @@ async function finish(): Promise<void> {
 	.provider-detail {
 		display: flex;
 		flex-direction: column;
-		gap: 9px;
+		gap: 8px;
 	}
 
 	.harness-list {
@@ -898,8 +853,8 @@ async function finish(): Promise<void> {
 	.provider-grid {
 		display: grid;
 		grid-template-columns: repeat(2, minmax(0, 1fr));
-		gap: 9px;
-		margin-bottom: 12px;
+		gap: 8px;
+		margin-bottom: 10px;
 	}
 
 	.provider-group-title {
@@ -927,11 +882,27 @@ async function finish(): Promise<void> {
 
 	.provider-card {
 		position: relative;
-		min-height: 64px;
-		padding: 10px 12px;
+		min-height: 40px;
+		padding: 8px 10px 8px 30px;
 		text-align: left;
 		color: var(--sig-text);
 		cursor: pointer;
+	}
+
+	.provider-radio {
+		position: absolute;
+		top: 13px;
+		left: 12px;
+		width: 12px;
+		height: 12px;
+		border: 1px solid var(--sig-border-strong);
+		background: var(--sig-bg);
+	}
+
+	.provider-card-active .provider-radio {
+		border-color: var(--sig-highlight);
+		background: var(--sig-highlight);
+		box-shadow: inset 0 0 0 3px var(--sig-bg), 0 0 9px color-mix(in srgb, var(--sig-highlight), transparent 36%);
 	}
 
 	.provider-card small {
@@ -940,7 +911,7 @@ async function finish(): Promise<void> {
 
 	.provider-card strong {
 		display: block;
-		margin: 6px 0 0;
+		margin: 4px 0 0;
 		font-family: var(--font-display, monospace);
 		font-size: 13px;
 		letter-spacing: 0.08em;
@@ -972,8 +943,8 @@ async function finish(): Promise<void> {
 	.advanced-toggle {
 		grid-column: 1 / -1;
 		justify-content: center;
-		min-height: 36px;
-		padding: 8px 12px;
+		min-height: 28px;
+		padding: 6px 10px;
 		font-family: var(--font-mono, monospace);
 		font-size: 11px;
 		letter-spacing: 0.08em;
@@ -986,7 +957,7 @@ async function finish(): Promise<void> {
 		display: flex;
 		gap: 12px;
 		align-items: center;
-		padding: 10px 12px;
+		padding: 8px 10px;
 		border: 1px solid var(--sig-border-strong);
 		border-radius: var(--sig-radius);
 		background: var(--sig-bg);
@@ -1038,7 +1009,7 @@ async function finish(): Promise<void> {
 		align-items: center;
 		justify-content: space-between;
 		gap: 12px;
-		padding: 12px 18px;
+		padding: 10px 18px;
 		background: var(--sig-surface);
 	}
 
@@ -1057,9 +1028,8 @@ async function finish(): Promise<void> {
 			grid-template-columns: 1fr;
 		}
 
-		.setup-summary {
-			position: relative;
-			min-height: auto;
+		.step-nav {
+			display: none;
 		}
 
 		.identity-panel,
@@ -1105,8 +1075,7 @@ async function finish(): Promise<void> {
 		}
 
 		.header-coordinate,
-		.progress-rail,
-		.setup-summary {
+		.step-nav {
 			display: none;
 		}
 

--- a/surfaces/dashboard/src/lib/components/onboarding/OnboardingStepShell.svelte
+++ b/surfaces/dashboard/src/lib/components/onboarding/OnboardingStepShell.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+	interface Props {
+		readonly stepNumber: string;
+		readonly title: string;
+		readonly subtitle: string;
+		readonly children: import("svelte").Snippet;
+	}
+
+	const { stepNumber, title, subtitle, children }: Props = $props();
+</script>
+
+<div class="step-shell">
+	<div class="step-shell-head">
+		<span class="step-shell-number">{stepNumber}</span>
+		<div>
+			<h3 class="step-shell-title">{title}</h3>
+			<p class="step-shell-subtitle">{subtitle}</p>
+		</div>
+	</div>
+	<div class="step-shell-body">
+		{@render children()}
+	</div>
+</div>
+
+<style>
+	.step-shell {
+		display: flex;
+		flex-direction: column;
+		gap: 14px;
+	}
+
+	.step-shell-head {
+		display: flex;
+		gap: 12px;
+		align-items: flex-start;
+	}
+
+	.step-shell-number {
+		display: inline-grid;
+		place-items: center;
+		width: 32px;
+		height: 32px;
+		border: 1px solid var(--sig-border-strong);
+		background: var(--sig-bg);
+		color: var(--sig-text-bright);
+		font-family: var(--font-mono, monospace);
+		font-size: 10px;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+		flex: 0 0 auto;
+	}
+
+	.step-shell-title {
+		margin: 0;
+		font-family: var(--font-display, monospace);
+		font-size: 14px;
+		letter-spacing: 0.09em;
+		color: var(--sig-text-bright);
+		text-transform: uppercase;
+	}
+
+	.step-shell-subtitle {
+		margin: 4px 0 0;
+		font-size: 12px;
+		line-height: 1.35;
+		color: var(--sig-text-muted);
+	}
+
+	.step-shell-body {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+</style>

--- a/surfaces/dashboard/src/lib/components/onboarding/onboarding-config.test.ts
+++ b/surfaces/dashboard/src/lib/components/onboarding/onboarding-config.test.ts
@@ -1,0 +1,117 @@
+/// <reference types="bun-types" />
+import { describe, expect, it } from "bun:test";
+import {
+	applyOnboardingConfig,
+	identityFileNamesForPreset,
+	missingIdentityFiles,
+	validateOnboardingStep,
+} from "./onboarding-config";
+import { createDefaultState } from "./onboarding-state.svelte";
+
+describe("onboarding config persistence", () => {
+	it("persists embedding and identity preset file lists into agent config", () => {
+		const state = createDefaultState();
+		state.identityPreset = "openclaw";
+		state.selectedHarnesses = ["codex"];
+		state.selectedHarness = "codex";
+		state.embeddingProvider = "ollama";
+		state.embeddingModel = "mxbai-embed-large";
+		state.embeddingEndpoint = "http://127.0.0.1:11434";
+		state.extractionProvider = "ollama";
+		state.extractionModel = "qwen3:4b";
+		state.extractionEndpoint = "http://127.0.0.1:11434";
+
+		const agent: Record<string, unknown> = {};
+		applyOnboardingConfig(agent, state);
+
+		expect(agent.embedding).toEqual({
+			provider: "ollama",
+			model: "mxbai-embed-large",
+			dimensions: 1024,
+			base_url: "http://127.0.0.1:11434",
+		});
+		expect(agent.identity).toMatchObject({
+			preset: "openclaw",
+			startup: {
+				load: [
+					{ path: "AGENTS.md" },
+					{ path: "SOUL.md" },
+					{ path: "IDENTITY.md" },
+					{ path: "USER.md" },
+					{ path: "MEMORY.md" },
+				],
+			},
+			special: [
+				{ path: "HEARTBEAT.md", kind: "heartbeat" },
+				{ path: "DREAMING.md", kind: "dreaming" },
+				{ path: "BOOTSTRAP.md", kind: "bootstrap" },
+			],
+		});
+		expect(agent.memory).toMatchObject({
+			pipelineV2: {
+				extractionProvider: "ollama",
+				extractionEndpoint: "http://127.0.0.1:11434",
+			},
+		});
+		expect(agent.inference).toBeUndefined();
+	});
+
+	it("persists selected ACPX harness as the generated inference agent", () => {
+		const state = createDefaultState();
+		state.selectedHarnesses = ["opencode"];
+		state.selectedHarness = "opencode";
+		state.extractionProvider = "acpx";
+		state.extractionModel = "gpt-5-codex-mini";
+
+		const agent: Record<string, unknown> = {};
+		applyOnboardingConfig(agent, state);
+
+		expect(agent.memory).toMatchObject({
+			pipelineV2: {
+				extraction: { provider: "acpx", harness: "opencode" },
+			},
+		});
+		expect(agent.inference).toMatchObject({
+			targets: {
+				"background-acpx": {
+					acpx: { agent: "opencode" },
+				},
+			},
+		});
+	});
+
+	it("removes embedding config when onboarding turns embeddings off", () => {
+		const state = createDefaultState();
+		state.embeddingProvider = "none";
+		state.extractionProvider = "none";
+		const agent: Record<string, unknown> = {
+			embedding: { provider: "native", model: "nomic-embed-text-v1.5", dimensions: 768 },
+		};
+
+		applyOnboardingConfig(agent, state);
+
+		expect(agent.embedding).toBeUndefined();
+	});
+
+	it("reports the preset files that must exist for selected identity", () => {
+		expect(identityFileNamesForPreset("hermes")).toEqual(["SOUL.md", "AGENTS.md", "DREAMING.md"]);
+		expect(
+			missingIdentityFiles(
+				[
+					{ name: "AGENTS.md", content: "", size: 0 },
+					{ name: "DREAMING.md", content: "", size: 0 },
+				],
+				"hermes",
+			),
+		).toEqual(["SOUL.md"]);
+	});
+
+	it("rejects malformed extraction endpoints before save", () => {
+		const state = createDefaultState();
+		state.extractionProvider = "ollama";
+		state.extractionModel = "qwen3:4b";
+		state.extractionEndpoint = "localhost:11434";
+
+		expect(validateOnboardingStep(state, 3)).toEqual(["Endpoint must be an http:// or https:// URL."]);
+	});
+});

--- a/surfaces/dashboard/src/lib/components/onboarding/onboarding-config.ts
+++ b/surfaces/dashboard/src/lib/components/onboarding/onboarding-config.ts
@@ -1,0 +1,175 @@
+import type { ConfigFile } from "$lib/api";
+import {
+	type AcpxDashboardAgent,
+	applyRecommendedPipelineSetup,
+} from "$lib/components/tabs/settings/pipeline-settings";
+import {
+	IDENTITY_PRESETS,
+	type IdentityContextFileEntry,
+	type IdentityPresetName,
+	type IdentitySpecialFileEntry,
+} from "@signet/core/identity-presets";
+import type { PipelineProviderChoice } from "@signet/core/pipeline-providers";
+import {
+	EMBEDDING_PROVIDER_OPTIONS,
+	EXTRACTION_PROVIDER_OPTIONS,
+	type EmbeddingProvider,
+	type OnboardingState,
+} from "./onboarding-state.svelte";
+
+export type OnboardingConfig = Record<string, unknown>;
+
+function ensureRecord(root: OnboardingConfig, key: string): OnboardingConfig {
+	const existing = root[key];
+	if (typeof existing === "object" && existing !== null && !Array.isArray(existing)) {
+		return existing as OnboardingConfig;
+	}
+	const next: OnboardingConfig = {};
+	root[key] = next;
+	return next;
+}
+
+function cloneStartup(entries: readonly IdentityContextFileEntry[]): IdentityContextFileEntry[] {
+	return entries.map((entry) => ({ ...entry }));
+}
+
+function cloneSpecial(entries: readonly IdentitySpecialFileEntry[]): IdentitySpecialFileEntry[] {
+	return entries.map((entry) => ({ ...entry }));
+}
+
+export function identityPresetEntries(preset: IdentityPresetName): {
+	readonly startup: IdentityContextFileEntry[];
+	readonly special: IdentitySpecialFileEntry[];
+} {
+	const spec = IDENTITY_PRESETS[preset] ?? IDENTITY_PRESETS.minimal;
+	return {
+		startup: cloneStartup(spec.startup),
+		special: cloneSpecial(spec.special),
+	};
+}
+
+export function identityFileNamesForPreset(preset: IdentityPresetName): string[] {
+	const entries = identityPresetEntries(preset);
+	return Array.from(
+		new Set([...entries.startup, ...entries.special].map((entry) => String(entry.path)).filter(Boolean)),
+	);
+}
+
+export function missingIdentityFiles(configFiles: readonly ConfigFile[], preset: IdentityPresetName): string[] {
+	const existing = new Set(configFiles.map((file) => file.name));
+	return identityFileNamesForPreset(preset).filter((name) => !existing.has(name));
+}
+
+export function defaultIdentityFileContent(fileName: string, agentName: string): string {
+	const title = fileName.replace(/\.md$/i, "");
+	return `# ${title}\n\n${agentName || "My Agent"} identity context. Update this file to personalize the agent.\n`;
+}
+
+export function getEmbeddingDimensions(model: string): number {
+	switch (model) {
+		case "all-minilm":
+			return 384;
+		case "mxbai-embed-large":
+			return 1024;
+		case "text-embedding-3-large":
+			return 3072;
+		case "text-embedding-3-small":
+			return 1536;
+		default:
+			return 768;
+	}
+}
+
+export function isHttpEndpoint(value: string): boolean {
+	const trimmed = value.trim();
+	if (!trimmed) return true;
+	try {
+		const parsed = new URL(trimmed);
+		return parsed.protocol === "http:" || parsed.protocol === "https:";
+	} catch {
+		return false;
+	}
+}
+
+export function extractionNeedsEndpoint(provider: PipelineProviderChoice): boolean {
+	const mode = EXTRACTION_PROVIDER_OPTIONS.find((option) => option.value === provider)?.mode;
+	return mode === "local" || mode === "api";
+}
+
+export function validateOnboardingStep(state: OnboardingState, step: number): string[] {
+	if (step === 1) {
+		const errors: string[] = [];
+		if (!state.agentName.trim()) errors.push("Agent name is required.");
+		if (state.selectedHarnesses.length === 0) errors.push("Select at least one harness.");
+		return errors;
+	}
+	if (step === 2) {
+		if (state.embeddingProvider === "none") return [];
+		if (!state.embeddingModel.trim()) return ["Embedding model is required."];
+		if (!isHttpEndpoint(state.embeddingEndpoint)) return ["Embedding endpoint must be an http:// or https:// URL."];
+		return [];
+	}
+	if (step === 3) {
+		if (state.extractionProvider === "none") return [];
+		if (!state.extractionModel.trim()) return ["Extraction model is required."];
+		if (extractionNeedsEndpoint(state.extractionProvider) && !isHttpEndpoint(state.extractionEndpoint)) {
+			return ["Endpoint must be an http:// or https:// URL."];
+		}
+		return [];
+	}
+	return [];
+}
+
+export function validateOnboardingState(state: OnboardingState): string[] {
+	return [1, 2, 3].flatMap((step) => validateOnboardingStep(state, step));
+}
+
+function selectedAcpxAgent(harness: string): AcpxDashboardAgent | undefined {
+	return harness === "codex" || harness === "claude-code" || harness === "opencode" ? harness : undefined;
+}
+
+export function applyOnboardingConfig(agentConfig: OnboardingConfig, state: OnboardingState): void {
+	const agent = ensureRecord(agentConfig, "agent");
+	agent.name = state.agentName.trim() || "My Agent";
+	agent.description = state.agentDescription.trim() || "Personal AI assistant";
+
+	const identity = ensureRecord(agentConfig, "identity");
+	const entries = identityPresetEntries(state.identityPreset);
+	identity.preset = state.identityPreset;
+	identity.startup = { load: entries.startup };
+	identity.special = entries.special;
+	agentConfig.harnesses = state.selectedHarnesses;
+
+	applyEmbeddingConfig(agentConfig, state.embeddingProvider, state.embeddingModel, state.embeddingEndpoint);
+	const acpxAgent = state.extractionProvider === "acpx" ? selectedAcpxAgent(state.selectedHarness) : undefined;
+	applyRecommendedPipelineSetup(agentConfig, {
+		provider: state.extractionProvider,
+		model: state.extractionModel,
+		endpoint: extractionNeedsEndpoint(state.extractionProvider) ? state.extractionEndpoint : "",
+		agent: acpxAgent,
+		acpxHarness: acpxAgent ?? "",
+		synthesisEnabled: state.synthesisEnabled,
+	});
+}
+
+function applyEmbeddingConfig(
+	agentConfig: OnboardingConfig,
+	provider: EmbeddingProvider,
+	modelValue: string,
+	endpointValue: string,
+): void {
+	if (provider === "none") {
+		agentConfig.embedding = undefined;
+		return;
+	}
+	const option = EMBEDDING_PROVIDER_OPTIONS.find((item) => item.value === provider);
+	const model = modelValue.trim() || option?.defaultModel || "nomic-embed-text-v1.5";
+	const endpoint = endpointValue.trim();
+	const embedding: OnboardingConfig = {
+		provider,
+		model,
+		dimensions: getEmbeddingDimensions(model),
+	};
+	if (endpoint) embedding.base_url = endpoint;
+	agentConfig.embedding = embedding;
+}

--- a/surfaces/dashboard/src/lib/components/onboarding/onboarding-state.svelte.ts
+++ b/surfaces/dashboard/src/lib/components/onboarding/onboarding-state.svelte.ts
@@ -1,0 +1,229 @@
+import type { PipelineProviderChoice } from "@signet/core/pipeline-providers";
+
+export type IdentityPresetName = "minimal" | "hermes" | "openclaw" | "custom";
+
+export const IDENTITY_PRESET_META: Array<{
+	name: IdentityPresetName;
+	title: string;
+	subtitle: string;
+	files: string;
+}> = [
+	{
+		name: "minimal",
+		title: "Minimal",
+		subtitle: "AGENTS.md operating instructions plus dreaming. Light and focused.",
+		files: "AGENTS.md + DREAMING.md",
+	},
+	{
+		name: "hermes",
+		title: "Hermes",
+		subtitle: "SOUL.md primary identity with project-context discovery.",
+		files: "SOUL.md + AGENTS.md + DREAMING.md",
+	},
+	{
+		name: "openclaw",
+		title: "OpenClaw",
+		subtitle: "Rich identity stack for character-forward agents.",
+		files: "AGENTS.md + SOUL.md + IDENTITY.md + USER.md + MEMORY.md",
+	},
+	{
+		name: "custom",
+		title: "Custom",
+		subtitle: "Select your own startup files later in settings.",
+		files: "AGENTS.md + DREAMING.md",
+	},
+];
+
+export interface OnboardingState {
+	identityPreset: IdentityPresetName;
+	agentName: string;
+	agentDescription: string;
+	selectedHarnesses: string[];
+	selectedHarness: string;
+	embeddingProvider: EmbeddingProvider;
+	embeddingModel: string;
+	embeddingEndpoint: string;
+	extractionProvider: PipelineProviderChoice;
+	extractionModel: string;
+	extractionEndpoint: string;
+	synthesisEnabled: boolean;
+	showAdvancedProviders: boolean;
+	currentStep: number;
+	saving: boolean;
+}
+
+export type EmbeddingProvider = "native" | "llama-cpp" | "ollama" | "openai" | "none";
+
+export const EMBEDDING_PROVIDER_OPTIONS: Array<{
+	readonly value: EmbeddingProvider;
+	readonly label: string;
+	readonly detail: string;
+	readonly defaultModel: string;
+	readonly defaultEndpoint: string;
+}> = [
+	{
+		value: "native",
+		label: "Native (built-in)",
+		detail: "On-device embedding with no external server. Recommended.",
+		defaultModel: "nomic-embed-text-v1.5",
+		defaultEndpoint: "",
+	},
+	{
+		value: "llama-cpp",
+		label: "llama.cpp",
+		detail: "OpenAI-compatible server bundled with llama.cpp.",
+		defaultModel: "nomic-embed-text",
+		defaultEndpoint: "http://localhost:8080/v1",
+	},
+	{
+		value: "ollama",
+		label: "Ollama",
+		detail: "Ollama daemon on this machine or LAN.",
+		defaultModel: "nomic-embed-text",
+		defaultEndpoint: "http://localhost:11434",
+	},
+	{
+		value: "openai",
+		label: "OpenAI",
+		detail: "OpenAI text-embedding API. Requires API key in secrets.",
+		defaultModel: "text-embedding-3-small",
+		defaultEndpoint: "https://api.openai.com/v1",
+	},
+	{
+		value: "none",
+		label: "Off",
+		detail: "Disable vector search. Memory will be keyword-only.",
+		defaultModel: "",
+		defaultEndpoint: "",
+	},
+];
+
+export const EMBEDDING_MODEL_PRESETS: Record<string, Array<{ value: string; label: string }>> = {
+	native: [{ value: "nomic-embed-text-v1.5", label: "nomic-embed-text-v1.5" }],
+	"llama-cpp": [
+		{ value: "nomic-embed-text", label: "nomic-embed-text" },
+		{ value: "all-minilm", label: "all-minilm" },
+		{ value: "mxbai-embed-large", label: "mxbai-embed-large" },
+	],
+	ollama: [
+		{ value: "nomic-embed-text", label: "nomic-embed-text" },
+		{ value: "all-minilm", label: "all-minilm" },
+		{ value: "mxbai-embed-large", label: "mxbai-embed-large" },
+	],
+	openai: [
+		{ value: "text-embedding-3-small", label: "text-embedding-3-small" },
+		{ value: "text-embedding-3-large", label: "text-embedding-3-large" },
+	],
+	none: [],
+};
+
+export type ExtractionProviderOption = {
+	value: PipelineProviderChoice;
+	label: string;
+	detail: string;
+	mode: "agent" | "local" | "api" | "off" | "custom";
+	endpointPlaceholder?: string;
+};
+
+export const EXTRACTION_PROVIDER_OPTIONS: ExtractionProviderOption[] = [
+	{
+		value: "acpx",
+		label: "ACPX",
+		detail: "Route extraction through a selected installed agent harness.",
+		mode: "agent",
+	},
+	{
+		value: "llama-cpp",
+		label: "llama.cpp",
+		detail: "Use a local llama.cpp OpenAI-compatible server.",
+		mode: "local",
+		endpointPlaceholder: "http://127.0.0.1:8080/v1",
+	},
+	{
+		value: "ollama",
+		label: "Ollama",
+		detail: "Use an Ollama daemon running on this machine or LAN.",
+		mode: "local",
+		endpointPlaceholder: "http://127.0.0.1:11434",
+	},
+	{
+		value: "claude-code",
+		label: "Claude Code",
+		detail: "Call the local Claude Code CLI directly for extraction.",
+		mode: "agent",
+	},
+	{
+		value: "codex",
+		label: "Codex",
+		detail: "Call the local Codex CLI directly for extraction.",
+		mode: "agent",
+	},
+	{
+		value: "opencode",
+		label: "OpenCode",
+		detail: "Use OpenCode as the extraction backend.",
+		mode: "agent",
+	},
+	{
+		value: "anthropic",
+		label: "Anthropic API",
+		detail: "Use Anthropic directly with configured secrets.",
+		mode: "api",
+		endpointPlaceholder: "https://api.anthropic.com",
+	},
+	{
+		value: "openrouter",
+		label: "OpenRouter",
+		detail: "Use OpenRouter with configured secrets.",
+		mode: "api",
+		endpointPlaceholder: "https://openrouter.ai/api/v1",
+	},
+	{
+		value: "command",
+		label: "Command",
+		detail: "Use a custom command provider configured in advanced settings.",
+		mode: "custom",
+	},
+	{
+		value: "none",
+		label: "Off",
+		detail: "Leave extraction disabled for now.",
+		mode: "off",
+	},
+];
+
+export const EXTRACTION_MODEL_PRESETS: Partial<Record<PipelineProviderChoice, string[]>> = {
+	acpx: ["gpt-5-codex-mini", "gpt-5-codex", "claude-haiku-4-5"],
+	"llama-cpp": ["qwen3.5:4b", "qwen3:8b", "llama-3.1-8b"],
+	ollama: ["qwen3:4b", "qwen3:8b", "glm-4.7-flash"],
+	"claude-code": ["haiku", "sonnet", "opus"],
+	codex: ["gpt-5-codex-mini", "gpt-5-codex", "gpt-5.4"],
+	opencode: ["anthropic/claude-haiku-4-5-20251001", "google/gemini-2.5-flash"],
+	anthropic: ["haiku", "sonnet", "opus"],
+	openrouter: ["openai/gpt-4o-mini", "anthropic/claude-haiku-4-5-20251001"],
+};
+
+export const EXTRACTION_SAFETY_TEXT =
+	"Remote API extraction can stack up extreme fees fast. Intended usage: Claude Code on haiku, Codex CLI on gpt-5-codex-mini with a pro/max subscription, or local providers (llama.cpp or Ollama) at qwen3:4b or larger.";
+
+export const RECOMMENDED_EXTRACTION: PipelineProviderChoice[] = ["acpx", "ollama", "codex", "claude-code"];
+
+export function createDefaultState(): OnboardingState {
+	return {
+		identityPreset: "minimal",
+		agentName: "My Agent",
+		agentDescription: "Personal AI assistant",
+		selectedHarnesses: [],
+		selectedHarness: "",
+		embeddingProvider: "native",
+		embeddingModel: "nomic-embed-text-v1.5",
+		embeddingEndpoint: "",
+		extractionProvider: "acpx",
+		extractionModel: "gpt-5-codex-mini",
+		extractionEndpoint: "",
+		synthesisEnabled: true,
+		showAdvancedProviders: false,
+		currentStep: 0,
+		saving: false,
+	};
+}

--- a/surfaces/dashboard/src/lib/components/onboarding/steps/EmbeddingStep.svelte
+++ b/surfaces/dashboard/src/lib/components/onboarding/steps/EmbeddingStep.svelte
@@ -1,0 +1,237 @@
+<script lang="ts">
+	import { Input } from "$lib/components/ui/input/index.js";
+	import * as Select from "$lib/components/ui/select/index.js";
+	import {
+		EMBEDDING_MODEL_PRESETS,
+		EMBEDDING_PROVIDER_OPTIONS,
+		type EmbeddingProvider,
+		type OnboardingState,
+	} from "../onboarding-state.svelte";
+
+	interface Props {
+		state: OnboardingState;
+	}
+
+	const { state }: Props = $props();
+
+	const selectTriggerClass =
+		"font-mono text-[11px] text-[var(--sig-text)] bg-[var(--sig-bg)] border-[var(--sig-border-strong)] rounded-lg w-full h-auto min-h-[30px] px-2 py-[5px] box-border focus-visible:border-[var(--sig-accent)]";
+	const selectContentClass =
+		"font-mono text-[11px] bg-[var(--sig-bg)] text-[var(--sig-text)] border-[var(--sig-border-strong)] rounded-lg";
+	const selectItemClass = "font-mono text-[11px] rounded-lg";
+
+	const providerOption = $derived(
+		EMBEDDING_PROVIDER_OPTIONS.find((o) => o.value === state.embeddingProvider),
+	);
+	const modelPresets = $derived(EMBEDDING_MODEL_PRESETS[state.embeddingProvider] ?? []);
+	const needsEndpoint = $derived(
+		state.embeddingProvider === "llama-cpp" ||
+			state.embeddingProvider === "ollama" ||
+			state.embeddingProvider === "openai",
+	);
+
+	function chooseProvider(next: EmbeddingProvider): void {
+		const option = EMBEDDING_PROVIDER_OPTIONS.find((o) => o.value === next);
+		if (!option) return;
+		state.embeddingProvider = next;
+		state.embeddingModel = option.defaultModel;
+		state.embeddingEndpoint = option.defaultEndpoint;
+	}
+
+	export function validate(): string[] {
+		if (state.embeddingProvider === "none") return [];
+		if (!state.embeddingModel.trim()) return ["Embedding model is required."];
+		return [];
+	}
+</script>
+
+<div class="embedding-step">
+	<p class="step-hint">
+		Embedding turns text into vectors for semantic search. The built-in native provider works out of
+		the box with no setup.
+	</p>
+
+	<div class="provider-grid">
+		{#each EMBEDDING_PROVIDER_OPTIONS as option (option.value)}
+			<button
+				type="button"
+				class="provider-card sig-switch"
+				class:provider-card-active={state.embeddingProvider === option.value}
+				onclick={() => chooseProvider(option.value)}
+				aria-pressed={state.embeddingProvider === option.value}
+			>
+				<span class="provider-radio" aria-hidden="true"></span>
+				<strong>{option.label}</strong>
+				{#if state.embeddingProvider === option.value}
+					<span class="selected-badge">selected</span>
+				{/if}
+			</button>
+		{/each}
+	</div>
+
+	{#if state.embeddingProvider !== "none"}
+		<div class="config-fields">
+			<div class="field-row">
+				<label class="field">
+					<span class="field-label">Model</span>
+					<Select.Root
+						type="single"
+						value={modelPresets.some((p) => p.value === state.embeddingModel)
+							? state.embeddingModel
+							: "__custom__"}
+						onValueChange={(v: string) => {
+							if (v !== "__custom__") state.embeddingModel = v;
+						}}
+					>
+						<Select.Trigger class={selectTriggerClass}>
+							{state.embeddingModel || "select model"}
+						</Select.Trigger>
+						<Select.Content class={selectContentClass}>
+							{#each modelPresets as preset (preset.value)}
+								<Select.Item class={selectItemClass} value={preset.value}>
+									{preset.label}
+								</Select.Item>
+							{/each}
+							<Select.Item class={selectItemClass} value="__custom__">Custom...</Select.Item>
+						</Select.Content>
+					</Select.Root>
+				</label>
+
+				{#if needsEndpoint}
+					<label class="field">
+						<span class="field-label">Base URL</span>
+						<Input
+							class="onboarding-input"
+							bind:value={state.embeddingEndpoint}
+							placeholder={providerOption?.defaultEndpoint ?? "https://..."}
+						/>
+					</label>
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.embedding-step {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+
+	.step-hint {
+		margin: 0;
+		font-size: 13px;
+		line-height: 1.4;
+		color: var(--sig-text);
+	}
+
+	.provider-grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 8px;
+	}
+
+	.provider-card {
+		position: relative;
+		min-height: 40px;
+		padding: 8px 10px 8px 30px;
+		text-align: left;
+		cursor: pointer;
+		border: 1px solid var(--sig-border-strong);
+		border-radius: var(--sig-radius);
+		background: color-mix(in srgb, var(--sig-surface), transparent 5%);
+		color: var(--sig-text);
+		transition: border-color var(--dur) var(--ease), background var(--dur) var(--ease);
+	}
+
+	.provider-card:hover {
+		border-color: var(--sig-highlight);
+	}
+
+	.provider-card-active {
+		border-color: var(--sig-highlight);
+		background: color-mix(in srgb, var(--sig-surface-raised), var(--sig-highlight) 10%);
+		box-shadow: var(--sig-glow-highlight), inset 3px 0 0 var(--sig-highlight),
+			inset 0 1px 0 rgba(255, 255, 255, 0.08);
+	}
+
+	.provider-radio {
+		position: absolute;
+		top: 13px;
+		left: 10px;
+		width: 12px;
+		height: 12px;
+		border: 1px solid var(--sig-border-strong);
+		background: var(--sig-bg);
+	}
+
+	.provider-card-active .provider-radio {
+		border-color: var(--sig-highlight);
+		background: var(--sig-highlight);
+		box-shadow: inset 0 0 0 3px var(--sig-bg),
+			0 0 9px color-mix(in srgb, var(--sig-highlight), transparent 36%);
+	}
+
+	.provider-card strong {
+		display: block;
+		font-family: var(--font-display, monospace);
+		font-size: 13px;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--sig-text-bright);
+	}
+
+	.selected-badge {
+		position: absolute;
+		top: 9px;
+		right: 10px;
+		font-family: var(--font-mono, monospace);
+		font-size: 9px;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--sig-highlight-text);
+	}
+
+	.config-fields {
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+	}
+
+	.field-row {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 10px;
+	}
+
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: 7px;
+	}
+
+	.field-label {
+		font-family: var(--font-mono, monospace);
+		font-size: 10px;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--sig-text-muted);
+	}
+
+	:global(.onboarding-input) {
+		border-radius: var(--sig-radius) !important;
+		border-color: var(--sig-border-strong) !important;
+		background: color-mix(in srgb, var(--sig-bg), transparent 6%) !important;
+		color: var(--sig-text-bright) !important;
+		font-family: var(--font-mono, monospace) !important;
+		box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.28) !important;
+	}
+
+	@media (max-width: 620px) {
+		.provider-grid,
+		.field-row {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/surfaces/dashboard/src/lib/components/onboarding/steps/ExtractionStep.svelte
+++ b/surfaces/dashboard/src/lib/components/onboarding/steps/ExtractionStep.svelte
@@ -1,0 +1,420 @@
+<script lang="ts">
+	import { Checkbox } from "$lib/components/ui/checkbox/index.js";
+	import { Input } from "$lib/components/ui/input/index.js";
+	import { defaultPipelineModel, type PipelineProviderChoice } from "@signet/core/pipeline-providers";
+	import {
+		EXTRACTION_MODEL_PRESETS,
+		EXTRACTION_PROVIDER_OPTIONS,
+		EXTRACTION_SAFETY_TEXT,
+		RECOMMENDED_EXTRACTION,
+		type OnboardingState,
+	} from "../onboarding-state.svelte";
+
+	interface Props {
+		state: OnboardingState;
+	}
+
+	const { state }: Props = $props();
+
+	const providerOption = $derived(
+		EXTRACTION_PROVIDER_OPTIONS.find((o) => o.value === state.extractionProvider) ??
+			EXTRACTION_PROVIDER_OPTIONS[0],
+	);
+	const modelPresets = $derived(EXTRACTION_MODEL_PRESETS[state.extractionProvider] ?? []);
+	const needsEndpoint = $derived(
+		providerOption.mode === "local" || providerOption.mode === "api",
+	);
+
+	function chooseProvider(next: PipelineProviderChoice): void {
+		state.extractionProvider = next;
+		state.extractionModel = EXTRACTION_MODEL_PRESETS[next]?.[0] ?? defaultPipelineModel(next);
+		state.extractionEndpoint =
+			EXTRACTION_PROVIDER_OPTIONS.find((o) => o.value === next)?.endpointPlaceholder ?? "";
+		if (next === "none") state.extractionEndpoint = "";
+	}
+
+	function isRecommended(provider: PipelineProviderChoice): boolean {
+		return RECOMMENDED_EXTRACTION.includes(provider);
+	}
+
+	export function validate(): string[] {
+		if (state.extractionProvider === "none") return [];
+		if (!state.extractionModel.trim()) return ["Extraction model is required."];
+		if (
+			needsEndpoint &&
+			state.extractionEndpoint.trim() &&
+			!/^https?:\/\//.test(state.extractionEndpoint.trim())
+		) {
+			return ["Endpoint must be an http:// or https:// URL."];
+		}
+		return [];
+	}
+</script>
+
+<div class="extraction-step">
+	<p class="step-hint">{EXTRACTION_SAFETY_TEXT}</p>
+
+	<div class="provider-grid">
+		<p class="provider-group-title">Recommended routes</p>
+		{#each EXTRACTION_PROVIDER_OPTIONS as option (option.value)}
+			{#if isRecommended(option.value)}
+				<button
+					type="button"
+					class="provider-card sig-switch"
+					class:provider-card-active={state.extractionProvider === option.value}
+					onclick={() => chooseProvider(option.value)}
+					aria-pressed={state.extractionProvider === option.value}
+				>
+					<span class="provider-radio" aria-hidden="true"></span>
+					<span class="provider-mode">{option.mode}</span>
+					{#if state.extractionProvider === option.value}
+						<span class="selected-badge">selected</span>
+					{/if}
+					<strong>{option.label}</strong>
+				</button>
+			{/if}
+		{/each}
+
+		<button
+			type="button"
+			class="advanced-toggle sig-switch"
+			onclick={() => (state.showAdvancedProviders = !state.showAdvancedProviders)}
+			aria-expanded={state.showAdvancedProviders}
+		>
+			<span>{state.showAdvancedProviders ? "Hide advanced routes" : "Show advanced routes"}</span>
+		</button>
+
+		{#if state.showAdvancedProviders}
+			<p class="provider-group-title provider-group-title-secondary">Advanced routes</p>
+			{#each EXTRACTION_PROVIDER_OPTIONS as option (option.value)}
+				{#if !isRecommended(option.value)}
+					<button
+						type="button"
+						class="provider-card provider-card-compact sig-switch"
+						class:provider-card-active={state.extractionProvider === option.value}
+						onclick={() => chooseProvider(option.value)}
+						aria-pressed={state.extractionProvider === option.value}
+					>
+						<span class="provider-radio" aria-hidden="true"></span>
+						<span class="provider-mode">{option.mode}</span>
+						{#if state.extractionProvider === option.value}
+							<span class="selected-badge">selected</span>
+						{/if}
+						<strong>{option.label}</strong>
+					</button>
+				{/if}
+			{/each}
+		{/if}
+	</div>
+
+	<div class="provider-detail">
+		<div class="detail-banner">
+			<span>{providerOption.mode}</span>
+			<p>{providerOption.detail}</p>
+		</div>
+
+		{#if state.extractionProvider === "acpx"}
+			<div class="field">
+				<span class="field-label">ACPX harness</span>
+				<div class="choice-row">
+					{#each state.selectedHarnesses as h (h)}
+						<button
+							type="button"
+							class="choice-pill sig-switch"
+							class:choice-pill-active={state.selectedHarness === h}
+							onclick={() => (state.selectedHarness = h)}
+						>
+							{h}
+						</button>
+					{/each}
+					{#if state.selectedHarnesses.length === 0}
+						<small class="empty-hint">Select at least one harness in the previous step.</small>
+					{/if}
+				</div>
+			</div>
+		{/if}
+
+		<div class="field-row">
+			<label class="field">
+				<span class="field-label">Model</span>
+				<Input
+					class="onboarding-input"
+					bind:value={state.extractionModel}
+					placeholder="model id"
+					disabled={state.extractionProvider === "none"}
+				/>
+			</label>
+			{#if needsEndpoint}
+				<label class="field">
+					<span class="field-label">Endpoint URL</span>
+					<Input
+						class="onboarding-input"
+						bind:value={state.extractionEndpoint}
+						placeholder={providerOption.endpointPlaceholder ?? "https://..."}
+					/>
+				</label>
+			{/if}
+		</div>
+
+		{#if modelPresets.length > 0 && state.extractionProvider !== "none"}
+			<div class="choice-row preset-row" aria-label="Model presets">
+				{#each modelPresets as preset (preset)}
+					<button
+						type="button"
+						class="choice-pill sig-switch"
+						class:choice-pill-active={state.extractionModel === preset}
+						onclick={() => (state.extractionModel = preset)}
+					>
+						{preset}
+					</button>
+				{/each}
+			</div>
+		{/if}
+
+		<label class="inline-toggle sig-switch">
+			<Checkbox
+				checked={state.synthesisEnabled}
+				onCheckedChange={(checked) => (state.synthesisEnabled = !!checked)}
+			/>
+			<span>Use the same provider for session synthesis</span>
+		</label>
+	</div>
+</div>
+
+<style>
+	.extraction-step {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+
+	.step-hint {
+		margin: 0;
+		padding: 8px 10px;
+		border: 1px solid var(--sig-border-strong);
+		border-radius: var(--sig-radius);
+		background: var(--sig-bg);
+		font-size: 12px;
+		line-height: 1.35;
+		color: var(--sig-text-muted);
+	}
+
+	.provider-grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 8px;
+	}
+
+	.provider-group-title {
+		grid-column: 1 / -1;
+		margin: 2px 0 -2px;
+		font-family: var(--font-mono, monospace);
+		font-size: 10px;
+		letter-spacing: 0.11em;
+		text-transform: uppercase;
+		color: var(--sig-highlight-text);
+	}
+
+	.provider-group-title-secondary {
+		margin-top: 8px;
+		color: var(--sig-text-muted);
+	}
+
+	.provider-card {
+		position: relative;
+		min-height: 40px;
+		padding: 8px 10px 8px 30px;
+		text-align: left;
+		cursor: pointer;
+		border: 1px solid var(--sig-border-strong);
+		border-radius: var(--sig-radius);
+		background: color-mix(in srgb, var(--sig-surface), transparent 5%);
+		color: var(--sig-text);
+		transition: border-color var(--dur) var(--ease), background var(--dur) var(--ease);
+	}
+
+	.provider-card:hover {
+		border-color: var(--sig-highlight);
+	}
+
+	.provider-card-active {
+		border-color: var(--sig-highlight);
+		background: color-mix(in srgb, var(--sig-surface-raised), var(--sig-highlight) 10%);
+		box-shadow: var(--sig-glow-highlight), inset 3px 0 0 var(--sig-highlight),
+			inset 0 1px 0 rgba(255, 255, 255, 0.08);
+	}
+
+	.provider-card-compact {
+		min-height: 32px;
+	}
+
+	.provider-radio {
+		position: absolute;
+		top: 13px;
+		left: 10px;
+		width: 12px;
+		height: 12px;
+		border: 1px solid var(--sig-border-strong);
+		background: var(--sig-bg);
+	}
+
+	.provider-card-active .provider-radio {
+		border-color: var(--sig-highlight);
+		background: var(--sig-highlight);
+		box-shadow: inset 0 0 0 3px var(--sig-bg),
+			0 0 9px color-mix(in srgb, var(--sig-highlight), transparent 36%);
+	}
+
+	.provider-mode {
+		font-family: var(--font-mono, monospace);
+		font-size: 10px;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--sig-highlight-text);
+	}
+
+	.provider-card strong {
+		display: block;
+		margin: 4px 0 0;
+		font-family: var(--font-display, monospace);
+		font-size: 13px;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--sig-text-bright);
+	}
+
+	.selected-badge {
+		position: absolute;
+		top: 9px;
+		right: 10px;
+		font-family: var(--font-mono, monospace);
+		font-size: 9px;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--sig-highlight-text);
+	}
+
+	.advanced-toggle {
+		grid-column: 1 / -1;
+		justify-content: center;
+		min-height: 28px;
+		padding: 6px 10px;
+		font-family: var(--font-mono, monospace);
+		font-size: 11px;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--sig-text);
+		cursor: pointer;
+		border: 1px solid var(--sig-border-strong);
+		border-radius: var(--sig-radius);
+		background: color-mix(in srgb, var(--sig-surface), transparent 5%);
+	}
+
+	.provider-detail {
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+	}
+
+	.detail-banner {
+		display: flex;
+		gap: 12px;
+		align-items: center;
+		padding: 8px 10px;
+		border: 1px solid var(--sig-border-strong);
+		border-radius: var(--sig-radius);
+		background: var(--sig-bg);
+	}
+
+	.detail-banner span {
+		font-family: var(--font-mono, monospace);
+		font-size: 10px;
+		text-transform: uppercase;
+		color: var(--sig-highlight-text);
+	}
+
+	.detail-banner p {
+		margin: 0;
+		font-size: 12px;
+		line-height: 1.35;
+		color: var(--sig-text-muted);
+	}
+
+	.field-row {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 10px;
+	}
+
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: 7px;
+	}
+
+	.field-label {
+		font-family: var(--font-mono, monospace);
+		font-size: 10px;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--sig-text-muted);
+	}
+
+	.choice-row {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+	}
+
+	.preset-row {
+		padding-top: 2px;
+	}
+
+	.choice-pill {
+		padding: 7px 10px;
+		font-family: var(--font-mono, monospace);
+		font-size: 12px;
+		color: var(--sig-text);
+		cursor: pointer;
+		border: 1px solid var(--sig-border-strong);
+		border-radius: var(--sig-radius);
+		background: color-mix(in srgb, var(--sig-surface), transparent 5%);
+	}
+
+	.choice-pill-active {
+		border-color: var(--sig-highlight);
+		color: var(--sig-text-bright);
+		background: var(--sig-highlight-muted);
+	}
+
+	.empty-hint {
+		font-size: 12px;
+		color: var(--sig-text-muted);
+	}
+
+	.inline-toggle {
+		display: flex;
+		align-items: center;
+		gap: 9px;
+		padding: 10px;
+		font-size: 12px;
+		color: var(--sig-text);
+		cursor: pointer;
+	}
+
+	:global(.onboarding-input) {
+		border-radius: var(--sig-radius) !important;
+		border-color: var(--sig-border-strong) !important;
+		background: color-mix(in srgb, var(--sig-bg), transparent 6%) !important;
+		color: var(--sig-text-bright) !important;
+		font-family: var(--font-mono, monospace) !important;
+		box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.28) !important;
+	}
+
+	@media (max-width: 620px) {
+		.provider-grid,
+		.field-row {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/surfaces/dashboard/src/lib/components/onboarding/steps/IdentityStep.svelte
+++ b/surfaces/dashboard/src/lib/components/onboarding/steps/IdentityStep.svelte
@@ -1,0 +1,212 @@
+<script lang="ts">
+	import type { Harness } from "$lib/api";
+	import { Checkbox } from "$lib/components/ui/checkbox/index.js";
+	import { Input } from "$lib/components/ui/input/index.js";
+	import { Textarea } from "$lib/components/ui/textarea/index.js";
+	import { KNOWN_HARNESSES } from "$lib/stores/settings.svelte";
+	import type { OnboardingState } from "../onboarding-state.svelte";
+
+	interface Props {
+		state: OnboardingState;
+		harnesses?: Harness[];
+	}
+
+	const { state, harnesses = [] }: Props = $props();
+
+	const harnessOptions = $derived.by(() => {
+		const fromApi = harnesses.map((h) => h.id || h.name).filter(Boolean);
+		const combined = [...new Set([...fromApi, ...KNOWN_HARNESSES])];
+		return combined.map((id) => ({
+			id,
+			meta: harnesses.find((h) => h.id === id || h.name === id),
+		}));
+	});
+
+	function toggleHarness(id: string, checked: boolean | string): void {
+		if (checked) {
+			state.selectedHarnesses = [...new Set([...state.selectedHarnesses, id])];
+			if (!state.selectedHarness) state.selectedHarness = id;
+			return;
+		}
+		state.selectedHarnesses = state.selectedHarnesses.filter((h) => h !== id);
+		if (state.selectedHarness === id) state.selectedHarness = state.selectedHarnesses[0] ?? "";
+	}
+
+	export function validate(): string[] {
+		const errors: string[] = [];
+		if (!state.agentName.trim()) errors.push("Agent name is required.");
+		if (state.selectedHarnesses.length === 0) errors.push("Select at least one harness.");
+		return errors;
+	}
+</script>
+
+<div class="identity-fields">
+	<div class="field-grid">
+		<label class="field">
+			<span class="field-label">Name</span>
+			<Input class="onboarding-input" bind:value={state.agentName} placeholder="Dot" />
+		</label>
+		<label class="field field-wide">
+			<span class="field-label">Description</span>
+			<Textarea
+				class="onboarding-input onboarding-textarea"
+				rows={2}
+				bind:value={state.agentDescription}
+				placeholder="A portable memory agent for..."
+			/>
+		</label>
+	</div>
+
+	<div class="harness-section">
+		<span class="field-label">Harnesses</span>
+		<div class="harness-list">
+			{#each harnessOptions as h (h.id)}
+				<label
+					class="harness-row sig-switch"
+					class:harness-row-active={state.selectedHarnesses.includes(h.id)}
+				>
+					<Checkbox
+						checked={state.selectedHarnesses.includes(h.id)}
+						onCheckedChange={(checked) => toggleHarness(h.id, checked)}
+					/>
+					<span class="status-dot" class:status-dot-installed={h.meta?.exists}></span>
+					<span class="harness-main">
+						<strong>{h.id}</strong>
+						<small>{h.meta?.path ?? "known harness"}</small>
+					</span>
+					<span class="harness-state">{h.meta?.exists ? "installed" : "not found"}</span>
+				</label>
+			{/each}
+		</div>
+	</div>
+</div>
+
+<style>
+	.identity-fields {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+	}
+
+	.field-grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 10px;
+	}
+
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: 7px;
+	}
+
+	.field-wide {
+		grid-column: 1 / -1;
+	}
+
+	.field-label {
+		font-family: var(--font-mono, monospace);
+		font-size: 10px;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--sig-text-muted);
+	}
+
+	:global(.onboarding-input) {
+		border-radius: var(--sig-radius) !important;
+		border-color: var(--sig-border-strong) !important;
+		background: color-mix(in srgb, var(--sig-bg), transparent 6%) !important;
+		color: var(--sig-text-bright) !important;
+		font-family: var(--font-mono, monospace) !important;
+		box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.28) !important;
+	}
+
+	:global(.onboarding-textarea) {
+		min-height: 48px !important;
+		resize: vertical;
+	}
+
+	.harness-section {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.harness-list {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		max-height: 240px;
+		overflow: auto;
+		padding-right: 2px;
+	}
+
+	.harness-row {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 8px 10px;
+		cursor: pointer;
+		border: 1px solid transparent;
+		border-radius: var(--sig-radius);
+		transition: background var(--dur) var(--ease), border-color var(--dur) var(--ease);
+	}
+
+	.harness-row-active {
+		border-color: var(--sig-highlight-dim);
+		background: var(--sig-highlight-muted);
+		box-shadow: inset 3px 0 0 var(--sig-highlight),
+			inset 0 1px 0 rgba(255, 255, 255, 0.05);
+	}
+
+	.status-dot {
+		width: 8px;
+		height: 8px;
+		border: 1px solid var(--sig-text-muted);
+		background: transparent;
+		flex: 0 0 auto;
+	}
+
+	.status-dot-installed {
+		border-color: var(--sig-success);
+		background: var(--sig-success);
+		box-shadow: 0 0 8px color-mix(in srgb, var(--sig-success), transparent 40%);
+	}
+
+	.harness-main {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		min-width: 0;
+		flex: 1;
+	}
+
+	.harness-main strong {
+		font-size: 13px;
+		color: var(--sig-text-bright);
+	}
+
+	.harness-main small {
+		font-size: 12px;
+		line-height: 1.35;
+		color: var(--sig-text-muted);
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+	}
+
+	.harness-state {
+		font-family: var(--font-mono, monospace);
+		font-size: 10px;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--sig-text-muted);
+		flex: 0 0 auto;
+	}
+
+	@media (max-width: 620px) {
+		.field-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/surfaces/dashboard/src/lib/components/onboarding/steps/ReviewStep.svelte
+++ b/surfaces/dashboard/src/lib/components/onboarding/steps/ReviewStep.svelte
@@ -1,0 +1,174 @@
+<script lang="ts">
+	import {
+		EMBEDDING_PROVIDER_OPTIONS,
+		EXTRACTION_PROVIDER_OPTIONS,
+		IDENTITY_PRESET_META,
+		type OnboardingState,
+	} from "../onboarding-state.svelte";
+
+	interface Props {
+		state: OnboardingState;
+	}
+
+	const { state }: Props = $props();
+
+	const presetLabel = $derived(IDENTITY_PRESET_META.find((p) => p.name === state.identityPreset)?.title ?? state.identityPreset);
+	const embeddingLabel = $derived(
+		EMBEDDING_PROVIDER_OPTIONS.find((o) => o.value === state.embeddingProvider)?.label ??
+			state.embeddingProvider,
+	);
+	const extractionLabel = $derived(
+		EXTRACTION_PROVIDER_OPTIONS.find((o) => o.value === state.extractionProvider)?.label ??
+			state.extractionProvider,
+	);
+</script>
+
+<div class="review-grid">
+	<section class="review-section">
+		<span class="review-label">Identity preset</span>
+		<span class="review-value review-badge">{presetLabel}</span>
+	</section>
+
+	<section class="review-section">
+		<span class="review-label">Agent name</span>
+		<span class="review-value">{state.agentName}</span>
+	</section>
+
+	<section class="review-section">
+		<span class="review-label">Description</span>
+		<span class="review-value">{state.agentDescription}</span>
+	</section>
+
+	<section class="review-section">
+		<span class="review-label">Harnesses</span>
+		<div class="review-harnesses">
+			{#each state.selectedHarnesses as h (h)}
+				<span class="review-badge">{h}</span>
+			{/each}
+		</div>
+	</section>
+
+	<div class="review-divider"></div>
+
+	<section class="review-section">
+		<span class="review-label">Embedding</span>
+		<span class="review-value"
+			>{embeddingLabel}
+			{#if state.embeddingProvider !== "none" && state.embeddingModel}
+				<span class="review-dim">/ {state.embeddingModel}</span>
+			{/if}</span
+		>
+	</section>
+
+	<section class="review-section">
+		<span class="review-label">Extraction</span>
+		<span class="review-value"
+			>{extractionLabel}
+			{#if state.extractionProvider !== "none" && state.extractionModel}
+				<span class="review-dim">/ {state.extractionModel}</span>
+			{/if}</span
+		>
+	</section>
+
+	{#if state.extractionEndpoint}
+		<section class="review-section">
+			<span class="review-label">Endpoint</span>
+			<span class="review-value review-mono">{state.extractionEndpoint}</span>
+		</section>
+	{/if}
+
+	<section class="review-section">
+		<span class="review-label">Session synthesis</span>
+		<span class="review-value">{state.synthesisEnabled ? "Enabled" : "Disabled"}</span>
+	</section>
+
+	<p class="review-note">
+		Additional settings (network mode, search tuning, auth, advanced pipeline options) are available in
+		the Settings tab after saving.
+	</p>
+</div>
+
+<style>
+	.review-grid {
+		display: grid;
+		grid-template-columns: minmax(130px, 0.35fr) minmax(0, 1fr);
+		gap: 10px 18px;
+		align-items: baseline;
+	}
+
+	.review-section {
+		display: contents;
+	}
+
+	.review-divider {
+		grid-column: 1 / -1;
+		height: 1px;
+		background: linear-gradient(90deg, var(--sig-border-strong), transparent 80%);
+		margin: 4px 0;
+	}
+
+	.review-label {
+		font-family: var(--font-mono, monospace);
+		font-size: 10px;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--sig-text-muted);
+		padding-top: 2px;
+	}
+
+	.review-value {
+		font-size: 13px;
+		color: var(--sig-text-bright);
+	}
+
+	.review-dim {
+		color: var(--sig-text-muted);
+	}
+
+	.review-mono {
+		font-family: var(--font-mono, monospace);
+		font-size: 12px;
+	}
+
+	.review-badge {
+		display: inline-block;
+		padding: 2px 8px;
+		border: 1px solid var(--sig-border-strong);
+		border-radius: var(--sig-radius);
+		font-family: var(--font-mono, monospace);
+		font-size: 11px;
+		letter-spacing: 0.04em;
+		color: var(--sig-text-bright);
+		background: color-mix(in srgb, var(--sig-surface), transparent 5%);
+	}
+
+	.review-harnesses {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 6px;
+	}
+
+	.review-note {
+		grid-column: 1 / -1;
+		margin: 10px 0 0;
+		padding: 10px 12px;
+		border: 1px solid var(--sig-border);
+		border-radius: var(--sig-radius);
+		background: var(--sig-surface);
+		font-size: 12px;
+		line-height: 1.35;
+		color: var(--sig-text-muted);
+	}
+
+	@media (max-width: 620px) {
+		.review-grid {
+			grid-template-columns: 1fr;
+			gap: 4px;
+		}
+
+		.review-label {
+			padding-top: 8px;
+			border-top: 1px solid var(--sig-border-strong);
+		}
+	}
+</style>

--- a/surfaces/dashboard/src/lib/components/onboarding/steps/WelcomeStep.svelte
+++ b/surfaces/dashboard/src/lib/components/onboarding/steps/WelcomeStep.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+	import { IDENTITY_PRESET_META, type IdentityPresetName, type OnboardingState } from "../onboarding-state.svelte";
+
+	interface Props {
+		state: OnboardingState;
+	}
+
+	const { state }: Props = $props();
+
+	const PRESET_META = IDENTITY_PRESET_META;
+
+	function selectPreset(name: IdentityPresetName): void {
+		state.identityPreset = name;
+	}
+</script>
+
+<div class="welcome-grid">
+	<p class="welcome-intro">
+		Choose an identity preset. This determines which files load at startup and shapes how your agent
+		thinks. You can change it later in Settings.
+	</p>
+
+	{#each PRESET_META as preset (preset.name)}
+		<button
+			type="button"
+			class="preset-card sig-switch"
+			class:preset-card-active={state.identityPreset === preset.name}
+			onclick={() => selectPreset(preset.name)}
+			aria-pressed={state.identityPreset === preset.name}
+		>
+			<span class="preset-radio" aria-hidden="true"></span>
+			<div class="preset-content">
+				<div class="preset-header">
+					<strong>{preset.title}</strong>
+					{#if state.identityPreset === preset.name}
+						<span class="selected-badge">selected</span>
+					{/if}
+				</div>
+				<p>{preset.subtitle}</p>
+				<span class="preset-files">{preset.files}</span>
+			</div>
+		</button>
+	{/each}
+</div>
+
+<style>
+	.welcome-grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 12px;
+	}
+
+	.welcome-intro {
+		grid-column: 1 / -1;
+		margin: 0 0 4px;
+		font-size: 13px;
+		line-height: 1.4;
+		color: var(--sig-text);
+	}
+
+	.preset-card {
+		position: relative;
+		padding: 14px 14px 14px 36px;
+		text-align: left;
+		cursor: pointer;
+		border: 1px solid var(--sig-border-strong);
+		border-radius: var(--sig-radius);
+		background: color-mix(in srgb, var(--sig-surface), transparent 5%);
+		color: var(--sig-text);
+		transition: border-color var(--dur) var(--ease), background var(--dur) var(--ease),
+			box-shadow var(--dur) var(--ease);
+	}
+
+	.preset-card:hover {
+		border-color: var(--sig-highlight);
+		background: color-mix(in srgb, var(--sig-surface), var(--sig-highlight) 4%);
+	}
+
+	.preset-card-active {
+		border-color: var(--sig-highlight);
+		background: color-mix(in srgb, var(--sig-surface-raised), var(--sig-highlight) 10%);
+		box-shadow: var(--sig-glow-highlight), inset 3px 0 0 var(--sig-highlight),
+			inset 0 1px 0 rgba(255, 255, 255, 0.08);
+	}
+
+	.preset-radio {
+		position: absolute;
+		top: 16px;
+		left: 12px;
+		width: 13px;
+		height: 13px;
+		border: 1px solid var(--sig-border-strong);
+		background: var(--sig-bg);
+		border-radius: 50%;
+	}
+
+	.preset-card-active .preset-radio {
+		border-color: var(--sig-highlight);
+		background: var(--sig-highlight);
+		box-shadow: inset 0 0 0 3px var(--sig-bg),
+			0 0 10px color-mix(in srgb, var(--sig-highlight), transparent 36%);
+	}
+
+	.preset-content {
+		display: flex;
+		flex-direction: column;
+		gap: 5px;
+	}
+
+	.preset-header {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.preset-header strong {
+		font-family: var(--font-display, monospace);
+		font-size: 13px;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--sig-text-bright);
+	}
+
+	.selected-badge {
+		font-family: var(--font-mono, monospace);
+		font-size: 9px;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--sig-highlight-text);
+	}
+
+	.preset-content p {
+		margin: 0;
+		font-size: 12px;
+		line-height: 1.35;
+		color: var(--sig-text-muted);
+	}
+
+	.preset-files {
+		font-family: var(--font-mono, monospace);
+		font-size: 10px;
+		letter-spacing: 0.04em;
+		color: var(--sig-text-muted);
+		opacity: 0.7;
+	}
+
+	@media (max-width: 620px) {
+		.welcome-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/surfaces/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
@@ -22,6 +22,7 @@ import {
 	type AcpxDashboardAgent,
 	DEFAULT_OPENAI_COMPATIBLE_ENDPOINT,
 	applyAcpxDashboardSetup,
+	applyRecommendedPipelineSetup,
 	defaultAcpxDashboardAgent,
 	defaultAcpxDashboardModel,
 	hasExplicitSynthesisConfig,
@@ -327,35 +328,11 @@ function extractionModelLabel(): string {
 	return preset ? preset.label : model;
 }
 
-let acpxAgent = $state<AcpxDashboardAgent>("codex");
-let acpxModel = $state(defaultAcpxDashboardModel("codex"));
-
-$effect(() => {
-	const nextAgent = defaultAcpxDashboardAgent(st.agent);
-	acpxAgent = nextAgent;
-	const current =
-		st.aStr(["memory", "pipelineV2", "extractionProvider"]) === "acpx"
-			? st.aStr(["memory", "pipelineV2", "extractionModel"])
-			: "";
-	acpxModel = current || defaultAcpxDashboardModel(nextAgent);
-});
-
-function acpxAgentLabel(): string {
-	return ACPX_DASHBOARD_AGENT_OPTIONS.find((option) => option.value === acpxAgent)?.label ?? acpxAgent;
-}
-
-function setAcpxAgent(value: string | undefined): void {
-	if (value !== "codex" && value !== "claude-code" && value !== "opencode") return;
-	acpxAgent = value;
-	acpxModel = defaultAcpxDashboardModel(value);
-}
-
-function setAcpxModel(e: Event): void {
-	acpxModel = (e.currentTarget as HTMLInputElement).value;
-}
-
-function applyAcpxQuickSetup(): void {
-	applyAcpxDashboardSetup(st.agent, { agent: acpxAgent, model: acpxModel });
+function applyRecommendedSetup(): void {
+	const currentProvider = extractionProvider();
+	const provider: PipelineProviderChoice = isKnownProvider(currentProvider) ? currentProvider : "acpx";
+	const model = extractionModel() || defaultModelForProvider(provider);
+	applyRecommendedPipelineSetup(st.agent, { provider, model });
 	st.agent = { ...st.agent };
 }
 
@@ -378,46 +355,20 @@ const ADVANCED_FEATURE_KEYS = ["autonomousFrozen"] as const;
 {#if st.agentFile}
 	<FormSection description="V2 memory pipeline. Runs LLM-based fact extraction on incoming memories, then decides whether to write, update, or skip. Lives under memory.pipelineV2 in agent.yaml.">
 		<div class="rounded-lg border border-[var(--sig-border-strong)] bg-[color-mix(in_srgb,var(--sig-bg),var(--sig-highlight)_4%)] p-3">
-			<div class="flex flex-col gap-3">
-				<div class="flex items-start justify-between gap-3">
-					<div class="flex flex-col gap-1">
-						<span class="font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--sig-highlight)]">ACPX quick setup</span>
-						<span class="text-[12px] leading-snug text-[var(--sig-text)]">Configure background extraction and session synthesis through ACPX with the guarded defaults Signet expects.</span>
-					</div>
-					<button
-						type="button"
-						class="shrink-0 rounded-md border border-[var(--sig-highlight)] bg-[color-mix(in_srgb,var(--sig-highlight),transparent_88%)] px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.08em] text-[var(--sig-highlight)] transition-colors hover:bg-[color-mix(in_srgb,var(--sig-highlight),transparent_80%)]"
-						onclick={applyAcpxQuickSetup}
-					>
-						Use ACPX defaults
-					</button>
+			<div class="flex items-start justify-between gap-3">
+				<div class="flex flex-col gap-1">
+					<span class="font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--sig-highlight)]">Pipeline setup</span>
+					<span class="text-[12px] leading-snug text-[var(--sig-text)]">Configure extraction and session synthesis through the unified provider settings below. Provider routing stays with the shared LLM configuration instead of dashboard-specific inference wiring.</span>
 				</div>
-
-				<div class="grid gap-2 md:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]">
-					<div class="flex flex-col gap-1.5">
-						<span class="font-mono text-[9px] uppercase tracking-[0.1em] text-[var(--sig-text-muted)]">Agent adapter</span>
-						<Select.Root type="single" value={acpxAgent} onValueChange={setAcpxAgent}>
-							<Select.Trigger class={selectTriggerClass}>{acpxAgentLabel()}</Select.Trigger>
-							<Select.Content class={selectContentClass}>
-								{#each ACPX_DASHBOARD_AGENT_OPTIONS as option (option.value)}
-									<Select.Item class={selectItemClass} value={option.value} label={option.label} />
-								{/each}
-							</Select.Content>
-						</Select.Root>
-					</div>
-					<div class="flex flex-col gap-1.5">
-						<span class="font-mono text-[9px] uppercase tracking-[0.1em] text-[var(--sig-text-muted)]">Model</span>
-						<Input value={acpxModel} oninput={setAcpxModel} placeholder="model passed through ACPX" />
-					</div>
-				</div>
-
-				<div class="grid gap-2 text-[9px] uppercase tracking-[0.08em] text-[var(--sig-text-muted)] md:grid-cols-3">
-					<span>npx acpx@0.7.0</span>
-					<span>permissions: deny-all</span>
-					<span>hooks: disabled</span>
-				</div>
-				<span class="text-[9px] uppercase tracking-wider text-[var(--sig-warning)]">Writes memory.pipelineV2 plus a background-acpx inference route for memory extraction and session synthesis. Save settings after applying.</span>
+				<button
+					type="button"
+					class="shrink-0 rounded-md border border-[var(--sig-highlight)] bg-[color-mix(in_srgb,var(--sig-highlight),transparent_88%)] px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.08em] text-[var(--sig-highlight)] transition-colors hover:bg-[color-mix(in_srgb,var(--sig-highlight),transparent_80%)]"
+					onclick={applyRecommendedSetup}
+				>
+					Use recommended defaults
+				</button>
 			</div>
+			<span class="mt-2 block text-[9px] uppercase tracking-wider text-[var(--sig-warning)]">Writes memory.pipelineV2 extraction and synthesis provider settings only. Save settings after applying.</span>
 		</div>
 
 		<FormField label={PIPELINE_CORE_BOOLS[0].key} description={PIPELINE_CORE_BOOLS[0].desc}>

--- a/surfaces/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
@@ -16,12 +16,11 @@ import {
 	st,
 } from "$lib/stores/settings.svelte";
 import { modelPresetsForProvider } from "@signet/core/llm-model-catalog";
-import { defaultPipelineModel } from "@signet/core/pipeline-providers";
+import { type PipelineProviderChoice, defaultPipelineModel } from "@signet/core/pipeline-providers";
 import {
 	ACPX_DASHBOARD_AGENT_OPTIONS,
 	type AcpxDashboardAgent,
 	DEFAULT_OPENAI_COMPATIBLE_ENDPOINT,
-	applyAcpxDashboardSetup,
 	applyRecommendedPipelineSetup,
 	defaultAcpxDashboardAgent,
 	defaultAcpxDashboardModel,

--- a/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from "bun:test";
 import { DEFAULT_PIPELINE_TIMEOUT_MS } from "@signet/core/pipeline-providers";
 import {
 	DEFAULT_OPENAI_COMPATIBLE_ENDPOINT,
-	defaultAcpxDashboardAgent,
 	applyRecommendedPipelineSetup,
+	defaultAcpxDashboardAgent,
 	hasExplicitSynthesisConfig,
 	hasExplicitSynthesisProvider,
 	resolveExtractionEndpoint,
@@ -257,8 +257,22 @@ describe("pipeline-settings ACPX dashboard setup", () => {
 		});
 	});
 
-	it("applies onboarding endpoint and ACPX harness choices", () => {
-		const localAgent: Record<string, unknown> = {};
+	it("applies onboarding endpoint without writing stale ACPX routing for non-ACPX providers", () => {
+		const localAgent: Record<string, unknown> = {
+			inference: {
+				defaultPolicy: "background-acpx",
+				targets: { "background-acpx": { executor: "acpx" }, "custom-local": { executor: "ollama" } },
+				policies: { "background-acpx": { mode: "automatic" } },
+				taskClasses: {
+					memory_extraction: { reasoning: "medium", toolsRequired: true, privacy: "restricted_remote" },
+					session_synthesis: { reasoning: "medium", toolsRequired: true, privacy: "restricted_remote" },
+				},
+				workloads: {
+					memoryExtraction: { target: "background-acpx/default", taskClass: "memory_extraction" },
+					sessionSynthesis: { target: "custom-local/default", taskClass: "session_synthesis" },
+				},
+			},
+		};
 		applyRecommendedPipelineSetup(localAgent, {
 			provider: "llama-cpp",
 			model: "qwen3.5:4b",
@@ -282,6 +296,35 @@ describe("pipeline-settings ACPX dashboard setup", () => {
 				},
 			},
 		});
+		expect(localAgent.inference).toMatchObject({
+			targets: { "custom-local": { executor: "ollama" } },
+			workloads: { sessionSynthesis: { target: "custom-local/default", taskClass: "session_synthesis" } },
+		});
+		expect((localAgent.inference as { defaultPolicy?: string }).defaultPolicy).toBeUndefined();
+		expect((localAgent.inference as { targets: Record<string, unknown> }).targets["background-acpx"]).toBeUndefined();
+		expect((localAgent.inference as { policies?: Record<string, unknown> }).policies).toBeUndefined();
+		expect((localAgent.inference as { taskClasses: Record<string, unknown> }).taskClasses).toEqual({
+			session_synthesis: { reasoning: "medium", toolsRequired: true, privacy: "restricted_remote" },
+		});
+		expect((localAgent.inference as { workloads: Record<string, unknown> }).workloads.memoryExtraction).toBeUndefined();
+
+		const generatedOnlyAgent: Record<string, unknown> = {
+			inference: {
+				defaultPolicy: "background-acpx",
+				targets: { "background-acpx": { executor: "acpx" } },
+				policies: { "background-acpx": { mode: "automatic" } },
+				taskClasses: {
+					memory_extraction: { reasoning: "medium", toolsRequired: true, privacy: "restricted_remote" },
+					session_synthesis: { reasoning: "medium", toolsRequired: true, privacy: "restricted_remote" },
+				},
+				workloads: {
+					memoryExtraction: { target: "background-acpx/default", taskClass: "memory_extraction" },
+					sessionSynthesis: { target: "background-acpx/default", taskClass: "session_synthesis" },
+				},
+			},
+		};
+		applyRecommendedPipelineSetup(generatedOnlyAgent, { provider: "ollama", model: "qwen3:4b" });
+		expect(generatedOnlyAgent.inference).toBeUndefined();
 
 		const acpxAgent: Record<string, unknown> = {};
 		applyRecommendedPipelineSetup(acpxAgent, {

--- a/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts
@@ -196,7 +196,11 @@ describe("pipeline-settings ACPX dashboard setup", () => {
 			pipelineV2: {
 				enabled: true,
 				extractionProvider: "acpx",
-				extractionModel: "haiku",
+				extractionModel: "gpt-5-codex-mini",
+				extraction: {
+					provider: "acpx",
+					model: "gpt-5-codex-mini",
+				},
 				synthesis: {
 					enabled: true,
 					provider: "acpx",
@@ -240,6 +244,49 @@ describe("pipeline-settings ACPX dashboard setup", () => {
 			workloads: {
 				memoryExtraction: { target: "background-acpx/default", taskClass: "memory_extraction" },
 				sessionSynthesis: { target: "background-acpx/default", taskClass: "session_synthesis" },
+			},
+		});
+	});
+
+	it("applies onboarding endpoint and ACPX harness choices", () => {
+		const localAgent: Record<string, unknown> = {};
+		applyRecommendedPipelineSetup(localAgent, {
+			provider: "llama-cpp",
+			model: "qwen3.5:4b",
+			endpoint: "http://127.0.0.1:8080/v1",
+		});
+		expect(localAgent.memory).toMatchObject({
+			pipelineV2: {
+				extractionProvider: "llama-cpp",
+				extractionModel: "qwen3.5:4b",
+				extractionEndpoint: "http://127.0.0.1:8080/v1",
+				extractionBaseUrl: "http://127.0.0.1:8080/v1",
+				extraction: {
+					provider: "llama-cpp",
+					model: "qwen3.5:4b",
+					endpoint: "http://127.0.0.1:8080/v1",
+				},
+				synthesis: {
+					provider: "llama-cpp",
+					model: "qwen3.5:4b",
+					endpoint: "http://127.0.0.1:8080/v1",
+				},
+			},
+		});
+
+		const acpxAgent: Record<string, unknown> = {};
+		applyRecommendedPipelineSetup(acpxAgent, {
+			provider: "acpx",
+			model: "gpt-5-codex-mini",
+			acpxHarness: "codex",
+		});
+		expect(acpxAgent.memory).toMatchObject({
+			pipelineV2: {
+				extraction: {
+					provider: "acpx",
+					model: "gpt-5-codex-mini",
+					harness: "codex",
+				},
 			},
 		});
 	});

--- a/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "bun:test";
 import { DEFAULT_PIPELINE_TIMEOUT_MS } from "@signet/core/pipeline-providers";
 import {
 	DEFAULT_OPENAI_COMPATIBLE_ENDPOINT,
-	applyAcpxDashboardSetup,
 	defaultAcpxDashboardAgent,
 	applyRecommendedPipelineSetup,
 	hasExplicitSynthesisConfig,
@@ -91,7 +90,7 @@ describe("pipeline-settings synthesis resolution", () => {
 					extractionModel: "qwen3:4b",
 					synthesis: {
 						provider: "claude-code",
-						model: "haiku",
+						model: "gpt-5-codex-mini",
 						endpoint: "http://127.0.0.1:9999",
 						timeout: 180000,
 					},
@@ -102,7 +101,7 @@ describe("pipeline-settings synthesis resolution", () => {
 		expect(hasExplicitSynthesisConfig(agent)).toBe(true);
 		expect(hasExplicitSynthesisProvider(agent)).toBe(true);
 		expect(resolveSynthesisProvider(agent)).toBe("claude-code");
-		expect(resolveSynthesisModel(agent)).toBe("haiku");
+		expect(resolveSynthesisModel(agent)).toBe("gpt-5-codex-mini");
 		expect(resolveSynthesisEndpoint(agent)).toBe("http://127.0.0.1:9999");
 		expect(resolveSynthesisTimeout(agent)).toBe(180000);
 		expect(resolveSynthesisEnabled(agent)).toBe(true);
@@ -197,14 +196,13 @@ describe("pipeline-settings ACPX dashboard setup", () => {
 				enabled: true,
 				extractionProvider: "acpx",
 				extractionModel: "gpt-5-codex-mini",
-				extraction: {
-					provider: "acpx",
-					model: "gpt-5-codex-mini",
-				},
+				graphEnabled: true,
+				rerankerEnabled: true,
+				semanticContradictionEnabled: true,
 				synthesis: {
 					enabled: true,
 					provider: "acpx",
-					model: "haiku",
+					model: "gpt-5-codex-mini",
 					timeout: 120000,
 				},
 			},
@@ -223,14 +221,20 @@ describe("pipeline-settings ACPX dashboard setup", () => {
 				"background-acpx": {
 					executor: "acpx",
 					acpx: {
-						agent: "claude",
+						agent: "codex",
 						package: "acpx@0.7.0",
+						version: "0.7.0",
+						mode: "exec",
+						terminal: "inherit",
 						permissions: "deny-all",
 						hooks: "disabled",
 					},
 					models: {
 						default: {
-							model: "haiku",
+							model: "gpt-5-codex-mini",
+							reasoning: "medium",
+							toolUse: true,
+							costTier: "medium",
 						},
 					},
 				},
@@ -239,7 +243,12 @@ describe("pipeline-settings ACPX dashboard setup", () => {
 				"background-acpx": {
 					mode: "automatic",
 					defaultTargets: ["background-acpx/default"],
+					fallbackTargets: ["background-acpx/default"],
 				},
+			},
+			taskClasses: {
+				memory_extraction: { reasoning: "medium", toolsRequired: true, privacy: "restricted_remote" },
+				session_synthesis: { reasoning: "medium", toolsRequired: true, privacy: "restricted_remote" },
 			},
 			workloads: {
 				memoryExtraction: { target: "background-acpx/default", taskClass: "memory_extraction" },

--- a/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts
@@ -5,6 +5,7 @@ import {
 	DEFAULT_OPENAI_COMPATIBLE_ENDPOINT,
 	applyAcpxDashboardSetup,
 	defaultAcpxDashboardAgent,
+	applyRecommendedPipelineSetup,
 	hasExplicitSynthesisConfig,
 	hasExplicitSynthesisProvider,
 	resolveExtractionEndpoint,
@@ -181,7 +182,6 @@ describe("pipeline-settings ACPX dashboard setup", () => {
 
 	it("applies a one-click ACPX background setup for extraction, synthesis, and routing", () => {
 		const agent: Record<string, unknown> = {
-			harnesses: ["claude-code"],
 			inference: {
 				defaultPolicy: "custom-local",
 				targets: {
@@ -190,7 +190,7 @@ describe("pipeline-settings ACPX dashboard setup", () => {
 			},
 		};
 
-		applyAcpxDashboardSetup(agent, { agent: "claude-code" });
+		applyRecommendedPipelineSetup(agent, { provider: "acpx", model: "gpt-5-codex-mini" });
 
 		expect(agent.memory).toMatchObject({
 			pipelineV2: {
@@ -212,7 +212,7 @@ describe("pipeline-settings ACPX dashboard setup", () => {
 			"allowUpdateDelete",
 		);
 		expect((agent.memory as { pipelineV2: Record<string, unknown> }).pipelineV2).not.toHaveProperty("maintenanceMode");
-		expect(agent.inference).toMatchObject({
+		expect(agent.inference).toEqual({
 			defaultPolicy: "custom-local",
 			targets: {
 				"custom-local": { executor: "ollama" },

--- a/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.ts
@@ -229,7 +229,7 @@ export function applyRecommendedPipelineSetup(
 	targets["background-acpx"] = {
 		executor: "acpx",
 		acpx: {
-			agent: acpxCommandAgent(options.agent),
+			agent: acpxCommandAgent(options.agent ?? "codex"),
 			package: "acpx@0.7.0",
 			version: "0.7.0",
 			mode: "exec",

--- a/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.ts
@@ -177,22 +177,50 @@ function acpxCommandAgent(agent: AcpxDashboardAgent): string {
 
 export function applyRecommendedPipelineSetup(
 	agentConfig: Record<string, unknown>,
-	options: { readonly provider?: PipelineProviderChoice; readonly model?: string; readonly agent?: AcpxDashboardAgent } = {},
+		options: {
+			readonly provider?: PipelineProviderChoice;
+			readonly model?: string;
+			readonly agent?: AcpxDashboardAgent;
+			readonly endpoint?: string;
+			readonly acpxHarness?: string;
+			readonly synthesisEnabled?: boolean;
+		} = {},
 ): void {
 	const provider = options.provider ?? "acpx";
 	const model = options.model?.trim() || defaultPipelineModel(provider);
+	const endpoint = options.endpoint?.trim() ?? "";
+	const acpxHarness = options.acpxHarness?.trim() ?? "";
+	const enabled = provider !== "none";
 	const memory = ensureRecord(agentConfig, "memory");
 	const pipeline = ensureRecord(memory, "pipelineV2");
-	pipeline.enabled = provider !== "none";
+	const extraction = ensureRecord(pipeline, "extraction");
+	pipeline.enabled = enabled;
 	pipeline.extractionProvider = provider;
 	pipeline.extractionModel = model;
-	pipeline.semanticContradictionEnabled = provider !== "none";
-	pipeline.graphEnabled = provider !== "none";
-	pipeline.rerankerEnabled = provider !== "none";
+	extraction.provider = provider;
+	extraction.model = model;
+	if (endpoint) {
+		pipeline.extractionEndpoint = endpoint;
+		pipeline.extractionBaseUrl = endpoint;
+		extraction.endpoint = endpoint;
+	} else {
+		pipeline.extractionEndpoint = undefined;
+		pipeline.extractionBaseUrl = undefined;
+		extraction.endpoint = undefined;
+	}
+	if (provider === "acpx" && acpxHarness) {
+		extraction.harness = acpxHarness;
+	} else {
+		extraction.harness = undefined;
+	}
+	pipeline.semanticContradictionEnabled = enabled;
+	pipeline.graphEnabled = enabled;
+	pipeline.rerankerEnabled = enabled;
 	pipeline.synthesis = {
-		enabled: provider !== "none",
+		enabled: options.synthesisEnabled ?? enabled,
 		provider,
 		model,
+		...(endpoint ? { endpoint } : {}),
 		timeout: 120000,
 	};
 

--- a/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.ts
@@ -175,16 +175,82 @@ function acpxCommandAgent(agent: AcpxDashboardAgent): string {
 	return agent === "claude-code" ? "claude" : agent;
 }
 
+function normalizeAcpxAgent(value: string | undefined): AcpxDashboardAgent | undefined {
+	return value === "codex" || value === "claude-code" || value === "opencode" ? value : undefined;
+}
+
+function withoutKey(record: Record<string, unknown>, key: string): Record<string, unknown> {
+	return Object.fromEntries(Object.entries(record).filter(([entryKey]) => entryKey !== key));
+}
+
+function definedKeys(record: Record<string, unknown>): string[] {
+	return Object.entries(record)
+		.filter(([, value]) => value !== undefined)
+		.map(([key]) => key);
+}
+
+function clearIfEmpty(root: Record<string, unknown>, key: string): void {
+	const record = mutableRecord(root[key]);
+	if (record && definedKeys(record).length === 0) root[key] = undefined;
+}
+
+function isGeneratedAcpxTaskClass(value: unknown): boolean {
+	const record = mutableRecord(value);
+	return record?.reasoning === "medium" && record.toolsRequired === true && record.privacy === "restricted_remote";
+}
+
+function removeStaleAcpxInference(agentConfig: Record<string, unknown>): void {
+	const inference = mutableRecord(agentConfig.inference);
+	if (!inference) return;
+	const targets = mutableRecord(inference.targets);
+	if (targets) inference.targets = withoutKey(targets, "background-acpx");
+	const policies = mutableRecord(inference.policies);
+	if (policies) inference.policies = withoutKey(policies, "background-acpx");
+	if (inference.defaultPolicy === "background-acpx") inference.defaultPolicy = undefined;
+	const workloads = mutableRecord(inference.workloads);
+	if (workloads) {
+		let nextWorkloads = workloads;
+		for (const key of ["memoryExtraction", "sessionSynthesis"]) {
+			const workload = mutableRecord(nextWorkloads[key]);
+			if (workload?.target === "background-acpx/default") nextWorkloads = withoutKey(nextWorkloads, key);
+		}
+		inference.workloads = nextWorkloads;
+	}
+	const taskClasses = mutableRecord(inference.taskClasses);
+	if (taskClasses) {
+		const referencedTaskClasses = new Set<string>();
+		const remainingWorkloads = mutableRecord(inference.workloads);
+		if (remainingWorkloads) {
+			for (const value of Object.values(remainingWorkloads)) {
+				const taskClass = mutableRecord(value)?.taskClass;
+				if (typeof taskClass === "string") referencedTaskClasses.add(taskClass);
+			}
+		}
+		let nextTaskClasses = taskClasses;
+		for (const key of ["memory_extraction", "session_synthesis"]) {
+			if (!referencedTaskClasses.has(key) && isGeneratedAcpxTaskClass(nextTaskClasses[key])) {
+				nextTaskClasses = withoutKey(nextTaskClasses, key);
+			}
+		}
+		inference.taskClasses = nextTaskClasses;
+	}
+	clearIfEmpty(inference, "targets");
+	clearIfEmpty(inference, "policies");
+	clearIfEmpty(inference, "workloads");
+	clearIfEmpty(inference, "taskClasses");
+	if (definedKeys(inference).length === 0) agentConfig.inference = undefined;
+}
+
 export function applyRecommendedPipelineSetup(
 	agentConfig: Record<string, unknown>,
-		options: {
-			readonly provider?: PipelineProviderChoice;
-			readonly model?: string;
-			readonly agent?: AcpxDashboardAgent;
-			readonly endpoint?: string;
-			readonly acpxHarness?: string;
-			readonly synthesisEnabled?: boolean;
-		} = {},
+	options: {
+		readonly provider?: PipelineProviderChoice;
+		readonly model?: string;
+		readonly agent?: AcpxDashboardAgent;
+		readonly endpoint?: string;
+		readonly acpxHarness?: string;
+		readonly synthesisEnabled?: boolean;
+	} = {},
 ): void {
 	const provider = options.provider ?? "acpx";
 	const model = options.model?.trim() || defaultPipelineModel(provider);
@@ -224,12 +290,18 @@ export function applyRecommendedPipelineSetup(
 		timeout: 120000,
 	};
 
+	if (provider !== "acpx") {
+		removeStaleAcpxInference(agentConfig);
+		return;
+	}
+
+	const acpxAgent = options.agent ?? normalizeAcpxAgent(acpxHarness) ?? "codex";
 	const inference = ensureRecord(agentConfig, "inference");
 	const targets = ensureRecord(inference, "targets");
 	targets["background-acpx"] = {
 		executor: "acpx",
 		acpx: {
-			agent: acpxCommandAgent(options.agent ?? "codex"),
+			agent: acpxCommandAgent(acpxAgent),
 			package: "acpx@0.7.0",
 			version: "0.7.0",
 			mode: "exec",

--- a/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.ts
@@ -175,22 +175,23 @@ function acpxCommandAgent(agent: AcpxDashboardAgent): string {
 	return agent === "claude-code" ? "claude" : agent;
 }
 
-export function applyAcpxDashboardSetup(
+export function applyRecommendedPipelineSetup(
 	agentConfig: Record<string, unknown>,
-	options: { readonly agent: AcpxDashboardAgent; readonly model?: string },
+	options: { readonly provider?: PipelineProviderChoice; readonly model?: string; readonly agent?: AcpxDashboardAgent } = {},
 ): void {
-	const model = options.model?.trim() || defaultAcpxDashboardModel(options.agent);
+	const provider = options.provider ?? "acpx";
+	const model = options.model?.trim() || defaultPipelineModel(provider);
 	const memory = ensureRecord(agentConfig, "memory");
 	const pipeline = ensureRecord(memory, "pipelineV2");
-	pipeline.enabled = true;
-	pipeline.extractionProvider = "acpx";
+	pipeline.enabled = provider !== "none";
+	pipeline.extractionProvider = provider;
 	pipeline.extractionModel = model;
-	pipeline.semanticContradictionEnabled = true;
-	pipeline.graphEnabled = true;
-	pipeline.rerankerEnabled = true;
+	pipeline.semanticContradictionEnabled = provider !== "none";
+	pipeline.graphEnabled = provider !== "none";
+	pipeline.rerankerEnabled = provider !== "none";
 	pipeline.synthesis = {
-		enabled: true,
-		provider: "acpx",
+		enabled: provider !== "none",
+		provider,
 		model,
 		timeout: 120000,
 	};

--- a/surfaces/dashboard/src/lib/lucide-icons.d.ts
+++ b/surfaces/dashboard/src/lib/lucide-icons.d.ts
@@ -1,0 +1,7 @@
+declare module "@lucide/svelte/icons/*" {
+	import type { Component } from "svelte";
+
+	type IconProps = Record<string, unknown> & { class?: string };
+	const icon: Component<IconProps>;
+	export default icon;
+}

--- a/surfaces/dashboard/src/routes/+page.svelte
+++ b/surfaces/dashboard/src/routes/+page.svelte
@@ -298,6 +298,7 @@ $effect(() => {
 <OnboardingModal
 	configFiles={data.configFiles}
 	memoryStats={data.memoryStats}
+	harnesses={data.harnesses}
 	{daemonStatus}
 	onnavigate={setTab}
 />

--- a/surfaces/dashboard/src/routes/+page.svelte
+++ b/surfaces/dashboard/src/routes/+page.svelte
@@ -8,6 +8,7 @@ import GlobalCommandPalette from "$lib/components/command/GlobalCommandPalette.s
 import PageFooter from "$lib/components/layout/PageFooter.svelte";
 import TabContentLoader from "$lib/components/layout/TabContentLoader.svelte";
 import WindowTitlebar from "$lib/components/layout/WindowTitlebar.svelte";
+import OnboardingModal from "$lib/components/onboarding/OnboardingModal.svelte";
 import * as Sidebar from "$lib/components/ui/sidebar/index.js";
 import { Toaster } from "$lib/components/ui/sonner/index.js";
 import { isDesktopShell } from "$lib/desktop-shell";
@@ -294,6 +295,12 @@ $effect(() => {
 </div>
 
 <GlobalCommandPalette />
+<OnboardingModal
+	configFiles={data.configFiles}
+	memoryStats={data.memoryStats}
+	{daemonStatus}
+	onnavigate={setTab}
+/>
 
 <Toaster
 	position="bottom-right"

--- a/surfaces/dashboard/vite.config.ts
+++ b/surfaces/dashboard/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
 	},
 	resolve: {
 		alias: {
+			"@signet/core/identity-presets": resolve(root, "../../platform/core/src/identity-presets.ts"),
 			"@signet/core/llm-model-catalog": resolve(root, "../../platform/core/src/llm-model-catalog.ts"),
 			"@signet/core/pipeline-providers": resolve(root, "../../platform/core/src/pipeline-providers.ts"),
 		},


### PR DESCRIPTION
## Summary
- Adds a dashboard setup mode to `signet setup`, including `--setup-mode dashboard`, so fresh installs can create safe defaults and open the dashboard instead of walking the full terminal wizard.
- Reworks the dashboard pipeline setup panel to use the existing `memory.pipelineV2` extraction/synthesis provider settings instead of inventing dashboard-specific ACPX routing.
- Updates focused tests for setup option plumbing and provider-only recommended pipeline setup.

## Test Plan
- [x] `bun run build:core`
- [x] `bun test surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts surfaces/cli/src/commands/app.test.ts`
- [x] `bunx biome check surfaces/cli/src/commands/app.ts surfaces/cli/src/commands/app.test.ts surfaces/cli/src/features/setup.ts surfaces/cli/src/features/setup-types.ts surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.ts surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts`
- [x] `bun run --filter '@signet/cli' build:cli`
- [x] `cd surfaces/dashboard && bun run check` (passes with existing unrelated warnings)

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes
- [x] No database migrations were added, removed, renumbered, or modified.
