### PR TITLE
fix(memory): harden aggregate recall dogfood paths

### DIFF
--- a/platform/daemon/src/aggregate-recall.test.ts
+++ b/platform/daemon/src/aggregate-recall.test.ts
@@ -74,16 +74,20 @@ function aggregateKeyForTest(input: {
 
 class StaticRouter implements AggregateInferenceRouter {
 	calls: RouteRequest[] = [];
+	prompts: string[] = [];
 
-	async execute(request: RouteRequest): Promise<RouterResult<{ readonly text: string }>> {
+	constructor(private readonly synthesisText = "Aggregate answer from memory evidence.") {}
+
+	async execute(request: RouteRequest, prompt: string): Promise<RouterResult<{ readonly text: string }>> {
 		this.calls.push(request);
+		this.prompts.push(prompt);
 		return {
 			ok: true,
 			value: {
 				text:
 					this.calls.length === 1
 						? JSON.stringify({ queries: ["follow up one", "follow up two"] })
-						: "Aggregate answer from memory evidence.",
+						: this.synthesisText,
 			},
 		};
 	}
@@ -166,6 +170,11 @@ describe("aggregateRecall", () => {
 
 		expect(calls).toEqual(["what happened", "follow up one", "follow up two"]);
 		expect(router.calls.map((call) => call.operation)).toEqual(["tool_planning", "tool_planning"]);
+		expect(router.prompts[1]).toContain("one concise atomic memory note");
+		expect(router.prompts[1]).toContain("not as a direct reply");
+		expect(router.prompts[1]).toContain("Restate the question's subject or relationship");
+		expect(router.prompts[1]).toContain("partially answers the question");
+		expect(router.prompts[1]).toContain("INSUFFICIENT_EVIDENCE");
 		expect(result.results).toHaveLength(1);
 		expect(result.results[0].id).toBe("aggregate-1");
 		expect(result.results[0].source).toBe("aggregate-recall");
@@ -194,6 +203,11 @@ describe("aggregateRecall", () => {
 				.all("aggregate-1"),
 		) as Array<{ source_memory_id: string }>;
 		expect(links.map((link) => link.source_memory_id)).toEqual(["mem-1", "mem-2", "mem-3"]);
+
+		const hint = getDbAccessor().withReadDb(
+			(db) => db.prepare("SELECT hint FROM memory_hints WHERE memory_id = ?").get("aggregate-1") as { hint: string },
+		);
+		expect(hint.hint).toBe("what happened");
 	});
 
 	it("dedupes repeated aggregate runs for the same evidence set", async () => {
@@ -222,6 +236,11 @@ describe("aggregateRecall", () => {
 		expect(first.results[0].id).toBe("aggregate-1");
 		expect(second.results[0].id).toBe("aggregate-1");
 		expect(second.aggregate?.deduped).toBe(true);
+		const hints = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT hint FROM memory_hints WHERE memory_id = ?").all("aggregate-1") as Array<{ hint: string }>,
+		);
+		expect(hints.map((hint) => hint.hint)).toEqual(["what happened"]);
 	});
 
 	it("logs when a saved aggregate memory cannot be embedded", async () => {
@@ -289,6 +308,114 @@ describe("aggregateRecall", () => {
 			n: number;
 		};
 		expect(count.n).toBe(0);
+	});
+
+	it("returns but does not save insufficient-evidence aggregate answers", async () => {
+		const result = await aggregateRecall(
+			{
+				query: "what is Nicholai's favorite food?",
+				aggregate: true,
+				agentId: "agent-a",
+				readPolicy: "isolated",
+			},
+			loadMemoryConfig(dir),
+			{
+				router: new StaticRouter(
+					"There isn't enough evidence here to determine Nicholai's favorite food. The only explicit preference shown is earl grey tea.",
+				),
+				embedFn: async () => null,
+				logger: quietLogger(),
+				idFactory: () => "aggregate-insufficient",
+				hybridRecall: async (input: RecallParams) =>
+					response(input.query, [row("mem-1", "Nicholai likes earl grey tea.")]),
+			},
+		);
+
+		expect(result.results).toHaveLength(1);
+		expect(result.aggregate).toMatchObject({
+			savedMemoryId: null,
+			saved: false,
+			deduped: false,
+			stoppedReason: "complete",
+		});
+		const count = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT COUNT(*) AS n FROM memories WHERE id = ?").get("aggregate-insufficient") as { n: number },
+		);
+		expect(count.n).toBe(0);
+		const hints = getDbAccessor().withReadDb(
+			(db) => db.prepare("SELECT COUNT(*) AS n FROM memory_hints").get() as { n: number },
+		);
+		expect(hints.n).toBe(0);
+	});
+
+	it("returns but does not save conversational aggregate answers", async () => {
+		const result = await aggregateRecall(
+			{
+				query: "does Nicholai like danishes?",
+				aggregate: true,
+				agentId: "agent-a",
+				readPolicy: "isolated",
+			},
+			loadMemoryConfig(dir),
+			{
+				router: new StaticRouter(
+					'Yes. The evidence says Nicholai ate two gas station danishes and called them "amazing".',
+				),
+				embedFn: async () => null,
+				logger: quietLogger(),
+				idFactory: () => "aggregate-conversational",
+				hybridRecall: async (input: RecallParams) =>
+					response(input.query, [row("mem-1", 'Nicholai ate two gas station danishes and called them "amazing".')]),
+			},
+		);
+
+		expect(result.results).toHaveLength(1);
+		expect(result.aggregate).toMatchObject({
+			savedMemoryId: null,
+			saved: false,
+			deduped: false,
+			stoppedReason: "complete",
+		});
+		const count = getDbAccessor().withReadDb(
+			(db) =>
+				db.prepare("SELECT COUNT(*) AS n FROM memories WHERE id = ?").get("aggregate-conversational") as {
+					n: number;
+				},
+		);
+		expect(count.n).toBe(0);
+	});
+
+	it("saves atomic partial answers when they restate the queried relationship", async () => {
+		const result = await aggregateRecall(
+			{
+				query: "what are the problems going on between Amari and Nicholai?",
+				aggregate: true,
+				agentId: "agent-a",
+				readPolicy: "isolated",
+			},
+			loadMemoryConfig(dir),
+			{
+				router: new StaticRouter(
+					"Nicholai and Amari broke up on March 14, 2026, were still figuring things out on May 12, and by May 20 Nicholai felt ready to move on.",
+				),
+				embedFn: async () => null,
+				logger: quietLogger(),
+				now: () => new Date("2026-05-20T12:00:00.000Z"),
+				idFactory: () => "aggregate-atomic-partial",
+				hybridRecall: async (input: RecallParams) =>
+					response(input.query, [
+						row("mem-1", "Nicholai and Amari broke up on March 14, 2026; by May 20 Nicholai felt ready to move on."),
+					]),
+			},
+		);
+
+		expect(result.results[0].content).toContain("Nicholai and Amari");
+		expect(result.aggregate).toMatchObject({
+			savedMemoryId: "aggregate-atomic-partial",
+			saved: true,
+			stoppedReason: "complete",
+		});
 	});
 
 	it("does not save global aggregate memories from private evidence", async () => {

--- a/platform/daemon/src/aggregate-recall.ts
+++ b/platform/daemon/src/aggregate-recall.ts
@@ -192,6 +192,31 @@ function evidenceCanSaveAsGlobalAggregate(rows: readonly RecallResult[]): boolea
 	return rows.every((row) => row.visibility === "global" && row.scope === null);
 }
 
+function isInsufficientAggregateAnswer(text: string): boolean {
+	const normalized = normalizeQuery(text);
+	return (
+		normalized === "insufficient_evidence" ||
+		/^(there (isn't|is not) enough|not enough|insufficient|no useful)\b.{0,80}\bevidence\b/.test(normalized) ||
+		/^(can't|cannot|could not|unable to)\b.{0,80}\b(determine|answer|infer)\b/.test(normalized)
+	);
+}
+
+function isConversationalAggregateAnswer(text: string): boolean {
+	const normalized = normalizeQuery(text);
+	return (
+		/^(yes|no|probably|maybe)\b[.!?,:;-]?/.test(normalized) ||
+		/\b(based on (the )?evidence|from the evidence|the evidence (says|shows|suggests)|the read is|so the read is)\b/.test(
+			normalized,
+		) ||
+		/^(answer|response):/.test(normalized)
+	);
+}
+
+function aggregateAnswerCanBeSaved(text: string): boolean {
+	const trimmed = text.trim();
+	return trimmed.length >= 12 && !isInsufficientAggregateAnswer(trimmed) && !isConversationalAggregateAnswer(trimmed);
+}
+
 function aggregateKey(input: {
 	readonly agentId: string;
 	readonly project: string | null;
@@ -311,12 +336,28 @@ function linkAggregateSources(
 	}
 }
 
+function linkAggregateQueryHint(
+	db: WriteDb,
+	aggregateMemoryId: string,
+	agentId: string,
+	query: string,
+	now: string,
+): void {
+	const hint = query.trim();
+	if (hint.length === 0) return;
+	db.prepare(
+		`INSERT OR IGNORE INTO memory_hints (id, memory_id, agent_id, hint, created_at)
+		 VALUES (?, ?, ?, ?, ?)`,
+	).run(randomUUID(), aggregateMemoryId, agentId, hint, now);
+}
+
 function resolveAggregateDuplicate(
 	db: WriteDb,
 	input: {
 		readonly key: string;
 		readonly agentId: string;
 		readonly project: string | null;
+		readonly query: string;
 		readonly contentHash: string;
 		readonly answer: string;
 		readonly sourceMemoryIds: readonly string[];
@@ -326,6 +367,7 @@ function resolveAggregateDuplicate(
 	const existing = loadAggregateByKey(db, input.key, { agentId: input.agentId, project: input.project });
 	if (existing) {
 		linkAggregateSources(db, existing.id, input.sourceMemoryIds, input.agentId, input.now);
+		linkAggregateQueryHint(db, existing.id, input.agentId, input.query, input.now);
 		return { row: existing, saved: true };
 	}
 	const duplicateContent = loadMemoryByContentHash(db, input.contentHash, {
@@ -337,6 +379,7 @@ function resolveAggregateDuplicate(
 		return { row: unsavedAggregateResult(input.answer, input.key, input.project), saved: false };
 	}
 	linkAggregateSources(db, duplicateContent.row.id, input.sourceMemoryIds, input.agentId, input.now);
+	linkAggregateQueryHint(db, duplicateContent.row.id, input.agentId, input.query, input.now);
 	return { row: duplicateContent.row, saved: true };
 }
 
@@ -425,8 +468,13 @@ async function synthesize(input: {
 	readonly evidence: readonly RecallResult[];
 }): Promise<string | null> {
 	const prompt = [
-		"Synthesize a concise answer from the memory evidence below.",
-		"Use only the evidence. If the evidence is insufficient, say so briefly.",
+		"Write one concise atomic memory note from the memory evidence below.",
+		"Use only the evidence.",
+		"Write in third person as a standalone memory, not as a direct reply to the question.",
+		"Restate the question's subject or relationship in the memory so the note is useful without the original query.",
+		"If the evidence partially answers the question, save the stable known facts and omit unknowns or speculation.",
+		'Do not begin with "yes", "no", "based on the evidence", "the evidence says", or similar conversational framing.',
+		"If there are no useful stable facts relevant to the question, return exactly: INSUFFICIENT_EVIDENCE",
 		`Question: ${input.params.query}`,
 		"",
 		"Evidence:",
@@ -516,13 +564,14 @@ export async function aggregateRecall(
 	let row: RecallResult | null;
 	let deduped = false;
 	let saved = false;
-	if (saveAggregate && evidenceCanSaveAsGlobalAggregate(evidence)) {
+	if (saveAggregate && evidenceCanSaveAsGlobalAggregate(evidence) && aggregateAnswerCanBeSaved(answer)) {
 		const normalized = normalizeAndHashContent(answer);
 		row = getDbAccessor().withWriteTx((db) => {
 			const duplicate = resolveAggregateDuplicate(db, {
 				key,
 				agentId,
 				project,
+				query: params.query,
 				contentHash: normalized.contentHash,
 				answer,
 				sourceMemoryIds,
@@ -567,6 +616,7 @@ export async function aggregateRecall(
 					key,
 					agentId,
 					project,
+					query: params.query,
 					contentHash: normalized.contentHash,
 					answer,
 					sourceMemoryIds,
@@ -582,6 +632,7 @@ export async function aggregateRecall(
 				return racedDuplicate.row;
 			}
 			linkAggregateSources(db, id, sourceMemoryIds, agentId, now);
+			linkAggregateQueryHint(db, id, agentId, params.query, now);
 			saved = true;
 			return loadAggregateMemory(db, id);
 		});

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -328,6 +328,54 @@ describe("hybridRecall", () => {
 		expect(result.meta.noHits).toBe(true);
 	});
 
+	it("does not satisfy tagged recall with unfiltered source fallback rows", async () => {
+		const now = new Date().toISOString();
+		const vec = unitVector();
+		const codexMemoryPath = join(dir, "codex", "memories", "MEMORY.md");
+		mkdirSync(join(dir, "codex", "memories"), { recursive: true });
+		writeFileSync(codexMemoryPath, "# Codex Memory\n\nFiltered source fallback marker from native artifact.\n");
+		indexExternalMemoryArtifact({
+			agentId: "default",
+			sourcePath: codexMemoryPath,
+			sourceKind: "native_memory_registry",
+			harness: "codex",
+			content: readFileSync(codexMemoryPath, "utf-8"),
+			sourceMtimeMs: Date.now(),
+		});
+
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO embeddings (
+					id, content_hash, vector, dimensions, source_type, source_id,
+					chunk_text, created_at, agent_id
+				) VALUES (?, ?, ?, 768, 'source_obsidian_chunk', ?, ?, ?, 'default')`,
+			).run(
+				"emb-filtered-source",
+				"hash-filtered-source",
+				vectorBlob(vec),
+				"obsidian:vault:filtered-source.md#overview:1-1:0",
+				"source_path: /vault/filtered-source.md\nFiltered source fallback marker from source chunk.",
+				now,
+			);
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "Filtered source fallback marker",
+				keywordQuery: "Filtered source fallback marker",
+				limit: 5,
+				agentId: "default",
+				readPolicy: "isolated",
+				tags: "cleanup-20260520",
+			},
+			testCfg(),
+			async () => vec,
+		);
+
+		expect(result.results).toEqual([]);
+		expect(result.meta.noHits).toBe(true);
+	});
+
 	it("falls back to keyword recall when embedding throws synchronously", async () => {
 		const now = new Date().toISOString();
 		getDbAccessor().withWriteTx((db) => {

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -297,6 +297,24 @@ function buildFilterClause(params: RecallParams): FilterClause {
 	return base;
 }
 
+function hasMemoryMetadataFilters(params: RecallParams): boolean {
+	const hasTags =
+		params.tags
+			?.split(",")
+			.map((tag) => tag.trim())
+			.some(Boolean) === true;
+	return (
+		params.type !== undefined ||
+		hasTags ||
+		params.who !== undefined ||
+		params.pinned === true ||
+		typeof params.importance_min === "number" ||
+		params.since !== undefined ||
+		params.until !== undefined ||
+		params.scope !== undefined
+	);
+}
+
 function normalizeRecallLimit(raw: number | undefined): number {
 	if (typeof raw !== "number" || !Number.isFinite(raw)) return 10;
 	return Math.max(1, Math.min(50, Math.floor(raw)));
@@ -1859,12 +1877,21 @@ export async function hybridRecall(
 			: limit;
 	const topIds = scored.slice(0, preHydrate).map((s) => s.id);
 	const recallTruncate = cfg.pipelineV2.guardrails.recallTruncateChars;
+	const allowSourceFallbacks = !hasMemoryMetadataFilters(params);
 
 	if (topIds.length === 0) {
 		const fallbackLimit = selectionDedupeEnabled ? Math.max(limit * 3, limit + 10) : limit;
-		const sourceChunkHits = timings.time("source_chunk_vector_fallback", () =>
-			buildSourceChunkVectorHits(queryVecF32, new Set(), fallbackLimit, params.agentId ?? "default", params.project),
-		);
+		const sourceChunkHits = allowSourceFallbacks
+			? timings.time("source_chunk_vector_fallback", () =>
+					buildSourceChunkVectorHits(
+						queryVecF32,
+						new Set(),
+						fallbackLimit,
+						params.agentId ?? "default",
+						params.project,
+					),
+				)
+			: [];
 		if (sourceChunkHits.length > 0) {
 			const results = suppressPreviouslyRecalledForSelection(
 				sourceChunkHits.slice(0, fallbackLimit).map((hit): RecallResult => {
@@ -1904,9 +1931,9 @@ export async function hybridRecall(
 				});
 			}
 		}
-		const nativeHits = timings.time("native_artifact_fallback", () =>
-			buildNativeArtifactRecallHits(params, expandedQuery, new Set()),
-		);
+		const nativeHits = allowSourceFallbacks
+			? timings.time("native_artifact_fallback", () => buildNativeArtifactRecallHits(params, expandedQuery, new Set()))
+			: [];
 		if (nativeHits.length > 0) {
 			const results = suppressPreviouslyRecalledForSelection(
 				nativeHits.slice(0, fallbackLimit).map((hit): RecallResult => {
@@ -2030,15 +2057,17 @@ export async function hybridRecall(
 	if (results.length < limit) {
 		const existingSourceIds = new Set(results.map((row) => row.source_id).filter((id): id is string => !!id));
 		const fill = limit - results.length;
-		const sourceChunkHits = timings.time("source_chunk_vector_supplement", () =>
-			buildSourceChunkVectorHits(
-				queryVecF32,
-				existingSourceIds,
-				selectionDedupeEnabled ? Math.max(fill * 3, fill + 10) : fill,
-				params.agentId ?? "default",
-				params.project,
-			),
-		);
+		const sourceChunkHits = allowSourceFallbacks
+			? timings.time("source_chunk_vector_supplement", () =>
+					buildSourceChunkVectorHits(
+						queryVecF32,
+						existingSourceIds,
+						selectionDedupeEnabled ? Math.max(fill * 3, fill + 10) : fill,
+						params.agentId ?? "default",
+						params.project,
+					),
+				)
+			: [];
 		const candidates = sourceChunkHits.map((hit): RecallResult => {
 			const content = `[Obsidian vault chunk: ${hit.sourcePath}]\n${hit.chunkText}`;
 			const truncated = content.length > recallTruncate;
@@ -2071,9 +2100,11 @@ export async function hybridRecall(
 
 	if (results.length < limit) {
 		const existingSourceIds = new Set(results.map((row) => row.source_id).filter((id): id is string => !!id));
-		const nativeHits = timings.time("native_artifact_supplement", () =>
-			buildNativeArtifactRecallHits(params, expandedQuery, existingSourceIds),
-		);
+		const nativeHits = allowSourceFallbacks
+			? timings.time("native_artifact_supplement", () =>
+					buildNativeArtifactRecallHits(params, expandedQuery, existingSourceIds),
+				)
+			: [];
 		const candidates = nativeHits.map((hit): RecallResult => {
 			const content = nativeArtifactRecallContent(hit);
 			const truncated = content.length > recallTruncate;

--- a/platform/daemon/src/transactions.test.ts
+++ b/platform/daemon/src/transactions.test.ts
@@ -285,6 +285,60 @@ describe("transactions: txModifyMemory + txForgetMemory + txRecoverMemory", () =
 		expect(history.reason).toBe("cleanup with force");
 	});
 
+	it("removes aggregate provenance links when a linked memory is forgotten", () => {
+		insertMemory(db, {
+			id: "mem-aggregate",
+			content: "Aggregate content",
+			contentHash: "hash-aggregate",
+		});
+		insertMemory(db, {
+			id: "mem-source",
+			content: "Source content",
+			contentHash: "hash-source",
+		});
+		insertMemory(db, {
+			id: "mem-other-aggregate",
+			content: "Other aggregate content",
+			contentHash: "hash-other-aggregate",
+		});
+		insertMemory(db, {
+			id: "mem-other-source",
+			content: "Other source content",
+			contentHash: "hash-other-source",
+		});
+
+		const now = new Date().toISOString();
+		const link = db.prepare(
+			`INSERT INTO aggregate_memory_sources (
+				aggregate_memory_id, source_memory_id, agent_id, created_at
+			) VALUES (?, ?, 'default', ?)`,
+		);
+		link.run("mem-aggregate", "mem-source", now);
+		link.run("mem-other-aggregate", "mem-aggregate", now);
+		link.run("mem-other-aggregate", "mem-other-source", now);
+
+		const result = txForgetMemory(asWriteDb(db), {
+			memoryId: "mem-aggregate",
+			reason: "cleanup",
+			changedBy: "operator",
+			changedAt: now,
+			force: false,
+		});
+
+		expect(result.status).toBe("deleted");
+		const linkedRows = db
+			.prepare(
+				`SELECT aggregate_memory_id, source_memory_id
+				 FROM aggregate_memory_sources
+				 WHERE aggregate_memory_id = ? OR source_memory_id = ?`,
+			)
+			.all("mem-aggregate", "mem-aggregate");
+		expect(linkedRows).toEqual([]);
+
+		const remaining = db.prepare("SELECT COUNT(*) AS count FROM aggregate_memory_sources").get() as { count: number };
+		expect(remaining.count).toBe(1);
+	});
+
 	it("recovers a soft-deleted memory within retention window", () => {
 		insertMemory(db, {
 			id: "mem-recoverable",

--- a/platform/daemon/src/transactions.ts
+++ b/platform/daemon/src/transactions.ts
@@ -7,7 +7,7 @@
  */
 
 import type { WriteDb } from "./db-accessor";
-import { vectorToBlob, syncVecInsert, syncVecDeleteBySourceId, syncVecDeleteBySourceExceptHash } from "./db-helpers";
+import { syncVecDeleteBySourceExceptHash, syncVecDeleteBySourceId, syncVecInsert, vectorToBlob } from "./db-helpers";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -204,6 +204,19 @@ export function insertHistoryEvent(
 		args.sessionId ?? null,
 		args.requestId ?? null,
 	);
+}
+
+function tableExists(db: WriteDb, name: string): boolean {
+	const row = db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(name);
+	return row !== null && row !== undefined;
+}
+
+function deleteAggregateMemorySourceLinks(db: WriteDb, memoryId: string): void {
+	if (!tableExists(db, "aggregate_memory_sources")) return;
+	db.prepare(
+		`DELETE FROM aggregate_memory_sources
+		 WHERE aggregate_memory_id = ? OR source_memory_id = ?`,
+	).run(memoryId, memoryId);
 }
 
 // ---------------------------------------------------------------------------
@@ -503,6 +516,7 @@ export function txForgetMemory(db: WriteDb, input: ForgetMemoryTxInput): ForgetM
 		     version = version + 1
 		 WHERE id = ?`,
 	).run(input.changedAt, input.changedAt, input.changedBy, input.memoryId);
+	deleteAggregateMemorySourceLinks(db, input.memoryId);
 
 	insertHistoryEvent(db, {
 		memoryId: input.memoryId,
@@ -656,6 +670,7 @@ export function txApplyDecision(db: WriteDb, decision: SemanticDecision): void {
 				     updated_by = ?, version = version + 1
 				 WHERE id = ?`,
 			).run(decision.updatedAt, decision.updatedAt, decision.updatedBy, decision.memoryId);
+			deleteAggregateMemorySourceLinks(db, decision.memoryId);
 
 			insertHistoryEvent(db, {
 				memoryId: decision.memoryId,
@@ -754,6 +769,7 @@ export function txApplyDecision(db: WriteDb, decision: SemanticDecision): void {
 				     updated_by = ?, version = version + 1
 				 WHERE id = ?`,
 			).run(decision.updatedAt, decision.updatedAt, decision.updatedBy, decision.memoryId);
+			deleteAggregateMemorySourceLinks(db, decision.memoryId);
 
 			insertHistoryEvent(db, {
 				memoryId: decision.memoryId,

--- a/surfaces/cli/src/commands/memory.test.ts
+++ b/surfaces/cli/src/commands/memory.test.ts
@@ -180,11 +180,13 @@ describe("registerMemoryCommands recall", () => {
 
 	test("forwards aggregate recall flags", async () => {
 		let capturedBody: unknown;
+		let capturedTimeout: number | undefined;
 		const program = new Command();
 		registerMemoryCommands(program, {
 			ensureDaemonForSecrets: async () => true,
-			secretApiCall: async (_method, _path, body) => {
+			secretApiCall: async (_method, _path, body, timeoutMs) => {
 				capturedBody = body;
+				capturedTimeout = timeoutMs;
 				return {
 					ok: true,
 					data: {
@@ -219,15 +221,18 @@ describe("registerMemoryCommands recall", () => {
 			aggregateBudget: "large",
 			saveAggregate: false,
 		});
+		expect(capturedTimeout).toBe(120_000);
 	});
 
 	test("--no-save-aggregate does not enable aggregate recall by itself", async () => {
 		let capturedBody: unknown;
+		let capturedTimeout: number | undefined;
 		const program = new Command();
 		registerMemoryCommands(program, {
 			ensureDaemonForSecrets: async () => true,
-			secretApiCall: async (_method, _path, body) => {
+			secretApiCall: async (_method, _path, body, timeoutMs) => {
 				capturedBody = body;
+				capturedTimeout = timeoutMs;
 				return {
 					ok: true,
 					data: {
@@ -250,5 +255,6 @@ describe("registerMemoryCommands recall", () => {
 			query: "project history",
 			limit: 10,
 		});
+		expect(capturedTimeout).toBe(30_000);
 	});
 });

--- a/surfaces/cli/src/commands/memory.ts
+++ b/surfaces/cli/src/commands/memory.ts
@@ -10,6 +10,7 @@ import type { Command } from "commander";
 import ora from "ora";
 
 const MEMORY_RECALL_TIMEOUT_MS = 30_000;
+const AGGREGATE_MEMORY_RECALL_TIMEOUT_MS = 120_000;
 
 function collectHint(value: string, previous: string[] = []): string[] {
 	const hint = value.trim();
@@ -105,6 +106,7 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 			if (!(await deps.ensureDaemonForSecrets())) return;
 
 			const aggregateRequested = options.aggregate === true || options.aggregateBudget !== "small";
+			const timeoutMs = aggregateRequested ? AGGREGATE_MEMORY_RECALL_TIMEOUT_MS : MEMORY_RECALL_TIMEOUT_MS;
 			const spinner = ora("Searching memories...").start();
 			const { ok, data } = await deps.secretApiCall(
 				"POST",
@@ -127,7 +129,7 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 					sessionKey: options.sessionKey,
 					includeRecalled: options.includeRecalled,
 				}),
-				MEMORY_RECALL_TIMEOUT_MS,
+				timeoutMs,
 			);
 
 			const err = typeof data === "object" && data !== null && "error" in data ? data.error : undefined;


### PR DESCRIPTION
## Summary

Fixes aggregate-recall dogfood issues:

- gives explicit aggregate CLI recall a longer timeout while keeping normal recall at 30s
- prevents source/native fallback rows from satisfying recall requests with memory metadata filters like `tags`
- removes `aggregate_memory_sources` provenance rows when a linked memory is soft-deleted
- changes aggregate synthesis to produce atomic memory notes that restate the queried subject/relation instead of direct conversational answers
- returns but does not save aggregate outputs that are effectively no-answer or conversational response text
- stores the original aggregate query as a prospective `memory_hints` row on saved/deduped aggregate memories

## PR Readiness Checklist

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

Notes: no API/spec/status docs changed; no new admin or mutation endpoint was added. The delete cleanup runs inside existing soft-delete transactions.

## Verification

- `bun test platform/daemon/src/aggregate-recall.test.ts`
- `bun test surfaces/cli/src/commands/memory.test.ts`
- `bun test platform/daemon/src/transactions.test.ts`
- `bun test platform/daemon/src/memory-search.test.ts`
- `bunx biome check platform/daemon/src/aggregate-recall.ts platform/daemon/src/aggregate-recall.test.ts platform/daemon/src/memory-search.ts platform/daemon/src/memory-search.test.ts platform/daemon/src/transactions.ts platform/daemon/src/transactions.test.ts surfaces/cli/src/commands/memory.ts surfaces/cli/src/commands/memory.test.ts` (passes with existing `any` warnings in `memory-search.ts`)
- `bun run typecheck`
- `bun run build:cli` from `surfaces/cli`
- `bun run build.ts` from `platform/daemon`

## Notes

`bun run lint` still fails repo-wide on pre-existing package.json formatting drift outside this change set.