### PR TITLE
fix(dashboard): limit constellation entity types

### DIFF
--- a/platform/daemon-rs/crates/signet-services/src/graph.rs
+++ b/platform/daemon-rs/crates/signet-services/src/graph.rs
@@ -1434,8 +1434,9 @@ pub fn get_constellation(
     // Phase 1: Get entities with mentions or pinned or aspects
     let mut stmt = conn.prepare(
         "SELECT e.id, e.name, e.entity_type, e.mentions, e.pinned FROM entities e
-         WHERE e.agent_id = ?1 AND (e.mentions > 0 OR e.pinned = 1
-           OR EXISTS(SELECT 1 FROM entity_aspects WHERE entity_id = e.id))
+         WHERE e.agent_id = ?1
+           AND LOWER(TRIM(e.entity_type)) IN ('person', 'project')
+           AND (e.mentions > 0 OR e.pinned = 1)
          ORDER BY e.pinned DESC, e.mentions DESC, e.name ASC LIMIT 500",
     )?;
     let entity_rows: Vec<(String, String, String, i64, bool)> = stmt

--- a/platform/daemon/src/knowledge-graph-list.test.ts
+++ b/platform/daemon/src/knowledge-graph-list.test.ts
@@ -350,12 +350,14 @@ describe("listKnowledgeEntities (issue #515)", () => {
 		dbPath = makeDbPath();
 		initDbAccessor(dbPath);
 
-		seedEntity("e-hub", "Hub", { mentions: 10 });
-		seedEntity("e-leaf", "Leaf", { mentions: 9 });
-		seedEntity("e-hidden", "Hidden", { mentions: 0 });
+		seedEntity("e-hub", "Hub", { entityType: "project", mentions: 10 });
+		seedEntity("e-leaf", "Leaf", { entityType: "person", mentions: 9 });
+		seedEntity("e-hidden", "Hidden", { entityType: "project", mentions: 0 });
+		seedEntity("e-topic", "Noisy Topic", { entityType: "topic", mentions: 99, pinned: true });
 		seedAspect("asp-hub-a", "e-hub", "alpha");
 		seedAspect("asp-hub-b", "e-hub", "beta");
 		seedAspect("asp-hidden", "e-hidden", "hidden");
+		seedAspect("asp-topic", "e-topic", "topic");
 		seedAttribute("attr-hub-a-1", "asp-hub-a", { content: "important alpha", memoryId: "mem-a" });
 		seedAttribute("attr-hub-a-2", "asp-hub-a", { content: "less important alpha" });
 		seedAttribute("attr-hidden", "asp-hidden", { content: "hidden attr" });
@@ -412,6 +414,7 @@ describe("listKnowledgeEntities (issue #515)", () => {
 		});
 
 		expect(graph.entities.map((entity) => entity.id)).toEqual(["e-hub", "e-leaf"]);
+		expect(graph.entities.map((entity) => entity.id)).not.toContain("e-topic");
 		expect(graph.entities[0].aspects.map((aspect) => aspect.id)).toEqual(["asp-hub-a"]);
 		expect(graph.entities[0].aspects[0].attributes.map((attr) => attr.id)).toEqual(["attr-hub-a-1"]);
 		expect(graph.entities[0].aspects[0].attributes[0].version).toBe(2);
@@ -435,9 +438,9 @@ describe("listKnowledgeEntities (issue #515)", () => {
 		seedAgent("default", "shared");
 		seedAgent("noam", "shared");
 		seedAgent("private-agent", "isolated");
-		seedEntity("e-default", "Default Entity", { agentId: "default", mentions: 5 });
-		seedEntity("e-noam", "Noam Entity", { agentId: "noam", mentions: 4 });
-		seedEntity("e-private", "Private Entity", { agentId: "private-agent", mentions: 9 });
+		seedEntity("e-default", "Default Entity", { agentId: "default", entityType: "project", mentions: 5 });
+		seedEntity("e-noam", "Noam Entity", { agentId: "noam", entityType: "person", mentions: 4 });
+		seedEntity("e-private", "Private Entity", { agentId: "private-agent", entityType: "project", mentions: 9 });
 		seedAspect("asp-noam", "e-noam", "shared aspect", "noam");
 		seedAttribute("attr-noam", "asp-noam", { agentId: "noam", content: "shared attribute" });
 		seedDependency("dep-shared", "e-default", "e-noam", { agentId: "noam", strength: 0.9 });

--- a/platform/daemon/src/knowledge-graph.ts
+++ b/platform/daemon/src/knowledge-graph.ts
@@ -2258,6 +2258,7 @@ export function getKnowledgeGraphForConstellation(
 				 FROM entities e
 				 WHERE e.agent_id IN (${agentPlaceholders})
 				   AND COALESCE(e.status, 'active') = 'active'
+				   AND LOWER(TRIM(e.entity_type)) IN ('person', 'project')
 				   AND (e.mentions > 0 OR e.pinned = 1)
 				 ORDER BY e.pinned DESC, e.mentions DESC, e.name ASC
 				 LIMIT ?`,

--- a/surfaces/dashboard/src/lib/components/ontology/knowledge-map-data.test.ts
+++ b/surfaces/dashboard/src/lib/components/ontology/knowledge-map-data.test.ts
@@ -66,10 +66,38 @@ const graph: ConstellationGraph = {
 			pinned: false,
 			aspects: [],
 		},
+		{
+			id: "entity-pinned-topic",
+			name: "Pinned Topic",
+			entityType: "topic",
+			mentions: 120,
+			pinned: true,
+			aspects: [
+				{
+					id: "aspect-topic",
+					name: "topic facts",
+					weight: 0.9,
+					attributes: [
+						{
+							id: "attr-topic",
+							content: "Pinned non-person/project entities should stay out of constellation view.",
+							kind: "attribute",
+							importance: 0.99,
+						},
+					],
+				},
+			],
+		},
 	],
 	dependencies: [
 		{ sourceEntityId: "entity-signet", targetEntityId: "entity-nicholai", dependencyType: "about", strength: 0.8 },
 		{ sourceEntityId: "entity-signet", targetEntityId: "entity-noisy", dependencyType: "generated", strength: 0.9 },
+		{
+			sourceEntityId: "entity-signet",
+			targetEntityId: "entity-pinned-topic",
+			dependencyType: "mentions",
+			strength: 0.9,
+		},
 	],
 };
 
@@ -85,12 +113,14 @@ describe("knowledge map data", () => {
 		expect(map.nodes.some((node) => node.id === "attribute:attr-source-native")).toBe(true);
 		expect(map.nodes.some((node) => node.id === "entity-noisy")).toBe(false);
 		expect(map.nodes.some((node) => node.id === "entity-empty-person")).toBe(false);
+		expect(map.nodes.some((node) => node.id === "entity-pinned-topic")).toBe(false);
+		expect(map.nodes.some((node) => node.id === "attribute:attr-topic")).toBe(false);
 		expect(map.edges.some((edge) => edge.kind === "supports")).toBe(true);
 		expect(map.edges.some((edge) => edge.kind === "about")).toBe(true);
 		expect(map.edges.find((edge) => edge.kind === "about")?.visualOnly).toBe(true);
 	});
 
-	it("keeps the map bounded and ranks useful people/projects/topics ahead of noisy extracted entities", () => {
+	it("keeps the map bounded and ranks useful people/projects ahead of other entity types", () => {
 		const map = buildKnowledgeMapFromConstellation(graph, { limit: 4 });
 
 		expect(map.nodes).toHaveLength(4);
@@ -117,7 +147,7 @@ describe("knowledge map data", () => {
 			entities: Array.from({ length: 32 }, (_, entityIndex) => ({
 				id: `entity-${entityIndex}`,
 				name: `Entity ${entityIndex}`,
-				entityType: "topic",
+				entityType: entityIndex % 2 === 0 ? "project" : "person",
 				mentions: 20 - (entityIndex % 6),
 				pinned: entityIndex === 0,
 				aspects: Array.from({ length: 5 }, (_, aspectIndex) => ({

--- a/surfaces/dashboard/src/lib/components/ontology/knowledge-map-data.ts
+++ b/surfaces/dashboard/src/lib/components/ontology/knowledge-map-data.ts
@@ -67,28 +67,7 @@ export interface KnowledgeMapBuildOptions {
 
 const DEFAULT_LIMIT = 600;
 const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5));
-const PRIMARY_ENTITY_TYPES = new Set([
-	"person",
-	"project",
-	"topic",
-	"system",
-	"product",
-	"organization",
-	"org",
-	"source",
-	"artifact",
-	"agent",
-	"policy",
-	"action",
-	"workflow",
-	"event",
-	"object_type",
-	"interface",
-	"observation",
-	"claim_slot",
-	"claim_value",
-]);
-const NOISY_ENTITY_TYPES = new Set(["benchmark", "run", "file", "chunk", "unknown"]);
+const VISIBLE_CONSTELLATION_ENTITY_TYPES = new Set(["person", "project"]);
 
 export const KNOWLEDGE_NODE_COLORS: Record<KnowledgeMapNodeKind, string> = {
 	source: "#38bdf8",
@@ -295,33 +274,15 @@ function clampLimit(value: number): number {
 }
 
 function includeEntity(entity: ConstellationEntity): boolean {
-	const type = entity.entityType.toLowerCase();
+	const type = entity.entityType.trim().toLowerCase();
 	if (entity.aspects.length === 0) return false;
-	if (entity.pinned) return true;
-	if (looksNoisy(entity.name)) return false;
-	if (PRIMARY_ENTITY_TYPES.has(type)) return true;
-	if (NOISY_ENTITY_TYPES.has(type)) return false;
-	return (
-		entity.mentions >= 3 || entity.aspects.some((aspect) => aspect.attributes.some((attr) => attr.importance >= 0.78))
-	);
-}
-
-function looksNoisy(name: string): boolean {
-	const lower = name.toLowerCase();
-	return (
-		lower.includes("benchmark") ||
-		lower.includes("artifact") ||
-		lower.includes("fixture") ||
-		lower.includes("chunk") ||
-		/\b[0-9a-f]{8,}\b/.test(lower) ||
-		/\d{6,}/.test(lower)
-	);
+	return VISIBLE_CONSTELLATION_ENTITY_TYPES.has(type);
 }
 
 function entityScore(entity: ConstellationEntity, focusLabel?: string): number {
 	const focus = focusLabel?.trim().toLowerCase();
 	const focusBoost = focus && entity.name.toLowerCase().includes(focus) ? 100 : 0;
-	const typeBoost = PRIMARY_ENTITY_TYPES.has(entity.entityType.toLowerCase()) ? 25 : 0;
+	const typeBoost = VISIBLE_CONSTELLATION_ENTITY_TYPES.has(entity.entityType.trim().toLowerCase()) ? 25 : 0;
 	const pinnedBoost = entity.pinned ? 40 : 0;
 	const attrScore = entity.aspects.reduce(
 		(sum, aspect) => sum + aspect.attributes.reduce((inner, attr) => inner + attr.importance, 0),


### PR DESCRIPTION
## Summary

Limit constellation view to only `person` and `project` entities.

## Changes

- Filter JS daemon constellation entities to `person` / `project` before backend limits are applied.
- Apply the same pre-limit filter in the Rust daemon services implementation for parity.
- Keep a dashboard-side reinforcement filter so non-person/project entities, their children, and their dependencies do not render.
- Add/update regression coverage for filtered entity types and backend limit behavior.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: `platform/daemon-rs`

## Screenshots

N/A — data/filtering behavior only; no visual design change.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`)
- [x] Agent scoping verified on all new/changed data queries
- [x] Input/config validation and bounds checks added
- [x] Error handling and fallback paths tested (no silent swallow)
- [x] Security checks applied to admin/mutation endpoints
- [x] Docs updated for API/spec/status changes
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [ ] Daemon Rust parity reviewed or explicitly N/A
- [ ] Rollback / compatibility note included in PR description

N/A — no migrations.

## Testing

- [x] `bun test surfaces/dashboard/src/lib/components/ontology/knowledge-map-data.test.ts platform/daemon/src/knowledge-graph-list.test.ts`
- [x] `bunx biome check surfaces/dashboard/src/lib/components/ontology/knowledge-map-data.ts surfaces/dashboard/src/lib/components/ontology/knowledge-map-data.test.ts platform/daemon/src/knowledge-graph.ts platform/daemon/src/knowledge-graph-list.test.ts`
- [x] `cargo fmt --all --check` from `platform/daemon-rs`
- [x] `cargo check -p signet-services` from `platform/daemon-rs`
- [x] `git diff --check`
- [x] `bun run --filter '@signet/core' build && bun run --filter '@signet/daemon' build`
- [x] Autoreview clean (`[]`)

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The first daemon build attempt failed because `platform/core/dist` was stale after recent main changes. Rebuilding `@signet/core` first fixed the generated export state; the core-first daemon build then passed.
