### PR TITLE
fix(inference): route direct API pipeline providers

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -163,7 +163,7 @@ Options:
 | `--identity-preset <preset>` | Identity/context preset (`minimal`, `hermes`, `openclaw`, `custom`); controls startup-loaded files and special prompt files like `DREAMING.md` |
 | `--embedding-provider <provider>` | Non-interactive embedding provider (`ollama`, `openai`, `native`, `none`) |
 | `--embedding-model <model>` | Non-interactive embedding model |
-| `--extraction-provider <provider>` | Non-interactive extraction provider (`claude-code`, `codex`, `ollama`, `opencode`, `openrouter`, `none`) |
+| `--extraction-provider <provider>` | Non-interactive extraction provider (`claude-code`, `codex`, `ollama`, `opencode`, `openrouter`, `openai-compatible`, `none`) |
 | `--extraction-model <model>` | Non-interactive extraction model |
 | `--search-balance <alpha>` | Non-interactive search alpha (`0-1`) |
 | `--openclaw-runtime-path <mode>` | Non-interactive OpenClaw mode (`plugin`, `legacy`) |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -165,6 +165,7 @@ Options:
 | `--embedding-model <model>` | Non-interactive embedding model |
 | `--extraction-provider <provider>` | Non-interactive extraction provider (`claude-code`, `codex`, `ollama`, `opencode`, `openrouter`, `openai-compatible`, `none`) |
 | `--extraction-model <model>` | Non-interactive extraction model |
+| `--extraction-endpoint <url>` | Non-interactive extraction endpoint for OpenAI-compatible providers |
 | `--search-balance <alpha>` | Non-interactive search alpha (`0-1`) |
 | `--openclaw-runtime-path <mode>` | Non-interactive OpenClaw mode (`plugin`, `legacy`) |
 | `--configure-openclaw-workspace` | Patch discovered OpenClaw configs to `$SIGNET_WORKSPACE` |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -632,7 +632,7 @@ Controls the LLM-based extraction stage. Supports multiple providers.
 
 | Field | Default | Range | Description |
 |-------|---------|-------|-------------|
-| `provider` | `"llama-cpp"` | — | `"none"`, `"acpx"`, `"llama-cpp"`, `"ollama"`, `"claude-code"`, `"opencode"`, `"codex"`, `"anthropic"`, `"openrouter"`, or `"command"` |
+| `provider` | `"llama-cpp"` | — | `"none"`, `"acpx"`, `"llama-cpp"`, `"ollama"`, `"claude-code"`, `"opencode"`, `"codex"`, `"anthropic"`, `"openrouter"`, `"openai-compatible"`, or `"command"` |
 | `model` | `"qwen3:4b"` | — | Model name for the configured provider |
 | `timeout` | `90000` | 5000-300000 ms | Extraction call timeout |
 | `minConfidence` | `0.7` | 0.0-1.0 | Confidence threshold; facts below this are dropped |
@@ -641,6 +641,12 @@ Controls the LLM-based extraction stage. Supports multiple providers.
 | `rateLimit.maxCallsPerHour` | `200` when `rateLimit` is set | 0-10000 | Max extraction-provider calls per hour; set `0` to disable rate limiting |
 | `rateLimit.burstSize` | `20` when `rateLimit` is set | 1-1000 | Max burst size before throttling begins |
 | `rateLimit.waitTimeoutMs` | `5000` when `rateLimit` is set | 0-60000 ms | How long to wait for a token before failing with `RateLimitExceededError` |
+
+For `provider: openai-compatible`, set `endpoint` to the gateway's
+OpenAI-compatible `/v1` base URL. Remote endpoints use `OPENAI_API_KEY` by
+default when this legacy pipeline config is compiled into inference routing;
+explicit top-level `inference.accounts.*.credentialRef` can point at any
+stored secret or environment variable.
 
 For safety, the intended extraction setups are:
 
@@ -655,13 +661,13 @@ calls.
 
 Remote API extraction can accumulate extreme fees quickly because the
 pipeline runs continuously in the background. Use `anthropic`,
-`openrouter`, or remote OpenCode routes only when you explicitly want
+`openrouter`, `openai-compatible`, or remote OpenCode routes only when you explicitly want
 that billing behavior.
 
 `rateLimit` is opt-in. If the stanza is omitted, Signet preserves the
 provider's existing behavior with no throughput throttling. When
 configured, it applies only to remote or paid providers
-(`acpx`, `claude-code`, `anthropic`, `openrouter`, `codex`, `opencode`).
+(`acpx`, `claude-code`, `anthropic`, `openrouter`, `openai-compatible`, `codex`, `opencode`).
 Ollama and `command` providers are always exempt. If you set `rateLimit`
 on an exempt provider, Signet logs a warning and passes calls through
 unthrottled.
@@ -758,9 +764,9 @@ handles synthesis.
 | Field | Default | Range | Description |
 |-------|---------|-------|-------------|
 | `enabled` | `true` | — | Enable background session summary generation |
-| `provider` | inherited from extraction when omitted | — | `"none"`, `"llama-cpp"`, `"ollama"`, `"claude-code"`, `"codex"`, `"opencode"`, `"anthropic"`, or `"openrouter"` |
+| `provider` | inherited from extraction when omitted | — | `"none"`, `"llama-cpp"`, `"ollama"`, `"claude-code"`, `"codex"`, `"opencode"`, `"anthropic"`, `"openrouter"`, or `"openai-compatible"` |
 | `model` | inherited from extraction when omitted | — | Model name for the configured provider |
-| `endpoint` | inherited from extraction when omitted | — | Optional base URL override for Ollama, OpenCode, or OpenRouter |
+| `endpoint` | inherited from extraction when omitted | — | Optional base URL override for Ollama, OpenCode, OpenRouter, or OpenAI-compatible gateways |
 | `timeout` | inherited from extraction when omitted | 5000-300000 ms | Summary generation timeout |
 | `structuredOutput` | inherited from extraction when omitted | — | Send JSON schema in the `format` field of LLM requests. Set `false` when the synthesis provider rejects structured output (e.g. GitHub Copilot API). Falls back to `extraction.structuredOutput` when omitted. |
 | `rateLimit.maxCallsPerHour` | `200` when `rateLimit` is set | 0-10000 | Max synthesis-provider calls per hour; set `0` to disable rate limiting |

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -1043,11 +1043,11 @@ Extraction safety note:
 - set `provider: none` on a VPS if you do not want background
   extraction
 - remote API extraction can accumulate extreme fees quickly
