### PR TITLE
docs(connectors): add remote harness setup guide

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -571,7 +571,7 @@ Database Schema
 SQLite with WAL mode. Migrations are numbered sequentially under
 `platform/core/src/migrations/`. Each migration is idempotent — safe
 to re-run against an existing database. Schema version is tracked in
-`schema_migrations`. The latest migration is `077-entity-aliases.ts`.
+`schema_migrations`. The latest migration is `078-api-keys.ts`.
 
 **schema_migrations**
 

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -36,9 +36,12 @@ a token (full access), but if a token is included it will be validated.
 Remote requests always require a valid token. This lets local tooling
 work without credentials while still securing remote access.
 
-Note: localhost detection in hybrid mode works by checking the `Host`
-request header, not the TCP peer address. This is spoofable in theory
-but acceptable given the daemon typically binds to 127.0.0.1.
+Note: localhost detection in hybrid mode uses the TCP peer address. If the
+daemon cannot determine a localhost peer, it treats the request as remote and
+requires a valid bearer credential. Do not rely on `hybrid` behind a same-host
+reverse proxy for untrusted traffic: proxied public requests can arrive from
+`127.0.0.1` and be treated as local. Use `team` mode or enforce auth at the
+proxy for public deployments.
 
 
 API Key Management
@@ -46,10 +49,11 @@ API Key Management
 
 API keys are the preferred credential for remote connectors. They are named,
 revocable, and stored hashed at rest. The raw key is printed once when it is
-created.
+created. For a complete cross-machine connector walkthrough, see
+[[remote-connectors|Remote Harness Connectors]].
 
 ```bash
-signet api-key create --name "work laptop pi" --connector pi
+signet api-key create --name "work laptop pi" --connector pi --agent-id pi-work-laptop
 signet api-key list
 signet api-key revoke <id-or-prefix>
 ```
@@ -65,15 +69,17 @@ Use `SIGNET_API_KEY` on remote machines:
 ```bash
 SIGNET_DAEMON_URL=https://signet-home.tailnet:3850 \
 SIGNET_API_KEY=sig_sk_... \
-signet connector install pi
+signet connector install pi --agent-id pi-work-laptop
 ```
 
 `SIGNET_TOKEN` remains a backwards-compatible alias for older integrations.
 
 API keys can also carry an optional explicit `permissions` list. When present,
 that list narrows the key beyond its role; for example an `admin` key with only
-`["recall"]` cannot perform admin mutations. Omit `permissions` for the full
-role-level permission set.
+`["recall"]` cannot perform admin mutations. Connector keys created with
+`--connector` default to the narrower connector permission set: `recall`,
+`remember`, and `documents`. For non-connector keys, omit `permissions` for the
+full role-level permission set.
 
 
 Token Management

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -883,10 +883,11 @@ Subcommands:
 `signet api-key`
 ---
 
-Create named API keys for remote connectors and other daemon clients.
+Create named API keys for remote connectors and other daemon clients. See
+[[remote-connectors|Remote Harness Connectors]] for the full remote setup flow.
 
 ```bash
-signet api-key create --name "work laptop pi" --connector pi
+signet api-key create --name "work laptop pi" --connector pi --agent-id pi-work-laptop
 signet api-key list
 signet api-key revoke <id-or-prefix>
 ```
@@ -900,11 +901,12 @@ The raw `sig_sk_...` key is printed once. Store it on the remote machine as
 ---
 
 Install portable harness connectors. Use `signet connect <harness>` as a short
-alias for `signet connector install <harness>`.
+alias for `signet connector install <harness>`. For a start-to-finish remote
+machine setup, see [[remote-connectors|Remote Harness Connectors]].
 
 ```bash
 signet connector install pi
-signet connector install pi --url https://signet-home.tailnet:3850 --api-key sig_sk_...
+signet connector install pi --url https://signet-home.tailnet:3850 --api-key sig_sk_... --agent-id pi-work-laptop
 signet connect codex --url https://signet-home.tailnet:3850 --api-key sig_sk_...
 ```
 
