### PR TITLE
fix(auth): guard daemon control surfaces

### DIFF
--- a/platform/daemon/src/daemon-auth-guard-colocation.test.ts
+++ b/platform/daemon/src/daemon-auth-guard-colocation.test.ts
@@ -586,4 +586,59 @@ describe("auth guard co-location", () => {
 			expect(await status(app, "GET", "/api/secrets")).toBe(403);
 		});
 	});
+
+	describe("marketplace MCP routes need admin guards", () => {
+		it("POST /api/marketplace/mcp/test returns 403 without auth", async () => {
+			const app = await makeApp();
+			const { mountMarketplaceRoutes } = await import("./routes/marketplace");
+			mountMarketplaceRoutes(app);
+			expect(await status(app, "POST", "/api/marketplace/mcp/test")).toBe(403);
+		});
+
+		it("POST /api/marketplace/mcp/call returns 403 without auth", async () => {
+			const app = await makeApp();
+			const { mountMarketplaceRoutes } = await import("./routes/marketplace");
+			mountMarketplaceRoutes(app);
+			expect(await status(app, "POST", "/api/marketplace/mcp/call")).toBe(403);
+		});
+	});
+
+	describe("source routes need data and mutation guards", () => {
+		it("GET /api/sources/:id/snapshot returns 403 without auth", async () => {
+			const app = await makeApp();
+			const { registerSourcesRoutes } = await import("./routes/sources-routes");
+			registerSourcesRoutes(app);
+			expect(await status(app, "GET", "/api/sources/source-1/snapshot")).toBe(403);
+		});
+
+		it("POST /api/sources/github returns 403 without auth", async () => {
+			const app = await makeApp();
+			const { registerSourcesRoutes } = await import("./routes/sources-routes");
+			registerSourcesRoutes(app);
+			expect(await status(app, "POST", "/api/sources/github")).toBe(403);
+		});
+	});
+
+	describe("OS control routes need admin guards", () => {
+		it("POST /api/os/chat returns 403 without auth", async () => {
+			const app = await makeApp();
+			const { mountOsChatRoutes } = await import("./routes/os-chat");
+			mountOsChatRoutes(app);
+			expect(await status(app, "POST", "/api/os/chat")).toBe(403);
+		});
+
+		it("POST /api/os/agent-execute returns 403 without auth", async () => {
+			const app = await makeApp();
+			const { mountOsAgentRoutes } = await import("./routes/os-agent");
+			mountOsAgentRoutes(app);
+			expect(await status(app, "POST", "/api/os/agent-execute")).toBe(403);
+		});
+
+		it("POST /api/os/tray/:id/reprobe returns 403 without auth", async () => {
+			const app = await makeApp();
+			const { mountAppTrayRoutes } = await import("./routes/app-tray");
+			mountAppTrayRoutes(app);
+			expect(await status(app, "POST", "/api/os/tray/test/reprobe")).toBe(403);
+		});
+	});
 });

--- a/platform/daemon/src/daemon-auth-guard-colocation.test.ts
+++ b/platform/daemon/src/daemon-auth-guard-colocation.test.ts
@@ -171,6 +171,20 @@ describe("auth guard co-location", () => {
 			expect(body.error).toContain("remember");
 		});
 
+		it("GET /api/memories returns 403 without auth", async () => {
+			const app = await makeApp();
+			const { registerMemoryRoutes } = await import("./routes/memory-routes");
+			registerMemoryRoutes(app);
+			expect(await status(app, "GET", "/api/memories")).toBe(403);
+		});
+
+		it("GET /api/embeddings returns 403 without auth", async () => {
+			const app = await makeApp();
+			const { registerMemoryRoutes } = await import("./routes/memory-routes");
+			registerMemoryRoutes(app);
+			expect(await status(app, "GET", "/api/embeddings?vectors=true")).toBe(403);
+		});
+
 		it("POST /api/memory/recall forwards read-only aggregate options", async () => {
 			const app = await makeApp();
 			const state = await import("./routes/state.js");
@@ -344,6 +358,13 @@ describe("auth guard co-location", () => {
 	});
 
 	describe("misc routes have config guards", () => {
+		it("GET /api/config returns 403 without auth", async () => {
+			const app = await makeApp();
+			const { registerMiscRoutes } = await import("./routes/misc-routes");
+			registerMiscRoutes(app);
+			expect(await status(app, "GET", "/api/config")).toBe(403);
+		});
+
 		it("POST /api/config returns 403 without auth", async () => {
 			const app = await makeApp();
 			const { registerMiscRoutes } = await import("./routes/misc-routes");
@@ -360,6 +381,48 @@ describe("auth guard co-location", () => {
 				headers: { "content-length": "1048577" },
 			});
 			expect(res.status).toBe(413);
+		});
+
+		it("GET /api/logs returns 403 without auth", async () => {
+			const app = await makeApp();
+			const { registerMiscRoutes } = await import("./routes/misc-routes");
+			registerMiscRoutes(app);
+			expect(await status(app, "GET", "/api/logs")).toBe(403);
+		});
+
+		it("GET /api/identity returns 403 without auth", async () => {
+			const app = await makeApp();
+			const { registerMiscRoutes } = await import("./routes/misc-routes");
+			registerMiscRoutes(app);
+			expect(await status(app, "GET", "/api/identity")).toBe(403);
+		});
+
+		it("POST /api/agents returns 403 without auth", async () => {
+			const app = await makeApp();
+			const { registerMiscRoutes } = await import("./routes/misc-routes");
+			registerMiscRoutes(app);
+			expect(await status(app, "POST", "/api/agents")).toBe(403);
+		});
+
+		it("DELETE /api/agents/:name returns 403 without auth", async () => {
+			const app = await makeApp();
+			const { registerMiscRoutes } = await import("./routes/misc-routes");
+			registerMiscRoutes(app);
+			expect(await status(app, "DELETE", "/api/agents/other?purge=true")).toBe(403);
+		});
+
+		it("POST /api/tasks returns 403 without auth", async () => {
+			const app = await makeApp();
+			const { registerMiscRoutes } = await import("./routes/misc-routes");
+			registerMiscRoutes(app);
+			expect(await status(app, "POST", "/api/tasks")).toBe(403);
+		});
+
+		it("POST /api/tasks/:id/run returns 403 without auth", async () => {
+			const app = await makeApp();
+			const { registerMiscRoutes } = await import("./routes/misc-routes");
+			registerMiscRoutes(app);
+			expect(await status(app, "POST", "/api/tasks/task-1/run")).toBe(403);
 		});
 	});
 
@@ -587,6 +650,30 @@ describe("auth guard co-location", () => {
 		});
 	});
 
