### PR TITLE
fix(memory): persist remember row provenance

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -789,6 +789,9 @@ Body-level fields override prefix-parsed values.
   "pinned": false,
   "sourceType": "manual",
   "sourceId": "optional-external-id",
+  "sourcePath": "/absolute/or/original/source.md",
+  "runtimePath": "memory/MEMORY.md",
+  "idempotencyKey": "stable-import-key",
   "createdAt": "2026-02-21T10:00:00.000Z",
   "agentId": "alice",
   "visibility": "global"
@@ -806,6 +809,14 @@ Only `content` is required. Multi-agent fields:
 memory is sourced from an older conversation or imported artifact so structured
 currentness and supersession can compare facts by source time instead of ingest
 time.
+
+Row-level provenance fields are optional: `sourcePath`/`source_path` stores the
+original source path, `runtimePath`/`runtime_path` stores the runtime-relative
+path, and `idempotencyKey`/`idempotency_key` stores a stable import key. When an
+`idempotencyKey` is supplied, remember checks it before content-hash dedupe;
+retries with the same key return the existing row instead of inserting a
+duplicate. Importers may also supply the snake_case names inside a `metadata`
+object for compatibility.
 
 Structured callers may also pass `structured.entities`, `structured.aspects`,
 and `structured.hints`. Aspect attributes are persisted directly under
@@ -838,7 +849,7 @@ or update the knowledge graph.
 }
 ```
 
-If an identical memory (by content hash or `sourceId`) already exists,
+If an identical memory (by `sourceId`, `idempotencyKey`, or content hash) already exists,
 `deduped: true` is returned with the existing record — no duplicate is
 created.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -815,8 +815,9 @@ original source path, `runtimePath`/`runtime_path` stores the runtime-relative
 path, and `idempotencyKey`/`idempotency_key` stores a stable import key. When an
 `idempotencyKey` is supplied, remember checks it before content-hash dedupe;
 retries with the same key return the existing row instead of inserting a
-duplicate. Importers may also supply the snake_case names inside a `metadata`
-object for compatibility.
+duplicate within the same `agentId`, `visibility`, and `scope` tuple. Importers
+may also supply the snake_case names inside a `metadata` object for
+compatibility.
 
 Structured callers may also pass `structured.entities`, `structured.aspects`,
 and `structured.hints`. Aspect attributes are persisted directly under
@@ -849,9 +850,9 @@ or update the knowledge graph.
 }
 ```
 
-If an identical memory (by `sourceId`, `idempotencyKey`, or content hash) already exists,
-`deduped: true` is returned with the existing record — no duplicate is
-created.
+If an identical memory (by `sourceId`, `idempotencyKey`, or content hash) already
+exists in the relevant scope, `deduped: true` is returned with the existing
+record — no duplicate is created.
 
 ### POST /api/memory/save
 

