### PR TITLE
fix(daemon): decouple summary worker from pipelineV2 so dreaming gets summaries

### DIFF
--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -49,7 +49,7 @@ import { logger } from "./logger";
 import { type ResolvedMemoryConfig, loadMemoryConfig, shouldWarnGraphExtractionWritesDisabled } from "./memory-config";
 import { registerGlobalMiddleware } from "./middleware";
 import { type NativeMemoryBridgeHandle, startNativeMemoryBridge } from "./native-memory-sources";
-import { DEFAULT_RETENTION, ensureRetentionWorker, setDreamingWorker, startPipeline, stopPipeline } from "./pipeline";
+import { DEFAULT_RETENTION, ensureRetentionWorker, ensureSummaryWorker, setDreamingWorker, startPipeline, stopPipeline } from "./pipeline";
 import { type DreamingWorkerHandle, startDreamingWorker } from "./pipeline/dreaming-worker";
 import type { WorkerInit } from "./pipeline/extraction-thread-protocol";
 import { invalidateTraversalCache } from "./pipeline/graph-traversal";
@@ -1092,6 +1092,12 @@ async function startPipelineRuntime(memoryCfg: ResolvedMemoryConfig, telemetry?:
 		interactive: await router.hasWorkload("interactive"),
 		default: await router.hasWorkload("default"),
 	});
