### PR TITLE
Resume Discord history backfill from checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Tag range: `bundle-0.130.1-13d784943001995e248894b6742fa2eec17144d8..v0.132.0`.
 
 ### Features
 
-- **sources**: resume Discord sync from checkpoints (#773)
+- **sources**: resume Discord history backfill from checkpoints (#775)
 
 ## [0.131.0] - 2026-05-24
 

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -59,7 +59,7 @@ The REST sync path indexes:
 - guilds, categories, text channels, announcement channels, forums, media channels, active threads, and archived public/private thread catalogs;
 - guild member snapshots and thread member snapshots;
 - per-message artifacts and message windows with reply references, pins, mentions, attachment metadata, embed metadata, poll metadata, reactions metadata, and message lifecycle fields;
-- source checkpoints with latest/backfill cursors and authoritative vs partial status; routine REST refreshes use the latest checkpoint cursor to fetch only newer messages while preserving older source-owned rows;
+- source checkpoints with latest/backfill cursors and authoritative vs partial status; routine REST refreshes fetch newer messages from the latest checkpoint cursor, then resume bounded historical backfill from the backfill cursor until history is complete within the configured `since` bound;
 - source failure artifacts for unavailable or partial fetches.
 
 The desktop-cache sync path indexes classifiable local Discord Desktop cache

--- a/platform/daemon/src/discord-source-fetch.test.ts
+++ b/platform/daemon/src/discord-source-fetch.test.ts
@@ -248,4 +248,90 @@ describe("discord-source-fetch", () => {
 		expect(requested[1]).toContain("before=101");
 		expect(requested[1]).not.toContain("after=");
 	});
+
+	it("uses the newer after cursor as the lower bound when since is older", async () => {
+		const requested: string[] = [];
+		const fetchImpl = mock((url: string | URL | Request) => {
+			requested.push(String(url));
+			if (requested.length === 1) {
+				return Promise.resolve(
+					Response.json(
+						Array.from({ length: 100 }, (_, index) => ({
+							id: String(200 - index),
+							type: 0,
+							content: `message-${index}`,
+							author: { id: "123456789012345681", username: "alice" },
+							timestamp: `2026-05-23T16:${String(index).padStart(2, "0")}:00.000Z`,
+							channel_id: "123456789012345678",
+						})),
+					),
+				);
+			}
+			return Promise.resolve(
+				Response.json([
+					{
+						id: "100",
+						type: 0,
+						content: "already indexed boundary",
+						author: { id: "123456789012345681", username: "alice" },
+						timestamp: "2026-05-23T15:59:00.000Z",
+						channel_id: "123456789012345678",
+					},
+				]),
+			);
+		}) as unknown as typeof fetch;
+
+		const result = await fetchChannelMessages(
+			{ token: "TOKEN", fetchImpl },
+			"123456789012345678",
+			101,
+			undefined,
+			"50",
+			"100",
+		);
+
+		expect(result.errors).toEqual([]);
+		expect(result.data).toHaveLength(100);
+		expect(result.data.map((msg) => msg.id)).not.toContain("100");
+		expect(result.reachedLowerBound).toBe(true);
+	});
+
+	it("reports whether capped message fetches exhausted the available history", async () => {
+		const fetchImpl = mock((url: string | URL | Request) => {
+			if (String(url).includes("before=1000")) {
+				return Promise.resolve(
+					Response.json([
+						{
+							id: "999",
+							type: 0,
+							content: "older",
+							author: { id: "123456789012345681", username: "alice" },
+							timestamp: "2026-05-23T15:59:00.000Z",
+							channel_id: "123456789012345678",
+						},
+					]),
+				);
+			}
+			return Promise.resolve(
+				Response.json([
+					{
+						id: "1000",
+						type: 0,
+						content: "latest",
+						author: { id: "123456789012345681", username: "alice" },
+						timestamp: "2026-05-23T16:00:00.000Z",
+						channel_id: "123456789012345678",
+					},
+				]),
+			);
+		}) as unknown as typeof fetch;
+
+		const capped = await fetchChannelMessages({ token: "TOKEN", fetchImpl }, "123456789012345678", 1);
+		const exhausted = await fetchChannelMessages({ token: "TOKEN", fetchImpl }, "123456789012345678", 2, "1000");
+
+		expect(capped.data.map((msg) => msg.id)).toEqual(["1000"]);
+		expect(capped.exhausted).toBe(false);
+		expect(exhausted.data.map((msg) => msg.id)).toEqual(["999"]);
+		expect(exhausted.exhausted).toBe(true);
+	});
 });

