### PR TITLE
feat(sources): add source operations diagnostics

### DIFF
--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -122,6 +122,19 @@ Partial GitHub failures are written as source-owned failure artifacts and cause
 the shared source job to report failure instead of silently marking incomplete
 data as fully indexed.
 
+Operations diagnostics
+----------------------
+
+The sources API and dashboard expose source health diagnostics for operational
+follow-up after sync, import, or removal. Each configured source reports
+artifact and chunk counts, latest artifact/checkpoint timestamps, Discord
+partial-failure artifacts, partial and stale checkpoints, purge residue, and
+source-provenance graph row counts. Discord sources degrade when Signet has
+recorded fetch failures, partial checkpoints, stale checkpoints, deleted
+artifact residue, or orphan chunks. If diagnostics cannot read the backing
+tables, the source health reports `unhealthy` with error context rather than
+pretending the source is healthy.
+
 Obsidian v1
 -----------
 
@@ -257,6 +270,9 @@ The daemon exposes the Sources lifecycle under `/api/sources`:
 | `POST` | `/api/sources/obsidian` | Add/update an Obsidian vault source and index it. |
 | `POST` | `/api/sources/discord` | Add/update a Discord source and queue a shared source index job. |
 | `POST` | `/api/sources/github` | Add/update a GitHub source and queue a shared source index job. |
+| `GET` | `/api/sources/:sourceId/health` | Inspect source health diagnostics used by the dashboard. |
+| `GET` | `/api/sources/:sourceId/snapshot` | Export source-owned artifacts as a Signet source snapshot. |
+| `POST` | `/api/sources/:sourceId/snapshot/import` | Import a Signet source snapshot into an existing source. |
 | `DELETE` | `/api/sources/:sourceId` | Remove a source config and purge Signet-owned source rows. |
 | `POST` | `/api/sources/pick-directory` | Development/browser fallback for choosing a local directory. |
 

--- a/docs/api/documents-sources.md
+++ b/docs/api/documents-sources.md
@@ -159,7 +159,18 @@ agent.
       "updatedAt": "2026-05-06T09:00:00.000Z",
       "lastIndexedAt": "2026-05-06T09:01:00.000Z",
       "excludeGlobs": ["**/.obsidian/**", "**/.trash/**", "**/.hermes/**"],
-      "stats": { "artifacts": 42, "chunks": 108, "indexed": 42 }
+      "stats": { "artifacts": 42, "chunks": 108, "indexed": 42 },
+      "health": {
+        "status": "healthy",
+        "generatedAt": "2026-05-06T09:01:00.000Z",
+        "latestArtifactAt": "2026-05-06T09:01:00.000Z",
+        "latestCheckpointAt": null,
+        "chunkCoverage": 1,
+        "failures": { "total": 0, "recoverable": 0 },
+        "checkpoints": { "total": 0, "partial": 0, "stale": 0 },
+        "purge": { "deletedArtifacts": 0, "orphanChunks": 0 },
+        "semantic": { "entities": 8, "attributes": 0, "dependencies": 12, "communities": 3, "total": 23 }
+      }
     }
   ]
 }