@@ -912,8 +914,8 @@ Connector installers are also published as individual npm packages for machines
 where you only want to configure one harness:
 
 ```bash
-npx -y @signetai/connector-pi install --url https://signet-home.tailnet:3850 --api-key sig_sk_...
-npx -y @signetai/connector-opencode install --url https://signet-home.tailnet:3850 --api-key sig_sk_...
+npx -y @signetai/connector-pi install --url https://signet-home.tailnet:3850 --api-key sig_sk_... --agent-id pi-work-laptop
+npx -y @signetai/connector-opencode install --url https://signet-home.tailnet:3850 --api-key sig_sk_... --agent-id opencode-work-laptop
 npx -y @signetai/connector-codex install --url https://signet-home.tailnet:3850 --api-key sig_sk_...
 ```
 

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -14,6 +14,10 @@ content into the memory store as searchable [[documents]]. Each connector
 follows a consistent register-sync-health lifecycle managed through
 the [[daemon]]'s [[api|HTTP API]].
 
+This page covers document-source connectors. If you want to install a harness
+adapter on another machine and point it at a remote Signet daemon, see
+[[remote-connectors|Remote Harness Connectors]].
+
 The connector framework lives in `platform/daemon/src/connectors/`.
 Type definitions are in `platform/core/src/connector-types.ts`.
 

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -10,6 +10,9 @@ section: "Reference"
 Harnesses are the AI platforms and tools that Signet integrates with
 through connectors, plugins, and lifecycle hooks.
 
+For the end-to-end process of connecting a harness on one machine to a Signet
+daemon on another machine, see [[remote-connectors|Remote Harness Connectors]].
+
 > **Path note:** `$SIGNET_WORKSPACE` means your active Signet workspace path.
 > Default is `~/.agents`, configurable via `signet workspace set <path>`.
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -417,7 +417,7 @@ The CLI calls the daemon's hook endpoints and outputs context that Claude Code i
 
 ## OpenCode Integration
 
-OpenCode uses a bundled plugin installed by `@signet/connector-opencode`
+OpenCode uses a bundled plugin installed by `@signetai/connector-opencode`
 at `~/.config/opencode/plugins/signet.mjs`. The plugin calls the daemon
 API at session lifecycle events (session-start, user-prompt-submit,
 session-end) and exposes `/remember` and `/recall` as native tools.
@@ -433,7 +433,7 @@ Install is handled automatically by `signet setup` or `signet connect opencode`.
 
 ## pi Integration
 
-pi uses a bundled extension installed by `@signet/connector-pi` at
+pi uses a bundled extension installed by `@signetai/connector-pi` at
 `~/.pi/agent/extensions/signet-pi.js` (or `$PI_CODING_AGENT_DIR/extensions/signet-pi.js`).
 The extension calls the daemon API at session lifecycle events (session-start,
 user-prompt-submit, session-end, compaction) and exposes `/recall`, `/remember`,
@@ -444,10 +444,11 @@ Install is handled automatically by `signet setup` or `signet connector install 
 For a remote daemon, pass the daemon URL and API key during install:
 
 ```bash
-signet api-key create --name "work laptop pi" --connector pi
+signet api-key create --name "work laptop pi" --connector pi --agent-id pi-work-laptop
 signet connector install pi \
   --url https://signet-home.tailnet:3850 \
