### PR TITLE
fix(openclaw): surface Signet health diagnostics

### DIFF
--- a/integrations/openclaw/memory-adapter/src/index.test.ts
+++ b/integrations/openclaw/memory-adapter/src/index.test.ts
@@ -36,6 +36,7 @@ let lastPromptSubmitBody: unknown = null;
 let lastMemoryRecallBody: unknown = null;
 let lastSessionSearchBody: unknown = null;
 let lastCheckpointBody: unknown = null;
+let lastHeartbeatBody: unknown = null;
 let warnMessages: string[] = [];
 let testDir = "";
 
@@ -140,6 +141,7 @@ beforeEach(() => {
 	lastMemoryRecallBody = null;
 	lastSessionSearchBody = null;
 	lastCheckpointBody = null;
+	lastHeartbeatBody = null;
 	checkpointResponse = null;
 	warnMessages = [];
 	testDir = mkdtempSync(join(tmpdir(), "signet-openclaw-test-"));
@@ -155,6 +157,9 @@ beforeEach(() => {
 			switch (path) {
 				case "/health":
 					return jsonResponse({ pid: 1234 });
+				case "/api/diagnostics/openclaw/heartbeat":
+					lastHeartbeatBody = init?.body ? JSON.parse(String(init.body)) : null;
+					return jsonResponse({ ok: true });
 				case "/api/hooks/session-start":
 					if (timeoutSessionStartCount > 0) {
 						timeoutSessionStartCount -= 1;
@@ -1823,6 +1828,17 @@ describe("registration guard (#422)", () => {
 		expect(tools.length).toBeGreaterThan(0);
 		expect(hooks.size).toBeGreaterThan(0);
 		expect(registeredServices.length).toBeGreaterThan(0);
+	});
+
+	it("publishes an OpenClaw diagnostics heartbeat after startup health succeeds", async () => {
+		const { api } = createMockApi({ registrationMode: "full", version: "test-plugin" });
+		signetPlugin.register(api);
+		await Bun.sleep(0);
+
+		expect(lastHeartbeatBody).toMatchObject({
+			pluginVersion: "test-plugin",
+			hooksRegistered: ["before_prompt_build", "before_agent_start", "agent_end", "before_compaction", "after_compaction"],
+		});
 	});
 
 	it("second full-mode register() call is a no-op", () => {

--- a/integrations/openclaw/memory-adapter/src/index.ts
+++ b/integrations/openclaw/memory-adapter/src/index.ts
@@ -40,6 +40,8 @@ const DEFAULT_DAEMON_URL = "http://localhost:3850";
 const RUNTIME_PATH = "plugin" as const;
 const READ_TIMEOUT = 5000;
 const WRITE_TIMEOUT = 10000;
+const HEARTBEAT_TIMEOUT = 2000;
+const HEARTBEAT_INTERVAL_MS = 60_000;
 const COMPACTION_HOOK_DEDUPE_MS = 1000;
 const SESSION_START_TIMEOUT = resolveSessionStartTimeoutMs(
 	process.env.SIGNET_SESSION_START_TIMEOUT ?? process.env.SIGNET_FETCH_TIMEOUT,
@@ -1549,6 +1551,38 @@ const signetPlugin = {
 			let healthTimer: ReturnType<typeof setInterval> | null = null;
 			let marketplaceProxyTimer: ReturnType<typeof setInterval> | null = null;
 			const marketplaceProxyNames = new Set<string>();
+			const hooksRegistered = [
+				"before_prompt_build",
+				"before_agent_start",
+				"agent_end",
+				"before_compaction",
+				"after_compaction",
+			];
+			let healthError: string | null = null;
+			let heartbeatInFlight = false;
+
+			const pluginVersion = typeof api.version === "string" && api.version.trim() ? api.version : "unknown";
+			const sendHeartbeat = async (): Promise<void> => {
+				if (heartbeatInFlight) return;
+				heartbeatInFlight = true;
+				try {
+					await daemonFetchResult<{ ok: boolean }>(daemonUrl, "/api/diagnostics/openclaw/heartbeat", {
+						method: "POST",
+						body: {
+							pluginVersion,
+							hooksRegistered,
+							lastHookCall: null,
+							lastError: healthError,
+							latencyMs: 0,
+							hooksSucceeded: 0,
+							hooksFailed: healthError ? 1 : 0,
+						},
+						timeout: HEARTBEAT_TIMEOUT,
+					});
+				} finally {
+					heartbeatInFlight = false;
+				}
+			};
 
 			api.logger.info(`signet-memory: registered (daemon: ${daemonUrl})`);
 
@@ -1557,9 +1591,13 @@ const signetPlugin = {
 				daemonReachable = pid !== null;
 				knownPid = pid;
 				if (!daemonReachable) {
+					healthError = `daemon unreachable at ${daemonUrl}; memory hooks are disabled until Signet is healthy`;
 					api.logger.warn(
-						`signet-memory: daemon unreachable at ${daemonUrl}. Memory tools will silently no-op until daemon is running.`,
+						`signet-memory: daemon unreachable at ${daemonUrl}. Memory hooks are disabled until daemon health recovers; run \`signet status\` or \`signet doctor\` for diagnostics.`,
 					);
+				} else {
+					healthError = null;
+					void sendHeartbeat();
 				}
 			});
 
@@ -2509,10 +2547,15 @@ const signetPlugin = {
 						if (ok !== daemonReachable) {
 							daemonReachable = ok;
 							if (ok) {
+								healthError = null;
 								api.logger.info("signet-memory: daemon reconnected");
+								void sendHeartbeat();
 							} else {
-								api.logger.warn("signet-memory: daemon became unreachable");
+								healthError = `daemon became unreachable at ${daemonUrl}; memory hooks are disabled`;
+								api.logger.warn("signet-memory: daemon became unreachable; memory hooks are disabled until health recovers");
 							}
+						} else if (ok) {
+							void sendHeartbeat();
 						}
 						// Daemon restarted (PID changed). Evict all claimed sessions so
 						// ensureSessionStarted re-inits on next turn, restoring identity
@@ -2522,7 +2565,7 @@ const signetPlugin = {
 							claimedSessions.clear();
 						}
 						knownPid = pid;
-					}, 60_000);
+					}, HEARTBEAT_INTERVAL_MS);
 				},
 				stop() {
 					api.logger.info("signet-memory: service stopped");

--- a/integrations/openclaw/memory-adapter/src/openclaw-types.ts
+++ b/integrations/openclaw/memory-adapter/src/openclaw-types.ts
@@ -75,6 +75,7 @@ export type PluginRegistrationMode = "full" | "setup-only" | "setup-runtime" | "
 export interface OpenClawPluginApi {
 	readonly pluginConfig?: Record<string, unknown>;
 	readonly config?: unknown;
+	readonly version?: string;
 	readonly registrationMode?: PluginRegistrationMode;
 	readonly logger: {
 		info(msg: string): void;

--- a/surfaces/cli/src/features/health.test.ts
+++ b/surfaces/cli/src/features/health.test.ts
@@ -368,6 +368,80 @@ describe("status report openclaw runtime", () => {
 		}
 	});
 
+	it("doctor reports OpenClaw stale heartbeat", async () => {
+		const root = mkdtempSync(join(tmpdir(), "health-runtime-"));
+		const workspace = join(root, "agents");
+		const lines: string[] = [];
+		const oldLog = console.log;
+		try {
+			process.env.HOME = root;
+			mkdirSync(workspace, { recursive: true });
+			writeFileSync(join(workspace, "AGENTS.md"), "# src\n");
+			writeFileSync(join(workspace, "agent.yaml"), "version: 1\n");
+			writeFileSync(join(workspace, "SOUL.md"), "soul\n");
+			writeFileSync(join(workspace, "IDENTITY.md"), "identity\n");
+			writeFileSync(join(workspace, "USER.md"), "user\n");
+			writeFileSync(join(workspace, "MEMORY.md"), "memory\n");
+			const cfgPath = join(root, "openclaw.json");
+			writeFileSync(
+				cfgPath,
+				JSON.stringify({
+					plugins: {
+						slots: { memory: "signet-memory-openclaw" },
+						entries: { "signet-memory-openclaw": { enabled: true } },
+					},
+				}),
+			);
+			process.env.OPENCLAW_CONFIG_PATH = cfgPath;
+			console.log = (...args: unknown[]) => {
+				lines.push(args.join(" "));
+			};
+
+			await showDoctor(
+				{},
+				{
+					...depsFor(workspace),
+					getDaemonStatus: async () => ({
+						running: true,
+						pid: 42,
+						uptime: 10,
+						version: "0.145.1",
+						host: "127.0.0.1",
+						bindHost: "127.0.0.1",
+						networkMode: "local",
+						extraction: null,
+						extractionWorker: null,
+						transcripts: null,
+						probe: {
+							status: "healthy",
+							detail: "/health responded",
+							url: "http://127.0.0.1:3850",
+							listenerPresent: true,
+							processPid: 42,
+							stalePid: null,
+						},
+						openclaw: {
+							status: "stale",
+							lastHeartbeat: "2026-06-25T00:00:00.000Z",
+							pluginVersion: "test-plugin",
+							hooksRegistered: ["before_prompt_build"],
+							hooksSucceeded: 1,
+							hooksFailed: 1,
+							lastLatencyMs: 42,
+							lastError: "daemon returned no prompt memory injection",
+						},
+					}),
+				},
+			);
+
+			const output = lines.join("\n");
+			expect(output).toContain("OpenClaw plugin heartbeat is stale");
+		} finally {
+			console.log = oldLog;
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("doctor warns when openclaw is still on the legacy-only runtime path", async () => {
 		const root = mkdtempSync(join(tmpdir(), "health-runtime-"));
 		const workspace = join(root, "agents");

--- a/surfaces/cli/src/features/health.ts
+++ b/surfaces/cli/src/features/health.ts
@@ -45,6 +45,24 @@ interface DaemonStatus {
 		readonly failed: number;
 		readonly dead: number;
 	} | null;
+	readonly probe?: {
+		readonly status: "healthy" | "listener-unhealthy" | "process-unhealthy" | "stale-artifact" | "absent";
+		readonly detail: string;
+		readonly url: string | null;
+		readonly listenerPresent: boolean;
+		readonly processPid: number | null;
+		readonly stalePid: number | null;
+	};
+	readonly openclaw?: {
+		readonly status: "connected" | "stale" | "never-seen";
+		readonly lastHeartbeat: string | null;
+		readonly pluginVersion: string | null;
+		readonly hooksRegistered: readonly string[];
+		readonly hooksSucceeded: number;
+		readonly hooksFailed: number;
+		readonly lastLatencyMs: number;
+		readonly lastError: string | null;
+	} | null;
 }
 
 interface DbReport {
@@ -220,8 +238,20 @@ export async function showStatus(options: { path?: string; json?: boolean }, dep
 			console.log(colorize(`    ${icon} ${extractionNotice.title}`));
 			console.log(chalk.dim(`      ${extractionNotice.detail}`));
 		}
+		if (report.daemon.openclaw && report.openclawRuntime === "plugin") {
+			const icon =
+				report.daemon.openclaw.status === "connected"
+					? chalk.green("✓")
+					: report.daemon.openclaw.status === "stale"
+						? chalk.yellow("⚠")
+						: chalk.yellow("◐");
+			console.log(`    ${icon} OpenClaw plugin ${report.daemon.openclaw.status}`);
+		}
 	} else {
 		console.log(`  ${chalk.red("○")} Daemon ${chalk.red("stopped")}`);
+		if (report.daemon.probe && report.daemon.probe.status !== "absent") {
+			console.log(chalk.dim(`    ${report.daemon.probe.detail}`));
+		}
 	}
 
 	console.log();
@@ -400,6 +430,95 @@ async function showHermesDoctor(options: { json?: boolean }): Promise<void> {
 	console.log();
 }
 
+function addDaemonProbeFindings(report: StatusReport, findings: DoctorFinding[]): void {
+	const probe = report.daemon.probe;
+	if (!probe || probe.status === "healthy") return;
+
+	if (probe.status === "listener-unhealthy") {
+		findings.push({
+			level: "error",
+			message: "Daemon port is listening, but /health is unreachable.",
+			fix: "Run `signet daemon restart`; if it recurs, inspect ~/.agents/.daemon/logs/daemon.err.log.",
+		});
+		return;
+	}
+
+	if (probe.status === "process-unhealthy") {
+		findings.push({
+			level: "error",
+			message: "Daemon process exists, but the HTTP health endpoint is unreachable.",
+			fix: "Run `signet daemon restart`; if it hangs, stop the stale process and inspect daemon logs.",
+		});
+		return;
+	}
+
+	if (probe.status === "stale-artifact") {
+		findings.push({
+			level: "warn",
+			message: "Daemon pid artifact is stale.",
+			fix: "Run `signet daemon start`; stale pid files are ignored by current status probes.",
+		});
+	}
+}
+
+function addOpenClawRuntimeFindings(report: StatusReport, findings: DoctorFinding[]): void {
+	if (report.openclawRuntime === "dual") {
+		findings.push({
+			level: "error",
+			message:
+				"OpenClaw dual-system conflict: legacy hook AND plugin are both enabled. This causes duplicate memories, 2× token burn, and 409 session errors.",
+			fix: 'Run `signet setup --harness openclaw` to repair, or set hooks.internal.entries["signet-memory"].enabled = false in your openclaw config.',
+		});
+	}
+
+	if (report.openclawRuntime === "legacy") {
+		findings.push({
+			level: "warn",
+			message:
+				"OpenClaw is still running on the legacy Signet hook path. Manual commands still work, but session-start, prompt-submit, compaction, and session-end capture stay disabled.",
+			fix: "Run `signet sync` to migrate this OpenClaw config to the plugin runtime path.",
+		});
+	}
+}
+
+function addOpenClawHeartbeatFindings(report: StatusReport, findings: DoctorFinding[]): void {
+	if (!report.daemon.running || report.openclawRuntime !== "plugin") return;
+	const health = report.daemon.openclaw;
+	if (!health) {
+		findings.push({
+			level: "warn",
+			message: "OpenClaw plugin path is configured, but daemon OpenClaw diagnostics are unavailable.",
+			fix: "Update/restart the Signet daemon, then rerun `signet doctor` to verify plugin heartbeat state.",
+		});
+		return;
+	}
+
+	if (health.status === "never-seen") {
+		findings.push({
+			level: "warn",
+			message: "OpenClaw plugin path is configured, but the Signet daemon has not seen a plugin heartbeat.",
+			fix: "Restart OpenClaw so the signet-memory plugin can register, then rerun `signet doctor`.",
+		});
+		return;
+	}
+
+	if (health.status === "stale") {
+		findings.push({
+			level: "warn",
+			message: "OpenClaw plugin heartbeat is stale.",
+			fix: "Restart OpenClaw or check its plugin logs for signet-memory registration errors.",
+		});
+	}
+
+	if (health.lastError) {
+		findings.push({
+			level: "warn",
+			message: `OpenClaw plugin reported degraded Signet hook activity: ${health.lastError}`,
+			fix: "Check the daemon logs and OpenClaw plugin logs for the failing hook or subsystem.",
+		});
+	}
+}
+
 function getDoctorFindings(report: StatusReport): DoctorFinding[] {
 	if (!report.installed) {
 		return [
@@ -441,11 +560,14 @@ function getDoctorFindings(report: StatusReport): DoctorFinding[] {
 	}
 
 	if (!report.daemon.running) {
-		findings.push({
-			level: "warn",
-			message: "Daemon is not running.",
-			fix: "Run `signet daemon start`.",
-		});
+		addDaemonProbeFindings(report, findings);
+		if (!report.daemon.probe || report.daemon.probe.status === "absent") {
+			findings.push({
+				level: "warn",
+				message: "Daemon is not running.",
+				fix: "Run `signet daemon start`.",
+			});
+		}
 	}
 
 	if (report.db.needsMigration && report.db.schema) {
@@ -464,23 +586,8 @@ function getDoctorFindings(report: StatusReport): DoctorFinding[] {
 		});
 	}
 
-	if (report.openclawRuntime === "dual") {
-		findings.push({
-			level: "error",
-			message:
-				"OpenClaw dual-system conflict: legacy hook AND plugin are both enabled. This causes duplicate memories, 2× token burn, and 409 session errors.",
-			fix: 'Run `signet setup --harness openclaw` to repair, or set hooks.internal.entries["signet-memory"].enabled = false in your openclaw config.',
-		});
-	}
-
-	if (report.openclawRuntime === "legacy") {
-		findings.push({
-			level: "warn",
-			message:
-				"OpenClaw is still running on the legacy Signet hook path. Manual commands still work, but session-start, prompt-submit, compaction, and session-end capture stay disabled.",
-			fix: "Run `signet sync` to migrate this OpenClaw config to the plugin runtime path.",
-		});
-	}
+	addOpenClawRuntimeFindings(report, findings);
+	addOpenClawHeartbeatFindings(report, findings);
 
 	if (report.openclawWorkspaceUnprotected) {
 		findings.push({

--- a/surfaces/cli/src/lib/runtime.test.ts
+++ b/surfaces/cli/src/lib/runtime.test.ts
@@ -369,6 +369,18 @@ describe("getDaemonStatus", () => {
 	it("parses extraction provider degradation from /api/status", async () => {
 		globalThis.fetch = async (input: string | URL) => {
 			const url = String(input);
+			if (url.endsWith("/api/diagnostics/openclaw")) {
+				return Response.json({
+					status: "connected",
+					lastHeartbeat: "2026-06-25T00:00:00.000Z",
+					pluginVersion: "test-plugin",
+					hooksRegistered: ["before_prompt_build"],
+					hooksSucceeded: 2,
+					hooksFailed: 1,
+					lastLatencyMs: 42,
+					lastError: "daemon returned no prompt memory injection",
+				});
+			}
 			if (url.endsWith("/health")) {
 				return new Response("ok", { status: 200 });
 			}
@@ -426,6 +438,16 @@ describe("getDaemonStatus", () => {
 			overloadBackoffMs: 30000,
 			overloadSince: "2026-03-26T00:00:02.000Z",
 			nextTickInMs: 28000,
+		});
+		expect(status.openclaw).toEqual({
+			status: "connected",
+			lastHeartbeat: "2026-06-25T00:00:00.000Z",
+			pluginVersion: "test-plugin",
+			hooksRegistered: ["before_prompt_build"],
+			hooksSucceeded: 2,
+			hooksFailed: 1,
+			lastLatencyMs: 42,
+			lastError: "daemon returned no prompt memory injection",
 		});
 	});
 });

--- a/surfaces/cli/src/lib/runtime.ts
+++ b/surfaces/cli/src/lib/runtime.ts
@@ -12,6 +12,7 @@ import {
 	unlinkSync,
 	writeFileSync,
 } from "node:fs";
+import { connect } from "node:net";
 import { homedir } from "node:os";
 import { basename, delimiter, dirname, join, normalize } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -23,6 +24,26 @@ import { resolveAgentsDir } from "./workspace.js";
 export const AGENTS_DIR = resolveAgentsDir().path;
 export const DEFAULT_PORT = 3850;
 const DAEMON_BASE_URLS = [`http://127.0.0.1:${DEFAULT_PORT}`, `http://[::1]:${DEFAULT_PORT}`] as const;
+
+export interface DaemonHealthProbe {
+	readonly status: "healthy" | "listener-unhealthy" | "process-unhealthy" | "stale-artifact" | "absent";
+	readonly detail: string;
+	readonly url: string | null;
+	readonly listenerPresent: boolean;
+	readonly processPid: number | null;
+	readonly stalePid: number | null;
+}
+
+export interface DaemonOpenClawHealthSummary {
+	readonly status: "connected" | "stale" | "never-seen";
+	readonly lastHeartbeat: string | null;
+	readonly pluginVersion: string | null;
+	readonly hooksRegistered: readonly string[];
+	readonly hooksSucceeded: number;
+	readonly hooksFailed: number;
+	readonly lastLatencyMs: number;
+	readonly lastError: string | null;
+}
 
 interface DaemonInstance {
 	readonly baseUrl: string;
@@ -55,6 +76,8 @@ interface DaemonInstance {
 		readonly failed: number;
 		readonly dead: number;
 	} | null;
+	readonly probe: DaemonHealthProbe;
+	readonly openclaw: DaemonOpenClawHealthSummary | null;
 }
 
 interface DaemonProbeDeps {
@@ -133,6 +156,118 @@ async function isDaemonHealthyAt(baseUrl: string): Promise<boolean> {
 	}
 }
 
+async function fetchJsonOrNull<T>(baseUrl: string, path: string): Promise<T | null> {
+	try {
+		const response = await fetch(`${baseUrl}${path}`, {
+			signal: AbortSignal.timeout(1200),
+		});
+		if (!response.ok) return null;
+		return (await response.json()) as T;
+	} catch {
+		return null;
+	}
+}
+
+function stringArray(value: unknown): string[] {
+	return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function summarizeOpenClawHealth(value: unknown): DaemonOpenClawHealthSummary | null {
+	if (!value || typeof value !== "object") return null;
+	const report = value as Record<string, unknown>;
+	const status = report.status;
+	if (status !== "connected" && status !== "stale" && status !== "never-seen") return null;
+	return {
+		status,
+		lastHeartbeat: typeof report.lastHeartbeat === "string" ? report.lastHeartbeat : null,
+		pluginVersion: typeof report.pluginVersion === "string" ? report.pluginVersion : null,
+		hooksRegistered: stringArray(report.hooksRegistered),
+		hooksSucceeded: typeof report.hooksSucceeded === "number" ? report.hooksSucceeded : 0,
+		hooksFailed: typeof report.hooksFailed === "number" ? report.hooksFailed : 0,
+		lastLatencyMs: typeof report.lastLatencyMs === "number" ? report.lastLatencyMs : 0,
+		lastError: typeof report.lastError === "string" ? report.lastError : null,
+	};
+}
+
+function canConnect(host: string, port: number, timeoutMs = 500): Promise<boolean> {
+	return new Promise((resolve) => {
+		const socket = connect({ host, port });
+		let settled = false;
+		const finish = (value: boolean) => {
+			if (settled) return;
+			settled = true;
+			socket.destroy();
+			resolve(value);
+		};
+		socket.setTimeout(timeoutMs);
+		socket.once("connect", () => finish(true));
+		socket.once("timeout", () => finish(false));
+		socket.once("error", () => finish(false));
+	});
+}
+
+function readPidArtifact(agentsDir: string): { pid: number | null; stale: boolean } {
+	const path = pidFile(agentsDir);
+	if (!existsSync(path)) return { pid: null, stale: false };
+	try {
+		const pid = Number.parseInt(readFileSync(path, "utf-8").trim(), 10);
+		if (!Number.isInteger(pid) || pid <= 0) return { pid: null, stale: true };
+		return { pid, stale: !isAlive(pid) };
+	} catch {
+		return { pid: null, stale: true };
+	}
+}
+
+async function buildUnreachableDaemonProbe(agentsDir: string): Promise<DaemonHealthProbe> {
+	const artifact = readPidArtifact(agentsDir);
+	const managedPid = readManagedDaemonPid(agentsDir);
+	const processPid = managedPid ?? findDaemonProcessPids()[0] ?? null;
+	const listenerPresent = await canConnect("127.0.0.1", DEFAULT_PORT);
+	const url = `http://127.0.0.1:${DEFAULT_PORT}`;
+
+	if (listenerPresent) {
+		return {
+			status: "listener-unhealthy",
+			detail: `TCP listener is present on ${url}, but /health did not return successfully within the probe timeout`,
+			url,
+			listenerPresent,
+			processPid,
+			stalePid: artifact.stale ? artifact.pid : null,
+		};
+	}
+
+	if (processPid !== null) {
+		return {
+			status: "process-unhealthy",
+			detail: "A Signet daemon process appears to be running, but the health endpoint is unreachable",
+			url,
+			listenerPresent,
+			processPid,
+			stalePid: artifact.stale ? artifact.pid : null,
+		};
+	}
+
+	if (artifact.stale) {
+		return {
+			status: "stale-artifact",
+			detail: "Daemon pid artifact is stale; no live Signet daemon process or healthy listener was found",
+			url,
+			listenerPresent,
+			processPid: null,
+			stalePid: artifact.pid,
+		};
+	}
+
+	return {
+		status: "absent",
+		detail: "No Signet daemon process or healthy listener was found",
+		url,
+		listenerPresent,
+		processPid: null,
+		stalePid: null,
+	};
+}
+
 export async function getReachableDaemonUrls(): Promise<string[]> {
 	const checks = await Promise.all(
 		DAEMON_BASE_URLS.map(async (baseUrl) => ((await isDaemonHealthyAt(baseUrl)) ? baseUrl : null)),
@@ -189,6 +324,7 @@ async function getDaemonInstances(): Promise<DaemonInstance[]> {
 					const extraction = data.providerResolution?.extraction;
 					const extractionWorker = data.pipeline?.extraction;
 					const transcripts = data.transcripts?.capture;
+					const openclawReport = await fetchJsonOrNull<unknown>(baseUrl, "/api/diagnostics/openclaw");
 					return {
 						baseUrl,
 						pid: data.pid ?? null,
@@ -229,6 +365,15 @@ async function getDaemonInstances(): Promise<DaemonInstance[]> {
 									dead: typeof transcripts.dead === "number" ? transcripts.dead : 0,
 								}
 							: null,
+						probe: {
+							status: "healthy",
+							detail: `/health responded successfully at ${baseUrl}`,
+							url: baseUrl,
+							listenerPresent: true,
+							processPid: data.pid ?? null,
+							stalePid: null,
+						},
+						openclaw: summarizeOpenClawHealth(openclawReport),
 					};
 				}
 			} catch {
@@ -246,6 +391,15 @@ async function getDaemonInstances(): Promise<DaemonInstance[]> {
 				extraction: null,
 				extractionWorker: null,
 				transcripts: null,
+				probe: {
+					status: "healthy",
+					detail: `/health responded successfully at ${baseUrl}; /api/status did not return full metadata`,
+					url: baseUrl,
+					listenerPresent: true,
+					processPid: null,
+					stalePid: null,
+				},
+				openclaw: null,
 			};
 		}),
 	);
@@ -358,6 +512,8 @@ export async function getDaemonStatus(): Promise<{
 	extraction: DaemonInstance["extraction"];
 	extractionWorker: DaemonInstance["extractionWorker"];
 	transcripts: DaemonInstance["transcripts"];
+	probe: DaemonHealthProbe;
+	openclaw: DaemonOpenClawHealthSummary | null;
 }> {
 	const instances = await getDaemonInstances();
 	if (instances.length > 0) {
@@ -374,12 +530,18 @@ export async function getDaemonStatus(): Promise<{
 			extraction: preferred.extraction,
 			extractionWorker: preferred.extractionWorker,
 			transcripts: preferred.transcripts,
+			probe: {
+				...preferred.probe,
+				processPid: preferred.probe.processPid ?? fallbackPid,
+			},
+			openclaw: preferred.openclaw,
 		};
 	}
 
+	const probe = await buildUnreachableDaemonProbe(AGENTS_DIR);
 	return {
 		running: false,
-		pid: null,
+		pid: probe.processPid,
 		uptime: null,
 		version: null,
 		host: null,
@@ -388,6 +550,8 @@ export async function getDaemonStatus(): Promise<{
 		extraction: null,
 		extractionWorker: null,
 		transcripts: null,
+		probe,
+		openclaw: null,
 	};
 }
 


### PR DESCRIPTION
## Summary
- make `signet status` honest about daemon health by distinguishing a healthy daemon from a stale pid, a Signet process with no healthy HTTP endpoint, and a TCP listener whose `/health` probe does not respond
- keep OpenClaw/Clawdbot/Moltbot as one integration path internally, with OpenClaw as the current canonical name
- have the OpenClaw memory adapter publish a minimal heartbeat to the existing daemon diagnostics route and log clearly when daemon health disables memory hooks
- surface OpenClaw runtime/heartbeat problems through the existing `signet doctor` flow; no new CLI command/target is added

Fixes #867.

## OpenClaw source validation
- Checked current OpenClaw source in `references/openclaw`:
  - `v2026.6.21-alpha.1` exposes `registerService`, `api.on`, `before_prompt_build`, and legacy `before_agent_start`.
- Checked older reported line in `references/openclaw`:
  - upstream/fork tags available for the reported date are `v2026.1.24` and `v2026.1.24-1`; no `v2026.1.24-3` tag exists on the checked remotes.
  - `v2026.1.24` exposes `registerService`, `api.on`, and legacy `before_agent_start`; `before_prompt_build` is absent there, so this change keeps the existing `before_agent_start` fallback compatible.

## Validation
- `PUPPETEER_SKIP_DOWNLOAD=1 bun install` in clean PR worktree
- `bun run build:core`
- `bun run --filter '@signet/sdk' build`
- `bun run build:connector-base`
- `bun run --filter '@signet/connector-openclaw' build`
- `bun run --filter '@signet/connector-hermes-agent' build`
- `cd integrations/openclaw/memory-adapter && bun test src/index.test.ts`
- `cd surfaces/cli && bun test src/lib/runtime.test.ts src/features/health.test.ts`
- `bun run --filter '@signetai/signet-memory-openclaw' build`
- `cd surfaces/cli && PUPPETEER_SKIP_DOWNLOAD=1 bun run build:workspace-deps && bun run build:cli`
- `autoreview` final simplified pass: no blockers
