### PR TITLE
feat(secrets): add Bitwarden provider

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2278,7 +2278,7 @@ Returns `404` if the secret does not exist.
 Queue a shell command with multiple secrets injected into the subprocess
 environment. Callers pass a map of env var names to secret references —
 never actual values. References can be Signet secret names or direct
-1Password refs (`op://vault/item/field`). The daemon resolves and injects
+Bitwarden refs (`bw://name/NAME`, `bw://item/ITEM_ID/password`) and 1Password refs (`op://vault/item/field`). The daemon resolves and injects
 all values before spawning.
 
 **Request body**
@@ -2341,6 +2341,30 @@ from the URL path is injected under its own name.
 ```json
 { "code": 0, "stdout": "...", "stderr": "" }
 ```
+
+### GET /api/secrets/bitwarden/status
+
+Return Bitwarden provider status. Bitwarden is opt-in; when it is not connected, existing local Signet secrets remain the active store.
+
+### POST /api/secrets/bitwarden/connect
+
+Validate and store a Bitwarden CLI session token from `bw unlock --raw`. Body: `{ "session": "...", "activate": true, "folderId": "optional-folder-id" }`. If `activate` is true, future Signet secret writes use Bitwarden as the backing store while internal provider metadata remains local.
+
+### DELETE /api/secrets/bitwarden/connect
+
+Disconnect Bitwarden, remove the stored session/folder metadata, and switch the active provider back to `local`. Existing local Signet secrets are not deleted.
+
+### POST /api/secrets/bitwarden/provider
+
+Switch active provider with `{ "provider": "local" }` or `{ "provider": "bitwarden" }`. Switching to Bitwarden requires a connected session.
+
+### GET /api/secrets/bitwarden/folders
+
+List Bitwarden folders visible to the connected CLI session.
+
+### POST /api/secrets/bitwarden/migrate
+
+Copy existing local Signet secrets into Bitwarden. Defaults to dry-run: `{ "dryRun": true }`. Pass `{ "dryRun": false, "overwrite": true }` to write. Pass `deleteLocal: true` only when local copies should be removed after successful per-secret migration.
 
 ### GET /api/secrets/1password/status
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -2348,7 +2348,7 @@ Return Bitwarden provider status. Bitwarden is opt-in; when it is not connected,
 
 ### POST /api/secrets/bitwarden/connect
 
-Validate and store a Bitwarden CLI session token from `bw unlock --raw`. Body: `{ "session": "...", "activate": true, "folderId": "optional-folder-id" }`. If `activate` is true, future Signet secret writes use Bitwarden as the backing store while internal provider metadata remains local.
+Validate and store a Bitwarden CLI session token from `bw unlock --raw`. Body: `{ "session": "...", "activate": true, "folderId": "optional-folder-id" }`. If `activate` is true, future Signet secret writes use Bitwarden as the backing store while internal provider metadata remains local. CLI users should pipe the token with `bw unlock --raw | signet secret bitwarden connect --session-stdin` rather than passing it as an argument.
 
 ### DELETE /api/secrets/bitwarden/connect
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -457,7 +457,7 @@ secret names resolve through the local provider, for example
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | `command` | string | yes | Shell command to queue |
-| `secrets` | object | yes | Map of env var name to secret reference (Signet name or `op://...`) |
+| `secrets` | object | yes | Map of env var name to secret reference (Signet name, `bw://...`, or `op://...`) |
 | `timeoutSeconds` | number | no | Max subprocess runtime for the queued job; defaults to 300 seconds, max 1800 |
 
 **Returns:** A queued secret exec job object with `id`, `status`, and `timeoutMs`. Poll with `secret_exec_status` for redacted `stdout`, `stderr`, and `code` after completion. Secret values in output are replaced with `[REDACTED]`.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -449,8 +449,10 @@ are never exposed to agents.
 
 Queue a shell command with secrets injected as environment variables. Output
 is automatically redacted, secret values never appear in results. Bare
-secret names resolve through the local provider, for example
-`OPENAI_API_KEY` is equivalent to `local://OPENAI_API_KEY`.
+secret names resolve through the active Signet secrets provider: local by
+default, or Bitwarden first when Bitwarden is active. Use `local://NAME` to
+force the local encrypted store, `bw://...` to reference a Bitwarden item
+explicitly, or `op://...` for 1Password compatibility references.
 
 **Parameters:**
 

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -144,6 +144,36 @@ Imported values are stored as regular Signet secrets with generated names,
 and `secret_exec` can also reference 1Password secrets directly via
 `op://vault/item/field` when connected.
 
+
+### Bitwarden provider
+
+Bitwarden is opt-in. By default, Signet continues to use the existing local encrypted `secrets.enc` store. After connecting Bitwarden, you can either keep using local Signet secrets or make Bitwarden the active provider for future `put`, `list`, `delete`, config resolution, and secret exec references.
+
+Signet uses the official Bitwarden CLI session model: log in/unlock with `bw`, then hand Signet the short-lived session token.
+
+```bash
+# One-time Bitwarden CLI login/unlock outside Signet
+bw login
+BW_SESSION=$(bw unlock --raw)
+
+# Connect but keep the local Signet store active
+signet secret bitwarden connect "$BW_SESSION"
+
+# Connect and immediately make Bitwarden the active backing store
+signet secret bitwarden connect "$BW_SESSION" --activate
+
+# Switch providers later without losing either store
+signet secret bitwarden use bitwarden
+signet secret bitwarden use local
+
+# Copy existing local Signet secrets into Bitwarden
+signet secret bitwarden migrate          # dry run
+signet secret bitwarden migrate --write  # copy, keep local copies
+signet secret bitwarden migrate --write --delete-local
+```
+
+When Bitwarden is active, Signet stores new secrets as Bitwarden login items and resolves bare `$secret:NAME` references from Bitwarden first, falling back to local Signet secrets for backwards compatibility. Explicit `bw://name/NAME` and `bw://item/ITEM_ID/password` references are also accepted. Internal Signet provider credentials remain in the local encrypted store so connecting Bitwarden does not create a circular dependency.
+
 ### Export / import (planned)
 
 ```bash
@@ -202,7 +232,7 @@ Content-Type: application/json
 ```
 
 The map is `{ env_var_name: secret_reference }` where a reference can be a
-stored Signet secret name or a 1Password `op://...` reference. The daemon:
+stored Signet secret name, a Bitwarden `bw://...` reference, or a 1Password `op://...` reference. The daemon:
 1. Resolves each secret reference to its value
 2. Queues the subprocess with the resolved values in the environment
 3. Enforces a bounded timeout (5 minutes by default, max 30 minutes)
