### PR TITLE
Promote dreaming evidence into attribute slots

### DIFF
--- a/docs/dreaming-skill-runbook.md
+++ b/docs/dreaming-skill-runbook.md
@@ -1,10 +1,11 @@
 # Dreaming Skill Runbook
 
-This is the first runnable proposal-first dreaming path for ontology
-maintenance. It uses existing daemon-backed CLI surfaces and the built-in
-`dreaming` skill instructions.
+This is the runnable dreaming path for promoting source-backed evidence into
+the ontology. Raw memories, transcripts, and source artifacts remain immutable
+evidence. Dreaming promotes only explicit, high-confidence statements into
+current attribute slots.
 
-## Proposal-First Path
+## Attribute Promotion Path
 
 Inspect the current graph write gates:
 
@@ -12,53 +13,33 @@ Inspect the current graph write gates:
 signet ontology pipeline explain --json
 ```
 
-Collect graph hygiene and proposal context:
+Preview promotions from all source evidence:
 
 ```bash
-signet knowledge hygiene --json > dreaming-hygiene.json
-signet ontology proposals --status pending --json > dreaming-pending.json
-signet ontology proposals --status applied --limit 50 --json > dreaming-applied-recent.json
-signet ontology proposals --status rejected --limit 50 --json > dreaming-rejected-recent.json
-signet dream status > dreaming-status.txt
+signet dream promote --from all --json
 ```
 
-Extract candidate proposals from a specific evidence artifact or transcript:
+Preview a narrower source:
 
 ```bash
-signet ontology extract --from transcript:<session-key> --json > dreaming-extract.json
+signet dream promote --from memories:recent --json
+signet dream promote --from memory:<id> --json
+signet dream promote --from artifact:<id> --json
+signet dream promote --from transcript:<session-key> --json
 ```
 
-Consolidate pending proposal candidates without mutation:
+Apply accepted explicit promotions:
 
 ```bash
-signet ontology consolidate --proposals pending --json > dreaming-consolidate.json
+signet dream promote --from all --apply --json
 ```
 
-Convert accepted candidates into operation JSONL, keeping one object per line:
+The promotion endpoint emits direct `set_claim_value` operations. That
+operation updates the current value for a stable `(entity, aspect, group,
+claim, kind)` slot and supersedes the older active value in place.
 
-```json
-{"operation":"set_claim_value","payload":{"entity":"Signet","aspect":"architecture","group_key":"ontology","claim_key":"mutation_policy","value":"Generated ontology maintenance emits proposals before graph mutation."},"reason":"Consolidated from cited transcript evidence.","evidence":[{"source_kind":"transcript","source_id":"<session-key>","quote":"..."}]}
-```
-
-Validate without writing:
-
-```bash
-signet ontology stream apply proposals.jsonl --dry-run --json
-```
-
-Write pending proposals for review:
-
-```bash
-signet ontology stream apply proposals.jsonl --propose --json
-signet ontology proposals --status pending --json
-```
-
-After human/operator review, apply or reject proposals explicitly:
-
-```bash
-signet ontology apply <proposal-id> --actor operator --json
-signet ontology reject <proposal-id> --reason "weak evidence" --actor operator --json
-```
+Low-confidence or ambiguous evidence is skipped or returned as a question. It
+is not stored as a pending proposal by default.
 
 Inspect versioned claim evidence:
 
@@ -68,10 +49,25 @@ signet ontology claim show <entity> <aspect> <group> <claim> --version 1 --json
 signet ontology claim-evidence <entity> <aspect> <group> <claim> --status all --json
 ```
 
+## Reviewable Proposal Path
+
+Use the ontology proposal loop when a human wants a durable pending review
+queue instead of direct promotion:
+
+```bash
+signet ontology extract --from transcript:<session-key> --json
+signet ontology consolidate --proposals pending --json
+signet ontology stream apply proposals.jsonl --propose --json
+signet ontology apply <proposal-id> --actor operator --json
+signet ontology reject <proposal-id> --reason "weak evidence" --actor operator --json
+```
+
 ## Rules
 
-- LLM-generated dreaming output uses `--dry-run` or `--propose` by default.
-- Raw memories, transcripts, and source artifacts are evidence only; do not
-  rewrite them when graph claims change.
-- Direct apply is reserved for exact operator-authored operations.
-- Every successful mutation must pass through `ontology_proposals`.
+- Dreaming promotion never rewrites raw memories, transcripts, or source
+  artifacts.
+- The default `signet dream promote` mode is a preview.
+- `--apply` uses audited ontology operation handlers, not Pipeline V2.
+- Ambiguous generated output is skipped or surfaced as a question.
+- Pending proposals are optional review artifacts, not the default dreaming
+  promotion path.

--- a/docs/dreaming-skill-runbook.md
+++ b/docs/dreaming-skill-runbook.md
@@ -6,8 +6,9 @@ evidence. Dreaming promotes only explicit, high-confidence statements into
 current attribute slots. In the default non-provider path, plain
 natural-language preference extraction is limited to confidence-bearing memory
 rows. Memory artifacts and transcripts are still readable evidence sources, but
-they must contain structured high-confidence `set_claim_value` or
-`claim_values` JSON unless the caller opts into `--use-provider`.
+embedded `set_claim_value` or `claim_values` JSON is preview-only because raw
+source JSON cannot self-attest confidence for direct apply. Plain prose in
+artifacts or transcripts needs `--use-provider` or the proposal review path.
 
 ## Attribute Promotion Path
 

--- a/docs/dreaming-skill-runbook.md
+++ b/docs/dreaming-skill-runbook.md
@@ -3,7 +3,11 @@
 This is the runnable dreaming path for promoting source-backed evidence into
 the ontology. Raw memories, transcripts, and source artifacts remain immutable
 evidence. Dreaming promotes only explicit, high-confidence statements into
-current attribute slots.
+current attribute slots. In the default non-provider path, plain
+natural-language preference extraction is limited to confidence-bearing memory
+rows. Memory artifacts and transcripts are still readable evidence sources, but
+they must contain structured high-confidence `set_claim_value` or
+`claim_values` JSON unless the caller opts into `--use-provider`.
 
 ## Attribute Promotion Path
 

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -145,7 +145,7 @@ and market subdirectories). Reference repos live in `references/`.
 | `predictive-memory-scorer` | MSAM-COMPARISON | How should scoring balance structural vs behavioral signals? |
 | `desire-paths-epic`, `retroactive-supersession` | RESEARCH-COMPETITIVE-SYSTEMS | What retrieval, lifecycle, and integration patterns from competing systems should be adopted? |
 | `ontology-evolution-core`, `ontology-governance-workflow` | RESEARCH-ONTOLOGY-EVOLUTION | How should ontology schema and governance evolve without losing local-first simplicity? |
-| `ontology-proposal-loop` | RESEARCH-ONTOLOGY-EVOLUTION, memory-md-rolling-window-lineage, dreaming-memory-consolidation, model-provider-router | How should extraction and consolidation propose ontology changes without directly mutating semantic state? |
+| `ontology-proposal-loop` | RESEARCH-ONTOLOGY-EVOLUTION, memory-md-rolling-window-lineage, dreaming-memory-consolidation, model-provider-router | How should extraction and consolidation expose reviewable ontology changes while direct maintenance paths use the same audited operation handlers? |
 | `ssm-foundation-evaluation`, `ssm-temporal-backbone`, `ssm-graph-traversal-model` | RESEARCH-SSM-INTEGRATION, SSM-GRAPH-INTERSECTION, SSM-LITERATURE-REVIEW, SYNTHETIC-DATA-GENERATION | How should SSM research translate into benchmarked, staged deployment without violating retrieval invariants? |
 | `engram-informed-predictor-track` | arxiv:2601.07372, RESEARCH-SSM-INTEGRATION, ssm-foundation-evaluation | How should Engram design patterns be translated into Signet scorer and SSM architecture decisions? |
 | `macos-sqlite-runtime-discovery` | RESEARCH-MACOS-SQLITE-RUNTIME-DISCOVERY | How should Signet select a compatible SQLite runtime on macOS so Bun can load sqlite-vec? |
@@ -773,7 +773,7 @@ Legend:
 | `sub-agent-context-continuity` | approved | `docs/specs/approved/sub-agent-context-continuity.md` | `session-continuity-protocol`, `multi-agent-support` | - | Parent transcript query + deterministic sub-agent inheritance (issue #315) |
 | `ontology-evolution-core` | planning | `docs/specs/planning/ontology-evolution-core.md` | `knowledge-architecture-schema`, `desire-paths-epic` | `ontology-governance-workflow` | Confidence/provenance edges, co-occurrence signals, typed relationships, temporal lineage |
 | `ontology-governance-workflow` | planning | `docs/specs/planning/ontology-governance-workflow.md` | `ontology-evolution-core`, `knowledge-architecture-schema` | - | Proposal/review workflow for ontology-impacting schema changes |
-| `ontology-proposal-loop` | approved | `docs/specs/approved/ontology-proposal-loop.md` | `knowledge-architecture-schema`, `memory-md-rolling-window-lineage` | - | Agent-scoped proposal storage and explicit apply/reject loop for reviewable ontology maintenance |
+| `ontology-proposal-loop` | approved | `docs/specs/approved/ontology-proposal-loop.md` | `knowledge-architecture-schema`, `memory-md-rolling-window-lineage` | - | Agent-scoped proposal storage plus shared audited operation handlers for reviewable and direct ontology maintenance |
 | `ssm-foundation-evaluation` | planning | `docs/specs/planning/ssm-foundation-evaluation.md` | `predictive-memory-scorer`, `desire-paths-epic` | `ssm-temporal-backbone` | Benchmark harness and canary gates for SSM adoption |
 | `engram-informed-predictor-track` | planning | `docs/specs/planning/engram-informed-predictor-track.md` | `predictive-memory-scorer` | `ssm-temporal-backbone` | Engram-pattern translation lane for scorer ablations and SSM handoff contracts |
 | `ssm-temporal-backbone` | planning | `docs/specs/planning/ssm-temporal-backbone.md` | `ssm-foundation-evaluation`, `ontology-evolution-core`, `session-continuity-protocol` | `ssm-graph-traversal-model` | Shadow-mode temporal state model with fallback |
@@ -801,7 +801,7 @@ Legend:
 | `postinstall-behavior-migration-audit` | planning | `docs/specs/planning/postinstall-behavior-migration-audit.md` | `memory-pipeline-v2` | - | Stub: ensure post-install behavior is daemon/CLI-owned |
 | `docker-self-hosting-stack` | planning | `docs/specs/planning/docker-self-hosting-stack.md` | `signet-runtime` | - | First-party Docker image + Compose + Caddy deployment contract with team-mode bootstrap path and operations runbook |
 | `system-prompt-extraction` | approved | `docs/specs/approved/system-prompt-extraction.md` | - | - | Move Signet system prompt injection to session-start runtime context and keep AGENTS.md as user-owned identity content |
-| `dreaming-memory-consolidation` | approved | `docs/specs/approved/dreaming-memory-consolidation.md` | `memory-pipeline-v2`, `knowledge-architecture-schema` | - | Phase 1 (consolidation engine, trigger, config, API, CLI) delivered in PR #442. Phase 2 (dreaming-as-session, incremental deltas, V2 exclusion, chunked compaction, dashboard, identity context) deferred. |
+| `dreaming-memory-consolidation` | approved | `docs/specs/approved/dreaming-memory-consolidation.md` | `memory-pipeline-v2`, `knowledge-architecture-schema` | - | Phase 1 (consolidation engine, trigger, config, API, CLI) delivered in PR #442. Source-backed attribute promotion uses direct audited operations outside Pipeline V2. Phase 2 (dreaming-as-session, incremental deltas, V2 exclusion, chunked compaction, dashboard, identity context) deferred. |
 | `ci-changed-files-selective` | planning | `docs/specs/planning/ci-changed-files-selective.md` | `memory-pipeline-v2` | - | Stub: selective PR CI by changed package graph |
 | `ci-contract-invariants-lane` | planning | `docs/specs/planning/ci-contract-invariants-lane.md` | `knowledge-architecture-schema` | - | Stub: mandatory fast invariant contract checks, including frozen lockfile integrity |
 | `ci-flaky-test-quarantine` | planning | `docs/specs/planning/ci-flaky-test-quarantine.md` | `ci-contract-invariants-lane` | - | Stub: flaky detection, quarantine, threshold policy |
@@ -873,10 +873,10 @@ constraint surfacing and agent scoping invariants.
 proposal/review metadata, compatibility notes, and rollback guidance with
 INDEX/dependency consistency checks in CI.
 
-**ontology-proposal-loop**: Extraction and consolidation produce durable,
-agent-scoped proposal objects before ontology mutation. Operators and agents
-can inspect, apply, or reject proposed semantic changes with evidence and audit
-metadata preserved.
+**ontology-proposal-loop**: Extraction and consolidation can produce durable,
+agent-scoped proposal objects before ontology mutation. Direct maintenance
+paths such as dreaming promotion use the same audited operation handlers,
+with evidence and audit metadata preserved.
 
 **ssm-foundation-evaluation**: SSM benchmarks and canary suites produce
 reproducible, decision-grade comparisons against current scorer behavior.
@@ -897,11 +897,12 @@ constraint surfacing invariants.
 **dreaming-memory-consolidation**: Entity graph density increases after
 a dreaming pass. Duplicate and near-duplicate entities are merged
 automatically. Stale or junk attributes are pruned without manual
-intervention. Token spend per pass is bounded and configurable. Phase 1
-(mechanical consolidation engine) is delivered. Phase 2 (dreaming as a
-session, incremental deltas, pipeline mutual exclusion, chunked
-compaction, dashboard observability, identity context injection) is
-required before spec moves to `complete`.
+intervention. Source-backed evidence can be promoted into update-in-place
+attribute slots without Pipeline V2 extraction. Token spend per pass is
+bounded and configurable. Phase 1 (mechanical consolidation engine) is
+delivered. Phase 2 (dreaming as a session, incremental deltas, pipeline mutual
+exclusion, chunked compaction, dashboard observability, identity context
+injection) is required before spec moves to `complete`.
 
 **wave-9 strategic stubs**: The strategic backlog items listed in Wave 9
 are intentionally tracked as planning stubs and require dedicated planning

--- a/docs/specs/approved/dreaming-memory-consolidation.md
+++ b/docs/specs/approved/dreaming-memory-consolidation.md
@@ -438,10 +438,12 @@ The mechanical consolidation engine is complete:
   memories, memory artifacts, and transcripts as evidence and emits direct
   `set_claim_value` operations. Default mechanical natural-language promotion
   is limited to confidence-bearing memory rows; memory artifacts and
-  transcripts must provide structured high-confidence operation JSON or opt into
-  provider extraction. The route previews by default and applies only when
-  requested; it does not use Pipeline V2 extraction and does not create pending
-  proposals as the default path.
+  transcripts can provide structured operation JSON for preview, but raw source
+  JSON cannot self-attest confidence for direct apply. Plain prose in artifacts
+  or transcripts requires provider extraction or the proposal review path. The
+  route previews by default and applies only when requested; it does not use
+  Pipeline V2 extraction and does not create pending proposals as the default
+  path.
 - **CLI.** `signet dream status`, `signet dream trigger [--compact]`,
   `signet dream promote [--from <source>] [--apply]`.
 - **DB migration 055.** `dreaming_state` (per-agent PK) and

--- a/docs/specs/approved/dreaming-memory-consolidation.md
+++ b/docs/specs/approved/dreaming-memory-consolidation.md
@@ -294,9 +294,11 @@ summary-heavy.
 A CLI command triggers it explicitly:
 
 ```bash
-signet dream --compact    # run compaction now
-signet dream --status     # show dreaming state
-signet dream --trigger    # force a dreaming pass now
+signet dream trigger --compact    # run compaction now
+signet dream status               # show dreaming state
+signet dream trigger              # force a dreaming pass now
+signet dream promote --from all    # preview source-backed attribute promotion
+signet dream promote --from all --apply
 ```
 
 
@@ -432,7 +434,13 @@ The mechanical consolidation engine is complete:
   provider config -- avoids duplication and supports all synthesis
   backends including `claude-code`, `codex`, `opencode`, etc.).
 - **API.** `GET /api/dream/status`, `POST /api/dream/trigger`.
