### PR TITLE
fix(daemon): scope dreaming triggers by agent

### DIFF
--- a/docs/api/knowledge-ontology.md
+++ b/docs/api/knowledge-ontology.md
@@ -313,16 +313,17 @@ Requires `admin` permission.
 
 **Query parameters**
 
-| Parameter | Type   | Required | Description         |
-|-----------|--------|----------|---------------------|
-| `agentId` | string | no       | Agent ID (default: `"default"`) |
+| Parameter  | Type   | Required | Description                                  |
+|------------|--------|----------|----------------------------------------------|
+| `agentId`  | string | no       | Agent ID (default: daemon configured agent)  |
+| `agent_id` | string | no       | Alias for `agentId`                          |
 
 **Response**
 
 ```json
 {
   "enabled": true,
-  "worker": { "running": true, "active": false },
+  "worker": { "running": true, "active": false, "activeAgentId": null },
   "state": {
     "tokensSinceLastPass": 42000,
     "lastPassAt": "2026-04-01T12:00:00.000Z",
@@ -368,11 +369,15 @@ Poll `GET /api/dream/status` and check `passes[0].status` for completion.
 
 ```json
 {
-  "mode": "incremental"
+  "mode": "incremental",
+  "agentId": "noam"
 }
 ```
 
-`mode` is `"incremental"` (default) or `"compact"`.
+`mode` is `"incremental"` (default) or `"compact"`. `agentId` is optional
+and defaults to the daemon configured agent; `agent_id`, the `agentId` query
+parameter, the `agent_id` query parameter, and `x-signet-agent-id` are also
+accepted.
 
 **Response** — `202 Accepted`
 
@@ -381,7 +386,8 @@ Poll `GET /api/dream/status` and check `passes[0].status` for completion.
   "accepted": true,
   "passId": "pass-uuid",
   "status": "running",
-  "mode": "incremental"
+  "mode": "incremental",
+  "agentId": "noam"
 }
 ```
 

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -29,7 +29,7 @@ import {
 } from "@signet/core";
 import { watch } from "chokidar";
 import { Hono } from "hono";
-import { resolveAgentId, resolveDaemonAgentId } from "./agent-id";
+import { resolveDaemonAgentId } from "./agent-id";
 import { yieldEvery } from "./async-yield";
 import { requirePermission } from "./auth";
 import { bindWithRetry } from "./bind-with-retry";
