### PR TITLE
fix(daemon): context-budget profile review fixes (#847)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1198,6 +1198,26 @@ hooks:
     recallLimit: 10
     maxInjectChars: 500
     minScore: 0.8
+  contextProfiles:
+    coding:
+      sessionStart:
+        recallLimit: 5
+        maxInjectTokens: 5000
+      userPromptSubmit:
+        maxInjectChars: 300
+      identity:
+        files:
+          - path: context-profiles/coding/AGENTS.md
+            maxChars: 2200
+    rich:
+      sessionStart:
+        recallLimit: 50
+        maxInjectTokens: 20000
+  harnessProfiles:
+    pi: coding
+    codex: coding
+    hermes-agent: rich
+    openclaw: rich
   preCompaction:
     includeRecentMemories: true
     memoryLimit: 5
@@ -1215,6 +1235,29 @@ harness session:
 | `includeRecentContext` | `true` | Include `MEMORY.md` content |
 | `recencyBias` | `0.7` | Weight toward recent vs. important memories (0-1) |
 | `maxInjectTokens` | `12000` | Maximum session-start injection budget after context assembly |
+
+Context profiles let a workspace set different session-start and
+prompt-submit budgets per harness. A profile can override
+`sessionStart`, `userPromptSubmit`, and the ordered identity/context
+files loaded at session start. `identity.files[].maxTokens` is a token
+budget for that source file; `maxChars` is also accepted when a character
+budget is easier to reason about. Map harness names to profile names with
+`hooks.harnessProfiles`; `hooks.defaultContextProfile` can provide a
+fallback for unmapped harnesses.
+
+For lean coding harnesses, compile the canonical identity files into a
+single bounded startup artifact and point the profile at that generated
+file:
+
+```bash
+signet context compile --profile coding --max-chars 2200
+```
+
+The compiler reads `AGENTS.md`, `USER.md`, `IDENTITY.md`, and `SOUL.md`,
+runs the configured inference `session_synthesis` route, hard-caps the
+result, and writes `context-profiles/coding/AGENTS.md`. Session-start
+hooks only read that artifact; they do not perform model synthesis at
+runtime.
 
 Predicted context from recent session summaries is scoped to the active
 project. If the harness does not provide a project path, Signet skips

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -126,11 +126,36 @@ In `agent.yaml` (see [[configuration]]):
 ```yaml
 hooks:
   sessionStart:
-    recallLimit: 10          # How many memories to include
-    includeIdentity: true    # Prepend "You are <name>..."
+    recallLimit: 10            # How many memories to include
+    includeIdentity: true      # Include identity files
     includeRecentContext: true # Include MEMORY.md content
-    recencyBias: 0.7         # 0=importance-only, 1=recency-only
+    recencyBias: 0.7           # 0=importance-only, 1=recency-only
+
+  contextProfiles:
+    coding:
+      sessionStart:
+        recallLimit: 5
+        maxInjectTokens: 5000
+      identity:
+        files:
+          - path: context-profiles/coding/AGENTS.md
+            maxChars: 2200
+    rich:
+      sessionStart:
+        recallLimit: 50
+        maxInjectTokens: 20000
+  harnessProfiles:
+    pi: coding
+    hermes-agent: rich
 ```
+
+Context profiles override hook budgets and startup identity/context files
+per harness. Use them to keep coding harnesses lean while preserving richer
+cold-start identity in operator or character-forward harnesses. For a compact
+coding prompt, run `signet context compile --profile coding --max-chars 2200`;
+that ACPX/inference-backed compiler reads the canonical identity files and
+writes `context-profiles/coding/AGENTS.md`. Session-start hooks only read the
+compiled artifact, so model synthesis is never performed in the hot hook path.
 
 Memory scoring uses: `score = importance × (1 - recencyBias) + recency × recencyBias`
 

--- a/platform/daemon/src/hooks-config.test.ts
+++ b/platform/daemon/src/hooks-config.test.ts
@@ -85,6 +85,34 @@ describe("hooks config", () => {
 		expect(resolved.identity?.files?.map((entry) => entry.path)).toEqual(["AGENTS.md", "USER.md"]);
 	});
 
+	test("profile overrides inherit unrelated global hook settings instead of clobbering them", () => {
+		const dir = makeTempDir();
+		writeFileSync(
+			join(dir, "agent.yaml"),
+			`hooks:
+  sessionStart:
+    recallLimit: 50
+    recencyBias: 0.3
+    includeIdentity: false
+    maxInjectTokens: 12000
+  contextProfiles:
+    coding:
+      sessionStart:
+        recallLimit: 5
+  harnessProfiles:
+    pi: coding
+`,
+		);
+
+		const resolved = resolveHooksConfigForHarness(loadHooksConfig(dir), "pi");
+
+		expect(resolved.sessionStart?.recallLimit).toBe(5);
+		// Keys the profile did not mention must fall back to the global values.
+		expect(resolved.sessionStart?.recencyBias).toBe(0.3);
+		expect(resolved.sessionStart?.includeIdentity).toBe(false);
+		expect(resolved.sessionStart?.maxInjectTokens).toBe(12000);
+	});
+
 	test("rejects unsafe profile identity paths and non-positive file budgets", () => {
 		const dir = makeTempDir();
 		writeFileSync(

--- a/platform/daemon/src/hooks-config.test.ts
+++ b/platform/daemon/src/hooks-config.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
 	DEFAULT_SESSION_START_MAX_INJECT_TOKENS,
 	loadHooksConfig,
+	resolveHooksConfigForHarness,
 	resolveUserPromptMinScore,
 } from "./hooks-config";
 
@@ -45,6 +46,89 @@ describe("hooks config", () => {
 		expect(config.userPromptSubmit?.enabled).toBe(false);
 		expect(config.userPromptSubmit?.minScore).toBe(0.42);
 		expect(config.preCompaction?.memoryLimit).toBe(3);
+	});
+
+	test("resolves harness context profiles over global hook defaults", () => {
+		const dir = makeTempDir();
+		writeFileSync(
+			join(dir, "agent.yaml"),
+			`hooks:
+  sessionStart:
+    recallLimit: 50
+    maxInjectTokens: 12000
+  userPromptSubmit:
+    maxInjectChars: 500
+  contextProfiles:
+    coding:
+      sessionStart:
+        recallLimit: 5
+        maxInjectTokens: 5000
+      userPromptSubmit:
+        maxInjectChars: 200
+      identity:
+        files:
+          - path: AGENTS.md
+            maxTokens: 1000
+          - path: USER.md
+            maxTokens: 500
+  harnessProfiles:
+    pi: coding
+`,
+		);
+
+		const resolved = resolveHooksConfigForHarness(loadHooksConfig(dir), "PI");
+
+		expect(resolved.profileName).toBe("coding");
+		expect(resolved.sessionStart?.recallLimit).toBe(5);
+		expect(resolved.sessionStart?.maxInjectTokens).toBe(5000);
+		expect(resolved.userPromptSubmit?.maxInjectChars).toBe(200);
+		expect(resolved.identity?.files?.map((entry) => entry.path)).toEqual(["AGENTS.md", "USER.md"]);
+	});
+
+	test("rejects unsafe profile identity paths and non-positive file budgets", () => {
+		const dir = makeTempDir();
+		writeFileSync(
+			join(dir, "agent.yaml"),
+			`hooks:
+  contextProfiles:
+    unsafe:
+      identity:
+        files:
+          - path: .secrets/API_KEY.md
+            maxTokens: 100
+          - path: memory/transcript.md
+            maxTokens: 100
+          - path: AGENTS.md
+            maxTokens: 0
+          - path: USER.md
+            maxTokens: 10
+  harnessProfiles:
+    pi: unsafe
+`,
+		);
+
+		const resolved = resolveHooksConfigForHarness(loadHooksConfig(dir), "pi");
+
+		expect(resolved.identity?.files?.map((entry) => entry.path)).toEqual(["USER.md"]);
+	});
+
+	test("supports a default context profile for unmapped harnesses", () => {
+		const dir = makeTempDir();
+		writeFileSync(
+			join(dir, "agent.yaml"),
+			`hooks:
+  contextProfiles:
+    lean:
+      sessionStart:
+        recallLimit: 3
+  defaultContextProfile: lean
+`,
+		);
+
+		const resolved = resolveHooksConfigForHarness(loadHooksConfig(dir), "unknown-harness");
+
+		expect(resolved.profileName).toBe("lean");
+		expect(resolved.sessionStart?.recallLimit).toBe(3);
 	});
 
 	test("clamps user prompt minimum score", () => {

--- a/platform/daemon/src/hooks-config.ts
+++ b/platform/daemon/src/hooks-config.ts
@@ -6,36 +6,82 @@ import { logger } from "./logger";
 export const DEFAULT_SESSION_START_MAX_INJECT_TOKENS = 12_000;
 
 export interface HooksConfig {
-	sessionStart?: {
-		recallLimit?: number;
-		candidatePoolLimit?: number;
-		includeIdentity?: boolean;
-		includeRecentContext?: boolean;
-		recencyBias?: number;
-		query?: string;
-		maxInjectTokens?: number;
-		/**
-		 * @deprecated Renamed to `maxInjectTokens`. If set without `maxInjectTokens`,
-		 * the value is auto-migrated using `Math.round(maxInjectChars / 4)` (~4 chars/token
-		 * for ASCII; code or Unicode content may be 1–2 chars/token, so migrate explicitly.
-		 */
-		maxInjectChars?: number;
-	};
-	userPromptSubmit?: {
-		/** Set to false to disable per-prompt entity-context injection entirely. Default: true. */
-		enabled?: boolean;
-		recallLimit?: number;
-		maxInjectChars?: number;
-		/** Minimum scoped attribute relevance required before injecting entity context. */
-		minScore?: number;
-	};
-	preCompaction?: {
-		summaryGuidelines?: string;
-		includeRecentMemories?: boolean;
-		memoryLimit?: number;
-		/** Cap the generated summary at this many characters. */
-		maxSummaryChars?: number;
-	};
+	sessionStart?: SessionStartHooksConfig;
+	userPromptSubmit?: UserPromptSubmitHooksConfig;
+	preCompaction?: PreCompactionHooksConfig;
+	/** Named context-budget profiles. Resolved per harness via `harnessProfiles`. */
+	contextProfiles?: Record<string, ContextBudgetProfileConfig>;
+	/** Maps harness names (for example `pi`) to a context profile name. */
+	harnessProfiles?: Record<string, string>;
+	/** Optional fallback profile when a harness has no explicit mapping. */
+	defaultContextProfile?: string;
+}
+
+export interface SessionStartHooksConfig {
+	recallLimit?: number;
+	candidatePoolLimit?: number;
+	includeIdentity?: boolean;
+	includeRecentContext?: boolean;
+	recencyBias?: number;
+	query?: string;
+	maxInjectTokens?: number;
+	/**
+	 * @deprecated Renamed to `maxInjectTokens`. If set without `maxInjectTokens`,
+	 * the value is auto-migrated using `Math.round(maxInjectChars / 4)` (~4 chars/token
+	 * for ASCII; code or Unicode content may be 1–2 chars/token, so migrate explicitly.
+	 */
+	maxInjectChars?: number;
+}
+
+export interface UserPromptSubmitHooksConfig {
+	/** Set to false to disable per-prompt entity-context injection entirely. Default: true. */
+	enabled?: boolean;
+	recallLimit?: number;
+	maxInjectChars?: number;
+	/** Minimum scoped attribute relevance required before injecting entity context. */
+	minScore?: number;
+}
+
+export interface PreCompactionHooksConfig {
+	summaryGuidelines?: string;
+	includeRecentMemories?: boolean;
+	memoryLimit?: number;
+	/** Cap the generated summary at this many characters. */
+	maxSummaryChars?: number;
+}
+
+export interface ContextIdentityFileConfig {
+	path: string;
+	header?: string;
+	role?: string;
+	/** Preferred budget unit for profile-managed identity files. */
+	maxTokens?: number;
+	/** Compatibility with existing identity startup entries; interpreted as characters. */
+	budget?: number;
+	/** Explicit character budget for callers that cannot reason in tokens. */
+	maxChars?: number;
+	enabled?: boolean;
+}
+
+export interface ContextIdentityConfig {
+	/** Set false to suppress profile-managed identity files. */
+	include?: boolean;
+	/** Explicit ordered identity/context files for this profile. */
+	files?: readonly ContextIdentityFileConfig[];
+}
+
+export interface ContextBudgetProfileConfig {
+	sessionStart?: SessionStartHooksConfig;
+	userPromptSubmit?: UserPromptSubmitHooksConfig;
+	identity?: ContextIdentityConfig;
+}
+
+export interface ResolvedHooksConfig {
+	profileName?: string;
+	sessionStart?: SessionStartHooksConfig;
+	userPromptSubmit?: UserPromptSubmitHooksConfig;
+	preCompaction?: PreCompactionHooksConfig;
+	identity?: ContextIdentityConfig;
 }
 
 // Derived from HooksConfig — update when adding new config sections.
@@ -43,7 +89,195 @@ const KNOWN_HOOKS_KEYS: ReadonlySet<keyof HooksConfig> = new Set<keyof HooksConf
 	"sessionStart",
 	"userPromptSubmit",
 	"preCompaction",
+	"contextProfiles",
+	"harnessProfiles",
+	"defaultContextProfile",
 ]);
+
+function readRecord(value: unknown): Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function readString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+	if (typeof value === "number" && Number.isFinite(value)) return value;
+	if (typeof value === "string" && value.trim().length > 0) {
+		const parsed = Number(value);
+		return Number.isFinite(parsed) ? parsed : undefined;
+	}
+	return undefined;
+}
+
+function readBoolean(value: unknown): boolean | undefined {
+	if (typeof value === "boolean") return value;
+	if (typeof value === "string") {
+		const normalized = value.trim().toLowerCase();
+		if (normalized === "true") return true;
+		if (normalized === "false") return false;
+	}
+	return undefined;
+}
+
+function readSessionStartConfig(value: unknown): SessionStartHooksConfig | undefined {
+	const record = readRecord(value);
+	if (Object.keys(record).length === 0) return undefined;
+	return {
+		recallLimit: readNumber(record.recallLimit),
+		candidatePoolLimit: readNumber(record.candidatePoolLimit),
+		includeIdentity: readBoolean(record.includeIdentity),
+		includeRecentContext: readBoolean(record.includeRecentContext),
+		recencyBias: readNumber(record.recencyBias),
+		query: readString(record.query),
+		maxInjectTokens: readNumber(record.maxInjectTokens),
+		maxInjectChars: readNumber(record.maxInjectChars),
+	};
+}
+
+function readUserPromptSubmitConfig(value: unknown): UserPromptSubmitHooksConfig | undefined {
+	const record = readRecord(value);
+	if (Object.keys(record).length === 0) return undefined;
+	return {
+		enabled: readBoolean(record.enabled),
+		recallLimit: readNumber(record.recallLimit),
+		maxInjectChars: readNumber(record.maxInjectChars),
+		minScore: readNumber(record.minScore),
+	};
+}
+
+function readPreCompactionConfig(value: unknown): PreCompactionHooksConfig | undefined {
+	const record = readRecord(value);
+	if (Object.keys(record).length === 0) return undefined;
+	return {
+		summaryGuidelines: readString(record.summaryGuidelines),
+		includeRecentMemories: readBoolean(record.includeRecentMemories),
+		memoryLimit: readNumber(record.memoryLimit),
+		maxSummaryChars: readNumber(record.maxSummaryChars),
+	};
+}
+
+function isSafeRelativeIdentityPath(path: string): boolean {
+	const trimmed = path.trim();
+	if (!trimmed) return false;
+	if (trimmed.startsWith("/") || trimmed.startsWith("~")) return false;
+	if (!trimmed.toLowerCase().endsWith(".md")) return false;
+	const parts = trimmed.split(/[\\/]/);
+	const deniedDirs = new Set([".daemon", ".secrets", "memory"]);
+	return parts.every((part) => {
+		const normalized = part.toLowerCase();
+		return normalized !== ".." && !normalized.startsWith(".") && !deniedDirs.has(normalized);
+	});
+}
+
+function readPositiveBudget(value: unknown): number | undefined | null {
+	const parsed = readNumber(value);
+	if (parsed === undefined) return undefined;
+	return parsed > 0 ? parsed : null;
+}
+
+function readIdentityFileEntry(value: unknown): ContextIdentityFileConfig | null {
+	if (typeof value === "string") {
+		const path = value.trim();
+		return isSafeRelativeIdentityPath(path) ? { path } : null;
+	}
+	const record = readRecord(value);
+	const path = readString(record.path);
+	if (!path || !isSafeRelativeIdentityPath(path)) return null;
+	const enabled = readBoolean(record.enabled);
+	if (enabled === false) return null;
+	const maxTokens = readPositiveBudget(record.maxTokens);
+	const budget = readPositiveBudget(record.budget);
+	const maxChars = readPositiveBudget(record.maxChars);
+	if (maxTokens === null || budget === null || maxChars === null) return null;
+	return {
+		path,
+		header: readString(record.header),
+		role: readString(record.role),
+		maxTokens,
+		budget,
+		maxChars,
+		enabled,
+	};
+}
+
+function readIdentityFileList(value: unknown): ContextIdentityFileConfig[] {
+	if (Array.isArray(value)) {
+		const files: ContextIdentityFileConfig[] = [];
+		for (const item of value) {
+			const entry = readIdentityFileEntry(item);
+			if (entry) files.push(entry);
+		}
+		return files;
+	}
+
+	const record = readRecord(value);
+	const files: ContextIdentityFileConfig[] = [];
+	for (const [path, budget] of Object.entries(record)) {
+		if (!isSafeRelativeIdentityPath(path)) continue;
+		const numericBudget = readNumber(budget);
+		if (numericBudget !== undefined && numericBudget <= 0) continue;
+		const entry: ContextIdentityFileConfig = { path };
+		if (numericBudget !== undefined) entry.maxTokens = numericBudget;
+		files.push(entry);
+	}
+	return files;
+}
+
+function readIdentityConfig(value: unknown): ContextIdentityConfig | undefined {
+	const record = readRecord(value);
+	if (Object.keys(record).length === 0) return undefined;
+	return {
+		include: readBoolean(record.include),
+		files: Object.hasOwn(record, "files") ? readIdentityFileList(record.files) : undefined,
+	};
+}
+
+function readContextProfileConfig(value: unknown): ContextBudgetProfileConfig | undefined {
+	const record = readRecord(value);
+	if (Object.keys(record).length === 0) return undefined;
+	return {
+		sessionStart: readSessionStartConfig(record.sessionStart),
+		userPromptSubmit: readUserPromptSubmitConfig(record.userPromptSubmit),
+		identity: readIdentityConfig(record.identity),
+	};
+}
+
+function readContextProfiles(value: unknown): Record<string, ContextBudgetProfileConfig> | undefined {
+	const record = readRecord(value);
+	const profiles: Record<string, ContextBudgetProfileConfig> = {};
+	for (const [name, profileValue] of Object.entries(record)) {
+		const safeName = name.trim();
+		const profile = readContextProfileConfig(profileValue);
+		if (!safeName || !profile) continue;
+		profiles[safeName] = profile;
+	}
+	return Object.keys(profiles).length > 0 ? profiles : undefined;
+}
+
+function normalizeHarnessName(value: string): string {
+	return value.trim().toLowerCase();
+}
+
+function readHarnessProfiles(value: unknown): Record<string, string> | undefined {
+	const record = readRecord(value);
+	const profiles: Record<string, string> = {};
+	for (const [harness, profile] of Object.entries(record)) {
+		const profileName = readString(profile);
+		if (!profileName) continue;
+		profiles[normalizeHarnessName(harness)] = profileName;
+	}
+	return Object.keys(profiles).length > 0 ? profiles : undefined;
+}
+
+function mergeConfig<T extends object>(base: T | undefined, override: T | undefined): T | undefined {
+	const merged = { ...(base ?? {}), ...(override ?? {}) } as Record<string, unknown>;
+	for (const key of Object.keys(merged)) {
+		if (merged[key] === undefined) delete merged[key];
+	}
+	return Object.keys(merged).length > 0 ? (merged as T) : undefined;
+}
 
 export function loadHooksConfig(agentsDir: string): HooksConfig {
 	const configPath = join(agentsDir, "agent.yaml");
@@ -65,21 +299,14 @@ export function loadHooksConfig(agentsDir: string): HooksConfig {
 				logger.warn("hooks", `Unknown hooks config key: ${key} — check agent.yaml`);
 			}
 		}
-		const cfg: HooksConfig = {
-			sessionStart:
-				typeof record.sessionStart === "object" && record.sessionStart !== null
-					? (record.sessionStart as HooksConfig["sessionStart"])
-					: undefined,
-			userPromptSubmit:
-				typeof record.userPromptSubmit === "object" && record.userPromptSubmit !== null
-					? (record.userPromptSubmit as HooksConfig["userPromptSubmit"])
-					: undefined,
-			preCompaction:
-				typeof record.preCompaction === "object" && record.preCompaction !== null
-					? (record.preCompaction as HooksConfig["preCompaction"])
-					: undefined,
+		return {
+			sessionStart: readSessionStartConfig(record.sessionStart),
+			userPromptSubmit: readUserPromptSubmitConfig(record.userPromptSubmit),
+			preCompaction: readPreCompactionConfig(record.preCompaction),
+			contextProfiles: readContextProfiles(record.contextProfiles),
+			harnessProfiles: readHarnessProfiles(record.harnessProfiles),
+			defaultContextProfile: readString(record.defaultContextProfile),
 		};
-		return cfg;
 	} catch {
 		logger.warn("hooks", "Failed to load hooks config, using defaults");
 		return getDefaultHooksConfig();
@@ -114,6 +341,22 @@ Keep the summary concise but complete. Use first person from the agent's perspec
 			includeRecentMemories: true,
 			memoryLimit: 5,
 		},
+	};
+}
+
+export function resolveHooksConfigForHarness(config: HooksConfig, harness: string): ResolvedHooksConfig {
+	const normalizedHarness = normalizeHarnessName(harness);
+	const profileName = config.harnessProfiles?.[normalizedHarness] ?? config.defaultContextProfile;
+	const profile = profileName ? config.contextProfiles?.[profileName] : undefined;
+	if (profileName && !profile) {
+		logger.warn("hooks", `Context profile '${profileName}' for harness '${harness}' was not found`);
+	}
+	return {
+		profileName: profile ? profileName : undefined,
+		sessionStart: mergeConfig(config.sessionStart, profile?.sessionStart),
+		userPromptSubmit: mergeConfig(config.userPromptSubmit, profile?.userPromptSubmit),
+		preCompaction: config.preCompaction,
+		identity: profile?.identity,
 	};
 }
 

