### PR TITLE
feat(sources): tail Discord gateway events

### DIFF
--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -47,11 +47,11 @@ signet sources remove discord:...
 
 The daemon rejects raw Discord tokens in source config. Store the bot token in Signet Secrets or an external secret reference, then pass the secret name with `--token-ref`.
 
-The dashboard Sources tab exposes both modes. Open Discord, choose Connect,
-then select Bot REST for guild indexing or Desktop cache for local cache import.
-Desktop cache mode can use the platform default Discord Desktop data folder or
-a picked folder path, and Signet queues the shared source index job in the
-background.
+The dashboard Sources tab exposes all Discord modes. Open Discord, choose
+Connect, then select Bot REST for bounded guild indexing, Gateway tail for live
+incremental events, or Desktop cache for local cache import. Desktop cache mode
+can use the platform default Discord Desktop data folder or a picked folder
+path, and Signet queues the shared source index job in the background.
 
 The REST sync path indexes:
 
@@ -75,6 +75,13 @@ messages without a bot token or user-token automation:
 Desktop cache imports are cache-observed, not authoritative. Cache eviction or
 missing local files do not delete previously indexed cache artifacts; removing
 the source still purges all Signet-owned rows for that source.
+
+Gateway tail mode keeps a bot gateway connection open through the shared source
+job lifecycle. It identifies with guild, guild member, guild message, message
+reaction, and message content intents, then indexes gateway-observed message
+creates, message updates, message deletes, channel/thread upserts, member
+upserts, member removals, and per-channel tail checkpoints as Signet source
+artifacts. Removing or canceling the source closes the gateway connection.
 
 Partial Discord listings are never treated as authoritative deletes. If a channel, thread, member, or message fetch fails, Signet records a source failure artifact and preserves existing source-owned rows until a successful sync can refresh them.
 
@@ -281,8 +288,8 @@ The desktop shell uses native folder selection through IPC. The daemon picker ro
 Limitations in v1
 -----------------
 
-- Discord gateway tailing is represented in config but not active yet. Supported
-  Discord sync modes are REST and local desktop cache import.
+- Discord gateway tailing depends on a bot token with the required gateway
+  intents and keeps a source job open while it is connected.
 - Sources are local/operator-managed. Permissions and RBAC are intentionally out of scope for v1.
 - Signet does not write back to Obsidian or Discord.
 - Rename handling is delete + add.

--- a/docs/api/documents-sources.md
+++ b/docs/api/documents-sources.md
@@ -254,6 +254,17 @@ folder exists. The selected cache root must be a known Discord-compatible
 application data folder. `desktopCacheFullScan` expands cache file scanning;
 the default scans LevelDB/log JSON and route-bearing Chromium cache entries.
 