-  (`anthropic`, `openrouter`, or remote OpenCode routes)
+  (`anthropic`, `openrouter`, `openai-compatible`, or remote OpenCode routes)
 
 ```yaml
 extraction:
-  provider: llama-cpp            # "none" | "llama-cpp" | "ollama" | "claude-code" | "codex" | "opencode" | "anthropic" | "openrouter" | "command"
+  provider: llama-cpp            # "none" | "llama-cpp" | "ollama" | "claude-code" | "codex" | "opencode" | "anthropic" | "openrouter" | "openai-compatible" | "command"
   model: qwen3:4b
   timeout: 90000                 # ms, range 5000–300000
   minConfidence: 0.7             # fraction 0.0–1.0
@@ -1061,7 +1061,7 @@ extraction:
 
 synthesis:
   enabled: true
-  provider: ollama               # "none" | "llama-cpp" | "ollama" | "claude-code" | "codex" | "opencode" | "anthropic" | "openrouter"
+  provider: ollama               # "none" | "llama-cpp" | "ollama" | "claude-code" | "codex" | "opencode" | "anthropic" | "openrouter" | "openai-compatible"
   model: qwen3:4b
   timeout: 120000                # ms, range 5000–300000
   # when omitted entirely, synthesis falls back to extraction provider/model

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -386,6 +386,7 @@ export {
 	ROUTING_OPERATION_KINDS,
 	makeRoutingTargetRef,
 	parseRoutingTargetRef,
+	isLocalInferenceEndpoint,
 	compileLegacyRoutingConfig,
 	parseRoutingConfig,
 	allTargetRefs,

--- a/platform/core/src/llm-model-catalog.ts
+++ b/platform/core/src/llm-model-catalog.ts
@@ -15,6 +15,7 @@ export type ModelCatalogProvider =
 	| "opencode"
 	| "anthropic"
 	| "openrouter"
+	| "openai-compatible"
 	| "command";
 
 export const PIPELINE_MODEL_CATALOG = {
@@ -61,6 +62,11 @@ export const PIPELINE_MODEL_CATALOG = {
 		{ value: "anthropic/claude-3.5-haiku", label: "anthropic/claude-3.5-haiku", tier: "low", source: "provider" },
 		{ value: "google/gemini-2.5-flash", label: "google/gemini-2.5-flash", tier: "low", source: "provider" },
 	],
+	"openai-compatible": [
+		{ value: "gpt-4o-mini", label: "gpt-4o-mini", tier: "low", source: "provider" },
+		{ value: "gpt-4.1-mini", label: "gpt-4.1-mini", tier: "low", source: "provider" },
+		{ value: "local-model", label: "local-model", tier: "low", source: "provider" },
+	],
 } as const satisfies Record<ModelCatalogProvider, readonly PipelineModelPreset[]>;
 
 export const MODEL_DEFAULTS = {
@@ -73,6 +79,7 @@ export const MODEL_DEFAULTS = {
 	opencode: "google/gemini-2.5-flash",
 	anthropic: "claude-3-5-haiku-20241022",
 	openrouter: "openai/gpt-4o-mini",
+	"openai-compatible": "gpt-4o-mini",
 	command: "",
 } as const satisfies Record<ModelCatalogProvider, string>;
 

--- a/platform/core/src/pipeline-providers.ts
+++ b/platform/core/src/pipeline-providers.ts
@@ -15,6 +15,7 @@ export const PIPELINE_PROVIDER_CHOICES = [
 	"opencode",
 	"anthropic",
 	"openrouter",
+	"openai-compatible",
 	"command",
 ] as const;
 

--- a/platform/core/src/routing.test.ts
+++ b/platform/core/src/routing.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
 	compileLegacyRoutingConfig,
+	isLocalInferenceEndpoint,
 	makeRoutingTargetRef,
 	parseRoutingConfig,
 	resolveRoutingDecision,
@@ -14,6 +15,14 @@ const ready = {
 } as const;
 
 describe("inference config + decision engine", () => {
+	it("classifies loopback inference endpoints as local", () => {
+		expect(isLocalInferenceEndpoint(undefined)).toBe(true);
+		expect(isLocalInferenceEndpoint("http://127.0.0.1:1234/v1")).toBe(true);
+		expect(isLocalInferenceEndpoint("http://localhost:1234/v1")).toBe(true);
+		expect(isLocalInferenceEndpoint("http://[::1]:1234/v1")).toBe(true);
+		expect(isLocalInferenceEndpoint("https://gateway.example.test/v1")).toBe(false);
+	});
+
 	it("prefers local targets for local_only task classes", () => {
 		const parsed = parseRoutingConfig({
 			inference: {
@@ -409,6 +418,25 @@ describe("inference config + decision engine", () => {
 		});
 		expect(compatible.targets["legacy-extraction"]?.executor).toBe("openai-compatible");
 		expect(compatible.targets["legacy-extraction"]?.account).toBe("legacy-openai-compatible");
+
+		const localCompatible = compileLegacyRoutingConfig({
+			extraction: {
+				provider: "openai-compatible",
+				model: "openai/gpt-oss-20b",
+				endpoint: "http://127.0.0.1:1234/v1",
+				command: undefined,
+			},
+			synthesis: {
+				enabled: false,
+				provider: "none",
+				model: "",
+				endpoint: undefined,
+			},
+		});
+		expect(localCompatible.accounts["legacy-openai-compatible"]).toBeUndefined();
+		expect(localCompatible.targets["legacy-extraction"]?.executor).toBe("openai-compatible");
+		expect(localCompatible.targets["legacy-extraction"]?.kind).toBe("local");
+		expect(localCompatible.targets["legacy-extraction"]?.account).toBeUndefined();
 	});
 
 	it("does not allow explicit target overrides outside the agent roster", () => {

--- a/platform/core/src/routing.test.ts
+++ b/platform/core/src/routing.test.ts
@@ -427,16 +427,21 @@ describe("inference config + decision engine", () => {
 				command: undefined,
 			},
 			synthesis: {
-				enabled: false,
-				provider: "none",
-				model: "",
-				endpoint: undefined,
+				enabled: true,
+				provider: "openai-compatible",
+				model: "openai/gpt-oss-20b",
+				endpoint: "http://127.0.0.1:1234/v1",
 			},
 		});
 		expect(localCompatible.accounts["legacy-openai-compatible"]).toBeUndefined();
 		expect(localCompatible.targets["legacy-extraction"]?.executor).toBe("openai-compatible");
 		expect(localCompatible.targets["legacy-extraction"]?.kind).toBe("local");
+		expect(localCompatible.targets["legacy-extraction"]?.privacy).toBe("local_only");
 		expect(localCompatible.targets["legacy-extraction"]?.account).toBeUndefined();
+		expect(localCompatible.targets["legacy-synthesis"]?.executor).toBe("openai-compatible");
+		expect(localCompatible.targets["legacy-synthesis"]?.kind).toBe("local");
+		expect(localCompatible.targets["legacy-synthesis"]?.privacy).toBe("local_only");
+		expect(localCompatible.targets["legacy-synthesis"]?.account).toBeUndefined();
 	});
 
 	it("does not allow explicit target overrides outside the agent roster", () => {

--- a/platform/core/src/routing.test.ts
+++ b/platform/core/src/routing.test.ts
@@ -359,6 +359,58 @@ describe("inference config + decision engine", () => {
 		expect(acpxLegacy.enabled).toBe(false);
 	});
 
+	it("attaches legacy API credentials to routed API-backed workloads", () => {
+		const legacy = compileLegacyRoutingConfig({
+			extraction: {
+				provider: "anthropic",
+				model: "claude-3-5-haiku-latest",
+				endpoint: undefined,
+				command: undefined,
+			},
+			synthesis: {
+				enabled: true,
+				provider: "openrouter",
+				model: "openai/gpt-4o-mini",
+				endpoint: "https://openrouter.ai/api/v1",
+			},
+		});
+
+		expect(legacy.accounts["legacy-anthropic"]).toMatchObject({
+			kind: "api",
+			providerFamily: "anthropic",
+			credentialRef: "ANTHROPIC_API_KEY",
+		});
+		expect(legacy.accounts["legacy-openrouter"]).toMatchObject({
+			kind: "api",
+			providerFamily: "openrouter",
+			credentialRef: "OPENROUTER_API_KEY",
+		});
+		expect(legacy.targets["legacy-extraction"]?.account).toBe("legacy-anthropic");
+		expect(legacy.targets["legacy-synthesis"]?.account).toBe("legacy-openrouter");
+
+		const compatible = compileLegacyRoutingConfig({
+			extraction: {
+				provider: "openai-compatible",
+				model: "gpt-4o-mini",
+				endpoint: "https://api.openai.com/v1",
+				command: undefined,
+			},
+			synthesis: {
+				enabled: false,
+				provider: "none",
+				model: "",
+				endpoint: undefined,
+			},
+		});
+		expect(compatible.accounts["legacy-openai-compatible"]).toMatchObject({
+			kind: "api",
+			providerFamily: "openai-compatible",
+			credentialRef: "OPENAI_API_KEY",
+		});
+		expect(compatible.targets["legacy-extraction"]?.executor).toBe("openai-compatible");
+		expect(compatible.targets["legacy-extraction"]?.account).toBe("legacy-openai-compatible");
+	});
+
 	it("does not allow explicit target overrides outside the agent roster", () => {
 		const parsed = parseRoutingConfig({
 			inference: {

--- a/platform/core/src/routing.ts
+++ b/platform/core/src/routing.ts
@@ -623,6 +623,7 @@ export function compileLegacyRoutingConfig(opts: {
 	readonly extraction: Pick<PipelineExtractionConfig, "provider" | "model" | "endpoint" | "command">;
 	readonly synthesis: Pick<PipelineSynthesisConfig, "enabled" | "provider" | "model" | "endpoint">;
 }): RoutingConfig {
+	const accounts: Record<string, RoutingAccountConfig> = {};
 	const targets: Record<string, RoutingTargetConfig> = {};
 	const policies: Record<string, RoutingPolicyConfig> = {};
 	const taskClasses: Record<string, RoutingTaskClassConfig> = {
@@ -649,6 +650,34 @@ export function compileLegacyRoutingConfig(opts: {
 	} = {};
 	let defaultTargets: readonly string[] = [];
 
+	const legacyAccountForProvider = (provider: RoutingExecutorKind): string | undefined => {
+		if (provider === "openrouter") {
+			accounts["legacy-openrouter"] = {
+				kind: "api",
+				providerFamily: "openrouter",
+				credentialRef: "OPENROUTER_API_KEY",
+			};
+			return "legacy-openrouter";
+		}
+		if (provider === "anthropic") {
+			accounts["legacy-anthropic"] = {
+				kind: "api",
+				providerFamily: "anthropic",
+				credentialRef: "ANTHROPIC_API_KEY",
+			};
+			return "legacy-anthropic";
+		}
+		if (provider === "openai-compatible") {
+			accounts["legacy-openai-compatible"] = {
+				kind: "api",
+				providerFamily: "openai-compatible",
+				credentialRef: "OPENAI_API_KEY",
+			};
+			return "legacy-openai-compatible";
+		}
+		return undefined;
+	};
+
 	if (
 		opts.extraction.provider !== "none" &&
 		opts.extraction.provider !== "command" &&
@@ -657,6 +686,7 @@ export function compileLegacyRoutingConfig(opts: {
 		targets["legacy-extraction"] = {
 			kind: inferTargetKind(opts.extraction.provider),
 			executor: opts.extraction.provider,
+			account: legacyAccountForProvider(opts.extraction.provider),
 			endpoint: opts.extraction.endpoint,
 			command: opts.extraction.command,
 			privacy: inferTargetPrivacy(opts.extraction.provider),
@@ -680,6 +710,7 @@ export function compileLegacyRoutingConfig(opts: {
 		targets["legacy-synthesis"] = {
 			kind: inferTargetKind(opts.synthesis.provider),
 			executor: opts.synthesis.provider,
+			account: legacyAccountForProvider(opts.synthesis.provider),
 			endpoint: opts.synthesis.endpoint,
 			privacy: inferTargetPrivacy(opts.synthesis.provider),
 			models: {
@@ -724,7 +755,7 @@ export function compileLegacyRoutingConfig(opts: {
 		source: "legacy-implicit",
 		enabled: defaultTargets.length > 0,
 		defaultPolicy: "legacy-default",
-		accounts: {},
+		accounts,
 		targets,
 		policies,
 		taskClasses,

--- a/platform/core/src/routing.ts
+++ b/platform/core/src/routing.ts
@@ -364,6 +364,11 @@ function inferTargetPrivacy(executor: string): RoutingPrivacyTier {
 	return "remote_ok";
 }
 
+function inferLegacyTargetPrivacy(executor: string, endpoint: string | undefined): RoutingPrivacyTier {
+	if (executor === "openai-compatible" && isLocalInferenceEndpoint(endpoint)) return "local_only";
+	return inferTargetPrivacy(executor);
+}
+
 function mergeUnique(base: readonly string[], extra: readonly string[]): readonly string[] {
 	const seen = new Set<string>();
 	const merged: string[] = [];
@@ -708,7 +713,7 @@ export function compileLegacyRoutingConfig(opts: {
 			account: legacyAccountForProvider(opts.extraction.provider, opts.extraction.endpoint),
 			endpoint: opts.extraction.endpoint,
 			command: opts.extraction.command,
-			privacy: inferTargetPrivacy(opts.extraction.provider),
+			privacy: inferLegacyTargetPrivacy(opts.extraction.provider, opts.extraction.endpoint),
 			models: {
 				default: {
 					model: opts.extraction.model,
@@ -731,7 +736,7 @@ export function compileLegacyRoutingConfig(opts: {
 			executor: opts.synthesis.provider,
 			account: legacyAccountForProvider(opts.synthesis.provider, opts.synthesis.endpoint),
 			endpoint: opts.synthesis.endpoint,
-			privacy: inferTargetPrivacy(opts.synthesis.provider),
+			privacy: inferLegacyTargetPrivacy(opts.synthesis.provider, opts.synthesis.endpoint),
 			models: {
 				default: {
 					model: opts.synthesis.model,

--- a/platform/core/src/routing.ts
+++ b/platform/core/src/routing.ts
@@ -257,6 +257,16 @@ function asString(value: unknown): string | undefined {
 	return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
 }
 
+export function isLocalInferenceEndpoint(endpoint: string | undefined): boolean {
+	if (!endpoint) return true;
+	try {
+		const parsed = new URL(endpoint);
+		return ["127.0.0.1", "localhost", "::1", "[::1]"].includes(parsed.hostname);
+	} catch {
+		return false;
+	}
+}
+
 function asBool(value: unknown): boolean | undefined {
 	return typeof value === "boolean" ? value : undefined;
 }
@@ -340,6 +350,11 @@ function inferTargetKind(executor: string): RoutingTargetKind {
 	}
 	if (executor === "anthropic" || executor === "openrouter") return "api";
 	return "subscription_session";
+}
+
+function inferLegacyTargetKind(executor: string, endpoint: string | undefined): RoutingTargetKind {
+	if (executor === "openai-compatible" && isLocalInferenceEndpoint(endpoint)) return "local";
+	return inferTargetKind(executor);
 }
 
 function inferTargetPrivacy(executor: string): RoutingPrivacyTier {
@@ -650,7 +665,10 @@ export function compileLegacyRoutingConfig(opts: {
 	} = {};
 	let defaultTargets: readonly string[] = [];
 
-	const legacyAccountForProvider = (provider: RoutingExecutorKind): string | undefined => {
+	const legacyAccountForProvider = (
+		provider: RoutingExecutorKind,
+		endpoint: string | undefined,
+	): string | undefined => {
 		if (provider === "openrouter") {
 			accounts["legacy-openrouter"] = {
 				kind: "api",
@@ -668,6 +686,7 @@ export function compileLegacyRoutingConfig(opts: {
 			return "legacy-anthropic";
 		}
 		if (provider === "openai-compatible") {
+			if (isLocalInferenceEndpoint(endpoint)) return undefined;
 			accounts["legacy-openai-compatible"] = {
 				kind: "api",
 				providerFamily: "openai-compatible",
@@ -684,9 +703,9 @@ export function compileLegacyRoutingConfig(opts: {
 		opts.extraction.provider !== "acpx"
 	) {
 		targets["legacy-extraction"] = {
-			kind: inferTargetKind(opts.extraction.provider),
+			kind: inferLegacyTargetKind(opts.extraction.provider, opts.extraction.endpoint),
 			executor: opts.extraction.provider,
-			account: legacyAccountForProvider(opts.extraction.provider),
+			account: legacyAccountForProvider(opts.extraction.provider, opts.extraction.endpoint),
 			endpoint: opts.extraction.endpoint,
 			command: opts.extraction.command,
 			privacy: inferTargetPrivacy(opts.extraction.provider),
@@ -708,9 +727,9 @@ export function compileLegacyRoutingConfig(opts: {
 
 	if (opts.synthesis.enabled && opts.synthesis.provider !== "none" && opts.synthesis.provider !== "acpx") {
 		targets["legacy-synthesis"] = {
-			kind: inferTargetKind(opts.synthesis.provider),
+			kind: inferLegacyTargetKind(opts.synthesis.provider, opts.synthesis.endpoint),
 			executor: opts.synthesis.provider,
-			account: legacyAccountForProvider(opts.synthesis.provider),
+			account: legacyAccountForProvider(opts.synthesis.provider, opts.synthesis.endpoint),
 			endpoint: opts.synthesis.endpoint,
 			privacy: inferTargetPrivacy(opts.synthesis.provider),
 			models: {

--- a/platform/core/src/types.ts
+++ b/platform/core/src/types.ts
@@ -218,6 +218,7 @@ export interface PipelineExtractionConfig {
 		| "codex"
 		| "anthropic"
 		| "openrouter"
+		| "openai-compatible"
 		| "command";
 	readonly fallbackProvider?: "llama-cpp" | "ollama" | "none";
 	readonly allowRemoteProviders?: boolean;
@@ -401,7 +402,8 @@ export interface PipelineSynthesisConfig {
 		| "codex"
 		| "opencode"
 		| "anthropic"
-		| "openrouter";
+		| "openrouter"
+		| "openai-compatible";
 	readonly model: string;
 	readonly endpoint?: string;
 	readonly timeout: number;

--- a/platform/daemon/src/aggregate-recall.test.ts
+++ b/platform/daemon/src/aggregate-recall.test.ts
@@ -7,9 +7,13 @@ import type { RouteRequest, RouterResult } from "@signet/core";
 import { type AggregateInferenceRouter, InvalidAggregateRecallBudgetError, aggregateRecall } from "./aggregate-recall";
 import { normalizeAndHashContent } from "./content-normalization";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { getOrCreateInferenceRouter, resetInferenceRouterForTests } from "./inference-router";
 import { loadMemoryConfig } from "./memory-config";
 import type { RecallParams, RecallResponse, RecallResult } from "./memory-search";
 import { txIngestEnvelope } from "./transactions";
+
+const originalFetch = globalThis.fetch;
+const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
 
 function row(
 	id: string,
@@ -130,6 +134,13 @@ describe("aggregateRecall", () => {
 
 	afterEach(() => {
 		closeDbAccessor();
+		globalThis.fetch = originalFetch;
+		if (originalOpenAiApiKey === undefined) {
+			delete process.env.OPENAI_API_KEY;
+		} else {
+			process.env.OPENAI_API_KEY = originalOpenAiApiKey;
+		}
+		resetInferenceRouterForTests();
 		if (prevSignetPath === undefined) {
 			Reflect.deleteProperty(process.env as Record<string, string | undefined>, "SIGNET_PATH");
 		} else {
@@ -233,6 +244,70 @@ describe("aggregateRecall", () => {
 			(db) => db.prepare("SELECT hint FROM memory_hints WHERE memory_id = ?").get("aggregate-1") as { hint: string },
 		);
 		expect(hint.hint).toBe("what happened");
+	});
+
+	it("synthesizes through a direct OpenAI-compatible API target without ACPX", async () => {
+		writeFileSync(
+			join(dir, "agent.yaml"),
+			`name: AggregateRecallTest
+memory:
+  pipelineV2:
+    extraction:
+      provider: openai-compatible
+      model: gpt-4o-mini
+      endpoint: https://gateway.example.test/v1
+    synthesis:
+      enabled: false
+`,
+		);
+		process.env.OPENAI_API_KEY = "test-openai-compatible-key";
+		let chatCalls = 0;
+		const seen: Array<{ readonly url: string; readonly authorization: string | null }> = [];
+		globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+			const url = String(input);
+			const headers = new Headers(init?.headers);
+			seen.push({ url, authorization: headers.get("authorization") });
+			if (url.endsWith("/models")) {
+				return Promise.resolve(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+			}
+			chatCalls += 1;
+			const content =
+				chatCalls === 1
+					? JSON.stringify({ queries: [] })
+					: "Aggregate recall can synthesize directly through an OpenAI-compatible API target.";
+			return Promise.resolve(new Response(JSON.stringify({ choices: [{ message: { content } }] }), { status: 200 }));
+		}) as unknown as typeof fetch;
+
+		const result = await aggregateRecall(
+			{
+				query: "can aggregate recall use direct API models",
+				aggregate: true,
+				aggregateBudget: "small",
+				saveAggregate: false,
+				agentId: "agent-a",
+				readPolicy: "isolated",
+			},
+			loadMemoryConfig(dir),
+			{
+				router: getOrCreateInferenceRouter(dir),
+				embedFn: async () => null,
+				logger: quietLogger(),
+				hybridRecall: async (params: RecallParams) =>
+					response(params.query, [row("mem-api-1", "Aggregate recall should use the unified LLM provider.")]),
+			},
+		);
+
+		expect(result.aggregate?.stoppedReason).toBe("complete");
+		expect(result.results[0]?.content).toBe(
+			"Aggregate recall can synthesize directly through an OpenAI-compatible API target.",
+		);
+		expect(chatCalls).toBe(2);
+		expect(seen.every((entry) => entry.authorization === "Bearer test-openai-compatible-key")).toBe(true);
+		expect(seen.map((entry) => entry.url)).toEqual([
+			"https://gateway.example.test/v1/models",
+			"https://gateway.example.test/v1/chat/completions",
+			"https://gateway.example.test/v1/chat/completions",
+		]);
 	});
 
 	it("dedupes repeated aggregate runs for the same evidence set", async () => {

--- a/platform/daemon/src/inference-router.test.ts
+++ b/platform/daemon/src/inference-router.test.ts
@@ -11,12 +11,12 @@ const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
 afterEach(() => {
 	globalThis.fetch = originalFetch;
 	if (originalOpenRouterApiKey === undefined) {
-		delete process.env.OPENROUTER_API_KEY;
+		process.env.OPENROUTER_API_KEY = undefined;
 	} else {
 		process.env.OPENROUTER_API_KEY = originalOpenRouterApiKey;
 	}
 	if (originalOpenAiApiKey === undefined) {
-		delete process.env.OPENAI_API_KEY;
+		process.env.OPENAI_API_KEY = undefined;
 	} else {
 		process.env.OPENAI_API_KEY = originalOpenAiApiKey;
 	}
@@ -140,6 +140,66 @@ describe("InferenceRouter legacy API credentials", () => {
 			expect(seen.every((entry) => entry.authorization === "Bearer test-openai-compatible-key")).toBe(true);
 			expect(seen.map((entry) => entry.url)).toContain("https://gateway.example.test/v1/models");
 			expect(seen.map((entry) => entry.url)).toContain("https://gateway.example.test/v1/chat/completions");
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not require OPENAI_API_KEY for local legacy OpenAI-compatible targets", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "signet-router-local-openai-compatible-"));
+		try {
+			mkdirSync(join(dir, "memory"), { recursive: true });
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`memory:
+  pipelineV2:
+    extraction:
+      provider: openai-compatible
+      model: openai/gpt-oss-20b
+      endpoint: http://127.0.0.1:1234/v1
+    synthesis:
+      enabled: false
+`,
+			);
+
+			process.env.OPENAI_API_KEY = undefined;
+			const seen: Array<{ readonly url: string; readonly authorization: string | null }> = [];
+			globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+				const url = String(input);
+				const headers = new Headers(init?.headers);
+				seen.push({ url, authorization: headers.get("authorization") });
+				if (url.endsWith("/models")) {
+					return Promise.resolve(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+				}
+				return Promise.resolve(
+					new Response(
+						JSON.stringify({
+							choices: [{ message: { content: "local compatible answer" } }],
+							usage: { prompt_tokens: 7, completion_tokens: 8 },
+						}),
+						{ status: 200 },
+					),
+				);
+			}) as unknown as typeof fetch;
+
+			const router = getOrCreateInferenceRouter(dir);
+			const result = await router.execute(
+				{
+					operation: "tool_planning",
+					promptPreview: "aggregate recall",
+					expectedOutputTokens: 64,
+				},
+				"Summarize evidence",
+				{ maxTokens: 64, timeoutMs: 1000 },
+			);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.text).toBe("local compatible answer");
+			expect(result.value.decision.targetRef).toBe("legacy-extraction/default");
+			expect(seen.every((entry) => entry.authorization === null)).toBe(true);
+			expect(seen.map((entry) => entry.url)).toContain("http://127.0.0.1:1234/v1/models");
+			expect(seen.map((entry) => entry.url)).toContain("http://127.0.0.1:1234/v1/chat/completions");
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}

--- a/platform/daemon/src/inference-router.test.ts
+++ b/platform/daemon/src/inference-router.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getOrCreateInferenceRouter, resetInferenceRouterForTests } from "./inference-router";
+
+const originalFetch = globalThis.fetch;
+const originalOpenRouterApiKey = process.env.OPENROUTER_API_KEY;
+const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	if (originalOpenRouterApiKey === undefined) {
+		delete process.env.OPENROUTER_API_KEY;
+	} else {
+		process.env.OPENROUTER_API_KEY = originalOpenRouterApiKey;
+	}
+	if (originalOpenAiApiKey === undefined) {
+		delete process.env.OPENAI_API_KEY;
+	} else {
+		process.env.OPENAI_API_KEY = originalOpenAiApiKey;
+	}
+	resetInferenceRouterForTests();
+});
+
+describe("InferenceRouter legacy API credentials", () => {
+	it("uses OPENROUTER_API_KEY for legacy pipeline OpenRouter synthesis targets", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "signet-router-openrouter-"));
+		try {
+			mkdirSync(join(dir, "memory"), { recursive: true });
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`memory:
+  pipelineV2:
+    extraction:
+      provider: none
+    synthesis:
+      enabled: true
+      provider: openrouter
+      model: openai/gpt-4o-mini
+      endpoint: https://openrouter.ai/api/v1
+`,
+			);
+
+			process.env.OPENROUTER_API_KEY = "test-openrouter-key";
+			const seen: Array<{ readonly url: string; readonly authorization: string | null }> = [];
+			globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+				const url = String(input);
+				const headers = new Headers(init?.headers);
+				seen.push({ url, authorization: headers.get("authorization") });
+				if (url.endsWith("/models")) {
+					return Promise.resolve(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+				}
+				return Promise.resolve(
+					new Response(
+						JSON.stringify({
+							choices: [{ message: { content: "aggregate recall answer" } }],
+							usage: { prompt_tokens: 3, completion_tokens: 4 },
+						}),
+						{ status: 200 },
+					),
+				);
+			}) as unknown as typeof fetch;
+
+			const router = getOrCreateInferenceRouter(dir);
+			const result = await router.execute(
+				{
+					operation: "tool_planning",
+					promptPreview: "aggregate recall",
+					expectedOutputTokens: 64,
+				},
+				"Summarize evidence",
+				{ maxTokens: 64, timeoutMs: 1000 },
+			);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.text).toBe("aggregate recall answer");
+			expect(result.value.decision.targetRef).toBe("legacy-synthesis/default");
+			expect(seen.every((entry) => entry.authorization === "Bearer test-openrouter-key")).toBe(true);
+			expect(seen.map((entry) => entry.url)).toContain("https://openrouter.ai/api/v1/models");
+			expect(seen.map((entry) => entry.url)).toContain("https://openrouter.ai/api/v1/chat/completions");
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("uses OPENAI_API_KEY for legacy pipeline OpenAI-compatible targets", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "signet-router-openai-compatible-"));
+		try {
+			mkdirSync(join(dir, "memory"), { recursive: true });
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`memory:
+  pipelineV2:
+    extraction:
+      provider: openai-compatible
+      model: gpt-4o-mini
+      endpoint: https://gateway.example.test/v1
+    synthesis:
+      enabled: false
+`,
+			);
+
+			process.env.OPENAI_API_KEY = "test-openai-compatible-key";
+			const seen: Array<{ readonly url: string; readonly authorization: string | null }> = [];
+			globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+				const url = String(input);
+				const headers = new Headers(init?.headers);
+				seen.push({ url, authorization: headers.get("authorization") });
+				if (url.endsWith("/models")) {
+					return Promise.resolve(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+				}
+				return Promise.resolve(
+					new Response(
+						JSON.stringify({
+							choices: [{ message: { content: "compatible gateway answer" } }],
+							usage: { prompt_tokens: 5, completion_tokens: 6 },
+						}),
+						{ status: 200 },
+					),
+				);
+			}) as unknown as typeof fetch;
+
+			const router = getOrCreateInferenceRouter(dir);
+			const result = await router.execute(
+				{
+					operation: "tool_planning",
+					promptPreview: "aggregate recall",
+					expectedOutputTokens: 64,
+				},
+				"Summarize evidence",
+				{ maxTokens: 64, timeoutMs: 1000 },
+			);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.text).toBe("compatible gateway answer");
+			expect(result.value.decision.targetRef).toBe("legacy-extraction/default");
+			expect(seen.every((entry) => entry.authorization === "Bearer test-openai-compatible-key")).toBe(true);
+			expect(seen.map((entry) => entry.url)).toContain("https://gateway.example.test/v1/models");
+			expect(seen.map((entry) => entry.url)).toContain("https://gateway.example.test/v1/chat/completions");
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -15,6 +15,7 @@ import type {
 import {
 	allTargetRefs,
 	compileLegacyRoutingConfig,
+	isLocalInferenceEndpoint,
 	parseRoutingConfig,
 	parseRoutingTargetRef,
 	parseYamlDocument,
@@ -155,16 +156,6 @@ interface SnapshotCacheEntry {
 interface ObservedRuntimeOverride {
 	readonly state: RoutingRuntimeState;
 	readonly expiresAt: number;
-}
-
-function isLocalBaseUrl(value: string | undefined): boolean {
-	if (!value) return true;
-	try {
-		const url = new URL(value);
-		return ["127.0.0.1", "localhost", "::1"].includes(url.hostname);
-	} catch {
-		return false;
-	}
 }
 
 function normalizePromptPreview(prompt: string): string {
@@ -613,7 +604,7 @@ export class InferenceRouter {
 		const needsCredential =
 			target.executor === "anthropic" ||
 			target.executor === "openrouter" ||
-			(target.executor === "openai-compatible" && !isLocalBaseUrl(target.endpoint));
+			(target.executor === "openai-compatible" && !isLocalInferenceEndpoint(target.endpoint));
 		if (target.account && !account) {
 			return {
 				available: false,

--- a/platform/daemon/src/memory-config.test.ts
+++ b/platform/daemon/src/memory-config.test.ts
@@ -361,6 +361,41 @@ describe("loadMemoryConfig", () => {
 		expect(cfg.pipelineV2.extraction.endpoint).toBe("https://gateway.example.test/v1");
 	});
 
+	it("keeps local openai-compatible extraction when remote providers are locked", () => {
+		const result = loadPipelineConfig({
+			memory: {
+				pipelineV2: {
+					allowRemoteProviders: false,
+					extraction: {
+						provider: "openai-compatible",
+						model: "local-model",
+						endpoint: "http://127.0.0.1:1234/v1",
+					},
+				},
+			},
+		});
+		expect(result.extraction.provider).toBe("openai-compatible");
+		expect(result.extraction.model).toBe("local-model");
+		expect(result.extraction.endpoint).toBe("http://127.0.0.1:1234/v1");
+	});
+
+	it("falls back from remote openai-compatible extraction when remote providers are locked", () => {
+		const result = loadPipelineConfig({
+			memory: {
+				pipelineV2: {
+					allowRemoteProviders: false,
+					extraction: {
+						provider: "openai-compatible",
+						model: "gpt-4o-mini",
+						endpoint: "https://gateway.example.test/v1",
+					},
+				},
+			},
+		});
+		expect(result.extraction.provider).toBe("llama-cpp");
+		expect(result.extraction.model).toBe("qwen3:4b");
+		expect(result.extraction.endpoint).toBeUndefined();
+	});
 
 	it("loads disabled extraction settings from agent.yaml", () => {
 		const agentsDir = makeTempAgentsDir();

--- a/platform/daemon/src/memory-config.test.ts
+++ b/platform/daemon/src/memory-config.test.ts
@@ -342,6 +342,26 @@ describe("loadMemoryConfig", () => {
 		expect(cfg.pipelineV2.extraction.model).toBe("openai/gpt-4o-mini");
 	});
 
+	it("loads openai-compatible extraction settings from agent.yaml", () => {
+		const agentsDir = makeTempAgentsDir();
+		writeFileSync(
+			join(agentsDir, "agent.yaml"),
+			`memory:
+  pipelineV2:
+    extraction:
+      provider: openai-compatible
+      model: gpt-4o-mini
+      endpoint: https://gateway.example.test/v1
+`,
+		);
+
+		const cfg = loadMemoryConfig(agentsDir);
+		expect(cfg.pipelineV2.extraction.provider).toBe("openai-compatible");
+		expect(cfg.pipelineV2.extraction.model).toBe("gpt-4o-mini");
+		expect(cfg.pipelineV2.extraction.endpoint).toBe("https://gateway.example.test/v1");
+	});
+
+
 	it("loads disabled extraction settings from agent.yaml", () => {
 		const agentsDir = makeTempAgentsDir();
 		writeFileSync(
@@ -435,6 +455,24 @@ describe("loadPipelineConfig", () => {
 		expect(result.synthesis.provider).toBe("openrouter");
 		expect(result.synthesis.model).toBe("openai/gpt-4o-mini");
 	});
+
+	it("accepts openai-compatible synthesis provider", () => {
+		const result = loadPipelineConfig({
+			memory: {
+				pipelineV2: {
+					synthesis: {
+						provider: "openai-compatible",
+						model: "gpt-4o-mini",
+						endpoint: "https://gateway.example.test/v1",
+					},
+				},
+			},
+		});
+		expect(result.synthesis.provider).toBe("openai-compatible");
+		expect(result.synthesis.model).toBe("gpt-4o-mini");
+		expect(result.synthesis.endpoint).toBe("https://gateway.example.test/v1");
+	});
+
 
 	it("accepts codex synthesis provider", () => {
 		const result = loadPipelineConfig({

--- a/platform/daemon/src/memory-config.ts
+++ b/platform/daemon/src/memory-config.ts
@@ -13,7 +13,7 @@ import {
 } from "@signet/core";
 import { type AuthConfig, parseAuthConfig } from "./auth";
 import { logger } from "./logger";
-import { isRemotePipelineProvider, providerFallbackForLock } from "./provider-safety";
+import { isRemotePipelineProviderForEndpoint, providerFallbackForLock } from "./provider-safety";
 
 export interface EmbeddingConfig {
 	provider: "native" | "llama-cpp" | "ollama" | "openai" | "none";
@@ -510,8 +510,8 @@ export function loadPipelineConfig(yaml: Record<string, unknown>): ResolvedPipel
 		);
 	}
 	const effectiveProvider =
-		!allowRemoteProviders && isRemotePipelineProvider(resolvedProvider)
-			? providerFallbackForLock(resolvedProvider, resolvedFallbackProvider)
+		!allowRemoteProviders && isRemotePipelineProviderForEndpoint(resolvedProvider, resolvedEndpoint)
+			? providerFallbackForLock(resolvedProvider, resolvedFallbackProvider, resolvedEndpoint)
 			: resolvedProvider;
 	const effectiveModel =
 		effectiveProvider === resolvedProvider ? resolvedModel : defaultPipelineModel(effectiveProvider);
@@ -535,9 +535,20 @@ export function loadPipelineConfig(yaml: Record<string, unknown>): ResolvedPipel
 		return effectiveProvider === "command" ? d.synthesis.provider : effectiveProvider;
 	};
 	const requestedSynthesisProvider: SynthesisProviderKind = resolveSynthesisProvider();
+	const requestedSynthesisEndpoint =
+		parseOptionalUrl(synthesisRaw?.endpoint) ??
+		parseOptionalUrl(synthesisRaw?.base_url) ??
+		(synthesisProviderWon || effectiveProvider === "command" ? undefined : effectiveEndpoint);
 	const resolveLockedSynthesisProvider = (): SynthesisProviderKind => {
-		if (!allowRemoteProviders && isRemotePipelineProvider(requestedSynthesisProvider)) {
-			const fallback = providerFallbackForLock(requestedSynthesisProvider, resolvedFallbackProvider);
+		if (
+			!allowRemoteProviders &&
+			isRemotePipelineProviderForEndpoint(requestedSynthesisProvider, requestedSynthesisEndpoint)
+		) {
+			const fallback = providerFallbackForLock(
+				requestedSynthesisProvider,
+				resolvedFallbackProvider,
+				requestedSynthesisEndpoint,
+			);
 			return isSynthesisProvider(fallback) ? fallback : "none";
 		}
 		return requestedSynthesisProvider;
@@ -555,9 +566,7 @@ export function loadPipelineConfig(yaml: Record<string, unknown>): ResolvedPipel
 					: effectiveModel;
 	const resolvedSynthesisEndpoint = synthesisProviderChangedForLock
 		? undefined
-		: (parseOptionalUrl(synthesisRaw?.endpoint) ??
-			parseOptionalUrl(synthesisRaw?.base_url) ??
-			(synthesisProviderWon || effectiveProvider === "command" ? undefined : effectiveEndpoint));
+		: requestedSynthesisEndpoint;
 	const resolvedSynthesisTimeout = clampPositive(
 		synthesisRaw?.timeout,
 		5000,

--- a/platform/daemon/src/pipeline/provider-resolution.test.ts
+++ b/platform/daemon/src/pipeline/provider-resolution.test.ts
@@ -62,4 +62,38 @@ describe("createRuntimeProvider", () => {
 		});
 		expect(provider?.name.startsWith("ollama:")).toBe(true);
 	});
+
+	it("creates an OpenAI-compatible provider for local endpoints without an API key", () => {
+		const provider = createRuntimeProvider({
+			role: "synthesis",
+			effectiveProvider: "openai-compatible",
+			configuredProvider: "openai-compatible",
+			configuredModel: "local-model",
+			timeoutMs: 1000,
+			ollamaBaseUrl: "http://127.0.0.1:11434",
+			ollamaFallbackBaseUrl: "http://127.0.0.1:11434",
+			ollamaFallbackMaxContextTokens: 4096,
+			openCodeBaseUrl: "http://127.0.0.1:4096",
+			openRouterBaseUrl: "https://openrouter.ai/api/v1",
+			openAiCompatibleBaseUrl: "http://127.0.0.1:1234/v1",
+		});
+		expect(provider?.name).toBe("openai-compatible:local-model");
+	});
+
+	it("requires an API key for remote OpenAI-compatible providers", () => {
+		const provider = createRuntimeProvider({
+			role: "synthesis",
+			effectiveProvider: "openai-compatible",
+			configuredProvider: "openai-compatible",
+			configuredModel: "gpt-4o-mini",
+			timeoutMs: 1000,
+			ollamaBaseUrl: "http://127.0.0.1:11434",
+			ollamaFallbackBaseUrl: "http://127.0.0.1:11434",
+			ollamaFallbackMaxContextTokens: 4096,
+			openCodeBaseUrl: "http://127.0.0.1:4096",
+			openRouterBaseUrl: "https://openrouter.ai/api/v1",
+			openAiCompatibleBaseUrl: "https://gateway.example.test/v1",
+		});
+		expect(provider).toBeNull();
+	});
 });

--- a/platform/daemon/src/pipeline/provider-resolution.ts
+++ b/platform/daemon/src/pipeline/provider-resolution.ts
@@ -7,6 +7,7 @@ import {
 	createClaudeCodeProvider,
 	createCodexProvider,
 	createOllamaProvider,
+	createOpenAiCompatibleProvider,
 	createOpenCodeProvider,
 	createOpenRouterProvider,
 } from "./provider";
@@ -17,6 +18,7 @@ export type RuntimeSynthesisProviderName = SynthesisProviderChoice;
 export type RuntimeProviderStatus = "active" | "degraded" | "blocked" | "disabled" | "paused";
 
 type CliPreflightResult = "ok" | "missing" | "failed";
+const DEFAULT_OPENAI_COMPATIBLE_BASE_URL = "http://127.0.0.1:1234/v1";
 
 export interface RuntimeProviderFactoryOptions {
 	readonly role: RuntimeRole;
@@ -29,8 +31,10 @@ export interface RuntimeProviderFactoryOptions {
 	readonly ollamaFallbackMaxContextTokens: number;
 	readonly openCodeBaseUrl: string;
 	readonly openRouterBaseUrl: string;
+	readonly openAiCompatibleBaseUrl?: string;
 	readonly anthropicApiKey?: string;
 	readonly openRouterApiKey?: string;
+	readonly openAiCompatibleApiKey?: string;
 	readonly openRouterReferer?: string;
 	readonly openRouterTitle?: string;
 }
@@ -40,6 +44,7 @@ export interface RuntimeEndpoints {
 	readonly ollamaFallbackBaseUrl: string;
 	readonly openCodeBaseUrl: string;
 	readonly openRouterBaseUrl: string;
+	readonly openAiCompatibleBaseUrl: string;
 	readonly openCodeShouldManage: boolean;
 }
 
@@ -55,6 +60,7 @@ export interface RuntimeStartupOptions {
 	readonly ollamaFallbackMaxContextTokens: number;
 	readonly anthropicApiKey?: string;
 	readonly openRouterApiKey?: string;
+	readonly openAiCompatibleApiKey?: string;
 	readonly openRouterReferer?: string;
 	readonly openRouterTitle?: string;
 	readonly ensureOpenCodeServer?: (port: number) => Promise<boolean>;
@@ -106,6 +112,16 @@ export function isManagedOpenCodeLocalEndpoint(baseUrl: string): boolean {
 	}
 }
 
+function isLocalBaseUrl(baseUrl: string | undefined): boolean {
+	if (!baseUrl) return true;
+	try {
+		const parsed = new URL(baseUrl);
+		return parsed.hostname === "127.0.0.1" || parsed.hostname === "localhost" || parsed.hostname === "::1";
+	} catch {
+		return false;
+	}
+}
+
 export function resolveRuntimeEndpoints(
 	configuredProvider: RuntimeProviderName,
 	endpoint: string | undefined,
@@ -117,6 +133,7 @@ export function resolveRuntimeEndpoints(
 		ollamaFallbackBaseUrl: configuredProvider === "opencode" ? "http://127.0.0.1:11434" : ollamaBaseUrl,
 		openCodeBaseUrl,
 		openRouterBaseUrl: normalizeRuntimeBaseUrl(endpoint, "https://openrouter.ai/api/v1"),
+		openAiCompatibleBaseUrl: normalizeRuntimeBaseUrl(endpoint, DEFAULT_OPENAI_COMPATIBLE_BASE_URL),
 		openCodeShouldManage: isManagedOpenCodeLocalEndpoint(openCodeBaseUrl),
 	};
 }
@@ -128,6 +145,7 @@ export function resolveRuntimeEndpointForLogs(
 	if (provider === "ollama") return endpoints.ollamaFallbackBaseUrl;
 	if (provider === "opencode") return endpoints.openCodeBaseUrl;
 	if (provider === "openrouter") return endpoints.openRouterBaseUrl;
+	if (provider === "openai-compatible") return endpoints.openAiCompatibleBaseUrl;
 	return undefined;
 }
 
@@ -165,6 +183,17 @@ export function createRuntimeProvider(opts: RuntimeProviderFactoryOptions): LlmP
 			baseUrl: opts.openRouterBaseUrl,
 			referer: opts.openRouterReferer,
 			title: opts.openRouterTitle,
+			defaultTimeoutMs: opts.timeoutMs,
+		});
+	}
+	if (opts.effectiveProvider === "openai-compatible") {
+		const baseUrl = opts.openAiCompatibleBaseUrl ?? DEFAULT_OPENAI_COMPATIBLE_BASE_URL;
+		if (!isLocalBaseUrl(baseUrl) && !opts.openAiCompatibleApiKey) return null;
+		return createOpenAiCompatibleProvider({
+			name: `openai-compatible:${model || defaultPipelineModel("openai-compatible")}`,
+			model: model || defaultPipelineModel("openai-compatible"),
+			baseUrl,
+			apiKey: opts.openAiCompatibleApiKey,
 			defaultTimeoutMs: opts.timeoutMs,
 		});
 	}
@@ -216,8 +245,10 @@ function createRuntimeProviderFromStartupOptions(
 		ollamaFallbackMaxContextTokens: opts.ollamaFallbackMaxContextTokens,
 		openCodeBaseUrl: opts.endpoints.openCodeBaseUrl,
 		openRouterBaseUrl: opts.endpoints.openRouterBaseUrl,
+		openAiCompatibleBaseUrl: opts.endpoints.openAiCompatibleBaseUrl,
 		anthropicApiKey: opts.anthropicApiKey,
 		openRouterApiKey: opts.openRouterApiKey,
+		openAiCompatibleApiKey: opts.openAiCompatibleApiKey,
 		openRouterReferer: opts.openRouterReferer,
 		openRouterTitle: opts.openRouterTitle,
 	});
@@ -298,6 +329,10 @@ export async function resolveRuntimeProviderStartup(opts: RuntimeStartupOptions)
 	} else if (effectiveProvider === "openrouter") {
 		if (!opts.openRouterApiKey) {
 			markUnavailable(`OPENROUTER_API_KEY not found for ${opts.role} startup preflight`);
+		}
+	} else if (effectiveProvider === "openai-compatible") {
+		if (!isLocalBaseUrl(opts.endpoints.openAiCompatibleBaseUrl) && !opts.openAiCompatibleApiKey) {
+			markUnavailable(`OPENAI_API_KEY not found for remote OpenAI-compatible ${opts.role} startup preflight`);
 		}
 	} else if (effectiveProvider === "claude-code") {
 		const cliResult = await preflightCliCommand("claude", { SIGNET_NO_HOOKS: "1" });

--- a/platform/daemon/src/pipeline/provider-resolution.ts
+++ b/platform/daemon/src/pipeline/provider-resolution.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import type { LlmProvider, PipelineProviderChoice, SynthesisProviderChoice } from "@signet/core";
-import { defaultPipelineModel, isPipelineProvider, isSynthesisProvider } from "@signet/core";
+import { defaultPipelineModel, isLocalInferenceEndpoint, isPipelineProvider, isSynthesisProvider } from "@signet/core";
 import { which } from "../which";
 import {
 	createAnthropicProvider,
@@ -112,16 +112,6 @@ export function isManagedOpenCodeLocalEndpoint(baseUrl: string): boolean {
 	}
 }
 
-function isLocalBaseUrl(baseUrl: string | undefined): boolean {
-	if (!baseUrl) return true;
-	try {
-		const parsed = new URL(baseUrl);
-		return parsed.hostname === "127.0.0.1" || parsed.hostname === "localhost" || parsed.hostname === "::1";
-	} catch {
-		return false;
-	}
-}
-
 export function resolveRuntimeEndpoints(
 	configuredProvider: RuntimeProviderName,
 	endpoint: string | undefined,
@@ -188,7 +178,7 @@ export function createRuntimeProvider(opts: RuntimeProviderFactoryOptions): LlmP
 	}
 	if (opts.effectiveProvider === "openai-compatible") {
 		const baseUrl = opts.openAiCompatibleBaseUrl ?? DEFAULT_OPENAI_COMPATIBLE_BASE_URL;
-		if (!isLocalBaseUrl(baseUrl) && !opts.openAiCompatibleApiKey) return null;
+		if (!isLocalInferenceEndpoint(baseUrl) && !opts.openAiCompatibleApiKey) return null;
 		return createOpenAiCompatibleProvider({
 			name: `openai-compatible:${model || defaultPipelineModel("openai-compatible")}`,
 			model: model || defaultPipelineModel("openai-compatible"),
@@ -331,7 +321,7 @@ export async function resolveRuntimeProviderStartup(opts: RuntimeStartupOptions)
 			markUnavailable(`OPENROUTER_API_KEY not found for ${opts.role} startup preflight`);
 		}
 	} else if (effectiveProvider === "openai-compatible") {
-		if (!isLocalBaseUrl(opts.endpoints.openAiCompatibleBaseUrl) && !opts.openAiCompatibleApiKey) {
+		if (!isLocalInferenceEndpoint(opts.endpoints.openAiCompatibleBaseUrl) && !opts.openAiCompatibleApiKey) {
 			markUnavailable(`OPENAI_API_KEY not found for remote OpenAI-compatible ${opts.role} startup preflight`);
 		}
 	} else if (effectiveProvider === "claude-code") {

--- a/platform/daemon/src/provider-safety.test.ts
+++ b/platform/daemon/src/provider-safety.test.ts
@@ -61,6 +61,20 @@ describe("provider safety", () => {
 		}
 	});
 
+	it("treats openai-compatible as remote for provider safety", () => {
+		const result = validateProviderSafety(`memory:
+  pipelineV2:
+    allowRemoteProviders: false
+    extractionProvider: openai-compatible
+`);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("allowRemoteProviders is false");
+			expect(result.error).toContain("openai-compatible");
+		}
+	});
+
 	it("blocks command extraction when allowRemoteProviders is false", () => {
 		const result = validateProviderSafety(`memory:
   pipelineV2:

