### PR TITLE
feat(ontology): add audited control plane

### DIFF
--- a/docs/dreaming-skill-runbook.md
+++ b/docs/dreaming-skill-runbook.md
@@ -1,0 +1,77 @@
+# Dreaming Skill Runbook
+
+This is the first runnable proposal-first dreaming path for ontology
+maintenance. It uses existing daemon-backed CLI surfaces and the built-in
+`dreaming` skill instructions.
+
+## Proposal-First Path
+
+Inspect the current graph write gates:
+
+```bash
+signet ontology pipeline explain --json
+```
+
+Collect graph hygiene and proposal context:
+
+```bash
+signet knowledge hygiene --json > dreaming-hygiene.json
+signet ontology proposals --status pending --json > dreaming-pending.json
+signet ontology proposals --status applied --limit 50 --json > dreaming-applied-recent.json
+signet ontology proposals --status rejected --limit 50 --json > dreaming-rejected-recent.json
+signet dream status > dreaming-status.txt
+```
+
+Extract candidate proposals from a specific evidence artifact or transcript:
+
+```bash
+signet ontology extract --from transcript:<session-key> --json > dreaming-extract.json
+```
+
+Consolidate pending proposal candidates without mutation:
+
+```bash
+signet ontology consolidate --proposals pending --json > dreaming-consolidate.json
+```
+
+Convert accepted candidates into operation JSONL, keeping one object per line:
+
+```json
+{"operation":"set_claim_value","payload":{"entity":"Signet","aspect":"architecture","group_key":"ontology","claim_key":"mutation_policy","value":"Generated ontology maintenance emits proposals before graph mutation."},"reason":"Consolidated from cited transcript evidence.","evidence":[{"source_kind":"transcript","source_id":"<session-key>","quote":"..."}]}
+```
+
+Validate without writing:
+
+```bash
+signet ontology stream apply proposals.jsonl --dry-run --json
+```
+
+Write pending proposals for review:
+
+```bash
+signet ontology stream apply proposals.jsonl --propose --json
+signet ontology proposals --status pending --json
+```
+
+After human/operator review, apply or reject proposals explicitly:
+
+```bash
+signet ontology apply <proposal-id> --actor operator --json
+signet ontology reject <proposal-id> --reason "weak evidence" --actor operator --json
+```
+
+Inspect versioned claim evidence:
+
+```bash
+signet ontology claim versions <entity> <aspect> <group> <claim> --json
+signet ontology claim show <entity> <aspect> <group> <claim> --version 1 --json
+signet ontology claim-evidence <entity> <aspect> <group> <claim> --status all --json
+```
+
+## Rules
+
+- LLM-generated dreaming output uses `--dry-run` or `--propose` by default.
+- Raw memories, transcripts, and source artifacts are evidence only; do not
+  rewrite them when graph claims change.
+- Direct apply is reserved for exact operator-authored operations.
+- Every successful mutation must pass through `ontology_proposals`.

--- a/docs/knowledge-graph-control-plane.md
+++ b/docs/knowledge-graph-control-plane.md
@@ -119,9 +119,8 @@ rejection, default hiding for archived graph rows, and an in-process
 end-to-end fixture that verifies dry-run, apply, propose, reject, evidence
 lookup, and raw source artifact immutability.
 
-Missing or thin coverage:
+Remaining thin coverage:
 
-- Route-level tests for `/api/ontology/operations/*` auth middleware.
 - Full end-to-end daemon + CLI process fixture using a real running daemon.
 - `graph.yaml` policy validation, because no active policy file is implemented
   in this slice.

--- a/docs/knowledge-graph-control-plane.md
+++ b/docs/knowledge-graph-control-plane.md
@@ -1,0 +1,127 @@
+# Knowledge Graph Control Plane Inventory
+
+This is an implementation inventory for the current ontology and knowledge
+graph control plane. It is not a speculative product spec.
+
+## Tables And Migrations
+
+| Surface | Migration | Exposure | Mutation model | Notes |
+|---|---:|---|---|---|
+| `entities` | 002, 005, 019, 022, 027, 037, 064, 070 | CLI/API | proposal/audit-backed through ontology operations; internal pipeline writes still exist | Agent-scoped after 019. 070 adds `status`, archive metadata, and proposal provenance. Name/canonical selectors must resolve to one same-agent active row. |
+| `relations` | 002, 005 | hidden/internal | internal graph legacy | Kept for legacy entity relation compatibility. New control-plane links use `entity_dependencies`. |
+| `memory_entity_mentions` | 002, 005 | hidden/internal | internal write-time linker | Links memories to entities; source memories remain immutable provenance. |
+| `entity_aspects` | 019, 070 | CLI/API | proposal/audit-backed through ontology operations | 070 adds archive metadata and proposal provenance. Default reads should treat archived aspects as hidden. |
+| `entity_attributes` | 019, 059, 060, 064, 067, 070 | CLI/API | proposal/audit-backed for operations; pipeline/supersession helpers also write | Claim slots use `group_key` + `claim_key`. 070 adds first-class versions: `version`, `version_root_id`, `previous_attribute_id`. Default reads show active rows; history reads can inspect all versions. |
+| `entity_dependencies` | 019, 031, 036, 039, 050, 064, 067, 070 | CLI/API | proposal/audit-backed through ontology operations; structural workers also write | Link operations create/update/archive rows here. Reason/confidence/proposal/source provenance are preserved. |
+| `entity_dependency_history` | 050 | hidden/internal | audit trigger | Trigger-backed history for dependency insert/update/delete. |
+| `task_meta` | 019, 054 | hidden/internal | task/procedural helpers | Agent-scoped task metadata, not part of this control-plane CLI slice. |
+| `ontology_proposals` | 067 | CLI/API | proposal loop and applied audit ledger | Pending, applied, rejected, and failed proposals. Direct operations create applied rows inside the same transaction as graph mutation. |
+| `dreaming_state`, `dreaming_passes` | 055 | CLI/API via dream status/trigger | dreaming worker | Existing dreaming pass records/status. LLM dreaming remains proposal-first for ontology changes in this slice. |
+| `memory_artifacts` | 051, 061, 062 | API/internal | immutable source artifact records | Source-backed evidence for proposals and applied graph rows. Ontology updates must not rewrite these rows. |
+| `session_transcripts` | 040, 045, 047 | API/internal | immutable transcript/index records | Proposal extraction can cite transcripts; graph mutation must preserve transcript provenance. |
+
+## Daemon Routes
+
+| Route | Exposure | Mutation model | Tests / risk |
+|---|---|---|---|
+| `GET /api/ontology/proposals` | CLI/API | read-only | Covered by ontology proposal tests. |
+| `GET /api/ontology/proposals/:id` | CLI/API | read-only | Covered by CLI/proposal tests. |
+| `POST /api/ontology/proposals` | CLI/API | creates pending proposal | Covered by proposal import/create tests. |
+| `POST /api/ontology/proposals/batch` | CLI/API | creates pending proposals atomically | Covered by batch proposal tests. |
+| `POST /api/ontology/proposals/:id/apply` | CLI/API | applies pending proposal | Covered by proposal apply tests. |
+| `POST /api/ontology/proposals/:id/reject` | CLI/API | rejects pending proposal | Covered by reject tests. |
+| `GET /api/ontology/proposals/:id/evidence` | CLI/API | read-only | Covered by evidence tests. |
+| `GET /api/ontology/proposals/conflicts` | CLI/API | read-only | Covered by conflict tests. |
+| `POST /api/ontology/proposals/repair/duplicates` | CLI/API | dry-run or pending proposals | Covered by duplicate repair tests. |
+| `POST /api/ontology/extract` | CLI/API | dry-run or pending proposals | Proposal-first. Covered by extraction tests. |
+| `POST /api/ontology/consolidate` | CLI/API | dry-run or pending proposals | Proposal-first. Covered by consolidation tests. |
+| `POST /api/ontology/operations/apply` | CLI/API | dry-run, pending proposal, or applied proposal + graph mutation | New direct operation endpoint. Requires `modify`. Covered through operation engine and CLI tests. |
+| `POST /api/ontology/operations/batch` | CLI/API | atomic batch dry-run/propose/apply | Requires `modify`; rolls back on invalid operation. Covered by operation batch tests. |
+| `GET /api/ontology/claims/evidence` | CLI/API | read-only | Covered by claim evidence tests. |
+| `GET /api/ontology/claims/versions` | CLI/API | read-only | Covered by version chain tests. |
+| `GET /api/ontology/claims/version` | CLI/API | read-only | Covered by version show tests. |
+| `GET /api/ontology/links/:id/evidence` | CLI/API | read-only | Covered by link evidence tests. |
+| `GET /api/knowledge/navigation/*` | CLI/API | read-only | Existing knowledge navigation tests cover entity/aspect/group/claim browsing. |
+| `GET /api/pipeline/status`, `GET /api/status` | CLI/API | read-only | `ontology pipeline *` uses these to explain graph mutation state. |
+| `GET /api/dream/status`, `POST /api/dream/trigger` | CLI/API | dreaming worker | Existing dream CLI/daemon surface. Ontology dreaming skill uses proposal JSON/JSONL by default. |
+
+## CLI Commands
+
+| Command | Exposure | Mutation model | Notes |
+|---|---|---|---|
+| `signet ontology proposals` | CLI | read-only | Existing proposal list. |
+| `signet ontology proposal <id>` | CLI | read-only | Existing proposal show. |
+| `signet ontology evidence <id>` | CLI | read-only | Existing proposal evidence. |
+| `signet ontology apply <id>` | CLI | applies pending proposal | Preserves proposal history and agent scope. |
+| `signet ontology reject <id>` | CLI | rejects pending proposal | Preserves rejected proposal history. |
+| `signet ontology conflicts` | CLI | read-only | Lists pending claim conflicts. |
+| `signet ontology entity create/rename/merge/archive` | CLI | direct operation endpoint | Supports `--dry-run`, `--propose`, `--json`, `--agent`, `--actor`, `--reason`, `--evidence-file`. |
+| `signet ontology claim set/versions/show/archive/restore` | CLI | operation endpoint for writes, read endpoints for versions | `set` creates version chains; `restore` only required for claim versions in this slice. |
+| `signet ontology aspect create/rename/archive` | CLI | direct operation endpoint | Uses same audited operation path. |
+| `signet ontology link create/update/archive` | CLI | direct operation endpoint | Uses `entity_dependencies`. |
+| `signet ontology stream apply <path|- >` | CLI | atomic JSONL operation batch | Supports file and stdin, `--dry-run`, `--propose`, `--json`, `--agent`, `--actor`. |
+| `signet ontology pipeline status/config/explain` | CLI | graph-state inspection | Explains Pipeline V2 graph flags and write gates. |
+| `signet ontology config show/validate/explain` | CLI | control-plane inspection | Confirms audited operation tools are usable and no external `graph.yaml` policy gate is active in this slice. |
+| `signet ontology extract` | CLI | dry-run/pending proposals | Existing proposal-first extraction surface. |
+| `signet ontology consolidate` | CLI | dry-run/pending proposals | Existing proposal-first consolidation surface. |
+| `signet dream status/trigger` | CLI | existing dream worker | Existing pass status and trigger behavior. |
+
+## Pipeline V2 Graph Knobs
+
+Current graph-affecting configuration is loaded from `memory.pipelineV2` in
+`agent.yaml` and surfaced through `signet ontology pipeline *`:
+
+- `enabled`
+- `paused`
+- `shadowMode`
+- `mutationsFrozen`
+- `graph.enabled`
+- `graph.extractionWritesEnabled`
+- traversal mode and bounds (`traversal.enabled`, `primary`, hop/branch/path limits, confidence, timeout, boost)
+- dampening settings
+- autonomous maintenance (`autonomous.enabled`, `frozen`, `allowUpdateDelete`, mode/polling)
+- extraction provider/workload settings
+- write gates such as `minFactConfidenceForWrite`
+- queue/worker health through `/api/pipeline/status`
+- dreaming state through `/api/dream/status`
+
+Unsafe or ambiguous behavior to keep watching:
+
+- Legacy graph workers still have internal write paths. Generated LLM changes
+  must remain proposal-first when they target ontology maintenance.
+- `relations` remains a legacy graph table; new audited control-plane links use
+  `entity_dependencies`.
+- `merge_entities` still moves graph rows and removes the source entity. Use
+  entity archive operations when lineage inspection of the source row matters.
+- A separate `$SIGNET_WORKSPACE/ontology/graph.yaml` policy is not active yet;
+  adding one should fail closed and must not introduce hidden mutation paths.
+
+## Tests
+
+Existing and new coverage:
+
+- `platform/core/src/migrations/migrations.test.ts`
+- `platform/daemon/src/ontology-proposals.test.ts`
+- `platform/daemon/src/knowledge-navigation.test.ts`
+- `platform/daemon/src/knowledge-graph-list.test.ts`
+- `platform/daemon/src/knowledge-expand-api.test.ts`
+- `platform/daemon/src/knowledge-graph-hygiene.test.ts`
+- `platform/daemon/src/pipeline/graph-transactions.test.ts`
+- `platform/daemon/src/pipeline/dreaming.test.ts`
+- `platform/daemon/src/dreaming-skill.test.ts`
+- `surfaces/cli/src/commands/ontology.test.ts`
+- `surfaces/cli/src/commands/knowledge.test.ts`
+- `surfaces/cli/src/commands/dream.ts` coverage through existing command behavior
+
+New control-plane coverage includes direct operation apply/propose/dry-run,
+atomic batch rollback, claim version restore/archive, ambiguous selector
+rejection, default hiding for archived graph rows, and an in-process
+end-to-end fixture that verifies dry-run, apply, propose, reject, evidence
+lookup, and raw source artifact immutability.
+
+Missing or thin coverage:
+
+- Route-level tests for `/api/ontology/operations/*` auth middleware.
+- Full end-to-end daemon + CLI process fixture using a real running daemon.
+- `graph.yaml` policy validation, because no active policy file is implemented
+  in this slice.

--- a/docs/ontology-control-plane-progress.md
+++ b/docs/ontology-control-plane-progress.md
@@ -1,0 +1,152 @@
+# Ontology Control Plane Progress
+
+## Inventory Checkpoint
+
+- Changed: added `docs/knowledge-graph-control-plane.md` with schema,
+  migration, route, CLI, Pipeline V2 graph knob, proposal, dream, and test
+  inventory.
+- Verified: `bun scripts/spec-deps-check.ts` passed with 87 specs indexed.
+- Commands run:
+  - `bun scripts/spec-deps-check.ts`
+- Failures encountered: none.
+- Remaining risk: route-level auth coverage is thinner than function-level
+  operation coverage.
+- Next checkpoint: operations API and operation handlers.
+
+## Operations API Checkpoint
+
+- Changed: added `/api/ontology/operations/apply` and
+  `/api/ontology/operations/batch`.
+- Changed: implemented direct operation execution through the existing
+  ontology proposal engine. Apply-first operations create an applied
+  `ontology_proposals` row inside the same transaction as graph mutation.
+- Changed: `--dry-run` executes validation and preview inside a rolled-back
+  transaction; `--propose` creates a pending proposal without graph mutation.
+- Verified: focused ontology proposal tests cover apply, dry-run, propose,
+  atomic batch rollback, dry-run per-line batch errors, evidence preservation,
+  and agent scoping.
+- Commands run:
+  - `bun run build:core`
+  - `bun test platform/daemon/src/ontology-proposals.test.ts surfaces/cli/src/commands/ontology.test.ts platform/core/src/migrations/migrations.test.ts`
+- Failures encountered: daemon tests initially loaded stale `@signet/core/dist`
+  without migration 070; rebuilding core fixed it.
+- Remaining risk: API auth middleware is wired through existing route patterns
+  but not separately route-tested.
+- Next checkpoint: entity/aspect/link handlers.
+
+## Entity/Aspect/Link Checkpoint
+
+- Changed: added handlers for entity create/rename/archive/merge,
+  aspect create/rename/archive, and link create/update/archive.
+- Changed: selectors now reject ambiguous same-agent active entity/aspect
+  matches and require ids when needed.
+- Verified: tests cover direct create, ambiguous selector rejection, merge,
+  link creation, link evidence, and batch rollback.
+- Commands run:
+  - `bun test platform/daemon/src/ontology-proposals.test.ts surfaces/cli/src/commands/ontology.test.ts platform/core/src/migrations/migrations.test.ts`
+- Failures encountered: none after core rebuild.
+- Remaining risk: merge still removes source entities after moving rows; archive
+  should be used when source-row history must remain visible.
+- Next checkpoint: claim/version handlers.
+
+## Claim/Version Checkpoint
+
+- Changed: migration 070 adds `version`, `version_root_id`, and
+  `previous_attribute_id` to `entity_attributes` and backfills existing rows to
+  v1/root=id.
+- Changed: `set_claim_value` creates v1/vN chains, supersedes previous active
+  versions, and leaves old versions queryable.
+- Changed: `archive_claim_value` hides a value from active reads while
+  preserving version history; `restore_claim_version` makes a chosen version
+  active and supersedes the previous active version.
+- Verified: tests cover v1/v2/v3 chains, version reads, restore, archive, and
+  default active visibility.
+- Commands run:
+  - `bun test platform/daemon/src/ontology-proposals.test.ts surfaces/cli/src/commands/ontology.test.ts platform/core/src/migrations/migrations.test.ts`
+- Failures encountered: none.
+- Remaining risk: merge still removes source rows after moving graph state;
+  archive should be preferred when source-row history matters.
+- Next checkpoint: CLI.
+
+## CLI Checkpoint
+
+- Changed: added `signet ontology entity`, `claim`, `aspect`, `link`, and
+  `stream apply` commands.
+- Changed: command options include `--dry-run`, `--propose`, `--json`,
+  `--agent`, `--actor`, `--reason`, and `--evidence-file` where practical.
+- Changed: JSONL stream apply supports file paths and `-` for stdin.
+- Verified: CLI tests cover entity create, claim set, claim versions/show,
+  claim archive/restore, aspect operations, link operations, stream apply, and
+  pipeline explain status calls.
+- Commands run:
+  - `bun test platform/daemon/src/ontology-proposals.test.ts surfaces/cli/src/commands/ontology.test.ts platform/core/src/migrations/migrations.test.ts`
+- Failures encountered: none.
+- Remaining risk: no spawned real daemon CLI smoke test yet.
+- Next checkpoint: Pipeline status/config.
+
+## Pipeline Status/Config Checkpoint
+
+- Changed: added `signet ontology pipeline status`, `config`, and `explain`
+  commands that inspect Pipeline V2 graph mutation state.
+- Changed: added `signet ontology config show`, `validate`, and `explain`
+  commands that confirm audited operation tools are usable immediately and
+  that no separate `ontology/graph.yaml` policy gate is active in this slice.
+- Verified: CLI test covers `pipeline explain` reading `/api/status`.
+- Commands run:
+  - `bun test surfaces/cli/src/commands/ontology.test.ts`
+- Failures encountered: none.
+- Remaining risk: a future active graph policy file needs fail-closed parser
+  tests before it can control generated maintenance.
+- Next checkpoint: dreaming skill.
+
+## Dreaming Skill Checkpoint
+
+- Changed: added built-in `skills/dreaming/SKILL.md` with proposal-first
+  ontology maintenance rules, expected inputs, JSONL operation output, and
+  hard constraints against hidden direct SQLite mutation.
+- Changed: added `docs/dreaming-skill-runbook.md` as the first runnable path
+  from hygiene/proposal context to dry-run, propose, review, apply/reject, and
+  version/evidence inspection.
+- Verified: `platform/daemon/src/dreaming-skill.test.ts` asserts the built-in
+  skill exists and preserves proposal-first/default-dry-run language.
+- Commands run:
+  - `bun test platform/daemon/src/dreaming-skill.test.ts`
+- Failures encountered: none.
+- Remaining risk: this slice documents and tests the built-in skill and CLI
+  path; it does not add a new autonomous dream scheduler.
+- Next checkpoint: default-read archive filtering and end-to-end validation.
+
+## Archive/Default-Read Checkpoint
+
+- Changed: default knowledge navigation, entity detail, dependency, and stats
+  reads now filter archived entities, archived aspects, and archived
+  dependencies out of active graph views.
+- Changed: claim history/version reads remain available for deleted and
+  superseded claim rows.
+- Verified: `knowledge-graph-list.test.ts` covers archived rows being excluded
+  from list counts, dependency counts, stats, and coverage.
+- Commands run:
+  - `bun test platform/daemon/src/knowledge-graph-list.test.ts`
+- Failures encountered: the first regression run showed dependency counts still
+  included links to archived entities; the query now joins source/target
+  entities and filters both active.
+- Remaining risk: specialized future graph readers should copy the same
+  active-row default unless they are explicitly history/audit surfaces.
+- Next checkpoint: final validation.
+
+## Final Validation Checkpoint
+
+- Verified: in-process end-to-end fixture covers dry-run, apply, propose,
+  reject, evidence lookup, and raw memory artifact immutability.
+- Verified: focused tests pass across ontology proposals, built-in dreaming
+  skill, graph list/stats, CLI commands, and migration framework.
+- Verified: core build and targeted Biome checks pass.
+- Commands run:
+  - `bun scripts/spec-deps-check.ts`
+  - `bun run build:core`
+  - `bunx biome check --write platform/daemon/src/knowledge-graph.ts platform/daemon/src/knowledge-graph-list.test.ts platform/daemon/src/ontology-proposals.test.ts`
+  - `bun test platform/core/src/migrations/migrations.test.ts surfaces/cli/src/commands/ontology.test.ts platform/daemon/src/ontology-proposals.test.ts platform/daemon/src/dreaming-skill.test.ts platform/daemon/src/knowledge-graph-list.test.ts`
+- Failures encountered: none in the final focused validation pass.
+- Remaining risk: root `bun run typecheck` still depends on the unrelated
+  desktop `electron-updater` dependency state; record that separately when
+  running full workspace validation.

