### PR TITLE
fix(install): bundle native assets in npm package

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -21,11 +21,6 @@ jobs:
           test -n "$NODE_AUTH_TOKEN"
           npm config set //registry.npmjs.org/:_authToken "$NODE_AUTH_TOKEN"
           required_packages=(
-            "signetai-linux-x64"
-            "signetai-linux-arm64"
-            "signetai-darwin-x64"
-            "signetai-darwin-arm64"
-            "signetai-win32-x64"
             "signetai"
           )
           for package in "${required_packages[@]}"; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,25 +287,25 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Stage native npm platform packages
+      - name: Stage native npm package assets
         shell: bash
         run: |
           set -euo pipefail
-          stage_platform_package() {
+          stage_bundled_binary() {
             local platform="$1"
             local asset="$2"
             local binary="$3"
-            local package_dir="dist/signetai-${platform}"
-            mkdir -p "${package_dir}/bin"
-            cp "dist/native/${asset}" "${package_dir}/bin/${binary}"
-            chmod 755 "${package_dir}/bin/${binary}"
+            local native_dir="dist/signetai/native/${platform}"
+            mkdir -p "${native_dir}"
+            cp "dist/native/${asset}" "${native_dir}/${binary}"
+            chmod 755 "${native_dir}/${binary}"
           }
 
-          stage_platform_package "linux-x64" "signet-linux-x64" "signet"
-          stage_platform_package "linux-arm64" "signet-linux-arm64" "signet"
-          stage_platform_package "darwin-x64" "signet-darwin-x64" "signet"
-          stage_platform_package "darwin-arm64" "signet-darwin-arm64" "signet"
-          stage_platform_package "win32-x64" "signet-win32-x64.exe" "signet.exe"
+          stage_bundled_binary "linux-x64" "signet-linux-x64" "signet"
+          stage_bundled_binary "linux-arm64" "signet-linux-arm64" "signet"
+          stage_bundled_binary "darwin-x64" "signet-darwin-x64" "signet"
+          stage_bundled_binary "darwin-arm64" "signet-darwin-arm64" "signet"
+          stage_bundled_binary "win32-x64" "signet-win32-x64.exe" "signet.exe"
 
       - name: Validate publish manifests
         run: bun scripts/check-publish-manifests.ts
@@ -333,11 +333,6 @@ jobs:
             (cd "$package_dir" && npm publish --tag next --access public)
           }
 
-          publish_npm_package dist/signetai-linux-x64
-          publish_npm_package dist/signetai-linux-arm64
-          publish_npm_package dist/signetai-darwin-x64
-          publish_npm_package dist/signetai-darwin-arm64
-          publish_npm_package dist/signetai-win32-x64
           publish_npm_package dist/signetai
           publish_npm_package integrations/openclaw/memory-adapter true
         env:

