### PR TITLE
fix(core): throw on unimplemented migration sources instead of silently no-oping

### DIFF
--- a/platform/core/src/migrate.ts
+++ b/platform/core/src/migrate.ts
@@ -24,18 +24,27 @@ export async function migrate(options: MigrationOptions): Promise<void> {
 	}
 }
 
-async function migrateChatGPT(inputPath: string): Promise<void> {
+async function migrateChatGPT(_inputPath: string): Promise<void> {
 	// TODO: Parse ChatGPT export (conversations.json)
 	// Extract: user preferences, facts mentioned, project context
-	console.log(`Migrating from ChatGPT export: ${inputPath}`);
+	throw new Error(
+		"ChatGPT migration is not yet implemented. " +
+			"See https://github.com/Signet-AI/signetai/issues for tracking.",
+	);
 }
 
-async function migrateClaude(inputPath: string): Promise<void> {
+async function migrateClaude(_inputPath: string): Promise<void> {
 	// TODO: Parse Claude.ai export
-	console.log(`Migrating from Claude.ai export: ${inputPath}`);
+	throw new Error(
+		"Claude.ai migration is not yet implemented. " +
+			"See https://github.com/Signet-AI/signetai/issues for tracking.",
+	);
 }
 
-async function migrateGemini(inputPath: string): Promise<void> {
+async function migrateGemini(_inputPath: string): Promise<void> {
 	// TODO: Parse Gemini export
-	console.log(`Migrating from Gemini export: ${inputPath}`);
+	throw new Error(
+		"Gemini migration is not yet implemented. " +
+			"See https://github.com/Signet-AI/signetai/issues for tracking.",
+	);
 }


### PR DESCRIPTION
﻿## Summary

- Replace silent `console.log` stubs in `migrateChatGPT()`, `migrateClaude()`, and `migrateGemini()` with explicit `throw new Error()` calls
- Prefix unused `inputPath` parameters with underscore to satisfy linters
- Callers of `migrate()` now get a clear error instead of a successful no-op when using an unimplemented source

## Motivation

The current stubs in `platform/core/src/migrate.ts` log a message and return successfully, which means callers have no way to distinguish between a successful migration and one that did nothing. This can mask issues in tooling that depends on `migrate()`.

## Test Plan

- [ ] Calling `migrate({ source: 'chatgpt', inputPath: '...' })` now throws with a descriptive error
- [ ] Same for `claude` and `gemini` sources
- [ ] The `default` case in the switch still throws for unknown sources
