### PR TITLE
feat(hooks): gate prompt injection on entity context

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -334,15 +334,18 @@ linked entities are all in the top-10% by degree (P90 threshold,
 date-anchored memories (1.2x). All three stages are independently
 toggleable via `DampeningConfig`.
 
-**Recall surface parity**: all recall entry points should route through the
-same daemon recall implementation whenever possible. Current daemon HTTP
-recall, search aliases, hook recall, prompt-submit injection, and MCP memory
-search all call `hybridRecall`, so they receive the same structured evidence
-shaping behavior. Any future recall surface, including CLI shortcuts, SDK
-helpers, desktop UI search, connector-specific recall, or daemon-rs parity work,
-must either call the daemon recall API or implement the same evidence-channel
-contract. Do not add a separate recall path that bypasses lexical, semantic,
-prospective hint, and traversal evidence shaping.
+**Recall surface parity**: explicit recall entry points should route through
+the same daemon recall implementation whenever possible. Current daemon HTTP
+recall, search aliases, hook recall, and MCP memory search call `hybridRecall`,
+so they receive the same structured evidence shaping behavior. Prompt-submit is
+intentionally not an explicit recall surface: it listens for known ontology
+entities or active aliases and injects compact current-view attributes only
+when an entity aspect clears the configured confidence gate. Any future recall
+surface, including CLI shortcuts, SDK helpers, desktop UI search,
+connector-specific recall, or daemon-rs parity work, must either call the
+daemon recall API or implement the same evidence-channel contract. Do not add a
+separate recall path that bypasses lexical, semantic, prospective hint, and
+traversal evidence shaping.
 
 **Graph boost fallback** (`graph-search.ts`): `getGraphBoostIds`
 is the legacy graph-augmented search path, used when traversal is
@@ -964,7 +967,7 @@ All endpoints are served by the Hono server on port 3850.
 | `/api/embeddings/health` | GET | recall | Embedding health metrics |
 | `/api/embeddings/projection` | GET | recall | UMAP 2D/3D projection |
 | `/api/hooks/session-start` | POST | remember | Inject context into session |
-| `/api/hooks/user-prompt-submit` | POST | recall | Per-prompt context load |
+| `/api/hooks/user-prompt-submit` | POST | recall | Per-prompt entity context load |
 | `/api/hooks/session-end` | POST | remember | Extract session memories |
 | `/api/hooks/remember` | POST | remember | Save a memory via hook |
 | `/api/hooks/recall` | POST | recall | Search via hook |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -569,7 +569,7 @@ Database Schema
 SQLite with WAL mode. Migrations are numbered sequentially under
 `platform/core/src/migrations/`. Each migration is idempotent — safe
 to re-run against an existing database. Schema version is tracked in
-`schema_migrations`. The latest migration is `076-temporal-edges.ts`.
+`schema_migrations`. The latest migration is `077-entity-aliases.ts`.
 
 **schema_migrations**
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -206,11 +206,11 @@ Vector embedding configuration for semantic memory search.
 | `dimensions` | number | `768` | Output vector dimensions |
 | `base_url` | string | `"http://localhost:11434"` | Ollama API base URL |
 | `api_key` | string | — | API key or `$secret:NAME` reference |
-| `promptSubmitTimeoutMs` | number | `1000` | Prompt-submit recall embedding timeout, range 1000-300000 ms |
+| `promptSubmitTimeoutMs` | number | `1000` | Explicit recall embedding timeout retained for compatibility, range 1000-300000 ms |
 
-Increase `promptSubmitTimeoutMs` when local embedding models are slow to
+Increase the embedding timeout when local embedding models are slow to
 cold-load. For example, Ollama with `mxbai-embed-large` may need `10000` ms
-to avoid aborted prompt-submit recall embeddings.
+to avoid aborted explicit recall embeddings.
 
 Recommended Ollama models:
 
@@ -1231,14 +1231,14 @@ a pre-compaction summary:
 | `memoryLimit` | `5` | How many recent memories to include |
 | `summaryGuidelines` | built-in | Custom instructions for session summary |
 
-`hooks.userPromptSubmit` controls per-prompt memory injection:
+`hooks.userPromptSubmit` controls per-prompt entity current-view injection:
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `enabled` | `true` | Enable per-prompt recall injection |
-| `recallLimit` | `10` | Max recall candidates considered |
-| `maxInjectChars` | `500` | Prompt-time injection character budget |
-| `minScore` | `0.8` | Minimum top recall score required before injecting memories |
+| `enabled` | `true` | Enable per-prompt entity context injection |
+| `recallLimit` | `10` | Legacy field retained for config compatibility; prompt-submit no longer runs generic recall |
+| `maxInjectChars` | `500` | Prompt-time entity-context character budget |
+| `minScore` | `0.8` | Minimum aspect score required before injecting current-view attributes |
 
 
 Environment Variables

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -106,8 +106,8 @@ mode expectations across harness paths.
 
 | Harness path | Prompt retrieval order | Thread-head continuity | Compaction artifact persistence | Forced post-event MEMORY refresh |
 |---|---|---|---|---|
-| TS daemon (primary) | hybrid -> temporal-fallback; transcripts via explicit `session_search` | yes | yes | yes (session-summary + compaction-complete) |
-| daemon-rs shadow | hybrid-style scoped recall with temporal fallback | yes (agent-scoped retrieval path) | partial (hook route persistence only) | degraded (full event-driven refresh parity follows rust cutover wave) |
+| TS daemon (primary) | entity current-view injection; transcripts via explicit `session_search` | yes | yes | yes (session-summary + compaction-complete) |
+| daemon-rs shadow | entity current-view injection | yes (agent-scoped retrieval path) | partial (hook route persistence only) | degraded (full event-driven refresh parity follows rust cutover wave) |
 
 Degraded mode rules:
 
@@ -281,7 +281,7 @@ still uses daemon-side dedupe keyed by `session_key`, `agent_id`, and
 2. On supported Codex installs, Signet writes a local plugin marketplace bundle and registers `signet@signet-local` in `~/.codex/config.toml`.
 3. While plugin lifecycle hooks are not available, Codex also reads compatibility hooks from `~/.codex/hooks.json`.
 4. On session start, Codex fires `SessionStart` → calls `signet hook session-start -H codex --codex-json` → Signet returns identity + memories as `hookSpecificOutput.additionalContext` with `suppressOutput: true`, injected into the model's context window without printing the hook payload to the user transcript.
-5. On every user prompt, Codex fires `UserPromptSubmit` → calls `signet hook user-prompt-submit -H codex --codex-json` → Signet returns bounded Signet context as `hookSpecificOutput.additionalContext` with `suppressOutput: true` so the context is model-visible but not printed into the user transcript. This is blocking — Codex waits for the hook before sending to the model.
+5. On every user prompt, Codex fires `UserPromptSubmit` → calls `signet hook user-prompt-submit -H codex --codex-json` → Signet returns bounded entity current-view context only when the prompt mentions a known entity or active alias. Empty matches return no additional context. This is blocking — Codex waits for the hook before sending to the model.
 6. On session end, Codex fires `Stop` → calls `signet hook session-end -H codex` → Signet extracts memories from the transcript.
 7. The MCP server exposes `signet_recall`, `signet_source_search`, `signet_session_search`, `signet_save_note`, and compatibility `memory_*` tools that Codex can invoke directly during sessions.
 
@@ -318,7 +318,7 @@ Claude Code or OpenCode.
 | Hook | Supported |
 |------|-----------|
 | session-start | yes — identity + memories via `hookSpecificOutput.additionalContext` |
-| user-prompt-submit | yes — per-prompt recall via `hookSpecificOutput.additionalContext` |
+| user-prompt-submit | yes — entity current-view context via `hookSpecificOutput.additionalContext` when matched |
 | session-end | yes — transcript extraction via `Stop` hook |
 
 ### MCP tools
@@ -743,8 +743,8 @@ Hermes lifecycle.
    `POST /api/hooks/session-start` to load identity, memories, and system
    prompt injection from the daemon.
 4. On each user turn, `queue_prefetch()` fires
-   `POST /api/hooks/user-prompt-submit` for per-turn hybrid recall
-   (BM25 + vector + KG + predictive scoring).
+   `POST /api/hooks/user-prompt-submit` for entity current-view context when
+   the prompt mentions a known entity or active alias.
 5. At session end, `on_session_end()` sends the accumulated transcript via
    `POST /api/hooks/session-end` for async pipeline extraction.
 
@@ -766,7 +766,7 @@ Hermes lifecycle.
 | Hook | Supported |
 |------|-----------|
 | session-start | yes — identity + memories via `system_prompt_block()` |
-| user-prompt-submit | yes — per-turn recall via `queue_prefetch()` / `prefetch()` |
+| user-prompt-submit | yes — entity current-view context via `queue_prefetch()` / `prefetch()` |
 | pre-compaction | yes — daemon-generated summary guidelines via `on_pre_compress()` |
 | compaction-complete | yes — saves summary as session memory via `on_compaction_complete()` |
 | checkpoint-extract | yes — periodic mid-session delta extraction every 30 turns |

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -18,7 +18,7 @@ Hooks are HTTP endpoints exposed by the Signet [[daemon]]. Harnesses call them a
 | Hook | When | Purpose |
 |------|------|---------|
 | `session-start` | New session begins | Inject memories, identity, and the Memory Check Loop into context |
-| `user-prompt-submit` | Before each user turn | Inject lightweight per-turn Memory Check guidance plus structured, temporal, or transcript recall when needed |
+| `user-prompt-submit` | Before each user turn | Inject compact current-view context only when the prompt mentions a known entity or active entity alias |
 | `session-end` | Session finishes | Persist transcript lineage and queue session summary |
 | `pre-compaction` | Before context compaction | Get summary guidelines |
 | `compaction-complete` | After compaction | Save a first-class compaction artifact into the temporal DAG |
@@ -142,28 +142,26 @@ where recency is `1 / (1 + age_in_days)`.
 
 **`POST /api/hooks/user-prompt-submit`**
 
-Called before each user turn is handed to the model. Returns lightweight
-context for the current prompt.
+Called before each user turn is handed to the model. Prompt-submit does not run
+generic memory recall and does not inject fallback guidance when it cannot find
+a confident match.
 
-The hook always includes current date/time metadata and per-turn Memory Check
-guidance unless the session is bypassed. When automatic recall finds useful
-context, the response also includes a `## Relevant Memory` block. When no
-strong automatic match is found, the response says so explicitly and reminds
-the agent to run targeted Signet recall before acting if the request depends
-on prior context, preferences, project history, or unresolved work. Both
-matched and no-strong-match paths also remind the agent to save durable facts
-with `/remember` or `memory_store`.
+The hook listens for known ontology entities and active entity aliases. When a
+prompt names one, Signet scores that entity's aspects against the prompt and
+injects a compact `## Relevant Entity Context` block from the highest-scoring
+current attributes and constraints. `hooks.userPromptSubmit.minScore` gates
+aspect injection; `maxInjectChars` caps the block.
 
-Recall order is:
+When the prompt is low-signal, mentions no known entity or alias, is ambiguous,
+or no aspect clears the confidence gate, the hook returns an empty `inject`
+string. This keeps the active agent loop trustable: absence of injected context
+means Signet chose not to inject, not that the broader source substrate has no
+relevant evidence.
 
-1. structured memory recall,
-2. temporal thread-head fallback.
-
-Raw transcript search is deliberately not injected through this hook. Use
-`session_search` when a caller needs transcript evidence.
-
-The guidance is meant to prevent agents from treating an empty automatic
-inject as proof that no prior context exists.
+Explicit recall remains available through `/api/memory/recall`, `signet_recall`,
+`memory_search`, and related MCP/CLI surfaces. Raw transcript search is
+deliberately not injected through this hook; use `session_search` when a caller
+needs transcript evidence.
 
 ---
 

--- a/docs/api/knowledge-ontology.md
+++ b/docs/api/knowledge-ontology.md
@@ -129,6 +129,49 @@ in a memory that is not yet linked. This endpoint does not mutate graph data.
 
 MCP exposes the same report as `knowledge_hygiene_report`.
 
+## Entity aliases
+
+Entity aliases are reviewed ontology metadata used by prompt-submit entity
+detection and navigation tooling. They do not create duplicate entities. Active
+aliases are matched as exact normalized phrases and resolve back to the
+canonical entity current view.
+
+### GET /api/ontology/entities/:id/aliases
+
+List aliases for an entity id. Query parameters: `agent_id` and `status`.
+`status` may be `active`, `archived`, or `all`; it defaults to `active`.
+
+```text
+/api/ontology/entities/entity_signet/aliases?agent_id=ant&status=all
+```
+
+### POST /api/ontology/entities/:id/aliases
+
+Create an active alias for an entity id. Body parameters: `alias`,
+`confidence`, and `source`. `confidence` is clamped to `0..1` and defaults to
+`1.0`.
+
+```json
+{
+  "alias": "SignetAI",
+  "confidence": 0.95,
+  "source": "operator"
+}
+```
+
+### DELETE /api/ontology/entities/:id/aliases/:aliasId
+
+Archive an alias. Archived aliases are retained for inspection but are ignored
+by prompt-submit entity matching.
+
+CLI equivalents:
+
+```bash
+signet ontology entity alias list entity_signet --status all
+signet ontology entity alias add entity_signet SignetAI --confidence 0.95 --source operator
+signet ontology entity alias archive entity_signet alias_123
+```
+
 
 ## Ontology proposal loop
 

--- a/docs/api/sessions-hooks.md
+++ b/docs/api/sessions-hooks.md
@@ -56,8 +56,9 @@ Code parent activity in the same project.
 
 ### POST /api/hooks/user-prompt-submit
 
-Called on each user message. Returns memories relevant to the current prompt
-for in-context injection.
+Called on each user message. Returns compact entity current-view context only
+when the prompt mentions a known ontology entity or active alias and at least
+one aspect clears the confidence gate.
 
 **Request body**
 
@@ -78,11 +79,13 @@ for in-context injection.
 `userPrompt`, `lastAssistantMessage`, `transcriptPath`, and inline `transcript`
 are optional.
 
-Prompt-submit retrieval prefers structured memory recall. When structured
-recall is weak or empty, the daemon may attempt temporal-summary fallback
-(session DAG artifacts). Raw transcript search is not injected on
-prompt-submit; use the dedicated `session_search` MCP/API surface when a
-caller needs transcript evidence.
+Prompt-submit does not run generic memory recall and has no fallback injection.
+Low-signal prompts, unknown entities, ambiguous entity mentions, and prompts
+where no aspect clears `hooks.userPromptSubmit.minScore` return `inject: ""`.
+Explicit recall is still available through `/api/memory/recall` and MCP/CLI
+recall tools. Raw transcript search is not injected on prompt-submit; use the
+dedicated `session_search` MCP/API surface when a caller needs transcript
+evidence.
 
 ### POST /api/hooks/session-end
 

--- a/platform/core/src/migrations/077-entity-aliases.ts
+++ b/platform/core/src/migrations/077-entity-aliases.ts
@@ -1,0 +1,26 @@
+import type { MigrationDb } from "./index";
+
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS entity_aliases (
+			id TEXT PRIMARY KEY,
+			entity_id TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+			agent_id TEXT NOT NULL DEFAULT 'default',
+			alias TEXT NOT NULL,
+			canonical_alias TEXT NOT NULL,
+			confidence REAL NOT NULL DEFAULT 1.0,
+			source TEXT,
+			status TEXT NOT NULL DEFAULT 'active',
+			created_at TEXT NOT NULL DEFAULT (datetime('now')),
+			updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+		);
+
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_entity_aliases_active_unique
+			ON entity_aliases(agent_id, canonical_alias)
+			WHERE status = 'active';
+		CREATE INDEX IF NOT EXISTS idx_entity_aliases_entity
+			ON entity_aliases(agent_id, entity_id, status);
+		CREATE INDEX IF NOT EXISTS idx_entity_aliases_lookup
+			ON entity_aliases(agent_id, canonical_alias, status);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -82,6 +82,7 @@ import { up as recallContextDedupe } from "./073-recall-context-dedupe";
 import { up as aggregateMemoryLinks } from "./074-aggregate-memory-links";
 import { up as memoryArtifactSourceProvenance } from "./075-memory-artifact-source-provenance";
 import { up as temporalEdges } from "./076-temporal-edges";
+import { up as entityAliases } from "./077-entity-aliases";
 
 // -- Public interface consumed by Database.init() --
 
@@ -724,6 +725,14 @@ export const MIGRATIONS: readonly Migration[] = [
 		up: temporalEdges,
 		artifacts: {
 			tables: ["temporal_edges"],
+		},
+	},
+	{
+		version: 77,
+		name: "entity-aliases",
+		up: entityAliases,
+		artifacts: {
+			tables: ["entity_aliases"],
 		},
 	},
 ];