--- a/platform/daemon/src/discord-source-fetch.ts
+++ b/platform/daemon/src/discord-source-fetch.ts
@@ -129,6 +129,8 @@ export interface DiscordFetchResult<T> {
 	readonly rateLimitRemaining: number;
 	readonly rateLimitReset: number;
 	readonly errors: readonly DiscordFetchError[];
+	readonly exhausted?: boolean;
+	readonly reachedLowerBound?: boolean;
 }
 
 export interface DiscordFetchError {
@@ -287,6 +289,8 @@ export async function fetchChannelMessages(
 	let fetched = 0;
 	let rateLimitRemaining = 5;
 	let rateLimitReset = 0;
+	let exhausted = false;
+	let reachedLowerBound = false;
 	if (beforeId && afterId) {
 		return {
 			data: [],
@@ -300,23 +304,25 @@ export async function fetchChannelMessages(
 			],
 		};
 	}
-	const effectiveSinceId = sinceId ?? afterId;
-	const sinceSnowflake = effectiveSinceId ? parseSnowflake(effectiveSinceId) : null;
-	if (effectiveSinceId && sinceSnowflake === null) {
+	const malformedLowerBound = [sinceId, afterId].find((value) => value && parseSnowflake(value) === null);
+	if (malformedLowerBound) {
 		return {
 			data: [],
 			rateLimitRemaining,
 			rateLimitReset,
 			errors: [
 				{
-					message: `Messages fetch used malformed since id for channel ${channelId}: ${effectiveSinceId}`,
+					message: `Messages fetch used malformed lower-bound id for channel ${channelId}: ${malformedLowerBound}`,
 					retryable: false,
 				},
 			],
 		};
 	}
+	const effectiveSinceId = newestSnowflakeBound(sinceId, afterId);
+	const sinceSnowflake = effectiveSinceId ? parseSnowflake(effectiveSinceId) : null;
 	while (fetched < maxMessages) {
-		const params = new URLSearchParams({ limit: String(Math.min(PER_PAGE, maxMessages - fetched)) });
+		const pageLimit = Math.min(PER_PAGE, maxMessages - fetched);
+		const params = new URLSearchParams({ limit: String(pageLimit) });
 		if (cursor) params.set("before", cursor);
 		if (afterCursor) params.set("after", afterCursor);
 		const prefix = `Messages fetch failed for channel ${channelId}`;
@@ -333,7 +339,10 @@ export async function fetchChannelMessages(
 			break;
 		}
 		const batch = Array.isArray(response.body) ? (response.body as DiscordMessage[]) : [];
-		if (batch.length === 0) break;
+		if (batch.length === 0) {
+			exhausted = true;
+			break;
+		}
 		for (const msg of batch) {
 			if (sinceSnowflake !== null) {
 				const msgSnowflake = parseSnowflake(msg.id);
@@ -344,16 +353,31 @@ export async function fetchChannelMessages(
 					});
 					continue;
 				}
-				if (msgSnowflake <= sinceSnowflake) return { data: messages, rateLimitRemaining, rateLimitReset, errors };
+				if (msgSnowflake <= sinceSnowflake) {
+					reachedLowerBound = true;
+					return { data: messages, rateLimitRemaining, rateLimitReset, errors, exhausted, reachedLowerBound };
+				}
 			}
 			messages.push(msg);
 			fetched++;
 		}
-		if (batch.length < PER_PAGE) break;
+		if (batch.length < pageLimit) {
+			exhausted = true;
+			break;
+		}
 		cursor = batch[batch.length - 1]?.id;
 		afterCursor = undefined;
 	}
-	return { data: messages, rateLimitRemaining, rateLimitReset, errors };
+	return { data: messages, rateLimitRemaining, rateLimitReset, errors, exhausted, reachedLowerBound };
+}
+
+function newestSnowflakeBound(left?: string, right?: string): string | undefined {
+	if (!left) return right;
+	if (!right) return left;
+	const leftId = parseSnowflake(left);
+	const rightId = parseSnowflake(right);
+	if (leftId === null || rightId === null) return left;
+	return leftId > rightId ? left : right;
 }
 
 export async function fetchGuildActiveThreads(

--- a/platform/daemon/src/discord-source-provider.test.ts
+++ b/platform/daemon/src/discord-source-provider.test.ts
@@ -915,6 +915,129 @@ describe("discord-source-provider", () => {
 		expect(checkpoint?.source_meta_json).toContain('"backfillCursor":"1000"');
 	});
 
+	it("resumes capped Discord history backfill from the checkpoint cursor", async () => {
+		const requestedMessages: string[] = [];
+		globalThis.fetch = mock((url: string | URL | Request) => {
+			const text = String(url);
+			if (text.includes("/guilds/123456789012345678?with_counts=true")) {
+				return Promise.resolve(Response.json({ id: "123456789012345678", name: "Guild A" }));
+			}
+			if (text.includes("/guilds/123456789012345678/channels")) {
+				return Promise.resolve(
+					Response.json([{ id: "123456789012345679", type: DISCORD_CHANNEL_TYPES.guildText, name: "general" }]),
+				);
+			}
+			if (text.includes("/channels/123456789012345679/messages")) {
+				requestedMessages.push(text);
+				if (text.includes("after=1001")) return Promise.resolve(Response.json([]));
+				if (text.includes("before=998")) {
+					return Promise.resolve(
+						Response.json([
+							{
+								id: "997",
+								type: 0,
+								channel_id: "123456789012345679",
+								content: "oldest final backfill",
+								author: { id: "123456789012345680", username: "alice" },
+								timestamp: "2015-01-01T00:00:00.997Z",
+							},
+						]),
+					);
+				}
+				if (text.includes("before=1000")) {
+					return Promise.resolve(
+						Response.json([
+							{
+								id: "999",
+								type: 0,
+								channel_id: "123456789012345679",
+								content: "older backfill page",
+								author: { id: "123456789012345680", username: "alice" },
+								timestamp: "2015-01-01T00:00:00.999Z",
+							},
+							{
+								id: "998",
+								type: 0,
+								channel_id: "123456789012345679",
+								content: "oldest incomplete backfill",
+								author: { id: "123456789012345680", username: "alice" },
+								timestamp: "2015-01-01T00:00:00.998Z",
+							},
+						]),
+					);
+				}
+				return Promise.resolve(
+					Response.json([
+						{
+							id: "1001",
+							type: 0,
+							channel_id: "123456789012345679",
+							content: "latest capped baseline",
+							author: { id: "123456789012345681", username: "bob" },
+							timestamp: "2015-01-01T00:00:01.001Z",
+						},
+						{
+							id: "1000",
+							type: 0,
+							channel_id: "123456789012345679",
+							content: "oldest capped baseline",
+							author: { id: "123456789012345680", username: "alice" },
+							timestamp: "2015-01-01T00:00:01.000Z",
+						},
+					]),
+				);
+			}
+			if (text.includes("/members?")) return Promise.resolve(Response.json([]));
+			if (text.includes("/threads/active")) return Promise.resolve(Response.json({ threads: [] }));
+			return Promise.resolve(Response.json([]));
+		}) as typeof fetch;
+		const added = addDiscordSource(
+			{
+				guildIds: ["123456789012345678"],
+				tokenRef: "DISCORD_BOT_TOKEN",
+				maxMessagesPerChannel: 2,
+				now: "2026-01-01T00:00:00.000Z",
+			},
+			dir,
+		);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+
+		const first = await discordSourceProvider.sync?.({
+			source: added.source,
+			agentsDir: dir,
+			agentId: "default",
+			shouldContinue: () => true,
+		});
+		const second = await discordSourceProvider.sync?.({
+			source: added.source,
+			agentsDir: dir,
+			agentId: "default",
+			shouldContinue: () => true,
+		});
+		const third = await discordSourceProvider.sync?.({
+			source: added.source,
+			agentsDir: dir,
+			agentId: "default",
+			shouldContinue: () => true,
+		});
+
+		expect(first?.failures).toEqual([]);
+		expect(second?.failures).toEqual([]);
+		expect(third?.failures).toEqual([]);
+		expect(requestedMessages.some((url) => url.includes("after=1001"))).toBe(true);
+		expect(requestedMessages.some((url) => url.includes("before=1000"))).toBe(true);
+		expect(requestedMessages.some((url) => url.includes("before=998"))).toBe(true);
+		const rows = sourceRows(added.source.id);
+		expect(rows.some((row) => row.content.includes("latest capped baseline"))).toBe(true);
+		expect(rows.some((row) => row.content.includes("older backfill page"))).toBe(true);
+		expect(rows.some((row) => row.content.includes("oldest final backfill"))).toBe(true);
+		const checkpoint = rows.find((row) => row.source_kind === "source_discord_checkpoint");
+		expect(checkpoint?.source_meta_json).toContain('"latestCursor":"1001"');
+		expect(checkpoint?.source_meta_json).toContain('"backfillCursor":"997"');
+		expect(checkpoint?.source_meta_json).toContain('"backfillComplete":true');
+	});
+
 	it("purges source-owned Discord artifacts and generic chunks by source id", async () => {
 		const added = addDiscordSource(
 			{ guildIds: ["123456789012345678"], tokenRef: "DISCORD_BOT_TOKEN", now: "2026-01-01T00:00:00.000Z" },

--- a/platform/daemon/src/discord-source-provider.ts
+++ b/platform/daemon/src/discord-source-provider.ts
@@ -223,7 +223,23 @@ async function syncDiscordSource(context: SourceProviderSyncContext): Promise<So
 				channelId: channel.id,
 				phase: "messages",
 			});
-			indexed += writeMessageArtifacts(context.source, agentId, guild, channel, messages.data, {
+			const backfillLimit = Math.max(0, settings.maxMessagesPerChannel - messages.data.length);
+			const backfillCursor = previousCheckpoint?.backfillComplete
+				? undefined
+				: (previousCheckpoint?.backfillCursor ?? previousCheckpoint?.latestCursor ?? undefined);
+			const backfill =
+				previousCheckpoint && backfillCursor && backfillLimit > 0
+					? await fetchChannelMessages(fetchConfig, channel.id, backfillLimit, backfillCursor, sinceId)
+					: null;
+			if (backfill) {
+				indexed += writeFetchFailures(context.source, agentId, failures, backfill.errors, {
+					guildId,
+					channelId: channel.id,
+					phase: "message_backfill",
+				});
+			}
+			const channelMessages = [...messages.data, ...(backfill?.data ?? [])];
+			indexed += writeMessageArtifacts(context.source, agentId, guild, channel, channelMessages, {
 				includeAttachments: settings.includeAttachments,
 				includeEmbeds: settings.includeEmbeds,
 				includePolls: settings.includePolls,
@@ -235,9 +251,18 @@ async function syncDiscordSource(context: SourceProviderSyncContext): Promise<So
 					context.source,
 					guild,
 					channel,
-					messages.data,
-					messages.errors.length === 0 ? "authoritative" : "partial",
+					channelMessages,
+					messages.errors.length === 0 && (backfill?.errors.length ?? 0) === 0 ? "authoritative" : "partial",
 					previousCheckpoint,
+					{
+						backfillMessages: backfill?.data ?? (previousCheckpoint ? [] : messages.data),
+						backfillComplete:
+							backfill !== null
+								? backfill.exhausted === true || backfill.reachedLowerBound === true
+								: previousCheckpoint
+									? previousCheckpoint.backfillComplete
+									: messages.exhausted === true || messages.reachedLowerBound === true,
+					},
 				),
 			);
 			context.onProgress?.({
@@ -803,13 +828,17 @@ function checkpointArtifact(
 	messages: readonly DiscordMessage[],
 	status: "authoritative" | "partial",
 	previous?: DiscordCheckpoint | null,
+	backfillUpdate: {
+		readonly backfillMessages: readonly DiscordMessage[];
+		readonly backfillComplete: boolean;
+	} = { backfillMessages: [], backfillComplete: false },
 ): DiscordArtifact {
 	const sorted = messages.slice().sort(compareDiscordMessagesByCursor);
 	const latest = sorted[sorted.length - 1];
-	const earliest = sorted[0];
+	const sortedBackfill = backfillUpdate.backfillMessages.slice().sort(compareDiscordMessagesByCursor);
+	const earliestBackfill = sortedBackfill[0];
 	const latestCursor = newestCheckpointCursor(previous?.latestCursor ?? null, latest?.id ?? null);
-	const backfillCursor = previous?.backfillCursor ?? earliest?.id ?? null;
-	const backfillComplete = previous?.backfillComplete ?? messages.length === 0;
+	const backfillCursor = earliestBackfill?.id ?? previous?.backfillCursor ?? null;
 	return {
 		kind: "source_discord_checkpoint",
 		externalId: `checkpoint:${channel.id}`,
@@ -833,7 +862,7 @@ function checkpointArtifact(
 			status,
 			latestCursor,
 			backfillCursor,
-			backfillComplete,
+			backfillComplete: backfillUpdate.backfillComplete,
 		},
 	};
 }


### PR DESCRIPTION
## Summary

Discord REST sources now resume historical backfill from checkpoint state. After fetching newer messages from the latest cursor, the provider uses the remaining per-channel sync budget to fetch older pages from `backfillCursor` until Discord history is exhausted or the configured `since` lower bound is reached.

## Changes

- Track whether Discord message fetches exhausted the queried history range or stopped at the lower bound.
- Resume older message history with `before=backfillCursor` after latest-delta syncs.
- Advance `backfillCursor` and `backfillComplete` truthfully across capped sync runs.
- Add regression coverage for capped initial syncs that require later historical backfill runs.
- Update source docs to describe forward-plus-backfill REST checkpoint behavior.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

N/A, no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A, no schema migrations.

## Testing

- [x] `bun test platform/daemon/src/discord-source-fetch.test.ts platform/daemon/src/discord-source-provider.test.ts`
- [x] `bun run --filter '@signet/core' build`
- [x] `bun run --filter '@signet/daemon' build`
- [x] `git diff --check`

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

This closes another Discrawl parity gap: Signet already had latest and backfill checkpoint fields, but historical backfill did not resume after capped REST syncs.

