### PR TITLE
refactor(memory): separate transcript search surfaces

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2574,7 +2574,6 @@ Explicit memory query from within a session. Requires `recall` permission.
   "who": "claude-code",
   "since": "2026-01-01T00:00:00Z",
   "until": "2026-04-01T00:00:00Z",
-  "expand": true,
   "sessionKey": "session-uuid",
   "runtimePath": "plugin"
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -1281,7 +1281,7 @@ Only `query` is required.
 
 Common `source` values include `hybrid`, `vector`, `keyword`, `hint`, `sec`,
 `structured`, `traversal`, `ka_traversal`, `source_obsidian`,
-`native_memory`, `transcript`, `constructed`, `graph`, and `llm_summary`.
+`native_memory`, `constructed`, `graph`, and `llm_summary`.
 `method` on the response reflects whether vector search was available for
 this call.
 
@@ -2501,9 +2501,10 @@ for in-context injection.
 are optional.
 
 Prompt-submit retrieval prefers structured memory recall. When structured
-recall is weak or empty, the daemon first attempts temporal-summary
-fallback (session DAG artifacts) and then transcript fallback from prior
-session transcripts instead of returning no context.
+recall is weak or empty, the daemon may attempt temporal-summary fallback
+(session DAG artifacts). Raw transcript search is not injected on
+prompt-submit; use the dedicated `session_search` MCP/API surface when a
+caller needs transcript evidence.
 
 ### POST /api/hooks/session-end
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -579,7 +579,7 @@ Search memories using hybrid vector + keyword search.
 
 ```bash
 signet recall "user preferences"
-signet recall "release notes" --project /home/user/myapp --expand
+signet recall "release notes" --project /home/user/myapp
 signet recall "deploy process" --limit 5 --type decision
 signet recall "auth" --tags backend --who claude-code --since 2026-01-01
 signet recall "deploy checklist" --keyword-query "deploy OR rollback" --min-score 0.8
@@ -592,7 +592,6 @@ Primary controls:
 |--------|-------------|
 | `-l, --limit <n>` | Max results (default: 10) |
 | `--project <project>` | Filter by project |
-| `--expand` | Include expanded transcript/context sources |
 
 Common refinements:
 
@@ -614,6 +613,31 @@ Advanced controls:
 | `--min-score <n>` | Minimum recall score threshold, applied client-side |
 | `--agent <name>` | Filter by agent ID |
 | `--json` | Print the recall response as JSON |
+
+---
+
+`signet session search`
+---
+
+Search active or completed session transcripts. This is separate from
+`signet recall`, which searches stored memories only.
+
+```bash
+signet session search "Juniper trunk ports"
+signet session search "handoff notes" --session-key parent-session --limit 5
+signet session search "delegated task" --current-session-key child-session --agent research-agent --json
+```
+
+Options:
+
+| Option | Description |
+|--------|-------------|
+| `--session-key <key>` | Search one transcript session |
+| `--current-session-key <key>` | Current session key; sub-agent lineage may resolve to the parent |
+| `--agent <name>` | Agent ID scope |
+| `--project <project>` | Filter by project |
+| `-l, --limit <n>` | Max results (default: 10, max: 20) |
+| `--json` | Print the transcript search response as JSON |
 
 ---
 

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -106,8 +106,8 @@ mode expectations across harness paths.
 
 | Harness path | Prompt retrieval order | Thread-head continuity | Compaction artifact persistence | Forced post-event MEMORY refresh |
 |---|---|---|---|---|
-| TS daemon (primary) | hybrid -> temporal-fallback -> transcript-fallback | yes | yes | yes (session-summary + compaction-complete) |
-| daemon-rs shadow | hybrid-style scoped recall with temporal/transcript fallback | yes (agent-scoped retrieval path) | partial (hook route persistence only) | degraded (full event-driven refresh parity follows rust cutover wave) |
+| TS daemon (primary) | hybrid -> temporal-fallback; transcripts via explicit `session_search` | yes | yes | yes (session-summary + compaction-complete) |
+| daemon-rs shadow | hybrid-style scoped recall with temporal fallback | yes (agent-scoped retrieval path) | partial (hook route persistence only) | degraded (full event-driven refresh parity follows rust cutover wave) |
 
 Degraded mode rules:
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -157,8 +157,10 @@ with `/remember` or `memory_store`.
 Recall order is:
 
 1. structured memory recall,
-2. temporal thread-head fallback,
-3. transcript fallback.
+2. temporal thread-head fallback.
+
+Raw transcript search is deliberately not injected through this hook. Use
+`session_search` when a caller needs transcript evidence.
 
 The guidance is meant to prevent agents from treating an empty automatic
 inject as proof that no prior context exists.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -73,7 +73,8 @@ not drift into separate request shapes or result formatting.
 
 Hybrid vector + keyword search over stored memories. Returns results ranked
 by combined BM25 + vector similarity score with optional graph boost and
-reranking.
+reranking. Transcript search is intentionally separate; use `session_search`
+when you need session transcript evidence.
 
 **Parameters:**
 
@@ -84,7 +85,6 @@ Primary controls:
 | `query` | string | yes | Search query text |
 | `limit` | number | no | Max results to return (default 10) |
 | `project` | string | no | Optional project path filter |
-| `expand` | boolean | no | Include expanded transcript/context sources |
 
 Common refinements:
 

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -206,7 +206,7 @@ New recall stages should follow this rule:
 
 - Stages that only produce IDs and scores may run before authorization.
 - Stages that read memory content, send text to a model, build summaries,
-  inspect entity coverage, expand transcripts, or update metadata must run
+  inspect entity coverage, or update metadata must run
   after authorization.
 
 ### Phase 4: Shape Authorized Evidence
@@ -248,7 +248,6 @@ Supplementary results may include:
 
 - source-backed Obsidian chunks,
 - native memory artifacts,
-- transcript fallback cards when `expand` is enabled,
 - an LLM summary card when the LLM reranker path has remaining timeout
   budget,
 - linked rationale memories for decision results,

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -257,24 +257,22 @@ The final response is capped to `limit`. Supplementary rows are marked with
 `supplementary: true` so callers can distinguish them from ordinary memory
 rows.
 
-### Source and Transcript Rescue Paths
+### Source Rescue Paths
 
 If normal memory candidates produce no hits, recall can fall back to source
-chunks, native memory artifacts, and transcript FTS. These paths return
-synthetic recall rows rather than materializing new `memories` records, but
-each fallback is only enabled when its backing rows can satisfy the caller's
-scope boundary.
+chunks and native memory artifacts. These paths return synthetic recall rows
+rather than materializing new `memories` records, but each fallback is only
+enabled when its backing rows can satisfy the caller's scope boundary.
 
 Source chunk vector fallback is disabled for project-scoped recall until chunk
 embeddings carry a strong source root/project binding. Project-scoped searches
-still use authorized memory rows, native source artifacts, and transcript
-fallbacks; they do not guess source ownership from chunk text metadata.
+still use authorized memory rows and native source artifacts; they do not guess
+source ownership from chunk text metadata.
 
-When `expand` is enabled and ordinary memory rows reference session source
-IDs, recall may fetch raw transcript excerpts and same-session structured
-summaries. This is a lossless backing-source path: extracted memories remain
-the primary row, but the transcript can restore details that extraction
-compressed away.
+Transcript lookup is intentionally outside memory recall. Raw session
+transcripts are searched through the dedicated `/api/sessions/search` API,
+MCP `session_search` tool, and CLI `signet session search` command so callers
+must ask for transcript evidence explicitly.
 
 ### Timing and Failure Behavior
 
@@ -283,9 +281,9 @@ stage breakdown so latency regressions can be localized without guessing.
 
 Secondary channels are deliberately best-effort. Embedding, vector search,
 graph traversal, structured evidence, reranking, dampening, currentness,
-source fallback, transcript expansion, and LLM summary failures are logged
-and skipped. The caller should receive the best safe recall response the
-daemon can produce from the remaining channels.
+source fallback, and LLM summary failures are logged and skipped. The caller
+should receive the best safe recall response the daemon can produce from the
+remaining channels.
 
 ### Recall API
 
@@ -301,8 +299,8 @@ curl -X POST http://localhost:3850/api/memory/recall \
 ```
 
 Optional filters: `type`, `tags`, `who`, `pinned`, `importance_min`,
-`since`, `until`, `agentId`, `readPolicy`, `policyGroup`, `project`,
-`scope`, and `expand`.
+`since`, `until`, `agentId`, `readPolicy`, `policyGroup`, `project`, and
+`scope`.
 
 
 Content Normalization

--- a/integrations/hermes-agent/connector/hermes-plugin/README.md
+++ b/integrations/hermes-agent/connector/hermes-plugin/README.md
@@ -34,6 +34,7 @@ Environment variables:
 | Tool | Description |
 |------|-------------|
 | `memory_search` | Hybrid memory search (keyword + semantic + knowledge graph) |
+| `session_search` | Search active or completed session transcripts |
 | `memory_store` | Store a fact, preference, or decision to memory |
 | `memory_get` | Retrieve a memory by ID |
 | `memory_list` | List memories with optional filters |

