### PR TITLE
feat(sources): add source snapshot operations

### DIFF
--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -40,6 +40,8 @@ signet sources add discord --guild 123456789012345678 --token-ref DISCORD_BOT_TO
 signet sources add discord --mode desktop-cache --name "Local Discord Cache"
 signet sources add discord --mode desktop-cache --desktop-cache-path ~/.config/discord --full-cache
 signet sources list
+signet sources snapshot export discord:... --out discord-source.snapshot.json
+signet sources snapshot import discord:... discord-source.snapshot.json
 signet sources remove discord:...
 ```
 
@@ -77,6 +79,20 @@ the source still purges all Signet-owned rows for that source.
 Partial Discord listings are never treated as authoritative deletes. If a channel, thread, member, or message fetch fails, Signet records a source failure artifact and preserves existing source-owned rows until a successful sync can refresh them.
 
 Discord sources stay read-only. Signet does not write to Discord, automate user tokens, or selfbot against user accounts.
+
+Source snapshots
+----------------
+
+Source snapshots export Signet source artifacts with their provenance so a
+Discord-backed source can be backed up or moved without adopting Discrawl's
+standalone SQLite archive model. Snapshots use `memory_artifacts` rows and are
+imported back through the shared artifact path, which keeps source paths,
+external IDs, FTS indexing, and purge-by-source behavior intact.
+
+Discord Desktop cache DMs are local-only. Snapshot export/import excludes
+artifacts under the synthetic `@me` guild by default; use
+`--include-local-discord` only when intentionally moving that private local
+cache data.
 
 Obsidian v1
 -----------

--- a/docs/api/documents-sources.md
+++ b/docs/api/documents-sources.md
@@ -281,6 +281,69 @@ and source chunk embeddings. Source files are not modified.
 }
 ```
 
+### GET /api/sources/:sourceId/snapshot
+
+Export source-owned artifact rows as a Signet source snapshot. Snapshots use
+`memory_artifacts` provenance instead of a provider-specific archive database.
+
+**Query parameters**
+
+| Parameter | Description |
+|-----------|-------------|
+| `includeLocalDiscord` | Include local Discord Desktop `@me` cache artifacts. Defaults to `false`. |
+
+By default, Discord Desktop cache DMs under the synthetic guild id `@me` are
+excluded so shared snapshots do not publish local-only private data.
+
+**Response**
+
+```json
+{
+  "version": 1,
+  "exportedAt": "2026-05-24T00:00:00.000Z",
+  "source": { "id": "discord:abc123", "kind": "discord", "name": "Team Discord", "root": "discord://123" },
+  "agentId": "default",
+  "artifacts": [
+    {
+      "sourcePath": "discord://guild/123/channel/456/message/789",
+      "sourceKind": "source_discord_message",
+      "sourceId": "discord:abc123",
+      "content": "# Discord Message\n..."
+    }
+  ],
+  "skipped": { "localDiscordArtifacts": 0 }
+}
+```
+
+### POST /api/sources/:sourceId/snapshot/import
+
+Import a Signet source snapshot into an existing configured source. The import
+replaces source-owned artifact rows for that source and reuses the normal
+artifact upsert path so FTS and provenance stay consistent.
+
+**Query parameters**
+
+| Parameter | Description |
+|-----------|-------------|
+| `includeLocalDiscord` | Import local Discord Desktop `@me` cache artifacts from the snapshot. Defaults to `false`. |
+
+Default imports preserve existing local `@me` Discord cache artifacts and skip
+any `@me` artifacts present in the incoming snapshot.
+
+**Request body**
+
+The JSON returned by `GET /api/sources/:sourceId/snapshot`.
+
+**Response**
+
+```json
+{
+  "ok": true,
+  "imported": 42,
+  "skipped": { "localDiscordArtifacts": 3 }
+}
+```
+
 ### POST /api/sources/pick-directory
 
 Best-effort local directory picker used by dashboard/browser flows. It returns

--- a/docs/api/route-inventory.md
+++ b/docs/api/route-inventory.md
@@ -51,6 +51,8 @@ silently disappear from the API reference.
 | POST | `/api/sources/pick-directory` | platform/daemon/src/routes/sources-routes.ts |
 | POST | `/api/sources/obsidian` | platform/daemon/src/routes/sources-routes.ts |
 | POST | `/api/sources/discord` | platform/daemon/src/routes/sources-routes.ts |
+| GET | `/api/sources/:sourceId/snapshot` | platform/daemon/src/routes/sources-routes.ts |
+| POST | `/api/sources/:sourceId/snapshot/import` | platform/daemon/src/routes/sources-routes.ts |
 | DELETE | `/api/sources/:sourceId` | platform/daemon/src/routes/sources-routes.ts |
 | GET | `/api/knowledge/entities` | platform/daemon/src/routes/knowledge-routes.ts |
 | POST | `/api/knowledge/entities/:id/pin` | platform/daemon/src/routes/knowledge-routes.ts |

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { addDiscordSource, addObsidianSource, loadSourcesConfig } from "@signet/core";
 import { Hono } from "hono";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