--- a/platform/core/src/migrations/migrations.test.ts
+++ b/platform/core/src/migrations/migrations.test.ts
@@ -199,6 +199,11 @@ describe("migration framework", () => {
 
 		// v66 tables (ontology proposal loop)
 		expect(tableNames).toContain("ontology_proposals");
+
+		// v77 tables (entity aliases)
+		expect(tableNames).toContain("entity_aliases");
+		const aliasIndexes = db.query("PRAGMA index_list(entity_aliases)").all() as Array<{ name: string }>;
+		expect(aliasIndexes.map((index) => index.name)).toContain("idx_entity_aliases_active_unique");
 	});
 
 	test("memories table has expected v2 columns", () => {

--- a/platform/core/src/types.ts
+++ b/platform/core/src/types.ts
@@ -662,6 +662,19 @@ export interface Entity {
 	updatedAt: string;
 }
 
+export interface EntityAlias {
+	readonly id: string;
+	readonly entityId: string;
+	readonly agentId: string;
+	readonly alias: string;
+	readonly canonicalAlias: string;
+	readonly confidence: number;
+	readonly source: string | null;
+	readonly status: OntologyRowStatus;
+	readonly createdAt: string;
+	readonly updatedAt: string;
+}
+
 export interface Relation {
 	id: string;
 	sourceEntityId: string;

--- a/platform/daemon-rs/contracts/schema.sql
+++ b/platform/daemon-rs/contracts/schema.sql
@@ -131,7 +131,7 @@ CREATE TABLE entities (
 			description TEXT,
 			created_at TEXT NOT NULL,
 			updated_at TEXT NOT NULL
-		, canonical_name TEXT, mentions INTEGER DEFAULT 0, embedding BLOB, agent_id TEXT NOT NULL DEFAULT 'default', pinned INTEGER NOT NULL DEFAULT 0, pinned_at TEXT);
+		, canonical_name TEXT, mentions INTEGER DEFAULT 0, embedding BLOB, agent_id TEXT NOT NULL DEFAULT 'default', pinned INTEGER NOT NULL DEFAULT 0, pinned_at TEXT, status TEXT NOT NULL DEFAULT 'active');
 CREATE TABLE relations (
 			id TEXT PRIMARY KEY,
 			source_entity_id TEXT NOT NULL,
@@ -408,6 +408,7 @@ CREATE TABLE entity_aspects (
 			weight         REAL NOT NULL DEFAULT 0.5,
 			created_at     TEXT NOT NULL DEFAULT (datetime('now')),
 			updated_at     TEXT NOT NULL DEFAULT (datetime('now')),
+			status          TEXT NOT NULL DEFAULT 'active',
 			UNIQUE(entity_id, canonical_name)
 		);
 CREATE INDEX idx_entity_aspects_entity ON entity_aspects(entity_id);
@@ -427,11 +428,31 @@ CREATE TABLE entity_attributes (
 			superseded_by      TEXT,
 			created_at         TEXT NOT NULL DEFAULT (datetime('now')),
 			updated_at         TEXT NOT NULL DEFAULT (datetime('now'))
+		, version INTEGER NOT NULL DEFAULT 1
 		);
 CREATE INDEX idx_entity_attributes_aspect ON entity_attributes(aspect_id);
 CREATE INDEX idx_entity_attributes_agent ON entity_attributes(agent_id);
 CREATE INDEX idx_entity_attributes_kind ON entity_attributes(kind);
 CREATE INDEX idx_entity_attributes_status ON entity_attributes(status);
+CREATE TABLE entity_aliases (
+    id TEXT PRIMARY KEY,
+    entity_id TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+    agent_id TEXT NOT NULL DEFAULT 'default',
+    alias TEXT NOT NULL,
+    canonical_alias TEXT NOT NULL,
+    confidence REAL NOT NULL DEFAULT 1.0,
+    source TEXT,
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE UNIQUE INDEX idx_entity_aliases_active_unique
+    ON entity_aliases(agent_id, canonical_alias)
+    WHERE status = 'active';
+CREATE INDEX idx_entity_aliases_entity
+    ON entity_aliases(agent_id, entity_id, status);
+CREATE INDEX idx_entity_aliases_lookup
+    ON entity_aliases(agent_id, canonical_alias, status);
 CREATE TABLE entity_dependencies (
 			id                TEXT PRIMARY KEY,
 			source_entity_id  TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,

--- a/platform/daemon-rs/crates/signet-core/src/migrations.rs
+++ b/platform/daemon-rs/crates/signet-core/src/migrations.rs
@@ -21,6 +21,8 @@ const TS_ONTOLOGY_PROPOSALS_VERSION: u32 = 67;
 const TS_ONTOLOGY_PROPOSALS_NAME: &str = "ontology-proposals";
 const TS_AGENT_SCOPED_IDEMPOTENCY_VERSION: u32 = 72;
 const TS_AGENT_SCOPED_IDEMPOTENCY_NAME: &str = "agent-scoped-idempotency-key";
+const TS_ENTITY_ALIASES_VERSION: u32 = 77;
+const TS_ENTITY_ALIASES_NAME: &str = "entity-aliases";
 
 /// Simple checksum matching the TS implementation (hash of "version:name").
 fn checksum(version: u32, name: &str) -> String {
@@ -385,11 +387,13 @@ pub fn run(conn: &Connection) -> Result<(), CoreError> {
 fn ensure_cross_daemon_parity_tables(conn: &Connection) -> Result<(), CoreError> {
     conn.execute_batch(include_str!("sql/040-memory-search-telemetry.sql"))?;
     conn.execute_batch(include_str!("sql/041-ontology-proposals.sql"))?;
+    conn.execute_batch(include_str!("sql/042-entity-aliases.sql"))?;
     stamp_typescript_parity_migration(
         conn,
         TS_MEMORY_SEARCH_TELEMETRY_VERSION,
         TS_MEMORY_SEARCH_TELEMETRY_NAME,
     )?;
+    stamp_typescript_parity_migration(conn, TS_ENTITY_ALIASES_VERSION, TS_ENTITY_ALIASES_NAME)?;
     Ok(())
 }
 
@@ -397,6 +401,7 @@ fn ensure_cross_daemon_parity_columns(conn: &Connection) -> Result<(), CoreError
     add_column_if_missing(conn, "entities", "mentions", "INTEGER NOT NULL DEFAULT 0")?;
     add_column_if_missing(conn, "entities", "pinned", "INTEGER NOT NULL DEFAULT 0")?;
     add_column_if_missing(conn, "entities", "pinned_at", "TEXT")?;
+    add_column_if_missing(conn, "entities", "status", "TEXT NOT NULL DEFAULT 'active'")?;
     add_column_if_missing(conn, "entities", "updated_at", "TEXT")?;
 
     add_column_if_missing(conn, "memories", "agent_id", "TEXT DEFAULT 'default'")?;
@@ -413,6 +418,13 @@ fn ensure_cross_daemon_parity_columns(conn: &Connection) -> Result<(), CoreError
     )?;
     add_column_if_missing(conn, "connectors", "enabled", "INTEGER NOT NULL DEFAULT 1")?;
 
+    add_column_if_missing(
+        conn,
+        "entity_aspects",
+        "status",
+        "TEXT NOT NULL DEFAULT 'active'",
+    )?;
+
     add_column_if_missing(conn, "entity_attributes", "proposal_id", "TEXT")?;
     add_column_if_missing(conn, "entity_attributes", "group_key", "TEXT")?;
     add_column_if_missing(conn, "entity_attributes", "claim_key", "TEXT")?;
@@ -425,6 +437,12 @@ fn ensure_cross_daemon_parity_columns(conn: &Connection) -> Result<(), CoreError
         "entity_attributes",
         "proposal_evidence",
         "TEXT NOT NULL DEFAULT '[]'",
+    )?;
+    add_column_if_missing(
+        conn,
+        "entity_attributes",
+        "version",
+        "INTEGER NOT NULL DEFAULT 1",
     )?;
     add_column_if_missing(conn, "entity_dependencies", "proposal_id", "TEXT")?;
     add_column_if_missing(conn, "entity_dependencies", "confidence", "REAL")?;

--- a/platform/daemon-rs/crates/signet-core/src/sql/042-entity-aliases.sql
+++ b/platform/daemon-rs/crates/signet-core/src/sql/042-entity-aliases.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS entity_aliases (
+    id TEXT PRIMARY KEY,
+    entity_id TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+    agent_id TEXT NOT NULL DEFAULT 'default',
+    alias TEXT NOT NULL,
+    canonical_alias TEXT NOT NULL,
+    confidence REAL NOT NULL DEFAULT 1.0,
+    source TEXT,
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_entity_aliases_active_unique
+    ON entity_aliases(agent_id, canonical_alias)
+    WHERE status = 'active';
+CREATE INDEX IF NOT EXISTS idx_entity_aliases_entity
+    ON entity_aliases(agent_id, entity_id, status);
+CREATE INDEX IF NOT EXISTS idx_entity_aliases_lookup
+    ON entity_aliases(agent_id, canonical_alias, status);

--- a/platform/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/platform/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -834,38 +834,147 @@ fn trim_for_inject(text: &str, limit: usize) -> String {
     format!("{}...", &trimmed[..end])
 }
 
-fn escape_like(text: &str) -> String {
-    text.replace('\\', "\\\\")
-        .replace('%', "\\%")
-        .replace('_', "\\_")
-}
-
-fn extract_anchor_terms(text: &str) -> Vec<String> {
-    let mut out = Vec::new();
-    let mut seen = std::collections::HashSet::new();
-    for token in text.to_lowercase().split(|c: char| {
-        !c.is_ascii_alphanumeric() && c != '_' && c != ':' && c != '/' && c != '.' && c != '-'
-    }) {
-        if token.len() < 6 {
-            continue;
-        }
-        let has_digit = token.chars().any(|c| c.is_ascii_digit());
-        let has_marker = token.contains('_')
-            || token.contains(':')
-            || token.contains('/')
-            || token.contains('.')
-            || token.contains('-');
-        if !has_digit && !has_marker && token.len() < 18 {
-            continue;
-        }
-        if seen.insert(token.to_string()) {
-            out.push(token.to_string());
-            if out.len() >= 8 {
-                break;
-            }
+fn normalize_prompt_entity_text(text: &str) -> String {
+    let mut out = String::new();
+    let mut prev_space = true;
+    for ch in text.to_lowercase().chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch);
+            prev_space = false;
+        } else if !prev_space {
+            out.push(' ');
+            prev_space = true;
         }
     }
-    out
+    out.trim().to_string()
+}
+
+fn phrase_appears_in_prompt(prompt: &str, phrase: &str) -> bool {
+    let prompt = format!(" {} ", normalize_prompt_entity_text(prompt));
+    let phrase = normalize_prompt_entity_text(phrase);
+    !phrase.is_empty() && prompt.contains(&format!(" {phrase} "))
+}
+
+fn is_low_signal_prompt(prompt: &str) -> bool {
+    let normalized = normalize_prompt_entity_text(prompt);
+    if normalized.is_empty() {
+        return true;
+    }
+    matches!(
+        normalized.as_str(),
+        "cool"
+            | "got it"
+            | "go ahead"
+            | "great"
+            | "k"
+            | "kk"
+            | "nice"
+            | "ok"
+            | "okay"
+            | "okay cool"
+            | "sounds good"
+            | "sure"
+            | "thanks"
+            | "thank you"
+            | "yes"
+            | "yes please"
+            | "yep"
+    )
+}
+
+fn is_prompt_context_term(term: &str) -> bool {
+    term.len() >= 3
+        && !matches!(
+            term,
+            "about"
+                | "actually"
+                | "after"
+                | "all"
+                | "also"
+                | "and"
+                | "any"
+                | "are"
+                | "before"
+                | "but"
+                | "can"
+                | "could"
+                | "did"
+                | "does"
+                | "doing"
+                | "done"
+                | "for"
+                | "from"
+                | "get"
+                | "had"
+                | "has"
+                | "have"
+                | "hey"
+                | "how"
+                | "into"
+                | "its"
+                | "just"
+                | "kind"
+                | "like"
+                | "make"
+                | "more"
+                | "need"
+                | "now"
+                | "okay"
+                | "our"
+                | "out"
+                | "please"
+                | "pretty"
+                | "really"
+                | "right"
+                | "say"
+                | "should"
+                | "some"
+                | "something"
+                | "still"
+                | "sure"
+                | "thanks"
+                | "thank"
+                | "that"
+                | "the"
+                | "their"
+                | "them"
+                | "then"
+                | "there"
+                | "these"
+                | "they"
+                | "this"
+                | "too"
+                | "use"
+                | "very"
+                | "want"
+                | "was"
+                | "well"
+                | "were"
+                | "what"
+                | "when"
+                | "which"
+                | "who"
+                | "why"
+                | "will"
+                | "with"
+                | "would"
+                | "yeah"
+                | "yes"
+                | "you"
+                | "your"
+        )
+        && !term.chars().all(|ch| ch.is_ascii_digit())
+}
+
+fn build_entity_context_inject(metadata_header: &str, lines: &[String]) -> String {
+    let mut parts = vec![
+        metadata_header.trim_end().to_string(),
+        String::new(),
+        "## Relevant Entity Context".to_string(),
+        String::new(),
+    ];
+    parts.extend_from_slice(lines);
+    format!("{}\n", parts.join("\n").trim_end())
 }
 
 fn format_metadata_header() -> String {
@@ -874,38 +983,6 @@ fn format_metadata_header() -> String {
         "# Current Date & Time\n{} ({})\n",
         now.format("%A, %B %-d, %Y at %-I:%M %p"),
         now.format("%Z")
-    )
-}
-
-fn build_prompt_recall_inject(metadata_header: &str, sources: &[String]) -> String {
-    // Keep formatting behavior aligned with TypeScript
-    // `buildPromptRecallInject()` in `platform/daemon/src/hooks.ts`.
-    let mut parts = vec![
-        metadata_header.trim_end().to_string(),
-        String::new(),
-        "## Memory Check".to_string(),
-        String::new(),
-        "Use the memories below as starting context before acting. If the task depends on prior context and anything is missing, run 1-3 targeted recalls with /recall or memory_search. Ask natural questions with entity + event + timeframe when possible. Avoid bag-of-keywords recall queries. Expand with lcm_expand or knowledge_expand only when you need deeper lineage or graph context. Treat graph expansion as supporting context, not proof."
-            .to_string(),
-        String::new(),
-        "## Relevant Memory".to_string(),
-        String::new(),
-    ];
-
-    parts.extend_from_slice(sources);
-    parts.push(String::new());
-
-    parts.push(
-        "If you learn something durable, save it with /remember or memory_store.".to_string(),
-    );
-
-    format!("{}\n", parts.join("\n").trim_end())
-}
-
-fn build_no_strong_memory_match_inject(metadata_header: &str) -> String {
-    format!(
-        "{}\n\n## Memory Check\n\nNo strong automatic memory match was injected for this turn. If the request depends on prior context, preferences, project history, or unresolved work, run 1-3 targeted Signet recalls before executing commands, editing files, or making decisions. Ask natural questions with entity + event + timeframe when possible. Avoid bag-of-keywords recall queries. Treat graph expansion as supporting context, not proof.\n\nIf you learn something durable, save it with /remember or memory_store.\n",
-        metadata_header.trim_end()
     )
 }
 
@@ -955,9 +1032,10 @@ pub async fn prompt_submit(
     let cleaned = strip_untrusted_metadata(message);
 
     // Extract simple query terms for search
-    let terms: Vec<&str> = cleaned
+    let terms: Vec<String> = normalize_prompt_entity_text(&cleaned)
         .split_whitespace()
-        .filter(|w| w.len() >= 3)
+        .filter(|w| is_prompt_context_term(w))
+        .map(str::to_string)
         .take(12)
         .collect();
     let query_terms = terms.join(" ");
@@ -1058,251 +1136,75 @@ pub async fn prompt_submit(
         }
     }
 
-    if query_terms.is_empty() {
+    if query_terms.is_empty() || is_low_signal_prompt(&cleaned) {
         return (
             StatusCode::OK,
             Json(serde_json::json!({
-                "inject": build_no_strong_memory_match_inject(&metadata_header),
+                "inject": "",
                 "memoryCount": 0,
                 "queryTerms": query_terms,
+                "engine": if query_terms.is_empty() { "no-entity" } else { "low-signal" },
             })),
         )
             .into_response();
     }
 
-    let project = body.project.clone();
-    let session_key = body.session_key.clone();
     let query_terms_for_resp = query_terms.clone();
-    // Mirror TS hooks.userPromptSubmit.minScore confidence gate. The TS path
-    // uses calibrated hybridRecall + reranker scores; here we use term-coverage
-    // (matched_terms / total_terms) as a query-relevance proxy until the Rust
-    // prompt_submit path integrates full hybrid scoring.
     let min_score = state
         .config
         .manifest
         .hooks
         .as_ref()
         .map(|h| h.user_prompt_submit.min_score)
-        .unwrap_or(0.8)
-        .clamp(0.0, 1.0);
+        .filter(|score| score.is_finite())
+        .map(|score| score.clamp(0.0, 1.0))
+        .unwrap_or(0.8);
 
     let result = state
         .pool
         .read(move |conn| {
-            let mut terms = query_terms
-                .split_whitespace()
-                .map(str::to_string)
-                .collect::<Vec<_>>();
-            if terms.is_empty() {
-                terms.push(cleaned.clone());
-            }
-            let needles = terms
-                .iter()
-                .take(6)
-                .map(|t| t.to_lowercase())
-                .collect::<Vec<_>>();
-            let like_patterns = needles
-                .iter()
-                .map(|t| format!("%{}%", escape_like(&t.to_lowercase())))
-                .collect::<Vec<_>>();
-
-            // 1) Structured recall from memories (best effort parity with TS hybrid-first path).
-            // NOTE: when full hybrid scoring / reranker integration lands, preserve actual
-            // calibrated scores from the reranker — never synthesize from rank position.
-            let mut mem_sql = String::from(
-                "SELECT id, content, created_at
-                 FROM memories
-                 WHERE deleted = 0",
-            );
-            let mut mem_params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
-            let read_policy: String = conn
+            let has_aliases = conn
                 .query_row(
-                    "SELECT read_policy FROM agents WHERE id = ?1",
-                    rusqlite::params![agent_id.clone()],
-                    |row| row.get(0),
+                    "SELECT COUNT(*) FROM sqlite_master
+                     WHERE type = 'table'
+                       AND name IN ('entities', 'entity_aspects', 'entity_attributes', 'entity_aliases')",
+                    [],
+                    |row| row.get::<_, i64>(0),
                 )
-                .unwrap_or_else(|_| "isolated".to_string());
-            match read_policy.as_str() {
-                "shared" => {
-                    mem_sql.push_str(" AND (visibility = 'global' OR agent_id = ?) AND visibility != 'archived'");
-                    mem_params.push(Box::new(agent_id.clone()));
-                }
-                "group" => {
-                    let group: Option<String> = conn
-                        .query_row(
-                            "SELECT policy_group FROM agents WHERE id = ?1",
-                            rusqlite::params![agent_id.clone()],
-                            |row| row.get(0),
-                        )
-                        .ok()
-                        .flatten();
-                    if let Some(g) = group {
-                        mem_sql.push_str(
-                            " AND ((visibility = 'global' AND agent_id IN (SELECT id FROM agents WHERE policy_group = ?)) OR agent_id = ?) AND visibility != 'archived'",
-                        );
-                        mem_params.push(Box::new(g));
-                        mem_params.push(Box::new(agent_id.clone()));
-                    } else {
-                        mem_sql.push_str(" AND agent_id = ? AND visibility != 'archived'");
-                        mem_params.push(Box::new(agent_id.clone()));
-                    }
-                }
-                _ => {
-                    mem_sql.push_str(" AND agent_id = ? AND visibility != 'archived'");
-                    mem_params.push(Box::new(agent_id.clone()));
-                }
-            }
-            if let Some(ref p) = project {
-                mem_sql.push_str(" AND project = ?");
-                mem_params.push(Box::new(p.clone()));
-            }
-            if !like_patterns.is_empty() {
-                let clauses = like_patterns
-                    .iter()
-                    .map(|_| "LOWER(content) LIKE ? ESCAPE '\\'")
-                    .collect::<Vec<_>>()
-                    .join(" OR ");
-                mem_sql.push_str(" AND (");
-                mem_sql.push_str(&clauses);
-                mem_sql.push(')');
-                for pat in &like_patterns {
-                    mem_params.push(Box::new(pat.clone()));
-                }
-            }
-            mem_sql.push_str(" ORDER BY importance DESC, created_at DESC LIMIT 5");
-            let mem_param_refs: Vec<&dyn rusqlite::types::ToSql> =
-                mem_params.iter().map(|p| p.as_ref()).collect();
-            let mem_rows = match conn.prepare(&mem_sql) {
-                Ok(mut stmt) => stmt
-                    .query_map(mem_param_refs.as_slice(), |row| {
-                        Ok((
-                            row.get::<_, String>(0)?,
-                            row.get::<_, String>(1)?,
-                            row.get::<_, String>(2)?,
-                        ))
-                    })
-                    .ok()
-                    .map(|rows| rows.filter_map(|r| r.ok()).collect::<Vec<_>>())
-                    .unwrap_or_default(),
-                Err(_) => vec![],
-            };
-
-            let anchors = extract_anchor_terms(&cleaned);
-            let anchor_missed = !anchors.is_empty()
-                && !mem_rows
-                    .iter()
-                    .take(8)
-                    .map(|(_, content, _)| content.to_lowercase())
-                    .any(|content| anchors.iter().any(|anchor| content.contains(anchor)));
-
-            // Confidence gate: compute term-coverage for the top result as a
-            // query-relevance proxy (matched_needles / total_needles → [0, 1]).
-            // Replaces the TS calibrated hybridRecall score until full hybrid
-            // scoring lands in this path.
-            let coverage = if !mem_rows.is_empty() && !needles.is_empty() {
-                let top = mem_rows[0].1.to_lowercase();
-                let matched = needles.iter().filter(|n| top.contains(n.as_str())).count();
-                matched as f64 / needles.len() as f64
-            } else {
-                0.0
-            };
-
-            if !mem_rows.is_empty() && !anchor_missed && coverage >= min_score {
-                let lines = mem_rows
-                    .iter()
-                    .map(|(_, content, created_at)| {
-                        format!("- [memory] {} ({})", trim_for_inject(content, 300), created_at)
-                    })
-                    .collect::<Vec<_>>();
+                .unwrap_or(0)
+                == 4;
+            if !has_aliases {
                 return Ok(serde_json::json!({
-                    "inject": build_prompt_recall_inject(&metadata_header, &lines),
-                    "memoryCount": lines.len(),
+                    "inject": "",
+                    "memoryCount": 0,
                     "queryTerms": query_terms_for_resp,
-                    "engine": "hybrid",
+                    "engine": "no-entity",
                 }));
             }
 
-            // 2) Temporal fallback from persisted thread heads.
-            if let Ok(mut stmt) = conn.prepare(
-                "SELECT node_id, sample, latest_at, label, project
-                 FROM memory_thread_heads
+            let entity_rows = match conn.prepare(
+                "SELECT id, name, COALESCE(canonical_name, LOWER(name)) AS matched_text,
+                        'name' AS source, COALESCE(mentions, 0) AS mentions
+                 FROM entities
                  WHERE agent_id = ?1
-                 ORDER BY latest_at DESC LIMIT 24",
+                   AND COALESCE(status, 'active') = 'active'
+                 UNION ALL
+                 SELECT e.id, e.name, a.alias AS matched_text,
+                        'alias' AS source, COALESCE(e.mentions, 0) AS mentions
+                 FROM entity_aliases a
+                 JOIN entities e ON e.id = a.entity_id AND e.agent_id = a.agent_id
+                 WHERE a.agent_id = ?1
+                   AND a.status = 'active'
+                   AND COALESCE(e.status, 'active') = 'active'",
             ) {
-                let rows = stmt
+                Ok(mut stmt) => stmt
                     .query_map([agent_id.clone()], |row| {
                         Ok((
                             row.get::<_, String>(0)?,
                             row.get::<_, String>(1)?,
                             row.get::<_, String>(2)?,
                             row.get::<_, String>(3)?,
-                            row.get::<_, Option<String>>(4)?,
-                        ))
-                    })
-                    .ok()
-                    .map(|rows| rows.filter_map(|r| r.ok()).collect::<Vec<_>>())
-                    .unwrap_or_default();
-
-                let mut picked = Vec::new();
-                for (id, sample, latest_at, label, row_project) in rows {
-                    let lower = sample.to_lowercase();
-                    if !needles.iter().any(|needle| !needle.is_empty() && lower.contains(needle)) {
-                        continue;
-                    }
-                    if let Some(ref want) = project {
-                        if row_project.as_deref() != Some(want.as_str()) {
-                            continue;
-                        }
-                    }
-                    picked.push(format!(
-                        "- [thread {}] {} ({}, {})",
-                        id,
-                        trim_for_inject(&sample, 280),
-                        latest_at,
-                        label
-                    ));
-                    if picked.len() >= 4 {
-                        break;
-                    }
-                }
-                if !picked.is_empty() {
-                    return Ok(serde_json::json!({
-                        "inject": build_prompt_recall_inject(&metadata_header, &picked),
-                        "memoryCount": picked.len(),
-                        "queryTerms": query_terms_for_resp,
-                        "engine": "temporal-fallback",
-                    }));
-                }
-            }
-
-            // 3) Transcript fallback.
-            let mut tx_sql = String::from(
-                "SELECT session_key, content, updated_at, project
-                 FROM session_transcripts
-                 WHERE agent_id = ?",
-            );
-            let mut tx_params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
-            tx_params.push(Box::new(agent_id.clone()));
-            if let Some(ref p) = project {
-                tx_sql.push_str(" AND project = ?");
-                tx_params.push(Box::new(p.clone()));
-            }
-            if let Some(ref sk) = session_key {
-                // Prefer other sessions first, but still allow this session if it is all we have.
-                tx_sql.push_str(" ORDER BY (session_key = ?) ASC, updated_at DESC LIMIT 6");
-                tx_params.push(Box::new(sk.clone()));
-            } else {
-                tx_sql.push_str(" ORDER BY updated_at DESC LIMIT 6");
-            }
-            let tx_param_refs: Vec<&dyn rusqlite::types::ToSql> =
-                tx_params.iter().map(|p| p.as_ref()).collect();
-            let tx_rows = match conn.prepare(&tx_sql) {
-                Ok(mut stmt) => stmt
-                    .query_map(tx_param_refs.as_slice(), |row| {
-                        Ok((
-                            row.get::<_, String>(0)?,
-                            row.get::<_, String>(1)?,
-                            row.get::<_, Option<String>>(2)?,
+                            row.get::<_, i64>(4)?,
                         ))
                     })
                     .ok()
@@ -1311,36 +1213,211 @@ pub async fn prompt_submit(
                 Err(_) => vec![],
             };
 
-            let mut tx_lines = Vec::new();
-            for (sk, content, updated_at) in tx_rows {
-                let lower = content.to_lowercase();
-                if !needles.iter().any(|needle| !needle.is_empty() && lower.contains(needle)) {
-                    continue;
+            let mut matches = entity_rows
+                .into_iter()
+                .filter(|(_, _, matched_text, _, _)| {
+                    phrase_appears_in_prompt(&cleaned, matched_text)
+                })
+                .collect::<Vec<_>>();
+            matches.sort_by(|a, b| {
+                normalize_prompt_entity_text(&b.2)
+                    .len()
+                    .cmp(&normalize_prompt_entity_text(&a.2).len())
+                    .then_with(|| b.4.cmp(&a.4))
+            });
+
+            let mut phrase_entities = std::collections::HashMap::<String, std::collections::HashSet<String>>::new();
+            for (id, _, matched_text, _, _) in &matches {
+                phrase_entities
+                    .entry(normalize_prompt_entity_text(matched_text))
+                    .or_default()
+                    .insert(id.clone());
+            }
+            if phrase_entities.values().any(|ids| ids.len() > 1) {
+                return Ok(serde_json::json!({
+                    "inject": "",
+                    "memoryCount": 0,
+                    "queryTerms": query_terms_for_resp,
+                    "engine": "ambiguous-entity",
+                }));
+            }
+
+            let mut seen = std::collections::HashSet::new();
+            let entity_matches = matches
+                .into_iter()
+                .filter(|(id, _, _, _, _)| seen.insert(id.clone()))
+                .take(2)
+                .collect::<Vec<_>>();
+            if entity_matches.is_empty() {
+                return Ok(serde_json::json!({
+                    "inject": "",
+                    "memoryCount": 0,
+                    "queryTerms": query_terms_for_resp,
+                    "engine": "no-entity",
+                }));
+            }
+
+            let prompt_terms = normalize_prompt_entity_text(&cleaned)
+                .split_whitespace()
+                .filter(|term| is_prompt_context_term(term))
+                .map(str::to_string)
+                .collect::<std::collections::HashSet<_>>();
+            let mut lines = Vec::new();
+            for (entity_id, entity_name, matched_text, _, _) in entity_matches {
+                let entity_terms = normalize_prompt_entity_text(&format!("{entity_name} {matched_text}"))
+                    .split_whitespace()
+                    .map(str::to_string)
+                    .collect::<std::collections::HashSet<_>>();
+                let context_terms = prompt_terms
+                    .iter()
+                    .filter(|term| !entity_terms.contains(*term))
+                    .cloned()
+                    .collect::<std::collections::HashSet<_>>();
+                let allow_weight_fallback = context_terms.is_empty();
+                let aspects = match conn.prepare(
+                    "SELECT id, name, canonical_name, weight
+                     FROM entity_aspects
+                     WHERE entity_id = ?1
+                       AND agent_id = ?2
+                       AND COALESCE(status, 'active') = 'active'
+                     ORDER BY weight DESC, name ASC
+                     LIMIT 12",
+                ) {
+                    Ok(mut stmt) => stmt
+                        .query_map(rusqlite::params![entity_id, agent_id.clone()], |row| {
+                            Ok((
+                                row.get::<_, String>(0)?,
+                                row.get::<_, String>(1)?,
+                                row.get::<_, String>(2)?,
+                                row.get::<_, f64>(3)?,
+                            ))
+                        })
+                        .ok()
+                        .map(|rows| rows.filter_map(|r| r.ok()).collect::<Vec<_>>())
+                        .unwrap_or_default(),
+                    Err(_) => vec![],
+                };
+                let mut selected_aspects = Vec::new();
+                for (aspect_id, aspect_name, canonical_name, weight) in aspects {
+                    let attr_texts = match conn.prepare(
+                        "SELECT content, COALESCE(group_key, ''), COALESCE(claim_key, '')
+                         FROM entity_attributes
+                         WHERE aspect_id = ?1
+                           AND agent_id = ?2
+                           AND status = 'active'
+                         ORDER BY importance DESC, updated_at DESC
+                         LIMIT 12",
+                    ) {
+                        Ok(mut stmt) => stmt
+                            .query_map(rusqlite::params![aspect_id, agent_id.clone()], |row| {
+                                Ok(format!(
+                                    "{} {} {}",
+                                    row.get::<_, String>(0)?,
+                                    row.get::<_, String>(1)?,
+                                    row.get::<_, String>(2)?
+                                ))
+                            })
+                            .ok()
+                            .map(|rows| rows.filter_map(|r| r.ok()).collect::<Vec<_>>())
+                            .unwrap_or_default(),
+                        Err(_) => vec![],
+                    };
+                    if attr_texts.is_empty() {
+                        continue;
+                    }
+                    let aspect_text = normalize_prompt_entity_text(&format!("{aspect_name} {canonical_name}"));
+                    let aspect_hit = aspect_text
+                        .split_whitespace()
+                        .any(|term| context_terms.contains(term));
+                    let attr_text = normalize_prompt_entity_text(&attr_texts.join(" "));
+                    let attr_hit = attr_text
+                        .split_whitespace()
+                        .any(|term| context_terms.contains(term));
+                    let score = if aspect_hit {
+                        1.0
+                    } else if attr_hit {
+                        0.75 + weight.clamp(0.0, 1.0) * 0.25
+                    } else if allow_weight_fallback {
+                        weight.clamp(0.0, 1.0)
+                    } else {
+                        0.0
+                    };
+                    if score >= min_score {
+                        selected_aspects.push((aspect_id, aspect_name));
+                    }
+                    if selected_aspects.len() >= 3 {
+                        break;
+                    }
                 }
-                let excerpt = trim_for_inject(&content, 260);
-                tx_lines.push(format!(
-                    "- [transcript {}] {} ({})",
-                    sk,
-                    excerpt,
-                    updated_at.unwrap_or_else(|| "unknown".to_string())
-                ));
-                if tx_lines.len() >= 3 {
+                for (aspect_id, aspect_name) in selected_aspects {
+                    let attrs = match conn.prepare(
+                        "SELECT kind, content, COALESCE(group_key, 'general'), COALESCE(claim_key, 'uncategorized'),
+                                COALESCE(source_kind, ''), COALESCE(source_id, ''), COALESCE(memory_id, ''),
+                                COALESCE(version, 1)
+                         FROM entity_attributes
+                         WHERE aspect_id = ?1
+                           AND agent_id = ?2
+                           AND status = 'active'
+                         ORDER BY CASE kind WHEN 'constraint' THEN 0 ELSE 1 END, importance DESC, updated_at DESC
+                         LIMIT 8",
+                    ) {
+                        Ok(mut stmt) => stmt
+                            .query_map(rusqlite::params![aspect_id, agent_id.clone()], |row| {
+                                Ok((
+                                    row.get::<_, String>(0)?,
+                                    row.get::<_, String>(1)?,
+                                    row.get::<_, String>(2)?,
+                                    row.get::<_, String>(3)?,
+                                    row.get::<_, String>(4)?,
+                                    row.get::<_, String>(5)?,
+                                    row.get::<_, String>(6)?,
+                                    row.get::<_, i64>(7)?,
+                                ))
+                            })
+                            .ok()
+                            .map(|rows| rows.filter_map(|r| r.ok()).collect::<Vec<_>>())
+                            .unwrap_or_default(),
+                        Err(_) => vec![],
+                    };
+                    for (kind, content, group, claim, source_kind, source_id, memory_id, version) in attrs {
+                        let source = if !source_kind.is_empty() && !source_id.is_empty() {
+                            format!("{source_kind}:{source_id}")
+                        } else if !memory_id.is_empty() {
+                            format!("memory:{memory_id}")
+                        } else {
+                            format!("v{version}")
+                        };
+                        lines.push(format!(
+                            "- [{kind}] {entity_name} / {aspect_name} / {group} / {claim}: {} ({source})",
+                            trim_for_inject(&content, 240)
+                        ));
+                        if lines.len() >= 8 {
+                            break;
+                        }
+                    }
+                    if lines.len() >= 8 {
+                        break;
+                    }
+                }
+                if lines.len() >= 8 {
                     break;
                 }
             }
-            if !tx_lines.is_empty() {
+
+            if lines.is_empty() {
                 return Ok(serde_json::json!({
-                    "inject": build_prompt_recall_inject(&metadata_header, &tx_lines),
-                    "memoryCount": tx_lines.len(),
+                    "inject": "",
+                    "memoryCount": 0,
                     "queryTerms": query_terms_for_resp,
-                    "engine": "transcript-fallback",
+                    "engine": "no-aspect-hit",
                 }));
             }
 
             Ok(serde_json::json!({
-                "inject": build_no_strong_memory_match_inject(&metadata_header),
-                "memoryCount": 0,
+                "inject": build_entity_context_inject(&metadata_header, &lines),
+                "memoryCount": lines.len(),
                 "queryTerms": query_terms_for_resp,
+                "engine": "entity-context",
             }))
         })
         .await;
@@ -2886,7 +2963,8 @@ mod tests {
     use serde_json::Value;
     use sha2::{Digest, Sha256};
     use signet_core::config::{
-        AgentManifest, DaemonConfig, MemoryManifestConfig, PipelineV2Config,
+        AgentManifest, DaemonConfig, HooksConfig, MemoryManifestConfig, PipelineV2Config,
+        UserPromptSubmitHookConfig,
     };
     use signet_core::db::{DbPool, Priority};
     use tempfile::TempDir;
@@ -2897,12 +2975,11 @@ mod tests {
 
     use super::{
         CHECKPOINT_MIN_DELTA, CheckpointExtractBody, CompactionCompleteBody, PromptSubmitBody,
-        SessionEndBody, build_no_strong_memory_match_inject, build_signet_system_prompt,
-        compaction_complete, extract_delta, normalize_session_transcript, parse_visibility,
-        prompt_submit, require_session_scope_for_write, resolve_audit_token,
-        resolve_compaction_project, resolve_remember_agent, session_agent_id,
-        session_checkpoint_extract, session_end, session_transcript_content,
-        strip_untrusted_metadata, upsert_session_transcript,
+        SessionEndBody, build_signet_system_prompt, compaction_complete, extract_delta,
+        normalize_session_transcript, parse_visibility, prompt_submit,
+        require_session_scope_for_write, resolve_audit_token, resolve_compaction_project,
+        resolve_remember_agent, session_agent_id, session_checkpoint_extract, session_end,
+        session_transcript_content, strip_untrusted_metadata, upsert_session_transcript,
     };
     use signet_services::session::{RuntimePath, SessionTracker};
 
@@ -2924,17 +3001,10 @@ mod tests {
         })
     }
 
-    #[test]
-    fn no_strong_memory_match_inject_keeps_save_hint() {
-        let inject = build_no_strong_memory_match_inject("# Current Date & Time\nnow\n");
-
-        assert!(inject.contains("## Memory Check"));
-        assert!(inject.contains("No strong automatic memory match was injected"));
-        assert!(inject.contains("run 1-3 targeted Signet recalls before executing commands"));
-        assert!(inject.contains("save it with /remember or memory_store"));
-    }
-
-    fn test_state(name: &str) -> (Arc<AppState>, tokio::task::JoinHandle<()>, TempDir) {
+    fn test_state_with_manifest(
+        name: &str,
+        configure: impl FnOnce(&mut AgentManifest),
+    ) -> (Arc<AppState>, tokio::task::JoinHandle<()>, TempDir) {
         let tmp = tempfile::Builder::new().prefix(name).tempdir().unwrap();
         std::fs::create_dir_all(tmp.path().join("memory")).unwrap();
         std::fs::create_dir_all(tmp.path().join(".daemon/logs")).unwrap();
@@ -2942,6 +3012,7 @@ mod tests {
         let mut memory = MemoryManifestConfig::default();
         memory.pipeline_v2 = Some(PipelineV2Config::default());
         manifest.memory = Some(memory);
+        configure(&mut manifest);
         let cfg = DaemonConfig {
             base_path: tmp.path().to_path_buf(),
             db_path: tmp.path().join("memory").join("memories.db"),
@@ -2963,6 +3034,10 @@ mod tests {
             AuthRateLimiter::from_rules(&default_limits()),
         ));
         (state, writer, tmp)
+    }
+
+    fn test_state(name: &str) -> (Arc<AppState>, tokio::task::JoinHandle<()>, TempDir) {
+        test_state_with_manifest(name, |_| {})
     }
 
     #[tokio::test]
@@ -3490,25 +3565,57 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prompt_submit_formats_temporal_fallback_as_lightweight_recall_block() {
-        let (state, writer, _tmp) = test_state("hooks-prompt-submit-structured-brief");
+    async fn prompt_submit_injects_entity_context_for_active_alias() {
+        let (state, writer, _tmp) = test_state("hooks-prompt-submit-entity-context");
         state
             .pool
             .write(Priority::Low, move |conn| {
                 conn.execute(
-                    "INSERT INTO memory_thread_heads (agent_id, thread_key, label, project, session_key, source_type, source_ref, harness, node_id, latest_at, sample, updated_at)
-                     VALUES (?1, ?2, ?3, ?4, ?5, 'summary', ?6, 'test', ?7, ?8, ?9, ?8)",
+                    "INSERT INTO entities (id, name, canonical_name, entity_type, description, agent_id, mentions, created_at, updated_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, 10, ?7, ?7)",
                     rusqlite::params![
+                        "entity-signet",
+                        "Signet",
+                        "signet",
+                        "project",
+                        "Source-backed agent continuity substrate",
                         "agent-a",
-                        "thread-prompt-structured",
-                        "recent work",
-                        "platform/daemon-rs",
-                        "sess-prompt-structured",
-                        "summary-node-1",
-                        "node-1",
-                        "2026-04-06T22:39:00Z",
-                        "prompt submit observability review now uses structured recall formatting",
+                        "2026-05-27T00:00:00Z",
                     ],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_aliases (id, entity_id, agent_id, alias, canonical_alias, confidence, source, status, created_at, updated_at)
+                     VALUES ('alias-signetai', 'entity-signet', 'agent-a', 'SignetAI', 'signetai', 1.0, 'test', 'active', ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_aspects (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+                     VALUES ('aspect-architecture', 'entity-signet', 'agent-a', 'architecture', 'architecture', 0.9, ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_aspects (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+                     VALUES ('aspect-marketing', 'entity-signet', 'agent-a', 'marketing', 'marketing', 0.2, ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_attributes
+                     (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, confidence, importance,
+                      status, group_key, claim_key, source_kind, source_id, created_at, updated_at)
+                     VALUES ('attr-architecture', 'aspect-architecture', 'agent-a', NULL, 'attribute',
+                      'Prompt context should come from entity current views.',
+                      'prompt context should come from entity current views', 0.95, 0.9, 'active',
+                      'runtime', 'prompt_context', 'memory', 'mem-architecture', ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_attributes
+                     (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, confidence, importance,
+                      status, group_key, claim_key, created_at, updated_at)
+                     VALUES ('attr-marketing', 'aspect-marketing', 'agent-a', NULL, 'attribute',
+                      'Marketing copy should stay secondary.', 'marketing copy', 0.8, 0.3, 'active',
+                      'copy', 'positioning', ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
                 )?;
                 Ok(serde_json::Value::Null)
             })
@@ -3522,10 +3629,10 @@ mod tests {
                 harness: Some("test".to_string()),
                 project: Some("platform/daemon-rs".to_string()),
                 agent_id: Some("agent-a".to_string()),
-                user_message: Some("show prompt submit observability review".to_string()),
+                user_message: Some("Should SignetAI architecture use current views?".to_string()),
                 user_prompt: None,
                 last_assistant_message: None,
-                session_key: Some("sess-prompt-structured".to_string()),
+                session_key: Some("sess-prompt-entity".to_string()),
                 transcript: None,
                 transcript_path: None,
                 runtime_path: None,
@@ -3538,19 +3645,133 @@ mod tests {
         let inject = body["inject"].as_str().unwrap_or_default();
         assert_eq!(
             body["engine"],
-            serde_json::Value::String("temporal-fallback".to_string())
+            serde_json::Value::String("entity-context".to_string())
         );
-        assert!(inject.contains("## Memory Check"));
-        assert!(inject.contains("## Relevant Memory"));
-        assert!(inject.contains("[thread node-1]"));
+        assert!(inject.contains("## Relevant Entity Context"));
+        assert!(inject.contains("Signet / architecture / runtime / prompt_context"));
+        assert!(inject.contains("Prompt context should come from entity current views."));
+        assert!(!inject.contains("## Relevant Memory"));
+        assert!(!inject.contains("Marketing copy should stay secondary"));
+
+        drop(state);
+        let _ = writer.await;
+    }
+
+    #[tokio::test]
+    async fn prompt_submit_preserves_zero_min_score_config() {
+        let (state, writer, _tmp) =
+            test_state_with_manifest("hooks-prompt-submit-zero-min-score", |manifest| {
+                manifest.hooks = Some(HooksConfig {
+                    user_prompt_submit: UserPromptSubmitHookConfig {
+                        min_score: 0.0,
+                        ..Default::default()
+                    },
+                });
+            });
+        state
+            .pool
+            .write(Priority::Low, move |conn| {
+                conn.execute(
+                    "INSERT INTO entities (id, name, canonical_name, entity_type, description, agent_id, mentions, created_at, updated_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, 10, ?7, ?7)",
+                    rusqlite::params![
+                        "entity-signet",
+                        "Signet",
+                        "signet",
+                        "project",
+                        "Source-backed agent continuity substrate",
+                        "agent-a",
+                        "2026-05-27T00:00:00Z",
+                    ],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_aliases (id, entity_id, agent_id, alias, canonical_alias, confidence, source, status, created_at, updated_at)
+                     VALUES ('alias-signetai', 'entity-signet', 'agent-a', 'SignetAI', 'signetai', 1.0, 'test', 'active', ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_aspects (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+                     VALUES ('aspect-low-weight', 'entity-signet', 'agent-a', 'low weight', 'low weight', 0.2, ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_attributes
+                     (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, confidence, importance,
+                      status, group_key, claim_key, created_at, updated_at)
+                     VALUES ('attr-low-weight', 'aspect-low-weight', 'agent-a', NULL, 'attribute',
+                      'Entity-only prompts can still opt into low-weight current views.',
+                      'entity only prompts can still opt into low weight current views', 0.8, 0.2, 'active',
+                      'runtime', 'min_score_zero', ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                Ok(serde_json::Value::Null)
+            })
+            .await
+            .unwrap();
+
+        let resp = prompt_submit(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(PromptSubmitBody {
+                harness: Some("test".to_string()),
+                project: Some("platform/daemon-rs".to_string()),
+                agent_id: Some("agent-a".to_string()),
+                user_message: Some("SignetAI".to_string()),
+                user_prompt: None,
+                last_assistant_message: None,
+                session_key: Some("sess-prompt-zero-min-score".to_string()),
+                transcript: None,
+                transcript_path: None,
+                runtime_path: None,
+            }),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = test_json(resp).await;
+        let inject = body["inject"].as_str().unwrap_or_default();
+        assert_eq!(
+            body["engine"],
+            serde_json::Value::String("entity-context".to_string())
+        );
+        assert!(inject.contains("Signet / low weight / runtime / min_score_zero"));
         assert!(
-            inject.contains(
-                "prompt submit observability review now uses structured recall formatting"
-            )
+            inject.contains("Entity-only prompts can still opt into low-weight current views.")
         );
-        assert!(inject.contains("Use the memories below as starting context before acting"));
-        assert!(inject.contains("run 1-3 targeted recalls with /recall or memory_search"));
-        assert!(!inject.contains("[signet:recall"));
+
+        drop(state);
+        let _ = writer.await;
+    }
+
+    #[tokio::test]
+    async fn prompt_submit_without_known_entity_stays_silent() {
+        let (state, writer, _tmp) = test_state("hooks-prompt-submit-no-entity");
+
+        let resp = prompt_submit(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(PromptSubmitBody {
+                harness: Some("test".to_string()),
+                project: Some("platform/daemon-rs".to_string()),
+                agent_id: Some("agent-a".to_string()),
+                user_message: Some("show prompt submit observability review".to_string()),
+                user_prompt: None,
+                last_assistant_message: None,
+                session_key: Some("sess-prompt-silent".to_string()),
+                transcript: None,
+                transcript_path: None,
+                runtime_path: None,
+            }),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = test_json(resp).await;
+        assert_eq!(body["inject"], serde_json::Value::String(String::new()));
+        assert_eq!(
+            body["engine"],
+            serde_json::Value::String("no-entity".to_string())
+        );
 
         drop(state);
         let _ = writer.await;

--- a/platform/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/platform/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -314,6 +314,7 @@ fn load_guarded_transcript_path(
 /// at the byte level before any allocation.  Content exceeding this limit is
 /// truncated with a `[truncated]` marker before artifact / DB writes.
 const MAX_TRANSCRIPT_BYTES: usize = 400_000; // ~100k chars * 4 bytes/char (UTF-8 worst case)
+const MIN_PROMPT_ENTITY_MATCH_CHARS: usize = 3;
 
 /// Normalize a caller-supplied project path so lineage lookups use a
 /// consistent key.  Mirrors session-start project normalization:
@@ -871,7 +872,7 @@ fn normalize_prompt_entity_text(text: &str) -> String {
 fn phrase_appears_in_prompt(prompt: &str, phrase: &str) -> bool {
     let prompt = format!(" {} ", normalize_prompt_entity_text(prompt));
     let phrase = normalize_prompt_entity_text(phrase);
-    !phrase.is_empty() && prompt.contains(&format!(" {phrase} "))
+    phrase.len() >= MIN_PROMPT_ENTITY_MATCH_CHARS && prompt.contains(&format!(" {phrase} "))
 }
 
 fn is_low_signal_prompt(prompt: &str) -> bool {
@@ -3750,6 +3751,76 @@ mod tests {
         assert_eq!(
             body["engine"],
             serde_json::Value::String("no-aspect-hit".to_string())
+        );
+
+        drop(state);
+        let _ = writer.await;
+    }
+
+    #[tokio::test]
+    async fn prompt_submit_short_entity_name_does_not_match_ordinary_token() {
+        let (state, writer, _tmp) = test_state("hooks-prompt-submit-short-entity");
+        state
+            .pool
+            .write(Priority::Low, move |conn| {
+                conn.execute(
+                    "INSERT INTO entities (id, name, canonical_name, entity_type, description, agent_id, mentions, created_at, updated_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, 10, ?7, ?7)",
+                    rusqlite::params![
+                        "entity-ai",
+                        "AI",
+                        "ai",
+                        "concept",
+                        "Short entity name",
+                        "agent-a",
+                        "2026-05-27T00:00:00Z",
+                    ],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_aspects (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+                     VALUES ('aspect-ai-architecture', 'entity-ai', 'agent-a', 'architecture', 'architecture', 1.0, ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_attributes
+                     (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, confidence, importance,
+                      status, group_key, claim_key, created_at, updated_at)
+                     VALUES ('attr-ai-architecture', 'aspect-ai-architecture', 'agent-a', NULL, 'attribute',
+                      'Short entity names should not match ordinary words.',
+                      'short entity names should not match ordinary words', 0.95, 0.9, 'active',
+                      'runtime', 'short_match_guard', ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                Ok(serde_json::Value::Null)
+            })
+            .await
+            .unwrap();
+
+        let resp = prompt_submit(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(PromptSubmitBody {
+                harness: Some("test".to_string()),
+                project: Some("platform/daemon-rs".to_string()),
+                agent_id: Some("agent-a".to_string()),
+                user_message: Some("Can AI architecture be summarized?".to_string()),
+                user_prompt: None,
+                last_assistant_message: None,
+                session_key: Some("sess-prompt-short-entity".to_string()),
+                transcript: None,
+                transcript_path: None,
+                runtime_path: None,
+            }),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = test_json(resp).await;
+        assert_eq!(body["inject"], serde_json::Value::String(String::new()));
+        assert_eq!(body["memoryCount"], serde_json::Value::Number(0.into()));
+        assert_eq!(
+            body["engine"],
+            serde_json::Value::String("no-entity".to_string())
         );
 
         drop(state);

--- a/platform/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/platform/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -834,6 +834,25 @@ fn trim_for_inject(text: &str, limit: usize) -> String {
     format!("{}...", &trimmed[..end])
 }
 
+fn cap_prompt_inject(text: &str, limit: usize) -> String {
+    if limit == 0 {
+        return String::new();
+    }
+    if text.len() <= limit {
+        return text.to_string();
+    }
+    let suffix = "...";
+    let keep = limit.saturating_sub(suffix.len());
+    let mut end = keep;
+    while !text.is_char_boundary(end) && end > 0 {
+        end -= 1;
+    }
+    if keep == 0 {
+        return text.chars().take(limit).collect();
+    }
+    format!("{}{}", &text[..end], suffix)
+}
+
 fn normalize_prompt_entity_text(text: &str) -> String {
     let mut out = String::new();
     let mut prev_space = true;
@@ -1159,10 +1178,17 @@ pub async fn prompt_submit(
         .filter(|score| score.is_finite())
         .map(|score| score.clamp(0.0, 1.0))
         .unwrap_or(0.8);
+    let max_inject_chars = state
+        .config
+        .manifest
+        .hooks
+        .as_ref()
+        .map(|h| h.user_prompt_submit.max_inject_chars)
+        .unwrap_or(500);
 
     let result = state
-        .pool
-        .read(move |conn| {
+		.pool
+		.read(move |conn| {
             let has_aliases = conn
                 .query_row(
                     "SELECT COUNT(*) FROM sqlite_master
@@ -1413,12 +1439,13 @@ pub async fn prompt_submit(
                 }));
             }
 
-            Ok(serde_json::json!({
-                "inject": build_entity_context_inject(&metadata_header, &lines),
-                "memoryCount": lines.len(),
-                "queryTerms": query_terms_for_resp,
-                "engine": "entity-context",
-            }))
+			let inject = build_entity_context_inject(&metadata_header, &lines);
+			Ok(serde_json::json!({
+				"inject": cap_prompt_inject(&inject, max_inject_chars),
+				"memoryCount": lines.len(),
+				"queryTerms": query_terms_for_resp,
+				"engine": "entity-context",
+			}))
         })
         .await;
 
@@ -3738,6 +3765,93 @@ mod tests {
         assert!(
             inject.contains("Entity-only prompts can still opt into low-weight current views.")
         );
+
+        drop(state);
+        let _ = writer.await;
+    }
+
+    #[tokio::test]
+    async fn prompt_submit_caps_entity_context_to_max_inject_chars() {
+        let (state, writer, _tmp) =
+            test_state_with_manifest("hooks-prompt-submit-max-inject-chars", |manifest| {
+                manifest.hooks = Some(HooksConfig {
+                    user_prompt_submit: UserPromptSubmitHookConfig {
+                        max_inject_chars: 180,
+                        ..Default::default()
+                    },
+                });
+            });
+        state
+			.pool
+			.write(Priority::Low, move |conn| {
+				conn.execute(
+					"INSERT INTO entities (id, name, canonical_name, entity_type, description, agent_id, mentions, created_at, updated_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, 10, ?7, ?7)",
+					rusqlite::params![
+						"entity-signet",
+						"Signet",
+						"signet",
+						"project",
+						"Source-backed agent continuity substrate",
+						"agent-a",
+						"2026-05-27T00:00:00Z",
+					],
+				)?;
+				conn.execute(
+					"INSERT INTO entity_aliases (id, entity_id, agent_id, alias, canonical_alias, confidence, source, status, created_at, updated_at)
+                     VALUES ('alias-signetai', 'entity-signet', 'agent-a', 'SignetAI', 'signetai', 1.0, 'test', 'active', ?1, ?1)",
+					rusqlite::params!["2026-05-27T00:00:00Z"],
+				)?;
+				conn.execute(
+					"INSERT INTO entity_aspects (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+                     VALUES ('aspect-architecture', 'entity-signet', 'agent-a', 'architecture', 'architecture', 1.0, ?1, ?1)",
+					rusqlite::params!["2026-05-27T00:00:00Z"],
+				)?;
+				conn.execute(
+					"INSERT INTO entity_attributes
+                     (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, confidence, importance,
+                      status, group_key, claim_key, created_at, updated_at)
+                     VALUES ('attr-architecture', 'aspect-architecture', 'agent-a', NULL, 'attribute',
+                      'Prompt context should include this opening but must not include the reviewer regression tail beyond the configured prompt-submit injection budget.',
+                      'prompt context should include this opening but must not include the reviewer regression tail beyond the configured prompt submit injection budget',
+                      0.95, 0.9, 'active', 'runtime', 'prompt_context_budget', ?1, ?1)",
+					rusqlite::params!["2026-05-27T00:00:00Z"],
+				)?;
+				Ok(serde_json::Value::Null)
+			})
+			.await
+			.unwrap();
+
+        let resp = prompt_submit(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(PromptSubmitBody {
+                harness: Some("test".to_string()),
+                project: Some("platform/daemon-rs".to_string()),
+                agent_id: Some("agent-a".to_string()),
+                user_message: Some("Should SignetAI architecture use current views?".to_string()),
+                user_prompt: None,
+                last_assistant_message: None,
+                session_key: Some("sess-prompt-max-inject-chars".to_string()),
+                transcript: None,
+                transcript_path: None,
+                runtime_path: None,
+            }),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = test_json(resp).await;
+        let inject = body["inject"].as_str().unwrap_or_default();
+        assert_eq!(
+            body["engine"],
+            serde_json::Value::String("entity-context".to_string())
+        );
+        assert!(inject.len() <= 180);
+        assert!(inject.contains("# Current Date & Time"));
+        assert!(inject.contains("## Relevant Entity Context"));
+        assert!(inject.ends_with("..."));
+        assert!(!inject.contains("reviewer regression tail"));
 
         drop(state);
         let _ = writer.await;

--- a/platform/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/platform/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -1299,7 +1299,6 @@ pub async fn prompt_submit(
                     .filter(|term| !entity_terms.contains(*term))
                     .cloned()
                     .collect::<std::collections::HashSet<_>>();
-                let allow_weight_fallback = context_terms.is_empty();
                 let aspects = match conn.prepare(
                     "SELECT id, name, canonical_name, weight
                      FROM entity_aspects
@@ -1363,8 +1362,6 @@ pub async fn prompt_submit(
                         1.0
                     } else if attr_hit {
                         0.75 + weight.clamp(0.0, 1.0) * 0.25
-                    } else if allow_weight_fallback {
-                        weight.clamp(0.0, 1.0)
                     } else {
                         0.0
                     };
@@ -3685,6 +3682,81 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn prompt_submit_entity_only_alias_without_aspect_hit_stays_silent() {
+        let (state, writer, _tmp) = test_state("hooks-prompt-submit-entity-only");
+        state
+            .pool
+            .write(Priority::Low, move |conn| {
+                conn.execute(
+                    "INSERT INTO entities (id, name, canonical_name, entity_type, description, agent_id, mentions, created_at, updated_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, 10, ?7, ?7)",
+                    rusqlite::params![
+                        "entity-signet",
+                        "Signet",
+                        "signet",
+                        "project",
+                        "Source-backed agent continuity substrate",
+                        "agent-a",
+                        "2026-05-27T00:00:00Z",
+                    ],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_aliases (id, entity_id, agent_id, alias, canonical_alias, confidence, source, status, created_at, updated_at)
+                     VALUES ('alias-signetai', 'entity-signet', 'agent-a', 'SignetAI', 'signetai', 1.0, 'test', 'active', ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_aspects (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+                     VALUES ('aspect-architecture', 'entity-signet', 'agent-a', 'architecture', 'architecture', 0.95, ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_attributes
+                     (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, confidence, importance,
+                      status, group_key, claim_key, created_at, updated_at)
+                     VALUES ('attr-architecture', 'aspect-architecture', 'agent-a', NULL, 'attribute',
+                      'Prompt context should come from entity current views.',
+                      'prompt context should come from entity current views', 0.95, 0.9, 'active',
+                      'runtime', 'prompt_context', ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                Ok(serde_json::Value::Null)
+            })
+            .await
+            .unwrap();
+
+        let resp = prompt_submit(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(PromptSubmitBody {
+                harness: Some("test".to_string()),
+                project: Some("platform/daemon-rs".to_string()),
+                agent_id: Some("agent-a".to_string()),
+                user_message: Some("SignetAI".to_string()),
+                user_prompt: None,
+                last_assistant_message: None,
+                session_key: Some("sess-prompt-entity-only".to_string()),
+                transcript: None,
+                transcript_path: None,
+                runtime_path: None,
+            }),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = test_json(resp).await;
+        assert_eq!(body["inject"], serde_json::Value::String(String::new()));
+        assert_eq!(body["memoryCount"], serde_json::Value::Number(0.into()));
+        assert_eq!(
+            body["engine"],
+            serde_json::Value::String("no-aspect-hit".to_string())
+        );
+
+        drop(state);
+        let _ = writer.await;
+    }
+
+    #[tokio::test]
     async fn prompt_submit_preserves_zero_min_score_config() {
         let (state, writer, _tmp) =
             test_state_with_manifest("hooks-prompt-submit-zero-min-score", |manifest| {
@@ -3726,8 +3798,8 @@ mod tests {
                      (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, confidence, importance,
                       status, group_key, claim_key, created_at, updated_at)
                      VALUES ('attr-low-weight', 'aspect-low-weight', 'agent-a', NULL, 'attribute',
-                      'Entity-only prompts can still opt into low-weight current views.',
-                      'entity only prompts can still opt into low weight current views', 0.8, 0.2, 'active',
+                      'Prompt context can opt into low-weight current views.',
+                      'prompt context can opt into low weight current views', 0.8, 0.2, 'active',
                       'runtime', 'min_score_zero', ?1, ?1)",
                     rusqlite::params!["2026-05-27T00:00:00Z"],
                 )?;
@@ -3743,7 +3815,7 @@ mod tests {
                 harness: Some("test".to_string()),
                 project: Some("platform/daemon-rs".to_string()),
                 agent_id: Some("agent-a".to_string()),
-                user_message: Some("SignetAI".to_string()),
+                user_message: Some("Should SignetAI use current views?".to_string()),
                 user_prompt: None,
                 last_assistant_message: None,
                 session_key: Some("sess-prompt-zero-min-score".to_string()),
@@ -3762,9 +3834,7 @@ mod tests {
             serde_json::Value::String("entity-context".to_string())
         );
         assert!(inject.contains("Signet / low weight / runtime / min_score_zero"));
-        assert!(
-            inject.contains("Entity-only prompts can still opt into low-weight current views.")
-        );
+        assert!(inject.contains("Prompt context can opt into low-weight current views."));
 
         drop(state);
         let _ = writer.await;

--- a/platform/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/platform/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -1326,12 +1326,25 @@ pub async fn prompt_submit(
                 let mut selected_aspects = Vec::new();
                 for (aspect_id, aspect_name, canonical_name, weight) in aspects {
                     let attr_texts = match conn.prepare(
-                        "SELECT content, COALESCE(group_key, ''), COALESCE(claim_key, '')
-                         FROM entity_attributes
-                         WHERE aspect_id = ?1
-                           AND agent_id = ?2
-                           AND status = 'active'
-                         ORDER BY importance DESC, updated_at DESC
+                        "SELECT ea.content, COALESCE(ea.group_key, ''), COALESCE(ea.claim_key, '')
+                         FROM entity_attributes ea
+                         WHERE ea.aspect_id = ?1
+                           AND ea.agent_id = ?2
+                           AND ea.status = 'active'
+                           AND ea.superseded_by IS NULL
+                           AND NOT EXISTS (
+                             SELECT 1
+                             FROM entity_attributes newer
+                             WHERE newer.aspect_id = ea.aspect_id
+                               AND newer.agent_id = ea.agent_id
+                               AND newer.kind = ea.kind
+                               AND COALESCE(newer.group_key, 'general') = COALESCE(ea.group_key, 'general')
+                               AND newer.claim_key = ea.claim_key
+                               AND newer.status = 'active'
+                               AND newer.superseded_by IS NULL
+                               AND COALESCE(newer.version, 1) > COALESCE(ea.version, 1)
+                           )
+                         ORDER BY ea.importance DESC, ea.updated_at DESC
                          LIMIT 12",
                     ) {
                         Ok(mut stmt) => stmt
@@ -1375,14 +1388,27 @@ pub async fn prompt_submit(
                 }
                 for (aspect_id, aspect_name) in selected_aspects {
                     let attrs = match conn.prepare(
-                        "SELECT kind, content, COALESCE(group_key, 'general'), COALESCE(claim_key, 'uncategorized'),
-                                COALESCE(source_kind, ''), COALESCE(source_id, ''), COALESCE(memory_id, ''),
-                                COALESCE(version, 1)
-                         FROM entity_attributes
-                         WHERE aspect_id = ?1
-                           AND agent_id = ?2
-                           AND status = 'active'
-                         ORDER BY CASE kind WHEN 'constraint' THEN 0 ELSE 1 END, importance DESC, updated_at DESC
+                        "SELECT ea.kind, ea.content, COALESCE(ea.group_key, 'general'), COALESCE(ea.claim_key, 'uncategorized'),
+                                COALESCE(ea.source_kind, ''), COALESCE(ea.source_id, ''), COALESCE(ea.memory_id, ''),
+                                COALESCE(ea.version, 1)
+                         FROM entity_attributes ea
+                         WHERE ea.aspect_id = ?1
+                           AND ea.agent_id = ?2
+                           AND ea.status = 'active'
+                           AND ea.superseded_by IS NULL
+                           AND NOT EXISTS (
+                             SELECT 1
+                             FROM entity_attributes newer
+                             WHERE newer.aspect_id = ea.aspect_id
+                               AND newer.agent_id = ea.agent_id
+                               AND newer.kind = ea.kind
+                               AND COALESCE(newer.group_key, 'general') = COALESCE(ea.group_key, 'general')
+                               AND newer.claim_key = ea.claim_key
+                               AND newer.status = 'active'
+                               AND newer.superseded_by IS NULL
+                               AND COALESCE(newer.version, 1) > COALESCE(ea.version, 1)
+                           )
+                         ORDER BY CASE ea.kind WHEN 'constraint' THEN 0 ELSE 1 END, ea.importance DESC, ea.updated_at DESC
                          LIMIT 8",
                     ) {
                         Ok(mut stmt) => stmt
@@ -3636,6 +3662,16 @@ mod tests {
                 conn.execute(
                     "INSERT INTO entity_attributes
                      (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, confidence, importance,
+                      status, group_key, claim_key, version, created_at, updated_at)
+                     VALUES ('attr-architecture-stale', 'aspect-architecture', 'agent-a', NULL, 'attribute',
+                      'Stale prompt context should not be injected.',
+                      'stale prompt context should not be injected', 0.5, 2.0, 'active',
+                      'runtime', 'prompt_context', 0, ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_attributes
+                     (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, confidence, importance,
                       status, group_key, claim_key, created_at, updated_at)
                      VALUES ('attr-marketing', 'aspect-marketing', 'agent-a', NULL, 'attribute',
                       'Marketing copy should stay secondary.', 'marketing copy', 0.8, 0.3, 'active',
@@ -3675,6 +3711,7 @@ mod tests {
         assert!(inject.contains("## Relevant Entity Context"));
         assert!(inject.contains("Signet / architecture / runtime / prompt_context"));
         assert!(inject.contains("Prompt context should come from entity current views."));
+        assert!(!inject.contains("Stale prompt context should not be injected."));
         assert!(!inject.contains("## Relevant Memory"));
         assert!(!inject.contains("Marketing copy should stay secondary"));
 

--- a/platform/daemon/src/hooks.prompt-submit.test.ts
+++ b/platform/daemon/src/hooks.prompt-submit.test.ts
@@ -233,6 +233,17 @@ describe("handleUserPromptSubmit entity context", () => {
 		expect(result.inject).toContain("Prompt context should come from entity current views.");
 	});
 
+	it("stays silent when the prompt only names an entity alias", async () => {
+		seedEntityContext();
+
+		const result = await handleUserPromptSubmit(
+			{ harness: "codex", userMessage: "SignetAI", sessionKey: "session-alias-only" },
+			makeDeps(),
+		);
+
+		expect(result).toMatchObject({ inject: "", memoryCount: 0, engine: "no-aspect-hit" });
+	});
+
 	it("stays silent when the entity is known but no aspect clears the gate", async () => {
 		seedEntityContext();
 

--- a/platform/daemon/src/hooks.prompt-submit.test.ts
+++ b/platform/daemon/src/hooks.prompt-submit.test.ts
@@ -124,6 +124,25 @@ function seedEntityContext(): void {
 		db.prepare(
 			`INSERT INTO entity_attributes
 			 (id, aspect_id, agent_id, kind, content, normalized_content, group_key, claim_key,
+			  confidence, importance, status, version, created_at, updated_at)
+			 VALUES (?, ?, 'default', ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?)`,
+		).run(
+			"attr-architecture-stale",
+			"aspect-architecture",
+			"attribute",
+			"Stale prompt context should not be injected.",
+			"stale prompt context should not be injected",
+			"runtime",
+			"prompt_context",
+			0.5,
+			2,
+			0,
+			now,
+			now,
+		);
+		db.prepare(
+			`INSERT INTO entity_attributes
+			 (id, aspect_id, agent_id, kind, content, normalized_content, group_key, claim_key,
 			  confidence, importance, status, created_at, updated_at)
 			 VALUES (?, ?, 'default', ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?)`,
 		).run(
@@ -216,6 +235,7 @@ describe("handleUserPromptSubmit entity context", () => {
 		expect(result.inject).toContain("[constraint] Signet / architecture / runtime / fallback_policy");
 		expect(result.inject).toContain("Do not use generic fallback injection.");
 		expect(result.inject).toContain("[attribute] Signet / architecture / runtime / prompt_context");
+		expect(result.inject).not.toContain("Stale prompt context should not be injected.");
 		expect(result.inject).not.toContain("## Relevant Memory");
 		expect(result.inject).not.toContain("Marketing copy should stay secondary");
 	});

--- a/platform/daemon/src/hooks.prompt-submit.test.ts
+++ b/platform/daemon/src/hooks.prompt-submit.test.ts
@@ -1,62 +1,37 @@
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import { handleUserPromptSubmit } from "./hooks";
 import { SIGNET_SECRETS_PLUGIN_ID, getDefaultPluginHost, resetDefaultPluginHostForTests } from "./plugins/index";
 
 type PromptDeps = Required<NonNullable<Parameters<typeof handleUserPromptSubmit>[1]>>;
 
 const originalSignetPath = process.env.SIGNET_PATH;
-const originalCodexNativeMemory = process.env.SIGNET_CODEX_NATIVE_MEMORY;
-const originalCodexHome = process.env.CODEX_HOME;
 const agentsDir = mkdtempSync(join(tmpdir(), "signet-hooks-prompt-submit-"));
 const memoryDir = join(agentsDir, "memory");
 const memoryDbPath = join(memoryDir, "memories.db");
 
-mkdirSync(memoryDir, { recursive: true });
-writeFileSync(memoryDbPath, "");
-process.env.SIGNET_PATH = agentsDir;
-
 const infoMock = mock((_cat: string, _msg: string, _data?: Record<string, unknown>) => {});
 const warnMock = mock((..._args: unknown[]) => {});
 const errorMock = mock((..._args: unknown[]) => {});
-const emptyHybridResults: Array<{ id: string; score: number; content: string; created_at: string; pinned?: boolean }> =
-	[];
-const hybridRecallMock = mock(async (..._args: Parameters<PromptDeps["hybridRecall"]>) => ({
-	results: emptyHybridResults,
-}));
-const fetchEmbeddingMock = mock(
-	async (..._args: Parameters<PromptDeps["fetchEmbedding"]>): Promise<number[] | null> => null,
-);
-const emptyTemporalHits: Array<{
-	id: string;
-	latestAt: string;
-	threadLabel: string;
-	excerpt: string;
-}> = [];
-const searchTemporalFallbackMock = mock(() => emptyTemporalHits);
+const hybridRecallMock = mock(async (..._args: Parameters<PromptDeps["hybridRecall"]>) => ({ results: [] }));
+const fetchEmbeddingMock = mock(async (..._args: Parameters<PromptDeps["fetchEmbedding"]>) => null);
+const searchTemporalFallbackMock = mock(() => []);
 
 const { loadMemoryConfig: realLoadMemoryConfig } = await import("./memory-config");
 
-function ensureMemoryDbExists(): void {
-	if (!existsSync(memoryDbPath)) {
-		writeFileSync(memoryDbPath, "");
-	}
+process.env.SIGNET_PATH = agentsDir;
+
+function resetDb(): void {
+	closeDbAccessor();
+	mkdirSync(memoryDir, { recursive: true });
+	if (existsSync(memoryDbPath)) rmSync(memoryDbPath);
+	initDbAccessor(memoryDbPath, { agentsDir });
 }
 
-function makePendingEmbedding(): {
-	readonly promise: Promise<number[] | null>;
-	readonly resolve: (value: number[] | null) => void;
-} {
-	let resolveEmbedding: (value: number[] | null) => void = () => {};
-	const promise = new Promise<number[] | null>((resolve) => {
-		resolveEmbedding = resolve;
-	});
-	return { promise, resolve: resolveEmbedding };
-}
-
-function makeDeps(opts: { readonly agentFeedback?: boolean } = {}): PromptDeps {
+function makeDeps(): PromptDeps {
 	return {
 		logger: {
 			debug() {},
@@ -70,26 +45,14 @@ function makeDeps(opts: { readonly agentFeedback?: boolean } = {}): PromptDeps {
 				...cfg,
 				pipelineV2: {
 					...cfg.pipelineV2,
-					feedback: {
-						...cfg.pipelineV2.feedback,
-						enabled: opts.agentFeedback ?? false,
-					},
-					continuity: {
-						...cfg.pipelineV2.continuity,
-						enabled: false,
-					},
-					guardrails: {
-						...cfg.pipelineV2.guardrails,
-						contextBudgetChars: 4000,
-					},
+					feedback: { ...cfg.pipelineV2.feedback, enabled: false },
+					continuity: { ...cfg.pipelineV2.continuity, enabled: false },
+					guardrails: { ...cfg.pipelineV2.guardrails, contextBudgetChars: 4000 },
 				},
 			};
 		},
 		resolveAgentId: () => "default",
-		getAgentScope: () => ({
-			readPolicy: "isolated" as const,
-			policyGroup: null,
-		}),
+		getAgentScope: () => ({ readPolicy: "isolated" as const, policyGroup: null }),
 		hybridRecall: hybridRecallMock,
 		fetchEmbedding: fetchEmbeddingMock,
 		searchTemporalFallback: searchTemporalFallbackMock,
@@ -114,776 +77,170 @@ function makeDeps(opts: { readonly agentFeedback?: boolean } = {}): PromptDeps {
 	} as unknown as PromptDeps;
 }
 
-describe("handleUserPromptSubmit observability", () => {
+function seedEntityContext(): void {
+	getDbAccessor().withWriteTx((db) => {
+		const now = "2026-05-27T00:00:00.000Z";
+		db.prepare(
+			`INSERT INTO entities
+			 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, 'default', 10, ?, ?)`,
+		).run("entity-signet", "Signet", "signet", "project", now, now);
+		db.prepare(
+			`INSERT INTO entity_aliases
+			 (id, entity_id, agent_id, alias, canonical_alias, confidence, source, status, created_at, updated_at)
+			 VALUES (?, ?, 'default', ?, ?, 1, 'test', 'active', ?, ?)`,
+		).run("alias-signetai", "entity-signet", "SignetAI", "signetai", now, now);
+		db.prepare(
+			`INSERT INTO entity_aspects
+			 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+			 VALUES (?, ?, 'default', ?, ?, ?, ?, ?)`,
+		).run("aspect-architecture", "entity-signet", "architecture", "architecture", 0.9, now, now);
+		db.prepare(
+			`INSERT INTO entity_aspects
+			 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+			 VALUES (?, ?, 'default', ?, ?, ?, ?, ?)`,
+		).run("aspect-marketing", "entity-signet", "marketing", "marketing", 0.2, now, now);
+		db.prepare(
+			`INSERT INTO entity_attributes
+			 (id, aspect_id, agent_id, kind, content, normalized_content, group_key, claim_key,
+			  confidence, importance, status, memory_id, source_kind, source_id, created_at, updated_at)
+			 VALUES (?, ?, 'default', ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?, ?, ?)`,
+		).run(
+			"attr-architecture",
+			"aspect-architecture",
+			"attribute",
+			"Prompt context should come from entity current views.",
+			"prompt context should come from entity current views",
+			"runtime",
+			"prompt_context",
+			0.95,
+			0.9,
+			"mem-architecture",
+			"memory",
+			"mem-architecture",
+			now,
+			now,
+		);
+		db.prepare(
+			`INSERT INTO entity_attributes
+			 (id, aspect_id, agent_id, kind, content, normalized_content, group_key, claim_key,
+			  confidence, importance, status, created_at, updated_at)
+			 VALUES (?, ?, 'default', ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?)`,
+		).run(
+			"constraint-architecture",
+			"aspect-architecture",
+			"constraint",
+			"Do not use generic fallback injection.",
+			"do not use generic fallback injection",
+			"runtime",
+			"fallback_policy",
+			0.99,
+			1,
+			now,
+			now,
+		);
+		db.prepare(
+			`INSERT INTO entity_attributes
+			 (id, aspect_id, agent_id, kind, content, normalized_content, group_key, claim_key,
+			  confidence, importance, status, created_at, updated_at)
+			 VALUES (?, ?, 'default', 'attribute', ?, ?, 'copy', 'positioning', 0.8, 0.3, 'active', ?, ?)`,
+		).run("attr-marketing", "aspect-marketing", "Marketing copy should stay secondary.", "marketing copy", now, now);
+	});
+}
+
+describe("handleUserPromptSubmit entity context", () => {
 	beforeEach(() => {
 		infoMock.mockClear();
 		warnMock.mockClear();
 		errorMock.mockClear();
 		hybridRecallMock.mockClear();
-		hybridRecallMock.mockImplementation(async () => ({ results: emptyHybridResults }));
 		fetchEmbeddingMock.mockClear();
 		searchTemporalFallbackMock.mockClear();
-		searchTemporalFallbackMock.mockImplementation(() => emptyTemporalHits);
-		ensureMemoryDbExists();
-		Reflect.deleteProperty(process.env, "SIGNET_CODEX_NATIVE_MEMORY");
-		Reflect.deleteProperty(process.env, "CODEX_HOME");
 		resetDefaultPluginHostForTests();
 		getDefaultPluginHost().setEnabled(SIGNET_SECRETS_PLUGIN_ID, true);
+		resetDb();
 	});
 
 	afterAll(() => {
+		closeDbAccessor();
 		rmSync(agentsDir, { recursive: true, force: true });
 		if (originalSignetPath === undefined) {
 			Reflect.deleteProperty(process.env, "SIGNET_PATH");
 		} else {
 			process.env.SIGNET_PATH = originalSignetPath;
 		}
-		if (originalCodexNativeMemory === undefined) {
-			Reflect.deleteProperty(process.env, "SIGNET_CODEX_NATIVE_MEMORY");
-		} else {
-			process.env.SIGNET_CODEX_NATIVE_MEMORY = originalCodexNativeMemory;
-		}
-		if (originalCodexHome === undefined) {
-			Reflect.deleteProperty(process.env, "CODEX_HOME");
-		} else {
-			process.env.CODEX_HOME = originalCodexHome;
-		}
 	});
 
-	it("logs successful no-query outcomes", async () => {
+	it("returns empty inject for low-signal turns without searching", async () => {
+		seedEntityContext();
+
 		const result = await handleUserPromptSubmit(
-			{
-				harness: "vscode-custom-agent",
-				userMessage: "   ",
-			},
+			{ harness: "codex", userMessage: "okay cool", sessionKey: "session-low-signal" },
 			makeDeps(),
 		);
 
-		expect(result.engine).toBeUndefined();
-		expect(result.inject).toContain("## Memory Check");
-		expect(result.inject).toContain("No strong automatic memory match was injected");
-		expect(result.inject).toContain("run 1-3 targeted Signet recalls before executing commands");
-		expect(result.inject).toContain("## Plugin Context");
-		expect(result.inject).toContain('plugin="signet.secrets"');
-		expect(result.inject).toContain("prefer storing them in Signet Secrets");
-		expect(result.inject).toContain("save it with /remember or memory_store");
-		const submitCalls = infoMock.mock.calls.filter((call) => call[1] === "User prompt submit");
-		expect(submitCalls).toHaveLength(1);
-		const payload = submitCalls[0]?.[2];
-		expect(payload?.engine).toBe("no-query");
-		expect(payload?.memoryCount).toBe(0);
+		expect(result).toMatchObject({ inject: "", memoryCount: 0, engine: "low-signal" });
+		expect(hybridRecallMock).not.toHaveBeenCalled();
+		expect(fetchEmbeddingMock).not.toHaveBeenCalled();
+		expect(searchTemporalFallbackMock).not.toHaveBeenCalled();
+		expect(infoMock.mock.calls.at(-1)?.[2]?.engine).toBe("low-signal");
 	});
 
-	it("uses Pi-native memory tools in no-memory prompt guidance", async () => {
+	it("returns empty inject when no known entity or alias is mentioned", async () => {
+		seedEntityContext();
+
 		const result = await handleUserPromptSubmit(
-			{
-				harness: "pi",
-				userMessage: "   ",
-			},
+			{ harness: "codex", userMessage: "what should we do about unrelated routing", sessionKey: "session-no-entity" },
 			makeDeps(),
 		);
 
-		expect(result.inject).toContain("No strong automatic memory match was injected");
-		expect(result.inject).toContain("run 1-3 targeted Signet recalls with signet_recall");
-		expect(result.inject).toContain("save it with /remember or signet_remember");
-		expect(result.inject).not.toContain("memory_search");
-		expect(result.inject).not.toContain("memory_store");
+		expect(result).toMatchObject({ inject: "", memoryCount: 0, engine: "no-entity" });
+		expect(hybridRecallMock).not.toHaveBeenCalled();
+		expect(searchTemporalFallbackMock).not.toHaveBeenCalled();
 	});
 
-	it("uses Codex-specific guidance when native memories are enabled", async () => {
-		process.env.SIGNET_CODEX_NATIVE_MEMORY = "1";
-		const result = await handleUserPromptSubmit(
-			{
-				harness: "codex",
-				userMessage: "   ",
-			},
-			makeDeps(),
-		);
-
-		expect(result.inject).toContain("Codex native memory may already cover ordinary memory needs");
-		expect(result.inject).toContain("run 1-3 targeted Signet recalls with signet_recall");
-		expect(result.inject).toContain("save it with signet_save_note");
-		expect(result.inject).not.toContain("memory_store");
-	});
-
-	it("filters Codex native memory rows from automatic prompt-submit injection", async () => {
-		process.env.SIGNET_CODEX_NATIVE_MEMORY = "1";
-		hybridRecallMock.mockImplementation(async () => ({
-			results: [
-				{
-					id: "native-1",
-					content: "Codex native memory duplicate",
-					score: 0.95,
-					source: "native_memory",
-					source_id: "native:codex:native_memory_registry:abc123",
-					type: "native_memory_registry",
-					tags: "codex,native-memory,native_memory_registry",
-					who: "codex",
-					created_at: "2026-05-24T00:00:00.000Z",
-				},
-				{
-					id: "native-claude",
-					content: "Claude Code source-backed Codex context still matters",
-					score: 0.93,
-					source: "native_memory",
-					source_id: "native:claude-code:native_claude_memory:def456",
-					type: "native_claude_memory",
-					tags: "claude-code,codex,native-memory,native_claude_memory",
-					who: "claude-code",
-					created_at: "2026-05-24T00:00:00.000Z",
-				},
-				{
-					id: "decision-1",
-					content: "Accepted Signet decision from another harness",
-					score: 0.9,
-					source: "hybrid",
-					type: "decision",
-					created_at: "2026-05-24T00:00:00.000Z",
-				},
-			],
-		}));
+	it("injects compact current-view context for an exact entity mention", async () => {
+		seedEntityContext();
 
 		const result = await handleUserPromptSubmit(
 			{
 				harness: "codex",
-				userMessage: "What Signet decision should I follow?",
-				sessionKey: "codex-native-filter",
+				userMessage: "How should Signet architecture handle prompt context?",
+				sessionKey: "session-entity",
 			},
 			makeDeps(),
 		);
 
-		expect(result.memoryCount).toBe(2);
-		expect(result.inject).toContain("Claude Code source-backed Codex context still matters");
-		expect(result.inject).toContain("Accepted Signet decision from another harness");
-		expect(result.inject).not.toContain("Codex native memory duplicate");
-	});
-
-	it("keeps native rows when Codex memories are disabled in the features table", async () => {
-		const codexHome = mkdtempSync(join(tmpdir(), "signet-codex-home-"));
-		try {
-			mkdirSync(join(codexHome, "memories"), { recursive: true });
-			writeFileSync(join(codexHome, "config.toml"), "[features]\nmemories = false\n", "utf-8");
-			process.env.CODEX_HOME = codexHome;
-			hybridRecallMock.mockImplementation(async () => ({
-				results: [
-					{
-						id: "native-1",
-						content: "Codex native memory should stay when Codex memory feature is off",
-						score: 0.95,
-						source: "native_memory",
-						source_id: "native:codex:native_memory_registry:abc123",
-						type: "native_memory_registry",
-						tags: "codex,native-memory,native_memory_registry",
-						who: "codex",
-						created_at: "2026-05-24T00:00:00.000Z",
-					},
-				],
-			}));
-
-			const result = await handleUserPromptSubmit(
-				{
-					harness: "codex",
-					userMessage: "What native memory should I use?",
-					sessionKey: "codex-memory-feature-disabled",
-				},
-				makeDeps(),
-			);
-
-			expect(result.memoryCount).toBe(1);
-			expect(result.inject).toContain("Codex native memory should stay when Codex memory feature is off");
-		} finally {
-			rmSync(codexHome, { recursive: true, force: true });
-		}
-	});
-
-	it("removes Secrets prompt contribution when signet.secrets is disabled", async () => {
-		getDefaultPluginHost().setEnabled(SIGNET_SECRETS_PLUGIN_ID, false);
-
-		const result = await handleUserPromptSubmit(
-			{
-				harness: "vscode-custom-agent",
-				userMessage: "   ",
-			},
-			makeDeps(),
-		);
-
-		expect(result.inject).toContain("## Memory Check");
-		expect(result.inject).toContain("No strong automatic memory match was injected");
-		expect(result.inject).not.toContain("## Plugin Context");
-		expect(result.inject).not.toContain('plugin="signet.secrets"');
-		expect(result.inject).not.toContain("prefer storing them in Signet Secrets");
-	});
-
-	it("logs successful temporal fallback outcomes", async () => {
-		searchTemporalFallbackMock.mockReturnValue([
-			{
-				id: "node-1",
-				latestAt: "2026-03-26T20:00:00.000Z",
-				threadLabel: "thread: recent work",
-				excerpt: "worked on prompt-submit observability",
-			},
-		]);
-
-		const result = await handleUserPromptSubmit(
-			{
-				harness: "vscode-custom-agent",
-				userMessage: "what did we do for prompt submit logs",
-				sessionKey: "session-1",
-			},
-			makeDeps(),
-		);
-
-		expect(result.engine).toBe("temporal-fallback");
-		const submitCalls = infoMock.mock.calls.filter((call) => call[1] === "User prompt submit");
-		expect(submitCalls).toHaveLength(1);
-		const payload = submitCalls[0]?.[2];
-		expect(payload?.engine).toBe("temporal-fallback");
-		expect(payload?.memoryCount).toBe(1);
-		expect(result.inject).toContain("## Memory Check");
-		expect(result.inject).toContain("## Relevant Memory");
-		expect(result.inject).toContain("[thread node-1]");
-		expect(result.inject).toContain("Use the memories below as starting context before acting");
-		expect(result.inject).toContain("run 1-3 targeted recalls with /recall or memory_search");
-		expect(result.inject).not.toContain("[signet:recall");
-	});
-
-	it("does not inject transcript fallback content when structured recall misses", async () => {
-		searchTemporalFallbackMock.mockReturnValue([]);
-
-		const result = await handleUserPromptSubmit(
-			{
-				harness: "vscode-custom-agent",
-				userMessage: "show transcript fallback context",
-				sessionKey: "session-2",
-			},
-			makeDeps(),
-		);
-
-		const submitCalls = infoMock.mock.calls.filter((call) => call[1] === "User prompt submit");
-		expect(submitCalls).toHaveLength(1);
-		const payload = submitCalls[0]?.[2];
-		expect(payload?.engine).not.toBe("transcript-fallback");
-		expect(payload?.memoryCount).toBe(0);
-		expect(result.inject).toContain("## Memory Check");
+		expect(result.engine).toBe("entity-context");
+		expect(result.inject).toContain("## Relevant Entity Context");
+		expect(result.inject).toContain("[constraint] Signet / architecture / runtime / fallback_policy");
+		expect(result.inject).toContain("Do not use generic fallback injection.");
+		expect(result.inject).toContain("[attribute] Signet / architecture / runtime / prompt_context");
 		expect(result.inject).not.toContain("## Relevant Memory");
-		expect(result.inject).not.toContain("[transcript");
-		expect(result.inject).toContain("save it with /remember or memory_store");
-		expect(result.inject).not.toContain("[signet:recall");
+		expect(result.inject).not.toContain("Marketing copy should stay secondary");
 	});
 
-	it("formats successful hybrid recall as a lightweight recall block", async () => {
-		hybridRecallMock.mockResolvedValueOnce({
-			results: [
-				{
-					id: "mem-1",
-					score: 0.96,
-					content: "prompt submit observability now logs fallback engine transitions",
-					created_at: "2026-03-26T20:10:00.000Z",
-				},
-				{
-					id: "mem-2",
-					score: 0.91,
-					content: "prompt submit injects a deterministic current date header",
-					created_at: "2026-03-25T10:00:00.000Z",
-				},
-			],
-		});
+	it("resolves active aliases to canonical entity context", async () => {
+		seedEntityContext();
 
 		const result = await handleUserPromptSubmit(
-			{
-				harness: "vscode-custom-agent",
-				userMessage: "show prompt submit observability behavior",
-				sessionKey: "session-hybrid-brief",
-			},
+			{ harness: "codex", userMessage: "Should SignetAI architecture use current views?", sessionKey: "session-alias" },
 			makeDeps(),
 		);
 
-		expect(result.engine).toBe("hybrid");
-		expect(result.memoryCount).toBe(2);
-		expect(result.inject).toContain("## Memory Check");
-		expect(result.inject).toContain("## Relevant Memory");
-		expect(result.inject).toContain("[memory] prompt submit observability now logs fallback engine transitions");
-		expect(result.inject).toContain("Use the memories below as starting context before acting");
-		expect(result.inject).toContain("run 1-3 targeted recalls with /recall or memory_search");
-		expect(result.inject).toContain("Ask natural questions with entity + event + timeframe when possible");
-		expect(result.inject).toContain("Avoid bag-of-keywords recall queries");
-		expect(result.inject).toContain("Treat graph expansion as supporting context, not proof");
-		expect(result.inject).not.toContain("[signet:recall");
+		expect(result.engine).toBe("entity-context");
+		expect(result.inject).toContain("Signet / architecture");
+		expect(result.inject).toContain("Prompt context should come from entity current views.");
 	});
 
-	it("uses Pi-native memory tools when injecting prompt-submit memories", async () => {
-		hybridRecallMock.mockResolvedValueOnce({
-			results: [
-				{
-					id: "mem-pi-guidance",
-					score: 0.95,
-					content: "Pi prompt guidance should use native Signet tool names",
-					created_at: "2026-03-26T20:10:00.000Z",
-				},
-			],
-		});
+	it("stays silent when the entity is known but no aspect clears the gate", async () => {
+		seedEntityContext();
 
 		const result = await handleUserPromptSubmit(
-			{
-				harness: "pi",
-				userMessage: "show pi prompt guidance behavior",
-				sessionKey: "session-pi-guidance",
-			},
+			{ harness: "codex", userMessage: "What about Signet billing?", sessionKey: "session-no-aspect" },
 			makeDeps(),
 		);
 
-		expect(result.engine).toBe("hybrid");
-		expect(result.inject).toContain("## Relevant Memory");
-		expect(result.inject).toContain("Pi prompt guidance should use native Signet tool names");
-		expect(result.inject).toContain("run 1-3 targeted recalls with signet_recall");
-		expect(result.inject).toContain("save it with /remember or signet_remember");
-		expect(result.inject).not.toContain("memory_search");
-		expect(result.inject).not.toContain("memory_store");
-	});
-
-	it("requests feedback with the namespaced MCP tool for non-Pi harnesses", async () => {
-		hybridRecallMock.mockResolvedValueOnce({
-			results: [
-				{
-					id: "mem-feedback-codex",
-					score: 0.95,
-					content: "feedback guidance should name the Codex MCP feedback tool",
-					created_at: "2026-03-26T20:10:00.000Z",
-				},
-			],
-		});
-
-		const result = await handleUserPromptSubmit(
-			{
-				harness: "codex",
-				userMessage: "show codex feedback guidance",
-				sessionKey: "session-codex-feedback",
-			},
-			makeDeps({ agentFeedback: true }),
-		);
-
-		expect(result.inject).toContain("mcp__signet__memory_feedback");
-		expect(result.inject).toContain('Pass session_key "session-codex-feedback"');
-		expect(result.inject).not.toContain("signet_memory_feedback tool");
-	});
-
-	it("requests feedback with the Pi-native feedback tool for Pi", async () => {
-		hybridRecallMock.mockResolvedValueOnce({
-			results: [
-				{
-					id: "mem-feedback-pi",
-					score: 0.95,
-					content: "feedback guidance should name the Pi feedback tool",
-					created_at: "2026-03-26T20:10:00.000Z",
-				},
-			],
-		});
-
-		const result = await handleUserPromptSubmit(
-			{
-				harness: "pi",
-				userMessage: "show pi feedback guidance",
-				sessionKey: "session-pi-feedback",
-			},
-			makeDeps({ agentFeedback: true }),
-		);
-
-		expect(result.inject).toContain("signet_memory_feedback");
-		expect(result.inject).not.toContain("mcp__signet__memory_feedback");
-		expect(result.inject).not.toContain('Pass session_key "session-pi-feedback"');
-		expect(result.inject).not.toContain("memory_store");
-	});
-
-	it("uses prompt-submit embeddings when they return within the hook budget", async () => {
-		fetchEmbeddingMock.mockResolvedValueOnce([0.1, 0.2, 0.3]);
-		hybridRecallMock.mockImplementationOnce(async (_params, _cfg, embed) => {
-			const vector = await embed("prompt submit timeout trace", {
-				provider: "ollama",
-				model: "nomic-embed-text",
-				dimensions: 768,
-				base_url: "http://localhost:11434",
-			});
-			return {
-				results: vector
-					? [
-							{
-								id: "mem-vector",
-								score: 0.95,
-								content: "prompt submit timeout trace uses fast vector context",
-								created_at: "2026-03-26T20:10:00.000Z",
-							},
-						]
-					: [],
-			};
-		});
-
-		const result = await handleUserPromptSubmit(
-			{
-				harness: "vscode-custom-agent",
-				userMessage: "prompt submit timeout trace",
-				sessionKey: "session-fast-embedding",
-			},
-			makeDeps(),
-		);
-
-		expect(fetchEmbeddingMock).toHaveBeenCalledTimes(1);
-		expect(result.memoryCount).toBe(1);
-		expect(result.inject).toContain("prompt submit timeout trace uses fast vector context");
-	});
-
-	it("preserves vector prompt-submit recall for concurrent fast embeddings", async () => {
-		const firstEmbedding = makePendingEmbedding();
-		const secondEmbedding = makePendingEmbedding();
-		fetchEmbeddingMock
-			.mockImplementationOnce(async () => firstEmbedding.promise)
-			.mockImplementationOnce(async () => secondEmbedding.promise);
-		hybridRecallMock.mockImplementation(async (_params, _cfg, embed) => {
-			const vector = await embed("prompt submit concurrent vector trace", {
-				provider: "ollama",
-				model: "nomic-embed-text",
-				dimensions: 768,
-				base_url: "http://localhost:11434",
-			});
-			return {
-				results: vector
-					? [
-							{
-								id: `mem-concurrent-${vector[0]}`,
-								score: 0.95,
-								content: `prompt submit concurrent vector recall ${vector[0]}`,
-								created_at: "2026-03-26T20:10:00.000Z",
-							},
-						]
-					: [],
-			};
-		});
-
-		const first = handleUserPromptSubmit(
-			{
-				harness: "vscode-custom-agent",
-				userMessage: "prompt submit concurrent vector trace",
-				sessionKey: "session-concurrent-fast-embedding-one",
-			},
-			makeDeps(),
-		);
-		const second = handleUserPromptSubmit(
-			{
-				harness: "vscode-custom-agent",
-				userMessage: "prompt submit concurrent vector trace",
-				sessionKey: "session-concurrent-fast-embedding-two",
-			},
-			makeDeps(),
-		);
-
-		firstEmbedding.resolve([0.1, 0.2, 0.3]);
-		secondEmbedding.resolve([0.4, 0.5, 0.6]);
-		const [firstResult, secondResult] = await Promise.all([first, second]);
-
-		expect(fetchEmbeddingMock).toHaveBeenCalledTimes(2);
-		expect(firstResult.memoryCount).toBe(1);
-		expect(firstResult.inject).toContain("prompt submit concurrent vector recall 0.1");
-		expect(secondResult.memoryCount).toBe(1);
-		expect(secondResult.inject).toContain("prompt submit concurrent vector recall 0.4");
-		expect(warnMock).not.toHaveBeenCalledWith(
-			"hooks",
-			"User prompt submit embedding already in flight, skipping vector recall",
-			expect.anything(),
-		);
-	});
-
-	it("bypasses prompt-submit embeddings when they exceed the hook budget", async () => {
-		const pending = makePendingEmbedding();
-		let signal: AbortSignal | undefined;
-		fetchEmbeddingMock.mockImplementationOnce(async (_text, _cfg, opts) => {
-			signal = opts?.signal;
-			return pending.promise;
-		});
-		hybridRecallMock.mockImplementationOnce(async (_params, _cfg, embed) => {
-			const vector = await embed("prompt submit timeout trace", {
-				provider: "ollama",
-				model: "nomic-embed-text",
-				dimensions: 768,
-				base_url: "http://localhost:11434",
-			});
-			return {
-				results: vector
-					? [
-							{
-								id: "mem-vector",
-								score: 0.95,
-								content: "prompt submit timeout trace should not wait forever",
-								created_at: "2026-03-26T20:10:00.000Z",
-							},
-						]
-					: [],
-			};
-		});
-
-		const start = Date.now();
-		const result = await handleUserPromptSubmit(
-			{
-				harness: "vscode-custom-agent",
-				userMessage: "prompt submit timeout trace",
-				sessionKey: "session-slow-embedding",
-			},
-			makeDeps(),
-		);
-
-		expect(Date.now() - start).toBeLessThan(1500);
-		expect(fetchEmbeddingMock).toHaveBeenCalledTimes(1);
-		expect(result.memoryCount).toBe(0);
-		expect(result.inject).toContain("No strong automatic memory match was injected");
-		expect(warnMock).toHaveBeenCalledWith(
-			"hooks",
-			"User prompt submit embedding timed out",
-			expect.objectContaining({ timeoutMs: 1000 }),
-		);
-		expect(signal?.aborted).toBe(true);
-		pending.resolve(null);
-		await Promise.resolve();
-	});
-
-	it("uses configured prompt-submit embedding timeout", async () => {
-		const pending = makePendingEmbedding();
-		let signal: AbortSignal | undefined;
-		fetchEmbeddingMock.mockImplementationOnce(async (_text, _cfg, opts) => {
-			signal = opts?.signal;
-			return pending.promise;
-		});
-		hybridRecallMock.mockImplementationOnce(async (_params, _cfg, embed) => {
-			const vector = await embed("prompt submit configured timeout", {
-				provider: "ollama",
-				model: "mxbai-embed-large",
-				dimensions: 1024,
-				base_url: "http://localhost:11434",
-			});
-			return {
-				results: vector
-					? [{ id: "mem-vector", score: 0.95, content: "vector", created_at: "2026-03-26T20:10:00.000Z" }]
-					: [],
-			};
-		});
-		writeFileSync(
-			join(agentsDir, "agent.yaml"),
-			"embedding:\n  provider: ollama\n  model: mxbai-embed-large\n  dimensions: 1024\n  promptSubmitTimeoutMs: 1200\n",
-		);
-
-		try {
-			const start = Date.now();
-			const result = await handleUserPromptSubmit(
-				{
-					harness: "vscode-custom-agent",
-					userMessage: "prompt submit configured timeout",
-					sessionKey: "session-configured-embedding-timeout",
-				},
-				makeDeps(),
-			);
-
-			expect(Date.now() - start).toBeLessThan(1700);
-			expect(result.memoryCount).toBe(0);
-			expect(warnMock).toHaveBeenCalledWith(
-				"hooks",
-				"User prompt submit embedding timed out",
-				expect.objectContaining({ timeoutMs: 1200 }),
-			);
-			expect(signal?.aborted).toBe(true);
-		} finally {
-			pending.resolve(null);
-			writeFileSync(join(agentsDir, "agent.yaml"), "");
-			await Promise.resolve();
-		}
-	});
-
-	it("preserves non-vector prompt-submit recall when embeddings exceed the hook budget", async () => {
-		const pending = makePendingEmbedding();
-		fetchEmbeddingMock.mockImplementationOnce(async () => pending.promise);
-		hybridRecallMock.mockImplementationOnce(async (_params, _cfg, embed) => {
-			const vector = await embed("prompt submit timeout lexical fallback", {
-				provider: "ollama",
-				model: "nomic-embed-text",
-				dimensions: 768,
-				base_url: "http://localhost:11434",
-			});
-			return {
-				results: vector
-					? []
-					: [
-							{
-								id: "mem-keyword",
-								score: 0.91,
-								content: "prompt submit timeout lexical fallback still injects keyword recall",
-								created_at: "2026-03-26T20:10:00.000Z",
-							},
-						],
-			};
-		});
-
-		const result = await handleUserPromptSubmit(
-			{
-				harness: "vscode-custom-agent",
-				userMessage: "prompt submit timeout lexical fallback",
-				sessionKey: "session-slow-embedding-keyword-fallback",
-			},
-			makeDeps(),
-		);
-
-		expect(fetchEmbeddingMock).toHaveBeenCalledTimes(1);
-		expect(result.memoryCount).toBe(1);
-		expect(result.inject).toContain("prompt submit timeout lexical fallback still injects keyword recall");
-		pending.resolve(null);
-		await Promise.resolve();
-	});
-
-	it("aborts timed-out prompt-submit embeddings and recovers vector recall on the next request", async () => {
-		const pending = makePendingEmbedding();
-		let signal: AbortSignal | undefined;
-		fetchEmbeddingMock.mockImplementationOnce(async (_text, _cfg, opts) => {
-			signal = opts?.signal;
-			return pending.promise;
-		});
-		fetchEmbeddingMock.mockResolvedValueOnce([0.4, 0.5, 0.6]);
-		hybridRecallMock.mockImplementation(async (_params, _cfg, embed) => {
-			const vector = await embed("prompt submit timeout trace", {
-				provider: "ollama",
-				model: "nomic-embed-text",
-				dimensions: 768,
-				base_url: "http://localhost:11434",
-			});
-			return {
-				results: vector
-					? [
-							{
-								id: "mem-recovered-vector",
-								score: 0.95,
-								content: "prompt submit vector recall recovers after timed-out embedding abort",
-								created_at: "2026-03-26T20:10:00.000Z",
-							},
-						]
-					: [],
-			};
-		});
-
-		const first = await handleUserPromptSubmit(
-			{
-				harness: "vscode-custom-agent",
-				userMessage: "prompt submit timeout trace",
-				sessionKey: "session-first-slow-embedding",
-			},
-			makeDeps(),
-		);
-
-		const second = await handleUserPromptSubmit(
-			{
-				harness: "vscode-custom-agent",
-				userMessage: "prompt submit timeout trace",
-				sessionKey: "session-second-slow-embedding",
-			},
-			makeDeps(),
-		);
-
-		expect(signal?.aborted).toBe(true);
-		expect(fetchEmbeddingMock).toHaveBeenCalledTimes(2);
-		expect(first.memoryCount).toBe(0);
-		expect(second.memoryCount).toBe(1);
-		expect(second.inject).toContain("prompt submit vector recall recovers after timed-out embedding abort");
-		pending.resolve(null);
-		await Promise.resolve();
-	});
-
-	it("rescues a later relevant memory when earlier compact candidates are irrelevant", async () => {
-		hybridRecallMock.mockResolvedValueOnce({
-			results: [
-				{
-					id: "mem-noisy",
-					score: 0.99,
-					content: `${"workspace migration checklist and daemon route refactor notes ".repeat(20).trim()}.`,
-					created_at: "2026-03-26T20:10:00.000Z",
-				},
-				{
-					id: "mem-proud",
-					score: 0.96,
-					content: "i am so proud of you for fixing recall and shipping the follow-up cleanly.",
-					created_at: "2026-03-25T10:00:00.000Z",
-				},
-			],
-		});
-
-		writeFileSync(
-			join(agentsDir, "agent.yaml"),
-			["hooks:", "  userPromptSubmit:", "    maxInjectChars: 110", ""].join("\n"),
-		);
-		try {
-			const result = await handleUserPromptSubmit(
-				{
-					harness: "vscode-custom-agent",
-					userMessage: "im proud of you",
-					sessionKey: "session-proud-rescue",
-				},
-				makeDeps(),
-			);
-
-			expect(result.engine).toBe("hybrid");
-			expect(result.memoryCount).toBe(1);
-			expect(result.inject).toContain("## Memory Check");
-			expect(result.inject).toContain("## Relevant Memory");
-			expect(result.inject).toContain("i am so proud of you");
-			expect(result.inject).not.toContain("workspace migration checklist");
-		} finally {
-			writeFileSync(join(agentsDir, "agent.yaml"), "");
-		}
-	});
-
-	it("skips prompt-submit injection when top recall score is below confidence gate", async () => {
-		hybridRecallMock.mockResolvedValueOnce({
-			results: [
-				{
-					id: "mem-low",
-					score: 0.69,
-					content: "weakly related memory",
-					created_at: "2026-03-26T20:10:00.000Z",
-				},
-			],
-		});
-
-		const result = await handleUserPromptSubmit(
-			{
-				harness: "vscode-custom-agent",
-				userMessage: "show memory confidence behavior",
-				sessionKey: "session-low-confidence",
-			},
-			makeDeps(),
-		);
-
-		expect(result.memoryCount).toBe(0);
-		expect(result.inject).toContain("Current Date & Time");
-		expect(result.inject).toContain("## Memory Check");
-		expect(result.inject).toContain("No strong automatic memory match was injected");
-		expect(result.inject).toContain("save it with /remember or memory_store");
-		expect(result.inject).not.toContain("[signet:recall");
-		const submitCalls = infoMock.mock.calls.filter((call) => call[1] === "User prompt submit");
-		expect(submitCalls).toHaveLength(1);
-		const payload = submitCalls[0]?.[2];
-		expect(payload?.engine).toBe("low-confidence");
-	});
-
-	it("returns Memory Check guidance when hybrid recall fails", async () => {
-		hybridRecallMock.mockRejectedValueOnce(new Error("synthetic recall failure"));
-
-		const result = await handleUserPromptSubmit(
-			{
-				harness: "vscode-custom-agent",
-				userMessage: "show memory failure behavior",
-				sessionKey: "session-recall-failure",
-			},
-			makeDeps(),
-		);
-
-		expect(result.memoryCount).toBe(0);
-		expect(result.inject).toContain("Current Date & Time");
-		expect(result.inject).toContain("## Memory Check");
-		expect(result.inject).toContain("No strong automatic memory match was injected");
-		expect(result.inject).toContain("run 1-3 targeted Signet recalls before executing commands");
-		expect(result.inject).toContain("save it with /remember or memory_store");
-		expect(errorMock).toHaveBeenCalledTimes(1);
+		expect(result).toMatchObject({ inject: "", memoryCount: 0, engine: "no-aspect-hit" });
 	});
 });

--- a/platform/daemon/src/hooks.prompt-submit.test.ts
+++ b/platform/daemon/src/hooks.prompt-submit.test.ts
@@ -244,6 +244,38 @@ describe("handleUserPromptSubmit entity context", () => {
 		expect(result).toMatchObject({ inject: "", memoryCount: 0, engine: "no-aspect-hit" });
 	});
 
+	it("does not match short entity names as ordinary prompt tokens", async () => {
+		getDbAccessor().withWriteTx((db) => {
+			const now = "2026-05-27T00:00:00.000Z";
+			db.prepare(
+				`INSERT INTO entities
+				 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+				 VALUES ('entity-ai', 'AI', 'ai', 'concept', 'default', 10, ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO entity_aspects
+				 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+				 VALUES ('aspect-ai-architecture', 'entity-ai', 'default', 'architecture', 'architecture', 1, ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO entity_attributes
+				 (id, aspect_id, agent_id, kind, content, normalized_content, group_key, claim_key,
+				  confidence, importance, status, created_at, updated_at)
+				 VALUES ('attr-ai-architecture', 'aspect-ai-architecture', 'default', 'attribute',
+				  'Short entity names should not match ordinary words.',
+				  'short entity names should not match ordinary words',
+				  'runtime', 'short_match_guard', 0.9, 0.9, 'active', ?, ?)`,
+			).run(now, now);
+		});
+
+		const result = await handleUserPromptSubmit(
+			{ harness: "codex", userMessage: "Can AI architecture be summarized?", sessionKey: "session-short-name" },
+			makeDeps(),
+		);
+
+		expect(result).toMatchObject({ inject: "", memoryCount: 0, engine: "no-entity" });
+	});
+
 	it("stays silent when the entity is known but no aspect clears the gate", async () => {
 		seedEntityContext();
 

--- a/platform/daemon/src/hooks.test.ts
+++ b/platform/daemon/src/hooks.test.ts
@@ -1211,30 +1211,22 @@ hooks:
 // ============================================================================
 
 describe("handleUserPromptSubmit", () => {
-	test.serial("returns matching memories for prompt", async () => {
-		createMemoryDb([
-			{
-				content: "Use TypeScript as the preferred language for this project",
-				importance: 0.8,
-			},
-		]);
+	test.serial("returns empty inject when no known entity or alias is mentioned", async () => {
+		createMemoryDb([{ content: "Use TypeScript as the preferred language for this project", importance: 0.8 }]);
 
 		const result = await handleUserPromptSubmit({
 			harness: "test",
 			userPrompt: "What TypeScript language should we use?",
 		});
 
-		expect(result.memoryCount).toBeGreaterThan(0);
-		expect(result.inject).toContain("TypeScript");
+		expect(result.memoryCount).toBe(0);
+		expect(result.inject).toBe("");
+		expect(result.engine).toBe("no-entity");
+		expect(result.queryTerms).toContain("typescript");
 	});
 
-	test.serial("strips untrusted metadata block from user prompt", async () => {
-		createMemoryDb([
-			{
-				content: "Reiterate the release checklist before deploy",
-				importance: 0.8,
-			},
-		]);
+	test.serial("strips untrusted metadata block before entity matching and telemetry", async () => {
+		createMemoryDb([]);
 
 		const result = await handleUserPromptSubmit({
 			harness: "test",
@@ -1242,18 +1234,14 @@ describe("handleUserPromptSubmit", () => {
 				'Conversation info (untrusted metadata):\n{"conversation_label":"OpenClaw Session","message_id":"msg_123","sender_id":"user_456"}\n\nCan you reiterate the release checklist?',
 		});
 
-		expect(result.memoryCount).toBeGreaterThan(0);
+		expect(result.memoryCount).toBe(0);
+		expect(result.inject).toBe("");
 		expect(result.queryTerms).toContain("reiterate");
 		expect(result.queryTerms).not.toContain("conversation_label");
 	});
 
 	test.serial("prefers adapter-provided userMessage over raw prompt envelope", async () => {
-		createMemoryDb([
-			{
-				content: "Reiterate the release checklist before deploy",
-				importance: 0.8,
-			},
-		]);
+		createMemoryDb([]);
 
 		const result = await handleUserPromptSubmit({
 			harness: "openclaw",
@@ -1262,81 +1250,27 @@ describe("handleUserPromptSubmit", () => {
 				'Conversation info (untrusted metadata):\n{"agent_path":"/home/user/.agents","channel":"discord"}\n\n<<<EXTERNAL_UNTRUSTED_CONTENT>>>\nSender (untrusted): discord\nEND_EXTERNAL_UNTRUSTED_CONTENT',
 		});
 
-		expect(result.memoryCount).toBeGreaterThan(0);
+		expect(result.memoryCount).toBe(0);
+		expect(result.inject).toBe("");
 		expect(result.queryTerms).toContain("reiterate");
 		expect(result.queryTerms).toContain("release");
 		expect(result.queryTerms).not.toContain("agents");
 		expect(result.queryTerms).not.toContain("discord");
 	});
 
-	test.serial("keeps recall query terms focused on the cleaned user prompt", async () => {
-		createMemoryDb([
-			{
-				content: "Use pgvector in PostgreSQL for semantic embeddings",
-				importance: 0.8,
-			},
-		]);
-
-		const result = await handleUserPromptSubmit({
-			harness: "test",
-			userPrompt: "Can you remind me which embeddings database to use?",
-			lastAssistantMessage: "Earlier I suggested pgvector for embeddings.",
-		});
-
-		expect(result.memoryCount).toBeGreaterThan(0);
-		expect(result.queryTerms).toContain("embeddings database");
-		expect(result.queryTerms).not.toContain("pgvector");
-	});
-
-	test.serial("returns empty for no-match prompt", async () => {
-		createMemoryDb([{ content: "PostgreSQL replication setup guide", importance: 0.8 }]);
-
-		const result = await handleUserPromptSubmit({
-			harness: "test",
-			userPrompt: "quantum entanglement photon wavelength",
-		});
-
-		expect(result.memoryCount).toBe(0);
-		expect(result.inject).toContain("Current Date & Time");
-		expect(result.inject).not.toContain("[signet:recall");
-	});
-
-	test.serial("skips very short prompts with no words >= 3 chars", async () => {
-		createMemoryDb([{ content: "Something important", importance: 0.8 }]);
-
-		const result = await handleUserPromptSubmit({
-			harness: "test",
-			userPrompt: "hi ok",
-		});
-
-		expect(result.memoryCount).toBe(0);
-		expect(result.inject).toContain("Current Date & Time");
-		expect(result.inject).not.toContain("[signet:recall");
-	});
-
-	test.serial("handles missing database gracefully", async () => {
-		const result = await handleUserPromptSubmit({
-			harness: "test",
-			userPrompt: "A reasonable question here",
-		});
-
-		expect(result.memoryCount).toBe(0);
-		expect(result.inject).toContain("Current Date & Time");
-		expect(result.inject).not.toContain("[signet:recall");
-	});
-
-	test.serial("upserts session transcript during prompt flow when provided", async () => {
-		createMemoryDb([{ content: "release checklist", importance: 0.8 }]);
+	test.serial("upserts session transcript during prompt flow even when no context is injected", async () => {
+		createMemoryDb([]);
 		const transcriptPath = join(TEST_DIR, "prompt-transcript.txt");
 		writeFileSync(transcriptPath, "User: review the release checklist\nAssistant: here's the checklist");
 
-		await handleUserPromptSubmit({
+		const result = await handleUserPromptSubmit({
 			harness: "test",
 			userPrompt: "review the release checklist",
 			sessionKey: "sess-prompt",
 			transcriptPath,
 		});
 
+		expect(result.inject).toBe("");
 		const db = openTestDb();
 		const row = db.prepare("SELECT content FROM session_transcripts WHERE session_key = ?").get("sess-prompt") as
 			| { content: string }
@@ -1344,422 +1278,6 @@ describe("handleUserPromptSubmit", () => {
 		db.close();
 
 		expect(row?.content).toContain("review the release checklist");
-	});
-
-	test.serial("does not fall back to transcript excerpts when structured recall is empty", async () => {
-		createMemoryDb([]);
-		const db = openTestDb();
-		db.prepare(
-			`INSERT INTO session_transcripts
-			 (session_key, content, harness, project, agent_id, created_at, updated_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		).run(
-			"sess-older",
-			"User: we decided the temporal index should preserve drill-down handles for MEMORY.md lineage.\nAssistant: yes, the temporal index needs lineage and drill-down handles.",
-			"test",
-			"proj",
-			"default",
-			"2026-03-25T10:00:00.000Z",
-			"2026-03-25T10:05:00.000Z",
-		);
-		db.close();
-
-		const result = await handleUserPromptSubmit({
-			harness: "test",
-			project: "proj",
-			sessionKey: "sess-current",
-			userPrompt: "where did we decide the temporal index drill-down handles should live?",
-		});
-
-		expect(result.memoryCount).toBe(0);
-		expect(result.engine).not.toBe("transcript-fallback");
-		expect(result.inject).not.toContain("temporal index");
-		expect(result.inject).not.toContain("sess-olde");
-	});
-
-	test.serial("uses temporal fallback before transcript fallback when weak hybrid misses anchors", async () => {
-		createMemoryDb([
-			{
-				content: "Locate deployment logs from the latest rollout runbook.",
-				importance: 0.95,
-			},
-		]);
-		const db = openTestDb();
-		db.prepare(
-			`INSERT INTO session_summaries (
-				id, project, depth, kind, content, token_count,
-				earliest_at, latest_at, session_key, harness,
-				agent_id, source_type, source_ref, meta_json, created_at
-			) VALUES (?, ?, 0, 'session', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		).run(
-			"temporal-node-1",
-			"proj",
-			"# Session\n\nultra-needle-transcript-only-5529931 is tracked in temporal summaries.",
-			24,
-			"2026-03-25T09:59:00.000Z",
-			"2026-03-25T10:05:00.000Z",
-			"sess-temporal",
-			"test",
-			"default",
-			"summary",
-			"sess-temporal",
-			JSON.stringify({ source: "summary-worker" }),
-			"2026-03-25T10:05:00.000Z",
-		);
-		db.prepare(
-			`INSERT INTO session_transcripts
-			 (session_key, content, harness, project, agent_id, created_at, updated_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		).run(
-			"sess-anchor",
-			"User: marker lookup\nAssistant: ultra-needle-transcript-only-5529931 is only in transcript history.",
-			"test",
-			"proj",
-			"default",
-			"2026-03-25T10:00:00.000Z",
-			"2026-03-25T10:05:00.000Z",
-		);
-		db.close();
-
-		const result = await handleUserPromptSubmit({
-			harness: "test",
-			project: "proj",
-			sessionKey: "sess-current",
-			userPrompt: "locate ultra-needle-transcript-only-5529931",
-		});
-
-		expect(result.memoryCount).toBeGreaterThan(0);
-		expect(result.engine).toBe("temporal-fallback");
-		expect(result.inject).toContain("temporal-node-1");
-		expect(result.inject).toContain("ultra-needle-transcript-only-5529931");
-	});
-
-	test.serial("uses persisted thread heads for temporal fallback and filters cross-project bleed", async () => {
-		createMemoryDb([]);
-		const db = openTestDb();
-		db.prepare(
-			`INSERT INTO memory_thread_heads (
-				agent_id, thread_key, label, project, session_key, source_type,
-				source_ref, harness, node_id, latest_at, sample, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		).run(
-			"default",
-			"project:/tmp/proj-good",
-			"project:proj-good",
-			"/tmp/proj-good",
-			"sess-good",
-			"summary",
-			"sess-good",
-			"test",
-			"node-good",
-			"2026-03-25T10:05:00.000Z",
-			"deploy rollback checklist and execution notes",
-			"2026-03-25T10:05:00.000Z",
-		);
-		db.prepare(
-			`INSERT INTO memory_thread_heads (
-				agent_id, thread_key, label, project, session_key, source_type,
-				source_ref, harness, node_id, latest_at, sample, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		).run(
-			"default",
-			"project:/tmp/proj-bleed",
-			"project:proj-bleed",
-			"/tmp/proj-bleed",
-			"sess-bleed",
-			"summary",
-			"sess-bleed",
-			"test",
-			"node-bleed",
-			"2026-03-25T10:06:00.000Z",
-			"deploy notes only",
-			"2026-03-25T10:06:00.000Z",
-		);
-		db.close();
-
-		const result = await handleUserPromptSubmit({
-			harness: "test",
-			project: "/tmp/proj-good",
-			sessionKey: "sess-current",
-			userPrompt: "deploy rollback",
-		});
-
-		expect(result.memoryCount).toBeGreaterThan(0);
-		expect(result.engine).toBe("temporal-fallback");
-		expect(result.inject).toContain("node-good");
-		expect(result.inject).not.toContain("node-bleed");
-	});
-
-	test.serial("keeps single-anchor temporal fallback project-scoped", async () => {
-		createMemoryDb([]);
-		const db = openTestDb();
-		db.prepare(
-			`INSERT INTO memory_thread_heads (
-				agent_id, thread_key, label, project, session_key, source_type,
-				source_ref, harness, node_id, latest_at, sample, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		).run(
-			"default",
-			"project:/tmp/proj-good|session:sess-good|harness:test",
-			"project:proj-good#session:sess-good#harness:test",
-			"/tmp/proj-good",
-			"sess-good",
-			"summary",
-			"sess-good",
-			"test",
-			"node-good",
-			"2026-03-25T10:05:00.000Z",
-			"ticket-7711 root cause and fix details",
-			"2026-03-25T10:05:00.000Z",
-		);
-		db.prepare(
-			`INSERT INTO memory_thread_heads (
-				agent_id, thread_key, label, project, session_key, source_type,
-				source_ref, harness, node_id, latest_at, sample, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		).run(
-			"default",
-			"project:/tmp/proj-bleed|session:sess-bleed|harness:test",
-			"project:proj-bleed#session:sess-bleed#harness:test",
-			"/tmp/proj-bleed",
-			"sess-bleed",
-			"summary",
-			"sess-bleed",
-			"test",
-			"node-bleed",
-			"2026-03-25T10:06:00.000Z",
-			"ticket-7711 appears in another project context",
-			"2026-03-25T10:06:00.000Z",
-		);
-		db.close();
-
-		const result = await handleUserPromptSubmit({
-			harness: "test",
-			project: "/tmp/proj-good",
-			sessionKey: "sess-current",
-			userPrompt: "ticket-7711",
-		});
-
-		expect(result.memoryCount).toBeGreaterThan(0);
-		expect(result.engine).toBe("temporal-fallback");
-		expect(result.inject).toContain("node-good");
-		expect(result.inject).not.toContain("node-bleed");
-	});
-
-	test.serial("escapes underscore anchors in temporal fallback matching", async () => {
-		createMemoryDb([]);
-		const db = openTestDb();
-		db.prepare(
-			`INSERT INTO memory_thread_heads (
-				agent_id, thread_key, label, project, session_key, source_type,
-				source_ref, harness, node_id, latest_at, sample, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		).run(
-			"default",
-			"project:/tmp/proj|session:sess-exact|harness:test",
-			"project:proj#session:sess-exact#harness:test",
-			"/tmp/proj",
-			"sess-exact",
-			"summary",
-			"sess-exact",
-			"test",
-			"node-exact",
-			"2026-03-25T10:05:00.000Z",
-			"ticket_7711 is tracked exactly in this lane",
-			"2026-03-25T10:05:00.000Z",
-		);
-		db.prepare(
-			`INSERT INTO memory_thread_heads (
-				agent_id, thread_key, label, project, session_key, source_type,
-				source_ref, harness, node_id, latest_at, sample, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		).run(
-			"default",
-			"project:/tmp/proj|session:sess-wild|harness:test",
-			"project:proj#session:sess-wild#harness:test",
-			"/tmp/proj",
-			"sess-wild",
-			"summary",
-			"sess-wild",
-			"test",
-			"node-wild",
-			"2026-03-25T10:06:00.000Z",
-			"ticketA7711 should stay isolated from the underscored ticket code",
-			"2026-03-25T10:06:00.000Z",
-		);
-		db.close();
-
-		const result = await handleUserPromptSubmit({
-			harness: "test",
-			project: "/tmp/proj",
-			sessionKey: "sess-current",
-			userPrompt: "ticket_7711",
-		});
-
-		expect(result.memoryCount).toBeGreaterThan(0);
-		expect(result.engine).toBe("temporal-fallback");
-		expect(result.inject).toContain("node-exact");
-		expect(result.inject).not.toContain("node-wild");
-	});
-
-	test.serial("does not collapse distinct thread keys that share the same label", async () => {
-		createMemoryDb([]);
-		const db = openTestDb();
-		db.prepare(
-			`INSERT INTO memory_thread_heads (
-				agent_id, thread_key, label, project, session_key, source_type,
-				source_ref, harness, node_id, latest_at, sample, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		).run(
-			"default",
-			"project:/work/foo|session:sess-a",
-			"project:foo",
-			"/work/foo",
-			"sess-a",
-			"summary",
-			null,
-			"test",
-			"node-foo-a",
-			"2026-03-25T10:05:00.000Z",
-			"deploy rollout checklist for foo lane a",
-			"2026-03-25T10:05:00.000Z",
-		);
-		db.prepare(
-			`INSERT INTO memory_thread_heads (
-				agent_id, thread_key, label, project, session_key, source_type,
-				source_ref, harness, node_id, latest_at, sample, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		).run(
-			"default",
-			"project:/tmp/foo|session:sess-b",
-			"project:foo",
-			"/tmp/foo",
-			"sess-b",
-			"summary",
-			null,
-			"test",
-			"node-foo-b",
-			"2026-03-25T10:06:00.000Z",
-			"deploy rollout checklist for foo lane b",
-			"2026-03-25T10:06:00.000Z",
-		);
-		db.close();
-
-		const result = await handleUserPromptSubmit({
-			harness: "test",
-			sessionKey: "sess-current",
-			userPrompt: "deploy rollout checklist",
-		});
-
-		expect(result.memoryCount).toBe(2);
-		expect(result.engine).toBe("temporal-fallback");
-		expect(result.inject).toContain("node-foo-a");
-		expect(result.inject).toContain("node-foo-b");
-	});
-
-	test.serial("does not fall back to transcript excerpts when hybrid top hit misses query anchors", async () => {
-		createMemoryDb([
-			{
-				content: "Locate deployment logs from the latest rollout runbook.",
-				importance: 0.95,
-			},
-		]);
-		const db = openTestDb();
-		db.prepare(
-			`INSERT INTO session_transcripts
-			 (session_key, content, harness, project, agent_id, created_at, updated_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		).run(
-			"sess-anchor",
-			"User: marker lookup\nAssistant: ultra-needle-transcript-only-5529931 is only in transcript history.",
-			"test",
-			"proj",
-			"default",
-			"2026-03-25T10:00:00.000Z",
-			"2026-03-25T10:05:00.000Z",
-		);
-		db.close();
-
-		const result = await handleUserPromptSubmit({
-			harness: "test",
-			project: "proj",
-			sessionKey: "sess-current",
-			userPrompt: "locate ultra-needle-transcript-only-5529931",
-		});
-
-		expect(result.memoryCount).toBe(0);
-		expect(result.engine).not.toBe("transcript-fallback");
-		expect(result.inject).not.toContain("ultra-needle-transcript-only-5529931");
-		expect(result.inject).not.toContain("sess-anch");
-	});
-
-	test.serial("applies character budget", async () => {
-		// Create many memories that would exceed the 500 char budget
-		const mems = Array.from({ length: 20 }, (_, i) => ({
-			content: `Important fact number ${i}: ${"x".repeat(80)}`,
-			importance: 0.9,
-		}));
-		createMemoryDb(mems);
-
-		const result = await handleUserPromptSubmit({
-			harness: "test",
-			userPrompt: "important fact number",
-		});
-
-		// Should be capped by budget, not return all 20
-		if (result.memoryCount > 0) {
-			// Memory budget is 500 chars, but inject also includes metadata header,
-			// recall status line, and optional feedback block
-			expect(result.memoryCount).toBeLessThan(20);
-		}
-	});
-
-	test.serial("skips conversational prompts with too few substantive words", async () => {
-		createMemoryDb([
-			{
-				content: "The payment retry queue should drain before deploy",
-				importance: 0.9,
-			},
-		]);
-
-		const result = await handleUserPromptSubmit({
-			harness: "test",
-			userPrompt: "yeah do that",
-		});
-
-		expect(result.memoryCount).toBe(0);
-		expect(result.inject).toContain("Current Date & Time");
-		expect(result.inject).not.toContain("[signet:recall");
-	});
-
-	test.serial("respects group visibility during prompt recall", async () => {
-		createMemoryDb([
-			{
-				content: "Team alpha uses shard-aware rollout plans",
-				importance: 0.95,
-				agent_id: "agent-alpha",
-				visibility: "global",
-			},
-			{
-				content: "Team beta migration notes",
-				importance: 0.95,
-				agent_id: "agent-beta",
-				visibility: "global",
-			},
-		]);
-		upsertAgent("agent-group", "group", "team-1");
-		upsertAgent("agent-alpha", "isolated", "team-1");
-		upsertAgent("agent-beta", "isolated", "team-2");
-
-		const result = await handleUserPromptSubmit({
-			harness: "test",
-			agentId: "agent-group",
-			userPrompt: "which rollout plans are shard aware?",
-		});
-
-		expect(result.memoryCount).toBeGreaterThan(0);
-		expect(result.inject).toContain("shard-aware rollout plans");
-		expect(result.inject).not.toContain("Team beta migration notes");
 	});
 });
 
@@ -3515,7 +3033,7 @@ describe("session memory recording integration", () => {
 		expect(count.cnt).toBe(0);
 	});
 
-	test.serial("handleUserPromptSubmit tracks FTS hits", async () => {
+	test.serial("handleUserPromptSubmit does not track FTS hits without entity context", async () => {
 		createMemoryDb([
 			{
 				content: "TypeScript is the preferred language for this project",
@@ -3529,7 +3047,6 @@ describe("session memory recording integration", () => {
 			sessionKey: "fts-tracking-session",
 		});
 
-		// Now submit a prompt that will match via hybrid recall
 		await handleUserPromptSubmit({
 			harness: "test",
 			sessionKey: "fts-tracking-session",
@@ -3546,9 +3063,8 @@ describe("session memory recording integration", () => {
 		}>;
 		db.close();
 
-		// Should have at least one row with fts_hit_count > 0
 		const withHits = rows.filter((r) => r.fts_hit_count > 0);
-		expect(withHits.length).toBeGreaterThan(0);
+		expect(withHits).toHaveLength(0);
 	});
 });
 

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -899,12 +899,25 @@ function loadEntityContextLines(
 	for (const aspect of aspects) {
 		const rows = db
 			.prepare(
-				`SELECT content, group_key, claim_key
-				 FROM entity_attributes
-				 WHERE aspect_id = ?
-				   AND agent_id = ?
-				   AND status = 'active'
-				 ORDER BY importance DESC, updated_at DESC
+				`SELECT ea.content, ea.group_key, ea.claim_key
+				 FROM entity_attributes ea
+				 WHERE ea.aspect_id = ?
+				   AND ea.agent_id = ?
+				   AND ea.status = 'active'
+				   AND ea.superseded_by IS NULL
+				   AND NOT EXISTS (
+				     SELECT 1
+				     FROM entity_attributes newer
+				     WHERE newer.aspect_id = ea.aspect_id
+				       AND newer.agent_id = ea.agent_id
+				       AND newer.kind = ea.kind
+				       AND COALESCE(newer.group_key, 'general') = COALESCE(ea.group_key, 'general')
+				       AND newer.claim_key = ea.claim_key
+				       AND newer.status = 'active'
+				       AND newer.superseded_by IS NULL
+				       AND COALESCE(newer.version, 1) > COALESCE(ea.version, 1)
+				   )
+				 ORDER BY ea.importance DESC, ea.updated_at DESC
 				 LIMIT 12`,
 			)
 			.all(aspect.id, agentId) as Array<{ content: string; group_key: string | null; claim_key: string | null }>;
@@ -935,6 +948,19 @@ function loadEntityContextLines(
 			 WHERE ea.aspect_id IN (${placeholders})
 			   AND ea.agent_id = ?
 			   AND ea.status = 'active'
+			   AND ea.superseded_by IS NULL
+			   AND NOT EXISTS (
+			     SELECT 1
+			     FROM entity_attributes newer
+			     WHERE newer.aspect_id = ea.aspect_id
+			       AND newer.agent_id = ea.agent_id
+			       AND newer.kind = ea.kind
+			       AND COALESCE(newer.group_key, 'general') = COALESCE(ea.group_key, 'general')
+			       AND newer.claim_key = ea.claim_key
+			       AND newer.status = 'active'
+			       AND newer.superseded_by IS NULL
+			       AND COALESCE(newer.version, 1) > COALESCE(ea.version, 1)
+			   )
 			 ORDER BY
 			   CASE ea.kind WHEN 'constraint' THEN 0 ELSE 1 END,
 			   ea.importance DESC,

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -859,7 +859,6 @@ function scoreAspectForPrompt(
 		readonly claim_key: string | null;
 	}>,
 	promptTerms: ReadonlyArray<string>,
-	allowWeightFallback: boolean,
 ): number {
 	const aspectTerms = extractSubstantiveWords(`${aspect.name} ${aspect.canonical_name}`);
 	const aspectOverlap = aspectTerms.some((term) => promptTerms.includes(term));
@@ -867,7 +866,7 @@ function scoreAspectForPrompt(
 	const attrText = rows.map((row) => `${row.group_key ?? ""} ${row.claim_key ?? ""} ${row.content}`).join(" ");
 	const overlap = countPromptTermOverlap(attrText, promptTerms);
 	if (overlap > 0) return Math.min(1, 0.75 + Math.min(aspect.weight, 1) * 0.25);
-	return allowWeightFallback ? Math.min(Math.max(aspect.weight, 0), 1) : 0;
+	return 0;
 }
 
 function loadEntityContextLines(
@@ -879,7 +878,6 @@ function loadEntityContextLines(
 ): PromptEntityContextLine[] {
 	const entityTerms = new Set(extractSubstantiveWords(`${entity.entityName} ${entity.matchedText}`));
 	const promptTerms = extractSubstantiveWords(userMessage).filter((term) => !entityTerms.has(term));
-	const allowWeightFallback = promptTerms.length === 0;
 	const aspects = db
 		.prepare(
 			`SELECT id, name, canonical_name, weight
@@ -910,7 +908,7 @@ function loadEntityContextLines(
 			)
 			.all(aspect.id, agentId) as Array<{ content: string; group_key: string | null; claim_key: string | null }>;
 		if (rows.length === 0) continue;
-		const score = scoreAspectForPrompt(aspect, rows, promptTerms, allowWeightFallback);
+		const score = scoreAspectForPrompt(aspect, rows, promptTerms);
 		if (score >= minScore) selectedAspectIds.add(aspect.id);
 		if (selectedAspectIds.size >= ENTITY_CONTEXT_MAX_ASPECTS_PER_ENTITY) break;
 	}

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -29,11 +29,11 @@ import {
 	shouldCheckpoint,
 } from "./continuity-state";
 import { listAgentPresence } from "./cross-agent";
-import { getDbAccessor, hasDbAccessor } from "./db-accessor";
+import { type ReadDb, getDbAccessor, hasDbAccessor } from "./db-accessor";
 import { fetchEmbedding } from "./embedding-fetch";
 import { propagateMemoryStatus } from "./knowledge-graph";
 import { logger } from "./logger";
-import { DEFAULT_PROMPT_SUBMIT_EMBEDDING_TIMEOUT_MS, loadMemoryConfig } from "./memory-config";
+import { loadMemoryConfig } from "./memory-config";
 import { writeMemoryHead } from "./memory-head";
 import {
 	NOISE_PURGE_REASON,
@@ -598,34 +598,6 @@ export function appendSynthesisIndexBlock(content: string, indexBlock: string): 
 	return appendRenderedIndexBlock(content, indexBlock);
 }
 
-function buildTemporalFallbackResponse(
-	metadataHeader: string,
-	harness: string,
-	queryTerms: string,
-	charBudget: number,
-	hits: ReadonlyArray<{
-		readonly id: string;
-		readonly latestAt: string;
-		readonly threadLabel: string;
-		readonly excerpt: string;
-	}>,
-	warnings?: string[],
-	pluginContext = "",
-): UserPromptSubmitResponse {
-	const rows = hits.map((hit) => ({
-		content: `- [thread ${hit.id}] ${hit.excerpt} (${formatMemoryDate(hit.latestAt)}, ${hit.threadLabel})`,
-	}));
-	const lines = selectWithBudget(rows, charBudget).map((row) => row.content);
-	const inject = buildPromptRecallInject(metadataHeader, lines, harness, pluginContext);
-	return {
-		inject,
-		memoryCount: lines.length,
-		queryTerms,
-		engine: "temporal-fallback",
-		warnings,
-	};
-}
-
 /** Truncate rows to fit a character budget, preserving the input type */
 export function selectWithBudget<T extends { content: string }>(rows: ReadonlyArray<T>, charBudget: number): T[] {
 	const selected: T[] = [];
@@ -705,129 +677,351 @@ function buildPluginPromptContributionSection(target: PluginPromptTargetV1, log:
 	}
 }
 
-function buildPromptRecallGuidance(harness: string): string {
-	if (harness === "codex") {
-		return "Use the Signet context below as starting context before acting. Codex native memory is already available separately, so run 1-3 targeted Signet recalls with signet_recall only when the task needs cross-harness history, source-backed artifacts, sessions, ontology, or accepted decisions. Ask natural questions with entity + event + timeframe when possible. Avoid bag-of-keywords recall queries. Treat graph expansion as supporting context, not proof.";
-	}
-	if (isPiHarness(harness)) {
-		return "Use the memories below as starting context before acting. If the task depends on prior context and anything is missing, run 1-3 targeted recalls with signet_recall. Ask natural questions with entity + event + timeframe when possible. Avoid bag-of-keywords recall queries. Treat graph expansion as supporting context, not proof.";
-	}
-	return "Use the memories below as starting context before acting. If the task depends on prior context and anything is missing, run 1-3 targeted recalls with /recall or memory_search. Ask natural questions with entity + event + timeframe when possible. Avoid bag-of-keywords recall queries. Expand with lcm_expand or knowledge_expand only when you need deeper lineage or graph context. Treat graph expansion as supporting context, not proof.";
+type PromptEntityMatch = {
+	readonly entityId: string;
+	readonly entityName: string;
+	readonly entityType: string;
+	readonly description: string | null;
+	readonly matchedText: string;
+	readonly matchSource: "name" | "alias";
+	readonly mentions: number;
+};
+
+type PromptEntityContextLine = {
+	readonly entityName: string;
+	readonly aspectName: string;
+	readonly groupKey: string | null;
+	readonly claimKey: string | null;
+	readonly kind: "attribute" | "constraint";
+	readonly content: string;
+	readonly confidence: number;
+	readonly importance: number;
+	readonly sourceKind: string | null;
+	readonly sourceId: string | null;
+	readonly sourcePath: string | null;
+	readonly memoryId: string | null;
+	readonly version: number;
+};
+
+type PromptEntityContextResult = {
+	readonly lines: readonly string[];
+	readonly memoryCount: number;
+	readonly engine: "entity-context" | "low-signal" | "no-entity" | "ambiguous-entity" | "no-aspect-hit";
+};
+
+const LOW_SIGNAL_PROMPTS = new Set([
+	"cool",
+	"got it",
+	"go ahead",
+	"great",
+	"k",
+	"kk",
+	"nice",
+	"ok",
+	"okay",
+	"okay cool",
+	"sounds good",
+	"sure",
+	"thanks",
+	"thank you",
+	"yes",
+	"yes please",
+	"yep",
+]);
+
+const ENTITY_CONTEXT_MAX_ENTITIES = 2;
+const ENTITY_CONTEXT_MAX_ASPECTS_PER_ENTITY = 3;
+const ENTITY_CONTEXT_MAX_LINES = 8;
+
+function normalizePromptEntityText(value: string): string {
+	return value
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
 }
 
-function buildNoStrongMemoryMatchGuidance(harness: string): string {
-	if (harness === "codex") {
-		return "No strong automatic Signet context was injected for this turn. Codex native memory may already cover ordinary memory needs; if this request depends on cross-harness history, source-backed docs, sessions, ontology, or accepted decisions, run 1-3 targeted Signet recalls with signet_recall before executing commands, editing files, or making decisions.";
+function phraseAppearsInPrompt(prompt: string, phrase: string): boolean {
+	const normalizedPrompt = ` ${normalizePromptEntityText(prompt)} `;
+	const normalizedPhrase = normalizePromptEntityText(phrase);
+	return normalizedPhrase.length > 0 && normalizedPrompt.includes(` ${normalizedPhrase} `);
+}
+
+function isLowSignalPrompt(userMessage: string): boolean {
+	const normalized = normalizePromptEntityText(stripUntrustedMetadata(userMessage));
+	if (normalized.length === 0) return true;
+	if (LOW_SIGNAL_PROMPTS.has(normalized)) return true;
+	const terms = extractSubstantiveWords(normalized);
+	return terms.length === 0;
+}
+
+function entityContextTablesAvailable(db: ReadDb): boolean {
+	const rows = db
+		.prepare(
+			`SELECT name FROM sqlite_master
+			 WHERE type = 'table'
+			   AND name IN ('entities', 'entity_aspects', 'entity_attributes', 'entity_aliases')`,
+		)
+		.all() as Array<{ name: string }>;
+	const names = new Set(rows.map((row) => row.name));
+	return (
+		names.has("entities") &&
+		names.has("entity_aspects") &&
+		names.has("entity_attributes") &&
+		names.has("entity_aliases")
+	);
+}
+
+function resolvePromptEntityMatches(
+	db: ReadDb,
+	agentId: string,
+	userMessage: string,
+): PromptEntityMatch[] | "ambiguous" {
+	if (!entityContextTablesAvailable(db)) return [];
+	const rows = db
+		.prepare(
+			`SELECT
+			   e.id AS entity_id,
+			   e.name AS entity_name,
+			   COALESCE(e.entity_type, 'unknown') AS entity_type,
+			   e.description AS description,
+			   COALESCE(e.canonical_name, LOWER(e.name)) AS matched_text,
+			   'name' AS match_source,
+			   COALESCE(e.mentions, 0) AS mentions
+			 FROM entities e
+			 WHERE e.agent_id = ?
+			   AND COALESCE(e.status, 'active') = 'active'
+			 UNION ALL
+			 SELECT
+			   e.id AS entity_id,
+			   e.name AS entity_name,
+			   COALESCE(e.entity_type, 'unknown') AS entity_type,
+			   e.description AS description,
+			   a.alias AS matched_text,
+			   'alias' AS match_source,
+			   COALESCE(e.mentions, 0) AS mentions
+			 FROM entity_aliases a
+			 JOIN entities e ON e.id = a.entity_id AND e.agent_id = a.agent_id
+			 WHERE a.agent_id = ?
+			   AND a.status = 'active'
+			   AND COALESCE(e.status, 'active') = 'active'`,
+		)
+		.all(agentId, agentId) as Array<{
+		entity_id: string;
+		entity_name: string;
+		entity_type: string;
+		description: string | null;
+		matched_text: string;
+		match_source: "name" | "alias";
+		mentions: number;
+	}>;
+
+	const matched = rows
+		.filter((row) => phraseAppearsInPrompt(userMessage, row.matched_text))
+		.sort((a, b) => {
+			const lengthDelta =
+				normalizePromptEntityText(b.matched_text).length - normalizePromptEntityText(a.matched_text).length;
+			if (lengthDelta !== 0) return lengthDelta;
+			return b.mentions - a.mentions;
+		});
+	const entityIdsByPhrase = new Map<string, Set<string>>();
+	for (const row of matched) {
+		const phrase = normalizePromptEntityText(row.matched_text);
+		if (!entityIdsByPhrase.has(phrase)) entityIdsByPhrase.set(phrase, new Set());
+		entityIdsByPhrase.get(phrase)?.add(row.entity_id);
 	}
-	if (isPiHarness(harness)) {
-		return "No strong automatic memory match was injected for this turn. If the request depends on prior context, preferences, project history, or unresolved work, run 1-3 targeted Signet recalls with signet_recall before executing commands, editing files, or making decisions. Ask natural questions with entity + event + timeframe when possible. Avoid bag-of-keywords recall queries. Treat graph expansion as supporting context, not proof.";
+	if ([...entityIdsByPhrase.values()].some((ids) => ids.size > 1)) return "ambiguous";
+
+	const seen = new Set<string>();
+	const result: PromptEntityMatch[] = [];
+	for (const row of matched) {
+		if (seen.has(row.entity_id)) continue;
+		seen.add(row.entity_id);
+		result.push({
+			entityId: row.entity_id,
+			entityName: row.entity_name,
+			entityType: row.entity_type,
+			description: row.description,
+			matchedText: row.matched_text,
+			matchSource: row.match_source,
+			mentions: row.mentions,
+		});
+		if (result.length >= ENTITY_CONTEXT_MAX_ENTITIES) break;
 	}
-	return "No strong automatic memory match was injected for this turn. If the request depends on prior context, preferences, project history, or unresolved work, run 1-3 targeted Signet recalls before executing commands, editing files, or making decisions. Ask natural questions with entity + event + timeframe when possible. Avoid bag-of-keywords recall queries. Treat graph expansion as supporting context, not proof.";
+	return result;
 }
 
-function buildDurableSaveGuidance(harness: string): string {
-	if (harness === "codex")
-		return "If you learn something explicitly durable for Codex memory, save it with signet_save_note.";
-	if (isPiHarness(harness)) return "If you learn something durable, save it with /remember or signet_remember.";
-	return "If you learn something durable, save it with /remember or memory_store.";
+function scoreAspectForPrompt(
+	aspect: { readonly name: string; readonly canonical_name: string; readonly weight: number },
+	rows: ReadonlyArray<{
+		readonly content: string;
+		readonly group_key: string | null;
+		readonly claim_key: string | null;
+	}>,
+	promptTerms: ReadonlyArray<string>,
+	allowWeightFallback: boolean,
+): number {
+	const aspectTerms = extractSubstantiveWords(`${aspect.name} ${aspect.canonical_name}`);
+	const aspectOverlap = aspectTerms.some((term) => promptTerms.includes(term));
+	if (aspectOverlap) return 1;
+	const attrText = rows.map((row) => `${row.group_key ?? ""} ${row.claim_key ?? ""} ${row.content}`).join(" ");
+	const overlap = countPromptTermOverlap(attrText, promptTerms);
+	if (overlap > 0) return Math.min(1, 0.75 + Math.min(aspect.weight, 1) * 0.25);
+	return allowWeightFallback ? Math.min(Math.max(aspect.weight, 0), 1) : 0;
 }
 
-function codexNativeMemoriesEnabled(): boolean {
-	const override = process.env.SIGNET_CODEX_NATIVE_MEMORY?.trim();
-	if (override === "1" || override === "true") return true;
-	if (override === "0" || override === "false") return false;
-	const home = process.env.CODEX_HOME?.trim() || join(homedir(), ".codex");
-	if (!existsSync(join(home, "memories"))) return false;
-	const configPath = join(home, "config.toml");
-	if (!existsSync(configPath)) return true;
-	try {
-		const config = readFileSync(configPath, "utf-8");
-		return !codexConfigDisablesNativeMemories(config);
-	} catch {
-		return true;
+function loadEntityContextLines(
+	db: ReadDb,
+	entity: PromptEntityMatch,
+	agentId: string,
+	userMessage: string,
+	minScore: number,
+): PromptEntityContextLine[] {
+	const entityTerms = new Set(extractSubstantiveWords(`${entity.entityName} ${entity.matchedText}`));
+	const promptTerms = extractSubstantiveWords(userMessage).filter((term) => !entityTerms.has(term));
+	const allowWeightFallback = promptTerms.length === 0;
+	const aspects = db
+		.prepare(
+			`SELECT id, name, canonical_name, weight
+			 FROM entity_aspects
+			 WHERE entity_id = ?
+			   AND agent_id = ?
+			   AND COALESCE(status, 'active') = 'active'
+			 ORDER BY weight DESC, name ASC
+			 LIMIT 12`,
+		)
+		.all(entity.entityId, agentId) as Array<{
+		id: string;
+		name: string;
+		canonical_name: string;
+		weight: number;
+	}>;
+	const selectedAspectIds = new Set<string>();
+	for (const aspect of aspects) {
+		const rows = db
+			.prepare(
+				`SELECT content, group_key, claim_key
+				 FROM entity_attributes
+				 WHERE aspect_id = ?
+				   AND agent_id = ?
+				   AND status = 'active'
+				 ORDER BY importance DESC, updated_at DESC
+				 LIMIT 12`,
+			)
+			.all(aspect.id, agentId) as Array<{ content: string; group_key: string | null; claim_key: string | null }>;
+		if (rows.length === 0) continue;
+		const score = scoreAspectForPrompt(aspect, rows, promptTerms, allowWeightFallback);
+		if (score >= minScore) selectedAspectIds.add(aspect.id);
+		if (selectedAspectIds.size >= ENTITY_CONTEXT_MAX_ASPECTS_PER_ENTITY) break;
 	}
+	if (selectedAspectIds.size === 0) return [];
+	const placeholders = [...selectedAspectIds].map(() => "?").join(", ");
+	const rows = db
+		.prepare(
+			`SELECT
+			   asp.name AS aspect_name,
+			   ea.kind,
+			   ea.content,
+			   ea.group_key,
+			   ea.claim_key,
+			   ea.confidence,
+			   ea.importance,
+			   ea.source_kind,
+			   ea.source_id,
+			   ea.source_path,
+			   ea.memory_id,
+			   COALESCE(ea.version, 1) AS version
+			 FROM entity_attributes ea
+			 JOIN entity_aspects asp ON asp.id = ea.aspect_id
+			 WHERE ea.aspect_id IN (${placeholders})
+			   AND ea.agent_id = ?
+			   AND ea.status = 'active'
+			 ORDER BY
+			   CASE ea.kind WHEN 'constraint' THEN 0 ELSE 1 END,
+			   ea.importance DESC,
+			   ea.updated_at DESC
+			 LIMIT ?`,
+		)
+		.all(...selectedAspectIds, agentId, ENTITY_CONTEXT_MAX_LINES) as Array<{
+		aspect_name: string;
+		kind: "attribute" | "constraint";
+		content: string;
+		group_key: string | null;
+		claim_key: string | null;
+		confidence: number;
+		importance: number;
+		source_kind: string | null;
+		source_id: string | null;
+		source_path: string | null;
+		memory_id: string | null;
+		version: number;
+	}>;
+	return rows.map((row) => ({
+		entityName: entity.entityName,
+		aspectName: row.aspect_name,
+		groupKey: row.group_key,
+		claimKey: row.claim_key,
+		kind: row.kind,
+		content: row.content,
+		confidence: row.confidence,
+		importance: row.importance,
+		sourceKind: row.source_kind,
+		sourceId: row.source_id,
+		sourcePath: row.source_path,
+		memoryId: row.memory_id,
+		version: row.version,
+	}));
 }
 
-function codexConfigDisablesNativeMemories(config: string): boolean {
-	const lines = config.split(/\r?\n/);
-	let section = "";
-	for (const line of lines) {
-		const trimmed = line.trim();
-		if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
-			section = trimmed;
-			continue;
-		}
-		if (section === "" && /^features\.memories\s*=\s*false\s*(?:#.*)?$/.test(trimmed)) return true;
-		if ((section === "" || section === "[features]") && /^memories\s*=\s*false\s*(?:#.*)?$/.test(trimmed)) {
-			return true;
-		}
-	}
-	return false;
+function formatEntityContextLine(line: PromptEntityContextLine): string {
+	const path = [line.entityName, line.aspectName, line.groupKey ?? "general", line.claimKey ?? "uncategorized"].join(
+		" / ",
+	);
+	const source =
+		line.sourceKind && line.sourceId
+			? `${line.sourceKind}:${line.sourceId}`
+			: line.memoryId
+				? `memory:${line.memoryId}`
+				: line.sourcePath
+					? line.sourcePath
+					: `v${line.version}`;
+	return `- [${line.kind}] ${path}: ${line.content} (${source})`;
 }
 
-function isCodexNativeMemoryRow(row: {
-	readonly source?: string;
-	readonly type?: string;
-	readonly source_id?: string;
-	readonly source_path?: string;
-	readonly tags?: string | null;
-	readonly who?: string;
-}): boolean {
-	const sourceId = row.source_id?.trim().toLowerCase() ?? "";
-	if (sourceId.startsWith("native:codex:") || sourceId.startsWith("codex_native_memory:")) return true;
-	const who = row.who?.trim().toLowerCase();
-	if (who === "codex") return true;
-	const path = row.source_path?.replace(/\\/g, "/");
-	if (!path) return false;
-	const home = (process.env.CODEX_HOME?.trim() || join(homedir(), ".codex")).replace(/\\/g, "/").replace(/\/$/, "");
-	return path === home || path.startsWith(`${home}/`);
-}
-
-function filterCodexNativeMemoryRows<
-	T extends {
-		readonly source?: string;
-		readonly type?: string;
-		readonly source_id?: string;
-		readonly source_path?: string;
-		readonly tags?: string | null;
-		readonly who?: string;
-	},
->(rows: readonly T[]): T[] {
-	if (!codexNativeMemoriesEnabled()) return [...rows];
-	return rows.filter((row) => {
-		const native = row.source === "native_memory" || row.type?.startsWith("native_");
-		return !native || !isCodexNativeMemoryRow(row);
+function buildEntityPromptContext(
+	userMessage: string,
+	agentId: string,
+	minScore: number,
+	injectBudget: number,
+): PromptEntityContextResult {
+	if (isLowSignalPrompt(userMessage)) return { lines: [], memoryCount: 0, engine: "low-signal" };
+	if (!existsSync(getMemoryDbPath())) return { lines: [], memoryCount: 0, engine: "no-entity" };
+	if (!hasDbAccessor()) return { lines: [], memoryCount: 0, engine: "no-entity" };
+	return getDbAccessor().withReadDb((db) => {
+		const matches = resolvePromptEntityMatches(db, agentId, userMessage);
+		if (matches === "ambiguous") return { lines: [], memoryCount: 0, engine: "ambiguous-entity" };
+		if (matches.length === 0) return { lines: [], memoryCount: 0, engine: "no-entity" };
+		const lines = matches.flatMap((entity) => loadEntityContextLines(db, entity, agentId, userMessage, minScore));
+		if (lines.length === 0) return { lines: [], memoryCount: 0, engine: "no-aspect-hit" };
+		const selected = selectWithBudgetSkippingOversized(
+			lines.map((line) => ({ content: formatEntityContextLine(line) })),
+			injectBudget,
+		).slice(0, ENTITY_CONTEXT_MAX_LINES);
+		return {
+			lines: selected.map((line) => line.content),
+			memoryCount: selected.length,
+			engine: selected.length > 0 ? "entity-context" : "no-aspect-hit",
+		};
 	});
 }
 
-function buildPromptRecallInject(
-	metadataHeader: string,
-	lines: ReadonlyArray<string>,
-	harness: string,
-	pluginContext = "",
-): string {
-	// Keep formatting behavior aligned with daemon-rs
-	// `build_prompt_recall_inject()` in `platform/daemon-rs/.../routes/hooks.rs`.
-	const parts = [metadataHeader.trimEnd(), "", "## Memory Check", "", buildPromptRecallGuidance(harness), ""];
+function buildEntityContextInject(metadataHeader: string, lines: ReadonlyArray<string>, pluginContext = ""): string {
+	const parts = [metadataHeader.trimEnd(), "", "## Relevant Entity Context", ""];
 	if (pluginContext.trim().length > 0) {
 		parts.push(pluginContext.trimEnd());
 		parts.push("");
 	}
-	parts.push("## Relevant Memory");
-	parts.push("");
 	parts.push(...lines);
-	parts.push("");
-	parts.push(buildDurableSaveGuidance(harness));
-	return `${parts.join("\n").trimEnd()}\n`;
-}
-
-function buildNoStrongMemoryMatchInject(metadataHeader: string, harness: string, pluginContext = ""): string {
-	const parts = [metadataHeader.trimEnd(), "", "## Memory Check", "", buildNoStrongMemoryMatchGuidance(harness), ""];
-	if (pluginContext.trim().length > 0) {
-		parts.push(pluginContext.trimEnd());
-		parts.push("");
-	}
-	parts.push(buildDurableSaveGuidance(harness));
 	return `${parts.join("\n").trimEnd()}\n`;
 }
 
@@ -2361,86 +2555,6 @@ function countPromptTermOverlap(text: string, promptTerms: ReadonlyArray<string>
 	return overlap;
 }
 
-function chooseCompactPromptSentence(content: string, promptTerms: ReadonlyArray<string>): string {
-	const normalized = content
-		.replace(/\s+/g, " ")
-		.replace(/\s*\[truncated\]\s*$/i, "")
-		.trim();
-	if (!normalized) return "";
-	const sentences = normalized
-		.split(/(?<=[.!?])\s+/)
-		.map((part) => part.trim())
-		.filter(Boolean) || [normalized];
-	const ranked = [...sentences].sort((a, b) => {
-		const overlapDelta = countPromptTermOverlap(b, promptTerms) - countPromptTermOverlap(a, promptTerms);
-		if (overlapDelta !== 0) return overlapDelta;
-		return a.length - b.length;
-	});
-	return ranked[0] ?? normalized;
-}
-
-function compactPromptMemoryLine(
-	content: string,
-	createdAt: string,
-	promptTerms: ReadonlyArray<string>,
-	maxChars = 160,
-): string {
-	const sentence = chooseCompactPromptSentence(content, promptTerms);
-	const compact = sentence.length > maxChars ? `${sentence.slice(0, maxChars - 1).trimEnd()}…` : sentence;
-	return `- [memory] ${compact} (${formatMemoryDate(createdAt)})`;
-}
-
-type PromptInjectCandidate = {
-	readonly id: string;
-	readonly content: string;
-	readonly score?: number;
-	readonly overlap: number;
-	readonly index: number;
-};
-
-function buildPromptInjectCandidates(
-	rows: ReadonlyArray<{
-		readonly id: string;
-		readonly content: string;
-		readonly created_at: string;
-		readonly score?: number;
-	}>,
-	promptTerms: ReadonlyArray<string>,
-): PromptInjectCandidate[] {
-	return rows.map((row, index) => {
-		const content = compactPromptMemoryLine(row.content, row.created_at, promptTerms);
-		return {
-			id: row.id,
-			content,
-			score: row.score,
-			overlap: countPromptTermOverlap(row.content, promptTerms),
-			index,
-		};
-	});
-}
-
-function shouldRescuePromptInjectSelection(
-	selected: ReadonlyArray<PromptInjectCandidate>,
-	all: ReadonlyArray<PromptInjectCandidate>,
-): boolean {
-	if (selected.length === 0) return true;
-	const selectedBest = Math.max(...selected.map((row) => row.overlap), 0);
-	if (selectedBest > 0) return false;
-	return all.some((row) => row.overlap > selectedBest);
-}
-
-function rerankPromptInjectCandidates(rows: ReadonlyArray<PromptInjectCandidate>): PromptInjectCandidate[] {
-	return [...rows].sort((a, b) => {
-		const overlapDelta = b.overlap - a.overlap;
-		if (overlapDelta !== 0) return overlapDelta;
-		const aScore = typeof a.score === "number" ? a.score : Number.NEGATIVE_INFINITY;
-		const bScore = typeof b.score === "number" ? b.score : Number.NEGATIVE_INFINITY;
-		if (aScore !== bScore) return bScore - aScore;
-		if (a.content.length !== b.content.length) return a.content.length - b.content.length;
-		return a.index - b.index;
-	});
-}
-
 export function queryAnchorsMissingFromRecall(query: string, results: ReadonlyArray<{ content: string }>): boolean {
 	const anchors = extractAnchorTerms(stripUntrustedMetadata(query));
 	if (anchors.length === 0) return false;
@@ -2536,30 +2650,6 @@ type UserPromptSubmitDeps = {
 	readonly trackFtsHits: typeof trackFtsHits;
 };
 
-async function fetchPromptSubmitEmbedding(
-	deps: Pick<UserPromptSubmitDeps, "fetchEmbedding" | "logger">,
-	text: string,
-	cfg: Parameters<typeof fetchEmbedding>[1],
-	timeoutMs: number,
-): Promise<number[] | null> {
-	const controller = new AbortController();
-	let timer: ReturnType<typeof setTimeout> | null = null;
-	const request = deps.fetchEmbedding(text, cfg, { signal: controller.signal, timeoutMs });
-	try {
-		return await Promise.race([
-			request,
-			new Promise<null>((resolve) => {
-				timer = setTimeout(() => {
-					controller.abort();
-					resolve(null);
-				}, timeoutMs);
-			}),
-		]);
-	} finally {
-		if (timer) clearTimeout(timer);
-	}
-}
-
 const DEFAULT_USER_PROMPT_SUBMIT_DEPS: UserPromptSubmitDeps = {
 	logger,
 	loadMemoryConfig,
@@ -2589,8 +2679,7 @@ export async function handleUserPromptSubmit(
 	const submitCfg = loadHooksConfig().userPromptSubmit ?? {};
 	const userMessage = resolveRecallUserMessage(req);
 	const agentId = deps.resolveAgentId(req);
-	const agentScope = deps.getAgentScope(agentId);
-	const { keywordTerms, vectorQuery } = buildRecallQueryShape(userMessage);
+	const { keywordTerms } = buildRecallQueryShape(userMessage);
 
 	// -- Parse and accumulate incoming agent feedback (from previous prompt) --
 	const memoryCfg = deps.loadMemoryConfig(getAgentsDir());
@@ -2731,7 +2820,6 @@ export async function handleUserPromptSubmit(
 	const metadataHeader = `# Current Date & Time\n${now} (${tz})\n`;
 	const expiryWarning = req.sessionKey ? deps.getExpiryWarning(req.sessionKey) : null;
 	const warnings = expiryWarning ? [expiryWarning] : undefined;
-	const pluginContext = buildPluginPromptContributionSection("user-prompt-submit", deps.logger);
 
 	if (submitCfg.enabled === false) {
 		return finalizeUserPromptSubmitSuccess(
@@ -2739,7 +2827,7 @@ export async function handleUserPromptSubmit(
 			userMessage,
 			start,
 			{
-				inject: buildNoStrongMemoryMatchInject(metadataHeader, req.harness, pluginContext),
+				inject: "",
 				memoryCount: 0,
 				warnings,
 			},
@@ -2748,220 +2836,40 @@ export async function handleUserPromptSubmit(
 		);
 	}
 
-	if (keywordTerms.length < 1 || vectorQuery.length === 0 || !existsSync(getMemoryDbPath())) {
-		return finalizeUserPromptSubmitSuccess(
-			req,
-			userMessage,
-			start,
-			{
-				inject: buildNoStrongMemoryMatchInject(metadataHeader, req.harness, pluginContext),
-				memoryCount: 0,
-				warnings,
-			},
-			deps.logger,
-			"no-query",
-		);
-	}
-
-	// `metadataHeader` is deliberately built before this try/catch so even
-	// recall failures can return the per-turn Memory Check guidance.
 	try {
 		const cfg = deps.loadMemoryConfig(getAgentsDir());
-		const recallLimit = submitCfg.recallLimit ?? 10;
-		// userPromptSubmit.maxInjectChars already reads from config — no hardcoded fallback here.
-		// Falls back to pipelineV2.guardrails.contextBudgetChars when not set in agent.yaml.
 		const injectBudget = submitCfg.maxInjectChars ?? cfg.pipelineV2.guardrails.contextBudgetChars;
-		const minScore = resolveUserPromptMinScore(submitCfg.minScore);
-		const embeddingTimeoutMs = cfg.embedding.promptSubmitTimeoutMs ?? DEFAULT_PROMPT_SUBMIT_EMBEDDING_TIMEOUT_MS;
-		const queryTerms = vectorQuery.slice(0, 80);
-		const recallStart = Date.now();
-		let embeddingTimedOut = false;
-		const recall = await deps.hybridRecall(
-			{
-				query: vectorQuery,
-				keywordQuery: vectorQuery,
-				limit: recallLimit,
-				importance_min: 0.3,
-				agentId,
-				readPolicy: agentScope.readPolicy,
-				policyGroup: agentScope.policyGroup,
-				project: req.project,
-				sessionKey: req.sessionKey,
-				recallSurface: "api.hooks.user-prompt-submit",
-				recallMode: "automatic",
-				claimRecallResults: false,
-				trackRecallAccess: false,
-			},
-			cfg,
-			async (text, embeddingCfg) => {
-				const startEmbedding = Date.now();
-				const embedding = await fetchPromptSubmitEmbedding(deps, text, embeddingCfg, embeddingTimeoutMs);
-				const embeddingDuration = Date.now() - startEmbedding;
-				if (!embedding && embeddingDuration >= embeddingTimeoutMs - 5) {
-					embeddingTimedOut = true;
-					deps.logger.warn("hooks", "User prompt submit embedding timed out", {
-						harness: req.harness,
-						project: req.project,
-						sessionKey: req.sessionKey,
-						durationMs: embeddingDuration,
-						timeoutMs: embeddingTimeoutMs,
-					});
-				}
-				return embedding;
-			},
+		const entityContext = buildEntityPromptContext(
+			userMessage,
+			agentId,
+			resolveUserPromptMinScore(submitCfg.minScore),
+			injectBudget,
 		);
-		const recallDuration = Date.now() - recallStart;
-		if (recallDuration > 1000) {
-			deps.logger.warn("hooks", "User prompt submit recall was slow", {
-				harness: req.harness,
-				project: req.project,
-				sessionKey: req.sessionKey,
-				durationMs: recallDuration,
-				resultCount: recall.results.length,
-				embeddingTimedOut,
-			});
-		}
-
-		const recallResults = req.harness === "codex" ? filterCodexNativeMemoryRows(recall.results) : recall.results;
-		const topRaw = recallResults[0]?.score;
-		const topScore = typeof topRaw === "number" ? clampScore01(topRaw) : undefined;
-		const noStructured = recallResults.length === 0 || typeof topScore !== "number" || topScore < 0.4;
-		// Anchor checks must be driven by the current user turn text, not any
-		// expanded/derived recall query shape.
-		const anchorsMissed = queryAnchorsMissingFromRecall(userMessage, recallResults);
-		if (noStructured || anchorsMissed) {
-			const temporalHits = deps.searchTemporalFallback({
-				query: vectorQuery,
-				agentId,
-				sessionKey: req.sessionKey,
-				project: req.project,
-				limit: 4,
-			});
-			if (temporalHits.length > 0) {
-				return finalizeUserPromptSubmitSuccess(
-					req,
-					userMessage,
-					start,
-					buildTemporalFallbackResponse(
-						metadataHeader,
-						req.harness,
-						queryTerms,
-						injectBudget,
-						temporalHits,
-						warnings,
-						pluginContext,
-					),
-					deps.logger,
-				);
-			}
-			if (noStructured) {
-				return finalizeUserPromptSubmitSuccess(
-					req,
-					userMessage,
-					start,
-					{
-						inject: buildNoStrongMemoryMatchInject(metadataHeader, req.harness, pluginContext),
-						memoryCount: 0,
-						warnings,
-					},
-					deps.logger,
-					"no-structured",
-				);
-			}
-		}
-		if (typeof topScore !== "number" || topScore < minScore) {
+		if (entityContext.lines.length === 0) {
 			return finalizeUserPromptSubmitSuccess(
 				req,
 				userMessage,
 				start,
 				{
-					inject: buildNoStrongMemoryMatchInject(metadataHeader, req.harness, pluginContext),
+					inject: "",
 					memoryCount: 0,
+					queryTerms: keywordTerms.join(" ") || undefined,
+					engine: entityContext.engine,
 					warnings,
 				},
 				deps.logger,
-				"low-confidence",
 			);
 		}
-
-		const mapped = recallResults.map((result) => ({
-			...result,
-			pinned: result.pinned ? 1 : 0,
-		}));
-		const promptTerms = extractSubstantiveWords(userMessage);
-		const candidates = buildPromptInjectCandidates(mapped, promptTerms);
-		let budgetFiltered = selectWithBudgetSkippingOversized(candidates, injectBudget);
-		if (shouldRescuePromptInjectSelection(budgetFiltered, candidates)) {
-			const reranked = rerankPromptInjectCandidates(candidates);
-			const overlapFirst = reranked.filter((row) => row.overlap > 0);
-			budgetFiltered = selectWithBudgetSkippingOversized(
-				overlapFirst.length > 0 ? overlapFirst : reranked,
-				injectBudget,
-			);
-		}
-		const budgetSelected = budgetFiltered.slice(0, 5);
-		// omitted reflects only budget truncation, not the 5-item display cap,
-		// so the hint correctly directs users to raise contextBudgetChars.
-		const omitted = Math.max(0, recallResults.length - budgetFiltered.length);
-
-		// Track FTS hits for predictive scorer data collection (full results, pre-dedup)
-		const allMatchedIds = recall.results.map((result) => result.id);
-		deps.trackFtsHits(req.sessionKey, allMatchedIds, deps.resolveAgentId(req));
-
-		const selected = req.sessionKey
-			? claimRecallItems({
-					sessionKey: req.sessionKey,
-					agentId,
-					surface: "api.hooks.user-prompt-submit",
-					mode: "automatic",
-					items: budgetSelected,
-				}).items
-			: budgetSelected;
-
-		if (selected.length === 0) {
-			return finalizeUserPromptSubmitSuccess(
-				req,
-				userMessage,
-				start,
-				{
-					inject: buildNoStrongMemoryMatchInject(metadataHeader, req.harness, pluginContext),
-					memoryCount: 0,
-					warnings,
-				},
-				deps.logger,
-				"dedup-empty",
-			);
-		}
-
-		const lines = selected.map((s) => s.content);
-		if (omitted > 0) {
-			lines.push(
-				`[signet:note] ${omitted} additional ${omitted === 1 ? "match was" : "matches were"} omitted to keep this lightweight (raise memory.guardrails.contextBudgetChars to include more).`,
-			);
-		}
-		let inject = buildPromptRecallInject(metadataHeader, lines, req.harness, pluginContext);
-
-		// Append agent feedback request if enabled and there are injected memories
-		const selectedIds = selected.map((s) => s.id);
-		updateAccessTracking(selectedIds);
-		if (feedbackEnabled && selectedIds.length > 0) {
-			const pi = isPiHarness(req.harness);
-			const toolName = pi ? "signet_memory_feedback" : "mcp__signet__memory_feedback";
-			const instruction = pi
-				? `Rate injected memories using the ${toolName} tool. Pass a ratings map of memory ID to score (-1 to 1). 0=unused, 1=directly helpful, -1=harmful.`
-				: `Rate injected memories using the ${toolName} tool. Pass session_key "${req.sessionKey}" and a ratings map of memory ID to score (-1 to 1). 0=unused, 1=directly helpful, -1=harmful.`;
-			inject += `\n<memory-feedback>\n${instruction}\nIDs: ${selectedIds.join(", ")}\n</memory-feedback>`;
-		}
-
+		const pluginContext = buildPluginPromptContributionSection("user-prompt-submit", deps.logger);
 		return finalizeUserPromptSubmitSuccess(
 			req,
 			userMessage,
 			start,
 			{
-				inject,
-				memoryCount: selected.length,
-				queryTerms,
-				engine: "hybrid",
+				inject: buildEntityContextInject(metadataHeader, entityContext.lines, pluginContext),
+				memoryCount: entityContext.memoryCount,
+				queryTerms: keywordTerms.join(" ") || undefined,
+				engine: "entity-context",
 				warnings,
 			},
 			deps.logger,
@@ -2969,7 +2877,7 @@ export async function handleUserPromptSubmit(
 	} catch (e) {
 		deps.logger.error("hooks", "User prompt submit failed", e as Error);
 		return {
-			inject: buildNoStrongMemoryMatchInject(metadataHeader, req.harness, pluginContext),
+			inject: "",
 			memoryCount: 0,
 			warnings,
 		};

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -732,6 +732,7 @@ const LOW_SIGNAL_PROMPTS = new Set([
 const ENTITY_CONTEXT_MAX_ENTITIES = 2;
 const ENTITY_CONTEXT_MAX_ASPECTS_PER_ENTITY = 3;
 const ENTITY_CONTEXT_MAX_LINES = 8;
+const MIN_PROMPT_ENTITY_MATCH_CHARS = 3;
 
 function normalizePromptEntityText(value: string): string {
 	return value
@@ -744,7 +745,7 @@ function normalizePromptEntityText(value: string): string {
 function phraseAppearsInPrompt(prompt: string, phrase: string): boolean {
 	const normalizedPrompt = ` ${normalizePromptEntityText(prompt)} `;
 	const normalizedPhrase = normalizePromptEntityText(phrase);
-	return normalizedPhrase.length > 0 && normalizedPrompt.includes(` ${normalizedPhrase} `);
+	return normalizedPhrase.length >= MIN_PROMPT_ENTITY_MATCH_CHARS && normalizedPrompt.includes(` ${normalizedPhrase} `);
 }
 
 function isLowSignalPrompt(userMessage: string): boolean {

--- a/platform/daemon/src/knowledge-graph-list.test.ts
+++ b/platform/daemon/src/knowledge-graph-list.test.ts
@@ -14,11 +14,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
 import {
+	archiveEntityAlias,
+	createEntityAlias,
 	getDependenciesFrom,
 	getDependenciesTo,
 	getKnowledgeEntityDetail,
 	getKnowledgeGraphForConstellation,
 	getKnowledgeStats,
+	listEntityAliases,
 	listKnowledgeEntities,
 } from "./knowledge-graph";
 
@@ -311,6 +314,36 @@ describe("listKnowledgeEntities (issue #515)", () => {
 
 		expect(mainScope.map((r) => r.entity.id)).toEqual(["e-main"]);
 		expect(defaultScope.map((r) => r.entity.id)).toEqual(["e-def"]);
+	});
+
+	test("entity alias archive is scoped to the owning entity", () => {
+		dbPath = makeDbPath();
+		initDbAccessor(dbPath);
+
+		seedEntity("e-signet", "Signet");
+		seedEntity("e-other", "Other");
+		const alias = createEntityAlias(getDbAccessor(), {
+			agentId: "default",
+			entityId: "e-signet",
+			alias: "SignetAI",
+			source: "test",
+		});
+
+		const wrongEntity = archiveEntityAlias(getDbAccessor(), {
+			agentId: "default",
+			entityId: "e-other",
+			aliasId: alias.id,
+		});
+		expect(wrongEntity).toBeNull();
+		expect(listEntityAliases(getDbAccessor(), { agentId: "default", entityId: "e-signet" })).toHaveLength(1);
+
+		const archived = archiveEntityAlias(getDbAccessor(), {
+			agentId: "default",
+			entityId: "e-signet",
+			aliasId: alias.id,
+		});
+		expect(archived?.status).toBe("archived");
+		expect(listEntityAliases(getDbAccessor(), { agentId: "default", entityId: "e-signet" })).toHaveLength(0);
 	});
 
 	test("builds a bounded constellation graph without loading every graph row", () => {

--- a/platform/daemon/src/knowledge-graph.ts
+++ b/platform/daemon/src/knowledge-graph.ts
@@ -13,6 +13,7 @@ import type {
 	AttributeStatus,
 	DependencyType,
 	Entity,
+	EntityAlias,
 	EntityAspect,
 	EntityAttribute,
 	EntityDependency,
@@ -61,6 +62,21 @@ function rowToEntity(r: Record<string, unknown>): Entity {
 		archiveReason: typeof r.archive_reason === "string" ? r.archive_reason : null,
 		proposalId: typeof r.proposal_id === "string" ? r.proposal_id : null,
 		proposalEvidence: parseJsonArray(r.proposal_evidence),
+		createdAt: r.created_at as string,
+		updatedAt: r.updated_at as string,
+	};
+}
+
+function rowToEntityAlias(r: Record<string, unknown>): EntityAlias {
+	return {
+		id: r.id as string,
+		entityId: r.entity_id as string,
+		agentId: r.agent_id as string,
+		alias: r.alias as string,
+		canonicalAlias: r.canonical_alias as string,
+		confidence: typeof r.confidence === "number" ? r.confidence : 1,
+		source: typeof r.source === "string" ? r.source : null,
+		status: r.status === "archived" ? "archived" : "active",
 		createdAt: r.created_at as string,
 		updatedAt: r.updated_at as string,
 	};
@@ -974,6 +990,96 @@ export function getKnowledgeEntityByName(
 ): KnowledgeEntityDetail | null {
 	const resolved = resolveNamedEntity(accessor, params);
 	return resolved ? getKnowledgeEntityDetail(accessor, resolved.id, params.agentId) : null;
+}
+
+export function listEntityAliases(
+	accessor: DbAccessor,
+	params: {
+		readonly agentId: string;
+		readonly entityId: string;
+		readonly status?: "active" | "archived" | "all";
+	},
+): readonly EntityAlias[] {
+	return accessor.withReadDb((db) => {
+		const conditions = ["entity_id = ?", "agent_id = ?"];
+		const args: string[] = [params.entityId, params.agentId];
+		if (params.status && params.status !== "all") {
+			conditions.push("status = ?");
+			args.push(params.status);
+		} else if (!params.status) {
+			conditions.push("status = 'active'");
+		}
+		const rows = db
+			.prepare(
+				`SELECT *
+				 FROM entity_aliases
+				 WHERE ${conditions.join(" AND ")}
+				 ORDER BY status ASC, alias ASC`,
+			)
+			.all(...args) as Array<Record<string, unknown>>;
+		return rows.map(rowToEntityAlias);
+	});
+}
+
+export function createEntityAlias(
+	accessor: DbAccessor,
+	params: {
+		readonly agentId: string;
+		readonly entityId: string;
+		readonly alias: string;
+		readonly confidence?: number;
+		readonly source?: string | null;
+	},
+): EntityAlias {
+	const alias = params.alias.trim();
+	const canonical = toCanonicalName(alias);
+	if (canonical.length === 0) {
+		throw new Error("alias is required");
+	}
+	const confidence =
+		typeof params.confidence === "number" && Number.isFinite(params.confidence)
+			? Math.min(Math.max(params.confidence, 0), 1)
+			: 1;
+	const ts = now();
+	const id = crypto.randomUUID();
+	return accessor.withWriteTx((db) => {
+		const entity = db
+			.prepare("SELECT id FROM entities WHERE id = ? AND agent_id = ? AND COALESCE(status, 'active') = 'active'")
+			.get(params.entityId, params.agentId) as { id: string } | undefined;
+		if (!entity) throw new Error("Entity not found");
+		db.prepare(
+			`INSERT INTO entity_aliases
+			 (id, entity_id, agent_id, alias, canonical_alias, confidence, source, status, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?, ?)`,
+		).run(id, params.entityId, params.agentId, alias, canonical, confidence, params.source ?? null, ts, ts);
+		const row = db.prepare("SELECT * FROM entity_aliases WHERE id = ? AND agent_id = ?").get(id, params.agentId) as
+			| Record<string, unknown>
+			| undefined;
+		if (!row) throw new Error("Alias not found after insert");
+		return rowToEntityAlias(row);
+	});
+}
+
+export function archiveEntityAlias(
+	accessor: DbAccessor,
+	params: {
+		readonly agentId: string;
+		readonly entityId: string;
+		readonly aliasId: string;
+	},
+): EntityAlias | null {
+	const ts = now();
+	return accessor.withWriteTx((db) => {
+		db.prepare(
+			`UPDATE entity_aliases
+			 SET status = 'archived', updated_at = ?
+			 WHERE id = ? AND entity_id = ? AND agent_id = ?`,
+		).run(ts, params.aliasId, params.entityId, params.agentId);
+		const row = db
+			.prepare("SELECT * FROM entity_aliases WHERE id = ? AND entity_id = ? AND agent_id = ?")
+			.get(params.aliasId, params.entityId, params.agentId) as Record<string, unknown> | undefined;
+		return row ? rowToEntityAlias(row) : null;
+	});
 }
 
 export function getEntityAspectsByName(
@@ -1998,9 +2104,9 @@ function placeholders(count: number): string {
 function getConstellationVisibleAgentIds(db: ReadDb, agentId: string): readonly string[] {
 	const ids = new Set<string>([agentId]);
 	try {
-		const rows = db
-			.prepare("SELECT id FROM agents WHERE id = ? OR read_policy = 'shared'")
-			.all(agentId) as Array<Record<string, unknown>>;
+		const rows = db.prepare("SELECT id FROM agents WHERE id = ? OR read_policy = 'shared'").all(agentId) as Array<
+			Record<string, unknown>
+		>;
 		for (const row of rows) {
 			if (typeof row.id === "string" && row.id.trim().length > 0) {
 				ids.add(row.id);

--- a/platform/daemon/src/routes/ontology-routes.ts
+++ b/platform/daemon/src/routes/ontology-routes.ts
@@ -1,6 +1,7 @@
 import type { Context, Hono } from "hono";
 import { requirePermission } from "../auth";
 import { getDbAccessor } from "../db-accessor";
+import { archiveEntityAlias, createEntityAlias, listEntityAliases } from "../knowledge-graph";
 import { getInferenceProviderOrNull } from "../llm";
 import {
 	OntologyAssertionError,
@@ -142,6 +143,14 @@ export function registerOntologyRoutes(app: Hono): void {
 		const permission = c.req.method === "GET" ? "recall" : "modify";
 		return requirePermission(permission, authConfig)(c, next);
 	});
+	app.use("/api/ontology/entities/*/aliases", async (c, next) => {
+		const permission = c.req.method === "GET" ? "recall" : "modify";
+		return requirePermission(permission, authConfig)(c, next);
+	});
+	app.use("/api/ontology/entities/*/aliases/*", async (c, next) => {
+		const permission = c.req.method === "GET" ? "recall" : "modify";
+		return requirePermission(permission, authConfig)(c, next);
+	});
 	app.use("/api/ontology/assertions", async (c, next) => {
 		const permission = c.req.method === "GET" ? "recall" : "modify";
 		return requirePermission(permission, authConfig)(c, next);
@@ -166,6 +175,56 @@ export function registerOntologyRoutes(app: Hono): void {
 				offset: parseBoundedInt(c.req.query("offset"), 0, 0, 10_000),
 			}),
 		);
+	});
+
+	app.get("/api/ontology/entities/:id/aliases", (c) => {
+		const scoped = resolveAgent(c, c.req.query("agent_id"));
+		if (scoped.response) return scoped.response;
+		const status = c.req.query("status");
+		const parsedStatus = status === "active" || status === "archived" || status === "all" ? status : undefined;
+		if (status && !parsedStatus) return c.json({ error: "status is invalid" }, 400);
+		return c.json({
+			items: listEntityAliases(getDbAccessor(), {
+				agentId: scoped.agentId,
+				entityId: c.req.param("id"),
+				status: parsedStatus,
+			}),
+		});
+	});
+
+	app.post("/api/ontology/entities/:id/aliases", async (c) => {
+		const scoped = resolveAgent(c, c.req.query("agent_id"));
+		if (scoped.response) return scoped.response;
+		const body = await readJsonRecord(c);
+		const alias = readString(body, "alias");
+		if (!alias) return c.json({ error: "alias is required" }, 400);
+		try {
+			const item = createEntityAlias(getDbAccessor(), {
+				agentId: scoped.agentId,
+				entityId: c.req.param("id"),
+				alias,
+				confidence: readNumber(body, "confidence"),
+				source: readString(body, "source") ?? null,
+			});
+			return c.json({ item }, 201);
+		} catch (err) {
+			const message = messageForError(err);
+			if (message.includes("UNIQUE")) return c.json({ error: "alias already exists" }, 409);
+			if (message === "Entity not found") return c.json({ error: message }, 404);
+			return c.json({ error: message }, 400);
+		}
+	});
+
+	app.delete("/api/ontology/entities/:id/aliases/:aliasId", (c) => {
+		const scoped = resolveAgent(c, c.req.query("agent_id"));
+		if (scoped.response) return scoped.response;
+		const item = archiveEntityAlias(getDbAccessor(), {
+			agentId: scoped.agentId,
+			entityId: c.req.param("id"),
+			aliasId: c.req.param("aliasId"),
+		});
+		if (!item) return c.json({ error: "Alias not found" }, 404);
+		return c.json({ item });
 	});
 
 	app.get("/api/ontology/proposals/conflicts", (c) => {

--- a/surfaces/cli/src/commands/ontology.test.ts
+++ b/surfaces/cli/src/commands/ontology.test.ts
@@ -31,7 +31,7 @@ describe("registerOntologyCommands", () => {
 		const names = (parent: Command, name: string): readonly string[] =>
 			parent.commands.find((cmd) => cmd.name() === name)?.commands.map((cmd) => cmd.name()) ?? [];
 		expect(names(ontology, "entity")).toEqual(
-			expect.arrayContaining(["create", "rename", "merge", "merge-plan", "archive"]),
+			expect.arrayContaining(["create", "rename", "merge", "merge-plan", "archive", "alias"]),
 		);
 		expect(names(ontology, "claim")).toEqual(expect.arrayContaining(["set", "versions", "show", "archive", "restore"]));
 		expect(names(ontology, "aspect")).toEqual(expect.arrayContaining(["create", "rename", "archive"]));
@@ -40,6 +40,91 @@ describe("registerOntologyCommands", () => {
 		expect(names(ontology, "assertion")).toEqual(
 			expect.arrayContaining(["show", "create", "link-claim", "archive", "supersede", "import"]),
 		);
+	});
+
+	test("entity alias commands call ontology alias endpoints", async () => {
+		const calls: Array<{ readonly method: string; readonly path: string; readonly body?: unknown }> = [];
+		const lines: string[] = [];
+		console.log = (line?: unknown) => {
+			lines.push(String(line ?? ""));
+		};
+
+		const program = new Command();
+		registerOntologyCommands(program, {
+			ensureDaemonForSecrets: async () => true,
+			secretApiCall: async (method, path, body) => {
+				calls.push({ method, path, body });
+				return {
+					ok: true,
+					data: {
+						item: { id: "alias-1", alias: "SignetAI", status: "active", confidence: 0.9 },
+						items: [{ id: "alias-1", alias: "SignetAI", status: "active", confidence: 0.9 }],
+					},
+				};
+			},
+		});
+
+		await program.parseAsync([
+			"node",
+			"test",
+			"ontology",
+			"entity",
+			"alias",
+			"list",
+			"entity-signet",
+			"--status",
+			"all",
+			"--agent",
+			"ant",
+		]);
+		await program.parseAsync([
+			"node",
+			"test",
+			"ontology",
+			"entity",
+			"alias",
+			"add",
+			"entity-signet",
+			"SignetAI",
+			"--confidence",
+			"0.9",
+			"--source",
+			"operator",
+			"--agent",
+			"ant",
+		]);
+		await program.parseAsync([
+			"node",
+			"test",
+			"ontology",
+			"entity",
+			"alias",
+			"archive",
+			"entity-signet",
+			"alias-1",
+			"--agent",
+			"ant",
+		]);
+
+		expect(calls).toEqual([
+			{
+				method: "GET",
+				path: "/api/ontology/entities/entity-signet/aliases?agent_id=ant&status=all",
+				body: undefined,
+			},
+			{
+				method: "POST",
+				path: "/api/ontology/entities/entity-signet/aliases?agent_id=ant",
+				body: { alias: "SignetAI", confidence: 0.9, source: "operator" },
+			},
+			{
+				method: "DELETE",
+				path: "/api/ontology/entities/entity-signet/aliases/alias-1?agent_id=ant",
+				body: undefined,
+			},
+		]);
+		expect(lines.join("\n")).toContain("Entity Aliases");
+		expect(lines.join("\n")).toContain("SignetAI");
 	});
 
 	test("objects lists ontology objects through knowledge navigation", async () => {

--- a/surfaces/cli/src/commands/ontology.ts
+++ b/surfaces/cli/src/commands/ontology.ts
@@ -47,6 +47,19 @@ interface OntologyObjectListResponse {
 	readonly items?: readonly OntologyObjectItem[];
 }
 
+interface EntityAliasItem {
+	readonly id?: string;
+	readonly alias?: string;
+	readonly canonicalAlias?: string;
+	readonly confidence?: number;
+	readonly source?: string | null;
+	readonly status?: string;
+}
+
+interface EntityAliasListResponse {
+	readonly items?: readonly EntityAliasItem[];
+}
+
 interface OntologyClaimItem {
 	readonly claimKey?: string;
 	readonly activeCount?: number;
@@ -466,6 +479,15 @@ async function apiPost(deps: OntologyDeps, path: string, body: unknown, timeoutM
 	return data;
 }
 
+async function apiDelete(deps: OntologyDeps, path: string, timeoutMs = 10_000): Promise<unknown> {
+	const { ok, data } = await deps.secretApiCall("DELETE", path, undefined, timeoutMs);
+	if (!ok || typeof asRecord(data).error === "string") {
+		console.error(chalk.red(errorMessage(data, "Ontology request failed")));
+		process.exit(1);
+	}
+	return data;
+}
+
 function printProposalList(data: unknown): void {
 	const items = ((asRecord(data) as ProposalListResponse).items ?? []) as readonly ProposalListItem[];
 	if (items.length === 0) {
@@ -512,6 +534,22 @@ function printOntologyObjects(data: unknown): void {
 			),
 		);
 		if (item.entity?.id) console.log(chalk.dim(`    ${item.entity.id}`));
+	}
+	console.log();
+}
+
+function printEntityAliases(data: unknown): void {
+	const items = ((asRecord(data) as EntityAliasListResponse).items ?? []) as readonly EntityAliasItem[];
+	if (items.length === 0) {
+		console.log(chalk.dim("  No aliases found"));
+		return;
+	}
+	console.log(chalk.bold("\n  Entity Aliases\n"));
+	for (const item of items) {
+		const status = item.status ? chalk.dim(` ${item.status}`) : "";
+		const confidence = typeof item.confidence === "number" ? chalk.dim(` · ${item.confidence.toFixed(2)}`) : "";
+		console.log(`  ${chalk.cyan(item.alias ?? "unknown")} ${chalk.dim(item.id ?? "unknown")}${status}${confidence}`);
+		if (item.source) console.log(chalk.dim(`    source ${item.source}`));
 	}
 	console.log();
 }
@@ -1336,6 +1374,63 @@ export function registerOntologyCommands(program: Command, deps: OntologyDeps): 
 		if (!(await deps.ensureDaemonForSecrets())) return;
 		const data = await postOperation(deps, "archive_entity", { selector, reason: options.reason }, options);
 		printOperationResult(data, options, "entity archive");
+	});
+	const alias = entity.command("alias").description("Manage entity aliases");
+	addCommonOptions(
+		alias
+			.command("list")
+			.description("List aliases for an entity id")
+			.argument("<entity-id>")
+			.option("--status <status>", "Alias status: active, archived, all"),
+	).action(async (entityId: string, options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const params = new URLSearchParams();
+		appendAgent(params, options.agent);
+		if (typeof options.status === "string") params.set("status", options.status);
+		const data = await apiGet(deps, `/api/ontology/entities/${encodeURIComponent(entityId)}/aliases`, params);
+		if (options.json) console.log(JSON.stringify(data, null, 2));
+		else printEntityAliases(data);
+	});
+	addCommonOptions(
+		alias
+			.command("add")
+			.description("Add an alias for an entity id")
+			.argument("<entity-id>")
+			.argument("<alias>")
+			.option("--confidence <n>", "Alias confidence 0..1", Number.parseFloat)
+			.option("--source <text>", "Alias source label"),
+	).action(async (entityId: string, aliasValue: string, options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const params = new URLSearchParams();
+		appendAgent(params, options.agent);
+		const query = params.toString();
+		const data = await apiPost(
+			deps,
+			`/api/ontology/entities/${encodeURIComponent(entityId)}/aliases${query ? `?${query}` : ""}`,
+			{
+				alias: aliasValue,
+				confidence: options.confidence,
+				source: options.source,
+			},
+		);
+		if (options.json) console.log(JSON.stringify(data, null, 2));
+		else printEntityAliases({ items: [asRecord(data).item] });
+	});
+	addCommonOptions(
+		alias.command("archive").description("Archive an entity alias").argument("<entity-id>").argument("<alias-id>"),
+	).action(async (entityId: string, aliasId: string, options) => {
+		if (!(await deps.ensureDaemonForSecrets())) return;
+		const params = new URLSearchParams();
+		appendAgent(params, options.agent);
+		const query = params.toString();
+		const data = await apiDelete(
+			deps,
+			`/api/ontology/entities/${encodeURIComponent(entityId)}/aliases/${encodeURIComponent(aliasId)}${
+				query ? `?${query}` : ""
+			}`,
+		);
+		if (options.json) console.log(JSON.stringify(data, null, 2));
+		else printEntityAliases({ items: [asRecord(data).item] });
 	});
 
 	const claim = ontology.command("claim").description("Apply audited claim/version operations");


### PR DESCRIPTION
## Summary

Changes prompt-submit injection to a trust-preserving entity-context path: Signet stays silent unless a prompt mentions a known entity or active alias and a matching ontology aspect clears the semantic gate.

## Changes

- Adds entity alias storage, migration, daemon API, and CLI commands.
- Replaces generic prompt-submit recall/fallback injection with compact ontology current-view context.
- Keeps fallback silent for low-signal, unknown-entity, ambiguous-entity, and no-aspect-hit prompts.
- Adds daemon-rs schema and prompt-submit parity, including explicit `minScore = 0` handling.
- Updates hook/API/config/architecture docs for the new behavior.
- Adds regressions for alias ownership on archive and prompt-submit entity/alias gating.

## Type

- [x] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: daemon-rs, docs

## Screenshots

N/A - no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Migration adds `entity_aliases` for scoped ontology aliases. Rollback compatibility: prompt-submit treats a missing alias table as no entity context and stays silent; daemon-rs has matching schema/parity coverage.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Targeted local validation:

- [x] `bun test platform/core/src/migrations/migrations.test.ts platform/daemon/src/hooks.prompt-submit.test.ts platform/daemon/src/knowledge-graph-list.test.ts surfaces/cli/src/commands/ontology.test.ts`
- [x] `bun run --filter '@signet/core' typecheck`
- [x] `bunx biome check platform/daemon/src/knowledge-graph.ts platform/daemon/src/routes/ontology-routes.ts platform/daemon/src/knowledge-graph-list.test.ts platform/daemon/src/hooks.ts platform/daemon/src/hooks.test.ts platform/daemon/src/hooks.prompt-submit.test.ts surfaces/cli/src/commands/ontology.ts surfaces/cli/src/commands/ontology.test.ts platform/core/src/types.ts platform/core/src/migrations/index.ts platform/core/src/migrations/migrations.test.ts platform/core/src/migrations/077-entity-aliases.ts`
- [x] `cargo fmt --check`
- [x] `cargo test -p signet-daemon prompt_submit`
- [x] `git diff --check`

Known existing issue: full `bun test platform/daemon/src/hooks.test.ts` still has two unrelated `handleSessionStart` dedupe/session-end failures; the stale prompt-submit failures were removed and covered by focused tests.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Prompt-submit no longer performs generic recall or fallback injection. Explicit recall remains available through the existing recall surfaces.