--- a/integrations/hermes-agent/connector/hermes-plugin/__init__.py
+++ b/integrations/hermes-agent/connector/hermes-plugin/__init__.py
@@ -5,8 +5,8 @@ Bridges Hermes Agent's memory provider interface to the Signet daemon
 predictive recall, cross-session memory, and the full Signet pipeline
 (extraction, knowledge graph, retention decay, synthesis).
 
-Canonical Signet memory tools (memory_search, memory_store, memory_get,
-memory_list, memory_modify, memory_forget, plus recall/remember aliases) are
+Canonical Signet memory tools (memory_search, session_search, memory_store,
+memory_get, memory_list, memory_modify, memory_forget, plus recall/remember aliases) are
 exposed through the MemoryProvider interface. The daemon handles all heavy
 lifting: embedding, reranking, knowledge graph traversal, and predictive
 scoring.
@@ -63,7 +63,6 @@ MEMORY_SEARCH_SCHEMA = {
             },
             "limit": {"type": "integer", "description": "Max results to return (default 10, max 50)."},
             "project": {"type": "string", "description": "Optional project path filter."},
-            "expand": {"type": "boolean", "description": "Include lossless session transcripts as sources."},
             "type": {"type": "string", "description": "Filter by memory type."},
             "tags": {"type": "string", "description": "Filter by tags, comma-separated."},
             "who": {"type": "string", "description": "Filter by author."},
@@ -81,6 +80,26 @@ MEMORY_SEARCH_SCHEMA = {
                 "type": "boolean",
                 "description": "When true, scope recall to SIGNET_AGENT_ID instead of searching shared effective memory.",
             },
+        },
+        "required": ["query"],
+    },
+}
+
+SESSION_SEARCH_SCHEMA = {
+    "name": "session_search",
+    "description": "Search active or completed Signet session transcripts.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Natural language or keyword query."},
+            "session_key": {"type": "string", "description": "Specific transcript session key to search."},
+            "current_session_key": {
+                "type": "string",
+                "description": "Current session key; sub-agent lineage may resolve this to the parent session.",
+            },
+            "agent_id": {"type": "string", "description": "Agent scope, default default."},
+            "project": {"type": "string", "description": "Optional project path filter."},
+            "limit": {"type": "integer", "description": "Max results to return (default 10, max 20)."},
         },
         "required": ["query"],
     },
@@ -240,6 +259,7 @@ REMEMBER_ALIAS_SCHEMA = {
 
 ALL_TOOL_SCHEMAS = [
     MEMORY_SEARCH_SCHEMA,
+    SESSION_SEARCH_SCHEMA,
     MEMORY_STORE_SCHEMA,
     MEMORY_GET_SCHEMA,
     MEMORY_LIST_SCHEMA,
@@ -878,7 +898,6 @@ class SignetMemoryProvider(MemoryProvider):
                 since=str(search_args.get("since", "") or ""),
                 until=str(search_args.get("until", "") or ""),
                 keyword_query=str(search_args.get("keyword_query", "") or ""),
-                expand=bool(search_args.get("expand", False)),
                 score_min=_as_float(search_args.get("score_min")),
                 agent_scoped=bool(search_args.get("agent_scoped", False)),
             )
@@ -919,6 +938,20 @@ class SignetMemoryProvider(MemoryProvider):
         try:
             if tool_name in ("memory_search", "recall", "signet_search"):
                 return _search(args)
+
+            if tool_name == "session_search":
+                query = str(args.get("query", "")).strip()
+                if not query:
+                    return json.dumps({"error": "Missing required parameter: query"})
+                result = self._client.session_search(
+                    query,
+                    session_key=str(args.get("session_key", "") or ""),
+                    current_session_key=str(args.get("current_session_key", "") or ""),
+                    agent_id=str(args.get("agent_id", "") or ""),
+                    project=str(args.get("project", "") or ""),
+                    limit=_as_int(args.get("limit"), 10, minimum=1, maximum=20),
+                )
+                return json.dumps(result if result else {"error": "Session search failed.", "hits": []})
 
             if tool_name in ("memory_store", "remember", "signet_store"):
                 return _store(args)

--- a/integrations/hermes-agent/connector/hermes-plugin/client.py
+++ b/integrations/hermes-agent/connector/hermes-plugin/client.py
@@ -361,7 +361,6 @@ class SignetClient:
         since: str = "",
         until: str = "",
         keyword_query: str = "",
-        expand: bool = False,
         score_min: Optional[float] = None,
         agent_scoped: bool = False,
     ) -> Optional[Dict[str, Any]]:
@@ -388,8 +387,6 @@ class SignetClient:
             body["until"] = until
         if keyword_query:
             body["keywordQuery"] = keyword_query
-        if expand:
-            body["expand"] = True
         if agent_scoped and self._agent_id:
             body["agentId"] = self._agent_id
 
@@ -409,6 +406,32 @@ class SignetClient:
             if isinstance(meta, dict):
                 result["meta"] = {**meta, "totalReturned": len(kept), "noHits": len(kept) == 0}
         return result
+
+    def session_search(
+        self,
+        query: str,
+        *,
+        session_key: str = "",
+        current_session_key: str = "",
+        agent_id: str = "",
+        project: str = "",
+        limit: int = 10,
+    ) -> Optional[Dict[str, Any]]:
+        """Search active or completed session transcripts."""
+        body: Dict[str, Any] = {
+            "query": query,
+            "limit": limit,
+        }
+        if session_key:
+            body["sessionKey"] = session_key
+        if current_session_key:
+            body["currentSessionKey"] = current_session_key
+        resolved_agent_id = agent_id or self._agent_id
+        if resolved_agent_id:
+            body["agentId"] = resolved_agent_id
+        if project:
+            body["project"] = project
+        return self._post("/api/sessions/search", body, timeout=_RECALL_TIMEOUT_SECS)
 
     def get_memory(self, memory_id: str) -> Optional[Dict[str, Any]]:
         """Retrieve a single memory by ID."""

