### PR TITLE
feat(dashboard): improve constellation ontology navigation

### DIFF
--- a/platform/daemon/src/knowledge-graph-list.test.ts
+++ b/platform/daemon/src/knowledge-graph-list.test.ts
@@ -321,6 +321,48 @@ describe("listKnowledgeEntities (issue #515)", () => {
 		seedAttribute("attr-hidden", "asp-hidden", { content: "hidden attr" });
 		seedDependency("dep-visible", "e-hub", "e-leaf", { strength: 0.9 });
 		seedDependency("dep-hidden", "e-hub", "e-hidden", { strength: 0.8 });
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`UPDATE entity_attributes
+				 SET version = 2,
+				     version_root_id = 'attr-hub-a-root',
+				     previous_attribute_id = 'attr-hub-a-0',
+				     group_key = 'general',
+				     claim_key = 'alpha_claim',
+				     source_kind = 'transcript',
+				     source_path = 'sessions/alpha.jsonl',
+				     proposal_id = 'proposal-applied-alpha',
+				     proposal_evidence = '[{"kind":"memory","id":"mem-a"}]'
+				 WHERE id = 'attr-hub-a-1'`,
+			).run();
+			db.prepare(
+				`INSERT INTO ontology_proposals
+				 (id, agent_id, operation, status, payload, confidence, rationale, evidence, source_kind, source_path, created_at, updated_at)
+				 VALUES (?, 'default', 'add_claim_value', 'pending', ?, 0.91, 'needs alpha claim', ?, 'transcript',
+				         'sessions/alpha.jsonl', '2026-05-16T12:00:00Z', '2026-05-16T12:00:00Z')`,
+			).run(
+				"proposal-pending-alpha",
+				JSON.stringify({ entity: "Hub", aspect: "alpha", claim_key: "alpha_claim", value: "important alpha" }),
+				JSON.stringify([{ kind: "memory", id: "mem-a" }]),
+			);
+			db.prepare(
+				`INSERT INTO ontology_proposals
+				 (id, agent_id, operation, status, payload, confidence, rationale, evidence, created_at, updated_at, applied_at)
+				 VALUES (?, 'default', 'add_claim_value', 'applied', ?, 0.82, 'already applied', '[]',
+				         datetime('now'), datetime('now'), datetime('now'))`,
+			).run("proposal-recent-applied", JSON.stringify({ entity: "Hub" }));
+			db.prepare(
+				`INSERT INTO dreaming_state
+				 (agent_id, tokens_since_last_pass, consecutive_failures, last_pass_at, last_pass_id, last_pass_mode)
+				 VALUES ('default', 2400, 0, '2026-05-16T13:00:00Z', 'dream-alpha', 'incremental')`,
+			).run();
+			db.prepare(
+				`INSERT INTO dreaming_passes
+				 (id, agent_id, mode, status, started_at, completed_at, mutations_applied, mutations_skipped, mutations_failed, created_at)
+				 VALUES ('dream-alpha', 'default', 'incremental', 'completed', '2026-05-16T12:50:00Z',
+				         '2026-05-16T13:00:00Z', 3, 1, 0, '2026-05-16T12:50:00Z')`,
+			).run();
+		});
 
 		const graph = getKnowledgeGraphForConstellation(getDbAccessor(), "default", {
 			limit: 2,
@@ -332,8 +374,18 @@ describe("listKnowledgeEntities (issue #515)", () => {
 		expect(graph.entities.map((entity) => entity.id)).toEqual(["e-hub", "e-leaf"]);
 		expect(graph.entities[0].aspects.map((aspect) => aspect.id)).toEqual(["asp-hub-a"]);
 		expect(graph.entities[0].aspects[0].attributes.map((attr) => attr.id)).toEqual(["attr-hub-a-1"]);
+		expect(graph.entities[0].aspects[0].attributes[0].version).toBe(2);
+		expect(graph.entities[0].aspects[0].attributes[0].proposalId).toBe("proposal-applied-alpha");
+		expect(graph.entities[0].aspects[0].attributes[0].proposalEvidenceCount).toBe(1);
 		expect(graph.dependencies.map((dependency) => dependency.sourceEntityId)).toEqual(["e-hub"]);
 		expect(graph.dependencies.map((dependency) => dependency.targetEntityId)).toEqual(["e-leaf"]);
+		expect(graph.proposals.map((proposal) => proposal.id)).toContain("proposal-pending-alpha");
+		expect(graph.proposals[0]?.targetEntityId).toBe("e-hub");
+		expect(graph.proposals[0]?.targetAspectName).toBe("alpha");
+		expect(graph.metadata.proposals.pending).toBe(1);
+		expect(graph.metadata.proposals.appliedRecent).toBe(1);
+		expect(graph.metadata.dreaming.tokensSinceLastPass).toBe(2400);
+		expect(graph.metadata.dreaming.latestPass?.mutationsApplied).toBe(3);
 	});
 });
 

--- a/platform/daemon/src/knowledge-graph.ts
+++ b/platform/daemon/src/knowledge-graph.ts
@@ -1890,12 +1890,24 @@ export interface ConstellationAttribute {
 	readonly kind: "attribute" | "constraint";
 	readonly importance: number;
 	readonly memoryId: string | null;
+	readonly status: AttributeStatus;
+	readonly version: number;
+	readonly versionRootId: string | null;
+	readonly previousAttributeId: string | null;
+	readonly groupKey: string | null;
+	readonly claimKey: string | null;
+	readonly sourceKind: string | null;
+	readonly sourcePath: string | null;
+	readonly proposalId: string | null;
+	readonly proposalEvidenceCount: number;
 }
 
 export interface ConstellationAspect {
 	readonly id: string;
 	readonly name: string;
 	readonly weight: number;
+	readonly status: "active" | "archived";
+	readonly proposalId: string | null;
 	readonly attributes: readonly ConstellationAttribute[];
 }
 
@@ -1905,6 +1917,8 @@ export interface ConstellationEntity {
 	readonly entityType: string;
 	readonly mentions: number;
 	readonly pinned: boolean;
+	readonly status: "active" | "archived";
+	readonly proposalId: string | null;
 	readonly aspects: readonly ConstellationAspect[];
 }
 
