### PR TITLE
fix(cli): surface daemon start journal diagnostics

### DIFF
--- a/surfaces/cli/src/lib/runtime.test.ts
+++ b/surfaces/cli/src/lib/runtime.test.ts
@@ -11,6 +11,7 @@ import {
 	didSystemdDaemonStart,
 	getDaemonStatus,
 	launchdDaemonPlistPath,
+	readDaemonStartFailureDiagnostics,
 	readManagedDaemonPid,
 } from "./runtime.js";
 
@@ -136,6 +137,47 @@ describe("didSystemdDaemonStart", () => {
 		expect(didSystemdDaemonStart({ status: 1, signal: null, error: undefined })).toBe(false);
 		expect(didSystemdDaemonStart({ status: null, signal: "SIGTERM", error: undefined })).toBe(false);
 		expect(didSystemdDaemonStart({ status: null, signal: null, error: new Error("spawn timed out") })).toBe(false);
+	});
+});
+
+describe("readDaemonStartFailureDiagnostics", () => {
+	it("prefers startup log stderr when present", () => {
+		const lines = readDaemonStartFailureDiagnostics(
+			{ startupLogPath: "/tmp/startup.log", platform: "linux", systemdUnitName: "signet-daemon-test" },
+			{
+				existsSync: () => true,
+				readFileSync: () => "first\nsecond\n",
+				spawnSync: () => ({ stdout: "" }),
+			},
+		);
+
+		expect(lines).toEqual(["Daemon failed to start. stderr output:", "first", "second"]);
+	});
+
+	it("falls back to the transient systemd unit journal when startup log is empty", () => {
+		let command = "";
+		let args: readonly string[] = [];
+		const lines = readDaemonStartFailureDiagnostics(
+			{ startupLogPath: "/tmp/startup.log", platform: "linux", systemdUnitName: "signet-daemon-123" },
+			{
+				existsSync: () => true,
+				readFileSync: () => "",
+				spawnSync: (cmd, argv) => {
+					command = cmd;
+					args = argv;
+					return { stdout: "May 13 signet-daemon-123: Fatal error\nMay 13 signet-daemon-123: ENOSPC\n" };
+				},
+			},
+		);
+
+		expect(command).toBe("journalctl");
+		expect(args).toContain("--unit");
+		expect(args).toContain("signet-daemon-123");
+		expect(lines).toEqual([
+			"Daemon failed to start. journalctl for signet-daemon-123:",
+			"May 13 signet-daemon-123: Fatal error",
+			"May 13 signet-daemon-123: ENOSPC",
+		]);
 	});
 });
 

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -384,6 +384,7 @@ export interface DaemonStartArgsInput {
 	readonly host: string;
 	readonly bind: string;
 	readonly startupLogPath: string;
+	readonly unitName?: string;
 }
 
 export type SystemdDaemonStartArgsInput = DaemonStartArgsInput;
@@ -397,7 +398,7 @@ export function buildSystemdDaemonStartArgs(input: SystemdDaemonStartArgsInput):
 		"--user",
 		"--quiet",
 		"--collect",
-		`--unit=signet-daemon-${process.pid}`,
+		`--unit=${input.unitName ?? `signet-daemon-${process.pid}`}`,
 		`--property=WorkingDirectory=${process.cwd()}`,
 		"--property=StandardOutput=null",
 		`--property=StandardError=append:${input.startupLogPath}`,
@@ -407,6 +408,83 @@ export function buildSystemdDaemonStartArgs(input: SystemdDaemonStartArgsInput):
 		`--setenv=SIGNET_PATH=${input.agentsDir}`,
 		processRuntimeCommand(),
 		input.daemonPath,
