### PR TITLE
docs: correct stale documentation claims

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -87,7 +87,7 @@ No authentication required. Lightweight liveness check.
   "status": "healthy",
   "uptime": 3600.5,
   "pid": 12345,
-  "version": "0.109.x",
+  "version": "0.124.0",
   "port": 3850,
   "agentsDir": "/home/user/.agents",
   "db": true,
@@ -116,7 +116,7 @@ silent fallback or hard-blocked extraction after boot.
 ```json
 {
   "status": "running",
-  "version": "0.109.x",
+  "version": "0.124.0",
   "pid": 12345,
   "uptime": 3600.5,
   "startedAt": "2026-02-21T10:00:00.000Z",
@@ -177,7 +177,7 @@ silent fallback or hard-blocked extraction after boot.
   "agentCreatedAt": "2026-02-21T10:00:00.000Z",
   "health": { "score": 0.97, "status": "healthy" },
   "update": {
-    "currentVersion": "0.109.x",
+    "currentVersion": "0.124.0",
     "latestVersion": null,
     "updateAvailable": false,
     "pendingRestart": null,
@@ -3174,10 +3174,10 @@ is passed.
 
 ```json
 {
-  "currentVersion": "0.109.x",
-  "latestVersion": "0.110.0",
+  "currentVersion": "0.124.0",
+  "latestVersion": "0.124.1",
   "updateAvailable": true,
-  "releaseUrl": "https://github.com/Signet-AI/signetai/releases/tag/v0.110.0",
+  "releaseUrl": "https://github.com/Signet-AI/signetai/releases/tag/v0.124.1",
   "releaseNotes": "...",
   "publishedAt": "2026-02-20T12:00:00Z",
   "restartRequired": false,
@@ -3247,7 +3247,7 @@ update.
   "success": true,
   "message": "Update installed. Restart daemon to apply.",
   "output": "...",
-  "installedVersion": "0.110.0",
+  "installedVersion": "0.124.1",
   "restartRequired": true
 }
 ```

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -251,7 +251,7 @@ GET /health
   "status": "healthy",
   "uptime": 3600,
   "pid": 12345,
-  "version": "0.109.x",
+  "version": "0.124.0",
   "port": 3850,
   "agentsDir": "/home/user/.agents",
   "db": true,
@@ -277,7 +277,7 @@ GET /api/status
 ```json
 {
   "status": "running",
-  "version": "0.109.x",
+  "version": "0.124.0",
   "pid": 12345,
   "uptime": 3600,
   "startedAt": "2025-02-17T16:00:00.000Z",


### PR DESCRIPTION
## Summary
- Manually audited the requested Signet docs against current implementation artifacts from latest origin/main.
- Corrected stale daemon version examples in docs/API.md and docs/DAEMON.md from old 0.109.x / 0.110.0 values to current 0.124.0-era examples.
- Left docs/specs/INDEX.md and docs/specs/dependencies.yaml unchanged because the source-backed spec registry check now passes.

## Evidence checked
- package.json
- platform/daemon/package.json
- surfaces/cli/package.json
- dist/signetai/package.json
- platform/daemon/src/routes/health.ts
- platform/daemon/src/routes/pipeline-routes.ts
- platform/daemon/src/routes/state.ts
- scripts/spec-deps-check.ts
- scripts/bench-memory.ts

## Checks
- bun scripts/spec-deps-check.ts
- bun scripts/sync-root-docs.ts --check
- bun scripts/bench-memory.ts --dry-run --port 3850 --limit 1
- git diff --check

## Notes
- Biome markdown check was not available because node_modules/.bin/biome is absent in this worktree.
