### PR TITLE
feat(ontology): add epistemic assertions

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -3702,6 +3702,8 @@ parameters match assertion creation plus `agent_id`. Omitting `predicate`
 preserves the old assertion predicate; pass a predicate only when the epistemic
 meaning is intentionally changing. Omitting source fields inherits source
 provenance from the old assertion, but replacement content is still required.
+Supersede keeps the old subject entity; use a new assertion when the subject
+entity changes.
 
 CLI equivalents:
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -3652,18 +3652,74 @@ Resolve evidence for an already-applied ontology link from stored dependency
 provenance. Links applied through proposals include the applying proposal id and
 copied proposal evidence before broader source fallback evidence.
 
+### GET /api/ontology/assertions
+
+List source-attributed epistemic assertions. Assertions record who claimed,
+believed, observed, decided, preferred, denied, or questioned something about an
+entity without promoting that statement into current ontology truth. Query
+parameters: `agent_id`, `entity`, `entity_id`, `predicate`, `status`,
+`speaker`, `source_kind`, `source_id`, `query`, `limit`, and `offset`.
+
+Valid predicates are `claims`, `believes`, `observed`, `decided`, `prefers`,
+`denies`, and `questions`. Valid statuses are `active`, `archived`,
+`superseded`, and `all` for list reads.
+
+```text
+/api/ontology/assertions?entity=Signet&predicate=believes&speaker=Nicholai
+```
+
+### GET /api/ontology/assertions/:id
+
+Return one epistemic assertion by id, scoped to the resolved `agent_id`.
+Returns `404` when the assertion does not exist in that agent scope.
+
+### POST /api/ontology/assertions
+
+Create a source-attributed epistemic assertion. Body parameters: `agent_id`,
+`entity` or `entity_id`, `predicate`, `content`, `speaker`, `asserted_at`,
+`confidence`, `evidence`, `source_kind`, `source_id`, `source_path`,
+`source_root`, `claim_attribute_id`, and `created_by`.
+
+Every assertion must include either structured `evidence` or source provenance
+fields. If `claim_attribute_id` is supplied, the referenced applied claim value
+must belong to the same agent and subject entity.
+
+### POST /api/ontology/assertions/:id/link-claim
+
+Link an existing assertion to an applied claim attribute. Body parameters:
+`agent_id` and `attribute_id`. The daemon rejects cross-agent and cross-entity
+links.
+
+### POST /api/ontology/assertions/:id/archive
+
+Archive an assertion without deleting evidence. Body parameters: `agent_id`,
+`actor`, and `reason`.
+
+### POST /api/ontology/assertions/:id/supersede
+
+Create a replacement assertion and mark the old assertion `superseded`. Body
+parameters match assertion creation plus `agent_id`. Omitting `predicate`
+preserves the old assertion predicate; pass a predicate only when the epistemic
+meaning is intentionally changing. Omitting source fields inherits source
+provenance from the old assertion, but replacement content is still required.
+
 ### POST /api/ontology/extract
 
-Extract candidate ontology proposals from an agent-scoped transcript or memory
-artifact. Body parameters: `from`, `agent_id`, `write_proposals`, `created_by`,
-`limit`, `use_provider`, `provider_timeout_ms`, and `provider_max_tokens`.
-`from` accepts refs such as `transcript:<id>`, `artifact:<source_path>`, or
-`source:<source_path>`. The route dry-runs by default and writes pending
-proposals only when `write_proposals` is true. When `use_provider` is true, the
-route uses the configured `memory_extraction` inference workload and falls back
-to deterministic extraction if no valid provider proposals are returned.
-Provider-returned `questions` are surfaced in the response for review; this
-route does not persist first-class question objects yet.
+Extract candidate ontology proposals and source-attributed assertions from an
+agent-scoped transcript or memory artifact. Body parameters: `from`, `agent_id`,
+`write_proposals`, `write_assertions`, `created_by`, `limit`, `use_provider`,
+`provider_timeout_ms`, and `provider_max_tokens`. `from` accepts refs such as
+`transcript:<id>`, `artifact:<source_path>`, or `source:<source_path>`.
+
+The route dry-runs by default. It writes pending proposals only when
+`write_proposals` is true and writes epistemic assertions only when
+`write_assertions` is true. If both write flags are set, proposal and assertion
+inserts share one transaction and roll back together on invalid extracted
+items. When `use_provider` is true, the route uses the configured
+`memory_extraction` inference workload and falls back to deterministic
+extraction if no valid provider proposals are returned. Provider-returned
+`questions` are surfaced in the response for review; this route does not persist
+first-class question objects yet.
 
 ### POST /api/ontology/consolidate
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -3703,6 +3703,18 @@ preserves the old assertion predicate; pass a predicate only when the epistemic
 meaning is intentionally changing. Omitting source fields inherits source
 provenance from the old assertion, but replacement content is still required.
 
+CLI equivalents:
+
+```bash
+signet ontology assertions --entity Signet --predicate believes --speaker Nicholai
+signet ontology assertion create --entity Signet --predicate believes --content "Signet should model attributed beliefs." --source-kind transcript
+signet ontology assertion show <assertion-id>
+signet ontology assertion link-claim <assertion-id> --attribute-id <claim-attribute-id>
+signet ontology assertion archive <assertion-id> --reason "superseded by newer evidence"
+signet ontology assertion supersede <assertion-id> --content "Updated attributed belief." --source-kind transcript
+signet ontology assertion import --file assertions.json
+```
+
 ### POST /api/ontology/extract
 
 Extract candidate ontology proposals and source-attributed assertions from an

--- a/docs/API.md
+++ b/docs/API.md
@@ -3682,13 +3682,13 @@ Create a source-attributed epistemic assertion. Body parameters: `agent_id`,
 
 Every assertion must include either structured `evidence` or source provenance
 fields. If `claim_attribute_id` is supplied, the referenced applied claim value
-must belong to the same agent and subject entity.
+must be active and belong to the same agent and subject entity.
 
 ### POST /api/ontology/assertions/:id/link-claim
 
 Link an existing assertion to an applied claim attribute. Body parameters:
 `agent_id` and `attribute_id`. The daemon rejects cross-agent and cross-entity
-links.
+links, and it only accepts active claim attribute rows.
 
 ### POST /api/ontology/assertions/:id/archive
 

--- a/docs/knowledge-graph-control-plane.md
+++ b/docs/knowledge-graph-control-plane.md
@@ -16,6 +16,7 @@ graph control plane. It is not a speculative product spec.
 | `entity_dependency_history` | 050 | hidden/internal | audit trigger | Trigger-backed history for dependency insert/update/delete. |
 | `task_meta` | 019, 054 | hidden/internal | task/procedural helpers | Agent-scoped task metadata, not part of this control-plane CLI slice. |
 | `ontology_proposals` | 067 | CLI/API | proposal loop and applied audit ledger | Pending, applied, rejected, and failed proposals. Direct operations create applied rows inside the same transaction as graph mutation. |
+| `epistemic_assertions` | 071 | CLI/API | source-attributed assertion ledger | Records who claimed, believed, observed, decided, preferred, denied, or questioned something, with confidence, evidence, source provenance, status, and optional link to an applied claim attribute. Assertions do not by themselves make the statement current ontology truth. |
 | `dreaming_state`, `dreaming_passes` | 055 | CLI/API via dream status/trigger | dreaming worker | Existing dreaming pass records/status. LLM dreaming remains proposal-first for ontology changes in this slice. |
 | `memory_artifacts` | 051, 061, 062 | API/internal | immutable source artifact records | Source-backed evidence for proposals and applied graph rows. Ontology updates must not rewrite these rows. |
 | `session_transcripts` | 040, 045, 047 | API/internal | immutable transcript/index records | Proposal extraction can cite transcripts; graph mutation must preserve transcript provenance. |
@@ -33,7 +34,13 @@ graph control plane. It is not a speculative product spec.
 | `GET /api/ontology/proposals/:id/evidence` | CLI/API | read-only | Covered by evidence tests. |
 | `GET /api/ontology/proposals/conflicts` | CLI/API | read-only | Covered by conflict tests. |
 | `POST /api/ontology/proposals/repair/duplicates` | CLI/API | dry-run or pending proposals | Covered by duplicate repair tests. |
-| `POST /api/ontology/extract` | CLI/API | dry-run or pending proposals | Proposal-first. Covered by extraction tests. |
+| `GET /api/ontology/assertions` | CLI/API | read-only | Lists source-attributed assertions by entity, predicate, speaker, source, status, or text query. Covered by assertion tests. |
+| `GET /api/ontology/assertions/:id` | CLI/API | read-only | Reads one same-agent assertion. Covered by assertion tests. |
+| `POST /api/ontology/assertions` | CLI/API | creates source-attributed assertion | Requires evidence or source provenance. Covered by assertion tests. |
+| `POST /api/ontology/assertions/:id/link-claim` | CLI/API | links assertion to applied claim value | Rejects cross-agent and cross-entity links. Covered by assertion tests. |
+| `POST /api/ontology/assertions/:id/archive` | CLI/API | archives assertion | Preserves assertion evidence. Covered by assertion tests. |
+| `POST /api/ontology/assertions/:id/supersede` | CLI/API | creates replacement assertion and supersedes old row | Omitting predicate preserves old predicate. Covered by assertion route tests. |
+| `POST /api/ontology/extract` | CLI/API | dry-run, pending proposals, and/or assertions | Proposal-first for ontology truth; assertion writes are source-attributed ledger writes. Proposal and assertion inserts are atomic when both write flags are set. Covered by extraction tests. |
 | `POST /api/ontology/consolidate` | CLI/API | dry-run or pending proposals | Proposal-first. Covered by consolidation tests. |
 | `POST /api/ontology/operations/apply` | CLI/API | dry-run, pending proposal, or applied proposal + graph mutation | New direct operation endpoint. Requires `modify`. Covered through operation engine and CLI tests. |
 | `POST /api/ontology/operations/batch` | CLI/API | atomic batch dry-run/propose/apply | Requires `modify`; rolls back on invalid operation. Covered by operation batch tests. |
@@ -55,6 +62,8 @@ graph control plane. It is not a speculative product spec.
 | `signet ontology apply <id>` | CLI | applies pending proposal | Preserves proposal history and agent scope. |
 | `signet ontology reject <id>` | CLI | rejects pending proposal | Preserves rejected proposal history. |
 | `signet ontology conflicts` | CLI | read-only | Lists pending claim conflicts. |
+| `signet ontology assertions` | CLI | read-only | Lists source-attributed assertions with filters for entity, predicate, speaker, source, status, query, and agent. |
+| `signet ontology assertion show/create/link-claim/archive/supersede/import` | CLI | assertion ledger writes | Creates and maintains attributed assertion rows. `supersede` preserves the old predicate when `--predicate` is omitted. `import` accepts a JSON array or `{ "assertions": [...] }`. |
 | `signet ontology entity create/rename/merge/archive` | CLI | direct operation endpoint | Supports `--dry-run`, `--propose`, `--json`, `--agent`, `--actor`, `--reason`, `--evidence-file`. |
 | `signet ontology claim set/versions/show/archive/restore` | CLI | operation endpoint for writes, read endpoints for versions | `set` creates version chains; `restore` only required for claim versions in this slice. |
 | `signet ontology aspect create/rename/archive` | CLI | direct operation endpoint | Uses same audited operation path. |
@@ -62,7 +71,7 @@ graph control plane. It is not a speculative product spec.
 | `signet ontology stream apply <path|- >` | CLI | atomic JSONL operation batch | Supports file and stdin, `--dry-run`, `--propose`, `--json`, `--agent`, `--actor`. |
 | `signet ontology pipeline status/config/explain` | CLI | graph-state inspection | Explains Pipeline V2 graph flags and write gates. |
 | `signet ontology config show/validate/explain` | CLI | control-plane inspection | Confirms audited operation tools are usable and no external `graph.yaml` policy gate is active in this slice. |
-| `signet ontology extract` | CLI | dry-run/pending proposals | Existing proposal-first extraction surface. |
+| `signet ontology extract` | CLI | dry-run/pending proposals/assertions | `--write-proposals` persists pending proposal rows; `--write-assertions` persists source-attributed assertion rows. |
 | `signet ontology consolidate` | CLI | dry-run/pending proposals | Existing proposal-first consolidation surface. |
 | `signet dream status/trigger` | CLI | existing dream worker | Existing pass status and trigger behavior. |
 

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -20,6 +20,8 @@ export {
 	TASK_STATUSES,
 	ONTOLOGY_PROPOSAL_STATUSES,
 	ONTOLOGY_PROPOSAL_OPERATIONS,
+	EPISTEMIC_ASSERTION_PREDICATES,
+	EPISTEMIC_ASSERTION_STATUSES,
 	TASK_HARNESSES,
 	DEFAULT_PROVIDER_RATE_LIMIT,
 } from "./types";
