### PR TITLE
fix(release): publish native npm assets as release tarballs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,28 +287,48 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Stage native npm package assets
+      - name: Pack native npm release assets
         shell: bash
         run: |
           set -euo pipefail
-          stage_bundled_binary() {
+          mkdir -p dist/native-packages
+          stage_native_package() {
             local platform="$1"
             local asset="$2"
             local binary="$3"
-            local native_dir="dist/signetai/native/${platform}"
-            mkdir -p "${native_dir}"
-            cp "dist/native/${asset}" "${native_dir}/${binary}"
-            chmod 755 "${native_dir}/${binary}"
+            local package_dir="dist/signetai-${platform}"
+            mkdir -p "${package_dir}/bin"
+            cp "dist/native/${asset}" "${package_dir}/bin/${binary}"
+            chmod 755 "${package_dir}/bin/${binary}"
+            npm pack "${package_dir}" --pack-destination dist/native-packages
           }
 
-          stage_bundled_binary "linux-x64" "signet-linux-x64" "signet"
-          stage_bundled_binary "linux-arm64" "signet-linux-arm64" "signet"
-          stage_bundled_binary "darwin-x64" "signet-darwin-x64" "signet"
-          stage_bundled_binary "darwin-arm64" "signet-darwin-arm64" "signet"
-          stage_bundled_binary "win32-x64" "signet-win32-x64.exe" "signet.exe"
+          stage_native_package "linux-x64" "signet-linux-x64" "signet"
+          stage_native_package "linux-arm64" "signet-linux-arm64" "signet"
+          stage_native_package "darwin-x64" "signet-darwin-x64" "signet"
+          stage_native_package "darwin-arm64" "signet-darwin-arm64" "signet"
+          stage_native_package "win32-x64" "signet-win32-x64.exe" "signet.exe"
+
+          gh release upload "v${NEW_VERSION}" dist/native-packages/*.tgz --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Point npm wrapper at native release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/v${NEW_VERSION}"
+          npm pkg set --prefix dist/signetai \
+            "optionalDependencies.signetai-linux-x64=${release_url}/signetai-linux-x64-${NEW_VERSION}.tgz" \
+            "optionalDependencies.signetai-linux-arm64=${release_url}/signetai-linux-arm64-${NEW_VERSION}.tgz" \
+            "optionalDependencies.signetai-darwin-x64=${release_url}/signetai-darwin-x64-${NEW_VERSION}.tgz" \
+            "optionalDependencies.signetai-darwin-arm64=${release_url}/signetai-darwin-arm64-${NEW_VERSION}.tgz" \
+            "optionalDependencies.signetai-win32-x64=${release_url}/signetai-win32-x64-${NEW_VERSION}.tgz"
 
       - name: Validate publish manifests
         run: bun scripts/check-publish-manifests.ts
+        env:
+          SIGNET_EXPECT_NATIVE_OPTIONAL_DEPS: "1"
 
       - name: Publish npm packages
         run: |

--- a/README.md
+++ b/README.md
@@ -190,11 +190,11 @@ signet setup               # interactive setup wizard
 ```
 
 curl, npm, and Bun all install the same compiled Signet binary. The npm and
-Bun package-manager paths install the `signetai` package with bundled native
-assets for the supported platforms. Install scripts only link the bundled binary
-into place; if scripts are disabled, the wrapper resolves the bundled binary
-directly. They do not install Bun, rebuild Signet, or install daemon
-dependencies.
+Bun package-manager paths install the `signetai` wrapper plus a platform
+native package tarball from the same GitHub release. Install scripts only link
+the native binary into place; if scripts are disabled, the wrapper resolves the
+native package directly. They do not install Bun, rebuild Signet, or install
+daemon dependencies.
 Published native binaries currently cover Linux x64, Linux arm64, macOS x64,
 macOS arm64, and Windows x64. Windows direct installs should use
 `npm install -g signetai`; the old PowerShell `install.ps1` path has been

--- a/dist/signetai/README.md
+++ b/dist/signetai/README.md
@@ -8,10 +8,10 @@ npm install -g signetai
 bun add -g signetai
 ```
 
-The package includes bundled native assets for the supported platforms.
-`postinstall` only links or copies the bundled binary into the package directory;
-if install scripts are disabled, the `signet` command resolves and executes the
-bundled native binary directly.
+The package installs a platform native package tarball from the same GitHub
+release. `postinstall` only links or copies that binary into the package
+directory; if install scripts are disabled, the `signet` command resolves and
+executes the native package directly.
 
 The package does not install Bun, does not build Signet from source, and does
 not install runtime dependencies such as `better-sqlite3`.

--- a/dist/signetai/bin/launch.js
+++ b/dist/signetai/bin/launch.js
@@ -2,27 +2,30 @@
 
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { detectNativePlatform, nativePlatforms } from "./native-platforms.js";
 
 const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const require = createRequire(import.meta.url);
 const binaryName = process.platform === "win32" ? "signet.exe" : "signet";
 const binaryPath = join(packageDir, "native", binaryName);
 
-function resolveBundledBinaryPath() {
+function resolveNativePackageBinaryPath() {
 	const platform = detectNativePlatform();
 	const nativePackage = nativePlatforms[platform];
-	return join(packageDir, "native", platform, nativePackage.binaryName);
+	const packageJsonPath = require.resolve(`${nativePackage.packageName}/package.json`);
+	return join(dirname(packageJsonPath), "bin", nativePackage.binaryName);
 }
 
 function resolveBinaryPath() {
 	if (existsSync(binaryPath)) return binaryPath;
 
 	try {
-		const bundledBinaryPath = resolveBundledBinaryPath();
-		if (existsSync(bundledBinaryPath)) return bundledBinaryPath;
+		const packageBinaryPath = resolveNativePackageBinaryPath();
+		if (existsSync(packageBinaryPath)) return packageBinaryPath;
 	} catch {
 		// Fall through to the user-facing install error below.
 	}
@@ -35,7 +38,7 @@ export function launchSignet(options = {}) {
 	if (!resolvedBinaryPath) {
 		console.error("Signet native binary is missing.");
 		console.error("Reinstall Signet: npm install -g signetai or bun add -g signetai");
-		console.error("The npm package should include native/<platform>/signet for your platform.");
+		console.error("The npm package should install the matching native optional dependency for your platform.");
 		process.exit(1);
 	}
 

--- a/dist/signetai/bin/native-platforms.js
+++ b/dist/signetai/bin/native-platforms.js
@@ -1,18 +1,23 @@
 export const nativePlatforms = {
 	"linux-x64": {
 		binaryName: "signet",
+		packageName: "signetai-linux-x64",
 	},
 	"linux-arm64": {
 		binaryName: "signet",
+		packageName: "signetai-linux-arm64",
 	},
 	"darwin-x64": {
 		binaryName: "signet",
+		packageName: "signetai-darwin-x64",
 	},
 	"darwin-arm64": {
 		binaryName: "signet",
+		packageName: "signetai-darwin-arm64",
 	},
 	"win32-x64": {
 		binaryName: "signet.exe",
+		packageName: "signetai-win32-x64",
 	},
 };
 

--- a/dist/signetai/package.json
+++ b/dist/signetai/package.json
@@ -12,7 +12,6 @@
     "bin/native-platforms.js",
     "bin/signet.js",
     "bin/signet-mcp.js",
-    "native/**",
     "scripts/install-native.js",
     "scripts/verify-wrapper.js",
     "README.md",

--- a/dist/signetai/scripts/install-native.js
+++ b/dist/signetai/scripts/install-native.js
@@ -2,12 +2,14 @@
 
 import { copyFileSync, existsSync, linkSync, mkdirSync, readFileSync, rmSync, unlinkSync } from "node:fs";
 import { chmod } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { detectNativePlatform, nativePlatforms } from "../bin/native-platforms.js";
 
 const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const require = createRequire(import.meta.url);
 
 function isWorkspacePackage() {
 	const workspaceRoot = dirname(dirname(packageDir));
@@ -52,10 +54,17 @@ async function main() {
 
 	const platform = detectNativePlatform();
 	const nativePackage = nativePlatforms[platform];
-	const source = join(packageDir, "native", platform, nativePackage.binaryName);
+	let source;
+	try {
+		source = join(dirname(require.resolve(`${nativePackage.packageName}/package.json`)), "bin", nativePackage.binaryName);
+	} catch {
+		console.error(`Signet native package ${nativePackage.packageName} was not installed.`);
+		console.error("The signet wrapper will try to resolve the optional native package at runtime.");
+		return;
+	}
 
 	if (!existsSync(source)) {
-		console.error(`Signet native binary is missing from the npm package: ${source}`);
+		console.error(`Signet native binary is missing from ${nativePackage.packageName}: ${source}`);
 		return;
 	}
 
@@ -67,7 +76,7 @@ async function main() {
 		if (process.platform !== "win32") {
 			await chmod(destination, 0o755);
 		}
-		console.log(`Linked bundled Signet native binary for ${platform}`);
+		console.log(`Linked Signet native binary for ${platform}`);
 	} catch (err) {
 		rmSync(destination, { force: true });
 		throw err;

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -31,10 +31,11 @@ bun add -g signetai
 ```
 
 All three install paths install the same compiled Signet binary. The npm and
-Bun paths install the `signetai` package with bundled native assets for the
-supported platforms. Install scripts only link the bundled binary into place; if
-scripts are disabled, the wrapper resolves the bundled binary directly. They do
-not install Bun, rebuild Signet, or install daemon dependencies.
+Bun paths install the `signetai` wrapper plus a platform native package tarball
+from the same GitHub release. Install scripts only link the native binary into
+place; if scripts are disabled, the wrapper resolves the native package
+directly. They do not install Bun, rebuild Signet, or install daemon
+dependencies.
 Published native binaries currently cover Linux x64, Linux arm64, macOS x64,
 macOS arm64, and Windows x64. Windows direct installs should use
 `npm install -g signetai`; the old PowerShell `install.ps1` path has been

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -128,10 +128,11 @@ Running `signet setup` launches an interactive wizard that walks you through
 the full setup. You don't need to read anything else first.
 
 All three install paths install the same compiled Signet binary. The npm and
-Bun paths install the `signetai` package with bundled native assets for the
-supported platforms. Install scripts only link the bundled binary into place; if
-scripts are disabled, the wrapper resolves the bundled binary directly. They do
-not install Bun, rebuild Signet, or install daemon dependencies.
+Bun paths install the `signetai` wrapper plus a platform native package tarball
+from the same GitHub release. Install scripts only link the native binary into
+place; if scripts are disabled, the wrapper resolves the native package
+directly. They do not install Bun, rebuild Signet, or install daemon
+dependencies.
 Published native binaries currently cover Linux x64, Linux arm64, macOS x64,
 macOS arm64, and Windows x64. Windows direct installs should use
 `npm install -g signetai`; the old PowerShell `install.ps1` path has been

--- a/scripts/check-publish-manifests.test.ts
+++ b/scripts/check-publish-manifests.test.ts
@@ -4,12 +4,13 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
 import {
-	collectBundledNativePackageIssues,
 	collectManifestIssues,
 	collectNativeManifestIssues,
+	collectNativeReleasePackageIssues,
 	collectWorkspacePackages,
 	isPublishableWorkspacePackage,
 	listPublishableManifestTargets,
+	parseNativePlatformPackages,
 	parseSupportedNativePlatforms,
 } from "./check-publish-manifests";
 
@@ -137,7 +138,7 @@ describe("check-publish-manifests", () => {
 		expect(workflow).not.toContain("if: matrix.platform != 'linux-arm64'");
 	});
 
-	test("publishes native release assets, bundled npm assets, and the native manifest", () => {
+	test("publishes native release assets, native package tarballs, and the native manifest", () => {
 		const root = join(import.meta.dir, "..");
 		const workflow = readFileSync(join(root, ".github", "workflows", "release.yml"), "utf-8");
 		const promoteWorkflow = readFileSync(join(root, ".github", "workflows", "promote-release.yml"), "utf-8");
@@ -150,19 +151,28 @@ describe("check-publish-manifests", () => {
 			workflow.indexOf("bun scripts/check-publish-manifests.ts"),
 		);
 		expect(workflow.indexOf('SIGNET_VERSION="$NEW_VERSION" bun scripts/generate-native-manifest.ts')).toBeLessThan(
-			workflow.indexOf('stage_bundled_binary "linux-x64" "signet-linux-x64" "signet"'),
+			workflow.indexOf('stage_native_package "linux-x64" "signet-linux-x64" "signet"'),
 		);
-		expect(workflow.indexOf('stage_bundled_binary "win32-x64" "signet-win32-x64.exe" "signet.exe"')).toBeLessThan(
+		expect(workflow.indexOf('stage_native_package "win32-x64" "signet-win32-x64.exe" "signet.exe"')).toBeLessThan(
+			workflow.indexOf("npm pkg set --prefix dist/signetai"),
+		);
+		expect(workflow.indexOf("npm pkg set --prefix dist/signetai")).toBeLessThan(
 			workflow.indexOf("bun scripts/check-publish-manifests.ts"),
 		);
 		expect(workflow.indexOf("bun scripts/check-publish-manifests.ts")).toBeLessThan(
 			workflow.indexOf("publish_npm_package dist/signetai\n"),
 		);
-		expect(workflow).toContain('stage_bundled_binary "linux-x64" "signet-linux-x64" "signet"');
-		expect(workflow).toContain('stage_bundled_binary "linux-arm64" "signet-linux-arm64" "signet"');
-		expect(workflow).toContain('stage_bundled_binary "darwin-x64" "signet-darwin-x64" "signet"');
-		expect(workflow).toContain('stage_bundled_binary "darwin-arm64" "signet-darwin-arm64" "signet"');
-		expect(workflow).toContain('stage_bundled_binary "win32-x64" "signet-win32-x64.exe" "signet.exe"');
+		expect(workflow).toContain('stage_native_package "linux-x64" "signet-linux-x64" "signet"');
+		expect(workflow).toContain('stage_native_package "linux-arm64" "signet-linux-arm64" "signet"');
+		expect(workflow).toContain('stage_native_package "darwin-x64" "signet-darwin-x64" "signet"');
+		expect(workflow).toContain('stage_native_package "darwin-arm64" "signet-darwin-arm64" "signet"');
+		expect(workflow).toContain('stage_native_package "win32-x64" "signet-win32-x64.exe" "signet.exe"');
+		expect(workflow).toContain('npm pack "${package_dir}" --pack-destination dist/native-packages');
+		expect(workflow).toContain('gh release upload "v${NEW_VERSION}" dist/native-packages/*.tgz --clobber');
+		expect(workflow).toContain(
+			'"optionalDependencies.signetai-linux-x64=${release_url}/signetai-linux-x64-${NEW_VERSION}.tgz"',
+		);
+		expect(workflow).toContain('SIGNET_EXPECT_NATIVE_OPTIONAL_DEPS: "1"');
 		expect(workflow).not.toContain("publish_npm_package dist/signetai-linux-x64");
 		expect(workflow).not.toContain("publish_npm_package dist/signetai-linux-arm64");
 		expect(workflow).not.toContain("publish_npm_package dist/signetai-darwin-x64");
@@ -245,23 +255,47 @@ describe("check-publish-manifests", () => {
 		});
 	});
 
-	test("validates bundled native package binaries", () => {
-		const root = mkdtempSync(join(tmpdir(), "signet-native-bundle-"));
+	test("validates native release package tarball wiring", () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-native-release-package-"));
+		const oldExpect = process.env.SIGNET_EXPECT_NATIVE_OPTIONAL_DEPS;
 		try {
+			process.env.SIGNET_EXPECT_NATIVE_OPTIONAL_DEPS = "1";
 			const packageDir = join(root, "dist", "signetai");
 			const packageFile = join(packageDir, "package.json");
 			mkdirSync(join(packageDir, "bin"), { recursive: true });
-			writeJson(packageFile, { name: "signetai", version: "0.1.0", publishConfig: { access: "public" } });
+			writeJson(packageFile, {
+				name: "signetai",
+				version: "0.1.0",
+				publishConfig: { access: "public" },
+				optionalDependencies: {
+					"signetai-linux-x64":
+						"https://github.com/Signet-AI/signetai/releases/download/v0.1.0/signetai-linux-x64-0.1.0.tgz",
+				},
+			});
 			writeFileSync(
 				join(packageDir, "bin", "native-platforms.js"),
-				`export const nativePlatforms = {\n\t"linux-x64": { binaryName: "signet" },\n};\n`,
+				`export const nativePlatforms = {\n\t"linux-x64": { binaryName: "signet", packageName: "signetai-linux-x64" },\n};\n`,
 			);
 
-			expect(collectBundledNativePackageIssues([packageFile])).toContainEqual({
+			expect(parseNativePlatformPackages(readFileSync(join(packageDir, "bin", "native-platforms.js"), "utf8"))).toEqual(
+				[
+					{
+						binaryName: "signet",
+						packageName: "signetai-linux-x64",
+						platform: "linux-x64",
+					},
+				],
+			);
+			expect(collectNativeReleasePackageIssues([packageFile])).toContainEqual({
 				file: packageFile,
-				reason: `missing bundled native binary ${join(packageDir, "native", "linux-x64", "signet")}`,
+				reason: `missing native package binary ${join(root, "dist", "signetai-linux-x64", "bin", "signet")}`,
 			});
 		} finally {
+			if (oldExpect === undefined) {
+				process.env.SIGNET_EXPECT_NATIVE_OPTIONAL_DEPS = undefined;
+			} else {
+				process.env.SIGNET_EXPECT_NATIVE_OPTIONAL_DEPS = oldExpect;
+			}
 			rmSync(root, { recursive: true, force: true });
 		}
 	});
@@ -307,23 +341,23 @@ describe("check-publish-manifests", () => {
 		expect(manifest.publishConfig).toEqual({ access: "public" });
 		expect(manifest.dependencies).toBeUndefined();
 		expect(manifest.optionalDependencies).toBeUndefined();
-		expect(manifest.files).toContain("native/**");
+		expect(manifest.files).not.toContain("native/**");
 		expect(manifest.scripts?.postinstall).toContain("scripts/install-native.js");
 		expect(manifest.bin?.signet).toBe("bin/signet.js");
 		expect(manifest.bin?.["signet-mcp"]).toBe("bin/signet-mcp.js");
 		expect(launcher).toContain('join(packageDir, "native"');
-		expect(launcher).toContain("resolveBundledBinaryPath");
-		expect(launcher).not.toContain("require.resolve");
+		expect(launcher).toContain("resolveNativePackageBinaryPath");
+		expect(launcher).toContain("require.resolve");
 		expect(nativePlatforms).toContain('"linux-x64"');
 		expect(nativePlatforms).toContain('"linux-arm64"');
 		expect(nativePlatforms).toContain('"darwin-x64"');
 		expect(nativePlatforms).toContain('"darwin-arm64"');
 		expect(nativePlatforms).toContain('"win32-x64"');
-		expect(nativePlatforms).not.toContain("packageName");
+		expect(nativePlatforms).toContain("packageName");
 		expect(mcpBin).toContain("forceMcp: true");
 		expect(installer).toContain("linkSync");
-		expect(installer).not.toContain("require.resolve");
-		expect(installer).toContain("Linked bundled Signet native binary");
+		expect(installer).toContain("require.resolve");
+		expect(installer).toContain("Linked Signet native binary");
 		expect(installer).not.toContain("native-manifest.json");
 		expect(installer).not.toContain("https");
 		expect(installer).not.toContain("better-sqlite3");
@@ -402,6 +436,39 @@ describe("check-publish-manifests", () => {
 			expect(issues).toHaveLength(1);
 			expect(issues[0]?.reason).toContain("not published");
 			expect(issues[0]?.dep).toBe("@signet/connector-pi");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("allows Signet native release tarball optional dependencies", () => {
+		const root = mkdtempSync(join(tmpdir(), "signet-publish-manifests-"));
+		try {
+			const signetaiDir = join(root, "dist", "signetai");
+			const nativeDir = join(root, "dist", "signetai-linux-x64");
+			mkdirSync(signetaiDir, { recursive: true });
+			mkdirSync(nativeDir, { recursive: true });
+
+			const signetaiFile = join(signetaiDir, "package.json");
+			const nativeFile = join(nativeDir, "package.json");
+
+			writeJson(signetaiFile, {
+				name: "signetai",
+				version: "1.2.3",
+				optionalDependencies: {
+					"signetai-linux-x64":
+						"https://github.com/Signet-AI/signetai/releases/download/v1.2.3/signetai-linux-x64-1.2.3.tgz",
+				},
+				publishConfig: { access: "public" },
+			});
+			writeJson(nativeFile, {
+				name: "signetai-linux-x64",
+				version: "1.2.3",
+				private: true,
+			});
+
+			const workspacePackages = collectWorkspacePackages([signetaiFile, nativeFile]);
+			expect(collectManifestIssues([signetaiFile], workspacePackages)).toEqual([]);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}

--- a/scripts/check-publish-manifests.ts
+++ b/scripts/check-publish-manifests.ts
@@ -36,6 +36,12 @@ type NativeManifestIssue = {
 	readonly reason: string;
 };
 
+type NativePlatformPackage = {
+	readonly platform: string;
+	readonly packageName: string;
+	readonly binaryName: string;
+};
+
 type NativeManifestAsset = {
 	readonly name?: unknown;
 	readonly platform?: unknown;
@@ -113,6 +119,15 @@ function getRuntimeDependencies(pkg: PackageJson, field: RuntimeField): Array<re
 	return Object.entries(value).flatMap(([name, spec]) => (typeof spec === "string" ? ([[name, spec]] as const) : []));
 }
 
+function isNativeReleaseTarballSpec(dep: string, spec: string): boolean {
+	return (
+		/^signetai-(linux|darwin|win32)-(x64|arm64)$/.test(dep) &&
+		/^https:\/\/github\.com\/[^/]+\/[^/]+\/releases\/download\/v[^/]+\/signetai-(linux|darwin|win32)-(x64|arm64)-[^/]+\.tgz$/.test(
+			spec,
+		)
+	);
+}
+
 export function collectManifestIssues(
 	targets: readonly string[],
 	workspacePackages: ReadonlyMap<string, WorkspacePackage>,
@@ -139,6 +154,10 @@ export function collectManifestIssues(
 
 				const workspaceDep = workspacePackages.get(dep);
 				if (workspaceDep && !workspaceDep.publishable) {
+					if (packageName === "signetai" && field === "optionalDependencies" && isNativeReleaseTarballSpec(dep, spec)) {
+						continue;
+					}
+
 					issues.push({
 						file,
 						packageName,
@@ -173,6 +192,19 @@ export function parseSupportedNativePlatforms(installerSource: string): string[]
 	if (!match) return [];
 
 	return Array.from(match[1].matchAll(/^\s*"([^"]+)":/gm), ([, platform]) => platform).sort();
+}
+
+export function parseNativePlatformPackages(installerSource: string): NativePlatformPackage[] {
+	return Array.from(
+		installerSource.matchAll(
+			/^\s*"([^"]+)":\s*\{\s*[\s\S]*?binaryName:\s*"([^"]+)"\s*,\s*packageName:\s*"([^"]+)"\s*,?\s*\}/gm,
+		),
+		([, platform, binaryName, packageName]) => ({
+			platform,
+			binaryName,
+			packageName,
+		}),
+	).sort((a, b) => a.platform.localeCompare(b.platform));
 }
 
 export function collectNativeManifestIssues(
@@ -243,22 +275,35 @@ export function collectNativeManifestIssues(
 	return issues;
 }
 
-export function collectBundledNativePackageIssues(targets: readonly string[]): NativeManifestIssue[] {
+export function collectNativeReleasePackageIssues(targets: readonly string[]): NativeManifestIssue[] {
 	const issues: NativeManifestIssue[] = [];
 	for (const file of targets) {
 		if (!file.endsWith("dist/signetai/package.json")) continue;
+		if (process.env.SIGNET_EXPECT_NATIVE_OPTIONAL_DEPS !== "1") continue;
 
+		const pkg = readPackageJson(file);
 		const nativePlatformsFile = file.replace(/package\.json$/, "bin/native-platforms.js");
-		const supportedPlatforms = parseSupportedNativePlatforms(readFileSync(nativePlatformsFile, "utf8"));
-		for (const platform of supportedPlatforms) {
-			const binaryName = platform.startsWith("win32-") ? "signet.exe" : "signet";
-			const binaryFile = file.replace(/package\.json$/, `native/${platform}/${binaryName}`);
+		const platformPackages = parseNativePlatformPackages(readFileSync(nativePlatformsFile, "utf8"));
+		const optionalDependencies = isRecord(pkg.optionalDependencies) ? pkg.optionalDependencies : {};
+		for (const platformPackage of platformPackages) {
+			const spec = optionalDependencies[platformPackage.packageName];
+			if (typeof spec !== "string" || !isNativeReleaseTarballSpec(platformPackage.packageName, spec)) {
+				issues.push({
+					file,
+					reason: `missing native release tarball optional dependency for ${platformPackage.packageName}`,
+				});
+			}
+
+			const binaryFile = file.replace(
+				"dist/signetai/package.json",
+				`dist/${platformPackage.packageName}/bin/${platformPackage.binaryName}`,
+			);
 			if (!existsSync(binaryFile)) {
-				issues.push({ file, reason: `missing bundled native binary ${binaryFile}` });
+				issues.push({ file, reason: `missing native package binary ${binaryFile}` });
 				continue;
 			}
 			if (!statSync(binaryFile).isFile()) {
-				issues.push({ file, reason: `bundled native binary is not a file: ${binaryFile}` });
+				issues.push({ file, reason: `native package binary is not a file: ${binaryFile}` });
 			}
 		}
 	}
@@ -283,7 +328,7 @@ function main(): void {
 					parseSupportedNativePlatforms(readFileSync("dist/signetai/bin/native-platforms.js", "utf8")),
 				)
 			: [];
-	const nativePackageIssues = collectBundledNativePackageIssues(targets);
+	const nativePackageIssues = collectNativeReleasePackageIssues(targets);
 
 	if (issues.length > 0 || nativeManifestIssues.length > 0 || nativePackageIssues.length > 0) {
 		if (issues.length > 0) console.error(formatIssues(issues));

--- a/scripts/install-copy-regression.test.ts
+++ b/scripts/install-copy-regression.test.ts
@@ -28,7 +28,7 @@ describe("install copy", () => {
 		for (const path of ["README.md", "docs/QUICKSTART.md", "docs/CLI.md", "dist/signetai/README.md"]) {
 			const content = read(path);
 			expect(content).toContain("same compiled Signet binary");
-			expect(content).toContain("bundled native");
+			expect(content).toContain("native package");
 			expect(content).toContain("npm install -g signetai");
 			expect(content).toContain("bun add -g signetai");
 		}
@@ -70,8 +70,8 @@ describe("install copy", () => {
 		expect(manifest.bin?.signet).toBe("bin/signet.js");
 		expect(manifest.bin?.["signet-mcp"]).toBe("bin/signet-mcp.js");
 		expect(launcher).toContain('join(packageDir, "native"');
-		expect(launcher).toContain("resolveBundledBinaryPath");
-		expect(launcher).not.toContain("require.resolve");
+		expect(launcher).toContain("resolveNativePackageBinaryPath");
+		expect(launcher).toContain("require.resolve");
 		expect(nativePlatforms).toContain('"linux-x64"');
 		expect(nativePlatforms).toContain('"linux-arm64"');
 		expect(nativePlatforms).toContain('"darwin-x64"');
@@ -79,7 +79,7 @@ describe("install copy", () => {
 		expect(nativePlatforms).toContain('"win32-x64"');
 		expect(mcpWrapper).toContain("forceMcp: true");
 		expect(installer).toContain("linkSync");
-		expect(installer).not.toContain("require.resolve");
+		expect(installer).toContain("require.resolve");
 		expect(installer).toContain("Skipping Signet native binary linking in workspace install");
 		expect(installer).not.toContain("native-manifest.json");
 		expect(installer).not.toContain("https");

--- a/scripts/native-install-smoke.test.ts
+++ b/scripts/native-install-smoke.test.ts
@@ -183,19 +183,24 @@ describe("native install smoke", () => {
 		expect(existsSync(join(binDir, "signet"))).toBe(true);
 	});
 
-	test("npm wrapper launches bundled binary with or without postinstall", async () => {
+	test("npm wrapper launches native optional package with or without postinstall", async () => {
 		if (process.platform === "win32") return;
 
 		const dir = tempDir();
 		const packageDir = join(dir, "signetai");
 		const platform = platformKey();
-		const nativePackageDir = join(packageDir, "native", platform);
-		const nativePackageBin = join(nativePackageDir, "signet");
+		const nativePackageName = `signetai-${platform}`;
+		const nativePackageDir = join(packageDir, "node_modules", nativePackageName);
+		const nativePackageBin = join(nativePackageDir, "bin", "signet");
 		mkdirSync(packageDir, { recursive: true });
-		mkdirSync(nativePackageDir, { recursive: true });
+		mkdirSync(join(nativePackageDir, "bin"), { recursive: true });
 		cpSync(join(root, "dist", "signetai", "scripts"), join(packageDir, "scripts"), { recursive: true });
 		cpSync(join(root, "dist", "signetai", "bin"), join(packageDir, "bin"), { recursive: true });
 		writeFileSync(join(packageDir, "package.json"), readFileSync(join(root, "dist", "signetai", "package.json")));
+		writeFileSync(
+			join(nativePackageDir, "package.json"),
+			JSON.stringify({ name: nativePackageName, version: "0.0.0", type: "module" }),
+		);
 		writeFileSync(nativePackageBin, fakeNativeBinary());
 		chmodSync(nativePackageBin, 0o755);
 
@@ -206,7 +211,7 @@ describe("native install smoke", () => {
 		const install = await runCommand("node", [join(packageDir, "scripts", "install-native.js")], process.env);
 
 		expect(install.status).toBe(0);
-		expect(install.stdout).toContain(`Linked bundled Signet native binary for ${platform}`);
+		expect(install.stdout).toContain(`Linked Signet native binary for ${platform}`);
 		const installedBinary = join(packageDir, "native", "signet");
 		expect(existsSync(installedBinary)).toBe(true);
 		chmodSync(installedBinary, 0o755);


### PR DESCRIPTION
## Summary

Fixes the main release failure after #819. npm rejected the all-platform `signetai` package with `E413 Payload Too Large`, so this keeps the public npm package small while still installing the compiled native runtime.

The release workflow now:
- packs each platform native package as a `.tgz` GitHub release asset,
- injects `signetai` optionalDependencies that point at those same-release tarballs,
- publishes only the existing `signetai` npm package,
- keeps platform packages private so CI does not try to create new npm package names.

The wrapper resolves the installed optional native package directly, so `npm install --ignore-scripts` / disabled postinstall still has a path to the native binary.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

Additional notes:
- Agent-scoped data queries and admin/mutation endpoints are not touched.
- Runtime package smoke was validated locally with `npm install --ignore-scripts` against tarball packages.

## Verification

- `bun test scripts/check-publish-manifests.test.ts scripts/install-copy-regression.test.ts scripts/native-install-smoke.test.ts scripts/version-sync.test.ts`
- `bunx biome check .github/workflows/release.yml dist/signetai/bin/launch.js dist/signetai/bin/native-platforms.js dist/signetai/scripts/install-native.js dist/signetai/package.json dist/signetai/README.md README.md docs/CLI.md docs/QUICKSTART.md scripts/check-publish-manifests.ts scripts/check-publish-manifests.test.ts scripts/install-copy-regression.test.ts scripts/native-install-smoke.test.ts`
- Local tarball smoke: packed fake `signetai-<platform>` tarball, injected it as `signetai` optionalDependency, installed `signetai` with `npm install --ignore-scripts`, and ran `signet --version` through the native package.