### PR TITLE
feat(sources): project provider artifacts into graph

### DIFF
--- a/platform/daemon/src/discord-desktop-cache-source.ts
+++ b/platform/daemon/src/discord-desktop-cache-source.ts
@@ -2,7 +2,10 @@ import { type Stats, existsSync, lstatSync, readFileSync, readdirSync } from "no
 import { basename, join, relative } from "node:path";
 import { gunzipSync } from "node:zlib";
 import type { SignetSourceEntry } from "@signet/core";
+import { getDbAccessor } from "./db-accessor";
+import { countChanges } from "./db-helpers";
 import { indexExternalMemoryArtifact } from "./memory-lineage";
+import { indexSourceArtifactStructure, purgeSourceArtifactStructure } from "./source-artifact-graph";
 import type { SourceProviderSyncResult } from "./source-providers";
 
 const DISCORD_PROVIDER_KIND = "discord";
@@ -144,14 +147,19 @@ interface CacheArtifact {
 export async function syncDiscordDesktopCacheSource(
 	options: DiscordDesktopCacheSyncOptions,
 ): Promise<SourceProviderSyncResult> {
+	const syncStartedAt = new Date().toISOString();
 	const stats = emptyStats();
 	const snapshot = emptySnapshot();
 	const root = options.cachePath;
 	const candidates = discoverCandidates(root, options.fullScan, stats);
 	let indexed = 0;
+	let cancelled = false;
 
 	for (const candidate of candidates) {
-		if (!options.shouldContinue()) break;
+		if (!options.shouldContinue()) {
+			cancelled = true;
+			break;
+		}
 		const data = readCandidateFile(candidate, stats);
 		if (!data) continue;
 		stats.filesScanned++;
@@ -170,10 +178,14 @@ export async function syncDiscordDesktopCacheSource(
 
 	finalizeSnapshot(snapshot, stats);
 	for (const artifact of artifactsForSnapshot(options.source, snapshot, stats, root, options.fullScan)) {
-		if (!options.shouldContinue()) break;
+		if (!options.shouldContinue()) {
+			cancelled = true;
+			break;
+		}
 		writeArtifact(options.source, options.agentId, artifact);
 		indexed++;
 	}
+	if (!cancelled) purgeStaleDesktopCacheArtifacts(options.source.id, options.agentId, syncStartedAt);
 
 	return { indexed, scanned: stats.filesScanned, total: candidates.length, failures: [] };
 }
@@ -398,6 +410,50 @@ function writeArtifact(source: SignetSourceEntry, agentId: string, artifact: Cac
 		content: artifact.content,
 		sourceMeta: artifact.meta,
 	});
+	if (artifact.kind !== "source_discord_checkpoint") {
+		indexSourceArtifactStructure({
+			agentId,
+			sourceId: source.id,
+			sourceKind: artifact.kind,
+			sourceRoot: source.root,
+			sourceParentPath: artifact.parentPath,
+			sourcePath: artifact.path,
+			displayName: sourceArtifactDisplayName(artifact),
+			content: artifact.content,
+		});
+	}
+}
+
+function sourceArtifactDisplayName(artifact: CacheArtifact): string | undefined {
+	const name = artifact.meta.name ?? artifact.meta.username ?? artifact.meta.filename ?? artifact.meta.title;
+	return typeof name === "string" && name.trim().length > 0 ? name.trim() : undefined;
+}
+
+function purgeStaleDesktopCacheArtifacts(sourceId: string, agentId: string, syncStartedAt: string): number {
+	const rows = getDbAccessor().withReadDb(
+		(db) =>
+			db
+				.prepare(
+					`SELECT source_path FROM memory_artifacts
+					 WHERE agent_id = ?
+					   AND source_id = ?
+					   AND updated_at < ?`,
+				)
+				.all(agentId, sourceId, syncStartedAt) as Array<{ source_path: string }>,
+	);
+	for (const row of rows) purgeSourceArtifactStructure({ agentId, sourceId, sourcePath: row.source_path });
+	return getDbAccessor().withWriteTx((db) =>
+		countChanges(
+			db
+				.prepare(
+					`DELETE FROM memory_artifacts
+					 WHERE agent_id = ?
+					   AND source_id = ?
+					   AND updated_at < ?`,
+				)
+				.run(agentId, sourceId, syncStartedAt),
+		),
+	);
 }
 
 function importStatsArtifact(

--- a/platform/daemon/src/discord-source-provider.test.ts
+++ b/platform/daemon/src/discord-source-provider.test.ts
@@ -8,6 +8,7 @@ import { DISCORD_CHANNEL_TYPES } from "./discord-source-fetch";
 import { discordSourceProvider } from "./discord-source-provider";
 import { indexExternalMemoryArtifact } from "./memory-lineage";
 import { putSecret } from "./secrets";
+import { indexSourceArtifactStructure } from "./source-artifact-graph";
 
 const originalFetch = globalThis.fetch;
 
@@ -81,6 +82,20 @@ describe("discord-source-provider", () => {
 		expect(message?.source_meta_json).toContain('"pinned":true');
 		const attachment = rows.find((row) => row.source_kind === "source_discord_attachment");
 		expect(attachment?.source_meta_json).toContain('"urlPresent":true');
+		const graph = getDbAccessor().withReadDb((db) => ({
+			docs: (
+				db
+					.prepare("SELECT COUNT(*) AS count FROM entities WHERE source_id = ? AND entity_type = 'source_document'")
+					.get(added.source.id) as { count: number }
+			).count,
+			attrs: (
+				db
+					.prepare("SELECT COUNT(*) AS count FROM entity_attributes WHERE source_id = ? AND memory_id IS NULL")
+					.get(added.source.id) as { count: number }
+			).count,
+		}));
+		expect(graph.docs).toBeGreaterThan(0);
+		expect(graph.attrs).toBeGreaterThan(0);
 	});
 
 	it("records partial Discord failures without deleting existing source-owned rows", async () => {
@@ -226,6 +241,87 @@ describe("discord-source-provider", () => {
 		expect(indexedText).not.toContain("mfa.DDDDDDDDDDDDDDDDDDDDDDDDDDDDDD");
 		expect(indexedText).not.toContain("mfa.EEEEEEEEEEEEEEEEEEEEEEEEEEEEEE");
 		expect(indexedText).toContain("[redacted]");
+		const graphDocs = getDbAccessor().withReadDb(
+			(db) =>
+				(
+					db
+						.prepare("SELECT COUNT(*) AS count FROM entities WHERE source_id = ? AND entity_type = 'source_document'")
+						.get(added.source.id) as { count: number }
+				).count,
+		);
+		expect(graphDocs).toBeGreaterThan(0);
+	});
+
+	it("purges stale Discord Desktop cache artifacts and graph rows after a complete sync", async () => {
+		const cachePath = join(dir, "discord");
+		mkdirSync(cachePath, { recursive: true });
+		const added = addDiscordSource(
+			{
+				guildIds: [],
+				name: "Desktop Cache",
+				desktopCachePath: cachePath,
+				syncMode: "desktop-cache",
+				now: "2026-01-01T00:00:00.000Z",
+			},
+			dir,
+		);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+		const stalePath = "discord-cache://guild/@me/channel/stale/messages/stale";
+		indexExternalMemoryArtifact({
+			agentId: "default",
+			harness: "discord",
+			sourceId: added.source.id,
+			sourceRoot: added.source.root,
+			sourceExternalId: "message:stale",
+			sourcePath: stalePath,
+			sourceKind: "source_discord_message",
+			sourceMtimeMs: Date.parse("2025-01-01T00:00:00.000Z"),
+			content: "stale cache message",
+		});
+		indexSourceArtifactStructure({
+			agentId: "default",
+			sourceId: added.source.id,
+			sourceKind: "source_discord_message",
+			sourceRoot: added.source.root,
+			sourcePath: stalePath,
+			content: "# Stale\n\nThis stale desktop-cache graph row should be purged after the next complete sync.\n",
+		});
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("UPDATE memory_artifacts SET updated_at = ? WHERE source_id = ? AND source_path = ?").run(
+				"2025-01-01T00:00:00.000Z",
+				added.source.id,
+				stalePath,
+			);
+			db.prepare("UPDATE entities SET updated_at = ? WHERE source_id = ? AND source_path = ?").run(
+				"2025-01-01T00:00:00.000Z",
+				added.source.id,
+				stalePath,
+			);
+		});
+
+		const result = await discordSourceProvider.sync?.({
+			source: added.source,
+			agentsDir: dir,
+			agentId: "default",
+			shouldContinue: () => true,
+		});
+
+		expect(result?.failures).toEqual([]);
+		expect(sourceRows(added.source.id).some((row) => row.source_path === stalePath)).toBe(false);
+		const graphRows = getDbAccessor().withReadDb((db) => ({
+			entities: (
+				db
+					.prepare("SELECT COUNT(*) AS count FROM entities WHERE source_id = ? AND source_path = ?")
+					.get(added.source.id, stalePath) as { count: number }
+			).count,
+			attrs: (
+				db
+					.prepare("SELECT COUNT(*) AS count FROM entity_attributes WHERE source_id = ? AND source_path = ?")
+					.get(added.source.id, stalePath) as { count: number }
+			).count,
+		}));
+		expect(graphRows).toEqual({ entities: 0, attrs: 0 });
 	});
 
 	it("classifies route-bearing Discord Desktop cache guild messages and skips ambiguous routes", async () => {

--- a/platform/daemon/src/discord-source-provider.ts
+++ b/platform/daemon/src/discord-source-provider.ts
@@ -32,6 +32,7 @@ import {
 } from "./discord-source-fetch";
 import { indexExternalMemoryArtifact } from "./memory-lineage";
 import { getSecret } from "./secrets";
+import { indexSourceArtifactStructure, purgeSourceArtifactStructure } from "./source-artifact-graph";
 import type { SourceProviderAdapter, SourceProviderSyncContext, SourceProviderSyncResult } from "./source-providers";
 import { purgeSourceOwnedRows } from "./source-purge";
 
@@ -258,7 +259,28 @@ function writeArtifact(source: SignetSourceEntry, agentId: string, artifact: Dis
 		content: artifact.content,
 		sourceMeta: artifact.meta,
 	});
+	if (indexesSourceArtifactGraph(artifact)) {
+		indexSourceArtifactStructure({
+			agentId,
+			sourceId: source.id,
+			sourceKind: artifact.kind,
+			sourceRoot: source.root,
+			sourceParentPath: artifact.parentPath,
+			sourcePath: artifact.path,
+			displayName: sourceArtifactDisplayName(artifact),
+			content: artifact.content,
+		});
+	}
 	return 1;
+}
+
+function indexesSourceArtifactGraph(artifact: DiscordArtifact): boolean {
+	return artifact.kind !== "source_discord_failure" && artifact.kind !== "source_discord_checkpoint";
+}
+
+function sourceArtifactDisplayName(artifact: DiscordArtifact): string | undefined {
+	const name = artifact.meta.name ?? artifact.meta.username ?? artifact.meta.filename ?? artifact.meta.title;
+	return typeof name === "string" && name.trim().length > 0 ? name.trim() : undefined;
 }
 
 function writeMessageArtifacts(
@@ -320,6 +342,18 @@ function writeFailureArtifact(source: SignetSourceEntry, agentId: string, failur
 }
 
 function purgeStaleDiscordArtifacts(sourceId: string, agentId: string, syncStartedAt: string): number {
+	const rows = getDbAccessor().withReadDb(
+		(db) =>
+			db
+				.prepare(
+					`SELECT source_path FROM memory_artifacts
+					 WHERE agent_id = ?
+					   AND source_id = ?
+					   AND updated_at < ?`,
+				)
+				.all(agentId, sourceId, syncStartedAt) as Array<{ source_path: string }>,
+	);
+	for (const row of rows) purgeSourceArtifactStructure({ agentId, sourceId, sourcePath: row.source_path });
 	return getDbAccessor().withWriteTx((db) =>
 		countChanges(
 			db

--- a/platform/daemon/src/github-source-provider.test.ts
+++ b/platform/daemon/src/github-source-provider.test.ts
@@ -105,6 +105,15 @@ describe("github-source-provider", () => {
 			"Signet-AI/signetai:issue:12",
 		);
 		expect(rows.find((row) => row.source_kind === "source_github_comment")?.content).toContain("comment body");
+		const graphDocs = getDbAccessor().withReadDb(
+			(db) =>
+				(
+					db
+						.prepare("SELECT COUNT(*) AS count FROM entities WHERE source_id = ? AND entity_type = 'source_document'")
+						.get(added.source.id) as { count: number }
+				).count,
+		);
+		expect(graphDocs).toBeGreaterThanOrEqual(2);
 	});
 
 	it("records requested discussion failures when no token is available", async () => {

--- a/platform/daemon/src/github-source-provider.ts
+++ b/platform/daemon/src/github-source-provider.ts
@@ -29,6 +29,7 @@ import {
 import { logger } from "./logger";
 import { indexExternalMemoryArtifact } from "./memory-lineage";
 import { getSecret } from "./secrets";
+import { indexSourceArtifactStructure, purgeSourceArtifactStructure } from "./source-artifact-graph";
 import type { SourceProviderAdapter, SourceProviderSyncContext, SourceProviderSyncResult } from "./source-providers";
 import { purgeSourceOwnedRows } from "./source-purge";
 
@@ -243,6 +244,8 @@ function writeResourceArtifact(
 	resource: GitHubResource,
 ): string {
 	const path = resourcePath(repo, resource);
+	const sourceKind = `source_github_${resource.type}`;
+	const content = resourceContent(repo, resource);
 	indexExternalMemoryArtifact({
 		agentId,
 		harness: GITHUB_HARNESS,
@@ -251,10 +254,10 @@ function writeResourceArtifact(
 		sourceExternalId: resourceExternalId(repo, resource),
 		sourceParentPath: `github://${repo}`,
 		sourcePath: path,
-		sourceKind: `source_github_${resource.type}`,
+		sourceKind,
 		sourceMtimeMs: Date.parse(resource.updatedAt) || Date.now(),
 		capturedAt: resource.updatedAt,
-		content: resourceContent(repo, resource),
+		content,
 		sourceMeta: {
 			provider: GITHUB_PROVIDER_KIND,
 			repo,
@@ -272,6 +275,16 @@ function writeResourceArtifact(
 			...resource.extra,
 		},
 	});
+	indexSourceArtifactStructure({
+		agentId,
+		sourceId: source.id,
+		sourceKind,
+		sourceRoot: source.root,
+		sourceParentPath: `github://${repo}`,
+		sourcePath: path,
+		displayName: resource.title,
+		content,
+	});
 	return path;
 }
 
@@ -286,6 +299,7 @@ function writeCommentArtifact(
 		typeof comment.author === "string" ? comment.author : (comment.author?.login ?? comment.user?.login ?? null);
 	const commentId = String(comment.id);
 	const path = `${resourcePath(repo, resource)}#comment-${commentId}`;
+	const content = [`# Comment on ${resource.title}`, "", `Author: ${author ?? "unknown"}`, "", comment.body].join("\n");
 	indexExternalMemoryArtifact({
 		agentId,
 		harness: GITHUB_HARNESS,
@@ -297,7 +311,7 @@ function writeCommentArtifact(
 		sourceKind: "source_github_comment",
 		sourceMtimeMs: Date.parse(comment.updated_at) || Date.now(),
 		capturedAt: comment.updated_at,
-		content: [`# Comment on ${resource.title}`, "", `Author: ${author ?? "unknown"}`, "", comment.body].join("\n"),
+		content,
 		sourceMeta: {
 			provider: GITHUB_PROVIDER_KIND,
 			repo,
@@ -309,6 +323,16 @@ function writeCommentArtifact(
 			createdAt: comment.created_at,
 			updatedAt: comment.updated_at,
 		},
+	});
+	indexSourceArtifactStructure({
+		agentId,
+		sourceId: source.id,
+		sourceKind: "source_github_comment",
+		sourceRoot: source.root,
+		sourceParentPath: resourcePath(repo, resource),
+		sourcePath: path,
+		displayName: `Comment on ${resource.title}`,
+		content,
 	});
 	return path;
 }
@@ -429,21 +453,28 @@ function purgeStaleGitHubArtifacts(
 	repo: string,
 ): void {
 	const repoPathPrefix = `github://${repo}/`;
+	const rows = getDbAccessor().withReadDb(
+		(db) =>
+			db
+				.prepare(
+					`SELECT rowid, source_path FROM memory_artifacts
+					 WHERE agent_id = ?
+					   AND source_id = ?
+					   AND source_path >= ?
+					   AND source_path < ?
+					   AND updated_at < ?
+					   AND COALESCE(is_deleted, 0) = 0`,
+				)
+				.all(agentId, sourceId, repoPathPrefix, `${repoPathPrefix}\uffff`, syncStartedAt) as Array<{
+				rowid: number;
+				source_path: string;
+			}>,
+	);
+	for (const row of rows) {
+		if (seenPaths.has(row.source_path)) continue;
+		purgeSourceArtifactStructure({ agentId, sourceId, sourcePath: row.source_path });
+	}
 	getDbAccessor().withWriteTx((db) => {
-		const rows = db
-			.prepare(
-				`SELECT rowid, source_path FROM memory_artifacts
-				 WHERE agent_id = ?
-				   AND source_id = ?
-				   AND source_path >= ?
-				   AND source_path < ?
-				   AND updated_at < ?
-				   AND COALESCE(is_deleted, 0) = 0`,
-			)
-			.all(agentId, sourceId, repoPathPrefix, `${repoPathPrefix}\uffff`, syncStartedAt) as Array<{
-			rowid: number;
-			source_path: string;
-		}>;
 		for (const row of rows) {
 			if (seenPaths.has(row.source_path)) continue;
 			countChanges(

--- a/platform/daemon/src/source-artifact-graph.test.ts
+++ b/platform/daemon/src/source-artifact-graph.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { indexSourceArtifactStructure, purgeSourceArtifactStructure } from "./source-artifact-graph";
+import { purgeSourceOwnedRows } from "./source-purge";
+
+describe("source artifact graph structure", () => {
+	let dir = "";
+	let previousSignetPath: string | undefined;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "signet-source-artifact-graph-"));
+		previousSignetPath = process.env.SIGNET_PATH;
+		process.env.SIGNET_PATH = dir;
+		mkdirSync(join(dir, "memory"), { recursive: true });
+		closeDbAccessor();
+		initDbAccessor(join(dir, "memory", "memories.db"));
+	});
+
+	afterEach(() => {
+		closeDbAccessor();
+		if (previousSignetPath === undefined) Reflect.deleteProperty(process.env, "SIGNET_PATH");
+		else process.env.SIGNET_PATH = previousSignetPath;
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("projects provider artifacts into source-owned graph rows without creating memories", () => {
+		const result = indexSourceArtifactStructure({
+			agentId: "default",
+			sourceId: "discord:test",
+			sourceKind: "source_discord_message",
+			sourceRoot: "discord://source/discord:test",
+			sourceParentPath: "discord://guild/123/channel/456",
+			sourcePath: "discord://guild/123/channel/456/message/789",
+			displayName: "Message 789",
+			content:
+				"# Message 789\n\nAuthor: alice\n\nSignet Discord source parity should preserve provider provenance for graph claims.\n\n## Attachments\n\nThe attachment metadata remains source-backed and purgeable by source id.\n",
+		});
+
+		expect(result.documentEntityId).toBeTruthy();
+		expect(result.entitiesTouched).toBeGreaterThanOrEqual(3);
+		expect(result.dependenciesTouched).toBe(1);
+		expect(result.aspectsTouched).toBe(2);
+		expect(result.attributesTouched).toBeGreaterThanOrEqual(2);
+
+		const rows = getDbAccessor().withReadDb((db) => ({
+			memories: (db.prepare("SELECT COUNT(*) AS count FROM memories").get() as { count: number }).count,
+			doc: db
+				.prepare(
+					`SELECT entity_type, source_id, source_kind, source_path
+					 FROM entities
+					 WHERE agent_id = ? AND source_path = ?`,
+				)
+				.get("default", "discord://guild/123/channel/456/message/789") as Record<string, unknown>,
+			attrs: db
+				.prepare(
+					`SELECT content, memory_id, source_id, source_kind, source_path
+					 FROM entity_attributes
+					 WHERE agent_id = ? AND source_path = ?
+					 ORDER BY claim_key`,
+				)
+				.all("default", "discord://guild/123/channel/456/message/789") as Array<Record<string, unknown>>,
+			deps: db
+				.prepare(
+					`SELECT dependency_type, source_id, source_path
+					 FROM entity_dependencies
+					 WHERE agent_id = ? AND source_path = ?`,
+				)
+				.all("default", "discord://guild/123/channel/456/message/789") as Array<Record<string, unknown>>,
+		}));
+
+		expect(rows.memories).toBe(0);
+		expect(rows.doc.entity_type).toBe("source_document");
+		expect(rows.doc.source_id).toBe("discord:test");
+		expect(rows.doc.source_kind).toBe("source_discord_message");
+		expect(rows.attrs.length).toBeGreaterThanOrEqual(2);
+		expect(rows.attrs.every((row) => row.memory_id === null)).toBe(true);
+		expect(rows.attrs.every((row) => row.source_id === "discord:test")).toBe(true);
+		expect(rows.attrs.some((row) => String(row.content).includes("provider provenance"))).toBe(true);
+		expect(rows.deps).toEqual([
+			{
+				dependency_type: "contains",
+				source_id: "discord:test",
+				source_path: "discord://guild/123/channel/456/message/789",
+			},
+		]);
+	});
+
+	it("refreshes and purges graph rows by source artifact path", () => {
+		const base = {
+			agentId: "default",
+			sourceId: "github:test",
+			sourceKind: "source_github_issue",
+			sourceRoot: "github://repos/Signet-AI/signetai",
+			sourceParentPath: "github://Signet-AI/signetai",
+			sourcePath: "github://Signet-AI/signetai/issues/12",
+			displayName: "Index GitHub",
+		};
+		indexSourceArtifactStructure({
+			...base,
+			content: "# Index GitHub\n\nThis original source-backed issue claim should disappear after refresh.\n",
+		});
+		indexSourceArtifactStructure({
+			...base,
+			content: "# Index GitHub\n\nThis replacement source-backed issue claim should stay active after refresh.\n",
+		});
+
+		const attrs = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare("SELECT content FROM entity_attributes WHERE agent_id = ? AND source_path = ?")
+					.all("default", base.sourcePath) as Array<{ content: string }>,
+		);
+		expect(attrs.some((row) => row.content.includes("replacement"))).toBe(true);
+		expect(attrs.some((row) => row.content.includes("original"))).toBe(false);
+
+		const purged = purgeSourceArtifactStructure({
+			agentId: "default",
+			sourceId: base.sourceId,
+			sourcePath: base.sourcePath,
+		});
+		expect(purged.entities).toBeGreaterThan(0);
+
+		const counts = getDbAccessor().withReadDb((db) => ({
+			entities: (
+				db
+					.prepare("SELECT COUNT(*) AS count FROM entities WHERE agent_id = ? AND source_path = ?")
+					.get("default", base.sourcePath) as { count: number }
+			).count,
+			attrs: (
+				db
+					.prepare("SELECT COUNT(*) AS count FROM entity_attributes WHERE agent_id = ? AND source_path = ?")
+					.get("default", base.sourcePath) as { count: number }
+			).count,
+			deps: (
+				db
+					.prepare("SELECT COUNT(*) AS count FROM entity_dependencies WHERE agent_id = ? AND source_path = ?")
+					.get("default", base.sourcePath) as { count: number }
+			).count,
+		}));
+		expect(counts).toEqual({ entities: 0, attrs: 0, deps: 0 });
+	});
+
+	it("purges source-owned aspects during whole-source removal", () => {
+		indexSourceArtifactStructure({
+			agentId: "default",
+			sourceId: "github:test",
+			sourceKind: "source_github_doc",
+			sourceRoot: "github://repos/Signet-AI/signetai",
+			sourcePath: "github://Signet-AI/signetai/docs/README.md",
+			displayName: "README",
+			content: "# README\n\nThis source document has a claim that creates an aspect row.\n",
+		});
+
+		const purged = purgeSourceOwnedRows({ agentId: "default", sourceId: "github:test" });
+		expect(purged).toBeGreaterThan(0);
+		const counts = getDbAccessor().withReadDb((db) => ({
+			entities: (
+				db.prepare("SELECT COUNT(*) AS count FROM entities WHERE source_id = ?").get("github:test") as {
+					count: number;
+				}
+			).count,
+			aspects: (db.prepare("SELECT COUNT(*) AS count FROM entity_aspects").get() as { count: number }).count,
+			attrs: (
+				db.prepare("SELECT COUNT(*) AS count FROM entity_attributes WHERE source_id = ?").get("github:test") as {
+					count: number;
+				}
+			).count,
+		}));
+		expect(counts).toEqual({ entities: 0, aspects: 0, attrs: 0 });
+	});
+});

--- a/platform/daemon/src/source-artifact-graph.ts
+++ b/platform/daemon/src/source-artifact-graph.ts
@@ -1,0 +1,431 @@
+import { createHash } from "node:crypto";
+import type { WriteDb } from "./db-accessor";
+import { getDbAccessor } from "./db-accessor";
+import { countChanges } from "./db-helpers";
+import { requireDependencyReason } from "./dependency-history";
+
+interface HeadingSection {
+	readonly heading: string;
+	readonly level: number;
+	readonly body: string;
+}
+
+export interface IndexSourceArtifactStructureInput {
+	readonly agentId: string;
+	readonly sourceId: string;
+	readonly sourceKind: string;
+	readonly sourceRoot: string;
+	readonly sourcePath: string;
+	readonly sourceParentPath?: string;
+	readonly displayName?: string;
+	readonly content: string;
+}
+
+export interface IndexSourceArtifactStructureResult {
+	readonly documentEntityId: string;
+	readonly entitiesTouched: number;
+	readonly dependenciesTouched: number;
+	readonly aspectsTouched: number;
+	readonly attributesTouched: number;
+}
+
+export interface PurgeSourceArtifactStructureInput {
+	readonly agentId: string;
+	readonly sourceId: string;
+	readonly sourcePath: string;
+}
+
+export interface PurgeSourceArtifactStructureResult {
+	readonly entities: number;
+	readonly aspects: number;
+	readonly attributes: number;
+	readonly dependencies: number;
+}
+
+function canonicalSegment(value: string): string {
+	return value.replace(/\\/g, "/").replace(/^\/+|\/+$/g, "");
+}
+
+function sourceCanonical(sourceId: string, kind: "source" | "document" | "reference", path: string): string {
+	const suffix = canonicalSegment(path);
+	return suffix.length > 0 ? `source:${sourceId}:${kind}:${suffix}` : `source:${sourceId}:${kind}:/`;
+}
+
+function idFor(...parts: readonly string[]): string {
+	return `src_${createHash("sha256").update(parts.join("\0")).digest("hex").slice(0, 32)}`;
+}
+
+function slug(value: string): string {
+	const out = value
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "_")
+		.replace(/^_+|_+$/g, "")
+		.replace(/_{2,}/g, "_");
+	return out || "general";
+}
+
+function stripFrontmatter(content: string): string {
+	const normalized = content.replace(/\r\n?/g, "\n");
+	if (!normalized.startsWith("---\n")) return normalized;
+	const end = normalized.indexOf("\n---\n", 4);
+	return end === -1 ? normalized : normalized.slice(end + 5);
+}
+
+function parseSections(content: string): HeadingSection[] {
+	const lines = stripFrontmatter(content).split("\n");
+	const sections: Array<{ heading: string; level: number; lines: string[] }> = [];
+	let current: { heading: string; level: number; lines: string[] } = { heading: "Overview", level: 0, lines: [] };
+	for (const line of lines) {
+		const match = /^(#{1,6})\s+(.+?)\s*$/.exec(line);
+		if (match) {
+			if (current.lines.join("\n").trim().length > 0 || current.heading !== "Overview") sections.push(current);
+			current = { heading: match[2] ?? "Untitled", level: match[1]?.length ?? 1, lines: [] };
+			continue;
+		}
+		current.lines.push(line);
+	}
+	if (current.lines.join("\n").trim().length > 0 || current.heading !== "Overview") sections.push(current);
+	return sections.map((section) => ({
+		heading: section.heading,
+		level: section.level,
+		body: section.lines.join("\n"),
+	}));
+}
+
+function bodyClaims(body: string): string[] {
+	return body
+		.split(/\n{2,}|\n(?=-\s+)/)
+		.map((part) => part.replace(/^[-*]\s+/gm, "").trim())
+		.filter((part) => part.length >= 20)
+		.slice(0, 12);
+}
+
+function safeDecodeURIComponent(value: string): string {
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		return value;
+	}
+}
+
+function displayNameFromPath(path: string): string {
+	const clean = canonicalSegment(path);
+	const tail = clean.split(/[\/#]/).filter(Boolean).at(-1);
+	return tail ? safeDecodeURIComponent(tail).replace(/\.[a-z0-9]+$/i, "") : path;
+}
+
+function displayNameFor(input: IndexSourceArtifactStructureInput): string {
+	if (input.displayName?.trim()) return input.displayName.trim();
+	const heading = /^(#{1,6})\s+(.+?)\s*$/m.exec(stripFrontmatter(input.content))?.[2]?.trim();
+	return heading && heading.length > 0 ? heading : displayNameFromPath(input.sourcePath);
+}
+
+function upsertSourceEntity(
+	db: WriteDb,
+	input: {
+		readonly id: string;
+		readonly name: string;
+		readonly canonicalName: string;
+		readonly entityType: string;
+		readonly agentId: string;
+		readonly sourceId: string;
+		readonly sourceKind: string;
+		readonly sourceRoot: string;
+		readonly sourcePath: string;
+		readonly now: string;
+	},
+): { readonly id: string; readonly inserted: boolean } {
+	const uniqueName = `${input.name} - ${input.canonicalName} - ${input.agentId}`;
+	const existing = db
+		.prepare("SELECT id FROM entities WHERE canonical_name = ? AND agent_id = ? LIMIT 1")
+		.get(input.canonicalName, input.agentId) as { id: string } | undefined;
+	if (existing) {
+		db.prepare(
+			`UPDATE entities
+			 SET name = ?, entity_type = ?, mentions = MAX(COALESCE(mentions, 0), 1), updated_at = ?,
+			     source_id = ?, source_kind = ?, source_path = ?, source_root = ?
+			 WHERE id = ?`,
+		).run(
+			uniqueName,
+			input.entityType,
+			input.now,
+			input.sourceId,
+			input.sourceKind,
+			input.sourcePath,
+			input.sourceRoot,
+			existing.id,
+		);
+		return { id: existing.id, inserted: false };
+	}
+	db.prepare(
+		`INSERT INTO entities
+		 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at,
+		  source_id, source_kind, source_path, source_root)
+		 VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?)`,
+	).run(
+		input.id,
+		uniqueName,
+		input.canonicalName,
+		input.entityType,
+		input.agentId,
+		input.now,
+		input.now,
+		input.sourceId,
+		input.sourceKind,
+		input.sourcePath,
+		input.sourceRoot,
+	);
+	return { id: input.id, inserted: true };
+}
+
+function upsertDependency(
+	db: WriteDb,
+	input: {
+		readonly sourceEntityId: string;
+		readonly targetEntityId: string;
+		readonly agentId: string;
+		readonly sourceId: string;
+		readonly sourceKind: string;
+		readonly sourceRoot: string;
+		readonly sourcePath: string;
+		readonly reason: string;
+		readonly now: string;
+	},
+): boolean {
+	const existing = db
+		.prepare(
+			`SELECT id FROM entity_dependencies
+			 WHERE source_entity_id = ? AND target_entity_id = ? AND dependency_type = 'contains' AND agent_id = ?
+			 LIMIT 1`,
+		)
+		.get(input.sourceEntityId, input.targetEntityId, input.agentId) as { id: string } | undefined;
+	if (existing) {
+		db.prepare(
+			`UPDATE entity_dependencies
+			 SET strength = MAX(strength, 1), confidence = MAX(COALESCE(confidence, 0), 1),
+			     reason = ?, updated_at = ?, source_id = ?, source_kind = ?, source_path = ?, source_root = ?
+			 WHERE id = ?`,
+		).run(
+			requireDependencyReason("related_to", input.reason),
+			input.now,
+			input.sourceId,
+			input.sourceKind,
+			input.sourcePath,
+			input.sourceRoot,
+			existing.id,
+		);
+		return false;
+	}
+	db.prepare(
+		`INSERT INTO entity_dependencies
+		 (id, source_entity_id, target_entity_id, agent_id, dependency_type, strength, confidence, reason,
+		  created_at, updated_at, source_id, source_kind, source_path, source_root)
+		 VALUES (?, ?, ?, ?, 'contains', 1, 1, ?, ?, ?, ?, ?, ?, ?)`,
+	).run(
+		idFor("dep", input.agentId, "contains", input.sourceEntityId, input.targetEntityId),
+		input.sourceEntityId,
+		input.targetEntityId,
+		input.agentId,
+		requireDependencyReason("related_to", input.reason),
+		input.now,
+		input.now,
+		input.sourceId,
+		input.sourceKind,
+		input.sourcePath,
+		input.sourceRoot,
+	);
+	return true;
+}
+
+function purgeSourceArtifactStructureInTx(
+	db: WriteDb,
+	input: PurgeSourceArtifactStructureInput,
+): PurgeSourceArtifactStructureResult {
+	const entityRows = db
+		.prepare(
+			`SELECT id FROM entities
+			 WHERE agent_id = ?
+			   AND source_id = ?
+			   AND source_path = ?
+			   AND entity_type IN ('source_document', 'source_document_reference')`,
+		)
+		.all(input.agentId, input.sourceId, input.sourcePath) as Array<{ id: string }>;
+	const entityIds = entityRows.map((row) => row.id);
+
+	const attributes = countChanges(
+		db
+			.prepare("DELETE FROM entity_attributes WHERE agent_id = ? AND source_id = ? AND source_path = ?")
+			.run(input.agentId, input.sourceId, input.sourcePath),
+	);
+	const dependencies = countChanges(
+		db
+			.prepare("DELETE FROM entity_dependencies WHERE agent_id = ? AND source_id = ? AND source_path = ?")
+			.run(input.agentId, input.sourceId, input.sourcePath),
+	);
+
+	let aspects = 0;
+	if (entityIds.length > 0) {
+		const stmt = db.prepare("DELETE FROM entity_aspects WHERE agent_id = ? AND entity_id = ?");
+		for (const entityId of entityIds) aspects += countChanges(stmt.run(input.agentId, entityId));
+	}
+
+	const entities = countChanges(
+		db
+			.prepare(
+				`DELETE FROM entities
+				 WHERE agent_id = ?
+				   AND source_id = ?
+				   AND source_path = ?
+				   AND entity_type IN ('source_document', 'source_document_reference')`,
+			)
+			.run(input.agentId, input.sourceId, input.sourcePath),
+	);
+
+	return { entities, aspects, attributes, dependencies };
+}
+
+export function purgeSourceArtifactStructure(
+	input: PurgeSourceArtifactStructureInput,
+): PurgeSourceArtifactStructureResult {
+	return getDbAccessor().withWriteTx((db) => purgeSourceArtifactStructureInTx(db, input));
+}
+
+export function indexSourceArtifactStructure(
+	input: IndexSourceArtifactStructureInput,
+): IndexSourceArtifactStructureResult {
+	const now = new Date().toISOString();
+	return getDbAccessor().withWriteTx((db) => {
+		purgeSourceArtifactStructureInTx(db, input);
+
+		let entitiesTouched = 0;
+		let dependenciesTouched = 0;
+		let aspectsTouched = 0;
+		let attributesTouched = 0;
+
+		const source = upsertSourceEntity(db, {
+			id: idFor(input.agentId, input.sourceId, "source", input.sourceRoot),
+			name: displayNameFromPath(input.sourceRoot),
+			canonicalName: sourceCanonical(input.sourceId, "source", "/"),
+			entityType: "source",
+			agentId: input.agentId,
+			sourceId: input.sourceId,
+			sourceKind: input.sourceKind,
+			sourceRoot: input.sourceRoot,
+			sourcePath: input.sourceRoot,
+			now,
+		});
+		entitiesTouched++;
+
+		let parentEntityId = source.id;
+		if (input.sourceParentPath?.trim()) {
+			const parentPath = input.sourceParentPath.trim();
+			const parent = upsertSourceEntity(db, {
+				id: idFor(input.agentId, input.sourceId, "reference", parentPath),
+				name: displayNameFromPath(parentPath),
+				canonicalName: sourceCanonical(input.sourceId, "reference", parentPath),
+				entityType: "source_document_reference",
+				agentId: input.agentId,
+				sourceId: input.sourceId,
+				sourceKind: input.sourceKind,
+				sourceRoot: input.sourceRoot,
+				sourcePath: parentPath,
+				now,
+			});
+			entitiesTouched++;
+			parentEntityId = parent.id;
+		}
+
+		const doc = upsertSourceEntity(db, {
+			id: idFor(input.agentId, input.sourceId, "document", input.sourcePath),
+			name: displayNameFor(input),
+			canonicalName: sourceCanonical(input.sourceId, "document", input.sourcePath),
+			entityType: "source_document",
+			agentId: input.agentId,
+			sourceId: input.sourceId,
+			sourceKind: input.sourceKind,
+			sourceRoot: input.sourceRoot,
+			sourcePath: input.sourcePath,
+			now,
+		});
+		entitiesTouched++;
+
+		if (
+			upsertDependency(db, {
+				sourceEntityId: parentEntityId,
+				targetEntityId: doc.id,
+				agentId: input.agentId,
+				sourceId: input.sourceId,
+				sourceKind: input.sourceKind,
+				sourceRoot: input.sourceRoot,
+				sourcePath: input.sourcePath,
+				reason: `Source artifact ${input.sourcePath} belongs to ${input.sourceParentPath ?? input.sourceRoot}`,
+				now,
+			})
+		) {
+			dependenciesTouched++;
+		}
+
+		for (const section of parseSections(input.content)) {
+			const aspectId = idFor(input.agentId, input.sourceId, "aspect", input.sourcePath, section.heading);
+			const aspectCanon = slug(section.heading);
+			db.prepare(
+				`INSERT INTO entity_aspects
+				 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+				 ON CONFLICT(entity_id, canonical_name) DO UPDATE SET updated_at = excluded.updated_at, name = excluded.name`,
+			).run(aspectId, doc.id, input.agentId, section.heading, aspectCanon, section.level === 1 ? 0.9 : 0.7, now, now);
+			aspectsTouched++;
+
+			let claimIndex = 0;
+			for (const claim of bodyClaims(section.body)) {
+				const attrId = idFor(
+					input.agentId,
+					input.sourceId,
+					"attribute",
+					input.sourcePath,
+					section.heading,
+					claimIndex.toString(),
+				);
+				db.prepare(
+					`INSERT INTO entity_attributes
+					 (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, group_key, claim_key,
+					  confidence, importance, status, created_at, updated_at, source_id, source_kind, source_path, source_root)
+					 VALUES (?, ?, ?, NULL, 'claim', ?, ?, ?, ?, 0.8, 0.5, 'active', ?, ?, ?, ?, ?, ?)
+					 ON CONFLICT(id) DO UPDATE SET
+					   content = excluded.content,
+					   normalized_content = excluded.normalized_content,
+					   updated_at = excluded.updated_at,
+					   source_id = excluded.source_id,
+					   source_kind = excluded.source_kind,
+					   source_path = excluded.source_path,
+					   source_root = excluded.source_root`,
+				).run(
+					attrId,
+					aspectId,
+					input.agentId,
+					claim,
+					claim.toLowerCase(),
+					slug(input.sourceKind),
+					`${aspectCanon}_${claimIndex}`,
+					now,
+					now,
+					input.sourceId,
+					input.sourceKind,
+					input.sourcePath,
+					input.sourceRoot,
+				);
+				attributesTouched++;
+				claimIndex++;
+			}
+		}
+
+		return {
+			documentEntityId: doc.id,
+			entitiesTouched,
+			dependenciesTouched,
+			aspectsTouched,
+			attributesTouched,
+		};
+	});
+}

--- a/platform/daemon/src/source-purge.ts
+++ b/platform/daemon/src/source-purge.ts
@@ -49,6 +49,14 @@ export function purgeSourceOwnedRows(input: PurgeSourceOwnedRowsInput): number {
 				.run(...(input.agentId ? [input.agentId] : []), sourceId),
 		);
 
+		const entityRows = db
+			.prepare(`SELECT id FROM entities WHERE ${agentWhere}source_id = ?`)
+			.all(...(input.agentId ? [input.agentId] : []), sourceId) as Array<{ id: string }>;
+		if (entityRows.length > 0) {
+			const stmt = db.prepare("DELETE FROM entity_aspects WHERE entity_id = ?");
+			for (const row of entityRows) purged += countChanges(stmt.run(row.id));
+		}
+
 		for (const table of SOURCE_OWNED_GRAPH_TABLES) {
 			if (!tableHasColumn(db, table, "source_id")) continue;
 			if (input.agentId && !tableHasColumn(db, table, "agent_id")) continue;


### PR DESCRIPTION
## Summary

Projects provider-backed source artifacts into the structural graph through a shared deterministic source artifact graph path, so Discord and GitHub sources become graph-addressable without becoming ordinary memories.

## Changes

- Added `source-artifact-graph` for source-document entities, source/parent containment edges, heading aspects, and source-backed claim attributes.
- Wired Discord REST, Discord desktop-cache, and GitHub artifact writes through the shared graph projector.
- Purged per-artifact graph rows during stale provider cleanup, and purged source-owned aspect rows during whole-source removal.
- Added regression coverage for graph provenance, no-memory projection, refresh/purge behavior, Discord source graph rows, Discord desktop-cache graph rows, and GitHub graph rows.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

N/A, no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A, no migrations are touched.

- [ ] Migration is idempotent
- [ ] Daemon Rust parity reviewed or explicitly N/A
- [ ] Rollback / compatibility note included in PR description

## Testing

- [x] `bun test platform/daemon/src/source-artifact-graph.test.ts platform/daemon/src/discord-source-provider.test.ts platform/daemon/src/github-source-provider.test.ts`
- [x] `bun run --filter '@signet/core' build`
- [x] `bun run --filter '@signet/daemon' build`
- [x] `git diff --check`

Note: daemon build still prints existing Svelte a11y/deprecation warnings in dashboard components outside this PR's touched files.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

No API routes, source config schema, docs surface, or migrations changed. The readiness items that do not directly apply were checked after verifying this PR does not touch those surfaces.