--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -644,8 +644,10 @@ describe("Hermes Agent bundled plugin", () => {
 		expect(plugin).toContain('"name": "memory_store"');
 		expect(plugin).toContain('"name": "memory_get"');
 		expect(plugin).toContain('"name": "memory_list"');
+		expect(plugin).toContain('"name": "session_search"');
 		expect(plugin).not.toContain('"name": "signet_search"');
 		expect(plugin).toContain('if tool_name in ("memory_search", "recall", "signet_search")');
+		expect(plugin).toContain('if tool_name == "session_search"');
 	});
 
 	it("returns Signet tool schemas before daemon initialization", () => {
@@ -788,8 +790,10 @@ describe("Hermes Agent bundled plugin", () => {
 					"manager.add_provider(provider)",
 					"names = manager.get_all_tool_names()",
 					"assert 'memory_search' in names",
+					"assert 'session_search' in names",
 					"assert 'recall' in names",
 					"assert manager.has_tool('memory_store')",
+					"assert manager.has_tool('session_search')",
 					"print(','.join(sorted(names)))",
 				].join("\n"),
 			],
@@ -798,6 +802,7 @@ describe("Hermes Agent bundled plugin", () => {
 
 		expect(result.status).toBe(0);
 		expect(result.stdout).toContain("memory_search");
+		expect(result.stdout).toContain("session_search");
 		expect(result.stdout).toContain("remember");
 	});
 
@@ -857,6 +862,56 @@ describe("Hermes Agent bundled plugin", () => {
 		expect(plugin).toContain('"agent_scoped"');
 		expect(plugin).toContain("scope recall to SIGNET_AGENT_ID");
 		expect(plugin).toContain('agent_scoped=bool(search_args.get("agent_scoped", False))');
+	});
+
+	it("exposes session_search as a dedicated transcript search tool", () => {
+		const plugin = readFileSync(join(import.meta.dir, "hermes-plugin", "__init__.py"), "utf-8");
+		const client = readFileSync(join(import.meta.dir, "hermes-plugin", "client.py"), "utf-8");
+
+		expect(plugin).toContain("SESSION_SEARCH_SCHEMA");
+		expect(plugin).toContain('"description": "Search active or completed Signet session transcripts."');
+		expect(plugin).not.toContain('"expand":');
+		expect(plugin).toContain("self._client.session_search(");
+		expect(client).toContain("def session_search(");
+		expect(client).toContain('self._post("/api/sessions/search", body, timeout=_RECALL_TIMEOUT_SECS)');
+		expect(client).not.toContain("expand: bool");
+		expect(client).not.toContain('body["expand"]');
+	});
+
+	it("defaults Hermes session_search to the configured agent scope", () => {
+		const fixture = join(tmpRoot, "python-session-search-client-fixture");
+		const pluginDir = join(fixture, "plugins", "signet");
+		cpSync(join(import.meta.dir, "hermes-plugin"), pluginDir, { recursive: true });
+
+		const result = spawnSync(
+			"python",
+			[
+				"-c",
+				[
+					"import importlib.util, json, types",
+					"from pathlib import Path",
+					`root = Path(${JSON.stringify(fixture)})`,
+					"spec = importlib.util.spec_from_file_location('signet_client', root / 'plugins' / 'signet' / 'client.py')",
+					"mod = importlib.util.module_from_spec(spec)",
+					"spec.loader.exec_module(mod)",
+					"client = mod.SignetClient(agent_id='research-agent', harness='hermes-agent')",
+					"calls = []",
+					"def fake_post(path, body, **kwargs):",
+					"    calls.append({'path': path, 'body': body, 'kwargs': kwargs})",
+					"    return {'hits': []}",
+					"client._post = fake_post",
+					"client.session_search('Juniper trunk ports')",
+					"client.session_search('other lane', agent_id='explicit-agent')",
+					"print(json.dumps(calls, sort_keys=True))",
+				].join("\n"),
+			],
+			{ env: { ...process.env, PYTHONPATH: fixture }, encoding: "utf-8" },
+		);
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain('"path": "/api/sessions/search"');
+		expect(result.stdout).toContain('"agentId": "research-agent"');
+		expect(result.stdout).toContain('"agentId": "explicit-agent"');
 	});
 
 	it("uses longer timeouts for recall paths", () => {

--- a/integrations/hermes-agent/connector/src/index.ts
+++ b/integrations/hermes-agent/connector/src/index.ts
@@ -34,6 +34,7 @@ const REQUIRED_TOOL_NAMES = [
 	"memory_list",
 	"memory_modify",
 	"memory_forget",
+	"session_search",
 	"recall",
 	"remember",
 ] as const;
@@ -551,7 +552,7 @@ function probeHermesProvider(hermesRepo: string): HermesProbeResult {
 		"manager = MemoryManager()",
 		"manager.add_provider(provider)",
 		"names = sorted(manager.get_all_tool_names())",
-		"required = ['memory_search', 'memory_store', 'memory_get', 'memory_list', 'memory_modify', 'memory_forget', 'recall', 'remember']",
+		"required = ['memory_search', 'memory_store', 'memory_get', 'memory_list', 'memory_modify', 'memory_forget', 'session_search', 'recall', 'remember']",
 		"print(json.dumps({'toolNames': names, 'missing': [name for name in required if name not in names]}))",
 	].join("\n");
 

--- a/integrations/openclaw/memory-adapter/src/index.test.ts
+++ b/integrations/openclaw/memory-adapter/src/index.test.ts
@@ -8,7 +8,7 @@ import type { OpenClawPluginApi } from "./openclaw-types";
 // mocking @signet/core globally, which otherwise leaks into later suites.
 const signet = await import("./index");
 const signetPlugin = signet.default;
-const { memoryStore, _resetRegistration, _sanitization, cleanupTimedMap } = signet;
+const { memoryStore, sessionSearch, _resetRegistration, _sanitization, cleanupTimedMap } = signet;
 
 type HookHandler = (event: Record<string, unknown>, ctx: unknown) => Promise<unknown> | unknown;
 type ToolRegistration = { name: string; label?: string; description?: string };
@@ -33,6 +33,7 @@ let lastPreCompactionBody: unknown = null;
 let lastCompactionBody: unknown = null;
 let lastSessionEndBody: unknown = null;
 let lastPromptSubmitBody: unknown = null;
+let lastSessionSearchBody: unknown = null;
 let lastCheckpointBody: unknown = null;
 let warnMessages: string[] = [];
 let testDir = "";
@@ -139,6 +140,7 @@ beforeEach(() => {
 	lastCompactionBody = null;
 	lastSessionEndBody = null;
 	lastPromptSubmitBody = null;
+	lastSessionSearchBody = null;
 	lastCheckpointBody = null;
 	checkpointResponse = null;
 	warnMessages = [];
@@ -204,6 +206,21 @@ beforeEach(() => {
 						return jsonResponse(resp);
 					}
 					return jsonResponse({ queued: true, jobId: "checkpoint-1" });
+				case "/api/sessions/search":
+					lastSessionSearchBody = init?.body ? JSON.parse(String(init.body)) : null;
+					return jsonResponse({
+						query: "Juniper trunk ports",
+						hits: [
+							{
+								sessionKey: "parent-session",
+								project: "/tmp/network",
+								updatedAt: "2026-03-25T10:05:00.000Z",
+								excerpt: "keep the Juniper EX4300 VLAN audit focused on trunk ports",
+								rank: -1.2,
+							},
+						],
+						count: 1,
+					});
 				case "/api/marketplace/mcp/tools":
 					return jsonResponse({
 						count: 2,
@@ -270,6 +287,28 @@ afterEach(async () => {
 });
 
 describe("signet-memory-openclaw lifecycle hooks", () => {
+	it("forwards session_search requests to the transcript search endpoint", async () => {
+		const result = await sessionSearch("Juniper trunk ports", {
+			daemonUrl: "http://daemon.test",
+			sessionKey: "parent-session",
+			currentSessionKey: "child-session",
+			agentId: "research-agent",
+			project: "/tmp/network",
+			limit: 3,
+		});
+
+		expect(getHits("/api/sessions/search")).toBe(1);
+		expect(lastSessionSearchBody).toEqual({
+			query: "Juniper trunk ports",
+			sessionKey: "parent-session",
+			currentSessionKey: "child-session",
+			agentId: "research-agent",
+			project: "/tmp/network",
+			limit: 3,
+		});
+		expect(result).toMatchObject({ count: 1 });
+	});
+
 	it("prefers before_prompt_build and deduplicates legacy fallback for the same turn", async () => {
 		const { api, hooks, hookOptions } = createMockApi();
 		signetPlugin.register(api);

--- a/integrations/openclaw/memory-adapter/src/index.ts
+++ b/integrations/openclaw/memory-adapter/src/index.ts
@@ -676,6 +676,33 @@ export async function memorySearch(
 	const result = await memoryRecall(query, options);
 	return result ? parseRecallPayload(result).rows : [];
 }
+
+export async function sessionSearch(
+	query: string,
+	options: {
+		daemonUrl?: string;
+		sessionKey?: string;
+		currentSessionKey?: string;
+		agentId?: string;
+		project?: string;
+		limit?: number;
+	} = {},
+): Promise<unknown | null> {
+	const daemonUrl = options.daemonUrl || DEFAULT_DAEMON_URL;
+	return daemonFetch<unknown>(daemonUrl, "/api/sessions/search", {
+		method: "POST",
+		body: {
+			query,
+			sessionKey: options.sessionKey,
+			currentSessionKey: options.currentSessionKey,
+			agentId: options.agentId,
+			project: options.project,
+			limit: options.limit,
+		},
+		timeout: READ_TIMEOUT,
+	});
+}
+
 export async function memoryStore(
 	content: string,
 	options: {
@@ -1635,6 +1662,71 @@ const signetPlugin = {
 					},
 				},
 				{ name: "memory_store" },
+			);
+
+			api.registerTool(
+				{
+					name: "session_search",
+					label: "Session Search",
+					description: "Search active or completed session transcripts",
+					parameters: Type.Object({
+						query: Type.String({
+							description: "Natural language or keyword query",
+						}),
+						session_key: Type.Optional(
+							Type.String({
+								description: "Specific transcript session key to search",
+							}),
+						),
+						current_session_key: Type.Optional(
+							Type.String({
+								description: "Current session key; sub-agent lineage may resolve this to the parent session",
+							}),
+						),
+						agent_id: Type.Optional(
+							Type.String({
+								description: "Agent scope, default default",
+							}),
+						),
+						project: Type.Optional(
+							Type.String({
+								description: "Optional project path filter",
+							}),
+						),
+						limit: Type.Optional(
+							Type.Number({
+								description: "Max results to return (default 10, max 20)",
+							}),
+						),
+					}),
+					async execute(_toolCallId, params) {
+						const { query, session_key, current_session_key, agent_id, project, limit } = params as {
+							query: string;
+							session_key?: string;
+							current_session_key?: string;
+							agent_id?: string;
+							project?: string;
+							limit?: number;
+						};
+						try {
+							const result = await sessionSearch(query, {
+								...opts,
+								sessionKey: session_key,
+								currentSessionKey: current_session_key,
+								agentId: agent_id,
+								project,
+								limit,
+							});
+							if (result === null) {
+								return textResult("Session search failed: daemon unavailable", { error: "daemon unavailable" });
+							}
+							return textResult(JSON.stringify(result, null, 2), { result });
+						} catch (err) {
+							return textResult(`Session search failed: ${String(err)}`, { error: String(err) });
+						}
+					},
+				},
+				{ name: "session_search" },
 			);
 
 			api.registerTool(

--- a/integrations/opencode/plugin/src/tools.test.ts
+++ b/integrations/opencode/plugin/src/tools.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import type { DaemonClient } from "./daemon-client.js";
+import { createTools } from "./tools.js";
+
+describe("createTools", () => {
+	test("session_search posts to the transcript search endpoint", async () => {
+		let capturedPath = "";
+		let capturedBody: unknown;
+		const client = {
+			post: async (path: string, body: unknown) => {
+				capturedPath = path;
+				capturedBody = body;
+				return {
+					query: "Juniper trunk ports",
+					hits: [
+						{
+							sessionKey: "parent-session",
+							project: "/tmp/network",
+							updatedAt: "2026-03-25T10:05:00.000Z",
+							excerpt: "keep the Juniper EX4300 VLAN audit focused on trunk ports",
+							rank: -1.2,
+						},
+					],
+					count: 1,
+				};
+			},
+		} as unknown as DaemonClient;
+
+		const tools = createTools(client);
+		const result = await tools.session_search.execute(
+			{
+				query: "Juniper trunk ports",
+				session_key: "parent-session",
+				current_session_key: "child-session",
+				agent_id: "research-agent",
+				project: "/tmp/network",
+				limit: 3,
+			},
+			{} as never,
+		);
+
+		expect(capturedPath).toBe("/api/sessions/search");
+		expect(capturedBody).toEqual({
+			query: "Juniper trunk ports",
+			sessionKey: "parent-session",
+			currentSessionKey: "child-session",
+			agentId: "research-agent",
+			project: "/tmp/network",
+			limit: 3,
+		});
+		expect(result).toContain('"sessionKey": "parent-session"');
+	});
+});

--- a/integrations/opencode/plugin/src/tools.ts
+++ b/integrations/opencode/plugin/src/tools.ts
@@ -1,7 +1,7 @@
 /**
  * Signet memory tools for OpenCode.
  *
- * 8 tools using tool() from @opencode-ai/plugin, mirroring the
+ * 9 tools using tool() from @opencode-ai/plugin, mirroring the
  * tool surface of @signetai/adapter-openclaw.
  */
 
@@ -33,6 +33,34 @@ async function searchMemory(
 
 	if (result === null) return DAEMON_OFFLINE_MSG;
 	return formatRecallText(applyRecallScoreThreshold(result, args.min_score));
+}
+
+async function searchSessions(
+	client: DaemonClient,
+	args: {
+		readonly query: string;
+		readonly session_key?: string;
+		readonly current_session_key?: string;
+		readonly agent_id?: string;
+		readonly project?: string;
+		readonly limit?: number;
+	},
+): Promise<string> {
+	const result = await client.post<unknown>(
+		"/api/sessions/search",
+		{
+			query: args.query,
+			sessionKey: args.session_key,
+			currentSessionKey: args.current_session_key,
+			agentId: args.agent_id,
+			project: args.project,
+			limit: args.limit,
+		},
+		READ_TIMEOUT,
+	);
+
+	if (result === null) return DAEMON_OFFLINE_MSG;
+	return JSON.stringify(result, null, 2);
 }
 
 async function storeMemory(
@@ -92,6 +120,24 @@ export function createTools(client: DaemonClient): Record<string, ReturnType<typ
 				if (result.offline) return DAEMON_OFFLINE_MSG;
 				const id = result.id ?? result.memoryId;
 				return id ? `Memory saved${args.pinned ? " (pinned)" : ""} (id: ${id})` : "Memory saved.";
+			},
+		}),
+
+		session_search: tool({
+			description: "Search active or completed session transcripts",
+			args: {
+				query: tool.schema.string().describe("Natural language or keyword query"),
+				session_key: tool.schema.string().optional().describe("Specific transcript session key to search"),
+				current_session_key: tool.schema
+					.string()
+					.optional()
+					.describe("Current session key; sub-agent lineage may resolve this to the parent session"),
+				agent_id: tool.schema.string().optional().describe("Agent scope, default default"),
+				project: tool.schema.string().optional().describe("Optional project path filter"),
+				limit: tool.schema.number().optional().describe("Max results to return (default 10, max 20)"),
+			},
+			async execute(args): Promise<string> {
+				return searchSessions(client, args);
 			},
 		}),
 

--- a/platform/daemon/src/hooks.prompt-submit.test.ts
+++ b/platform/daemon/src/hooks.prompt-submit.test.ts
@@ -34,12 +34,6 @@ const emptyTemporalHits: Array<{
 	excerpt: string;
 }> = [];
 const searchTemporalFallbackMock = mock(() => emptyTemporalHits);
-const emptyTranscriptHits: Array<{
-	sessionKey: string;
-	updatedAt: string;
-	excerpt: string;
-}> = [];
-const searchTranscriptFallbackMock = mock(() => emptyTranscriptHits);
 
 const { loadMemoryConfig: realLoadMemoryConfig } = await import("./memory-config");
 
@@ -97,7 +91,6 @@ function makeDeps(opts: { readonly agentFeedback?: boolean } = {}): PromptDeps {
 		hybridRecall: hybridRecallMock,
 		fetchEmbedding: fetchEmbeddingMock,
 		searchTemporalFallback: searchTemporalFallbackMock,
-		searchTranscriptFallback: searchTranscriptFallbackMock,
 		upsertSessionTranscript() {},
 		getExpiryWarning: () => null,
 		recordPrompt() {},
@@ -129,8 +122,6 @@ describe("handleUserPromptSubmit observability", () => {
 		fetchEmbeddingMock.mockClear();
 		searchTemporalFallbackMock.mockClear();
 		searchTemporalFallbackMock.mockImplementation(() => emptyTemporalHits);
-		searchTranscriptFallbackMock.mockClear();
-		searchTranscriptFallbackMock.mockImplementation(() => emptyTranscriptHits);
 		ensureMemoryDbExists();
 		resetDefaultPluginHostForTests();
 		getDefaultPluginHost().setEnabled(SIGNET_SECRETS_PLUGIN_ID, true);
@@ -228,7 +219,6 @@ describe("handleUserPromptSubmit observability", () => {
 		const payload = submitCalls[0]?.[2];
 		expect(payload?.engine).toBe("temporal-fallback");
 		expect(payload?.memoryCount).toBe(1);
-		expect(searchTranscriptFallbackMock).not.toHaveBeenCalled();
 		expect(result.inject).toContain("## Memory Check");
 		expect(result.inject).toContain("## Relevant Memory");
 		expect(result.inject).toContain("[thread node-1]");
@@ -237,15 +227,8 @@ describe("handleUserPromptSubmit observability", () => {
 		expect(result.inject).not.toContain("[signet:recall");
 	});
 
-	it("logs successful transcript fallback outcomes", async () => {
+	it("does not inject transcript fallback content when structured recall misses", async () => {
 		searchTemporalFallbackMock.mockReturnValue([]);
-		searchTranscriptFallbackMock.mockReturnValue([
-			{
-				sessionKey: "session-2",
-				updatedAt: "2026-03-26T20:10:00.000Z",
-				excerpt: "fallback logs now appear in hooks telemetry",
-			},
-		]);
 
 		const result = await handleUserPromptSubmit(
 			{
@@ -256,20 +239,14 @@ describe("handleUserPromptSubmit observability", () => {
 			makeDeps(),
 		);
 
-		expect(result.engine).toBe("transcript-fallback");
 		const submitCalls = infoMock.mock.calls.filter((call) => call[1] === "User prompt submit");
 		expect(submitCalls).toHaveLength(1);
 		const payload = submitCalls[0]?.[2];
-		expect(payload?.engine).toBe("transcript-fallback");
-		expect(payload?.memoryCount).toBe(1);
-		expect(searchTranscriptFallbackMock).toHaveBeenCalledWith(
-			expect.objectContaining({
-				allowScanFallback: false,
-			}),
-		);
+		expect(payload?.engine).not.toBe("transcript-fallback");
+		expect(payload?.memoryCount).toBe(0);
 		expect(result.inject).toContain("## Memory Check");
-		expect(result.inject).toContain("## Relevant Memory");
-		expect(result.inject).toContain("[transcript session-2]");
+		expect(result.inject).not.toContain("## Relevant Memory");
+		expect(result.inject).not.toContain("[transcript");
 		expect(result.inject).toContain("save it with /remember or memory_store");
 		expect(result.inject).not.toContain("[signet:recall");
 	});

--- a/platform/daemon/src/hooks.test.ts
+++ b/platform/daemon/src/hooks.test.ts
@@ -1346,7 +1346,7 @@ describe("handleUserPromptSubmit", () => {
 		expect(row?.content).toContain("review the release checklist");
 	});
 
-	test.serial("falls back to transcript excerpts when structured recall is empty", async () => {
+	test.serial("does not fall back to transcript excerpts when structured recall is empty", async () => {
 		createMemoryDb([]);
 		const db = openTestDb();
 		db.prepare(
@@ -1371,10 +1371,10 @@ describe("handleUserPromptSubmit", () => {
 			userPrompt: "where did we decide the temporal index drill-down handles should live?",
 		});
 
-		expect(result.memoryCount).toBeGreaterThan(0);
-		expect(result.engine).toBe("transcript-fallback");
-		expect(result.inject).toContain("temporal index");
-		expect(result.inject).toContain("sess-olde");
+		expect(result.memoryCount).toBe(0);
+		expect(result.engine).not.toBe("transcript-fallback");
+		expect(result.inject).not.toContain("temporal index");
+		expect(result.inject).not.toContain("sess-olde");
 	});
 
 	test.serial("uses temporal fallback before transcript fallback when weak hybrid misses anchors", async () => {
@@ -1657,7 +1657,7 @@ describe("handleUserPromptSubmit", () => {
 		expect(result.inject).toContain("node-foo-b");
 	});
 
-	test.serial("falls back to transcript excerpts when hybrid top hit misses query anchors", async () => {
+	test.serial("does not fall back to transcript excerpts when hybrid top hit misses query anchors", async () => {
 		createMemoryDb([
 			{
 				content: "Locate deployment logs from the latest rollout runbook.",
@@ -1687,10 +1687,10 @@ describe("handleUserPromptSubmit", () => {
 			userPrompt: "locate ultra-needle-transcript-only-5529931",
 		});
 
-		expect(result.memoryCount).toBeGreaterThan(0);
-		expect(result.engine).toBe("transcript-fallback");
-		expect(result.inject).toContain("ultra-needle-transcript-only-5529931");
-		expect(result.inject).toContain("sess-anch");
+		expect(result.memoryCount).toBe(0);
+		expect(result.engine).not.toBe("transcript-fallback");
+		expect(result.inject).not.toContain("ultra-needle-transcript-only-5529931");
+		expect(result.inject).not.toContain("sess-anch");
 	});
 
 	test.serial("applies character budget", async () => {

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -86,7 +86,6 @@ import { getExpiryWarning } from "./session-tracker";
 import {
 	ensureCanonicalTranscriptHistory,
 	getSessionTranscriptContent,
-	searchTranscriptFallback,
 	upsertSessionTranscript,
 } from "./session-transcripts";
 import { type StructuralFeatures, getStructuralFeatures } from "./structural-features";
@@ -292,11 +291,6 @@ function formatLastSeenShort(isoDate: string): string {
 	if (hours < 24) return `${hours}h ago`;
 	const days = Math.floor(hours / 24);
 	return `${days}d ago`;
-}
-
-function formatTranscriptSessionLabel(sessionKey: string): string {
-	if (sessionKey.length <= 18) return sessionKey;
-	return `${sessionKey.slice(0, 8)}…${sessionKey.slice(-6)}`;
 }
 
 function harnessSupportsNamedCrossAgentTools(harness: string): boolean {
@@ -585,33 +579,6 @@ export function effectiveScore(importance: number, createdAt: string, pinned: bo
 
 export function appendSynthesisIndexBlock(content: string, indexBlock: string): string {
 	return appendRenderedIndexBlock(content, indexBlock);
-}
-
-function buildTranscriptFallbackResponse(
-	metadataHeader: string,
-	harness: string,
-	queryTerms: string,
-	charBudget: number,
-	hits: ReadonlyArray<{
-		readonly sessionKey: string;
-		readonly updatedAt: string;
-		readonly excerpt: string;
-	}>,
-	warnings?: string[],
-	pluginContext = "",
-): UserPromptSubmitResponse {
-	const rows = hits.map((hit) => ({
-		content: `- [transcript ${formatTranscriptSessionLabel(hit.sessionKey)}] ${hit.excerpt} (${formatMemoryDate(hit.updatedAt)})`,
-	}));
-	const lines = selectWithBudget(rows, charBudget).map((row) => row.content);
-	const inject = buildPromptRecallInject(metadataHeader, lines, harness, pluginContext);
-	return {
-		inject,
-		memoryCount: lines.length,
-		queryTerms,
-		engine: "transcript-fallback",
-		warnings,
-	};
 }
 
 function buildTemporalFallbackResponse(
@@ -2462,7 +2429,6 @@ type UserPromptSubmitDeps = {
 	readonly hybridRecall: typeof hybridRecall;
 	readonly fetchEmbedding: typeof fetchEmbedding;
 	readonly searchTemporalFallback: typeof searchTemporalFallback;
-	readonly searchTranscriptFallback: typeof searchTranscriptFallback;
 	readonly trackFtsHits: typeof trackFtsHits;
 };
 
@@ -2507,7 +2473,6 @@ const DEFAULT_USER_PROMPT_SUBMIT_DEPS: UserPromptSubmitDeps = {
 	hybridRecall,
 	fetchEmbedding,
 	searchTemporalFallback,
-	searchTranscriptFallback,
 	trackFtsHits,
 };
 
@@ -2773,31 +2738,6 @@ export async function handleUserPromptSubmit(
 						queryTerms,
 						injectBudget,
 						temporalHits,
-						warnings,
-						pluginContext,
-					),
-					deps.logger,
-				);
-			}
-			const transcriptHits = deps.searchTranscriptFallback({
-				query: vectorQuery,
-				agentId,
-				sessionKey: req.sessionKey,
-				project: req.project,
-				limit: 3,
-				allowScanFallback: false,
-			});
-			if (transcriptHits.length > 0) {
-				return finalizeUserPromptSubmitSuccess(
-					req,
-					userMessage,
-					start,
-					buildTranscriptFallbackResponse(
-						metadataHeader,
-						req.harness,
-						queryTerms,
-						injectBudget,
-						transcriptHits,
 						warnings,
 						pluginContext,
 					),

--- a/platform/daemon/src/mcp/tools.test.ts
+++ b/platform/daemon/src/mcp/tools.test.ts
@@ -518,7 +518,6 @@ describe("createMcpServer", () => {
 				importance_min: 0.7,
 				since: "2026-01-01",
 				until: "2026-04-01",
-				expand: true,
 				score_min: 0.8,
 			});
 
@@ -535,7 +534,7 @@ describe("createMcpServer", () => {
 			expect(body.importance_min).toBe(0.7);
 			expect(body.since).toBe("2026-01-01");
 			expect(body.until).toBe("2026-04-01");
-			expect(body.expand).toBe(true);
+			expect(body.expand).toBeUndefined();
 			expect(body.min_score).toBeUndefined();
 			expect(body.score_min).toBeUndefined();
 			expect(result.isError).toBeUndefined();

--- a/platform/daemon/src/mcp/tools.ts
+++ b/platform/daemon/src/mcp/tools.ts
@@ -789,7 +789,6 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 				query: z.string().describe("Search query text"),
 				limit: z.number().optional().describe("Max results to return (default 10)"),
 				project: z.string().optional().describe("Optional project path filter"),
-				expand: z.boolean().optional().describe("Include lossless session transcripts as sources"),
 				type: z.string().optional().describe("Filter by memory type"),
 				tags: z.string().optional().describe("Filter by tags (comma-separated)"),
 				who: z.string().optional().describe("Filter by author"),
@@ -819,7 +818,6 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 			until,
 			min_score,
 			score_min,
-			expand,
 		}) => {
 			const result = await daemonFetch<unknown>(baseUrl, "/api/memory/recall", {
 				method: "POST",
@@ -834,7 +832,6 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 					importance_min: importance_min ?? min_score,
 					since,
 					until,
-					expand,
 				}),
 			});
 

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -72,7 +72,7 @@ describe("hybridRecall", () => {
 		return Array.from({ length: 768 }, (_, index) => (index === 0 ? 1 : 0));
 	}
 
-	it("keeps expanded transcript sources scoped to the requesting agent", async () => {
+	it("keeps recall memory-only even when legacy expand is requested", async () => {
 		const now = new Date().toISOString();
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
@@ -108,10 +108,10 @@ describe("hybridRecall", () => {
 		);
 
 		expect(result.results.map((row) => row.id)).toContain("mem-a");
-		expect(result.results.find((row) => row.id === "mem-a")?.content).toStartWith("[Transcript excerpt]");
-		expect(result.sources).toBeDefined();
-		expect(result.sources?.["sess-shared"]).toBe("agent-a transcript context");
-		expect(Object.values(result.sources ?? {})).not.toContain("agent-b transcript context");
+		expect(result.results.find((row) => row.id === "mem-a")?.content).not.toContain("[Transcript excerpt]");
+		expect(result).not.toHaveProperty("sources");
+		expect(JSON.stringify(result)).not.toContain("agent-a transcript context");
+		expect(JSON.stringify(result)).not.toContain("agent-b transcript context");
 		expect(result.meta.totalReturned).toBe(result.results.length);
 		expect(result.meta.noHits).toBe(false);
 	});
@@ -145,7 +145,6 @@ describe("hybridRecall", () => {
 				"final_rank",
 				"source_chunk_vector_fallback",
 				"native_artifact_fallback",
-				"transcript_fallback",
 			]),
 		);
 		for (const stage of result.meta.timings.stages) {
@@ -1160,7 +1159,7 @@ describe("hybridRecall", () => {
 		);
 	});
 
-	it("uses transcript fallback when extracted memory compressed away media details", async () => {
+	it("does not use transcript fallback when extracted memory compressed away media details", async () => {
 		const now = new Date().toISOString();
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(
@@ -1199,118 +1198,8 @@ assistant: John Mulaney's Kid Gorgeous is an excellent example. Hasan Minhaj: Ho
 			async () => null,
 		);
 
-		expect(result.results[0]?.source).toBe("transcript");
-		expect(result.results[0]?.source_id).toBe("bench-scope:answer_0250ae1c");
-		expect(result.results[0]?.content).toContain("stand-up comedy specials on Netflix");
-		expect(result.results[0]?.tags).toContain("answer_0250ae1c");
-	});
-
-	it("hydrates transcript fallback with the same-session structured memory summary", async () => {
-		const now = new Date().toISOString();
-		getDbAccessor().withWriteTx((db) => {
-			db.prepare(
-				`INSERT INTO memories (
-					id, content, type, source_id, agent_id, project, created_at, updated_at, updated_by
-				) VALUES (?, ?, 'fact', ?, 'default', ?, ?, ?, 'test')`,
-			).run(
-				"mem-routine-summary",
-				"Speaker A mentioned starting yoga on Wednesdays.",
-				"bench-scope:session-28",
-				"memorybench",
-				now,
-				now,
-			);
-
-			db.prepare(
-				`INSERT INTO session_transcripts (
-					session_key, content, harness, project, agent_id, created_at, updated_at
-				) VALUES (?, ?, 'memorybench-session', ?, ?, ?, ?)`,
-			).run(
-				"bench-scope:session-28",
-				`user: We talked through exercise classes and calendar planning.
-assistant: Considering your weightlifting background, power yoga might be useful.`,
-				"memorybench",
-				"default",
-				now,
-				now,
-			);
-		});
-
-		const cfg = loadMemoryConfig(dir);
-		cfg.search.rehearsal_enabled = false;
-		cfg.search.min_score = 0;
-		cfg.pipelineV2.graph.enabled = false;
-		cfg.pipelineV2.traversal.enabled = false;
-		cfg.pipelineV2.reranker.enabled = false;
-
-		const result = await hybridRecall(
-			{
-				query: "exercise classes calendar",
-				limit: 5,
-				agentId: "default",
-				readPolicy: "isolated",
-				project: "memorybench",
-				scope: "bench-scope",
-				expand: true,
-			},
-			cfg,
-			async () => null,
-		);
-
-		const hit = result.results.find((row) => row.id === "transcript:bench-scope:session-28");
-		expect(hit?.source).toBe("transcript");
-		expect(hit?.content).toStartWith("[Structured memory summary]");
-		expect(hit?.content).toContain("starting yoga on Wednesdays");
-		expect(hit?.content).toContain("[Transcript excerpt]");
-		expect(hit?.content).toContain("exercise classes and calendar planning");
-	});
-
-	it("defaults transcript summary hydration to the default agent when agentId is omitted", async () => {
-		const now = new Date().toISOString();
-		getDbAccessor().withWriteTx((db) => {
-			const memory = db.prepare(
-				`INSERT INTO memories (
-					id, content, type, source_id, agent_id, project, created_at, updated_at, updated_by
-				) VALUES (?, ?, 'fact', ?, ?, NULL, ?, ?, 'test')`,
-			);
-			memory.run(
-				"mem-default-summary",
-				"Default agent summary says the user maintains a fermented dough culture in the fridge.",
-				"shared-session-42",
-				"default",
-				now,
-				now,
-			);
-			memory.run(
-				"mem-other-agent-summary",
-				"Other agent summary says the user keeps backup API keys in a notebook.",
-				"shared-session-42",
-				"agent-b",
-				now,
-				now,
-			);
-
-			db.prepare(
-				`INSERT INTO session_transcripts (
-					session_key, content, harness, project, agent_id, created_at, updated_at
-				) VALUES (?, ?, 'codex', NULL, 'default', ?, ?)`,
-			).run("shared-session-42", "user: We discussed sourdough starter storage and feeding cadence.", now, now);
-		});
-
-		const result = await hybridRecall(
-			{
-				query: "sourdough starter feeding cadence",
-				limit: 5,
-				expand: true,
-			},
-			testCfg({ reranker: false }),
-			async () => null,
-		);
-
-		const hit = result.results.find((row) => row.id === "transcript:shared-session-42");
-		expect(hit?.content).toContain("Default agent summary");
-		expect(hit?.content).not.toContain("Other agent summary");
-		expect(hit?.content).not.toContain("backup API keys");
+		expect(result.results).toEqual([]);
+		expect(JSON.stringify(result)).not.toContain("stand-up comedy specials on Netflix");
 	});
 
 	it("dampens stale structured memories and annotates current replacements", async () => {

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -99,7 +99,6 @@ export interface RecallResponse {
 			attributes: Array<{ content: string; status: string; importance: number }>;
 		}>;
 	}>;
-	sources?: Record<string, string>;
 }
 
 export type EmbedFn = (text: string, cfg: EmbeddingConfig) => Promise<number[] | null>;
@@ -597,14 +596,6 @@ function annotateCurrentness(content: string, info: CurrentnessInfo | undefined)
 	return `${lines.join("\n")}\n\n${content}`;
 }
 
-interface TranscriptRecallHit {
-	readonly sessionKey: string;
-	readonly project: string | null;
-	readonly updatedAt: string;
-	readonly excerpt: string;
-	readonly rank: number;
-}
-
 interface NativeArtifactRecallHit {
 	readonly rowid: number;
 	readonly sourcePath: string;
@@ -824,76 +815,6 @@ export function transcriptExcerpt(content: string, query: string, maxChars = 650
 	return `${prefix}${clean.slice(start, end).trim()}${suffix}`;
 }
 
-function buildTranscriptRecallHits(
-	params: RecallParams,
-	query: string,
-	existingSourceIds: Set<string>,
-): TranscriptRecallHit[] {
-	if (!params.expand) return [];
-	const fts = sanitizeFtsQuery(query);
-	if (fts.length === 0) return [];
-
-	try {
-		return getDbAccessor().withReadDb((db) => {
-			const table = db
-				.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='session_transcripts_fts'`)
-				.get();
-			if (!table) return [];
-
-			const parts = [
-				"SELECT st.session_key, st.project, COALESCE(st.updated_at, st.created_at) AS updated_at,",
-				`st.content, snippet(session_transcripts_fts, 0, '', '', ' … ', 36) AS excerpt,`,
-				"bm25(session_transcripts_fts) AS rank",
-				"FROM session_transcripts_fts",
-				"JOIN session_transcripts st ON st.rowid = session_transcripts_fts.rowid",
-				"WHERE session_transcripts_fts MATCH ?",
-				"AND st.agent_id = ?",
-			];
-			const args: unknown[] = [fts, params.agentId ?? "default"];
-			if (params.project) {
-				parts.push("AND st.project = ?");
-				args.push(params.project);
-			}
-			if (params.scope !== undefined && params.scope !== null) {
-				parts.push(`AND st.session_key LIKE ? ESCAPE '\\'`);
-				args.push(`${escapeLike(params.scope)}:%`);
-			}
-			if (existingSourceIds.size > 0) {
-				const placeholders = [...existingSourceIds].map(() => "?").join(", ");
-				parts.push(`AND st.session_key NOT IN (${placeholders})`);
-				args.push(...existingSourceIds);
-			}
-			parts.push("ORDER BY rank ASC, updated_at DESC LIMIT ?");
-			args.push(Math.max(2, Math.min(3, params.limit ?? 10)));
-
-			const rows = db.prepare(parts.join("\n")).all(...args) as Array<{
-				session_key: string;
-				project: string | null;
-				updated_at: string;
-				content: string;
-				excerpt: string | null;
-				rank: number;
-			}>;
-
-			const maxRank = rows.reduce((max, row) => Math.max(max, Math.abs(row.rank)), 1);
-			return rows
-				.map((row) => ({
-					sessionKey: row.session_key,
-					project: row.project,
-					updatedAt: row.updated_at,
-					excerpt: transcriptExcerpt(row.content || row.excerpt || "", query),
-					rank: maxRank > 0 ? Math.abs(row.rank) / maxRank : 0.2,
-				}))
-				.filter((row) => row.excerpt.length > 0);
-		});
-	} catch (e) {
-		logger.warn("memory", "Transcript recall fallback failed (non-fatal)", {
-			error: e instanceof Error ? e.message : String(e),
-		});
-		return [];
-	}
-}
-
 function buildNativeArtifactRecallHits(
 	params: RecallParams,
 	query: string,
@@ -963,68 +884,6 @@ function buildNativeArtifactRecallHits(
 	}
 }
 
-function loadStructuredSummariesBySourceId(params: RecallParams, sourceIds: readonly string[]): Map<string, string> {
-	const unique = [...new Set(sourceIds.filter((sourceId) => sourceId.length > 0))];
-	if (unique.length === 0) return new Map();
-
-	try {
-		return getDbAccessor().withReadDb((db) => {
-			const placeholders = unique.map(() => "?").join(", ");
-			const scope = buildAgentScopeClause(
-				params.agentId ?? "default",
-				params.readPolicy ?? "isolated",
-				params.policyGroup ?? null,
-			);
-			const projectSql = params.project ? "AND m.project = ?" : "";
-			const projectArgs: unknown[] = params.project ? [params.project] : [];
-			const parts = [
-				"SELECT m.source_id, m.content",
-				"FROM memories m",
-				`WHERE m.source_id IN (${placeholders})`,
-				"AND COALESCE(m.is_deleted, 0) = 0",
-				"AND TRIM(m.content) != ''",
-				projectSql,
-				scope.sql,
-			];
-			const args: unknown[] = [...unique, ...projectArgs, ...scope.args];
-			parts.push("ORDER BY m.importance DESC, m.updated_at DESC, m.created_at DESC");
-
-			const rows = db.prepare(parts.join("\n")).all(...args) as Array<{
-				source_id: string | null;
-				content: string;
-			}>;
-
-			const summaries = new Map<string, string>();
-			for (const row of rows) {
-				if (!row.source_id || summaries.has(row.source_id)) continue;
-				summaries.set(row.source_id, row.content.trim());
-			}
-			return summaries;
-		});
-	} catch (e) {
-		logger.warn("memory", "Transcript summary hydration failed (non-fatal)", {
-			error: e instanceof Error ? e.message : String(e),
-		});
-		return new Map();
-	}
-}
-
-function buildTranscriptFallbackContent(
-	excerpt: string,
-	summary: string | undefined,
-	recallTruncate: number,
-): { content: string; contentLength: number; truncated: boolean } {
-	const content = summary
-		? `[Structured memory summary]\n${summary}\n\n[Transcript excerpt]\n${excerpt}`
-		: `[Transcript excerpt]\n${excerpt}`;
-	const truncated = content.length > recallTruncate;
-	return {
-		content: truncated ? `${content.slice(0, recallTruncate)} [truncated]` : content,
-		contentLength: content.length,
-		truncated,
-	};
-}
-
 function cosineSimilarity(query: Float32Array, memory: Float32Array): number {
 	const len = Math.min(query.length, memory.length);
 	let dot = 0;
@@ -1060,7 +919,7 @@ const HINT_ONLY_SCORE_CAP = 0.75;
  *    graph traversal collect IDs and scores. These stages may over-fetch.
  * 2. Authorized content handling: after `authorize_candidates`, later stages
  *    may read content, call rerankers, apply dampening/currentness, hydrate
- *    results, expand transcripts, and update access counts.
+ *    results, and update access counts.
  *
  * Keep that boundary intact. It is what prevents high-recall channels such as
  * vector search and traversal from leaking out-of-scope content into model or
@@ -1980,51 +1839,6 @@ export async function hybridRecall(
 				},
 			});
 		}
-		const transcriptHits = timings.time("transcript_fallback", () =>
-			buildTranscriptRecallHits(params, expandedQuery, new Set()),
-		);
-		if (transcriptHits.length > 0) {
-			const transcriptSummaries = loadStructuredSummariesBySourceId(
-				params,
-				transcriptHits.map((hit) => hit.sessionKey),
-			);
-			const results = transcriptHits.slice(0, limit).map((hit): RecallResult => {
-				const sessionId = sessionIdFromSourceId(hit.sessionKey);
-				const assembled = buildTranscriptFallbackContent(
-					hit.excerpt,
-					transcriptSummaries.get(hit.sessionKey),
-					recallTruncate,
-				);
-				return {
-					id: `transcript:${hit.sessionKey}`,
-					content: assembled.content,
-					content_length: assembled.contentLength,
-					truncated: assembled.truncated,
-					score: Math.round(Math.max(0.01, Math.min(1.1, hit.rank)) * 100) / 100,
-					source: "transcript",
-					source_id: hit.sessionKey,
-					session_id: sessionId,
-					type: "transcript",
-					tags: params.scope ? `memorybench,${params.scope},${sessionId},transcript` : null,
-					pinned: false,
-					importance: 0.55,
-					who: "",
-					project: hit.project,
-					created_at: hit.updatedAt,
-					supplementary: true,
-				};
-			});
-			return finish({
-				results,
-				query,
-				method: "keyword",
-				meta: {
-					totalReturned: results.length,
-					hasSupplementary: true,
-					noHits: false,
-				},
-			});
-		}
 		return finish({
 			results: [],
 			query,
@@ -2456,111 +2270,6 @@ export async function hybridRecall(
 		}
 	}
 
-	// --- Transcript recall fallback ---
-	// When the caller asks for expansion, raw transcripts are an allowed
-	// lossless backing source. Use them as a mechanical rescue channel for
-	// cases where the extracted memory compressed away the exact detail.
-	if (params.expand) {
-		const transcriptExpansionStart = performance.now();
-		const sourceIds = new Set(
-			results
-				.map((result) => rowMap.get(result.id)?.source_id ?? result.source_id)
-				.filter((sourceId): sourceId is string => typeof sourceId === "string" && sourceId.length > 0),
-		);
-		const transcriptHits = buildTranscriptRecallHits(params, expandedQuery, sourceIds);
-		const transcriptSummaries = loadStructuredSummariesBySourceId(
-			params,
-			transcriptHits.map((hit) => hit.sessionKey),
-		);
-		const realScores = results.filter((row) => row.source !== "transcript").map((row) => row.score);
-		const maxTranscriptScore = realScores.length > 0 ? Math.max(0.01, Math.min(...realScores) - 0.01) : 0.5;
-		for (const hit of transcriptHits) {
-			const sessionId = sessionIdFromSourceId(hit.sessionKey);
-			const id = `transcript:${hit.sessionKey}`;
-			if (existingIds.has(id)) continue;
-			existingIds.add(id);
-			const assembled = buildTranscriptFallbackContent(
-				hit.excerpt,
-				transcriptSummaries.get(hit.sessionKey),
-				recallTruncate,
-			);
-			results.push({
-				id,
-				content: assembled.content,
-				content_length: assembled.contentLength,
-				truncated: assembled.truncated,
-				score: Math.round(Math.max(0.01, Math.min(maxTranscriptScore, hit.rank)) * 100) / 100,
-				source: "transcript",
-				source_id: hit.sessionKey,
-				session_id: sessionId,
-				type: "transcript",
-				tags: params.scope ? `memorybench,${params.scope},${sessionId},transcript` : null,
-				pinned: false,
-				importance: 0.55,
-				who: "",
-				project: hit.project,
-				created_at: hit.updatedAt,
-				supplementary: true,
-			});
-		}
-		if (transcriptHits.length > 0) {
-			results.sort((a, b) => b.score - a.score);
-			if (results.length > limit) results.length = limit;
-		}
-		timings.record("transcript_expansion", transcriptExpansionStart);
-	}
-
-	// --- Lossless expansion: fetch raw session transcripts ---
-	let sources: Record<string, string> | undefined;
-	if (params.expand) {
-		const sourceExpansionStart = performance.now();
-		try {
-			const keys = [
-				...new Set([...rowMap.values()].map((r) => r.source_id).filter((s): s is string => s !== null && s !== "")),
-			];
-			if (keys.length > 0) {
-				const ph = keys.map(() => "?").join(", ");
-				const agentId = params.agentId ?? "default";
-				const projectSql = params.project ? " AND project = ?" : "";
-				const projectArgs: unknown[] = params.project ? [params.project] : [];
-				const transcripts = getDbAccessor().withReadDb(
-					(db) =>
-						db
-							.prepare(
-								`SELECT session_key, content FROM session_transcripts
-								 WHERE agent_id = ? AND session_key IN (${ph})${projectSql}`,
-							)
-							.all(agentId, ...keys, ...projectArgs) as Array<{ session_key: string; content: string }>,
-				);
-				if (transcripts.length > 0) {
-					sources = {};
-					for (const t of transcripts) sources[t.session_key] = t.content;
-				}
-			}
-		} catch {
-			// Non-fatal — table may not exist pre-migration
-		} finally {
-			timings.record("source_expansion_fetch", sourceExpansionStart);
-		}
-	}
-
-	if (params.expand && sources) {
-		const sourceExcerptStart = performance.now();
-		for (const result of results.filter((row) => row.source !== "transcript").slice(0, Math.min(5, limit))) {
-			const sourceId = rowMap.get(result.id)?.source_id ?? result.source_id;
-			if (!sourceId) continue;
-			const transcript = sources[sourceId];
-			if (!transcript) continue;
-			const excerpt = transcriptExcerpt(transcript, expandedQuery);
-			if (!excerpt || result.content.includes(excerpt)) continue;
-			const content = `[Transcript excerpt]\n${excerpt}\n\n${result.content}`;
-			result.content = content.length > recallTruncate ? `${content.slice(0, recallTruncate)} [truncated]` : content;
-			result.content_length = content.length;
-			result.truncated = content.length > recallTruncate;
-		}
-		timings.record("source_excerpt_merge", sourceExcerptStart);
-	}
-
 	if (results.length > limit) results.length = limit;
 
 	return finish({
@@ -2573,6 +2282,5 @@ export async function hybridRecall(
 			noHits: results.length === 0,
 		},
 		entities: entityContext && entityContext.length > 0 ? entityContext : undefined,
-		sources,
 	});
 }

--- a/surfaces/cli/src/commands/memory.test.ts
+++ b/surfaces/cli/src/commands/memory.test.ts
@@ -61,10 +61,7 @@ describe("registerMemoryCommands remember", () => {
 			content: "Avery said Signet recall works in the terminal",
 			importance: 0.7,
 			who: "user",
-			hints: [
-				"What did Avery say about Signet recall?",
-				"Can Signet recall be useful from the terminal?",
-			],
+			hints: ["What did Avery say about Signet recall?", "Can Signet recall be useful from the terminal?"],
 		});
 	});
 });
@@ -101,7 +98,7 @@ describe("registerMemoryCommands recall", () => {
 		expect(lines[0]).toContain('"meta"');
 	});
 
-	test("forwards expanded recall filters and applies min-score in json mode", async () => {
+	test("forwards recall filters and applies min-score in json mode", async () => {
 		const lines: string[] = [];
 		console.log = (line?: unknown) => {
 			lines.push(String(line ?? ""));
@@ -156,7 +153,6 @@ describe("registerMemoryCommands recall", () => {
 			"2026-01-01",
 			"--until",
 			"2026-04-01",
-			"--expand",
 			"--min-score",
 			"0.8",
 			"--json",
@@ -174,7 +170,6 @@ describe("registerMemoryCommands recall", () => {
 			importance_min: 0.7,
 			since: "2026-01-01",
 			until: "2026-04-01",
-			expand: true,
 		});
 		expect(capturedTimeout).toBe(30_000);
 		expect(lines).toHaveLength(1);

--- a/surfaces/cli/src/commands/memory.ts
+++ b/surfaces/cli/src/commands/memory.ts
@@ -85,7 +85,6 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 		.description("Search memories using hybrid (vector + keyword) search")
 		.option("-l, --limit <n>", "Max results", Number.parseInt, 10)
 		.option("--project <project>", "Filter by project")
-		.option("--expand", "Include expanded transcript/context sources", false)
 		.option("-t, --type <type>", "Filter by type")
 		.option("--tags <tags>", "Filter by tags (comma-separated)")
 		.option("--who <who>", "Filter by who")
@@ -115,7 +114,6 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 					importance_min: options.importanceMin,
 					since: options.since,
 					until: options.until,
-					expand: options.expand,
 					agentId: options.agent,
 				}),
 				MEMORY_RECALL_TIMEOUT_MS,

--- a/surfaces/cli/src/commands/session.test.ts
+++ b/surfaces/cli/src/commands/session.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Command } from "commander";
+import { registerSessionCommands } from "./session";
+
+const prevLog = console.log;
+const prevError = console.error;
+
+afterEach(() => {
+	console.log = prevLog;
+	console.error = prevError;
+});
+
+describe("registerSessionCommands search", () => {
+	test("posts transcript search request and prints json response", async () => {
+		const lines: string[] = [];
+		console.log = (line?: unknown) => {
+			lines.push(String(line ?? ""));
+		};
+
+		let capturedPath = "";
+		let capturedOpts: (RequestInit & { timeout?: number }) | undefined;
+		const program = new Command();
+		registerSessionCommands(program, {
+			fetchFromDaemon: async (path, opts) => {
+				capturedPath = path;
+				capturedOpts = opts;
+				return {
+					query: "Juniper trunk ports",
+					hits: [
+						{
+							sessionKey: "parent-session",
+							project: "/tmp/network",
+							updatedAt: "2026-03-25T10:05:00.000Z",
+							excerpt: "keep the Juniper EX4300 VLAN audit focused on trunk ports",
+							rank: -1.2,
+						},
+					],
+					count: 1,
+				};
+			},
+		});
+
+		await program.parseAsync([
+			"node",
+			"test",
+			"session",
+			"search",
+			"Juniper trunk ports",
+			"--session-key",
+			"parent-session",
+			"--current-session-key",
+			"child-session",
+			"--agent",
+			"research-agent",
+			"--project",
+			"/tmp/network",
+			"--limit",
+			"3",
+			"--json",
+		]);
+
+		expect(capturedPath).toBe("/api/sessions/search");
+		expect(capturedOpts?.method).toBe("POST");
+		expect(capturedOpts?.timeout).toBe(30_000);
+		expect(JSON.parse(String(capturedOpts?.body))).toEqual({
+			query: "Juniper trunk ports",
+			sessionKey: "parent-session",
+			currentSessionKey: "child-session",
+			agentId: "research-agent",
+			project: "/tmp/network",
+			limit: 3,
+		});
+		expect(lines).toHaveLength(1);
+		expect(lines[0]).toContain('"sessionKey": "parent-session"');
+	});
+
+	test("prints no-hit transcript search response", async () => {
+		const lines: string[] = [];
+		console.log = (line?: unknown) => {
+			lines.push(String(line ?? ""));
+		};
+
+		const program = new Command();
+		registerSessionCommands(program, {
+			fetchFromDaemon: async () => ({
+				query: "missing",
+				hits: [],
+				count: 0,
+			}),
+		});
+
+		await program.parseAsync(["node", "test", "session", "search", "missing"]);
+
+		expect(lines).toEqual(["  No transcripts found"]);
+	});
+});

--- a/surfaces/cli/src/commands/session.ts
+++ b/surfaces/cli/src/commands/session.ts
@@ -5,7 +5,81 @@ interface SessionDeps {
 	readonly fetchFromDaemon: <T>(path: string, opts?: RequestInit & { timeout?: number }) => Promise<T | null>;
 }
 
+interface SessionSearchHit {
+	readonly sessionKey: string;
+	readonly project?: string | null;
+	readonly updatedAt: string;
+	readonly excerpt: string;
+	readonly rank: number;
+}
+
 export function registerSessionCommands(program: Command, deps: SessionDeps): void {
+	const session = program.command("session").description("Search transcripts and manage active sessions");
+
+	session
+		.command("search <query>")
+		.description("Search active or completed session transcripts")
+		.option("--session-key <key>", "Specific transcript session key to search")
+		.option("--current-session-key <key>", "Current session key; sub-agent lineage may resolve to the parent")
+		.option("--agent <name>", "Agent ID scope")
+		.option("--project <project>", "Filter by project")
+		.option("-l, --limit <n>", "Max results (default 10, max 20)", Number.parseInt, 10)
+		.option("--json", "Output as JSON", false)
+		.action(
+			async (
+				query: string,
+				options: {
+					sessionKey?: string;
+					currentSessionKey?: string;
+					agent?: string;
+					project?: string;
+					limit?: number;
+					json?: boolean;
+				},
+			) => {
+				const data = await deps.fetchFromDaemon<{
+					query: string;
+					hits: SessionSearchHit[];
+					count: number;
+					error?: string;
+				}>("/api/sessions/search", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						query,
+						sessionKey: options.sessionKey,
+						currentSessionKey: options.currentSessionKey,
+						agentId: options.agent,
+						project: options.project,
+						limit: options.limit,
+					}),
+					timeout: 30_000,
+				});
+				if (!data || data.error) {
+					console.error(chalk.red(data?.error ?? "Failed to search transcripts (is the daemon running?)"));
+					process.exit(1);
+				}
+
+				if (options.json) {
+					console.log(JSON.stringify(data, null, 2));
+					return;
+				}
+
+				if (data.hits.length === 0) {
+					console.log(chalk.dim("  No transcripts found"));
+					return;
+				}
+
+				console.log(chalk.bold(`\n  Transcript Search: ${data.query}\n`));
+				for (const hit of data.hits) {
+					const project = hit.project ? ` ${chalk.dim(hit.project)}` : "";
+					console.log(`  ${chalk.cyan(hit.sessionKey)} ${chalk.dim(formatSessionSearchDate(hit.updatedAt))}${project}`);
+					console.log(`  ${hit.excerpt}`);
+					console.log();
+				}
+			},
+		);
+
 	program
 		.command("bypass")
 		.description("Toggle per-session bypass (disable Signet hooks for one session)")
@@ -61,6 +135,12 @@ export function registerSessionCommands(program: Command, deps: SessionDeps): vo
 			}
 			console.log(chalk.green(`  Session ${sessionKey.slice(0, 12)} bypass removed — hooks re-enabled`));
 		});
+}
+
+function formatSessionSearchDate(isoDate: string): string {
+	const date = new Date(isoDate);
+	if (Number.isNaN(date.getTime())) return isoDate;
+	return date.toISOString().slice(0, 10);
 }
 
 function formatAge(isoDate: string): string {


### PR DESCRIPTION
## Summary

- remove raw transcript fallback from prompt-submit injection and memory search
- keep transcript lookup behind the dedicated session_search surface across MCP, CLI, OpenCode, OpenClaw, and Hermes
- remove legacy expand transcript behavior from memory_search and update docs/tests

## Validation

- bun test platform/daemon/src/hooks.prompt-submit.test.ts platform/daemon/src/hooks.test.ts platform/daemon/src/memory-search.test.ts platform/daemon/src/mcp/tools.test.ts
- bun test surfaces/cli/src/commands/memory.test.ts surfaces/cli/src/commands/session.test.ts integrations/opencode/plugin/src/tools.test.ts integrations/openclaw/memory-adapter/src/index.test.ts integrations/hermes-agent/connector/index.test.ts
- bun test integrations/hermes-agent/connector/index.test.ts
- python -m py_compile integrations/hermes-agent/connector/hermes-plugin/__init__.py integrations/hermes-agent/connector/hermes-plugin/client.py
- cd integrations/hermes-agent/connector && bun run typecheck
- cd integrations/opencode/plugin && bun run typecheck
- cd surfaces/cli && bun run build:cli
- cd integrations/openclaw/memory-adapter && bun run build
- cd integrations/hermes-agent/connector && bun run build
- cd integrations/opencode/plugin && bun run build
- bunx biome check on touched TypeScript files
- git diff --check

## Notes

platform/daemon build:types is currently blocked by existing repo-wide declaration issues where daemon declaration generation pulls platform/core/src outside the daemon rootDir and includes unrelated test type errors.
