### PR TITLE
fix(daemon): generate Daily Brief on dashboard open

### DIFF
--- a/platform/core/src/migrations/068-daily-reflections.ts
+++ b/platform/core/src/migrations/068-daily-reflections.ts
@@ -29,7 +29,7 @@ export function up(db: MigrationDb): void {
 			ON daily_reflections(agent_id, date, created_at DESC);
 
 		CREATE UNIQUE INDEX IF NOT EXISTS idx_daily_reflections_agent_content_key
-			ON daily_reflections(agent_id, content_key)
+			ON daily_reflections(agent_id, date, content_key)
 			WHERE content_key IS NOT NULL;
 	`);
 }

--- a/platform/core/src/migrations/068-daily-reflections.ts
+++ b/platform/core/src/migrations/068-daily-reflections.ts
@@ -17,6 +17,7 @@ export function up(db: MigrationDb): void {
 			question         TEXT,
 			answer           TEXT,
 			answer_memory_id TEXT,
+			content_key      TEXT,
 			memory_ids       TEXT NOT NULL DEFAULT '[]',
 			summary_ids      TEXT NOT NULL DEFAULT '[]',
 			model            TEXT,
@@ -26,5 +27,9 @@ export function up(db: MigrationDb): void {
 
 		CREATE INDEX IF NOT EXISTS idx_daily_reflections_agent_date
 			ON daily_reflections(agent_id, date, created_at DESC);
+
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_daily_reflections_agent_content_key
+			ON daily_reflections(agent_id, content_key)
+			WHERE content_key IS NOT NULL;
 	`);
 }

--- a/platform/core/src/migrations/068-daily-reflections.ts
+++ b/platform/core/src/migrations/068-daily-reflections.ts
@@ -24,7 +24,7 @@ export function up(db: MigrationDb): void {
 			answered_at      TEXT
 		);
 
-		CREATE UNIQUE INDEX IF NOT EXISTS idx_daily_reflections_agent_date
-			ON daily_reflections(agent_id, date);
+		CREATE INDEX IF NOT EXISTS idx_daily_reflections_agent_date
+			ON daily_reflections(agent_id, date, created_at DESC);
 	`);
 }

--- a/platform/core/src/migrations/069-daily-reflections-multiple-insights.ts
+++ b/platform/core/src/migrations/069-daily-reflections-multiple-insights.ts
@@ -9,6 +9,12 @@ import type { MigrationDb } from "./index";
  * more than one row per day.
  */
 export function up(db: MigrationDb): void {
+	const cols = db.prepare("PRAGMA table_info(daily_reflections)").all() as ReadonlyArray<Record<string, unknown>>;
+	const colNames = new Set(cols.flatMap((c) => (typeof c.name === "string" ? [c.name] : [])));
+	if (!colNames.has("content_key")) {
+		db.exec("ALTER TABLE daily_reflections ADD COLUMN content_key TEXT");
+	}
+
 	db.exec(`
 		DROP INDEX IF EXISTS idx_daily_reflections_agent_date;
 