--- a/libs/sdk/src/index.ts
+++ b/libs/sdk/src/index.ts
@@ -126,6 +126,7 @@ export class SignetClient extends SignetClientHelpers {
 			readonly pinned?: boolean;
 			readonly sourceType?: string;
 			readonly sourceId?: string;
+			readonly sourcePath?: string;
 			readonly mode?: "auto" | "sync" | "async";
 			readonly idempotencyKey?: string;
 			readonly runtimePath?: string;

--- a/platform/core/src/migrations/072-agent-scoped-idempotency-key.ts
+++ b/platform/core/src/migrations/072-agent-scoped-idempotency-key.ts
@@ -7,6 +7,7 @@ function ensureMemoriesScopeColumns(db: MigrationDb): void {
 	if (!names.has("visibility")) db.exec("ALTER TABLE memories ADD COLUMN visibility TEXT DEFAULT 'global'");
 	if (!names.has("scope")) db.exec("ALTER TABLE memories ADD COLUMN scope TEXT");
 	if (!names.has("idempotency_key")) db.exec("ALTER TABLE memories ADD COLUMN idempotency_key TEXT");
+	if (!names.has("runtime_path")) db.exec("ALTER TABLE memories ADD COLUMN runtime_path TEXT");
 }
 
 /**

--- a/platform/core/src/migrations/072-agent-scoped-idempotency-key.ts
+++ b/platform/core/src/migrations/072-agent-scoped-idempotency-key.ts
@@ -1,0 +1,32 @@
+import type { MigrationDb } from "./index";
+
+function ensureMemoriesScopeColumns(db: MigrationDb): void {
+	const cols = db.prepare("PRAGMA table_info(memories)").all() as ReadonlyArray<Record<string, unknown>>;
+	const names = new Set(cols.map((col) => col.name).filter((name): name is string => typeof name === "string"));
+	if (!names.has("agent_id")) db.exec("ALTER TABLE memories ADD COLUMN agent_id TEXT DEFAULT 'default'");
+	if (!names.has("visibility")) db.exec("ALTER TABLE memories ADD COLUMN visibility TEXT DEFAULT 'global'");
+	if (!names.has("scope")) db.exec("ALTER TABLE memories ADD COLUMN scope TEXT");
+	if (!names.has("idempotency_key")) db.exec("ALTER TABLE memories ADD COLUMN idempotency_key TEXT");
+}
+
+/**
+ * Migration 072: Agent-aware idempotency key dedupe.
+ *
+ * Import keys are stable within a memory owner and visibility domain. The old
+ * global index could make retries collide across agents or scopes.
+ */
+export function up(db: MigrationDb): void {
+	ensureMemoriesScopeColumns(db);
+
+	db.exec("DROP INDEX IF EXISTS idx_memories_idempotency_key");
+	db.exec(`
+		CREATE UNIQUE INDEX idx_memories_idempotency_key
+		ON memories(
+			idempotency_key,
+			COALESCE(NULLIF(agent_id, ''), 'default'),
+			COALESCE(visibility, 'global'),
+			COALESCE(scope, '__NULL__')
+		)
+		WHERE idempotency_key IS NOT NULL AND is_deleted = 0
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -677,6 +677,12 @@ export const MIGRATIONS: readonly Migration[] = [
 		version: 72,
 		name: "agent-scoped-idempotency-key",
 		up: agentScopedIdempotencyKey,
+		artifacts: {
+			columns: [
+				{ table: "memories", column: "idempotency_key" },
+				{ table: "memories", column: "runtime_path" },
+			],
+		},
 	},
 ];
 

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -77,6 +77,7 @@ import { up as dailyReflections } from "./068-daily-reflections";
 import { up as dailyReflectionsMultipleInsights } from "./069-daily-reflections-multiple-insights";
 import { up as ontologyControlPlaneState } from "./070-ontology-control-plane-state";
 import { up as epistemicAssertions } from "./071-epistemic-assertions";
+import { up as agentScopedIdempotencyKey } from "./072-agent-scoped-idempotency-key";
 
 // -- Public interface consumed by Database.init() --
 
@@ -671,6 +672,11 @@ export const MIGRATIONS: readonly Migration[] = [
 		artifacts: {
 			tables: ["epistemic_assertions"],
 		},
+	},
+	{
+		version: 72,
+		name: "agent-scoped-idempotency-key",
+		up: agentScopedIdempotencyKey,
 	},
 ];
 

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -775,6 +775,52 @@ describe("migration framework", () => {
 		).run("f", "deleted", "hash1", "fact", "default", null, now, now, "test");
 	});
 
+	test("unique partial index on idempotency_key is agent-, visibility-, and scope-aware", () => {
+		db = createFreshDb();
+		runMigrations(db);
+
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO memories
+			 (id, content, idempotency_key, type, agent_id, visibility, scope, created_at, updated_at, updated_by)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run("a", "first import", "import-key", "fact", "default", "global", null, now, now, "test");
+
+		expect(() =>
+			db
+				.prepare(
+					`INSERT INTO memories
+					 (id, content, idempotency_key, type, agent_id, visibility, scope, created_at, updated_at, updated_by)
+					 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				)
+				.run("b", "same tuple import", "import-key", "fact", "default", "global", null, now, now, "test"),
+		).toThrow();
+
+		db.prepare(
+			`INSERT INTO memories
+			 (id, content, idempotency_key, type, agent_id, visibility, scope, created_at, updated_at, updated_by)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run("c", "other agent import", "import-key", "fact", "agent-a", "global", null, now, now, "test");
+
+		db.prepare(
+			`INSERT INTO memories
+			 (id, content, idempotency_key, type, agent_id, visibility, scope, created_at, updated_at, updated_by)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run("d", "private import", "import-key", "fact", "default", "private", null, now, now, "test");
+
+		db.prepare(
+			`INSERT INTO memories
+			 (id, content, idempotency_key, type, agent_id, visibility, scope, created_at, updated_at, updated_by)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run("e", "scoped import", "import-key", "fact", "default", "global", "bench:run-1", now, now, "test");
+
+		db.prepare(
+			`INSERT INTO memories
+			 (id, content, idempotency_key, is_deleted, type, agent_id, visibility, scope, created_at, updated_at, updated_by)
+			 VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?)`,
+		).run("f", "deleted import", "import-key", "fact", "default", "global", null, now, now, "test");
+	});
+
 	test("migration 003 deduplicates existing content hashes", () => {
 		db = createFreshDb();
 

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -821,6 +821,20 @@ describe("migration framework", () => {
 		).run("f", "deleted import", "import-key", "fact", "default", "global", null, now, now, "test");
 	});
 
+	test("migration 072 repairs missing runtime_path on partial provenance schemas", () => {
+		db = createFreshDb();
+		runMigrations(db);
+
+		db.exec("ALTER TABLE memories DROP COLUMN runtime_path");
+		db.prepare("DELETE FROM schema_migrations WHERE version = 72").run();
+		runMigrations(db);
+
+		const cols = db.query("PRAGMA table_info(memories)").all() as Array<{ name: string }>;
+		const colNames = cols.map((c) => c.name);
+		expect(colNames).toContain("idempotency_key");
+		expect(colNames).toContain("runtime_path");
+	});
+
 	test("migration 003 deduplicates existing content hashes", () => {
 		db = createFreshDb();
 

--- a/platform/core/src/recall.test.ts
+++ b/platform/core/src/recall.test.ts
@@ -61,6 +61,9 @@ describe("recall surface helpers", () => {
 	it("normalizes legacy structured aspect tuples for remember callers", () => {
 		const body = buildRememberRequestBody("Remember this", {
 			tags: ["graph", "parity"],
+			sourcePath: "/tmp/source.md",
+			runtimePath: "memory/source.md",
+			idempotencyKey: "stable-import-key",
 			structured: {
 				aspects: [
 					{
@@ -76,6 +79,9 @@ describe("recall surface helpers", () => {
 		});
 
 		expect(body.tags).toBe("graph,parity");
+		expect(body.sourcePath).toBe("/tmp/source.md");
+		expect(body.runtimePath).toBe("memory/source.md");
+		expect(body.idempotencyKey).toBe("stable-import-key");
 		expect(body.structured).toEqual({
 			aspects: [
 				{

--- a/platform/core/src/recall.ts
+++ b/platform/core/src/recall.ts
@@ -67,6 +67,7 @@ export interface RememberRequestOptions {
 	readonly pinned?: boolean;
 	readonly sourceType?: string;
 	readonly sourceId?: string;
+	readonly sourcePath?: string;
 	readonly createdAt?: string;
 	readonly hints?: readonly string[];
 	readonly transcript?: string;
@@ -290,6 +291,7 @@ export function buildRememberRequestBody(
 		pinned: options.pinned === true ? true : undefined,
 		sourceType: options.sourceType,
 		sourceId: options.sourceId,
+		sourcePath: options.sourcePath,
 		createdAt: options.createdAt,
 		hints: options.hints,
 		transcript: options.transcript,

--- a/platform/daemon/src/mutation-api.test.ts
+++ b/platform/daemon/src/mutation-api.test.ts
@@ -274,6 +274,98 @@ memory:
 		expect(row?.count).toBe(3);
 	});
 
+	it("POST /api/memory/remember matches normalized idempotency-key index scope", async () => {
+		const first = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: "Legacy normalized idempotency row",
+				who: "soulvessel.tests",
+				idempotencyKey: "legacy-normalized-key",
+			}),
+		});
+		const firstJson = (await first.json()) as { id?: string };
+		expect(first.status).toBe(200);
+		expect(firstJson.id).toBeString();
+
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE memories SET agent_id = '', visibility = NULL WHERE id = ?").run(firstJson.id);
+		});
+
+		const retry = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: "Different retry content for normalized idempotency row",
+				who: "soulvessel.tests",
+				idempotencyKey: "legacy-normalized-key",
+			}),
+		});
+		const retryJson = (await retry.json()) as { id?: string; deduped?: boolean };
+		expect(retry.status).toBe(200);
+		expect(retryJson).toMatchObject({ id: firstJson.id, deduped: true });
+	});
+
+	it("POST /api/memory/remember returns existing chunk ids on idempotent oversized retries", async () => {
+		const content = Array.from(
+			{ length: 90 },
+			(_, index) => `Chunked provenance sentence ${index} carries enough words to split predictably.`,
+		).join(" ");
+		expect(content.length).toBeGreaterThan(800);
+
+		const first = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content,
+				who: "soulvessel.tests",
+				idempotencyKey: "chunked-import-key",
+			}),
+		});
+		const firstJson = (await first.json()) as {
+			chunked?: boolean;
+			chunk_count?: number;
+			ids?: string[];
+			group_id?: string;
+		};
+		expect(first.status).toBe(200);
+		expect(firstJson.chunked).toBe(true);
+		expect(firstJson.ids?.length).toBeGreaterThan(1);
+
+		const retry = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content,
+				who: "soulvessel.tests",
+				idempotencyKey: "chunked-import-key",
+			}),
+		});
+		const retryJson = (await retry.json()) as {
+			chunked?: boolean;
+			chunk_count?: number;
+			deduped?: boolean;
+			ids?: string[];
+			group_id?: string;
+		};
+		expect(retry.status).toBe(200);
+		expect(retryJson).toMatchObject({
+			chunked: true,
+			chunk_count: firstJson.chunk_count,
+			deduped: true,
+			group_id: firstJson.group_id,
+			ids: firstJson.ids,
+		});
+
+		const row = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT COUNT(*) AS count FROM entities WHERE entity_type = 'chunk_group'").get() as
+					| { count: number }
+					| undefined,
+		);
+		expect(row?.count).toBe(1);
+	});
+
 	it("POST /api/memory/remember persists structured graph data under the requested agent", async () => {
 		const res = await app.request("http://localhost/api/memory/remember", {
 			method: "POST",

--- a/platform/daemon/src/mutation-api.test.ts
+++ b/platform/daemon/src/mutation-api.test.ts
@@ -224,7 +224,7 @@ memory:
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({
-				content: "Other agent provenance import",
+				content: "Default global provenance import",
 				who: "soulvessel.tests",
 				agentId: "agent-a",
 				idempotencyKey: "shared-import-key",

--- a/platform/daemon/src/mutation-api.test.ts
+++ b/platform/daemon/src/mutation-api.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Hono } from "hono";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { chunkBySentence } from "./routes/utils";
 import { txIngestEnvelope } from "./transactions";
 
 let app: Hono;
@@ -476,6 +477,40 @@ memory:
 		const smallAfterChunkJson = (await smallAfterChunk.json()) as { error?: string };
 		expect(smallAfterChunk.status).toBe(409);
 		expect(smallAfterChunkJson.error).toContain("chunked content");
+	});
+
+	it("POST /api/memory/remember rejects chunked imports that would reuse unrelated content rows", async () => {
+		const oversized = Array.from(
+			{ length: 90 },
+			(_, index) => `Existing chunk hash sentence ${index} carries enough words to split predictably.`,
+		).join(" ");
+		const firstChunk = chunkBySentence(oversized, 600)[0];
+		expect(oversized.length).toBeGreaterThan(800);
+		expect(firstChunk.length).toBeLessThan(800);
+
+		const existing = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: firstChunk,
+				who: "soulvessel.tests",
+				idempotencyKey: "existing-normal-chunk-content-key",
+			}),
+		});
+		expect(existing.status).toBe(200);
+
+		const chunked = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: oversized,
+				who: "soulvessel.tests",
+				idempotencyKey: "chunked-existing-content-key",
+			}),
+		});
+		const chunkedJson = (await chunked.json()) as { error?: string };
+		expect(chunked.status).toBe(409);
+		expect(chunkedJson.error).toContain("chunk content already exists");
 	});
 
 	it("POST /api/memory/remember persists structured graph data under the requested agent", async () => {

--- a/platform/daemon/src/mutation-api.test.ts
+++ b/platform/daemon/src/mutation-api.test.ts
@@ -422,6 +422,62 @@ memory:
 		expect(rows.chunks).toBe(firstJson.ids?.length);
 	});
 
+	it("POST /api/memory/remember rejects mixed chunked and non-chunk idempotency-key reuse", async () => {
+		const oversized = Array.from(
+			{ length: 90 },
+			(_, index) => `Mixed idempotency chunk sentence ${index} carries enough words to split predictably.`,
+		).join(" ");
+		expect(oversized.length).toBeGreaterThan(800);
+
+		const small = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: "Small memory using a key before a chunked import.",
+				who: "soulvessel.tests",
+				idempotencyKey: "mixed-small-first-key",
+			}),
+		});
+		expect(small.status).toBe(200);
+
+		const chunkAfterSmall = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: oversized,
+				who: "soulvessel.tests",
+				idempotencyKey: "mixed-small-first-key",
+			}),
+		});
+		const chunkAfterSmallJson = (await chunkAfterSmall.json()) as { error?: string };
+		expect(chunkAfterSmall.status).toBe(409);
+		expect(chunkAfterSmallJson.error).toContain("non-chunk content");
+
+		const chunkFirst = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: oversized,
+				who: "soulvessel.tests",
+				idempotencyKey: "mixed-chunk-first-key",
+			}),
+		});
+		expect(chunkFirst.status).toBe(200);
+
+		const smallAfterChunk = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: "Small memory using a key after a chunked import.",
+				who: "soulvessel.tests",
+				idempotencyKey: "mixed-chunk-first-key",
+			}),
+		});
+		const smallAfterChunkJson = (await smallAfterChunk.json()) as { error?: string };
+		expect(smallAfterChunk.status).toBe(409);
+		expect(smallAfterChunkJson.error).toContain("chunked content");
+	});
+
 	it("POST /api/memory/remember persists structured graph data under the requested agent", async () => {
 		const res = await app.request("http://localhost/api/memory/remember", {
 			method: "POST",

--- a/platform/daemon/src/mutation-api.test.ts
+++ b/platform/daemon/src/mutation-api.test.ts
@@ -513,6 +513,34 @@ memory:
 		expect(chunkedJson.error).toContain("chunk content already exists");
 	});
 
+	it("POST /api/memory/remember resolves concurrent chunk hash collisions as conflicts", async () => {
+		const oversized = Array.from(
+			{ length: 90 },
+			(_, index) => `Concurrent chunk hash sentence ${index} carries enough words to split predictably.`,
+		).join(" ");
+		expect(oversized.length).toBeGreaterThan(800);
+
+		const [first, second] = await Promise.all(
+			["concurrent-chunk-content-key-a", "concurrent-chunk-content-key-b"].map((idempotencyKey) =>
+				app.request("http://localhost/api/memory/remember", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						content: oversized,
+						who: "soulvessel.tests",
+						idempotencyKey,
+					}),
+				}),
+			),
+		);
+		const statuses = [first.status, second.status].sort((a, b) => a - b);
+		expect(statuses).toEqual([200, 409]);
+
+		const conflict = first.status === 409 ? first : second;
+		const conflictJson = (await conflict.json()) as { error?: string };
+		expect(conflictJson.error).toContain("chunk content already exists");
+	});
+
 	it("POST /api/memory/remember persists structured graph data under the requested agent", async () => {
 		const res = await app.request("http://localhost/api/memory/remember", {
 			method: "POST",

--- a/platform/daemon/src/mutation-api.test.ts
+++ b/platform/daemon/src/mutation-api.test.ts
@@ -205,6 +205,75 @@ memory:
 		expect(retryJson).toMatchObject({ id: json.id, deduped: true });
 	});
 
+	it("POST /api/memory/remember scopes idempotency-key dedupe by agent and visibility", async () => {
+		const first = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: "Default global provenance import",
+				who: "soulvessel.tests",
+				idempotencyKey: "shared-import-key",
+			}),
+		});
+		const firstJson = (await first.json()) as { id?: string; deduped?: boolean };
+		expect(first.status).toBe(200);
+		expect(firstJson.id).toBeString();
+		expect(firstJson.deduped).toBeUndefined();
+
+		const otherAgent = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: "Other agent provenance import",
+				who: "soulvessel.tests",
+				agentId: "agent-a",
+				idempotencyKey: "shared-import-key",
+			}),
+		});
+		const otherAgentJson = (await otherAgent.json()) as { id?: string; deduped?: boolean };
+		expect(otherAgent.status).toBe(200);
+		expect(otherAgentJson.id).toBeString();
+		expect(otherAgentJson.id).not.toBe(firstJson.id);
+		expect(otherAgentJson.deduped).toBeUndefined();
+
+		const privateVisibility = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: "Default private provenance import",
+				who: "soulvessel.tests",
+				visibility: "private",
+				idempotencyKey: "shared-import-key",
+			}),
+		});
+		const privateJson = (await privateVisibility.json()) as { id?: string; deduped?: boolean };
+		expect(privateVisibility.status).toBe(200);
+		expect(privateJson.id).toBeString();
+		expect(privateJson.id).not.toBe(firstJson.id);
+		expect(privateJson.deduped).toBeUndefined();
+
+		const retry = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: "Default global provenance import retry",
+				who: "soulvessel.tests",
+				idempotencyKey: "shared-import-key",
+			}),
+		});
+		const retryJson = (await retry.json()) as { id?: string; deduped?: boolean };
+		expect(retry.status).toBe(200);
+		expect(retryJson).toMatchObject({ id: firstJson.id, deduped: true });
+
+		const row = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT COUNT(*) AS count FROM memories WHERE idempotency_key = ?").get("shared-import-key") as
+					| { count: number }
+					| undefined,
+		);
+		expect(row?.count).toBe(3);
+	});
+
 	it("POST /api/memory/remember persists structured graph data under the requested agent", async () => {
 		const res = await app.request("http://localhost/api/memory/remember", {
 			method: "POST",

--- a/platform/daemon/src/mutation-api.test.ts
+++ b/platform/daemon/src/mutation-api.test.ts
@@ -366,6 +366,62 @@ memory:
 		expect(row?.count).toBe(1);
 	});
 
+	it("POST /api/memory/remember rejects changed oversized content for an existing idempotency key", async () => {
+		const content = Array.from(
+			{ length: 90 },
+			(_, index) => `Stable chunked import sentence ${index} carries enough words to split predictably.`,
+		).join(" ");
+		const changed = Array.from(
+			{ length: 92 },
+			(_, index) => `Changed chunked import sentence ${index} carries enough words to split predictably.`,
+		).join(" ");
+		expect(content.length).toBeGreaterThan(800);
+		expect(changed.length).toBeGreaterThan(800);
+
+		const first = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content,
+				who: "soulvessel.tests",
+				idempotencyKey: "chunked-import-conflict-key",
+			}),
+		});
+		const firstJson = (await first.json()) as { ids?: string[] };
+		expect(first.status).toBe(200);
+		expect(firstJson.ids?.length).toBeGreaterThan(1);
+
+		const conflict = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: changed,
+				who: "soulvessel.tests",
+				idempotencyKey: "chunked-import-conflict-key",
+			}),
+		});
+		const conflictJson = (await conflict.json()) as { error?: string };
+		expect(conflict.status).toBe(409);
+		expect(conflictJson.error).toContain("different chunked content");
+
+		const rows = getDbAccessor().withReadDb((db) => ({
+			groups: (
+				db.prepare("SELECT COUNT(*) AS count FROM entities WHERE entity_type = 'chunk_group'").get() as
+					| { count: number }
+					| undefined
+			)?.count,
+			chunks: (
+				db
+					.prepare(
+						"SELECT COUNT(*) AS count FROM memories WHERE idempotency_key LIKE 'chunked-import-conflict-key:chunk:%'",
+					)
+					.get() as { count: number } | undefined
+			)?.count,
+		}));
+		expect(rows.groups).toBe(1);
+		expect(rows.chunks).toBe(firstJson.ids?.length);
+	});
+
 	it("POST /api/memory/remember persists structured graph data under the requested agent", async () => {
 		const res = await app.request("http://localhost/api/memory/remember", {
 			method: "POST",

--- a/platform/daemon/src/mutation-api.test.ts
+++ b/platform/daemon/src/mutation-api.test.ts
@@ -145,6 +145,66 @@ memory:
 		}
 	});
 
+	it("POST /api/memory/remember persists row-level provenance from metadata", async () => {
+		const res = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: "Provenance-backed imported memory",
+				who: "soulvessel.tests",
+				sourceType: "hermes-memory",
+				sourceId: "hermes-doc-provenance-test",
+				metadata: {
+					source_path: "/tmp/signet-provenance/MEMORY.md",
+					runtime_path: "memories/MEMORY.md",
+					idempotency_key: "hermes:provenance-test",
+				},
+			}),
+		});
+		const json = (await res.json()) as { id?: string; sourceId?: string };
+
+		expect(res.status).toBe(200);
+		expect(json.id).toBeString();
+
+		const row = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare(
+						`SELECT source_type, source_id, source_path, runtime_path, idempotency_key
+						 FROM memories WHERE id = ?`,
+					)
+					.get(json.id) as
+					| {
+							source_type: string | null;
+							source_id: string | null;
+							source_path: string | null;
+							runtime_path: string | null;
+							idempotency_key: string | null;
+					  }
+					| undefined,
+		);
+		expect(row).toEqual({
+			source_type: "hermes-memory",
+			source_id: "hermes-doc-provenance-test",
+			source_path: "/tmp/signet-provenance/MEMORY.md",
+			runtime_path: "memories/MEMORY.md",
+			idempotency_key: "hermes:provenance-test",
+		});
+
+		const retry = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: "Different retry content with the same stable import key",
+				who: "soulvessel.tests",
+				idempotencyKey: "hermes:provenance-test",
+			}),
+		});
+		const retryJson = (await retry.json()) as { id?: string; deduped?: boolean };
+		expect(retry.status).toBe(200);
+		expect(retryJson).toMatchObject({ id: json.id, deduped: true });
+	});
+
 	it("POST /api/memory/remember persists structured graph data under the requested agent", async () => {
 		const res = await app.request("http://localhost/api/memory/remember", {
 			method: "POST",

--- a/platform/daemon/src/mutation-api.test.ts
+++ b/platform/daemon/src/mutation-api.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -53,6 +54,20 @@ function seedMemory(args: {
 			db.prepare("UPDATE memories SET version = ? WHERE id = ?").run(args.version, args.id);
 		}
 	});
+}
+
+function chunkGroupIdForDefaultScope(baseKey: string): string {
+	const hash = createHash("sha256")
+		.update("default")
+		.update("\0")
+		.update("global")
+		.update("\0")
+		.update("__NULL__")
+		.update("\0")
+		.update(baseKey)
+		.digest("hex")
+		.slice(0, 32);
+	return `chunk-group:${hash}`;
 }
 
 describe("mutation API routes", () => {
@@ -520,8 +535,9 @@ memory:
 		).join(" ");
 		expect(oversized.length).toBeGreaterThan(800);
 
+		const keys = ["concurrent-chunk-content-key-a", "concurrent-chunk-content-key-b"] as const;
 		const [first, second] = await Promise.all(
-			["concurrent-chunk-content-key-a", "concurrent-chunk-content-key-b"].map((idempotencyKey) =>
+			keys.map((idempotencyKey) =>
 				app.request("http://localhost/api/memory/remember", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
@@ -539,6 +555,20 @@ memory:
 		const conflict = first.status === 409 ? first : second;
 		const conflictJson = (await conflict.json()) as { error?: string };
 		expect(conflictJson.error).toContain("chunk content already exists");
+
+		const losingKey = first.status === 409 ? keys[0] : keys[1];
+		const losingGroupId = chunkGroupIdForDefaultScope(losingKey);
+		const partial = getDbAccessor().withReadDb((db) => {
+			const rows = db
+				.prepare("SELECT id FROM memories WHERE idempotency_key LIKE ?")
+				.all(`${losingKey}:chunk:%`) as Array<{
+				id: string;
+			}>;
+			const group = db.prepare("SELECT id FROM entities WHERE id = ?").get(losingGroupId) as { id: string } | null;
+			return { group, rows };
+		});
+		expect(partial.rows).toHaveLength(0);
+		expect(partial.group).toBeNull();
 	});
 
 	it("POST /api/memory/remember persists structured graph data under the requested agent", async () => {

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -3,7 +3,7 @@ import type { Hono } from "hono";
 import { getAgentScope, resolveAgentId } from "../agent-id";
 import { checkScope, requirePermission, requireRateLimit } from "../auth";
 import { normalizeAndHashContent } from "../content-normalization";
-import { getDbAccessor } from "../db-accessor";
+import { type WriteDb, getDbAccessor } from "../db-accessor";
 import { syncVecDeleteBySourceId, syncVecInsert, vectorToBlob } from "../db-helpers";
 import { fetchEmbedding } from "../embedding-fetch";
 import { buildEmbeddingHealth } from "../embedding-health";
@@ -86,6 +86,21 @@ interface RememberRowProvenance {
 	readonly idempotencyKey?: string;
 }
 
+interface RememberDedupeScope {
+	readonly agentId: string;
+	readonly visibility: "global" | "private" | "archived";
+	readonly scope: string | null;
+}
+
+interface RememberDedupeRow {
+	readonly id: string;
+	readonly type: string;
+	readonly tags: string | null;
+	readonly pinned: number;
+	readonly importance: number;
+	readonly content: string;
+}
+
 function pickOptionalString(...values: readonly unknown[]): string | undefined {
 	for (const value of values) {
 		const parsed = parseOptionalString(value);
@@ -97,7 +112,14 @@ function pickOptionalString(...values: readonly unknown[]): string | undefined {
 function parseRememberRowProvenance(body: Record<string, unknown>): RememberRowProvenance {
 	const metadata = toRecord(body.metadata) ?? {};
 	return {
-		sourcePath: pickOptionalString(body.sourcePath, body.source_path, body.source, metadata.sourcePath, metadata.source_path, metadata.source),
+		sourcePath: pickOptionalString(
+			body.sourcePath,
+			body.source_path,
+			body.source,
+			metadata.sourcePath,
+			metadata.source_path,
+			metadata.source,
+		),
 		runtimePath: pickOptionalString(body.runtimePath, body.runtime_path, metadata.runtimePath, metadata.runtime_path),
 		idempotencyKey: pickOptionalString(
 			body.idempotencyKey,
@@ -110,6 +132,50 @@ function parseRememberRowProvenance(body: Record<string, unknown>): RememberRowP
 
 function idempotencyKeyForChunk(baseKey: string | undefined, index: number): string | undefined {
 	return baseKey ? `${baseKey}:chunk:${index + 1}` : undefined;
+}
+
+function scopedMemoryPredicate(input: RememberDedupeScope): {
+	readonly sql: string;
+	readonly params: readonly string[];
+} {
+	return input.scope === null
+		? {
+				sql: "agent_id = ? AND visibility = ? AND scope IS NULL",
+				params: [input.agentId, input.visibility],
+			}
+		: {
+				sql: "agent_id = ? AND visibility = ? AND scope = ?",
+				params: [input.agentId, input.visibility, input.scope],
+			};
+}
+
+function getScopedIdempotencyMemoryId(
+	db: WriteDb,
+	key: string | undefined,
+	input: RememberDedupeScope,
+): { readonly id: string } | undefined {
+	if (!key) return undefined;
+	const scoped = scopedMemoryPredicate(input);
+	return db
+		.prepare(`SELECT id FROM memories WHERE idempotency_key = ? AND ${scoped.sql} AND is_deleted = 0 LIMIT 1`)
+		.get(key, ...scoped.params) as { readonly id: string } | undefined;
+}
+
+function getScopedIdempotencyDedupeRow(
+	db: WriteDb,
+	key: string | undefined,
+	input: RememberDedupeScope,
+): RememberDedupeRow | undefined {
+	if (!key) return undefined;
+	const scoped = scopedMemoryPredicate(input);
+	return db
+		.prepare(
+			`SELECT id, type, tags, pinned, importance, content
+			 FROM memories
+			 WHERE idempotency_key = ? AND ${scoped.sql} AND is_deleted = 0
+			 LIMIT 1`,
+		)
+		.get(key, ...scoped.params) as RememberDedupeRow | undefined;
 }
 
 function hasMemoriesSessionIdColumn(db: any): boolean {
@@ -558,6 +624,7 @@ export function registerMemoryRoutes(app: Hono): void {
 		const rowProvenance = parseRememberRowProvenance(body as Record<string, unknown>);
 		const agentId = resolveAgentId({ agentId: body.agentId, sessionKey: c.req.header("x-signet-session-key") });
 		const visibility = body.visibility === "private" ? "private" : "global";
+		const dedupeScope = { agentId, visibility, scope };
 		const hasBodyTags = Object.prototype.hasOwnProperty.call(body, "tags");
 		const bodyTags = hasBodyTags ? parseTagsMutation(body.tags) : undefined;
 		if (hasBodyTags && bodyTags === undefined) {
@@ -620,12 +687,7 @@ export function registerMemoryRoutes(app: Hono): void {
 
 				try {
 					const inserted = getDbAccessor().withWriteTx((db) => {
-						const byIdempotencyKey = chunkIdempotencyKey
-							? (db
-									.prepare("SELECT id FROM memories WHERE idempotency_key = ? AND is_deleted = 0 LIMIT 1")
-									.get(chunkIdempotencyKey) as { id: string } | undefined)
-							: undefined;
-						if (byIdempotencyKey) return false;
+						if (getScopedIdempotencyMemoryId(db, chunkIdempotencyKey, dedupeScope)) return false;
 
 						const byHash =
 							scope !== null
@@ -784,14 +846,7 @@ export function registerMemoryRoutes(app: Hono): void {
 		const contentHash = normalizedContent.contentHash;
 		const pipelineEnqueueEnabled = pipelineCfg.enabled;
 
-		type DedupeRow = {
-			id: string;
-			type: string;
-			tags: string | null;
-			pinned: number;
-			importance: number;
-			content: string;
-		};
+		type DedupeRow = RememberDedupeRow;
 
 		try {
 			const result = getDbAccessor().withWriteTx((db) => {
@@ -815,15 +870,8 @@ export function registerMemoryRoutes(app: Hono): void {
 					if (bySource) return { deduped: true as const, row: bySource };
 				}
 
-				if (rowProvenance.idempotencyKey) {
-					const byIdempotencyKey = db
-						.prepare(
-							`SELECT id, type, tags, pinned, importance, content
-					 FROM memories WHERE idempotency_key = ? AND is_deleted = 0 LIMIT 1`,
-						)
-						.get(rowProvenance.idempotencyKey) as DedupeRow | undefined;
-					if (byIdempotencyKey) return { deduped: true as const, row: byIdempotencyKey };
-				}
+				const byIdempotencyKey = getScopedIdempotencyDedupeRow(db, rowProvenance.idempotencyKey, dedupeScope);
+				if (byIdempotencyKey) return { deduped: true as const, row: byIdempotencyKey };
 
 				// Check content_hash dedupe (scope-aware)
 				const byHash = (
@@ -895,16 +943,8 @@ export function registerMemoryRoutes(app: Hono): void {
 			const msg = e instanceof Error ? e.message : "";
 			if (msg.includes("UNIQUE constraint")) {
 				const existing = getDbAccessor().withReadDb((db) => {
-					if (rowProvenance.idempotencyKey) {
-						const byIdempotencyKey = db
-							.prepare(
-								`SELECT id, type, tags, pinned, importance, content
-						 FROM memories
-						 WHERE idempotency_key = ? AND is_deleted = 0 LIMIT 1`,
-							)
-							.get(rowProvenance.idempotencyKey) as DedupeRow | undefined;
-						if (byIdempotencyKey) return byIdempotencyKey;
-					}
+					const byIdempotencyKey = getScopedIdempotencyDedupeRow(db, rowProvenance.idempotencyKey, dedupeScope);
+					if (byIdempotencyKey) return byIdempotencyKey;
 					return db
 						.prepare(
 							`SELECT id, type, tags, pinned, importance, content

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -815,6 +815,19 @@ export function registerMemoryRoutes(app: Hono): void {
 					deduped: true,
 				});
 			}