--- a/platform/core/src/migrations/070-ontology-control-plane-state.ts
+++ b/platform/core/src/migrations/070-ontology-control-plane-state.ts
@@ -1,0 +1,65 @@
+import type { MigrationDb } from "./index";
+
+function hasColumn(db: MigrationDb, table: string, column: string): boolean {
+	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name?: unknown }>;
+	return rows.some((row) => row.name === column);
+}
+
+function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): void {
+	if (!hasColumn(db, table, column)) {
+		db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+	}
+}
+
+function backfillVersionRoots(db: MigrationDb): void {
+	db.exec(`
+		UPDATE entity_attributes
+		SET version_root_id = id
+		WHERE version_root_id IS NULL
+	`);
+}
+
+/**
+ * Migration 070: ontology control-plane state.
+ *
+ * Adds first-class claim version lineage, archive/status metadata, and
+ * proposal provenance columns needed by daemon-backed ontology operations.
+ */
+export function up(db: MigrationDb): void {
+	for (const table of ["entities", "entity_aspects", "entity_dependencies"] as const) {
+		addColumnIfMissing(db, table, "status", "TEXT NOT NULL DEFAULT 'active'");
+		addColumnIfMissing(db, table, "archived_at", "TEXT");
+		addColumnIfMissing(db, table, "archived_by", "TEXT");
+		addColumnIfMissing(db, table, "archive_reason", "TEXT");
+	}
+
+	for (const table of ["entities", "entity_aspects"] as const) {
+		addColumnIfMissing(db, table, "proposal_id", "TEXT");
+		addColumnIfMissing(db, table, "proposal_evidence", "TEXT NOT NULL DEFAULT '[]'");
+	}
+
+	addColumnIfMissing(db, "entity_attributes", "version", "INTEGER NOT NULL DEFAULT 1");
+	addColumnIfMissing(db, "entity_attributes", "version_root_id", "TEXT");
+	addColumnIfMissing(db, "entity_attributes", "previous_attribute_id", "TEXT");
+	addColumnIfMissing(db, "entity_attributes", "archived_at", "TEXT");
+	addColumnIfMissing(db, "entity_attributes", "archived_by", "TEXT");
+	addColumnIfMissing(db, "entity_attributes", "archive_reason", "TEXT");
+	backfillVersionRoots(db);
+
+	db.exec(`
+		CREATE INDEX IF NOT EXISTS idx_entities_status
+			ON entities(agent_id, status, updated_at DESC);
+		CREATE INDEX IF NOT EXISTS idx_entity_aspects_status
+			ON entity_aspects(agent_id, entity_id, status);
+		CREATE INDEX IF NOT EXISTS idx_entity_attributes_version_root
+			ON entity_attributes(agent_id, version_root_id, version DESC);
+		CREATE INDEX IF NOT EXISTS idx_entity_attributes_claim_version
+			ON entity_attributes(agent_id, aspect_id, group_key, claim_key, version DESC);
+		CREATE INDEX IF NOT EXISTS idx_entity_dependencies_status
+			ON entity_dependencies(agent_id, status, updated_at DESC);
+		CREATE INDEX IF NOT EXISTS idx_entities_proposal
+			ON entities(agent_id, proposal_id);
+		CREATE INDEX IF NOT EXISTS idx_entity_aspects_proposal
+			ON entity_aspects(agent_id, proposal_id);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -75,6 +75,7 @@ import { up as memorySearchTelemetry } from "./066-memory-search-telemetry";
 import { up as ontologyProposals } from "./067-ontology-proposals";
 import { up as dailyReflections } from "./068-daily-reflections";
 import { up as dailyReflectionsMultipleInsights } from "./069-daily-reflections-multiple-insights";
+import { up as ontologyControlPlaneState } from "./070-ontology-control-plane-state";
 
 // -- Public interface consumed by Database.init() --
 
@@ -645,6 +646,21 @@ export const MIGRATIONS: readonly Migration[] = [
 		up: dailyReflectionsMultipleInsights,
 		artifacts: {
 			tables: ["daily_reflections"],
+		},
+	},
+	{
+		version: 70,
+		name: "ontology-control-plane-state",
+		up: ontologyControlPlaneState,
+		artifacts: {
+			columns: [
+				{ table: "entities", column: "status" },
+				{ table: "entity_aspects", column: "status" },
+				{ table: "entity_attributes", column: "version" },
+				{ table: "entity_attributes", column: "version_root_id" },
+				{ table: "entity_attributes", column: "previous_attribute_id" },
+				{ table: "entity_dependencies", column: "status" },
+			],
 		},
 	},
 ];

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -12,6 +12,7 @@ import { readMemoriesFtsSql } from "../fts-schema";
 import { up as sessionSummaryUniqueness } from "./046-session-summary-uniqueness";
 import { up as agentScopedTemporalUniqueness } from "./047-agent-scoped-temporal-uniqueness";
 import { up as threadHeadsMigration } from "./048-thread-heads";
+import { up as ontologyControlPlaneState } from "./070-ontology-control-plane-state";
 import { MIGRATIONS, hasPendingMigrations, runMigrations } from "./index";
 
 function createFreshDb(): Database {
@@ -640,6 +641,81 @@ describe("migration framework", () => {
 
 		const indexes = db.query("PRAGMA index_list(memory_artifacts)").all() as Array<{ name: string }>;
 		expect(indexes.map((row) => row.name)).toContain("idx_memory_artifacts_agent_deleted");
+	});
+
+	test("migration 070 adds ontology control-plane status and version state safely", () => {
+		db = createFreshDb();
+		db.exec(`
+			CREATE TABLE entities (
+				id TEXT PRIMARY KEY,
+				agent_id TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			);
+			CREATE TABLE entity_aspects (
+				id TEXT PRIMARY KEY,
+				entity_id TEXT NOT NULL,
+				agent_id TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			);
+			CREATE TABLE entity_attributes (
+				id TEXT PRIMARY KEY,
+				aspect_id TEXT NOT NULL,
+				agent_id TEXT NOT NULL,
+				group_key TEXT,
+				claim_key TEXT,
+				status TEXT NOT NULL DEFAULT 'active',
+				updated_at TEXT NOT NULL
+			);
+			CREATE TABLE entity_dependencies (
+				id TEXT PRIMARY KEY,
+				source_entity_id TEXT NOT NULL,
+				target_entity_id TEXT NOT NULL,
+				agent_id TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			);
+			INSERT INTO entities (id, agent_id, updated_at) VALUES ('entity-1', 'ant', '2026-05-16T00:00:00.000Z');
+			INSERT INTO entity_aspects (id, entity_id, agent_id, updated_at)
+			VALUES ('aspect-1', 'entity-1', 'ant', '2026-05-16T00:00:00.000Z');
+			INSERT INTO entity_attributes (id, aspect_id, agent_id, updated_at)
+			VALUES ('attr-1', 'aspect-1', 'ant', '2026-05-16T00:00:00.000Z');
+			INSERT INTO entity_dependencies (id, source_entity_id, target_entity_id, agent_id, updated_at)
+			VALUES ('dep-1', 'entity-1', 'entity-1', 'ant', '2026-05-16T00:00:00.000Z');
+		`);
+
+		ontologyControlPlaneState(db);
+
+		const entity = db.query("SELECT status, archived_at FROM entities WHERE id = 'entity-1'").get() as {
+			status: string;
+			archived_at: string | null;
+		};
+		const aspect = db.query("SELECT status, archive_reason FROM entity_aspects WHERE id = 'aspect-1'").get() as {
+			status: string;
+			archive_reason: string | null;
+		};
+		const attr = db
+			.query(
+				"SELECT version, version_root_id, previous_attribute_id, archived_at FROM entity_attributes WHERE id = 'attr-1'",
+			)
+			.get() as {
+			version: number;
+			version_root_id: string;
+			previous_attribute_id: string | null;
+			archived_at: string | null;
+		};
+		const dep = db.query("SELECT status, archived_by FROM entity_dependencies WHERE id = 'dep-1'").get() as {
+			status: string;
+			archived_by: string | null;
+		};
+
+		expect(entity).toEqual({ status: "active", archived_at: null });
+		expect(aspect).toEqual({ status: "active", archive_reason: null });
+		expect(attr).toEqual({
+			version: 1,
+			version_root_id: "attr-1",
+			previous_attribute_id: null,
+			archived_at: null,
+		});
+		expect(dep).toEqual({ status: "active", archived_by: null });
 	});
 
 	test("entities table has pinning columns after migration 022", () => {

--- a/platform/core/src/types.ts
+++ b/platform/core/src/types.ts
@@ -647,6 +647,12 @@ export interface Entity {
 	mentions?: number;
 	pinned?: boolean;
 	pinnedAt?: string | null;
+	status?: OntologyRowStatus;
+	archivedAt?: string | null;
+	archivedBy?: string | null;
+	archiveReason?: string | null;
+	proposalId?: string | null;
+	proposalEvidence?: readonly unknown[];
 	createdAt: string;
 	updatedAt: string;
 }
@@ -738,6 +744,8 @@ export type AttributeKind = (typeof ATTRIBUTE_KINDS)[number];
 
 export const ATTRIBUTE_STATUSES = ["active", "superseded", "deleted"] as const;
 export type AttributeStatus = (typeof ATTRIBUTE_STATUSES)[number];
+export const ONTOLOGY_ROW_STATUSES = ["active", "archived"] as const;
+export type OntologyRowStatus = (typeof ONTOLOGY_ROW_STATUSES)[number];
 
 export const DEPENDENCY_TYPES = [
 	// core
@@ -824,7 +832,17 @@ export type OntologyProposalStatus = (typeof ONTOLOGY_PROPOSAL_STATUSES)[number]
 export const ONTOLOGY_PROPOSAL_OPERATIONS = [
 	"create_entity",
 	"add_claim_value",
+	"set_claim_value",
+	"rename_entity",
+	"archive_entity",
+	"create_aspect",
+	"rename_aspect",
+	"archive_aspect",
+	"archive_claim_value",
+	"restore_claim_version",
 	"create_link",
+	"update_link",
+	"archive_link",
 	"merge_entities",
 	"supersede_claim_value",
 	"create_policy",
@@ -865,6 +883,12 @@ export interface EntityAspect {
 	readonly name: string;
 	readonly canonicalName: string;
 	readonly weight: number;
+	readonly status?: OntologyRowStatus;
+	readonly archivedAt?: string | null;
+	readonly archivedBy?: string | null;
+	readonly archiveReason?: string | null;
+	readonly proposalId?: string | null;
+	readonly proposalEvidence?: readonly unknown[];
 	readonly createdAt: string;
 	readonly updatedAt: string;
 }
@@ -883,6 +907,12 @@ export interface EntityAttribute {
 	readonly importance: number;
 	readonly status: AttributeStatus;
 	readonly supersededBy: string | null;
+	readonly version?: number;
+	readonly versionRootId?: string | null;
+	readonly previousAttributeId?: string | null;
+	readonly archivedAt?: string | null;
+	readonly archivedBy?: string | null;
+	readonly archiveReason?: string | null;
 	readonly sourceKind: string | null;
 	readonly sourceId: string | null;
 	readonly sourcePath: string | null;
@@ -903,6 +933,10 @@ export interface EntityDependency {
 	readonly strength: number;
 	readonly confidence: number;
 	readonly reason: string | null;
+	readonly status?: OntologyRowStatus;
+	readonly archivedAt?: string | null;
+	readonly archivedBy?: string | null;
+	readonly archiveReason?: string | null;
 	readonly sourceKind: string | null;
 	readonly sourceId: string | null;
 	readonly sourcePath: string | null;

--- a/platform/daemon/src/daemon-auth-guard-colocation.test.ts
+++ b/platform/daemon/src/daemon-auth-guard-colocation.test.ts
@@ -47,8 +47,10 @@ writeFileSync(
 `,
 );
 process.env.SIGNET_PATH = tmpDir;
+let closeAccessor: (() => void) | null = null;
 
 afterAll(() => {
+	closeAccessor?.();
 	if (prevSignetPath === undefined) {
 		Reflect.deleteProperty(process.env, "SIGNET_PATH");
 	}
@@ -61,8 +63,10 @@ describe("auth guard co-location", () => {
 		// Import daemon to warm the full module graph and break the
 		// circular dependency chain (state → pipeline → hooks → daemon → git-sync → state).
 		await import("./daemon");
-		const { initDbAccessor } = await import("./db-accessor");
+		const { closeDbAccessor, initDbAccessor } = await import("./db-accessor");
+		closeDbAccessor();
 		initDbAccessor(join(tmpDir, "memory", "memories.db"));
+		closeAccessor = closeDbAccessor;
 
 		// Switch to team mode.  The initial parseAuthConfig(undefined, ...)
 		// always defaults to local.  reloadAuthState reads agent.yaml from
@@ -168,6 +172,20 @@ describe("auth guard co-location", () => {
 			const { registerOntologyRoutes } = await import("./routes/ontology-routes");
 			registerOntologyRoutes(app);
 			expect(await status(app, "POST", "/api/ontology/proposals/batch")).toBe(403);
+		});
+
+		it("POST /api/ontology/operations/apply returns 403 without auth", async () => {
+			const app = await makeApp();
+			const { registerOntologyRoutes } = await import("./routes/ontology-routes");
+			registerOntologyRoutes(app);
+			expect(await status(app, "POST", "/api/ontology/operations/apply")).toBe(403);
+		});
+
+		it("POST /api/ontology/operations/batch returns 403 without auth", async () => {
+			const app = await makeApp();
+			const { registerOntologyRoutes } = await import("./routes/ontology-routes");
+			registerOntologyRoutes(app);
+			expect(await status(app, "POST", "/api/ontology/operations/batch")).toBe(403);
 		});
 
 		it("GET /api/ontology/proposals/:id/evidence returns 403 without auth", async () => {

--- a/platform/daemon/src/dreaming-skill.test.ts
+++ b/platform/daemon/src/dreaming-skill.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("built-in dreaming skill", () => {
+	test("exists and keeps ontology maintenance proposal-first", () => {
+		const content = readFileSync(resolve(import.meta.dir, "../../../skills/dreaming/SKILL.md"), "utf8");
+
+		expect(content).toContain("name: dreaming");
+		expect(content).toContain("transcripts, memory artifacts, source artifacts, notes, summaries, and imported");
+		expect(content).toContain("entities, aspects, groups, claims, attributes, and links");
+		expect(content).toContain("recently saved memory artifacts");
+		expect(content).toContain("flexible bulk ingestion");
+		expect(content).toContain("signet ontology stream apply proposals.jsonl --dry-run --json");
+		expect(content).toContain("signet ontology stream apply proposals.jsonl --propose --json");
+		expect(content).toContain("Do not edit SQLite directly.");
+		expect(content).toContain("Do not bypass `ontology_proposals`");
+		expect(content).not.toContain("sqlite3 ");
+		expect(content).not.toContain("UPDATE entity_attributes");
+	});
+});

--- a/platform/daemon/src/dreaming-skill.test.ts
+++ b/platform/daemon/src/dreaming-skill.test.ts
@@ -12,7 +12,7 @@ describe("built-in dreaming skill", () => {
 		expect(content).toContain("entities, aspects, groups, claims, attributes, and links");
 		expect(content).toContain("recently saved memory artifacts");
 		expect(content).toContain("flexible bulk ingestion");
-		expect(content).toContain("The point is to maintain the graph, not to create JSON.");
+		expect(content).toContain("Memory artifacts are evidence\nfor attributes");
 		expect(content).toContain("source-backed memory artifacts");
 		expect(content).toContain("not the API\n  `remember` endpoint");
 		expect(content).toContain("signet ontology stream apply ops.jsonl --json");
@@ -23,6 +23,7 @@ describe("built-in dreaming skill", () => {
 		expect(content).toContain("Do not call `/api/memory/remember`");
 		expect(content).not.toContain("Default mode is proposal-first");
 		expect(content).not.toContain("Start with `--dry-run`");
+		expect(content).not.toContain("not to create JSON");
 		expect(content).not.toContain("sqlite3 ");
 		expect(content).not.toContain("UPDATE entity_attributes");
 	});

--- a/platform/daemon/src/dreaming-skill.test.ts
+++ b/platform/daemon/src/dreaming-skill.test.ts
@@ -3,18 +3,26 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 describe("built-in dreaming skill", () => {
-	test("exists and keeps ontology maintenance proposal-first", () => {
+	test("exists and keeps ontology maintenance graph-first", () => {
 		const content = readFileSync(resolve(import.meta.dir, "../../../skills/dreaming/SKILL.md"), "utf8");
 
 		expect(content).toContain("name: dreaming");
+		expect(content).toContain("Maintain Signet's living ontology and memory substrate");
 		expect(content).toContain("transcripts, memory artifacts, source artifacts, notes, summaries, and imported");
 		expect(content).toContain("entities, aspects, groups, claims, attributes, and links");
 		expect(content).toContain("recently saved memory artifacts");
 		expect(content).toContain("flexible bulk ingestion");
-		expect(content).toContain("signet ontology stream apply proposals.jsonl --dry-run --json");
+		expect(content).toContain("The point is to maintain the graph, not to create JSON.");
+		expect(content).toContain("source-backed memory artifacts");
+		expect(content).toContain("not the API\n  `remember` endpoint");
+		expect(content).toContain("signet ontology stream apply ops.jsonl --json");
 		expect(content).toContain("signet ontology stream apply proposals.jsonl --propose --json");
+		expect(content).toContain("Use dry-run only when the operator asks");
 		expect(content).toContain("Do not edit SQLite directly.");
 		expect(content).toContain("Do not bypass `ontology_proposals`");
+		expect(content).toContain("Do not call `/api/memory/remember`");
+		expect(content).not.toContain("Default mode is proposal-first");
+		expect(content).not.toContain("Start with `--dry-run`");
 		expect(content).not.toContain("sqlite3 ");
 		expect(content).not.toContain("UPDATE entity_attributes");
 	});

--- a/platform/daemon/src/knowledge-graph-list.test.ts
+++ b/platform/daemon/src/knowledge-graph-list.test.ts
@@ -197,6 +197,35 @@ describe("listKnowledgeEntities (issue #515)", () => {
 		expect(hub?.dependencyCount).toBe(2);
 	});
 
+	test("excludes archived graph rows from default list counts", () => {
+		dbPath = makeDbPath();
+		initDbAccessor(dbPath);
+
+		seedEntity("e-active", "Active", { mentions: 5 });
+		seedEntity("e-archived", "Archived", { mentions: 10 });
+		seedAspect("asp-active", "e-active", "capability");
+		seedAspect("asp-archived", "e-active", "retired");
+		seedAttribute("attr-active", "asp-active", { kind: "attribute" });
+		seedAttribute("constraint-archived-aspect", "asp-archived", { kind: "constraint" });
+		seedDependency("dep-archived", "e-active", "e-archived");
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE entities SET status = 'archived' WHERE id = ?").run("e-archived");
+			db.prepare("UPDATE entity_aspects SET status = 'archived' WHERE id = ?").run("asp-archived");
+		});
+
+		const result = listKnowledgeEntities(getDbAccessor(), {
+			agentId: "default",
+			limit: 10,
+			offset: 0,
+		});
+
+		expect(result.map((item) => item.entity.id)).toEqual(["e-active"]);
+		expect(result[0]?.aspectCount).toBe(1);
+		expect(result[0]?.attributeCount).toBe(1);
+		expect(result[0]?.constraintCount).toBe(0);
+		expect(result[0]?.dependencyCount).toBe(0);
+	});
+
 	test("respects limit and offset pagination", () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
@@ -376,5 +405,34 @@ describe("getKnowledgeStats (issue #515)", () => {
 
 		const stats = getKnowledgeStats(getDbAccessor(), "default");
 		expect(stats.unassignedMemoryCount).toBe(0);
+	});
+
+	test("excludes archived graph rows from stats and coverage", () => {
+		dbPath = makeDbPath();
+		initDbAccessor(dbPath);
+
+		seedEntity("e-active", "Active", { agentId: "default" });
+		seedEntity("e-archived", "Archived", { agentId: "default" });
+		seedAspect("asp-active", "e-active", "capability");
+		seedAspect("asp-archived", "e-active", "retired");
+		seedAttribute("attr-active", "asp-active", { memoryId: "m-active" });
+		seedAttribute("attr-archived-aspect", "asp-archived", { memoryId: "m-archived-aspect" });
+		seedDependency("dep-archived-target", "e-active", "e-archived");
+		seedMemory("m-active");
+		seedMemory("m-archived-entity");
+		seedMention("m-active", "e-active");
+		seedMention("m-archived-entity", "e-archived");
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE entities SET status = 'archived' WHERE id = ?").run("e-archived");
+			db.prepare("UPDATE entity_aspects SET status = 'archived' WHERE id = ?").run("asp-archived");
+		});
+
+		const stats = getKnowledgeStats(getDbAccessor(), "default");
+		expect(stats.entityCount).toBe(1);
+		expect(stats.aspectCount).toBe(1);
+		expect(stats.attributeCount).toBe(1);
+		expect(stats.dependencyCount).toBe(0);
+		expect(stats.unassignedMemoryCount).toBe(0);
+		expect(stats.coveragePercent).toBe(100);
 	});
 });

--- a/platform/daemon/src/knowledge-graph-list.test.ts
+++ b/platform/daemon/src/knowledge-graph-list.test.ts
@@ -14,6 +14,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import {
+	getDependenciesFrom,
+	getDependenciesTo,
 	getKnowledgeEntityDetail,
 	getKnowledgeGraphForConstellation,
 	getKnowledgeStats,
@@ -224,6 +226,27 @@ describe("listKnowledgeEntities (issue #515)", () => {
 		expect(result[0]?.attributeCount).toBe(1);
 		expect(result[0]?.constraintCount).toBe(0);
 		expect(result[0]?.dependencyCount).toBe(0);
+	});
+
+	test("dependency reads hide edges attached to archived endpoint entities", () => {
+		dbPath = makeDbPath();
+		initDbAccessor(dbPath);
+
+		seedEntity("e-active", "Active");
+		seedEntity("e-archived", "Archived");
+		seedEntity("e-other", "Other");
+		seedDependency("dep-hidden-target", "e-active", "e-archived");
+		seedDependency("dep-hidden-source", "e-archived", "e-active");
+		seedDependency("dep-visible-out", "e-active", "e-other");
+		seedDependency("dep-visible-in", "e-other", "e-active");
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE entities SET status = 'archived' WHERE id = ?").run("e-archived");
+		});
+
+		expect(getDependenciesFrom(getDbAccessor(), "e-active", "default").map((dep) => dep.id)).toEqual([
+			"dep-visible-out",
+		]);
+		expect(getDependenciesTo(getDbAccessor(), "e-active", "default").map((dep) => dep.id)).toEqual(["dep-visible-in"]);
 	});
 
 	test("respects limit and offset pagination", () => {

--- a/platform/daemon/src/knowledge-graph.ts
+++ b/platform/daemon/src/knowledge-graph.ts
@@ -483,9 +483,14 @@ export function getDependenciesFrom(
 	return accessor.withReadDb((db) => {
 		const rows = db
 			.prepare(
-				`SELECT * FROM entity_dependencies
-				 WHERE source_entity_id = ? AND agent_id = ?
-				   AND COALESCE(status, 'active') = 'active'`,
+				`SELECT dep.*
+				 FROM entity_dependencies dep
+				 JOIN entities src ON src.id = dep.source_entity_id AND src.agent_id = dep.agent_id
+				 JOIN entities dst ON dst.id = dep.target_entity_id AND dst.agent_id = dep.agent_id
+				 WHERE dep.source_entity_id = ? AND dep.agent_id = ?
+				   AND COALESCE(dep.status, 'active') = 'active'
+				   AND COALESCE(src.status, 'active') = 'active'
+				   AND COALESCE(dst.status, 'active') = 'active'`,
 			)
 			.all(entityId, agentId) as Array<Record<string, unknown>>;
 		return rows.map(rowToDependency);
@@ -500,9 +505,14 @@ export function getDependenciesTo(
 	return accessor.withReadDb((db) => {
 		const rows = db
 			.prepare(
-				`SELECT * FROM entity_dependencies
-				 WHERE target_entity_id = ? AND agent_id = ?
-				   AND COALESCE(status, 'active') = 'active'`,
+				`SELECT dep.*
+				 FROM entity_dependencies dep
+				 JOIN entities src ON src.id = dep.source_entity_id AND src.agent_id = dep.agent_id
+				 JOIN entities dst ON dst.id = dep.target_entity_id AND dst.agent_id = dep.agent_id
+				 WHERE dep.target_entity_id = ? AND dep.agent_id = ?
+				   AND COALESCE(dep.status, 'active') = 'active'
+				   AND COALESCE(src.status, 'active') = 'active'
+				   AND COALESCE(dst.status, 'active') = 'active'`,
 			)
 			.all(entityId, agentId) as Array<Record<string, unknown>>;
 		return rows.map(rowToDependency);

--- a/platform/daemon/src/knowledge-graph.ts
+++ b/platform/daemon/src/knowledge-graph.ts
@@ -55,6 +55,12 @@ function rowToEntity(r: Record<string, unknown>): Entity {
 		mentions: typeof r.mentions === "number" ? r.mentions : undefined,
 		pinned: r.pinned === 1,
 		pinnedAt: typeof r.pinned_at === "string" ? r.pinned_at : null,
+		status: r.status === "archived" ? "archived" : "active",
+		archivedAt: typeof r.archived_at === "string" ? r.archived_at : null,
+		archivedBy: typeof r.archived_by === "string" ? r.archived_by : null,
+		archiveReason: typeof r.archive_reason === "string" ? r.archive_reason : null,
+		proposalId: typeof r.proposal_id === "string" ? r.proposal_id : null,
+		proposalEvidence: parseJsonArray(r.proposal_evidence),
 		createdAt: r.created_at as string,
 		updatedAt: r.updated_at as string,
 	};
@@ -72,6 +78,12 @@ function rowToAspect(r: Record<string, unknown>): EntityAspect {
 		name: r.name as string,
 		canonicalName: r.canonical_name as string,
 		weight: r.weight as number,
+		status: r.status === "archived" ? "archived" : "active",
+		archivedAt: typeof r.archived_at === "string" ? r.archived_at : null,
+		archivedBy: typeof r.archived_by === "string" ? r.archived_by : null,
+		archiveReason: typeof r.archive_reason === "string" ? r.archive_reason : null,
+		proposalId: typeof r.proposal_id === "string" ? r.proposal_id : null,
+		proposalEvidence: parseJsonArray(r.proposal_evidence),
 		createdAt: r.created_at as string,
 		updatedAt: r.updated_at as string,
 	};
@@ -93,6 +105,12 @@ function rowToAttribute(r: Record<string, unknown>): EntityAttribute {
 		importance: r.importance as number,
 		status: r.status as AttributeStatus,
 		supersededBy: (r.superseded_by as string) ?? null,
+		version: typeof r.version === "number" ? r.version : 1,
+		versionRootId: typeof r.version_root_id === "string" ? r.version_root_id : (r.id as string),
+		previousAttributeId: typeof r.previous_attribute_id === "string" ? r.previous_attribute_id : null,
+		archivedAt: typeof r.archived_at === "string" ? r.archived_at : null,
+		archivedBy: typeof r.archived_by === "string" ? r.archived_by : null,
+		archiveReason: typeof r.archive_reason === "string" ? r.archive_reason : null,
 		sourceKind: (r.source_kind as string) ?? null,
 		sourceId: (r.source_id as string) ?? null,
 		sourcePath: (r.source_path as string) ?? null,
@@ -116,6 +134,10 @@ function rowToDependency(r: Record<string, unknown>): EntityDependency {
 		strength: r.strength as number,
 		confidence: typeof r.confidence === "number" ? r.confidence : 0.7,
 		reason: typeof r.reason === "string" ? r.reason : null,
+		status: r.status === "archived" ? "archived" : "active",
+		archivedAt: typeof r.archived_at === "string" ? r.archived_at : null,
+		archivedBy: typeof r.archived_by === "string" ? r.archived_by : null,
+		archiveReason: typeof r.archive_reason === "string" ? r.archive_reason : null,
 		sourceKind: (r.source_kind as string) ?? null,
 		sourceId: (r.source_id as string) ?? null,
 		sourcePath: (r.source_path as string) ?? null,
@@ -184,6 +206,7 @@ export function getAspectsForEntity(accessor: DbAccessor, entityId: string, agen
 			.prepare(
 				`SELECT * FROM entity_aspects
 				 WHERE entity_id = ? AND agent_id = ?
+				   AND COALESCE(status, 'active') = 'active'
 				 ORDER BY weight DESC`,
 			)
 			.all(entityId, agentId) as Array<Record<string, unknown>>;
@@ -297,6 +320,7 @@ export function getConstraintsForEntity(
 				 JOIN entity_aspects asp ON asp.id = ea.aspect_id
 				 WHERE asp.entity_id = ? AND asp.agent_id = ?
 				   AND ea.agent_id = ?
+				   AND COALESCE(asp.status, 'active') = 'active'
 				   AND ea.kind = 'constraint'
 				   AND ea.status = 'active'
 				 ORDER BY ea.importance DESC`,
@@ -460,7 +484,8 @@ export function getDependenciesFrom(
 		const rows = db
 			.prepare(
 				`SELECT * FROM entity_dependencies
-				 WHERE source_entity_id = ? AND agent_id = ?`,
+				 WHERE source_entity_id = ? AND agent_id = ?
+				   AND COALESCE(status, 'active') = 'active'`,
 			)
 			.all(entityId, agentId) as Array<Record<string, unknown>>;
 		return rows.map(rowToDependency);
@@ -476,7 +501,8 @@ export function getDependenciesTo(
 		const rows = db
 			.prepare(
 				`SELECT * FROM entity_dependencies
-				 WHERE target_entity_id = ? AND agent_id = ?`,
+				 WHERE target_entity_id = ? AND agent_id = ?
+				   AND COALESCE(status, 'active') = 'active'`,
 			)
 			.all(entityId, agentId) as Array<Record<string, unknown>>;
 		return rows.map(rowToDependency);
@@ -526,6 +552,7 @@ export function getPinnedEntities(accessor: DbAccessor, agentId: string): Readon
 				 FROM entities
 				 WHERE agent_id = ?
 				   AND pinned = 1
+				   AND COALESCE(status, 'active') = 'active'
 				 ORDER BY pinned_at DESC, updated_at DESC, name ASC`,
 			)
 			.all(agentId) as Array<Record<string, unknown>>;
@@ -797,6 +824,7 @@ export function resolveNamedEntity(
 					END AS match_rank
 				 FROM entities
 				 WHERE agent_id = ?
+				   AND COALESCE(status, 'active') = 'active'
 				   AND (
 						COALESCE(canonical_name, LOWER(name)) = ?
 						OR LOWER(name) = ?
@@ -859,6 +887,7 @@ function resolveAspectByName(
 			 FROM entity_aspects
 			 WHERE entity_id = ?
 			   AND agent_id = ?
+			   AND COALESCE(status, 'active') = 'active'
 			   AND (canonical_name = ? OR LOWER(name) = ?)
 			 ORDER BY weight DESC, updated_at DESC
 			 LIMIT 1`,
@@ -884,6 +913,7 @@ function resolveEntityRecordByName(
 			`SELECT *
 			 FROM entities
 			 WHERE agent_id = ?
+			   AND COALESCE(status, 'active') = 'active'
 			   AND (
 					COALESCE(canonical_name, LOWER(name)) = ?
 					OR LOWER(name) = ?
@@ -995,6 +1025,7 @@ export function getEntityKnowledgeTree(
 				 LEFT JOIN entity_attributes attr
 				   ON attr.aspect_id = asp.id AND attr.agent_id = asp.agent_id
 				 WHERE asp.entity_id = ? AND asp.agent_id = ?
+				   AND COALESCE(asp.status, 'active') = 'active'
 				 GROUP BY asp.id
 				 ORDER BY asp.weight DESC, asp.name ASC
 				 LIMIT ?`,
@@ -1308,6 +1339,7 @@ export function listKnowledgeEntities(
 	return accessor.withReadDb((db) => {
 		const conditions = ["e.agent_id = ?"];
 		const args: Array<string | number> = [params.agentId];
+		conditions.push("COALESCE(e.status, 'active') = 'active'");
 		if (params.type) {
 			conditions.push("e.entity_type = ?");
 			args.push(params.type);
@@ -1335,12 +1367,14 @@ export function listKnowledgeEntities(
 					(
 						SELECT COUNT(*) FROM entity_aspects asp
 						WHERE asp.entity_id = e.id AND asp.agent_id = e.agent_id
+						  AND COALESCE(asp.status, 'active') = 'active'
 					) AS aspect_count,
 					(
 						SELECT COUNT(*) FROM entity_attributes attr
 						JOIN entity_aspects asp ON asp.id = attr.aspect_id
 						WHERE asp.entity_id = e.id
 						  AND asp.agent_id = e.agent_id
+						  AND COALESCE(asp.status, 'active') = 'active'
 						  AND attr.agent_id = e.agent_id
 						  AND attr.kind = 'attribute'
 						  AND attr.status = 'active'
@@ -1350,13 +1384,19 @@ export function listKnowledgeEntities(
 						JOIN entity_aspects asp ON asp.id = attr.aspect_id
 						WHERE asp.entity_id = e.id
 						  AND asp.agent_id = e.agent_id
+						  AND COALESCE(asp.status, 'active') = 'active'
 						  AND attr.agent_id = e.agent_id
 						  AND attr.kind = 'constraint'
 						  AND attr.status = 'active'
 					) AS constraint_count,
 					(
 						SELECT COUNT(*) FROM entity_dependencies dep
+						JOIN entities src ON src.id = dep.source_entity_id AND src.agent_id = dep.agent_id
+						JOIN entities dst ON dst.id = dep.target_entity_id AND dst.agent_id = dep.agent_id
 						WHERE dep.agent_id = e.agent_id
+						  AND COALESCE(dep.status, 'active') = 'active'
+						  AND COALESCE(src.status, 'active') = 'active'
+						  AND COALESCE(dst.status, 'active') = 'active'
 						  AND (dep.source_entity_id = e.id OR dep.target_entity_id = e.id)
 					) AS dependency_count
 				 FROM page p
@@ -1391,13 +1431,15 @@ export function getKnowledgeEntityDetail(
 					e.*,
 					(
 						SELECT COUNT(*) FROM entity_aspects asp
-						WHERE asp.entity_id = e.id AND asp.agent_id = e.agent_id
+						  WHERE asp.entity_id = e.id AND asp.agent_id = e.agent_id
+						    AND COALESCE(asp.status, 'active') = 'active'
 					) AS aspect_count,
 					(
 						SELECT COUNT(*) FROM entity_attributes attr
 						JOIN entity_aspects asp ON asp.id = attr.aspect_id
-						WHERE asp.entity_id = e.id
+						  WHERE asp.entity_id = e.id
 						  AND asp.agent_id = e.agent_id
+						  AND COALESCE(asp.status, 'active') = 'active'
 						  AND attr.agent_id = e.agent_id
 						  AND attr.kind = 'attribute'
 						  AND attr.status = 'active'
@@ -1405,22 +1447,32 @@ export function getKnowledgeEntityDetail(
 					(
 						SELECT COUNT(*) FROM entity_attributes attr
 						JOIN entity_aspects asp ON asp.id = attr.aspect_id
-						WHERE asp.entity_id = e.id
+						  WHERE asp.entity_id = e.id
 						  AND asp.agent_id = e.agent_id
+						  AND COALESCE(asp.status, 'active') = 'active'
 						  AND attr.agent_id = e.agent_id
 						  AND attr.kind = 'constraint'
 						  AND attr.status = 'active'
 					) AS constraint_count,
 					(
 						SELECT COUNT(*) FROM entity_dependencies dep
-						WHERE dep.agent_id = e.agent_id AND dep.source_entity_id = e.id
+						JOIN entities dst ON dst.id = dep.target_entity_id AND dst.agent_id = dep.agent_id
+						WHERE dep.agent_id = e.agent_id
+						  AND COALESCE(dep.status, 'active') = 'active'
+						  AND COALESCE(dst.status, 'active') = 'active'
+						  AND dep.source_entity_id = e.id
 					) AS outgoing_dependency_count,
 					(
 						SELECT COUNT(*) FROM entity_dependencies dep
-						WHERE dep.agent_id = e.agent_id AND dep.target_entity_id = e.id
+						JOIN entities src ON src.id = dep.source_entity_id AND src.agent_id = dep.agent_id
+						WHERE dep.agent_id = e.agent_id
+						  AND COALESCE(dep.status, 'active') = 'active'
+						  AND COALESCE(src.status, 'active') = 'active'
+						  AND dep.target_entity_id = e.id
 					) AS incoming_dependency_count
 				 FROM entities e
-				 WHERE e.id = ? AND e.agent_id = ?`,
+				 WHERE e.id = ? AND e.agent_id = ?
+				   AND COALESCE(e.status, 'active') = 'active'`,
 			)
 			.get(entityId, agentId) as Record<string, unknown> | undefined;
 
@@ -1462,6 +1514,7 @@ export function getEntityAspectsWithCounts(
 				 LEFT JOIN entity_attributes attr
 				   ON attr.aspect_id = asp.id AND attr.agent_id = asp.agent_id
 				 WHERE asp.entity_id = ? AND asp.agent_id = ?
+				   AND COALESCE(asp.status, 'active') = 'active'
 				 GROUP BY asp.id
 				 ORDER BY asp.weight DESC, asp.name ASC`,
 			)
@@ -1488,7 +1541,14 @@ export function getAttributesForAspectFiltered(
 	},
 ): readonly EntityAttribute[] {
 	return accessor.withReadDb((db) => {
-		const conditions = ["asp.entity_id = ?", "asp.id = ?", "asp.agent_id = ?", "ea.agent_id = ?"];
+		const conditions = [
+			"asp.entity_id = ?",
+			"asp.id = ?",
+			"asp.agent_id = ?",
+			"ea.agent_id = ?",
+			"COALESCE(e.status, 'active') = 'active'",
+			"COALESCE(asp.status, 'active') = 'active'",
+		];
 		const args: Array<string | number> = [params.entityId, params.aspectId, params.agentId, params.agentId];
 		if (params.kind) {
 			conditions.push("ea.kind = ?");
@@ -1504,6 +1564,7 @@ export function getAttributesForAspectFiltered(
 				`SELECT ea.*
 				 FROM entity_attributes ea
 				 JOIN entity_aspects asp ON asp.id = ea.aspect_id
+				 JOIN entities e ON e.id = asp.entity_id AND e.agent_id = asp.agent_id
 				 WHERE ${conditions.join(" AND ")}
 				 ORDER BY ea.importance DESC, ea.created_at DESC
 				 LIMIT ? OFFSET ?`,
@@ -1540,6 +1601,9 @@ export function getEntityDependenciesDetailed(
 				 JOIN entities dst ON dst.id = dep.target_entity_id
 				 WHERE dep.agent_id = ?
 				   AND (${directionClauses.join(" OR ")})
+				   AND COALESCE(dep.status, 'active') = 'active'
+				   AND COALESCE(src.status, 'active') = 'active'
+				   AND COALESCE(dst.status, 'active') = 'active'
 				 ORDER BY dep.strength DESC, dep.updated_at DESC`,
 			)
 			.all(
@@ -1576,37 +1640,72 @@ export function getKnowledgeStats(accessor: DbAccessor, agentId: string): Knowle
 				`SELECT COUNT(DISTINCT mem.memory_id) as n
 				 FROM memory_entity_mentions mem
 				 JOIN entities e ON e.id = mem.entity_id AND e.agent_id = ?
-				 JOIN memories m ON m.id = mem.memory_id AND m.is_deleted = 0`,
+				 JOIN memories m ON m.id = mem.memory_id AND m.is_deleted = 0
+				 WHERE COALESCE(e.status, 'active') = 'active'`,
 			)
 			.get(agentId) as { n: number };
-		const entityCount = db.prepare("SELECT COUNT(*) as n FROM entities WHERE agent_id = ?").get(agentId) as {
-			n: number;
-		};
-		const aspectCount = db.prepare("SELECT COUNT(*) as n FROM entity_aspects WHERE agent_id = ?").get(agentId) as {
-			n: number;
-		};
+		const entityCount = db
+			.prepare("SELECT COUNT(*) as n FROM entities WHERE agent_id = ? AND COALESCE(status, 'active') = 'active'")
+			.get(agentId) as { n: number };
+		const aspectCount = db
+			.prepare(
+				`SELECT COUNT(*) as n
+				 FROM entity_aspects asp
+				 JOIN entities e ON e.id = asp.entity_id AND e.agent_id = asp.agent_id
+				 WHERE asp.agent_id = ?
+				   AND COALESCE(e.status, 'active') = 'active'
+				   AND COALESCE(asp.status, 'active') = 'active'`,
+			)
+			.get(agentId) as { n: number };
 		const attributeCount = db
 			.prepare(
-				`SELECT COUNT(*) as n FROM entity_attributes
-				 WHERE agent_id = ? AND kind = 'attribute' AND status = 'active'`,
+				`SELECT COUNT(*) as n
+				 FROM entity_attributes attr
+				 JOIN entity_aspects asp ON asp.id = attr.aspect_id AND asp.agent_id = attr.agent_id
+				 JOIN entities e ON e.id = asp.entity_id AND e.agent_id = asp.agent_id
+				 WHERE attr.agent_id = ?
+				   AND attr.kind = 'attribute'
+				   AND attr.status = 'active'
+				   AND COALESCE(e.status, 'active') = 'active'
+				   AND COALESCE(asp.status, 'active') = 'active'`,
 			)
 			.get(agentId) as { n: number };
 		const constraintCount = db
 			.prepare(
-				`SELECT COUNT(*) as n FROM entity_attributes
-				 WHERE agent_id = ? AND kind = 'constraint' AND status = 'active'`,
+				`SELECT COUNT(*) as n
+				 FROM entity_attributes attr
+				 JOIN entity_aspects asp ON asp.id = attr.aspect_id AND asp.agent_id = attr.agent_id
+				 JOIN entities e ON e.id = asp.entity_id AND e.agent_id = asp.agent_id
+				 WHERE attr.agent_id = ?
+				   AND attr.kind = 'constraint'
+				   AND attr.status = 'active'
+				   AND COALESCE(e.status, 'active') = 'active'
+				   AND COALESCE(asp.status, 'active') = 'active'`,
 			)
 			.get(agentId) as { n: number };
 		const dependencyCount = db
-			.prepare("SELECT COUNT(*) as n FROM entity_dependencies WHERE agent_id = ?")
+			.prepare(
+				`SELECT COUNT(*) as n
+				 FROM entity_dependencies dep
+				 JOIN entities src ON src.id = dep.source_entity_id AND src.agent_id = dep.agent_id
+				 JOIN entities dst ON dst.id = dep.target_entity_id AND dst.agent_id = dep.agent_id
+				 WHERE dep.agent_id = ?
+				   AND COALESCE(dep.status, 'active') = 'active'
+				   AND COALESCE(src.status, 'active') = 'active'
+				   AND COALESCE(dst.status, 'active') = 'active'`,
+			)
 			.get(agentId) as { n: number };
 		const assignedMemoryCount = db
 			.prepare(
-				`SELECT COUNT(DISTINCT memory_id) as n
-				 FROM entity_attributes
-				 WHERE agent_id = ?
-				   AND status = 'active'
-				   AND memory_id IS NOT NULL`,
+				`SELECT COUNT(DISTINCT attr.memory_id) as n
+				 FROM entity_attributes attr
+				 JOIN entity_aspects asp ON asp.id = attr.aspect_id AND asp.agent_id = attr.agent_id
+				 JOIN entities e ON e.id = asp.entity_id AND e.agent_id = asp.agent_id
+				 WHERE attr.agent_id = ?
+				   AND attr.status = 'active'
+				   AND attr.memory_id IS NOT NULL
+				   AND COALESCE(e.status, 'active') = 'active'
+				   AND COALESCE(asp.status, 'active') = 'active'`,
 			)
 			.get(agentId) as { n: number };
 		const feedbackStats = db
@@ -1617,10 +1716,13 @@ export function getKnowledgeStats(accessor: DbAccessor, agentId: string): Knowle
 					COUNT(CASE WHEN weight >= 1.0 THEN 1 END) AS max_weight_count,
 					COUNT(CASE WHEN weight <= 0.1 THEN 1 END) AS min_weight_count,
 					COUNT(CASE
-						WHEN updated_at >= datetime('now', '-7 days') THEN 1
+						WHEN asp.updated_at >= datetime('now', '-7 days') THEN 1
 					END) AS updated_last_7_days
-				 FROM entity_aspects
-				 WHERE agent_id = ?`,
+				 FROM entity_aspects asp
+				 JOIN entities e ON e.id = asp.entity_id AND e.agent_id = asp.agent_id
+				 WHERE asp.agent_id = ?
+				   AND COALESCE(e.status, 'active') = 'active'
+				   AND COALESCE(asp.status, 'active') = 'active'`,
 			)
 			.get(agentId) as {
 			aspect_count: number;

--- a/platform/daemon/src/ontology-proposals.test.ts
+++ b/platform/daemon/src/ontology-proposals.test.ts
@@ -1743,6 +1743,82 @@ describe("ontology proposals", () => {
 		expect(version?.content).toBe("History survives entity archival.");
 	});
 
+	it("requires strict claim-version entity selectors across archived duplicates", () => {
+		insertEntity("archived-history", "Duplicate History A", "duplicate history", "ant", 1);
+		insertEntity("active-history", "Duplicate History B", "duplicate history", "ant", 2);
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE entities SET status = 'archived' WHERE id = ?").run("archived-history");
+			db.prepare(
+				`INSERT INTO entity_aspects
+				 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?, 0.5, datetime('now'), datetime('now'))`,
+			).run("archived-history-aspect", "archived-history", "ant", "architecture", "architecture");
+			db.prepare(
+				`INSERT INTO entity_aspects
+				 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?, 0.5, datetime('now'), datetime('now'))`,
+			).run("active-history-aspect", "active-history", "ant", "architecture", "architecture");
+			db.prepare(
+				`INSERT INTO entity_attributes
+				 (id, aspect_id, agent_id, kind, content, normalized_content,
+				  confidence, importance, status, group_key, claim_key,
+				  version, version_root_id, created_at, updated_at)
+				 VALUES (?, ?, ?, 'attribute', ?, ?, 0.8, 0.5, 'active', ?, ?, 1, ?, datetime('now'), datetime('now'))`,
+			).run(
+				"archived-history-attr",
+				"archived-history-aspect",
+				"ant",
+				"Archived entity history.",
+				"archived entity history.",
+				"ontology",
+				"lineage",
+				"archived-history-attr",
+			);
+			db.prepare(
+				`INSERT INTO entity_attributes
+				 (id, aspect_id, agent_id, kind, content, normalized_content,
+				  confidence, importance, status, group_key, claim_key,
+				  version, version_root_id, created_at, updated_at)
+				 VALUES (?, ?, ?, 'attribute', ?, ?, 0.8, 0.5, 'active', ?, ?, 1, ?, datetime('now'), datetime('now'))`,
+			).run(
+				"active-history-attr",
+				"active-history-aspect",
+				"ant",
+				"Active entity history.",
+				"active entity history.",
+				"ontology",
+				"lineage",
+				"active-history-attr",
+			);
+		});
+
+		expect(() =>
+			listClaimVersions(getDbAccessor(), {
+				agentId: "ant",
+				entity: "duplicate history",
+				aspect: "architecture",
+				group: "ontology",
+				claim: "lineage",
+			}),
+		).toThrow("ambiguous");
+		const archivedVersions = listClaimVersions(getDbAccessor(), {
+			agentId: "ant",
+			entity: "archived-history",
+			aspect: "archived-history-aspect",
+			group: "ontology",
+			claim: "lineage",
+		});
+		const activeVersions = listClaimVersions(getDbAccessor(), {
+			agentId: "ant",
+			entity: "active-history",
+			aspect: "active-history-aspect",
+			group: "ontology",
+			claim: "lineage",
+		});
+		expect(archivedVersions.items.map((item) => item.content)).toEqual(["Archived entity history."]);
+		expect(activeVersions.items.map((item) => item.content)).toEqual(["Active entity history."]);
+	});
+
 	it("rolls back an operation batch when one operation is invalid", () => {
 		expect(() =>
 			applyOntologyOperationBatch(getDbAccessor(), {

--- a/platform/daemon/src/ontology-proposals.test.ts
+++ b/platform/daemon/src/ontology-proposals.test.ts
@@ -1361,6 +1361,118 @@ describe("ontology proposals", () => {
 		expect(versions.items.map((item) => item.status)).toEqual(["active", "deleted"]);
 	});
 
+	it("preserves original claim provenance when repeated writes dedupe", () => {
+		const first = createOntologyProposal(getDbAccessor(), {
+			agentId: "ant",
+			operation: "set_claim_value",
+			payload: {
+				entity: "Dedupe Provenance",
+				entity_type: "project",
+				aspect: "architecture",
+				group_key: "ontology",
+				claim_key: "source_truth",
+				value: "The original evidence owns this row.",
+			},
+			evidence: [{ source: "transcript:first", message_ids: ["m1"] }],
+			createdBy: "first",
+		});
+		const applied = applyOntologyProposal(getDbAccessor(), {
+			agentId: "ant",
+			id: first.id,
+			actor: "operator",
+		});
+		const repeated = createOntologyProposal(getDbAccessor(), {
+			agentId: "ant",
+			operation: "set_claim_value",
+			payload: {
+				entity: "Dedupe Provenance",
+				entity_type: "project",
+				aspect: "architecture",
+				group_key: "ontology",
+				claim_key: "source_truth",
+				value: "The original evidence owns this row.",
+			},
+			evidence: [{ source: "transcript:repeat", message_ids: ["m2"] }],
+			createdBy: "repeat",
+		});
+
+		const second = applyOntologyProposal(getDbAccessor(), {
+			agentId: "ant",
+			id: repeated.id,
+			actor: "operator",
+		});
+
+		const row = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT proposal_id, proposal_evidence FROM entity_attributes WHERE id = ?")
+					.get(applied.result?.attributeId as string) as
+					| { proposal_id: string | null; proposal_evidence: string | null }
+					| undefined,
+		);
+		expect(second.result?.deduped).toBe(true);
+		expect(second.result?.attributeId).toBe(applied.result?.attributeId);
+		expect(row?.proposal_id).toBe(first.id);
+		expect(JSON.parse(row?.proposal_evidence ?? "[]")).toEqual([{ source: "transcript:first", message_ids: ["m1"] }]);
+	});
+
+	it("preserves original additive claim provenance when repeated values dedupe", () => {
+		const first = createOntologyProposal(getDbAccessor(), {
+			agentId: "ant",
+			operation: "add_claim_value",
+			payload: {
+				entity: "Additive Provenance",
+				entity_type: "project",
+				aspect: "architecture",
+				group_key: "ontology",
+				claim_key: "source_truth",
+				value: "Repeated additive values keep the first source.",
+			},
+			evidence: [{ source: "transcript:first-add", message_ids: ["m1"] }],
+			createdBy: "first",
+		});
+		const applied = applyOntologyProposal(getDbAccessor(), {
+			agentId: "ant",
+			id: first.id,
+			actor: "operator",
+		});
+		const repeated = createOntologyProposal(getDbAccessor(), {
+			agentId: "ant",
+			operation: "add_claim_value",
+			payload: {
+				entity: "Additive Provenance",
+				entity_type: "project",
+				aspect: "architecture",
+				group_key: "ontology",
+				claim_key: "source_truth",
+				value: "Repeated additive values keep the first source.",
+			},
+			evidence: [{ source: "transcript:repeat-add", message_ids: ["m2"] }],
+			createdBy: "repeat",
+		});
+
+		const second = applyOntologyProposal(getDbAccessor(), {
+			agentId: "ant",
+			id: repeated.id,
+			actor: "operator",
+		});
+
+		const row = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT proposal_id, proposal_evidence FROM entity_attributes WHERE id = ?")
+					.get(applied.result?.attributeId as string) as
+					| { proposal_id: string | null; proposal_evidence: string | null }
+					| undefined,
+		);
+		expect(second.result?.deduped).toBe(true);
+		expect(second.result?.attributeId).toBe(applied.result?.attributeId);
+		expect(row?.proposal_id).toBe(first.id);
+		expect(JSON.parse(row?.proposal_evidence ?? "[]")).toEqual([
+			{ source: "transcript:first-add", message_ids: ["m1"] },
+		]);
+	});
+
 	it("records the applying actor when pending archive proposals are applied", () => {
 		const entity = applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",

--- a/platform/daemon/src/ontology-proposals.test.ts
+++ b/platform/daemon/src/ontology-proposals.test.ts
@@ -9,11 +9,15 @@ import { extractOntologyProposals } from "./ontology-extraction";
 import { getOntologyLinkEvidence } from "./ontology-link-evidence";
 import {
 	OntologyProposalError,
+	applyOntologyOperation,
+	applyOntologyOperationBatch,
 	applyOntologyProposal,
 	createOntologyProposal,
 	createOntologyProposals,
+	getClaimVersion,
 	getOntologyProposal,
 	getOntologyProposalEvidence,
+	listClaimVersions,
 	listOntologyProposalConflicts,
 	listOntologyProposals,
 	proposeDuplicateEntityMerges,
@@ -1039,5 +1043,348 @@ describe("ontology proposals", () => {
 		const failed = getOntologyProposal(getDbAccessor(), proposal.id, "default");
 		expect(failed?.status).toBe("failed");
 		expect(failed?.result?.error).toContain("Unsupported");
+	});
+
+	it("applies direct operations by creating an applied proposal and graph mutation atomically", () => {
+		const result = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			operation: "set_claim_value",
+			payload: {
+				entity: "Signet",
+				entity_type: "project",
+				aspect: "architecture",
+				group_key: "ontology",
+				claim_key: "control_plane",
+				value: "Direct ontology operations are audited through applied proposals.",
+			},
+			reason: "operator asserted audited control plane behavior",
+			evidence: [{ source_kind: "test", quote: "audited control plane" }],
+			confidence: 0.94,
+		});
+
+		expect(result.dryRun).toBe(false);
+		expect(result.proposed).toBe(false);
+		expect(result.proposal.status).toBe("applied");
+		expect(result.proposal.appliedBy).toBe("operator");
+		expect(result.result?.version).toBe(1);
+
+		const attrs = listClaimVersions(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Signet",
+			aspect: "architecture",
+			group: "ontology",
+			claim: "control_plane",
+		});
+		expect(attrs.count).toBe(1);
+		expect(attrs.items[0]?.proposalId).toBe(result.proposal.id);
+		expect(attrs.items[0]?.content).toContain("audited");
+	});
+
+	it("dry-runs direct operations without writing proposals or graph state", () => {
+		const result = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			operation: "create_entity",
+			payload: { name: "Dry Run Entity", entity_type: "project" },
+			dryRun: true,
+		});
+
+		expect(result.dryRun).toBe(true);
+		expect(result.proposal.status).toBe("applied");
+		const proposal = getOntologyProposal(getDbAccessor(), result.proposal.id, "ant");
+		const entity = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT id FROM entities WHERE agent_id = ? AND name = ?").get("ant", "Dry Run Entity") as
+					| { id: string }
+					| undefined,
+		);
+		expect(proposal).toBeNull();
+		expect(entity).toBeNull();
+	});
+
+	it("exercises dry-run, apply, propose, reject, evidence, and immutable source artifacts end to end", () => {
+		const sourcePath = "memory/codex/transcripts/control-plane-e2e.jsonl";
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memory_artifacts
+				 (agent_id, source_path, source_sha256, source_kind, session_id,
+				  session_key, session_token, harness, captured_at, content, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			).run(
+				"ant",
+				sourcePath,
+				"sha-control-plane-e2e",
+				"transcript",
+				"session-control-plane-e2e",
+				"control-plane-e2e",
+				"token-control-plane-e2e",
+				"codex",
+				"2026-05-16T00:01:00.000Z",
+				"Raw artifact says ontology control-plane mutations are audited through proposals.",
+				"2026-05-16T00:01:00.000Z",
+			);
+		});
+		const sourceBefore = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT content FROM memory_artifacts WHERE agent_id = ? AND source_path = ?")
+					.get("ant", sourcePath) as { content: string } | undefined,
+		);
+
+		const payload = {
+			entity: "Signet",
+			entity_type: "project",
+			aspect: "architecture",
+			group_key: "ontology",
+			claim_key: "control_plane_e2e",
+			value: "Ontology control-plane mutations are audited through proposals.",
+		};
+		const dryRun = applyOntologyOperationBatch(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			dryRun: true,
+			operations: [{ operation: "set_claim_value", payload }],
+		});
+		expect(dryRun.dryRun).toBe(true);
+		expect(listOntologyProposals(getDbAccessor(), { agentId: "ant" }).items).toHaveLength(0);
+
+		const applied = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			operation: "set_claim_value",
+			payload,
+			sourceKind: "transcript",
+			sourceId: "control-plane-e2e",
+			sourcePath,
+			evidence: [{ source_kind: "memory_artifact", source_path: sourcePath, quote: "audited through proposals" }],
+		});
+		const proposed = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			operation: "create_entity",
+			payload: { name: "Rejected Candidate", entity_type: "project" },
+			propose: true,
+		});
+		const rejected = rejectOntologyProposal(getDbAccessor(), {
+			agentId: "ant",
+			id: proposed.proposal.id,
+			actor: "operator",
+			reason: "proposal review rejected this candidate",
+		});
+		const evidence = getOntologyClaimEvidence(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Signet",
+			aspect: "architecture",
+			group: "ontology",
+			claim: "control_plane_e2e",
+		});
+		const sourceAfter = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT content FROM memory_artifacts WHERE agent_id = ? AND source_path = ?")
+					.get("ant", sourcePath) as { content: string } | undefined,
+		);
+
+		expect(applied.proposal.status).toBe("applied");
+		expect(rejected.status).toBe("rejected");
+		expect(evidence.items[0]?.attribute.proposalId).toBe(applied.proposal.id);
+		expect(evidence.items[0]?.evidence.map((item) => item.kind)).toContain("memory_artifact");
+		expect(sourceAfter?.content).toBe(sourceBefore?.content);
+	});
+
+	it("proposes direct operations without mutating graph state", () => {
+		const result = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			operation: "create_entity",
+			payload: { name: "Proposed Entity", entity_type: "project" },
+			propose: true,
+		});
+
+		expect(result.proposed).toBe(true);
+		expect(result.proposal.status).toBe("pending");
+		const entity = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT id FROM entities WHERE agent_id = ? AND name = ?").get("ant", "Proposed Entity") as
+					| { id: string }
+					| undefined,
+		);
+		expect(entity).toBeNull();
+	});
+
+	it("set_claim_value creates queryable version chains and restore switches the active version", () => {
+		const payload = {
+			entity: "Signet",
+			entity_type: "project",
+			aspect: "architecture",
+			group_key: "ontology",
+			claim_key: "versioned_claim",
+		};
+		const v1 = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			operation: "set_claim_value",
+			payload: { ...payload, value: "Version one." },
+		});
+		const v2 = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			operation: "set_claim_value",
+			payload: { ...payload, value: "Version two." },
+		});
+		const v3 = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			operation: "set_claim_value",
+			payload: { ...payload, value: "Version three." },
+		});
+
+		expect(v1.result?.version).toBe(1);
+		expect(v2.result?.version).toBe(2);
+		expect(v3.result?.version).toBe(3);
+		const versions = listClaimVersions(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Signet",
+			aspect: "architecture",
+			group: "ontology",
+			claim: "versioned_claim",
+		});
+		expect(versions.items.map((item) => item.version)).toEqual([3, 2, 1]);
+		expect(versions.items.map((item) => item.status)).toEqual(["active", "superseded", "superseded"]);
+
+		const shown = getClaimVersion(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Signet",
+			aspect: "architecture",
+			group: "ontology",
+			claim: "versioned_claim",
+			version: 2,
+		});
+		expect(shown?.content).toBe("Version two.");
+
+		applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			operation: "restore_claim_version",
+			payload: { attribute_id: shown?.id },
+		});
+		const restored = listClaimVersions(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Signet",
+			aspect: "architecture",
+			group: "ontology",
+			claim: "versioned_claim",
+		});
+		expect(restored.items.find((item) => item.version === 2)?.status).toBe("active");
+		expect(restored.items.find((item) => item.version === 3)?.status).toBe("superseded");
+	});
+
+	it("archives claim values and hides them from default active reads", () => {
+		const applied = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			operation: "set_claim_value",
+			payload: {
+				entity: "Signet",
+				entity_type: "project",
+				aspect: "architecture",
+				group_key: "ontology",
+				claim_key: "archive_claim",
+				value: "Archive me.",
+			},
+		});
+		const attributeId = applied.result?.attributeId as string;
+		applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			operation: "archive_claim_value",
+			payload: { attribute_id: attributeId, reason: "obsolete" },
+		});
+
+		const active = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT COUNT(*) AS n FROM entity_attributes WHERE id = ? AND status = 'active'")
+					.get(attributeId) as { n: number },
+		);
+		const versions = listClaimVersions(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Signet",
+			aspect: "architecture",
+			group: "ontology",
+			claim: "archive_claim",
+		});
+		expect(active.n).toBe(0);
+		expect(versions.items[0]?.status).toBe("deleted");
+	});
+
+	it("rolls back an operation batch when one operation is invalid", () => {
+		expect(() =>
+			applyOntologyOperationBatch(getDbAccessor(), {
+				agentId: "ant",
+				actor: "operator",
+				operations: [
+					{ operation: "create_entity", payload: { name: "Batch Good", entity_type: "project" } },
+					{ operation: "rename_entity", payload: { selector: "Missing", new_name: "Nope" } },
+				],
+			}),
+		).toThrow(OntologyProposalError);
+		const count = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT COUNT(*) AS n FROM entities WHERE agent_id = ? AND name = ?").get("ant", "Batch Good") as {
+					n: number;
+				},
+		);
+		expect(count.n).toBe(0);
+		expect(listOntologyProposals(getDbAccessor(), { agentId: "ant" }).items).toHaveLength(0);
+	});
+
+	it("returns per-line dry-run batch validation errors without writing", () => {
+		const result = applyOntologyOperationBatch(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			dryRun: true,
+			operations: [
+				{ operation: "create_entity", payload: { name: "Batch Preview", entity_type: "project" } },
+				{ operation: "rename_entity", payload: { selector: "Missing", new_name: "Nope" } },
+			],
+		});
+		const count = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT COUNT(*) AS n FROM entities WHERE agent_id = ? AND name = ?")
+					.get("ant", "Batch Preview") as {
+					n: number;
+				},
+		);
+
+		expect(result.dryRun).toBe(true);
+		expect(result.items).toHaveLength(1);
+		expect(result.errors).toEqual([
+			{
+				index: 1,
+				line: 2,
+				operation: "rename_entity",
+				error: "Entity not found: Missing",
+				status: 404,
+			},
+		]);
+		expect(count.n).toBe(0);
+		expect(listOntologyProposals(getDbAccessor(), { agentId: "ant" }).items).toHaveLength(0);
+	});
+
+	it("rejects ambiguous same-agent entity selectors", () => {
+		insertEntity("one", "Signet A", "signet", "ant", 1);
+		insertEntity("two", "Signet B", "signet", "ant", 2);
+
+		expect(() =>
+			applyOntologyOperation(getDbAccessor(), {
+				agentId: "ant",
+				actor: "operator",
+				operation: "rename_entity",
+				payload: { selector: "signet", new_name: "Signet" },
+			}),
+		).toThrow("ambiguous");
 	});
 });

