### PR TITLE
fix(connector-codex): remove stale MCP before plugin install

### DIFF
--- a/integrations/codex/connector/src/config-toml.test.ts
+++ b/integrations/codex/connector/src/config-toml.test.ts
@@ -361,7 +361,8 @@ describe("CodexConnector.install — native plugin bundle", () => {
 		expect(config).toContain("[marketplaces.signet-local]");
 		expect(config).toContain("[plugins.\"signet@signet-local\"]");
 		expect(config).toContain("enabled = true");
-		expect(config).not.toContain("[mcp_servers.signet]");
+		expect(config).toContain("[mcp_servers.signet]");
+		expect(config).toContain("command = 'signet-mcp'");
 		expect(config).toContain("[hooks.state.");
 
 		const plugin = JSON.parse(readFileSync(pluginManifestPath, "utf-8")) as {
@@ -404,7 +405,8 @@ describe("CodexConnector.install — native plugin bundle", () => {
 		expect(result.message).toBe("Codex integration installed — native plugin bundle + Signet lifecycle hooks");
 		expect(result.warnings).not.toContain("codex refused stale mcp_servers.signet");
 		expect(config).toContain("[plugins.\"signet@signet-local\"]");
-		expect(config).not.toContain("[mcp_servers.signet]");
+		expect(config).toContain("[mcp_servers.signet]");
+		expect(config).toContain("command = 'signet-mcp'");
 		expect(config).not.toContain("transport = 'sse'");
 	});
 

--- a/integrations/codex/connector/src/config-toml.test.ts
+++ b/integrations/codex/connector/src/config-toml.test.ts
@@ -46,6 +46,20 @@ class NativePluginFailingTempConnector extends TempConnector {
 	}
 }
 
+class NativePluginConfigParsingTempConnector extends TempConnector {
+	protected override supportsNativePluginInstall(): boolean {
+		return true;
+	}
+	protected override installNativePlugin(codexHome: string): { success: boolean; filesWritten: readonly string[]; warning?: string } {
+		if (readFileSync(this.getConfigPath(), "utf-8").includes("[mcp_servers.signet]")) {
+			return { success: false, filesWritten: [], warning: "codex refused stale mcp_servers.signet" };
+		}
+		const installedRoot = join(codexHome, "plugins", "cache", "signet-local", "signet", "0.1.0");
+		mkdirSync(installedRoot, { recursive: true });
+		return { success: true, filesWritten: [installedRoot] };
+	}
+}
+
 let tempHome: string;
 let codexDir: string;
 let configPath: string;
@@ -97,6 +111,10 @@ function nativePluginConnector(): TempConnector {
 
 function failingNativePluginConnector(): TempConnector {
 	return new NativePluginFailingTempConnector(tempHome);
+}
+
+function configParsingNativePluginConnector(): TempConnector {
+	return new NativePluginConfigParsingTempConnector(tempHome);
 }
 
 describe("CodexConnector.install — legacy SIGNET block migration", () => {
@@ -364,6 +382,30 @@ describe("CodexConnector.install — native plugin bundle", () => {
 		expect(readFileSync(configPath, "utf-8")).toBe(firstConfig);
 		expect(firstConfig.match(/\[plugins\."signet@signet-local"\]/g)).toHaveLength(1);
 		expect(firstConfig.match(/\[marketplaces\.signet-local\]/g)).toHaveLength(1);
+	});
+
+	test("removes stale compatibility MCP before native plugin add reads Codex config", async () => {
+		writeFileSync(
+			configPath,
+			[
+				"[model]",
+				'name = "gpt-5.4-mini"',
+				"",
+				"[mcp_servers.signet]",
+				"transport = 'sse'",
+				"command = 'signet-mcp'",
+				"",
+			].join("\n"),
+		);
+
+		const result = await configParsingNativePluginConnector().install(tempHome);
+
+		const config = readFileSync(configPath, "utf-8");
+		expect(result.message).toBe("Codex integration installed — native plugin bundle + Signet lifecycle hooks");
+		expect(result.warnings).not.toContain("codex refused stale mcp_servers.signet");
+		expect(config).toContain("[plugins.\"signet@signet-local\"]");
+		expect(config).not.toContain("[mcp_servers.signet]");
+		expect(config).not.toContain("transport = 'sse'");
 	});
 
 	test("falls back to compatibility hooks and MCP when native plugin add fails", async () => {

--- a/integrations/codex/connector/src/index.ts
+++ b/integrations/codex/connector/src/index.ts
@@ -890,6 +890,9 @@ export class CodexConnector extends BaseConnector {
 			filesWritten.push(...pluginInstall.filesWritten);
 			if (pluginInstall.warning) warnings.push(pluginInstall.warning);
 			if (pluginInstall.success) {
+				if (patchConfigToml(this.getConfigPath(), mcp) && !configsPatched.includes(this.getConfigPath())) {
+					configsPatched.push(this.getConfigPath());
+				}
 				if (this.nativePluginProvidesHooks()) {
 					const existingHooks = readHooksFile(this.getHooksJsonPath());
 					const trustEntries = existingHooks ? buildHookTrustEntries(this.getHooksJsonPath(), existingHooks) : [];

--- a/integrations/codex/connector/src/index.ts
+++ b/integrations/codex/connector/src/index.ts
@@ -883,13 +883,13 @@ export class CodexConnector extends BaseConnector {
 			if (patchNativePluginConfig(this.getConfigPath(), bundle.marketplaceRoot)) {
 				configsPatched.push(this.getConfigPath());
 			}
+			if (unpatchConfigToml(this.getConfigPath()) && !configsPatched.includes(this.getConfigPath())) {
+				configsPatched.push(this.getConfigPath());
+			}
 			const pluginInstall = this.installNativePlugin(codexHome);
 			filesWritten.push(...pluginInstall.filesWritten);
 			if (pluginInstall.warning) warnings.push(pluginInstall.warning);
 			if (pluginInstall.success) {
-				if (unpatchConfigToml(this.getConfigPath()) && !configsPatched.includes(this.getConfigPath())) {
-					configsPatched.push(this.getConfigPath());
-				}
 				if (this.nativePluginProvidesHooks()) {
 					const existingHooks = readHooksFile(this.getHooksJsonPath());
 					const trustEntries = existingHooks ? buildHookTrustEntries(this.getHooksJsonPath(), existingHooks) : [];


### PR DESCRIPTION
## Summary
- Remove stale compatibility `[mcp_servers.signet]` config before invoking `codex plugin add` on native plugin installs.
- Keep a clean compatibility `[mcp_servers.signet]` block after native plugin installation because Codex 0.133 still reports zero configured MCP servers when only the plugin MCP bundle is present.
- Add regression coverage for stale invalid transport config blocking the native plugin migration path.

## Test Plan
- [x] `bun test integrations/codex/connector/src/config-toml.test.ts`
- [x] `bun run --filter '@signet/connector-codex' typecheck`
- [x] `bun run --filter '@signet/connector-codex' build`
- [x] Direct MCP SDK probe: `signet-mcp` lists tools and successfully calls `signet_recall` / `signet_session_search`
- [x] Live check: `codex plugin list` shows `signet@signet-local` installed/enabled
- [x] Live check: `codex mcp get signet` reports `transport: stdio`
- [x] Live check: `codex doctor` reports `1 server (1 stdio)`

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)
- [x] No database migrations changed
- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

No database migrations are involved. This only changes Codex connector config migration order and preserves compatibility fallback behavior for MCP and lifecycle hooks while the native plugin path is still maturing.
