### PR TITLE
fix(daemon): avoid startup reprocessing for vectors and legacy markdown

### DIFF
--- a/platform/core/src/migrations/084-legacy-markdown-import-state.ts
+++ b/platform/core/src/migrations/084-legacy-markdown-import-state.ts
@@ -1,0 +1,32 @@
+import type { MigrationDb } from "./index";
+
+export function up(db: MigrationDb): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS legacy_markdown_imports (
+			path TEXT PRIMARY KEY,
+			mtime_ms INTEGER NOT NULL,
+			ctime_ms INTEGER NOT NULL,
+			size INTEGER NOT NULL,
+			content_hash TEXT NOT NULL,
+			importer_version INTEGER NOT NULL,
+			chunk_count INTEGER NOT NULL DEFAULT 0,
+			last_imported_at TEXT NOT NULL,
+			last_seen_at TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'imported',
+			error TEXT
+		);
+
+		CREATE TABLE IF NOT EXISTS legacy_markdown_chunks (
+			file_path TEXT NOT NULL,
+			chunk_hash TEXT NOT NULL,
+			chunk_index INTEGER NOT NULL,
+			memory_id TEXT,
+			source_id TEXT,
+			created_at TEXT NOT NULL,
+			PRIMARY KEY (file_path, chunk_hash)
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_legacy_markdown_chunks_memory_id
+			ON legacy_markdown_chunks(memory_id);
+	`);
+}

--- a/platform/core/src/migrations/index.ts
+++ b/platform/core/src/migrations/index.ts
@@ -89,6 +89,7 @@ import { up as documentScopeColumns } from "./080-document-scope-columns";
 import { up as aggregateEvidenceSources } from "./081-aggregate-evidence-sources";
 import { up as skillInvocationsHarness } from "./082-skill-invocations-harness";
 import { up as memoryLifecycleRepair } from "./083-memory-lifecycle-repair";
+import { up as legacyMarkdownImportState } from "./084-legacy-markdown-import-state";
 
 // -- Public interface consumed by Database.init() --
 
@@ -802,7 +803,14 @@ export const MIGRATIONS: readonly Migration[] = [
 			],
 		},
 	},
-];
+	{
+		version: 84,
+		name: "legacy-markdown-import-state",
+		up: legacyMarkdownImportState,
+		artifacts: {
+			tables: ["legacy_markdown_imports", "legacy_markdown_chunks"],
+		},
+	},
 
 /** Simple checksum for audit trail (hash of migration name + version). */
 function checksum(m: Migration): string {

--- a/platform/daemon-rs/crates/signet-core/src/migrations.rs
+++ b/platform/daemon-rs/crates/signet-core/src/migrations.rs
@@ -119,6 +119,8 @@ const TS_SKILL_INVOCATIONS_HARNESS_VERSION: u32 = 82;
 const TS_SKILL_INVOCATIONS_HARNESS_NAME: &str = "skill-invocations-harness";
 const TS_MEMORY_LIFECYCLE_REPAIR_VERSION: u32 = 83;
 const TS_MEMORY_LIFECYCLE_REPAIR_NAME: &str = "memory-lifecycle-repair";
+const TS_LEGACY_MARKDOWN_IMPORT_STATE_VERSION: u32 = 84;
+const TS_LEGACY_MARKDOWN_IMPORT_STATE_NAME: &str = "legacy-markdown-import-state";
 
 /// Simple checksum matching the TS implementation (hash of "version:name").
 fn checksum(version: u32, name: &str) -> String {
@@ -581,7 +583,37 @@ fn ensure_cross_daemon_parity_tables(conn: &Connection) -> Result<(), CoreError>
             updated_at TEXT NOT NULL
         );
         CREATE INDEX IF NOT EXISTS idx_os_widgets_status
-            ON os_widgets(status, updated_at DESC);",
+            ON os_widgets(status, updated_at DESC);
+
+        CREATE TABLE IF NOT EXISTS legacy_markdown_imports (
+            path TEXT PRIMARY KEY,
+            mtime_ms INTEGER NOT NULL,
+            ctime_ms INTEGER NOT NULL,
+            size INTEGER NOT NULL,
+            content_hash TEXT NOT NULL,
+            importer_version INTEGER NOT NULL,
+            chunk_count INTEGER NOT NULL DEFAULT 0,
+            last_imported_at TEXT NOT NULL,
+            last_seen_at TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'imported'
+                CHECK(status IN ('imported', 'empty', 'failed')),
+            error TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS legacy_markdown_chunks (
+            file_path TEXT NOT NULL,
+            chunk_hash TEXT NOT NULL,
+            chunk_index INTEGER NOT NULL,
+            memory_id TEXT,
+            source_id TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            PRIMARY KEY (file_path, chunk_hash),
+            FOREIGN KEY (file_path) REFERENCES legacy_markdown_imports(path) ON DELETE CASCADE,
+            FOREIGN KEY (memory_id) REFERENCES memories(id) ON DELETE SET NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_legacy_markdown_chunks_memory
+            ON legacy_markdown_chunks(memory_id);",
     )?;
 
     // Stamp all TS migration versions whose artifacts are already present in a
@@ -746,6 +778,11 @@ fn ensure_cross_daemon_parity_tables(conn: &Connection) -> Result<(), CoreError>
         TS_ARTIFACT_SOURCE_PROVENANCE_NAME,
     )?;
     stamp_typescript_parity_migration(conn, TS_TEMPORAL_EDGES_VERSION, TS_TEMPORAL_EDGES_NAME)?;
+    stamp_typescript_parity_migration(
+        conn,
+        TS_LEGACY_MARKDOWN_IMPORT_STATE_VERSION,
+        TS_LEGACY_MARKDOWN_IMPORT_STATE_NAME,
+    )?;
     Ok(())
 }
 

--- a/platform/daemon-rs/crates/signet-daemon/src/watcher.rs
+++ b/platform/daemon-rs/crates/signet-daemon/src/watcher.rs
@@ -1,11 +1,13 @@
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use notify::{RecursiveMode, Watcher};
+use rusqlite::OptionalExtension;
 use sha2::{Digest, Sha256};
 use signet_core::db::Priority;
+use signet_core::error::CoreError;
 use signet_services::transactions;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error, info, warn};
@@ -16,6 +18,7 @@ const SYNC_DEBOUNCE_MS: u64 = 2_000;
 const COMMIT_DEBOUNCE_MS: u64 = 5_000;
 const GIT_AUTOCOMMIT_TIMEOUT_MS: u64 = 30_000;
 const MEMORY_IMPORT_POLL_MS: u64 = 30_000;
+const LEGACY_MARKDOWN_IMPORTER_VERSION: i64 = 1;
 const CONFIG_FILES: [&str; 3] = ["agent.yaml", "AGENT.yaml", "config.yaml"];
 const SYNC_TRIGGER_FILES: [&str; 8] = [
     "agent.yaml",
@@ -289,6 +292,184 @@ fn is_memory_artifact_filename(name: &str) -> bool {
         .any(|suffix| name.ends_with(suffix))
 }
 
+#[derive(Clone, Copy)]
+struct LegacyMarkdownFileState {
+    mtime_ms: i64,
+    ctime_ms: i64,
+    size: i64,
+}
+
+struct LegacyMarkdownImportState {
+    mtime_ms: i64,
+    ctime_ms: i64,
+    size: i64,
+    content_hash: String,
+    importer_version: i64,
+    chunk_count: i64,
+    status: String,
+}
+
+fn system_time_ms(time: SystemTime) -> i64 {
+    time.duration_since(UNIX_EPOCH)
+        .map(|duration| i64::try_from(duration.as_millis()).unwrap_or(i64::MAX))
+        .unwrap_or(0)
+}
+
+#[cfg(unix)]
+fn metadata_ctime_ms(metadata: &std::fs::Metadata) -> i64 {
+    use std::os::unix::fs::MetadataExt;
+    metadata.ctime().saturating_mul(1000) + (metadata.ctime_nsec() / 1_000_000)
+}
+
+#[cfg(not(unix))]
+fn metadata_ctime_ms(metadata: &std::fs::Metadata) -> i64 {
+    metadata
+        .created()
+        .or_else(|_| metadata.modified())
+        .map(system_time_ms)
+        .unwrap_or(0)
+}
+
+fn legacy_markdown_file_state(path: &Path) -> Option<LegacyMarkdownFileState> {
+    let metadata = std::fs::metadata(path).ok()?;
+    Some(LegacyMarkdownFileState {
+        mtime_ms: metadata.modified().map(system_time_ms).unwrap_or(0),
+        ctime_ms: metadata_ctime_ms(&metadata),
+        size: i64::try_from(metadata.len()).unwrap_or(i64::MAX),
+    })
+}
+
+async fn read_legacy_markdown_import_state(
+    state: &AppState,
+    path: &Path,
+) -> Option<LegacyMarkdownImportState> {
+    let path = path.to_string_lossy().to_string();
+    state
+        .pool
+        .read(move |conn| {
+            conn.query_row(
+                "SELECT mtime_ms, ctime_ms, size, content_hash, importer_version, chunk_count, status
+                   FROM legacy_markdown_imports
+                  WHERE path = ?1",
+                [&path],
+                |row| {
+                    Ok(LegacyMarkdownImportState {
+                        mtime_ms: row.get(0)?,
+                        ctime_ms: row.get(1)?,
+                        size: row.get(2)?,
+                        content_hash: row.get(3)?,
+                        importer_version: row.get(4)?,
+                        chunk_count: row.get(5)?,
+                        status: row.get(6)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(CoreError::from)
+        })
+        .await
+        .ok()
+        .flatten()
+}
+
+fn legacy_markdown_import_is_current(
+    row: Option<&LegacyMarkdownImportState>,
+    state: LegacyMarkdownFileState,
+) -> bool {
+    row.is_some_and(|row| {
+        row.importer_version == LEGACY_MARKDOWN_IMPORTER_VERSION
+            && row.mtime_ms == state.mtime_ms
+            && row.ctime_ms == state.ctime_ms
+            && row.size == state.size
+            && (row.status == "imported" || row.status == "empty")
+    })
+}
+
+fn upsert_legacy_markdown_import_state(
+    conn: &rusqlite::Connection,
+    path: &str,
+    state: LegacyMarkdownFileState,
+    content_hash: &str,
+    chunk_count: i64,
+    status: &str,
+    error: Option<&str>,
+) -> Result<(), CoreError> {
+    let now = chrono::Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT INTO legacy_markdown_imports
+          (path, mtime_ms, ctime_ms, size, content_hash, importer_version, chunk_count,
+           last_imported_at, last_seen_at, status, error)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?8, ?9, ?10)
+         ON CONFLICT(path) DO UPDATE SET
+           mtime_ms = excluded.mtime_ms,
+           ctime_ms = excluded.ctime_ms,
+           size = excluded.size,
+           content_hash = excluded.content_hash,
+           importer_version = excluded.importer_version,
+           chunk_count = excluded.chunk_count,
+           last_imported_at = excluded.last_imported_at,
+           last_seen_at = excluded.last_seen_at,
+           status = excluded.status,
+           error = excluded.error",
+        rusqlite::params![
+            path,
+            state.mtime_ms,
+            state.ctime_ms,
+            state.size,
+            content_hash,
+            LEGACY_MARKDOWN_IMPORTER_VERSION,
+            chunk_count,
+            now,
+            status,
+            error,
+        ],
+    )?;
+    Ok(())
+}
+
+fn legacy_markdown_chunk_known(
+    conn: &rusqlite::Connection,
+    path: &str,
+    chunk_hash: &str,
+) -> Result<bool, CoreError> {
+    let found: Option<i64> = conn
+        .query_row(
+            "SELECT 1 FROM legacy_markdown_chunks WHERE file_path = ?1 AND chunk_hash = ?2",
+            rusqlite::params![path, chunk_hash],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(found.is_some())
+}
+
+fn record_legacy_markdown_chunk(
+    conn: &rusqlite::Connection,
+    path: &str,
+    chunk_hash: &str,
+    chunk_index: i64,
+    memory_id: Option<&str>,
+    source_id: &str,
+) -> Result<(), CoreError> {
+    conn.execute(
+        "INSERT INTO legacy_markdown_chunks
+          (file_path, chunk_hash, chunk_index, memory_id, source_id, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT(file_path, chunk_hash) DO UPDATE SET
+           chunk_index = excluded.chunk_index,
+           memory_id = COALESCE(excluded.memory_id, legacy_markdown_chunks.memory_id),
+           source_id = excluded.source_id",
+        rusqlite::params![
+            path,
+            chunk_hash,
+            chunk_index,
+            memory_id,
+            source_id,
+            chrono::Utc::now().to_rfc3339(),
+        ],
+    )?;
+    Ok(())
+}
+
 async fn ingest_memory_markdown(
     state: &AppState,
     path: &Path,
@@ -297,6 +478,14 @@ async fn ingest_memory_markdown(
     if path.file_name().and_then(|name| name.to_str()) == Some("MEMORY.md") {
         return 0;
     }
+    let Some(file_state) = legacy_markdown_file_state(path) else {
+        return 0;
+    };
+    let prior_state = read_legacy_markdown_import_state(state, path).await;
+    if legacy_markdown_import_is_current(prior_state.as_ref(), file_state) {
+        return 0;
+    }
+
     let content = match std::fs::read_to_string(path) {
         Ok(content) => content,
         Err(err) => {
@@ -308,16 +497,63 @@ async fn ingest_memory_markdown(
             return 0;
         }
     };
-    if content.trim().is_empty() {
+    let content_hash = sha256_hex_prefix(&content, 16);
+    if prior_state.as_ref().is_some_and(|row| {
+        row.content_hash == content_hash
+            && row.importer_version == LEGACY_MARKDOWN_IMPORTER_VERSION
+            && (row.status == "imported" || row.status == "empty")
+    }) {
+        let path_text = path.to_string_lossy().to_string();
+        let content_hash_for_tx = content_hash.clone();
+        let chunk_count = prior_state.as_ref().map(|row| row.chunk_count).unwrap_or(0);
+        let status = prior_state
+            .as_ref()
+            .map(|row| row.status.clone())
+            .unwrap_or_else(|| "imported".to_string());
+        let _ = state
+            .pool
+            .write_tx(Priority::Low, move |conn| {
+                upsert_legacy_markdown_import_state(
+                    conn,
+                    &path_text,
+                    file_state,
+                    &content_hash_for_tx,
+                    chunk_count,
+                    &status,
+                    None,
+                )?;
+                Ok(serde_json::json!({}))
+            })
+            .await;
         return 0;
     }
 
-    let content_hash = sha256_hex_prefix(&content, 16);
+    if content.trim().is_empty() {
+        let path_text = path.to_string_lossy().to_string();
+        let content_hash_for_tx = content_hash.clone();
+        let _ = state
+            .pool
+            .write_tx(Priority::Low, move |conn| {
+                upsert_legacy_markdown_import_state(
+                    conn,
+                    &path_text,
+                    file_state,
+                    &content_hash_for_tx,
+                    0,
+                    "empty",
+                    None,
+                )?;
+                Ok(serde_json::json!({}))
+            })
+            .await;
+        ingested.insert(path.to_path_buf(), content_hash);
+        return 0;
+    }
+
     if ingested.get(path) == Some(&content_hash) {
         debug!(path = %path.display(), "legacy memory markdown file unchanged, skipping");
         return 0;
     }
-    ingested.insert(path.to_path_buf(), content_hash);
 
     let filename = path
         .file_stem()
@@ -326,7 +562,8 @@ async fn ingest_memory_markdown(
     let date = filename.get(..10).filter(|value| is_iso_date_prefix(value));
     let plans = chunk_markdown_hierarchically(&content, 512)
         .into_iter()
-        .filter_map(|chunk| {
+        .enumerate()
+        .filter_map(|(chunk_index, chunk)| {
             let body = if !chunk.header.is_empty() && chunk.text.starts_with(&chunk.header) {
                 chunk.text[chunk.header.len()..].trim()
             } else {
@@ -335,13 +572,16 @@ async fn ingest_memory_markdown(
             if body.len() < 80 {
                 return None;
             }
-            let chunk_key = format!("openclaw:{filename}:{}", sha256_hex_prefix(&chunk.text, 16));
+            let chunk_hash = sha256_hex_prefix(&chunk.text, 16);
+            let chunk_key = format!("openclaw:{filename}:{chunk_hash}");
             let level_tag = match chunk.level {
                 MemoryMarkdownChunkLevel::Section => "hierarchical-section",
                 MemoryMarkdownChunkLevel::Paragraph => "hierarchical-paragraph",
             };
             Some(MemoryImportPlan {
                 content: chunk.text,
+                chunk_hash,
+                chunk_index,
                 importance: match chunk.level {
                     MemoryMarkdownChunkLevel::Section => 0.65,
                     MemoryMarkdownChunkLevel::Paragraph => 0.55,
@@ -359,15 +599,39 @@ async fn ingest_memory_markdown(
         .collect::<Vec<_>>();
 
     if plans.is_empty() {
+        let path_text = path.to_string_lossy().to_string();
+        let content_hash_for_tx = content_hash.clone();
+        let _ = state
+            .pool
+            .write_tx(Priority::Low, move |conn| {
+                upsert_legacy_markdown_import_state(
+                    conn,
+                    &path_text,
+                    file_state,
+                    &content_hash_for_tx,
+                    0,
+                    "empty",
+                    None,
+                )?;
+                Ok(serde_json::json!({}))
+            })
+            .await;
+        ingested.insert(path.to_path_buf(), content_hash);
         return 0;
     }
 
+    let path_text = path.to_string_lossy().to_string();
+    let content_hash_for_tx = content_hash.clone();
     let result = state
         .pool
         .write_tx(Priority::High, move |conn| {
             let mut imported = 0usize;
             for plan in &plans {
-                transactions::ingest(
+                if legacy_markdown_chunk_known(conn, &path_text, &plan.chunk_hash)? {
+                    imported += 1;
+                    continue;
+                }
+                let result = transactions::ingest(
                     conn,
                     &transactions::IngestInput {
                         content: &plan.content,
@@ -389,8 +653,25 @@ async fn ingest_memory_markdown(
                         scope: None,
                     },
                 )?;
+                record_legacy_markdown_chunk(
+                    conn,
+                    &path_text,
+                    &plan.chunk_hash,
+                    i64::try_from(plan.chunk_index).unwrap_or(i64::MAX),
+                    Some(&result.id),
+                    &plan.source_id,
+                )?;
                 imported += 1;
             }
+            upsert_legacy_markdown_import_state(
+                conn,
+                &path_text,
+                file_state,
+                &content_hash_for_tx,
+                i64::try_from(imported).unwrap_or(i64::MAX),
+                "imported",
+                None,
+            )?;
             Ok(serde_json::json!({ "imported": imported }))
         })
         .await;
@@ -402,6 +683,7 @@ async fn ingest_memory_markdown(
                 .and_then(serde_json::Value::as_u64)
                 .and_then(|count| usize::try_from(count).ok())
                 .unwrap_or(0);
+            ingested.insert(path.to_path_buf(), content_hash);
             if imported > 0 {
                 info!(
                     path = %path.display(),
@@ -413,6 +695,25 @@ async fn ingest_memory_markdown(
             imported
         }
         Err(err) => {
+            ingested.remove(path);
+            let path_text = path.to_string_lossy().to_string();
+            let content_hash_for_tx = content_hash.clone();
+            let error_message = err.to_string();
+            let _ = state
+                .pool
+                .write_tx(Priority::Low, move |conn| {
+                    upsert_legacy_markdown_import_state(
+                        conn,
+                        &path_text,
+                        file_state,
+                        &content_hash_for_tx,
+                        0,
+                        "failed",
+                        Some(&error_message),
+                    )?;
+                    Ok(serde_json::json!({}))
+                })
+                .await;
             error!(
                 path = %path.display(),
                 error = %err,
@@ -426,6 +727,8 @@ async fn ingest_memory_markdown(
 #[derive(Clone)]
 struct MemoryImportPlan {
     content: String,
+    chunk_hash: String,
+    chunk_index: usize,
     importance: f64,
     source_id: String,
     tags: Vec<String>,

--- a/platform/daemon/src/daemon.ts
+++ b/platform/daemon/src/daemon.ts
@@ -266,8 +266,11 @@ setupDashboardRoutes(app);
 let watcher: ReturnType<typeof watch> | null = null;
 let nativeMemoryBridge: NativeMemoryBridgeHandle | null = null;
 
-// Track ingested files to avoid re-processing (path -> content hash)
+// Fast in-process cache layered on top of the persistent legacy_markdown_imports
+// manifest. The DB manifest is the authoritative restart-safe skip state;
+// this map only avoids duplicate work within a single daemon lifetime.
 const ingestedMemoryFiles = new Map<string, string>();
+const LEGACY_MARKDOWN_IMPORTER_VERSION = 1;
 const MEMORY_IMPORT_POLL_MS = 30_000;
 const MEMORY_IMPORT_FILE_DELAY_MS = 50;
 let memoryImportTimer: ReturnType<typeof setInterval> | null = null;
@@ -601,11 +604,171 @@ function chunkMarkdownHierarchically(
 export const ARTIFACT_FILENAME_RE = /--(?:summary|transcript|compaction|manifest)\.md$/;
 export const MEMORY_BACKUP_FILENAME_RE = /^MEMORY\.(?:backup|bak|pre)-.+\.md$/;
 
+interface LegacyMarkdownFileState {
+	readonly mtimeMs: number;
+	readonly ctimeMs: number;
+	readonly size: number;
+}
+
+function legacyMarkdownFileState(filePath: string): LegacyMarkdownFileState | null {
+	try {
+		const stat = statSync(filePath);
+		return { mtimeMs: Math.round(stat.mtimeMs), ctimeMs: Math.round(stat.ctimeMs), size: stat.size };
+	} catch {
+		return null;
+	}
+}
+
+function readLegacyMarkdownImportState(filePath: string): {
+	readonly mtime_ms: number;
+	readonly ctime_ms: number;
+	readonly size: number;
+	readonly content_hash: string;
+	readonly importer_version: number;
+	readonly chunk_count: number;
+	readonly status: string;
+} | null {
+	try {
+		return getDbAccessor().withReadDb((db) => {
+			const row = db
+				.prepare(
+					`SELECT mtime_ms, ctime_ms, size, content_hash, importer_version, chunk_count, status
+					 FROM legacy_markdown_imports
+					 WHERE path = ?`,
+				)
+				.get(filePath) as
+				| {
+						mtime_ms: number;
+						ctime_ms: number;
+						size: number;
+						content_hash: string;
+						importer_version: number;
+						chunk_count: number;
+						status: string;
+				  }
+				| undefined;
+			return row ?? null;
+		});
+	} catch {
+		// Older/unmigrated DBs fall back to the legacy importer behavior.
+		return null;
+	}
+}
+
+function legacyMarkdownImportIsCurrent(
+	row: ReturnType<typeof readLegacyMarkdownImportState>,
+	state: LegacyMarkdownFileState,
+): boolean {
+	return (
+		row !== null &&
+		row.importer_version === LEGACY_MARKDOWN_IMPORTER_VERSION &&
+		row.mtime_ms === state.mtimeMs &&
+		row.ctime_ms === state.ctimeMs &&
+		row.size === state.size &&
+		(row.status === "imported" || row.status === "empty")
+	);
+}
+
+function writeLegacyMarkdownImportState(args: {
+	readonly filePath: string;
+	readonly state: LegacyMarkdownFileState;
+	readonly contentHash: string;
+	readonly chunkCount: number;
+	readonly status: "imported" | "empty" | "failed";
+	readonly error?: string | null;
+}): void {
+	try {
+		const now = new Date().toISOString();
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO legacy_markdown_imports
+				 (path, mtime_ms, ctime_ms, size, content_hash, importer_version, chunk_count,
+				  last_imported_at, last_seen_at, status, error)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				 ON CONFLICT(path) DO UPDATE SET
+				   mtime_ms = excluded.mtime_ms,
+				   ctime_ms = excluded.ctime_ms,
+				   size = excluded.size,
+				   content_hash = excluded.content_hash,
+				   importer_version = excluded.importer_version,
+				   chunk_count = excluded.chunk_count,
+				   last_imported_at = excluded.last_imported_at,
+				   last_seen_at = excluded.last_seen_at,
+				   status = excluded.status,
+				   error = excluded.error`,
+			).run(
+				args.filePath,
+				args.state.mtimeMs,
+				args.state.ctimeMs,
+				args.state.size,
+				args.contentHash,
+				LEGACY_MARKDOWN_IMPORTER_VERSION,
+				args.chunkCount,
+				now,
+				now,
+				args.status,
+				args.error ?? null,
+			);
+		});
+	} catch {
+		// Non-fatal: importer correctness still falls back to idempotency/source dedupe.
+	}
+}
+
+function legacyMarkdownChunkKnown(filePath: string, chunkHash: string): boolean {
+	try {
+		return getDbAccessor().withReadDb((db) => {
+			const row = db
+				.prepare("SELECT 1 FROM legacy_markdown_chunks WHERE file_path = ? AND chunk_hash = ?")
+				.get(filePath, chunkHash);
+			return row !== undefined;
+		});
+	} catch {
+		return false;
+	}
+}
+
+function recordLegacyMarkdownChunk(args: {
+	readonly filePath: string;
+	readonly chunkHash: string;
+	readonly chunkIndex: number;
+	readonly memoryId: string | null;
+	readonly sourceId: string;
+}): void {
+	try {
+		getDbAccessor().withWriteTx((db) => {
+			db.prepare(
+				`INSERT INTO legacy_markdown_chunks
+				 (file_path, chunk_hash, chunk_index, memory_id, source_id, created_at)
+				 VALUES (?, ?, ?, ?, ?, ?)
+				 ON CONFLICT(file_path, chunk_hash) DO UPDATE SET
+				   chunk_index = excluded.chunk_index,
+				   memory_id = COALESCE(excluded.memory_id, legacy_markdown_chunks.memory_id),
+				   source_id = excluded.source_id`,
+			).run(args.filePath, args.chunkHash, args.chunkIndex, args.memoryId, args.sourceId, new Date().toISOString());
+		});
+	} catch {
+		// Non-fatal.
+	}
+}
+
+function memoryIdFromRememberResponse(value: unknown): string | null {
+	if (typeof value !== "object" || value === null) return null;
+	const id = (value as { id?: unknown }).id;
+	return typeof id === "string" && id.length > 0 ? id : null;
+}
+
 async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 	if (filePath.endsWith("MEMORY.md")) return 0;
 
 	const filenameWithExt = basename(filePath);
 	if (MEMORY_BACKUP_FILENAME_RE.test(filenameWithExt) || ARTIFACT_FILENAME_RE.test(filenameWithExt)) return 0;