--- a/platform/daemon/src/hooks-config.ts
+++ b/platform/daemon/src/hooks-config.ts
@@ -272,9 +272,14 @@ function readHarnessProfiles(value: unknown): Record<string, string> | undefined
 }
 
 function mergeConfig<T extends object>(base: T | undefined, override: T | undefined): T | undefined {
-	const merged = { ...(base ?? {}), ...(override ?? {}) } as Record<string, unknown>;
-	for (const key of Object.keys(merged)) {
-		if (merged[key] === undefined) delete merged[key];
+	// Profile readers emit fully-populated objects with `undefined` for unset keys.
+	// A naive spread would let an unset override key clobber a defined base value,
+	// so only copy override keys that are actually present and defined. This keeps
+	// global hook settings (e.g. `sessionStart.recencyBias`) inherited when a profile
+	// only overrides a subset of keys.
+	const merged = { ...(base ?? {}) } as Record<string, unknown>;
+	for (const [key, value] of Object.entries(override ?? {})) {
+		if (value !== undefined) merged[key] = value;
 	}
 	return Object.keys(merged).length > 0 ? (merged as T) : undefined;
 }

--- a/platform/daemon/src/hooks.test.ts
+++ b/platform/daemon/src/hooks.test.ts
@@ -864,6 +864,61 @@ creature: digital assistant
 		expect(result.inject).toContain("## Working Memory");
 	});
 
