### PR TITLE
fix(docker): restore native vector runtime

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -22,6 +22,19 @@ COPY public ./public
 COPY web ./web
 
 RUN bun install --frozen-lockfile
+ARG TARGETOS=linux
+ARG TARGETARCH
+RUN set -eux; \
+	arch="${TARGETARCH:-$(uname -m)}"; \
+	case "$arch" in \
+		amd64|x86_64) arch="x64" ;; \
+		aarch64) arch="arm64" ;; \
+	esac; \
+	pkg="sqlite-vec-${TARGETOS}-${arch}"; \
+	vec_path="$(find node_modules -path "*/${pkg}/vec0.so" -type f | head -n 1)"; \
+	test -n "$vec_path"; \
+	mkdir -p dist/docker-sqlite-vec; \
+	cp "$vec_path" dist/docker-sqlite-vec/vec0.so
 RUN bun run build:core
 RUN bun run build:connector-base
 RUN bun run build:opencode-plugin
@@ -43,8 +56,10 @@ ENV SIGNET_PATH=/data/agents
 ENV SIGNET_BIND=0.0.0.0
 ENV SIGNET_PORT=3850
 ENV SIGNET_DAEMON_ENTRYPOINT=1
+ENV SIGNET_VEC_PATH=/app/sqlite-vec/vec0.so
 
 COPY --from=build /app/dist/native/signet ./bin/signet
+COPY --from=build /app/dist/docker-sqlite-vec ./sqlite-vec
 COPY --from=build /app/dist/signetai/templates ./dist/signetai/templates
 COPY deploy/docker/entrypoint.sh ./deploy/docker/entrypoint.sh
 COPY deploy/docker/scripts ./deploy/docker/scripts

--- a/platform/daemon/build.ts
+++ b/platform/daemon/build.ts
@@ -41,6 +41,7 @@ if (isBun) {
 			outdir: ".",
 			naming: outfile,
 			target: "bun",
+			format: "esm",
 			external: EXTERNAL_BUN,
 			alias: ALIAS,
 		});

