### PR TITLE
fix(ci): install bun in bundle release job

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -448,6 +448,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: oven-sh/setup-bun@v2
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:

--- a/scripts/check-publish-manifests.test.ts
+++ b/scripts/check-publish-manifests.test.ts
@@ -149,6 +149,16 @@ describe("check-publish-manifests", () => {
 		expect(workflow).toContain("github.ref == 'refs/heads/main'");
 	});
 
+	test("installs Bun before release manifest generation", () => {
+		const root = join(import.meta.dir, "..");
+		const workflow = readFileSync(join(root, ".github", "workflows", "bundle.yml"), "utf-8");
+		const release = workflow.slice(workflow.indexOf("  release:"));
+
+		expect(release).toContain("- uses: oven-sh/setup-bun@v2");
+		expect(release.indexOf("- uses: oven-sh/setup-bun@v2")).toBeLessThan(release.indexOf("- name: Generate manifests"));
+		expect(release).toContain("bun deploy/bundle/scripts/generate-manifest.ts");
+	});
+
 	test("retries transient bundle dependency install failures", () => {
 		const root = join(import.meta.dir, "..");
 		const workflow = readFileSync(join(root, ".github", "workflows", "bundle.yml"), "utf-8");


### PR DESCRIPTION
## Summary
- installs Bun in the Bundle workflow release job before manifest generation
- adds a regression guard that keeps Bun setup before the release manifest script

## Root cause
The failing `Bundle` run on `main` reached the separate `release` job, then exited during `Generate manifests` with:

```text
/home/runner/work/_temp/...sh: line 39: bun: command not found
Process completed with exit code 127.
```

The build matrix jobs set up Bun, but the release job runs on a fresh runner and also invokes `bun deploy/bundle/scripts/generate-manifest.ts`.

## PR readiness checklist
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) - no spec changes.
- [x] Agent scoping verified on all new/changed data queries - no data queries changed.
- [x] Input/config validation and bounds checks added - no runtime input/config surface changed.
- [x] Error handling and fallback paths tested (no silent swallow) - regression covers the workflow prerequisite for the failing command.
- [x] Security checks applied to admin/mutation endpoints - no endpoints changed.
- [x] Docs updated for API/spec/status changes - no API/spec/status docs changed.
- [x] Regression tests added for each bug fix - added `installs Bun before release manifest generation`.
- [x] Lint/typecheck/tests pass locally - focused test, lint-only check, and diff whitespace check passed.

## Tests
- `bun test scripts/check-publish-manifests.test.ts`
- `bunx biome lint scripts/check-publish-manifests.test.ts`
- `git diff --check`