### PR TITLE
feat(recall): add exact date temporal recall

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -566,7 +566,7 @@ Database Schema
 SQLite with WAL mode. Migrations are numbered sequentially under
 `platform/core/src/migrations/`. Each migration is idempotent — safe
 to re-run against an existing database. Schema version is tracked in
-`schema_migrations`. The latest migration is `066-memory-search-telemetry.ts`.
+`schema_migrations`. The latest migration is `076-temporal-edges.ts`.
 
 **schema_migrations**
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -558,6 +558,7 @@ an embedding provider is configured.
 signet remember "User prefers dark mode"
 signet remember "critical: never push to main" --critical
 signet remember "deploy runs on Friday" --tags devops,deploy --who user
+signet remember "deploy incident started before it was written down" --occurred-at 2026-05-13T18:00:00Z
 ```
 
 Options:
@@ -568,6 +569,11 @@ Options:
 | `-t, --tags <tags>` | Comma-separated tags |
 | `-i, --importance <n>` | Importance score, 0-1 (default: 0.7) |
 | `--critical` | Mark as critical/pinned |
+| `--occurred-at <iso>` | Event time this memory is about |
+| `--observed-at <iso>` | Observation time this memory records |
+| `--source-created-at <iso>` | Source-system creation time for this memory |
+| `--valid-from <iso>` | Start of validity window for this memory |
+| `--valid-until <iso>` | End of validity window for this memory |
 
 Output:
 
@@ -589,6 +595,8 @@ signet recall "release notes" --project /home/user/myapp
 signet recall "deploy process" --limit 5 --type decision
 signet recall "auth" --tags backend --who claude-code --since 2026-01-01
 signet recall "deploy checklist" --keyword-query "deploy OR rollback" --min-score 0.8
+signet recall "2026/05/13"
+signet recall "temporal recall" --time-start 2026-05-13T00:00:00Z --time-end 2026-05-14T00:00:00Z
 signet recall "project history" --aggregate --aggregate-budget small
 signet recall "secrets" --json
 ```
@@ -609,6 +617,14 @@ Common refinements:
 | `--who <who>` | Filter by author |
 | `--since <date>` | Only include memories created after this date |
 | `--until <date>` | Only include memories created before this date |
+| `--time-start <iso>` | Temporal recall lower bound |
+| `--time-end <iso>` | Temporal recall upper bound |
+| `--time-facets <facets>` | Temporal facets to search: `session`, `source`, `captured`, `observed`, `occurred`, `valid` |
+| `--time-mode <mode>` | Temporal mode: `auto`, `timeline`, or `filter` |
+
+Exact date queries such as `2026/05/13`, `2026-05-13`, and `May 13 2026`
+activate temporal recall automatically. Date-only queries return a timeline;
+date plus topic filters recall to matching temporal rows.
 
 Advanced controls:
 

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -73,6 +73,7 @@ const result = await signet.remember("Prefers TypeScript over JavaScript", {
   importance: 0.9,
   tags: "language,tooling",
   pinned: false,
+  occurredAt: "2026-05-13T18:00:00Z",
   mode: "sync",         // "auto" | "sync" | "async"
   idempotencyKey: "pref-ts-001",
 });
@@ -93,9 +94,11 @@ A good default posture is:
 const { results, query, method, meta } = await signet.recall("language preferences", {
   project: "/home/user/myapp",
   limit: 10,
+  time: { start: "2026-05-13T00:00:00Z", end: "2026-05-14T00:00:00Z" },
   expand: true,
 });
 // meta.timings?.stages — daemon-side recall stages and durations
+// meta.temporal — resolved temporal window when date recall is active
 ```
 
 You can refine further when needed:

--- a/docs/api/memory.md
+++ b/docs/api/memory.md
@@ -82,6 +82,11 @@ Body-level fields override prefix-parsed values.
   "runtimePath": "memory/MEMORY.md",
   "idempotencyKey": "stable-import-key",
   "createdAt": "2026-02-21T10:00:00.000Z",
+  "occurredAt": "2026-02-20T15:00:00.000Z",
+  "observedAt": "2026-02-21T09:55:00.000Z",
+  "sourceCreatedAt": "2026-02-20T15:05:00.000Z",
+  "validFrom": "2026-02-20T00:00:00.000Z",
+  "validUntil": "2026-03-01T00:00:00.000Z",
   "agentId": "alice",
   "visibility": "global"
 }
@@ -98,6 +103,12 @@ Only `content` is required. Multi-agent fields:
 memory is sourced from an older conversation or imported artifact so structured
 currentness and supersession can compare facts by source time instead of ingest
 time.
+
+`occurredAt`, `observedAt`, `sourceCreatedAt`, and `validFrom`/`validUntil`
+attach explicit temporal edges to the memory without duplicating the memory
+content. Use them when the memory is saved later than the event, observation,
+source creation time, or validity window it describes. Each value must be a
+valid ISO timestamp; `validUntil` must be after `validFrom` when both are set.
 
 Row-level provenance fields are optional: `sourcePath`/`source_path` stores the
 original source path, `runtimePath`/`runtime_path` stores the runtime-relative
@@ -147,6 +158,34 @@ record — no duplicate is created.
 
 Alias for `POST /api/memory/remember`. Accepts the same request body and
 returns the same response. Requires `remember` permission.
+
+### POST /api/memory/codex-native-note
+
+Write an explicit Codex native memory note under the local Codex memory
+extension path. Requires `remember` permission and respects the
+`mutationsFrozen` kill switch.
+
+**Request body**
+
+```json
+{
+  "content": "Small scoped note to preserve",
+  "title": "Optional title",
+  "tags": "codex,note"
+}
+```
+
+`content` is required and capped at 8000 characters. `title` and `tags` are
+optional strings.
+
+**Response**
+
+```json
+{
+  "ok": true,
+  "path": "/home/user/.codex/memories/extensions/ad_hoc/notes/..."
+}
+```
 
 ### POST /api/hook/remember
 
@@ -532,6 +571,12 @@ permission. For the full execution model, see [Hybrid Recall](../MEMORY.md#hybri
   "pinned": false,
   "importance_min": 0.5,
   "since": "2026-01-01T00:00:00Z",
+  "time": {
+    "start": "2026-05-13T00:00:00.000Z",
+    "end": "2026-05-14T00:00:00.000Z",
+    "facets": ["session", "occurred", "source", "captured"],
+    "mode": "auto"
+  },
   "aggregate": false,
   "aggregateBudget": "small",
   "saveAggregate": true,
@@ -542,6 +587,15 @@ permission. For the full execution model, see [Hybrid Recall](../MEMORY.md#hybri
 ```
 
 Only `query` is required.
+
+Exact date phrases in `query`, such as `2026/05/13`, `2026-05-13`, or
+`May 13 2026`, activate temporal recall automatically. A date-only query
+returns a timeline assembled from existing session, source, captured-memory,
+and explicit temporal-edge metadata. A date plus topic uses the date as a
+filter and the remaining words as the content query. Callers can also pass a
+`time` object directly. Supported temporal facets are `session`, `source`,
+`captured`, `observed`, `occurred`, and `valid`; `mode` may be `auto`,
+`timeline`, or `filter`.
 
 When `sessionKey` is present, recall uses a daemon-owned context ledger keyed by
 `(sessionKey, agentId, contextEpoch)`. Rows returned once in the current epoch
@@ -567,6 +621,11 @@ to return repeats; repeated rows are annotated with
       "who": "claude-code",
       "project": null,
       "created_at": "2026-02-21T10:00:00.000Z",
+      "temporal_facet": "occurred",
+      "temporal_start_at": "2026-02-20T15:00:00.000Z",
+      "temporal_end_at": "2026-02-20T15:00:00.000Z",
+      "subject_type": "memory",
+      "subject_id": "uuid",
       "supplementary": false,
       "already_recalled": false
     }
@@ -590,6 +649,15 @@ to return repeats; repeated rows are annotated with
       "contextEpoch": 0,
       "suppressed": 0,
       "repeatedReturned": 0
+    },
+    "temporal": {
+      "mode": "filter",
+      "source": "query",
+      "originalQuery": "2026/05/13 editor",
+      "contentQuery": "editor",
+      "start": "2026-05-13T06:00:00.000Z",
+      "end": "2026-05-14T06:00:00.000Z",
+      "facets": ["session", "source", "occurred", "observed", "valid", "captured"]
     }
   }
 }
@@ -609,6 +677,8 @@ normally but found no matching results.
 milliseconds. Aggregate recall fills the same field with aggregate-specific
 stages such as `aggregate_planning`, `aggregate_followup_recalls`, and
 `aggregate_synthesis`.
+`meta.temporal`, when present, describes the resolved temporal window, facets,
+and content query used by automatic date parsing or an explicit `time` request.
 When session dedupe is enabled, `meta.dedupe.suppressed` counts rows omitted
 because they were already recalled in the current epoch, and
 `meta.dedupe.repeatedReturned` counts repeated rows returned only because the
@@ -715,6 +785,7 @@ to the recall endpoint. Requires `recall` permission.
 | `pinned`       | `1` or `true` to filter       |
 | `importance_min` | Minimum importance float    |
 | `since`        | ISO timestamp lower bound     |
+| `until`        | ISO timestamp upper bound     |
 | `sessionKey` / `session_key` | Session key for context dedupe |
 | `includeRecalled` / `include_recalled` | `1` or `true` to return repeats |
 

