### PR TITLE
Route prompt entity context through attribute relevance

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -339,9 +339,10 @@ the same daemon recall implementation whenever possible. Current daemon HTTP
 recall, search aliases, hook recall, and MCP memory search call `hybridRecall`,
 so they receive the same structured evidence shaping behavior. Prompt-submit is
 intentionally not an explicit recall surface: it listens for known ontology
-entities or active aliases and injects compact current-view attributes only
-when an entity aspect clears the configured confidence gate. Any future recall
-surface, including CLI shortcuts, SDK helpers, desktop UI search,
+entities or active aliases, uses that entity match as the search scope, and
+injects compact current-view attributes only when scoped attribute relevance
+clears the configured confidence gate. Any future recall surface, including CLI
+shortcuts, SDK helpers, desktop UI search,
 connector-specific recall, or daemon-rs parity work, must either call the
 daemon recall API or implement the same evidence-channel contract. Do not add a
 separate recall path that bypasses lexical, semantic, prospective hint, and

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1238,7 +1238,7 @@ a pre-compaction summary:
 | `enabled` | `true` | Enable per-prompt entity context injection |
 | `recallLimit` | `10` | Legacy field retained for config compatibility; prompt-submit no longer runs generic recall |
 | `maxInjectChars` | `500` | Prompt-time entity-context character budget |
-| `minScore` | `0.8` | Minimum aspect score required before injecting current-view attributes |
+| `minScore` | `0.8` | Minimum attribute relevance score required before injecting current-view aspect context |
 
 
 Environment Variables

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -147,16 +147,17 @@ generic memory recall and does not inject fallback guidance when it cannot find
 a confident match.
 
 The hook listens for known ontology entities and active entity aliases. When a
-prompt names one, Signet scores that entity's aspects against the prompt and
-injects a compact `## Relevant Entity Context` block from the highest-scoring
-current attributes and constraints. `hooks.userPromptSubmit.minScore` gates
-aspect injection; `maxInjectChars` caps the block.
+prompt names one, the entity match scopes the search, then Signet scores that
+entity's current attributes against the remaining prompt. The highest-scoring
+attributes choose which aspects to inject into a compact
+`## Relevant Entity Context` block. `hooks.userPromptSubmit.minScore` gates
+attribute-driven aspect selection; `maxInjectChars` caps the block.
 
 When the prompt is low-signal, mentions no known entity or alias, is ambiguous,
-or no aspect clears the confidence gate, the hook returns an empty `inject`
-string. This keeps the active agent loop trustable: absence of injected context
-means Signet chose not to inject, not that the broader source substrate has no
-relevant evidence.
+or no attribute clears the confidence gate, the hook returns an empty `inject`
+string. Literal aspect names alone do not select context. This keeps the active
+agent loop trustable: absence of injected context means Signet chose not to
+inject, not that the broader source substrate has no relevant evidence.
 
 Explicit recall remains available through `/api/memory/recall`, `signet_recall`,
 `memory_search`, and related MCP/CLI surfaces. Raw transcript search is

--- a/docs/api/sessions-hooks.md
+++ b/docs/api/sessions-hooks.md
@@ -58,7 +58,8 @@ Code parent activity in the same project.
 
 Called on each user message. Returns compact entity current-view context only
 when the prompt mentions a known ontology entity or active alias and at least
-one aspect clears the confidence gate.
+one current attribute clears the confidence gate. The entity mention scopes the
+search; attribute relevance chooses which aspect context to inject.
 
 **Request body**
 
@@ -81,7 +82,7 @@ are optional.
 
 Prompt-submit does not run generic memory recall and has no fallback injection.
 Low-signal prompts, unknown entities, ambiguous entity mentions, and prompts
-where no aspect clears `hooks.userPromptSubmit.minScore` return `inject: ""`.
+where no attribute clears `hooks.userPromptSubmit.minScore` return `inject: ""`.
 Explicit recall is still available through `/api/memory/recall` and MCP/CLI
 recall tools. Raw transcript search is not injected on prompt-submit; use the
 dedicated `session_search` MCP/API surface when a caller needs transcript

--- a/platform/daemon-rs/crates/signet-core/src/migrations.rs
+++ b/platform/daemon-rs/crates/signet-core/src/migrations.rs
@@ -409,6 +409,11 @@ fn ensure_cross_daemon_parity_columns(conn: &Connection) -> Result<(), CoreError
     add_column_if_missing(conn, "memories", "scope", "TEXT")?;
     add_column_if_missing(conn, "memories", "idempotency_key", "TEXT")?;
     add_column_if_missing(conn, "memories", "runtime_path", "TEXT")?;