--- a/platform/daemon/src/ontology-proposals.test.ts
+++ b/platform/daemon/src/ontology-proposals.test.ts
@@ -1319,6 +1319,46 @@ describe("ontology proposals", () => {
 		expect(versions.items[0]?.status).toBe("deleted");
 	});
 
+	it("keeps claim version history readable after archiving its parent entity", () => {
+		applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			operation: "set_claim_value",
+			payload: {
+				entity: "Signet",
+				entity_type: "project",
+				aspect: "architecture",
+				group_key: "ontology",
+				claim_key: "archived_parent_history",
+				value: "History survives entity archival.",
+			},
+		});
+		applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			operation: "archive_entity",
+			payload: { selector: "Signet", reason: "retired" },
+		});
+
+		const versions = listClaimVersions(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Signet",
+			aspect: "architecture",
+			group: "ontology",
+			claim: "archived_parent_history",
+		});
+		const version = getClaimVersion(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Signet",
+			aspect: "architecture",
+			group: "ontology",
+			claim: "archived_parent_history",
+			version: 1,
+		});
+		expect(versions.count).toBe(1);
+		expect(version?.content).toBe("History survives entity archival.");
+	});
+
 	it("rolls back an operation batch when one operation is invalid", () => {
 		expect(() =>
 			applyOntologyOperationBatch(getDbAccessor(), {

--- a/platform/daemon/src/ontology-proposals.test.ts
+++ b/platform/daemon/src/ontology-proposals.test.ts
@@ -1319,6 +1319,48 @@ describe("ontology proposals", () => {
 		expect(versions.items[0]?.status).toBe("deleted");
 	});
 
+	it("continues claim version chains after the active value is archived", () => {
+		const payload = {
+			entity: "Archive Version Chain",
+			entity_type: "project",
+			aspect: "architecture",
+			group_key: "ontology",
+			claim_key: "archived_chain",
+		};
+		const first = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			operation: "set_claim_value",
+			payload: { ...payload, value: "Archived first version." },
+		});
+		applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			operation: "archive_claim_value",
+			payload: { attribute_id: first.result?.attributeId, reason: "retired" },
+		});
+		const second = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			operation: "set_claim_value",
+			payload: { ...payload, value: "Replacement after archive." },
+		});
+
+		const versions = listClaimVersions(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Archive Version Chain",
+			aspect: "architecture",
+			group: "ontology",
+			claim: "archived_chain",
+		});
+
+		expect(second.result?.version).toBe(2);
+		expect(second.result?.versionRootId).toBe(first.result?.versionRootId);
+		expect(second.result?.previousAttributeId).toBe(first.result?.attributeId);
+		expect(versions.items.map((item) => item.version)).toEqual([2, 1]);
+		expect(versions.items.map((item) => item.status)).toEqual(["active", "deleted"]);
+	});
+
 	it("records the applying actor when pending archive proposals are applied", () => {
 		const entity = applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",

--- a/platform/daemon/src/ontology-proposals.test.ts
+++ b/platform/daemon/src/ontology-proposals.test.ts
@@ -1319,6 +1319,236 @@ describe("ontology proposals", () => {
 		expect(versions.items[0]?.status).toBe("deleted");
 	});
 
+	it("records the applying actor when pending archive proposals are applied", () => {
+		const entity = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "creator",
+			operation: "create_entity",
+			payload: { name: "Archive Actor Entity", entity_type: "project" },
+		});
+		const claim = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "creator",
+			operation: "set_claim_value",
+			payload: {
+				entity: "Archive Actor Claim",
+				entity_type: "project",
+				aspect: "audit",
+				group_key: "ontology",
+				claim_key: "actor",
+				value: "Archive me.",
+			},
+		});
+		const link = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "creator",
+			operation: "create_link",
+			payload: {
+				source_entity: "Archive Actor Source",
+				source_type: "project",
+				link_type: "related_to",
+				target_entity: "Archive Actor Target",
+				target_type: "project",
+				reason: "Audit actor fixture.",
+			},
+		});
+		applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "creator",
+			operation: "set_claim_value",
+			payload: {
+				entity: "Archive Actor Aspect",
+				entity_type: "project",
+				aspect: "retire_me",
+				group_key: "ontology",
+				claim_key: "actor",
+				value: "Archive my aspect.",
+			},
+		});
+
+		const proposals = createOntologyProposals(getDbAccessor(), [
+			{
+				agentId: "ant",
+				operation: "archive_entity",
+				payload: { selector: entity.result?.entityId },
+				createdBy: "creator",
+			},
+			{
+				agentId: "ant",
+				operation: "archive_claim_value",
+				payload: { attribute_id: claim.result?.attributeId },
+				createdBy: "creator",
+			},
+			{
+				agentId: "ant",
+				operation: "archive_link",
+				payload: { id: link.result?.dependencyId },
+				createdBy: "creator",
+			},
+			{
+				agentId: "ant",
+				operation: "archive_aspect",
+				payload: { entity: "Archive Actor Aspect", selector: "retire_me" },
+				createdBy: "creator",
+			},
+		]);
+
+		for (const proposal of proposals.items) {
+			applyOntologyProposal(getDbAccessor(), {
+				agentId: "ant",
+				id: proposal.id,
+				actor: "reviewer",
+			});
+		}
+
+		const row = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare(
+						`SELECT
+						 (SELECT archived_by FROM entities WHERE id = ?) AS entity_actor,
+						 (SELECT archived_by FROM entity_attributes WHERE id = ?) AS claim_actor,
+						 (SELECT archived_by FROM entity_dependencies WHERE id = ?) AS link_actor,
+						 (SELECT asp.archived_by
+						    FROM entity_aspects asp
+						    JOIN entities ent ON ent.id = asp.entity_id
+						   WHERE ent.agent_id = ? AND ent.name = ? AND asp.name = ?) AS aspect_actor,
+						 (SELECT attr.archived_by
+						    FROM entity_attributes attr
+						    JOIN entity_aspects asp ON asp.id = attr.aspect_id
+						    JOIN entities ent ON ent.id = asp.entity_id
+						   WHERE ent.agent_id = ? AND ent.name = ? AND asp.name = ?) AS aspect_attr_actor`,
+					)
+					.get(
+						entity.result?.entityId as string,
+						claim.result?.attributeId as string,
+						link.result?.dependencyId as string,
+						"ant",
+						"Archive Actor Aspect",
+						"retire_me",
+						"ant",
+						"Archive Actor Aspect",
+						"retire_me",
+					) as {
+					entity_actor: string | null;
+					claim_actor: string | null;
+					link_actor: string | null;
+					aspect_actor: string | null;
+					aspect_attr_actor: string | null;
+				},
+		);
+		expect(row).toEqual({
+			entity_actor: "reviewer",
+			claim_actor: "reviewer",
+			link_actor: "reviewer",
+			aspect_actor: "reviewer",
+			aspect_attr_actor: "reviewer",
+		});
+	});
+
+	it("reactivates archived aspects when creating claims for the same aspect slot", () => {
+		applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			operation: "set_claim_value",
+			payload: {
+				entity: "Aspect Restore",
+				entity_type: "project",
+				aspect: "architecture",
+				group_key: "ontology",
+				claim_key: "old_claim",
+				value: "Before archive.",
+			},
+		});
+		applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			operation: "archive_aspect",
+			payload: { entity: "Aspect Restore", selector: "architecture", reason: "retired" },
+		});
+		const recreated = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			operation: "set_claim_value",
+			payload: {
+				entity: "Aspect Restore",
+				entity_type: "project",
+				aspect: "architecture",
+				group_key: "ontology",
+				claim_key: "new_claim",
+				value: "After archive.",
+			},
+		});
+
+		const row = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare(
+						`SELECT asp.status AS aspect_status, asp.archived_by, attr.status AS claim_status
+						 FROM entity_aspects asp
+						 JOIN entity_attributes attr ON attr.aspect_id = asp.id
+						 WHERE asp.id = ? AND attr.id = ?`,
+					)
+					.get(recreated.result?.aspectId as string, recreated.result?.attributeId as string) as
+					| { aspect_status: string; archived_by: string | null; claim_status: string }
+					| undefined,
+		);
+		expect(row?.aspect_status).toBe("active");
+		expect(row?.archived_by).toBeNull();
+		expect(row?.claim_status).toBe("active");
+	});
+
+	it("reactivates archived links when creating the same link again", () => {
+		const created = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			operation: "create_link",
+			payload: {
+				source_entity: "Archived Link Source",
+				source_type: "project",
+				link_type: "related_to",
+				target_entity: "Archived Link Target",
+				target_type: "project",
+				reason: "Initial relationship.",
+			},
+		});
+		applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			operation: "archive_link",
+			payload: { id: created.result?.dependencyId, reason: "retired" },
+		});
+		const recreated = applyOntologyOperation(getDbAccessor(), {
+			agentId: "ant",
+			actor: "operator",
+			operation: "create_link",
+			payload: {
+				source_entity: "Archived Link Source",
+				source_type: "project",
+				link_type: "related_to",
+				target_entity: "Archived Link Target",
+				target_type: "project",
+				reason: "Restored relationship.",
+				strength: 0.9,
+			},
+		});
+
+		const row = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT status, archived_by, reason, strength FROM entity_dependencies WHERE id = ?")
+					.get(created.result?.dependencyId as string) as
+					| { status: string; archived_by: string | null; reason: string; strength: number }
+					| undefined,
+		);
+		expect(recreated.result?.dependencyId).toBe(created.result?.dependencyId);
+		expect(recreated.result?.reactivated).toBe(true);
+		expect(row?.status).toBe("active");
+		expect(row?.archived_by).toBeNull();
+		expect(row?.reason).toBe("Restored relationship.");
+		expect(row?.strength).toBeCloseTo(0.9);
+	});
+
 	it("keeps claim version history readable after archiving its parent entity", () => {
 		applyOntologyOperation(getDbAccessor(), {
 			agentId: "ant",

--- a/platform/daemon/src/ontology-proposals.ts
+++ b/platform/daemon/src/ontology-proposals.ts
@@ -1512,36 +1512,60 @@ export function listClaimVersions(
 	const kind = params.kind ?? "attribute";
 	return accessor.withReadDb((db) => {
 		const entityKey = canonical(params.entity);
+		const exactEntity = db
+			.prepare("SELECT id FROM entities WHERE agent_id = ? AND id = ? LIMIT 1")
+			.get(params.agentId, params.entity) as { id: string } | undefined;
+		const entity =
+			exactEntity ??
+			(() => {
+				const rows = db
+					.prepare(
+						`SELECT id FROM entities
+						 WHERE agent_id = ?
+						   AND (COALESCE(canonical_name, LOWER(name)) = ? OR LOWER(name) = ?)
+						 ORDER BY updated_at DESC, name ASC`,
+					)
+					.all(params.agentId, entityKey, entityKey) as Array<{ id: string }>;
+				if (rows.length === 0) throw new OntologyProposalError(`Entity not found: ${params.entity}`, 404);
+				if (rows.length > 1) {
+					throw new OntologyProposalError(`Entity selector is ambiguous: ${params.entity}. Use an id.`, 409);
+				}
+				return rows[0] as { id: string };
+			})();
 		const aspectKey = canonical(params.aspect);
+		const exactAspect = db
+			.prepare("SELECT id FROM entity_aspects WHERE entity_id = ? AND agent_id = ? AND id = ? LIMIT 1")
+			.get(entity.id, params.agentId, params.aspect) as { id: string } | undefined;
+		const aspect =
+			exactAspect ??
+			(() => {
+				const rows = db
+					.prepare(
+						`SELECT id FROM entity_aspects
+						 WHERE entity_id = ?
+						   AND agent_id = ?
+						   AND (canonical_name = ? OR LOWER(name) = ?)
+						 ORDER BY updated_at DESC, name ASC`,
+					)
+					.all(entity.id, params.agentId, aspectKey, aspectKey) as Array<{ id: string }>;
+				if (rows.length === 0) throw new OntologyProposalError(`Aspect not found: ${params.aspect}`, 404);
+				if (rows.length > 1) {
+					throw new OntologyProposalError(`Aspect selector is ambiguous: ${params.aspect}. Use an id.`, 409);
+				}
+				return rows[0] as { id: string };
+			})();
 		const rows = db
 			.prepare(
 				`SELECT attr.*
 				 FROM entity_attributes attr
-				 JOIN entity_aspects asp ON asp.id = attr.aspect_id
-				 JOIN entities ent ON ent.id = asp.entity_id
-				 WHERE ent.agent_id = ?
-				   AND asp.agent_id = ?
-				   AND attr.agent_id = ?
-				   AND (ent.id = ? OR COALESCE(ent.canonical_name, LOWER(ent.name)) = ? OR LOWER(ent.name) = ?)
-				   AND (asp.canonical_name = ? OR LOWER(asp.name) = ?)
+				 WHERE attr.agent_id = ?
+				   AND attr.aspect_id = ?
 				   AND COALESCE(attr.group_key, 'general') = ?
 				   AND attr.claim_key = ?
 				   AND attr.kind = ?
 				 ORDER BY attr.version DESC, attr.updated_at DESC`,
 			)
-			.all(
-				params.agentId,
-				params.agentId,
-				params.agentId,
-				params.entity,
-				entityKey,
-				entityKey,
-				aspectKey,
-				aspectKey,
-				groupKey,
-				claimKey,
-				kind,
-			) as Array<Record<string, unknown>>;
+			.all(params.agentId, aspect.id, groupKey, claimKey, kind) as Array<Record<string, unknown>>;
 		const items = rows.map(claimVersionRow);
 		return { items, count: items.length };
 	});

--- a/platform/daemon/src/ontology-proposals.ts
+++ b/platform/daemon/src/ontology-proposals.ts
@@ -1512,8 +1512,6 @@ export function listClaimVersions(
 				 WHERE ent.agent_id = ?
 				   AND asp.agent_id = ?
 				   AND attr.agent_id = ?
-				   AND COALESCE(ent.status, 'active') = 'active'
-				   AND COALESCE(asp.status, 'active') = 'active'
 				   AND (ent.id = ? OR COALESCE(ent.canonical_name, LOWER(ent.name)) = ? OR LOWER(ent.name) = ?)
 				   AND (asp.canonical_name = ? OR LOWER(asp.name) = ?)
 				   AND COALESCE(attr.group_key, 'general') = ?

--- a/platform/daemon/src/ontology-proposals.ts
+++ b/platform/daemon/src/ontology-proposals.ts
@@ -519,12 +519,22 @@ function resolveOrCreateAspect(db: WriteDb, entityId: string, agentId: string, n
 	const key = canonical(name);
 	const existing = db
 		.prepare(
-			`SELECT id FROM entity_aspects
+			`SELECT id, status FROM entity_aspects
 			 WHERE entity_id = ? AND agent_id = ? AND canonical_name = ?
 			 LIMIT 1`,
 		)
-		.get(entityId, agentId, key) as { id: string } | undefined;
-	if (existing) return existing.id;
+		.get(entityId, agentId, key) as { id: string; status: string | null } | undefined;
+	if (existing) {
+		if ((existing.status ?? "active") !== "active") {
+			db.prepare(
+				`UPDATE entity_aspects
+				 SET status = 'active', archived_at = NULL, archived_by = NULL,
+				     archive_reason = NULL, updated_at = datetime('now')
+				 WHERE id = ? AND agent_id = ?`,
+			).run(existing.id, agentId);
+		}
+		return existing.id;
+	}
 
 	const id = crypto.randomUUID();
 	db.prepare(
@@ -878,6 +888,7 @@ function applyArchiveEntity(
 	agentId: string,
 	proposal: ProposalRow,
 	payload: Readonly<Record<string, unknown>>,
+	actor: string,
 ): Readonly<Record<string, unknown>> {
 	const selector = readPayloadSelector(payload, "selector", "entity", "entity_id", "name");
 	if (selector === null) throw new OntologyProposalError("payload.selector is required", 400);
@@ -894,7 +905,7 @@ function applyArchiveEntity(
 		     archive_reason = ?, proposal_id = ?, proposal_evidence = ?, updated_at = datetime('now')
 		 WHERE id = ? AND agent_id = ?`,
 	).run(
-		proposal.applied_by ?? proposal.created_by,
+		actor,
 		readString(payload, "reason") ?? proposal.rationale,
 		proposal.id,
 		JSON.stringify(proposalAuditEvidence(proposal)),
@@ -962,6 +973,7 @@ function applyArchiveAspect(
 	agentId: string,
 	proposal: ProposalRow,
 	payload: Readonly<Record<string, unknown>>,
+	actor: string,
 ): Readonly<Record<string, unknown>> {
 	const entitySelector = readPayloadSelector(payload, "entity", "entity_id");
 	const aspectSelector = readPayloadSelector(payload, "selector", "aspect", "aspect_id", "name");
@@ -975,7 +987,7 @@ function applyArchiveAspect(
 		     archive_reason = ?, proposal_id = ?, proposal_evidence = ?, updated_at = datetime('now')
 		 WHERE id = ? AND agent_id = ?`,
 	).run(
-		proposal.applied_by ?? proposal.created_by,
+		actor,
 		readString(payload, "reason") ?? proposal.rationale,
 		proposal.id,
 		JSON.stringify(proposalAuditEvidence(proposal)),
@@ -987,12 +999,7 @@ function applyArchiveAspect(
 		 SET status = 'deleted', archived_at = datetime('now'), archived_by = ?,
 		     archive_reason = ?, updated_at = datetime('now')
 		 WHERE aspect_id = ? AND agent_id = ? AND status = 'active'`,
-	).run(
-		proposal.applied_by ?? proposal.created_by,
-		readString(payload, "reason") ?? proposal.rationale,
-		aspect.id,
-		agentId,
-	);
+	).run(actor, readString(payload, "reason") ?? proposal.rationale, aspect.id, agentId);
 	return { entityId: entity.id, aspectId: aspect.id, archived: true };
 }
 
@@ -1001,6 +1008,7 @@ function applyArchiveClaimValue(
 	agentId: string,
 	proposal: ProposalRow,
 	payload: Readonly<Record<string, unknown>>,
+	actor: string,
 ): Readonly<Record<string, unknown>> {
 	const attributeId = readString(payload, "attribute_id");
 	if (attributeId === null) throw new OntologyProposalError("payload.attribute_id is required", 400);
@@ -1017,7 +1025,7 @@ function applyArchiveClaimValue(
 		     archive_reason = ?, proposal_id = ?, proposal_evidence = ?, updated_at = datetime('now')
 		 WHERE id = ? AND agent_id = ?`,
 	).run(
-		proposal.applied_by ?? proposal.created_by,
+		actor,
 		readString(payload, "reason") ?? proposal.rationale,
 		proposal.id,
 		JSON.stringify(proposalAuditEvidence(proposal)),
@@ -1179,16 +1187,18 @@ function applyCreateLink(
 
 	const existing = db
 		.prepare(
-			`SELECT id FROM entity_dependencies
+			`SELECT id, status FROM entity_dependencies
 			 WHERE source_entity_id = ? AND target_entity_id = ?
 			   AND dependency_type = ? AND agent_id = ?
 			 LIMIT 1`,
 		)
-		.get(sourceId, targetId, dependencyType, agentId) as { id: string } | undefined;
+		.get(sourceId, targetId, dependencyType, agentId) as { id: string; status: string | null } | undefined;
 	if (existing) {
 		db.prepare(
 			`UPDATE entity_dependencies
-			 SET strength = ?, confidence = ?, reason = ?, updated_at = datetime('now'),
+			 SET status = 'active', archived_at = NULL, archived_by = NULL,
+			     archive_reason = NULL, strength = ?, confidence = ?, reason = ?,
+			     updated_at = datetime('now'),
 			     source_id = ?, source_kind = ?, source_path = ?, source_root = ?,
 			     proposal_id = ?, proposal_evidence = ?
 			 WHERE id = ? AND agent_id = ?`,
@@ -1205,7 +1215,13 @@ function applyCreateLink(
 			existing.id,
 			agentId,
 		);
-		return { dependencyId: existing.id, sourceId, targetId, updated: true };
+		return {
+			dependencyId: existing.id,
+			sourceId,
+			targetId,
+			updated: true,
+			reactivated: (existing.status ?? "active") !== "active",
+		};
 	}
 
 	const id = crypto.randomUUID();
@@ -1290,6 +1306,7 @@ function applyArchiveLink(
 	agentId: string,
 	proposal: ProposalRow,
 	payload: Readonly<Record<string, unknown>>,
+	actor: string,
 ): Readonly<Record<string, unknown>> {
 	const id = readString(payload, "id") ?? readString(payload, "dependency_id") ?? readString(payload, "link_id");
 	if (id === null) throw new OntologyProposalError("payload.id is required", 400);
@@ -1303,7 +1320,7 @@ function applyArchiveLink(
 		     archive_reason = ?, proposal_id = ?, proposal_evidence = ?, updated_at = datetime('now')
 		 WHERE id = ? AND agent_id = ?`,
 	).run(
-		proposal.applied_by ?? proposal.created_by,
+		actor,
 		readString(payload, "reason") ?? proposal.rationale,
 		proposal.id,
 		JSON.stringify(proposalAuditEvidence(proposal)),
@@ -1313,14 +1330,16 @@ function applyArchiveLink(
 	return { dependencyId: id, archived: true };
 }
 
-function applyOperation(db: WriteDb, proposal: ProposalRow): Readonly<Record<string, unknown>> {
+function applyOperation(db: WriteDb, proposal: ProposalRow, actor: string): Readonly<Record<string, unknown>> {
 	const payload = parseJsonRecord(proposal.payload);
 	if (proposal.operation === "create_entity") return applyCreateEntity(db, proposal.agent_id, proposal, payload);
 	if (proposal.operation === "rename_entity") return applyRenameEntity(db, proposal.agent_id, proposal, payload);
-	if (proposal.operation === "archive_entity") return applyArchiveEntity(db, proposal.agent_id, proposal, payload);
+	if (proposal.operation === "archive_entity")
+		return applyArchiveEntity(db, proposal.agent_id, proposal, payload, actor);
 	if (proposal.operation === "create_aspect") return applyCreateAspect(db, proposal.agent_id, proposal, payload);
 	if (proposal.operation === "rename_aspect") return applyRenameAspect(db, proposal.agent_id, proposal, payload);
-	if (proposal.operation === "archive_aspect") return applyArchiveAspect(db, proposal.agent_id, proposal, payload);
+	if (proposal.operation === "archive_aspect")
+		return applyArchiveAspect(db, proposal.agent_id, proposal, payload, actor);
 	if (proposal.operation === "add_claim_value") return applyAddClaimValue(db, proposal.agent_id, proposal, payload);
 	if (proposal.operation === "set_claim_value") return applySetClaimValue(db, proposal.agent_id, proposal, payload);
 	if (proposal.operation === "merge_entities") return applyMergeEntities(db, proposal.agent_id, payload);
@@ -1328,13 +1347,13 @@ function applyOperation(db: WriteDb, proposal: ProposalRow): Readonly<Record<str
 		return applySupersedeClaimValue(db, proposal.agent_id, proposal, payload);
 	}
 	if (proposal.operation === "archive_claim_value")
-		return applyArchiveClaimValue(db, proposal.agent_id, proposal, payload);
+		return applyArchiveClaimValue(db, proposal.agent_id, proposal, payload, actor);
 	if (proposal.operation === "restore_claim_version") {
 		return applyRestoreClaimVersion(db, proposal.agent_id, proposal, payload);
 	}
 	if (proposal.operation === "create_link") return applyCreateLink(db, proposal.agent_id, proposal, payload);
 	if (proposal.operation === "update_link") return applyUpdateLink(db, proposal.agent_id, proposal, payload);
-	if (proposal.operation === "archive_link") return applyArchiveLink(db, proposal.agent_id, proposal, payload);
+	if (proposal.operation === "archive_link") return applyArchiveLink(db, proposal.agent_id, proposal, payload, actor);
 	throw new OntologyProposalError(`Unsupported ontology proposal operation: ${proposal.operation}`, 400);
 }
 
@@ -1712,7 +1731,7 @@ export function applyOntologyProposal(accessor: DbAccessor, params: ApplyOntolog
 				throw new OntologyProposalError(`Proposal is ${proposal.status}, not pending`, 409);
 			}
 
-			const result = applyOperation(db, proposal);
+			const result = applyOperation(db, proposal, params.actor);
 			const ts = now();
 			db.prepare(
 				`UPDATE ontology_proposals
@@ -1789,7 +1808,7 @@ export function applyOntologyOperation(
 			const inserted = insertProposalInTx(db, operationToProposalInput(params), now());
 			const row = getProposalInTx(db, inserted.id, params.agentId);
 			if (row === null) throw new OntologyProposalError("Proposal not found", 404);
-			const operationResult = applyOperation(db, row);
+			const operationResult = applyOperation(db, row, params.actor);
 			const proposal = markAppliedInTx(db, row, params.actor, operationResult);
 			const item = { proposal, result: operationResult, dryRun: params.dryRun === true, proposed: false };
 			if (params.dryRun) {
@@ -1869,7 +1888,7 @@ export function applyOntologyOperationBatch(
 					);
 					const row = getProposalInTx(db, inserted.id, params.agentId);
 					if (row === null) throw new OntologyProposalError("Proposal not found", 404);
-					const operationResult = applyOperation(db, row);
+					const operationResult = applyOperation(db, row, params.actor);
 					const proposal = markAppliedInTx(db, row, params.actor, operationResult);
 					items.push({ proposal, result: operationResult, dryRun: params.dryRun === true, proposed: false });
 				} catch (err) {

--- a/platform/daemon/src/ontology-proposals.ts
+++ b/platform/daemon/src/ontology-proposals.ts
@@ -608,11 +608,6 @@ function applyAddClaimValue(
 		)
 		.get(aspectId, agentId, kind, normalized, groupKey, claimKey) as { id: string } | undefined;
 	if (existing) {
-		db.prepare(
-			`UPDATE entity_attributes
-			 SET proposal_id = ?, proposal_evidence = ?, updated_at = datetime('now')
-			 WHERE id = ? AND agent_id = ?`,
-		).run(proposal.id, JSON.stringify(proposalAuditEvidence(proposal)), existing.id, agentId);
 		return { entityId, aspectId, attributeId: existing.id, deduped: true };
 	}
 
@@ -695,11 +690,6 @@ function applySetClaimValue(
 	const normalized = canonical(value);
 	const existing = active.find((row) => row.normalized_content === normalized);
 	if (existing && active.length === 1) {
-		db.prepare(
-			`UPDATE entity_attributes
-			 SET proposal_id = ?, proposal_evidence = ?, updated_at = datetime('now')
-			 WHERE id = ? AND agent_id = ?`,
-		).run(proposal.id, JSON.stringify(proposalAuditEvidence(proposal)), existing.id, agentId);
 		return {
 			entityId,
 			aspectId,

--- a/platform/daemon/src/ontology-proposals.ts
+++ b/platform/daemon/src/ontology-proposals.ts
@@ -149,6 +149,82 @@ export interface ProposeDuplicateEntityMergesParams {
 	readonly createdBy?: string;
 }
 
+export interface OntologyOperationInput {
+	readonly operation: string;
+	readonly payload: Readonly<Record<string, unknown>>;
+	readonly reason?: string;
+	readonly evidence?: readonly unknown[];
+	readonly confidence?: number;
+	readonly risk?: string | null;
+	readonly sourceKind?: string | null;
+	readonly sourceId?: string | null;
+	readonly sourcePath?: string | null;
+	readonly sourceRoot?: string | null;
+}
+
+export interface ApplyOntologyOperationParams extends OntologyOperationInput {
+	readonly agentId: string;
+	readonly actor: string;
+	readonly dryRun?: boolean;
+	readonly propose?: boolean;
+}
+
+export interface ApplyOntologyOperationResult {
+	readonly proposal: OntologyProposal;
+	readonly result: Readonly<Record<string, unknown>> | null;
+	readonly dryRun: boolean;
+	readonly proposed: boolean;
+}
+
+export interface ApplyOntologyOperationBatchParams {
+	readonly agentId: string;
+	readonly actor: string;
+	readonly operations: readonly OntologyOperationInput[];
+	readonly dryRun?: boolean;
+	readonly propose?: boolean;
+}
+
+export interface ApplyOntologyOperationBatchResult {
+	readonly items: readonly ApplyOntologyOperationResult[];
+	readonly errors?: readonly OntologyOperationBatchError[];
+	readonly count: number;
+	readonly dryRun: boolean;
+	readonly proposed: boolean;
+}
+
+export interface OntologyOperationBatchError {
+	readonly index: number;
+	readonly line: number;
+	readonly operation: string;
+	readonly error: string;
+	readonly status: 400 | 404 | 409;
+}
+
+export interface ClaimVersionReadParams {
+	readonly agentId: string;
+	readonly entity: string;
+	readonly aspect: string;
+	readonly group: string;
+	readonly claim: string;
+	readonly kind?: AttributeKind;
+}
+
+export interface ClaimVersionItem {
+	readonly id: string;
+	readonly version: number;
+	readonly versionRootId: string;
+	readonly previousAttributeId: string | null;
+	readonly content: string;
+	readonly status: string;
+	readonly confidence: number;
+	readonly proposalId: string | null;
+	readonly sourceKind: string | null;
+	readonly sourceId: string | null;
+	readonly sourcePath: string | null;
+	readonly createdAt: string;
+	readonly updatedAt: string;
+}
+
 export class OntologyProposalError extends Error {
 	constructor(
 		message: string,
@@ -351,17 +427,80 @@ function proposalAuditEvidence(proposal: ProposalRow): readonly unknown[] {
 	return parseJsonArray(proposal.evidence);
 }
 
+function canonicalKey(value: string | null): string | null {
+	if (value === null) return null;
+	const key = canonical(value).replace(/\s+/g, "_");
+	return key.length > 0 ? key : null;
+}
+
+function truthy(value: unknown): boolean {
+	return value === true || value === 1 || value === "1" || value === "true";
+}
+
+function readPayloadSelector(payload: Readonly<Record<string, unknown>>, ...keys: readonly string[]): string | null {
+	for (const key of keys) {
+		const value = readString(payload, key);
+		if (value !== null) return value;
+	}
+	return null;
+}
+
+function resolveEntityStrict(
+	db: WriteDb,
+	agentId: string,
+	selector: string,
+): { readonly id: string; readonly name: string } {
+	const key = canonical(selector);
+	const rows = db
+		.prepare(
+			`SELECT id, name FROM entities
+			 WHERE agent_id = ?
+			   AND COALESCE(status, 'active') = 'active'
+			   AND (id = ? OR COALESCE(canonical_name, LOWER(name)) = ? OR LOWER(name) = ?)
+			 ORDER BY CASE WHEN id = ? THEN 0 ELSE 1 END, updated_at DESC, name ASC`,
+		)
+		.all(agentId, selector, key, key, selector) as Array<{ id: string; name: string }>;
+	if (rows.length === 0) throw new OntologyProposalError(`Entity not found: ${selector}`, 404);
+	if (rows.length > 1) throw new OntologyProposalError(`Entity selector is ambiguous: ${selector}. Use an id.`, 409);
+	return rows[0] as { id: string; name: string };
+}
+
+function resolveAspectStrict(
+	db: WriteDb,
+	agentId: string,
+	entityId: string,
+	selector: string,
+): { readonly id: string; readonly name: string } {
+	const key = canonical(selector);
+	const rows = db
+		.prepare(
+			`SELECT id, name FROM entity_aspects
+			 WHERE entity_id = ?
+			   AND agent_id = ?
+			   AND COALESCE(status, 'active') = 'active'
+			   AND (id = ? OR canonical_name = ? OR LOWER(name) = ?)
+			 ORDER BY CASE WHEN id = ? THEN 0 ELSE 1 END, updated_at DESC, name ASC`,
+		)
+		.all(entityId, agentId, selector, key, key, selector) as Array<{ id: string; name: string }>;
+	if (rows.length === 0) throw new OntologyProposalError(`Aspect not found: ${selector}`, 404);
+	if (rows.length > 1) throw new OntologyProposalError(`Aspect selector is ambiguous: ${selector}. Use an id.`, 409);
+	return rows[0] as { id: string; name: string };
+}
+
 function resolveEntity(db: WriteDb, agentId: string, name: string): string | null {
 	const key = canonical(name);
 	const row = db
 		.prepare(
 			`SELECT id FROM entities
 			 WHERE agent_id = ?
+			   AND COALESCE(status, 'active') = 'active'
 			   AND (COALESCE(canonical_name, LOWER(name)) = ? OR LOWER(name) = ?)
-			 LIMIT 1`,
+			 ORDER BY updated_at DESC, name ASC
+			 LIMIT 2`,
 		)
-		.get(agentId, key, key) as { id: string } | undefined;
-	return row?.id ?? null;
+		.all(agentId, key, key) as Array<{ id: string }>;
+	if (row.length > 1) throw new OntologyProposalError(`Entity selector is ambiguous: ${name}. Use an id.`, 409);
+	return row[0]?.id ?? null;
 }
 
 function resolveOrCreateEntity(db: WriteDb, agentId: string, name: string, type: EntityType): string {
@@ -411,11 +550,17 @@ function resolveAspect(db: WriteDb, entityId: string, agentId: string, name: str
 function applyCreateEntity(
 	db: WriteDb,
 	agentId: string,
+	proposal: ProposalRow,
 	payload: Readonly<Record<string, unknown>>,
 ): Readonly<Record<string, unknown>> {
 	const name = readString(payload, "name");
 	if (name === null) throw new OntologyProposalError("payload.name is required", 400);
 	const entityId = resolveOrCreateEntity(db, agentId, name, normalizeEntityType(readString(payload, "entity_type")));
+	db.prepare(
+		`UPDATE entities
+		 SET proposal_id = ?, proposal_evidence = ?, updated_at = datetime('now')
+		 WHERE id = ? AND agent_id = ?`,
+	).run(proposal.id, JSON.stringify(proposalAuditEvidence(proposal)), entityId, agentId);
 	return { entityId, entity: name };
 }
 
@@ -469,9 +614,11 @@ function applyAddClaimValue(
 		`INSERT INTO entity_attributes
 		 (id, aspect_id, agent_id, kind, content, normalized_content,
 		  confidence, importance, status, group_key, claim_key,
+		  version, version_root_id, previous_attribute_id,
 		  created_at, updated_at, source_id, source_kind, source_path, source_root,
 		  proposal_id, proposal_evidence)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?,
+		         1, ?, NULL,
 		         datetime('now'), datetime('now'), ?, ?, ?, ?, ?, ?)`,
 	).run(
 		id,
@@ -484,6 +631,7 @@ function applyAddClaimValue(
 		importance,
 		groupKey,
 		claimKey,
+		id,
 		proposal.source_id,
 		proposal.source_kind,
 		proposal.source_path,
@@ -492,6 +640,127 @@ function applyAddClaimValue(
 		JSON.stringify(proposalEvidence),
 	);
 	return { entityId, aspectId, attributeId: id, deduped: false };
+}
+
+function applySetClaimValue(
+	db: WriteDb,
+	agentId: string,
+	proposal: ProposalRow,
+	payload: Readonly<Record<string, unknown>>,
+): Readonly<Record<string, unknown>> {
+	const entity = readString(payload, "entity");
+	const aspect = readString(payload, "aspect");
+	const claimKey = canonicalKey(readString(payload, "claim_key") ?? readString(payload, "claim"));
+	const value = readString(payload, "value");
+	if (entity === null) throw new OntologyProposalError("payload.entity is required", 400);
+	if (aspect === null) throw new OntologyProposalError("payload.aspect is required", 400);
+	if (claimKey === null) throw new OntologyProposalError("payload.claim_key is required", 400);
+	if (value === null) throw new OntologyProposalError("payload.value is required", 400);
+
+	const entityId = resolveOrCreateEntity(db, agentId, entity, normalizeEntityType(readString(payload, "entity_type")));
+	const aspectId = resolveOrCreateAspect(db, entityId, agentId, aspect);
+	const groupKey = canonicalKey(readString(payload, "group_key") ?? readString(payload, "group")) ?? "general";
+	const kind = normalizeAttributeKind(readString(payload, "kind"));
+	const active = db
+		.prepare(
+			`SELECT id, content, normalized_content, version, version_root_id, kind
+			 FROM entity_attributes
+			 WHERE aspect_id = ?
+			   AND agent_id = ?
+			   AND kind = ?
+			   AND COALESCE(group_key, 'general') = ?
+			   AND claim_key = ?
+			   AND status = 'active'
+			 ORDER BY version DESC, updated_at DESC`,
+		)
+		.all(aspectId, agentId, kind, groupKey, claimKey) as Array<{
+		id: string;
+		content: string;
+		normalized_content: string;
+		version: number | null;
+		version_root_id: string | null;
+		kind: string;
+	}>;
+	const normalized = canonical(value);
+	const existing = active.find((row) => row.normalized_content === normalized);
+	if (existing && active.length === 1) {
+		db.prepare(
+			`UPDATE entity_attributes
+			 SET proposal_id = ?, proposal_evidence = ?, updated_at = datetime('now')
+			 WHERE id = ? AND agent_id = ?`,
+		).run(proposal.id, JSON.stringify(proposalAuditEvidence(proposal)), existing.id, agentId);
+		return {
+			entityId,
+			aspectId,
+			attributeId: existing.id,
+			version: existing.version ?? 1,
+			versionRootId: existing.version_root_id ?? existing.id,
+			deduped: true,
+		};
+	}
+	if (kind === "constraint" && active.length > 0 && !truthy(payload.force)) {
+		throw new OntologyProposalError("Refusing to replace active constraint claim without force", 409);
+	}
+
+	const previous = active[0] ?? null;
+	const version = previous === null ? 1 : Math.max(...active.map((row) => row.version ?? 1)) + 1;
+	const rootId = previous?.version_root_id ?? previous?.id ?? crypto.randomUUID();
+	const id = version === 1 ? rootId : crypto.randomUUID();
+	const confidence = clamp01(readNumber(payload, "confidence") ?? proposal.confidence);
+	const importance = clamp01(readNumber(payload, "importance") ?? confidence);
+	db.prepare(
+		`INSERT INTO entity_attributes
+		 (id, aspect_id, agent_id, kind, content, normalized_content,
+		  confidence, importance, status, group_key, claim_key,
+		  version, version_root_id, previous_attribute_id,
+		  created_at, updated_at, source_id, source_kind, source_path, source_root,
+		  proposal_id, proposal_evidence)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?, ?, ?,
+		         datetime('now'), datetime('now'), ?, ?, ?, ?, ?, ?)`,
+	).run(
+		id,
+		aspectId,
+		agentId,
+		kind,
+		value,
+		normalized,
+		confidence,
+		importance,
+		groupKey,
+		claimKey,
+		version,
+		rootId,
+		previous?.id ?? null,
+		proposal.source_id,
+		proposal.source_kind,
+		proposal.source_path,
+		proposal.source_root,
+		proposal.id,
+		JSON.stringify(proposalAuditEvidence(proposal)),
+	);
+
+	if (active.length > 0) {
+		db.prepare(
+			`UPDATE entity_attributes
+			 SET status = 'superseded', superseded_by = ?, updated_at = datetime('now')
+			 WHERE agent_id = ?
+			   AND aspect_id = ?
+			   AND kind = ?
+			   AND COALESCE(group_key, 'general') = ?
+			   AND claim_key = ?
+			   AND status = 'active'
+			   AND id != ?`,
+		).run(id, agentId, aspectId, kind, groupKey, claimKey, id);
+	}
+
+	return {
+		entityId,
+		aspectId,
+		attributeId: id,
+		version,
+		versionRootId: rootId,
+		previousAttributeId: previous?.id ?? null,
+	};
 }
 
 function applySupersedeClaimValue(
@@ -543,7 +812,7 @@ function applySupersedeClaimValue(
 		if (oldValue !== null && canonical(replacementValue) === canonical(oldValue)) {
 			throw new OntologyProposalError("payload.new_value must differ from payload.old_value", 400);
 		}
-		const replacement = applyAddClaimValue(db, agentId, proposal, {
+		const replacement = applySetClaimValue(db, agentId, proposal, {
 			entity,
 			aspect,
 			claim_key: claimKey,
@@ -566,6 +835,237 @@ function applySupersedeClaimValue(
 	).run(supersededBy, agentId, ...ids);
 
 	return { supersededAttributeIds: ids, replacementAttributeId: replacementId };
+}
+
+function applyRenameEntity(
+	db: WriteDb,
+	agentId: string,
+	proposal: ProposalRow,
+	payload: Readonly<Record<string, unknown>>,
+): Readonly<Record<string, unknown>> {
+	const selector = readPayloadSelector(payload, "selector", "entity", "entity_id", "name");
+	const name = readString(payload, "new_name");
+	if (selector === null) throw new OntologyProposalError("payload.selector is required", 400);
+	if (name === null) throw new OntologyProposalError("payload.new_name is required", 400);
+	const entity = resolveEntityStrict(db, agentId, selector);
+	const key = canonical(name);
+	const collision = db
+		.prepare(
+			`SELECT id, name FROM entities
+			 WHERE agent_id = ?
+			   AND id != ?
+			   AND COALESCE(status, 'active') = 'active'
+			   AND (COALESCE(canonical_name, LOWER(name)) = ? OR LOWER(name) = ?)
+			 LIMIT 1`,
+		)
+		.get(agentId, entity.id, key, key) as { id: string; name: string } | undefined;
+	if (collision) {
+		throw new OntologyProposalError(
+			`Entity canonical name collides with "${collision.name}". Use merge_entities instead.`,
+			409,
+		);
+	}
+	db.prepare(
+		`UPDATE entities
+		 SET name = ?, canonical_name = ?, proposal_id = ?, proposal_evidence = ?, updated_at = datetime('now')
+		 WHERE id = ? AND agent_id = ?`,
+	).run(name, key, proposal.id, JSON.stringify(proposalAuditEvidence(proposal)), entity.id, agentId);
+	return { entityId: entity.id, oldName: entity.name, newName: name };
+}
+
+function applyArchiveEntity(
+	db: WriteDb,
+	agentId: string,
+	proposal: ProposalRow,
+	payload: Readonly<Record<string, unknown>>,
+): Readonly<Record<string, unknown>> {
+	const selector = readPayloadSelector(payload, "selector", "entity", "entity_id", "name");
+	if (selector === null) throw new OntologyProposalError("payload.selector is required", 400);
+	const entity = resolveEntityStrict(db, agentId, selector);
+	const pinned = db.prepare("SELECT pinned FROM entities WHERE id = ? AND agent_id = ?").get(entity.id, agentId) as
+		| { pinned: number | null }
+		| undefined;
+	if (pinned?.pinned === 1 && !truthy(payload.force)) {
+		throw new OntologyProposalError("Refusing to archive pinned entity without force", 409);
+	}
+	db.prepare(
+		`UPDATE entities
+		 SET status = 'archived', archived_at = datetime('now'), archived_by = ?,
+		     archive_reason = ?, proposal_id = ?, proposal_evidence = ?, updated_at = datetime('now')
+		 WHERE id = ? AND agent_id = ?`,
+	).run(
+		proposal.applied_by ?? proposal.created_by,
+		readString(payload, "reason") ?? proposal.rationale,
+		proposal.id,
+		JSON.stringify(proposalAuditEvidence(proposal)),
+		entity.id,
+		agentId,
+	);
+	return { entityId: entity.id, archived: true };
+}
+
+function applyCreateAspect(
+	db: WriteDb,
+	agentId: string,
+	proposal: ProposalRow,
+	payload: Readonly<Record<string, unknown>>,
+): Readonly<Record<string, unknown>> {
+	const entitySelector = readPayloadSelector(payload, "entity", "entity_id");
+	const name = readString(payload, "name") ?? readString(payload, "aspect");
+	if (entitySelector === null) throw new OntologyProposalError("payload.entity is required", 400);
+	if (name === null) throw new OntologyProposalError("payload.name is required", 400);
+	const entity = resolveEntityStrict(db, agentId, entitySelector);
+	const aspectId = resolveOrCreateAspect(db, entity.id, agentId, name);
+	db.prepare(
+		`UPDATE entity_aspects
+		 SET proposal_id = ?, proposal_evidence = ?, updated_at = datetime('now')
+		 WHERE id = ? AND agent_id = ?`,
+	).run(proposal.id, JSON.stringify(proposalAuditEvidence(proposal)), aspectId, agentId);
+	return { entityId: entity.id, aspectId, aspect: name };
+}
+
+function applyRenameAspect(
+	db: WriteDb,
+	agentId: string,
+	proposal: ProposalRow,
+	payload: Readonly<Record<string, unknown>>,
+): Readonly<Record<string, unknown>> {
+	const entitySelector = readPayloadSelector(payload, "entity", "entity_id");
+	const aspectSelector = readPayloadSelector(payload, "selector", "aspect", "aspect_id", "name");
+	const name = readString(payload, "new_name");
+	if (entitySelector === null) throw new OntologyProposalError("payload.entity is required", 400);
+	if (aspectSelector === null) throw new OntologyProposalError("payload.selector is required", 400);
+	if (name === null) throw new OntologyProposalError("payload.new_name is required", 400);
+	const entity = resolveEntityStrict(db, agentId, entitySelector);
+	const aspect = resolveAspectStrict(db, agentId, entity.id, aspectSelector);
+	const key = canonical(name);
+	const collision = db
+		.prepare(
+			`SELECT id, name FROM entity_aspects
+			 WHERE entity_id = ? AND agent_id = ? AND id != ?
+			   AND COALESCE(status, 'active') = 'active'
+			   AND (canonical_name = ? OR LOWER(name) = ?)
+			 LIMIT 1`,
+		)
+		.get(entity.id, agentId, aspect.id, key, key) as { id: string; name: string } | undefined;
+	if (collision) throw new OntologyProposalError(`Aspect collides with "${collision.name}"`, 409);
+	db.prepare(
+		`UPDATE entity_aspects
+		 SET name = ?, canonical_name = ?, proposal_id = ?, proposal_evidence = ?, updated_at = datetime('now')
+		 WHERE id = ? AND agent_id = ?`,
+	).run(name, key, proposal.id, JSON.stringify(proposalAuditEvidence(proposal)), aspect.id, agentId);
+	return { entityId: entity.id, aspectId: aspect.id, oldName: aspect.name, newName: name };
+}
+
+function applyArchiveAspect(
+	db: WriteDb,
+	agentId: string,
+	proposal: ProposalRow,
+	payload: Readonly<Record<string, unknown>>,
+): Readonly<Record<string, unknown>> {
+	const entitySelector = readPayloadSelector(payload, "entity", "entity_id");
+	const aspectSelector = readPayloadSelector(payload, "selector", "aspect", "aspect_id", "name");
+	if (entitySelector === null) throw new OntologyProposalError("payload.entity is required", 400);
+	if (aspectSelector === null) throw new OntologyProposalError("payload.selector is required", 400);
+	const entity = resolveEntityStrict(db, agentId, entitySelector);
+	const aspect = resolveAspectStrict(db, agentId, entity.id, aspectSelector);
+	db.prepare(
+		`UPDATE entity_aspects
+		 SET status = 'archived', archived_at = datetime('now'), archived_by = ?,
+		     archive_reason = ?, proposal_id = ?, proposal_evidence = ?, updated_at = datetime('now')
+		 WHERE id = ? AND agent_id = ?`,
+	).run(
+		proposal.applied_by ?? proposal.created_by,
+		readString(payload, "reason") ?? proposal.rationale,
+		proposal.id,
+		JSON.stringify(proposalAuditEvidence(proposal)),
+		aspect.id,
+		agentId,
+	);
+	db.prepare(
+		`UPDATE entity_attributes
+		 SET status = 'deleted', archived_at = datetime('now'), archived_by = ?,
+		     archive_reason = ?, updated_at = datetime('now')
+		 WHERE aspect_id = ? AND agent_id = ? AND status = 'active'`,
+	).run(
+		proposal.applied_by ?? proposal.created_by,
+		readString(payload, "reason") ?? proposal.rationale,
+		aspect.id,
+		agentId,
+	);
+	return { entityId: entity.id, aspectId: aspect.id, archived: true };
+}
+
+function applyArchiveClaimValue(
+	db: WriteDb,
+	agentId: string,
+	proposal: ProposalRow,
+	payload: Readonly<Record<string, unknown>>,
+): Readonly<Record<string, unknown>> {
+	const attributeId = readString(payload, "attribute_id");
+	if (attributeId === null) throw new OntologyProposalError("payload.attribute_id is required", 400);
+	const row = db
+		.prepare("SELECT id, kind FROM entity_attributes WHERE id = ? AND agent_id = ?")
+		.get(attributeId, agentId) as { id: string; kind: string } | undefined;
+	if (!row) throw new OntologyProposalError("Attribute not found", 404);
+	if (row.kind === "constraint" && !truthy(payload.force)) {
+		throw new OntologyProposalError("Refusing to archive constraint attribute without force", 409);
+	}
+	db.prepare(
+		`UPDATE entity_attributes
+		 SET status = 'deleted', archived_at = datetime('now'), archived_by = ?,
+		     archive_reason = ?, proposal_id = ?, proposal_evidence = ?, updated_at = datetime('now')
+		 WHERE id = ? AND agent_id = ?`,
+	).run(
+		proposal.applied_by ?? proposal.created_by,
+		readString(payload, "reason") ?? proposal.rationale,
+		proposal.id,
+		JSON.stringify(proposalAuditEvidence(proposal)),
+		attributeId,
+		agentId,
+	);
+	return { attributeId, archived: true };
+}
+
+function applyRestoreClaimVersion(
+	db: WriteDb,
+	agentId: string,
+	proposal: ProposalRow,
+	payload: Readonly<Record<string, unknown>>,
+): Readonly<Record<string, unknown>> {
+	const attributeId = readString(payload, "attribute_id");
+	if (attributeId === null) throw new OntologyProposalError("payload.attribute_id is required", 400);
+	const row = db
+		.prepare(
+			`SELECT id, aspect_id, kind, group_key, claim_key, version_root_id
+			 FROM entity_attributes
+			 WHERE id = ? AND agent_id = ?`,
+		)
+		.get(attributeId, agentId) as
+		| {
+				id: string;
+				aspect_id: string;
+				kind: string;
+				group_key: string | null;
+				claim_key: string;
+				version_root_id: string | null;
+		  }
+		| undefined;
+	if (!row) throw new OntologyProposalError("Attribute not found", 404);
+	db.prepare(
+		`UPDATE entity_attributes
+		 SET status = 'superseded', superseded_by = ?, updated_at = datetime('now')
+		 WHERE agent_id = ? AND aspect_id = ? AND kind = ?
+		   AND COALESCE(group_key, 'general') = COALESCE(?, 'general')
+		   AND claim_key = ? AND status = 'active' AND id != ?`,
+	).run(attributeId, agentId, row.aspect_id, row.kind, row.group_key, row.claim_key, attributeId);
+	db.prepare(
+		`UPDATE entity_attributes
+		 SET status = 'active', superseded_by = NULL, archived_at = NULL, archived_by = NULL,
+		     archive_reason = NULL, proposal_id = ?, proposal_evidence = ?, updated_at = datetime('now')
+		 WHERE id = ? AND agent_id = ?`,
+	).run(proposal.id, JSON.stringify(proposalAuditEvidence(proposal)), attributeId, agentId);
+	return { attributeId, versionRootId: row.version_root_id ?? attributeId, restored: true };
 }
 
 function mergeEntityAspects(db: WriteDb, agentId: string, sourceId: string, targetId: string): number {
@@ -734,15 +1234,107 @@ function applyCreateLink(
 	return { dependencyId: id, sourceId, targetId, updated: false };
 }
 
+function applyUpdateLink(
+	db: WriteDb,
+	agentId: string,
+	proposal: ProposalRow,
+	payload: Readonly<Record<string, unknown>>,
+): Readonly<Record<string, unknown>> {
+	const id = readString(payload, "id") ?? readString(payload, "dependency_id") ?? readString(payload, "link_id");
+	if (id === null) throw new OntologyProposalError("payload.id is required", 400);
+	const existing = db
+		.prepare(
+			"SELECT dependency_type, reason, strength, confidence FROM entity_dependencies WHERE id = ? AND agent_id = ?",
+		)
+		.get(id, agentId) as
+		| { dependency_type: DependencyType; reason: string | null; strength: number | null; confidence: number | null }
+		| undefined;
+	if (!existing) throw new OntologyProposalError("Link not found", 404);
+	const dependencyType = readString(payload, "link_type")
+		? normalizeDependencyType(readString(payload, "link_type"))
+		: existing.dependency_type;
+	const reason = requireDependencyReason(
+		dependencyType,
+		readString(payload, "reason") ?? existing.reason ?? proposal.rationale,
+	);
+	const strength = clamp01(readNumber(payload, "strength") ?? existing.strength ?? 0.5);
+	const confidence = clamp01(readNumber(payload, "confidence") ?? existing.confidence ?? proposal.confidence);
+	db.prepare(
+		`UPDATE entity_dependencies
+		 SET dependency_type = ?, reason = ?, strength = ?, confidence = ?,
+		     source_id = COALESCE(?, source_id),
+		     source_kind = COALESCE(?, source_kind),
+		     source_path = COALESCE(?, source_path),
+		     source_root = COALESCE(?, source_root),
+		     proposal_id = ?, proposal_evidence = ?, updated_at = datetime('now')
+		 WHERE id = ? AND agent_id = ?`,
+	).run(
+		dependencyType,
+		reason,
+		strength,
+		confidence,
+		proposal.source_id,
+		proposal.source_kind,
+		proposal.source_path,
+		proposal.source_root,
+		proposal.id,
+		JSON.stringify(proposalAuditEvidence(proposal)),
+		id,
+		agentId,
+	);
+	return { dependencyId: id, updated: true };
+}
+
+function applyArchiveLink(
+	db: WriteDb,
+	agentId: string,
+	proposal: ProposalRow,
+	payload: Readonly<Record<string, unknown>>,
+): Readonly<Record<string, unknown>> {
+	const id = readString(payload, "id") ?? readString(payload, "dependency_id") ?? readString(payload, "link_id");
+	if (id === null) throw new OntologyProposalError("payload.id is required", 400);
+	const existing = db.prepare("SELECT id FROM entity_dependencies WHERE id = ? AND agent_id = ?").get(id, agentId) as
+		| { id: string }
+		| undefined;
+	if (!existing) throw new OntologyProposalError("Link not found", 404);
+	db.prepare(
+		`UPDATE entity_dependencies
+		 SET status = 'archived', archived_at = datetime('now'), archived_by = ?,
+		     archive_reason = ?, proposal_id = ?, proposal_evidence = ?, updated_at = datetime('now')
+		 WHERE id = ? AND agent_id = ?`,
+	).run(
+		proposal.applied_by ?? proposal.created_by,
+		readString(payload, "reason") ?? proposal.rationale,
+		proposal.id,
+		JSON.stringify(proposalAuditEvidence(proposal)),
+		id,
+		agentId,
+	);
+	return { dependencyId: id, archived: true };
+}
+
 function applyOperation(db: WriteDb, proposal: ProposalRow): Readonly<Record<string, unknown>> {
 	const payload = parseJsonRecord(proposal.payload);
-	if (proposal.operation === "create_entity") return applyCreateEntity(db, proposal.agent_id, payload);
+	if (proposal.operation === "create_entity") return applyCreateEntity(db, proposal.agent_id, proposal, payload);
+	if (proposal.operation === "rename_entity") return applyRenameEntity(db, proposal.agent_id, proposal, payload);
+	if (proposal.operation === "archive_entity") return applyArchiveEntity(db, proposal.agent_id, proposal, payload);
+	if (proposal.operation === "create_aspect") return applyCreateAspect(db, proposal.agent_id, proposal, payload);
+	if (proposal.operation === "rename_aspect") return applyRenameAspect(db, proposal.agent_id, proposal, payload);
+	if (proposal.operation === "archive_aspect") return applyArchiveAspect(db, proposal.agent_id, proposal, payload);
 	if (proposal.operation === "add_claim_value") return applyAddClaimValue(db, proposal.agent_id, proposal, payload);
+	if (proposal.operation === "set_claim_value") return applySetClaimValue(db, proposal.agent_id, proposal, payload);
 	if (proposal.operation === "merge_entities") return applyMergeEntities(db, proposal.agent_id, payload);
 	if (proposal.operation === "supersede_claim_value") {
 		return applySupersedeClaimValue(db, proposal.agent_id, proposal, payload);
 	}
+	if (proposal.operation === "archive_claim_value")
+		return applyArchiveClaimValue(db, proposal.agent_id, proposal, payload);
+	if (proposal.operation === "restore_claim_version") {
+		return applyRestoreClaimVersion(db, proposal.agent_id, proposal, payload);
+	}
 	if (proposal.operation === "create_link") return applyCreateLink(db, proposal.agent_id, proposal, payload);
+	if (proposal.operation === "update_link") return applyUpdateLink(db, proposal.agent_id, proposal, payload);
+	if (proposal.operation === "archive_link") return applyArchiveLink(db, proposal.agent_id, proposal, payload);
 	throw new OntologyProposalError(`Unsupported ontology proposal operation: ${proposal.operation}`, 400);
 }
 
@@ -880,6 +1472,79 @@ export function listOntologyProposalConflicts(
 		);
 		return { items, count: items.length };
 	});
+}
+
+function claimVersionRow(row: Record<string, unknown>): ClaimVersionItem {
+	return {
+		id: row.id as string,
+		version: Number(row.version ?? 1),
+		versionRootId: typeof row.version_root_id === "string" ? row.version_root_id : (row.id as string),
+		previousAttributeId: typeof row.previous_attribute_id === "string" ? row.previous_attribute_id : null,
+		content: row.content as string,
+		status: row.status as string,
+		confidence: Number(row.confidence ?? 0),
+		proposalId: typeof row.proposal_id === "string" ? row.proposal_id : null,
+		sourceKind: typeof row.source_kind === "string" ? row.source_kind : null,
+		sourceId: typeof row.source_id === "string" ? row.source_id : null,
+		sourcePath: typeof row.source_path === "string" ? row.source_path : null,
+		createdAt: row.created_at as string,
+		updatedAt: row.updated_at as string,
+	};
+}
+
+export function listClaimVersions(
+	accessor: DbAccessor,
+	params: ClaimVersionReadParams,
+): { readonly items: readonly ClaimVersionItem[]; readonly count: number } {
+	const groupKey = canonicalKey(params.group) ?? "general";
+	const claimKey = canonicalKey(params.claim);
+	if (claimKey === null) throw new OntologyProposalError("claim is required", 400);
+	const kind = params.kind ?? "attribute";
+	return accessor.withReadDb((db) => {
+		const entityKey = canonical(params.entity);
+		const aspectKey = canonical(params.aspect);
+		const rows = db
+			.prepare(
+				`SELECT attr.*
+				 FROM entity_attributes attr
+				 JOIN entity_aspects asp ON asp.id = attr.aspect_id
+				 JOIN entities ent ON ent.id = asp.entity_id
+				 WHERE ent.agent_id = ?
+				   AND asp.agent_id = ?
+				   AND attr.agent_id = ?
+				   AND COALESCE(ent.status, 'active') = 'active'
+				   AND COALESCE(asp.status, 'active') = 'active'
+				   AND (ent.id = ? OR COALESCE(ent.canonical_name, LOWER(ent.name)) = ? OR LOWER(ent.name) = ?)
+				   AND (asp.canonical_name = ? OR LOWER(asp.name) = ?)
+				   AND COALESCE(attr.group_key, 'general') = ?
+				   AND attr.claim_key = ?
+				   AND attr.kind = ?
+				 ORDER BY attr.version DESC, attr.updated_at DESC`,
+			)
+			.all(
+				params.agentId,
+				params.agentId,
+				params.agentId,
+				params.entity,
+				entityKey,
+				entityKey,
+				aspectKey,
+				aspectKey,
+				groupKey,
+				claimKey,
+				kind,
+			) as Array<Record<string, unknown>>;
+		const items = rows.map(claimVersionRow);
+		return { items, count: items.length };
+	});
+}
+
+export function getClaimVersion(
+	accessor: DbAccessor,
+	params: ClaimVersionReadParams & { readonly version: number },
+): ClaimVersionItem | null {
+	const versions = listClaimVersions(accessor, params);
+	return versions.items.find((item) => item.version === params.version) ?? null;
 }
 
 interface DuplicateEntityRow {
@@ -1063,6 +1728,179 @@ export function applyOntologyProposal(accessor: DbAccessor, params: ApplyOntolog
 		if (err instanceof OntologyProposalError && err.status !== 404 && err.status !== 409) {
 			markFailed(accessor, params.id, params.agentId, err);
 		}
+		throw err;
+	}
+}
+
+class DryRunRollback extends Error {
+	constructor() {
+		super("dry-run rollback");
+		this.name = "DryRunRollback";
+	}
+}
+
+function operationToProposalInput(params: ApplyOntologyOperationParams): CreateOntologyProposalInput {
+	return {
+		agentId: params.agentId,
+		operation: params.operation,
+		payload: params.payload,
+		confidence: params.confidence,
+		rationale: params.reason,
+		evidence: params.evidence,
+		risk: params.risk,
+		sourceKind: params.sourceKind,
+		sourceId: params.sourceId,
+		sourcePath: params.sourcePath,
+		sourceRoot: params.sourceRoot,
+		createdBy: params.actor,
+	};
+}
+
+function markAppliedInTx(
+	db: WriteDb,
+	proposal: ProposalRow,
+	actor: string,
+	result: Readonly<Record<string, unknown>>,
+): OntologyProposal {
+	const ts = now();
+	db.prepare(
+		`UPDATE ontology_proposals
+		 SET status = 'applied', applied_by = ?, result = ?,
+		     applied_at = ?, updated_at = ?
+		 WHERE id = ? AND agent_id = ?`,
+	).run(actor, JSON.stringify(result), ts, ts, proposal.id, proposal.agent_id);
+	return readBackInTx(db, proposal.id, proposal.agent_id);
+}
+
+export function applyOntologyOperation(
+	accessor: DbAccessor,
+	params: ApplyOntologyOperationParams,
+): ApplyOntologyOperationResult {
+	if (params.propose && params.dryRun) {
+		throw new OntologyProposalError("--dry-run and --propose cannot be used together", 400);
+	}
+	if (Object.keys(params.payload).length === 0) throw new OntologyProposalError("payload is required", 400);
+	if (params.propose) {
+		const proposal = createOntologyProposal(accessor, operationToProposalInput(params));
+		return { proposal, result: null, dryRun: false, proposed: true };
+	}
+
+	let preview: ApplyOntologyOperationResult | null = null;
+	try {
+		const result = accessor.withWriteTx((db) => {
+			const inserted = insertProposalInTx(db, operationToProposalInput(params), now());
+			const row = getProposalInTx(db, inserted.id, params.agentId);
+			if (row === null) throw new OntologyProposalError("Proposal not found", 404);
+			const operationResult = applyOperation(db, row);
+			const proposal = markAppliedInTx(db, row, params.actor, operationResult);
+			const item = { proposal, result: operationResult, dryRun: params.dryRun === true, proposed: false };
+			if (params.dryRun) {
+				preview = item;
+				throw new DryRunRollback();
+			}
+			return item;
+		});
+		return result;
+	} catch (err) {
+		if (err instanceof DryRunRollback && preview !== null) return preview;
+		throw err;
+	}
+}
+
+export function applyOntologyOperationBatch(
+	accessor: DbAccessor,
+	params: ApplyOntologyOperationBatchParams,
+): ApplyOntologyOperationBatchResult {
+	if (params.operations.length === 0) throw new OntologyProposalError("operations are required", 400);
+	if (params.operations.length > 500)
+		throw new OntologyProposalError("cannot apply more than 500 operations at once", 400);
+	if (params.propose && params.dryRun) {
+		throw new OntologyProposalError("--dry-run and --propose cannot be used together", 400);
+	}
+
+	if (params.propose) {
+		const written = createOntologyProposals(
+			accessor,
+			params.operations.map((operation) => ({
+				agentId: params.agentId,
+				operation: operation.operation,
+				payload: operation.payload,
+				confidence: operation.confidence,
+				rationale: operation.reason,
+				evidence: operation.evidence,
+				risk: operation.risk,
+				sourceKind: operation.sourceKind,
+				sourceId: operation.sourceId,
+				sourcePath: operation.sourcePath,
+				sourceRoot: operation.sourceRoot,
+				createdBy: params.actor,
+			})),
+		);
+		return {
+			items: written.items.map((proposal) => ({ proposal, result: null, dryRun: false, proposed: true })),
+			count: written.count,
+			dryRun: false,
+			proposed: true,
+		};
+	}
+
+	let preview: ApplyOntologyOperationBatchResult | null = null;
+	try {
+		const result = accessor.withWriteTx((db) => {
+			const items: ApplyOntologyOperationResult[] = [];
+			const errors: OntologyOperationBatchError[] = [];
+			for (const [index, operation] of params.operations.entries()) {
+				try {
+					const inserted = insertProposalInTx(
+						db,
+						{
+							agentId: params.agentId,
+							operation: operation.operation,
+							payload: operation.payload,
+							confidence: operation.confidence,
+							rationale: operation.reason,
+							evidence: operation.evidence,
+							risk: operation.risk,
+							sourceKind: operation.sourceKind,
+							sourceId: operation.sourceId,
+							sourcePath: operation.sourcePath,
+							sourceRoot: operation.sourceRoot,
+							createdBy: params.actor,
+						},
+						now(),
+					);
+					const row = getProposalInTx(db, inserted.id, params.agentId);
+					if (row === null) throw new OntologyProposalError("Proposal not found", 404);
+					const operationResult = applyOperation(db, row);
+					const proposal = markAppliedInTx(db, row, params.actor, operationResult);
+					items.push({ proposal, result: operationResult, dryRun: params.dryRun === true, proposed: false });
+				} catch (err) {
+					if (!params.dryRun) throw err;
+					errors.push({
+						index,
+						line: index + 1,
+						operation: operation.operation,
+						error: err instanceof Error ? err.message : String(err),
+						status: err instanceof OntologyProposalError ? err.status : 400,
+					});
+				}
+			}
+			const batch = {
+				items,
+				errors: errors.length > 0 ? errors : undefined,
+				count: items.length,
+				dryRun: params.dryRun === true,
+				proposed: false,
+			};
+			if (params.dryRun) {
+				preview = batch;
+				throw new DryRunRollback();
+			}
+			return batch;
+		});
+		return result;
+	} catch (err) {
+		if (err instanceof DryRunRollback && preview !== null) return preview;
 		throw err;
 	}
 }

--- a/platform/daemon/src/ontology-proposals.ts
+++ b/platform/daemon/src/ontology-proposals.ts
@@ -671,16 +671,15 @@ function applySetClaimValue(
 	const aspectId = resolveOrCreateAspect(db, entityId, agentId, aspect);
 	const groupKey = canonicalKey(readString(payload, "group_key") ?? readString(payload, "group")) ?? "general";
 	const kind = normalizeAttributeKind(readString(payload, "kind"));
-	const active = db
+	const slot = db
 		.prepare(
-			`SELECT id, content, normalized_content, version, version_root_id, kind
+			`SELECT id, content, normalized_content, version, version_root_id, kind, status
 			 FROM entity_attributes
 			 WHERE aspect_id = ?
 			   AND agent_id = ?
 			   AND kind = ?
 			   AND COALESCE(group_key, 'general') = ?
 			   AND claim_key = ?
-			   AND status = 'active'
 			 ORDER BY version DESC, updated_at DESC`,
 		)
 		.all(aspectId, agentId, kind, groupKey, claimKey) as Array<{
@@ -690,7 +689,9 @@ function applySetClaimValue(
 		version: number | null;
 		version_root_id: string | null;
 		kind: string;
+		status: string;
 	}>;
+	const active = slot.filter((row) => row.status === "active");
 	const normalized = canonical(value);
 	const existing = active.find((row) => row.normalized_content === normalized);
 	if (existing && active.length === 1) {
@@ -712,8 +713,8 @@ function applySetClaimValue(
 		throw new OntologyProposalError("Refusing to replace active constraint claim without force", 409);
 	}
 
-	const previous = active[0] ?? null;
-	const version = previous === null ? 1 : Math.max(...active.map((row) => row.version ?? 1)) + 1;
+	const previous = active[0] ?? slot[0] ?? null;
+	const version = previous === null ? 1 : Math.max(...slot.map((row) => row.version ?? 1)) + 1;
 	const rootId = previous?.version_root_id ?? previous?.id ?? crypto.randomUUID();
 	const id = version === 1 ? rootId : crypto.randomUUID();
 	const confidence = clamp01(readNumber(payload, "confidence") ?? proposal.confidence);

--- a/platform/daemon/src/routes/ontology-routes.ts
+++ b/platform/daemon/src/routes/ontology-routes.ts
@@ -13,11 +13,15 @@ import { OntologyExtractionError, extractOntologyProposals } from "../ontology-e
 import { OntologyLinkEvidenceError, getOntologyLinkEvidence } from "../ontology-link-evidence";
 import {
 	OntologyProposalError,
+	applyOntologyOperation,
+	applyOntologyOperationBatch,
 	applyOntologyProposal,
 	createOntologyProposal,
 	createOntologyProposals,
+	getClaimVersion,
 	getOntologyProposal,
 	getOntologyProposalEvidence,
+	listClaimVersions,
 	listOntologyProposalConflicts,
 	listOntologyProposals,
 	parseOntologyProposalStatus,
@@ -105,6 +109,9 @@ export function registerOntologyRoutes(app: Hono): void {
 	app.use("/api/ontology/consolidate", async (c, next) => {
 		const permission = c.req.method === "GET" ? "recall" : "modify";
 		return requirePermission(permission, authConfig)(c, next);
+	});
+	app.use("/api/ontology/operations/*", async (c, next) => {
+		return requirePermission("modify", authConfig)(c, next);
 	});
 	app.use("/api/ontology/claims/*", async (c, next) => {
 		const permission = c.req.method === "GET" ? "recall" : "modify";
@@ -257,11 +264,133 @@ export function registerOntologyRoutes(app: Hono): void {
 		}
 	});
 
+	app.get("/api/ontology/claims/versions", (c) => {
+		const scoped = resolveAgent(c, c.req.query("agent_id"));
+		if (scoped.response) return scoped.response;
+		const entity = c.req.query("entity")?.trim();
+		const aspect = c.req.query("aspect")?.trim();
+		const group = c.req.query("group")?.trim();
+		const claim = c.req.query("claim")?.trim();
+		if (!entity) return c.json({ error: "entity is required" }, 400);
+		if (!aspect) return c.json({ error: "aspect is required" }, 400);
+		if (!group) return c.json({ error: "group is required" }, 400);
+		if (!claim) return c.json({ error: "claim is required" }, 400);
+		const kind = parseOntologyClaimAttributeKind(c.req.query("kind"));
+		if (c.req.query("kind") && !kind) return c.json({ error: "kind is invalid" }, 400);
+		try {
+			return c.json(
+				listClaimVersions(getDbAccessor(), { agentId: scoped.agentId, entity, aspect, group, claim, kind }),
+			);
+		} catch (err) {
+			return c.json({ error: messageForError(err) }, statusForError(err));
+		}
+	});
+
+	app.get("/api/ontology/claims/version", (c) => {
+		const scoped = resolveAgent(c, c.req.query("agent_id"));
+		if (scoped.response) return scoped.response;
+		const entity = c.req.query("entity")?.trim();
+		const aspect = c.req.query("aspect")?.trim();
+		const group = c.req.query("group")?.trim();
+		const claim = c.req.query("claim")?.trim();
+		const version = parseBoundedInt(c.req.query("version"), 0, 1, 1_000_000);
+		if (!entity) return c.json({ error: "entity is required" }, 400);
+		if (!aspect) return c.json({ error: "aspect is required" }, 400);
+		if (!group) return c.json({ error: "group is required" }, 400);
+		if (!claim) return c.json({ error: "claim is required" }, 400);
+		if (version === 0) return c.json({ error: "version is required" }, 400);
+		const kind = parseOntologyClaimAttributeKind(c.req.query("kind"));
+		if (c.req.query("kind") && !kind) return c.json({ error: "kind is invalid" }, 400);
+		try {
+			const item = getClaimVersion(getDbAccessor(), {
+				agentId: scoped.agentId,
+				entity,
+				aspect,
+				group,
+				claim,
+				kind,
+				version,
+			});
+			if (item === null) return c.json({ error: "Claim version not found" }, 404);
+			return c.json(item);
+		} catch (err) {
+			return c.json({ error: messageForError(err) }, statusForError(err));
+		}
+	});
+
 	app.get("/api/ontology/links/:id/evidence", (c) => {
 		const scoped = resolveAgent(c, c.req.query("agent_id"));
 		if (scoped.response) return scoped.response;
 		try {
 			return c.json(getOntologyLinkEvidence(getDbAccessor(), { agentId: scoped.agentId, id: c.req.param("id") }));
+		} catch (err) {
+			return c.json({ error: messageForError(err) }, statusForError(err));
+		}
+	});
+
+	app.post("/api/ontology/operations/apply", async (c) => {
+		const body = await readJsonRecord(c);
+		const scoped = resolveAgent(c, c.req.query("agent_id") ?? readString(body, "agent_id"));
+		if (scoped.response) return scoped.response;
+		const operation = readString(body, "operation");
+		if (!operation) return c.json({ error: "operation is required" }, 400);
+		const payload = asRecord(body.payload);
+		if (Object.keys(payload).length === 0) return c.json({ error: "payload object is required" }, 400);
+		try {
+			return c.json(
+				applyOntologyOperation(getDbAccessor(), {
+					agentId: scoped.agentId,
+					actor: readString(body, "actor") ?? c.req.header("x-signet-actor") ?? "operator",
+					operation,
+					payload,
+					reason: readString(body, "reason") ?? readString(body, "rationale"),
+					evidence: readArray(body, "evidence"),
+					confidence: readNumber(body, "confidence"),
+					risk: readString(body, "risk") ?? null,
+					sourceKind: readString(body, "source_kind") ?? null,
+					sourceId: readString(body, "source_id") ?? null,
+					sourcePath: readString(body, "source_path") ?? null,
+					sourceRoot: readString(body, "source_root") ?? null,
+					dryRun: readBoolean(body, "dry_run") ?? false,
+					propose: readBoolean(body, "propose") ?? false,
+				}),
+			);
+		} catch (err) {
+			return c.json({ error: messageForError(err) }, statusForError(err));
+		}
+	});
+
+	app.post("/api/ontology/operations/batch", async (c) => {
+		const body = await readJsonRecord(c);
+		const scoped = resolveAgent(c, c.req.query("agent_id") ?? readString(body, "agent_id"));
+		if (scoped.response) return scoped.response;
+		const operations = readArray(body, "operations") ?? readArray(body, "items") ?? [];
+		if (operations.length === 0) return c.json({ error: "operations are required" }, 400);
+		const actor = readString(body, "actor") ?? c.req.header("x-signet-actor") ?? "operator";
+		try {
+			return c.json(
+				applyOntologyOperationBatch(getDbAccessor(), {
+					agentId: scoped.agentId,
+					actor,
+					dryRun: readBoolean(body, "dry_run") ?? false,
+					propose: readBoolean(body, "propose") ?? false,
+					operations: operations.map((raw) => {
+						const op = asRecord(raw);
+						return {
+							operation: readString(op, "operation") ?? "",
+							payload: asRecord(op.payload),
+							reason: readString(op, "reason") ?? readString(op, "rationale"),
+							evidence: readArray(op, "evidence"),
+							confidence: readNumber(op, "confidence"),
+							risk: readString(op, "risk") ?? null,
+							sourceKind: readString(op, "source_kind") ?? readString(body, "source_kind") ?? null,
+							sourceId: readString(op, "source_id") ?? readString(body, "source_id") ?? null,
+							sourcePath: readString(op, "source_path") ?? readString(body, "source_path") ?? null,
+							sourceRoot: readString(op, "source_root") ?? readString(body, "source_root") ?? null,
+						};
+					}),
+				}),
+			);
 		} catch (err) {
 			return c.json({ error: messageForError(err) }, statusForError(err));
 		}

--- a/skills/dreaming/SKILL.md
+++ b/skills/dreaming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dreaming
-description: "Ingest memory, transcript, and source artifacts into Signet's living ontology by producing evidence-backed proposal JSON/JSONL through the audited ontology control plane."
+description: "Maintain Signet's living ontology and memory substrate from transcripts, memory artifacts, source artifacts, notes, summaries, and imported records."
 version: 1.0.0
 ---
 
@@ -9,16 +9,18 @@ version: 1.0.0
 Use this skill when an agent should wake up, read accumulated source evidence,
 and turn it into Signet ontology structure. The job is flexible bulk ingestion:
 transcripts, memory artifacts, source artifacts, notes, summaries, and imported
-records go in; evidence-backed ontology operations come out.
+records go in; the knowledge graph, scoped memories, and maintenance trail get
+better.
 
-The ontology control plane is the only write path. Generated work should fill
-in entities, aspects, groups, claims, attributes, and links by producing
-operation JSON/JSONL for the daemon-backed CLI/API. It must not silently save
-ordinary memories, rewrite source artifacts, or edit SQLite directly.
+The point is to maintain the graph, not to create JSON. JSON/JSONL is only the
+transport for audited ontology operations when the daemon-backed CLI/API needs a
+batch. Successful graph mutations must go through the ontology control plane so
+they are permission-checked and auditable.
 
-Default mode is proposal-first. Start with `--dry-run`, then write pending
-proposals with `--propose` unless the operator explicitly asks for exact
-operations to be applied.
+Dreaming may save memories when the evidence supports durable recall, but not by
+calling the API `remember` endpoint. Save explicit source-backed memory artifacts
+or use the configured source/import machinery so provenance remains inspectable.
+Do not rewrite raw transcript/source artifacts or edit SQLite directly.
 
 ## Inputs
 
@@ -50,20 +52,23 @@ signet knowledge hygiene --json
 signet dream status
 ```
 
-## Output Artifacts
+## Outputs
 
-Produce these artifacts for the operator or harness:
+Produce the artifacts needed to complete the maintenance pass:
 
-- proposal JSON or JSONL using the ontology operation line shape
-- a dreaming log artifact with sources examined, candidate count, rejects, and
-  questions
-- a short summary of high-confidence changes
+- applied ontology operations, pending ontology proposals, or an operation
+  stream for the daemon control plane
+- source-backed memory artifacts for durable recall when the evidence warrants
+  saving memory
+- a dreaming log artifact with sources examined, changes made or proposed,
+  rejected candidates, and questions
+- a short summary of high-confidence graph and memory changes
 - rejected candidates with reasons
 - explicit questions where evidence is weak
 - optional AGENTS.md, identity-file, or skill patch proposals as written
   artifacts, never as silent edits
 
-JSONL operation line shape:
+Ontology operation line shape when batching is useful:
 
 ```json
 {"operation":"set_claim_value","payload":{"entity":"Signet","aspect":"architecture","group_key":"ontology","claim_key":"mutation_policy","value":"Generated ontology maintenance emits proposals before graph mutation."},"reason":"Consolidated from cited transcript evidence.","evidence":[{"source_kind":"transcript","source_id":"session-key","quote":"..."}]}
@@ -80,15 +85,17 @@ Use one JSON object per line. Good operation streams usually contain a mix of:
 - `archive_*` or `restore_claim_version` only when evidence is strong and the
   operator asked for maintenance, not just ingestion
 
-For large ingests, split output into reviewable batches. Prefer fewer,
-high-confidence operations with direct evidence quotes over broad speculative
+For large ingests, split work into coherent batches. Prefer fewer,
+high-confidence changes with direct evidence quotes over broad speculative
 coverage.
 
 ## Routing Rules
 
-- Source-backed graph facts -> ontology operation JSON/JSONL.
+- Source-backed graph facts -> ontology operations through the control plane.
 - Entity, aspect, group, claim, attribute, and link updates -> ontology
   operations.
+- Durable recall lessons -> source-backed memory artifacts, not the API
+  `remember` endpoint.
 - Behavioral lessons -> AGENTS.md or identity-file patch proposals.
 - Repeated procedures -> skill patch proposals.
 - Source-backed concepts -> source/literature note proposals when that source
@@ -108,40 +115,46 @@ or operating rule, route it to identity/AGENTS/skill patch proposals instead.
 3. Extract concrete semantic objects and stable facts.
 4. Reconcile against existing entities, aspects, groups, claims, and pending
    proposals.
-5. Emit operation JSONL with direct evidence for each proposed mutation.
-6. Dry-run the full stream and fix selector or validation errors.
-7. Write pending proposals for review, or apply only if explicitly authorized.
+5. Apply straightforward, authorized maintenance through the control plane, or
+   write pending proposals when review is requested or confidence is not high
+   enough for direct mutation.
+6. Save source-backed memory artifacts for durable recall when the pass learns
+   something useful that is not already represented in the graph.
+7. Keep a dreaming log with source ranges, changes, rejected candidates, and
+   open questions.
 
 When source volume is large, process in chunks and keep a dreaming log that
 records source ranges, skipped inputs, rejected candidates, and open questions.
 
 ## Control-Plane Commands
 
-Validate proposal JSON before asking the operator to apply it:
+Apply exact, authorized operations:
 
 ```bash
-signet ontology stream apply proposals.jsonl --dry-run --json
+signet ontology stream apply ops.jsonl --json
 ```
 
-Write proposals for review by default:
+Write proposals when review is desired:
 
 ```bash
 signet ontology stream apply proposals.jsonl --propose --json
 signet ontology proposals --status pending --json
 ```
 
-Only apply exact operator-authored operations directly when explicitly asked:
+Use dry-run only when the operator asks for validation first, or when a risky or
+destructive maintenance batch needs a cheap selector check:
 
 ```bash
-signet ontology stream apply approved-ops.jsonl --json
+signet ontology stream apply ops.jsonl --dry-run --json
 ```
 
 ## Hard Constraints
 
 - Do not edit SQLite directly.
 - Do not instruct an agent to silently mutate ontology state from LLM output.
-- Use `--dry-run` or `--propose` by default.
-- Preserve evidence for every proposed mutation.
+- Do not call `/api/memory/remember`, `/memory/remember`, or equivalent
+  remember endpoints from this skill.
+- Preserve evidence for every graph mutation or memory artifact.
 - Produce an evidence-backed mutation diff, not a vibe summary.
 - Treat source memories, source artifacts, transcripts, and raw records as
   immutable provenance.
@@ -149,8 +162,8 @@ signet ontology stream apply approved-ops.jsonl --json
 - Do not invent entities or attributes just to fill a schema. Weak evidence
   belongs in rejected candidates or open questions.
 - Do not bypass `ontology_proposals` for successful graph mutations.
-- Do not treat bulk ingestion as permission to apply generated changes without
-  review.
+- Do not treat bulk ingestion as permission to apply low-confidence, ambiguous,
+  destructive, or authority-changing mutations without review.
 
 ## Review Standard
 

--- a/skills/dreaming/SKILL.md
+++ b/skills/dreaming/SKILL.md
@@ -12,10 +12,10 @@ transcripts, memory artifacts, source artifacts, notes, summaries, and imported
 records go in; the knowledge graph, scoped memories, and maintenance trail get
 better.
 
-The point is to maintain the graph, not to create JSON. JSON/JSONL is only the
-transport for audited ontology operations when the daemon-backed CLI/API needs a
-batch. Successful graph mutations must go through the ontology control plane so
-they are permission-checked and auditable.
+Dreaming maintains the graph by turning source and memory artifacts into
+entities, aspects, claim attributes, and links. Memory artifacts are evidence
+for attributes; the ontology control plane is the audited path that applies
+those attributes to the graph.
 
 Dreaming may save memories when the evidence supports durable recall, but not by
 calling the API `remember` endpoint. Save explicit source-backed memory artifacts

--- a/skills/dreaming/SKILL.md
+++ b/skills/dreaming/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: dreaming
+description: "Ingest memory, transcript, and source artifacts into Signet's living ontology by producing evidence-backed proposal JSON/JSONL through the audited ontology control plane."
+version: 1.0.0
+---
+
+# Dreaming
+
+Use this skill when an agent should wake up, read accumulated source evidence,
+and turn it into Signet ontology structure. The job is flexible bulk ingestion:
+transcripts, memory artifacts, source artifacts, notes, summaries, and imported
+records go in; evidence-backed ontology operations come out.
+
+The ontology control plane is the only write path. Generated work should fill
+in entities, aspects, groups, claims, attributes, and links by producing
+operation JSON/JSONL for the daemon-backed CLI/API. It must not silently save
+ordinary memories, rewrite source artifacts, or edit SQLite directly.
+
+Default mode is proposal-first. Start with `--dry-run`, then write pending
+proposals with `--propose` unless the operator explicitly asks for exact
+operations to be applied.
+
+## Inputs
+
+Gather enough source evidence and graph context to infer useful ontology
+structure. Prefer recent transcript and memory-artifact windows first, then
+expand to bulk source sets when requested.
+
+- recent session summaries
+- raw transcripts and transcript artifacts
+- recently saved memory artifacts
+- source artifacts
+- imported notes, documents, literature, or other indexed source records
+- pending ontology proposals
+- applied, rejected, and failed proposal history
+- existing entities, aspects, groups, claims, attributes, and links
+- knowledge graph hygiene reports
+- retrieval failures or feedback when available
+- recent dreaming pass logs when available
+
+Useful commands:
+
+```bash
+signet ontology pipeline explain --json
+signet knowledge objects --json
+signet ontology proposals --status pending --json
+signet ontology proposals --status applied --limit 50 --json
+signet ontology proposals --status rejected --limit 50 --json
+signet knowledge hygiene --json
+signet dream status
+```
+
+## Output Artifacts
+
+Produce these artifacts for the operator or harness:
+
+- proposal JSON or JSONL using the ontology operation line shape
+- a dreaming log artifact with sources examined, candidate count, rejects, and
+  questions
+- a short summary of high-confidence changes
+- rejected candidates with reasons
+- explicit questions where evidence is weak
+- optional AGENTS.md, identity-file, or skill patch proposals as written
+  artifacts, never as silent edits
+
+JSONL operation line shape:
+
+```json
+{"operation":"set_claim_value","payload":{"entity":"Signet","aspect":"architecture","group_key":"ontology","claim_key":"mutation_policy","value":"Generated ontology maintenance emits proposals before graph mutation."},"reason":"Consolidated from cited transcript evidence.","evidence":[{"source_kind":"transcript","source_id":"session-key","quote":"..."}]}
+```
+
+Use one JSON object per line. Good operation streams usually contain a mix of:
+
+- `create_entity` for concrete people, organizations, projects, tools,
+  documents, products, places, and events that do not already exist
+- `create_aspect` for new coherent rooms of knowledge under an entity
+- `set_claim_value` for attributes and constraints, preserving `group_key` and
+  `claim_key` as stable slots
+- `create_link` for typed relationships between concrete entities
+- `archive_*` or `restore_claim_version` only when evidence is strong and the
+  operator asked for maintenance, not just ingestion
+
+For large ingests, split output into reviewable batches. Prefer fewer,
+high-confidence operations with direct evidence quotes over broad speculative
+coverage.
+
+## Routing Rules
+
+- Source-backed graph facts -> ontology operation JSON/JSONL.
+- Entity, aspect, group, claim, attribute, and link updates -> ontology
+  operations.
+- Behavioral lessons -> AGENTS.md or identity-file patch proposals.
+- Repeated procedures -> skill patch proposals.
+- Source-backed concepts -> source/literature note proposals when that source
+  workflow exists.
+- Permissions and authority changes -> policy/authority proposals when that
+  surface exists.
+
+Do not collapse every observation into a memory. If the source teaches stable
+structure about the world, a project, a person, a system, a document, or a
+relationship, route it to the ontology. If it teaches a behavioral preference
+or operating rule, route it to identity/AGENTS/skill patch proposals instead.
+
+## Ingestion Workflow
+
+1. Inspect graph mutation state and existing ontology shape.
+2. Read the requested transcript/artifact/source window.
+3. Extract concrete semantic objects and stable facts.
+4. Reconcile against existing entities, aspects, groups, claims, and pending
+   proposals.
+5. Emit operation JSONL with direct evidence for each proposed mutation.
+6. Dry-run the full stream and fix selector or validation errors.
+7. Write pending proposals for review, or apply only if explicitly authorized.
+
+When source volume is large, process in chunks and keep a dreaming log that
+records source ranges, skipped inputs, rejected candidates, and open questions.
+
+## Control-Plane Commands
+
+Validate proposal JSON before asking the operator to apply it:
+
+```bash
+signet ontology stream apply proposals.jsonl --dry-run --json
+```
+
+Write proposals for review by default:
+
+```bash
+signet ontology stream apply proposals.jsonl --propose --json
+signet ontology proposals --status pending --json
+```
+
+Only apply exact operator-authored operations directly when explicitly asked:
+
+```bash
+signet ontology stream apply approved-ops.jsonl --json
+```
+
+## Hard Constraints
+
+- Do not edit SQLite directly.
+- Do not instruct an agent to silently mutate ontology state from LLM output.
+- Use `--dry-run` or `--propose` by default.
+- Preserve evidence for every proposed mutation.
+- Produce an evidence-backed mutation diff, not a vibe summary.
+- Treat source memories, source artifacts, transcripts, and raw records as
+  immutable provenance.
+- Do not rewrite raw artifacts when ontology attributes change.
+- Do not invent entities or attributes just to fill a schema. Weak evidence
+  belongs in rejected candidates or open questions.
+- Do not bypass `ontology_proposals` for successful graph mutations.
+- Do not treat bulk ingestion as permission to apply generated changes without
+  review.
+
+## Review Standard
+
+Reject a candidate instead of proposing it when:
+
+- evidence is missing or only paraphrased
+- the selector is ambiguous and no stable id is available
+- the mutation would archive or replace a protected entity, aspect, group, or
+  constraint without explicit operator force
+- the candidate creates a generic scaffolding entity instead of a concrete
+  semantic object
+- it duplicates an existing pending proposal
+
+The final dreaming log should make rejected candidates and open questions as
+visible as accepted proposals.

--- a/surfaces/cli/src/commands/ontology.test.ts
+++ b/surfaces/cli/src/commands/ontology.test.ts
@@ -14,6 +14,29 @@ afterEach(() => {
 });
 
 describe("registerOntologyCommands", () => {
+	test("registers the public audited mutation command tree", () => {
+		const program = new Command();
+		registerOntologyCommands(program, {
+			ensureDaemonForSecrets: async () => true,
+			secretApiCall: async () => ({ ok: true, data: {} }),
+		});
+
+		const ontology = program.commands.find((cmd) => cmd.name() === "ontology");
+		expect(ontology).toBeDefined();
+		if (!ontology) throw new Error("ontology command was not registered");
+		expect(ontology?.commands.map((cmd) => cmd.name())).toEqual(
+			expect.arrayContaining(["entity", "claim", "aspect", "link", "stream"]),
+		);
+
+		const names = (parent: Command, name: string): readonly string[] =>
+			parent.commands.find((cmd) => cmd.name() === name)?.commands.map((cmd) => cmd.name()) ?? [];
+		expect(names(ontology, "entity")).toEqual(expect.arrayContaining(["create", "rename", "merge", "archive"]));
+		expect(names(ontology, "claim")).toEqual(expect.arrayContaining(["set", "versions", "show", "archive", "restore"]));
+		expect(names(ontology, "aspect")).toEqual(expect.arrayContaining(["create", "rename", "archive"]));
+		expect(names(ontology, "link")).toEqual(expect.arrayContaining(["create", "update", "archive"]));
+		expect(names(ontology, "stream")).toEqual(expect.arrayContaining(["apply"]));
+	});
+
 	test("objects lists ontology objects through knowledge navigation", async () => {
 		const calls: Array<{ readonly method: string; readonly path: string }> = [];
 		const lines: string[] = [];

--- a/surfaces/cli/src/commands/ontology.test.ts
+++ b/surfaces/cli/src/commands/ontology.test.ts
@@ -486,4 +486,289 @@ describe("registerOntologyCommands", () => {
 		expect(body.proposals?.[0]?.payload?.claim_key).toBe("proposal_loop");
 		expect(body.proposals?.[1]?.payload?.link_type).toBe("supports_claim");
 	});
+
+	test("entity create posts audited operation payloads", async () => {
+		const calls: Array<{ readonly method: string; readonly path: string; readonly body: unknown }> = [];
+		console.log = () => {};
+		const program = new Command();
+		registerOntologyCommands(program, {
+			ensureDaemonForSecrets: async () => true,
+			secretApiCall: async (method, path, body) => {
+				calls.push({ method, path, body });
+				return { ok: true, data: { proposal: { id: "proposal-1" }, dryRun: true } };
+			},
+		});
+
+		await program.parseAsync([
+			"node",
+			"test",
+			"ontology",
+			"entity",
+			"create",
+			"Signet",
+			"--type",
+			"project",
+			"--agent",
+			"ant",
+			"--dry-run",
+			"--reason",
+			"manual",
+			"--json",
+		]);
+
+		expect(calls).toEqual([
+			{
+				method: "POST",
+				path: "/api/ontology/operations/apply",
+				body: {
+					agent_id: "ant",
+					actor: "operator",
+					operation: "create_entity",
+					payload: { name: "Signet", entity_type: "project" },
+					reason: "manual",
+					evidence: undefined,
+					dry_run: true,
+					propose: false,
+				},
+			},
+		]);
+	});
+
+	test("claim set and stream apply use operation endpoints", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "signet-ontology-cli-ops-"));
+		const file = join(dir, "ops.jsonl");
+		writeFileSync(
+			file,
+			`${JSON.stringify({ operation: "create_entity", payload: { name: "Signet", entity_type: "project" } })}\n`,
+		);
+		const calls: Array<{ readonly method: string; readonly path: string; readonly body: unknown }> = [];
+		console.log = () => {};
+		try {
+			const program = new Command();
+			registerOntologyCommands(program, {
+				ensureDaemonForSecrets: async () => true,
+				secretApiCall: async (method, path, body) => {
+					calls.push({ method, path, body });
+					return { ok: true, data: { proposal: { id: "proposal-1" }, items: [], count: 1 } };
+				},
+			});
+
+			await program.parseAsync([
+				"node",
+				"test",
+				"ontology",
+				"claim",
+				"set",
+				"Signet",
+				"architecture",
+				"ontology",
+				"control_plane",
+				"--value",
+				"Audited operations",
+				"--propose",
+				"--agent",
+				"ant",
+			]);
+			await program.parseAsync(["node", "test", "ontology", "stream", "apply", file, "--dry-run", "--json"]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+
+		expect(calls[0]?.path).toBe("/api/ontology/operations/apply");
+		expect((calls[0]?.body as { readonly operation?: string }).operation).toBe("set_claim_value");
+		expect((calls[0]?.body as { readonly propose?: boolean }).propose).toBe(true);
+		expect(calls[1]?.path).toBe("/api/ontology/operations/batch");
+		expect((calls[1]?.body as { readonly dry_run?: boolean }).dry_run).toBe(true);
+		expect((calls[1]?.body as { readonly operations?: readonly unknown[] }).operations).toHaveLength(1);
+	});
+
+	test("claim version commands call version read and archive/restore operation endpoints", async () => {
+		const calls: Array<{ readonly method: string; readonly path: string; readonly body: unknown }> = [];
+		console.log = () => {};
+		const program = new Command();
+		registerOntologyCommands(program, {
+			ensureDaemonForSecrets: async () => true,
+			secretApiCall: async (method, path, body) => {
+				calls.push({ method, path, body });
+				return { ok: true, data: { proposal: { id: "proposal-1" }, items: [], count: 1 } };
+			},
+		});
+
+		await program.parseAsync([
+			"node",
+			"test",
+			"ontology",
+			"claim",
+			"versions",
+			"Signet",
+			"architecture",
+			"ontology",
+			"control_plane",
+			"--agent",
+			"ant",
+		]);
+		await program.parseAsync([
+			"node",
+			"test",
+			"ontology",
+			"claim",
+			"show",
+			"Signet",
+			"architecture",
+			"ontology",
+			"control_plane",
+			"--version",
+			"2",
+			"--agent",
+			"ant",
+		]);
+		await program.parseAsync([
+			"node",
+			"test",
+			"ontology",
+			"claim",
+			"archive",
+			"--attribute-id",
+			"attr-1",
+			"--reason",
+			"obsolete",
+		]);
+		await program.parseAsync(["node", "test", "ontology", "claim", "restore", "--attribute-id", "attr-1"]);
+
+		expect(calls[0]?.path).toBe(
+			"/api/ontology/claims/versions?entity=Signet&aspect=architecture&group=ontology&claim=control_plane&agent_id=ant",
+		);
+		expect(calls[1]?.path).toBe(
+			"/api/ontology/claims/version?entity=Signet&aspect=architecture&group=ontology&claim=control_plane&version=2&agent_id=ant",
+		);
+		expect((calls[2]?.body as { readonly operation?: string }).operation).toBe("archive_claim_value");
+		expect((calls[3]?.body as { readonly operation?: string }).operation).toBe("restore_claim_version");
+	});
+
+	test("aspect and link commands hit audited operation endpoints", async () => {
+		const calls: Array<{ readonly method: string; readonly path: string; readonly body: unknown }> = [];
+		console.log = () => {};
+		const program = new Command();
+		registerOntologyCommands(program, {
+			ensureDaemonForSecrets: async () => true,
+			secretApiCall: async (method, path, body) => {
+				calls.push({ method, path, body });
+				return { ok: true, data: { proposal: { id: "proposal-1" } } };
+			},
+		});
+
+		await program.parseAsync([
+			"node",
+			"test",
+			"ontology",
+			"aspect",
+			"create",
+			"Signet",
+			"architecture",
+			"--agent",
+			"ant",
+			"--dry-run",
+		]);
+		await program.parseAsync([
+			"node",
+			"test",
+			"ontology",
+			"aspect",
+			"rename",
+			"Signet",
+			"architecture",
+			"design",
+			"--propose",
+		]);
+		await program.parseAsync([
+			"node",
+			"test",
+			"ontology",
+			"aspect",
+			"archive",
+			"Signet",
+			"design",
+			"--reason",
+			"obsolete",
+		]);
+		await program.parseAsync([
+			"node",
+			"test",
+			"ontology",
+			"link",
+			"create",
+			"Signet",
+			"supports_claim",
+			"Transcript",
+			"--strength",
+			"0.8",
+			"--confidence",
+			"0.9",
+		]);
+		await program.parseAsync(["node", "test", "ontology", "link", "update", "link-1", "--type", "related_to"]);
+		await program.parseAsync(["node", "test", "ontology", "link", "archive", "link-1", "--reason", "obsolete"]);
+
+		expect(calls.map((call) => (call.body as { readonly operation?: string }).operation)).toEqual([
+			"create_aspect",
+			"rename_aspect",
+			"archive_aspect",
+			"create_link",
+			"update_link",
+			"archive_link",
+		]);
+		expect((calls[0]?.body as { readonly agent_id?: string; readonly dry_run?: boolean }).agent_id).toBe("ant");
+		expect((calls[0]?.body as { readonly dry_run?: boolean }).dry_run).toBe(true);
+		expect((calls[1]?.body as { readonly propose?: boolean }).propose).toBe(true);
+		expect((calls[3]?.body as { readonly payload?: { readonly strength?: number } }).payload?.strength).toBe(0.8);
+	});
+
+	test("pipeline explain reads daemon status", async () => {
+		let capturedPath = "";
+		console.log = () => {};
+		const program = new Command();
+		registerOntologyCommands(program, {
+			ensureDaemonForSecrets: async () => true,
+			secretApiCall: async (_method, path) => {
+				capturedPath = path;
+				return {
+					ok: true,
+					data: {
+						pipelineV2: {
+							enabled: true,
+							shadowMode: false,
+							mutationsFrozen: false,
+							graph: { enabled: true, extractionWritesEnabled: false },
+							traversal: { enabled: true },
+							autonomous: { enabled: true, frozen: false, allowUpdateDelete: false },
+						},
+					},
+				};
+			},
+		});
+
+		await program.parseAsync(["node", "test", "ontology", "pipeline", "explain"]);
+
+		expect(capturedPath).toBe("/api/status");
+	});
+
+	test("config show makes the audited operation surface explicit", async () => {
+		const lines: string[] = [];
+		console.log = (line?: unknown) => {
+			lines.push(String(line ?? ""));
+		};
+		const program = new Command();
+		registerOntologyCommands(program, {
+			ensureDaemonForSecrets: async () => true,
+			secretApiCall: async () => ({ ok: true, data: {} }),
+		});
+
+		await program.parseAsync(["node", "test", "ontology", "config", "show", "--json"]);
+
+		const data = JSON.parse(lines.join("\n")) as {
+			readonly operationsUsable?: boolean;
+			readonly policyFile?: { readonly active?: boolean };
+		};
+		expect(data.operationsUsable).toBe(true);
+		expect(data.policyFile?.active).toBe(false);
+	});
 });

--- a/surfaces/cli/src/commands/ontology.ts
+++ b/surfaces/cli/src/commands/ontology.ts
@@ -228,6 +228,31 @@ function readProposalFile(path: string): readonly ProposalImportInput[] {
 	return normalizeProposalFile(readJsonFile(path));
 }
 
+function readTextFileOrStdin(path: string): string {
+	if (path === "-") return readFileSync(0, "utf8");
+	return readFileSync(path, "utf8");
+}
+
+function readOperationJsonl(path: string): readonly Record<string, unknown>[] {
+	return readTextFileOrStdin(path)
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0)
+		.map((line, index) => {
+			try {
+				const parsed: unknown = JSON.parse(line);
+				if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+					return parsed as Record<string, unknown>;
+				}
+				throw new Error("line is not an object");
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				console.error(chalk.red(`Invalid JSONL operation on line ${index + 1}: ${message}`));
+				process.exit(1);
+			}
+		});
+}
+
 function proposalInput(
 	operation: string | undefined,
 	payload: Record<string, unknown>,
@@ -616,6 +641,57 @@ function addCommonOptions(cmd: Command): Command {
 	return cmd.option("--agent <name>", "Agent scope, default default").option("--json", "Output as JSON");
 }
 
+function addOperationOptions(cmd: Command): Command {
+	return addCommonOptions(cmd)
+		.option("--dry-run", "Validate and preview without writing")
+		.option("--propose", "Create a pending proposal instead of applying")
+		.option("--actor <name>", "Audit actor", "operator")
+		.option("--reason <text>", "Audit reason")
+		.option("--evidence-file <path>", "JSON evidence file, array or single object");
+}
+
+function operationBody(
+	operation: string,
+	payload: Record<string, unknown>,
+	options: Record<string, unknown>,
+): Record<string, unknown> {
+	return {
+		agent_id: options.agent,
+		actor: options.actor,
+		operation,
+		payload,
+		reason: options.reason,
+		evidence: readEvidenceFile(typeof options.evidenceFile === "string" ? options.evidenceFile : undefined),
+		dry_run: options.dryRun === true,
+		propose: options.propose === true,
+	};
+}
+
+async function postOperation(
+	deps: OntologyDeps,
+	operation: string,
+	payload: Record<string, unknown>,
+	options: Record<string, unknown>,
+): Promise<unknown> {
+	if (options.dryRun && options.propose) {
+		console.error(chalk.red("--dry-run and --propose cannot be used together"));
+		process.exit(1);
+	}
+	return apiPost(deps, "/api/ontology/operations/apply", operationBody(operation, payload, options));
+}
+
+function printOperationResult(data: unknown, options: Record<string, unknown>, label: string): void {
+	if (options.json) {
+		console.log(JSON.stringify(data, null, 2));
+		return;
+	}
+	const record = asRecord(data);
+	const proposal = asRecord(record.proposal);
+	const id = typeof proposal.id === "string" ? proposal.id : "";
+	const mode = record.dryRun === true ? "Dry-run validated" : record.proposed === true ? "Proposed" : "Applied";
+	console.log(chalk.green(`${mode} ${label}${id ? ` (${id})` : ""}`));
+}
+
 export function registerOntologyCommands(program: Command, deps: OntologyDeps): void {
 	const ontology = program.command("ontology").description("Inspect and maintain the operational ontology");
 
@@ -854,6 +930,423 @@ export function registerOntologyCommands(program: Command, deps: OntologyDeps): 
 		if (options.json) console.log(JSON.stringify(data, null, 2));
 		else printOntologyClaims(data);
 	});
+
+	const entity = ontology.command("entity").description("Apply audited entity operations");
+	addOperationOptions(
+		entity
+			.command("create")
+			.description("Create an entity")
+			.argument("<name>", "Entity name")
+			.requiredOption("--type <type>"),
+	).action(async (name: string, options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const data = await postOperation(deps, "create_entity", { name, entity_type: options.type }, options);
+		printOperationResult(data, options, "entity create");
+	});
+	addOperationOptions(
+		entity
+			.command("rename")
+			.description("Rename an entity")
+			.argument("<selector>", "Entity id or exact canonical name")
+			.argument("<new-name>", "New entity name"),
+	).action(async (selector: string, newName: string, options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const data = await postOperation(deps, "rename_entity", { selector, new_name: newName }, options);
+		printOperationResult(data, options, "entity rename");
+	});
+	addOperationOptions(
+		entity
+			.command("merge")
+			.description("Merge source entities into a target entity")
+			.argument("<target>", "Target entity selector")
+			.argument("<source...>", "Source entity selectors"),
+	).action(async (target: string, source: readonly string[], options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const data = await postOperation(
+			deps,
+			"merge_entities",
+			{ target_entity: target, source_entities: source },
+			options,
+		);
+		printOperationResult(data, options, "entity merge");
+	});
+	addOperationOptions(
+		entity
+			.command("archive")
+			.description("Archive an entity")
+			.argument("<selector>", "Entity id or exact canonical name"),
+	).action(async (selector: string, options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const data = await postOperation(deps, "archive_entity", { selector, reason: options.reason }, options);
+		printOperationResult(data, options, "entity archive");
+	});
+
+	const claim = ontology.command("claim").description("Apply audited claim/version operations");
+	addOperationOptions(
+		claim
+			.command("set")
+			.description("Set the current value for a claim")
+			.argument("<entity>", "Entity selector")
+			.argument("<aspect>", "Aspect name")
+			.argument("<group>", "Group key")
+			.argument("<claim>", "Claim key")
+			.requiredOption("--value <text>", "Claim value")
+			.option("--kind <kind>", "attribute or constraint"),
+	).action(async (entityName: string, aspect: string, group: string, claimKey: string, options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const data = await postOperation(
+			deps,
+			"set_claim_value",
+			{
+				entity: entityName,
+				aspect,
+				group_key: group,
+				claim_key: claimKey,
+				value: options.value,
+				kind: options.kind,
+			},
+			options,
+		);
+		printOperationResult(data, options, "claim set");
+	});
+	addCommonOptions(
+		claim
+			.command("versions")
+			.description("List versions for a claim")
+			.argument("<entity>", "Entity selector")
+			.argument("<aspect>", "Aspect name")
+			.argument("<group>", "Group key")
+			.argument("<claim>", "Claim key")
+			.option("--kind <kind>", "attribute or constraint"),
+	).action(async (entityName: string, aspect: string, group: string, claimKey: string, options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const params = new URLSearchParams({ entity: entityName, aspect, group, claim: claimKey });
+		appendAgent(params, options.agent);
+		if (options.kind) params.set("kind", options.kind);
+		const data = await apiGet(deps, "/api/ontology/claims/versions", params);
+		console.log(JSON.stringify(data, null, 2));
+	});
+	addCommonOptions(
+		claim
+			.command("show")
+			.description("Show one claim version")
+			.argument("<entity>", "Entity selector")
+			.argument("<aspect>", "Aspect name")
+			.argument("<group>", "Group key")
+			.argument("<claim>", "Claim key")
+			.requiredOption("--version <n>", "Version number", Number.parseInt)
+			.option("--kind <kind>", "attribute or constraint"),
+	).action(async (entityName: string, aspect: string, group: string, claimKey: string, options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const params = new URLSearchParams({
+			entity: entityName,
+			aspect,
+			group,
+			claim: claimKey,
+			version: String(options.version),
+		});
+		appendAgent(params, options.agent);
+		if (options.kind) params.set("kind", options.kind);
+		const data = await apiGet(deps, "/api/ontology/claims/version", params);
+		console.log(JSON.stringify(data, null, 2));
+	});
+	addOperationOptions(
+		claim.command("archive").description("Archive a claim value").requiredOption("--attribute-id <id>"),
+	).action(async (options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const data = await postOperation(
+			deps,
+			"archive_claim_value",
+			{ attribute_id: options.attributeId, reason: options.reason },
+			options,
+		);
+		printOperationResult(data, options, "claim archive");
+	});
+	addOperationOptions(
+		claim.command("restore").description("Restore a claim version").requiredOption("--attribute-id <id>"),
+	).action(async (options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const data = await postOperation(deps, "restore_claim_version", { attribute_id: options.attributeId }, options);
+		printOperationResult(data, options, "claim restore");
+	});
+
+	const aspect = ontology.command("aspect").description("Apply audited aspect operations");
+	addOperationOptions(
+		aspect
+			.command("create")
+			.description("Create an aspect")
+			.argument("<entity>", "Entity selector")
+			.argument("<name>", "Aspect name"),
+	).action(async (entityName: string, name: string, options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const data = await postOperation(deps, "create_aspect", { entity: entityName, name }, options);
+		printOperationResult(data, options, "aspect create");
+	});
+	addOperationOptions(
+		aspect
+			.command("rename")
+			.description("Rename an aspect")
+			.argument("<entity>", "Entity selector")
+			.argument("<selector>", "Aspect selector")
+			.argument("<new-name>", "New aspect name"),
+	).action(async (entityName: string, selector: string, newName: string, options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const data = await postOperation(
+			deps,
+			"rename_aspect",
+			{ entity: entityName, selector, new_name: newName },
+			options,
+		);
+		printOperationResult(data, options, "aspect rename");
+	});
+	addOperationOptions(
+		aspect
+			.command("archive")
+			.description("Archive an aspect")
+			.argument("<entity>", "Entity selector")
+			.argument("<selector>", "Aspect selector"),
+	).action(async (entityName: string, selector: string, options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const data = await postOperation(
+			deps,
+			"archive_aspect",
+			{ entity: entityName, selector, reason: options.reason },
+			options,
+		);
+		printOperationResult(data, options, "aspect archive");
+	});
+
+	const link = ontology.command("link").description("Apply audited link operations");
+	addOperationOptions(
+		link
+			.command("create")
+			.description("Create a link")
+			.argument("<source>", "Source entity selector")
+			.argument("<type>", "Dependency/link type")
+			.argument("<target>", "Target entity selector")
+			.option("--source-type <type>")
+			.option("--target-type <type>")
+			.option("--strength <n>", "Strength from 0 to 1", Number.parseFloat)
+			.option("--confidence <n>", "Confidence from 0 to 1", Number.parseFloat),
+	).action(async (source: string, type: string, target: string, options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const data = await postOperation(
+			deps,
+			"create_link",
+			{
+				source_entity: source,
+				link_type: type,
+				target_entity: target,
+				source_type: options.sourceType,
+				target_type: options.targetType,
+				strength: options.strength,
+				confidence: options.confidence,
+				reason: options.reason,
+			},
+			options,
+		);
+		printOperationResult(data, options, "link create");
+	});
+	addOperationOptions(
+		link
+			.command("update")
+			.description("Update a link")
+			.argument("<id>", "Link id")
+			.option("--type <type>", "Dependency/link type")
+			.option("--strength <n>", "Strength from 0 to 1", Number.parseFloat)
+			.option("--confidence <n>", "Confidence from 0 to 1", Number.parseFloat),
+	).action(async (id: string, options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const data = await postOperation(
+			deps,
+			"update_link",
+			{
+				id,
+				link_type: options.type,
+				strength: options.strength,
+				confidence: options.confidence,
+				reason: options.reason,
+			},
+			options,
+		);
+		printOperationResult(data, options, "link update");
+	});
+	addOperationOptions(link.command("archive").description("Archive a link").argument("<id>", "Link id")).action(
+		async (id: string, options) => {
+			if (!(await deps.ensureDaemonForSecrets())) return;
+			const data = await postOperation(deps, "archive_link", { id, reason: options.reason }, options);
+			printOperationResult(data, options, "link archive");
+		},
+	);
+
+	const stream = ontology.command("stream").description("Apply JSONL operation streams");
+	stream
+		.command("apply")
+		.description("Apply, dry-run, or propose a JSONL operation stream")
+		.argument("<path>", "JSONL path or - for stdin")
+		.option("--dry-run", "Validate and preview without writing")
+		.option("--propose", "Create pending proposals instead of applying")
+		.option("--agent <name>", "Agent scope, default default")
+		.option("--actor <name>", "Audit actor", "operator")
+		.option("--json", "Output as JSON")
+		.action(async (path: string, options) => {
+			if (options.dryRun && options.propose) {
+				console.error(chalk.red("--dry-run and --propose cannot be used together"));
+				process.exit(1);
+			}
+			if (!(await deps.ensureDaemonForSecrets())) return;
+			const operations = readOperationJsonl(path);
+			const data = await apiPost(deps, "/api/ontology/operations/batch", {
+				agent_id: options.agent,
+				actor: options.actor,
+				dry_run: options.dryRun === true,
+				propose: options.propose === true,
+				operations,
+			});
+			if (options.json) console.log(JSON.stringify(data, null, 2));
+			else printOperationResult(data, options, "operation stream");
+		});
+
+	const pipeline = ontology.command("pipeline").description("Inspect Pipeline V2 graph mutation state");
+	pipeline
+		.command("status")
+		.description("Show graph-related Pipeline V2 status")
+		.option("--json", "Output as JSON")
+		.action(async (options) => {
+			if (!(await deps.ensureDaemonForSecrets())) return;
+			const status = asRecord(await apiGet(deps, "/api/status", new URLSearchParams()));
+			const pipe = asRecord(status.pipelineV2);
+			const data = {
+				enabled: pipe.enabled,
+				paused: pipe.paused,
+				graphEnabled: asRecord(pipe.graph).enabled,
+				traversal: pipe.traversal,
+				shadowMode: pipe.shadowMode,
+				mutationsFrozen: pipe.mutationsFrozen,
+				autonomousEnabled: asRecord(pipe.autonomous).enabled,
+				allowUpdateDelete: asRecord(pipe.autonomous).allowUpdateDelete,
+				extraction: pipe.extraction,
+				dampening: pipe.dampening,
+				writeGates: {
+					shadowMode: pipe.shadowMode,
+					mutationsFrozen: pipe.mutationsFrozen,
+					minFactConfidenceForWrite: pipe.minFactConfidenceForWrite,
+					allowUpdateDelete: asRecord(pipe.autonomous).allowUpdateDelete,
+				},
+			};
+			if (options.json) console.log(JSON.stringify(data, null, 2));
+			else {
+				console.log(chalk.bold("\n  Ontology Pipeline Status\n"));
+				console.log(chalk.dim(`  Pipeline V2: ${data.enabled ? "enabled" : "disabled"}`));
+				console.log(chalk.dim(`  Graph:       ${data.graphEnabled ? "enabled" : "disabled"}`));
+				console.log(chalk.dim(`  Traversal:   ${asRecord(data.traversal).enabled ? "enabled" : "disabled"}`));
+				console.log(chalk.dim(`  Shadow:      ${data.shadowMode ? "on" : "off"}`));
+				console.log(chalk.dim(`  Frozen:      ${data.mutationsFrozen ? "yes" : "no"}`));
+				console.log(chalk.dim(`  Autonomous:  ${data.autonomousEnabled ? "enabled" : "disabled"}`));
+				console.log(chalk.dim(`  Update/del:  ${data.allowUpdateDelete ? "allowed" : "blocked"}`));
+				console.log();
+			}
+		});
+	pipeline
+		.command("config")
+		.description("Show graph-related Pipeline V2 config")
+		.option("--json", "Output as JSON")
+		.action(async (options) => {
+			if (!(await deps.ensureDaemonForSecrets())) return;
+			const status = asRecord(await apiGet(deps, "/api/status", new URLSearchParams()));
+			const pipe = asRecord(status.pipelineV2);
+			const data = {
+				pipelineV2: {
+					enabled: pipe.enabled,
+					paused: pipe.paused,
+					graph: pipe.graph,
+					traversal: pipe.traversal,
+					reranker: pipe.reranker,
+					dampening: pipe.dampening,
+					shadowMode: pipe.shadowMode,
+					mutationsFrozen: pipe.mutationsFrozen,
+					autonomous: pipe.autonomous,
+					extraction: pipe.extraction,
+					hints: pipe.hints,
+				},
+			};
+			console.log(JSON.stringify(data, null, 2));
+		});
+	pipeline
+		.command("explain")
+		.description("Explain what can currently mutate or shape the graph")
+		.option("--json", "Output as JSON")
+		.action(async (options) => {
+			if (!(await deps.ensureDaemonForSecrets())) return;
+			const status = asRecord(await apiGet(deps, "/api/status", new URLSearchParams()));
+			const pipe = asRecord(status.pipelineV2);
+			const graph = asRecord(pipe.graph);
+			const autonomous = asRecord(pipe.autonomous);
+			const data = {
+				directOperations:
+					"signet ontology entity/claim/aspect/link/stream commands mutate only through applied proposals.",
+				generatedChanges: "ontology extract/consolidate/dreaming skill paths are proposal-first by default.",
+				pipelineWrites:
+					pipe.enabled === true && pipe.shadowMode !== true && pipe.mutationsFrozen !== true
+						? "Pipeline V2 controlled writes may add memories; graph extraction writes depend on graph config."
+						: "Pipeline V2 direct writes are blocked by disabled, shadow, or frozen mode.",
+				graphExtractionWrites: graph.extractionWritesEnabled,
+				traversalShapesRecall: asRecord(pipe.traversal).enabled === true,
+				autonomousMaintenance: autonomous.enabled === true && autonomous.frozen !== true,
+				allowUpdateDelete: autonomous.allowUpdateDelete === true,
+			};
+			if (options.json) console.log(JSON.stringify(data, null, 2));
+			else {
+				console.log(chalk.bold("\n  What Can Shape The Knowledge Graph\n"));
+				for (const [key, value] of Object.entries(data)) console.log(`  ${chalk.dim(`${key}:`)} ${value}`);
+				console.log();
+			}
+		});
+
+	const config = ontology.command("config").description("Inspect ontology control-plane config");
+	config
+		.command("show")
+		.option("--json", "Output as JSON")
+		.action(async () => {
+			const data = {
+				operationsUsable: true,
+				operationSurface: {
+					applyFirst: true,
+					propose: true,
+					dryRun: true,
+					auditedThrough: "ontology_proposals",
+				},
+				policyFile: {
+					path: "$SIGNET_WORKSPACE/ontology/graph.yaml",
+					active: false,
+					note: "No separate graph.yaml policy gate is active; audited daemon operation tools are usable without it.",
+				},
+			};
+			console.log(JSON.stringify(data, null, 2));
+		});
+	config
+		.command("validate")
+		.option("--json", "Output as JSON")
+		.action(async () => {
+			const data = {
+				valid: true,
+				operationsUsable: true,
+				policyFileActive: false,
+				warnings: ["No external ontology graph.yaml policy gate is active."],
+			};
+			console.log(JSON.stringify(data, null, 2));
+		});
+	config
+		.command("explain")
+		.option("--json", "Output as JSON")
+		.action(async () => {
+			const data = {
+				hiddenMutationPaths: false,
+				explanation:
+					"Generated maintenance must use pending proposals or dry-run diffs; exact CLI/API operations can apply directly only through audited daemon operation endpoints.",
+			};
+			console.log(JSON.stringify(data, null, 2));
+		});
 
 	ontology
 		.command("repair")


### PR DESCRIPTION
## Summary

Adds an audited ontology control plane for daemon-backed graph mutations, plus a built-in dreaming ingestion skill that turns transcript/source evidence into ontology operation JSONL.

These tools are usable as soon as this PR merges: exact CLI/API ontology operations can apply directly through permission-checked daemon endpoints, and generated/dreaming ingestion can dry-run or write pending proposals for review.

## Changes

- Added migration 070 for ontology row status/archive metadata and first-class claim version fields.
- Added `/api/ontology/operations/apply` and `/api/ontology/operations/batch` with apply-first audit rows, `--dry-run`, `--propose`, atomic batch behavior, and dry-run line errors.
- Added operation handlers for entities, aspects, claims/versions, and links.
- Expanded `signet ontology` CLI with entity, claim, aspect, link, stream, pipeline, and config commands.
- Added default active-read filtering for archived graph rows while preserving history/version inspection.
- Added the built-in `dreaming` skill and docs for inventory, runbook, and implementation progress.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: built-in skills and docs

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [ ] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Migration 070 is additive. Existing ontology rows default to active state; existing attributes are backfilled to version 1 with `version_root_id = id`. Rollback would require removing the added status/archive/proposal/version columns and indexes.

Rust daemon parity is N/A for this slice because these changes extend the JS daemon ontology control-plane surface.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Focused validation run locally:

Checklist exception label is applied because repo-wide lint/typecheck remain blocked by unrelated issues listed below; focused validation for this PR slice is green.

- `bun scripts/spec-deps-check.ts` passed.
- `bun run build:core` passed.
- `cd platform/core && bun run typecheck` passed.
- `cd surfaces/cli && bun run build` passed.
- `cd platform/daemon && bun run build` passed with existing unrelated dashboard Svelte warnings.
- `bun test platform/core/src/migrations/migrations.test.ts surfaces/cli/src/commands/ontology.test.ts platform/daemon/src/ontology-proposals.test.ts platform/daemon/src/dreaming-skill.test.ts platform/daemon/src/knowledge-graph-list.test.ts` passed: 129 pass, 0 fail.
- Targeted Biome check on changed files passed.
- `git diff --check` passed.

Known unrelated repo-wide blockers observed locally:

- `bun run typecheck` fails in `@signet/desktop` because `src/desktop-updates.ts` cannot resolve `electron-updater`.
- `bun run lint` fails repo-wide on existing broad Biome formatting diagnostics across package/generated files.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

This PR does not add an external `$SIGNET_WORKSPACE/ontology/graph.yaml` policy gate. That does not make the tool surface read-only: the daemon-backed `signet ontology entity`, `claim`, `aspect`, `link`, and `stream apply` commands are live write tools after merge, with all successful mutations audited through `ontology_proposals`.

`goal.md` was left untracked and is not part of this PR.





