### PR TITLE
fix(cli): keep Rust daemon runtime opt-in

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1041,6 +1041,7 @@ Environment Variables
 | `SIGNET_LOG_FILE` | Explicit daemon log file path | unset |
 | `SIGNET_LOG_DIR` | Daemon log directory override | `$SIGNET_WORKSPACE/.daemon/logs` |
 | `SIGNET_SQLITE_PATH` | macOS explicit SQLite dylib override used by the daemon before opening the database | unset |
+| `SIGNET_DAEMON_RUNTIME` | Installed daemon runtime selector. Set to `rust` only for explicit daemon-rs parity testing; default uses the TypeScript/Bun daemon | `typescript` |
 | `SIGNET_SESSION_START_TIMEOUT` | Session-start daemon wait budget in ms for Signet-managed clients. Generated Claude Code hook config writes this value directly. Generated Codex hook config rounds up to seconds and adds 5 seconds of harness grace | `15000` |
 | `SIGNET_FETCH_TIMEOUT` | Legacy fallback for session-start timeout in ms when `SIGNET_SESSION_START_TIMEOUT` is unset | `15000` |
 | `SIGNET_PROMPT_SUBMIT_TIMEOUT` | Prompt-submit daemon wait budget in ms; OpenCode uses this value directly, generated Claude Code hook config writes this value + 2000 ms grace, and generated Codex hook config rounds up to seconds and adds 2 seconds of harness grace | `5000` |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1256,6 +1256,7 @@ editing the config file is impractical.
 | `SIGNET_LOG_FILE` | — | Optional explicit daemon log file path |
 | `SIGNET_LOG_DIR` | `$SIGNET_WORKSPACE/.daemon/logs` | Optional daemon log directory override |
 | `SIGNET_SQLITE_PATH` | — | macOS explicit SQLite dylib override used before Bun opens the database |
+| `SIGNET_DAEMON_RUNTIME` | `typescript` | Installed daemon runtime selector. Set to `rust` only for explicit daemon-rs parity testing; route parity alone is not a production cutover. |
 | `SIGNET_SESSION_START_TIMEOUT` | `15000` | Session-start daemon wait budget in ms for Signet-managed clients. Generated Claude Code hook config writes this value directly. Generated Codex hook config rounds up to seconds and adds 5 seconds of harness grace |
 | `SIGNET_FETCH_TIMEOUT` | `15000` | Legacy fallback for session-start timeout in ms when `SIGNET_SESSION_START_TIMEOUT` is unset |
 | `SIGNET_PROMPT_SUBMIT_TIMEOUT` | `5000` | Prompt-submit daemon wait budget in ms; OpenCode uses this value directly, generated Claude Code hook config writes this value + 2000 ms grace, and generated Codex hook config rounds up to seconds and adds 2 seconds of harness grace |
@@ -1274,6 +1275,11 @@ it is unset, Signet checks `$SIGNET_WORKSPACE/libsqlite3.dylib`, where
 `~/.config/signet/workspace.json`, then the default `~/.agents`, before
 trying standard Homebrew SQLite locations and finally falling back to
 Apple's system SQLite.
+
+`SIGNET_DAEMON_RUNTIME=rust` is an explicit test opt-in for installed bundles
+that include `runtime/daemon-rs/signet-daemon`. Leave it unset for normal
+operation; the TypeScript/Bun daemon remains the default until daemon-rs has
+stateful subsystem and rollback proof, not just endpoint-shape parity.
 
 For non-loopback Anthropic endpoint overrides, daemon-rs
 only sends provider credentials during startup preflight when the host

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -72,6 +72,19 @@ Configuration
 | `SIGNET_LOG_FILE` | — | Optional explicit log file path |
 | `SIGNET_LOG_DIR` | `$SIGNET_WORKSPACE/.daemon/logs` | Optional log directory override |
 | `SIGNET_SQLITE_PATH` | — | macOS explicit SQLite dylib override used before Bun opens the database |
