### PR TITLE
fix: normalize dashboard acpx claude regression

### DIFF
--- a/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts
@@ -140,6 +140,21 @@ describe("pipeline-settings ACPX dashboard setup", () => {
 		expect(defaultAcpxDashboardAgent(agent)).toBe("opencode");
 	});
 
+	it("maps ACPX's Claude command back to the Claude Code dashboard option", () => {
+		const agent = {
+			harnesses: ["codex"],
+			inference: {
+				targets: {
+					"background-acpx": {
+						acpx: { agent: "claude" },
+					},
+				},
+			},
+		};
+
+		expect(defaultAcpxDashboardAgent(agent)).toBe("claude-code");
+	});
+
 	it("applies a one-click ACPX background setup for extraction, synthesis, and routing", () => {
 		const agent: Record<string, unknown> = {
 			harnesses: ["claude-code"],
@@ -180,7 +195,7 @@ describe("pipeline-settings ACPX dashboard setup", () => {
 				"background-acpx": {
 					executor: "acpx",
 					acpx: {
-						agent: "claude-code",
+						agent: "claude",
 						package: "acpx@0.7.0",
 						permissions: "deny-all",
 						hooks: "disabled",

--- a/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.ts
@@ -142,6 +142,7 @@ export function defaultAcpxDashboardAgent(agentConfig: unknown): AcpxDashboardAg
 	const target = toRecord(toRecord(inference?.targets)?.["background-acpx"]);
 	const acpx = toRecord(target?.acpx);
 	const configured = acpx?.agent;
+	if (configured === "claude") return "claude-code";
 	if (configured === "claude-code" || configured === "opencode" || configured === "codex") return configured;
 	const harnesses = toRecord(agentConfig)?.harnesses;
 	if (Array.isArray(harnesses)) {
@@ -154,6 +155,10 @@ export function defaultAcpxDashboardAgent(agentConfig: unknown): AcpxDashboardAg
 
 export function defaultAcpxDashboardModel(agent: AcpxDashboardAgent): string {
 	return ACPX_DASHBOARD_AGENT_OPTIONS.find((option) => option.value === agent)?.model ?? "gpt-5-codex-mini";
+}
+
+function acpxCommandAgent(agent: AcpxDashboardAgent): string {
+	return agent === "claude-code" ? "claude" : agent;
 }
 
 export function applyAcpxDashboardSetup(
@@ -181,7 +186,7 @@ export function applyAcpxDashboardSetup(
 	targets["background-acpx"] = {
 		executor: "acpx",
 		acpx: {
-			agent: options.agent,
+			agent: acpxCommandAgent(options.agent),
 			package: "acpx@0.7.0",
 			version: "0.7.0",
 			mode: "exec",


### PR DESCRIPTION
## Summary
- Fixes the dashboard ACPX quick setup to write ACPX's canonical `claude` adapter command when the user selects the Claude Code dashboard option.
- Maps existing `acpx.agent: claude` configs back to the Claude Code UI option so the dashboard does not fall through to another harness/default.

## Regression detected
PR #688 added dashboard ACPX quick setup, but its dashboard helper used the Signet harness label `claude-code` directly in the generated ACPX target. The CLI setup path and ACPX/provider runtime contract use ACPX's command name `claude` for Claude Code.

## Root cause
The new dashboard helper conflated the UI/harness identifier (`claude-code`) with the ACPX adapter command (`claude`). It also only recognized `claude-code`, `codex`, and `opencode` when reading an existing `background-acpx` target, so an existing canonical CLI-generated `acpx.agent: claude` route could be mis-detected as Codex or a harness fallback.

## Fix summary
- Added a regression test for reading canonical `acpx.agent: claude` as the Claude Code dashboard option.
- Added a small alias function so dashboard quick setup persists `claude` for the Claude Code ACPX target while keeping the UI option as `claude-code`.

## Tests/checks run
- `bun scripts/version-sync.ts --check` — passed (`All versions already aligned at 0.116.4.`)
- `bun scripts/check-publish-manifests.ts` — passed
- `bun test surfaces/cli/src/lib/runtime.test.ts tests/integration/installer-path-regression.test.ts platform/daemon/src/routes/git-sync.test.ts surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts tests/integration/docker-build-regression.test.ts` — passed (43 tests)
- RED check before fix: `bun test surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts` — failed as expected on `defaultAcpxDashboardAgent(...).toBe("claude-code")`, received `codex`
- `bun test surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts surfaces/cli/src/features/setup-pipeline.test.ts platform/daemon/src/pipeline/provider.test.ts` — passed (120 tests)
- `cd surfaces/dashboard && bun run check` — passed with 0 errors, 12 pre-existing warnings
- `cd platform/daemon-rs && cargo check -p signet-daemon -p signet-mcp-stdio` — passed
- `cd platform/daemon-rs && cargo test -p signet-daemon most_used_memories_orders_limits_and_shapes_hot_list` — command passed; targeted contract test is ignored unless the daemon binary is built
- `git diff --check` — passed

## Remaining risk / follow-up
- No release/publish/deploy commands were run.
- Dashboard `bun run check` still reports existing unrelated warnings in other components, but no errors.

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes
- [x] No database migrations were added, removed, renumbered, or modified.