@@ -1913,11 +1927,57 @@ export interface ConstellationDependency {
 	readonly targetEntityId: string;
 	readonly dependencyType: string;
 	readonly strength: number;
+	readonly status: "active" | "archived";
+	readonly proposalId: string | null;
+	readonly proposalEvidenceCount: number;
+}
+
+export interface ConstellationProposal {
+	readonly id: string;
+	readonly operation: string;
+	readonly confidence: number;
+	readonly rationale: string;
+	readonly evidenceCount: number;
+	readonly sourceKind: string | null;
+	readonly sourcePath: string | null;
+	readonly updatedAt: string;
+	readonly targetEntityId: string | null;
+	readonly targetEntityName: string | null;
+	readonly targetAspectName: string | null;
+	readonly preview: string | null;
+}
+
+export interface ConstellationDreamingSummary {
+	readonly tokensSinceLastPass: number;
+	readonly consecutiveFailures: number;
+	readonly lastPassAt: string | null;
+	readonly lastPassId: string | null;
+	readonly lastPassMode: string | null;
+	readonly latestPass: {
+		readonly id: string;
+		readonly mode: string;
+		readonly status: string;
+		readonly completedAt: string | null;
+		readonly mutationsApplied: number | null;
+		readonly mutationsSkipped: number | null;
+		readonly mutationsFailed: number | null;
+	} | null;
+}
+
+export interface ConstellationProposalSummary {
+	readonly pending: number;
+	readonly appliedRecent: number;
+	readonly failedRecent: number;
 }
 
 export interface ConstellationGraph {
 	readonly entities: readonly ConstellationEntity[];
 	readonly dependencies: readonly ConstellationDependency[];
+	readonly proposals: readonly ConstellationProposal[];
+	readonly metadata: {
+		readonly dreaming: ConstellationDreamingSummary;
+		readonly proposals: ConstellationProposalSummary;
+	};
 }
 
 export interface ConstellationGraphOptions {
@@ -1935,6 +1995,123 @@ function placeholders(count: number): string {
 	return Array.from({ length: count }, () => "?").join(", ");
 }
 
+function parseJsonRecord(value: unknown): Record<string, unknown> {
+	if (typeof value !== "string") return {};
+	try {
+		const parsed: unknown = JSON.parse(value);
+		return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+			? (parsed as Record<string, unknown>)
+			: {};
+	} catch {
+		return {};
+	}
+}
+
+function readStringValue(record: Record<string, unknown>, keys: readonly string[]): string | null {
+	for (const key of keys) {
+		const value = record[key];
+		if (typeof value === "string" && value.trim().length > 0) return value.trim();
+	}
+	return null;
+}
+
+function previewFromProposalPayload(payload: Record<string, unknown>): string | null {
+	const value = readStringValue(payload, ["value", "content", "name", "target", "reason"]);
+	if (!value) return null;
+	return value.length > 140 ? `${value.slice(0, 137)}...` : value;
+}
+
+function resolveProposalTargetEntity(
+	payload: Record<string, unknown>,
+	entitiesById: ReadonlyMap<string, string>,
+	entitiesByName: ReadonlyMap<string, string>,
+): { readonly id: string | null; readonly name: string | null } {
+	const id = readStringValue(payload, ["entity_id", "target_entity_id", "target_id"]);
+	if (id && entitiesById.has(id)) return { id, name: entitiesById.get(id) ?? null };
+
+	const name = readStringValue(payload, ["entity", "target_entity", "name", "target"]);
+	if (!name) return { id: null, name: null };
+	return { id: entitiesByName.get(toCanonicalName(name)) ?? null, name };
+}
+
+function getConstellationDreamingSummary(db: ReadDb, agentId: string): ConstellationDreamingSummary {
+	const state = db
+		.prepare(
+			`SELECT tokens_since_last_pass, consecutive_failures, last_pass_at, last_pass_id, last_pass_mode
+			 FROM dreaming_state WHERE agent_id = ?`,
+		)
+		.get(agentId) as
+		| {
+				tokens_since_last_pass: number;
+				consecutive_failures: number;
+				last_pass_at: string | null;
+				last_pass_id: string | null;
+				last_pass_mode: string | null;
+		  }
+		| undefined;
+	const latestPass = db
+		.prepare(
+			`SELECT id, mode, status, completed_at, mutations_applied, mutations_skipped, mutations_failed
+			 FROM dreaming_passes
+			 WHERE agent_id = ?
+			 ORDER BY created_at DESC
+			 LIMIT 1`,
+		)
+		.get(agentId) as
+		| {
+				id: string;
+				mode: string;
+				status: string;
+				completed_at: string | null;
+				mutations_applied: number | null;
+				mutations_skipped: number | null;
+				mutations_failed: number | null;
+		  }
+		| undefined;
+
+	return {
+		tokensSinceLastPass: Math.max(0, state?.tokens_since_last_pass ?? 0),
+		consecutiveFailures: Math.max(0, state?.consecutive_failures ?? 0),
+		lastPassAt: state?.last_pass_at ?? null,
+		lastPassId: state?.last_pass_id ?? null,
+		lastPassMode: state?.last_pass_mode ?? null,
+		latestPass: latestPass
+			? {
+					id: latestPass.id,
+					mode: latestPass.mode,
+					status: latestPass.status,
+					completedAt: latestPass.completed_at,
+					mutationsApplied: latestPass.mutations_applied,
+					mutationsSkipped: latestPass.mutations_skipped,
+					mutationsFailed: latestPass.mutations_failed,
+				}
+			: null,
+	};
+}
+
+function getConstellationProposalSummary(db: ReadDb, agentId: string): ConstellationProposalSummary {
+	const pending = db
+		.prepare("SELECT COUNT(*) AS n FROM ontology_proposals WHERE agent_id = ? AND status = 'pending'")
+		.get(agentId) as { n: number } | undefined;
+	const applied = db
+		.prepare(
+			`SELECT COUNT(*) AS n FROM ontology_proposals
+			 WHERE agent_id = ? AND status = 'applied' AND updated_at >= datetime('now', '-7 days')`,
+		)
+		.get(agentId) as { n: number } | undefined;
+	const failed = db
+		.prepare(
+			`SELECT COUNT(*) AS n FROM ontology_proposals
+			 WHERE agent_id = ? AND status = 'failed' AND updated_at >= datetime('now', '-7 days')`,
+		)
+		.get(agentId) as { n: number } | undefined;
+	return {
+		pending: Math.max(0, pending?.n ?? 0),
+		appliedRecent: Math.max(0, applied?.n ?? 0),
+		failedRecent: Math.max(0, failed?.n ?? 0),
+	};
+}
+
 export function getKnowledgeGraphForConstellation(
 	accessor: DbAccessor,
 	agentId: string,
@@ -1942,7 +2119,7 @@ export function getKnowledgeGraphForConstellation(
 ): ConstellationGraph {
 	const limit = boundedInteger(options.limit, 150, 1, 300);
 	const maxAspectsPerEntity = boundedInteger(options.maxAspectsPerEntity, 6, 1, 25);
-	const maxAttributesPerAspect = boundedInteger(options.maxAttributesPerAspect, 4, 1, 20);
+	const maxAttributesPerAspect = boundedInteger(options.maxAttributesPerAspect, 4, 1, 250);
 	const dependencyLimit = boundedInteger(options.dependencyLimit, 500, 1, 2000);
 
 	return accessor.withReadDb((db) => {
@@ -1952,9 +2129,10 @@ export function getKnowledgeGraphForConstellation(
 		// event-loop/RSS spike big enough for systemd to SIGKILL the daemon.
 		const entityRows = db
 			.prepare(
-				`SELECT e.id, e.name, e.entity_type, e.mentions, e.pinned
+				`SELECT e.id, e.name, e.entity_type, e.mentions, e.pinned, e.status, e.proposal_id
 				 FROM entities e
 				 WHERE e.agent_id = ?
+				   AND COALESCE(e.status, 'active') = 'active'
 				   AND (e.mentions > 0 OR e.pinned = 1)
 				 ORDER BY e.pinned DESC, e.mentions DESC, e.name ASC
 				 LIMIT ?`,
@@ -1964,19 +2142,29 @@ export function getKnowledgeGraphForConstellation(
 		const entityIds = entityRows.map((r) => r.id as string).filter((id) => typeof id === "string");
 
 		if (entityIds.length === 0) {
-			return { entities: [], dependencies: [] };
+			return {
+				entities: [],
+				dependencies: [],
+				proposals: [],
+				metadata: {
+					dreaming: getConstellationDreamingSummary(db, agentId),
+					proposals: getConstellationProposalSummary(db, agentId),
+				},
+			};
 		}
 
 		const entityIdSet = new Set(entityIds);
 		const entityIdPlaceholders = placeholders(entityIds.length);
 		const aspectRows = db
 			.prepare(
-				`SELECT id, entity_id, name, weight
+				`SELECT id, entity_id, name, weight, status, proposal_id
 				 FROM (
-				   SELECT id, entity_id, name, weight,
+				   SELECT id, entity_id, name, weight, status, proposal_id,
 				          ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY weight DESC, name ASC) AS rn
 				   FROM entity_aspects
-				   WHERE agent_id = ? AND entity_id IN (${entityIdPlaceholders})
+				   WHERE agent_id = ?
+				     AND COALESCE(status, 'active') = 'active'
+				     AND entity_id IN (${entityIdPlaceholders})
 				 ) ranked_aspects
 				 WHERE rn <= ?
 				 ORDER BY entity_id ASC, weight DESC, name ASC`,
@@ -1989,6 +2177,8 @@ export function getKnowledgeGraphForConstellation(
 				id: string;
 				name: string;
 				weight: number;
+				status: "active" | "archived";
+				proposalId: string | null;
 			}>
 		>();
 		const aspectIds: string[] = [];
@@ -2004,6 +2194,8 @@ export function getKnowledgeGraphForConstellation(
 				id: aspectId,
 				name: row.name as string,
 				weight: Number(row.weight ?? 0.5),
+				status: row.status === "archived" ? "archived" : "active",
+				proposalId: typeof row.proposal_id === "string" ? row.proposal_id : null,
 			});
 			aspectsByEntity.set(entityId, bucket);
 		}
@@ -2014,9 +2206,15 @@ export function getKnowledgeGraphForConstellation(
 			const aspectIdPlaceholders = placeholders(aspectIds.length);
 			const attrRows = db
 				.prepare(
-					`SELECT id, aspect_id, content, kind, importance, memory_id
+					`SELECT id, aspect_id, content, kind, importance, memory_id, status,
+					        version, version_root_id, previous_attribute_id,
+					        group_key, claim_key, source_kind, source_path,
+					        proposal_id, proposal_evidence
 					 FROM (
-					   SELECT id, aspect_id, content, kind, importance, memory_id,
+					   SELECT id, aspect_id, content, kind, importance, memory_id, status,
+					          version, version_root_id, previous_attribute_id,
+					          group_key, claim_key, source_kind, source_path,
+					          proposal_id, proposal_evidence,
 					          ROW_NUMBER() OVER (PARTITION BY aspect_id ORDER BY importance DESC, id ASC) AS rn
 					   FROM entity_attributes
 					   WHERE agent_id = ? AND status = 'active' AND aspect_id IN (${aspectIdPlaceholders})
@@ -2037,34 +2235,54 @@ export function getKnowledgeGraphForConstellation(
 					kind: row.kind as "attribute" | "constraint",
 					importance: Number(row.importance ?? 0.5),
 					memoryId: typeof row.memory_id === "string" ? row.memory_id : null,
+					status: row.status as AttributeStatus,
+					version: typeof row.version === "number" ? row.version : 1,
+					versionRootId: typeof row.version_root_id === "string" ? row.version_root_id : null,
+					previousAttributeId: typeof row.previous_attribute_id === "string" ? row.previous_attribute_id : null,
+					groupKey: typeof row.group_key === "string" ? row.group_key : null,
+					claimKey: typeof row.claim_key === "string" ? row.claim_key : null,
+					sourceKind: typeof row.source_kind === "string" ? row.source_kind : null,
+					sourcePath: typeof row.source_path === "string" ? row.source_path : null,
+					proposalId: typeof row.proposal_id === "string" ? row.proposal_id : null,
+					proposalEvidenceCount: parseJsonArray(row.proposal_evidence).length,
 				});
 				attrsByAspect.set(aspectId, bucket);
 			}
 		}
 
+		const entitiesById = new Map<string, string>();
+		const entitiesByName = new Map<string, string>();
 		const entities: ConstellationEntity[] = entityRows.map((row) => {
 			const eid = row.id as string;
+			const name = row.name as string;
+			entitiesById.set(eid, name);
+			entitiesByName.set(toCanonicalName(name), eid);
 			const aspects: ConstellationAspect[] = (aspectsByEntity.get(eid) ?? []).map((asp) => ({
 				id: asp.id,
 				name: asp.name,
 				weight: asp.weight,
+				status: asp.status,
+				proposalId: asp.proposalId,
 				attributes: attrsByAspect.get(asp.id) ?? [],
 			}));
 			return {
 				id: eid,
-				name: row.name as string,
+				name,
 				entityType: row.entity_type as string,
 				mentions: typeof row.mentions === "number" ? row.mentions : 0,
 				pinned: row.pinned === 1,
+				status: row.status === "archived" ? "archived" : "active",
+				proposalId: typeof row.proposal_id === "string" ? row.proposal_id : null,
 				aspects,
 			};
 		});
 
 		const depRows = db
 			.prepare(
-				`SELECT source_entity_id, target_entity_id, dependency_type, strength
+				`SELECT source_entity_id, target_entity_id, dependency_type, strength, status, proposal_id, proposal_evidence
 				 FROM entity_dependencies
 				 WHERE agent_id = ?
+				   AND COALESCE(status, 'active') = 'active'
 				   AND source_entity_id IN (${entityIdPlaceholders})
 				   AND target_entity_id IN (${entityIdPlaceholders})
 				 ORDER BY strength DESC
@@ -2077,9 +2295,49 @@ export function getKnowledgeGraphForConstellation(
 			targetEntityId: row.target_entity_id as string,
 			dependencyType: row.dependency_type as string,
 			strength: Number(row.strength ?? 0.5),
+			status: row.status === "archived" ? "archived" : "active",
+			proposalId: typeof row.proposal_id === "string" ? row.proposal_id : null,
+			proposalEvidenceCount: parseJsonArray(row.proposal_evidence).length,
 		}));
 
-		return { entities, dependencies };
+		const proposalRows = db
+			.prepare(
+				`SELECT id, operation, payload, confidence, rationale, evidence,
+				        source_kind, source_path, updated_at
+				 FROM ontology_proposals
+				 WHERE agent_id = ? AND status = 'pending'
+				 ORDER BY updated_at DESC
+				 LIMIT 80`,
+			)
+			.all(agentId) as Array<Record<string, unknown>>;
+		const proposals: ConstellationProposal[] = proposalRows.map((row) => {
+			const payload = parseJsonRecord(row.payload);
+			const target = resolveProposalTargetEntity(payload, entitiesById, entitiesByName);
+			return {
+				id: row.id as string,
+				operation: row.operation as string,
+				confidence: Number(row.confidence ?? 0),
+				rationale: typeof row.rationale === "string" ? row.rationale : "",
+				evidenceCount: parseJsonArray(row.evidence).length,
+				sourceKind: typeof row.source_kind === "string" ? row.source_kind : null,
+				sourcePath: typeof row.source_path === "string" ? row.source_path : null,
+				updatedAt: row.updated_at as string,
+				targetEntityId: target.id,
+				targetEntityName: target.name,
+				targetAspectName: readStringValue(payload, ["aspect", "target_aspect", "aspect_name"]),
+				preview: previewFromProposalPayload(payload),
+			};
+		});
+
+		return {
+			entities,
+			dependencies,
+			proposals,
+			metadata: {
+				dreaming: getConstellationDreamingSummary(db, agentId),
+				proposals: getConstellationProposalSummary(db, agentId),
+			},
+		};
 	});
 }
 

--- a/platform/daemon/src/routes/knowledge-routes.ts
+++ b/platform/daemon/src/routes/knowledge-routes.ts
@@ -316,7 +316,7 @@ export function registerKnowledgeRoutes(app: Hono): void {
 			getKnowledgeGraphForConstellation(getDbAccessor(), agentId, {
 				limit: parseNavigationLimit(c.req.query("limit"), 150, 300),
 				maxAspectsPerEntity: parseNavigationLimit(c.req.query("max_aspects_per_entity"), 6, 25),
-				maxAttributesPerAspect: parseNavigationLimit(c.req.query("max_attributes_per_aspect"), 4, 20),
+				maxAttributesPerAspect: parseNavigationLimit(c.req.query("max_attributes_per_aspect"), 4, 250),
 				dependencyLimit: parseNavigationLimit(c.req.query("dependency_limit"), 500, 2000),
 			}),
 		);

--- a/surfaces/dashboard/src/lib/api.ts
+++ b/surfaces/dashboard/src/lib/api.ts
@@ -2871,12 +2871,24 @@ export interface ConstellationAttribute {
 	kind: "attribute" | "constraint";
 	importance: number;
 	memoryId: string | null;
+	status?: "active" | "superseded" | "deleted";
+	version?: number;
+	versionRootId?: string | null;
+	previousAttributeId?: string | null;
+	groupKey?: string | null;
+	claimKey?: string | null;
+	sourceKind?: string | null;
+	sourcePath?: string | null;
+	proposalId?: string | null;
+	proposalEvidenceCount?: number;
 }
 
 export interface ConstellationAspect {
 	id: string;
 	name: string;
 	weight: number;
+	status?: "active" | "archived";
+	proposalId?: string | null;
 	attributes: ConstellationAttribute[];
 }
 
@@ -2886,6 +2898,8 @@ export interface ConstellationEntity {
 	entityType: string;
 	mentions: number;
 	pinned: boolean;
+	status?: "active" | "archived";
+	proposalId?: string | null;
 	aspects: ConstellationAspect[];
 }
 
@@ -2894,16 +2908,69 @@ export interface ConstellationDependency {
 	targetEntityId: string;
 	dependencyType: string;
 	strength: number;
+	status?: "active" | "archived";
+	proposalId?: string | null;
+	proposalEvidenceCount?: number;
+}
+
+export interface ConstellationProposal {
+	id: string;
+	operation: string;
+	confidence: number;
+	rationale: string;
+	evidenceCount: number;
+	sourceKind: string | null;
+	sourcePath: string | null;
+	updatedAt: string;
+	targetEntityId: string | null;
+	targetEntityName: string | null;
+	targetAspectName: string | null;
+	preview: string | null;
+}
+
+export interface ConstellationDreamingSummary {
+	tokensSinceLastPass: number;
+	consecutiveFailures: number;
+	lastPassAt: string | null;
+	lastPassId: string | null;
+	lastPassMode: string | null;
+	latestPass: {
+		id: string;
+		mode: string;
+		status: string;
+		completedAt: string | null;
+		mutationsApplied: number | null;
+		mutationsSkipped: number | null;
+		mutationsFailed: number | null;
+	} | null;
+}
+
+export interface ConstellationProposalSummary {
+	pending: number;
+	appliedRecent: number;
+	failedRecent: number;
 }
 
 export interface ConstellationGraph {
 	entities: ConstellationEntity[];
 	dependencies: ConstellationDependency[];
+	proposals?: ConstellationProposal[];
+	metadata?: {
+		dreaming: ConstellationDreamingSummary;
+		proposals: ConstellationProposalSummary;
+	};
 }
 
 export async function getConstellationOverlay(agentId: string): Promise<ConstellationGraph | null> {
 	try {
-		const path = `${API_BASE}/api/knowledge/constellation?agent_id=${encodeURIComponent(agentId)}&limit=150&max_aspects_per_entity=6&max_attributes_per_aspect=4&dependency_limit=500`;
+		const params = new URLSearchParams({
+			agent_id: agentId,
+			limit: "120",
+			max_aspects_per_entity: "20",
+			max_attributes_per_aspect: "150",
+			dependency_limit: "800",
+		});
+		const path = `${API_BASE}/api/knowledge/constellation?${params.toString()}`;
 		const res = await fetch(path);
 		if (!res.ok) return null;
 		return (await res.json()) as ConstellationGraph;

--- a/surfaces/dashboard/src/lib/components/ontology/ConstellationGraph.svelte
+++ b/surfaces/dashboard/src/lib/components/ontology/ConstellationGraph.svelte
@@ -23,6 +23,8 @@ interface Props {
 }
 const { agentId = "default" }: Props = $props();
 
+type FocusLevel = "overview" | "entity" | "aspect" | "attribute";
+
 const BASE_SIZES: Record<KnowledgeMapNodeKind, number> = {
 	source: 58,
 	document: 48,
@@ -46,6 +48,18 @@ const ENTITY_TYPE_COLORS: Record<string, { color: string; dim: string }> = {
 	org: { color: "#f59e0b", dim: "rgba(245, 158, 11, 0.28)" },
 	skill: { color: "#f59e0b", dim: "rgba(245, 158, 11, 0.28)" },
 	task: { color: "#64748b", dim: "rgba(100, 116, 139, 0.3)" },
+	source: { color: "#38bdf8", dim: "rgba(56, 189, 248, 0.3)" },
+	artifact: { color: "#f97316", dim: "rgba(249, 115, 22, 0.28)" },
+	agent: { color: "#22c55e", dim: "rgba(34, 197, 94, 0.3)" },
+	policy: { color: "#fb7185", dim: "rgba(251, 113, 133, 0.3)" },
+	action: { color: "#84cc16", dim: "rgba(132, 204, 22, 0.28)" },
+	workflow: { color: "#c084fc", dim: "rgba(192, 132, 252, 0.3)" },
+	event: { color: "#facc15", dim: "rgba(250, 204, 21, 0.28)" },
+	object_type: { color: "#2dd4bf", dim: "rgba(45, 212, 191, 0.3)" },
+	interface: { color: "#60a5fa", dim: "rgba(96, 165, 250, 0.3)" },
+	observation: { color: "#e879f9", dim: "rgba(232, 121, 249, 0.3)" },
+	claim_slot: { color: "#a3e635", dim: "rgba(163, 230, 53, 0.28)" },
+	claim_value: { color: "#f472b6", dim: "rgba(244, 114, 182, 0.3)" },
 };
 
 const ENTITY_SPRITE_TYPES = new Set([
@@ -63,26 +77,57 @@ const ENTITY_SPRITE_TYPES = new Set([
 	"unknown",
 ]);
 
-const EDGE_COLORS: GraphRenderColors["edges"] = {
-	contains: { color: "rgb(96, 165, 250)", alpha: 0.18, width: 1.1 },
-	has_aspect: { color: "rgb(96, 165, 250)", alpha: 0.46, width: 1.35 },
-	has_attribute: { color: "rgb(167, 139, 250)", alpha: 0.42, width: 1.2 },
-	supports: { color: "rgb(34, 211, 238)", alpha: 0.42, width: 1.25 },
-	updates: { color: "rgb(34, 211, 238)", alpha: 0.58, width: 1.8 },
-	extends: { color: "rgb(14, 165, 233)", alpha: 0.36, width: 1.2 },
-	mentions: { color: "rgb(59, 130, 246)", alpha: 0.12, width: 0.9 },
-	about: { color: "rgb(59, 130, 246)", alpha: 0.24, width: 1.2 },
+const EDGE_COLORS_DARK: GraphRenderColors["edges"] = {
+	contains: { color: "rgb(96, 165, 250)", alpha: 0.14, width: 1.0 },
+	has_aspect: { color: "rgb(96, 165, 250)", alpha: 0.38, width: 1.25 },
+	has_attribute: { color: "rgb(167, 139, 250)", alpha: 0.34, width: 1.1 },
+	supports: { color: "rgb(34, 211, 238)", alpha: 0.34, width: 1.15 },
+	updates: { color: "rgb(34, 211, 238)", alpha: 0.48, width: 1.6 },
+	extends: { color: "rgb(14, 165, 233)", alpha: 0.3, width: 1.1 },
+	mentions: { color: "rgb(59, 130, 246)", alpha: 0.1, width: 0.85 },
+	about: { color: "rgb(59, 130, 246)", alpha: 0.2, width: 1.1 },
 };
 
-const RENDER_COLORS: GraphRenderColors = {
+const EDGE_COLORS_LIGHT: GraphRenderColors["edges"] = {
+	contains: { color: "rgb(10, 57, 255)", alpha: 0.18, width: 1.0 },
+	has_aspect: { color: "rgb(10, 57, 255)", alpha: 0.42, width: 1.25 },
+	has_attribute: { color: "rgb(124, 58, 237)", alpha: 0.38, width: 1.1 },
+	supports: { color: "rgb(6, 182, 212)", alpha: 0.38, width: 1.15 },
+	updates: { color: "rgb(6, 182, 212)", alpha: 0.52, width: 1.6 },
+	extends: { color: "rgb(2, 132, 199)", alpha: 0.34, width: 1.1 },
+	mentions: { color: "rgb(37, 99, 235)", alpha: 0.14, width: 0.85 },
+	about: { color: "rgb(37, 99, 235)", alpha: 0.26, width: 1.1 },
+};
+
+const RENDER_COLORS_DARK: GraphRenderColors = {
 	selection: "#7cc7ff",
 	selectionGlow: "rgba(59, 130, 246, 0.24)",
 	text: "rgba(226, 232, 240, 0.74)",
 	textMuted: "rgba(148, 163, 184, 0.66)",
 	textDim: "rgba(148, 163, 184, 0.14)",
 	labelShadow: "rgba(0, 0, 0, 0.82)",
-	edges: EDGE_COLORS,
+	edges: EDGE_COLORS_DARK,
 	relatedGlow: KNOWLEDGE_RELATED_GLOW,
+};
+
+const RENDER_COLORS_LIGHT: GraphRenderColors = {
+	selection: "#0a39ff",
+	selectionGlow: "rgba(10, 57, 255, 0.18)",
+	text: "rgba(36, 41, 54, 0.78)",
+	textMuted: "rgba(94, 102, 117, 0.72)",
+	textDim: "rgba(94, 102, 117, 0.18)",
+	labelShadow: "rgba(255, 255, 255, 0.7)",
+	edges: EDGE_COLORS_LIGHT,
+	relatedGlow: {
+		source: "rgba(10, 57, 255, 0.18)",
+		document: "rgba(10, 57, 255, 0.18)",
+		session: "rgba(10, 57, 255, 0.18)",
+		aspect: "rgba(10, 57, 255, 0.14)",
+		attribute: "rgba(124, 58, 237, 0.14)",
+		memory: "rgba(10, 57, 255, 0.12)",
+		entity: "rgba(10, 57, 255, 0.18)",
+		proposal: "rgba(10, 57, 255, 0.14)",
+	},
 };
 
 const ENTITY_TYPE_ORDER = [
@@ -96,6 +141,18 @@ const ENTITY_TYPE_ORDER = [
 	"org",
 	"skill",
 	"task",
+	"source",
+	"artifact",
+	"agent",
+	"policy",
+	"action",
+	"workflow",
+	"event",
+	"object_type",
+	"interface",
+	"observation",
+	"claim_slot",
+	"claim_value",
 	"extracted",
 	"unknown",
 ];
@@ -111,6 +168,18 @@ const ENTITY_TYPE_LABELS: Record<string, string> = {
 	org: "Org",
 	skill: "Skill",
 	task: "Task",
+	source: "Source",
+	artifact: "Artifact",
+	agent: "Agent",
+	policy: "Policy",
+	action: "Action",
+	workflow: "Workflow",
+	event: "Event",
+	object_type: "Object Type",
+	interface: "Interface",
+	observation: "Observation",
+	claim_slot: "Claim Slot",
+	claim_value: "Claim Value",
 	extracted: "Extracted",
 	unknown: "Other",
 };
@@ -124,6 +193,7 @@ const STRUCTURE_LEGEND: { kind: "aspect" | "attribute" | "memory"; label: string
 ];
 const ENTITY_FOCUS_ZOOM = 0.56;
 const ASPECT_FOCUS_ZOOM = 0.72;
+const ATTRIBUTE_FOCUS_ZOOM = 0.92;
 const ENTITY_DESELECT_ZOOM = 0.36;
 const ASPECT_DESELECT_ZOOM = 0.44;
 
@@ -144,9 +214,12 @@ let legendOpen = $state(true);
 let width = $state(800);
 let height = $state(600);
 let zoomDisplay = $state(50);
-let viewportVersion = $state(0);
+let entitySearch = $state("");
+let lightTheme = $state(false);
 const popoverNode = $derived(focusedNode());
 const visibleSummary = $derived(summaryText());
+const entitySearchResults = $derived(entitySearchResultsFor(rawNodes, entitySearch));
+const renderColors = $derived(lightTheme ? RENDER_COLORS_LIGHT : RENDER_COLORS_DARK);
 let nodeCache = new Map<string, GraphCanvasNode>();
 let nodeMap = new Map<string, GraphCanvasNode>();
 let viewport: ViewportState | null = null;
@@ -200,6 +273,9 @@ function toCanvasNode(node: KnowledgeMapNode): GraphCanvasNode {
 		anchorDy: cached?.anchorDy,
 		size,
 		mass: node.kind === "entity" ? Math.max(0, Math.min(node.counts?.scale ?? 0, 1)) : undefined,
+		systemRadius: systemRadiusForNode(node, size),
+		iconScale: iconScaleForKind(node.kind),
+		counts: node.counts,
 		color: entityTone?.color ?? KNOWLEDGE_NODE_COLORS[node.kind],
 		dimColor: entityTone?.dim ?? KNOWLEDGE_NODE_COLORS_DIM[node.kind],
 		sprite: node.kind === "entity" ? entitySprite(node.entityType) : undefined,
@@ -207,6 +283,26 @@ function toCanvasNode(node: KnowledgeMapNode): GraphCanvasNode {
 		data: node,
 	};
 	return next;
+}
+
+function iconScaleForKind(kind: KnowledgeMapNodeKind): number {
+	if (kind === "aspect") return 1.35;
+	if (kind === "attribute") return 1.45;
+	return 1;
+}
+
+function systemRadiusForNode(node: KnowledgeMapNode, size: number): number | undefined {
+	if (node.kind === "entity") {
+		const aspects = node.counts?.aspects ?? 0;
+		const attributes = node.counts?.attributes ?? 0;
+		const scale = Math.max(0, Math.min(node.counts?.scale ?? 0, 1));
+		return clamp(370 + scale * 230 + Math.sqrt(aspects) * 36 + Math.sqrt(attributes) * 9, 440, 860);
+	}
+	if (node.kind === "aspect") {
+		const attributes = node.counts?.attributes ?? 0;
+		return clamp(150 + Math.sqrt(attributes) * 17, size + 96, 360);
+	}
+	return undefined;
 }
 
 function entityColor(type: string | undefined): { color: string; dim: string } {
@@ -261,6 +357,106 @@ function entityTypeLabel(type: string): string {
 		.join(" ");
 }
 
+function entitySearchResultsFor(nodes: KnowledgeMapNode[], query: string): KnowledgeMapNode[] {
+	const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+	if (terms.length === 0) return [];
+	return nodes
+		.filter((node) => node.kind === "entity")
+		.map((node) => ({ node, score: entitySearchScore(node, terms) }))
+		.filter((result) => result.score > 0)
+		.sort(
+			(a, b) =>
+				b.score - a.score || entityRank(b.node) - entityRank(a.node) || a.node.label.localeCompare(b.node.label),
+		)
+		.slice(0, 10)
+		.map((result) => result.node);
+}
+
+function entitySearchScore(node: KnowledgeMapNode, terms: string[]): number {
+	const text = entitySearchText(node);
+	let score = 0;
+	for (const term of terms) {
+		if (node.label.toLowerCase() === term) score += 80;
+		else if (node.label.toLowerCase().startsWith(term)) score += 45;
+		else if (node.label.toLowerCase().includes(term)) score += 25;
+		else if (text.includes(term)) score += 8;
+		else return 0;
+	}
+	return score + Math.min(entityRank(node) / 70, 25);
+}
+
+function entitySearchText(node: KnowledgeMapNode): string {
+	return [node.label, node.entityType, node.sublabel, node.preview, node.searchText]
+		.filter((value): value is string => typeof value === "string")
+		.join(" ")
+		.toLowerCase();
+}
+
+function entityRank(node: KnowledgeMapNode): number {
+	const mentions = Math.max(0, node.counts?.mentions ?? 0);
+	const scale = Math.max(0, Math.min(node.counts?.scale ?? 0, 1));
+	const aspects = Math.max(0, node.counts?.aspects ?? 0);
+	const attributes = Math.max(0, node.counts?.attributes ?? 0);
+	return mentions * 8 + scale * 1000 + aspects * 10 + attributes;
+}
+
+function applyEntityTypeZones(nodes: GraphCanvasNode[], resetPositions: boolean): void {
+	const entities = nodes.filter((node) => node.kind === "entity");
+	if (entities.length === 0) return;
+	const groups = new Map<string, GraphCanvasNode[]>();
+	for (const node of entities) {
+		const type = normalizeEntityType(canvasEntityType(node));
+		const group = groups.get(type) ?? [];
+		group.push(node);
+		groups.set(type, group);
+	}
+	const order = new Map(ENTITY_TYPE_ORDER.map((type, index) => [type, index]));
+	const sortedGroups = [...groups.entries()].sort(([a, aNodes], [b, bNodes]) => {
+		const aOrder = order.get(a);
+		const bOrder = order.get(b);
+		if (aOrder !== undefined || bOrder !== undefined) return (aOrder ?? 999) - (bOrder ?? 999);
+		return bNodes.length - aNodes.length || a.localeCompare(b);
+	});
+	const columns = Math.max(2, Math.ceil(Math.sqrt(sortedGroups.length * 1.45)));
+	const rows = Math.max(1, Math.ceil(sortedGroups.length / columns));
+	for (const [zoneIndex, [, group]] of sortedGroups.entries()) {
+		const centerX = ((zoneIndex % columns) - (columns - 1) / 2) * 1320;
+		const centerY = (Math.floor(zoneIndex / columns) - (rows - 1) / 2) * 1060;
+		group.sort((a, b) => b.size - a.size || a.label.localeCompare(b.label));
+		for (const [index, node] of group.entries()) {
+			const target = zonePoint(index, group.length, centerX, centerY, node.systemRadius ?? node.size * 3);
+			node.zoneX = target.x;
+			node.zoneY = target.y;
+			if (resetPositions) {
+				node.x = target.x;
+				node.y = target.y;
+				node.vx = 0;
+				node.vy = 0;
+			}
+		}
+	}
+}
+
+function zonePoint(
+	index: number,
+	total: number,
+	centerX: number,
+	centerY: number,
+	systemRadius: number,
+): { x: number; y: number } {
+	if (index === 0) return { x: centerX, y: centerY };
+	const ring = Math.floor(Math.sqrt(index));
+	const firstInRing = ring * ring;
+	const ringCount = Math.max(1, Math.min(total - firstInRing, (ring + 1) * (ring + 1) - firstInRing));
+	const position = index - firstInRing;
+	const angle = -Math.PI / 2 + (position / ringCount) * Math.PI * 2 + ring * 0.38;
+	const radius = Math.max(420, systemRadius * 0.42) + ring * 420;
+	return {
+		x: centerX + Math.cos(angle) * radius,
+		y: centerY + Math.sin(angle) * radius,
+	};
+}
+
 function toCanvasEdge(edge: KnowledgeMapEdge): GraphCanvasEdge {
 	return {
 		...edge,
@@ -274,6 +470,7 @@ function toCanvasEdge(edge: KnowledgeMapEdge): GraphCanvasEdge {
 
 function buildSim(nodes: KnowledgeMapNode[], edges: KnowledgeMapEdge[], forceInit = false): void {
 	const nextNodes = nodes.map(toCanvasNode);
+	applyEntityTypeZones(nextNodes, forceInit && selectedId === null);
 	const nodeIds = new Set(nextNodes.map((node) => node.id));
 	const nextEdges = edges.filter((edge) => nodeIds.has(edge.source) && nodeIds.has(edge.target)).map(toCanvasEdge);
 	simNodes = nextNodes;
@@ -285,18 +482,21 @@ function buildSim(nodes: KnowledgeMapNode[], edges: KnowledgeMapEdge[], forceIni
 	initializeAnchors(activeNodes);
 	syncAnchoredNodes();
 	rebuildSpatial();
-	const charge = activeNodes.length > 1000 ? -650 : activeNodes.length > 400 ? -1000 : activeNodes.length > 90 ? -1500 : -2000;
 	const layoutNodes = activeNodes.filter(shouldSimulateNode);
+	const charge =
+		layoutNodes.length > 600 ? -900 : layoutNodes.length > 250 ? -1500 : layoutNodes.length > 90 ? -2200 : -2800;
 	const layoutIds = new Set(layoutNodes.map((node) => node.id));
 	const layoutEdges = activeEdges.filter((edge) => layoutIds.has(edge.sourceId) && layoutIds.has(edge.targetId));
 	if (forceInit)
 		sim.init(layoutNodes, layoutEdges, {
 			chargeStrength: charge,
-			linkDistance: activeNodes.length > 1000 ? 150 : 220,
-			collisionPadding: activeNodes.length > 1000 ? 10 : 18,
-			preSettleTicks: activeNodes.length > 1000 ? 24 : activeNodes.length > 400 ? 45 : 140,
-			maxActiveTicks: activeNodes.length > 1000 ? 18 : activeNodes.length > 400 ? 28 : 70,
-			maxActiveMs: activeNodes.length > 1000 ? 280 : activeNodes.length > 400 ? 420 : 900,
+			linkDistance: activeNodes.length > 1000 ? 210 : 280,
+			collisionPadding: activeNodes.length > 1000 ? 20 : 34,
+			solarPadding: activeNodes.length > 1000 ? 170 : 240,
+			solarStrength: activeNodes.length > 1000 ? 0.42 : 0.5,
+			preSettleTicks: activeNodes.length > 1000 ? 48 : activeNodes.length > 400 ? 90 : 180,
+			maxActiveTicks: activeNodes.length > 1000 ? 28 : activeNodes.length > 400 ? 48 : 90,
+			maxActiveMs: activeNodes.length > 1000 ? 420 : activeNodes.length > 400 ? 680 : 1100,
 		});
 	else sim.update(layoutNodes, layoutEdges);
 	autoFitPending = forceInit;
@@ -304,11 +504,89 @@ function buildSim(nodes: KnowledgeMapNode[], edges: KnowledgeMapEdge[], forceIni
 }
 
 function applyVisibleGraph(forceInit = false): void {
-	buildSim(rawNodes, rawEdges, forceInit);
+	const graph = visibleGraphForFocus();
+	buildSim(graph.nodes, graph.edges, forceInit);
 }
 
 function directChildren(id: string): KnowledgeMapNode[] {
 	return rawNodes.filter((node) => node.parentId === id);
+}
+
+function visibleGraphForFocus(): { nodes: KnowledgeMapNode[]; edges: KnowledgeMapEdge[] } {
+	const selected = selectedNode();
+	const ids = selected ? focusedVisibleIds(selected) : overviewVisibleIds();
+	const nodes = rawNodes.filter((node) => ids.has(node.id));
+	return {
+		nodes,
+		edges: rawEdges.filter(
+			(edge) => ids.has(edge.source) && ids.has(edge.target) && includeEdgeForFocus(edge, selected),
+		),
+	};
+}
+
+function overviewVisibleIds(): Set<string> {
+	const ids = new Set<string>();
+	for (const node of rawNodes) {
+		if (node.kind === "entity" || node.kind === "session") ids.add(node.id);
+	}
+	return ids;
+}
+
+function focusedVisibleIds(node: KnowledgeMapNode): Set<string> {
+	const ids = new Set<string>();
+	const ancestors = ancestorNodes(node);
+	const entity = node.kind === "entity" ? node : ancestors.find((item) => item.kind === "entity");
+	const aspect = node.kind === "aspect" ? node : ancestors.find((item) => item.kind === "aspect");
+
+	if (node.kind === "entity" && entity) {
+		ids.add(entity.id);
+		for (const child of directChildren(entity.id)) ids.add(child.id);
+		for (const edge of rawEdges) {
+			if (edge.kind !== "about") continue;
+			if (edge.source === node.id) ids.add(edge.target);
+			if (edge.target === node.id) ids.add(edge.source);
+		}
+		return ids;
+	}
+
+	if (node.kind === "aspect" && aspect) {
+		if (entity) ids.add(entity.id);
+		ids.add(aspect.id);
+		for (const child of directChildren(aspect.id)) ids.add(child.id);
+		return ids;
+	}
+
+	if (node.kind === "attribute") {
+		if (entity) ids.add(entity.id);
+		if (aspect) ids.add(aspect.id);
+		ids.add(node.id);
+		if (aspect) {
+			for (const child of directChildren(aspect.id)) ids.add(child.id);
+		}
+		for (const child of directChildren(node.id)) ids.add(child.id);
+		return ids;
+	}
+
+	if (node.kind === "memory") {
+		for (const ancestor of ancestors) ids.add(ancestor.id);
+		ids.add(node.id);
+		return ids;
+	}
+
+	ids.add(node.id);
+	return ids;
+}
+
+function includeEdgeForFocus(edge: KnowledgeMapEdge, selected: KnowledgeMapNode | null): boolean {
+	if (!selected) return edge.kind === "about" || edge.kind === "updates";
+	if (selected.kind === "entity") return edge.kind === "has_aspect" || edge.kind === "about" || edge.kind === "updates";
+	if (selected.kind === "aspect")
+		return edge.kind === "has_aspect" || edge.kind === "has_attribute" || edge.kind === "updates";
+	if (selected.kind === "attribute" || selected.kind === "memory")
+		return (
+			edge.kind === "has_aspect" || edge.kind === "has_attribute" || edge.kind === "supports" || edge.kind === "updates"
+		);
+	return true;
 }
 
 async function loadMap(id: string): Promise<void> {
@@ -325,7 +603,7 @@ async function loadMap(id: string): Promise<void> {
 			buildSim([], [], true);
 			return;
 		}
-		const graph = buildKnowledgeMapFromConstellation(data, { focusLabel: "Signet", limit: 2000 });
+		const graph = buildKnowledgeMapFromConstellation(data, { focusLabel: "Signet", limit: 5000 });
 		rawNodes = graph.nodes;
 		rawEdges = graph.edges;
 		nodeCache = new Map();
@@ -385,8 +663,9 @@ function loop(): void {
 	if (draggingNode) captureAnchorOffset(draggingNode);
 	const anchoredChanged = syncAnchoredNodes(draggingNode);
 	const spatialChanged =
-		viewportMoving || simActive || dragging || anchoredChanged || renderNeeded ? rebuildSpatial(spatialFrame++ % 3 !== 0) : false;
-	if ((selectedId ?? hoveredId) && (viewportMoving || simActive || spatialChanged)) viewportVersion += 1;
+		viewportMoving || simActive || dragging || anchoredChanged || renderNeeded
+			? rebuildSpatial(spatialFrame++ % 3 !== 0)
+			: false;
 	if (autoFitPending && simNodes.length > 0 && width > 0 && height > 0) {
 		vp.fitToNodes(simNodes, width, height);
 		autoFitPending = false;
@@ -408,7 +687,7 @@ function loop(): void {
 			dimProgress,
 		},
 		nodeMap,
-		RENDER_COLORS,
+		renderColors,
 	);
 }
 
@@ -417,10 +696,7 @@ function selectGraphNode(node: GraphCanvasNode | null): void {
 		clearSelection();
 		return;
 	}
-	selectedId = node.id;
-	relatedIds = focusRelatedIds(node.id);
-	if (node.kind === "entity" || node.kind === "aspect") focusNodeNeighborhood(node.id);
-	requestRender();
+	enterFocus(node.id);
 }
 
 function selectedNode(): KnowledgeMapNode | null {
@@ -458,10 +734,15 @@ function zoomBy(factor: number): void {
 }
 
 function selectAndCenter(id: string): void {
+	enterFocus(id);
+}
+
+function enterFocus(id: string): void {
 	selectedId = id;
 	relatedIds = focusRelatedIds(id);
+	applyVisibleGraph();
 	const node = nodeMap.get(id);
-	if (node?.kind === "entity" || node?.kind === "aspect") focusNodeNeighborhood(id);
+	if (node?.kind === "entity" || node?.kind === "aspect" || node?.kind === "attribute") focusNodeNeighborhood(id);
 	else centerNode(id);
 	requestRender();
 }
@@ -469,27 +750,12 @@ function selectAndCenter(id: string): void {
 function focusRelatedIds(id: string): Set<string> {
 	const node = rawNodes.find((item) => item.id === id);
 	if (!node) return new Set();
-	const ids = new Set<string>();
-	ids.add(id);
+	const ids = new Set<string>([id]);
 	const ancestors = ancestorNodes(node);
-	const entity = node.kind === "entity" ? node : ancestors.find((item) => item.kind === "entity");
-	const aspect = node.kind === "aspect" ? node : ancestors.find((item) => item.kind === "aspect");
-
-	if (entity) {
-		ids.add(entity.id);
-		for (const child of directChildren(entity.id)) ids.add(child.id);
-	}
-	if (aspect) {
-		ids.add(aspect.id);
-		for (const child of directChildren(aspect.id)) ids.add(child.id);
-	}
+	for (const ancestor of ancestors) ids.add(ancestor.id);
 	for (const child of directChildren(id)) ids.add(child.id);
-	if (node.kind === "attribute" || node.kind === "memory") {
-		for (const edge of rawEdges) {
-			if (edge.kind !== "supports") continue;
-			if (edge.source === id) ids.add(edge.target);
-			if (edge.target === id) ids.add(edge.source);
-		}
+	if (node.kind === "entity" || node.kind === "aspect") {
+		for (const visibleId of focusedVisibleIds(node)) ids.add(visibleId);
 	}
 	return ids;
 }
@@ -505,10 +771,9 @@ function ancestorNodes(node: KnowledgeMapNode): KnowledgeMapNode[] {
 }
 
 function clearSelection(): void {
-	const previousId = selectedId;
 	selectedId = null;
 	relatedIds = new Set();
-	if (previousId) zoomOutFromFocus(previousId);
+	applyVisibleGraph(true);
 	requestRender();
 }
 
@@ -523,14 +788,19 @@ function focusNodeNeighborhood(id: string): void {
 	const node = nodeMap.get(id);
 	if (!node) return;
 	const children = directCanvasChildren(id);
-	arrangeOrbit(node, children);
+	arrangeFocusLayout(node, children);
 	sim.pause();
 	syncAnchoredNodes();
 	rebuildSpatial();
-	const maxZoom = node.kind === "entity" ? ENTITY_FOCUS_ZOOM : ASPECT_FOCUS_ZOOM;
-	viewport?.fitToNodes([node, ...children], width, height, {
+	if (node.kind === "attribute") {
+		requestRender();
+		return;
+	}
+	const maxZoom =
+		node.kind === "entity" ? ENTITY_FOCUS_ZOOM : node.kind === "aspect" ? ASPECT_FOCUS_ZOOM : ATTRIBUTE_FOCUS_ZOOM;
+	viewport?.fitToNodes(focusViewportNodes(node), width, height, {
 		maxZoom,
-		padding: node.kind === "entity" ? 0.34 : 0.42,
+		padding: node.kind === "entity" ? 0.34 : node.kind === "aspect" ? 0.42 : 0.58,
 	});
 	requestRender();
 }
@@ -565,16 +835,46 @@ function directCanvasChildren(id: string): GraphCanvasNode[] {
 		.filter((child): child is GraphCanvasNode => child !== undefined);
 }
 
-function arrangeOrbit(parent: GraphCanvasNode, children: GraphCanvasNode[]): void {
+function focusViewportNodes(node: GraphCanvasNode): GraphCanvasNode[] {
+	const ids = new Set<string>([node.id]);
+	for (const child of directCanvasChildren(node.id)) ids.add(child.id);
+	let current = node.parentId ? nodeMap.get(node.parentId) : null;
+	while (current) {
+		ids.add(current.id);
+		if (node.kind === "attribute" && current.kind === "aspect") {
+			for (const sibling of directCanvasChildren(current.id)) ids.add(sibling.id);
+		}
+		current = current.parentId ? nodeMap.get(current.parentId) : null;
+	}
+	return [...ids].map((id) => nodeMap.get(id)).filter((item): item is GraphCanvasNode => item !== undefined);
+}
+
+function arrangeFocusLayout(parent: GraphCanvasNode, children: GraphCanvasNode[]): void {
+	if (parent.kind === "aspect") {
+		if (children.length === 0) return;
+		arrangeAttributeLane(parent, children);
+		return;
+	}
+	if (parent.kind === "attribute") {
+		arrangeEvidenceTerminals(parent, children);
+		return;
+	}
 	if (children.length === 0) return;
-	const radius = parent.kind === "entity" ? 210 : 132;
-	const ringStep = parent.kind === "entity" ? 46 : 34;
-	const startAngle = -Math.PI / 2;
+	arrangeAspectRing(parent, children);
+}
+
+function arrangeAspectRing(parent: GraphCanvasNode, children: GraphCanvasNode[]): void {
+	const baseRadius =
+		parent.kind === "entity" ? Math.max(290, parent.size * 0.8 + 190) : Math.max(188, parent.size * 1.15 + 118);
+	const ringStep = parent.kind === "entity" ? 122 : 96;
+	const minArc = parent.kind === "entity" ? 190 : 188;
+	const startAngle = -Math.PI / 2 + stableOrbitOffset(parent.id) * 0.4;
 	parent.vx = 0;
 	parent.vy = 0;
 	for (const [index, child] of children.entries()) {
-		const angle = startAngle + (Math.PI * 2 * index) / children.length;
-		const ring = radius + (children.length > 6 ? (index % 2) * ringStep : 0);
+		const point = orbitPoint(index, children.length, baseRadius, ringStep, minArc, startAngle);
+		const angle = point.angle;
+		const ring = point.radius;
 		child.x = parent.x + Math.cos(angle) * ring;
 		child.y = parent.y + Math.sin(angle) * ring;
 		child.vx = 0;
@@ -586,12 +886,91 @@ function arrangeOrbit(parent: GraphCanvasNode, children: GraphCanvasNode[]): voi
 	}
 }
 
+function arrangeAttributeLane(parent: GraphCanvasNode, children: GraphCanvasNode[]): void {
+	const parentEntity = parent.parentId ? nodeMap.get(parent.parentId) : null;
+	const angle = parentEntity
+		? Math.atan2(parent.y - parentEntity.y, parent.x - parentEntity.x)
+		: stableOrbitOffset(parent.id);
+	const tangent = angle + Math.PI / 2;
+	const columns = children.length > 42 ? 7 : children.length > 24 ? 6 : children.length > 12 ? 5 : 4;
+	parent.vx = 0;
+	parent.vy = 0;
+	for (const [index, child] of children.entries()) {
+		const row = Math.floor(index / columns);
+		const column = index % columns;
+		const finalColumns = Math.min(columns, children.length - row * columns);
+		const center = (finalColumns - 1) / 2;
+		const radial = 178 + row * 124;
+		const tangentOffset = (column - center) * 118;
+		child.x = parent.x + Math.cos(angle) * radial + Math.cos(tangent) * tangentOffset;
+		child.y = parent.y + Math.sin(angle) * radial + Math.sin(tangent) * tangentOffset;
+		child.vx = 0;
+		child.vy = 0;
+		child.fx = null;
+		child.fy = null;
+		child.anchorDx = child.x - parent.x;
+		child.anchorDy = child.y - parent.y;
+	}
+}
+
+function arrangeEvidenceTerminals(parent: GraphCanvasNode, children: GraphCanvasNode[]): void {
+	const aspect = parent.parentId ? nodeMap.get(parent.parentId) : null;
+	const entity = aspect?.parentId ? nodeMap.get(aspect.parentId) : null;
+	const angle = aspect && entity ? Math.atan2(aspect.y - entity.y, aspect.x - entity.x) : stableOrbitOffset(parent.id);
+	const tangent = angle + Math.PI / 2;
+	parent.vx = 0;
+	parent.vy = 0;
+	for (const [index, child] of children.entries()) {
+		const side = index % 2 === 0 ? 1 : -1;
+		const radial = 86 + Math.floor(index / 2) * 48;
+		const tangentOffset = side * (34 + Math.floor(index / 2) * 16);
+		child.x = parent.x + Math.cos(angle) * radial + Math.cos(tangent) * tangentOffset;
+		child.y = parent.y + Math.sin(angle) * radial + Math.sin(tangent) * tangentOffset;
+		child.vx = 0;
+		child.vy = 0;
+		child.fx = null;
+		child.fy = null;
+		child.anchorDx = child.x - parent.x;
+		child.anchorDy = child.y - parent.y;
+	}
+}
+
+function orbitPoint(
+	index: number,
+	total: number,
+	baseRadius: number,
+	ringStep: number,
+	minArc: number,
+	startAngle: number,
+): { radius: number; angle: number } {
+	let consumed = 0;
+	let ring = 0;
+	while (true) {
+		const radius = baseRadius + ring * ringStep;
+		const capacity = Math.max(5, Math.floor((Math.PI * 2 * radius) / minArc));
+		const ringIndex = index - consumed;
+		if (ringIndex < capacity) {
+			const count = Math.min(capacity, total - consumed);
+			const angle = startAngle + (Math.PI * 2 * ringIndex) / Math.max(count, 1);
+			return { radius, angle };
+		}
+		consumed += capacity;
+		ring += 1;
+	}
+}
+
+function stableOrbitOffset(id: string): number {
+	let hash = 0;
+	for (let i = 0; i < id.length; i++) hash = (Math.imul(31, hash) + id.charCodeAt(i)) | 0;
+	return (((hash >>> 0) % 10000) / 10000 - 0.5) * 0.6;
+}
+
 function shouldSimulateNode(node: GraphCanvasNode): boolean {
 	return node.kind === "entity" || node.kind === "aspect";
 }
 
 function shouldAnchorNode(node: GraphCanvasNode): boolean {
-	return node.kind === "attribute" || node.kind === "memory";
+	return node.kind === "attribute" || node.kind === "memory" || node.kind === "proposal";
 }
 
 function initializeAnchors(nodes: GraphCanvasNode[]): void {
@@ -674,9 +1053,19 @@ function nodeKindLabel(kind: KnowledgeMapNodeKind): string {
 	return kind === "memory" ? "Evidence" : kind[0]?.toUpperCase() + kind.slice(1);
 }
 
+function cardTitle(node: KnowledgeMapNode): string {
+	if (node.kind === "attribute" && node.preview) return node.preview;
+	return node.label;
+}
+
+function shouldShowCardPreview(node: KnowledgeMapNode): boolean {
+	return node.kind !== "attribute" && Boolean(node.preview);
+}
+
 function footerSummary(node: KnowledgeMapNode): string {
 	if (node.counts?.mentions) return `${node.counts.mentions} mentions`;
 	if (node.counts?.importance) return `${node.counts.importance}% importance`;
+	if (node.counts?.confidence) return `${node.counts.confidence}% confidence`;
 	return node.status ?? "current";
 }
 
@@ -690,33 +1079,28 @@ function focusedNode(): KnowledgeMapNode | null {
 }
 
 function popoverStyle(node: KnowledgeMapNode): string {
-	void viewportVersion;
-	const canvasNode = nodeMap.get(node.id);
-	const vp = viewport;
-	if (!canvasNode || !vp) return "display: none";
-	const screen = vp.worldToScreen(canvasNode.x, canvasNode.y);
-	const gap = 20;
 	const panelWidth = Math.max(260, Math.min(330, width - 32));
-	const panelHeight = 250;
-	const radius = (canvasNode.size * vp.zoom) / 2;
-	const rightSpace = width - (screen.x + radius + gap);
-	const leftSpace = screen.x - radius - gap;
-	const belowSpace = height - (screen.y + radius + gap);
-	const aboveSpace = screen.y - radius - gap;
+	const panelHeight = popoverPanelHeight(node);
+	const inset = width < 700 ? 14 : 24;
+	return `right: ${inset}px; bottom: ${inset}px; width: ${panelWidth}px; height: ${panelHeight}px;`;
+}
 
-	let left = screen.x + radius + gap;
-	let top = screen.y - panelHeight / 2;
-	if (rightSpace < panelWidth && leftSpace >= panelWidth) {
-		left = screen.x - radius - gap - panelWidth;
-	} else if (rightSpace < panelWidth && belowSpace >= panelHeight) {
-		left = screen.x - panelWidth / 2;
-		top = screen.y + radius + gap;
-	} else if (rightSpace < panelWidth && aboveSpace > belowSpace) {
-		left = screen.x - panelWidth / 2;
-		top = screen.y - radius - gap - panelHeight;
-	}
+function entityNavigatorStyle(): string {
+	const panelWidth = Math.max(300, Math.min(360, width - 32));
+	const inset = width < 700 ? 14 : 24;
+	return `right: ${inset}px; bottom: ${inset}px; width: ${panelWidth}px; height: auto; max-height: ${Math.min(420, height - 80)}px;`;
+}
 
-	return `left: ${clamp(left, 16, width - panelWidth - 16)}px; top: ${clamp(top, 16, height - panelHeight - 16)}px; width: ${panelWidth}px;`;
+function popoverPanelHeight(node: KnowledgeMapNode): number {
+	const actions = Math.min(directChildren(node.id).length, popoverChildLimit(node));
+	return clamp(236 + Math.ceil(actions / 2) * 32, 270, Math.min(430, height - 32));
+}
+
+function popoverChildLimit(node: KnowledgeMapNode): number {
+	if (node.kind === "aspect") return 8;
+	if (node.kind === "entity") return 6;
+	if (node.kind === "attribute") return 6;
+	return 4;
 }
 
 function shortId(id: string): string {
@@ -731,7 +1115,22 @@ function summaryText(): string {
 	const visible = simNodes.length;
 	if (loading) return "Loading knowledge map...";
 	if (error) return error;
-	return `${visible} ontology nodes • ${simEdges.length} relationships`;
+	const focus = selectedNode();
+	const proposals = simNodes.filter((node) => node.kind === "proposal").length;
+	const dreams = simNodes.filter((node) => node.kind === "session").length;
+	const overlays = [
+		focus ? `${focusLevelForNode(focus)} focus` : "overview",
+		proposals > 0 ? `${proposals} proposals` : "",
+		dreams > 0 ? `${dreams} dreaming signals` : "",
+	].filter(Boolean);
+	return `${visible} ontology nodes • ${simEdges.length} relationships${overlays.length > 0 ? ` • ${overlays.join(" • ")}` : ""}`;
+}
+
+function focusLevelForNode(node: KnowledgeMapNode): FocusLevel {
+	if (node.kind === "entity") return "entity";
+	if (node.kind === "aspect") return "aspect";
+	if (node.kind === "attribute" || node.kind === "memory") return "attribute";
+	return "overview";
 }
 
 function keyboard(e: KeyboardEvent): void {
@@ -776,6 +1175,22 @@ function keyboard(e: KeyboardEvent): void {
 	}
 }
 
+function handleEntitySearchKeydown(e: KeyboardEvent): void {
+	if (e.key === "Enter") {
+		e.preventDefault();
+		const first = entitySearchResults[0];
+		if (first) selectAndCenter(first.id);
+	}
+	if (e.key === "Escape") {
+		e.stopPropagation();
+		entitySearch = "";
+	}
+}
+
+function readLightTheme(): boolean {
+	return typeof document !== "undefined" && document.documentElement.dataset.theme === "light";
+}
+
 $effect(() => {
 	void agentId;
 	loadMap(agentId);
@@ -789,6 +1204,7 @@ $effect(() => {
 });
 
 onMount(() => {
+	lightTheme = readLightTheme();
 	const el = canvas;
 	if (el) {
 		viewport = new ViewportState(el.clientWidth / 2, el.clientHeight / 2, 0.5);
@@ -811,11 +1227,24 @@ onMount(() => {
 	}
 	window.addEventListener("keydown", keyboard);
 	raf = requestAnimationFrame(loop);
+
+	const themeObserver = new MutationObserver((mutations) => {
+		for (const mutation of mutations) {
+			if (mutation.attributeName === "data-theme") {
+				lightTheme = readLightTheme();
+				renderNeeded = true;
+				break;
+			}
+		}
+	});
+	themeObserver.observe(document.documentElement, { attributes: true });
+
 	return () => {
 		window.removeEventListener("keydown", keyboard);
 		cancelAnimationFrame(raf);
 		input?.destroy();
 		sim.destroy();
+		themeObserver.disconnect();
 	};
 });
 </script>
@@ -879,44 +1308,95 @@ onMount(() => {
 		</div>
 	</div>
 
-	{#if popoverNode}
-		<div class="node-popover" class:selected={selectedId === popoverNode.id} style={popoverStyle(popoverNode)}>
-			<div class="node-card-kind">
-				{nodeKindLabel(popoverNode.kind)}{popoverNode.sublabel ? ` • ${popoverNode.sublabel}` : ""}
-			</div>
-			<div class="node-card-title">{popoverNode.label}</div>
-			{#if popoverNode.preview}
-				<div class="node-card-preview">{popoverNode.preview}</div>
-			{/if}
-			{#if popoverNode.details?.length}
-				<div class="node-detail-list">
-					{#each popoverNode.details.slice(0, 4) as row (`${row.label}:${row.value}`)}
-						<div class="node-detail-row">
-							<span>{row.label}</span>
-							<strong>{row.value}</strong>
-						</div>
+	<div
+		class="node-popover"
+		class:selected={popoverNode ? selectedId === popoverNode.id : false}
+		class:attribute-popover={popoverNode?.kind === "attribute"}
+		class:entity-navigator-popover={!popoverNode}
+		style={popoverNode ? popoverStyle(popoverNode) : entityNavigatorStyle()}
+	>
+		<div class="node-popover-content">
+			{#if popoverNode}
+				<div class="node-card-kind">
+					{nodeKindLabel(popoverNode.kind)}{popoverNode.sublabel ? ` • ${popoverNode.sublabel}` : ""}
+				</div>
+				<div class="node-card-title">{cardTitle(popoverNode)}</div>
+				{#if shouldShowCardPreview(popoverNode)}
+					<div class="node-card-preview">{popoverNode.preview}</div>
+				{/if}
+				{#if popoverNode.details?.length}
+					<div class="node-detail-list">
+						{#each popoverNode.details.slice(0, 4) as row (`${row.label}:${row.value}`)}
+							<div class="node-detail-row">
+								<span>{row.label}</span>
+								<strong>{row.value}</strong>
+							</div>
+						{/each}
+					</div>
+				{/if}
+				<div class="popover-actions">
+					{#if parentNode(popoverNode)}
+						<button type="button" onclick={() => popoverNode.parentId && selectAndCenter(popoverNode.parentId)}>
+							Parent
+						</button>
+					{/if}
+					{#each directChildren(popoverNode.id).slice(0, popoverChildLimit(popoverNode)) as child (child.id)}
+						<button type="button" onclick={() => selectAndCenter(child.id)}>
+							<span>{nodeKindLabel(child.kind)}</span>
+							<strong>{child.label}</strong>
+						</button>
 					{/each}
+					{#if directChildren(popoverNode.id).length > popoverChildLimit(popoverNode)}
+						<div class="popover-more">
+							+{directChildren(popoverNode.id).length - popoverChildLimit(popoverNode)} more
+						</div>
+					{/if}
+				</div>
+			{:else}
+				<div class="node-card-kind">Navigator</div>
+				<div class="node-card-title entity-navigator-title">Entities</div>
+				<div class="entity-navigator-subtitle">
+					{rawNodes.filter((node) => node.kind === "entity").length} selectable entities
+				</div>
+				<label class="entity-search-label" for="constellation-entity-search">Search entity</label>
+				<input
+					id="constellation-entity-search"
+					class="entity-search-input"
+					type="search"
+					bind:value={entitySearch}
+					placeholder="Name, type, or memory path"
+					autocomplete="off"
+					onkeydown={handleEntitySearchKeydown}
+				/>
+				<div class="entity-navigator-results" aria-label="Entity search results">
+					{#if entitySearch.trim().length === 0}
+						<div class="entity-navigator-empty">Type to locate an entity</div>
+					{:else if entitySearchResults.length === 0}
+						<div class="entity-navigator-empty">No matching entities</div>
+					{:else}
+						{#each entitySearchResults as node (node.id)}
+							<button type="button" onclick={() => selectAndCenter(node.id)} title={node.label}>
+								<span>{node.label}</span>
+								<small>
+									{entityTypeLabel(normalizeEntityType(node.entityType))} • {node.counts?.aspects ?? 0} aspects • {node
+										.counts?.attributes ?? 0} attributes
+								</small>
+							</button>
+						{/each}
+					{/if}
 				</div>
 			{/if}
-			<div class="popover-actions">
-				{#if parentNode(popoverNode)}
-					<button type="button" onclick={() => popoverNode.parentId && selectAndCenter(popoverNode.parentId)}>
-						Parent
-					</button>
-				{/if}
-				{#each directChildren(popoverNode.id).slice(0, 3) as child (child.id)}
-					<button type="button" onclick={() => selectAndCenter(child.id)}>
-						<span>{nodeKindLabel(child.kind)}</span>
-						<strong>{child.label}</strong>
-					</button>
-				{/each}
-			</div>
-			<div class="node-card-footer">
+		</div>
+		<div class="node-card-footer">
+			{#if popoverNode}
 				<span>{footerSummary(popoverNode)}</span>
 				<code>{shortId(popoverNode.id)}</code>
-			</div>
+			{:else}
+				<span>overview</span>
+				<code>{entitySearchResults.length} results</code>
+			{/if}
 		</div>
-	{/if}
+	</div>
 </div>
 
 <style>
@@ -934,7 +1414,7 @@ onMount(() => {
 		z-index: 0;
 		content: "";
 		background: url("/constellation-assets/background.png") center / cover no-repeat;
-		opacity: 0.26;
+		opacity: 0.35;
 		pointer-events: none;
 	}
 
@@ -944,8 +1424,9 @@ onMount(() => {
 		z-index: 0;
 		content: "";
 		background:
-			linear-gradient(90deg, rgba(2, 6, 18, 0.72), rgba(2, 6, 18, 0.28) 24%, rgba(2, 6, 18, 0.28) 70%, rgba(2, 6, 18, 0.7)),
-			linear-gradient(180deg, rgba(2, 6, 18, 0.58), rgba(2, 6, 18, 0.36) 40%, rgba(2, 6, 18, 0.72));
+			linear-gradient(90deg, rgba(2, 6, 18, 0.78), rgba(2, 6, 18, 0.22) 28%, rgba(2, 6, 18, 0.22) 68%, rgba(2, 6, 18, 0.76)),
+			linear-gradient(180deg, rgba(2, 6, 18, 0.62), rgba(2, 6, 18, 0.32) 40%, rgba(2, 6, 18, 0.76)),
+			radial-gradient(ellipse at 50% 50%, rgba(6, 22, 56, 0.15) 0%, rgba(2, 6, 18, 0) 70%);
 		pointer-events: none;
 	}
 
@@ -973,16 +1454,17 @@ onMount(() => {
 	.map-title {
 		font-family: var(--font-heading);
 		font-size: 13px;
-		letter-spacing: 0.18em;
-		color: rgba(226, 232, 240, 0.92);
+		letter-spacing: 0.22em;
+		color: rgba(226, 232, 240, 0.95);
+		text-shadow: 0 0 18px rgba(96, 165, 250, 0.25);
 	}
 
 	.map-subtitle {
-		margin-top: 4px;
+		margin-top: 5px;
 		font-family: var(--font-body);
 		font-size: 10px;
-		letter-spacing: 0.08em;
-		color: rgba(148, 163, 184, 0.66);
+		letter-spacing: 0.1em;
+		color: rgba(148, 163, 184, 0.72);
 		text-transform: uppercase;
 	}
 
@@ -993,17 +1475,19 @@ onMount(() => {
 		z-index: 6;
 		display: flex;
 		flex-direction: column;
-		gap: 9px;
+		gap: 8px;
 		align-items: flex-start;
 		width: 276px;
 	}
 
 	.map-controls button,
-	.zoom-row,
-	.legend-list {
-		border: 0;
-		background: url("/constellation-assets/button.png") center / 100% 100% no-repeat;
-		background-color: transparent;
+	.zoom-row {
+		border: 1px solid rgba(96, 165, 250, 0.12);
+		background: rgba(4, 10, 28, 0.78);
+		backdrop-filter: blur(10px);
+		box-shadow:
+			0 1px 2px rgba(0, 0, 0, 0.25),
+			inset 0 1px 0 rgba(255, 255, 255, 0.04);
 	}
 
 	.map-controls button,
@@ -1012,25 +1496,28 @@ onMount(() => {
 		align-items: center;
 		justify-content: center;
 		gap: 8px;
-		height: 40px;
-		padding: 0 18px;
-		border-radius: 0;
+		height: 36px;
+		padding: 0 16px;
+		border-radius: 6px;
 		font-family: var(--font-body);
 		font-size: 11px;
-		color: rgba(241, 245, 249, 0.92);
+		color: rgba(241, 245, 249, 0.9);
 		cursor: pointer;
+		transition: border-color 120ms ease, color 120ms ease, box-shadow 120ms ease, background 120ms ease;
 	}
 
 	.map-controls button:hover,
 	.popover-actions button:hover {
-		border-color: rgba(96, 165, 250, 0.78);
+		border-color: rgba(96, 165, 250, 0.45);
 		color: rgba(255, 255, 255, 0.98);
+		background: rgba(15, 30, 72, 0.65);
+		box-shadow: 0 0 12px rgba(96, 165, 250, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.06);
 	}
 
 	.map-controls button {
-		width: 132px;
+		width: 124px;
 		justify-content: flex-start;
-		gap: 14px;
+		gap: 12px;
 		letter-spacing: 0.01em;
 	}
 
@@ -1043,52 +1530,55 @@ onMount(() => {
 
 	kbd {
 		margin-left: auto;
-		min-width: 24px;
-		padding: 2px 6px;
-		border-radius: 5px;
-		border: 1px solid rgba(71, 85, 105, 0.72);
+		min-width: 22px;
+		padding: 2px 5px;
+		border-radius: 4px;
+		border: 1px solid rgba(71, 85, 105, 0.5);
+		background: rgba(2, 6, 23, 0.5);
 		font-family: var(--font-mono);
 		font-size: 9px;
 		line-height: 1.4;
 		text-align: center;
-		color: rgba(148, 163, 184, 0.82);
+		color: rgba(148, 163, 184, 0.7);
 	}
 
 	.zoom-row {
 		display: flex;
 		align-items: center;
-		gap: 7px;
-		width: 158px;
-		height: 42px;
-		padding: 0 10px 0 18px;
+		gap: 6px;
+		width: 148px;
+		height: 38px;
+		padding: 0 10px 0 14px;
+		border-radius: 6px;
 		font-family: var(--font-body);
 		font-size: 11px;
-		color: rgba(241, 245, 249, 0.9);
+		color: rgba(241, 245, 249, 0.88);
 	}
 
 	.zoom-row > span {
-		width: 48px;
+		width: 44px;
 		text-align: left;
 	}
 
 	.zoom-row button {
-		min-width: 30px;
-		width: 30px;
-		height: 30px;
+		min-width: 28px;
+		width: 28px;
+		height: 28px;
 		justify-content: center;
 		padding: 0;
 		font-size: 12px;
+		border-radius: 5px;
 	}
 
 	.legend-shell {
 		display: flex;
 		flex-direction: column;
-		gap: 8px;
+		gap: 6px;
 		width: 100%;
 	}
 
 	.legend-toggle {
-		width: 250px !important;
+		width: 234px !important;
 		justify-content: flex-start;
 	}
 
@@ -1096,6 +1586,7 @@ onMount(() => {
 		display: inline-flex;
 		width: 10px;
 		transition: transform 120ms ease;
+		color: rgba(96, 165, 250, 0.7);
 	}
 
 	.legend-toggle-open .legend-chevron {
@@ -1105,51 +1596,61 @@ onMount(() => {
 	.legend-list {
 		display: flex;
 		flex-direction: column;
-		gap: 12px;
-		width: 250px;
-		min-height: 248px;
-		padding: 26px 30px 24px 34px;
+		gap: 14px;
+		width: 234px;
+		min-height: 220px;
+		padding: 22px 24px 20px;
 		box-sizing: border-box;
-		border: 0;
-		background: url("/constellation-assets/large-card.png") center / 100% 100% no-repeat;
-		background-color: transparent;
+		border: 1px solid rgba(96, 165, 250, 0.1);
+		border-radius: 10px;
+		background: rgba(4, 10, 28, 0.82);
+		backdrop-filter: blur(12px);
+		box-shadow:
+			0 4px 24px rgba(0, 0, 0, 0.35),
+			inset 0 1px 0 rgba(255, 255, 255, 0.04);
 	}
 
 	.legend-section {
 		display: flex;
 		flex-direction: column;
-		gap: 6px;
+		gap: 8px;
 		min-width: 0;
 	}
 
 	.legend-heading {
 		font-family: var(--font-mono);
-		font-size: 7px;
-		letter-spacing: 0.18em;
+		font-size: 8px;
+		letter-spacing: 0.2em;
 		line-height: 1.4;
-		color: rgba(125, 211, 252, 0.82);
+		color: rgba(125, 211, 252, 0.7);
 		text-transform: uppercase;
 	}
 
 	.legend-grid {
 		display: grid;
 		grid-template-columns: repeat(2, minmax(0, 1fr));
-		column-gap: 12px;
-		row-gap: 2px;
+		column-gap: 10px;
+		row-gap: 4px;
 	}
 
 	.legend-item {
 		display: grid;
-		grid-template-columns: 14px minmax(0, 1fr);
+		grid-template-columns: 12px minmax(0, 1fr);
 		align-items: center;
 		gap: 8px;
-		min-height: 20px;
-		padding: 0 4px;
+		min-height: 22px;
+		padding: 2px 6px;
+		border-radius: 4px;
 		font-family: var(--font-body);
-		font-size: 7px;
-		letter-spacing: 0.14em;
-		color: rgba(203, 213, 225, 0.82);
+		font-size: 8px;
+		letter-spacing: 0.12em;
+		color: rgba(203, 213, 225, 0.78);
 		text-transform: uppercase;
+		transition: background 100ms ease;
+	}
+
+	.legend-item:hover {
+		background: rgba(96, 165, 250, 0.06);
 	}
 
 	.legend-item span:last-child {
@@ -1161,27 +1662,28 @@ onMount(() => {
 
 	.legend-empty {
 		grid-column: 1 / -1;
-		min-height: 20px;
-		padding: 0 4px;
+		min-height: 22px;
+		padding: 2px 6px;
 		font-family: var(--font-body);
-		font-size: 7px;
-		letter-spacing: 0.14em;
-		color: rgba(148, 163, 184, 0.62);
+		font-size: 8px;
+		letter-spacing: 0.12em;
+		color: rgba(148, 163, 184, 0.5);
 		text-transform: uppercase;
 	}
 
 	.legend-structure .legend-item + .legend-item {
-		border-top: 1px solid rgba(96, 165, 250, 0.1);
+		border-top: 1px solid rgba(96, 165, 250, 0.06);
 	}
 
 	.legend-dot {
 		flex: 0 0 auto;
 		justify-self: center;
-		width: 7px;
-		height: 7px;
+		width: 6px;
+		height: 6px;
 		border-radius: 2px;
 		transform: rotate(45deg);
-		border: 1px solid rgba(226, 232, 240, 0.46);
+		border: 1px solid rgba(226, 232, 240, 0.35);
+		box-shadow: 0 0 4px rgba(226, 232, 240, 0.15);
 	}
 
 	.node-popover {
@@ -1189,58 +1691,265 @@ onMount(() => {
 		z-index: 8;
 		display: flex;
 		flex-direction: column;
-		max-height: min(350px, calc(100% - 32px));
-		padding: 28px 38px 26px;
-		border: 0;
-		background: url("/constellation-assets/large-card.png") center / 100% 100% no-repeat;
-		background-color: transparent;
-		overflow: auto;
+		padding: 24px 28px 20px;
+		border: 1px solid rgba(96, 165, 250, 0.1);
+		border-radius: 12px;
+		background: rgba(4, 10, 28, 0.88);
+		backdrop-filter: blur(16px);
+		box-shadow:
+			0 8px 32px rgba(0, 0, 0, 0.4),
+			0 0 0 1px rgba(96, 165, 250, 0.04),
+			inset 0 1px 0 rgba(255, 255, 255, 0.04);
+		overflow: hidden;
 		color: rgba(241, 245, 249, 0.94);
 		pointer-events: auto;
 	}
 
+	.node-popover::before {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		height: 1px;
+		content: "";
+		background: linear-gradient(90deg, transparent 5%, rgba(96, 165, 250, 0.25) 50%, transparent 95%);
+		pointer-events: none;
+	}
+
+	/* Subtle inner starfield pattern */
+	.node-popover::after {
+		position: absolute;
+		inset: 14px;
+		content: "";
+		background:
+			radial-gradient(circle at 20% 30%, rgba(96, 165, 250, 0.035) 0%, transparent 2px),
+			radial-gradient(circle at 70% 20%, rgba(96, 165, 250, 0.025) 0%, transparent 1.5px),
+			radial-gradient(circle at 40% 70%, rgba(96, 165, 250, 0.03) 0%, transparent 2px),
+			radial-gradient(circle at 85% 60%, rgba(96, 165, 250, 0.02) 0%, transparent 1.5px),
+			radial-gradient(circle at 10% 80%, rgba(96, 165, 250, 0.025) 0%, transparent 2px);
+		pointer-events: none;
+		z-index: 0;
+	}
+
+	.node-popover > * {
+		position: relative;
+		z-index: 1;
+	}
+
 	.node-popover.selected {
-		background: url("/constellation-assets/large-card.png") center / 100% 100% no-repeat;
+		border-color: rgba(96, 165, 250, 0.18);
+		background: rgba(5, 14, 40, 0.92);
+		box-shadow:
+			0 8px 32px rgba(0, 0, 0, 0.45),
+			0 0 0 1px rgba(96, 165, 250, 0.06),
+			0 0 24px rgba(96, 165, 250, 0.06),
+			inset 0 1px 0 rgba(255, 255, 255, 0.05);
+	}
+
+	.node-popover-content {
+		min-height: 0;
+		padding-right: 4px;
+		overflow-y: auto;
+		overscroll-behavior: contain;
+		scrollbar-width: thin;
+		scrollbar-color: rgba(96, 165, 250, 0.38) transparent;
 	}
 
 	.node-card-kind {
 		font-family: var(--font-mono);
 		font-size: 9px;
-		letter-spacing: 0.16em;
+		letter-spacing: 0.18em;
 		text-transform: uppercase;
-		color: rgba(96, 165, 250, 0.96);
+		color: rgba(96, 165, 250, 0.85);
 	}
 
 	.node-card-title {
-		margin-top: 10px;
+		margin-top: 8px;
 		font-family: var(--font-heading);
-		font-size: 22px;
-		line-height: 1.05;
-		letter-spacing: 0.02em;
+		font-size: 20px;
+		line-height: 1.1;
+		letter-spacing: 0.01em;
+		color: rgba(241, 245, 249, 0.96);
+		text-shadow: 0 0 14px rgba(96, 165, 250, 0.12);
+	}
+
+	.attribute-popover .node-card-title {
+		font-family: var(--font-body);
+		font-size: 13px;
+		line-height: 1.48;
+		letter-spacing: 0;
+		overflow-wrap: anywhere;
+		word-break: normal;
+		color: rgba(226, 232, 240, 0.92);
+	}
+
+	.entity-navigator-popover {
+		height: auto;
+		padding: 16px 20px 12px;
+	}
+
+	/* Hide starfield pattern in navigator - too much visual noise when empty */
+	.entity-navigator-popover::after {
+		display: none;
+	}
+
+	.entity-navigator-popover .node-popover-content {
+		padding-right: 4px;
+		min-height: 0;
+	}
+
+	.entity-navigator-title {
+		margin-top: 4px;
+		font-size: 17px;
+		line-height: 1;
+	}
+
+	.entity-navigator-subtitle {
+		margin-top: 3px;
+		font-family: var(--font-mono);
+		font-size: 8px;
+		letter-spacing: 0.1em;
+		color: rgba(148, 163, 184, 0.6);
+		text-transform: uppercase;
+	}
+
+	.entity-search-label {
+		display: block;
+		margin-top: 10px;
+		font-family: var(--font-mono);
+		font-size: 8px;
+		letter-spacing: 0.14em;
+		color: rgba(125, 211, 252, 0.6);
+		text-transform: uppercase;
+	}
+
+	.entity-search-input {
+		box-sizing: border-box;
+		width: 100%;
+		height: 34px;
+		margin-top: 4px;
+		padding: 0 11px;
+		border: 1px solid rgba(96, 165, 250, 0.12);
+		border-radius: 6px;
+		outline: none;
+		background: rgba(2, 6, 23, 0.55);
+		font-family: var(--font-body);
+		font-size: 12px;
 		color: rgba(241, 245, 249, 0.94);
+		transition: border-color 150ms ease, box-shadow 150ms ease, background 150ms ease;
+	}
+
+	.entity-search-input:focus {
+		border-color: rgba(96, 165, 250, 0.45);
+		background: rgba(2, 6, 23, 0.7);
+		box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.08), 0 0 12px rgba(96, 165, 250, 0.08);
+	}
+
+	.entity-search-input::placeholder {
+		color: rgba(148, 163, 184, 0.4);
+	}
+
+	.entity-navigator-results {
+		display: grid;
+		gap: 3px;
+		margin-top: 8px;
+		max-height: 220px;
+		overflow-y: auto;
+		scrollbar-width: thin;
+		scrollbar-color: rgba(96, 165, 250, 0.3) transparent;
+	}
+
+	.entity-navigator-results button {
+		position: relative;
+		display: grid;
+		grid-template-columns: minmax(0, 1fr);
+		gap: 1px;
+		align-items: center;
+		justify-content: stretch;
+		width: 100%;
+		min-height: 36px;
+		padding: 4px 9px 5px;
+		border: 1px solid rgba(96, 165, 250, 0.06);
+		border-radius: 5px;
+		background: rgba(15, 23, 42, 0.22);
+		color: rgba(226, 232, 240, 0.85);
+		text-align: left;
+		cursor: pointer;
+		transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
+	}
+
+	.entity-navigator-results button:hover {
+		border-color: rgba(96, 165, 250, 0.25);
+		background: rgba(30, 58, 138, 0.15);
+		box-shadow: 0 0 10px rgba(96, 165, 250, 0.05);
+	}
+
+	.entity-navigator-results button span {
+		position: relative;
+		min-width: 0;
+		overflow: hidden;
+		font-family: var(--font-body);
+		font-size: 11px;
+		line-height: 1.25;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.entity-navigator-results button small {
+		position: relative;
+		min-width: 0;
+		overflow: hidden;
+		font-family: var(--font-mono);
+		font-size: 8px;
+		line-height: 1.2;
+		color: rgba(125, 211, 252, 0.55);
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.entity-navigator-empty {
+		min-height: 28px;
+		padding-top: 6px;
+		font-family: var(--font-body);
+		font-size: 9px;
+		letter-spacing: 0.1em;
+		color: rgba(148, 163, 184, 0.4);
+		text-transform: uppercase;
+		text-align: center;
+	}
+
+	.entity-navigator-empty::before {
+		display: block;
+		width: 14px;
+		height: 14px;
+		margin: 0 auto 4px;
+		content: "";
+		background: radial-gradient(circle, rgba(96, 165, 250, 0.15) 0%, transparent 70%);
+		border: 1px solid rgba(96, 165, 250, 0.08);
+		transform: rotate(45deg);
 	}
 
 	.node-card-preview {
 		margin-top: 8px;
 		max-height: 54px;
-		overflow: auto;
+		overflow: hidden;
 		font-family: var(--font-body);
 		font-size: 11px;
 		line-height: 1.45;
-		color: rgba(203, 213, 225, 0.82);
+		color: rgba(203, 213, 225, 0.78);
 	}
 
 	.node-detail-list {
 		display: grid;
-		gap: 8px;
-		margin-top: 12px;
+		gap: 6px;
+		margin-top: 10px;
 		padding-top: 10px;
-		overflow: auto;
+		border-top: 1px solid rgba(96, 165, 250, 0.08);
 	}
 
 	.node-detail-row {
 		display: grid;
-		grid-template-columns: 92px minmax(0, 1fr);
+		grid-template-columns: 88px minmax(0, 1fr);
 		gap: 10px;
 		align-items: baseline;
 		font-family: var(--font-body);
@@ -1254,7 +1963,7 @@ onMount(() => {
 		font-size: 8px;
 		letter-spacing: 0.08em;
 		text-transform: uppercase;
-		color: rgba(125, 211, 252, 0.78);
+		color: rgba(125, 211, 252, 0.65);
 	}
 
 	.node-detail-row strong {
@@ -1262,23 +1971,41 @@ onMount(() => {
 		max-height: 48px;
 		overflow: hidden;
 		font-weight: 500;
-		color: rgba(226, 232, 240, 0.9);
+		color: rgba(226, 232, 240, 0.88);
 	}
 
 	.popover-actions {
 		display: flex;
 		flex-wrap: wrap;
-		gap: 8px;
-		margin-top: 12px;
+		gap: 6px;
+		margin-top: 10px;
 	}
 
 	.popover-actions button {
 		min-width: 0;
-		height: 34px;
+		height: 32px;
 		max-width: 100%;
-		border: 0;
-		background: url("/constellation-assets/button.png") center / 100% 100% no-repeat;
-		background-color: transparent;
+		padding: 0 14px;
+		border: 1px solid rgba(96, 165, 250, 0.15);
+		border-radius: 6px;
+		background: rgba(15, 23, 42, 0.5);
+		transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
+	}
+
+	.popover-actions button:hover {
+		border-color: rgba(96, 165, 250, 0.4);
+		background: rgba(30, 58, 138, 0.2);
+		box-shadow: 0 0 10px rgba(96, 165, 250, 0.08);
+	}
+
+	.popover-more {
+		display: inline-flex;
+		align-items: center;
+		height: 28px;
+		padding: 0 10px;
+		font-family: var(--font-mono);
+		font-size: 9px;
+		color: rgba(148, 163, 184, 0.7);
 	}
 
 	.popover-actions button strong {
@@ -1288,7 +2015,7 @@ onMount(() => {
 		font-weight: 500;
 		text-overflow: ellipsis;
 		white-space: nowrap;
-		color: rgba(226, 232, 240, 0.9);
+		color: rgba(226, 232, 240, 0.88);
 	}
 
 	.node-card-footer {
@@ -1296,15 +2023,222 @@ onMount(() => {
 		justify-content: space-between;
 		gap: 14px;
 		margin-top: auto;
-		padding-top: 10px;
+		padding-top: 8px;
+		border-top: 1px solid rgba(96, 165, 250, 0.06);
 		font-family: var(--font-mono);
 		font-size: 9px;
-		color: rgba(148, 163, 184, 0.78);
+		color: rgba(148, 163, 184, 0.65);
+	}
+
+	.entity-navigator-popover .node-card-footer {
+		margin-top: 10px;
+		padding-top: 6px;
 	}
 
 	.node-card-footer code {
 		font-family: var(--font-mono);
-		color: rgba(148, 163, 184, 0.86);
+		color: rgba(148, 163, 184, 0.75);
+	}
+
+	/* === Light mode overrides === */
+	:global([data-theme="light"]) .knowledge-map-zone {
+		background: #f0f1f5;
+	}
+
+	:global([data-theme="light"]) .knowledge-map-zone::before {
+		opacity: 0.08;
+		filter: invert(1);
+	}
+
+	:global([data-theme="light"]) .knowledge-map-zone::after {
+		background:
+			linear-gradient(90deg, rgba(240, 241, 245, 0.85), rgba(240, 241, 245, 0.35) 28%, rgba(240, 241, 245, 0.35) 68%, rgba(240, 241, 245, 0.82)),
+			linear-gradient(180deg, rgba(240, 241, 245, 0.7), rgba(240, 241, 245, 0.4) 40%, rgba(240, 241, 245, 0.78)),
+			radial-gradient(ellipse at 50% 50%, rgba(10, 57, 255, 0.04) 0%, rgba(240, 241, 245, 0) 70%);
+	}
+
+	:global([data-theme="light"]) .map-title {
+		color: rgba(36, 41, 54, 0.95);
+		text-shadow: none;
+	}
+
+	:global([data-theme="light"]) .map-subtitle {
+		color: rgba(94, 102, 117, 0.72);
+	}
+
+	:global([data-theme="light"]) .map-controls button,
+	:global([data-theme="light"]) .zoom-row {
+		border-color: rgba(10, 57, 255, 0.14);
+		background: rgba(252, 252, 250, 0.88);
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.5);
+		color: rgba(36, 41, 54, 0.9);
+	}
+
+	:global([data-theme="light"]) .map-controls button:hover {
+		border-color: rgba(10, 57, 255, 0.4);
+		background: rgba(255, 255, 255, 0.95);
+		box-shadow: 0 0 12px rgba(10, 57, 255, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.6);
+		color: rgba(11, 14, 23, 0.98);
+	}
+
+	:global([data-theme="light"]) kbd {
+		border-color: rgba(10, 57, 255, 0.2);
+		background: rgba(237, 238, 240, 0.7);
+		color: rgba(94, 102, 117, 0.7);
+	}
+
+	:global([data-theme="light"]) .legend-list {
+		border-color: rgba(10, 57, 255, 0.12);
+		background: rgba(252, 252, 250, 0.9);
+		box-shadow: 0 4px 24px rgba(0, 0, 0, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.5);
+	}
+
+	:global([data-theme="light"]) .legend-heading {
+		color: rgba(10, 57, 255, 0.7);
+	}
+
+	:global([data-theme="light"]) .legend-item {
+		color: rgba(36, 41, 54, 0.78);
+	}
+
+	:global([data-theme="light"]) .legend-item:hover {
+		background: rgba(10, 57, 255, 0.04);
+	}
+
+	:global([data-theme="light"]) .legend-empty {
+		color: rgba(94, 102, 117, 0.55);
+	}
+
+	:global([data-theme="light"]) .legend-dot {
+		border-color: rgba(36, 41, 54, 0.3);
+		box-shadow: 0 0 4px rgba(36, 41, 54, 0.1);
+	}
+
+	:global([data-theme="light"]) .node-popover {
+		border-color: rgba(10, 57, 255, 0.12);
+		background: rgba(252, 252, 250, 0.94);
+		box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(10, 57, 255, 0.04), inset 0 1px 0 rgba(255, 255, 255, 0.6);
+	}
+
+	:global([data-theme="light"]) .node-popover::before {
+		background: linear-gradient(90deg, transparent 5%, rgba(10, 57, 255, 0.2) 50%, transparent 95%);
+	}
+
+	:global([data-theme="light"]) .node-popover.selected {
+		border-color: rgba(10, 57, 255, 0.2);
+		background: rgba(255, 255, 255, 0.96);
+		box-shadow: 0 8px 32px rgba(0, 0, 0, 0.14), 0 0 0 1px rgba(10, 57, 255, 0.06), 0 0 24px rgba(10, 57, 255, 0.06), inset 0 1px 0 rgba(255, 255, 255, 0.7);
+	}
+
+	:global([data-theme="light"]) .node-card-kind {
+		color: rgba(10, 57, 255, 0.8);
+	}
+
+	:global([data-theme="light"]) .node-card-title {
+		color: rgba(11, 14, 23, 0.96);
+		text-shadow: none;
+	}
+
+	:global([data-theme="light"]) .attribute-popover .node-card-title {
+		color: rgba(36, 41, 54, 0.92);
+	}
+
+	:global([data-theme="light"]) .node-card-preview {
+		color: rgba(94, 102, 117, 0.82);
+	}
+
+	:global([data-theme="light"]) .entity-navigator-subtitle {
+		color: rgba(94, 102, 117, 0.6);
+	}
+
+	:global([data-theme="light"]) .entity-search-label {
+		color: rgba(10, 57, 255, 0.65);
+	}
+
+	:global([data-theme="light"]) .entity-search-input {
+		border-color: rgba(10, 57, 255, 0.14);
+		background: rgba(255, 255, 255, 0.7);
+		color: rgba(11, 14, 23, 0.94);
+	}
+
+	:global([data-theme="light"]) .entity-search-input:focus {
+		border-color: rgba(10, 57, 255, 0.45);
+		background: rgba(255, 255, 255, 0.9);
+		box-shadow: 0 0 0 3px rgba(10, 57, 255, 0.06), 0 0 12px rgba(10, 57, 255, 0.06);
+	}
+
+	:global([data-theme="light"]) .entity-search-input::placeholder {
+		color: rgba(94, 102, 117, 0.4);
+	}
+
+	:global([data-theme="light"]) .entity-navigator-results button {
+		border-color: rgba(10, 57, 255, 0.06);
+		background: rgba(237, 238, 240, 0.4);
+		color: rgba(36, 41, 54, 0.85);
+	}
+
+	:global([data-theme="light"]) .entity-navigator-results button:hover {
+		border-color: rgba(10, 57, 255, 0.2);
+		background: rgba(10, 57, 255, 0.04);
+		box-shadow: 0 0 10px rgba(10, 57, 255, 0.04);
+	}
+
+	:global([data-theme="light"]) .entity-navigator-results button small {
+		color: rgba(10, 57, 255, 0.6);
+	}
+
+	:global([data-theme="light"]) .entity-navigator-empty {
+		color: rgba(94, 102, 117, 0.4);
+	}
+
+	:global([data-theme="light"]) .entity-navigator-empty::before {
+		background: radial-gradient(circle, rgba(10, 57, 255, 0.18) 0%, transparent 70%);
+		border-color: rgba(10, 57, 255, 0.1);
+	}
+
+	:global([data-theme="light"]) .node-detail-list {
+		border-top-color: rgba(10, 57, 255, 0.08);
+	}
+
+	:global([data-theme="light"]) .node-detail-row span,
+	:global([data-theme="light"]) .popover-actions button span {
+		color: rgba(10, 57, 255, 0.65);
+	}
+
+	:global([data-theme="light"]) .node-detail-row strong {
+		color: rgba(36, 41, 54, 0.9);
+	}
+
+	:global([data-theme="light"]) .popover-actions button {
+		border-color: rgba(10, 57, 255, 0.15);
+		background: rgba(237, 238, 240, 0.6);
+	}
+
+	:global([data-theme="light"]) .popover-actions button:hover {
+		border-color: rgba(10, 57, 255, 0.35);
+		background: rgba(10, 57, 255, 0.06);
+		box-shadow: 0 0 10px rgba(10, 57, 255, 0.06);
+	}
+
+	:global([data-theme="light"]) .popover-actions button strong {
+		color: rgba(36, 41, 54, 0.88);
+	}
+
+	:global([data-theme="light"]) .popover-more {
+		color: rgba(94, 102, 117, 0.7);
+	}
+
+	:global([data-theme="light"]) .node-card-footer {
+		border-top-color: rgba(10, 57, 255, 0.06);
+		color: rgba(94, 102, 117, 0.65);
+	}
+
+	:global([data-theme="light"]) .node-card-footer code {
+		color: rgba(94, 102, 117, 0.75);
+	}
+
+	:global([data-theme="light"]) .legend-chevron {
+		color: rgba(10, 57, 255, 0.7);
 	}
 
 	@media (max-width: 700px) {

--- a/surfaces/dashboard/src/lib/components/ontology/canvas/renderer.ts
+++ b/surfaces/dashboard/src/lib/components/ontology/canvas/renderer.ts
@@ -44,6 +44,7 @@ export function renderFrame(
 ): void {
 	ctx.clearRect(0, 0, width, height);
 	drawEdges(ctx, edges, viewport, width, height, state, nodeMap, colors);
+	drawSystemFields(ctx, nodes, viewport, width, height, state);
 	drawNodes(ctx, nodes, viewport, width, height, state, colors);
 }
 
@@ -77,17 +78,18 @@ function drawEdges(
 		const emphasized = isEdgeEmphasizedForState(edge, state);
 		if (!isEdgeVisibleAtLod(edge, viewport.zoom, emphasized)) continue;
 		const connected = !hasSelection || emphasized;
-			const prepared: PreparedEdge = {
-				...endpoints,
-				color: style.color,
-				alpha:
-					(connected ? Math.min(style.alpha * (emphasized ? 1.45 : 1), 0.9) : style.alpha * (1 - state.dimProgress * 0.92)) *
-					edgeLodAlpha(edge, viewport.zoom, emphasized),
-				width: style.width * edgeLodWidth(edge, viewport.zoom, emphasized) * (emphasized ? 1.2 : 1),
-				dashed: edge.dashed ?? false,
-				connected,
-				emphasized,
-			};
+		const prepared: PreparedEdge = {
+			...endpoints,
+			color: style.color,
+			alpha:
+				(connected
+					? Math.min(style.alpha * (emphasized ? 1.25 : 1), 0.85)
+					: style.alpha * (1 - state.dimProgress * 0.92)) * edgeLodAlpha(edge, viewport.zoom, emphasized),
+			width: style.width * edgeLodWidth(edge, viewport.zoom, emphasized) * (emphasized ? 1.1 : 1),
+			dashed: edge.dashed ?? false,
+			connected,
+			emphasized,
+		};
 		const key = `${prepared.color}|${prepared.alpha.toFixed(3)}|${prepared.width}|${prepared.dashed}`;
 		const bucket = edgeBatches.get(key) ?? [];
 		bucket.push(prepared);
@@ -112,9 +114,27 @@ export function isEdgeEmphasizedForState(edge: GraphCanvasEdge, state: GraphRend
 }
 
 function strokeEdgeBatch(ctx: CanvasRenderingContext2D, batch: PreparedEdge[], style: PreparedEdge): void {
+	const hasGlow = batch.some((e) => e.emphasized);
+	if (hasGlow) {
+		ctx.save();
+		ctx.globalAlpha = style.alpha * 0.18;
+		ctx.strokeStyle = style.color;
+		ctx.lineWidth = style.width * 2.5;
+		ctx.lineCap = "round";
+		ctx.setLineDash(style.dashed ? [7, 7] : []);
+		ctx.beginPath();
+		for (const edge of batch) {
+			if (!edge.emphasized) continue;
+			ctx.moveTo(edge.startX, edge.startY);
+			ctx.lineTo(edge.endX, edge.endY);
+		}
+		ctx.stroke();
+		ctx.restore();
+	}
 	ctx.globalAlpha = style.alpha;
 	ctx.strokeStyle = style.color;
 	ctx.lineWidth = style.width;
+	ctx.lineCap = "round";
 	ctx.setLineDash(style.dashed ? [7, 7] : []);
 	ctx.beginPath();
 	for (const edge of batch) {
@@ -156,7 +176,8 @@ function drawNodes(
 	for (const node of nodes) {
 		const screen = viewport.worldToScreen(node.x, node.y);
 		const size = node.size * viewport.zoom;
-		const cullSize = Math.max(size, 3);
+		const visualSize = size * (node.iconScale ?? 1);
+		const cullSize = Math.max(visualSize, 3);
 		if (
 			screen.x + cullSize < -margin ||
 			screen.x - cullSize > width + margin ||
@@ -170,22 +191,51 @@ function drawNodes(
 		const matched = state.searchMatchIds?.has(node.id) ?? false;
 		if (!isNodeVisibleAtLod(node, viewport.zoom, selected || hovered || related || matched)) continue;
 		const dimmed = state.selectedId !== null && !selected && !related;
-		const tone: NodeTone = selected || hovered || matched ? "selected" : related ? "related" : dimmed ? "dim" : "normal";
+		const tone: NodeTone =
+			selected || hovered || matched ? "selected" : related ? "related" : dimmed ? "dim" : "normal";
+		const dimFloor = node.kind === "attribute" || node.kind === "aspect" ? 0.34 : 0.12;
 		const alpha =
-			(tone === "dim" ? Math.max(0.08, 1 - state.dimProgress * 0.9) : tone === "related" ? 0.96 : 1) *
+			(tone === "dim" ? Math.max(dimFloor, 1 - state.dimProgress * 0.88) : tone === "related" ? 1 : 1) *
 			nodeLodAlpha(node, viewport.zoom, selected || hovered || related || matched);
 		ctx.save();
 		ctx.globalAlpha = alpha;
-		if (size < 6 && !selected && !hovered) {
-			drawTinyNode(ctx, screen.x, screen.y, Math.max(2.2, size * 0.45), tone === "dim" ? node.dimColor : node.color, node.kind, tone);
+		if (visualSize < 6 && !selected && !hovered) {
+			drawTinyNode(
+				ctx,
+				screen.x,
+				screen.y,
+				Math.max(2.2, visualSize * 0.45),
+				tone === "dim" ? node.dimColor : node.color,
+				node.kind,
+				tone,
+			);
 			ctx.restore();
 			continue;
 		}
+
+		// Subtle ambient glow for visible entity nodes at all sizes
+		if (node.kind === "entity" && !dimmed && !selected && !related) {
+			const ambientGlow = ctx.createRadialGradient(
+				screen.x,
+				screen.y,
+				visualSize * 0.6,
+				screen.x,
+				screen.y,
+				visualSize * 2.2,
+			);
+			ambientGlow.addColorStop(0, `${node.color}20`);
+			ambientGlow.addColorStop(1, "rgba(0,0,0,0)");
+			ctx.fillStyle = ambientGlow;
+			ctx.beginPath();
+			ctx.arc(screen.x, screen.y, visualSize * 2.2, 0, Math.PI * 2);
+			ctx.fill();
+		}
+
 		drawNodeShape(
 			ctx,
 			screen.x,
 			screen.y,
-			size,
+			visualSize,
 			selected ? colors.selection : dimmed ? node.dimColor : node.color,
 			selected || related ? colors.selection : node.color,
 			node.shape ?? "circle",
@@ -193,18 +243,116 @@ function drawNodes(
 			node.sprite,
 			tone,
 		);
-		if (shouldDrawLabel(node, viewport.zoom, selected, hovered, related || matched, size))
+		const suppressDimAttributeLabel = dimmed && node.kind === "attribute" && !hovered && !matched;
+		if (!suppressDimAttributeLabel && shouldDrawLabel(node, viewport.zoom, selected, hovered, related || matched, size))
 			drawLabel(
 				ctx,
 				node.label,
 				screen.x,
-				screen.y + size * 0.5 + 4,
+				screen.y + visualSize * 0.5 + 4,
 				selected ? colors.selection : related || matched ? node.color : dimmed ? colors.textDim : colors.text,
 				colors.labelShadow,
 				node.kind === "memory" ? 8 : 10,
 				viewport.zoom,
 			);
 		ctx.restore();
+	}
+}
+
+function drawSystemFields(
+	ctx: CanvasRenderingContext2D,
+	nodes: GraphCanvasNode[],
+	viewport: ViewportState,
+	width: number,
+	height: number,
+	state: GraphRenderState,
+): void {
+	if (state.selectedId !== null) return;
+	const margin = 180;
+	ctx.save();
+	for (const node of nodes) {
+		if (node.kind !== "entity") continue;
+		const aspects = Math.max(0, Math.floor(node.counts?.aspects ?? 0));
+		const attributes = Math.max(0, Math.floor(node.counts?.attributes ?? 0));
+		if (aspects === 0 && attributes === 0) continue;
+		const screen = viewport.worldToScreen(node.x, node.y);
+		const radius = Math.max(28, Math.min(92, ((node.systemRadius ?? node.size * 5) * viewport.zoom) / 4));
+		if (
+			screen.x + radius < -margin ||
+			screen.x - radius > width + margin ||
+			screen.y + radius < -margin ||
+			screen.y - radius > height + margin
+		)
+			continue;
+		drawEntitySystemField(ctx, screen.x, screen.y, radius, aspects, attributes, node.color, viewport.zoom);
+	}
+	ctx.restore();
+}
+
+function drawEntitySystemField(
+	ctx: CanvasRenderingContext2D,
+	x: number,
+	y: number,
+	radius: number,
+	aspects: number,
+	attributes: number,
+	color: string,
+	zoom: number,
+): void {
+	const ringCount = Math.min(3, Math.max(1, Math.ceil(aspects / 5)));
+	const density = Math.min(1, Math.sqrt(attributes) / 13);
+
+	// Stronger, more luminous glow
+	const glow = ctx.createRadialGradient(x, y, radius * 0.22, x, y, radius * 1.3);
+	glow.addColorStop(0, `rgba(96, 165, 250, ${0.04 + density * 0.04})`);
+	glow.addColorStop(0.5, `rgba(96, 165, 250, ${0.03 + density * 0.06})`);
+	glow.addColorStop(1, "rgba(96, 165, 250, 0)");
+	ctx.fillStyle = glow;
+	ctx.beginPath();
+	ctx.arc(x, y, radius * 1.3, 0, Math.PI * 2);
+	ctx.fill();
+
+	// Elegant orbital rings with soft glow
+	ctx.strokeStyle = "rgba(96, 165, 250, 0.18)";
+	ctx.lineWidth = Math.max(0.8, zoom * 1.2);
+	ctx.setLineDash([Math.max(3, radius * 0.04), Math.max(8, radius * 0.12)]);
+	for (let i = 0; i < ringCount; i++) {
+		ctx.beginPath();
+		ctx.arc(x, y, radius * (0.56 + i * 0.26), 0, Math.PI * 2);
+		ctx.stroke();
+	}
+	ctx.setLineDash([]);
+
+	// Orbital ticks (satellites) - slightly larger and more luminous
+	const tickCount = Math.min(18, Math.max(3, aspects));
+	for (let i = 0; i < tickCount; i++) {
+		const angle = -Math.PI / 2 + (Math.PI * 2 * i) / tickCount;
+		const orbit = radius * (0.68 + (i % ringCount) * 0.24);
+		const tx = x + Math.cos(angle) * orbit;
+		const ty = y + Math.sin(angle) * orbit;
+		ctx.save();
+		ctx.translate(tx, ty);
+		ctx.rotate(angle + Math.PI / 4);
+		ctx.fillStyle = i < aspects ? color : "rgba(96, 165, 250, 0.32)";
+		ctx.globalAlpha = i < aspects ? 0.65 : 0.28;
+		const size = Math.max(2.6, Math.min(6, radius * 0.05));
+		ctx.fillRect(-size / 2, -size / 2, size, size);
+		// Small inner highlight for active ticks
+		if (i < aspects) {
+			ctx.globalAlpha = 0.4;
+			ctx.fillStyle = "rgba(255, 255, 255, 0.7)";
+			ctx.fillRect(-size * 0.25, -size * 0.25, size * 0.5, size * 0.5);
+		}
+		ctx.restore();
+	}
+
+	// Attribute density arc
+	if (attributes > 0) {
+		ctx.strokeStyle = `rgba(167, 139, 250, ${0.08 + density * 0.18})`;
+		ctx.lineWidth = Math.max(1.2, zoom * 1.5);
+		ctx.beginPath();
+		ctx.arc(x, y, radius * 1.04, -Math.PI / 2, -Math.PI / 2 + Math.PI * 2 * density);
+		ctx.stroke();
 	}
 }
 
@@ -226,26 +374,26 @@ export function isEdgeVisibleAtLod(edge: GraphCanvasEdge, zoom: number, emphasiz
 export function nodeLodAlpha(node: GraphCanvasNode, zoom: number, emphasized = false): number {
 	if (emphasized || zoom >= 0.34) return 1;
 	if (node.kind === "entity") return 1;
-	if (node.kind === "aspect") return 0.82;
-	if (node.kind === "attribute") return 0.62;
-	if (node.kind === "memory") return 0.48;
-	return 0.62;
+	if (node.kind === "aspect") return 0.88;
+	if (node.kind === "attribute") return 0.68;
+	if (node.kind === "memory") return 0.55;
+	return 0.68;
 }
 
 export function edgeLodAlpha(edge: GraphCanvasEdge, zoom: number, emphasized = false): number {
 	if (emphasized || zoom >= 0.34) return 1;
-	if (edge.kind === "about") return 0.42;
-	if (edge.kind === "has_aspect") return 0.76;
-	if (edge.kind === "has_attribute") return 0.58;
-	if (edge.kind === "supports") return 0.44;
-	return 0.5;
+	if (edge.kind === "about") return 0.52;
+	if (edge.kind === "has_aspect") return 0.82;
+	if (edge.kind === "has_attribute") return 0.65;
+	if (edge.kind === "supports") return 0.55;
+	return 0.6;
 }
 
 function edgeLodWidth(edge: GraphCanvasEdge, zoom: number, emphasized = false): number {
 	if (emphasized || zoom >= 0.34) return 1;
-	if (edge.kind === "about") return 0.82;
-	if (edge.kind === "supports") return 0.78;
-	return 0.86;
+	if (edge.kind === "about") return 0.9;
+	if (edge.kind === "supports") return 0.88;
+	return 0.92;
 }
 
 function drawTinyNode(
@@ -259,8 +407,23 @@ function drawTinyNode(
 ): void {
 	ctx.save();
 	ctx.translate(x, y);
+
+	// Soft outer bloom for all tiny nodes
+	if (tone !== "dim") {
+		const bloom = ctx.createRadialGradient(0, 0, radius * 0.5, 0, 0, radius * 2.8);
+		bloom.addColorStop(0, color);
+		bloom.addColorStop(1, "rgba(0,0,0,0)");
+		ctx.fillStyle = bloom;
+		ctx.globalAlpha = tone === "selected" ? 0.45 : tone === "related" ? 0.32 : 0.18;
+		ctx.beginPath();
+		ctx.arc(0, 0, radius * 2.8, 0, Math.PI * 2);
+		ctx.fill();
+	}
+
+	ctx.globalAlpha = tone === "dim" ? 0.55 : 1;
 	ctx.fillStyle = color;
-	ctx.strokeStyle = color;
+	ctx.strokeStyle =
+		tone === "selected" ? "rgba(241, 245, 249, 0.96)" : tone === "related" ? "rgba(180, 230, 255, 0.9)" : color;
 	ctx.lineWidth = tone === "selected" ? 1.6 : tone === "related" ? 1.2 : 0.8;
 	ctx.beginPath();
 	if (kind === "attribute" || kind === "memory") {
@@ -366,8 +529,24 @@ function drawHexGem(
 	const selected = tone === "selected";
 	const related = tone === "related";
 	ctx.save();
+
+	// Outer glow bloom
+	if (selected || related) {
+		const glow = ctx.createRadialGradient(x, y, radius * 0.8, x, y, radius * 2.4);
+		glow.addColorStop(0, selected ? "rgba(255, 255, 255, 0.35)" : "rgba(125, 211, 252, 0.22)");
+		glow.addColorStop(1, "rgba(0, 0, 0, 0)");
+		ctx.fillStyle = glow;
+		ctx.beginPath();
+		ctx.arc(x, y, radius * 2.4, 0, Math.PI * 2);
+		ctx.fill();
+	}
+
 	ctx.lineWidth = selected ? 1.9 : related ? 1.55 : 1.15;
-	ctx.strokeStyle = selected ? "rgba(241, 245, 249, 0.96)" : related ? "rgba(180, 214, 255, 0.88)" : "rgba(132, 166, 207, 0.68)";
+	ctx.strokeStyle = selected
+		? "rgba(241, 245, 249, 0.96)"
+		: related
+			? "rgba(180, 214, 255, 0.88)"
+			: "rgba(132, 166, 207, 0.68)";
 	ctx.fillStyle = tone === "dim" ? "rgba(4, 14, 31, 0.42)" : "rgba(4, 14, 31, 0.84)";
 	hexPath(ctx, x, y, radius * 1.12);
 	ctx.fill();
@@ -409,8 +588,24 @@ function drawSquareGem(
 	const selected = tone === "selected";
 	const related = tone === "related";
 	ctx.save();
+
+	// Outer glow bloom
+	if (selected || related) {
+		const glow = ctx.createRadialGradient(x, y, radius * 0.8, x, y, radius * 2.2);
+		glow.addColorStop(0, selected ? "rgba(255, 255, 255, 0.3)" : "rgba(125, 211, 252, 0.18)");
+		glow.addColorStop(1, "rgba(0, 0, 0, 0)");
+		ctx.fillStyle = glow;
+		ctx.beginPath();
+		ctx.arc(x, y, radius * 2.2, 0, Math.PI * 2);
+		ctx.fill();
+	}
+
 	ctx.fillStyle = tone === "dim" ? "rgba(5, 18, 40, 0.36)" : "rgba(5, 18, 40, 0.78)";
-	ctx.strokeStyle = selected ? "rgba(241, 245, 249, 0.96)" : related ? "rgba(191, 219, 254, 0.86)" : "rgba(137, 166, 204, 0.58)";
+	ctx.strokeStyle = selected
+		? "rgba(241, 245, 249, 0.96)"
+		: related
+			? "rgba(191, 219, 254, 0.86)"
+			: "rgba(137, 166, 204, 0.58)";
 	ctx.lineWidth = selected ? 1.7 : related ? 1.35 : 0.95;
 	ctx.beginPath();
 	ctx.rect(x - radius, y - radius, radius * 2, radius * 2);
@@ -443,11 +638,25 @@ function drawRoundGem(
 	stroke: string,
 	tone: NodeTone,
 ): void {
+	const selected = tone === "selected";
+	const related = tone === "related";
+	ctx.save();
+
+	// Outer glow bloom
+	if (selected || related) {
+		const glow = ctx.createRadialGradient(x, y, radius * 0.8, x, y, radius * 2.2);
+		glow.addColorStop(0, selected ? "rgba(255, 255, 255, 0.3)" : "rgba(125, 211, 252, 0.18)");
+		glow.addColorStop(1, "rgba(0, 0, 0, 0)");
+		ctx.fillStyle = glow;
+		ctx.beginPath();
+		ctx.arc(x, y, radius * 2.2, 0, Math.PI * 2);
+		ctx.fill();
+	}
+
 	const core = ctx.createRadialGradient(x - radius * 0.26, y - radius * 0.26, 1, x, y, radius);
 	core.addColorStop(0, tone === "selected" ? "rgba(255, 255, 255, 1)" : "rgba(240, 249, 255, 0.68)");
 	core.addColorStop(0.35, fill);
 	core.addColorStop(1, tone === "dim" ? "rgba(2, 6, 23, 0.88)" : "rgba(2, 6, 23, 0.76)");
-	ctx.save();
 	ctx.fillStyle = core;
 	ctx.strokeStyle = tone === "selected" ? "rgba(241, 245, 249, 0.94)" : stroke;
 	ctx.lineWidth = tone === "selected" ? 1.4 : tone === "related" ? 1.2 : 0.9;
@@ -530,15 +739,17 @@ function drawLabel(
 	ctx.font = `${size}px var(--font-mono), monospace`;
 	ctx.textAlign = "center";
 	ctx.textBaseline = "top";
-	const labelWidth = ctx.measureText(label).width + 12;
-	ctx.fillStyle = "rgba(2, 6, 23, 0.58)";
+	const labelWidth = ctx.measureText(label).width + 14;
+	// Softer, more integrated label background
+	ctx.fillStyle = "rgba(2, 6, 23, 0.62)";
 	ctx.fillRect(x - labelWidth / 2, y - 2, labelWidth, size + 6);
-	ctx.strokeStyle = "rgba(96, 165, 250, 0.24)";
-	ctx.lineWidth = 0.8;
+	ctx.strokeStyle = "rgba(96, 165, 250, 0.18)";
+	ctx.lineWidth = 0.7;
 	ctx.beginPath();
 	ctx.moveTo(x - labelWidth / 2, y - 2);
 	ctx.lineTo(x + labelWidth / 2, y - 2);
 	ctx.stroke();
+	// Subtle text shadow for depth
 	ctx.fillStyle = shadow;
 	ctx.fillText(label, x + 1, y + 1);
 	ctx.fillStyle = color;

--- a/surfaces/dashboard/src/lib/components/ontology/canvas/simulation.ts
+++ b/surfaces/dashboard/src/lib/components/ontology/canvas/simulation.ts
@@ -6,6 +6,8 @@ export interface ForceSimulationOptions {
 	linkDistance: number;
 	linkStrength: number;
 	collisionPadding: number;
+	solarPadding: number;
+	solarStrength: number;
 	preSettleTicks: number;
 	maxActiveTicks: number;
 	maxActiveMs: number;
@@ -16,6 +18,8 @@ const DEFAULT_OPTIONS: ForceSimulationOptions = {
 	linkDistance: 220,
 	linkStrength: 0.15,
 	collisionPadding: 18,
+	solarPadding: 120,
+	solarStrength: 0.34,
 	preSettleTicks: 150,
 	maxActiveTicks: 80,
 	maxActiveMs: 1000,
@@ -42,13 +46,19 @@ export class KnowledgeForceSimulation {
 					.distance((edge) => edgeDistance(edge, this.opts.linkDistance))
 					.strength((edge) => edgeStrength(edge, this.opts.linkStrength)),
 			)
-			.force("charge", forceManyBody<GraphCanvasNode>().strength((node) => this.opts.chargeStrength * chargeMultiplier(node)))
+			.force(
+				"charge",
+				forceManyBody<GraphCanvasNode>().strength((node) => this.opts.chargeStrength * chargeMultiplier(node)),
+			)
 			.force(
 				"collide",
-				forceCollide<GraphCanvasNode>((node) => node.size * collideMultiplier(node) + this.opts.collisionPadding).strength(0.74),
+				forceCollide<GraphCanvasNode>(
+					(node) => node.size * collideMultiplier(node) + this.opts.collisionPadding,
+				).strength(0.74),
 			)
-			.force("x", forceX<GraphCanvasNode>(0).strength(0.06))
-			.force("y", forceY<GraphCanvasNode>(0).strength(0.06))
+			.force("solar", forceSolarSystems().padding(this.opts.solarPadding).strength(this.opts.solarStrength))
+			.force("x", forceX<GraphCanvasNode>((node) => node.zoneX ?? 0).strength(zoneStrength))
+			.force("y", forceY<GraphCanvasNode>((node) => node.zoneY ?? 0).strength(zoneStrength))
 			.on("tick.signetBudget", () => this.enforceBudget());
 
 		this.sim.stop();
@@ -111,7 +121,7 @@ function edgeDistance(edge: GraphCanvasEdge, fallback: number): number {
 	const spread = Math.min(Math.max(endpointSize(edge.source), endpointSize(edge.target)) * 0.68 + mass * 190, 290);
 	if (edge.kind === "supports") return 64;
 	if (edge.kind === "has_attribute") return 115;
-	if (edge.kind === "has_aspect") return 165 + spread;
+	if (edge.kind === "has_aspect") return Math.max(230 + spread, endpointSystemRadius(edge.target) + 170);
 	if (edge.kind === "contains") return 170;
 	if (edge.kind === "about") return 260 + spread;
 	if (edge.kind === "updates" || edge.kind === "extends") return 78;
@@ -123,17 +133,21 @@ function endpointSize(value: string | GraphCanvasNode): number {
 }
 
 function endpointMass(value: string | GraphCanvasNode): number {
-	return typeof value === "string" ? 0 : value.mass ?? 0;
+	return typeof value === "string" ? 0 : (value.mass ?? 0);
+}
+
+function endpointSystemRadius(value: string | GraphCanvasNode): number {
+	return typeof value === "string" ? 0 : (value.systemRadius ?? value.size);
 }
 
 function chargeMultiplier(node: GraphCanvasNode): number {
-	if (node.kind === "entity") return 0.72 + Math.pow(node.mass ?? 0, 1.18) * 8.2;
+	if (node.kind === "entity") return 0.72 + (node.mass ?? 0) ** 1.18 * 8.2;
 	if (node.kind === "aspect") return Math.min(1.16, 0.78 + node.size / 160);
 	return 0.62;
 }
 
 function collideMultiplier(node: GraphCanvasNode): number {
-	if (node.kind === "entity") return 0.62 + Math.pow(node.mass ?? 0, 1.08) * 1.65;
+	if (node.kind === "entity") return 0.62 + (node.mass ?? 0) ** 1.08 * 1.65;
 	if (node.kind === "aspect") return 0.58;
 	return 0.5;
 }
@@ -148,6 +162,11 @@ function edgeStrength(edge: GraphCanvasEdge, fallback: number): number {
 	return fallback;
 }
 
+function zoneStrength(node: GraphCanvasNode): number {
+	if (node.kind === "entity" && node.zoneX !== undefined && node.zoneY !== undefined) return 0.085;
+	return 0.028;
+}
+
 function structuralLinks(edges: GraphCanvasEdge[]): GraphCanvasEdge[] {
 	return edges
 		.filter((edge) => !edge.visualOnly)
@@ -156,6 +175,69 @@ function structuralLinks(edges: GraphCanvasEdge[]): GraphCanvasEdge[] {
 			source: edge.sourceId,
 			target: edge.targetId,
 		}));
+}
+
+interface SolarSystemForce {
+	(alpha: number): void;
+	initialize(nodes: GraphCanvasNode[]): void;
+	padding(value: number): SolarSystemForce;
+	strength(value: number): SolarSystemForce;
+}
+
+function forceSolarSystems(): SolarSystemForce {
+	let nodes: GraphCanvasNode[] = [];
+	let padding = 120;
+	let strength = 0.34;
+
+	const force = ((alpha: number) => {
+		const entities = nodes.filter((node) => node.kind === "entity");
+		for (let i = 0; i < entities.length; i++) {
+			const a = entities[i];
+			if (!a) continue;
+			for (let j = i + 1; j < entities.length; j++) {
+				const b = entities[j];
+				if (!b) continue;
+				const min = solarRadius(a) + solarRadius(b) + padding;
+				let dx = (b.x ?? 0) - (a.x ?? 0);
+				let dy = (b.y ?? 0) - (a.y ?? 0);
+				let distance = Math.hypot(dx, dy);
+				if (distance >= min) continue;
+				if (distance < 0.001) {
+					const angle = ((i + 1) * 12.9898 + (j + 1) * 78.233) % (Math.PI * 2);
+					dx = Math.cos(angle);
+					dy = Math.sin(angle);
+					distance = 1;
+				}
+				const push = ((min - distance) / distance) * strength * alpha;
+				const aMass = 1 + (a.mass ?? 0) * 3;
+				const bMass = 1 + (b.mass ?? 0) * 3;
+				const total = aMass + bMass;
+				const aShare = bMass / total;
+				const bShare = aMass / total;
+				a.vx = (a.vx ?? 0) - dx * push * aShare;
+				a.vy = (a.vy ?? 0) - dy * push * aShare;
+				b.vx = (b.vx ?? 0) + dx * push * bShare;
+				b.vy = (b.vy ?? 0) + dy * push * bShare;
+			}
+		}
+	}) as SolarSystemForce;
+
+	force.initialize = (next: GraphCanvasNode[]) => {
+		nodes = next;
+	};
+	force.padding = (value: number) => {
+		padding = value;
+		return force;
+	};
+	force.strength = (value: number) => {
+		strength = value;
+		return force;
+	};
+	return force;
+}
+
+function solarRadius(node: GraphCanvasNode): number {
+	return Math.max(node.systemRadius ?? node.size, node.size * 2);
 }
 
 function now(): number {

--- a/surfaces/dashboard/src/lib/components/ontology/canvas/types.ts
+++ b/surfaces/dashboard/src/lib/components/ontology/canvas/types.ts
@@ -11,6 +11,8 @@ export interface GraphCanvasNode {
 	parentId?: string;
 	x: number;
 	y: number;
+	zoneX?: number;
+	zoneY?: number;
 	vx?: number;
 	vy?: number;
 	fx?: number | null;
@@ -19,6 +21,9 @@ export interface GraphCanvasNode {
 	anchorDy?: number;
 	size: number;
 	mass?: number;
+	systemRadius?: number;
+	iconScale?: number;
+	counts?: Record<string, number>;
 	color: string;
 	dimColor: string;
 	sprite?: string;

--- a/surfaces/dashboard/src/lib/components/ontology/knowledge-map-data.ts
+++ b/surfaces/dashboard/src/lib/components/ontology/knowledge-map-data.ts
@@ -1,4 +1,10 @@
-import type { ConstellationAspect, ConstellationAttribute, ConstellationEntity, ConstellationGraph } from "$lib/api";
+import type {
+	ConstellationAspect,
+	ConstellationAttribute,
+	ConstellationEntity,
+	ConstellationGraph,
+	ConstellationProposal,
+} from "$lib/api";
 
 export type KnowledgeMapNodeKind =
 	| "source"
@@ -60,8 +66,28 @@ export interface KnowledgeMapBuildOptions {
 
 const DEFAULT_LIMIT = 600;
 const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5));
-const PRIMARY_ENTITY_TYPES = new Set(["person", "project", "topic", "system", "product", "organization", "org"]);
-const NOISY_ENTITY_TYPES = new Set(["artifact", "benchmark", "run", "file", "chunk", "unknown"]);
+const PRIMARY_ENTITY_TYPES = new Set([
+	"person",
+	"project",
+	"topic",
+	"system",
+	"product",
+	"organization",
+	"org",
+	"source",
+	"artifact",
+	"agent",
+	"policy",
+	"action",
+	"workflow",
+	"event",
+	"object_type",
+	"interface",
+	"observation",
+	"claim_slot",
+	"claim_value",
+]);
+const NOISY_ENTITY_TYPES = new Set(["benchmark", "run", "file", "chunk", "unknown"]);
 
 export const KNOWLEDGE_NODE_COLORS: Record<KnowledgeMapNodeKind, string> = {
 	source: "#38bdf8",
@@ -110,6 +136,7 @@ export function buildKnowledgeMapFromConstellation(
 	const edges: KnowledgeMapEdge[] = [];
 	const includedEntityIds = new Set<string>();
 	const entityNodes = new Map<string, KnowledgeMapNode>();
+	const aspectNodesByEntityPath = new Map<string, KnowledgeMapNode>();
 	const aspectRecords: Array<{
 		readonly aspect: ConstellationAspect;
 		readonly node: KnowledgeMapNode;
@@ -135,11 +162,13 @@ export function buildKnowledgeMapFromConstellation(
 			if (nodes.length >= limit) break;
 			const entityNode = entityNodes.get(entity.id);
 			if (!entityNode) continue;
-			const aspect = entity.aspects.toSorted((a, b) => aspectScore(b) - aspectScore(a))[aspectIndex];
+			const aspects = entity.aspects.toSorted((a, b) => aspectScore(b) - aspectScore(a));
+			const aspect = aspects[aspectIndex];
 			if (!aspect) continue;
-			const aspectNode = toAspectNode(entityNode, aspect, aspectIndex);
+			const aspectNode = toAspectNode(entityNode, aspect, aspectIndex, aspects.length);
 			nodes.push(aspectNode);
 			aspectRecords.push({ aspect, node: aspectNode });
+			aspectNodesByEntityPath.set(`${entity.id}:${canonical(aspect.name)}`, aspectNode);
 			edges.push({
 				id: `has_aspect:${entity.id}:${aspectNode.id}`,
 				source: entity.id,
@@ -158,9 +187,10 @@ export function buildKnowledgeMapFromConstellation(
 	for (let attributeIndex = 0; attributeIndex < maxAttributeCount; attributeIndex++) {
 		for (const record of aspectRecords) {
 			if (nodes.length >= limit) break;
-			const attribute = sortedAttributes(record.aspect)[attributeIndex];
+			const attributes = sortedAttributes(record.aspect);
+			const attribute = attributes[attributeIndex];
 			if (!attribute) continue;
-			const attributeNode = toAttributeNode(record.node, attribute, attributeIndex);
+			const attributeNode = toAttributeNode(record.node, attribute, attributeIndex, attributes.length);
 			nodes.push(attributeNode);
 			attributeRecords.push({ attribute, node: attributeNode });
 			edges.push({
@@ -186,6 +216,46 @@ export function buildKnowledgeMapFromConstellation(
 			kind: "supports",
 			strength: 0.64,
 		});
+	}
+
+	for (const proposal of sortedProposals(graph.proposals ?? [])) {
+		if (nodes.length >= limit) break;
+		const target = proposalTarget(proposal, entityNodes, aspectNodesByEntityPath);
+		if (!target && nodes.length >= Math.floor(limit * 0.95)) continue;
+		const proposalNode = toProposalNode(proposal, target, nodes.length);
+		nodes.push(proposalNode);
+		if (target) {
+			edges.push({
+				id: `updates:${proposal.id}:${target.id}`,
+				source: proposalNode.id,
+				target: target.id,
+				label: proposal.operation,
+				kind: "updates",
+				strength: Math.max(0.35, proposal.confidence),
+			});
+		}
+	}
+
+	const dreaming = graph.metadata?.dreaming;
+	if (
+		dreaming &&
+		nodes.length < limit &&
+		(dreaming.latestPass || dreaming.lastPassId || dreaming.tokensSinceLastPass > 0)
+	) {
+		const target = entityNodes.values().next().value ?? null;
+		const dreamingNode = toDreamingNode(dreaming, target);
+		nodes.push(dreamingNode);
+		if (target) {
+			edges.push({
+				id: `updates:${dreamingNode.id}:${target.id}`,
+				source: dreamingNode.id,
+				target: target.id,
+				label: "dreaming",
+				kind: "updates",
+				strength: 0.42,
+				visualOnly: true,
+			});
+		}
 	}
 
 	for (const dep of graph.dependencies) {
@@ -227,9 +297,9 @@ function includeEntity(entity: ConstellationEntity): boolean {
 	const type = entity.entityType.toLowerCase();
 	if (entity.aspects.length === 0) return false;
 	if (entity.pinned) return true;
+	if (looksNoisy(entity.name)) return false;
 	if (PRIMARY_ENTITY_TYPES.has(type)) return true;
 	if (NOISY_ENTITY_TYPES.has(type)) return false;
-	if (looksNoisy(entity.name)) return false;
 	return (
 		entity.mentions >= 3 || entity.aspects.some((aspect) => aspect.attributes.some((attr) => attr.importance >= 0.78))
 	);
@@ -264,7 +334,9 @@ function aspectScore(aspect: ConstellationAspect): number {
 }
 
 function sortedAttributes(aspect: ConstellationAspect): ConstellationAttribute[] {
-	return aspect.attributes.filter((item) => item.content.trim().length > 0).toSorted((a, b) => b.importance - a.importance);
+	return aspect.attributes
+		.filter((item) => item.content.trim().length > 0)
+		.toSorted((a, b) => b.importance - a.importance);
 }
 
 function toEntityNode(entity: ConstellationEntity, index: number, total: number): KnowledgeMapNode {
@@ -284,12 +356,20 @@ function toEntityNode(entity: ConstellationEntity, index: number, total: number)
 		sublabel: entity.entityType,
 		preview: `${entity.mentions} mentions • ${entity.aspects.length} aspects`,
 		entityType: entity.entityType,
+		status: entity.proposalId ? "review" : "current",
 		weight: entityScore(entity),
-		counts: { mentions: entity.mentions, aspects: entity.aspects.length, attributes: attributeCount, influence, scale: 0 },
+		counts: {
+			mentions: entity.mentions,
+			aspects: entity.aspects.length,
+			attributes: attributeCount,
+			influence,
+			scale: 0,
+		},
 		details: [
 			{ label: "Type", value: entity.entityType },
 			{ label: "Mentions", value: String(entity.mentions) },
 			{ label: "Aspects", value: String(entity.aspects.length) },
+			...(entity.proposalId ? [{ label: "Proposal", value: entity.proposalId }] : []),
 			{ label: "Strongest", value: topAspects || "None indexed" },
 		],
 		x: Math.cos(angle) * radius,
@@ -310,7 +390,7 @@ function normalizeEntityScales(nodes: KnowledgeMapNode[]): void {
 	const high = Math.max(percentile(scores, 0.96), low + 1);
 	for (const node of entities) {
 		const normalized = clamp01(((node.counts?.influence ?? 0) - low) / (high - low));
-		const scale = Math.pow(normalized, 2.15);
+		const scale = normalized ** 2.15;
 		node.counts = { ...node.counts, scale };
 	}
 }
@@ -325,10 +405,23 @@ function clamp01(value: number): number {
 	return Math.max(0, Math.min(value, 1));
 }
 
-function toAspectNode(parent: KnowledgeMapNode, aspect: ConstellationAspect, index: number): KnowledgeMapNode {
-	const angle = index * GOLDEN_ANGLE + stableUnit(aspect.id, "aspect") * 0.5;
+function toAspectNode(
+	parent: KnowledgeMapNode,
+	aspect: ConstellationAspect,
+	index: number,
+	total: number,
+): KnowledgeMapNode {
 	const parentScale = Math.max(0, Math.min(parent.counts?.scale ?? 0, 1));
-	const radius = 145 + parentScale * 155 + stableUnit(aspect.id, "aspect-r") * (58 + parentScale * 42);
+	const point = orbitPoint({
+		index,
+		total,
+		baseRadius: 250 + parentScale * 170,
+		ringStep: 128,
+		minArc: 176,
+		offset: -Math.PI / 2 + stableUnit(parent.id, "aspect-offset") * 0.28,
+	});
+	const angle = point.angle;
+	const radius = point.radius;
 	const topAttributes = aspect.attributes
 		.toSorted((a, b) => b.importance - a.importance)
 		.slice(0, 3)
@@ -342,14 +435,15 @@ function toAspectNode(parent: KnowledgeMapNode, aspect: ConstellationAspect, ind
 		sublabel: "aspect",
 		preview: topAttributes || "No attributes indexed for this aspect yet.",
 		parentId: parent.id,
-		status: "current",
+		status: aspect.proposalId ? "review" : "current",
 		weight: aspect.weight,
-		counts: { attributes: aspect.attributes.length },
+		counts: { attributes: aspect.attributes.length, laneAngle: angle, laneIndex: index, laneRing: point.ring },
 		details: [
 			{ label: "Entity", value: parent.label },
 			{ label: "Aspect", value: aspect.name },
 			{ label: "Weight", value: aspect.weight.toFixed(2) },
 			{ label: "Attributes", value: String(aspect.attributes.length) },
+			...(aspect.proposalId ? [{ label: "Proposal", value: aspect.proposalId }] : []),
 			{ label: "Strongest", value: topAttributes || "None indexed" },
 		],
 		x: parent.x + Math.cos(angle) * radius,
@@ -358,9 +452,29 @@ function toAspectNode(parent: KnowledgeMapNode, aspect: ConstellationAspect, ind
 	};
 }
 
-function toAttributeNode(parent: KnowledgeMapNode, attribute: ConstellationAttribute, index: number): KnowledgeMapNode {
-	const angle = index * GOLDEN_ANGLE + stableUnit(attribute.id, "attribute") * 0.65;
-	const radius = 96 + stableUnit(attribute.id, "attribute-r") * 34;
+function toAttributeNode(
+	parent: KnowledgeMapNode,
+	attribute: ConstellationAttribute,
+	index: number,
+	total: number,
+): KnowledgeMapNode {
+	const point = orbitPoint({
+		index,
+		total,
+		baseRadius: 154,
+		ringStep: 94,
+		minArc: 142,
+		offset: stableUnit(parent.id, "attribute-offset") * Math.PI * 2,
+	});
+	const angle = numericCount(parent, "laneAngle") ?? point.angle;
+	const columns = total > 36 ? 6 : total > 18 ? 5 : total > 8 ? 4 : 3;
+	const row = Math.floor(index / columns);
+	const column = index % columns;
+	const finalColumns = Math.min(columns, total - row * columns);
+	const center = (finalColumns - 1) / 2;
+	const tangentOffset = (column - center) * 86;
+	const radius = 150 + row * 98;
+	const tangent = angle + Math.PI / 2;
 	return {
 		id: `attribute:${attribute.id}`,
 		kind: "attribute",
@@ -369,24 +483,190 @@ function toAttributeNode(parent: KnowledgeMapNode, attribute: ConstellationAttri
 		sublabel: attribute.kind,
 		preview: attribute.content,
 		parentId: parent.id,
-		status: "current",
+		status: attribute.proposalId ? "review" : attribute.status === "deleted" ? "forgotten" : "current",
 		weight: attribute.importance,
-		counts: { importance: Math.round(attribute.importance * 100) },
+		counts: {
+			importance: Math.round(attribute.importance * 100),
+			version: attribute.version ?? 1,
+			proposalEvidence: attribute.proposalEvidenceCount ?? 0,
+			laneAngle: angle,
+			laneRow: row,
+			laneColumn: column,
+		},
 		details: [
 			{ label: "Aspect", value: parent.label },
 			{ label: "Kind", value: attribute.kind },
 			{ label: "Importance", value: `${Math.round(attribute.importance * 100)}%` },
+			{ label: "Version", value: `v${attribute.version ?? 1}` },
+			...(attribute.groupKey ? [{ label: "Group", value: attribute.groupKey }] : []),
+			...(attribute.claimKey ? [{ label: "Claim", value: attribute.claimKey }] : []),
+			...(attribute.sourceKind ? [{ label: "Source", value: attribute.sourcePath ?? attribute.sourceKind }] : []),
+			...(attribute.proposalId ? [{ label: "Proposal", value: attribute.proposalId }] : []),
 			{ label: "Evidence", value: attribute.memoryId ?? "No memory id" },
 		],
-		x: parent.x + Math.cos(angle) * radius,
-		y: parent.y + Math.sin(angle) * radius,
+		x: parent.x + Math.cos(angle) * radius + Math.cos(tangent) * tangentOffset,
+		y: parent.y + Math.sin(angle) * radius + Math.sin(tangent) * tangentOffset,
 		data: attribute,
 	};
 }
 
+function sortedProposals(proposals: readonly ConstellationProposal[]): ConstellationProposal[] {
+	return [...proposals]
+		.filter((proposal) => proposal.id.trim().length > 0)
+		.toSorted((a, b) => b.confidence - a.confidence || b.evidenceCount - a.evidenceCount);
+}
+
+function proposalTarget(
+	proposal: ConstellationProposal,
+	entities: ReadonlyMap<string, KnowledgeMapNode>,
+	aspects: ReadonlyMap<string, KnowledgeMapNode>,
+): KnowledgeMapNode | null {
+	if (!proposal.targetEntityId) return null;
+	const aspectName = proposal.targetAspectName?.trim();
+	if (aspectName) {
+		const aspect = aspects.get(`${proposal.targetEntityId}:${canonical(aspectName)}`);
+		if (aspect) return aspect;
+	}
+	return entities.get(proposal.targetEntityId) ?? null;
+}
+
+function toProposalNode(
+	proposal: ConstellationProposal,
+	target: KnowledgeMapNode | null,
+	index: number,
+): KnowledgeMapNode {
+	const angle = stableUnit(proposal.id, "proposal") * Math.PI * 2;
+	const targetRadius = target ? 136 + stableUnit(proposal.id, "proposal-r") * 46 : 620 + index * 14;
+	const x = target ? target.x + Math.cos(angle) * targetRadius : Math.cos(angle) * targetRadius;
+	const y = target ? target.y + Math.sin(angle) * targetRadius : Math.sin(angle) * targetRadius;
+	const preview = proposal.preview ?? proposal.rationale;
+	return {
+		id: `proposal:${proposal.id}`,
+		kind: "proposal",
+		label: operationLabel(proposal.operation),
+		searchText: `${proposal.operation} ${proposal.targetEntityName ?? ""} ${proposal.targetAspectName ?? ""} ${preview}`,
+		sublabel: proposal.targetEntityName ?? "pending",
+		preview: preview || "Pending ontology operation",
+		parentId: target?.id,
+		status: "review",
+		weight: proposal.confidence,
+		counts: {
+			confidence: Math.round(proposal.confidence * 100),
+			evidence: proposal.evidenceCount,
+		},
+		details: [
+			{ label: "Operation", value: operationLabel(proposal.operation) },
+			{ label: "Confidence", value: `${Math.round(proposal.confidence * 100)}%` },
+			{ label: "Evidence", value: String(proposal.evidenceCount) },
+			...(proposal.targetEntityName ? [{ label: "Target", value: proposal.targetEntityName }] : []),
+			...(proposal.targetAspectName ? [{ label: "Aspect", value: proposal.targetAspectName }] : []),
+			...(proposal.sourceKind ? [{ label: "Source", value: proposal.sourcePath ?? proposal.sourceKind }] : []),
+		],
+		x,
+		y,
+		data: proposal,
+	};
+}
+
+function operationLabel(operation: string): string {
+	return operation
+		.split(/[-_\s]+/)
+		.filter(Boolean)
+		.map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+		.join(" ");
+}
+
+function toDreamingNode(
+	dreaming: NonNullable<ConstellationGraph["metadata"]>["dreaming"],
+	target: KnowledgeMapNode | null,
+): KnowledgeMapNode {
+	const latest = dreaming.latestPass;
+	const id = `dreaming:${latest?.id ?? dreaming.lastPassId ?? "queued"}`;
+	const applied = latest?.mutationsApplied ?? 0;
+	const skipped = latest?.mutationsSkipped ?? 0;
+	const failed = latest?.mutationsFailed ?? 0;
+	const status = latest
+		? `${latest.status} ${latest.mode}`
+		: `${formatCount(dreaming.tokensSinceLastPass)} tokens queued`;
+	const x = target ? target.x - 260 : -260;
+	const y = target ? target.y - 220 : -220;
+	return {
+		id,
+		kind: "session",
+		label: "Dreaming",
+		searchText: `dreaming ${status} ${dreaming.lastPassMode ?? ""}`,
+		sublabel: status,
+		preview: latest
+			? `${applied} applied / ${skipped} skipped / ${failed} failed`
+			: `${formatCount(dreaming.tokensSinceLastPass)} summary tokens queued for consolidation`,
+		status: failed > 0 || dreaming.consecutiveFailures > 0 ? "conflict" : "current",
+		weight: latest ? Math.min(1, Math.max(0.2, (applied + skipped + failed) / 12)) : 0.35,
+		counts: {
+			applied,
+			skipped,
+			failed,
+			tokens: dreaming.tokensSinceLastPass,
+		},
+		details: [
+			{ label: "Status", value: status },
+			{ label: "Tokens", value: formatCount(dreaming.tokensSinceLastPass) },
+			...(dreaming.lastPassAt ? [{ label: "Last pass", value: dreaming.lastPassAt }] : []),
+			...(latest ? [{ label: "Mutations", value: `${applied} / ${skipped} / ${failed}` }] : []),
+		],
+		x,
+		y,
+		data: dreaming,
+	};
+}
+
+function formatCount(value: number): string {
+	return Intl.NumberFormat(undefined, { notation: value >= 10000 ? "compact" : "standard" }).format(value);
+}
+
+function canonical(value: string): string {
+	return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function numericCount(node: KnowledgeMapNode, key: string): number | null {
+	const value = node.counts?.[key];
+	return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function orbitPoint(opts: {
+	index: number;
+	total: number;
+	baseRadius: number;
+	ringStep: number;
+	minArc: number;
+	offset: number;
+}): { radius: number; angle: number; ring: number } {
+	let consumed = 0;
+	let ring = 0;
+	while (true) {
+		const radius = opts.baseRadius + ring * opts.ringStep;
+		const capacity = Math.max(5, Math.floor((Math.PI * 2 * radius) / opts.minArc));
+		const ringIndex = opts.index - consumed;
+		if (ringIndex < capacity) {
+			const count = Math.min(capacity, opts.total - consumed);
+			return {
+				radius,
+				angle: opts.offset + (Math.PI * 2 * ringIndex) / Math.max(count, 1),
+				ring,
+			};
+		}
+		consumed += capacity;
+		ring += 1;
+	}
+}
+
 function toMemoryNode(parent: KnowledgeMapNode, attribute: ConstellationAttribute): KnowledgeMapNode {
-	const angle = stableUnit(attribute.id, "memory") * Math.PI * 2;
-	const radius = 74 + stableUnit(attribute.id, "memory-r") * 34;
+	const angle = numericCount(parent, "laneAngle") ?? stableUnit(attribute.id, "memory") * Math.PI * 2;
+	const row = numericCount(parent, "laneRow") ?? 0;
+	const column = numericCount(parent, "laneColumn") ?? 0;
+	const tangent = angle + Math.PI / 2;
+	const side = column % 2 === 0 ? 1 : -1;
+	const radius = 70 + (row % 2) * 12;
+	const tangentOffset = side * 28;
 	return {
 		id: `memory:${attribute.memoryId ?? attribute.id}:${attribute.id}`,
 		kind: "memory",
@@ -403,8 +683,8 @@ function toMemoryNode(parent: KnowledgeMapNode, attribute: ConstellationAttribut
 			{ label: "Memory", value: attribute.memoryId ?? "unknown" },
 			{ label: "Claim", value: attribute.content },
 		],
-		x: parent.x + Math.cos(angle) * radius,
-		y: parent.y + Math.sin(angle) * radius,
+		x: parent.x + Math.cos(angle) * radius + Math.cos(tangent) * tangentOffset,
+		y: parent.y + Math.sin(angle) * radius + Math.sin(tangent) * tangentOffset,
 		data: attribute,
 	};
 }


### PR DESCRIPTION
## Summary
- Expands the constellation graph payload with ontology status, version, proposal, source, dreaming, and larger attribute neighborhoods.
- Reworks the dashboard constellation view into bounded entity/aspect/attribute/evidence focus states with zoned overview layout and stronger canvas rendering.
- Adds the bottom-right entity search navigator and keeps node details in the same inspector card.
- Adds/updates regression coverage for bounded constellation graph counts and dashboard graph modeling.

## Test Plan
- `bun test platform/daemon/src/knowledge-graph-list.test.ts surfaces/dashboard/src/lib/components/ontology/knowledge-map-data.test.ts`
- `bunx biome check surfaces/dashboard/src/lib/components/ontology/ConstellationGraph.svelte surfaces/dashboard/src/lib/components/ontology/canvas/renderer.ts surfaces/dashboard/src/lib/components/ontology/canvas/simulation.ts surfaces/dashboard/src/lib/components/ontology/canvas/types.ts`
- `cd surfaces/dashboard && bun run check`
- `cd surfaces/dashboard && bun run build`
- `bun scripts/spec-deps-check.ts`

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)
- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

No database migrations are included. Rollback is reverting the dashboard/API payload changes; older clients are unaffected because added constellation fields are additive.