@@ -323,6 +334,38 @@ and source chunk embeddings. Source files are not modified.
 {
   "source": { "id": "obsidian:abc123", "kind": "obsidian" },
   "purged": 150
+}
+```
+
+### GET /api/sources/:sourceId/health
+
+Return operational diagnostics for a configured source. The payload is the same
+health object embedded in `GET /api/sources`, plus the source config and index
+stats.
+
+Diagnostics include artifact/chunk counts, latest artifact and checkpoint
+timestamps, Discord partial-failure/checkpoint counts, stale checkpoint counts,
+purge residue, and source-provenance graph row counts. If diagnostic queries
+fail, the route returns `status: "unhealthy"` with an `error` field instead of
+synthesizing a healthy source.
+
+**Response**
+
+```json
+{
+  "source": { "id": "discord:abc123", "kind": "discord", "name": "Team Discord" },
+  "stats": { "artifacts": 420, "chunks": 250, "indexed": 420 },
+  "health": {
+    "status": "degraded",
+    "generatedAt": "2026-05-24T00:00:00.000Z",
+    "latestArtifactAt": "2026-05-24T00:00:00.000Z",
+    "latestCheckpointAt": "2026-05-24T00:00:00.000Z",
+    "chunkCoverage": 0.6,
+    "failures": { "total": 1, "recoverable": 1 },
+    "checkpoints": { "total": 20, "partial": 1, "stale": 0 },
+    "purge": { "deletedArtifacts": 0, "orphanChunks": 0 },
+    "semantic": { "entities": 12, "attributes": 4, "dependencies": 6, "communities": 2, "total": 24 }
+  }
 }
 ```
 

--- a/docs/api/route-inventory.md
+++ b/docs/api/route-inventory.md
@@ -51,6 +51,7 @@ silently disappear from the API reference.
 | POST | `/api/sources/pick-directory` | platform/daemon/src/routes/sources-routes.ts |
 | POST | `/api/sources/obsidian` | platform/daemon/src/routes/sources-routes.ts |
 | POST | `/api/sources/discord` | platform/daemon/src/routes/sources-routes.ts |
+| GET | `/api/sources/:sourceId/health` | platform/daemon/src/routes/sources-routes.ts |
 | GET | `/api/sources/:sourceId/snapshot` | platform/daemon/src/routes/sources-routes.ts |
 | POST | `/api/sources/:sourceId/snapshot/import` | platform/daemon/src/routes/sources-routes.ts |
 | DELETE | `/api/sources/:sourceId` | platform/daemon/src/routes/sources-routes.ts |

--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -456,9 +456,16 @@ describe("Sources routes", () => {
 		const res = await makeApp().request("/api/sources");
 		expect(res.status).toBe(200);
 		const body = (await res.json()) as {
-			sources: Array<{ stats?: { artifacts: number; chunks: number; indexed: number } }>;
+			sources: Array<{
+				stats?: { artifacts: number; chunks: number; indexed: number };
+				health?: { status?: string; purge?: { orphanChunks?: number } };
+			}>;
 		};
 		expect(body.sources[0]?.stats).toEqual({ artifacts: 1, chunks: 1, indexed: 1 });
+		expect(body.sources[0]?.health).toMatchObject({
+			status: "healthy",
+			purge: { orphanChunks: 0 },
+		});
 	});
 
 	it("reports generic source stats for Discord source-owned artifacts and chunks", async () => {
@@ -862,6 +869,214 @@ describe("Sources routes", () => {
 			sources: Array<{ indexJob?: { status?: string; scanned?: number; indexed?: number } }>;
 		};
 		expect(completed.sources[0]?.indexJob).toMatchObject({ status: "complete", scanned: 3, indexed: 2 });
+	});
+
+	it("reports source health diagnostics from artifacts, chunks, failures, and checkpoints", async () => {
+		const added = addDiscordSource(
+			{
+				guildIds: ["123456789012345678"],
+				tokenRef: "DISCORD_BOT_TOKEN",
+				name: "Health Discord",
+			},
+			dir,
+		);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+
+		insertSourceArtifact({
+			sourceId: added.source.id,
+			sourceRoot: added.source.root,
+			sourcePath: "discord://guild/123/channel/456/message/789",
+			sourceKind: "source_discord_message",
+			content: "health test message",
+			metaJson: "{}",
+		});
+		insertSourceArtifact({
+			sourceId: added.source.id,
+			sourceRoot: added.source.root,
+			sourcePath: `discord://source/${added.source.id}/checkpoint/123/456`,
+			sourceKind: "source_discord_checkpoint",
+			content: "partial checkpoint",
+			metaJson: JSON.stringify({ status: "partial", recordType: "checkpoint" }),
+		});
+		insertSourceArtifact({
+			sourceId: added.source.id,
+			sourceRoot: added.source.root,
+			sourcePath: `discord://source/${added.source.id}/failure/rate-limit`,
+			sourceKind: "source_discord_failure",
+			content: "recoverable failure",
+			metaJson: JSON.stringify({ recoverable: true, status: 429 }),
+		});
+		insertSourceChunk({
+			id: "health-discord-chunk",
+			sourceId: `${added.source.id}:discord://guild/123/channel/456/message/789#0`,
+			chunkText: "health test message",
+		});
+
+		const res = await makeApp().request("/api/sources");
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			sources: Array<{
+				stats?: { artifacts?: number; chunks?: number };
+				health?: {
+					status?: string;
+					failures?: { total?: number; recoverable?: number };
+					checkpoints?: { total?: number; partial?: number };
+					latestArtifactAt?: string | null;
+					latestCheckpointAt?: string | null;
+				};
+			}>;
+		};
+		expect(body.sources[0]?.stats).toMatchObject({ artifacts: 3, chunks: 1 });
+		expect(body.sources[0]?.health).toMatchObject({
+			status: "degraded",
+			failures: { total: 1, recoverable: 1 },
+			checkpoints: { total: 1, partial: 1 },
+		});
+		expect(body.sources[0]?.health?.latestArtifactAt).toBe("2026-05-24T00:00:00.000Z");
+		expect(body.sources[0]?.health?.latestCheckpointAt).toBe("2026-05-24T00:00:00.000Z");
+
+		const healthRes = await makeApp().request(`/api/sources/${encodeURIComponent(added.source.id)}/health`);
+		expect(healthRes.status).toBe(200);
+		const healthBody = (await healthRes.json()) as {
+			stats?: { artifacts?: number; chunks?: number };
+			health?: { status?: string; failures?: { total?: number }; checkpoints?: { partial?: number } };
+		};
+		expect(healthBody.stats).toMatchObject({ artifacts: 3, chunks: 1 });
+		expect(healthBody.health).toMatchObject({
+			status: "degraded",
+			failures: { total: 1 },
+			checkpoints: { partial: 1 },
+		});
+	});
+
+	it("reports orphan source chunks when live artifacts still exist", async () => {
+		const added = addDiscordSource(
+			{
+				guildIds: ["123456789012345678"],
+				tokenRef: "DISCORD_BOT_TOKEN",
+				name: "Orphan Chunk Discord",
+			},
+			dir,
+		);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+
+		insertSourceArtifact({
+			sourceId: added.source.id,
+			sourceRoot: added.source.root,
+			sourcePath: "discord://guild/123/channel/456/message/live",
+			sourceKind: "source_discord_message",
+			content: "live message",
+			metaJson: "{}",
+		});
+		insertSourceChunk({
+			id: "live-discord-chunk",
+			sourceId: `${added.source.id}:guild/123/channel/456/message/live#0`,
+			chunkText: "source_path: discord://guild/123/channel/456/message/live\n\nlive message",
+		});
+		insertSourceChunk({
+			id: "orphan-discord-chunk",
+			sourceId: `${added.source.id}:guild/123/channel/456/message/deleted#0`,
+			chunkText: "deleted message",
+		});
+
+		const res = await makeApp().request(`/api/sources/${encodeURIComponent(added.source.id)}/health`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { health?: { status?: string; purge?: { orphanChunks?: number } } };
+		expect(body.health).toMatchObject({
+			status: "degraded",
+			purge: { orphanChunks: 1 },
+		});
+	});
+
+	it("degrades source health when only deleted artifact residue remains", async () => {
+		const added = addDiscordSource(
+			{
+				guildIds: ["123456789012345678"],
+				tokenRef: "DISCORD_BOT_TOKEN",
+				name: "Deleted Residue Discord",
+			},
+			dir,
+		);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+
+		insertSourceArtifact({
+			sourceId: added.source.id,
+			sourceRoot: added.source.root,
+			sourcePath: "discord://guild/123/channel/456/message/deleted",
+			sourceKind: "source_discord_message",
+			content: "deleted message",
+			metaJson: "{}",
+		});
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE memory_artifacts SET is_deleted = 1 WHERE source_id = ?").run(added.source.id);
+		});
+
+		const res = await makeApp().request(`/api/sources/${encodeURIComponent(added.source.id)}/health`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			stats?: { artifacts?: number; chunks?: number };
+			health?: { status?: string; purge?: { deletedArtifacts?: number } };
+		};
+		expect(body.stats).toMatchObject({ artifacts: 0, chunks: 0 });
+		expect(body.health).toMatchObject({
+			status: "degraded",
+			purge: { deletedArtifacts: 1 },
+		});
+	});
+
+	it("returns a clear 404 for source health on an unknown source", async () => {
+		const res = await makeApp().request("/api/sources/discord%3Amissing/health");
+		expect(res.status).toBe(404);
+		expect(((await res.json()) as { error: string }).error).toContain("Source not found");
+	});
+
+	it("marks source health unhealthy when diagnostics queries fail", async () => {
+		const added = addDiscordSource(
+			{
+				guildIds: ["123456789012345678"],
+				tokenRef: "DISCORD_BOT_TOKEN",
+				name: "Broken Health Discord",
+			},
+			dir,
+		);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("DROP TABLE memory_artifacts").run();
+		});
+
+		const res = await makeApp().request(`/api/sources/${encodeURIComponent(added.source.id)}/health`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { health?: { status?: string; error?: string } };
+		expect(body.health?.status).toBe("unhealthy");
+		expect(body.health?.error).toContain("Source health diagnostics failed");
+	});
+
+	it("marks source health unhealthy when semantic diagnostics queries fail", async () => {
+		const added = addDiscordSource(
+			{
+				guildIds: ["123456789012345678"],
+				tokenRef: "DISCORD_BOT_TOKEN",
+				name: "Broken Semantic Health Discord",
+			},
+			dir,
+		);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("DROP TABLE entity_communities").run();
+		});
+
+		const res = await makeApp().request(`/api/sources/${encodeURIComponent(added.source.id)}/health`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { health?: { status?: string; error?: string } };
+		expect(body.health?.status).toBe("unhealthy");
+		expect(body.health?.error).toContain("Source health diagnostics failed");
 	});
 
 	it("completes startup source jobs from their own progress, not aggregate bridge counts", () => {

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -17,7 +17,7 @@ import {
 } from "@signet/core";
 import type { Hono } from "hono";
 import { resolveDaemonAgentId } from "../agent-id";
-import { getDbAccessor } from "../db-accessor";
+import { type ReadDb, getDbAccessor } from "../db-accessor";
 import {
 	type NativeMemoryBridgeHandle,
 	purgeNativeMemorySourceArtifacts,
@@ -119,11 +119,15 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 		const agentId = resolveDaemonAgentId();
 		return c.json({
 			version: config.version,
-			sources: config.sources.map((source) => ({
-				...source,
-				stats: sourceStats(source, agentId),
-				indexJob: getSourceIndexJob(source.id),
-			})),
+			sources: config.sources.map((source) => {
+				const stats = sourceStats(source, agentId);
+				return {
+					...source,
+					stats,
+					health: sourceHealth(source, agentId, stats),
+					indexJob: getSourceIndexJob(source.id),
+				};
+			}),
 		});
 	});
 
@@ -229,6 +233,15 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 				includeLocalDiscord,
 			}),
 		);
