### PR TITLE
fix(memory): harden aggregate recall

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1243,6 +1243,9 @@ permission. For the full execution model, see [Hybrid Recall](./MEMORY.md#hybrid
   "pinned": false,
   "importance_min": 0.5,
   "since": "2026-01-01T00:00:00Z",
+  "aggregate": false,
+  "aggregateBudget": "small",
+  "saveAggregate": true,
   "agentId": "alice"
 }
 ```
@@ -1289,6 +1292,40 @@ this call.
 is `true` when the response includes supporting context such as an LLM summary
 card or linked rationale context. `meta.noHits` is `true` when recall completed
 normally but found no matching results.
+
+Set `aggregate: true` to opt into bounded aggregate recall. The daemon first
+runs normal hybrid recall, optionally asks the inference router for follow-up
+recall queries, synthesizes one concise answer from unique evidence rows, and
+returns only that aggregate row. Normal recall ranking is unchanged when
+`aggregate` is omitted or `false`.
+
+Aggregate budgets cap total recall queries: `small` = 3, `medium` = 5,
+`large` = 8. `saveAggregate` defaults to `true`; saved aggregate answers are
+normal memories with `source_type: "aggregate-recall"` and tags
+`aggregate,recall`. Saving requires `remember` permission; recall-only callers
+can still use aggregate mode by sending `saveAggregate: false`. Repeating the
+same agent/query/project/budget/source-memory set returns the same saved memory
+through the aggregate idempotency key.
+
+When aggregate synthesis cannot complete, the response is a no-hit recall
+shape with `results: []` and `aggregate.stoppedReason` set to `no_evidence`,
+`router_unavailable`, or `synthesis_failed`.
+
+Successful aggregate responses include aggregate metadata:
+
+```json
+{
+  "aggregate": {
+    "savedMemoryId": "uuid",
+    "saved": true,
+    "deduped": false,
+    "budget": "small",
+    "queries": ["user preferences for editor"],
+    "sourceMemoryIds": ["source-memory-id"],
+    "stoppedReason": "complete"
+  }
+}
+```
 
 When `memory.pipelineV2.reranker.useExtractionModel` is enabled, an
 additional synthesized summary card may be prepended to results. This card
@@ -2574,6 +2611,9 @@ Explicit memory query from within a session. Requires `recall` permission.
   "who": "claude-code",
   "since": "2026-01-01T00:00:00Z",
   "until": "2026-04-01T00:00:00Z",
+  "aggregate": true,
+  "aggregateBudget": "small",
+  "saveAggregate": true,
   "sessionKey": "session-uuid",
   "runtimePath": "plugin"
 }
@@ -2583,7 +2623,8 @@ Explicit memory query from within a session. Requires `recall` permission.
 
 This route is a hook-oriented wrapper around `POST /api/memory/recall`. It
 accepts a narrower request surface, applies hook/session policy checks, and
-then forwards the supported recall filters into the shared hybrid recall path.
+then forwards the supported recall filters and explicit aggregate recall flags
+into the shared recall path.
 
 `project` on this route is forwarded as the memory `project` filter. It is not
 remapped to recall `scope`.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -583,6 +583,7 @@ signet recall "release notes" --project /home/user/myapp
 signet recall "deploy process" --limit 5 --type decision
 signet recall "auth" --tags backend --who claude-code --since 2026-01-01
 signet recall "deploy checklist" --keyword-query "deploy OR rollback" --min-score 0.8
+signet recall "project history" --aggregate --aggregate-budget small
 signet recall "secrets" --json
 ```
 
@@ -612,6 +613,9 @@ Advanced controls:
 | `--importance-min <n>` | Only return memories at or above this importance |
 | `--min-score <n>` | Minimum recall score threshold, applied client-side |
 | `--agent <name>` | Filter by agent ID |
+| `--aggregate` | Synthesize one aggregate answer from bounded recall evidence |
+| `--aggregate-budget <budget>` | Aggregate recall budget: `small`, `medium`, or `large` |
+| `--no-save-aggregate` | Return the aggregate answer without saving it as a memory; saving requires `remember` permission |
 | `--json` | Print the recall response as JSON |
 
 ---

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -105,6 +105,9 @@ Advanced controls:
 | `importance_min` | number | no | Minimum memory importance threshold |
 | `min_score` | number | no | Deprecated compatibility alias for `importance_min` |
 | `score_min` | number | no | Minimum recall score threshold, applied client-side to returned rows |
+| `aggregate` | boolean | no | Synthesize one aggregate answer from bounded recall evidence |
+| `aggregate_budget` | `"small" \| "medium" \| "large"` | no | Aggregate recall budget; defaults to `small` |
+| `save_aggregate` | boolean | no | Save the aggregate answer as a normal memory; defaults to true when aggregate mode is enabled and requires `remember` permission |
 
 **Returns:** A formatted recall brief with primary matches, supporting
 context, and no-hit handling. The tool still reads from
@@ -118,7 +121,9 @@ context, and no-hit handling. The tool still reads from
   "project": "/home/user/myapp",
   "limit": 5,
   "type": "preference",
-  "score_min": 0.8
+  "score_min": 0.8,
+  "aggregate": true,
+  "aggregate_budget": "small"
 }
 ```
 

--- a/docs/MEMORY-SKILLS.md
+++ b/docs/MEMORY-SKILLS.md
@@ -103,6 +103,8 @@ For critical:
 signet recall <query>
 signet recall <query> -l 5
 signet recall <query> --type decision --tags project
+signet recall <query> --aggregate --aggregate-budget small
+signet recall <query> --aggregate --no-save-aggregate
 
 # In harness
 /recall <query>
@@ -114,6 +116,8 @@ signet recall <query> --type decision --tags project
 - **Score display**: Shows relevance scores for transparency
 - **Rich results**: Content, tags, source, type, timestamps
 - **Filters**: Filter by type (`--type`), tags (`--tags`), who (`--who`)
+- **Aggregate recall**: `--aggregate` synthesizes one answer from bounded
+  evidence and saves it as a normal memory by default
 
 ### Examples
 
@@ -122,6 +126,7 @@ signet recall "signet architecture"
 signet recall "preferences" -l 5
 signet recall "API" --type decision --tags project
 signet recall "bun vs npm" --json
+signet recall "what did we decide about aggregate recall?" --aggregate
 ```
 
 ### Implementation
@@ -135,7 +140,7 @@ signet recall "search query" -l 10
 # Direct API call
 curl -X POST http://localhost:3850/api/memory/recall \
   -H "Content-Type: application/json" \
-  -d '{"query": "search query", "limit": 10}'
+  -d '{"query": "search query", "limit": 10, "aggregate": true}'
 ```
 
 ### Response Format

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -398,6 +398,8 @@ suppress the search.
 const { data: results, loading } = useMemorySearch("user preferences", {
   limit: 5,
   type: "preference",
+  aggregate: true,
+  aggregateBudget: "small",
 });
 ```
 
@@ -441,6 +443,8 @@ const result = await generateText({
 
 Each tool is a standard Vercel AI SDK tool with `description`,
 `parameters` (zod schema), and `execute` function.
+The `memory_search` tool accepts `aggregate`, `aggregateBudget`, and
+`saveAggregate` for explicit aggregate recall.
 
 **`getMemoryContext(client, userMessage, opts?)`** — Convenience helper
 that runs a recall search and formats the results as a markdown string

--- a/integrations/hermes-agent/connector/hermes-plugin/__init__.py
+++ b/integrations/hermes-agent/connector/hermes-plugin/__init__.py
@@ -76,6 +76,19 @@ MEMORY_SEARCH_SCHEMA = {
                 "description": "Deprecated compatibility alias for importance_min; ignored when importance_min is set.",
             },
             "score_min": {"type": "number", "description": "Minimum recall score threshold, applied client-side."},
+            "aggregate": {
+                "type": "boolean",
+                "description": "Synthesize an aggregate answer from bounded recall evidence.",
+            },
+            "aggregate_budget": {
+                "type": "string",
+                "enum": ["small", "medium", "large"],
+                "description": "Aggregate recall budget.",
+            },
+            "save_aggregate": {
+                "type": "boolean",
+                "description": "Save aggregate answers as memories.",
+            },
             "agent_scoped": {
                 "type": "boolean",
                 "description": "When true, scope recall to SIGNET_AGENT_ID instead of searching shared effective memory.",
@@ -899,6 +912,11 @@ class SignetMemoryProvider(MemoryProvider):
                 until=str(search_args.get("until", "") or ""),
                 keyword_query=str(search_args.get("keyword_query", "") or ""),
                 score_min=_as_float(search_args.get("score_min")),
+                aggregate=bool(search_args.get("aggregate", False)),
+                aggregate_budget=str(search_args.get("aggregate_budget", "") or ""),
+                save_aggregate=search_args.get("save_aggregate")
+                if isinstance(search_args.get("save_aggregate"), bool)
+                else None,
                 agent_scoped=bool(search_args.get("agent_scoped", False)),
             )
             if not result:

--- a/integrations/hermes-agent/connector/hermes-plugin/client.py
+++ b/integrations/hermes-agent/connector/hermes-plugin/client.py
@@ -362,6 +362,9 @@ class SignetClient:
         until: str = "",
         keyword_query: str = "",
         score_min: Optional[float] = None,
+        aggregate: bool = False,
+        aggregate_budget: str = "",
+        save_aggregate: Optional[bool] = None,
         agent_scoped: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """Search memories via hybrid recall."""
@@ -387,6 +390,12 @@ class SignetClient:
             body["until"] = until
         if keyword_query:
             body["keywordQuery"] = keyword_query
+        if aggregate:
+            body["aggregate"] = True
+            if aggregate_budget in ("small", "medium", "large"):
+                body["aggregateBudget"] = aggregate_budget
+            if save_aggregate is not None:
+                body["saveAggregate"] = save_aggregate
         if agent_scoped and self._agent_id:
             body["agentId"] = self._agent_id
 

--- a/integrations/openclaw/memory-adapter/src/index.ts
+++ b/integrations/openclaw/memory-adapter/src/index.ts
@@ -650,6 +650,9 @@ export async function memoryRecall(
 		limit?: number;
 		type?: string;
 		minScore?: number;
+		aggregate?: boolean;
+		aggregateBudget?: "small" | "medium" | "large";
+		saveAggregate?: boolean;
 	} = {},
 ): Promise<RecallPayload | null> {
 	const daemonUrl = options.daemonUrl || DEFAULT_DAEMON_URL;
@@ -658,6 +661,9 @@ export async function memoryRecall(
 		body: buildRecallRequestBody(query, {
 			limit: options.limit ?? 10,
 			type: options.type,
+			aggregate: options.aggregate,
+			aggregateBudget: options.aggregateBudget,
+			saveAggregate: options.saveAggregate,
 		}),
 		timeout: READ_TIMEOUT,
 	});
@@ -1577,13 +1583,29 @@ const signetPlugin = {
 								description: "Minimum relevance score threshold",
 							}),
 						),