+import { hashNormalizedBody } from "../memory-lineage";
 import type { NativeMemoryBridgeHandle, NativeMemoryBridgeOptions, NativeMemorySource } from "../native-memory-sources";
 import {
 	beginSourceIndexJob,
@@ -12,6 +13,7 @@ import {
 	completeSourceIndexJob,
 	completeSourceIndexJobFromProgress,
 	getSourceIndexJob,
+	markSourceIndexInFlight,
 	markSourceIndexJobRunning,
 	updateSourceIndexJobProgress,
 } from "../source-index-progress";
@@ -458,6 +460,323 @@ describe("Sources routes", () => {
 		expect(body.sources[0]?.stats).toEqual({ artifacts: 1, chunks: 1, indexed: 1 });
 	});
 
+	it("exports source snapshots while excluding local Discord cache DMs by default", async () => {
+		const added = addDiscordSource(
+			{
+				name: "Snapshot Discord",
+				desktopCachePath: join(dir, "discord"),
+				syncMode: "desktop-cache",
+			},
+			dir,
+		);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+
+		insertSourceArtifact({
+			sourceId: added.source.id,
+			sourceRoot: added.source.root,
+			sourcePath: "discord-cache://guild/123/channel/456/message/789",
+			sourceKind: "source_discord_message",
+			content: "public cached message",
+			metaJson: JSON.stringify({ guildId: "123", channelId: "456" }),
+		});
+		insertSourceArtifact({
+			sourceId: added.source.id,
+			sourceRoot: added.source.root,
+			sourcePath: "discord-cache://guild/@me/channel/111/message/222",
+			sourceKind: "source_discord_message",
+			content: "private dm message",
+			metaJson: JSON.stringify({ guildId: "@me", channelId: "111" }),
+		});
+
+		const res = await makeApp().request(`/api/sources/${encodeURIComponent(added.source.id)}/snapshot`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			artifacts: Array<{ sourcePath: string; content: string }>;
+			skipped?: { localDiscordArtifacts?: number };
+		};
+		expect(body.artifacts).toHaveLength(1);
+		expect(body.artifacts[0]?.content).toBe("public cached message");
+		expect(body.artifacts[0]?.sourcePath).not.toContain("@me");
+		expect(body.skipped?.localDiscordArtifacts).toBe(1);
+
+		const local = await makeApp().request(
+			`/api/sources/${encodeURIComponent(added.source.id)}/snapshot?includeLocalDiscord=true`,
+		);
+		const localBody = (await local.json()) as { artifacts: Array<{ sourcePath: string }> };
+		expect(localBody.artifacts.map((artifact) => artifact.sourcePath)).toContain(
+			"discord-cache://guild/@me/channel/111/message/222",
+		);
+	});
+
+	it("imports source snapshots through existing source artifact provenance", async () => {
+		const added = addDiscordSource(
+			{ guildIds: ["123456789012345678"], tokenRef: "DISCORD_BOT_TOKEN", name: "Import Discord" },
+			dir,
+		);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+
+		insertSourceArtifact({
+			sourceId: added.source.id,
+			sourceRoot: added.source.root,
+			sourcePath: "discord://guild/123/channel/456/message/stale",
+			sourceKind: "source_discord_message",
+			content: "stale message",
+			metaJson: JSON.stringify({ guildId: "123", channelId: "456" }),
+		});
+		insertSourceChunk({
+			id: "snapshot-stale-discord-chunk",
+			sourceId: `${added.source.id}:guild/123/channel/456/message/stale#0`,
+			chunkText: "source_path: discord://guild/123/channel/456/message/stale\n\nstale chunk",
+		});
+		const snapshot = {
+			version: 1,
+			exportedAt: "2026-05-24T00:00:00.000Z",
+			source: { id: added.source.id, kind: "discord", name: "Import Discord", root: added.source.root },
+			agentId: "default",
+			artifacts: [
+				sourceSnapshotArtifact({
+					sourceId: added.source.id,
+					sourceRoot: added.source.root,
+					sourcePath: "discord://guild/123/channel/456/message/fresh",
+					sourceKind: "source_discord_message",
+					content: "fresh imported message",
+					metaJson: JSON.stringify({ guildId: "123", channelId: "456" }),
+				}),
+			],
+			skipped: { localDiscordArtifacts: 0 },
+		};
+
+		const res = await makeApp().request(`/api/sources/${encodeURIComponent(added.source.id)}/snapshot/import`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(snapshot),
+		});
+		expect(res.status).toBe(200);
+		expect((await res.json()) as { imported: number }).toMatchObject({ imported: 1 });
+
+		const rows = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT source_path, content FROM memory_artifacts WHERE source_id = ? ORDER BY source_path")
+					.all(added.source.id) as Array<{ source_path: string; content: string }>,
+		);
+		expect(rows).toEqual([
+			{ source_path: "discord://guild/123/channel/456/message/fresh", content: "fresh imported message" },
+		]);
+		expect(sourceChunkRows(added.source.id)).toEqual([]);
+	});
+
+	it("preserves local Discord cache DM artifacts during default snapshot import", async () => {
+		const added = addDiscordSource(
+			{
+				name: "Preserve Local Discord",
+				desktopCachePath: join(dir, "discord"),
+				syncMode: "desktop-cache",
+			},
+			dir,
+		);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+
+		insertSourceArtifact({
+			sourceId: added.source.id,
+			sourceRoot: added.source.root,
+			sourcePath: "discord-cache://guild/@me/channel/111/message/local",
+			sourceKind: "source_discord_message",
+			content: "local dm should remain",
+			metaJson: JSON.stringify({ guildId: "@me", channelId: "111" }),
+		});
+		insertSourceArtifact({
+			sourceId: added.source.id,
+			sourceRoot: added.source.root,
+			sourcePath: "discord-cache://guild/123/channel/456/message/stale",
+			sourceKind: "source_discord_message",
+			content: "stale public cache",
+			metaJson: JSON.stringify({ guildId: "123", channelId: "456" }),
+		});
+		insertSourceChunk({
+			id: "snapshot-local-discord-chunk",
+			sourceId: `${added.source.id}:discord-cache://guild/@me/channel/111/message/local#0`,
+			chunkText: "source_path: discord-cache://guild/@me/channel/111/message/local\n\nlocal dm chunk",
+		});
+		insertSourceChunk({
+			id: "snapshot-public-discord-chunk",
+			sourceId: `${added.source.id}:discord-cache://guild/123/channel/456/message/stale#0`,
+			chunkText: "source_path: discord-cache://guild/123/channel/456/message/stale\n\nstale public chunk",
+		});
+
+		const snapshot = {
+			version: 1,
+			exportedAt: "2026-05-24T00:00:00.000Z",
+			source: { id: added.source.id, kind: "discord", name: "Preserve Local Discord", root: added.source.root },
+			agentId: "default",
+			artifacts: [
+				sourceSnapshotArtifact({
+					sourceId: added.source.id,
+					sourceRoot: added.source.root,
+					sourcePath: "discord-cache://guild/123/channel/456/message/fresh",
+					sourceKind: "source_discord_message",
+					content: "fresh public cache",
+					metaJson: JSON.stringify({ guildId: "123", channelId: "456" }),
+				}),
+				sourceSnapshotArtifact({
+					sourceId: added.source.id,
+					sourceRoot: added.source.root,
+					sourcePath: "discord-cache://guild/@me/channel/111/message/imported",
+					sourceKind: "source_discord_message",
+					content: "imported dm should be skipped",
+					metaJson: JSON.stringify({ guildId: "@me", channelId: "111" }),
+				}),
+			],
+			skipped: { localDiscordArtifacts: 0 },
+		};
+
+		const res = await makeApp().request(`/api/sources/${encodeURIComponent(added.source.id)}/snapshot/import`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(snapshot),
+		});
+		expect(res.status).toBe(200);
+		expect((await res.json()) as { imported: number; skipped: { localDiscordArtifacts: number } }).toMatchObject({
+			imported: 1,
+			skipped: { localDiscordArtifacts: 1 },
+		});
+		const rows = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT source_path, content FROM memory_artifacts WHERE source_id = ? ORDER BY source_path")
+					.all(added.source.id) as Array<{ source_path: string; content: string }>,
+		);
+		expect(rows).toEqual([
+			{ source_path: "discord-cache://guild/123/channel/456/message/fresh", content: "fresh public cache" },
+			{ source_path: "discord-cache://guild/@me/channel/111/message/local", content: "local dm should remain" },
+		]);
+		expect(sourceChunkRows(added.source.id)).toEqual([
+			{
+				id: "snapshot-local-discord-chunk",
+				source_id: `${added.source.id}:discord-cache://guild/@me/channel/111/message/local#0`,
+			},
+		]);
+	});
+
+	it("rejects source snapshots that would overwrite another source path", async () => {
+		const added = addDiscordSource(
+			{ guildIds: ["123456789012345678"], tokenRef: "DISCORD_BOT_TOKEN", name: "Import Conflict Discord" },
+			dir,
+		);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+
+		insertSourceArtifact({
+			sourceId: "obsidian:other",
+			sourceRoot: vault,
+			sourcePath: "discord://guild/123/channel/456/message/shared",
+			sourceKind: "source_obsidian_markdown",
+			content: "other source content",
+			metaJson: JSON.stringify({ provider: "obsidian" }),
+		});
+		const snapshot = {
+			version: 1,
+			exportedAt: "2026-05-24T00:00:00.000Z",
+			source: { id: added.source.id, kind: "discord", name: "Import Conflict Discord", root: added.source.root },
+			agentId: "default",
+			artifacts: [
+				sourceSnapshotArtifact({
+					sourceId: added.source.id,
+					sourceRoot: added.source.root,
+					sourcePath: "discord://guild/123/channel/456/message/shared",
+					sourceKind: "source_discord_message",
+					content: "attacker controlled content",
+					metaJson: JSON.stringify({ guildId: "123", channelId: "456" }),
+				}),
+			],
+			skipped: { localDiscordArtifacts: 0 },
+		};
+
+		const res = await makeApp().request(`/api/sources/${encodeURIComponent(added.source.id)}/snapshot/import`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(snapshot),
+		});
+		expect(res.status).toBe(400);
+		expect(((await res.json()) as { error: string }).error).toContain("already owned by another source");
+		const row = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT source_id, content FROM memory_artifacts WHERE source_path = ?")
+					.get("discord://guild/123/channel/456/message/shared") as { source_id: string; content: string },
+		);
+		expect(row).toEqual({ source_id: "obsidian:other", content: "other source content" });
+	});
+
+	it("rejects source snapshot import while indexing is active", async () => {
+		const added = addDiscordSource(
+			{ guildIds: ["123456789012345678"], tokenRef: "DISCORD_BOT_TOKEN", name: "Busy Import Discord" },
+			dir,
+		);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+
+		const job = beginSourceIndexJob(added.source.id);
+		markSourceIndexJobRunning(added.source.id, job.id);
+		markSourceIndexInFlight(added.source.id);
+
+		const res = await makeApp().request(`/api/sources/${encodeURIComponent(added.source.id)}/snapshot/import`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+		});
+
+		expect(res.status).toBe(409);
+		expect(((await res.json()) as { error: string }).error).toContain("cannot run while source indexing");
+	});
+
+	it("reserves the source while snapshot import is parsing", async () => {
+		const added = addDiscordSource(
+			{ guildIds: ["123456789012345678"], tokenRef: "DISCORD_BOT_TOKEN", name: "Reserved Import Discord" },
+			dir,
+		);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+
+		const snapshot = {
+			version: 1,
+			exportedAt: "2026-05-24T00:00:00.000Z",
+			source: { id: added.source.id, kind: "discord", name: "Reserved Import Discord", root: added.source.root },
+			agentId: "default",
+			artifacts: [],
+			skipped: { localDiscordArtifacts: 0 },
+		};
+		let controller: ReadableStreamDefaultController<Uint8Array> | null = null;
+		const body = new ReadableStream<Uint8Array>({
+			start(next) {
+				controller = next;
+			},
+		});
+		const app = makeApp();
+		const first = app.request(
+			new Request(`http://localhost/api/sources/${encodeURIComponent(added.source.id)}/snapshot/import`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body,
+				duplex: "half",
+			} as RequestInit & { duplex: "half" }),
+		);
+
+		const second = await app.request(`/api/sources/${encodeURIComponent(added.source.id)}/snapshot/import`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(snapshot),
+		});
+		expect(second.status).toBe(409);
+
+		controller?.enqueue(new TextEncoder().encode(JSON.stringify(snapshot)));
+		controller?.close();
+		expect((await first).status).toBe(200);
+	});
+
 	it("surfaces background source sync progress in the sources response", async () => {
 		const added = addObsidianSource({ root: vault, name: "Background Vault" }, dir);
 		expect(added.ok).toBe(true);
@@ -534,4 +853,113 @@ describe("Sources routes", () => {
 		expect(res.status).toBe(404);
 		expect(((await res.json()) as { error: string }).error).toContain("Source not found");
 	});
+
+	function insertSourceArtifact(input: {
+		sourceId: string;
+		sourceRoot: string;
+		sourcePath: string;
+		sourceKind: string;
+		content: string;
+		metaJson: string;
+	}): void {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memory_artifacts
+				 (agent_id, source_path, source_sha256, source_kind, source_id, source_root,
+				  source_external_id, source_meta_json, session_id, session_token, harness,
+				  captured_at, content, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			).run(
+				"default",
+				input.sourcePath,
+				hashNormalizedBody(input.content),
+				input.sourceKind,
+				input.sourceId,
+				input.sourceRoot,
+				`artifact:${input.sourcePath}`,
+				input.metaJson,
+				`native:discord:${input.sourcePath}`,
+				"snapshot-token",
+				"discord",
+				"2026-05-24T00:00:00.000Z",
+				input.content,
+				"2026-05-24T00:00:00.000Z",
+			);
+		});
+	}
+
+	function insertSourceChunk(input: { id: string; sourceId: string; chunkText: string }): void {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO embeddings
+				 (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			).run(
+				input.id,
+				`${input.id}-hash`,
+				new Uint8Array([0]),
+				1,
+				"source_chunk",
+				input.sourceId,
+				input.chunkText,
+				"2026-05-24T00:00:00.000Z",
+				"default",
+			);
+		});
+	}
+
+	function sourceChunkRows(sourceId: string): Array<{ id: string; source_id: string }> {
+		return getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare(
+						`SELECT id, source_id
+						   FROM embeddings
+						  WHERE agent_id = ?
+						    AND source_type = ?
+						    AND source_id >= ?
+						    AND source_id < ?
+						  ORDER BY id`,
+					)
+					.all("default", "source_chunk", `${sourceId}:`, `${sourceId}:\uffff`) as Array<{
+					id: string;
+					source_id: string;
+				}>,
+		);
+	}
+
+	function sourceSnapshotArtifact(input: {
+		sourceId: string;
+		sourceRoot: string;
+		sourcePath: string;
+		sourceKind: string;
+		content: string;
+		metaJson: string;
+	}): Record<string, unknown> {
+		return {
+			sourcePath: input.sourcePath,
+			sourceSha256: hashNormalizedBody(input.content),
+			sourceKind: input.sourceKind,
+			sessionId: `native:discord:${input.sourcePath}`,
+			sessionKey: "native:discord",
+			sessionToken: "snapshot-token",
+			project: null,
+			harness: "discord",
+			capturedAt: "2026-05-24T00:00:00.000Z",
+			startedAt: "2026-05-24T00:00:00.000Z",
+			endedAt: "2026-05-24T00:00:00.000Z",
+			manifestPath: null,
+			sourceNodeId: null,
+			memorySentence: "snapshot artifact",
+			memorySentenceQuality: "fallback",
+			content: input.content,
+			updatedAt: "2026-05-24T00:00:00.000Z",
+			sourceMtimeMs: Date.parse("2026-05-24T00:00:00.000Z"),
+			sourceId: input.sourceId,
+			sourceRoot: input.sourceRoot,
+			sourceExternalId: `artifact:${input.sourcePath}`,
+			sourceParentPath: null,
+			sourceMetaJson: input.metaJson,
+		};
+	}
 });

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -38,6 +38,7 @@ import {
 	updateSourceIndexJobProgress,
 } from "../source-index-progress";
 import { getSourceProvider } from "../source-providers";
