### PR TITLE
fix(hooks): harden prompt entity context filtering

### DIFF
--- a/platform/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/platform/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -964,6 +964,34 @@ fn prompt_generic_entity_phrase(phrase_terms: &[String]) -> bool {
         .is_some_and(|singular| !prompt_bare_possessive_allowed(singular))
 }
 
+fn prompt_role_entity(row: &PromptEntityRow) -> bool {
+    if row.pinned.clamp(0, 1) > 0 {
+        return false;
+    }
+    let entity_terms = prompt_entity_terms(&row.entity_name);
+    let matched_terms = prompt_entity_terms(&row.matched_text);
+    if entity_terms.len() != 1 || matched_terms.len() != 1 {
+        return false;
+    }
+    matches!(entity_terms[0].as_str(), "assistant" | "human" | "user")
+        && matches!(matched_terms[0].as_str(), "assistant" | "human" | "user")
+}
+
+fn prompt_broad_uncategorized_attribute(group: &str, claim: &str) -> bool {
+    normalize_prompt_entity_text(group) == "general"
+        && normalize_prompt_entity_text(claim) == "uncategorized"
+}
+
+fn prompt_generic_context_query(context_terms: &HashSet<String>) -> bool {
+    !context_terms.is_empty()
+        && context_terms.iter().all(|term| {
+            matches!(
+                term.as_str(),
+                "context" | "contexts" | "current" | "prompt" | "relevant" | "view" | "views"
+            )
+        })
+}
+
 fn score_prompt_entity_candidate(
     match_source: &str,
     matched_text: &str,
@@ -1437,6 +1465,7 @@ pub async fn prompt_submit(
             let mut candidates_by_phrase = HashMap::<String, Vec<PromptEntityCandidate>>::new();
             for row in entity_rows {
                 if !prompt_entity_context_type_allowed(&row.entity_type)
+                    || prompt_role_entity(&row)
                     || prompt_generic_entity_phrase(&prompt_entity_terms(&row.matched_text))
                 {
                     continue;
@@ -1528,19 +1557,24 @@ pub async fn prompt_submit(
                 .filter(|term| is_prompt_context_term(term))
                 .map(str::to_string)
                 .collect::<HashSet<_>>();
-            let mut lines = Vec::new();
-            for entity in entity_matches {
-                let entity_terms = normalize_prompt_entity_text(&format!(
-                    "{} {}",
-                    entity.entity_name, entity.matched_text
-                ))
+            let all_entity_terms = entity_matches
+                .iter()
+                .flat_map(|entity| {
+                    normalize_prompt_entity_text(&format!(
+                        "{} {}",
+                        entity.entity_name, entity.matched_text
+                    ))
                     .split_whitespace()
                     .map(str::to_string)
-                    .collect::<HashSet<_>>();
+                    .collect::<Vec<_>>()
+                })
+                .collect::<HashSet<_>>();
+            let mut lines = Vec::new();
+            for entity in entity_matches {
                 let context_terms = prompt_terms
                     .iter()
                     .filter(|term| {
-                        !entity_terms
+                        !all_entity_terms
                             .iter()
                             .any(|entity_term| prompt_entity_term_matches(term, entity_term))
                     })
@@ -1571,11 +1605,14 @@ pub async fn prompt_submit(
                 };
                 let mut selected_aspects = Vec::new();
                 for (aspect_id, aspect_name, _canonical_name, _weight) in aspects {
+                    let generic_context_query = prompt_generic_context_query(&context_terms);
                     let attr_rows = match conn.prepare(
-                        "SELECT ea.content, COALESCE(ea.memory_id, ''), ea.confidence, ea.importance
+                        "SELECT ea.id, ea.content, COALESCE(ea.memory_id, ''), ea.confidence, ea.importance
                          FROM entity_attributes ea
                          WHERE ea.aspect_id = ?1
                            AND ea.agent_id = ?2
+                           AND NOT (COALESCE(ea.group_key, 'general') = 'general'
+                             AND COALESCE(ea.claim_key, 'uncategorized') = 'uncategorized')
                            AND ea.status = 'active'
                            AND ea.superseded_by IS NULL
                            AND NOT EXISTS (
@@ -1594,14 +1631,21 @@ pub async fn prompt_submit(
                          LIMIT 12",
                     ) {
                         Ok(mut stmt) => stmt
-                            .query_map(rusqlite::params![aspect_id, agent_id.clone()], |row| {
+                            .query_map(
+                                rusqlite::params![
+                                    aspect_id,
+                                    agent_id.clone()
+                                ],
+                                |row| {
                                 Ok((
                                     row.get::<_, String>(0)?,
                                     row.get::<_, String>(1)?,
-                                    row.get::<_, f64>(2)?,
+                                    row.get::<_, String>(2)?,
                                     row.get::<_, f64>(3)?,
+                                    row.get::<_, f64>(4)?,
                                 ))
-                            })
+                                },
+                            )
                             .ok()
                             .map(|rows| rows.filter_map(|r| r.ok()).collect::<Vec<_>>())
                             .unwrap_or_default(),
@@ -1610,9 +1654,9 @@ pub async fn prompt_submit(
                     if attr_rows.is_empty() || context_terms.is_empty() {
                         continue;
                     }
-                    let score = attr_rows
+                    let matched_attr_ids = attr_rows
                         .iter()
-                        .map(|(content, memory_id, confidence, importance)| {
+                        .filter_map(|(attr_id, content, memory_id, confidence, importance)| {
                             let attr_text = normalize_prompt_entity_text(content);
                             let lexical_score = if attr_text
                                 .split_whitespace()
@@ -1633,24 +1677,31 @@ pub async fn prompt_submit(
                                     query_vector_for_scoring.as_deref(),
                                 )
                             };
-                            lexical_score.max(semantic_score)
+                            if generic_context_query && lexical_score == 0.0 {
+                                None
+                            } else {
+                                let score = lexical_score.max(semantic_score);
+                                (score >= min_score).then(|| attr_id.clone())
+                            }
                         })
-                        .fold(0.0, f64::max);
-                    if score >= min_score {
-                        selected_aspects.push((aspect_id, aspect_name));
+                        .collect::<HashSet<_>>();
+                    if !matched_attr_ids.is_empty() {
+                        selected_aspects.push((aspect_id, aspect_name, matched_attr_ids));
                     }
                     if selected_aspects.len() >= 3 {
                         break;
                     }
                 }
-                for (aspect_id, aspect_name) in selected_aspects {
+                for (aspect_id, aspect_name, matched_attr_ids) in selected_aspects {
                     let attrs = match conn.prepare(
-                        "SELECT ea.kind, ea.content, COALESCE(ea.group_key, 'general'), COALESCE(ea.claim_key, 'uncategorized'),
+                        "SELECT ea.id, ea.kind, ea.content, COALESCE(ea.group_key, 'general'), COALESCE(ea.claim_key, 'uncategorized'),
                                 COALESCE(ea.source_kind, ''), COALESCE(ea.source_id, ''), COALESCE(ea.memory_id, ''),
                                 COALESCE(ea.version, 1)
                          FROM entity_attributes ea
                          WHERE ea.aspect_id = ?1
                            AND ea.agent_id = ?2
+                           AND NOT (COALESCE(ea.group_key, 'general') = 'general'
+                             AND COALESCE(ea.claim_key, 'uncategorized') = 'uncategorized')
                            AND ea.status = 'active'
                            AND ea.superseded_by IS NULL
                            AND NOT EXISTS (
@@ -1669,7 +1720,12 @@ pub async fn prompt_submit(
                          LIMIT 8",
                     ) {
                         Ok(mut stmt) => stmt
-                            .query_map(rusqlite::params![aspect_id, agent_id.clone()], |row| {
+                            .query_map(
+                                rusqlite::params![
+                                    aspect_id,
+                                    agent_id.clone()
+                                ],
+                                |row| {
                                 Ok((
                                     row.get::<_, String>(0)?,
                                     row.get::<_, String>(1)?,
@@ -1678,15 +1734,23 @@ pub async fn prompt_submit(
                                     row.get::<_, String>(4)?,
                                     row.get::<_, String>(5)?,
                                     row.get::<_, String>(6)?,
-                                    row.get::<_, i64>(7)?,
+                                    row.get::<_, String>(7)?,
+                                    row.get::<_, i64>(8)?,
                                 ))
-                            })
+                                },
+                            )
                             .ok()
                             .map(|rows| rows.filter_map(|r| r.ok()).collect::<Vec<_>>())
                             .unwrap_or_default(),
                         Err(_) => vec![],
                     };
-                    for (kind, content, group, claim, source_kind, source_id, memory_id, version) in attrs {
+                    for (attr_id, kind, content, group, claim, source_kind, source_id, memory_id, version) in attrs {
+                        if !matched_attr_ids.contains(&attr_id) {
+                            continue;
+                        }
+                        if prompt_broad_uncategorized_attribute(&group, &claim) {
+                            continue;
+                        }
                         let source = if !source_kind.is_empty() && !source_id.is_empty() {
                             format!("{source_kind}:{source_id}")
                         } else if !memory_id.is_empty() {
@@ -3949,6 +4013,21 @@ mod tests {
                     rusqlite::params!["2026-05-27T00:00:00Z"],
                 )?;
                 conn.execute(
+                    "INSERT INTO entity_aspects (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+                     VALUES ('aspect-general', 'entity-signet', 'agent-a', 'general', 'general', 1.0, ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_attributes
+                     (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, confidence, importance,
+                      status, group_key, claim_key, created_at, updated_at)
+                     VALUES ('attr-general-junk', 'aspect-general', 'agent-a', NULL, 'constraint',
+                      'Prompt context junk from general uncategorized should not inject.',
+                      'prompt context junk from general uncategorized should not inject', 0.99, 1.0, 'active',
+                      'general', 'uncategorized', ?1, ?1)",
+                    rusqlite::params!["2026-05-27T00:00:00Z"],
+                )?;
+                conn.execute(
                     "INSERT INTO entity_attributes
                      (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, confidence, importance,
                       status, group_key, claim_key, version, created_at, updated_at)
@@ -4002,6 +4081,8 @@ mod tests {
         assert!(inject.contains("## Relevant Entity Context"));
         assert!(inject.contains("Signet / architecture / runtime / prompt_context"));
         assert!(inject.contains("Prompt context should come from entity current views."));
+        assert!(!inject.contains("Signet / general / general / uncategorized"));
+        assert!(!inject.contains("Prompt context junk from general uncategorized"));
         assert!(!inject.contains("Stale prompt context should not be injected."));
         assert!(!inject.contains("## Relevant Memory"));
         assert!(!inject.contains("Marketing copy should stay secondary"));
@@ -4268,6 +4349,68 @@ mod tests {
                 user_prompt: None,
                 last_assistant_message: None,
                 session_key: Some("sess-prompt-disallowed-entity-type".to_string()),
+                transcript: None,
+                transcript_path: None,
+                runtime_path: None,
+            }),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = test_json(resp).await;
+        assert_eq!(
+            body["engine"],
+            serde_json::Value::String("no-entity".to_string())
+        );
+        assert_eq!(body["inject"], serde_json::Value::String(String::new()));
+
+        drop(state);
+        let _ = writer.await;
+    }
+
+    #[tokio::test]
+    async fn prompt_submit_ignores_generic_role_label_people() {
+        let (state, writer, _tmp) = test_state("hooks-prompt-submit-role-label-entity");
+        state
+            .pool
+            .write(Priority::Low, move |conn| {
+                let now = "2026-05-27T00:00:00Z";
+                conn.execute(
+                    "INSERT INTO entities (id, name, canonical_name, entity_type, description, agent_id, mentions, created_at, updated_at)
+                     VALUES ('entity-user-role', 'User', 'user', 'person', 'Role label', 'agent-a', 2000, ?1, ?1)",
+                    rusqlite::params![now],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_aspects (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+                     VALUES ('aspect-user-general', 'entity-user-role', 'agent-a', 'general', 'general', 1.0, ?1, ?1)",
+                    rusqlite::params![now],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_attributes
+                     (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, confidence, importance,
+                      status, group_key, claim_key, created_at, updated_at)
+                     VALUES ('attr-user-role-context', 'aspect-user-general', 'agent-a', NULL, 'attribute',
+                      'User prompt context role-label junk should not inject.',
+                      'user prompt context role label junk should not inject',
+                      0.95, 0.9, 'active', 'general', 'uncategorized', ?1, ?1)",
+                    rusqlite::params![now],
+                )?;
+                Ok(serde_json::Value::Null)
+            })
+            .await
+            .unwrap();
+
+        let resp = prompt_submit(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(PromptSubmitBody {
+                harness: Some("test".to_string()),
+                project: Some("platform/daemon-rs".to_string()),
+                agent_id: Some("agent-a".to_string()),
+                user_message: Some("tell the user about prompt context".to_string()),
+                user_prompt: None,
+                last_assistant_message: None,
+                session_key: Some("sess-prompt-role-label-entity".to_string()),
                 transcript: None,
                 transcript_path: None,
                 runtime_path: None,

--- a/platform/daemon/src/hooks.prompt-submit.test.ts
+++ b/platform/daemon/src/hooks.prompt-submit.test.ts
@@ -266,9 +266,8 @@ describe("handleUserPromptSubmit entity context", () => {
 
 		expect(result.engine).toBe("entity-context");
 		expect(result.inject).toContain("## Relevant Entity Context");
-		expect(result.inject).toContain("[constraint] Signet / architecture / runtime / fallback_policy");
-		expect(result.inject).toContain("Do not use generic fallback injection.");
 		expect(result.inject).toContain("[attribute] Signet / architecture / runtime / prompt_context");
+		expect(result.inject).not.toContain("[constraint] Signet / architecture / runtime / fallback_policy");
 		expect(result.inject).not.toContain("Stale prompt context should not be injected.");
 		expect(result.inject).not.toContain("## Relevant Memory");
 		expect(result.inject).not.toContain("Marketing copy should stay secondary");
@@ -455,6 +454,165 @@ describe("handleUserPromptSubmit entity context", () => {
 
 		expect(result.engine).toBe("no-entity");
 		expect(result.inject).not.toContain("Claude Code connector / runtime");
+	});
+
+	it("ignores generic role-label person entities for prompt context", async () => {
+		getDbAccessor().withWriteTx((db) => {
+			const now = "2026-05-27T00:00:00.000Z";
+			db.prepare(
+				`INSERT INTO entities
+				 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+				 VALUES ('entity-user-role', 'User', 'user', 'person', 'default', 2000, ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO entity_aspects
+				 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+				 VALUES ('aspect-user-general', 'entity-user-role', 'default', 'general', 'general', 1, ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO entity_attributes
+				 (id, aspect_id, agent_id, kind, content, normalized_content, group_key, claim_key,
+				  confidence, importance, status, created_at, updated_at)
+				 VALUES ('attr-user-role-context', 'aspect-user-general', 'default', 'attribute',
+				  'User prompt context role-label junk should not inject.',
+				  'user prompt context role label junk should not inject',
+				  'general', 'uncategorized', 0.9, 0.9, 'active', ?, ?)`,
+			).run(now, now);
+		});
+
+		const result = await handleUserPromptSubmit(
+			{
+				harness: "codex",
+				userMessage: "tell the user about prompt context",
+				sessionKey: "session-role-label-entity",
+			},
+			makeDeps(),
+		);
+
+		expect(result.engine).toBe("no-entity");
+		expect(result.inject).not.toContain("User / general");
+	});
+
+	it("does not inject broad general uncategorized entity attributes", async () => {
+		seedEntityContext();
+		getDbAccessor().withWriteTx((db) => {
+			const now = "2026-05-27T00:00:00.000Z";
+			db.prepare(
+				`INSERT INTO entity_aspects
+				 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+				 VALUES ('aspect-signet-general', 'entity-signet', 'default', 'general', 'general', 1, ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO entity_attributes
+				 (id, aspect_id, agent_id, kind, content, normalized_content, group_key, claim_key,
+				  confidence, importance, status, created_at, updated_at)
+				 VALUES ('attr-signet-general-junk', 'aspect-signet-general', 'default', 'constraint',
+				  'Prompt context junk from general uncategorized should not inject.',
+				  'prompt context junk from general uncategorized should not inject',
+				  'general', 'uncategorized', 0.99, 1, 'active', ?, ?)`,
+			).run(now, now);
+		});
+		fetchEmbeddingMock.mockImplementationOnce(async () => [1, 0]);
+
+		const result = await handleUserPromptSubmit(
+			{
+				harness: "codex",
+				userMessage: "Signet prompt context",
+				sessionKey: "session-general-uncategorized-filter",
+			},
+			makeDeps(),
+		);
+
+		expect(result.engine).toBe("entity-context");
+		expect(result.inject).toContain("Signet / architecture / runtime / prompt_context");
+		expect(result.inject).not.toContain("Signet / general / general / uncategorized");
+		expect(result.inject).not.toContain("Prompt context junk from general uncategorized");
+	});
+
+	it("strips all selected entity terms from semantic attribute queries", async () => {
+		seedEntityContext();
+		getDbAccessor().withWriteTx((db) => {
+			const now = "2026-05-27T00:00:00.000Z";
+			db.prepare(
+				`INSERT INTO entities
+				 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+				 VALUES ('entity-nicholai', 'Nicholai', 'nicholai', 'person', 'default', 10, ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO entity_aspects
+				 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+				 VALUES ('aspect-nicholai-collaboration', 'entity-nicholai', 'default',
+				  'collaboration', 'collaboration', 1, ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO entity_attributes
+				 (id, aspect_id, agent_id, kind, content, normalized_content, group_key, claim_key,
+				  confidence, importance, status, created_at, updated_at)
+				 VALUES ('attr-nicholai-collaboration-style', 'aspect-nicholai-collaboration',
+				  'default', 'attribute', 'Collaboration style prefers direct artifact-first work.',
+				  'collaboration style prefers direct artifact first work',
+				  'working_style', 'style_summary', 0.9, 0.9, 'active', ?, ?)`,
+			).run(now, now);
+		});
+		fetchEmbeddingMock.mockImplementation(async () => [0, 0]);
+
+		await handleUserPromptSubmit(
+			{
+				harness: "codex",
+				userMessage: "Signet Nicholai collaboration style",
+				sessionKey: "session-strip-all-entities",
+			},
+			makeDeps(),
+		);
+
+		expect(fetchEmbeddingMock.mock.calls.map((call) => call[0])).toEqual([
+			"collaboration style",
+			"collaboration style",
+		]);
+	});
+
+	it("requires lexical support for generic prompt context semantic hits", async () => {
+		getDbAccessor().withWriteTx((db) => {
+			const now = "2026-05-27T00:00:00.000Z";
+			db.prepare(
+				`INSERT INTO entities
+				 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+				 VALUES ('entity-nicholai', 'Nicholai', 'nicholai', 'person', 'default', 10, ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO entity_aspects
+				 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+				 VALUES ('aspect-nicholai-projects', 'entity-nicholai', 'default', 'projects', 'projects', 1, ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO entity_attributes
+				 (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, group_key, claim_key,
+				  confidence, importance, status, created_at, updated_at)
+				 VALUES ('attr-nicholai-compass', 'aspect-nicholai-projects', 'default', 'mem-nicholai-compass',
+				  'attribute', 'Compass is an active client project management tool.',
+				  'compass is an active client project management tool',
+				  'active_projects', 'compass', 0.9, 0.9, 'active', ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO embeddings
+				 (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
+				 VALUES ('emb-nicholai-compass', 'hash-nicholai-compass', ?, 2, 'memory',
+				  'mem-nicholai-compass', 'Compass is an active client project management tool.', ?, 'default')`,
+			).run(vectorToBlob([1, 0]), now);
+		});
+		fetchEmbeddingMock.mockImplementationOnce(async () => [1, 0]);
+
+		const result = await handleUserPromptSubmit(
+			{
+				harness: "codex",
+				userMessage: "Nicholai prompt context",
+				sessionKey: "session-generic-context-semantic-gate",
+			},
+			makeDeps(),
+		);
+
+		expect(result.engine).toBe("no-aspect-hit");
+		expect(result.inject).not.toContain("Compass is an active client project management tool.");
 	});
 
 	it("ignores low-quality generic entity collisions when a stronger entity is present", async () => {

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -830,6 +830,16 @@ function entityContextTablesAvailable(db: ReadDb): boolean {
 }
 
 const PROMPT_ENTITY_CONTEXT_ALLOWED_TYPES = new Set(["person", "project"]);
+const PROMPT_ROLE_ENTITY_DENY_TERMS = new Set(["assistant", "human", "user"]);
+const PROMPT_GENERIC_CONTEXT_QUERY_TERMS = new Set([
+	"context",
+	"contexts",
+	"current",
+	"prompt",
+	"relevant",
+	"view",
+	"views",
+]);
 
 function isPromptEntityContextTypeAllowed(entityType: string): boolean {
 	return PROMPT_ENTITY_CONTEXT_ALLOWED_TYPES.has(entityType.toLowerCase());
@@ -840,6 +850,35 @@ function isPromptGenericEntityPhrase(phraseTerms: readonly string[]): boolean {
 	const term = phraseTerms[0] ?? "";
 	if (PROMPT_BARE_POSSESSIVE_DENY_TERMS.has(term)) return true;
 	return term.endsWith("s") && PROMPT_BARE_POSSESSIVE_DENY_TERMS.has(term.slice(0, -1));
+}
+
+function isPromptRoleEntity(row: {
+	readonly entity_name: string;
+	readonly matched_text: string;
+	readonly pinned: number;
+}): boolean {
+	if (Math.min(Math.max(0, row.pinned), 1) > 0) return false;
+	const entityTerms = promptEntityTerms(row.entity_name);
+	const matchedTerms = promptEntityTerms(row.matched_text);
+	if (entityTerms.length !== 1 || matchedTerms.length !== 1) return false;
+	return (
+		PROMPT_ROLE_ENTITY_DENY_TERMS.has(entityTerms[0] ?? "") && PROMPT_ROLE_ENTITY_DENY_TERMS.has(matchedTerms[0] ?? "")
+	);
+}
+
+function isPromptBroadUncategorizedAttribute(row: {
+	readonly aspect_name: string;
+	readonly group_key: string | null;
+	readonly claim_key: string | null;
+}): boolean {
+	return (
+		normalizePromptEntityText(row.group_key ?? "general") === "general" &&
+		normalizePromptEntityText(row.claim_key ?? "uncategorized") === "uncategorized"
+	);
+}
+
+function isPromptGenericContextQuery(promptTerms: ReadonlyArray<string>): boolean {
+	return promptTerms.length > 0 && promptTerms.every((term) => PROMPT_GENERIC_CONTEXT_QUERY_TERMS.has(term));
 }
 
 function scorePromptEntityCandidate(row: {
@@ -905,6 +944,7 @@ function resolvePromptEntityMatches(db: ReadDb, agentId: string, userMessage: st
 	const candidatesByPhrase = new Map<string, PromptEntityCandidate[]>();
 	for (const row of rows) {
 		if (!isPromptEntityContextTypeAllowed(row.entity_type)) continue;
+		if (isPromptRoleEntity(row)) continue;
 		if (isPromptGenericEntityPhrase(promptEntityTerms(row.matched_text))) continue;
 		const span = promptPhraseSpan(userMessage, row.matched_text);
 		if (!span) continue;
@@ -1104,37 +1144,48 @@ function loadEntityContextLines(
 	const semanticScores = loadAttributeSemanticScores(
 		db,
 		agentId,
-		candidateRows.map((row) => ({ attributeId: row.attribute_id, memoryId: row.memory_id })),
+		candidateRows
+			.filter((row) => !isPromptBroadUncategorizedAttribute(row))
+			.map((row) => ({ attributeId: row.attribute_id, memoryId: row.memory_id })),
 		queryVector,
 	);
+	const genericContextQuery = isPromptGenericContextQuery(promptTerms);
 	const candidates: PromptAttributeCandidate[] = candidateRows
-		.map((row) => ({
-			attributeId: row.attribute_id,
-			aspectId: row.aspect_id,
-			entityName: entity.entityName,
-			aspectName: row.aspect_name,
-			groupKey: row.group_key,
-			claimKey: row.claim_key,
-			kind: row.kind,
-			content: row.content,
-			confidence: row.confidence,
-			importance: row.importance,
-			sourceKind: row.source_kind,
-			sourceId: row.source_id,
-			sourcePath: row.source_path,
-			memoryId: row.memory_id,
-			version: row.version,
-			score: Math.max(semanticScores.get(row.attribute_id) ?? 0, scoreAttributeLexically(row, promptTerms)),
-		}))
+		.filter((row) => !isPromptBroadUncategorizedAttribute(row))
+		.map((row) => {
+			const lexicalScore = scoreAttributeLexically(row, promptTerms);
+			const semanticScore = semanticScores.get(row.attribute_id) ?? 0;
+			return {
+				attributeId: row.attribute_id,
+				aspectId: row.aspect_id,
+				entityName: entity.entityName,
+				aspectName: row.aspect_name,
+				groupKey: row.group_key,
+				claimKey: row.claim_key,
+				kind: row.kind,
+				content: row.content,
+				confidence: row.confidence,
+				importance: row.importance,
+				sourceKind: row.source_kind,
+				sourceId: row.source_id,
+				sourcePath: row.source_path,
+				memoryId: row.memory_id,
+				version: row.version,
+				score: genericContextQuery && lexicalScore === 0 ? 0 : Math.max(semanticScore, lexicalScore),
+			};
+		})
 		.filter((row) => row.score >= minScore)
 		.sort((a, b) => b.score - a.score || b.importance - a.importance);
 	const selectedAspectIds = new Set<string>();
+	const selectedAttributeIds = new Set<string>();
 	for (const candidate of candidates) {
 		selectedAspectIds.add(candidate.aspectId);
+		selectedAttributeIds.add(candidate.attributeId);
 		if (selectedAspectIds.size >= ENTITY_CONTEXT_MAX_ASPECTS_PER_ENTITY) break;
 	}
 	if (selectedAspectIds.size === 0) return [];
 	const placeholders = [...selectedAspectIds].map(() => "?").join(", ");
+	const attributePlaceholders = [...selectedAttributeIds].map(() => "?").join(", ");
 	const rows = db
 		.prepare(
 			`SELECT
@@ -1153,6 +1204,7 @@ function loadEntityContextLines(
 			 FROM entity_attributes ea
 			 JOIN entity_aspects asp ON asp.id = ea.aspect_id
 			 WHERE ea.aspect_id IN (${placeholders})
+			   AND ea.id IN (${attributePlaceholders})
 			   AND ea.agent_id = ?
 			   AND ea.status = 'active'
 			   AND ea.superseded_by IS NULL
@@ -1174,7 +1226,7 @@ function loadEntityContextLines(
 			   ea.updated_at DESC
 			 LIMIT ?`,
 		)
-		.all(...selectedAspectIds, agentId, ENTITY_CONTEXT_MAX_LINES) as Array<{
+		.all(...selectedAspectIds, ...selectedAttributeIds, agentId, ENTITY_CONTEXT_MAX_LINES) as Array<{
 		aspect_name: string;
 		kind: "attribute" | "constraint";
 		content: string;
@@ -1188,21 +1240,23 @@ function loadEntityContextLines(
 		memory_id: string | null;
 		version: number;
 	}>;
-	return rows.map((row) => ({
-		entityName: entity.entityName,
-		aspectName: row.aspect_name,
-		groupKey: row.group_key,
-		claimKey: row.claim_key,
-		kind: row.kind,
-		content: row.content,
-		confidence: row.confidence,
-		importance: row.importance,
-		sourceKind: row.source_kind,
-		sourceId: row.source_id,
-		sourcePath: row.source_path,
-		memoryId: row.memory_id,
-		version: row.version,
-	}));
+	return rows
+		.filter((row) => !isPromptBroadUncategorizedAttribute(row))
+		.map((row) => ({
+			entityName: entity.entityName,
+			aspectName: row.aspect_name,
+			groupKey: row.group_key,
+			claimKey: row.claim_key,
+			kind: row.kind,
+			content: row.content,
+			confidence: row.confidence,
+			importance: row.importance,
+			sourceKind: row.source_kind,
+			sourceId: row.source_id,
+			sourcePath: row.source_path,
+			memoryId: row.memory_id,
+			version: row.version,
+		}));
 }
 
 function formatEntityContextLine(line: PromptEntityContextLine): string {
@@ -1238,8 +1292,9 @@ async function buildEntityPromptContext(
 		string,
 		{ readonly semanticQuery: string; readonly queryVector: Float32Array | null }
 	>();
+	const sharedSemanticQuery = queryWithoutPromptEntities(userMessage, matches);
 	for (const entity of matches) {
-		const semanticQuery = queryWithoutPromptEntities(userMessage, [entity]);
+		const semanticQuery = sharedSemanticQuery;
 		if (!semanticQuery) continue;
 		let queryVector: Float32Array | null = null;
 		try {


### PR DESCRIPTION
## Summary
- suppress unpinned generic role-label person entities like `User` and `Assistant` during prompt entity matching
- strip all selected entity terms from the shared semantic attribute query for multi-entity prompts
- filter broad `general` / `uncategorized` attributes and only expand attributes that actually cleared the relevance gate
- require lexical support for generic prompt-context queries so semantic-only noise does not inject unrelated entity rows
- keep daemon-rs prompt-submit behavior in parity with the TypeScript daemon path

## Dogfood
Live daemon rebuilt from this branch and restarted with `signet daemon restart --no-sync`.

Observed prompt-submit matrix:
- `tell the user about prompt context` -> `no-entity`
- `user prompt context` -> `no-entity`
- `assistant prompt context` -> `no-entity`
- `what should assistant do about prompt context` -> `no-entity`
- `signet prompt context` -> `no-aspect-hit`
- `signets prompt context` -> `no-aspect-hit`
- `tell me about signet context sources` -> `no-aspect-hit`
- `signet and nicholai prompt context` -> one focused Nicholai Signet project row, no role-label or broad uncategorized rows
- `signet nicholai collaboration style` -> one focused Nicholai collaboration-style row
- `nicholai collaboration style` -> one focused Nicholai collaboration-style row
- `nicholais timezone` -> one focused Nicholai timezone row
- `projects roadmap`, `agents are useful`, `tools setup`, `claude code connector setup`, `context` -> `no-entity`

## Validation
- `bunx biome check platform/daemon/src/hooks.ts platform/daemon/src/hooks.prompt-submit.test.ts`
- `bun test platform/daemon/src/hooks.prompt-submit.test.ts` - 21 pass
- `cargo fmt --check`
- `cargo test -p signet-daemon prompt_submit` - 17 pass
- `bun run build:signetai`
- live daemon restart + prompt-submit dogfood matrix against `http://127.0.0.1:3850/api/hooks/user-prompt-submit`

## Rollback / Compatibility
No migrations or API contract changes. This only tightens prompt-submit entity context selection and keeps existing silent outcomes for missing or low-relevance entity context.

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)
- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description