+For live gateway tailing:
+
+```json
+{
+  "guildIds": ["123456789012345678"],
+  "tokenRef": "DISCORD_BOT_TOKEN",
+  "name": "Team Discord Tail",
+  "syncMode": "gateway-tail"
+}
+```
+
 **Response**
 
 ```json
@@ -271,6 +282,12 @@ channels, forums, active and archived threads, member snapshots, thread member
 snapshots, per-message artifacts, message windows, mentions, attachment
 metadata, embeds, polls, checkpoints, and partial-failure artifacts. Partial Discord listings are not
 used as authoritative deletes.
+
+The gateway-tail sync path keeps the shared source job open while it listens for
+Discord gateway events. It indexes message create/update/delete lifecycle
+events, deleted-message tombstones, channel/thread upserts, member upserts,
+member removals, and per-channel tail checkpoints. Canceling or removing the
+source closes the gateway connection.
 
 The desktop-cache sync path indexes classifiable route-bearing cached messages,
 DMs under the synthetic guild id `@me`, cache-observed channel metadata, message

--- a/platform/daemon/src/discord-gateway-tail.ts
+++ b/platform/daemon/src/discord-gateway-tail.ts
@@ -1,0 +1,486 @@
+import type { SignetSourceEntry } from "@signet/core";
+import {
+	DISCORD_CHANNEL_TYPES,
+	type DiscordAttachment,
+	type DiscordChannel,
+	type DiscordEmbed,
+	type DiscordGuildMember,
+	type DiscordMessage,
+	type DiscordPoll,
+	type DiscordReaction,
+	type DiscordUser,
+} from "./discord-source-fetch";
+import type { SourceProviderSyncContext } from "./source-providers";
+
+const DISCORD_GATEWAY_URL = "wss://gateway.discord.gg/?v=10&encoding=json";
+const DISCORD_GATEWAY_IDENTIFY_OP = 2;
+const DISCORD_GATEWAY_HEARTBEAT_OP = 1;
+const DISCORD_GATEWAY_DISPATCH_OP = 0;
+const DISCORD_GATEWAY_HELLO_OP = 10;
+const DISCORD_GATEWAY_RECONNECT_OP = 7;
+const DISCORD_GATEWAY_INVALID_SESSION_OP = 9;
+const DISCORD_GATEWAY_INTENTS =
+	1 | // GUILDS
+	2 | // GUILD_MEMBERS
+	512 | // GUILD_MESSAGES
+	1024 | // GUILD_MESSAGE_REACTIONS
+	32768; // MESSAGE_CONTENT
+const GATEWAY_RECONNECT_DELAY_MS = 1_000;
+const GATEWAY_SHOULD_CONTINUE_POLL_MS = 250;
+
+interface DiscordGatewaySocket {
+	onopen: ((event: unknown) => void) | null;
+	onmessage: ((event: { readonly data: unknown }) => void) | null;
+	onerror: ((event: unknown) => void) | null;
+	onclose: ((event: { readonly code?: number; readonly reason?: string }) => void) | null;
+	send(data: string): void;
+	close(code?: number, reason?: string): void;
+}
+
+type DiscordGatewaySocketFactory = (url: string) => DiscordGatewaySocket;
+
+let discordGatewaySocketFactory: DiscordGatewaySocketFactory = (url) => new WebSocket(url);
+
+export function setDiscordGatewaySocketFactoryForTest(factory: DiscordGatewaySocketFactory | null): void {
+	discordGatewaySocketFactory = factory ?? ((url) => new WebSocket(url));
+}
+
+export interface DiscordGatewayTailHandlers {
+	readonly source: SignetSourceEntry;
+	readonly token: string;
+	readonly guildIds: readonly string[];
+	readonly shouldContinue: () => boolean;
+	readonly onProgress?: SourceProviderSyncContext["onProgress"];
+	readonly recordFailure: (message: string, metadata: Readonly<Record<string, unknown>>, recoverable: boolean) => void;
+	readonly recordMessage: (
+		guildId: string,
+		channelId: string,
+		messageId: string,
+		message: DiscordMessage | null,
+		gatewayEventType: string,
+		sequence: number | null,
+		payload: unknown,
+	) => void;
+	readonly recordMessageDelete: (
+		guildId: string,
+		channelId: string,
+		messageId: string,
+		sequence: number | null,
+		payload: unknown,
+	) => void;
+	readonly recordChannel: (guildId: string, channel: DiscordChannel) => void;
+	readonly recordMember: (guildId: string, member: DiscordGuildMember) => void;
+	readonly recordMemberRemove: (guildId: string, userId: string, sequence: number | null, payload: unknown) => void;
+}
+
+export async function syncDiscordGatewayTail(
+	input: DiscordGatewayTailHandlers,
+): Promise<{ readonly indexedEvents: number; readonly failures: number; readonly canceled: boolean }> {
+	let indexedEvents = 0;
+	let failures = 0;
+	const allowedGuilds = new Set(input.guildIds);
+	while (input.shouldContinue()) {
+		const result = await runDiscordGatewayConnection({
+			...input,
+			allowedGuilds,
+			recordFailure: (message, metadata, recoverable) => {
+				failures++;
+				input.recordFailure(message, metadata, recoverable);
+			},
+			recordEvent: () => {
+				indexedEvents++;
+			},
+		});
+		if (!result.retry) break;
+		await Bun.sleep(GATEWAY_RECONNECT_DELAY_MS);
+	}
+	return { indexedEvents, failures, canceled: !input.shouldContinue() };
+}
+
+async function runDiscordGatewayConnection(
+	input: DiscordGatewayTailHandlers & {
+		readonly allowedGuilds: ReadonlySet<string>;
+		readonly recordEvent: () => void;
+	},
+): Promise<{ readonly retry: boolean }> {
+	return await new Promise((resolve) => {
+		const socket = discordGatewaySocketFactory(DISCORD_GATEWAY_URL);
+		let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+		let continueTimer: ReturnType<typeof setInterval> | null = null;
+		let sequence: number | null = null;
+		let settled = false;
+		let closeFailureRecorded = false;
+		let reconnectRequested = false;
+		const cleanup = (): void => {
+			if (heartbeatTimer) clearInterval(heartbeatTimer);
+			if (continueTimer) clearInterval(continueTimer);
+			heartbeatTimer = null;
+			continueTimer = null;
+		};
+		const settle = (retry: boolean): void => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			resolve({ retry });
+		};
+		const closeForCancellation = (): void => {
+			try {
+				socket.close(1000, "source sync canceled");
+			} catch {
+				settle(false);
+			}
+		};
+		continueTimer = setInterval(() => {
+			if (!input.shouldContinue()) closeForCancellation();
+		}, GATEWAY_SHOULD_CONTINUE_POLL_MS);
+		socket.onopen = () => {
+			input.onProgress?.({ scanned: 0, total: input.allowedGuilds.size, indexed: 0, currentPath: "discord://gateway" });
+		};
+		socket.onerror = () => {
+			closeFailureRecorded = true;
+			input.recordFailure("Discord gateway websocket error", { phase: "gateway_tail" }, true);
+			try {
+				socket.close(1011, "gateway websocket error");
+			} catch {
+				settle(true);
+			}
+		};
+		socket.onclose = (event) => {
+			if (!input.shouldContinue()) {
+				settle(false);
+				return;
+			}
+			if (reconnectRequested) {
+				settle(true);
+				return;
+			}
+			if (isFatalGatewayCloseCode(event.code)) {
+				input.recordFailure(
+					`Discord gateway closed with non-retryable code ${event.code}${event.reason ? `: ${event.reason}` : ""}`,
+					{ phase: "gateway_tail", code: event.code ?? null },
+					false,
+				);
+				settle(false);
+				return;
+			}
+			if (!closeFailureRecorded)
+				input.recordFailure(
+					`Discord gateway closed unexpectedly${event.reason ? `: ${event.reason}` : ""}`,
+					{ phase: "gateway_tail", code: event.code ?? null },
+					true,
+				);
+			settle(true);
+		};
+		socket.onmessage = (event) => {
+			const payload = parseGatewayPayload(event.data);
+			if (!payload) return;
+			if (typeof payload.s === "number") sequence = payload.s;
+			if (payload.op === DISCORD_GATEWAY_HELLO_OP) {
+				const heartbeatInterval = gatewayHeartbeatInterval(payload.d);
+				if (heartbeatInterval !== null) {
+					heartbeatTimer = setInterval(() => {
+						socket.send(JSON.stringify({ op: DISCORD_GATEWAY_HEARTBEAT_OP, d: sequence }));
+					}, heartbeatInterval);
+				}
+				socket.send(
+					JSON.stringify({
+						op: DISCORD_GATEWAY_IDENTIFY_OP,
+						d: {
+							token: input.token,
+							intents: DISCORD_GATEWAY_INTENTS,
+							properties: { os: "linux", browser: "signet", device: "signet" },
+						},
+					}),
+				);
+				return;
+			}
+			if (payload.op === DISCORD_GATEWAY_RECONNECT_OP || payload.op === DISCORD_GATEWAY_INVALID_SESSION_OP) {
+				reconnectRequested = true;
+				try {
+					socket.close(1012, "discord requested reconnect");
+				} catch {
+					settle(true);
+				}
+				return;
+			}
+			if (payload.op !== DISCORD_GATEWAY_DISPATCH_OP || typeof payload.t !== "string") return;
+			const eventResult = handleDiscordGatewayDispatch({
+				...input,
+				eventType: payload.t,
+				sequence,
+				data: payload.d,
+			});
+			if (!eventResult.indexed) return;
+			input.recordEvent();
+			input.onProgress?.({
+				scanned: 0,
+				total: input.allowedGuilds.size,
+				indexed: 0,
+				currentPath: eventResult.path,
+			});
+		};
+	});
+}
+
+function handleDiscordGatewayDispatch(
+	input: DiscordGatewayTailHandlers & {
+		readonly allowedGuilds: ReadonlySet<string>;
+		readonly eventType: string;
+		readonly sequence: number | null;
+		readonly data: unknown;
+	},
+): { readonly indexed: boolean; readonly path: string } {
+	if (!isRecord(input.data)) return { indexed: false, path: "discord://gateway" };
+	const guildId = readString(input.data, "guild_id");
+	if (!guildId || !input.allowedGuilds.has(guildId)) return { indexed: false, path: "discord://gateway" };
+	if (input.eventType === "MESSAGE_CREATE" || input.eventType === "MESSAGE_UPDATE") {
+		const channelId = readString(input.data, "channel_id");
+		const messageId = readString(input.data, "id");
+		if (!channelId || !messageId) return { indexed: false, path: "discord://gateway" };
+		input.recordMessage(
+			guildId,
+			channelId,
+			messageId,
+			gatewayMessage(input.data),
+			input.eventType,
+			input.sequence,
+			input.data,
+		);
+		return { indexed: true, path: `discord://guild/${guildId}/channel/${channelId}/messages/${messageId}` };
+	}
+	if (input.eventType === "MESSAGE_DELETE") {
+		const channelId = readString(input.data, "channel_id");
+		const messageId = readString(input.data, "id");
+		if (!channelId || !messageId) return { indexed: false, path: "discord://gateway" };
+		input.recordMessageDelete(guildId, channelId, messageId, input.sequence, input.data);
+		return { indexed: true, path: `discord://guild/${guildId}/channel/${channelId}/messages/${messageId}` };
+	}
+	if (
+		input.eventType === "CHANNEL_CREATE" ||
+		input.eventType === "CHANNEL_UPDATE" ||
+		input.eventType === "THREAD_CREATE" ||
+		input.eventType === "THREAD_UPDATE"
+	) {
+		const channel = gatewayChannelFromEvent(input.data);
+		if (!channel) return { indexed: false, path: "discord://gateway" };
+		input.recordChannel(guildId, channel);
+		return { indexed: true, path: `discord://guild/${guildId}/channel/${channel.id}` };
+	}
+	if (input.eventType === "GUILD_MEMBER_ADD" || input.eventType === "GUILD_MEMBER_UPDATE") {
+		const member = gatewayMember(input.data);
+		if (!member) return { indexed: false, path: "discord://gateway" };
+		input.recordMember(guildId, member);
+		return { indexed: true, path: `discord://guild/${guildId}/member/${member.user?.id ?? "unknown"}` };
+	}
+	if (input.eventType === "GUILD_MEMBER_REMOVE") {
+		const user = gatewayUser(input.data.user);
+		if (!user) return { indexed: false, path: "discord://gateway" };
+		input.recordMemberRemove(guildId, user.id, input.sequence, input.data);
+		return { indexed: true, path: `discord://guild/${guildId}/member/${user.id}` };
+	}
+	return { indexed: false, path: "discord://gateway" };
+}
+
+interface DiscordGatewayPayload {
+	readonly op: number;
+	readonly t?: string | null;
+	readonly s?: number | null;
+	readonly d?: unknown;
+}
+
+function parseGatewayPayload(data: unknown): DiscordGatewayPayload | null {
+	const text =
+		typeof data === "string"
+			? data
+			: data instanceof ArrayBuffer
+				? new TextDecoder().decode(data)
+				: data instanceof Uint8Array
+					? new TextDecoder().decode(data)
+					: null;
+	if (text === null) return null;
+	try {
+		const parsed = JSON.parse(text) as unknown;
+		if (!isRecord(parsed) || typeof parsed.op !== "number") return null;
+		return {
+			op: parsed.op,
+			t: typeof parsed.t === "string" ? parsed.t : null,
+			s: typeof parsed.s === "number" ? parsed.s : null,
+			d: parsed.d,
+		};
+	} catch {
+		return null;
+	}
+}
+
+function gatewayHeartbeatInterval(data: unknown): number | null {
+	if (!isRecord(data) || typeof data.heartbeat_interval !== "number") return null;
+	return Math.max(1_000, data.heartbeat_interval);
+}
+
+function isFatalGatewayCloseCode(code: number | undefined): boolean {
+	return code === 4004 || code === 4010 || code === 4011 || code === 4013 || code === 4014;
+}
+
+function gatewayChannelFromEvent(data: Record<string, unknown>): DiscordChannel | null {
+	const id = readString(data, "id");
+	const guildId = readString(data, "guild_id");
+	const type = typeof data.type === "number" ? data.type : DISCORD_CHANNEL_TYPES.guildText;
+	if (!id || !guildId) return null;
+	const name = readString(data, "name") ?? undefined;
+	const topic = readString(data, "topic");
+	const parentId = readString(data, "parent_id");
+	return {
+		id,
+		guild_id: guildId,
+		type,
+		...(name ? { name } : {}),
+		...(topic ? { topic } : {}),
+		...(parentId ? { parent_id: parentId } : {}),
+		...(isRecord(data.thread_metadata) ? { thread_metadata: data.thread_metadata } : {}),
+	};
+}
+
+function gatewayMessage(data: Record<string, unknown>): DiscordMessage | null {
+	const id = readString(data, "id");
+	const channelId = readString(data, "channel_id");
+	const content = readString(data, "content");
+	const timestamp = readString(data, "timestamp");
+	const author = gatewayUser(data.author);
+	if (!id || !channelId || content === null || !timestamp || !author) return null;
+	return {
+		id,
+		channel_id: channelId,
+		content,
+		timestamp,
+		type: typeof data.type === "number" ? data.type : 0,
+		author,
+		...(readString(data, "edited_timestamp") ? { edited_timestamp: readString(data, "edited_timestamp") } : {}),
+		...(typeof data.flags === "number" ? { flags: data.flags } : {}),
+		...(readString(data, "webhook_id") ? { webhook_id: readString(data, "webhook_id") ?? undefined } : {}),
+		...(isRecord(data.message_reference) ? { message_reference: gatewayMessageReference(data.message_reference) } : {}),
+		...(isRecord(data.referenced_message) ? { referenced_message: gatewayMessage(data.referenced_message) } : {}),
+		...(Array.isArray(data.attachments)
+			? { attachments: data.attachments.map(gatewayAttachment).filter(isPresent) }
+			: {}),
+		...(Array.isArray(data.embeds) ? { embeds: data.embeds.map(gatewayEmbed).filter(isPresent) } : {}),
+		...(Array.isArray(data.mentions) ? { mentions: data.mentions.map(gatewayUser).filter(isPresent) } : {}),
+		...(Array.isArray(data.mention_roles) ? { mention_roles: data.mention_roles.filter(isString) } : {}),
+		...(typeof data.pinned === "boolean" ? { pinned: data.pinned } : {}),
+		...(isRecord(data.poll) ? { poll: gatewayPoll(data.poll) } : {}),
+		...(Array.isArray(data.reactions) ? { reactions: data.reactions.map(gatewayReaction).filter(isPresent) } : {}),
+	};
+}
+
+function gatewayUser(data: unknown): DiscordUser | null {
+	if (!isRecord(data)) return null;
+	const id = readString(data, "id");
+	const username = readString(data, "username") ?? readString(data, "global_name") ?? id;
+	if (!id || !username) return null;
+	return {
+		id,
+		username,
+		...(readString(data, "discriminator") ? { discriminator: readString(data, "discriminator") ?? undefined } : {}),
+		...(readString(data, "global_name") ? { global_name: readString(data, "global_name") } : {}),
+		...(typeof data.bot === "boolean" ? { bot: data.bot } : {}),
+	};
+}
+
+function gatewayMember(data: Record<string, unknown>): DiscordGuildMember | null {
+	const user = gatewayUser(data.user);
+	if (!user) return null;
+	return {
+		user,
+		...(readString(data, "nick") ? { nick: readString(data, "nick") } : {}),
+		...(Array.isArray(data.roles) ? { roles: data.roles.filter(isString) } : {}),
+		...(readString(data, "joined_at") ? { joined_at: readString(data, "joined_at") } : {}),
+	};
+}
+
+function gatewayAttachment(data: unknown): DiscordAttachment | null {
+	if (!isRecord(data)) return null;
+	const id = readString(data, "id");
+	const filename = readString(data, "filename");
+	const size = typeof data.size === "number" ? data.size : 0;
+	if (!id || !filename) return null;
+	return {
+		id,
+		filename,
+		size,
+		...(readString(data, "url") ? { url: readString(data, "url") ?? undefined } : {}),
+		...(readString(data, "proxy_url") ? { proxy_url: readString(data, "proxy_url") ?? undefined } : {}),
+		...(readString(data, "content_type") ? { content_type: readString(data, "content_type") ?? undefined } : {}),
+		...(readString(data, "description") ? { description: readString(data, "description") } : {}),
+		...(typeof data.width === "number" ? { width: data.width } : {}),
+		...(typeof data.height === "number" ? { height: data.height } : {}),
+	};
+}
+
+function gatewayEmbed(data: unknown): DiscordEmbed | null {
+	if (!isRecord(data)) return null;
+	const fields = Array.isArray(data.fields)
+		? data.fields.flatMap((field) => {
+				if (!isRecord(field)) return [];
+				const name = readString(field, "name");
+				const value = readString(field, "value");
+				return name && value ? [{ name, value }] : [];
+			})
+		: undefined;
+	return {
+		...(readString(data, "title") ? { title: readString(data, "title") ?? undefined } : {}),
+		...(readString(data, "description") ? { description: readString(data, "description") ?? undefined } : {}),
+		...(readString(data, "url") ? { url: readString(data, "url") ?? undefined } : {}),
+		...(readString(data, "type") ? { type: readString(data, "type") ?? undefined } : {}),
+		...(fields && fields.length > 0 ? { fields } : {}),
+	};
+}
+
+function gatewayPoll(data: Record<string, unknown>): DiscordPoll {
+	const question = isRecord(data.question) ? readString(data.question, "text") : null;
+	const answers = Array.isArray(data.answers)
+		? data.answers.flatMap((answer) => {
+				if (!isRecord(answer)) return [];
+				const pollMedia = isRecord(answer.poll_media) ? readString(answer.poll_media, "text") : null;
+				const answerId = typeof answer.answer_id === "number" ? answer.answer_id : undefined;
+				return [
+					{ ...(answerId ? { answer_id: answerId } : {}), ...(pollMedia ? { poll_media: { text: pollMedia } } : {}) },
+				];
+			})
+		: undefined;
+	return {
+		...(question ? { question: { text: question } } : {}),
+		...(answers && answers.length > 0 ? { answers } : {}),
+	};
+}
+
+function gatewayReaction(data: unknown): DiscordReaction | null {
+	if (!isRecord(data)) return null;
+	const emoji = isRecord(data.emoji)
+		? { emoji: { id: readString(data.emoji, "id"), name: readString(data.emoji, "name") } }
+		: {};
+	return { ...(typeof data.count === "number" ? { count: data.count } : {}), ...emoji };
+}
+
+function gatewayMessageReference(data: Record<string, unknown>): DiscordMessage["message_reference"] {
+	return {
+		...(readString(data, "message_id") ? { message_id: readString(data, "message_id") ?? undefined } : {}),
+		...(readString(data, "channel_id") ? { channel_id: readString(data, "channel_id") ?? undefined } : {}),
+		...(readString(data, "guild_id") ? { guild_id: readString(data, "guild_id") ?? undefined } : {}),
+	};
+}
+
+function readString(record: Record<string, unknown>, key: string): string | null {
+	const value = record[key];
+	return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function isString(value: unknown): value is string {
+	return typeof value === "string";
+}
+
+function isPresent<T>(value: T | null): value is T {
+	return value !== null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/platform/daemon/src/discord-source-provider.test.ts
+++ b/platform/daemon/src/discord-source-provider.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { addDiscordSource } from "@signet/core";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import { DISCORD_CHANNEL_TYPES } from "./discord-source-fetch";
-import { discordSourceProvider } from "./discord-source-provider";
+import { discordSourceProvider, setDiscordGatewaySocketFactoryForTest } from "./discord-source-provider";
 import { indexExternalMemoryArtifact } from "./memory-lineage";
 import { putSecret } from "./secrets";
 import { indexSourceArtifactStructure } from "./source-artifact-graph";
@@ -28,6 +28,7 @@ describe("discord-source-provider", () => {
 
 	afterEach(() => {
 		globalThis.fetch = originalFetch;
+		setDiscordGatewaySocketFactoryForTest(null);
 		closeDbAccessor();
 		if (previousSignetPath === undefined) Reflect.deleteProperty(process.env, "SIGNET_PATH");
 		else process.env.SIGNET_PATH = previousSignetPath;
@@ -96,6 +97,52 @@ describe("discord-source-provider", () => {
 		}));
 		expect(graph.docs).toBeGreaterThan(0);
 		expect(graph.attrs).toBeGreaterThan(0);
+	});
+
+	it("tails Discord gateway events into source lifecycle artifacts", async () => {
+		let shouldContinue = true;
+		let socket: FakeDiscordGatewaySocket | null = null;
+		setDiscordGatewaySocketFactoryForTest(() => {
+			socket = new FakeDiscordGatewaySocket(() => {
+				shouldContinue = false;
+			});
+			return socket;
+		});
+		const added = addDiscordSource(
+			{
+				guildIds: ["123456789012345678"],
+				tokenRef: "DISCORD_BOT_TOKEN",
+				syncMode: "gateway-tail",
+				now: "2026-01-01T00:00:00.000Z",
+			},
+			dir,
+		);
+		expect(added.ok).toBe(true);
+		if (added.ok === false) throw new Error(added.error);
+
+		const result = await discordSourceProvider.sync?.({
+			source: added.source,
+			agentsDir: dir,
+			agentId: "default",
+			shouldContinue: () => shouldContinue,
+		});
+
+		expect(result?.failures).toEqual([]);
+		expect(socket?.sent.some((entry) => entry.includes('"op":2'))).toBe(true);
+		const rows = sourceRows(added.source.id);
+		expect(rows.map((row) => row.source_kind)).toContain("source_discord_message");
+		expect(rows.map((row) => row.source_kind)).toContain("source_discord_message_event");
+		expect(rows.map((row) => row.source_kind)).toContain("source_discord_message_tombstone");
+		expect(rows.map((row) => row.source_kind)).toContain("source_discord_channel");
+		expect(rows.map((row) => row.source_kind)).toContain("source_discord_member");
+		expect(rows.map((row) => row.source_kind)).toContain("source_discord_member_event");
+		expect(rows.map((row) => row.source_kind)).toContain("source_discord_checkpoint");
+		const deleteEvent = rows.find(
+			(row) => row.source_kind === "source_discord_message_event" && row.content.includes("delete"),
+		);
+		expect(deleteEvent?.source_meta_json).toContain('"eventType":"delete"');
+		const tombstone = rows.find((row) => row.source_kind === "source_discord_message_tombstone");
+		expect(tombstone?.source_meta_json).toContain('"deleted":true');
 	});
 
 	it("records partial Discord failures without deleting existing source-owned rows", async () => {
@@ -1090,6 +1137,84 @@ describe("discord-source-provider", () => {
 		).toBe(0);
 	});
 });
+
+class FakeDiscordGatewaySocket {
+	onopen: ((event: unknown) => void) | null = null;
+	onmessage: ((event: { readonly data: unknown }) => void) | null = null;
+	onerror: ((event: unknown) => void) | null = null;
+	onclose: ((event: { readonly code?: number; readonly reason?: string }) => void) | null = null;
+	readonly sent: string[] = [];
+	private readonly stop: () => void;
+
+	constructor(stop: () => void) {
+		this.stop = stop;
+		queueMicrotask(() => {
+			this.onopen?.({});
+			this.onmessage?.({ data: JSON.stringify({ op: 10, d: { heartbeat_interval: 1_000 } }) });
+		});
+	}
+
+	send(data: string): void {
+		this.sent.push(data);
+		if (!data.includes('"op":2')) return;
+		queueMicrotask(() => {
+			this.dispatch("CHANNEL_UPDATE", 1, {
+				id: "123456789012345679",
+				guild_id: "123456789012345678",
+				type: DISCORD_CHANNEL_TYPES.guildText,
+				name: "general",
+				topic: "tail",
+			});
+			this.dispatch("GUILD_MEMBER_UPDATE", 2, {
+				guild_id: "123456789012345678",
+				user: { id: "123456789012345681", username: "alice", global_name: "Alice" },
+				roles: ["role1"],
+				joined_at: "2026-01-01T00:00:00.000Z",
+			});
+			this.dispatch("MESSAGE_CREATE", 3, gatewayMessagePayload("999999999999999991", "hello gateway"));
+			this.dispatch("MESSAGE_UPDATE", 4, {
+				...gatewayMessagePayload("999999999999999991", "hello gateway edited"),
+				edited_timestamp: "2026-01-02T00:01:00.000Z",
+			});
+			this.dispatch("MESSAGE_DELETE", 5, {
+				id: "999999999999999991",
+				guild_id: "123456789012345678",
+				channel_id: "123456789012345679",
+			});
+			this.dispatch("GUILD_MEMBER_REMOVE", 6, {
+				guild_id: "123456789012345678",
+				user: { id: "123456789012345681", username: "alice", global_name: "Alice" },
+			});
+			this.stop();
+			this.close(1000, "test complete");
+		});
+	}
+
+	close(code?: number, reason?: string): void {
+		this.onclose?.({ code, reason });
+	}
+
+	private dispatch(type: string, sequence: number, data: Record<string, unknown>): void {
+		this.onmessage?.({ data: JSON.stringify({ op: 0, t: type, s: sequence, d: data }) });
+	}
+}
+
+function gatewayMessagePayload(id: string, content: string): Record<string, unknown> {
+	return {
+		id,
+		type: 0,
+		guild_id: "123456789012345678",
+		channel_id: "123456789012345679",
+		content,
+		author: { id: "123456789012345681", username: "alice", global_name: "Alice" },
+		timestamp: "2026-01-02T00:00:00.000Z",
+		mentions: [{ id: "123456789012345682", username: "bob", global_name: "Bob" }],
+		attachments: [{ id: "123456789012345684", filename: "context.txt", size: 42 }],
+		embeds: [{ title: "Embed title", description: "Embed body" }],
+		poll: { question: { text: "Ship it?" }, answers: [{ answer_id: 1, poll_media: { text: "yes" } }] },
+		reactions: [{ count: 2, emoji: { id: null, name: "thumbsup" } }],
+	};
+}
 
 function discordResponse(url: string): Response {
 	if (url.includes("/guilds/123456789012345678?with_counts=true")) {

--- a/platform/daemon/src/discord-source-provider.ts
+++ b/platform/daemon/src/discord-source-provider.ts
@@ -8,6 +8,7 @@ import { resolveDaemonAgentId } from "./agent-id";
 import { getDbAccessor } from "./db-accessor";
 import { countChanges } from "./db-helpers";
 import { syncDiscordDesktopCacheSource } from "./discord-desktop-cache-source";
+import { setDiscordGatewaySocketFactoryForTest, syncDiscordGatewayTail } from "./discord-gateway-tail";
 import {
 	DISCORD_CHANNEL_TYPES,
 	type DiscordAttachment,
@@ -43,11 +44,15 @@ const DEFAULT_MAX_THREADS_PER_PARENT = 1_000;
 const DISCORD_MESSAGE_HISTORY_KINDS = [
 	"source_discord_message_window",
 	"source_discord_message",
+	"source_discord_message_tombstone",
+	"source_discord_message_event",
 	"source_discord_mention",
 	"source_discord_attachment",
 	"source_discord_embed",
 	"source_discord_poll",
 ] as const;
+
+export { setDiscordGatewaySocketFactoryForTest };
 
 export const discordSourceProvider: SourceProviderAdapter = {
 	kind: "discord",
@@ -79,18 +84,8 @@ async function syncDiscordSource(context: SourceProviderSyncContext): Promise<So
 	const fetchConfig: DiscordFetchConfig = { token };
 	const incrementalMessageChannelPaths = new Set<string>();
 
-	if (settings.syncMode !== "rest") {
-		const failure = failureState(
-			context.source,
-			`Discord sync mode '${settings.syncMode}' is configured but not implemented`,
-			{
-				syncMode: settings.syncMode,
-			},
-		);
-		failures.push(failure);
-		writeFailureArtifact(context.source, agentId, failure);
-		return { indexed: 1, scanned: 0, total, failures };
-	}
+	if (settings.syncMode === "gateway-tail")
+		return syncDiscordGatewayTailSource(context, agentId, token, settings.guildIds);
 
 	const sinceId = settings.since ? snowflakeIdForTimestamp(settings.since) : undefined;
 	for (const guildId of settings.guildIds) {
@@ -284,6 +279,94 @@ async function syncDiscordSource(context: SourceProviderSyncContext): Promise<So
 	}
 
 	return { indexed, scanned, total, failures };
+}
+
+async function syncDiscordGatewayTailSource(
+	context: SourceProviderSyncContext,
+	agentId: string,
+	token: string,
+	guildIds: readonly string[],
+): Promise<SourceProviderSyncResult> {
+	const failures: SourceFailureState[] = [];
+	let indexed = 0;
+	const total = guildIds.length;
+	const result = await syncDiscordGatewayTail({
+		source: context.source,
+		token,
+		guildIds,
+		shouldContinue: context.shouldContinue,
+		onProgress: context.onProgress,
+		recordFailure: (message, metadata, recoverable) => {
+			const failure = failureState(context.source, message, metadata, recoverable);
+			failures.push(failure);
+			writeFailureArtifact(context.source, agentId, failure);
+			indexed++;
+		},
+		recordMessage: (guildId, channelId, messageId, message, gatewayEventType, sequence, payload) => {
+			if (message) {
+				const guild = gatewayGuild(guildId);
+				const channel = gatewayChannel(guildId, channelId);
+				indexed += writeArtifact(context.source, agentId, messageArtifact(guild, channel, message));
+				if (message.mentions && message.mentions.length > 0)
+					indexed += writeArtifact(context.source, agentId, mentionArtifact(guild, channel, message));
+				for (const attachment of message.attachments ?? []) {
+					indexed += writeArtifact(context.source, agentId, attachmentArtifact(guild, channel, message, attachment));
+				}
+				for (let index = 0; index < (message.embeds ?? []).length; index++) {
+					const embed = message.embeds?.[index];
+					if (embed)
+						indexed += writeArtifact(context.source, agentId, embedArtifact(guild, channel, message, embed, index));
+				}
+				if (message.poll) indexed += writeArtifact(context.source, agentId, pollArtifact(guild, channel, message));
+			}
+			indexed += writeArtifact(
+				context.source,
+				agentId,
+				messageEventArtifact(context.source, guildId, channelId, messageId, gatewayEventType, sequence, payload),
+			);
+			if (message)
+				indexed += writeArtifact(
+					context.source,
+					agentId,
+					gatewayCheckpointArtifact(context.source, guildId, channelId, message.id, gatewayEventType),
+				);
+		},
+		recordMessageDelete: (guildId, channelId, messageId, sequence, payload) => {
+			indexed += writeArtifact(
+				context.source,
+				agentId,
+				messageTombstoneArtifact(guildId, channelId, messageId, sequence, payload),
+			);
+			indexed += writeArtifact(
+				context.source,
+				agentId,
+				messageEventArtifact(context.source, guildId, channelId, messageId, "MESSAGE_DELETE", sequence, payload),
+			);
+			indexed += writeArtifact(
+				context.source,
+				agentId,
+				gatewayCheckpointArtifact(context.source, guildId, channelId, messageId, "MESSAGE_DELETE"),
+			);
+		},
+		recordChannel: (guildId, channel) => {
+			indexed += writeArtifact(
+				context.source,
+				agentId,
+				channelArtifact(context.source, gatewayGuild(guildId), channel),
+			);
+		},
+		recordMember: (guildId, member) => {
+			indexed += writeArtifact(context.source, agentId, memberArtifact(gatewayGuild(guildId), member));
+		},
+		recordMemberRemove: (guildId, userId, sequence, payload) => {
+			indexed += writeArtifact(
+				context.source,
+				agentId,
+				memberEventArtifact(guildId, userId, "remove", sequence, payload),
+			);
+		},
+	});
+	return { indexed, scanned: result.indexedEvents, total, failures: result.canceled ? [] : failures };
 }
 
 function writeArtifact(source: SignetSourceEntry, agentId: string, artifact: DiscordArtifact): number {
@@ -821,6 +904,142 @@ function pollArtifact(guild: DiscordGuild, channel: DiscordChannel, msg: Discord
 	};
 }
 
+function messageEventArtifact(
+	source: SignetSourceEntry,
+	guildId: string,
+	channelId: string,
+	messageId: string,
+	gatewayEventType: string,
+	sequence: number | null,
+	payload: unknown,
+): DiscordArtifact {
+	const eventType = gatewayEventType.replace(/^MESSAGE_/, "").toLowerCase();
+	const eventKey = sequence === null ? hashKey(JSON.stringify(payload)) : String(sequence);
+	return {
+		kind: "source_discord_message_event",
+		externalId: `message_event:${gatewayEventType}:${messageId}:${eventKey}`,
+		path: `discord://guild/${guildId}/channel/${channelId}/message/${messageId}/event/${eventKey}`,
+		parentPath: `discord://guild/${guildId}/channel/${channelId}/messages/${messageId}`,
+		mtimeMs: Date.now(),
+		content: [
+			"# Discord Message Event",
+			"",
+			`Source: ${source.name}`,
+			`Guild: ${guildId}`,
+			`Channel: ${channelId}`,
+			`Message: ${messageId}`,
+			`Event: ${eventType}`,
+		].join("\n"),
+		meta: {
+			provider: DISCORD_PROVIDER_KIND,
+			recordType: "message_event",
+			guildId,
+			channelId,
+			messageId,
+			eventType,
+			gatewayEventType,
+			sequence,
+			payload: compactGatewayPayload(payload),
+		},
+	};
+}
+
+function messageTombstoneArtifact(
+	guildId: string,
+	channelId: string,
+	messageId: string,
+	sequence: number | null,
+	payload: unknown,
+): DiscordArtifact {
+	return {
+		kind: "source_discord_message_tombstone",
+		externalId: `message_tombstone:${messageId}`,
+		path: `discord://guild/${guildId}/channel/${channelId}/messages/${messageId}/deleted`,
+		parentPath: `discord://guild/${guildId}/channel/${channelId}/messages/${messageId}`,
+		mtimeMs: Date.now(),
+		content: [
+			"# Discord Deleted Message",
+			"",
+			`Guild: ${guildId}`,
+			`Channel: ${channelId}`,
+			`Message: ${messageId}`,
+			"Deleted: true",
+		].join("\n"),
+		meta: {
+			provider: DISCORD_PROVIDER_KIND,
+			recordType: "message_tombstone",
+			guildId,
+			channelId,
+			messageId,
+			deleted: true,
+			sequence,
+			payload: compactGatewayPayload(payload),
+		},
+	};
+}
+
+function memberEventArtifact(
+	guildId: string,
+	userId: string,
+	eventType: "remove",
+	sequence: number | null,
+	payload: unknown,
+): DiscordArtifact {
+	return {
+		kind: "source_discord_member_event",
+		externalId: `member_event:${guildId}:${userId}:${eventType}:${sequence ?? hashKey(JSON.stringify(payload))}`,
+		path: `discord://guild/${guildId}/member/${userId}/event/${sequence ?? "unknown"}`,
+		parentPath: `discord://guild/${guildId}/member/${userId}`,
+		mtimeMs: Date.now(),
+		content: ["# Discord Member Event", "", `Guild: ${guildId}`, `User: ${userId}`, `Event: ${eventType}`].join("\n"),
+		meta: {
+			provider: DISCORD_PROVIDER_KIND,
+			recordType: "member_event",
+			guildId,
+			userId,
+			eventType,
+			sequence,
+			payload: compactGatewayPayload(payload),
+		},
+	};
+}
+
+function gatewayCheckpointArtifact(
+	source: SignetSourceEntry,
+	guildId: string,
+	channelId: string,
+	messageId: string,
+	gatewayEventType: string,
+): DiscordArtifact {
+	return {
+		kind: "source_discord_checkpoint",
+		externalId: `checkpoint:gateway:${guildId}:${channelId}`,
+		path: `discord://source/${source.id}/checkpoint/gateway/${guildId}/${channelId}`,
+		parentPath: `discord://guild/${guildId}/channel/${channelId}`,
+		mtimeMs: Date.now(),
+		content: [
+			"# Discord Gateway Checkpoint",
+			"",
+			`Guild: ${guildId}`,
+			`Channel: ${channelId}`,
+			`Latest event: ${gatewayEventType}`,
+			`Latest cursor: ${messageId}`,
+		].join("\n"),
+		meta: {
+			provider: DISCORD_PROVIDER_KIND,
+			recordType: "checkpoint",
+			syncMode: "gateway-tail",
+			guildId,
+			channelId,
+			status: "tailing",
+			latestCursor: messageId,
+			backfillCursor: null,
+			backfillComplete: false,
+			gatewayEventType,
+		},
+	};
+}
+
 function checkpointArtifact(
 	source: SignetSourceEntry,
 	guild: DiscordGuild,
@@ -895,6 +1114,33 @@ function parseDiscordSnowflake(value: string): bigint | null {
 	} catch {
 		return null;
 	}
+}
+
+function gatewayGuild(guildId: string): DiscordGuild {
+	return { id: guildId, name: guildId };
+}
+
+function gatewayChannel(guildId: string, channelId: string): DiscordChannel {
+	return { id: channelId, guild_id: guildId, type: DISCORD_CHANNEL_TYPES.guildText, name: channelId };
+}
+
+function compactGatewayPayload(payload: unknown): unknown {
+	if (!isRecord(payload)) return payload;
+	const compact: Record<string, unknown> = {};
+	for (const key of [
+		"id",
+		"guild_id",
+		"channel_id",
+		"type",
+		"timestamp",
+		"edited_timestamp",
+		"author",
+		"user",
+		"message_reference",
+	]) {
+		if (key in payload) compact[key] = payload[key];
+	}
+	return compact;
 }
 
 function failureState(

--- a/surfaces/dashboard/src/lib/components/tabs/SourcesTab.svelte
+++ b/surfaces/dashboard/src/lib/components/tabs/SourcesTab.svelte
@@ -119,7 +119,7 @@ let excludeGlobsText = $state("**/.obsidian/**\n**/.trash/**\n**/.hermes/**\n**/
 // biome-ignore lint/style/useConst: Svelte bind:value mutates this rune from markup.
 let discordName = $state("Discord");
 // biome-ignore lint/style/useConst: Svelte bind:value mutates this rune from markup.
-let discordSyncMode = $state<"rest" | "desktop-cache">("rest");
+let discordSyncMode = $state<"rest" | "gateway-tail" | "desktop-cache">("rest");
 let discordGuildIdsText = $state("");
 let discordTokenRef = $state("");
 let discordDesktopCachePath = $state("");
@@ -1343,6 +1343,7 @@ function sourceIndexCurrentPath(source: SignetSourceEntry): string {
 												<span>Mode</span>
 												<select bind:value={discordSyncMode}>
 													<option value="rest">Bot REST</option>
+													<option value="gateway-tail">Gateway tail</option>
 													<option value="desktop-cache">Desktop cache</option>
 												</select>
 											</label>


### PR DESCRIPTION
## Summary

- enables the existing `gateway-tail` Discord source mode with a live Discord Gateway v10 loop
- indexes gateway-observed message create/update/delete events, deleted-message tombstones, channel/thread upserts, member upserts/removals, and per-channel tail checkpoints through the shared source artifact path
- exposes Gateway tail in the dashboard Discord source mode selector and updates Sources/API docs

## Discrawl parity notes

This mirrors Discrawl's tail worker event coverage for message create/update/delete, channel upsert, member upsert, and member delete while preserving Signet's shared Sources substrate. The gateway transport handles hello/identify/heartbeat, Discord reconnect/invalid-session requests, fatal gateway close codes, cancellation/removal, and test-injected sockets.

## Validation

- `bunx biome check --write platform/daemon/src/discord-gateway-tail.ts platform/daemon/src/discord-source-provider.ts platform/daemon/src/discord-source-provider.test.ts surfaces/dashboard/src/lib/components/tabs/SourcesTab.svelte`
- `bun test platform/daemon/src/discord-source-provider.test.ts`
- `bun test platform/core/src/sources-config.test.ts`
- `bun test surfaces/cli/src/features/sources.test.ts surfaces/cli/src/commands/sources.test.ts`
- `bun test platform/daemon/src/routes/sources-routes.test.ts`
- `bun run --filter '@signet/core' build`
- `bun run --filter '@signet/daemon' build`
- `git diff --check`

`@signet/daemon` build still emits the existing unrelated Svelte accessibility/deprecation warnings in SecretsTab, TroubleshooterPanel, SidebarGroups, WidgetGrid, and WidgetCard.
