### PR TITLE
fix(bundle): repair native bundle regressions

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -684,7 +684,7 @@ jobs:
             done
           done
 
-      - name: Upload manifests
+      - name: Upload manifests and latest helpers
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -693,4 +693,13 @@ jobs:
           # bundle-latest is the stable pointer. It only advances after immutable assets exist.
           find /tmp/release-staging -type f -name 'manifest-*.json' | while read -r f; do
             gh release upload "$TAG" "$f" --repo "$REPO" --clobber
+          done
+          for script in install.sh update.sh uninstall.sh; do
+            for helper_asset in "/tmp/release-staging/$script" "/tmp/release-staging/$script.sha256"; do
+              if [ ! -f "$helper_asset" ]; then
+                echo "::error::Missing staged latest helper asset: $(basename "$helper_asset")"
+                exit 1
+              fi
+              gh release upload "$TAG" "$helper_asset" --repo "$REPO" --clobber
+            done
           done

--- a/deploy/bundle/install.sh
+++ b/deploy/bundle/install.sh
@@ -603,11 +603,11 @@ WRAPPER
   chmod +x "${bindir}/signet-mcp"
 
   if download_verified_script "uninstall.sh" "${bindir}/_uninstall.sh"; then
-    cat > "${bindir}/signet-uninstall" << WRAPPER
+    cat > "${bindir}/signet-uninstall" << 'WRAPPER'
 #!/usr/bin/env bash
 SIGNET_INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 export SIGNET_INSTALL_DIR
-exec "\$SIGNET_INSTALL_DIR/bin/_uninstall.sh" "\$@"
+exec "$SIGNET_INSTALL_DIR/bin/_uninstall.sh" "$@"
 WRAPPER
     chmod +x "${bindir}/signet-uninstall"
   else
@@ -616,11 +616,11 @@ WRAPPER
   fi
 
   if download_verified_script "update.sh" "${bindir}/_update.sh"; then
-    cat > "${bindir}/signet-update" << WRAPPER
+    cat > "${bindir}/signet-update" << 'WRAPPER'
 #!/usr/bin/env bash
 SIGNET_INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 export SIGNET_INSTALL_DIR
-exec "\$SIGNET_INSTALL_DIR/bin/_update.sh" "\$@"
+exec "$SIGNET_INSTALL_DIR/bin/_update.sh" "$@"
 WRAPPER
     chmod +x "${bindir}/signet-update"
   else

--- a/deploy/bundle/update.sh
+++ b/deploy/bundle/update.sh
@@ -552,11 +552,11 @@ WRAPPER
   chmod +x "${bindir}/signet-mcp"
 
   if download_verified_script "uninstall.sh" "${bindir}/_uninstall.sh"; then
-    cat > "${bindir}/signet-uninstall" << WRAPPER
+    cat > "${bindir}/signet-uninstall" << 'WRAPPER'
 #!/usr/bin/env bash
 SIGNET_INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 export SIGNET_INSTALL_DIR
-exec "\$SIGNET_INSTALL_DIR/bin/_uninstall.sh" "\$@"
+exec "$SIGNET_INSTALL_DIR/bin/_uninstall.sh" "$@"
 WRAPPER
     chmod +x "${bindir}/signet-uninstall"
   else
@@ -565,11 +565,11 @@ WRAPPER
   fi
 
   if download_verified_script "update.sh" "${bindir}/_update.sh"; then
-    cat > "${bindir}/signet-update" << WRAPPER
+    cat > "${bindir}/signet-update" << 'WRAPPER'
 #!/usr/bin/env bash
 SIGNET_INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 export SIGNET_INSTALL_DIR
-exec "\$SIGNET_INSTALL_DIR/bin/_update.sh" "\$@"
+exec "$SIGNET_INSTALL_DIR/bin/_update.sh" "$@"
 WRAPPER
     chmod +x "${bindir}/signet-update"
   else