-  --api-key sig_sk_...
+  --api-key sig_sk_... \
+  --agent-id pi-work-laptop
 ```
 
 Configuration is optional via `~/.pi/agent/extensions/signet.json`. Set

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -585,7 +585,8 @@ Next Steps
 - [Configuration Reference](./CONFIGURATION.md) — all agent.yaml options
 - [Memory System](./MEMORY.md) — how remember/recall works
 - [Pipeline](./PIPELINE.md) — how Pipeline V2 extracts and processes memories
-- [Connectors](./CONNECTORS.md) — platform connector details
+- [Connectors](./CONNECTORS.md) — document-source connector details
+- [Remote Harness Connectors](./REMOTE-CONNECTORS.md) — connect harnesses on other machines to one Signet daemon
 - [Hooks](./HOOKS.md) — lifecycle hooks for harness integration
 - [Analytics](./ANALYTICS.md) — session and memory analytics
 - [Diagnostics](./DIAGNOSTICS.md) — health checks and pipeline status

--- a/docs/REMOTE-CONNECTORS.md
+++ b/docs/REMOTE-CONNECTORS.md
@@ -1,0 +1,418 @@
+---
+title: "Remote Harness Connectors"
+description: "Connect Claude Code, Codex, Pi, OpenCode, and other harnesses on one machine to a Signet daemon on another."
+order: 16
+section: "How-to"
+---
+
+# Remote Harness Connectors
+
+Use remote harness connectors when Signet is running on one trusted machine and
+your agent harness runs somewhere else: a laptop, desktop, server, VM, or
+Tailscale peer.
+
+The setup model is:
+
+> Run one Signet daemon. Point every harness connector at it with
+> `SIGNET_DAEMON_URL` and `SIGNET_API_KEY`.
+
+The daemon keeps ownership of memory, sources, sessions, identity, auth, and
+policy. The connector on the remote machine is a small adapter that installs
+into the harness, forwards lifecycle events, and exposes Signet tools inside
+that harness.
+
+## What you need
+
+- A Signet daemon running on the machine that owns your Signet workspace.
+- Network reachability from the remote machine to that daemon.
+- A named Signet API key for each remote connector.
+- The target harness installed on the remote machine.
+
+Examples below use a tailnet/LAN URL such as `http://signet-home:3850`. Replace
+it with your daemon URL, for example:
+
+```text
+http://100.107.87.47:3850
+http://signet-home.tailnet:3850
+https://signet.example.com
+```
+
+Do not paste real API keys into chat, issues, logs, screenshots, or shell
+history you plan to share. The raw key is shown once when created.
+
+## 1. Prepare the Signet daemon machine
+
+On the machine that already has your Signet workspace:
+
+```bash
+signet --version
+signet daemon status --json
+curl http://127.0.0.1:3850/health
+```
+
+The daemon must be reachable from the remote machine, not only from localhost.
+For a trusted tailnet or private LAN, set the daemon network mode to `tailscale`
+so it binds to `0.0.0.0`:
+
+```yaml
+# $SIGNET_WORKSPACE/agent.yaml
+network:
+  mode: tailscale
+```
+
+Then restart the daemon:
+
+```bash
+signet daemon restart
+```
+
+You can also use an explicit environment override when you manage the daemon
+service yourself:
+
+```bash
+SIGNET_BIND=0.0.0.0 SIGNET_PORT=3850 signet daemon start
+```
+
+Check the reported bind mode:
+
+```bash
+signet daemon status --json
+```
+
+Look for `bindHost: "0.0.0.0"` and `networkMode: "tailscale"` in the daemon
+status output.
+
+## 2. Choose an auth mode
+
+Use `hybrid` or `team` mode for remote connectors.
+
+```yaml
+# $SIGNET_WORKSPACE/agent.yaml
+auth:
+  mode: hybrid
+```
+
+- `hybrid` keeps local CLI/dashboard requests convenient while requiring a
+  valid bearer key from remote machines.
+- `team` requires auth for every request, including localhost.
+- `local` has no auth. Only use it on a private, trusted network while
+  testing, never on an exposed interface.
+
+Restart after changing auth:
+
+```bash
+signet daemon restart
+```
+
+Verify remote unauthenticated requests are rejected in `hybrid` or `team` mode
+from the remote machine:
+
+```bash
+curl -i http://signet-home:3850/api/auth/whoami
+```
+
+A `401 Unauthorized` response is expected for a remote request without a key.
+`/health` may still be reachable because it is a basic health endpoint.
+
+## 3. Create a connector API key
+
+Create one key per machine/harness pair. This makes revocation and audit trails
+clear.
+
+```bash
+signet api-key create \
+  --name "work laptop pi" \
+  --connector pi \
+  --agent-id pi-work-laptop
+```
+
+The command prints the raw `sig_sk_...` key once. Save it in your password
+manager or pass it directly to the remote installer. Do not commit it.
+
+If you create the key with `--agent-id`, pass the same `--agent-id` when you
+install the connector. This keeps scope-guarded API calls and connector
+attribution aligned. In Signet 0.140.1, connector lifecycle hook traffic is
+authenticated but not every hook path enforces agent scope as a hard isolation
+boundary, so use one named key per connector and revoke keys you no longer
+trust.
+
+Codex note for Signet 0.140.1: the Codex installer does not yet persist
+`SIGNET_AGENT_ID` into generated Codex hook/MCP config. Use a named but
+unscoped Codex key for now unless you manually manage the generated Codex
+runtime environment.
+
+For other harnesses, change `--connector` and the name:
+
+```bash
+signet api-key create --name "work laptop codex" --connector codex
+signet api-key create --name "work laptop opencode" --connector opencode --agent-id opencode-work-laptop
+```
+
+List keys without revealing secrets:
+
+```bash
+signet api-key list
+```
+
+Revoke a key if a machine is retired or the key was exposed:
+
+```bash
+signet api-key revoke <id-or-prefix>
+```
+
+## 4. Install the connector on the remote machine
+
+There are two install paths.
+
+### Option A: Signet CLI installed on the remote machine
+
+Use this if the remote machine already has the `signet` CLI:
+
+```bash
+signet connector install pi \
+  --url http://signet-home:3850 \
+  --api-key sig_sk_... \
+  --agent-id pi-work-laptop
+```
+
+`signet connect <harness>` is a short alias:
+
+```bash
+signet connect codex \
+  --url http://signet-home:3850 \
+  --api-key sig_sk_...
+```
+
+### Option B: connector-only npm installers
+
+Use this if you only want to configure one harness and do not want to install
+the full Signet CLI first:
+
+```bash
+npx -y @signetai/connector-pi install \
+  --url http://signet-home:3850 \
+  --api-key sig_sk_... \
+  --agent-id pi-work-laptop
+```
+
+Available connector packages:
+
+| Harness | Package | Binary |
+|---|---|---|
+| Claude Code | `@signetai/connector-claude-code` | `signet-connector-claude-code` |
+| Codex | `@signetai/connector-codex` | `signet-connector-codex` |
+| Codex native plugin UX | `@signetai/codex-plugin` | `signet-codex-plugin` |
+| Gemini | `@signetai/connector-gemini` | `signet-connector-gemini` |
+| Hermes Agent | `@signetai/connector-hermes-agent` | `signet-connector-hermes-agent` |
+| Oh My Pi | `@signetai/connector-oh-my-pi` | `signet-connector-oh-my-pi` |
+| OpenClaw | `@signetai/connector-openclaw` | `signet-connector-openclaw` |
+| OpenCode | `@signetai/connector-opencode` | `signet-connector-opencode` |
+| Pi | `@signetai/connector-pi` | `signet-connector-pi` |
+
+Codex users should usually prefer the native-plugin-oriented package name:
+
+```bash
+npx -y @signetai/codex-plugin install \
+  --url http://signet-home:3850 \
+  --api-key sig_sk_...
+```
+
+The installer writes the daemon URL and API key into the harness config it
+manages. It uses `SIGNET_DAEMON_URL` and `SIGNET_API_KEY` at runtime.
+`SIGNET_TOKEN` remains a backwards-compatible alias, but new installs should
+use `SIGNET_API_KEY`.
+
+## 5. Verify the connection before first run
+
+From the remote machine:
+
+```bash
+curl http://signet-home:3850/health
+```
+
+Then check the installed connector status:
+
+```bash
+npx -y @signetai/connector-pi status
+npx -y @signetai/codex-plugin status
+npx -y @signetai/connector-opencode status
+```
+
+If you installed through the Signet CLI, the harness-specific status commands
+are still available through the package installers. `signet connector install`
+only installs; it does not currently have a separate `status` subcommand.
+
+For an authenticated route smoke test without printing the key, run this from a
+shell where `SIGNET_API_KEY` is set:
+
+```bash
+export SIGNET_DAEMON_URL=http://signet-home:3850
+export SIGNET_API_KEY=sig_sk_...
+
+curl -fsS "$SIGNET_DAEMON_URL/api/auth/whoami" \
+  -H "Authorization: Bearer $SIGNET_API_KEY"
+```
+
+You should get JSON describing the authenticated connector role/scope. If you
+get `401`, check the key, auth mode, and daemon URL.
+
+## 6. Start the harness and run a first check
+
+Open a fresh session in the target harness after installing or updating a
+connector. Most harnesses load extensions, plugins, MCP servers, or hooks at
+process/session startup; an already-running session may still have the old tool
+list.
+
+Good first checks:
+
+- Ask the harness to recall a harmless preference or project fact.
+- Ask it to search source-backed context if the connector exposes
+  `signet_source_search`.
+- Ask it to search transcript/session history if the connector exposes
+  `signet_session_search`.
+- Save a harmless test memory, then revoke/delete it if you do not want to keep
+  it.
+
+For Pi and Oh My Pi, restart the Pi session after installing so the extension
+bundle is reloaded. A refreshed install can be correct on disk while the current
+session still shows the old tool list.
+
+## Common setups
+
+### One desktop daemon, laptop connectors over Tailscale
+
+On the desktop:
+
+```yaml
+# $SIGNET_WORKSPACE/agent.yaml
+network:
+  mode: tailscale
+auth:
+  mode: hybrid
+```
+
+```bash
+signet daemon restart
+signet api-key create --name "laptop codex" --connector codex
+```
+
+On the laptop:
+
+```bash
+npx -y @signetai/codex-plugin install \
+  --url http://100.107.87.47:3850 \
+  --api-key sig_sk_...
+```
+
+Start a new Codex session and use the Signet MCP tools from that session.
+
+### Remote OpenCode connector
+
+On the daemon machine:
+
+```bash
+signet api-key create --name "mini pc opencode" --connector opencode --agent-id opencode-mini-pc
+```
+
+On the OpenCode machine:
+
+```bash
+npx -y @signetai/connector-opencode install \
+  --url http://signet-home.tailnet:3850 \
+  --api-key sig_sk_... \
+  --agent-id opencode-mini-pc
+```
+
+Start a new OpenCode session so it picks up the new plugin/config.
+
+### Remote Pi connector
+
+On the daemon machine:
+
+```bash
+signet api-key create --name "work laptop pi" --connector pi --agent-id pi-work-laptop
+```
+
+On the Pi machine:
+
+```bash
+npx -y @signetai/connector-pi install \
+  --url http://signet-home.tailnet:3850 \
+  --api-key sig_sk_... \
+  --agent-id pi-work-laptop
+```
+
+Start a new Pi session. The Pi connector should expose Signet tools such as
+`signet_recall`, `signet_remember`, `signet_source_search`, and
+`signet_session_search`.
+
+## Troubleshooting
+
+### `curl /health` fails from the remote machine
+
+- Confirm the daemon is running: `signet daemon status --json`.
+- Confirm it is not bound only to localhost. Use `network.mode: tailscale` or
+  `SIGNET_BIND=0.0.0.0`.
+- Confirm firewall, tailnet ACLs, or security-group rules allow TCP port 3850.
+- Try the daemon machine's tailnet IP directly instead of a hostname.
+
+### Authenticated requests return `401 Unauthorized`
+
+- Make sure the remote connector uses `SIGNET_API_KEY`, not a placeholder.
+- Confirm the key was not revoked: `signet api-key list`.
+- Create a fresh key and reinstall the connector if the original key may have
+  been copied incorrectly.
+- Confirm the daemon URL points to the Signet daemon origin only, not a nested
+  path.
+
+### The harness starts but no Signet tools appear
+
+- Restart the harness session after installing the connector.
+- Re-run the connector install command to refresh managed config.
+- Check the package status command, for example
+  `npx -y @signetai/connector-pi status`.
+- For MCP-based harnesses, inspect the harness MCP config and confirm the
+  Signet server entry is present.
+
+### Local CLI works but remote connector fails in `hybrid` mode
+
+That usually means auth is working: localhost is allowed without a key, while
+remote requests require one. Verify with:
+
+```bash
+curl -i http://signet-home:3850/api/auth/whoami
+curl -i http://signet-home:3850/api/auth/whoami \
+  -H "Authorization: Bearer $SIGNET_API_KEY"
+```
+
+The first remote request should be `401`; the second should succeed.
+
+### You exposed a key accidentally
+
+Revoke it immediately:
+
+```bash
+signet api-key revoke <id-or-prefix>
+```
+
+Then create a new key and rerun the connector installer on the affected
+machine.
+
+## Security notes
+
+- Prefer Tailscale, WireGuard, a private LAN, or HTTPS through a reverse proxy.
+- Do not expose a `local` auth-mode daemon to the public internet.
+- Use one named key per connector/machine so revocation is precise.
+- Store API keys in the target harness config or a local secret manager, not in
+  shell scripts committed to a repo.
+- If the daemon is reachable from untrusted networks, use `auth.mode: team` and
+  terminate TLS with a reverse proxy. See [[self-hosting|Self-Hosting]] and
+  [[auth|Authentication]].
+
+## Related docs
+
+- [[auth|Authentication]] — auth modes, API-key records, roles, and revocation.
+- [[harnesses|Harnesses]] — harness-specific files and runtime behavior.
+- [[cli|CLI Reference]] — exact CLI command reference.
+- [[self-hosting|Self-Hosting]] — service deployment, reverse proxy, TLS, and
+  production hardening.