--- a/libs/sdk/src/client-p2.ts
+++ b/libs/sdk/src/client-p2.ts
@@ -175,6 +175,12 @@ export class SignetClientP2 {
 		readonly who?: string;
 		readonly since?: string;
 		readonly until?: string;
+		readonly time?: {
+			readonly start?: string;
+			readonly end?: string;
+			readonly facets?: readonly string[];
+			readonly mode?: "auto" | "timeline" | "filter";
+		};
 		readonly expand?: boolean;
 		readonly sessionKey?: string;
 		readonly agentId?: string;
@@ -197,6 +203,12 @@ export class SignetClientP2 {
 		readonly who?: string;
 		readonly since?: string;
 		readonly until?: string;
+		readonly time?: {
+			readonly start?: string;
+			readonly end?: string;
+			readonly facets?: readonly string[];
+			readonly mode?: "auto" | "timeline" | "filter";
+		};
 		readonly expand?: boolean;
 		readonly sessionKey?: string;
 		readonly agentId?: string;

--- a/libs/sdk/src/helpers.ts
+++ b/libs/sdk/src/helpers.ts
@@ -156,6 +156,12 @@ export class SignetClientHelpers {
 			readonly importance_min?: number;
 			readonly since?: string;
 			readonly until?: string;
+			readonly time?: {
+				readonly start?: string;
+				readonly end?: string;
+				readonly facets?: readonly string[];
+				readonly mode?: "auto" | "timeline" | "filter";
+			};
 			readonly expand?: boolean;
 			readonly minScore?: number;
 			readonly agentId?: string;

--- a/libs/sdk/src/index.ts
+++ b/libs/sdk/src/index.ts
@@ -129,6 +129,11 @@ export class SignetClient extends SignetClientHelpers {
 			readonly sourceType?: string;
 			readonly sourceId?: string;
 			readonly sourcePath?: string;
+			readonly occurredAt?: string;
+			readonly observedAt?: string;
+			readonly sourceCreatedAt?: string;
+			readonly validFrom?: string;
+			readonly validUntil?: string;
 			readonly mode?: "auto" | "sync" | "async";
 			readonly idempotencyKey?: string;
 			readonly runtimePath?: string;
@@ -153,6 +158,12 @@ export class SignetClient extends SignetClientHelpers {
 			readonly importance_min?: number;
 			readonly since?: string;
 			readonly until?: string;
+			readonly time?: {
+				readonly start?: string;
+				readonly end?: string;
+				readonly facets?: readonly string[];
+				readonly mode?: "auto" | "timeline" | "filter";
+			};
 			readonly minScore?: number;
 			readonly expand?: boolean;
 			readonly agentId?: string;

--- a/platform/core/src/migrations/076-temporal-edges.ts
+++ b/platform/core/src/migrations/076-temporal-edges.ts
@@ -1,0 +1,25 @@
+import type { MigrationDb } from "./index";
+
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS temporal_edges (
+			id TEXT PRIMARY KEY,
+			agent_id TEXT NOT NULL DEFAULT 'default',
+			subject_type TEXT NOT NULL,
+			subject_id TEXT NOT NULL,
+			facet TEXT NOT NULL CHECK(facet IN ('captured', 'session', 'source', 'observed', 'occurred', 'valid')),
+			start_at TEXT NOT NULL,
+			end_at TEXT,
+			confidence REAL NOT NULL DEFAULT 1.0,
+			provenance_json TEXT,
+			metadata_json TEXT,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_temporal_edges_agent_facet_range
+			ON temporal_edges(agent_id, facet, start_at, end_at);
+		CREATE INDEX IF NOT EXISTS idx_temporal_edges_agent_subject
+			ON temporal_edges(agent_id, subject_type, subject_id);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -81,6 +81,7 @@ import { up as agentScopedIdempotencyKey } from "./072-agent-scoped-idempotency-
 import { up as recallContextDedupe } from "./073-recall-context-dedupe";
 import { up as aggregateMemoryLinks } from "./074-aggregate-memory-links";
 import { up as memoryArtifactSourceProvenance } from "./075-memory-artifact-source-provenance";
+import { up as temporalEdges } from "./076-temporal-edges";
 
 // -- Public interface consumed by Database.init() --
 
@@ -715,6 +716,14 @@ export const MIGRATIONS: readonly Migration[] = [
 				{ table: "memory_artifacts", column: "source_parent_path" },
 				{ table: "memory_artifacts", column: "source_meta_json" },
 			],
+		},
+	},
+	{
+		version: 76,
+		name: "temporal-edges",
+		up: temporalEdges,
+		artifacts: {
+			tables: ["temporal_edges"],
 		},
 	},
 ];

--- a/platform/core/src/recall.test.ts
+++ b/platform/core/src/recall.test.ts
@@ -63,6 +63,27 @@ describe("recall surface helpers", () => {
 		});
 	});
 
+	it("forwards temporal recall request options", () => {
+		expect(
+			buildRecallRequestBody("2026/05/13", {
+				time: {
+					start: "2026-05-13T00:00:00.000Z",
+					end: "2026-05-14T00:00:00.000Z",
+					facets: ["session", "occurred"],
+					mode: "timeline",
+				},
+			}),
+		).toEqual({
+			query: "2026/05/13",
+			time: {
+				start: "2026-05-13T00:00:00.000Z",
+				end: "2026-05-14T00:00:00.000Z",
+				facets: ["session", "occurred"],
+				mode: "timeline",
+			},
+		});
+	});
+
 	it("preserves dedupe metadata when client-side score filtering rewrites counts", () => {
 		const result = applyRecallScoreThreshold(
 			{
@@ -125,6 +146,8 @@ describe("recall surface helpers", () => {
 		const body = buildRememberRequestBody("Remember this", {
 			tags: ["graph", "parity"],
 			sourcePath: "/tmp/source.md",
+			occurredAt: "2026-05-13T18:00:00.000Z",
+			sourceCreatedAt: "2026-05-13T17:00:00.000Z",
 			runtimePath: "memory/source.md",
 			idempotencyKey: "stable-import-key",
 			structured: {
@@ -143,6 +166,8 @@ describe("recall surface helpers", () => {
 
 		expect(body.tags).toBe("graph,parity");
 		expect(body.sourcePath).toBe("/tmp/source.md");
+		expect(body.occurredAt).toBe("2026-05-13T18:00:00.000Z");
+		expect(body.sourceCreatedAt).toBe("2026-05-13T17:00:00.000Z");
 		expect(body.runtimePath).toBe("memory/source.md");
 		expect(body.idempotencyKey).toBe("stable-import-key");
 		expect(body.structured).toEqual({

--- a/platform/core/src/recall.ts
+++ b/platform/core/src/recall.ts
@@ -13,6 +13,8 @@ export interface RecallRow extends RecallPartitionableRow {
 	readonly created_at?: string;
 	readonly score?: number;
 	readonly source?: string;
+	readonly source_id?: string;
+	readonly source_path?: string;
 	readonly who?: string;
 	readonly type?: string;
 	readonly tags?: string | null;
@@ -20,12 +22,18 @@ export interface RecallRow extends RecallPartitionableRow {
 	readonly project?: string | null;
 	readonly importance?: number;
 	readonly already_recalled?: boolean;
+	readonly temporal_facet?: TemporalFacet;
+	readonly temporal_start_at?: string;
+	readonly temporal_end_at?: string | null;
+	readonly subject_type?: string;
+	readonly subject_id?: string;
 }
 
 export interface RecallMeta {
 	readonly totalReturned: number;
 	readonly hasSupplementary: boolean;
 	readonly noHits: boolean;
+	readonly temporal?: RecallTemporalMeta;
 	readonly dedupe?: {
 		readonly enabled: boolean;
 		readonly contextEpoch?: number;
@@ -35,6 +43,25 @@ export interface RecallMeta {
 }
 
 export type AggregateRecallBudget = "small" | "medium" | "large";
+
+export type TemporalFacet = "captured" | "session" | "source" | "observed" | "occurred" | "valid";
+
+export interface RecallTimeOptions {
+	readonly start?: string;
+	readonly end?: string;
+	readonly facets?: readonly TemporalFacet[];
+	readonly mode?: "auto" | "timeline" | "filter";
+}
+
+export interface RecallTemporalMeta {
+	readonly mode: "timeline" | "filter";
+	readonly source: "query" | "request";
+	readonly originalQuery: string;
+	readonly contentQuery: string;
+	readonly start: string;
+	readonly end: string;
+	readonly facets: readonly TemporalFacet[];
+}
 
 export interface AggregateRecallMeta {
 	readonly savedMemoryId: string | null;
@@ -98,6 +125,7 @@ export interface RecallRequestOptions {
 	readonly importance_min?: number;
 	readonly since?: string;
 	readonly until?: string;
+	readonly time?: RecallTimeOptions;
 	readonly expand?: boolean;
 	readonly agentId?: string;
 	readonly sessionKey?: string;
@@ -121,6 +149,11 @@ export interface RememberRequestOptions {
 	readonly sourceId?: string;
 	readonly sourcePath?: string;
 	readonly createdAt?: string;
+	readonly occurredAt?: string;
+	readonly observedAt?: string;
+	readonly validFrom?: string;
+	readonly validUntil?: string;
+	readonly sourceCreatedAt?: string;
 	readonly hints?: readonly string[];
 	readonly transcript?: string;
 	readonly structured?: unknown;
@@ -194,7 +227,8 @@ export function parseRecallMeta(raw: unknown, fallbackCount: number): RecallMeta
 				repeatedReturned: typeof raw.dedupe.repeatedReturned === "number" ? raw.dedupe.repeatedReturned : 0,
 			}
 		: undefined;
-	return { totalReturned, hasSupplementary, noHits, ...(dedupe ? { dedupe } : {}) };
+	const temporal = isRecord(raw.temporal) ? (raw.temporal as unknown as RecallTemporalMeta) : undefined;
+	return { totalReturned, hasSupplementary, noHits, ...(dedupe ? { dedupe } : {}), ...(temporal ? { temporal } : {}) };
 }
 
 export function parseRecallPayload(raw: unknown): {
@@ -246,6 +280,7 @@ export function applyRecallScoreThreshold(raw: unknown, minScore?: number): unkn
 			hasSupplementary: filtered.some((row) => row.supplementary === true),
 			noHits: filtered.length === 0,
 			...(isRecord(payload.meta) && isRecord(payload.meta.dedupe) ? { dedupe: payload.meta.dedupe } : {}),
+			...(isRecord(payload.meta) && isRecord(payload.meta.temporal) ? { temporal: payload.meta.temporal } : {}),
 		},
 	};
 }
@@ -265,6 +300,41 @@ function formatRecallRow(row: RecallRow, options?: { readonly includeIndex?: num
 	return `${prefix}${score}${id}${row.content ?? ""} (${type}, ${source}, ${createdAt}${who})`;
 }
 
+function temporalGroupLabel(row: RecallRow): string {
+	if (row.temporal_facet === "session") return "Sessions";
+	if (row.temporal_facet === "source") return "Source Activity";
+	if (row.temporal_facet === "occurred" || row.temporal_facet === "observed" || row.temporal_facet === "valid") {
+		return "Events";
+	}
+	return "Memories Captured";
+}
+
+function formatTemporalDate(value: string): string {
+	const parsed = new Date(value);
+	if (Number.isNaN(parsed.getTime())) return value.slice(0, 10);
+	return parsed.toLocaleDateString("en-US", {
+		month: "long",
+		day: "numeric",
+		year: "numeric",
+		timeZone: "UTC",
+	});
+}
+
+function formatTemporalRecallText(rows: readonly RecallRow[], meta: RecallTemporalMeta): string {
+	const parts = [formatTemporalDate(meta.start)];
+	const groups = new Map<string, RecallRow[]>();
+	for (const row of rows) {
+		const label = temporalGroupLabel(row);
+		groups.set(label, [...(groups.get(label) ?? []), row]);
+	}
+	for (const label of ["Sessions", "Source Activity", "Events", "Memories Captured"]) {
+		const group = groups.get(label);
+		if (!group || group.length === 0) continue;
+		parts.push("", label, ...group.map((row) => formatRecallRow(row)));
+	}
+	return parts.join("\n");
+}
+
 export function formatRecallText(raw: unknown): string {
 	if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
 		return typeof raw === "string" ? raw : JSON.stringify(raw, null, 2);
@@ -276,6 +346,7 @@ export function formatRecallText(raw: unknown): string {
 	if (parsed.meta.noHits || parsed.rows.length === 0) return "No matching memories found.";
 
 	const { primary, supporting } = partitionRecallRows(parsed.rows);
+	if (parsed.meta.temporal?.mode === "timeline") return formatTemporalRecallText(primary, parsed.meta.temporal);
 	const noun = parsed.meta.totalReturned === 1 ? "memory" : "memories";
 	const parts = [`Found ${parsed.meta.totalReturned} ${noun}${parsed.method ? ` (${parsed.method})` : ""}.`];
 
@@ -303,6 +374,7 @@ export function buildRecallRequestBody(query: string, options: RecallRequestOpti
 		importance_min: options.importance_min,
 		since: options.since,
 		until: options.until,
+		time: options.time,
 		expand: options.expand === true ? true : undefined,
 		agentId: options.agentId,
 		sessionKey: options.sessionKey,
@@ -365,6 +437,11 @@ export function buildRememberRequestBody(
 		sourceId: options.sourceId,
 		sourcePath: options.sourcePath,
 		createdAt: options.createdAt,
+		occurredAt: options.occurredAt,
+		observedAt: options.observedAt,
+		validFrom: options.validFrom,
+		validUntil: options.validUntil,
+		sourceCreatedAt: options.sourceCreatedAt,
 		hints: options.hints,
 		transcript: options.transcript,
 		structured: normalizeStructuredMemoryPayload(options.structured),

--- a/platform/daemon/src/daemon-auth-guard-colocation.test.ts
+++ b/platform/daemon/src/daemon-auth-guard-colocation.test.ts
@@ -248,6 +248,54 @@ describe("auth guard co-location", () => {
 			const body = (await res.json()) as { error?: string };
 			expect(body.error).toContain("aggregateBudget");
 		});
+
+		it("POST /api/memory/recall rejects invalid temporal ranges before recall", async () => {
+			const app = await makeApp();
+			const state = await import("./routes/state.js");
+			const { createAuthMiddleware, createToken } = await import("./auth");
+			const { registerMemoryRoutes } = await import("./routes/memory-routes");
+			const secret = state.authSecret;
+			if (!secret) throw new Error("expected auth secret for team-mode recall test");
+
+			const hybridRecallMock = mock(async (_params: RecallParams): Promise<RecallResponse> => {
+				throw new Error("hybridRecall should not run for invalid time ranges");
+			});
+
+			app.use("*", createAuthMiddleware(state.authConfig, secret));
+			registerMemoryRoutes(app, {
+				hybridRecall: hybridRecallMock,
+				fetchEmbedding: async () => null,
+			});
+			const token = createToken(secret, { sub: "readonly-recall", role: "readonly", scope: {} }, 60);
+
+			for (const [time, expectedError] of [
+				[{ start: "not-a-date" }, "time.start"],
+				[
+					{
+						start: "2026-05-14T00:00:00.000Z",
+						end: "2026-05-13T00:00:00.000Z",
+					},
+					"time.end must be after time.start",
+				],
+			] as const) {
+				const res = await app.request("/api/memory/recall", {
+					method: "POST",
+					headers: {
+						authorization: `Bearer ${token}`,
+						"content-type": "application/json",
+					},
+					body: JSON.stringify({
+						query: "temporal recall",
+						time,
+					}),
+				});
+
+				expect(res.status).toBe(400);
+				const body = (await res.json()) as { error?: string };
+				expect(body.error).toContain(expectedError);
+			}
+			expect(hybridRecallMock).toHaveBeenCalledTimes(0);
+		});
 	});
 
 	describe("session routes need guards", () => {

--- a/platform/daemon/src/daemon-auth-guard-colocation.test.ts
+++ b/platform/daemon/src/daemon-auth-guard-colocation.test.ts
@@ -114,6 +114,35 @@ describe("auth guard co-location", () => {
 			expect(await status(app, "POST", "/api/memory/remember")).toBe(403);
 		});
 
+		it("POST /api/memory/remember rejects zero-length validity windows", async () => {
+			const app = await makeApp();
+			const state = await import("./routes/state.js");
+			const { createAuthMiddleware, createToken } = await import("./auth");
+			const { registerMemoryRoutes } = await import("./routes/memory-routes");
+			const secret = state.authSecret;
+			if (!secret) throw new Error("expected auth secret for team-mode remember test");
+
+			app.use("*", createAuthMiddleware(state.authConfig, secret));
+			registerMemoryRoutes(app);
+			const token = createToken(secret, { sub: "remember-operator", role: "operator", scope: {} }, 60);
+			const res = await app.request("/api/memory/remember", {
+				method: "POST",
+				headers: {
+					authorization: `Bearer ${token}`,
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({
+					content: "Validity windows must have positive duration.",
+					validFrom: "2026-05-13T00:00:00.000Z",
+					validUntil: "2026-05-13T00:00:00.000Z",
+				}),
+			});
+
+			expect(res.status).toBe(400);
+			const body = (await res.json()) as { error?: string };
+			expect(body.error).toContain("validUntil must be after validFrom");
+		});
+
 		it("POST /api/memory/recall aggregate save requires remember permission", async () => {
 			const app = await makeApp();
 			const state = await import("./routes/state.js");

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -544,6 +544,12 @@ export interface RecallRequest {
 	who?: string;
 	since?: string;
 	until?: string;
+	time?: {
+		start?: string;
+		end?: string;
+		facets?: readonly string[];
+		mode?: "auto" | "timeline" | "filter";
+	};
 	expand?: boolean;
 	sessionKey?: string;
 	agentId?: string;
@@ -720,7 +726,8 @@ function buildNoStrongMemoryMatchGuidance(harness: string): string {
 }
 
 function buildDurableSaveGuidance(harness: string): string {
-	if (harness === "codex") return "If you learn something explicitly durable for Codex memory, save it with signet_save_note.";
+	if (harness === "codex")
+		return "If you learn something explicitly durable for Codex memory, save it with signet_save_note.";
 	if (isPiHarness(harness)) return "If you learn something durable, save it with /remember or signet_remember.";
 	return "If you learn something durable, save it with /remember or memory_store.";
 }

--- a/platform/daemon/src/mcp/tools.test.ts
+++ b/platform/daemon/src/mcp/tools.test.ts
@@ -528,6 +528,12 @@ describe("createMcpServer", () => {
 				importance_min: 0.7,
 				since: "2026-01-01",
 				until: "2026-04-01",
+				time: {
+					start: "2026-05-13T00:00:00.000Z",
+					end: "2026-05-14T00:00:00.000Z",
+					facets: ["session", "occurred"],
+					mode: "timeline",
+				},
 				score_min: 0.8,
 				aggregate: true,
 				aggregate_budget: "medium",
@@ -547,6 +553,12 @@ describe("createMcpServer", () => {
 			expect(body.importance_min).toBe(0.7);
 			expect(body.since).toBe("2026-01-01");
 			expect(body.until).toBe("2026-04-01");
+			expect(body.time).toEqual({
+				start: "2026-05-13T00:00:00.000Z",
+				end: "2026-05-14T00:00:00.000Z",
+				facets: ["session", "occurred"],
+				mode: "timeline",
+			});
 			expect(body.expand).toBeUndefined();
 			expect(body.aggregate).toBe(true);
 			expect(body.aggregateBudget).toBe("medium");
@@ -851,6 +863,22 @@ describe("createMcpServer", () => {
 
 			const body = JSON.parse(cap.body ?? "{}");
 			expect(body.pinned).toBe(true);
+		});
+
+		it("passes explicit temporal fields through to remember", async () => {
+			const cap: { body?: string } = {};
+			mockFetch(200, { id: "temporal-1", deduped: false }, cap);
+
+			await callTool(server, "memory_store", {
+				content: "We worked on exact date recall",
+				hints: ["What did we work on during exact date recall?"],
+				occurredAt: "2026-05-13T18:00:00.000Z",
+				sourceCreatedAt: "2026-05-13T17:00:00.000Z",
+			});
+
+			const body = JSON.parse(cap.body ?? "{}");
+			expect(body.occurredAt).toBe("2026-05-13T18:00:00.000Z");
+			expect(body.sourceCreatedAt).toBe("2026-05-13T17:00:00.000Z");
 		});
 
 		it("passes hints, transcript, and structured graph payloads through to remember", async () => {

--- a/platform/daemon/src/mcp/tools.ts
+++ b/platform/daemon/src/mcp/tools.ts
@@ -798,6 +798,15 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 				who: z.string().optional().describe("Filter by author"),
 				since: z.string().optional().describe("Only include memories created after this date"),
 				until: z.string().optional().describe("Only include memories created before this date"),
+				time: z
+					.object({
+						start: z.string().optional(),
+						end: z.string().optional(),
+						facets: z.array(z.enum(["captured", "session", "source", "observed", "occurred", "valid"])).optional(),
+						mode: z.enum(["auto", "timeline", "filter"]).optional(),
+					})
+					.optional()
+					.describe("Temporal recall range/facet options for date and timeline queries"),
 				keyword_query: z.string().optional().describe("Override the keyword/FTS query used for recall"),
 				pinned: z.boolean().optional().describe("Only return pinned memories"),
 				importance_min: z.number().optional().describe("Minimum memory importance threshold"),
@@ -826,6 +835,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 			importance_min,
 			since,
 			until,
+			time,
 			min_score,
 			score_min,
 			aggregate,
@@ -848,6 +858,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 					importance_min: importance_min ?? min_score,
 					since,
 					until,
+					time,
 					aggregate,
 					aggregate_budget,
 					save_aggregate,
@@ -881,6 +892,15 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 				who: z.string().optional().describe("Filter by author"),
 				since: z.string().optional().describe("Only include memories created after this date"),
 				until: z.string().optional().describe("Only include memories created before this date"),
+				time: z
+					.object({
+						start: z.string().optional(),
+						end: z.string().optional(),
+						facets: z.array(z.enum(["captured", "session", "source", "observed", "occurred", "valid"])).optional(),
+						mode: z.enum(["auto", "timeline", "filter"]).optional(),
+					})
+					.optional()
+					.describe("Temporal recall range/facet options for date and timeline queries"),
 				keyword_query: z.string().optional().describe("Override the keyword/FTS query used for recall"),
 				score_min: z.number().optional().describe("Minimum recall score threshold (client-side)"),
 				aggregate: z.boolean().optional().describe("Synthesize an aggregate answer from bounded recall evidence"),
@@ -901,6 +921,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 			who,
 			since,
 			until,
+			time,
 			score_min,
 			aggregate,
 			aggregate_budget,
@@ -920,6 +941,7 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 					who,
 					since,
 					until,
+					time,
 					aggregate,
 					aggregate_budget,
 					save_aggregate,
@@ -993,6 +1015,11 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 					.string()
 					.optional()
 					.describe("Source ISO timestamp for imported/older memories; used for currentness and supersession."),
+				occurredAt: z.string().optional().describe("Event time this memory is about"),
+				observedAt: z.string().optional().describe("Observation time this memory records"),
+				sourceCreatedAt: z.string().optional().describe("Source-system creation time for this memory"),
+				validFrom: z.string().optional().describe("Start of validity window for this memory"),
+				validUntil: z.string().optional().describe("End of validity window for this memory"),
 				transcript: z
 					.string()
 					.optional()
@@ -1057,7 +1084,22 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 			}),
 			annotations: { readOnlyHint: false },
 		},
-		async ({ content, type, importance, tags, hints, transcript, structured, pinned, createdAt }) => {
+		async ({
+			content,
+			type,
+			importance,
+			tags,
+			hints,
+			transcript,
+			structured,
+			pinned,
+			createdAt,
+			occurredAt,
+			observedAt,
+			sourceCreatedAt,
+			validFrom,
+			validUntil,
+		}) => {
 			const result = await daemonFetch<unknown>(baseUrl, "/api/memory/remember", {
 				method: "POST",
 				body: buildRememberRequestBody(content, {
@@ -1069,6 +1111,11 @@ export async function createMcpServer(opts?: McpServerOptions): Promise<McpServe
 					structured,
 					pinned,
 					createdAt,
+					occurredAt,
+					observedAt,
+					sourceCreatedAt,
+					validFrom,
+					validUntil,
 				}),
 			});
 

--- a/platform/daemon/src/memory-access-scope.ts
+++ b/platform/daemon/src/memory-access-scope.ts
@@ -1,0 +1,22 @@
+export function buildAgentScopeClause(
+	agentId: string,
+	readPolicy: string,
+	policyGroup: string | null,
+): { sql: string; args: unknown[] } {
+	if (readPolicy === "shared") {
+		return {
+			sql: " AND (m.visibility = 'global' OR m.agent_id = ?) AND m.visibility != 'archived'",
+			args: [agentId],
+		};
+	}
+	if (readPolicy === "group" && policyGroup) {
+		return {
+			sql: " AND ((m.visibility = 'global' AND m.agent_id IN (SELECT id FROM agents WHERE policy_group = ?)) OR m.agent_id = ?) AND m.visibility != 'archived'",
+			args: [policyGroup, agentId],
+		};
+	}
+	return {
+		sql: " AND m.agent_id = ? AND m.visibility != 'archived'",
+		args: [agentId],
+	};
+}

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -383,6 +383,18 @@ describe("hybridRecall", () => {
 				"2026-05-14T01:00:00.000Z",
 				Date.parse("2026-05-13T18:30:00.000Z"),
 			);
+			db.prepare(
+				`INSERT INTO session_transcripts (
+					session_key, content, harness, project, agent_id, created_at, updated_at
+				) VALUES (?, ?, 'codex', ?, ?, ?, ?)`,
+			).run(
+				"sess-raw-may-13",
+				"Raw transcript text must stay on session search.",
+				"/repo",
+				"agent-a",
+				"2026-05-13T18:15:00.000Z",
+				"2026-05-13T18:45:00.000Z",
+			);
 		});
 
 		const result = await hybridRecall(
@@ -401,6 +413,7 @@ describe("hybridRecall", () => {
 		expect(result.results[0]?.subject_type).toBe("session_summary");
 		expect(result.results[0]?.temporal_facet).toBe("session");
 		expect(result.results[0]?.content).toContain("temporal recall");
+		expect(JSON.stringify(result)).not.toContain("Raw transcript text");
 		expect(result.results.some((row) => row.source_path === "/repo/notes/temporal.md")).toBe(true);
 	});
 

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -548,6 +548,71 @@ describe("hybridRecall", () => {
 		expect(result.results.map((row) => row.id)).not.toContain("mem-later");
 	});
 
+	it("uses scoped temporal edge candidates without lexical prefiltering", async () => {
+		const savedAt = "2026-05-24T18:00:00.000Z";
+		getDbAccessor().withWriteTx((db) => {
+			const agent = db.prepare(
+				`INSERT INTO agents (id, name, read_policy, policy_group, created_at, updated_at)
+				 VALUES (?, ?, 'isolated', ?, ?, ?)
+				 ON CONFLICT(id) DO UPDATE SET policy_group = excluded.policy_group, updated_at = excluded.updated_at`,
+			);
+			agent.run("agent-group", "agent-group", "team-1", savedAt, savedAt);
+			agent.run("agent-alpha", "agent-alpha", "team-1", savedAt, savedAt);
+			agent.run("agent-beta", "agent-beta", "team-2", savedAt, savedAt);
+
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, type, agent_id, visibility, created_at, updated_at, updated_by, is_deleted
+				) VALUES (?, ?, 'fact', ?, 'global', ?, ?, 'test', 0)`,
+			).run("mem-alpha-edge", "Alpha dated memory uses launch checklist wording.", "agent-alpha", savedAt, savedAt);
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, type, agent_id, visibility, created_at, updated_at, updated_by, is_deleted
+				) VALUES (?, ?, 'fact', ?, 'global', ?, ?, 'test', 0)`,
+			).run("mem-beta-edge", "Beta dated memory mentions rollout directly.", "agent-beta", savedAt, savedAt);
+			const edge = db.prepare(
+				`INSERT INTO temporal_edges (
+					id, agent_id, subject_type, subject_id, facet, start_at, end_at,
+					confidence, created_at, updated_at
+				) VALUES (?, ?, 'memory', ?, 'occurred', ?, ?, 1.0, ?, ?)`,
+			);
+			edge.run(
+				"edge-alpha-group",
+				"agent-alpha",
+				"mem-alpha-edge",
+				"2026-05-13T18:00:00.000Z",
+				"2026-05-13T18:00:00.000Z",
+				savedAt,
+				savedAt,
+			);
+			edge.run(
+				"edge-beta-group",
+				"agent-beta",
+				"mem-beta-edge",
+				"2026-05-13T18:00:00.000Z",
+				"2026-05-13T18:00:00.000Z",
+				savedAt,
+				savedAt,
+			);
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "2026/05/13 rollout",
+				keywordQuery: "rollout",
+				limit: 5,
+				agentId: "agent-group",
+				readPolicy: "group",
+				policyGroup: "team-1",
+			},
+			testCfg(),
+			async () => null,
+		);
+
+		expect(result.results.map((row) => row.id)).toContain("mem-alpha-edge");
+		expect(result.results.map((row) => row.id)).not.toContain("mem-beta-edge");
+	});
+
 	it("honors explicit timeline mode even when query text is present", async () => {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -417,6 +417,91 @@ describe("hybridRecall", () => {
 		expect(result.results.some((row) => row.source_path === "/repo/notes/temporal.md")).toBe(true);
 	});
 
+	it("honors group policy for temporal session and source rows", async () => {
+		const now = "2026-05-24T18:00:00.000Z";
+		getDbAccessor().withWriteTx((db) => {
+			const agent = db.prepare(
+				`INSERT INTO agents (id, name, read_policy, policy_group, created_at, updated_at)
+				 VALUES (?, ?, 'isolated', ?, ?, ?)
+				 ON CONFLICT(id) DO UPDATE SET policy_group = excluded.policy_group, updated_at = excluded.updated_at`,
+			);
+			agent.run("agent-group", "agent-group", "team-1", now, now);
+			agent.run("agent-alpha", "agent-alpha", "team-1", now, now);
+			agent.run("agent-beta", "agent-beta", "team-2", now, now);
+
+			const summary = db.prepare(
+				`INSERT INTO session_summaries (
+					id, project, depth, kind, content, earliest_at, latest_at, session_key, harness, agent_id, created_at
+				) VALUES (?, ?, 0, 'session', ?, ?, ?, ?, 'codex', ?, ?)`,
+			);
+			summary.run(
+				"summary-alpha-group",
+				"/repo",
+				"Team alpha session timeline activity.",
+				"2026-05-13T16:00:00.000Z",
+				"2026-05-13T17:00:00.000Z",
+				"sess-alpha-group",
+				"agent-alpha",
+				"2026-05-13T17:00:00.000Z",
+			);
+			summary.run(
+				"summary-beta-group",
+				"/repo",
+				"Team beta session timeline activity.",
+				"2026-05-13T18:00:00.000Z",
+				"2026-05-13T19:00:00.000Z",
+				"sess-beta-group",
+				"agent-beta",
+				"2026-05-13T19:00:00.000Z",
+			);
+
+			const artifact = db.prepare(
+				`INSERT INTO memory_artifacts (
+					agent_id, source_path, source_sha256, source_kind, session_id, session_token,
+					project, harness, captured_at, content, updated_at
+				) VALUES (?, ?, ?, 'obsidian', ?, ?, '/repo', 'codex', ?, ?, ?)`,
+			);
+			artifact.run(
+				"agent-alpha",
+				"/repo/alpha-temporal.md",
+				createHash("sha256").update("alpha-temporal").digest("hex"),
+				"sess-alpha-group",
+				"token-alpha-group",
+				"2026-05-13T16:30:00.000Z",
+				"Team alpha source activity.",
+				"2026-05-13T16:30:00.000Z",
+			);
+			artifact.run(
+				"agent-beta",
+				"/repo/beta-temporal.md",
+				createHash("sha256").update("beta-temporal").digest("hex"),
+				"sess-beta-group",
+				"token-beta-group",
+				"2026-05-13T18:30:00.000Z",
+				"Team beta source activity.",
+				"2026-05-13T18:30:00.000Z",
+			);
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "2026/05/13",
+				limit: 10,
+				agentId: "agent-group",
+				readPolicy: "group",
+				policyGroup: "team-1",
+			},
+			testCfg(),
+			async () => null,
+		);
+
+		const resultText = JSON.stringify(result);
+		expect(resultText).toContain("Team alpha session timeline activity");
+		expect(resultText).toContain("/repo/alpha-temporal.md");
+		expect(resultText).not.toContain("Team beta session timeline activity");
+		expect(resultText).not.toContain("/repo/beta-temporal.md");
+	});
+
 	it("uses explicit occurred temporal edges for date plus topic recall", async () => {
 		const savedAt = "2026-05-24T18:00:00.000Z";
 		getDbAccessor().withWriteTx((db) => {

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -502,6 +502,89 @@ describe("hybridRecall", () => {
 		expect(resultText).not.toContain("/repo/beta-temporal.md");
 	});
 
+	it("keeps shared temporal session and source rows own-agent only", async () => {
+		const now = "2026-05-24T18:00:00.000Z";
+		getDbAccessor().withWriteTx((db) => {
+			const agent = db.prepare(
+				`INSERT INTO agents (id, name, read_policy, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?)
+				 ON CONFLICT(id) DO UPDATE SET read_policy = excluded.read_policy, updated_at = excluded.updated_at`,
+			);
+			agent.run("agent-a", "agent-a", "shared", now, now);
+			agent.run("agent-shared-other", "agent-shared-other", "shared", now, now);
+
+			const summary = db.prepare(
+				`INSERT INTO session_summaries (
+					id, project, depth, kind, content, earliest_at, latest_at, session_key, harness, agent_id, created_at
+				) VALUES (?, ?, 0, 'session', ?, ?, ?, ?, 'codex', ?, ?)`,
+			);
+			summary.run(
+				"summary-own-shared",
+				"/repo",
+				"Own shared-policy session timeline activity.",
+				"2026-05-13T16:00:00.000Z",
+				"2026-05-13T17:00:00.000Z",
+				"sess-own-shared",
+				"agent-a",
+				"2026-05-13T17:00:00.000Z",
+			);
+			summary.run(
+				"summary-other-shared",
+				"/repo",
+				"Other shared-policy session timeline activity.",
+				"2026-05-13T18:00:00.000Z",
+				"2026-05-13T19:00:00.000Z",
+				"sess-other-shared",
+				"agent-shared-other",
+				"2026-05-13T19:00:00.000Z",
+			);
+
+			const artifact = db.prepare(
+				`INSERT INTO memory_artifacts (
+					agent_id, source_path, source_sha256, source_kind, session_id, session_token,
+					project, harness, captured_at, content, updated_at
+				) VALUES (?, ?, ?, 'obsidian', ?, ?, '/repo', 'codex', ?, ?, ?)`,
+			);
+			artifact.run(
+				"agent-a",
+				"/repo/own-shared-temporal.md",
+				createHash("sha256").update("own-shared-temporal").digest("hex"),
+				"sess-own-shared",
+				"token-own-shared",
+				"2026-05-13T16:30:00.000Z",
+				"Own shared-policy source activity.",
+				"2026-05-13T16:30:00.000Z",
+			);
+			artifact.run(
+				"agent-shared-other",
+				"/repo/other-shared-temporal.md",
+				createHash("sha256").update("other-shared-temporal").digest("hex"),
+				"sess-other-shared",
+				"token-other-shared",
+				"2026-05-13T18:30:00.000Z",
+				"Other shared-policy source activity.",
+				"2026-05-13T18:30:00.000Z",
+			);
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "2026/05/13",
+				limit: 10,
+				agentId: "agent-a",
+				readPolicy: "shared",
+			},
+			testCfg(),
+			async () => null,
+		);
+
+		const resultText = JSON.stringify(result);
+		expect(resultText).toContain("Own shared-policy session timeline activity");
+		expect(resultText).toContain("/repo/own-shared-temporal.md");
+		expect(resultText).not.toContain("Other shared-policy session timeline activity");
+		expect(resultText).not.toContain("/repo/other-shared-temporal.md");
+	});
+
 	it("uses explicit occurred temporal edges for date plus topic recall", async () => {
 		const savedAt = "2026-05-24T18:00:00.000Z";
 		getDbAccessor().withWriteTx((db) => {
@@ -548,7 +631,7 @@ describe("hybridRecall", () => {
 		expect(result.results.map((row) => row.id)).not.toContain("mem-later");
 	});
 
-	it("uses scoped temporal edge candidates without lexical prefiltering", async () => {
+	it("lets hybrid topic evidence filter scoped temporal edge candidates", async () => {
 		const savedAt = "2026-05-24T18:00:00.000Z";
 		getDbAccessor().withWriteTx((db) => {
 			const agent = db.prepare(
@@ -564,7 +647,24 @@ describe("hybridRecall", () => {
 				`INSERT INTO memories (
 					id, content, type, agent_id, visibility, created_at, updated_at, updated_by, is_deleted
 				) VALUES (?, ?, 'fact', ?, 'global', ?, ?, 'test', 0)`,
-			).run("mem-alpha-edge", "Alpha dated memory uses launch checklist wording.", "agent-alpha", savedAt, savedAt);
+			).run(
+				"mem-alpha-edge",
+				"Alpha dated memory mentions rollout but not every topic word.",
+				"agent-alpha",
+				savedAt,
+				savedAt,
+			);
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, type, agent_id, visibility, created_at, updated_at, updated_by, is_deleted
+				) VALUES (?, ?, 'fact', ?, 'global', ?, ?, 'test', 0)`,
+			).run(
+				"mem-alpha-offtopic-edge",
+				"Alpha dated memory uses unrelated checklist wording.",
+				"agent-alpha",
+				savedAt,
+				savedAt,
+			);
 			db.prepare(
 				`INSERT INTO memories (
 					id, content, type, agent_id, visibility, created_at, updated_at, updated_by, is_deleted
@@ -586,6 +686,15 @@ describe("hybridRecall", () => {
 				savedAt,
 			);
 			edge.run(
+				"edge-alpha-offtopic-group",
+				"agent-alpha",
+				"mem-alpha-offtopic-edge",
+				"2026-05-13T18:00:00.000Z",
+				"2026-05-13T18:00:00.000Z",
+				savedAt,
+				savedAt,
+			);
+			edge.run(
 				"edge-beta-group",
 				"agent-beta",
 				"mem-beta-edge",
@@ -598,8 +707,8 @@ describe("hybridRecall", () => {
 
 		const result = await hybridRecall(
 			{
-				query: "2026/05/13 rollout",
-				keywordQuery: "rollout",
+				query: "2026/05/13 rollout planning migration schedule",
+				keywordQuery: "rollout planning migration schedule",
 				limit: 5,
 				agentId: "agent-group",
 				readPolicy: "group",
@@ -610,6 +719,7 @@ describe("hybridRecall", () => {
 		);
 
 		expect(result.results.map((row) => row.id)).toContain("mem-alpha-edge");
+		expect(result.results.map((row) => row.id)).not.toContain("mem-alpha-offtopic-edge");
 		expect(result.results.map((row) => row.id)).not.toContain("mem-beta-edge");
 	});
 

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -463,6 +463,46 @@ describe("hybridRecall", () => {
 		expect(result.results.map((row) => row.id)).not.toContain("mem-later");
 	});
 
+	it("honors explicit timeline mode even when query text is present", async () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO session_summaries (
+					id, project, depth, kind, content, earliest_at, latest_at, session_key, harness, agent_id, created_at
+				) VALUES (?, ?, 0, 'session', ?, ?, ?, ?, 'codex', ?, ?)`,
+			).run(
+				"sess-summary-timeline-mode",
+				"/repo",
+				"Worked on dashboard polish.",
+				"2026-05-13T18:00:00.000Z",
+				"2026-05-13T19:00:00.000Z",
+				"sess-timeline-mode",
+				"agent-a",
+				"2026-05-13T19:00:00.000Z",
+			);
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "temporal recall",
+				time: {
+					start: "2026-05-13T00:00:00.000Z",
+					end: "2026-05-14T00:00:00.000Z",
+					mode: "timeline",
+				},
+				limit: 5,
+				agentId: "agent-a",
+				readPolicy: "isolated",
+			},
+			testCfg(),
+			async () => null,
+		);
+
+		expect(result.meta.temporal?.mode).toBe("timeline");
+		expect(result.results.map((row) => row.id)).toContain(
+			"temporal:session_summary:sess-summary-timeline-mode:session",
+		);
+	});
+
 	it("keeps explicit temporal edge recall behind memory visibility rules", async () => {
 		const savedAt = "2026-05-24T18:00:00.000Z";
 		getDbAccessor().withWriteTx((db) => {

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -774,8 +774,8 @@ describe("hybridRecall", () => {
 
 		const result = await hybridRecall(
 			{
-				query: "2026/05/13 rollout planning migration schedule",
-				keywordQuery: "rollout planning migration schedule",
+				query: "2026/05/13 rollout planning migration",
+				keywordQuery: "rollout planning migration",
 				limit: 2,
 				agentId: "agent-a",
 				readPolicy: "isolated",

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -348,6 +348,144 @@ describe("hybridRecall", () => {
 		expect(result.meta.noHits).toBe(true);
 	});
 
+	it("returns a timeline for date-only recall from session summaries", async () => {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO session_summaries (
+					id, project, depth, kind, content, earliest_at, latest_at, session_key, harness, agent_id, created_at
+				) VALUES (?, ?, 0, 'session', ?, ?, ?, ?, 'codex', ?, ?)`,
+			).run(
+				"summary-may-13",
+				"/repo",
+				"We worked on temporal recall and source-backed date lookup.",
+				"2026-05-13T18:00:00.000Z",
+				"2026-05-13T19:00:00.000Z",
+				"sess-may-13",
+				"agent-a",
+				"2026-05-13T19:00:00.000Z",
+			);
+			db.prepare(
+				`INSERT INTO memory_artifacts (
+					agent_id, source_path, source_sha256, source_kind, session_id, session_token,
+					project, harness, captured_at, content, updated_at, source_mtime_ms
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			).run(
+				"agent-a",
+				"/repo/notes/temporal.md",
+				"sha-temporal",
+				"obsidian",
+				"sess-may-13",
+				"token-may-13",
+				"/repo",
+				"codex",
+				"2026-05-14T01:00:00.000Z",
+				"Source file changed while working on exact date recall.",
+				"2026-05-14T01:00:00.000Z",
+				Date.parse("2026-05-13T18:30:00.000Z"),
+			);
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "2026/05/13",
+				limit: 5,
+				agentId: "agent-a",
+				readPolicy: "isolated",
+			},
+			testCfg(),
+			async () => null,
+		);
+
+		expect(result.meta.temporal?.mode).toBe("timeline");
+		expect(result.results).toHaveLength(2);
+		expect(result.results[0]?.subject_type).toBe("session_summary");
+		expect(result.results[0]?.temporal_facet).toBe("session");
+		expect(result.results[0]?.content).toContain("temporal recall");
+		expect(result.results.some((row) => row.source_path === "/repo/notes/temporal.md")).toBe(true);
+	});
+
+	it("uses explicit occurred temporal edges for date plus topic recall", async () => {
+		const savedAt = "2026-05-24T18:00:00.000Z";
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, type, agent_id, visibility, created_at, updated_at, updated_by, is_deleted
+				) VALUES (?, ?, 'fact', ?, 'global', ?, ?, 'test', 0)`,
+			).run("mem-temporal", "Signet recall should support exact date queries", "agent-a", savedAt, savedAt);
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, type, agent_id, visibility, created_at, updated_at, updated_by, is_deleted
+				) VALUES (?, ?, 'fact', ?, 'global', ?, ?, 'test', 0)`,
+			).run("mem-later", "Signet recall unrelated saved later", "agent-a", savedAt, savedAt);
+			db.prepare(
+				`INSERT INTO temporal_edges (
+					id, agent_id, subject_type, subject_id, facet, start_at, end_at,
+					confidence, created_at, updated_at
+				) VALUES (?, ?, 'memory', ?, 'occurred', ?, ?, 1.0, ?, ?)`,
+			).run(
+				"edge-temporal",
+				"agent-a",
+				"mem-temporal",
+				"2026-05-13T18:00:00.000Z",
+				"2026-05-13T18:00:00.000Z",
+				savedAt,
+				savedAt,
+			);
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "2026/05/13 Signet recall",
+				keywordQuery: "Signet recall",
+				limit: 5,
+				agentId: "agent-a",
+				readPolicy: "isolated",
+			},
+			testCfg(),
+			async () => null,
+		);
+
+		expect(result.meta.temporal?.mode).toBe("filter");
+		expect(result.results.map((row) => row.id)).toContain("mem-temporal");
+		expect(result.results.map((row) => row.id)).not.toContain("mem-later");
+	});
+
+	it("keeps explicit temporal edge recall behind memory visibility rules", async () => {
+		const savedAt = "2026-05-24T18:00:00.000Z";
+		getDbAccessor().withWriteTx((db) => {
+			for (const [id, visibility] of [
+				["mem-temporal-visible", "global"],
+				["mem-temporal-archived", "archived"],
+			] as const) {
+				db.prepare(
+					`INSERT INTO memories (
+						id, content, type, agent_id, visibility, created_at, updated_at, updated_by, is_deleted
+					) VALUES (?, ?, 'fact', ?, ?, ?, ?, 'test', 0)`,
+				).run(id, "Hidden temporal recall project marker", "agent-a", visibility, savedAt, savedAt);
+				db.prepare(
+					`INSERT INTO temporal_edges (
+						id, agent_id, subject_type, subject_id, facet, start_at, end_at,
+						confidence, created_at, updated_at
+					) VALUES (?, ?, 'memory', ?, 'occurred', ?, ?, 1.0, ?, ?)`,
+				).run(`edge-${id}`, "agent-a", id, "2026-05-13T18:00:00.000Z", "2026-05-13T18:00:00.000Z", savedAt, savedAt);
+			}
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "2026/05/13 Hidden temporal recall",
+				keywordQuery: "Hidden temporal recall",
+				limit: 5,
+				agentId: "agent-a",
+				readPolicy: "isolated",
+			},
+			testCfg(),
+			async () => null,
+		);
+
+		expect(result.results.map((row) => row.id)).toEqual(["mem-temporal-visible"]);
+	});
+
 	it("drops ambiguous source chunk vector matches for project-scoped recall", async () => {
 		const now = new Date().toISOString();
 		const vec = unitVector();

--- a/platform/daemon/src/memory-search.test.ts
+++ b/platform/daemon/src/memory-search.test.ts
@@ -723,6 +723,71 @@ describe("hybridRecall", () => {
 		expect(result.results.map((row) => row.id)).not.toContain("mem-beta-edge");
 	});
 
+	it("does not cap temporal edge candidates to result limit before topic evidence", async () => {
+		const savedAt = "2026-05-24T18:00:00.000Z";
+		getDbAccessor().withWriteTx((db) => {
+			for (let index = 0; index < 8; index += 1) {
+				const id = `mem-offtopic-limit-${index}`;
+				db.prepare(
+					`INSERT INTO memories (
+						id, content, type, agent_id, visibility, created_at, updated_at, updated_by, is_deleted
+					) VALUES (?, ?, 'fact', 'agent-a', 'global', ?, ?, 'test', 0)`,
+				).run(id, `Same-day off-topic temporal candidate ${index}.`, savedAt, savedAt);
+				db.prepare(
+					`INSERT INTO temporal_edges (
+						id, agent_id, subject_type, subject_id, facet, start_at, end_at,
+						confidence, created_at, updated_at
+					) VALUES (?, 'agent-a', 'memory', ?, 'occurred', ?, ?, 1.0, ?, ?)`,
+				).run(
+					`edge-offtopic-limit-${index}`,
+					id,
+					`2026-05-13T20:${index.toString().padStart(2, "0")}:00.000Z`,
+					`2026-05-13T20:${index.toString().padStart(2, "0")}:00.000Z`,
+					savedAt,
+					savedAt,
+				);
+			}
+			db.prepare(
+				`INSERT INTO memories (
+					id, content, type, agent_id, visibility, created_at, updated_at, updated_by, is_deleted
+				) VALUES (?, ?, 'fact', 'agent-a', 'global', ?, ?, 'test', 0)`,
+			).run(
+				"mem-relevant-limit",
+				"Relevant rollout memory should survive temporal candidate scanning.",
+				savedAt,
+				savedAt,
+			);
+			db.prepare(
+				`INSERT INTO temporal_edges (
+					id, agent_id, subject_type, subject_id, facet, start_at, end_at,
+					confidence, created_at, updated_at
+				) VALUES (?, 'agent-a', 'memory', ?, 'occurred', ?, ?, 1.0, ?, ?)`,
+			).run(
+				"edge-relevant-limit",
+				"mem-relevant-limit",
+				"2026-05-13T12:00:00.000Z",
+				"2026-05-13T12:00:00.000Z",
+				savedAt,
+				savedAt,
+			);
+		});
+
+		const result = await hybridRecall(
+			{
+				query: "2026/05/13 rollout planning migration schedule",
+				keywordQuery: "rollout planning migration schedule",
+				limit: 2,
+				agentId: "agent-a",
+				readPolicy: "isolated",
+			},
+			testCfg(),
+			async () => null,
+		);
+
+		expect(result.results.map((row) => row.id)).toContain("mem-relevant-limit");
+		expect(result.results.some((row) => row.id.startsWith("mem-offtopic-limit-"))).toBe(false);
+	});
+
 	it("honors explicit timeline mode even when query text is present", async () => {
 		getDbAccessor().withWriteTx((db) => {
 			db.prepare(

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -972,6 +972,22 @@ function cosineSimilarity(query: Float32Array, memory: Float32Array): number {
 // not outrank directly grounded lexical/vector/structured evidence. A hint
 // supported by direct evidence can keep its score; only hint-only rows are capped.
 const HINT_ONLY_SCORE_CAP = 0.75;
+const TEMPORAL_TOPIC_SCORE_CAP = 0.85;
+
+function temporalTopicTokens(raw: string): string[] {
+	return [...new Set(tokenizeGraphQuery(raw))];
+}
+
+function scoreTemporalTopicEvidence(query: string, content: string): number {
+	const queryTokens = temporalTopicTokens(query);
+	if (queryTokens.length === 0) return 0;
+	const contentTokens = new Set(temporalTopicTokens(content));
+	const matched = queryTokens.filter((token) => contentTokens.has(token));
+	if (matched.length === 0) return 0;
+	const coverage = matched.length / queryTokens.length;
+	const density = matched.length / Math.max(8, contentTokens.size);
+	return Math.min(TEMPORAL_TOPIC_SCORE_CAP, 0.35 + coverage * 0.4 + density * 0.1);
+}
 
 /**
  * Run the recall pipeline.
@@ -1103,6 +1119,9 @@ export async function hybridRecall(
 		query = temporal.adjustedQuery;
 	}
 	const temporalCandidateSet = new Set(temporal.candidateIds ?? []);
+	const temporalCandidateMap = new Map<string, number>(
+		[...temporalCandidateSet].map((id) => [id, Math.max(minScore, 0.05)]),
+	);
 
 	const expandedQuery = expandRecallKeywordQuery(query);
 	const keywordQuery = sanitizeFtsQuery((params.keywordQuery ?? expandedQuery).trim());
@@ -1296,7 +1315,13 @@ export async function hybridRecall(
 	}
 
 	// --- Flat search: merge BM25 + vector + structured path candidate scores ---
-	const allIds = new Set([...bm25Map.keys(), ...hintMap.keys(), ...vectorMap.keys(), ...structuredCandidateMap.keys()]);
+	const allIds = new Set([
+		...bm25Map.keys(),
+		...hintMap.keys(),
+		...vectorMap.keys(),
+		...structuredCandidateMap.keys(),
+		...temporalCandidateMap.keys(),
+	]);
 	const flatScored: Array<{ id: string; score: number; source: string }> = [];
 
 	timings.time("flat_score_merge", () => {
@@ -1305,6 +1330,7 @@ export async function hybridRecall(
 			const hint = hintMap.get(id) ?? 0;
 			const vec = vectorMap.get(id) ?? 0;
 			const structured = structuredCandidateMap.get(id) ?? 0;
+			const temporalCandidate = temporalCandidateMap.get(id) ?? 0;
 			const topicEvidence = bm25 > 0 || hint > 0 || vec > 0 || structured > 0;
 			const temporalScore = temporalCandidateSet.has(id) && topicEvidence ? 0.85 : 0;
 			let score: number;
@@ -1322,6 +1348,9 @@ export async function hybridRecall(
 			} else if (temporalScore > 0) {
 				score = temporalScore;
 				source = "temporal";
+			} else if (temporalCandidate > 0) {
+				score = temporalCandidate;
+				source = "temporal_candidate";
 			} else {
 				score = structured;
 				source = "structured";
@@ -1609,6 +1638,43 @@ export async function hybridRecall(
 	// Everything below this point may assume `scored` only contains memory IDs
 	// visible to the caller. Keep new content-bearing stages below this line.
 	const structuredEvidenceMap = new Map(structuredCandidateMap);
+	const temporalTopicEvidenceMap = new Map<string, number>();
+	if (temporalCandidateSet.size > 0 && scored.length > 0) {
+		try {
+			const candidateIds = scored.filter((row) => temporalCandidateSet.has(row.id)).map((row) => row.id);
+			if (candidateIds.length > 0) {
+				const placeholders = candidateIds.map(() => "?").join(", ");
+				const contentRows = getDbAccessor().withReadDb(
+					(db) =>
+						db
+							.prepare(
+								`SELECT id, content FROM memories
+								 WHERE id IN (${placeholders})`,
+							)
+							.all(...candidateIds) as Array<{ id: string; content: string }>,
+				);
+				for (const row of contentRows) {
+					const score = scoreTemporalTopicEvidence(query, row.content);
+					if (score <= 0) continue;
+					temporalTopicEvidenceMap.set(row.id, score);
+					semanticEvidenceMap.set(row.id, Math.max(semanticEvidenceMap.get(row.id) ?? 0, score));
+				}
+			}
+		} catch (e) {
+			logger.warn("memory", "Temporal topic evidence failed (non-fatal)", {
+				error: e instanceof Error ? e.message : String(e),
+			});
+		}
+		for (const row of scored) {
+			const topicScore = temporalTopicEvidenceMap.get(row.id) ?? 0;
+			if (topicScore <= 0) continue;
+			if (row.source === "temporal_candidate" || topicScore > row.score) {
+				row.score = topicScore;
+				row.source = row.source === "temporal_candidate" ? "temporal_topic" : "temporal_hybrid";
+			}
+		}
+		scored.sort((a, b) => b.score - a.score);
+	}
 
 	// --- Structured Evidence Convolution (SEC-lite) ---
 	// Keep retrieval channels separate until after traversal/boosting. This
@@ -1643,7 +1709,7 @@ export async function hybridRecall(
 			const evidence: EvidenceCandidateInput[] = candidates.map((row) => ({
 				id: row.id,
 				source: row.source,
-				lexical: bm25Map.get(row.id),
+				lexical: Math.max(bm25Map.get(row.id) ?? 0, temporalTopicEvidenceMap.get(row.id) ?? 0),
 				semantic: semanticEvidenceMap.get(row.id),
 				hint: hintMap.get(row.id),
 				traversal: traversalEvidenceMap.get(row.id),
@@ -1901,7 +1967,16 @@ export async function hybridRecall(
 
 	timings.time("final_rank", () => {
 		if (temporalCandidateSet.size > 0) {
-			scored = scored.filter((row) => temporalCandidateSet.has(row.id));
+			scored = scored.filter((row) => {
+				if (!temporalCandidateSet.has(row.id)) return false;
+				return (
+					(bm25Map.get(row.id) ?? 0) > 0 ||
+					(vectorMap.get(row.id) ?? 0) > 0 ||
+					(hintMap.get(row.id) ?? 0) > 0 ||
+					(structuredEvidenceMap.get(row.id) ?? 0) > 0 ||
+					(temporalTopicEvidenceMap.get(row.id) ?? 0) > 0
+				);
+			});
 		}
 		for (const row of scored) {
 			const hasDirectEvidence =

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -15,13 +15,15 @@
 import { createHash } from "node:crypto";
 import {
 	LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE,
-	SOURCE_CHUNK_SOURCE_TYPE,
 	type LlmUsage,
+	type RecallTemporalMeta,
+	SOURCE_CHUNK_SOURCE_TYPE,
 	vectorSearch,
 } from "@signet/core";
 import { getDbAccessor } from "./db-accessor";
 import { getLlmProvider } from "./llm";
 import { logger } from "./logger";
+import { buildAgentScopeClause } from "./memory-access-scope";
 import type { EmbeddingConfig, MemorySearchConfig, ResolvedMemoryConfig } from "./memory-config";
 import { NATIVE_MEMORY_BRIDGE_SOURCE_NODE_ID } from "./native-memory-constants";
 import { constructContextBlocks } from "./pipeline/context-construction";
@@ -40,6 +42,7 @@ import {
 import { findStructuredPathCandidates, scoreStructuredPathEvidence } from "./pipeline/structured-path-evidence";
 import { type RecallDedupeMeta, applyRecallDedupe } from "./session-recall-dedupe";
 import { escapeLike } from "./sql-utils";
+import { type TemporalTimeOptions, resolveTemporalRecall } from "./temporal-recall";
 
 // ---------------------------------------------------------------------------
 // Public interfaces
@@ -66,6 +69,7 @@ export interface RecallParams {
 	importance_min?: number;
 	since?: string;
 	until?: string;
+	time?: TemporalTimeOptions;
 	scope?: string | null;
 	expand?: boolean;
 	/** When set, restricts results to memories belonging to this project (auth scope enforcement). */
@@ -117,6 +121,7 @@ export interface RecallResponse {
 		hasSupplementary: boolean;
 		noHits: boolean;
 		timings: RecallTimings;
+		temporal?: RecallTemporalMeta;
 		dedupe?: RecallDedupeMeta;
 	};
 	aggregate?: {
@@ -210,33 +215,7 @@ function createRecallTimingCollector(): {
 	};
 }
 
-// ---------------------------------------------------------------------------
-// Agent scope clause (exported for testing)
-// ---------------------------------------------------------------------------
-
-export function buildAgentScopeClause(
-	agentId: string,
-	readPolicy: string,
-	policyGroup: string | null,
-): { sql: string; args: unknown[] } {
-	if (readPolicy === "shared") {
-		return {
-			sql: " AND (m.visibility = 'global' OR m.agent_id = ?) AND m.visibility != 'archived'",
-			args: [agentId],
-		};
-	}
-	if (readPolicy === "group" && policyGroup) {
-		return {
-			sql: " AND ((m.visibility = 'global' AND m.agent_id IN (SELECT id FROM agents WHERE policy_group = ?)) OR m.agent_id = ?) AND m.visibility != 'archived'",
-			args: [policyGroup, agentId],
-		};
-	}
-	// 'isolated', 'group' without policyGroup, or unknown — own memories only
-	return {
-		sql: " AND m.agent_id = ? AND m.visibility != 'archived'",
-		args: [agentId],
-	};
-}
+export { buildAgentScopeClause } from "./memory-access-scope";
 
 // ---------------------------------------------------------------------------
 // Filter clause builder (private)
@@ -1014,9 +993,7 @@ export async function hybridRecall(
 	cfg: ResolvedMemoryConfig,
 	embedFn: EmbedFn,
 ): Promise<RecallResponse> {
-	const query = params.query;
-	const expandedQuery = expandRecallKeywordQuery(params.query);
-	const keywordQuery = sanitizeFtsQuery((params.keywordQuery ?? expandedQuery).trim());
+	let query = params.query;
 	const limit = normalizeRecallLimit(params.limit);
 	const alpha = cfg.search.alpha;
 	const minScore = cfg.search.min_score;
@@ -1108,6 +1085,27 @@ export async function hybridRecall(
 			},
 		};
 	};
+
+	const temporal = resolveTemporalRecall({
+		query,
+		time: params.time,
+		limit,
+		agentId: params.agentId,
+		readPolicy: params.readPolicy,
+		policyGroup: params.policyGroup,
+		project: params.project,
+		sessionKey: params.sessionKey,
+	});
+	if (temporal.response) {
+		return await finish(temporal.response);
+	}
+	if (temporal.adjustedQuery) {
+		query = temporal.adjustedQuery;
+	}
+	const temporalCandidateSet = new Set(temporal.candidateIds ?? []);
+
+	const expandedQuery = expandRecallKeywordQuery(query);
+	const keywordQuery = sanitizeFtsQuery((params.keywordQuery ?? expandedQuery).trim());
 	const queryVecPromise = (() => {
 		const embeddingStart = performance.now();
 		let promise: Promise<number[] | null>;
@@ -1298,7 +1296,13 @@ export async function hybridRecall(
 	}
 
 	// --- Flat search: merge BM25 + vector + structured path candidate scores ---
-	const allIds = new Set([...bm25Map.keys(), ...hintMap.keys(), ...vectorMap.keys(), ...structuredCandidateMap.keys()]);
+	const allIds = new Set([
+		...bm25Map.keys(),
+		...hintMap.keys(),
+		...vectorMap.keys(),
+		...structuredCandidateMap.keys(),
+		...temporalCandidateSet,
+	]);
 	const flatScored: Array<{ id: string; score: number; source: string }> = [];
 
 	timings.time("flat_score_merge", () => {
@@ -1307,6 +1311,7 @@ export async function hybridRecall(
 			const hint = hintMap.get(id) ?? 0;
 			const vec = vectorMap.get(id) ?? 0;
 			const structured = structuredCandidateMap.get(id) ?? 0;
+			const temporalScore = temporalCandidateSet.has(id) ? 0.85 : 0;
 			let score: number;
 			let source: string;
 
@@ -1319,6 +1324,9 @@ export async function hybridRecall(
 			} else if (bm25 > 0) {
 				score = bm25;
 				source = "keyword";
+			} else if (temporalScore > 0) {
+				score = temporalScore;
+				source = "temporal";
 			} else {
 				score = structured;
 				source = "structured";
@@ -1331,6 +1339,10 @@ export async function hybridRecall(
 			if (structured > 0 && structured >= score) {
 				score = structured;
 				source = bm25 > 0 || vec > 0 || hint > 0 ? "sec" : "structured";
+			}
+			if (temporalScore > 0 && temporalScore >= score) {
+				score = temporalScore;
+				source = bm25 > 0 || vec > 0 || hint > 0 || structured > 0 ? "temporal_hybrid" : "temporal";
 			}
 
 			if (score >= minScore) flatScored.push({ id, score, source });
@@ -1893,6 +1905,9 @@ export async function hybridRecall(
 	}
 
 	timings.time("final_rank", () => {
+		if (temporalCandidateSet.size > 0) {
+			scored = scored.filter((row) => temporalCandidateSet.has(row.id));
+		}
 		for (const row of scored) {
 			const hasDirectEvidence =
 				(bm25Map.get(row.id) ?? 0) > 0 ||
@@ -2453,6 +2468,7 @@ export async function hybridRecall(
 			totalReturned: results.length,
 			hasSupplementary: results.some((row) => row.supplementary === true),
 			noHits: results.length === 0,
+			...(temporal.meta ? { temporal: temporal.meta } : {}),
 		},
 		entities: entityContext && entityContext.length > 0 ? entityContext : undefined,
 	});

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -1296,13 +1296,7 @@ export async function hybridRecall(
 	}
 
 	// --- Flat search: merge BM25 + vector + structured path candidate scores ---
-	const allIds = new Set([
-		...bm25Map.keys(),
-		...hintMap.keys(),
-		...vectorMap.keys(),
-		...structuredCandidateMap.keys(),
-		...temporalCandidateSet,
-	]);
+	const allIds = new Set([...bm25Map.keys(), ...hintMap.keys(), ...vectorMap.keys(), ...structuredCandidateMap.keys()]);
 	const flatScored: Array<{ id: string; score: number; source: string }> = [];
 
 	timings.time("flat_score_merge", () => {
@@ -1311,7 +1305,8 @@ export async function hybridRecall(
 			const hint = hintMap.get(id) ?? 0;
 			const vec = vectorMap.get(id) ?? 0;
 			const structured = structuredCandidateMap.get(id) ?? 0;
-			const temporalScore = temporalCandidateSet.has(id) ? 0.85 : 0;
+			const topicEvidence = bm25 > 0 || hint > 0 || vec > 0 || structured > 0;
+			const temporalScore = temporalCandidateSet.has(id) && topicEvidence ? 0.85 : 0;
 			let score: number;
 			let source: string;
 
@@ -1928,7 +1923,7 @@ export async function hybridRecall(
 			: limit;
 	const topIds = params.sourceOnly === true ? [] : scored.slice(0, preHydrate).map((s) => s.id);
 	const recallTruncate = cfg.pipelineV2.guardrails.recallTruncateChars;
-	const allowSourceFallbacks = !hasMemoryMetadataFilters(params);
+	const allowSourceFallbacks = temporalCandidateSet.size === 0 && !hasMemoryMetadataFilters(params);
 
 	if (topIds.length === 0) {
 		const fallbackLimit = selectionDedupeEnabled ? Math.max(limit * 3, limit + 10) : limit;

--- a/platform/daemon/src/mutation-api.test.ts
+++ b/platform/daemon/src/mutation-api.test.ts
@@ -290,6 +290,58 @@ memory:
 		expect(row?.count).toBe(3);
 	});
 
+	it("POST /api/memory/remember scopes source-id temporal dedupe by memory owner", async () => {
+		const first = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: "Default source temporal provenance import",
+				who: "soulvessel.tests",
+				sourceType: "source-temporal-test",
+				sourceId: "shared-source-temporal-key",
+				occurredAt: "2026-05-13T18:00:00.000Z",
+			}),
+		});
+		const firstJson = (await first.json()) as { id?: string; deduped?: boolean };
+		expect(first.status).toBe(200);
+		expect(firstJson.id).toBeString();
+		expect(firstJson.deduped).toBeUndefined();
+
+		const otherAgent = await app.request("http://localhost/api/memory/remember", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: "Agent source temporal provenance import",
+				who: "soulvessel.tests",
+				agentId: "agent-a",
+				sourceType: "source-temporal-test",
+				sourceId: "shared-source-temporal-key",
+				occurredAt: "2026-05-13T19:00:00.000Z",
+			}),
+		});
+		const otherAgentJson = (await otherAgent.json()) as { id?: string; deduped?: boolean };
+		expect(otherAgent.status).toBe(200);
+		expect(otherAgentJson.id).toBeString();
+		expect(otherAgentJson.id).not.toBe(firstJson.id);
+		expect(otherAgentJson.deduped).toBeUndefined();
+
+		const rows = getDbAccessor().withReadDb(
+			(db) =>
+				db
+					.prepare(
+						`SELECT agent_id AS agentId, subject_id AS subjectId
+						 FROM temporal_edges
+						 WHERE subject_type = 'memory' AND facet = 'occurred'
+						 ORDER BY agent_id`,
+					)
+					.all() as Array<{ agentId: string; subjectId: string }>,
+		);
+		expect(rows).toEqual([
+			{ agentId: "agent-a", subjectId: otherAgentJson.id },
+			{ agentId: "default", subjectId: firstJson.id },
+		]);
+	});
+
 	it("POST /api/memory/remember matches normalized idempotency-key index scope", async () => {
 		const first = await app.request("http://localhost/api/memory/remember", {
 			method: "POST",

--- a/platform/daemon/src/routes/hooks-routes.ts
+++ b/platform/daemon/src/routes/hooks-routes.ts
@@ -60,6 +60,7 @@ import {
 	releaseSession,
 	renewSession,
 } from "../session-tracker.js";
+import { validateTemporalTimeOptions } from "../temporal-recall";
 import { upsertThreadHead } from "../thread-heads";
 import { autoConnectGraphiq } from "./graphiq-routes.js";
 import {
@@ -514,6 +515,8 @@ function registerRecall(app: Hono): void {
 			if (aggregateBudgetInput !== undefined && aggregateBudget === null) {
 				return c.json({ error: "Invalid aggregateBudget. Expected one of: small, medium, large." }, 400);
 			}
+			const temporalTimeError = validateTemporalTimeOptions(body.time);
+			if (temporalTimeError) return c.json({ error: temporalTimeError }, 400);
 
 			const runtimePath = resolveRuntimePath(c, body);
 			if (runtimePath) body.runtimePath = runtimePath;

--- a/platform/daemon/src/routes/hooks-routes.ts
+++ b/platform/daemon/src/routes/hooks-routes.ts
@@ -562,6 +562,7 @@ function registerRecall(app: Hono): void {
 				who: body.who,
 				since: body.since,
 				until: body.until,
+				time: body.time,
 				expand: body.expand,
 				agentId,
 				readPolicy: agentScope.readPolicy,

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -119,7 +119,7 @@ function collectExplicitTemporalInputs(body: {
 	if (body.occurredAt !== undefined && !occurredAt) return { error: "occurredAt must be a valid ISO timestamp" };
 	if (body.validFrom !== undefined && !validFrom) return { error: "validFrom must be a valid ISO timestamp" };
 	if (body.validUntil !== undefined && !validUntil) return { error: "validUntil must be a valid ISO timestamp" };
-	if (validUntil && validFrom && validUntil < validFrom) return { error: "validUntil must be after validFrom" };
+	if (validUntil && validFrom && validUntil <= validFrom) return { error: "validUntil must be after validFrom" };
 
 	const inputs: ExplicitTemporalInput[] = [];
 	if (sourceCreatedAt)

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -24,6 +24,7 @@ import { recordPathFeedback } from "../path-feedback";
 import { enqueueDocumentIngestJob } from "../pipeline";
 import { parseFeedback, recordAgentFeedback } from "../session-memories";
 import { upsertSessionTranscript } from "../session-transcripts";
+import { createTemporalEdgeId, normalizeTemporalTimestamp } from "../temporal-recall";
 import { txForgetMemory, txIngestEnvelope, txModifyMemory, txRecoverMemory } from "../transactions";
 import { cacheProjection, computeProjection, computeProjectionForQuery, getCachedProjection } from "../umap-projection";
 import {
@@ -91,6 +92,92 @@ function parseOptionalIsoTimestamp(value: unknown): string | null {
 	if (!trimmed) return null;
 	const ts = new Date(trimmed);
 	return Number.isNaN(ts.getTime()) ? null : ts.toISOString();
+}
+
+interface ExplicitTemporalInput {
+	readonly facet: "source" | "observed" | "occurred" | "valid";
+	readonly startAt: string;
+	readonly endAt: string | null;
+	readonly provenance: string;
+}
+
+function collectExplicitTemporalInputs(body: {
+	readonly sourceCreatedAt?: string;
+	readonly observedAt?: string;
+	readonly occurredAt?: string;
+	readonly validFrom?: string;
+	readonly validUntil?: string;
+}): { inputs?: readonly ExplicitTemporalInput[]; error?: string } {
+	const sourceCreatedAt = normalizeTemporalTimestamp(body.sourceCreatedAt);
+	const observedAt = normalizeTemporalTimestamp(body.observedAt);
+	const occurredAt = normalizeTemporalTimestamp(body.occurredAt);
+	const validFrom = normalizeTemporalTimestamp(body.validFrom);
+	const validUntil = normalizeTemporalTimestamp(body.validUntil);
+	if (body.sourceCreatedAt !== undefined && !sourceCreatedAt)
+		return { error: "sourceCreatedAt must be a valid ISO timestamp" };
+	if (body.observedAt !== undefined && !observedAt) return { error: "observedAt must be a valid ISO timestamp" };
+	if (body.occurredAt !== undefined && !occurredAt) return { error: "occurredAt must be a valid ISO timestamp" };
+	if (body.validFrom !== undefined && !validFrom) return { error: "validFrom must be a valid ISO timestamp" };
+	if (body.validUntil !== undefined && !validUntil) return { error: "validUntil must be a valid ISO timestamp" };
+	if (validUntil && validFrom && validUntil < validFrom) return { error: "validUntil must be after validFrom" };
+
+	const inputs: ExplicitTemporalInput[] = [];
+	if (sourceCreatedAt)
+		inputs.push({
+			facet: "source",
+			startAt: sourceCreatedAt,
+			endAt: sourceCreatedAt,
+			provenance: "remember.sourceCreatedAt",
+		});
+	if (observedAt)
+		inputs.push({ facet: "observed", startAt: observedAt, endAt: observedAt, provenance: "remember.observedAt" });
+	if (occurredAt)
+		inputs.push({ facet: "occurred", startAt: occurredAt, endAt: occurredAt, provenance: "remember.occurredAt" });
+	if (validFrom)
+		inputs.push({ facet: "valid", startAt: validFrom, endAt: validUntil, provenance: "remember.validRange" });
+	return { inputs };
+}
+
+function txInsertExplicitTemporalEdges(params: {
+	readonly db: WriteDb;
+	readonly memoryId: string;
+	readonly agentId: string;
+	readonly inputs: readonly ExplicitTemporalInput[];
+	readonly now: string;
+}): void {
+	if (params.inputs.length === 0) return;
+	const table = params.db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='temporal_edges'").get();
+	if (!table) return;
+	const stmt = params.db.prepare(
+		`INSERT INTO temporal_edges
+		   (id, agent_id, subject_type, subject_id, facet, start_at, end_at, confidence,
+		    provenance_json, metadata_json, created_at, updated_at)
+		 VALUES (?, ?, 'memory', ?, ?, ?, ?, 1.0, ?, NULL, ?, ?)
+		 ON CONFLICT(id) DO UPDATE SET
+		   end_at = excluded.end_at,
+		   confidence = excluded.confidence,
+		   provenance_json = excluded.provenance_json,
+		   updated_at = excluded.updated_at`,
+	);
+	for (const input of params.inputs) {
+		stmt.run(
+			createTemporalEdgeId({
+				agentId: params.agentId,
+				subjectType: "memory",
+				subjectId: params.memoryId,
+				facet: input.facet,
+				startAt: input.startAt,
+			}),
+			params.agentId,
+			params.memoryId,
+			input.facet,
+			input.startAt,
+			input.endAt,
+			JSON.stringify({ source: input.provenance }),
+			params.now,
+			params.now,
+		);
+	}
 }
 
 function codexHome(): string {
@@ -795,6 +882,11 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			sourceType?: string;
 			sourceId?: string;
 			createdAt?: string;
+			occurredAt?: string;
+			observedAt?: string;
+			validFrom?: string;
+			validUntil?: string;
+			sourceCreatedAt?: string;
 			scope?: string | null;
 			agentId?: string;
 			visibility?: "global" | "private" | "archived";
@@ -845,6 +937,8 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		if (body.createdAt !== undefined && !requestedCreatedAt) {
 			return c.json({ error: "createdAt must be a valid ISO timestamp" }, 400);
 		}
+		const temporalInputs = collectExplicitTemporalInputs(body);
+		if (temporalInputs.error) return c.json({ error: temporalInputs.error }, 400);
 		const scope = body.scope ?? null;
 		const rowProvenance = parseRememberRowProvenance(body as Record<string, unknown>);
 		const agentId = resolveAgentId({ agentId: body.agentId, sessionKey: c.req.header("x-signet-session-key") });
@@ -1236,10 +1330,26 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					visibility,
 					createdAt,
 				});
+				txInsertExplicitTemporalEdges({
+					db,
+					memoryId: id,
+					agentId,
+					inputs: temporalInputs.inputs ?? [],
+					now,
+				});
 				return { deduped: false as const };
 			});
 
 			if (result.deduped) {
+				getDbAccessor().withWriteTx((db) =>
+					txInsertExplicitTemporalEdges({
+						db,
+						memoryId: result.row.id,
+						agentId,
+						inputs: temporalInputs.inputs ?? [],
+						now,
+					}),
+				);
 				return c.json({
 					id: result.row.id,
 					type: result.row.type,
@@ -1260,6 +1370,15 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					return getScopedContentHashDedupeRow(db, contentHash, dedupeScope);
 				});
 				if (existing) {
+					getDbAccessor().withWriteTx((db) =>
+						txInsertExplicitTemporalEdges({
+							db,
+							memoryId: existing.id,
+							agentId,
+							inputs: temporalInputs.inputs ?? [],
+							now,
+						}),
+					);
 					return c.json({
 						id: existing.id,
 						type: existing.type,
@@ -2486,6 +2605,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const pinned = c.req.query("pinned");
 		const importanceMin = c.req.query("importance_min");
 		const since = c.req.query("since");
+		const until = c.req.query("until");
 		const expand = c.req.query("expand");
 		const project = c.req.query("project");
 		const includeRecalled = c.req.query("includeRecalled") ?? c.req.query("include_recalled");
@@ -2510,6 +2630,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				pinned: pinned === "1" || pinned === "true",
 				importance_min: importanceMin ? Number.parseFloat(importanceMin) : undefined,
 				since,
+				until,
 				expand: expand === "1" || expand === "true",
 				project,
 				agentId,

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -256,6 +256,7 @@ interface RememberDedupeScope {
 
 interface RememberDedupeRow {
 	readonly id: string;
+	readonly agentId: string;
 	readonly type: string;
 	readonly tags: string | null;
 	readonly pinned: number;
@@ -385,12 +386,29 @@ function getScopedIdempotencyDedupeRow(
 	const scoped = scopedMemoryPredicate(input);
 	return db
 		.prepare(
-			`SELECT id, type, tags, pinned, importance, content
+			`SELECT id, COALESCE(NULLIF(agent_id, ''), 'default') AS agentId, type, tags, pinned, importance, content
 			 FROM memories
 			 WHERE idempotency_key = ? AND ${scoped.sql} AND is_deleted = 0
 			 LIMIT 1`,
 		)
 		.get(key, ...scoped.params) as RememberDedupeRow | undefined;
+}
+
+function getScopedSourceDedupeRow(
+	db: WriteDb,
+	sourceType: string,
+	sourceId: string,
+	input: RememberDedupeScope,
+): RememberDedupeRow | undefined {
+	const scoped = scopedMemoryPredicate(input);
+	return db
+		.prepare(
+			`SELECT id, COALESCE(NULLIF(agent_id, ''), 'default') AS agentId, type, tags, pinned, importance, content
+			 FROM memories
+			 WHERE source_type = ? AND source_id = ? AND ${scoped.sql} AND is_deleted = 0
+			 LIMIT 1`,
+		)
+		.get(sourceType, sourceId, ...scoped.params) as RememberDedupeRow | undefined;
 }
 
 function getScopedContentHashMemoryId(
@@ -422,7 +440,7 @@ function getScopedContentHashDedupeRow(
 	const scoped = scopedContentHashPredicate(input);
 	return db
 		.prepare(
-			`SELECT id, type, tags, pinned, importance, content
+			`SELECT id, COALESCE(NULLIF(agent_id, ''), 'default') AS agentId, type, tags, pinned, importance, content
 			 FROM memories
 			 WHERE content_hash = ? AND ${scoped.sql} AND is_deleted = 0
 			 LIMIT 1`,
@@ -1266,27 +1284,11 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 			return c.json({ error: "idempotencyKey already used for chunked content" }, 409);
 		}
 
-		type DedupeRow = RememberDedupeRow;
-
 		try {
 			const result = getDbAccessor().withWriteTx((db) => {
 				// Check sourceId-based dedupe first (scope-aware)
 				if (sourceId) {
-					const bySource = (
-						scope !== null
-							? db
-									.prepare(
-										`SELECT id, type, tags, pinned, importance, content
-						 FROM memories WHERE source_type = ? AND source_id = ? AND scope = ? AND is_deleted = 0 LIMIT 1`,
-									)
-									.get(sourceType, sourceId, scope)
-							: db
-									.prepare(
-										`SELECT id, type, tags, pinned, importance, content
-						 FROM memories WHERE source_type = ? AND source_id = ? AND scope IS NULL AND is_deleted = 0 LIMIT 1`,
-									)
-									.get(sourceType, sourceId)
-					) as DedupeRow | undefined;
+					const bySource = getScopedSourceDedupeRow(db, sourceType, sourceId, dedupeScope);
 					if (bySource) return { deduped: true as const, row: bySource };
 				}
 
@@ -1345,7 +1347,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					txInsertExplicitTemporalEdges({
 						db,
 						memoryId: result.row.id,
-						agentId,
+						agentId: result.row.agentId,
 						inputs: temporalInputs.inputs ?? [],
 						now,
 					}),
@@ -1374,7 +1376,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 						txInsertExplicitTemporalEdges({
 							db,
 							memoryId: existing.id,
-							agentId,
+							agentId: existing.agentId,
 							inputs: temporalInputs.inputs ?? [],
 							now,
 						}),

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -24,7 +24,7 @@ import { recordPathFeedback } from "../path-feedback";
 import { enqueueDocumentIngestJob } from "../pipeline";
 import { parseFeedback, recordAgentFeedback } from "../session-memories";
 import { upsertSessionTranscript } from "../session-transcripts";
-import { createTemporalEdgeId, normalizeTemporalTimestamp } from "../temporal-recall";
+import { createTemporalEdgeId, normalizeTemporalTimestamp, validateTemporalTimeOptions } from "../temporal-recall";
 import { txForgetMemory, txIngestEnvelope, txModifyMemory, txRecoverMemory } from "../transactions";
 import { cacheProjection, computeProjection, computeProjectionForQuery, getCachedProjection } from "../umap-projection";
 import {
@@ -2524,6 +2524,8 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		if (aggregateBudgetInput !== undefined && aggregateBudget === null) {
 			return c.json({ error: "Invalid aggregateBudget. Expected one of: small, medium, large." }, 400);
 		}
+		const temporalTimeError = validateTemporalTimeOptions(body.time);
+		if (temporalTimeError) return c.json({ error: temporalTimeError }, 400);
 
 		const aggregateSaveRequested =
 			body.aggregate === true && body.saveAggregate !== false && body.save_aggregate !== false;

--- a/platform/daemon/src/temporal-recall.ts
+++ b/platform/daemon/src/temporal-recall.ts
@@ -157,10 +157,6 @@ interface RawTemporalRow {
 	readonly source_rank: number;
 }
 
-function pad(value: number): string {
-	return String(value).padStart(2, "0");
-}
-
 function localDayRange(year: number, month: number, day: number): { start: string; end: string } | null {
 	const start = new Date(year, month - 1, day);
 	if (start.getFullYear() !== year || start.getMonth() !== month - 1 || start.getDate() !== day) return null;

--- a/platform/daemon/src/temporal-recall.ts
+++ b/platform/daemon/src/temporal-recall.ts
@@ -328,6 +328,23 @@ function memoryVisibilitySql(params: TemporalRecallParams): { sql: string; args:
 	);
 }
 
+function temporalOwnerSql(column: string, params: TemporalRecallParams): { sql: string; args: unknown[] } {
+	const agentId = params.agentId ?? "default";
+	if (params.readPolicy === "shared") {
+		return {
+			sql: ` AND (${column} = ? OR ${column} IN (SELECT id FROM agents WHERE read_policy = 'shared'))`,
+			args: [agentId],
+		};
+	}
+	if (params.readPolicy === "group" && params.policyGroup) {
+		return {
+			sql: ` AND (${column} = ? OR ${column} IN (SELECT id FROM agents WHERE policy_group = ?))`,
+			args: [agentId, params.policyGroup],
+		};
+	}
+	return { sql: ` AND ${column} = ?`, args: [agentId] };
+}
+
 function shorten(content: string, maxChars: number): { content: string; truncated: boolean; length: number } {
 	const oneLine = content.replace(/\s+/g, " ").trim();
 	return {
@@ -372,18 +389,19 @@ function collectTemporalRows(intent: ParsedTemporalIntent, params: TemporalRecal
 
 	return getDbAccessor().withReadDb((db) => {
 		if (temporalFacetAllowed(intent.facets, "session") && tableExists(db, "session_summaries")) {
+			const owner = temporalOwnerSql("agent_id", params);
 			const project = projectSql(params.project, "project");
 			const sessionRows = db
 				.prepare(
 					`SELECT id, content, project, session_key, harness, earliest_at, latest_at, created_at
 					 FROM session_summaries
-					 WHERE agent_id = ?
+					 WHERE 1 = 1${owner.sql}
 					   AND COALESCE(source_type, kind) != 'chunk'
 					   AND ${overlapClause("earliest_at", "latest_at")}${project.sql}
 					 ORDER BY latest_at DESC
 					 LIMIT ?`,
 				)
-				.all(agentId, intent.end, intent.start, ...project.args, params.limit * 6) as Array<{
+				.all(...owner.args, intent.end, intent.start, ...project.args, params.limit * 6) as Array<{
 				id: string;
 				content: string;
 				project: string | null;
@@ -469,20 +487,21 @@ function collectTemporalRows(intent: ParsedTemporalIntent, params: TemporalRecal
 		}
 
 		if (tableExists(db, "memory_artifacts")) {
+			const owner = temporalOwnerSql("agent_id", params);
 			const project = projectSql(params.project, "project");
 			if (temporalFacetAllowed(intent.facets, "captured")) {
 				const artifactRows = db
 					.prepare(
 						`SELECT rowid, source_path, source_kind, source_id, harness, project, content, captured_at, updated_at
 						 FROM memory_artifacts
-						 WHERE agent_id = ?
+						 WHERE 1 = 1${owner.sql}
 						   AND COALESCE(is_deleted, 0) = 0
 						   AND captured_at >= ?
 						   AND captured_at < ?${project.sql}
 						 ORDER BY captured_at DESC
 						 LIMIT ?`,
 					)
-					.all(agentId, intent.start, intent.end, ...project.args, params.limit * 4) as Array<{
+					.all(...owner.args, intent.start, intent.end, ...project.args, params.limit * 4) as Array<{
 					rowid: number;
 					source_path: string;
 					source_kind: string;
@@ -523,7 +542,7 @@ function collectTemporalRows(intent: ParsedTemporalIntent, params: TemporalRecal
 						`SELECT rowid, source_path, source_kind, source_id, harness, project, content,
 						        ${sourceAtExpr} AS source_at
 						 FROM memory_artifacts
-						 WHERE agent_id = ?
+						 WHERE 1 = 1${owner.sql}
 						   AND COALESCE(is_deleted, 0) = 0
 						   AND source_mtime_ms IS NOT NULL
 						   AND ${sourceAtExpr} >= ?
@@ -531,7 +550,7 @@ function collectTemporalRows(intent: ParsedTemporalIntent, params: TemporalRecal
 						 ORDER BY source_at DESC
 						 LIMIT ?`,
 					)
-					.all(agentId, intent.start, intent.end, ...project.args, params.limit * 4) as Array<{
+					.all(...owner.args, intent.start, intent.end, ...project.args, params.limit * 4) as Array<{
 					rowid: number;
 					source_path: string;
 					source_kind: string;

--- a/platform/daemon/src/temporal-recall.ts
+++ b/platform/daemon/src/temporal-recall.ts
@@ -1,0 +1,715 @@
+import type { RecallTemporalMeta, TemporalFacet } from "@signet/core";
+import { getDbAccessor } from "./db-accessor";
+import { buildAgentScopeClause } from "./memory-access-scope";
+
+const DEFAULT_TEMPORAL_FACETS: readonly TemporalFacet[] = [
+	"session",
+	"source",
+	"occurred",
+	"observed",
+	"valid",
+	"captured",
+];
+
+const WEAK_TEMPORAL_TERMS = new Set([
+	"what",
+	"were",
+	"was",
+	"we",
+	"you",
+	"i",
+	"doing",
+	"did",
+	"do",
+	"on",
+	"in",
+	"at",
+	"the",
+	"that",
+	"day",
+	"date",
+	"tell",
+	"me",
+	"about",
+	"working",
+	"worked",
+]);
+
+const MONTHS = new Map([
+	["january", 1],
+	["jan", 1],
+	["february", 2],
+	["feb", 2],
+	["march", 3],
+	["mar", 3],
+	["april", 4],
+	["apr", 4],
+	["may", 5],
+	["june", 6],
+	["jun", 6],
+	["july", 7],
+	["jul", 7],
+	["august", 8],
+	["aug", 8],
+	["september", 9],
+	["sep", 9],
+	["sept", 9],
+	["october", 10],
+	["oct", 10],
+	["november", 11],
+	["nov", 11],
+	["december", 12],
+	["dec", 12],
+]);
+
+export interface TemporalTimeOptions {
+	readonly start?: string;
+	readonly end?: string;
+	readonly facets?: readonly TemporalFacet[];
+	readonly mode?: "auto" | "timeline" | "filter";
+}
+
+export interface TemporalRecallParams {
+	readonly query: string;
+	readonly time?: TemporalTimeOptions;
+	readonly limit: number;
+	readonly agentId?: string;
+	readonly readPolicy?: string;
+	readonly policyGroup?: string | null;
+	readonly project?: string;
+	readonly sessionKey?: string;
+}
+
+export interface TemporalRecallResult {
+	readonly response?: {
+		readonly results: readonly TemporalRecallRow[];
+		readonly query: string;
+		readonly method: "keyword";
+		readonly meta: {
+			readonly totalReturned: number;
+			readonly hasSupplementary: boolean;
+			readonly noHits: boolean;
+			readonly temporal: RecallTemporalMeta;
+		};
+	};
+	readonly adjustedQuery?: string;
+	readonly meta?: RecallTemporalMeta;
+	readonly candidateIds?: readonly string[];
+}
+
+export interface TemporalRecallRow {
+	readonly id: string;
+	readonly content: string;
+	readonly content_length: number;
+	readonly truncated: boolean;
+	readonly score: number;
+	readonly source: string;
+	readonly source_id?: string;
+	readonly session_id?: string;
+	readonly source_path?: string;
+	readonly type: string;
+	readonly tags: string | null;
+	readonly pinned: boolean;
+	readonly importance: number;
+	readonly who: string;
+	readonly project: string | null;
+	readonly created_at: string;
+	readonly visibility?: string | null;
+	readonly scope?: string | null;
+	readonly temporal_facet: TemporalFacet;
+	readonly temporal_start_at: string;
+	readonly temporal_end_at?: string | null;
+	readonly subject_type: string;
+	readonly subject_id: string;
+}
+
+interface ParsedTemporalIntent {
+	readonly start: string;
+	readonly end: string;
+	readonly source: "query" | "request";
+	readonly contentQuery: string;
+	readonly mode: "timeline" | "filter";
+	readonly facets: readonly TemporalFacet[];
+}
+
+interface RawTemporalRow {
+	readonly id: string;
+	readonly content: string;
+	readonly project: string | null;
+	readonly created_at: string;
+	readonly source_id?: string | null;
+	readonly session_id?: string | null;
+	readonly source_path?: string | null;
+	readonly type: string;
+	readonly who: string;
+	readonly importance: number;
+	readonly pinned: boolean;
+	readonly tags: string | null;
+	readonly visibility?: string | null;
+	readonly scope?: string | null;
+	readonly facet: TemporalFacet;
+	readonly start_at: string;
+	readonly end_at: string | null;
+	readonly subject_type: string;
+	readonly subject_id: string;
+	readonly source_rank: number;
+}
+
+function pad(value: number): string {
+	return String(value).padStart(2, "0");
+}
+
+function localDayRange(year: number, month: number, day: number): { start: string; end: string } | null {
+	const start = new Date(year, month - 1, day);
+	if (start.getFullYear() !== year || start.getMonth() !== month - 1 || start.getDate() !== day) return null;
+	const end = new Date(year, month - 1, day + 1);
+	return { start: start.toISOString(), end: end.toISOString() };
+}
+
+function parseExplicitDay(raw: string): { range: { start: string; end: string }; matched: string } | null {
+	const numeric = raw.match(/\b(\d{4})[/-](\d{1,2})[/-](\d{1,2})\b/);
+	if (numeric) {
+		const year = Number.parseInt(numeric[1] ?? "", 10);
+		const month = Number.parseInt(numeric[2] ?? "", 10);
+		const day = Number.parseInt(numeric[3] ?? "", 10);
+		const range = localDayRange(year, month, day);
+		return range ? { range, matched: numeric[0] } : null;
+	}
+
+	const named = raw.match(
+		/\b(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t|tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+(\d{1,2})(?:st|nd|rd|th)?[,]?\s+(\d{4})\b/i,
+	);
+	if (!named) return null;
+	const month = MONTHS.get((named[1] ?? "").toLowerCase());
+	if (!month) return null;
+	const day = Number.parseInt(named[2] ?? "", 10);
+	const year = Number.parseInt(named[3] ?? "", 10);
+	const range = localDayRange(year, month, day);
+	return range ? { range, matched: named[0] } : null;
+}
+
+function normalizeContentQuery(query: string, matched: string): string {
+	const withoutDate = query.replace(matched, " ");
+	const words = withoutDate
+		.toLowerCase()
+		.split(/\W+/)
+		.map((word) => word.trim())
+		.filter((word) => word.length > 0 && !WEAK_TEMPORAL_TERMS.has(word));
+	return words.join(" ");
+}
+
+function normalizeFacets(input: readonly TemporalFacet[] | undefined): readonly TemporalFacet[] {
+	if (!input || input.length === 0) return DEFAULT_TEMPORAL_FACETS;
+	const allowed = new Set(DEFAULT_TEMPORAL_FACETS);
+	const facets = [...new Set(input.filter((facet) => allowed.has(facet)))];
+	return facets.length > 0 ? facets : DEFAULT_TEMPORAL_FACETS;
+}
+
+function parseTimeRange(time: TemporalTimeOptions | undefined): { start: string; end: string } | null {
+	if (!time?.start) return null;
+	const startDate = new Date(time.start);
+	if (Number.isNaN(startDate.getTime())) return null;
+	if (time.end) {
+		const endDate = new Date(time.end);
+		if (Number.isNaN(endDate.getTime())) return null;
+		return { start: startDate.toISOString(), end: endDate.toISOString() };
+	}
+	const endDate = new Date(startDate.getTime() + 86_400_000);
+	return { start: startDate.toISOString(), end: endDate.toISOString() };
+}
+
+export function parseTemporalRecallIntent(params: {
+	readonly query: string;
+	readonly time?: TemporalTimeOptions;
+}): ParsedTemporalIntent | null {
+	const requestRange = parseTimeRange(params.time);
+	if (requestRange) {
+		const contentQuery = params.query.trim();
+		return {
+			...requestRange,
+			source: "request",
+			contentQuery,
+			mode: params.time?.mode === "filter" || contentQuery.length > 0 ? "filter" : "timeline",
+			facets: normalizeFacets(params.time?.facets),
+		};
+	}
+
+	const parsed = parseExplicitDay(params.query);
+	if (!parsed) return null;
+	const contentQuery = normalizeContentQuery(params.query, parsed.matched);
+	return {
+		...parsed.range,
+		source: "query",
+		contentQuery,
+		mode: params.time?.mode === "filter" || contentQuery.length > 0 ? "filter" : "timeline",
+		facets: normalizeFacets(params.time?.facets),
+	};
+}
+
+function tableExists(db: { prepare(sql: string): { get(...args: unknown[]): unknown } }, name: string): boolean {
+	return db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(name) !== undefined;
+}
+
+function columnExists(
+	db: { prepare(sql: string): { all(...args: unknown[]): Record<string, unknown>[] } },
+	table: string,
+	column: string,
+): boolean {
+	return db
+		.prepare(`PRAGMA table_info(${table})`)
+		.all()
+		.some((row) => row.name === column);
+}
+
+function overlapClause(startExpr: string, endExpr: string): string {
+	return `${startExpr} < ? AND COALESCE(${endExpr}, ${startExpr}) >= ?`;
+}
+
+function textMatches(content: string, query: string): boolean {
+	if (!query) return true;
+	const lower = content.toLowerCase();
+	return query
+		.split(/\s+/)
+		.filter((term) => term.length > 0)
+		.every((term) => lower.includes(term));
+}
+
+function projectSql(project: string | undefined, column = "project"): { sql: string; args: unknown[] } {
+	if (!project) return { sql: "", args: [] };
+	return { sql: ` AND ${column} = ?`, args: [project] };
+}
+
+function temporalFacetAllowed(facets: readonly TemporalFacet[], facet: TemporalFacet): boolean {
+	return facets.includes(facet);
+}
+
+function memoryVisibilitySql(params: TemporalRecallParams): { sql: string; args: unknown[] } {
+	return buildAgentScopeClause(
+		params.agentId ?? "default",
+		params.readPolicy ?? "isolated",
+		params.policyGroup ?? null,
+	);
+}
+
+function shorten(content: string, maxChars: number): { content: string; truncated: boolean; length: number } {
+	const oneLine = content.replace(/\s+/g, " ").trim();
+	return {
+		content: oneLine.length > maxChars ? `${oneLine.slice(0, maxChars - 12).trim()} [truncated]` : oneLine,
+		truncated: oneLine.length > maxChars,
+		length: oneLine.length,
+	};
+}
+
+function toRecallRow(row: RawTemporalRow): TemporalRecallRow {
+	const shortened = shorten(row.content, 900);
+	return {
+		id: `temporal:${row.subject_type}:${row.subject_id}:${row.facet}`,
+		content: shortened.content,
+		content_length: shortened.length,
+		truncated: shortened.truncated,
+		score: row.source_rank,
+		source: `temporal_${row.facet}`,
+		...(row.source_id ? { source_id: row.source_id } : {}),
+		...(row.session_id ? { session_id: row.session_id } : {}),
+		...(row.source_path ? { source_path: row.source_path } : {}),
+		type: row.type,
+		tags: row.tags,
+		pinned: row.pinned,
+		importance: row.importance,
+		who: row.who,
+		project: row.project,
+		created_at: row.created_at,
+		visibility: row.visibility,
+		scope: row.scope,
+		temporal_facet: row.facet,
+		temporal_start_at: row.start_at,
+		temporal_end_at: row.end_at,
+		subject_type: row.subject_type,
+		subject_id: row.subject_id,
+	};
+}
+
+function collectTemporalRows(intent: ParsedTemporalIntent, params: TemporalRecallParams): RawTemporalRow[] {
+	const agentId = params.agentId ?? "default";
+	const rows: RawTemporalRow[] = [];
+
+	return getDbAccessor().withReadDb((db) => {
+		if (temporalFacetAllowed(intent.facets, "session") && tableExists(db, "session_summaries")) {
+			const project = projectSql(params.project, "project");
+			const sessionRows = db
+				.prepare(
+					`SELECT id, content, project, session_key, harness, earliest_at, latest_at, created_at
+					 FROM session_summaries
+					 WHERE agent_id = ?
+					   AND COALESCE(source_type, kind) != 'chunk'
+					   AND ${overlapClause("earliest_at", "latest_at")}${project.sql}
+					 ORDER BY latest_at DESC
+					 LIMIT ?`,
+				)
+				.all(agentId, intent.end, intent.start, ...project.args, params.limit * 6) as Array<{
+				id: string;
+				content: string;
+				project: string | null;
+				session_key: string | null;
+				harness: string | null;
+				earliest_at: string;
+				latest_at: string;
+				created_at: string;
+			}>;
+			for (const row of sessionRows) {
+				rows.push({
+					id: row.id,
+					content: row.content,
+					project: row.project,
+					created_at: row.created_at,
+					session_id: row.session_key,
+					type: "session",
+					who: row.harness ?? "session",
+					importance: 0.8,
+					pinned: false,
+					tags: "temporal,session",
+					facet: "session",
+					start_at: row.earliest_at,
+					end_at: row.latest_at,
+					subject_type: "session_summary",
+					subject_id: row.id,
+					source_rank: 1,
+				});
+			}
+		}
+
+		if (temporalFacetAllowed(intent.facets, "session") && tableExists(db, "session_transcripts")) {
+			const updatedExpr = columnExists(db, "session_transcripts", "updated_at")
+				? "COALESCE(updated_at, created_at)"
+				: "created_at";
+			const project = projectSql(params.project, "project");
+			const transcriptRows = db
+				.prepare(
+					`SELECT session_key, content, harness, project, created_at, ${updatedExpr} AS end_at
+					 FROM session_transcripts
+					 WHERE agent_id = ?
+					   AND ${overlapClause("created_at", updatedExpr)}${project.sql}
+					 ORDER BY end_at DESC
+					 LIMIT ?`,
+				)
+				.all(agentId, intent.end, intent.start, ...project.args, params.limit * 4) as Array<{
+				session_key: string;
+				content: string;
+				harness: string | null;
+				project: string | null;
+				created_at: string;
+				end_at: string;
+			}>;
+			for (const row of transcriptRows) {
+				rows.push({
+					id: row.session_key,
+					content: row.content,
+					project: row.project,
+					created_at: row.created_at,
+					session_id: row.session_key,
+					type: "transcript",
+					who: row.harness ?? "session",
+					importance: 0.65,
+					pinned: false,
+					tags: "temporal,transcript",
+					facet: "session",
+					start_at: row.created_at,
+					end_at: row.end_at,
+					subject_type: "session_transcript",
+					subject_id: row.session_key,
+					source_rank: 0.9,
+				});
+			}
+		}
+
+		if (temporalFacetAllowed(intent.facets, "captured") && tableExists(db, "memories")) {
+			const visibility = memoryVisibilitySql(params);
+			const project = projectSql(params.project, "m.project");
+			const memoryRows = db
+				.prepare(
+					`SELECT m.id, m.content, m.source_id, m.type, m.tags, m.pinned, m.importance, m.who, m.project,
+					        m.created_at, m.visibility, m.scope
+					 FROM memories m
+					 WHERE m.is_deleted = 0
+					   AND m.scope IS NULL
+					   AND m.created_at >= ?
+					   AND m.created_at < ?${visibility.sql}${project.sql}
+					 ORDER BY m.created_at DESC
+					 LIMIT ?`,
+				)
+				.all(intent.start, intent.end, ...visibility.args, ...project.args, params.limit * 4) as Array<{
+				id: string;
+				content: string;
+				source_id: string | null;
+				type: string;
+				tags: string | null;
+				pinned: number;
+				importance: number;
+				who: string;
+				project: string | null;
+				created_at: string;
+				visibility: string | null;
+				scope: string | null;
+			}>;
+			for (const row of memoryRows) {
+				rows.push({
+					id: row.id,
+					content: row.content,
+					project: row.project,
+					created_at: row.created_at,
+					source_id: row.source_id,
+					type: row.type,
+					who: row.who,
+					importance: row.importance,
+					pinned: row.pinned === 1,
+					tags: row.tags,
+					visibility: row.visibility,
+					scope: row.scope,
+					facet: "captured",
+					start_at: row.created_at,
+					end_at: row.created_at,
+					subject_type: "memory",
+					subject_id: row.id,
+					source_rank: 0.7,
+				});
+			}
+		}
+
+		if (tableExists(db, "memory_artifacts")) {
+			const project = projectSql(params.project, "project");
+			if (temporalFacetAllowed(intent.facets, "captured")) {
+				const artifactRows = db
+					.prepare(
+						`SELECT rowid, source_path, source_kind, source_id, harness, project, content, captured_at, updated_at
+						 FROM memory_artifacts
+						 WHERE agent_id = ?
+						   AND COALESCE(is_deleted, 0) = 0
+						   AND captured_at >= ?
+						   AND captured_at < ?${project.sql}
+						 ORDER BY captured_at DESC
+						 LIMIT ?`,
+					)
+					.all(agentId, intent.start, intent.end, ...project.args, params.limit * 4) as Array<{
+					rowid: number;
+					source_path: string;
+					source_kind: string;
+					source_id: string | null;
+					harness: string | null;
+					project: string | null;
+					content: string;
+					captured_at: string;
+					updated_at: string;
+				}>;
+				for (const row of artifactRows) {
+					rows.push({
+						id: String(row.rowid),
+						content: `[Source artifact: ${row.source_path}]\n${row.content}`,
+						project: row.project,
+						created_at: row.captured_at,
+						source_id: row.source_id,
+						source_path: row.source_path,
+						type: row.source_kind,
+						who: row.harness ?? "source",
+						importance: 0.55,
+						pinned: false,
+						tags: "temporal,source",
+						facet: "captured",
+						start_at: row.captured_at,
+						end_at: row.updated_at,
+						subject_type: "memory_artifact",
+						subject_id: String(row.rowid),
+						source_rank: 0.6,
+					});
+				}
+			}
+
+			if (temporalFacetAllowed(intent.facets, "source") && columnExists(db, "memory_artifacts", "source_mtime_ms")) {
+				const sourceAtExpr = "strftime('%Y-%m-%dT%H:%M:%fZ', source_mtime_ms / 1000, 'unixepoch')";
+				const sourceRows = db
+					.prepare(
+						`SELECT rowid, source_path, source_kind, source_id, harness, project, content,
+						        ${sourceAtExpr} AS source_at
+						 FROM memory_artifacts
+						 WHERE agent_id = ?
+						   AND COALESCE(is_deleted, 0) = 0
+						   AND source_mtime_ms IS NOT NULL
+						   AND ${sourceAtExpr} >= ?
+						   AND ${sourceAtExpr} < ?${project.sql}
+						 ORDER BY source_at DESC
+						 LIMIT ?`,
+					)
+					.all(agentId, intent.start, intent.end, ...project.args, params.limit * 4) as Array<{
+					rowid: number;
+					source_path: string;
+					source_kind: string;
+					source_id: string | null;
+					harness: string | null;
+					project: string | null;
+					content: string;
+					source_at: string;
+				}>;
+				for (const row of sourceRows) {
+					rows.push({
+						id: String(row.rowid),
+						content: `[Source artifact: ${row.source_path}]\n${row.content}`,
+						project: row.project,
+						created_at: row.source_at,
+						source_id: row.source_id,
+						source_path: row.source_path,
+						type: row.source_kind,
+						who: row.harness ?? "source",
+						importance: 0.6,
+						pinned: false,
+						tags: "temporal,source",
+						facet: "source",
+						start_at: row.source_at,
+						end_at: row.source_at,
+						subject_type: "memory_artifact",
+						subject_id: String(row.rowid),
+						source_rank: 0.8,
+					});
+				}
+			}
+		}
+
+		if (tableExists(db, "temporal_edges")) {
+			const visibility = memoryVisibilitySql(params);
+			const edgeRows = db
+				.prepare(
+					`SELECT te.id, te.subject_type, te.subject_id, te.facet, te.start_at, te.end_at, te.confidence,
+					        m.content AS memory_content, m.source_id, m.type AS memory_type, m.tags, m.pinned,
+					        m.importance, m.who, m.project, m.created_at, m.visibility, m.scope
+					 FROM temporal_edges te
+					 LEFT JOIN memories m
+					   ON te.subject_type = 'memory'
+					  AND m.id = te.subject_id
+					  AND m.is_deleted = 0
+					 WHERE te.agent_id = ?
+					   AND te.facet IN (${intent.facets.map(() => "?").join(", ")})
+					   AND ${overlapClause("te.start_at", "te.end_at")}
+					   AND (te.subject_type != 'memory' OR (m.id IS NOT NULL AND m.scope IS NULL${visibility.sql}))
+					 ORDER BY te.start_at DESC
+					 LIMIT ?`,
+				)
+				.all(agentId, ...intent.facets, intent.end, intent.start, ...visibility.args, params.limit * 4) as Array<{
+				id: string;
+				subject_type: string;
+				subject_id: string;
+				facet: TemporalFacet;
+				start_at: string;
+				end_at: string | null;
+				confidence: number;
+				memory_content: string | null;
+				source_id: string | null;
+				memory_type: string | null;
+				tags: string | null;
+				pinned: number | null;
+				importance: number | null;
+				who: string | null;
+				project: string | null;
+				created_at: string | null;
+				visibility: string | null;
+				scope: string | null;
+			}>;
+			for (const row of edgeRows) {
+				if (params.project && row.project !== params.project) continue;
+				rows.push({
+					id: row.id,
+					content: row.memory_content ?? `[Temporal ${row.facet}: ${row.subject_type} ${row.subject_id}]`,
+					project: row.project,
+					created_at: row.created_at ?? row.start_at,
+					source_id: row.source_id,
+					type: row.memory_type ?? row.subject_type,
+					who: row.who ?? "temporal",
+					importance: row.importance ?? 0.65,
+					pinned: row.pinned === 1,
+					tags: row.tags,
+					visibility: row.visibility,
+					scope: row.scope,
+					facet: row.facet,
+					start_at: row.start_at,
+					end_at: row.end_at,
+					subject_type: row.subject_type,
+					subject_id: row.subject_id,
+					source_rank: Math.max(0.1, Math.min(1, row.confidence)),
+				});
+			}
+		}
+
+		return rows;
+	});
+}
+
+export function resolveTemporalRecall(params: TemporalRecallParams): TemporalRecallResult {
+	const intent = parseTemporalRecallIntent({ query: params.query, time: params.time });
+	if (!intent) return {};
+	const meta: RecallTemporalMeta = {
+		mode: intent.mode,
+		source: intent.source,
+		originalQuery: params.query,
+		contentQuery: intent.contentQuery,
+		start: intent.start,
+		end: intent.end,
+		facets: intent.facets,
+	};
+
+	const rows = collectTemporalRows(intent, params)
+		.filter((row) => textMatches(row.content, intent.contentQuery))
+		.sort(
+			(a, b) =>
+				b.source_rank - a.source_rank ||
+				b.start_at.localeCompare(a.start_at) ||
+				a.subject_type.localeCompare(b.subject_type),
+		);
+
+	const deduped: RawTemporalRow[] = [];
+	const seen = new Set<string>();
+	for (const row of rows) {
+		const key = `${row.subject_type}:${row.subject_id}:${row.facet}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
+		deduped.push(row);
+		if (deduped.length >= params.limit) break;
+	}
+
+	if (intent.mode === "filter" && intent.contentQuery.length > 0) {
+		const memoryIds = deduped.filter((row) => row.subject_type === "memory").map((row) => row.subject_id);
+		if (memoryIds.length > 0) {
+			return { adjustedQuery: intent.contentQuery, meta, candidateIds: memoryIds };
+		}
+	}
+
+	const results = deduped.map(toRecallRow);
+	return {
+		response: {
+			results,
+			query: params.query,
+			method: "keyword",
+			meta: {
+				totalReturned: results.length,
+				hasSupplementary: false,
+				noHits: results.length === 0,
+				temporal: meta,
+			},
+		},
+	};
+}
+
+export function createTemporalEdgeId(input: {
+	readonly agentId: string;
+	readonly subjectType: string;
+	readonly subjectId: string;
+	readonly facet: TemporalFacet;
+	readonly startAt: string;
+}): string {
+	return ["temporal", input.agentId, input.subjectType, input.subjectId, input.facet, input.startAt]
+		.join(":")
+		.replace(/[^a-zA-Z0-9:._-]+/g, "-");
+}
+
+export function normalizeTemporalTimestamp(value: unknown): string | null {
+	if (typeof value !== "string" || value.trim().length === 0) return null;
+	const parsed = new Date(value);
+	if (Number.isNaN(parsed.getTime())) return null;
+	return parsed.toISOString();
+}

--- a/platform/daemon/src/temporal-recall.ts
+++ b/platform/daemon/src/temporal-recall.ts
@@ -330,12 +330,6 @@ function memoryVisibilitySql(params: TemporalRecallParams): { sql: string; args:
 
 function temporalOwnerSql(column: string, params: TemporalRecallParams): { sql: string; args: unknown[] } {
 	const agentId = params.agentId ?? "default";
-	if (params.readPolicy === "shared") {
-		return {
-			sql: ` AND (${column} = ? OR ${column} IN (SELECT id FROM agents WHERE read_policy = 'shared'))`,
-			args: [agentId],
-		};
-	}
 	if (params.readPolicy === "group" && params.policyGroup) {
 		return {
 			sql: ` AND (${column} = ? OR ${column} IN (SELECT id FROM agents WHERE policy_group = ?))`,

--- a/platform/daemon/src/temporal-recall.ts
+++ b/platform/daemon/src/temporal-recall.ts
@@ -216,6 +216,14 @@ function parseTimeRange(time: TemporalTimeOptions | undefined): { start: string;
 	return { start: startDate.toISOString(), end: endDate.toISOString() };
 }
 
+function resolveTemporalMode(
+	mode: TemporalTimeOptions["mode"] | undefined,
+	contentQuery: string,
+): ParsedTemporalIntent["mode"] {
+	if (mode === "timeline" || mode === "filter") return mode;
+	return contentQuery.length > 0 ? "filter" : "timeline";
+}
+
 export function validateTemporalTimeOptions(time: unknown): string | null {
 	if (time === undefined) return null;
 	if (typeof time !== "object" || time === null || Array.isArray(time)) return "time must be an object";
@@ -258,7 +266,7 @@ export function parseTemporalRecallIntent(params: {
 			...requestRange,
 			source: "request",
 			contentQuery,
-			mode: params.time?.mode === "filter" || contentQuery.length > 0 ? "filter" : "timeline",
+			mode: resolveTemporalMode(params.time?.mode, contentQuery),
 			facets: normalizeFacets(params.time?.facets),
 		};
 	}
@@ -270,7 +278,7 @@ export function parseTemporalRecallIntent(params: {
 		...parsed.range,
 		source: "query",
 		contentQuery,
-		mode: params.time?.mode === "filter" || contentQuery.length > 0 ? "filter" : "timeline",
+		mode: resolveTemporalMode(params.time?.mode, contentQuery),
 		facets: normalizeFacets(params.time?.facets),
 	};
 }
@@ -639,7 +647,7 @@ export function resolveTemporalRecall(params: TemporalRecallParams): TemporalRec
 	};
 
 	const rows = collectTemporalRows(intent, params)
-		.filter((row) => textMatches(row.content, intent.contentQuery))
+		.filter((row) => intent.mode !== "filter" || textMatches(row.content, intent.contentQuery))
 		.sort(
 			(a, b) =>
 				b.source_rank - a.source_rank ||

--- a/platform/daemon/src/temporal-recall.ts
+++ b/platform/daemon/src/temporal-recall.ts
@@ -10,6 +10,8 @@ const DEFAULT_TEMPORAL_FACETS: readonly TemporalFacet[] = [
 	"valid",
 	"captured",
 ];
+const TEMPORAL_FACET_SET = new Set<string>(DEFAULT_TEMPORAL_FACETS);
+const TEMPORAL_MODES = new Set(["auto", "timeline", "filter"]);
 
 const WEAK_TEMPORAL_TERMS = new Set([
 	"what",
@@ -218,6 +220,37 @@ function parseTimeRange(time: TemporalTimeOptions | undefined): { start: string;
 	return { start: startDate.toISOString(), end: endDate.toISOString() };
 }
 
+export function validateTemporalTimeOptions(time: unknown): string | null {
+	if (time === undefined) return null;
+	if (typeof time !== "object" || time === null || Array.isArray(time)) return "time must be an object";
+	const options = time as Record<string, unknown>;
+	if (typeof options.start !== "string" || options.start.trim().length === 0) {
+		return "time.start is required when time is provided";
+	}
+	const startDate = new Date(options.start);
+	if (Number.isNaN(startDate.getTime())) return "time.start must be a valid ISO timestamp";
+	if (options.end !== undefined) {
+		if (typeof options.end !== "string" || options.end.trim().length === 0) {
+			return "time.end must be a valid ISO timestamp";
+		}
+		const endDate = new Date(options.end);
+		if (Number.isNaN(endDate.getTime())) return "time.end must be a valid ISO timestamp";
+		if (endDate.getTime() <= startDate.getTime()) return "time.end must be after time.start";
+	}
+	if (options.facets !== undefined) {
+		if (!Array.isArray(options.facets)) return "time.facets must be an array";
+		for (const facet of options.facets) {
+			if (typeof facet !== "string" || !TEMPORAL_FACET_SET.has(facet)) {
+				return "time.facets entries must be one of: session, source, captured, observed, occurred, valid";
+			}
+		}
+	}
+	if (options.mode !== undefined && (typeof options.mode !== "string" || !TEMPORAL_MODES.has(options.mode))) {
+		return "time.mode must be one of: auto, timeline, filter";
+	}
+	return null;
+}
+
 export function parseTemporalRecallIntent(params: {
 	readonly query: string;
 	readonly time?: TemporalTimeOptions;
@@ -374,50 +407,6 @@ function collectTemporalRows(intent: ParsedTemporalIntent, params: TemporalRecal
 					subject_type: "session_summary",
 					subject_id: row.id,
 					source_rank: 1,
-				});
-			}
-		}
-
-		if (temporalFacetAllowed(intent.facets, "session") && tableExists(db, "session_transcripts")) {
-			const updatedExpr = columnExists(db, "session_transcripts", "updated_at")
-				? "COALESCE(updated_at, created_at)"
-				: "created_at";
-			const project = projectSql(params.project, "project");
-			const transcriptRows = db
-				.prepare(
-					`SELECT session_key, content, harness, project, created_at, ${updatedExpr} AS end_at
-					 FROM session_transcripts
-					 WHERE agent_id = ?
-					   AND ${overlapClause("created_at", updatedExpr)}${project.sql}
-					 ORDER BY end_at DESC
-					 LIMIT ?`,
-				)
-				.all(agentId, intent.end, intent.start, ...project.args, params.limit * 4) as Array<{
-				session_key: string;
-				content: string;
-				harness: string | null;
-				project: string | null;
-				created_at: string;
-				end_at: string;
-			}>;
-			for (const row of transcriptRows) {
-				rows.push({
-					id: row.session_key,
-					content: row.content,
-					project: row.project,
-					created_at: row.created_at,
-					session_id: row.session_key,
-					type: "transcript",
-					who: row.harness ?? "session",
-					importance: 0.65,
-					pinned: false,
-					tags: "temporal,transcript",
-					facet: "session",
-					start_at: row.created_at,
-					end_at: row.end_at,
-					subject_type: "session_transcript",
-					subject_id: row.session_key,
-					source_rank: 0.9,
 				});
 			}
 		}

--- a/platform/daemon/src/temporal-recall.ts
+++ b/platform/daemon/src/temporal-recall.ts
@@ -384,7 +384,6 @@ function toRecallRow(row: RawTemporalRow): TemporalRecallRow {
 }
 
 function collectTemporalRows(intent: ParsedTemporalIntent, params: TemporalRecallParams): RawTemporalRow[] {
-	const agentId = params.agentId ?? "default";
 	const rows: RawTemporalRow[] = [];
 
 	return getDbAccessor().withReadDb((db) => {
@@ -586,6 +585,7 @@ function collectTemporalRows(intent: ParsedTemporalIntent, params: TemporalRecal
 
 		if (tableExists(db, "temporal_edges")) {
 			const visibility = memoryVisibilitySql(params);
+			const nonMemoryOwner = temporalOwnerSql("te.agent_id", params);
 			const edgeRows = db
 				.prepare(
 					`SELECT te.id, te.subject_type, te.subject_id, te.facet, te.start_at, te.end_at, te.confidence,
@@ -596,14 +596,23 @@ function collectTemporalRows(intent: ParsedTemporalIntent, params: TemporalRecal
 					   ON te.subject_type = 'memory'
 					  AND m.id = te.subject_id
 					  AND m.is_deleted = 0
-					 WHERE te.agent_id = ?
-					   AND te.facet IN (${intent.facets.map(() => "?").join(", ")})
+					 WHERE te.facet IN (${intent.facets.map(() => "?").join(", ")})
 					   AND ${overlapClause("te.start_at", "te.end_at")}
-					   AND (te.subject_type != 'memory' OR (m.id IS NOT NULL AND m.scope IS NULL${visibility.sql}))
+					   AND (
+					     (te.subject_type = 'memory' AND m.id IS NOT NULL AND m.scope IS NULL${visibility.sql})
+					     OR (te.subject_type != 'memory'${nonMemoryOwner.sql})
+					   )
 					 ORDER BY te.start_at DESC
 					 LIMIT ?`,
 				)
-				.all(agentId, ...intent.facets, intent.end, intent.start, ...visibility.args, params.limit * 4) as Array<{
+				.all(
+					...intent.facets,
+					intent.end,
+					intent.start,
+					...visibility.args,
+					...nonMemoryOwner.args,
+					params.limit * 4,
+				) as Array<{
 				id: string;
 				subject_type: string;
 				subject_id: string;
@@ -666,7 +675,10 @@ export function resolveTemporalRecall(params: TemporalRecallParams): TemporalRec
 	};
 
 	const rows = collectTemporalRows(intent, params)
-		.filter((row) => intent.mode !== "filter" || textMatches(row.content, intent.contentQuery))
+		.filter(
+			(row) =>
+				intent.mode !== "filter" || row.subject_type === "memory" || textMatches(row.content, intent.contentQuery),
+		)
 		.sort(
 			(a, b) =>
 				b.source_rank - a.source_rank ||

--- a/platform/daemon/src/temporal-recall.ts
+++ b/platform/daemon/src/temporal-recall.ts
@@ -12,6 +12,8 @@ const DEFAULT_TEMPORAL_FACETS: readonly TemporalFacet[] = [
 ];
 const TEMPORAL_FACET_SET = new Set<string>(DEFAULT_TEMPORAL_FACETS);
 const TEMPORAL_MODES = new Set(["auto", "timeline", "filter"]);
+const TEMPORAL_FILTER_MIN_CANDIDATES = 100;
+const TEMPORAL_FILTER_LIMIT_MULTIPLIER = 20;
 
 const WEAK_TEMPORAL_TERMS = new Set([
 	"what",
@@ -318,6 +320,13 @@ function projectSql(project: string | undefined, column = "project"): { sql: str
 
 function temporalFacetAllowed(facets: readonly TemporalFacet[], facet: TemporalFacet): boolean {
 	return facets.includes(facet);
+}
+
+function temporalRowLimit(intent: ParsedTemporalIntent, resultLimit: number): number {
+	if (intent.mode === "filter" && intent.contentQuery.length > 0) {
+		return Math.max(resultLimit * TEMPORAL_FILTER_LIMIT_MULTIPLIER, TEMPORAL_FILTER_MIN_CANDIDATES);
+	}
+	return resultLimit;
 }
 
 function memoryVisibilitySql(params: TemporalRecallParams): { sql: string; args: unknown[] } {
@@ -658,6 +667,7 @@ function collectTemporalRows(intent: ParsedTemporalIntent, params: TemporalRecal
 export function resolveTemporalRecall(params: TemporalRecallParams): TemporalRecallResult {
 	const intent = parseTemporalRecallIntent({ query: params.query, time: params.time });
 	if (!intent) return {};
+	const rowLimit = temporalRowLimit(intent, params.limit);
 	const meta: RecallTemporalMeta = {
 		mode: intent.mode,
 		source: intent.source,
@@ -668,7 +678,7 @@ export function resolveTemporalRecall(params: TemporalRecallParams): TemporalRec
 		facets: intent.facets,
 	};
 
-	const rows = collectTemporalRows(intent, params)
+	const rows = collectTemporalRows(intent, { ...params, limit: rowLimit })
 		.filter(
 			(row) =>
 				intent.mode !== "filter" || row.subject_type === "memory" || textMatches(row.content, intent.contentQuery),
@@ -687,7 +697,7 @@ export function resolveTemporalRecall(params: TemporalRecallParams): TemporalRec
 		if (seen.has(key)) continue;
 		seen.add(key);
 		deduped.push(row);
-		if (deduped.length >= params.limit) break;
+		if (deduped.length >= rowLimit) break;
 	}
 
 	if (intent.mode === "filter" && intent.contentQuery.length > 0) {
@@ -697,7 +707,7 @@ export function resolveTemporalRecall(params: TemporalRecallParams): TemporalRec
 		}
 	}
 
-	const results = deduped.map(toRecallRow);
+	const results = deduped.slice(0, params.limit).map(toRecallRow);
 	return {
 		response: {
 			results,

--- a/scripts/doc-drift.ts
+++ b/scripts/doc-drift.ts
@@ -396,6 +396,20 @@ function parsePackageTable(content: string, sectionHeader: string): Map<string, 
 	return result;
 }
 
+function tableCoversDir(table: Map<string, string>, dir: string): boolean {
+	if (table.has(dir)) return true;
+	for (const key of table.keys()) {
+		if (!key.includes("*")) continue;
+		const pattern = new RegExp(`^${key.split("*").map(escapeRegex).join(".*")}$`);
+		if (pattern.test(dir)) return true;
+	}
+	return false;
+}
+
+function escapeRegex(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function checkPackageDrift(claudeMd: string): PackageTableDrift[] {
 	const actual = getActualPackages();
 	const actualDirs = new Set(actual.map((p) => p.dir));
@@ -403,11 +417,16 @@ function checkPackageDrift(claudeMd: string): PackageTableDrift[] {
 	const results: PackageTableDrift[] = [];
 
 	// CLAUDE.md
-	const claudeTable = parsePackageTable(claudeMd, "## Package map");
+	const legacyClaudeTable = parsePackageTable(claudeMd, "## Package map");
+	const claudeTable =
+		legacyClaudeTable.size > 0 ? legacyClaudeTable : parsePackageTable(claudeMd, "## Package And Directory Map");
 	results.push({
 		file: "AGENTS.md",
-		missingFromTable: actual.filter((p) => !claudeTable.has(p.dir)),
-		extraInTable: [...claudeTable.keys()].filter((dir) => !actualDirs.has(dir) && !fileExists(dir)),
+		missingFromTable: actual.filter((p) => !tableCoversDir(claudeTable, p.dir)),
+		extraInTable: [...claudeTable.keys()].filter((dir) => {
+			if (dir.includes("*")) return !actual.some((p) => tableCoversDir(new Map([[dir, ""]]), p.dir));
+			return !actualDirs.has(dir) && !fileExists(dir);
+		}),
 	});
 
 	// README.md

--- a/surfaces/cli/src/commands/memory.test.ts
+++ b/surfaces/cli/src/commands/memory.test.ts
@@ -64,6 +64,40 @@ describe("registerMemoryCommands remember", () => {
 			hints: ["What did Avery say about Signet recall?", "Can Signet recall be useful from the terminal?"],
 		});
 	});
+
+	test("forwards explicit temporal memory fields", async () => {
+		let capturedBody: unknown;
+		const program = new Command();
+		registerMemoryCommands(program, {
+			ensureDaemonForSecrets: async () => true,
+			secretApiCall: async (_method, _path, body) => {
+				capturedBody = body;
+				return {
+					ok: true,
+					data: { id: "mem-1", embedded: true },
+				};
+			},
+		});
+
+		await program.parseAsync([
+			"node",
+			"test",
+			"remember",
+			"We debugged exact date recall",
+			"--occurred-at",
+			"2026-05-13T18:00:00.000Z",
+			"--source-created-at",
+			"2026-05-13T17:00:00.000Z",
+		]);
+
+		expect(capturedBody).toEqual({
+			content: "We debugged exact date recall",
+			importance: 0.7,
+			who: "user",
+			occurredAt: "2026-05-13T18:00:00.000Z",
+			sourceCreatedAt: "2026-05-13T17:00:00.000Z",
+		});
+	});
 });
 
 describe("registerMemoryCommands recall", () => {
@@ -153,6 +187,14 @@ describe("registerMemoryCommands recall", () => {
 			"2026-01-01",
 			"--until",
 			"2026-04-01",
+			"--time-start",
+			"2026-05-13T00:00:00.000Z",
+			"--time-end",
+			"2026-05-14T00:00:00.000Z",
+			"--time-facets",
+			"session,occurred",
+			"--time-mode",
+			"timeline",
 			"--min-score",
 			"0.8",
 			"--json",
@@ -170,6 +212,12 @@ describe("registerMemoryCommands recall", () => {
 			importance_min: 0.7,
 			since: "2026-01-01",
 			until: "2026-04-01",
+			time: {
+				start: "2026-05-13T00:00:00.000Z",
+				end: "2026-05-14T00:00:00.000Z",
+				facets: ["session", "occurred"],
+				mode: "timeline",
+			},
 		});
 		expect(capturedTimeout).toBe(30_000);
 		expect(lines).toHaveLength(1);

--- a/surfaces/cli/src/commands/memory.ts
+++ b/surfaces/cli/src/commands/memory.ts
@@ -40,6 +40,11 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 		.option("--critical", "Mark as critical (pinned)", false)
 		.option("--agent <name>", "Agent ID to associate with this memory")
 		.option("--hint <hint>", "Prospective recall hint (repeatable)", collectHint)
+		.option("--occurred-at <iso>", "Event time this memory is about")
+		.option("--observed-at <iso>", "Observation time this memory records")
+		.option("--source-created-at <iso>", "Source-system creation time for this memory")
+		.option("--valid-from <iso>", "Start of validity window for this memory")
+		.option("--valid-until <iso>", "End of validity window for this memory")
 		.option("--private", "Set visibility to private", false)
 		.action(async (content: string, options) => {
 			if (!(await deps.ensureDaemonForSecrets())) return;
@@ -55,6 +60,11 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 					pinned: options.critical,
 					agentId: options.agent,
 					hints: options.hint,
+					occurredAt: options.occurredAt,
+					observedAt: options.observedAt,
+					sourceCreatedAt: options.sourceCreatedAt,
+					validFrom: options.validFrom,
+					validUntil: options.validUntil,
 					visibility: options.private ? "private" : undefined,
 				}),
 			);
@@ -91,6 +101,10 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 		.option("--who <who>", "Filter by who")
 		.option("--since <date>", "Only memories created after this date (ISO or YYYY-MM-DD)")
 		.option("--until <date>", "Only memories created before this date (ISO or YYYY-MM-DD)")
+		.option("--time-start <iso>", "Temporal recall lower bound")
+		.option("--time-end <iso>", "Temporal recall upper bound")
+		.option("--time-facets <facets>", "Temporal facets to search (comma-separated)")
+		.option("--time-mode <mode>", "Temporal mode: auto, timeline, or filter", "auto")
 		.option("--keyword-query <query>", "Override the keyword/FTS query used for recall")
 		.option("--pinned", "Only return pinned memories", false)
 		.option("--importance-min <n>", "Only return memories at or above this importance", Number.parseFloat)
@@ -122,6 +136,17 @@ export function registerMemoryCommands(program: Command, deps: MemoryDeps): void
 					importance_min: options.importanceMin,
 					since: options.since,
 					until: options.until,
+					time: options.timeStart
+						? {
+								start: options.timeStart,
+								end: options.timeEnd,
+								facets:
+									typeof options.timeFacets === "string"
+										? options.timeFacets.split(",").map((s: string) => s.trim())
+										: undefined,
+								mode: options.timeMode,
+							}
+						: undefined,
 					agentId: options.agent,
 					aggregate: aggregateRequested,
 					aggregateBudget: aggregateRequested ? options.aggregateBudget : undefined,


### PR DESCRIPTION
## Summary
- Add a `temporal_edges` sidecar table for explicit event/source/observed/valid memory time without duplicating memory content.
- Resolve exact date recall from query text or explicit `time` options, supporting date-only timeline recall and date-plus-topic filtered recall.
- Wire temporal recall and temporal remember fields through daemon routes, hooks, MCP tools, CLI, SDK, and core helpers.
- Document the new Memory API, CLI, SDK behavior, and keep doc drift checks aligned with the current package-map format.

## Validation
- `bun test platform/core/src/recall.test.ts platform/daemon/src/memory-search.test.ts surfaces/cli/src/commands/memory.test.ts platform/daemon/src/mcp/tools.test.ts`
- `bun run typecheck`
- `bun run --filter '@signet/daemon' build`
- `bun scripts/doc-drift.ts --markdown`
- `git diff --check`

## Notes
- Daemon build passes with existing dashboard Svelte warnings in SecretsTab, TroubleshooterPanel, SidebarGroups, WidgetGrid, and WidgetCard.
- Biome warnings from pre-existing explicit `any` usages in memory search/routes are unchanged by this PR.

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)
- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Rollback / compatibility note: migration 076 only creates the additive `temporal_edges` sidecar table and indexes. Existing memory/session/source recall remains compatible; rollback can ignore or drop the sidecar if the feature is disabled or reverted.
