### PR TITLE
fix(sdk): expose recall timing metadata

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1288,6 +1288,14 @@ to return repeats; repeated rows are annotated with
     "totalReturned": 1,
     "hasSupplementary": false,
     "noHits": false,
+    "timings": {
+      "totalMs": 14.25,
+      "stages": [
+        { "name": "memory_fts", "durationMs": 1.12 },
+        { "name": "query_embedding_wait", "durationMs": 8.4 },
+        { "name": "final_rank", "durationMs": 0.08 }
+      ]
+    },
     "dedupe": {
       "enabled": true,
       "contextEpoch": 0,
@@ -1308,6 +1316,10 @@ this call.
 is `true` when the response includes supporting context such as an LLM summary
 card or linked rationale context. `meta.noHits` is `true` when recall completed
 normally but found no matching results.
+`meta.timings`, when present, reports daemon-side stage timings in
+milliseconds. Aggregate recall fills the same field with aggregate-specific
+stages such as `aggregate_planning`, `aggregate_followup_recalls`, and
+`aggregate_synthesis`.
 When session dedupe is enabled, `meta.dedupe.suppressed` counts rows omitted
 because they were already recalled in the current epoch, and
 `meta.dedupe.repeatedReturned` counts repeated rows returned only because the

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -95,6 +95,7 @@ const { results, query, method, meta } = await signet.recall("language preferenc
   limit: 10,
   expand: true,
 });
+// meta.timings?.stages — daemon-side recall stages and durations
 ```
 
 You can refine further when needed:
@@ -115,11 +116,25 @@ const result = await signet.recall("language preferences", {
 // result.query — normalized query used by the daemon
 // result.method — "hybrid" | "keyword"
 // result.meta.totalReturned — result count after client-side minScore filtering
+// result.meta.timings — present when the daemon returns recall stage timings
 ```
 
 `minScore` is applied client-side by the SDK after the daemon returns recall
 results. This keeps the API contract honest while preserving compatibility for
 existing SDK callers that already rely on score thresholding.
+
+Explicit aggregate recall is available through the same method:
+
+```typescript
+const aggregate = await signet.recall("what did we decide about onboarding?", {
+  aggregate: true,
+  aggregateBudget: "small",
+  saveAggregate: false,
+});
+// aggregate.results[0] — synthesized aggregate row when evidence exists
+// aggregate.aggregate?.queries — recall queries used during aggregation
+// aggregate.meta.timings?.stages — aggregate planning/synthesis timings
+```
 
 **`getMemory(id)`** — Fetch a single memory record by ID.
 

--- a/libs/sdk/src/__tests__/client.test.ts
+++ b/libs/sdk/src/__tests__/client.test.ts
@@ -148,6 +148,10 @@ describe("SignetClient", () => {
 						totalReturned: 2,
 						hasSupplementary: true,
 						noHits: false,
+						timings: {
+							totalMs: 12.5,
+							stages: [{ name: "memory_fts", durationMs: 1.25 }],
+						},
 						dedupe: {
 							enabled: true,
 							contextEpoch: 2,
@@ -194,6 +198,10 @@ describe("SignetClient", () => {
 			totalReturned: 1,
 			hasSupplementary: true,
 			noHits: false,
+			timings: {
+				totalMs: 12.5,
+				stages: [{ name: "memory_fts", durationMs: 1.25 }],
+			},
 			dedupe: {
 				enabled: true,
 				contextEpoch: 2,

--- a/libs/sdk/src/types.ts
+++ b/libs/sdk/src/types.ts
@@ -54,6 +54,10 @@ export interface RecallMeta {
 	readonly totalReturned: number;
 	readonly hasSupplementary: boolean;
 	readonly noHits: boolean;
+	readonly timings?: {
+		readonly totalMs: number;
+		readonly stages: readonly { readonly name: string; readonly durationMs: number }[];
+	};
 	readonly dedupe?: {
 		readonly enabled: boolean;
 		readonly contextEpoch?: number;


### PR DESCRIPTION
## Summary
- document recall `meta.timings` in the API recall response shape
- add SDK docs for explicit aggregate recall and timing stages
- expose optional `RecallMeta.timings` in the exported SDK type

## Changes
- `docs/API.md`: recall response example and field notes now include stage timings.
- `docs/SDK.md`: `recall()` examples now mention timing metadata and aggregate recall options.
- `libs/sdk/src/types.ts`: `RecallMeta` includes optional timing metadata.
- `libs/sdk/src/__tests__/client.test.ts`: regression coverage that timing metadata is preserved.

## Type
- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected
- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [x] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: docs

## Screenshots
N/A, no UI changes.

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)
N/A, no migrations touched.

- [ ] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Rollback: revert this PR to remove the SDK timing type addition and docs clarification.

## Testing
- [ ] `bun test` passes
- [x] `bun test libs/sdk/src/__tests__/client.test.ts`
- [x] `bun run typecheck` passes
- [x] `bunx biome check libs/sdk/src/types.ts libs/sdk/src/__tests__/client.test.ts`
- [ ] Tested against running daemon
- [ ] N/A

## AI disclosure
- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes
The aggregate recall feature was already documented in API, MCP, memory-skill, and SDK prose. This PR closes the remaining drift for `meta.timings`, which became visible while dogfooding aggregate recall performance.