--- a/README.md
+++ b/README.md
@@ -190,9 +190,11 @@ signet setup               # interactive setup wizard
 ```
 
 curl, npm, and Bun all install the same compiled Signet binary. The npm and
-Bun package-manager paths use optional native packages for the current platform;
-install scripts only link the already-installed binary into place. They do not
-install Bun, rebuild Signet, or install daemon dependencies.
+Bun package-manager paths install the `signetai` package with bundled native
+assets for the supported platforms. Install scripts only link the bundled binary
+into place; if scripts are disabled, the wrapper resolves the bundled binary
+directly. They do not install Bun, rebuild Signet, or install daemon
+dependencies.
 Published native binaries currently cover Linux x64, Linux arm64, macOS x64,
 macOS arm64, and Windows x64. Windows direct installs should use
 `npm install -g signetai`; the old PowerShell `install.ps1` path has been

--- a/bun.lock
+++ b/bun.lock
@@ -21,13 +21,6 @@
         "signet": "bin/signet.js",
         "signet-mcp": "bin/signet-mcp.js",
       },
-      "optionalDependencies": {
-        "signetai-darwin-arm64": "0.138.13",
-        "signetai-darwin-x64": "0.138.13",
-        "signetai-linux-arm64": "0.138.13",
-        "signetai-linux-x64": "0.138.13",
-        "signetai-win32-x64": "0.138.13",
-      },
     },
     "dist/signetai-darwin-arm64": {
       "name": "signetai-darwin-arm64",

--- a/dist/signetai-darwin-arm64/package.json
+++ b/dist/signetai-darwin-arm64/package.json
@@ -13,8 +13,6 @@
     "README.md",
     "LICENSE"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "license": "Apache-2.0"
 }

--- a/dist/signetai-darwin-x64/package.json
+++ b/dist/signetai-darwin-x64/package.json
@@ -13,8 +13,6 @@
     "README.md",
     "LICENSE"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "license": "Apache-2.0"
 }

--- a/dist/signetai-linux-arm64/package.json
+++ b/dist/signetai-linux-arm64/package.json
@@ -13,8 +13,6 @@
     "README.md",
     "LICENSE"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "license": "Apache-2.0"
 }

--- a/dist/signetai-linux-x64/package.json
+++ b/dist/signetai-linux-x64/package.json
@@ -13,8 +13,6 @@
     "README.md",
     "LICENSE"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "license": "Apache-2.0"
 }

--- a/dist/signetai-win32-x64/package.json
+++ b/dist/signetai-win32-x64/package.json
@@ -13,8 +13,6 @@
     "README.md",
     "LICENSE"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "license": "Apache-2.0"
 }

--- a/dist/signetai/README.md
+++ b/dist/signetai/README.md
@@ -8,10 +8,10 @@ npm install -g signetai
 bun add -g signetai
 ```
 
-The package uses optional native packages to install the binary for your
-platform. `postinstall` only links or copies that already-installed binary into
-the package directory; if install scripts are disabled, the `signet` command can
-still resolve and execute the optional native package directly.
+The package includes bundled native assets for the supported platforms.
+`postinstall` only links or copies the bundled binary into the package directory;
+if install scripts are disabled, the `signet` command resolves and executes the
+bundled native binary directly.
 
 The package does not install Bun, does not build Signet from source, and does
 not install runtime dependencies such as `better-sqlite3`.

--- a/dist/signetai/bin/launch.js
+++ b/dist/signetai/bin/launch.js
@@ -2,30 +2,27 @@
 
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
-import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { detectNativePlatform, nativePlatforms } from "./native-platforms.js";
 
 const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
-const require = createRequire(import.meta.url);
 const binaryName = process.platform === "win32" ? "signet.exe" : "signet";
 const binaryPath = join(packageDir, "native", binaryName);
 
