### PR TITLE
fix(cli): add HOME to launchd daemon plist env

### DIFF
--- a/surfaces/cli/src/lib/runtime.test.ts
+++ b/surfaces/cli/src/lib/runtime.test.ts
@@ -70,6 +70,7 @@ describe("buildLaunchdDaemonPlist", () => {
 		expect(plist).toContain("<string>0.0.0.0</string>");
 		expect(plist).toContain("<key>SIGNET_PATH</key>");
 		expect(plist).toContain("<string>/Users/user/.agents</string>");
+		expect(plist).toContain("<key>HOME</key>");
 		expect(plist).toContain("<key>RunAtLoad</key>");
 		expect(plist).toContain("<true/>");
 		expect(plist).toContain("<key>KeepAlive</key>");

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -454,6 +454,7 @@ export function buildLaunchdDaemonPlist(input: LaunchdDaemonPlistInput): string 
 		SIGNET_HOST: input.host,
 		SIGNET_BIND: input.bind,
 		SIGNET_PATH: input.agentsDir,
+		HOME: process.env.HOME ?? homedir(),
 		PATH: process.env.PATH ?? "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
 	};
 	const envEntries = Object.entries(env)


### PR DESCRIPTION
## Summary

The launchd plist generated by `buildLaunchdDaemonPlist` does not include `HOME` in its `EnvironmentVariables` dict. Bun requires `HOME` to resolve its global install directory and `bun:sqlite` paths. When launchd starts the daemon, `HOME` is not set in the service environment, causing an immediate exit with `EX_CONFIG` (78) on every launchd-managed start.

This adds `HOME` to the generated plist using `process.env.HOME ?? homedir()`.

## Changes

- Add `HOME` env var to `buildLaunchdDaemonPlist` output (`surfaces/cli/src/lib/runtime.ts`)
- Add regression test asserting `HOME` key is present in plist (`surfaces/cli/src/lib/runtime.test.ts`)

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/cli` / dashboard

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — N/A: narrow launchd plist fix, no spec-governed behavior changed
- [x] Agent scoping verified on all new/changed data queries — N/A: no data queries changed
- [x] Input/config validation and bounds checks added — N/A: no new inputs, HOME resolved from existing `process.env`/`homedir()`
- [x] Error handling and fallback paths tested (no silent swallow) — `homedir()` always returns a value on supported platforms
- [x] Security checks applied to admin/mutation endpoints — N/A: no endpoints changed
- [x] Docs updated for API/spec/status changes — N/A: internal plist generation, no public API change
- [x] Regression tests added for each bug fix — test asserts `<key>HOME</key>` is present in plist output
- [x] Lint/typecheck/tests pass locally — all 13 runtime tests pass

## Testing

- [x] `bun test` passes
- [x] Tested against running daemon — verified daemon starts via launchd after fix (was EX_CONFIG before)

## AI disclosure

- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Minimal one-line fix. The `homedir()` fallback ensures this works even in unusual environments where `process.env.HOME` is not set. The daemon was completely unable to start via launchd on macOS without this.