+	describe("skill routes need admin guards", () => {
+		it("POST /api/skills/install returns 403 without auth", async () => {
+			const app = await makeApp();
+			const { mountSkillsRoutes } = await import("./routes/skills");
+			mountSkillsRoutes(app);
+			expect(await status(app, "POST", "/api/skills/install")).toBe(403);
+		});
+	});
+
+	describe("hook lifecycle routes need remember guards", () => {
+		for (const path of [
+			"/api/hooks/session-end",
+			"/api/hooks/session-checkpoint-extract",
+			"/api/hooks/compaction-complete",
+		]) {
+			it(`POST ${path} returns 403 without auth`, async () => {
+				const app = await makeApp();
+				const { registerHooksRoutes } = await import("./routes/hooks-routes");
+				registerHooksRoutes(app);
+				expect(await status(app, "POST", path)).toBe(403);
+			});
+		}
+	});
+
 	describe("marketplace MCP routes need admin guards", () => {
 		it("POST /api/marketplace/mcp/test returns 403 without auth", async () => {
 			const app = await makeApp();
@@ -639,6 +726,30 @@ describe("auth guard co-location", () => {
 			const { mountAppTrayRoutes } = await import("./routes/app-tray");
 			mountAppTrayRoutes(app);
 			expect(await status(app, "POST", "/api/os/tray/test/reprobe")).toBe(403);
+		});
+
+		it("rate limits non-GET requests to the exact tray collection path", async () => {
+			const app = await makeApp();
+			const state = await import("./routes/state.js");
+			const { createAuthMiddleware, createToken } = await import("./auth");
+			const { mountAppTrayRoutes } = await import("./routes/app-tray");
+			const secret = state.authSecret;
+			if (!secret) throw new Error("expected auth secret for team-mode tray test");
+
+			state.authAdminLimiter.reset();
+			app.use("*", createAuthMiddleware(state.authConfig, secret));
+			mountAppTrayRoutes(app);
+			const token = createToken(secret, { sub: "tray-limiter", role: "admin", scope: {} }, 60);
+			const headers = { authorization: `Bearer ${token}` };
+			const limit = state.authConfig.rateLimits.admin.max;
+
+			for (let i = 0; i < limit; i++) {
+				const res = await app.request("/api/os/tray", { method: "POST", headers });
+				expect(res.status).toBe(404);
+			}
+
+			const limited = await app.request("/api/os/tray", { method: "POST", headers });
+			expect(limited.status).toBe(429);
 		});
 	});
 });

--- a/platform/daemon/src/daemon-auth-guard-colocation.test.ts
+++ b/platform/daemon/src/daemon-auth-guard-colocation.test.ts
@@ -728,6 +728,24 @@ describe("auth guard co-location", () => {
 			expect(await status(app, "POST", "/api/os/tray/test/reprobe")).toBe(403);
 		});
 
