### PR TITLE
docs: add README for all 9 integration connectors

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -1,0 +1,44 @@
+# Claude Code Integration
+
+Signet connector for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (Anthropic CLI).
+
+## What It Does
+
+Integrates Signet's memory system with Claude Code's lifecycle hooks so your agent retains context across sessions.
+
+- Registers hook scripts in `~/.claude/settings.json` for `SessionStart`, `UserPromptSubmit`, `PreCompact`, and `SessionEnd` events
+- Registers the Signet MCP server in `~/.claude.json` for tool-based memory access
+- Generates `AGENTS.md` identity files from your agent workspace
+
+## Installation
+
+```bash
+signet install claude-code
+```
+
+This is handled automatically when you run `signet install` and Claude Code is detected.
+
+## Uninstallation
+
+```bash
+signet uninstall claude-code
+```
+
+Removes hooks and MCP server registration. Your memories are preserved in the Signet daemon.
+
+## Package
+
+| Field | Value |
+|-------|-------|
+| Package | `@signet/connector-claude-code` |
+| License | Apache-2.0 |
+
+## Architecture
+
+```
+~/.claude/settings.json    <-- hooks registered here
+~/.claude.json             <-- MCP server registered here
+~/.agents/                 <-- agent workspace (identity, skills, memories)
+```
+
+The connector extends `BaseConnector` from `@signet/connector-base` and implements `install()` / `uninstall()` for reversible setup.

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -1,0 +1,45 @@
+# Codex CLI Integration
+
+Signet connector for [Codex CLI](https://github.com/openai/codex).
+
+## What It Does
+
+Integrates Signet's memory system with Codex CLI's hook and MCP configuration.
+
+- Registers JSON hooks at `~/.codex/hooks.json` for `SessionStart`, `UserPromptSubmit`, and `SessionEnd` events
+- Registers the Signet MCP server in `~/.codex/config.toml`
+- Configurable timeout grace periods (5 s for SessionStart, 2 s for UserPromptSubmit)
+- Supports remote daemon URL via `SIGNET_DAEMON_URL` environment variable
+
+## Installation
+
+```bash
+signet install codex
+```
+
+This is handled automatically when you run `signet install` and Codex CLI is detected.
+
+## Uninstallation
+
+```bash
+signet uninstall codex
+```
+
+Removes hooks and MCP server registration. Your memories are preserved in the Signet daemon.
+
+## Package
+
+| Field | Value |
+|-------|-------|
+| Package | `@signet/connector-codex` |
+| License | Apache-2.0 |
+
+## Architecture
+
+```
+~/.codex/hooks.json        <-- hooks registered here
+~/.codex/config.toml       <-- MCP server registered here
+~/.agents/                 <-- agent workspace (identity, skills, memories)
+```
+
+The connector extends `BaseConnector` from `@signet/connector-base` and implements `install()` / `uninstall()` for reversible setup.

--- a/integrations/forge/README.md
+++ b/integrations/forge/README.md
@@ -1,0 +1,44 @@
+# ForgeCode Integration
+
+Signet connector for [ForgeCode](https://forgecode.dev).
+
+## What It Does
+
+Integrates Signet's memory system with ForgeCode's configuration and hook system.
+
+- Registers the Signet MCP server in ForgeCode's MCP configuration
+- Symlinks the agent skills directory into the ForgeCode workspace
+- Generates `AGENTS.md` identity files from your agent workspace
+- Manages marker-tagged configuration entries for clean install/uninstall
+
+## Installation
+
+```bash
+signet install forge
+```
+
+This is handled automatically when you run `signet install` and ForgeCode is detected.
+
+## Uninstallation
+
+```bash
+signet uninstall forge
+```
+
+Removes configuration entries and symlinks. Your memories are preserved in the Signet daemon.
+
+## Package
+
+| Field | Value |
+|-------|-------|
+| Package | `@signet/connector-forge` |
+| License | Apache-2.0 |
+
+## Architecture
+
+```
+~/.forge/mcp.json          <-- MCP server registered here
+~/.agents/                 <-- agent workspace (identity, skills, memories)
+```
+
+The connector extends `BaseConnector` from `@signet/connector-base` and implements `install()` / `uninstall()` for reversible setup.

--- a/integrations/gemini/README.md
+++ b/integrations/gemini/README.md
@@ -1,0 +1,44 @@
+# Gemini CLI Integration
+
+Signet connector for [Gemini CLI](https://github.com/google-gemini/gemini-cli).
+
+## What It Does
+
+Integrates Signet's memory system with Gemini CLI's settings and extension model.
+
+- Patches Gemini CLI settings to register the Signet MCP server
+- Symlinks the agent skills directory into the Gemini workspace
+- Generates `AGENTS.md` identity files from your agent workspace
+- Validates workspace path boundaries to prevent misconfiguration
+
+## Installation
+
+```bash
+signet install gemini
+```
+
+This is handled automatically when you run `signet install` and Gemini CLI is detected.
+
+## Uninstallation
+
+```bash
+signet uninstall gemini
+```
+
+Removes settings patches and symlinks. Your memories are preserved in the Signet daemon.
+
+## Package
+
+| Field | Value |
+|-------|-------|
+| Package | `@signet/connector-gemini` |
+| License | Apache-2.0 |
+
+## Architecture
+
+```
+~/.gemini/settings.json    <-- MCP server registered here
+~/.agents/                 <-- agent workspace (identity, skills, memories)
+```
+
+The connector extends `BaseConnector` from `@signet/connector-base` and implements `install()` / `uninstall()` for reversible setup.

--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -1,0 +1,45 @@
+# Hermes Agent Integration
+
+Signet connector for [Hermes Agent](https://github.com/hermes-ai/hermes-agent) -- installs Signet as a pluggable memory provider.
+
+## What It Does
+
+Integrates Signet's memory system into Hermes Agent as a native plugin.
+
+- Installs the Signet memory plugin into the Hermes plugin directory
+- Registers memory tools: `memory_search`, `memory_store`, `memory_get`, `memory_list`, `memory_modify`, `memory_forget`, `session_search`, `recall`, and `remember`
+- Backs up existing provider configuration for safe uninstallation
+- Uses content hashing to detect when the plugin needs updating
+
+## Installation
+
+```bash
+signet install hermes-agent
+```
+
+This is handled automatically when you run `signet install` and Hermes Agent is detected.
+
+## Uninstallation
+
+```bash
+signet uninstall hermes-agent
+```
+
+Restores the previous memory provider configuration. Your memories are preserved in the Signet daemon.
+
+## Package
+
+| Field | Value |
+|-------|-------|
+| Package | `@signet/connector-hermes-agent` |
+| License | Apache-2.0 |
+
+## Architecture
+
+```
+<hermes-home>/plugins/signet/   <-- plugin files installed here
+<hermes-home>/signet.install.json <-- install marker with metadata
+~/.agents/                       <-- agent workspace (identity, skills, memories)
+```
+
+The connector extends `BaseConnector` from `@signet/connector-base` and ships a bundled Python plugin (`__init__.py`, `client.py`, `plugin.yaml`).

--- a/integrations/oh-my-pi/README.md
+++ b/integrations/oh-my-pi/README.md
@@ -1,0 +1,45 @@
+# Oh My Pi Integration
+
+Signet connector for Oh My Pi.
+
+## What It Does
+
+Integrates Signet's memory system with Oh My Pi via its extension mechanism.
+
+- Installs a managed Signet extension into the Oh My Pi extensions directory
+- Configures the agent workspace path in Oh My Pi's config
+- Handles migration from legacy `.mjs` extension format to current `.js` format
+- Detects and resolves multiple candidate agent directories
+
+## Installation
+
+```bash
+signet install oh-my-pi
+```
+
+This is handled automatically when you run `signet install` and Oh My Pi is detected.
+
+## Uninstallation
+
+```bash
+signet uninstall oh-my-pi
+```
+
+Removes the extension file and clears workspace configuration. Your memories are preserved in the Signet daemon.
+
+## Package
+
+| Field | Value |
+|-------|-------|
+| Package | `@signet/connector-oh-my-pi` |
+| License | Apache-2.0 |
+
+## Architecture
+
+```
+<oh-my-pi-extensions>/signet-oh-my-pi.js  <-- managed extension
+<oh-my-pi-config>/config.json             <-- agent dir configured here
+~/.agents/                                <-- agent workspace
+```
+
+The connector extends `BaseConnector` from `@signet/connector-base` and ships a bundled extension that is written to disk on install.

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -1,0 +1,48 @@
+# OpenClaw Integration
+
+Signet connector for [OpenClaw](https://github.com/openclaw/openclaw) (and its earlier names: clawdbot, moltbot).
+
+## What It Does
+
+Integrates Signet's memory system with OpenClaw's hook and workspace configuration.
+
+- Patches OpenClaw config to set `agents.defaults.workspace` to `~/.agents`
+- Enables the `signet-memory` internal hook entry
+- Installs hook handler files for `/remember`, `/recall`, and `/context` commands
+- Supports JSON5 configuration parsing (OpenClaw uses `.json5` / JSONC config files)
+
+Unlike other connectors, OpenClaw reads `~/.agents/AGENTS.md` directly, so no generated output file is needed.
+
+## Installation
+
+```bash
+signet install openclaw
+```
+
+This is handled automatically when you run `signet install` and OpenClaw is detected.
+
+## Uninstallation
+
+```bash
+signet uninstall openclaw
+```
+
+Removes hook handlers and configuration patches. Your memories are preserved in the Signet daemon.
+
+## Package
+
+| Field | Value |
+|-------|-------|
+| Package | `@signet/connector-openclaw` |
+| License | Apache-2.0 |
+| Extra dependency | `json5` (for JSONC config parsing) |
+
+## Architecture
+
+```
+<openclaw-config>/config.json5  <-- workspace + hook config patched here
+<openclaw-hooks>/                <-- hook handler files installed here
+~/.agents/AGENTS.md             <-- read directly by OpenClaw
+```
+
+The connector extends `BaseConnector` from `@signet/connector-base` and implements deep-merge config patching with `json5` for JSONC support.

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -1,0 +1,48 @@
+# OpenCode Integration
+
+Signet connector for [OpenCode](https://github.com/opencode-ai/opencode).
+
+## What It Does
+
+Integrates Signet's memory system with OpenCode via its plugin system.
+
+- Bundles and writes `signet.mjs` plugin to `~/.config/opencode/plugins/`
+- Generates `AGENTS.md` from identity files in your agent workspace
+- Registers the plugin in OpenCode's configuration (`opencode.json` / `opencode.jsonc` / `config.json`)
+- Symlinks the skills directory for tool access
+- Migrates away from the legacy `memory.mjs` approach on install/uninstall
+- Supports JSONC configuration files (strips comments before parsing)
+
+## Installation
+
+```bash
+signet install opencode
+```
+
+This is handled automatically when you run `signet install` and OpenCode is detected.
+
+## Uninstallation
+
+```bash
+signet uninstall opencode
+```
+
+Removes the plugin file and configuration entries. Your memories are preserved in the Signet daemon.
+
+## Package
+
+| Field | Value |
+|-------|-------|
+| Package | `@signet/connector-opencode` |
+| License | Apache-2.0 |
+
+## Architecture
+
+```
+~/.config/opencode/plugins/signet.mjs  <-- bundled plugin
+~/.config/opencode/opencode.json       <-- plugin registered here
+~/.config/opencode/AGENTS.md           <-- generated identity file
+~/.agents/                             <-- agent workspace
+```
+
+The connector extends `BaseConnector` from `@signet/connector-base` and ships a self-contained plugin bundle that OpenCode auto-discovers from its plugins directory.

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -1,0 +1,45 @@
+# Pi Integration
+
+Signet connector for Pi.
+
+## What It Does
+
+Integrates Signet's memory system with Pi via its extension mechanism.
+
+- Installs a managed Signet extension into the Pi extensions directory
+- Configures the agent workspace path in Pi's config
+- Detects and resolves multiple candidate agent directories
+- Ships a bundled extension that is written to disk on install
+
+## Installation
+
+```bash
+signet install pi
+```
+
+This is handled automatically when you run `signet install` and Pi is detected.
+
+## Uninstallation
+
+```bash
+signet uninstall pi
+```
+
+Removes the extension file and clears workspace configuration. Your memories are preserved in the Signet daemon.
+
+## Package
+
+| Field | Value |
+|-------|-------|
+| Package | `@signet/connector-pi` |
+| License | Apache-2.0 |
+
+## Architecture
+
+```
+<pi-extensions>/signet-pi.js   <-- managed extension
+<pi-config>/config.json        <-- agent dir configured here
+~/.agents/                     <-- agent workspace
+```
+
+The connector extends `BaseConnector` from `@signet/connector-base` and implements `install()` / `uninstall()` for reversible setup.


### PR DESCRIPTION
﻿## Summary

- Add a README.md to each of the 9 integration directories: `claude-code`, `codex`, `forge`, `gemini`, `hermes-agent`, `oh-my-pi`, `openclaw`, `opencode`, and `pi`
- Each README documents what the connector does, install/uninstall commands, package metadata, and an architecture diagram of config file locations
- Written by reading each connector's source code to ensure accuracy

## Motivation

New contributors exploring the `integrations/` directory have no documentation explaining what each connector does or how it integrates with its target harness. These READMEs lower the barrier to understanding and contributing to individual connectors.

## Test Plan

- [ ] Verify README content matches actual connector behavior
- [ ] Confirm no existing files were modified
