### PR TITLE
fix(cli): enqueue source adds through daemon

### DIFF
--- a/surfaces/cli/src/commands/sources.test.ts
+++ b/surfaces/cli/src/commands/sources.test.ts
@@ -10,6 +10,7 @@ describe("sources CLI commands", () => {
 	let dir = "";
 	let originalLog: typeof console.log;
 	let originalError: typeof console.error;
+	let originalWarn: typeof console.warn;
 	let previousExitCode: string | number | undefined;
 
 	beforeEach(() => {
@@ -18,13 +19,16 @@ describe("sources CLI commands", () => {
 		Reflect.deleteProperty(process, "exitCode");
 		originalLog = console.log;
 		originalError = console.error;
+		originalWarn = console.warn;
 		console.log = () => {};
 		console.error = () => {};
+		console.warn = () => {};
 	});
 
 	afterEach(() => {
 		console.log = originalLog;
 		console.error = originalError;
+		console.warn = originalWarn;
 		if (previousExitCode === undefined) process.exitCode = 0;
 		else process.exitCode = previousExitCode;
 		rmSync(dir, { recursive: true, force: true });
@@ -56,6 +60,187 @@ describe("sources CLI commands", () => {
 		expect(source?.root).toBe(cachePath);
 		expect(source?.providerSettings?.syncMode).toBe("desktop-cache");
 		expect(source?.providerSettings?.desktopCacheFullScan).toBe(true);
+		expect(process.exitCode).not.toBe(1);
+	});
+
+	it("wires GitHub source adds through the daemon so the initial index job is queued", async () => {
+		const calls: Array<{ method: string; path: string; body: unknown; timeoutMs?: number }> = [];
+		const program = new Command();
+		program.exitOverride();
+		registerSourcesCommands(program, {
+			agentsDir: dir,
+			secretApiCall: async (method, path, body, timeoutMs) => {
+				calls.push({ method, path, body, timeoutMs });
+				return {
+					ok: true,
+					data: {
+						created: true,
+						queued: true,
+						source: {
+							id: "github:signet-ai-signetai",
+							kind: "github",
+							name: "GitHub CLI",
+							root: "github://repos/Signet-AI/signetai",
+							enabled: true,
+							mode: "read-only",
+							createdAt: "2026-05-24T00:00:00.000Z",
+							updatedAt: "2026-05-24T00:00:00.000Z",
+							providerSettings: {
+								repos: ["Signet-AI/signetai"],
+								tokenRef: "gh_token",
+								resourceTypes: ["issues"],
+							},
+						},
+						job: { id: "source-index:github:signet-ai-signetai:1" },
+					},
+				};
+			},
+		});
+
+		await program.parseAsync([
+			"node",
+			"test",
+			"sources",
+			"add",
+			"github",
+			"--repo",
+			"Signet-AI/signetai",
+			"--token-ref",
+			"gh_token",
+			"--resource-type",
+			"issues",
+			"--max-items",
+			"50",
+			"--name",
+			"GitHub CLI",
+		]);
+
+		expect(calls).toEqual([
+			{
+				method: "POST",
+				path: "/api/sources/github",
+				timeoutMs: 30_000,
+				body: {
+					repos: ["Signet-AI/signetai"],
+					tokenRef: "gh_token",
+					name: "GitHub CLI",
+					resourceTypes: ["issues"],
+					state: "all",
+					includeComments: true,
+					labels: [],
+					docPaths: [],
+					maxItemsPerRepo: 50,
+				},
+			},
+		]);
+		expect(loadSourcesConfig(dir).sources).toHaveLength(0);
+		expect(process.exitCode).not.toBe(1);
+	});
+
+	it("falls back to local GitHub source config when the daemon is unreachable", async () => {
+		const calls: Array<{ method: string; path: string }> = [];
+		const program = new Command();
+		program.exitOverride();
+		registerSourcesCommands(program, {
+			agentsDir: dir,
+			secretApiCall: async (method, path) => {
+				calls.push({ method, path });
+				return { ok: false, data: { error: "Could not reach Signet daemon" } };
+			},
+		});
+
+		await program.parseAsync([
+			"node",
+			"test",
+			"sources",
+			"add",
+			"github",
+			"--repo",
+			"Signet-AI/signetai",
+			"--resource-type",
+			"issues",
+			"--name",
+			"GitHub CLI",
+		]);
+
+		const [source] = loadSourcesConfig(dir).sources;
+		expect(calls).toEqual([{ method: "POST", path: "/api/sources/github" }]);
+		expect(source?.kind).toBe("github");
+		expect(source?.providerSettings?.repos).toEqual(["Signet-AI/signetai"]);
+		expect(process.exitCode).not.toBe(1);
+	});
+
+	it("wires Discord source adds through the daemon so the initial index job is queued", async () => {
+		const calls: Array<{ method: string; path: string; body: unknown; timeoutMs?: number }> = [];
+		const program = new Command();
+		program.exitOverride();
+		registerSourcesCommands(program, {
+			agentsDir: dir,
+			secretApiCall: async (method, path, body, timeoutMs) => {
+				calls.push({ method, path, body, timeoutMs });
+				return {
+					ok: true,
+					data: {
+						created: true,
+						queued: true,
+						source: {
+							id: "discord:source",
+							kind: "discord",
+							name: "Discord CLI",
+							root: "discord://guilds/123456789012345678",
+							enabled: true,
+							mode: "read-only",
+							createdAt: "2026-05-24T00:00:00.000Z",
+							updatedAt: "2026-05-24T00:00:00.000Z",
+							providerSettings: { guildIds: ["123456789012345678"], tokenRef: "discord_token" },
+						},
+						job: { id: "source-index:discord:source:1" },
+					},
+				};
+			},
+		});
+
+		await program.parseAsync([
+			"node",
+			"test",
+			"sources",
+			"add",
+			"discord",
+			"--guild",
+			"123456789012345678",
+			"--token-ref",
+			"discord_token",
+			"--name",
+			"Discord CLI",
+		]);
+
+		expect(calls).toEqual([
+			{
+				method: "POST",
+				path: "/api/sources/discord",
+				timeoutMs: 30_000,
+				body: {
+					guildIds: ["123456789012345678"],
+					tokenRef: "discord_token",
+					name: "Discord CLI",
+					desktopCachePath: undefined,
+					desktopCacheFullScan: undefined,
+					channelFilter: [],
+					maxMessagesPerChannel: undefined,
+					includeThreads: true,
+					includeArchivedThreads: true,
+					includePrivateArchivedThreads: undefined,
+					includeMembers: true,
+					includeAttachments: true,
+					includeEmbeds: true,
+					includePolls: true,
+					includeThreadMembers: true,
+					since: undefined,
+					syncMode: "rest",
+				},
+			},
+		]);
+		expect(loadSourcesConfig(dir).sources).toHaveLength(0);
 		expect(process.exitCode).not.toBe(1);
 	});
 

--- a/surfaces/cli/src/commands/sources.ts
+++ b/surfaces/cli/src/commands/sources.ts
@@ -1,5 +1,7 @@
+import type { SignetSourceEntry } from "@signet/core";
 import type { Command } from "commander";
 import {
+	type DaemonAddSourceResult,
 	type SourcesDeps,
 	addDiscordSourceFromCli,
 	addGitHubSourceFromCli,
@@ -153,7 +155,14 @@ export function registerSourcesCommands(program: Command, deps: RegisterSourcesC
 		.option("--label <label>", "Label filter (repeatable)", collect, [])
 		.option("--doc-path <path>", "Markdown doc path or glob (repeatable)", collect, [])
 		.option("--max-items <count>", "Maximum items per repo per resource class")
-		.action((options) => addGitHubSourceFromCli(options, deps));
+		.action((options) =>
+			addGitHubSourceFromCli(options, {
+				...deps,
+				addGitHubSourceToDaemon: deps.secretApiCall
+					? (input) => addSourceThroughDaemon(deps.secretApiCall, "/api/sources/github", input)
+					: undefined,
+			}),
+		);
 
 	add
 		.command("discord")
@@ -175,7 +184,61 @@ export function registerSourcesCommands(program: Command, deps: RegisterSourcesC
 		.option("--no-polls", "Skip poll metadata artifacts")
 		.option("--no-thread-members", "Skip thread member snapshots")
 		.option("--mode <mode>", "Sync mode: rest, gateway-tail, or desktop-cache", "rest")
-		.action((options) => addDiscordSourceFromCli(options, deps));
+		.action((options) =>
+			addDiscordSourceFromCli(options, {
+				...deps,
+				addDiscordSourceToDaemon: deps.secretApiCall
+					? (input) => addSourceThroughDaemon(deps.secretApiCall, "/api/sources/discord", input)
+					: undefined,
+			}),
+		);
+}
+
+async function addSourceThroughDaemon(
+	secretApiCall: DaemonApiCall,
+	path: string,
+	body: unknown,
+): Promise<DaemonAddSourceResult> {
+	const result = await secretApiCall("POST", path, body, 30_000);
+	if (!result.ok) {
+		const error = errorFromDaemonData(result.data);
+		return {
+			ok: false,
+			error,
+			fallbackToLocal: error.startsWith("Could not reach Signet daemon") || error.startsWith("Request timed out"),
+		};
+	}
+	return addSourceResultFromDaemonData(result.data);
+}
+
+function addSourceResultFromDaemonData(data: unknown): DaemonAddSourceResult {
+	if (typeof data !== "object" || data === null || !("source" in data)) {
+		return { ok: false, error: "daemon returned an invalid source add response" };
+	}
+	const source = (data as { source?: unknown }).source;
+	if (!isDaemonSourceEntry(source)) {
+		return { ok: false, error: "daemon returned an invalid source add response" };
+	}
+	return {
+		ok: true,
+		source,
+		created: (data as { created?: unknown }).created === true,
+		queued: (data as { queued?: unknown }).queued === true,
+		job: (data as { job?: unknown }).job,
+	};
+}
+
+function isDaemonSourceEntry(value: unknown): value is SignetSourceEntry {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"id" in value &&
+		"name" in value &&
+		"root" in value &&
+		typeof value.id === "string" &&
+		typeof value.name === "string" &&
+		typeof value.root === "string"
+	);
 }
 
 function errorFromDaemonData(data: unknown): string {

--- a/surfaces/cli/src/features/sources.ts
+++ b/surfaces/cli/src/features/sources.ts
@@ -1,9 +1,20 @@
 import { readFileSync, writeFileSync } from "node:fs";
-import { addDiscordSource, addGitHubSource, addObsidianSource, loadSourcesConfig, removeSource } from "@signet/core";
+import {
+	type AddDiscordSourceInput,
+	type AddGitHubSourceInput,
+	type SignetSourceEntry,
+	addDiscordSource,
+	addGitHubSource,
+	addObsidianSource,
+	loadSourcesConfig,
+	removeSource,
+} from "@signet/core";
 import chalk from "chalk";
 
 export interface SourcesDeps {
 	readonly agentsDir: string;
+	readonly addDiscordSourceToDaemon?: (input: AddDiscordSourceInput) => Promise<DaemonAddSourceResult>;
+	readonly addGitHubSourceToDaemon?: (input: AddGitHubSourceInput) => Promise<DaemonAddSourceResult>;
 	readonly removeSourceFromDaemon?: (sourceId: string) => Promise<DaemonRemoveSourceResult>;
 	readonly exportSourceSnapshotFromDaemon?: (
 		sourceId: string,
@@ -15,6 +26,16 @@ export interface SourcesDeps {
 		options: { readonly includeLocalDiscord?: boolean },
 	) => Promise<DaemonImportSourceSnapshotResult>;
 }
+
+export type DaemonAddSourceResult =
+	| {
+			readonly ok: true;
+			readonly source: SignetSourceEntry;
+			readonly created: boolean;
+			readonly queued?: boolean;
+			readonly job?: unknown;
+	  }
+	| { readonly ok: false; readonly error: string; readonly fallbackToLocal?: boolean };
 
 export type DaemonRemoveSourceResult =
 	| {
@@ -117,28 +138,32 @@ export async function addDiscordSourceFromCli(options: AddDiscordSourceOptions, 
 		process.exitCode = 1;
 		return;
 	}
-	const result = addDiscordSource(
-		{
-			guildIds,
-			tokenRef: options.tokenRef ?? "",
-			name: options.name,
-			desktopCachePath: options.desktopCachePath,
-			desktopCacheFullScan: options.fullCache,
-			channelFilter: options.channel,
-			maxMessagesPerChannel,
-			includeThreads: options.threads,
-			includeArchivedThreads: options.archivedThreads,
-			includePrivateArchivedThreads: options.includePrivateArchivedThreads,
-			includeMembers: options.members,
-			includeAttachments: options.attachments,
-			includeEmbeds: options.embeds,
-			includePolls: options.polls,
-			includeThreadMembers: options.threadMembers,
-			since: options.since,
-			syncMode: options.mode,
-		},
-		deps.agentsDir,
-	);
+	const input: AddDiscordSourceInput = {
+		guildIds,
+		tokenRef: options.tokenRef ?? "",
+		name: options.name,
+		desktopCachePath: options.desktopCachePath,
+		desktopCacheFullScan: options.fullCache,
+		channelFilter: options.channel,
+		maxMessagesPerChannel,
+		includeThreads: options.threads,
+		includeArchivedThreads: options.archivedThreads,
+		includePrivateArchivedThreads: options.includePrivateArchivedThreads,
+		includeMembers: options.members,
+		includeAttachments: options.attachments,
+		includeEmbeds: options.embeds,
+		includePolls: options.polls,
+		includeThreadMembers: options.threadMembers,
+		since: options.since,
+		syncMode: options.mode,
+	};
+	const daemonResult = await addSourceThroughDaemon(input, deps.addDiscordSourceToDaemon);
+	if (daemonResult) {
+		const handled = printDaemonAddSourceResult("Discord", daemonResult);
+		if (handled) return;
+	}
+
+	const result = addDiscordSource(input, deps.agentsDir);
 	if (result.ok === false) {
 		console.error(chalk.red(`✗ ${result.error}`));
 		process.exitCode = 1;
@@ -172,20 +197,24 @@ export async function addGitHubSourceFromCli(options: AddGitHubSourceOptions, de
 		process.exitCode = 1;
 		return;
 	}
-	const result = addGitHubSource(
-		{
-			repos: options.repo ?? [],
-			tokenRef: options.tokenRef,
-			name: options.name,
-			resourceTypes,
-			state: options.state,
-			includeComments: options.includeComments,
-			labels: options.label,
-			docPaths: options.docPath,
-			maxItemsPerRepo,
-		},
-		deps.agentsDir,
-	);
+	const input: AddGitHubSourceInput = {
+		repos: options.repo ?? [],
+		tokenRef: options.tokenRef,
+		name: options.name,
+		resourceTypes,
+		state: options.state,
+		includeComments: options.includeComments,
+		labels: options.label,
+		docPaths: options.docPath,
+		maxItemsPerRepo,
+	};
+	const daemonResult = await addSourceThroughDaemon(input, deps.addGitHubSourceToDaemon);
+	if (daemonResult) {
+		const handled = printDaemonAddSourceResult("GitHub", daemonResult);
+		if (handled) return;
+	}
+
+	const result = addGitHubSource(input, deps.agentsDir);
 	if (result.ok === false) {
 		console.error(chalk.red(`✗ ${result.error}`));
 		process.exitCode = 1;
@@ -344,6 +373,39 @@ export async function importConfiguredSourceSnapshot(
 
 function isGitHubResourceType(value: string): value is "issues" | "pulls" | "discussions" | "docs" {
 	return value === "issues" || value === "pulls" || value === "discussions" || value === "docs";
+}
+
+async function addSourceThroughDaemon<TInput>(
+	input: TInput,
+	addSourceToDaemon: ((input: TInput) => Promise<DaemonAddSourceResult>) | undefined,
+): Promise<DaemonAddSourceResult | undefined> {
+	if (!addSourceToDaemon) return undefined;
+	const result = await addSourceToDaemon(input);
+	if (result.ok === false && result.fallbackToLocal) {
+		console.warn(chalk.yellow(`! Daemon add unavailable (${result.error}). Falling back to local config-only add.`));
+		return undefined;
+	}
+	return result;
+}
+
+function printDaemonAddSourceResult(kind: string, result: DaemonAddSourceResult): boolean {
+	if (result.ok === false) {
+		console.error(chalk.red(`✗ ${result.error}`));
+		process.exitCode = 1;
+		return true;
+	}
+
+	const verb = result.created ? "Added" : "Updated";
+	console.log(chalk.green(`✓ ${verb} ${kind} source: ${result.source.name}`));
+	console.log(chalk.dim(`  ${result.source.root}`));
+	if (
+		typeof result.source.providerSettings?.tokenRef === "string" &&
+		result.source.providerSettings.tokenRef.length > 0
+	) {
+		console.log(chalk.dim(`  tokenRef: ${result.source.providerSettings.tokenRef}`));
+	}
+	if (result.queued) console.log(chalk.dim("  queued initial index job"));
+	return true;
 }
 
 type ParseIntegerResult = number | undefined | { readonly error: string };


### PR DESCRIPTION
## Summary
- route `signet sources add github` and `signet sources add discord` through the daemon add APIs when the daemon is reachable, so the shared source index job pipeline queues immediately
- keep local config-only fallback when the daemon is unreachable
- add CLI regression coverage for daemon-backed GitHub/Discord adds and offline fallback

Fixes #768

## PR Checklist
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Notes
- Spec/dependency surfaces are not changed by this CLI routing fix.
- No data queries, admin endpoints, mutation endpoints, schema, API, or status docs changed.
- Existing daemon route validation remains the boundary validation for daemon-backed adds; CLI max-items/resource-type validation remains local before the daemon call.

## Validation
- `bun test surfaces/cli/src/commands/sources.test.ts surfaces/cli/src/features/sources.test.ts`
- `bunx biome check surfaces/cli/src/features/sources.ts surfaces/cli/src/commands/sources.ts surfaces/cli/src/commands/sources.test.ts`
- `bun run --filter '@signet/cli' build:cli`
- runtime smoke: temporary daemon on `SIGNET_PORT=43850`, then `bun surfaces/cli/src/cli.ts sources add github --repo Signet-AI/signetai --resource-type issues --state open --max-items 1 --name "Smoke GitHub"`; `/api/sources` reported an `indexJob` with status `running`