@@ -1141,7 +1141,7 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 
 	if (memoryCfg.dreaming.enabled && !pipelinePaused && !memoryCfg.pipelineV2.mutationsFrozen) {
 		try {
-			dreamingWorkerHandle = startDreamingWorker(getDbAccessor(), memoryCfg.dreaming, AGENTS_DIR, resolveAgentId({}));
+			dreamingWorkerHandle = startDreamingWorker(getDbAccessor(), memoryCfg.dreaming, AGENTS_DIR, defaultAgentId);
 			setDreamingWorker(dreamingWorkerHandle);
 		} catch (err) {
 			logger.warn("dreaming", "Failed to start dreaming worker (non-fatal)", {

--- a/platform/daemon/src/pipeline/dreaming-worker.test.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.test.ts
@@ -1,0 +1,123 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { DreamingConfig, LlmProvider } from "@signet/core";
+import { runMigrations } from "../../../core/src/migrations";
+import type { DbAccessor } from "../db-accessor";
+import { closeInferenceProviderResolver, initInferenceProviderResolver } from "../llm";
+import { getDreamingWorkerAgentIds, startDreamingWorker } from "./dreaming-worker";
+
+function defaultCfg(overrides?: Partial<DreamingConfig>): DreamingConfig {
+	return {
+		enabled: true,
+		tokenThreshold: 100_000,
+		maxInputTokens: 32_000,
+		maxOutputTokens: 16_000,
+		timeout: 300_000,
+		backfillOnFirstRun: false,
+		...overrides,
+	};
+}
+
+function wrapDb(db: Database): DbAccessor {
+	return {
+		withReadDb<T>(fn: (db: Database) => T): T {
+			return fn(db);
+		},
+		withWriteTx<T>(fn: (db: Database) => T): T {
+			db.exec("BEGIN IMMEDIATE");
+			try {
+				const result = fn(db);
+				db.exec("COMMIT");
+				return result;
+			} catch (e) {
+				db.exec("ROLLBACK");
+				throw e;
+			}
+		},
+	} as unknown as DbAccessor;
+}
+
+function makeProvider(): LlmProvider {
+	return {
+		name: "test",
+		async available() {
+			return true;
+		},
+		async generate() {
+			return JSON.stringify({ summary: "noop", mutations: [] });
+		},
+	};
+}
+
+describe("dreaming worker agent scope", () => {
+	let db: Database;
+	let accessor: DbAccessor;
+	let agentsDir: string;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		runMigrations(db as unknown as Parameters<typeof runMigrations>[0]);
+		accessor = wrapDb(db);
+		agentsDir = mkdtempSync(join(tmpdir(), "dreaming-worker-"));
+		initInferenceProviderResolver(() => makeProvider());
+	});
+
+	afterEach(() => {
+		closeInferenceProviderResolver();
+		rmSync(agentsDir, { recursive: true, force: true });
+		db.close();
+	});
+
+	it("discovers registered and data-bearing agents for periodic checks", () => {
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO agents (id, name, read_policy, created_at, updated_at)
+			 VALUES (?, ?, 'isolated', ?, ?)`,
+		).run("noam", "noam", now, now);
+		db.prepare(
+			`INSERT INTO memories (id, content, type, agent_id, created_at, updated_at, updated_by)
+			 VALUES (?, ?, 'fact', ?, ?, ?, 'test')`,
+		).run("mem-agent", "agent-owned memory", "memory-agent", now, now);
+		db.prepare(
+			`INSERT INTO session_summaries (id, agent_id, content, token_count, depth, kind, earliest_at, latest_at, created_at)
+			 VALUES (?, ?, ?, 10, 0, 'session', ?, ?, ?)`,
+		).run("summary-agent", "summary-agent", "agent-owned summary", now, now, now);
+		db.prepare(
+			`INSERT INTO dreaming_state (agent_id, tokens_since_last_pass)
+			 VALUES (?, 500)`,
+		).run("state-agent");
+
+		expect(getDreamingWorkerAgentIds(accessor, "default")).toEqual([
+			"default",
+			"memory-agent",
+			"noam",
+			"state-agent",
+			"summary-agent",
+		]);
+	});
+
+	it("writes manual async trigger passes to the requested agent", async () => {
+		const worker = startDreamingWorker(accessor, defaultCfg(), agentsDir, "default");
+		try {
+			const passId = worker.triggerAsync("incremental", "noam");
+			await worker.activePass;
+
+			const row = db.prepare("SELECT agent_id, status, mode FROM dreaming_passes WHERE id = ?").get(passId) as {
+				agent_id: string;
+				status: string;
+				mode: string;
+			};
+			expect(row).toEqual({ agent_id: "noam", status: "completed", mode: "incremental" });
+			expect(
+				db.prepare("SELECT COUNT(*) AS count FROM dreaming_passes WHERE agent_id = 'default'").get() as {
+					count: number;
+				},
+			).toEqual({ count: 0 });
+		} finally {
+			worker.stop();
+		}
+	});
+});

--- a/platform/daemon/src/pipeline/dreaming-worker.ts
+++ b/platform/daemon/src/pipeline/dreaming-worker.ts
@@ -6,8 +6,8 @@
 
 import type { DreamingConfig } from "@signet/core";
 import type { DbAccessor } from "../db-accessor";
-import { logger } from "../logger";
 import { getSynthesisProvider } from "../llm";
+import { logger } from "../logger";
 import {
 	type DreamingMode,
 	createDreamingPass,
@@ -30,6 +30,7 @@ export interface DreamingWorkerHandle {
 	/** Force-trigger a pass synchronously (CLI / testing). */
 	trigger(
 		mode: DreamingMode,
+		agentId?: string,
 	): Promise<{ passId: string; applied: number; skipped: number; failed: number; summary: string }>;
 	/**
 	 * Fire-and-forget trigger: creates the pass record synchronously
@@ -37,8 +38,9 @@ export interface DreamingWorkerHandle {
 	 * background. Callers should poll GET /api/dream/status for completion.
 	 * Throws AlreadyRunningError if a pass is already active.
 	 */
-	triggerAsync(mode: DreamingMode): string;
+	triggerAsync(mode: DreamingMode, agentId?: string): string;
 	readonly running: boolean;
+	readonly activeAgentId: string | null;
 	/**
 	 * Resolves when the in-flight pass completes (or is null when idle).
 	 * Await this (with a timeout) during shutdown before closing the DB.
@@ -48,19 +50,51 @@ export interface DreamingWorkerHandle {
 
 const CHECK_INTERVAL_MS = 5 * 60 * 1000; // 5 min
 
+function normalizeAgentId(agentId: string | undefined, fallback: string): string {
+	const trimmed = agentId?.trim();
+	return trimmed ? trimmed : fallback;
+}
+
+export function getDreamingWorkerAgentIds(accessor: DbAccessor, defaultAgentId: string): readonly string[] {
+	return accessor.withReadDb((db) => {
+		const rows = db
+			.prepare(
+				`SELECT id FROM agents
+				 UNION
+				 SELECT DISTINCT agent_id AS id FROM dreaming_state
+				 UNION
+				 SELECT DISTINCT agent_id AS id FROM dreaming_passes
+				 UNION
+				 SELECT DISTINCT agent_id AS id FROM memories WHERE is_deleted = 0
+				 UNION
+				 SELECT DISTINCT agent_id AS id FROM session_summaries
+				 UNION
+				 SELECT DISTINCT agent_id AS id FROM entities`,
+			)
+			.all() as Array<{ id: string | null }>;
+		const ids = new Set<string>([defaultAgentId]);
+		for (const row of rows) {
+			const id = normalizeAgentId(row.id ?? undefined, "");
+			if (id) ids.add(id);
+		}
+		return [...ids].sort();
+	});
+}
+
 export function startDreamingWorker(
 	accessor: DbAccessor,
 	cfg: DreamingConfig,
 	agentsDir: string,
-	agentId: string,
+	defaultAgentId: string,
 ): DreamingWorkerHandle {
 	let timer: ReturnType<typeof setTimeout> | null = null;
 	let active = false;
+	let activeAgent: string | null = null;
 	let stopped = false;
 	let activePassPromise: Promise<unknown> | null = null;
 
 	// Sweep orphaned passes from unclean shutdown: any 'running' record
-	// for this agent was left by a crash or forced stop — mark it failed
+	// was left by a crash or forced stop — mark it failed
 	// so the status API doesn't show a forever-running ghost pass.
 	accessor.withWriteTx((db) => {
 		const orphaned = db
@@ -69,43 +103,64 @@ export function startDreamingWorker(
 				 SET status = 'failed',
 				     completed_at = datetime('now'),
 				     error = 'Orphaned by daemon restart'
-				 WHERE agent_id = ? AND status = 'running'`,
+				 WHERE status = 'running'`,
 			)
-			.run(agentId);
+			.run();
 		if (orphaned.changes > 0) {
 			logger.warn("dreaming-worker", `Swept ${orphaned.changes} orphaned running pass(es) from prior shutdown`);
 		}
 	});
 
+	async function runPass(
+		runAgentId: string,
+		mode: DreamingMode,
+		existingPassId?: string,
+	): Promise<{ passId: string; applied: number; skipped: number; failed: number; summary: string }> {
+		if (active) throw new AlreadyRunningError();
+		const synth = getSynthesisProvider();
+		active = true;
+		activeAgent = runAgentId;
+		const p = runDreamingPass(accessor, synth.generate.bind(synth), cfg, agentsDir, runAgentId, mode, existingPassId);
+		activePassPromise = p;
+		try {
+			return await p;
+		} catch (e) {
+			recordDreamingFailure(accessor, runAgentId);
+			throw e;
+		} finally {
+			active = false;
+			activeAgent = null;
+			activePassPromise = null;
+		}
+	}
+
 	async function check(): Promise<void> {
 		if (stopped || active) return;
 
-		try {
-			const state = getDreamingState(accessor, agentId);
-			const isFirst = state.lastPassAt === null && cfg.backfillOnFirstRun;
-			const mode: DreamingMode = isFirst ? "compact" : "incremental";
+		for (const runAgentId of getDreamingWorkerAgentIds(accessor, defaultAgentId)) {
+			if (stopped || active) return;
+			try {
+				const state = getDreamingState(accessor, runAgentId);
+				const isFirst = state.lastPassAt === null && cfg.backfillOnFirstRun;
+				const mode: DreamingMode = isFirst ? "compact" : "incremental";
 
-			if (!shouldTriggerDreaming(accessor, cfg, agentId)) return;
+				if (!shouldTriggerDreaming(accessor, cfg, runAgentId)) continue;
 
-			logger.info("dreaming-worker", "Token threshold reached, starting dreaming pass", {
-				tokens: state.tokensSinceLastPass,
-				threshold: cfg.tokenThreshold,
-				mode,
-			});
+				logger.info("dreaming-worker", "Token threshold reached, starting dreaming pass", {
+					agentId: runAgentId,
+					tokens: state.tokensSinceLastPass,
+					threshold: cfg.tokenThreshold,
+					mode,
+				});
 
-			active = true;
-			const synth = getSynthesisProvider();
-			const p = runDreamingPass(accessor, synth.generate.bind(synth), cfg, agentsDir, agentId, mode);
-			activePassPromise = p;
-			await p;
-		} catch (e) {
-			recordDreamingFailure(accessor, agentId);
-			logger.error("dreaming-worker", "Dreaming check failed", undefined, {
-				error: e instanceof Error ? e.message : String(e),
-			});
-		} finally {
-			active = false;
-			activePassPromise = null;
+				await runPass(runAgentId, mode);
+			} catch (e) {
+				if (e instanceof AlreadyRunningError) return;
+				logger.error("dreaming-worker", "Dreaming check failed", undefined, {
+					agentId: runAgentId,
+					error: e instanceof Error ? e.message : String(e),
+				});
+			}
 		}
 	}
 
@@ -136,38 +191,29 @@ export function startDreamingWorker(
 			}
 		},
 
-		async trigger(mode: DreamingMode) {
-			if (active) throw new AlreadyRunningError();
-			active = true;
-			const synth = getSynthesisProvider();
-			const p = runDreamingPass(accessor, synth.generate.bind(synth), cfg, agentsDir, agentId, mode);
-			activePassPromise = p;
-			try {
-				return await p;
-			} catch (e) {
-				recordDreamingFailure(accessor, agentId);
-				throw e;
-			} finally {
-				active = false;
-				activePassPromise = null;
-			}
+		trigger(mode: DreamingMode, agentId?: string) {
+			return runPass(normalizeAgentId(agentId, defaultAgentId), mode);
 		},
 
-		triggerAsync(mode: DreamingMode): string {
+		triggerAsync(mode: DreamingMode, agentId?: string): string {
 			if (active) throw new AlreadyRunningError();
-			const passId = createDreamingPass(accessor, agentId, mode);
-			active = true;
+			const runAgentId = normalizeAgentId(agentId, defaultAgentId);
 			const synth = getSynthesisProvider();
-			const p = runDreamingPass(accessor, synth.generate.bind(synth), cfg, agentsDir, agentId, mode, passId);
+			const passId = createDreamingPass(accessor, runAgentId, mode);
+			active = true;
+			activeAgent = runAgentId;
+			const p = runDreamingPass(accessor, synth.generate.bind(synth), cfg, agentsDir, runAgentId, mode, passId);
 			activePassPromise = p;
 			p.catch((e) => {
-				recordDreamingFailure(accessor, agentId);
-			logger.error("dreaming-worker", "Async trigger failed", undefined, {
-				passId,
-				error: e instanceof Error ? e.message : String(e),
-			});
+				recordDreamingFailure(accessor, runAgentId);
+				logger.error("dreaming-worker", "Async trigger failed", undefined, {
+					agentId: runAgentId,
+					passId,
+					error: e instanceof Error ? e.message : String(e),
+				});
 			}).finally(() => {
 				active = false;
+				activeAgent = null;
 				activePassPromise = null;
 			});
 			return passId;
@@ -175,6 +221,10 @@ export function startDreamingWorker(
 
 		get running() {
 			return active;
+		},
+
+		get activeAgentId() {
+			return activeAgent;
 		},
 
 		get activePass() {

--- a/platform/daemon/src/routes/pipeline-routes-agent.test.ts
+++ b/platform/daemon/src/routes/pipeline-routes-agent.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type { Context } from "hono";
+import { resolveDreamRequestAgentId } from "./pipeline-routes";
+
+const originalAgentId = process.env.SIGNET_AGENT_ID;
+
+function makeContext(query: Record<string, string | undefined>, headers: Record<string, string | undefined>): Context {
+	return {
+		req: {
+			query(key: string) {
+				return query[key];
+			},
+			header(key: string) {
+				return headers[key];
+			},
+		},
+	} as unknown as Context;
+}
+
+describe("dream route agent resolution", () => {
+	afterEach(() => {
+		if (originalAgentId === undefined) {
+			Reflect.deleteProperty(process.env, "SIGNET_AGENT_ID");
+		} else {
+			process.env.SIGNET_AGENT_ID = originalAgentId;
+		}
+	});
+
+	it("prefers JSON agentId over query, header, and daemon fallback", () => {
+		process.env.SIGNET_AGENT_ID = "daemon-agent";
+		const c = makeContext({ agent_id: "query-agent" }, { "x-signet-agent-id": "header-agent" });
+
+		expect(resolveDreamRequestAgentId(c, { agentId: "body-agent" })).toBe("body-agent");
+	});
+
+	it("accepts snake_case query and falls back to the daemon agent", () => {
+		process.env.SIGNET_AGENT_ID = "daemon-agent";
+
+		expect(resolveDreamRequestAgentId(makeContext({ agent_id: "query-agent" }, {}))).toBe("query-agent");
+		expect(resolveDreamRequestAgentId(makeContext({}, {}))).toBe("daemon-agent");
+	});
+});

--- a/platform/daemon/src/routes/pipeline-routes.ts
+++ b/platform/daemon/src/routes/pipeline-routes.ts
@@ -90,6 +90,18 @@ function readBoolean(record: Readonly<Record<string, unknown>>, key: string): bo
 	return undefined;
 }
 
+export function resolveDreamRequestAgentId(c: Context, body: Readonly<Record<string, unknown>> = {}): string {
+	return resolveAgentId({
+		agentId:
+			readString(body, "agentId") ??
+			readString(body, "agent_id") ??
+			c.req.query("agentId") ??
+			c.req.query("agent_id") ??
+			c.req.header("x-signet-agent-id") ??
+			resolveDaemonAgentId(),
+	});
+}
+
 async function togglePipelinePause(c: Context, paused: boolean): Promise<Response> {
 	if (pipelineTransition) {
 		return c.json({ error: "Pipeline transition already in progress" }, 409);
@@ -474,18 +486,19 @@ export function registerPipelineRoutes(app: Hono): void {
 	app.get("/api/dream/status", (c) => {
 		const cfg = loadMemoryConfig(AGENTS_DIR);
 		const accessor = getDbAccessor();
-		const agentId = resolveAgentId({
-			agentId: c.req.query("agentId") ?? c.req.header("x-signet-agent-id"),
-		});
+		const agentId = resolveDreamRequestAgentId(c);
 
 		const state = getDreamingState(accessor, agentId);
 		const passes = getDreamingPasses(accessor, agentId, 10);
-		const defaultAgent = resolveAgentId({});
-		const worker = agentId === defaultAgent ? getDreamingWorker() : null;
+		const worker = getDreamingWorker();
 
 		return c.json({
 			enabled: cfg.dreaming.enabled,
-			worker: { running: worker !== null, active: worker?.running ?? false },
+			worker: {
+				running: worker !== null,
+				active: worker?.activeAgentId === agentId,
+				activeAgentId: worker?.activeAgentId ?? null,
+			},
 			state,
 			config: {
 				tokenThreshold: cfg.dreaming.tokenThreshold,
@@ -502,9 +515,7 @@ export function registerPipelineRoutes(app: Hono): void {
 		const raw: unknown = await c.req.json().catch(() => null);
 		if (raw === null) return c.json({ error: "Malformed JSON body" }, 400);
 		const body = asRecord(raw);
-		const agentId = resolveAgentId({
-			agentId: readString(body, "agent_id") ?? c.req.header("x-signet-agent-id"),
-		});
+		const agentId = resolveDreamRequestAgentId(c, body);
 		const from = readString(body, "from");
 		if (!from) return c.json({ error: "from is required" }, 400);
 		const useProvider = readBoolean(body, "use_provider") ?? false;
@@ -537,27 +548,27 @@ export function registerPipelineRoutes(app: Hono): void {
 
 		const contentType = c.req.header("content-type") ?? "";
 		let mode: "compact" | "incremental" = "incremental";
+		let body: Record<string, unknown> = {};
 		if (contentType.includes("application/json")) {
 			const raw: unknown = await c.req.json().catch(() => null);
 			if (raw === null) {
 				return c.json({ error: "Malformed JSON body" }, 400);
 			}
-			if (typeof raw === "object") {
-				const body = raw as { mode?: unknown };
-				if (body.mode === "compact") {
-					mode = "compact";
-				}
+			body = asRecord(raw);
+			if (body.mode === "compact") {
+				mode = "compact";
 			}
 		}
+		const agentId = resolveDreamRequestAgentId(c, body);
 
 		let passId: string;
 		try {
-			passId = worker.triggerAsync(mode);
+			passId = worker.triggerAsync(mode, agentId);
 		} catch (e) {
 			if (e instanceof AlreadyRunningError) return c.json({ error: e.message }, 409);
 			const msg = e instanceof Error ? e.message : String(e);
 			return c.json({ error: msg }, 500);
 		}
-		return c.json({ accepted: true, passId, status: "running", mode }, 202);
+		return c.json({ accepted: true, passId, status: "running", mode, agentId }, 202);
 	});
 }

--- a/platform/daemon/src/routes/repair-routes.ts
+++ b/platform/daemon/src/routes/repair-routes.ts
@@ -1,4 +1,5 @@
 import type { Context, Hono } from "hono";
+import { resolveAgentId, resolveDaemonAgentId } from "../agent-id";
 import { requirePermission } from "../auth";
 import { getDbAccessor } from "../db-accessor.js";
 import { fetchEmbedding } from "../embedding-fetch.js";
@@ -48,6 +49,30 @@ function repairHttpStatus(result: RepairResult): 200 | 429 | 500 {
 		return 429;
 	}
 	return 500;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+	return value as Record<string, unknown>;
+}
+
+function readString(record: Readonly<Record<string, unknown>>, key: string): string | undefined {
+	const value = record[key];
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function resolveRepairAgentId(c: Context, body: Readonly<Record<string, unknown>> = {}): string {
+	return resolveAgentId({
+		agentId:
+			readString(body, "agentId") ??
+			readString(body, "agent_id") ??
+			c.req.query("agentId") ??
+			c.req.query("agent_id") ??
+			c.req.header("x-signet-agent-id") ??
+			resolveDaemonAgentId(),
+	});
 }
 
 export function registerRepairRoutes(app: Hono): void {
@@ -269,15 +294,15 @@ export function registerRepairRoutes(app: Hono): void {
 		const ctx = resolveRepairContext(c);
 		let batchSize = 100;
 		let dryRun = true;
-		let agentId = c.req.query("agent_id") ?? "default";
+		let body: Record<string, unknown> = {};
 		try {
-			const body = await c.req.json();
+			body = asRecord(await c.req.json());
 			if (typeof body?.batchSize === "number") batchSize = body.batchSize;
 			if (typeof body?.dryRun === "boolean") dryRun = body.dryRun;
-			if (typeof body?.agentId === "string" && body.agentId.trim()) agentId = body.agentId.trim();
 		} catch {
 			// no body or invalid JSON — use defaults
 		}
+		const agentId = resolveRepairAgentId(c, body);
 		const result = pruneGenericEntities(getDbAccessor(), cfg.pipelineV2, ctx, repairLimiter, {
 			batchSize,
 			dryRun,
@@ -350,20 +375,21 @@ export function registerRepairRoutes(app: Hono): void {
 	});
 
 	app.post("/api/repair/cluster-entities", (c) => {
-		const agentId = c.req.query("agent_id") ?? "default";
+		const agentId = resolveRepairAgentId(c);
 		const result = getDbAccessor().withWriteTx((db) => clusterEntities(db, agentId));
 		return c.json(result);
 	});
 
 	app.post("/api/repair/relink-entities", async (c) => {
-		const agentId = c.req.query("agent_id") ?? "default";
 		let batchSize = 500;
+		let body: Record<string, unknown> = {};
 		try {
-			const body = await c.req.json();
+			body = asRecord(await c.req.json());
 			if (typeof body?.batchSize === "number") batchSize = body.batchSize;
 		} catch {
 			// defaults
 		}
+		const agentId = resolveRepairAgentId(c, body);
 		const accessor = getDbAccessor();
 
 		const unlinked = accessor.withReadDb(
@@ -372,10 +398,11 @@ export function registerRepairRoutes(app: Hono): void {
 					.prepare(
 						`SELECT id, content FROM memories
 			 WHERE is_deleted = 0
+			   AND COALESCE(NULLIF(agent_id, ''), 'default') = ?
 			   AND id NOT IN (SELECT DISTINCT memory_id FROM memory_entity_mentions)
 			 LIMIT ?`,
 					)
-					.all(batchSize) as Array<{ id: string; content: string }>,
+					.all(agentId, batchSize) as Array<{ id: string; content: string }>,
 		);
 
 		if (unlinked.length === 0) {
@@ -402,9 +429,10 @@ export function registerRepairRoutes(app: Hono): void {
 						.prepare(
 							`SELECT COUNT(*) as cnt FROM memories
 			 WHERE is_deleted = 0
+			   AND COALESCE(NULLIF(agent_id, ''), 'default') = ?
 			   AND id NOT IN (SELECT DISTINCT memory_id FROM memory_entity_mentions)`,
 						)
-						.get() as { cnt: number }
+						.get(agentId) as { cnt: number }
 				).cnt,
 		);
 


### PR DESCRIPTION
## Summary

Fixes the issue #785 agent-scope leak in dreaming triggers and the adjacent hardcoded repair fallbacks.

## Changes

- Resolve dream route agent IDs from body `agentId` / `agent_id`, query aliases, `x-signet-agent-id`, then daemon configured fallback.
- Let the dreaming worker run manual triggers against a requested agent instead of only the startup default.
- Make periodic dreaming checks scan registered and data-bearing agents serially.
- Replace hardcoded default fallbacks in the flagged repair endpoints and scope `relink-entities` memory reads to the selected agent.
- Update API docs for the dream endpoint agent contract.

Closes #785.

## Type

- [x] `fix` — bug fix

## Packages affected

- [x] `@signet/daemon`

## Screenshots

N/A — daemon/API change only.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes

N/A — no migrations or schema changes.

## Testing

- [x] `bun test platform/daemon/src/routes/pipeline-routes-agent.test.ts platform/daemon/src/pipeline/dreaming-worker.test.ts platform/daemon/src/pipeline/dreaming.test.ts platform/daemon/src/agent-id.test.ts`
- [x] `bunx biome check platform/daemon/src/pipeline/dreaming-worker.ts platform/daemon/src/pipeline/dreaming-worker.test.ts platform/daemon/src/routes/pipeline-routes.ts platform/daemon/src/routes/pipeline-routes-agent.test.ts platform/daemon/src/routes/repair-routes.ts platform/daemon/src/daemon.ts docs/api/knowledge-ontology.md`
- [x] `git diff --check`
- [x] `bun run --filter '@signet/daemon' build`

## AI disclosure

- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

`bun run --filter '@signet/daemon' build:types` is currently blocked by pre-existing repo-wide TypeScript issues outside this patch, including `TS6059` rootDir errors for `platform/core/src/migrations/*` and existing test casts from `Database` to `ReadDb`/`WriteDb`. The PR has `checklist-exception` for that local typecheck caveat; no generated declaration artifacts are included.