### PR TITLE
Fix source snapshot graph import

### DIFF
--- a/platform/daemon/src/routes/sources-routes.test.ts
+++ b/platform/daemon/src/routes/sources-routes.test.ts
@@ -7,6 +7,7 @@ import { Hono } from "hono";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "../db-accessor";
 import { hashNormalizedBody } from "../memory-lineage";
 import type { NativeMemoryBridgeHandle, NativeMemoryBridgeOptions, NativeMemorySource } from "../native-memory-sources";
+import { indexSourceArtifactStructure } from "../source-artifact-graph";
 import {
 	beginSourceIndexJob,
 	clearSourceIndexProgressForTests,
@@ -582,14 +583,24 @@ describe("Sources routes", () => {
 			sourceRoot: added.source.root,
 			sourcePath: "discord://guild/123/channel/456/message/stale",
 			sourceKind: "source_discord_message",
-			content: "stale message",
+			content: "# Stale Message\n\nThis stale graph claim should disappear after snapshot import.",
 			metaJson: JSON.stringify({ guildId: "123", channelId: "456" }),
+		});
+		indexSourceArtifactStructure({
+			agentId: "default",
+			sourceId: added.source.id,
+			sourceKind: "source_discord_message",
+			sourceRoot: added.source.root,
+			sourcePath: "discord://guild/123/channel/456/message/stale",
+			content: "# Stale Message\n\nThis stale graph claim should disappear after snapshot import.",
 		});
 		insertSourceChunk({
 			id: "snapshot-stale-discord-chunk",
 			sourceId: `${added.source.id}:guild/123/channel/456/message/stale#0`,
 			chunkText: "source_path: discord://guild/123/channel/456/message/stale\n\nstale chunk",
 		});
+		const freshContent =
+			"# Fresh Imported Message\n\nFresh imported Discord message should be restored into source graph structure.";
 		const snapshot = {
 			version: 1,
 			exportedAt: "2026-05-24T00:00:00.000Z",
@@ -601,7 +612,7 @@ describe("Sources routes", () => {
 					sourceRoot: added.source.root,
 					sourcePath: "discord://guild/123/channel/456/message/fresh",
 					sourceKind: "source_discord_message",
-					content: "fresh imported message",
+					content: freshContent,
 					metaJson: JSON.stringify({ guildId: "123", channelId: "456" }),
 				}),
 			],
@@ -622,10 +633,34 @@ describe("Sources routes", () => {
 					.prepare("SELECT source_path, content FROM memory_artifacts WHERE source_id = ? ORDER BY source_path")
 					.all(added.source.id) as Array<{ source_path: string; content: string }>,
 		);
-		expect(rows).toEqual([
-			{ source_path: "discord://guild/123/channel/456/message/fresh", content: "fresh imported message" },
-		]);
+		expect(rows).toEqual([{ source_path: "discord://guild/123/channel/456/message/fresh", content: freshContent }]);
 		expect(sourceChunkRows(added.source.id)).toEqual([]);
+		const graph = getDbAccessor().withReadDb((db) => ({
+			documentPaths: (
+				db
+					.prepare(
+						`SELECT source_path
+						   FROM entities
+						  WHERE agent_id = ?
+						    AND source_id = ?
+						    AND entity_type = 'source_document'
+						  ORDER BY source_path`,
+					)
+					.all("default", added.source.id) as Array<{ source_path: string }>
+			).map((row) => row.source_path),
+			attributes: db
+				.prepare(
+					`SELECT source_path, content
+					   FROM entity_attributes
+					  WHERE agent_id = ?
+					    AND source_id = ?
+					  ORDER BY source_path, content`,
+				)
+				.all("default", added.source.id) as Array<{ source_path: string; content: string }>,
+		}));
+		expect(graph.documentPaths).toEqual(["discord://guild/123/channel/456/message/fresh"]);
+		expect(graph.attributes.some((row) => row.content.includes("Fresh imported Discord message"))).toBe(true);
+		expect(graph.attributes.some((row) => row.content.includes("stale graph claim"))).toBe(false);
 	});
 
 	it("preserves local Discord cache DM artifacts during default snapshot import", async () => {
@@ -655,6 +690,22 @@ describe("Sources routes", () => {
 			sourceKind: "source_discord_message",
 			content: "stale public cache",
 			metaJson: JSON.stringify({ guildId: "123", channelId: "456" }),
+		});
+		indexSourceArtifactStructure({
+			agentId: "default",
+			sourceId: added.source.id,
+			sourceKind: "source_discord_message",
+			sourceRoot: added.source.root,
+			sourcePath: "discord-cache://guild/@me/channel/111/message/local",
+			content: "local dm should remain",
+		});
+		indexSourceArtifactStructure({
+			agentId: "default",
+			sourceId: added.source.id,
+			sourceKind: "source_discord_message",
+			sourceRoot: added.source.root,
+			sourcePath: "discord-cache://guild/123/channel/456/message/stale",
+			content: "stale public cache",
 		});
 		insertSourceChunk({
 			id: "snapshot-local-discord-chunk",
@@ -718,6 +769,24 @@ describe("Sources routes", () => {
 				id: "snapshot-local-discord-chunk",
 				source_id: `${added.source.id}:discord-cache://guild/@me/channel/111/message/local#0`,
 			},
+		]);
+		const graphPaths = getDbAccessor().withReadDb((db) =>
+			(
+				db
+					.prepare(
+						`SELECT source_path
+						   FROM entities
+						  WHERE agent_id = ?
+						    AND source_id = ?
+						    AND entity_type = 'source_document'
+						  ORDER BY source_path`,
+					)
+					.all("default", added.source.id) as Array<{ source_path: string }>
+			).map((row) => row.source_path),
+		);
+		expect(graphPaths).toEqual([
+			"discord-cache://guild/123/channel/456/message/fresh",
+			"discord-cache://guild/@me/channel/111/message/local",
 		]);
 	});
 

--- a/platform/daemon/src/source-artifact-graph.ts
+++ b/platform/daemon/src/source-artifact-graph.ts
@@ -238,7 +238,7 @@ function upsertDependency(
 	return true;
 }
 
-function purgeSourceArtifactStructureInTx(
+export function purgeSourceArtifactStructureInTx(
 	db: WriteDb,
 	input: PurgeSourceArtifactStructureInput,
 ): PurgeSourceArtifactStructureResult {
@@ -295,100 +295,107 @@ export function indexSourceArtifactStructure(
 	input: IndexSourceArtifactStructureInput,
 ): IndexSourceArtifactStructureResult {
 	const now = new Date().toISOString();
-	return getDbAccessor().withWriteTx((db) => {
-		purgeSourceArtifactStructureInTx(db, input);
+	return getDbAccessor().withWriteTx((db) => indexSourceArtifactStructureInTx(db, input, now));
+}
 
-		let entitiesTouched = 0;
-		let dependenciesTouched = 0;
-		let aspectsTouched = 0;
-		let attributesTouched = 0;
+export function indexSourceArtifactStructureInTx(
+	db: WriteDb,
+	input: IndexSourceArtifactStructureInput,
+	now = new Date().toISOString(),
+): IndexSourceArtifactStructureResult {
+	purgeSourceArtifactStructureInTx(db, input);
 
-		const source = upsertSourceEntity(db, {
-			id: idFor(input.agentId, input.sourceId, "source", input.sourceRoot),
-			name: displayNameFromPath(input.sourceRoot),
-			canonicalName: sourceCanonical(input.sourceId, "source", "/"),
-			entityType: "source",
+	let entitiesTouched = 0;
+	let dependenciesTouched = 0;
+	let aspectsTouched = 0;
+	let attributesTouched = 0;
+
+	const source = upsertSourceEntity(db, {
+		id: idFor(input.agentId, input.sourceId, "source", input.sourceRoot),
+		name: displayNameFromPath(input.sourceRoot),
+		canonicalName: sourceCanonical(input.sourceId, "source", "/"),
+		entityType: "source",
+		agentId: input.agentId,
+		sourceId: input.sourceId,
+		sourceKind: input.sourceKind,
+		sourceRoot: input.sourceRoot,
+		sourcePath: input.sourceRoot,
+		now,
+	});
+	entitiesTouched++;
+
+	let parentEntityId = source.id;
+	if (input.sourceParentPath?.trim()) {
+		const parentPath = input.sourceParentPath.trim();
+		const parent = upsertSourceEntity(db, {
+			id: idFor(input.agentId, input.sourceId, "reference", parentPath),
+			name: displayNameFromPath(parentPath),
+			canonicalName: sourceCanonical(input.sourceId, "reference", parentPath),
+			entityType: "source_document_reference",
 			agentId: input.agentId,
 			sourceId: input.sourceId,
 			sourceKind: input.sourceKind,
 			sourceRoot: input.sourceRoot,
-			sourcePath: input.sourceRoot,
+			sourcePath: parentPath,
 			now,
 		});
 		entitiesTouched++;
+		parentEntityId = parent.id;
+	}
 
-		let parentEntityId = source.id;
-		if (input.sourceParentPath?.trim()) {
-			const parentPath = input.sourceParentPath.trim();
-			const parent = upsertSourceEntity(db, {
-				id: idFor(input.agentId, input.sourceId, "reference", parentPath),
-				name: displayNameFromPath(parentPath),
-				canonicalName: sourceCanonical(input.sourceId, "reference", parentPath),
-				entityType: "source_document_reference",
-				agentId: input.agentId,
-				sourceId: input.sourceId,
-				sourceKind: input.sourceKind,
-				sourceRoot: input.sourceRoot,
-				sourcePath: parentPath,
-				now,
-			});
-			entitiesTouched++;
-			parentEntityId = parent.id;
-		}
+	const doc = upsertSourceEntity(db, {
+		id: idFor(input.agentId, input.sourceId, "document", input.sourcePath),
+		name: displayNameFor(input),
+		canonicalName: sourceCanonical(input.sourceId, "document", input.sourcePath),
+		entityType: "source_document",
+		agentId: input.agentId,
+		sourceId: input.sourceId,
+		sourceKind: input.sourceKind,
+		sourceRoot: input.sourceRoot,
+		sourcePath: input.sourcePath,
+		now,
+	});
+	entitiesTouched++;
 
-		const doc = upsertSourceEntity(db, {
-			id: idFor(input.agentId, input.sourceId, "document", input.sourcePath),
-			name: displayNameFor(input),
-			canonicalName: sourceCanonical(input.sourceId, "document", input.sourcePath),
-			entityType: "source_document",
+	if (
+		upsertDependency(db, {
+			sourceEntityId: parentEntityId,
+			targetEntityId: doc.id,
 			agentId: input.agentId,
 			sourceId: input.sourceId,
 			sourceKind: input.sourceKind,
 			sourceRoot: input.sourceRoot,
 			sourcePath: input.sourcePath,
+			reason: `Source artifact ${input.sourcePath} belongs to ${input.sourceParentPath ?? input.sourceRoot}`,
 			now,
-		});
-		entitiesTouched++;
+		})
+	) {
+		dependenciesTouched++;
+	}
 
-		if (
-			upsertDependency(db, {
-				sourceEntityId: parentEntityId,
-				targetEntityId: doc.id,
-				agentId: input.agentId,
-				sourceId: input.sourceId,
-				sourceKind: input.sourceKind,
-				sourceRoot: input.sourceRoot,
-				sourcePath: input.sourcePath,
-				reason: `Source artifact ${input.sourcePath} belongs to ${input.sourceParentPath ?? input.sourceRoot}`,
-				now,
-			})
-		) {
-			dependenciesTouched++;
-		}
-
-		for (const section of parseSections(input.content)) {
-			const aspectId = idFor(input.agentId, input.sourceId, "aspect", input.sourcePath, section.heading);
-			const aspectCanon = slug(section.heading);
-			db.prepare(
-				`INSERT INTO entity_aspects
+	for (const section of parseSections(input.content)) {
+		const aspectId = idFor(input.agentId, input.sourceId, "aspect", input.sourcePath, section.heading);
+		const aspectCanon = slug(section.heading);
+		db.prepare(
+			`INSERT INTO entity_aspects
 				 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
 				 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 				 ON CONFLICT(entity_id, canonical_name) DO UPDATE SET updated_at = excluded.updated_at, name = excluded.name`,
-			).run(aspectId, doc.id, input.agentId, section.heading, aspectCanon, section.level === 1 ? 0.9 : 0.7, now, now);
-			aspectsTouched++;
+		).run(aspectId, doc.id, input.agentId, section.heading, aspectCanon, section.level === 1 ? 0.9 : 0.7, now, now);
+		aspectsTouched++;
 
-			let claimIndex = 0;
-			for (const claim of bodyClaims(section.body)) {
-				const attrId = idFor(
-					input.agentId,
-					input.sourceId,
-					"attribute",
-					input.sourcePath,
-					section.heading,
-					claimIndex.toString(),
-				);
-				db.prepare(
-					`INSERT INTO entity_attributes
+		let claimIndex = 0;
+		for (const claim of bodyClaims(section.body)) {
+			const attrId = idFor(
+				input.agentId,
+				input.sourceId,
+				"attribute",
+				input.sourcePath,
+				section.heading,
+				claimIndex.toString(),
+			);
+			db.prepare(
+				`INSERT INTO entity_attributes
 					 (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, group_key, claim_key,
 					  confidence, importance, status, created_at, updated_at, source_id, source_kind, source_path, source_root)
 					 VALUES (?, ?, ?, NULL, 'claim', ?, ?, ?, ?, 0.8, 0.5, 'active', ?, ?, ?, ?, ?, ?)
@@ -400,32 +407,31 @@ export function indexSourceArtifactStructure(
 					   source_kind = excluded.source_kind,
 					   source_path = excluded.source_path,
 					   source_root = excluded.source_root`,
-				).run(
-					attrId,
-					aspectId,
-					input.agentId,
-					claim,
-					claim.toLowerCase(),
-					slug(input.sourceKind),
-					`${aspectCanon}_${claimIndex}`,
-					now,
-					now,
-					input.sourceId,
-					input.sourceKind,
-					input.sourcePath,
-					input.sourceRoot,
-				);
-				attributesTouched++;
-				claimIndex++;
-			}
+			).run(
+				attrId,
+				aspectId,
+				input.agentId,
+				claim,
+				claim.toLowerCase(),
+				slug(input.sourceKind),
+				`${aspectCanon}_${claimIndex}`,
+				now,
+				now,
+				input.sourceId,
+				input.sourceKind,
+				input.sourcePath,
+				input.sourceRoot,
+			);
+			attributesTouched++;
+			claimIndex++;
 		}
+	}
 
-		return {
-			documentEntityId: doc.id,
-			entitiesTouched,
-			dependenciesTouched,
-			aspectsTouched,
-			attributesTouched,
-		};
-	});
+	return {
+		documentEntityId: doc.id,
+		entitiesTouched,
+		dependenciesTouched,
+		aspectsTouched,
+		attributesTouched,
+	};
 }

--- a/platform/daemon/src/source-snapshots.ts
+++ b/platform/daemon/src/source-snapshots.ts
@@ -4,6 +4,7 @@ import { getDbAccessor } from "./db-accessor";
 import type { WriteDb } from "./db-accessor";
 import { syncVecDeleteByEmbeddingIds } from "./db-helpers";
 import { hashNormalizedBody } from "./memory-lineage";
+import { indexSourceArtifactStructureInTx } from "./source-artifact-graph";
 
 export const SOURCE_SNAPSHOT_VERSION = 1;
 
@@ -176,6 +177,7 @@ export function importSourceSnapshot(options: ImportSourceSnapshotOptions): Impo
 			const writeDb = db as WriteDb as Database;
 			const conflict = findPathOwnershipConflict(writeDb, artifacts, options.agentId, options.source.id);
 			if (conflict) throw new Error(conflict);
+			purgeImportScopeGraph(writeDb, options.source.id, options.agentId, options.source.root, includeLocalDiscord);
 			deleteImportScope(writeDb, options.source.id, options.agentId, includeLocalDiscord);
 			purgeImportScopeChunks(writeDb, options.source.id, options.agentId, includeLocalDiscord);
 			const stmt = writeDb.prepare(
@@ -241,6 +243,22 @@ export function importSourceSnapshot(options: ImportSourceSnapshotOptions): Impo
 					artifact.sourceParentPath,
 					artifact.sourceMetaJson,
 				);
+				if (indexesSnapshotArtifactGraph(artifact)) {
+					indexSourceArtifactStructureInTx(
+						db as WriteDb,
+						{
+							agentId: options.agentId,
+							sourceId: artifact.sourceId,
+							sourceKind: artifact.sourceKind,
+							sourceRoot: artifact.sourceRoot ?? options.source.root,
+							sourceParentPath: artifact.sourceParentPath ?? undefined,
+							sourcePath: artifact.sourcePath,
+							displayName: sourceArtifactDisplayName(artifact),
+							content: artifact.content,
+						},
+						artifact.updatedAt,
+					);
+				}
 			}
 		});
 	} catch (err) {
@@ -306,6 +324,106 @@ function purgeImportScopeChunks(db: Database, sourceId: string, agentId: string,
 	syncVecDeleteByEmbeddingIds(db as WriteDb, ids);
 	const stmt = db.prepare("DELETE FROM embeddings WHERE id = ?");
 	for (const id of ids) stmt.run(id);
+}
+
+function purgeImportScopeGraph(
+	db: Database,
+	sourceId: string,
+	agentId: string,
+	sourceRoot: string,
+	includeLocalDiscord: boolean,
+): void {
+	const entityRows = db
+		.prepare(
+			`SELECT id, source_path
+			   FROM entities
+			  WHERE agent_id = ?
+			    AND source_id = ?`,
+		)
+		.all(agentId, sourceId) as Array<{ id: string; source_path: string | null }>;
+	const entityIds = entityRows
+		.filter((row) => shouldPurgeImportedSourcePath(row.source_path, sourceRoot, includeLocalDiscord))
+		.map((row) => row.id);
+
+	const attrRows = db
+		.prepare(
+			`SELECT id, source_path
+			   FROM entity_attributes
+			  WHERE agent_id = ?
+			    AND source_id = ?`,
+		)
+		.all(agentId, sourceId) as Array<{ id: string; source_path: string | null }>;
+	const depRows = db
+		.prepare(
+			`SELECT id, source_path
+			   FROM entity_dependencies
+			  WHERE agent_id = ?
+			    AND source_id = ?`,
+		)
+		.all(agentId, sourceId) as Array<{ id: string; source_path: string | null }>;
+	const communityRows = db
+		.prepare(
+			`SELECT id, source_path
+			   FROM entity_communities
+			  WHERE agent_id = ?
+			    AND source_id = ?`,
+		)
+		.all(agentId, sourceId) as Array<{ id: string; source_path: string | null }>;
+
+	const deleteAspect = db.prepare("DELETE FROM entity_aspects WHERE agent_id = ? AND entity_id = ?");
+	for (const entityId of entityIds) deleteAspect.run(agentId, entityId);
+
+	const deleteAttr = db.prepare("DELETE FROM entity_attributes WHERE agent_id = ? AND id = ?");
+	for (const row of attrRows) {
+		if (shouldPurgeImportedSourcePath(row.source_path, sourceRoot, includeLocalDiscord))
+			deleteAttr.run(agentId, row.id);
+	}
+
+	const deleteDep = db.prepare("DELETE FROM entity_dependencies WHERE agent_id = ? AND id = ?");
+	for (const row of depRows) {
+		if (shouldPurgeImportedSourcePath(row.source_path, sourceRoot, includeLocalDiscord)) deleteDep.run(agentId, row.id);
+	}
+
+	const deleteCommunity = db.prepare("DELETE FROM entity_communities WHERE agent_id = ? AND id = ?");
+	for (const row of communityRows) {
+		if (shouldPurgeImportedSourcePath(row.source_path, sourceRoot, includeLocalDiscord)) {
+			deleteCommunity.run(agentId, row.id);
+		}
+	}
+
+	const deleteEntity = db.prepare("DELETE FROM entities WHERE agent_id = ? AND id = ?");
+	for (const entityId of entityIds) deleteEntity.run(agentId, entityId);
+}
+
+function shouldPurgeImportedSourcePath(
+	sourcePath: string | null,
+	sourceRoot: string,
+	includeLocalDiscord: boolean,
+): boolean {
+	if (includeLocalDiscord) return true;
+	if (sourcePath === sourceRoot) return false;
+	return !isLocalDiscordArtifact({ sourcePath: sourcePath ?? "", sourceMetaJson: null });
+}
+
+function indexesSnapshotArtifactGraph(artifact: SourceSnapshotArtifact): boolean {
+	return !["source_discord_checkpoint", "source_discord_failure", "source_github_failure"].includes(
+		artifact.sourceKind,
+	);
+}
+
+function sourceArtifactDisplayName(artifact: SourceSnapshotArtifact): string | undefined {
+	if (!artifact.sourceMetaJson) return undefined;
+	try {
+		const parsed = JSON.parse(artifact.sourceMetaJson) as unknown;
+		if (!isRecord(parsed)) return undefined;
+		for (const key of ["name", "username", "filename", "title"] as const) {
+			const value = parsed[key];
+			if (typeof value === "string" && value.trim().length > 0) return value.trim();
+		}
+	} catch {
+		return undefined;
+	}
+	return undefined;
 }
 
 function artifactFromRow(row: ArtifactRow): SourceSnapshotArtifact {


### PR DESCRIPTION
## Summary

Fix source snapshot import so restored source artifacts are structurally usable immediately after import. Snapshot import now purges stale source-owned graph rows and rebuilds graph structure for imported artifacts in the same write transaction as the artifact restore.

## Changes

- Added an in-transaction source artifact graph projection helper used by snapshot import.
- Purged stale source-owned entities, aspects, attributes, dependencies, and communities during snapshot import.
- Preserved local Discord Desktop cache graph rows during default imports, matching local artifact/chunk preservation.
- Skipped graph projection for provider failure/checkpoint artifacts, matching live Discord/GitHub sync behavior.
- Added route regression coverage for stale graph purge, fresh graph rebuild, and local Discord cache graph preservation.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A. No UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A. No migrations touched.

- [ ] Migration is idempotent
- [ ] Daemon Rust parity reviewed or explicitly N/A
- [ ] Rollback / compatibility note included in PR description

## Testing

- [x] `bun test platform/daemon/src/source-artifact-graph.test.ts platform/daemon/src/routes/sources-routes.test.ts`
- [x] `bun test platform/daemon/src/discord-source-provider.test.ts platform/daemon/src/github-source-provider.test.ts`
- [x] `bunx biome check --write platform/daemon/src/source-artifact-graph.ts platform/daemon/src/source-snapshots.ts platform/daemon/src/routes/sources-routes.test.ts`
- [x] `bun run --filter '@signet/core' build`
- [x] `bun run --filter '@signet/daemon' build`
- [x] `git diff --check`

Additional note: I also tried `bun run --filter '@signet/daemon' build:types`; it still fails on existing declaration-build issues around `rootDir` including `platform/core/src` files and Bun SQLite row typings across unrelated daemon files.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

No API or schema changes. This is a snapshot restore data-integrity fix for the source graph rows introduced by the shared source graph projection path.