+
+	const fileState = legacyMarkdownFileState(filePath);
+	if (fileState === null) return 0;
+
+	const priorState = readLegacyMarkdownImportState(filePath);
+	if (legacyMarkdownImportIsCurrent(priorState, fileState)) return 0;
 
 	let content: string;
 	try {
@@ -618,23 +781,41 @@ async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 		return 0;
 	}
 
-	if (!content.trim()) return 0;
-
 	const hash = createHash("sha256").update(content).digest("hex").slice(0, 16);
-	if (ingestedMemoryFiles.get(filePath) === hash) {
-		logger.debug("watcher", "Memory file unchanged, skipping", {
-			path: filePath,
+	if (
+		priorState?.content_hash === hash &&
+		priorState.importer_version === LEGACY_MARKDOWN_IMPORTER_VERSION &&
+		(priorState.status === "imported" || priorState.status === "empty")
+	) {
+		writeLegacyMarkdownImportState({
+			filePath,
+			state: fileState,
+			contentHash: hash,
+			chunkCount: priorState.chunk_count,
+			status: priorState.status === "empty" ? "empty" : "imported",
 		});
 		return 0;
 	}
-	ingestedMemoryFiles.set(filePath, hash);
+
+	if (!content.trim()) {
+		writeLegacyMarkdownImportState({
+			filePath,
+			state: fileState,
+			contentHash: hash,
+			chunkCount: 0,
+			status: "empty",
+		});
+		return 0;
+	}
 
 	const filename = basename(filePath, ".md");
 	const dateMatch = filename.match(/^(\d{4}-\d{2}-\d{2})/);
 	const date = dateMatch ? dateMatch[1] : null;
 
 	const chunks = chunkMarkdownHierarchically(content, 512);
-	let inserted = 0;
+	let imported = 0;
+	let transientFailures = 0;
+	let eligibleChunks = 0;
 	const yielder = yieldEvery(1);
 
 	for (let i = 0; i < chunks.length; i++) {
@@ -648,8 +829,16 @@ async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 			await yielder();
 			continue;
 		}
+		eligibleChunks++;
 
-		const chunkKey = `openclaw:${filename}:${createHash("sha256").update(chunk.text).digest("hex").slice(0, 16)}`;
+		const chunkHash = createHash("sha256").update(chunk.text).digest("hex").slice(0, 16);
+		const chunkKey = `openclaw:${filename}:${chunkHash}`;
+		if (legacyMarkdownChunkKnown(filePath, chunkHash)) {
+			imported++;
+			await yielder();
+			continue;
+		}
+
 		try {
 			const response = await fetch(`http://${INTERNAL_SELF_HOST}:${PORT}/api/memory/remember`, {
 				method: "POST",
@@ -674,8 +863,23 @@ async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 			});
 
 			if (response.ok) {
-				inserted++;
+				let memoryId: string | null = null;
+				try {
+					memoryId = memoryIdFromRememberResponse(await response.json());
+				} catch {
+					memoryId = null;
+				}
+				recordLegacyMarkdownChunk({ filePath, chunkHash, chunkIndex: i, memoryId, sourceId: chunkKey });
+				imported++;
+			} else if (response.status === 409) {
+				// Existing historical imports can predate this manifest table. A 409 still
+				// proves this deterministic chunk should not be posted again on every
+				// daemon restart, so persist a manifest row without a memory id.
+				recordLegacyMarkdownChunk({ filePath, chunkHash, chunkIndex: i, memoryId: null, sourceId: chunkKey });
+				imported++;
+				logger.debug("watcher", "Legacy memory chunk already exists", { path: filePath, chunkIndex: i });
 			} else {
+				transientFailures++;
 				logger.warn("watcher", "Failed to ingest memory chunk", {
 					path: filePath,
 					chunkIndex: i,
@@ -683,6 +887,7 @@ async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 				});
 			}
 		} catch (e) {
+			transientFailures++;
 			const errDetails = e instanceof Error ? { message: e.message } : { error: String(e) };
 			logger.error("watcher", "Failed to ingest memory chunk", undefined, {
 				path: filePath,
@@ -693,15 +898,36 @@ async function ingestMemoryMarkdown(filePath: string): Promise<number> {
 		await yielder();
 	}
 
-	if (inserted > 0) {
+	if (transientFailures > 0) {
+		ingestedMemoryFiles.delete(filePath);
+		writeLegacyMarkdownImportState({
+			filePath,
+			state: fileState,
+			contentHash: hash,
+			chunkCount: imported,
+			status: "failed",
+			error: `${transientFailures} transient chunk import failure(s)`,
+		});
+	} else {
+		ingestedMemoryFiles.set(filePath, hash);
+		writeLegacyMarkdownImportState({
+			filePath,
+			state: fileState,
+			contentHash: hash,
+			chunkCount: imported,
+			status: eligibleChunks === 0 ? "empty" : "imported",
+		});
+	}
+
+	if (imported > 0) {
 		logger.info("watcher", "Ingested memory file", {
 			path: filePath,
-			chunks: inserted,
+			chunks: imported,
 			sections: chunks.filter((c) => c.level === "section").length,
 			filename,
 		});
 	}
-	return inserted;
+	return imported;
 }
 
 async function importExistingMemoryFiles(): Promise<number> {
@@ -733,7 +959,7 @@ async function importExistingMemoryFiles(): Promise<number> {
 		const count = await ingestMemoryMarkdown(join(memoryDir, file));
 		totalChunks += count;
 		await yielder();
-		await sleep(MEMORY_IMPORT_FILE_DELAY_MS);
+		if (count > 0) await sleep(MEMORY_IMPORT_FILE_DELAY_MS);
 	}
 
 	if (totalChunks > 0) {

--- a/platform/daemon/src/db-accessor.ts
+++ b/platform/daemon/src/db-accessor.ts
@@ -811,9 +811,7 @@ function ensureVecTable(db: SqliteDatabase, expectedDimensions: number): void {
 	if (existing) {
 		if (!vecEmbeddingsSchemaNeedsRepair(existing.sql, expectedDimensions)) return;
 		if (/\bid\s+TEXT\b/i.test(existing.sql)) {
-			console.warn(
-				`[db-accessor] vec_embeddings schema drift detected; recreating with FLOAT[${expectedDimensions}]`,
-			);
+			console.warn(`[db-accessor] vec_embeddings schema drift detected; recreating with FLOAT[${expectedDimensions}]`);
 		}
 		db.exec("DROP TABLE vec_embeddings");
 	}
@@ -826,26 +824,54 @@ function ensureVecTable(db: SqliteDatabase, expectedDimensions: number): void {
 	`);
 }
 
+function vecRowidsTableAvailable(db: SqliteDatabase): boolean {
+	try {
+		const row = db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'vec_embeddings_rowids'").get();
+		return row !== undefined;
+	} catch {
+		return false;
+	}
+}
+
+function missingVecEmbeddingsRows(
+	db: SqliteDatabase,
+	expectedDimensions: number,
+): Array<{ id: string; vector: Buffer }> {
+	// sqlite-vec's virtual table is expensive for anti-joins: on a 43k-row local
+	// DB, `LEFT JOIN vec_embeddings` costs ~6.5s even when no rows are missing.
+	// The backing rowid table is a normal SQLite table with a UNIQUE id index and
+	// answers the same existence question in tens of milliseconds. Keep the
+	// virtual-table fallback for non-sqlite-vec test doubles and unexpected
+	// future layouts.
+	const targetTable = vecRowidsTableAvailable(db) ? "vec_embeddings_rowids" : "vec_embeddings";
+	return db
+		.prepare(
+			`SELECT e.id, e.vector FROM embeddings e
+			 LEFT JOIN ${targetTable} v ON v.id = e.id
+			 WHERE v.id IS NULL AND e.dimensions = ?`,
+		)
+		.all(expectedDimensions) as Array<{ id: string; vector: Buffer }>;
+}
+
+function countSkippedVecEmbeddingsRows(db: SqliteDatabase, expectedDimensions: number): number {
+	const targetTable = vecRowidsTableAvailable(db) ? "vec_embeddings_rowids" : "vec_embeddings";
+	const skippedRow = db
+		.prepare(
+			`SELECT COUNT(*) AS n FROM embeddings e
+			 LEFT JOIN ${targetTable} v ON v.id = e.id
+			 WHERE v.id IS NULL AND e.dimensions != ?`,
+		)
+		.get(expectedDimensions) as { n: number } | undefined;
+	return skippedRow?.n ?? 0;
+}
+
 function backfillVecEmbeddings(db: SqliteDatabase, expectedDimensions: number): void {
 	// Directly query for missing rows instead of comparing counts.
 	// Count comparison is racy — a row can exist in embeddings but not
 	// vec_embeddings even when counts match (e.g. after a crash mid-sync).
-	const rows = db
-		.prepare(
-			`SELECT e.id, e.vector FROM embeddings e
-			 LEFT JOIN vec_embeddings v ON v.id = e.id
-			 WHERE v.id IS NULL AND e.dimensions = ?`,
-		)
-		.all(expectedDimensions) as Array<{ id: string; vector: Buffer }>;
+	const rows = missingVecEmbeddingsRows(db, expectedDimensions);
 
-	const skippedRow = db
-		.prepare(
-			`SELECT COUNT(*) AS n FROM embeddings e
-			 LEFT JOIN vec_embeddings v ON v.id = e.id
-			 WHERE v.id IS NULL AND e.dimensions != ?`,
-		)
-		.get(expectedDimensions) as { n: number } | undefined;
-	const skippedCount = skippedRow?.n ?? 0;
+	const skippedCount = countSkippedVecEmbeddingsRows(db, expectedDimensions);
 	if (skippedCount > 0) {
 		console.warn(
 			`[db-accessor] Skipped ${skippedCount} embeddings with dimensions that do not match FLOAT[${expectedDimensions}]`,


### PR DESCRIPTION
## Summary
- speed up vec embedding reconciliation by checking sqlite-vec rowids instead of anti-joining the virtual table
- add persistent legacy markdown import/chunk manifests so unchanged memory logs are skipped across daemon restarts
- mirror the manifest schema and importer behavior in the Rust daemon path

## Rebase notes
Rebased onto main (d06e98e0b). Migration renumbered from v81 → v84 to resolve conflict with aggregate-evidence-sources (v81) and memory-lifecycle-repair (v83) that landed on main since this PR was opened.

## Validation
- bunx biome check platform/core/src/migrations/index.ts platform/core/src/migrations/084-legacy-markdown-import-state.ts platform/daemon/src/daemon.ts platform/daemon/src/db-accessor.ts
- bun run --filter @signet/core build
- bun test platform/core/src/migrations/migrations.test.ts platform/daemon/src/db-accessor.test.ts
- bun run --filter @signet/daemon build
- cargo check -p signet-daemon -p signet-core
- cargo test -p signet-core --test migrations

Note: cargo check still reports pre-existing signet-pipeline warnings.