+import { exportSourceSnapshot, importSourceSnapshot } from "../source-snapshots";
 
 interface SourceIndexJobInput {
 	readonly source: SignetSourceEntry;
@@ -202,6 +203,48 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 		return c.json({ source: result.source, created: result.created, indexed: 0, queued: true, job }, 202);
 	});
 
+	app.get("/api/sources/:sourceId/snapshot", (c) => {
+		const sourceId = c.req.param("sourceId");
+		const source = findConfiguredSource(sourceId, agentsDir);
+		if (!source) return c.json({ error: "Source not found" }, 404);
+		const includeLocalDiscord = c.req.query("includeLocalDiscord") === "true";
+		return c.json(
+			exportSourceSnapshot({
+				source,
+				agentId: resolveDaemonAgentId(),
+				includeLocalDiscord,
+			}),
+		);
+	});
+
+	app.post("/api/sources/:sourceId/snapshot/import", async (c) => {
+		const sourceId = c.req.param("sourceId");
+		const source = findConfiguredSource(sourceId, agentsDir);
+		if (!source) return c.json({ error: "Source not found" }, 404);
+		if (isSourceImportBlocked(source.id)) {
+			return c.json({ error: "Source snapshot import cannot run while source indexing is queued or running" }, 409);
+		}
+		markSourceIndexInFlight(source.id);
+		try {
+			let body: unknown;
+			try {
+				body = await c.req.json();
+			} catch {
+				return c.json({ error: "Invalid JSON body" }, 400);
+			}
+			const result = importSourceSnapshot({
+				source,
+				agentId: resolveDaemonAgentId(),
+				snapshot: body,
+				includeLocalDiscord: c.req.query("includeLocalDiscord") === "true",
+			});
+			if (result.ok === false) return c.json({ error: result.error }, 400);
+			return c.json(result);
+		} finally {
+			clearSourceIndexInFlight(source.id);
+		}
+	});
+
 	app.delete("/api/sources/:sourceId", (c) => {
 		const sourceId = c.req.param("sourceId");
 		const result = removeSource(sourceId, agentsDir);
@@ -216,6 +259,15 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 			clearSourceDeletionTombstone(result.source.id, sourceAgentId, agentsDir);
 		return c.json({ source: result.source, purged });
 	});
