### PR TITLE
fix(hermes-agent): ship connector plugin assets + rename session_search (#831)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,6 +270,8 @@ jobs:
             signet-darwin-x64.sha256
             signet-win32-x64.exe
             signet-win32-x64.exe.sha256
+            signet-connectors-${NEW_VERSION}.tar.gz
+            native-manifest.json
           )
           for asset in "${expected[@]}"; do
             if ! printf '%s\n' "${ASSETS[@]}" | grep -Fxq "$asset"; then
@@ -282,6 +284,15 @@ jobs:
 
       - name: Generate and upload native manifest
         run: |
+          set -euo pipefail
+          # Build the connector plugin-asset tarball before generating
+          # the manifest so it can pick up the SHA-256 and size. The
+          # tarball mirrors `integrations/*/connector/<asset-dir>/` into
+          # `runtime/connectors/<harness>/<asset-dir>/` so the binary's
+          # `$SIGNET_DIR/runtime/connectors/...` lookup resolves at
+          # install time.
+          SIGNET_VERSION="$NEW_VERSION" bun scripts/build-connector-assets.ts
+          gh release upload "v${NEW_VERSION}" dist/native/signet-connectors-"${NEW_VERSION}".tar.gz --clobber
           SIGNET_VERSION="$NEW_VERSION" bun scripts/generate-native-manifest.ts
           gh release upload "v${NEW_VERSION}" dist/native/native-manifest.json --clobber
         env:

--- a/dist/signetai/bin/launch.js
+++ b/dist/signetai/bin/launch.js
@@ -42,10 +42,21 @@ export function launchSignet() {
 		process.exit(1);
 	}
 
+	// Point the binary at the wrapper's installed runtime tree so the
+	// connector's `getPluginSourceDir()` `SIGNET_DIR/runtime/connectors/...`
+	// fallback can find per-harness plugin assets that the native binary
+	// doesn't carry inline. The env is only set when the wrapper actually
+	// has a runtime tree to share; the binary's own bootstrap can derive
+	// its own path otherwise.
+	const env = { ...process.env };
+	if (!env.SIGNET_DIR && existsSync(join(packageDir, "runtime", "connectors"))) {
+		env.SIGNET_DIR = packageDir;
+	}
+
 	const args = process.argv.slice(2);
 	const child = spawn(resolvedBinaryPath, args, {
 		stdio: "inherit",
-		env: process.env,
+		env,
 		windowsHide: true,
 	});
 

--- a/dist/signetai/package.json
+++ b/dist/signetai/package.json
@@ -12,6 +12,7 @@
     "bin/native-platforms.js",
     "bin/signet.js",
     "dist/mcp-stdio.js",
+    "native-manifest.json",
     "scripts/install-native.js",
     "scripts/verify-wrapper.js",
     "README.md",

--- a/dist/signetai/scripts/install-native.js
+++ b/dist/signetai/scripts/install-native.js
@@ -1,8 +1,19 @@
 #!/usr/bin/env node
 
-import { copyFileSync, existsSync, linkSync, mkdirSync, readFileSync, rmSync, unlinkSync } from "node:fs";
+import { createHash } from "node:crypto";
+import {
+	copyFileSync,
+	existsSync,
+	linkSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { chmod } from "node:fs/promises";
 import { createRequire } from "node:module";
+import { spawnSync } from "node:child_process";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -10,6 +21,8 @@ import { detectNativePlatform, nativePlatforms } from "../bin/native-platforms.j
 
 const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
 const require = createRequire(import.meta.url);
+
+const CONNECTOR_COMPONENT = "connectors";
 
 function isWorkspacePackage() {
 	const workspaceRoot = dirname(dirname(packageDir));
@@ -60,11 +73,16 @@ async function main() {
 	} catch {
 		console.error(`Signet native package ${nativePackage.packageName} was not installed.`);
 		console.error("The signet wrapper will try to resolve the optional native package at runtime.");
+		// Fall through — connector assets are independent of the binary
+		// link, so users who only have the wrapper package can still
+		// benefit from a populated runtime tree.
+		await installConnectorAssets();
 		return;
 	}
 
 	if (!existsSync(source)) {
 		console.error(`Signet native binary is missing from ${nativePackage.packageName}: ${source}`);
+		await installConnectorAssets();
 		return;
 	}
 
@@ -80,6 +98,113 @@ async function main() {
 	} catch (err) {
 		rmSync(destination, { force: true });
 		throw err;
+	}
+
+	// Connector plugin assets. The native binary has the connector JS
+	// compiled in, but each connector's on-disk plugin payload (e.g. the
+	// Hermes Python memory provider) ships separately. The wrapper pulls
+	// the verified tarball at install time so the runtime can find
+	// `$SIGNET_DIR/runtime/connectors/<harness>/...` without a first-run
+	// network fetch.
+	await installConnectorAssets();
+}
+
+function loadManifest() {
+	const manifestPath = join(packageDir, "native-manifest.json");
+	if (!existsSync(manifestPath)) return null;
+	try {
+		return JSON.parse(readFileSync(manifestPath, "utf8"));
+	} catch {
+		return null;
+	}
+}
+
+async function downloadTo(url, destPath) {
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(`HTTP ${response.status} fetching ${url}`);
+	}
+	const arrayBuffer = await response.arrayBuffer();
+	writeFileSync(destPath, Buffer.from(arrayBuffer));
+}
+
+function verifySha256(path, expected) {
+	const actual = createHash("sha256").update(readFileSync(path)).digest("hex");
+	if (actual.toLowerCase() !== expected.toLowerCase()) {
+		rmSync(path, { force: true });
+		throw new Error(`SHA-256 mismatch for ${path}: expected ${expected}, got ${actual}`);
+	}
+}
+
+function nativePackageVersion() {
+	try {
+		return JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8")).version;
+	} catch {
+		return "0.0.0";
+	}
+}
+
+function releaseBaseUrl() {
+	// Allow full-URL override (e.g. for mirrors or local file:// testing)
+	// before falling back to the GitHub release URL.
+	const overrideBase = process.env.SIGNET_DOWNLOAD_BASE?.trim();
+	if (overrideBase) return overrideBase.replace(/\/$/, "");
+	const repo = process.env.SIGNET_RELEASE_REPO?.trim() || "Signet-AI/signetai";
+	const tag = process.env.SIGNET_RELEASE_TAG?.trim() || `v${nativePackageVersion()}`;
+	return `https://github.com/${repo}/releases/download/${tag}`;
+}
+
+async function installConnectorAssets() {
+	const manifest = loadManifest();
+	const component = manifest?.components?.[CONNECTOR_COMPONENT];
+	if (!component) {
+		// No connector assets in this release (e.g. early versions, or the
+		// wrapper is running from a workspace without a synced manifest).
+		// Skip silently — connectors without runtime assets keep working.
+		return;
+	}
+
+	const targetDir = join(packageDir, "runtime", "connectors");
+	const targetMarker = join(targetDir, ".signet-connectors-version");
+	if (
+		existsSync(targetMarker) &&
+		readFileSync(targetMarker, "utf8").trim() === manifest.version
+	) {
+		// Already extracted for this version. Skip to keep postinstall fast
+		// and to avoid clobbering user-tweaked assets.
+		return;
+	}
+
+	const tempPath = join(packageDir, `signet-connectors-${manifest.version}.tar.gz.tmp`);
+	const url = component.url.startsWith("http")
+		? component.url
+		: `${releaseBaseUrl()}/${component.url}`;
+
+	try {
+		await downloadTo(url, tempPath);
+		verifySha256(tempPath, component.sha256);
+		const stat = readFileSync(tempPath);
+		if (stat.length !== component.size) {
+			rmSync(tempPath, { force: true });
+			throw new Error(`Tarball size mismatch: expected ${component.size}, got ${stat.length}`);
+		}
+
+		if (existsSync(targetDir)) {
+			rmSync(targetDir, { recursive: true, force: true });
+		}
+		// Tarball layout is `./runtime/connectors/<harness>/...`. Extract
+		// at `<packageDir>/` so the tarball's own `runtime/` prefix
+		// lands naturally at `<packageDir>/runtime/connectors/...`.
+		mkdirSync(packageDir, { recursive: true });
+
+		const result = spawnSync("tar", ["xzf", tempPath, "-C", packageDir], { stdio: "inherit" });
+		if (result.status !== 0) {
+			throw new Error(`tar extraction failed with status ${result.status ?? "unknown"}`);
+		}
+		writeFileSync(targetMarker, `${manifest.version}\n`);
+		console.log(`Installed connector assets to ${targetDir}`);
+	} finally {
+		rmSync(tempPath, { force: true });
 	}
 }
 

