### PR TITLE
fix(inference): route aggregate recall through synthesis

### DIFF
--- a/platform/core/src/routing.test.ts
+++ b/platform/core/src/routing.test.ts
@@ -444,6 +444,37 @@ describe("inference config + decision engine", () => {
 		expect(localCompatible.targets["legacy-synthesis"]?.account).toBeUndefined();
 	});
 
+	it("parses OpenRouter reasoning controls on explicit targets", () => {
+		const parsed = parseRoutingConfig({
+			inference: {
+				targets: {
+					mercury: {
+						executor: "openrouter",
+						account: "openrouter-api",
+						openrouter: {
+							reasoning: {
+								enabled: false,
+								max_tokens: 0,
+							},
+						},
+						models: {
+							default: {
+								model: "inception/mercury-2",
+							},
+						},
+					},
+				},
+			},
+		});
+
+		expect(parsed.ok).toBe(true);
+		if (!parsed.ok) return;
+		expect(parsed.value.targets.mercury?.openrouter?.reasoning).toEqual({
+			enabled: false,
+			maxTokens: 0,
+		});
+	});
+
 	it("does not allow explicit target overrides outside the agent roster", () => {
 		const parsed = parseRoutingConfig({
 			inference: {

--- a/platform/core/src/routing.ts
+++ b/platform/core/src/routing.ts
@@ -80,6 +80,15 @@ export interface RoutingModelConfig {
 	readonly averageLatencyMs?: number;
 }
 
+export interface RoutingOpenRouterReasoningConfig {
+	readonly enabled?: boolean;
+	readonly maxTokens?: number;
+}
+
+export interface RoutingOpenRouterConfig {
+	readonly reasoning?: RoutingOpenRouterReasoningConfig;
+}
+
 export type RoutingAcpxPermissionMode = "inherit" | "deny-all" | "approve-reads" | "approve-all";
 export type RoutingAcpxHooksMode = "inherit" | "disabled" | "enabled";
 export type RoutingAcpxTerminalMode = "inherit" | "disabled" | "enabled";
@@ -112,6 +121,7 @@ export interface RoutingTargetConfig {
 	readonly endpoint?: string;
 	readonly command?: PipelineCommandConfig;
 	readonly acpx?: RoutingAcpxConfig;
+	readonly openrouter?: RoutingOpenRouterConfig;
 	readonly privacy?: RoutingPrivacyTier;
 	readonly models: Readonly<Record<string, RoutingModelConfig>>;
 }
@@ -273,6 +283,11 @@ function asBool(value: unknown): boolean | undefined {
 
 function asPositiveInt(value: unknown): number | undefined {
 	if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return undefined;
+	return Math.floor(value);
+}
+
+function asNonNegativeInt(value: unknown): number | undefined {
+	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return undefined;
 	return Math.floor(value);
 }
 
@@ -553,6 +568,20 @@ function parseAcpxConfig(raw: unknown): RoutingAcpxConfig | undefined {
 	};
 }
 
+function parseOpenRouterConfig(raw: unknown): RoutingOpenRouterConfig | undefined {
+	if (!isRecord(raw)) return undefined;
+	const nested = isRecord(raw.openrouter) ? raw.openrouter : raw;
+	const reasoningRaw = isRecord(nested.reasoning) ? nested.reasoning : undefined;
+	if (!reasoningRaw) return undefined;
+	const enabled = asBool(reasoningRaw.enabled);
+	const maxTokens = asNonNegativeInt(reasoningRaw.maxTokens ?? reasoningRaw.max_tokens);
+	const reasoning = {
+		...(enabled !== undefined ? { enabled } : {}),
+		...(maxTokens !== undefined ? { maxTokens } : {}),
+	};
+	return Object.keys(reasoning).length > 0 ? { reasoning } : undefined;
+}
+
 function parseTargetConfig(raw: unknown): RoutingTargetConfig | null {
 	if (!isRecord(raw)) return null;
 	const executor = asString(raw.executor);
@@ -567,6 +596,7 @@ function parseTargetConfig(raw: unknown): RoutingTargetConfig | null {
 	if (Object.keys(models).length === 0) return null;
 	const acpx = executor === "acpx" ? parseAcpxConfig(raw) : undefined;
 	if (executor === "acpx" && !acpx) return null;
+	const openrouter = executor === "openrouter" ? parseOpenRouterConfig(raw) : undefined;
 	return {
 		kind: (() => {
 			const parsed = asString(raw.kind);
@@ -580,6 +610,7 @@ function parseTargetConfig(raw: unknown): RoutingTargetConfig | null {
 		endpoint: asString(raw.endpoint ?? raw.baseUrl ?? raw.base_url),
 		command: parseCommandConfig(raw.command),
 		acpx,
+		openrouter,
 		privacy: asRoutingPrivacyTier(raw.privacy, inferTargetPrivacy(executor)),
 		models,
 	};

--- a/platform/daemon/src/aggregate-recall.test.ts
+++ b/platform/daemon/src/aggregate-recall.test.ts
@@ -196,7 +196,7 @@ describe("aggregateRecall", () => {
 		);
 
 		expect(calls).toEqual(["what happened", "follow up one", "follow up two"]);
-		expect(router.calls.map((call) => call.operation)).toEqual(["tool_planning", "tool_planning"]);
+		expect(router.calls.map((call) => call.operation)).toEqual(["session_synthesis", "session_synthesis"]);
 		expect(router.opts.map((opts) => opts.acpxHooks)).toEqual(["disabled", "disabled"]);
 		expect(router.prompts[1]).toContain("one concise atomic memory note");
 		expect(router.prompts[1]).toContain("not as a direct reply");

--- a/platform/daemon/src/aggregate-recall.ts
+++ b/platform/daemon/src/aggregate-recall.ts
@@ -505,7 +505,7 @@ async function planQueries(input: {
 	const result = await input.router.execute(
 		{
 			agentId: input.params.agentId,
-			operation: "tool_planning",
+			operation: "session_synthesis",
 			promptPreview: input.params.query,
 			expectedOutputTokens: 300,
 		},
@@ -539,7 +539,7 @@ async function synthesize(input: {
 	const result = await input.router.execute(
 		{
 			agentId: input.params.agentId,
-			operation: "tool_planning",
+			operation: "session_synthesis",
 			promptPreview: input.params.query,
 			expectedOutputTokens: 700,
 		},

--- a/platform/daemon/src/inference-router.test.ts
+++ b/platform/daemon/src/inference-router.test.ts
@@ -204,4 +204,84 @@ describe("InferenceRouter legacy API credentials", () => {
 			rmSync(dir, { recursive: true, force: true });
 		}
 	});
+
+	it("passes explicit OpenRouter reasoning controls through routed targets", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "signet-router-openrouter-reasoning-"));
+		try {
+			mkdirSync(join(dir, "memory"), { recursive: true });
+			writeFileSync(
+				join(dir, "agent.yaml"),
+				`inference:
+  defaultPolicy: mercury
+  accounts:
+    openrouter-api:
+      kind: api
+      providerFamily: openrouter
+      credentialRef: OPENROUTER_API_KEY
+  targets:
+    mercury:
+      executor: openrouter
+      account: openrouter-api
+      openrouter:
+        reasoning:
+          enabled: false
+          max_tokens: 0
+      models:
+        default:
+          model: inception/mercury-2
+          reasoning: medium
+  policies:
+    mercury:
+      mode: automatic
+      allow:
+        - mercury/default
+      defaultTargets:
+        - mercury/default
+  workloads:
+    sessionSynthesis:
+      target: mercury/default
+      taskClass: session_synthesis
+`,
+			);
+
+			process.env.OPENROUTER_API_KEY = "test-openrouter-key";
+			let requestBody: Record<string, unknown> | null = null;
+			globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+				const url = String(input);
+				if (url.endsWith("/chat/completions") && typeof init?.body === "string") {
+					const parsed: unknown = JSON.parse(init.body);
+					if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+						requestBody = parsed as Record<string, unknown>;
+					}
+				}
+				if (url.endsWith("/models")) {
+					return Promise.resolve(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+				}
+				return Promise.resolve(
+					new Response(JSON.stringify({ choices: [{ message: { content: "mercury answer" } }] }), {
+						status: 200,
+					}),
+				);
+			}) as unknown as typeof fetch;
+
+			const router = getOrCreateInferenceRouter(dir);
+			const result = await router.execute(
+				{
+					operation: "session_synthesis",
+					promptPreview: "aggregate recall",
+					expectedOutputTokens: 64,
+				},
+				"Summarize evidence",
+				{ maxTokens: 64, timeoutMs: 1000 },
+			);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.text).toBe("mercury answer");
+			expect(result.value.decision.targetRef).toBe("mercury/default");
+			expect(requestBody?.reasoning).toEqual({ enabled: false, max_tokens: 0 });
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
 });

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -523,6 +523,7 @@ export class InferenceRouter {
 						model: model.model,
 						apiKey: credential,
 						baseUrl: target.endpoint ?? "https://openrouter.ai/api/v1",
+						reasoning: target.openrouter?.reasoning,
 						referer: process.env.OPENROUTER_HTTP_REFERER,
 						title: process.env.OPENROUTER_TITLE,
 					});

--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -2402,6 +2402,25 @@ describe("createOpenRouterProvider", () => {
 		expect(h.get("X-Title")).toBe("Signet");
 	});
 
+	it("passes OpenRouter reasoning controls in chat completion requests", async () => {
+		let requestBody: Record<string, unknown> | null = null;
+		mockFetch(async (_url, init) => {
+			requestBody = parseJsonObjectBody(init?.body);
+			return Response.json({
+				choices: [{ message: { content: "ok" } }],
+			});
+		});
+
+		const provider = createOpenRouterProvider({
+			model: "inception/mercury-2",
+			apiKey: "sk-or-test",
+			reasoning: { enabled: false, maxTokens: 0 },
+		});
+		await provider.generate("test");
+
+		expect(requestBody?.reasoning).toEqual({ enabled: false, max_tokens: 0 });
+	});
+
 	it("generate() throws timeout on slow responses", async () => {
 		mockFetch((_url, init) => {
 			return new Promise((_resolve, reject) => {

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -2183,6 +2183,10 @@ export interface OpenRouterProviderConfig {
 	readonly maxRetries: number;
 	readonly referer?: string;
 	readonly title?: string;
+	readonly reasoning?: {
+		readonly enabled?: boolean;
+		readonly maxTokens?: number;
+	};
 }
 
 const DEFAULT_OPENROUTER_CONFIG: OpenRouterProviderConfig = {
@@ -2193,6 +2197,7 @@ const DEFAULT_OPENROUTER_CONFIG: OpenRouterProviderConfig = {
 	maxRetries: 2,
 	referer: undefined,
 	title: undefined,
+	reasoning: undefined,
 };
 
 interface OpenRouterChoice {
@@ -2239,6 +2244,14 @@ export function createOpenRouterProvider(config?: Partial<OpenRouterProviderConf
 			model: cfg.model,
 			messages: [{ role: "user", content: prompt }],
 			max_tokens: maxTokens,
+			...(cfg.reasoning
+				? {
+						reasoning: {
+							...(cfg.reasoning.enabled !== undefined ? { enabled: cfg.reasoning.enabled } : {}),
+							...(cfg.reasoning.maxTokens !== undefined ? { max_tokens: cfg.reasoning.maxTokens } : {}),
+						},
+					}
+				: {}),
 		});
 
 		return httpProviderCall<{ text: string; usage: OpenRouterUsage | null }>(


### PR DESCRIPTION
## Summary
- routes aggregate recall planning and final synthesis through the existing `session_synthesis` workload instead of generic `tool_planning`
- adds OpenRouter target-level reasoning controls so Mercury can disable hidden reasoning budget for synthesis-style calls
- covers parser, provider request body, router propagation, and aggregate recall operation routing with tests

## Test Plan
- `bun test platform/daemon/src/aggregate-recall.test.ts platform/daemon/src/inference-router.test.ts platform/core/src/routing.test.ts`
- `bun test platform/daemon/src/pipeline/provider.test.ts --test-name-pattern OpenRouter`
- `bun run build:core`
- `bun run --filter '@signet/core' typecheck`
- `cd platform/daemon && bun run build.ts`

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)
- [x] No database/schema migration required
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Rollback/compatibility: remove the optional `openrouter.reasoning` target config and aggregate recall falls back to the existing session synthesis workload behavior. No persisted data shape changes.