+	test.serial("applies harness context profile identity files and recall budget", async () => {
+		writeAgentYaml(`
+hooks:
+  contextProfiles:
+    coding:
+      sessionStart:
+        recallLimit: 1
+        maxInjectTokens: 5000
+      identity:
+        files:
+          - path: AGENTS.md
+            maxTokens: 4
+          - path: USER.md
+            maxTokens: 20
+  harnessProfiles:
+    pi: coding
+`);
+		writeAgentsMd("alpha beta gamma delta epsilon zeta");
+		writeFileSync(join(TEST_DIR, "USER.md"), "User prefers concise coding context.");
+		writeMemoryMd("# Working Memory\n\nThis should be excluded by the coding profile.");
+		createMemoryDb([
+			{ content: "First profile memory", importance: 0.9 },
+			{ content: "Second profile memory", importance: 0.8 },
+		]);
+
+		const result = await handleSessionStart({ harness: "pi" });
+
+		expect(result.memories).toHaveLength(1);
+		expect(result.inject).toContain("## Agent Instructions");
+		expect(result.inject).toContain("[truncated]");
+		expect(result.inject).toContain("User prefers concise coding context.");
+		expect(result.inject).not.toContain("This should be excluded");
+		expect(result.inject).toContain("First profile memory");
+		expect(result.inject).not.toContain("Second profile memory");
+	});
+
+	test.serial("profile identity include false does not disable working memory context", async () => {
+		writeAgentYaml(`
+hooks:
+  contextProfiles:
+    noIdentity:
+      identity:
+        include: false
+  harnessProfiles:
+    pi: noIdentity
+`);
+		writeAgentsMd("Do not include this identity file.");
+		writeMemoryMd("# Working Memory\n\nKeep this recent context.");
+
+		const result = await handleSessionStart({ harness: "pi" });
+
+		expect(result.inject).not.toContain("Do not include this identity file.");
+		expect(result.inject).toContain("Keep this recent context.");
+	});
+
 	test.serial("loads AGENTS.md before MEMORY.md in inject context", async () => {
 		writeAgentsMd("# AGENTS\n\nFollow AGENTS instructions first.");
 		writeMemoryMd("# Working Memory\n\nThis is working memory context.");

--- a/platform/daemon/src/hooks.test.ts
+++ b/platform/daemon/src/hooks.test.ts
@@ -875,7 +875,7 @@ hooks:
       identity:
         files:
           - path: AGENTS.md
-            maxTokens: 4
+            maxTokens: 6
           - path: USER.md
             maxTokens: 20
   harnessProfiles:

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -820,21 +820,21 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	const tokenBudget = Math.max(1, rawTokenBudget);
 	let memories = selectWithTokenBudget(sortedCandidates.slice(0, recallLimit), tokenBudget);
 
-	// Get predicted context from recent session analysis (~30% of budget).
+	// Predicted context from recent session analysis is additive on top of main
+	// recall: it surfaces topics the user is likely to need next regardless of how
+	// much of the token budget main recall consumed. Capping it by memories.length
+	// would starve it to zero whenever recall fills to recallLimit (default 50),
+	// silently dropping the predicted-context feature entirely.
 	const existingIds = new Set(memories.map((m) => m.id));
-	const predictedLimit = Math.max(0, recallLimit - memories.length);
-	const predictedMemories =
-		predictedLimit > 0
-			? getPredictedContextMemories(
-				req.project,
-				Math.min(10, predictedLimit),
-				600,
-				existingIds,
-				agentId,
-				agentScope.readPolicy,
-				agentScope.policyGroup,
-			)
-			: [];
+	const predictedMemories = getPredictedContextMemories(
+		req.project,
+		10,
+		600,
+		existingIds,
+		agentId,
+		agentScope.readPolicy,
+		agentScope.policyGroup,
+	);
 	if (predictedMemories.length > 0) {
 		memories.push(...predictedMemories);
 	}

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -32,9 +32,17 @@ import {
 	type HooksConfig,
 	getDefaultHooksConfig,
 	loadHooksConfig as loadHooksConfigFromDisk,
+	resolveHooksConfigForHarness,
 	resolveUserPromptMinScore,
 } from "./hooks-config";
-import { loadIdentity, readAgentsMd, readIdentityFile, readMemoryMd, resolveIdentityFiles } from "./identity-context";
+import {
+	loadIdentity,
+	readAgentsMd,
+	readContextIdentitySections,
+	readIdentityFile,
+	readMemoryMd,
+	resolveIdentityFiles,
+} from "./identity-context";
 import { propagateMemoryStatus } from "./knowledge-graph";
 import { logger } from "./logger";
 import { buildAgentScopeClause } from "./memory-access-scope";
@@ -116,7 +124,7 @@ import {
 	getSessionTranscriptContent,
 	upsertSessionTranscript,
 } from "./session-transcripts";
-import { type StructuralFeatures, getStructuralFeatures } from "./structural-features";
+import { type StructuralCandidateSource, type StructuralFeatures, getStructuralFeatures } from "./structural-features";
 import { assembleInheritedContextBlock, resolveParentSession } from "./subagent-context";
 import { searchTemporalFallback } from "./temporal-fallback";
 import { writeTranscriptAudit } from "./transcript-audit";
@@ -436,6 +444,10 @@ function loadHooksConfig(): HooksConfig {
 	return loadHooksConfigFromDisk(getAgentsDir());
 }
 
+function loadHooksConfigForHarness(harness: string) {
+	return resolveHooksConfigForHarness(loadHooksConfig(), harness);
+}
+
 // ============================================================================
 // Memory Queries
 // ============================================================================
@@ -517,7 +529,8 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	const start = Date.now();
 	const agentId = resolveAgentId(req);
 	ensureAgentRegistered(agentId);
-	const config = loadHooksConfig().sessionStart || {};
+	const resolvedHooksConfig = loadHooksConfigForHarness(req.harness);
+	const config = resolvedHooksConfig.sessionStart || {};
 	const memoryCfg = loadMemoryConfig(getAgentsDir());
 	const includeIdentity = config.includeIdentity !== false;
 
@@ -583,11 +596,22 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	const identityFiles = resolveIdentityFiles(agentId, agentsDir);
 	const identity = includeIdentity ? loadIdentity(agentsDir, identityFiles) : { name: "Agent" };
 
-	// Read AGENTS.md first so harness instructions precede synthesized memory
-	const agentsMdContent = includeIdentity ? readAgentsMd(agentsDir, 12000, identityFiles) : undefined;
+	const profileIdentitySections = includeIdentity
+		? readContextIdentitySections(agentsDir, resolvedHooksConfig.identity, identityFiles)
+		: null;
+	const profileHasExplicitIdentityFiles =
+		includeIdentity && resolvedHooksConfig.identity?.include !== false && resolvedHooksConfig.identity?.files !== undefined;
 
-	// Read MEMORY.md with 10k char budget
-	const memoryMdContent = readMemoryMd(agentsDir, 10000, identityFiles);
+	// Read AGENTS.md first so harness instructions precede synthesized memory.
+	const agentsMdContent =
+		includeIdentity && profileIdentitySections === null ? readAgentsMd(agentsDir, 12000, identityFiles) : undefined;
+
+	// Read MEMORY.md with 10k char budget unless a context profile supplies the identity/context file list.
+	const memoryMdContent =
+		profileIdentitySections?.find((section) => section.path === "MEMORY.md")?.content ??
+		(!profileHasExplicitIdentityFiles && config.includeRecentContext !== false
+			? readMemoryMd(agentsDir, 10000, identityFiles)
+			: undefined);
 
 	const traversalCfg = memoryCfg.pipelineV2.traversal;
 	const traversalEnabled = memoryCfg.pipelineV2.graph.enabled && traversalCfg?.enabled === true;
@@ -635,11 +659,11 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 
 	// Candidate pool fusion: traversal U effective (capped before budget truncation)
 	const recallLimit = Math.max(1, config.recallLimit ?? 50);
-	const candidatePoolLimit = Math.max(1, config.candidatePoolLimit ?? 100);
+	const candidatePoolLimit = Math.max(recallLimit, config.candidatePoolLimit ?? 100);
 	const _candidatesStart = Date.now();
 	const allCandidates = getAllScoredCandidates(
 		req.project,
-		recallLimit,
+		candidatePoolLimit,
 		traversalAgentId,
 		agentScope.readPolicy,
 		agentScope.policyGroup,
@@ -647,6 +671,9 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	const candidatesMs = Date.now() - _candidatesStart;
 	const candidateById = new Map(allCandidates.map((candidate) => [candidate.id, candidate]));
 	const candidateSourceById = new Map<string, SessionMemoryCandidate["source"]>(
+		allCandidates.map((candidate) => [candidate.id, "effective" as const]),
+	);
+	const structuralCandidateSourceById = new Map<string, StructuralCandidateSource>(
 		allCandidates.map((candidate) => [candidate.id, "effective" as const]),
 	);
 
@@ -696,6 +723,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 				for (const memoryId of traversalResult.memoryIds) {
 					if (!candidateById.has(memoryId)) {
 						candidateSourceById.set(memoryId, "ka_traversal");
+						structuralCandidateSourceById.set(memoryId, "ka_traversal");
 					}
 				}
 
@@ -756,7 +784,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	const dbAcc = loadDbAccessor();
 	const candidateIdsForFeatures = mergedCandidates.map((c) => c.id);
 	const structuralById = dbAcc
-		? getStructuralFeatures(dbAcc, candidateIdsForFeatures, agentId, candidateSourceById)
+		? getStructuralFeatures(dbAcc, candidateIdsForFeatures, agentId, structuralCandidateSourceById)
 		: new Map<string, StructuralFeatures>();
 	const sortedCandidates = [...mergedCandidates].sort((a, b) => {
 		if (req.project) {
@@ -790,19 +818,23 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 		});
 	}
 	const tokenBudget = Math.max(1, rawTokenBudget);
-	let memories = selectWithTokenBudget(sortedCandidates, tokenBudget);
+	let memories = selectWithTokenBudget(sortedCandidates.slice(0, recallLimit), tokenBudget);
 
-	// Get predicted context from recent session analysis (~30% of budget)
+	// Get predicted context from recent session analysis (~30% of budget).
 	const existingIds = new Set(memories.map((m) => m.id));
-	const predictedMemories = getPredictedContextMemories(
-		req.project,
-		10,
-		600,
-		existingIds,
-		agentId,
-		agentScope.readPolicy,
-		agentScope.policyGroup,
-	);
+	const predictedLimit = Math.max(0, recallLimit - memories.length);
+	const predictedMemories =
+		predictedLimit > 0
+			? getPredictedContextMemories(
+				req.project,
+				Math.min(10, predictedLimit),
+				600,
+				existingIds,
+				agentId,
+				agentScope.readPolicy,
+				agentScope.policyGroup,
+			)
+			: [];
 	if (predictedMemories.length > 0) {
 		memories.push(...predictedMemories);
 	}
@@ -833,7 +865,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	// Re-fetch structural features for any predicted memories not in the first batch
 	const fullStructuralById =
 		allCandidateIdsForRecording.length > candidateIdsForFeatures.length && dbAcc
-			? getStructuralFeatures(dbAcc, allCandidateIdsForRecording, agentId, candidateSourceById)
+			? getStructuralFeatures(dbAcc, allCandidateIdsForRecording, agentId, structuralCandidateSourceById)
 			: structuralById;
 
 	const candidatesForRecording = [
@@ -930,31 +962,44 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	if (agentsMdContent) {
 		injectParts.push("\n## Agent Instructions\n");
 		injectParts.push(agentsMdContent);
-	} else if (identity.name !== "Agent" || identity.description) {
+	} else if (profileIdentitySections === null && (identity.name !== "Agent" || identity.description)) {
 		injectParts.push(`You are ${identity.name}${identity.description ? `, ${identity.description}` : ""}.`);
 	}
 
-	// Inject additional identity files
-	const soulContent = includeIdentity ? readIdentityFile(agentsDir, "SOUL.md", 4000, identityFiles) : undefined;
-	const identityContent = includeIdentity ? readIdentityFile(agentsDir, "IDENTITY.md", 2000, identityFiles) : undefined;
-	const userContent = includeIdentity ? readIdentityFile(agentsDir, "USER.md", 6000, identityFiles) : undefined;
+	if (profileIdentitySections !== null) {
+		for (const section of profileIdentitySections) {
+			injectParts.push(`\n## ${section.header}\n`);
+			injectParts.push(section.content);
+		}
+		if (memoryMdContent && !profileIdentitySections.some((section) => section.path === "MEMORY.md")) {
+			injectParts.push("\n## Working Memory\n");
+			injectParts.push(memoryMdContent);
+		}
+	} else {
+		// Inject additional identity files.
+		const soulContent = includeIdentity ? readIdentityFile(agentsDir, "SOUL.md", 4000, identityFiles) : undefined;
+		const identityContent = includeIdentity
+			? readIdentityFile(agentsDir, "IDENTITY.md", 2000, identityFiles)
+			: undefined;
+		const userContent = includeIdentity ? readIdentityFile(agentsDir, "USER.md", 6000, identityFiles) : undefined;
 
-	if (soulContent) {
-		injectParts.push("\n## Soul\n");
-		injectParts.push(soulContent);
-	}
-	if (identityContent) {
-		injectParts.push("\n## Identity\n");
-		injectParts.push(identityContent);
-	}
-	if (userContent) {
-		injectParts.push("\n## About Your User\n");
-		injectParts.push(userContent);
-	}
+		if (soulContent) {
+			injectParts.push("\n## Soul\n");
+			injectParts.push(soulContent);
+		}
+		if (identityContent) {
+			injectParts.push("\n## Identity\n");
+			injectParts.push(identityContent);
+		}
+		if (userContent) {
+			injectParts.push("\n## About Your User\n");
+			injectParts.push(userContent);
+		}
 
-	if (memoryMdContent) {
-		injectParts.push("\n## Working Memory\n");
-		injectParts.push(memoryMdContent);
+		if (memoryMdContent) {
+			injectParts.push("\n## Working Memory\n");
+			injectParts.push(memoryMdContent);
+		}
 	}
 
 	if (memories.length > 0) {
@@ -1034,7 +1079,7 @@ export async function handleSessionStart(req: SessionStartRequest): Promise<Sess
 	}
 
 	const duration = Date.now() - start;
-	const maxTokens = config.maxInjectTokens ?? (config.maxInjectChars ? Math.round(config.maxInjectChars / 4) : 20000);
+	const maxTokens = tokenBudget;
 	// Pre-reserve space for deterministic continuity sections so they are never truncated.
 	const reservedTokens = countTokens(recoverySection) + countTokens(constraintsSection) + countTokens(inheritedSection);
 	const mainBudget = Math.max(0, maxTokens - reservedTokens);
@@ -1273,7 +1318,7 @@ export async function handleUserPromptSubmit(
 ): Promise<UserPromptSubmitResponse> {
 	const deps = { ...DEFAULT_USER_PROMPT_SUBMIT_DEPS, ...overrides };
 	const start = Date.now();
-	const submitCfg = loadHooksConfig().userPromptSubmit ?? {};
+	const submitCfg = loadHooksConfigForHarness(req.harness).userPromptSubmit ?? {};
 	const userMessage = resolveRecallUserMessage(req);
 	const agentId = deps.resolveAgentId(req);
 	const { keywordTerms } = buildRecallQueryShape(userMessage);

--- a/platform/daemon/src/identity-context.test.ts
+++ b/platform/daemon/src/identity-context.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadIdentity, parseIdentityMarkdown, readIdentityFile } from "./identity-context";
+import { loadIdentity, parseIdentityMarkdown, readContextIdentitySections, readIdentityFile } from "./identity-context";
 
 let tempDir: string | null = null;
 
@@ -32,6 +32,39 @@ describe("identity context", () => {
 		writeFileSync(join(dir, "IDENTITY.md"), "name: Markdown Agent\n");
 
 		expect(loadIdentity(dir)).toEqual({ name: "YAML Agent", description: "from yaml" });
+	});
+
+	test("renders profile-managed identity sections in configured order with token budgets", () => {
+		const dir = makeTempDir();
+		writeFileSync(join(dir, "AGENTS.md"), "alpha beta gamma delta epsilon zeta");
+		writeFileSync(join(dir, "USER.md"), "user preference detail");
+
+		const sections = readContextIdentitySections(dir, {
+			files: [
+				{ path: "USER.md", maxTokens: 20 },
+				{ path: "AGENTS.md", maxTokens: 3 },
+			],
+		});
+
+		expect(sections?.map((section) => section.header)).toEqual(["About Your User", "Agent Instructions"]);
+		expect(sections?.[0]?.content).toBe("user preference detail");
+		expect(sections?.[1]?.content).toContain("[truncated]");
+	});
+
+	test("profile identity sections reject symlinks into denied workspace directories", () => {
+		const dir = makeTempDir();
+		mkdirSync(join(dir, ".secrets"), { recursive: true });
+		writeFileSync(join(dir, ".secrets", "secret.md"), "do not leak");
+		symlinkSync(join(dir, ".secrets", "secret.md"), join(dir, "context.md"));
+
+		expect(readContextIdentitySections(dir, { files: [{ path: "context.md", maxTokens: 20 }] })).toEqual([]);
+	});
+
+	test("profile identity include false suppresses all identity sections", () => {
+		const dir = makeTempDir();
+		writeFileSync(join(dir, "AGENTS.md"), "agent instructions");
+
+		expect(readContextIdentitySections(dir, { include: false })).toEqual([]);
 	});
 
 	test("reads and truncates identity files through agent override map", () => {

--- a/platform/daemon/src/identity-context.test.ts
+++ b/platform/daemon/src/identity-context.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadIdentity, parseIdentityMarkdown, readContextIdentitySections, readIdentityFile } from "./identity-context";
+import { countTokens } from "./pipeline/tokenizer";
 
 let tempDir: string | null = null;
 
@@ -36,19 +37,60 @@ describe("identity context", () => {
 
 	test("renders profile-managed identity sections in configured order with token budgets", () => {
 		const dir = makeTempDir();
-		writeFileSync(join(dir, "AGENTS.md"), "alpha beta gamma delta epsilon zeta");
+		// Content is ~10 tokens; budget (6) is larger than the truncation marker (~5)
+		// but smaller than the content, so the file is truncated with the marker.
+		writeFileSync(join(dir, "AGENTS.md"), "alpha beta gamma delta epsilon zeta eta theta iota");
 		writeFileSync(join(dir, "USER.md"), "user preference detail");
 
 		const sections = readContextIdentitySections(dir, {
 			files: [
 				{ path: "USER.md", maxTokens: 20 },
-				{ path: "AGENTS.md", maxTokens: 3 },
+				{ path: "AGENTS.md", maxTokens: 6 },
 			],
 		});
 
 		expect(sections?.map((section) => section.header)).toEqual(["About Your User", "Agent Instructions"]);
 		expect(sections?.[0]?.content).toBe("user preference detail");
 		expect(sections?.[1]?.content).toContain("[truncated]");
+	});
+
+	test("truncated profile identity sections never exceed the declared budget", () => {
+		const dir = makeTempDir();
+		writeFileSync(join(dir, "AGENTS.md"), `${"word ".repeat(400)}`);
+		writeFileSync(join(dir, "USER.md"), `${"x".repeat(4000)}`);
+
+		const tokenBudget = 40;
+		const charBudget = 100;
+		const sections = readContextIdentitySections(dir, {
+			files: [
+				{ path: "AGENTS.md", maxTokens: tokenBudget },
+				{ path: "USER.md", maxChars: charBudget },
+			],
+		});
+
+		expect(sections?.[0]?.content).toContain("[truncated]");
+		// Token budget is the hard contract for the maxTokens variant.
+		expect(countTokens(sections?.[0]?.content ?? "")).toBeLessThanOrEqual(tokenBudget);
+		expect(sections?.[1]?.content).toContain("[truncated]");
+		// Character budget is the hard contract for the maxChars variant.
+		expect(sections?.[1]?.content.length).toBeLessThanOrEqual(charBudget);
+	});
+
+	test("tiny per-file budgets never overflow even when smaller than the truncation marker", () => {
+		const dir = makeTempDir();
+		writeFileSync(join(dir, "AGENTS.md"), "alpha beta gamma delta epsilon zeta eta theta");
+		writeFileSync(join(dir, "USER.md"), "user preference detail goes here");
+
+		const sections = readContextIdentitySections(dir, {
+			files: [
+				{ path: "AGENTS.md", maxTokens: 1 },
+				{ path: "USER.md", maxChars: 1 },
+			],
+		});
+
+		// Even a 1-unit budget must hold (no marker overflow).
+		expect(countTokens(sections?.[0]?.content ?? "")).toBeLessThanOrEqual(1);
+		expect(sections?.[1]?.content.length).toBeLessThanOrEqual(1);
 	});
 
 	test("profile identity sections reject symlinks into denied workspace directories", () => {

--- a/platform/daemon/src/identity-context.ts
+++ b/platform/daemon/src/identity-context.ts
@@ -6,6 +6,8 @@ import { countTokens, truncateToTokens } from "./pipeline/tokenizer";
 
 export type IdentityFileMap = Record<string, string>;
 
+const TRUNCATED_MARKER = "\n[truncated]";
+
 export interface IdentityContextSection {
 	path: string;
 	header: string;
@@ -78,7 +80,12 @@ function readIdentityPathWithBudget(
 			if (!Number.isFinite(budget.maxTokens) || budget.maxTokens <= 0) return undefined;
 			const maxTokens = Math.floor(budget.maxTokens);
 			if (countTokens(content) <= maxTokens) return content;
-			return `${truncateToTokens(content, maxTokens)}\n[truncated]`;
+			// Reserve room for the marker so the final string stays within budget.
+			// If the budget is too small to also flag truncation, cap without the marker
+			// rather than exceed the declared budget.
+			const markerTokens = countTokens(TRUNCATED_MARKER);
+			if (markerTokens >= maxTokens) return truncateToTokens(content, maxTokens);
+			return `${truncateToTokens(content, maxTokens - markerTokens)}${TRUNCATED_MARKER}`;
 		}
 
 		const charBudget = budget.maxChars ?? budget.budget;
@@ -86,7 +93,9 @@ function readIdentityPathWithBudget(
 			if (!Number.isFinite(charBudget) || charBudget <= 0) return undefined;
 			const maxChars = Math.floor(charBudget);
 			if (content.length <= maxChars) return content;
-			return `${content.slice(0, maxChars)}\n[truncated]`;
+			const markerChars = TRUNCATED_MARKER.length;
+			if (markerChars >= maxChars) return content.slice(0, maxChars);
+			return `${content.slice(0, maxChars - markerChars)}${TRUNCATED_MARKER}`;
 		}
 
 		return content;

--- a/platform/daemon/src/identity-context.ts
+++ b/platform/daemon/src/identity-context.ts
@@ -1,8 +1,30 @@
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { isAbsolute, join, relative } from "node:path";
 import { getAgentIdentityFiles, parseSimpleYaml } from "@signet/core";
+import type { ContextIdentityConfig, ContextIdentityFileConfig } from "./hooks-config";
+import { countTokens, truncateToTokens } from "./pipeline/tokenizer";
 
 export type IdentityFileMap = Record<string, string>;
+
+export interface IdentityContextSection {
+	path: string;
+	header: string;
+	content: string;
+}
+
+const IDENTITY_HEADER_BY_FILE: Record<string, string> = {
+	"AGENTS.md": "Agent Instructions",
+	"SOUL.md": "Soul",
+	"IDENTITY.md": "Identity",
+	"USER.md": "About Your User",
+	"MEMORY.md": "Working Memory",
+};
+
+function identityHeaderFor(path: string, entry?: Pick<ContextIdentityFileConfig, "header" | "role">): string {
+	if (entry?.header) return entry.header;
+	const filename = path.split(/[\\/]/).pop() ?? path;
+	return IDENTITY_HEADER_BY_FILE[filename] ?? entry?.role ?? filename.replace(/\.md$/i, "");
+}
 
 function readIdentityPath(filePath: string | undefined, charBudget: number): string | undefined {
 	if (!filePath || !existsSync(filePath)) return undefined;
@@ -40,6 +62,77 @@ export function readAgentsMd(
 	identityFiles?: IdentityFileMap,
 ): string | undefined {
 	return readIdentityFile(agentsDir, "AGENTS.md", charBudget, identityFiles);
+}
+
+function readIdentityPathWithBudget(
+	filePath: string | undefined,
+	budget: Pick<ContextIdentityFileConfig, "maxTokens" | "maxChars" | "budget">,
+): string | undefined {
+	if (!filePath || !existsSync(filePath)) return undefined;
+
+	try {
+		const content = readFileSync(filePath, "utf-8").trim();
+		if (!content) return undefined;
+
+		if (budget.maxTokens !== undefined) {
+			if (!Number.isFinite(budget.maxTokens) || budget.maxTokens <= 0) return undefined;
+			const maxTokens = Math.floor(budget.maxTokens);
+			if (countTokens(content) <= maxTokens) return content;
+			return `${truncateToTokens(content, maxTokens)}\n[truncated]`;
+		}
+
+		const charBudget = budget.maxChars ?? budget.budget;
+		if (charBudget !== undefined) {
+			if (!Number.isFinite(charBudget) || charBudget <= 0) return undefined;
+			const maxChars = Math.floor(charBudget);
+			if (content.length <= maxChars) return content;
+			return `${content.slice(0, maxChars)}\n[truncated]`;
+		}
+
+		return content;
+	} catch {
+		return undefined;
+	}
+}
+
+function identityPathFor(agentsDir: string, path: string, identityFiles?: IdentityFileMap): string {
+	return identityFiles?.[path] ?? join(agentsDir, path);
+}
+
+function isSafeResolvedIdentityPath(agentsDir: string, filePath: string): boolean {
+	try {
+		const base = realpathSync(agentsDir);
+		const target = realpathSync(filePath);
+		const rel = relative(base, target);
+		if (!rel || rel.startsWith("..") || isAbsolute(rel)) return false;
+		const deniedDirs = new Set([".daemon", ".secrets", "memory"]);
+		return rel.split(/[\\/]/).every((part) => {
+			const normalized = part.toLowerCase();
+			return !normalized.startsWith(".") && !deniedDirs.has(normalized);
+		});
+	} catch {
+		return false;
+	}
+}
+
+export function readContextIdentitySections(
+	agentsDir: string,
+	identity: ContextIdentityConfig | undefined,
+	identityFiles?: IdentityFileMap,
+): IdentityContextSection[] | null {
+	if (identity?.include === false) return [];
+	if (!identity?.files) return null;
+
+	const sections: IdentityContextSection[] = [];
+	for (const entry of identity.files) {
+		if (entry.enabled === false) continue;
+		const filePath = identityPathFor(agentsDir, entry.path, identityFiles);
+		if (!isSafeResolvedIdentityPath(agentsDir, filePath)) continue;
+		const content = readIdentityPathWithBudget(filePath, entry);
+		if (!content) continue;
+		sections.push({ path: entry.path, header: identityHeaderFor(entry.path, entry), content });
+	}
+	return sections;
 }
 
 export function resolveIdentityFiles(agentId: string, agentsDir: string): IdentityFileMap {

--- a/platform/daemon/src/memory-candidates.ts
+++ b/platform/daemon/src/memory-candidates.ts
@@ -159,7 +159,7 @@ export function fetchTraversalCandidates(
 							 m.created_at,
 							 m.access_count`,
 						)
-						.all(agentId, ...memoryIds) as ScoredMemory[],
+						.all(agentId, ...memoryIds) as unknown as ScoredMemory[],
 			)
 			.map((row) => ({
 				...row,
@@ -227,7 +227,7 @@ export function getAllScoredCandidates(
 			return b.effScore - a.effScore;
 		});
 
-		return scored;
+		return scored.slice(0, limit);
 	} catch (e) {
 		logger.error("hooks", "Failed to get scored candidates", e as Error);
 		return [];
@@ -386,7 +386,7 @@ export function getRecentMemories(memoryDbPath: string, limit: number, recencyBi
         LIMIT ?
       `;
 
-			return db.prepare(query).all(limit) as Array<SimpleMemory>;
+			return db.prepare(query).all(limit) as unknown as Array<SimpleMemory>;
 		});
 
 		return rows.map((r) => ({
@@ -419,7 +419,7 @@ export function getMemoriesSince(memoryDbPath: string, sinceMs: number, limit: n
 				ORDER BY created_at DESC
 				LIMIT ?
 			`)
-				.all(sinceIso, limit) as Array<SimpleMemory>;
+				.all(sinceIso, limit) as unknown as Array<SimpleMemory>;
 		});
 
 		return rows.map((r) => ({

--- a/surfaces/cli/src/cli.ts
+++ b/surfaces/cli/src/cli.ts
@@ -59,6 +59,7 @@ import ora from "ora";
 import { registerBrowseCommand } from "./browse.js";
 import { registerAgentCommands } from "./commands/agent.js";
 import { registerConnectorCommands } from "./commands/connector.js";
+import { registerContextCommands } from "./commands/context.js";
 import { registerApiKeyCommands } from "./commands/api-key.js";
 import { registerAppCommands } from "./commands/app.js";
 import { registerDaemonCommands } from "./commands/daemon.js";
@@ -1082,6 +1083,11 @@ registerAgentCommands(program, {
 registerRouteCommands(program, {
 	AGENTS_DIR,
 	fetchFromDaemon,
+	secretApiCall,
+});
+
+registerContextCommands(program, {
+	AGENTS_DIR,
 	secretApiCall,
 });
 

--- a/surfaces/cli/src/commands/context.test.ts
+++ b/surfaces/cli/src/commands/context.test.ts
@@ -1,0 +1,113 @@
+import { mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
+import {
+	buildContextCompilePrompt,
+	compileContextPrompt,
+	readContextSources,
+} from "./context";
+
+function tempWorkspace(): string {
+	return mkdtempSync(join(tmpdir(), "signet-context-compile-"));
+}
+
+describe("context compile", () => {
+	it("builds a synthesis prompt from canonical identity sources", () => {
+		const root = tempWorkspace();
+		writeFileSync(join(root, "AGENTS.md"), "# Policy\nPreserve user files.");
+		writeFileSync(join(root, "USER.md"), "# User\nPrefers concise coding context.");
+
+		const sources = readContextSources(root, ["AGENTS.md", "USER.md", "SOUL.md"]);
+		const prompt = buildContextCompilePrompt(sources, 2200);
+
+		expect(sources.map((source) => source.path)).toEqual(["AGENTS.md", "USER.md"]);
+		expect(prompt).toContain("2200 characters or fewer");
+		expect(prompt).toContain("Preserve user files");
+		expect(prompt).toContain("Drop biography");
+	});
+
+	it("writes a profile artifact with a hard character cap", async () => {
+		const root = tempWorkspace();
+		writeFileSync(join(root, "AGENTS.md"), "# Policy\nPreserve user files.");
+		writeFileSync(join(root, "USER.md"), "# User\nPrefers concise coding context.");
+		const longText = `${"a".repeat(80)}\n${"b".repeat(80)}`;
+
+		const result = await compileContextPrompt({
+			agentsDir: root,
+			profile: "coding",
+			outputPath: "context-profiles/coding/AGENTS.md",
+			sourceFiles: ["AGENTS.md", "USER.md"],
+			maxChars: 100,
+			timeoutMs: 1000,
+			dryRun: false,
+			secretApiCall: async (_method, path, body, timeoutMs) => {
+				expect(path).toBe("/api/inference/execute");
+				const request = body as { operation?: string; taskClass?: string; privacy?: string; timeoutMs?: number };
+				expect(request.operation).toBe("session_synthesis");
+				expect(request.taskClass).toBeUndefined();
+				expect(request.privacy).toBeUndefined();
+				expect(request.timeoutMs).toBe(1000);
+				expect(timeoutMs).toBe(6000);
+				return { ok: true, data: { text: longText, decision: { targetRef: "local/default" } } };
+			},
+		});
+
+		expect(result.charCount).toBeLessThanOrEqual(100);
+		expect(result.truncated).toBe(true);
+		expect(result.targetRef).toBe("local/default");
+		expect(readFileSync(join(root, "context-profiles/coding/AGENTS.md"), "utf-8").length).toBeLessThanOrEqual(101);
+	});
+
+	it("rejects source and output paths that escape protected workspace areas", async () => {
+		const root = tempWorkspace();
+		mkdirSync(join(root, ".secrets"));
+		writeFileSync(join(root, ".secrets", "AGENTS.md"), "secret");
+		symlinkSync(join(root, ".secrets", "AGENTS.md"), join(root, "SAFE.md"));
+		expect(() => readContextSources(root, [".secrets/AGENTS.md"])).toThrow("Unsafe context path");
+		expect(() => readContextSources(root, ["SAFE.md"])).toThrow("Context path escapes workspace");
+
+		const outside = tempWorkspace();
+		writeFileSync(join(outside, "AGENTS.md"), "outside");
+		mkdirSync(join(root, "context-profiles"));
+		symlinkSync(outside, join(root, "context-profiles", "escape"));
+		writeFileSync(join(root, "AGENTS.md"), "# Policy\nNo secrets.");
+		let apiCalls = 0;
+
+		await expect(
+			compileContextPrompt({
+				agentsDir: root,
+				profile: "coding",
+				outputPath: "context-profiles/escape/AGENTS.md",
+				sourceFiles: ["AGENTS.md"],
+				maxChars: 100,
+				timeoutMs: 1000,
+				dryRun: false,
+				secretApiCall: async () => {
+					apiCalls += 1;
+					return { ok: true, data: { text: "compiled" } };
+				},
+			}),
+		).rejects.toThrow("Context path escapes workspace");
+		expect(apiCalls).toBe(0);
+
+		writeFileSync(join(outside, "artifact.md"), "outside");
+		symlinkSync(join(outside, "artifact.md"), join(root, "context-profiles", "AGENTS.md"));
+		await expect(
+			compileContextPrompt({
+				agentsDir: root,
+				profile: "coding",
+				outputPath: "context-profiles/AGENTS.md",
+				sourceFiles: ["AGENTS.md"],
+				maxChars: 100,
+				timeoutMs: 1000,
+				dryRun: false,
+				secretApiCall: async () => {
+					apiCalls += 1;
+					return { ok: true, data: { text: "compiled" } };
+				},
+			}),
+		).rejects.toThrow("must not be a symlink");
+		expect(apiCalls).toBe(0);
+	});
+});

--- a/surfaces/cli/src/commands/context.ts
+++ b/surfaces/cli/src/commands/context.ts
@@ -1,0 +1,295 @@
+import { existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, join, parse, relative } from "node:path";
+import chalk from "chalk";
+import type { Command } from "commander";
+import type { DaemonApiCall } from "../lib/daemon.js";
+
+export const DEFAULT_CONTEXT_PROFILE = "coding";
+export const DEFAULT_COMPILED_CONTEXT_MAX_CHARS = 2200;
+export const DEFAULT_CONTEXT_SOURCE_FILES = ["AGENTS.md", "USER.md", "IDENTITY.md", "SOUL.md"] as const;
+
+interface ContextDeps {
+	readonly AGENTS_DIR: string;
+	readonly secretApiCall: DaemonApiCall;
+}
+
+interface CompileOptions {
+	readonly profile?: string;
+	readonly output?: string;
+	readonly maxChars?: string;
+	readonly sources?: string;
+	readonly agent?: string;
+	readonly policy?: string;
+	readonly target?: string;
+	readonly timeout?: string;
+	readonly dryRun?: boolean;
+	readonly json?: boolean;
+}
+
+export interface ContextSource {
+	readonly path: string;
+	readonly content: string;
+}
+
+export interface CompileContextPromptParams {
+	readonly agentsDir: string;
+	readonly profile: string;
+	readonly outputPath: string;
+	readonly sourceFiles: readonly string[];
+	readonly maxChars: number;
+	readonly agentId?: string;
+	readonly policy?: string;
+	readonly target?: string;
+	readonly timeoutMs: number;
+	readonly dryRun: boolean;
+	readonly secretApiCall: DaemonApiCall;
+}
+
+export interface CompileContextPromptResult {
+	readonly profile: string;
+	readonly outputPath: string;
+	readonly maxChars: number;
+	readonly charCount: number;
+	readonly truncated: boolean;
+	readonly sources: readonly string[];
+	readonly text: string;
+	readonly targetRef?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number, max: number): number | null {
+	if (value === undefined) return fallback;
+	const trimmed = value.trim();
+	if (!/^[1-9]\d*$/.test(trimmed)) return null;
+	const parsed = Number.parseInt(trimmed, 10);
+	return Number.isSafeInteger(parsed) && parsed <= max ? parsed : null;
+}
+
+function parseSourceList(value: string | undefined): readonly string[] {
+	if (!value) return DEFAULT_CONTEXT_SOURCE_FILES;
+	return value
+		.split(",")
+		.map((part) => part.trim())
+		.filter((part) => part.length > 0);
+}
+
+function isSafeContextRelativePath(path: string): boolean {
+	const trimmed = path.trim();
+	if (!trimmed || trimmed.startsWith("~") || isAbsolute(trimmed)) return false;
+	const parts = trimmed.split(/[\\/]/);
+	const denied = new Set([".daemon", ".secrets", "memory"]);
+	return parts.every((part) => {
+		const normalized = part.toLowerCase();
+		return normalized !== ".." && !normalized.startsWith(".") && !denied.has(normalized);
+	});
+}
+
+function nearestExistingAncestor(path: string): string {
+	let current = path;
+	const root = parse(path).root;
+	while (!existsSync(current) && current !== root) {
+		current = dirname(current);
+	}
+	return current;
+}
+
+function isAllowedResolvedRelative(rel: string): boolean {
+	if (rel.startsWith("..") || isAbsolute(rel)) return false;
+	const denied = new Set([".daemon", ".secrets", "memory"]);
+	return rel
+		.split(/[\\/]/)
+		.filter((part) => part.length > 0)
+		.every((part) => {
+			const normalized = part.toLowerCase();
+			return !normalized.startsWith(".") && !denied.has(normalized);
+		});
+}
+
+function ensureContainedPath(baseDir: string, path: string): string {
+	if (!isSafeContextRelativePath(path)) {
+		throw new Error(`Unsafe context path: ${path}`);
+	}
+	const resolved = join(baseDir, path);
+	const baseReal = realpathSync(baseDir);
+	const ancestorReal = realpathSync(nearestExistingAncestor(dirname(resolved)));
+	const rel = relative(baseReal, ancestorReal);
+	if (!isAllowedResolvedRelative(rel)) {
+		throw new Error(`Context path escapes workspace: ${path}`);
+	}
+	return resolved;
+}
+
+function assertExistingPathContained(baseDir: string, path: string, resolved: string): void {
+	const baseReal = realpathSync(baseDir);
+	const targetReal = realpathSync(resolved);
+	const rel = relative(baseReal, targetReal);
+	if (!isAllowedResolvedRelative(rel)) {
+		throw new Error(`Context path escapes workspace: ${path}`);
+	}
+}
+
+export function readContextSources(agentsDir: string, sourceFiles: readonly string[]): readonly ContextSource[] {
+	return sourceFiles.flatMap((sourcePath) => {
+		const resolved = ensureContainedPath(agentsDir, sourcePath);
+		if (!existsSync(resolved)) return [];
+		assertExistingPathContained(agentsDir, sourcePath, resolved);
+		return [{ path: sourcePath, content: readFileSync(resolved, "utf-8") }];
+	});
+}
+
+function formatSourceBlock(source: ContextSource): string {
+	return [`### ${source.path}`, "```md", source.content.trim(), "```"].join("\n");
+}
+
+export function buildContextCompilePrompt(sources: readonly ContextSource[], maxChars: number): string {
+	const sourceBlocks = sources.map(formatSourceBlock).join("\n\n");
+	return `Synthesize the Signet identity and operating-policy sources below into one coding-agent AGENTS.md prompt.\n\nHard requirements:\n- Output only the final prompt text; no code fences, commentary, preamble, or metadata.\n- The final prompt must be ${maxChars} characters or fewer.\n- Preserve hard repo/workflow policy, safety constraints, user preferences, file-preservation rules, scoping rules, dependency-inspection requirements, proof/test expectations, and secret-handling rules.\n- Drop biography, decorative voice, repeated explanations, broad product philosophy, and non-coding details.\n- Do not invent new policy.\n- Use concise imperative bullets suitable for a system prompt.\n\nSources:\n${sourceBlocks}`;
+}
+
+function stripCodeFence(text: string): string {
+	const trimmed = text.trim();
+	const match = /^```(?:md|markdown)?\s*\n([\s\S]*?)\n```$/i.exec(trimmed);
+	return match ? match[1].trim() : trimmed;
+}
+
+function truncateAtCharacterLimit(text: string, maxChars: number): { readonly text: string; readonly truncated: boolean } {
+	const normalized = stripCodeFence(text).replace(/\n{3,}/g, "\n\n").trim();
+	if (normalized.length <= maxChars) return { text: normalized, truncated: false };
+	const slice = normalized.slice(0, maxChars).trimEnd();
+	return { text: slice, truncated: true };
+}
+
+function readTargetRef(data: unknown): string | undefined {
+	if (!isRecord(data)) return undefined;
+	const decision = data.decision;
+	if (!isRecord(decision)) return undefined;
+	return typeof decision.targetRef === "string" ? decision.targetRef : undefined;
+}
+
+function readGeneratedText(data: unknown): string | undefined {
+	return isRecord(data) && typeof data.text === "string" ? data.text : undefined;
+}
+
+function assertWritableOutputPath(agentsDir: string, outputPath: string): string {
+	const resolved = ensureContainedPath(agentsDir, outputPath);
+	if (existsSync(resolved) && lstatSync(resolved).isSymbolicLink()) {
+		throw new Error(`Context output path must not be a symlink: ${outputPath}`);
+	}
+	return resolved;
+}
+
+export async function compileContextPrompt(params: CompileContextPromptParams): Promise<CompileContextPromptResult> {
+	const resolvedOutput = assertWritableOutputPath(params.agentsDir, params.outputPath);
+	const sources = readContextSources(params.agentsDir, params.sourceFiles);
+	if (sources.length === 0) {
+		throw new Error(`No source files found. Checked: ${params.sourceFiles.join(", ")}`);
+	}
+	const prompt = buildContextCompilePrompt(sources, params.maxChars);
+	const { ok, data } = await params.secretApiCall(
+		"POST",
+		"/api/inference/execute",
+		{
+			prompt,
+			agentId: params.agentId,
+			operation: "session_synthesis",
+			explicitPolicy: params.policy,
+			explicitTargets: params.target ? [params.target] : undefined,
+			maxTokens: Math.max(256, Math.ceil(params.maxChars / 2)),
+			timeoutMs: params.timeoutMs,
+			refresh: false,
+		},
+		params.timeoutMs + 5_000,
+	);
+	if (!ok) {
+		throw new Error(`Context synthesis failed: ${JSON.stringify(data)}`);
+	}
+	const generated = readGeneratedText(data);
+	if (!generated) {
+		throw new Error("Context synthesis response did not include text.");
+	}
+	const capped = truncateAtCharacterLimit(generated, params.maxChars);
+	if (!params.dryRun) {
+		mkdirSync(dirname(resolvedOutput), { recursive: true });
+		assertWritableOutputPath(params.agentsDir, params.outputPath);
+		writeFileSync(resolvedOutput, `${capped.text}\n`);
+	}
+	return {
+		profile: params.profile,
+		outputPath: params.outputPath,
+		maxChars: params.maxChars,
+		charCount: capped.text.length,
+		truncated: capped.truncated,
+		sources: sources.map((source) => source.path),
+		text: capped.text,
+		targetRef: readTargetRef(data),
+	};
+}
+
+export function registerContextCommands(program: Command, deps: ContextDeps): void {
+	const context = program.command("context").description("Compile and inspect Signet context artifacts");
+
+	context
+		.command("compile")
+		.description("Synthesize canonical identity files into a bounded profile prompt artifact")
+		.option("--profile <name>", "Context profile name", DEFAULT_CONTEXT_PROFILE)
+		.option("--output <path>", "Output path relative to the Signet workspace")
+		.option("--max-chars <n>", "Maximum generated prompt characters", String(DEFAULT_COMPILED_CONTEXT_MAX_CHARS))
+		.option("--sources <paths>", "Comma-separated source files", DEFAULT_CONTEXT_SOURCE_FILES.join(","))
+		.option("--agent <agent>", "Inference agent id")
+		.option("--policy <policy>", "Inference policy override")
+		.option("--target <targetRef>", "Explicit inference target ref")
+		.option("--timeout <ms>", "Inference timeout in milliseconds", "120000")
+		.option("--dry-run", "Print generated prompt without writing it")
+		.option("--json", "Output metadata as JSON")
+		.action(async (options: CompileOptions) => {
+			const maxChars = parsePositiveInt(options.maxChars, DEFAULT_COMPILED_CONTEXT_MAX_CHARS, 20_000);
+			if (maxChars === null) {
+				console.error(chalk.red("--max-chars must be a positive integer no greater than 20000."));
+				process.exit(1);
+				return;
+			}
+			const timeoutMs = parsePositiveInt(options.timeout, 120_000, 600_000);
+			if (timeoutMs === null) {
+				console.error(chalk.red("--timeout must be a positive integer no greater than 600000."));
+				process.exit(1);
+				return;
+			}
+			const profile = options.profile?.trim() || DEFAULT_CONTEXT_PROFILE;
+			const outputPath = options.output?.trim() || `context-profiles/${profile}/AGENTS.md`;
+			try {
+				const result = await compileContextPrompt({
+					agentsDir: deps.AGENTS_DIR,
+					profile,
+					outputPath,
+					sourceFiles: parseSourceList(options.sources),
+					maxChars,
+					agentId: options.agent,
+					policy: options.policy,
+					target: options.target,
+					timeoutMs,
+					dryRun: options.dryRun === true,
+					secretApiCall: deps.secretApiCall,
+				});
+				if (options.json) {
+					console.log(JSON.stringify(result, null, 2));
+					return;
+				}
+				if (options.dryRun) {
+					console.log(result.text);
+					return;
+				}
+				console.log(chalk.green(`Compiled ${result.outputPath} (${result.charCount}/${result.maxChars} chars)`));
+				if (result.truncated) {
+					console.log(chalk.yellow("Generated prompt exceeded the limit and was deterministically truncated."));
+				}
+				if (result.targetRef) console.log(chalk.dim(`Target: ${result.targetRef}`));
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				console.error(chalk.red(message));
+				process.exit(1);
+			}
+		});
+}

--- a/surfaces/cli/templates/agent.yaml.template
+++ b/surfaces/cli/templates/agent.yaml.template
@@ -169,6 +169,31 @@ hooks:
     # Weight recent memories higher (0-1, higher = more recency bias)
     recencyBias: 0.7
 
+  # Optional named context-budget profiles for different harness workflows.
+  # Use leaner profiles for coding harnesses and richer profiles for
+  # operator/character-forward harnesses. Generate a compact coding prompt with:
+  #   signet context compile --profile coding --max-chars 2200
+  # contextProfiles:
+  #   coding:
+  #     sessionStart:
+  #       recallLimit: 5
+  #       maxInjectTokens: 5000
+  #     userPromptSubmit:
+  #       maxInjectChars: 300
+  #     identity:
+  #       files:
+  #         - path: context-profiles/coding/AGENTS.md
+  #           maxChars: 2200
+  #   rich:
+  #     sessionStart:
+  #       recallLimit: 50
+  #       maxInjectTokens: 20000
+  # harnessProfiles:
+  #   pi: coding
+  #   codex: coding
+  #   hermes-agent: rich
+  #   openclaw: rich
+
   # Called before session compaction/summarization
   preCompaction:
     # Guidelines for the agent when generating session summary


### PR DESCRIPTION
Stacked on top of #847. Addresses three findings from the review of `feat(daemon): add context budget profiles`.

## Fixes

### 🔴 Keep predicted context additive at session start (regression)
The feature change capped predicted context by how full main recall was (`predictedLimit = max(0, recallLimit - memories.length)`). When recall filled to `recallLimit` (default `50`), `predictedLimit` became `0` and the **entire** predicted-context feature was silently dropped.

- **Proof:** session-start `memoryCount` dropped from `52` on `main` to `50` on the feature branch; the two existing `predictive context …` tests **pass on `main`, failed on the branch, pass again now**.
- Predicted context is additive by design — it surfaces topics the user is likely to need next regardless of token budget consumed. Restored the additive call matching `main`.

### 🟠 Preserve global hook settings in context profile merge
`mergeConfig` spread the profile override over the base, but profile readers emit fully-populated objects with `undefined` for unset keys. The post-spread `undefined`-delete ran too late, so an unset override key (e.g. a profile that only sets `recallLimit`) clobbered a defined global value like `sessionStart.recencyBias` or `includeIdentity`, silently reverting it to the code default.

- Only copy override keys that are actually present and defined.
- New test: profile overrides `recallLimit` while an unrelated global `recencyBias` / `includeIdentity` / `maxInjectTokens` survives.

### 🟡 Hold profile identity budgets under the truncation marker
Truncated profile identity sections appended `\n[truncated]` *after* hitting the declared `maxTokens`/`maxChars`, so a truncated section exceeded its configured per-file budget — breaking the strict bounded-context contract this feature exists to enforce.

- Reserve room for the marker (`maxTokens - markerTokens` / `maxChars - marker.length`); when the budget is smaller than the marker itself, cap without the marker rather than overflow.
- New tests for both the normal overflow case and tiny budgets below the marker size.
- Two existing tests used `maxTokens` below the marker size (`4` and `3`), which encoded the old overflow; bumped to `6` so the file is still truncated but the marker fits legitimately.

## Verification
Run in an isolated worktree at the latest PR tip (`86c010591`):

| Suite | result |
|---|---|
| `hooks.test.ts` (full) | 165 pass / 0 fail (was 162/3) |
| `hooks-config.test.ts` | 7 pass / 0 fail |
| `identity-context.test.ts` | 8 pass / 0 fail |
| `context-budget.test.ts` + CLI `context.test.ts` | 7 pass / 0 fail |
| Each new regression test fails on the un-fixed feature branch | ✅ confirmed |
| `autoreview` on the full fix set | 0 findings |

The only remaining `hooks.test.ts` failure (`handleSynthesisRequest > returns prompt with database-backed temporal sources`) is **pre-existing** — it fails identically on `origin/main` and is unrelated to context profiles.

## Notes
- Stacked PR → base is `nicholai/context-budget-profiles`. Once merged, #847 picks these up.
- No `main` rebase needed (this targets the feature branch tip directly).
- Touched files introduce no new typecheck errors (the pre-existing `build:types` failures in `context-construction.ts` / `subagent-context.test.ts` are unchanged).

## Type
- [x] `fix`