--- a/platform/daemon/src/pipeline/provider-executable-availability.test.ts
+++ b/platform/daemon/src/pipeline/provider-executable-availability.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+
+import { createAcpxProvider, createCommandLineProvider } from "./provider";
+
+describe("provider executable availability", () => {
+	test("checks explicit relative ACPX executable paths instead of assuming they exist", async () => {
+		const provider = createAcpxProvider({
+			agent: "codex",
+			bin: "./node_modules/.bin/signet-missing-acpx",
+			hooks: "disabled",
+		});
+
+		await expect(provider.available()).resolves.toBe(false);
+	});
+
+	test("checks explicit relative command executable paths instead of assuming they exist", async () => {
+		const provider = createCommandLineProvider({
+			name: "missing-relative-command",
+			bin: "./node_modules/.bin/signet-missing-command",
+			args: [],
+		});
+
+		await expect(provider.available()).resolves.toBe(false);
+	});
+});

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -1315,7 +1315,7 @@ export function createAcpxProvider(config: AcpxProviderConfig): LlmProvider {
 		},
 		async available(): Promise<boolean> {
 			const bin = config.bin ?? "npx";
-			return bin.includes("/") || which(bin) !== null;
+			return which(bin) !== null;
 		},
 	};
 }
@@ -1385,7 +1385,7 @@ export function createCommandLineProvider(config: CommandLineProviderConfig): Ll
 			});
 		},
 		async available(): Promise<boolean> {
-			return config.bin.includes("/") || which(config.bin) !== null;
+			return which(config.bin) !== null;
 		},
 	};
 }