+
+	// Summary worker — shared infrastructure, owned here not by startPipeline.
+	// Both pipelineV2 and dreaming consume session summaries.
+	if ((memoryCfg.pipelineV2.enabled || memoryCfg.dreaming.enabled) && !pipelinePaused) {
+		ensureSummaryWorker(getDbAccessor());
+	}
 
 	if (memoryCfg.pipelineV2.enabled && !pipelinePaused && extractionAvailable) {
 		const workerInit: WorkerInit | undefined = memoryCfg.pipelineV2.worker.threadedExtraction

--- a/platform/daemon/src/hooks.test.ts
+++ b/platform/daemon/src/hooks.test.ts
@@ -3279,8 +3279,52 @@ describe("handleCheckpointExtract", () => {
 });
 
 // ============================================================================
-// Pure / stateless function tests (from co-located src/ tests)
+// Summary worker tick gate — verifies the worker processes jobs when
+// dreaming is enabled even with pipelineV2 disabled (regression for #812).
 // ============================================================================
+
+describe("summary worker tick gate", () => {
+	test.serial(
+		"processes enqueued job when only dreaming is enabled",
+		async () => {
+			writeAgentYaml(`memory:
+  pipelineV2:
+    enabled: false
+  dreaming:
+    enabled: true
+`);
+			createMemoryDb([]);
+
+			const enq = handleCheckpointExtract({
+				harness: "test",
+				sessionKey: "ckpt-worker-dreaming",
+				transcript: "x".repeat(600),
+			});
+			expect(enq.queued).toBe(true);
+			expect(typeof enq.jobId).toBe("string");
+			const jobId = enq.jobId!;
+
+			const { startSummaryWorker } = await import("./pipeline/summary-worker");
+			const handle = startSummaryWorker(getDbAccessor());
+
+			// First tick fires after POLL_INTERVAL_MS (5s)
+			await new Promise((resolve) => setTimeout(resolve, 5500));
+			handle.stop();
+
+			const db = openTestDb();
+			const job = db
+				.prepare("SELECT status, attempts FROM summary_jobs WHERE id = ?")
+				.get(jobId) as { status: string; attempts: number } | undefined;
+			db.close();
+
+			expect(job).toBeDefined();
+			// Gate allowed tick through → job was leased → attempts incremented.
+			// Without LLM the processing will fail, but that doesn't matter.
+			expect(job!.attempts).toBeGreaterThan(0);
+		},
+		15_000,
+	);
+});
 
 describe("buildSignetSystemPrompt", () => {
 	it("lists primary signet retrieval tools with namespaced ids", () => {

--- a/platform/daemon/src/hooks.test.ts
+++ b/platform/daemon/src/hooks.test.ts
@@ -1935,6 +1935,51 @@ memory:
 		expect(second).toMatch(/^session-end:agent:main:main:[0-9a-f-]{36}$/);
 		expect(first).not.toBe(second);
 	});
+
+	test.serial("enqueues summary job when only dreaming is enabled (pipelineV2 disabled)", async () => {
+		writeAgentYaml(`memory:
+  pipelineV2:
+    enabled: false
+  dreaming:
+    enabled: true
+`);
+		createMemoryDb([]);
+		const transcriptPath = join(TEST_DIR, "transcript.txt");
+		writeFileSync(transcriptPath, "x".repeat(1000));
+
+		const result = await handleSessionEnd({
+			harness: "test",
+			transcriptPath,
+			sessionKey: "sess-dreaming",
+			sessionId: "sess-dreaming",
+			cwd: "/home/user/signetai",
+		});
+
+		expect(result.queued).toBe(true);
+		expect(typeof result.jobId).toBe("string");
+	});
+
+	test.serial("skips enqueueing when neither pipelineV2 nor dreaming is enabled", async () => {
+		writeAgentYaml(`memory:
+  pipelineV2:
+    enabled: false
+  dreaming:
+    enabled: false
+`);
+		createMemoryDb([]);
+		const transcriptPath = join(TEST_DIR, "transcript.txt");
+		writeFileSync(transcriptPath, "x".repeat(1000));
+
+		const result = await handleSessionEnd({
+			harness: "test",
+			transcriptPath,
+			sessionKey: "sess-both-disabled",
+			sessionId: "sess-both-disabled",
+			cwd: "/home/user/signetai",
+		});
+
+		expect(result.queued).toBe(false);
+	});
 });
 
 // ============================================================================
@@ -3191,9 +3236,45 @@ describe("handleCheckpointExtract", () => {
 			sessionKey: "ckpt-nopath",
 			transcriptPath: "/nonexistent/path/transcript.jsonl",
 		});
-
 		expect(result.skipped).toBe(true);
 		expect(result.queued).toBeUndefined();
+	});
+
+	test.serial("enqueues checkpoint when only dreaming is enabled", () => {
+		writeAgentYaml(`memory:
+  pipelineV2:
+    enabled: false
+  dreaming:
+    enabled: true
+`);
+		createMemoryDb([]);
+
+		const result = handleCheckpointExtract({
+			harness: "test",
+			sessionKey: "ckpt-dreaming",
+			transcript: "x".repeat(600),
+		});
+
+		expect(result.queued).toBe(true);
+		expect(typeof result.jobId).toBe("string");
+	});
+
+	test.serial("skips checkpoint when neither pipelineV2 nor dreaming is enabled", () => {
+		writeAgentYaml(`memory:
+  pipelineV2:
+    enabled: false
+  dreaming:
+    enabled: false
+`);
+		createMemoryDb([]);
+
+		const result = handleCheckpointExtract({
+			harness: "test",
+			sessionKey: "ckpt-both-disabled",
+			transcript: "x".repeat(600),
+		});
+
+		expect(result.skipped).toBe(true);
 	});
 });
 

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -3411,7 +3411,7 @@ export async function handleSessionEnd(req: SessionEndRequest): Promise<SessionE
 		truncated = true;
 	}
 
-	const pipelineEnabled = memoryCfg.pipelineV2.enabled || memoryCfg.pipelineV2.shadowMode;
+	const pipelineEnabled = memoryCfg.pipelineV2.enabled || memoryCfg.pipelineV2.shadowMode || memoryCfg.dreaming.enabled;
 	const hasSummaryLength = summaryTranscript.length >= 500;
 	let jobId: string | undefined;
 
@@ -3697,7 +3697,7 @@ export function handleCheckpointExtract(req: CheckpointExtractRequest): Checkpoi
 
 	// Respect the pipeline master switch
 	const memoryCfg = loadMemoryConfig(getAgentsDir());
