### PR TITLE
fix(release): pack native tarballs from local paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,7 +300,7 @@ jobs:
             mkdir -p "${package_dir}/bin"
             cp "dist/native/${asset}" "${package_dir}/bin/${binary}"
             chmod 755 "${package_dir}/bin/${binary}"
-            npm pack "${package_dir}" --pack-destination dist/native-packages
+            npm pack "./${package_dir}" --pack-destination dist/native-packages
           }
 
           stage_native_package "linux-x64" "signet-linux-x64" "signet"

--- a/scripts/check-publish-manifests.test.ts
+++ b/scripts/check-publish-manifests.test.ts
@@ -167,7 +167,8 @@ describe("check-publish-manifests", () => {
 		expect(workflow).toContain('stage_native_package "darwin-x64" "signet-darwin-x64" "signet"');
 		expect(workflow).toContain('stage_native_package "darwin-arm64" "signet-darwin-arm64" "signet"');
 		expect(workflow).toContain('stage_native_package "win32-x64" "signet-win32-x64.exe" "signet.exe"');
-		expect(workflow).toContain('npm pack "${package_dir}" --pack-destination dist/native-packages');
+		expect(workflow).toContain('npm pack "./${package_dir}" --pack-destination dist/native-packages');
+		expect(workflow).not.toContain('npm pack "${package_dir}"');
 		expect(workflow).toContain('gh release upload "v${NEW_VERSION}" dist/native-packages/*.tgz --clobber');
 		expect(workflow).toContain(
 			'"optionalDependencies.signetai-linux-x64=${release_url}/signetai-linux-x64-${NEW_VERSION}.tgz"',


### PR DESCRIPTION
## Summary

Fixes the follow-up release failure in `Pack native npm release assets`.

`npm pack "${package_dir}"` treated `dist/signetai-linux-x64` as a package spec and tried to resolve `git@github.com:dist/signetai-linux-x64.git`. Prefixing the path as `./${package_dir}` forces npm to pack the local dist package directory.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

Additional notes:
- Data queries and admin/mutation endpoints are not touched.
- No API/spec/docs behavior changed beyond the release workflow fix.

## Verification

- `bun test scripts/check-publish-manifests.test.ts`
- `bunx biome check .github/workflows/release.yml scripts/check-publish-manifests.test.ts`
- Local pack smoke: created a fake `dist/signetai-linux-x64/bin/signet` and ran `npm pack ./dist/signetai-linux-x64 --pack-destination <tmp>` successfully.