--- a/docs/api/core-configuration.md
+++ b/docs/api/core-configuration.md
@@ -65,6 +65,126 @@ requests/min.
 Returns `400` if `role` is invalid or auth secret is unavailable (local
 mode). Returns `400` if the request body is missing or malformed.
 
+### GET /api/auth/api-keys
+
+List named daemon API keys. Requires `admin` permission. The response never
+includes raw `sig_sk_...` key values; raw keys are only returned once at
+creation time.
+
+**Response**
+
+```json
+{
+  "apiKeys": [
+    {
+      "id": "key_abc123",
+      "prefix": "1b363ad385e1",
+      "name": "work laptop pi",
+      "role": "agent",
+      "scope": { "agent": "pi-work-laptop" },
+      "permissions": ["recall", "remember", "documents"],
+      "connector": "pi",
+      "harness": "pi",
+      "agentId": "pi-work-laptop",
+      "allowedProjects": [],
+      "createdAt": "2026-06-11T04:02:17.922Z",
+      "lastUsedAt": null,
+      "revokedAt": null,
+      "expiresAt": null
+    }
+  ]
+}
+```
+
+### POST /api/auth/api-keys
+
+Create a named API key for remote connectors or other daemon clients. Requires
+`admin` permission. The raw `key` is returned once in this response and is
+stored hashed at rest.
+
+**Request body**
+
+```json
+{
+  "name": "work laptop pi",
+  "connector": "pi",
+  "role": "agent",
+  "agentId": "pi-work-laptop",
+  "scope": { "agent": "pi-work-laptop" },
+  "allowedProjects": [],
+  "expiresAt": null
+}
+```
+
+`name` is required. `role` defaults to `agent` and must be one of `admin`,
+`operator`, `agent`, or `readonly` when provided. `connector`, `harness`,
+`agentId`, `allowedProjects`, `scope`, `permissions`, and `expiresAt` are
+optional. `agentId` is connector metadata; API callers should also set
+`scope: { "agent": "..." }` when scope-guarded API surfaces should be limited
+to that agent. For connector keys, `scope.agent` should usually match
+`agentId`. In Signet 0.140.1, connector lifecycle hook traffic authenticates
+the key but not every hook path enforces agent scope as a hard isolation
+boundary. Connector keys default to the connector permission set: `recall`,
+`remember`, and `documents`.
+
+**Response**
+
+```json
+{
+  "apiKey": {
+    "id": "key_abc123",
+    "prefix": "1b363ad385e1",
+    "name": "work laptop pi",
+    "role": "agent",
+    "scope": { "agent": "pi-work-laptop" },
+    "permissions": ["recall", "remember", "documents"],
+    "connector": "pi",
+    "harness": "pi",
+    "agentId": "pi-work-laptop",
+    "allowedProjects": [],
+    "createdAt": "2026-06-11T04:02:17.922Z",
+    "lastUsedAt": null,
+    "revokedAt": null,
+    "expiresAt": null,
+    "key": "sig_sk_..."
+  }
+}
+```
+
+Returns `400` if the request body is missing or malformed, `name` is empty,
+`role` is invalid, or `expiresAt` is not a valid ISO timestamp.
+
+### DELETE /api/auth/api-keys/:id
+
+Revoke an API key by id or prefix. Requires `admin` permission. Revocation is
+idempotent for an existing key: already-revoked keys are returned with their
+original `revokedAt` timestamp.
+
+**Response**
+
+```json
+{
+  "apiKey": {
+    "id": "key_abc123",
+    "prefix": "1b363ad385e1",
+    "name": "work laptop pi",
+    "role": "agent",
+    "scope": { "agent": "pi-work-laptop" },
+    "permissions": ["recall", "remember", "documents"],
+    "connector": "pi",
+    "harness": "pi",
+    "agentId": "pi-work-laptop",
+    "allowedProjects": [],
+    "createdAt": "2026-06-11T04:02:17.922Z",
+    "lastUsedAt": null,
+    "revokedAt": "2026-06-11T05:00:00.000Z",
+    "expiresAt": null
+  }
+}
+```
+
+Returns `404` if the id or prefix does not match an API key.
+
 
 ## Config
 

