### PR TITLE
fix(recall): surface aggregate usage and credit fallback

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1343,6 +1343,11 @@ When aggregate synthesis cannot complete, the response is a no-hit recall
 shape with `results: []` and `aggregate.stoppedReason` set to `no_evidence`,
 `router_unavailable`, or `synthesis_failed`.
 
+When the routed inference provider reports token or billing metadata,
+`aggregate.usage` includes planning/synthesis totals plus per-stage target,
+attempt, fallback, token, duration, and cost fields. Missing provider usage is
+reported as `null` rather than estimated.
+
 Successful aggregate responses include aggregate metadata:
 
 ```json
@@ -1354,7 +1359,29 @@ Successful aggregate responses include aggregate metadata:
     "budget": "small",
     "queries": ["user preferences for editor"],
     "sourceMemoryIds": ["source-memory-id"],
-    "stoppedReason": "complete"
+    "stoppedReason": "complete",
+    "usage": {
+      "inputTokens": 534,
+      "outputTokens": 84,
+      "cacheReadTokens": 128,
+      "cacheCreationTokens": null,
+      "totalCost": 0.00018,
+      "totalDurationMs": 812,
+      "stages": [
+        {
+          "name": "planning",
+          "targetRef": "recall-openrouter-mercury/default",
+          "attemptCount": 1,
+          "fallbackCount": 0,
+          "inputTokens": 142,
+          "outputTokens": 28,
+          "cacheReadTokens": 64,
+          "cacheCreationTokens": null,
+          "totalCost": 0.00005,
+          "totalDurationMs": 310
+        }
+      ]
+    }
   }
 }
 ```

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -133,6 +133,7 @@ const aggregate = await signet.recall("what did we decide about onboarding?", {
 });
 // aggregate.results[0] — synthesized aggregate row when evidence exists
 // aggregate.aggregate?.queries — recall queries used during aggregation