+}
+
+function findConfiguredSource(sourceId: string, agentsDir: string): SignetSourceEntry | undefined {
+	return loadSourcesConfig(agentsDir).sources.find((source) => source.id === sourceId);
+}
+
+function isSourceImportBlocked(sourceId: string): boolean {
+	const job = getSourceIndexJob(sourceId);
+	return isSourceIndexInFlight(sourceId) || job?.status === "queued" || job?.status === "running";
 }
 
 function enqueueSourceIndexJob(input: SourceIndexJobInput): SourceIndexJob {

--- a/platform/daemon/src/source-snapshots.ts
+++ b/platform/daemon/src/source-snapshots.ts
@@ -1,0 +1,454 @@
+import type { Database } from "bun:sqlite";
+import { SOURCE_CHUNK_SOURCE_TYPE, type SignetSourceEntry } from "@signet/core";
+import { getDbAccessor } from "./db-accessor";
+import type { WriteDb } from "./db-accessor";
+import { syncVecDeleteByEmbeddingIds } from "./db-helpers";
+import { hashNormalizedBody } from "./memory-lineage";
+
+export const SOURCE_SNAPSHOT_VERSION = 1;
+
+export interface SourceSnapshotArtifact {
+	readonly sourcePath: string;
+	readonly sourceSha256: string;
+	readonly sourceKind: string;
+	readonly sessionId: string;
+	readonly sessionKey: string | null;
+	readonly sessionToken: string;
+	readonly project: string | null;
+	readonly harness: string | null;
+	readonly capturedAt: string;
+	readonly startedAt: string | null;
+	readonly endedAt: string | null;
+	readonly manifestPath: string | null;
+	readonly sourceNodeId: string | null;
+	readonly memorySentence: string | null;
+	readonly memorySentenceQuality: string | null;
+	readonly content: string;
+	readonly updatedAt: string;
+	readonly sourceMtimeMs: number | null;
+	readonly sourceId: string;
+	readonly sourceRoot: string | null;
+	readonly sourceExternalId: string | null;
+	readonly sourceParentPath: string | null;
+	readonly sourceMetaJson: string | null;
+}
+
+export interface SourceSnapshot {
+	readonly version: typeof SOURCE_SNAPSHOT_VERSION;
+	readonly exportedAt: string;
+	readonly source: {
+		readonly id: string;
+		readonly kind: string;
+		readonly name: string;
+		readonly root: string;
+	};
+	readonly agentId: string;
+	readonly artifacts: readonly SourceSnapshotArtifact[];
+	readonly skipped: {
+		readonly localDiscordArtifacts: number;
+	};
+}
+
+export interface ExportSourceSnapshotOptions {
+	readonly source: SignetSourceEntry;
+	readonly agentId: string;
+	readonly includeLocalDiscord?: boolean;
+}
+
+export interface ImportSourceSnapshotOptions {
+	readonly source: SignetSourceEntry;
+	readonly agentId: string;
+	readonly snapshot: unknown;
+	readonly includeLocalDiscord?: boolean;
+}
+
+export type ImportSourceSnapshotResult =
+	| {
+			readonly ok: true;
+			readonly imported: number;
+			readonly skipped: { readonly localDiscordArtifacts: number };
+	  }
+	| { readonly ok: false; readonly error: string };
+
+interface ArtifactRow {
+	readonly source_path: string;
+	readonly source_sha256: string;
+	readonly source_kind: string;
+	readonly session_id: string;
+	readonly session_key: string | null;
+	readonly session_token: string;
+	readonly project: string | null;
+	readonly harness: string | null;
+	readonly captured_at: string;
+	readonly started_at: string | null;
+	readonly ended_at: string | null;
+	readonly manifest_path: string | null;
+	readonly source_node_id: string | null;
+	readonly memory_sentence: string | null;
+	readonly memory_sentence_quality: string | null;
+	readonly content: string;
+	readonly updated_at: string;
+	readonly source_mtime_ms: number | null;
+	readonly source_id: string;
+	readonly source_root: string | null;
+	readonly source_external_id: string | null;
+	readonly source_parent_path: string | null;
+	readonly source_meta_json: string | null;
+}
+
+export function exportSourceSnapshot(options: ExportSourceSnapshotOptions): SourceSnapshot {
+	const includeLocalDiscord = options.includeLocalDiscord === true;
+	return getDbAccessor().withReadDb((db) => {
+		let skippedLocal = 0;
+		const artifacts = (
+			db
+				.prepare(
+					`SELECT source_path, source_sha256, source_kind, session_id,
+					        session_key, session_token, project, harness, captured_at,
+					        started_at, ended_at, manifest_path, source_node_id,
+					        memory_sentence, memory_sentence_quality, content,
+					        updated_at, source_mtime_ms, source_id, source_root,
+					        source_external_id, source_parent_path, source_meta_json
+					   FROM memory_artifacts
+					  WHERE agent_id = ?
+					    AND source_id = ?
+					    AND COALESCE(is_deleted, 0) = 0
+					  ORDER BY source_path ASC`,
+				)
+				.all(options.agentId, options.source.id) as ArtifactRow[]
+		).flatMap((row) => {
+			const artifact = artifactFromRow(row);
+			if (!includeLocalDiscord && isLocalDiscordArtifact(artifact)) {
+				skippedLocal++;
+				return [];
+			}
+			return [artifact];
+		});
+
+		return {
+			version: SOURCE_SNAPSHOT_VERSION,
+			exportedAt: new Date().toISOString(),
+			source: {
+				id: options.source.id,
+				kind: options.source.kind,
+				name: options.source.name,
+				root: options.source.root,
+			},
+			agentId: options.agentId,
+			artifacts,
+			skipped: { localDiscordArtifacts: skippedLocal },
+		};
+	});
+}
+
+export function importSourceSnapshot(options: ImportSourceSnapshotOptions): ImportSourceSnapshotResult {
+	const snapshot = parseSourceSnapshot(options.snapshot);
+	if (snapshot.ok === false) return snapshot;
+	if (snapshot.value.source.id !== options.source.id) {
+		return { ok: false, error: `Snapshot source id ${snapshot.value.source.id} does not match ${options.source.id}` };
+	}
+	if (snapshot.value.source.kind !== options.source.kind) {
+		return {
+			ok: false,
+			error: `Snapshot source kind ${snapshot.value.source.kind} does not match ${options.source.kind}`,
+		};
+	}
+
+	const includeLocalDiscord = options.includeLocalDiscord === true;
+	const artifacts: SourceSnapshotArtifact[] = [];
+	let skippedLocal = 0;
+	for (const artifact of snapshot.value.artifacts) {
+		if (artifact.sourceId !== options.source.id) {
+			return { ok: false, error: `Snapshot artifact ${artifact.sourcePath} belongs to ${artifact.sourceId}` };
+		}
+		if (hashNormalizedBody(artifact.content) !== artifact.sourceSha256) {
+			return { ok: false, error: `Snapshot artifact checksum mismatch: ${artifact.sourcePath}` };
+		}
+		if (!includeLocalDiscord && isLocalDiscordArtifact(artifact)) {
+			skippedLocal++;
+			continue;
+		}
+		artifacts.push(artifact);
+	}
+
+	try {
+		getDbAccessor().withWriteTx((db) => {
+			const writeDb = db as WriteDb as Database;
+			const conflict = findPathOwnershipConflict(writeDb, artifacts, options.agentId, options.source.id);
+			if (conflict) throw new Error(conflict);
+			deleteImportScope(writeDb, options.source.id, options.agentId, includeLocalDiscord);
+			purgeImportScopeChunks(writeDb, options.source.id, options.agentId, includeLocalDiscord);
+			const stmt = writeDb.prepare(
+				`INSERT INTO memory_artifacts (
+				agent_id, source_path, source_sha256, source_kind, session_id,
+				session_key, session_token, project, harness, captured_at,
+				started_at, ended_at, manifest_path, source_node_id,
+				memory_sentence, memory_sentence_quality, content, updated_at,
+				source_mtime_ms, source_id, source_root, source_external_id,
+				source_parent_path, source_meta_json
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(agent_id, source_path) DO UPDATE SET
+				source_sha256 = excluded.source_sha256,
+				source_kind = excluded.source_kind,
+				session_id = excluded.session_id,
+				session_key = excluded.session_key,
+				session_token = excluded.session_token,
+				project = excluded.project,
+				harness = excluded.harness,
+				captured_at = excluded.captured_at,
+				started_at = excluded.started_at,
+				ended_at = excluded.ended_at,
+				manifest_path = excluded.manifest_path,
+				source_node_id = excluded.source_node_id,
+				memory_sentence = excluded.memory_sentence,
+				memory_sentence_quality = excluded.memory_sentence_quality,
+				content = excluded.content,
+				updated_at = excluded.updated_at,
+				source_mtime_ms = excluded.source_mtime_ms,
+				source_id = excluded.source_id,
+				source_root = excluded.source_root,
+				source_external_id = excluded.source_external_id,
+				source_parent_path = excluded.source_parent_path,
+				source_meta_json = excluded.source_meta_json,
+				is_deleted = 0,
+				deleted_at = NULL
+			WHERE memory_artifacts.source_id = excluded.source_id`,
+			);
+			for (const artifact of artifacts) {
+				stmt.run(
+					options.agentId,
+					artifact.sourcePath,
+					artifact.sourceSha256,
+					artifact.sourceKind,
+					artifact.sessionId,
+					artifact.sessionKey,
+					artifact.sessionToken,
+					artifact.project,
+					artifact.harness,
+					artifact.capturedAt,
+					artifact.startedAt,
+					artifact.endedAt,
+					artifact.manifestPath,
+					artifact.sourceNodeId,
+					artifact.memorySentence,
+					artifact.memorySentenceQuality,
+					artifact.content,
+					artifact.updatedAt,
+					artifact.sourceMtimeMs,
+					artifact.sourceId,
+					artifact.sourceRoot,
+					artifact.sourceExternalId,
+					artifact.sourceParentPath,
+					artifact.sourceMetaJson,
+				);
+			}
+		});
+	} catch (err) {
+		return { ok: false, error: err instanceof Error ? err.message : String(err) };
+	}
+
+	return { ok: true, imported: artifacts.length, skipped: { localDiscordArtifacts: skippedLocal } };
+}
+
+function findPathOwnershipConflict(
+	db: Database,
+	artifacts: readonly SourceSnapshotArtifact[],
+	agentId: string,
+	sourceId: string,
+): string | null {
+	const stmt = db.prepare("SELECT source_id FROM memory_artifacts WHERE agent_id = ? AND source_path = ? LIMIT 1");
+	for (const artifact of artifacts) {
+		const row = stmt.get(agentId, artifact.sourcePath) as { source_id: string | null } | undefined;
+		if (row && row.source_id !== sourceId) {
+			return `Snapshot artifact path is already owned by another source: ${artifact.sourcePath}`;
+		}
+	}
+	return null;
+}
+
+function deleteImportScope(db: Database, sourceId: string, agentId: string, includeLocalDiscord: boolean): void {
+	if (includeLocalDiscord) {
+		db.prepare("DELETE FROM memory_artifacts WHERE agent_id = ? AND source_id = ?").run(agentId, sourceId);
+		return;
+	}
+	const rows = db
+		.prepare(
+			`SELECT source_path, source_meta_json
+			   FROM memory_artifacts
+			  WHERE agent_id = ?
+			    AND source_id = ?`,
+		)
+		.all(agentId, sourceId) as Array<{ source_path: string; source_meta_json: string | null }>;
+	const stmt = db.prepare("DELETE FROM memory_artifacts WHERE agent_id = ? AND source_path = ?");
+	for (const row of rows) {
+		if (isLocalDiscordArtifact({ sourcePath: row.source_path, sourceMetaJson: row.source_meta_json })) continue;
+		stmt.run(agentId, row.source_path);
+	}
+}
+
+function purgeImportScopeChunks(db: Database, sourceId: string, agentId: string, includeLocalDiscord: boolean): void {
+	const prefix = `${sourceId}:`;
+	const rows = db
+		.prepare(
+			`SELECT id, source_id, chunk_text
+			   FROM embeddings
+			  WHERE agent_id = ?
+			    AND source_type = ?
+			    AND source_id >= ?
+			    AND source_id < ?`,
+		)
+		.all(agentId, SOURCE_CHUNK_SOURCE_TYPE, prefix, `${prefix}\uffff`) as Array<{
+		id: string;
+		source_id: string;
+		chunk_text: string | null;
+	}>;
+	const ids = rows.filter((row) => includeLocalDiscord || !isLocalDiscordChunk(row)).map((row) => row.id);
+	syncVecDeleteByEmbeddingIds(db as WriteDb, ids);
+	const stmt = db.prepare("DELETE FROM embeddings WHERE id = ?");
+	for (const id of ids) stmt.run(id);
+}
+
+function artifactFromRow(row: ArtifactRow): SourceSnapshotArtifact {
+	return {
+		sourcePath: row.source_path,
+		sourceSha256: row.source_sha256,
+		sourceKind: row.source_kind,
+		sessionId: row.session_id,
+		sessionKey: row.session_key,
+		sessionToken: row.session_token,
+		project: row.project,
+		harness: row.harness,
+		capturedAt: row.captured_at,
+		startedAt: row.started_at,
+		endedAt: row.ended_at,
+		manifestPath: row.manifest_path,
+		sourceNodeId: row.source_node_id,
+		memorySentence: row.memory_sentence,
+		memorySentenceQuality: row.memory_sentence_quality,
+		content: row.content,
+		updatedAt: row.updated_at,
+		sourceMtimeMs: row.source_mtime_ms,
+		sourceId: row.source_id,
+		sourceRoot: row.source_root,
+		sourceExternalId: row.source_external_id,
+		sourceParentPath: row.source_parent_path,
+		sourceMetaJson: row.source_meta_json,
+	};
+}
+
+function parseSourceSnapshot(value: unknown): { ok: true; value: SourceSnapshot } | { ok: false; error: string } {
+	if (!isRecord(value)) return { ok: false, error: "Snapshot must be a JSON object" };
+	if (value.version !== SOURCE_SNAPSHOT_VERSION) return { ok: false, error: "Unsupported source snapshot version" };
+	if (!isRecord(value.source)) return { ok: false, error: "Snapshot source must be an object" };
+	const source = {
+		id: readString(value.source, "id"),
+		kind: readString(value.source, "kind"),
+		name: readString(value.source, "name"),
+		root: readString(value.source, "root"),
+	};
+	if (!source.id || !source.kind || !source.name || !source.root) {
+		return { ok: false, error: "Snapshot source is missing id, kind, name, or root" };
+	}
+	const exportedAt = readString(value, "exportedAt");
+	const agentId = readString(value, "agentId");
+	if (!exportedAt || !agentId) return { ok: false, error: "Snapshot is missing exportedAt or agentId" };
+	if (!Array.isArray(value.artifacts)) return { ok: false, error: "Snapshot artifacts must be an array" };
+
+	const artifacts: SourceSnapshotArtifact[] = [];
+	for (const artifact of value.artifacts) {
+		const parsed = parseArtifact(artifact);
+		if (parsed.ok === false) return parsed;
+		artifacts.push(parsed.value);
+	}
+
+	const skipped = isRecord(value.skipped)
+		? { localDiscordArtifacts: readNumber(value.skipped, "localDiscordArtifacts") ?? 0 }
+		: { localDiscordArtifacts: 0 };
+	return { ok: true, value: { version: SOURCE_SNAPSHOT_VERSION, exportedAt, source, agentId, artifacts, skipped } };
+}
+
+function parseArtifact(value: unknown): { ok: true; value: SourceSnapshotArtifact } | { ok: false; error: string } {
+	if (!isRecord(value)) return { ok: false, error: "Snapshot artifact must be an object" };
+	const required = {
+		sourcePath: readString(value, "sourcePath"),
+		sourceSha256: readString(value, "sourceSha256"),
+		sourceKind: readString(value, "sourceKind"),
+		sessionId: readString(value, "sessionId"),
+		sessionToken: readString(value, "sessionToken"),
+		content: readString(value, "content"),
+		updatedAt: readString(value, "updatedAt"),
+		sourceId: readString(value, "sourceId"),
+		capturedAt: readString(value, "capturedAt"),
+	};
+	for (const [key, entry] of Object.entries(required)) {
+		if (!entry) return { ok: false, error: `Snapshot artifact is missing ${key}` };
+	}
+	return {
+		ok: true,
+		value: {
+			...required,
+			sessionKey: readNullableString(value, "sessionKey"),
+			project: readNullableString(value, "project"),
+			harness: readNullableString(value, "harness"),
+			startedAt: readNullableString(value, "startedAt"),
+			endedAt: readNullableString(value, "endedAt"),
+			manifestPath: readNullableString(value, "manifestPath"),
+			sourceNodeId: readNullableString(value, "sourceNodeId"),
+			memorySentence: readNullableString(value, "memorySentence"),
+			memorySentenceQuality: readNullableString(value, "memorySentenceQuality"),
+			sourceMtimeMs: readNullableNumber(value, "sourceMtimeMs"),
+			sourceRoot: readNullableString(value, "sourceRoot"),
+			sourceExternalId: readNullableString(value, "sourceExternalId"),
+			sourceParentPath: readNullableString(value, "sourceParentPath"),
+			sourceMetaJson: readNullableString(value, "sourceMetaJson"),
+		},
+	};
+}
+
+function isLocalDiscordArtifact(input: {
+	readonly sourcePath: string;
+	readonly sourceMetaJson: string | null;
+}): boolean {
+	if (input.sourcePath.startsWith("discord-cache://guild/@me/")) return true;
+	if (!input.sourceMetaJson) return false;
+	try {
+		const parsed = JSON.parse(input.sourceMetaJson) as unknown;
+		return isRecord(parsed) && parsed.guildId === "@me";
+	} catch {
+		return false;
+	}
+}
+
+function isLocalDiscordChunk(input: {
+	readonly source_id: string;
+	readonly chunk_text: string | null;
+}): boolean {
+	if (input.source_id.includes("discord-cache://guild/@me/")) return true;
+	if (!input.chunk_text) return false;
+	return (
+		input.chunk_text.includes("source_path: discord-cache://guild/@me/") || input.chunk_text.includes('"guildId":"@me"')
+	);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(record: Record<string, unknown>, key: string): string {
+	const value = record[key];
+	return typeof value === "string" ? value : "";
+}
+
+function readNullableString(record: Record<string, unknown>, key: string): string | null {
+	const value = record[key];
+	return typeof value === "string" ? value : null;
+}
+
+function readNumber(record: Record<string, unknown>, key: string): number | null {
+	const value = record[key];
+	return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function readNullableNumber(record: Record<string, unknown>, key: string): number | null {
+	return readNumber(record, key);
+}

--- a/surfaces/cli/src/commands/sources.test.ts
+++ b/surfaces/cli/src/commands/sources.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadSourcesConfig } from "@signet/core";
@@ -9,6 +9,7 @@ import { registerSourcesCommands } from "./sources";
 describe("sources CLI commands", () => {
 	let dir = "";
 	let originalLog: typeof console.log;
+	let originalError: typeof console.error;
 	let previousExitCode: string | number | undefined;
 
 	beforeEach(() => {
@@ -16,11 +17,14 @@ describe("sources CLI commands", () => {
 		previousExitCode = process.exitCode;
 		Reflect.deleteProperty(process, "exitCode");
 		originalLog = console.log;
+		originalError = console.error;
 		console.log = () => {};
+		console.error = () => {};
 	});
 
 	afterEach(() => {
 		console.log = originalLog;
+		console.error = originalError;
 		if (previousExitCode === undefined) process.exitCode = 0;
 		else process.exitCode = previousExitCode;
 		rmSync(dir, { recursive: true, force: true });
@@ -52,6 +56,39 @@ describe("sources CLI commands", () => {
 		expect(source?.root).toBe(cachePath);
 		expect(source?.providerSettings?.syncMode).toBe("desktop-cache");
 		expect(source?.providerSettings?.desktopCacheFullScan).toBe(true);
+		expect(process.exitCode).not.toBe(1);
+	});
+
+	it("wires source snapshot export through the daemon command path", async () => {
+		const out = join(dir, "snapshot.json");
+		const calls: Array<{ method: string; path: string }> = [];
+		const program = new Command();
+		program.exitOverride();
+		registerSourcesCommands(program, {
+			agentsDir: dir,
+			secretApiCall: async (method, path) => {
+				calls.push({ method, path });
+				return {
+					ok: true,
+					data: { version: 1, source: { id: "discord:source" }, artifacts: [], skipped: { localDiscordArtifacts: 0 } },
+				};
+			},
+		});
+
+		await program.parseAsync([
+			"node",
+			"test",
+			"sources",
+			"snapshot",
+			"export",
+			"discord:source",
+			"--include-local-discord",
+			"--out",
+			out,
+		]);
+
+		expect(calls).toEqual([{ method: "GET", path: "/api/sources/discord%3Asource/snapshot?includeLocalDiscord=true" }]);
+		expect(existsSync(out)).toBe(true);
 		expect(process.exitCode).not.toBe(1);
 	});
 });

--- a/surfaces/cli/src/commands/sources.ts
+++ b/surfaces/cli/src/commands/sources.ts
@@ -3,6 +3,8 @@ import {
 	type SourcesDeps,
 	addDiscordSourceFromCli,
 	addObsidianVaultSource,
+	exportConfiguredSourceSnapshot,
+	importConfiguredSourceSnapshot,
 	listSources,
 	removeConfiguredSource,
 } from "../features/sources.js";
@@ -53,6 +55,75 @@ export function registerSourcesCommands(program: Command, deps: RegisterSourcesC
 			}),
 		);
 
+	const snapshot = sources.command("snapshot").description("Export or import source-owned snapshot data");
+
+	snapshot
+		.command("export <sourceId>")
+		.description("Export source-owned artifacts as a JSON snapshot")
+		.option("--out <path>", "Write snapshot JSON to a file instead of stdout")
+		.option("--include-local-discord", "Include local Discord @me desktop-cache artifacts")
+		.action((sourceId: string, options: { out?: string; includeLocalDiscord?: boolean }) =>
+			exportConfiguredSourceSnapshot(sourceId, options, {
+				...deps,
+				exportSourceSnapshotFromDaemon: deps.secretApiCall
+					? async (id, exportOptions) => {
+							const query = exportOptions.includeLocalDiscord ? "?includeLocalDiscord=true" : "";
+							const result = await deps.secretApiCall?.(
+								"GET",
+								`/api/sources/${encodeURIComponent(id)}/snapshot${query}`,
+								undefined,
+								30_000,
+							);
+							if (!result?.ok) return { ok: false, error: errorFromDaemonData(result?.data) };
+							const data = result.data as { artifacts?: unknown[]; skipped?: { localDiscordArtifacts?: number } };
+							return {
+								ok: true,
+								snapshot: result.data,
+								artifactCount: Array.isArray(data.artifacts) ? data.artifacts.length : 0,
+								skippedLocalDiscordArtifacts:
+									typeof data.skipped?.localDiscordArtifacts === "number" ? data.skipped.localDiscordArtifacts : 0,
+							};
+						}
+					: undefined,
+			}),
+		);
+
+	snapshot
+		.command("import <sourceId> <file>")
+		.description("Import a source snapshot into an existing configured source")
+		.option("--include-local-discord", "Import local Discord @me desktop-cache artifacts from the snapshot")
+		.action((sourceId: string, file: string, options: { includeLocalDiscord?: boolean }) =>
+			importConfiguredSourceSnapshot(
+				sourceId,
+				{ file, ...options },
+				{
+					...deps,
+					importSourceSnapshotToDaemon: deps.secretApiCall
+						? async (id, sourceSnapshot, importOptions) => {
+								const query = importOptions.includeLocalDiscord ? "?includeLocalDiscord=true" : "";
+								const result = await deps.secretApiCall?.(
+									"POST",
+									`/api/sources/${encodeURIComponent(id)}/snapshot/import${query}`,
+									sourceSnapshot,
+									60_000,
+								);
+								if (!result?.ok) return { ok: false, error: errorFromDaemonData(result?.data) };
+								const data = result.data as {
+									imported?: unknown;
+									skipped?: { localDiscordArtifacts?: unknown };
+								};
+								return {
+									ok: true,
+									imported: typeof data.imported === "number" ? data.imported : 0,
+									skippedLocalDiscordArtifacts:
+										typeof data.skipped?.localDiscordArtifacts === "number" ? data.skipped.localDiscordArtifacts : 0,
+								};
+							}
+						: undefined,
+				},
+			),
+		);
+
 	const add = sources.command("add").description("Add an external read-only knowledge source");
 
 	add
@@ -90,4 +161,10 @@ export function registerSourcesCommands(program: Command, deps: RegisterSourcesC
 		.option("--no-thread-members", "Skip thread member snapshots")
 		.option("--mode <mode>", "Sync mode: rest, gateway-tail, or desktop-cache", "rest")
 		.action((options) => addDiscordSourceFromCli(options, deps));
+}
+
+function errorFromDaemonData(data: unknown): string {
+	return typeof data === "object" && data !== null && "error" in data
+		? String((data as { error?: unknown }).error)
+		: "daemon request failed";
 }

--- a/surfaces/cli/src/features/sources.test.ts
+++ b/surfaces/cli/src/features/sources.test.ts
@@ -1,9 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { addObsidianSource, loadSourcesConfig } from "@signet/core";
-import { addDiscordSourceFromCli, addObsidianVaultSource, removeConfiguredSource } from "./sources";
+import {
+	addDiscordSourceFromCli,
+	addObsidianVaultSource,
+	exportConfiguredSourceSnapshot,
+	importConfiguredSourceSnapshot,
+	removeConfiguredSource,
+} from "./sources";
 
 describe("sources CLI features", () => {
 	let dir = "";
@@ -120,5 +126,64 @@ describe("sources CLI features", () => {
 
 		expect(errors.join("\n")).toContain("Source not found");
 		expect(process.exitCode).toBe(1);
+	});
+
+	it("exports a source snapshot from the daemon to a file", async () => {
+		const out = join(dir, "snapshot.json");
+		await exportConfiguredSourceSnapshot(
+			"discord:source",
+			{ out },
+			{
+				agentsDir: dir,
+				exportSourceSnapshotFromDaemon: async (sourceId, options) => ({
+					ok: true,
+					snapshot: { version: 1, source: { id: sourceId }, artifacts: [{ id: "a1" }] },
+					artifactCount: 1,
+					skippedLocalDiscordArtifacts: options.includeLocalDiscord ? 0 : 2,
+				}),
+			},
+		);
+
+		expect(JSON.parse(readFileSync(out, "utf8"))).toMatchObject({ version: 1, source: { id: "discord:source" } });
+		expect(logs.join("\n")).toContain("Exported source snapshot: discord:source");
+		expect(errors.join("\n")).toContain("Exported 1 source artifacts");
+		expect(errors.join("\n")).toContain("Skipped 2 local Discord @me artifacts");
+		expect(process.exitCode).not.toBe(1);
+	});
+
+	it("imports a source snapshot through the daemon", async () => {
+		const file = join(dir, "snapshot.json");
+		await exportConfiguredSourceSnapshot(
+			"discord:source",
+			{ out: file, includeLocalDiscord: true },
+			{
+				agentsDir: dir,
+				exportSourceSnapshotFromDaemon: async () => ({
+					ok: true,
+					snapshot: { version: 1, source: { id: "discord:source" }, artifacts: [] },
+					artifactCount: 0,
+					skippedLocalDiscordArtifacts: 0,
+				}),
+			},
+		);
+		logs = [];
+		errors = [];
+
+		await importConfiguredSourceSnapshot(
+			"discord:source",
+			{ file, includeLocalDiscord: true },
+			{
+				agentsDir: dir,
+				importSourceSnapshotToDaemon: async (sourceId, snapshot, options) => ({
+					ok: true,
+					imported: sourceId === "discord:source" && options.includeLocalDiscord && !!snapshot ? 3 : 0,
+					skippedLocalDiscordArtifacts: 0,
+				}),
+			},
+		);
+
+		expect(logs.join("\n")).toContain("Imported source snapshot: discord:source");
+		expect(logs.join("\n")).toContain("Imported 3 source artifacts");
+		expect(process.exitCode).not.toBe(1);
 	});
 });

--- a/surfaces/cli/src/features/sources.ts
+++ b/surfaces/cli/src/features/sources.ts
@@ -1,9 +1,19 @@
+import { readFileSync, writeFileSync } from "node:fs";
 import { addDiscordSource, addObsidianSource, loadSourcesConfig, removeSource } from "@signet/core";
 import chalk from "chalk";
 
 export interface SourcesDeps {
 	readonly agentsDir: string;
 	readonly removeSourceFromDaemon?: (sourceId: string) => Promise<DaemonRemoveSourceResult>;
+	readonly exportSourceSnapshotFromDaemon?: (
+		sourceId: string,
+		options: { readonly includeLocalDiscord?: boolean },
+	) => Promise<DaemonSourceSnapshotResult>;
+	readonly importSourceSnapshotToDaemon?: (
+		sourceId: string,
+		snapshot: unknown,
+		options: { readonly includeLocalDiscord?: boolean },
+	) => Promise<DaemonImportSourceSnapshotResult>;
 }
 
 export type DaemonRemoveSourceResult =
@@ -11,6 +21,23 @@ export type DaemonRemoveSourceResult =
 			readonly ok: true;
 			readonly source?: { readonly name?: string; readonly root?: string };
 			readonly purged?: number;
+	  }
+	| { readonly ok: false; readonly error: string };
+
+export type DaemonSourceSnapshotResult =
+	| {
+			readonly ok: true;
+			readonly snapshot: unknown;
+			readonly artifactCount?: number;
+			readonly skippedLocalDiscordArtifacts?: number;
+	  }
+	| { readonly ok: false; readonly error: string };
+
+export type DaemonImportSourceSnapshotResult =
+	| {
+			readonly ok: true;
+			readonly imported?: number;
+			readonly skippedLocalDiscordArtifacts?: number;
 	  }
 	| { readonly ok: false; readonly error: string };
 
@@ -37,6 +64,16 @@ export interface AddDiscordSourceOptions {
 	readonly polls?: boolean;
 	readonly threadMembers?: boolean;
 	readonly mode?: "rest" | "gateway-tail" | "desktop-cache";
+}
+
+export interface ExportSourceSnapshotOptions {
+	readonly out?: string;
+	readonly includeLocalDiscord?: boolean;
+}
+
+export interface ImportSourceSnapshotOptions {
+	readonly file: string;
+	readonly includeLocalDiscord?: boolean;
 }
 
 export async function addObsidianVaultSource(
@@ -164,4 +201,75 @@ export async function removeConfiguredSource(sourceId: string, deps: SourcesDeps
 		chalk.dim("  Indexed source rows/chunks/graph artifacts were not purged because the daemon API was unavailable."),
 	);
 	console.log(chalk.dim("  Start the daemon and run this command again if a database purge is still required."));
+}
+
+export async function exportConfiguredSourceSnapshot(
+	sourceId: string,
+	options: ExportSourceSnapshotOptions,
+	deps: SourcesDeps,
+): Promise<void> {
+	if (!deps.exportSourceSnapshotFromDaemon) {
+		console.error(chalk.red("✗ Source snapshot export requires the Signet daemon API."));
+		process.exitCode = 1;
+		return;
+	}
+	const result = await deps.exportSourceSnapshotFromDaemon(sourceId, {
+		includeLocalDiscord: options.includeLocalDiscord,
+	});
+	if (result.ok === false) {
+		console.error(chalk.red(`✗ ${result.error}`));
+		process.exitCode = 1;
+		return;
+	}
+
+	const text = `${JSON.stringify(result.snapshot, null, 2)}\n`;
+	if (options.out) {
+		writeFileSync(options.out, text, "utf8");
+		console.log(chalk.green(`✓ Exported source snapshot: ${sourceId}`));
+		console.log(chalk.dim(`  ${options.out}`));
+	} else {
+		console.log(text.trimEnd());
+	}
+	console.error(chalk.dim(`Exported ${result.artifactCount ?? 0} source artifacts.`));
+	if ((result.skippedLocalDiscordArtifacts ?? 0) > 0) {
+		console.error(
+			chalk.dim(
+				`Skipped ${result.skippedLocalDiscordArtifacts} local Discord @me artifacts. Use --include-local-discord to include them.`,
+			),
+		);
+	}
+}
+
+export async function importConfiguredSourceSnapshot(
+	sourceId: string,
+	options: ImportSourceSnapshotOptions,
+	deps: SourcesDeps,
+): Promise<void> {
+	if (!deps.importSourceSnapshotToDaemon) {
+		console.error(chalk.red("✗ Source snapshot import requires the Signet daemon API."));
+		process.exitCode = 1;
+		return;
+	}
+	let snapshot: unknown;
+	try {
+		snapshot = JSON.parse(readFileSync(options.file, "utf8")) as unknown;
+	} catch (err) {
+		console.error(chalk.red(`✗ Could not read source snapshot: ${err instanceof Error ? err.message : String(err)}`));
+		process.exitCode = 1;
+		return;
+	}
+
+	const result = await deps.importSourceSnapshotToDaemon(sourceId, snapshot, {
+		includeLocalDiscord: options.includeLocalDiscord,
+	});
+	if (result.ok === false) {
+		console.error(chalk.red(`✗ ${result.error}`));
+		process.exitCode = 1;
+		return;
+	}
+	console.log(chalk.green(`✓ Imported source snapshot: ${sourceId}`));
+	console.log(chalk.dim(`  Imported ${result.imported ?? 0} source artifacts.`));
+	if ((result.skippedLocalDiscordArtifacts ?? 0) > 0) {
+		console.log(chalk.dim(`  Skipped ${result.skippedLocalDiscordArtifacts} local Discord @me artifacts.`));
+	}
 }


### PR DESCRIPTION
## Summary
- Adds generic Signet source snapshot export/import for source-owned `memory_artifacts`.
- Adds daemon API routes and CLI commands for `signet sources snapshot export|import`.
- Defaults to excluding Discord Desktop cache `@me` artifacts, while preserving local `@me` rows on import unless explicitly included.
- Documents the snapshot contract in Sources and API reference docs.

## Test Plan
- [x] `bun test platform/daemon/src/routes/sources-routes.test.ts surfaces/cli/src/features/sources.test.ts surfaces/cli/src/commands/sources.test.ts`
- [x] `bun test platform/core/src/sources-config.test.ts platform/daemon/src/discord-source-provider.test.ts platform/daemon/src/routes/sources-routes.test.ts surfaces/cli/src/commands/sources.test.ts surfaces/cli/src/features/sources.test.ts`
- [x] `bun run --filter '@signet/core' build`
- [x] `bun run --filter '@signet/cli' build`
- [x] `bun run --filter '@signet/daemon' build`
- [x] `git diff --check`
- [ ] `bun scripts/doc-drift.ts --markdown` currently reports pre-existing migration/package inventory drift unrelated to this PR.

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)
- [x] No database migrations changed
