### PR TITLE
refactor(types): tighten recall scope typing

### DIFF
--- a/platform/core/src/search.ts
+++ b/platform/core/src/search.ts
@@ -24,14 +24,14 @@ export interface SearchOptions {
 	query: string;
 	limit?: number;
 	alpha?: number; // Vector weight (1-alpha = BM25 weight)
-	type?: "fact" | "preference" | "decision";
+	type?: string;
 	minScore?: number;
 	topK?: number; // Candidates per source before blending
 }
 
 export interface VectorSearchOptions {
 	limit?: number;
-	type?: "fact" | "preference" | "decision";
+	type?: string;
 	excludeAggregateRecall?: boolean;
 }
 
@@ -40,7 +40,7 @@ export interface HybridSearchOptions {
 	alpha?: number;
 	minScore?: number;
 	topK?: number;
-	type?: "fact" | "preference" | "decision";
+	type?: string;
 }
 
 export interface SearchResult {

--- a/platform/daemon/src/agent-id.ts
+++ b/platform/daemon/src/agent-id.ts
@@ -2,10 +2,11 @@
  * Agent ID resolution helpers.
  */
 
+import type { AgentRosterReadPolicy } from "@signet/core";
 import { getDbAccessor } from "./db-accessor";
 
 export interface AgentScope {
-	readonly readPolicy: string;
+	readonly readPolicy: AgentRosterReadPolicy;
 	readonly policyGroup: string | null;
 }
 
@@ -43,6 +44,12 @@ function parseScopeValue(value: unknown): string | null {
 	return text.length > 0 ? text : null;
 }
 
+function parseReadPolicy(value: unknown): AgentRosterReadPolicy {
+	const policy = parseScopeValue(value);
+	if (policy === "shared" || policy === "group" || policy === "isolated") return policy;
+	return "isolated";
+}
+
 export function getAgentScope(agentId: string): AgentScope {
 	try {
 		return getDbAccessor().withReadDb((db) => {
@@ -54,7 +61,7 @@ export function getAgentScope(agentId: string): AgentScope {
 				};
 			}
 
-			const readPolicy = parseScopeValue("read_policy" in row ? row.read_policy : undefined) ?? "isolated";
+			const readPolicy = parseReadPolicy("read_policy" in row ? row.read_policy : undefined);
 			const policyGroup = parseScopeValue("policy_group" in row ? row.policy_group : undefined);
 			return { readPolicy, policyGroup };
 		});
@@ -66,7 +73,7 @@ export function getAgentScope(agentId: string): AgentScope {
 	}
 }
 
-export function ensureAgentRegistered(agentId: string, readPolicy = "shared"): void {
+export function ensureAgentRegistered(agentId: string, readPolicy: AgentRosterReadPolicy = "shared"): void {
 	const id = agentId.trim() || "default";
 	const now = new Date().toISOString();
 	try {

--- a/platform/daemon/src/db-accessor.ts
+++ b/platform/daemon/src/db-accessor.ts
@@ -35,16 +35,36 @@ import { loadMemoryConfig } from "./memory-config";
 const isBun = typeof (globalThis as Record<string, unknown>).Bun !== "undefined";
 const require = createRequire(import.meta.url);
 
-type SqliteStatement = {
+export type SqliteStatement = {
 	run(...params: unknown[]): void;
 	get(...params: unknown[]): Record<string, unknown> | undefined;
 	all(...params: unknown[]): Record<string, unknown>[];
 };
 
+export interface TypedSqliteStatement<Row extends object> {
+	run(...params: unknown[]): void;
+	get(...params: unknown[]): Row | undefined;
+	all(...params: unknown[]): Row[];
+}
+
+export function prepareTypedStatement<Row extends object>(
+	db: {
+		prepare(sql: string): {
+			run(...params: unknown[]): unknown;
+			get(...params: unknown[]): unknown;
+			all(...params: unknown[]): unknown[];
+		};
+	},
+	sql: string,
+): TypedSqliteStatement<Row> {
+	return db.prepare(sql) as unknown as TypedSqliteStatement<Row>;
+}
+
 type SqliteDatabase = {
 	prepare(sql: string): SqliteStatement;
 	exec(sql: string): void;
 	close(): void;
+	loadExtension?(path: string): void;
 };
 
 let Database: new (path: string, opts?: Record<string, unknown>) => SqliteDatabase;
@@ -307,8 +327,9 @@ export function resolveSqliteRuntimeConfig(opts?: {
 	const set =
 		opts?.set ??
 		((path: string) => {
-			if (typeof (Database as Record<string, unknown>).setCustomSQLite === "function") {
-				(Database as { setCustomSQLite(p: string): void }).setCustomSQLite(path);
+			const sqliteCtor = Database as unknown as { setCustomSQLite?: (p: string) => void };
+			if (typeof sqliteCtor.setCustomSQLite === "function") {
+				sqliteCtor.setCustomSQLite(path);
 			}
 		});
 	const agentsDir = opts?.agentsDir ?? resolveSqliteAgentsDir({ env });
@@ -396,6 +417,7 @@ function loadVecExtension(db: SqliteDatabase): void {
 	}
 	if (vecExtPath) {
 		try {
+			if (typeof db.loadExtension !== "function") throw new Error("SQLite loadExtension API unavailable");
 			db.loadExtension(vecExtPath);
 			vecLoaded = true;
 			vecLoadError = null;
@@ -728,6 +750,7 @@ export function initDbAccessorLite(dbPathParam: string, vecExtensionPath: string
 
 	if (vecExtensionPath) {
 		try {
+			if (typeof writeConn.loadExtension !== "function") throw new Error("SQLite loadExtension API unavailable");
 			writeConn.loadExtension(vecExtensionPath);
 			vecLoaded = true;
 			vecLoadError = null;

--- a/platform/daemon/src/hooks.ts
+++ b/platform/daemon/src/hooks.ts
@@ -14,6 +14,7 @@ import { createHash } from "node:crypto";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import {
+	type AgentRosterReadPolicy,
 	identityModeManagesFiles,
 	identityModeReadsFiles,
 	loadIdentityMode,
@@ -473,7 +474,7 @@ export function getAllScoredCandidates(
 	project: string | undefined,
 	limit: number,
 	agentId = "default",
-	readPolicy = "isolated",
+	readPolicy: AgentRosterReadPolicy = "isolated",
 	policyGroup: string | null = null,
 ): ScoredMemory[] {
 	return memoryCandidates.getAllScoredCandidates(getMemoryDbPath(), project, limit, agentId, readPolicy, policyGroup);
@@ -485,7 +486,7 @@ function getPredictedContextMemories(
 	charBudget: number,
 	excludeIds: ReadonlySet<string>,
 	agentId: string,
-	readPolicy = "isolated",
+	readPolicy: AgentRosterReadPolicy = "isolated",
 	policyGroup: string | null = null,
 ): ScoredMemory[] {
 	return memoryCandidates.getPredictedContextMemories(
@@ -523,7 +524,7 @@ function loadHooksConfigForHarness(harness: string) {
 function getRecentMemories(
 	limit: number,
 	recencyBias = 0.7,
-	agentScope?: { agentId: string; readPolicy: string; policyGroup: string | null },
+	agentScope?: { agentId: string; readPolicy: AgentRosterReadPolicy; policyGroup: string | null },
 ): Array<{
 	id: string;
 	content: string;

--- a/platform/daemon/src/memory-access-scope.ts
+++ b/platform/daemon/src/memory-access-scope.ts
@@ -1,6 +1,8 @@
+import type { AgentRosterReadPolicy } from "@signet/core";
+
 export function buildAgentScopeClause(
 	agentId: string,
-	readPolicy: string,
+	readPolicy: AgentRosterReadPolicy,
 	policyGroup: string | null,
 ): { sql: string; args: unknown[] } {
 	if (readPolicy === "shared") {

--- a/platform/daemon/src/memory-candidates.ts
+++ b/platform/daemon/src/memory-candidates.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs";
+import type { AgentRosterReadPolicy } from "@signet/core";
 import { type WriteDb, getDbAccessor } from "./db-accessor";
 import { logger } from "./logger";
 import { effectiveScore } from "./memory-classification";
@@ -180,7 +181,7 @@ export function getAllScoredCandidates(
 	project: string | undefined,
 	limit: number,
 	agentId = "default",
-	readPolicy = "isolated",
+	readPolicy: AgentRosterReadPolicy = "isolated",
 	policyGroup: string | null = null,
 ): ScoredMemory[] {
 	if (!existsSync(memoryDbPath)) return [];
@@ -247,7 +248,7 @@ export function getPredictedContextMemories(
 	charBudget: number,
 	excludeIds: ReadonlySet<string>,
 	agentId: string,
-	readPolicy = "isolated",
+	readPolicy: AgentRosterReadPolicy = "isolated",
 	policyGroup: string | null = null,
 ): ScoredMemory[] {
 	if (!existsSync(memoryDbPath)) return [];

--- a/platform/daemon/src/memory-search.ts
+++ b/platform/daemon/src/memory-search.ts
@@ -14,13 +14,14 @@
 
 import { createHash } from "node:crypto";
 import {
+	type AgentRosterReadPolicy,
 	LEGACY_OBSIDIAN_CHUNK_SOURCE_TYPE,
 	type LlmUsage,
 	type RecallTemporalMeta,
 	SOURCE_CHUNK_SOURCE_TYPE,
 	vectorSearch,
 } from "@signet/core";
-import { getDbAccessor } from "./db-accessor";
+import { getDbAccessor, prepareTypedStatement } from "./db-accessor";
 import { getLlmProvider } from "./llm";
 import { logger } from "./logger";
 import { buildAgentScopeClause } from "./memory-access-scope";
@@ -64,7 +65,7 @@ export interface RecallParams {
 	save_aggregate?: boolean;
 	agentId?: string;
 	/** Agent read policy — 'isolated' | 'shared' | 'group'. When set with agentId, filters by visibility. */
-	readPolicy?: string;
+	readPolicy?: AgentRosterReadPolicy;
 	/** Policy group name (required when readPolicy is 'group'). */
 	policyGroup?: string | null;
 	type?: string;
@@ -1247,7 +1248,7 @@ export async function hybridRecall(
 		sessionKey: params.sessionKey,
 	});
 	if (temporal.response) {
-		return await finish(temporal.response);
+		return await finish({ ...temporal.response, results: [...temporal.response.results] });
 	}
 	if (temporal.adjustedQuery) {
 		query = temporal.adjustedQuery;
@@ -1303,8 +1304,9 @@ export async function hybridRecall(
 			getDbAccessor().withReadDb((db) => {
 				// CROSS JOIN keeps SQLite from scanning memories first via
 				// low-selectivity filters before applying the FTS rowid match.
-				const ftsRows = (
-					db.prepare(`
+				const ftsRows = prepareTypedStatement<{ id: string; raw_score: number }>(
+					db,
+					`
         SELECT m.id, bm25(memories_fts) AS raw_score
         FROM memories_fts
         CROSS JOIN memories m ON memories_fts.rowid = m.rowid
@@ -1313,11 +1315,8 @@ export async function hybridRecall(
           ${memorySupersessionSql(db)}${filter.sql}
         ORDER BY raw_score
         LIMIT ?
-      `) as any
-				).all(keywordQuery, ...filter.args, cfg.search.top_k) as Array<{
-					id: string;
-					raw_score: number;
-				}>;
+      `,
+				).all(keywordQuery, ...filter.args, cfg.search.top_k);
 
 				// Min-max normalize BM25 scores to [0,1] within the batch
 				const rawScores = ftsRows.map((r) => Math.abs(r.raw_score));
@@ -1358,10 +1357,7 @@ export async function hybridRecall(
 					const agentId = params.agentId ?? "default";
 					const args = [keywordQuery, agentId, ...filter.args, cfg.search.top_k];
 
-					const rows = (db.prepare(sql) as any).all(...args) as Array<{
-						id: string;
-						raw_score: number;
-					}>;
+					const rows = prepareTypedStatement<{ id: string; raw_score: number }>(db, sql).all(...args);
 
 					// Normalize hint scores the same way as memory FTS
 					const rawScores = rows.map((r) => Math.abs(r.raw_score));
@@ -1407,11 +1403,11 @@ export async function hybridRecall(
 		try {
 			timings.time("vector_search", () => {
 				getDbAccessor().withReadDb((db) => {
-					const vecResults = vectorSearch(db as any, queryVector, {
+					const vecResults = vectorSearch(db, queryVector, {
 						limit: vecLimit,
-						type: params.type as "fact" | "preference" | "decision" | undefined,
-						excludeAggregateRecall,
-					});
+					type: params.type,
+					excludeAggregateRecall,
+				});
 					for (const r of vecResults) {
 						vectorMap.set(r.id, r.score);
 					}

--- a/platform/daemon/src/memory-timeline.ts
+++ b/platform/daemon/src/memory-timeline.ts
@@ -1,4 +1,5 @@
-import type { ReadDb } from "./db-accessor";
+import type { AgentRosterReadPolicy } from "@signet/core";
+import { type ReadDb, prepareTypedStatement } from "./db-accessor";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
@@ -227,7 +228,7 @@ export function buildMemoryTimeline(
 		readonly tzOffsetMin?: number;
 		/** Optional agent scope filter (undefined = all). */
 		readonly agentId?: string;
-		readonly readPolicy?: string;
+		readonly readPolicy?: AgentRosterReadPolicy;
 		readonly policyGroup?: string;
 	},
 ): MemoryTimelineResponse {
@@ -261,26 +262,24 @@ export function buildMemoryTimeline(
 	}
 	const scopeSql = scopePredicates.length > 0 ? ` AND ${scopePredicates.join(" AND ")}` : "";
 
-	const memoryRows = db
-		.prepare(
-			`SELECT id, created_at, type, who, tags, importance, pinned
+	const memoryRows = prepareTypedStatement<MemoryRow>(
+		db,
+		`SELECT id, created_at, type, who, tags, importance, pinned
 			 FROM memories
 			 WHERE is_deleted = 0
 			   AND created_at >= ?${scopeSql}
 			 ORDER BY created_at DESC`,
-		)
-		.all(cutoffIso, ...scopeParams) as MemoryRow[];
+	).all(cutoffIso, ...scopeParams);
 
-	const historyRows = db
-		.prepare(
-			`SELECT h.memory_id, h.event, h.reason, h.created_at
+	const historyRows = prepareTypedStatement<HistoryRow>(
+		db,
+		`SELECT h.memory_id, h.event, h.reason, h.created_at
 			 FROM memory_history h
 			 INNER JOIN memories m ON m.id = h.memory_id
 			 WHERE m.is_deleted = 0
 			   AND h.created_at >= ?${scopeSql.replace(/(?<!\.)agent_id/g, "m.agent_id").replace(/(?<=AND |\()visibility/g, "m.visibility")}
 			 ORDER BY h.created_at DESC`,
-		)
-		.all(cutoffIso, ...scopeParams) as HistoryRow[];
+	).all(cutoffIso, ...scopeParams);
 
 	let invalidMemoryTimestamps = 0;
 	let invalidHistoryTimestamps = 0;

--- a/platform/daemon/src/routes/hooks-routes.ts
+++ b/platform/daemon/src/routes/hooks-routes.ts
@@ -43,7 +43,7 @@ import { getInferenceRouterOrNull } from "../inference-router";
 import { logger } from "../logger";
 import { loadMemoryConfig } from "../memory-config";
 import { writeCompactionArtifact } from "../memory-lineage.js";
-import { hybridRecall } from "../memory-search";
+import { type RecallParams, hybridRecall } from "../memory-search";
 import { getSynthesisWorker, readLastSynthesisTime } from "../pipeline";
 import { isNoiseSession } from "../session-noise";
 import { advanceRecallContextEpoch } from "../session-recall-dedupe";
@@ -684,14 +684,14 @@ function registerRecall(app: Hono): void {
 			const scopedP = resolveScopedProject(c, requestedProject);
 			if (scopedP.error) return c.json({ error: scopedP.error }, 403);
 			const project = scopedP.project ?? requestedProject;
-			const params = {
+			const params: RecallParams = {
 				query: body.query,
 				keywordQuery: body.keywordQuery,
 				limit: body.limit,
 				project,
 				aggregate: body.aggregate,
-				aggregateBudget,
-				aggregate_budget: aggregateBudget,
+				aggregateBudget: aggregateBudget ?? undefined,
+				aggregate_budget: aggregateBudget ?? undefined,
 				saveAggregate: body.saveAggregate ?? body.save_aggregate,
 				save_aggregate: body.save_aggregate ?? body.saveAggregate,
 				type: body.type,
@@ -699,7 +699,7 @@ function registerRecall(app: Hono): void {
 				who: body.who,
 				since: body.since,
 				until: body.until,
-				time: body.time,
+				time: body.time as RecallParams["time"],
 				expand: body.expand,
 				agentId,
 				readPolicy: agentScope.readPolicy,
@@ -951,12 +951,12 @@ function registerCompactionComplete(app: Hono): void {
 				sessionKey: body.sessionKey,
 				agentId,
 				reason: "compaction-complete",
-				sourceRef: summaryId ?? body.sessionKey ?? null,
+				sourceRef: summaryId ?? body.sessionKey ?? undefined,
 			});
 			resetSessionStartDedupe({
 				harness: body.harness,
 				agentId,
-				project,
+				project: project ?? undefined,
 				sessionKey: body.sessionKey,
 			});
 

--- a/platform/daemon/src/routes/memory-routes.ts
+++ b/platform/daemon/src/routes/memory-routes.ts
@@ -8,7 +8,7 @@ import { ensureAgentRegistered, getAgentScope, resolveAgentId } from "../agent-i
 import { aggregateRecall, parseAggregateRecallBudget, readAggregateRecallBudgetInput } from "../aggregate-recall";
 import { checkScope, requirePermission, requireRateLimit } from "../auth";
 import { normalizeAndHashContent } from "../content-normalization";
-import { type WriteDb, getDbAccessor } from "../db-accessor";
+import { type ReadDb, type WriteDb, getDbAccessor, prepareTypedStatement } from "../db-accessor";
 import { syncVecDeleteBySourceId, syncVecInsert, vectorToBlob } from "../db-helpers";
 import { fetchEmbedding } from "../embedding-fetch";
 import { buildEmbeddingHealth } from "../embedding-health";
@@ -368,7 +368,7 @@ function scopedContentHashPredicate(input: RememberDedupeScope): {
 }
 
 function getScopedIdempotencyMemoryId(
-	db: WriteDb,
+	db: ReadDb | WriteDb,
 	key: string | undefined,
 	input: RememberDedupeScope,
 ): RememberDedupeIdRow | undefined {
@@ -385,7 +385,7 @@ function getScopedIdempotencyMemoryId(
 }
 
 function getScopedIdempotencyDedupeRow(
-	db: WriteDb,
+	db: ReadDb | WriteDb,
 	key: string | undefined,
 	input: RememberDedupeScope,
 ): RememberDedupeRow | undefined {
@@ -402,7 +402,7 @@ function getScopedIdempotencyDedupeRow(
 }
 
 function getScopedSourceDedupeRow(
-	db: WriteDb,
+	db: ReadDb | WriteDb,
 	sourceType: string,
 	sourceId: string,
 	input: RememberDedupeScope,
@@ -419,7 +419,7 @@ function getScopedSourceDedupeRow(
 }
 
 function getScopedContentHashMemoryId(
-	db: WriteDb,
+	db: ReadDb | WriteDb,
 	contentHash: string,
 	input: RememberDedupeScope,
 ): { readonly id: string } | undefined {
@@ -440,7 +440,7 @@ function isMemoryContentHashUniqueError(err: unknown): boolean {
 }
 
 function getScopedContentHashDedupeRow(
-	db: WriteDb,
+	db: ReadDb | WriteDb,
 	contentHash: string,
 	input: RememberDedupeScope,
 ): RememberDedupeRow | undefined {
@@ -456,21 +456,19 @@ function getScopedContentHashDedupeRow(
 }
 
 function getScopedChunkIdempotencyRows(
-	db: WriteDb,
+	db: ReadDb | WriteDb,
 	baseKey: string | undefined,
 	input: RememberDedupeScope,
 ): readonly RememberChunkDedupeRow[] {
 	if (!baseKey) return [];
 	const scoped = scopedMemoryPredicate(input);
-	return (
-		db
-			.prepare(
-				`SELECT id, source_id AS sourceId, content_hash AS contentHash, idempotency_key AS idempotencyKey
-				 FROM memories
-				 WHERE idempotency_key LIKE ? ESCAPE '\\' AND ${scoped.sql} AND is_deleted = 0`,
-			)
-			.all(`${escapeSqlLike(baseKey)}:chunk:%`, ...scoped.params) as RememberChunkDedupeRow[]
+	return prepareTypedStatement<RememberChunkDedupeRow>(
+		db,
+		`SELECT id, source_id AS sourceId, content_hash AS contentHash, idempotency_key AS idempotencyKey
+			 FROM memories
+			 WHERE idempotency_key LIKE ? ESCAPE '\\' AND ${scoped.sql} AND is_deleted = 0`,
 	)
+		.all(`${escapeSqlLike(baseKey)}:chunk:%`, ...scoped.params)
 		.filter((row) => chunkIdempotencyIndex(baseKey, row.idempotencyKey) !== null)
 		.sort((left, right) => {
 			const leftIndex = chunkIdempotencyIndex(baseKey, left.idempotencyKey);
@@ -479,7 +477,7 @@ function getScopedChunkIdempotencyRows(
 		});
 }
 
-function hasMemoriesSessionIdColumn(db: any): boolean {
+function hasMemoriesSessionIdColumn(db: ReadDb | WriteDb): boolean {
 	if (hasMemoriesSessionIdColumnCache !== null) {
 		return hasMemoriesSessionIdColumnCache;
 	}
@@ -1010,8 +1008,9 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					// FTS path
 					const { clause, args } = buildWhere(filterParams);
 					try {
-						rows = (
-							db.prepare(`
+						rows = prepareTypedStatement<Record<string, unknown>>(
+							db,
+							`
             SELECT m.id, m.content, m.created_at, m.who, m.importance, m.tags,
                    m.type, m.pinned, bm25(memories_fts) as score
             FROM memories_fts
@@ -1019,26 +1018,28 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
             WHERE memories_fts MATCH ?${clause}
             ORDER BY score
             LIMIT ${limit ?? 20}
-          `) as any
+          `,
 						).all(query, ...args);
 					} catch {
 						// FTS not available — fall back to LIKE
 						const { clause: rc, args: rargs } = buildWhereRaw(filterParams);
-						rows = (
-							db.prepare(`
+						rows = prepareTypedStatement<Record<string, unknown>>(
+							db,
+							`
             SELECT id, content, created_at, who, importance, tags, type, pinned
             FROM memories
             WHERE (content LIKE ? OR tags LIKE ?)${rc}
             ORDER BY created_at DESC
             LIMIT ${limit ?? 20}
-          `) as any
+          `,
 						).all(`%${query}%`, `%${query}%`, ...rargs);
 					}
 				} else if (hasFilters) {
 					// Pure filter path
 					const { clause, args } = buildWhereRaw(filterParams);
-					rows = (
-						db.prepare(`
+					rows = prepareTypedStatement<Record<string, unknown>>(
+						db,
+						`
           SELECT id, content, created_at, who, importance, tags, type, pinned,
                  CASE WHEN pinned = 1 THEN 1.0
                       ELSE importance * MAX(0.1, POWER(0.95,
@@ -1048,7 +1049,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
           WHERE 1=1${clause}
           ORDER BY score DESC
           LIMIT ${limit ?? 50}
-        `) as any
+        `,
 					).all(...args);
 				}
 
@@ -1187,8 +1188,8 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		}
 
 		ensureAgentRegistered(agentId);
-		const visibility = body.visibility === "private" ? "private" : "global";
-		const dedupeScope = { agentId, visibility, project: body.project ?? null, scope };
+		const visibility: RememberDedupeScope["visibility"] = body.visibility === "private" ? "private" : "global";
+		const dedupeScope: RememberDedupeScope = { agentId, visibility, project: body.project ?? null, scope };
 		const hasBodyTags = Object.prototype.hasOwnProperty.call(body, "tags");
 		const bodyTags = hasBodyTags ? parseTagsMutation(body.tags) : undefined;
 		if (hasBodyTags && bodyTags === undefined) {
@@ -1853,7 +1854,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const body = await c.req.json().catch(() => ({}));
 		const headers: Record<string, string> = { "Content-Type": "application/json" };
 		const authHdr = c.req.header("authorization");
-		if (authHdr) headers["authorization"] = authHdr;
+		if (authHdr) headers.authorization = authHdr;
 		const sessionKey = c.req.header("x-signet-session-key");
 		if (sessionKey) headers["x-signet-session-key"] = sessionKey;
 		return fetch(`http://${INTERNAL_SELF_HOST}:${PORT}/api/memory/remember`, {
@@ -1870,7 +1871,7 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 		const body = await c.req.json().catch(() => ({}));
 		const headers: Record<string, string> = { "Content-Type": "application/json" };
 		const authHdr = c.req.header("authorization");
-		if (authHdr) headers["authorization"] = authHdr;
+		if (authHdr) headers.authorization = authHdr;
 		const sessionKey = c.req.header("x-signet-session-key");
 		if (sessionKey) headers["x-signet-session-key"] = sessionKey;
 		return fetch(`http://${INTERNAL_SELF_HOST}:${PORT}/api/memory/remember`, {
@@ -2927,8 +2928,8 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				...body,
 				query,
 				aggregate: body.aggregate,
-				aggregateBudget,
-				aggregate_budget: aggregateBudget,
+				aggregateBudget: aggregateBudget ?? undefined,
+				aggregate_budget: aggregateBudget ?? undefined,
 				saveAggregate: body.saveAggregate ?? body.save_aggregate,
 				save_aggregate: body.save_aggregate ?? body.saveAggregate,
 				agentId,
@@ -3063,9 +3064,9 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 					),
 				);
 
-				return vectorSearch(db as any, queryVector, {
+				return vectorSearch(db, queryVector, {
 					limit: k + 1,
-					type: type as "fact" | "preference" | "decision" | undefined,
+					type,
 				});
 			});
 
@@ -3470,13 +3471,12 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 
 			const result = accessor.withWriteTx((db) => {
 				if (sourceUrl) {
-					const candidates = db
-						.prepare(
-							`SELECT id, status, agent_id, project FROM documents
+					const candidates = prepareTypedStatement<{ id: string; status: string } & DocumentScopeRow>(
+						db,
+						`SELECT id, status, agent_id, project FROM documents
 							 WHERE source_url = ?
 							   AND status NOT IN ('failed', 'deleted')`,
-						)
-						.all(sourceUrl) as ReadonlyArray<{ id: string; status: string } & DocumentScopeRow>;
+					).all(sourceUrl);
 					const existing = candidates.find((candidate) =>
 						documentScopeMatches(candidate, {
 							agentId: scopedAgent.agentId,
@@ -3690,9 +3690,10 @@ export function registerMemoryRoutes(app: Hono, deps: MemoryRoutesDeps = {}): vo
 				).run(`Document deleted: ${reason}`, now, now, id);
 
 				let removed = 0;
-				const linkedMemories = db
-					.prepare(linkedMemorySql)
-					.all(id, ...(enforceScope ? delScopeArgs : [])) as ReadonlyArray<{ memory_id: string }>;
+				const linkedMemories = prepareTypedStatement<{ memory_id: string }>(db, linkedMemorySql).all(
+					id,
+					...(enforceScope ? delScopeArgs : []),
+				);
 				for (const link of linkedMemories) {
 					const mem = db.prepare("SELECT is_deleted FROM memories WHERE id = ?").get(link.memory_id) as
 						| { is_deleted: number }

--- a/platform/daemon/src/temporal-recall.ts
+++ b/platform/daemon/src/temporal-recall.ts
@@ -1,4 +1,4 @@
-import type { RecallTemporalMeta, TemporalFacet } from "@signet/core";
+import type { AgentRosterReadPolicy, RecallTemporalMeta, TemporalFacet } from "@signet/core";
 import { getDbAccessor } from "./db-accessor";
 import { buildAgentScopeClause } from "./memory-access-scope";
 
@@ -78,7 +78,7 @@ export interface TemporalRecallParams {
 	readonly time?: TemporalTimeOptions;
 	readonly limit: number;
 	readonly agentId?: string;
-	readonly readPolicy?: string;
+	readonly readPolicy?: AgentRosterReadPolicy;
 	readonly policyGroup?: string | null;
 	readonly project?: string;
 	readonly sessionKey?: string;


### PR DESCRIPTION
## Summary
- Thread `AgentRosterReadPolicy` through recall/scope call paths instead of plain strings
- Add a typed SQLite statement helper and replace focused `as any` casts in recall/search code
- Preserve public memory type filters by widening core search type options to `string`

## Validation
- `bunx biome check platform/core/src/index.ts platform/core/src/search.ts platform/daemon/src/agent-id.ts platform/daemon/src/db-accessor.ts platform/daemon/src/hooks.ts platform/daemon/src/memory-access-scope.ts platform/daemon/src/memory-candidates.ts platform/daemon/src/memory-search.ts platform/daemon/src/memory-timeline.ts platform/daemon/src/routes/hooks-routes.ts platform/daemon/src/routes/memory-routes.ts platform/daemon/src/temporal-recall.ts`
- `cd platform/core && bun run build`
- `bun test platform/daemon/src/memory-search.test.ts platform/daemon/src/memory-timeline.test.ts`
- `bun test platform/daemon/src/hooks.prompt-submit.test.ts`
- `autoreview` clean after preserving public type-filter behavior

## Notes
- `cd platform/daemon && bun run build:types` still fails on pre-existing broad daemon typing issues; the checked output had no errors in the changed files after this patch.
