### PR TITLE
fix(daemon-rs): make transcript recapture idempotent

### DIFF
--- a/platform/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
+++ b/platform/daemon-rs/crates/signet-daemon/src/routes/hooks.rs
@@ -2245,6 +2245,12 @@ pub async fn session_end(
             }
             state.dedup.clear_session_start(&session_key);
             state.dedup.clear(&session_key);
+            warn!(
+                session = %session_key,
+                agent_id = %agent_id,
+                error = %e,
+                "session-end: transcript artifact write failed"
+            );
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(

--- a/platform/daemon-rs/crates/signet-pipeline/src/memory_lineage.rs
+++ b/platform/daemon-rs/crates/signet-pipeline/src/memory_lineage.rs
@@ -783,9 +783,16 @@ fn write_immutable_artifact(
         let current = read_string(&existing_frontmatter, "content_sha256");
         let next = read_string(&frontmatter, "content_sha256");
         if current == next {
+            let existing_body = normalize_markdown_body(&existing_body);
+            upsert_artifact_row(conn, root, &path, &existing_frontmatter, &existing_body)?;
             return Ok(path);
         }
         if normalize_markdown_body(&existing_body) != body {
+            if seed.kind == ArtifactKind::Transcript {
+                let existing_body = normalize_markdown_body(&existing_body);
+                upsert_artifact_row(conn, root, &path, &existing_frontmatter, &existing_body)?;
+                return Ok(path);
+            }
             return Err(format!(
                 "refusing to mutate immutable artifact {}",
                 path.display()

--- a/platform/daemon-rs/crates/signet-pipeline/tests/memory_lineage.rs
+++ b/platform/daemon-rs/crates/signet-pipeline/tests/memory_lineage.rs
@@ -1,0 +1,174 @@
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rusqlite::Connection;
+use signet_pipeline::memory_lineage::{
+    MemorySentence, SummaryArtifactInput, TranscriptArtifactInput, write_summary_artifact,
+    write_transcript_artifact,
+};
+
+fn temp_root(name: &str) -> PathBuf {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|value| value.as_nanos())
+        .unwrap_or(0);
+    let dir = std::env::temp_dir().join(format!(
+        "signet-lineage-{name}-{}-{now}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&dir).expect("create temp root");
+    dir
+}
+
+fn setup_conn() -> Connection {
+    let conn = Connection::open_in_memory().expect("open in-memory db");
+    signet_core::migrations::run(&conn).expect("run migrations");
+    conn
+}
+
+fn transcript_input(transcript: &str) -> TranscriptArtifactInput {
+    TranscriptArtifactInput {
+        agent_id: "default".to_string(),
+        session_id: "race-session".to_string(),
+        session_key: Some("race-session".to_string()),
+        project: Some("/work/signet".to_string()),
+        harness: Some("opencode".to_string()),
+        captured_at: "2026-06-01T01:45:42.236233+00:00".to_string(),
+        started_at: None,
+        ended_at: Some("2026-06-01T01:45:42.236233+00:00".to_string()),
+        transcript: transcript.to_string(),
+    }
+}
+
+fn summary_input(summary: &str) -> SummaryArtifactInput {
+    SummaryArtifactInput {
+        agent_id: "default".to_string(),
+        session_id: "race-session".to_string(),
+        session_key: Some("race-session".to_string()),
+        project: Some("/work/signet".to_string()),
+        harness: Some("opencode".to_string()),
+        captured_at: "2026-06-01T01:45:42.236233+00:00".to_string(),
+        started_at: None,
+        ended_at: Some("2026-06-01T01:45:42.236233+00:00".to_string()),
+        summary: summary.to_string(),
+    }
+}
+
+fn sentence() -> MemorySentence {
+    MemorySentence {
+        text: "Captured Signet session lineage artifact behavior.".to_string(),
+        quality: "ok".to_string(),
+        generated_at: "2026-06-01T01:45:42.236233+00:00".to_string(),
+    }
+}
+
+#[test]
+fn transcript_recapture_with_different_body_returns_existing_artifact() {
+    let conn = setup_conn();
+    let root = temp_root("transcript-recapture");
+
+    let first = write_transcript_artifact(
+        &conn,
+        &root,
+        transcript_input("User: first idle capture\nAssistant: ok"),
+    )
+    .expect("write first transcript");
+    let first_content = fs::read_to_string(root.join(&first.artifact_path))
+        .expect("read first transcript artifact");
+    conn.execute(
+        "DELETE FROM memory_artifacts WHERE source_path = ?1",
+        [&first.artifact_path],
+    )
+    .expect("simulate DB index missing after artifact file write");
+
+    let second = write_transcript_artifact(
+        &conn,
+        &root,
+        transcript_input("User: first idle capture\nUser: later message\nAssistant: ok"),
+    )
+    .expect("recapture should return existing transcript artifact");
+    let second_content = fs::read_to_string(root.join(&second.artifact_path))
+        .expect("read recaptured transcript artifact");
+
+    assert_eq!(second.artifact_path, first.artifact_path);
+    assert_eq!(second_content, first_content);
+    assert!(second_content.contains("first idle capture"));
+    assert!(!second_content.contains("later message"));
+    let indexed_content: String = conn
+        .query_row(
+            "SELECT content FROM memory_artifacts WHERE source_path = ?1",
+            [&first.artifact_path],
+            |row| row.get(0),
+        )
+        .expect("recapture should repair missing memory_artifacts row");
+    assert!(indexed_content.contains("first idle capture"));
+    assert!(!indexed_content.contains("later message"));
+
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn identical_transcript_recapture_repairs_missing_artifact_index() {
+    let conn = setup_conn();
+    let root = temp_root("transcript-identical-recapture");
+
+    let first = write_transcript_artifact(
+        &conn,
+        &root,
+        transcript_input("User: same idle capture\nAssistant: ok"),
+    )
+    .expect("write first transcript");
+    conn.execute(
+        "DELETE FROM memory_artifacts WHERE source_path = ?1",
+        [&first.artifact_path],
+    )
+    .expect("simulate DB index missing after artifact file write");
+
+    let second = write_transcript_artifact(
+        &conn,
+        &root,
+        transcript_input("User: same idle capture\nAssistant: ok"),
+    )
+    .expect("identical recapture should return existing transcript artifact");
+
+    assert_eq!(second.artifact_path, first.artifact_path);
+    let indexed_content: String = conn
+        .query_row(
+            "SELECT content FROM memory_artifacts WHERE source_path = ?1",
+            [&first.artifact_path],
+            |row| row.get(0),
+        )
+        .expect("identical recapture should repair missing memory_artifacts row");
+    assert!(indexed_content.contains("same idle capture"));
+
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn summary_collision_with_different_body_still_refuses_mutation() {
+    let conn = setup_conn();
+    let root = temp_root("summary-collision");
+
+    write_summary_artifact(
+        &conn,
+        &root,
+        summary_input("# Summary\n\nFirst body."),
+        sentence(),
+    )
+    .expect("write first summary");
+    let collision = write_summary_artifact(
+        &conn,
+        &root,
+        summary_input("# Summary\n\nDifferent body."),
+        sentence(),
+    );
+
+    assert!(
+        collision
+            .expect_err("summary mutation should remain strict")
+            .contains("refusing to mutate immutable artifact")
+    );
+
+    fs::remove_dir_all(root).ok();
+}


### PR DESCRIPTION
## Summary
- Treat same-path transcript recaptures with different bodies as idempotent in the Rust daemon lineage writer, returning the existing canonical transcript artifact instead of surfacing a spurious `session-end` 500.
- Preserve strict immutability for summary/compaction/manifest artifacts when the body differs.
- Add diagnostic logging for real transcript artifact write failures at the `session-end` HTTP boundary.
- Add integration regression tests for transcript recapture idempotency and summary collision refusal.

Closes #805

## Test Plan
- [x] `cd platform/daemon-rs && cargo fmt`
- [x] `cd platform/daemon-rs && cargo test -p signet-pipeline --test memory_lineage`
- [x] `cd platform/daemon-rs && cargo test -p signet-pipeline memory_lineage`
- [x] `cd platform/daemon-rs && cargo test -p signet-daemon session_end_persists_transcript_artifact_and_queues_summary`
- [x] `cd platform/daemon-rs && cargo build -p signet-daemon`
- [x] `cd platform/daemon-rs && cargo test -p signet-daemon --test contract_replay hook_session_lifecycle -- --ignored --test-threads=1`
- [x] `cd platform/daemon-rs && cargo test -p signet-pipeline`
- [x] `git diff --check`

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

Applicability notes: this changes Rust daemon artifact-write behavior only. It adds no new API route, schema migration, admin endpoint, mutation endpoint, or agent-scoped data query. The changed fallback/error path now logs session, agent id, and error context instead of relying only on the HTTP body.

## Migration Notes (if applicable)
- [x] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A
- [x] Rollback / compatibility note included in PR description

Rollback / compatibility: no database migration is included. The compatibility behavior is intentionally narrow: transcript artifacts become first-write-wins for repeated same-session recaptures, while summary/compaction/manifest artifacts still refuse same-path different-body mutation.