+	});
+
+	app.get("/api/sources/:sourceId/health", (c) => {
+		const sourceId = c.req.param("sourceId");
+		const source = findConfiguredSource(sourceId, agentsDir);
+		if (!source) return c.json({ error: "Source not found" }, 404);
+		const agentId = resolveDaemonAgentId();
+		const stats = sourceStats(source, agentId);
+		return c.json({ source, stats, health: sourceHealth(source, agentId, stats) });
 	});
 
 	app.post("/api/sources/:sourceId/snapshot/import", async (c) => {
@@ -509,6 +522,35 @@ interface SourceStats {
 	readonly indexed: number;
 }
 
+interface SourceHealth {
+	readonly status: "healthy" | "degraded" | "unhealthy" | "empty";
+	readonly generatedAt: string;
+	readonly error?: string;
+	readonly latestArtifactAt: string | null;
+	readonly latestCheckpointAt: string | null;
+	readonly chunkCoverage: number;
+	readonly failures: {
+		readonly total: number;
+		readonly recoverable: number;
+	};
+	readonly checkpoints: {
+		readonly total: number;
+		readonly partial: number;
+		readonly stale: number;
+	};
+	readonly purge: {
+		readonly deletedArtifacts: number;
+		readonly orphanChunks: number;
+	};
+	readonly semantic: {
+		readonly entities: number;
+		readonly attributes: number;
+		readonly dependencies: number;
+		readonly communities: number;
+		readonly total: number;
+	};
+}
+
 function sourceStats(source: SignetSourceEntry, agentId: string): SourceStats {
 	const rootPrefix = `${source.root.replace(/\\/g, "/").replace(/\/$/, "")}/`;
 	const chunkPrefix = `${source.id}:`;
@@ -566,6 +608,334 @@ function sourceStats(source: SignetSourceEntry, agentId: string): SourceStats {
 	} catch {
 		return { artifacts: 0, chunks: 0, indexed: 0 };
 	}
+}
+
+function sourceHealth(source: SignetSourceEntry, agentId: string, stats: SourceStats): SourceHealth {
+	const generatedAt = new Date().toISOString();
+	try {
+		const artifactSummary = artifactHealthSummary(source, agentId);
+		const discordSummary = discordHealthSummary(source, agentId);
+		const semantic = semanticHealthSummary(source, agentId);
+		const orphanChunks = sourceOrphanChunks(source, agentId);
+		const hasDegradation =
+			discordSummary.failures.total > 0 ||
+			discordSummary.checkpoints.partial > 0 ||
+			discordSummary.checkpoints.stale > 0 ||
+			artifactSummary.deletedArtifacts > 0 ||
+			orphanChunks > 0;
+		const status = hasDegradation ? "degraded" : stats.artifacts === 0 && stats.chunks === 0 ? "empty" : "healthy";
+		return {
+			status,
+			generatedAt,
+			latestArtifactAt: artifactSummary.latestArtifactAt,
+			latestCheckpointAt: discordSummary.latestCheckpointAt,
+			chunkCoverage: stats.artifacts > 0 ? Math.min(1, stats.chunks / stats.artifacts) : stats.chunks > 0 ? 1 : 0,
+			failures: discordSummary.failures,
+			checkpoints: discordSummary.checkpoints,
+			purge: {
+				deletedArtifacts: artifactSummary.deletedArtifacts,
+				orphanChunks,
+			},
+			semantic,
+		};
+	} catch (err) {
+		return {
+			status: "unhealthy",
+			error: `Source health diagnostics failed: ${err instanceof Error ? err.message : String(err)}`,
+			generatedAt,
+			latestArtifactAt: null,
+			latestCheckpointAt: null,
+			chunkCoverage: stats.artifacts > 0 ? Math.min(1, stats.chunks / stats.artifacts) : stats.chunks > 0 ? 1 : 0,
+			failures: { total: 0, recoverable: 0 },
+			checkpoints: { total: 0, partial: 0, stale: 0 },
+			purge: { deletedArtifacts: 0, orphanChunks: stats.artifacts === 0 ? stats.chunks : 0 },
+			semantic: { entities: 0, attributes: 0, dependencies: 0, communities: 0, total: 0 },
+		};
+	}
+}
+
+function sourceOrphanChunks(source: SignetSourceEntry, agentId: string): number {
+	const chunkPrefix = `${source.id}:`;
+	return getDbAccessor().withReadDb((db) => {
+		const livePaths = liveSourceArtifactPaths(db, source, agentId);
+		const chunks = db
+			.prepare(
+				`SELECT source_id, chunk_text
+				   FROM embeddings
+				  WHERE agent_id = ?
+				    AND source_type IN (?, ?)
+				    AND source_id >= ?
+				    AND source_id < ?`,
+			)
+			.all(
+				agentId,
+				SOURCE_CHUNK_SOURCE_TYPE,
+				LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE,
+				chunkPrefix,
+				`${chunkPrefix}\uffff`,
+			) as SourceChunkHealthRow[];
+		return chunks.filter((chunk) => !sourceChunkMatchesLiveArtifact(source, chunk, livePaths)).length;
+	});
+}
+
+function liveSourceArtifactPaths(db: ReadDb, source: SignetSourceEntry, agentId: string): ReadonlySet<string> {
+	if (source.kind === "obsidian") {
+		const rootPrefix = `${source.root.replace(/\\/g, "/").replace(/\/$/, "")}/`;
+		const rows = db
+			.prepare(
+				`SELECT source_path
+				   FROM memory_artifacts
+				  WHERE agent_id = ?
+				    AND COALESCE(is_deleted, 0) = 0
+				    AND (
+					    source_id = ?
+					    OR (
+						    harness = 'obsidian'
+						    AND source_id IS NULL
+						    AND source_path >= ?
+						    AND source_path < ?
+					    )
+				    )`,
+			)
+			.all(agentId, source.id, rootPrefix, `${rootPrefix}\uffff`) as SourcePathHealthRow[];
+		return new Set(rows.map((row) => normalizeSourcePath(row.source_path)));
+	}
+	const rows = db
+		.prepare(
+			`SELECT source_path
+			   FROM memory_artifacts
+			  WHERE agent_id = ?
+			    AND source_id = ?
+			    AND COALESCE(is_deleted, 0) = 0`,
+		)
+		.all(agentId, source.id) as SourcePathHealthRow[];
+	return new Set(rows.map((row) => normalizeSourcePath(row.source_path)));
+}
+
+interface SourceChunkHealthRow {
+	readonly source_id: string;
+	readonly chunk_text: string | null;
+}
+
+interface SourcePathHealthRow {
+	readonly source_path: string;
+}
+
+function sourceChunkMatchesLiveArtifact(
+	source: SignetSourceEntry,
+	chunk: SourceChunkHealthRow,
+	livePaths: ReadonlySet<string>,
+): boolean {
+	const explicitPath = sourcePathFromChunkText(chunk.chunk_text);
+	if (explicitPath && livePaths.has(normalizeSourcePath(explicitPath))) return true;
+	const localPath = sourceLocalPathFromChunkId(source.id, chunk.source_id);
+	if (!localPath) return false;
+	return sourcePathCandidates(source, localPath).some((candidate) => livePaths.has(candidate));
+}
+
+function sourcePathFromChunkText(chunkText: string | null): string | null {
+	if (!chunkText) return null;
+	const line = chunkText.split("\n").find((part) => part.trimStart().toLowerCase().startsWith("source_path:"));
+	return line ? normalizeSourcePath(line.trimStart().slice("source_path:".length).trim()) : null;
+}
+
+function sourceLocalPathFromChunkId(sourceId: string, chunkSourceId: string): string | null {
+	const prefix = `${sourceId}:`;
+	if (!chunkSourceId.startsWith(prefix)) return null;
+	const localWithAnchor = chunkSourceId.slice(prefix.length);
+	const anchorIndex = localWithAnchor.indexOf("#");
+	const localPath = anchorIndex >= 0 ? localWithAnchor.slice(0, anchorIndex) : localWithAnchor;
+	return localPath ? normalizeSourcePath(localPath) : null;
+}
+
+function sourcePathCandidates(source: SignetSourceEntry, localPath: string): readonly string[] {
+	const normalized = normalizeSourcePath(localPath);
+	const root = normalizeSourcePath(source.root).replace(/\/$/, "");
+	return [normalized, `${root}/${normalized}`, `discord://${normalized}`, `discord-cache://${normalized}`].map(
+		normalizeSourcePath,
+	);
+}
+
+function normalizeSourcePath(value: string): string {
+	return value.replace(/\\/g, "/").replace(/([^:])\/{2,}/g, "$1/");
+}
+
+function artifactHealthSummary(
+	source: SignetSourceEntry,
+	agentId: string,
+): {
+	readonly latestArtifactAt: string | null;
+	readonly deletedArtifacts: number;
+} {
+	return getDbAccessor().withReadDb((db) => {
+		if (source.kind === "obsidian") {
+			const rootPrefix = `${source.root.replace(/\\/g, "/").replace(/\/$/, "")}/`;
+			const row = db
+				.prepare(
+					`SELECT MAX(updated_at) AS latestArtifactAt,
+					        SUM(CASE WHEN COALESCE(is_deleted, 0) = 1 THEN 1 ELSE 0 END) AS deletedArtifacts
+					   FROM memory_artifacts
+					  WHERE agent_id = ?
+					    AND (
+						    source_id = ?
+						    OR (
+							    harness = 'obsidian'
+							    AND source_id IS NULL
+							    AND source_path >= ?
+							    AND source_path < ?
+						    )
+					    )`,
+				)
+				.get(agentId, source.id, rootPrefix, `${rootPrefix}\uffff`) as HealthAggregateRow | null;
+			return {
+				latestArtifactAt: stringOrNull(row?.latestArtifactAt),
+				deletedArtifacts: numberOrZero(row?.deletedArtifacts),
+			};
+		}
+		const row = db
+			.prepare(
+				`SELECT MAX(updated_at) AS latestArtifactAt,
+				        SUM(CASE WHEN COALESCE(is_deleted, 0) = 1 THEN 1 ELSE 0 END) AS deletedArtifacts
+				   FROM memory_artifacts
+				  WHERE agent_id = ?
+				    AND source_id = ?`,
+			)
+			.get(agentId, source.id) as HealthAggregateRow | null;
+		return {
+			latestArtifactAt: stringOrNull(row?.latestArtifactAt),
+			deletedArtifacts: numberOrZero(row?.deletedArtifacts),
+		};
+	});
+}
+
+interface DiscordHealthSummary {
+	readonly latestCheckpointAt: string | null;
+	readonly failures: {
+		readonly total: number;
+		readonly recoverable: number;
+	};
+	readonly checkpoints: {
+		readonly total: number;
+		readonly partial: number;
+		readonly stale: number;
+	};
+}
+
+function discordHealthSummary(source: SignetSourceEntry, agentId: string): DiscordHealthSummary {
+	if (source.kind !== "discord") {
+		return {
+			latestCheckpointAt: null,
+			failures: { total: 0, recoverable: 0 },
+			checkpoints: { total: 0, partial: 0, stale: 0 },
+		};
+	}
+	return getDbAccessor().withReadDb((db) => {
+		const rows = db
+			.prepare(
+				`SELECT source_kind, source_meta_json, updated_at
+				   FROM memory_artifacts
+				  WHERE agent_id = ?
+				    AND source_id = ?
+				    AND source_kind IN ('source_discord_failure', 'source_discord_checkpoint')
+				    AND COALESCE(is_deleted, 0) = 0`,
+			)
+			.all(agentId, source.id) as DiscordHealthRow[];
+		let failures = 0;
+		let recoverable = 0;
+		let checkpoints = 0;
+		let partial = 0;
+		let stale = 0;
+		let latestCheckpointAt: string | null = null;
+		for (const row of rows) {
+			const meta = parseJsonObject(row.source_meta_json);
+			if (row.source_kind === "source_discord_failure") {
+				failures++;
+				if (meta?.recoverable === true) recoverable++;
+				continue;
+			}
+			checkpoints++;
+			if (meta?.status === "partial") partial++;
+			if (isStaleCheckpoint(row.updated_at, source.lastIndexedAt)) stale++;
+			latestCheckpointAt = maxIsoTimestamp(latestCheckpointAt, stringOrNull(row.updated_at));
+		}
+		return {
+			latestCheckpointAt,
+			failures: { total: failures, recoverable },
+			checkpoints: { total: checkpoints, partial, stale },
+		};
+	});
+}
+
+function semanticHealthSummary(source: SignetSourceEntry, agentId: string): SourceHealth["semantic"] {
+	return getDbAccessor().withReadDb((db) => {
+		const entities = countSourceRows(db, "entities", agentId, source.id);
+		const attributes = countSourceRows(db, "entity_attributes", agentId, source.id);
+		const dependencies = countSourceRows(db, "entity_dependencies", agentId, source.id);
+		const communities = countSourceRows(db, "entity_communities", agentId, source.id);
+		return {
+			entities,
+			attributes,
+			dependencies,
+			communities,
+			total: entities + attributes + dependencies + communities,
+		};
+	});
+}
+
+function countSourceRows(
+	db: { prepare: (sql: string) => { get: (...args: unknown[]) => unknown } },
+	table: string,
+	agentId: string,
+	sourceId: string,
+): number {
+	return countRow(
+		db.prepare(`SELECT COUNT(*) AS n FROM ${table} WHERE agent_id = ? AND source_id = ?`).get(agentId, sourceId),
+	);
+}
+
+interface HealthAggregateRow {
+	readonly latestArtifactAt?: unknown;
+	readonly deletedArtifacts?: unknown;
+}
+
+interface DiscordHealthRow {
+	readonly source_kind: string;
+	readonly source_meta_json: string | null;
+	readonly updated_at: string | null;
+}
+
+function parseJsonObject(value: string | null): Readonly<Record<string, unknown>> | null {
+	if (!value) return null;
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+			? (parsed as Readonly<Record<string, unknown>>)
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+function isStaleCheckpoint(updatedAt: string | null, lastIndexedAt: string | undefined): boolean {
+	if (!updatedAt || !lastIndexedAt) return false;
+	const updatedMs = Date.parse(updatedAt);
+	const indexedMs = Date.parse(lastIndexedAt);
+	if (!Number.isFinite(updatedMs) || !Number.isFinite(indexedMs)) return false;
+	return indexedMs - updatedMs > 60_000;
+}
+
+function maxIsoTimestamp(left: string | null, right: string | null): string | null {
+	if (!right) return left;
+	if (!left) return right;
+	return Date.parse(right) > Date.parse(left) ? right : left;
+}
+
+function stringOrNull(value: unknown): string | null {
+	return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function numberOrZero(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }
 
 function countRow(row: unknown): number {

--- a/surfaces/dashboard/src/lib/api.ts
+++ b/surfaces/dashboard/src/lib/api.ts
@@ -99,6 +99,35 @@ export interface SignetSourceStats {
 	indexed: number;
 }
 
+export interface SignetSourceHealth {
+	status: "healthy" | "degraded" | "unhealthy" | "empty";
+	generatedAt: string;
+	error?: string;
+	latestArtifactAt: string | null;
+	latestCheckpointAt: string | null;
+	chunkCoverage: number;
+	failures: {
+		total: number;
+		recoverable: number;
+	};
+	checkpoints: {
+		total: number;
+		partial: number;
+		stale: number;
+	};
+	purge: {
+		deletedArtifacts: number;
+		orphanChunks: number;
+	};
+	semantic: {
+		entities: number;
+		attributes: number;
+		dependencies: number;
+		communities: number;
+		total: number;
+	};
+}
+
 export interface SignetSourceIndexJob {
 	id: string;
 	sourceId: string;
@@ -126,6 +155,7 @@ export interface SignetSourceEntry {
 	excludeGlobs?: string[];
 	providerSettings?: Record<string, unknown>;
 	stats?: SignetSourceStats;
+	health?: SignetSourceHealth;
 	indexJob?: SignetSourceIndexJob;
 }
 

--- a/surfaces/dashboard/src/lib/components/tabs/SourcesTab.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/SourcesTab.svelte
@@ -807,6 +807,31 @@ function sourceScanLabel(source: SignetSourceEntry): string {
 		: `Connected; waiting for first indexed ${itemLabel.slice(0, -1)}`;
 }
 
+function sourceHealthLabel(source: SignetSourceEntry): string {
+	const health = source.health;
+	if (!health) return "Health pending";
+	if (health.status === "empty") return "No indexed source rows yet";
+	if (health.status === "unhealthy") return health.error ?? "Health diagnostics failed";
+	if (health.status === "healthy") {
+		const checkpointLabel =
+			source.kind === "discord" && health.checkpoints.total > 0 ? ` · ${health.checkpoints.total} checkpoints` : "";
+		const semanticLabel = health.semantic.total > 0 ? ` · ${health.semantic.total} graph rows` : "";
+		return `Healthy${checkpointLabel}${semanticLabel}`;
+	}
+	const issues: string[] = [];
+	if (health.failures.total > 0) issues.push(`${health.failures.total} fetch failures`);
+	if (health.checkpoints.partial > 0) issues.push(`${health.checkpoints.partial} partial checkpoints`);
+	if (health.checkpoints.stale > 0) issues.push(`${health.checkpoints.stale} stale checkpoints`);
+	if (health.purge.deletedArtifacts > 0) issues.push(`${health.purge.deletedArtifacts} deleted rows retained`);
+	if (health.purge.orphanChunks > 0) issues.push(`${health.purge.orphanChunks} orphan chunks`);
+	return issues.length > 0 ? issues.join(" · ") : "Needs attention";
+}
+
+function sourceHealthTone(source: SignetSourceEntry): string {
+	if (!source.health) return "unknown";
+	return source.health.status;
+}
+
 function sourceIndexPercent(source: SignetSourceEntry): number {
 	const scanned = source.indexJob?.scanned ?? 0;
 	const total = source.indexJob?.total ?? 0;
@@ -1107,6 +1132,9 @@ function sourceIndexCurrentPath(source: SignetSourceEntry): string {
 													<ul>
 														<li><CheckCircle2 /> {source.enabled ? "Enabled" : "Disabled"}</li>
 														<li><Database /> {sourceScanLabel(source)}</li>
+														<li class={`source-health source-health--${sourceHealthTone(source)}`}>
+															<Info /> {sourceHealthLabel(source)}
+														</li>
 														<li><Database /> Last complete scan: {formatDate(source.lastIndexedAt)}</li>
 													</ul>
 													{#if source.indexJob?.status === "queued" || source.indexJob?.status === "running"}
@@ -2435,6 +2463,23 @@ function sourceIndexCurrentPath(source: SignetSourceEntry): string {
 		.connected-row li :global(svg) {
 			width: 13px;
 			height: 13px;
+		}
+
+		.connected-row li.source-health--healthy {
+			color: #6fa97f;
+		}
+
+		.connected-row li.source-health--degraded {
+			color: #c4a24a;
+		}
+
+		.connected-row li.source-health--unhealthy {
+			color: #d06f62;
+		}
+
+		.connected-row li.source-health--empty,
+		.connected-row li.source-health--unknown {
+			color: var(--sig-text-muted);
 		}
 
 		.source-index-progress {


### PR DESCRIPTION
## Summary

Adds provider-neutral source operations diagnostics so Discord source health is visible from the daemon API and dashboard after sync, import, or removal.

## Changes

- Adds a source health payload to `GET /api/sources` and a dedicated `GET /api/sources/:sourceId/health` endpoint.
- Reports latest artifact/checkpoint timestamps, Discord failure/checkpoint health, chunk coverage, purge residue, and source-provenance graph row counts.
- Shows compact source health status in the dashboard Sources card for connected Obsidian/Discord sources.
- Documents the new health route and operations diagnostics model.
- Adds route regression coverage for degraded Discord source health and unknown-source health lookups.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

Not captured in this environment. The UI change is a compact health row in the existing connected-source card; `svelte-check` and the daemon dashboard bundle build both pass.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

No database migrations changed. Rollback is removing the health route/dashboard row; existing source artifacts, chunks, and graph rows are read-only inputs to these diagnostics.

## Testing

- [x] `bun test platform/daemon/src/routes/sources-routes.test.ts`
- [x] `bunx biome check platform/daemon/src/routes/sources-routes.ts platform/daemon/src/routes/sources-routes.test.ts surfaces/dashboard/src/lib/api.ts`
- [x] `bunx svelte-check --tsconfig surfaces/dashboard/tsconfig.json`
- [x] `bun run --filter '@signet/core' build`
- [x] `bun run --filter '@signet/daemon' build`
- [x] `git diff --check`

Notes: dashboard Svelte check and daemon build still emit existing unrelated accessibility warnings in Secrets/OS/Cortex files.

## AI disclosure

Assisted-by: OpenAI Codex