--- a/platform/daemon/src/provider-safety.test.ts
+++ b/platform/daemon/src/provider-safety.test.ts
@@ -61,11 +61,37 @@ describe("provider safety", () => {
 		}
 	});
 
-	it("treats openai-compatible as remote for provider safety", () => {
+	it("allows local openai-compatible endpoints when remote providers are locked", () => {
 		const result = validateProviderSafety(`memory:
   pipelineV2:
     allowRemoteProviders: false
-    extractionProvider: openai-compatible
+    extraction:
+      provider: openai-compatible
+      endpoint: http://127.0.0.1:1234/v1
+`);
+
+		expect(result).toEqual({ ok: true });
+	});
+
+	it("allows IPv6 loopback openai-compatible endpoints when remote providers are locked", () => {
+		const result = validateProviderSafety(`memory:
+  pipelineV2:
+    allowRemoteProviders: false
+    extraction:
+      provider: openai-compatible
+      endpoint: http://[::1]:1234/v1
+`);
+
+		expect(result).toEqual({ ok: true });
+	});
+
+	it("treats remote openai-compatible endpoints as remote for provider safety", () => {
+		const result = validateProviderSafety(`memory:
+  pipelineV2:
+    allowRemoteProviders: false
+    extraction:
+      provider: openai-compatible
+      endpoint: https://gateway.example.test/v1
 `);
 
 		expect(result.ok).toBe(false);

--- a/platform/daemon/src/provider-safety.ts
+++ b/platform/daemon/src/provider-safety.ts
@@ -37,7 +37,9 @@ export interface ProviderTransitionAuditEntry {
 
 export interface ProviderSafetySnapshot {
 	readonly extractionProvider?: string;
+	readonly extractionEndpoint?: string;
 	readonly synthesisProvider?: string;
+	readonly synthesisEndpoint?: string;
 	readonly allowRemoteProviders: boolean;
 	readonly allowRemoteProvidersExplicit: boolean;
 }
@@ -81,11 +83,35 @@ export function isRemotePipelineProvider(provider: string | undefined | null): b
 	return provider !== undefined && provider !== null && REMOTE_PROVIDERS.has(provider);
 }
 
+function isLocalEndpoint(endpoint: string | undefined): boolean {
+	if (!endpoint) return true;
+	try {
+		const parsed = new URL(endpoint);
+		return (
+			parsed.hostname === "127.0.0.1" ||
+			parsed.hostname === "localhost" ||
+			parsed.hostname === "::1" ||
+			parsed.hostname === "[::1]"
+		);
+	} catch {
+		return false;
+	}
+}
+
+export function isRemotePipelineProviderForEndpoint(
+	provider: string | undefined | null,
+	endpoint: string | undefined,
+): boolean {
+	if (provider === "openai-compatible") return !isLocalEndpoint(endpoint);
+	return isRemotePipelineProvider(provider);
+}
+
 export function providerFallbackForLock(
 	provider: PipelineProviderChoice,
 	fallback: "llama-cpp" | "ollama" | "none" | undefined,
+	endpoint?: string,
 ): PipelineProviderChoice {
-	return isRemotePipelineProvider(provider) ? (fallback ?? "none") : provider;
+	return isRemotePipelineProviderForEndpoint(provider, endpoint) ? (fallback ?? "none") : provider;
 }
 
 export function readProviderSafetySnapshot(content: string): ProviderSafetySnapshot {
@@ -96,7 +122,10 @@ export function readProviderSafetySnapshot(content: string): ProviderSafetySnaps
 	const synthesis = asRecord(pipeline?.synthesis);
 	const flatExtraction = readProvider(pipeline?.extractionProvider);
 	const nestedExtraction = readProvider(extraction?.provider);
+	const flatExtractionEndpoint = readString(pipeline?.extractionEndpoint) ?? readString(pipeline?.extractionBaseUrl);
+	const nestedExtractionEndpoint = readString(extraction?.endpoint) ?? readString(extraction?.base_url);
 	const synthesisProvider = readProvider(synthesis?.provider);
+	const synthesisEndpoint = readString(synthesis?.endpoint) ?? readString(synthesis?.base_url);
 	const explicitAllowRemote =
 		typeof pipeline?.allowRemoteProviders === "boolean" || typeof extraction?.allowRemoteProviders === "boolean";
 	const topLevelRemote =
@@ -113,7 +142,9 @@ export function readProviderSafetySnapshot(content: string): ProviderSafetySnaps
 	const allowRemoteProviders = topLevelRemote ?? extractionRemote ?? true;
 	return {
 		extractionProvider: flatExtraction ?? nestedExtraction,
+		extractionEndpoint: flatExtractionEndpoint ?? nestedExtractionEndpoint,
 		synthesisProvider,
+		synthesisEndpoint,
 		allowRemoteProviders,
 		allowRemoteProvidersExplicit: explicitAllowRemote,
 	};
@@ -124,9 +155,9 @@ export function validateProviderSafety(content: string): { ok: true } | { ok: fa
 	if (!snapshot) return { ok: false, error: "Invalid YAML config" };
 	if (snapshot.allowRemoteProviders) return { ok: true };
 	const blocked = [
-		["extraction", snapshot.extractionProvider],
-		["synthesis", snapshot.synthesisProvider],
-	].filter(([, provider]) => isRemotePipelineProvider(provider));
+		["extraction", snapshot.extractionProvider, snapshot.extractionEndpoint],
+		["synthesis", snapshot.synthesisProvider, snapshot.synthesisEndpoint],
+	].filter(([, provider, endpoint]) => isRemotePipelineProviderForEndpoint(provider, endpoint));
 	if (blocked.length === 0) return { ok: true };
 	const parts = blocked.map(([role, provider]) => `${role} provider '${provider}'`);
 	return {
@@ -167,6 +198,7 @@ export function detectProviderTransitions(
 	];
 	for (const [role, from, to] of pairs) {
 		if (!to || from === to) continue;
+		const endpoint = role === "extraction" ? after.extractionEndpoint : after.synthesisEndpoint;
 		entries.push({
 			role,
 			from: from ?? null,
@@ -174,7 +206,9 @@ export function detectProviderTransitions(
 			timestamp,
 			source,
 			actor,
-			risky: (from === undefined || LOCAL_PROVIDERS.has(from)) && isRemotePipelineProvider(to),
+			risky:
+				(from === undefined || LOCAL_PROVIDERS.has(from)) &&
+				isRemotePipelineProviderForEndpoint(to, endpoint),
 		});
 	}
 	return entries;

--- a/platform/daemon/src/provider-safety.ts
+++ b/platform/daemon/src/provider-safety.ts
@@ -42,7 +42,16 @@ export interface ProviderSafetySnapshot {
 	readonly allowRemoteProvidersExplicit: boolean;
 }
 
-const REMOTE_PROVIDERS = new Set(["acpx", "claude-code", "codex", "opencode", "anthropic", "openrouter", "command"]);
+const REMOTE_PROVIDERS = new Set([
+	"acpx",
+	"claude-code",
+	"codex",
+	"opencode",
+	"anthropic",
+	"openrouter",
+	"openai-compatible",
+	"command",
+]);
 const LOCAL_PROVIDERS = new Set(["none", "llama-cpp", "ollama"]);
 const AUDIT_FILE = ".daemon/provider-transitions.json";
 

--- a/platform/daemon/src/provider-safety.ts
+++ b/platform/daemon/src/provider-safety.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
-import { type PipelineProviderChoice, isPipelineProvider } from "@signet/core";
+import { type PipelineProviderChoice, isLocalInferenceEndpoint, isPipelineProvider } from "@signet/core";
 import { parse, stringify } from "yaml";
 import { logger } from "./logger.js";
 
@@ -83,26 +83,11 @@ export function isRemotePipelineProvider(provider: string | undefined | null): b
 	return provider !== undefined && provider !== null && REMOTE_PROVIDERS.has(provider);
 }
 
-function isLocalEndpoint(endpoint: string | undefined): boolean {
-	if (!endpoint) return true;
-	try {
-		const parsed = new URL(endpoint);
-		return (
-			parsed.hostname === "127.0.0.1" ||
-			parsed.hostname === "localhost" ||
-			parsed.hostname === "::1" ||
-			parsed.hostname === "[::1]"
-		);
-	} catch {
-		return false;
-	}
-}
-
 export function isRemotePipelineProviderForEndpoint(
 	provider: string | undefined | null,
 	endpoint: string | undefined,
 ): boolean {
-	if (provider === "openai-compatible") return !isLocalEndpoint(endpoint);
+	if (provider === "openai-compatible") return !isLocalInferenceEndpoint(endpoint);
 	return isRemotePipelineProvider(provider);
 }
 
@@ -206,9 +191,7 @@ export function detectProviderTransitions(
 			timestamp,
 			source,
 			actor,
-			risky:
-				(from === undefined || LOCAL_PROVIDERS.has(from)) &&
-				isRemotePipelineProviderForEndpoint(to, endpoint),
+			risky: (from === undefined || LOCAL_PROVIDERS.has(from)) && isRemotePipelineProviderForEndpoint(to, endpoint),
 		});
 	}
 	return entries;

--- a/platform/daemon/src/routes/misc-routes.ts
+++ b/platform/daemon/src/routes/misc-routes.ts
@@ -11,7 +11,7 @@ import {
 	appendProviderTransitions,
 	detectProviderTransitions,
 	executeProviderRollback,
-	isRemotePipelineProvider,
+	isRemotePipelineProviderForEndpoint,
 	parseProviderSafetyRole,
 	preserveLockInYaml,
 	readProviderSafetySnapshot,
@@ -210,9 +210,9 @@ export function registerMiscRoutes(app: Hono): void {
 							incoming && !incoming.allowRemoteProvidersExplicit && incoming.allowRemoteProviders;
 						if (lockImplicitlyLifted) {
 							const blocked = [
-								["extraction", incoming.extractionProvider],
-								["synthesis", incoming.synthesisProvider],
-							].filter(([, p]) => isRemotePipelineProvider(p));
+								["extraction", incoming.extractionProvider, incoming.extractionEndpoint],
+								["synthesis", incoming.synthesisProvider, incoming.synthesisEndpoint],
+							].filter(([, p, endpoint]) => isRemotePipelineProviderForEndpoint(p, endpoint));
 							if (blocked.length > 0) {
 								return c.json(
 									{

--- a/platform/daemon/src/routes/state.ts
+++ b/platform/daemon/src/routes/state.ts
@@ -118,6 +118,14 @@ export function resolveRegistryOpenRouterBaseUrl(provider: string, endpoint: str
 	return normalizeRuntimeBaseUrl(endpoint, "https://openrouter.ai/api/v1");
 }
 
+export function resolveRegistryOpenAiCompatibleBaseUrl(
+	provider: string,
+	endpoint: string | undefined,
+): string | undefined {
+	if (provider !== "openai-compatible") return undefined;
+	return normalizeRuntimeBaseUrl(endpoint, "http://127.0.0.1:1234/v1");
+}
+
 export function isManagedOpenCodeLocalEndpoint(baseUrl: string): boolean {
 	try {
 		const parsed = new URL(baseUrl);
@@ -213,6 +221,7 @@ export type RuntimeProviderName =
 	| "codex"
 	| "anthropic"
 	| "openrouter"
+	| "openai-compatible"
 	| "command"
 	| "inference";
 
@@ -226,6 +235,7 @@ export type RuntimeSynthesisProviderName =
 	| "opencode"
 	| "anthropic"
 	| "openrouter"
+	| "openai-compatible"
 	| "inference";
 
 export interface ProviderRuntimeResolution {

--- a/surfaces/cli/src/commands/app.ts
+++ b/surfaces/cli/src/commands/app.ts
@@ -13,6 +13,7 @@ interface SetupOptions {
 	embeddingModel?: string;
 	extractionProvider?: string;
 	extractionModel?: string;
+	extractionEndpoint?: string;
 	searchBalance?: string;
 	openclawRuntimePath?: string;
 	configureOpenclawWorkspace?: boolean;
@@ -74,6 +75,7 @@ export function registerAppCommands(program: Command, deps: AppDeps): void {
 			"Extraction provider in non-interactive mode (claude-code, codex, llama-cpp, ollama, opencode, openrouter, openai-compatible, none)",
 		)
 		.option("--extraction-model <model>", "Extraction model in non-interactive mode")
+		.option("--extraction-endpoint <url>", "OpenAI-compatible extraction endpoint in non-interactive mode")
 		.option("--search-balance <alpha>", "Search balance alpha in non-interactive mode (0-1)")
 		.option("--openclaw-runtime-path <mode>", "OpenClaw runtime path in non-interactive mode (plugin, legacy)")
 		.option(

--- a/surfaces/cli/src/commands/app.ts
+++ b/surfaces/cli/src/commands/app.ts
@@ -71,7 +71,7 @@ export function registerAppCommands(program: Command, deps: AppDeps): void {
 		.option("--embedding-model <model>", "Embedding model in non-interactive mode")
 		.option(
 			"--extraction-provider <provider>",
-			"Extraction provider in non-interactive mode (claude-code, codex, llama-cpp, ollama, opencode, openrouter, none)",
+			"Extraction provider in non-interactive mode (claude-code, codex, llama-cpp, ollama, opencode, openrouter, openai-compatible, none)",
 		)
 		.option("--extraction-model <model>", "Extraction model in non-interactive mode")
 		.option("--search-balance <alpha>", "Search balance alpha in non-interactive mode (0-1)")

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -139,7 +139,7 @@ export async function runFreshSetup(cfg: FreshSetupConfig, deps: SetupDeps): Pro
 		}
 
 		const memory = readRecord(config.memory);
-		memory.pipelineV2 = buildSetupPipeline(cfg.extractionProvider, cfg.extractionModel);
+		memory.pipelineV2 = buildSetupPipeline(cfg.extractionProvider, cfg.extractionModel, cfg.extractionEndpoint);
 		config.memory = memory;
 		const inference = buildSetupInference(
 			cfg.extractionProvider,

--- a/surfaces/cli/src/features/setup-migrate.ts
+++ b/surfaces/cli/src/features/setup-migrate.ts
@@ -76,6 +76,7 @@ export async function runExistingSetupWizard(
 		embeddingModel?: string;
 		extractionProvider?: ExtractionProviderChoice;
 		extractionModel?: string;
+		extractionEndpoint?: string;
 		availableExtractionProviders?: readonly ExtractionProviderChoice[];
 		acpxBin?: string;
 		signetSecretsEnabled?: boolean;
@@ -237,7 +238,7 @@ export async function runExistingSetupWizard(
 					? defaultAcpxModel(detectedHarnesses, options.availableExtractionProviders)
 					: defaultExtractionModel(options.extractionProvider));
 			const memory = readRecord(config.memory);
-			memory.pipelineV2 = buildSetupPipeline(options.extractionProvider, model);
+			memory.pipelineV2 = buildSetupPipeline(options.extractionProvider, model, options.extractionEndpoint);
 			config.memory = memory;
 			const inference = buildSetupInference(
 				options.extractionProvider,

--- a/surfaces/cli/src/features/setup-pipeline.test.ts
+++ b/surfaces/cli/src/features/setup-pipeline.test.ts
@@ -67,6 +67,23 @@ describe("buildSetupPipeline", () => {
 		});
 	});
 
+	it("writes the selected endpoint into extraction and synthesis config", () => {
+		expect(
+			buildSetupPipeline("openai-compatible", "openai/gpt-oss-20b", "https://gateway.example.test/v1"),
+		).toMatchObject({
+			extraction: {
+				provider: "openai-compatible",
+				model: "openai/gpt-oss-20b",
+				endpoint: "https://gateway.example.test/v1",
+			},
+			synthesis: {
+				provider: "openai-compatible",
+				model: "openai/gpt-oss-20b",
+				endpoint: "https://gateway.example.test/v1",
+			},
+		});
+	});
+
 	it("does not invent a generic ACPX model when no harness agent is known", () => {
 		expect(buildSetupPipeline("acpx").extraction.model).toBe("");
 		expect(buildSetupPipeline("acpx").synthesis?.model).toBe("");
@@ -80,17 +97,13 @@ describe("buildSetupInference", () => {
 		expect(defaultAcpxModel(["claude-code"], ["acpx"])).toBe("haiku");
 
 		expect(
-			buildSetupInference("acpx", undefined, ["codex"], ["acpx"], "/usr/local/bin/bunx")?.targets[
-				"background-acpx"
-			],
+			buildSetupInference("acpx", undefined, ["codex"], ["acpx"], "/usr/local/bin/bunx")?.targets["background-acpx"],
 		).toMatchObject({
 			acpx: { agent: "codex" },
 			models: { default: { model: "gpt-5.4-mini" } },
 		});
 		expect(
-			buildSetupInference("acpx", undefined, ["opencode"], ["acpx"], "/usr/local/bin/bunx")?.targets[
-				"background-acpx"
-			],
+			buildSetupInference("acpx", undefined, ["opencode"], ["acpx"], "/usr/local/bin/bunx")?.targets["background-acpx"],
 		).toMatchObject({
 			acpx: { agent: "opencode" },
 			models: { default: { model: "google/gemini-2.5-flash" } },
@@ -98,7 +111,13 @@ describe("buildSetupInference", () => {
 	});
 
 	it("writes ACPX as explicit inference routing with the selected harness agent", () => {
-		const inference = buildSetupInference("acpx", "google/gemini-2.5-flash", ["opencode", "codex"], [], "/usr/local/bin/bunx");
+		const inference = buildSetupInference(
+			"acpx",
+			"google/gemini-2.5-flash",
+			["opencode", "codex"],
+			[],
+			"/usr/local/bin/bunx",
+		);
 		expect(inference?.targets["background-acpx"]).toMatchObject({
 			executor: "acpx",
 			acpx: {

--- a/surfaces/cli/src/features/setup-pipeline.ts
+++ b/surfaces/cli/src/features/setup-pipeline.ts
@@ -9,11 +9,13 @@ export interface SetupPipelineConfig {
 	readonly extraction: {
 		readonly provider: ExtractionProviderChoice;
 		readonly model: string;
+		readonly endpoint?: string;
 	};
 	readonly synthesis?: {
 		readonly enabled: boolean;
 		readonly provider: ExtractionProviderChoice;
 		readonly model: string;
+		readonly endpoint?: string;
 		readonly timeout: number;
 	};
 	readonly semanticContradictionEnabled?: boolean;
@@ -36,8 +38,13 @@ export function defaultExtractionModel(provider: DirectExtractionProviderChoice)
 	return defaultPipelineModel(provider);
 }
 
-export function buildSetupPipeline(provider: ExtractionProviderChoice, model?: string): SetupPipelineConfig {
+export function buildSetupPipeline(
+	provider: ExtractionProviderChoice,
+	model?: string,
+	endpoint?: string,
+): SetupPipelineConfig {
 	const resolved = model?.trim() || (provider === "acpx" ? "" : defaultExtractionModel(provider));
+	const resolvedEndpoint = endpoint?.trim() || undefined;
 	if (provider === "none") {
 		return {
 			enabled: false,
@@ -59,11 +66,13 @@ export function buildSetupPipeline(provider: ExtractionProviderChoice, model?: s
 		extraction: {
 			provider,
 			model: resolved,
+			...(resolvedEndpoint ? { endpoint: resolvedEndpoint } : {}),
 		},
 		synthesis: {
 			enabled: true,
 			provider,
 			model: resolved,
+			...(resolvedEndpoint ? { endpoint: resolvedEndpoint } : {}),
 			timeout: 120000,
 		},
 		semanticContradictionEnabled: true,

--- a/surfaces/cli/src/features/setup-shared.ts
+++ b/surfaces/cli/src/features/setup-shared.ts
@@ -13,7 +13,16 @@ export type HarnessChoice =
 	| "hermes-agent"
 	| "gemini";
 export type EmbeddingProviderChoice = "native" | "llama-cpp" | "ollama" | "openai" | "none";
-export type ExtractionProviderChoice = "acpx" | "claude-code" | "llama-cpp" | "ollama" | "opencode" | "codex" | "openrouter" | "none";
+export type ExtractionProviderChoice =
+	| "acpx"
+	| "claude-code"
+	| "llama-cpp"
+	| "ollama"
+	| "opencode"
+	| "codex"
+	| "openrouter"
+	| "openai-compatible"
+	| "none";
 export type OpenClawRuntimeChoice = "plugin" | "legacy";
 export type DeploymentTypeChoice = "local" | "vps" | "server";
 export interface ResolveSetupExtractionProviderOptions {
@@ -46,6 +55,7 @@ export const EXTRACTION_PROVIDER_CHOICES: readonly ExtractionProviderChoice[] = 
 	"opencode",
 	"codex",
 	"openrouter",
+	"openai-compatible",
 	"none",
 ];
 export const OPENCLAW_RUNTIME_CHOICES: readonly OpenClawRuntimeChoice[] = ["plugin", "legacy"];

--- a/surfaces/cli/src/features/setup-types.ts
+++ b/surfaces/cli/src/features/setup-types.ts
@@ -19,6 +19,7 @@ export interface SetupWizardOptions {
 	embeddingModel?: string;
 	extractionProvider?: string;
 	extractionModel?: string;
+	extractionEndpoint?: string;
 	searchBalance?: string;
 	skipGit?: boolean;
 	openDashboard?: boolean;
@@ -85,6 +86,7 @@ export interface FreshSetupConfig {
 	readonly embeddingDimensions: number;
 	readonly extractionProvider: ExtractionProviderChoice;
 	readonly extractionModel: string;
+	readonly extractionEndpoint?: string;
 	readonly availableExtractionProviders: readonly ExtractionProviderChoice[];
 	readonly acpxBin?: string;
 	readonly searchBalance: number;

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -231,6 +231,41 @@ describe("setupWizard non-interactive harness hooks", () => {
 		expect(configureHarnessHooks).not.toHaveBeenCalled();
 	});
 
+	it("writes OpenAI-compatible endpoint during non-interactive setup", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-ni-compatible-endpoint-"));
+		const basePath = join(root, "agents");
+		const templatesPath = join(root, "templates");
+		mkdirSync(templatesPath, { recursive: true });
+
+		const deps = stubDeps({
+			AGENTS_DIR: basePath,
+			getTemplatesDir: mock(() => templatesPath),
+			normalizeAgentPath: mock((p: string) => p),
+			detectExistingSetup: mock(() => ({
+				...fakeDetection(basePath),
+				agentsDir: false,
+				memoryDb: false,
+				hasMemoryDir: false,
+			})),
+		});
+
+		await setupWizard(
+			{
+				nonInteractive: true,
+				extractionProvider: "openai-compatible",
+				extractionModel: "openai/gpt-oss-20b",
+				extractionEndpoint: "https://gateway.example.test/v1",
+				skipGit: true,
+			},
+			deps,
+		);
+
+		const agentYaml = readFileSync(join(basePath, "agent.yaml"), "utf-8");
+		expect(agentYaml).toContain("provider: openai-compatible");
+		expect(agentYaml).toContain("model: openai/gpt-oss-20b");
+		expect(agentYaml).toContain("endpoint: https://gateway.example.test/v1");
+	});
+
 	it("persists disabled signet secrets when existing non-interactive setup opts out", async () => {
 		root = mkdtempSync(join(tmpdir(), "setup-ni-secrets-disabled-"));
 		const basePath = join(root, "agents");

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -67,6 +67,32 @@ function modelChoices(provider: ExtractionProviderChoice): Array<{ value: string
 	return modelPresetsForProvider(provider).map((preset) => ({ value: preset.value, name: preset.label }));
 }
 
+const DEFAULT_OPENAI_COMPATIBLE_ENDPOINT = "http://127.0.0.1:1234/v1";
+
+function normalizeHttpEndpoint(value: string | null | undefined): string | undefined {
+	if (!value) return undefined;
+	const trimmed = value.trim();
+	if (!trimmed) return undefined;
+	try {
+		const parsed = new URL(trimmed);
+		return parsed.protocol === "http:" || parsed.protocol === "https:" ? trimmed : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function resolveSetupExtractionEndpoint(options: {
+	readonly provider: ExtractionProviderChoice;
+	readonly requestedEndpoint?: string;
+	readonly existingProvider?: ExtractionProviderChoice | null;
+	readonly existingEndpoint?: string | null;
+}): string | undefined {
+	if (options.requestedEndpoint) return options.requestedEndpoint;
+	if (options.provider === options.existingProvider && options.existingEndpoint) return options.existingEndpoint;
+	if (options.provider === "openai-compatible") return DEFAULT_OPENAI_COMPATIBLE_ENDPOINT;
+	return undefined;
+}
+
 const IDENTITY_PRESET_CHOICES = ["minimal", "hermes", "openclaw", "custom"] as const;
 
 function cloneStartupFiles(preset: IdentityPresetName): IdentityContextFileEntry[] {
@@ -141,12 +167,19 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 	const existingMemory = readRecord(existingConfig.memory);
 	const existingPipeline = readRecord(existingMemory.pipelineV2);
 	const existingExtraction = readRecord(existingPipeline.extraction);
+	const existingExtractionEndpoint =
+		readString(existingPipeline.extractionEndpoint) ??
+		readString(existingPipeline.extractionBaseUrl) ??
+		readString(existingExtraction.endpoint) ??
+		readString(existingExtraction.base_url);
 	const rawDeploymentType = deps.normalizeStringValue(options.deploymentType);
 	const requestedDeploymentType = deps.normalizeChoice(rawDeploymentType, DEPLOYMENT_TYPE_CHOICES);
 	const rawEmbeddingProvider = deps.normalizeStringValue(options.embeddingProvider);
 	const requestedEmbeddingProvider = deps.normalizeChoice(rawEmbeddingProvider, EMBEDDING_PROVIDER_CHOICES);
 	const rawExtractionProvider = deps.normalizeStringValue(options.extractionProvider);
 	const requestedExtractionProvider = deps.normalizeChoice(rawExtractionProvider, EXTRACTION_PROVIDER_CHOICES);
+	const rawExtractionEndpoint = deps.normalizeStringValue(options.extractionEndpoint);
+	const requestedExtractionEndpoint = normalizeHttpEndpoint(rawExtractionEndpoint);
 	const existingName = readString(existingConfig.name) ?? readString(existingAgent.name) ?? "My Agent";
 	const existingDesc =
 		readString(existingConfig.description) ?? readString(existingAgent.description) ?? "Personal AI assistant";
@@ -191,6 +224,9 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		failSetupValidation(
 			`Unknown --extraction-provider value: ${rawExtractionProvider}. Valid choices: ${EXTRACTION_PROVIDER_CHOICES.join(", ")}.`,
 		);
+	}
+	if (rawExtractionEndpoint && !requestedExtractionEndpoint) {
+		failSetupValidation("--extraction-endpoint must be an http:// or https:// URL.");
 	}
 	const unknownHarnessValues = findUnknownHarnessValues(options.harness, deps);
 	if (nonInteractive && unknownHarnessValues.length > 0) {
@@ -334,6 +370,12 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 				availableProviders: availableToolExtractionProviders,
 				preferredHarnesses: normalizedExistingHarnesses,
 			});
+			const migrationExtractionEndpoint = resolveSetupExtractionEndpoint({
+				provider: migrationExtractionProvider,
+				requestedEndpoint: requestedExtractionEndpoint,
+				existingProvider: existingExtractionProvider,
+				existingEndpoint: existingExtractionEndpoint,
+			});
 
 			const signetSecretsEnabled = await resolveSignetSecretsCorePluginSelection(basePath, true, options);
 			const graphiqEnabled = await resolveGraphiqPluginSelection(basePath, true, options);
@@ -348,6 +390,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 				embeddingModel: deps.normalizeStringValue(options.embeddingModel) || undefined,
 				extractionProvider: migrationExtractionProvider,
 				extractionModel: deps.normalizeStringValue(options.extractionModel) || undefined,
+				extractionEndpoint: migrationExtractionEndpoint,
 				availableExtractionProviders: availableToolExtractionProviders,
 				acpxBin,
 				signetSecretsEnabled,
@@ -421,6 +464,12 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 				availableProviders: availableToolExtractionProviders,
 				preferredHarnesses: normalizedExistingHarnesses,
 			});
+			const migrationExtractionEndpoint = resolveSetupExtractionEndpoint({
+				provider: migrationExtractionProvider,
+				requestedEndpoint: requestedExtractionEndpoint,
+				existingProvider: existingExtractionProvider,
+				existingEndpoint: existingExtractionEndpoint,
+			});
 
 			const signetSecretsEnabled = await resolveSignetSecretsCorePluginSelection(basePath, false, options);
 			const graphiqEnabled = await resolveGraphiqPluginSelection(basePath, false, options);
@@ -435,6 +484,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 					deps.normalizeStringValue(existingPipeline.extractionModel) ||
 					deps.normalizeStringValue(existingExtraction.model) ||
 					undefined,
+				extractionEndpoint: migrationExtractionEndpoint,
 				availableExtractionProviders: availableToolExtractionProviders,
 				acpxBin,
 				signetSecretsEnabled,
@@ -770,15 +820,15 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 				],
 			});
 
+	const existingSetupExtractionProvider =
+		deps.normalizeChoice(existingPipeline.extractionProvider, EXTRACTION_PROVIDER_CHOICES) ||
+		deps.normalizeChoice(existingExtraction.provider, EXTRACTION_PROVIDER_CHOICES);
 	let extractionProvider: ExtractionProviderChoice;
 	if (nonInteractive) {
-		const providerFromConfig =
-			deps.normalizeChoice(existingPipeline.extractionProvider, EXTRACTION_PROVIDER_CHOICES) ||
-			deps.normalizeChoice(existingExtraction.provider, EXTRACTION_PROVIDER_CHOICES);
 		extractionProvider = resolveSetupExtractionProvider({
 			deploymentType,
 			requestedProvider: requestedExtractionProvider,
-			providerFromConfig,
+			providerFromConfig: existingSetupExtractionProvider,
 			preserveExisting: false,
 			detectedProvider,
 			availableProviders: availableToolExtractionProviders,
@@ -941,6 +991,22 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		}
 	}
 
+	let extractionEndpoint = resolveSetupExtractionEndpoint({
+		provider: extractionProvider,
+		requestedEndpoint: requestedExtractionEndpoint,
+		existingProvider: existingSetupExtractionProvider,
+		existingEndpoint: existingExtractionEndpoint,
+	});
+	if (!nonInteractive && extractionProvider === "openai-compatible") {
+		console.log();
+		const endpointInput = await input({
+			message: "OpenAI-compatible endpoint:",
+			default: extractionEndpoint ?? DEFAULT_OPENAI_COMPATIBLE_ENDPOINT,
+			validate: (value) => normalizeHttpEndpoint(value) !== undefined || "Enter an http:// or https:// URL.",
+		});
+		extractionEndpoint = normalizeHttpEndpoint(endpointInput) ?? DEFAULT_OPENAI_COMPATIBLE_ENDPOINT;
+	}
+
 	const wantAdvanced = nonInteractive
 		? false
 		: await confirm({
@@ -1019,6 +1085,7 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 		embeddingDimensions,
 		extractionProvider,
 		extractionModel,
+		extractionEndpoint,
 		availableExtractionProviders: availableToolExtractionProviders,
 		acpxBin,
 		searchBalance,

--- a/surfaces/cli/src/features/setup.ts
+++ b/surfaces/cli/src/features/setup.ts
@@ -823,6 +823,10 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 				value: "openrouter",
 				name: "OpenRouter (cloud API, billed usage, expensive if left running)",
 			},
+			{
+				value: "openai-compatible",
+				name: "OpenAI-compatible endpoint (advanced, uses OPENAI_API_KEY and extraction endpoint config)",
+			},
 		];
 		extractionProvider = await select({
 			message: "Memory extraction provider (analyzes conversations):",
@@ -905,6 +909,20 @@ export async function setupWizard(options: SetupWizardOptions, deps: SetupDeps):
 			extractionModel = await select({
 				message: "Which OpenRouter model for extraction? (provider/model format)",
 				choices: modelChoices("openrouter"),
+			});
+		}
+	} else if (extractionProvider === "openai-compatible") {
+		if (nonInteractive) {
+			extractionModel =
+				deps.normalizeStringValue(options.extractionModel) ||
+				deps.normalizeStringValue(existingPipeline.extractionModel) ||
+				deps.normalizeStringValue(existingExtraction.model) ||
+				defaultExtractionModel("openai-compatible");
+		} else {
+			console.log();
+			extractionModel = await select({
+				message: "Which OpenAI-compatible model for extraction?",
+				choices: modelChoices("openai-compatible"),
 			});
 		}
 	} else if (extractionProvider === "ollama") {

--- a/surfaces/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
@@ -20,11 +20,13 @@ import { defaultPipelineModel } from "@signet/core/pipeline-providers";
 import {
 	ACPX_DASHBOARD_AGENT_OPTIONS,
 	type AcpxDashboardAgent,
+	DEFAULT_OPENAI_COMPATIBLE_ENDPOINT,
 	applyAcpxDashboardSetup,
 	defaultAcpxDashboardAgent,
 	defaultAcpxDashboardModel,
 	hasExplicitSynthesisConfig,
 	hasExplicitSynthesisProvider,
+	resolveExtractionEndpoint,
 	resolveSynthesisEnabled,
 	resolveSynthesisEndpoint,
 	resolveSynthesisModel,
@@ -120,7 +122,9 @@ function extractionModelSelectValue(): string {
 }
 
 function isKnownPreset(model: string): boolean {
-	return EXTRACTION_PROVIDER_OPTIONS.some((option) => getModelPresets(option.value).some((preset) => preset.value === model));
+	return EXTRACTION_PROVIDER_OPTIONS.some((option) =>
+		getModelPresets(option.value).some((preset) => preset.value === model),
+	);
 }
 
 function isKnownProvider(provider: string): provider is Parameters<typeof defaultPipelineModel>[0] {
@@ -135,6 +139,10 @@ function defaultModelForProvider(provider: string): string {
 
 function extractionModel(): string {
 	return st.aStr(["memory", "pipelineV2", "extractionModel"]);
+}
+
+function extractionEndpoint(): string {
+	return resolveExtractionEndpoint(st.agent);
 }
 
 function extractionDisabled(): boolean {
@@ -253,11 +261,19 @@ function setSelect(path: string[]) {
 function setExtractionProvider(v: string | undefined): void {
 	const nextProvider = v ?? "";
 	const currentModel = st.aStr(["memory", "pipelineV2", "extractionModel"]);
+	const currentEndpoint =
+		st.aStr(["memory", "pipelineV2", "extractionEndpoint"]) ||
+		st.aStr(["memory", "pipelineV2", "extractionBaseUrl"]) ||
+		st.aStr(["memory", "pipelineV2", "extraction", "endpoint"]) ||
+		st.aStr(["memory", "pipelineV2", "extraction", "base_url"]);
 	customModelActive = false;
 	st.aSetStr(["memory", "pipelineV2", "extractionProvider"], nextProvider);
 	if (!nextProvider) {
 		st.aSetStr(["memory", "pipelineV2", "extractionModel"], "");
 		return;
+	}
+	if (nextProvider === "openai-compatible" && !currentEndpoint) {
+		st.aSetStr(["memory", "pipelineV2", "extractionEndpoint"], DEFAULT_OPENAI_COMPATIBLE_ENDPOINT);
 	}
 	if (!currentModel || isKnownPreset(currentModel)) {
 		st.aSetStr(["memory", "pipelineV2", "extractionModel"], defaultModelForProvider(nextProvider));
@@ -462,6 +478,12 @@ const ADVANCED_FEATURE_KEYS = ["autonomousFrozen"] as const;
 				{/if}
 			</div>
 		</FormField>
+
+		{#if extractionProvider() === "openai-compatible"}
+			<FormField label="Extraction endpoint" description="OpenAI-compatible /v1 endpoint for extraction. Loopback endpoints are treated as local; remote gateways use OPENAI_API_KEY.">
+				<Input value={extractionEndpoint()} oninput={setStr(["memory", "pipelineV2", "extractionEndpoint"])} placeholder={DEFAULT_OPENAI_COMPATIBLE_ENDPOINT} />
+			</FormField>
+		{/if}
 
 		<FormField label="Session synthesis" description="Provider used by the summary-worker for session summaries. This is separate from fact extraction once explicitly configured.">
 			<div class="flex flex-col gap-2">

--- a/surfaces/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/PipelineSection.svelte
@@ -51,6 +51,7 @@ const EXTRACTION_PROVIDER_OPTIONS = [
 	{ value: "opencode", label: "opencode" },
 	{ value: "anthropic", label: "anthropic" },
 	{ value: "openrouter", label: "openrouter" },
+	{ value: "openai-compatible", label: "openai-compatible" },
 ] as const;
 
 function getModelPresets(provider: string): Array<{ value: string; label: string }> {
@@ -93,6 +94,9 @@ function pickPreferredModel(provider: string, presets: Array<{ value: string; la
 			vals[0] ??
 			""
 		);
+	}
+	if (provider === "openai-compatible") {
+		return vals.find((v) => v.toLowerCase().includes("mini")) ?? vals[0] ?? "";
 	}
 	return vals[0] ?? "";
 }
@@ -138,7 +142,13 @@ function extractionDisabled(): boolean {
 }
 
 function providerRisky(provider: string): boolean {
-	return provider === "acpx" || provider === "anthropic" || provider === "openrouter" || provider === "opencode";
+	return (
+		provider === "acpx" ||
+		provider === "anthropic" ||
+		provider === "openrouter" ||
+		provider === "openai-compatible" ||
+		provider === "opencode"
+	);
 }
 
 function extractionProviderRisky(): boolean {
@@ -398,7 +408,7 @@ const ADVANCED_FEATURE_KEYS = ["autonomousFrozen"] as const;
 			<Switch checked={st.aBool(["memory", "pipelineV2", PIPELINE_CORE_BOOLS[0].key])} onCheckedChange={setBool(["memory", "pipelineV2", PIPELINE_CORE_BOOLS[0].key])} />
 		</FormField>
 
-		<FormField label="Extraction provider" description="LLM backend for fact extraction. Ollama runs locally; claude-code uses Claude Code CLI; codex uses the local Codex CLI; opencode uses the OpenCode server; anthropic uses direct API; openrouter uses the OpenRouter API.">
+		<FormField label="Extraction provider" description="LLM backend for fact extraction. Ollama runs locally; claude-code uses Claude Code CLI; codex uses the local Codex CLI; opencode uses the OpenCode server; anthropic, openrouter, and openai-compatible use direct APIs.">
 			<div class="flex flex-col gap-2">
 				<Select.Root
 					type="single"

--- a/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts
@@ -2,10 +2,12 @@
 import { describe, expect, it } from "bun:test";
 import { DEFAULT_PIPELINE_TIMEOUT_MS } from "@signet/core/pipeline-providers";
 import {
+	DEFAULT_OPENAI_COMPATIBLE_ENDPOINT,
 	applyAcpxDashboardSetup,
 	defaultAcpxDashboardAgent,
 	hasExplicitSynthesisConfig,
 	hasExplicitSynthesisProvider,
+	resolveExtractionEndpoint,
 	resolveSynthesisEnabled,
 	resolveSynthesisEndpoint,
 	resolveSynthesisModel,
@@ -14,6 +16,28 @@ import {
 } from "./pipeline-settings";
 
 describe("pipeline-settings synthesis resolution", () => {
+	it("resolves extraction endpoints for OpenAI-compatible dashboard setup", () => {
+		expect(
+			resolveExtractionEndpoint({
+				memory: {
+					pipelineV2: {
+						extractionProvider: "openai-compatible",
+					},
+				},
+			}),
+		).toBe(DEFAULT_OPENAI_COMPATIBLE_ENDPOINT);
+		expect(
+			resolveExtractionEndpoint({
+				memory: {
+					pipelineV2: {
+						extractionProvider: "openai-compatible",
+						extractionEndpoint: "https://gateway.example.test/v1",
+					},
+				},
+			}),
+		).toBe("https://gateway.example.test/v1");
+	});
+
 	it("falls back to extraction values when synthesis is absent", () => {
 		const agent = {
 			memory: {

--- a/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.ts
+++ b/surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.ts
@@ -5,6 +5,8 @@ import {
 	isPipelineProvider,
 } from "@signet/core/pipeline-providers";
 
+export const DEFAULT_OPENAI_COMPATIBLE_ENDPOINT = "http://127.0.0.1:1234/v1";
+
 function toRecord(value: unknown): Record<string, unknown> | null {
 	return typeof value === "object" && value !== null && !Array.isArray(value)
 		? Object.fromEntries(Object.entries(value))
@@ -68,6 +70,18 @@ export function hasExplicitSynthesisConfig(agent: unknown): boolean {
 export function hasExplicitSynthesisProvider(agent: unknown): boolean {
 	const pipeline = readPipeline(agent);
 	return isPipelineProvider(readString(pipeline, "synthesis", "provider"));
+}
+
+export function resolveExtractionEndpoint(agent: unknown): string {
+	const pipeline = readPipeline(agent);
+	const explicit =
+		readString(pipeline, "extractionEndpoint") ??
+		readString(pipeline, "extractionBaseUrl") ??
+		readString(pipeline, "extraction", "endpoint") ??
+		readString(pipeline, "extraction", "base_url");
+	if (explicit) return explicit;
+	const provider = readString(pipeline, "extractionProvider") ?? readString(pipeline, "extraction", "provider");
+	return provider === "openai-compatible" ? DEFAULT_OPENAI_COMPATIBLE_ENDPOINT : "";
 }
 
 export function resolveSynthesisProvider(agent: unknown): PipelineProviderChoice {


### PR DESCRIPTION
## Summary

- attach legacy routed API accounts for OpenRouter, Anthropic, and OpenAI-compatible pipeline providers so aggregate recall and other routed synthesis tasks can use direct API keys
- promote `openai-compatible` to a first-class pipeline extraction/synthesis provider across core types, daemon startup, safety checks, setup CLI, dashboard settings, and docs
- add regression coverage proving aggregate recall can synthesize through a direct OpenAI-compatible API target without ACPX or CLI harness execution

## Verification

- `bun run build:core`
- `bun test platform/core/src/routing.test.ts`
- `bun test platform/daemon/src/inference-router.test.ts`
- `bun test platform/daemon/src/memory-config.test.ts`
- `bun test platform/daemon/src/pipeline/provider-resolution.test.ts platform/daemon/src/provider-safety.test.ts`
- `bun test platform/daemon/src/aggregate-recall.test.ts`
- `bun test surfaces/dashboard/src/lib/components/tabs/settings/pipeline-settings.test.ts`
- `bun test surfaces/cli/src/features/setup-pipeline.test.ts surfaces/cli/src/commands/memory.test.ts`
- `bun run --filter '@signet/core' typecheck`
- `cd platform/daemon && bun run build.ts`

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)
- [x] No database migrations or schema changes
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

## Rollback / Compatibility

No schema changes. Rollback is reverting this PR; existing ACPX, CLI harness, OpenRouter, Anthropic, local Ollama/llama.cpp, and explicit `inference.targets` routing remain compatible. The new legacy `openai-compatible` pipeline provider uses the existing OpenAI-compatible provider implementation and `OPENAI_API_KEY` credential convention.

## Notes

The aggregate recall regression uses the real `InferenceRouter` and mocks only the HTTP boundary. It verifies calls to the configured OpenAI-compatible `/v1` endpoint with `OPENAI_API_KEY`, with no ACPX or CLI harness provider involved.
