### PR TITLE
fix(cli): sync built-in dreaming skill

### DIFF
--- a/platform/daemon/src/routes/skills.test.ts
+++ b/platform/daemon/src/routes/skills.test.ts
@@ -60,7 +60,7 @@ describe("repo skills frontmatter", () => {
 	});
 
 	it.skipIf(!hasSkillsDir)("builtin skills have builtin: true in frontmatter", () => {
-		const expectedBuiltin = ["memory-debug", "onboarding", "recall", "remember", "signet"];
+		const expectedBuiltin = ["dreaming", "memory-debug", "onboarding", "recall", "remember", "signet"];
 
 		for (const name of expectedBuiltin) {
 			const skillMd = join(skillsRoot, name, "SKILL.md");

--- a/skills/dreaming/SKILL.md
+++ b/skills/dreaming/SKILL.md
@@ -2,6 +2,7 @@
 name: dreaming
 description: "Maintain Signet's living ontology and memory substrate from transcripts, memory artifacts, source artifacts, notes, summaries, and imported records."
 version: 1.0.0
+builtin: true
 ---
 
 # Dreaming

--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -8,12 +8,10 @@ import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
 	chmodSync,
-	copyFileSync,
 	existsSync,
 	lstatSync,
 	mkdirSync,
 	readFileSync,
-	readdirSync,
 	readlinkSync,
 	renameSync,
 	rmSync,
@@ -98,9 +96,16 @@ import { doctorForge, installForge, showForgeStatus, updateForge } from "./featu
 import { getStatusReport, showDoctor, showStatus } from "./features/health.js";
 import { importFromGitHub } from "./features/import.js";
 import { setupWizard } from "./features/setup.js";
-import { syncTemplates } from "./features/sync.js";
+import { copyDirRecursive, syncBuiltinSkills, syncTemplates } from "./features/sync.js";
 import { createDaemonClient, ensureDaemonRunning } from "./lib/daemon.js";
 import { gitAddAndCommit, gitInit, isGitRepo } from "./lib/git.js";
+import {
+	acquireNativeSyncLock,
+	embeddingProvider,
+	hasNativeModelCache,
+	isRecord,
+	releaseNativeSyncLock,
+} from "./lib/native-sync.js";
 import {
 	AGENTS_DIR,
 	DEFAULT_PORT,
@@ -113,13 +118,6 @@ import {
 	startDaemon,
 	stopDaemon,
 } from "./lib/runtime.js";
-import {
-	acquireNativeSyncLock,
-	embeddingProvider,
-	hasNativeModelCache,
-	isRecord,
-	releaseNativeSyncLock,
-} from "./lib/native-sync.js";
 import "./sqlite.js";
 
 // Template directory location (relative to built CLI)
@@ -147,98 +145,6 @@ function getSkillsSourceDir() {
 
 	// Backward compat: fall back to templates/skills/
 	return join(getTemplatesDir(), "skills");
-}
-
-function copyDirRecursive(src: string, dest: string) {
-	mkdirSync(dest, { recursive: true });
-	const entries = readdirSync(src, { withFileTypes: true });
-
-	for (const entry of entries) {
-		const srcPath = join(src, entry.name);
-		const destPath = join(dest, entry.name);
-
-		if (entry.isDirectory()) {
-			copyDirRecursive(srcPath, destPath);
-		} else {
-			copyFileSync(srcPath, destPath);
-		}
-	}
-}
-
-function isBuiltinSkillDir(skillDir: string): boolean {
-	const skillMdPath = join(skillDir, "SKILL.md");
-	if (!existsSync(skillMdPath)) {
-		return false;
-	}
-
-	try {
-		const content = readFileSync(skillMdPath, "utf-8");
-		const frontmatter = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-		if (!frontmatter) {
-			return false;
-		}
-
-		return /^builtin:\s*true$/m.test(frontmatter[1]);
-	} catch {
-		return false;
-	}
-}
-
-function syncBuiltinSkills(
-	skillsSourceDir: string,
-	basePath: string,
-): {
-	installed: string[];
-	updated: string[];
-	skipped: string[];
-} {
-	const skillsSource = skillsSourceDir;
-	const skillsDest = join(basePath, "skills");
-	const result = {
-		installed: [] as string[],
-		updated: [] as string[],
-		skipped: [] as string[],
-	};
-
-	if (!existsSync(skillsSource)) {
-		return result;
-	}
-
-	mkdirSync(skillsDest, { recursive: true });
-
-	const entries = readdirSync(skillsSource, { withFileTypes: true }).filter((d) => d.isDirectory());
-
-	for (const entry of entries) {
-		const src = join(skillsSource, entry.name);
-		const dest = join(skillsDest, entry.name);
-
-		if (!existsSync(dest)) {
-			copyDirRecursive(src, dest);
-			result.installed.push(entry.name);
-			continue;
-		}
-
-		try {
-			const destStat = lstatSync(dest);
-			if (destStat.isSymbolicLink() || !destStat.isDirectory()) {
-				result.skipped.push(entry.name);
-				continue;
-			}
-		} catch {
-			result.skipped.push(entry.name);
-			continue;
-		}
-
-		if (!isBuiltinSkillDir(dest)) {
-			result.skipped.push(entry.name);
-			continue;
-		}
-
-		copyDirRecursive(src, dest);
-		result.updated.push(entry.name);
-	}
-
-	return result;
 }
 
 // ============================================================================

--- a/surfaces/cli/src/features/sync.test.ts
+++ b/surfaces/cli/src/features/sync.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { OpenClawConnector } from "@signet/connector-openclaw";
-import { syncTemplates } from "./sync.js";
+import { syncBuiltinSkills, syncTemplates } from "./sync.js";
 
 const originalHome = process.env.HOME;
 const originalOpenClawConfig = process.env.OPENCLAW_CONFIG_PATH;
@@ -144,6 +144,58 @@ describe("syncTemplates workspace detection", () => {
 			expect(output).not.toContain("hooks re-registered for opencode");
 		} finally {
 			console.log = origLog;
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("syncBuiltinSkills", () => {
+	it("refreshes an existing skill when the source is now a built-in", () => {
+		const root = mkdtempSync(join(tmpdir(), "sync-builtin-skills-"));
+		const source = join(root, "source");
+		const basePath = join(root, "agents");
+
+		try {
+			mkdirSync(join(source, "dreaming"), { recursive: true });
+			mkdirSync(join(basePath, "skills", "dreaming"), { recursive: true });
+			writeFileSync(
+				join(source, "dreaming", "SKILL.md"),
+				"---\nname: dreaming\ndescription: Dreaming\nbuiltin: true\n---\n\n# Dreaming\n\ncurrent",
+			);
+			writeFileSync(
+				join(basePath, "skills", "dreaming", "SKILL.md"),
+				"---\nname: dreaming\ndescription: Dreaming\n---\n\n# Dreaming\n\nstale",
+			);
+
+			const result = syncBuiltinSkills(source, basePath);
+
+			expect(result).toEqual({ installed: [], updated: ["dreaming"], skipped: [] });
+			expect(readFileSync(join(basePath, "skills", "dreaming", "SKILL.md"), "utf-8")).toContain("current");
+			expect(readFileSync(join(basePath, "skills", "dreaming", "SKILL.md"), "utf-8")).toContain("builtin: true");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("does not overwrite user-owned skills when the source is not a built-in", () => {
+		const root = mkdtempSync(join(tmpdir(), "sync-user-skills-"));
+		const source = join(root, "source");
+		const basePath = join(root, "agents");
+
+		try {
+			mkdirSync(join(source, "custom"), { recursive: true });
+			mkdirSync(join(basePath, "skills", "custom"), { recursive: true });
+			writeFileSync(join(source, "custom", "SKILL.md"), "---\nname: custom\ndescription: Official\n---\n\nsource");
+			writeFileSync(
+				join(basePath, "skills", "custom", "SKILL.md"),
+				"---\nname: custom\ndescription: User\n---\n\nuser",
+			);
+
+			const result = syncBuiltinSkills(source, basePath);
+
+			expect(result).toEqual({ installed: [], updated: [], skipped: ["custom"] });
+			expect(readFileSync(join(basePath, "skills", "custom", "SKILL.md"), "utf-8")).toContain("user");
+		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}
 	});

--- a/surfaces/cli/src/features/sync.ts
+++ b/surfaces/cli/src/features/sync.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync } from "node:fs";
+import { copyFileSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { OpenClawConnector } from "@signet/connector-openclaw";
@@ -76,6 +76,91 @@ function syncGitignore(basePath: string, templatesDir: string): number {
 	return 1;
 }
 
+export function copyDirRecursive(src: string, dest: string): void {
+	mkdirSync(dest, { recursive: true });
+	const entries = readdirSync(src, { withFileTypes: true });
+
+	for (const entry of entries) {
+		const srcPath = join(src, entry.name);
+		const destPath = join(dest, entry.name);
+
+		if (entry.isDirectory()) {
+			copyDirRecursive(srcPath, destPath);
+		} else {
+			copyFileSync(srcPath, destPath);
+		}
+	}
+}
+
+function isBuiltinSkillDir(skillDir: string): boolean {
+	const skillMdPath = join(skillDir, "SKILL.md");
+	if (!existsSync(skillMdPath)) {
+		return false;
+	}
+
+	try {
+		const content = readFileSync(skillMdPath, "utf-8");
+		const frontmatter = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+		if (!frontmatter) {
+			return false;
+		}
+
+		return /^builtin:\s*true$/m.test(frontmatter[1]);
+	} catch {
+		return false;
+	}
+}
+
+export function syncBuiltinSkills(skillsSourceDir: string, basePath: string): SkillSync {
+	const skillsDest = join(basePath, "skills");
+	const result = {
+		installed: [] as string[],
+		updated: [] as string[],
+		skipped: [] as string[],
+	};
+
+	if (!existsSync(skillsSourceDir)) {
+		return result;
+	}
+
+	mkdirSync(skillsDest, { recursive: true });
+
+	const entries = readdirSync(skillsSourceDir, { withFileTypes: true }).filter((d) => d.isDirectory());
+
+	for (const entry of entries) {
+		const src = join(skillsSourceDir, entry.name);
+		const dest = join(skillsDest, entry.name);
+		const sourceIsBuiltin = isBuiltinSkillDir(src);
+
+		if (!existsSync(dest)) {
+			copyDirRecursive(src, dest);
+			result.installed.push(entry.name);
+			continue;
+		}
+
+		try {
+			const destStat = lstatSync(dest);
+			if (destStat.isSymbolicLink() || !destStat.isDirectory()) {
+				result.skipped.push(entry.name);
+				continue;
+			}
+		} catch {
+			result.skipped.push(entry.name);
+			continue;
+		}
+
+		if (!sourceIsBuiltin && !isBuiltinSkillDir(dest)) {
+			result.skipped.push(entry.name);
+			continue;
+		}
+
+		copyDirRecursive(src, dest);
+		result.updated.push(entry.name);
+	}
+
+	return result;
+}
+
 function syncSkills(basePath: string, deps: Deps): number {
 	const result = deps.syncBuiltinSkills(deps.getSkillsSourceDir(), basePath);
 	for (const skill of result.installed) {
@@ -108,7 +193,6 @@ async function syncSourceRepo(basePath: string, deps: Deps): Promise<number> {
 	// current: already up to date, no output
 	return 0;
 }
-
 
 async function syncNative(basePath: string, deps: Deps): Promise<number> {
 	const native = await deps.syncNativeEmbeddingModel(basePath);


### PR DESCRIPTION
## Summary

Fixes `signet sync` so the built-in `dreaming` skill is installed and refreshed like the other Signet-owned skills.

## Changes

- Marks `skills/dreaming` as a built-in skill.
- Makes `syncBuiltinSkills` refresh destinations when the source skill is built-in, including older installed copies missing the marker.
- Adds regression coverage for stale built-in refresh behavior and the dreaming frontmatter guard.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: root `skills/dreaming`

## Screenshots

N/A, no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

No schema migrations touched; checklist items are N/A for this PR.

- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Rollback / compatibility note: reverting this PR restores the prior `signet sync` behavior. Existing user-owned non-built-in skills remain protected by the sync guard.

## Testing

- [x] `bun test surfaces/cli/src/features/sync.test.ts`
- [x] `bun test --test-name-pattern 'repo skills frontmatter|built-in dreaming skill' platform/daemon/src/routes/skills.test.ts platform/daemon/src/dreaming-skill.test.ts`
- [x] `bunx biome check surfaces/cli/src/features/sync.ts surfaces/cli/src/features/sync.test.ts surfaces/cli/src/cli.ts platform/daemon/src/routes/skills.test.ts skills/dreaming/SKILL.md`
- [x] `bun run build:core`
- [x] `cd surfaces/cli && bun run build:cli`

Note: the full `platform/daemon/src/routes/skills.test.ts` file has unrelated live catalog/install tests that timed out locally, so this PR uses the targeted frontmatter regression guard for the touched behavior.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

`dist/signetai/skills` and `platform/daemon/skills` were regenerated locally to verify packaging, but they are ignored generated outputs and are not committed.