+// aggregate.aggregate?.usage — provider-reported token/cost totals when available
 // aggregate.meta.timings?.stages — aggregate planning/synthesis timings
 ```
 

--- a/libs/sdk/src/index.ts
+++ b/libs/sdk/src/index.ts
@@ -7,6 +7,8 @@ import { SignetClientP2 } from "./client-p2.js";
 import { SignetClientHelpers, applyRecallMinScore } from "./helpers.js";
 import { SignetTransport } from "./transport.js";
 import type {
+	AggregateRecallUsage,
+	AggregateRecallUsageStage,
 	BatchModifyItemResult,
 	BatchModifyResponse,
 	BitwardenConnectResult,
@@ -1387,6 +1389,8 @@ export type {
 	PluginSurfaceBase,
 	PluginSurfaceSummary,
 	PluginToolSummary,
+	AggregateRecallUsage,
+	AggregateRecallUsageStage,
 	RecallResponse,
 	RecallResult,
 	RecoverResult,

--- a/libs/sdk/src/types.ts
+++ b/libs/sdk/src/types.ts
@@ -74,6 +74,30 @@ export interface AggregateRecallMeta {
 	readonly queries: readonly string[];
 	readonly sourceMemoryIds: readonly string[];
 	readonly stoppedReason: "complete" | "no_evidence" | "router_unavailable" | "synthesis_failed";
+	readonly usage?: AggregateRecallUsage;
+}
+
+export interface AggregateRecallUsage {
+	readonly inputTokens: number | null;
+	readonly outputTokens: number | null;
+	readonly cacheReadTokens: number | null;
+	readonly cacheCreationTokens: number | null;
+	readonly totalCost: number | null;
+	readonly totalDurationMs: number | null;
+	readonly stages: readonly AggregateRecallUsageStage[];
+}
+
+export interface AggregateRecallUsageStage {
+	readonly name: "planning" | "synthesis";
+	readonly targetRef: string | null;
+	readonly attemptCount: number;
+	readonly fallbackCount: number;
+	readonly inputTokens: number | null;
+	readonly outputTokens: number | null;
+	readonly cacheReadTokens: number | null;
+	readonly cacheCreationTokens: number | null;
+	readonly totalCost: number | null;
+	readonly totalDurationMs: number | null;
 }
 
 export interface RecallEntityAttribute {

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -151,6 +151,8 @@ export {
 	withHookRecallCompat,
 } from "./recall";
 export type {
+	AggregateRecallUsage,
+	AggregateRecallUsageStage,
 	RecallMeta,
 	RecallPartitionableRow,
 	RecallPayload,

--- a/platform/core/src/recall.ts
+++ b/platform/core/src/recall.ts
@@ -44,6 +44,30 @@ export interface AggregateRecallMeta {
 	readonly queries: readonly string[];
 	readonly sourceMemoryIds: readonly string[];
 	readonly stoppedReason: "complete" | "no_evidence" | "router_unavailable" | "synthesis_failed";
+	readonly usage?: AggregateRecallUsage;
+}
+
+export interface AggregateRecallUsage {
+	readonly inputTokens: number | null;
+	readonly outputTokens: number | null;
+	readonly cacheReadTokens: number | null;
+	readonly cacheCreationTokens: number | null;
+	readonly totalCost: number | null;
+	readonly totalDurationMs: number | null;
+	readonly stages: readonly AggregateRecallUsageStage[];
+}
+
+export interface AggregateRecallUsageStage {
+	readonly name: "planning" | "synthesis";
+	readonly targetRef: string | null;
+	readonly attemptCount: number;
+	readonly fallbackCount: number;
+	readonly inputTokens: number | null;
+	readonly outputTokens: number | null;
+	readonly cacheReadTokens: number | null;
+	readonly cacheCreationTokens: number | null;
+	readonly totalCost: number | null;
+	readonly totalDurationMs: number | null;
 }
 
 export interface RecallPayload {

--- a/platform/daemon/src/aggregate-recall.test.ts
+++ b/platform/daemon/src/aggregate-recall.test.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { RouteRequest, RouterResult } from "@signet/core";
+import type { RouteRequest } from "@signet/core";
 import { type AggregateInferenceRouter, InvalidAggregateRecallBudgetError, aggregateRecall } from "./aggregate-recall";
 import { normalizeAndHashContent } from "./content-normalization";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
@@ -97,17 +97,38 @@ class StaticRouter implements AggregateInferenceRouter {
 			readonly refresh?: boolean;
 			readonly acpxHooks?: "disabled" | "inherit";
 		},
-	): Promise<RouterResult<{ readonly text: string }>> {
+	): ReturnType<AggregateInferenceRouter["execute"]> {
 		this.calls.push(request);
 		this.prompts.push(prompt);
 		this.opts.push(opts ?? {});
+		const callNumber = this.calls.length;
 		return {
 			ok: true,
 			value: {
-				text:
-					this.calls.length === 1
-						? JSON.stringify({ queries: ["follow up one", "follow up two"] })
-						: this.synthesisText,
+				text: callNumber === 1 ? JSON.stringify({ queries: ["follow up one", "follow up two"] }) : this.synthesisText,
+				usage: {
+					inputTokens: callNumber * 10,
+					outputTokens: callNumber,
+					cacheReadTokens: callNumber,
+					cacheCreationTokens: null,
+					totalCost: callNumber / 1000,
+					totalDurationMs: callNumber * 100,
+				},
+				attempts: [
+					{
+						targetRef: "test-router/default",
+						ok: true,
+						durationMs: callNumber * 100,
+						usage: {
+							inputTokens: callNumber * 10,
+							outputTokens: callNumber,
+							cacheReadTokens: callNumber,
+							cacheCreationTokens: null,
+							totalCost: callNumber / 1000,
+							totalDurationMs: callNumber * 100,
+						},
+					},
+				],
 			},
 		};
 	}
@@ -136,7 +157,7 @@ describe("aggregateRecall", () => {
 		closeDbAccessor();
 		globalThis.fetch = originalFetch;
 		if (originalOpenAiApiKey === undefined) {
-			delete process.env.OPENAI_API_KEY;
+			Reflect.deleteProperty(process.env, "OPENAI_API_KEY");
 		} else {
 			process.env.OPENAI_API_KEY = originalOpenAiApiKey;
 		}
@@ -212,6 +233,29 @@ describe("aggregateRecall", () => {
 			deduped: false,
 			sourceMemoryIds: ["mem-1", "mem-2", "mem-3"],
 			stoppedReason: "complete",
+			usage: {
+				inputTokens: 30,
+				outputTokens: 3,
+				cacheReadTokens: 3,
+				totalCost: 0.003,
+				totalDurationMs: 300,
+				stages: [
+					{
+						name: "planning",
+						targetRef: "test-router/default",
+						attemptCount: 1,
+						fallbackCount: 0,
+						inputTokens: 10,
+					},
+					{
+						name: "synthesis",
+						targetRef: "test-router/default",
+						attemptCount: 1,
+						fallbackCount: 0,
+						inputTokens: 20,
+					},
+				],
+			},
 		});
 		expect(result.meta.timings.stages.map((stage) => stage.name)).toEqual([
 			"aggregate_initial_recall",

--- a/platform/daemon/src/aggregate-recall.ts
+++ b/platform/daemon/src/aggregate-recall.ts
@@ -1,11 +1,13 @@
 import { createHash, randomUUID } from "node:crypto";
-import type { RouteRequest, RouterResult } from "@signet/core";
+import type { LlmUsage, RouteRequest, RouterResult } from "@signet/core";
 import { normalizeAndHashContent } from "./content-normalization";
 import { type WriteDb, getDbAccessor } from "./db-accessor";
 import { syncVecDeleteBySourceId, syncVecInsert, vectorToBlob } from "./db-helpers";
 import { logger } from "./logger";
 import type { EmbeddingConfig, ResolvedMemoryConfig } from "./memory-config";
 import {
+	type AggregateRecallUsage,
+	type AggregateRecallUsageStage,
 	type EmbedFn,
 	type RecallParams,
 	type RecallResponse,
@@ -20,6 +22,15 @@ export type AggregateRecallStoppedReason = "complete" | "no_evidence" | "router_
 
 interface AggregateInferenceResult {
 	readonly text: string;
+	readonly usage?: LlmUsage | null;
+	readonly attempts?: readonly AggregateInferenceAttempt[];
+}
+
+interface AggregateInferenceAttempt {
+	readonly targetRef: string;
+	readonly ok: boolean;
+	readonly durationMs: number;
+	readonly usage?: LlmUsage | null;
 }
 
 export interface AggregateInferenceRouter {
@@ -84,6 +95,60 @@ const AGGREGATE_RECALL_TIMING_LOG_THRESHOLD_MS = 1000;
 
 function roundAggregateDuration(ms: number): number {
 	return Math.round(ms * 100) / 100;
+}
+
+function addNullableNumbers(left: number | null, right: number | null): number | null {
+	if (left === null && right === null) return null;
+	return (left ?? 0) + (right ?? 0);
+}
+
+function sumUsage(stages: readonly AggregateRecallUsageStage[]): LlmUsage {
+	return stages.reduce<LlmUsage>(
+		(total, stage) => ({
+			inputTokens: addNullableNumbers(total.inputTokens, stage.inputTokens),
+			outputTokens: addNullableNumbers(total.outputTokens, stage.outputTokens),
+			cacheReadTokens: addNullableNumbers(total.cacheReadTokens, stage.cacheReadTokens),
+			cacheCreationTokens: addNullableNumbers(total.cacheCreationTokens, stage.cacheCreationTokens),
+			totalCost: addNullableNumbers(total.totalCost, stage.totalCost),
+			totalDurationMs: addNullableNumbers(total.totalDurationMs, stage.totalDurationMs),
+		}),
+		{
+			inputTokens: null,
+			outputTokens: null,
+			cacheReadTokens: null,
+			cacheCreationTokens: null,
+			totalCost: null,
+			totalDurationMs: null,
+		},
+	);
+}
+
+function usageStage(
+	name: AggregateRecallUsageStage["name"],
+	result: AggregateInferenceResult,
+): AggregateRecallUsageStage {
+	const okAttempt = result.attempts?.find((attempt) => attempt.ok) ?? null;
+	const usage = result.usage ?? okAttempt?.usage ?? null;
+	return {
+		name,
+		targetRef: okAttempt?.targetRef ?? null,
+		attemptCount: result.attempts?.length ?? 1,
+		fallbackCount: result.attempts?.filter((attempt) => !attempt.ok).length ?? 0,
+		inputTokens: usage?.inputTokens ?? null,
+		outputTokens: usage?.outputTokens ?? null,
+		cacheReadTokens: usage?.cacheReadTokens ?? null,
+		cacheCreationTokens: usage?.cacheCreationTokens ?? null,
+		totalCost: usage?.totalCost ?? null,
+		totalDurationMs: usage?.totalDurationMs ?? okAttempt?.durationMs ?? null,
+	};
+}
+
+function buildAggregateUsage(stages: readonly AggregateRecallUsageStage[]): AggregateRecallUsage | undefined {
+	if (stages.length === 0) return undefined;
+	return {
+		...sumUsage(stages),
+		stages,
+	};
 }
 
 function createAggregateTimingCollector(): {
@@ -491,9 +556,9 @@ async function planQueries(input: {
 	readonly budget: AggregateRecallBudget;
 	readonly maxQueries: number;
 	readonly initialRows: readonly RecallResult[];
-}): Promise<string[]> {
+}): Promise<{ readonly queries: readonly string[]; readonly usage?: AggregateRecallUsageStage }> {
 	const remaining = input.maxQueries - 1;
-	if (remaining <= 0) return [];
+	if (remaining <= 0) return { queries: [] };
 	const prompt = [
 		"Propose focused follow-up memory recall queries.",
 		'Return only JSON with this shape: {"queries":["..."]}.',
@@ -512,14 +577,19 @@ async function planQueries(input: {
 		prompt,
 		{ maxTokens: 300, timeoutMs: 20_000, acpxHooks: "disabled" },
 	);
-	return result.ok ? parsePlannerQueries(result.value.text).slice(0, remaining) : [];
+	return result.ok
+		? {
+				queries: parsePlannerQueries(result.value.text).slice(0, remaining),
+				usage: usageStage("planning", result.value),
+			}
+		: { queries: [] };
 }
 
 async function synthesize(input: {
 	readonly router: AggregateInferenceRouter;
 	readonly params: RecallParams;
 	readonly evidence: readonly RecallResult[];
-}): Promise<string | null> {
+}): Promise<{ readonly answer: string | null; readonly usage?: AggregateRecallUsageStage }> {
 	const prompt = [
 		"Write one concise atomic memory note from the memory evidence below.",
 		"Use only the evidence.",
@@ -546,9 +616,12 @@ async function synthesize(input: {
 		prompt,
 		{ maxTokens: 700, timeoutMs: 30_000, acpxHooks: "disabled" },
 	);
-	if (!result.ok) return null;
+	if (!result.ok) return { answer: null };
 	const text = result.value.text.trim();
-	return text.length > 0 ? text : null;
+	return {
+		answer: text.length > 0 ? text : null,
+		usage: usageStage("synthesis", result.value),
+	};
 }
 
 export async function aggregateRecall(
@@ -563,8 +636,10 @@ export async function aggregateRecall(
 	const log = deps.logger ?? logger;
 	const ingestEnvelope = deps.ingestEnvelope ?? txIngestEnvelope;
 	const timings = createAggregateTimingCollector();
+	const usageStages: AggregateRecallUsageStage[] = [];
 	const finish = (response: RecallResponse): RecallResponse => {
 		const recallTimings = timings.finish();
+		const usage = buildAggregateUsage(usageStages);
 		if (recallTimings.totalMs >= AGGREGATE_RECALL_TIMING_LOG_THRESHOLD_MS) {
 			log.warn("memory", "Aggregate recall stage timings", {
 				agentId: params.agentId ?? "default",
@@ -574,6 +649,13 @@ export async function aggregateRecall(
 				resultCount: response.meta.totalReturned,
 				totalMs: recallTimings.totalMs,
 				stages: recallTimings.stages,
+				...(usage
+					? {
+							llmInputTokens: usage.inputTokens,
+							llmOutputTokens: usage.outputTokens,
+							llmTotalCost: usage.totalCost,
+						}
+					: {}),
 			});
 		}
 		return {
@@ -582,6 +664,12 @@ export async function aggregateRecall(
 				...response.meta,
 				timings: recallTimings,
 			},
+			aggregate: response.aggregate
+				? {
+						...response.aggregate,
+						...(usage ? { usage } : {}),
+					}
+				: response.aggregate,
 		};
 	};
 	const first = await timings.timeAsync("aggregate_initial_recall", () => recall(params, cfg, deps.embedFn));
@@ -608,7 +696,8 @@ export async function aggregateRecall(
 			initialRows: first.results,
 		}),
 	);
-	const queries = uniqueQueries(params.query, planned, maxQueries);
+	const queries = uniqueQueries(params.query, planned.queries, maxQueries);
+	if (planned.usage) usageStages.push(planned.usage);
 	const followupQueries = queries.slice(1);
 	const followupRecalls =
 		followupQueries.length === 0
@@ -636,9 +725,11 @@ export async function aggregateRecall(
 		return finish(emptyAggregateResponse(params, budget, queries, [], "no_evidence"));
 	}
 
-	const answer = await timings.timeAsync("aggregate_synthesis", () =>
+	const synthesized = await timings.timeAsync("aggregate_synthesis", () =>
 		synthesize({ router: deps.router, params, evidence }),
 	);
+	if (synthesized.usage) usageStages.push(synthesized.usage);
+	const answer = synthesized.answer;
 	if (!answer) {
 		return finish(emptyAggregateResponse(params, budget, queries, sourceMemoryIds, "synthesis_failed"));
 	}

--- a/platform/daemon/src/inference-api.test.ts
+++ b/platform/daemon/src/inference-api.test.ts
@@ -319,7 +319,15 @@ interface FakeOpenAiServer {
 }
 
 function startFakeOpenAiServer(
-	mode: "success" | "slow_success" | "slow_stream" | "error" | "rate_limit" | "unauthorized" | "secret_error",
+	mode:
+		| "success"
+		| "slow_success"
+		| "slow_stream"
+		| "error"
+		| "rate_limit"
+		| "payment_required"
+		| "unauthorized"
+		| "secret_error",
 ): FakeOpenAiServer {
 	const server = Bun.serve({
 		port: 0,
@@ -337,6 +345,9 @@ function startFakeOpenAiServer(
 					const payload = typeof body === "object" && body !== null ? (body as Record<string, unknown>) : {};
 					if (mode === "rate_limit") {
 						return new Response("rate limited", { status: 429 });
+					}
+					if (mode === "payment_required") {
+						return new Response("insufficient credits", { status: 402 });
 					}
 					if (mode === "unauthorized") {
 						return new Response("unauthorized", { status: 401 });
@@ -1071,6 +1082,72 @@ describe("inference session and quota state", () => {
 			);
 			expect(JSON.stringify(blocked["primary/fast"])).toContain("rate_limited");
 			expect(JSON.stringify(blocked["secondary/deep"])).toContain("rate_limited");
+		} finally {
+			resetInferenceRouterForTests();
+			primary.stop();
+			secondary.stop();
+			backup.stop();
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("marks exhausted API credits as rate limited and uses configured fallbacks", async () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-inference-credit-state-"));
+		const primary = startFakeOpenAiServer("payment_required");
+		const secondary = startFakeOpenAiServer("success");
+		const backup = startFakeOpenAiServer("success");
+		writeAccountFallbackRoutingFixture(root, {
+			primary: primary.url,
+			secondary: secondary.url,
+			backup: backup.url,
+		});
+		try {
+			const { app, secret } = createInferenceTestApp(root);
+			const adminToken = createToken(secret, { sub: "admin", scope: {}, role: "admin" }, 60);
+
+			const executeRes = await app.request(
+				new Request("http://localhost/api/inference/execute", {
+					method: "POST",
+					headers: {
+						Authorization: `Bearer ${adminToken}`,
+						"content-type": "application/json",
+					},
+					body: JSON.stringify({
+						operation: "interactive",
+						prompt: "hello there",
+					}),
+				}),
+			);
+			expect(executeRes.status).toBe(200);
+			const executeBody = (await executeRes.json()) as {
+				text?: string;
+				attempts?: Array<{ targetRef?: string; ok?: boolean; error?: string }>;
+			};
+			expect(executeBody.text).toBe("hello");
+			expect(executeBody.attempts?.map((attempt) => attempt.targetRef)).toEqual([
+				"primary/fast",
+				"secondary/deep",
+				"backup/safe",
+			]);
+			expect(executeBody.attempts?.[0]?.ok).toBe(false);
+			expect(executeBody.attempts?.[0]?.error).toContain("402");
+			expect(executeBody.attempts?.[1]?.ok).toBe(false);
+			expect(executeBody.attempts?.[2]?.ok).toBe(true);
+
+			const statusRes = await app.request(
+				new Request("http://localhost/api/inference/status", {
+					headers: { Authorization: `Bearer ${adminToken}` },
+				}),
+			);
+			expect(statusRes.status).toBe(200);
+			const statusBody = (await statusRes.json()) as {
+				runtimeSnapshot?: {
+					targets?: Record<string, { accountState?: string }>;
+				};
+			};
+			expect(statusBody.runtimeSnapshot?.targets?.["primary/fast"]?.accountState).toBe("rate_limited");
+			expect(statusBody.runtimeSnapshot?.targets?.["secondary/deep"]?.accountState).toBe("rate_limited");
+			expect(statusBody.runtimeSnapshot?.targets?.["backup/safe"]?.accountState).toBe("ready");
 		} finally {
 			resetInferenceRouterForTests();
 			primary.stop();

--- a/platform/daemon/src/inference-router.ts
+++ b/platform/daemon/src/inference-router.ts
@@ -367,7 +367,14 @@ export class InferenceRouter {
 			lower.includes("rate-limit") ||
 			lower.includes("too many requests") ||
 			lower.includes("quota") ||
-			lower.includes("usage limit")
+			lower.includes("usage limit") ||
+			lower.includes("http 402") ||
+			lower.includes("payment required") ||
+			lower.includes("insufficient credit") ||
+			lower.includes("insufficient credits") ||
+			lower.includes("credit balance") ||
+			lower.includes("billing") ||
+			lower.includes("balance")
 		) {
 			return {
 				state: {

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -13,7 +13,7 @@
  */
 
 import { createHash } from "node:crypto";
-import { vectorSearch } from "@signet/core";
+import { type LlmUsage, vectorSearch } from "@signet/core";
 import { getDbAccessor } from "./db-accessor";
 import { getLlmProvider } from "./llm";
 import { logger } from "./logger";
@@ -120,6 +120,7 @@ export interface RecallResponse {
 		queries: readonly string[];
 		sourceMemoryIds: readonly string[];
 		stoppedReason: "complete" | "no_evidence" | "router_unavailable" | "synthesis_failed";
+		usage?: AggregateRecallUsage;
 	};
 	entities?: Array<{
 		name: string;
@@ -129,6 +130,17 @@ export interface RecallResponse {
 			attributes: Array<{ content: string; status: string; importance: number }>;
 		}>;
 	}>;
+}
+
+export interface AggregateRecallUsage extends LlmUsage {
+	readonly stages: readonly AggregateRecallUsageStage[];
+}
+
+export interface AggregateRecallUsageStage extends LlmUsage {
+	readonly name: "planning" | "synthesis";
+	readonly targetRef: string | null;
+	readonly attemptCount: number;
+	readonly fallbackCount: number;
 }
 
 export type EmbedFn = (text: string, cfg: EmbeddingConfig) => Promise<number[] | null>;


### PR DESCRIPTION
## Summary
- expose provider-reported aggregate recall LLM usage on `aggregate.usage`, including planning/synthesis stage attempts and fallback counts
- classify OpenAI-compatible/OpenRouter 402, billing, balance, and insufficient-credit failures as temporary quota/rate-limit account state so configured fallbacks are used
- document aggregate usage metadata in API and SDK docs

## PR Readiness
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Verification
- `bun test platform/daemon/src/aggregate-recall.test.ts platform/daemon/src/inference-api.test.ts --test-name-pattern "credits|rate limited|synthesizes, saves"`
- `bun test platform/daemon/src/aggregate-recall.test.ts`
- `bun test platform/daemon/src/inference-api.test.ts --test-name-pattern "credits|rate limited"`
- `bun run build:core`
- `bun run --filter '@signet/core' typecheck`
- `cd platform/daemon && bun run build.ts`
- `bun run --filter '@signet/sdk' build`
- `bunx biome check platform/daemon/src/aggregate-recall.ts platform/daemon/src/aggregate-recall.test.ts platform/daemon/src/inference-router.ts platform/daemon/src/inference-api.test.ts platform/daemon/src/memory-search.ts platform/core/src/recall.ts platform/core/src/index.ts libs/sdk/src/types.ts libs/sdk/src/index.ts`

Note: Biome reports existing `any` warnings in `platform/daemon/src/memory-search.ts`.
