### PR TITLE
fix(codex): avoid duplicate native plugin hooks

### DIFF
--- a/integrations/codex/connector/src/config-toml.test.ts
+++ b/integrations/codex/connector/src/config-toml.test.ts
@@ -50,7 +50,11 @@ class NativePluginConfigParsingTempConnector extends TempConnector {
 	protected override supportsNativePluginInstall(): boolean {
 		return true;
 	}
-	protected override installNativePlugin(codexHome: string): { success: boolean; filesWritten: readonly string[]; warning?: string } {
+	protected override installNativePlugin(codexHome: string): {
+		success: boolean;
+		filesWritten: readonly string[];
+		warning?: string;
+	} {
 		if (readFileSync(this.getConfigPath(), "utf-8").includes("[mcp_servers.signet]")) {
 			return { success: false, filesWritten: [], warning: "codex refused stale mcp_servers.signet" };
 		}
@@ -68,6 +72,7 @@ let previousSessionStartTimeout: string | undefined;
 let previousFetchTimeout: string | undefined;
 let previousPromptSubmitTimeout: string | undefined;
 let previousDaemonUrl: string | undefined;
+let previousForceCompatHooks: string | undefined;
 
 function restoreEnv(name: string, value: string | undefined): void {
 	if (value === undefined) {
@@ -82,10 +87,12 @@ beforeEach(() => {
 	previousFetchTimeout = process.env.SIGNET_FETCH_TIMEOUT;
 	previousPromptSubmitTimeout = process.env.SIGNET_PROMPT_SUBMIT_TIMEOUT;
 	previousDaemonUrl = process.env.SIGNET_DAEMON_URL;
+	previousForceCompatHooks = process.env.SIGNET_CODEX_FORCE_COMPAT_HOOKS;
 	Reflect.deleteProperty(process.env, "SIGNET_SESSION_START_TIMEOUT");
 	Reflect.deleteProperty(process.env, "SIGNET_FETCH_TIMEOUT");
 	Reflect.deleteProperty(process.env, "SIGNET_PROMPT_SUBMIT_TIMEOUT");
 	Reflect.deleteProperty(process.env, "SIGNET_DAEMON_URL");
+	Reflect.deleteProperty(process.env, "SIGNET_CODEX_FORCE_COMPAT_HOOKS");
 	tempHome = join(tmpdir(), `signet-codex-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	codexDir = join(tempHome, ".codex");
 	configPath = join(codexDir, "config.toml");
@@ -98,6 +105,7 @@ afterEach(() => {
 	restoreEnv("SIGNET_FETCH_TIMEOUT", previousFetchTimeout);
 	restoreEnv("SIGNET_PROMPT_SUBMIT_TIMEOUT", previousPromptSubmitTimeout);
 	restoreEnv("SIGNET_DAEMON_URL", previousDaemonUrl);
+	restoreEnv("SIGNET_CODEX_FORCE_COMPAT_HOOKS", previousForceCompatHooks);
 	rmSync(tempHome, { recursive: true, force: true });
 });
 
@@ -341,7 +349,14 @@ describe("CodexConnector.install — native plugin bundle", () => {
 	test("installs a local Codex plugin marketplace when plugin support is available", async () => {
 		const result = await nativePluginConnector().install(tempHome);
 
-		const marketplacePath = join(codexDir, ".tmp", "signet-plugin-marketplace", ".agents", "plugins", "marketplace.json");
+		const marketplacePath = join(
+			codexDir,
+			".tmp",
+			"signet-plugin-marketplace",
+			".agents",
+			"plugins",
+			"marketplace.json",
+		);
 		const pluginManifestPath = join(
 			codexDir,
 			".tmp",
@@ -359,11 +374,12 @@ describe("CodexConnector.install — native plugin bundle", () => {
 
 		const config = readFileSync(configPath, "utf-8");
 		expect(config).toContain("[marketplaces.signet-local]");
-		expect(config).toContain("[plugins.\"signet@signet-local\"]");
+		expect(config).toContain('[plugins."signet@signet-local"]');
 		expect(config).toContain("enabled = true");
 		expect(config).toContain("[mcp_servers.signet]");
 		expect(config).toContain("command = 'signet-mcp'");
-		expect(config).toContain("[hooks.state.");
+		expect(config).not.toContain(`[hooks.state."${hooksPath}:`);
+		expect(existsSync(hooksPath)).toBe(false);
 
 		const plugin = JSON.parse(readFileSync(pluginManifestPath, "utf-8")) as {
 			mcpServers?: string;
@@ -385,6 +401,33 @@ describe("CodexConnector.install — native plugin bundle", () => {
 		expect(firstConfig.match(/\[marketplaces\.signet-local\]/g)).toHaveLength(1);
 	});
 
+	test("native plugin install removes stale compatibility Signet hooks", async () => {
+		await connector().install(tempHome);
+		expect(existsSync(hooksPath)).toBe(true);
+		expect(readFileSync(configPath, "utf-8")).toContain(`[hooks.state."${hooksPath}:user_prompt_submit:0:0"]`);
+
+		await nativePluginConnector().install(tempHome);
+
+		const config = readFileSync(configPath, "utf-8");
+		expect(config).toContain('[plugins."signet@signet-local"]');
+		expect(config).toContain("[mcp_servers.signet]");
+		expect(config).not.toContain(`[hooks.state."${hooksPath}:`);
+		expect(existsSync(hooksPath)).toBe(false);
+	});
+
+	test("can force compatibility hooks when native plugin hooks are unavailable", async () => {
+		process.env.SIGNET_CODEX_FORCE_COMPAT_HOOKS = "1";
+
+		const result = await nativePluginConnector().install(tempHome);
+
+		const config = readFileSync(configPath, "utf-8");
+		expect(result.warnings).toContain(
+			"Codex plugin support detected, but lifecycle hooks still require the compatibility hooks.json path in this Codex version",
+		);
+		expect(config).toContain(`[hooks.state."${hooksPath}:user_prompt_submit:0:0"]`);
+		expect(existsSync(hooksPath)).toBe(true);
+	});
+
 	test("removes stale compatibility MCP before native plugin add reads Codex config", async () => {
 		writeFileSync(
 			configPath,
@@ -402,9 +445,9 @@ describe("CodexConnector.install — native plugin bundle", () => {
 		const result = await configParsingNativePluginConnector().install(tempHome);
 
 		const config = readFileSync(configPath, "utf-8");
-		expect(result.message).toBe("Codex integration installed — native plugin bundle + Signet lifecycle hooks");
+		expect(result.message).toBe("Codex integration installed — native plugin bundle + compatibility MCP server");
 		expect(result.warnings).not.toContain("codex refused stale mcp_servers.signet");
-		expect(config).toContain("[plugins.\"signet@signet-local\"]");
+		expect(config).toContain('[plugins."signet@signet-local"]');
 		expect(config).toContain("[mcp_servers.signet]");
 		expect(config).toContain("command = 'signet-mcp'");
 		expect(config).not.toContain("transport = 'sse'");
@@ -417,7 +460,7 @@ describe("CodexConnector.install — native plugin bundle", () => {
 		expect(result.message).toBe("Codex integration installed — native hooks + MCP server");
 		expect(result.warnings).toContain("native plugin add failed in test");
 		expect(config).toContain("[mcp_servers.signet]");
-		expect(config).not.toContain("[plugins.\"signet@signet-local\"]");
+		expect(config).not.toContain('[plugins."signet@signet-local"]');
 		expect(config).not.toContain("[marketplaces.signet-local]");
 		expect(existsSync(hooksPath)).toBe(true);
 	});
@@ -434,7 +477,7 @@ describe("CodexConnector.install — native plugin bundle", () => {
 		await c.uninstall();
 
 		const config = readFileSync(configPath, "utf-8");
-		expect(config).not.toContain("[plugins.\"signet@signet-local\"]");
+		expect(config).not.toContain('[plugins."signet@signet-local"]');
 		expect(config).not.toContain("[marketplaces.signet-local]");
 		expect(existsSync(pluginCache)).toBe(false);
 		expect(existsSync(join(codexDir, ".tmp", "signet-plugin-marketplace"))).toBe(false);

--- a/integrations/codex/connector/src/index.ts
+++ b/integrations/codex/connector/src/index.ts
@@ -1,8 +1,8 @@
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { spawnSync } from "node:child_process";
 import { BaseConnector, type InstallResult, type UninstallResult, atomicWriteJson } from "@signet/connector-base";
 import {
 	expandHome,
@@ -714,7 +714,10 @@ function removeTomlSection(content: string, header: string): string {
 		}
 		if (!inSection) filtered.push(line);
 	}
-	return `${filtered.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd()}\n`;
+	return `${filtered
+		.join("\n")
+		.replace(/\n{3,}/g, "\n\n")
+		.trimEnd()}\n`;
 }
 
 function patchNativePluginConfig(path: string, marketplaceRoot: string): boolean {
@@ -773,7 +776,7 @@ export class CodexConnector extends BaseConnector {
 	}
 
 	protected nativePluginProvidesHooks(): boolean {
-		return false;
+		return readEnv("SIGNET_CODEX_FORCE_COMPAT_HOOKS") !== "1";
 	}
 
 	protected installNativePlugin(codexHome: string): NativePluginCommandResult {
@@ -855,6 +858,40 @@ export class CodexConnector extends BaseConnector {
 		}
 	}
 
+	private removeCompatibilityHooks(configsPatched: string[]): void {
+		const hooksPath = this.getHooksJsonPath();
+		const existing = readHooksFile(hooksPath);
+		const hookTrustEntries = existing ? buildHookTrustEntries(hooksPath, existing) : [];
+		if (existing) {
+			const hasMarker = isSignetOwned(existing);
+			const events = existing.hooks;
+			const hasHandlers =
+				events &&
+				typeof events === "object" &&
+				Object.values(events as Record<string, unknown[]>).some(
+					(groups) => Array.isArray(groups) && groups.some(isSignetMatcherGroup),
+				);
+			if (hasMarker || hasHandlers) {
+				const cleaned = removeSignetEntries(existing);
+				const remaining = Object.keys(cleaned).filter((k) => k !== "_signet" && k !== "hooks");
+				const hooksRemain = cleaned.hooks && Object.keys(cleaned.hooks as Record<string, unknown>).length > 0;
+				if (remaining.length === 0 && !hooksRemain) {
+					rmSync(hooksPath, { force: true });
+				} else {
+					writeHooksFile(hooksPath, cleaned);
+				}
+				if (!configsPatched.includes(hooksPath)) {
+					configsPatched.push(hooksPath);
+				}
+			}
+		}
+
+		const configPath = this.getConfigPath();
+		if (removeHookTrustState(configPath, hookTrustEntries) && !configsPatched.includes(configPath)) {
+			configsPatched.push(configPath);
+		}
+	}
+
 	async install(basePath: string): Promise<InstallResult> {
 		const filesWritten: string[] = [];
 		const configsPatched: string[] = [];
@@ -894,11 +931,7 @@ export class CodexConnector extends BaseConnector {
 					configsPatched.push(this.getConfigPath());
 				}
 				if (this.nativePluginProvidesHooks()) {
-					const existingHooks = readHooksFile(this.getHooksJsonPath());
-					const trustEntries = existingHooks ? buildHookTrustEntries(this.getHooksJsonPath(), existingHooks) : [];
-					if (removeHookTrustState(this.getConfigPath(), trustEntries) && !configsPatched.includes(this.getConfigPath())) {
-						configsPatched.push(this.getConfigPath());
-					}
+					this.removeCompatibilityHooks(configsPatched);
 				} else {
 					this.installCompatibilityHooks(signetArgs, filesWritten, configsPatched, warnings);
 					warnings.push(
@@ -908,7 +941,7 @@ export class CodexConnector extends BaseConnector {
 
 				return {
 					success: true,
-					message: "Codex integration installed — native plugin bundle + Signet lifecycle hooks",
+					message: "Codex integration installed — native plugin bundle + compatibility MCP server",
 					filesWritten,
 					configsPatched,
 					warnings,
@@ -1012,7 +1045,10 @@ export class CodexConnector extends BaseConnector {
 
 	isInstalled(): boolean {
 		const configPath = this.getConfigPath();
-		if (existsSync(configPath) && readFileSync(configPath, "utf-8").includes(`[plugins."${CODEX_PLUGIN_CONFIG_NAME}"]`)) {
+		if (
+			existsSync(configPath) &&
+			readFileSync(configPath, "utf-8").includes(`[plugins."${CODEX_PLUGIN_CONFIG_NAME}"]`)
+		) {
 			return true;
 		}
 		const file = readHooksFile(this.getHooksJsonPath());


### PR DESCRIPTION
## Summary

Stops `signet sync` from leaving both native Codex plugin hooks and legacy compatibility hooks active for Signet. Codex 0.133 loads the plugin bundle hooks, so the compatibility `~/.codex/hooks.json` path can double-send `UserPromptSubmit`.

## Changes

- Treat native Codex plugin installs as owning Signet lifecycle hooks by default.
- Remove stale Signet entries and hook trust state from the legacy compatibility `hooks.json` path after native plugin install succeeds.
- Keep the compatibility `[mcp_servers.signet]` registration so MCP remains available while plugin MCP behavior is still unreliable.
- Add `SIGNET_CODEX_FORCE_COMPAT_HOOKS=1` as an escape hatch for Codex versions where plugin hooks are unavailable.
- Add regression coverage for upgrading from compatibility hooks to native plugin hooks.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [x] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: N/A

## Screenshots

N/A; no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

No database migrations. Rollback is to set `SIGNET_CODEX_FORCE_COMPAT_HOOKS=1` or revert this connector change.

## Testing

- [x] `bun test integrations/codex/connector/src/config-toml.test.ts`
- [x] `bunx biome check integrations/codex/connector/src/config-toml.test.ts integrations/codex/connector/src/index.ts`
- [x] `bun run --filter '@signet/connector-codex' typecheck`
- [x] `bun run --filter '@signet/connector-codex' build`
- [x] Live source connector install against `~/.codex` removed legacy Signet `hooks.json` and kept plugin hooks + MCP healthy under `codex doctor`.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The live machine was repaired with this patch: `~/.codex/hooks.json` was removed because it only contained Signet compatibility hooks, and `~/.codex/config.toml` now only trusts the plugin hook path for Signet lifecycle events.