+						aggregate: Type.Optional(
+							Type.Boolean({
+								description: "Synthesize an aggregate answer from recall evidence",
+							}),
+						),
+						aggregate_budget: Type.Optional(
+							Type.Union([Type.Literal("small"), Type.Literal("medium"), Type.Literal("large")]),
+						),
+						save_aggregate: Type.Optional(
+							Type.Boolean({
+								description: "Save aggregate answers as memories",
+							}),
+						),
 					}),
 					async execute(_toolCallId, params) {
-						const { query, limit, type, min_score } = params as {
+						const { query, limit, type, min_score, aggregate, aggregate_budget, save_aggregate } = params as {
 							query: string;
 							limit?: number;
 							type?: string;
 							min_score?: number;
+							aggregate?: boolean;
+							aggregate_budget?: "small" | "medium" | "large";
+							save_aggregate?: boolean;
 						};
 						try {
 							const recall = await memoryRecall(query, {
@@ -1591,6 +1613,9 @@ const signetPlugin = {
 								limit,
 								type,
 								minScore: min_score,
+								aggregate,
+								aggregateBudget: aggregate_budget,
+								saveAggregate: save_aggregate,
 							});
 							const parsed = parseRecallPayload(recall);
 							if (parsed.rows.length === 0) {

--- a/integrations/opencode/plugin/src/tools.ts
+++ b/integrations/opencode/plugin/src/tools.ts
@@ -20,13 +20,28 @@ const DAEMON_OFFLINE_MSG = "Signet daemon not running. Start with: signet daemon
 
 async function searchMemory(
 	client: DaemonClient,
-	args: { readonly query: string; readonly limit?: number; readonly type?: string; readonly min_score?: number },
+	args: {
+		readonly query: string;
+		readonly limit?: number;
+		readonly type?: string;
+		readonly min_score?: number;
+		readonly aggregate?: boolean;
+		readonly aggregate_budget?: string;
+		readonly save_aggregate?: boolean;
+	},
 ): Promise<string> {
+	const aggregateBudget =
+		args.aggregate_budget === "medium" || args.aggregate_budget === "large" || args.aggregate_budget === "small"
+			? args.aggregate_budget
+			: undefined;
 	const result = await client.post<unknown>(
 		"/api/memory/recall",
 		buildRecallRequestBody(args.query, {
 			limit: args.limit ?? 10,
 			type: args.type,
+			aggregate: args.aggregate,
+			aggregate_budget: aggregateBudget,
+			save_aggregate: args.save_aggregate,
 		}),
 		READ_TIMEOUT,
 	);
@@ -101,6 +116,9 @@ export function createTools(client: DaemonClient): Record<string, ReturnType<typ
 				limit: tool.schema.number().optional().describe("Max results to return (default 10)"),
 				type: tool.schema.string().optional().describe("Filter by memory type"),
 				min_score: tool.schema.number().optional().describe("Minimum relevance score threshold"),
+				aggregate: tool.schema.boolean().optional().describe("Synthesize an aggregate answer from recall evidence"),
+				aggregate_budget: tool.schema.string().optional().describe("Aggregate recall budget: small, medium, or large"),
+				save_aggregate: tool.schema.boolean().optional().describe("Save aggregate answers as memories"),
 			},
 			async execute(args): Promise<string> {
 				return searchMemory(client, args);

--- a/integrations/pi/extension/src/index.ts
+++ b/integrations/pi/extension/src/index.ts
@@ -124,9 +124,12 @@ export async function recallMemories(
 		limit?: number;
 		agentId?: string;
 		scope?: "global" | "agent" | "session";
+		aggregate?: boolean;
+		aggregateBudget?: "small" | "medium" | "large";
+		saveAggregate?: boolean;
 	} = {},
 ): Promise<RecallPayload> {
-	const { limit = 10, agentId, scope } = options;
+	const { limit = 10, agentId, scope, aggregate, aggregateBudget, saveAggregate } = options;
 
 	const response = await fetch(`${daemonUrl}/api/memory/recall`, {
 		method: "POST",
@@ -136,6 +139,9 @@ export async function recallMemories(
 				limit,
 				agentId,
 				scope,
+				aggregate,
+				aggregateBudget,
+				saveAggregate,
 			}),
 		),
 		signal: AbortSignal.timeout(READ_TIMEOUT),

--- a/libs/sdk/src/__tests__/ai-sdk.test.ts
+++ b/libs/sdk/src/__tests__/ai-sdk.test.ts
@@ -1,12 +1,13 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { SignetClient } from "../index.js";
 import { getMemoryContext, memoryTools } from "../ai-sdk.js";
+import { SignetClient } from "../index.js";
 
 let mockServer: ReturnType<typeof Bun.serve>;
 let port: number;
 
 // Track calls the mock client receives
 const calls: { method: string; args: unknown[] }[] = [];
+let lastRecallBody: Record<string, unknown> | null = null;
 
 function mockClient(): SignetClient {
 	const client = new SignetClient({ daemonUrl: `http://localhost:${port}` });
@@ -16,11 +17,12 @@ function mockClient(): SignetClient {
 beforeAll(() => {
 	mockServer = Bun.serve({
 		port: 0,
-		fetch(req) {
+		async fetch(req) {
 			const url = new URL(req.url);
 
 			// recall endpoint - used by memory_search and getMemoryContext
 			if (url.pathname === "/api/memory/recall") {
+				lastRecallBody = (await req.json().catch(() => null)) as Record<string, unknown> | null;
 				return Response.json({
 					results: [
 						{
@@ -106,10 +108,20 @@ describe("memoryTools", () => {
 			query: "test query",
 			limit: 3,
 			type: undefined,
+			aggregate: true,
+			aggregateBudget: "small",
+			saveAggregate: false,
 		});
 
 		expect(result).toHaveProperty("results");
 		expect(result).toHaveProperty("stats");
+		expect(lastRecallBody).toMatchObject({
+			query: "test query",
+			limit: 3,
+			aggregate: true,
+			aggregateBudget: "small",
+			saveAggregate: false,
+		});
 	});
 
 	test("memory_store executes remember", async () => {

--- a/libs/sdk/src/__tests__/client.test.ts
+++ b/libs/sdk/src/__tests__/client.test.ts
@@ -84,7 +84,13 @@ describe("SignetClient", () => {
 
 	test("recall() sends POST /api/memory/recall with query", async () => {
 		const { client } = mockDaemon();
-		await client.recall("dark mode", { limit: 5, type: "preference" });
+		await client.recall("dark mode", {
+			limit: 5,
+			type: "preference",
+			aggregate: true,
+			aggregateBudget: "medium",
+			saveAggregate: false,
+		});
 
 		const req = lastRequest();
 		expect(req.method).toBe("POST");
@@ -93,6 +99,9 @@ describe("SignetClient", () => {
 			query: "dark mode",
 			limit: 5,
 			type: "preference",
+			aggregate: true,
+			aggregateBudget: "medium",
+			saveAggregate: false,
 		});
 	});
 

--- a/libs/sdk/src/__tests__/openai.test.ts
+++ b/libs/sdk/src/__tests__/openai.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { memoryToolDefinitions, executeMemoryTool } from "../openai.js";
 import { SignetError } from "../errors.js";
 import type { SignetClient } from "../index.js";
+import { executeMemoryTool, memoryToolDefinitions } from "../openai.js";
 
 // Lightweight mock that tracks calls to each method.
 interface MockCall {
@@ -54,6 +54,10 @@ describe("memoryToolDefinitions", () => {
 		const search = tools.find((t) => t.function.name === "memory_search");
 		const params = search?.function.parameters as Record<string, unknown>;
 		expect(params.required).toEqual(["query"]);
+		const properties = params.properties as Record<string, unknown>;
+		expect(properties.aggregate).toBeDefined();
+		expect(properties.aggregateBudget).toBeDefined();
+		expect(properties.saveAggregate).toBeDefined();
 	});
 
 	test("memory_store requires content", () => {
@@ -82,12 +86,21 @@ describe("executeMemoryTool", () => {
 			query: "preferences",
 			limit: 5,
 			type: "preference",
+			aggregate: true,
+			aggregateBudget: "medium",
+			saveAggregate: false,
 		});
 
 		expect(calls).toHaveLength(1);
 		expect(calls[0].method).toBe("recall");
 		expect(calls[0].args[0]).toBe("preferences");
-		expect(calls[0].args[1]).toEqual({ limit: 5, type: "preference" });
+		expect(calls[0].args[1]).toEqual({
+			limit: 5,
+			type: "preference",
+			aggregate: true,
+			aggregateBudget: "medium",
+			saveAggregate: false,
+		});
 	});
 
 	test("memory_store dispatches to client.remember()", async () => {

--- a/libs/sdk/src/ai-sdk.ts
+++ b/libs/sdk/src/ai-sdk.ts
@@ -24,17 +24,26 @@ export async function memoryTools(client: SignetClient) {
 				query: z.string().describe("Search query"),
 				limit: z.number().optional().describe("Max results"),
 				type: z.string().optional().describe("Memory type filter"),
+				aggregate: z.boolean().optional().describe("Synthesize an aggregate answer from recall evidence"),
+				aggregateBudget: z.enum(["small", "medium", "large"]).optional().describe("Aggregate recall budget"),
+				saveAggregate: z.boolean().optional().describe("Save aggregate answers as memories"),
 			}),
 			execute: async ({
 				query,
 				limit,
 				type,
+				aggregate,
+				aggregateBudget,
+				saveAggregate,
 			}: {
 				query: string;
 				limit?: number;
 				type?: string;
+				aggregate?: boolean;
+				aggregateBudget?: "small" | "medium" | "large";
+				saveAggregate?: boolean;
 			}) => {
-				return client.recall(query, { limit, type });
+				return client.recall(query, { limit, type, aggregate, aggregateBudget, saveAggregate });
 			},
 		},
 

--- a/libs/sdk/src/helpers.ts
+++ b/libs/sdk/src/helpers.ts
@@ -158,6 +158,9 @@ export class SignetClientHelpers {
 			readonly expand?: boolean;
 			readonly minScore?: number;
 			readonly agentId?: string;
+			readonly aggregate?: boolean;
+			readonly aggregateBudget?: "small" | "medium" | "large";
+			readonly saveAggregate?: boolean;
 		},
 	): Promise<RecallResponse> {
 		const result = applyRecallMinScore(

--- a/libs/sdk/src/index.ts
+++ b/libs/sdk/src/index.ts
@@ -154,6 +154,9 @@ export class SignetClient extends SignetClientHelpers {
 			readonly minScore?: number;
 			readonly expand?: boolean;
 			readonly agentId?: string;
+			readonly aggregate?: boolean;
+			readonly aggregateBudget?: "small" | "medium" | "large";
+			readonly saveAggregate?: boolean;
 		},
 	): Promise<RecallResponse> {
 		return applyRecallMinScore(

--- a/libs/sdk/src/openai.ts
+++ b/libs/sdk/src/openai.ts
@@ -30,6 +30,13 @@ export function memoryToolDefinitions(): readonly OpenAIToolDefinition[] {
 						query: { type: "string", description: "Search query" },
 						limit: { type: "number", description: "Max results" },
 						type: { type: "string", description: "Memory type filter" },
+						aggregate: { type: "boolean", description: "Synthesize an aggregate answer from recall evidence" },
+						aggregateBudget: {
+							type: "string",
+							enum: ["small", "medium", "large"],
+							description: "Aggregate recall budget",
+						},
+						saveAggregate: { type: "boolean", description: "Save aggregate answers as memories" },
 					},
 					required: ["query"],
 				},
@@ -121,6 +128,22 @@ function optionalNumber(args: Record<string, unknown>, key: string): number | un
 	return value;
 }
 
+function optionalBoolean(args: Record<string, unknown>, key: string): boolean | undefined {
+	const value = args[key];
+	if (value === undefined || value === null) return undefined;
+	if (typeof value !== "boolean") {
+		throw new SignetError(`Expected boolean for "${key}", got ${typeof value}`, "invalid_args");
+	}
+	return value;
+}
+
+function optionalAggregateBudget(args: Record<string, unknown>): "small" | "medium" | "large" | undefined {
+	const value = optionalString(args, "aggregateBudget");
+	if (value === undefined) return undefined;
+	if (value === "small" || value === "medium" || value === "large") return value;
+	throw new SignetError("Expected aggregateBudget to be small, medium, or large", "invalid_args");
+}
+
 export async function executeMemoryTool(
 	client: SignetClient,
 	toolName: string,
@@ -131,6 +154,9 @@ export async function executeMemoryTool(
 			return client.recall(requireString(args, "query"), {
 				limit: optionalNumber(args, "limit"),
 				type: optionalString(args, "type"),
+				aggregate: optionalBoolean(args, "aggregate"),
+				aggregateBudget: optionalAggregateBudget(args),
+				saveAggregate: optionalBoolean(args, "saveAggregate"),
 			});
 
 		case "memory_store":

--- a/libs/sdk/src/react.tsx
+++ b/libs/sdk/src/react.tsx
@@ -67,9 +67,20 @@ interface AsyncState<T> {
 
 export function useMemorySearch(
 	query: string | null,
-	opts?: { readonly limit?: number; readonly type?: string },
+	opts?: {
+		readonly limit?: number;
+		readonly type?: string;
+		readonly aggregate?: boolean;
+		readonly aggregateBudget?: "small" | "medium" | "large";
+		readonly saveAggregate?: boolean;
+	},
 ): AsyncState<readonly RecallResult[]> {
 	const { client } = useSignet();
+	const limit = opts?.limit;
+	const type = opts?.type;
+	const aggregate = opts?.aggregate;
+	const aggregateBudget = opts?.aggregateBudget;
+	const saveAggregate = opts?.saveAggregate;
 	const [state, setState] = useState<AsyncState<readonly RecallResult[]>>({
 		data: null,
 		loading: false,
@@ -86,7 +97,7 @@ export function useMemorySearch(
 		setState((prev) => ({ ...prev, loading: true, error: null }));
 
 		client
-			.recall(query, opts)
+			.recall(query, { limit, type, aggregate, aggregateBudget, saveAggregate })
 			.then((response) => {
 				if (!controller.signal.aborted) {
 					setState({ data: response.results, loading: false, error: null });
@@ -103,7 +114,7 @@ export function useMemorySearch(
 			});
 
 		return () => controller.abort();
-	}, [client, query, opts?.limit, opts?.type]);
+	}, [client, query, limit, type, aggregate, aggregateBudget, saveAggregate]);
 
 	return state;
 }

--- a/libs/sdk/src/types.ts
+++ b/libs/sdk/src/types.ts
@@ -55,6 +55,16 @@ export interface RecallMeta {
 	readonly noHits: boolean;
 }
 
+export interface AggregateRecallMeta {
+	readonly savedMemoryId: string | null;
+	readonly saved: boolean;
+	readonly deduped: boolean;
+	readonly budget: "small" | "medium" | "large";
+	readonly queries: readonly string[];
+	readonly sourceMemoryIds: readonly string[];
+	readonly stoppedReason: "complete" | "no_evidence" | "router_unavailable" | "synthesis_failed";
+}
+
 export interface RecallEntityAttribute {
 	readonly content: string;
 	readonly status: string;
@@ -77,6 +87,7 @@ export interface RecallResponse {
 	readonly query: string;
 	readonly method: "hybrid" | "keyword";
 	readonly meta: RecallMeta;
+	readonly aggregate?: AggregateRecallMeta;
 	readonly entities?: readonly RecallEntity[];
 	readonly sources?: Readonly<Record<string, string>>;
 }

--- a/platform/core/src/migrations/073-aggregate-memory-links.ts
+++ b/platform/core/src/migrations/073-aggregate-memory-links.ts
@@ -1,0 +1,19 @@
+import type { MigrationDb } from "./index";
+
+/**
+ * Migration 073: provenance links from aggregate recall memories to the
+ * memory IDs used as evidence during synthesis.
+ */
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS aggregate_memory_sources (
+			aggregate_memory_id TEXT NOT NULL,
+			source_memory_id TEXT NOT NULL,
+			agent_id TEXT NOT NULL DEFAULT 'default',
+			created_at TEXT NOT NULL,
+			PRIMARY KEY (aggregate_memory_id, source_memory_id)
+		);
+		CREATE INDEX IF NOT EXISTS idx_aggregate_memory_sources_agent
+			ON aggregate_memory_sources(agent_id, aggregate_memory_id);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -78,6 +78,7 @@ import { up as dailyReflectionsMultipleInsights } from "./069-daily-reflections-
 import { up as ontologyControlPlaneState } from "./070-ontology-control-plane-state";
 import { up as epistemicAssertions } from "./071-epistemic-assertions";
 import { up as agentScopedIdempotencyKey } from "./072-agent-scoped-idempotency-key";
+import { up as aggregateMemoryLinks } from "./073-aggregate-memory-links";
 
 // -- Public interface consumed by Database.init() --
 
@@ -682,6 +683,14 @@ export const MIGRATIONS: readonly Migration[] = [
 				{ table: "memories", column: "idempotency_key" },
 				{ table: "memories", column: "runtime_path" },
 			],
+		},
+	},
+	{
+		version: 73,
+		name: "aggregate-memory-links",
+		up: aggregateMemoryLinks,
+		artifacts: {
+			tables: ["aggregate_memory_sources"],
 		},
 	},
 ];

--- a/platform/core/src/recall.test.ts
+++ b/platform/core/src/recall.test.ts
@@ -58,6 +58,21 @@ describe("recall surface helpers", () => {
 		});
 	});
 
+	it("forwards aggregate recall options only when callers set them", () => {
+		expect(
+			buildRecallRequestBody("graph", {
+				aggregate: true,
+				aggregate_budget: "medium",
+				save_aggregate: false,
+			}),
+		).toEqual({
+			query: "graph",
+			aggregate: true,
+			aggregateBudget: "medium",
+			saveAggregate: false,
+		});
+	});
+
 	it("normalizes legacy structured aspect tuples for remember callers", () => {
 		const body = buildRememberRequestBody("Remember this", {
 			tags: ["graph", "parity"],

--- a/platform/core/src/recall.ts
+++ b/platform/core/src/recall.ts
@@ -27,11 +27,24 @@ export interface RecallMeta {
 	readonly noHits: boolean;
 }
 
+export type AggregateRecallBudget = "small" | "medium" | "large";
+
+export interface AggregateRecallMeta {
+	readonly savedMemoryId: string | null;
+	readonly saved: boolean;
+	readonly deduped: boolean;
+	readonly budget: AggregateRecallBudget;
+	readonly queries: readonly string[];
+	readonly sourceMemoryIds: readonly string[];
+	readonly stoppedReason: "complete" | "no_evidence" | "router_unavailable" | "synthesis_failed";
+}
+
 export interface RecallPayload {
 	readonly query?: string;
 	readonly method?: string;
 	readonly results?: ReadonlyArray<RecallRow>;
 	readonly meta?: Partial<RecallMeta>;
+	readonly aggregate?: AggregateRecallMeta;
 	readonly memories?: ReadonlyArray<RecallRow>;
 	readonly count?: number;
 	readonly message?: string;
@@ -57,6 +70,11 @@ export interface RecallRequestOptions {
 	readonly expand?: boolean;
 	readonly agentId?: string;
 	readonly scope?: "global" | "agent" | "session";
+	readonly aggregate?: boolean;
+	readonly aggregateBudget?: AggregateRecallBudget;
+	readonly aggregate_budget?: AggregateRecallBudget;
+	readonly saveAggregate?: boolean;
+	readonly save_aggregate?: boolean;
 }
 
 export interface RememberRequestOptions {
@@ -245,6 +263,14 @@ export function buildRecallRequestBody(query: string, options: RecallRequestOpti
 		expand: options.expand === true ? true : undefined,
 		agentId: options.agentId,
 		scope: options.scope,
+		aggregate: options.aggregate === true ? true : undefined,
+		aggregateBudget: options.aggregateBudget ?? options.aggregate_budget,
+		saveAggregate:
+			options.saveAggregate === false || options.save_aggregate === false
+				? false
+				: options.saveAggregate === true || options.save_aggregate === true
+					? true
+					: undefined,
 	});
 }
 

--- a/platform/daemon/src/aggregate-recall.test.ts
+++ b/platform/daemon/src/aggregate-recall.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -48,6 +49,27 @@ function response(query: string, results: readonly RecallResult[]): RecallRespon
 			timings: { totalMs: 0, stages: [] },
 		},
 	};
+}
+
+function aggregateKeyForTest(input: {
+	readonly agentId: string;
+	readonly project: string | null;
+	readonly query: string;
+	readonly budget: "small" | "medium" | "large";
+	readonly sourceMemoryIds: readonly string[];
+}): string {
+	const hash = createHash("sha256")
+		.update(input.agentId)
+		.update("\0")
+		.update(input.project ?? "")
+		.update("\0")
+		.update(input.query.trim().replace(/\s+/g, " ").toLowerCase())
+		.update("\0")
+		.update(input.budget)
+		.update("\0")
+		.update([...input.sourceMemoryIds].sort().join("\0"))
+		.digest("hex");
+	return `aggregate-recall:${hash}`;
 }
 
 class StaticRouter implements AggregateInferenceRouter {
@@ -495,6 +517,83 @@ describe("aggregateRecall", () => {
 		) as { aggregate_count: number; link_count: number };
 		expect(rows.aggregate_count).toBe(0);
 		expect(rows.link_count).toBe(0);
+	});
+
+	it("does not reuse ordinary memories with matching aggregate idempotency keys", async () => {
+		const content = "Ordinary memory with caller-provided idempotency.";
+		const normalized = normalizeAndHashContent(content);
+		const now = "2026-05-20T12:00:00.000Z";
+		const key = aggregateKeyForTest({
+			agentId: "agent-a",
+			project: "current-project",
+			query: "what happened",
+			budget: "small",
+			sourceMemoryIds: ["mem-1"],
+		});
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, normalized_content, content_hash, idempotency_key,
+					who, project, type, agent_id, visibility, source_type,
+					created_at, updated_at, updated_by
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			).run(
+				"ordinary-idempotency-match",
+				content,
+				normalized.normalizedContent || normalized.hashBasis,
+				normalized.contentHash,
+				key,
+				"test",
+				"current-project",
+				"semantic",
+				"agent-a",
+				"global",
+				"manual",
+				now,
+				now,
+				"test",
+			);
+		});
+
+		const result = await aggregateRecall(
+			{
+				query: "what happened",
+				aggregate: true,
+				agentId: "agent-a",
+				readPolicy: "isolated",
+				project: "current-project",
+			},
+			loadMemoryConfig(dir),
+			{
+				router: new StaticRouter(),
+				embedFn: async () => null,
+				idFactory: () => "aggregate-idempotency-safe",
+				hybridRecall: async (input: RecallParams) => response(input.query, [row("mem-1", "First evidence")]),
+			},
+		);
+
+		expect(result.results).toHaveLength(1);
+		expect(result.results[0].id).toStartWith("aggregate-recall:");
+		expect(result.results[0].id).not.toBe("ordinary-idempotency-match");
+		expect(result.aggregate).toMatchObject({
+			savedMemoryId: null,
+			saved: false,
+			deduped: true,
+			stoppedReason: "complete",
+		});
+		const rows = getDbAccessor().withReadDb((db) =>
+			db
+				.prepare(
+					`SELECT
+						(SELECT COUNT(*) FROM aggregate_memory_sources WHERE aggregate_memory_id = 'ordinary-idempotency-match') AS ordinary_link_count,
+						(SELECT COUNT(*) FROM memories WHERE id = 'aggregate-idempotency-safe') AS aggregate_count,
+						(SELECT COUNT(*) FROM aggregate_memory_sources WHERE aggregate_memory_id = 'aggregate-idempotency-safe') AS aggregate_link_count`,
+				)
+				.get(),
+		) as { ordinary_link_count: number; aggregate_count: number; aggregate_link_count: number };
+		expect(rows.ordinary_link_count).toBe(0);
+		expect(rows.aggregate_count).toBe(0);
+		expect(rows.aggregate_link_count).toBe(0);
 	});
 
 	it("dedupes when a concurrent aggregate insert wins the content-hash race", async () => {

--- a/platform/daemon/src/aggregate-recall.test.ts
+++ b/platform/daemon/src/aggregate-recall.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { RouteRequest, RouterResult } from "@signet/core";
-import { type AggregateInferenceRouter, aggregateRecall } from "./aggregate-recall";
+import { type AggregateInferenceRouter, InvalidAggregateRecallBudgetError, aggregateRecall } from "./aggregate-recall";
 import { normalizeAndHashContent } from "./content-normalization";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import { loadMemoryConfig } from "./memory-config";
@@ -87,6 +87,25 @@ describe("aggregateRecall", () => {
 			process.env.SIGNET_PATH = prevSignetPath;
 		}
 		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("rejects invalid aggregate budgets instead of falling back to small", async () => {
+		await expect(
+			aggregateRecall(
+				{
+					query: "what happened",
+					aggregate: true,
+					aggregateBudget: "maximum",
+				} as unknown as RecallParams,
+				loadMemoryConfig(dir),
+				{
+					router: new StaticRouter(),
+					embedFn: async () => null,
+					logger: quietLogger(),
+					hybridRecall: async () => response("what happened", []),
+				},
+			),
+		).rejects.toBeInstanceOf(InvalidAggregateRecallBudgetError);
 	});
 
 	it("synthesizes, saves one normal memory, and links evidence sources", async () => {

--- a/platform/daemon/src/aggregate-recall.test.ts
+++ b/platform/daemon/src/aggregate-recall.test.ts
@@ -8,6 +8,7 @@ import { normalizeAndHashContent } from "./content-normalization";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import { loadMemoryConfig } from "./memory-config";
 import type { RecallParams, RecallResponse, RecallResult } from "./memory-search";
+import { txIngestEnvelope } from "./transactions";
 
 function row(id: string, content: string): RecallResult {
 	const now = "2026-05-20T12:00:00.000Z";
@@ -363,6 +364,56 @@ describe("aggregateRecall", () => {
 		) as { aggregate_count: number; link_count: number };
 		expect(rows.aggregate_count).toBe(0);
 		expect(rows.link_count).toBe(0);
+	});
+
+	it("dedupes when a concurrent aggregate insert wins the content-hash race", async () => {
+		let raced = false;
+		const result = await aggregateRecall(
+			{
+				query: "what happened",
+				aggregate: true,
+				agentId: "agent-a",
+				readPolicy: "isolated",
+				project: "current-project",
+			},
+			loadMemoryConfig(dir),
+			{
+				router: new StaticRouter(),
+				embedFn: async () => null,
+				idFactory: () => "aggregate-loser",
+				hybridRecall: async (input: RecallParams) => response(input.query, [row("mem-1", "First evidence")]),
+				ingestEnvelope: (db, mem) => {
+					if (!raced) {
+						raced = true;
+						txIngestEnvelope(db, {
+							...mem,
+							id: "aggregate-race-winner",
+						});
+					}
+					return txIngestEnvelope(db, mem);
+				},
+			},
+		);
+
+		expect(result.results).toHaveLength(1);
+		expect(result.results[0].id).toBe("aggregate-race-winner");
+		expect(result.aggregate).toMatchObject({
+			savedMemoryId: "aggregate-race-winner",
+			saved: true,
+			deduped: true,
+			stoppedReason: "complete",
+		});
+		const rows = getDbAccessor().withReadDb((db) =>
+			db
+				.prepare(
+					`SELECT
+						(SELECT COUNT(*) FROM memories WHERE id = 'aggregate-loser') AS loser_count,
+						(SELECT COUNT(*) FROM aggregate_memory_sources WHERE aggregate_memory_id = 'aggregate-race-winner') AS link_count`,
+				)
+				.get(),
+		) as { loser_count: number; link_count: number };
+		expect(rows.loser_count).toBe(0);
+		expect(rows.link_count).toBe(1);
 	});
 
 	it("returns structured no-hit metadata when synthesis is unavailable", async () => {

--- a/platform/daemon/src/aggregate-recall.test.ts
+++ b/platform/daemon/src/aggregate-recall.test.ts
@@ -1,0 +1,279 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { RouteRequest, RouterResult } from "@signet/core";
+import { type AggregateInferenceRouter, aggregateRecall } from "./aggregate-recall";
+import { normalizeAndHashContent } from "./content-normalization";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { loadMemoryConfig } from "./memory-config";
+import type { RecallParams, RecallResponse, RecallResult } from "./memory-search";
+
+function row(id: string, content: string): RecallResult {
+	const now = "2026-05-20T12:00:00.000Z";
+	return {
+		id,
+		content,
+		content_length: content.length,
+		truncated: false,
+		score: 0.9,
+		source: "hybrid",
+		type: "semantic",
+		tags: null,
+		pinned: false,
+		importance: 0.7,
+		who: "test",
+		project: null,
+		created_at: now,
+	};
+}
+
+function response(query: string, results: readonly RecallResult[]): RecallResponse {
+	return {
+		results: [...results],
+		query,
+		method: "hybrid",
+		meta: {
+			totalReturned: results.length,
+			hasSupplementary: false,
+			noHits: results.length === 0,
+			timings: { totalMs: 0, stages: [] },
+		},
+	};
+}
+
+class StaticRouter implements AggregateInferenceRouter {
+	calls: RouteRequest[] = [];
+
+	async execute(request: RouteRequest): Promise<RouterResult<{ readonly text: string }>> {
+		this.calls.push(request);
+		return {
+			ok: true,
+			value: {
+				text:
+					this.calls.length === 1
+						? JSON.stringify({ queries: ["follow up one", "follow up two"] })
+						: "Aggregate answer from memory evidence.",
+			},
+		};
+	}
+}
+
+describe("aggregateRecall", () => {
+	let dir = "";
+	let prevSignetPath: string | undefined;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "signet-aggregate-recall-"));
+		mkdirSync(join(dir, "memory"), { recursive: true });
+		writeFileSync(join(dir, "agent.yaml"), "name: AggregateRecallTest\n");
+		prevSignetPath = process.env.SIGNET_PATH;
+		process.env.SIGNET_PATH = dir;
+		initDbAccessor(join(dir, "memory", "memories.db"));
+	});
+
+	afterEach(() => {
+		closeDbAccessor();
+		if (prevSignetPath === undefined) {
+			Reflect.deleteProperty(process.env as Record<string, string | undefined>, "SIGNET_PATH");
+		} else {
+			process.env.SIGNET_PATH = prevSignetPath;
+		}
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("synthesizes, saves one normal memory, and links evidence sources", async () => {
+		const router = new StaticRouter();
+		const calls: string[] = [];
+		const result = await aggregateRecall(
+			{
+				query: "what happened",
+				aggregate: true,
+				aggregateBudget: "small",
+				agentId: "agent-a",
+				readPolicy: "isolated",
+			},
+			loadMemoryConfig(dir),
+			{
+				router,
+				embedFn: async () => null,
+				now: () => new Date("2026-05-20T12:00:00.000Z"),
+				idFactory: () => "aggregate-1",
+				hybridRecall: async (params: RecallParams) => {
+					calls.push(params.query);
+					if (params.query === "follow up one") return response(params.query, [row("mem-2", "Second evidence")]);
+					if (params.query === "follow up two") return response(params.query, [row("mem-3", "Third evidence")]);
+					return response(params.query, [row("mem-1", "First evidence")]);
+				},
+			},
+		);
+
+		expect(calls).toEqual(["what happened", "follow up one", "follow up two"]);
+		expect(router.calls.map((call) => call.operation)).toEqual(["tool_planning", "tool_planning"]);
+		expect(result.results).toHaveLength(1);
+		expect(result.results[0].id).toBe("aggregate-1");
+		expect(result.results[0].source).toBe("aggregate-recall");
+		expect(result.aggregate).toMatchObject({
+			savedMemoryId: "aggregate-1",
+			saved: true,
+			deduped: false,
+			sourceMemoryIds: ["mem-1", "mem-2", "mem-3"],
+			stoppedReason: "complete",
+		});
+
+		const saved = getDbAccessor().withReadDb((db) =>
+			db.prepare("SELECT source_type, idempotency_key, tags, who, type FROM memories WHERE id = ?").get("aggregate-1"),
+		) as Record<string, unknown>;
+		expect(saved.source_type).toBe("aggregate-recall");
+		expect(saved.idempotency_key).toStartWith("aggregate-recall:");
+		expect(saved.tags).toBe("aggregate,recall");
+		expect(saved.who).toBe("signet");
+		expect(saved.type).toBe("semantic");
+
+		const links = getDbAccessor().withReadDb((db) =>
+			db
+				.prepare(
+					"SELECT source_memory_id FROM aggregate_memory_sources WHERE aggregate_memory_id = ? ORDER BY source_memory_id",
+				)
+				.all("aggregate-1"),
+		) as Array<{ source_memory_id: string }>;
+		expect(links.map((link) => link.source_memory_id)).toEqual(["mem-1", "mem-2", "mem-3"]);
+	});
+
+	it("dedupes repeated aggregate runs for the same evidence set", async () => {
+		const params: RecallParams = {
+			query: "what happened",
+			aggregate: true,
+			agentId: "agent-a",
+			readPolicy: "isolated",
+		};
+		const deps = {
+			router: new StaticRouter(),
+			embedFn: async () => null,
+			now: () => new Date("2026-05-20T12:00:00.000Z"),
+			idFactory: () => "aggregate-1",
+			hybridRecall: async (input: RecallParams) => response(input.query, [row("mem-1", "First evidence")]),
+		};
+
+		const first = await aggregateRecall(params, loadMemoryConfig(dir), deps);
+		const second = await aggregateRecall(params, loadMemoryConfig(dir), {
+			...deps,
+			router: new StaticRouter(),
+			idFactory: () => "aggregate-2",
+		});
+
+		expect(first.results[0].id).toBe("aggregate-1");
+		expect(second.results[0].id).toBe("aggregate-1");
+		expect(second.aggregate?.deduped).toBe(true);
+	});
+
+	it("returns an unsaved aggregate answer when saving is disabled", async () => {
+		const result = await aggregateRecall(
+			{
+				query: "what happened",
+				aggregate: true,
+				saveAggregate: false,
+				agentId: "agent-a",
+				readPolicy: "isolated",
+			},
+			loadMemoryConfig(dir),
+			{
+				router: new StaticRouter(),
+				embedFn: async () => null,
+				hybridRecall: async (input: RecallParams) => response(input.query, [row("mem-1", "First evidence")]),
+			},
+		);
+
+		expect(result.results).toHaveLength(1);
+		expect(result.results[0].content).toBe("Aggregate answer from memory evidence.");
+		expect(result.aggregate?.saved).toBe(false);
+		expect(result.aggregate?.savedMemoryId).toBeNull();
+		const count = getDbAccessor().withReadDb((db) => db.prepare("SELECT COUNT(*) AS n FROM memories").get()) as {
+			n: number;
+		};
+		expect(count.n).toBe(0);
+	});
+
+	it("returns unsaved aggregate when content hash conflicts with an inaccessible memory", async () => {
+		const answer = "Aggregate answer from memory evidence.";
+		const normalized = normalizeAndHashContent(answer);
+		const now = "2026-05-20T12:00:00.000Z";
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, normalized_content, content_hash, who, project, type,
+					agent_id, visibility, created_at, updated_at, updated_by
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			).run(
+				"private-duplicate",
+				answer,
+				normalized.normalizedContent || normalized.hashBasis,
+				normalized.contentHash,
+				"test",
+				"other-project",
+				"semantic",
+				"agent-a",
+				"private",
+				now,
+				now,
+				"test",
+			);
+		});
+
+		const result = await aggregateRecall(
+			{
+				query: "what happened",
+				aggregate: true,
+				agentId: "agent-a",
+				readPolicy: "isolated",
+				project: "current-project",
+			},
+			loadMemoryConfig(dir),
+			{
+				router: new StaticRouter(),
+				embedFn: async () => null,
+				idFactory: () => "aggregate-conflict",
+				hybridRecall: async (input: RecallParams) => response(input.query, [row("mem-1", "First evidence")]),
+			},
+		);
+
+		expect(result.results).toHaveLength(1);
+		expect(result.results[0].id).toStartWith("aggregate-recall:");
+		expect(result.aggregate).toMatchObject({
+			savedMemoryId: null,
+			saved: false,
+			deduped: true,
+			stoppedReason: "complete",
+		});
+		const aggregateRows = getDbAccessor().withReadDb((db) =>
+			db.prepare("SELECT COUNT(*) AS n FROM memories WHERE id = ?").get("aggregate-conflict"),
+		) as { n: number };
+		expect(aggregateRows.n).toBe(0);
+	});
+
+	it("returns structured no-hit metadata when synthesis is unavailable", async () => {
+		const result = await aggregateRecall(
+			{
+				query: "what happened",
+				aggregate: true,
+				agentId: "agent-a",
+				readPolicy: "isolated",
+			},
+			loadMemoryConfig(dir),
+			{
+				router: null,
+				embedFn: async () => null,
+				hybridRecall: async (input: RecallParams) => response(input.query, [row("mem-1", "First evidence")]),
+			},
+		);
+
+		expect(result.results).toEqual([]);
+		expect(result.meta.noHits).toBe(true);
+		expect(result.aggregate).toMatchObject({
+			saved: false,
+			savedMemoryId: null,
+			stoppedReason: "router_unavailable",
+			sourceMemoryIds: ["mem-1"],
+		});
+	});
+});

--- a/platform/daemon/src/aggregate-recall.test.ts
+++ b/platform/daemon/src/aggregate-recall.test.ts
@@ -299,6 +299,72 @@ describe("aggregateRecall", () => {
 		expect(aggregateRows.n).toBe(0);
 	});
 
+	it("does not reuse visible ordinary memories as saved aggregate dedupes", async () => {
+		const answer = "Aggregate answer from memory evidence.";
+		const normalized = normalizeAndHashContent(answer);
+		const now = "2026-05-20T12:00:00.000Z";
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, normalized_content, content_hash, who, project, type,
+					agent_id, visibility, source_type, created_at, updated_at, updated_by
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			).run(
+				"ordinary-duplicate",
+				answer,
+				normalized.normalizedContent || normalized.hashBasis,
+				normalized.contentHash,
+				"test",
+				"current-project",
+				"semantic",
+				"agent-a",
+				"global",
+				"manual",
+				now,
+				now,
+				"test",
+			);
+		});
+
+		const result = await aggregateRecall(
+			{
+				query: "what happened",
+				aggregate: true,
+				agentId: "agent-a",
+				readPolicy: "isolated",
+				project: "current-project",
+			},
+			loadMemoryConfig(dir),
+			{
+				router: new StaticRouter(),
+				embedFn: async () => null,
+				idFactory: () => "aggregate-visible-conflict",
+				hybridRecall: async (input: RecallParams) => response(input.query, [row("mem-1", "First evidence")]),
+			},
+		);
+
+		expect(result.results).toHaveLength(1);
+		expect(result.results[0].id).toStartWith("aggregate-recall:");
+		expect(result.results[0].id).not.toBe("ordinary-duplicate");
+		expect(result.aggregate).toMatchObject({
+			savedMemoryId: null,
+			saved: false,
+			deduped: true,
+			stoppedReason: "complete",
+		});
+		const rows = getDbAccessor().withReadDb((db) =>
+			db
+				.prepare(
+					`SELECT
+						(SELECT COUNT(*) FROM memories WHERE id = 'aggregate-visible-conflict') AS aggregate_count,
+						(SELECT COUNT(*) FROM aggregate_memory_sources WHERE aggregate_memory_id = 'ordinary-duplicate') AS link_count`,
+				)
+				.get(),
+		) as { aggregate_count: number; link_count: number };
+		expect(rows.aggregate_count).toBe(0);
+		expect(rows.link_count).toBe(0);
+	});
+
 	it("returns structured no-hit metadata when synthesis is unavailable", async () => {
 		const result = await aggregateRecall(
 			{

--- a/platform/daemon/src/aggregate-recall.test.ts
+++ b/platform/daemon/src/aggregate-recall.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -59,6 +59,12 @@ class StaticRouter implements AggregateInferenceRouter {
 	}
 }
 
+function quietLogger(): { readonly warn: ReturnType<typeof mock> } {
+	return {
+		warn: mock((_category: string, _message: string, _data?: Record<string, unknown>) => {}),
+	};
+}
+
 describe("aggregateRecall", () => {
 	let dir = "";
 	let prevSignetPath: string | undefined;
@@ -97,6 +103,7 @@ describe("aggregateRecall", () => {
 			{
 				router,
 				embedFn: async () => null,
+				logger: quietLogger(),
 				now: () => new Date("2026-05-20T12:00:00.000Z"),
 				idFactory: () => "aggregate-1",
 				hybridRecall: async (params: RecallParams) => {
@@ -150,6 +157,7 @@ describe("aggregateRecall", () => {
 		const deps = {
 			router: new StaticRouter(),
 			embedFn: async () => null,
+			logger: quietLogger(),
 			now: () => new Date("2026-05-20T12:00:00.000Z"),
 			idFactory: () => "aggregate-1",
 			hybridRecall: async (input: RecallParams) => response(input.query, [row("mem-1", "First evidence")]),
@@ -165,6 +173,46 @@ describe("aggregateRecall", () => {
 		expect(first.results[0].id).toBe("aggregate-1");
 		expect(second.results[0].id).toBe("aggregate-1");
 		expect(second.aggregate?.deduped).toBe(true);
+	});
+
+	it("logs when a saved aggregate memory cannot be embedded", async () => {
+		const log = quietLogger();
+		const result = await aggregateRecall(
+			{
+				query: "what happened",
+				aggregate: true,
+				agentId: "agent-a",
+				readPolicy: "isolated",
+			},
+			loadMemoryConfig(dir),
+			{
+				router: new StaticRouter(),
+				logger: log,
+				embedFn: async () => {
+					throw new Error("embedding provider unavailable");
+				},
+				now: () => new Date("2026-05-20T12:00:00.000Z"),
+				idFactory: () => "aggregate-embed-fail",
+				hybridRecall: async (input: RecallParams) => response(input.query, [row("mem-1", "First evidence")]),
+			},
+		);
+
+		expect(result.aggregate).toMatchObject({
+			savedMemoryId: "aggregate-embed-fail",
+			saved: true,
+			stoppedReason: "complete",
+		});
+		expect(log.warn).toHaveBeenCalledTimes(1);
+		expect(log.warn).toHaveBeenCalledWith(
+			"memory",
+			"Aggregate recall memory saved without embedding",
+			expect.objectContaining({
+				memoryId: "aggregate-embed-fail",
+				agentId: "agent-a",
+				reason: "embedding_exception",
+				errorMessage: "embedding provider unavailable",
+			}),
+		);
 	});
 
 	it("returns an unsaved aggregate answer when saving is disabled", async () => {

--- a/platform/daemon/src/aggregate-recall.test.ts
+++ b/platform/daemon/src/aggregate-recall.test.ts
@@ -298,6 +298,44 @@ describe("aggregateRecall", () => {
 		expect(count.n).toBe(0);
 	});
 
+	it("does not link synthesized recall rows as aggregate memory sources", async () => {
+		const result = await aggregateRecall(
+			{
+				query: "what happened",
+				aggregate: true,
+				agentId: "agent-a",
+			},
+			loadMemoryConfig(dir),
+			{
+				router: new StaticRouter(),
+				embedFn: async () => null,
+				logger: quietLogger(),
+				now: () => new Date("2026-05-20T12:00:00.000Z"),
+				idFactory: () => "aggregate-sources",
+				hybridRecall: async (params: RecallParams) =>
+					response(params.query, [
+						{
+							...row("summary:abc", "Synthetic summary should not be provenance"),
+							source: "llm_summary",
+							supplementary: true,
+						},
+						row("mem-1", "Real evidence"),
+					]),
+			},
+		);
+
+		expect(result.aggregate?.sourceMemoryIds).toEqual(["mem-1"]);
+		const links = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare(
+						"SELECT source_memory_id FROM aggregate_memory_sources WHERE aggregate_memory_id = ? ORDER BY source_memory_id",
+					)
+					.all("aggregate-sources") as Array<{ source_memory_id: string }>,
+		);
+		expect(links.map((link) => link.source_memory_id)).toEqual(["mem-1"]);
+	});
+
 	it("returns unsaved aggregate when content hash conflicts with an inaccessible memory", async () => {
 		const answer = "Aggregate answer from memory evidence.";
 		const normalized = normalizeAndHashContent(answer);

--- a/platform/daemon/src/aggregate-recall.test.ts
+++ b/platform/daemon/src/aggregate-recall.test.ts
@@ -10,7 +10,11 @@ import { loadMemoryConfig } from "./memory-config";
 import type { RecallParams, RecallResponse, RecallResult } from "./memory-search";
 import { txIngestEnvelope } from "./transactions";
 
-function row(id: string, content: string): RecallResult {
+function row(
+	id: string,
+	content: string,
+	opts: { readonly visibility?: string | null; readonly scope?: string | null } = {},
+): RecallResult {
 	const now = "2026-05-20T12:00:00.000Z";
 	return {
 		id,
@@ -26,6 +30,7 @@ function row(id: string, content: string): RecallResult {
 		who: "test",
 		project: null,
 		created_at: now,
+		...opts,
 	};
 }
 
@@ -259,6 +264,37 @@ describe("aggregateRecall", () => {
 		const count = getDbAccessor().withReadDb((db) => db.prepare("SELECT COUNT(*) AS n FROM memories").get()) as {
 			n: number;
 		};
+		expect(count.n).toBe(0);
+	});
+
+	it("does not save global aggregate memories from private evidence", async () => {
+		const result = await aggregateRecall(
+			{
+				query: "private history",
+				aggregate: true,
+				agentId: "agent-private",
+			},
+			loadMemoryConfig(dir),
+			{
+				router: new StaticRouter(),
+				embedFn: async () => null,
+				logger: quietLogger(),
+				idFactory: () => "aggregate-private",
+				hybridRecall: async (params: RecallParams) =>
+					response(params.query, [row("mem-private", "Private evidence", { visibility: "private" })]),
+			},
+		);
+
+		expect(result.results[0].id).toStartWith("aggregate-recall:");
+		expect(result.aggregate).toMatchObject({
+			savedMemoryId: null,
+			saved: false,
+			deduped: false,
+			stoppedReason: "complete",
+		});
+		const count = getDbAccessor().withReadDb(
+			(db) => db.prepare("SELECT COUNT(*) AS n FROM memories WHERE id = ?").get("aggregate-private") as { n: number },
+		);
 		expect(count.n).toBe(0);
 	});
 

--- a/platform/daemon/src/aggregate-recall.test.ts
+++ b/platform/daemon/src/aggregate-recall.test.ts
@@ -30,6 +30,8 @@ function row(
 		who: "test",
 		project: null,
 		created_at: now,
+		visibility: "global",
+		scope: null,
 		...opts,
 	};
 }
@@ -294,6 +296,42 @@ describe("aggregateRecall", () => {
 		});
 		const count = getDbAccessor().withReadDb(
 			(db) => db.prepare("SELECT COUNT(*) AS n FROM memories WHERE id = ?").get("aggregate-private") as { n: number },
+		);
+		expect(count.n).toBe(0);
+	});
+
+	it("does not save aggregate memories when evidence lacks explicit global scope metadata", async () => {
+		const result = await aggregateRecall(
+			{
+				query: "legacy history",
+				aggregate: true,
+				agentId: "agent-legacy",
+			},
+			loadMemoryConfig(dir),
+			{
+				router: new StaticRouter(),
+				embedFn: async () => null,
+				logger: quietLogger(),
+				idFactory: () => "aggregate-legacy",
+				hybridRecall: async (params: RecallParams) =>
+					response(params.query, [
+						row("mem-legacy", "Legacy evidence without scope metadata", {
+							visibility: undefined,
+							scope: undefined,
+						}),
+					]),
+			},
+		);
+
+		expect(result.results[0].id).toStartWith("aggregate-recall:");
+		expect(result.aggregate).toMatchObject({
+			savedMemoryId: null,
+			saved: false,
+			deduped: false,
+			stoppedReason: "complete",
+		});
+		const count = getDbAccessor().withReadDb(
+			(db) => db.prepare("SELECT COUNT(*) AS n FROM memories WHERE id = ?").get("aggregate-legacy") as { n: number },
 		);
 		expect(count.n).toBe(0);
 	});

--- a/platform/daemon/src/aggregate-recall.ts
+++ b/platform/daemon/src/aggregate-recall.ts
@@ -182,6 +182,10 @@ function uniqueEvidence(rows: readonly RecallResult[]): RecallResult[] {
 	return result;
 }
 
+function evidenceCanSaveAsGlobalAggregate(rows: readonly RecallResult[]): boolean {
+	return rows.every((row) => (row.visibility ?? "global") === "global" && (row.scope ?? null) === null);
+}
+
 function aggregateKey(input: {
 	readonly agentId: string;
 	readonly project: string | null;
@@ -506,7 +510,7 @@ export async function aggregateRecall(
 	let row: RecallResult | null;
 	let deduped = false;
 	let saved = false;
-	if (saveAggregate) {
+	if (saveAggregate && evidenceCanSaveAsGlobalAggregate(evidence)) {
 		const normalized = normalizeAndHashContent(answer);
 		row = getDbAccessor().withWriteTx((db) => {
 			const duplicate = resolveAggregateDuplicate(db, {

--- a/platform/daemon/src/aggregate-recall.ts
+++ b/platform/daemon/src/aggregate-recall.ts
@@ -259,6 +259,7 @@ function loadAggregateByKey(
 			 FROM memories
 			 WHERE idempotency_key = ?
 			   AND COALESCE(NULLIF(agent_id, ''), 'default') = ?
+			   AND source_type = 'aggregate-recall'
 			   AND visibility = 'global'
 			   AND scope IS NULL
 			   AND is_deleted = 0
@@ -571,7 +572,11 @@ export async function aggregateRecall(
 					sourceMemoryIds,
 					now,
 				});
-				if (!racedDuplicate) throw err;
+				if (!racedDuplicate) {
+					deduped = true;
+					saved = false;
+					return unsavedAggregateResult(answer, key, project);
+				}
 				deduped = true;
 				saved = racedDuplicate.saved;
 				return racedDuplicate.row;

--- a/platform/daemon/src/aggregate-recall.ts
+++ b/platform/daemon/src/aggregate-recall.ts
@@ -6,7 +6,7 @@ import { syncVecDeleteBySourceId, syncVecInsert, vectorToBlob } from "./db-helpe
 import { logger } from "./logger";
 import type { EmbeddingConfig, ResolvedMemoryConfig } from "./memory-config";
 import { type EmbedFn, type RecallParams, type RecallResponse, type RecallResult, hybridRecall } from "./memory-search";
-import { txIngestEnvelope } from "./transactions";
+import { type IngestEnvelope, txIngestEnvelope } from "./transactions";
 
 export type AggregateRecallBudget = "small" | "medium" | "large";
 export type AggregateRecallStoppedReason = "complete" | "no_evidence" | "router_unavailable" | "synthesis_failed";
@@ -30,6 +30,7 @@ interface AggregateRecallDeps {
 	readonly now?: () => Date;
 	readonly idFactory?: () => string;
 	readonly logger?: AggregateRecallLogger;
+	readonly ingestEnvelope?: (db: WriteDb, mem: IngestEnvelope) => string;
 }
 
 interface AggregateRecallLogger {
@@ -55,6 +56,11 @@ interface ContentHashMatch {
 	readonly row: RecallResult;
 	readonly visibleForAggregate: boolean;
 	readonly aggregateRecallMemory: boolean;
+}
+
+interface AggregateDuplicateResolution {
+	readonly row: RecallResult;
+	readonly saved: boolean;
 }
 
 const BUDGET_QUERY_LIMITS: Record<AggregateRecallBudget, number> = {
@@ -271,6 +277,39 @@ function linkAggregateSources(
 	}
 }
 
+function resolveAggregateDuplicate(
+	db: WriteDb,
+	input: {
+		readonly key: string;
+		readonly agentId: string;
+		readonly project: string | null;
+		readonly contentHash: string;
+		readonly answer: string;
+		readonly sourceMemoryIds: readonly string[];
+		readonly now: string;
+	},
+): AggregateDuplicateResolution | null {
+	const existing = loadAggregateByKey(db, input.key, { agentId: input.agentId, project: input.project });
+	if (existing) {
+		linkAggregateSources(db, existing.id, input.sourceMemoryIds, input.agentId, input.now);
+		return { row: existing, saved: true };
+	}
+	const duplicateContent = loadMemoryByContentHash(db, input.contentHash, {
+		agentId: input.agentId,
+		project: input.project,
+	});
+	if (!duplicateContent) return null;
+	if (!duplicateContent.visibleForAggregate || !duplicateContent.aggregateRecallMemory) {
+		return { row: unsavedAggregateResult(input.answer, input.key, input.project), saved: false };
+	}
+	linkAggregateSources(db, duplicateContent.row.id, input.sourceMemoryIds, input.agentId, input.now);
+	return { row: duplicateContent.row, saved: true };
+}
+
+function isUniqueConstraintError(err: unknown): boolean {
+	return err instanceof Error && /UNIQUE constraint failed|constraint failed/i.test(err.message);
+}
+
 async function embedAggregateMemory(
 	memoryId: string,
 	content: string,
@@ -387,6 +426,7 @@ export async function aggregateRecall(
 	const recall = deps.hybridRecall ?? hybridRecall;
 	const saveAggregate = params.saveAggregate !== false && params.save_aggregate !== false;
 	const log = deps.logger ?? logger;
+	const ingestEnvelope = deps.ingestEnvelope ?? txIngestEnvelope;
 	const first = await recall(params, cfg, deps.embedFn);
 
 	if (!deps.router) {
@@ -445,26 +485,22 @@ export async function aggregateRecall(
 	if (saveAggregate) {
 		const normalized = normalizeAndHashContent(answer);
 		row = getDbAccessor().withWriteTx((db) => {
-			const existing = loadAggregateByKey(db, key, { agentId, project });
-			if (existing) {
-				linkAggregateSources(db, existing.id, sourceMemoryIds, agentId, now);
+			const duplicate = resolveAggregateDuplicate(db, {
+				key,
+				agentId,
+				project,
+				contentHash: normalized.contentHash,
+				answer,
+				sourceMemoryIds,
+				now,
+			});
+			if (duplicate) {
 				deduped = true;
-				saved = true;
-				return existing;
-			}
-			const duplicateContent = loadMemoryByContentHash(db, normalized.contentHash, { agentId, project });
-			if (duplicateContent) {
-				if (!duplicateContent.visibleForAggregate || !duplicateContent.aggregateRecallMemory) {
-					deduped = true;
-					return unsavedAggregateResult(answer, key, project);
-				}
-				linkAggregateSources(db, duplicateContent.row.id, sourceMemoryIds, agentId, now);
-				deduped = true;
-				saved = true;
-				return duplicateContent.row;
+				saved = duplicate.saved;
+				return duplicate.row;
 			}
 			const id = deps.idFactory?.() ?? randomUUID();
-			txIngestEnvelope(db, {
+			const envelope: IngestEnvelope = {
 				id,
 				content: normalized.storageContent,
 				normalizedContent: normalized.normalizedContent || normalized.hashBasis,
@@ -488,7 +524,25 @@ export async function aggregateRecall(
 				agentId,
 				visibility: "global",
 				createdAt: now,
-			});
+			};
+			try {
+				ingestEnvelope(db, envelope);
+			} catch (err) {
+				if (!isUniqueConstraintError(err)) throw err;
+				const racedDuplicate = resolveAggregateDuplicate(db, {
+					key,
+					agentId,
+					project,
+					contentHash: normalized.contentHash,
+					answer,
+					sourceMemoryIds,
+					now,
+				});
+				if (!racedDuplicate) throw err;
+				deduped = true;
+				saved = racedDuplicate.saved;
+				return racedDuplicate.row;
+			}
 			linkAggregateSources(db, id, sourceMemoryIds, agentId, now);
 			saved = true;
 			return loadAggregateMemory(db, id);

--- a/platform/daemon/src/aggregate-recall.ts
+++ b/platform/daemon/src/aggregate-recall.ts
@@ -39,6 +39,7 @@ interface AggregateRecallLogger {
 interface AggregateMemoryRow {
 	readonly id: string;
 	readonly content: string;
+	readonly source_type?: string | null;
 	readonly source_id: string | null;
 	readonly type: string;
 	readonly tags: string | null;
@@ -53,6 +54,7 @@ interface AggregateMemoryRow {
 interface ContentHashMatch {
 	readonly row: RecallResult;
 	readonly visibleForAggregate: boolean;
+	readonly aggregateRecallMemory: boolean;
 }
 
 const BUDGET_QUERY_LIMITS: Record<AggregateRecallBudget, number> = {
@@ -235,7 +237,7 @@ function loadMemoryByContentHash(
 ): ContentHashMatch | null {
 	const row = db
 		.prepare(
-			`SELECT id, content, source_id, type, tags, pinned, importance, who, project, visibility, created_at
+			`SELECT id, content, source_type, source_id, type, tags, pinned, importance, who, project, visibility, created_at
 			 FROM memories
 			 WHERE content_hash = ?
 			   AND COALESCE(NULLIF(agent_id, ''), 'default') = ?
@@ -249,6 +251,7 @@ function loadMemoryByContentHash(
 		row: rowToRecallResult(row),
 		visibleForAggregate:
 			(row.visibility ?? "global") === "global" && (input.project === null || row.project === input.project),
+		aggregateRecallMemory: row.source_type === "aggregate-recall",
 	};
 }
 
@@ -451,7 +454,7 @@ export async function aggregateRecall(
 			}
 			const duplicateContent = loadMemoryByContentHash(db, normalized.contentHash, { agentId, project });
 			if (duplicateContent) {
-				if (!duplicateContent.visibleForAggregate) {
+				if (!duplicateContent.visibleForAggregate || !duplicateContent.aggregateRecallMemory) {
 					deduped = true;
 					return unsavedAggregateResult(answer, key, project);
 				}

--- a/platform/daemon/src/aggregate-recall.ts
+++ b/platform/daemon/src/aggregate-recall.ts
@@ -168,7 +168,13 @@ function parsePlannerQueries(raw: string): string[] {
 }
 
 function isSourceMemoryRow(row: RecallResult): boolean {
-	return !row.id.startsWith("constructed:");
+	return (
+		row.source !== "llm_summary" &&
+		!row.id.startsWith("constructed:") &&
+		!row.id.startsWith("summary:") &&
+		!row.id.startsWith("source-chunk:") &&
+		!row.id.startsWith("native-artifact:")
+	);
 }
 
 function uniqueEvidence(rows: readonly RecallResult[]): RecallResult[] {

--- a/platform/daemon/src/aggregate-recall.ts
+++ b/platform/daemon/src/aggregate-recall.ts
@@ -69,8 +69,32 @@ const BUDGET_QUERY_LIMITS: Record<AggregateRecallBudget, number> = {
 	large: 8,
 };
 
+export class InvalidAggregateRecallBudgetError extends Error {
+	constructor() {
+		super("Invalid aggregateBudget. Expected one of: small, medium, large.");
+		this.name = "InvalidAggregateRecallBudgetError";
+	}
+}
+
+export function parseAggregateRecallBudget(raw: unknown): AggregateRecallBudget | null {
+	if (raw === undefined) return "small";
+	if (raw === "small" || raw === "medium" || raw === "large") return raw;
+	return null;
+}
+
+export function readAggregateRecallBudgetInput(input: {
+	readonly aggregateBudget?: unknown;
+	readonly aggregate_budget?: unknown;
+}): unknown {
+	if (Object.hasOwn(input, "aggregateBudget")) return input.aggregateBudget;
+	if (Object.hasOwn(input, "aggregate_budget")) return input.aggregate_budget;
+	return undefined;
+}
+
 function normalizeBudget(raw: unknown): AggregateRecallBudget {
-	return raw === "medium" || raw === "large" ? raw : "small";
+	const budget = parseAggregateRecallBudget(raw);
+	if (!budget) throw new InvalidAggregateRecallBudgetError();
+	return budget;
 }
 
 function emptyAggregateResponse(

--- a/platform/daemon/src/aggregate-recall.ts
+++ b/platform/daemon/src/aggregate-recall.ts
@@ -3,6 +3,7 @@ import type { RouteRequest, RouterResult } from "@signet/core";
 import { normalizeAndHashContent } from "./content-normalization";
 import { type WriteDb, getDbAccessor } from "./db-accessor";
 import { syncVecDeleteBySourceId, syncVecInsert, vectorToBlob } from "./db-helpers";
+import { logger } from "./logger";
 import type { EmbeddingConfig, ResolvedMemoryConfig } from "./memory-config";
 import { type EmbedFn, type RecallParams, type RecallResponse, type RecallResult, hybridRecall } from "./memory-search";
 import { txIngestEnvelope } from "./transactions";
@@ -28,6 +29,11 @@ interface AggregateRecallDeps {
 	readonly embedFn: EmbedFn;
 	readonly now?: () => Date;
 	readonly idFactory?: () => string;
+	readonly logger?: AggregateRecallLogger;
+}
+
+interface AggregateRecallLogger {
+	readonly warn: (category: "memory", message: string, data?: Record<string, unknown>) => void;
 }
 
 interface AggregateMemoryRow {
@@ -377,6 +383,7 @@ export async function aggregateRecall(
 	const maxQueries = BUDGET_QUERY_LIMITS[budget];
 	const recall = deps.hybridRecall ?? hybridRecall;
 	const saveAggregate = params.saveAggregate !== false && params.save_aggregate !== false;
+	const log = deps.logger ?? logger;
 	const first = await recall(params, cfg, deps.embedFn);
 
 	if (!deps.router) {
@@ -484,9 +491,34 @@ export async function aggregateRecall(
 			return loadAggregateMemory(db, id);
 		});
 		if (row && !deduped) {
-			await embedAggregateMemory(row.id, row.content, normalized.contentHash, now, cfg.embedding, deps.embedFn).catch(
-				() => false,
-			);
+			let embedded = false;
+			let embeddingError: unknown;
+			try {
+				embedded = await embedAggregateMemory(
+					row.id,
+					row.content,
+					normalized.contentHash,
+					now,
+					cfg.embedding,
+					deps.embedFn,
+				);
+			} catch (err) {
+				embeddingError = err;
+			}
+			if (!embedded) {
+				log.warn("memory", "Aggregate recall memory saved without embedding", {
+					memoryId: row.id,
+					agentId,
+					project,
+					sourceId: key,
+					contentHash: normalized.contentHash,
+					sourceMemoryIds,
+					reason: embeddingError instanceof Error ? "embedding_exception" : "embedding_unavailable",
+					...(embeddingError instanceof Error
+						? { errorName: embeddingError.name, errorMessage: embeddingError.message }
+						: {}),
+				});
+			}
 		}
 	} else {
 		row = unsavedAggregateResult(answer, key, project);

--- a/platform/daemon/src/aggregate-recall.ts
+++ b/platform/daemon/src/aggregate-recall.ts
@@ -189,7 +189,7 @@ function uniqueEvidence(rows: readonly RecallResult[]): RecallResult[] {
 }
 
 function evidenceCanSaveAsGlobalAggregate(rows: readonly RecallResult[]): boolean {
-	return rows.every((row) => (row.visibility ?? "global") === "global" && (row.scope ?? null) === null);
+	return rows.every((row) => row.visibility === "global" && row.scope === null);
 }
 
 function aggregateKey(input: {
@@ -259,7 +259,7 @@ function loadAggregateByKey(
 			 FROM memories
 			 WHERE idempotency_key = ?
 			   AND COALESCE(NULLIF(agent_id, ''), 'default') = ?
-			   AND COALESCE(visibility, 'global') = 'global'
+			   AND visibility = 'global'
 			   AND scope IS NULL
 			   AND is_deleted = 0
 			 LIMIT 1`,
@@ -289,8 +289,7 @@ function loadMemoryByContentHash(
 	if (!row) return null;
 	return {
 		row: rowToRecallResult(row),
-		visibleForAggregate:
-			(row.visibility ?? "global") === "global" && (input.project === null || row.project === input.project),
+		visibleForAggregate: row.visibility === "global" && (input.project === null || row.project === input.project),
 		aggregateRecallMemory: row.source_type === "aggregate-recall",
 	};
 }

--- a/platform/daemon/src/aggregate-recall.ts
+++ b/platform/daemon/src/aggregate-recall.ts
@@ -1,0 +1,515 @@
+import { createHash, randomUUID } from "node:crypto";
+import type { RouteRequest, RouterResult } from "@signet/core";
+import { normalizeAndHashContent } from "./content-normalization";
+import { type WriteDb, getDbAccessor } from "./db-accessor";
+import { syncVecDeleteBySourceId, syncVecInsert, vectorToBlob } from "./db-helpers";
+import type { EmbeddingConfig, ResolvedMemoryConfig } from "./memory-config";
+import { type EmbedFn, type RecallParams, type RecallResponse, type RecallResult, hybridRecall } from "./memory-search";
+import { txIngestEnvelope } from "./transactions";
+
+export type AggregateRecallBudget = "small" | "medium" | "large";
+export type AggregateRecallStoppedReason = "complete" | "no_evidence" | "router_unavailable" | "synthesis_failed";
+
+interface AggregateInferenceResult {
+	readonly text: string;
+}
+
+export interface AggregateInferenceRouter {
+	execute(
+		request: RouteRequest,
+		prompt: string,
+		opts?: { readonly timeoutMs?: number; readonly maxTokens?: number; readonly refresh?: boolean },
+	): Promise<RouterResult<AggregateInferenceResult>>;
+}
+
+interface AggregateRecallDeps {
+	readonly hybridRecall?: typeof hybridRecall;
+	readonly router: AggregateInferenceRouter | null;
+	readonly embedFn: EmbedFn;
+	readonly now?: () => Date;
+	readonly idFactory?: () => string;
+}
+
+interface AggregateMemoryRow {
+	readonly id: string;
+	readonly content: string;
+	readonly source_id: string | null;
+	readonly type: string;
+	readonly tags: string | null;
+	readonly pinned: number;
+	readonly importance: number;
+	readonly who: string | null;
+	readonly project: string | null;
+	readonly visibility?: string | null;
+	readonly created_at: string;
+}
+
+interface ContentHashMatch {
+	readonly row: RecallResult;
+	readonly visibleForAggregate: boolean;
+}
+
+const BUDGET_QUERY_LIMITS: Record<AggregateRecallBudget, number> = {
+	small: 3,
+	medium: 5,
+	large: 8,
+};
+
+function normalizeBudget(raw: unknown): AggregateRecallBudget {
+	return raw === "medium" || raw === "large" ? raw : "small";
+}
+
+function emptyAggregateResponse(
+	params: RecallParams,
+	budget: AggregateRecallBudget,
+	queries: readonly string[],
+	sourceMemoryIds: readonly string[],
+	stoppedReason: AggregateRecallStoppedReason,
+): RecallResponse {
+	return {
+		results: [],
+		query: params.query,
+		method: "hybrid",
+		meta: {
+			totalReturned: 0,
+			hasSupplementary: false,
+			noHits: true,
+			timings: { totalMs: 0, stages: [] },
+		},
+		aggregate: {
+			savedMemoryId: null,
+			saved: false,
+			deduped: false,
+			budget,
+			queries,
+			sourceMemoryIds,
+			stoppedReason,
+		},
+	};
+}
+
+function normalizeQuery(value: string): string {
+	return value.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function uniqueQueries(query: string, candidates: readonly string[], max: number): string[] {
+	const seen = new Set<string>();
+	const result: string[] = [];
+	for (const candidate of [query, ...candidates]) {
+		const trimmed = candidate.trim();
+		const key = normalizeQuery(trimmed);
+		if (!trimmed || seen.has(key)) continue;
+		seen.add(key);
+		result.push(trimmed);
+		if (result.length >= max) break;
+	}
+	return result;
+}
+
+function parsePlannerQueries(raw: string): string[] {
+	const trimmed = raw.trim();
+	if (!trimmed) return [];
+	try {
+		const parsed = JSON.parse(trimmed) as unknown;
+		if (Array.isArray(parsed)) {
+			return parsed.filter((item): item is string => typeof item === "string");
+		}
+		if (typeof parsed === "object" && parsed !== null) {
+			const value = (parsed as { readonly queries?: unknown }).queries;
+			if (Array.isArray(value)) {
+				return value.filter((item): item is string => typeof item === "string");
+			}
+		}
+	} catch {
+		// Fall through to line parsing for permissive model output.
+	}
+	return trimmed
+		.split(/\r?\n/)
+		.map((line) => line.replace(/^[-*\d.\s]+/, "").trim())
+		.filter((line) => line.length > 0);
+}
+
+function isSourceMemoryRow(row: RecallResult): boolean {
+	return !row.id.startsWith("constructed:");
+}
+
+function uniqueEvidence(rows: readonly RecallResult[]): RecallResult[] {
+	const seen = new Set<string>();
+	const result: RecallResult[] = [];
+	for (const row of rows) {
+		if (!isSourceMemoryRow(row) || seen.has(row.id)) continue;
+		seen.add(row.id);
+		result.push(row);
+	}
+	return result;
+}
+
+function aggregateKey(input: {
+	readonly agentId: string;
+	readonly project: string | null;
+	readonly query: string;
+	readonly budget: AggregateRecallBudget;
+	readonly sourceMemoryIds: readonly string[];
+}): string {
+	const hash = createHash("sha256")
+		.update(input.agentId)
+		.update("\0")
+		.update(input.project ?? "")
+		.update("\0")
+		.update(normalizeQuery(input.query))
+		.update("\0")
+		.update(input.budget)
+		.update("\0")
+		.update([...input.sourceMemoryIds].sort().join("\0"))
+		.digest("hex");
+	return `aggregate-recall:${hash}`;
+}
+
+function sourceProject(params: RecallParams): string | null {
+	return typeof params.project === "string" && params.project.trim().length > 0 ? params.project : null;
+}
+
+function rowToRecallResult(row: AggregateMemoryRow): RecallResult {
+	const content = row.content;
+	return {
+		id: row.id,
+		content,
+		content_length: content.length,
+		truncated: false,
+		score: 1,
+		source: "aggregate-recall",
+		source_id: row.source_id ?? undefined,
+		type: row.type,
+		tags: row.tags,
+		pinned: row.pinned === 1,
+		importance: row.importance,
+		who: row.who ?? "",
+		project: row.project,
+		created_at: row.created_at,
+	};
+}
+
+function loadAggregateMemory(db: WriteDb, id: string): RecallResult | null {
+	const row = db
+		.prepare(
+			`SELECT id, content, source_id, type, tags, pinned, importance, who, project, created_at
+			 FROM memories
+			 WHERE id = ? AND is_deleted = 0`,
+		)
+		.get(id) as AggregateMemoryRow | undefined;
+	return row ? rowToRecallResult(row) : null;
+}
+
+function loadAggregateByKey(
+	db: WriteDb,
+	key: string,
+	input: { readonly agentId: string; readonly project: string | null },
+): RecallResult | null {
+	const row = db
+		.prepare(
+			`SELECT id, content, source_id, type, tags, pinned, importance, who, project, created_at
+			 FROM memories
+			 WHERE idempotency_key = ?
+			   AND COALESCE(NULLIF(agent_id, ''), 'default') = ?
+			   AND COALESCE(visibility, 'global') = 'global'
+			   AND scope IS NULL
+			   AND is_deleted = 0
+			 LIMIT 1`,
+		)
+		.get(key, input.agentId) as AggregateMemoryRow | undefined;
+	if (!row) return null;
+	if (input.project !== null && row.project !== input.project) return null;
+	return rowToRecallResult(row);
+}
+
+function loadMemoryByContentHash(
+	db: WriteDb,
+	contentHash: string,
+	input: { readonly agentId: string; readonly project: string | null },
+): ContentHashMatch | null {
+	const row = db
+		.prepare(
+			`SELECT id, content, source_id, type, tags, pinned, importance, who, project, visibility, created_at
+			 FROM memories
+			 WHERE content_hash = ?
+			   AND COALESCE(NULLIF(agent_id, ''), 'default') = ?
+			   AND scope IS NULL
+			   AND is_deleted = 0
+			 LIMIT 1`,
+		)
+		.get(contentHash, input.agentId) as AggregateMemoryRow | undefined;
+	if (!row) return null;
+	return {
+		row: rowToRecallResult(row),
+		visibleForAggregate:
+			(row.visibility ?? "global") === "global" && (input.project === null || row.project === input.project),
+	};
+}
+
+function linkAggregateSources(
+	db: WriteDb,
+	aggregateMemoryId: string,
+	sourceMemoryIds: readonly string[],
+	agentId: string,
+	now: string,
+): void {
+	for (const sourceMemoryId of sourceMemoryIds) {
+		db.prepare(
+			`INSERT OR IGNORE INTO aggregate_memory_sources
+			 (aggregate_memory_id, source_memory_id, agent_id, created_at)
+			 VALUES (?, ?, ?, ?)`,
+		).run(aggregateMemoryId, sourceMemoryId, agentId, now);
+	}
+}
+
+async function embedAggregateMemory(
+	memoryId: string,
+	content: string,
+	contentHash: string,
+	createdAt: string,
+	cfg: EmbeddingConfig,
+	embedFn: EmbedFn,
+): Promise<boolean> {
+	const vec = await embedFn(content, cfg);
+	if (!vec || vec.length !== cfg.dimensions) return false;
+	getDbAccessor().withWriteTx((db) => {
+		const embId = randomUUID();
+		syncVecDeleteBySourceId(db, "memory", memoryId);
+		db.prepare("DELETE FROM embeddings WHERE source_type = 'memory' AND source_id = ?").run(memoryId);
+		db.prepare(`
+			INSERT INTO embeddings
+			  (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at)
+			VALUES (?, ?, ?, ?, 'memory', ?, ?, ?)
+		`).run(embId, contentHash, vectorToBlob(vec), vec.length, memoryId, content, createdAt);
+		syncVecInsert(db, embId, vec);
+		db.prepare("UPDATE memories SET embedding_model = ? WHERE id = ?").run(cfg.model, memoryId);
+	});
+	return true;
+}
+
+function unsavedAggregateResult(content: string, key: string, project: string | null): RecallResult {
+	const now = new Date().toISOString();
+	return {
+		id: `${key}:unsaved`,
+		content,
+		content_length: content.length,
+		truncated: false,
+		score: 1,
+		source: "aggregate-recall",
+		source_id: key,
+		type: "semantic",
+		tags: "aggregate,recall",
+		pinned: false,
+		importance: 0.75,
+		who: "signet",
+		project,
+		created_at: now,
+	};
+}
+
+async function planQueries(input: {
+	readonly router: AggregateInferenceRouter;
+	readonly params: RecallParams;
+	readonly budget: AggregateRecallBudget;
+	readonly maxQueries: number;
+	readonly initialRows: readonly RecallResult[];
+}): Promise<string[]> {
+	const remaining = input.maxQueries - 1;
+	if (remaining <= 0) return [];
+	const prompt = [
+		"Propose focused follow-up memory recall queries.",
+		'Return only JSON with this shape: {"queries":["..."]}.',
+		`Original query: ${input.params.query}`,
+		`Budget: ${input.budget}; maximum follow-up queries: ${remaining}.`,
+		"Current evidence:",
+		...input.initialRows.slice(0, 8).map((row, index) => `${index + 1}. ${row.content}`),
+	].join("\n");
+	const result = await input.router.execute(
+		{
+			agentId: input.params.agentId,
+			operation: "tool_planning",
+			promptPreview: input.params.query,
+			expectedOutputTokens: 300,
+		},
+		prompt,
+		{ maxTokens: 300, timeoutMs: 20_000 },
+	);
+	return result.ok ? parsePlannerQueries(result.value.text).slice(0, remaining) : [];
+}
+
+async function synthesize(input: {
+	readonly router: AggregateInferenceRouter;
+	readonly params: RecallParams;
+	readonly evidence: readonly RecallResult[];
+}): Promise<string | null> {
+	const prompt = [
+		"Synthesize a concise answer from the memory evidence below.",
+		"Use only the evidence. If the evidence is insufficient, say so briefly.",
+		`Question: ${input.params.query}`,
+		"",
+		"Evidence:",
+		...input.evidence.map((row, index) => {
+			const createdAt = row.created_at.slice(0, 10);
+			return `${index + 1}. [${row.id}; ${createdAt}; ${row.type}] ${row.content}`;
+		}),
+	].join("\n");
+	const result = await input.router.execute(
+		{
+			agentId: input.params.agentId,
+			operation: "tool_planning",
+			promptPreview: input.params.query,
+			expectedOutputTokens: 700,
+		},
+		prompt,
+		{ maxTokens: 700, timeoutMs: 30_000 },
+	);
+	if (!result.ok) return null;
+	const text = result.value.text.trim();
+	return text.length > 0 ? text : null;
+}
+
+export async function aggregateRecall(
+	params: RecallParams,
+	cfg: ResolvedMemoryConfig,
+	deps: AggregateRecallDeps,
+): Promise<RecallResponse> {
+	const budget = normalizeBudget(params.aggregateBudget ?? params.aggregate_budget);
+	const maxQueries = BUDGET_QUERY_LIMITS[budget];
+	const recall = deps.hybridRecall ?? hybridRecall;
+	const saveAggregate = params.saveAggregate !== false && params.save_aggregate !== false;
+	const first = await recall(params, cfg, deps.embedFn);
+
+	if (!deps.router) {
+		const sourceMemoryIds = uniqueEvidence(first.results).map((row) => row.id);
+		return emptyAggregateResponse(
+			params,
+			budget,
+			[params.query],
+			sourceMemoryIds,
+			sourceMemoryIds.length === 0 ? "no_evidence" : "router_unavailable",
+		);
+	}
+
+	const planned = await planQueries({
+		router: deps.router,
+		params,
+		budget,
+		maxQueries,
+		initialRows: first.results,
+	});
+	const queries = uniqueQueries(params.query, planned, maxQueries);
+	const recalls = [first];
+	for (const query of queries.slice(1)) {
+		recalls.push(
+			await recall(
+				{
+					...params,
+					query,
+					aggregate: false,
+				},
+				cfg,
+				deps.embedFn,
+			),
+		);
+	}
+
+	const evidence = uniqueEvidence(recalls.flatMap((result) => result.results));
+	const sourceMemoryIds = evidence.map((row) => row.id);
+	if (evidence.length === 0) {
+		return emptyAggregateResponse(params, budget, queries, [], "no_evidence");
+	}
+
+	const answer = await synthesize({ router: deps.router, params, evidence });
+	if (!answer) {
+		return emptyAggregateResponse(params, budget, queries, sourceMemoryIds, "synthesis_failed");
+	}
+
+	const agentId = params.agentId ?? "default";
+	const project = sourceProject(params);
+	const key = aggregateKey({ agentId, project, query: params.query, budget, sourceMemoryIds });
+	const now = (deps.now?.() ?? new Date()).toISOString();
+
+	let row: RecallResult | null;
+	let deduped = false;
+	let saved = false;
+	if (saveAggregate) {
+		const normalized = normalizeAndHashContent(answer);
+		row = getDbAccessor().withWriteTx((db) => {
+			const existing = loadAggregateByKey(db, key, { agentId, project });
+			if (existing) {
+				linkAggregateSources(db, existing.id, sourceMemoryIds, agentId, now);
+				deduped = true;
+				saved = true;
+				return existing;
+			}
+			const duplicateContent = loadMemoryByContentHash(db, normalized.contentHash, { agentId, project });
+			if (duplicateContent) {
+				if (!duplicateContent.visibleForAggregate) {
+					deduped = true;
+					return unsavedAggregateResult(answer, key, project);
+				}
+				linkAggregateSources(db, duplicateContent.row.id, sourceMemoryIds, agentId, now);
+				deduped = true;
+				saved = true;
+				return duplicateContent.row;
+			}
+			const id = deps.idFactory?.() ?? randomUUID();
+			txIngestEnvelope(db, {
+				id,
+				content: normalized.storageContent,
+				normalizedContent: normalized.normalizedContent || normalized.hashBasis,
+				contentHash: normalized.contentHash,
+				who: "signet",
+				why: "aggregate recall",
+				project,
+				importance: 0.75,
+				type: "semantic",
+				tags: "aggregate,recall",
+				pinned: 0,
+				isDeleted: 0,
+				extractionStatus: "none",
+				embeddingModel: null,
+				extractionModel: null,
+				updatedBy: "signet",
+				sourceType: "aggregate-recall",
+				sourceId: key,
+				idempotencyKey: key,
+				scope: null,
+				agentId,
+				visibility: "global",
+				createdAt: now,
+			});
+			linkAggregateSources(db, id, sourceMemoryIds, agentId, now);
+			saved = true;
+			return loadAggregateMemory(db, id);
+		});
+		if (row && !deduped) {
+			await embedAggregateMemory(row.id, row.content, normalized.contentHash, now, cfg.embedding, deps.embedFn).catch(
+				() => false,
+			);
+		}
+	} else {
+		row = unsavedAggregateResult(answer, key, project);
+	}
+
+	return {
+		results: row ? [row] : [],
+		query: params.query,
+		method: "hybrid",
+		meta: {
+			totalReturned: row ? 1 : 0,
+			hasSupplementary: false,
+			noHits: !row,
+			timings: { totalMs: 0, stages: [] },
+		},
+		aggregate: {
+			savedMemoryId: saved && row ? row.id : null,
+			saved,
+			deduped,
+			budget,
+			queries,
+			sourceMemoryIds,
+			stoppedReason: "complete",
+		},
+	};
+}

--- a/platform/daemon/src/daemon-auth-guard-colocation.test.ts
+++ b/platform/daemon/src/daemon-auth-guard-colocation.test.ts
@@ -112,6 +112,34 @@ describe("auth guard co-location", () => {
 			registerMemoryRoutes(app);
 			expect(await status(app, "POST", "/api/memory/remember")).toBe(403);
 		});
+
+		it("POST /api/memory/recall aggregate save requires remember permission", async () => {
+			const app = await makeApp();
+			const state = await import("./routes/state.js");
+			const { createAuthMiddleware, createToken } = await import("./auth");
+			const { registerMemoryRoutes } = await import("./routes/memory-routes");
+			const secret = state.authSecret;
+			if (!secret) throw new Error("expected auth secret for team-mode recall test");
+
+			app.use("*", createAuthMiddleware(state.authConfig, secret));
+			registerMemoryRoutes(app);
+			const token = createToken(secret, { sub: "readonly-recall", role: "readonly", scope: {} }, 60);
+			const res = await app.request("/api/memory/recall", {
+				method: "POST",
+				headers: {
+					authorization: `Bearer ${token}`,
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({
+					query: "aggregate save should need write permission",
+					aggregate: true,
+				}),
+			});
+
+			expect(res.status).toBe(403);
+			const body = (await res.json()) as { error?: string };
+			expect(body.error).toContain("remember");
+		});
 	});
 
 	describe("session routes need guards", () => {

--- a/platform/daemon/src/daemon-auth-guard-colocation.test.ts
+++ b/platform/daemon/src/daemon-auth-guard-colocation.test.ts
@@ -1,7 +1,8 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { RecallParams, RecallResponse } from "./memory-search";
 
 /*
  * Regression test for auth guard co-location refactoring.
@@ -139,6 +140,74 @@ describe("auth guard co-location", () => {
 			expect(res.status).toBe(403);
 			const body = (await res.json()) as { error?: string };
 			expect(body.error).toContain("remember");
+		});
+
+		it("POST /api/memory/recall forwards read-only aggregate options", async () => {
+			const app = await makeApp();
+			const state = await import("./routes/state.js");
+			const { createAuthMiddleware, createToken } = await import("./auth");
+			const { registerMemoryRoutes } = await import("./routes/memory-routes");
+			const secret = state.authSecret;
+			if (!secret) throw new Error("expected auth secret for team-mode recall test");
+
+			let captured: RecallParams | null = null;
+			const aggregateRecallMock = mock(async (params: RecallParams): Promise<RecallResponse> => {
+				captured = params;
+				return {
+					results: [],
+					query: params.query,
+					method: "hybrid",
+					meta: {
+						totalReturned: 0,
+						hasSupplementary: false,
+						noHits: true,
+						timings: { totalMs: 0, stages: [] },
+					},
+					aggregate: {
+						savedMemoryId: null,
+						saved: false,
+						deduped: false,
+						budget: "large",
+						queries: [params.query],
+						sourceMemoryIds: [],
+						stoppedReason: "no_evidence",
+					},
+				};
+			});
+
+			app.use("*", createAuthMiddleware(state.authConfig, secret));
+			registerMemoryRoutes(app, {
+				aggregateRecall: aggregateRecallMock,
+				getInferenceRouterOrNull: () => null,
+				fetchEmbedding: async () => null,
+			});
+			const token = createToken(secret, { sub: "readonly-recall", role: "readonly", scope: {} }, 60);
+			const res = await app.request("/api/memory/recall", {
+				method: "POST",
+				headers: {
+					authorization: `Bearer ${token}`,
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({
+					query: "read-only aggregate should not save",
+					aggregate: true,
+					aggregateBudget: "large",
+					saveAggregate: false,
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			expect(aggregateRecallMock).toHaveBeenCalledTimes(1);
+			expect(captured).toMatchObject({
+				query: "read-only aggregate should not save",
+				aggregate: true,
+				aggregateBudget: "large",
+				aggregate_budget: "large",
+				saveAggregate: false,
+				save_aggregate: false,
+			});
+			const body = (await res.json()) as RecallResponse;
+			expect(body.aggregate?.saved).toBe(false);
 		});
 	});
 

--- a/platform/daemon/src/daemon-auth-guard-colocation.test.ts
+++ b/platform/daemon/src/daemon-auth-guard-colocation.test.ts
@@ -209,6 +209,45 @@ describe("auth guard co-location", () => {
 			const body = (await res.json()) as RecallResponse;
 			expect(body.aggregate?.saved).toBe(false);
 		});
+
+		it("POST /api/memory/recall rejects invalid aggregate budgets before aggregation", async () => {
+			const app = await makeApp();
+			const state = await import("./routes/state.js");
+			const { createAuthMiddleware, createToken } = await import("./auth");
+			const { registerMemoryRoutes } = await import("./routes/memory-routes");
+			const secret = state.authSecret;
+			if (!secret) throw new Error("expected auth secret for team-mode recall test");
+
+			const aggregateRecallMock = mock(async (_params: RecallParams): Promise<RecallResponse> => {
+				throw new Error("aggregateRecall should not run for invalid budgets");
+			});
+
+			app.use("*", createAuthMiddleware(state.authConfig, secret));
+			registerMemoryRoutes(app, {
+				aggregateRecall: aggregateRecallMock,
+				getInferenceRouterOrNull: () => null,
+				fetchEmbedding: async () => null,
+			});
+			const token = createToken(secret, { sub: "readonly-recall", role: "readonly", scope: {} }, 60);
+			const res = await app.request("/api/memory/recall", {
+				method: "POST",
+				headers: {
+					authorization: `Bearer ${token}`,
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({
+					query: "bad aggregate budget",
+					aggregate: true,
+					aggregateBudget: "maximum",
+					saveAggregate: false,
+				}),
+			});
+
+			expect(res.status).toBe(400);
+			expect(aggregateRecallMock).toHaveBeenCalledTimes(0);
+			const body = (await res.json()) as { error?: string };
+			expect(body.error).toContain("aggregateBudget");
+		});
 	});
 
 	describe("session routes need guards", () => {

--- a/platform/daemon/src/hooks-recall.test.ts
+++ b/platform/daemon/src/hooks-recall.test.ts
@@ -104,6 +104,24 @@ memory:
 		expect(resp.status).toBe(400);
 	});
 
+	it("rejects invalid aggregate budgets", async () => {
+		const resp = await app.request("/api/hooks/recall", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				harness: "openclaw",
+				query: "project history",
+				aggregate: true,
+				aggregate_budget: "maximum",
+				saveAggregate: false,
+			}),
+		});
+
+		expect(resp.status).toBe(400);
+		const body = (await resp.json()) as { error?: string };
+		expect(body.error).toContain("aggregateBudget");
+	});
+
 	it("returns the normalized no-op shape for internal calls", async () => {
 		const resp = await app.request("/api/hooks/recall", {
 			method: "POST",

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -530,6 +530,11 @@ export interface RecallRequest {
 	keywordQuery?: string;
 	project?: string;
 	limit?: number;
+	aggregate?: boolean;
+	aggregateBudget?: "small" | "medium" | "large";
+	aggregate_budget?: "small" | "medium" | "large";
+	saveAggregate?: boolean;
+	save_aggregate?: boolean;
 	type?: string;
 	tags?: string;
 	who?: string;

--- a/platform/daemon/src/mcp/tools.test.ts
+++ b/platform/daemon/src/mcp/tools.test.ts
@@ -519,6 +519,9 @@ describe("createMcpServer", () => {
 				since: "2026-01-01",
 				until: "2026-04-01",
 				score_min: 0.8,
+				aggregate: true,
+				aggregate_budget: "medium",
+				save_aggregate: false,
 			});
 
 			expect(cap.url).toBe("http://localhost:3850/api/memory/recall");
@@ -535,6 +538,9 @@ describe("createMcpServer", () => {
 			expect(body.since).toBe("2026-01-01");
 			expect(body.until).toBe("2026-04-01");
 			expect(body.expand).toBeUndefined();
+			expect(body.aggregate).toBe(true);
+			expect(body.aggregateBudget).toBe("medium");
+			expect(body.saveAggregate).toBe(false);
 			expect(body.min_score).toBeUndefined();
 			expect(body.score_min).toBeUndefined();
 			expect(result.isError).toBeUndefined();

--- a/platform/daemon/src/mcp/tools.ts
+++ b/platform/daemon/src/mcp/tools.ts
@@ -802,6 +802,9 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 					.optional()
 					.describe("Deprecated compatibility alias for importance_min; ignored when importance_min is also set"),
 				score_min: z.number().optional().describe("Minimum recall score threshold (client-side)"),
+				aggregate: z.boolean().optional().describe("Synthesize an aggregate answer from bounded recall evidence"),
+				aggregate_budget: z.enum(["small", "medium", "large"]).optional().describe("Aggregate recall budget"),
+				save_aggregate: z.boolean().optional().describe("Save the aggregate answer as a memory"),
 			}),
 		},
 		async ({
@@ -818,6 +821,9 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 			until,
 			min_score,
 			score_min,
+			aggregate,
+			aggregate_budget,
+			save_aggregate,
 		}) => {
 			const result = await daemonFetch<unknown>(baseUrl, "/api/memory/recall", {
 				method: "POST",
@@ -832,6 +838,9 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 					importance_min: importance_min ?? min_score,
 					since,
 					until,
+					aggregate,
+					aggregate_budget,
+					save_aggregate,
 				}),
 			});
 

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -83,6 +83,8 @@ export interface RecallResult {
 	who: string;
 	project: string | null;
 	created_at: string;
+	visibility?: string | null;
+	scope?: string | null;
 	supplementary?: boolean;
 }
 
@@ -1875,7 +1877,7 @@ export async function hybridRecall(
 			(db) =>
 				db
 					.prepare(
-						`SELECT m.id, m.content, m.source_id, m.type, m.tags, m.pinned, m.importance, m.who, m.project, m.created_at
+						`SELECT m.id, m.content, m.source_id, m.type, m.tags, m.pinned, m.importance, m.who, m.project, m.created_at, m.visibility, m.scope
         FROM memories m
         WHERE m.id IN (${placeholders}) AND m.is_deleted = 0${filter.sql}`,
 					)
@@ -1890,6 +1892,8 @@ export async function hybridRecall(
 					who: string;
 					project: string | null;
 					created_at: string;
+					visibility: string | null;
+					scope: string | null;
 				}>,
 		),
 	);
@@ -1923,6 +1927,8 @@ export async function hybridRecall(
 						who: r.who,
 						project: r.project,
 						created_at: r.created_at,
+						visibility: r.visibility,
+						scope: r.scope,
 					},
 				];
 			}),
@@ -2089,7 +2095,7 @@ export async function hybridRecall(
 				return db
 					.prepare(
 						`SELECT DISTINCT m.id, m.content, m.type, m.tags, m.pinned,
-							        m.importance, m.who, m.project, m.created_at
+							        m.importance, m.who, m.project, m.created_at, m.visibility, m.scope
 							 FROM memory_entity_mentions mem
 							 JOIN memories m ON m.id = mem.memory_id
 							 WHERE mem.entity_id IN (${ePlaceholders})
@@ -2108,6 +2114,8 @@ export async function hybridRecall(
 					who: string;
 					project: string | null;
 					created_at: string;
+					visibility?: string | null;
+					scope?: string | null;
 				}>;
 			});
 
@@ -2130,6 +2138,8 @@ export async function hybridRecall(
 					who: r.who,
 					project: r.project,
 					created_at: r.created_at,
+					visibility: r.visibility,
+					scope: r.scope,
 					supplementary: true,
 				});
 			}

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -43,6 +43,11 @@ export interface RecallParams {
 	query: string;
 	keywordQuery?: string;
 	limit?: number;
+	aggregate?: boolean;
+	aggregateBudget?: "small" | "medium" | "large";
+	aggregate_budget?: "small" | "medium" | "large";
+	saveAggregate?: boolean;
+	save_aggregate?: boolean;
 	agentId?: string;
 	/** Agent read policy — 'isolated' | 'shared' | 'group'. When set with agentId, filters by visibility. */
 	readPolicy?: string;
@@ -90,6 +95,15 @@ export interface RecallResponse {
 		hasSupplementary: boolean;
 		noHits: boolean;
 		timings: RecallTimings;
+	};
+	aggregate?: {
+		savedMemoryId: string | null;
+		saved: boolean;
+		deduped: boolean;
+		budget: "small" | "medium" | "large";
+		queries: readonly string[];
+		sourceMemoryIds: readonly string[];
+		stoppedReason: "complete" | "no_evidence" | "router_unavailable" | "synthesis_failed";
 	};
 	entities?: Array<{
 		name: string;

--- a/platform/daemon/src/routes/hooks-routes.ts
+++ b/platform/daemon/src/routes/hooks-routes.ts
@@ -4,6 +4,7 @@ import { emptyHookRecallResponse, withHookRecallCompat } from "@signet/core";
 import type { Context } from "hono";
 import type { Hono } from "hono";
 import { getAgentScope, resolveAgentId } from "../agent-id";
+import { aggregateRecall } from "../aggregate-recall";
 import { requirePermission, requireRateLimit } from "../auth";
 import {
 	type AgentMessage,
@@ -38,6 +39,7 @@ import {
 	resetPromptDedup,
 	writeMemoryMd,
 } from "../hooks.js";
+import { getInferenceRouterOrNull } from "../inference-router";
 import { logger } from "../logger";
 import { loadMemoryConfig } from "../memory-config";
 import { writeCompactionArtifact } from "../memory-lineage.js";
@@ -65,6 +67,7 @@ import {
 	PORT,
 	authConfig,
 	authCrossAgentMessageLimiter,
+	authRecallLlmLimiter,
 	getCurrentMemoryDbPath,
 	harnessLastSeen,
 } from "./state";
@@ -516,31 +519,53 @@ function registerRecall(app: Hono): void {
 				return c.json(emptyHookRecallResponse(body.query, { bypassed: true }));
 			}
 
+			const aggregateSaveRequested =
+				body.aggregate === true && body.saveAggregate !== false && body.save_aggregate !== false;
+			if (aggregateSaveRequested) {
+				const denied = await requirePermission("remember", authConfig)(c, () => Promise.resolve());
+				if (denied) return denied;
+			}
+
 			const agentId = resolveAgentId({
 				agentId: c.req.header("x-signet-agent-id"),
 				sessionKey: body.sessionKey,
 			});
 			const agentScope = getAgentScope(agentId);
 			const cfg = loadMemoryConfig(AGENTS_DIR);
-			const result = await hybridRecall(
-				{
-					query: body.query,
-					keywordQuery: body.keywordQuery,
-					limit: body.limit,
-					project: body.project,
-					type: body.type,
-					tags: body.tags,
-					who: body.who,
-					since: body.since,
-					until: body.until,
-					expand: body.expand,
-					agentId,
-					readPolicy: agentScope.readPolicy,
-					policyGroup: agentScope.policyGroup,
-				},
-				cfg,
-				fetchEmbedding,
-			);
+			if (body.aggregate === true && authConfig.mode !== "local") {
+				const actor = c.get("auth")?.claims?.sub ?? "anonymous";
+				const check = authRecallLlmLimiter.check(actor);
+				if (!check.allowed) {
+					c.header("Retry-After", String(Math.ceil((check.resetAt - Date.now()) / 1000)));
+					return c.json({ error: "rate limit exceeded", retryAfter: check.resetAt }, 429);
+				}
+				authRecallLlmLimiter.record(actor);
+			}
+			const params = {
+				query: body.query,
+				keywordQuery: body.keywordQuery,
+				limit: body.limit,
+				project: body.project,
+				aggregate: body.aggregate,
+				aggregateBudget: body.aggregateBudget ?? body.aggregate_budget,
+				saveAggregate: body.saveAggregate ?? body.save_aggregate,
+				type: body.type,
+				tags: body.tags,
+				who: body.who,
+				since: body.since,
+				until: body.until,
+				expand: body.expand,
+				agentId,
+				readPolicy: agentScope.readPolicy,
+				policyGroup: agentScope.policyGroup,
+			};
+			const result =
+				body.aggregate === true
+					? await aggregateRecall(params, cfg, {
+							router: getInferenceRouterOrNull(),
+							embedFn: fetchEmbedding,
+						})
+					: await hybridRecall(params, cfg, fetchEmbedding);
 			return c.json(withHookRecallCompat(result));
 		} catch (e) {
 			logger.error("hooks", "Recall hook failed", e as Error);

--- a/platform/daemon/src/routes/hooks-routes.ts
+++ b/platform/daemon/src/routes/hooks-routes.ts
@@ -4,7 +4,7 @@ import { emptyHookRecallResponse, withHookRecallCompat } from "@signet/core";
 import type { Context } from "hono";
 import type { Hono } from "hono";
 import { getAgentScope, resolveAgentId } from "../agent-id";
-import { aggregateRecall } from "../aggregate-recall";
+import { aggregateRecall, parseAggregateRecallBudget, readAggregateRecallBudgetInput } from "../aggregate-recall";
 import { requirePermission, requireRateLimit } from "../auth";
 import {
 	type AgentMessage,
@@ -508,6 +508,11 @@ function registerRecall(app: Hono): void {
 			if (!body.harness || !body.query) {
 				return c.json({ error: "harness and query are required" }, 400);
 			}
+			const aggregateBudgetInput = readAggregateRecallBudgetInput(body);
+			const aggregateBudget = parseAggregateRecallBudget(aggregateBudgetInput);
+			if (aggregateBudgetInput !== undefined && aggregateBudget === null) {
+				return c.json({ error: "Invalid aggregateBudget. Expected one of: small, medium, large." }, 400);
+			}
 
 			const runtimePath = resolveRuntimePath(c, body);
 			if (runtimePath) body.runtimePath = runtimePath;
@@ -547,8 +552,10 @@ function registerRecall(app: Hono): void {
 				limit: body.limit,
 				project: body.project,
 				aggregate: body.aggregate,
-				aggregateBudget: body.aggregateBudget ?? body.aggregate_budget,
+				aggregateBudget,
+				aggregate_budget: aggregateBudget,
 				saveAggregate: body.saveAggregate ?? body.save_aggregate,
+				save_aggregate: body.save_aggregate ?? body.saveAggregate,
 				type: body.type,
 				tags: body.tags,
 				who: body.who,

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { vectorSearch } from "@signet/core";
 import type { Hono } from "hono";
 import { getAgentScope, resolveAgentId } from "../agent-id";
-import { aggregateRecall } from "../aggregate-recall";
+import { aggregateRecall, parseAggregateRecallBudget, readAggregateRecallBudgetInput } from "../aggregate-recall";
 import { checkScope, requirePermission, requireRateLimit } from "../auth";
 import { normalizeAndHashContent } from "../content-normalization";
 import { type WriteDb, getDbAccessor } from "../db-accessor";
@@ -2303,6 +2303,11 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 		const query = body.query?.trim() ?? "";
 		if (!query) return c.json({ error: "query is required" }, 400);
+		const aggregateBudgetInput = readAggregateRecallBudgetInput(body);
+		const aggregateBudget = parseAggregateRecallBudget(aggregateBudgetInput);
+		if (aggregateBudgetInput !== undefined && aggregateBudget === null) {
+			return c.json({ error: "Invalid aggregateBudget. Expected one of: small, medium, large." }, 400);
+		}
 
 		const aggregateSaveRequested =
 			body.aggregate === true && body.saveAggregate !== false && body.save_aggregate !== false;
@@ -2334,8 +2339,8 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				...body,
 				query,
 				aggregate: body.aggregate,
-				aggregateBudget: body.aggregateBudget ?? body.aggregate_budget,
-				aggregate_budget: body.aggregate_budget ?? body.aggregateBudget,
+				aggregateBudget,
+				aggregate_budget: aggregateBudget,
 				saveAggregate: body.saveAggregate ?? body.save_aggregate,
 				save_aggregate: body.save_aggregate ?? body.saveAggregate,
 				agentId,

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -75,6 +75,13 @@ const FORGET_CONFIRM_THRESHOLD = 25;
 const SOFT_DELETE_RETENTION_DAYS = 30;
 const SOFT_DELETE_RETENTION_MS = SOFT_DELETE_RETENTION_DAYS * 24 * 60 * 60 * 1000;
 
+export interface MemoryRoutesDeps {
+	readonly aggregateRecall?: typeof aggregateRecall;
+	readonly hybridRecall?: typeof hybridRecall;
+	readonly fetchEmbedding?: typeof fetchEmbedding;
+	readonly getInferenceRouterOrNull?: typeof getInferenceRouterOrNull;
+}
+
 function parseOptionalIsoTimestamp(value: unknown): string | null {
 	if (typeof value !== "string") return null;
 	const trimmed = value.trim();
@@ -329,7 +336,11 @@ function recordRecallQaTelemetry(input: {
 	});
 }
 
-export function registerMemoryRoutes(app: Hono): void {
+export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): void {
+	const aggregateRecallFn = deps.aggregateRecall ?? aggregateRecall;
+	const hybridRecallFn = deps.hybridRecall ?? hybridRecall;
+	const fetchEmbeddingFn = deps.fetchEmbedding ?? fetchEmbedding;
+	const getInferenceRouterOrNullFn = deps.getInferenceRouterOrNull ?? getInferenceRouterOrNull;
 	// =========================================================================
 	// Permission guards — memory routes
 	// =========================================================================
@@ -2322,6 +2333,11 @@ export function registerMemoryRoutes(app: Hono): void {
 			const params = {
 				...body,
 				query,
+				aggregate: body.aggregate,
+				aggregateBudget: body.aggregateBudget ?? body.aggregate_budget,
+				aggregate_budget: body.aggregate_budget ?? body.aggregateBudget,
+				saveAggregate: body.saveAggregate ?? body.save_aggregate,
+				save_aggregate: body.save_aggregate ?? body.saveAggregate,
 				agentId,
 				readPolicy: agentScope.readPolicy,
 				policyGroup: agentScope.policyGroup,
@@ -2329,11 +2345,11 @@ export function registerMemoryRoutes(app: Hono): void {
 			};
 			const result =
 				body.aggregate === true
-					? await aggregateRecall(params, cfg, {
-							router: getInferenceRouterOrNull(),
-							embedFn: fetchEmbedding,
+					? await aggregateRecallFn(params, cfg, {
+							router: getInferenceRouterOrNullFn(),
+							embedFn: fetchEmbeddingFn,
 						})
-					: await hybridRecall(params, cfg, fetchEmbedding);
+					: await hybridRecallFn(params, cfg, fetchEmbeddingFn);
 			recordRecallQaTelemetry({
 				route: "POST /api/memory/recall",
 				agentId,

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -2,12 +2,14 @@ import { createHash } from "node:crypto";
 import { vectorSearch } from "@signet/core";
 import type { Hono } from "hono";
 import { getAgentScope, resolveAgentId } from "../agent-id";
+import { aggregateRecall } from "../aggregate-recall";
 import { checkScope, requirePermission, requireRateLimit } from "../auth";
 import { normalizeAndHashContent } from "../content-normalization";
 import { type WriteDb, getDbAccessor } from "../db-accessor";
 import { syncVecDeleteBySourceId, syncVecInsert, vectorToBlob } from "../db-helpers";
 import { fetchEmbedding } from "../embedding-fetch";
 import { buildEmbeddingHealth } from "../embedding-health";
+import { getInferenceRouterOrNull } from "../inference-router";
 import { linkMemoryToEntities } from "../inline-entity-linker";
 import { logger } from "../logger";
 import { loadMemoryConfig } from "../memory-config";
@@ -2291,8 +2293,18 @@ export function registerMemoryRoutes(app: Hono): void {
 		const query = body.query?.trim() ?? "";
 		if (!query) return c.json({ error: "query is required" }, 400);
 
+		const aggregateSaveRequested =
+			body.aggregate === true && body.saveAggregate !== false && body.save_aggregate !== false;
+		if (aggregateSaveRequested) {
+			const denied = await requirePermission("remember", authConfig)(c, () => Promise.resolve());
+			if (denied) return denied;
+		}
+
 		const cfg = loadMemoryConfig(AGENTS_DIR);
-		if (cfg.pipelineV2.reranker.enabled && cfg.pipelineV2.reranker.useExtractionModel && authConfig.mode !== "local") {
+		if (
+			((cfg.pipelineV2.reranker.enabled && cfg.pipelineV2.reranker.useExtractionModel) || body.aggregate === true) &&
+			authConfig.mode !== "local"
+		) {
 			const actor = c.get("auth")?.claims?.sub ?? "anonymous";
 			const check = authRecallLlmLimiter.check(actor);
 			if (!check.allowed) {
@@ -2315,7 +2327,13 @@ export function registerMemoryRoutes(app: Hono): void {
 				policyGroup: agentScope.policyGroup,
 				...(scopeProject ? { project: scopeProject } : {}),
 			};
-			const result = await hybridRecall(params, cfg, fetchEmbedding);
+			const result =
+				body.aggregate === true
+					? await aggregateRecall(params, cfg, {
+							router: getInferenceRouterOrNull(),
+							embedFn: fetchEmbedding,
+						})
+					: await hybridRecall(params, cfg, fetchEmbedding);
 			recordRecallQaTelemetry({
 				route: "POST /api/memory/recall",
 				agentId,

--- a/surfaces/cli/src/commands/memory.test.ts
+++ b/surfaces/cli/src/commands/memory.test.ts
@@ -220,4 +220,35 @@ describe("registerMemoryCommands recall", () => {
 			saveAggregate: false,
 		});
 	});
+
+	test("--no-save-aggregate does not enable aggregate recall by itself", async () => {
+		let capturedBody: unknown;
+		const program = new Command();
+		registerMemoryCommands(program, {
+			ensureDaemonForSecrets: async () => true,
+			secretApiCall: async (_method, _path, body) => {
+				capturedBody = body;
+				return {
+					ok: true,
+					data: {
+						query: "project history",
+						method: "hybrid",
+						results: [],
+						meta: {
+							totalReturned: 0,
+							hasSupplementary: false,
+							noHits: true,
+						},
+					},
+				};
+			},
+		});
+
+		await program.parseAsync(["node", "test", "recall", "project history", "--no-save-aggregate", "--json"]);
+
+		expect(capturedBody).toEqual({
+			query: "project history",
+			limit: 10,
+		});
+	});
 });

--- a/surfaces/cli/src/commands/memory.test.ts
+++ b/surfaces/cli/src/commands/memory.test.ts
@@ -177,4 +177,47 @@ describe("registerMemoryCommands recall", () => {
 		expect(lines[0]).not.toContain('"low score row"');
 		expect(lines[0]).toContain('"totalReturned": 1');
 	});
+
+	test("forwards aggregate recall flags", async () => {
+		let capturedBody: unknown;
+		const program = new Command();
+		registerMemoryCommands(program, {
+			ensureDaemonForSecrets: async () => true,
+			secretApiCall: async (_method, _path, body) => {
+				capturedBody = body;
+				return {
+					ok: true,
+					data: {
+						query: "project history",
+						method: "hybrid",
+						results: [],
+						meta: {
+							totalReturned: 0,
+							hasSupplementary: false,
+							noHits: true,
+						},
+					},
+				};
+			},
+		});
+
+		await program.parseAsync([
+			"node",
+			"test",
+			"recall",
+			"project history",
+			"--aggregate",
+			"--aggregate-budget",
+			"large",
+			"--no-save-aggregate",
+			"--json",
+		]);
+
+		expect(capturedBody).toMatchObject({
+			query: "project history",
+			aggregate: true,
+			aggregateBudget: "large",
+			saveAggregate: false,
+		});
+	});
 });

--- a/surfaces/cli/src/commands/memory.ts
+++ b/surfaces/cli/src/commands/memory.ts
@@ -102,8 +102,7 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 		.action(async (query: string, options) => {
 			if (!(await deps.ensureDaemonForSecrets())) return;
 
-			const aggregateRequested =
-				options.aggregate === true || options.aggregateBudget !== "small" || options.saveAggregate === false;
+			const aggregateRequested = options.aggregate === true || options.aggregateBudget !== "small";
 			const spinner = ora("Searching memories...").start();
 			const { ok, data } = await deps.secretApiCall(
 				"POST",

--- a/surfaces/cli/src/commands/memory.ts
+++ b/surfaces/cli/src/commands/memory.ts
@@ -95,10 +95,15 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 		.option("--importance-min <n>", "Only return memories at or above this importance", Number.parseFloat)
 		.option("--min-score <n>", "Minimum recall score threshold (client-side)", Number.parseFloat)
 		.option("--agent <name>", "Filter by agent ID")
+		.option("--aggregate", "Synthesize an aggregate answer from bounded recall evidence", false)
+		.option("--aggregate-budget <budget>", "Aggregate recall budget: small, medium, or large", "small")
+		.option("--no-save-aggregate", "Return the aggregate answer without saving it as a memory")
 		.option("--json", "Output as JSON")
 		.action(async (query: string, options) => {
 			if (!(await deps.ensureDaemonForSecrets())) return;
 
+			const aggregateRequested =
+				options.aggregate === true || options.aggregateBudget !== "small" || options.saveAggregate === false;
 			const spinner = ora("Searching memories...").start();
 			const { ok, data } = await deps.secretApiCall(
 				"POST",
@@ -115,6 +120,9 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 					since: options.since,
 					until: options.until,
 					agentId: options.agent,
+					aggregate: aggregateRequested,
+					aggregateBudget: aggregateRequested ? options.aggregateBudget : undefined,
+					saveAggregate: aggregateRequested ? options.saveAggregate : undefined,
 				}),
 				MEMORY_RECALL_TIMEOUT_MS,
 			);


### PR DESCRIPTION
## Summary
- Adds explicit aggregate recall mode across daemon, CLI, MCP, SDK, and integration surfaces.
- Requires `remember` permission before recall routes can persist aggregate memories, while `saveAggregate: false` remains read-only.
- Aligns aggregate content-hash dedupe with the existing unique index and returns an unsaved aggregate on inaccessible duplicate content instead of 500ing.
- Adds provenance links from saved aggregate memories to source memory IDs.

## Test Plan
- `bun test platform/daemon/src/aggregate-recall.test.ts platform/daemon/src/daemon-auth-guard-colocation.test.ts platform/core/src/recall.test.ts platform/daemon/src/mcp/tools.test.ts surfaces/cli/src/commands/memory.test.ts libs/sdk/src/__tests__/client.test.ts libs/sdk/src/__tests__/openai.test.ts libs/sdk/src/__tests__/ai-sdk.test.ts`
- `bun run typecheck`
- `bunx biome check docs/API.md docs/MCP.md docs/CLI.md platform/daemon/src/aggregate-recall.ts platform/daemon/src/aggregate-recall.test.ts platform/daemon/src/routes/memory-routes.ts platform/daemon/src/routes/hooks-routes.ts platform/daemon/src/daemon-auth-guard-colocation.test.ts platform/daemon/src/mcp/tools.ts platform/daemon/src/mcp/tools.test.ts integrations/hermes-agent/connector/hermes-plugin/client.py`

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)
- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Rollback / compatibility: migration 073 only adds aggregate-memory provenance links. Existing memories and normal recall results remain compatible; old clients ignore aggregate metadata, and rollback would only remove aggregate source-link provenance while leaving ordinary saved memories intact.
