### PR TITLE
refactor(sources): add provider-neutral source substrate

### DIFF
--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -239,8 +239,24 @@ export type {
 	SignetSourceEntry,
 	SignetSourceKind,
 	SignetSourceMode,
+	SignetSourceProviderSettings,
 	SignetSourcesConfig,
 } from "./sources-config";
+export {
+	LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE,
+	SOURCE_CHUNK_SOURCE_TYPE,
+} from "./source-substrate";
+export type {
+	SourceArtifactRecord,
+	SourceCheckpointRecord,
+	SourceContainerRecord,
+	SourceFailureState,
+	SourceProviderKind,
+	SourceRecordKind,
+	SourceRelationRecord,
+	SourceSyncResult,
+	SourceSyncStatus,
+} from "./source-substrate";
 
 // Portable export/import
 export {

--- a/platform/core/src/migrations/075-memory-artifact-source-provenance.ts
+++ b/platform/core/src/migrations/075-memory-artifact-source-provenance.ts
@@ -1,0 +1,22 @@
+import type { MigrationDb } from "./index";
+
+function addColumnIfMissing(db: MigrationDb, table: string, column: string, definition: string): void {
+	const cols = db.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<Record<string, unknown>>;
+	if (cols.some((col) => col.name === column)) return;
+	db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+}
+
+export function up(db: MigrationDb): void {
+	addColumnIfMissing(db, "memory_artifacts", "source_id", "TEXT");
+	addColumnIfMissing(db, "memory_artifacts", "source_root", "TEXT");
+	addColumnIfMissing(db, "memory_artifacts", "source_external_id", "TEXT");
+	addColumnIfMissing(db, "memory_artifacts", "source_parent_path", "TEXT");
+	addColumnIfMissing(db, "memory_artifacts", "source_meta_json", "TEXT");
+
+	db.exec(`
+		CREATE INDEX IF NOT EXISTS idx_memory_artifacts_agent_source
+			ON memory_artifacts(agent_id, source_id, source_external_id);
+		CREATE INDEX IF NOT EXISTS idx_memory_artifacts_agent_source_root
+			ON memory_artifacts(agent_id, source_id, source_root);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -80,6 +80,7 @@ import { up as epistemicAssertions } from "./071-epistemic-assertions";
 import { up as agentScopedIdempotencyKey } from "./072-agent-scoped-idempotency-key";
 import { up as recallContextDedupe } from "./073-recall-context-dedupe";
 import { up as aggregateMemoryLinks } from "./074-aggregate-memory-links";
+import { up as memoryArtifactSourceProvenance } from "./075-memory-artifact-source-provenance";
 
 // -- Public interface consumed by Database.init() --
 
@@ -700,6 +701,20 @@ export const MIGRATIONS: readonly Migration[] = [
 		up: aggregateMemoryLinks,
 		artifacts: {
 			tables: ["aggregate_memory_sources"],
+		},
+	},
+	{
+		version: 75,
+		name: "memory-artifact-source-provenance",
+		up: memoryArtifactSourceProvenance,
+		artifacts: {
+			columns: [
+				{ table: "memory_artifacts", column: "source_id" },
+				{ table: "memory_artifacts", column: "source_root" },
+				{ table: "memory_artifacts", column: "source_external_id" },
+				{ table: "memory_artifacts", column: "source_parent_path" },
+				{ table: "memory_artifacts", column: "source_meta_json" },
+			],
 		},
 	},
 ];

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -691,6 +691,23 @@ describe("migration framework", () => {
 		expect(indexes.map((row) => row.name)).toContain("idx_memory_artifacts_agent_deleted");
 	});
 
+	test("migration 075 adds provider-neutral source provenance to memory_artifacts", () => {
+		db = createFreshDb();
+		runMigrations(db);
+
+		const cols = db.query("PRAGMA table_info(memory_artifacts)").all() as Array<{ name: string }>;
+		const colNames = cols.map((col) => col.name);
+		expect(colNames).toContain("source_id");
+		expect(colNames).toContain("source_root");
+		expect(colNames).toContain("source_external_id");
+		expect(colNames).toContain("source_parent_path");
+		expect(colNames).toContain("source_meta_json");
+
+		const indexes = db.query("PRAGMA index_list(memory_artifacts)").all() as Array<{ name: string }>;
+		expect(indexes.map((row) => row.name)).toContain("idx_memory_artifacts_agent_source");
+		expect(indexes.map((row) => row.name)).toContain("idx_memory_artifacts_agent_source_root");
+	});
+
 	test("migration 070 adds ontology control-plane status and version state safely", () => {
 		db = createFreshDb();
 		db.exec(`

--- a/platform/core/src/source-substrate.ts
+++ b/platform/core/src/source-substrate.ts
@@ -1,0 +1,69 @@
+export const SOURCE_CHUNK_SOURCE_TYPE = "source_chunk";
+export const LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE = "source_obsidian_chunk";
+
+export type SourceProviderKind = "obsidian" | (string & {});
+export type SourceRecordKind = "artifact" | "container" | "relation" | "checkpoint" | "failure";
+export type SourceSyncStatus = "complete" | "partial" | "failed" | "canceled";
+
+export interface SourceArtifactRecord {
+	readonly sourceId: string;
+	readonly providerKind: SourceProviderKind;
+	readonly externalId: string;
+	readonly path: string;
+	readonly parentPath?: string;
+	readonly title?: string;
+	readonly content: string;
+	readonly contentType: string;
+	readonly capturedAt: string;
+	readonly updatedAt?: string;
+	readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface SourceContainerRecord {
+	readonly sourceId: string;
+	readonly providerKind: SourceProviderKind;
+	readonly externalId: string;
+	readonly path: string;
+	readonly parentPath?: string;
+	readonly title: string;
+	readonly containerType: string;
+	readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface SourceRelationRecord {
+	readonly sourceId: string;
+	readonly providerKind: SourceProviderKind;
+	readonly fromExternalId: string;
+	readonly toExternalId: string;
+	readonly relationType: string;
+	readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface SourceCheckpointRecord {
+	readonly sourceId: string;
+	readonly providerKind: SourceProviderKind;
+	readonly checkpointKey: string;
+	readonly cursor: string;
+	readonly updatedAt: string;
+	readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface SourceFailureState {
+	readonly sourceId: string;
+	readonly providerKind: SourceProviderKind;
+	readonly failedAt: string;
+	readonly recoverable: boolean;
+	readonly message: string;
+	readonly externalId?: string;
+	readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface SourceSyncResult {
+	readonly sourceId: string;
+	readonly providerKind: SourceProviderKind;
+	readonly status: SourceSyncStatus;
+	readonly scanned: number;
+	readonly indexed: number;
+	readonly skipped: number;
+	readonly failures: readonly SourceFailureState[];
+}

--- a/platform/core/src/sources-config.test.ts
+++ b/platform/core/src/sources-config.test.ts
@@ -75,6 +75,27 @@ describe("sources-config", () => {
 		expect(loadSourcesConfig(agentsDir).sources).toHaveLength(1);
 	});
 
+	it("round-trips provider-neutral source settings for future adapters", () => {
+		const agentsDir = tmp();
+		const source = {
+			id: "discord:test",
+			kind: "discord",
+			name: "Discord",
+			root: "discord://workspace",
+			enabled: true,
+			mode: "read-only" as const,
+			createdAt: "2026-01-01T00:00:00.000Z",
+			updatedAt: "2026-01-01T00:00:00.000Z",
+			providerSettings: {
+				guildIds: ["123", "456"],
+				includeThreads: true,
+			},
+		};
+		writeFileSync(getSourcesConfigPath(agentsDir), `${JSON.stringify({ version: 1, sources: [source] })}\n`);
+
+		expect(loadSourcesConfig(agentsDir).sources).toEqual([source]);
+	});
+
 	it("removes a source by id from the config", () => {
 		const agentsDir = tmp();
 		const vault = join(agentsDir, "vault");

--- a/platform/core/src/sources-config.ts
+++ b/platform/core/src/sources-config.ts
@@ -3,8 +3,9 @@ import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writ
 import { homedir } from "node:os";
 import { dirname, resolve } from "node:path";
 
-export type SignetSourceKind = "obsidian";
+export type SignetSourceKind = "obsidian" | (string & {});
 export type SignetSourceMode = "read-only";
+export type SignetSourceProviderSettings = Readonly<Record<string, unknown>>;
 
 export interface SignetSourceEntry {
 	readonly id: string;
@@ -17,6 +18,7 @@ export interface SignetSourceEntry {
 	readonly updatedAt: string;
 	readonly lastIndexedAt?: string;
 	readonly excludeGlobs?: readonly string[];
+	readonly providerSettings?: SignetSourceProviderSettings;
 }
 
 export const DEFAULT_OBSIDIAN_EXCLUDE_GLOBS = [
@@ -272,7 +274,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function isSourceEntry(value: unknown): value is SignetSourceEntry {
 	return (
 		isRecord(value) &&
-		value.kind === "obsidian" &&
+		typeof value.kind === "string" &&
+		value.kind.trim().length > 0 &&
 		typeof value.id === "string" &&
 		typeof value.name === "string" &&
 		typeof value.root === "string" &&
@@ -282,6 +285,20 @@ function isSourceEntry(value: unknown): value is SignetSourceEntry {
 		typeof value.updatedAt === "string" &&
 		(value.lastIndexedAt === undefined || typeof value.lastIndexedAt === "string") &&
 		(value.excludeGlobs === undefined ||
-			(Array.isArray(value.excludeGlobs) && value.excludeGlobs.every((entry) => typeof entry === "string")))
+			(Array.isArray(value.excludeGlobs) && value.excludeGlobs.every((entry) => typeof entry === "string"))) &&
+		(value.providerSettings === undefined || isJsonRecord(value.providerSettings))
 	);
+}
+
+function isJsonRecord(value: unknown): value is SignetSourceProviderSettings {
+	if (!isRecord(value)) return false;
+	return Object.values(value).every(isJsonValue);
+}
+
+function isJsonValue(value: unknown): boolean {
+	if (value === null) return true;
+	if (typeof value === "string" || typeof value === "boolean") return true;
+	if (typeof value === "number") return Number.isFinite(value);
+	if (Array.isArray(value)) return value.every(isJsonValue);
+	return isJsonRecord(value);
 }

--- a/platform/daemon/src/memory-lineage.ts
+++ b/platform/daemon/src/memory-lineage.ts
@@ -535,6 +535,11 @@ function upsertArtifactRowInTx(
 	const rawSourceNodeId = typeof frontmatter.source_node_id === "string" ? frontmatter.source_node_id : null;
 	const sourceNodeId =
 		rawSourceNodeId === NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID && !options.trustNativeMarker ? null : rawSourceNodeId;
+	const sourceId = typeof frontmatter.source_id === "string" ? frontmatter.source_id : null;
+	const sourceRoot = typeof frontmatter.source_root === "string" ? frontmatter.source_root : null;
+	const sourceExternalId = typeof frontmatter.source_external_id === "string" ? frontmatter.source_external_id : null;
+	const sourceParentPath = typeof frontmatter.source_parent_path === "string" ? frontmatter.source_parent_path : null;
+	const sourceMetaJson = typeof frontmatter.source_meta_json === "string" ? frontmatter.source_meta_json : null;
 	const memorySentence = typeof frontmatter.memory_sentence === "string" ? frontmatter.memory_sentence : null;
 	const quality = typeof frontmatter.memory_sentence_quality === "string" ? frontmatter.memory_sentence_quality : null;
 	const sourceSha =
@@ -546,8 +551,9 @@ function upsertArtifactRowInTx(
 			session_key, session_token, project, harness, captured_at,
 			started_at, ended_at, manifest_path, source_node_id,
 			memory_sentence, memory_sentence_quality, content, updated_at,
-			source_mtime_ms
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			source_mtime_ms, source_id, source_root, source_external_id,
+			source_parent_path, source_meta_json
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(agent_id, source_path) DO UPDATE SET
 			source_sha256 = excluded.source_sha256,
 			source_kind = excluded.source_kind,
@@ -566,6 +572,11 @@ function upsertArtifactRowInTx(
 			content = excluded.content,
 			updated_at = excluded.updated_at,
 			source_mtime_ms = excluded.source_mtime_ms,
+			source_id = excluded.source_id,
+			source_root = excluded.source_root,
+			source_external_id = excluded.source_external_id,
+			source_parent_path = excluded.source_parent_path,
+			source_meta_json = excluded.source_meta_json,
 			is_deleted = 0,
 			deleted_at = NULL`,
 	).run(
@@ -588,6 +599,11 @@ function upsertArtifactRowInTx(
 		body,
 		updatedAt,
 		sourceMtimeMs,
+		sourceId,
+		sourceRoot,
+		sourceExternalId,
+		sourceParentPath,
+		sourceMetaJson,
 	);
 }
 
@@ -612,6 +628,11 @@ export function indexExternalMemoryArtifact(input: {
 	readonly sourceMtimeMs: number;
 	readonly capturedAt?: string;
 	readonly project?: string | null;
+	readonly sourceId?: string | null;
+	readonly sourceRoot?: string | null;
+	readonly sourceExternalId?: string | null;
+	readonly sourceParentPath?: string | null;
+	readonly sourceMeta?: Readonly<Record<string, unknown>>;
 }): void {
 	const capturedAt =
 		input.capturedAt ??
@@ -630,6 +651,11 @@ export function indexExternalMemoryArtifact(input: {
 			started_at: capturedAt,
 			ended_at: capturedAt,
 			updated_at: new Date().toISOString(),
+			source_id: input.sourceId ?? null,
+			source_root: input.sourceRoot ?? null,
+			source_external_id: input.sourceExternalId ?? null,
+			source_parent_path: input.sourceParentPath ?? null,
+			source_meta_json: input.sourceMeta ? JSON.stringify(input.sourceMeta) : null,
 			source_node_id: NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID,
 			content_sha256: hashNormalizedBody(input.content),
 			memory_sentence: `Indexed ${input.harness} native memory from ${basename(input.sourcePath)}.`,

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -152,6 +152,45 @@ describe("hybridRecall", () => {
 		}
 	});
 
+	it("returns provider-generic source chunk vector fallback hits", async () => {
+		const now = new Date().toISOString();
+		const vec = unitVector();
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO embeddings (
+					id, content_hash, vector, dimensions, source_type, source_id,
+					chunk_text, created_at, agent_id
+				) VALUES (?, ?, ?, 768, 'source_chunk', ?, ?, ?, 'default')`,
+			).run(
+				"emb-generic-source",
+				"hash-generic-source",
+				vectorBlob(vec),
+				"obsidian:vault:generic.md#overview:1-1:0",
+				"source_id: obsidian:vault\nsource_provider: obsidian\nsource_path: /vault/generic.md\nGeneric source chunk fallback marker.",
+				now,
+			);
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "Generic source chunk fallback marker",
+				keywordQuery: "Generic source chunk fallback marker",
+				limit: 3,
+				agentId: "default",
+				readPolicy: "isolated",
+			},
+			testCfg(),
+			async () => vec,
+		);
+
+		expect(result.results[0]).toMatchObject({
+			source: "source_obsidian",
+			type: "source_chunk",
+			source_path: "/vault/generic.md",
+			supplementary: true,
+		});
+	});
+
 	it("refills capped recall responses after suppressing repeated session rows", async () => {
 		const now = new Date().toISOString();
 		getDbAccessor().withWriteTx((db) => {

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -13,7 +13,12 @@
  */
 
 import { createHash } from "node:crypto";
-import { type LlmUsage, vectorSearch } from "@signet/core";
+import {
+	LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE,
+	SOURCE_CHUNK_SOURCE_TYPE,
+	type LlmUsage,
+	vectorSearch,
+} from "@signet/core";
 import { getDbAccessor } from "./db-accessor";
 import { getLlmProvider } from "./llm";
 import { logger } from "./logger";
@@ -670,6 +675,7 @@ interface NativeArtifactRecallHit {
 interface SourceChunkVectorHit {
 	readonly embeddingId: string;
 	readonly sourceId: string;
+	readonly sourceType: string;
 	readonly sourcePath: string;
 	readonly chunkText: string;
 	readonly score: number;
@@ -714,6 +720,20 @@ function sourcePathFromChunkText(chunkText: string): string {
 	return line?.slice("source_path:".length).trim() ?? "";
 }
 
+function sourceChunkRecallSource(sourceId: string): string {
+	return sourceId.startsWith("obsidian:") ? "source_obsidian" : "source";
+}
+
+function sourceChunkProvider(sourceId: string): string {
+	const separator = sourceId.indexOf(":");
+	return separator > 0 ? sourceId.slice(0, separator) : "source";
+}
+
+function sourceChunkRecallTags(hit: SourceChunkVectorHit): string {
+	const provider = sourceChunkProvider(hit.sourceId);
+	return [provider, "source", hit.sourceType, "vector"].join(",");
+}
+
 function buildSourceChunkVectorHits(
 	queryVec: Float32Array | null,
 	existingSourceIds: ReadonlySet<string>,
@@ -731,14 +751,15 @@ function buildSourceChunkVectorHits(
 		return getDbAccessor().withReadDb((db) => {
 			const rows = db
 				.prepare(
-					`SELECT id, source_id, vector, chunk_text, created_at
+					`SELECT id, source_type, source_id, vector, chunk_text, created_at
 					 FROM embeddings
-					 WHERE source_type = 'source_obsidian_chunk'
+					 WHERE source_type IN (?, ?)
 					   AND vector IS NOT NULL
 					   AND agent_id = ?`,
 				)
-				.all(agentId) as Array<{
+				.all(SOURCE_CHUNK_SOURCE_TYPE, LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE, agentId) as Array<{
 				id: string;
+				source_type: string;
 				source_id: string;
 				vector: Buffer;
 				chunk_text: string;
@@ -751,6 +772,7 @@ function buildSourceChunkVectorHits(
 						{
 							embeddingId: row.id,
 							sourceId: row.source_id,
+							sourceType: row.source_type,
 							sourcePath,
 							chunkText: row.chunk_text,
 							score: cosineSimilarity(
@@ -1907,7 +1929,7 @@ export async function hybridRecall(
 		if (sourceChunkHits.length > 0) {
 			const results = suppressPreviouslyRecalledForSelection(
 				sourceChunkHits.slice(0, fallbackLimit).map((hit): RecallResult => {
-					const content = `[Obsidian vault chunk: ${hit.sourcePath}]\n${hit.chunkText}`;
+					const content = `[Source chunk: ${hit.sourcePath}]\n${hit.chunkText}`;
 					const truncated = content.length > recallTruncate;
 					return {
 						id: `source-chunk:${hit.embeddingId}`,
@@ -1915,14 +1937,14 @@ export async function hybridRecall(
 						content_length: content.length,
 						truncated,
 						score: Math.round(Math.max(0.01, Math.min(1, hit.score)) * 100) / 100,
-						source: "source_obsidian",
+						source: sourceChunkRecallSource(hit.sourceId),
 						source_id: hit.sourceId,
 						session_id: hit.sourceId,
-						type: "source_obsidian_chunk",
-						tags: "obsidian,source,source_obsidian_chunk,vector",
+						type: hit.sourceType,
+						tags: sourceChunkRecallTags(hit),
 						pinned: false,
 						importance: 0.6,
-						who: "obsidian",
+						who: sourceChunkProvider(hit.sourceId),
 						project: hit.project,
 						created_at: hit.createdAt,
 						source_path: hit.sourcePath,
@@ -2081,7 +2103,7 @@ export async function hybridRecall(
 				)
 			: [];
 		const candidates = sourceChunkHits.map((hit): RecallResult => {
-			const content = `[Obsidian vault chunk: ${hit.sourcePath}]\n${hit.chunkText}`;
+			const content = `[Source chunk: ${hit.sourcePath}]\n${hit.chunkText}`;
 			const truncated = content.length > recallTruncate;
 			return {
 				id: `source-chunk:${hit.embeddingId}`,
@@ -2089,14 +2111,14 @@ export async function hybridRecall(
 				content_length: content.length,
 				truncated,
 				score: Math.round(Math.max(0.01, Math.min(1, hit.score)) * 100) / 100,
-				source: "source_obsidian",
+				source: sourceChunkRecallSource(hit.sourceId),
 				source_id: hit.sourceId,
 				session_id: hit.sourceId,
-				type: "source_obsidian_chunk",
-				tags: "obsidian,source,source_obsidian_chunk,vector",
+				type: hit.sourceType,
+				tags: sourceChunkRecallTags(hit),
 				pinned: false,
 				importance: 0.6,
-				who: "obsidian",
+				who: sourceChunkProvider(hit.sourceId),
 				project: hit.project,
 				created_at: hit.createdAt,
 				source_path: hit.sourcePath,

--- a/platform/daemon/src/native-memory-sources.test.ts
+++ b/platform/daemon/src/native-memory-sources.test.ts
@@ -490,16 +490,32 @@ describe("native memory sources", () => {
 
 		const row = getDbAccessor().withReadDb(
 			(db) =>
-				db.prepare("SELECT source_path, source_kind, harness, content FROM memory_artifacts").get() as {
+				db
+					.prepare(
+						`SELECT source_path, source_kind, harness, source_id, source_root,
+						        source_external_id, source_parent_path, source_meta_json, content
+						 FROM memory_artifacts`,
+					)
+					.get() as {
 					source_path: string;
 					source_kind: string;
 					harness: string;
+					source_id: string;
+					source_root: string;
+					source_external_id: string;
+					source_parent_path: string;
+					source_meta_json: string;
 					content: string;
 				},
 		);
 		expect(row.source_path).toBe(file);
 		expect(row.source_kind).toBe("source_obsidian_markdown");
 		expect(row.harness).toBe("obsidian");
+		expect(row.source_id).toStartWith("obsidian:");
+		expect(row.source_root).toBe(root);
+		expect(row.source_external_id).toBe("permanent/Signet.md");
+		expect(row.source_parent_path).toBe("permanent");
+		expect(JSON.parse(row.source_meta_json)).toMatchObject({ provider: "obsidian" });
 		expect(row.content).toContain("Obsidian source knowledge base note");
 	});
 
@@ -561,7 +577,7 @@ describe("native memory sources", () => {
 			embeddings: (
 				db
 					.prepare("SELECT COUNT(*) AS count FROM embeddings WHERE agent_id = ? AND source_type = ?")
-					.get("agent-native", "source_obsidian_chunk") as { count: number }
+					.get("agent-native", "source_chunk") as { count: number }
 			).count,
 		}));
 		expect(rows.entities).toBeGreaterThan(0);
@@ -669,7 +685,7 @@ describe("native memory sources", () => {
 			(db) =>
 				db
 					.prepare(
-						"SELECT source_id, chunk_text FROM embeddings WHERE source_type = 'source_obsidian_chunk' ORDER BY source_id",
+						"SELECT source_id, chunk_text FROM embeddings WHERE source_type = 'source_chunk' ORDER BY source_id",
 					)
 					.all() as Array<{ source_id: string; chunk_text: string }>,
 		);
@@ -796,7 +812,7 @@ describe("native memory sources", () => {
 			chunks: (
 				db
 					.prepare(
-						"SELECT COUNT(*) AS count FROM embeddings WHERE agent_id = ? AND source_type = 'source_obsidian_chunk' AND source_id >= ? AND source_id < ?",
+						"SELECT COUNT(*) AS count FROM embeddings WHERE agent_id = ? AND source_type = 'source_chunk' AND source_id >= ? AND source_id < ?",
 					)
 					.get("agent-native", `${sourceId}:`, `${sourceId}:\uffff`) as { count: number }
 			).count,
@@ -837,7 +853,7 @@ describe("native memory sources", () => {
 			chunks: (
 				db
 					.prepare(
-						"SELECT COUNT(*) AS count FROM embeddings WHERE agent_id = ? AND source_type = 'source_obsidian_chunk' AND source_id >= ? AND source_id < ?",
+						"SELECT COUNT(*) AS count FROM embeddings WHERE agent_id = ? AND source_type = 'source_chunk' AND source_id >= ? AND source_id < ?",
 					)
 					.get("agent-native", `${sourceId}:`, `${sourceId}:\uffff`) as { count: number }
 			).count,

--- a/platform/daemon/src/native-memory-sources.ts
+++ b/platform/daemon/src/native-memory-sources.ts
@@ -1,8 +1,14 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, join, resolve } from "node:path";
-import { DEFAULT_OBSIDIAN_EXCLUDE_GLOBS, loadSourcesConfig, markSourceIndexed } from "@signet/core";
+import { basename, dirname, join, relative, resolve } from "node:path";
+import {
+	DEFAULT_OBSIDIAN_EXCLUDE_GLOBS,
+	LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE,
+	SOURCE_CHUNK_SOURCE_TYPE,
+	loadSourcesConfig,
+	markSourceIndexed,
+} from "@signet/core";
 import { resolveDaemonAgentId } from "./agent-id";
 import { yieldEvery } from "./async-yield";
 import { getDbAccessor } from "./db-accessor";
@@ -10,7 +16,6 @@ import { logger } from "./logger";
 import type { EmbeddingConfig } from "./memory-config";
 import { hashNormalizedBody, indexExternalMemoryArtifact, softDeleteArtifactRowsForPath } from "./memory-lineage";
 import {
-	OBSIDIAN_CHUNK_SOURCE_TYPE,
 	type SourceEmbeddingFetch,
 	buildObsidianSourceChunks,
 	indexObsidianSourceEmbeddings,
@@ -60,6 +65,7 @@ export interface NativeMemoryBridgeOptions {
 	readonly sourceFileDelayMs?: number;
 	readonly sourceCleanupEnabled?: boolean;
 	readonly sourceGraphEnabled?: boolean;
+	readonly shouldContinue?: (source: NativeMemorySource) => boolean;
 	readonly onFileIndexed?: (event: NativeMemoryFileIndexEvent) => void;
 }
 
@@ -236,6 +242,14 @@ function contentFingerprint(content: string): string {
 	return hashNormalizedBody(content);
 }
 
+function normalizedRoot(root: string): string {
+	return resolve(root).replace(/\\/g, "/").replace(/\/$/, "");
+}
+
+function sourceRelativePath(root: string, filePath: string): string {
+	return relative(normalizedRoot(root), filePath.replace(/\\/g, "/")).replace(/\\/g, "/");
+}
+
 function sourceFileDelayMs(source: NativeMemorySource, options: NativeMemoryBridgeOptions): number {
 	if (options.sourceFileDelayMs !== undefined) {
 		return Math.max(0, Math.floor(options.sourceFileDelayMs));
@@ -298,10 +312,15 @@ function obsidianEmbeddingsExist(input: {
 				.prepare(
 					`SELECT source_id FROM embeddings
 					 WHERE agent_id = ?
-					   AND source_type = ?
+					   AND source_type IN (?, ?)
 					   AND source_id IN (${chunks.map(() => "?").join(", ")})`,
 				)
-				.all(input.agentId, OBSIDIAN_CHUNK_SOURCE_TYPE, ...chunks.map((chunk) => chunk.id)) as Array<{
+				.all(
+					input.agentId,
+					SOURCE_CHUNK_SOURCE_TYPE,
+					LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE,
+					...chunks.map((chunk) => chunk.id),
+				) as Array<{
 				source_id: string;
 			}>;
 			return new Set(rows.map((row) => row.source_id)).size === chunks.length;
@@ -312,8 +331,7 @@ function obsidianEmbeddingsExist(input: {
 }
 
 function activeNativeArtifactPaths(source: NativeMemorySource, agentId: string): string[] {
-	const normalizedRoot = resolve(source.root).replace(/\\/g, "/").replace(/\/$/, "");
-	const rootPrefix = `${normalizedRoot}/`;
+	const rootPrefix = `${normalizedRoot(source.root)}/`;
 	try {
 		return getDbAccessor().withReadDb((db) => {
 			const rows = db
@@ -321,14 +339,17 @@ function activeNativeArtifactPaths(source: NativeMemorySource, agentId: string):
 					`SELECT source_path FROM memory_artifacts
 					 WHERE agent_id = ?
 					   AND harness = ?
-					   AND source_path >= ?
-					   AND source_path < ?
+					   AND (
+						   source_id = ?
+						   OR (source_id IS NULL AND source_path >= ? AND source_path < ?)
+					   )
 					   AND source_kind IN (${source.files.map(() => "?").join(", ")})
 					   AND COALESCE(is_deleted, 0) = 0`,
 				)
 				.all(
 					agentId,
 					source.harness,
+					source.sourceId ?? "",
 					rootPrefix,
 					prefixUpperBound(rootPrefix),
 					...source.files.map((file) => file.kind),
@@ -410,6 +431,7 @@ export async function indexNativeMemoryFile(
 	try {
 		const artifactChanged = persistedHash !== hash;
 		if (artifactChanged) {
+			const sourceExternalId = obsidian ? sourceRelativePath(source.root, filePath) : null;
 			indexExternalMemoryArtifact({
 				agentId,
 				sourcePath: filePath,
@@ -417,6 +439,16 @@ export async function indexNativeMemoryFile(
 				harness: source.harness,
 				content,
 				sourceMtimeMs: mtimeMs,
+				sourceId,
+				sourceRoot: obsidian ? normalizedRoot(source.root) : null,
+				sourceExternalId,
+				sourceParentPath: sourceExternalId ? dirname(sourceExternalId).replace(/^\.$/, "") : null,
+				sourceMeta: obsidian
+					? {
+							provider: "obsidian",
+							displayName: source.displayName,
+						}
+					: undefined,
 			});
 		}
 		let semanticIndexed = false;
@@ -498,8 +530,7 @@ export function removeNativeMemoryFile(
 }
 
 export function purgeNativeMemorySourceArtifacts(source: NativeMemorySource, agentId?: string): number {
-	const normalizedRoot = resolve(source.root).replace(/\\/g, "/").replace(/\/$/, "");
-	const rootPrefix = `${normalizedRoot}/`;
+	const rootPrefix = `${normalizedRoot(source.root)}/`;
 	for (const key of indexed.keys()) {
 		const parts = key.split(":");
 		const cachedAgentId = parts[0];
@@ -516,14 +547,23 @@ export function purgeNativeMemorySourceArtifacts(source: NativeMemorySource, age
 		const agentWhere = agentId ? "agent_id = ? AND " : "";
 		const rootUpperBound = prefixUpperBound(rootPrefix);
 		const params = agentId
-			? [agentId, source.harness, rootPrefix, rootUpperBound, ...source.files.map((file) => file.kind)]
-			: [source.harness, rootPrefix, rootUpperBound, ...source.files.map((file) => file.kind)];
+			? [
+					agentId,
+					source.harness,
+					source.sourceId ?? "",
+					rootPrefix,
+					rootUpperBound,
+					...source.files.map((file) => file.kind),
+				]
+			: [source.harness, source.sourceId ?? "", rootPrefix, rootUpperBound, ...source.files.map((file) => file.kind)];
 		const result = db
 			.prepare(
 				`DELETE FROM memory_artifacts
 				 WHERE ${agentWhere}harness = ?
-				   AND source_path >= ?
-				   AND source_path < ?
+				   AND (
+					   source_id = ?
+					   OR (source_id IS NULL AND source_path >= ? AND source_path < ?)
+				   )
 				   AND source_kind IN (${source.files.map(() => "?").join(", ")})`,
 			)
 			.run(...params);
@@ -559,6 +599,7 @@ export function startNativeMemoryBridge(
 		let count = 0;
 		const yielder = yieldEvery(options.yieldEveryFiles ?? 20);
 		for (const source of activeBridgeSources(sources, options)) {
+			if (options.shouldContinue && !options.shouldContinue(source)) continue;
 			let changedCount = 0;
 			let scanned = 0;
 			const key = sourceStateKey(source, agentId);
@@ -578,6 +619,7 @@ export function startNativeMemoryBridge(
 						? buildObsidianMarkdownPathIndex(source.root, files)
 						: undefined;
 				for (const file of files) {
+					if (options.shouldContinue && !options.shouldContinue(source)) break;
 					scanned++;
 					const changed = await indexNativeMemoryFile(source, file, agentId, {
 						...options,
@@ -606,7 +648,9 @@ export function startNativeMemoryBridge(
 				}
 			}
 			known.set(key, current);
-			if (rootExists && source.sourceId) markSourceIndexed(source.sourceId, undefined, options.agentsDir);
+			if (rootExists && source.sourceId && (!options.shouldContinue || options.shouldContinue(source))) {
+				markSourceIndexed(source.sourceId, undefined, options.agentsDir);
+			}
 		}
 		return count;
 	};

--- a/platform/daemon/src/obsidian-source-embeddings.test.ts
+++ b/platform/daemon/src/obsidian-source-embeddings.test.ts
@@ -79,7 +79,7 @@ describe("Obsidian source embeddings", () => {
 					.prepare(
 						`SELECT source_type, source_id, agent_id, dimensions, chunk_text
 					 FROM embeddings
-					 WHERE source_type = 'source_obsidian_chunk'
+					 WHERE source_type = 'source_chunk'
 					 ORDER BY source_id`,
 					)
 					.all() as Array<{
@@ -144,6 +144,57 @@ describe("Obsidian source embeddings", () => {
 		expect(fetches).toBe(first.chunks);
 	});
 
+	it("removes legacy Obsidian chunk rows once generic chunks are refreshed", async () => {
+		const filePath = join(vault, "literature", "source-memory.md");
+		const content =
+			"# Source Memory\n\nThis section explains that Obsidian vault files remain canonical source truth while Signet indexes addressable chunks for retrieval.\n";
+
+		await indexObsidianSourceEmbeddings({
+			agentId: "obsidian-embedding-agent",
+			sourceId: "obsidian:test-vault",
+			root: vault,
+			filePath,
+			content,
+			embeddingConfig,
+			fetchEmbedding: async () => testVector(1),
+		});
+
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO embeddings
+				 (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
+				 VALUES (?, ?, ?, ?, 'source_obsidian_chunk', ?, ?, ?, ?)`,
+			).run(
+				"legacy-source-chunk",
+				"legacy-source-chunk-hash",
+				Buffer.from(new Float32Array(testVector(1)).buffer),
+				embeddingConfig.dimensions,
+				"obsidian:test-vault:literature/source-memory.md#source-memory:1-2:legacy",
+				"source_path: legacy",
+				new Date().toISOString(),
+				"obsidian-embedding-agent",
+			);
+		});
+
+		await indexObsidianSourceEmbeddings({
+			agentId: "obsidian-embedding-agent",
+			sourceId: "obsidian:test-vault",
+			root: vault,
+			filePath,
+			content,
+			embeddingConfig,
+			fetchEmbedding: async () => testVector(1),
+		});
+
+		const rows = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT source_type FROM embeddings ORDER BY source_type")
+					.all() as Array<{ source_type: string }>,
+		);
+		expect(rows.map((row) => row.source_type)).toEqual(["source_chunk"]);
+	});
+
 	it("keeps chunk IDs distinct for repeated heading paths", () => {
 		const filePath = join(vault, "literature", "repeated-headings.md");
 		const chunks = buildObsidianSourceChunks({
@@ -193,7 +244,7 @@ describe("Obsidian source embeddings", () => {
 		const remaining = getDbAccessor().withReadDb(
 			(db) =>
 				db
-					.prepare("SELECT source_id FROM embeddings WHERE source_type = 'source_obsidian_chunk' ORDER BY source_id")
+					.prepare("SELECT source_id FROM embeddings WHERE source_type = 'source_chunk' ORDER BY source_id")
 					.all() as Array<{ source_id: string }>,
 		);
 		expect(remaining).toHaveLength(1);
@@ -218,7 +269,7 @@ describe("Obsidian source embeddings", () => {
 		const remaining = getDbAccessor().withReadDb(
 			(db) =>
 				(
-					db.prepare("SELECT COUNT(*) AS count FROM embeddings WHERE source_type = 'source_obsidian_chunk'").get() as {
+					db.prepare("SELECT COUNT(*) AS count FROM embeddings WHERE source_type = 'source_chunk'").get() as {
 						count: number;
 					}
 				).count,
@@ -276,11 +327,11 @@ describe("Obsidian source embeddings", () => {
 			async () => testVector(1),
 		);
 
-		const hit = response.results.find((row) => row.type === "source_obsidian_chunk");
+		const hit = response.results.find((row) => row.type === "source_chunk");
 		expect(hit).toBeTruthy();
 		expect(hit?.source).toBe("source_obsidian");
 		expect(hit?.source_path).toBe(filePath);
-		expect(hit?.content).toContain("[Obsidian vault chunk:");
+		expect(hit?.content).toContain("[Source chunk:");
 		expect(hit?.content).toContain("heading: Retrieval Covenant");
 	});
 
@@ -323,7 +374,7 @@ describe("Obsidian source embeddings", () => {
 			cfg,
 			async () => testVector(1),
 		);
-		const hit = agentARecall.results.find((row) => row.type === "source_obsidian_chunk");
+		const hit = agentARecall.results.find((row) => row.type === "source_chunk");
 		expect(hit).toBeTruthy();
 		expect(hit?.content).not.toContain("agent-b");
 
@@ -334,7 +385,7 @@ describe("Obsidian source embeddings", () => {
 				db
 					.prepare(
 						`SELECT agent_id, COUNT(*) AS count FROM embeddings
-						 WHERE source_type = 'source_obsidian_chunk'
+						 WHERE source_type = 'source_chunk'
 						 GROUP BY agent_id ORDER BY agent_id`,
 					)
 					.all() as Array<{ agent_id: string; count: number }>,

--- a/platform/daemon/src/obsidian-source-embeddings.ts
+++ b/platform/daemon/src/obsidian-source-embeddings.ts
@@ -1,12 +1,14 @@
 import { createHash } from "node:crypto";
 import { relative } from "node:path";
+import { LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE, SOURCE_CHUNK_SOURCE_TYPE } from "@signet/core";
 import { yieldEvery } from "./async-yield";
 import { getDbAccessor } from "./db-accessor";
 import { syncVecDeleteByEmbeddingIds, syncVecInsert, vectorToBlob } from "./db-helpers";
 import type { EmbeddingConfig } from "./memory-config";
 
-export const OBSIDIAN_CHUNK_SOURCE_TYPE = "source_obsidian_chunk";
+export const OBSIDIAN_CHUNK_SOURCE_TYPE = SOURCE_CHUNK_SOURCE_TYPE;
 const OBSIDIAN_SOURCE_CHUNK_DELAY_MS = 100;
+const OBSIDIAN_CHUNK_SOURCE_TYPES = [SOURCE_CHUNK_SOURCE_TYPE, LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE] as const;
 
 export type SourceEmbeddingFetch = (text: string, cfg: EmbeddingConfig) => Promise<number[] | null>;
 
@@ -178,6 +180,8 @@ export function buildObsidianSourceChunks(input: {
 				const chunkId = `${input.sourceId}:${relativePath}#${headingKey}:${lineKey}:${chunkIndex}`;
 				const chunkText = [
 					`source_id: ${input.sourceId}`,
+					"source_provider: obsidian",
+					`source_root: ${root}`,
 					`source_path: ${filePath}`,
 					`vault_relative_path: ${relativePath}`,
 					`heading: ${section.headingPath}`,
@@ -291,15 +295,20 @@ export async function indexObsidianSourceEmbeddings(
 
 	getDbAccessor().withWriteTx((db) => {
 		const prefix = `${input.sourceId}:${relPath(normalizePath(input.root).replace(/\/$/, ""), normalizePath(input.filePath))}#`;
-		const stale = db
-			.prepare(
-				"SELECT id, content_hash FROM embeddings WHERE source_type = ? AND source_id >= ? AND source_id < ? AND agent_id = ?",
-			)
-			.all(OBSIDIAN_CHUNK_SOURCE_TYPE, prefix, prefixUpperBound(prefix), input.agentId) as Array<{
-			id: string;
-			content_hash: string;
-		}>;
-		const staleIds = stale.filter((row) => !currentHashes.has(row.content_hash)).map((row) => row.id);
+		const stale = OBSIDIAN_CHUNK_SOURCE_TYPES.flatMap((sourceType) =>
+			db
+				.prepare(
+					"SELECT id, source_type, content_hash FROM embeddings WHERE source_type = ? AND source_id >= ? AND source_id < ? AND agent_id = ?",
+				)
+				.all(sourceType, prefix, prefixUpperBound(prefix), input.agentId) as Array<{
+				id: string;
+				source_type: string;
+				content_hash: string;
+			}>,
+		);
+		const staleIds = stale
+			.filter((row) => row.source_type === LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE || !currentHashes.has(row.content_hash))
+			.map((row) => row.id);
 		if (staleIds.length > 0) {
 			syncVecDeleteByEmbeddingIds(db, staleIds);
 			const stmt = db.prepare("DELETE FROM embeddings WHERE id = ?");
@@ -318,7 +327,7 @@ function existingChunkEmbeddingContentHash(agentId: string, chunkId: string): st
 	const row = getDbAccessor().withReadDb((db) =>
 		db
 			.prepare("SELECT content_hash FROM embeddings WHERE source_type = ? AND source_id = ? AND agent_id = ? LIMIT 1")
-			.get(OBSIDIAN_CHUNK_SOURCE_TYPE, chunkId, agentId),
+			.get(SOURCE_CHUNK_SOURCE_TYPE, chunkId, agentId),
 	) as { content_hash: string } | undefined;
 	return row?.content_hash ?? null;
 }
@@ -336,18 +345,21 @@ function purgeEmbeddingsBySourceIdPrefix(prefix: string, agentId?: string): numb
 	return getDbAccessor().withWriteTx((db) => {
 		const agentWhere = agentId ? " AND agent_id = ?" : "";
 		const upper = prefixUpperBound(prefix);
-		const args = agentId
-			? [OBSIDIAN_CHUNK_SOURCE_TYPE, prefix, upper, agentId]
-			: [OBSIDIAN_CHUNK_SOURCE_TYPE, prefix, upper];
-		const rows = db
-			.prepare(`SELECT id FROM embeddings WHERE source_type = ? AND source_id >= ? AND source_id < ?${agentWhere}`)
-			.all(...args) as Array<{ id: string }>;
-		const ids = rows.map((row) => row.id);
+		const ids: string[] = [];
+		let changes = 0;
+		for (const sourceType of OBSIDIAN_CHUNK_SOURCE_TYPES) {
+			const args = agentId ? [sourceType, prefix, upper, agentId] : [sourceType, prefix, upper];
+			const rows = db
+				.prepare(`SELECT id FROM embeddings WHERE source_type = ? AND source_id >= ? AND source_id < ?${agentWhere}`)
+				.all(...args) as Array<{ id: string }>;
+			ids.push(...rows.map((row) => row.id));
+			const result = db
+				.prepare(`DELETE FROM embeddings WHERE source_type = ? AND source_id >= ? AND source_id < ?${agentWhere}`)
+				.run(...args);
+			changes += result.changes;
+		}
 		syncVecDeleteByEmbeddingIds(db, ids);
-		const result = db
-			.prepare(`DELETE FROM embeddings WHERE source_type = ? AND source_id >= ? AND source_id < ?${agentWhere}`)
-			.run(...args);
-		return result.changes;
+		return changes;
 	});
 }
 

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -311,7 +311,7 @@ describe("Sources routes", () => {
 				"chunk-hash-1",
 				new Uint8Array([0]),
 				1,
-				"source_obsidian_chunk",
+				"source_chunk",
 				`${added.source.id}:permanent/Note.md#overview:1-3:0`,
 				"source chunk",
 				"2026-01-01T00:00:00.000Z",

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -5,6 +5,8 @@ import { homedir } from "node:os";
 import { dirname } from "node:path";
 import { promisify } from "node:util";
 import {
+	LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE,
+	SOURCE_CHUNK_SOURCE_TYPE,
 	type SignetSourceEntry,
 	addObsidianSource,
 	loadSourcesConfig,
@@ -16,10 +18,10 @@ import { resolveDaemonAgentId } from "../agent-id";
 import { getDbAccessor } from "../db-accessor";
 import {
 	type NativeMemoryBridgeHandle,
-	obsidianNativeMemorySource,
 	purgeNativeMemorySourceArtifacts,
 	startNativeMemoryBridge,
 } from "../native-memory-sources";
+import { getSourceProvider } from "../source-providers";
 import {
 	type SourceIndexJob,
 	beginSourceIndexJob,
@@ -133,13 +135,8 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 
 		const sourceAgentId = resolveDaemonAgentId();
 		recordSourceDeletionTombstone(result.source, sourceAgentId, agentsDir);
-		const purged =
-			result.source.kind === "obsidian"
-				? purgeNativeSource(
-						obsidianNativeMemorySource(result.source.root, result.source.name, result.source.id),
-						sourceAgentId,
-					)
-				: 0;
+		const provider = getSourceProvider(result.source.kind);
+		const purged = provider ? purgeNativeSource(provider.toNativeSource(result.source), sourceAgentId) : 0;
 		if (!isSourceIndexInFlight(result.source.id))
 			clearSourceDeletionTombstone(result.source.id, sourceAgentId, agentsDir);
 		return c.json({ source: result.source, purged });
@@ -166,8 +163,10 @@ async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob
 	let bridge: NativeMemoryBridgeHandle | null = null;
 
 	try {
+		const provider = getSourceProvider(input.source.kind);
+		if (!provider) throw new Error(`Unsupported source provider: ${input.source.kind}`);
 		bridge = input.startBridge(
-			[obsidianNativeMemorySource(input.source.root, input.source.name, input.source.id, input.source.excludeGlobs)],
+			[provider.toNativeSource(input.source)],
 			{
 				pollIntervalMs: 0,
 				agentsDir: input.agentsDir,
@@ -183,6 +182,7 @@ async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob
 						currentPath: event.filePath,
 					});
 				},
+				shouldContinue: () => isCurrentSourceIndexJob(input.source.id, job.id),
 			},
 		);
 		const indexed = await bridge.syncExisting();
@@ -195,10 +195,8 @@ async function runSourceIndexJob(input: SourceIndexJobInput, job: SourceIndexJob
 	} finally {
 		await bridge?.close().catch(() => undefined);
 		if (consumeCanceledSourceIndexJob(job.id)) {
-			input.purgeNativeSource(
-				obsidianNativeMemorySource(input.source.root, input.source.name, input.source.id, input.source.excludeGlobs),
-				resolveDaemonAgentId(),
-			);
+			const provider = getSourceProvider(input.source.kind);
+			if (provider) input.purgeNativeSource(provider.toNativeSource(input.source), resolveDaemonAgentId());
 			clearSourceDeletionTombstone(input.source.id, resolveDaemonAgentId(), input.agentsDir);
 		}
 		clearSourceIndexInFlight(input.source.id);
@@ -222,17 +220,8 @@ function cleanupSourceDeletionTombstones(
 	const remaining: SourceDeletionTombstone[] = [];
 	for (const tombstone of tombstones) {
 		if (configuredIds.has(tombstone.source.id)) continue;
-		if (tombstone.source.kind === "obsidian") {
-			purgeNativeSource(
-				obsidianNativeMemorySource(
-					tombstone.source.root,
-					tombstone.source.name,
-					tombstone.source.id,
-					tombstone.source.excludeGlobs,
-				),
-				tombstone.agentId,
-			);
-		}
+		const provider = getSourceProvider(tombstone.source.kind);
+		if (provider) purgeNativeSource(provider.toNativeSource(tombstone.source), tombstone.agentId);
 	}
 	saveSourceDeletionTombstones(remaining, agentsDir);
 }
@@ -294,7 +283,7 @@ function isSourceDeletionTombstone(value: unknown): value is SourceDeletionTombs
 		!!candidate.source &&
 		typeof candidate.source === "object" &&
 		typeof candidate.source.id === "string" &&
-		candidate.source.kind === "obsidian"
+		typeof candidate.source.kind === "string"
 	);
 }
 
@@ -313,16 +302,33 @@ function sourceStats(source: SignetSourceEntry, agentId: string): SourceStats {
 			const artifacts = countRow(
 				db
 					.prepare(
-						"SELECT COUNT(*) AS n FROM memory_artifacts WHERE agent_id = ? AND harness = 'obsidian' AND source_path >= ? AND source_path < ? AND COALESCE(is_deleted, 0) = 0",
+						`SELECT COUNT(*) AS n FROM memory_artifacts
+						 WHERE agent_id = ?
+						   AND harness = 'obsidian'
+						   AND (
+							   source_id = ?
+							   OR (source_id IS NULL AND source_path >= ? AND source_path < ?)
+						   )
+						   AND COALESCE(is_deleted, 0) = 0`,
 					)
-					.get(agentId, rootPrefix, `${rootPrefix}\uffff`),
+					.get(agentId, source.id, rootPrefix, `${rootPrefix}\uffff`),
 			);
 			const chunks = countRow(
 				db
 					.prepare(
-						"SELECT COUNT(*) AS n FROM embeddings WHERE agent_id = ? AND source_type = 'source_obsidian_chunk' AND source_id >= ? AND source_id < ?",
+						`SELECT COUNT(*) AS n FROM embeddings
+						 WHERE agent_id = ?
+						   AND source_type IN (?, ?)
+						   AND source_id >= ?
+						   AND source_id < ?`,
 					)
-					.get(agentId, chunkPrefix, `${chunkPrefix}\uffff`),
+					.get(
+						agentId,
+						SOURCE_CHUNK_SOURCE_TYPE,
+						LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE,
+						chunkPrefix,
+						`${chunkPrefix}\uffff`,
+					),
 			);
 			return { artifacts, chunks, indexed: artifacts };
 		});

--- a/platform/daemon/src/source-providers.ts
+++ b/platform/daemon/src/source-providers.ts
@@ -1,0 +1,37 @@
+import type { SignetSourceEntry, SignetSourceKind } from "@signet/core";
+import {
+	type NativeMemorySource,
+	obsidianNativeMemorySource,
+	purgeNativeMemorySourceArtifacts,
+} from "./native-memory-sources";
+
+export interface SourceProviderAdapter {
+	readonly kind: SignetSourceKind;
+	readonly toNativeSource: (source: SignetSourceEntry) => NativeMemorySource;
+	readonly purge: (source: SignetSourceEntry, agentId: string | undefined) => number;
+}
+
+const additionalProviders = new Map<SignetSourceKind, SourceProviderAdapter>();
+
+export const obsidianSourceProvider: SourceProviderAdapter = {
+	kind: "obsidian",
+	toNativeSource: (source) => obsidianNativeMemorySource(source.root, source.name, source.id, source.excludeGlobs),
+	purge: (source, agentId) =>
+		purgeNativeMemorySourceArtifacts(
+			obsidianNativeMemorySource(source.root, source.name, source.id, source.excludeGlobs),
+			agentId,
+		),
+};
+
+export function registerSourceProvider(provider: SourceProviderAdapter): void {
+	additionalProviders.set(provider.kind, provider);
+}
+
+export function getSourceProvider(kind: SignetSourceKind): SourceProviderAdapter | undefined {
+	if (kind === obsidianSourceProvider.kind) return obsidianSourceProvider;
+	return additionalProviders.get(kind);
+}
+
+export function configuredSourceProviders(): readonly SourceProviderAdapter[] {
+	return [obsidianSourceProvider, ...additionalProviders.values()];
+}


### PR DESCRIPTION
## Summary
- Adds provider-neutral source substrate types and a daemon source provider registry, with Obsidian wired through the adapter boundary.
- Adds source-owned provenance columns on `memory_artifacts` for `source_id`, `source_root`, external ids, parent paths, and provider metadata.
- Moves Obsidian source chunk indexing to generic `source_chunk` rows while preserving legacy `source_obsidian_chunk` recall and purge compatibility.
- Tightens source job cancellation so native source scans can stop before stale writes after disconnect.

## Stack Context
This is PR 1 of the replacement stack after closing #750. Follow-up PRs should migrate more Obsidian behavior behind this provider contract, then add Discord through the shared source path instead of a bespoke Discord pipeline.

## Test Plan
- [x] `bun test platform/core/src/sources-config.test.ts platform/core/src/migrations/migrations.test.ts`
- [x] `bun run --filter '@signet/core' build`
- [x] `bun test platform/daemon/src/obsidian-source-embeddings.test.ts platform/daemon/src/native-memory-sources.test.ts platform/daemon/src/routes/sources-routes.test.ts platform/daemon/src/memory-search.test.ts`
- [x] `bun run --filter '@signet/daemon' build`
- [x] `git diff --check`

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)
- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Migration 075 only adds nullable provenance columns and indexes to `memory_artifacts`. Rollback compatibility is additive: older rows remain readable, and source stats/purge fall back to the existing Obsidian root/path matching when `source_id` is absent.