--- a/docs/specs/approved/portable-remote-connectors.md
+++ b/docs/specs/approved/portable-remote-connectors.md
@@ -33,27 +33,32 @@ stable API.
 
 Each harness connector should be its own npm package, for example:
 
-- `@signet/connector-pi`
-- `@signet/connector-codex`
-- `@signet/connector-opencode`
-- `@signet/connector-claude-code`
+- `@signetai/connector-pi`
+- `@signetai/connector-codex`
+- `@signetai/connector-opencode`
+- `@signetai/connector-claude-code`
+
+The source workspace package names may remain `@signet/*`; release staging
+rewrites public npm artifacts to the `@signetai/*` scope.
 
 Connector packages must remain directly installable for portable use:
 
 ```bash
-npx @signet/connector-pi install \
+npx -y @signetai/connector-pi install \
   --url https://signet-home.tailnet:3850 \
-  --api-key sig_sk_...
+  --api-key sig_sk_... \
+  --agent-id pi-work-laptop
 ```
 
 The Signet CLI may wrap these packages for the local/common path:
 
 ```bash
 signet connector install pi
-signet connector install pi --url https://signet-home.tailnet:3850 --api-key sig_sk_...
+signet connector install pi --url https://signet-home.tailnet:3850 --api-key sig_sk_... --agent-id pi-work-laptop
 ```
 
-Shared behavior belongs in `@signet/connector-base`: config loading, daemon
+Shared behavior belongs in the connector-base package (`@signet/connector-base`
+in source, published as `@signetai/connector-base`): config loading, daemon
 client defaults, API-key handling, request envelopes, timeouts, retries, health
 checks, and common Signet tool contracts. Harness-specific packages should own
 only installation and runtime glue required by that harness.
@@ -67,10 +72,9 @@ protocol for V1.
 The CLI must be able to generate connector API keys:
 
 ```bash
-signet api-key create --name "work laptop pi" --connector pi
+signet api-key create --name "work laptop pi" --connector pi --agent-id pi-work-laptop
 signet api-key list
 signet api-key revoke <id-or-prefix>
-signet api-key rotate <id-or-prefix>
 ```
 
 The daemon prints the raw key once and stores only a hash:
@@ -80,11 +84,15 @@ API key created:
 
   name:      work laptop pi
   id:        key_...
+  prefix:    ...
   key:       sig_sk_...
-  scopes:    connector:pi, recall, remember, source_search, session_search, session_events
-  daemon:    https://signet-home.tailnet:3850
+  role:      agent
+  connector: pi
 
-Save this now. It will not be shown again.
+Save this key now. It will not be shown again.
+
+Use `--json` when automation needs structured fields such as `agentId`,
+`scope`, `permissions`, and `expiresAt`.
 ```
 
 Connector requests authenticate with bearer auth:
@@ -95,28 +103,31 @@ X-Signet-Harness: pi
 X-Signet-Connector-Version: 0.140.0
 ```
 
-Internally, API keys should be named, scoped, revocable records:
+The public API-key metadata shape should be named, scoped, and revocable. The
+underlying database row also stores the secret verifier as `key_hash`; the raw
+key is never stored.
 
 ```ts
 type ApiKeyRecord = {
   id: string;
   prefix: string;
-  hash: string;
   name: string;
-  scopes: string[];
-  connector?: string;
-  harness?: string;
-  agentId?: string;
-  allowedProjects?: string[];
+  role: "admin" | "operator" | "agent" | "readonly";
+  scope: { project?: string; agent?: string; user?: string };
+  permissions: string[];
+  connector: string | null;
+  harness: string | null;
+  agentId: string | null;
+  allowedProjects: string[];
   createdAt: string;
-  lastUsedAt?: string;
-  revokedAt?: string;
-  expiresAt?: string;
+  lastUsedAt: string | null;
+  revokedAt: string | null;
+  expiresAt: string | null;
 };
 ```
 
-The user-facing model is still just a URL and key. Scopes are the safety rail,
-not the main setup ceremony.
+The user-facing model is still just a URL and key. Scope and permissions are
+the safety rails, not the main setup ceremony.
 
 ## Request context
 


### PR DESCRIPTION
## Summary

Add a user-facing remote harness connector guide that walks from daemon prep through API-key creation, connector install, first-run checks, troubleshooting, and security notes.

