### PR TITLE
fix(ci): minimize bundle release smoke workspace

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -574,6 +574,21 @@ jobs:
                 printf '%s\n' 'exec "$SIGNET_DIR/runtime/node/bin/node" "$SIGNET_DIR/runtime/cli/cli.js" "$@"'
               } > "$CHECK_DIR/bin/signet"
               chmod +x "$CHECK_DIR/bin/signet"
+              cat > "$CHECK_DIR/smoke-agents/agent.yaml" <<'YAML'
+              embedding:
+                provider: none
+              memory:
+                pipelineV2:
+                  paused: true
+                  synthesis:
+                    enabled: false
+                  procedural:
+                    enabled: false
+                  embeddingTracker:
+                    enabled: false
+                  modelRegistry:
+                    enabled: false
+              YAML
               "$CHECK_DIR/bin/signet" --help >/dev/null
               "$CHECK_DIR/bin/signet" setup --help >/dev/null
               "$CHECK_DIR/bin/signet" dashboard --help >/dev/null

--- a/scripts/check-publish-manifests.test.ts
+++ b/scripts/check-publish-manifests.test.ts
@@ -256,6 +256,10 @@ describe("check-publish-manifests", () => {
 		expect(workflow).toContain('"$CHECK_DIR/bin/signet" mcp --help >/dev/null');
 		expect(workflow).toContain('SMOKE_PORT="$(python3 -c');
 		expect(workflow).toContain('SIGNET_DAEMON_ENTRYPOINT="1"');
+		expect(workflow).toContain('cat > "$CHECK_DIR/smoke-agents/agent.yaml" <<\'YAML\'');
+		expect(workflow).toContain("embedding:\n                provider: none");
+		expect(workflow).toContain("pipelineV2:\n                  paused: true");
+		expect(workflow).toContain("embeddingTracker:\n                    enabled: false");
 		expect(workflow).toContain('"$CHECK_DIR/runtime/node/bin/node" "$CHECK_DIR/runtime/daemon-js/daemon.js" > "$SMOKE_LOG" 2>&1 &');
 		expect(workflow).toContain('curl -fsS "http://127.0.0.1:${SMOKE_PORT}/health"');
 		expect(workflow).toContain("Bundled Node daemon did not become healthy");


### PR DESCRIPTION
## Summary
- writes a minimal smoke `agent.yaml` before launching the bundled daemon in the Bundle release job
- disables embeddings and pauses background memory pipeline work for the release smoke workspace
- keeps the smoke focused on packaged layout, CLI startup, daemon startup, and `/health`

## Root cause
After #729 installed Bun in the release job, the `Bundle` workflow advanced to the packaged daemon smoke. The daemon process stayed alive but `/health` did not become ready within the 30-second smoke window:

```text
curl: (7) Failed to connect to 127.0.0.1 port ...
::error::Bundled Node daemon did not become healthy
```

The daemon only binds after startup work such as DB setup, worker initialization, pipeline runtime setup, watchers, scheduler, and update timers. The release smoke should validate the packaged daemon can start and serve health, not run the full default background memory pipeline on the release runner.

## PR readiness checklist
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) - no spec changes.
- [x] Agent scoping verified on all new/changed data queries - no data queries changed.
- [x] Input/config validation and bounds checks added - no runtime input/config surface changed.
- [x] Error handling and fallback paths tested (no silent swallow) - regression keeps the release smoke workspace minimal before daemon launch.
- [x] Security checks applied to admin/mutation endpoints - no endpoints changed.
- [x] Docs updated for API/spec/status changes - no API/spec/status docs changed.
- [x] Regression tests added for each bug fix - extended the bundle workflow guard test.
- [x] Lint/typecheck/tests pass locally - focused test, lint-only check, and diff whitespace check passed.

## Tests
- `bun test scripts/check-publish-manifests.test.ts`
- `bunx biome lint scripts/check-publish-manifests.test.ts`
- `git diff --check`