--- a/platform/daemon/src/which.test.ts
+++ b/platform/daemon/src/which.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { whichWithoutBun } from "./which";
+
+describe("whichWithoutBun", () => {
+	test("resolves explicit relative executable paths against cwd", () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-which-"));
+		const previous = process.cwd();
+		const binDir = join(root, "node_modules", ".bin");
+		const bin = join(binDir, "acpx");
+		mkdirSync(binDir, { recursive: true });
+		writeFileSync(bin, "#!/usr/bin/env bash\nexit 0\n");
+		chmodSync(bin, 0o755);
+
+		try {
+			process.chdir(root);
+			expect(whichWithoutBun("./node_modules/.bin/acpx", "")).toBe(bin);
+		} finally {
+			process.chdir(previous);
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("returns null for missing explicit relative executable paths", () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-which-missing-"));
+		const previous = process.cwd();
+
+		try {
+			process.chdir(root);
+			expect(whichWithoutBun("./node_modules/.bin/acpx", "")).toBeNull();
+		} finally {
+			process.chdir(previous);
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("searches PATH for bare executable names", () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-which-path-"));
+		const bin = join(root, "acpx");
+		writeFileSync(bin, "#!/usr/bin/env bash\nexit 0\n");
+		chmodSync(bin, 0o755);
+
+		try {
+			expect(whichWithoutBun("acpx", root)).toBe(bin);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/platform/daemon/src/which.ts
+++ b/platform/daemon/src/which.ts
@@ -3,21 +3,25 @@ import { isAbsolute, resolve, sep } from "node:path";
 
 const isBun = typeof (globalThis as Record<string, unknown>).Bun !== "undefined";
 
-export function which(bin: string): string | null {
-	if (isBun) {
-		return (globalThis.Bun as { which(b: string): string | null }).which(bin);
+function isExecutableFile(file: string): boolean {
+	try {
+		accessSync(file, constants.X_OK);
+		return statSync(file).isFile();
+	} catch {
+		return false;
+	}
+}
+
+function hasPathSeparator(bin: string): boolean {
+	return bin.includes("/") || (sep === "\\" && bin.includes("\\"));
+}
+
+export function whichWithoutBun(bin: string, pathEnv = process.env.PATH ?? ""): string | null {
+	if (isAbsolute(bin) || hasPathSeparator(bin)) {
+		const candidate = resolve(bin);
+		return isExecutableFile(candidate) ? candidate : null;
 	}
 
-	if (isAbsolute(bin)) {
-		try {
-			accessSync(bin, constants.X_OK);
-			return statSync(bin).isFile() ? bin : null;
-		} catch {
-			return null;
-		}
-	}
-
-	const pathEnv = process.env.PATH ?? "";
 	const pathSep = sep === "\\" ? ";" : ":";
 	const exts = process.platform === "win32" ? (process.env.PATHEXT ?? ".EXE;.CMD;.BAT").split(";") : [""];
 
@@ -25,12 +29,17 @@ export function which(bin: string): string | null {
 		if (!dir) continue;
 		for (const ext of exts) {
 			const candidate = resolve(dir, `${bin}${ext}`);
-			try {
-				accessSync(candidate, constants.X_OK);
-				if (statSync(candidate).isFile()) return candidate;
-			} catch {}
+			if (isExecutableFile(candidate)) return candidate;
 		}
 	}
 
 	return null;
+}
+
+export function which(bin: string): string | null {
+	if (isBun) {
+		return (globalThis.Bun as { which(b: string): string | null }).which(bin);
+	}
+
+	return whichWithoutBun(bin);
 }

--- a/scripts/bundle-release-regressions.test.ts
+++ b/scripts/bundle-release-regressions.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "..");
+
+describe("native bundle release regressions", () => {
+	test("publishes bootstrap helper scripts to the latest bundle release", () => {
+		const workflow = readFileSync(join(root, ".github", "workflows", "bundle.yml"), "utf-8");
+
+		expect(workflow).toContain("Upload manifests and latest helpers");
+		expect(workflow).toContain("Missing staged latest helper asset");
+		expect(workflow).toContain(
+			'for helper_asset in "/tmp/release-staging/$script" "/tmp/release-staging/$script.sha256"; do',
+		);
+		expect(workflow).toContain('gh release upload "$TAG" "$helper_asset" --repo "$REPO" --clobber');
+	});
+
+	test("defers helper wrapper path resolution until wrapper execution", () => {
+		const installer = readFileSync(join(root, "deploy", "bundle", "install.sh"), "utf-8");
+		const updater = readFileSync(join(root, "deploy", "bundle", "update.sh"), "utf-8");
+
+		for (const script of [installer, updater]) {
+			expect(script).toContain("cat > \"${bindir}/signet-uninstall\" << 'WRAPPER'");
+			expect(script).toContain("cat > \"${bindir}/signet-update\" << 'WRAPPER'");
+			expect(script).toContain('SIGNET_INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"');
+			expect(script).toContain('exec "$SIGNET_INSTALL_DIR/bin/_uninstall.sh" "$@"');
+			expect(script).toContain('exec "$SIGNET_INSTALL_DIR/bin/_update.sh" "$@"');
+			expect(script).not.toContain('cat > "${bindir}/signet-uninstall" << WRAPPER');
+			expect(script).not.toContain('cat > "${bindir}/signet-update" << WRAPPER');
+			expect(script).not.toContain('exec "\\$SIGNET_INSTALL_DIR/bin/_uninstall.sh" "\\$@"');
+			expect(script).not.toContain('exec "\\$SIGNET_INSTALL_DIR/bin/_update.sh" "\\$@"');
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- Upload install/update/uninstall helper scripts and checksums to `bundle-latest` alongside latest manifests.
- Quote generated install/update helper wrapper heredocs so wrapper paths resolve when the wrapper runs.
- Resolve explicit relative provider binaries through the Node fallback `which()` path and use that for provider availability checks.

## Validation
- `bun test scripts/bundle-release-regressions.test.ts platform/daemon/src/which.test.ts platform/daemon/src/pipeline/provider-executable-availability.test.ts`
- `bun test scripts/check-publish-manifests.test.ts`
- `bash -n deploy/bundle/install.sh && bash -n deploy/bundle/update.sh && bash -n deploy/bundle/uninstall.sh`
- `bunx biome check .github/workflows/bundle.yml deploy/bundle/install.sh deploy/bundle/update.sh scripts/bundle-release-regressions.test.ts platform/daemon/src/which.ts platform/daemon/src/which.test.ts platform/daemon/src/pipeline/provider.ts platform/daemon/src/pipeline/provider-executable-availability.test.ts`
- `bun run typecheck`
- `cd platform/daemon && bun run build.ts`

## Notes
- `cd platform/daemon && bun run build:types` was attempted and failed on existing declaration-build rootDir/cross-package DB typing issues unrelated to this patch; generated artifacts were removed.

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)
- [x] No migrations changed.
- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Rollback / compatibility: reverting this PR restores the previous bundle release upload, wrapper generation, and Node executable resolution behavior. No schema or persisted data changes are included.