@@ -17,5 +23,9 @@ export function up(db: MigrationDb): void {
 
 		CREATE INDEX IF NOT EXISTS idx_daily_reflections_agent_date
 			ON daily_reflections(agent_id, date, created_at DESC);
+
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_daily_reflections_agent_content_key
+			ON daily_reflections(agent_id, content_key)
+			WHERE content_key IS NOT NULL;
 	`);
 }

--- a/platform/core/src/migrations/069-daily-reflections-multiple-insights.ts
+++ b/platform/core/src/migrations/069-daily-reflections-multiple-insights.ts
@@ -5,8 +5,8 @@ import type { MigrationDb } from "./index";
  *
  * The dashboard should generate fresh Daily Brief items whenever it opens,
  * so an agent can have multiple insights on the same date. De-duplication
- * happens at generation time against recent brief content, not by forbidding
- * more than one row per day.
+ * happens at generation time against recent brief content. The database only
+ * prevents concurrent duplicate inserts for the same agent and date.
  */
 export function up(db: MigrationDb): void {
 	const cols = db.prepare("PRAGMA table_info(daily_reflections)").all() as ReadonlyArray<Record<string, unknown>>;
@@ -17,6 +17,7 @@ export function up(db: MigrationDb): void {
 
 	db.exec(`
 		DROP INDEX IF EXISTS idx_daily_reflections_agent_date;
+		DROP INDEX IF EXISTS idx_daily_reflections_agent_content_key;
 
 		CREATE INDEX IF NOT EXISTS idx_daily_reflections_agent_created
 			ON daily_reflections(agent_id, created_at DESC);
@@ -25,7 +26,7 @@ export function up(db: MigrationDb): void {
 			ON daily_reflections(agent_id, date, created_at DESC);
 
 		CREATE UNIQUE INDEX IF NOT EXISTS idx_daily_reflections_agent_content_key
-			ON daily_reflections(agent_id, content_key)
+			ON daily_reflections(agent_id, date, content_key)
 			WHERE content_key IS NOT NULL;
 	`);
 }

--- a/platform/core/src/migrations/069-daily-reflections-multiple-insights.ts
+++ b/platform/core/src/migrations/069-daily-reflections-multiple-insights.ts
@@ -1,0 +1,21 @@
+import type { MigrationDb } from "./index";
+
+/**
+ * Migration 069: Daily reflections become dashboard-open insights.
+ *
+ * The dashboard should generate fresh Daily Brief items whenever it opens,
+ * so an agent can have multiple insights on the same date. De-duplication
+ * happens at generation time against recent brief content, not by forbidding
+ * more than one row per day.
+ */
+export function up(db: MigrationDb): void {
+	db.exec(`
+		DROP INDEX IF EXISTS idx_daily_reflections_agent_date;
+
+		CREATE INDEX IF NOT EXISTS idx_daily_reflections_agent_created
+			ON daily_reflections(agent_id, created_at DESC);
+
+		CREATE INDEX IF NOT EXISTS idx_daily_reflections_agent_date
+			ON daily_reflections(agent_id, date, created_at DESC);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -74,6 +74,7 @@ import { up as sourceEmbeddingAgentScope } from "./065-source-embedding-agent-sc
 import { up as memorySearchTelemetry } from "./066-memory-search-telemetry";
 import { up as ontologyProposals } from "./067-ontology-proposals";
 import { up as dailyReflections } from "./068-daily-reflections";
+import { up as dailyReflectionsMultipleInsights } from "./069-daily-reflections-multiple-insights";
 
 // -- Public interface consumed by Database.init() --
 
@@ -634,6 +635,14 @@ export const MIGRATIONS: readonly Migration[] = [
 		version: 68,
 		name: "daily-reflections",
 		up: dailyReflections,
+		artifacts: {
+			tables: ["daily_reflections"],
+		},
+	},
+	{
+		version: 69,
+		name: "daily-reflections-multiple-insights",
+		up: dailyReflectionsMultipleInsights,
 		artifacts: {
 			tables: ["daily_reflections"],
 		},

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -104,7 +104,7 @@ describe("migration framework", () => {
 		expect(uniqueVersions.size).toBe(migrations.length);
 	});
 
-	test("daily reflections are unique per agent and date", () => {
+	test("daily reflections allow multiple dashboard-open insights per agent and date", () => {
 		db = createFreshDb();
 		runMigrations(db);
 
@@ -114,7 +114,7 @@ describe("migration framework", () => {
 		);
 
 		insert.run("reflection-1", "agent-a", "2026-05-13", "First");
-		expect(() => insert.run("reflection-2", "agent-a", "2026-05-13", "Duplicate")).toThrow();
+		expect(() => insert.run("reflection-2", "agent-a", "2026-05-13", "Another fresh insight")).not.toThrow();
 		expect(() => insert.run("reflection-3", "agent-b", "2026-05-13", "Different agent")).not.toThrow();
 		expect(() => insert.run("reflection-4", "agent-a", "2026-05-14", "Different date")).not.toThrow();
 	});

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -110,13 +110,30 @@ describe("migration framework", () => {
 
 		const insert = db.prepare(
 			`INSERT INTO daily_reflections (id, agent_id, date, summary)
-			 VALUES (?, ?, ?, ?)`,
+		 VALUES (?, ?, ?, ?)`,
 		);
 
 		insert.run("reflection-1", "agent-a", "2026-05-13", "First");
 		expect(() => insert.run("reflection-2", "agent-a", "2026-05-13", "Another fresh insight")).not.toThrow();
 		expect(() => insert.run("reflection-3", "agent-b", "2026-05-13", "Different agent")).not.toThrow();
 		expect(() => insert.run("reflection-4", "agent-a", "2026-05-14", "Different date")).not.toThrow();
+	});
+
+	test("daily reflection content keys are unique only within one agent day", () => {
+		db = createFreshDb();
+		runMigrations(db);
+
+		const insert = db.prepare(
+			`INSERT INTO daily_reflections (id, agent_id, date, summary, content_key)
+		 VALUES (?, ?, ?, ?, ?)`,
+		);
+
+		insert.run("reflection-1", "agent-a", "2026-05-13", "First", "same-question");
+		expect(() => insert.run("reflection-2", "agent-a", "2026-05-13", "Duplicate today", "same-question")).toThrow();
+		expect(() =>
+			insert.run("reflection-3", "agent-a", "2026-05-14", "Legitimate later recurrence", "same-question"),
+		).not.toThrow();
+		expect(() => insert.run("reflection-4", "agent-b", "2026-05-13", "Different agent", "same-question")).not.toThrow();
 	});
 
 	test("all expected tables exist after migration", () => {

--- a/platform/daemon/src/pipeline/index.ts
+++ b/platform/daemon/src/pipeline/index.ts
@@ -13,9 +13,12 @@ import type { DecisionConfig } from "./decision";
 import { type DependencySynthesisHandle, startDependencySynthesisWorker } from "./dependency-synthesis";
 import { type DocumentWorkerHandle, startDocumentWorker } from "./document-worker";
 import type { DreamingWorkerHandle } from "./dreaming-worker";
+import { startExtractionThread } from "./extraction-thread-handle";
+import type { ExtractionThreadOpts } from "./extraction-thread-handle";
+import type { WorkerInit } from "./extraction-thread-protocol";
 import { type MaintenanceHandle, startMaintenanceWorker } from "./maintenance-worker";
 import { type HintsWorkerHandle, startHintsWorker } from "./prospective-index";
-import { type ReflectionWorkerHandle, startReflectionWorker } from "./reflection-worker";
+import type { ReflectionWorkerHandle } from "./reflection-worker";
 import {
 	DEFAULT_RETENTION,
 	type RetentionConfig,
@@ -27,9 +30,6 @@ import { type StructuralDependencyHandle, startStructuralDependencyWorker } from
 import { type SummaryWorkerHandle, startSummaryWorker } from "./summary-worker";
 import { type SynthesisWorkerHandle, startSynthesisWorker } from "./synthesis-worker";
 import { type WorkerHandle, type WorkerProgressStats, type WorkerStats, startWorker } from "./worker";
-import { startExtractionThread } from "./extraction-thread-handle";
-import type { ExtractionThreadOpts } from "./extraction-thread-handle";
-import type { WorkerInit } from "./extraction-thread-protocol";
 
 export { enqueueExtractionJob } from "./worker";
 export type { WorkerStats } from "./worker";
@@ -276,10 +276,9 @@ export function startPipeline(
 		hintsWorkerHandle = startHintsWorker({ accessor, provider, pipelineCfg });
 	}
 
-	// Daily reflections worker — periodic narrative insight generation
-	if (!reflectionWorkerHandle && pipelineCfg.reflections?.enabled) {
-		reflectionWorkerHandle = startReflectionWorker(pipelineCfg.reflections);
-	}
+	// Daily Brief generation is dashboard-open driven. Do not start a
+	// background schedule here; /api/reflections/generate creates fresh,
+	// de-duplicated insights when the dashboard opens.
 
 	logger.info("pipeline", "Pipeline started", {
 		mode:

--- a/platform/daemon/src/pipeline/reflection-worker.test.ts
+++ b/platform/daemon/src/pipeline/reflection-worker.test.ts
@@ -111,7 +111,7 @@ describe("reflection worker", () => {
 		expect(existsSync(join(dir, ".daemon", "last-reflection.default.json"))).toBe(false);
 	});
 
-	it("persists generated reflections and scoped question memories", async () => {
+	it("persists generated brief insights", async () => {
 		const memoryId = seedMemory("default");
 		const worker = startReflectionWorker(config, {
 			getDbAccessor,
@@ -135,42 +135,28 @@ describe("reflection worker", () => {
 				},
 		);
 		expect(reflection).toEqual({
-			summary: "Worker persisted.",
+			summary: "Should we keep it?",
 			model: "test-model",
 			memory_ids: JSON.stringify([memoryId]),
 		});
 
-		const question = getDbAccessor().withReadDb(
+		const questionCount = getDbAccessor().withReadDb(
 			(db) =>
-				db.prepare("SELECT content, agent_id FROM memories WHERE source_type = ?").get("reflection-question") as {
-					content: string;
-					agent_id: string;
-				},
+				(
+					db.prepare("SELECT COUNT(*) AS count FROM memories WHERE source_type = ?").get("reflection-question") as {
+						count: number;
+					}
+				).count,
 		);
-		expect(question).toEqual({
-			content: "Daily reflection question: Should we keep it?",
-			agent_id: "default",
-		});
+		expect(questionCount).toBe(0);
 	});
 
-	it("skips question ingestion when another writer wins the daily insert race", async () => {
+	it("allows multiple same-day insights but de-duplicates repeated brief text", async () => {
 		seedMemory("default");
-		let inserted = false;
+		seedReflection("default");
 		const worker = startReflectionWorker(config, {
 			getDbAccessor,
-			getInferenceProvider: () => ({
-				name: "racing-provider",
-				async available(): Promise<boolean> {
-					return true;
-				},
-				async generate(): Promise<string> {
-					if (!inserted) {
-						seedReflection("default");
-						inserted = true;
-					}
-					return "SUMMARY: Lost race.\nPATTERNS: race\nQUESTION: Should not ingest?";
-				},
-			}),
+			getInferenceProvider: () => provider("INSIGHT: Existing reflection\nFOCUS: duplicate"),
 			logger,
 		});
 
@@ -193,7 +179,6 @@ describe("reflection worker", () => {
 			).count,
 		}));
 		expect(counts).toEqual({ questions: 0, reflections: 1 });
-		expect(existsSync(join(dir, ".daemon", "last-reflection.default.json"))).toBe(true);
 	});
 
 	it("scheduled trigger reflects every active agent instead of hardcoding default", async () => {

--- a/platform/daemon/src/pipeline/reflection-worker.test.ts
+++ b/platform/daemon/src/pipeline/reflection-worker.test.ts
@@ -7,7 +7,7 @@ import type { LlmProvider, PipelineReflectionsConfig } from "@signet/core";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
 import { logger } from "../logger";
 import { txIngestEnvelope } from "../transactions";
-import { nextReflectionDelayMs, startReflectionWorker } from "./reflection-worker";
+import { generateDailyBriefInsights, nextReflectionDelayMs, startReflectionWorker } from "./reflection-worker";
 
 let dir: string;
 const previousSignetPath = process.env.SIGNET_PATH;
@@ -179,6 +179,52 @@ describe("reflection worker", () => {
 			).count,
 		}));
 		expect(counts).toEqual({ questions: 0, reflections: 1 });
+	});
+
+	it("deduplicates concurrent dashboard-open generations at insert time", async () => {
+		seedMemory("default");
+		let waiting = 0;
+		let release: (() => void) | null = null;
+		const barrier = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const raceProvider: LlmProvider = {
+			name: "race-provider",
+			async available(): Promise<boolean> {
+				return true;
+			},
+			async generate(): Promise<string> {
+				waiting += 1;
+				if (waiting === 2) release?.();
+				await barrier;
+				return "INSIGHT: Should this duplicate be inserted once?\nFOCUS: race, dedupe";
+			},
+		};
+		await Promise.all([
+			generateDailyBriefInsights("default", config, 1, {
+				getDbAccessor,
+				getInferenceProvider: () => raceProvider,
+				logger,
+			}),
+			generateDailyBriefInsights("default", config, 1, {
+				getDbAccessor,
+				getInferenceProvider: () => raceProvider,
+				logger,
+			}),
+		]);
+
+		const rows = getDbAccessor().withReadDb((db) => {
+			return db.prepare("SELECT summary, content_key FROM daily_reflections WHERE agent_id = ?").all("default") as {
+				summary: string;
+				content_key: string;
+			}[];
+		});
+		expect(rows).toEqual([
+			{
+				summary: "Should this duplicate be inserted once?",
+				content_key: "should this duplicate be inserted once",
+			},
+		]);
 	});
 
 	it("scheduled trigger reflects every active agent instead of hardcoding default", async () => {

--- a/platform/daemon/src/pipeline/reflection-worker.test.ts
+++ b/platform/daemon/src/pipeline/reflection-worker.test.ts
@@ -7,7 +7,12 @@ import type { LlmProvider, PipelineReflectionsConfig } from "@signet/core";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
 import { logger } from "../logger";
 import { txIngestEnvelope } from "../transactions";
-import { generateDailyBriefInsights, nextReflectionDelayMs, startReflectionWorker } from "./reflection-worker";
+import {
+	collectReflectionContext,
+	generateDailyBriefInsights,
+	nextReflectionDelayMs,
+	startReflectionWorker,
+} from "./reflection-worker";
 
 let dir: string;
 const previousSignetPath = process.env.SIGNET_PATH;
@@ -35,21 +40,29 @@ function provider(text: string): LlmProvider {
 	};
 }
 
-function seedMemory(agentId: string): string {
-	const now = new Date().toISOString();
+function seedMemory(
+	agentId: string,
+	opts: {
+		readonly content?: string;
+		readonly createdAt?: string;
+		readonly pinned?: number;
+		readonly hash?: string;
+	} = {},
+): string {
+	const now = opts.createdAt ?? new Date().toISOString();
 	const id = randomUUID();
 	getDbAccessor().withWriteTx((db) => {
 		txIngestEnvelope(db, {
 			id,
-			content: "The reflection worker needs durable persistence.",
-			contentHash: `worker-test-${agentId}`,
+			content: opts.content ?? "The reflection worker needs durable persistence.",
+			contentHash: opts.hash ?? `worker-test-${agentId}`,
 			who: "tester",
 			why: "test-seed",
 			project: null,
 			importance: 0.5,
 			type: "fact",
 			tags: "test",
-			pinned: 0,
+			pinned: opts.pinned ?? 0,
 			sourceType: "test",
 			sourceId: "reflection-worker.test",
 			agentId,
@@ -109,6 +122,23 @@ describe("reflection worker", () => {
 		}
 
 		expect(existsSync(join(dir, ".daemon", "last-reflection.default.json"))).toBe(false);
+	});
+
+	it("collects recent source context and only lets pinned old memories bypass the cutoff", () => {
+		const old = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+		const recentId = seedMemory("default", { content: "Recent source", hash: "recent-source" });
+		const pinnedId = seedMemory("default", {
+			content: "Pinned durable source",
+			createdAt: old,
+			pinned: 1,
+			hash: "pinned-source",
+		});
+		seedMemory("default", { content: "Stale unpinned source", createdAt: old, hash: "stale-source" });
+
+		const context = collectReflectionContext("default", config);
+
+		expect(context.memories.map((m) => m.id)).toEqual([pinnedId, recentId]);
+		expect(context.memories.map((m) => m.content)).not.toContain("Stale unpinned source");
 	});
 
 	it("persists generated brief insights", async () => {

--- a/platform/daemon/src/pipeline/reflection-worker.ts
+++ b/platform/daemon/src/pipeline/reflection-worker.ts
@@ -251,16 +251,17 @@ export function collectReflectionContext(
 ): ReflectionSourceContext {
 	const maxMemories = Math.max(config.maxMemories, 24);
 	const maxSummaries = Math.max(config.maxSummaries, 12);
+	const cutoff = new Date(Date.now() - Math.max(config.timeWindowHours, 1) * 60 * 60 * 1000).toISOString();
 	const dbAccessor = deps.getDbAccessor();
 
 	const memories = dbAccessor.withReadDb((db) => {
 		const rows = db
 			.prepare(
 				`SELECT id, content, type, tags, created_at FROM memories
-             WHERE agent_id = ? AND is_deleted = 0
-             ORDER BY pinned DESC, importance DESC, created_at DESC LIMIT ?`,
+				 WHERE agent_id = ? AND is_deleted = 0 AND (created_at >= ? OR pinned = 1)
+				 ORDER BY pinned DESC, importance DESC, created_at DESC LIMIT ?`,
 			)
-			.all(agentId, maxMemories) as {
+			.all(agentId, cutoff, maxMemories) as {
 			id: string;
 			content: string;
 			type: string;
@@ -280,10 +281,10 @@ export function collectReflectionContext(
 		const rows = db
 			.prepare(
 				`SELECT id, content, created_at, latest_at, session_key FROM session_summaries
-             WHERE agent_id = ?
-             ORDER BY COALESCE(latest_at, created_at) DESC LIMIT ?`,
+				 WHERE agent_id = ? AND COALESCE(latest_at, created_at) >= ?
+				 ORDER BY COALESCE(latest_at, created_at) DESC LIMIT ?`,
 			)
-			.all(agentId, maxSummaries) as {
+			.all(agentId, cutoff, maxSummaries) as {
 			id: string;
 			content: string;
 			created_at: string;
@@ -303,10 +304,10 @@ export function collectReflectionContext(
 		const rows = db
 			.prepare(
 				`SELECT session_key, content, project, created_at FROM session_transcripts
-             WHERE agent_id = ?
-             ORDER BY created_at DESC LIMIT 4`,
+				 WHERE agent_id = ? AND COALESCE(updated_at, created_at) >= ?
+				 ORDER BY COALESCE(updated_at, created_at) DESC LIMIT 4`,
 			)
-			.all(agentId) as { session_key: string; content: string; project: string | null; created_at: string }[];
+			.all(agentId, cutoff) as { session_key: string; content: string; project: string | null; created_at: string }[];
 		return rows.map((r) => ({
 			sessionKey: r.session_key,
 			content: r.content,
@@ -319,13 +320,14 @@ export function collectReflectionContext(
 		const attributes = db
 			.prepare(
 				`SELECT e.name AS entity, e.entity_type AS kind, ea.name AS aspect, attr.content AS content, attr.updated_at AS updated_at
-             FROM entity_attributes attr
-             LEFT JOIN entity_aspects ea ON ea.id = attr.aspect_id
-             LEFT JOIN entities e ON e.id = ea.entity_id
-             WHERE attr.agent_id = ? AND attr.status = 'active' AND e.name IS NOT NULL
-             ORDER BY attr.importance DESC, attr.updated_at DESC LIMIT 28`,
+				 FROM entity_attributes attr
+				 LEFT JOIN entity_aspects ea ON ea.id = attr.aspect_id
+				 LEFT JOIN entities e ON e.id = ea.entity_id
+				 WHERE attr.agent_id = ? AND attr.status = 'active' AND e.name IS NOT NULL
+				   AND COALESCE(attr.updated_at, attr.created_at) >= ?
+				 ORDER BY attr.importance DESC, attr.updated_at DESC LIMIT 28`,
 			)
-			.all(agentId) as {
+			.all(agentId, cutoff) as {
 			entity: string;
 			kind: string;
 			aspect: string | null;

--- a/platform/daemon/src/pipeline/reflection-worker.ts
+++ b/platform/daemon/src/pipeline/reflection-worker.ts
@@ -391,28 +391,33 @@ export async function generateDailyBriefInsights(
 	const date = todayDate();
 	const memoryIds = JSON.stringify(context.memories.map((m) => m.id).filter(Boolean));
 	const summaryIds = JSON.stringify(context.summaries.map((s) => s.id).filter(Boolean));
-	const ids = insights.map(() => randomUUID());
+	const ids: string[] = [];
 
 	deps.getDbAccessor().withWriteTx((db) => {
-		insights.forEach((insight, index) => {
-			const id = ids[index];
-			db.prepare(
-				`INSERT INTO daily_reflections
-				 (id, agent_id, date, summary, patterns, question, memory_ids, summary_ids, model, created_at)
-				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-			).run(
-				id,
-				agentId,
-				date,
-				insight.summary,
-				JSON.stringify(insight.patterns),
-				insight.question ?? null,
-				memoryIds,
-				summaryIds,
-				config.model,
-				now,
-			);
-		});
+		for (const insight of insights) {
+			const id = randomUUID();
+			const contentKey = normalizeInsight(insight.question ?? insight.summary);
+			const result = db
+				.prepare(
+					`INSERT OR IGNORE INTO daily_reflections
+				 (id, agent_id, date, summary, patterns, question, content_key, memory_ids, summary_ids, model, created_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				)
+				.run(
+					id,
+					agentId,
+					date,
+					insight.summary,
+					JSON.stringify(insight.patterns),
+					insight.question ?? null,
+					contentKey,
+					memoryIds,
+					summaryIds,
+					config.model,
+					now,
+				);
+			if (result.changes > 0) ids.push(id);
+		}
 	});
 
 	return ids;

--- a/platform/daemon/src/pipeline/reflection-worker.ts
+++ b/platform/daemon/src/pipeline/reflection-worker.ts
@@ -6,7 +6,6 @@ import type { PipelineReflectionsConfig } from "@signet/core";
 import { getDbAccessor } from "../db-accessor";
 import { getInferenceProvider } from "../llm";
 import { logger } from "../logger";
-import { txIngestEnvelope } from "../transactions";
 
 type ReflectionDeps = {
 	readonly getDbAccessor: typeof getDbAccessor;
@@ -60,11 +59,6 @@ function todayDate(now = new Date()): string {
 	return now.toISOString().slice(0, 10);
 }
 
-function isDailyReflectionUniqueConflict(e: unknown): boolean {
-	const message = e instanceof Error ? e.message : String(e);
-	return message.toLowerCase().includes("unique") && message.includes("daily_reflections");
-}
-
 function scheduledTimeFor(schedule: string, now = new Date()): Date | null {
 	const parts = schedule.trim().split(/\s+/);
 	if (parts.length !== 5 || parts[2] !== "*" || parts[3] !== "*" || parts[4] !== "*") return null;
@@ -88,33 +82,98 @@ export function nextReflectionDelayMs(schedule: string, lastDate: string | null,
 	return POLL_INTERVAL_MS;
 }
 
-export function buildReflectionPrompt(
-	memories: { content: string; type: string; tags: string; createdAt: string }[],
-	summaries: { content: string; createdAt: string }[],
-): string {
+type ReflectionMemory = { id?: string; content: string; type: string; tags: string; createdAt: string };
+type ReflectionSummary = {
+	id?: string;
+	content: string;
+	createdAt: string;
+	latestAt?: string | null;
+	sessionKey?: string | null;
+};
+type ReflectionTranscript = { sessionKey: string; content: string; createdAt: string; project?: string | null };
+type ReflectionGraphFact = { entity: string; kind: string; detail: string; updatedAt?: string | null };
+type ExistingReflection = { id: string; question: string | null; summary: string; createdAt: string };
+
+export type DailyBriefInsight = {
+	readonly summary: string;
+	readonly question?: string;
+	readonly patterns: string[];
+};
+
+export type ReflectionSourceContext = {
+	readonly memories: ReflectionMemory[];
+	readonly summaries: ReflectionSummary[];
+	readonly transcripts: ReflectionTranscript[];
+	readonly graphFacts: ReflectionGraphFact[];
+	readonly existingReflections: ExistingReflection[];
+};
+
+function normalizeInsight(text: string): string {
+	return text
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, " ")
+		.trim()
+		.replace(/\s+/g, " ");
+}
+
+function trimLine(text: string, max = 260): string {
+	const single = text.replace(/\s+/g, " ").trim();
+	return single.length > max ? `${single.slice(0, max - 1).trim()}…` : single;
+}
+
+export function buildReflectionPrompt(context: ReflectionSourceContext, count = 3): string {
 	const lines: string[] = [
-		"You are a thoughtful assistant reviewing the last 24 hours of activity.",
-		"Your task is to produce a daily reflection in the following format:",
+		"You are Signet's Daily Brief generator.",
+		"Reason over recent transcripts, memory, and the knowledge graph like a helpful assistant searching its memory for what is unclear or worth resolving.",
+		"Generate fresh, concrete, non-redundant insights for the dashboard. Do not write a daily report. Do not summarize the last 24 hours.",
+		`Return exactly ${count} items. Each item should be one short useful question or observation, ideally one sentence and never more than two.`,
+		"Prefer open loops, contradictions, unresolved decisions, repeated blockers, or connections the user has not explicitly closed.",
+		"Avoid repeating existing brief items. Avoid generic productivity advice.",
 		"",
-		"SUMMARY: <2-3 sentence narrative of what the user worked on>",
-		"PATTERNS: <comma-separated list of themes or patterns noticed>",
-		"QUESTION: <optional - a specific question that only makes sense because you were watching. If nothing worth asking, omit this line>",
+		"Output only lines in this format:",
+		"INSIGHT: <short useful question or insight>",
+		"FOCUS: <2-5 comma-separated concrete tags>",
 		"",
-		"Keep the summary concrete and specific. The question should be about something the user",
-		"might want to act on or think about. If nothing stands out, just provide the summary.",
-		"",
-		"Recent memories:",
 	];
 
-	for (const m of memories) {
-		const date = m.createdAt.slice(0, 10);
-		lines.push(`  [${date}] (${m.type}) ${m.tags ? `[${m.tags}] ` : ""}${m.content}`);
+	if (context.existingReflections.length > 0) {
+		lines.push("Existing brief items to avoid repeating:");
+		for (const r of context.existingReflections.slice(0, 12)) {
+			lines.push(`  [${r.createdAt.slice(0, 10)}] ${trimLine(r.question ?? r.summary, 220)}`);
+		}
+		lines.push("");
 	}
 
-	if (summaries.length > 0) {
-		lines.push("", "Recent session summaries:");
-		for (const s of summaries) {
-			lines.push(`  [${s.createdAt.slice(0, 10)}] ${s.content.slice(0, 500)}`);
+	if (context.transcripts.length > 0) {
+		lines.push("Recent transcript excerpts:");
+		for (const t of context.transcripts) {
+			const project = t.project ? ` project=${t.project}` : "";
+			lines.push(`  [${t.createdAt.slice(0, 10)}${project}] ${trimLine(t.content, 900)}`);
+		}
+		lines.push("");
+	}
+
+	if (context.summaries.length > 0) {
+		lines.push("Recent session summaries:");
+		for (const s of context.summaries) {
+			lines.push(`  [${s.createdAt.slice(0, 10)}] ${trimLine(s.content, 650)}`);
+		}
+		lines.push("");
+	}
+
+	if (context.memories.length > 0) {
+		lines.push("Relevant memories:");
+		for (const m of context.memories) {
+			const date = m.createdAt.slice(0, 10);
+			lines.push(`  [${date}] (${m.type}) ${m.tags ? `[${m.tags}] ` : ""}${trimLine(m.content, 500)}`);
+		}
+		lines.push("");
+	}
+
+	if (context.graphFacts.length > 0) {
+		lines.push("Knowledge graph facts:");
+		for (const g of context.graphFacts) {
+			lines.push(`  ${g.entity} (${g.kind}): ${trimLine(g.detail, 360)}`);
 		}
 	}
 
@@ -122,6 +181,8 @@ export function buildReflectionPrompt(
 }
 
 export function parseReflectionResponse(text: string): { summary: string; patterns: string[]; question?: string } {
+	const insight = parseDailyBriefInsights(text, 1)[0];
+	if (insight) return { summary: insight.summary, patterns: insight.patterns, question: insight.question };
 	const summary = text.match(/SUMMARY:\s*(.+?)(?:\n|$)/)?.[1]?.trim() ?? text.slice(0, 500);
 	const patternsRaw = text.match(/PATTERNS:\s*(.+?)(?:\n|$)/)?.[1]?.trim() ?? "";
 	const patterns = patternsRaw
@@ -131,6 +192,230 @@ export function parseReflectionResponse(text: string): { summary: string; patter
 	const question = text.match(/QUESTION:\s*(.+?)(?:\n|$)/)?.[1]?.trim();
 
 	return { summary, patterns, question };
+}
+
+export function parseDailyBriefInsights(text: string, limit = 3): DailyBriefInsight[] {
+	const insights: DailyBriefInsight[] = [];
+	let pending: string | null = null;
+	let patterns: string[] = [];
+
+	function flush(): void {
+		if (!pending) return;
+		const summary = trimLine(pending, 420);
+		insights.push({ summary, question: summary.includes("?") ? summary : undefined, patterns });
+		pending = null;
+		patterns = [];
+	}
+
+	for (const rawLine of text.split(/\r?\n/)) {
+		const line = rawLine.trim();
+		if (!line) continue;
+		const insight = line.match(/^(?:[-*]\s*)?(?:INSIGHT|QUESTION|BRIEF)\s*:\s*(.+)$/i)?.[1];
+		if (insight) {
+			flush();
+			pending = insight.trim();
+			continue;
+		}
+		const focus = line.match(/^(?:FOCUS|PATTERNS|TAGS)\s*:\s*(.+)$/i)?.[1];
+		if (focus && pending) {
+			patterns = focus
+				.split(",")
+				.map((p) => p.trim())
+				.filter(Boolean)
+				.slice(0, 5);
+		}
+	}
+	flush();
+
+	if (insights.length === 0) {
+		const fallback = trimLine(text, 420);
+		if (fallback)
+			insights.push({ summary: fallback, question: fallback.includes("?") ? fallback : undefined, patterns: [] });
+	}
+
+	const seen = new Set<string>();
+	return insights
+		.filter((item) => {
+			const key = normalizeInsight(item.question ?? item.summary);
+			if (!key || seen.has(key)) return false;
+			seen.add(key);
+			return true;
+		})
+		.slice(0, limit);
+}
+
+export function collectReflectionContext(
+	agentId: string,
+	config: PipelineReflectionsConfig,
+	deps: Pick<ReflectionDeps, "getDbAccessor"> = DEFAULT_DEPS,
+): ReflectionSourceContext {
+	const maxMemories = Math.max(config.maxMemories, 24);
+	const maxSummaries = Math.max(config.maxSummaries, 12);
+	const dbAccessor = deps.getDbAccessor();
+
+	const memories = dbAccessor.withReadDb((db) => {
+		const rows = db
+			.prepare(
+				`SELECT id, content, type, tags, created_at FROM memories
+             WHERE agent_id = ? AND is_deleted = 0
+             ORDER BY pinned DESC, importance DESC, created_at DESC LIMIT ?`,
+			)
+			.all(agentId, maxMemories) as {
+			id: string;
+			content: string;
+			type: string;
+			tags: string | null;
+			created_at: string;
+		}[];
+		return rows.map((r) => ({
+			id: r.id,
+			content: r.content,
+			type: r.type,
+			tags: r.tags ?? "",
+			createdAt: r.created_at,
+		}));
+	});
+
+	const summaries = dbAccessor.withReadDb((db) => {
+		const rows = db
+			.prepare(
+				`SELECT id, content, created_at, latest_at, session_key FROM session_summaries
+             WHERE agent_id = ?
+             ORDER BY COALESCE(latest_at, created_at) DESC LIMIT ?`,
+			)
+			.all(agentId, maxSummaries) as {
+			id: string;
+			content: string;
+			created_at: string;
+			latest_at: string | null;
+			session_key: string | null;
+		}[];
+		return rows.map((r) => ({
+			id: r.id,
+			content: r.content,
+			createdAt: r.created_at,
+			latestAt: r.latest_at,
+			sessionKey: r.session_key,
+		}));
+	});
+
+	const transcripts = dbAccessor.withReadDb((db) => {
+		const rows = db
+			.prepare(
+				`SELECT session_key, content, project, created_at FROM session_transcripts
+             WHERE agent_id = ?
+             ORDER BY created_at DESC LIMIT 4`,
+			)
+			.all(agentId) as { session_key: string; content: string; project: string | null; created_at: string }[];
+		return rows.map((r) => ({
+			sessionKey: r.session_key,
+			content: r.content,
+			project: r.project,
+			createdAt: r.created_at,
+		}));
+	});
+
+	const graphFacts = dbAccessor.withReadDb((db) => {
+		const attributes = db
+			.prepare(
+				`SELECT e.name AS entity, e.entity_type AS kind, ea.name AS aspect, attr.content AS content, attr.updated_at AS updated_at
+             FROM entity_attributes attr
+             LEFT JOIN entity_aspects ea ON ea.id = attr.aspect_id
+             LEFT JOIN entities e ON e.id = ea.entity_id
+             WHERE attr.agent_id = ? AND attr.status = 'active' AND e.name IS NOT NULL
+             ORDER BY attr.importance DESC, attr.updated_at DESC LIMIT 28`,
+			)
+			.all(agentId) as {
+			entity: string;
+			kind: string;
+			aspect: string | null;
+			content: string;
+			updated_at: string | null;
+		}[];
+		return attributes.map((r) => ({
+			entity: r.entity,
+			kind: r.kind,
+			detail: `${r.aspect ? `${r.aspect}: ` : ""}${r.content}`,
+			updatedAt: r.updated_at,
+		}));
+	});
+
+	const existingReflections = dbAccessor.withReadDb((db) => {
+		const rows = db
+			.prepare(
+				`SELECT id, question, summary, created_at FROM daily_reflections
+             WHERE agent_id = ?
+             ORDER BY created_at DESC LIMIT 24`,
+			)
+			.all(agentId) as { id: string; question: string | null; summary: string; created_at: string }[];
+		return rows.map((r) => ({ id: r.id, question: r.question, summary: r.summary, createdAt: r.created_at }));
+	});
+
+	return { memories, summaries, transcripts, graphFacts, existingReflections };
+}
+
+export async function generateDailyBriefInsights(
+	agentId: string,
+	config: PipelineReflectionsConfig,
+	count = 3,
+	deps: ReflectionDeps = DEFAULT_DEPS,
+): Promise<string[]> {
+	const context = collectReflectionContext(agentId, config, deps);
+	if (
+		context.memories.length === 0 &&
+		context.summaries.length === 0 &&
+		context.transcripts.length === 0 &&
+		context.graphFacts.length === 0
+	) {
+		return [];
+	}
+
+	const prompt = buildReflectionPrompt(context, count);
+	const provider = deps.getInferenceProvider("default");
+	const raw = await provider.generate(prompt, { timeoutMs: config.timeout, maxTokens: config.maxTokens });
+	const existing = new Set(
+		context.existingReflections.map((r) => normalizeInsight(r.question ?? r.summary)).filter(Boolean),
+	);
+	const insights = parseDailyBriefInsights(raw, Math.max(count * 2, count))
+		.filter((insight) => {
+			const key = normalizeInsight(insight.question ?? insight.summary);
+			if (!key || existing.has(key)) return false;
+			existing.add(key);
+			return true;
+		})
+		.slice(0, count);
+
+	if (insights.length === 0) return [];
+
+	const now = new Date().toISOString();
+	const date = todayDate();
+	const memoryIds = JSON.stringify(context.memories.map((m) => m.id).filter(Boolean));
+	const summaryIds = JSON.stringify(context.summaries.map((s) => s.id).filter(Boolean));
+	const ids = insights.map(() => randomUUID());
+
+	deps.getDbAccessor().withWriteTx((db) => {
+		insights.forEach((insight, index) => {
+			const id = ids[index];
+			db.prepare(
+				`INSERT INTO daily_reflections
+				 (id, agent_id, date, summary, patterns, question, memory_ids, summary_ids, model, created_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			).run(
+				id,
+				agentId,
+				date,
+				insight.summary,
+				JSON.stringify(insight.patterns),
+				insight.question ?? null,
+				memoryIds,
+				summaryIds,
+				config.model,
+				now,
+			);
+		});
+	});
+
+	return ids;
 }
 
 export interface ReflectionWorkerHandle {
@@ -149,142 +434,20 @@ export function startReflectionWorker(
 	let generating = false;
 
 	async function runReflection(agentId: string): Promise<void> {
-		const date = todayDate();
-		const existing = deps.getDbAccessor().withReadDb((db) => {
-			const row = db.prepare("SELECT id FROM daily_reflections WHERE agent_id = ? AND date = ?").get(agentId, date) as
-				| { id: string }
-				| undefined;
-			return row?.id ?? null;
-		});
-		if (existing) {
-			writeLastReflectionTime(agentId, date);
-			return;
-		}
-
-		const cutoff = new Date(Date.now() - config.timeWindowHours * 60 * 60 * 1000).toISOString();
-
-		const memories = deps.getDbAccessor().withReadDb((db) => {
-			const rows = db
-				.prepare(
-					`SELECT id, content, type, tags, created_at FROM memories
-           WHERE agent_id = ? AND created_at >= ? AND is_deleted = 0
-           ORDER BY created_at DESC LIMIT ?`,
-				)
-				.all(agentId, cutoff, config.maxMemories) as {
-				id: string;
-				content: string;
-				type: string;
-				tags: string;
-				created_at: string;
-			}[];
-			return rows.map((r) => ({
-				id: r.id,
-				content: r.content,
-				type: r.type,
-				tags: r.tags ?? "",
-				createdAt: r.created_at,
-			}));
-		});
-
-		const summaries = deps.getDbAccessor().withReadDb((db) => {
-			const rows = db
-				.prepare(
-					`SELECT id, content, created_at FROM session_summaries
-           WHERE agent_id = ? AND created_at >= ?
-           ORDER BY created_at DESC LIMIT ?`,
-				)
-				.all(agentId, cutoff, config.maxSummaries) as {
-				id: string;
-				content: string;
-				created_at: string;
-			}[];
-			return rows.map((r) => ({ id: r.id, content: r.content, createdAt: r.created_at }));
-		});
-
-		if (memories.length === 0 && summaries.length === 0) {
-			deps.logger.debug("reflections", "No memories or summaries to reflect on", { agentId, date });
-			return;
-		}
-
-		const prompt = buildReflectionPrompt(memories, summaries);
-
-		let raw: string;
 		try {
-			const provider = deps.getInferenceProvider("default");
-			raw = await provider.generate(prompt, {
-				timeoutMs: config.timeout,
-				maxTokens: config.maxTokens,
-			});
+			const ids = await generateDailyBriefInsights(agentId, config, 1, deps);
+			if (ids.length === 0) {
+				deps.logger.debug("reflections", "No source material or fresh insight to reflect on", { agentId });
+				return;
+			}
+			writeLastReflectionTime(agentId, todayDate());
+			deps.logger.info("reflections", "Generated daily brief insight", { agentId, count: ids.length });
 		} catch (e) {
 			deps.logger.warn("reflections", "Generation failed", {
 				error: e instanceof Error ? e.message : String(e),
 				agentId,
 			});
-			return;
 		}
-
-		const { summary, patterns, question } = parseReflectionResponse(raw);
-
-		const id = randomUUID();
-		const memoryIds = JSON.stringify(memories.map((m) => m.id));
-		const summaryIds = JSON.stringify(summaries.map((s) => s.id));
-		const now = new Date().toISOString();
-
-		try {
-			deps.getDbAccessor().withWriteTx((db) => {
-				db.prepare(
-					`INSERT INTO daily_reflections
-					 (id, agent_id, date, summary, patterns, question, memory_ids, summary_ids, model, created_at)
-					 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-				).run(
-					id,
-					agentId,
-					date,
-					summary,
-					JSON.stringify(patterns),
-					question ?? null,
-					memoryIds,
-					summaryIds,
-					config.model,
-					now,
-				);
-
-				if (question) {
-					txIngestEnvelope(db, {
-						id: randomUUID(),
-						content: `Daily reflection question: ${question}`,
-						contentHash: `reflection-q-${id}`,
-						who: "system",
-						why: "daily-reflection-question",
-						project: null,
-						importance: 0.5,
-						type: "reflection",
-						tags: "reflection,unanswered",
-						pinned: 0,
-						sourceType: "reflection-question",
-						sourceId: id,
-						agentId,
-						createdAt: now,
-					});
-				}
-			});
-		} catch (e) {
-			if (isDailyReflectionUniqueConflict(e)) {
-				deps.logger.debug("reflections", "Reflection already generated before worker insert", { agentId, date });
-				writeLastReflectionTime(agentId, date);
-				return;
-			}
-			throw e;
-		}
-
-		writeLastReflectionTime(agentId, date);
-
-		deps.logger.info("reflections", "Generated daily reflection", {
-			agentId,
-			date,
-			hasQuestion: !!question,
-			patterns: patterns.length,
-		});
 	}
 
 	function listActiveAgentIds(): string[] {

--- a/platform/daemon/src/routes/reflection-routes.test.ts
+++ b/platform/daemon/src/routes/reflection-routes.test.ts
@@ -49,23 +49,19 @@ function seedMemory(agentId: string, content = "Built daily reflections."): stri
 	return id;
 }
 
-function seedReflection(id: string, agentId: string, date = "2026-05-12"): void {
+function seedReflection(
+	id: string,
+	agentId: string,
+	date = "2026-05-12",
+	summary = "Reflection summary",
+	createdAt = new Date().toISOString(),
+): void {
 	getDbAccessor().withWriteTx((db) => {
 		db.prepare(
 			`INSERT INTO daily_reflections
 			 (id, agent_id, date, summary, patterns, question, memory_ids, summary_ids, created_at)
 			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		).run(
-			id,
-			agentId,
-			date,
-			"Reflection summary",
-			JSON.stringify(["testing"]),
-			"What did we learn?",
-			"[]",
-			"[]",
-			new Date().toISOString(),
-		);
+		).run(id, agentId, date, summary, JSON.stringify(["testing"]), "What did we learn?", "[]", "[]", createdAt);
 	});
 }
 
@@ -117,8 +113,8 @@ describe("reflection routes", () => {
 		const res = await app().request("/api/reflections/generate?agentId=agent-a", { method: "POST" });
 		expect(res.status).toBe(200);
 		const body = await res.json();
-		expect(body.reflection.summary).toBe("We fixed reflections.");
-		expect(body.reflection.patterns).toEqual(["persistence", "scoping"]);
+		expect(body.reflection.summary).toBe("Keep it?");
+		expect(body.reflection.patterns).toEqual([]);
 
 		const row = getDbAccessor().withReadDb(
 			(db) =>
@@ -131,6 +127,20 @@ describe("reflection routes", () => {
 				},
 		);
 		expect(row).toEqual({ agent_id: "agent-a", model: "test-model", memory_ids: JSON.stringify([memoryId]) });
+	});
+
+	it("returns all same-day brief items from the today endpoint", async () => {
+		seedReflection("older", "agent-today", "2026-05-13", "Older insight", "2026-05-13T08:00:00.000Z");
+		seedReflection("newer", "agent-today", "2026-05-13", "Newer insight", "2026-05-13T09:00:00.000Z");
+
+		const res = await app().request("/api/reflections/today?agentId=agent-today&limit=10");
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.reflection.summary).toBe("Newer insight");
+		expect(body.reflections.map((reflection: { summary: string }) => reflection.summary)).toEqual([
+			"Newer insight",
+			"Older insight",
+		]);
 	});
 
 	it("defaults invalid list limits instead of allowing unlimited history", async () => {

--- a/platform/daemon/src/routes/reflection-routes.ts
+++ b/platform/daemon/src/routes/reflection-routes.ts
@@ -79,19 +79,17 @@ export function registerReflectionRoutes(app: Hono): void {
 	app.get("/api/reflections/today", (c) => {
 		const agentId = c.req.query("agentId") ?? "default";
 		const date = new Date().toISOString().slice(0, 10);
+		const limit = parseReflectionLimit(c.req.query("limit"));
 
 		try {
-			const row = getDbAccessor().withReadDb((db) => {
-				return db.prepare("SELECT * FROM daily_reflections WHERE agent_id = ? AND date = ?").get(agentId, date) as
-					| ReflectionRow
-					| undefined;
+			const rows = getDbAccessor().withReadDb((db) => {
+				return db
+					.prepare("SELECT * FROM daily_reflections WHERE agent_id = ? AND date = ? ORDER BY created_at DESC LIMIT ?")
+					.all(agentId, date, limit) as ReflectionRow[];
 			});
 
-			if (!row) {
-				return c.json({ reflection: null });
-			}
-
-			return c.json({ reflection: formatReflection(row) });
+			const reflections = rows.map(formatReflection);
+			return c.json({ reflection: reflections[0] ?? null, reflections });
 		} catch (e) {
 			logger.error("reflections", "Failed to fetch today's reflection", e instanceof Error ? e : undefined);
 			return c.json({ error: "Failed to fetch reflection" }, 500);

--- a/platform/daemon/src/routes/reflection-routes.ts
+++ b/platform/daemon/src/routes/reflection-routes.ts
@@ -4,10 +4,9 @@ import { join } from "node:path";
 import type { Hono } from "hono";
 import { requirePermission } from "../auth";
 import { getDbAccessor } from "../db-accessor";
-import { getInferenceProvider } from "../llm";
 import { logger } from "../logger";
 import { loadMemoryConfig } from "../memory-config";
-import { buildReflectionPrompt, parseReflectionResponse } from "../pipeline/reflection-worker";
+import { generateDailyBriefInsights } from "../pipeline/reflection-worker";
 import { txIngestEnvelope } from "../transactions";
 import { authConfig } from "./state";
 
@@ -24,6 +23,13 @@ function parseReflectionLimit(raw: string | undefined): number {
 	const parsed = Number.parseInt(raw, 10);
 	if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_REFLECTION_LIMIT;
 	return Math.min(parsed, MAX_REFLECTION_LIMIT);
+}
+
+function parseGenerateCount(raw: string | undefined): number {
+	if (raw === undefined) return 3;
+	const parsed = Number.parseInt(raw, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) return 3;
+	return Math.min(parsed, 6);
 }
 
 interface ReflectionRow {
@@ -104,7 +110,7 @@ export function registerReflectionRoutes(app: Hono): void {
                         answer_memory_id, created_at, answered_at
                  FROM daily_reflections
                  WHERE agent_id = ?
-                 ORDER BY date DESC
+                 ORDER BY created_at DESC
                  LIMIT ?`,
 					)
 					.all(agentId, limit) as ReflectionRow[];
@@ -119,16 +125,8 @@ export function registerReflectionRoutes(app: Hono): void {
 
 	app.post("/api/reflections/generate", async (c) => {
 		const agentId = c.req.query("agentId") ?? "default";
+		const count = parseGenerateCount(c.req.query("count"));
 		const date = new Date().toISOString().slice(0, 10);
-
-		const existing = getDbAccessor().withReadDb((db) => {
-			return db.prepare("SELECT id FROM daily_reflections WHERE agent_id = ? AND date = ?").get(agentId, date) as
-				| { id: string }
-				| undefined;
-		});
-		if (existing) {
-			return c.json({ error: "Reflection already exists for today" }, 409);
-		}
 
 		const pipelineCfg = loadMemoryConfig(getAgentsDir()).pipelineV2;
 		const cfg = pipelineCfg.reflections;
@@ -136,104 +134,33 @@ export function registerReflectionRoutes(app: Hono): void {
 			return c.json({ error: "Reflections are disabled in pipeline config" }, 400);
 		}
 
-		const cutoff = new Date(Date.now() - cfg.timeWindowHours * 60 * 60 * 1000).toISOString();
-
-		const memories = getDbAccessor().withReadDb((db) => {
-			return (
-				db
-					.prepare(
-						`SELECT id, content, type, tags, created_at FROM memories
-             WHERE agent_id = ? AND created_at >= ? AND is_deleted = 0
-             ORDER BY created_at DESC LIMIT ?`,
-					)
-					.all(agentId, cutoff, cfg.maxMemories) as {
-					id: string;
-					content: string;
-					type: string;
-					tags: string;
-					created_at: string;
-				}[]
-			).map((r) => ({
-				id: r.id,
-				content: r.content,
-				type: r.type,
-				tags: r.tags ?? "",
-				createdAt: r.created_at,
-			}));
-		});
-
-		const summaries = getDbAccessor().withReadDb((db) => {
-			return (
-				db
-					.prepare(
-						`SELECT id, content, created_at FROM session_summaries
-             WHERE agent_id = ? AND created_at >= ?
-             ORDER BY created_at DESC LIMIT ?`,
-					)
-					.all(agentId, cutoff, cfg.maxSummaries) as {
-					id: string;
-					content: string;
-					created_at: string;
-				}[]
-			).map((r) => ({ id: r.id, content: r.content, createdAt: r.created_at }));
-		});
-
-		if (memories.length === 0 && summaries.length === 0) {
-			return c.json({ error: "No memories or summaries in the time window" }, 400);
-		}
-
-		const prompt = buildReflectionPrompt(memories, summaries);
-		let raw: string;
+		let ids: string[];
 		try {
-			const provider = getInferenceProvider("default");
-			raw = await provider.generate(prompt, {
-				timeoutMs: cfg.timeout,
-				maxTokens: cfg.maxTokens,
-			});
+			ids = await generateDailyBriefInsights(agentId, cfg, count);
 		} catch (e) {
-			logger.error("reflections", "Manual generation failed", e instanceof Error ? e : undefined);
+			logger.error("reflections", "Daily brief generation failed", e instanceof Error ? e : undefined);
 			return c.json({ error: "LLM generation failed" }, 500);
 		}
 
-		const { summary, patterns, question } = parseReflectionResponse(raw);
-		const id = randomUUID();
-		const now = new Date().toISOString();
-
-		try {
-			getDbAccessor().withWriteTx((db) => {
-				db.prepare(
-					`INSERT INTO daily_reflections
-					 (id, agent_id, date, summary, patterns, question, memory_ids, summary_ids, model, created_at)
-					 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-				).run(
-					id,
-					agentId,
-					date,
-					summary,
-					JSON.stringify(patterns),
-					question ?? null,
-					JSON.stringify(memories.map((m) => m.id)),
-					JSON.stringify(summaries.map((s) => s.id)),
-					cfg.model,
-					now,
-				);
+		if (ids.length === 0) {
+			return c.json({
+				reflections: [],
+				generated: 0,
+				message: "No source material or fresh non-duplicate insight found",
 			});
-		} catch (e) {
-			const message = e instanceof Error ? e.message : String(e);
-			if (message.toLowerCase().includes("unique") && message.includes("daily_reflections")) {
-				return c.json({ error: "Reflection already exists for today" }, 409);
-			}
-			logger.error("reflections", "Failed to persist manual reflection", e instanceof Error ? e : undefined);
-			return c.json({ error: "Failed to persist reflection" }, 500);
 		}
 
-		logger.info("reflections", "Manually generated daily reflection", { id, agentId, date });
-
-		const row = getDbAccessor().withReadDb((db) => {
-			return db.prepare("SELECT * FROM daily_reflections WHERE id = ?").get(id) as ReflectionRow;
+		const rows = getDbAccessor().withReadDb((db) => {
+			return db
+				.prepare(
+					`SELECT * FROM daily_reflections WHERE id IN (${ids.map(() => "?").join(",")}) ORDER BY created_at DESC`,
+				)
+				.all(...ids) as ReflectionRow[];
 		});
 
-		return c.json({ reflection: formatReflection(row) });
+		logger.info("reflections", "Generated daily brief insights", { agentId, date, count: rows.length });
+		const reflections = rows.map(formatReflection);
+		return c.json({ reflection: reflections[0] ?? null, reflections, generated: reflections.length });
 	});
 
 	app.post("/api/reflections/:id/answer", async (c) => {

--- a/surfaces/dashboard/src/lib/api.ts
+++ b/surfaces/dashboard/src/lib/api.ts
@@ -2907,6 +2907,7 @@ export interface DailyReflection {
 
 export interface TodayReflectionResponse {
 	reflection: DailyReflection | null;
+	reflections?: DailyReflection[];
 }
 
 function agentQuery(agentId?: string): string {
@@ -2920,6 +2921,20 @@ export async function getTodayReflection(agentId?: string): Promise<TodayReflect
 		return (await res.json()) as TodayReflectionResponse;
 	} catch {
 		return { reflection: null };
+	}
+}
+
+export async function generateReflection(agentId?: string, count = 3): Promise<TodayReflectionResponse> {
+	try {
+		const suffix = agentQuery(agentId);
+		const separator = suffix ? "&" : "?";
+		const res = await fetch(`${API_BASE}/api/reflections/generate${suffix}${separator}count=${count}`, {
+			method: "POST",
+		});
+		if (!res.ok) return { reflection: null, reflections: [] };
+		return (await res.json()) as TodayReflectionResponse;
+	} catch {
+		return { reflection: null, reflections: [] };
 	}
 }
 

--- a/surfaces/dashboard/src/lib/components/home/DailyReflection.svelte
+++ b/surfaces/dashboard/src/lib/components/home/DailyReflection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { DailyReflection } from "$lib/api";
-import { answerReflection, getTodayReflection } from "$lib/api";
+import { answerReflection, generateReflection, getTodayReflection } from "$lib/api";
 import { toast } from "$lib/stores/toast.svelte";
 import { onMount } from "svelte";
 
@@ -10,30 +10,41 @@ interface Props {
 
 const { agentId }: Props = $props();
 
-let reflection = $state<DailyReflection | null>(null);
+let reflections = $state<DailyReflection[]>([]);
 let loading = $state(true);
-// biome-ignore lint/style/useConst: Svelte bind:value mutates state declared with let.
 let answerText = $state("");
-let submitting = $state(false);
-let answered = $state(false);
-// biome-ignore lint/style/useConst: Svelte event handlers reassign state declared with let.
-let showAnswer = $state(false);
+let submittingId = $state<string | null>(null);
+let showAnswerId = $state<string | null>(null);
+
+const reflection = $derived(reflections[0] ?? null);
 
 onMount(async () => {
-	const data = await getTodayReflection(agentId);
-	reflection = data.reflection;
+	loading = true;
+	const generated = await generateReflection(agentId, 3);
+	let next = generated.reflections ?? (generated.reflection ? [generated.reflection] : []);
+
+	if (next.length === 0) {
+		const today = await getTodayReflection(agentId);
+		next = today.reflections ?? (today.reflection ? [today.reflection] : []);
+	}
+
+	reflections = next;
 	loading = false;
-	if (reflection?.answer) answered = true;
 });
 
-async function handleAnswer(): Promise<void> {
-	if (!reflection || !answerText.trim()) return;
-	submitting = true;
-	const result = await answerReflection(reflection.id, answerText, agentId);
-	submitting = false;
+async function handleAnswer(item: DailyReflection): Promise<void> {
+	if (!answerText.trim()) return;
+	submittingId = item.id;
+	const result = await answerReflection(item.id, answerText, agentId);
+	submittingId = null;
 	if (result.success) {
-		answered = true;
-		reflection = { ...reflection, answer: answerText, answerMemoryId: result.memoryId ?? null };
+		reflections = reflections.map((reflection) =>
+			reflection.id === item.id
+				? { ...reflection, answer: answerText, answerMemoryId: result.memoryId ?? null }
+				: reflection,
+		);
+		answerText = "";
+		showAnswerId = null;
 		toast("Answer saved as memory", "success");
 	} else {
 		toast(result.error ?? "Failed to save answer", "error");
@@ -43,7 +54,7 @@ async function handleAnswer(): Promise<void> {
 
 <div class="panel sig-panel">
 	<div class="panel-header sig-panel-header">
-		<span class="panel-title">REFLECTION</span>
+		<span class="panel-title">DAILY BRIEF</span>
 		{#if reflection}
 			<span class="panel-date">{reflection.date}</span>
 		{/if}
@@ -56,58 +67,67 @@ async function handleAnswer(): Promise<void> {
 				<span class="loading-line short"></span>
 				<span class="loading-line"></span>
 			</div>
-		{:else if !reflection}
+		{:else if reflections.length === 0}
 			<div class="empty-state">
-				<span>No reflection yet today</span>
-				<span class="empty-hint">Appears after your next scheduled pass</span>
+				<span>No brief yet</span>
+				<span class="empty-hint">No fresh memory signal found</span>
 			</div>
 		{:else}
-			<p class="reflection-summary">{reflection.summary}</p>
+			{#each reflections as item (item.id)}
+				<section class="reflection-item">
+					<p class="reflection-summary">{item.summary}</p>
 
-			{#if reflection.patterns.length > 0}
-				<div class="patterns">
-					{#each reflection.patterns as pattern}
-						<span class="pattern-tag">{pattern}</span>
-					{/each}
-				</div>
-			{/if}
-
-			{#if reflection.question && !answered}
-				<div class="question-block">
-					<span class="question-text">{reflection.question}</span>
-					{#if showAnswer}
-						<textarea
-							class="answer-input"
-							placeholder="Type your reflection..."
-							bind:value={answerText}
-							rows="2"
-						></textarea>
-						<div class="answer-actions">
-							<button
-								class="answer-submit"
-								disabled={!answerText.trim() || submitting}
-								onclick={handleAnswer}
-							>
-								{submitting ? "Saving..." : "Save"}
-							</button>
-							<button class="answer-cancel" onclick={() => (showAnswer = false)}>
-								Cancel
-							</button>
+					{#if item.patterns.length > 0}
+						<div class="patterns">
+							{#each item.patterns as pattern}
+								<span class="pattern-tag">{pattern}</span>
+							{/each}
 						</div>
-					{:else}
-						<button class="answer-prompt" onclick={() => (showAnswer = true)}>
-							Answer
-						</button>
 					{/if}
-				</div>
-			{/if}
 
-			{#if answered && reflection.answer}
-				<div class="answered-block">
-					<span class="answered-label">YOUR ANSWER</span>
-					<p class="answered-text">{reflection.answer}</p>
-				</div>
-			{/if}
+					{#if item.question && !item.answer}
+						<div class="question-block">
+							{#if showAnswerId === item.id}
+								<textarea
+									class="answer-input"
+									placeholder="Type your reflection..."
+									bind:value={answerText}
+									rows="2"
+								></textarea>
+								<div class="answer-actions">
+									<button
+										class="answer-submit"
+										disabled={!answerText.trim() || submittingId === item.id}
+										onclick={() => handleAnswer(item)}
+									>
+										{submittingId === item.id ? "Saving..." : "Save"}
+									</button>
+									<button class="answer-cancel" onclick={() => (showAnswerId = null)}>
+										Cancel
+									</button>
+								</div>
+							{:else}
+								<button
+									class="answer-prompt"
+									onclick={() => {
+										answerText = "";
+										showAnswerId = item.id;
+									}}
+								>
+									Answer
+								</button>
+							{/if}
+						</div>
+					{/if}
+
+					{#if item.answer}
+						<div class="answered-block">
+							<span class="answered-label">YOUR ANSWER</span>
+							<p class="answered-text">{item.answer}</p>
+						</div>
+					{/if}
+				</section>
+			{/each}
 		{/if}
 	</div>
 </div>
@@ -154,6 +174,19 @@ async function handleAnswer(): Promise<void> {
 		gap: var(--space-sm);
 	}
 
+	.reflection-item {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-sm);
+		border-top: 1px solid var(--sig-border);
+		padding-top: var(--space-sm);
+	}
+
+	.reflection-item:first-child {
+		border-top: none;
+		padding-top: 0;
+	}
+
 	.reflection-summary {
 		font-family: var(--font-body);
 		font-size: 13px;
@@ -185,14 +218,6 @@ async function handleAnswer(): Promise<void> {
 		gap: 6px;
 		border-top: 1px solid var(--sig-border);
 		padding-top: var(--space-sm);
-	}
-
-	.question-text {
-		font-family: var(--font-body);
-		font-size: 11px;
-		line-height: 1.5;
-		color: var(--sig-accent);
-		font-style: italic;
 	}
 
 	.answer-prompt {


### PR DESCRIPTION
Follow-up to #699.

## Summary
- Generate Daily Brief insights when the dashboard opens instead of relying on the scheduled worker.
- Produce multiple fresh insight rows per open, grounded in recent transcripts, session summaries, memories, and graph facts.
- De-duplicate generated insights against recent Daily Brief items.
- Keep the existing dashboard surface/design; only data flow/copy changed to show loading and multiple brief items.
- Migrate `daily_reflections` away from one-row-per-agent-per-day uniqueness.

## PR Readiness
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)
- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Migration 069 drops the old unique `(agent_id, date)` Daily Reflection index and replaces it with non-unique agent/date and agent/created-at indexes so dashboard-open generation can persist multiple fresh insights on the same day. This is backward compatible with existing rows. Rollback is also safe for data shape, but reintroducing the old unique index would require deleting or consolidating duplicate same-day rows first. Rust daemon parity is N/A because this touches the TypeScript daemon/dashboard reflection route and SQLite migration only.

## Validation
- `bunx biome check platform/daemon/src/pipeline/reflection-worker.ts platform/daemon/src/routes/reflection-routes.ts platform/daemon/src/pipeline/index.ts platform/core/src/migrations/068-daily-reflections.ts platform/core/src/migrations/069-daily-reflections-multiple-insights.ts platform/core/src/migrations/index.ts platform/core/src/migrations/migrations.test.ts surfaces/dashboard/src/lib/api.ts surfaces/dashboard/src/lib/components/home/DailyReflection.svelte`
- `bun test platform/daemon/src/pipeline/reflection-worker.test.ts platform/core/src/migrations/migrations.test.ts`
- `bun run --cwd platform/daemon build`

Note: dashboard build/check still emits existing unrelated Svelte warnings in Secrets/OS/Cortex components.
