### PR TITLE
fix(memory): queue aggregate recall extraction

### DIFF
--- a/platform/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/platform/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -316,6 +316,7 @@ fn load_guarded_transcript_path(
 /// truncated with a `[truncated]` marker before artifact / DB writes.
 const MAX_TRANSCRIPT_BYTES: usize = 400_000; // ~100k chars * 4 bytes/char (UTF-8 worst case)
 const MIN_PROMPT_ENTITY_MATCH_CHARS: usize = 3;
+const ENTITY_CONTEXT_MAX_ATTRIBUTES_PER_ASPECT: i64 = 48;
 
 /// Normalize a caller-supplied project path so lineage lookups use a
 /// consistent key.  Mirrors session-start project normalization:
@@ -1607,7 +1608,9 @@ pub async fn prompt_submit(
                 for (aspect_id, aspect_name, _canonical_name, _weight) in aspects {
                     let generic_context_query = prompt_generic_context_query(&context_terms);
                     let attr_rows = match conn.prepare(
-                        "SELECT ea.id, ea.content, COALESCE(ea.memory_id, ''), ea.confidence, ea.importance
+                        "SELECT ea.id, ea.content, COALESCE(ea.memory_id, ''),
+                                COALESCE(ea.group_key, ''), COALESCE(ea.claim_key, ''),
+                                ea.confidence, ea.importance
                          FROM entity_attributes ea
                          WHERE ea.aspect_id = ?1
                            AND ea.agent_id = ?2
@@ -1628,21 +1631,24 @@ pub async fn prompt_submit(
                                AND COALESCE(newer.version, 1) > COALESCE(ea.version, 1)
                            )
                          ORDER BY ea.importance DESC, ea.updated_at DESC
-                         LIMIT 12",
+                         LIMIT ?3",
                     ) {
                         Ok(mut stmt) => stmt
                             .query_map(
                                 rusqlite::params![
                                     aspect_id,
-                                    agent_id.clone()
+                                    agent_id.clone(),
+                                    ENTITY_CONTEXT_MAX_ATTRIBUTES_PER_ASPECT
                                 ],
                                 |row| {
                                 Ok((
                                     row.get::<_, String>(0)?,
                                     row.get::<_, String>(1)?,
                                     row.get::<_, String>(2)?,
-                                    row.get::<_, f64>(3)?,
-                                    row.get::<_, f64>(4)?,
+                                    row.get::<_, String>(3)?,
+                                    row.get::<_, String>(4)?,
+                                    row.get::<_, f64>(5)?,
+                                    row.get::<_, f64>(6)?,
                                 ))
                                 },
                             )
@@ -1656,13 +1662,29 @@ pub async fn prompt_submit(
                     }
                     let matched_attr_ids = attr_rows
                         .iter()
-                        .filter_map(|(attr_id, content, memory_id, confidence, importance)| {
+                        .filter_map(|(attr_id, content, memory_id, group, claim, confidence, importance)| {
                             let attr_text = normalize_prompt_entity_text(content);
-                            let lexical_score = if attr_text
+                            let group_text = normalize_prompt_entity_text(group);
+                            let claim_text = normalize_prompt_entity_text(claim);
+                            let content_overlap = attr_text
                                 .split_whitespace()
-                                .any(|term| context_terms.contains(term))
-                            {
-                                0.72 + importance.clamp(0.0, 1.0) * 0.18
+                                .any(|term| context_terms.contains(term));
+                            let claim_overlap = claim_text
+                                .split_whitespace()
+                                .filter(|term| context_terms.contains(*term))
+                                .count();
+                            let group_overlap = if claim_overlap > 0 {
+                                group_text
+                                    .split_whitespace()
+                                    .filter(|term| context_terms.contains(*term))
+                                    .count()
+                            } else {
+                                0
+                            };
+                            let path_overlap = claim_overlap + group_overlap > 0;
+                            let lexical_score = if content_overlap || path_overlap {
+                                let base = if path_overlap { 0.8 } else { 0.72 };
+                                base + importance.clamp(0.0, 1.0) * 0.18
                                     + confidence.clamp(0.0, 1.0) * 0.1
                             } else {
                                 0.0
@@ -4425,6 +4447,70 @@ mod tests {
             serde_json::Value::String("no-entity".to_string())
         );
         assert_eq!(body["inject"], serde_json::Value::String(String::new()));
+
+        drop(state);
+        let _ = writer.await;
+    }
+
+    #[tokio::test]
+    async fn prompt_submit_uses_structured_path_terms_for_zero_confidence_attributes() {
+        let (state, writer, _tmp) = test_state("hooks-prompt-submit-path-terms");
+        state
+            .pool
+            .write(Priority::Low, move |conn| {
+                let now = "2026-05-27T00:00:00Z";
+                conn.execute(
+                    "INSERT INTO entities (id, name, canonical_name, entity_type, description, agent_id, mentions, created_at, updated_at)
+                     VALUES ('entity-nicholai', 'Nicholai', 'nicholai', 'person', NULL, 'agent-a', 10, ?1, ?1)",
+                    rusqlite::params![now],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_aspects (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+                     VALUES ('aspect-nicholai-preferences', 'entity-nicholai', 'agent-a', 'preferences', 'preferences', 1.0, ?1, ?1)",
+                    rusqlite::params![now],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_attributes
+                     (id, aspect_id, agent_id, memory_id, kind, content, normalized_content, confidence, importance,
+                      status, group_key, claim_key, created_at, updated_at)
+                     VALUES ('attr-nicholai-favorite-pens', 'aspect-nicholai-preferences', 'agent-a', NULL, 'attribute',
+                      'Nicholai prefers Pilot G-2 0.7 mm, Pilot G-TEC-C4, and Pilot Razor Point II pens.',
+                      'nicholai prefers pilot g 2 0 7 mm pilot g tec c4 and pilot razor point ii pens',
+                      0.0, 0.0, 'active', 'writing_tools', 'favorite_pens', ?1, ?1)",
+                    rusqlite::params![now],
+                )?;
+                Ok(serde_json::Value::Null)
+            })
+            .await
+            .unwrap();
+
+        let resp = prompt_submit(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(PromptSubmitBody {
+                harness: Some("test".to_string()),
+                project: Some("platform/daemon-rs".to_string()),
+                agent_id: Some("agent-a".to_string()),
+                user_message: Some("what are nicholais favorite pens?".to_string()),
+                user_prompt: None,
+                last_assistant_message: None,
+                session_key: Some("sess-prompt-path-terms".to_string()),
+                transcript: None,
+                transcript_path: None,
+                runtime_path: None,
+            }),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = test_json(resp).await;
+        assert_eq!(
+            body["engine"],
+            serde_json::Value::String("entity-context".to_string())
+        );
+        let inject = body["inject"].as_str().unwrap_or_default();
+        assert!(inject.contains("Nicholai / preferences / writing_tools / favorite_pens"));
+        assert!(inject.contains("Pilot G-2 0.7 mm"));
 
         drop(state);
         let _ = writer.await;

--- a/platform/daemon/src/aggregate-recall.test.ts
+++ b/platform/daemon/src/aggregate-recall.test.ts
@@ -267,13 +267,21 @@ describe("aggregateRecall", () => {
 		]);
 
 		const saved = getDbAccessor().withReadDb((db) =>
-			db.prepare("SELECT source_type, idempotency_key, tags, who, type FROM memories WHERE id = ?").get("aggregate-1"),
+			db
+				.prepare("SELECT source_type, idempotency_key, tags, who, type, extraction_status FROM memories WHERE id = ?")
+				.get("aggregate-1"),
 		) as Record<string, unknown>;
 		expect(saved.source_type).toBe("aggregate-recall");
 		expect(saved.idempotency_key).toStartWith("aggregate-recall:");
 		expect(saved.tags).toBe("aggregate,recall");
 		expect(saved.who).toBe("signet");
 		expect(saved.type).toBe("semantic");
+		expect(saved.extraction_status).toBe("none");
+
+		const extractJob = getDbAccessor().withReadDb((db) =>
+			db.prepare("SELECT job_type, status FROM memory_jobs WHERE memory_id = ?").get("aggregate-1"),
+		) as Record<string, unknown>;
+		expect(extractJob).toEqual({ job_type: "extract", status: "pending" });
 
 		const links = getDbAccessor().withReadDb((db) =>
 			db
@@ -346,8 +354,12 @@ memory:
 			"Aggregate recall can synthesize directly through an OpenAI-compatible API target.",
 		);
 		expect(chatCalls).toBe(2);
-		expect(seen.every((entry) => entry.authorization === "Bearer test-openai-compatible-key")).toBe(true);
-		expect(seen.map((entry) => entry.url)).toEqual([
+		expect(
+			seen
+				.filter((entry) => entry.url.endsWith("/chat/completions"))
+				.every((entry) => entry.authorization === "Bearer test-openai-compatible-key"),
+		).toBe(true);
+		expect(seen.map((entry) => entry.url).filter((url) => url.startsWith("https://gateway.example.test/"))).toEqual([
 			"https://gateway.example.test/v1/models",
 			"https://gateway.example.test/v1/chat/completions",
 			"https://gateway.example.test/v1/chat/completions",
@@ -940,12 +952,14 @@ memory:
 				.prepare(
 					`SELECT
 						(SELECT COUNT(*) FROM memories WHERE id = 'aggregate-loser') AS loser_count,
-						(SELECT COUNT(*) FROM aggregate_memory_sources WHERE aggregate_memory_id = 'aggregate-race-winner') AS link_count`,
+						(SELECT COUNT(*) FROM aggregate_memory_sources WHERE aggregate_memory_id = 'aggregate-race-winner') AS link_count,
+						(SELECT COUNT(*) FROM memory_jobs WHERE memory_id = 'aggregate-race-winner' AND job_type = 'extract' AND status = 'pending') AS pending_extract_count`,
 				)
 				.get(),
-		) as { loser_count: number; link_count: number };
+		) as { loser_count: number; link_count: number; pending_extract_count: number };
 		expect(rows.loser_count).toBe(0);
 		expect(rows.link_count).toBe(1);
+		expect(rows.pending_extract_count).toBe(1);
 	});
 
 	it("returns structured no-hit metadata when synthesis is unavailable", async () => {

--- a/platform/daemon/src/aggregate-recall.ts
+++ b/platform/daemon/src/aggregate-recall.ts
@@ -15,6 +15,7 @@ import {
 	type RecallTimings,
 	hybridRecall,
 } from "./memory-search";
+import { enqueueExtractionJobInTx } from "./pipeline/extraction-queue";
 import { type IngestEnvelope, txIngestEnvelope } from "./transactions";
 
 export type AggregateRecallBudget = "small" | "medium" | "large";
@@ -759,6 +760,7 @@ export async function aggregateRecall(
 				if (duplicate) {
 					deduped = true;
 					saved = duplicate.saved;
+					if (duplicate.saved) enqueueExtractionJobInTx(db, duplicate.row.id);
 					return duplicate.row;
 				}
 				const id = deps.idFactory?.() ?? randomUUID();
@@ -808,10 +810,12 @@ export async function aggregateRecall(
 					}
 					deduped = true;
 					saved = racedDuplicate.saved;
+					if (racedDuplicate.saved) enqueueExtractionJobInTx(db, racedDuplicate.row.id);
 					return racedDuplicate.row;
 				}
 				linkAggregateSources(db, id, sourceMemoryIds, agentId, now);
 				linkAggregateQueryHint(db, id, agentId, params.query, now);
+				enqueueExtractionJobInTx(db, id);
 				saved = true;
 				return loadAggregateMemory(db, id);
 			}),

--- a/platform/daemon/src/hooks.prompt-submit.test.ts
+++ b/platform/daemon/src/hooks.prompt-submit.test.ts
@@ -303,6 +303,46 @@ describe("handleUserPromptSubmit entity context", () => {
 		expect(result.inject).not.toContain("## Relevant Memory");
 	});
 
+	it("uses structured path terms to select zero-confidence curated attributes", async () => {
+		getDbAccessor().withWriteTx((db) => {
+			const now = "2026-05-27T00:00:00.000Z";
+			db.prepare(
+				`INSERT INTO entities
+				 (id, name, canonical_name, entity_type, agent_id, mentions, created_at, updated_at)
+				 VALUES ('entity-nicholai', 'Nicholai', 'nicholai', 'person', 'default', 10, ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO entity_aspects
+				 (id, entity_id, agent_id, name, canonical_name, weight, created_at, updated_at)
+				 VALUES ('aspect-nicholai-preferences', 'entity-nicholai', 'default',
+				  'preferences', 'preferences', 1, ?, ?)`,
+			).run(now, now);
+			db.prepare(
+				`INSERT INTO entity_attributes
+				 (id, aspect_id, agent_id, kind, content, normalized_content, group_key, claim_key,
+				  confidence, importance, status, created_at, updated_at)
+				 VALUES ('attr-nicholai-favorite-pens', 'aspect-nicholai-preferences',
+				  'default', 'attribute',
+				  'Nicholai prefers Pilot G-2 0.7 mm, Pilot G-TEC-C4, and Pilot Razor Point II pens.',
+				  'nicholai prefers pilot g 2 0 7 mm pilot g tec c4 and pilot razor point ii pens',
+				  'writing_tools', 'favorite_pens', 0, 0, 'active', ?, ?)`,
+			).run(now, now);
+		});
+
+		const result = await handleUserPromptSubmit(
+			{
+				harness: "codex",
+				userMessage: "what are nicholais favorite pens?",
+				sessionKey: "session-structured-path-favorite-pens",
+			},
+			makeDeps(),
+		);
+
+		expect(result.engine).toBe("entity-context");
+		expect(result.inject).toContain("Nicholai / preferences / writing_tools / favorite_pens");
+		expect(result.inject).toContain("Pilot G-2 0.7 mm");
+	});
+
 	it("normalizes possessive entity matches to the dominant canonical entity", async () => {
 		seedEntityContext();
 		getDbAccessor().withWriteTx((db) => {

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -739,6 +739,7 @@ const LOW_SIGNAL_PROMPTS = new Set([
 const ENTITY_CONTEXT_MAX_ENTITIES = 2;
 const ENTITY_CONTEXT_MAX_ASPECTS_PER_ENTITY = 3;
 const ENTITY_CONTEXT_MAX_LINES = 8;
+const ENTITY_CONTEXT_MAX_ATTRIBUTE_CANDIDATES = 192;
 const MIN_PROMPT_ENTITY_MATCH_CHARS = 3;
 
 function normalizePromptEntityText(value: string): string {
@@ -1027,12 +1028,25 @@ function queryWithoutPromptEntities(userMessage: string, entities: ReadonlyArray
 }
 
 function scoreAttributeLexically(
-	row: { readonly content: string; readonly confidence: number; readonly importance: number },
+	row: {
+		readonly aspect_name: string;
+		readonly group_key: string | null;
+		readonly claim_key: string | null;
+		readonly content: string;
+		readonly confidence: number;
+		readonly importance: number;
+	},
 	promptTerms: ReadonlyArray<string>,
 ): number {
 	if (promptTerms.length === 0) return 0;
-	if (countPromptTermOverlap(row.content, promptTerms) === 0) return 0;
-	return Math.min(1, 0.72 + Math.min(row.importance, 1) * 0.18 + Math.min(row.confidence, 1) * 0.1);
+	const contentOverlap = countPromptTermOverlap(row.content, promptTerms);
+	const claimOverlap = countPromptTermOverlap(normalizePromptEntityText(row.claim_key ?? ""), promptTerms);
+	const groupOverlap =
+		claimOverlap > 0 ? countPromptTermOverlap(normalizePromptEntityText(row.group_key ?? ""), promptTerms) : 0;
+	const pathOverlap = claimOverlap > 0 ? claimOverlap + groupOverlap : 0;
+	if (contentOverlap === 0 && pathOverlap === 0) return 0;
+	const base = pathOverlap > 0 ? 0.8 : 0.72;
+	return Math.min(1, base + Math.min(row.importance, 1) * 0.18 + Math.min(row.confidence, 1) * 0.1);
 }
 
 function loadAttributeSemanticScores(
@@ -1123,9 +1137,9 @@ function loadEntityContextLines(
 			       AND COALESCE(newer.version, 1) > COALESCE(ea.version, 1)
 			   )
 			 ORDER BY ea.importance DESC, ea.updated_at DESC
-			 LIMIT 48`,
+			 LIMIT ?`,
 		)
-		.all(entity.entityId, agentId, agentId) as Array<{
+		.all(entity.entityId, agentId, agentId, ENTITY_CONTEXT_MAX_ATTRIBUTE_CANDIDATES) as Array<{
 		attribute_id: string;
 		aspect_id: string;
 		aspect_name: string;

--- a/platform/daemon/src/pipeline/extraction-queue.ts
+++ b/platform/daemon/src/pipeline/extraction-queue.ts
@@ -1,0 +1,41 @@
+import type { DbAccessor, WriteDb } from "../db-accessor";
+
+// ---------------------------------------------------------------------------
+// Job enqueue (called by daemon remember endpoint and other write surfaces)
+// ---------------------------------------------------------------------------
+
+export function enqueueExtractionJobInTx(db: WriteDb, memoryId: string): void {
+	// Skip if memory extraction is already complete (structured passthrough
+	// or prior pipeline run). This prevents re-processing memories that
+	// were ingested with pre-extracted data.
+	const mem = db.prepare("SELECT extraction_status FROM memories WHERE id = ? LIMIT 1").get(memoryId) as
+		| { extraction_status: string | null }
+		| undefined;
+	if (mem?.extraction_status === "complete" || mem?.extraction_status === "completed") return;
+
+	// Dedup: skip if a pending/leased job already exists
+	const existing = db
+		.prepare(
+			`SELECT 1 FROM memory_jobs
+				 WHERE memory_id = ? AND job_type = 'extract'
+				   AND status IN ('pending', 'leased')
+				 LIMIT 1`,
+		)
+		.get(memoryId);
+	if (existing) return;
+
+	const id = crypto.randomUUID();
+	const now = new Date().toISOString();
+	db.prepare(
+		`INSERT INTO memory_jobs
+			 (id, memory_id, job_type, status, attempts, max_attempts,
+			  created_at, updated_at)
+			 VALUES (?, ?, 'extract', 'pending', 0, ?, ?, ?)`,
+	).run(id, memoryId, 3, now, now);
+}
+
+export function enqueueExtractionJob(accessor: DbAccessor, memoryId: string): void {
+	accessor.withWriteTx((db) => {
+		enqueueExtractionJobInTx(db, memoryId);
+	});
+}

--- a/platform/daemon/src/pipeline/index.ts
+++ b/platform/daemon/src/pipeline/index.ts
@@ -31,7 +31,7 @@ import { type SummaryWorkerHandle, startSummaryWorker } from "./summary-worker";
 import { type SynthesisWorkerHandle, startSynthesisWorker } from "./synthesis-worker";
 import { type WorkerHandle, type WorkerProgressStats, type WorkerStats, startWorker } from "./worker";
 
-export { enqueueExtractionJob } from "./worker";
+export { enqueueExtractionJob } from "./extraction-queue";
 export type { WorkerStats } from "./worker";
 export { enqueueDocumentIngestJob } from "./document-worker";
 export {

--- a/platform/daemon/src/pipeline/summary-worker.ts
+++ b/platform/daemon/src/pipeline/summary-worker.ts
@@ -28,10 +28,10 @@ import { isNoiseSession } from "../session-noise";
 import { upsertSessionTranscript } from "../session-transcripts";
 import { upsertThreadHead } from "../thread-heads";
 import { addDreamingTokens } from "./dreaming";
+import { enqueueExtractionJobInTx } from "./extraction-queue";
 import { RateLimitExceededError } from "./provider";
 import { type SignificanceConfig, assessSignificance } from "./significance-gate";
 import { countTokens } from "./tokenizer";
-import { enqueueExtractionJobInTx } from "./worker";
 
 // ---------------------------------------------------------------------------
 // Types

--- a/platform/daemon/src/pipeline/worker.ts
+++ b/platform/daemon/src/pipeline/worker.ts
@@ -22,6 +22,7 @@ import type { DecisionConfig, FactDecisionProposal } from "./decision";
 import { runShadowDecisions } from "./decision";
 import { extractFactsAndEntities } from "./extraction";
 import { escalate } from "./extraction-escalation";
+import { enqueueExtractionJob, enqueueExtractionJobInTx } from "./extraction-queue";
 import { txPersistEntities } from "./graph-transactions";
 import { invalidateTraversalCache } from "./graph-traversal";
 import { enqueueHintsJob } from "./prospective-index";
@@ -156,45 +157,7 @@ function zeroWriteStats(): AppliedWriteStats {
 	};
 }
 
-// ---------------------------------------------------------------------------
-// Job enqueue (called by daemon remember endpoint)
-// ---------------------------------------------------------------------------
-
-export function enqueueExtractionJobInTx(db: WriteDb, memoryId: string): void {
-	// Skip if memory extraction is already complete (structured passthrough
-	// or prior pipeline run). This prevents re-processing memories that
-	// were ingested with pre-extracted data.
-	const mem = db.prepare("SELECT extraction_status FROM memories WHERE id = ? LIMIT 1").get(memoryId) as
-		| { extraction_status: string | null }
-		| undefined;
-	if (mem?.extraction_status === "complete" || mem?.extraction_status === "completed") return;
-
-	// Dedup: skip if a pending/leased job already exists
-	const existing = db
-		.prepare(
-			`SELECT 1 FROM memory_jobs
-				 WHERE memory_id = ? AND job_type = 'extract'
-				   AND status IN ('pending', 'leased')
-				 LIMIT 1`,
-		)
-		.get(memoryId);
-	if (existing) return;
-
-	const id = crypto.randomUUID();
-	const now = new Date().toISOString();
-	db.prepare(
-		`INSERT INTO memory_jobs
-			 (id, memory_id, job_type, status, attempts, max_attempts,
-			  created_at, updated_at)
-			 VALUES (?, ?, 'extract', 'pending', 0, ?, ?, ?)`,
-	).run(id, memoryId, 3, now, now);
-}
-
-export function enqueueExtractionJob(accessor: DbAccessor, memoryId: string): void {
-	accessor.withWriteTx((db) => {
-		enqueueExtractionJobInTx(db, memoryId);
-	});
-}
+export { enqueueExtractionJob, enqueueExtractionJobInTx } from "./extraction-queue";
 
 // ---------------------------------------------------------------------------
 // Lease a job atomically


### PR DESCRIPTION
## Summary

Queues ontology extraction for saved aggregate recall rows and tightens prompt-submit attribute selection so structured claim keys like `favorite_pens` can surface low-confidence curated attributes without reintroducing broad fallback injection.

## Changes

- Extracted pipeline job enqueueing into a shared daemon helper and used it when aggregate recall saves or reuses a saved aggregate row.
- Updated prompt entity context scoring to treat entity mention as scope and claim-key matches as the structured lexical trigger, with group keys only supporting claim hits.
- Raised the scoped attribute candidate pool so low-importance structured attributes are not excluded before scoring.
- Kept daemon-rs prompt-submit parity for structured path-term scoring and candidate bounds.
- Added regression coverage for aggregate extraction queueing and zero-confidence structured attribute injection.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: `platform/daemon-rs`

## Screenshots

N/A, no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`): no spec/dependency contract changes.
- [x] Agent scoping verified on all new/changed data queries.
- [x] Input/config validation and bounds checks added: candidate limits are explicit constants; no new external inputs.
- [x] Error handling and fallback paths tested (no silent swallow).
- [x] Security checks applied to admin/mutation endpoints: N/A, no admin or mutation endpoint added.
- [x] Docs updated for API/spec/status changes: N/A, no public API change.
- [x] Regression tests added for each bug fix.
- [x] Lint/typecheck/tests pass locally.

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

No migrations. Rollback removes aggregate extraction job enqueueing and returns prompt-submit selection to the previous content-only lexical path.

## Testing

- [x] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [x] Tested against running daemon
- [ ] N/A

Commands run:

```bash
bunx biome check platform/daemon/src/hooks.ts platform/daemon/src/hooks.prompt-submit.test.ts platform/daemon/src/aggregate-recall.ts platform/daemon/src/aggregate-recall.test.ts platform/daemon/src/pipeline/extraction-queue.ts platform/daemon/src/pipeline/worker.ts platform/daemon/src/pipeline/index.ts platform/daemon/src/pipeline/summary-worker.ts
bun test platform/daemon/src/hooks.prompt-submit.test.ts platform/daemon/src/aggregate-recall.test.ts platform/daemon/src/pipeline/worker.test.ts
cd platform/daemon-rs && cargo fmt --check && cargo test -p signet-daemon prompt_submit
bun run --filter '@signet/daemon' build
bun run build:signetai
signet daemon restart --no-sync
curl -fsS http://127.0.0.1:3850/health
```

Live dogfood after rebuild/restart:

- `what are nicholais favorite pens?` -> `engine: entity-context`, injected `Nicholai / preferences / writing_tools / favorite_pens`.
- `nicholai favorite pen` -> `engine: entity-context`, injected `favorite_pens`.
- `nicholai preferred pens` -> `engine: entity-context`, injected `favorite_pens`.
- `nicholai likes pilot g2 pens` -> `engine: entity-context`, injected `favorite_pens`.
- `context` -> `engine: no-entity`.
- `assistant prompt context` -> `engine: no-entity`.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

This intentionally keeps fallback injection silent. Aggregate recall can now feed ontology extraction, and prompt-submit can then pick scoped attributes by claim-key relevance without requiring literal aspect names in the user prompt.