+    add_column_if_missing(conn, "embeddings", "agent_id", "TEXT")?;
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_embeddings_agent_source
+            ON embeddings(agent_id, source_type, source_id);",
+    )?;
 
     add_column_if_missing(
         conn,

--- a/platform/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/platform/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -986,6 +986,62 @@ fn is_prompt_context_term(term: &str) -> bool {
         && !term.chars().all(|ch| ch.is_ascii_digit())
 }
 
+fn f32_vector_from_blob(blob: &[u8]) -> Vec<f32> {
+    blob.chunks_exact(4)
+        .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+        .collect()
+}
+
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f64 {
+    let mut dot = 0.0_f64;
+    let mut norm_a = 0.0_f64;
+    let mut norm_b = 0.0_f64;
+    for (left, right) in a.iter().zip(b.iter()) {
+        let left = f64::from(*left);
+        let right = f64::from(*right);
+        dot += left * right;
+        norm_a += left * left;
+        norm_b += right * right;
+    }
+    let denom = norm_a.sqrt() * norm_b.sqrt();
+    if denom > 0.0 { dot / denom } else { 0.0 }
+}
+
+fn memory_embedding_score(
+    conn: &rusqlite::Connection,
+    memory_id: &str,
+    agent_id: &str,
+    query_vector: Option<&[f32]>,
+) -> f64 {
+    let Some(query_vector) = query_vector else {
+        return 0.0;
+    };
+    let vectors = match conn.prepare(
+        "SELECT vector, dimensions
+         FROM embeddings
+         WHERE source_type = 'memory'
+           AND source_id = ?1
+           AND agent_id = ?2
+           AND vector IS NOT NULL",
+    ) {
+        Ok(mut stmt) => stmt
+            .query_map(rusqlite::params![memory_id, agent_id], |row| {
+                Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, usize>(1)?))
+            })
+            .ok()
+            .map(|rows| rows.filter_map(|r| r.ok()).collect::<Vec<_>>())
+            .unwrap_or_default(),
+        Err(_) => vec![],
+    };
+    vectors
+        .iter()
+        .filter(|(blob, dimensions)| {
+            *dimensions == query_vector.len() && blob.len() == query_vector.len() * 4
+        })
+        .map(|(blob, _)| cosine_similarity(query_vector, &f32_vector_from_blob(blob)))
+        .fold(0.0, f64::max)
+}
+
 fn build_entity_context_inject(metadata_header: &str, lines: &[String]) -> String {
     let mut parts = vec![
         metadata_header.trim_end().to_string(),
@@ -1186,10 +1242,18 @@ pub async fn prompt_submit(
         .as_ref()
         .map(|h| h.user_prompt_submit.max_inject_chars)
         .unwrap_or(500);
+    let semantic_query = query_terms.clone();
+    let embedding_provider = state.embedding.read().await.clone();
+    let query_vector_for_scoring = match embedding_provider {
+        Some(provider) if !semantic_query.trim().is_empty() => {
+            provider.embed(&semantic_query).await
+        }
+        _ => None,
+    };
 
     let result = state
-		.pool
-		.read(move |conn| {
+			.pool
+			.read(move |conn| {
             let has_aliases = conn
                 .query_row(
                     "SELECT COUNT(*) FROM sqlite_master
@@ -1324,9 +1388,9 @@ pub async fn prompt_submit(
                     Err(_) => vec![],
                 };
                 let mut selected_aspects = Vec::new();
-                for (aspect_id, aspect_name, canonical_name, weight) in aspects {
-                    let attr_texts = match conn.prepare(
-                        "SELECT ea.content, COALESCE(ea.group_key, ''), COALESCE(ea.claim_key, '')
+                for (aspect_id, aspect_name, _canonical_name, _weight) in aspects {
+                    let attr_rows = match conn.prepare(
+                        "SELECT ea.content, COALESCE(ea.memory_id, ''), ea.confidence, ea.importance
                          FROM entity_attributes ea
                          WHERE ea.aspect_id = ?1
                            AND ea.agent_id = ?2
@@ -1349,11 +1413,11 @@ pub async fn prompt_submit(
                     ) {
                         Ok(mut stmt) => stmt
                             .query_map(rusqlite::params![aspect_id, agent_id.clone()], |row| {
-                                Ok(format!(
-                                    "{} {} {}",
+                                Ok((
                                     row.get::<_, String>(0)?,
                                     row.get::<_, String>(1)?,
-                                    row.get::<_, String>(2)?
+                                    row.get::<_, f64>(2)?,
+                                    row.get::<_, f64>(3)?,
                                 ))
                             })
                             .ok()
@@ -1361,24 +1425,35 @@ pub async fn prompt_submit(
                             .unwrap_or_default(),
                         Err(_) => vec![],
                     };
-                    if attr_texts.is_empty() {
+                    if attr_rows.is_empty() || context_terms.is_empty() {
                         continue;
                     }
-                    let aspect_text = normalize_prompt_entity_text(&format!("{aspect_name} {canonical_name}"));
-                    let aspect_hit = aspect_text
-                        .split_whitespace()
-                        .any(|term| context_terms.contains(term));
-                    let attr_text = normalize_prompt_entity_text(&attr_texts.join(" "));
-                    let attr_hit = attr_text
-                        .split_whitespace()
-                        .any(|term| context_terms.contains(term));
-                    let score = if aspect_hit {
-                        1.0
-                    } else if attr_hit {
-                        0.75 + weight.clamp(0.0, 1.0) * 0.25
-                    } else {
-                        0.0
-                    };
+                    let score = attr_rows
+                        .iter()
+                        .map(|(content, memory_id, confidence, importance)| {
+                            let attr_text = normalize_prompt_entity_text(content);
+                            let lexical_score = if attr_text
+                                .split_whitespace()
+                                .any(|term| context_terms.contains(term))
+                            {
+                                0.72 + importance.clamp(0.0, 1.0) * 0.18
+                                    + confidence.clamp(0.0, 1.0) * 0.1
+                            } else {
+                                0.0
+                            };
+                            let semantic_score = if memory_id.is_empty() {
+                                0.0
+                            } else {
+                                memory_embedding_score(
+                                    conn,
+                                    memory_id,
+                                    &agent_id,
+                                    query_vector_for_scoring.as_deref(),
+                                )
+                            };
+                            lexical_score.max(semantic_score)
+                        })
+                        .fold(0.0, f64::max);
                     if score >= min_score {
                         selected_aspects.push((aspect_id, aspect_name));
                     }
@@ -3018,6 +3093,7 @@ mod tests {
         UserPromptSubmitHookConfig,
     };
     use signet_core::db::{DbPool, Priority};
+    use signet_pipeline::embedding::EmbeddingProvider;
     use tempfile::TempDir;
 
     use crate::auth::rate_limiter::{AuthRateLimiter, default_limits};
@@ -3027,7 +3103,7 @@ mod tests {
     use super::{
         CHECKPOINT_MIN_DELTA, CheckpointExtractBody, CompactionCompleteBody, PromptSubmitBody,
         SessionEndBody, build_signet_system_prompt, compaction_complete, extract_delta,
-        normalize_session_transcript, parse_visibility, prompt_submit,
+        memory_embedding_score, normalize_session_transcript, parse_visibility, prompt_submit,
         require_session_scope_for_write, resolve_audit_token, resolve_compaction_project,
         resolve_remember_agent, session_agent_id, session_checkpoint_extract, session_end,
         session_transcript_content, strip_untrusted_metadata, upsert_session_transcript,
@@ -3037,6 +3113,36 @@ mod tests {
     async fn test_json(resp: axum::response::Response) -> Value {
         let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
         serde_json::from_slice(&body).unwrap()
+    }
+
+    struct TestEmbeddingProvider {
+        vector: Vec<f32>,
+    }
+
+    impl EmbeddingProvider for TestEmbeddingProvider {
+        fn embed(
+            &self,
+            _text: &str,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<Vec<f32>>> + Send + '_>>
+        {
+            let vector = self.vector.clone();
+            Box::pin(async move { Some(vector) })
+        }
+
+        fn name(&self) -> &str {
+            "test"
+        }
+
+        fn dimensions(&self) -> usize {
+            self.vector.len()
+        }
+    }
+
+    fn vector_blob(values: &[f32]) -> Vec<u8> {
+        values
+            .iter()
+            .flat_map(|value| value.to_le_bytes())
+            .collect()
     }
 
     fn has_markdown(dir: &Path) -> bool {
@@ -3690,7 +3796,9 @@ mod tests {
                 harness: Some("test".to_string()),
                 project: Some("platform/daemon-rs".to_string()),
                 agent_id: Some("agent-a".to_string()),
-                user_message: Some("Should SignetAI architecture use current views?".to_string()),
+                user_message: Some(
+                    "Should SignetAI prompt context include current views?".to_string(),
+                ),
                 user_prompt: None,
                 last_assistant_message: None,
                 session_key: Some("sess-prompt-entity".to_string()),
@@ -3774,6 +3882,232 @@ mod tests {
                 user_prompt: None,
                 last_assistant_message: None,
                 session_key: Some("sess-prompt-entity-only".to_string()),
+                transcript: None,
+                transcript_path: None,
+                runtime_path: None,
+            }),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = test_json(resp).await;
+        assert_eq!(body["inject"], serde_json::Value::String(String::new()));
+        assert_eq!(body["memoryCount"], serde_json::Value::Number(0.into()));
+        assert_eq!(
+            body["engine"],
+            serde_json::Value::String("no-aspect-hit".to_string())
+        );
+
+        drop(state);
+        let _ = writer.await;
+    }
+
+    #[tokio::test]
+    async fn prompt_submit_uses_scoped_semantic_attribute_relevance() {
+        let (state, writer, _tmp) = test_state("hooks-prompt-submit-semantic-attribute");
+        *state.embedding.write().await = Some(Arc::new(TestEmbeddingProvider {
+            vector: vec![1.0, 0.0],
+        }));
+        state
+            .pool
+            .write(Priority::Low, move |conn| {
+                conn.execute(
+                    "INSERT INTO entities (id, name, canonical_name, entity_type, description, agent_id, mentions, created_at, updated_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, 10, ?7, ?7)",
+                    rusqlite::params![
+                        "entity-signet",
+                        "Signet",
+                        "signet",
+                        "project",
+                        "Source-backed agent continuity substrate",
+                        "agent-a",
+                        "2026-05-27T00:00:00Z",
+                    ],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_aliases (id, entity_id, agent_id, alias, canonical_alias, confidence, source, status, created_at, updated_at)
+                     VALUES ('alias-signetai', 'entity-signet', 'agent-a', 'SignetAI', 'signetai', 1.0, 'test', 'active', ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_aspects (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+                     VALUES ('aspect-preferences', 'entity-signet', 'agent-a', 'preferences', 'preferences', 0.8, ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_aspects (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+                     VALUES ('aspect-marketing', 'entity-signet', 'agent-a', 'marketing', 'marketing', 0.2, ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                conn.execute(
+                    "INSERT INTO memories (id, type, content, confidence, importance, created_at, updated_at, agent_id)
+                     VALUES ('mem-preferences-pen', 'preference', 'Favorite pen is a Pilot G-2.', 0.95, 0.9, ?1, ?1, 'agent-a')",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_attributes
+                     (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, confidence, importance,
+                      status, group_key, claim_key, created_at, updated_at)
+                     VALUES ('attr-preferences-pen', 'aspect-preferences', 'agent-a', 'mem-preferences-pen', 'attribute',
+                      'Favorite pen is a Pilot G-2.',
+                      'favorite pen is a pilot g 2', 0.95, 0.9, 'active',
+                      'writing', 'favorite_pen', ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_attributes
+                     (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, confidence, importance,
+                      status, group_key, claim_key, created_at, updated_at)
+                     VALUES ('attr-marketing', 'aspect-marketing', 'agent-a', NULL, 'attribute',
+                      'Marketing copy should stay secondary.',
+                      'marketing copy should stay secondary', 0.8, 0.3, 'active',
+                      'copy', 'positioning', ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                conn.execute(
+                    "INSERT INTO embeddings
+                     (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
+                     VALUES ('emb-preferences-pen', 'hash-preferences-pen', ?1, 2, 'memory',
+                      'mem-preferences-pen', 'Favorite pen is a Pilot G-2.', ?2, 'agent-a')",
+                    rusqlite::params![vector_blob(&[1.0, 0.0]), "2026-05-27T00:00:00Z"],
+                )?;
+                Ok(serde_json::Value::Null)
+            })
+            .await
+            .unwrap();
+
+        let resp = prompt_submit(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(PromptSubmitBody {
+                harness: Some("test".to_string()),
+                project: Some("platform/daemon-rs".to_string()),
+                agent_id: Some("agent-a".to_string()),
+                user_message: Some("Signet likes taking notes".to_string()),
+                user_prompt: None,
+                last_assistant_message: None,
+                session_key: Some("sess-prompt-semantic-attribute".to_string()),
+                transcript: None,
+                transcript_path: None,
+                runtime_path: None,
+            }),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = test_json(resp).await;
+        let inject = body["inject"].as_str().unwrap_or_default();
+        assert_eq!(
+            body["engine"],
+            serde_json::Value::String("entity-context".to_string())
+        );
+        assert!(inject.contains("Signet / preferences / writing / favorite_pen"));
+        assert!(inject.contains("Favorite pen is a Pilot G-2."));
+        assert!(!inject.contains("Marketing copy should stay secondary"));
+
+        drop(state);
+        let _ = writer.await;
+    }
+
+    #[tokio::test]
+    async fn prompt_submit_rejects_mismatched_semantic_embedding_dimensions() {
+        let (state, writer, _tmp) = test_state("hooks-prompt-submit-semantic-dimension");
+        state
+            .pool
+            .write(Priority::Low, move |conn| {
+                conn.execute(
+                    "INSERT INTO memories (id, type, content, confidence, importance, created_at, updated_at, agent_id)
+                     VALUES ('mem-preferences-pen', 'preference', 'Favorite pen is a Pilot G-2.', 0.95, 0.9, ?1, ?1, 'agent-a')",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                conn.execute(
+                    "INSERT INTO embeddings
+                     (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
+                     VALUES ('emb-preferences-pen-short', 'hash-preferences-pen-short', ?1, 1, 'memory',
+                      'mem-preferences-pen', 'Favorite pen is a Pilot G-2.', ?2, 'agent-a')",
+                    rusqlite::params![vector_blob(&[1.0]), "2026-05-27T00:00:00Z"],
+                )?;
+                Ok(serde_json::Value::Null)
+            })
+            .await
+            .unwrap();
+
+        let score = state
+            .pool
+            .read(move |conn| {
+                Ok(serde_json::json!(memory_embedding_score(
+                    conn,
+                    "mem-preferences-pen",
+                    "agent-a",
+                    Some(&[1.0, 0.0]),
+                )))
+            })
+            .await
+            .unwrap()
+            .as_f64()
+            .unwrap_or(1.0);
+
+        assert_eq!(score, 0.0);
+
+        drop(state);
+        let _ = writer.await;
+    }
+
+    #[tokio::test]
+    async fn prompt_submit_aspect_name_without_attribute_hit_stays_silent() {
+        let (state, writer, _tmp) = test_state("hooks-prompt-submit-aspect-name-only");
+        state
+            .pool
+            .write(Priority::Low, move |conn| {
+                conn.execute(
+                    "INSERT INTO entities (id, name, canonical_name, entity_type, description, agent_id, mentions, created_at, updated_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, 10, ?7, ?7)",
+                    rusqlite::params![
+                        "entity-signet",
+                        "Signet",
+                        "signet",
+                        "project",
+                        "Source-backed agent continuity substrate",
+                        "agent-a",
+                        "2026-05-27T00:00:00Z",
+                    ],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_aliases (id, entity_id, agent_id, alias, canonical_alias, confidence, source, status, created_at, updated_at)
+                     VALUES ('alias-signetai', 'entity-signet', 'agent-a', 'SignetAI', 'signetai', 1.0, 'test', 'active', ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_aspects (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+                     VALUES ('aspect-architecture', 'entity-signet', 'agent-a', 'architecture', 'architecture', 0.95, ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_attributes
+                     (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, confidence, importance,
+                      status, group_key, claim_key, created_at, updated_at)
+                     VALUES ('attr-architecture', 'aspect-architecture', 'agent-a', NULL, 'attribute',
+                      'Prompt context should come from entity current views.',
+                      'prompt context should come from entity current views', 0.95, 0.9, 'active',
+                      'runtime', 'prompt_context', ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                Ok(serde_json::Value::Null)
+            })
+            .await
+            .unwrap();
+
+        let resp = prompt_submit(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(PromptSubmitBody {
+                harness: Some("test".to_string()),
+                project: Some("platform/daemon-rs".to_string()),
+                agent_id: Some("agent-a".to_string()),
+                user_message: Some("SignetAI architecture".to_string()),
+                user_prompt: None,
+                last_assistant_message: None,
+                session_key: Some("sess-prompt-aspect-name-only".to_string()),
                 transcript: None,
                 transcript_path: None,
                 runtime_path: None,
@@ -4007,7 +4341,9 @@ mod tests {
                 harness: Some("test".to_string()),
                 project: Some("platform/daemon-rs".to_string()),
                 agent_id: Some("agent-a".to_string()),
-                user_message: Some("Should SignetAI architecture use current views?".to_string()),
+                user_message: Some(
+                    "Should SignetAI prompt context include current views?".to_string(),
+                ),
                 user_prompt: None,
                 last_assistant_message: None,
                 session_key: Some("sess-prompt-max-inject-chars".to_string()),

--- a/platform/daemon/src/hooks.prompt-submit.test.ts
+++ b/platform/daemon/src/hooks.prompt-submit.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { closeDbAccessor, getDbAccessor, initDbAccessor } from "./db-accessor";
+import { vectorToBlob } from "./db-helpers";
 import { handleUserPromptSubmit } from "./hooks";
 import { SIGNET_SECRETS_PLUGIN_ID, getDefaultPluginHost, resetDefaultPluginHostForTests } from "./plugins/index";
 
@@ -101,6 +102,11 @@ function seedEntityContext(): void {
 			 VALUES (?, ?, 'default', ?, ?, ?, ?, ?)`,
 		).run("aspect-marketing", "entity-signet", "marketing", "marketing", 0.2, now, now);
 		db.prepare(
+			`INSERT INTO entity_aspects
+			 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+			 VALUES (?, ?, 'default', ?, ?, ?, ?, ?)`,
+		).run("aspect-preferences", "entity-signet", "preferences", "preferences", 0.8, now, now);
+		db.prepare(
 			`INSERT INTO entity_attributes
 			 (id, aspect_id, agent_id, kind, content, normalized_content, group_key, claim_key,
 			  confidence, importance, status, memory_id, source_kind, source_id, created_at, updated_at)
@@ -164,6 +170,34 @@ function seedEntityContext(): void {
 			  confidence, importance, status, created_at, updated_at)
 			 VALUES (?, ?, 'default', 'attribute', ?, ?, 'copy', 'positioning', 0.8, 0.3, 'active', ?, ?)`,
 		).run("attr-marketing", "aspect-marketing", "Marketing copy should stay secondary.", "marketing copy", now, now);
+		db.prepare(
+			`INSERT INTO entity_attributes
+			 (id, aspect_id, agent_id, kind, content, normalized_content, group_key, claim_key,
+			  confidence, importance, status, memory_id, source_kind, source_id, created_at, updated_at)
+			 VALUES (?, ?, 'default', 'attribute', ?, ?, 'writing', 'favorite_pen', 0.95, 0.9, 'active', ?, 'memory', ?, ?, ?)`,
+		).run(
+			"attr-preferences-pen",
+			"aspect-preferences",
+			"Favorite pen is a Pilot G-2.",
+			"favorite pen is a pilot g 2",
+			"mem-preferences-pen",
+			"mem-preferences-pen",
+			now,
+			now,
+		);
+		db.prepare(
+			`INSERT INTO embeddings
+			 (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
+			 VALUES (?, ?, ?, ?, 'memory', ?, ?, ?, 'default')`,
+		).run(
+			"emb-preferences-pen",
+			"hash-preferences-pen",
+			vectorToBlob([1, 0]),
+			2,
+			"mem-preferences-pen",
+			"Favorite pen is a Pilot G-2.",
+			now,
+		);
 	});
 }
 
@@ -253,6 +287,81 @@ describe("handleUserPromptSubmit entity context", () => {
 		expect(result.inject).toContain("Prompt context should come from entity current views.");
 	});
 
+	it("uses entity match only as the semantic scope for attribute relevance", async () => {
+		seedEntityContext();
+		fetchEmbeddingMock.mockImplementationOnce(async () => [1, 0]);
+
+		const result = await handleUserPromptSubmit(
+			{ harness: "codex", userMessage: "Signet likes taking notes", sessionKey: "session-attribute-semantic" },
+			makeDeps(),
+		);
+
+		expect(fetchEmbeddingMock.mock.calls.at(-1)?.[0]).toBe("likes taking notes");
+		expect(result.engine).toBe("entity-context");
+		expect(result.inject).toContain("Signet / preferences / writing / favorite_pen");
+		expect(result.inject).toContain("Favorite pen is a Pilot G-2.");
+		expect(result.inject).not.toContain("Marketing copy should stay secondary");
+		expect(result.inject).not.toContain("## Relevant Memory");
+	});
+
+	it("keeps semantic attribute scoring scoped to the current agent", async () => {
+		seedEntityContext();
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO embeddings
+				 (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
+				 VALUES (?, ?, ?, ?, 'memory', ?, ?, ?, ?)`,
+			).run(
+				"emb-other-agent-preferences-pen",
+				"hash-other-agent-preferences-pen",
+				vectorToBlob([0, 1]),
+				2,
+				"mem-preferences-pen",
+				"Other agent favorite pen evidence.",
+				"2026-05-27T00:00:00.000Z",
+				"other-agent",
+			);
+		});
+		fetchEmbeddingMock.mockImplementationOnce(async () => [0, 1]);
+
+		const result = await handleUserPromptSubmit(
+			{ harness: "codex", userMessage: "Signet likes taking notes", sessionKey: "session-agent-scoped-embedding" },
+			makeDeps(),
+		);
+
+		expect(result).toMatchObject({ inject: "", memoryCount: 0, engine: "no-aspect-hit" });
+		expect(result.inject).not.toContain("Favorite pen is a Pilot G-2.");
+	});
+
+	it("ignores mismatched embedding dimensions for semantic attribute scoring", async () => {
+		seedEntityContext();
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare("DELETE FROM embeddings WHERE id = ?").run("emb-preferences-pen");
+			db.prepare(
+				`INSERT INTO embeddings
+				 (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
+				 VALUES (?, ?, ?, ?, 'memory', ?, ?, ?, 'default')`,
+			).run(
+				"emb-preferences-pen-short",
+				"hash-preferences-pen-short",
+				vectorToBlob([1]),
+				1,
+				"mem-preferences-pen",
+				"Favorite pen is a Pilot G-2.",
+				"2026-05-27T00:00:00.000Z",
+			);
+		});
+		fetchEmbeddingMock.mockImplementationOnce(async () => [1, 0]);
+
+		const result = await handleUserPromptSubmit(
+			{ harness: "codex", userMessage: "Signet likes taking notes", sessionKey: "session-dimension-mismatch" },
+			makeDeps(),
+		);
+
+		expect(result).toMatchObject({ inject: "", memoryCount: 0, engine: "no-aspect-hit" });
+		expect(result.inject).not.toContain("Favorite pen is a Pilot G-2.");
+	});
+
 	it("stays silent when the prompt only names an entity alias", async () => {
 		seedEntityContext();
 
@@ -262,6 +371,18 @@ describe("handleUserPromptSubmit entity context", () => {
 		);
 
 		expect(result).toMatchObject({ inject: "", memoryCount: 0, engine: "no-aspect-hit" });
+	});
+
+	it("does not select aspects from literal aspect names without an attribute hit", async () => {
+		seedEntityContext();
+
+		const result = await handleUserPromptSubmit(
+			{ harness: "codex", userMessage: "SignetAI architecture", sessionKey: "session-aspect-name-only" },
+			makeDeps(),
+		);
+
+		expect(result).toMatchObject({ inject: "", memoryCount: 0, engine: "no-aspect-hit" });
+		expect(result.inject).not.toContain("Prompt context should come from entity current views.");
 	});
 
 	it("does not match short entity names as ordinary prompt tokens", async () => {

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -16,7 +16,7 @@ import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { Worker } from "node:worker_threads";
-import { getAgentIdentityFiles, parseSimpleYaml } from "@signet/core";
+import { cosineSimilarity, getAgentIdentityFiles, parseSimpleYaml } from "@signet/core";
 import { ensureAgentRegistered, getAgentScope, resolveAgentId } from "./agent-id";
 import { extractAnchorTerms } from "./anchor-terms";
 import {
@@ -381,11 +381,11 @@ export interface HooksConfig {
 		maxInjectChars?: number;
 	};
 	userPromptSubmit?: {
-		/** Set to false to disable per-prompt memory injection entirely. Default: true. */
+		/** Set to false to disable per-prompt entity-context injection entirely. Default: true. */
 		enabled?: boolean;
 		recallLimit?: number;
 		maxInjectChars?: number;
-		/** Minimum top recall score required before injecting memories. */
+		/** Minimum scoped attribute relevance required before injecting entity context. */
 		minScore?: number;
 	};
 	preCompaction?: {
@@ -852,22 +852,69 @@ function resolvePromptEntityMatches(
 	return result;
 }
 
-function scoreAspectForPrompt(
-	aspect: { readonly name: string; readonly canonical_name: string; readonly weight: number },
-	rows: ReadonlyArray<{
-		readonly content: string;
-		readonly group_key: string | null;
-		readonly claim_key: string | null;
-	}>,
+type PromptAttributeCandidate = PromptEntityContextLine & {
+	readonly attributeId: string;
+	readonly aspectId: string;
+	readonly memoryId: string | null;
+	readonly score: number;
+};
+
+function queryWithoutPromptEntities(userMessage: string, entities: ReadonlyArray<PromptEntityMatch>): string {
+	const entityTerms = new Set(
+		entities.flatMap((entity) => extractSubstantiveWords(`${entity.entityName} ${entity.matchedText}`)),
+	);
+	return extractSubstantiveWords(userMessage)
+		.filter((term) => !entityTerms.has(term))
+		.join(" ");
+}
+
+function scoreAttributeLexically(
+	row: { readonly content: string; readonly confidence: number; readonly importance: number },
 	promptTerms: ReadonlyArray<string>,
 ): number {
-	const aspectTerms = extractSubstantiveWords(`${aspect.name} ${aspect.canonical_name}`);
-	const aspectOverlap = aspectTerms.some((term) => promptTerms.includes(term));
-	if (aspectOverlap) return 1;
-	const attrText = rows.map((row) => `${row.group_key ?? ""} ${row.claim_key ?? ""} ${row.content}`).join(" ");
-	const overlap = countPromptTermOverlap(attrText, promptTerms);
-	if (overlap > 0) return Math.min(1, 0.75 + Math.min(aspect.weight, 1) * 0.25);
-	return 0;
+	if (promptTerms.length === 0) return 0;
+	if (countPromptTermOverlap(row.content, promptTerms) === 0) return 0;
+	return Math.min(1, 0.72 + Math.min(row.importance, 1) * 0.18 + Math.min(row.confidence, 1) * 0.1);
+}
+
+function loadAttributeSemanticScores(
+	db: ReadDb,
+	agentId: string,
+	rows: ReadonlyArray<{ readonly attributeId: string; readonly memoryId: string | null }>,
+	queryVector: Float32Array | null,
+): Map<string, number> {
+	if (!queryVector) return new Map();
+	const memoryIds = [...new Set(rows.map((row) => row.memoryId).filter((id): id is string => !!id))];
+	if (memoryIds.length === 0) return new Map();
+	const placeholders = memoryIds.map(() => "?").join(", ");
+	const embeddings = db
+		.prepare(
+			`SELECT source_id, vector
+			 FROM embeddings
+			 WHERE source_type = 'memory'
+			   AND source_id IN (${placeholders})
+			   AND agent_id = ?
+			   AND dimensions = ?
+			   AND vector IS NOT NULL`,
+		)
+		.all(...memoryIds, agentId, queryVector.length) as Array<{ source_id: string; vector: Buffer }>;
+	const scoreByMemoryId = new Map<string, number>();
+	for (const embedding of embeddings) {
+		const vector = new Float32Array(
+			embedding.vector.buffer,
+			embedding.vector.byteOffset,
+			embedding.vector.byteLength / 4,
+		);
+		scoreByMemoryId.set(
+			embedding.source_id,
+			Math.max(scoreByMemoryId.get(embedding.source_id) ?? 0, cosineSimilarity(queryVector, vector)),
+		);
+	}
+	return new Map(
+		rows
+			.map((row) => [row.attributeId, row.memoryId ? (scoreByMemoryId.get(row.memoryId) ?? 0) : 0] as const)
+			.filter(([, score]) => score > 0),
+	);
 }
 
 function loadEntityContextLines(
@@ -876,54 +923,97 @@ function loadEntityContextLines(
 	agentId: string,
 	userMessage: string,
 	minScore: number,
+	queryVector: Float32Array | null,
 ): PromptEntityContextLine[] {
 	const entityTerms = new Set(extractSubstantiveWords(`${entity.entityName} ${entity.matchedText}`));
 	const promptTerms = extractSubstantiveWords(userMessage).filter((term) => !entityTerms.has(term));
-	const aspects = db
+	if (promptTerms.length === 0) return [];
+	const candidateRows = db
 		.prepare(
-			`SELECT id, name, canonical_name, weight
-			 FROM entity_aspects
-			 WHERE entity_id = ?
-			   AND agent_id = ?
-			   AND COALESCE(status, 'active') = 'active'
-			 ORDER BY weight DESC, name ASC
-			 LIMIT 12`,
+			`SELECT
+			   ea.id AS attribute_id,
+			   asp.id AS aspect_id,
+			   asp.name AS aspect_name,
+			   ea.kind,
+			   ea.content,
+			   ea.group_key,
+			   ea.claim_key,
+			   ea.confidence,
+			   ea.importance,
+			   ea.source_kind,
+			   ea.source_id,
+			   ea.source_path,
+			   ea.memory_id,
+			   COALESCE(ea.version, 1) AS version
+			 FROM entity_aspects asp
+			 JOIN entity_attributes ea ON ea.aspect_id = asp.id
+			 WHERE asp.entity_id = ?
+			   AND asp.agent_id = ?
+			   AND COALESCE(asp.status, 'active') = 'active'
+			   AND ea.agent_id = ?
+			   AND ea.status = 'active'
+			   AND ea.superseded_by IS NULL
+			   AND NOT EXISTS (
+			     SELECT 1
+			     FROM entity_attributes newer
+			     WHERE newer.aspect_id = ea.aspect_id
+			       AND newer.agent_id = ea.agent_id
+			       AND newer.kind = ea.kind
+			       AND COALESCE(newer.group_key, 'general') = COALESCE(ea.group_key, 'general')
+			       AND newer.claim_key = ea.claim_key
+			       AND newer.status = 'active'
+			       AND newer.superseded_by IS NULL
+			       AND COALESCE(newer.version, 1) > COALESCE(ea.version, 1)
+			   )
+			 ORDER BY ea.importance DESC, ea.updated_at DESC
+			 LIMIT 48`,
 		)
-		.all(entity.entityId, agentId) as Array<{
-		id: string;
-		name: string;
-		canonical_name: string;
-		weight: number;
+		.all(entity.entityId, agentId, agentId) as Array<{
+		attribute_id: string;
+		aspect_id: string;
+		aspect_name: string;
+		kind: "attribute" | "constraint";
+		content: string;
+		group_key: string | null;
+		claim_key: string | null;
+		confidence: number;
+		importance: number;
+		source_kind: string | null;
+		source_id: string | null;
+		source_path: string | null;
+		memory_id: string | null;
+		version: number;
 	}>;
+	const semanticScores = loadAttributeSemanticScores(
+		db,
+		agentId,
+		candidateRows.map((row) => ({ attributeId: row.attribute_id, memoryId: row.memory_id })),
+		queryVector,
+	);
+	const candidates: PromptAttributeCandidate[] = candidateRows
+		.map((row) => ({
+			attributeId: row.attribute_id,
+			aspectId: row.aspect_id,
+			entityName: entity.entityName,
+			aspectName: row.aspect_name,
+			groupKey: row.group_key,
+			claimKey: row.claim_key,
+			kind: row.kind,
+			content: row.content,
+			confidence: row.confidence,
+			importance: row.importance,
+			sourceKind: row.source_kind,
+			sourceId: row.source_id,
+			sourcePath: row.source_path,
+			memoryId: row.memory_id,
+			version: row.version,
+			score: Math.max(semanticScores.get(row.attribute_id) ?? 0, scoreAttributeLexically(row, promptTerms)),
+		}))
+		.filter((row) => row.score >= minScore)
+		.sort((a, b) => b.score - a.score || b.importance - a.importance);
 	const selectedAspectIds = new Set<string>();
-	for (const aspect of aspects) {
-		const rows = db
-			.prepare(
-				`SELECT ea.content, ea.group_key, ea.claim_key
-				 FROM entity_attributes ea
-				 WHERE ea.aspect_id = ?
-				   AND ea.agent_id = ?
-				   AND ea.status = 'active'
-				   AND ea.superseded_by IS NULL
-				   AND NOT EXISTS (
-				     SELECT 1
-				     FROM entity_attributes newer
-				     WHERE newer.aspect_id = ea.aspect_id
-				       AND newer.agent_id = ea.agent_id
-				       AND newer.kind = ea.kind
-				       AND COALESCE(newer.group_key, 'general') = COALESCE(ea.group_key, 'general')
-				       AND newer.claim_key = ea.claim_key
-				       AND newer.status = 'active'
-				       AND newer.superseded_by IS NULL
-				       AND COALESCE(newer.version, 1) > COALESCE(ea.version, 1)
-				   )
-				 ORDER BY ea.importance DESC, ea.updated_at DESC
-				 LIMIT 12`,
-			)
-			.all(aspect.id, agentId) as Array<{ content: string; group_key: string | null; claim_key: string | null }>;
-		if (rows.length === 0) continue;
-		const score = scoreAspectForPrompt(aspect, rows, promptTerms);
-		if (score >= minScore) selectedAspectIds.add(aspect.id);
+	for (const candidate of candidates) {
+		selectedAspectIds.add(candidate.aspectId);
 		if (selectedAspectIds.size >= ENTITY_CONTEXT_MAX_ASPECTS_PER_ENTITY) break;
 	}
 	if (selectedAspectIds.size === 0) return [];
@@ -1013,20 +1103,35 @@ function formatEntityContextLine(line: PromptEntityContextLine): string {
 	return `- [${line.kind}] ${path}: ${line.content} (${source})`;
 }
 
-function buildEntityPromptContext(
+async function buildEntityPromptContext(
 	userMessage: string,
 	agentId: string,
 	minScore: number,
 	injectBudget: number,
-): PromptEntityContextResult {
+	embedFn: typeof fetchEmbedding,
+	embeddingCfg: Parameters<typeof fetchEmbedding>[1],
+): Promise<PromptEntityContextResult> {
 	if (isLowSignalPrompt(userMessage)) return { lines: [], memoryCount: 0, engine: "low-signal" };
 	if (!existsSync(getMemoryDbPath())) return { lines: [], memoryCount: 0, engine: "no-entity" };
 	if (!hasDbAccessor()) return { lines: [], memoryCount: 0, engine: "no-entity" };
+	const matches = getDbAccessor().withReadDb((db) => resolvePromptEntityMatches(db, agentId, userMessage));
+	if (matches === "ambiguous") return { lines: [], memoryCount: 0, engine: "ambiguous-entity" };
+	if (matches.length === 0) return { lines: [], memoryCount: 0, engine: "no-entity" };
+	const semanticQuery = queryWithoutPromptEntities(userMessage, matches);
+	if (!semanticQuery) return { lines: [], memoryCount: 0, engine: "no-aspect-hit" };
+	let queryVector: Float32Array | null = null;
+	try {
+		const vector = await embedFn(semanticQuery, embeddingCfg);
+		if (vector) queryVector = new Float32Array(vector);
+	} catch (error) {
+		logger.warn("hooks", "Entity attribute semantic scoring failed; using lexical attribute scoring", {
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
 	return getDbAccessor().withReadDb((db) => {
-		const matches = resolvePromptEntityMatches(db, agentId, userMessage);
-		if (matches === "ambiguous") return { lines: [], memoryCount: 0, engine: "ambiguous-entity" };
-		if (matches.length === 0) return { lines: [], memoryCount: 0, engine: "no-entity" };
-		const lines = matches.flatMap((entity) => loadEntityContextLines(db, entity, agentId, userMessage, minScore));
+		const lines = matches.flatMap((entity) =>
+			loadEntityContextLines(db, entity, agentId, userMessage, minScore, queryVector),
+		);
 		if (lines.length === 0) return { lines: [], memoryCount: 0, engine: "no-aspect-hit" };
 		const selected = selectWithBudgetSkippingOversized(
 			lines.map((line) => ({ content: formatEntityContextLine(line) })),
@@ -2864,11 +2969,13 @@ export async function handleUserPromptSubmit(
 	try {
 		const cfg = deps.loadMemoryConfig(getAgentsDir());
 		const injectBudget = submitCfg.maxInjectChars ?? cfg.pipelineV2.guardrails.contextBudgetChars;
-		const entityContext = buildEntityPromptContext(
+		const entityContext = await buildEntityPromptContext(
 			userMessage,
 			agentId,
 			resolveUserPromptMinScore(submitCfg.minScore),
 			injectBudget,
+			deps.fetchEmbedding,
+			cfg.embedding,
 		);
 		if (entityContext.lines.length === 0) {
 			return finalizeUserPromptSubmitSuccess(


### PR DESCRIPTION
## Summary
- Treat entity and alias matches as the scope for prompt-submit context, not as evidence that any aspect should inject.
- Score scoped current attributes semantically through linked memory embeddings, with lexical attribute-content fallback when embeddings are unavailable.
- Stop literal aspect names from selecting context without an attribute hit, and update TS/Rust parity tests plus docs.

## Changes
- `platform/daemon/src/hooks.ts`: removes aspect-name scoring, strips matched entity terms before scoring, embeds the remaining query, and selects aspects from scoped, agent-filtered attribute relevance.
- `platform/daemon/src/hooks.prompt-submit.test.ts`: covers semantic attribute selection, aspect-name-only silence, and cross-agent embedding source-id collisions.
- `platform/daemon-rs/crates/signet-daemon/src/routes/hooks.rs`: adds semantic linked-memory embedding scoring for prompt-submit parity.
- `platform/daemon-rs/crates/signet-core/src/migrations.rs`: ensures Rust-created databases have `embeddings.agent_id` and the scoped embedding index used by the route.
- `docs/HOOKS.md`, `docs/api/sessions-hooks.md`, `docs/CONFIGURATION.md`, `docs/ARCHITECTURE.md`: document the attribute-first prompt-submit contract.

## Type
- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected
- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: `platform/daemon-rs`, docs

## Screenshots
N/A, no UI changes.

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)
- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Rust parity startup now idempotently adds `embeddings.agent_id` and `idx_embeddings_agent_source` when missing. Rollback compatibility is low risk because this only adds a nullable column and an index that match the existing TypeScript migration contract.

## Testing
- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Focused validation run:
- `bun test platform/daemon/src/hooks.prompt-submit.test.ts`
- `cargo test -p signet-daemon prompt_submit`
- `bunx biome check platform/daemon/src/hooks.ts platform/daemon/src/hooks.prompt-submit.test.ts`
- `cargo fmt --check`
- `bun run --filter '@signet/daemon' build`
- `git diff --check`

Note: `bun run --filter '@signet/daemon' build:types` remains blocked by existing repo-wide declaration emit issues: the daemon tsconfig `rootDir` excludes imported core migration files, followed by existing `bun:sqlite` type mismatches in unrelated tests.

## AI disclosure
- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes
The active installed daemon may still show the old prompt-submit behavior until a build containing this PR is installed or released.
