### PR TITLE
fix(daemon-rs): embed memory writes

### DIFF
--- a/platform/daemon-rs/crates/signet-core/src/queries/embedding.rs
+++ b/platform/daemon-rs/crates/signet-core/src/queries/embedding.rs
@@ -36,6 +36,7 @@ pub struct InsertEmbedding<'a> {
     pub source_id: &'a str,
     pub chunk_text: &'a str,
     pub now: &'a str,
+    pub agent_id: Option<&'a str>,
 }
 
 /// Upsert an embedding row (idempotent via ON CONFLICT on content_hash).
@@ -45,15 +46,16 @@ pub fn upsert(conn: &Connection, e: &InsertEmbedding) -> Result<(), CoreError> {
 
     conn.execute(
         "INSERT INTO embeddings
-         (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at)
-         VALUES (?1,?2,?3,?4,?5,?6,?7,?8)
+         (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
+         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)
          ON CONFLICT(content_hash) DO UPDATE SET
            vector = excluded.vector,
            dimensions = excluded.dimensions,
            source_type = excluded.source_type,
            source_id = excluded.source_id,
            chunk_text = excluded.chunk_text,
-           created_at = excluded.created_at",
+           created_at = excluded.created_at,
+           agent_id = excluded.agent_id",
         params![
             e.id,
             e.content_hash,
@@ -62,7 +64,8 @@ pub fn upsert(conn: &Connection, e: &InsertEmbedding) -> Result<(), CoreError> {
             e.source_type,
             e.source_id,
             e.chunk_text,
-            e.now
+            e.now,
+            e.agent_id
         ],
     )?;
 

--- a/platform/daemon-rs/crates/signet-core/src/search.rs
+++ b/platform/daemon-rs/crates/signet-core/src/search.rs
@@ -909,6 +909,7 @@ mod tests {
             source_id: "m1",
             chunk_text: "Rust programming",
             now: "2024-01-01T00:00:00Z",
+            agent_id: Some("default"),
         };
         crate::queries::embedding::upsert(&conn, &emb).unwrap();
 

--- a/platform/daemon-rs/crates/signet-core/tests/embedding_upsert.rs
+++ b/platform/daemon-rs/crates/signet-core/tests/embedding_upsert.rs
@@ -1,0 +1,71 @@
+use rusqlite::{Connection, params};
+
+use signet_core::queries::embedding::{InsertEmbedding, upsert};
+use signet_core::search::vector_search;
+
+fn setup() -> Connection {
+    signet_core::db::register_vec_extension();
+    let conn = Connection::open_in_memory().expect("open in-memory db");
+    signet_core::db::configure_pragmas_pub(&conn).expect("configure pragmas");
+    signet_core::migrations::run(&conn).expect("run migrations");
+    signet_core::db::ensure_fts_pub(&conn).expect("ensure fts");
+    signet_core::db::ensure_vec_table_pub(&conn).expect("ensure vec table");
+    conn
+}
+
+#[test]
+fn upsert_embedding_stamps_agent_and_syncs_vec_index() {
+    let conn = setup();
+    conn.execute(
+        "INSERT INTO memories
+         (id, content, type, agent_id, created_at, updated_at, updated_by, importance)
+         VALUES (?1, ?2, 'fact', ?3, ?4, ?4, 'test', 0.5)",
+        params![
+            "mem-agent",
+            "Rust daemon embeds memories on write",
+            "agent-a",
+            "2026-06-01T00:00:00Z"
+        ],
+    )
+    .expect("insert memory");
+
+    let vector: Vec<f32> = (0..768).map(|i| (i as f32) / 768.0).collect();
+    upsert(
+        &conn,
+        &InsertEmbedding {
+            id: "memory:mem-agent",
+            content_hash: "memory:agent-a:mem-agent:hash",
+            vector: &vector,
+            source_type: "memory",
+            source_id: "mem-agent",
+            chunk_text: "Rust daemon embeds memories on write",
+            now: "2026-06-01T00:00:01Z",
+            agent_id: Some("agent-a"),
+        },
+    )
+    .expect("upsert embedding");
+
+    let agent_id: String = conn
+        .query_row(
+            "SELECT agent_id FROM embeddings WHERE source_id = ?1",
+            params!["mem-agent"],
+            |row| row.get(0),
+        )
+        .expect("read embedding agent");
+    assert_eq!(agent_id, "agent-a");
+
+    let vec_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM vec_embeddings WHERE id = ?1",
+            params!["memory:mem-agent"],
+            |row| row.get(0),
+        )
+        .expect("read vec count");
+    assert_eq!(vec_count, 1);
+
+    let results = vector_search(&conn, &vector, 5, None);
+    assert_eq!(
+        results.first().map(|(id, _)| id.as_str()),
+        Some("mem-agent")
+    );
+}

--- a/platform/daemon-rs/crates/signet-daemon/src/routes.rs
+++ b/platform/daemon-rs/crates/signet-daemon/src/routes.rs
@@ -18,6 +18,7 @@ pub mod knowledge;
 pub mod marketplace;
 pub mod marketplace_reviews;
 pub mod memory;
+pub mod memory_embeddings;
 pub mod ontology;
 pub mod os;
 pub mod pipeline;

--- a/platform/daemon-rs/crates/signet-daemon/src/routes/memory_embeddings.rs
+++ b/platform/daemon-rs/crates/signet-daemon/src/routes/memory_embeddings.rs
@@ -1,0 +1,93 @@
+//! Shared memory embedding helpers for write and repair routes.
+
+use std::sync::Arc;
+
+use rusqlite::{Connection, params};
+use tracing::warn;
+
+use signet_core::CoreError;
+use signet_core::queries::embedding::{InsertEmbedding, upsert};
+
+use crate::state::AppState;
+
+#[derive(Clone, Debug)]
+pub(crate) struct PreparedMemoryEmbedding {
+    pub provider: String,
+    pub vector: Vec<f32>,
+}
+
+pub(crate) async fn prepare_memory_embedding(
+    state: &Arc<AppState>,
+    content: &str,
+) -> Option<PreparedMemoryEmbedding> {
+    let provider = state.embedding.read().await.clone()?;
+    let provider_name = provider.name().to_string();
+    let expected_dimensions = provider.dimensions();
+    let vector = provider.embed(content).await?;
+    if vector.len() != expected_dimensions {
+        warn!(
+            provider = %provider_name,
+            expected_dimensions,
+            actual_dimensions = vector.len(),
+            "memory embedding provider returned unexpected dimensions"
+        );
+        return None;
+    }
+    Some(PreparedMemoryEmbedding {
+        provider: provider_name,
+        vector,
+    })
+}
+
+pub(crate) fn memory_has_embedding(conn: &Connection, memory_id: &str) -> Result<bool, CoreError> {
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*)
+         FROM embeddings
+         WHERE source_type = 'memory'
+           AND source_id = ?1",
+        params![memory_id],
+        |row| row.get(0),
+    )?;
+    Ok(count > 0)
+}
+
+pub(crate) fn memory_embedding_hash(agent_id: &str, memory_id: &str, memory_hash: &str) -> String {
+    format!("memory:{agent_id}:{memory_id}:{memory_hash}")
+}
+
+pub(crate) fn upsert_memory_embedding(
+    conn: &Connection,
+    memory_id: &str,
+    memory_hash: &str,
+    content: &str,
+    agent_id: &str,
+    embedding: Option<&PreparedMemoryEmbedding>,
+) -> Result<bool, CoreError> {
+    let Some(embedding) = embedding else {
+        return Ok(false);
+    };
+
+    let now = chrono::Utc::now().to_rfc3339();
+    let embedding_id = format!("memory:{memory_id}");
+    let embedding_hash = memory_embedding_hash(agent_id, memory_id, memory_hash);
+    upsert(
+        conn,
+        &InsertEmbedding {
+            id: &embedding_id,
+            content_hash: &embedding_hash,
+            vector: &embedding.vector,
+            source_type: "memory",
+            source_id: memory_id,
+            chunk_text: content,
+            now: &now,
+            agent_id: Some(agent_id),
+        },
+    )?;
+    conn.execute(
+        "UPDATE memories
+         SET embedding_model = ?1
+         WHERE id = ?2",
+        params![embedding.provider, memory_id],
+    )?;
+    Ok(true)
+}