-function resolvePackageBinaryPath() {
+function resolveBundledBinaryPath() {
 	const platform = detectNativePlatform();
 	const nativePackage = nativePlatforms[platform];
-	const packageJsonPath = require.resolve(`${nativePackage.packageName}/package.json`);
-	return join(dirname(packageJsonPath), "bin", nativePackage.binaryName);
+	return join(packageDir, "native", platform, nativePackage.binaryName);
 }
 
 function resolveBinaryPath() {
 	if (existsSync(binaryPath)) return binaryPath;
 
 	try {
-		const packageBinaryPath = resolvePackageBinaryPath();
-		if (existsSync(packageBinaryPath)) return packageBinaryPath;
+		const bundledBinaryPath = resolveBundledBinaryPath();
+		if (existsSync(bundledBinaryPath)) return bundledBinaryPath;
 	} catch {
 		// Fall through to the user-facing install error below.
 	}
@@ -37,8 +34,8 @@ export function launchSignet(options = {}) {
 	const resolvedBinaryPath = resolveBinaryPath();
 	if (!resolvedBinaryPath) {
 		console.error("Signet native binary is missing.");
-		console.error("Reinstall without --omit=optional: npm install -g signetai or bun add -g signetai");
-		console.error("If install scripts were disabled, rerun the command; the wrapper can use optional native packages directly.");
+		console.error("Reinstall Signet: npm install -g signetai or bun add -g signetai");
+		console.error("The npm package should include native/<platform>/signet for your platform.");
 		process.exit(1);
 	}
 

--- a/dist/signetai/bin/native-platforms.js
+++ b/dist/signetai/bin/native-platforms.js
@@ -1,22 +1,17 @@
 export const nativePlatforms = {
 	"linux-x64": {
-		packageName: "signetai-linux-x64",
 		binaryName: "signet",
 	},
 	"linux-arm64": {
-		packageName: "signetai-linux-arm64",
 		binaryName: "signet",
 	},
 	"darwin-x64": {
-		packageName: "signetai-darwin-x64",
 		binaryName: "signet",
 	},
 	"darwin-arm64": {
-		packageName: "signetai-darwin-arm64",
 		binaryName: "signet",
 	},
 	"win32-x64": {
-		packageName: "signetai-win32-x64",
 		binaryName: "signet.exe",
 	},
 };

--- a/dist/signetai/package.json
+++ b/dist/signetai/package.json
@@ -12,6 +12,7 @@
     "bin/native-platforms.js",
     "bin/signet.js",
     "bin/signet-mcp.js",
+    "native/**",
     "scripts/install-native.js",
     "scripts/verify-wrapper.js",
     "README.md",
@@ -20,13 +21,6 @@
   "scripts": {
     "build": "node scripts/verify-wrapper.js",
     "postinstall": "node scripts/install-native.js"
-  },
-  "optionalDependencies": {
-    "signetai-linux-x64": "0.138.13",
-    "signetai-linux-arm64": "0.138.13",
-    "signetai-darwin-x64": "0.138.13",
-    "signetai-darwin-arm64": "0.138.13",
-    "signetai-win32-x64": "0.138.13"
   },
   "keywords": [
     "ai",

--- a/dist/signetai/scripts/install-native.js
+++ b/dist/signetai/scripts/install-native.js
@@ -2,14 +2,12 @@
 
 import { copyFileSync, existsSync, linkSync, mkdirSync, readFileSync, rmSync, unlinkSync } from "node:fs";
 import { chmod } from "node:fs/promises";
-import { createRequire } from "node:module";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { detectNativePlatform, nativePlatforms } from "../bin/native-platforms.js";
 
 const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
-const require = createRequire(import.meta.url);
 
 function isWorkspacePackage() {
 	const workspaceRoot = dirname(dirname(packageDir));
@@ -54,18 +52,10 @@ async function main() {
 
 	const platform = detectNativePlatform();
 	const nativePackage = nativePlatforms[platform];
-	let source;
-	try {
-		source = join(dirname(require.resolve(`${nativePackage.packageName}/package.json`)), "bin", nativePackage.binaryName);
-	} catch {
-		console.error(`Signet native package ${nativePackage.packageName} was not installed.`);
-		console.error("This usually means optional dependencies were disabled with --omit=optional.");
-		console.error("The signet wrapper will try to resolve the optional native package at runtime.");
-		return;
-	}
+	const source = join(packageDir, "native", platform, nativePackage.binaryName);
 
 	if (!existsSync(source)) {
-		console.error(`Signet native binary is missing from ${nativePackage.packageName}: ${source}`);
+		console.error(`Signet native binary is missing from the npm package: ${source}`);
 		return;
 	}
 
@@ -77,7 +67,7 @@ async function main() {
 		if (process.platform !== "win32") {
 			await chmod(destination, 0o755);
 		}
-		console.log(`Linked Signet native binary for ${platform}`);
+		console.log(`Linked bundled Signet native binary for ${platform}`);
 	} catch (err) {
 		rmSync(destination, { force: true });
 		throw err;

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -31,9 +31,10 @@ bun add -g signetai
 ```
 
 All three install paths install the same compiled Signet binary. The npm and
-Bun paths use optional native packages for the current platform; install scripts
-only link the already-installed binary into place. They do not install Bun,
-rebuild Signet, or install daemon dependencies.
+Bun paths install the `signetai` package with bundled native assets for the
+supported platforms. Install scripts only link the bundled binary into place; if
+scripts are disabled, the wrapper resolves the bundled binary directly. They do
+not install Bun, rebuild Signet, or install daemon dependencies.
 Published native binaries currently cover Linux x64, Linux arm64, macOS x64,
 macOS arm64, and Windows x64. Windows direct installs should use
 `npm install -g signetai`; the old PowerShell `install.ps1` path has been

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -128,9 +128,10 @@ Running `signet setup` launches an interactive wizard that walks you through
 the full setup. You don't need to read anything else first.
 
 All three install paths install the same compiled Signet binary. The npm and
-Bun paths use optional native packages for the current platform; install scripts
-only link the already-installed binary into place. They do not install Bun,
-rebuild Signet, or install daemon dependencies.
+Bun paths install the `signetai` package with bundled native assets for the
+supported platforms. Install scripts only link the bundled binary into place; if
+scripts are disabled, the wrapper resolves the bundled binary directly. They do
+not install Bun, rebuild Signet, or install daemon dependencies.
 Published native binaries currently cover Linux x64, Linux arm64, macOS x64,
 macOS arm64, and Windows x64. Windows direct installs should use
 `npm install -g signetai`; the old PowerShell `install.ps1` path has been

--- a/scripts/check-publish-manifests.test.ts
+++ b/scripts/check-publish-manifests.test.ts
@@ -4,9 +4,9 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
 import {
+	collectBundledNativePackageIssues,
 	collectManifestIssues,
 	collectNativeManifestIssues,
-	collectNativePackageIssues,
 	collectWorkspacePackages,
 	isPublishableWorkspacePackage,
 	listPublishableManifestTargets,
@@ -137,7 +137,7 @@ describe("check-publish-manifests", () => {
 		expect(workflow).not.toContain("if: matrix.platform != 'linux-arm64'");
 	});
 
-	test("publishes native release assets, platform packages, and the native manifest", () => {
+	test("publishes native release assets, bundled npm assets, and the native manifest", () => {
 		const root = join(import.meta.dir, "..");
 		const workflow = readFileSync(join(root, ".github", "workflows", "release.yml"), "utf-8");
 		const promoteWorkflow = readFileSync(join(root, ".github", "workflows", "promote-release.yml"), "utf-8");
@@ -149,22 +149,25 @@ describe("check-publish-manifests", () => {
 		expect(workflow.indexOf('SIGNET_VERSION="$NEW_VERSION" bun scripts/generate-native-manifest.ts')).toBeLessThan(
 			workflow.indexOf("bun scripts/check-publish-manifests.ts"),
 		);
-		expect(workflow.indexOf("bun scripts/check-publish-manifests.ts")).toBeLessThan(
-			workflow.indexOf("publish_npm_package dist/signetai-linux-x64"),
+		expect(workflow.indexOf('SIGNET_VERSION="$NEW_VERSION" bun scripts/generate-native-manifest.ts')).toBeLessThan(
+			workflow.indexOf('stage_bundled_binary "linux-x64" "signet-linux-x64" "signet"'),
 		);
-		expect(workflow).toContain('stage_platform_package "linux-x64" "signet-linux-x64" "signet"');
-		expect(workflow).toContain('stage_platform_package "linux-arm64" "signet-linux-arm64" "signet"');
-		expect(workflow).toContain('stage_platform_package "darwin-x64" "signet-darwin-x64" "signet"');
-		expect(workflow).toContain('stage_platform_package "darwin-arm64" "signet-darwin-arm64" "signet"');
-		expect(workflow).toContain('stage_platform_package "win32-x64" "signet-win32-x64.exe" "signet.exe"');
-		expect(workflow).toContain("publish_npm_package dist/signetai-linux-x64");
-		expect(workflow).toContain("publish_npm_package dist/signetai-linux-arm64");
-		expect(workflow).toContain("publish_npm_package dist/signetai-darwin-x64");
-		expect(workflow).toContain("publish_npm_package dist/signetai-darwin-arm64");
-		expect(workflow).toContain("publish_npm_package dist/signetai-win32-x64");
-		expect(workflow.indexOf("publish_npm_package dist/signetai-win32-x64")).toBeLessThan(
+		expect(workflow.indexOf('stage_bundled_binary "win32-x64" "signet-win32-x64.exe" "signet.exe"')).toBeLessThan(
+			workflow.indexOf("bun scripts/check-publish-manifests.ts"),
+		);
+		expect(workflow.indexOf("bun scripts/check-publish-manifests.ts")).toBeLessThan(
 			workflow.indexOf("publish_npm_package dist/signetai\n"),
 		);
+		expect(workflow).toContain('stage_bundled_binary "linux-x64" "signet-linux-x64" "signet"');
+		expect(workflow).toContain('stage_bundled_binary "linux-arm64" "signet-linux-arm64" "signet"');
+		expect(workflow).toContain('stage_bundled_binary "darwin-x64" "signet-darwin-x64" "signet"');
+		expect(workflow).toContain('stage_bundled_binary "darwin-arm64" "signet-darwin-arm64" "signet"');
+		expect(workflow).toContain('stage_bundled_binary "win32-x64" "signet-win32-x64.exe" "signet.exe"');
+		expect(workflow).not.toContain("publish_npm_package dist/signetai-linux-x64");
+		expect(workflow).not.toContain("publish_npm_package dist/signetai-linux-arm64");
+		expect(workflow).not.toContain("publish_npm_package dist/signetai-darwin-x64");
+		expect(workflow).not.toContain("publish_npm_package dist/signetai-darwin-arm64");
+		expect(workflow).not.toContain("publish_npm_package dist/signetai-win32-x64");
 		expect(workflow).toContain('npm dist-tag add "${package_name}@${NEW_VERSION}" next');
 		expect(workflow).toContain("NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/.npmrc");
 		expect(workflow).toContain("npm publish --tag next --access public");
@@ -175,11 +178,11 @@ describe("check-publish-manifests", () => {
 		expect(workflow).not.toContain("npm publish --access public");
 		expect(workflow).not.toContain("bundle-latest");
 		expect(workflow).not.toContain("deploy/bundle");
-		expect(promoteWorkflow).toContain('"signetai-linux-x64"');
-		expect(promoteWorkflow).toContain('"signetai-linux-arm64"');
-		expect(promoteWorkflow).toContain('"signetai-darwin-x64"');
-		expect(promoteWorkflow).toContain('"signetai-darwin-arm64"');
-		expect(promoteWorkflow).toContain('"signetai-win32-x64"');
+		expect(promoteWorkflow).not.toContain('"signetai-linux-x64"');
+		expect(promoteWorkflow).not.toContain('"signetai-linux-arm64"');
+		expect(promoteWorkflow).not.toContain('"signetai-darwin-x64"');
+		expect(promoteWorkflow).not.toContain('"signetai-darwin-arm64"');
+		expect(promoteWorkflow).not.toContain('"signetai-win32-x64"');
 		expect(promoteWorkflow).toContain('"signetai"');
 		expect(promoteWorkflow).toContain('npm view "${package}@${VERSION}" version >/dev/null');
 		expect(promoteWorkflow).toContain('npm dist-tag add "${package}@${VERSION}" latest');
@@ -242,20 +245,21 @@ describe("check-publish-manifests", () => {
 		});
 	});
 
-	test("validates staged native platform package binaries", () => {
-		const root = mkdtempSync(join(tmpdir(), "signet-native-packages-"));
+	test("validates bundled native package binaries", () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-native-bundle-"));
 		try {
-			const packageFile = join(root, "dist", "signetai-linux-x64", "package.json");
-			mkdirSync(dirname(packageFile), { recursive: true });
-			writeJson(packageFile, {
-				name: "signetai-linux-x64",
-				version: "0.1.0",
-				publishConfig: { access: "public" },
-			});
+			const packageDir = join(root, "dist", "signetai");
+			const packageFile = join(packageDir, "package.json");
+			mkdirSync(join(packageDir, "bin"), { recursive: true });
+			writeJson(packageFile, { name: "signetai", version: "0.1.0", publishConfig: { access: "public" } });
+			writeFileSync(
+				join(packageDir, "bin", "native-platforms.js"),
+				`export const nativePlatforms = {\n\t"linux-x64": { binaryName: "signet" },\n};\n`,
+			);
 
-			expect(collectNativePackageIssues([packageFile])).toContainEqual({
+			expect(collectBundledNativePackageIssues([packageFile])).toContainEqual({
 				file: packageFile,
-				reason: `missing staged native binary ${join(root, "dist", "signetai-linux-x64", "bin", "signet")}`,
+				reason: `missing bundled native binary ${join(packageDir, "native", "linux-x64", "signet")}`,
 			});
 		} finally {
 			rmSync(root, { recursive: true, force: true });
@@ -289,6 +293,7 @@ describe("check-publish-manifests", () => {
 			name?: string;
 			dependencies?: Record<string, string>;
 			optionalDependencies?: Record<string, string>;
+			files?: string[];
 			publishConfig?: unknown;
 			scripts?: Record<string, string>;
 			bin?: Record<string, string>;
@@ -301,26 +306,24 @@ describe("check-publish-manifests", () => {
 		expect(manifest.name).toBe("signetai");
 		expect(manifest.publishConfig).toEqual({ access: "public" });
 		expect(manifest.dependencies).toBeUndefined();
-		expect(manifest.optionalDependencies).toEqual({
-			"signetai-linux-x64": manifest.version,
-			"signetai-linux-arm64": manifest.version,
-			"signetai-darwin-x64": manifest.version,
-			"signetai-darwin-arm64": manifest.version,
-			"signetai-win32-x64": manifest.version,
-		});
+		expect(manifest.optionalDependencies).toBeUndefined();
+		expect(manifest.files).toContain("native/**");
 		expect(manifest.scripts?.postinstall).toContain("scripts/install-native.js");
 		expect(manifest.bin?.signet).toBe("bin/signet.js");
 		expect(manifest.bin?.["signet-mcp"]).toBe("bin/signet-mcp.js");
 		expect(launcher).toContain('join(packageDir, "native"');
-		expect(launcher).toContain("require.resolve");
-		expect(nativePlatforms).toContain("signetai-linux-x64");
-		expect(nativePlatforms).toContain("signetai-linux-arm64");
-		expect(nativePlatforms).toContain("signetai-darwin-x64");
-		expect(nativePlatforms).toContain("signetai-darwin-arm64");
-		expect(nativePlatforms).toContain("signetai-win32-x64");
+		expect(launcher).toContain("resolveBundledBinaryPath");
+		expect(launcher).not.toContain("require.resolve");
+		expect(nativePlatforms).toContain('"linux-x64"');
+		expect(nativePlatforms).toContain('"linux-arm64"');
+		expect(nativePlatforms).toContain('"darwin-x64"');
+		expect(nativePlatforms).toContain('"darwin-arm64"');
+		expect(nativePlatforms).toContain('"win32-x64"');
+		expect(nativePlatforms).not.toContain("packageName");
 		expect(mcpBin).toContain("forceMcp: true");
 		expect(installer).toContain("linkSync");
-		expect(installer).toContain("require.resolve");
+		expect(installer).not.toContain("require.resolve");
+		expect(installer).toContain("Linked bundled Signet native binary");
 		expect(installer).not.toContain("native-manifest.json");
 		expect(installer).not.toContain("https");
 		expect(installer).not.toContain("better-sqlite3");

--- a/scripts/check-publish-manifests.ts
+++ b/scripts/check-publish-manifests.ts
@@ -243,27 +243,23 @@ export function collectNativeManifestIssues(
 	return issues;
 }
 
-function packageNameToNativePlatform(packageName: string): string | null {
-	const prefix = "signetai-";
-	return packageName.startsWith(prefix) ? packageName.slice(prefix.length) : null;
-}
-
-export function collectNativePackageIssues(targets: readonly string[]): NativeManifestIssue[] {
+export function collectBundledNativePackageIssues(targets: readonly string[]): NativeManifestIssue[] {
 	const issues: NativeManifestIssue[] = [];
 	for (const file of targets) {
-		const pkg = readPackageJson(file);
-		const packageName = getPackageName(file, pkg);
-		const platform = packageNameToNativePlatform(packageName);
-		if (!platform) continue;
+		if (!file.endsWith("dist/signetai/package.json")) continue;
 
-		const binaryName = platform.startsWith("win32-") ? "signet.exe" : "signet";
-		const binaryFile = file.replace(/package\.json$/, `bin/${binaryName}`);
-		if (!existsSync(binaryFile)) {
-			issues.push({ file, reason: `missing staged native binary ${binaryFile}` });
-			continue;
-		}
-		if (!statSync(binaryFile).isFile()) {
-			issues.push({ file, reason: `staged native binary is not a file: ${binaryFile}` });
+		const nativePlatformsFile = file.replace(/package\.json$/, "bin/native-platforms.js");
+		const supportedPlatforms = parseSupportedNativePlatforms(readFileSync(nativePlatformsFile, "utf8"));
+		for (const platform of supportedPlatforms) {
+			const binaryName = platform.startsWith("win32-") ? "signet.exe" : "signet";
+			const binaryFile = file.replace(/package\.json$/, `native/${platform}/${binaryName}`);
+			if (!existsSync(binaryFile)) {
+				issues.push({ file, reason: `missing bundled native binary ${binaryFile}` });
+				continue;
+			}
+			if (!statSync(binaryFile).isFile()) {
+				issues.push({ file, reason: `bundled native binary is not a file: ${binaryFile}` });
+			}
 		}
 	}
 
@@ -287,7 +283,7 @@ function main(): void {
 					parseSupportedNativePlatforms(readFileSync("dist/signetai/bin/native-platforms.js", "utf8")),
 				)
 			: [];
-	const nativePackageIssues = collectNativePackageIssues(targets);
+	const nativePackageIssues = collectBundledNativePackageIssues(targets);
 
 	if (issues.length > 0 || nativeManifestIssues.length > 0 || nativePackageIssues.length > 0) {
 		if (issues.length > 0) console.error(formatIssues(issues));

--- a/scripts/install-copy-regression.test.ts
+++ b/scripts/install-copy-regression.test.ts
@@ -28,7 +28,7 @@ describe("install copy", () => {
 		for (const path of ["README.md", "docs/QUICKSTART.md", "docs/CLI.md", "dist/signetai/README.md"]) {
 			const content = read(path);
 			expect(content).toContain("same compiled Signet binary");
-			expect(content).toContain("optional native packages");
+			expect(content).toContain("bundled native");
 			expect(content).toContain("npm install -g signetai");
 			expect(content).toContain("bun add -g signetai");
 		}
@@ -66,25 +66,20 @@ describe("install copy", () => {
 
 		expect(manifest.scripts?.postinstall).toContain("scripts/install-native.js");
 		expect(manifest.dependencies).toBeUndefined();
-		expect(manifest.optionalDependencies).toEqual({
-			"signetai-linux-x64": "0.138.12",
-			"signetai-linux-arm64": "0.138.12",
-			"signetai-darwin-x64": "0.138.12",
-			"signetai-darwin-arm64": "0.138.12",
-			"signetai-win32-x64": "0.138.12",
-		});
+		expect(manifest.optionalDependencies).toBeUndefined();
 		expect(manifest.bin?.signet).toBe("bin/signet.js");
 		expect(manifest.bin?.["signet-mcp"]).toBe("bin/signet-mcp.js");
 		expect(launcher).toContain('join(packageDir, "native"');
-		expect(launcher).toContain("require.resolve");
-		expect(nativePlatforms).toContain("signetai-linux-x64");
-		expect(nativePlatforms).toContain("signetai-linux-arm64");
-		expect(nativePlatforms).toContain("signetai-darwin-x64");
-		expect(nativePlatforms).toContain("signetai-darwin-arm64");
-		expect(nativePlatforms).toContain("signetai-win32-x64");
+		expect(launcher).toContain("resolveBundledBinaryPath");
+		expect(launcher).not.toContain("require.resolve");
+		expect(nativePlatforms).toContain('"linux-x64"');
+		expect(nativePlatforms).toContain('"linux-arm64"');
+		expect(nativePlatforms).toContain('"darwin-x64"');
+		expect(nativePlatforms).toContain('"darwin-arm64"');
+		expect(nativePlatforms).toContain('"win32-x64"');
 		expect(mcpWrapper).toContain("forceMcp: true");
 		expect(installer).toContain("linkSync");
-		expect(installer).toContain("require.resolve");
+		expect(installer).not.toContain("require.resolve");
 		expect(installer).toContain("Skipping Signet native binary linking in workspace install");
 		expect(installer).not.toContain("native-manifest.json");
 		expect(installer).not.toContain("https");

--- a/scripts/native-install-smoke.test.ts
+++ b/scripts/native-install-smoke.test.ts
@@ -183,23 +183,19 @@ describe("native install smoke", () => {
 		expect(existsSync(join(binDir, "signet"))).toBe(true);
 	});
 
-	test("npm wrapper launches optional package binary with or without postinstall", async () => {
+	test("npm wrapper launches bundled binary with or without postinstall", async () => {
 		if (process.platform === "win32") return;
 
 		const dir = tempDir();
 		const packageDir = join(dir, "signetai");
 		const platform = platformKey();
-		const nativePackageDir = join(packageDir, "node_modules", `signetai-${platform}`);
-		const nativePackageBin = join(nativePackageDir, "bin", "signet");
+		const nativePackageDir = join(packageDir, "native", platform);
+		const nativePackageBin = join(nativePackageDir, "signet");
 		mkdirSync(packageDir, { recursive: true });
-		mkdirSync(join(nativePackageDir, "bin"), { recursive: true });
+		mkdirSync(nativePackageDir, { recursive: true });
 		cpSync(join(root, "dist", "signetai", "scripts"), join(packageDir, "scripts"), { recursive: true });
 		cpSync(join(root, "dist", "signetai", "bin"), join(packageDir, "bin"), { recursive: true });
 		writeFileSync(join(packageDir, "package.json"), readFileSync(join(root, "dist", "signetai", "package.json")));
-		writeFileSync(
-			join(nativePackageDir, "package.json"),
-			JSON.stringify({ name: `signetai-${platform}`, version: "0.0.0-test", type: "module" }, null, 2),
-		);
 		writeFileSync(nativePackageBin, fakeNativeBinary());
 		chmodSync(nativePackageBin, 0o755);
 
@@ -210,7 +206,7 @@ describe("native install smoke", () => {
 		const install = await runCommand("node", [join(packageDir, "scripts", "install-native.js")], process.env);
 
 		expect(install.status).toBe(0);
-		expect(install.stdout).toContain(`Linked Signet native binary for ${platform}`);
+		expect(install.stdout).toContain(`Linked bundled Signet native binary for ${platform}`);
 		const installedBinary = join(packageDir, "native", "signet");
 		expect(existsSync(installedBinary)).toBe(true);
 		chmodSync(installedBinary, 0o755);


### PR DESCRIPTION
## Summary

Follow-up to the post-merge release failures from PR #816 and PR #818.

Both publish attempts failed at the first new native platform package:

```text
npm error 404 Not Found - PUT https://registry.npmjs.org/signetai-linux-x64 - Not found
```

The scoped and unscoped package attempts both failed, which means the current npm token can publish the existing `signetai` package but cannot create new package names. This PR removes that requirement entirely.

What changes:

- `signetai` now carries bundled native assets under `native/<platform>/<binary>`.
- The wrapper resolves `native/<platform>/<binary>` directly, so installs still work if postinstall scripts are disabled.
- `postinstall` only links/copies the bundled binary to the legacy `native/signet` path when scripts are allowed.
- Release publishing stages downloaded native release assets into `dist/signetai/native/...` and publishes only the existing `signetai` npm package.
- Promote-release only requires/promotes `signetai` plus the optional OpenClaw adapter.
- Publish checks now fail if the bundled native binaries are missing before npm publish.

Tradeoff: npm/Bun installs will download the bundled assets for all supported platforms. That is heavier than per-platform optional packages, but it works with the npm token we actually have and preserves scripts-disabled installs.

## Verification

- `bun install --frozen-lockfile`
- `bun test scripts/check-publish-manifests.test.ts scripts/install-copy-regression.test.ts scripts/native-install-smoke.test.ts scripts/version-sync.test.ts`
- `bunx biome check dist/signetai/bin/launch.js dist/signetai/bin/native-platforms.js dist/signetai/scripts/install-native.js scripts/check-publish-manifests.ts scripts/check-publish-manifests.test.ts scripts/install-copy-regression.test.ts scripts/native-install-smoke.test.ts`
- Staged fake `dist/signetai/native/<platform>` binaries and `dist/native/native-manifest.json`, then ran `bun scripts/check-publish-manifests.ts`
- With staged fake binaries, `npm pack --dry-run ./dist/signetai` included all five native asset paths

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally
