### PR TITLE
feat(daemon): daily reflections with dashboard card

### DIFF
--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -53,6 +53,7 @@ export type {
 	PipelineGraphConfig,
 	PipelineTraversalConfig,
 	PipelineRerankerConfig,
+	PipelineReflectionsConfig,
 	PipelineAutonomousConfig,
 	PipelineRepairConfig,
 	PipelineDocumentsConfig,

--- a/platform/core/src/migrations/068-daily-reflections.ts
+++ b/platform/core/src/migrations/068-daily-reflections.ts
@@ -24,7 +24,7 @@ export function up(db: MigrationDb): void {
 			answered_at      TEXT
 		);
 
-		CREATE INDEX IF NOT EXISTS idx_daily_reflections_agent_date
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_daily_reflections_agent_date
 			ON daily_reflections(agent_id, date);
 	`);
 }

--- a/platform/core/src/migrations/068-daily-reflections.ts
+++ b/platform/core/src/migrations/068-daily-reflections.ts
@@ -1,0 +1,30 @@
+import type { MigrationDb } from "./index";
+
+/**
+ * Migration 068: Daily reflections.
+ *
+ * Stores generated daily narrative insights and user answers.
+ * Each row represents one day's reflection for one agent.
+ */
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS daily_reflections (
+			id               TEXT PRIMARY KEY,
+			agent_id         TEXT NOT NULL DEFAULT 'default',
+			date             TEXT NOT NULL,
+			summary          TEXT NOT NULL DEFAULT '',
+			patterns         TEXT NOT NULL DEFAULT '[]',
+			question         TEXT,
+			answer           TEXT,
+			answer_memory_id TEXT,
+			memory_ids       TEXT NOT NULL DEFAULT '[]',
+			summary_ids      TEXT NOT NULL DEFAULT '[]',
+			model            TEXT,
+			created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+			answered_at      TEXT
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_daily_reflections_agent_date
+			ON daily_reflections(agent_id, date);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -73,6 +73,7 @@ import { up as sourceGraphProvenance } from "./064-source-graph-provenance";
 import { up as sourceEmbeddingAgentScope } from "./065-source-embedding-agent-scope";
 import { up as memorySearchTelemetry } from "./066-memory-search-telemetry";
 import { up as ontologyProposals } from "./067-ontology-proposals";
+import { up as dailyReflections } from "./068-daily-reflections";
 
 // -- Public interface consumed by Database.init() --
 
@@ -627,6 +628,14 @@ export const MIGRATIONS: readonly Migration[] = [
 				{ table: "entity_dependencies", column: "proposal_id" },
 				{ table: "entity_dependencies", column: "proposal_evidence" },
 			],
+		},
+	},
+	{
+		version: 68,
+		name: "daily-reflections",
+		up: dailyReflections,
+		artifacts: {
+			tables: ["daily_reflections"],
 		},
 	},
 ];

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -104,6 +104,21 @@ describe("migration framework", () => {
 		expect(uniqueVersions.size).toBe(migrations.length);
 	});
 
+	test("daily reflections are unique per agent and date", () => {
+		db = createFreshDb();
+		runMigrations(db);
+
+		const insert = db.prepare(
+			`INSERT INTO daily_reflections (id, agent_id, date, summary)
+			 VALUES (?, ?, ?, ?)`,
+		);
+
+		insert.run("reflection-1", "agent-a", "2026-05-13", "First");
+		expect(() => insert.run("reflection-2", "agent-a", "2026-05-13", "Duplicate")).toThrow();
+		expect(() => insert.run("reflection-3", "agent-b", "2026-05-13", "Different agent")).not.toThrow();
+		expect(() => insert.run("reflection-4", "agent-a", "2026-05-14", "Different date")).not.toThrow();
+	});
+
 	test("all expected tables exist after migration", () => {
 		db = createFreshDb();
 		runMigrations(db);
@@ -160,7 +175,6 @@ describe("migration framework", () => {
 		const attributeColumns = db.query("PRAGMA table_info(entity_attributes)").all() as Array<{ name: string }>;
 		expect(attributeColumns.map((col) => col.name)).toContain("claim_key");
 		expect(attributeColumns.map((col) => col.name)).toContain("group_key");
-
 
 		// v50 tables (dependency audit)
 		expect(tableNames).toContain("entity_dependency_history");

--- a/platform/core/src/types.ts
+++ b/platform/core/src/types.ts
@@ -368,6 +368,7 @@ export interface PipelineV2Config {
 	readonly writeGate?: PipelineWriteGateConfig;
 	readonly modelRegistry: PipelineModelRegistryConfig;
 	readonly hints?: PipelineHintsConfig;
+	readonly reflections: PipelineReflectionsConfig;
 }
 
 export interface ModelRegistryEntry {
@@ -460,6 +461,17 @@ export interface PipelineHintsConfig {
 	readonly timeout: number;
 	readonly maxTokens: number;
 	readonly poll: number;
+}
+
+export interface PipelineReflectionsConfig {
+	readonly enabled: boolean;
+	readonly model: string;
+	readonly timeout: number;
+	readonly maxTokens: number;
+	readonly schedule: string;
+	readonly timeWindowHours: number;
+	readonly maxMemories: number;
+	readonly maxSummaries: number;
 }
 
 export interface DreamingConfig {

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -136,6 +136,7 @@ import { mountOsAgentRoutes } from "./routes/os-agent.js";
 import { mountOsChatRoutes } from "./routes/os-chat.js";
 import { registerPipelineRoutes } from "./routes/pipeline-routes.js";
 import { registerPluginRoutes } from "./routes/plugins-routes.js";
+import { registerReflectionRoutes } from "./routes/reflection-routes.js";
 import { registerRepairRoutes } from "./routes/repair-routes.js";
 import { registerSecretRoutes } from "./routes/secrets-routes.js";
 import { registerSessionRoutes } from "./routes/session-routes.js";
@@ -195,6 +196,7 @@ registerSecretRoutes(app);
 registerSessionRoutes(app, { gitConfig, stopGitSyncTimer, startGitSyncTimer, getGitStatus, gitPull, gitPush, gitSync });
 registerSourcesRoutes(app);
 registerPipelineRoutes(app);
+registerReflectionRoutes(app);
 registerTelemetryRoutes(app);
 registerMiscRoutes(app);
 app.use("/api/inference", async (c, next) => {

--- a/platform/daemon/src/logger.ts
+++ b/platform/daemon/src/logger.ts
@@ -48,6 +48,7 @@ export type LogCategory =
 	| "predictor" // Predictive memory scorer
 	| "maintenance" // Autonomous maintenance worker
 	| "retention" // Retention worker (decay + cold archival)
+	| "reflections" // Daily reflection generation and writeback
 	| "summary-condensation" // Session summary DAG condensation
 	| "session-tracker" // Runtime-path session ownership + bypass TTL tracking
 	| "system" // System events

--- a/platform/daemon/src/memory-config.ts
+++ b/platform/daemon/src/memory-config.ts
@@ -246,6 +246,16 @@ export const DEFAULT_PIPELINE_V2: ResolvedPipelineV2Config = {
 		maxTokens: 256,
 		poll: 5000,
 	},
+	reflections: {
+		enabled: true,
+		model: "qwen3:4b",
+		timeout: 120000,
+		maxTokens: 4000,
+		schedule: "0 8 * * *",
+		timeWindowHours: 24,
+		maxMemories: 50,
+		maxSummaries: 10,
+	},
 };
 
 export const DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434";
@@ -419,6 +429,7 @@ export function loadPipelineConfig(yaml: Record<string, unknown>): ResolvedPipel
 	const writeGateRaw = raw.writeGate as Record<string, unknown> | undefined;
 	const modelRegistryRaw = raw.modelRegistry as Record<string, unknown> | undefined;
 	const hintsRaw = raw.hints as Record<string, unknown> | undefined;
+	const reflectionsRaw = raw.reflections as Record<string, unknown> | undefined;
 
 	// Helper: resolve with flat-fallback (non-extraction fields still nested-first)
 	const d = DEFAULT_PIPELINE_V2;
@@ -990,6 +1001,23 @@ export function loadPipelineConfig(yaml: Record<string, unknown>): ResolvedPipel
 			timeout: clampPositive(hintsRaw?.timeout, 5000, 120000, d.hints?.timeout ?? 60000),
 			maxTokens: clampPositive(hintsRaw?.maxTokens, 64, 1024, d.hints?.maxTokens ?? 256),
 			poll: clampPositive(hintsRaw?.poll, 1000, 60000, d.hints?.poll ?? 5000),
+		},
+
+		reflections: {
+			enabled: resolveBool(reflectionsRaw?.enabled, undefined, d.reflections.enabled),
+			model:
+				typeof reflectionsRaw?.model === "string" && reflectionsRaw.model.trim().length > 0
+					? reflectionsRaw.model
+					: d.reflections.model,
+			timeout: clampPositive(reflectionsRaw?.timeout, 5000, 300000, d.reflections.timeout),
+			maxTokens: clampPositive(reflectionsRaw?.maxTokens, 500, 16000, d.reflections.maxTokens),
+			schedule:
+				typeof reflectionsRaw?.schedule === "string" && reflectionsRaw.schedule.trim().length > 0
+					? reflectionsRaw.schedule
+					: d.reflections.schedule,
+			timeWindowHours: clampPositive(reflectionsRaw?.timeWindowHours, 1, 168, d.reflections.timeWindowHours),
+			maxMemories: clampPositive(reflectionsRaw?.maxMemories, 5, 500, d.reflections.maxMemories),
+			maxSummaries: clampPositive(reflectionsRaw?.maxSummaries, 1, 50, d.reflections.maxSummaries),
 		},
 	};
 }

--- a/platform/daemon/src/pipeline/index.ts
+++ b/platform/daemon/src/pipeline/index.ts
@@ -15,6 +15,7 @@ import { type DocumentWorkerHandle, startDocumentWorker } from "./document-worke
 import type { DreamingWorkerHandle } from "./dreaming-worker";
 import { type MaintenanceHandle, startMaintenanceWorker } from "./maintenance-worker";
 import { type HintsWorkerHandle, startHintsWorker } from "./prospective-index";
+import { type ReflectionWorkerHandle, startReflectionWorker } from "./reflection-worker";
 import {
 	DEFAULT_RETENTION,
 	type RetentionConfig,
@@ -80,6 +81,7 @@ let structuralDependencyHandle: StructuralDependencyHandle | null = null;
 let dependencySynthesisHandle: DependencySynthesisHandle | null = null;
 let hintsWorkerHandle: HintsWorkerHandle | null = null;
 let dreamingWorkerHandle: DreamingWorkerHandle | null = null;
+let reflectionWorkerHandle: ReflectionWorkerHandle | null = null;
 let pendingStartup: Promise<void> | null = null;
 
 /** Snapshot of running state for each worker — used by /api/pipeline/status */
@@ -99,6 +101,7 @@ export function getPipelineWorkerStatus(): Record<string, { running: boolean; st
 		dependencySynthesis: { running: dependencySynthesisHandle !== null },
 		hints: { running: hintsWorkerHandle !== null },
 		dreaming: { running: dreamingWorkerHandle !== null },
+		reflections: { running: reflectionWorkerHandle !== null },
 	};
 }
 
@@ -273,6 +276,11 @@ export function startPipeline(
 		hintsWorkerHandle = startHintsWorker({ accessor, provider, pipelineCfg });
 	}
 
+	// Daily reflections worker — periodic narrative insight generation
+	if (!reflectionWorkerHandle && pipelineCfg.reflections?.enabled) {
+		reflectionWorkerHandle = startReflectionWorker(pipelineCfg.reflections);
+	}
+
 	logger.info("pipeline", "Pipeline started", {
 		mode:
 			pipelineCfg.enabled && !pipelineCfg.shadowMode && !pipelineCfg.mutationsFrozen && !pipelineCfg.nativeShadowEnabled
@@ -286,6 +294,10 @@ export async function stopPipeline(): Promise<void> {
 	// before checking workerHandle — prevents orphan threads.
 	if (pendingStartup) {
 		await pendingStartup;
+	}
+	if (reflectionWorkerHandle) {
+		reflectionWorkerHandle.stop();
+		reflectionWorkerHandle = null;
 	}
 	if (hintsWorkerHandle) {
 		await hintsWorkerHandle.stop();

--- a/platform/daemon/src/pipeline/reflection-worker.test.ts
+++ b/platform/daemon/src/pipeline/reflection-worker.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { LlmProvider, PipelineReflectionsConfig } from "@signet/core";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
+import { logger } from "../logger";
+import { txIngestEnvelope } from "../transactions";
+import { nextReflectionDelayMs, startReflectionWorker } from "./reflection-worker";
+
+let dir: string;
+const previousSignetPath = process.env.SIGNET_PATH;
+
+const config: PipelineReflectionsConfig = {
+	enabled: true,
+	timeWindowHours: 24,
+	maxMemories: 10,
+	maxSummaries: 10,
+	schedule: "daily",
+	timeout: 1000,
+	maxTokens: 200,
+	model: "test-model",
+};
+
+function provider(text: string): LlmProvider {
+	return {
+		name: "test-provider",
+		async available(): Promise<boolean> {
+			return true;
+		},
+		async generate(): Promise<string> {
+			return text;
+		},
+	};
+}
+
+function seedMemory(agentId: string): string {
+	const now = new Date().toISOString();
+	const id = randomUUID();
+	getDbAccessor().withWriteTx((db) => {
+		txIngestEnvelope(db, {
+			id,
+			content: "The reflection worker needs durable persistence.",
+			contentHash: `worker-test-${agentId}`,
+			who: "tester",
+			why: "test-seed",
+			project: null,
+			importance: 0.5,
+			type: "fact",
+			tags: "test",
+			pinned: 0,
+			sourceType: "test",
+			sourceId: "reflection-worker.test",
+			agentId,
+			createdAt: now,
+		});
+	});
+	return id;
+}
+
+function seedReflection(agentId: string, date = new Date().toISOString().slice(0, 10)): string {
+	const id = randomUUID();
+	getDbAccessor().withWriteTx((db) => {
+		db.prepare(
+			`INSERT INTO daily_reflections
+			 (id, agent_id, date, summary, patterns, question, memory_ids, summary_ids, created_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(id, agentId, date, "Existing reflection", "[]", null, "[]", "[]", new Date().toISOString());
+	});
+	return id;
+}
+
+beforeEach(() => {
+	dir = join(tmpdir(), `signet-reflection-worker-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	mkdirSync(join(dir, "memory"), { recursive: true });
+	process.env.SIGNET_PATH = dir;
+	initDbAccessor(join(dir, "memory", "memories.db"));
+});
+
+afterEach(() => {
+	closeDbAccessor();
+	if (previousSignetPath === undefined) {
+		process.env.SIGNET_PATH = undefined;
+	} else {
+		process.env.SIGNET_PATH = previousSignetPath;
+	}
+	rmSync(dir, { recursive: true, force: true });
+});
+
+describe("reflection worker", () => {
+	it("uses cron-style daily schedule delays", () => {
+		expect(nextReflectionDelayMs("0 8 * * *", null, new Date(2026, 4, 13, 7, 30))).toBe(30 * 60 * 1000);
+		expect(nextReflectionDelayMs("0 8 * * *", null, new Date(2026, 4, 13, 8, 30))).toBe(300_000);
+		expect(nextReflectionDelayMs("0 8 * * *", "2026-05-13", new Date(2026, 4, 13, 8, 30))).toBe(23.5 * 60 * 60 * 1000);
+	});
+
+	it("does not mark the day complete when there is no source material", async () => {
+		const worker = startReflectionWorker(config, {
+			getDbAccessor,
+			getInferenceProvider: () => provider("SUMMARY: Should not run."),
+			logger,
+		});
+
+		try {
+			await worker.triggerNow();
+		} finally {
+			worker.stop();
+		}
+
+		expect(existsSync(join(dir, ".daemon", "last-reflection.default.json"))).toBe(false);
+	});
+
+	it("persists generated reflections and scoped question memories", async () => {
+		const memoryId = seedMemory("default");
+		const worker = startReflectionWorker(config, {
+			getDbAccessor,
+			getInferenceProvider: () =>
+				provider("SUMMARY: Worker persisted.\nPATTERNS: persistence\nQUESTION: Should we keep it?"),
+			logger,
+		});
+
+		try {
+			await worker.triggerNow();
+		} finally {
+			worker.stop();
+		}
+
+		const reflection = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT summary, model, memory_ids FROM daily_reflections WHERE agent_id = ?").get("default") as {
+					summary: string;
+					model: string;
+					memory_ids: string;
+				},
+		);
+		expect(reflection).toEqual({
+			summary: "Worker persisted.",
+			model: "test-model",
+			memory_ids: JSON.stringify([memoryId]),
+		});
+
+		const question = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT content, agent_id FROM memories WHERE source_type = ?").get("reflection-question") as {
+					content: string;
+					agent_id: string;
+				},
+		);
+		expect(question).toEqual({
+			content: "Daily reflection question: Should we keep it?",
+			agent_id: "default",
+		});
+	});
+
+	it("skips question ingestion when another writer wins the daily insert race", async () => {
+		seedMemory("default");
+		let inserted = false;
+		const worker = startReflectionWorker(config, {
+			getDbAccessor,
+			getInferenceProvider: () => ({
+				name: "racing-provider",
+				async available(): Promise<boolean> {
+					return true;
+				},
+				async generate(): Promise<string> {
+					if (!inserted) {
+						seedReflection("default");
+						inserted = true;
+					}
+					return "SUMMARY: Lost race.\nPATTERNS: race\nQUESTION: Should not ingest?";
+				},
+			}),
+			logger,
+		});
+
+		try {
+			await worker.triggerNow();
+		} finally {
+			worker.stop();
+		}
+
+		const counts = getDbAccessor().withReadDb((db) => ({
+			questions: (
+				db.prepare("SELECT COUNT(*) AS count FROM memories WHERE source_type = ?").get("reflection-question") as {
+					count: number;
+				}
+			).count,
+			reflections: (
+				db.prepare("SELECT COUNT(*) AS count FROM daily_reflections WHERE agent_id = ?").get("default") as {
+					count: number;
+				}
+			).count,
+		}));
+		expect(counts).toEqual({ questions: 0, reflections: 1 });
+		expect(existsSync(join(dir, ".daemon", "last-reflection.default.json"))).toBe(true);
+	});
+
+	it("scheduled trigger reflects every active agent instead of hardcoding default", async () => {
+		const memoryId = seedMemory("agent-c");
+		const worker = startReflectionWorker(config, {
+			getDbAccessor,
+			getInferenceProvider: () => provider("SUMMARY: Agent C reflection.\nPATTERNS: scoped\nQUESTION: Continue?"),
+			logger,
+		});
+
+		try {
+			await worker.triggerNow();
+		} finally {
+			worker.stop();
+		}
+
+		const rows = getDbAccessor().withReadDb((db) => {
+			return db.prepare("SELECT agent_id, memory_ids FROM daily_reflections ORDER BY agent_id").all() as {
+				agent_id: string;
+				memory_ids: string;
+			}[];
+		});
+		expect(rows).toEqual([{ agent_id: "agent-c", memory_ids: JSON.stringify([memoryId]) }]);
+		expect(existsSync(join(dir, ".daemon", "last-reflection.agent-c.json"))).toBe(true);
+	});
+});

--- a/platform/daemon/src/pipeline/reflection-worker.ts
+++ b/platform/daemon/src/pipeline/reflection-worker.ts
@@ -21,7 +21,8 @@ const DEFAULT_DEPS: ReflectionDeps = {
 };
 
 const POLL_INTERVAL_MS = 300_000;
-const STARTUP_DELAY_MS = 60_000;
+const MINUTE_MS = 60_000;
+const DAY_MS = 24 * 60 * MINUTE_MS;
 
 function getAgentsDir(): string {
 	return process.env.SIGNET_PATH || join(homedir(), ".agents");
@@ -55,8 +56,36 @@ function writeLastReflectionTime(agentId: string, date: string): void {
 	}
 }
 
-function todayDate(): string {
-	return new Date().toISOString().slice(0, 10);
+function todayDate(now = new Date()): string {
+	return now.toISOString().slice(0, 10);
+}
+
+function isDailyReflectionUniqueConflict(e: unknown): boolean {
+	const message = e instanceof Error ? e.message : String(e);
+	return message.toLowerCase().includes("unique") && message.includes("daily_reflections");
+}
+
+function scheduledTimeFor(schedule: string, now = new Date()): Date | null {
+	const parts = schedule.trim().split(/\s+/);
+	if (parts.length !== 5 || parts[2] !== "*" || parts[3] !== "*" || parts[4] !== "*") return null;
+	const minute = Number(parts[0]);
+	const hour = Number(parts[1]);
+	if (!Number.isInteger(minute) || !Number.isInteger(hour) || minute < 0 || minute > 59 || hour < 0 || hour > 23) {
+		return null;
+	}
+	const scheduled = new Date(now);
+	scheduled.setHours(hour, minute, 0, 0);
+	return scheduled;
+}
+
+export function nextReflectionDelayMs(schedule: string, lastDate: string | null, now = new Date()): number {
+	const scheduled = scheduledTimeFor(schedule, now);
+	if (!scheduled) return POLL_INTERVAL_MS;
+
+	const date = todayDate(now);
+	if (lastDate === date) return Math.max(0, scheduled.getTime() + DAY_MS - now.getTime());
+	if (now.getTime() < scheduled.getTime()) return Math.max(0, scheduled.getTime() - now.getTime());
+	return POLL_INTERVAL_MS;
 }
 
 export function buildReflectionPrompt(
@@ -92,9 +121,7 @@ export function buildReflectionPrompt(
 	return lines.join("\n");
 }
 
-export function parseReflectionResponse(
-	text: string,
-): { summary: string; patterns: string[]; question?: string } {
+export function parseReflectionResponse(text: string): { summary: string; patterns: string[]; question?: string } {
 	const summary = text.match(/SUMMARY:\s*(.+?)(?:\n|$)/)?.[1]?.trim() ?? text.slice(0, 500);
 	const patternsRaw = text.match(/PATTERNS:\s*(.+?)(?:\n|$)/)?.[1]?.trim() ?? "";
 	const patterns = patternsRaw
@@ -109,7 +136,7 @@ export function parseReflectionResponse(
 export interface ReflectionWorkerHandle {
 	stop(): void;
 	readonly running: boolean;
-	triggerNow(): Promise<void>;
+	triggerNow(agentId?: string): Promise<void>;
 }
 
 export function startReflectionWorker(
@@ -124,29 +151,34 @@ export function startReflectionWorker(
 	async function runReflection(agentId: string): Promise<void> {
 		const date = todayDate();
 		const existing = deps.getDbAccessor().withReadDb((db) => {
-			const row = db
-				.prepare("SELECT id FROM daily_reflections WHERE agent_id = ? AND date = ?")
-				.get(agentId, date) as { id: string } | undefined;
+			const row = db.prepare("SELECT id FROM daily_reflections WHERE agent_id = ? AND date = ?").get(agentId, date) as
+				| { id: string }
+				| undefined;
 			return row?.id ?? null;
 		});
-		if (existing) return;
+		if (existing) {
+			writeLastReflectionTime(agentId, date);
+			return;
+		}
 
 		const cutoff = new Date(Date.now() - config.timeWindowHours * 60 * 60 * 1000).toISOString();
 
 		const memories = deps.getDbAccessor().withReadDb((db) => {
 			const rows = db
 				.prepare(
-					`SELECT content, type, tags, created_at FROM memories
+					`SELECT id, content, type, tags, created_at FROM memories
            WHERE agent_id = ? AND created_at >= ? AND is_deleted = 0
            ORDER BY created_at DESC LIMIT ?`,
 				)
 				.all(agentId, cutoff, config.maxMemories) as {
+				id: string;
 				content: string;
 				type: string;
 				tags: string;
 				created_at: string;
 			}[];
 			return rows.map((r) => ({
+				id: r.id,
 				content: r.content,
 				type: r.type,
 				tags: r.tags ?? "",
@@ -157,20 +189,20 @@ export function startReflectionWorker(
 		const summaries = deps.getDbAccessor().withReadDb((db) => {
 			const rows = db
 				.prepare(
-					`SELECT content, created_at FROM session_summaries
+					`SELECT id, content, created_at FROM session_summaries
            WHERE agent_id = ? AND created_at >= ?
            ORDER BY created_at DESC LIMIT ?`,
 				)
 				.all(agentId, cutoff, config.maxSummaries) as {
+				id: string;
 				content: string;
 				created_at: string;
 			}[];
-			return rows.map((r) => ({ content: r.content, createdAt: r.created_at }));
+			return rows.map((r) => ({ id: r.id, content: r.content, createdAt: r.created_at }));
 		});
 
 		if (memories.length === 0 && summaries.length === 0) {
 			deps.logger.debug("reflections", "No memories or summaries to reflect on", { agentId, date });
-			writeLastReflectionTime(agentId, date);
 			return;
 		}
 
@@ -194,45 +226,55 @@ export function startReflectionWorker(
 		const { summary, patterns, question } = parseReflectionResponse(raw);
 
 		const id = randomUUID();
-		const memoryIds = JSON.stringify(memories.map((m) => m.content.slice(0, 40)));
-		const summaryIds = JSON.stringify(summaries.map((s) => s.createdAt));
+		const memoryIds = JSON.stringify(memories.map((m) => m.id));
+		const summaryIds = JSON.stringify(summaries.map((s) => s.id));
 		const now = new Date().toISOString();
 
-		deps.getDbAccessor().withWriteTx((db) => {
-			db.exec(
-				`INSERT INTO daily_reflections (id, agent_id, date, summary, patterns, question, memory_ids, summary_ids, model, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-				id,
-				agentId,
-				date,
-				summary,
-				JSON.stringify(patterns),
-				question ?? null,
-				memoryIds,
-				summaryIds,
-				config.model,
-				now,
-			);
-		});
-
-		if (question) {
+		try {
 			deps.getDbAccessor().withWriteTx((db) => {
-				txIngestEnvelope(db, {
-					id: randomUUID(),
-					content: `Daily reflection question: ${question}`,
-					contentHash: `reflection-q-${id}`,
-					who: "system",
-					why: "daily-reflection-question",
-					project: null,
-					importance: 0.5,
-					type: "reflection",
-					tags: "reflection,unanswered",
-					pinned: 0,
-					sourceType: "reflection-question",
-					sourceId: id,
-					createdAt: now,
-				});
+				db.prepare(
+					`INSERT INTO daily_reflections
+					 (id, agent_id, date, summary, patterns, question, memory_ids, summary_ids, model, created_at)
+					 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				).run(
+					id,
+					agentId,
+					date,
+					summary,
+					JSON.stringify(patterns),
+					question ?? null,
+					memoryIds,
+					summaryIds,
+					config.model,
+					now,
+				);
+
+				if (question) {
+					txIngestEnvelope(db, {
+						id: randomUUID(),
+						content: `Daily reflection question: ${question}`,
+						contentHash: `reflection-q-${id}`,
+						who: "system",
+						why: "daily-reflection-question",
+						project: null,
+						importance: 0.5,
+						type: "reflection",
+						tags: "reflection,unanswered",
+						pinned: 0,
+						sourceType: "reflection-question",
+						sourceId: id,
+						agentId,
+						createdAt: now,
+					});
+				}
 			});
+		} catch (e) {
+			if (isDailyReflectionUniqueConflict(e)) {
+				deps.logger.debug("reflections", "Reflection already generated before worker insert", { agentId, date });
+				writeLastReflectionTime(agentId, date);
+				return;
+			}
+			throw e;
 		}
 
 		writeLastReflectionTime(agentId, date);
@@ -245,19 +287,48 @@ export function startReflectionWorker(
 		});
 	}
 
+	function listActiveAgentIds(): string[] {
+		const cutoff = new Date(Date.now() - config.timeWindowHours * 60 * 60 * 1000).toISOString();
+		const rows = deps.getDbAccessor().withReadDb((db) => {
+			return db
+				.prepare(
+					`SELECT DISTINCT agent_id FROM memories
+					 WHERE created_at >= ? AND is_deleted = 0
+					 UNION
+					 SELECT DISTINCT agent_id FROM session_summaries
+					 WHERE created_at >= ?`,
+				)
+				.all(cutoff, cutoff) as { agent_id: string | null }[];
+		});
+		const agentIds = rows.map((row) => row.agent_id).filter((agentId): agentId is string => !!agentId);
+		return agentIds.length > 0 ? agentIds : ["default"];
+	}
+
+	async function runDueAgents(): Promise<void> {
+		const date = todayDate();
+		for (const agentId of listActiveAgentIds()) {
+			const lastDate = readLastReflectionTime(agentId);
+			if (lastDate !== date && nextReflectionDelayMs(config.schedule, lastDate) === POLL_INTERVAL_MS) {
+				await runReflection(agentId);
+			}
+		}
+	}
+
+	function nextWorkerDelayMs(): number {
+		return Math.min(
+			...listActiveAgentIds().map((agentId) => nextReflectionDelayMs(config.schedule, readLastReflectionTime(agentId))),
+		);
+	}
+
 	async function tick(): Promise<void> {
 		if (stopped || generating) return;
 		generating = true;
 		try {
-			const date = todayDate();
-			const lastDate = readLastReflectionTime("default");
-			if (lastDate !== date) {
-				await runReflection("default");
-			}
+			await runDueAgents();
 		} finally {
 			generating = false;
 			if (!stopped) {
-				timer = setTimeout(tick, POLL_INTERVAL_MS);
+				timer = setTimeout(tick, nextWorkerDelayMs());
 			}
 		}
 	}
@@ -265,7 +336,7 @@ export function startReflectionWorker(
 	function start(): void {
 		if (running) return;
 		running = true;
-		timer = setTimeout(tick, STARTUP_DELAY_MS);
+		timer = setTimeout(tick, nextWorkerDelayMs());
 	}
 
 	function stop(): void {
@@ -284,8 +355,12 @@ export function startReflectionWorker(
 		get running() {
 			return running;
 		},
-		async triggerNow() {
-			await runReflection("default");
+		async triggerNow(agentId?: string) {
+			if (agentId) {
+				await runReflection(agentId);
+				return;
+			}
+			await runDueAgents();
 		},
 	};
 }

--- a/platform/daemon/src/pipeline/reflection-worker.ts
+++ b/platform/daemon/src/pipeline/reflection-worker.ts
@@ -1,0 +1,291 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { PipelineReflectionsConfig } from "@signet/core";
+import { getDbAccessor } from "../db-accessor";
+import { getInferenceProvider } from "../llm";
+import { logger } from "../logger";
+import { txIngestEnvelope } from "../transactions";
+
+type ReflectionDeps = {
+	readonly getDbAccessor: typeof getDbAccessor;
+	readonly getInferenceProvider: typeof getInferenceProvider;
+	readonly logger: typeof logger;
+};
+
+const DEFAULT_DEPS: ReflectionDeps = {
+	getDbAccessor,
+	getInferenceProvider,
+	logger,
+};
+
+const POLL_INTERVAL_MS = 300_000;
+const STARTUP_DELAY_MS = 60_000;
+
+function getAgentsDir(): string {
+	return process.env.SIGNET_PATH || join(homedir(), ".agents");
+}
+
+function getLastReflectionPath(agentId: string): string {
+	const key = agentId === "default" ? "default" : encodeURIComponent(agentId);
+	return join(getAgentsDir(), ".daemon", `last-reflection.${key}.json`);
+}
+
+function readLastReflectionTime(agentId: string): string | null {
+	try {
+		const path = getLastReflectionPath(agentId);
+		if (!existsSync(path)) return null;
+		const data = JSON.parse(readFileSync(path, "utf-8"));
+		return typeof data.lastDate === "string" ? data.lastDate : null;
+	} catch {
+		return null;
+	}
+}
+
+function writeLastReflectionTime(agentId: string, date: string): void {
+	try {
+		const dir = join(getAgentsDir(), ".daemon");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(getLastReflectionPath(agentId), JSON.stringify({ lastDate: date }));
+	} catch (e) {
+		logger.warn("reflections", "Failed to persist reflection timestamp", {
+			error: e instanceof Error ? e.message : String(e),
+		});
+	}
+}
+
+function todayDate(): string {
+	return new Date().toISOString().slice(0, 10);
+}
+
+export function buildReflectionPrompt(
+	memories: { content: string; type: string; tags: string; createdAt: string }[],
+	summaries: { content: string; createdAt: string }[],
+): string {
+	const lines: string[] = [
+		"You are a thoughtful assistant reviewing the last 24 hours of activity.",
+		"Your task is to produce a daily reflection in the following format:",
+		"",
+		"SUMMARY: <2-3 sentence narrative of what the user worked on>",
+		"PATTERNS: <comma-separated list of themes or patterns noticed>",
+		"QUESTION: <optional - a specific question that only makes sense because you were watching. If nothing worth asking, omit this line>",
+		"",
+		"Keep the summary concrete and specific. The question should be about something the user",
+		"might want to act on or think about. If nothing stands out, just provide the summary.",
+		"",
+		"Recent memories:",
+	];
+
+	for (const m of memories) {
+		const date = m.createdAt.slice(0, 10);
+		lines.push(`  [${date}] (${m.type}) ${m.tags ? `[${m.tags}] ` : ""}${m.content}`);
+	}
+
+	if (summaries.length > 0) {
+		lines.push("", "Recent session summaries:");
+		for (const s of summaries) {
+			lines.push(`  [${s.createdAt.slice(0, 10)}] ${s.content.slice(0, 500)}`);
+		}
+	}
+
+	return lines.join("\n");
+}
+
+export function parseReflectionResponse(
+	text: string,
+): { summary: string; patterns: string[]; question?: string } {
+	const summary = text.match(/SUMMARY:\s*(.+?)(?:\n|$)/)?.[1]?.trim() ?? text.slice(0, 500);
+	const patternsRaw = text.match(/PATTERNS:\s*(.+?)(?:\n|$)/)?.[1]?.trim() ?? "";
+	const patterns = patternsRaw
+		.split(",")
+		.map((p) => p.trim())
+		.filter(Boolean);
+	const question = text.match(/QUESTION:\s*(.+?)(?:\n|$)/)?.[1]?.trim();
+
+	return { summary, patterns, question };
+}
+
+export interface ReflectionWorkerHandle {
+	stop(): void;
+	readonly running: boolean;
+	triggerNow(): Promise<void>;
+}
+
+export function startReflectionWorker(
+	config: PipelineReflectionsConfig,
+	deps: ReflectionDeps = DEFAULT_DEPS,
+): ReflectionWorkerHandle {
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	let stopped = false;
+	let running = false;
+	let generating = false;
+
+	async function runReflection(agentId: string): Promise<void> {
+		const date = todayDate();
+		const existing = deps.getDbAccessor().withReadDb((db) => {
+			const row = db
+				.prepare("SELECT id FROM daily_reflections WHERE agent_id = ? AND date = ?")
+				.get(agentId, date) as { id: string } | undefined;
+			return row?.id ?? null;
+		});
+		if (existing) return;
+
+		const cutoff = new Date(Date.now() - config.timeWindowHours * 60 * 60 * 1000).toISOString();
+
+		const memories = deps.getDbAccessor().withReadDb((db) => {
+			const rows = db
+				.prepare(
+					`SELECT content, type, tags, created_at FROM memories
+           WHERE agent_id = ? AND created_at >= ? AND is_deleted = 0
+           ORDER BY created_at DESC LIMIT ?`,
+				)
+				.all(agentId, cutoff, config.maxMemories) as {
+				content: string;
+				type: string;
+				tags: string;
+				created_at: string;
+			}[];
+			return rows.map((r) => ({
+				content: r.content,
+				type: r.type,
+				tags: r.tags ?? "",
+				createdAt: r.created_at,
+			}));
+		});
+
+		const summaries = deps.getDbAccessor().withReadDb((db) => {
+			const rows = db
+				.prepare(
+					`SELECT content, created_at FROM session_summaries
+           WHERE agent_id = ? AND created_at >= ?
+           ORDER BY created_at DESC LIMIT ?`,
+				)
+				.all(agentId, cutoff, config.maxSummaries) as {
+				content: string;
+				created_at: string;
+			}[];
+			return rows.map((r) => ({ content: r.content, createdAt: r.created_at }));
+		});
+
+		if (memories.length === 0 && summaries.length === 0) {
+			deps.logger.debug("reflections", "No memories or summaries to reflect on", { agentId, date });
+			writeLastReflectionTime(agentId, date);
+			return;
+		}
+
+		const prompt = buildReflectionPrompt(memories, summaries);
+
+		let raw: string;
+		try {
+			const provider = deps.getInferenceProvider("default");
+			raw = await provider.generate(prompt, {
+				timeoutMs: config.timeout,
+				maxTokens: config.maxTokens,
+			});
+		} catch (e) {
+			deps.logger.warn("reflections", "Generation failed", {
+				error: e instanceof Error ? e.message : String(e),
+				agentId,
+			});
+			return;
+		}
+
+		const { summary, patterns, question } = parseReflectionResponse(raw);
+
+		const id = randomUUID();
+		const memoryIds = JSON.stringify(memories.map((m) => m.content.slice(0, 40)));
+		const summaryIds = JSON.stringify(summaries.map((s) => s.createdAt));
+		const now = new Date().toISOString();
+
+		deps.getDbAccessor().withWriteTx((db) => {
+			db.exec(
+				`INSERT INTO daily_reflections (id, agent_id, date, summary, patterns, question, memory_ids, summary_ids, model, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				id,
+				agentId,
+				date,
+				summary,
+				JSON.stringify(patterns),
+				question ?? null,
+				memoryIds,
+				summaryIds,
+				config.model,
+				now,
+			);
+		});
+
+		if (question) {
+			deps.getDbAccessor().withWriteTx((db) => {
+				txIngestEnvelope(db, {
+					id: randomUUID(),
+					content: `Daily reflection question: ${question}`,
+					contentHash: `reflection-q-${id}`,
+					who: "system",
+					why: "daily-reflection-question",
+					project: null,
+					importance: 0.5,
+					type: "reflection",
+					tags: "reflection,unanswered",
+					pinned: 0,
+					sourceType: "reflection-question",
+					sourceId: id,
+					createdAt: now,
+				});
+			});
+		}
+
+		writeLastReflectionTime(agentId, date);
+
+		deps.logger.info("reflections", "Generated daily reflection", {
+			agentId,
+			date,
+			hasQuestion: !!question,
+			patterns: patterns.length,
+		});
+	}
+
+	async function tick(): Promise<void> {
+		if (stopped || generating) return;
+		generating = true;
+		try {
+			const date = todayDate();
+			const lastDate = readLastReflectionTime("default");
+			if (lastDate !== date) {
+				await runReflection("default");
+			}
+		} finally {
+			generating = false;
+			if (!stopped) {
+				timer = setTimeout(tick, POLL_INTERVAL_MS);
+			}
+		}
+	}
+
+	function start(): void {
+		if (running) return;
+		running = true;
+		timer = setTimeout(tick, STARTUP_DELAY_MS);
+	}
+
+	function stop(): void {
+		stopped = true;
+		if (timer) {
+			clearTimeout(timer);
+			timer = null;
+		}
+		running = false;
+	}
+
+	start();
+
+	return {
+		stop,
+		get running() {
+			return running;
+		},
+		async triggerNow() {
+			await runReflection("default");
+		},
+	};
+}

--- a/platform/daemon/src/routes/reflection-routes.test.ts
+++ b/platform/daemon/src/routes/reflection-routes.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { LlmProvider } from "@signet/core";
+import { Hono } from "hono";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
+import { closeInferenceProviderResolver, initInferenceProviderResolver } from "../llm";
+import { txIngestEnvelope } from "../transactions";
+import { registerReflectionRoutes } from "./reflection-routes";
+
+let dir: string;
+const previousSignetPath = process.env.SIGNET_PATH;
+
+function makeProvider(text: string): LlmProvider {
+	return {
+		name: "test-provider",
+		async available(): Promise<boolean> {
+			return true;
+		},
+		async generate(): Promise<string> {
+			return text;
+		},
+	};
+}
+
+function seedMemory(agentId: string, content = "Built daily reflections."): string {
+	const now = new Date().toISOString();
+	const id = randomUUID();
+	getDbAccessor().withWriteTx((db) => {
+		txIngestEnvelope(db, {
+			id,
+			content,
+			contentHash: `test-${agentId}-${content}`,
+			who: "tester",
+			why: "test-seed",
+			project: null,
+			importance: 0.5,
+			type: "fact",
+			tags: "test",
+			pinned: 0,
+			sourceType: "test",
+			sourceId: "reflection-routes.test",
+			agentId,
+			createdAt: now,
+		});
+	});
+	return id;
+}
+
+function seedReflection(id: string, agentId: string, date = "2026-05-12"): void {
+	getDbAccessor().withWriteTx((db) => {
+		db.prepare(
+			`INSERT INTO daily_reflections
+			 (id, agent_id, date, summary, patterns, question, memory_ids, summary_ids, created_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			id,
+			agentId,
+			date,
+			"Reflection summary",
+			JSON.stringify(["testing"]),
+			"What did we learn?",
+			"[]",
+			"[]",
+			new Date().toISOString(),
+		);
+	});
+}
+
+function app(): Hono {
+	const next = new Hono();
+	registerReflectionRoutes(next);
+	return next;
+}
+
+beforeEach(() => {
+	dir = join(tmpdir(), `signet-reflections-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	mkdirSync(join(dir, "memory"), { recursive: true });
+	process.env.SIGNET_PATH = dir;
+	writeFileSync(
+		join(dir, "agent.yaml"),
+		`memory:
+  pipelineV2:
+    reflections:
+      enabled: true
+      timeWindowHours: 24
+      maxMemories: 10
+      maxSummaries: 10
+      timeout: 1000
+      maxTokens: 200
+      model: test-model
+`,
+	);
+	initDbAccessor(join(dir, "memory", "memories.db"));
+	initInferenceProviderResolver(() =>
+		makeProvider("SUMMARY: We fixed reflections.\nPATTERNS: persistence, scoping\nQUESTION: Keep it?"),
+	);
+});
+
+afterEach(() => {
+	closeInferenceProviderResolver();
+	closeDbAccessor();
+	if (previousSignetPath === undefined) {
+		process.env.SIGNET_PATH = undefined;
+	} else {
+		process.env.SIGNET_PATH = previousSignetPath;
+	}
+	rmSync(dir, { recursive: true, force: true });
+});
+
+describe("reflection routes", () => {
+	it("loads pipeline config from SIGNET_PATH and persists manual generation", async () => {
+		const memoryId = seedMemory("agent-a");
+
+		const res = await app().request("/api/reflections/generate?agentId=agent-a", { method: "POST" });
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.reflection.summary).toBe("We fixed reflections.");
+		expect(body.reflection.patterns).toEqual(["persistence", "scoping"]);
+
+		const row = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT agent_id, model, memory_ids FROM daily_reflections WHERE id = ?")
+					.get(body.reflection.id) as {
+					agent_id: string;
+					model: string;
+					memory_ids: string;
+				},
+		);
+		expect(row).toEqual({ agent_id: "agent-a", model: "test-model", memory_ids: JSON.stringify([memoryId]) });
+	});
+
+	it("defaults invalid list limits instead of allowing unlimited history", async () => {
+		for (let i = 0; i < 35; i += 1) {
+			seedReflection(randomUUID(), "agent-list", `2026-04-${String(i + 1).padStart(2, "0")}`);
+		}
+
+		const res = await app().request("/api/reflections?agentId=agent-list&limit=-1");
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.reflections).toHaveLength(30);
+	});
+
+	it("rejects oversized reflection answers before persistence", async () => {
+		const reflectionId = randomUUID();
+		seedReflection(reflectionId, "agent-b");
+
+		const res = await app().request(`/api/reflections/${reflectionId}/answer?agentId=agent-b`, {
+			method: "POST",
+			body: JSON.stringify({ answer: "x".repeat(10_001) }),
+			headers: { "content-type": "application/json" },
+		});
+		expect(res.status).toBe(413);
+
+		const state = getDbAccessor().withReadDb((db) => {
+			return {
+				answer: (
+					db.prepare("SELECT answer FROM daily_reflections WHERE id = ?").get(reflectionId) as { answer: string | null }
+				).answer,
+				memories: (
+					db
+						.prepare("SELECT COUNT(*) AS count FROM memories WHERE source_type = ? AND source_id = ?")
+						.get("reflection-answer", reflectionId) as { count: number }
+				).count,
+			};
+		});
+		expect(state).toEqual({ answer: null, memories: 0 });
+	});
+
+	it("stores answers under the reflection agent scope", async () => {
+		const reflectionId = randomUUID();
+		seedReflection(reflectionId, "agent-b");
+
+		const res = await app().request(`/api/reflections/${reflectionId}/answer?agentId=agent-b`, {
+			method: "POST",
+			body: JSON.stringify({ answer: "  Ship the scoping fix.  " }),
+			headers: { "content-type": "application/json" },
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+
+		const memory = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT content, agent_id FROM memories WHERE id = ?").get(body.memoryId) as {
+					content: string;
+					agent_id: string;
+				},
+		);
+		expect(memory).toEqual({ content: "Ship the scoping fix.", agent_id: "agent-b" });
+	});
+
+	it("does not create duplicate answer memories after the answer is claimed", async () => {
+		const reflectionId = randomUUID();
+		seedReflection(reflectionId, "agent-b");
+
+		const first = await app().request(`/api/reflections/${reflectionId}/answer?agentId=agent-b`, {
+			method: "POST",
+			body: JSON.stringify({ answer: "First answer." }),
+			headers: { "content-type": "application/json" },
+		});
+		expect(first.status).toBe(200);
+
+		const second = await app().request(`/api/reflections/${reflectionId}/answer?agentId=agent-b`, {
+			method: "POST",
+			body: JSON.stringify({ answer: "Second answer." }),
+			headers: { "content-type": "application/json" },
+		});
+		expect(second.status).toBe(409);
+
+		const state = getDbAccessor().withReadDb((db) => {
+			return {
+				answer: (
+					db.prepare("SELECT answer FROM daily_reflections WHERE id = ?").get(reflectionId) as { answer: string }
+				).answer,
+				memories: (
+					db
+						.prepare("SELECT COUNT(*) AS count FROM memories WHERE source_type = ? AND source_id = ?")
+						.get("reflection-answer", reflectionId) as { count: number }
+				).count,
+			};
+		});
+		expect(state).toEqual({ answer: "First answer.", memories: 1 });
+	});
+});

--- a/platform/daemon/src/routes/reflection-routes.ts
+++ b/platform/daemon/src/routes/reflection-routes.ts
@@ -1,0 +1,273 @@
+import { randomUUID } from "node:crypto";
+import type { Hono } from "hono";
+import { getDbAccessor } from "../db-accessor";
+import { getInferenceProvider } from "../llm";
+import { logger } from "../logger";
+import {
+	buildReflectionPrompt,
+	parseReflectionResponse,
+} from "../pipeline/reflection-worker";
+import { loadPipelineConfig } from "../memory-config";
+import { txIngestEnvelope } from "../transactions";
+
+interface ReflectionRow {
+	id: string;
+	agent_id: string;
+	date: string;
+	summary: string;
+	patterns: string;
+	question: string | null;
+	answer: string | null;
+	answer_memory_id: string | null;
+	memory_ids: string;
+	summary_ids: string;
+	model: string | null;
+	created_at: string;
+	answered_at: string | null;
+}
+
+function formatReflection(r: ReflectionRow) {
+	return {
+		id: r.id,
+		date: r.date,
+		summary: r.summary,
+		patterns: JSON.parse(r.patterns),
+		question: r.question,
+		answer: r.answer,
+		answerMemoryId: r.answer_memory_id,
+		createdAt: r.created_at,
+		answeredAt: r.answered_at,
+	};
+}
+
+export function registerReflectionRoutes(app: Hono): void {
+	app.get("/api/reflections/today", (c) => {
+		const agentId = c.req.query("agentId") ?? "default";
+		const date = new Date().toISOString().slice(0, 10);
+
+		try {
+			const row = getDbAccessor().withReadDb((db) => {
+				return db
+					.prepare(
+						"SELECT * FROM daily_reflections WHERE agent_id = ? AND date = ?",
+					)
+					.get(agentId, date) as ReflectionRow | undefined;
+			});
+
+			if (!row) {
+				return c.json({ reflection: null });
+			}
+
+			return c.json({ reflection: formatReflection(row) });
+		} catch (e) {
+			logger.error("reflections", "Failed to fetch today's reflection", {
+				error: e instanceof Error ? e.message : String(e),
+			});
+			return c.json({ error: "Failed to fetch reflection" }, 500);
+		}
+	});
+
+	app.get("/api/reflections", (c) => {
+		const agentId = c.req.query("agentId") ?? "default";
+		const limit = Math.min(Number(c.req.query("limit")) || 30, 100);
+
+		try {
+			const rows = getDbAccessor().withReadDb((db) => {
+				return db
+					.prepare(
+						`SELECT id, date, summary, patterns, question, answer,
+                        answer_memory_id, created_at, answered_at
+                 FROM daily_reflections
+                 WHERE agent_id = ?
+                 ORDER BY date DESC
+                 LIMIT ?`,
+					)
+					.all(agentId, limit) as ReflectionRow[];
+			});
+
+			return c.json({ reflections: rows.map(formatReflection) });
+		} catch (e) {
+			logger.error("reflections", "Failed to list reflections", {
+				error: e instanceof Error ? e.message : String(e),
+			});
+			return c.json({ error: "Failed to list reflections" }, 500);
+		}
+	});
+
+	app.post("/api/reflections/generate", async (c) => {
+		const agentId = c.req.query("agentId") ?? "default";
+		const date = new Date().toISOString().slice(0, 10);
+
+		const existing = getDbAccessor().withReadDb((db) => {
+			return db
+				.prepare("SELECT id FROM daily_reflections WHERE agent_id = ? AND date = ?")
+				.get(agentId, date) as { id: string } | undefined;
+		});
+		if (existing) {
+			return c.json({ error: "Reflection already exists for today" }, 409);
+		}
+
+		const pipelineCfg = loadPipelineConfig();
+		const cfg = pipelineCfg.reflections;
+		if (!cfg?.enabled) {
+			return c.json({ error: "Reflections are disabled in pipeline config" }, 400);
+		}
+
+		const cutoff = new Date(Date.now() - cfg.timeWindowHours * 60 * 60 * 1000).toISOString();
+
+		const memories = getDbAccessor().withReadDb((db) => {
+			return (db
+				.prepare(
+					`SELECT content, type, tags, created_at FROM memories
+             WHERE agent_id = ? AND created_at >= ? AND is_deleted = 0
+             ORDER BY created_at DESC LIMIT ?`,
+				)
+				.all(agentId, cutoff, cfg.maxMemories) as {
+				content: string;
+				type: string;
+				tags: string;
+				created_at: string;
+			}[]).map((r) => ({
+				content: r.content,
+				type: r.type,
+				tags: r.tags ?? "",
+				createdAt: r.created_at,
+			}));
+		});
+
+		const summaries = getDbAccessor().withReadDb((db) => {
+			return (db
+				.prepare(
+					`SELECT content, created_at FROM session_summaries
+             WHERE agent_id = ? AND created_at >= ?
+             ORDER BY created_at DESC LIMIT ?`,
+				)
+				.all(agentId, cutoff, cfg.maxSummaries) as {
+				content: string;
+				created_at: string;
+			}[]).map((r) => ({ content: r.content, createdAt: r.created_at }));
+		});
+
+		if (memories.length === 0 && summaries.length === 0) {
+			return c.json({ error: "No memories or summaries in the time window" }, 400);
+		}
+
+		const prompt = buildReflectionPrompt(memories, summaries);
+		let raw: string;
+		try {
+			const provider = getInferenceProvider("default");
+			raw = await provider.generate(prompt, {
+				timeoutMs: cfg.timeout,
+				maxTokens: cfg.maxTokens,
+			});
+		} catch (e) {
+			logger.error("reflections", "Manual generation failed", {
+				error: e instanceof Error ? e.message : String(e),
+			});
+			return c.json({ error: "LLM generation failed" }, 500);
+		}
+
+		const { summary, patterns, question } = parseReflectionResponse(raw);
+		const id = randomUUID();
+		const now = new Date().toISOString();
+
+		getDbAccessor().withWriteTx((db) => {
+			db.exec(
+				`INSERT INTO daily_reflections (id, agent_id, date, summary, patterns, question, memory_ids, summary_ids, model, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				id,
+				agentId,
+				date,
+				summary,
+				JSON.stringify(patterns),
+				question ?? null,
+				JSON.stringify(memories.map((m) => m.content.slice(0, 40))),
+				JSON.stringify(summaries.map((s) => s.createdAt)),
+				cfg.model,
+				now,
+			);
+		});
+
+		logger.info("reflections", "Manually generated daily reflection", { id, agentId, date });
+
+		const row = getDbAccessor().withReadDb((db) => {
+			return db
+				.prepare("SELECT * FROM daily_reflections WHERE id = ?")
+				.get(id) as ReflectionRow;
+		});
+
+		return c.json({ reflection: formatReflection(row) });
+	});
+
+	app.post("/api/reflections/:id/answer", async (c) => {
+		const id = c.req.param("id");
+		const agentId = c.req.query("agentId") ?? "default";
+
+		let body: { answer?: string };
+		try {
+			body = await c.req.json();
+		} catch {
+			return c.json({ error: "Invalid JSON body" }, 400);
+		}
+
+		if (!body.answer || typeof body.answer !== "string" || body.answer.trim().length === 0) {
+			return c.json({ error: "answer is required" }, 400);
+		}
+
+		try {
+			const existing = getDbAccessor().withReadDb((db) => {
+				return db
+					.prepare("SELECT * FROM daily_reflections WHERE id = ? AND agent_id = ?")
+					.get(id, agentId) as ReflectionRow | undefined;
+			});
+
+			if (!existing) {
+				return c.json({ error: "Reflection not found" }, 404);
+			}
+			if (existing.answer) {
+				return c.json({ error: "Already answered" }, 409);
+			}
+
+			const now = new Date().toISOString();
+			const memoryId = randomUUID();
+
+			getDbAccessor().withWriteTx((db) => {
+				db.exec(
+					`UPDATE daily_reflections
+           SET answer = ?, answer_memory_id = ?, answered_at = ?
+           WHERE id = ? AND agent_id = ?`,
+					body.answer.trim(),
+					memoryId,
+					now,
+					id,
+					agentId,
+				);
+
+				txIngestEnvelope(db, {
+					id: memoryId,
+					content: body.answer.trim(),
+					contentHash: `reflection-a-${id}`,
+					who: agentId,
+					why: "daily-reflection-answer",
+					project: null,
+					importance: 0.6,
+					type: "reflection",
+					tags: "reflection,answered",
+					pinned: 0,
+					sourceType: "reflection-answer",
+					sourceId: id,
+					createdAt: now,
+				});
+			});
+
+			logger.info("reflections", "Reflection answered", { id, agentId, memoryId });
+
+			return c.json({ success: true, memoryId });
+		} catch (e) {
+			logger.error("reflections", "Failed to save answer", {
+				error: e instanceof Error ? e.message : String(e),
+			});
+			return c.json({ error: "Failed to save answer" }, 500);
+		}
+	});
+}

--- a/platform/daemon/src/routes/reflection-routes.ts
+++ b/platform/daemon/src/routes/reflection-routes.ts
@@ -1,14 +1,30 @@
 import { randomUUID } from "node:crypto";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import type { Hono } from "hono";
+import { requirePermission } from "../auth";
 import { getDbAccessor } from "../db-accessor";
 import { getInferenceProvider } from "../llm";
 import { logger } from "../logger";
-import {
-	buildReflectionPrompt,
-	parseReflectionResponse,
-} from "../pipeline/reflection-worker";
-import { loadPipelineConfig } from "../memory-config";
+import { loadMemoryConfig } from "../memory-config";
+import { buildReflectionPrompt, parseReflectionResponse } from "../pipeline/reflection-worker";
 import { txIngestEnvelope } from "../transactions";
+import { authConfig } from "./state";
+
+const DEFAULT_REFLECTION_LIMIT = 30;
+const MAX_REFLECTION_LIMIT = 100;
+const MAX_REFLECTION_ANSWER_CHARS = 10_000;
+
+function getAgentsDir(): string {
+	return process.env.SIGNET_PATH || join(homedir(), ".agents");
+}
+
+function parseReflectionLimit(raw: string | undefined): number {
+	if (raw === undefined) return DEFAULT_REFLECTION_LIMIT;
+	const parsed = Number.parseInt(raw, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_REFLECTION_LIMIT;
+	return Math.min(parsed, MAX_REFLECTION_LIMIT);
+}
 
 interface ReflectionRow {
 	id: string;
@@ -41,17 +57,28 @@ function formatReflection(r: ReflectionRow) {
 }
 
 export function registerReflectionRoutes(app: Hono): void {
+	app.use("/api/reflections", async (c, next) => {
+		return requirePermission("recall", authConfig)(c, next);
+	});
+	app.use("/api/reflections/*", async (c, next) => {
+		return requirePermission("recall", authConfig)(c, next);
+	});
+	app.use("/api/reflections/generate", async (c, next) => {
+		return requirePermission("admin", authConfig)(c, next);
+	});
+	app.use("/api/reflections/:id/answer", async (c, next) => {
+		return requirePermission("modify", authConfig)(c, next);
+	});
+
 	app.get("/api/reflections/today", (c) => {
 		const agentId = c.req.query("agentId") ?? "default";
 		const date = new Date().toISOString().slice(0, 10);
 
 		try {
 			const row = getDbAccessor().withReadDb((db) => {
-				return db
-					.prepare(
-						"SELECT * FROM daily_reflections WHERE agent_id = ? AND date = ?",
-					)
-					.get(agentId, date) as ReflectionRow | undefined;
+				return db.prepare("SELECT * FROM daily_reflections WHERE agent_id = ? AND date = ?").get(agentId, date) as
+					| ReflectionRow
+					| undefined;
 			});
 
 			if (!row) {
@@ -60,16 +87,14 @@ export function registerReflectionRoutes(app: Hono): void {
 
 			return c.json({ reflection: formatReflection(row) });
 		} catch (e) {
-			logger.error("reflections", "Failed to fetch today's reflection", {
-				error: e instanceof Error ? e.message : String(e),
-			});
+			logger.error("reflections", "Failed to fetch today's reflection", e instanceof Error ? e : undefined);
 			return c.json({ error: "Failed to fetch reflection" }, 500);
 		}
 	});
 
 	app.get("/api/reflections", (c) => {
 		const agentId = c.req.query("agentId") ?? "default";
-		const limit = Math.min(Number(c.req.query("limit")) || 30, 100);
+		const limit = parseReflectionLimit(c.req.query("limit"));
 
 		try {
 			const rows = getDbAccessor().withReadDb((db) => {
@@ -87,9 +112,7 @@ export function registerReflectionRoutes(app: Hono): void {
 
 			return c.json({ reflections: rows.map(formatReflection) });
 		} catch (e) {
-			logger.error("reflections", "Failed to list reflections", {
-				error: e instanceof Error ? e.message : String(e),
-			});
+			logger.error("reflections", "Failed to list reflections", e instanceof Error ? e : undefined);
 			return c.json({ error: "Failed to list reflections" }, 500);
 		}
 	});
@@ -99,15 +122,15 @@ export function registerReflectionRoutes(app: Hono): void {
 		const date = new Date().toISOString().slice(0, 10);
 
 		const existing = getDbAccessor().withReadDb((db) => {
-			return db
-				.prepare("SELECT id FROM daily_reflections WHERE agent_id = ? AND date = ?")
-				.get(agentId, date) as { id: string } | undefined;
+			return db.prepare("SELECT id FROM daily_reflections WHERE agent_id = ? AND date = ?").get(agentId, date) as
+				| { id: string }
+				| undefined;
 		});
 		if (existing) {
 			return c.json({ error: "Reflection already exists for today" }, 409);
 		}
 
-		const pipelineCfg = loadPipelineConfig();
+		const pipelineCfg = loadMemoryConfig(getAgentsDir()).pipelineV2;
 		const cfg = pipelineCfg.reflections;
 		if (!cfg?.enabled) {
 			return c.json({ error: "Reflections are disabled in pipeline config" }, 400);
@@ -116,18 +139,22 @@ export function registerReflectionRoutes(app: Hono): void {
 		const cutoff = new Date(Date.now() - cfg.timeWindowHours * 60 * 60 * 1000).toISOString();
 
 		const memories = getDbAccessor().withReadDb((db) => {
-			return (db
-				.prepare(
-					`SELECT content, type, tags, created_at FROM memories
+			return (
+				db
+					.prepare(
+						`SELECT id, content, type, tags, created_at FROM memories
              WHERE agent_id = ? AND created_at >= ? AND is_deleted = 0
              ORDER BY created_at DESC LIMIT ?`,
-				)
-				.all(agentId, cutoff, cfg.maxMemories) as {
-				content: string;
-				type: string;
-				tags: string;
-				created_at: string;
-			}[]).map((r) => ({
+					)
+					.all(agentId, cutoff, cfg.maxMemories) as {
+					id: string;
+					content: string;
+					type: string;
+					tags: string;
+					created_at: string;
+				}[]
+			).map((r) => ({
+				id: r.id,
 				content: r.content,
 				type: r.type,
 				tags: r.tags ?? "",
@@ -136,16 +163,19 @@ export function registerReflectionRoutes(app: Hono): void {
 		});
 
 		const summaries = getDbAccessor().withReadDb((db) => {
-			return (db
-				.prepare(
-					`SELECT content, created_at FROM session_summaries
+			return (
+				db
+					.prepare(
+						`SELECT id, content, created_at FROM session_summaries
              WHERE agent_id = ? AND created_at >= ?
              ORDER BY created_at DESC LIMIT ?`,
-				)
-				.all(agentId, cutoff, cfg.maxSummaries) as {
-				content: string;
-				created_at: string;
-			}[]).map((r) => ({ content: r.content, createdAt: r.created_at }));
+					)
+					.all(agentId, cutoff, cfg.maxSummaries) as {
+					id: string;
+					content: string;
+					created_at: string;
+				}[]
+			).map((r) => ({ id: r.id, content: r.content, createdAt: r.created_at }));
 		});
 
 		if (memories.length === 0 && summaries.length === 0) {
@@ -161,9 +191,7 @@ export function registerReflectionRoutes(app: Hono): void {
 				maxTokens: cfg.maxTokens,
 			});
 		} catch (e) {
-			logger.error("reflections", "Manual generation failed", {
-				error: e instanceof Error ? e.message : String(e),
-			});
+			logger.error("reflections", "Manual generation failed", e instanceof Error ? e : undefined);
 			return c.json({ error: "LLM generation failed" }, 500);
 		}
 
@@ -171,29 +199,38 @@ export function registerReflectionRoutes(app: Hono): void {
 		const id = randomUUID();
 		const now = new Date().toISOString();
 
-		getDbAccessor().withWriteTx((db) => {
-			db.exec(
-				`INSERT INTO daily_reflections (id, agent_id, date, summary, patterns, question, memory_ids, summary_ids, model, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-				id,
-				agentId,
-				date,
-				summary,
-				JSON.stringify(patterns),
-				question ?? null,
-				JSON.stringify(memories.map((m) => m.content.slice(0, 40))),
-				JSON.stringify(summaries.map((s) => s.createdAt)),
-				cfg.model,
-				now,
-			);
-		});
+		try {
+			getDbAccessor().withWriteTx((db) => {
+				db.prepare(
+					`INSERT INTO daily_reflections
+					 (id, agent_id, date, summary, patterns, question, memory_ids, summary_ids, model, created_at)
+					 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				).run(
+					id,
+					agentId,
+					date,
+					summary,
+					JSON.stringify(patterns),
+					question ?? null,
+					JSON.stringify(memories.map((m) => m.id)),
+					JSON.stringify(summaries.map((s) => s.id)),
+					cfg.model,
+					now,
+				);
+			});
+		} catch (e) {
+			const message = e instanceof Error ? e.message : String(e);
+			if (message.toLowerCase().includes("unique") && message.includes("daily_reflections")) {
+				return c.json({ error: "Reflection already exists for today" }, 409);
+			}
+			logger.error("reflections", "Failed to persist manual reflection", e instanceof Error ? e : undefined);
+			return c.json({ error: "Failed to persist reflection" }, 500);
+		}
 
 		logger.info("reflections", "Manually generated daily reflection", { id, agentId, date });
 
 		const row = getDbAccessor().withReadDb((db) => {
-			return db
-				.prepare("SELECT * FROM daily_reflections WHERE id = ?")
-				.get(id) as ReflectionRow;
+			return db.prepare("SELECT * FROM daily_reflections WHERE id = ?").get(id) as ReflectionRow;
 		});
 
 		return c.json({ reflection: formatReflection(row) });
@@ -214,11 +251,16 @@ export function registerReflectionRoutes(app: Hono): void {
 			return c.json({ error: "answer is required" }, 400);
 		}
 
+		const answer = body.answer.trim();
+		if (answer.length > MAX_REFLECTION_ANSWER_CHARS) {
+			return c.json({ error: `answer exceeds ${MAX_REFLECTION_ANSWER_CHARS} characters` }, 413);
+		}
+
 		try {
 			const existing = getDbAccessor().withReadDb((db) => {
-				return db
-					.prepare("SELECT * FROM daily_reflections WHERE id = ? AND agent_id = ?")
-					.get(id, agentId) as ReflectionRow | undefined;
+				return db.prepare("SELECT * FROM daily_reflections WHERE id = ? AND agent_id = ?").get(id, agentId) as
+					| ReflectionRow
+					| undefined;
 			});
 
 			if (!existing) {
@@ -231,21 +273,22 @@ export function registerReflectionRoutes(app: Hono): void {
 			const now = new Date().toISOString();
 			const memoryId = randomUUID();
 
+			let claimed = false;
 			getDbAccessor().withWriteTx((db) => {
-				db.exec(
-					`UPDATE daily_reflections
-           SET answer = ?, answer_memory_id = ?, answered_at = ?
-           WHERE id = ? AND agent_id = ?`,
-					body.answer.trim(),
-					memoryId,
-					now,
-					id,
-					agentId,
-				);
+				const result = db
+					.prepare(
+						`UPDATE daily_reflections
+						 SET answer = ?, answer_memory_id = ?, answered_at = ?
+						 WHERE id = ? AND agent_id = ? AND answer IS NULL`,
+					)
+					.run(answer, memoryId, now, id, agentId);
+
+				if (result.changes === 0) return;
+				claimed = true;
 
 				txIngestEnvelope(db, {
 					id: memoryId,
-					content: body.answer.trim(),
+					content: answer,
 					contentHash: `reflection-a-${id}`,
 					who: agentId,
 					why: "daily-reflection-answer",
@@ -256,17 +299,20 @@ export function registerReflectionRoutes(app: Hono): void {
 					pinned: 0,
 					sourceType: "reflection-answer",
 					sourceId: id,
+					agentId,
 					createdAt: now,
 				});
 			});
+
+			if (!claimed) {
+				return c.json({ error: "Already answered" }, 409);
+			}
 
 			logger.info("reflections", "Reflection answered", { id, agentId, memoryId });
 
 			return c.json({ success: true, memoryId });
 		} catch (e) {
-			logger.error("reflections", "Failed to save answer", {
-				error: e instanceof Error ? e.message : String(e),
-			});
+			logger.error("reflections", "Failed to save answer", e instanceof Error ? e : undefined);
 			return c.json({ error: "Failed to save answer" }, 500);
 		}
 	});

--- a/surfaces/dashboard/src/lib/api.ts
+++ b/surfaces/dashboard/src/lib/api.ts
@@ -2909,9 +2909,13 @@ export interface TodayReflectionResponse {
 	reflection: DailyReflection | null;
 }
 
-export async function getTodayReflection(): Promise<TodayReflectionResponse> {
+function agentQuery(agentId?: string): string {
+	return agentId && agentId !== "default" ? `?agentId=${encodeURIComponent(agentId)}` : "";
+}
+
+export async function getTodayReflection(agentId?: string): Promise<TodayReflectionResponse> {
 	try {
-		const res = await fetch(`${API_BASE}/api/reflections/today`);
+		const res = await fetch(`${API_BASE}/api/reflections/today${agentQuery(agentId)}`);
 		if (!res.ok) return { reflection: null };
 		return (await res.json()) as TodayReflectionResponse;
 	} catch {
@@ -2922,9 +2926,10 @@ export async function getTodayReflection(): Promise<TodayReflectionResponse> {
 export async function answerReflection(
 	id: string,
 	answer: string,
+	agentId?: string,
 ): Promise<{ success: boolean; memoryId?: string; error?: string }> {
 	try {
-		const res = await fetch(`${API_BASE}/api/reflections/${id}/answer`, {
+		const res = await fetch(`${API_BASE}/api/reflections/${id}/answer${agentQuery(agentId)}`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ answer: answer.trim() }),

--- a/surfaces/dashboard/src/lib/api.ts
+++ b/surfaces/dashboard/src/lib/api.ts
@@ -2890,6 +2890,54 @@ export async function getDiagnostics(): Promise<DiagnosticsReport | null> {
 }
 
 // ---------------------------------------------------------------------------
+// Daily Reflections
+// ---------------------------------------------------------------------------
+
+export interface DailyReflection {
+	id: string;
+	date: string;
+	summary: string;
+	patterns: string[];
+	question: string | null;
+	answer: string | null;
+	answerMemoryId: string | null;
+	createdAt: string;
+	answeredAt: string | null;
+}
+
+export interface TodayReflectionResponse {
+	reflection: DailyReflection | null;
+}
+
+export async function getTodayReflection(): Promise<TodayReflectionResponse> {
+	try {
+		const res = await fetch(`${API_BASE}/api/reflections/today`);
+		if (!res.ok) return { reflection: null };
+		return (await res.json()) as TodayReflectionResponse;
+	} catch {
+		return { reflection: null };
+	}
+}
+
+export async function answerReflection(
+	id: string,
+	answer: string,
+): Promise<{ success: boolean; memoryId?: string; error?: string }> {
+	try {
+		const res = await fetch(`${API_BASE}/api/reflections/${id}/answer`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ answer: answer.trim() }),
+		});
+		const data = await res.json();
+		if (!res.ok) return { success: false, error: data.error ?? "Request failed" };
+		return data as { success: boolean; memoryId?: string };
+	} catch {
+		return { success: false, error: "Network error" };
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Home greeting (falls back gracefully)
 // ---------------------------------------------------------------------------
 

--- a/surfaces/dashboard/src/lib/components/home/DailyReflection.svelte
+++ b/surfaces/dashboard/src/lib/components/home/DailyReflection.svelte
@@ -1,0 +1,338 @@
+<script lang="ts">
+import type { DailyReflection } from "$lib/api";
+import { getTodayReflection, answerReflection } from "$lib/api";
+import { toast } from "$lib/stores/toast.svelte";
+import { onMount } from "svelte";
+
+let reflection = $state<DailyReflection | null>(null);
+let loading = $state(true);
+let answerText = $state("");
+let submitting = $state(false);
+let answered = $state(false);
+let showAnswer = $state(false);
+
+onMount(async () => {
+	const data = await getTodayReflection();
+	reflection = data.reflection;
+	loading = false;
+	if (reflection?.answer) answered = true;
+});
+
+async function handleAnswer(): Promise<void> {
+	if (!reflection || !answerText.trim()) return;
+	submitting = true;
+	const result = await answerReflection(reflection.id, answerText);
+	submitting = false;
+	if (result.success) {
+		answered = true;
+		reflection = { ...reflection, answer: answerText, answerMemoryId: result.memoryId ?? null };
+		toast("Answer saved as memory", "success");
+	} else {
+		toast(result.error ?? "Failed to save answer", "error");
+	}
+}
+</script>
+
+<div class="panel sig-panel">
+	<div class="panel-header sig-panel-header">
+		<span class="panel-title">REFLECTION</span>
+		{#if reflection}
+			<span class="panel-date">{reflection.date}</span>
+		{/if}
+	</div>
+
+	<div class="panel-body">
+		{#if loading}
+			<div class="loading-state">
+				<span class="loading-line"></span>
+				<span class="loading-line short"></span>
+				<span class="loading-line"></span>
+			</div>
+		{:else if !reflection}
+			<div class="empty-state">
+				<span>No reflection yet today</span>
+				<span class="empty-hint">Appears after your next scheduled pass</span>
+			</div>
+		{:else}
+			<p class="reflection-summary">{reflection.summary}</p>
+
+			{#if reflection.patterns.length > 0}
+				<div class="patterns">
+					{#each reflection.patterns as pattern}
+						<span class="pattern-tag">{pattern}</span>
+					{/each}
+				</div>
+			{/if}
+
+			{#if reflection.question && !answered}
+				<div class="question-block">
+					<span class="question-text">{reflection.question}</span>
+					{#if showAnswer}
+						<textarea
+							class="answer-input"
+							placeholder="Type your reflection..."
+							bind:value={answerText}
+							rows="2"
+						></textarea>
+						<div class="answer-actions">
+							<button
+								class="answer-submit"
+								disabled={!answerText.trim() || submitting}
+								onclick={handleAnswer}
+							>
+								{submitting ? "Saving..." : "Save"}
+							</button>
+							<button class="answer-cancel" onclick={() => (showAnswer = false)}>
+								Cancel
+							</button>
+						</div>
+					{:else}
+						<button class="answer-prompt" onclick={() => (showAnswer = true)}>
+							Answer
+						</button>
+					{/if}
+				</div>
+			{/if}
+
+			{#if answered && reflection.answer}
+				<div class="answered-block">
+					<span class="answered-label">YOUR ANSWER</span>
+					<p class="answered-text">{reflection.answer}</p>
+				</div>
+			{/if}
+		{/if}
+	</div>
+</div>
+
+<style>
+	.panel {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		background: var(--sig-surface);
+	}
+
+	.panel-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--space-sm) var(--space-md);
+		flex-shrink: 0;
+	}
+
+	.panel-title {
+		font-family: var(--font-display);
+		font-size: 11px;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--sig-text-bright);
+	}
+
+	.panel-date {
+		font-family: var(--font-body);
+		font-size: 8px;
+		letter-spacing: 0.1em;
+		color: var(--sig-text-muted);
+	}
+
+	.panel-body {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+		padding: var(--space-sm) var(--space-md);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-sm);
+	}
+
+	.reflection-summary {
+		font-family: var(--font-body);
+		font-size: 13px;
+		line-height: 1.6;
+		color: var(--sig-text);
+		margin: 0;
+	}
+
+	.patterns {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 4px;
+	}
+
+	.pattern-tag {
+		font-family: var(--font-body);
+		font-size: 9px;
+		padding: 1px 6px;
+		background: var(--sig-bg);
+		border: 1px solid var(--sig-border);
+		border-radius: 2px;
+		color: var(--sig-highlight);
+		letter-spacing: 0.04em;
+	}
+
+	.question-block {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		border-top: 1px solid var(--sig-border);
+		padding-top: var(--space-sm);
+	}
+
+	.question-text {
+		font-family: var(--font-body);
+		font-size: 11px;
+		line-height: 1.5;
+		color: var(--sig-accent);
+		font-style: italic;
+	}
+
+	.answer-prompt {
+		font-family: var(--font-body);
+		font-size: 10px;
+		letter-spacing: 0.06em;
+		color: var(--sig-surface);
+		background: var(--sig-accent);
+		border: none;
+		padding: 4px 12px;
+		border-radius: 2px;
+		cursor: pointer;
+		align-self: flex-start;
+		transition: opacity var(--dur) var(--ease);
+	}
+
+	.answer-prompt:hover {
+		opacity: 0.8;
+	}
+
+	.answer-input {
+		font-family: var(--font-body);
+		font-size: 11px;
+		line-height: 1.5;
+		color: var(--sig-text);
+		background: var(--sig-surface-raised);
+		border: 1px solid var(--sig-border);
+		border-radius: 2px;
+		padding: 6px 8px;
+		resize: none;
+		outline: none;
+		width: 100%;
+	}
+
+	.answer-input:focus {
+		border-color: var(--sig-border-strong);
+	}
+
+	.answer-actions {
+		display: flex;
+		gap: 8px;
+	}
+
+	.answer-submit {
+		font-family: var(--font-body);
+		font-size: 9px;
+		letter-spacing: 0.08em;
+		color: var(--sig-accent);
+		background: none;
+		border: none;
+		padding: 0;
+		cursor: pointer;
+		transition: color var(--dur) var(--ease);
+	}
+
+	.answer-submit:hover:not(:disabled) {
+		color: var(--sig-highlight-text);
+	}
+
+	.answer-submit:disabled {
+		opacity: 0.4;
+		cursor: default;
+	}
+
+	.answer-cancel {
+		font-family: var(--font-body);
+		font-size: 9px;
+		letter-spacing: 0.08em;
+		color: var(--sig-text-muted);
+		background: none;
+		border: none;
+		padding: 0;
+		cursor: pointer;
+	}
+
+	.answered-block {
+		border-top: 1px solid var(--sig-border);
+		padding-top: var(--space-sm);
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	.answered-label {
+		font-family: var(--font-display);
+		font-size: 8px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--sig-success);
+	}
+
+	.answered-text {
+		font-family: var(--font-body);
+		font-size: 11px;
+		line-height: 1.5;
+		color: var(--sig-text);
+		margin: 0;
+	}
+
+	.empty-state {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: var(--space-sm);
+		font-family: var(--font-body);
+		font-size: 9px;
+		letter-spacing: 0.08em;
+		color: var(--sig-text-muted);
+		text-align: center;
+	}
+
+	.empty-hint {
+		font-family: var(--font-body);
+		font-size: 8px;
+		letter-spacing: 0.06em;
+		color: var(--sig-text-muted);
+		opacity: 0.6;
+	}
+
+	.loading-state {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		padding-top: 4px;
+	}
+
+	.loading-line {
+		height: 10px;
+		background: var(--sig-surface-raised);
+		border-radius: 2px;
+		opacity: 0.5;
+		animation: pulse 1.5s ease-in-out infinite;
+	}
+
+	.loading-line.short {
+		width: 60%;
+	}
+
+	@keyframes pulse {
+		0%,
+		100% {
+			opacity: 0.5;
+		}
+		50% {
+			opacity: 0.2;
+		}
+	}
+</style>

--- a/surfaces/dashboard/src/lib/components/home/DailyReflection.svelte
+++ b/surfaces/dashboard/src/lib/components/home/DailyReflection.svelte
@@ -1,18 +1,26 @@
 <script lang="ts">
 import type { DailyReflection } from "$lib/api";
-import { getTodayReflection, answerReflection } from "$lib/api";
+import { answerReflection, getTodayReflection } from "$lib/api";
 import { toast } from "$lib/stores/toast.svelte";
 import { onMount } from "svelte";
 
+interface Props {
+	agentId: string;
+}
+
+const { agentId }: Props = $props();
+
 let reflection = $state<DailyReflection | null>(null);
 let loading = $state(true);
+// biome-ignore lint/style/useConst: Svelte bind:value mutates state declared with let.
 let answerText = $state("");
 let submitting = $state(false);
 let answered = $state(false);
+// biome-ignore lint/style/useConst: Svelte event handlers reassign state declared with let.
 let showAnswer = $state(false);
 
 onMount(async () => {
-	const data = await getTodayReflection();
+	const data = await getTodayReflection(agentId);
 	reflection = data.reflection;
 	loading = false;
 	if (reflection?.answer) answered = true;
@@ -21,7 +29,7 @@ onMount(async () => {
 async function handleAnswer(): Promise<void> {
 	if (!reflection || !answerText.trim()) return;
 	submitting = true;
-	const result = await answerReflection(reflection.id, answerText);
+	const result = await answerReflection(reflection.id, answerText, agentId);
 	submitting = false;
 	if (result.success) {
 		answered = true;

--- a/surfaces/dashboard/src/lib/components/tabs/HomeTab.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/HomeTab.svelte
@@ -14,9 +14,9 @@ import type {
 } from "$lib/api";
 import { API_BASE, getConnectors, getContinuityLatest, getDiagnostics, getPipelineStatus } from "$lib/api";
 import AgentHeader from "$lib/components/home/AgentHeader.svelte";
+import DailyReflection from "$lib/components/home/DailyReflection.svelte";
 import KnowledgeBaseMap from "$lib/components/home/KnowledgeBaseMap.svelte";
 import PinnedEntityCluster from "$lib/components/home/PinnedEntityCluster.svelte";
-import DailyReflection from "$lib/components/home/DailyReflection.svelte";
 import { onMount } from "svelte";
 
 interface Props {
@@ -75,7 +75,7 @@ onMount(async () => {
 		<KnowledgeBaseMap />
 	</div>
 	<div class="area-insights">
-		<DailyReflection />
+		<DailyReflection {agentId} />
 	</div>
 	<div class="area-sidebar">
 		<PinnedEntityCluster {memories} />

--- a/surfaces/dashboard/src/lib/components/tabs/HomeTab.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/HomeTab.svelte
@@ -16,7 +16,7 @@ import { API_BASE, getConnectors, getContinuityLatest, getDiagnostics, getPipeli
 import AgentHeader from "$lib/components/home/AgentHeader.svelte";
 import KnowledgeBaseMap from "$lib/components/home/KnowledgeBaseMap.svelte";
 import PinnedEntityCluster from "$lib/components/home/PinnedEntityCluster.svelte";
-import SuggestedInsights from "$lib/components/home/SuggestedInsights.svelte";
+import DailyReflection from "$lib/components/home/DailyReflection.svelte";
 import { onMount } from "svelte";
 
 interface Props {
@@ -75,7 +75,7 @@ onMount(async () => {
 		<KnowledgeBaseMap />
 	</div>
 	<div class="area-insights">
-		<SuggestedInsights {memories} />
+		<DailyReflection />
 	</div>
 	<div class="area-sidebar">
 		<PinnedEntityCluster {memories} />
@@ -90,8 +90,8 @@ onMount(async () => {
 		grid-template-rows: auto minmax(auto, max-content) 1fr;
 		grid-template-areas:
 			"banner     banner"
-			"spotlights sidebar"
-			"insights   sidebar";
+			"insights   sidebar"
+			"spotlights sidebar";
 		gap: var(--space-sm);
 		flex: 1;
 		min-height: 0;


### PR DESCRIPTION
## Summary

- Adds a periodic reflection worker (`reflection-worker.ts`) that generates once-daily narrative insights from recent memories and session summaries using the default inference provider
- Adds API routes: `GET /api/reflections/today`, `GET /api/reflections`, `POST /api/reflections/generate`, `POST /api/reflections/:id/answer`
- Adds `DailyReflection.svelte` dashboard component on the home tab, replacing the old SuggestedInsights panel
- Answer writeback saves as memory via `txIngestEnvelope` with provenance and the active `agentId` scope
- Migration `068` creates `daily_reflections` table

## Fixes in latest update

- Reflection read endpoints now require `recall` permission, matching the private memory-derived data they return.

- Scheduled reflection generation now discovers active agent IDs from recent memories/session summaries and runs due reflections per agent instead of hardcoding `default`.

- Reflection list `limit` now clamps to `1..100` with invalid values falling back to 30, preventing `LIMIT -1` unlimited history reads.

- Reflection answers now reject bodies over 10,000 characters before DB update or memory ingestion.

- Scheduled worker inserts now handle the daily unique-index race and ingest question memory only after the reflection insert wins.

- Answer writeback now atomically claims unanswered reflections with `answer IS NULL` before ingesting memory, preventing duplicate answer memories under concurrent submissions.

- Manual generation now loads `memory.pipelineV2` through the normal active `SIGNET_PATH` config path
- Reflection inserts and answer updates now use prepared statements instead of `db.exec()` with bind placeholders
- Reflection question and answer memories now carry the same `agentId` scope as the reflection
- Added route, worker, and migration regression tests for manual generation, persistence, scoped answer writeback, duplicate prevention, and empty-day retry behavior
- Daily reflections are constrained unique per `(agent_id, date)` so pre-check races cannot create duplicates
- The worker no longer marks a day complete when there is no source material, so later same-day activity can still generate a reflection
- Reflection provenance now stores actual memory/session summary row IDs instead of content prefixes or timestamps
- The worker now honors cron-style daily `reflections.schedule` values such as `0 8 * * *`, while retrying every five minutes after the scheduled time until a reflection is successfully generated

## Test plan

- [x] `bunx biome check platform/daemon/src/routes/reflection-routes.ts platform/daemon/src/routes/reflection-routes.test.ts platform/daemon/src/pipeline/reflection-worker.ts platform/daemon/src/pipeline/reflection-worker.test.ts platform/daemon/src/logger.ts platform/core/src/index.ts`
- [x] `bun run build:core`
- [x] `bun test platform/core/src/migrations/migrations.test.ts platform/daemon/src/routes/reflection-routes.test.ts platform/daemon/src/pipeline/reflection-worker.test.ts`
- [x] `git diff --check origin/main...HEAD`

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)
- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Migration `068-daily-reflections` adds the `daily_reflections` table for generated reflections and answers. It uses `CREATE TABLE IF NOT EXISTS` plus a unique index via `CREATE UNIQUE INDEX IF NOT EXISTS`, so reruns are safe. This is JS daemon/dashboard-only storage for a new table; no Rust daemon parity surface currently exists, so parity is N/A. Rollback compatibility is straightforward: older daemons ignore the table, and normal daemon startup migration handling applies it automatically with no manual operator action.
