### PR TITLE
fix(daemon-rs): repair summary_jobs migration columns

### DIFF
--- a/platform/daemon-rs/crates/signet-core/src/migrations.rs
+++ b/platform/daemon-rs/crates/signet-core/src/migrations.rs
@@ -398,6 +398,8 @@ fn ensure_cross_daemon_parity_tables(conn: &Connection) -> Result<(), CoreError>
 }
 
 fn ensure_cross_daemon_parity_columns(conn: &Connection) -> Result<(), CoreError> {
+    ensure_summary_jobs_required_columns(conn)?;
+
     add_column_if_missing(conn, "entities", "mentions", "INTEGER NOT NULL DEFAULT 0")?;
     add_column_if_missing(conn, "entities", "pinned", "INTEGER NOT NULL DEFAULT 0")?;
     add_column_if_missing(conn, "entities", "pinned_at", "TEXT")?;
@@ -516,6 +518,39 @@ fn ensure_cross_daemon_parity_columns(conn: &Connection) -> Result<(), CoreError
         conn,
         TS_AGENT_SCOPED_IDEMPOTENCY_VERSION,
         TS_AGENT_SCOPED_IDEMPOTENCY_NAME,
+    )?;
+
+    Ok(())
+}
+
+fn ensure_summary_jobs_required_columns(conn: &Connection) -> Result<(), CoreError> {
+    for (column, typedef) in [
+        ("session_id", "TEXT"),
+        ("trigger", "TEXT NOT NULL DEFAULT 'session_end'"),
+        ("captured_at", "TEXT"),
+        ("started_at", "TEXT"),
+        ("ended_at", "TEXT"),
+        ("leased_at", "TEXT"),
+        ("updated_at", "TEXT"),
+        ("failed_at", "TEXT"),
+        ("agent_id", "TEXT NOT NULL DEFAULT 'default'"),
+    ] {
+        add_column_if_missing(conn, "summary_jobs", column, typedef)?;
+    }
+
+    conn.execute_batch(
+        "UPDATE summary_jobs
+            SET session_id = COALESCE(session_id, session_key, id),
+                trigger = COALESCE(NULLIF(trigger, ''), 'session_end'),
+                captured_at = COALESCE(captured_at, completed_at, created_at),
+                ended_at = COALESCE(ended_at, completed_at),
+                updated_at = COALESCE(updated_at, completed_at, created_at),
+                agent_id = COALESCE(NULLIF(agent_id, ''), 'default')
+          WHERE 1 = 1;
+         CREATE INDEX IF NOT EXISTS idx_summary_jobs_agent_trigger
+            ON summary_jobs(agent_id, trigger, created_at);
+         CREATE INDEX IF NOT EXISTS idx_summary_jobs_agent_session
+            ON summary_jobs(agent_id, session_key, created_at);",
     )?;
 
     Ok(())

--- a/platform/daemon-rs/crates/signet-core/tests/migrations.rs
+++ b/platform/daemon-rs/crates/signet-core/tests/migrations.rs
@@ -1,0 +1,72 @@
+use rusqlite::Connection;
+
+#[test]
+fn repairs_partial_summary_jobs_columns_when_migration_is_already_stamped() {
+    let conn = Connection::open_in_memory().expect("open in-memory db");
+    signet_core::migrations::run(&conn).expect("initial migrations run");
+    conn.execute_batch(
+        "DROP TABLE summary_jobs;
+         CREATE TABLE summary_jobs (
+            id TEXT PRIMARY KEY,
+            session_key TEXT,
+            harness TEXT NOT NULL,
+            project TEXT,
+            transcript TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            result TEXT,
+            attempts INTEGER DEFAULT 0,
+            max_attempts INTEGER DEFAULT 3,
+            created_at TEXT NOT NULL,
+            completed_at TEXT,
+            error TEXT,
+            agent_id TEXT NOT NULL DEFAULT 'default',
+            session_id TEXT,
+            trigger TEXT NOT NULL DEFAULT 'session_end',
+            captured_at TEXT,
+            started_at TEXT,
+            ended_at TEXT
+         );
+         INSERT INTO summary_jobs
+            (id, session_key, harness, transcript, status, created_at)
+         VALUES
+            ('job-partial', 'session-a', 'opencode', 'user: hi', 'pending', '2026-06-01T00:00:00Z');",
+    )
+    .expect("simulate partially applied migration 37");
+
+    signet_core::migrations::run(&conn).expect("rerun migrations repairs summary_jobs columns");
+
+    let mut stmt = conn
+        .prepare("PRAGMA table_info(summary_jobs)")
+        .expect("prepare table_info");
+    let columns: Vec<String> = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .expect("query table_info")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect table_info");
+    for column in ["leased_at", "updated_at", "failed_at"] {
+        assert!(
+            columns.iter().any(|name| name == column),
+            "summary_jobs should repair missing {column}"
+        );
+    }
+
+    let updated_at: String = conn
+        .query_row(
+            "SELECT updated_at FROM summary_jobs WHERE id = 'job-partial'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("read backfilled updated_at");
+    assert_eq!(updated_at, "2026-06-01T00:00:00Z");
+
+    conn.execute(
+        "UPDATE summary_jobs
+         SET status = 'leased',
+             leased_at = '2026-06-01T00:01:00Z',
+             updated_at = '2026-06-01T00:01:00Z',
+             attempts = attempts + 1
+         WHERE id = 'job-partial'",
+        [],
+    )
+    .expect("leased summary job update should succeed after repair");
+}


### PR DESCRIPTION
## Summary
- Adds an always-run Rust daemon schema repair for required `summary_jobs` columns, including `leased_at`, `updated_at`, and `failed_at`.
- Backfills `summary_jobs` runtime fields and recreates the agent/session indexes when an upgraded DB already has migration 37 stamped.
- Adds an integration regression test that simulates the partial migration-37 schema from #803 and verifies the leased-job update succeeds.

Closes #803

## Test Plan
- [x] `cd platform/daemon-rs && cargo fmt`
- [x] `cd platform/daemon-rs && cargo test -p signet-core --test migrations`
- [x] `cd platform/daemon-rs && cargo test -p signet-core`
- [x] `cd platform/daemon-rs && cargo test -p signet-pipeline summary::tests::recovers_leased_summary_jobs_in_batches`
- [x] `cd platform/daemon-rs && cargo test -p signet-daemon session_end_persists_transcript_artifact_and_queues_summary`
- [x] `cd platform/daemon-rs && cargo build -p signet-daemon`
- [x] `cd platform/daemon-rs && cargo test -p signet-daemon --test contract_replay hook_session_lifecycle -- --ignored --test-threads=1`
- [x] `git diff --check`

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

Applicability notes: this is a Rust daemon migration repair only. It adds no new API route, user-facing docs contract, admin endpoint, mutation endpoint, or agent-scoped data query.

## Migration Notes (if applicable)
- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Rollback / compatibility: the repair only adds missing nullable/defaulted columns that current Rust daemon session-summary code already expects. Existing DBs that already have the columns are unchanged; partial upgraded DBs self-heal on startup instead of failing `session-end` with `summary_jobs has no column named updated_at`.
