### PR TITLE
fix(daemon): clean up detached codex acp processes

### DIFF
--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -207,6 +207,51 @@ printf 'ok\\n'
 		}
 	});
 
+	it("cleans up detached Codex ACP agent processes after successful ACPX exec", async () => {
+		if (process.platform !== "linux") return;
+		const root = join(tmpdir(), `signet-acpx-success-cleanup-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(root, { recursive: true });
+		const bin = join(root, "fake-acpx-daemonizes.sh");
+		const codexAcp = join(root, "codex-acp");
+		const childPidPath = join(root, "child.pid");
+		writeFileSync(
+			codexAcp,
+			`#!/usr/bin/env bash
+sleep 30
+`,
+		);
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+setsid ${JSON.stringify(codexAcp)} >/dev/null 2>&1 < /dev/null &
+printf '%s' "$!" > ${JSON.stringify(childPidPath)}
+printf 'ok\\n'
+`,
+		);
+		chmodSync(bin, 0o755);
+		chmodSync(codexAcp, 0o755);
+		try {
+			const provider = createAcpxProvider({ agent: "codex", bin, hooks: "disabled" });
+			await expect(provider.generate("hello", { timeoutMs: 1000 })).resolves.toBe("ok");
+			const pid = Number(readFileSync(childPidPath, "utf-8"));
+			expect(pid).toBeGreaterThan(0);
+
+			let alive = true;
+			for (let i = 0; i < 40; i += 1) {
+				try {
+					process.kill(pid, 0);
+					await new Promise((resolve) => setTimeout(resolve, 25));
+				} catch {
+					alive = false;
+					break;
+				}
+			}
+			expect(alive).toBe(false);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("captures ACPX JSON events while preserving the final text provider contract", async () => {
 		const root = join(tmpdir(), `signet-acpx-events-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		mkdirSync(root, { recursive: true });

--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -252,6 +252,30 @@ printf 'ok\\n'
 		}
 	});
 
+	it("treats an unreadable ACPX proc root as best-effort cleanup", async () => {
+		if (process.platform !== "linux") return;
+		const root = join(tmpdir(), `signet-acpx-missing-proc-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(root, { recursive: true });
+		const bin = join(root, "fake-acpx-ok.sh");
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env bash
+printf 'ok\\n'
+`,
+		);
+		chmodSync(bin, 0o755);
+		const previousProcRoot = process.env.SIGNET_ACPX_PROC_ROOT;
+		process.env.SIGNET_ACPX_PROC_ROOT = join(root, "missing-proc");
+		try {
+			const provider = createAcpxProvider({ agent: "codex", bin, hooks: "disabled" });
+			await expect(provider.generate("hello", { timeoutMs: 1000 })).resolves.toBe("ok");
+		} finally {
+			if (previousProcRoot === undefined) Reflect.deleteProperty(process.env, "SIGNET_ACPX_PROC_ROOT");
+			else process.env.SIGNET_ACPX_PROC_ROOT = previousProcRoot;
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("captures ACPX JSON events while preserving the final text provider contract", async () => {
 		const root = join(tmpdir(), `signet-acpx-events-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		mkdirSync(root, { recursive: true });

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -8,13 +8,12 @@
 // On Windows, use node:child_process spawn with windowsHide to prevent
 // console window flashing. Bun.spawn doesn't support windowsHide.
 import { spawn as nodeSpawn } from "node:child_process";
-import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { isAbsolute, join, resolve as resolvePath } from "node:path";
 import { Readable } from "node:stream";
 import {
 	DEFAULT_PROVIDER_RATE_LIMIT,
-	defaultPipelineModel,
 	type LlmGenerateResult,
 	type LlmProvider,
 	type LlmUsage,
@@ -22,6 +21,7 @@ import {
 	OPENCODE_PIPELINE_SYSTEM_PROMPT,
 	type PipelineExtractionConfig,
 	type ProviderRateLimitConfig,
+	defaultPipelineModel,
 } from "@signet/core";
 import { logger } from "../logger";
 import { bypassSession } from "../session-tracker";
@@ -1000,13 +1000,14 @@ function acpxPermissionArgs(mode: AcpxPermissionMode | undefined): string[] {
 	}
 }
 
-function acpxEnv(hooks: AcpxHooksMode | undefined): NodeJS.ProcessEnv {
+function acpxEnv(hooks: AcpxHooksMode | undefined, runId?: string): NodeJS.ProcessEnv {
 	const env: NodeJS.ProcessEnv = { ...process.env };
 	if (hooks === "disabled") {
 		env.SIGNET_NO_HOOKS = "1";
 	} else if (hooks === "enabled") {
 		env.SIGNET_NO_HOOKS = undefined;
 	}
+	if (runId) env.SIGNET_ACPX_RUN_ID = runId;
 	return env;
 }
 
@@ -1133,6 +1134,63 @@ function terminateChildProcessTreeWithEscalation(child: ReturnType<typeof nodeSp
 	child.once("close", () => clearTimeout(escalation));
 }
 
+function acpxAgentProcessBasenames(agent: string): string[] {
+	switch (normalizeAcpxAgent(agent).toLowerCase()) {
+		case "codex":
+			return ["codex-acp"];
+		default:
+			return [];
+	}
+}
+
+function procEnvContainsRunId(pid: string, runId: string): boolean {
+	try {
+		const environ = readFileSync(`/proc/${pid}/environ`, "utf8");
+		return environ.includes(`SIGNET_ACPX_RUN_ID=${runId}`);
+	} catch {
+		return false;
+	}
+}
+
+function procCommandMatchesAgent(pid: string, basenames: ReadonlySet<string>): boolean {
+	try {
+		const cmdline = readFileSync(`/proc/${pid}/cmdline`, "utf8");
+		return cmdline
+			.split("\0")
+			.filter(Boolean)
+			.some((arg) => basenames.has(arg.split("/").pop() ?? ""));
+	} catch {
+		return false;
+	}
+}
+
+function cleanupAcpxAgentProcesses(agent: string, runId: string): void {
+	if (process.platform !== "linux") return;
+	const basenames = new Set(acpxAgentProcessBasenames(agent));
+	if (basenames.size === 0) return;
+	const pids = readdirSync("/proc")
+		.filter((pid) => /^\d+$/.test(pid))
+		.filter((pid) => procCommandMatchesAgent(pid, basenames))
+		.filter((pid) => procEnvContainsRunId(pid, runId))
+		.map((pid) => Number(pid))
+		.filter((pid) => Number.isFinite(pid) && pid > 0);
+	for (const pid of pids) {
+		try {
+			process.kill(pid, "SIGTERM");
+		} catch {
+			// Already gone or not ours to signal.
+		}
+		const escalation = setTimeout(() => {
+			try {
+				process.kill(pid, "SIGKILL");
+			} catch {
+				// Already exited.
+			}
+		}, 1000);
+		escalation.unref?.();
+	}
+}
+
 function parseAcpxJsonOutput(
 	stdout: string,
 	config: Pick<AcpxProviderConfig, "agent" | "captureEvents" | "maxCapturedEvents" | "onEvent">,
@@ -1186,13 +1244,14 @@ export function createAcpxProvider(config: AcpxProviderConfig): LlmProvider {
 			const timeoutMs = opts?.timeoutMs ?? config.timeoutMs ?? 60_000;
 			const { bin, args, cwd } = buildAcpxCommand(config, timeoutMs);
 			const outputFormat = resolveAcpxFormat(config);
+			const runId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 			return new Promise<string>((resolve, reject) => {
 				let stdout = "";
 				let stderr = "";
 				let settled = false;
 				const child = nodeSpawn(bin, args, {
 					cwd,
-					env: acpxEnv(config.hooks),
+					env: acpxEnv(config.hooks, runId),
 					stdio: ["pipe", "pipe", "pipe"],
 					detached: process.platform !== "win32",
 					windowsHide: true,
@@ -1201,6 +1260,7 @@ export function createAcpxProvider(config: AcpxProviderConfig): LlmProvider {
 					if (settled) return;
 					settled = true;
 					clearTimeout(timer);
+					cleanupAcpxAgentProcesses(config.agent, runId);
 					fn();
 				};
 				const timer = setTimeout(() => {

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -1143,18 +1143,22 @@ function acpxAgentProcessBasenames(agent: string): string[] {
 	}
 }
 
-function procEnvContainsRunId(pid: string, runId: string): boolean {
+function acpxProcRoot(): string {
+	return process.env.SIGNET_ACPX_PROC_ROOT || "/proc";
+}
+
+function procEnvContainsRunId(procRoot: string, pid: string, runId: string): boolean {
 	try {
-		const environ = readFileSync(`/proc/${pid}/environ`, "utf8");
+		const environ = readFileSync(`${procRoot}/${pid}/environ`, "utf8");
 		return environ.includes(`SIGNET_ACPX_RUN_ID=${runId}`);
 	} catch {
 		return false;
 	}
 }
 
-function procCommandMatchesAgent(pid: string, basenames: ReadonlySet<string>): boolean {
+function procCommandMatchesAgent(procRoot: string, pid: string, basenames: ReadonlySet<string>): boolean {
 	try {
-		const cmdline = readFileSync(`/proc/${pid}/cmdline`, "utf8");
+		const cmdline = readFileSync(`${procRoot}/${pid}/cmdline`, "utf8");
 		return cmdline
 			.split("\0")
 			.filter(Boolean)
@@ -1168,10 +1172,17 @@ function cleanupAcpxAgentProcesses(agent: string, runId: string): void {
 	if (process.platform !== "linux") return;
 	const basenames = new Set(acpxAgentProcessBasenames(agent));
 	if (basenames.size === 0) return;
-	const pids = readdirSync("/proc")
+	const procRoot = acpxProcRoot();
+	let procEntries: string[];
+	try {
+		procEntries = readdirSync(procRoot);
+	} catch {
+		return;
+	}
+	const pids = procEntries
 		.filter((pid) => /^\d+$/.test(pid))
-		.filter((pid) => procCommandMatchesAgent(pid, basenames))
-		.filter((pid) => procEnvContainsRunId(pid, runId))
+		.filter((pid) => procCommandMatchesAgent(procRoot, pid, basenames))
+		.filter((pid) => procEnvContainsRunId(procRoot, pid, runId))
 		.map((pid) => Number(pid))
 		.filter((pid) => Number.isFinite(pid) && pid > 0);
 	for (const pid of pids) {


### PR DESCRIPTION
## Summary
- tag each ACPX provider invocation with a unique run id inherited by child processes
- clean up detached `codex-acp` processes that escape the ACPX launcher process group
- add a Linux regression test for successful ACPX runs that daemonize Codex ACP outside the original process group

## Test Plan
- [x] `bun install --frozen-lockfile`
- [x] `bun run build:core`
- [x] `bun test platform/daemon/src/pipeline/provider.test.ts --timeout 10000 --test-name-pattern 'createAcpxProvider'`
- [x] `bunx biome check platform/daemon/src/pipeline/provider.ts`
- [x] `git diff --check -- platform/daemon/src/pipeline/provider.ts platform/daemon/src/pipeline/provider.test.ts`
- [x] `bun run --filter @signet/daemon build`

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)
- [x] No database migrations changed
- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Rollback / compatibility: revert the provider cleanup change to restore previous ACPX lifecycle behavior. No schema or config migration is involved.