+		it("GET /api/os/tray remains diagnostics-readable for operators", async () => {
+			const app = await makeApp();
+			const state = await import("./routes/state.js");
+			const { createAuthMiddleware, createToken } = await import("./auth");
+			const { mountAppTrayRoutes } = await import("./routes/app-tray");
+			const secret = state.authSecret;
+			if (!secret) throw new Error("expected auth secret for team-mode tray test");
+
+			app.use("*", createAuthMiddleware(state.authConfig, secret));
+			mountAppTrayRoutes(app);
+			const token = createToken(secret, { sub: "tray-operator", role: "operator", scope: {} }, 60);
+
+			const res = await app.request("/api/os/tray", {
+				headers: { authorization: `Bearer ${token}` },
+			});
+			expect(res.status).toBe(200);
+		});
+
 		it("rate limits non-GET requests to the exact tray collection path", async () => {
 			const app = await makeApp();
 			const state = await import("./routes/state.js");

--- a/platform/daemon/src/daemon-refactor.test.ts
+++ b/platform/daemon/src/daemon-refactor.test.ts
@@ -97,4 +97,33 @@ describe("daemon route extraction refactor", () => {
 			rmSync(tmpDir, { recursive: true, force: true });
 		}
 	});
+
+	it("reloadAuthState applies hybrid auth for tailscale configs without explicit auth mode", async () => {
+		const state = await import("./routes/state.js");
+
+		const tmpDir = join(tmpdir(), `signet-test-tailscale-auth-${Date.now()}`);
+		mkdirSync(join(tmpDir, "memory"), { recursive: true });
+		mkdirSync(join(tmpDir, ".daemon"), { recursive: true });
+		writeFileSync(
+			join(tmpDir, "agent.yaml"),
+			[
+				"network:",
+				"  mode: tailscale",
+				"auth:",
+				"  rateLimits:",
+				"    admin:",
+				"      windowMs: 60000",
+				"      max: 10",
+			].join("\n"),
+		);
+
+		try {
+			state.reloadAuthState(tmpDir);
+			expect(state.authConfig.mode).toBe("hybrid");
+			expect(state.authSecret).not.toBeNull();
+		} finally {
+			state.reloadAuthState(state.AGENTS_DIR);
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
 });

--- a/platform/daemon/src/daemon-refactor.test.ts
+++ b/platform/daemon/src/daemon-refactor.test.ts
@@ -126,4 +126,22 @@ describe("daemon route extraction refactor", () => {
 			rmSync(tmpDir, { recursive: true, force: true });
 		}
 	});
+
+	it("reloadAuthState preserves explicit local auth for tailscale configs", async () => {
+		const state = await import("./routes/state.js");
+
+		const tmpDir = join(tmpdir(), `signet-test-tailscale-local-auth-${Date.now()}`);
+		mkdirSync(join(tmpDir, "memory"), { recursive: true });
+		mkdirSync(join(tmpDir, ".daemon"), { recursive: true });
+		writeFileSync(join(tmpDir, "agent.yaml"), ["network:", "  mode: tailscale", "auth:", "  mode: local"].join("\n"));
+
+		try {
+			state.reloadAuthState(tmpDir);
+			expect(state.authConfig.mode).toBe("local");
+			expect(state.authSecret).toBeNull();
+		} finally {
+			state.reloadAuthState(state.AGENTS_DIR);
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
 });

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -215,6 +215,9 @@ app.use("/api/inference/*", async (c, next) => {
 	if (c.req.method === "GET") return requirePermission("diagnostics", authConfig)(c, next);
 	return requirePermission("admin", authConfig)(c, next);
 });
+app.use("/v1/*", async (c, next) => {
+	return requirePermission("admin", authConfig)(c, next);
+});
 mountInferenceRoutes(app, {
 	getAuthMode: () => authConfig.mode,
 	getTelemetry: () => telemetryRef,

--- a/platform/daemon/src/inference-api.test.ts
+++ b/platform/daemon/src/inference-api.test.ts
@@ -679,6 +679,40 @@ describe("inference route hardening", () => {
 		}
 	});
 
+	it("blocks OpenAI-compatible gateway routes without admin permission", async () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-inference-gateway-auth-"));
+		writeRoutingFixture(root);
+		try {
+			const { app, secret } = createInferenceTestApp(root);
+			const operatorToken = createToken(secret, { sub: "operator", scope: {}, role: "operator" }, 60);
+
+			const modelsRes = await app.request(
+				new Request("http://localhost/v1/models", {
+					headers: { Authorization: `Bearer ${operatorToken}` },
+				}),
+			);
+			expect(modelsRes.status).toBe(403);
+
+			const completionsRes = await app.request(
+				new Request("http://localhost/v1/chat/completions", {
+					method: "POST",
+					headers: {
+						Authorization: `Bearer ${operatorToken}`,
+						"content-type": "application/json",
+					},
+					body: JSON.stringify({
+						model: "signet:auto",
+						messages: [{ role: "user", content: "hello" }],
+					}),
+				}),
+			);
+			expect(completionsRes.status).toBe(403);
+		} finally {
+			resetInferenceRouterForTests();
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("rejects mismatched scoped agent ids on route requests", async () => {
 		const root = mkdtempSync(join(tmpdir(), "signet-inference-scope-"));
 		writeRoutingFixture(root);

--- a/platform/daemon/src/memory-config.test.ts
+++ b/platform/daemon/src/memory-config.test.ts
@@ -97,6 +97,19 @@ describe("loadMemoryConfig", () => {
 		expect(cfg.embedding.promptSubmitTimeoutMs).toBe(MIN_PROMPT_SUBMIT_EMBEDDING_TIMEOUT_MS);
 	});
 
+	it("defaults tailscale network mode to hybrid auth", () => {
+		const agentsDir = makeTempAgentsDir();
+		writeFileSync(
+			join(agentsDir, "agent.yaml"),
+			`network:
+  mode: tailscale
+`,
+		);
+
+		const cfg = loadMemoryConfig(agentsDir);
+		expect(cfg.auth?.mode).toBe("hybrid");
+	});
+
 	it("enables graph extraction writes by default", () => {
 		const agentsDir = makeTempAgentsDir();
 		const cfg = loadMemoryConfig(agentsDir);

--- a/platform/daemon/src/memory-config.test.ts
+++ b/platform/daemon/src/memory-config.test.ts
@@ -110,6 +110,21 @@ describe("loadMemoryConfig", () => {
 		expect(cfg.auth?.mode).toBe("hybrid");
 	});
 
+	it("preserves explicit local auth on tailscale network mode", () => {
+		const agentsDir = makeTempAgentsDir();
+		writeFileSync(
+			join(agentsDir, "agent.yaml"),
+			`network:
+  mode: tailscale
+auth:
+  mode: local
+`,
+		);
+
+		const cfg = loadMemoryConfig(agentsDir);
+		expect(cfg.auth?.mode).toBe("local");
+	});
+
 	it("enables graph extraction writes by default", () => {
 		const agentsDir = makeTempAgentsDir();
 		const cfg = loadMemoryConfig(agentsDir);

--- a/platform/daemon/src/memory-config.ts
+++ b/platform/daemon/src/memory-config.ts
@@ -1154,8 +1154,9 @@ export function loadMemoryConfig(agentsDir: string): ResolvedMemoryConfig {
 			defaults.pipelineV2 = loadPipelineConfig(yaml);
 			defaults.dreaming = loadDreamingConfig(yaml);
 			const parsedAuth = parseAuthConfig(yaml.auth, agentsDir);
+			const hasExplicitAuthMode = isRecord(yaml.auth) && "mode" in yaml.auth;
 			defaults.auth =
-				readNetworkMode(yaml) === "tailscale" && parsedAuth.mode === "local"
+				readNetworkMode(yaml) === "tailscale" && !hasExplicitAuthMode && parsedAuth.mode === "local"
 					? { ...parsedAuth, mode: "hybrid" }
 					: parsedAuth;
 

--- a/platform/daemon/src/memory-config.ts
+++ b/platform/daemon/src/memory-config.ts
@@ -10,6 +10,7 @@ import {
 	defaultPipelineModel,
 	isPipelineProvider,
 	parseSimpleYaml,
+	readNetworkMode,
 } from "@signet/core";
 import { type AuthConfig, parseAuthConfig } from "./auth";
 import { logger } from "./logger";
@@ -1152,7 +1153,11 @@ export function loadMemoryConfig(agentsDir: string): ResolvedMemoryConfig {
 
 			defaults.pipelineV2 = loadPipelineConfig(yaml);
 			defaults.dreaming = loadDreamingConfig(yaml);
-			defaults.auth = parseAuthConfig(yaml.auth, agentsDir);
+			const parsedAuth = parseAuthConfig(yaml.auth, agentsDir);
+			defaults.auth =
+				readNetworkMode(yaml) === "tailscale" && parsedAuth.mode === "local"
+					? { ...parsedAuth, mode: "hybrid" }
+					: parsedAuth;
 
 			break;
 		} catch (error) {

--- a/platform/daemon/src/routes/app-tray.ts
+++ b/platform/daemon/src/routes/app-tray.ts
@@ -1,15 +1,17 @@
 /** App Tray API routes — CRUD for app tray entries and MCP install endpoint. */
 
-import type { Hono } from "hono";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
 import { homedir } from "node:os";
-import type { AutoCardToolAction, AutoCardResource, SignetAppManifest } from "@signet/core";
+import { join } from "node:path";
+import type { AutoCardResource, AutoCardToolAction, SignetAppManifest } from "@signet/core";
+import type { Hono } from "hono";
 
-import { isPrivateHostname } from "../url-validation.js";
-import { loadAppTray, loadProbeResult, probeServer, reprobeServer, storeProbeResult } from "../mcp-probe.js";
+import { requirePermission, requireRateLimit } from "../auth";
 import { logger } from "../logger.js";
+import { loadAppTray, loadProbeResult, probeServer, reprobeServer, storeProbeResult } from "../mcp-probe.js";
+import { isPrivateHostname } from "../url-validation.js";
 import { readInstalledServersPublic } from "./marketplace-helpers.js";
+import { authAdminLimiter, authConfig } from "./state.js";
 
 function isValidState(s: string): s is "tray" | "grid" | "dock" {
 	return s === "tray" || s === "grid" || s === "dock";
@@ -63,6 +65,22 @@ function findFreeGridPosition(
  * Mount app tray routes on the Hono app.
  */
 export function mountAppTrayRoutes(app: Hono): void {
+	app.use("/api/os/tray", async (c, next) => {
+		return requirePermission("admin", authConfig)(c, next);
+	});
+	app.use("/api/os/tray/*", async (c, next) => {
+		return requirePermission("admin", authConfig)(c, next);
+	});
+	app.use("/api/os/install", async (c, next) => {
+		return requirePermission("admin", authConfig)(c, next);
+	});
+	for (const path of ["/api/os/tray/*", "/api/os/install"]) {
+		app.use(path, async (c, next) => {
+			if (c.req.method === "GET") return next();
+			return requireRateLimit("admin", authAdminLimiter, authConfig)(c, next);
+		});
+	}
+
 	/**
 	 * GET /api/os/tray — list all app tray entries.
 	 * Automatically syncs installed MCP servers that are missing

--- a/platform/daemon/src/routes/app-tray.ts
+++ b/platform/daemon/src/routes/app-tray.ts
@@ -17,6 +17,14 @@ function isValidState(s: string): s is "tray" | "grid" | "dock" {
 	return s === "tray" || s === "grid" || s === "dock";
 }
 
+function isTrayRoutePath(path: string): boolean {
+	return path === "/api/os/tray" || path.startsWith("/api/os/tray/");
+}
+
+function isGuardedOsRoutePath(path: string): boolean {
+	return isTrayRoutePath(path) || path === "/api/os/install";
+}
+
 /** Resolve an icon URL from a marketplace source and catalog ID. */
 function resolveServerIcon(source: string, catalogId?: string): string | null {
 	if (source === "modelcontextprotocol/servers") return "https://github.com/modelcontextprotocol.png?size=40";
@@ -65,21 +73,13 @@ function findFreeGridPosition(
  * Mount app tray routes on the Hono app.
  */
 export function mountAppTrayRoutes(app: Hono): void {
-	app.use("/api/os/tray", async (c, next) => {
-		return requirePermission("admin", authConfig)(c, next);
+	app.use("/api/os/*", async (c, next) => {
+		if (!isGuardedOsRoutePath(c.req.path)) return next();
+		const denied = await requirePermission("admin", authConfig)(c, () => Promise.resolve());
+		if (denied) return denied;
+		if (c.req.method === "GET") return next();
+		return requireRateLimit("admin", authAdminLimiter, authConfig)(c, next);
 	});
-	app.use("/api/os/tray/*", async (c, next) => {
-		return requirePermission("admin", authConfig)(c, next);
-	});
-	app.use("/api/os/install", async (c, next) => {
-		return requirePermission("admin", authConfig)(c, next);
-	});
-	for (const path of ["/api/os/tray/*", "/api/os/install"]) {
-		app.use(path, async (c, next) => {
-			if (c.req.method === "GET") return next();
-			return requireRateLimit("admin", authAdminLimiter, authConfig)(c, next);
-		});
-	}
 
 	/**
 	 * GET /api/os/tray — list all app tray entries.

--- a/platform/daemon/src/routes/app-tray.ts
+++ b/platform/daemon/src/routes/app-tray.ts
@@ -75,9 +75,11 @@ function findFreeGridPosition(
 export function mountAppTrayRoutes(app: Hono): void {
 	app.use("/api/os/*", async (c, next) => {
 		if (!isGuardedOsRoutePath(c.req.path)) return next();
+		if (c.req.method === "GET") {
+			return requirePermission("diagnostics", authConfig)(c, next);
+		}
 		const denied = await requirePermission("admin", authConfig)(c, () => Promise.resolve());
 		if (denied) return denied;
-		if (c.req.method === "GET") return next();
 		return requireRateLimit("admin", authAdminLimiter, authConfig)(c, next);
 	});
 

--- a/platform/daemon/src/routes/hooks-routes.ts
+++ b/platform/daemon/src/routes/hooks-routes.ts
@@ -1361,6 +1361,17 @@ function registerSynthesis(app: Hono): void {
 }
 
 export function registerHooksRoutes(app: Hono): void {
+	for (const path of [
+		"/api/hooks/session-end",
+		"/api/hooks/session-checkpoint-extract",
+		"/api/hooks/compaction-complete",
+	]) {
+		app.use(path, async (c, next) => {
+			if (isInternalCall(c)) return next();
+			return requirePermission("remember", authConfig)(c, next);
+		});
+	}
+
 	app.use("/api/cross-agent", async (c, next) => {
 		if (c.req.method === "GET") {
 			return requirePermission("recall", authConfig)(c, next);

--- a/platform/daemon/src/routes/marketplace.ts
+++ b/platform/daemon/src/routes/marketplace.ts
@@ -11,6 +11,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Hono } from "hono";
+import { requirePermission } from "../auth";
 import { getDbAccessor } from "../db-accessor.js";
 import { logger } from "../logger.js";
 import { probeServer, removeProbeResult, storeProbeResult } from "../mcp-probe.js";
@@ -1139,6 +1140,13 @@ function recordMcpInvocation(record: McpInvocationRecord): void {
 }
 
 export function mountMarketplaceRoutes(app: Hono): void {
+	app.use("/api/marketplace/mcp", async (c, next) => {
+		return requirePermission("admin", authConfig)(c, next);
+	});
+	app.use("/api/marketplace/mcp/*", async (c, next) => {
+		return requirePermission("admin", authConfig)(c, next);
+	});
+
 	app.get("/api/marketplace/mcp", (c) => {
 		const servers = readInstalledServers();
 		const context = extractContextFromRequest(c);

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -544,6 +544,18 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 	app.use("/api/memory/timeline", async (c, next) => {
 		return requirePermission("recall", authConfig)(c, next);
 	});
+	app.use("/api/memories", async (c, next) => {
+		return requirePermission("recall", authConfig)(c, next);
+	});
+	app.use("/api/memories/*", async (c, next) => {
+		return requirePermission("recall", authConfig)(c, next);
+	});
+	app.use("/api/embeddings", async (c, next) => {
+		return requirePermission("recall", authConfig)(c, next);
+	});
+	app.use("/api/embeddings/*", async (c, next) => {
+		return requirePermission("recall", authConfig)(c, next);
+	});
 
 	// Modify — with rate limiting
 	app.use("/api/memory/modify", async (c, next) => {

--- a/platform/daemon/src/routes/misc-routes.ts
+++ b/platform/daemon/src/routes/misc-routes.ts
@@ -74,7 +74,30 @@ export function registerMiscRoutes(app: Hono): void {
 			}
 			return requirePermission("admin", authConfig)(c, next);
 		}
-		return next();
+		return requirePermission("diagnostics", authConfig)(c, next);
+	});
+	app.use("/api/logs", async (c, next) => {
+		return requirePermission("diagnostics", authConfig)(c, next);
+	});
+	app.use("/api/logs/*", async (c, next) => {
+		return requirePermission("diagnostics", authConfig)(c, next);
+	});
+	app.use("/api/identity", async (c, next) => {
+		return requirePermission("diagnostics", authConfig)(c, next);
+	});
+	app.use("/api/agents", async (c, next) => {
+		if (c.req.method === "GET") return requirePermission("diagnostics", authConfig)(c, next);
+		return requirePermission("admin", authConfig)(c, next);
+	});
+	app.use("/api/agents/*", async (c, next) => {
+		if (c.req.method === "GET") return requirePermission("diagnostics", authConfig)(c, next);
+		return requirePermission("admin", authConfig)(c, next);
+	});
+	app.use("/api/tasks", async (c, next) => {
+		return requirePermission("admin", authConfig)(c, next);
+	});
+	app.use("/api/tasks/*", async (c, next) => {
+		return requirePermission("admin", authConfig)(c, next);
 	});
 
 	app.get("/api/logs", (c) => {

--- a/platform/daemon/src/routes/os-agent.ts
+++ b/platform/daemon/src/routes/os-agent.ts
@@ -16,9 +16,11 @@
 
 import type { RoutingPrivacyTier } from "@signet/core";
 import type { Hono } from "hono";
+import { requirePermission, requireRateLimit } from "../auth";
 import { getInferenceRouterOrNull } from "../inference-router.js";
 import { getInteractiveLlmProviderOrNull } from "../llm.js";
 import { logger } from "../logger.js";
+import { authAdminLimiter, authConfig } from "./state.js";
 
 // ============================================================================
 // Agent Session State (in-memory)
@@ -429,6 +431,17 @@ function sleep(ms: number): Promise<void> {
 // ============================================================================
 
 export function mountOsAgentRoutes(app: Hono): void {
+	for (const path of ["/api/os/agent-execute", "/api/os/agent-state", "/api/os/agent-events"]) {
+		app.use(path, async (c, next) => {
+			return requirePermission("admin", authConfig)(c, next);
+		});
+	}
+	for (const path of ["/api/os/agent-execute", "/api/os/agent-state"]) {
+		app.use(path, async (c, next) => {
+			return requireRateLimit("admin", authAdminLimiter, authConfig)(c, next);
+		});
+	}
+
 	/**
 	 * POST /api/os/agent-execute — Start an agent execution session.
 	 *

--- a/platform/daemon/src/routes/os-chat.ts
+++ b/platform/daemon/src/routes/os-chat.ts
@@ -8,10 +8,12 @@
 
 import type { RoutingPrivacyTier } from "@signet/core";
 import type { Hono } from "hono";
+import { requirePermission, requireRateLimit } from "../auth";
 import { getInferenceRouterOrNull } from "../inference-router.js";
 import { getInteractiveLlmProviderOrNull } from "../llm.js";
 import { logger } from "../logger.js";
 import { loadProbeResult } from "../mcp-probe.js";
+import { authAdminLimiter, authConfig } from "./state.js";
 
 function buildPrompt(systemPrompt: string, userMessage: string): string {
 	return `${systemPrompt}\n\nUser message:\n${userMessage}`;
@@ -213,6 +215,12 @@ function parseLlmResponse(raw: string): {
  * Mount OS chat routes on the Hono app.
  */
 export function mountOsChatRoutes(app: Hono): void {
+	app.use("/api/os/chat", async (c, next) => {
+		const denied = await requirePermission("admin", authConfig)(c, () => Promise.resolve());
+		if (denied) return denied;
+		return requireRateLimit("admin", authAdminLimiter, authConfig)(c, next);
+	});
+
 	app.post("/api/os/chat", async (c) => {
 		let body: ChatRequest;
 		try {
@@ -284,7 +292,10 @@ export function mountOsChatRoutes(app: Hono): void {
 							`http://127.0.0.1:${process.env.SIGNET_PORT || 3850}/api/marketplace/mcp/call`,
 							{
 								method: "POST",
-								headers: { "Content-Type": "application/json" },
+								headers: {
+									"Content-Type": "application/json",
+									...(c.req.header("authorization") ? { authorization: c.req.header("authorization") ?? "" } : {}),
+								},
 								body: JSON.stringify({
 									serverId: call.serverId,
 									toolName: call.toolName,

--- a/platform/daemon/src/routes/skills.ts
+++ b/platform/daemon/src/routes/skills.ts
@@ -26,7 +26,7 @@ import { getSkillsRunnerCommand, resolvePrimaryPackageManager } from "@signet/co
 import type { Hono } from "hono";
 import type { Entry, ZipFile } from "yauzl";
 import * as yauzl from "yauzl";
-import type { AuthMode } from "../auth/index.js";
+import { type AuthMode, requirePermission } from "../auth/index.js";
 import { type DbAccessor, getDbAccessor } from "../db-accessor.js";
 import { getLlmProvider } from "../llm.js";
 import { logger } from "../logger.js";
@@ -34,6 +34,7 @@ import { type EmbeddingConfig, type PipelineV2Config, loadMemoryConfig } from ".
 import type { LlmProvider } from "../pipeline/provider.js";
 import { parseSkillFile, patchSkillFrontmatter } from "../pipeline/skill-frontmatter.js";
 import { installSkillNode, uninstallSkillNode } from "../pipeline/skill-graph.js";
+import { authConfig } from "./state.js";
 
 function getAgentsDir(): string {
 	return process.env.SIGNET_PATH || join(homedir(), ".agents");
@@ -892,6 +893,14 @@ function onSkillUninstalling(skillName: string): void {
 }
 
 export function mountSkillsRoutes(app: Hono, _authMode: AuthMode = "local"): void {
+	app.use("/api/skills/install", async (c, next) => {
+		return requirePermission("admin", authConfig)(c, next);
+	});
+	app.use("/api/skills/*", async (c, next) => {
+		if (c.req.method === "DELETE") return requirePermission("admin", authConfig)(c, next);
+		return next();
+	});
+
 	// GET /api/skills - list installed skills
 	app.get("/api/skills", (c) => {
 		try {

--- a/platform/daemon/src/routes/sources-routes.ts
+++ b/platform/daemon/src/routes/sources-routes.ts
@@ -17,6 +17,7 @@ import {
 } from "@signet/core";
 import type { Hono } from "hono";
 import { resolveDaemonAgentId } from "../agent-id";
+import { requirePermission } from "../auth";
 import { type ReadDb, getDbAccessor } from "../db-accessor";
 import {
 	type NativeMemoryBridgeHandle,
@@ -40,6 +41,7 @@ import {
 } from "../source-index-progress";
 import { getSourceProvider } from "../source-providers";
 import { exportSourceSnapshot, importSourceSnapshot } from "../source-snapshots";
+import { authConfig } from "./state";
 
 interface SourceIndexJobInput {
 	readonly source: SignetSourceEntry;
@@ -116,6 +118,24 @@ export function registerSourcesRoutes(app: Hono, deps: RegisterSourcesRoutesDeps
 	const startBridge = deps.startBridge ?? startNativeMemoryBridge;
 	const purgeNativeSource = deps.purgeNativeSource ?? purgeNativeMemorySourceArtifacts;
 	cleanupSourceDeletionTombstones(agentsDir, purgeNativeSource);
+
+	app.use("/api/sources", async (c, next) => {
+		return requirePermission("documents", authConfig)(c, next);
+	});
+	app.use("/api/sources/pick-directory", async (c, next) => {
+		return requirePermission("admin", authConfig)(c, next);
+	});
+	app.use("/api/sources/*/snapshot", async (c, next) => {
+		return requirePermission("admin", authConfig)(c, next);
+	});
+	app.use("/api/sources/*/snapshot/import", async (c, next) => {
+		return requirePermission("admin", authConfig)(c, next);
+	});
+	app.use("/api/sources/*", async (c, next) => {
+		if (c.req.method === "GET") return requirePermission("documents", authConfig)(c, next);
+		return requirePermission("admin", authConfig)(c, next);
+	});
+
 	app.get("/api/sources", (c) => {
 		const config = loadSourcesConfig(agentsDir);
 		const agentId = resolveDaemonAgentId();

--- a/surfaces/cli/src/features/setup-fresh.ts
+++ b/surfaces/cli/src/features/setup-fresh.ts
@@ -106,6 +106,9 @@ export async function runFreshSetup(cfg: FreshSetupConfig, deps: SetupDeps): Pro
 			network: {
 				mode: cfg.networkMode,
 			},
+			auth: {
+				mode: cfg.networkMode === "tailscale" ? "hybrid" : "local",
+			},
 			harnesses: cfg.harnesses,
 			install: {
 				primary_package_manager: packageManager.family,

--- a/surfaces/cli/src/features/setup.test.ts
+++ b/surfaces/cli/src/features/setup.test.ts
@@ -6,6 +6,7 @@ import {
 	SIGNET_SECRETS_PLUGIN_ID,
 	type SetupDetection,
 	detectExistingSetup,
+	parseSimpleYaml,
 	readGraphiqState,
 	updateGraphiqActiveProject,
 } from "@signet/core";
@@ -479,5 +480,22 @@ describe("setupWizard non-interactive harness hooks", () => {
 			exitSpy.mockRestore();
 			errorSpy.mockRestore();
 		}
+	});
+
+	it("writes hybrid auth when non-interactive setup enables tailscale hosting", async () => {
+		root = mkdtempSync(join(tmpdir(), "setup-tailscale-auth-"));
+		const basePath = join(root, "agents");
+		const deps = stubDeps({
+			AGENTS_DIR: basePath,
+			normalizeAgentPath: mock((p: string) => p),
+			detectExistingSetup: mock(() => ({ ...fakeDetection(basePath), agentsDir: false })),
+		});
+
+		await setupWizard({ nonInteractive: true, networkMode: "tailscale", skipGit: true }, deps);
+
+		const raw = readFileSync(join(basePath, "agent.yaml"), "utf8");
+		const parsed = parseSimpleYaml(raw) as { auth?: { mode?: string }; network?: { mode?: string } };
+		expect(parsed.network?.mode).toBe("tailscale");
+		expect(parsed.auth?.mode).toBe("hybrid");
 	});
 });


### PR DESCRIPTION
## Summary

Adds permission guards to the daemon control-plane surfaces called out in the follow-up security review and closes the Tailscale setup gap where a remote bind could otherwise default to local unauthenticated mode when no explicit auth mode is configured.

## Changes

- Requires admin permission for marketplace MCP configuration, test/install/register/call/resource, and policy mutation routes that can spawn stdio commands or invoke installed MCP servers.
- Requires source-data permissions for source listing/health and admin permission for source snapshot export/import, directory picking, add, and delete mutation paths.
- Requires recall permission for plural memory and embedding export endpoints that return memory content or vectors.
- Requires diagnostics permission for config, identity, log read endpoints, and non-mutating tray status reads.
- Requires admin permission for agent create/delete, scheduled task creation/mutation/manual runs, skill install/uninstall, and OpenAI-compatible `/v1/*` inference gateway routes.
- Requires remember permission for external hook lifecycle endpoints that write session or memory artifacts.
- Requires admin permission and rate limiting for OS chat, visual agent execution/state, exact tray collection mutations, tray reprobe/update, and OS install routes.
- Defaults Tailscale-hosted setup/config loading to `auth.mode: hybrid` only when `auth.mode` is absent, preserving loopback access while requiring tokens for remote callers on default configs.
- Preserves an explicit `auth.mode: local` on Tailscale configs for compatibility with intentionally configured local-mode deployments.
- Adds regression coverage for the guarded route groups, exact tray collection rate limiting, diagnostics-readable tray status, and Tailscale auth default/explicit-mode behavior.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

N/A; no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

No database migrations. Rollback is reverting this guard commit; Tailscale setups would again need explicit auth configuration if rolled back.

## Testing

- [x] `bun test platform/daemon/src/daemon-refactor.test.ts platform/daemon/src/daemon-auth-guard-colocation.test.ts platform/daemon/src/memory-config.test.ts`
- [x] `bun test platform/daemon/src/daemon-refactor.test.ts platform/daemon/src/daemon-auth-guard-colocation.test.ts platform/daemon/src/inference-api.test.ts platform/daemon/src/memory-config.test.ts`
- [x] `bun test platform/daemon/src/daemon-auth-guard-colocation.test.ts platform/daemon/src/inference-api.test.ts platform/daemon/src/memory-config.test.ts`
- [x] `bun test surfaces/cli/src/features/setup.test.ts -t "writes hybrid auth"`
- [x] `bun test surfaces/cli/src/features/setup.test.ts`
- [x] `bunx biome check platform/daemon/src/daemon-refactor.test.ts platform/daemon/src/memory-config.ts platform/daemon/src/memory-config.test.ts platform/daemon/src/routes/app-tray.ts platform/daemon/src/daemon-auth-guard-colocation.test.ts`
- [x] `bunx biome check platform/daemon/src/routes/app-tray.ts platform/daemon/src/routes/memory-routes.ts platform/daemon/src/routes/misc-routes.ts platform/daemon/src/routes/hooks-routes.ts platform/daemon/src/routes/skills.ts platform/daemon/src/daemon-auth-guard-colocation.test.ts`
- [x] `bunx biome check platform/daemon/src/routes/marketplace.ts platform/daemon/src/routes/sources-routes.ts platform/daemon/src/routes/os-chat.ts platform/daemon/src/routes/os-agent.ts platform/daemon/src/routes/app-tray.ts platform/daemon/src/daemon.ts platform/daemon/src/memory-config.ts platform/daemon/src/daemon-auth-guard-colocation.test.ts platform/daemon/src/inference-api.test.ts platform/daemon/src/memory-config.test.ts surfaces/cli/src/features/setup-fresh.ts surfaces/cli/src/features/setup.test.ts`
- [x] `bun audit --audit-level critical`
- [x] `git diff --check`

Notes on local checks:

- The targeted Biome check over the newly touched route files exits successfully but reports pre-existing `noExplicitAny` warnings in unchanged sections of `platform/daemon/src/routes/memory-routes.ts`.
- Full daemon type generation was not re-run here; the predecessor PR documented existing daemon/core TypeScript project-boundary and DB typing failures unrelated to this patch.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

This is a follow-up to #793, which already merged the critical dependency audit fixes. This PR is intentionally scoped to the route/auth findings from the follow-up review.
