### PR TITLE
fix(release): embed native cli version

### DIFF
--- a/platform/daemon/src/routes/state.ts
+++ b/platform/daemon/src/routes/state.ts
@@ -334,6 +334,11 @@ export function queueExtractionJob(memoryId: string): void {
 
 // Version
 function getDaemonVersion(): string {
+	const envVersion = readEnvTrimmed("SIGNET_VERSION");
+	if (envVersion) {
+		return envVersion;
+	}
+
 	const __filename = fileURLToPath(import.meta.url);
 	const __dirname = join(__filename, "..");
 

--- a/scripts/build-native-bun.ts
+++ b/scripts/build-native-bun.ts
@@ -24,6 +24,8 @@ const platformKey = process.env.SIGNET_NATIVE_PLATFORM ?? `${platform()}-${arch(
 const binaryName = platformKey.startsWith("win32-") ? `signet-${platformKey}.exe` : `signet-${platformKey}`;
 const outfile = join(outDir, binaryName);
 const daemonRequire = createRequire(join(root, "platform", "daemon", "package.json"));
+const rootPackage = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as { version?: unknown };
+const nativeVersion = typeof rootPackage.version === "string" ? rootPackage.version : "0.0.0";
 
 mkdirSync(outDir, { recursive: true });
 rmSync(buildDir, { recursive: true, force: true });
@@ -155,14 +157,17 @@ writeFileSync(
 
 writeFileSync(
 	join(buildDir, "cli-native.ts"),
-	`import { materializeEmbeddedAssetTree, registerNativeAssets, registerNativeTransformersBindings } from "../platform/daemon/src/native-runtime-assets";\n` +
-		`import { dashboardAssets, skillAssets, templateAssets, wasmAssets, workerAssets } from "./native-assets";\n` +
-		`import * as transformersWebRuntime from "./transformers-web-runtime";\n\n` +
-		"registerNativeAssets({ dashboard: dashboardAssets, skills: skillAssets, templates: templateAssets, workers: workerAssets, wasm: wasmAssets });\n" +
-		"registerNativeTransformersBindings(transformersWebRuntime);\n" +
-		'process.env.SIGNET_TEMPLATES_DIR ??= materializeEmbeddedAssetTree("templates") ?? "";\n' +
-		'process.env.SIGNET_SKILLS_SOURCE ??= materializeEmbeddedAssetTree("skills") ?? "";\n' +
-		`await import("../surfaces/cli/src/cli.ts");\n`,
+	`import { materializeEmbeddedAssetTree, registerNativeAssets, registerNativeTransformersBindings } from "../platform/daemon/src/native-runtime-assets";
+import { dashboardAssets, skillAssets, templateAssets, wasmAssets, workerAssets } from "./native-assets";
+import * as transformersWebRuntime from "./transformers-web-runtime";
+
+registerNativeAssets({ dashboard: dashboardAssets, skills: skillAssets, templates: templateAssets, workers: workerAssets, wasm: wasmAssets });
+registerNativeTransformersBindings(transformersWebRuntime);
+process.env.SIGNET_VERSION = process.env.SIGNET_VERSION?.trim() || ${JSON.stringify(nativeVersion)};
+process.env.SIGNET_TEMPLATES_DIR ??= materializeEmbeddedAssetTree("templates") ?? "";
+process.env.SIGNET_SKILLS_SOURCE ??= materializeEmbeddedAssetTree("skills") ?? "";
+await import("../surfaces/cli/src/cli.ts");
+`,
 );
 
 runBunBuild([

--- a/scripts/check-publish-manifests.test.ts
+++ b/scripts/check-publish-manifests.test.ts
@@ -113,6 +113,8 @@ describe("check-publish-manifests", () => {
 		expect(buildScript).toContain('join(root, "skills")');
 		expect(buildScript).toContain("templateAssets");
 		expect(buildScript).toContain("skillAssets");
+		expect(buildScript).toContain("process.env.SIGNET_VERSION");
+		expect(buildScript).toContain("process.env.SIGNET_VERSION?.trim()");
 		expect(buildScript).toContain("SIGNET_TEMPLATES_DIR");
 		expect(buildScript).toContain("SIGNET_SKILLS_SOURCE");
 		expect(buildScript).not.toContain('"@1password/sdk"');
@@ -136,6 +138,17 @@ describe("check-publish-manifests", () => {
 		expect(workflow).toContain("bun run build:native-bun");
 		expect(workflow).toContain('./dist/native/"$RELEASE_ASSET" --help');
 		expect(workflow).not.toContain("if: matrix.platform != 'linux-arm64'");
+	});
+
+	test("trims native Signet version overrides before package metadata fallback", () => {
+		const root = join(import.meta.dir, "..");
+		const cliSource = readFileSync(join(root, "surfaces", "cli", "src", "cli.ts"), "utf-8");
+		const stateSource = readFileSync(join(root, "platform", "daemon", "src", "routes", "state.ts"), "utf-8");
+
+		expect(cliSource).toContain("process.env.SIGNET_VERSION?.trim()");
+		expect(cliSource).not.toContain("return process.env.SIGNET_VERSION;");
+		expect(stateSource).toContain('readEnvTrimmed("SIGNET_VERSION")');
+		expect(stateSource).not.toContain("return process.env.SIGNET_VERSION;");
 	});
 
 	test("publishes native release assets, native package tarballs, and the native manifest", () => {

--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -297,6 +297,11 @@ function getVersionFromPackageJson(packageJsonPath: string): string | null {
 }
 
 function getCliVersion(): string {
+	const envVersion = process.env.SIGNET_VERSION?.trim();
+	if (envVersion) {
+		return envVersion;
+	}
+
 	const candidates = [
 		join(__dirname, "..", "package.json"),
 		join(__dirname, "..", "..", "signetai", "package.json"),


### PR DESCRIPTION
## Summary
- embed the root package version into Bun-compiled native Signet binaries through `SIGNET_VERSION`
- make CLI and daemon version resolution prefer trimmed non-empty `SIGNET_VERSION` before filesystem package metadata
- add a publish-manifest guard so native builds keep wiring and trimming the version in the compiled entrypoint

## PR Readiness (MANDATORY)
- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Verification
- `bun test scripts/check-publish-manifests.test.ts`
- `bunx biome check scripts/build-native-bun.ts scripts/check-publish-manifests.test.ts surfaces/cli/src/cli.ts platform/daemon/src/routes/state.ts`
- `bun run build`
- `SIGNET_NATIVE_PLATFORM=linux-x64 bun run build:native-bun`
- `./dist/native/signet-linux-x64 --version` -> `0.138.18`
- `SIGNET_VERSION='   ' ./dist/native/signet-linux-x64 --version` -> `0.138.18`
- `SIGNET_VERSION='  9.9.9-test  ' ./dist/native/signet-linux-x64 --version` -> `9.9.9-test`
- `./dist/native/signet-linux-x64 --help`

## Dogfood Notes
- Installed `signetai@next` globally with `bun add -g signetai@next`.
- Bun blocked postinstall, and the no-postinstall wrapper path still ran.
- Restarted the local daemon through the installed CLI. It now runs from `/home/nicholai/node_modules/signetai-linux-x64/bin/signet`.
- Found the published `0.138.17` native binary and daemon report `0.0.0`; this PR fixes that for the next release.
- `signet status`, `signet doctor`, `signet recall`, `signet ontology pipeline explain`, `signet mcp list`, `signet sources list`, dashboard HTML, and `/health` work against the native daemon.
- Restart triggered a finite startup memory-ingestion sweep with many `409` chunk warnings; it stopped after startup and health stayed green.
