### PR TITLE
fix(memory): expose row provenance on read

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -882,7 +882,14 @@ Requires `recall` permission.
   "tags": "preference,editor",
   "pinned": 0,
   "who": "claude-code",
+  "source_id": "optional-external-id",
   "source_type": "manual",
+  "source_path": "/absolute/or/original/source.md",
+  "runtime_path": "memory/MEMORY.md",
+  "idempotency_key": "stable-import-key",
+  "sourcePath": "/absolute/or/original/source.md",
+  "runtimePath": "memory/MEMORY.md",
+  "idempotencyKey": "stable-import-key",
   "project": null,
   "session_id": null,
   "confidence": null,
@@ -898,6 +905,10 @@ Requires `recall` permission.
   "updated_by": "operator"
 }
 ```
+
+`sourcePath`, `runtimePath`, and `idempotencyKey` are camelCase aliases for
+`source_path`, `runtime_path`, and `idempotency_key` so import provenance written
+through `POST /api/memory/remember` is visible on direct reads.
 
 ### GET /api/memory/:id/history
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -868,6 +868,11 @@ compatibility. Requires `remember` permission.
 
 Get a single memory by ID. Returns deleted memories only if the query
 explicitly requests them; by default, soft-deleted records return `404`.
+Direct reads are filtered through the same resolved agent read policy used by
+recall/search. Pass `agentId`/`agent_id`, `x-signet-agent-id`, or an
+`x-signet-session-key` that resolves to an agent when reading non-default
+agent memories; cross-agent or private memories outside that read scope return
+`404` without provenance fields.
 
 Requires `recall` permission.
 

--- a/libs/sdk/src/types.ts
+++ b/libs/sdk/src/types.ts
@@ -9,7 +9,14 @@ export interface MemoryRecord {
 	readonly tags: string | null;
 	readonly pinned: boolean;
 	readonly who: string | null;
+	readonly source_id: string | null;
 	readonly source_type: string | null;
+	readonly source_path: string | null;
+	readonly runtime_path: string | null;
+	readonly idempotency_key: string | null;
+	readonly sourcePath: string | null;
+	readonly runtimePath: string | null;
+	readonly idempotencyKey: string | null;
 	readonly project: string | null;
 	readonly session_id: string | null;
 	readonly confidence: number;

--- a/platform/core/src/database.test.ts
+++ b/platform/core/src/database.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "./database";
+
+describe("Database memory CRUD", () => {
+	let dir: string | null = null;
+	let db: Database | null = null;
+
+	afterEach(() => {
+		db?.close();
+		db = null;
+		if (dir) rmSync(dir, { force: true, recursive: true });
+		dir = null;
+	});
+
+	it("addMemory persists row provenance fields accepted by the Memory input shape", async () => {
+		dir = mkdtempSync(join(tmpdir(), "signet-core-db-"));
+		db = new Database(join(dir, "memories.db"));
+		await db.init();
+
+		const id = db.addMemory({
+			type: "fact",
+			content: "Database addMemory keeps row provenance.",
+			confidence: 0.94,
+			sourceId: "core-db-provenance-source",
+			sourceType: "manual",
+			sourcePath: "/tmp/signet-core/source.md",
+			runtimePath: "memory/source.md",
+			idempotencyKey: "core-db-provenance-key",
+			tags: ["core", "provenance"],
+			updatedBy: "database.test",
+			vectorClock: {},
+			manualOverride: false,
+		});
+
+		expect(db.getMemoryById(id)).toMatchObject({
+			id,
+			sourceId: "core-db-provenance-source",
+			sourceType: "manual",
+			sourcePath: "/tmp/signet-core/source.md",
+			runtimePath: "memory/source.md",
+			idempotencyKey: "core-db-provenance-key",
+		});
+	});
+});

--- a/platform/core/src/database.ts
+++ b/platform/core/src/database.ts
@@ -257,9 +257,10 @@ export class Database {
 			.prepare(
 				`INSERT INTO memories
 				 (id, type, category, content, confidence, source_id,
-				  source_type, tags, created_at, updated_at, updated_by,
-				  vector_clock, manual_override)
-				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				  source_type, source_path, runtime_path, idempotency_key,
+				  tags, created_at, updated_at, updated_by, vector_clock,
+				  manual_override)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			)
 			.run(
 				id,
@@ -269,6 +270,9 @@ export class Database {
 				memory.confidence,
 				memory.sourceId ?? null,
 				memory.sourceType ?? null,
+				memory.sourcePath ?? null,
+				memory.runtimePath ?? null,
+				memory.idempotencyKey ?? null,
 				JSON.stringify(memory.tags),
 				now,
 				now,
@@ -312,6 +316,11 @@ export class Database {
 			extractionStatus: "extraction_status",
 			embeddingModel: "embedding_model",
 			extractionModel: "extraction_model",
+			sourceId: "source_id",
+			sourceType: "source_type",
+			sourcePath: "source_path",
+			runtimePath: "runtime_path",
+			idempotencyKey: "idempotency_key",
 			who: "who",
 		};
 

--- a/platform/core/src/database.ts
+++ b/platform/core/src/database.ts
@@ -3,13 +3,13 @@
  * Runtime-detecting: uses bun:sqlite under Bun, better-sqlite3 under Node.js
  */
 
-import { existsSync, readdirSync } from "fs";
-import { join, dirname } from "path";
-import { fileURLToPath } from "url";
-import { homedir } from "os";
-import { arch, platform } from "process";
+import { existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { arch, platform } from "node:process";
+import { fileURLToPath } from "node:url";
 import { runMigrations } from "./migrations/index";
-import type { Memory, Conversation, Embedding } from "./types";
+import type { Conversation, Embedding, Memory } from "./types";
 import type { MemoryHistory, MemoryJob } from "./types";
 
 // Compute __dirname at runtime so bun's bundler doesn't bake in a static path
@@ -42,7 +42,7 @@ function findSqliteVecExtension(): string | null {
 
 	// Try `npm root -g` to find the actual global prefix (works regardless of runtime)
 	try {
-		const { execFileSync } = require("child_process");
+		const { execFileSync } = require("node:child_process");
 		const npmRoot = (execFileSync("npm", ["root", "-g"], { encoding: "utf8", timeout: 3000 }) as string).trim();
 		if (npmRoot) {
 			const direct = join(npmRoot, platformPkg, extFile);
@@ -187,7 +187,7 @@ export class Database {
 	private dbPath: string;
 	private db: SQLiteDatabase | null = null;
 	private options?: { readonly?: boolean };
-	private vecEnabled: boolean = false;
+	private vecEnabled = false;
 
 	constructor(dbPath: string, options?: { readonly?: boolean }) {
 		this.dbPath = dbPath;
@@ -203,16 +203,19 @@ export class Database {
 			const bunOpts = this.options?.readonly ? { readonly: true } : { readwrite: true, create: true };
 			this.db = new BunDatabase(this.dbPath, bunOpts) as unknown as SQLiteDatabase;
 		} else {
-			let BetterSqlite3;
+			let BetterSqlite3: new (path: string, options?: { readonly?: boolean }) => SQLiteDatabase;
 			try {
-				BetterSqlite3 = (await import("better-sqlite3")).default;
+				BetterSqlite3 = (await import("better-sqlite3")).default as new (
+					path: string,
+					options?: { readonly?: boolean },
+				) => SQLiteDatabase;
 			} catch {
 				throw new Error(
-					"Signet requires Bun (recommended) or the better-sqlite3 npm package. " +
-						(platform === "win32"
+					`Signet requires Bun (recommended) or the better-sqlite3 npm package. ${
+						platform === "win32"
 							? 'Install Bun: powershell -c "irm bun.sh/install.ps1 | iex"\n'
-							: "Install Bun: curl -fsSL https://bun.sh/install | bash\n") +
-						"Or install better-sqlite3: npm install -g better-sqlite3",
+							: "Install Bun: curl -fsSL https://bun.sh/install | bash\n"
+					}Or install better-sqlite3: npm install -g better-sqlite3`,
 				);
 			}
 			this.db = new BetterSqlite3(this.dbPath, {
@@ -568,6 +571,9 @@ function rowToMemory(row: Record<string, unknown>): Memory {
 		confidence: row.confidence as number,
 		sourceId: row.source_id as string | undefined,
 		sourceType: row.source_type as string | undefined,
+		sourcePath: row.source_path as string | undefined,
+		runtimePath: row.runtime_path as string | undefined,
+		idempotencyKey: row.idempotency_key as string | undefined,
 		tags: safeJsonParse(row.tags, []) as string[],
 		createdAt: row.created_at as string,
 		updatedAt: row.updated_at as string,

--- a/platform/core/src/types.ts
+++ b/platform/core/src/types.ts
@@ -554,6 +554,9 @@ export interface Memory {
 	confidence: number;
 	sourceId?: string;
 	sourceType?: string;
+	sourcePath?: string;
+	runtimePath?: string;
+	idempotencyKey?: string;
 	tags: string[];
 	createdAt: string;
 	updatedAt: string;

--- a/platform/daemon/src/mutation-api.test.ts
+++ b/platform/daemon/src/mutation-api.test.ts
@@ -617,6 +617,47 @@ memory:
 		});
 	});
 
+	it("GET /api/memory/:id applies agent scope before returning provenance", async () => {
+		const res = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: "Private scoped provenance memory",
+				agentId: "direct-read-agent-a",
+				visibility: "private",
+				who: "soulvessel.tests",
+				sourceType: "hermes-memory",
+				sourceId: "hermes-doc-private-provenance-test",
+				sourcePath: "/tmp/signet-provenance/private.md",
+				runtimePath: "memories/private.md",
+				idempotencyKey: "hermes:private-provenance-test",
+			}),
+		});
+		const remembered = (await res.json()) as { id?: string };
+
+		expect(res.status).toBe(200);
+		expect(remembered.id).toBeString();
+
+		const crossAgent = await app.request(`http://localhost/api/memory/${remembered.id}?agentId=direct-read-agent-b`);
+		const crossAgentJson = (await crossAgent.json()) as { error?: string; source_path?: string | null };
+		expect(crossAgent.status).toBe(404);
+		expect(crossAgentJson.error).toBe("not found");
+		expect(crossAgentJson.source_path).toBeUndefined();
+
+		const sameAgent = await app.request(`http://localhost/api/memory/${remembered.id}?agentId=direct-read-agent-a`);
+		const sameAgentJson = (await sameAgent.json()) as {
+			id?: string;
+			source_path?: string | null;
+			idempotency_key?: string | null;
+		};
+		expect(sameAgent.status).toBe(200);
+		expect(sameAgentJson).toMatchObject({
+			id: remembered.id,
+			source_path: "/tmp/signet-provenance/private.md",
+			idempotency_key: "hermes:private-provenance-test",
+		});
+	});
+
 	it("POST /api/memory/remember persists structured graph data under the requested agent", async () => {
 		const res = await app.request("http://localhost/api/memory/remember", {
 			method: "POST",

--- a/platform/daemon/src/mutation-api.test.ts
+++ b/platform/daemon/src/mutation-api.test.ts
@@ -571,6 +571,52 @@ memory:
 		expect(partial.group).toBeNull();
 	});
 
+	it("GET /api/memory/:id returns row-level provenance for remembered rows", async () => {
+		const res = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: "HTTP-visible provenance memory",
+				who: "soulvessel.tests",
+				sourceType: "hermes-memory",
+				sourceId: "hermes-doc-http-provenance-test",
+				sourcePath: "/tmp/signet-provenance/HTTP.md",
+				runtimePath: "memories/HTTP.md",
+				idempotencyKey: "hermes:http-provenance-test",
+			}),
+		});
+		const remembered = (await res.json()) as { id?: string };
+
+		expect(res.status).toBe(200);
+		expect(remembered.id).toBeString();
+
+		const read = await app.request(`http://localhost/api/memory/${remembered.id}`);
+		const json = (await read.json()) as {
+			id?: string;
+			source_id?: string | null;
+			source_type?: string | null;
+			source_path?: string | null;
+			runtime_path?: string | null;
+			idempotency_key?: string | null;
+			sourcePath?: string | null;
+			runtimePath?: string | null;
+			idempotencyKey?: string | null;
+		};
+
+		expect(read.status).toBe(200);
+		expect(json).toMatchObject({
+			id: remembered.id,
+			source_type: "hermes-memory",
+			source_id: "hermes-doc-http-provenance-test",
+			source_path: "/tmp/signet-provenance/HTTP.md",
+			runtime_path: "memories/HTTP.md",
+			idempotency_key: "hermes:http-provenance-test",
+			sourcePath: "/tmp/signet-provenance/HTTP.md",
+			runtimePath: "memories/HTTP.md",
+			idempotencyKey: "hermes:http-provenance-test",
+		});
+	});
+
 	it("POST /api/memory/remember persists structured graph data under the requested agent", async () => {
 		const res = await app.request("http://localhost/api/memory/remember", {
 			method: "POST",

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -1413,7 +1413,8 @@ export function registerMemoryRoutes(app: Hono): void {
 			return db
 				.prepare(
 					`SELECT id, content, type, importance, tags, pinned, who,
-					        source_id, source_type, project, ${sessionSelect} confidence,
+					        source_id, source_type, source_path, runtime_path,
+					        idempotency_key, project, ${sessionSelect} confidence,
 					        access_count, last_accessed, is_deleted, deleted_at,
 					        extraction_status, embedding_model, version,
 					        created_at, updated_at, updated_by
@@ -1437,6 +1438,9 @@ export function registerMemoryRoutes(app: Hono): void {
 
 		return c.json({
 			...row,
+			sourcePath: row.source_path,
+			runtimePath: row.runtime_path,
+			idempotencyKey: row.idempotency_key,
 			sessionId,
 		});
 	});

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -11,7 +11,7 @@ import { buildEmbeddingHealth } from "../embedding-health";
 import { linkMemoryToEntities } from "../inline-entity-linker";
 import { logger } from "../logger";
 import { loadMemoryConfig } from "../memory-config";
-import { type RecallParams, hybridRecall } from "../memory-search";
+import { type RecallParams, buildAgentScopeClause, hybridRecall } from "../memory-search";
 import { recordMemorySearchTelemetry } from "../memory-search-telemetry";
 import { resolveMemorySearchTelemetryProject } from "../memory-search-telemetry-project";
 import { buildMemoryTimeline } from "../memory-timeline";
@@ -1407,20 +1407,33 @@ export function registerMemoryRoutes(app: Hono): void {
 			return c.json({ error: "memory id is required" }, 400);
 		}
 
+		const sessionKeyRaw = c.req.header("x-signet-session-key");
+		const agentId = resolveAgentId({
+			agentId: c.req.query("agentId") ?? c.req.query("agent_id") ?? c.req.header("x-signet-agent-id"),
+			sessionKey: sessionKeyRaw,
+		});
+		const agentScope = getAgentScope(agentId);
+		const access = buildAgentScopeClause(agentId, agentScope.readPolicy, agentScope.policyGroup);
+		const scopeProject = c.get("auth")?.claims?.scope?.project;
+		const projectSql = scopeProject ? " AND m.project = ?" : "";
 		const row = getDbAccessor().withReadDb((db) => {
-			const sessionSelect = hasMemoriesSessionIdColumn(db) ? "session_id," : "NULL AS session_id,";
+			const sessionSelect = hasMemoriesSessionIdColumn(db) ? "m.session_id," : "NULL AS session_id,";
 
 			return db
 				.prepare(
-					`SELECT id, content, type, importance, tags, pinned, who,
-					        source_id, source_type, source_path, runtime_path,
-					        idempotency_key, project, ${sessionSelect} confidence,
-					        access_count, last_accessed, is_deleted, deleted_at,
-					        extraction_status, embedding_model, version,
-					        created_at, updated_at, updated_by
-					 FROM memories WHERE id = ? AND (is_deleted = 0 OR is_deleted IS NULL)`,
+					`SELECT m.id, m.content, m.type, m.importance, m.tags, m.pinned, m.who,
+					        m.source_id, m.source_type, m.source_path, m.runtime_path,
+					        m.idempotency_key, m.project, ${sessionSelect} m.confidence,
+					        m.access_count, m.last_accessed, m.is_deleted, m.deleted_at,
+					        m.extraction_status, m.embedding_model, m.version,
+					        m.created_at, m.updated_at, m.updated_by
+					 FROM memories m
+					 WHERE m.id = ?
+					   AND (m.is_deleted = 0 OR m.is_deleted IS NULL)
+					   ${access.sql}
+					   ${projectSql}`,
 				)
-				.get(memoryId) as Record<string, unknown> | undefined;
+				.get(memoryId, ...access.args, ...(scopeProject ? [scopeProject] : [])) as Record<string, unknown> | undefined;
 		});
 
 		if (!row) {


### PR DESCRIPTION
## Summary
- Extends `GET /api/memory/:id` to return row-level provenance columns: `source_path`, `runtime_path`, and `idempotency_key`.
- Adds camelCase read aliases (`sourcePath`, `runtimePath`, `idempotencyKey`) for callers that wrote provenance through the remember API.
- Updates daemon regression coverage, core/SDK types, and API docs for the read response shape.

## Changes
- `platform/daemon/src/routes/memory-routes.ts`: selects and serializes provenance fields on memory reads.
- `platform/daemon/src/mutation-api.test.ts`: covers read-after-remember provenance visibility.
- `platform/core/src/database.ts` and `platform/core/src/types.ts`: include provenance in memory row types.
- `libs/sdk/src/types.ts`: exposes provenance fields in SDK response types.
- `docs/API.md`: documents the read response fields.

## Type
- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected
- [x] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [x] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots
N/A; no UI changes.

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)
No migration files are touched by this PR after #733 merged.

- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Rollback / compatibility note: this PR only exposes fields that now exist on the persisted memory rows after #733. Reverting this PR removes the read/API/type exposure without changing schema or stored data.

## Testing
- [x] `bun test` passes
- [ ] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Validation run after restacking on merged #733:
- `bun test platform/daemon/src/mutation-api.test.ts` — 29 pass
- `cd libs/sdk && bun run build` — pass
- `bunx biome check docs/API.md libs/sdk/src/types.ts platform/core/src/database.ts platform/core/src/types.ts platform/daemon/src/routes/memory-routes.ts platform/daemon/src/mutation-api.test.ts` — pass with existing `noExplicitAny` warnings in `memory-routes.ts`

## AI disclosure
- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes
#733 has merged. This branch is now restacked on current `origin/main` and includes the read-side provenance exposure plus direct-read scope hardening from review feedback.



## Latest review follow-up
Addressed the latest review feedback on direct memory reads.

Current head: `b2598fb21`

Changes:
- `GET /api/memory/:id` now resolves the caller agent from `agentId`/`agent_id`, `x-signet-agent-id`, or `x-signet-session-key`.
- Direct reads now apply the same `buildAgentScopeClause` filtering used by recall/search, plus auth project scope when present.
- Cross-agent/private reads now return `404` before any provenance fields are returned.
- Added a regression covering a private memory with provenance: another agent gets `404` and no `source_path`, while the owning agent can read the provenance.

Validation after rebasing onto `origin/main` `f8f81156c`:
- `bun test platform/daemon/src/mutation-api.test.ts` — 29 pass
- `cd libs/sdk && bun run build` — pass
- `bunx biome check docs/API.md libs/sdk/src/types.ts platform/core/src/database.ts platform/core/src/types.ts platform/daemon/src/routes/memory-routes.ts platform/daemon/src/mutation-api.test.ts` — pass with existing `noExplicitAny` warnings in `memory-routes.ts`

## Latest core API review follow-up
Addressed the latest core API review feedback.

Current head: `f8d876f68`

Changes:
- `Database.addMemory(...)` now persists `sourcePath`, `runtimePath`, and `idempotencyKey` instead of accepting and dropping them.
- `Database.updateMemory(...)` now maps those provenance fields as well, keeping the `Partial<Memory>` write surface consistent.
- Added `platform/core/src/database.test.ts` to cover provenance round-trip via `addMemory` and `getMemoryById`.

Validation:
- `bun test platform/core/src/database.test.ts` — 1 pass
- `bun test platform/daemon/src/mutation-api.test.ts` — 29 pass
- `cd libs/sdk && bun run build` — pass
- `bunx biome check docs/API.md libs/sdk/src/types.ts platform/core/src/database.ts platform/core/src/database.test.ts platform/core/src/types.ts platform/daemon/src/routes/memory-routes.ts platform/daemon/src/mutation-api.test.ts` — pass with existing `noExplicitAny` warnings in `memory-routes.ts`