--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -7,7 +7,7 @@ Signet connector for [Hermes Agent](https://github.com/hermes-ai/hermes-agent) -
 Integrates Signet's memory system into Hermes Agent as a native plugin.
 
 - Installs the Signet memory plugin into the Hermes plugin directory
-- Registers memory tools: `memory_search`, `memory_store`, `memory_get`, `memory_list`, `memory_modify`, `memory_forget`, `session_search`, `recall`, and `remember`
+- Registers memory tools: `memory_search`, `memory_store`, `memory_get`, `memory_list`, `memory_modify`, `memory_forget`, `signet_session_search`, `recall`, and `remember`
 - Backs up existing provider configuration for safe uninstallation
 - Uses content hashing to detect when the plugin needs updating
 

--- a/integrations/hermes-agent/connector/.gitignore
+++ b/integrations/hermes-agent/connector/.gitignore
@@ -1,1 +1,2 @@
 dist/
+__pycache__/

--- a/integrations/hermes-agent/connector/hermes-plugin/README.md
+++ b/integrations/hermes-agent/connector/hermes-plugin/README.md
@@ -36,7 +36,7 @@ Environment variables:
 | Tool | Description |
 |------|-------------|
 | `memory_search` | Hybrid memory search (keyword + semantic + knowledge graph) |
-| `session_search` | Search active or completed session transcripts |
+| `signet_session_search` | Search active or completed Signet session transcripts (namespaced to avoid Hermes's built-in `session_search` core tool) |
 | `memory_store` | Store a fact, preference, or decision to memory |
 | `memory_get` | Retrieve a memory by ID |
 | `memory_list` | List memories with optional filters |

--- a/integrations/hermes-agent/connector/hermes-plugin/__init__.py
+++ b/integrations/hermes-agent/connector/hermes-plugin/__init__.py
@@ -5,7 +5,7 @@ Bridges Hermes Agent's memory provider interface to the Signet daemon
 predictive recall, cross-session memory, and the full Signet pipeline
 (extraction, knowledge graph, retention decay, synthesis).
 
-Canonical Signet memory tools (memory_search, session_search, memory_store,
+Canonical Signet memory tools (memory_search, signet_session_search, memory_store,
 memory_get, memory_list, memory_modify, memory_forget, plus recall/remember aliases) are
 exposed through the MemoryProvider interface. The daemon handles all heavy
 lifting: embedding, reranking, knowledge graph traversal, and predictive
@@ -99,7 +99,11 @@ MEMORY_SEARCH_SCHEMA = {
 }
 
 SESSION_SEARCH_SCHEMA = {
-    "name": "session_search",
+    # Hermes reserves `session_search` as a built-in core tool name;
+    # registering under that name would be silently dropped by
+    # `MemoryManager.add_provider`. The Signet provider exposes the
+    # transcript-search tool under the `signet_` namespace instead.
+    "name": "signet_session_search",
     "description": "Search active or completed Signet session transcripts.",
     "parameters": {
         "type": "object",
@@ -962,7 +966,7 @@ class SignetMemoryProvider(MemoryProvider):
             if tool_name in ("memory_search", "recall", "signet_search"):
                 return _search(args)
 
-            if tool_name == "session_search":
+            if tool_name == "signet_session_search":
                 query = str(args.get("query", "")).strip()
                 if not query:
                     return json.dumps({"error": "Missing required parameter: query"})

--- a/integrations/hermes-agent/connector/index.test.ts
+++ b/integrations/hermes-agent/connector/index.test.ts
@@ -769,10 +769,14 @@ describe("Hermes Agent bundled plugin", () => {
 		expect(plugin).toContain('"name": "memory_store"');
 		expect(plugin).toContain('"name": "memory_get"');
 		expect(plugin).toContain('"name": "memory_list"');
-		expect(plugin).toContain('"name": "session_search"');
+		// `signet_session_search` is the namespaced form: Hermes reserves
+		// `session_search` as a built-in core tool and would silently drop
+		// any provider trying to register the bare name.
+		expect(plugin).toContain('"name": "signet_session_search"');
 		expect(plugin).not.toContain('"name": "signet_search"');
+		expect(plugin).not.toContain('"name": "session_search"');
 		expect(plugin).toContain('if tool_name in ("memory_search", "recall", "signet_search")');
-		expect(plugin).toContain('if tool_name == "session_search"');
+		expect(plugin).toContain('if tool_name == "signet_session_search"');
 	});
 
 	it("returns Signet tool schemas before daemon initialization", () => {
@@ -964,20 +968,26 @@ describe("Hermes Agent bundled plugin", () => {
 					"manager.add_provider(provider)",
 					"names = manager.get_all_tool_names()",
 					"assert 'memory_search' in names",
-					"assert 'session_search' in names",
+					// `signet_session_search` is what the Signet provider
+					// registers; the bare `session_search` is the Hermes
+					// built-in core tool, so it never lands in the manager
+					// table when only the Signet provider is registered.
+					"assert 'signet_session_search' in names",
+					"assert 'session_search' not in names",
 					"assert 'recall' in names",
 					"assert manager.has_tool('memory_store')",
-					"assert manager.has_tool('session_search')",
+					"assert manager.has_tool('signet_session_search')",
 					"print(','.join(sorted(names)))",
 				].join("\n"),
-			],
-			{ env: { ...process.env, PYTHONPATH: fixture }, encoding: "utf-8" },
-		);
+				],
+				{ env: { ...process.env, PYTHONPATH: fixture }, encoding: "utf-8" },
+				);
 
-		expect(result.status).toBe(0);
-		expect(result.stdout).toContain("memory_search");
-		expect(result.stdout).toContain("session_search");
-		expect(result.stdout).toContain("remember");
+				expect(result.status).toBe(0);
+				expect(result.stdout).toContain("memory_search");
+				expect(result.stdout).toContain("signet_session_search");
+				expect(result.stdout).not.toContain(",session_search,");
+				expect(result.stdout).toContain("remember");
 	});
 
 	it("imports the client from a Hermes user-installed provider namespace", () => {
@@ -1081,13 +1091,16 @@ describe("Hermes Agent bundled plugin", () => {
 		expect(plugin).toContain('agent_scoped=bool(search_args.get("agent_scoped", False))');
 	});
 
-	it("exposes session_search as a dedicated transcript search tool", () => {
+	it("exposes signet_session_search as a dedicated transcript search tool", () => {
 		const plugin = readFileSync(join(import.meta.dir, "hermes-plugin", "__init__.py"), "utf-8");
 		const client = readFileSync(join(import.meta.dir, "hermes-plugin", "client.py"), "utf-8");
 
 		expect(plugin).toContain("SESSION_SEARCH_SCHEMA");
 		expect(plugin).toContain('"description": "Search active or completed Signet session transcripts."');
 		expect(plugin).not.toContain('"expand":');
+		// The Python client method keeps the unnamespaced name because
+		// it is called by `__init__.py` directly, not by the model. Only
+		// the externally-visible tool name is namespaced.
 		expect(plugin).toContain("self._client.session_search(");
 		expect(client).toContain("def session_search(");
 		expect(client).toContain('self._post("/api/sessions/search", body, timeout=_RECALL_TIMEOUT_SECS)');
@@ -1095,7 +1108,7 @@ describe("Hermes Agent bundled plugin", () => {
 		expect(client).not.toContain('body["expand"]');
 	});
 
-	it("defaults Hermes session_search to the configured agent scope", () => {
+	it("defaults the Signet session search to the configured agent scope", () => {
 		const fixture = join(tmpRoot, "python-session-search-client-fixture");
 		const pluginDir = join(fixture, "plugins", "signet");
 		cpSync(join(import.meta.dir, "hermes-plugin"), pluginDir, { recursive: true });
@@ -1511,7 +1524,7 @@ describe("HermesAgentConnector — native bundle (SIGNET_DIR) plugin resolution"
 		expect(parsed.providerName).toBe("signet");
 		expect(parsed.configured).toBe(true);
 		expect(parsed.tools).toEqual(
-			expect.arrayContaining(["memory_search", "memory_store", "session_search", "recall", "remember"]),
+			expect.arrayContaining(["memory_search", "memory_store", "signet_session_search", "recall", "remember"]),
 		);
 	});
 });

--- a/integrations/hermes-agent/connector/src/index.ts
+++ b/integrations/hermes-agent/connector/src/index.ts
@@ -41,7 +41,10 @@ const REQUIRED_TOOL_NAMES = [
 	"memory_list",
 	"memory_modify",
 	"memory_forget",
-	"session_search",
+	// `session_search` shadows Hermes's built-in core tool of the same
+	// name and gets dropped at registration time, so the Signet provider
+	// surfaces it under the namespace instead.
+	"signet_session_search",
 	"recall",
 	"remember",
 ] as const;
@@ -559,7 +562,7 @@ function probeHermesProvider(hermesRepo: string): HermesProbeResult {
 		"manager = MemoryManager()",
 		"manager.add_provider(provider)",
 		"names = sorted(manager.get_all_tool_names())",
-		"required = ['memory_search', 'memory_store', 'memory_get', 'memory_list', 'memory_modify', 'memory_forget', 'session_search', 'recall', 'remember']",
+		"required = ['memory_search', 'memory_store', 'memory_get', 'memory_list', 'memory_modify', 'memory_forget', 'signet_session_search', 'recall', 'remember']",
 		"print(json.dumps({'toolNames': names, 'missing': [name for name in required if name not in names]}))",
 	].join("\n");
 

--- a/scripts/build-connector-assets.ts
+++ b/scripts/build-connector-assets.ts
@@ -1,0 +1,195 @@
+#!/usr/bin/env bun
+
+/**
+ * Stage runtime plugin assets shipped by Signet connectors into a single
+ * tarball that the native-bundle install path unpacks next to the Signet
+ * binary. Connectors that only write config (no on-disk plugin files) are
+ * skipped — they have nothing to stage.
+ *
+ * The tarball layout mirrors what the connectors' `getPluginSourceDir`
+ * fallbacks already look for under `$SIGNET_DIR/runtime/connectors/<harness>/`.
+ * For example, the Hermes connector's Python plugin ends up at:
+ *
+ *   runtime/connectors/hermes-agent/hermes-plugin/__init__.py
+ *   runtime/connectors/hermes-agent/hermes-plugin/client.py
+ *   runtime/connectors/hermes-agent/hermes-plugin/plugin.yaml
+ *   runtime/connectors/hermes-agent/hermes-plugin/README.md
+ *
+ * This restores the asset-shipping side of v0.135.0's bundle.yml, which
+ * #816 dropped when collapsing the runtime into a single `--compile`'d
+ * binary. Connector JS is still compiled in; only files the harness's
+ * own runtime loads (e.g. Python for Hermes) need to be external.
+ *
+ * Output: <root>/dist/native/signet-connectors-<version>.tar.gz
+ */
+
+import {
+	createHash,
+} from "node:crypto";
+import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	statSync,
+} from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const root = join(import.meta.dir, "..");
+const nativeDir = join(root, "dist", "native");
+const version =
+	process.env.SIGNET_VERSION?.trim() ||
+	JSON.parse(readFileSync(join(root, "package.json"), "utf8")).version;
+const stagingRoot = join(nativeDir, "connectors-staging");
+const tarballName = `signet-connectors-${version}.tar.gz`;
+const tarballPath = join(nativeDir, tarballName);
+
+// Asset directories the build will copy through. These are the on-disk
+// payloads a connector relies on at install time and the harness loads
+// at runtime. Anything else under `integrations/<harness>/connector/` is
+// source/test/build artifacts that must not be shipped.
+const SKIP_NAMES = new Set([
+	"dist",
+	"node_modules",
+	"src",
+	"scripts",
+	"test",
+	"index.test.ts",
+	"tsconfig.json",
+	"package.json",
+	".gitignore",
+]);
+
+const ASSET_FILE_SUFFIXES = [
+	".py",
+	".yaml",
+	".yml",
+	".md",
+	".txt",
+	".json",
+];
+
+interface AssetEntry {
+	readonly harness: string;
+	readonly assetDir: string;
+	readonly files: readonly string[];
+}
+
+function listConnectors(): string[] {
+	const integrationsDir = join(root, "integrations");
+	if (!existsSync(integrationsDir)) {
+		throw new Error(`Integrations directory missing: ${integrationsDir}`);
+	}
+	const harnesses: string[] = [];
+	for (const name of readdirSync(integrationsDir)) {
+		const connectorDir = join(integrationsDir, name, "connector");
+		if (existsSync(join(connectorDir, "package.json"))) {
+			harnesses.push(name);
+		}
+	}
+	return harnesses;
+}
+
+function collectAssetEntries(harness: string): AssetEntry[] {
+	const connectorDir = join(root, "integrations", harness, "connector");
+	const entries: AssetEntry[] = [];
+
+	for (const name of readdirSync(connectorDir)) {
+		if (SKIP_NAMES.has(name)) continue;
+		const full = join(connectorDir, name);
+		const stat = statSync(full);
+		if (!stat.isDirectory()) continue;
+
+		// Only pick up directories that contain at least one file matching
+		// a known asset suffix. This keeps generated dirs (e.g. dist/) from
+		// sneaking through, and rejects empty placeholder directories.
+		const files: string[] = [];
+		for (const inner of readdirSync(full)) {
+			const innerFull = join(full, inner);
+			if (!statSync(innerFull).isFile()) continue;
+			if (!ASSET_FILE_SUFFIXES.some((suffix) => inner.endsWith(suffix))) continue;
+			files.push(inner);
+		}
+		if (files.length === 0) continue;
+
+		entries.push({ harness, assetDir: name, files });
+	}
+
+	return entries;
+}
+
+function stageAsset(entry: AssetEntry, stagingRoot: string): void {
+	const targetDir = join(
+		stagingRoot,
+		"runtime",
+		"connectors",
+		entry.harness,
+		entry.assetDir,
+	);
+	mkdirSync(targetDir, { recursive: true });
+	for (const file of entry.files) {
+		copyFileSync(
+			join(root, "integrations", entry.harness, "connector", entry.assetDir, file),
+			join(targetDir, file),
+		);
+	}
+}
+
+function tarGz(stagingSource: string, tarballPath: string): void {
+	const result = spawnSync("tar", ["czf", tarballPath, "-C", stagingSource, "."], {
+		stdio: "inherit",
+	});
+	if (result.status !== 0) {
+		throw new Error(`tar exited with status ${result.status ?? "unknown"}`);
+	}
+}
+
+function main(): void {
+	if (!existsSync(nativeDir)) {
+		mkdirSync(nativeDir, { recursive: true });
+	}
+
+	// Clean and re-stage. Cached tarballs are removed so re-runs always
+	// reflect the current tree.
+	if (existsSync(stagingRoot)) {
+		rmSync(stagingRoot, { recursive: true, force: true });
+	}
+	mkdirSync(stagingRoot, { recursive: true });
+
+	const entries: AssetEntry[] = [];
+	for (const harness of listConnectors()) {
+		for (const entry of collectAssetEntries(harness)) {
+			stageAsset(entry, stagingRoot);
+			entries.push(entry);
+		}
+	}
+
+	if (entries.length === 0) {
+		console.log("No connector runtime assets to stage; skipping tarball.");
+		// Remove any stale tarball from a prior release that may have shipped
+		// these assets so the manifest and install flow stay consistent.
+		if (existsSync(tarballPath)) rmSync(tarballPath);
+		return;
+	}
+
+	for (const entry of entries) {
+		console.log(
+			`staged ${entry.files.length} file(s) for ${entry.harness}/${entry.assetDir}`,
+		);
+	}
+
+	tarGz(stagingRoot, tarballPath);
+
+	const bytes = statSync(tarballPath).size;
+	const sha256 = createHash("sha256")
+		.update(readFileSync(tarballPath))
+		.digest("hex");
+	console.log(
+		`wrote ${tarballPath} (${bytes} bytes, sha256=${sha256.slice(0, 16)}…)`,
+	);
+}
+
+main();

--- a/scripts/build-native-bun.ts
+++ b/scripts/build-native-bun.ts
@@ -160,12 +160,34 @@ writeFileSync(
 	`import { materializeEmbeddedAssetTree, registerNativeAssets, registerNativeTransformersBindings } from "../platform/daemon/src/native-runtime-assets";
 import { dashboardAssets, skillAssets, templateAssets, wasmAssets, workerAssets } from "./native-assets";
 import * as transformersWebRuntime from "./transformers-web-runtime";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
 
 registerNativeAssets({ dashboard: dashboardAssets, skills: skillAssets, templates: templateAssets, workers: workerAssets, wasm: wasmAssets });
 registerNativeTransformersBindings(transformersWebRuntime);
 process.env.SIGNET_VERSION = process.env.SIGNET_VERSION?.trim() || ${JSON.stringify(nativeVersion)};
 process.env.SIGNET_TEMPLATES_DIR ??= materializeEmbeddedAssetTree("templates") ?? "";
 process.env.SIGNET_SKILLS_SOURCE ??= materializeEmbeddedAssetTree("skills") ?? "";
+
+// When the binary is invoked directly (curl-install + signet install,
+// raw binary from PATH) without a parent process setting SIGNET_DIR,
+// fall back to the binary's own install root so connector plugins
+// extracted to \`<install-root>/runtime/connectors/...\` resolve. npm
+// wrapper installs set this explicitly via launch.js and win the
+// priority check below.
+if (!process.env.SIGNET_DIR?.trim()) {
+	const candidates = [
+		dirname(process.execPath),
+		join(dirname(process.execPath), ".."),
+		join(dirname(process.execPath), "..", ".."),
+	];
+	for (const candidate of candidates) {
+		if (existsSync(join(candidate, "runtime", "connectors"))) {
+			process.env.SIGNET_DIR = candidate;
+			break;
+		}
+	}
+}
 await import("../surfaces/cli/src/cli.ts");
 `,
 );

--- a/scripts/generate-native-manifest.ts
+++ b/scripts/generate-native-manifest.ts
@@ -11,6 +11,16 @@ interface NativeAsset {
 	readonly size: number;
 }
 
+interface ComponentEntry {
+	readonly url: string;
+	readonly sha256: string;
+	readonly size: number;
+}
+
+type ComponentsMap = {
+	readonly connectors?: ComponentEntry;
+};
+
 const root = join(import.meta.dir, "..");
 const nativeDir = join(root, "dist", "native");
 const version = process.env.SIGNET_VERSION ?? JSON.parse(readFileSync(join(root, "package.json"), "utf8")).version;
@@ -20,7 +30,14 @@ if (!existsSync(nativeDir)) {
 }
 
 function platformFromName(name: string): string | null {
-	if (name === "native-manifest.json" || name.endsWith(".sha256")) {
+	if (
+		name === "native-manifest.json" ||
+		name.endsWith(".sha256") ||
+		// Connector-asset tarball is a component, not a binary. Skip it
+		// from the `assets` listing so the install-time platform lookup
+		// doesn't accidentally match `connectors-<version>.tar.gz`.
+		name.startsWith("signet-connectors-")
+	) {
 		return null;
 	}
 
@@ -46,14 +63,35 @@ const assets: NativeAsset[] = readdirSync(nativeDir)
 	})
 	.sort((a, b) => a.platform.localeCompare(b.platform));
 
-if (assets.length === 0) {
-	throw new Error(`No native Signet binaries found in ${nativeDir}`);
+function loadConnectorComponent(): ComponentEntry | null {
+	const tarballName = `signet-connectors-${version}.tar.gz`;
+	const tarballPath = join(nativeDir, tarballName);
+	if (!existsSync(tarballPath)) return null;
+	const stat = statSync(tarballPath);
+	if (!stat.isFile() || stat.size === 0) return null;
+	const sha256 = createHash("sha256").update(readFileSync(tarballPath)).digest("hex");
+	return {
+		// The wrapper resolves the manifest URL relative to the GitHub release
+		// page that hosts the binary. Keep the path consistent with how the
+		// release workflow uploads the tarball.
+		url: `signet-connectors-${version}.tar.gz`,
+		sha256,
+		size: stat.size,
+	};
 }
 
+if (assets.length === 0 && !loadConnectorComponent()) {
+	throw new Error(`No native Signet binaries or connector components found in ${nativeDir}`);
+}
+
+const connectors = loadConnectorComponent();
+const components: ComponentsMap = connectors ? { connectors: connectors } : {};
+
 const manifest = {
-	schemaVersion: 1,
+	schemaVersion: 1 as const,
 	version,
 	assets,
+	components,
 };
 
 const out = join(nativeDir, "native-manifest.json");

--- a/scripts/install-copy-regression.test.ts
+++ b/scripts/install-copy-regression.test.ts
@@ -72,10 +72,12 @@ describe("install copy", () => {
 		// wrapper that forwards to the native binary (issue #826).
 		expect(manifest.bin?.["signet-mcp"]).toBe("dist/mcp-stdio.js");
 		expect(manifest.files).toContain("dist/mcp-stdio.js");
+		expect(manifest.files).toContain("native-manifest.json");
 		expect(manifest.files).not.toContain("bin/signet-mcp.js");
 		expect(launcher).toContain('join(packageDir, "native"');
 		expect(launcher).toContain("resolveNativePackageBinaryPath");
 		expect(launcher).toContain("require.resolve");
+		expect(launcher).toContain("SIGNET_DIR");
 		expect(nativePlatforms).toContain('"linux-x64"');
 		expect(nativePlatforms).toContain('"linux-arm64"');
 		expect(nativePlatforms).toContain('"darwin-x64"');
@@ -84,9 +86,43 @@ describe("install copy", () => {
 		expect(installer).toContain("linkSync");
 		expect(installer).toContain("require.resolve");
 		expect(installer).toContain("Skipping Signet native binary linking in workspace install");
-		expect(installer).not.toContain("native-manifest.json");
-		expect(installer).not.toContain("https");
+		// Connector-asset install reads the manifest shipped with the
+		// wrapper to discover the tarball URL and SHA-256. This is the
+		// peer of the launch.js `SIGNET_DIR` wiring: the postinstall
+		// extracts the connector plugin payload that the native binary
+		// expects to find at `$SIGNET_DIR/runtime/connectors/...`.
+		expect(installer).toContain("native-manifest.json");
+		expect(installer).toContain("CONNECTOR_COMPONENT");
+		expect(installer).toContain("verifySha256");
+		expect(installer).toContain("signet-connectors-${manifest.version}.tar.gz");
 		expect(installer).not.toContain("bun.sh/install");
 		expect(installer).not.toContain("better-sqlite3");
+	});
+
+	test("curl installer downloads and verifies the connector-asset tarball", () => {
+		const installer = read("web/marketing/public/install.sh");
+
+		// The curl installer reads `components.connectors` from the
+		// manifest, downloads the tarball, verifies its SHA-256, and
+		// passes it to `signet install --connector-assets <path>` so the
+		// native command can extract the assets next to the installed
+		// binary.
+		expect(installer).toContain("components.connectors");
+		expect(installer).toContain("--connector-assets");
+		expect(installer).toContain("install --connector-assets");
+	});
+
+	test("build-connector-assets stages runtime plugin assets into a tarball", () => {
+		const buildScript = read("scripts/build-connector-assets.ts");
+		expect(buildScript).toContain("signet-connectors-${version}.tar.gz");
+		expect(buildScript).toContain("runtime/connectors");
+		// The build script walks every `integrations/*/connector/` and
+		// ships any non-source/asset dir under the runtime tree.
+		expect(buildScript).toContain("integrations");
+		expect(buildScript).toContain("hermes-plugin");
+		// Skips build/test output dirs.
+		expect(buildScript).toContain('"dist"');
+		expect(buildScript).toContain('"node_modules"');
+		expect(buildScript).toContain('"src"');
 	});
 });

--- a/scripts/native-install-smoke.test.ts
+++ b/scripts/native-install-smoke.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { type Server, createServer } from "node:http";
@@ -157,7 +157,276 @@ async function serveNativeRelease(binary: Buffer): Promise<NativeReleaseServer> 
 	};
 }
 
+interface ConnectorReleaseServer {
+	readonly downloadBase: string;
+	readonly version: string;
+}
+
+async function serveConnectorRelease(
+	connectorTarball: Buffer,
+	version: string,
+): Promise<ConnectorReleaseServer> {
+	const sha256 = createHash("sha256").update(connectorTarball).digest("hex");
+	const manifest = JSON.stringify({
+		schemaVersion: 1,
+		version,
+		assets: [],
+		components: {
+			connectors: {
+				url: `signet-connectors-${version}.tar.gz`,
+				sha256,
+				size: connectorTarball.length,
+			},
+		},
+	});
+
+	const server = createServer((req, res) => {
+		if (
+			req.url === "/download/native-manifest.json" ||
+			req.url === `/download/v${version}/native-manifest.json`
+		) {
+			res.writeHead(200, { "Content-Type": "application/json" });
+			res.end(manifest);
+			return;
+		}
+		if (
+			req.url === `/download/signet-connectors-${version}.tar.gz` ||
+			req.url === `/download/v${version}/signet-connectors-${version}.tar.gz`
+		) {
+			res.writeHead(200, { "Content-Type": "application/octet-stream" });
+			res.end(connectorTarball);
+			return;
+		}
+		res.writeHead(404);
+		res.end("not found");
+	});
+	servers.push(server);
+	await new Promise<void>((resolve) => {
+		server.listen(0, "127.0.0.1", resolve);
+	});
+	const address = server.address();
+	if (address === null || typeof address === "string") {
+		throw new Error("connector release smoke server did not bind to a TCP port");
+	}
+	return {
+		downloadBase: `http://127.0.0.1:${address.port}/download`,
+		version,
+	};
+}
+
+function buildFakeConnectorTarball(): Buffer {
+	// Build a real tar.gz with a `runtime/connectors/hermes-agent/hermes-plugin/...`
+	// layout so the install path's tar extraction is exercised end-to-end.
+	// Tar the explicit directory entries to avoid tar seeing the staging
+	// dir as "file changed as we read it" under aggressive test-runner
+	// file-watching.
+	const stage = mkdtempSync(join(tmpdir(), "signet-connector-tar-"));
+	tempDirs.push(stage);
+	const pluginDir = join(stage, "runtime", "connectors", "hermes-agent", "hermes-plugin");
+	mkdirSync(pluginDir, { recursive: true });
+	writeFileSync(
+		join(pluginDir, "__init__.py"),
+		"\"\"\"Smoke test plugin for issue #831 connector install path.\"\"\"\n",
+	);
+	writeFileSync(join(pluginDir, "plugin.yaml"), "name: signet\nversion: 1.0.0\n");
+	const tarballPath = join(stage, "out.tar.gz");
+	const tar = spawnSync(
+		"tar",
+		[
+			"czf",
+			tarballPath,
+			"-C",
+			stage,
+			"runtime/connectors/hermes-agent/hermes-plugin/__init__.py",
+			"runtime/connectors/hermes-agent/hermes-plugin/plugin.yaml",
+		],
+		{ stdio: "pipe" },
+	);
+	if (tar.status !== 0) {
+		throw new Error(
+			`tar staging failed: status ${tar.status ?? "unknown"} stderr=${tar.stderr?.toString() ?? "(none)"}`,
+		);
+	}
+	const buf = readFileSync(tarballPath);
+	rmSync(stage, { recursive: true, force: true });
+	const idx = tempDirs.indexOf(stage);
+	if (idx >= 0) tempDirs.splice(idx, 1);
+	return buf;
+}
+
 describe("native install smoke", () => {
+	test("postinstall extracts connector assets from a manifest-aware release", async () => {
+		if (process.platform === "win32") return;
+
+		const version = "0.0.0-smoke-831";
+		const tarball = buildFakeConnectorTarball();
+		const release = await serveConnectorRelease(tarball, version);
+
+		const dir = tempDir();
+		const packageDir = join(dir, "signetai");
+		const platform = platformKey();
+		const nativePackageName = `signetai-${platform}`;
+		const nativePackageDir = join(packageDir, "node_modules", nativePackageName);
+		const nativePackageBin = join(nativePackageDir, "bin", "signet");
+		mkdirSync(packageDir, { recursive: true });
+		mkdirSync(join(nativePackageDir, "bin"), { recursive: true });
+		cpSync(join(root, "dist", "signetai", "scripts"), join(packageDir, "scripts"), {
+			recursive: true,
+		});
+		cpSync(join(root, "dist", "signetai", "bin"), join(packageDir, "bin"), {
+			recursive: true,
+		});
+		// Stash the manifest in the wrapper root. `install-native.js`
+		// looks for `native-manifest.json` next to the wrapper's own
+		// package.json.
+		const manifest = JSON.stringify({
+			schemaVersion: 1,
+			version,
+			assets: [],
+			components: {
+				connectors: {
+					url: `signet-connectors-${version}.tar.gz`,
+					sha256: createHash("sha256").update(tarball).digest("hex"),
+					size: tarball.length,
+				},
+			},
+		});
+		writeFileSync(join(packageDir, "native-manifest.json"), manifest);
+		writeFileSync(
+			join(nativePackageDir, "package.json"),
+			JSON.stringify({ name: nativePackageName, version, type: "module" }),
+		);
+		// Native binary can be empty here — the connector install path
+		// runs even when the binary link is skipped.
+		writeFileSync(nativePackageBin, "");
+		chmodSync(nativePackageBin, 0o755);
+
+		const result = await runCommand(
+			"node",
+			[join(packageDir, "scripts", "install-native.js")],
+			{ ...process.env, SIGNET_DOWNLOAD_BASE: release.downloadBase },
+		);
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("Installed connector assets to");
+
+		// Tarball layout puts files at `<packageDir>/runtime/connectors/...`.
+		// This is the path the binary's `$SIGNET_DIR/runtime/connectors/...`
+		// lookup resolves to, and the layout the connector's
+		// `getPluginSourceDir()` expects.
+		const extractedDir = join(
+			packageDir,
+			"runtime",
+			"connectors",
+			"hermes-agent",
+			"hermes-plugin",
+		);
+		expect(existsSync(join(extractedDir, "__init__.py"))).toBe(true);
+		expect(existsSync(join(extractedDir, "plugin.yaml"))).toBe(true);
+		expect(
+			readFileSync(join(extractedDir, "__init__.py"), "utf8"),
+		).toContain("Smoke test plugin for issue #831");
+		expect(
+			readFileSync(join(packageDir, "runtime", "connectors", ".signet-connectors-version"), "utf8").trim(),
+		).toBe(version);
+	});
+
+	test("postinstall rejects a tarball whose SHA-256 does not match the manifest", async () => {
+		if (process.platform === "win32") return;
+
+		const version = "0.0.0-smoke-831-bad";
+		const tarball = buildFakeConnectorTarball();
+		// Serve a manifest with a wrong SHA so verification must fail.
+		const wrongSha = "0".repeat(64);
+		const server = createServer((req, res) => {
+			if (
+				req.url === "/download/native-manifest.json" ||
+				req.url === `/download/v${version}/native-manifest.json`
+			) {
+				res.writeHead(200, { "Content-Type": "application/json" });
+				res.end(
+					JSON.stringify({
+						schemaVersion: 1,
+						version,
+						assets: [],
+						components: {
+							connectors: {
+								url: `signet-connectors-${version}.tar.gz`,
+								sha256: wrongSha,
+								size: tarball.length,
+							},
+						},
+					}),
+				);
+				return;
+			}
+			if (
+				req.url === `/download/signet-connectors-${version}.tar.gz` ||
+				req.url === `/download/v${version}/signet-connectors-${version}.tar.gz`
+			) {
+				res.writeHead(200, { "Content-Type": "application/octet-stream" });
+				res.end(tarball);
+				return;
+			}
+			res.writeHead(404);
+			res.end("not found");
+		});
+		servers.push(server);
+		await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+		const address = server.address();
+		if (address === null || typeof address === "string") {
+			throw new Error("connector bad-sha server did not bind to a TCP port");
+		}
+
+		const dir = tempDir();
+		const packageDir = join(dir, "signetai");
+		const platform = platformKey();
+		const nativePackageName = `signetai-${platform}`;
+		const nativePackageDir = join(packageDir, "node_modules", nativePackageName);
+		const nativePackageBin = join(nativePackageDir, "bin", "signet");
+		mkdirSync(packageDir, { recursive: true });
+		mkdirSync(join(nativePackageDir, "bin"), { recursive: true });
+		cpSync(join(root, "dist", "signetai", "scripts"), join(packageDir, "scripts"), {
+			recursive: true,
+		});
+		cpSync(join(root, "dist", "signetai", "bin"), join(packageDir, "bin"), {
+			recursive: true,
+		});
+		// The wrapper-side manifest must match what the HTTP server
+		// advertises, otherwise the postinstall skips the connector
+		// install entirely (no URL to fetch from). We override the
+		// SHA via the test server so the postinstall sees a mismatching
+		// value and bails out with the expected error.
+		const manifest = JSON.stringify({
+			schemaVersion: 1,
+			version,
+			assets: [],
+			components: {
+				connectors: {
+					url: `signet-connectors-${version}.tar.gz`,
+					sha256: "0".repeat(64),
+					size: tarball.length,
+				},
+			},
+		});
+		writeFileSync(join(packageDir, "native-manifest.json"), manifest);
+		writeFileSync(
+			join(nativePackageDir, "package.json"),
+			JSON.stringify({ name: nativePackageName, version, type: "module" }),
+		);
+		writeFileSync(nativePackageBin, "");
+		chmodSync(nativePackageBin, 0o755);
+
+		const result = await runCommand(
+			"node",
+			[join(packageDir, "scripts", "install-native.js")],
+			{ ...process.env, SIGNET_DOWNLOAD_BASE: `http://127.0.0.1:${address.port}/download` },
+		);
+
+		expect(result.status).not.toBe(0);
+		expect(result.stderr).toContain("SHA-256 mismatch");
+	});
+
 	test("curl installer installs the manifest-selected native binary", async () => {
 		if (process.platform === "win32") return;
 

--- a/surfaces/cli/src/commands/app.ts
+++ b/surfaces/cli/src/commands/app.ts
@@ -39,6 +39,7 @@ interface InstallOptions {
 	binDir?: string;
 	force?: boolean;
 	json?: boolean;
+	connectorAssets?: string;
 }
 
 interface AppDeps {
@@ -60,6 +61,10 @@ export function registerAppCommands(program: Command, deps: AppDeps): void {
 		.option("--bin-dir <path>", "Directory where the signet binary should be installed")
 		.option("--force", "Replace an existing signet binary")
 		.option("--json", "Output install result as JSON")
+		.option(
+			"--connector-assets <path>",
+			"Path to a connector-asset tarball (signet-connectors-*.tar.gz) to extract alongside the binary",
+		)
 		.action(deps.installNative);
 
 	program

--- a/surfaces/cli/src/features/native-install.ts
+++ b/surfaces/cli/src/features/native-install.ts
@@ -139,16 +139,21 @@ export function installNativeBinary(options: NativeInstallOptions = {}): NativeI
 	const target = join(binDir, binaryName());
 	const pathHint = pathContains(binDir) ? null : binDir;
 
-	if (!existsSync(target) || options.force) {
-		if (existsSync(target) && options.force) {
-			rmSync(target, { force: true });
-		}
-		mkdirSync(binDir, { recursive: true });
-		const tmp = join(dirname(target), `.${basename(target)}.${process.pid}.tmp`);
-		copyFileSync(source, tmp);
-		if (process.platform !== "win32") chmodSync(tmp, 0o755);
-		renameSync(tmp, target);
+	if (existsSync(target) && !options.force) {
+		const connectorAssetsDir = options.connectorAssets
+			? installConnectorAssetsFromManifest(options.connectorAssets, binDir)
+			: null;
+		return { source, target, installed: false, pathHint, connectorAssetsDir };
 	}
+
+	if (existsSync(target) && options.force) {
+		rmSync(target, { force: true });
+	}
+	mkdirSync(binDir, { recursive: true });
+	const tmp = join(dirname(target), `.${basename(target)}.${process.pid}.tmp`);
+	copyFileSync(source, tmp);
+	if (process.platform !== "win32") chmodSync(tmp, 0o755);
+	renameSync(tmp, target);
 
 	const connectorAssetsDir = options.connectorAssets
 		? installConnectorAssetsFromManifest(options.connectorAssets, binDir)
@@ -163,7 +168,12 @@ export function printNativeInstallResult(result: NativeInstallResult, json = fal
 		return;
 	}
 
-	console.log(chalk.green(`Installed Signet binary at ${result.target}`));
+	if (result.installed) {
+		console.log(chalk.green(`Installed Signet binary at ${result.target}`));
+	} else {
+		console.log(chalk.yellow(`Signet binary already exists at ${result.target}`));
+		console.log(chalk.dim("Use --force to replace it."));
+	}
 
 	if (result.connectorAssetsDir) {
 		console.log(

--- a/surfaces/cli/src/features/native-install.ts
+++ b/surfaces/cli/src/features/native-install.ts
@@ -1,12 +1,24 @@
-import { chmodSync, copyFileSync, existsSync, mkdirSync, renameSync } from "node:fs";
+import {
+	chmodSync,
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { createHash } from "node:crypto";
 import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
 import chalk from "chalk";
 
 export interface NativeInstallOptions {
 	readonly binDir?: string;
 	readonly force?: boolean;
 	readonly json?: boolean;
+	readonly connectorAssets?: string;
 }
 
 export interface NativeInstallResult {
@@ -14,6 +26,7 @@ export interface NativeInstallResult {
 	readonly target: string;
 	readonly installed: boolean;
 	readonly pathHint: string | null;
+	readonly connectorAssetsDir: string | null;
 }
 
 function isRuntimeExecutable(path: string): boolean {
@@ -40,6 +53,80 @@ function pathContains(dir: string): boolean {
 	return pathValue.split(separator).some((entry) => normalize(entry) === normalize(dir));
 }
 
+function verifySha256(path: string, expected: string): void {
+	const actual = createHash("sha256").update(readFileSync(path)).digest("hex").toLowerCase();
+	if (actual !== expected.toLowerCase()) {
+		throw new Error(
+			`SHA-256 mismatch for ${path}: expected ${expected.toLowerCase()}, got ${actual}`,
+		);
+	}
+}
+
+function extractConnectorAssets(archivePath: string, extractRoot: string): void {
+	mkdirSync(extractRoot, { recursive: true });
+	// Tarballs are produced by `scripts/build-connector-assets.ts` with a
+	// `runtime/connectors/<harness>/...` layout, so we extract to the
+	// runtime root and let the tarball's own `runtime/` prefix land
+	// naturally at `<extractRoot>/runtime/connectors/...`.
+	const result = spawnSync("tar", ["xzf", archivePath, "-C", extractRoot], { stdio: "inherit" });
+	if (result.status !== 0) {
+		throw new Error(`tar extraction failed with status ${result.status ?? "unknown"}`);
+	}
+}
+
+/**
+ * Install connector plugin assets (e.g. the Hermes Python memory
+ * provider) alongside the Signet binary. The tarball is verified
+ * against the manifest's `components.connectors.sha256` and extracted
+ * to `<binDir>/../runtime/connectors/`, mirroring the layout the npm
+ * wrapper uses after `install-native.js` runs.
+ */
+function installConnectorAssetsFromManifest(
+	tarballPath: string,
+	binDir: string,
+): string {
+	// Look up the expected SHA-256 from the manifest. The manifest is
+	// resolved relative to the wrapper's `native-manifest.json` if it
+	// exists, otherwise we fall back to trusting the tarball as-is
+	// (curl installs without the manifest will skip verification but
+	// still extract, matching the npm-wrapper happy path).
+	const manifestCandidates = [
+		join(process.cwd(), "native-manifest.json"),
+		join(dirname(process.execPath), "..", "native-manifest.json"),
+		join(dirname(process.execPath), "..", "..", "native-manifest.json"),
+	];
+	for (const manifestPath of manifestCandidates) {
+		if (!existsSync(manifestPath)) continue;
+		try {
+			const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+				components?: { connectors?: { sha256?: string; size?: number } };
+			};
+			const expected = manifest.components?.connectors?.sha256;
+			const expectedSize = manifest.components?.connectors?.size;
+			if (expected) verifySha256(tarballPath, expected);
+			if (typeof expectedSize === "number") {
+				const actual = readFileSync(tarballPath).length;
+				if (actual !== expectedSize) {
+					throw new Error(
+						`Tarball size mismatch: expected ${expectedSize}, got ${actual}`,
+					);
+				}
+			}
+			break;
+		} catch (err) {
+			if (err instanceof Error && err.message.startsWith("SHA-256")) throw err;
+			// Ignore JSON parse errors and keep looking at the next candidate.
+		}
+	}
+
+	// Tarballs use a `runtime/connectors/<harness>/...` layout, so we
+	// extract at `<binDir>/..` (one level above `bin/`) and let the
+	// tarball's own `runtime/` prefix land at the right place.
+	const extractRoot = join(binDir, "..");
+	extractConnectorAssets(tarballPath, extractRoot);
+	return join(extractRoot, "runtime", "connectors");
+}
+
 export function installNativeBinary(options: NativeInstallOptions = {}): NativeInstallResult {
 	const source = process.execPath;
 	if (isRuntimeExecutable(source)) {
@@ -52,17 +139,22 @@ export function installNativeBinary(options: NativeInstallOptions = {}): NativeI
 	const target = join(binDir, binaryName());
 	const pathHint = pathContains(binDir) ? null : binDir;
 
-	if (existsSync(target) && !options.force) {
-		return { source, target, installed: false, pathHint };
+	if (!existsSync(target) || options.force) {
+		if (existsSync(target) && options.force) {
+			rmSync(target, { force: true });
+		}
+		mkdirSync(binDir, { recursive: true });
+		const tmp = join(dirname(target), `.${basename(target)}.${process.pid}.tmp`);
+		copyFileSync(source, tmp);
+		if (process.platform !== "win32") chmodSync(tmp, 0o755);
+		renameSync(tmp, target);
 	}
 
-	mkdirSync(binDir, { recursive: true });
-	const tmp = join(dirname(target), `.${basename(target)}.${process.pid}.tmp`);
-	copyFileSync(source, tmp);
-	if (process.platform !== "win32") chmodSync(tmp, 0o755);
-	renameSync(tmp, target);
+	const connectorAssetsDir = options.connectorAssets
+		? installConnectorAssetsFromManifest(options.connectorAssets, binDir)
+		: null;
 
-	return { source, target, installed: true, pathHint };
+	return { source, target, installed: true, pathHint, connectorAssetsDir };
 }
 
 export function printNativeInstallResult(result: NativeInstallResult, json = false): void {
@@ -71,11 +163,12 @@ export function printNativeInstallResult(result: NativeInstallResult, json = fal
 		return;
 	}
 
-	if (result.installed) {
-		console.log(chalk.green(`Installed Signet binary at ${result.target}`));
-	} else {
-		console.log(chalk.yellow(`Signet binary already exists at ${result.target}`));
-		console.log(chalk.dim("Use --force to replace it."));
+	console.log(chalk.green(`Installed Signet binary at ${result.target}`));
+
+	if (result.connectorAssetsDir) {
+		console.log(
+			chalk.green(`Installed connector assets to ${result.connectorAssetsDir}`),
+		);
 	}
 
 	if (result.pathHint) {

--- a/web/marketing/public/install.sh
+++ b/web/marketing/public/install.sh
@@ -95,7 +95,7 @@ checksum=""
 if command -v jq >/dev/null 2>&1; then
 	checksum="$(jq -r --arg platform "$platform" '.assets[] | select(.platform == $platform) | .sha256' "$manifest_path")"
 else
-	manifest="$(tr -d '\n\r\t' < "$manifest_path" | sed 's/ \+/ /g')"
+	manifest="$(tr -d '\n\r	' < "$manifest_path" | sed 's/ \+/ /g')"
 	if [[ $manifest =~ \"platform\"[[:space:]]*:[[:space:]]*\"$platform\"[^}]*\"sha256\"[[:space:]]*:[[:space:]]*\"([a-f0-9]{64})\" ]]; then
 		checksum="${BASH_REMATCH[1]}"
 	fi
@@ -121,5 +121,50 @@ if [ "$actual" != "$checksum" ]; then
 fi
 
 chmod +x "$binary_path"
-"$binary_path" install "$@"
+
+# Connector plugin assets. Newer releases ship a tarball listed under
+# `components.connectors` in the manifest; older ones have no entry and
+# we silently skip. The tarball is passed to `signet install` so the
+# native command can extract it to the install location and point
+# `SIGNET_DIR` at it.
+connector_url=""
+connector_sha=""
+if command -v jq >/dev/null 2>&1; then
+	connector_url="$(jq -r '.components.connectors.url // empty' "$manifest_path")"
+	connector_sha="$(jq -r '.components.connectors.sha256 // empty' "$manifest_path")"
+fi
+
+connector_path=""
+if [ -n "$connector_url" ] && [ -n "$connector_sha" ]; then
+	# The wrapper exposes `connector_url` as a relative path; promote it
+	# to a full GitHub release URL when only the basename was given.
+	case "$connector_url" in
+		http*) connector_full="$connector_url" ;;
+		*)     connector_full="$DOWNLOAD_BASE/$connector_url" ;;
+	esac
+	connector_path="$DOWNLOAD_DIR/$(basename "$connector_full")"
+	download_to "$connector_full" "$connector_path"
+	actual_conn="$(sha256sum "$connector_path" 2>/dev/null | awk '{print $1}')"
+	if [ -z "$actual_conn" ]; then
+		actual_conn="$(shasum -a 256 "$connector_path" | awk '{print $1}')"
+	fi
+	if [ "$actual_conn" != "$connector_sha" ]; then
+		echo "Checksum verification failed for $(basename "$connector_full")" >&2
+		rm -f "$connector_path" "$binary_path"
+		exit 1
+	fi
+fi
+
+# `signet install` accepts a `--connector-assets <path>` flag so it can
+# verify and extract the tarball next to the binary at its final
+# install location. Older binaries without the flag ignore the unknown
+# argument and continue working.
+if [ -n "$connector_path" ]; then
+	"$binary_path" install --connector-assets "$connector_path" "$@"
+else
+	"$binary_path" install "$@"
+fi
 rm -f "$binary_path"
+if [ -n "$connector_path" ]; then
+	rm -f "$connector_path"
+fi


### PR DESCRIPTION
## Problem

Issue #831 reports two failures in the native binary hermes-agent connector:

1. **`signet setup --harness hermes-agent` fails** with `Cannot find hermes-plugin directory in connector package`. The native binary (`bun build --compile`) embeds the connector JS but cannot carry on-disk plugin payloads. The `SIGNET_DIR/runtime/connectors/...` fallback from PR #789 is dead code because nothing populates that path.

2. **`signet doctor hermes` fails** because Hermes has a built-in core tool called `session_search` that preempts the Signet provider's registration. The probe script asserts on the bare name, which never appears in the tool table.

## Fix

### PR A — connector-asset shipping (commit `8b5bf83`)

Restores the asset-shipping side of v0.135.0's `bundle.yml` (which #816 dropped). The release pipeline now:

- Builds `signet-connectors-<version>.tar.gz` from `integrations/*/connector/` non-source dirs
- Lists it in `native-manifest.json` under `components.connectors` with SHA-256 + size
- The npm wrapper postinstall (`install-native.js`) downloads, verifies, and extracts the tarball to `<packageDir>/runtime/connectors/`
- `launch.js` sets `SIGNET_DIR=<packageDir>` in the spawn env
- The curl installer (`install.sh`) also downloads + verifies the tarball and passes it to `signet install --connector-assets <path>`
- The native binary bootstrap derives `SIGNET_DIR` from `process.execPath` as a fallback

Connectors with no on-disk assets (claude-code, codex, gemini, oh-my-pi, openclaw, opencode, pi) are unaffected.

### PR D — `session_search` → `signet_session_search` (commit `58cb6e4`)

Renames the externally-visible tool name so the Signet provider registration succeeds. The Python client method keeps its unnamespaced name (`SignetClient.session_search()`) since it's an internal dispatch target, not model-facing.

## Tests

- 10 install tests pass (5 smoke + 5 regression), including two new connector-asset smoke tests exercising the full postinstall path with a local HTTP server
- 65 hermes-connector tests pass with updated assertions that pin the namespaced form and explicitly assert the bare name is absent

Closes #831