-- **CLI.** `signet dream status`, `signet dream trigger [--compact]`.
+- **Source-backed promotion.** `POST /api/dream/promote` reads saved
+  memories, memory artifacts, and transcripts as evidence and emits direct
+  `set_claim_value` operations. The route previews by default and applies only
+  when requested; it does not use Pipeline V2 extraction and does not create
+  pending proposals as the default path.
+- **CLI.** `signet dream status`, `signet dream trigger [--compact]`,
+  `signet dream promote [--from <source>] [--apply]`.
 - **DB migration 055.** `dreaming_state` (per-agent PK) and
   `dreaming_passes` (audit log with applied/skipped/failed counts).
 - **Graph safety.** LIMIT caps on entity graph queries (2000 entities,

--- a/docs/specs/approved/dreaming-memory-consolidation.md
+++ b/docs/specs/approved/dreaming-memory-consolidation.md
@@ -436,9 +436,12 @@ The mechanical consolidation engine is complete:
 - **API.** `GET /api/dream/status`, `POST /api/dream/trigger`.
 - **Source-backed promotion.** `POST /api/dream/promote` reads saved
   memories, memory artifacts, and transcripts as evidence and emits direct
-  `set_claim_value` operations. The route previews by default and applies only
-  when requested; it does not use Pipeline V2 extraction and does not create
-  pending proposals as the default path.
+  `set_claim_value` operations. Default mechanical natural-language promotion
+  is limited to confidence-bearing memory rows; memory artifacts and
+  transcripts must provide structured high-confidence operation JSON or opt into
+  provider extraction. The route previews by default and applies only when
+  requested; it does not use Pipeline V2 extraction and does not create pending
+  proposals as the default path.
 - **CLI.** `signet dream status`, `signet dream trigger [--compact]`,
   `signet dream promote [--from <source>] [--apply]`.
 - **DB migration 055.** `dreaming_state` (per-agent PK) and

--- a/docs/specs/approved/ontology-proposal-loop.md
+++ b/docs/specs/approved/ontology-proposal-loop.md
@@ -162,10 +162,12 @@ It writes pending proposals only when `write_proposals` is true.
 skill. It reads memories, memory artifacts, and transcripts as evidence and
 emits `set_claim_value` operations. The default non-provider path only
 mechanically promotes natural-language statements from confidence-bearing memory
-rows; artifacts and transcripts need structured high-confidence operation JSON
-or provider extraction. The default mode is dry-run. When `apply` is true, the
-route uses the same audited operation handlers and stores applied lineage, but
-it does not create pending proposal work items.
+rows; artifacts and transcripts can provide structured operation JSON for
+preview, but raw source JSON cannot self-attest confidence for direct apply.
+Plain prose in artifacts or transcripts requires provider extraction or the
+proposal review path. The default mode is dry-run. When `apply` is true, the
+route uses the same audited operation handlers and stores applied lineage, but it
+does not create pending proposal work items.
 
 ## CLI contract
 

--- a/docs/specs/approved/ontology-proposal-loop.md
+++ b/docs/specs/approved/ontology-proposal-loop.md
@@ -160,9 +160,12 @@ It writes pending proposals only when `write_proposals` is true.
 
 `/api/dream/promote` is a direct applied maintenance path for the dreaming
 skill. It reads memories, memory artifacts, and transcripts as evidence and
-emits `set_claim_value` operations. The default mode is dry-run. When `apply`
-is true, the route uses the same audited operation handlers and stores applied
-lineage, but it does not create pending proposal work items.
+emits `set_claim_value` operations. The default non-provider path only
+mechanically promotes natural-language statements from confidence-bearing memory
+rows; artifacts and transcripts need structured high-confidence operation JSON
+or provider extraction. The default mode is dry-run. When `apply` is true, the
+route uses the same audited operation handlers and stores applied lineage, but
+it does not create pending proposal work items.
 
 ## CLI contract
 

--- a/docs/specs/approved/ontology-proposal-loop.md
+++ b/docs/specs/approved/ontology-proposal-loop.md
@@ -17,9 +17,9 @@ soft_depends_on:
 success_criteria:
   - "Extraction and consolidation can persist proposed ontology operations without mutating ontology state"
   - "Operators and agents can list, inspect, apply, and reject proposals through daemon API and CLI surfaces"
-  - "Applied proposals record audit metadata and mutate ontology state only through explicit operation handlers"
+  - "Applied proposals and direct applied operations record audit metadata and mutate ontology state only through explicit operation handlers"
   - "All proposal reads and writes are agent-scoped and preserve evidence references for later lineage inspection"
-scope_boundary: "Defines the first reviewable mutation loop for ontology maintenance. It does not define the full object-type/interface ontology, node-graph UI, or ACPX provider backend."
+scope_boundary: "Defines the first reviewable mutation loop for ontology maintenance and the shared operation handlers used by direct applied maintenance paths. It does not define the full object-type/interface ontology, node-graph UI, or ACPX provider backend."
 ---
 
 # Ontology Proposal Loop
@@ -31,8 +31,8 @@ source-backed artifacts, and graph traversal. The missing first-class object is
 the reviewable semantic proposal: a durable record that says, "based on this
 evidence, here is an ontology change worth making."
 
-Without proposal objects, extraction and consolidation have only two bad
-choices:
+Without proposal objects and audited operation handlers, extraction and
+consolidation have only two bad choices:
 
 1. write directly into ontology state and risk promoting weak evidence into
    truth; or
@@ -40,11 +40,14 @@ choices:
 
 The proposal loop gives Signet a middle path. Agents can reason over
 transcripts and source artifacts, emit candidate ontology operations, inspect
-them, and apply or reject them explicitly.
+them, and apply or reject them explicitly. The same operation handlers are
+also the allowed path for direct dreaming promotion when evidence is explicit
+enough to skip a pending review queue.
 
 ## Goals
 
-1. Make ontology maintenance proposal-first instead of write-first.
+1. Make reviewable ontology maintenance proposal-first instead of ad hoc
+   writes.
 2. Keep the daemon responsible for durable storage, agent scoping, API
    contracts, and explicit mutation application.
 3. Keep inference providers and harness-backed reasoning outside this first
@@ -111,6 +114,7 @@ The first implementation supports a small, safe set:
 - `create_entity`
 - `merge_entities`
 - `add_claim_value`
+- `set_claim_value`
 - `supersede_claim_value`
 - `create_link`
 
@@ -141,6 +145,8 @@ POST /api/ontology/proposals/batch
 POST /api/ontology/proposals/repair/duplicates
 POST /api/ontology/proposals/:id/apply
 POST /api/ontology/proposals/:id/reject
+POST /api/ontology/operations/batch
+POST /api/dream/promote
 ```
 
 Read routes require recall permission. Mutation routes require modify
@@ -151,6 +157,12 @@ scope when absent.
 entities for duplicate `canonical_name` values, picks the strongest existing
 entity as the merge target, and returns candidate `merge_entities` operations.
 It writes pending proposals only when `write_proposals` is true.
+
+`/api/dream/promote` is a direct applied maintenance path for the dreaming
+skill. It reads memories, memory artifacts, and transcripts as evidence and
+emits `set_claim_value` operations. The default mode is dry-run. When `apply`
+is true, the route uses the same audited operation handlers and stores applied
+lineage, but it does not create pending proposal work items.
 
 ## CLI contract
 
@@ -177,6 +189,8 @@ signet ontology repair --duplicates --dry-run
 signet ontology repair --duplicates --write-proposals
 signet ontology apply <id>
 signet ontology reject <id> --reason "weak evidence"
+signet dream promote --from all
+signet dream promote --from all --apply
 ```
 
 The CLI is a thin wrapper over the daemon API. It should not apply ontology
@@ -206,7 +220,9 @@ without introducing a second read model before typed object interfaces exist.
 
 or the extraction-output shape from this spec's prompt examples
 (`entities`, `claim_values`, `links`, and `actions_or_policies`). Importing
-only creates pending proposals. It does not apply them.
+only creates pending proposals. It does not apply them. Dreaming promotion is
+intentionally separate: it previews direct operations by default and only
+applies them when called with `--apply`.
 
 Provider extraction may also return `questions`. This slice surfaces those
 questions in the extraction result for operator or later stronger-model review;

--- a/platform/daemon/src/daemon-auth-guard-colocation.test.ts
+++ b/platform/daemon/src/daemon-auth-guard-colocation.test.ts
@@ -238,6 +238,15 @@ describe("auth guard co-location", () => {
 		});
 	});
 
