### PR TITLE
fix(dashboard): preserve constellation pointer input

### DIFF
--- a/surfaces/dashboard/src/lib/components/ontology/ConstellationGraph.svelte
+++ b/surfaces/dashboard/src/lib/components/ontology/ConstellationGraph.svelte
@@ -1401,6 +1401,7 @@ onMount(() => {
 
 <style>
 	.knowledge-map-zone {
+		-webkit-app-region: no-drag;
 		position: relative;
 		height: 100%;
 		min-height: 0;
@@ -1431,6 +1432,7 @@ onMount(() => {
 	}
 
 	.graph-canvas {
+		-webkit-app-region: no-drag;
 		position: absolute;
 		inset: 0;
 		z-index: 1;
@@ -1469,6 +1471,7 @@ onMount(() => {
 	}
 
 	.map-controls {
+		-webkit-app-region: no-drag;
 		position: absolute;
 		left: 24px;
 		bottom: 24px;
@@ -1687,6 +1690,7 @@ onMount(() => {
 	}
 
 	.node-popover {
+		-webkit-app-region: no-drag;
 		position: absolute;
 		z-index: 8;
 		display: flex;

--- a/surfaces/dashboard/src/lib/components/ontology/canvas/input-handler.test.ts
+++ b/surfaces/dashboard/src/lib/components/ontology/canvas/input-handler.test.ts
@@ -1,0 +1,153 @@
+// @ts-nocheck
+import { describe, expect, test } from "bun:test";
+import { SpatialIndex } from "./hit-test";
+import { GraphInputHandler } from "./input-handler";
+import type { GraphCanvasNode } from "./types";
+import { ViewportState } from "./viewport";
+
+type Listener = (event: EventLike) => void;
+
+interface EventLike {
+	readonly clientX: number;
+	readonly clientY: number;
+	readonly button?: number;
+	readonly pointerId?: number;
+	readonly isPrimary?: boolean;
+	preventDefault?: () => void;
+}
+
+class FakeCanvas {
+	readonly style: { cursor: string } = { cursor: "" };
+	readonly captured = new Set<number>();
+	readonly released = new Set<number>();
+	private readonly listeners = new Map<string, Set<Listener>>();
+
+	constructor(pointerEvents = false) {
+		if (pointerEvents) {
+			Object.defineProperty(this, "onpointerdown", { value: null, configurable: true });
+		}
+	}
+
+	addEventListener(name: string, listener: Listener): void {
+		const listeners = this.listeners.get(name) ?? new Set<Listener>();
+		listeners.add(listener);
+		this.listeners.set(name, listeners);
+	}
+
+	removeEventListener(name: string, listener: Listener): void {
+		this.listeners.get(name)?.delete(listener);
+	}
+
+	getBoundingClientRect(): { left: number; top: number } {
+		return { left: 0, top: 0 };
+	}
+
+	setPointerCapture(pointerId: number): void {
+		this.captured.add(pointerId);
+	}
+
+	hasPointerCapture(pointerId: number): boolean {
+		return this.captured.has(pointerId) && !this.released.has(pointerId);
+	}
+
+	releasePointerCapture(pointerId: number): void {
+		this.released.add(pointerId);
+	}
+
+	fire(name: string, event: EventLike): void {
+		for (const listener of this.listeners.get(name) ?? []) {
+			listener(event);
+		}
+	}
+
+	hasListener(name: string): boolean {
+		return (this.listeners.get(name)?.size ?? 0) > 0;
+	}
+}
+
+function node(overrides: Partial<GraphCanvasNode> = {}): GraphCanvasNode {
+	return {
+		id: "entity-1",
+		kind: "entity",
+		label: "Entity",
+		x: 0,
+		y: 0,
+		size: 30,
+		color: "#fff",
+		dimColor: "#444",
+		...overrides,
+	};
+}
+
+function setup(pointerEvents: boolean): {
+	canvas: FakeCanvas;
+	target: GraphCanvasNode;
+	handler: GraphInputHandler;
+	dragStarts: GraphCanvasNode[];
+	dragEnds: GraphCanvasNode[];
+} {
+	const canvas = new FakeCanvas(pointerEvents);
+	const target = node();
+	const spatial = new SpatialIndex();
+	spatial.rebuild([target]);
+	const dragStarts: GraphCanvasNode[] = [];
+	const dragEnds: GraphCanvasNode[] = [];
+	const handler = new GraphInputHandler(canvas as unknown as HTMLCanvasElement, new ViewportState(0, 0, 1), spatial, {
+		onNodeHover: () => undefined,
+		onNodeClick: () => undefined,
+		onNodeDragStart: (item) => dragStarts.push(item),
+		onNodeDragEnd: (item) => dragEnds.push(item),
+		onNodeDoubleClick: () => undefined,
+		onRequestRender: () => undefined,
+	});
+	return { canvas, target, handler, dragStarts, dragEnds };
+}
+
+describe("GraphInputHandler", () => {
+	test("captures pointer drags so Electron canvas interaction survives frame-shell pointer routing", () => {
+		const { canvas, target, handler, dragStarts, dragEnds } = setup(true);
+
+		expect(canvas.hasListener("pointerdown")).toBe(true);
+		expect(canvas.hasListener("mousedown")).toBe(false);
+
+		canvas.fire("pointerdown", {
+			clientX: 0,
+			clientY: 0,
+			button: 0,
+			pointerId: 7,
+			isPrimary: true,
+			preventDefault: () => undefined,
+		});
+		canvas.fire("pointermove", { clientX: 20, clientY: 12, pointerId: 7, isPrimary: true });
+		canvas.fire("pointerup", { clientX: 20, clientY: 12, pointerId: 7, isPrimary: true });
+
+		expect(canvas.captured.has(7)).toBe(true);
+		expect(canvas.released.has(7)).toBe(true);
+		expect(target.x).toBe(20);
+		expect(target.y).toBe(12);
+		expect(target.fx).toBeNull();
+		expect(target.fy).toBeNull();
+		expect(dragStarts.map((item) => item.id)).toEqual(["entity-1"]);
+		expect(dragEnds.map((item) => item.id)).toEqual(["entity-1"]);
+
+		handler.destroy();
+	});
+
+	test("keeps the mouse fallback for non-pointer browsers", () => {
+		const { canvas, target, handler, dragStarts, dragEnds } = setup(false);
+
+		expect(canvas.hasListener("pointerdown")).toBe(false);
+		expect(canvas.hasListener("mousedown")).toBe(true);
+
+		canvas.fire("mousedown", { clientX: 0, clientY: 0, button: 0 });
+		canvas.fire("mousemove", { clientX: 8, clientY: 9 });
+		canvas.fire("mouseup", { clientX: 8, clientY: 9 });
+
+		expect(target.x).toBe(8);
+		expect(target.y).toBe(9);
+		expect(dragStarts.map((item) => item.id)).toEqual(["entity-1"]);
+		expect(dragEnds.map((item) => item.id)).toEqual(["entity-1"]);
+
+		handler.destroy();
+	});
+});

--- a/surfaces/dashboard/src/lib/components/ontology/canvas/input-handler.ts
+++ b/surfaces/dashboard/src/lib/components/ontology/canvas/input-handler.ts
@@ -17,9 +17,16 @@ export class GraphInputHandler {
 	private didDrag = false;
 	private lastX = 0;
 	private lastY = 0;
+	private activePointerId: number | null = null;
 	private currentHoverId: string | null = null;
 	private posHistory: Array<{ x: number; y: number; t: number }> = [];
 
+	private readonly pointerEventsSupported: boolean;
+	private readonly pointerDown = this.onPointerDown.bind(this);
+	private readonly pointerMove = this.onPointerMove.bind(this);
+	private readonly pointerUp = this.onPointerUp.bind(this);
+	private readonly pointerCancel = this.onPointerCancel.bind(this);
+	private readonly lostPointerCapture = this.onLostPointerCapture.bind(this);
 	private readonly mouseDown = this.onMouseDown.bind(this);
 	private readonly mouseMove = this.onMouseMove.bind(this);
 	private readonly mouseUp = this.onMouseUp.bind(this);
@@ -33,20 +40,37 @@ export class GraphInputHandler {
 		private readonly spatial: SpatialIndex,
 		private readonly callbacks: InputCallbacks,
 	) {
-		canvas.addEventListener("mousedown", this.mouseDown);
-		canvas.addEventListener("mousemove", this.mouseMove);
-		canvas.addEventListener("mouseup", this.mouseUp);
-		canvas.addEventListener("mouseleave", this.mouseUp);
+		this.pointerEventsSupported = "onpointerdown" in canvas;
+		if (this.pointerEventsSupported) {
+			canvas.addEventListener("pointerdown", this.pointerDown);
+			canvas.addEventListener("pointermove", this.pointerMove);
+			canvas.addEventListener("pointerup", this.pointerUp);
+			canvas.addEventListener("pointercancel", this.pointerCancel);
+			canvas.addEventListener("lostpointercapture", this.lostPointerCapture);
+		} else {
+			canvas.addEventListener("mousedown", this.mouseDown);
+			canvas.addEventListener("mousemove", this.mouseMove);
+			canvas.addEventListener("mouseup", this.mouseUp);
+			canvas.addEventListener("mouseleave", this.mouseUp);
+		}
 		canvas.addEventListener("click", this.click);
 		canvas.addEventListener("dblclick", this.doubleClick);
 		canvas.addEventListener("wheel", this.wheel, { passive: false });
 	}
 
 	destroy(): void {
-		this.canvas.removeEventListener("mousedown", this.mouseDown);
-		this.canvas.removeEventListener("mousemove", this.mouseMove);
-		this.canvas.removeEventListener("mouseup", this.mouseUp);
-		this.canvas.removeEventListener("mouseleave", this.mouseUp);
+		if (this.pointerEventsSupported) {
+			this.canvas.removeEventListener("pointerdown", this.pointerDown);
+			this.canvas.removeEventListener("pointermove", this.pointerMove);
+			this.canvas.removeEventListener("pointerup", this.pointerUp);
+			this.canvas.removeEventListener("pointercancel", this.pointerCancel);
+			this.canvas.removeEventListener("lostpointercapture", this.lostPointerCapture);
+		} else {
+			this.canvas.removeEventListener("mousedown", this.mouseDown);
+			this.canvas.removeEventListener("mousemove", this.mouseMove);
+			this.canvas.removeEventListener("mouseup", this.mouseUp);
+			this.canvas.removeEventListener("mouseleave", this.mouseUp);
+		}
 		this.canvas.removeEventListener("click", this.click);
 		this.canvas.removeEventListener("dblclick", this.doubleClick);
 		this.canvas.removeEventListener("wheel", this.wheel);
@@ -66,7 +90,7 @@ export class GraphInputHandler {
 		return this.spatial.queryPoint(world.x, world.y);
 	}
 
-	private onMouseDown(e: MouseEvent): void {
+	private beginInteraction(e: MouseEvent | PointerEvent): void {
 		const point = this.canvasPoint(e);
 		const node = this.nodeAt(point.x, point.y);
 		this.lastX = point.x;
@@ -85,7 +109,7 @@ export class GraphInputHandler {
 		this.canvas.style.cursor = "grabbing";
 	}
 
-	private onMouseMove(e: MouseEvent): void {
+	private moveInteraction(e: MouseEvent | PointerEvent): void {
 		const point = this.canvasPoint(e);
 		if (this.draggingNode) {
 			const world = this.viewport.screenToWorld(point.x, point.y);
@@ -118,7 +142,7 @@ export class GraphInputHandler {
 		}
 	}
 
-	private onMouseUp(): void {
+	private endInteraction(): void {
 		if (this.draggingNode) {
 			const node = this.draggingNode;
 			node.fx = null;
@@ -139,6 +163,56 @@ export class GraphInputHandler {
 		}
 		this.canvas.style.cursor = "default";
 		this.callbacks.onRequestRender();
+	}
+
+	private onPointerDown(e: PointerEvent): void {
+		if (!e.isPrimary || e.button !== 0) return;
+		e.preventDefault();
+		this.activePointerId = e.pointerId;
+		this.canvas.setPointerCapture(e.pointerId);
+		this.beginInteraction(e);
+	}
+
+	private onPointerMove(e: PointerEvent): void {
+		if (!e.isPrimary) return;
+		if (this.activePointerId !== null && e.pointerId !== this.activePointerId) return;
+		this.moveInteraction(e);
+	}
+
+	private onPointerUp(e: PointerEvent): void {
+		if (this.activePointerId !== e.pointerId) return;
+		this.releasePointer(e.pointerId);
+		this.endInteraction();
+	}
+
+	private onPointerCancel(e: PointerEvent): void {
+		if (this.activePointerId !== e.pointerId) return;
+		this.releasePointer(e.pointerId);
+		this.endInteraction();
+	}
+
+	private onLostPointerCapture(e: PointerEvent): void {
+		if (this.activePointerId !== e.pointerId) return;
+		this.activePointerId = null;
+		this.endInteraction();
+	}
+
+	private releasePointer(pointerId: number): void {
+		this.activePointerId = null;
+		if (this.canvas.hasPointerCapture(pointerId)) this.canvas.releasePointerCapture(pointerId);
+	}
+
+	private onMouseDown(e: MouseEvent): void {
+		if (e.button !== 0) return;
+		this.beginInteraction(e);
+	}
+
+	private onMouseMove(e: MouseEvent): void {
+		this.moveInteraction(e);
+	}
+
+	private onMouseUp(): void {
+		this.endInteraction();
 	}
 
 	private onClick(e: MouseEvent): void {


### PR DESCRIPTION
## Summary
- switch the constellation canvas input handler to pointer events with pointer capture when available
- keep the existing mouse-event fallback for non-pointer runtimes
- mark the constellation canvas, controls, and popover as Electron no-drag regions so desktop frame routing does not steal interaction

## Validation
- `bun test surfaces/dashboard/src/lib/components/ontology/canvas/input-handler.test.ts surfaces/dashboard/src/lib/components/ontology/canvas/hit-test.test.ts surfaces/dashboard/src/lib/components/ontology/canvas/viewport.test.ts`
- `bunx biome check surfaces/dashboard/src/lib/components/ontology/ConstellationGraph.svelte surfaces/dashboard/src/lib/components/ontology/canvas/input-handler.ts surfaces/dashboard/src/lib/components/ontology/canvas/input-handler.test.ts`
- `cd surfaces/dashboard && bun run check` passed with existing unrelated warnings
- `cd surfaces/dashboard && bun run build` passed with existing unrelated warnings
- `cd platform/daemon && bun run build:dashboard` passed with existing unrelated warnings

## Notes
- Left the pre-existing unstaged `.github/workflows/bundle.yml` edit and untracked `goal.md` out of this PR.