+| `SIGNET_DAEMON_RUNTIME` | `typescript` | Installed runtime selector. Set to `rust` only for explicit daemon-rs parity testing; the TypeScript/Bun daemon remains the default runtime. |
+
+### Runtime Selection
+
+The Rust daemon in `platform/daemon-rs` is a parity runtime, not the default
+production daemon. `signet daemon start` uses the TypeScript/Bun daemon unless
+`SIGNET_DAEMON_RUNTIME=rust` is set and the installed bundle contains
+`runtime/daemon-rs/signet-daemon`.
+
+Do not treat route-parity or contract-replay success as a cutover signal by
+itself. Runtime replacement also requires stateful subsystem proof for file
+watching, pipeline workers, source indexing, schema round-trips, installed
+launcher behavior, rollback, and daemon-managed side effects.
 
 ### Files
 

--- a/surfaces/cli/src/lib/runtime.test.ts
+++ b/surfaces/cli/src/lib/runtime.test.ts
@@ -26,10 +26,16 @@ afterEach(() => {
 });
 
 describe("resolveDaemonPaths", () => {
-	it("prefers the native bundle daemon path when SIGNET_DIR is set", () => {
+	it("keeps the JavaScript daemon bundle as the default when SIGNET_DIR is set", () => {
 		const paths = resolveDaemonPaths({ SIGNET_DIR: "/opt/signet" });
+		expect(paths[0]).toBe("/opt/signet/runtime/daemon-js/daemon.js");
+		expect(paths).not.toContain("/opt/signet/runtime/daemon-rs/signet-daemon");
+	});
+
+	it("uses the Rust daemon bundle only when explicitly requested", () => {
+		const paths = resolveDaemonPaths({ SIGNET_DIR: "/opt/signet", SIGNET_DAEMON_RUNTIME: " Rust " });
 		expect(paths[0]).toBe("/opt/signet/runtime/daemon-rs/signet-daemon");
-		expect(paths).toContain("/opt/signet/runtime/daemon-js/daemon.js");
+		expect(paths[1]).toBe("/opt/signet/runtime/daemon-js/daemon.js");
 	});
 });
 
@@ -185,6 +191,30 @@ describe("buildLaunchdDaemonPlist", () => {
 		expect(launchdDaemonPlistPath("/Users/user/.agents", "/Users/user")).toBe(
 			"/Users/user/Library/LaunchAgents/ai.signet.daemon.plist",
 		);
+	});
+
+	it("preserves explicit Rust runtime opt-in in LaunchAgent environment", () => {
+		const original = process.env.SIGNET_DAEMON_RUNTIME;
+		process.env.SIGNET_DAEMON_RUNTIME = "rust";
+		try {
+			const plist = buildLaunchdDaemonPlist({
+				daemonPath: "/opt/signet/runtime/daemon-rs/signet-daemon",
+				agentsDir: "/Users/user/.agents",
+				port: 3850,
+				host: "127.0.0.1",
+				bind: "0.0.0.0",
+				startupLogPath: "/Users/user/.agents/.daemon/logs/startup.log",
+			});
+
+			expect(plist).toContain("<key>SIGNET_DAEMON_RUNTIME</key>");
+			expect(plist).toContain("<string>rust</string>");
+		} finally {
+			if (original === undefined) {
+				Reflect.deleteProperty(process.env, "SIGNET_DAEMON_RUNTIME");
+			} else {
+				process.env.SIGNET_DAEMON_RUNTIME = original;
+			}
+		}
 	});
 
 	it("uses launchctl bootstrap against the current user launchd domain", () => {

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -73,16 +73,22 @@ function pidFile(agentsDir: string): string {
 	return join(agentsDir, ".daemon", "pid");
 }
 
+function rustDaemonRuntimeEnabled(env: NodeJS.ProcessEnv): boolean {
+	return env.SIGNET_DAEMON_RUNTIME?.trim().toLowerCase() === "rust";
+}
+
 export function resolveDaemonPaths(env: NodeJS.ProcessEnv = process.env): string[] {
 	const currentNativeExecutable = currentNativeExecutablePath();
 	const bundledNativeDaemon = env.SIGNET_DIR
 		? join(env.SIGNET_DIR, "runtime", "daemon-rs", process.platform === "win32" ? "signet-daemon.exe" : "signet-daemon")
 		: null;
 	const bundledJsDaemon = env.SIGNET_DIR ? join(env.SIGNET_DIR, "runtime", "daemon-js", "daemon.js") : null;
+	const bundledRuntimePaths = rustDaemonRuntimeEnabled(env)
+		? [bundledNativeDaemon, bundledJsDaemon]
+		: [bundledJsDaemon];
 	return [
 		currentNativeExecutable,
-		bundledNativeDaemon,
-		bundledJsDaemon,
+		...bundledRuntimePaths,
 		join(__dirname, "daemon.js"),
 		join(cliDir, "daemon.js"),
 		join(pkgDir, "..", "daemon", "dist", "daemon.js"),
@@ -630,6 +636,7 @@ export function buildLaunchdDaemonPlist(input: LaunchdDaemonPlistInput): string 
 		SIGNET_PATH: input.agentsDir,
 		SIGNET_DAEMON_ENTRYPOINT: "1",
 		...(process.env.SIGNET_DIR ? { SIGNET_DIR: process.env.SIGNET_DIR } : {}),
+		...(process.env.SIGNET_DAEMON_RUNTIME ? { SIGNET_DAEMON_RUNTIME: process.env.SIGNET_DAEMON_RUNTIME } : {}),
 		...(process.env.SIGNET_DASHBOARD_DIR ? { SIGNET_DASHBOARD_DIR: process.env.SIGNET_DASHBOARD_DIR } : {}),
 		HOME: process.env.HOME ?? homedir(),
 		PATH: process.env.PATH ?? "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",


### PR DESCRIPTION
## Summary

Corrective follow-up to PR #813. This does not revert the Rust parity work, but it makes clear in code and docs that the merge was not a cutover: daemon-rs is an explicit test/runtime opt-in, not the default daemon replacement.

## Changes

- Keep the installed JavaScript/TypeScript daemon path as the default when `SIGNET_DIR` is set.
- Select `runtime/daemon-rs/signet-daemon` only when `SIGNET_DAEMON_RUNTIME=rust` is explicitly set.
- Preserve `SIGNET_DAEMON_RUNTIME` in macOS LaunchAgent environment when users intentionally opt in.
- Document that route parity and contract replay are not sufficient cutover proof; stateful subsystem and rollback proof are still required.

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: daemon/runtime docs

## Screenshots

N/A — no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — no spec or dependency graph change; this narrows runtime selection behavior and updates docs.
- [x] Agent scoping verified on all new/changed data queries — no data queries changed.
- [x] Input/config validation and bounds checks added — `SIGNET_DAEMON_RUNTIME` is trimmed/lowercased and only `rust` enables daemon-rs selection.
- [x] Error handling and fallback paths tested (no silent swallow) — tests assert default JS fallback and explicit Rust opt-in behavior.
- [x] Security checks applied to admin/mutation endpoints — no endpoints changed.
- [x] Docs updated for API/spec/status changes — daemon/config/CLI docs now label daemon-rs as opt-in parity runtime, not cutover.
- [x] Regression tests added for each bug fix — runtime path resolver and LaunchAgent env preservation tests added.
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

N/A — no migrations touched.

- [ ] Migration is idempotent
- [ ] Daemon Rust parity reviewed or explicitly N/A
- [ ] Rollback / compatibility note included in PR description

## Testing

- [x] `bun test` passes — `cd surfaces/cli && bun test src/lib/runtime.test.ts` (24 pass)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes — focused `bunx biome check surfaces/cli/src/lib/runtime.ts surfaces/cli/src/lib/runtime.test.ts`
- [ ] Tested against running daemon
- [x] N/A — launcher path selection covered by unit tests; no daemon API/runtime behavior changed

Additional checks:

- `bun test scripts/check-publish-manifests.test.ts` (20 pass)
- `git diff --check`

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

This PR intentionally does not claim daemon-rs replacement. It only prevents accidental launcher selection of daemon-rs and documents that a real Rust daemon cutover still needs stateful subsystem proof beyond endpoint parity.