+	];
+}
+
+interface DaemonStartDiagnosticsDeps {
+	readonly readFileSync: (path: string, encoding: "utf-8") => string;
+	readonly existsSync: (path: string) => boolean;
+	readonly spawnSync: (
+		command: string,
+		args: readonly string[],
+		options: {
+			readonly encoding: "utf8";
+			readonly stdio: "pipe";
+			readonly windowsHide: true;
+			readonly timeout: number;
+		},
+	) => { readonly stdout?: string };
+}
+
+const daemonStartDiagnosticsDeps: DaemonStartDiagnosticsDeps = {
+	readFileSync,
+	existsSync,
+	spawnSync,
+};
+
+function tailNonEmptyLines(value: string, max: number): string[] {
+	return value
+		.split("\n")
+		.map((line) => line.trimEnd())
+		.filter((line) => line.trim().length > 0)
+		.slice(-max);
+}
+
+export function readDaemonStartFailureDiagnostics(
+	input: {
+		readonly startupLogPath: string;
+		readonly platform?: NodeJS.Platform;
+		readonly systemdUnitName?: string;
+	},
+	deps: DaemonStartDiagnosticsDeps = daemonStartDiagnosticsDeps,
+): string[] {
+	if (deps.existsSync(input.startupLogPath)) {
+		try {
+			const startupLines = tailNonEmptyLines(deps.readFileSync(input.startupLogPath, "utf-8"), 20);
+			if (startupLines.length > 0) {
+				return ["Daemon failed to start. stderr output:", ...startupLines];
+			}
+		} catch {
+			// Continue to service-manager diagnostics.
+		}
+	}
+
+	if ((input.platform ?? process.platform) === "linux" && input.systemdUnitName) {
+		const result = deps.spawnSync(
+			"journalctl",
+			[
+				"--user",
+				"--unit",
+				input.systemdUnitName,
+				"--since",
+				"5 minutes ago",
+				"--no-pager",
+				"--output=short-iso",
+				"-n",
+				"40",
+			],
+			{ encoding: "utf8", stdio: "pipe", windowsHide: true, timeout: 3000 },
+		);
+		const journal = result.stdout ?? "";
+		const journalLines = tailNonEmptyLines(journal, 20);
+		if (journalLines.length > 0) {
+			return [`Daemon failed to start. journalctl for ${input.systemdUnitName}:`, ...journalLines];
+		}
+	}
+
+	return [
+		"Daemon failed to start, and no startup diagnostics were captured.",
+		`Startup log checked: ${input.startupLogPath}`,
 	];
 }
 
@@ -583,6 +661,7 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR): Promise<boole
 	// platforms or environments where that is unavailable.
 	let procExited = false;
 	let startedByServiceManager = false;
+	const systemdUnitName = `signet-daemon-${process.pid}`;
 	if (process.platform === "linux") {
 		const systemdArgs = buildSystemdDaemonStartArgs({
 			daemonPath,
@@ -591,6 +670,7 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR): Promise<boole
 			host: net.host,
 			bind: net.bind,
 			startupLogPath,
+			unitName: systemdUnitName,
 		});
 		const result = spawnSync("systemd-run", systemdArgs, {
 			stdio: ["ignore", "ignore", stderrTarget],
@@ -702,13 +782,14 @@ export async function startDaemon(agentsDir: string = AGENTS_DIR): Promise<boole
 	}
 
 	try {
-		if (stderrFd !== null && existsSync(startupLogPath)) {
-			const stderr = readFileSync(startupLogPath, "utf-8").trim();
-			if (stderr) {
-				console.error(chalk.red("\nDaemon failed to start. stderr output:"));
-				for (const line of stderr.split("\n").slice(-20)) {
-					console.error(chalk.dim(line));
-				}
+		const diagnostics = readDaemonStartFailureDiagnostics({
+			startupLogPath,
+			systemdUnitName: process.platform === "linux" ? systemdUnitName : undefined,
+		});
+		if (diagnostics.length > 0) {
+			console.error(chalk.red(`\n${diagnostics[0]}`));
+			for (const line of diagnostics.slice(1)) {
+				console.error(chalk.dim(line));
 			}
 		}
 	} catch {


### PR DESCRIPTION
## Summary
- Surfaces useful daemon startup diagnostics when `signet daemon start` fails with an empty `startup.log`.
- Tracks the transient systemd unit name used for daemon start and falls back to recent `journalctl --user --unit <unit>` output on Linux.
- Keeps the existing startup-log stderr path as the first diagnostic source.

## Context
The 0.118.1 migration failure exited under a transient systemd unit with an empty startup log, so the CLI only printed `Failed to start daemon`. Running the daemon foreground exposed the real ENOSPC backup error. This change makes the CLI pull the relevant journal snippet when systemd owns the failed daemon process.

## Validation
- [x] `bun test surfaces/cli/src/lib/runtime.test.ts`
- [x] `bunx biome check surfaces/cli/src/lib/runtime.ts surfaces/cli/src/lib/runtime.test.ts`
- [x] `bun run --filter @signet/cli build`
- [x] `git diff --check`

## Rollback / compatibility
No schema or API changes. On daemon start failure, CLI output may include additional startup-log or systemd journal lines to make the failure actionable.

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)
- [x] No database migrations changed
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description