-	if (!memoryCfg.pipelineV2.enabled && !memoryCfg.pipelineV2.shadowMode) {
+	if (!memoryCfg.pipelineV2.enabled && !memoryCfg.pipelineV2.shadowMode && !memoryCfg.dreaming.enabled) {
 		logger.info("hooks", "Checkpoint extract skipped — pipeline disabled");
 		return { skipped: true };
 	}

--- a/platform/daemon/src/pipeline/index.ts
+++ b/platform/daemon/src/pipeline/index.ts
@@ -66,6 +66,14 @@ export function setDreamingWorker(handle: DreamingWorkerHandle | null): void {
 	dreamingWorkerHandle = handle;
 }
 
+/** Start the summary worker if not already running (used when dreaming
+ *  is enabled but pipelineV2 is disabled — dreaming needs summaries). */
+export function ensureSummaryWorker(accessor: DbAccessor): void {
+	if (!summaryWorkerHandle) {
+		summaryWorkerHandle = startSummaryWorker(accessor);
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Singleton state
 // ---------------------------------------------------------------------------
@@ -160,9 +168,6 @@ export function startPipeline(
 				pipelineCfg,
 			});
 		}
-		if (!summaryWorkerHandle) {
-			summaryWorkerHandle = startSummaryWorker(accessor);
-		}
 		if (!synthesisWorkerHandle && pipelineCfg.synthesis.enabled && pipelineCfg.synthesis.provider !== "none") {
 			synthesisWorkerHandle = startSynthesisWorker(pipelineCfg.synthesis);
 		}
@@ -218,11 +223,6 @@ export function startPipeline(
 			fetchEmbedding,
 			pipelineCfg,
 		});
-	}
-
-	// Summary worker — async session-end processing
-	if (!summaryWorkerHandle) {
-		summaryWorkerHandle = startSummaryWorker(accessor);
 	}
 
 	// Synthesis worker — session-activity-based MEMORY.md regeneration

--- a/platform/daemon/src/pipeline/summary-worker.ts
+++ b/platform/daemon/src/pipeline/summary-worker.ts
@@ -1347,7 +1347,7 @@ export function startSummaryWorker(accessor: DbAccessor): SummaryWorkerHandle {
 
 		// Re-check config each tick — respect runtime config changes
 		const cfg = loadMemoryConfig(AGENTS_DIR);
-		if (!cfg.pipelineV2.enabled || cfg.pipelineV2.shadowMode) {
+		if ((!cfg.pipelineV2.enabled && !cfg.dreaming.enabled) || cfg.pipelineV2.shadowMode) {
 			scheduleTick(POLL_INTERVAL_MS);
 			return;
 		}


### PR DESCRIPTION
Closes #812

## Problem

When `pipelineV2.enabled: false` and `dreaming.enabled: true`, session summaries stop entirely and dreaming starves. Four gates were responsible — three config checks and one lifecycle ownership problem.

## Root cause

The summary worker is owned by `startPipeline` and gated on `pipelineV2.enabled`. When V2 is off, the worker never starts, no jobs are enqueued, and even if they were, nothing would process them.

## Fix

**Architecture change**: Move summary worker lifecycle from `startPipeline` into `daemon.ts` with a single gate `(pipelineV2.enabled || dreaming.enabled)`. The summary worker is shared infrastructure, not a V2 component.

1. **daemon.ts** — single startup gate owns the summary worker lifecycle for both consumers
2. **pipeline/index.ts** — remove summary worker ownership from both `startPipeline` code paths; add `ensureSummaryWorker()` helper (manages the module-level singleton)
3. **hooks.ts** — widen session-end enqueueing and mid-session checkpoint gates to `V2 || dreaming`
4. **summary-worker.ts** — widen worker tick gate to `(!V2 && !dreaming) || shadowMode`