@@ -77,6 +79,9 @@ export type {
 	OntologyProposalStatus,
 	OntologyProposalOperation,
 	OntologyProposal,
+	EpistemicAssertionPredicate,
+	EpistemicAssertionStatus,
+	EpistemicAssertion,
 	TaskHarness,
 	EntityAspect,
 	EntityAttribute,

--- a/platform/core/src/migrations/071-epistemic-assertions.ts
+++ b/platform/core/src/migrations/071-epistemic-assertions.ts
@@ -1,0 +1,51 @@
+import type { MigrationDb } from "./index";
+
+/**
+ * Migration 071: Epistemic assertions.
+ *
+ * Records source-attributed assertions separately from current ontology truth.
+ * Entity attributes remain the claim-value layer; assertions preserve who said
+ * or believed what, when, and with what evidence.
+ */
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS epistemic_assertions (
+			id TEXT PRIMARY KEY,
+			agent_id TEXT NOT NULL DEFAULT 'default',
+			subject_entity_id TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+			claim_attribute_id TEXT REFERENCES entity_attributes(id) ON DELETE SET NULL,
+			predicate TEXT NOT NULL CHECK (
+				predicate IN ('claims', 'believes', 'observed', 'decided', 'prefers', 'denies', 'questions')
+			),
+			content TEXT NOT NULL,
+			normalized_content TEXT NOT NULL,
+			speaker TEXT,
+			asserted_at TEXT NOT NULL,
+			confidence REAL NOT NULL DEFAULT 0.0 CHECK (confidence >= 0.0 AND confidence <= 1.0),
+			evidence TEXT NOT NULL DEFAULT '[]',
+			source_kind TEXT,
+			source_id TEXT,
+			source_path TEXT,
+			source_root TEXT,
+			status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'archived', 'superseded')),
+			supersedes_assertion_id TEXT REFERENCES epistemic_assertions(id) ON DELETE SET NULL,
+			archived_at TEXT,
+			archived_by TEXT,
+			archive_reason TEXT,
+			created_by TEXT NOT NULL DEFAULT 'operator',
+			created_at TEXT NOT NULL DEFAULT (datetime('now')),
+			updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_epistemic_assertions_agent_entity
+			ON epistemic_assertions(agent_id, subject_entity_id, status, asserted_at DESC);
+		CREATE INDEX IF NOT EXISTS idx_epistemic_assertions_agent_speaker
+			ON epistemic_assertions(agent_id, speaker, asserted_at DESC);
+		CREATE INDEX IF NOT EXISTS idx_epistemic_assertions_agent_predicate
+			ON epistemic_assertions(agent_id, predicate, status, asserted_at DESC);
+		CREATE INDEX IF NOT EXISTS idx_epistemic_assertions_agent_source
+			ON epistemic_assertions(agent_id, source_kind, source_id);
+		CREATE INDEX IF NOT EXISTS idx_epistemic_assertions_claim
+			ON epistemic_assertions(agent_id, claim_attribute_id);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -76,6 +76,7 @@ import { up as ontologyProposals } from "./067-ontology-proposals";
 import { up as dailyReflections } from "./068-daily-reflections";
 import { up as dailyReflectionsMultipleInsights } from "./069-daily-reflections-multiple-insights";
 import { up as ontologyControlPlaneState } from "./070-ontology-control-plane-state";
+import { up as epistemicAssertions } from "./071-epistemic-assertions";
 
 // -- Public interface consumed by Database.init() --
 
@@ -661,6 +662,14 @@ export const MIGRATIONS: readonly Migration[] = [
 				{ table: "entity_attributes", column: "previous_attribute_id" },
 				{ table: "entity_dependencies", column: "status" },
 			],
+		},
+	},
+	{
+		version: 71,
+		name: "epistemic-assertions",
+		up: epistemicAssertions,
+		artifacts: {
+			tables: ["epistemic_assertions"],
 		},
 	},
 ];

--- a/platform/core/src/types.ts
+++ b/platform/core/src/types.ts
@@ -829,6 +829,20 @@ export type TaskStatus = (typeof TASK_STATUSES)[number];
 export const ONTOLOGY_PROPOSAL_STATUSES = ["pending", "applied", "rejected", "failed"] as const;
 export type OntologyProposalStatus = (typeof ONTOLOGY_PROPOSAL_STATUSES)[number];
 