+	describe("dream routes need guards", () => {
+		it("POST /api/dream/promote returns 403 without auth", async () => {
+			const app = await makeApp();
+			const { registerPipelineRoutes } = await import("./routes/pipeline-routes");
+			registerPipelineRoutes(app);
+			expect(await status(app, "POST", "/api/dream/promote")).toBe(403);
+		});
+	});
+
 	describe("connector routes need guards", () => {
 		it("POST /api/connectors returns 403 without auth", async () => {
 			const app = await makeApp();

--- a/platform/daemon/src/dream-promotion.test.ts
+++ b/platform/daemon/src/dream-promotion.test.ts
@@ -19,13 +19,19 @@ describe("dreaming evidence promotion", () => {
 		rmSync(dir, { recursive: true, force: true });
 	});
 
-	function insertMemory(id: string, content: string, agentId = "ant", updatedAt = "2026-05-16T10:00:00.000Z"): void {
+	function insertMemory(
+		id: string,
+		content: string,
+		agentId = "ant",
+		updatedAt = "2026-05-16T10:00:00.000Z",
+		confidence = 0.9,
+	): void {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
 				`INSERT INTO memories
 				 (id, type, content, confidence, importance, project, created_at, updated_at, updated_by, agent_id)
-				 VALUES (?, 'preference', ?, 0.9, 0.8, '/tmp/signet', ?, ?, 'test', ?)`,
-			).run(id, content, updatedAt, updatedAt, agentId);
+				 VALUES (?, 'preference', ?, ?, 0.8, '/tmp/signet', ?, ?, 'test', ?)`,
+			).run(id, content, confidence, updatedAt, updatedAt, agentId);
 		});
 	}
 
@@ -195,6 +201,32 @@ describe("dreaming evidence promotion", () => {
 		expect(rows).toHaveLength(0);
 	});
 
+	it("skips mechanical preference extraction from low-confidence memories", async () => {
+		insertMemory(
+			"mem-low-confidence-text",
+			"Nicholai prefers weakly supported memories when we're testing.",
+			"ant",
+			"2026-05-16T12:06:00.000Z",
+			0.1,
+		);
+
+		const result = await promoteDreamingEvidence(getDbAccessor(), {
+			agentId: "ant",
+			from: "memory:mem-low-confidence-text",
+			apply: true,
+		});
+
+		expect(result.count).toBe(0);
+		expect(result.appliedCount).toBe(0);
+		const rows = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT content FROM entity_attributes WHERE agent_id = ?").all("ant") as Array<{
+					content: string;
+				}>,
+		);
+		expect(rows).toHaveLength(0);
+	});
+
 	it("does not split the all-source candidate limit across source classes", async () => {
 		insertMemory(
 			"mem-all-1",
@@ -266,9 +298,12 @@ describe("dreaming evidence promotion", () => {
 		});
 
 		expect(result.sources.map((source) => source.kind).sort()).toEqual(["artifact", "memory", "transcript"]);
+		expect(result.sources.map((source) => source.sourceId)).toContain("mem-all");
+		expect(result.sources.map((source) => source.sourcePath)).toContain("memory/artifact.md");
+		expect(result.sources.map((source) => source.sourcePath)).not.toContain("memory/deleted.md");
+		expect(result.sources.map((source) => source.sourcePath)).not.toContain("memory/other.md");
+		expect(result.sources.map((source) => source.sourceId)).toContain("sess-transcript");
 		expect(result.operations.map((operation) => operation.sourceId)).toContain("mem-all");
-		expect(result.operations.map((operation) => operation.sourcePath)).toContain("memory/artifact.md");
-		expect(result.operations.map((operation) => operation.sourceId)).toContain("sess-transcript");
 		expect(result.operations.map((operation) => operation.sourceId)).not.toContain("mem-other");
 		expect(result.operations.map((operation) => operation.sourcePath)).not.toContain("memory/deleted.md");
 		expect(result.operations.map((operation) => operation.sourcePath)).not.toContain("memory/other.md");

--- a/platform/daemon/src/dream-promotion.test.ts
+++ b/platform/daemon/src/dream-promotion.test.ts
@@ -142,6 +142,59 @@ describe("dreaming evidence promotion", () => {
 		expect(claims[1]?.previous_attribute_id).toBeString();
 	});
 
+	it("skips explicit embedded operations without high-confidence low-risk evidence", async () => {
+		insertMemory(
+			"mem-low-confidence-json",
+			JSON.stringify({
+				operations: [
+					{
+						operation: "set_claim_value",
+						payload: {
+							entity: "Nicholai",
+							aspect: "preferences",
+							group_key: "workflow",
+							claim_key: "low_confidence_slot",
+							value: "Nicholai prefers weak evidence when testing.",
+							kind: "attribute",
+						},
+						confidence: 0.1,
+						risk: "low",
+					},
+					{
+						operation: "set_claim_value",
+						payload: {
+							entity: "Nicholai",
+							aspect: "preferences",
+							group_key: "workflow",
+							claim_key: "high_risk_slot",
+							value: "Nicholai prefers high-risk evidence when testing.",
+							kind: "attribute",
+						},
+						confidence: 0.95,
+						risk: "high",
+					},
+				],
+			}),
+		);
+
+		const result = await promoteDreamingEvidence(getDbAccessor(), {
+			agentId: "ant",
+			from: "memory:mem-low-confidence-json",
+			apply: true,
+		});
+
+		expect(result.count).toBe(0);
+		expect(result.appliedCount).toBe(0);
+		expect(result.skipped).toEqual(["No explicit high-confidence attribute promotions found."]);
+		const rows = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT content FROM entity_attributes WHERE agent_id = ?").all("ant") as Array<{
+					content: string;
+				}>,
+		);
+		expect(rows).toHaveLength(0);
+	});
+
 	it("reads all evidence sources in agent scope and skips deleted or other-agent artifacts", async () => {
 		insertMemory("mem-all", "Nicholai prefers compact status updates when we're pairing.");
 		insertMemory("mem-other", "Nicholai prefers noisy updates when we're pairing.", "other");

--- a/platform/daemon/src/dream-promotion.test.ts
+++ b/platform/daemon/src/dream-promotion.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { promoteDreamingEvidence } from "./dream-promotion";
+
+describe("dreaming evidence promotion", () => {
+	let dir = "";
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "signet-dream-promotion-"));
+		mkdirSync(join(dir, "memory"), { recursive: true });
+		initDbAccessor(join(dir, "memory", "memories.db"));
+	});
+
+	afterEach(() => {
+		closeDbAccessor();
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	function insertMemory(id: string, content: string, agentId = "ant", updatedAt = "2026-05-16T10:00:00.000Z"): void {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memories
+				 (id, type, content, confidence, importance, project, created_at, updated_at, updated_by, agent_id)
+				 VALUES (?, 'preference', ?, 0.9, 0.8, '/tmp/signet', ?, ?, 'test', ?)`,
+			).run(id, content, updatedAt, updatedAt, agentId);
+		});
+	}
+
+	function readActiveClaims(): Array<{
+		content: string;
+		status: string;
+		version: number;
+		previous_attribute_id: string | null;
+		source_kind: string | null;
+		source_id: string | null;
+	}> {
+		return getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare(
+						`SELECT attr.content, attr.status, attr.version, attr.previous_attribute_id,
+						        attr.source_kind, attr.source_id
+						 FROM entity_attributes attr
+						 JOIN entity_aspects asp ON asp.id = attr.aspect_id
+						 JOIN entities e ON e.id = asp.entity_id
+						 WHERE e.agent_id = 'ant'
+						   AND e.name = 'Nicholai'
+						   AND asp.name = 'preferences'
+						   AND attr.group_key = 'workflow'
+						   AND attr.claim_key = 'prefers_xyz_when_we_re_doing_that'
+						   AND attr.kind = 'attribute'
+						 ORDER BY attr.version ASC`,
+					)
+					.all() as Array<{
+					content: string;
+					status: string;
+					version: number;
+					previous_attribute_id: string | null;
+					source_kind: string | null;
+					source_id: string | null;
+				}>,
+		);
+	}
+
+	it("previews direct set_claim_value operations from saved memory artifacts without mutating attributes", async () => {
+		insertMemory("mem-pref", "Nicholai prefers xyz to be like this when we're doing that.");
+
+		const result = await promoteDreamingEvidence(getDbAccessor(), {
+			agentId: "ant",
+			from: "memory:mem-pref",
+		});
+
+		expect(result.dryRun).toBe(true);
+		expect(result.count).toBe(1);
+		expect(result.appliedCount).toBe(0);
+		expect(result.sources[0]?.kind).toBe("memory");
+		expect(result.operations[0]?.operation).toBe("set_claim_value");
+		expect(result.operations[0]?.payload).toMatchObject({
+			entity: "Nicholai",
+			aspect: "preferences",
+			group_key: "workflow",
+			claim_key: "prefers_xyz_when_we_re_doing_that",
+			value: "Nicholai prefers xyz to be like this when we're doing that.",
+			kind: "attribute",
+		});
+
+		expect(readActiveClaims()).toHaveLength(0);
+	});
+
+	it("applies preference memories into the current attribute slot and supersedes older values", async () => {
+		insertMemory("mem-pref-1", "Nicholai prefers xyz to be like this when we're doing that.");
+		const first = await promoteDreamingEvidence(getDbAccessor(), {
+			agentId: "ant",
+			from: "memory:mem-pref-1",
+			apply: true,
+			actor: "test-dreaming",
+		});
+
+		expect(first.dryRun).toBe(false);
+		expect(first.appliedCount).toBe(1);
+		expect(readActiveClaims()).toMatchObject([
+			{
+				content: "Nicholai prefers xyz to be like this when we're doing that.",
+				status: "active",
+				version: 1,
+				previous_attribute_id: null,
+				source_kind: "memory",
+				source_id: "mem-pref-1",
+			},
+		]);
+
+		insertMemory(
+			"mem-pref-2",
+			"Nicholai prefers xyz to be updated when we're doing that.",
+			"ant",
+			"2026-05-16T11:00:00.000Z",
+		);
+		const second = await promoteDreamingEvidence(getDbAccessor(), {
+			agentId: "ant",
+			from: "memory:mem-pref-2",
+			apply: true,
+			actor: "test-dreaming",
+		});
+
+		expect(second.appliedCount).toBe(1);
+		const claims = readActiveClaims();
+		expect(claims).toHaveLength(2);
+		expect(claims[0]).toMatchObject({
+			content: "Nicholai prefers xyz to be like this when we're doing that.",
+			status: "superseded",
+			version: 1,
+		});
+		expect(claims[1]).toMatchObject({
+			content: "Nicholai prefers xyz to be updated when we're doing that.",
+			status: "active",
+			version: 2,
+			source_id: "mem-pref-2",
+		});
+		expect(claims[1]?.previous_attribute_id).toBeString();
+	});
+
+	it("reads all evidence sources in agent scope and skips deleted or other-agent artifacts", async () => {
+		insertMemory("mem-all", "Nicholai prefers compact status updates when we're pairing.");
+		insertMemory("mem-other", "Nicholai prefers noisy updates when we're pairing.", "other");
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memory_artifacts
+				 (agent_id, source_path, source_sha256, source_kind, session_id, session_key, session_token,
+				  project, harness, captured_at, content, updated_at, is_deleted)
+				 VALUES
+				 ('ant', 'memory/artifact.md', 'sha1', 'artifact', 'sess-a', 'sess-a', 'tok-a',
+				  '/tmp/signet', 'codex', '2026-05-16T12:00:00.000Z',
+				  'Nicholai prefers direct apply paths when evidence is explicit.', '2026-05-16T12:00:00.000Z', 0),
+				 ('ant', 'memory/deleted.md', 'sha2', 'artifact', 'sess-b', 'sess-b', 'tok-b',
+				  '/tmp/signet', 'codex', '2026-05-16T12:01:00.000Z',
+				  'Nicholai prefers deleted evidence when testing.', '2026-05-16T12:01:00.000Z', 1),
+				 ('other', 'memory/other.md', 'sha3', 'artifact', 'sess-c', 'sess-c', 'tok-c',
+				  '/tmp/signet', 'codex', '2026-05-16T12:02:00.000Z',
+				  'Nicholai prefers other-agent evidence when testing.', '2026-05-16T12:02:00.000Z', 0)`,
+			).run();
+			db.prepare(
+				`INSERT INTO session_transcripts
+				 (session_key, content, harness, project, agent_id, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			).run(
+				"sess-transcript",
+				"Nicholai prefers transcript-backed evidence when explicit.",
+				"codex",
+				"/tmp/signet",
+				"ant",
+				"2026-05-16T12:03:00.000Z",
+				"2026-05-16T12:03:00.000Z",
+			);
+		});
+
+		const result = await promoteDreamingEvidence(getDbAccessor(), {
+			agentId: "ant",
+			from: "all",
+			limit: 20,
+		});
+
+		expect(result.sources.map((source) => source.kind).sort()).toEqual(["artifact", "memory", "transcript"]);
+		expect(result.operations.map((operation) => operation.sourceId)).toContain("mem-all");
+		expect(result.operations.map((operation) => operation.sourcePath)).toContain("memory/artifact.md");
+		expect(result.operations.map((operation) => operation.sourceId)).toContain("sess-transcript");
+		expect(result.operations.map((operation) => operation.sourceId)).not.toContain("mem-other");
+		expect(result.operations.map((operation) => operation.sourcePath)).not.toContain("memory/deleted.md");
+		expect(result.operations.map((operation) => operation.sourcePath)).not.toContain("memory/other.md");
+	});
+});

--- a/platform/daemon/src/dream-promotion.test.ts
+++ b/platform/daemon/src/dream-promotion.test.ts
@@ -195,6 +195,36 @@ describe("dreaming evidence promotion", () => {
 		expect(rows).toHaveLength(0);
 	});
 
+	it("does not split the all-source candidate limit across source classes", async () => {
+		insertMemory(
+			"mem-all-1",
+			"Nicholai prefers compact first updates when we're pairing.",
+			"ant",
+			"2026-05-16T12:05:00.000Z",
+		);
+		insertMemory(
+			"mem-all-2",
+			"Nicholai prefers compact second updates when we're pairing.",
+			"ant",
+			"2026-05-16T12:04:00.000Z",
+		);
+		insertMemory(
+			"mem-all-3",
+			"Nicholai prefers compact third updates when we're pairing.",
+			"ant",
+			"2026-05-16T12:03:00.000Z",
+		);
+
+		const result = await promoteDreamingEvidence(getDbAccessor(), {
+			agentId: "ant",
+			from: "all",
+			limit: 3,
+		});
+
+		expect(result.count).toBe(3);
+		expect(result.operations.map((operation) => operation.sourceId)).toEqual(["mem-all-1", "mem-all-2", "mem-all-3"]);
+	});
+
 	it("reads all evidence sources in agent scope and skips deleted or other-agent artifacts", async () => {
 		insertMemory("mem-all", "Nicholai prefers compact status updates when we're pairing.");
 		insertMemory("mem-other", "Nicholai prefers noisy updates when we're pairing.", "other");

--- a/platform/daemon/src/dream-promotion.test.ts
+++ b/platform/daemon/src/dream-promotion.test.ts
@@ -201,6 +201,48 @@ describe("dreaming evidence promotion", () => {
 		expect(rows).toHaveLength(0);
 	});
 
+	it("keeps self-attested embedded operations in preview during apply", async () => {
+		insertMemory(
+			"mem-self-attested-json",
+			JSON.stringify({
+				operations: [
+					{
+						operation: "set_claim_value",
+						payload: {
+							entity: "Nicholai",
+							aspect: "preferences",
+							group_key: "workflow",
+							claim_key: "self_attested_slot",
+							value: "Nicholai prefers self-attested JSON when testing.",
+							kind: "attribute",
+						},
+						confidence: 0.99,
+						risk: "low",
+					},
+				],
+			}),
+		);
+
+		const result = await promoteDreamingEvidence(getDbAccessor(), {
+			agentId: "ant",
+			from: "memory:mem-self-attested-json",
+			apply: true,
+		});
+
+		expect(result.count).toBe(1);
+		expect(result.appliedCount).toBe(0);
+		expect(result.warnings).toEqual([
+			"1 embedded operation left in preview because source JSON cannot self-attest confidence for direct apply.",
+		]);
+		const rows = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT content FROM entity_attributes WHERE agent_id = ?").all("ant") as Array<{
+					content: string;
+				}>,
+		);
+		expect(rows).toHaveLength(0);
+	});
+
 	it("skips mechanical preference extraction from low-confidence memories", async () => {
 		insertMemory(
 			"mem-low-confidence-text",

--- a/platform/daemon/src/dream-promotion.ts
+++ b/platform/daemon/src/dream-promotion.ts
@@ -83,6 +83,7 @@ const DEFAULT_PROVIDER_TIMEOUT_MS = 90_000;
 const MAX_PROVIDER_TIMEOUT_MS = 10 * 60_000;
 const DEFAULT_PROVIDER_MAX_TOKENS = 4096;
 const MAX_PROVIDER_MAX_TOKENS = 16_000;
+const MIN_EXPLICIT_CONFIDENCE = 0.75;
 
 function boundedInt(value: number | undefined, fallback: number, min: number, max: number): number {
 	if (value === undefined || !Number.isFinite(value)) return fallback;
@@ -103,6 +104,19 @@ function readString(record: Readonly<Record<string, unknown>>, key: string): str
 function readNumber(record: Readonly<Record<string, unknown>>, key: string): number | undefined {
 	const value = record[key];
 	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function explicitConfidence(
+	raw: Readonly<Record<string, unknown>>,
+	payload: Readonly<Record<string, unknown>>,
+): number | null {
+	const confidence = readNumber(raw, "confidence") ?? readNumber(payload, "confidence");
+	if (confidence === undefined || confidence < MIN_EXPLICIT_CONFIDENCE || confidence > 1) return null;
+	return confidence;
+}
+
+function isBlockedRisk(value: string | null): boolean {
+	return value?.toLowerCase() === "high";
 }
 
 function readArray(record: Readonly<Record<string, unknown>>, key: string): readonly unknown[] {
@@ -510,6 +524,8 @@ function normalizeExplicitOperation(raw: unknown, source: SourceRecord): DreamPr
 	const payload = isRecord(raw.payload) ? raw.payload : {};
 	const kind = readString(payload, "kind") ?? "attribute";
 	if (kind !== "attribute") return null;
+	const confidence = explicitConfidence(raw, payload);
+	if (confidence === null || isBlockedRisk(readString(raw, "risk"))) return null;
 	const entity = readString(payload, "entity");
 	const aspect = readString(payload, "aspect");
 	const claimKey = readString(payload, "claim_key") ?? readString(payload, "claim");
@@ -521,8 +537,9 @@ function normalizeExplicitOperation(raw: unknown, source: SourceRecord): DreamPr
 			...payload,
 			claim_key: claimKey,
 			kind,
+			confidence,
 		},
-		confidence: readNumber(raw, "confidence") ?? readNumber(payload, "confidence"),
+		confidence,
 		reason:
 			readString(raw, "reason") ??
 			readString(raw, "rationale") ??
@@ -540,6 +557,8 @@ function normalizeClaimValue(raw: unknown, source: SourceRecord): DreamPromotion
 	if (!isRecord(raw)) return null;
 	const kind = readString(raw, "kind") ?? "attribute";
 	if (kind !== "attribute") return null;
+	const confidence = explicitConfidence(raw, raw);
+	if (confidence === null || isBlockedRisk(readString(raw, "risk"))) return null;
 	const entity = readString(raw, "entity");
 	const aspect = readString(raw, "aspect");
 	const claimKey = readString(raw, "claim_key") ?? readString(raw, "claim");
@@ -555,10 +574,10 @@ function normalizeClaimValue(raw: unknown, source: SourceRecord): DreamPromotion
 			claim_key: claimKey,
 			value,
 			kind,
-			confidence: readNumber(raw, "confidence"),
+			confidence,
 			importance: readNumber(raw, "importance"),
 		},
-		confidence: readNumber(raw, "confidence"),
+		confidence,
 		reason:
 			readString(raw, "reason") ??
 			readString(raw, "rationale") ??

--- a/platform/daemon/src/dream-promotion.ts
+++ b/platform/daemon/src/dream-promotion.ts
@@ -40,6 +40,7 @@ export interface DreamPromotionOperation {
 	readonly sourceId?: string | null;
 	readonly sourcePath?: string | null;
 	readonly sourceRoot?: string | null;
+	readonly trustedForApply?: boolean;
 }
 
 export interface DreamPromotionParams {
@@ -523,12 +524,17 @@ function mechanicalPreferenceOperations(source: SourceRecord): DreamPromotionOpe
 			sourceId: source.sourceId,
 			sourcePath: source.sourcePath,
 			sourceRoot: source.kind,
+			trustedForApply: true,
 		});
 	}
 	return operations;
 }
 
-function normalizeExplicitOperation(raw: unknown, source: SourceRecord): DreamPromotionOperation | null {
+function normalizeExplicitOperation(
+	raw: unknown,
+	source: SourceRecord,
+	trustedForApply: boolean,
+): DreamPromotionOperation | null {
 	if (!isRecord(raw)) return null;
 	const operation = readString(raw, "operation");
 	if (operation !== "set_claim_value") return null;
@@ -561,10 +567,15 @@ function normalizeExplicitOperation(raw: unknown, source: SourceRecord): DreamPr
 		sourceId: source.sourceId,
 		sourcePath: source.sourcePath,
 		sourceRoot: source.kind,
+		trustedForApply,
 	};
 }
 
-function normalizeClaimValue(raw: unknown, source: SourceRecord): DreamPromotionOperation | null {
+function normalizeClaimValue(
+	raw: unknown,
+	source: SourceRecord,
+	trustedForApply: boolean,
+): DreamPromotionOperation | null {
 	if (!isRecord(raw)) return null;
 	const kind = readString(raw, "kind") ?? "attribute";
 	if (kind !== "attribute") return null;
@@ -599,6 +610,7 @@ function normalizeClaimValue(raw: unknown, source: SourceRecord): DreamPromotion
 		sourceId: source.sourceId,
 		sourcePath: source.sourcePath,
 		sourceRoot: source.kind,
+		trustedForApply,
 	};
 }
 
@@ -621,6 +633,7 @@ function extractJsonBlocks(content: string): unknown[] {
 function normalizeJsonOperations(
 	raw: unknown,
 	source: SourceRecord,
+	trustedForApply: boolean,
 ): {
 	readonly operations: readonly DreamPromotionOperation[];
 	readonly questions: readonly string[];
@@ -628,16 +641,16 @@ function normalizeJsonOperations(
 	if (Array.isArray(raw))
 		return {
 			operations: raw
-				.map((item) => normalizeExplicitOperation(item, source))
+				.map((item) => normalizeExplicitOperation(item, source, trustedForApply))
 				.filter((item): item is DreamPromotionOperation => item !== null),
 			questions: [],
 		};
 	if (!isRecord(raw)) return { operations: [], questions: [] };
 	const explicit = readArray(raw, "operations")
-		.map((item) => normalizeExplicitOperation(item, source))
+		.map((item) => normalizeExplicitOperation(item, source, trustedForApply))
 		.filter((item): item is DreamPromotionOperation => item !== null);
 	const claims = readArray(raw, "claim_values")
-		.map((item) => normalizeClaimValue(item, source))
+		.map((item) => normalizeClaimValue(item, source, trustedForApply))
 		.filter((item): item is DreamPromotionOperation => item !== null);
 	return {
 		operations: [...explicit, ...claims],
@@ -665,7 +678,7 @@ function parseProviderOutput(
 		const parsed = tryParseJson(object);
 		if (parsed !== null) candidates.push(parsed);
 	}
-	const parsed = candidates.map((candidate) => normalizeJsonOperations(candidate, source));
+	const parsed = candidates.map((candidate) => normalizeJsonOperations(candidate, source, true));
 	return {
 		operations: parsed.flatMap((item) => item.operations),
 		questions: [...new Set(parsed.flatMap((item) => item.questions).map((item) => item.trim()))],
@@ -676,7 +689,9 @@ function extractExplicitOperations(source: SourceRecord): {
 	readonly operations: readonly DreamPromotionOperation[];
 	readonly questions: readonly string[];
 } {
-	const parsed = extractJsonBlocks(source.content).map((candidate) => normalizeJsonOperations(candidate, source));
+	const parsed = extractJsonBlocks(source.content).map((candidate) =>
+		normalizeJsonOperations(candidate, source, false),
+	);
 	return {
 		operations: parsed.flatMap((item) => item.operations),
 		questions: [...new Set(parsed.flatMap((item) => item.questions).map((item) => item.trim()))],
@@ -808,12 +823,19 @@ export async function promoteDreamingEvidence(
 	if (deduped.length === 0 && sources.length > 0) {
 		skipped.push("No explicit high-confidence attribute promotions found.");
 	}
+	const applyable = params.apply === true ? deduped.filter((operation) => operation.trustedForApply === true) : deduped;
+	const previewOnly = deduped.length - applyable.length;
+	if (params.apply === true && previewOnly > 0) {
+		warnings.push(
+			`${previewOnly} embedded operation${previewOnly === 1 ? "" : "s"} left in preview because source JSON cannot self-attest confidence for direct apply.`,
+		);
+	}
 	const applied =
-		deduped.length > 0
+		applyable.length > 0
 			? applyOntologyOperationBatch(accessor, {
 					agentId: params.agentId,
 					actor: params.actor ?? "dreaming-promote",
-					operations: deduped,
+					operations: applyable,
 					dryRun: params.apply !== true,
 					propose: false,
 				})

--- a/platform/daemon/src/dream-promotion.ts
+++ b/platform/daemon/src/dream-promotion.ts
@@ -1,0 +1,803 @@
+import type { LlmProvider } from "@signet/core";
+import type { DbAccessor, ReadDb } from "./db-accessor";
+import { type ApplyOntologyOperationBatchResult, applyOntologyOperationBatch } from "./ontology-proposals";
+import { extractBalancedJsonObject, stripFences, tryParseJson } from "./pipeline/extraction";
+
+type SourceKind = "memory" | "artifact" | "transcript";
+
+type SourceRecord = {
+	readonly kind: SourceKind;
+	readonly id: string;
+	readonly content: string;
+	readonly sourceKind: string;
+	readonly sourceId: string;
+	readonly sourcePath: string | null;
+	readonly project: string | null;
+	readonly harness: string | null;
+	readonly capturedAt: string;
+};
+
+export interface DreamPromotionSourceInfo {
+	readonly kind: SourceKind;
+	readonly id: string;
+	readonly sourceKind: string;
+	readonly sourceId: string;
+	readonly sourcePath: string | null;
+	readonly project: string | null;
+	readonly harness: string | null;
+	readonly capturedAt: string;
+}
+
+export interface DreamPromotionOperation {
+	readonly operation: "set_claim_value";
+	readonly payload: Readonly<Record<string, unknown>>;
+	readonly reason?: string;
+	readonly evidence?: readonly unknown[];
+	readonly confidence?: number;
+	readonly risk?: string | null;
+	readonly sourceKind?: string | null;
+	readonly sourceId?: string | null;
+	readonly sourcePath?: string | null;
+	readonly sourceRoot?: string | null;
+}
+
+export interface DreamPromotionParams {
+	readonly agentId: string;
+	readonly from: string;
+	readonly apply?: boolean;
+	readonly actor?: string;
+	readonly limit?: number;
+	readonly useProvider?: boolean;
+	readonly provider?: LlmProvider | null;
+	readonly providerTimeoutMs?: number;
+	readonly providerMaxTokens?: number;
+}
+
+export interface DreamPromotionResult {
+	readonly sources: readonly DreamPromotionSourceInfo[];
+	readonly operations: readonly DreamPromotionOperation[];
+	readonly applied: ApplyOntologyOperationBatchResult | null;
+	readonly count: number;
+	readonly appliedCount: number;
+	readonly skipped: readonly string[];
+	readonly questions: readonly string[];
+	readonly warnings: readonly string[];
+	readonly dryRun: boolean;
+	readonly providerName: string | null;
+}
+
+export class DreamPromotionError extends Error {
+	constructor(
+		message: string,
+		readonly status: 400 | 404,
+	) {
+		super(message);
+		this.name = "DreamPromotionError";
+	}
+}
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 500;
+const MAX_PROVIDER_INPUT_CHARS = 20_000;
+const DEFAULT_PROVIDER_TIMEOUT_MS = 90_000;
+const MAX_PROVIDER_TIMEOUT_MS = 10 * 60_000;
+const DEFAULT_PROVIDER_MAX_TOKENS = 4096;
+const MAX_PROVIDER_MAX_TOKENS = 16_000;
+
+function boundedInt(value: number | undefined, fallback: number, min: number, max: number): number {
+	if (value === undefined || !Number.isFinite(value)) return fallback;
+	return Math.min(Math.max(Math.floor(value), min), max);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(record: Readonly<Record<string, unknown>>, key: string): string | null {
+	const value = record[key];
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+function readNumber(record: Readonly<Record<string, unknown>>, key: string): number | undefined {
+	const value = record[key];
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readArray(record: Readonly<Record<string, unknown>>, key: string): readonly unknown[] {
+	const value = record[key];
+	return Array.isArray(value) ? value : [];
+}
+
+function canonicalKey(value: string): string {
+	const key = value
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "_")
+		.replace(/^_+|_+$/g, "")
+		.replace(/_+/g, "_")
+		.slice(0, 120);
+	return key.length > 0 ? key : "preference";
+}
+
+function sourceInfo(source: SourceRecord): DreamPromotionSourceInfo {
+	return {
+		kind: source.kind,
+		id: source.id,
+		sourceKind: source.sourceKind,
+		sourceId: source.sourceId,
+		sourcePath: source.sourcePath,
+		project: source.project,
+		harness: source.harness,
+		capturedAt: source.capturedAt,
+	};
+}
+
+function sourceIdCandidates(value: string): string[] {
+	const trimmed = value.trim();
+	const stripped = trimmed.replace(/^(memory|artifact|source|transcript|session):/, "");
+	return [
+		...new Set(
+			[
+				trimmed,
+				stripped,
+				`memory:${stripped}`,
+				`artifact:${stripped}`,
+				`transcript:${stripped}`,
+				`session:${stripped}`,
+			].filter(Boolean),
+		),
+	];
+}
+
+function readMemorySource(db: ReadDb, agentId: string, id: string): SourceRecord | null {
+	const ids = sourceIdCandidates(id);
+	const placeholders = ids.map(() => "?").join(", ");
+	const row = db
+		.prepare(
+			`SELECT id, content, project, created_at, updated_at
+			 FROM memories
+			 WHERE agent_id = ?
+			   AND COALESCE(is_deleted, 0) = 0
+			   AND id IN (${placeholders})
+			 ORDER BY updated_at DESC
+			 LIMIT 1`,
+		)
+		.get(agentId, ...ids) as
+		| {
+				readonly id: string;
+				readonly content: string;
+				readonly project: string | null;
+				readonly created_at: string;
+				readonly updated_at: string;
+		  }
+		| undefined;
+	if (!row) return null;
+	return {
+		kind: "memory",
+		id: row.id,
+		content: row.content,
+		sourceKind: "memory",
+		sourceId: row.id,
+		sourcePath: null,
+		project: row.project,
+		harness: null,
+		capturedAt: row.updated_at ?? row.created_at,
+	};
+}
+
+function readRecentMemorySources(db: ReadDb, agentId: string, limit: number): SourceRecord[] {
+	return db
+		.prepare(
+			`SELECT id, content, project, created_at, updated_at
+			 FROM memories
+			 WHERE agent_id = ?
+			   AND COALESCE(is_deleted, 0) = 0
+			 ORDER BY updated_at DESC, created_at DESC
+			 LIMIT ?`,
+		)
+		.all(agentId, limit)
+		.map((row) => {
+			const memory = row as {
+				readonly id: string;
+				readonly content: string;
+				readonly project: string | null;
+				readonly created_at: string;
+				readonly updated_at: string;
+			};
+			return {
+				kind: "memory",
+				id: memory.id,
+				content: memory.content,
+				sourceKind: "memory",
+				sourceId: memory.id,
+				sourcePath: null,
+				project: memory.project,
+				harness: null,
+				capturedAt: memory.updated_at ?? memory.created_at,
+			} satisfies SourceRecord;
+		});
+}
+
+function readTranscriptSource(db: ReadDb, agentId: string, id: string): SourceRecord | null {
+	const ids = sourceIdCandidates(id);
+	const placeholders = ids.map(() => "?").join(", ");
+	const row = db
+		.prepare(
+			`SELECT session_key, content, harness, project, created_at, updated_at
+			 FROM session_transcripts
+			 WHERE agent_id = ? AND session_key IN (${placeholders})
+			 ORDER BY updated_at DESC, created_at DESC
+			 LIMIT 1`,
+		)
+		.get(agentId, ...ids) as
+		| {
+				readonly session_key: string;
+				readonly content: string;
+				readonly harness: string | null;
+				readonly project: string | null;
+				readonly created_at: string;
+				readonly updated_at: string | null;
+		  }
+		| undefined;
+	if (!row) return null;
+	return {
+		kind: "transcript",
+		id: row.session_key,
+		content: row.content,
+		sourceKind: "transcript",
+		sourceId: row.session_key,
+		sourcePath: null,
+		project: row.project,
+		harness: row.harness,
+		capturedAt: row.updated_at ?? row.created_at,
+	};
+}
+
+function readRecentTranscriptSources(db: ReadDb, agentId: string, limit: number): SourceRecord[] {
+	return db
+		.prepare(
+			`SELECT session_key, content, harness, project, created_at, updated_at
+			 FROM session_transcripts
+			 WHERE agent_id = ?
+			 ORDER BY updated_at DESC, created_at DESC
+			 LIMIT ?`,
+		)
+		.all(agentId, limit)
+		.map((row) => {
+			const transcript = row as {
+				readonly session_key: string;
+				readonly content: string;
+				readonly harness: string | null;
+				readonly project: string | null;
+				readonly created_at: string;
+				readonly updated_at: string | null;
+			};
+			return {
+				kind: "transcript",
+				id: transcript.session_key,
+				content: transcript.content,
+				sourceKind: "transcript",
+				sourceId: transcript.session_key,
+				sourcePath: null,
+				project: transcript.project,
+				harness: transcript.harness,
+				capturedAt: transcript.updated_at ?? transcript.created_at,
+			} satisfies SourceRecord;
+		});
+}
+
+function readArtifactSource(db: ReadDb, agentId: string, id: string): SourceRecord | null {
+	const ids = sourceIdCandidates(id);
+	const placeholders = ids.map(() => "?").join(", ");
+	const row = db
+		.prepare(
+			`SELECT source_path, source_kind, source_node_id, session_id, session_key, session_token,
+			        project, harness, content, captured_at, updated_at
+			 FROM memory_artifacts
+			 WHERE agent_id = ?
+			   AND COALESCE(is_deleted, 0) = 0
+			   AND (
+			     source_path = ?
+			     OR source_node_id IN (${placeholders})
+			     OR session_id IN (${placeholders})
+			     OR session_key IN (${placeholders})
+			     OR session_token IN (${placeholders})
+			   )
+			 ORDER BY captured_at DESC
+			 LIMIT 1`,
+		)
+		.get(agentId, id, ...ids, ...ids, ...ids, ...ids) as
+		| {
+				readonly source_path: string;
+				readonly source_kind: string;
+				readonly source_node_id: string | null;
+				readonly session_id: string;
+				readonly session_key: string | null;
+				readonly session_token: string;
+				readonly project: string | null;
+				readonly harness: string | null;
+				readonly content: string;
+				readonly captured_at: string;
+				readonly updated_at: string;
+		  }
+		| undefined;
+	if (!row) return null;
+	return {
+		kind: "artifact",
+		id: row.source_path,
+		content: row.content,
+		sourceKind: row.source_kind,
+		sourceId: row.source_node_id ?? row.session_key ?? row.session_id ?? row.session_token,
+		sourcePath: row.source_path,
+		project: row.project,
+		harness: row.harness,
+		capturedAt: row.captured_at ?? row.updated_at,
+	};
+}
+
+function readRecentArtifactSources(db: ReadDb, agentId: string, limit: number): SourceRecord[] {
+	return db
+		.prepare(
+			`SELECT source_path, source_kind, source_node_id, session_id, session_key, session_token,
+			        project, harness, content, captured_at, updated_at
+			 FROM memory_artifacts
+			 WHERE agent_id = ?
+			   AND COALESCE(is_deleted, 0) = 0
+			 ORDER BY captured_at DESC, updated_at DESC
+			 LIMIT ?`,
+		)
+		.all(agentId, limit)
+		.map((row) => {
+			const artifact = row as {
+				readonly source_path: string;
+				readonly source_kind: string;
+				readonly source_node_id: string | null;
+				readonly session_id: string;
+				readonly session_key: string | null;
+				readonly session_token: string;
+				readonly project: string | null;
+				readonly harness: string | null;
+				readonly content: string;
+				readonly captured_at: string;
+				readonly updated_at: string;
+			};
+			return {
+				kind: "artifact",
+				id: artifact.source_path,
+				content: artifact.content,
+				sourceKind: artifact.source_kind,
+				sourceId: artifact.source_node_id ?? artifact.session_key ?? artifact.session_id ?? artifact.session_token,
+				sourcePath: artifact.source_path,
+				project: artifact.project,
+				harness: artifact.harness,
+				capturedAt: artifact.captured_at ?? artifact.updated_at,
+			} satisfies SourceRecord;
+		});
+}
+
+function readSources(
+	accessor: DbAccessor,
+	params: Pick<DreamPromotionParams, "agentId" | "from" | "limit">,
+): SourceRecord[] {
+	const from = params.from.trim();
+	if (from.length === 0) throw new DreamPromotionError("from is required", 400);
+	const limit = boundedInt(params.limit, DEFAULT_LIMIT, 1, MAX_LIMIT);
+	return accessor.withReadDb((db) => {
+		if (from === "all") {
+			const perKind = Math.max(1, Math.ceil(limit / 3));
+			return [
+				...readRecentMemorySources(db, params.agentId, perKind),
+				...readRecentArtifactSources(db, params.agentId, perKind),
+				...readRecentTranscriptSources(db, params.agentId, perKind),
+			]
+				.sort((a, b) => b.capturedAt.localeCompare(a.capturedAt))
+				.slice(0, limit);
+		}
+		if (from === "memories:recent") return readRecentMemorySources(db, params.agentId, limit);
+		if (from === "artifacts:recent") return readRecentArtifactSources(db, params.agentId, limit);
+		if (from === "transcripts:recent") return readRecentTranscriptSources(db, params.agentId, limit);
+		if (from.startsWith("memory:")) {
+			const memory = readMemorySource(db, params.agentId, from);
+			if (memory) return [memory];
+		}
+		if (from.startsWith("transcript:") || from.startsWith("session:")) {
+			const transcript = readTranscriptSource(db, params.agentId, from);
+			if (transcript) return [transcript];
+		}
+		const artifactId = from.replace(/^(artifact|source):/, "");
+		const artifact = readArtifactSource(db, params.agentId, artifactId);
+		if (artifact) return [artifact];
+		const memory = readMemorySource(db, params.agentId, from);
+		if (memory) return [memory];
+		const transcript = readTranscriptSource(db, params.agentId, from);
+		if (transcript) return [transcript];
+		throw new DreamPromotionError("Dream promotion source not found", 404);
+	});
+}
+
+function evidence(source: SourceRecord, quote: string): readonly unknown[] {
+	return [
+		{
+			source_kind: source.sourceKind,
+			source_id: source.sourceId,
+			source_path: source.sourcePath,
+			quote,
+		},
+	];
+}
+
+function normalizeSentence(value: string): string {
+	const sentence = value.replace(/\s+/g, " ").trim();
+	if (sentence.length === 0) return sentence;
+	return /[.!?]$/.test(sentence) ? sentence : `${sentence}.`;
+}
+
+function statementParts(
+	sentence: string,
+): { readonly entity: string; readonly verb: string; readonly object: string; readonly context: string | null } | null {
+	const match = sentence
+		.replace(/\s+/g, " ")
+		.trim()
+		.match(/^(Nicholai|User|The user)\s+(prefers|likes|wants|expects)\s+(.+?)(?:\s+when\s+(.+))?$/i);
+	if (!match) return null;
+	const actor = match[1] ?? "";
+	const verb = (match[2] ?? "").toLowerCase();
+	const object = (match[3] ?? "").trim();
+	const context = (match[4] ?? "").trim();
+	if (object.length < 3) return null;
+	const entity = actor.toLowerCase() === "nicholai" ? "Nicholai" : "Nicholai";
+	return {
+		entity,
+		verb,
+		object,
+		context: context.length > 0 ? context : null,
+	};
+}
+
+function claimTarget(object: string): string {
+	const target = object
+		.replace(/\s+to\s+be\s+.*$/i, "")
+		.replace(/\s+as\s+.*$/i, "")
+		.trim();
+	return target.length > 0 ? target : object;
+}
+
+function mechanicalPreferenceOperations(source: SourceRecord): DreamPromotionOperation[] {
+	const seen = new Set<string>();
+	const operations: DreamPromotionOperation[] = [];
+	for (const sentence of source.content.split(/(?<=[.!?])\s+|\n+/).map(normalizeSentence)) {
+		const parts = statementParts(sentence.replace(/[.!?]$/, ""));
+		if (!parts) continue;
+		const claim = parts.context
+			? `${parts.verb} ${parts.object} when ${parts.context}`
+			: `${parts.verb} ${parts.object}`;
+		const claimKey = parts.context
+			? canonicalKey(`${parts.verb} ${claimTarget(parts.object)} when ${parts.context}`)
+			: canonicalKey(`${parts.verb} ${claimTarget(parts.object)}`);
+		const key = `${parts.entity}:${claimKey}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
+		operations.push({
+			operation: "set_claim_value",
+			payload: {
+				entity: parts.entity,
+				entity_type: "person",
+				aspect: "preferences",
+				group_key: parts.context ? "workflow" : "general",
+				claim_key: claimKey,
+				value: normalizeSentence(`${parts.entity} ${claim}`),
+				kind: "attribute",
+				confidence: 0.88,
+			},
+			confidence: 0.88,
+			reason: "Dreaming promoted an explicit user preference into an update-in-place attribute slot.",
+			evidence: evidence(source, sentence),
+			risk: "low",
+			sourceKind: source.sourceKind,
+			sourceId: source.sourceId,
+			sourcePath: source.sourcePath,
+			sourceRoot: source.kind,
+		});
+	}
+	return operations;
+}
+
+function normalizeExplicitOperation(raw: unknown, source: SourceRecord): DreamPromotionOperation | null {
+	if (!isRecord(raw)) return null;
+	const operation = readString(raw, "operation");
+	if (operation !== "set_claim_value") return null;
+	const payload = isRecord(raw.payload) ? raw.payload : {};
+	const kind = readString(payload, "kind") ?? "attribute";
+	if (kind !== "attribute") return null;
+	const entity = readString(payload, "entity");
+	const aspect = readString(payload, "aspect");
+	const claimKey = readString(payload, "claim_key") ?? readString(payload, "claim");
+	const value = readString(payload, "value");
+	if (!entity || !aspect || !claimKey || !value) return null;
+	return {
+		operation,
+		payload: {
+			...payload,
+			claim_key: claimKey,
+			kind,
+		},
+		confidence: readNumber(raw, "confidence") ?? readNumber(payload, "confidence"),
+		reason:
+			readString(raw, "reason") ??
+			readString(raw, "rationale") ??
+			"Dreaming promoted explicit ontology operation evidence.",
+		evidence: readArray(raw, "evidence").length > 0 ? readArray(raw, "evidence") : evidence(source, value),
+		risk: readString(raw, "risk"),
+		sourceKind: source.sourceKind,
+		sourceId: source.sourceId,
+		sourcePath: source.sourcePath,
+		sourceRoot: source.kind,
+	};
+}
+
+function normalizeClaimValue(raw: unknown, source: SourceRecord): DreamPromotionOperation | null {
+	if (!isRecord(raw)) return null;
+	const kind = readString(raw, "kind") ?? "attribute";
+	if (kind !== "attribute") return null;
+	const entity = readString(raw, "entity");
+	const aspect = readString(raw, "aspect");
+	const claimKey = readString(raw, "claim_key") ?? readString(raw, "claim");
+	const value = readString(raw, "value");
+	if (!entity || !aspect || !claimKey || !value) return null;
+	return {
+		operation: "set_claim_value",
+		payload: {
+			entity,
+			entity_type: readString(raw, "entity_type") ?? undefined,
+			aspect,
+			group_key: readString(raw, "group_key") ?? readString(raw, "group") ?? undefined,
+			claim_key: claimKey,
+			value,
+			kind,
+			confidence: readNumber(raw, "confidence"),
+			importance: readNumber(raw, "importance"),
+		},
+		confidence: readNumber(raw, "confidence"),
+		reason:
+			readString(raw, "reason") ??
+			readString(raw, "rationale") ??
+			"Dreaming promoted extracted claim evidence into a current attribute value.",
+		evidence: readArray(raw, "evidence").length > 0 ? readArray(raw, "evidence") : evidence(source, value),
+		risk: readString(raw, "risk"),
+		sourceKind: source.sourceKind,
+		sourceId: source.sourceId,
+		sourcePath: source.sourcePath,
+		sourceRoot: source.kind,
+	};
+}
+
+function parseJsonContent(content: string): unknown | null {
+	try {
+		return JSON.parse(content);
+	} catch {
+		return null;
+	}
+}
+
+function extractJsonBlocks(content: string): unknown[] {
+	const parsed = parseJsonContent(content);
+	if (parsed !== null) return [parsed];
+	return [...content.matchAll(/```(?:json)?\s*([\s\S]*?)```/gi)]
+		.map((match) => parseJsonContent(match[1]?.trim() ?? ""))
+		.filter((value): value is unknown => value !== null);
+}
+
+function normalizeJsonOperations(
+	raw: unknown,
+	source: SourceRecord,
+): {
+	readonly operations: readonly DreamPromotionOperation[];
+	readonly questions: readonly string[];
+} {
+	if (Array.isArray(raw))
+		return {
+			operations: raw
+				.map((item) => normalizeExplicitOperation(item, source))
+				.filter((item): item is DreamPromotionOperation => item !== null),
+			questions: [],
+		};
+	if (!isRecord(raw)) return { operations: [], questions: [] };
+	const explicit = readArray(raw, "operations")
+		.map((item) => normalizeExplicitOperation(item, source))
+		.filter((item): item is DreamPromotionOperation => item !== null);
+	const claims = readArray(raw, "claim_values")
+		.map((item) => normalizeClaimValue(item, source))
+		.filter((item): item is DreamPromotionOperation => item !== null);
+	return {
+		operations: [...explicit, ...claims],
+		questions: readArray(raw, "questions").filter(
+			(item): item is string => typeof item === "string" && item.trim().length > 0,
+		),
+	};
+}
+
+function parseProviderOutput(
+	raw: string,
+	source: SourceRecord,
+): {
+	readonly operations: readonly DreamPromotionOperation[];
+	readonly questions: readonly string[];
+} {
+	const candidates: unknown[] = [];
+	const whole = parseJsonContent(raw);
+	if (whole !== null) candidates.push(whole);
+	const stripped = stripFences(raw);
+	const strippedParsed = tryParseJson(stripped);
+	if (strippedParsed !== null) candidates.push(strippedParsed);
+	const object = extractBalancedJsonObject(raw);
+	if (object) {
+		const parsed = tryParseJson(object);
+		if (parsed !== null) candidates.push(parsed);
+	}
+	const parsed = candidates.map((candidate) => normalizeJsonOperations(candidate, source));
+	return {
+		operations: parsed.flatMap((item) => item.operations),
+		questions: [...new Set(parsed.flatMap((item) => item.questions).map((item) => item.trim()))],
+	};
+}
+
+function extractExplicitOperations(source: SourceRecord): {
+	readonly operations: readonly DreamPromotionOperation[];
+	readonly questions: readonly string[];
+} {
+	const parsed = extractJsonBlocks(source.content).map((candidate) => normalizeJsonOperations(candidate, source));
+	return {
+		operations: parsed.flatMap((item) => item.operations),
+		questions: [...new Set(parsed.flatMap((item) => item.questions).map((item) => item.trim()))],
+	};
+}
+
+function dedupeOperations(operations: readonly DreamPromotionOperation[], limit: number): DreamPromotionOperation[] {
+	const seen = new Set<string>();
+	return operations
+		.filter((operation) => {
+			const key = JSON.stringify([operation.operation, operation.payload]);
+			if (seen.has(key)) return false;
+			seen.add(key);
+			return true;
+		})
+		.slice(0, limit);
+}
+
+function buildProviderPrompt(source: SourceRecord): string {
+	const content =
+		source.content.length > MAX_PROVIDER_INPUT_CHARS
+			? `${source.content.slice(0, MAX_PROVIDER_INPUT_CHARS)}\n[truncated]`
+			: source.content;
+	return `You are running Signet's dreaming skill over source evidence.
+
+Source of truth:
+- kind: ${source.kind}
+- source_kind: ${source.sourceKind}
+- source_id: ${source.sourceId}
+- source_path: ${source.sourcePath ?? ""}
+- project: ${source.project ?? ""}
+- harness: ${source.harness ?? ""}
+
+Task:
+Promote explicit durable user preferences, stable project facts, or maintained policy statements into current ontology attributes.
+Return direct operations only. Do not create pending proposals. Do not write memories.
+Use operation "set_claim_value" so repeated evidence updates the same claim slot in place.
+Skip ambiguous or low-confidence candidates and put the uncertainty in questions.
+Preserve provenance for every operation using a short exact quote.
+
+Return ONLY JSON with this shape:
+{
+  "operations": [
+    {
+      "operation": "set_claim_value",
+      "payload": {
+        "entity": "Nicholai",
+        "entity_type": "person|project|system|tool|source|artifact|concept|task|unknown",
+        "aspect": "preferences",
+        "group_key": "workflow",
+        "claim_key": "stable_snake_case_slot",
+        "value": "Nicholai prefers ...",
+        "kind": "attribute",
+        "confidence": 0.0
+      },
+      "confidence": 0.0,
+      "reason": "string",
+      "evidence": [{ "source_kind": "${source.sourceKind}", "source_id": "${source.sourceId}", "source_path": ${JSON.stringify(source.sourcePath)}, "quote": "short exact quote" }],
+      "risk": "low|medium|high"
+    }
+  ],
+  "questions": ["uncertainties that need review"]
+}
+
+Source content:
+${content}`;
+}
+
+async function providerOperations(
+	source: SourceRecord,
+	provider: LlmProvider,
+	params: Pick<DreamPromotionParams, "providerTimeoutMs" | "providerMaxTokens">,
+): Promise<{
+	readonly operations: readonly DreamPromotionOperation[];
+	readonly questions: readonly string[];
+	readonly warnings: readonly string[];
+}> {
+	try {
+		const raw = await provider.generate(buildProviderPrompt(source), {
+			timeoutMs: boundedInt(params.providerTimeoutMs, DEFAULT_PROVIDER_TIMEOUT_MS, 1_000, MAX_PROVIDER_TIMEOUT_MS),
+			maxTokens: boundedInt(params.providerMaxTokens, DEFAULT_PROVIDER_MAX_TOKENS, 1, MAX_PROVIDER_MAX_TOKENS),
+			temperature: 0,
+		});
+		const parsed = parseProviderOutput(raw, source);
+		return {
+			operations: parsed.operations,
+			questions: parsed.questions,
+			warnings:
+				parsed.operations.length > 0
+					? []
+					: [`Provider ${provider.name} returned no valid dreaming promotion operations.`],
+		};
+	} catch (err) {
+		return {
+			operations: [],
+			questions: [],
+			warnings: [`Provider ${provider.name} promotion failed: ${err instanceof Error ? err.message : String(err)}`],
+		};
+	}
+}
+
+export async function promoteDreamingEvidence(
+	accessor: DbAccessor,
+	params: DreamPromotionParams,
+): Promise<DreamPromotionResult> {
+	const limit = boundedInt(params.limit, DEFAULT_LIMIT, 1, MAX_LIMIT);
+	const sources = readSources(accessor, params);
+	const warnings: string[] = [];
+	const questions: string[] = [];
+	const skipped: string[] = [];
+	const operations: DreamPromotionOperation[] = [];
+	for (const source of sources) {
+		const explicit = extractExplicitOperations(source);
+		operations.push(...explicit.operations);
+		questions.push(...explicit.questions);
+		operations.push(...mechanicalPreferenceOperations(source));
+		if (params.useProvider) {
+			if (params.provider) {
+				const generated = await providerOperations(source, params.provider, params);
+				operations.push(...generated.operations);
+				questions.push(...generated.questions);
+				warnings.push(...generated.warnings);
+			} else {
+				warnings.push("Provider promotion requested but no inference provider is configured.");
+			}
+		}
+	}
+	const deduped = dedupeOperations(operations, limit);
+	if (deduped.length === 0 && sources.length > 0) {
+		skipped.push("No explicit high-confidence attribute promotions found.");
+	}
+	const applied =
+		deduped.length > 0
+			? applyOntologyOperationBatch(accessor, {
+					agentId: params.agentId,
+					actor: params.actor ?? "dreaming-promote",
+					operations: deduped,
+					dryRun: params.apply !== true,
+					propose: false,
+				})
+			: null;
+	return {
+		sources: sources.map(sourceInfo),
+		operations: deduped,
+		applied,
+		count: deduped.length,
+		appliedCount: params.apply === true ? (applied?.count ?? 0) : 0,
+		skipped,
+		questions: [...new Set(questions)],
+		warnings,
+		dryRun: params.apply !== true,
+		providerName: params.useProvider ? (params.provider?.name ?? null) : null,
+	};
+}

--- a/platform/daemon/src/dream-promotion.ts
+++ b/platform/daemon/src/dream-promotion.ts
@@ -399,14 +399,11 @@ function readSources(
 	const limit = boundedInt(params.limit, DEFAULT_LIMIT, 1, MAX_LIMIT);
 	return accessor.withReadDb((db) => {
 		if (from === "all") {
-			const perKind = Math.max(1, Math.ceil(limit / 3));
 			return [
-				...readRecentMemorySources(db, params.agentId, perKind),
-				...readRecentArtifactSources(db, params.agentId, perKind),
-				...readRecentTranscriptSources(db, params.agentId, perKind),
-			]
-				.sort((a, b) => b.capturedAt.localeCompare(a.capturedAt))
-				.slice(0, limit);
+				...readRecentMemorySources(db, params.agentId, limit),
+				...readRecentArtifactSources(db, params.agentId, limit),
+				...readRecentTranscriptSources(db, params.agentId, limit),
+			].sort((a, b) => b.capturedAt.localeCompare(a.capturedAt));
 		}
 		if (from === "memories:recent") return readRecentMemorySources(db, params.agentId, limit);
 		if (from === "artifacts:recent") return readRecentArtifactSources(db, params.agentId, limit);

--- a/platform/daemon/src/dream-promotion.ts
+++ b/platform/daemon/src/dream-promotion.ts
@@ -15,6 +15,7 @@ type SourceRecord = {
 	readonly project: string | null;
 	readonly harness: string | null;
 	readonly capturedAt: string;
+	readonly confidence: number | null;
 };
 
 export interface DreamPromotionSourceInfo {
@@ -119,6 +120,10 @@ function isBlockedRisk(value: string | null): boolean {
 	return value?.toLowerCase() === "high";
 }
 
+function meetsPromotionConfidence(value: number | null): value is number {
+	return value !== null && value >= MIN_EXPLICIT_CONFIDENCE && value <= 1;
+}
+
 function readArray(record: Readonly<Record<string, unknown>>, key: string): readonly unknown[] {
 	const value = record[key];
 	return Array.isArray(value) ? value : [];
@@ -169,7 +174,7 @@ function readMemorySource(db: ReadDb, agentId: string, id: string): SourceRecord
 	const placeholders = ids.map(() => "?").join(", ");
 	const row = db
 		.prepare(
-			`SELECT id, content, project, created_at, updated_at
+			`SELECT id, content, project, confidence, created_at, updated_at
 			 FROM memories
 			 WHERE agent_id = ?
 			   AND COALESCE(is_deleted, 0) = 0
@@ -184,6 +189,7 @@ function readMemorySource(db: ReadDb, agentId: string, id: string): SourceRecord
 				readonly project: string | null;
 				readonly created_at: string;
 				readonly updated_at: string;
+				readonly confidence: number | null;
 		  }
 		| undefined;
 	if (!row) return null;
@@ -197,13 +203,14 @@ function readMemorySource(db: ReadDb, agentId: string, id: string): SourceRecord
 		project: row.project,
 		harness: null,
 		capturedAt: row.updated_at ?? row.created_at,
+		confidence: row.confidence,
 	};
 }
 
 function readRecentMemorySources(db: ReadDb, agentId: string, limit: number): SourceRecord[] {
 	return db
 		.prepare(
-			`SELECT id, content, project, created_at, updated_at
+			`SELECT id, content, project, confidence, created_at, updated_at
 			 FROM memories
 			 WHERE agent_id = ?
 			   AND COALESCE(is_deleted, 0) = 0
@@ -218,6 +225,7 @@ function readRecentMemorySources(db: ReadDb, agentId: string, limit: number): So
 				readonly project: string | null;
 				readonly created_at: string;
 				readonly updated_at: string;
+				readonly confidence: number | null;
 			};
 			return {
 				kind: "memory",
@@ -229,6 +237,7 @@ function readRecentMemorySources(db: ReadDb, agentId: string, limit: number): So
 				project: memory.project,
 				harness: null,
 				capturedAt: memory.updated_at ?? memory.created_at,
+				confidence: memory.confidence,
 			} satisfies SourceRecord;
 		});
 }
@@ -265,6 +274,7 @@ function readTranscriptSource(db: ReadDb, agentId: string, id: string): SourceRe
 		project: row.project,
 		harness: row.harness,
 		capturedAt: row.updated_at ?? row.created_at,
+		confidence: null,
 	};
 }
 
@@ -297,6 +307,7 @@ function readRecentTranscriptSources(db: ReadDb, agentId: string, limit: number)
 				project: transcript.project,
 				harness: transcript.harness,
 				capturedAt: transcript.updated_at ?? transcript.created_at,
+				confidence: null,
 			} satisfies SourceRecord;
 		});
 }
@@ -347,6 +358,7 @@ function readArtifactSource(db: ReadDb, agentId: string, id: string): SourceReco
 		project: row.project,
 		harness: row.harness,
 		capturedAt: row.captured_at ?? row.updated_at,
+		confidence: null,
 	};
 }
 
@@ -386,6 +398,7 @@ function readRecentArtifactSources(db: ReadDb, agentId: string, limit: number): 
 				project: artifact.project,
 				harness: artifact.harness,
 				capturedAt: artifact.captured_at ?? artifact.updated_at,
+				confidence: null,
 			} satisfies SourceRecord;
 		});
 }
@@ -475,6 +488,7 @@ function claimTarget(object: string): string {
 }
 
 function mechanicalPreferenceOperations(source: SourceRecord): DreamPromotionOperation[] {
+	if (!meetsPromotionConfidence(source.confidence)) return [];
 	const seen = new Set<string>();
 	const operations: DreamPromotionOperation[] = [];
 	for (const sentence of source.content.split(/(?<=[.!?])\s+|\n+/).map(normalizeSentence)) {
@@ -499,9 +513,9 @@ function mechanicalPreferenceOperations(source: SourceRecord): DreamPromotionOpe
 				claim_key: claimKey,
 				value: normalizeSentence(`${parts.entity} ${claim}`),
 				kind: "attribute",
-				confidence: 0.88,
+				confidence: source.confidence,
 			},
-			confidence: 0.88,
+			confidence: source.confidence,
 			reason: "Dreaming promoted an explicit user preference into an update-in-place attribute slot.",
 			evidence: evidence(source, sentence),
 			risk: "low",

--- a/platform/daemon/src/routes/pipeline-routes.ts
+++ b/platform/daemon/src/routes/pipeline-routes.ts
@@ -66,8 +66,8 @@ const pipelineAdminGuard = async (c: Context, next: () => Promise<void>): Promis
 };
 
 function asRecord(value: unknown): Record<string, unknown> {
-	if (typeof value === "object" && value !== null && !Array.isArray(value)) return value as Record<string, unknown>;
-	return {};
+	if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+	return value as Record<string, unknown>;
 }
 
 function readString(record: Readonly<Record<string, unknown>>, key: string): string | undefined {
@@ -465,6 +465,7 @@ export function registerPipelineRoutes(app: Hono): void {
 		});
 	});
 
+	app.use("/api/dream/promote", pipelineAdminGuard);
 	app.use("/api/dream/*", async (c, next) => {
 		return requirePermission("admin", authConfig)(c, next);
 	});

--- a/platform/daemon/src/routes/pipeline-routes.ts
+++ b/platform/daemon/src/routes/pipeline-routes.ts
@@ -5,7 +5,8 @@ import type { Context, Hono } from "hono";
 import { resolveAgentId } from "../agent-id.js";
 import { requirePermission, requireRateLimit } from "../auth";
 import { getDbAccessor } from "../db-accessor.js";
-import { getLlmProvider } from "../llm.js";
+import { DreamPromotionError, promoteDreamingEvidence } from "../dream-promotion.js";
+import { getInferenceProviderOrNull, getLlmProvider } from "../llm.js";
 import { loadMemoryConfig } from "../memory-config.js";
 import {
 	getDreamingPasses,
@@ -56,13 +57,38 @@ import {
 } from "./state.js";
 import { STATUS_CACHE_TTL, cachedEmbeddingStatus, statusCacheTime } from "./utils.js";
 
-const pipelineAdminGuard = async (c: Context, next: () => Promise<void>): Promise<Response | void> => {
+const pipelineAdminGuard = async (c: Context, next: () => Promise<void>): Promise<Response | undefined> => {
 	const permDenied = await requirePermission("admin", authConfig)(c, () => Promise.resolve());
 	if (permDenied) return permDenied;
 	const rateDenied = await requireRateLimit("admin", authAdminLimiter, authConfig)(c, () => Promise.resolve());
 	if (rateDenied) return rateDenied;
 	await next();
 };
+
+function asRecord(value: unknown): Record<string, unknown> {
+	if (typeof value === "object" && value !== null && !Array.isArray(value)) return value as Record<string, unknown>;
+	return {};
+}
+
+function readString(record: Readonly<Record<string, unknown>>, key: string): string | undefined {
+	const value = record[key];
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readNumber(record: Readonly<Record<string, unknown>>, key: string): number | undefined {
+	const value = record[key];
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readBoolean(record: Readonly<Record<string, unknown>>, key: string): boolean | undefined {
+	const value = record[key];
+	if (typeof value === "boolean") return value;
+	if (value === "true") return true;
+	if (value === "false") return false;
+	return undefined;
+}
 
 async function togglePipelinePause(c: Context, paused: boolean): Promise<Response> {
 	if (pipelineTransition) {
@@ -94,7 +120,11 @@ async function togglePipelinePause(c: Context, paused: boolean): Promise<Respons
 		});
 	} catch (err) {
 		const { logger } = await import("../logger.js");
-		logger.error("pipeline", paused ? "Failed to pause pipeline" : "Failed to resume pipeline", err instanceof Error ? err : new Error(String(err)));
+		logger.error(
+			"pipeline",
+			paused ? "Failed to pause pipeline" : "Failed to resume pipeline",
+			err instanceof Error ? err : new Error(String(err)),
+		);
 		return c.json({ error: err instanceof Error ? err.message : String(err) }, 500);
 	} finally {
 		setPipelineTransition(false);
@@ -340,7 +370,6 @@ export function registerPipelineRoutes(app: Hono): void {
 		const pipelineV2 = cfg.pipelineV2;
 		const mode = readPipelineMode(pipelineV2);
 
-
 		return c.json({
 			workers: getPipelineWorkerStatus(),
 			queues: dbData.queues,
@@ -467,6 +496,37 @@ export function registerPipelineRoutes(app: Hono): void {
 		});
 	});
 
+	app.post("/api/dream/promote", async (c) => {
+		const raw: unknown = await c.req.json().catch(() => null);
+		if (raw === null) return c.json({ error: "Malformed JSON body" }, 400);
+		const body = asRecord(raw);
+		const agentId = resolveAgentId({
+			agentId: readString(body, "agent_id") ?? c.req.header("x-signet-agent-id"),
+		});
+		const from = readString(body, "from");
+		if (!from) return c.json({ error: "from is required" }, 400);
+		const useProvider = readBoolean(body, "use_provider") ?? false;
+		try {
+			return c.json(
+				await promoteDreamingEvidence(getDbAccessor(), {
+					agentId,
+					from,
+					apply: readBoolean(body, "apply") ?? false,
+					actor: readString(body, "actor") ?? c.req.header("x-signet-actor") ?? "dreaming-promote",
+					limit: readNumber(body, "limit"),
+					useProvider,
+					provider: useProvider ? getInferenceProviderOrNull("memoryExtraction") : null,
+					providerTimeoutMs: readNumber(body, "provider_timeout_ms"),
+					providerMaxTokens: readNumber(body, "provider_max_tokens"),
+				}),
+			);
+		} catch (err) {
+			if (err instanceof DreamPromotionError) return c.json({ error: err.message }, err.status);
+			const message = err instanceof Error ? err.message : String(err);
+			return c.json({ error: message }, 500);
+		}
+	});
+
 	app.post("/api/dream/trigger", async (c) => {
 		const worker = getDreamingWorker();
 		if (!worker) {
@@ -498,5 +558,4 @@ export function registerPipelineRoutes(app: Hono): void {
 		}
 		return c.json({ accepted: true, passId, status: "running", mode }, 202);
 	});
-
 }

--- a/surfaces/cli/src/commands/dream.test.ts
+++ b/surfaces/cli/src/commands/dream.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Command } from "commander";
+import { registerDreamCommands } from "./dream";
+
+const prevLog = console.log;
+const prevError = console.error;
+
+afterEach(() => {
+	console.log = prevLog;
+	console.error = prevError;
+});
+
+describe("registerDreamCommands", () => {
+	test("promote posts a dry-run request by default", async () => {
+		let capturedPath = "";
+		let capturedOpts: RequestInit | undefined;
+		console.log = () => {};
+
+		const program = new Command();
+		registerDreamCommands(program, {
+			fetchFromDaemon: async (path, opts) => {
+				capturedPath = path;
+				capturedOpts = opts;
+				return {
+					sources: [],
+					operations: [],
+					count: 0,
+					appliedCount: 0,
+					skipped: ["No explicit high-confidence attribute promotions found."],
+					questions: [],
+					warnings: [],
+					dryRun: true,
+				};
+			},
+		});
+
+		await program.parseAsync([
+			"node",
+			"test",
+			"dream",
+			"promote",
+			"--from",
+			"memories:recent",
+			"--agent",
+			"ant",
+			"--limit",
+			"12",
+		]);
+
+		expect(capturedPath).toBe("/api/dream/promote");
+		expect(capturedOpts?.method).toBe("POST");
+		expect(JSON.parse(String(capturedOpts?.body))).toMatchObject({
+			from: "memories:recent",
+			apply: false,
+			limit: 12,
+			agent_id: "ant",
+			actor: "dreaming-promote",
+			use_provider: false,
+		});
+	});
+
+	test("promote can apply direct operations and print JSON", async () => {
+		let capturedBody: Record<string, unknown> = {};
+		const lines: string[] = [];
+		console.log = (line?: unknown) => {
+			lines.push(String(line ?? ""));
+		};
+
+		const program = new Command();
+		registerDreamCommands(program, {
+			fetchFromDaemon: async (_path, opts) => {
+				capturedBody = JSON.parse(String(opts?.body));
+				return {
+					sources: [{ kind: "memory" }],
+					operations: [{ operation: "set_claim_value", payload: { entity: "Nicholai" } }],
+					count: 1,
+					appliedCount: 1,
+					skipped: [],
+					questions: [],
+					warnings: [],
+					dryRun: false,
+				};
+			},
+		});
+
+		await program.parseAsync(["node", "test", "dream", "promote", "--from", "memory:mem-1", "--apply", "--json"]);
+
+		expect(capturedBody).toMatchObject({
+			from: "memory:mem-1",
+			apply: true,
+		});
+		expect(JSON.parse(lines.join("\n"))).toMatchObject({
+			count: 1,
+			appliedCount: 1,
+			dryRun: false,
+		});
+	});
+});

--- a/surfaces/cli/src/commands/dream.ts
+++ b/surfaces/cli/src/commands/dream.ts
@@ -47,6 +47,33 @@ interface TriggerAccepted {
 	readonly error?: string;
 }
 
+interface DreamPromotionOperation {
+	readonly operation: string;
+	readonly payload: Readonly<Record<string, unknown>>;
+}
+
+interface DreamPromotionResult {
+	readonly sources: readonly unknown[];
+	readonly operations: readonly DreamPromotionOperation[];
+	readonly count: number;
+	readonly appliedCount: number;
+	readonly skipped: readonly string[];
+	readonly questions: readonly string[];
+	readonly warnings: readonly string[];
+	readonly dryRun: boolean;
+}
+
+function parsePositiveInt(value: string | undefined, label: string): number | undefined {
+	if (value === undefined) return undefined;
+	const trimmed = value.trim();
+	const parsed = Number.parseInt(trimmed, 10);
+	if (!/^\d+$/.test(trimmed) || Number.isNaN(parsed) || parsed <= 0) {
+		console.error(chalk.red(`  Invalid ${label} value: "${value}" (must be a positive integer)`));
+		process.exit(1);
+	}
+	return parsed;
+}
+
 export function registerDreamCommands(program: Command, deps: DreamDeps): void {
 	const dream = program.command("dream").description("Manage dreaming memory consolidation");
 
@@ -111,6 +138,83 @@ export function registerDreamCommands(program: Command, deps: DreamDeps): void {
 			}
 			console.log();
 		});
+
+	dream
+		.command("promote")
+		.description("Promote source-backed evidence into update-in-place ontology attributes")
+		.option(
+			"--from <source>",
+			"Source selector: all, memories:recent, memory:<id>, artifact:<id>, source:<path>, transcript:<id>",
+			"all",
+		)
+		.option("--apply", "Apply operations instead of previewing them")
+		.option("--limit <n>", "Maximum operations to promote", "50")
+		.option("--agent <id>", "Agent scope")
+		.option("--actor <name>", "Actor recorded on applied operations", "dreaming-promote")
+		.option("--use-provider", "Use configured inference provider in addition to mechanical extraction")
+		.option("--provider-timeout-ms <n>", "Provider timeout in milliseconds")
+		.option("--provider-max-tokens <n>", "Provider max output tokens")
+		.option("--json", "Print raw JSON")
+		.action(
+			async (opts: {
+				from?: string;
+				apply?: boolean;
+				limit?: string;
+				agent?: string;
+				actor?: string;
+				useProvider?: boolean;
+				providerTimeoutMs?: string;
+				providerMaxTokens?: string;
+				json?: boolean;
+			}) => {
+				const data = await deps.fetchFromDaemon<DreamPromotionResult>("/api/dream/promote", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						from: opts.from ?? "all",
+						apply: opts.apply === true,
+						limit: parsePositiveInt(opts.limit, "--limit"),
+						agent_id: opts.agent,
+						actor: opts.actor,
+						use_provider: opts.useProvider === true,
+						provider_timeout_ms: parsePositiveInt(opts.providerTimeoutMs, "--provider-timeout-ms"),
+						provider_max_tokens: parsePositiveInt(opts.providerMaxTokens, "--provider-max-tokens"),
+					}),
+				});
+
+				if (!data) {
+					console.error(chalk.red("Failed to promote dreaming evidence (is the daemon running?)"));
+					process.exit(1);
+				}
+
+				if (opts.json) {
+					console.log(JSON.stringify(data, null, 2));
+					return;
+				}
+
+				console.log(chalk.bold("\n  Dreaming Promotion\n"));
+				console.log(`  ${chalk.dim("Mode:")}       ${data.dryRun ? chalk.yellow("preview") : chalk.green("apply")}`);
+				console.log(`  ${chalk.dim("Sources:")}    ${data.sources.length}`);
+				console.log(`  ${chalk.dim("Operations:")} ${data.count}`);
+				console.log(`  ${chalk.dim("Applied:")}    ${data.appliedCount}`);
+				if (data.operations.length > 0) {
+					console.log(chalk.bold("\n  Operations\n"));
+					for (const operation of data.operations.slice(0, 12)) {
+						const entity = String(operation.payload.entity ?? "");
+						const aspect = String(operation.payload.aspect ?? "");
+						const claim = String(operation.payload.claim_key ?? "");
+						console.log(`  ${operation.operation} ${chalk.dim(`${entity}/${aspect}/${claim}`)}`);
+					}
+					if (data.operations.length > 12) {
+						console.log(chalk.dim(`  ...${data.operations.length - 12} more`));
+					}
+				}
+				for (const warning of data.warnings) console.log(chalk.yellow(`  Warning: ${warning}`));
+				for (const item of data.skipped) console.log(chalk.dim(`  Skipped: ${item}`));
+				for (const question of data.questions) console.log(chalk.dim(`  Question: ${question}`));
+				console.log();
+			},
+		);
 
 	dream
 		.command("trigger")


### PR DESCRIPTION
## Summary

- Add a dreaming promotion control-plane path that reads saved memories, memory artifacts, and transcripts as evidence.
- Promote explicit high-confidence statements into ontology attributes via direct `set_claim_value` operations, with preview-by-default and `--apply` for mutation.
- Add `POST /api/dream/promote` and `signet dream promote` CLI support.
- Update the dreaming runbook and approved specs to separate direct applied promotion from the optional pending proposal review queue.

## Review Notes

- Raw memories, transcripts, and memory artifacts stay immutable provenance.
- The promotion path does not call Pipeline V2 extraction and does not create pending proposals by default.
- Direct promotion is restricted to attribute slots; ambiguous or unsupported evidence is skipped or returned as a question.
- Default mechanical natural-language promotion is limited to confidence-bearing saved memory rows.
- Memory artifacts and transcripts are still readable evidence sources. Embedded source JSON can be parsed for preview, but cannot self-attest confidence for direct apply.
- Plain prose in artifacts or transcripts needs `--use-provider` or the proposal review path.
- Explicit embedded operations require high-confidence, non-high-risk metadata to appear in preview; only trusted extraction paths can be applied.
- Applied writes still go through the existing audited ontology operation handler, so `set_claim_value` supersedes the old active row in the same claim slot.
- The mutation endpoint is protected by the admin mutation guard and rate limiter.

## Verification

- `bun install`
- `bun run build:core`
- `bun test platform/daemon/src/dream-promotion.test.ts`
- `bun test surfaces/cli/src/commands/dream.test.ts`
- `bun test platform/daemon/src/daemon-auth-guard-colocation.test.ts`
- `bunx biome check docs/dreaming-skill-runbook.md docs/specs/INDEX.md docs/specs/approved/dreaming-memory-consolidation.md docs/specs/approved/ontology-proposal-loop.md platform/daemon/src/dream-promotion.ts platform/daemon/src/dream-promotion.test.ts platform/daemon/src/routes/pipeline-routes.ts platform/daemon/src/daemon-auth-guard-colocation.test.ts surfaces/cli/src/commands/dream.ts surfaces/cli/src/commands/dream.test.ts`
- `bun scripts/spec-deps-check.ts`
- `git diff --check`
- `cd platform/daemon && bun run build.ts`
- `cd surfaces/cli && bun run build:workspace-deps`
- `cd surfaces/cli && bun run build:cli`

## Caveat

- `bunx tsc --noEmit -p platform/daemon/tsconfig.json` is not currently clean on main in this worktree; it reports existing rootDir/package-wide errors plus older unrelated daemon test/type issues. Package bundle builds passed for the changed daemon and CLI surfaces.

## Readiness Checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally
