### PR TITLE
fix(connector-base): reject invalid workspace config

### DIFF
--- a/libs/connector-base/index.test.ts
+++ b/libs/connector-base/index.test.ts
@@ -154,6 +154,13 @@ describe("resolveSignetWorkspacePath", () => {
 		expect(resolveSignetWorkspacePath()).toBe(resolve(relativeWorkspace));
 	});
 
+	it("uses the default workspace path when no persisted config exists", () => {
+		dir = mkdtempSync(join(tmpdir(), "signet-connector-base-workspace-"));
+		process.env.XDG_CONFIG_HOME = dir;
+
+		expect(resolveSignetWorkspacePath()).toBe(join(homedir(), ".agents"));
+	});
+
 	it("expands and normalizes the configured workspace path", () => {
 		dir = mkdtempSync(join(tmpdir(), "signet-connector-base-workspace-"));
 		process.env.XDG_CONFIG_HOME = dir;
@@ -173,6 +180,26 @@ describe("resolveSignetWorkspacePath", () => {
 		);
 
 		expect(resolveSignetWorkspacePath()).toBe(resolve(join(homedir(), rel, "..", rel, "agents")));
+	});
+
+	it("rejects malformed persisted workspace config instead of falling back to ~/.agents", () => {
+		dir = mkdtempSync(join(tmpdir(), "signet-connector-base-workspace-"));
+		process.env.XDG_CONFIG_HOME = dir;
+		const cfgDir = join(dir, "signet");
+		mkdirSync(cfgDir, { recursive: true });
+		writeFileSync(join(cfgDir, "workspace.json"), "{not json", "utf-8");
+
+		expect(() => resolveSignetWorkspacePath()).toThrow("Invalid Signet workspace config");
+	});
+
+	it("rejects persisted workspace config without a non-empty workspace path", () => {
+		dir = mkdtempSync(join(tmpdir(), "signet-connector-base-workspace-"));
+		process.env.XDG_CONFIG_HOME = dir;
+		const cfgDir = join(dir, "signet");
+		mkdirSync(cfgDir, { recursive: true });
+		writeFileSync(join(cfgDir, "workspace.json"), JSON.stringify({ version: 1, workspace: "  " }), "utf-8");
+
+		expect(() => resolveSignetWorkspacePath()).toThrow("workspace must be a non-empty string");
 	});
 });
 

--- a/libs/connector-base/src/index.ts
+++ b/libs/connector-base/src/index.ts
@@ -262,18 +262,29 @@ export function resolveSignetWorkspacePath(home = homedir()): string {
 	const configured = readManagedTrimmedEnv("SIGNET_PATH");
 	if (configured) return resolve(expandHome(configured));
 
+	const defaultWorkspace = join(home, ".agents");
 	const configHome = readManagedTrimmedEnv("XDG_CONFIG_HOME") ?? join(home, ".config");
 	const workspaceConfigPath = join(configHome, "signet", "workspace.json");
-	if (!existsSync(workspaceConfigPath)) return join(home, ".agents");
+	if (!existsSync(workspaceConfigPath)) return defaultWorkspace;
 
+	let raw: unknown;
 	try {
-		const raw = JSON.parse(readFileSync(workspaceConfigPath, "utf8")) as { workspace?: unknown };
-		return typeof raw.workspace === "string" && raw.workspace.trim().length > 0
-			? resolve(expandHome(raw.workspace.trim()))
-			: join(home, ".agents");
-	} catch {
-		return join(home, ".agents");
+		raw = JSON.parse(readFileSync(workspaceConfigPath, "utf8"));
+	} catch (err) {
+		const detail = err instanceof Error ? err.message : String(err);
+		throw new Error(`Invalid Signet workspace config at ${workspaceConfigPath}: ${detail}`);
 	}
+
+	if (typeof raw !== "object" || raw === null || !("workspace" in raw)) {
+		throw new Error(`Invalid Signet workspace config at ${workspaceConfigPath}: missing workspace`);
+	}
+
+	const workspace = raw.workspace;
+	if (typeof workspace !== "string" || workspace.trim().length === 0) {
+		throw new Error(`Invalid Signet workspace config at ${workspaceConfigPath}: workspace must be a non-empty string`);
+	}
+
+	return resolve(expandHome(workspace.trim()));
 }
 
 export function resolveSignetDaemonUrl(): string {


### PR DESCRIPTION
## Summary
- make connector workspace discovery fail closed when persisted workspace config is malformed
- preserve the default `~/.agents` fallback only when no config file exists
- add regression coverage for missing, malformed, and empty workspace config cases

## Verification
- `cd platform/core && bun run build`
- `cd libs/connector-base && bun test index.test.ts`
- `cd libs/connector-base && bun run typecheck`
- `cd libs/connector-base && bun run build`
- `git diff --check`
- `autoreview` clean

Note: initial dependency install required `PUPPETEER_SKIP_DOWNLOAD=1 bun install` because Puppeteer could not repair an incomplete cached Chrome download.
