### PR TITLE
(fix) disable DeepSeek reasoning for OpenAI-compatible provider

### DIFF
--- a/platform/daemon/src/pipeline/provider.test.ts
+++ b/platform/daemon/src/pipeline/provider.test.ts
@@ -19,6 +19,7 @@ import {
 	createCodexProvider,
 	createLlamaCppProvider,
 	createOllamaProvider,
+	createOpenAiCompatibleProvider,
 	createOpenCodeProvider,
 	createOpenRouterProvider,
 	resolveDefaultOllamaFallbackMaxContextTokens,
@@ -2315,6 +2316,86 @@ describe("createOpenCodeProvider", () => {
 		expect(uniqueDeleted).toContain("ses_leak_2");
 		expect(uniqueDeleted).toContain("ses_leak_3");
 	}, 15000);
+});
+
+describe("createOpenAiCompatibleProvider", () => {
+	afterEach(() => restoreFetch());
+
+	it("disables DeepSeek thinking for non-streaming chat completions", async () => {
+		let requestBody: Record<string, unknown> | null = null;
+		mockFetch(async (_url, init) => {
+			requestBody = parseJsonObjectBody(init?.body);
+			return Response.json({
+				choices: [{ message: { content: "deepseek answer" } }],
+			});
+		});
+
+		const provider = createOpenAiCompatibleProvider({
+			name: "openai-compatible:deepseek-v4-flash",
+			model: "deepseek-v4-flash",
+			baseUrl: "https://api.deepseek.com/v1",
+			apiKey: "sk-deepseek",
+			defaultTimeoutMs: 1000,
+		});
+
+		await expect(provider.generate("extract one fact")).resolves.toBe("deepseek answer");
+		expect(requestBody?.thinking).toEqual({ type: "disabled" });
+	});
+
+	it("disables DeepSeek thinking for streaming chat completions", async () => {
+		let requestBody: Record<string, unknown> | null = null;
+		mockFetch(async (_url, init) => {
+			requestBody = parseJsonObjectBody(init?.body);
+			return new Response(
+				streamFromString(
+					[
+						`data: ${JSON.stringify({ choices: [{ delta: { content: "streamed answer" } }] })}`,
+						"data: [DONE]",
+						"",
+					].join("\n\n"),
+				),
+				{ status: 200 },
+			);
+		});
+
+		const provider = createOpenAiCompatibleProvider({
+			name: "openai-compatible:deepseek-reasoner",
+			model: "deepseek-reasoner",
+			baseUrl: "https://api.deepseek.com/v1/",
+			apiKey: "sk-deepseek",
+			defaultTimeoutMs: 1000,
+		});
+
+		const result = await provider.streamWithUsage?.("extract one fact", { maxTokens: 64 });
+		expect(result).toBeDefined();
+		const reader = result?.stream.getReader();
+		await reader?.read();
+		await reader?.read();
+		expect(requestBody?.thinking).toEqual({ type: "disabled" });
+		expect(requestBody?.stream).toBe(true);
+		expect(requestBody?.max_tokens).toBe(64);
+	});
+
+	it("does not send DeepSeek-only thinking controls to other gateways", async () => {
+		let requestBody: Record<string, unknown> | null = null;
+		mockFetch(async (_url, init) => {
+			requestBody = parseJsonObjectBody(init?.body);
+			return Response.json({
+				choices: [{ message: { content: "gateway answer" } }],
+			});
+		});
+
+		const provider = createOpenAiCompatibleProvider({
+			name: "openai-compatible:gpt-4o-mini",
+			model: "gpt-4o-mini",
+			baseUrl: "https://gateway.example.test/v1",
+			apiKey: "sk-gateway",
+			defaultTimeoutMs: 1000,
+		});
+
+		await expect(provider.generate("extract one fact")).resolves.toBe("gateway answer");
+		expect(requestBody).not.toHaveProperty("thinking");
+	});
 });
 
 describe("createOpenRouterProvider", () => {

--- a/platform/daemon/src/pipeline/provider.ts
+++ b/platform/daemon/src/pipeline/provider.ts
@@ -806,6 +806,14 @@ function extractOpenAiLikeText(content: unknown): string {
 		.join("");
 }
 
+function isDeepSeekOpenAiCompatibleEndpoint(baseUrl: string): boolean {
+	try {
+		return new URL(baseUrl).hostname.toLowerCase() === "api.deepseek.com";
+	} catch {
+		return /api\.deepseek\.com/i.test(baseUrl);
+	}
+}
+
 function createOpenAiLikeStreamResult(res: Response, cancel: () => void): LlmProviderStreamResult {
 	if (!res.body) {
 		throw new Error("streaming response body was missing");
@@ -1398,6 +1406,7 @@ export interface OpenAiCompatibleProviderConfig {
 
 export function createOpenAiCompatibleProvider(config: OpenAiCompatibleProviderConfig): StreamCapableLlmProvider {
 	const baseUrl = trimTrailingSlash(config.baseUrl);
+	const extraRequestBody = isDeepSeekOpenAiCompatibleEndpoint(baseUrl) ? { thinking: { type: "disabled" } } : {};
 	const headers = (): Record<string, string> => ({
 		"Content-Type": "application/json",
 		...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {}),
@@ -1414,6 +1423,7 @@ export function createOpenAiCompatibleProvider(config: OpenAiCompatibleProviderC
 					model: config.model,
 					messages: [{ role: "user", content: prompt }],
 					max_tokens: opts?.maxTokens ?? 4096,
+					...extraRequestBody,
 				}),
 				signal: abort.signal,
 			});
@@ -1479,6 +1489,7 @@ export function createOpenAiCompatibleProvider(config: OpenAiCompatibleProviderC
 						max_tokens: opts?.maxTokens ?? 4096,
 						stream: true,
 						stream_options: { include_usage: true },
+						...extraRequestBody,
 					}),
 					signal: abort.signal,
 				});


### PR DESCRIPTION
## Summary

Fixes #809 by making the OpenAI-compatible provider disable DeepSeek reasoning for background extraction and synthesis calls. DeepSeek reasoning models can spend the whole completion budget on `reasoning_content` and return `content: null`, which made the provider throw `returned empty response`.

This keeps the existing OpenAI-compatible request path, but adds a DeepSeek endpoint guard that sends `thinking: { type: "disabled" }` for both non-streaming and streaming chat completions.

## Changes

- Detect `api.deepseek.com` OpenAI-compatible endpoints in the daemon provider.
- Add DeepSeek-only `thinking: { type: "disabled" }` to generate and stream request bodies.
- Add regression tests for DeepSeek non-streaming, DeepSeek streaming, and non-DeepSeek gateway behavior.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [ ] Other:

## Screenshots

N/A — daemon provider fix, no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [ ] Lint/typecheck/tests pass locally

Notes on readiness:

- Spec alignment checked against `docs/specs/INDEX.md`, `docs/specs/dependencies.yaml`, `docs/specs/approved/model-provider-router.md`, and `docs/specs/complete/memory-pipeline-plan.md`.
- Agent scoping is N/A because this PR changes provider request shaping only; it adds no data queries.
- Admin/mutation endpoint security is N/A because this PR does not touch routes or mutation endpoints.
- Docs are N/A because this is not an API, spec, or status surface change.
- Local targeted tests pass. Full lint/typecheck are left unchecked while this is draft because existing unrelated failures remain in the daemon/provider test file and daemon type build.

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [ ] Daemon Rust parity reviewed or explicitly N/A
- [ ] Rollback / compatibility note included in PR description

N/A — no migrations.

## Testing

- [x] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [ ] N/A

Commands run:

- `bun install --frozen-lockfile`
- `bun run build:core`
- `bun install --frozen-lockfile` from `platform/daemon`
- `bun test platform/daemon/src/pipeline/provider.test.ts -t createOpenAiCompatibleProvider`
- `bun build platform/daemon/src/pipeline/provider.ts --target node --external @signet/core --external better-sqlite3 --external sharp --external onnxruntime-node --outfile /tmp/signet-provider-pr809-check.js`
- `bunx biome check platform/daemon/src/pipeline/provider.ts platform/daemon/src/pipeline/provider.test.ts` — fails on pre-existing unrelated `provider.test.ts` lint/format findings outside this PR's added block.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

Draft until the broader local lint/typecheck readiness item is green or explicitly waived.
