### PR TITLE
perf(daemon): speed up aggregate recall

### DIFF
--- a/platform/daemon/src/aggregate-recall.test.ts
+++ b/platform/daemon/src/aggregate-recall.test.ts
@@ -75,12 +75,28 @@ function aggregateKeyForTest(input: {
 class StaticRouter implements AggregateInferenceRouter {
 	calls: RouteRequest[] = [];
 	prompts: string[] = [];
+	opts: Array<{
+		readonly timeoutMs?: number;
+		readonly maxTokens?: number;
+		readonly refresh?: boolean;
+		readonly acpxHooks?: "disabled" | "inherit";
+	}> = [];
 
 	constructor(private readonly synthesisText = "Aggregate answer from memory evidence.") {}
 
-	async execute(request: RouteRequest, prompt: string): Promise<RouterResult<{ readonly text: string }>> {
+	async execute(
+		request: RouteRequest,
+		prompt: string,
+		opts?: {
+			readonly timeoutMs?: number;
+			readonly maxTokens?: number;
+			readonly refresh?: boolean;
+			readonly acpxHooks?: "disabled" | "inherit";
+		},
+	): Promise<RouterResult<{ readonly text: string }>> {
 		this.calls.push(request);
 		this.prompts.push(prompt);
+		this.opts.push(opts ?? {});
 		return {
 			ok: true,
 			value: {
@@ -170,6 +186,7 @@ describe("aggregateRecall", () => {
 
 		expect(calls).toEqual(["what happened", "follow up one", "follow up two"]);
 		expect(router.calls.map((call) => call.operation)).toEqual(["tool_planning", "tool_planning"]);
+		expect(router.opts.map((opts) => opts.acpxHooks)).toEqual(["disabled", "disabled"]);
 		expect(router.prompts[1]).toContain("one concise atomic memory note");
 		expect(router.prompts[1]).toContain("not as a direct reply");
 		expect(router.prompts[1]).toContain("Restate the question's subject or relationship");
@@ -185,6 +202,14 @@ describe("aggregateRecall", () => {
 			sourceMemoryIds: ["mem-1", "mem-2", "mem-3"],
 			stoppedReason: "complete",
 		});
+		expect(result.meta.timings.stages.map((stage) => stage.name)).toEqual([
+			"aggregate_initial_recall",
+			"aggregate_planning",
+			"aggregate_followup_recalls",
+			"aggregate_synthesis",
+			"aggregate_save",
+			"aggregate_embedding",
+		]);
 
 		const saved = getDbAccessor().withReadDb((db) =>
 			db.prepare("SELECT source_type, idempotency_key, tags, who, type FROM memories WHERE id = ?").get("aggregate-1"),
@@ -241,6 +266,37 @@ describe("aggregateRecall", () => {
 				db.prepare("SELECT hint FROM memory_hints WHERE memory_id = ?").all("aggregate-1") as Array<{ hint: string }>,
 		);
 		expect(hints.map((hint) => hint.hint)).toEqual(["what happened"]);
+	});
+
+	it("runs planned follow-up recalls concurrently", async () => {
+		let activeFollowups = 0;
+		let maxActiveFollowups = 0;
+		const result = await aggregateRecall(
+			{
+				query: "what happened",
+				aggregate: true,
+				saveAggregate: false,
+				agentId: "agent-a",
+				readPolicy: "isolated",
+			},
+			loadMemoryConfig(dir),
+			{
+				router: new StaticRouter(),
+				embedFn: async () => null,
+				hybridRecall: async (input: RecallParams) => {
+					if (input.query.startsWith("follow up")) {
+						activeFollowups += 1;
+						maxActiveFollowups = Math.max(maxActiveFollowups, activeFollowups);
+						await new Promise((resolve) => setTimeout(resolve, 20));
+						activeFollowups -= 1;
+					}
+					return response(input.query, [row(input.query, `${input.query} evidence`)]);
+				},
+			},
+		);
+
+		expect(result.results).toHaveLength(1);
+		expect(maxActiveFollowups).toBe(2);
 	});
 
 	it("logs when a saved aggregate memory cannot be embedded", async () => {
@@ -797,5 +853,6 @@ describe("aggregateRecall", () => {
 			stoppedReason: "router_unavailable",
 			sourceMemoryIds: ["mem-1"],
 		});
+		expect(result.meta.timings.stages.map((stage) => stage.name)).toEqual(["aggregate_initial_recall"]);
 	});
 });

--- a/platform/daemon/src/aggregate-recall.ts
+++ b/platform/daemon/src/aggregate-recall.ts
@@ -5,7 +5,14 @@ import { type WriteDb, getDbAccessor } from "./db-accessor";
 import { syncVecDeleteBySourceId, syncVecInsert, vectorToBlob } from "./db-helpers";
 import { logger } from "./logger";
 import type { EmbeddingConfig, ResolvedMemoryConfig } from "./memory-config";
-import { type EmbedFn, type RecallParams, type RecallResponse, type RecallResult, hybridRecall } from "./memory-search";
+import {
+	type EmbedFn,
+	type RecallParams,
+	type RecallResponse,
+	type RecallResult,
+	type RecallTimings,
+	hybridRecall,
+} from "./memory-search";
 import { type IngestEnvelope, txIngestEnvelope } from "./transactions";
 
 export type AggregateRecallBudget = "small" | "medium" | "large";
@@ -19,7 +26,12 @@ export interface AggregateInferenceRouter {
 	execute(
 		request: RouteRequest,
 		prompt: string,
-		opts?: { readonly timeoutMs?: number; readonly maxTokens?: number; readonly refresh?: boolean },
+		opts?: {
+			readonly timeoutMs?: number;
+			readonly maxTokens?: number;
+			readonly refresh?: boolean;
+			readonly acpxHooks?: "disabled" | "inherit";
+		},
 	): Promise<RouterResult<AggregateInferenceResult>>;
 }
 
@@ -68,6 +80,47 @@ const BUDGET_QUERY_LIMITS: Record<AggregateRecallBudget, number> = {
 	medium: 5,
 	large: 8,
 };
+const AGGREGATE_RECALL_TIMING_LOG_THRESHOLD_MS = 1000;
+
+function roundAggregateDuration(ms: number): number {
+	return Math.round(ms * 100) / 100;
+}
+
+function createAggregateTimingCollector(): {
+	readonly time: <T>(name: string, fn: () => T) => T;
+	readonly timeAsync: <T>(name: string, fn: () => Promise<T>) => Promise<T>;
+	readonly finish: () => RecallTimings;
+} {
+	const start = performance.now();
+	const stages: RecallTimings["stages"] = [];
+	const record = (name: string, stageStart: number): void => {
+		stages.push({ name, durationMs: roundAggregateDuration(performance.now() - stageStart) });
+	};
+	return {
+		time<T>(name: string, fn: () => T): T {
+			const stageStart = performance.now();
+			try {
+				return fn();
+			} finally {
+				record(name, stageStart);
+			}
+		},
+		async timeAsync<T>(name: string, fn: () => Promise<T>): Promise<T> {
+			const stageStart = performance.now();
+			try {
+				return await fn();
+			} finally {
+				record(name, stageStart);
+			}
+		},
+		finish(): RecallTimings {
+			return {
+				totalMs: roundAggregateDuration(performance.now() - start),
+				stages: [...stages],
+			};
+		},
+	};
+}
 
 export class InvalidAggregateRecallBudgetError extends Error {
 	constructor() {
@@ -457,7 +510,7 @@ async function planQueries(input: {
 			expectedOutputTokens: 300,
 		},
 		prompt,
-		{ maxTokens: 300, timeoutMs: 20_000 },
+		{ maxTokens: 300, timeoutMs: 20_000, acpxHooks: "disabled" },
 	);
 	return result.ok ? parsePlannerQueries(result.value.text).slice(0, remaining) : [];
 }
@@ -491,7 +544,7 @@ async function synthesize(input: {
 			expectedOutputTokens: 700,
 		},
 		prompt,
-		{ maxTokens: 700, timeoutMs: 30_000 },
+		{ maxTokens: 700, timeoutMs: 30_000, acpxHooks: "disabled" },
 	);
 	if (!result.ok) return null;
 	const text = result.value.text.trim();
@@ -509,51 +562,85 @@ export async function aggregateRecall(
 	const saveAggregate = params.saveAggregate !== false && params.save_aggregate !== false;
 	const log = deps.logger ?? logger;
 	const ingestEnvelope = deps.ingestEnvelope ?? txIngestEnvelope;
-	const first = await recall(params, cfg, deps.embedFn);
+	const timings = createAggregateTimingCollector();
+	const finish = (response: RecallResponse): RecallResponse => {
+		const recallTimings = timings.finish();
+		if (recallTimings.totalMs >= AGGREGATE_RECALL_TIMING_LOG_THRESHOLD_MS) {
+			log.warn("memory", "Aggregate recall stage timings", {
+				agentId: params.agentId ?? "default",
+				budget,
+				queryCount: response.aggregate?.queries.length ?? 1,
+				sourceMemoryCount: response.aggregate?.sourceMemoryIds.length ?? 0,
+				resultCount: response.meta.totalReturned,
+				totalMs: recallTimings.totalMs,
+				stages: recallTimings.stages,
+			});
+		}
+		return {
+			...response,
+			meta: {
+				...response.meta,
+				timings: recallTimings,
+			},
+		};
+	};
+	const first = await timings.timeAsync("aggregate_initial_recall", () => recall(params, cfg, deps.embedFn));
 
 	if (!deps.router) {
 		const sourceMemoryIds = uniqueEvidence(first.results).map((row) => row.id);
-		return emptyAggregateResponse(
-			params,
-			budget,
-			[params.query],
-			sourceMemoryIds,
-			sourceMemoryIds.length === 0 ? "no_evidence" : "router_unavailable",
-		);
-	}
-
-	const planned = await planQueries({
-		router: deps.router,
-		params,
-		budget,
-		maxQueries,
-		initialRows: first.results,
-	});
-	const queries = uniqueQueries(params.query, planned, maxQueries);
-	const recalls = [first];
-	for (const query of queries.slice(1)) {
-		recalls.push(
-			await recall(
-				{
-					...params,
-					query,
-					aggregate: false,
-				},
-				cfg,
-				deps.embedFn,
+		return finish(
+			emptyAggregateResponse(
+				params,
+				budget,
+				[params.query],
+				sourceMemoryIds,
+				sourceMemoryIds.length === 0 ? "no_evidence" : "router_unavailable",
 			),
 		);
 	}
 
+	const planned = await timings.timeAsync("aggregate_planning", () =>
+		planQueries({
+			router: deps.router,
+			params,
+			budget,
+			maxQueries,
+			initialRows: first.results,
+		}),
+	);
+	const queries = uniqueQueries(params.query, planned, maxQueries);
+	const followupQueries = queries.slice(1);
+	const followupRecalls =
+		followupQueries.length === 0
+			? []
+			: await timings.timeAsync("aggregate_followup_recalls", () =>
+					Promise.all(
+						followupQueries.map((query) =>
+							recall(
+								{
+									...params,
+									query,
+									aggregate: false,
+								},
+								cfg,
+								deps.embedFn,
+							),
+						),
+					),
+				);
+	const recalls = [first, ...followupRecalls];
+
 	const evidence = uniqueEvidence(recalls.flatMap((result) => result.results));
 	const sourceMemoryIds = evidence.map((row) => row.id);
 	if (evidence.length === 0) {
-		return emptyAggregateResponse(params, budget, queries, [], "no_evidence");
+		return finish(emptyAggregateResponse(params, budget, queries, [], "no_evidence"));
 	}
 
-	const answer = await synthesize({ router: deps.router, params, evidence });
+	const answer = await timings.timeAsync("aggregate_synthesis", () =>
+		synthesize({ router: deps.router, params, evidence }),
+	);
 	if (!answer) {
-		return emptyAggregateResponse(params, budget, queries, sourceMemoryIds, "synthesis_failed");
+		return finish(emptyAggregateResponse(params, budget, queries, sourceMemoryIds, "synthesis_failed"));
 	}
 
 	const agentId = params.agentId ?? "default";
@@ -566,53 +653,9 @@ export async function aggregateRecall(
 	let saved = false;
 	if (saveAggregate && evidenceCanSaveAsGlobalAggregate(evidence) && aggregateAnswerCanBeSaved(answer)) {
 		const normalized = normalizeAndHashContent(answer);
-		row = getDbAccessor().withWriteTx((db) => {
-			const duplicate = resolveAggregateDuplicate(db, {
-				key,
-				agentId,
-				project,
-				query: params.query,
-				contentHash: normalized.contentHash,
-				answer,
-				sourceMemoryIds,
-				now,
-			});
-			if (duplicate) {
-				deduped = true;
-				saved = duplicate.saved;
-				return duplicate.row;
-			}
-			const id = deps.idFactory?.() ?? randomUUID();
-			const envelope: IngestEnvelope = {
-				id,
-				content: normalized.storageContent,
-				normalizedContent: normalized.normalizedContent || normalized.hashBasis,
-				contentHash: normalized.contentHash,
-				who: "signet",
-				why: "aggregate recall",
-				project,
-				importance: 0.75,
-				type: "semantic",
-				tags: "aggregate,recall",
-				pinned: 0,
-				isDeleted: 0,
-				extractionStatus: "none",
-				embeddingModel: null,
-				extractionModel: null,
-				updatedBy: "signet",
-				sourceType: "aggregate-recall",
-				sourceId: key,
-				idempotencyKey: key,
-				scope: null,
-				agentId,
-				visibility: "global",
-				createdAt: now,
-			};
-			try {
-				ingestEnvelope(db, envelope);
-			} catch (err) {
-				if (!isUniqueConstraintError(err)) throw err;
-				const racedDuplicate = resolveAggregateDuplicate(db, {
+		row = timings.time("aggregate_save", () =>
+			getDbAccessor().withWriteTx((db) => {
+				const duplicate = resolveAggregateDuplicate(db, {
 					key,
 					agentId,
 					project,
@@ -622,31 +665,72 @@ export async function aggregateRecall(
 					sourceMemoryIds,
 					now,
 				});
-				if (!racedDuplicate) {
+				if (duplicate) {
 					deduped = true;
-					saved = false;
-					return unsavedAggregateResult(answer, key, project);
+					saved = duplicate.saved;
+					return duplicate.row;
 				}
-				deduped = true;
-				saved = racedDuplicate.saved;
-				return racedDuplicate.row;
-			}
-			linkAggregateSources(db, id, sourceMemoryIds, agentId, now);
-			linkAggregateQueryHint(db, id, agentId, params.query, now);
-			saved = true;
-			return loadAggregateMemory(db, id);
-		});
+				const id = deps.idFactory?.() ?? randomUUID();
+				const envelope: IngestEnvelope = {
+					id,
+					content: normalized.storageContent,
+					normalizedContent: normalized.normalizedContent || normalized.hashBasis,
+					contentHash: normalized.contentHash,
+					who: "signet",
+					why: "aggregate recall",
+					project,
+					importance: 0.75,
+					type: "semantic",
+					tags: "aggregate,recall",
+					pinned: 0,
+					isDeleted: 0,
+					extractionStatus: "none",
+					embeddingModel: null,
+					extractionModel: null,
+					updatedBy: "signet",
+					sourceType: "aggregate-recall",
+					sourceId: key,
+					idempotencyKey: key,
+					scope: null,
+					agentId,
+					visibility: "global",
+					createdAt: now,
+				};
+				try {
+					ingestEnvelope(db, envelope);
+				} catch (err) {
+					if (!isUniqueConstraintError(err)) throw err;
+					const racedDuplicate = resolveAggregateDuplicate(db, {
+						key,
+						agentId,
+						project,
+						query: params.query,
+						contentHash: normalized.contentHash,
+						answer,
+						sourceMemoryIds,
+						now,
+					});
+					if (!racedDuplicate) {
+						deduped = true;
+						saved = false;
+						return unsavedAggregateResult(answer, key, project);
+					}
+					deduped = true;
+					saved = racedDuplicate.saved;
+					return racedDuplicate.row;
+				}
+				linkAggregateSources(db, id, sourceMemoryIds, agentId, now);
+				linkAggregateQueryHint(db, id, agentId, params.query, now);
+				saved = true;
+				return loadAggregateMemory(db, id);
+			}),
+		);
 		if (row && !deduped) {
 			let embedded = false;
 			let embeddingError: unknown;
 			try {
-				embedded = await embedAggregateMemory(
-					row.id,
-					row.content,
-					normalized.contentHash,
-					now,
-					cfg.embedding,
-					deps.embedFn,
+				embedded = await timings.timeAsync("aggregate_embedding", () =>
+					embedAggregateMemory(row.id, row.content, normalized.contentHash, now, cfg.embedding, deps.embedFn),
 				);
 			} catch (err) {
 				embeddingError = err;
@@ -670,7 +754,7 @@ export async function aggregateRecall(
 		row = unsavedAggregateResult(answer, key, project);
 	}
 
-	return {
+	return finish({
 		results: row ? [row] : [],
 		query: params.query,
 		method: "hybrid",
@@ -689,5 +773,5 @@ export async function aggregateRecall(
 			sourceMemoryIds,
 			stoppedReason: "complete",
 		},
-	};
+	});
 }

--- a/platform/daemon/src/inference-api.test.ts
+++ b/platform/daemon/src/inference-api.test.ts
@@ -185,6 +185,53 @@ inference:
 	return { argsPath, promptPath };
 }
 
+function writeAcpxInferenceFixtureWithoutHooks(root: string): {
+	readonly promptPath: string;
+	readonly hooksPath: string;
+} {
+	mkdirSync(join(root, "memory"), { recursive: true });
+	const bin = join(root, "fake-acpx.sh");
+	const promptPath = join(root, "acpx-prompt.txt");
+	const hooksPath = join(root, "acpx-hooks.txt");
+	writeFileSync(
+		bin,
+		`#!/usr/bin/env bash
+cat > ${JSON.stringify(promptPath)}
+printf '%s' "\${SIGNET_NO_HOOKS:-}" > ${JSON.stringify(hooksPath)}
+printf 'acpx:%s\n' "$(cat ${JSON.stringify(promptPath)})"
+	`,
+	);
+	chmodSync(bin, 0o755);
+	writeFileSync(
+		join(root, "agent.yaml"),
+		`memory:
+  pipelineV2:
+    extraction:
+      provider: none
+inference:
+  defaultPolicy: background-acpx
+  targets:
+    background-acpx:
+      executor: acpx
+      acpx:
+        agent: codex
+        bin: ${bin}
+      models:
+        default:
+          model: gpt-5.4-mini
+  policies:
+    background-acpx:
+      mode: strict
+      defaultTargets:
+        - background-acpx/default
+  workloads:
+    default:
+      policy: background-acpx
+	`,
+	);
+	return { promptPath, hooksPath };
+}
+
 function writeAccountFallbackRoutingFixture(
 	root: string,
 	endpoints: {
@@ -781,6 +828,25 @@ describe("inference route hardening", () => {
 			expect(args).toContain("--deny-all");
 			expect(args).toContain("--no-terminal");
 			expect(args.slice(-4)).toEqual(["codex", "exec", "--file", "-"]);
+		} finally {
+			resetInferenceRouterForTests();
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("can force ACPX hooks off for sterile background router calls", async () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-inference-acpx-hooks-"));
+		const fixture = writeAcpxInferenceFixtureWithoutHooks(root);
+		try {
+			const router = getOrCreateInferenceRouter(root);
+			const result = await router.execute({ operation: "tool_planning" }, "sterile aggregate prompt", {
+				acpxHooks: "disabled",
+			});
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.text).toBe("acpx:sterile aggregate prompt");
+			expect(readFileSync(fixture.promptPath, "utf-8")).toBe("sterile aggregate prompt");
+			expect(readFileSync(fixture.hooksPath, "utf-8")).toBe("1");
 		} finally {
 			resetInferenceRouterForTests();
 			rmSync(root, { recursive: true, force: true });

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -23,6 +23,7 @@ import {
 import { logger } from "./logger";
 import { loadMemoryConfig } from "./memory-config";
 import {
+	type AcpxHooksMode,
 	type LlmProviderStreamEvent,
 	type LlmProviderStreamResult,
 	type StreamCapableLlmProvider,
@@ -496,8 +497,9 @@ export class InferenceRouter {
 		loaded: LoadedRoutingConfig,
 		targetId: string,
 		modelId: string,
+		acpxHooks?: AcpxHooksMode,
 	): Promise<StreamCapableLlmProvider> {
-		const cacheKey = `${loaded.signature}:${targetId}/${modelId}`;
+		const cacheKey = `${loaded.signature}:${targetId}/${modelId}:${acpxHooks ?? "configured-hooks"}`;
 		const cached = this.providerCache.get(cacheKey);
 		if (cached) return cached;
 
@@ -514,6 +516,7 @@ export class InferenceRouter {
 					if (!target.acpx) throw new Error(`Missing ACPX config for target ${targetId}`);
 					return createAcpxProvider({
 						...target.acpx,
+						...(acpxHooks ? { hooks: acpxHooks } : {}),
 						model: model.model,
 					});
 				case "anthropic":
@@ -697,7 +700,12 @@ export class InferenceRouter {
 	async execute(
 		request: RouteRequest,
 		prompt: string,
-		opts?: { readonly timeoutMs?: number; readonly maxTokens?: number; readonly refresh?: boolean },
+		opts?: {
+			readonly timeoutMs?: number;
+			readonly maxTokens?: number;
+			readonly refresh?: boolean;
+			readonly acpxHooks?: AcpxHooksMode;
+		},
 	): Promise<RouterResult<InferenceExecutionResult>> {
 		const loaded = await this.loadConfig();
 		if (!loaded.ok) return loaded;
@@ -727,7 +735,12 @@ export class InferenceRouter {
 				continue;
 			}
 			try {
-				const provider = await this.createProvider(loaded.value, parsed.value.targetId, parsed.value.modelId);
+				const provider = await this.createProvider(
+					loaded.value,
+					parsed.value.targetId,
+					parsed.value.modelId,
+					opts?.acpxHooks,
+				);
 				const result = await generateWithTracking(provider, prompt, {
 					timeoutMs: opts?.timeoutMs,
 					maxTokens: opts?.maxTokens,


### PR DESCRIPTION
## Summary
- Add aggregate recall stage timings to response metadata and slow-call logs.
- Run planned follow-up recall queries concurrently after the planner returns them.
- Force aggregate recall planning/synthesis router calls to spawn ACPX with hooks disabled, avoiding recursive Signet lifecycle hook overhead.

## Changes
- `platform/daemon/src/aggregate-recall.ts`: aggregate timing collector, parallel follow-up recalls, sterile ACPX router option for aggregate router calls.
- `platform/daemon/src/inference-router.ts`: optional `acpxHooks` execute override with provider-cache separation.
- Tests cover timings, concurrent follow-ups, aggregate hook suppression, and router-level ACPX hook override.

## Type
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [x] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected
- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots
N/A, no UI changes.

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)
N/A, no migrations touched.

- [ ] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Rollback: revert this PR to return aggregate recall to sequential follow-up recalls and configured ACPX hook behavior.

## Testing
- [ ] `bun test` passes
- [x] `bun test platform/daemon/src/aggregate-recall.test.ts`
- [x] `bun test platform/daemon/src/inference-api.test.ts`
- [x] `bun run typecheck` passes
- [x] `bunx biome check platform/daemon/src/aggregate-recall.ts platform/daemon/src/aggregate-recall.test.ts platform/daemon/src/inference-router.ts platform/daemon/src/inference-api.test.ts`
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure
- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes
No API/schema/status docs were changed: the existing aggregate response already exposes `meta.timings`, and this PR fills it with aggregate stages instead of zeroes. No admin or mutation endpoint behavior changed.