--- a/platform/daemon-rs/crates/signet-daemon/src/routes/repair.rs
+++ b/platform/daemon-rs/crates/signet-daemon/src/routes/repair.rs
@@ -13,6 +13,7 @@ use axum::{
     http::{StatusCode, header},
     response::{IntoResponse, Json, Response},
 };
+use rusqlite::OptionalExtension;
 use serde::Deserialize;
 use signet_core::queries::embedding::{self, InsertEmbedding};
 use signet_core::queries::memory;
@@ -21,6 +22,7 @@ use tokio::io::AsyncReadExt;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
+use crate::routes::memory_embeddings::memory_embedding_hash;
 use crate::state::AppState;
 
 // ---------------------------------------------------------------------------
@@ -675,6 +677,13 @@ struct UnembeddedMemory {
     content_hash: Option<String>,
 }
 
+struct FreshMemoryForEmbedding {
+    content: String,
+    normalized_content: String,
+    content_hash: String,
+    agent_id: String,
+}
+
 fn count_active_memories(conn: &rusqlite::Connection) -> rusqlite::Result<i64> {
     conn.query_row(
         "SELECT COUNT(*) FROM memories WHERE COALESCE(is_deleted, 0) = 0",
@@ -690,12 +699,6 @@ fn count_unembedded_memories(conn: &rusqlite::Connection) -> rusqlite::Result<i6
            AND NOT EXISTS (
              SELECT 1 FROM embeddings e
              WHERE e.source_type = 'memory' AND e.source_id = m.id
-           )
-           AND NOT EXISTS (
-             SELECT 1 FROM embeddings e
-             WHERE e.source_type = 'memory'
-               AND m.content_hash IS NOT NULL
-               AND e.content_hash = m.content_hash
            )",
         [],
         |row| row.get(0),
@@ -714,12 +717,6 @@ fn list_unembedded_memories(
              SELECT 1 FROM embeddings e
              WHERE e.source_type = 'memory' AND e.source_id = m.id
            )
-           AND NOT EXISTS (
-             SELECT 1 FROM embeddings e
-             WHERE e.source_type = 'memory'
-               AND m.content_hash IS NOT NULL
-               AND e.content_hash = m.content_hash
-           )
          ORDER BY m.created_at ASC
          LIMIT ?1",
     )?;
@@ -733,6 +730,56 @@ fn list_unembedded_memories(
     .collect()
 }
 
+fn fresh_memory_for_embedding(
+    conn: &rusqlite::Connection,
+    memory: &UnembeddedMemory,
+) -> Result<Option<FreshMemoryForEmbedding>, signet_core::CoreError> {
+    let candidate_normalized = normalize_and_hash(&memory.content);
+    let candidate_hash = memory
+        .content_hash
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(&candidate_normalized.hash);
+    let row = conn
+        .query_row(
+            "SELECT content,
+                    content_hash,
+                    COALESCE(NULLIF(agent_id, ''), 'default') AS agent_id
+             FROM memories
+             WHERE id = ?1
+               AND COALESCE(is_deleted, 0) = 0",
+            rusqlite::params![memory.id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            },
+        )
+        .optional()?;
+
+    let Some((content, content_hash, agent_id)) = row else {
+        return Ok(None);
+    };
+    let current_normalized = normalize_and_hash(&content);
+    let current_hash = content_hash
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(&current_normalized.hash);
+    if current_hash != candidate_hash {
+        return Ok(None);
+    }
+    let content_hash = current_hash.to_string();
+
+    Ok(Some(FreshMemoryForEmbedding {
+        content,
+        normalized_content: current_normalized.normalized,
+        content_hash,
+        agent_id,
+    }))
+}
+
 fn write_embedding_batch(
     conn: &rusqlite::Connection,
     results: &[(UnembeddedMemory, Vec<f32>)],
@@ -741,12 +788,9 @@ fn write_embedding_batch(
     let now = chrono::Utc::now().to_rfc3339();
     let mut written = 0;
     for (memory, vector) in results {
-        let normalized = normalize_and_hash(&memory.content);
-        let content_hash = memory
-            .content_hash
-            .as_deref()
-            .filter(|value| !value.trim().is_empty())
-            .unwrap_or(&normalized.hash);
+        let Some(fresh) = fresh_memory_for_embedding(conn, memory)? else {
+            continue;
+        };
 
         if memory
             .content_hash
@@ -761,7 +805,7 @@ fn write_embedding_batch(
                        AND COALESCE(is_deleted, 0) = 0
                        AND id <> ?2
                      LIMIT 1",
-                    rusqlite::params![content_hash, memory.id],
+                    rusqlite::params![fresh.content_hash, memory.id],
                     |row| row.get::<_, String>(0),
                 )
                 .ok();
@@ -771,22 +815,25 @@ fn write_embedding_batch(
                      SET content_hash = ?1,
                          normalized_content = COALESCE(normalized_content, ?2)
                      WHERE id = ?3 AND content_hash IS NULL",
-                    rusqlite::params![content_hash, normalized.normalized, memory.id],
+                    rusqlite::params![fresh.content_hash, fresh.normalized_content, memory.id],
                 )?;
             }
         }
 
-        embedding::delete_by_source(conn, "memory", &memory.id, Some(content_hash))?;
+        let embedding_hash =
+            memory_embedding_hash(&fresh.agent_id, &memory.id, &fresh.content_hash);
+        embedding::delete_by_source(conn, "memory", &memory.id, Some(&embedding_hash))?;
         embedding::upsert(
             conn,
             &InsertEmbedding {
                 id: &uuid::Uuid::new_v4().to_string(),
-                content_hash,
+                content_hash: &embedding_hash,
                 vector,
                 source_type: "memory",
                 source_id: &memory.id,
-                chunk_text: &memory.content,
+                chunk_text: &fresh.content,
                 now: &now,
+                agent_id: Some(&fresh.agent_id),
             },
         )?;
         if let Some(model) = embedding_model {
@@ -1270,9 +1317,7 @@ pub async fn resync_vec(State(state): State<Arc<AppState>>) -> impl IntoResponse
             conn.execute("DELETE FROM vec_embeddings", [])?;
             let count = conn.execute(
                 "INSERT INTO vec_embeddings(id, embedding)
-                 SELECT e.id, e.vector FROM embeddings e
-                 JOIN memories m ON m.id = e.source_id
-                 WHERE e.source_type = 'memory' AND m.is_deleted = 0",
+                 SELECT e.id, e.vector FROM embeddings e",
                 [],
             )?;
             Ok(serde_json::json!(count))
@@ -2165,6 +2210,325 @@ mod tests {
 
         drop(state);
         writer.abort();
+    }
+
+    #[tokio::test]
+    async fn re_embed_skips_stale_candidates_after_modify_or_delete() {
+        let (state, writer) = test_state_with_embedding(None);
+        let old_a = normalize_and_hash("Old modified content");
+        let old_b = normalize_and_hash("Old deleted content");
+        let new_a = normalize_and_hash("New modified content");
+        state
+            .pool
+            .write(signet_core::db::Priority::High, move |conn| {
+                conn.execute(
+                    "INSERT INTO memories
+                     (id, type, content, content_hash, confidence, importance, created_at,
+                      updated_at, updated_by, is_deleted, agent_id, visibility)
+                     VALUES
+                     ('mem-stale-modified', 'fact', 'Old modified content', ?1, 1.0, 0.5,
+                      '2026-06-01T00:00:00Z', '2026-06-01T00:00:00Z', 'test', 0, 'agent-a', 'private'),
+                     ('mem-stale-deleted', 'fact', 'Old deleted content', ?2, 1.0, 0.5,
+                      '2026-06-01T00:00:00Z', '2026-06-01T00:00:00Z', 'test', 0, 'agent-a', 'private')",
+                    rusqlite::params![old_a.hash, old_b.hash],
+                )?;
+                Ok(serde_json::Value::Null)
+            })
+            .await
+            .expect("seed stale memories");
+
+        let candidates = state
+            .pool
+            .read(|conn| Ok(list_unembedded_memories(conn, 10)?))
+            .await
+            .expect("list candidates");
+        assert_eq!(candidates.len(), 2);
+
+        state
+            .pool
+            .write(signet_core::db::Priority::High, move |conn| {
+                conn.execute(
+                    "UPDATE memories
+                     SET content = ?1,
+                         normalized_content = ?2,
+                         content_hash = ?3
+                     WHERE id = 'mem-stale-modified'",
+                    rusqlite::params![new_a.storage, new_a.normalized, new_a.hash],
+                )?;
+                conn.execute(
+                    "UPDATE memories SET is_deleted = 1 WHERE id = 'mem-stale-deleted'",
+                    [],
+                )?;
+                Ok(serde_json::Value::Null)
+            })
+            .await
+            .expect("make candidates stale");
+
+        state
+            .pool
+            .write(signet_core::db::Priority::High, move |conn| {
+                let vectors = candidates
+                    .into_iter()
+                    .map(|candidate| (candidate, vec![0.5; 768]))
+                    .collect::<Vec<_>>();
+                Ok(serde_json::json!(write_embedding_batch(
+                    conn,
+                    &vectors,
+                    Some("fake-embedding")
+                )?))
+            })
+            .await
+            .expect("write stale candidates");
+
+        let embeddings = state
+            .pool
+            .read(|conn| {
+                Ok(
+                    conn.query_row("SELECT COUNT(*) FROM embeddings", [], |row| {
+                        row.get::<_, i64>(0)
+                    })?,
+                )
+            })
+            .await
+            .expect("count embeddings");
+        assert_eq!(embeddings, 0);
+
+        drop(state);
+        writer.abort();
+    }
+
+    #[tokio::test]
+    async fn re_embed_scopes_embedding_hash_by_agent_and_memory() {
+        let (state, writer) = test_state_with_embedding(None);
+        let normalized = normalize_and_hash("Shared normalized content");
+        let expected_hash = normalized.hash.clone();
+        let normalized_content = normalized.normalized.clone();
+        let memory_hash = normalized.hash.clone();
+        state
+            .pool
+            .write(signet_core::db::Priority::High, move |conn| {
+                conn.execute(
+                    "INSERT INTO memories
+                     (id, type, content, normalized_content, content_hash, confidence, importance,
+                      created_at, updated_at, updated_by, is_deleted, agent_id, visibility)
+                     VALUES
+                     ('mem-scope-a', 'fact', 'Shared normalized content', ?1, ?2, 1.0, 0.5,
+                      '2026-06-01T00:00:00Z', '2026-06-01T00:00:00Z', 'test', 0, 'agent-a', 'private'),
+                     ('mem-scope-b', 'fact', 'Shared normalized content', ?1, ?2, 1.0, 0.5,
+                      '2026-06-01T00:00:00Z', '2026-06-01T00:00:00Z', 'test', 0, 'agent-b', 'private')",
+                    rusqlite::params![normalized_content, memory_hash],
+                )?;
+                Ok(serde_json::Value::Null)
+            })
+            .await
+            .expect("seed scoped memories");
+
+        let candidates = state
+            .pool
+            .read(|conn| Ok(list_unembedded_memories(conn, 10)?))
+            .await
+            .expect("list scoped candidates");
+        assert_eq!(candidates.len(), 2);
+
+        state
+            .pool
+            .write(signet_core::db::Priority::High, move |conn| {
+                let vectors = candidates
+                    .into_iter()
+                    .map(|candidate| (candidate, vec![0.5; 768]))
+                    .collect::<Vec<_>>();
+                Ok(serde_json::json!(write_embedding_batch(
+                    conn,
+                    &vectors,
+                    Some("fake-embedding")
+                )?))
+            })
+            .await
+            .expect("write scoped embeddings");
+
+        let query_hash = expected_hash.clone();
+        let embeddings = state
+            .pool
+            .read(move |conn| {
+                Ok(serde_json::json!({
+                    "count": conn.query_row("SELECT COUNT(*) FROM embeddings", [], |row| row.get::<_, i64>(0))?,
+                    "agentA": conn.query_row(
+                        "SELECT content_hash FROM embeddings
+                         WHERE source_type = 'memory' AND source_id = 'mem-scope-a'",
+                        [],
+                        |row| row.get::<_, String>(0),
+                    )?,
+                    "agentB": conn.query_row(
+                        "SELECT content_hash FROM embeddings
+                         WHERE source_type = 'memory' AND source_id = 'mem-scope-b'",
+                        [],
+                        |row| row.get::<_, String>(0),
+                    )?,
+                    "rawHashRows": conn.query_row(
+                        "SELECT COUNT(*) FROM embeddings WHERE content_hash = ?1",
+                        [&query_hash],
+                        |row| row.get::<_, i64>(0),
+                    )?,
+                }))
+            })
+            .await
+            .expect("read scoped embeddings");
+
+        assert_eq!(embeddings["count"], 2);
+        assert_eq!(
+            embeddings["agentA"],
+            format!("memory:agent-a:mem-scope-a:{expected_hash}")
+        );
+        assert_eq!(
+            embeddings["agentB"],
+            format!("memory:agent-b:mem-scope-b:{expected_hash}")
+        );
+        assert_eq!(embeddings["rawHashRows"], 0);
+
+        drop(state);
+        writer.abort();
+    }
+
+    #[tokio::test]
+    async fn re_embed_gap_detection_ignores_legacy_raw_hash_for_other_memories() {
+        let (state, writer) = test_state_with_embedding(None);
+        let normalized = normalize_and_hash("Legacy shared content");
+        state
+            .pool
+            .write(signet_core::db::Priority::High, move |conn| {
+                let vector = signet_core::queries::embedding::vector_to_blob(&vec![0.25; 768]);
+                conn.execute(
+                    "INSERT INTO memories
+                     (id, type, content, normalized_content, content_hash, confidence, importance,
+                      created_at, updated_at, updated_by, is_deleted, agent_id, visibility)
+                     VALUES
+                     ('mem-legacy-a', 'fact', 'Legacy shared content', ?1, ?2, 1.0, 0.5,
+                      '2026-06-01T00:00:00Z', '2026-06-01T00:00:00Z', 'test', 0, 'agent-a', 'private'),
+                     ('mem-legacy-b', 'fact', 'Legacy shared content', ?1, ?2, 1.0, 0.5,
+                      '2026-06-01T00:00:01Z', '2026-06-01T00:00:01Z', 'test', 0, 'agent-b', 'private')",
+                    rusqlite::params![normalized.normalized, normalized.hash],
+                )?;
+                conn.execute(
+                    "INSERT INTO embeddings
+                     (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
+                     VALUES ('emb-legacy-a', ?1, ?2, 768, 'memory', 'mem-legacy-a',
+                             'Legacy shared content', '2026-06-01T00:00:00Z', 'agent-a')",
+                    rusqlite::params![normalized.hash, vector],
+                )?;
+                Ok(serde_json::Value::Null)
+            })
+            .await
+            .expect("seed legacy raw embedding");
+
+        let gaps = state
+            .pool
+            .read(|conn| {
+                let rows = list_unembedded_memories(conn, 10)?;
+                Ok(serde_json::json!({
+                    "count": count_unembedded_memories(conn)?,
+                    "ids": rows.into_iter().map(|row| row.id).collect::<Vec<_>>(),
+                }))
+            })
+            .await
+            .expect("read embedding gaps");
+
+        assert_eq!(gaps["count"], 1);
+        assert_eq!(gaps["ids"], serde_json::json!(["mem-legacy-b"]));
+
+        drop(state);
+        writer.abort();
+    }
+
+    #[tokio::test]
+    async fn resync_vec_preserves_non_memory_embeddings() {
+        let state = test_state();
+        state
+            .pool
+            .write(signet_core::db::Priority::High, |conn| {
+                let memory_vector =
+                    signet_core::queries::embedding::vector_to_blob(&vec![0.25; 768]);
+                let document_vector =
+                    signet_core::queries::embedding::vector_to_blob(&vec![0.5; 768]);
+                conn.execute(
+                    "INSERT INTO memories
+                     (id, content, normalized_content, content_hash, type, agent_id, created_at, updated_at, updated_by, importance)
+                     VALUES (?1, ?2, ?2, ?3, 'fact', ?4, ?5, ?5, 'test', 0.5)",
+                    rusqlite::params![
+                        "mem-resync",
+                        "Memory vector row",
+                        "mem-resync-hash",
+                        "agent-a",
+                        "2026-06-01T00:00:00Z"
+                    ],
+                )?;
+                conn.execute(
+                    "INSERT INTO embeddings
+                     (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
+                     VALUES (?1, ?2, ?3, 768, 'memory', ?4, ?5, ?6, ?7)",
+                    rusqlite::params![
+                        "emb-memory-resync",
+                        "emb-memory-hash",
+                        memory_vector,
+                        "mem-resync",
+                        "Memory vector row",
+                        "2026-06-01T00:00:00Z",
+                        "agent-a"
+                    ],
+                )?;
+                conn.execute(
+                    "INSERT INTO embeddings
+                     (id, content_hash, vector, dimensions, source_type, source_id, chunk_text, created_at, agent_id)
+                     VALUES (?1, ?2, ?3, 768, 'document', ?4, ?5, ?6, ?7)",
+                    rusqlite::params![
+                        "emb-document-resync",
+                        "emb-document-hash",
+                        document_vector,
+                        "doc-resync",
+                        "Document vector row",
+                        "2026-06-01T00:00:00Z",
+                        "agent-a"
+                    ],
+                )?;
+                Ok(serde_json::Value::Null)
+            })
+            .await
+            .expect("seed embeddings");
+
+        let app = Router::new()
+            .route("/api/repair/resync-vec", post(resync_vec))
+            .with_state(state.clone());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/repair/resync-vec")
+                    .body(Body::empty())
+                    .expect("build request"),
+            )
+            .await
+            .expect("send request");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(json["success"], true);
+        assert_eq!(json["affected"], 2);
+
+        let document_vec_count = state
+            .pool
+            .read(|conn| {
+                Ok(conn.query_row(
+                    "SELECT COUNT(*) FROM vec_embeddings WHERE id = 'emb-document-resync'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )?)
+            })
+            .await
+            .expect("read document vec count");
+
+        assert_eq!(document_vec_count, 1);
     }
 
     struct FakeEmbeddingProvider;

--- a/platform/daemon-rs/crates/signet-daemon/src/routes/skills.rs
+++ b/platform/daemon-rs/crates/signet-daemon/src/routes/skills.rs
@@ -729,6 +729,7 @@ async fn install_skill_graph_node(state: Arc<AppState>, name: String) -> Result<
                             source_id: &embedding_source_id,
                             chunk_text: &embedding_text,
                             now: &now,
+                            agent_id: None,
                         },
                     )?;
                     Ok(json!({"embeddingCreated": true}))

--- a/platform/daemon-rs/crates/signet-daemon/src/routes/write.rs
+++ b/platform/daemon-rs/crates/signet-daemon/src/routes/write.rs
@@ -29,6 +29,9 @@ use signet_services::transactions;
 use crate::analytics::ErrorEntry;
 use crate::auth::middleware::{authenticate_headers, require_scope_guard};
 use crate::auth::types::TokenScope;
+use crate::routes::memory_embeddings::{
+    memory_has_embedding, prepare_memory_embedding, upsert_memory_embedding,
+};
 use crate::state::AppState;
 
 // ---------------------------------------------------------------------------
@@ -1872,6 +1875,14 @@ pub async fn remember(
                 .into_response();
         }
 
+        let chunk_embeddings = {
+            let mut embeddings = Vec::with_capacity(chunk_plans.len());
+            for plan in &chunk_plans {
+                embeddings.push(prepare_memory_embedding(&state, &plan.content).await);
+            }
+            embeddings
+        };
+
         let result = state
             .pool
             .write_tx(Priority::High, {
@@ -1967,7 +1978,8 @@ pub async fn remember(
 
                     let blocked_reason = blocked_extraction_reason_blocking(&state);
                     let mut ids = Vec::with_capacity(chunk_plans.len());
-                    for plan in &chunk_plans {
+                    let mut embedded_count = 0usize;
+                    for (index, plan) in chunk_plans.iter().enumerate() {
                         let r = ingest_remember_with_blocked_guard(
                             conn,
                             &transactions::IngestInput {
@@ -2003,12 +2015,23 @@ pub async fn remember(
                              VALUES (?1, ?2, 'chunk', 1.0, ?3)",
                             params![r.id, group_id, now],
                         )?;
+                        if upsert_memory_embedding(
+                            conn,
+                            &r.id,
+                            &r.hash,
+                            &plan.content,
+                            &agent_id,
+                            chunk_embeddings.get(index).and_then(Option::as_ref),
+                        )? {
+                            embedded_count += 1;
+                        }
                         ids.push(r.id);
                     }
 
                     Ok(serde_json::json!({
                         "chunked": true,
                         "chunk_count": ids.len(),
+                        "embedded_count": embedded_count,
                         "ids": ids,
                         "group_id": group_id
                     }))
@@ -2044,6 +2067,8 @@ pub async fn remember(
         };
     }
 
+    let prepared_embedding = prepare_memory_embedding(&state, &content).await;
+
     let result = state
         .pool
         .write_tx(Priority::High, {
@@ -2074,7 +2099,7 @@ pub async fn remember(
                         "pinned": row.pinned,
                         "importance": row.importance,
                         "content": row.content,
-                        "embedded": true,
+                        "embedded": memory_has_embedding(conn, &row.id)?,
                         "deduped": true,
                     }));
                 }
@@ -2155,6 +2180,18 @@ pub async fn remember(
                 } else {
                     "created"
                 };
+                let embedded = if r.duplicate_of.is_some() {
+                    memory_has_embedding(conn, &r.id)?
+                } else {
+                    upsert_memory_embedding(
+                        conn,
+                        &r.id,
+                        &r.hash,
+                        &content,
+                        &agent_id,
+                        prepared_embedding.as_ref(),
+                    )?
+                };
                 let mut response = serde_json::json!({
                     "id": r.id,
                     "status": status,
@@ -2165,7 +2202,7 @@ pub async fn remember(
                     "pinned": pinned,
                     "importance": importance,
                     "content": content,
-                    "embedded": false,
+                    "embedded": embedded,
                     "entities_linked": entities_linked,
                     "hints_written": hints_written,
                     "structured": has_structured,
@@ -2242,7 +2279,9 @@ pub async fn remember(
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::future::Future;
     use std::net::SocketAddr;
+    use std::pin::Pin;
     use std::sync::Arc;
 
     use axum::Json;
@@ -2258,6 +2297,7 @@ mod tests {
         PipelineV2Config,
     };
     use signet_core::db::{DbPool, Priority};
+    use signet_pipeline::embedding::EmbeddingProvider;
     use signet_services::session::{RuntimePath, SessionTracker};
 
     use crate::auth::rate_limiter::{AuthRateLimiter, default_limits};
@@ -2268,6 +2308,28 @@ mod tests {
         RememberBody, dead_letter_blocked_extraction_memory, normalize_scope, parse_remember_tags,
         parse_visibility, remember, require_session_scope_for_write, resolve_remember_agent,
     };
+
+    struct TestEmbeddingProvider {
+        vector: Vec<f32>,
+    }
+
+    impl EmbeddingProvider for TestEmbeddingProvider {
+        fn embed(
+            &self,
+            _text: &str,
+        ) -> Pin<Box<dyn Future<Output = Option<Vec<f32>>> + Send + '_>> {
+            let vector = self.vector.clone();
+            Box::pin(async move { Some(vector) })
+        }
+
+        fn name(&self) -> &str {
+            "test-embedding"
+        }
+
+        fn dimensions(&self) -> usize {
+            self.vector.len()
+        }
+    }
 
     #[test]
     fn remember_tags_accepts_comma_separated_strings() {
@@ -2686,6 +2748,140 @@ mod tests {
             .await
             .expect("body bytes");
         serde_json::from_slice(&bytes).expect("json body")
+    }
+
+    #[tokio::test]
+    async fn remember_embeds_created_memory_rows() {
+        let (state, _dir) = build_test_state().await;
+        *state.embedding.write().await = Some(Arc::new(TestEmbeddingProvider {
+            vector: (0..768).map(|i| (i as f32) / 768.0).collect(),
+        }));
+
+        let response = remember(
+            State(state.clone()),
+            ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 3850))),
+            HeaderMap::new(),
+            Json(RememberBody {
+                content: Some("Rust daemon should embed memory writes".to_string()),
+                who: None,
+                project: None,
+                importance: None,
+                tags: None,
+                pinned: None,
+                source_type: None,
+                source_id: None,
+                created_at: None,
+                source_path: None,
+                runtime_path: None,
+                idempotency_key: None,
+                metadata: None,
+                memory_type: None,
+                agent_id: None,
+                visibility: None,
+                scope: None,
+                session_key: None,
+                hints: None,
+                structured: None,
+            }),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = read_json_body(response).await;
+        assert_eq!(body["status"], "created");
+        assert_eq!(body["embedded"], true);
+        let memory_id = body["id"].as_str().expect("memory id").to_string();
+
+        let embedding = state
+            .pool
+            .read(move |conn| {
+                Ok(conn.query_row(
+                    "SELECT e.source_type, e.agent_id, e.dimensions, m.embedding_model
+                     FROM embeddings e
+                     JOIN memories m ON m.id = e.source_id
+                     WHERE e.source_id = ?1",
+                    rusqlite::params![memory_id],
+                    |row| {
+                        Ok((
+                            row.get::<_, String>(0)?,
+                            row.get::<_, String>(1)?,
+                            row.get::<_, i64>(2)?,
+                            row.get::<_, Option<String>>(3)?,
+                        ))
+                    },
+                )?)
+            })
+            .await
+            .expect("read embedding");
+
+        assert_eq!(embedding.0, "memory");
+        assert_eq!(embedding.1, "default");
+        assert_eq!(embedding.2, 768);
+        assert_eq!(embedding.3.as_deref(), Some("test-embedding"));
+    }
+
+    #[tokio::test]
+    async fn remember_structured_payload_embeds_resulting_memory_row() {
+        let (state, _dir) = build_test_state().await;
+        *state.embedding.write().await = Some(Arc::new(TestEmbeddingProvider {
+            vector: vec![0.25; 768],
+        }));
+
+        let response = remember(
+            State(state.clone()),
+            ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 3850))),
+            HeaderMap::new(),
+            Json(RememberBody {
+                content: Some("Structured writes keep passthrough and get embeddings".to_string()),
+                who: None,
+                project: None,
+                importance: None,
+                tags: None,
+                pinned: None,
+                source_type: None,
+                source_id: None,
+                created_at: None,
+                source_path: None,
+                runtime_path: None,
+                idempotency_key: None,
+                metadata: None,
+                memory_type: None,
+                agent_id: None,
+                visibility: None,
+                scope: None,
+                session_key: None,
+                hints: None,
+                structured: Some(json!({"hints": ["structured"]})),
+            }),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = read_json_body(response).await;
+        assert_eq!(body["structured"], true);
+        assert_eq!(body["embedded"], true);
+        let memory_id = body["id"].as_str().expect("memory id").to_string();
+
+        let stored = state
+            .pool
+            .read(move |conn| {
+                Ok(conn.query_row(
+                    "SELECT m.extraction_model, COUNT(e.id)
+                     FROM memories m
+                     LEFT JOIN embeddings e
+                       ON e.source_type = 'memory'
+                      AND e.source_id = m.id
+                     WHERE m.id = ?1
+                     GROUP BY m.id",
+                    rusqlite::params![memory_id],
+                    |row| Ok((row.get::<_, Option<String>>(0)?, row.get::<_, i64>(1)?)),
+                )?)
+            })
+            .await
+            .expect("read structured embedding");
+
+        assert_eq!(stored.0.as_deref(), Some("structured-passthrough"));
+        assert_eq!(stored.1, 1);
     }
 
     #[tokio::test]

--- a/platform/daemon-rs/crates/signet-pipeline/src/document.rs
+++ b/platform/daemon-rs/crates/signet-pipeline/src/document.rs
@@ -247,6 +247,7 @@ async fn process_document(
     let text = payload["content"]
         .as_str()
         .ok_or("payload missing 'content' field")?;
+    let agent_id = document_payload_agent_id(&payload);
     let document_id = job.document_id.clone().or_else(|| {
         payload["documentId"]
             .as_str()
@@ -298,7 +299,7 @@ async fn process_document(
 
     if let Some(document_id) = document_id {
         update_document_status(pool, &document_id, "indexing", None).await?;
-        persist_document_chunks(pool, &document_id, &embedded_chunks, config).await?;
+        persist_document_chunks(pool, &document_id, &agent_id, &embedded_chunks, config).await?;
     }
 
     Ok(DocumentResult {
@@ -318,6 +319,21 @@ struct DocumentJob {
     document_id: Option<String>,
     payload: Option<String>,
     attempts: i64,
+}
+
+fn document_payload_agent_id(payload: &serde_json::Value) -> String {
+    payload
+        .get("agentId")
+        .or_else(|| payload.get("agent_id"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("default")
+        .to_string()
+}
+
+fn document_memory_embedding_hash(agent_id: &str, memory_id: &str, memory_hash: &str) -> String {
+    format!("memory:{agent_id}:{memory_id}:{memory_hash}")
 }
 
 async fn update_document_status(
@@ -375,10 +391,12 @@ async fn mark_document_done(
 async fn persist_document_chunks(
     pool: &DbPool,
     document_id: &str,
+    agent_id: &str,
     chunks: &[EmbeddedChunk],
     config: &DocumentConfig,
 ) -> Result<(), String> {
     let document_id = document_id.to_string();
+    let agent_id = agent_id.to_string();
     let chunks = chunks.to_vec();
     let embedding_model = config.embedding_model.clone();
     pool.write(signet_core::db::Priority::Low, move |conn| {
@@ -413,11 +431,11 @@ async fn persist_document_chunks(
                     "SELECT id FROM memories
                      WHERE content_hash = ?1
                        AND COALESCE(is_deleted, 0) = 0
-                       AND agent_id = 'default'
+                       AND agent_id = ?2
                        AND visibility = 'private'
                        AND IFNULL(scope, '') = ''
                      LIMIT 1",
-                    rusqlite::params![normalized.hash],
+                    rusqlite::params![normalized.hash, agent_id],
                     |row| row.get::<_, String>(0),
                 )
                 .ok();
@@ -429,12 +447,12 @@ async fn persist_document_chunks(
                     "INSERT INTO memories
                      (id, type, category, content, normalized_content, content_hash,
                       confidence, importance, source_id, source_type, tags, created_at,
-                      updated_at, updated_by, vector_clock, agent_id, visibility,
-                      is_deleted, extraction_status, embedding_model)
+                     updated_at, updated_by, vector_clock, agent_id, visibility,
+                     is_deleted, extraction_status, embedding_model)
                      VALUES (?1, 'document_chunk', 'document_chunk', ?2, ?3, ?4,
                              1.0, 0.3, ?5, 'document', ?6, ?7,
-                             ?7, 'document-worker', '{}', 'default', 'private',
-                             0, 'none', ?8)",
+                             ?7, 'document-worker', '{}', ?8, 'private',
+                             0, 'none', ?9)",
                     rusqlite::params![
                         memory_id,
                         normalized.storage,
@@ -443,6 +461,7 @@ async fn persist_document_chunks(
                         document_id,
                         format!("document,chunk:{}", chunk.chunk.index),
                         ts,
+                        agent_id,
                         chunk.vector.as_ref().and(embedding_model.as_deref()),
                     ],
                 )?;
@@ -455,16 +474,29 @@ async fn persist_document_chunks(
             )?;
 
             if let Some(vector) = chunk.vector.as_ref() {
+                let linked_agent_id: String = conn.query_row(
+                    "SELECT COALESCE(NULLIF(agent_id, ''), 'default')
+                     FROM memories
+                     WHERE id = ?1",
+                    rusqlite::params![linked_memory_id],
+                    |row| row.get(0),
+                )?;
+                let embedding_hash = document_memory_embedding_hash(
+                    &linked_agent_id,
+                    &linked_memory_id,
+                    &normalized.hash,
+                );
                 embedding::upsert(
                     conn,
                     &InsertEmbedding {
                         id: &uuid::Uuid::new_v4().to_string(),
-                        content_hash: &normalized.hash,
+                        content_hash: &embedding_hash,
                         vector,
                         source_type: "memory",
                         source_id: &linked_memory_id,
                         chunk_text: &chunk.chunk.text,
                         now: &ts,
+                        agent_id: Some(&linked_agent_id),
                     },
                 )?;
             }
@@ -635,7 +667,13 @@ mod tests {
             &DocumentJob {
                 id: "job-document".to_string(),
                 document_id: Some("doc-replay".to_string()),
-                payload: Some(serde_json::json!({"content": "abcdefghi"}).to_string()),
+                payload: Some(
+                    serde_json::json!({
+                        "content": "abcdefghi",
+                        "agentId": "agent-doc"
+                    })
+                    .to_string(),
+                ),
                 attempts: 1,
             },
             &DocumentConfig {
@@ -687,6 +725,22 @@ mod tests {
                     [],
                     |row| row.get(0),
                 )?;
+                let memory_agents: i64 = conn.query_row(
+                    "SELECT COUNT(*) FROM memories
+                     WHERE source_id = 'doc-replay'
+                       AND is_deleted = 0
+                       AND agent_id = 'agent-doc'",
+                    [],
+                    |row| row.get(0),
+                )?;
+                let embedding_agents: i64 = conn.query_row(
+                    "SELECT COUNT(*) FROM embeddings e
+                     JOIN document_memories dm ON dm.memory_id = e.source_id
+                     WHERE dm.document_id = 'doc-replay'
+                       AND e.agent_id = 'agent-doc'",
+                    [],
+                    |row| row.get(0),
+                )?;
                 Ok(serde_json::json!({
                     "status": status,
                     "chunkCount": chunk_count,
@@ -695,6 +749,8 @@ mod tests {
                     "embeddings": embeddings,
                     "vecEmbeddings": vec_embeddings,
                     "embeddingModel": embedding_model,
+                    "memoryAgents": memory_agents,
+                    "embeddingAgents": embedding_agents,
                 }))
             })
             .await
@@ -706,6 +762,111 @@ mod tests {
         assert_eq!(persisted["embeddings"], 3);
         assert_eq!(persisted["vecEmbeddings"], 3);
         assert_eq!(persisted["embeddingModel"], "fake-embedding");
+        assert_eq!(persisted["memoryAgents"], 3);
+        assert_eq!(persisted["embeddingAgents"], 3);
+
+        drop(pool);
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn process_document_scopes_embedding_hash_by_agent_and_memory() {
+        let (pool, handle) = open_test_pool();
+        pool.write(Priority::High, |conn| {
+            let now = chrono::Utc::now().to_rfc3339();
+            conn.execute(
+                "INSERT INTO documents
+                 (id, source_type, content_type, title, raw_content, status,
+                  chunk_count, memory_count, created_at, updated_at)
+                 VALUES
+                 ('doc-agent-a', 'text', 'text/plain', 'Agent A', 'same chunk',
+                  'queued', 0, 0, ?1, ?1),
+                 ('doc-agent-b', 'text', 'text/plain', 'Agent B', 'same chunk',
+                  'queued', 0, 0, ?1, ?1)",
+                rusqlite::params![now],
+            )?;
+            Ok(serde_json::Value::Null)
+        })
+        .await
+        .expect("seed document rows");
+
+        let config = DocumentConfig {
+            chunk_size: 64,
+            chunk_overlap: 0,
+            max_chunks: 10,
+            embedding_model: Some("fake-embedding".to_string()),
+            ..DocumentConfig::default()
+        };
+        for (document_id, agent_id) in [("doc-agent-a", "agent-a"), ("doc-agent-b", "agent-b")] {
+            process_document(
+                &pool,
+                &FakeEmbeddingProvider { dims: 768 },
+                &DocumentJob {
+                    id: format!("job-{document_id}"),
+                    document_id: Some(document_id.to_string()),
+                    payload: Some(
+                        serde_json::json!({
+                            "content": "same chunk",
+                            "agentId": agent_id,
+                        })
+                        .to_string(),
+                    ),
+                    attempts: 1,
+                },
+                &config,
+            )
+            .await
+            .expect("process scoped document");
+        }
+
+        let raw_hash = normalize_and_hash("same chunk").hash;
+        let query_hash = raw_hash.clone();
+        let persisted = pool
+            .read(move |conn| {
+                Ok(serde_json::json!({
+                    "embeddingCount": conn.query_row(
+                        "SELECT COUNT(*) FROM embeddings WHERE source_type = 'memory'",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )?,
+                    "distinctHashes": conn.query_row(
+                        "SELECT COUNT(DISTINCT content_hash) FROM embeddings WHERE source_type = 'memory'",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )?,
+                    "rawHashRows": conn.query_row(
+                        "SELECT COUNT(*) FROM embeddings WHERE content_hash = ?1",
+                        [&query_hash],
+                        |row| row.get::<_, i64>(0),
+                    )?,
+                    "agentA": conn.query_row(
+                        "SELECT COUNT(*) FROM embeddings WHERE source_type = 'memory' AND agent_id = 'agent-a'",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )?,
+                    "agentB": conn.query_row(
+                        "SELECT COUNT(*) FROM embeddings WHERE source_type = 'memory' AND agent_id = 'agent-b'",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )?,
+                    "scopedHashes": conn.query_row(
+                        "SELECT COUNT(*) FROM embeddings e
+                         JOIN memories m ON m.id = e.source_id
+                         WHERE e.content_hash = 'memory:' || m.agent_id || ':' || m.id || ':' || m.content_hash",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )?,
+                }))
+            })
+            .await
+            .expect("read scoped document embeddings");
+
+        assert_eq!(persisted["embeddingCount"], 2);
+        assert_eq!(persisted["distinctHashes"], 2);
+        assert_eq!(persisted["rawHashRows"], 0);
+        assert_eq!(persisted["agentA"], 1);
+        assert_eq!(persisted["agentB"], 1);
+        assert_eq!(persisted["scopedHashes"], 2);
 
         drop(pool);
         handle.abort();


### PR DESCRIPTION
## Summary

Fixes the Rust daemon memory write path so stored memories get vector embeddings when an embedding provider is configured. This is rebased onto current `main` and preserves the current structured `remember` passthrough path.

Closes #804

## Changes

- Added shared Rust daemon helpers for preparing and upserting memory embeddings with `agent_id`.
- Embedded new `remember` writes, including structured passthrough writes and chunked writes, and returned explicit `embedded` / `embedded_count` response fields.
- Extended core embedding upsert to persist `agent_id` and keep `vec_embeddings` synchronized.
- Re-read repair re-embed candidates inside the write transaction so stale async embeddings are skipped after concurrent modify/delete.
- Fixed `/api/repair/resync-vec` to rebuild the shared vector table from all stored embeddings instead of dropping non-memory vector rows.
- Added focused regressions for write-side embedding, structured writes, stale re-embed candidates, scoped repair/document embedding identity, raw-hash gap detection, shared vector resync, and core vector sync.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [x] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other: <!-- specify -->

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A — no migrations touched.

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Additional focused Rust checks run:

- [x] `cargo test -p signet-core --test embedding_upsert`
- [x] `cargo test -p signet-daemon remember_embeds_created_memory_rows`
- [x] `cargo test -p signet-daemon remember_structured_payload_embeds_resulting_memory_row`
- [x] `cargo test -p signet-daemon re_embed_skips_stale_candidates_after_modify_or_delete`
- [x] `cargo test -p signet-daemon re_embed_scopes_embedding_hash_by_agent_and_memory`
- [x] `cargo test -p signet-daemon re_embed_gap_detection_ignores_legacy_raw_hash_for_other_memories`
- [x] `cargo test -p signet-daemon resync_vec_preserves_non_memory_embeddings`
- [x] `cargo check -p signet-daemon`
- [x] `cargo test -p signet-daemon`
- [x] `cargo test -p signet-pipeline`
- [x] `cargo test -p signet-pipeline process_document_scopes_embedding_hash_by_agent_and_memory`
- [x] `git diff --check`

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Existing API docs already describe `/api/repair/re-embed`, `/api/repair/embedding-gaps`, and related repair endpoints as real operations. `docs/API.md` does not enumerate `remember` response fields, so no docs source change was required for the `embedded` response correction.