+			const contentHashes = new Set<string>();
+			for (const plan of chunkPlans) {
+				if (contentHashes.has(plan.normalized.contentHash)) {
+					return c.json({ error: "chunked content contains duplicate chunks" }, 409);
+				}
+				contentHashes.add(plan.normalized.contentHash);
+				const byHash = getDbAccessor().withReadDb((db) =>
+					getScopedContentHashMemoryId(db, plan.normalized.contentHash, dedupeScope),
+				);
+				if (byHash) {
+					return c.json({ error: "chunk content already exists for this agent and scope" }, 409);
+				}
+			}
 
 			const groupId = chunkGroupIdForIdempotencyKey(rowProvenance.idempotencyKey, dedupeScope) ?? crypto.randomUUID();
 			const now = new Date().toISOString();
@@ -842,9 +855,6 @@ export function registerMemoryRoutes(app: Hono): void {
 					const result = getDbAccessor().withWriteTx((db) => {
 						const byIdempotencyKey = getScopedIdempotencyMemoryId(db, plan.idempotencyKey, dedupeScope);
 						if (byIdempotencyKey) return { id: byIdempotencyKey.id, inserted: false as const };
-
-						const byHash = getScopedContentHashMemoryId(db, plan.normalized.contentHash, dedupeScope);
-						if (byHash) return { id: byHash.id, inserted: false as const };
 
 						txIngestEnvelope(db, {
 							id: chunkId,

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -169,6 +169,19 @@ function scopedMemoryPredicate(input: RememberDedupeScope): {
 	};
 }
 
+function scopedContentHashPredicate(input: RememberDedupeScope): {
+	readonly sql: string;
+	readonly params: readonly string[];
+} {
+	return {
+		sql: `
+			COALESCE(NULLIF(agent_id, ''), 'default') = ?
+			AND COALESCE(scope, '__NULL__') = ?
+		`,
+		params: [input.agentId || "default", input.scope ?? "__NULL__"],
+	};
+}
+
 function getScopedIdempotencyMemoryId(
 	db: WriteDb,
 	key: string | undefined,
@@ -201,6 +214,38 @@ function getScopedIdempotencyDedupeRow(
 			 LIMIT 1`,
 		)
 		.get(key, ...scoped.params) as RememberDedupeRow | undefined;
+}
+
+function getScopedContentHashMemoryId(
+	db: WriteDb,
+	contentHash: string,
+	input: RememberDedupeScope,
+): { readonly id: string } | undefined {
+	const scoped = scopedContentHashPredicate(input);
+	return db
+		.prepare(
+			`SELECT id
+			 FROM memories
+			 WHERE content_hash = ? AND ${scoped.sql} AND is_deleted = 0
+			 LIMIT 1`,
+		)
+		.get(contentHash, ...scoped.params) as { readonly id: string } | undefined;
+}
+
+function getScopedContentHashDedupeRow(
+	db: WriteDb,
+	contentHash: string,
+	input: RememberDedupeScope,
+): RememberDedupeRow | undefined {
+	const scoped = scopedContentHashPredicate(input);
+	return db
+		.prepare(
+			`SELECT id, type, tags, pinned, importance, content
+			 FROM memories
+			 WHERE content_hash = ? AND ${scoped.sql} AND is_deleted = 0
+			 LIMIT 1`,
+		)
+		.get(contentHash, ...scoped.params) as RememberDedupeRow | undefined;
 }
 
 function getScopedChunkIdempotencyRows(
@@ -775,16 +820,7 @@ export function registerMemoryRoutes(app: Hono): void {
 						const byIdempotencyKey = getScopedIdempotencyMemoryId(db, plan.idempotencyKey, dedupeScope);
 						if (byIdempotencyKey) return { id: byIdempotencyKey.id, inserted: false as const };
 
-						const byHash =
-							scope !== null
-								? (db
-										.prepare("SELECT id FROM memories WHERE content_hash = ? AND scope = ? AND is_deleted = 0 LIMIT 1")
-										.get(plan.normalized.contentHash, scope) as { id: string } | undefined)
-								: (db
-										.prepare(
-											"SELECT id FROM memories WHERE content_hash = ? AND scope IS NULL AND is_deleted = 0 LIMIT 1",
-										)
-										.get(plan.normalized.contentHash) as { id: string } | undefined);
+						const byHash = getScopedContentHashMemoryId(db, plan.normalized.contentHash, dedupeScope);
 						if (byHash) return { id: byHash.id, inserted: false as const };
 
 						txIngestEnvelope(db, {
@@ -964,22 +1000,8 @@ export function registerMemoryRoutes(app: Hono): void {
 				const byIdempotencyKey = getScopedIdempotencyDedupeRow(db, rowProvenance.idempotencyKey, dedupeScope);
 				if (byIdempotencyKey) return { deduped: true as const, row: byIdempotencyKey };
 
-				// Check content_hash dedupe (scope-aware)
-				const byHash = (
-					scope !== null
-						? db
-								.prepare(
-									`SELECT id, type, tags, pinned, importance, content
-					 FROM memories WHERE content_hash = ? AND scope = ? AND is_deleted = 0 LIMIT 1`,
-								)
-								.get(contentHash, scope)
-						: db
-								.prepare(
-									`SELECT id, type, tags, pinned, importance, content
-					 FROM memories WHERE content_hash = ? AND scope IS NULL AND is_deleted = 0 LIMIT 1`,
-								)
-								.get(contentHash)
-				) as DedupeRow | undefined;
+				// Check content_hash dedupe using the same agent/scope tuple as the unique index.
+				const byHash = getScopedContentHashDedupeRow(db, contentHash, dedupeScope);
 				if (byHash) return { deduped: true as const, row: byHash };
 
 				// No duplicate — insert
@@ -1036,13 +1058,7 @@ export function registerMemoryRoutes(app: Hono): void {
 				const existing = getDbAccessor().withReadDb((db) => {
 					const byIdempotencyKey = getScopedIdempotencyDedupeRow(db, rowProvenance.idempotencyKey, dedupeScope);
 					if (byIdempotencyKey) return byIdempotencyKey;
-					return db
-						.prepare(
-							`SELECT id, type, tags, pinned, importance, content
-						 FROM memories
-						 WHERE content_hash = ? AND is_deleted = 0 LIMIT 1`,
-						)
-						.get(contentHash) as DedupeRow | undefined;
+					return getScopedContentHashDedupeRow(db, contentHash, dedupeScope);
 				});
 				if (existing) {
 					return c.json({

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -836,38 +836,52 @@ export function registerMemoryRoutes(app: Hono): void {
 
 			const groupId = chunkGroupIdForIdempotencyKey(rowProvenance.idempotencyKey, dedupeScope) ?? crypto.randomUUID();
 			const now = new Date().toISOString();
-			const chunkIds = Array<string | undefined>(chunkPlans.length);
+			const plannedChunkIds = chunkPlans.map(() => crypto.randomUUID());
 			type ChunkInsertResult =
-				| { readonly id: string; readonly status: "existing" }
-				| { readonly id: string; readonly status: "inserted" }
-				| { readonly status: "content_conflict" };
+				| { readonly ids: readonly string[]; readonly status: "inserted" }
+				| { readonly groupId: string | undefined; readonly ids: readonly string[]; readonly status: "deduped" }
+				| { readonly status: "chunk_idempotency_conflict" }
+				| { readonly status: "content_conflict" }
+				| { readonly status: "non_chunk_idempotency_conflict" };
 
-			// Create chunk group entity
 			try {
-				getDbAccessor().withWriteTx((db) => {
+				const result: ChunkInsertResult = getDbAccessor().withWriteTx((db) => {
+					const baseMemory = getScopedIdempotencyMemoryId(db, rowProvenance.idempotencyKey, dedupeScope);
+					if (baseMemory) return { status: "non_chunk_idempotency_conflict" };
+
+					const txExistingChunks = getScopedChunkIdempotencyRows(db, rowProvenance.idempotencyKey, dedupeScope);
+					if (txExistingChunks.length > 0) {
+						const groupIds = new Set(txExistingChunks.map((row) => row.sourceId).filter((id): id is string => !!id));
+						const matchesExistingPlan =
+							groupIds.size === 1 &&
+							txExistingChunks.length === chunkPlans.length &&
+							txExistingChunks.every((row, index) => {
+								const plan = chunkPlans[index];
+								return row.idempotencyKey === plan.idempotencyKey && row.contentHash === plan.normalized.contentHash;
+							});
+						if (!matchesExistingPlan) return { status: "chunk_idempotency_conflict" };
+
+						return {
+							groupId: Array.from(groupIds)[0],
+							ids: txExistingChunks.map((row) => row.id),
+							status: "deduped",
+						};
+					}
+
+					for (const plan of chunkPlans) {
+						const byHash = getScopedContentHashMemoryId(db, plan.normalized.contentHash, dedupeScope);
+						if (byHash) return { status: "content_conflict" };
+					}
+
 					db.prepare(
 						`INSERT OR IGNORE INTO entities
 						 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
 						 VALUES (?, ?, ?, 'chunk_group', ?, 0, ?, ?)`,
 					).run(groupId, `chunk-group:${groupId}`, `chunk-group:${groupId}`, agentId, now, now);
-				});
-			} catch (e) {
-				logger.error("memory", "Failed to create chunk group entity", e as Error);
-				return c.json({ error: "Failed to create chunk group" }, 500);
-			}
 
-			for (let chunkIndex = 0; chunkIndex < chunkPlans.length; chunkIndex += 1) {
-				const plan = chunkPlans[chunkIndex];
-				const chunkId = crypto.randomUUID();
-
-				try {
-					const result: ChunkInsertResult = getDbAccessor().withWriteTx((db) => {
-						const byIdempotencyKey = getScopedIdempotencyMemoryId(db, plan.idempotencyKey, dedupeScope);
-						if (byIdempotencyKey) return { id: byIdempotencyKey.id, status: "existing" };
-
-						const byHash = getScopedContentHashMemoryId(db, plan.normalized.contentHash, dedupeScope);
-						if (byHash) return { status: "content_conflict" };
-
+					for (let chunkIndex = 0; chunkIndex < chunkPlans.length; chunkIndex += 1) {
+						const plan = chunkPlans[chunkIndex];
+						const chunkId = plannedChunkIds[chunkIndex];
 						txIngestEnvelope(db, {
 							id: chunkId,
 							content: plan.normalized.storageContent,
@@ -902,16 +916,35 @@ export function registerMemoryRoutes(app: Hono): void {
 							 (memory_id, entity_id, mention_text, confidence, created_at)
 							 VALUES (?, ?, 'chunk', 1.0, ?)`,
 						).run(chunkId, groupId, now);
-
-						return { id: chunkId, status: "inserted" };
-					});
-
-					if (result.status === "content_conflict") {
-						return c.json({ error: "chunk content already exists for this agent and scope" }, 409);
 					}
-					chunkIds[chunkIndex] = result.id;
-					if (result.status !== "inserted") continue;
 
+					return { ids: plannedChunkIds, status: "inserted" };
+				});
+
+				if (result.status === "non_chunk_idempotency_conflict") {
+					return c.json({ error: "idempotencyKey already used for non-chunk content" }, 409);
+				}
+				if (result.status === "chunk_idempotency_conflict") {
+					return c.json({ error: "idempotencyKey already used for different chunked content" }, 409);
+				}
+				if (result.status === "content_conflict") {
+					return c.json({ error: "chunk content already exists for this agent and scope" }, 409);
+				}
+				if (result.status === "deduped") {
+					return c.json({
+						chunked: true,
+						chunk_count: result.ids.length,
+						ids: result.ids,
+						group_id: result.groupId,
+						deduped: true,
+					});
+				}
+
+				const savedChunkIds = [...result.ids];
+
+				for (let chunkIndex = 0; chunkIndex < chunkPlans.length; chunkIndex += 1) {
+					const plan = chunkPlans[chunkIndex];
+					const chunkId = savedChunkIds[chunkIndex];
 					// Generate embedding async
 					try {
 						const vec = await fetchEmbedding(plan.normalized.storageContent, fullCfg.embedding);
@@ -920,24 +953,24 @@ export function registerMemoryRoutes(app: Hono): void {
 								logger.warn("memory", "Embedding dimension mismatch, skipping vector insert", {
 									got: vec.length,
 									expected: fullCfg.embedding.dimensions,
-									memoryId: result.id,
+									memoryId: chunkId,
 								});
 							} else {
 								const embId = crypto.randomUUID();
 								const blob = vectorToBlob(vec);
 								const embHash = scope ? `${plan.normalized.contentHash}:${scope}` : plan.normalized.contentHash;
 								getDbAccessor().withWriteTx((db) => {
-									syncVecDeleteBySourceId(db, "memory", result.id);
-									db.prepare(`DELETE FROM embeddings WHERE source_type = 'memory' AND source_id = ?`).run(result.id);
+									syncVecDeleteBySourceId(db, "memory", chunkId);
+									db.prepare(`DELETE FROM embeddings WHERE source_type = 'memory' AND source_id = ?`).run(chunkId);
 									db.prepare(`
 										INSERT INTO embeddings
 										  (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at)
 										VALUES (?, ?, ?, ?, 'memory', ?, ?, ?)
-									`).run(embId, embHash, blob, vec.length, result.id, plan.normalized.storageContent, now);
+									`).run(embId, embHash, blob, vec.length, chunkId, plan.normalized.storageContent, now);
 									syncVecInsert(db, embId, vec);
 									db.prepare("UPDATE memories SET embedding_model = ? WHERE id = ?").run(
 										fullCfg.embedding.model,
-										result.id,
+										chunkId,
 									);
 								});
 							}
@@ -952,7 +985,7 @@ export function registerMemoryRoutes(app: Hono): void {
 					// Inline entity linking for chunk
 					try {
 						getDbAccessor().withWriteTx((db) => {
-							linkMemoryToEntities(db, result.id, plan.chunk, agentId);
+							linkMemoryToEntities(db, chunkId, plan.chunk, agentId);
 						});
 					} catch {
 						// Non-fatal — pipeline extraction handles deeper linking
@@ -961,41 +994,37 @@ export function registerMemoryRoutes(app: Hono): void {
 					// Enqueue pipeline extraction if enabled
 					if (pipelineEnqueueEnabled) {
 						try {
-							queueExtractionJob(result.id);
+							queueExtractionJob(chunkId);
 						} catch (e) {
 							logger.warn("pipeline", "Failed to enqueue chunk extraction", {
-								chunkId: result.id,
+								chunkId,
 								error: String(e),
 							});
 						}
 					}
-				} catch (e) {
-					if (isMemoryContentHashUniqueError(e)) {
-						return c.json({ error: "chunk content already exists for this agent and scope" }, 409);
-					}
-					logger.warn("memory", "Failed to save chunk", {
-						chunkId,
-						error: String(e),
-					});
-					return c.json({ error: "Failed to save chunk" }, 500);
 				}
-			}
-			const savedChunkIds = chunkIds.filter((id): id is string => !!id);
-			if (savedChunkIds.length !== chunkPlans.length) {
-				return c.json({ error: "Failed to save all chunks" }, 500);
-			}
 
-			logger.info("memory", "Chunked memory saved", {
-				groupId,
-				chunkCount: savedChunkIds.length,
-			});
+				logger.info("memory", "Chunked memory saved", {
+					groupId,
+					chunkCount: savedChunkIds.length,
+				});
 
-			return c.json({
-				chunked: true,
-				chunk_count: savedChunkIds.length,
-				ids: savedChunkIds,
-				group_id: groupId,
-			});
+				return c.json({
+					chunked: true,
+					chunk_count: savedChunkIds.length,
+					ids: savedChunkIds,
+					group_id: groupId,
+				});
+			} catch (e) {
+				if (isMemoryContentHashUniqueError(e)) {
+					return c.json({ error: "chunk content already exists for this agent and scope" }, 409);
+				}
+				logger.warn("memory", "Failed to save chunked memory", {
+					groupId,
+					error: String(e),
+				});
+				return c.json({ error: "Failed to save chunks" }, 500);
+			}
 		}
 
 		const who = body.who ?? "daemon";

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { vectorSearch } from "@signet/core";
 import type { Hono } from "hono";
 import { getAgentScope, resolveAgentId } from "../agent-id";
@@ -142,6 +143,21 @@ function parseRememberRowProvenance(body: Record<string, unknown>): RememberRowP
 
 function idempotencyKeyForChunk(baseKey: string | undefined, index: number): string | undefined {
 	return baseKey ? `${baseKey}:chunk:${index + 1}` : undefined;
+}
+
+function chunkGroupIdForIdempotencyKey(baseKey: string | undefined, input: RememberDedupeScope): string | undefined {
+	if (!baseKey) return undefined;
+	const hash = createHash("sha256")
+		.update(input.agentId || "default")
+		.update("\0")
+		.update(input.visibility)
+		.update("\0")
+		.update(input.scope ?? "__NULL__")
+		.update("\0")
+		.update(baseKey)
+		.digest("hex")
+		.slice(0, 32);
+	return `chunk-group:${hash}`;
 }
 
 function escapeSqlLike(value: string): string {
@@ -800,7 +816,7 @@ export function registerMemoryRoutes(app: Hono): void {
 				});
 			}
 
-			const groupId = crypto.randomUUID();
+			const groupId = chunkGroupIdForIdempotencyKey(rowProvenance.idempotencyKey, dedupeScope) ?? crypto.randomUUID();
 			const now = new Date().toISOString();
 			const chunkIds = Array<string | undefined>(chunkPlans.length);
 

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -750,7 +750,7 @@ export function registerMemoryRoutes(app: Hono): void {
 
 			const groupId = crypto.randomUUID();
 			const now = new Date().toISOString();
-			const chunkIds: string[] = [];
+			const chunkIds = Array<string | undefined>(chunkPlans.length);
 
 			// Create chunk group entity
 			try {
@@ -825,7 +825,7 @@ export function registerMemoryRoutes(app: Hono): void {
 						return { id: chunkId, inserted: true as const };
 					});
 
-					chunkIds.push(result.id);
+					chunkIds[chunkIndex] = result.id;
 					if (!result.inserted) continue;
 
 					// Generate embedding async
@@ -890,18 +890,23 @@ export function registerMemoryRoutes(app: Hono): void {
 						chunkId,
 						error: String(e),
 					});
+					return c.json({ error: "Failed to save chunk" }, 500);
 				}
+			}
+			const savedChunkIds = chunkIds.filter((id): id is string => !!id);
+			if (savedChunkIds.length !== chunkPlans.length) {
+				return c.json({ error: "Failed to save all chunks" }, 500);
 			}
 
 			logger.info("memory", "Chunked memory saved", {
 				groupId,
-				chunkCount: chunkIds.length,
+				chunkCount: savedChunkIds.length,
 			});
 
 			return c.json({
 				chunked: true,
-				chunk_count: chunkIds.length,
-				ids: chunkIds,
+				chunk_count: savedChunkIds.length,
+				ids: savedChunkIds,
 				group_id: groupId,
 			});
 		}

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -248,6 +248,11 @@ function getScopedContentHashMemoryId(
 		.get(contentHash, ...scoped.params) as { readonly id: string } | undefined;
 }
 
+function isMemoryContentHashUniqueError(err: unknown): boolean {
+	if (!(err instanceof Error)) return false;
+	return err.message.includes("idx_memories_content_hash_unique") || err.message.includes("memories.content_hash");
+}
+
 function getScopedContentHashDedupeRow(
 	db: WriteDb,
 	contentHash: string,
@@ -832,6 +837,10 @@ export function registerMemoryRoutes(app: Hono): void {
 			const groupId = chunkGroupIdForIdempotencyKey(rowProvenance.idempotencyKey, dedupeScope) ?? crypto.randomUUID();
 			const now = new Date().toISOString();
 			const chunkIds = Array<string | undefined>(chunkPlans.length);
+			type ChunkInsertResult =
+				| { readonly id: string; readonly status: "existing" }
+				| { readonly id: string; readonly status: "inserted" }
+				| { readonly status: "content_conflict" };
 
 			// Create chunk group entity
 			try {
@@ -852,9 +861,12 @@ export function registerMemoryRoutes(app: Hono): void {
 				const chunkId = crypto.randomUUID();
 
 				try {
-					const result = getDbAccessor().withWriteTx((db) => {
+					const result: ChunkInsertResult = getDbAccessor().withWriteTx((db) => {
 						const byIdempotencyKey = getScopedIdempotencyMemoryId(db, plan.idempotencyKey, dedupeScope);
-						if (byIdempotencyKey) return { id: byIdempotencyKey.id, inserted: false as const };
+						if (byIdempotencyKey) return { id: byIdempotencyKey.id, status: "existing" };
+
+						const byHash = getScopedContentHashMemoryId(db, plan.normalized.contentHash, dedupeScope);
+						if (byHash) return { status: "content_conflict" };
 
 						txIngestEnvelope(db, {
 							id: chunkId,
@@ -891,11 +903,14 @@ export function registerMemoryRoutes(app: Hono): void {
 							 VALUES (?, ?, 'chunk', 1.0, ?)`,
 						).run(chunkId, groupId, now);
 
-						return { id: chunkId, inserted: true as const };
+						return { id: chunkId, status: "inserted" };
 					});
 
+					if (result.status === "content_conflict") {
+						return c.json({ error: "chunk content already exists for this agent and scope" }, 409);
+					}
 					chunkIds[chunkIndex] = result.id;
-					if (!result.inserted) continue;
+					if (result.status !== "inserted") continue;
 
 					// Generate embedding async
 					try {
@@ -955,6 +970,9 @@ export function registerMemoryRoutes(app: Hono): void {
 						}
 					}
 				} catch (e) {
+					if (isMemoryContentHashUniqueError(e)) {
+						return c.json({ error: "chunk content already exists for this agent and scope" }, 409);
+					}
 					logger.warn("memory", "Failed to save chunk", {
 						chunkId,
 						error: String(e),

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -101,6 +101,11 @@ interface RememberDedupeRow {
 	readonly content: string;
 }
 
+interface RememberDedupeIdRow {
+	readonly id: string;
+	readonly sourceId: string | null;
+}
+
 function pickOptionalString(...values: readonly unknown[]): string | undefined {
 	for (const value of values) {
 		const parsed = parseOptionalString(value);
@@ -138,27 +143,31 @@ function scopedMemoryPredicate(input: RememberDedupeScope): {
 	readonly sql: string;
 	readonly params: readonly string[];
 } {
-	return input.scope === null
-		? {
-				sql: "agent_id = ? AND visibility = ? AND scope IS NULL",
-				params: [input.agentId, input.visibility],
-			}
-		: {
-				sql: "agent_id = ? AND visibility = ? AND scope = ?",
-				params: [input.agentId, input.visibility, input.scope],
-			};
+	return {
+		sql: `
+			COALESCE(NULLIF(agent_id, ''), 'default') = ?
+			AND COALESCE(visibility, 'global') = ?
+			AND COALESCE(scope, '__NULL__') = ?
+		`,
+		params: [input.agentId || "default", input.visibility, input.scope ?? "__NULL__"],
+	};
 }
 
 function getScopedIdempotencyMemoryId(
 	db: WriteDb,
 	key: string | undefined,
 	input: RememberDedupeScope,
-): { readonly id: string } | undefined {
+): RememberDedupeIdRow | undefined {
 	if (!key) return undefined;
 	const scoped = scopedMemoryPredicate(input);
 	return db
-		.prepare(`SELECT id FROM memories WHERE idempotency_key = ? AND ${scoped.sql} AND is_deleted = 0 LIMIT 1`)
-		.get(key, ...scoped.params) as { readonly id: string } | undefined;
+		.prepare(
+			`SELECT id, source_id AS sourceId
+			 FROM memories
+			 WHERE idempotency_key = ? AND ${scoped.sql} AND is_deleted = 0
+			 LIMIT 1`,
+		)
+		.get(key, ...scoped.params) as RememberDedupeIdRow | undefined;
 }
 
 function getScopedIdempotencyDedupeRow(
@@ -656,7 +665,45 @@ export function registerMemoryRoutes(app: Hono): void {
 			const tags = hasBodyTags ? bodyTags : parsedPrefixes.tags;
 			const pipelineEnqueueEnabled = pipelineCfg.enabled;
 
-			const groupId = crypto.randomUUID();
+			const chunkPlans = chunks
+				.map((chunk, index) => {
+					const normalized = normalizeAndHashContent(chunk);
+					if (!normalized.storageContent) return null;
+					return {
+						chunk,
+						contentForInsert:
+							normalized.normalizedContent.length > 0 ? normalized.normalizedContent : normalized.hashBasis,
+						idempotencyKey: idempotencyKeyForChunk(rowProvenance.idempotencyKey, index),
+						memType: inferType(chunk),
+						normalized,
+					};
+				})
+				.filter((plan): plan is NonNullable<typeof plan> => plan !== null);
+			if (chunkPlans.length === 0) {
+				return c.json({ error: "content produced no valid chunks" }, 400);
+			}
+
+			const existingChunks = getDbAccessor().withReadDb((db) => {
+				const rows = new Map<number, RememberDedupeIdRow>();
+				for (let index = 0; index < chunkPlans.length; index += 1) {
+					const row = getScopedIdempotencyMemoryId(db, chunkPlans[index].idempotencyKey, dedupeScope);
+					if (row) rows.set(index, row);
+				}
+				return rows;
+			});
+			const existingGroupId = Array.from(existingChunks.values()).find((row) => row.sourceId)?.sourceId ?? null;
+			if (existingChunks.size === chunkPlans.length) {
+				const ids = chunkPlans.map((_, index) => existingChunks.get(index)?.id).filter((id): id is string => !!id);
+				return c.json({
+					chunked: true,
+					chunk_count: ids.length,
+					ids,
+					group_id: existingGroupId,
+					deduped: true,
+				});
+			}
+
+			const groupId = existingGroupId ?? crypto.randomUUID();
 			const now = new Date().toISOString();
 			const chunkIds: string[] = [];
 
@@ -664,7 +711,7 @@ export function registerMemoryRoutes(app: Hono): void {
 			try {
 				getDbAccessor().withWriteTx((db) => {
 					db.prepare(
-						`INSERT INTO entities
+						`INSERT OR IGNORE INTO entities
 						 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
 						 VALUES (?, ?, ?, 'chunk_group', ?, 0, ?, ?)`,
 					).run(groupId, `chunk-group:${groupId}`, `chunk-group:${groupId}`, agentId, now, now);
@@ -674,43 +721,38 @@ export function registerMemoryRoutes(app: Hono): void {
 				return c.json({ error: "Failed to create chunk group" }, 500);
 			}
 
-			for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex += 1) {
-				const chunk = chunks[chunkIndex];
-				const chunkNormalized = normalizeAndHashContent(chunk);
-				if (!chunkNormalized.storageContent) continue;
-
+			for (let chunkIndex = 0; chunkIndex < chunkPlans.length; chunkIndex += 1) {
+				const plan = chunkPlans[chunkIndex];
 				const chunkId = crypto.randomUUID();
-				const chunkIdempotencyKey = idempotencyKeyForChunk(rowProvenance.idempotencyKey, chunkIndex);
-				const chunkContentForInsert =
-					chunkNormalized.normalizedContent.length > 0 ? chunkNormalized.normalizedContent : chunkNormalized.hashBasis;
-				const memType = inferType(chunk);
 
 				try {
-					const inserted = getDbAccessor().withWriteTx((db) => {
-						if (getScopedIdempotencyMemoryId(db, chunkIdempotencyKey, dedupeScope)) return false;
+					const result = getDbAccessor().withWriteTx((db) => {
+						const byIdempotencyKey =
+							existingChunks.get(chunkIndex) ?? getScopedIdempotencyMemoryId(db, plan.idempotencyKey, dedupeScope);
+						if (byIdempotencyKey) return { id: byIdempotencyKey.id, inserted: false as const };
 
 						const byHash =
 							scope !== null
 								? (db
 										.prepare("SELECT id FROM memories WHERE content_hash = ? AND scope = ? AND is_deleted = 0 LIMIT 1")
-										.get(chunkNormalized.contentHash, scope) as { id: string } | undefined)
+										.get(plan.normalized.contentHash, scope) as { id: string } | undefined)
 								: (db
 										.prepare(
 											"SELECT id FROM memories WHERE content_hash = ? AND scope IS NULL AND is_deleted = 0 LIMIT 1",
 										)
-										.get(chunkNormalized.contentHash) as { id: string } | undefined);
-						if (byHash) return false;
+										.get(plan.normalized.contentHash) as { id: string } | undefined);
+						if (byHash) return { id: byHash.id, inserted: false as const };
 
 						txIngestEnvelope(db, {
 							id: chunkId,
-							content: chunkNormalized.storageContent,
-							normalizedContent: chunkContentForInsert,
-							contentHash: chunkNormalized.contentHash,
+							content: plan.normalized.storageContent,
+							normalizedContent: plan.contentForInsert,
+							contentHash: plan.normalized.contentHash,
 							who,
 							why: pinned ? "explicit-critical" : "explicit",
 							project,
 							importance,
-							type: memType,
+							type: plan.memType,
 							tags: tags ?? null,
 							pinned,
 							isDeleted: 0,
@@ -722,7 +764,7 @@ export function registerMemoryRoutes(app: Hono): void {
 							sourceId: groupId,
 							sourcePath: rowProvenance.sourcePath ?? null,
 							runtimePath: rowProvenance.runtimePath ?? null,
-							idempotencyKey: chunkIdempotencyKey ?? null,
+							idempotencyKey: plan.idempotencyKey ?? null,
 							scope,
 							agentId,
 							visibility,
@@ -736,38 +778,38 @@ export function registerMemoryRoutes(app: Hono): void {
 							 VALUES (?, ?, 'chunk', 1.0, ?)`,
 						).run(chunkId, groupId, now);
 
-						return true;
+						return { id: chunkId, inserted: true as const };
 					});
 
-					if (!inserted) continue;
-					chunkIds.push(chunkId);
+					chunkIds.push(result.id);
+					if (!result.inserted) continue;
 
 					// Generate embedding async
 					try {
-						const vec = await fetchEmbedding(chunkNormalized.storageContent, fullCfg.embedding);
+						const vec = await fetchEmbedding(plan.normalized.storageContent, fullCfg.embedding);
 						if (vec) {
 							if (vec.length !== fullCfg.embedding.dimensions) {
 								logger.warn("memory", "Embedding dimension mismatch, skipping vector insert", {
 									got: vec.length,
 									expected: fullCfg.embedding.dimensions,
-									memoryId: chunkId,
+									memoryId: result.id,
 								});
 							} else {
 								const embId = crypto.randomUUID();
 								const blob = vectorToBlob(vec);
-								const embHash = scope ? `${chunkNormalized.contentHash}:${scope}` : chunkNormalized.contentHash;
+								const embHash = scope ? `${plan.normalized.contentHash}:${scope}` : plan.normalized.contentHash;
 								getDbAccessor().withWriteTx((db) => {
-									syncVecDeleteBySourceId(db, "memory", chunkId);
-									db.prepare(`DELETE FROM embeddings WHERE source_type = 'memory' AND source_id = ?`).run(chunkId);
+									syncVecDeleteBySourceId(db, "memory", result.id);
+									db.prepare(`DELETE FROM embeddings WHERE source_type = 'memory' AND source_id = ?`).run(result.id);
 									db.prepare(`
 										INSERT INTO embeddings
 										  (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at)
 										VALUES (?, ?, ?, ?, 'memory', ?, ?, ?)
-									`).run(embId, embHash, blob, vec.length, chunkId, chunkNormalized.storageContent, now);
+									`).run(embId, embHash, blob, vec.length, result.id, plan.normalized.storageContent, now);
 									syncVecInsert(db, embId, vec);
 									db.prepare("UPDATE memories SET embedding_model = ? WHERE id = ?").run(
 										fullCfg.embedding.model,
-										chunkId,
+										result.id,
 									);
 								});
 							}
@@ -782,7 +824,7 @@ export function registerMemoryRoutes(app: Hono): void {
 					// Inline entity linking for chunk
 					try {
 						getDbAccessor().withWriteTx((db) => {
-							linkMemoryToEntities(db, chunkId, chunk, agentId);
+							linkMemoryToEntities(db, result.id, plan.chunk, agentId);
 						});
 					} catch {
 						// Non-fatal — pipeline extraction handles deeper linking
@@ -791,10 +833,10 @@ export function registerMemoryRoutes(app: Hono): void {
 					// Enqueue pipeline extraction if enabled
 					if (pipelineEnqueueEnabled) {
 						try {
-							queueExtractionJob(chunkId);
+							queueExtractionJob(result.id);
 						} catch (e) {
 							logger.warn("pipeline", "Failed to enqueue chunk extraction", {
-								chunkId,
+								chunkId: result.id,
 								error: String(e),
 							});
 						}

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -80,6 +80,38 @@ function parseOptionalIsoTimestamp(value: unknown): string | null {
 	return Number.isNaN(ts.getTime()) ? null : ts.toISOString();
 }
 
+interface RememberRowProvenance {
+	readonly sourcePath?: string;
+	readonly runtimePath?: string;
+	readonly idempotencyKey?: string;
+}
+
+function pickOptionalString(...values: readonly unknown[]): string | undefined {
+	for (const value of values) {
+		const parsed = parseOptionalString(value);
+		if (parsed) return parsed;
+	}
+	return undefined;
+}
+
+function parseRememberRowProvenance(body: Record<string, unknown>): RememberRowProvenance {
+	const metadata = toRecord(body.metadata) ?? {};
+	return {
+		sourcePath: pickOptionalString(body.sourcePath, body.source_path, body.source, metadata.sourcePath, metadata.source_path, metadata.source),
+		runtimePath: pickOptionalString(body.runtimePath, body.runtime_path, metadata.runtimePath, metadata.runtime_path),
+		idempotencyKey: pickOptionalString(
+			body.idempotencyKey,
+			body.idempotency_key,
+			metadata.idempotencyKey,
+			metadata.idempotency_key,
+		),
+	};
+}
+
+function idempotencyKeyForChunk(baseKey: string | undefined, index: number): string | undefined {
+	return baseKey ? `${baseKey}:chunk:${index + 1}` : undefined;
+}
+
 function hasMemoriesSessionIdColumn(db: any): boolean {
 	if (hasMemoriesSessionIdColumnCache !== null) {
 		return hasMemoriesSessionIdColumnCache;
@@ -475,6 +507,14 @@ export function registerMemoryRoutes(app: Hono): void {
 			scope?: string | null;
 			agentId?: string;
 			visibility?: "global" | "private" | "archived";
+			sourcePath?: string;
+			source_path?: string;
+			source?: string;
+			runtimePath?: string;
+			runtime_path?: string;
+			idempotencyKey?: string;
+			idempotency_key?: string;
+			metadata?: Record<string, unknown>;
 			hints?: string[];
 			transcript?: string;
 			structured?: {
@@ -515,6 +555,7 @@ export function registerMemoryRoutes(app: Hono): void {
 			return c.json({ error: "createdAt must be a valid ISO timestamp" }, 400);
 		}
 		const scope = body.scope ?? null;
+		const rowProvenance = parseRememberRowProvenance(body as Record<string, unknown>);
 		const agentId = resolveAgentId({ agentId: body.agentId, sessionKey: c.req.header("x-signet-session-key") });
 		const visibility = body.visibility === "private" ? "private" : "global";
 		const hasBodyTags = Object.prototype.hasOwnProperty.call(body, "tags");
@@ -566,17 +607,26 @@ export function registerMemoryRoutes(app: Hono): void {
 				return c.json({ error: "Failed to create chunk group" }, 500);
 			}
 
-			for (const chunk of chunks) {
+			for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex += 1) {
+				const chunk = chunks[chunkIndex];
 				const chunkNormalized = normalizeAndHashContent(chunk);
 				if (!chunkNormalized.storageContent) continue;
 
 				const chunkId = crypto.randomUUID();
+				const chunkIdempotencyKey = idempotencyKeyForChunk(rowProvenance.idempotencyKey, chunkIndex);
 				const chunkContentForInsert =
 					chunkNormalized.normalizedContent.length > 0 ? chunkNormalized.normalizedContent : chunkNormalized.hashBasis;
 				const memType = inferType(chunk);
 
 				try {
 					const inserted = getDbAccessor().withWriteTx((db) => {
+						const byIdempotencyKey = chunkIdempotencyKey
+							? (db
+									.prepare("SELECT id FROM memories WHERE idempotency_key = ? AND is_deleted = 0 LIMIT 1")
+									.get(chunkIdempotencyKey) as { id: string } | undefined)
+							: undefined;
+						if (byIdempotencyKey) return false;
+
 						const byHash =
 							scope !== null
 								? (db
@@ -608,6 +658,9 @@ export function registerMemoryRoutes(app: Hono): void {
 							updatedBy: who,
 							sourceType: "chunk",
 							sourceId: groupId,
+							sourcePath: rowProvenance.sourcePath ?? null,
+							runtimePath: rowProvenance.runtimePath ?? null,
+							idempotencyKey: chunkIdempotencyKey ?? null,
 							scope,
 							agentId,
 							visibility,
@@ -762,6 +815,16 @@ export function registerMemoryRoutes(app: Hono): void {
 					if (bySource) return { deduped: true as const, row: bySource };
 				}
 
+				if (rowProvenance.idempotencyKey) {
+					const byIdempotencyKey = db
+						.prepare(
+							`SELECT id, type, tags, pinned, importance, content
+					 FROM memories WHERE idempotency_key = ? AND is_deleted = 0 LIMIT 1`,
+						)
+						.get(rowProvenance.idempotencyKey) as DedupeRow | undefined;
+					if (byIdempotencyKey) return { deduped: true as const, row: byIdempotencyKey };
+				}
+
 				// Check content_hash dedupe (scope-aware)
 				const byHash = (
 					scope !== null
@@ -805,6 +868,9 @@ export function registerMemoryRoutes(app: Hono): void {
 					updatedBy: who,
 					sourceType,
 					sourceId,
+					sourcePath: rowProvenance.sourcePath ?? null,
+					runtimePath: rowProvenance.runtimePath ?? null,
+					idempotencyKey: rowProvenance.idempotencyKey ?? null,
 					scope,
 					agentId,
 					visibility,
@@ -828,16 +894,25 @@ export function registerMemoryRoutes(app: Hono): void {
 		} catch (e) {
 			const msg = e instanceof Error ? e.message : "";
 			if (msg.includes("UNIQUE constraint")) {
-				const existing = getDbAccessor().withReadDb(
-					(db) =>
-						db
+				const existing = getDbAccessor().withReadDb((db) => {
+					if (rowProvenance.idempotencyKey) {
+						const byIdempotencyKey = db
 							.prepare(
 								`SELECT id, type, tags, pinned, importance, content
 						 FROM memories
-						 WHERE content_hash = ? AND is_deleted = 0 LIMIT 1`,
+						 WHERE idempotency_key = ? AND is_deleted = 0 LIMIT 1`,
 							)
-							.get(contentHash) as DedupeRow | undefined,
-				);
+							.get(rowProvenance.idempotencyKey) as DedupeRow | undefined;
+						if (byIdempotencyKey) return byIdempotencyKey;
+					}
+					return db
+						.prepare(
+							`SELECT id, type, tags, pinned, importance, content
+						 FROM memories
+						 WHERE content_hash = ? AND is_deleted = 0 LIMIT 1`,
+						)
+						.get(contentHash) as DedupeRow | undefined;
+				});
 				if (existing) {
 					return c.json({
 						id: existing.id,

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -768,6 +768,13 @@ export function registerMemoryRoutes(app: Hono): void {
 				return c.json({ error: "content produced no valid chunks" }, 400);
 			}
 
+			const baseIdempotencyMemory = getDbAccessor().withReadDb((db) =>
+				getScopedIdempotencyMemoryId(db, rowProvenance.idempotencyKey, dedupeScope),
+			);
+			if (baseIdempotencyMemory) {
+				return c.json({ error: "idempotencyKey already used for non-chunk content" }, 409);
+			}
+
 			const existingChunks = getDbAccessor().withReadDb((db) =>
 				getScopedChunkIdempotencyRows(db, rowProvenance.idempotencyKey, dedupeScope),
 			);
@@ -972,6 +979,15 @@ export function registerMemoryRoutes(app: Hono): void {
 				: normalizedContent.hashBasis;
 		const contentHash = normalizedContent.contentHash;
 		const pipelineEnqueueEnabled = pipelineCfg.enabled;
+		const chunkedIdempotencyMemory =
+			rowProvenance.idempotencyKey === undefined
+				? []
+				: getDbAccessor().withReadDb((db) =>
+						getScopedChunkIdempotencyRows(db, rowProvenance.idempotencyKey, dedupeScope),
+					);
+		if (chunkedIdempotencyMemory.length > 0) {
+			return c.json({ error: "idempotencyKey already used for chunked content" }, 409);
+		}
 
 		type DedupeRow = RememberDedupeRow;
 

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -106,6 +106,11 @@ interface RememberDedupeIdRow {
 	readonly sourceId: string | null;
 }
 
+interface RememberChunkDedupeRow extends RememberDedupeIdRow {
+	readonly contentHash: string | null;
+	readonly idempotencyKey: string;
+}
+
 function pickOptionalString(...values: readonly unknown[]): string | undefined {
 	for (const value of values) {
 		const parsed = parseOptionalString(value);
@@ -137,6 +142,17 @@ function parseRememberRowProvenance(body: Record<string, unknown>): RememberRowP
 
 function idempotencyKeyForChunk(baseKey: string | undefined, index: number): string | undefined {
 	return baseKey ? `${baseKey}:chunk:${index + 1}` : undefined;
+}
+
+function escapeSqlLike(value: string): string {
+	return value.replace(/[\\%_]/g, "\\$&");
+}
+
+function chunkIdempotencyIndex(baseKey: string, key: string): number | null {
+	const prefix = `${baseKey}:chunk:`;
+	if (!key.startsWith(prefix)) return null;
+	const index = Number.parseInt(key.slice(prefix.length), 10);
+	return Number.isSafeInteger(index) && index > 0 ? index - 1 : null;
 }
 
 function scopedMemoryPredicate(input: RememberDedupeScope): {
@@ -185,6 +201,30 @@ function getScopedIdempotencyDedupeRow(
 			 LIMIT 1`,
 		)
 		.get(key, ...scoped.params) as RememberDedupeRow | undefined;
+}
+
+function getScopedChunkIdempotencyRows(
+	db: WriteDb,
+	baseKey: string | undefined,
+	input: RememberDedupeScope,
+): readonly RememberChunkDedupeRow[] {
+	if (!baseKey) return [];
+	const scoped = scopedMemoryPredicate(input);
+	return (
+		db
+			.prepare(
+				`SELECT id, source_id AS sourceId, content_hash AS contentHash, idempotency_key AS idempotencyKey
+				 FROM memories
+				 WHERE idempotency_key LIKE ? ESCAPE '\\' AND ${scoped.sql} AND is_deleted = 0`,
+			)
+			.all(`${escapeSqlLike(baseKey)}:chunk:%`, ...scoped.params) as RememberChunkDedupeRow[]
+	)
+		.filter((row) => chunkIdempotencyIndex(baseKey, row.idempotencyKey) !== null)
+		.sort((left, right) => {
+			const leftIndex = chunkIdempotencyIndex(baseKey, left.idempotencyKey);
+			const rightIndex = chunkIdempotencyIndex(baseKey, right.idempotencyKey);
+			return (leftIndex ?? 0) - (rightIndex ?? 0);
+		});
 }
 
 function hasMemoriesSessionIdColumn(db: any): boolean {
@@ -683,27 +723,32 @@ export function registerMemoryRoutes(app: Hono): void {
 				return c.json({ error: "content produced no valid chunks" }, 400);
 			}
 
-			const existingChunks = getDbAccessor().withReadDb((db) => {
-				const rows = new Map<number, RememberDedupeIdRow>();
-				for (let index = 0; index < chunkPlans.length; index += 1) {
-					const row = getScopedIdempotencyMemoryId(db, chunkPlans[index].idempotencyKey, dedupeScope);
-					if (row) rows.set(index, row);
+			const existingChunks = getDbAccessor().withReadDb((db) =>
+				getScopedChunkIdempotencyRows(db, rowProvenance.idempotencyKey, dedupeScope),
+			);
+			if (existingChunks.length > 0) {
+				const groupIds = new Set(existingChunks.map((row) => row.sourceId).filter((id): id is string => !!id));
+				const matchesExistingPlan =
+					groupIds.size === 1 &&
+					existingChunks.length === chunkPlans.length &&
+					existingChunks.every((row, index) => {
+						const plan = chunkPlans[index];
+						return row.idempotencyKey === plan.idempotencyKey && row.contentHash === plan.normalized.contentHash;
+					});
+				if (!matchesExistingPlan) {
+					return c.json({ error: "idempotencyKey already used for different chunked content" }, 409);
 				}
-				return rows;
-			});
-			const existingGroupId = Array.from(existingChunks.values()).find((row) => row.sourceId)?.sourceId ?? null;
-			if (existingChunks.size === chunkPlans.length) {
-				const ids = chunkPlans.map((_, index) => existingChunks.get(index)?.id).filter((id): id is string => !!id);
+
 				return c.json({
 					chunked: true,
-					chunk_count: ids.length,
-					ids,
-					group_id: existingGroupId,
+					chunk_count: existingChunks.length,
+					ids: existingChunks.map((row) => row.id),
+					group_id: Array.from(groupIds)[0],
 					deduped: true,
 				});
 			}
 
-			const groupId = existingGroupId ?? crypto.randomUUID();
+			const groupId = crypto.randomUUID();
 			const now = new Date().toISOString();
 			const chunkIds: string[] = [];
 
@@ -727,8 +772,7 @@ export function registerMemoryRoutes(app: Hono): void {
 
 				try {
 					const result = getDbAccessor().withWriteTx((db) => {
-						const byIdempotencyKey =
-							existingChunks.get(chunkIndex) ?? getScopedIdempotencyMemoryId(db, plan.idempotencyKey, dedupeScope);
+						const byIdempotencyKey = getScopedIdempotencyMemoryId(db, plan.idempotencyKey, dedupeScope);
 						if (byIdempotencyKey) return { id: byIdempotencyKey.id, inserted: false as const };
 
 						const byHash =

--- a/platform/daemon/src/transactions.ts
+++ b/platform/daemon/src/transactions.ts
@@ -32,6 +32,9 @@ export interface IngestEnvelope {
 	updatedBy?: string;
 	sourceType: string;
 	sourceId: string | null;
+	sourcePath?: string | null;
+	runtimePath?: string | null;
+	idempotencyKey?: string | null;
 	scope?: string | null;
 	agentId?: string;
 	visibility?: "global" | "private" | "archived";
@@ -218,8 +221,8 @@ export function txIngestEnvelope(db: WriteDb, mem: IngestEnvelope): string {
 		 (id, content, normalized_content, content_hash, who, why, project,
 		  importance, type, tags, pinned, is_deleted, extraction_status,
 		  embedding_model, extraction_model, created_at, updated_at, updated_by,
-		  source_type, source_id, scope, agent_id, visibility)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		  source_type, source_id, source_path, runtime_path, idempotency_key, scope, agent_id, visibility)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 	).run(
 		mem.id,
 		mem.content,
@@ -241,6 +244,9 @@ export function txIngestEnvelope(db: WriteDb, mem: IngestEnvelope): string {
 		mem.updatedBy ?? mem.who,
 		mem.sourceType,
 		mem.sourceId,
+		mem.sourcePath ?? null,
+		mem.runtimePath ?? null,
+		mem.idempotencyKey ?? null,
 		mem.scope ?? null,
 		mem.agentId ?? "default",
 		mem.visibility ?? "global",


### PR DESCRIPTION
## Summary
- Add row-level provenance handling to `/api/memory/remember` for `sourcePath`/`source_path`, `runtimePath`/`runtime_path`, and `idempotencyKey`/`idempotency_key`.
- Persist the provenance fields through the live daemon write path as first-class memory row columns via `txIngestEnvelope`.
- Use `idempotency_key` for remember dedupe before content-hash dedupe, including stable per-chunk keys.
- Expose `sourcePath` through the shared core recall helper and SDK remember payload types.
- Update `docs/API.md` to document the provenance request fields and idempotency-key dedupe behavior.

## Changed files
- `docs/API.md`
- `libs/sdk/src/index.ts`
- `platform/core/src/recall.ts`
- `platform/core/src/recall.test.ts`
- `platform/daemon/src/routes/memory-routes.ts`
- `platform/daemon/src/transactions.ts`
- `platform/daemon/src/mutation-api.test.ts`

## Test plan
- `cd platform/daemon && bun test src/mutation-api.test.ts` — PASS, 20/20 tests.
- `cd platform/core && bun test src/recall.test.ts` — PASS, 4/4 tests.
- `cd libs/sdk && bun run build` — PASS.
- `cd platform/core && bun run build` — PASS.
- `cd platform/daemon && bun run build` — PASS; existing Svelte a11y/deprecation warnings were emitted by dashboard files outside this change.

## Soul Vessel M10 note
The regression test `POST /api/memory/remember persists row-level provenance from metadata` demonstrates the live daemon remember path now persists `source_path`, `runtime_path`, and `idempotency_key` and dedupes retries by `idempotency_key`; this test failed before the fix when metadata-supplied row provenance was not stored.

The Soul Vessel opt-in live diagnostic from PR #26 was not rerun during this PR-packaging pass. M10 should be unblocked after this upstream fix is reviewed/merged and the disposable live diagnostic is rerun green; until Seer review and that final diagnostic, M10 remains gated.

No production Signet DB/workspace, live Hermes profile, or Soul Vessel `SPEC.md` was touched.