+export const EPISTEMIC_ASSERTION_PREDICATES = [
+	"claims",
+	"believes",
+	"observed",
+	"decided",
+	"prefers",
+	"denies",
+	"questions",
+] as const;
+export type EpistemicAssertionPredicate = (typeof EPISTEMIC_ASSERTION_PREDICATES)[number];
+
+export const EPISTEMIC_ASSERTION_STATUSES = ["active", "archived", "superseded"] as const;
+export type EpistemicAssertionStatus = (typeof EPISTEMIC_ASSERTION_STATUSES)[number];
+
 export const ONTOLOGY_PROPOSAL_OPERATIONS = [
 	"create_entity",
 	"add_claim_value",
@@ -943,6 +957,33 @@ export interface EntityDependency {
 	readonly sourceRoot: string | null;
 	readonly proposalId: string | null;
 	readonly proposalEvidence: readonly unknown[];
+	readonly createdAt: string;
+	readonly updatedAt: string;
+}
+
+export interface EpistemicAssertion {
+	readonly id: string;
+	readonly agentId: string;
+	readonly subjectEntityId: string;
+	readonly subjectEntityName: string | null;
+	readonly claimAttributeId: string | null;
+	readonly predicate: EpistemicAssertionPredicate;
+	readonly content: string;
+	readonly normalizedContent: string;
+	readonly speaker: string | null;
+	readonly assertedAt: string;
+	readonly confidence: number;
+	readonly evidence: readonly unknown[];
+	readonly sourceKind: string | null;
+	readonly sourceId: string | null;
+	readonly sourcePath: string | null;
+	readonly sourceRoot: string | null;
+	readonly status: EpistemicAssertionStatus;
+	readonly supersedesAssertionId: string | null;
+	readonly archivedAt: string | null;
+	readonly archivedBy: string | null;
+	readonly archiveReason: string | null;
+	readonly createdBy: string;
 	readonly createdAt: string;
 	readonly updatedAt: string;
 }

--- a/platform/daemon/src/ontology-assertions.test.ts
+++ b/platform/daemon/src/ontology-assertions.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import {
+	OntologyAssertionError,
+	archiveEpistemicAssertion,
+	createEpistemicAssertion,
+	getEpistemicAssertion,
+	linkEpistemicAssertionClaim,
+	listEpistemicAssertions,
+	supersedeEpistemicAssertion,
+} from "./ontology-assertions";
+
+describe("epistemic assertions", () => {
+	let dir = "";
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "signet-ontology-assertions-"));
+		mkdirSync(join(dir, "memory"), { recursive: true });
+		initDbAccessor(join(dir, "memory", "memories.db"));
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO entities
+				 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+				 VALUES ('entity-signet', 'Signet', 'signet', 'project', 'ant', 1, ?, ?)`,
+			).run("2026-05-16T00:00:00.000Z", "2026-05-16T00:00:00.000Z");
+			db.prepare(
+				`INSERT INTO entities
+				 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+				 VALUES ('entity-other', 'Other', 'other', 'project', 'dot', 1, ?, ?)`,
+			).run("2026-05-16T00:00:00.000Z", "2026-05-16T00:00:00.000Z");
+			db.prepare(
+				`INSERT INTO entity_aspects
+				 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+				 VALUES ('aspect-signet', 'entity-signet', 'ant', 'architecture', 'architecture', 0.7, ?, ?)`,
+			).run("2026-05-16T00:00:00.000Z", "2026-05-16T00:00:00.000Z");
+			db.prepare(
+				`INSERT INTO entity_attributes
+				 (id, aspect_id, agent_id, kind, content, normalized_content, confidence, importance,
+				  status, group_key, claim_key, created_at, updated_at)
+				 VALUES ('attr-signet', 'aspect-signet', 'ant', 'attribute', 'Signet has epistemic assertions.',
+				  'signet has epistemic assertions.', 0.9, 0.8, 'active', 'ontology', 'epistemic_assertions', ?, ?)`,
+			).run("2026-05-16T00:00:00.000Z", "2026-05-16T00:00:00.000Z");
+		});
+	});
+
+	afterEach(() => {
+		closeDbAccessor();
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("creates, lists, and reads a source-attributed assertion", () => {
+		const assertion = createEpistemicAssertion(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Signet",
+			predicate: "believes",
+			content: "Signet should model who believes what over time.",
+			speaker: "Nicholai",
+			assertedAt: "2026-05-16T19:36:00.000Z",
+			confidence: 0.91,
+			evidence: [{ quote: "who believes what" }],
+			sourceKind: "transcript",
+			sourceId: "session-1",
+			createdBy: "test",
+		});
+
+		expect(assertion.subjectEntityName).toBe("Signet");
+		expect(assertion.predicate).toBe("believes");
+		expect(assertion.confidence).toBeCloseTo(0.91);
+		expect(assertion.evidence).toEqual([{ quote: "who believes what" }]);
+
+		const list = listEpistemicAssertions(getDbAccessor(), { agentId: "ant", speaker: "Nicholai" });
+		expect(list.items).toHaveLength(1);
+		expect(list.items[0]?.id).toBe(assertion.id);
+		expect(getEpistemicAssertion(getDbAccessor(), { agentId: "ant", id: assertion.id })?.content).toContain(
+			"believes what",
+		);
+		expect(listEpistemicAssertions(getDbAccessor(), { agentId: "dot", status: "all" }).items).toHaveLength(0);
+	});
+
+	it("links assertions to same-agent claim attributes and rejects cross-entity links", () => {
+		const assertion = createEpistemicAssertion(getDbAccessor(), {
+			agentId: "ant",
+			entityId: "entity-signet",
+			predicate: "claims",
+			content: "Signet has epistemic assertions.",
+			evidence: [{ source_kind: "test", quote: "assertion" }],
+		});
+
+		const linked = linkEpistemicAssertionClaim(getDbAccessor(), {
+			agentId: "ant",
+			id: assertion.id,
+			attributeId: "attr-signet",
+		});
+		expect(linked.claimAttributeId).toBe("attr-signet");
+
+		expect(() =>
+			linkEpistemicAssertionClaim(getDbAccessor(), {
+				agentId: "dot",
+				id: assertion.id,
+				attributeId: "attr-signet",
+			}),
+		).toThrow(OntologyAssertionError);
+	});
+
+	it("archives and supersedes assertions without deleting evidence", () => {
+		const first = createEpistemicAssertion(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Signet",
+			predicate: "claims",
+			content: "Signet only needs similar text search.",
+			evidence: [{ quote: "similar text" }],
+			sourceKind: "transcript",
+		});
+
+		const next = supersedeEpistemicAssertion(getDbAccessor(), {
+			agentId: "ant",
+			oldAssertionId: first.id,
+			entity: "Signet",
+			predicate: "claims",
+			content: "Signet needs attributed assertions in addition to similarity.",
+			evidence: [{ quote: "who believes what" }],
+			sourceKind: "transcript",
+		});
+
+		expect(next.supersedesAssertionId).toBe(first.id);
+		expect(getEpistemicAssertion(getDbAccessor(), { agentId: "ant", id: first.id })?.status).toBe("superseded");
+
+		const archived = archiveEpistemicAssertion(getDbAccessor(), {
+			agentId: "ant",
+			id: next.id,
+			actor: "test",
+			reason: "replaced by claim",
+		});
+		expect(archived.status).toBe("archived");
+		expect(archived.evidence).toEqual([{ quote: "who believes what" }]);
+	});
+
+	it("rejects invalid assertions before writing", () => {
+		expect(() =>
+			createEpistemicAssertion(getDbAccessor(), {
+				agentId: "ant",
+				entity: "Signet",
+				predicate: "maybe",
+				content: "Invalid predicate.",
+				evidence: [{ quote: "invalid" }],
+			}),
+		).toThrow(OntologyAssertionError);
+
+		expect(() =>
+			createEpistemicAssertion(getDbAccessor(), {
+				agentId: "ant",
+				entity: "Signet",
+				predicate: "claims",
+				content: "No provenance.",
+			}),
+		).toThrow(OntologyAssertionError);
+	});
+});

--- a/platform/daemon/src/ontology-assertions.test.ts
+++ b/platform/daemon/src/ontology-assertions.test.ts
@@ -34,6 +34,11 @@ describe("epistemic assertions", () => {
 				 VALUES ('entity-other', 'Other', 'other', 'project', 'dot', 1, ?, ?)`,
 			).run("2026-05-16T00:00:00.000Z", "2026-05-16T00:00:00.000Z");
 			db.prepare(
+				`INSERT INTO entities
+				 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+				 VALUES ('entity-rival', 'Rival', 'rival', 'project', 'ant', 1, ?, ?)`,
+			).run("2026-05-16T00:00:00.000Z", "2026-05-16T00:00:00.000Z");
+			db.prepare(
 				`INSERT INTO entity_aspects
 				 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
 				 VALUES ('aspect-signet', 'entity-signet', 'ant', 'architecture', 'architecture', 0.7, ?, ?)`,
@@ -183,6 +188,31 @@ describe("epistemic assertions", () => {
 		});
 		expect(archived.status).toBe("archived");
 		expect(archived.evidence).toEqual([{ quote: "who believes what" }]);
+	});
+
+	it("rejects supersede requests that change the subject entity", () => {
+		const first = createEpistemicAssertion(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Signet",
+			predicate: "believes",
+			content: "Signet should keep assertion history entity-scoped.",
+			evidence: [{ quote: "entity-scoped history" }],
+			sourceKind: "transcript",
+		});
+
+		expect(() =>
+			supersedeEpistemicAssertion(getDbAccessor(), {
+				agentId: "ant",
+				oldAssertionId: first.id,
+				entityId: "entity-rival",
+				predicate: "believes",
+				content: "Rival should not enter Signet's assertion history.",
+				evidence: [{ quote: "different entity" }],
+				sourceKind: "transcript",
+			}),
+		).toThrow(OntologyAssertionError);
+
+		expect(getEpistemicAssertion(getDbAccessor(), { agentId: "ant", id: first.id })?.status).toBe("active");
 	});
 
 	it("preserves the old predicate when route supersede omits a replacement predicate", async () => {

--- a/platform/daemon/src/ontology-assertions.test.ts
+++ b/platform/daemon/src/ontology-assertions.test.ts
@@ -45,6 +45,20 @@ describe("epistemic assertions", () => {
 				 VALUES ('attr-signet', 'aspect-signet', 'ant', 'attribute', 'Signet has epistemic assertions.',
 				  'signet has epistemic assertions.', 0.9, 0.8, 'active', 'ontology', 'epistemic_assertions', ?, ?)`,
 			).run("2026-05-16T00:00:00.000Z", "2026-05-16T00:00:00.000Z");
+			db.prepare(
+				`INSERT INTO entity_attributes
+				 (id, aspect_id, agent_id, kind, content, normalized_content, confidence, importance,
+				  status, group_key, claim_key, created_at, updated_at)
+				 VALUES ('attr-superseded', 'aspect-signet', 'ant', 'attribute', 'Old assertion claim.',
+				  'old assertion claim.', 0.5, 0.4, 'superseded', 'ontology', 'epistemic_assertions', ?, ?),
+				 ('attr-deleted', 'aspect-signet', 'ant', 'attribute', 'Deleted assertion claim.',
+				  'deleted assertion claim.', 0.5, 0.4, 'deleted', 'ontology', 'epistemic_assertions', ?, ?)`,
+			).run(
+				"2026-05-16T00:00:00.000Z",
+				"2026-05-16T00:00:00.000Z",
+				"2026-05-16T00:00:00.000Z",
+				"2026-05-16T00:00:00.000Z",
+			);
 		});
 	});
 
@@ -103,6 +117,37 @@ describe("epistemic assertions", () => {
 				agentId: "dot",
 				id: assertion.id,
 				attributeId: "attr-signet",
+			}),
+		).toThrow(OntologyAssertionError);
+	});
+
+	it("rejects links to inactive claim attribute versions", () => {
+		const assertion = createEpistemicAssertion(getDbAccessor(), {
+			agentId: "ant",
+			entityId: "entity-signet",
+			predicate: "claims",
+			content: "Signet has active assertion claims.",
+			evidence: [{ source_kind: "test", quote: "active claim" }],
+		});
+
+		for (const attributeId of ["attr-superseded", "attr-deleted"]) {
+			expect(() =>
+				linkEpistemicAssertionClaim(getDbAccessor(), {
+					agentId: "ant",
+					id: assertion.id,
+					attributeId,
+				}),
+			).toThrow(OntologyAssertionError);
+		}
+
+		expect(() =>
+			createEpistemicAssertion(getDbAccessor(), {
+				agentId: "ant",
+				entityId: "entity-signet",
+				predicate: "claims",
+				content: "Signet should not point new assertions at inactive claim rows.",
+				evidence: [{ source_kind: "test", quote: "inactive claim" }],
+				claimAttributeId: "attr-superseded",
 			}),
 		).toThrow(OntologyAssertionError);
 	});

--- a/platform/daemon/src/ontology-assertions.test.ts
+++ b/platform/daemon/src/ontology-assertions.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Hono } from "hono";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import {
 	OntologyAssertionError,
@@ -12,6 +13,7 @@ import {
 	listEpistemicAssertions,
 	supersedeEpistemicAssertion,
 } from "./ontology-assertions";
+import { registerOntologyRoutes } from "./routes/ontology-routes";
 
 describe("epistemic assertions", () => {
 	let dir = "";
@@ -136,6 +138,33 @@ describe("epistemic assertions", () => {
 		});
 		expect(archived.status).toBe("archived");
 		expect(archived.evidence).toEqual([{ quote: "who believes what" }]);
+	});
+
+	it("preserves the old predicate when route supersede omits a replacement predicate", async () => {
+		const first = createEpistemicAssertion(getDbAccessor(), {
+			agentId: "ant",
+			entity: "Signet",
+			predicate: "believes",
+			content: "Signet should preserve epistemic predicates.",
+			evidence: [{ quote: "preserve predicates" }],
+			sourceKind: "transcript",
+		});
+		const app = new Hono();
+		registerOntologyRoutes(app);
+
+		const res = await app.request(`/api/ontology/assertions/${first.id}/supersede?agent_id=ant`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				content: "Signet still preserves epistemic predicates.",
+				evidence: [{ quote: "still preserves" }],
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const next = (await res.json()) as { readonly predicate?: string; readonly supersedesAssertionId?: string };
+		expect(next.predicate).toBe("believes");
+		expect(next.supersedesAssertionId).toBe(first.id);
 	});
 
 	it("rejects invalid assertions before writing", () => {

--- a/platform/daemon/src/ontology-assertions.ts
+++ b/platform/daemon/src/ontology-assertions.ts
@@ -186,7 +186,7 @@ function readClaimAttributeEntityId(db: ReadDb | WriteDb, agentId: string, attri
 			`SELECT asp.entity_id
 			 FROM entity_attributes attr
 			 JOIN entity_aspects asp ON asp.id = attr.aspect_id AND asp.agent_id = attr.agent_id
-			 WHERE attr.id = ? AND attr.agent_id = ?`,
+			 WHERE attr.id = ? AND attr.agent_id = ? AND attr.status = 'active'`,
 		)
 		.get(attributeId, agentId) as { entity_id: string } | undefined;
 	return row?.entity_id ?? null;

--- a/platform/daemon/src/ontology-assertions.ts
+++ b/platform/daemon/src/ontology-assertions.ts
@@ -432,9 +432,15 @@ export function supersedeEpistemicAssertion(
 			)
 			.get(input.oldAssertionId, input.agentId) as Record<string, unknown> | undefined;
 		if (!old) throw new OntologyAssertionError("assertion was not found", 404);
+		if (trim(input.entityId) !== null || trim(input.entity) !== null) {
+			const subject = resolveSubject(accessor, db, input);
+			if (subject.id !== old.subject_entity_id) {
+				throw new OntologyAssertionError("supersede cannot change assertion subject entity", 409);
+			}
+		}
 		const next = insertAssertion(accessor, db, {
 			...input,
-			entityId: input.entityId ?? (old.subject_entity_id as string),
+			entityId: old.subject_entity_id as string,
 			predicate: input.predicate || (old.predicate as string),
 			speaker: input.speaker ?? (typeof old.speaker === "string" ? old.speaker : null),
 			sourceKind: input.sourceKind ?? (typeof old.source_kind === "string" ? old.source_kind : null),

--- a/platform/daemon/src/ontology-assertions.ts
+++ b/platform/daemon/src/ontology-assertions.ts
@@ -1,0 +1,453 @@
+import type { EpistemicAssertion, EpistemicAssertionPredicate, EpistemicAssertionStatus } from "@signet/core";
+import type { DbAccessor, ReadDb, WriteDb } from "./db-accessor";
+import { resolveNamedEntity } from "./knowledge-graph";
+
+export class OntologyAssertionError extends Error {
+	constructor(
+		message: string,
+		readonly status: 400 | 404 | 409,
+	) {
+		super(message);
+		this.name = "OntologyAssertionError";
+	}
+}
+
+export interface CreateEpistemicAssertionInput {
+	readonly agentId: string;
+	readonly entity?: string;
+	readonly entityId?: string;
+	readonly predicate: string;
+	readonly content: string;
+	readonly speaker?: string | null;
+	readonly assertedAt?: string | null;
+	readonly confidence?: number;
+	readonly evidence?: readonly unknown[];
+	readonly sourceKind?: string | null;
+	readonly sourceId?: string | null;
+	readonly sourcePath?: string | null;
+	readonly sourceRoot?: string | null;
+	readonly claimAttributeId?: string | null;
+	readonly supersedesAssertionId?: string | null;
+	readonly createdBy?: string | null;
+}
+
+export interface ListEpistemicAssertionsParams {
+	readonly agentId: string;
+	readonly entity?: string;
+	readonly entityId?: string;
+	readonly predicate?: EpistemicAssertionPredicate;
+	readonly status?: EpistemicAssertionStatus | "all";
+	readonly speaker?: string;
+	readonly sourceKind?: string;
+	readonly sourceId?: string;
+	readonly query?: string;
+	readonly limit?: number;
+	readonly offset?: number;
+}
+
+export interface ListEpistemicAssertionsResult {
+	readonly items: readonly EpistemicAssertion[];
+	readonly count: number;
+}
+
+const assertionPredicates = ["claims", "believes", "observed", "decided", "prefers", "denies", "questions"] as const;
+const assertionStatuses = ["active", "archived", "superseded"] as const;
+const predicates = new Set<string>(assertionPredicates);
+const statuses = new Set<string>(assertionStatuses);
+
+function trim(value: string | null | undefined): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeContent(value: string): string {
+	return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function clamp01(value: number | undefined): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) return 0.7;
+	return Math.min(Math.max(value, 0), 1);
+}
+
+function parseJsonArray(value: unknown): readonly unknown[] {
+	if (typeof value !== "string") return [];
+	try {
+		const parsed: unknown = JSON.parse(value);
+		return Array.isArray(parsed) ? parsed : [];
+	} catch {
+		return [];
+	}
+}
+
+function rowToAssertion(row: Record<string, unknown>): EpistemicAssertion {
+	return {
+		id: row.id as string,
+		agentId: row.agent_id as string,
+		subjectEntityId: row.subject_entity_id as string,
+		subjectEntityName: typeof row.subject_entity_name === "string" ? row.subject_entity_name : null,
+		claimAttributeId: typeof row.claim_attribute_id === "string" ? row.claim_attribute_id : null,
+		predicate: row.predicate as EpistemicAssertionPredicate,
+		content: row.content as string,
+		normalizedContent: row.normalized_content as string,
+		speaker: typeof row.speaker === "string" ? row.speaker : null,
+		assertedAt: row.asserted_at as string,
+		confidence: typeof row.confidence === "number" ? row.confidence : 0,
+		evidence: parseJsonArray(row.evidence),
+		sourceKind: typeof row.source_kind === "string" ? row.source_kind : null,
+		sourceId: typeof row.source_id === "string" ? row.source_id : null,
+		sourcePath: typeof row.source_path === "string" ? row.source_path : null,
+		sourceRoot: typeof row.source_root === "string" ? row.source_root : null,
+		status: row.status as EpistemicAssertionStatus,
+		supersedesAssertionId: typeof row.supersedes_assertion_id === "string" ? row.supersedes_assertion_id : null,
+		archivedAt: typeof row.archived_at === "string" ? row.archived_at : null,
+		archivedBy: typeof row.archived_by === "string" ? row.archived_by : null,
+		archiveReason: typeof row.archive_reason === "string" ? row.archive_reason : null,
+		createdBy: row.created_by as string,
+		createdAt: row.created_at as string,
+		updatedAt: row.updated_at as string,
+	};
+}
+
+function parsePredicate(value: string): EpistemicAssertionPredicate {
+	const normalized = trim(value);
+	if (normalized !== null && predicates.has(normalized)) return normalized as EpistemicAssertionPredicate;
+	throw new OntologyAssertionError("predicate is invalid", 400);
+}
+
+export function parseEpistemicAssertionPredicate(value: string | undefined): EpistemicAssertionPredicate | undefined {
+	const normalized = trim(value);
+	return normalized !== null && predicates.has(normalized) ? (normalized as EpistemicAssertionPredicate) : undefined;
+}
+
+export function parseEpistemicAssertionStatus(value: string | undefined): EpistemicAssertionStatus | "all" | undefined {
+	const normalized = trim(value);
+	if (normalized === "all") return "all";
+	return normalized !== null && statuses.has(normalized) ? (normalized as EpistemicAssertionStatus) : undefined;
+}
+
+function parseAssertedAt(value: string | null | undefined): string {
+	const raw = trim(value) ?? new Date().toISOString();
+	const ms = Date.parse(raw);
+	if (!Number.isFinite(ms)) throw new OntologyAssertionError("asserted_at is invalid", 400);
+	return new Date(ms).toISOString();
+}
+
+function readEntityById(
+	db: ReadDb | WriteDb,
+	agentId: string,
+	id: string,
+): { readonly id: string; readonly name: string } | null {
+	const row = db
+		.prepare(
+			`SELECT id, name
+			 FROM entities
+			 WHERE id = ? AND agent_id = ? AND COALESCE(status, 'active') = 'active'`,
+		)
+		.get(id, agentId) as { id: string; name: string } | undefined;
+	return row ?? null;
+}
+
+function resolveSubject(
+	accessor: DbAccessor,
+	db: ReadDb | WriteDb,
+	input: Pick<CreateEpistemicAssertionInput, "agentId" | "entity" | "entityId">,
+): { readonly id: string; readonly name: string } {
+	const entityId = trim(input.entityId);
+	if (entityId !== null) {
+		const byId = readEntityById(db, input.agentId, entityId);
+		if (byId === null) throw new OntologyAssertionError("entity_id was not found", 404);
+		return byId;
+	}
+	const entity = trim(input.entity);
+	if (entity === null) throw new OntologyAssertionError("entity or entity_id is required", 400);
+	const resolved = resolveNamedEntity(accessor, { agentId: input.agentId, name: entity });
+	if (resolved === null) throw new OntologyAssertionError("entity was not found", 404);
+	return { id: resolved.id, name: resolved.name };
+}
+
+function validateEvidence(input: CreateEpistemicAssertionInput): readonly unknown[] {
+	const evidence = input.evidence ?? [];
+	if (
+		evidence.length === 0 &&
+		trim(input.sourceKind) === null &&
+		trim(input.sourceId) === null &&
+		trim(input.sourcePath) === null &&
+		trim(input.sourceRoot) === null
+	) {
+		throw new OntologyAssertionError("evidence or source provenance is required", 400);
+	}
+	return evidence;
+}
+
+function readClaimAttributeEntityId(db: ReadDb | WriteDb, agentId: string, attributeId: string): string | null {
+	const row = db
+		.prepare(
+			`SELECT asp.entity_id
+			 FROM entity_attributes attr
+			 JOIN entity_aspects asp ON asp.id = attr.aspect_id AND asp.agent_id = attr.agent_id
+			 WHERE attr.id = ? AND attr.agent_id = ?`,
+		)
+		.get(attributeId, agentId) as { entity_id: string } | undefined;
+	return row?.entity_id ?? null;
+}
+
+function validateClaimAttribute(
+	db: ReadDb | WriteDb,
+	agentId: string,
+	subjectEntityId: string,
+	attributeId: string | null,
+): string | null {
+	if (attributeId === null) return null;
+	const entityId = readClaimAttributeEntityId(db, agentId, attributeId);
+	if (entityId === null) throw new OntologyAssertionError("claim attribute was not found", 404);
+	if (entityId !== subjectEntityId) {
+		throw new OntologyAssertionError("claim attribute belongs to a different entity", 409);
+	}
+	return attributeId;
+}
+
+function insertAssertion(accessor: DbAccessor, db: WriteDb, input: CreateEpistemicAssertionInput): EpistemicAssertion {
+	const subject = resolveSubject(accessor, db, input);
+	const content = trim(input.content);
+	if (content === null) throw new OntologyAssertionError("content is required", 400);
+	const predicate = parsePredicate(input.predicate);
+	const evidence = validateEvidence(input);
+	const assertedAt = parseAssertedAt(input.assertedAt);
+	const claimAttributeId = validateClaimAttribute(db, input.agentId, subject.id, trim(input.claimAttributeId));
+	const supersedesAssertionId = trim(input.supersedesAssertionId);
+	if (supersedesAssertionId !== null) {
+		const existing = db
+			.prepare("SELECT id FROM epistemic_assertions WHERE id = ? AND agent_id = ?")
+			.get(supersedesAssertionId, input.agentId) as { id: string } | undefined;
+		if (!existing) throw new OntologyAssertionError("superseded assertion was not found", 404);
+	}
+
+	const now = new Date().toISOString();
+	const id = crypto.randomUUID();
+	db.prepare(
+		`INSERT INTO epistemic_assertions
+		 (id, agent_id, subject_entity_id, claim_attribute_id, predicate,
+		  content, normalized_content, speaker, asserted_at, confidence, evidence,
+		  source_kind, source_id, source_path, source_root, status,
+		  supersedes_assertion_id, created_by, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?, ?)`,
+	).run(
+		id,
+		input.agentId,
+		subject.id,
+		claimAttributeId,
+		predicate,
+		content,
+		normalizeContent(content),
+		trim(input.speaker),
+		assertedAt,
+		clamp01(input.confidence),
+		JSON.stringify(evidence),
+		trim(input.sourceKind),
+		trim(input.sourceId),
+		trim(input.sourcePath),
+		trim(input.sourceRoot),
+		supersedesAssertionId,
+		trim(input.createdBy) ?? "operator",
+		now,
+		now,
+	);
+
+	const row = db
+		.prepare(
+			`SELECT a.*, e.name AS subject_entity_name
+			 FROM epistemic_assertions a
+			 JOIN entities e ON e.id = a.subject_entity_id AND e.agent_id = a.agent_id
+			 WHERE a.id = ? AND a.agent_id = ?`,
+		)
+		.get(id, input.agentId) as Record<string, unknown>;
+	return rowToAssertion(row);
+}
+
+export function createEpistemicAssertion(
+	accessor: DbAccessor,
+	input: CreateEpistemicAssertionInput,
+): EpistemicAssertion {
+	return accessor.withWriteTx((db) => insertAssertion(accessor, db, input));
+}
+
+export function createEpistemicAssertionsInTx(
+	accessor: DbAccessor,
+	db: WriteDb,
+	inputs: readonly CreateEpistemicAssertionInput[],
+): readonly EpistemicAssertion[] {
+	if (inputs.length > 500) throw new OntologyAssertionError("cannot create more than 500 assertions at once", 400);
+	return inputs.map((input) => insertAssertion(accessor, db, input));
+}
+
+export function listEpistemicAssertions(
+	accessor: DbAccessor,
+	params: ListEpistemicAssertionsParams,
+): ListEpistemicAssertionsResult {
+	const limit = Math.min(Math.max(params.limit ?? 50, 1), 200);
+	const offset = Math.max(params.offset ?? 0, 0);
+	return accessor.withReadDb((db) => {
+		const where = ["a.agent_id = ?"];
+		const args: unknown[] = [params.agentId];
+		const entityId = trim(params.entityId);
+		if (entityId !== null) {
+			where.push("a.subject_entity_id = ?");
+			args.push(entityId);
+		} else if (trim(params.entity) !== null) {
+			const resolved = resolveNamedEntity(accessor, { agentId: params.agentId, name: params.entity ?? "" });
+			if (resolved === null) return { items: [], count: 0 };
+			where.push("a.subject_entity_id = ?");
+			args.push(resolved.id);
+		}
+		if (params.status !== "all") {
+			where.push("a.status = ?");
+			args.push(params.status ?? "active");
+		}
+		if (params.predicate) {
+			where.push("a.predicate = ?");
+			args.push(params.predicate);
+		}
+		if (params.speaker) {
+			where.push("a.speaker = ?");
+			args.push(params.speaker);
+		}
+		if (params.sourceKind) {
+			where.push("a.source_kind = ?");
+			args.push(params.sourceKind);
+		}
+		if (params.sourceId) {
+			where.push("a.source_id = ?");
+			args.push(params.sourceId);
+		}
+		if (params.query) {
+			where.push("a.normalized_content LIKE ?");
+			args.push(`%${normalizeContent(params.query)}%`);
+		}
+		const clause = where.join(" AND ");
+		const rows = db
+			.prepare(
+				`SELECT a.*, e.name AS subject_entity_name
+				 FROM epistemic_assertions a
+				 JOIN entities e ON e.id = a.subject_entity_id AND e.agent_id = a.agent_id
+				 WHERE ${clause}
+				 ORDER BY a.asserted_at DESC, a.created_at DESC
+				 LIMIT ? OFFSET ?`,
+			)
+			.all(...args, limit, offset) as Array<Record<string, unknown>>;
+		const count = db
+			.prepare(
+				`SELECT COUNT(*) AS count
+				 FROM epistemic_assertions a
+				 JOIN entities e ON e.id = a.subject_entity_id AND e.agent_id = a.agent_id
+				 WHERE ${clause}`,
+			)
+			.get(...args) as { count: number } | undefined;
+		return { items: rows.map(rowToAssertion), count: count?.count ?? rows.length };
+	});
+}
+
+export function getEpistemicAssertion(
+	accessor: DbAccessor,
+	params: { readonly agentId: string; readonly id: string },
+): EpistemicAssertion | null {
+	return accessor.withReadDb((db) => {
+		const row = db
+			.prepare(
+				`SELECT a.*, e.name AS subject_entity_name
+				 FROM epistemic_assertions a
+				 JOIN entities e ON e.id = a.subject_entity_id AND e.agent_id = a.agent_id
+				 WHERE a.id = ? AND a.agent_id = ?`,
+			)
+			.get(params.id, params.agentId) as Record<string, unknown> | undefined;
+		return row ? rowToAssertion(row) : null;
+	});
+}
+
+export function linkEpistemicAssertionClaim(
+	accessor: DbAccessor,
+	params: { readonly agentId: string; readonly id: string; readonly attributeId: string },
+): EpistemicAssertion {
+	return accessor.withWriteTx((db) => {
+		const assertion = db
+			.prepare("SELECT subject_entity_id FROM epistemic_assertions WHERE id = ? AND agent_id = ?")
+			.get(params.id, params.agentId) as { subject_entity_id: string } | undefined;
+		if (!assertion) throw new OntologyAssertionError("assertion was not found", 404);
+		validateClaimAttribute(db, params.agentId, assertion.subject_entity_id, params.attributeId);
+		db.prepare(
+			`UPDATE epistemic_assertions
+			 SET claim_attribute_id = ?, updated_at = ?
+			 WHERE id = ? AND agent_id = ?`,
+		).run(params.attributeId, new Date().toISOString(), params.id, params.agentId);
+		const row = db
+			.prepare(
+				`SELECT a.*, e.name AS subject_entity_name
+				 FROM epistemic_assertions a
+				 JOIN entities e ON e.id = a.subject_entity_id AND e.agent_id = a.agent_id
+				 WHERE a.id = ? AND a.agent_id = ?`,
+			)
+			.get(params.id, params.agentId) as Record<string, unknown>;
+		return rowToAssertion(row);
+	});
+}
+
+export function archiveEpistemicAssertion(
+	accessor: DbAccessor,
+	params: { readonly agentId: string; readonly id: string; readonly actor: string; readonly reason?: string | null },
+): EpistemicAssertion {
+	return accessor.withWriteTx((db) => {
+		const existing = db
+			.prepare("SELECT id FROM epistemic_assertions WHERE id = ? AND agent_id = ?")
+			.get(params.id, params.agentId) as { id: string } | undefined;
+		if (!existing) throw new OntologyAssertionError("assertion was not found", 404);
+		const now = new Date().toISOString();
+		db.prepare(
+			`UPDATE epistemic_assertions
+			 SET status = 'archived', archived_at = ?, archived_by = ?, archive_reason = ?, updated_at = ?
+			 WHERE id = ? AND agent_id = ?`,
+		).run(now, params.actor, trim(params.reason), now, params.id, params.agentId);
+		const row = db
+			.prepare(
+				`SELECT a.*, e.name AS subject_entity_name
+				 FROM epistemic_assertions a
+				 JOIN entities e ON e.id = a.subject_entity_id AND e.agent_id = a.agent_id
+				 WHERE a.id = ? AND a.agent_id = ?`,
+			)
+			.get(params.id, params.agentId) as Record<string, unknown>;
+		return rowToAssertion(row);
+	});
+}
+
+export function supersedeEpistemicAssertion(
+	accessor: DbAccessor,
+	input: CreateEpistemicAssertionInput & { readonly oldAssertionId: string },
+): EpistemicAssertion {
+	return accessor.withWriteTx((db) => {
+		const old = db
+			.prepare(
+				`SELECT a.*, e.name AS subject_entity_name
+				 FROM epistemic_assertions a
+				 JOIN entities e ON e.id = a.subject_entity_id AND e.agent_id = a.agent_id
+				 WHERE a.id = ? AND a.agent_id = ?`,
+			)
+			.get(input.oldAssertionId, input.agentId) as Record<string, unknown> | undefined;
+		if (!old) throw new OntologyAssertionError("assertion was not found", 404);
+		const next = insertAssertion(accessor, db, {
+			...input,
+			entityId: input.entityId ?? (old.subject_entity_id as string),
+			predicate: input.predicate || (old.predicate as string),
+			speaker: input.speaker ?? (typeof old.speaker === "string" ? old.speaker : null),
+			sourceKind: input.sourceKind ?? (typeof old.source_kind === "string" ? old.source_kind : null),
+			sourceId: input.sourceId ?? (typeof old.source_id === "string" ? old.source_id : null),
+			sourcePath: input.sourcePath ?? (typeof old.source_path === "string" ? old.source_path : null),
+			sourceRoot: input.sourceRoot ?? (typeof old.source_root === "string" ? old.source_root : null),
+			supersedesAssertionId: input.oldAssertionId,
+		});
+		db.prepare(
+			`UPDATE epistemic_assertions
+			 SET status = 'superseded', updated_at = ?
+			 WHERE id = ? AND agent_id = ?`,
+		).run(new Date().toISOString(), input.oldAssertionId, input.agentId);
+		return next;
+	});
+}

--- a/platform/daemon/src/ontology-extraction.ts
+++ b/platform/daemon/src/ontology-extraction.ts
@@ -1,6 +1,7 @@
-import type { LlmProvider, OntologyProposal } from "@signet/core";
+import type { EpistemicAssertion, LlmProvider, OntologyProposal } from "@signet/core";
 import type { DbAccessor, ReadDb } from "./db-accessor";
-import { createOntologyProposals } from "./ontology-proposals";
+import { type CreateEpistemicAssertionInput, createEpistemicAssertionsInTx } from "./ontology-assertions";
+import { type CreateOntologyProposalInput, createOntologyProposalsInTx } from "./ontology-proposals";
 import { extractBalancedJsonObject, stripFences, tryParseJson } from "./pipeline/extraction";
 
 type ProposalDraft = {
@@ -14,7 +15,24 @@ type ProposalDraft = {
 
 type ParsedProposalJson = {
 	readonly proposals: readonly ProposalDraft[];
+	readonly assertions: readonly AssertionDraft[];
 	readonly questions: readonly string[];
+};
+
+type AssertionDraft = {
+	readonly entity?: string;
+	readonly entity_id?: string;
+	readonly predicate: string;
+	readonly content: string;
+	readonly speaker?: string | null;
+	readonly asserted_at?: string | null;
+	readonly confidence?: number;
+	readonly evidence?: readonly unknown[];
+	readonly source_kind?: string | null;
+	readonly source_id?: string | null;
+	readonly source_path?: string | null;
+	readonly source_root?: string | null;
+	readonly claim_attribute_id?: string | null;
 };
 
 type SourceRecord = {
@@ -42,6 +60,7 @@ export interface ExtractOntologyParams {
 	readonly agentId: string;
 	readonly from: string;
 	readonly writeProposals?: boolean;
+	readonly writeAssertions?: boolean;
 	readonly createdBy?: string;
 	readonly limit?: number;
 	readonly useProvider?: boolean;
@@ -54,8 +73,12 @@ export interface OntologyExtractionResult {
 	readonly source: OntologyExtractionSourceInfo;
 	readonly proposals: readonly ProposalDraft[];
 	readonly items: readonly OntologyProposal[];
+	readonly assertions: readonly AssertionDraft[];
+	readonly assertionItems: readonly EpistemicAssertion[];
 	readonly count: number;
 	readonly writtenCount: number;
+	readonly assertionCount: number;
+	readonly writtenAssertionCount: number;
 	readonly dryRun: boolean;
 	readonly extractionMode: "mechanical" | "provider" | "mixed";
 	readonly providerName: string | null;
@@ -228,19 +251,49 @@ function normalizeExtractionPolicies(root: Readonly<Record<string, unknown>>): P
 		.filter((proposal): proposal is ProposalDraft => proposal !== null);
 }
 
+function normalizeExtractionAssertions(root: Readonly<Record<string, unknown>>): AssertionDraft[] {
+	return readArray(root, "assertions").flatMap((raw): AssertionDraft[] => {
+		if (!isRecord(raw)) return [];
+		const entity = readString(raw, "entity");
+		const entityId = readString(raw, "entity_id");
+		const predicate = readString(raw, "predicate") ?? "claims";
+		const content = readString(raw, "content") ?? readString(raw, "value");
+		if ((!entity && !entityId) || !content) return [];
+		return [
+			{
+				entity: entity ?? undefined,
+				entity_id: entityId ?? undefined,
+				predicate,
+				content,
+				speaker: readString(raw, "speaker"),
+				asserted_at: readString(raw, "asserted_at") ?? readString(raw, "when"),
+				confidence: readNumber(raw, "confidence"),
+				evidence: readArray(raw, "evidence"),
+				source_kind: readString(raw, "source_kind"),
+				source_id: readString(raw, "source_id"),
+				source_path: readString(raw, "source_path"),
+				source_root: readString(raw, "source_root"),
+				claim_attribute_id: readString(raw, "claim_attribute_id"),
+			},
+		];
+	});
+}
+
 function normalizeProposalJson(raw: unknown): ParsedProposalJson {
 	if (Array.isArray(raw))
 		return {
 			proposals: raw.map(normalizeExplicitProposal).filter((proposal): proposal is ProposalDraft => proposal !== null),
+			assertions: [],
 			questions: [],
 		};
-	if (!isRecord(raw)) return { proposals: [], questions: [] };
+	if (!isRecord(raw)) return { proposals: [], assertions: [], questions: [] };
 	const explicit = readArray(raw, "proposals");
 	if (explicit.length > 0) {
 		return {
 			proposals: explicit
 				.map(normalizeExplicitProposal)
 				.filter((proposal): proposal is ProposalDraft => proposal !== null),
+			assertions: normalizeExtractionAssertions(raw),
 			questions: readStringArray(raw, "questions"),
 		};
 	}
@@ -251,6 +304,7 @@ function normalizeProposalJson(raw: unknown): ParsedProposalJson {
 			...normalizeExtractionLinks(raw),
 			...normalizeExtractionPolicies(raw),
 		],
+		assertions: normalizeExtractionAssertions(raw),
 		questions: readStringArray(raw, "questions"),
 	};
 }
@@ -258,6 +312,7 @@ function normalizeProposalJson(raw: unknown): ParsedProposalJson {
 function mergeParsedProposalJson(items: readonly ParsedProposalJson[]): ParsedProposalJson {
 	return {
 		proposals: items.flatMap((item) => item.proposals),
+		assertions: items.flatMap((item) => item.assertions),
 		questions: [...new Set(items.flatMap((item) => item.questions))],
 	};
 }
@@ -348,33 +403,34 @@ function mechanicalClaimProposals(source: SourceRecord): ProposalDraft[] {
 	];
 	const seen = new Set<string>();
 	return matches
-		.map((match) => {
+		.flatMap((match): ProposalDraft[] => {
 			const entity = normalizeName(match[1] ?? "");
 			const verb = normalizeName(match[2] ?? "");
 			const rest = normalizeName(match[3] ?? "");
 			const first = entity.split(/\s+/)[0] ?? "";
-			if (blocked.has(first) || entity.length < 2 || rest.length < 12) return null;
+			if (blocked.has(first) || entity.length < 2 || rest.length < 12) return [];
 			const value = `${entity} ${verb} ${rest}.`;
 			const key = `${entity.toLowerCase()}:${value.toLowerCase()}`;
-			if (seen.has(key)) return null;
+			if (seen.has(key)) return [];
 			seen.add(key);
-			return {
-				operation: "add_claim_value",
-				payload: {
-					entity,
-					entity_type: "concept",
-					aspect: "extracted",
-					group_key: "transcript",
-					claim_key: claimKeyFor(`${verb} ${rest}`),
-					value,
+			return [
+				{
+					operation: "add_claim_value",
+					payload: {
+						entity,
+						entity_type: "concept",
+						aspect: "extracted",
+						group_key: "transcript",
+						claim_key: claimKeyFor(`${verb} ${rest}`),
+						value,
+					},
+					confidence: 0.55,
+					rationale: "Detected explicit sentence-level claim in source text.",
+					evidence: evidence(source, value),
+					risk: "medium",
 				},
-				confidence: 0.55,
-				rationale: "Detected explicit sentence-level claim in source text.",
-				evidence: evidence(source, value),
-				risk: "medium",
-			} satisfies ProposalDraft;
+			];
 		})
-		.filter((proposal): proposal is ProposalDraft => proposal !== null)
 		.slice(0, 50);
 }
 
@@ -397,32 +453,33 @@ function mechanicalLinkProposals(source: SourceRecord): ProposalDraft[] {
 	];
 	const seen = new Set<string>();
 	return matches
-		.map((match) => {
+		.flatMap((match): ProposalDraft[] => {
 			const sourceEntity = normalizeName(match[1] ?? "");
 			const linkType = normalizeName(match[2] ?? "");
 			const targetEntity = normalizeName(match[3] ?? "");
-			if (!linkTypes.has(linkType) || sourceEntity.length < 2 || targetEntity.length < 2) return null;
+			if (!linkTypes.has(linkType) || sourceEntity.length < 2 || targetEntity.length < 2) return [];
 			const key = `${sourceEntity.toLowerCase()}:${linkType}:${targetEntity.toLowerCase()}`;
-			if (seen.has(key)) return null;
+			if (seen.has(key)) return [];
 			seen.add(key);
 			const quote = `${sourceEntity} ${linkType} ${targetEntity}`;
-			return {
-				operation: "create_link",
-				payload: {
-					source_entity: sourceEntity,
-					source_type: "concept",
-					link_type: linkType === "supports" ? "supports_claim" : linkType,
-					target_entity: targetEntity,
-					target_type: "concept",
-					reason: "Detected explicit relationship statement in source text.",
+			return [
+				{
+					operation: "create_link",
+					payload: {
+						source_entity: sourceEntity,
+						source_type: "concept",
+						link_type: linkType === "supports" ? "supports_claim" : linkType,
+						target_entity: targetEntity,
+						target_type: "concept",
+						reason: "Detected explicit relationship statement in source text.",
+					},
+					confidence: 0.58,
+					rationale: "Detected explicit relationship statement in source text.",
+					evidence: evidence(source, quote),
+					risk: "medium",
 				},
-				confidence: 0.58,
-				rationale: "Detected explicit relationship statement in source text.",
-				evidence: evidence(source, quote),
-				risk: "medium",
-			} satisfies ProposalDraft;
+			];
 		})
-		.filter((proposal): proposal is ProposalDraft => proposal !== null)
 		.slice(0, 50);
 }
 
@@ -525,6 +582,17 @@ Return ONLY JSON with this shape:
       "evidence": [{ "source_kind": "${source.sourceKind}", "source_id": "${source.sourceId}", "source_path": ${JSON.stringify(source.sourcePath)}, "quote": "short exact quote" }]
     }
   ],
+  "assertions": [
+    {
+      "entity": "string",
+      "predicate": "claims|believes|observed|decided|prefers|denies|questions",
+      "content": "what the source says, believes, asks, denies, decides, or observes",
+      "speaker": "person/tool/source name|null",
+      "asserted_at": "ISO timestamp if available|null",
+      "confidence": 0.0,
+      "evidence": [{ "source_kind": "${source.sourceKind}", "source_id": "${source.sourceId}", "source_path": ${JSON.stringify(source.sourcePath)}, "quote": "short exact quote" }]
+    }
+  ],
   "questions": ["uncertainties that need review"]
 }
 
@@ -538,6 +606,7 @@ async function extractProviderProposals(
 	params: Pick<ExtractOntologyParams, "providerTimeoutMs" | "providerMaxTokens">,
 ): Promise<{
 	readonly proposals: readonly ProposalDraft[];
+	readonly assertions: readonly AssertionDraft[];
 	readonly questions: readonly string[];
 	readonly warnings: readonly string[];
 }> {
@@ -550,12 +619,17 @@ async function extractProviderProposals(
 		const parsed = parseOntologyJsonOutput(raw);
 		return {
 			proposals: parsed.proposals,
+			assertions: parsed.assertions,
 			questions: parsed.questions,
-			warnings: parsed.proposals.length > 0 ? [] : [`Provider ${provider.name} returned no valid ontology proposals.`],
+			warnings:
+				parsed.proposals.length > 0 || parsed.assertions.length > 0
+					? []
+					: [`Provider ${provider.name} returned no valid ontology proposals or assertions.`],
 		};
 	} catch (err) {
 		return {
 			proposals: [],
+			assertions: [],
 			questions: [],
 			warnings: [`Provider ${provider.name} extraction failed: ${err instanceof Error ? err.message : String(err)}`],
 		};
@@ -683,14 +757,17 @@ export async function extractOntologyProposals(
 	const source = readSource(accessor, params);
 	const explicitParsed = mergeParsedProposalJson(extractJsonBlocks(source.content).map(normalizeProposalJson));
 	const explicit = explicitParsed.proposals;
+	const explicitAssertions = explicitParsed.assertions;
 	const mechanical = extractProposals(source, limit);
 	const warnings: string[] = [];
 	let providerProposals: readonly ProposalDraft[] = [];
+	let providerAssertions: readonly AssertionDraft[] = [];
 	let providerQuestions: readonly string[] = [];
 	if (params.useProvider) {
 		if (params.provider) {
 			const provider = await extractProviderProposals(source, params.provider, params);
 			providerProposals = provider.proposals;
+			providerAssertions = provider.assertions;
 			providerQuestions = provider.questions;
 			warnings.push(...provider.warnings);
 		} else {
@@ -701,6 +778,7 @@ export async function extractOntologyProposals(
 		params.useProvider && providerProposals.length > 0
 			? dedupeProposals([...explicit, ...providerProposals], limit)
 			: mechanical;
+	const assertions = [...explicitAssertions, ...providerAssertions].slice(0, limit);
 	const proposals = raw.map((proposal) => ({
 		...proposal,
 		evidence: proposal.evidence && proposal.evidence.length > 0 ? proposal.evidence : evidence(source, source.id),
@@ -712,13 +790,50 @@ export async function extractOntologyProposals(
 				? "provider"
 				: "mechanical";
 	const questions = [...new Set([...explicitParsed.questions, ...providerQuestions])];
-	if (!params.writeProposals || proposals.length === 0) {
+	const proposalInputs: readonly CreateOntologyProposalInput[] = proposals.map((proposal) => ({
+		agentId: params.agentId,
+		operation: proposal.operation,
+		payload: proposal.payload,
+		confidence: proposal.confidence,
+		rationale: proposal.rationale,
+		evidence: proposal.evidence,
+		risk: proposal.risk,
+		sourceKind: source.sourceKind,
+		sourceId: source.sourceId,
+		sourcePath: source.sourcePath,
+		createdBy: params.createdBy ?? "ontology-extract",
+	}));
+	const assertionInputs: readonly CreateEpistemicAssertionInput[] = assertions.map((assertion) => ({
+		agentId: params.agentId,
+		entity: assertion.entity,
+		entityId: assertion.entity_id,
+		predicate: assertion.predicate,
+		content: assertion.content,
+		speaker: assertion.speaker ?? null,
+		assertedAt: assertion.asserted_at ?? null,
+		confidence: assertion.confidence,
+		evidence:
+			assertion.evidence && assertion.evidence.length > 0 ? assertion.evidence : evidence(source, assertion.content),
+		sourceKind: assertion.source_kind ?? source.sourceKind,
+		sourceId: assertion.source_id ?? source.sourceId,
+		sourcePath: assertion.source_path ?? source.sourcePath,
+		sourceRoot: assertion.source_root ?? null,
+		claimAttributeId: assertion.claim_attribute_id ?? null,
+		createdBy: params.createdBy ?? "ontology-extract",
+	}));
+	const shouldWriteProposals = params.writeProposals === true && proposalInputs.length > 0;
+	const shouldWriteAssertions = params.writeAssertions === true && assertionInputs.length > 0;
+	if (!shouldWriteProposals && !shouldWriteAssertions) {
 		return {
 			source: sourceInfo(source),
 			proposals,
 			items: [],
+			assertions,
+			assertionItems: [],
 			count: proposals.length,
 			writtenCount: 0,
+			assertionCount: assertions.length,
+			writtenAssertionCount: 0,
 			dryRun: true,
 			extractionMode,
 			providerName: params.useProvider ? (params.provider?.name ?? null) : null,
@@ -727,29 +842,24 @@ export async function extractOntologyProposals(
 		};
 	}
 
-	const written = createOntologyProposals(
-		accessor,
-		proposals.map((proposal) => ({
-			agentId: params.agentId,
-			operation: proposal.operation,
-			payload: proposal.payload,
-			confidence: proposal.confidence,
-			rationale: proposal.rationale,
-			evidence: proposal.evidence,
-			risk: proposal.risk,
-			sourceKind: source.sourceKind,
-			sourceId: source.sourceId,
-			sourcePath: source.sourcePath,
-			createdBy: params.createdBy ?? "ontology-extract",
-		})),
-	);
+	const written = accessor.withWriteTx((db) => {
+		const proposalResult = shouldWriteProposals
+			? createOntologyProposalsInTx(db, proposalInputs)
+			: { items: [] as readonly OntologyProposal[], count: 0 };
+		const assertionItems = shouldWriteAssertions ? createEpistemicAssertionsInTx(accessor, db, assertionInputs) : [];
+		return { proposalResult, assertionItems };
+	});
 
 	return {
 		source: sourceInfo(source),
 		proposals,
-		items: written.items,
+		items: written.proposalResult.items,
+		assertions,
+		assertionItems: written.assertionItems,
 		count: proposals.length,
-		writtenCount: written.count,
+		writtenCount: written.proposalResult.count,
+		assertionCount: assertions.length,
+		writtenAssertionCount: written.assertionItems.length,
 		dryRun: false,
 		extractionMode,
 		providerName: params.useProvider ? (params.provider?.name ?? null) : null,

--- a/platform/daemon/src/ontology-proposals.test.ts
+++ b/platform/daemon/src/ontology-proposals.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { listEpistemicAssertions } from "./ontology-assertions";
 import { getOntologyClaimEvidence } from "./ontology-claim-evidence";
 import { consolidateOntologyProposals } from "./ontology-consolidation";
 import { extractOntologyProposals } from "./ontology-extraction";
@@ -268,6 +269,102 @@ describe("ontology proposals", () => {
 		expect(written.writtenCount).toBe(2);
 		expect(written.items.map((item) => item.createdBy)).toEqual(["test-extractor", "test-extractor"]);
 		expect(written.items.every((item) => item.sourceKind === "transcript")).toBe(true);
+	});
+
+	it("writes extracted assertions without marking the response as a dry run", async () => {
+		insertEntity("entity-signet", "Signet", "signet", "ant", 1);
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO session_transcripts
+				 (session_key, content, harness, project, agent_id, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			).run(
+				"assertion-extract",
+				JSON.stringify({
+					assertions: [
+						{
+							entity: "Signet",
+							predicate: "believes",
+							content: "Signet should model who believes what over time.",
+							speaker: "Nicholai",
+							confidence: 0.91,
+							evidence: [{ quote: "who believes what" }],
+						},
+					],
+				}),
+				"codex",
+				"/tmp/signet",
+				"ant",
+				"2026-05-06T00:00:00.000Z",
+				"2026-05-06T00:01:00.000Z",
+			);
+		});
+
+		const result = await extractOntologyProposals(getDbAccessor(), {
+			agentId: "ant",
+			from: "transcript:assertion-extract",
+			writeAssertions: true,
+		});
+
+		expect(result.dryRun).toBe(false);
+		expect(result.writtenCount).toBe(0);
+		expect(result.writtenAssertionCount).toBe(1);
+		expect(result.assertionItems[0]?.predicate).toBe("believes");
+	});
+
+	it("rolls back proposal and assertion extraction when one assertion is invalid", async () => {
+		insertEntity("entity-signet", "Signet", "signet", "ant", 1);
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO session_transcripts
+				 (session_key, content, harness, project, agent_id, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			).run(
+				"invalid-assertion-extract",
+				JSON.stringify({
+					proposals: [
+						{
+							operation: "create_entity",
+							payload: { name: "Rollback Candidate", entity_type: "concept" },
+							confidence: 0.7,
+							rationale: "Candidate from source evidence.",
+							evidence: [{ quote: "candidate" }],
+						},
+					],
+					assertions: [
+						{
+							entity: "Signet",
+							predicate: "claims",
+							content: "Signet keeps attributed assertions.",
+							evidence: [{ quote: "attributed assertions" }],
+						},
+						{
+							entity: "Signet",
+							predicate: "maybe",
+							content: "This invalid assertion should roll back the batch.",
+							evidence: [{ quote: "invalid assertion" }],
+						},
+					],
+				}),
+				"codex",
+				"/tmp/signet",
+				"ant",
+				"2026-05-06T00:00:00.000Z",
+				"2026-05-06T00:01:00.000Z",
+			);
+		});
+
+		await expect(
+			extractOntologyProposals(getDbAccessor(), {
+				agentId: "ant",
+				from: "transcript:invalid-assertion-extract",
+				writeProposals: true,
+				writeAssertions: true,
+			}),
+		).rejects.toThrow("predicate is invalid");
+
+		expect(listOntologyProposals(getDbAccessor(), { agentId: "ant" }).items).toHaveLength(0);
+		expect(listEpistemicAssertions(getDbAccessor(), { agentId: "ant", status: "all" }).items).toHaveLength(0);
 	});
 
 	it("mechanically extracts conservative proposals from plain transcript text", async () => {

--- a/platform/daemon/src/ontology-proposals.ts
+++ b/platform/daemon/src/ontology-proposals.ts
@@ -1370,11 +1370,18 @@ export function createOntologyProposals(
 ): CreateOntologyProposalsResult {
 	if (inputs.length === 0) throw new OntologyProposalError("proposals are required", 400);
 	if (inputs.length > 500) throw new OntologyProposalError("cannot create more than 500 proposals at once", 400);
+	return accessor.withWriteTx((db) => createOntologyProposalsInTx(db, inputs));
+}
+
+export function createOntologyProposalsInTx(
+	db: WriteDb,
+	inputs: readonly CreateOntologyProposalInput[],
+): CreateOntologyProposalsResult {
+	if (inputs.length === 0) throw new OntologyProposalError("proposals are required", 400);
+	if (inputs.length > 500) throw new OntologyProposalError("cannot create more than 500 proposals at once", 400);
 	const ts = now();
-	return accessor.withWriteTx((db) => {
-		const items = inputs.map((input) => insertProposalInTx(db, input, ts));
-		return { items, count: items.length };
-	});
+	const items = inputs.map((input) => insertProposalInTx(db, input, ts));
+	return { items, count: items.length };
 }
 
 export function getOntologyProposal(accessor: DbAccessor, id: string, agentId: string): OntologyProposal | null {

--- a/platform/daemon/src/routes/ontology-routes.ts
+++ b/platform/daemon/src/routes/ontology-routes.ts
@@ -459,7 +459,7 @@ export function registerOntologyRoutes(app: Hono): void {
 					oldAssertionId: c.req.param("id"),
 					entity: readString(body, "entity"),
 					entityId: readString(body, "entity_id"),
-					predicate: readString(body, "predicate") ?? "claims",
+					predicate: readString(body, "predicate") ?? "",
 					content: readString(body, "content") ?? "",
 					speaker: readString(body, "speaker") ?? null,
 					assertedAt: readString(body, "asserted_at") ?? null,

--- a/platform/daemon/src/routes/ontology-routes.ts
+++ b/platform/daemon/src/routes/ontology-routes.ts
@@ -3,6 +3,17 @@ import { requirePermission } from "../auth";
 import { getDbAccessor } from "../db-accessor";
 import { getInferenceProviderOrNull } from "../llm";
 import {
+	OntologyAssertionError,
+	archiveEpistemicAssertion,
+	createEpistemicAssertion,
+	getEpistemicAssertion,
+	linkEpistemicAssertionClaim,
+	listEpistemicAssertions,
+	parseEpistemicAssertionPredicate,
+	parseEpistemicAssertionStatus,
+	supersedeEpistemicAssertion,
+} from "../ontology-assertions";
+import {
 	OntologyClaimEvidenceError,
 	getOntologyClaimEvidence,
 	parseOntologyClaimAttributeKind,
@@ -78,6 +89,7 @@ function statusForError(err: unknown): 400 | 404 | 409 | 500 {
 	if (err instanceof OntologyLinkEvidenceError) return err.status;
 	if (err instanceof OntologyExtractionError) return err.status;
 	if (err instanceof OntologyConsolidationError) return err.status;
+	if (err instanceof OntologyAssertionError) return err.status;
 	return 500;
 }
 
@@ -118,6 +130,14 @@ export function registerOntologyRoutes(app: Hono): void {
 		return requirePermission(permission, authConfig)(c, next);
 	});
 	app.use("/api/ontology/links/*", async (c, next) => {
+		const permission = c.req.method === "GET" ? "recall" : "modify";
+		return requirePermission(permission, authConfig)(c, next);
+	});
+	app.use("/api/ontology/assertions", async (c, next) => {
+		const permission = c.req.method === "GET" ? "recall" : "modify";
+		return requirePermission(permission, authConfig)(c, next);
+	});
+	app.use("/api/ontology/assertions/*", async (c, next) => {
 		const permission = c.req.method === "GET" ? "recall" : "modify";
 		return requirePermission(permission, authConfig)(c, next);
 	});
@@ -181,6 +201,7 @@ export function registerOntologyRoutes(app: Hono): void {
 					agentId: scoped.agentId,
 					from,
 					writeProposals: readBoolean(body, "write_proposals") ?? false,
+					writeAssertions: readBoolean(body, "write_assertions") ?? false,
 					createdBy: readString(body, "created_by") ?? c.req.header("x-signet-actor") ?? "ontology-extract",
 					limit: readNumber(body, "limit"),
 					useProvider,
@@ -323,6 +344,135 @@ export function registerOntologyRoutes(app: Hono): void {
 		if (scoped.response) return scoped.response;
 		try {
 			return c.json(getOntologyLinkEvidence(getDbAccessor(), { agentId: scoped.agentId, id: c.req.param("id") }));
+		} catch (err) {
+			return c.json({ error: messageForError(err) }, statusForError(err));
+		}
+	});
+
+	app.get("/api/ontology/assertions", (c) => {
+		const scoped = resolveAgent(c, c.req.query("agent_id"));
+		if (scoped.response) return scoped.response;
+		const predicate = parseEpistemicAssertionPredicate(c.req.query("predicate"));
+		if (c.req.query("predicate") && !predicate) return c.json({ error: "predicate is invalid" }, 400);
+		const status = parseEpistemicAssertionStatus(c.req.query("status"));
+		if (c.req.query("status") && !status) return c.json({ error: "status is invalid" }, 400);
+		return c.json(
+			listEpistemicAssertions(getDbAccessor(), {
+				agentId: scoped.agentId,
+				entity: c.req.query("entity"),
+				entityId: c.req.query("entity_id"),
+				predicate,
+				status,
+				speaker: c.req.query("speaker"),
+				sourceKind: c.req.query("source_kind"),
+				sourceId: c.req.query("source_id"),
+				query: c.req.query("query"),
+				limit: parseBoundedInt(c.req.query("limit"), 50, 1, 200),
+				offset: parseBoundedInt(c.req.query("offset"), 0, 0, 10_000),
+			}),
+		);
+	});
+
+	app.get("/api/ontology/assertions/:id", (c) => {
+		const scoped = resolveAgent(c, c.req.query("agent_id"));
+		if (scoped.response) return scoped.response;
+		const assertion = getEpistemicAssertion(getDbAccessor(), { agentId: scoped.agentId, id: c.req.param("id") });
+		if (assertion === null) return c.json({ error: "Assertion not found" }, 404);
+		return c.json(assertion);
+	});
+
+	app.post("/api/ontology/assertions", async (c) => {
+		const body = await readJsonRecord(c);
+		const scoped = resolveAgent(c, c.req.query("agent_id") ?? readString(body, "agent_id"));
+		if (scoped.response) return scoped.response;
+		try {
+			return c.json(
+				createEpistemicAssertion(getDbAccessor(), {
+					agentId: scoped.agentId,
+					entity: readString(body, "entity"),
+					entityId: readString(body, "entity_id"),
+					predicate: readString(body, "predicate") ?? "",
+					content: readString(body, "content") ?? "",
+					speaker: readString(body, "speaker") ?? null,
+					assertedAt: readString(body, "asserted_at") ?? null,
+					confidence: readNumber(body, "confidence"),
+					evidence: readArray(body, "evidence"),
+					sourceKind: readString(body, "source_kind") ?? null,
+					sourceId: readString(body, "source_id") ?? null,
+					sourcePath: readString(body, "source_path") ?? null,
+					sourceRoot: readString(body, "source_root") ?? null,
+					claimAttributeId: readString(body, "claim_attribute_id") ?? null,
+					createdBy: readString(body, "created_by") ?? c.req.header("x-signet-actor") ?? "operator",
+				}),
+				201,
+			);
+		} catch (err) {
+			return c.json({ error: messageForError(err) }, statusForError(err));
+		}
+	});
+
+	app.post("/api/ontology/assertions/:id/link-claim", async (c) => {
+		const body = await readJsonRecord(c);
+		const scoped = resolveAgent(c, c.req.query("agent_id") ?? readString(body, "agent_id"));
+		if (scoped.response) return scoped.response;
+		const attributeId = readString(body, "attribute_id");
+		if (!attributeId) return c.json({ error: "attribute_id is required" }, 400);
+		try {
+			return c.json(
+				linkEpistemicAssertionClaim(getDbAccessor(), {
+					agentId: scoped.agentId,
+					id: c.req.param("id"),
+					attributeId,
+				}),
+			);
+		} catch (err) {
+			return c.json({ error: messageForError(err) }, statusForError(err));
+		}
+	});
+
+	app.post("/api/ontology/assertions/:id/archive", async (c) => {
+		const body = await readJsonRecord(c);
+		const scoped = resolveAgent(c, c.req.query("agent_id") ?? readString(body, "agent_id"));
+		if (scoped.response) return scoped.response;
+		try {
+			return c.json(
+				archiveEpistemicAssertion(getDbAccessor(), {
+					agentId: scoped.agentId,
+					id: c.req.param("id"),
+					actor: readString(body, "actor") ?? c.req.header("x-signet-actor") ?? "operator",
+					reason: readString(body, "reason") ?? null,
+				}),
+			);
+		} catch (err) {
+			return c.json({ error: messageForError(err) }, statusForError(err));
+		}
+	});
+
+	app.post("/api/ontology/assertions/:id/supersede", async (c) => {
+		const body = await readJsonRecord(c);
+		const scoped = resolveAgent(c, c.req.query("agent_id") ?? readString(body, "agent_id"));
+		if (scoped.response) return scoped.response;
+		try {
+			return c.json(
+				supersedeEpistemicAssertion(getDbAccessor(), {
+					agentId: scoped.agentId,
+					oldAssertionId: c.req.param("id"),
+					entity: readString(body, "entity"),
+					entityId: readString(body, "entity_id"),
+					predicate: readString(body, "predicate") ?? "claims",
+					content: readString(body, "content") ?? "",
+					speaker: readString(body, "speaker") ?? null,
+					assertedAt: readString(body, "asserted_at") ?? null,
+					confidence: readNumber(body, "confidence"),
+					evidence: readArray(body, "evidence"),
+					sourceKind: readString(body, "source_kind") ?? null,
+					sourceId: readString(body, "source_id") ?? null,
+					sourcePath: readString(body, "source_path") ?? null,
+					sourceRoot: readString(body, "source_root") ?? null,
+					claimAttributeId: readString(body, "claim_attribute_id") ?? null,
+					createdBy: readString(body, "created_by") ?? c.req.header("x-signet-actor") ?? "operator",
+				}),
+			);
 		} catch (err) {
 			return c.json({ error: messageForError(err) }, statusForError(err));
 		}

--- a/surfaces/cli/src/commands/ontology.test.ts
+++ b/surfaces/cli/src/commands/ontology.test.ts
@@ -25,7 +25,7 @@ describe("registerOntologyCommands", () => {
 		expect(ontology).toBeDefined();
 		if (!ontology) throw new Error("ontology command was not registered");
 		expect(ontology?.commands.map((cmd) => cmd.name())).toEqual(
-			expect.arrayContaining(["entity", "claim", "aspect", "link", "stream"]),
+			expect.arrayContaining(["entity", "claim", "aspect", "link", "stream", "assertions", "assertion"]),
 		);
 
 		const names = (parent: Command, name: string): readonly string[] =>
@@ -35,6 +35,9 @@ describe("registerOntologyCommands", () => {
 		expect(names(ontology, "aspect")).toEqual(expect.arrayContaining(["create", "rename", "archive"]));
 		expect(names(ontology, "link")).toEqual(expect.arrayContaining(["create", "update", "archive"]));
 		expect(names(ontology, "stream")).toEqual(expect.arrayContaining(["apply"]));
+		expect(names(ontology, "assertion")).toEqual(
+			expect.arrayContaining(["show", "create", "link-claim", "archive", "supersede", "import"]),
+		);
 	});
 
 	test("objects lists ontology objects through knowledge navigation", async () => {
@@ -772,6 +775,86 @@ describe("registerOntologyCommands", () => {
 		await program.parseAsync(["node", "test", "ontology", "pipeline", "explain"]);
 
 		expect(capturedPath).toBe("/api/status");
+	});
+
+	test("assertion commands use epistemic assertion endpoints", async () => {
+		const calls: Array<{ readonly method: string; readonly path: string; readonly body: unknown }> = [];
+		let daemonChecks = 0;
+		console.log = () => {};
+		const program = new Command();
+		registerOntologyCommands(program, {
+			ensureDaemonForSecrets: async () => {
+				daemonChecks += 1;
+				return true;
+			},
+			secretApiCall: async (method, path, body) => {
+				calls.push({ method, path, body });
+				return {
+					ok: true,
+					data: {
+						id: "assertion-1",
+						subjectEntityName: "Signet",
+						predicate: "claims",
+						content: "Signet tracks attributed claims.",
+						confidence: 0.9,
+						status: "active",
+					},
+				};
+			},
+		});
+
+		await program.parseAsync(["node", "test", "ontology", "assertions", "--entity", "Signet", "--agent", "ant"]);
+		await program.parseAsync(["node", "test", "ontology", "assertion", "show", "assertion-1", "--agent", "ant"]);
+		await program.parseAsync([
+			"node",
+			"test",
+			"ontology",
+			"assertion",
+			"create",
+			"--entity",
+			"Signet",
+			"--predicate",
+			"claims",
+			"--content",
+			"Signet tracks attributed claims.",
+			"--source-kind",
+			"transcript",
+			"--confidence",
+			"0.9",
+		]);
+		await program.parseAsync([
+			"node",
+			"test",
+			"ontology",
+			"assertion",
+			"link-claim",
+			"assertion-1",
+			"--attribute-id",
+			"attr-1",
+		]);
+		await program.parseAsync(["node", "test", "ontology", "assertion", "archive", "assertion-1", "--reason", "stale"]);
+		await program.parseAsync([
+			"node",
+			"test",
+			"ontology",
+			"assertion",
+			"supersede",
+			"assertion-1",
+			"--content",
+			"Signet tracks attributed assertions.",
+			"--source-kind",
+			"transcript",
+		]);
+
+		expect(calls[0]?.path).toBe("/api/ontology/assertions?entity=Signet&status=active&agent_id=ant");
+		expect(calls[1]?.path).toBe("/api/ontology/assertions/assertion-1?agent_id=ant");
+		expect(calls[2]?.path).toBe("/api/ontology/assertions");
+		expect((calls[2]?.body as { readonly predicate?: string; readonly confidence?: number }).predicate).toBe("claims");
+		expect((calls[2]?.body as { readonly confidence?: number }).confidence).toBe(0.9);
+		expect(calls[3]?.path).toBe("/api/ontology/assertions/assertion-1/link-claim");
+		expect(calls[4]?.path).toBe("/api/ontology/assertions/assertion-1/archive");
+		expect(calls[5]?.path).toBe("/api/ontology/assertions/assertion-1/supersede");
+		expect(daemonChecks).toBe(calls.length);
 	});
 
 	test("config show makes the audited operation surface explicit", async () => {

--- a/surfaces/cli/src/commands/ontology.ts
+++ b/surfaces/cli/src/commands/ontology.ts
@@ -100,6 +100,25 @@ interface ClaimEvidenceResponse {
 	readonly items?: readonly ClaimEvidenceValue[];
 }
 
+interface EpistemicAssertionItem {
+	readonly id?: string;
+	readonly subjectEntityName?: string | null;
+	readonly predicate?: string;
+	readonly content?: string;
+	readonly speaker?: string | null;
+	readonly assertedAt?: string;
+	readonly confidence?: number;
+	readonly status?: string;
+	readonly sourceKind?: string | null;
+	readonly sourceId?: string | null;
+	readonly sourcePath?: string | null;
+	readonly claimAttributeId?: string | null;
+}
+
+interface EpistemicAssertionsResponse {
+	readonly items?: readonly EpistemicAssertionItem[];
+}
+
 interface ConflictValue {
 	readonly proposalId?: string;
 	readonly value?: string;
@@ -148,8 +167,11 @@ interface ProposalImportInput {
 
 interface ExtractionResponse {
 	readonly proposals?: readonly ProposalImportInput[];
+	readonly assertions?: readonly EpistemicAssertionItem[];
 	readonly count?: number;
 	readonly writtenCount?: number;
+	readonly assertionCount?: number;
+	readonly writtenAssertionCount?: number;
 	readonly dryRun?: boolean;
 	readonly extractionMode?: string;
 	readonly providerName?: string | null;
@@ -537,6 +559,30 @@ function printClaimEvidence(data: unknown): void {
 	console.log();
 }
 
+function printAssertions(data: unknown, title = "Epistemic Assertions"): void {
+	const record = asRecord(data);
+	const items = (((record as EpistemicAssertionsResponse).items as readonly EpistemicAssertionItem[] | undefined) ??
+		(record.id ? ([record as EpistemicAssertionItem] as const) : [])) as readonly EpistemicAssertionItem[];
+	if (items.length === 0) {
+		console.log(chalk.dim("  No epistemic assertions found"));
+		return;
+	}
+	console.log(chalk.bold(`\n  ${title}\n`));
+	for (const item of items) {
+		const confidence = typeof item.confidence === "number" ? ` · ${item.confidence.toFixed(2)}` : "";
+		const status = item.status ? chalk.dim(` ${item.status}`) : "";
+		console.log(
+			`  ${chalk.cyan(item.id ?? "unknown")}${status} ${chalk.yellow(item.predicate ?? "claims")}${confidence}`,
+		);
+		const actor = item.speaker ?? item.sourcePath ?? item.sourceId ?? item.sourceKind;
+		const when = item.assertedAt ? ` · ${item.assertedAt}` : "";
+		console.log(chalk.dim(`    ${item.subjectEntityName ?? "unknown"}${actor ? ` · ${actor}` : ""}${when}`));
+		if (item.content) console.log(chalk.dim(`    ${item.content}`));
+		if (item.claimAttributeId) console.log(chalk.dim(`    claim ${item.claimAttributeId}`));
+	}
+	console.log();
+}
+
 function printConflicts(data: unknown): void {
 	const items = ((asRecord(data) as ConflictsResponse).items ?? []) as readonly ConflictItem[];
 	if (items.length === 0) {
@@ -587,6 +633,13 @@ function printExtraction(data: unknown): void {
 	console.log(chalk.dim(`  mode ${result.extractionMode ?? "unknown"}`));
 	if (result.providerName) console.log(chalk.dim(`  provider ${result.providerName}`));
 	console.log(chalk.dim(`  ${result.writtenCount ?? 0} written · ${result.count ?? proposals.length} candidate(s)`));
+	if ((result.assertionCount ?? 0) > 0 || (result.writtenAssertionCount ?? 0) > 0) {
+		console.log(
+			chalk.dim(
+				`  ${result.writtenAssertionCount ?? 0} assertions written · ${result.assertionCount ?? 0} assertion candidate(s)`,
+			),
+		);
+	}
 	for (const warning of result.warnings ?? []) {
 		console.log(chalk.yellow(`  warning ${warning}`));
 	}
@@ -791,11 +844,214 @@ export function registerOntologyCommands(program: Command, deps: OntologyDeps): 
 		else printConflicts(data);
 	});
 
+	addCommonOptions(
+		ontology
+			.command("assertions")
+			.description("List source-attributed epistemic assertions")
+			.option("--entity <name>", "Filter by entity name")
+			.option("--entity-id <id>", "Filter by entity id")
+			.option("--predicate <predicate>", "Filter by predicate")
+			.option("--status <status>", "Filter by status", "active")
+			.option("--speaker <name>", "Filter by speaker")
+			.option("--source-kind <kind>", "Filter by source kind")
+			.option("--source-id <id>", "Filter by source id")
+			.option("--query <text>", "Filter assertion text")
+			.option("-l, --limit <n>", "Max assertions to return", Number.parseInt),
+	).action(async (options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const params = new URLSearchParams();
+		for (const [key, value] of [
+			["entity", options.entity],
+			["entity_id", options.entityId],
+			["predicate", options.predicate],
+			["status", options.status],
+			["speaker", options.speaker],
+			["source_kind", options.sourceKind],
+			["source_id", options.sourceId],
+			["query", options.query],
+		] as const) {
+			if (typeof value === "string" && value.length > 0) params.set(key, value);
+		}
+		if (typeof options.limit === "number") params.set("limit", String(options.limit));
+		appendAgent(params, options.agent);
+		const data = await apiGet(deps, "/api/ontology/assertions", params);
+		if (options.json) console.log(JSON.stringify(data, null, 2));
+		else printAssertions(data);
+	});
+
+	const assertion = ontology.command("assertion").description("Inspect and maintain epistemic assertions");
+
+	addCommonOptions(
+		assertion.command("show").description("Show one epistemic assertion").argument("<id>", "Assertion id"),
+	).action(async (id: string, options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const params = new URLSearchParams();
+		appendAgent(params, options.agent);
+		const data = await apiGet(deps, `/api/ontology/assertions/${encodeURIComponent(id)}`, params);
+		if (options.json) console.log(JSON.stringify(data, null, 2));
+		else printAssertions(data, "Epistemic Assertion");
+	});
+
+	addCommonOptions(
+		assertion
+			.command("create")
+			.description("Create a source-attributed epistemic assertion")
+			.option("--entity <name>", "Subject entity name")
+			.option("--entity-id <id>", "Subject entity id")
+			.requiredOption("--predicate <predicate>", "claims|believes|observed|decided|prefers|denies|questions")
+			.requiredOption("--content <text>", "Assertion content")
+			.option("--speaker <name>", "Speaker or claimant")
+			.option("--asserted-at <iso>", "When the assertion was made")
+			.option("--confidence <n>", "Assertion confidence", Number.parseFloat)
+			.option("--source-kind <kind>", "Evidence source kind")
+			.option("--source-id <id>", "Evidence source id")
+			.option("--source-path <path>", "Evidence source path")
+			.option("--source-root <path>", "Evidence source root")
+			.option("--claim-attribute-id <id>", "Applied claim attribute this assertion supports")
+			.option("--evidence-file <path>", "JSON evidence file, array or single object")
+			.option("--created-by <name>", "Audit creator", "operator"),
+	).action(async (options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		if (!options.entity && !options.entityId) {
+			console.error(chalk.red("--entity or --entity-id is required"));
+			process.exit(1);
+		}
+		const body = {
+			agent_id: options.agent,
+			entity: options.entity,
+			entity_id: options.entityId,
+			predicate: options.predicate,
+			content: options.content,
+			speaker: options.speaker,
+			asserted_at: options.assertedAt,
+			confidence: options.confidence,
+			source_kind: options.sourceKind,
+			source_id: options.sourceId,
+			source_path: options.sourcePath,
+			source_root: options.sourceRoot,
+			claim_attribute_id: options.claimAttributeId,
+			evidence: readEvidenceFile(options.evidenceFile),
+			created_by: options.createdBy,
+		};
+		const data = await apiPost(deps, "/api/ontology/assertions", body);
+		if (options.json) console.log(JSON.stringify(data, null, 2));
+		else printAssertions(data, "Created Epistemic Assertion");
+	});
+
+	addCommonOptions(
+		assertion
+			.command("link-claim")
+			.description("Link an epistemic assertion to an applied claim attribute")
+			.argument("<id>", "Assertion id")
+			.requiredOption("--attribute-id <id>", "Claim attribute id"),
+	).action(async (id: string, options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const params = new URLSearchParams();
+		appendAgent(params, options.agent);
+		const query = params.toString();
+		const data = await apiPost(
+			deps,
+			`/api/ontology/assertions/${encodeURIComponent(id)}/link-claim${query ? `?${query}` : ""}`,
+			{ attribute_id: options.attributeId },
+		);
+		if (options.json) console.log(JSON.stringify(data, null, 2));
+		else printAssertions(data, "Linked Epistemic Assertion");
+	});
+
+	addCommonOptions(
+		assertion
+			.command("archive")
+			.description("Archive an epistemic assertion")
+			.argument("<id>", "Assertion id")
+			.option("--reason <text>", "Archive reason")
+			.option("--actor <name>", "Audit actor", "operator"),
+	).action(async (id: string, options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const params = new URLSearchParams();
+		appendAgent(params, options.agent);
+		const query = params.toString();
+		const data = await apiPost(
+			deps,
+			`/api/ontology/assertions/${encodeURIComponent(id)}/archive${query ? `?${query}` : ""}`,
+			{ reason: options.reason, actor: options.actor },
+		);
+		if (options.json) console.log(JSON.stringify(data, null, 2));
+		else printAssertions(data, "Archived Epistemic Assertion");
+	});
+
+	addCommonOptions(
+		assertion
+			.command("supersede")
+			.description("Supersede an epistemic assertion with a newer assertion")
+			.argument("<id>", "Assertion id")
+			.requiredOption("--content <text>", "Replacement assertion content")
+			.option("--predicate <predicate>", "Replacement predicate", "claims")
+			.option("--speaker <name>", "Speaker or claimant")
+			.option("--asserted-at <iso>", "When the replacement assertion was made")
+			.option("--confidence <n>", "Assertion confidence", Number.parseFloat)
+			.option("--source-kind <kind>", "Evidence source kind")
+			.option("--source-id <id>", "Evidence source id")
+			.option("--source-path <path>", "Evidence source path")
+			.option("--source-root <path>", "Evidence source root")
+			.option("--evidence-file <path>", "JSON evidence file, array or single object")
+			.option("--created-by <name>", "Audit creator", "operator"),
+	).action(async (id: string, options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const params = new URLSearchParams();
+		appendAgent(params, options.agent);
+		const query = params.toString();
+		const data = await apiPost(
+			deps,
+			`/api/ontology/assertions/${encodeURIComponent(id)}/supersede${query ? `?${query}` : ""}`,
+			{
+				predicate: options.predicate,
+				content: options.content,
+				speaker: options.speaker,
+				asserted_at: options.assertedAt,
+				confidence: options.confidence,
+				source_kind: options.sourceKind,
+				source_id: options.sourceId,
+				source_path: options.sourcePath,
+				source_root: options.sourceRoot,
+				evidence: readEvidenceFile(options.evidenceFile),
+				created_by: options.createdBy,
+			},
+		);
+		if (options.json) console.log(JSON.stringify(data, null, 2));
+		else printAssertions(data, "Superseding Epistemic Assertion");
+	});
+
+	addCommonOptions(
+		assertion
+			.command("import")
+			.description("Import epistemic assertions from JSON")
+			.requiredOption("--file <path>", "JSON assertion array or { assertions }")
+			.option("--created-by <name>", "Audit creator", "operator"),
+	).action(async (options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const raw = readJsonFile(options.file);
+		const assertions = Array.isArray(raw) ? raw : (readArray(asRecord(raw), "assertions") ?? []);
+		const written: unknown[] = [];
+		for (const item of assertions) {
+			const assertionRecord = asRecord(item);
+			const data = await apiPost(deps, "/api/ontology/assertions", {
+				...assertionRecord,
+				agent_id: options.agent,
+				created_by: readString(assertionRecord, "created_by") ?? options.createdBy,
+			});
+			written.push(data);
+		}
+		const data = { items: written, count: written.length };
+		if (options.json) console.log(JSON.stringify(data, null, 2));
+		else printAssertions(data, "Imported Epistemic Assertions");
+	});
+
 	ontology
 		.command("extract")
 		.description("Extract candidate ontology proposals from a transcript or artifact")
 		.requiredOption("--from <source>", "Source ref, e.g. transcript:<id>, artifact:<path>, or source:<path>")
 		.option("--write-proposals", "Persist extracted candidates as pending proposals")
+		.option("--write-assertions", "Persist extracted epistemic assertions")
 		.option("--dry-run", "Preview candidates without writing", true)
 		.option("--use-provider", "Use the configured memory extraction inference workload")
 		.option("--provider-timeout-ms <n>", "Provider extraction timeout in milliseconds", Number.parseInt)
@@ -813,6 +1069,7 @@ export function registerOntologyCommands(program: Command, deps: OntologyDeps): 
 					agent_id: options.agent,
 					from: options.from,
 					write_proposals: options.writeProposals === true,
+					...(options.writeAssertions === true ? { write_assertions: true } : {}),
 					use_provider: options.useProvider === true,
 					provider_timeout_ms: options.providerTimeoutMs,
 					provider_max_tokens: options.providerMaxTokens,

--- a/surfaces/cli/src/commands/ontology.ts
+++ b/surfaces/cli/src/commands/ontology.ts
@@ -985,7 +985,7 @@ export function registerOntologyCommands(program: Command, deps: OntologyDeps): 
 			.description("Supersede an epistemic assertion with a newer assertion")
 			.argument("<id>", "Assertion id")
 			.requiredOption("--content <text>", "Replacement assertion content")
-			.option("--predicate <predicate>", "Replacement predicate", "claims")
+			.option("--predicate <predicate>", "Replacement predicate")
 			.option("--speaker <name>", "Speaker or claimant")
 			.option("--asserted-at <iso>", "When the replacement assertion was made")
 			.option("--confidence <n>", "Assertion confidence", Number.parseFloat)


### PR DESCRIPTION
## Summary
- add an agent-scoped `epistemic_assertions` table for source-attributed claims, beliefs, observations, decisions, preferences, denials, and questions
- expose daemon APIs and CLI commands for listing, creating, linking, archiving, superseding, importing, and extracting assertions
- make ontology extraction write proposals and assertions atomically and report assertion writes as non-dry-run mutations
- add regression coverage for assertion extraction rollback, assertion-only writes, CLI daemon bootstrap, active-claim linking, predicate-preserving supersede behavior, and entity-scoped assertion supersession
- document the new assertion API/CLI lifecycle in `docs/API.md` and `docs/knowledge-graph-control-plane.md`

## Validation
- [x] `bunx biome check platform/daemon/src/ontology-assertions.ts platform/daemon/src/ontology-assertions.test.ts`
- [x] `bun test surfaces/cli/src/commands/ontology.test.ts platform/daemon/src/ontology-assertions.test.ts platform/daemon/src/ontology-proposals.test.ts`
- [x] `cd platform/daemon && bun build.ts`
- [x] `git diff --check`
- [x] GitHub Actions on latest head `7de1f944`: CodeQL, smoke, migration guard, regression-test guard, checklist guard, and version consistency all passed

Earlier validation on this PR also passed `bunx biome check` over the full touched TS file set, `bun run build:core`, and `cd surfaces/cli && bun run build:cli`. The latest feedback commits are daemon/docs-only. On the latest head, rerunning `cd surfaces/cli && bun run build:cli` did not complete after more than a minute in local Bun bundling, so it is not used as latest-head readiness evidence.

Note: the broad daemon declaration build is not used here as readiness evidence; this checkout still has pre-existing package-wide `platform/daemon` declaration issues outside this PR's changed implementation paths.

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Focused lint/build/tests listed above pass locally; full GitHub Actions pass on latest head

## Migration Notes (if applicable)
- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Adds migration 071, `epistemic_assertions`. The migration is additive and idempotent. Rollback compatibility: older daemons ignore the new table; downgrading does not require data mutation, but assertion data is only available to daemons that include this API/CLI surface. Rust daemon parity is N/A because this is JS daemon ontology-control-plane storage/API work, with no Rust route implementation in this slice.