## Changes

- Add `docs/REMOTE-CONNECTORS.md` as the end-to-end cross-machine setup guide.
- Link the guide from Harnesses, CLI, Auth, Connectors, and Quickstart docs.
- Document API-key management routes in the HTTP API reference.
- Clarify remote connector auth/scoping caveats for 0.140.1:
  - named key per connector/machine
  - matching `--agent-id` where supported
  - Codex 0.140.1 does not yet persist `SIGNET_AGENT_ID`
  - hook traffic is authenticated, but not every hook path is a hard agent-scope boundary
- Update stale connector package examples in the portable connector spec to `@signetai/*`.
- Update latest migration reference to `078-api-keys.ts`.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage
- [x] `docs` — documentation only

## Packages affected

- [ ] `@signet/core`
- [ ] `@signet/daemon`
- [ ] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: docs only

## Screenshots

N/A — docs only.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

Docs-only PR; code/test checklist items are N/A but checked after confirming no runtime code changed.

## Migration Notes (if applicable)

N/A — no database migrations.

- [ ] Migration is idempotent
- [ ] Daemon Rust parity reviewed or explicitly N/A
- [ ] Rollback / compatibility note included in PR description

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] Tested against running daemon
- [x] N/A

Validated:

- `git diff --check`
- `bun scripts/doc-drift.ts` routes/migrations are clean
  - remaining package-table summary is pre-existing broad drift in `AGENTS.md`/`README.md`
- targeted grep for stale public connector examples / nonexistent commands
- `autoreview` clean for release-blocking remote connector/API-key documentation accuracy

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The guide intentionally documents shipped 0.140.1 behavior, including the current Codex `SIGNET_AGENT_ID` caveat and hook scope-enforcement caveat, rather than promising future isolation semantics.
