### PR TITLE
fix(bundle): build mac zip artifacts

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -405,7 +405,7 @@ jobs:
           bun run build:daemon
           bun run stage:runtime
           bun run build:main
-          npx electron-builder --mac dmg --${{ matrix.electron_arch }} --publish never
+          npx electron-builder --mac --${{ matrix.electron_arch }} --publish never
           mkdir -p "$ARTIFACT_DIR"
           if ! ls release/*.dmg >/dev/null 2>&1; then
             echo "::error::Electron build produced no macOS DMG"

--- a/scripts/check-publish-manifests.test.ts
+++ b/scripts/check-publish-manifests.test.ts
@@ -117,6 +117,8 @@ describe("check-publish-manifests", () => {
 
 		expect(workflow).toContain("Electron build produced no macOS DMG");
 		expect(workflow).toContain("Electron build produced no macOS zip");
+		expect(workflow).toContain("npx electron-builder --mac --${{ matrix.electron_arch }} --publish never");
+		expect(workflow).not.toContain("npx electron-builder --mac dmg");
 		expect(workflow).not.toContain('cp release/*.dmg "$ARTIFACT_DIR/" 2>/dev/null || true');
 		expect(workflow).not.toContain('cp release/*.zip "$ARTIFACT_DIR/" 2>/dev/null || true');
 	});


### PR DESCRIPTION
## Summary
- let the Bundle workflow use the desktop package mac target config instead of overriding it to DMG-only
- add a regression assertion that the bundle workflow does not pass `--mac dmg` while still requiring both DMG and zip outputs

## Root cause
Recent `main` Bundle failures were in the macOS Electron jobs. The workflow ran `npx electron-builder --mac dmg --<arch> --publish never`, which overrides `surfaces/desktop/package.json` and only produces a DMG. The same step then required `release/*.zip`, so it failed with `Electron build produced no macOS zip`.

## Type
- [x] `fix` — bug fix

## Packages affected
- [x] Other: Bundle workflow / desktop packaging CI

## PR Readiness
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no spec dependency changed
- [x] Agent scoping verified on all new/changed data queries — no data queries changed
- [x] Input/config validation and bounds checks added — no external input path changed
- [x] Error handling and fallback paths tested (no silent swallow) — workflow still fails loudly when expected artifacts are missing
- [x] Security checks applied to admin/mutation endpoints — no endpoint changed
- [x] Docs updated for API/spec/status changes — no API/spec/status docs affected
- [x] Regression tests added for each bug fix
- [ ] Lint/typecheck/tests pass locally — typecheck/tests passed; repo-wide lint is blocked by existing unrelated formatting diagnostics

## Migration Notes
N/A — no migrations touched.

## Verification
- [x] `bun test scripts/check-publish-manifests.test.ts`
- [x] `bun test surfaces/desktop/src/desktop-updates.test.ts`
- [x] `bun run typecheck`
- [x] `git diff --check`
- [ ] `bun run lint` — fails on existing unrelated formatting diagnostics in package manifests and pre-existing test formatting
- [ ] `bunx biome check .github/workflows/bundle.yml scripts/check-publish-manifests.test.ts` — fails on pre-existing formatting in `scripts/check-publish-manifests.test.ts`

## AI disclosure
- [x] AI tools were used (see `Assisted-by` tags in commits)
