### PR TITLE
fix(daemon): preserve root-only filesystem globs

### DIFF
--- a/platform/daemon/src/connectors/filesystem.test.ts
+++ b/platform/daemon/src/connectors/filesystem.test.ts
@@ -1,7 +1,7 @@
+import { describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, test } from "bun:test";
 import { discoverFiles, matchConnectorPattern, matchGlob } from "./filesystem";
 
 describe("globToRegex", () => {
@@ -22,10 +22,10 @@ describe("globToRegex", () => {
 		expect(matchGlob("**/*.txt", "file.md")).toBe(false);
 	});
 
-	test("*.md matches at any depth (Bun.Glob compat)", () => {
+	test("*.md only matches root-level files", () => {
 		expect(matchGlob("*.md", "AGENTS.md")).toBe(true);
-		expect(matchGlob("*.md", "sub/file.md")).toBe(true);
-		expect(matchGlob("*.md", "a/b/c.md")).toBe(true);
+		expect(matchGlob("*.md", "sub/file.md")).toBe(false);
+		expect(matchGlob("*.md", "a/b/c.md")).toBe(false);
 	});
 
 	test("dotfiles match when explicitly in pattern", () => {
@@ -62,6 +62,29 @@ describe("globToRegex", () => {
 				".github/CONTRIBUTING.md",
 				"docs/.private/notes.md",
 			]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("filesystem discovery keeps basename globs at connector root", async () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-fs-connector-"));
+		try {
+			mkdirSync(join(root, "sub"), { recursive: true });
+			mkdirSync(join(root, "a", "b"), { recursive: true });
+			writeFileSync(join(root, "README.md"), "root");
+			writeFileSync(join(root, "sub", "file.md"), "nested");
+			writeFileSync(join(root, "a", "b", "deep.md"), "deep");
+			writeFileSync(join(root, "notes.txt"), "text");
+
+			const files = await discoverFiles({
+				rootPath: root,
+				patterns: ["*.md"],
+				ignorePatterns: [],
+				maxFileSize: 1_048_576,
+			});
+
+			expect(files.map((file) => file.relativePath).sort()).toEqual(["README.md"]);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}

--- a/platform/daemon/src/connectors/filesystem.ts
+++ b/platform/daemon/src/connectors/filesystem.ts
@@ -120,14 +120,7 @@ export function globToRegex(pattern: string): RegExp {
 		.replace(/\/\{\{GLOBSTAR\}\}/g, "(?:/.*)?")
 		.replace(/\{\{GLOBSTAR\}\}\//g, "(?:.*/)?")
 		.replace(/\{\{GLOBSTAR\}\}/g, ".*");
-	const anchored = `^${normalized}$`;
-	if (!pattern.includes("/") && !pattern.includes("*") && !pattern.includes("?")) {
-		return new RegExp(`^${normalized}$`, "i");
-	}
-	if (!pattern.includes("/") && !pattern.includes("{{GLOBSTAR}}")) {
-		return new RegExp(`(?:^|/)${normalized}$`, "i");
-	}
-	return new RegExp(anchored, "i");
+	return new RegExp(`^${normalized}$`, "i");
 }
 
 export async function discoverFiles(settings: FilesystemSettings): Promise<readonly DiscoveredFile[]> {


### PR DESCRIPTION
## Summary
- Restores root-only matching for basename filesystem connector globs such as `*.md`.
- Keeps explicit recursive patterns such as `**/*.md` matching nested files.
- Adds matcher and discovery regression coverage so basename globs cannot ingest nested files again.

## Validation
- `bun test platform/daemon/src/connectors/filesystem.test.ts`
- `bunx biome check platform/daemon/src/connectors/filesystem.ts platform/daemon/src/connectors/filesystem.test.ts`
- `git diff --check`
- `bun run --filter '@signet/daemon' build` passed, with existing dashboard/Svelte warnings unrelated to this change.
- `bun run --filter '@signet/daemon' build:types` was attempted and failed on existing project-wide declaration/rootDir and `Database` typing errors outside this change.
- `bun run lint` was attempted and failed on existing repository-wide formatting diagnostics, primarily package manifests outside this change; touched-file Biome check passes.

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

Applicability notes: this change does not add data queries, admin/mutation endpoints, API/schema/status docs, or migrations. Focused tests, touched-file lint, diff check, and daemon build passed; repo-wide lint/type declaration commands currently fail on unrelated existing diagnostics listed above.

## Migration Notes (if applicable)
- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

No migrations changed. Rollback is reverting this commit; connector configs using `*.md` would again match nested markdown files, which is the regression fixed here.