--- a/platform/daemon/src/__tests__/extraction-thread.test.ts
+++ b/platform/daemon/src/__tests__/extraction-thread.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { EventEmitter } from "node:events";
+import type { WorkerOptions } from "node:worker_threads";
 import {
 	type ExtractionWorker,
 	type ExtractionWorkerFactory,
@@ -18,6 +19,7 @@ class FakeExtractionWorker implements ExtractionWorker {
 	terminateCalls = 0;
 	readonly paths: string[] = [];
 	readonly inits: WorkerInit[] = [];
+	readonly options: WorkerOptions[] = [];
 
 	private readonly emitter = new EventEmitter();
 
@@ -71,9 +73,10 @@ function testInit(): WorkerInit {
 }
 
 function fakeFactory(worker: FakeExtractionWorker): ExtractionWorkerFactory {
-	return (path, init) => {
+	return (path, init, options) => {
 		worker.paths.push(path);
 		worker.inits.push(init);
+		worker.options.push(options);
 		return worker;
 	};
 }
@@ -317,6 +320,8 @@ describe("startExtractionThread lifecycle", () => {
 		expect(handle.running).toBe(true);
 		expect(handle.stats.processed).toBe(7);
 		expect(worker.inits).toHaveLength(1);
+		expect(worker.options[0]?.type).toBe("module");
+		expect(worker.options[0]?.workerData).toEqual(testInit());
 
 		handle.nudge();
 		expect(worker.messages).toContainEqual({ type: "nudge" });

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -1475,7 +1475,7 @@ async function main() {
 		: (resolveEmbeddedWorkerPath("synthesis-render-worker") ?? join(__dirname, "synthesis-render-worker.ts"));
 	let synthWorker: Worker | null = null;
 	try {
-		synthWorker = new Worker(workerPath);
+		synthWorker = new Worker(workerPath, { type: "module" });
 	} catch (err) {
 		logger.warn(
 			"daemon",

--- a/platform/daemon/src/native-runtime-assets.test.ts
+++ b/platform/daemon/src/native-runtime-assets.test.ts
@@ -40,13 +40,14 @@ describe("native-runtime-assets", () => {
 
 	test("materializes embedded worker and wasm files", () => {
 		registerNativeAssets({
-			workers: [{ name: "example-worker", contentBase64: Buffer.from("module.exports = 1;").toString("base64") }],
+			workers: [{ name: "example-worker", contentBase64: Buffer.from("export default 1;").toString("base64") }],
 			wasm: [{ name: "example.wasm", contentBase64: Buffer.from("wasm-bytes").toString("base64") }],
 		});
 
 		const workerPath = resolveEmbeddedWorkerPath("example-worker");
 		expect(workerPath).toBeTruthy();
-		expect(workerPath ? readFileSync(workerPath, "utf8") : "").toBe("module.exports = 1;");
+		expect(workerPath?.endsWith(".mjs")).toBe(true);
+		expect(workerPath ? readFileSync(workerPath, "utf8") : "").toBe("export default 1;");
 
 		const wasmDir = materializeEmbeddedWasmAssets();
 		expect(wasmDir).toBeTruthy();

--- a/platform/daemon/src/native-runtime-assets.ts
+++ b/platform/daemon/src/native-runtime-assets.ts
@@ -72,7 +72,7 @@ export function resolveEmbeddedWorkerPath(name: string): string | null {
 
 	const hash = createHash("sha256").update(worker.contentBase64).digest("hex").slice(0, 16);
 	const dir = join(tmpdir(), "signet-native-workers");
-	const path = join(dir, `${name.replace(/[^a-zA-Z0-9_.-]/g, "_")}-${hash}.cjs`);
+	const path = join(dir, `${name.replace(/[^a-zA-Z0-9_.-]/g, "_")}-${hash}.mjs`);
 	mkdirSync(dir, { recursive: true });
 	if (!existsSync(path)) {
 		writeFileSync(path, Buffer.from(worker.contentBase64, "base64"));

--- a/platform/daemon/src/pipeline/extraction-thread-handle.ts
+++ b/platform/daemon/src/pipeline/extraction-thread-handle.ts
@@ -10,7 +10,7 @@
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { Worker } from "node:worker_threads";
+import { Worker, type WorkerOptions } from "node:worker_threads";
 import type { AnalyticsCollector } from "../analytics";
 import { logger } from "../logger";
 import type { LogCategory } from "../logger";
@@ -30,7 +30,11 @@ export interface ExtractionWorker {
 	terminate(): Promise<number> | number;
 }
 
-export type ExtractionWorkerFactory = (workerPath: string, init: WorkerInit) => ExtractionWorker;
+export type ExtractionWorkerFactory = (
+	workerPath: string,
+	init: WorkerInit,
+	options: WorkerOptions,
+) => ExtractionWorker;
 
 export interface ExtractionThreadOpts {
 	readonly init: WorkerInit;
@@ -49,7 +53,8 @@ export function startExtractionThread(opts: ExtractionThreadOpts): Promise<Worke
 		const workerPath = existsSync(bundled)
 			? bundled
 			: (resolveEmbeddedWorkerPath("extraction-thread") ?? join(__dirname, "extraction-thread.ts"));
-		const worker = (opts.workerFactory ?? createNodeWorker)(workerPath, init);
+		const workerOptions = createExtractionWorkerOptions(init);
+		const worker = (opts.workerFactory ?? createNodeWorker)(workerPath, init, workerOptions);
 
 		let running = true;
 		let settled = false;
@@ -186,6 +191,10 @@ export function startExtractionThread(opts: ExtractionThreadOpts): Promise<Worke
 	});
 }
 
-function createNodeWorker(workerPath: string, init: WorkerInit): ExtractionWorker {
-	return new Worker(workerPath, { workerData: init });
+export function createExtractionWorkerOptions(init: WorkerInit): WorkerOptions {
+	return { workerData: init, type: "module" };
+}
+
+function createNodeWorker(workerPath: string, _init: WorkerInit, options: WorkerOptions): ExtractionWorker {
+	return new Worker(workerPath, options);
 }

--- a/scripts/build-native-bun.ts
+++ b/scripts/build-native-bun.ts
@@ -101,9 +101,9 @@ const nativeExternalArgs = ["--external", "better-sqlite3"] as const;
 for (const [name, entry] of workerEntries) {
 	runBunBuild([
 		"--target=bun",
-		"--format=cjs",
+		"--format=esm",
 		"--outfile",
-		join(workerDir, `${name}.cjs`),
+		join(workerDir, `${name}.mjs`),
 		...nativeExternalArgs,
 		entry,
 	]);
@@ -131,7 +131,7 @@ const skillAssets = fileAssetsFor(skillsDir);
 
 const workerAssets = workerEntries.map(([name]) => ({
 	name,
-	contentBase64: readFileSync(join(workerDir, `${name}.cjs`)).toString("base64"),
+	contentBase64: readFileSync(join(workerDir, `${name}.mjs`)).toString("base64"),
 }));
 const transformersPackageJson = daemonRequire.resolve("@huggingface/transformers/package.json");
 const transformersDir = dirname(transformersPackageJson);

--- a/scripts/check-publish-manifests.test.ts
+++ b/scripts/check-publish-manifests.test.ts
@@ -49,7 +49,10 @@ describe("check-publish-manifests", () => {
 
 		expect(missingSources).toEqual([]);
 		expect(dockerfile).toContain("RUN bun run build:native-bun");
+		expect(dockerfile).toContain('pkg="sqlite-vec-${TARGETOS}-${arch}"');
+		expect(dockerfile).toContain("ENV SIGNET_VEC_PATH=/app/sqlite-vec/vec0.so");
 		expect(dockerfile).toContain("COPY --from=build /app/dist/native/signet ./bin/signet");
+		expect(dockerfile).toContain("COPY --from=build /app/dist/docker-sqlite-vec ./sqlite-vec");
 		expect(dockerfile).not.toContain("/app/dist/signetai/dist");
 		expect(dockerfile).not.toContain("/app/dist/signetai/dashboard");
 		expect(dockerfile).not.toContain("/app/dist/signetai/skills");


### PR DESCRIPTION
## Summary

Fixes #855 by restoring the native runtime pieces the Docker image needs:

- copy the target-platform `sqlite-vec` `vec0.so` into the runtime image and set `SIGNET_VEC_PATH`
- emit embedded Bun worker bundles as ESM `.mjs`
- spawn extraction/synthesis worker threads with `type: "module"` so Bun 1.3.x does not hit the CommonJS worker loader crash

## Changes

- `deploy/docker/Dockerfile`
  - resolves `sqlite-vec-${TARGETOS}-${arch}/vec0.so` from Bun's installed optional dependency layout
  - copies it to `/app/sqlite-vec/vec0.so`
  - sets `SIGNET_VEC_PATH=/app/sqlite-vec/vec0.so`
- `scripts/build-native-bun.ts`
  - builds embedded worker entries as ESM `.mjs`
- `platform/daemon/src/native-runtime-assets.ts`
  - materializes embedded workers as `.mjs`
- `platform/daemon/src/pipeline/extraction-thread-handle.ts`
  - creates worker threads with `{ workerData, type: "module" }`
- `platform/daemon/src/daemon.ts`
  - uses module workers for the synthesis worker too
- Regression tests cover Docker vec packaging expectations, embedded worker extension, and extraction worker options.

## Type

- [ ] `feat` — new user-facing feature (bumps minor)
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [x] `test` — test coverage

## Packages affected

- [ ] `@signet/core`
- [x] `@signet/daemon`
- [x] `@signet/cli` / dashboard
- [ ] `@signet/sdk`
- [ ] `@signet/connector-*`
- [ ] `@signet/web`
- [ ] `predictor`
- [x] Other: Docker/native binary packaging

## Screenshots

N/A — Docker/runtime packaging fix, no UI changes.

## PR Readiness (MANDATORY)

- [x] Spec alignment validated (`INDEX.md` + `dependencies.yaml`) — N/A; no spec/API/status change
- [x] Agent scoping verified on all new/changed data queries — N/A; no data queries changed
- [x] Input/config validation and bounds checks added — N/A; packaging/worker module-mode fix
- [x] Error handling and fallback paths tested (no silent swallow) — existing worker fallback retained; worker options regression added
- [x] Security checks applied to admin/mutation endpoints — N/A; no endpoint changes
- [x] Docs updated for API/spec/status changes — N/A; no docs-facing contract change
- [x] Regression tests added for each bug fix
- [x] Lint/typecheck/tests pass locally — focused checks below

## Migration Notes (if applicable)

- [ ] Migration is idempotent
- [x] Daemon Rust parity reviewed or explicitly N/A — N/A Docker/native Bun runtime only
- [x] Rollback / compatibility note included in PR description — rollback removes Docker `SIGNET_VEC_PATH` and ESM worker packaging; no data migration

## Testing

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [x] Tested against running daemon
- [ ] N/A

Focused validation run:

```bash
PUPPETEER_SKIP_DOWNLOAD=1 bun install
bun test scripts/check-publish-manifests.test.ts platform/daemon/src/native-runtime-assets.test.ts platform/daemon/src/__tests__/extraction-thread.test.ts
bunx biome check deploy/docker/Dockerfile scripts/build-native-bun.ts scripts/check-publish-manifests.test.ts platform/daemon/build.ts platform/daemon/src/native-runtime-assets.ts platform/daemon/src/native-runtime-assets.test.ts platform/daemon/src/pipeline/extraction-thread-handle.ts platform/daemon/src/__tests__/extraction-thread.test.ts
git diff --check
bun run --filter '@signet/core' build && bun run --filter '@signet/daemon' build
bun run build:connector-base && bun run build:opencode-plugin && bun run build:oh-my-pi-extension && bun run build:connector-oh-my-pi && bun run build:pi-extension && bun run build:connector-pi && bun run build:deps
bun run build:native-bun
./dist/native/signet --version
```

Additional runtime evidence:

- `find node_modules -path '*/sqlite-vec-linux-x64/vec0.so' -type f` locates Bun's installed `sqlite-vec` native extension at `node_modules/.bun/sqlite-vec-linux-x64@0.1.9/node_modules/sqlite-vec-linux-x64/vec0.so`, matching the Docker copy pattern.
- A direct Bun worker smoke against `platform/daemon/dist/extraction-thread.js` returned structured worker IPC instead of the Bun `Expected CommonJS module to have a function wrapper` loader crash.
- `bun run build:native-bun` emitted `synthesis-render-worker.mjs` and `extraction-thread.mjs`, then compiled `dist/native/signet-linux-x64` successfully.

Notes:

- Running Biome over the entire `platform/daemon/src/daemon.ts` file still reports pre-existing unrelated formatter drift in untouched blocks, so the focused Biome command excludes that file rather than rewriting unrelated code.
- The native daemon entrypoint was smoke-started in a temp workspace; it reached daemon/pipeline initialization under the compiled binary. The selected test port was already in use, so this was treated as startup evidence rather than a full HTTP bind smoke.

## AI disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used (see `Assisted-by` tags in commits)

## Notes

The fix intentionally uses the existing `SIGNET_VEC_PATH` override rather than adding another sqlite-vec loader path. The runtime image now owns a stable `/app/sqlite-vec/vec0.so` location, while local/npm installs continue using the existing discovery logic.