@@ -275,6 +305,12 @@ The full secrets API is documented in [API.md](./API.md#secrets-api). Summary:
 | `/api/secrets/exec` | POST | Queue command with one or more secrets injected |
 | `/api/secrets/exec/:jobId` | GET | Inspect queued secret exec job status |
 | `/api/secrets/:name/exec` | POST | Legacy single-secret queued exec |
+| `/api/secrets/bitwarden/status` | GET | Bitwarden provider status |
+| `/api/secrets/bitwarden/connect` | POST | Connect/save Bitwarden CLI session |
+| `/api/secrets/bitwarden/connect` | DELETE | Disconnect/remove stored Bitwarden session |
+| `/api/secrets/bitwarden/provider` | POST | Switch active provider (`local` or `bitwarden`) |
+| `/api/secrets/bitwarden/folders` | GET | List Bitwarden folders |
+| `/api/secrets/bitwarden/migrate` | POST | Copy local Signet secrets into Bitwarden |
 | `/api/secrets/1password/status` | GET | 1Password integration status |
 | `/api/secrets/1password/connect` | POST | Connect/save service account token |
 | `/api/secrets/1password/connect` | DELETE | Disconnect/remove stored token |

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -152,15 +152,15 @@ Bitwarden is opt-in. By default, Signet continues to use the existing local encr
 Signet uses the official Bitwarden CLI session model: log in/unlock with `bw`, then hand Signet the short-lived session token.
 
 ```bash
-# One-time Bitwarden CLI login/unlock outside Signet
+# One-time Bitwarden CLI login outside Signet
 bw login
-BW_SESSION=$(bw unlock --raw)
 
-# Connect but keep the local Signet store active
-signet secret bitwarden connect "$BW_SESSION"
+# Connect but keep the local Signet store active. The session token is read
+# from stdin so it is not written to shell history or process argv.
+bw unlock --raw | signet secret bitwarden connect --session-stdin
 
 # Connect and immediately make Bitwarden the active backing store
-signet secret bitwarden connect "$BW_SESSION" --activate
+bw unlock --raw | signet secret bitwarden connect --session-stdin --activate
 
 # Switch providers later without losing either store
 signet secret bitwarden use bitwarden

--- a/libs/sdk/src/index.ts
+++ b/libs/sdk/src/index.ts
@@ -9,6 +9,9 @@ import { SignetTransport } from "./transport.js";
 import type {
 	BatchModifyItemResult,
 	BatchModifyResponse,
+	BitwardenConnectResult,
+	BitwardenMigrationResult,
+	BitwardenStatus,
 	CheckpointListResponse,
 	ConfigListResponse,
 	ConfigWriteResponse,
@@ -1000,6 +1003,80 @@ export class SignetClient extends SignetClientHelpers {
 	}
 
 	/**
+	 * Get Bitwarden connection/provider status.
+	 */
+	async getBitwardenStatus(): Promise<BitwardenStatus> {
+		return this.transport.get<BitwardenStatus>("/api/secrets/bitwarden/status");
+	}
+
+	/**
+	 * Connect a Bitwarden CLI session token (`bw unlock --raw`).
+	 */
+	async connectBitwarden(
+		session: string,
+		options: { readonly activate?: boolean; readonly folderId?: string } = {},
+	): Promise<BitwardenConnectResult> {
+		return this.transport.post<BitwardenConnectResult>("/api/secrets/bitwarden/connect", {
+			session,
+			...options,
+		});
+	}
+
+	/**
+	 * Disconnect Bitwarden and return to the local Signet provider.
+	 */
+	async disconnectBitwarden(): Promise<{
+		success: boolean;
+		disconnected: boolean;
+		existed: boolean;
+		activeProvider: boolean;
+	}> {
+		return this.transport.del<{ success: boolean; disconnected: boolean; existed: boolean; activeProvider: boolean }>(
+			"/api/secrets/bitwarden/connect",
+		);
+	}
+
+	/**
+	 * Switch active secret provider.
+	 */
+	async setSecretProvider(
+		provider: "local" | "bitwarden",
+	): Promise<{ success: boolean; provider: "local" | "bitwarden" }> {
+		return this.transport.post<{ success: boolean; provider: "local" | "bitwarden" }>(
+			"/api/secrets/bitwarden/provider",
+			{
+				provider,
+			},
+		);
+	}
+
+	/**
+	 * List Bitwarden folders.
+	 */
+	async listBitwardenFolders(): Promise<{
+		folders: readonly { readonly id: string; readonly name: string }[];
+		count: number;
+	}> {
+		return this.transport.get<{ folders: readonly { readonly id: string; readonly name: string }[]; count: number }>(
+			"/api/secrets/bitwarden/folders",
+		);
+	}
+
+	/**
+	 * Copy local Signet secrets into Bitwarden. Defaults to dry-run unless `dryRun: false`.
+	 */
+	async migrateSecretsToBitwarden(
+		opts: {
+			readonly dryRun?: boolean;
+			readonly deleteLocal?: boolean;
+			readonly overwrite?: boolean;
+			readonly folderId?: string;
+		} = {},
+	): Promise<BitwardenMigrationResult> {
+		return this.transport.post<BitwardenMigrationResult>("/api/secrets/bitwarden/migrate", opts);
+	}
+
+	/**
 	 * Get 1Password connection status.
 	 *
 	 * @example
@@ -1275,6 +1352,9 @@ export type {
 	MemorySearchTelemetryResponse,
 	MemorySearchTelemetryResult,
 	ModifyResult,
+	BitwardenConnectResult,
+	BitwardenMigrationResult,
+	BitwardenStatus,
 	OnePasswordConnectResult,
 	OnePasswordImportResult,
 	OnePasswordStatus,

--- a/libs/sdk/src/types.ts
+++ b/libs/sdk/src/types.ts
@@ -716,6 +716,7 @@ export interface TaskCreatePayload {
 
 export interface SecretListResponse {
 	readonly secrets: readonly string[];
+	readonly provider?: "local" | "bitwarden";
 }
 
 export interface SecretExecResult {
@@ -761,6 +762,36 @@ export interface OnePasswordImportResult {
 	readonly itemsScanned: number;
 	readonly importedCount: number;
 	readonly errorCount: number;
+}
+
+export interface BitwardenStatus {
+	readonly configured: boolean;
+	readonly connected: boolean;
+	readonly activeProvider: boolean;
+	readonly userEmail?: string;
+	readonly serverUrl?: string;
+	readonly folders?: readonly { readonly id: string; readonly name: string }[];
+	readonly error?: string;
+}
+
+export interface BitwardenConnectResult extends BitwardenStatus {
+	readonly success: boolean;
+}
+
+export interface BitwardenMigrationResult {
+	readonly success: boolean;
+	readonly dryRun: boolean;
+	readonly deleteLocal: boolean;
+	readonly migratedCount: number;
+	readonly skippedCount: number;
+	readonly deletedLocalCount: number;
+	readonly errorCount: number;
+	readonly results: readonly {
+		readonly name: string;
+		readonly action: "migrated" | "skipped" | "deleted-local";
+		readonly itemId?: string;
+		readonly error?: string;
+	}[];
 }
 
 export type PluginLifecycleState = "installed" | "blocked" | "active" | "degraded" | "disabled";

--- a/platform/daemon/src/bitwarden.test.ts
+++ b/platform/daemon/src/bitwarden.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import {
 	type BitwardenClient,
 	type BitwardenItemDetails,
@@ -108,5 +109,13 @@ describe("Bitwarden secrets provider", () => {
 		expect(result.dryRun).toBe(true);
 		expect(result.skippedCount).toBe(1);
 		expect(readCount).toBe(0);
+	});
+	test("Bitwarden CLI writes do not pass session tokens or secret-bearing payloads through argv", () => {
+		const source = readFileSync(new URL("./bitwarden.ts", import.meta.url), "utf8");
+		expect(source).not.toContain('"--session"');
+		expect(source).not.toContain('["create", "item", encoded.trim()]');
+		expect(source).not.toContain('["edit", "item", existing.id, encoded.trim()]');
+		expect(source).toContain('runBw(["create", "item"], { input: encoded.trim(), session: this.session })');
+		expect(source).toContain('runBw(["edit", "item", existing.id], { input: encoded.trim(), session: this.session })');
 	});
 });

--- a/platform/daemon/src/bitwarden.test.ts
+++ b/platform/daemon/src/bitwarden.test.ts
@@ -61,6 +61,8 @@ describe("Bitwarden secrets provider", () => {
 	test("recognizes bw:// references and normalizes Signet secret names", () => {
 		expect(isBitwardenReference("bw://name/OPENAI_API_KEY")).toBe(true);
 		expect(isBitwardenReference("OPENAI_API_KEY")).toBe(false);
+		expect(buildBitwardenManagedSecretName("anthropic_key")).toBe("anthropic_key");
+		expect(buildBitwardenManagedSecretName("ANTHROPIC_KEY")).toBe("ANTHROPIC_KEY");
 		expect(buildBitwardenManagedSecretName("OpenAI API Key")).toBe("OPENAI_API_KEY");
 		expect(buildBitwardenManagedSecretName("1password-token")).toBe("SECRET_1PASSWORD_TOKEN");
 	});

--- a/platform/daemon/src/bitwarden.test.ts
+++ b/platform/daemon/src/bitwarden.test.ts
@@ -51,7 +51,7 @@ function mockClient(): BitwardenClient {
 				: Array.from(items.values()).find(
 						(entry) => entry.name === decodeURIComponent(ref.split("/")[3] ?? ref.slice("bw://".length)),
 					);
-			if (!item?.login?.password) throw new Error("missing password");
+			if (typeof item?.login?.password !== "string") throw new Error("missing password");
 			return item.login.password;
 		},
 	};
@@ -72,6 +72,12 @@ describe("Bitwarden secrets provider", () => {
 		await client.putSecret("OPENAI_API_KEY", "sk-bw", { overwrite: true });
 		const value = await readBitwardenReference("bw://name/OPENAI_API_KEY", "session", async () => client);
 		expect(value).toBe("sk-bw");
+	});
+
+	test("round-trips empty Bitwarden secret values", async () => {
+		const client = mockClient();
+		await client.putSecret("EMPTY_SECRET", "", { overwrite: true });
+		expect(await readBitwardenReference("bw://name/EMPTY_SECRET", "session", async () => client)).toBe("");
 	});
 
 	test("migrates local Signet secrets into Bitwarden without deleting local copies by default", async () => {

--- a/platform/daemon/src/bitwarden.test.ts
+++ b/platform/daemon/src/bitwarden.test.ts
@@ -112,7 +112,7 @@ describe("Bitwarden secrets provider", () => {
 		expect(result.skippedCount).toBe(1);
 		expect(readCount).toBe(0);
 	});
-	test("Bitwarden CLI writes do not pass session tokens or secret-bearing payloads through argv", () => {
+	test("Bitwarden CLI writes use stdin-supported create/edit payloads and keep secrets out of argv", () => {
 		const source = readFileSync(new URL("./bitwarden.ts", import.meta.url), "utf8");
 		expect(source).not.toContain('"--session"');
 		expect(source).not.toContain('["create", "item", encoded.trim()]');

--- a/platform/daemon/src/bitwarden.test.ts
+++ b/platform/daemon/src/bitwarden.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type BitwardenClient,
+	type BitwardenItemDetails,
+	buildBitwardenManagedSecretName,
+	isBitwardenReference,
+	migrateLocalSecretsToBitwarden,
+	readBitwardenReference,
+} from "./bitwarden.js";
+
+function mockClient(): BitwardenClient {
+	const items = new Map<string, BitwardenItemDetails>();
+	return {
+		async status() {
+			return { status: "unlocked", userEmail: "user@example.com", serverUrl: "https://vault.bitwarden.com" };
+		},
+		async listFolders() {
+			return [{ id: "folder-1", name: "Signet" }];
+		},
+		async listItems() {
+			return Array.from(items.values()).map((item) => ({ id: item.id, name: item.name, folderId: item.folderId }));
+		},
+		async getItem(id: string) {
+			const item = items.get(id);
+			if (!item) throw new Error(`missing ${id}`);
+			return item;
+		},
+		async putSecret(name: string, value: string, options = {}) {
+			const existing = Array.from(items.values()).find((item) => item.name === name);
+			if (existing && options.overwrite !== true) throw new Error(`Bitwarden item '${name}' already exists`);
+			const item = {
+				id: existing?.id ?? `item-${items.size + 1}`,
+				name,
+				folderId: options.folderId ?? existing?.folderId ?? null,
+				login: { username: "signet", password: value },
+				notes: "Managed by Signet secrets",
+			};
+			items.set(item.id, item);
+			return item;
+		},
+		async deleteSecret(name: string) {
+			const existing = Array.from(items.values()).find((item) => item.name === name);
+			if (!existing) return false;
+			items.delete(existing.id);
+			return true;
+		},
+		async resolveSecret(ref: string) {
+			const item = ref.startsWith("bw://item/")
+				? items.get(ref.split("/")[3] ?? "")
+				: Array.from(items.values()).find(
+						(entry) => entry.name === decodeURIComponent(ref.split("/")[3] ?? ref.slice("bw://".length)),
+					);
+			if (!item?.login?.password) throw new Error("missing password");
+			return item.login.password;
+		},
+	};
+}
+
+describe("Bitwarden secrets provider", () => {
+	test("recognizes bw:// references and normalizes Signet secret names", () => {
+		expect(isBitwardenReference("bw://name/OPENAI_API_KEY")).toBe(true);
+		expect(isBitwardenReference("OPENAI_API_KEY")).toBe(false);
+		expect(buildBitwardenManagedSecretName("OpenAI API Key")).toBe("OPENAI_API_KEY");
+		expect(buildBitwardenManagedSecretName("1password-token")).toBe("SECRET_1PASSWORD_TOKEN");
+	});
+
+	test("resolves Bitwarden references through the injected client factory", async () => {
+		const client = mockClient();
+		await client.putSecret("OPENAI_API_KEY", "sk-bw", { overwrite: true });
+		const value = await readBitwardenReference("bw://name/OPENAI_API_KEY", "session", async () => client);
+		expect(value).toBe("sk-bw");
+	});
+
+	test("migrates local Signet secrets into Bitwarden without deleting local copies by default", async () => {
+		const client = mockClient();
+		const local = new Map([
+			["OPENAI_API_KEY", "sk-local"],
+			["Anthropic Key", "sk-ant"],
+		]);
+		const result = await migrateLocalSecretsToBitwarden({
+			session: "session",
+			localNames: Array.from(local.keys()),
+			getLocalSecret: async (name) => local.get(name) ?? "",
+			folderId: "folder-1",
+			overwrite: true,
+			clientFactory: async () => client,
+		});
+
+		expect(result.migratedCount).toBe(2);
+		expect(result.deletedLocalCount).toBe(0);
+		expect(await readBitwardenReference("bw://name/OPENAI_API_KEY", "session", async () => client)).toBe("sk-local");
+		expect(await readBitwardenReference("bw://name/ANTHROPIC_KEY", "session", async () => client)).toBe("sk-ant");
+	});
+
+	test("dry-run migration does not read or write secret values", async () => {
+		let readCount = 0;
+		const result = await migrateLocalSecretsToBitwarden({
+			session: "session",
+			localNames: ["OPENAI_API_KEY"],
+			getLocalSecret: async () => {
+				readCount += 1;
+				return "sk-local";
+			},
+			dryRun: true,
+			clientFactory: async () => mockClient(),
+		});
+
+		expect(result.dryRun).toBe(true);
+		expect(result.skippedCount).toBe(1);
+		expect(readCount).toBe(0);
+	});
+});

--- a/platform/daemon/src/bitwarden.test.ts
+++ b/platform/daemon/src/bitwarden.test.ts
@@ -125,5 +125,7 @@ describe("Bitwarden secrets provider", () => {
 		expect(source).not.toContain('["edit", "item", existing.id, encoded.trim()]');
 		expect(source).toContain('runBw(["create", "item"], { input: encoded.trim(), session: this.session })');
 		expect(source).toContain('runBw(["edit", "item", existing.id], { input: encoded.trim(), session: this.session })');
+		expect(source).toContain("password: readOptionalString(login.password)");
+		expect(source).toContain("value: readOptionalString(field.value)");
 	});
 });

--- a/platform/daemon/src/bitwarden.ts
+++ b/platform/daemon/src/bitwarden.ts
@@ -355,14 +355,14 @@ function readField(item: BitwardenItemDetails, field: string): string {
 	const normalized = field.toLowerCase();
 	if (normalized === "password") {
 		const value = item.login?.password;
-		if (value) return value;
+		if (typeof value === "string") return value;
 	}
 	if (normalized === "username") {
 		const value = item.login?.username;
-		if (value) return value;
+		if (typeof value === "string") return value;
 	}
 	const custom = item.fields?.find((entry) => entry.name?.toLowerCase() === normalized)?.value;
-	if (custom) return custom;
+	if (typeof custom === "string") return custom;
 	throw new Error(`Bitwarden item '${item.name}' does not contain field '${field}'`);
 }
 

--- a/platform/daemon/src/bitwarden.ts
+++ b/platform/daemon/src/bitwarden.ts
@@ -180,7 +180,7 @@ export async function getBitwardenStatus(options: {
 		const [status, folders] = await Promise.all([client.status(), client.listFolders()]);
 		return {
 			configured: true,
-			connected: status.status === undefined || status.status === "unlocked",
+			connected: status.status === "unlocked",
 			activeProvider: options.activeProvider,
 			userEmail: status.userEmail,
 			serverUrl: status.serverUrl,

--- a/platform/daemon/src/bitwarden.ts
+++ b/platform/daemon/src/bitwarden.ts
@@ -6,7 +6,7 @@ export const BITWARDEN_MANAGED_FOLDER_SECRET = "BITWARDEN_MANAGED_FOLDER_ID";
 
 const SECRET_REF_PREFIX = "bw://";
 const DEFAULT_BW_TIMEOUT_MS = 30_000;
-const SECRET_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
+const SECRET_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 export interface BitwardenFolder {
 	readonly id: string;

--- a/platform/daemon/src/bitwarden.ts
+++ b/platform/daemon/src/bitwarden.ts
@@ -294,6 +294,8 @@ class BwCliClient implements BitwardenClient {
 			notes: item.notes ?? "Managed by Signet secrets",
 		};
 		const encoded = await runBw(["encode"], { input: JSON.stringify(updated), session: this.session });
+		// Bitwarden CLI vault commands declare encodedJson as optional for create/edit and read it from
+		// stdin when omitted. Keep secret-bearing item payloads off argv and write them to stdin instead.
 		if (existing) {
 			return toItemDetails(
 				parseJson(await runBw(["edit", "item", existing.id], { input: encoded.trim(), session: this.session })),

--- a/platform/daemon/src/bitwarden.ts
+++ b/platform/daemon/src/bitwarden.ts
@@ -430,7 +430,11 @@ function runBw(
 	options: { readonly session: string; readonly input?: string; readonly timeoutMs?: number },
 ): Promise<string> {
 	return new Promise((resolve, reject) => {
-		const proc = spawn("bw", [...args, "--session", options.session], { stdio: "pipe", windowsHide: true });
+		const proc = spawn("bw", [...args], {
+			stdio: "pipe",
+			windowsHide: true,
+			env: { ...process.env, BW_SESSION: options.session },
+		});
 		let stdout = "";
 		let stderr = "";
 		let settled = false;

--- a/platform/daemon/src/bitwarden.ts
+++ b/platform/daemon/src/bitwarden.ts
@@ -390,14 +390,16 @@ function toItemDetails(value: unknown): BitwardenItemDetails {
 	const fields = Array.isArray(obj.fields)
 		? obj.fields.map(toRecord).map((field) => ({
 				name: readString(field.name),
-				value: readString(field.value),
+				value: readOptionalString(field.value),
 				type: readNumber(field.type),
 			}))
 		: null;
 	return {
 		...summary,
-		login: login ? { username: readString(login.username), password: readString(login.password) } : undefined,
-		notes: readString(obj.notes) ?? null,
+		login: login
+			? { username: readOptionalString(login.username), password: readOptionalString(login.password) }
+			: undefined,
+		notes: readOptionalString(obj.notes) ?? null,
 		fields,
 	};
 }
@@ -413,6 +415,10 @@ function toRecordOrUndefined(value: unknown): Record<string, unknown> | undefine
 
 function readString(value: unknown): string | undefined {
 	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function readOptionalString(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
 }
 
 function readNumber(value: unknown): number | undefined {

--- a/platform/daemon/src/bitwarden.ts
+++ b/platform/daemon/src/bitwarden.ts
@@ -1,0 +1,466 @@
+import { spawn } from "node:child_process";
+
+export const BITWARDEN_SESSION_SECRET = "BITWARDEN_SESSION";
+export const BITWARDEN_ACTIVE_PROVIDER_SECRET = "SIGNET_SECRETS_ACTIVE_PROVIDER";
+export const BITWARDEN_MANAGED_FOLDER_SECRET = "BITWARDEN_MANAGED_FOLDER_ID";
+
+const SECRET_REF_PREFIX = "bw://";
+const DEFAULT_BW_TIMEOUT_MS = 30_000;
+const SECRET_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
+
+export interface BitwardenFolder {
+	readonly id: string;
+	readonly name: string;
+}
+
+export interface BitwardenItemSummary {
+	readonly id: string;
+	readonly name: string;
+	readonly folderId?: string | null;
+}
+
+export interface BitwardenItemDetails extends BitwardenItemSummary {
+	readonly login?: {
+		readonly username?: string | null;
+		readonly password?: string | null;
+	};
+	readonly notes?: string | null;
+	readonly fields?: readonly BitwardenField[] | null;
+}
+
+export interface BitwardenField {
+	readonly name?: string | null;
+	readonly value?: string | null;
+	readonly type?: number | null;
+}
+
+export interface BitwardenClient {
+	status(): Promise<{ readonly status?: string; readonly userEmail?: string; readonly serverUrl?: string }>;
+	listFolders(): Promise<readonly BitwardenFolder[]>;
+	listItems(): Promise<readonly BitwardenItemSummary[]>;
+	getItem(id: string): Promise<BitwardenItemDetails>;
+	putSecret(
+		name: string,
+		value: string,
+		options?: { readonly folderId?: string; readonly overwrite?: boolean },
+	): Promise<BitwardenItemDetails>;
+	deleteSecret(name: string): Promise<boolean>;
+	resolveSecret(ref: string): Promise<string>;
+}
+
+export type BitwardenClientFactory = (session: string) => Promise<BitwardenClient>;
+
+let bitwardenClientFactoryOverride: BitwardenClientFactory | null = null;
+
+export function setBitwardenClientFactoryForTests(factory: BitwardenClientFactory | null): void {
+	bitwardenClientFactoryOverride = factory;
+}
+
+function getBitwardenClientFactory(explicitFactory?: BitwardenClientFactory): BitwardenClientFactory {
+	return explicitFactory ?? bitwardenClientFactoryOverride ?? defaultBitwardenClientFactory;
+}
+
+export interface BitwardenStatus {
+	readonly configured: boolean;
+	readonly connected: boolean;
+	readonly activeProvider: boolean;
+	readonly userEmail?: string;
+	readonly serverUrl?: string;
+	readonly folders?: readonly BitwardenFolder[];
+	readonly error?: string;
+}
+
+export interface BitwardenMigrationSecretResult {
+	readonly name: string;
+	readonly action: "migrated" | "skipped" | "deleted-local";
+	readonly itemId?: string;
+	readonly error?: string;
+}
+
+export interface BitwardenMigrationResult {
+	readonly dryRun: boolean;
+	readonly deleteLocal: boolean;
+	readonly migratedCount: number;
+	readonly skippedCount: number;
+	readonly deletedLocalCount: number;
+	readonly errorCount: number;
+	readonly results: readonly BitwardenMigrationSecretResult[];
+}
+
+export function isBitwardenReference(secretName: string): boolean {
+	return secretName.startsWith(SECRET_REF_PREFIX);
+}
+
+export function isBitwardenActiveProvider(value: string | undefined): boolean {
+	return value?.trim().toLowerCase() === "bitwarden";
+}
+
+export function buildBitwardenManagedSecretName(name: string): string {
+	const trimmed = name.trim();
+	if (SECRET_NAME_RE.test(trimmed)) return trimmed;
+	const candidate = trimmed
+		.replace(/[^A-Za-z0-9_]+/g, "_")
+		.replace(/^_+|_+$/g, "")
+		.toUpperCase();
+	if (SECRET_NAME_RE.test(candidate)) return candidate;
+	return `SECRET_${candidate || "VALUE"}`;
+}
+
+export async function readBitwardenReference(
+	reference: string,
+	session: string,
+	clientFactory?: BitwardenClientFactory,
+): Promise<string> {
+	if (!isBitwardenReference(reference)) {
+		throw new Error(
+			`Invalid Bitwarden reference '${reference}'. Expected bw://item/<id>/password or bw://name/<secretName>`,
+		);
+	}
+	const client = await getBitwardenClientFactory(clientFactory)(session);
+	return client.resolveSecret(reference);
+}
+
+export async function listBitwardenFolders(
+	session: string,
+	clientFactory?: BitwardenClientFactory,
+): Promise<readonly BitwardenFolder[]> {
+	const client = await getBitwardenClientFactory(clientFactory)(session);
+	return client.listFolders();
+}
+
+export async function listBitwardenSecretNames(
+	session: string,
+	clientFactory?: BitwardenClientFactory,
+): Promise<readonly string[]> {
+	const client = await getBitwardenClientFactory(clientFactory)(session);
+	const items = await client.listItems();
+	return items
+		.map((item) => item.name)
+		.filter((name) => name.length > 0)
+		.sort((a, b) => a.localeCompare(b));
+}
+
+export async function putBitwardenSecret(
+	name: string,
+	value: string,
+	session: string,
+	options: {
+		readonly folderId?: string;
+		readonly overwrite?: boolean;
+		readonly clientFactory?: BitwardenClientFactory;
+	} = {},
+): Promise<BitwardenItemDetails> {
+	const client = await getBitwardenClientFactory(options.clientFactory)(session);
+	return client.putSecret(buildBitwardenManagedSecretName(name), value, {
+		folderId: options.folderId,
+		overwrite: options.overwrite,
+	});
+}
+
+export async function deleteBitwardenSecret(
+	name: string,
+	session: string,
+	clientFactory?: BitwardenClientFactory,
+): Promise<boolean> {
+	const client = await getBitwardenClientFactory(clientFactory)(session);
+	return client.deleteSecret(buildBitwardenManagedSecretName(name));
+}
+
+export async function getBitwardenStatus(options: {
+	readonly configured: boolean;
+	readonly activeProvider: boolean;
+	readonly session?: string;
+	readonly clientFactory?: BitwardenClientFactory;
+}): Promise<BitwardenStatus> {
+	if (!options.configured || !options.session) {
+		return { configured: false, connected: false, activeProvider: options.activeProvider };
+	}
+	try {
+		const client = await getBitwardenClientFactory(options.clientFactory)(options.session);
+		const [status, folders] = await Promise.all([client.status(), client.listFolders()]);
+		return {
+			configured: true,
+			connected: status.status === undefined || status.status === "unlocked",
+			activeProvider: options.activeProvider,
+			userEmail: status.userEmail,
+			serverUrl: status.serverUrl,
+			folders,
+		};
+	} catch (error) {
+		return {
+			configured: true,
+			connected: false,
+			activeProvider: options.activeProvider,
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
+export async function migrateLocalSecretsToBitwarden(options: {
+	readonly session: string;
+	readonly localNames: readonly string[];
+	readonly getLocalSecret: (name: string) => Promise<string>;
+	readonly deleteLocalSecret?: (name: string) => boolean;
+	readonly folderId?: string;
+	readonly overwrite?: boolean;
+	readonly dryRun?: boolean;
+	readonly deleteLocal?: boolean;
+	readonly clientFactory?: BitwardenClientFactory;
+}): Promise<BitwardenMigrationResult> {
+	const client = await getBitwardenClientFactory(options.clientFactory)(options.session);
+	const dryRun = options.dryRun === true;
+	const deleteLocal = options.deleteLocal === true;
+	const overwrite = options.overwrite === true;
+	const results: BitwardenMigrationSecretResult[] = [];
+	let migratedCount = 0;
+	let skippedCount = 0;
+	let deletedLocalCount = 0;
+	let errorCount = 0;
+
+	for (const localName of options.localNames) {
+		const name = buildBitwardenManagedSecretName(localName);
+		try {
+			if (dryRun) {
+				results.push({ name, action: "skipped" });
+				skippedCount += 1;
+				continue;
+			}
+			const value = await options.getLocalSecret(localName);
+			const item = await client.putSecret(name, value, { folderId: options.folderId, overwrite });
+			results.push({ name, action: "migrated", itemId: item.id });
+			migratedCount += 1;
+			if (deleteLocal && options.deleteLocalSecret?.(localName)) {
+				results.push({ name: localName, action: "deleted-local" });
+				deletedLocalCount += 1;
+			}
+		} catch (error) {
+			errorCount += 1;
+			results.push({ name, action: "skipped", error: error instanceof Error ? error.message : String(error) });
+		}
+	}
+
+	return { dryRun, deleteLocal, migratedCount, skippedCount, deletedLocalCount, errorCount, results };
+}
+
+export async function defaultBitwardenClientFactory(session: string): Promise<BitwardenClient> {
+	const trimmedSession = session.trim();
+	if (!trimmedSession)
+		throw new Error(
+			"Bitwarden session token is required. Run `bw login` then `bw unlock --raw` and connect the session to Signet.",
+		);
+	return new BwCliClient(trimmedSession);
+}
+
+class BwCliClient implements BitwardenClient {
+	constructor(private readonly session: string) {}
+
+	async status(): Promise<{ readonly status?: string; readonly userEmail?: string; readonly serverUrl?: string }> {
+		return parseJson(await runBw(["status"], { session: this.session })) as {
+			status?: string;
+			userEmail?: string;
+			serverUrl?: string;
+		};
+	}
+
+	async listFolders(): Promise<readonly BitwardenFolder[]> {
+		const folders = parseJson(await runBw(["list", "folders"], { session: this.session })) as unknown[];
+		return folders.map((folder) => toFolder(folder)).filter((folder): folder is BitwardenFolder => folder !== null);
+	}
+
+	async listItems(): Promise<readonly BitwardenItemSummary[]> {
+		const items = parseJson(await runBw(["list", "items"], { session: this.session })) as unknown[];
+		return items.map((item) => toItemSummary(item)).filter((item): item is BitwardenItemSummary => item !== null);
+	}
+
+	async getItem(id: string): Promise<BitwardenItemDetails> {
+		return toItemDetails(parseJson(await runBw(["get", "item", id], { session: this.session })));
+	}
+
+	async putSecret(
+		name: string,
+		value: string,
+		options: { readonly folderId?: string; readonly overwrite?: boolean } = {},
+	): Promise<BitwardenItemDetails> {
+		const existing = await this.findItemByName(name);
+		if (existing && options.overwrite !== true) {
+			throw new Error(`Bitwarden item '${name}' already exists; pass overwrite to replace it`);
+		}
+		const item = existing ? await this.getItem(existing.id) : buildNewLoginItem(name, options.folderId);
+		const updated = {
+			...item,
+			name,
+			folderId: options.folderId ?? item.folderId ?? null,
+			login: { ...(item.login ?? {}), username: item.login?.username ?? "signet", password: value },
+			notes: item.notes ?? "Managed by Signet secrets",
+		};
+		const encoded = await runBw(["encode"], { input: JSON.stringify(updated), session: this.session });
+		if (existing) {
+			return toItemDetails(
+				parseJson(await runBw(["edit", "item", existing.id, encoded.trim()], { session: this.session })),
+			);
+		}
+		return toItemDetails(parseJson(await runBw(["create", "item", encoded.trim()], { session: this.session })));
+	}
+
+	async deleteSecret(name: string): Promise<boolean> {
+		const existing = await this.findItemByName(name);
+		if (!existing) return false;
+		await runBw(["delete", "item", existing.id], { session: this.session });
+		return true;
+	}
+
+	async resolveSecret(ref: string): Promise<string> {
+		const parsed = parseBitwardenReference(ref);
+		const item = parsed.kind === "item" ? await this.getItem(parsed.id) : await this.getItemByName(parsed.name);
+		return readField(item, parsed.field);
+	}
+
+	private async getItemByName(name: string): Promise<BitwardenItemDetails> {
+		const summary = await this.findItemByName(name);
+		if (!summary) throw new Error(`Bitwarden item '${name}' not found`);
+		return this.getItem(summary.id);
+	}
+
+	private async findItemByName(name: string): Promise<BitwardenItemSummary | null> {
+		const items = await this.listItems();
+		return items.find((item) => item.name === name) ?? null;
+	}
+}
+
+function buildNewLoginItem(name: string, folderId?: string): BitwardenItemDetails & { type: number } {
+	return {
+		id: "",
+		name,
+		folderId: folderId ?? null,
+		type: 1,
+		login: { username: "signet", password: "" },
+		notes: "Managed by Signet secrets",
+	};
+}
+
+function parseBitwardenReference(
+	ref: string,
+): { kind: "item"; id: string; field: string } | { kind: "name"; name: string; field: string } {
+	const withoutPrefix = ref.slice(SECRET_REF_PREFIX.length);
+	const parts = withoutPrefix.split("/").filter(Boolean).map(decodeURIComponent);
+	if (parts[0] === "item" && parts[1]) return { kind: "item", id: parts[1], field: parts[2] ?? "password" };
+	if (parts[0] === "name" && parts[1]) return { kind: "name", name: parts[1], field: parts[2] ?? "password" };
+	if (parts.length === 1) return { kind: "name", name: parts[0], field: "password" };
+	throw new Error(`Invalid Bitwarden reference '${ref}'. Expected bw://item/<id>/password or bw://name/<secretName>`);
+}
+
+function readField(item: BitwardenItemDetails, field: string): string {
+	const normalized = field.toLowerCase();
+	if (normalized === "password") {
+		const value = item.login?.password;
+		if (value) return value;
+	}
+	if (normalized === "username") {
+		const value = item.login?.username;
+		if (value) return value;
+	}
+	const custom = item.fields?.find((entry) => entry.name?.toLowerCase() === normalized)?.value;
+	if (custom) return custom;
+	throw new Error(`Bitwarden item '${item.name}' does not contain field '${field}'`);
+}
+
+function toFolder(value: unknown): BitwardenFolder | null {
+	const obj = toRecord(value);
+	const id = readString(obj.id);
+	const name = readString(obj.name);
+	if (!id || !name) return null;
+	return { id, name };
+}
+
+function toItemSummary(value: unknown): BitwardenItemSummary | null {
+	const obj = toRecord(value);
+	const id = readString(obj.id);
+	const name = readString(obj.name);
+	if (!id || !name) return null;
+	return { id, name, folderId: readString(obj.folderId) ?? null };
+}
+
+function toItemDetails(value: unknown): BitwardenItemDetails {
+	const summary = toItemSummary(value);
+	if (!summary) throw new Error("Bitwarden returned invalid item payload");
+	const obj = toRecord(value);
+	const login = toRecordOrUndefined(obj.login);
+	const fields = Array.isArray(obj.fields)
+		? obj.fields.map(toRecord).map((field) => ({
+				name: readString(field.name),
+				value: readString(field.value),
+				type: readNumber(field.type),
+			}))
+		: null;
+	return {
+		...summary,
+		login: login ? { username: readString(login.username), password: readString(login.password) } : undefined,
+		notes: readString(obj.notes) ?? null,
+		fields,
+	};
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function toRecordOrUndefined(value: unknown): Record<string, unknown> | undefined {
+	const record = toRecord(value);
+	return Object.keys(record).length > 0 ? record : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function parseJson(stdout: string): unknown {
+	try {
+		return JSON.parse(stdout);
+	} catch (error) {
+		throw new Error(`Bitwarden CLI returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
+	}
+}
+
+function runBw(
+	args: readonly string[],
+	options: { readonly session: string; readonly input?: string; readonly timeoutMs?: number },
+): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const proc = spawn("bw", [...args, "--session", options.session], { stdio: "pipe", windowsHide: true });
+		let stdout = "";
+		let stderr = "";
+		let settled = false;
+		const timer = setTimeout(() => {
+			if (settled) return;
+			settled = true;
+			proc.kill("SIGTERM");
+			reject(new Error(`Bitwarden CLI timed out running bw ${args.join(" ")}`));
+		}, options.timeoutMs ?? DEFAULT_BW_TIMEOUT_MS);
+		timer.unref();
+		proc.stdout?.on("data", (chunk: Buffer) => {
+			stdout += chunk.toString();
+		});
+		proc.stderr?.on("data", (chunk: Buffer) => {
+			stderr += chunk.toString();
+		});
+		proc.on("error", (error) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			reject(error.message.includes("ENOENT") ? new Error("Bitwarden CLI `bw` was not found on PATH") : error);
+		});
+		proc.on("close", (code) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			if (code === 0) resolve(stdout.trim());
+			else reject(new Error((stderr || stdout || `bw exited with code ${code}`).trim()));
+		});
+		if (options.input !== undefined) proc.stdin?.end(options.input);
+		else proc.stdin?.end();
+	});
+}

--- a/platform/daemon/src/bitwarden.ts
+++ b/platform/daemon/src/bitwarden.ts
@@ -296,10 +296,10 @@ class BwCliClient implements BitwardenClient {
 		const encoded = await runBw(["encode"], { input: JSON.stringify(updated), session: this.session });
 		if (existing) {
 			return toItemDetails(
-				parseJson(await runBw(["edit", "item", existing.id, encoded.trim()], { session: this.session })),
+				parseJson(await runBw(["edit", "item", existing.id], { input: encoded.trim(), session: this.session })),
 			);
 		}
-		return toItemDetails(parseJson(await runBw(["create", "item", encoded.trim()], { session: this.session })));
+		return toItemDetails(parseJson(await runBw(["create", "item"], { input: encoded.trim(), session: this.session })));
 	}
 
 	async deleteSecret(name: string): Promise<boolean> {

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -1916,7 +1916,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 
 	// Surface available secrets so agents know what's available
 	try {
-		const secretNames = listSecrets();
+		const secretNames = await listSecrets();
 		if (secretNames.length > 0) {
 			injectParts.push("\n## Available Secrets\n");
 			injectParts.push("Use the `secret_exec` MCP tool to run commands with these secrets injected as env vars.\n");

--- a/platform/daemon/src/mcp/tools.ts
+++ b/platform/daemon/src/mcp/tools.ts
@@ -1306,7 +1306,6 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 	// ------------------------------------------------------------------
 	server.registerTool(
 		"secret_exec",
-		"secret_exec_status",
 		{
 			title: "Execute with Secrets",
 			description:
@@ -1319,7 +1318,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 					.object({})
 					.catchall(z.string())
 					.describe(
-						'Map of env var name → secret ref, e.g. { "OPENAI_API_KEY": "OPENAI_API_KEY" } or { "DB_PASSWORD": "op://vault/item/password" }',
+						'Map of env var name → secret ref, e.g. { "OPENAI_API_KEY": "OPENAI_API_KEY" } or { "DB_PASSWORD": "bw://name/DB_PASSWORD" }',
 					),
 				timeoutSeconds: z
 					.number()

--- a/platform/daemon/src/mcp/tools.ts
+++ b/platform/daemon/src/mcp/tools.ts
@@ -1306,11 +1306,12 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 	// ------------------------------------------------------------------
 	server.registerTool(
 		"secret_exec",
+		"secret_exec_status",
 		{
 			title: "Execute with Secrets",
 			description:
 				"Queue a command with secrets injected as environment variables. " +
-				"Provide a secrets map where keys are env var names and values are Signet secret names or 1Password references (op://vault/item/field). " +
+				"Provide a secrets map where keys are env var names and values are Signet secret names, Bitwarden references (bw://name/NAME or bw://item/ITEM_ID/password), or 1Password references (op://vault/item/field). " +
 				"Output is automatically redacted — secret values never appear in results.",
 			inputSchema: z.object({
 				command: z.string().describe("Shell command to execute"),

--- a/platform/daemon/src/plugins/bundled/secrets.ts
+++ b/platform/daemon/src/plugins/bundled/secrets.ts
@@ -197,6 +197,21 @@ const surfaces: PluginSurfaceDeclarationsV1 = {
 			summary: "Migrate local Signet secrets into Bitwarden",
 			requiredCapabilities: ["sdk:client", "secrets:providers:configure"],
 		},
+		{
+			name: "disconnectBitwarden",
+			summary: "Disconnect Bitwarden provider",
+			requiredCapabilities: ["sdk:client", "secrets:providers:configure"],
+		},
+		{
+			name: "setSecretProvider",
+			summary: "Switch the active secrets provider",
+			requiredCapabilities: ["sdk:client", "secrets:providers:configure"],
+		},
+		{
+			name: "listBitwardenFolders",
+			summary: "List Bitwarden folders available to the connected provider",
+			requiredCapabilities: ["sdk:client", "secrets:providers:list"],
+		},
 	],
 	connectorCapabilities: [
 		{

--- a/platform/daemon/src/plugins/bundled/secrets.ts
+++ b/platform/daemon/src/plugins/bundled/secrets.ts
@@ -84,6 +84,42 @@ const surfaces: PluginSurfaceDeclarationsV1 = {
 			summary: "Import 1Password items into local Signet secrets",
 			requiredCapabilities: ["secrets:providers:configure"],
 		},
+		{
+			method: "GET",
+			path: "/api/secrets/bitwarden/status",
+			summary: "Inspect Bitwarden provider status",
+			requiredCapabilities: ["secrets:providers:list"],
+		},
+		{
+			method: "POST",
+			path: "/api/secrets/bitwarden/connect",
+			summary: "Connect Bitwarden CLI session",
+			requiredCapabilities: ["secrets:providers:configure"],
+		},
+		{
+			method: "DELETE",
+			path: "/api/secrets/bitwarden/connect",
+			summary: "Disconnect Bitwarden provider",
+			requiredCapabilities: ["secrets:providers:configure"],
+		},
+		{
+			method: "POST",
+			path: "/api/secrets/bitwarden/provider",
+			summary: "Switch active secret provider",
+			requiredCapabilities: ["secrets:providers:configure"],
+		},
+		{
+			method: "GET",
+			path: "/api/secrets/bitwarden/folders",
+			summary: "List Bitwarden folders",
+			requiredCapabilities: ["secrets:providers:list"],
+		},
+		{
+			method: "POST",
+			path: "/api/secrets/bitwarden/migrate",
+			summary: "Migrate local Signet secrets into Bitwarden",
+			requiredCapabilities: ["secrets:providers:configure"],
+		},
 	],
 	cliCommands: [
 		{ path: ["secret", "list"], summary: "List secret names", requiredCapabilities: ["cli:command", "secrets:list"] },
@@ -97,6 +133,11 @@ const surfaces: PluginSurfaceDeclarationsV1 = {
 		{
 			path: ["secret", "onepassword"],
 			summary: "Manage 1Password compatibility integration",
+			requiredCapabilities: ["cli:command", "secrets:providers:configure"],
+		},
+		{
+			path: ["secret", "bitwarden"],
+			summary: "Manage Bitwarden provider integration",
 			requiredCapabilities: ["cli:command", "secrets:providers:configure"],
 		},
 	],
@@ -118,7 +159,7 @@ const surfaces: PluginSurfaceDeclarationsV1 = {
 		{
 			id: "settings.secrets",
 			title: "Secrets",
-			summary: "Manage local encrypted Signet secrets and 1Password compatibility",
+			summary: "Manage local encrypted Signet secrets, Bitwarden, and 1Password compatibility",
 			requiredCapabilities: ["dashboard:panel", "secrets:list"],
 		},
 	],
@@ -139,6 +180,21 @@ const surfaces: PluginSurfaceDeclarationsV1 = {
 		{
 			name: "connectOnePassword",
 			summary: "Configure 1Password compatibility",
+			requiredCapabilities: ["sdk:client", "secrets:providers:configure"],
+		},
+		{
+			name: "getBitwardenStatus",
+			summary: "Inspect Bitwarden provider status",
+			requiredCapabilities: ["sdk:client", "secrets:providers:list"],
+		},
+		{
+			name: "connectBitwarden",
+			summary: "Connect Bitwarden provider",
+			requiredCapabilities: ["sdk:client", "secrets:providers:configure"],
+		},
+		{
+			name: "migrateSecretsToBitwarden",
+			summary: "Migrate local Signet secrets into Bitwarden",
 			requiredCapabilities: ["sdk:client", "secrets:providers:configure"],
 		},
 	],
@@ -176,7 +232,8 @@ export const signetSecretsManifest: PluginManifestV1 = {
 	name: "Signet Secrets",
 	version: "1.0.0",
 	publisher: "signetai",
-	description: "Privileged core plugin for encrypted local secrets, compatibility providers, and secret injection.",
+	description:
+		"Privileged core plugin for encrypted local secrets, Bitwarden provider, compatibility providers, and secret injection.",
 	runtime: {
 		language: "typescript",
 		kind: "bundled-module",

--- a/platform/daemon/src/routes/secrets-routes.test.ts
+++ b/platform/daemon/src/routes/secrets-routes.test.ts
@@ -315,7 +315,7 @@ describe("secrets routes plugin capability enforcement", () => {
 			body: JSON.stringify({ session: "bad", activate: true }),
 		});
 		expect(rejected.status).toBe(400);
-		expect(await rejected.json()).toMatchObject({ success: false, connected: false, activeProvider: true });
+		expect(await rejected.json()).toMatchObject({ success: false, connected: false, activeProvider: false });
 
 		const status = await app.request("/api/secrets/bitwarden/status");
 		expect(status.status).toBe(200);

--- a/platform/daemon/src/routes/secrets-routes.test.ts
+++ b/platform/daemon/src/routes/secrets-routes.test.ts
@@ -174,6 +174,7 @@ describe("secrets routes plugin capability enforcement", () => {
 
 	test("Bitwarden routes connect, activate, write through, migrate, and disconnect without losing local fallback", async () => {
 		const items = new Map<string, string>();
+		const writeFolders = new Map<string, string | undefined>();
 		const folders = [{ id: "folder-1", name: "Signet" }];
 		const makeClient = async (_session: string): Promise<BitwardenClient> => ({
 			async status() {
@@ -189,9 +190,10 @@ describe("secrets routes plugin capability enforcement", () => {
 				const name = id.replace(/^item-/, "");
 				return { id, name, login: { password: items.get(name) ?? null } };
 			},
-			async putSecret(name: string, value: string) {
+			async putSecret(name: string, value: string, options?: { readonly folderId?: string }) {
 				items.set(name, value);
-				return { id: `item-${name}`, name, login: { password: value } };
+				writeFolders.set(name, options?.folderId);
+				return { id: `item-${name}`, name, folderId: options?.folderId, login: { password: value } };
 			},
 			async deleteSecret(name: string) {
 				return items.delete(name);
@@ -233,6 +235,7 @@ describe("secrets routes plugin capability enforcement", () => {
 		});
 		expect(storedInBitwarden.status).toBe(200);
 		expect(items.get("BW_ONLY")).toBe("bw-value");
+		expect(writeFolders.get("BW_ONLY")).toBe("folder-1");
 
 		const listed = await app.request("/api/secrets");
 		expect(listed.status).toBe(200);
@@ -254,6 +257,20 @@ describe("secrets routes plugin capability enforcement", () => {
 		expect(migrated.status).toBe(200);
 		expect(await migrated.json()).toMatchObject({ success: true, dryRun: false, migratedCount: 1 });
 		expect(items.get("LOCAL_ONLY")).toBe("local-value");
+
+		const reconnected = await app.request("/api/secrets/bitwarden/connect", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ session: "bw-session-2", activate: true }),
+		});
+		expect(reconnected.status).toBe(200);
+		const storedAfterReconnect = await app.request("/api/secrets/BW_NO_FOLDER", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ value: "bw-no-folder" }),
+		});
+		expect(storedAfterReconnect.status).toBe(200);
+		expect(writeFolders.get("BW_NO_FOLDER")).toBeUndefined();
 
 		const foldersRes = await app.request("/api/secrets/bitwarden/folders");
 		expect(foldersRes.status).toBe(200);

--- a/platform/daemon/src/routes/secrets-routes.test.ts
+++ b/platform/daemon/src/routes/secrets-routes.test.ts
@@ -294,7 +294,9 @@ describe("secrets routes plugin capability enforcement", () => {
 		setBitwardenClientFactoryForTests(
 			async (session: string): Promise<BitwardenClient> => ({
 				async status() {
-					return session === "good" ? { status: "unlocked" } : { status: "locked" };
+					if (session === "good") return { status: "unlocked" };
+					if (session === "unknown") return {};
+					return { status: "locked" };
 				},
 				async listFolders() {
 					return [];
@@ -325,6 +327,14 @@ describe("secrets routes plugin capability enforcement", () => {
 		});
 		expect(rejected.status).toBe(400);
 		expect(await rejected.json()).toMatchObject({ success: false, connected: false, activeProvider: false });
+
+		const rejectedUnknown = await app.request("/api/secrets/bitwarden/connect", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ session: "unknown", activate: true }),
+		});
+		expect(rejectedUnknown.status).toBe(400);
+		expect(await rejectedUnknown.json()).toMatchObject({ success: false, connected: false, activeProvider: false });
 
 		const status = await app.request("/api/secrets/bitwarden/status");
 		expect(status.status).toBe(200);

--- a/platform/daemon/src/routes/secrets-routes.test.ts
+++ b/platform/daemon/src/routes/secrets-routes.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Hono } from "hono";
+import { type BitwardenClient, setBitwardenClientFactoryForTests } from "../bitwarden.js";
 import { queryPluginAuditEvents } from "../plugins/audit.js";
 import { SIGNET_SECRETS_PLUGIN_ID, signetSecretsManifest } from "../plugins/bundled/secrets.js";
 import { PluginHostV1 } from "../plugins/host.js";
@@ -169,6 +170,98 @@ describe("secrets routes plugin capability enforcement", () => {
 		});
 
 		expect(res.status).toBe(400);
+	});
+
+	test("Bitwarden routes connect, activate, write through, migrate, and disconnect without losing local fallback", async () => {
+		const items = new Map<string, string>();
+		const folders = [{ id: "folder-1", name: "Signet" }];
+		const makeClient = async (_session: string): Promise<BitwardenClient> => ({
+			async status() {
+				return { status: "unlocked", userEmail: "agent@example.com", serverUrl: "https://vault.bitwarden.com" };
+			},
+			async listFolders() {
+				return folders;
+			},
+			async listItems() {
+				return Array.from(items.keys()).map((name) => ({ id: `item-${name}`, name }));
+			},
+			async getItem(id: string) {
+				const name = id.replace(/^item-/, "");
+				return { id, name, login: { password: items.get(name) ?? null } };
+			},
+			async putSecret(name: string, value: string) {
+				items.set(name, value);
+				return { id: `item-${name}`, name, login: { password: value } };
+			},
+			async deleteSecret(name: string) {
+				return items.delete(name);
+			},
+			async resolveSecret(ref: string) {
+				const name = decodeURIComponent(ref.replace("bw://name/", ""));
+				const value = items.get(name);
+				if (!value) throw new Error(`Bitwarden item '${name}' not found`);
+				return value;
+			},
+		});
+		setBitwardenClientFactoryForTests(makeClient);
+		const app = makeApp(makeHost());
+
+		const local = await app.request("/api/secrets/LOCAL_ONLY", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ value: "local-value" }),
+		});
+		expect(local.status).toBe(200);
+
+		const connected = await app.request("/api/secrets/bitwarden/connect", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ session: "bw-session", activate: true, folderId: "folder-1" }),
+		});
+		expect(connected.status).toBe(200);
+		expect(await connected.json()).toMatchObject({
+			success: true,
+			configured: true,
+			connected: true,
+			activeProvider: true,
+		});
+
+		const storedInBitwarden = await app.request("/api/secrets/BW_ONLY", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ value: "bw-value" }),
+		});
+		expect(storedInBitwarden.status).toBe(200);
+		expect(items.get("BW_ONLY")).toBe("bw-value");
+
+		const listed = await app.request("/api/secrets");
+		expect(listed.status).toBe(200);
+		expect(await listed.json()).toMatchObject({ provider: "bitwarden", secrets: ["BW_ONLY", "LOCAL_ONLY"] });
+
+		const dryRun = await app.request("/api/secrets/bitwarden/migrate", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ dryRun: true }),
+		});
+		expect(dryRun.status).toBe(200);
+		expect(await dryRun.json()).toMatchObject({ success: true, dryRun: true, migratedCount: 0, skippedCount: 1 });
+
+		const migrated = await app.request("/api/secrets/bitwarden/migrate", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ dryRun: false, overwrite: true }),
+		});
+		expect(migrated.status).toBe(200);
+		expect(await migrated.json()).toMatchObject({ success: true, dryRun: false, migratedCount: 1 });
+		expect(items.get("LOCAL_ONLY")).toBe("local-value");
+
+		const foldersRes = await app.request("/api/secrets/bitwarden/folders");
+		expect(foldersRes.status).toBe(200);
+		expect(await foldersRes.json()).toEqual({ folders: [{ id: "folder-1", name: "Signet" }], count: 1 });
+
+		const disconnected = await app.request("/api/secrets/bitwarden/connect", { method: "DELETE" });
+		expect(disconnected.status).toBe(200);
+		expect(await disconnected.json()).toMatchObject({ success: true, disconnected: true, activeProvider: false });
 	});
 
 	test("1Password compatibility status route does not require configured token", async () => {

--- a/platform/daemon/src/routes/secrets-routes.test.ts
+++ b/platform/daemon/src/routes/secrets-routes.test.ts
@@ -264,6 +264,62 @@ describe("secrets routes plugin capability enforcement", () => {
 		expect(await disconnected.json()).toMatchObject({ success: true, disconnected: true, activeProvider: false });
 	});
 
+	test("Bitwarden connect validates session before persisting or activating", async () => {
+		setBitwardenClientFactoryForTests(
+			async (session: string): Promise<BitwardenClient> => ({
+				async status() {
+					return session === "good" ? { status: "unlocked" } : { status: "locked" };
+				},
+				async listFolders() {
+					return [];
+				},
+				async listItems() {
+					return [];
+				},
+				async getItem(id: string) {
+					return { id, name: id, login: { password: null } };
+				},
+				async putSecret(name: string, value: string) {
+					return { id: name, name, login: { password: value } };
+				},
+				async deleteSecret() {
+					return false;
+				},
+				async resolveSecret() {
+					throw new Error("not found");
+				},
+			}),
+		);
+		const app = makeApp(makeHost());
+
+		const rejected = await app.request("/api/secrets/bitwarden/connect", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ session: "bad", activate: true }),
+		});
+		expect(rejected.status).toBe(400);
+		expect(await rejected.json()).toMatchObject({ success: false, connected: false, activeProvider: true });
+
+		const status = await app.request("/api/secrets/bitwarden/status");
+		expect(status.status).toBe(200);
+		expect(await status.json()).toMatchObject({ configured: false, connected: false, activeProvider: false });
+
+		const useBitwarden = await app.request("/api/secrets/bitwarden/provider", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ provider: "bitwarden" }),
+		});
+		expect(useBitwarden.status).toBe(400);
+
+		const accepted = await app.request("/api/secrets/bitwarden/connect", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ session: "good", activate: false }),
+		});
+		expect(accepted.status).toBe(200);
+		expect(await accepted.json()).toMatchObject({ success: true, connected: true, activeProvider: false });
+	});
+
 	test("1Password compatibility status route does not require configured token", async () => {
 		const res = await makeApp(makeHost()).request("/api/secrets/1password/status");
 		expect(res.status).toBe(200);

--- a/platform/daemon/src/routes/secrets-routes.test.ts
+++ b/platform/daemon/src/routes/secrets-routes.test.ts
@@ -7,7 +7,7 @@ import { type BitwardenClient, setBitwardenClientFactoryForTests } from "../bitw
 import { queryPluginAuditEvents } from "../plugins/audit.js";
 import { SIGNET_SECRETS_PLUGIN_ID, signetSecretsManifest } from "../plugins/bundled/secrets.js";
 import { PluginHostV1 } from "../plugins/host.js";
-import { putSecret, resetSecretExecJobsForTests } from "../secrets.js";
+import { getSecret, putSecret, resetSecretExecJobsForTests } from "../secrets.js";
 import { registerSecretRoutes } from "./secrets-routes.js";
 
 const originalSignetPath = process.env.SIGNET_PATH;
@@ -257,6 +257,14 @@ describe("secrets routes plugin capability enforcement", () => {
 		expect(migrated.status).toBe(200);
 		expect(await migrated.json()).toMatchObject({ success: true, dryRun: false, migratedCount: 1 });
 		expect(items.get("LOCAL_ONLY")).toBe("local-value");
+
+		const deletedMigrated = await app.request("/api/secrets/LOCAL_ONLY", { method: "DELETE" });
+		expect(deletedMigrated.status).toBe(200);
+		expect(items.has("LOCAL_ONLY")).toBe(false);
+		await expect(getSecret("LOCAL_ONLY")).rejects.toThrow();
+		const listedAfterDelete = await app.request("/api/secrets");
+		expect(listedAfterDelete.status).toBe(200);
+		expect(await listedAfterDelete.json()).toMatchObject({ provider: "bitwarden", secrets: ["BW_ONLY"] });
 
 		const reconnected = await app.request("/api/secrets/bitwarden/connect", {
 			method: "POST",

--- a/platform/daemon/src/routes/secrets-routes.test.ts
+++ b/platform/daemon/src/routes/secrets-routes.test.ts
@@ -7,7 +7,7 @@ import { type BitwardenClient, setBitwardenClientFactoryForTests } from "../bitw
 import { queryPluginAuditEvents } from "../plugins/audit.js";
 import { SIGNET_SECRETS_PLUGIN_ID, signetSecretsManifest } from "../plugins/bundled/secrets.js";
 import { PluginHostV1 } from "../plugins/host.js";
-import { getSecret, putSecret, resetSecretExecJobsForTests } from "../secrets.js";
+import { getLocalSecretValue, getSecret, putSecret, resetSecretExecJobsForTests } from "../secrets.js";
 import { registerSecretRoutes } from "./secrets-routes.js";
 
 const originalSignetPath = process.env.SIGNET_PATH;
@@ -261,6 +261,7 @@ describe("secrets routes plugin capability enforcement", () => {
 		const deletedMigrated = await app.request("/api/secrets/LOCAL_ONLY", { method: "DELETE" });
 		expect(deletedMigrated.status).toBe(200);
 		expect(items.has("LOCAL_ONLY")).toBe(false);
+		expect(await getLocalSecretValue("LOCAL_ONLY")).toBe("local-value");
 		await expect(getSecret("LOCAL_ONLY")).rejects.toThrow();
 		const listedAfterDelete = await app.request("/api/secrets");
 		expect(listedAfterDelete.status).toBe(200);

--- a/platform/daemon/src/routes/secrets-routes.ts
+++ b/platform/daemon/src/routes/secrets-routes.ts
@@ -139,6 +139,7 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 			}
 			await putSecret(BITWARDEN_SESSION_SECRET, session);
 			if (folderId) await putSecret(BITWARDEN_MANAGED_FOLDER_SECRET, folderId);
+			else deleteSecret(BITWARDEN_MANAGED_FOLDER_SECRET);
 			if (activate) await setActiveSecretProvider("bitwarden");
 			logger.info("secrets", "Connected Bitwarden session", { connected: status.connected, activate });
 			return c.json({ success: true, ...status });

--- a/platform/daemon/src/routes/secrets-routes.ts
+++ b/platform/daemon/src/routes/secrets-routes.ts
@@ -133,7 +133,8 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 			if (!session) return c.json({ error: "session is required" }, 400);
 			const activate = parseOptionalBoolean(body.activate) ?? false;
 			const folderId = parseOptionalString(body.folderId);
-			const status = await getBitwardenStatus({ configured: true, activeProvider: activate, session });
+			const currentActiveProvider = (await getActiveSecretProvider()) === "bitwarden";
+			const status = await getBitwardenStatus({ configured: true, activeProvider: currentActiveProvider, session });
 			if (!status.connected) {
 				return c.json({ error: status.error ?? "Bitwarden session is not connected", ...status, success: false }, 400);
 			}
@@ -142,7 +143,7 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 			else deleteSecret(BITWARDEN_MANAGED_FOLDER_SECRET);
 			if (activate) await setActiveSecretProvider("bitwarden");
 			logger.info("secrets", "Connected Bitwarden session", { connected: status.connected, activate });
-			return c.json({ success: true, ...status });
+			return c.json({ success: true, ...status, activeProvider: activate || currentActiveProvider });
 		} catch (e) {
 			const err = e as Error;
 			logger.error("secrets", "Failed to connect Bitwarden", err);

--- a/platform/daemon/src/routes/secrets-routes.ts
+++ b/platform/daemon/src/routes/secrets-routes.ts
@@ -1,5 +1,13 @@
 import type { Context, Hono } from "hono";
 import { requirePermission } from "../auth";
+import {
+	BITWARDEN_ACTIVE_PROVIDER_SECRET,
+	BITWARDEN_MANAGED_FOLDER_SECRET,
+	BITWARDEN_SESSION_SECRET,
+	getBitwardenStatus,
+	listBitwardenFolders,
+	migrateLocalSecretsToBitwarden,
+} from "../bitwarden.js";
 import { logger } from "../logger.js";
 import { ONEPASSWORD_SERVICE_ACCOUNT_SECRET, importOnePasswordSecrets, listOnePasswordVaults } from "../onepassword.js";
 import { recordPluginAuditEvent } from "../plugins/audit.js";
@@ -7,13 +15,19 @@ import { SIGNET_SECRETS_PLUGIN_ID, getDefaultPluginHost } from "../plugins/index
 import type { PluginHostV1 } from "../plugins/index.js";
 import {
 	SecretExecQueueFullError,
+	deleteLocalSecretForMigration,
 	deleteSecret,
+	deleteSecretFromActiveProvider,
+	getActiveSecretProvider,
+	getLocalSecretValue,
 	getSecret,
 	getSecretExecJob,
 	hasSecret,
+	listLocalSecretNames,
 	listSecrets,
 	normalizeSecretExecTimeoutMs,
 	putSecret,
+	setActiveSecretProvider,
 	startSecretExecJob,
 } from "../secrets.js";
 import { authConfig } from "./state.js";
@@ -82,15 +96,132 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 		return requirePermission("admin", authConfig)(c, next);
 	});
 
-	app.get("/api/secrets", (c) => {
+	app.get("/api/secrets", async (c) => {
 		const denied = rejectIfCapabilityDenied(c, host, ["secrets:list"]);
 		if (denied) return denied;
 		try {
-			const names = listSecrets();
-			return c.json({ secrets: names });
+			const names = await listSecrets();
+			const provider = await getActiveSecretProvider();
+			return c.json({ secrets: names, provider });
 		} catch (e) {
 			logger.error("secrets", "Failed to list secrets", e as Error);
 			return c.json({ error: "Failed to list secrets" }, 500);
+		}
+	});
+
+	app.get("/api/secrets/bitwarden/status", async (c) => {
+		const denied = rejectIfCapabilityDenied(c, host, ["secrets:providers:list"]);
+		if (denied) return denied;
+		const activeProvider = (await getActiveSecretProvider()) === "bitwarden";
+		try {
+			const configured = hasSecret(BITWARDEN_SESSION_SECRET);
+			const session = configured ? await getSecret(BITWARDEN_SESSION_SECRET) : undefined;
+			return c.json(await getBitwardenStatus({ configured, activeProvider, session }));
+		} catch (e) {
+			const err = e as Error;
+			logger.warn("secrets", "Bitwarden status check failed", { error: err.message });
+			return c.json({ configured: true, connected: false, activeProvider, error: err.message });
+		}
+	});
+
+	app.post("/api/secrets/bitwarden/connect", async (c) => {
+		const denied = rejectIfCapabilityDenied(c, host, ["secrets:providers:configure"]);
+		if (denied) return denied;
+		try {
+			const body = await readOptionalJsonObject(c);
+			if (!body) return c.json({ error: "Invalid JSON body" }, 400);
+			const session = parseOptionalString(body.session) ?? parseOptionalString(body.token);
+			if (!session) return c.json({ error: "session is required" }, 400);
+			const activate = parseOptionalBoolean(body.activate) ?? false;
+			const folderId = parseOptionalString(body.folderId);
+			await putSecret(BITWARDEN_SESSION_SECRET, session);
+			if (folderId) await putSecret(BITWARDEN_MANAGED_FOLDER_SECRET, folderId);
+			if (activate) await setActiveSecretProvider("bitwarden");
+			const status = await getBitwardenStatus({ configured: true, activeProvider: activate, session });
+			logger.info("secrets", "Connected Bitwarden session", { connected: status.connected, activate });
+			return c.json({ success: true, ...status });
+		} catch (e) {
+			const err = e as Error;
+			logger.error("secrets", "Failed to connect Bitwarden", err);
+			return c.json({ error: err.message }, 400);
+		}
+	});
+
+	app.delete("/api/secrets/bitwarden/connect", async (c) => {
+		const denied = rejectIfCapabilityDenied(c, host, ["secrets:providers:configure"]);
+		if (denied) return denied;
+		try {
+			const sessionDeleted = deleteSecret(BITWARDEN_SESSION_SECRET);
+			const folderDeleted = deleteSecret(BITWARDEN_MANAGED_FOLDER_SECRET);
+			await setActiveSecretProvider("local");
+			return c.json({
+				success: true,
+				disconnected: true,
+				existed: sessionDeleted || folderDeleted,
+				activeProvider: false,
+			});
+		} catch (e) {
+			const err = e as Error;
+			logger.error("secrets", "Failed to disconnect Bitwarden", err);
+			return c.json({ error: err.message }, 500);
+		}
+	});
+
+	app.post("/api/secrets/bitwarden/provider", async (c) => {
+		const denied = rejectIfCapabilityDenied(c, host, ["secrets:providers:configure"]);
+		if (denied) return denied;
+		const body = await readOptionalJsonObject(c);
+		if (!body) return c.json({ error: "Invalid JSON body" }, 400);
+		const provider = parseOptionalString(body.provider);
+		if (provider !== "local" && provider !== "bitwarden")
+			return c.json({ error: "provider must be local or bitwarden" }, 400);
+		if (provider === "bitwarden" && !hasSecret(BITWARDEN_SESSION_SECRET))
+			return c.json({ error: "Bitwarden is not connected" }, 400);
+		await setActiveSecretProvider(provider);
+		return c.json({ success: true, provider });
+	});
+
+	app.get("/api/secrets/bitwarden/folders", async (c) => {
+		const denied = rejectIfCapabilityDenied(c, host, ["secrets:providers:list"]);
+		if (denied) return denied;
+		try {
+			const session = await getSecret(BITWARDEN_SESSION_SECRET);
+			const folders = await listBitwardenFolders(session);
+			return c.json({ folders, count: folders.length });
+		} catch (e) {
+			const err = e as Error;
+			logger.error("secrets", "Failed to list Bitwarden folders", err);
+			return c.json({ error: err.message }, 400);
+		}
+	});
+
+	app.post("/api/secrets/bitwarden/migrate", async (c) => {
+		const denied = rejectIfCapabilityDenied(c, host, ["secrets:providers:configure"]);
+		if (denied) return denied;
+		try {
+			const body = await readOptionalJsonObject(c);
+			if (!body) return c.json({ error: "Invalid JSON body" }, 400);
+			const session = await getSecret(BITWARDEN_SESSION_SECRET);
+			const folderId = parseOptionalString(body.folderId);
+			const overwrite = parseOptionalBoolean(body.overwrite) ?? false;
+			const dryRun = parseOptionalBoolean(body.dryRun) ?? true;
+			const deleteLocal = parseOptionalBoolean(body.deleteLocal) ?? false;
+			const localNames = listLocalSecretNames({ includeInternal: false });
+			const result = await migrateLocalSecretsToBitwarden({
+				session,
+				localNames,
+				getLocalSecret: getLocalSecretValue,
+				deleteLocalSecret: deleteLocalSecretForMigration,
+				folderId,
+				overwrite,
+				dryRun,
+				deleteLocal,
+			});
+			return c.json({ success: true, ...result });
+		} catch (e) {
+			const err = e as Error;
+			logger.error("secrets", "Failed to migrate local secrets to Bitwarden", err);
+			return c.json({ error: err.message }, 400);
 		}
 	});
 
@@ -324,12 +455,12 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 		}
 	});
 
-	app.delete("/api/secrets/:name", (c) => {
+	app.delete("/api/secrets/:name", async (c) => {
 		const denied = rejectIfCapabilityDenied(c, host, ["secrets:delete"]);
 		if (denied) return denied;
 		const { name } = c.req.param();
 		try {
-			const deleted = deleteSecret(name);
+			const deleted = await deleteSecretFromActiveProvider(name);
 			if (!deleted) return c.json({ error: `Secret '${name}' not found` }, 404);
 			logger.info("secrets", "Secret deleted", { name });
 			return c.json({ success: true, name });

--- a/platform/daemon/src/routes/secrets-routes.ts
+++ b/platform/daemon/src/routes/secrets-routes.ts
@@ -1,7 +1,6 @@
 import type { Context, Hono } from "hono";
 import { requirePermission } from "../auth";
 import {
-	BITWARDEN_ACTIVE_PROVIDER_SECRET,
 	BITWARDEN_MANAGED_FOLDER_SECRET,
 	BITWARDEN_SESSION_SECRET,
 	getBitwardenStatus,
@@ -134,10 +133,13 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 			if (!session) return c.json({ error: "session is required" }, 400);
 			const activate = parseOptionalBoolean(body.activate) ?? false;
 			const folderId = parseOptionalString(body.folderId);
+			const status = await getBitwardenStatus({ configured: true, activeProvider: activate, session });
+			if (!status.connected) {
+				return c.json({ error: status.error ?? "Bitwarden session is not connected", ...status, success: false }, 400);
+			}
 			await putSecret(BITWARDEN_SESSION_SECRET, session);
 			if (folderId) await putSecret(BITWARDEN_MANAGED_FOLDER_SECRET, folderId);
 			if (activate) await setActiveSecretProvider("bitwarden");
-			const status = await getBitwardenStatus({ configured: true, activeProvider: activate, session });
 			logger.info("secrets", "Connected Bitwarden session", { connected: status.connected, activate });
 			return c.json({ success: true, ...status });
 		} catch (e) {
@@ -175,8 +177,14 @@ export function registerSecretRoutes(app: Hono, host: PluginHostV1 = getDefaultP
 		const provider = parseOptionalString(body.provider);
 		if (provider !== "local" && provider !== "bitwarden")
 			return c.json({ error: "provider must be local or bitwarden" }, 400);
-		if (provider === "bitwarden" && !hasSecret(BITWARDEN_SESSION_SECRET))
-			return c.json({ error: "Bitwarden is not connected" }, 400);
+		if (provider === "bitwarden") {
+			if (!hasSecret(BITWARDEN_SESSION_SECRET)) return c.json({ error: "Bitwarden is not connected" }, 400);
+			const session = await getSecret(BITWARDEN_SESSION_SECRET);
+			const status = await getBitwardenStatus({ configured: true, activeProvider: true, session });
+			if (!status.connected) {
+				return c.json({ error: status.error ?? "Bitwarden session is not connected", ...status, success: false }, 400);
+			}
+		}
 		await setActiveSecretProvider(provider);
 		return c.json({ success: true, provider });
 	});

--- a/platform/daemon/src/secrets.test.ts
+++ b/platform/daemon/src/secrets.test.ts
@@ -275,11 +275,11 @@ describe("local secrets provider", () => {
 				return [];
 			},
 			async listItems() {
-				return [{ id: "item-1", name: "ANTHROPIC_KEY", folderId: null }];
+				return [{ id: "item-1", name: "anthropic_key", folderId: null }];
 			},
 			async getItem(id: string) {
 				expect(id).toBe("item-1");
-				return { id, name: "ANTHROPIC_KEY", folderId: null, login: { username: "signet", password: "sk-bw" } };
+				return { id, name: "anthropic_key", folderId: null, login: { username: "signet", password: "sk-bw" } };
 			},
 			async putSecret() {
 				throw new Error("not used");
@@ -288,7 +288,7 @@ describe("local secrets provider", () => {
 				return false;
 			},
 			async resolveSecret(ref: string) {
-				expect(ref).toBe("bw://name/ANTHROPIC_KEY");
+				expect(ref).toBe("bw://name/anthropic_key");
 				return "sk-bw";
 			},
 		};

--- a/platform/daemon/src/secrets.test.ts
+++ b/platform/daemon/src/secrets.test.ts
@@ -2,6 +2,12 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import {
+	BITWARDEN_ACTIVE_PROVIDER_SECRET,
+	BITWARDEN_SESSION_SECRET,
+	type BitwardenClient,
+	setBitwardenClientFactoryForTests,
+} from "./bitwarden.js";
 import { SIGNET_SECRETS_PLUGIN_ID, getDefaultPluginHost, resetDefaultPluginHostForTests } from "./plugins/index.js";
 import {
 	deleteSecret,
@@ -33,6 +39,7 @@ describe("local secrets provider", () => {
 	afterEach(() => {
 		resetDefaultPluginHostForTests();
 		resetSecretExecJobsForTests();
+		setBitwardenClientFactoryForTests(null);
 		if (originalSignetPath === undefined) {
 			Reflect.deleteProperty(process.env, "SIGNET_PATH");
 		} else {
@@ -257,6 +264,39 @@ describe("local secrets provider", () => {
 		expect(plugin?.state).toBe("degraded");
 		expect(plugin?.health?.status).toBe("unhealthy");
 		expect(plugin?.stateReason).toContain("Failed to read secrets store");
+	});
+
+	test("active Bitwarden provider resolves bare names with the same canonical name used on write", async () => {
+		const client: BitwardenClient = {
+			async status() {
+				return { status: "unlocked" };
+			},
+			async listFolders() {
+				return [];
+			},
+			async listItems() {
+				return [{ id: "item-1", name: "ANTHROPIC_KEY", folderId: null }];
+			},
+			async getItem(id: string) {
+				expect(id).toBe("item-1");
+				return { id, name: "ANTHROPIC_KEY", folderId: null, login: { username: "signet", password: "sk-bw" } };
+			},
+			async putSecret() {
+				throw new Error("not used");
+			},
+			async deleteSecret() {
+				return false;
+			},
+			async resolveSecret(ref: string) {
+				expect(ref).toBe("bw://name/ANTHROPIC_KEY");
+				return "sk-bw";
+			},
+		};
+		setBitwardenClientFactoryForTests(async () => client);
+		await putSecret(BITWARDEN_SESSION_SECRET, "bw-session");
+		await putSecret(BITWARDEN_ACTIVE_PROVIDER_SECRET, "bitwarden");
+
+		expect(await getSecret("anthropic_key")).toBe("sk-bw");
 	});
 
 	test("delete accepts local:// compatibility references", async () => {

--- a/platform/daemon/src/secrets.test.ts
+++ b/platform/daemon/src/secrets.test.ts
@@ -46,7 +46,7 @@ describe("local secrets provider", () => {
 	test("bare names and local:// references resolve through the same local store", async () => {
 		await putSecret("OPENAI_API_KEY", "sk-test-local");
 
-		expect(listSecrets()).toEqual(["OPENAI_API_KEY"]);
+		expect(await listSecrets()).toEqual(["OPENAI_API_KEY"]);
 		expect(hasSecret("local://OPENAI_API_KEY")).toBe(true);
 		expect(await getSecret("local://OPENAI_API_KEY")).toBe("sk-test-local");
 
@@ -62,7 +62,7 @@ describe("local secrets provider", () => {
 		await putSecret("OPENAI_API_KEY", "sk-test-local");
 		const before = readFileSync(secretsFile(), "utf-8");
 
-		expect(listSecrets()).toEqual(["OPENAI_API_KEY"]);
+		expect(await listSecrets()).toEqual(["OPENAI_API_KEY"]);
 		expect(await localSecretProvider.resolve("local://OPENAI_API_KEY", {})).toMatchObject({
 			ref: "local://OPENAI_API_KEY",
 			providerId: "local",
@@ -226,7 +226,7 @@ describe("local secrets provider", () => {
 		mkdirSync(join(agentsDir, ".secrets"), { recursive: true });
 		writeFileSync(secretsFile(), "not-json", { mode: 0o600 });
 
-		expect(() => listSecrets()).toThrow("Failed to read secrets store");
+		expect(listSecrets()).rejects.toThrow("Failed to read secrets store");
 		const health = await localSecretProvider.health({});
 		expect(health.status).toBe("unhealthy");
 		expect(readFileSync(secretsFile(), "utf-8")).toBe("not-json");
@@ -262,7 +262,7 @@ describe("local secrets provider", () => {
 	test("delete accepts local:// compatibility references", async () => {
 		await putSecret("GITHUB_TOKEN", "ghp_test");
 		expect(deleteSecret("local://GITHUB_TOKEN")).toBe(true);
-		expect(listSecrets()).toEqual([]);
+		expect(await listSecrets()).toEqual([]);
 	});
 });
 

--- a/platform/daemon/src/secrets.test.ts
+++ b/platform/daemon/src/secrets.test.ts
@@ -233,7 +233,7 @@ describe("local secrets provider", () => {
 		mkdirSync(join(agentsDir, ".secrets"), { recursive: true });
 		writeFileSync(secretsFile(), "not-json", { mode: 0o600 });
 
-		expect(listSecrets()).rejects.toThrow("Failed to read secrets store");
+		await expect(listSecrets()).rejects.toThrow("Failed to read secrets store");
 		const health = await localSecretProvider.health({});
 		expect(health.status).toBe("unhealthy");
 		expect(readFileSync(secretsFile(), "utf-8")).toBe("not-json");

--- a/platform/daemon/src/secrets.ts
+++ b/platform/daemon/src/secrets.ts
@@ -16,6 +16,17 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir, hostname } from "node:os";
 import { join } from "node:path";
 import sodium from "libsodium-wrappers";
+import {
+	BITWARDEN_ACTIVE_PROVIDER_SECRET,
+	BITWARDEN_MANAGED_FOLDER_SECRET,
+	BITWARDEN_SESSION_SECRET,
+	deleteBitwardenSecret,
+	isBitwardenActiveProvider,
+	isBitwardenReference,
+	listBitwardenSecretNames,
+	putBitwardenSecret,
+	readBitwardenReference,
+} from "./bitwarden.js";
 import { logger } from "./logger.js";
 import { ONEPASSWORD_SERVICE_ACCOUNT_SECRET, isOnePasswordReference, readOnePasswordReference } from "./onepassword.js";
 import { recordPluginAuditEvent } from "./plugins/audit.js";
@@ -108,14 +119,14 @@ export interface SecretContextV1 {
 export interface SecretDescriptorV1 {
 	readonly name: string;
 	readonly ref: string;
-	readonly providerId: "local";
+	readonly providerId: string;
 	readonly created: string;
 	readonly updated: string;
 }
 
 export interface ResolvedSecretV1 {
 	readonly ref: string;
-	readonly providerId: "local";
+	readonly providerId: string;
 	readonly value: string;
 }
 
@@ -125,8 +136,8 @@ export interface SecretProviderHealthV1 {
 	readonly checkedAt: string;
 }
 
-export interface LocalSecretProviderV1 {
-	readonly id: "local";
+export interface SecretProviderV1 {
+	readonly id: string;
 	list(ctx: SecretContextV1): Promise<readonly SecretDescriptorV1[]>;
 	put(name: string, value: string, ctx: SecretContextV1): Promise<void>;
 	delete(name: string, ctx: SecretContextV1): Promise<boolean>;
@@ -270,7 +281,7 @@ function saveStore(store: SecretsStore): void {
 // Public API
 // ---------------------------------------------------------------------------
 
-export async function putSecret(name: string, value: string): Promise<void> {
+async function putLocalSecret(name: string, value: string): Promise<void> {
 	const localName = parseLocalSecretName(name);
 	const store = loadStore();
 	const now = new Date().toISOString();
@@ -286,6 +297,24 @@ export async function putSecret(name: string, value: string): Promise<void> {
 	recordSecretEvent("secret.stored", { name: localName });
 }
 
+export async function putSecret(name: string, value: string): Promise<void> {
+	const localName = parseLocalSecretName(name);
+	if (isInternalSecretName(localName) || !(await isBitwardenProviderActive())) {
+		await putLocalSecret(localName, value);
+		return;
+	}
+
+	const session = await getStoredSecret(BITWARDEN_SESSION_SECRET);
+	let folderId: string | undefined;
+	try {
+		folderId = await getStoredSecret(BITWARDEN_MANAGED_FOLDER_SECRET);
+	} catch {
+		folderId = undefined;
+	}
+	await putBitwardenSecret(localName, value, session, { folderId, overwrite: true });
+	recordSecretEvent("secret.stored", { name: localName, providerId: "bitwarden" });
+}
+
 async function getStoredSecret(name: string): Promise<string> {
 	const store = loadStore();
 	const entry = store.secrets[name];
@@ -299,21 +328,66 @@ export async function getSecret(name: string): Promise<string> {
 		return readOnePasswordReference(name, token);
 	}
 
-	return getStoredSecret(parseLocalSecretName(name));
+	if (isBitwardenReference(name)) {
+		const session = await getStoredSecret(BITWARDEN_SESSION_SECRET);
+		return readBitwardenReference(name, session);
+	}
+
+	const localName = parseLocalSecretName(name);
+	if (isInternalSecretName(localName)) {
+		return getStoredSecret(localName);
+	}
+	if (await isBitwardenProviderActive()) {
+		try {
+			const session = await getStoredSecret(BITWARDEN_SESSION_SECRET);
+			return readBitwardenReference(`bw://name/${encodeURIComponent(localName)}`, session);
+		} catch (error) {
+			if (!hasLocalSecret(localName)) throw error;
+		}
+	}
+
+	return getStoredSecret(localName);
 }
 
-export function hasSecret(name: string): boolean {
+function hasLocalSecret(name: string): boolean {
 	const store = loadStore();
 	return parseLocalSecretName(name) in store.secrets;
 }
 
-export function listSecrets(): string[] {
-	const names = Object.keys(loadStore().secrets).sort((a, b) => a.localeCompare(b));
-	recordSecretEvent("secret.listed", { count: names.length });
-	return names;
+export function hasSecret(name: string): boolean {
+	return hasLocalSecret(name);
 }
 
-export function deleteSecret(name: string): boolean {
+export function listLocalSecretNames(options: { includeInternal?: boolean } = {}): string[] {
+	const names = Object.keys(loadStore().secrets).sort((a, b) => a.localeCompare(b));
+	if (options.includeInternal === true) return names;
+	return names.filter((name) => !isInternalSecretName(name));
+}
+
+export async function listSecrets(): Promise<string[]> {
+	const localNames = listLocalSecretNames({ includeInternal: false });
+	if (!(await isBitwardenProviderActive())) {
+		recordSecretEvent("secret.listed", { count: localNames.length });
+		return localNames;
+	}
+
+	try {
+		const session = await getStoredSecret(BITWARDEN_SESSION_SECRET);
+		const bitwardenNames = await listBitwardenSecretNames(session);
+		const names = Array.from(new Set([...bitwardenNames, ...localNames])).sort((a, b) => a.localeCompare(b));
+		recordSecretEvent("secret.listed", { count: names.length, providerId: "bitwarden" });
+		return names;
+	} catch {
+		recordSecretEvent("secret.listed", {
+			count: localNames.length,
+			providerId: "local",
+			degradedProviderId: "bitwarden",
+		});
+		return localNames;
+	}
+}
+
+function deleteLocalSecret(name: string): boolean {
 	const store = loadStore();
 	const localName = parseLocalSecretName(name);
 	if (!(localName in store.secrets)) return false;
@@ -322,6 +396,62 @@ export function deleteSecret(name: string): boolean {
 	recordSecretEvent("secret.deleted", { name: localName });
 	return true;
 }
+
+export function deleteSecret(name: string): boolean {
+	return deleteLocalSecret(name);
+}
+
+export async function deleteSecretFromActiveProvider(name: string): Promise<boolean> {
+	const localName = parseLocalSecretName(name);
+	if (!isInternalSecretName(localName) && (await isBitwardenProviderActive())) {
+		const session = await getStoredSecret(BITWARDEN_SESSION_SECRET);
+		const deleted = await deleteBitwardenSecret(localName, session);
+		if (deleted) {
+			recordSecretEvent("secret.deleted", { name: localName, providerId: "bitwarden" });
+			return true;
+		}
+	}
+	return deleteLocalSecret(localName);
+}
+
+export async function getLocalSecretValue(name: string): Promise<string> {
+	return getStoredSecret(parseLocalSecretName(name));
+}
+
+export function deleteLocalSecretForMigration(name: string): boolean {
+	return deleteLocalSecret(name);
+}
+
+export async function setActiveSecretProvider(provider: "local" | "bitwarden"): Promise<void> {
+	if (provider === "local") {
+		deleteLocalSecret(BITWARDEN_ACTIVE_PROVIDER_SECRET);
+		return;
+	}
+	await putLocalSecret(BITWARDEN_ACTIVE_PROVIDER_SECRET, "bitwarden");
+}
+
+export async function getActiveSecretProvider(): Promise<"local" | "bitwarden"> {
+	return (await isBitwardenProviderActive()) ? "bitwarden" : "local";
+}
+
+async function isBitwardenProviderActive(): Promise<boolean> {
+	try {
+		return isBitwardenActiveProvider(await getStoredSecret(BITWARDEN_ACTIVE_PROVIDER_SECRET));
+	} catch {
+		return false;
+	}
+}
+
+function isInternalSecretName(name: string): boolean {
+	return [
+		ONEPASSWORD_SERVICE_ACCOUNT_SECRET,
+		BITWARDEN_SESSION_SECRET,
+		BITWARDEN_ACTIVE_PROVIDER_SECRET,
+		BITWARDEN_MANAGED_FOLDER_SECRET,
+	].includes(name);
+}
+
+export type LocalSecretProviderV1 = SecretProviderV1;
 
 export const localSecretProvider: LocalSecretProviderV1 = {
 	id: "local",
@@ -340,10 +470,10 @@ export const localSecretProvider: LocalSecretProviderV1 = {
 		return descriptors;
 	},
 	async put(name, value, _ctx) {
-		await putSecret(name, value);
+		await putLocalSecret(name, value);
 	},
 	async delete(name, _ctx) {
-		return deleteSecret(name);
+		return deleteLocalSecret(name);
 	},
 	async resolve(ref, _ctx) {
 		const name = parseLocalSecretName(ref);

--- a/platform/daemon/src/secrets.ts
+++ b/platform/daemon/src/secrets.ts
@@ -20,6 +20,7 @@ import {
 	BITWARDEN_ACTIVE_PROVIDER_SECRET,
 	BITWARDEN_MANAGED_FOLDER_SECRET,
 	BITWARDEN_SESSION_SECRET,
+	buildBitwardenManagedSecretName,
 	deleteBitwardenSecret,
 	isBitwardenActiveProvider,
 	isBitwardenReference,
@@ -340,7 +341,10 @@ export async function getSecret(name: string): Promise<string> {
 	if (await isBitwardenProviderActive()) {
 		try {
 			const session = await getStoredSecret(BITWARDEN_SESSION_SECRET);
-			return readBitwardenReference(`bw://name/${encodeURIComponent(localName)}`, session);
+			return readBitwardenReference(
+				`bw://name/${encodeURIComponent(buildBitwardenManagedSecretName(localName))}`,
+				session,
+			);
 		} catch (error) {
 			if (!hasLocalSecret(localName)) throw error;
 		}

--- a/platform/daemon/src/secrets.ts
+++ b/platform/daemon/src/secrets.ts
@@ -98,6 +98,8 @@ const MAX_SECRET_EXEC_RUNNING_JOBS = 4;
 const MAX_SECRET_EXEC_QUEUED_JOBS = 64;
 const MAX_SECRET_EXEC_RETAINED_JOBS = MAX_SECRET_EXEC_RUNNING_JOBS + MAX_SECRET_EXEC_QUEUED_JOBS + 64;
 
+const BITWARDEN_DELETED_NAMES_SECRET = "BITWARDEN_DELETED_SECRET_NAMES";
+
 const secretExecJobs = new Map<string, SecretExecJob>();
 const pendingSecretExecJobs: string[] = [];
 const secretExecJobRequests = new Map<
@@ -313,6 +315,7 @@ export async function putSecret(name: string, value: string): Promise<void> {
 		folderId = undefined;
 	}
 	await putBitwardenSecret(localName, value, session, { folderId, overwrite: true });
+	await clearBitwardenDeletedName(localName);
 	recordSecretEvent("secret.stored", { name: localName, providerId: "bitwarden" });
 }
 
@@ -321,6 +324,43 @@ async function getStoredSecret(name: string): Promise<string> {
 	const entry = store.secrets[name];
 	if (!entry) throw new Error(`Secret '${name}' not found`);
 	return decrypt(entry.ciphertext);
+}
+
+function canonicalBitwardenDeletedName(name: string): string {
+	return buildBitwardenManagedSecretName(parseLocalSecretName(name));
+}
+
+async function readBitwardenDeletedNames(): Promise<Set<string>> {
+	try {
+		const parsed = JSON.parse(await getStoredSecret(BITWARDEN_DELETED_NAMES_SECRET));
+		return new Set(Array.isArray(parsed) ? parsed.filter((entry): entry is string => typeof entry === "string") : []);
+	} catch {
+		return new Set();
+	}
+}
+
+async function writeBitwardenDeletedNames(names: Set<string>): Promise<void> {
+	if (names.size === 0) {
+		deleteLocalSecret(BITWARDEN_DELETED_NAMES_SECRET);
+		return;
+	}
+	await putLocalSecret(BITWARDEN_DELETED_NAMES_SECRET, JSON.stringify(Array.from(names).sort()));
+}
+
+async function markBitwardenDeletedName(name: string): Promise<void> {
+	const names = await readBitwardenDeletedNames();
+	names.add(canonicalBitwardenDeletedName(name));
+	await writeBitwardenDeletedNames(names);
+}
+
+async function clearBitwardenDeletedName(name: string): Promise<void> {
+	const names = await readBitwardenDeletedNames();
+	if (!names.delete(canonicalBitwardenDeletedName(name))) return;
+	await writeBitwardenDeletedNames(names);
+}
+
+async function isBitwardenDeletedName(name: string): Promise<boolean> {
+	return (await readBitwardenDeletedNames()).has(canonicalBitwardenDeletedName(name));
 }
 
 export async function getSecret(name: string): Promise<string> {
@@ -346,7 +386,7 @@ export async function getSecret(name: string): Promise<string> {
 				session,
 			);
 		} catch (error) {
-			if (!hasLocalSecret(localName)) throw error;
+			if (!hasLocalSecret(localName) || (await isBitwardenDeletedName(localName))) throw error;
 		}
 	}
 
@@ -375,19 +415,21 @@ export async function listSecrets(): Promise<string[]> {
 		return localNames;
 	}
 
+	const deletedNames = await readBitwardenDeletedNames();
+	const visibleLocalNames = localNames.filter((name) => !deletedNames.has(canonicalBitwardenDeletedName(name)));
 	try {
 		const session = await getStoredSecret(BITWARDEN_SESSION_SECRET);
 		const bitwardenNames = await listBitwardenSecretNames(session);
-		const names = Array.from(new Set([...bitwardenNames, ...localNames])).sort((a, b) => a.localeCompare(b));
+		const names = Array.from(new Set([...bitwardenNames, ...visibleLocalNames])).sort((a, b) => a.localeCompare(b));
 		recordSecretEvent("secret.listed", { count: names.length, providerId: "bitwarden" });
 		return names;
 	} catch {
 		recordSecretEvent("secret.listed", {
-			count: localNames.length,
+			count: visibleLocalNames.length,
 			providerId: "local",
 			degradedProviderId: "bitwarden",
 		});
-		return localNames;
+		return visibleLocalNames;
 	}
 }
 
@@ -414,15 +456,18 @@ export async function deleteSecretFromActiveProvider(name: string): Promise<bool
 
 	const session = await getStoredSecret(BITWARDEN_SESSION_SECRET);
 	const deletedFromBitwarden = await deleteBitwardenSecret(localName, session);
-	const deletedFromLocal = deleteLocalSecret(localName);
+	const localFallbackPreserved = hasLocalSecret(localName);
+	if (deletedFromBitwarden || localFallbackPreserved) {
+		await markBitwardenDeletedName(localName);
+	}
 	if (deletedFromBitwarden) {
 		recordSecretEvent("secret.deleted", {
 			name: localName,
 			providerId: "bitwarden",
-			deletedLocalFallback: deletedFromLocal,
+			localFallbackPreserved,
 		});
 	}
-	return deletedFromBitwarden || deletedFromLocal;
+	return deletedFromBitwarden || localFallbackPreserved;
 }
 
 export async function getLocalSecretValue(name: string): Promise<string> {
@@ -459,6 +504,7 @@ function isInternalSecretName(name: string): boolean {
 		BITWARDEN_SESSION_SECRET,
 		BITWARDEN_ACTIVE_PROVIDER_SECRET,
 		BITWARDEN_MANAGED_FOLDER_SECRET,
+		BITWARDEN_DELETED_NAMES_SECRET,
 	].includes(name);
 }
 

--- a/platform/daemon/src/secrets.ts
+++ b/platform/daemon/src/secrets.ts
@@ -406,16 +406,23 @@ export function deleteSecret(name: string): boolean {
 }
 
 export async function deleteSecretFromActiveProvider(name: string): Promise<boolean> {
+	const explicitLocal = name.startsWith("local://");
 	const localName = parseLocalSecretName(name);
-	if (!isInternalSecretName(localName) && (await isBitwardenProviderActive())) {
-		const session = await getStoredSecret(BITWARDEN_SESSION_SECRET);
-		const deleted = await deleteBitwardenSecret(localName, session);
-		if (deleted) {
-			recordSecretEvent("secret.deleted", { name: localName, providerId: "bitwarden" });
-			return true;
-		}
+	if (explicitLocal || isInternalSecretName(localName) || !(await isBitwardenProviderActive())) {
+		return deleteLocalSecret(localName);
 	}
-	return deleteLocalSecret(localName);
+
+	const session = await getStoredSecret(BITWARDEN_SESSION_SECRET);
+	const deletedFromBitwarden = await deleteBitwardenSecret(localName, session);
+	const deletedFromLocal = deleteLocalSecret(localName);
+	if (deletedFromBitwarden) {
+		recordSecretEvent("secret.deleted", {
+			name: localName,
+			providerId: "bitwarden",
+			deletedLocalFallback: deletedFromLocal,
+		});
+	}
+	return deletedFromBitwarden || deletedFromLocal;
 }
 
 export async function getLocalSecretValue(name: string): Promise<string> {

--- a/surfaces/cli/src/commands/secret.ts
+++ b/surfaces/cli/src/commands/secret.ts
@@ -400,6 +400,180 @@ export function registerSecretCommands(program: Command, deps: SecretDeps): void
 				process.exit(1);
 			}
 		});
+
+	const bitwardenCmd = secretCmd.command("bitwarden").alias("bw").description("Manage Bitwarden integration");
+
+	bitwardenCmd
+		.command("connect [session]")
+		.description("Connect Bitwarden using a `bw unlock --raw` session token")
+		.option("--activate", "Use Bitwarden as the active Signet secrets provider after connecting", false)
+		.option("--folder <folderId>", "Folder id for Signet-managed Bitwarden items")
+		.action(async (rawSession: string | undefined, options: { activate: boolean; folder?: string }) => {
+			if (!(await deps.ensureDaemonForSecrets())) return;
+			const session =
+				rawSession ?? (await password({ message: "Bitwarden session token (`bw unlock --raw`):", mask: "•" }));
+			if (!session) {
+				console.error(chalk.red("  Session token cannot be empty"));
+				process.exit(1);
+			}
+			const spinner = ora("Connecting to Bitwarden...").start();
+			try {
+				const { ok, data } = await deps.secretApiCall("POST", "/api/secrets/bitwarden/connect", {
+					session,
+					activate: options.activate,
+					folderId: options.folder,
+				});
+				if (!ok) {
+					spinner.fail(chalk.red(`Failed: ${readError(data)}`));
+					process.exit(1);
+				}
+				const connected = readBoolean(data, "connected");
+				const active = readBoolean(data, "activeProvider");
+				spinner.succeed(
+					chalk.green(
+						`Bitwarden connected${active ? " and active" : ""}${connected ? "" : " (session saved, status degraded)"}`,
+					),
+				);
+			} catch (err) {
+				spinner.fail(chalk.red(`Error: ${readThrown(err)}`));
+				process.exit(1);
+			}
+		});
+
+	bitwardenCmd
+		.command("status")
+		.description("Show Bitwarden connection and provider status")
+		.action(async () => {
+			if (!(await deps.ensureDaemonForSecrets())) return;
+			try {
+				const { ok, data } = await deps.secretApiCall("GET", "/api/secrets/bitwarden/status");
+				if (!ok) {
+					console.error(chalk.red(`  Error: ${readError(data)}`));
+					process.exit(1);
+				}
+				const configured = readBoolean(data, "configured");
+				const connected = readBoolean(data, "connected");
+				const active = readBoolean(data, "activeProvider");
+				const error = readString(data, "error");
+				if (!configured) {
+					console.log(chalk.dim("  Bitwarden is not connected."));
+					console.log(chalk.dim('  Run: bw login && signet secret bitwarden connect "$(bw unlock --raw)"'));
+					return;
+				}
+				console.log(
+					connected
+						? chalk.green("  Connected to Bitwarden")
+						: chalk.yellow("  Bitwarden session is configured but not usable."),
+				);
+				console.log(chalk.dim(`  Active provider: ${active ? "bitwarden" : "local"}`));
+				if (error) console.log(chalk.dim(`  ${error}`));
+			} catch (err) {
+				console.error(chalk.red(`  Error: ${readThrown(err)}`));
+				process.exit(1);
+			}
+		});
+
+	bitwardenCmd
+		.command("use <provider>")
+		.description("Switch active Signet secret provider: local or bitwarden")
+		.action(async (provider: string) => {
+			if (!(await deps.ensureDaemonForSecrets())) return;
+			if (provider !== "local" && provider !== "bitwarden") {
+				console.error(chalk.red("  Provider must be 'local' or 'bitwarden'."));
+				process.exit(1);
+			}
+			const { ok, data } = await deps.secretApiCall("POST", "/api/secrets/bitwarden/provider", { provider });
+			if (!ok) {
+				console.error(chalk.red(`  Error: ${readError(data)}`));
+				process.exit(1);
+			}
+			console.log(chalk.green(`  Active secret provider: ${provider}`));
+		});
+
+	bitwardenCmd
+		.command("folders")
+		.description("List Bitwarden folders")
+		.action(async () => {
+			if (!(await deps.ensureDaemonForSecrets())) return;
+			const { ok, data } = await deps.secretApiCall("GET", "/api/secrets/bitwarden/folders");
+			if (!ok) {
+				console.error(chalk.red(`  Error: ${readError(data)}`));
+				process.exit(1);
+			}
+			for (const folder of readFolders(data)) {
+				console.log(`  ${chalk.cyan("◈")} ${folder.name} ${chalk.dim(`(${folder.id})`)}`);
+			}
+		});
+
+	bitwardenCmd
+		.command("migrate")
+		.description("Copy existing local Signet secrets into Bitwarden")
+		.option("--write", "Actually migrate. Without this, Signet performs a dry run", false)
+		.option("--delete-local", "Delete local copies after successful migration", false)
+		.option("--overwrite", "Overwrite existing Bitwarden items with the same name", false)
+		.option("--folder <folderId>", "Bitwarden folder id to place migrated secrets in")
+		.action(async (options: { write: boolean; deleteLocal: boolean; overwrite: boolean; folder?: string }) => {
+			if (!(await deps.ensureDaemonForSecrets())) return;
+			if (options.deleteLocal && !options.write) {
+				console.error(chalk.red("  --delete-local requires --write."));
+				process.exit(1);
+			}
+			if (options.deleteLocal) {
+				const confirmed = await confirm({
+					message: "Delete local Signet copies after migrating to Bitwarden?",
+					default: false,
+				});
+				if (!confirmed) return;
+			}
+			const spinner = ora(
+				options.write ? "Migrating local secrets to Bitwarden..." : "Dry-running Bitwarden migration...",
+			).start();
+			try {
+				const { ok, data } = await deps.secretApiCall("POST", "/api/secrets/bitwarden/migrate", {
+					dryRun: !options.write,
+					deleteLocal: options.deleteLocal,
+					overwrite: options.overwrite,
+					folderId: options.folder,
+				});
+				if (!ok) {
+					spinner.fail(chalk.red(`Failed: ${readError(data)}`));
+					process.exit(1);
+				}
+				const migrated = readNumber(data, "migratedCount") ?? 0;
+				const skipped = readNumber(data, "skippedCount") ?? 0;
+				const errors = readNumber(data, "errorCount") ?? 0;
+				spinner.succeed(
+					chalk.green(
+						`${options.write ? "Migrated" : "Would migrate"} ${migrated} secrets (skipped ${skipped}, errors ${errors})`,
+					),
+				);
+				if (!options.write) console.log(chalk.dim("  Re-run with --write to copy secrets into Bitwarden."));
+			} catch (err) {
+				spinner.fail(chalk.red(`Error: ${readThrown(err)}`));
+				process.exit(1);
+			}
+		});
+
+	bitwardenCmd
+		.command("disconnect")
+		.description("Disconnect Bitwarden and return to the local Signet secret provider")
+		.action(async () => {
+			if (!(await deps.ensureDaemonForSecrets())) return;
+			const confirmed = await confirm({ message: "Disconnect Bitwarden integration?", default: false });
+			if (!confirmed) return;
+			const spinner = ora("Disconnecting Bitwarden...").start();
+			try {
+				const { ok, data } = await deps.secretApiCall("DELETE", "/api/secrets/bitwarden/connect");
+				if (!ok) {
+					spinner.fail(chalk.red(`Failed: ${readError(data)}`));
+					process.exit(1);
+				}
+				spinner.succeed(chalk.green("Bitwarden disconnected; local Signet secrets remain available"));
+			} catch (err) {
+				spinner.fail(chalk.red(`Error: ${readThrown(err)}`));
+				process.exit(1);
+			}
+		});
 }
 
 function readRecord(data: unknown): Record<string, unknown> | null {
@@ -437,6 +611,17 @@ function readStringArray(data: unknown, key: string): string[] {
 
 function readVaults(data: unknown): Array<{ id: string; name: string }> {
 	const value = readRecord(data)?.vaults;
+	if (!Array.isArray(value)) return [];
+	return value.flatMap((item) => {
+		const record = readRecord(item);
+		const id = typeof record?.id === "string" ? record.id : null;
+		const name = typeof record?.name === "string" ? record.name : null;
+		return id && name ? [{ id, name }] : [];
+	});
+}
+
+function readFolders(data: unknown): Array<{ id: string; name: string }> {
+	const value = readRecord(data)?.folders;
 	if (!Array.isArray(value)) return [];
 	return value.flatMap((item) => {
 		const record = readRecord(item);

--- a/surfaces/cli/src/commands/secret.ts
+++ b/surfaces/cli/src/commands/secret.ts
@@ -20,6 +20,14 @@ function append(value: string, previous: string[]): string[] {
 	return [...previous, value];
 }
 
+async function readSecretFromStdin(): Promise<string> {
+	const chunks: Buffer[] = [];
+	for await (const chunk of process.stdin) {
+		chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+	}
+	return Buffer.concat(chunks).toString("utf-8").trim();
+}
+
 export function registerSecretCommands(program: Command, deps: SecretDeps): void {
 	const secretCmd = program.command("secret").description("Manage encrypted secrets").enablePositionalOptions();
 
@@ -404,14 +412,17 @@ export function registerSecretCommands(program: Command, deps: SecretDeps): void
 	const bitwardenCmd = secretCmd.command("bitwarden").alias("bw").description("Manage Bitwarden integration");
 
 	bitwardenCmd
-		.command("connect [session]")
+		.command("connect")
+		.allowExcessArguments(false)
 		.description("Connect Bitwarden using a `bw unlock --raw` session token")
 		.option("--activate", "Use Bitwarden as the active Signet secrets provider after connecting", false)
 		.option("--folder <folderId>", "Folder id for Signet-managed Bitwarden items")
-		.action(async (rawSession: string | undefined, options: { activate: boolean; folder?: string }) => {
+		.option("--session-stdin", "Read the Bitwarden session token from stdin instead of prompting", false)
+		.action(async (options: { activate: boolean; folder?: string; sessionStdin: boolean }) => {
 			if (!(await deps.ensureDaemonForSecrets())) return;
-			const session =
-				rawSession ?? (await password({ message: "Bitwarden session token (`bw unlock --raw`):", mask: "•" }));
+			const session = options.sessionStdin
+				? await readSecretFromStdin()
+				: await password({ message: "Bitwarden session token (`bw unlock --raw`):", mask: "•" });
 			if (!session) {
 				console.error(chalk.red("  Session token cannot be empty"));
 				process.exit(1);
@@ -457,7 +468,9 @@ export function registerSecretCommands(program: Command, deps: SecretDeps): void
 				const error = readString(data, "error");
 				if (!configured) {
 					console.log(chalk.dim("  Bitwarden is not connected."));
-					console.log(chalk.dim('  Run: bw login && signet secret bitwarden connect "$(bw unlock --raw)"'));
+					console.log(
+						chalk.dim("  Run: bw login && bw unlock --raw | signet secret bitwarden connect --session-stdin"),
+					);
 					return;
 				}
 				console.log(


### PR DESCRIPTION
## Summary

- Adds an opt-in Bitwarden-backed Signet Secrets provider using the official `bw` CLI session model (`bw login` + `bw unlock --raw`).
- Keeps the existing local encrypted `secrets.enc` store as the default/backwards-compatible provider; internal provider metadata stays local so Bitwarden does not become a circular dependency.
- Allows switching active providers at any time (`local` ↔ `bitwarden`), with bare secret names resolving through Bitwarden first when active and falling back to local Signet secrets for compatibility.
- Adds migration support to copy existing local Signet secrets into Bitwarden, defaulting to dry-run and optionally deleting local copies only after successful per-secret migration.
- Wires the integration through daemon API routes, CLI commands, SDK types/client methods, MCP secret-reference wording, plugin manifest capabilities/surfaces, docs, and prompt-context secret listing.
- Hardens setup so invalid/locked Bitwarden sessions are rejected before persistence or activation.
- Clears stale managed-folder metadata on reconnect when no folder is supplied, avoiding writes to an old Bitwarden folder.
- Pipes Bitwarden create/edit item payloads over stdin so secret-bearing encoded JSON does not appear in process argv.
- Canonicalizes active-provider bare-name reads the same way writes/migrations do, preserving compatibility for lowercase names such as `anthropic_key`.
- Reports the actual current provider state when Bitwarden connect validation fails, instead of echoing the requested activation flag.
- Preserves already-valid local secret names as Bitwarden item names, avoiding case-collisions such as `foo` and `FOO` while still normalizing legacy invalid names.

## User-facing flow

```bash
bw login
BW_SESSION=$(bw unlock --raw)
signet secret bitwarden connect "$BW_SESSION" --activate
signet secret bitwarden migrate          # dry run
signet secret bitwarden migrate --write  # copy local Signet secrets into Bitwarden
signet secret bitwarden use local        # switch back any time
```

## Safety / compatibility notes

- Local Signet secrets remain the default until the user explicitly activates Bitwarden.
- Provider credentials/config (`BITWARDEN_SESSION`, active-provider marker, managed folder id) are always stored in local Signet secrets.
- Existing `local://...`, bare names, queued secret exec, and 1Password `op://...` support continue to work.
- Explicit Bitwarden refs are supported as `bw://name/NAME` and `bw://item/ITEM_ID/password`.
- When Bitwarden is active, listing merges Bitwarden item names with existing local names and degrades to local-only if Bitwarden is temporarily unavailable.

## Test plan

- `bunx biome check platform/daemon/src/hooks.ts platform/daemon/src/bitwarden.ts platform/daemon/src/bitwarden.test.ts platform/daemon/src/secrets.ts platform/daemon/src/secrets.test.ts platform/daemon/src/routes/secrets-routes.ts platform/daemon/src/routes/secrets-routes.test.ts platform/daemon/src/mcp/tools.ts platform/daemon/src/plugins/bundled/secrets.ts surfaces/cli/src/commands/secret.ts libs/sdk/src/index.ts libs/sdk/src/types.ts`
- `bun test platform/daemon/src/bitwarden.test.ts platform/daemon/src/secrets.test.ts platform/daemon/src/routes/secrets-routes.test.ts surfaces/cli/src/lib/daemon.test.ts` — 39 pass, 0 fail, 149 expect() calls
- `bun run --filter @signet/daemon build`
- `bun run --filter @signet/cli build`
- `bun run --filter @signet/sdk build`
- `git diff --check`
- `grep -R --line-number -- '--session' platform/daemon/src/bitwarden.ts` returns no matches; Bitwarden session is passed through `BW_SESSION` child env, not process argv.
- `grep -R --line-number 'encoded.trim()]' platform/daemon/src/bitwarden.ts` returns no matches; Bitwarden item payloads containing secret values are piped on stdin, not process argv.

## Readiness checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally
