### PR TITLE
feat(ontology): add safe entity merge planning

### DIFF
--- a/platform/daemon/src/ontology-proposals.test.ts
+++ b/platform/daemon/src/ontology-proposals.test.ts
@@ -1135,6 +1135,25 @@ describe("ontology proposals", () => {
 		expect(written.proposal?.payload.target_entity_id).toBe("entity-signet");
 	});
 
+	it("keeps blocked manual merge-plan writes reported as dry-runs", () => {
+		insertEntity("entity-signet", "Signet", "signet", "ant", 8, false, "project");
+		insertEntity("entity-signet-skill", "signet", "signet", "ant", 2, false, "skill");
+
+		const result = createEntityMergePlan(getDbAccessor(), {
+			agentId: "ant",
+			targetEntityId: "entity-signet",
+			sourceEntityIds: ["entity-signet-skill"],
+			writeProposal: true,
+			createdBy: "merge-plan-test",
+		});
+
+		expect(result.blocked).toBe(true);
+		expect(result.dryRun).toBe(true);
+		expect(result.proposal).toBeUndefined();
+		const listed = listOntologyProposals(getDbAccessor(), { agentId: "ant", operation: "merge_entities" });
+		expect(listed.items).toHaveLength(0);
+	});
+
 	it("rejects invalid proposal batches without partial writes", () => {
 		expect(() =>
 			createOntologyProposals(getDbAccessor(), [

--- a/platform/daemon/src/ontology-proposals.test.ts
+++ b/platform/daemon/src/ontology-proposals.test.ts
@@ -12,6 +12,7 @@ import {
 	applyOntologyOperation,
 	applyOntologyOperationBatch,
 	applyOntologyProposal,
+	createEntityMergePlan,
 	createOntologyProposal,
 	createOntologyProposals,
 	getClaimVersion,
@@ -45,16 +46,18 @@ describe("ontology proposals", () => {
 		agentId: string,
 		mentions: number,
 		pinned = false,
+		entityType = "project",
 	): void {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
 				`INSERT INTO entities
 				 (id, name, canonical_name, entity_type, agent_id, mentions, pinned, created_at, updated_at)
-				 VALUES (?, ?, ?, 'project', ?, ?, ?, ?, ?)`,
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			).run(
 				id,
 				name,
 				canonicalName,
+				entityType,
 				agentId,
 				mentions,
 				pinned ? 1 : 0,
@@ -938,6 +941,97 @@ describe("ontology proposals", () => {
 		expect(rows.map((row) => row.content)).toContain("Proposal-first mutation loop");
 	});
 
+	it("applies ID-first merge_entities when entity names are ambiguous", () => {
+		const target = createOntologyProposal(getDbAccessor(), {
+			agentId: "ant",
+			operation: "add_claim_value",
+			payload: {
+				entity: "Signet",
+				entity_type: "project",
+				aspect: "identity",
+				group_key: "product",
+				claim_key: "category",
+				value: "Context substrate",
+			},
+		});
+		applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: target.id, actor: "test" });
+
+		const source = createOntologyProposal(getDbAccessor(), {
+			agentId: "ant",
+			operation: "add_claim_value",
+			payload: {
+				entity: "Signet Alias",
+				entity_type: "project",
+				aspect: "architecture",
+				group_key: "ontology",
+				claim_key: "proposal_loop",
+				value: "Proposal-first maintenance.",
+			},
+		});
+		applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: source.id, actor: "test" });
+
+		const ids = getDbAccessor().withWriteTx((db) => {
+			const targetRow = db.prepare("SELECT id FROM entities WHERE agent_id = ? AND name = ?").get("ant", "Signet") as {
+				id: string;
+			};
+			const sourceRow = db
+				.prepare("SELECT id FROM entities WHERE agent_id = ? AND name = ?")
+				.get("ant", "Signet Alias") as { id: string };
+			db.prepare("UPDATE entities SET canonical_name = ? WHERE id = ?").run("signet", sourceRow.id);
+			db.prepare(
+				`INSERT INTO entities
+				 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?, 0, ?, ?)`,
+			).run(
+				"entity-signet-skill",
+				"signet",
+				"signet",
+				"skill",
+				"ant",
+				"2026-05-06T00:00:00.000Z",
+				"2026-05-06T00:00:00.000Z",
+			);
+			return { targetId: targetRow.id, sourceId: sourceRow.id };
+		});
+
+		const merge = createOntologyProposal(getDbAccessor(), {
+			agentId: "ant",
+			operation: "merge_entities",
+			payload: {
+				target_entity: "Signet",
+				target_entity_id: ids.targetId,
+				source_entities: ["Signet Alias"],
+				source_entity_ids: [ids.sourceId],
+			},
+		});
+
+		const applied = applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: merge.id, actor: "test" });
+
+		expect(applied.status).toBe("applied");
+		expect(applied.result?.targetEntityId).toBe(ids.targetId);
+		expect(applied.result?.mergedEntities).toEqual([{ name: "Signet Alias", entityId: ids.sourceId, movedAspects: 1 }]);
+	});
+
+	it("rejects merge_entities when supplied IDs and names disagree", () => {
+		insertEntity("entity-signet", "Signet", "signet", "ant", 8);
+		insertEntity("entity-other", "Other", "other", "ant", 4);
+		insertEntity("entity-alias", "Signet Alias", "signet alias", "ant", 1);
+
+		const merge = createOntologyProposal(getDbAccessor(), {
+			agentId: "ant",
+			operation: "merge_entities",
+			payload: {
+				target_entity: "Other",
+				target_entity_id: "entity-signet",
+				source_entity_ids: ["entity-alias"],
+			},
+		});
+
+		expect(() => applyOntologyProposal(getDbAccessor(), { agentId: "ant", id: merge.id, actor: "test" })).toThrow(
+			OntologyProposalError,
+		);
+	});
+
 	it("dry-runs duplicate entity repair candidates without creating proposals", () => {
 		insertEntity("entity-signet", "Signet", "signet", "ant", 8, true);
 		insertEntity("entity-signet-upper", "SIGNET", "signet", "ant", 3);
@@ -957,6 +1051,26 @@ describe("ontology proposals", () => {
 		expect(result.items[0]?.target.name).toBe("Signet");
 		expect(result.items[0]?.sources.map((source) => source.name).sort()).toEqual(["SIGNET", "signet.ai"]);
 
+		const listed = listOntologyProposals(getDbAccessor(), { agentId: "ant", operation: "merge_entities" });
+		expect(listed.items).toHaveLength(0);
+	});
+
+	it("blocks mixed-type duplicate entity repair proposals by default", () => {
+		insertEntity("entity-signet", "Signet", "signet", "ant", 8, true, "project");
+		insertEntity("entity-signet-skill", "signet", "signet", "ant", 3, false, "skill");
+
+		const result = proposeDuplicateEntityMerges(getDbAccessor(), {
+			agentId: "ant",
+			limit: 10,
+			writeProposals: true,
+			createdBy: "repair-test",
+		});
+
+		expect(result.count).toBe(1);
+		expect(result.writtenCount).toBe(0);
+		expect(result.skippedCount).toBe(1);
+		expect(result.items[0]?.blocked).toBe(true);
+		expect(result.items[0]?.warnings.join("\n")).toContain("differs from target type");
 		const listed = listOntologyProposals(getDbAccessor(), { agentId: "ant", operation: "merge_entities" });
 		expect(listed.items).toHaveLength(0);
 	});
@@ -990,6 +1104,35 @@ describe("ontology proposals", () => {
 
 		const listed = listOntologyProposals(getDbAccessor(), { agentId: "ant", operation: "merge_entities" });
 		expect(listed.items).toHaveLength(1);
+	});
+
+	it("previews and writes manual entity merge plans with ID-first payloads", () => {
+		insertEntity("entity-signet", "Signet", "signet", "ant", 8);
+		insertEntity("entity-alias", "Signet Alias", "signet alias", "ant", 2);
+
+		const preview = createEntityMergePlan(getDbAccessor(), {
+			agentId: "ant",
+			targetEntityId: "entity-signet",
+			sourceEntityIds: ["entity-alias"],
+		});
+
+		expect(preview.dryRun).toBe(true);
+		expect(preview.proposal).toBeUndefined();
+		expect(preview.payload.target_entity_id).toBe("entity-signet");
+		expect(preview.payload.source_entity_ids).toEqual(["entity-alias"]);
+
+		const written = createEntityMergePlan(getDbAccessor(), {
+			agentId: "ant",
+			targetEntityId: "entity-signet",
+			sourceEntityIds: ["entity-alias"],
+			writeProposal: true,
+			createdBy: "merge-plan-test",
+		});
+
+		expect(written.dryRun).toBe(false);
+		expect(written.proposal?.operation).toBe("merge_entities");
+		expect(written.proposal?.createdBy).toBe("merge-plan-test");
+		expect(written.proposal?.payload.target_entity_id).toBe("entity-signet");
 	});
 
 	it("rejects invalid proposal batches without partial writes", () => {

--- a/platform/daemon/src/ontology-proposals.ts
+++ b/platform/daemon/src/ontology-proposals.ts
@@ -2027,7 +2027,7 @@ export function createEntityMergePlan(accessor: DbAccessor, params: EntityMergeP
 	const agentId = requireText(params.agentId, "agentId");
 	const dryRun = params.writeProposal !== true;
 	const plan = accessor.withReadDb((db) => buildEntityMergePlan(db, { ...params, agentId }, "manual_entity_merge"));
-	if (dryRun || plan.blocked) return { ...plan, dryRun };
+	if (dryRun || plan.blocked) return { ...plan, dryRun: true };
 	const proposal = createOntologyProposal(accessor, {
 		agentId,
 		operation: plan.operation,

--- a/platform/daemon/src/ontology-proposals.ts
+++ b/platform/daemon/src/ontology-proposals.ts
@@ -110,10 +110,13 @@ export interface DuplicateEntityMergeCandidate {
 	readonly target: DuplicateEntityRef;
 	readonly sources: readonly DuplicateEntityRef[];
 	readonly payload: Readonly<Record<string, unknown>>;
+	readonly impact: EntityMergeImpact;
+	readonly warnings: readonly string[];
+	readonly blocked: boolean;
 	readonly confidence: number;
 	readonly rationale: string;
 	readonly evidence: readonly unknown[];
-	readonly risk: "low";
+	readonly risk: "low" | "review_required" | "blocked";
 }
 
 export interface DuplicateEntityMergeResult {
@@ -121,7 +124,46 @@ export interface DuplicateEntityMergeResult {
 	readonly proposals: readonly OntologyProposal[];
 	readonly count: number;
 	readonly writtenCount: number;
+	readonly skippedCount: number;
 	readonly dryRun: boolean;
+}
+
+export interface EntityMergeImpact {
+	readonly sourceMentions: number;
+	readonly memoryMentions: number;
+	readonly aspects: number;
+	readonly attributes: number;
+	readonly dependencies: number;
+	readonly relations: number;
+}
+
+export interface EntityMergePlanParams {
+	readonly agentId: string;
+	readonly targetEntity?: string;
+	readonly targetEntityId?: string;
+	readonly sourceEntities?: readonly string[];
+	readonly sourceEntityIds?: readonly string[];
+	readonly force?: boolean;
+	readonly writeProposal?: boolean;
+	readonly createdBy?: string;
+	readonly rationale?: string;
+	readonly evidence?: readonly unknown[];
+}
+
+export interface EntityMergePlanResult {
+	readonly operation: "merge_entities";
+	readonly target: DuplicateEntityRef;
+	readonly sources: readonly DuplicateEntityRef[];
+	readonly payload: Readonly<Record<string, unknown>>;
+	readonly impact: EntityMergeImpact;
+	readonly warnings: readonly string[];
+	readonly blocked: boolean;
+	readonly confidence: number;
+	readonly rationale: string;
+	readonly evidence: readonly unknown[];
+	readonly risk: "low" | "review_required" | "blocked";
+	readonly dryRun: boolean;
+	readonly proposal?: OntologyProposal;
 }
 
 export interface ListOntologyProposalsParams {
@@ -1124,38 +1166,37 @@ function applyMergeEntities(
 	agentId: string,
 	payload: Readonly<Record<string, unknown>>,
 ): Readonly<Record<string, unknown>> {
-	const target = readString(payload, "target_entity") ?? readString(payload, "target");
-	const rawSources = [
-		...readStringArray(payload, "source_entities"),
-		...readStringArray(payload, "sources"),
-		...(readString(payload, "source_entity") ? [readString(payload, "source_entity") as string] : []),
-		...(readString(payload, "source") ? [readString(payload, "source") as string] : []),
-	];
-	const sources = unique(rawSources);
-	if (target === null) throw new OntologyProposalError("payload.target_entity is required", 400);
-	if (sources.length === 0) throw new OntologyProposalError("payload.source_entities is required", 400);
-
-	const targetId = resolveEntity(db, agentId, target);
-	if (targetId === null) throw new OntologyProposalError("payload.target_entity was not found", 400);
+	const sources = sourceMergeSpecs(payload);
+	const plan = buildEntityMergePlan(db, {
+		agentId,
+		targetEntity: readString(payload, "target_entity") ?? readString(payload, "target") ?? undefined,
+		targetEntityId: readString(payload, "target_entity_id") ?? readString(payload, "target_id") ?? undefined,
+		sourceEntities: sources.map((spec) => spec.selector).filter((selector): selector is string => selector !== null),
+		sourceEntityIds: sources.map((spec) => spec.id).filter((id): id is string => id !== null),
+		force: truthy(payload.force),
+	});
+	if (plan.blocked) throw new OntologyProposalError(`Merge blocked: ${plan.warnings.join("; ")}`, 409);
 
 	const merged: Array<{ readonly name: string; readonly entityId: string; readonly movedAspects: number }> = [];
-	for (const source of sources) {
-		const sourceId = resolveEntity(db, agentId, source);
-		if (sourceId === null) throw new OntologyProposalError(`source entity not found: ${source}`, 400);
-		if (sourceId === targetId) continue;
-		const movedAspects = mergeEntityAspects(db, agentId, sourceId, targetId);
-		mergeEntityEdges(db, agentId, sourceId, targetId);
+	for (const source of plan.sources) {
+		const movedAspects = mergeEntityAspects(db, agentId, source.id, plan.target.id);
+		mergeEntityEdges(db, agentId, source.id, plan.target.id);
 		db.prepare(
 			`UPDATE entities
 			 SET mentions = COALESCE(mentions, 0) + COALESCE((SELECT mentions FROM entities WHERE id = ?), 0),
 			     updated_at = datetime('now')
 			 WHERE id = ? AND agent_id = ?`,
-		).run(sourceId, targetId, agentId);
-		db.prepare("DELETE FROM entities WHERE id = ? AND agent_id = ?").run(sourceId, agentId);
-		merged.push({ name: source, entityId: sourceId, movedAspects });
+		).run(source.id, plan.target.id, agentId);
+		db.prepare("DELETE FROM entities WHERE id = ? AND agent_id = ?").run(source.id, agentId);
+		merged.push({ name: source.name, entityId: source.id, movedAspects });
 	}
 	if (merged.length === 0) throw new OntologyProposalError("No distinct source entities to merge", 400);
-	return { targetEntityId: targetId, mergedEntities: merged };
+	return {
+		targetEntityId: plan.target.id,
+		targetEntityName: plan.target.name,
+		mergedEntities: merged,
+		warnings: plan.warnings,
+	};
 }
 
 function applyCreateLink(
@@ -1601,6 +1642,231 @@ function toDuplicateEntityRef(row: DuplicateEntityRow, key: string): DuplicateEn
 	};
 }
 
+function entityRowToRef(row: DuplicateEntityRow): DuplicateEntityRef {
+	return toDuplicateEntityRef(row, canonical(row.canonical_name ?? row.name));
+}
+
+function getEntityRefById(db: ReadDb, agentId: string, id: string): DuplicateEntityRef | null {
+	const row = db
+		.prepare(
+			`SELECT id, name, canonical_name, entity_type,
+			        COALESCE(mentions, 0) AS mentions,
+			        COALESCE(pinned, 0) AS pinned,
+			        updated_at
+			 FROM entities
+			 WHERE agent_id = ?
+			   AND COALESCE(status, 'active') = 'active'
+			   AND id = ?
+			 LIMIT 1`,
+		)
+		.get(agentId, id) as DuplicateEntityRow | undefined;
+	return row ? entityRowToRef(row) : null;
+}
+
+function resolveEntityRefStrict(db: ReadDb, agentId: string, selector: string): DuplicateEntityRef {
+	const key = canonical(selector);
+	const rows = db
+		.prepare(
+			`SELECT id, name, canonical_name, entity_type,
+			        COALESCE(mentions, 0) AS mentions,
+			        COALESCE(pinned, 0) AS pinned,
+			        updated_at
+			 FROM entities
+			 WHERE agent_id = ?
+			   AND COALESCE(status, 'active') = 'active'
+			   AND (id = ? OR COALESCE(canonical_name, LOWER(name)) = ? OR LOWER(name) = ?)
+			 ORDER BY CASE WHEN id = ? THEN 0 ELSE 1 END, updated_at DESC, name ASC`,
+		)
+		.all(agentId, selector, key, key, selector) as DuplicateEntityRow[];
+	if (rows.length === 0) throw new OntologyProposalError(`Entity not found: ${selector}`, 404);
+	if (rows.length > 1) throw new OntologyProposalError(`Entity selector is ambiguous: ${selector}. Use an id.`, 409);
+	return entityRowToRef(rows[0] as DuplicateEntityRow);
+}
+
+function resolveMergeEntityRef(
+	db: ReadDb,
+	agentId: string,
+	field: string,
+	selector: string | null,
+	id: string | null,
+): DuplicateEntityRef {
+	if (id !== null) {
+		const byId = getEntityRefById(db, agentId, id);
+		if (byId === null) throw new OntologyProposalError(`${field}_id was not found: ${id}`, 404);
+		if (selector !== null && !selectorMatchesEntityRef(selector, byId)) {
+			throw new OntologyProposalError(`${field}_id does not match ${field}`, 409);
+		}
+		return byId;
+	}
+	if (selector === null) throw new OntologyProposalError(`${field} is required`, 400);
+	return resolveEntityRefStrict(db, agentId, selector);
+}
+
+function selectorMatchesEntityRef(selector: string, entity: DuplicateEntityRef): boolean {
+	const key = canonical(selector);
+	return selector === entity.id || key === canonical(entity.name) || key === canonical(entity.canonicalName);
+}
+
+function sourceMergeSpecs(payload: Readonly<Record<string, unknown>>): Array<{
+	readonly selector: string | null;
+	readonly id: string | null;
+}> {
+	const selectors = unique([
+		...readStringArray(payload, "source_entities"),
+		...readStringArray(payload, "sources"),
+		...(readString(payload, "source_entity") ? [readString(payload, "source_entity") as string] : []),
+		...(readString(payload, "source") ? [readString(payload, "source") as string] : []),
+	]);
+	const ids = unique([
+		...readStringArray(payload, "source_entity_ids"),
+		...readStringArray(payload, "source_ids"),
+		...(readString(payload, "source_entity_id") ? [readString(payload, "source_entity_id") as string] : []),
+		...(readString(payload, "source_id") ? [readString(payload, "source_id") as string] : []),
+	]);
+	if (ids.length > 0) {
+		if (selectors.length > ids.length) {
+			throw new OntologyProposalError("payload.source_entities and payload.source_entity_ids must match", 400);
+		}
+		return ids.map((id, index) => ({ id, selector: selectors[index] ?? null }));
+	}
+	return selectors.map((selector) => ({ selector, id: null }));
+}
+
+function entityMergeImpact(db: ReadDb, agentId: string, sources: readonly DuplicateEntityRef[]): EntityMergeImpact {
+	const ids = sources.map((source) => source.id);
+	if (ids.length === 0) {
+		return { sourceMentions: 0, memoryMentions: 0, aspects: 0, attributes: 0, dependencies: 0, relations: 0 };
+	}
+	const placeholders = ids.map(() => "?").join(", ");
+	const sourceMentions = sources.reduce((sum, source) => sum + source.mentions, 0);
+	const aspects = db
+		.prepare(`SELECT COUNT(*) AS count FROM entity_aspects WHERE agent_id = ? AND entity_id IN (${placeholders})`)
+		.get(agentId, ...ids) as { count: number };
+	const attributes = db
+		.prepare(
+			`SELECT COUNT(*) AS count
+			 FROM entity_attributes attr
+			 JOIN entity_aspects asp ON asp.id = attr.aspect_id
+			 WHERE attr.agent_id = ? AND asp.entity_id IN (${placeholders})`,
+		)
+		.get(agentId, ...ids) as { count: number };
+	const dependencies = db
+		.prepare(
+			`SELECT COUNT(*) AS count
+			 FROM entity_dependencies
+			 WHERE agent_id = ? AND (source_entity_id IN (${placeholders}) OR target_entity_id IN (${placeholders}))`,
+		)
+		.get(agentId, ...ids, ...ids) as { count: number };
+	const relations = db
+		.prepare(
+			`SELECT COUNT(*) AS count
+			 FROM relations
+			 WHERE source_entity_id IN (${placeholders}) OR target_entity_id IN (${placeholders})`,
+		)
+		.get(...ids, ...ids) as { count: number };
+	const memoryMentions = db
+		.prepare(`SELECT COUNT(*) AS count FROM memory_entity_mentions WHERE entity_id IN (${placeholders})`)
+		.get(...ids) as { count: number };
+	return {
+		sourceMentions,
+		memoryMentions: memoryMentions.count,
+		aspects: aspects.count,
+		attributes: attributes.count,
+		dependencies: dependencies.count,
+		relations: relations.count,
+	};
+}
+
+function mergeWarnings(
+	target: DuplicateEntityRef,
+	sources: readonly DuplicateEntityRef[],
+	force: boolean,
+): {
+	readonly warnings: readonly string[];
+	readonly blocked: boolean;
+	readonly risk: "low" | "review_required" | "blocked";
+} {
+	const warnings: string[] = [];
+	for (const source of sources) {
+		if (source.pinned) warnings.push(`source entity "${source.name}" is pinned`);
+		if (source.entityType !== target.entityType) {
+			warnings.push(
+				`source entity "${source.name}" type ${source.entityType} differs from target type ${target.entityType}`,
+			);
+		}
+	}
+	if (warnings.length === 0) return { warnings, blocked: false, risk: "low" };
+	return { warnings, blocked: !force, risk: force ? "review_required" : "blocked" };
+}
+
+function mergePlanPayload(
+	target: DuplicateEntityRef,
+	sources: readonly DuplicateEntityRef[],
+	force: boolean,
+): Readonly<Record<string, unknown>> {
+	return {
+		repair_kind: "manual_entity_merge",
+		target_entity: target.name,
+		target_entity_id: target.id,
+		source_entities: sources.map((source) => source.name),
+		source_entity_ids: sources.map((source) => source.id),
+		...(force ? { force: true } : {}),
+	};
+}
+
+function buildEntityMergePlan(
+	db: ReadDb,
+	params: EntityMergePlanParams,
+	payloadKind = "manual_entity_merge",
+): Omit<EntityMergePlanResult, "dryRun" | "proposal"> {
+	const agentId = requireText(params.agentId, "agentId");
+	const targetSelector = params.targetEntity?.trim() || null;
+	const targetId = params.targetEntityId?.trim() || null;
+	const target = resolveMergeEntityRef(db, agentId, "payload.target_entity", targetSelector, targetId);
+	const specs = params.sourceEntityIds?.length
+		? params.sourceEntityIds.map((id, index) => ({ id, selector: params.sourceEntities?.[index] ?? null }))
+		: (params.sourceEntities ?? []).map((selector) => ({ selector, id: null }));
+	if (params.sourceEntityIds?.length && (params.sourceEntities?.length ?? 0) > params.sourceEntityIds.length) {
+		throw new OntologyProposalError("sourceEntities and sourceEntityIds must match", 400);
+	}
+	if (specs.length === 0) throw new OntologyProposalError("source entities are required", 400);
+	const resolved = specs.map((spec) =>
+		resolveMergeEntityRef(db, agentId, "payload.source_entity", spec.selector, spec.id),
+	);
+	const sourceMap = new Map(resolved.map((source) => [source.id, source]));
+	sourceMap.delete(target.id);
+	const sources = [...sourceMap.values()];
+	if (sources.length === 0) throw new OntologyProposalError("No distinct source entities to merge", 400);
+	const force = params.force === true;
+	const safety = mergeWarnings(target, sources, force);
+	const payload = {
+		...mergePlanPayload(target, sources, force),
+		repair_kind: payloadKind,
+	};
+	const evidence = params.evidence ?? [
+		{
+			source_kind: "ontology_index",
+			source_id: `entities:${target.canonicalName}`,
+			quote: `Merge ${sources.map((source) => source.name).join(", ")} into ${target.name}.`,
+		},
+	];
+	return {
+		operation: "merge_entities",
+		target,
+		sources,
+		payload,
+		impact: entityMergeImpact(db, agentId, sources),
+		warnings: safety.warnings,
+		blocked: safety.blocked,
+		confidence: safety.risk === "low" ? 0.86 : 0.72,
+		rationale:
+			params.rationale?.trim() ||
+			`Merge ${sources.map((source) => `"${source.name}"`).join(", ")} into "${target.name}".`,
+		evidence,
+		risk: safety.risk,
+	};
+}
+
 function timeRank(value: string): number {
 	const parsed = Date.parse(value);
 	return Number.isFinite(parsed) ? parsed : 0;
@@ -1653,6 +1919,7 @@ function duplicateMergeCandidates(
 			        updated_at
 			 FROM entities
 			 WHERE agent_id = ?
+			   AND COALESCE(status, 'active') = 'active'
 			 ORDER BY COALESCE(canonical_name, LOWER(name)), COALESCE(mentions, 0) DESC, updated_at DESC`,
 		)
 		.all(agentId) as DuplicateEntityRow[];
@@ -1668,16 +1935,6 @@ function duplicateMergeCandidates(
 			const ordered = [...group].sort(compareDuplicateTargets);
 			const target = ordered[0];
 			const sources = ordered.slice(1);
-			const refs = sources.map((row) => toDuplicateEntityRef(row, key));
-			const targetRef = toDuplicateEntityRef(target, key);
-			const payload = {
-				repair_kind: "duplicate_entities",
-				canonical_name: key,
-				target_entity: target.name,
-				target_entity_id: target.id,
-				source_entities: refs.map((ref) => ref.name),
-				source_entity_ids: refs.map((ref) => ref.id),
-			};
 			const evidence = [
 				{
 					source_kind: "ontology_index",
@@ -1685,16 +1942,33 @@ function duplicateMergeCandidates(
 					quote: `Duplicate canonical_name "${key}" appears on ${ordered.map((row) => row.name).join(", ")}.`,
 				},
 			];
+			const plan = buildEntityMergePlan(
+				db,
+				{
+					agentId,
+					targetEntityId: target.id,
+					sourceEntityIds: sources.map((row) => row.id),
+					rationale: `Entities share canonical_name "${key}" in the same agent scope.`,
+					evidence,
+				},
+				"duplicate_entities",
+			);
 			return {
 				operation: "merge_entities" as const,
 				canonicalName: key,
-				target: targetRef,
-				sources: refs,
-				payload,
-				confidence: 0.86,
-				rationale: `Entities share canonical_name "${key}" in the same agent scope.`,
-				evidence,
-				risk: "low" as const,
+				target: plan.target,
+				sources: plan.sources,
+				payload: {
+					...plan.payload,
+					canonical_name: key,
+				},
+				impact: plan.impact,
+				warnings: plan.warnings,
+				blocked: plan.blocked,
+				confidence: plan.confidence,
+				rationale: plan.rationale,
+				evidence: plan.evidence,
+				risk: plan.risk,
 			};
 		})
 		.sort((a, b) => b.sources.length - a.sources.length || a.canonicalName.localeCompare(b.canonicalName))
@@ -1710,12 +1984,23 @@ export function proposeDuplicateEntityMerges(
 	const items = accessor.withReadDb((db) => duplicateMergeCandidates(db, agentId, limit));
 	const dryRun = params.writeProposals !== true;
 	if (dryRun || items.length === 0) {
-		return { items, proposals: [], count: items.length, writtenCount: 0, dryRun };
+		return {
+			items,
+			proposals: [],
+			count: items.length,
+			writtenCount: 0,
+			skippedCount: items.filter((item) => item.blocked).length,
+			dryRun,
+		};
+	}
+	const writableItems = items.filter((item) => !item.blocked);
+	if (writableItems.length === 0) {
+		return { items, proposals: [], count: items.length, writtenCount: 0, skippedCount: items.length, dryRun };
 	}
 
 	const written = createOntologyProposals(
 		accessor,
-		items.map((item) => ({
+		writableItems.map((item) => ({
 			agentId,
 			operation: item.operation,
 			payload: item.payload,
@@ -1733,8 +2018,29 @@ export function proposeDuplicateEntityMerges(
 		proposals: written.items,
 		count: items.length,
 		writtenCount: written.count,
+		skippedCount: items.length - writableItems.length,
 		dryRun: false,
 	};
+}
+
+export function createEntityMergePlan(accessor: DbAccessor, params: EntityMergePlanParams): EntityMergePlanResult {
+	const agentId = requireText(params.agentId, "agentId");
+	const dryRun = params.writeProposal !== true;
+	const plan = accessor.withReadDb((db) => buildEntityMergePlan(db, { ...params, agentId }, "manual_entity_merge"));
+	if (dryRun || plan.blocked) return { ...plan, dryRun };
+	const proposal = createOntologyProposal(accessor, {
+		agentId,
+		operation: plan.operation,
+		payload: plan.payload,
+		confidence: plan.confidence,
+		rationale: plan.rationale,
+		evidence: plan.evidence,
+		risk: plan.risk,
+		sourceKind: "ontology_index",
+		sourceId: `entities:${plan.target.id}`,
+		createdBy: params.createdBy?.trim() || "ontology-merge-plan",
+	});
+	return { ...plan, dryRun: false, proposal };
 }
 
 export function applyOntologyProposal(accessor: DbAccessor, params: ApplyOntologyProposalParams): OntologyProposal {

--- a/platform/daemon/src/routes/ontology-routes.ts
+++ b/platform/daemon/src/routes/ontology-routes.ts
@@ -16,6 +16,7 @@ import {
 	applyOntologyOperation,
 	applyOntologyOperationBatch,
 	applyOntologyProposal,
+	createEntityMergePlan,
 	createOntologyProposal,
 	createOntologyProposals,
 	getClaimVersion,
@@ -62,6 +63,14 @@ function readBoolean(record: Record<string, unknown>, key: string): boolean | un
 function readArray(record: Record<string, unknown>, key: string): readonly unknown[] | undefined {
 	const value = record[key];
 	return Array.isArray(value) ? value : undefined;
+}
+
+function readStringArray(record: Record<string, unknown>, key: string): readonly string[] | undefined {
+	const value = readArray(record, key);
+	if (!value) return undefined;
+	return value
+		.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+		.map((item) => item.trim());
 }
 
 async function readJsonRecord(c: Context): Promise<Record<string, unknown>> {
@@ -161,6 +170,30 @@ export function registerOntologyRoutes(app: Hono): void {
 					limit: readNumber(body, "limit"),
 					writeProposals: readBoolean(body, "write_proposals") ?? false,
 					createdBy: readString(body, "created_by") ?? c.req.header("x-signet-actor") ?? "operator",
+				}),
+			);
+		} catch (err) {
+			return c.json({ error: messageForError(err) }, statusForError(err));
+		}
+	});
+
+	app.post("/api/ontology/proposals/repair/merge-plan", async (c) => {
+		const body = await readJsonRecord(c);
+		const scoped = resolveAgent(c, c.req.query("agent_id") ?? readString(body, "agent_id"));
+		if (scoped.response) return scoped.response;
+		try {
+			return c.json(
+				createEntityMergePlan(getDbAccessor(), {
+					agentId: scoped.agentId,
+					targetEntity: readString(body, "target_entity") ?? readString(body, "target"),
+					targetEntityId: readString(body, "target_entity_id") ?? readString(body, "target_id"),
+					sourceEntities: readStringArray(body, "source_entities") ?? readStringArray(body, "sources"),
+					sourceEntityIds: readStringArray(body, "source_entity_ids") ?? readStringArray(body, "source_ids"),
+					force: readBoolean(body, "force") ?? false,
+					writeProposal: readBoolean(body, "write_proposal") ?? readBoolean(body, "write_proposals") ?? false,
+					createdBy: readString(body, "created_by") ?? c.req.header("x-signet-actor") ?? "ontology-merge-plan",
+					rationale: readString(body, "rationale") ?? readString(body, "reason"),
+					evidence: readArray(body, "evidence"),
 				}),
 			);
 		} catch (err) {

--- a/surfaces/cli/src/commands/ontology.test.ts
+++ b/surfaces/cli/src/commands/ontology.test.ts
@@ -30,7 +30,9 @@ describe("registerOntologyCommands", () => {
 
 		const names = (parent: Command, name: string): readonly string[] =>
 			parent.commands.find((cmd) => cmd.name() === name)?.commands.map((cmd) => cmd.name()) ?? [];
-		expect(names(ontology, "entity")).toEqual(expect.arrayContaining(["create", "rename", "merge", "archive"]));
+		expect(names(ontology, "entity")).toEqual(
+			expect.arrayContaining(["create", "rename", "merge", "merge-plan", "archive"]),
+		);
 		expect(names(ontology, "claim")).toEqual(expect.arrayContaining(["set", "versions", "show", "archive", "restore"]));
 		expect(names(ontology, "aspect")).toEqual(expect.arrayContaining(["create", "rename", "archive"]));
 		expect(names(ontology, "link")).toEqual(expect.arrayContaining(["create", "update", "archive"]));
@@ -433,6 +435,65 @@ describe("registerOntologyCommands", () => {
 		]);
 		expect(lines.join("\n")).toContain("Duplicate Merge Candidates");
 		expect(lines.join("\n")).toContain("Signet <- SIGNET");
+	});
+
+	test("entity merge-plan posts a read-only merge preview request", async () => {
+		const calls: Array<{ readonly method: string; readonly path: string; readonly body: unknown }> = [];
+		const lines: string[] = [];
+		console.log = (line?: unknown) => {
+			lines.push(String(line ?? ""));
+		};
+
+		const program = new Command();
+		registerOntologyCommands(program, {
+			ensureDaemonForSecrets: async () => true,
+			secretApiCall: async (method, path, body) => {
+				calls.push({ method, path, body });
+				return {
+					ok: true,
+					data: {
+						dryRun: true,
+						target: { id: "entity-signet", name: "Signet", entityType: "project" },
+						sources: [{ id: "entity-alias", name: "Signet Alias", entityType: "project" }],
+						impact: { aspects: 1, attributes: 2, dependencies: 0, memoryMentions: 3 },
+						warnings: [],
+						blocked: false,
+						rationale: "Merge duplicate Signet aliases.",
+					},
+				};
+			},
+		});
+
+		await program.parseAsync([
+			"node",
+			"test",
+			"ontology",
+			"entity",
+			"merge-plan",
+			"entity-signet",
+			"entity-alias",
+			"--agent",
+			"ant",
+		]);
+
+		expect(calls).toEqual([
+			{
+				method: "POST",
+				path: "/api/ontology/proposals/repair/merge-plan",
+				body: {
+					agent_id: "ant",
+					target_entity: "entity-signet",
+					source_entities: ["entity-alias"],
+					force: false,
+					write_proposal: false,
+					created_by: "ontology-merge-plan",
+					rationale: undefined,
+					evidence: undefined,
+				},
+			},
+		]);
+		expect(lines.join("\n")).toContain("Entity Merge Plan");
+		expect(lines.join("\n")).toContain("Signet <- Signet Alias");
 	});
 
 	test("import-proposals maps extraction output to batch proposal creation", async () => {

--- a/surfaces/cli/src/commands/ontology.ts
+++ b/surfaces/cli/src/commands/ontology.ts
@@ -121,20 +121,48 @@ interface ConflictsResponse {
 interface RepairDuplicateEntity {
 	readonly name?: string;
 	readonly id?: string;
+	readonly entityType?: string;
 	readonly mentions?: number;
+	readonly pinned?: boolean;
 }
 
 interface RepairDuplicateItem {
 	readonly canonicalName?: string;
 	readonly target?: RepairDuplicateEntity;
 	readonly sources?: readonly RepairDuplicateEntity[];
+	readonly impact?: EntityMergeImpact;
+	readonly warnings?: readonly string[];
+	readonly blocked?: boolean;
+	readonly risk?: string;
 	readonly rationale?: string;
 }
 
 interface RepairDuplicatesResponse {
 	readonly items?: readonly RepairDuplicateItem[];
 	readonly writtenCount?: number;
+	readonly skippedCount?: number;
 	readonly dryRun?: boolean;
+}
+
+interface EntityMergeImpact {
+	readonly sourceMentions?: number;
+	readonly memoryMentions?: number;
+	readonly aspects?: number;
+	readonly attributes?: number;
+	readonly dependencies?: number;
+	readonly relations?: number;
+}
+
+interface EntityMergePlanResponse {
+	readonly target?: RepairDuplicateEntity;
+	readonly sources?: readonly RepairDuplicateEntity[];
+	readonly impact?: EntityMergeImpact;
+	readonly warnings?: readonly string[];
+	readonly blocked?: boolean;
+	readonly risk?: string;
+	readonly rationale?: string;
+	readonly dryRun?: boolean;
+	readonly proposal?: ProposalListItem;
 }
 
 interface ProposalImportInput {
@@ -561,6 +589,7 @@ function printDuplicateRepairs(data: unknown): void {
 	const record = asRecord(data) as RepairDuplicatesResponse;
 	const items = record.items ?? [];
 	const writtenCount = record.writtenCount ?? 0;
+	const skippedCount = record.skippedCount ?? 0;
 	if (items.length === 0) {
 		console.log(chalk.dim("  No duplicate entity merge candidates found"));
 		return;
@@ -571,10 +600,55 @@ function printDuplicateRepairs(data: unknown): void {
 	for (const item of items) {
 		const target = item.target?.name ?? "unknown";
 		const sources = (item.sources ?? []).map((source) => source.name ?? source.id ?? "unknown").join(", ");
-		console.log(`  ${chalk.yellow(item.canonicalName ?? "unknown")} ${chalk.cyan(target)} <- ${sources}`);
+		const marker = item.blocked ? chalk.red("blocked") : item.risk ? chalk.dim(item.risk) : "";
+		console.log(`  ${chalk.yellow(item.canonicalName ?? "unknown")} ${chalk.cyan(target)} <- ${sources} ${marker}`);
+		if (item.impact) {
+			console.log(
+				chalk.dim(
+					`    ${item.impact.aspects ?? 0} aspects · ${item.impact.attributes ?? 0} attributes · ${
+						item.impact.memoryMentions ?? 0
+					} mentions`,
+				),
+			);
+		}
+		for (const warning of item.warnings ?? []) console.log(chalk.yellow(`    warning ${warning}`));
 		if (item.rationale) console.log(chalk.dim(`    ${item.rationale}`));
 	}
 	if (writtenCount > 0) console.log(chalk.green(`\n  Created ${writtenCount} pending merge proposals`));
+	if (skippedCount > 0) console.log(chalk.yellow(`  Skipped ${skippedCount} blocked merge candidate(s)`));
+	console.log();
+}
+
+function printEntityMergePlan(data: unknown): void {
+	const result = asRecord(data) as EntityMergePlanResponse;
+	const target = result.target?.name ?? result.target?.id ?? "unknown";
+	const sources = result.sources ?? [];
+	const title = result.blocked
+		? chalk.red("Entity Merge Blocked")
+		: result.proposal
+			? "Entity Merge Proposal"
+			: "Entity Merge Plan";
+	console.log(chalk.bold(`\n  ${title}\n`));
+	console.log(
+		`  ${chalk.cyan(target)} <- ${sources.map((source) => source.name ?? source.id ?? "unknown").join(", ")}`,
+	);
+	if (result.target?.id) console.log(chalk.dim(`    target ${result.target.id}`));
+	for (const source of sources) {
+		if (source.id)
+			console.log(chalk.dim(`    source ${source.id}${source.entityType ? ` (${source.entityType})` : ""}`));
+	}
+	if (result.impact) {
+		console.log(
+			chalk.dim(
+				`    ${result.impact.aspects ?? 0} aspects · ${result.impact.attributes ?? 0} attributes · ${
+					result.impact.dependencies ?? 0
+				} links · ${result.impact.memoryMentions ?? 0} mentions`,
+			),
+		);
+	}
+	for (const warning of result.warnings ?? []) console.log(chalk.yellow(`    warning ${warning}`));
+	if (result.rationale) console.log(chalk.dim(`    ${result.rationale}`));
+	if (result.proposal?.id) console.log(chalk.green(`\n  Created pending proposal ${result.proposal.id}`));
 	console.log();
 }
 
@@ -969,6 +1043,32 @@ export function registerOntologyCommands(program: Command, deps: OntologyDeps): 
 			options,
 		);
 		printOperationResult(data, options, "entity merge");
+	});
+	addCommonOptions(
+		entity
+			.command("merge-plan")
+			.description("Preview an entity merge and optionally create a pending proposal")
+			.argument("<target>", "Target entity selector")
+			.argument("<source...>", "Source entity selectors")
+			.option("--propose", "Create a pending merge proposal")
+			.option("--force", "Allow pinned or mixed-type source entities")
+			.option("--created-by <name>", "Audit creator", "ontology-merge-plan")
+			.option("--rationale <text>", "Short rationale")
+			.option("--evidence-file <path>", "JSON evidence file, array or single object"),
+	).action(async (target: string, source: readonly string[], options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const data = await apiPost(deps, "/api/ontology/proposals/repair/merge-plan", {
+			agent_id: options.agent,
+			target_entity: target,
+			source_entities: source,
+			force: options.force === true,
+			write_proposal: options.propose === true,
+			created_by: options.createdBy,
+			rationale: options.rationale,
+			evidence: readEvidenceFile(typeof options.evidenceFile === "string" ? options.evidenceFile : undefined),
+		});
+		if (options.json) console.log(JSON.stringify(data, null, 2));
+		else printEntityMergePlan(data);
 	});
 	addOperationOptions(
 		entity


### PR DESCRIPTION
## Summary
- Adds an ID-aware entity merge planner for ontology maintenance.
- Makes duplicate-entity repair proposals report impact, warnings, blocked candidates, and skipped writes.
- Adds `signet ontology entity merge-plan` for safe dry-run/proposal-first entity merge workflows.

## Test Plan
- [x] `bun test platform/daemon/src/ontology-proposals.test.ts`
- [x] `bun test surfaces/cli/src/commands/ontology.test.ts`
- [x] `bunx biome check platform/daemon/src/ontology-proposals.ts platform/daemon/src/routes/ontology-routes.ts surfaces/cli/src/commands/ontology.ts platform/daemon/src/ontology-proposals.test.ts surfaces/cli/src/commands/ontology.test.ts`
- [x] `git diff --check`

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)
- [x] No database migrations were added or changed
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

## Rollback / Compatibility
- Existing name-based `merge_entities` payloads remain accepted.
- New ID-first payloads are additive and preserve existing apply/reject proposal flow.
- No schema migration is required; rollback is reverting this branch.
